### PR TITLE
fix: スキル内 python3 直呼び出しを uv run 経由に統一

### DIFF
--- a/.claude/skills/channel-setup/references/verification.md
+++ b/.claude/skills/channel-setup/references/verification.md
@@ -6,7 +6,7 @@
 ## JSON 構文検証
 
 ```bash
-python3 -c "import json; json.load(open('config/channel_config.json'))"
+uv run python3 -c "import json; json.load(open('config/channel_config.json'))"
 ```
 
 エラーが出なければ構文 OK。
@@ -64,7 +64,7 @@ uv run yt-generate-image --prompt "..." --output branding/icon.png --aspect-rati
 uv run yt-generate-image --prompt "..." --output branding/banner.png --aspect-ratio 16:9 -y
 
 # リサイズ（上限超過時）
-python3 -c "
+uv run python3 -c "
 from PIL import Image
 icon = Image.open('branding/icon.png').resize((800, 800), Image.LANCZOS)
 icon.save('branding/icon.png', 'PNG', optimize=True)

--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -107,7 +107,7 @@ mkdir -p collections/planning/_plan-previews/${PREVIEW_DIR}
 # 順次実行（API レート制限回避）
 # <dir> は上で作成したセッション固有ディレクトリ名（例: 20260306-a3f1）
 # <slug> はテーマ名をケバブケースに変換（例: "The Wanderer's Road" → "wanderers-road"）
-REF=$(python3 -c "from youtube_automation.utils.skill_config import load_skill_config; c=load_skill_config('thumbnail'); print(c.get('gemini_image',{}).get('reference_images',{}).get('default',''))")
+REF=$(uv run python3 -c "from youtube_automation.utils.skill_config import load_skill_config; c=load_skill_config('thumbnail'); print(c.get('gemini_image',{}).get('reference_images',{}).get('default',''))")
 uv run yt-generate-image --reference "$REF" --prompt "<企画Aプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-a-<slug>.png -y
 uv run yt-generate-image --reference "$REF" --prompt "<企画Bプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-b-<slug>.png -y
 uv run yt-generate-image --reference "$REF" --prompt "<企画Cプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-c-<slug>.png -y

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist/
 build/
 *.egg-info/
 .coverage
+.worktrees/


### PR DESCRIPTION
## 概要
スキル内シェルコマンド例の `python3 -c ...` を `uv run python3 -c ...` に統一し、CLAUDE.md の Python 実行規約と整合させた。
Fixes #13

## バグ詳細
- **症状**: `.claude/skills/` 配下の一部コマンド例で `python3` を直接呼び出しており、環境に依存した実行パスを誘発する可能性がある
- **再現条件**: プロジェクトの uv 管理環境外で当該コマンドを実行した場合
- **再現方法**:
  1. `.claude/skills/channel-setup/references/verification.md:9` 等のコマンドをそのまま実行
  2. システム Python に依存関係が揃っていない場合 ImportError になる

## 原因
スキルドキュメント執筆時に `uv run` プレフィックスを付け忘れていた。CLAUDE.md では uv 管理下での実行を前提としているため整合性が取れていなかった。

## 修正内容
- `.claude/skills/channel-setup/references/verification.md`: JSON 構文検証とリサイズ処理の 2 箇所を `uv run python3 -c` に変更
- `.claude/skills/ideate/SKILL.md`: `skill_config` ロード部分を `uv run python3 -c` に変更

## 影響範囲
スキルドキュメントの記述のみ。実行コードには影響しない。

## テスト計画
- [x] `uv run ruff check .` が green
- [x] `uv run pytest` が 370 件 all pass
- [ ] 修正後のコマンド例が実行可能であることを目視確認