### PR TITLE
fix: yt-playlist-manager の --status import エラー修正 + --clean-deleted を追加

### DIFF
--- a/src/youtube_automation/scripts/playlist_manager.py
+++ b/src/youtube_automation/scripts/playlist_manager.py
@@ -273,6 +273,62 @@ class PlaylistManager:
 
         return results
 
+    # ─── 削除済み動画エントリの除去 ────────────────────
+
+    def clean_deleted_entries(self, dry_run: bool = False) -> dict[str, int]:
+        """全プレイリストから削除済み/非公開動画のエントリを除去する。
+
+        YouTube は動画が削除/非公開化された後もプレイリスト内にプレースホルダー
+        エントリ (snippet.title が "Deleted video" / "Private video") を残す。
+        これらを playlistItems.delete で除去する。
+
+        Returns:
+            {playlist_key: removed_count}
+        """
+        youtube = self._get_youtube()
+        playlists_config = self.config.playlists
+        removed_per_playlist: dict[str, int] = {}
+
+        deleted_titles = {"Deleted video", "Private video"}
+
+        for key, pl in playlists_config.items():
+            playlist_id = pl.get('playlist_id')
+            if not playlist_id:
+                logger.info(f"  {key}: playlist_id 未設定 — スキップ")
+                continue
+
+            removed = 0
+            page_token = None
+            while True:
+                resp = youtube.playlistItems().list(
+                    part='snippet',
+                    playlistId=playlist_id,
+                    maxResults=50,
+                    pageToken=page_token,
+                ).execute()
+
+                for item in resp.get('items', []):
+                    title = item['snippet'].get('title', '')
+                    if title in deleted_titles:
+                        item_id = item['id']
+                        video_id = item['snippet'].get('resourceId', {}).get('videoId', '?')
+                        if dry_run:
+                            print(f"  [DRY-RUN] {key}: 除去予定 {video_id} ({title})")
+                        else:
+                            youtube.playlistItems().delete(id=item_id).execute()
+                            logger.info(f"  {key}: 除去 {video_id} ({title})")
+                        removed += 1
+
+                page_token = resp.get('nextPageToken')
+                if not page_token:
+                    break
+
+            removed_per_playlist[key] = removed
+            if removed == 0:
+                logger.info(f"  {key}: 削除済みエントリなし")
+
+        return removed_per_playlist
+
     # ─── init（作成 + 同期） ──────────────────────────
 
     def init(self, dry_run: bool = False):
@@ -302,6 +358,8 @@ def main():
     parser.add_argument('--status', action='store_true', help='現在の状態表示')
     parser.add_argument('--assign', metavar='VIDEO_ID', help='単一動画をプレイリストに追加')
     parser.add_argument('--theme', help='--assign 用のテーマ名')
+    parser.add_argument('--clean-deleted', action='store_true',
+                        help='全プレイリストから削除済み/非公開動画のエントリを除去')
     parser.add_argument('--dry-run', action='store_true', help='ドライラン（実行せず計画のみ表示）')
 
     args = parser.parse_args()
@@ -312,8 +370,16 @@ def main():
         if args.init:
             manager.init(dry_run=args.dry_run)
         elif args.status:
-            from playlist_status import PlaylistStatusViewer
+            from youtube_automation.scripts.playlist_status import PlaylistStatusViewer
             PlaylistStatusViewer().show_status()
+        elif args.clean_deleted:
+            print("\n=== 削除済み/非公開動画エントリの除去 ===")
+            results = manager.clean_deleted_entries(dry_run=args.dry_run)
+            total = sum(results.values())
+            print(f"\n=== 完了: {total} 件除去 ===")
+            for key, count in results.items():
+                if count > 0:
+                    print(f"  {key}: {count} 件")
         elif args.assign:
             if not args.theme:
                 parser.error('--assign には --theme が必要です')


### PR DESCRIPTION
## Summary

- `yt-playlist-manager --status` が `No module named 'playlist_status'` で失敗していた import バグを修正
- 削除済み/非公開動画のプレースホルダーエントリを除去する `--clean-deleted` を追加

## 背景

### Bug
`playlist_manager.py:315` の `from playlist_status import PlaylistStatusViewer` が非絶対 import で、パッケージインストール時に解決できず実行時エラーになっていた。

### Feature
YouTube は動画を削除/非公開化してもプレイリスト内にプレースホルダーエントリ (`snippet.title == "Deleted video"` / `"Private video"`) を残し、`contentDetails.itemCount` にも加算する。これによりプレイリストの実数把握や視聴体験に影響が出る。

## 変更内容

### Bug fix
\`\`\`diff
-            from playlist_status import PlaylistStatusViewer
+            from youtube_automation.scripts.playlist_status import PlaylistStatusViewer
\`\`\`

### Feature
- \`PlaylistManager.clean_deleted_entries(dry_run)\` メソッド追加
- \`--clean-deleted\` CLI フラグ追加（\`--dry-run\` と組み合わせ可能）
- 全 playlists を走査 → snippet.title が deleted/private のエントリを \`playlistItems.delete\` で除去

## Test plan

- [x] \`--status\` が import エラーなく動作することを確認
- [x] \`--clean-deleted --dry-run\` で除去対象を表示できること
- [x] \`--clean-deleted\` 本実行で削除済みエントリが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)