### PR TITLE
docs: alignment-check に Next Step セクションを追加

### DIFF
--- a/.claude/skills/alignment-check/SKILL.md
+++ b/.claude/skills/alignment-check/SKILL.md
@@ -78,3 +78,16 @@ AskUserQuestion で新タイトルフォーマットを確認。
 - `collections/live/*/10-assets/thumbnail.jpg` — サムネイル
 - `collections/live/*/20-documentation/` — 音楽プロンプト
 - `collections/live/*/workflow-state.json` — タイトル・テーマ
+
+## Next Step
+
+`docs/plans/alignment-audit.md` 保存後、不整合カテゴリに応じて以下のスキルを再実行する:
+
+| 不整合カテゴリ | 症状 | 再実行スキル |
+|---------------|------|-------------|
+| **サムネ不一致** | 音楽ムードとサムネ雰囲気がズレ（例: lofi なのに派手な色調） | `/thumbnail <collection>` — 対象コレクションのサムネイル再生成 |
+| **音楽ミスマッチ** | テーマ・タイトルと音楽プロンプトがズレ（例: 「rain」テーマなのに upbeat） | `/ideate` で企画段階から見直し、その後 `/suno` または `/lyria` で再生成 |
+| **タイトル改善のみ** | サムネ・音楽は OK だがタイトルの訴求/語彙が弱い | YouTube Studio で手動変更 + `channel_config.json` の `title.template` を更新 |
+| **横断的な方向性ズレ** | 複数コレクションで同じ不整合パターン | `/channel-direction` でチャンネル全体の方向性を再検討 |
+
+再実行後は `/alignment-check` を再度走らせて解消を確認する（フィードバックループ）。

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist/
 build/
 *.egg-info/
 .coverage
+.worktrees/


### PR DESCRIPTION
## 概要

`alignment-check` スキルで不整合監査レポート保存後にユーザーが取るべき次アクションがドキュメント化されておらず、ワークフローが閉じていなかった。末尾に「Next Step」セクションを追加し、フィードバックループを宣言する。

Closes #14

## 変更内容

- `.claude/skills/alignment-check/SKILL.md` 末尾に `## Next Step` セクションを追加
- 不整合カテゴリ別（サムネ不一致 / 音楽ミスマッチ / タイトル改善 / 横断的な方向性ズレ）の表形式で、対応する再実行スキル（`/thumbnail`, `/ideate`, `/suno`, `/lyria`, `/channel-direction` 等）を明示
- 再実行後に `/alignment-check` を再走させる旨を記載し、フィードバックループを明文化

## テスト計画

- [ ] `/alignment-check` 実行後、末尾に Next Step が表示されること
- [ ] 不整合カテゴリに応じた再実行スキル案内が参照可能なこと