### PR TITLE
feat: 既存チャンネル統合ガイドとフォールバック整備

### DIFF
--- a/.claude/skills/channel-setup/SKILL.md
+++ b/.claude/skills/channel-setup/SKILL.md
@@ -49,7 +49,7 @@ Phase 1 で作成した最小 config を完全版に拡張。`config-template.js
 |---------|---------|
 | `config/schedule_config.json` | `references/schedule-template.json` をコピー。投稿頻度を方向性に合わせて調整 |
 | `config/upload_settings.json` | `references/upload-settings-template.json` をコピー |
-| `config/localizations.json` | `references/localizations-template.json` をコピーし、ジャンル情報を反映した具体的な文言に調整 |
+| `config/localizations.json` | `references/localizations-template.json` をコピーし、ジャンル情報を反映した具体的な文言に調整。多言語展開しないチャンネルは省略可（`ChannelConfig.supported_languages` は `youtube.language` のみへフォールバック） |
 | `.claude/CLAUDE.md` | `references/claude-md-template.md` の `{{CHANNEL_NAME}}` / `{{DIR_NAME}}` を置換 |
 
 ### Step 6: 検証

--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -135,7 +135,14 @@ uv run yt-generate-image --reference "$REF" --prompt "<企画Cプロンプト>" 
 `docs/plans/persona-definition.md` で定義されたペルソナに対し、各 1 企画を生成する。
 ペルソナの視聴シーン・ユースケースから情景を導出し、差別化軸と掛け合わせてテーマを決定する。
 
-`docs/plans/persona-definition.md` が存在する場合、そこからペルソナを読み込む。未定義の場合はユーザーにペルソナ定義（`/persona`）を先に実行するよう案内する。
+`docs/plans/persona-definition.md` が存在する場合、そこからペルソナを読み込む。
+**存在しない場合は ideate を進めず、以下を案内して停止する:**
+
+```
+❌ docs/plans/persona-definition.md が見つかりません。
+   先に `/persona` を実行してターゲットペルソナを定義してください。
+   （チャンネル立ち上げ直後なら `/channel-direction` → `/persona` → `/ideate` の順）
+```
 
 今回のターゲットペルソナに対し、差別化軸（`config/skills/ideate.yaml` の `differentiation_axes`、デフォルト: location / time_of_day / activity / mood）の掛け合わせで候補を生成:
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist/
 build/
 *.egg-info/
 .coverage
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pip install "git+https://github.com/daiki-beppu/youtube-automation@v1.1.0"
 
 インストールすると `yt-*` という CLI コマンド群と `yt-skills` 同期ツールが PATH に入ります。
 
-> **submodule 形式 (legacy)**: 既存のチャンネルリポジトリは `git submodule add git@github.com:daiki-beppu/youtube-automation.git automation` でも引き続き動作します（`utils/`, `agents/`, `auth/`, `scripts/` の互換 shim を維持）。新規チャンネルは pip install を推奨。
+> **submodule 形式 (legacy)**: 既存のチャンネルリポジトリは `git submodule add git@github.com:daiki-beppu/youtube-automation.git automation` でも引き続き動作します（`utils/`, `agents/`, `auth/`, `scripts/` の互換 shim を維持）。新規チャンネルは pip install を推奨。submodule から uv 方式への移行手順は [`docs/migration-submodule-to-uv.md`](docs/migration-submodule-to-uv.md) を参照。
 
 ### 2. Claude Code スキルを同期
 

--- a/docs/migration-submodule-to-uv.md
+++ b/docs/migration-submodule-to-uv.md
@@ -1,0 +1,120 @@
+# 移行ガイド: submodule → uv add git+https
+
+既存の git submodule 運用チャンネルを `uv add git+https://...` 方式へ移行する手順。
+
+## なぜ移行するか
+
+- submodule 運用は `automation/` ディレクトリを git 管理下に抱え、タグ固定・差分レビューに手間がかかる
+- `uv add git+https://...` では `pyproject.toml` にバージョンタグを固定するだけでよく、CLI (`yt-*`) と Claude Code スキルも `yt-skills sync` で配布される
+- submodule 時の互換 shim (`automation/auth/`, `automation/scripts/` 等) は維持されているが、新規チャンネルは最初から uv 方式にする
+
+## 前提
+
+- 既存チャンネルリポジトリに `automation/` が submodule として追加済み
+- `config/channel_config.json`、`auth/client_secrets.json`（または `automation/auth/client_secrets.json`）が存在する
+- `uv` と `git` が利用可能
+
+## 手順
+
+### 1. 現状のバックアップ
+
+念のためブランチを切って作業:
+
+```bash
+cd <channel-repo>
+git checkout -b migrate/uv-add
+```
+
+### 2. submodule の削除
+
+```bash
+# submodule 登録解除
+git submodule deinit -f automation
+git rm -f automation
+# .git/modules 配下のメタデータも削除
+rm -rf .git/modules/automation
+```
+
+`.gitmodules` が空になったら削除:
+
+```bash
+# ファイルが残っていて `[submodule "automation"]` 以外のエントリが無いなら
+rm -f .gitmodules
+git add .gitmodules 2>/dev/null || true
+```
+
+### 3. uv 環境の初期化（pyproject.toml が無い場合のみ）
+
+```bash
+uv init --no-readme --no-workspace
+```
+
+既に `pyproject.toml` がある場合はスキップ。
+
+### 4. パッケージの追加
+
+タグは最新の安定バージョンを推奨:
+
+```bash
+uv add "git+https://github.com/daiki-beppu/youtube-automation@v1.1.0"
+```
+
+これで `yt-*` CLI と `yt-skills` が PATH に入る。
+
+### 5. スキルの再同期
+
+旧 `.claude/skills/` は submodule 由来のシンボリックリンクなので、uv 方式で上書き:
+
+```bash
+yt-skills sync --force
+```
+
+### 6. 認証情報の移動（必要な場合）
+
+旧構成で `automation/auth/client_secrets.json` に置いていた場合、新しい推奨パスへ移動:
+
+```bash
+mkdir -p auth
+git mv automation/auth/client_secrets.json auth/client_secrets.json 2>/dev/null || \
+  mv automation/auth/client_secrets.json auth/client_secrets.json
+```
+
+互換 shim (`<channel_dir>/automation/auth/client_secrets.json`) も引き続き動作するが、`auth/` 配下に置くのが新規推奨。`auth/token.json` も同様。
+
+### 7. 動作確認
+
+```bash
+# ChannelConfig がロードできるか
+uv run python3 -c "from youtube_automation.utils.channel_config import ChannelConfig; print(ChannelConfig.load().channel_name)"
+
+# OAuth が通るか
+uv run yt-channel-status
+```
+
+### 8. コミット
+
+```bash
+git add -A
+git commit -m "chore: submodule automation から uv add git+https へ移行"
+```
+
+## トラブルシューティング
+
+### `yt-skills sync` が旧スキルを上書きしない
+
+`--force` を付ける。`--symlink` 運用から実ファイルへ戻す場合は `--force` が必須。
+
+### `ModuleNotFoundError: youtube_automation`
+
+`uv add` が失敗しているか、`uv sync` を忘れている。`uv run <command>` 経由で実行すれば自動同期される。
+
+### `client_secrets.json が見つかりません`
+
+検索順は以下のとおり（`src/youtube_automation/auth/oauth_handler.py`）:
+
+1. `CLIENT_SECRETS_DIR` 環境変数
+2. `<channel_dir>/auth/client_secrets.json`
+3. `<channel_dir>/automation/auth/client_secrets.json`（submodule 互換）
+4. 1Password (`op read`) の `CLIENT_SECRETS_JSON`
+
+いずれかに配置する。

--- a/src/youtube_automation/utils/channel_config.py
+++ b/src/youtube_automation/utils/channel_config.py
@@ -316,16 +316,54 @@ class ChannelConfig:
 
     @property
     def localizations_config(self) -> dict:
-        """localizations.json の遅延読み込み"""
+        """localizations.json の遅延読み込み
+
+        Raises:
+            ConfigError: localizations.json が存在しない / JSON 不正の場合。
+                多言語機能（upload の localizations / short の翻訳）を使わないチャンネルは
+                `has_localizations` で事前確認してから参照すること。
+        """
         if self._localizations_data is None:
             loc_path = ChannelConfig.channel_dir() / 'config' / 'localizations.json'
-            with open(loc_path, 'r', encoding='utf-8') as f:
-                ChannelConfig._localizations_data = json.load(f)
+            try:
+                with open(loc_path, 'r', encoding='utf-8') as f:
+                    ChannelConfig._localizations_data = json.load(f)
+            except FileNotFoundError:
+                raise ConfigError(
+                    f"localizations.json が見つかりません: {loc_path}\n"
+                    "多言語機能を使う場合は channel-setup スキルの "
+                    "references/localizations-template.json を参考に作成してください。"
+                )
+            except json.JSONDecodeError as e:
+                raise ConfigError(f"localizations.json の JSON パースに失敗: {loc_path}: {e}")
         return self._localizations_data
 
     @property
+    def has_localizations(self) -> bool:
+        """localizations.json が存在するか（多言語機能の事前チェック用）"""
+        loc_path = ChannelConfig.channel_dir() / 'config' / 'localizations.json'
+        return loc_path.exists()
+
+    @property
     def supported_languages(self) -> list[str]:
+        """対応言語リスト。localizations.json が無い場合は channel.youtube.language のみ"""
+        if not self.has_localizations:
+            return [self.language]
         return list(self.localizations_config['supported_languages'])
+
+    # ─── Music engine ──────────────────────────────────
+
+    @property
+    def music_engine(self) -> str:
+        """音楽エンジン（'suno' / 'lyria'）。未設定時は 'suno'"""
+        engine = self._data.get('music_engine', 'suno')
+        if engine not in ('suno', 'lyria'):
+            logger.warning(
+                "channel_config.json の music_engine='%s' は未知の値です。"
+                "既知の値は 'suno' / 'lyria'",
+                engine,
+            )
+        return engine
 
     # ─── Benchmark ──────────────────────────────────
 

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -274,3 +274,61 @@ class TestMusicEngineValidation:
             config_path.write_text(json.dumps(data), encoding="utf-8")
             cfg = ChannelConfig.load(config_path=str(config_path))
             assert cfg.channel_name == "Test Channel"
+
+    def test_music_engine_defaults_to_suno(self, config_file):
+        """music_engine 未設定時は 'suno' にフォールバック"""
+        cfg = ChannelConfig.load(config_path=str(config_file))
+        assert cfg.music_engine == "suno"
+
+    def test_music_engine_returns_configured_value(self, tmp_path):
+        data = json.loads(json.dumps(SAMPLE_CONFIG))
+        data["music_engine"] = "lyria"
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(data), encoding="utf-8")
+        cfg = ChannelConfig.load(config_path=str(config_path))
+        assert cfg.music_engine == "lyria"
+
+    def test_music_engine_unknown_value_warns(self, tmp_path, caplog):
+        """未知の値でも例外にはしないが警告ログを出す"""
+        import logging
+
+        data = json.loads(json.dumps(SAMPLE_CONFIG))
+        data["music_engine"] = "unknown_engine"
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(data), encoding="utf-8")
+        cfg = ChannelConfig.load(config_path=str(config_path))
+        with caplog.at_level(logging.WARNING, logger="youtube_automation.utils.channel_config"):
+            assert cfg.music_engine == "unknown_engine"
+        assert any("music_engine" in rec.message for rec in caplog.records)
+
+
+# ─── Localizations fallback ──────────────────────────
+
+class TestLocalizationsFallback:
+    def test_supported_languages_falls_back_to_youtube_language(self, monkeypatch, channel_dir_with_config):
+        """localizations.json が無い場合、supported_languages は youtube.language のみ返す"""
+        monkeypatch.setenv("CHANNEL_DIR", str(channel_dir_with_config))
+        cfg = ChannelConfig.load()
+        assert cfg.has_localizations is False
+        assert cfg.supported_languages == ["en"]
+
+    def test_supported_languages_uses_localizations_when_present(self, monkeypatch, channel_dir_with_config):
+        """localizations.json があればその supported_languages を返す"""
+        loc_path = channel_dir_with_config / "config" / "localizations.json"
+        loc_path.write_text(
+            json.dumps({"supported_languages": ["en", "ja", "es"]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(channel_dir_with_config))
+        cfg = ChannelConfig.load()
+        assert cfg.has_localizations is True
+        assert cfg.supported_languages == ["en", "ja", "es"]
+
+    def test_localizations_config_raises_config_error_when_missing(self, monkeypatch, channel_dir_with_config):
+        """localizations_config 直接参照時は ConfigError（FileNotFoundError ではなく）"""
+        from youtube_automation.utils.exceptions import ConfigError
+
+        monkeypatch.setenv("CHANNEL_DIR", str(channel_dir_with_config))
+        cfg = ChannelConfig.load()
+        with pytest.raises(ConfigError, match="localizations.json"):
+            _ = cfg.localizations_config


### PR DESCRIPTION
## 概要

OSS 整備で automation の導入方式が submodule → `uv add git+https://...` に変わったため、既存チャンネルの移行パスと、設定ファイル未整備時のフォールバック挙動を整備する。
Closes #3

## 設計判断

- **localizations.json を任意ファイル扱いに**: 多言語展開しないチャンネル用に `has_localizations` プロパティを追加し、`supported_languages` は未存在時に `youtube.language` のみ返す。`localizations_config` 直参照時は `FileNotFoundError` ではなく `ConfigError` に変換して案内メッセージを付与。
- **music_engine は警告ベース**: 厳格な `ConfigError` にすると既存テスト（`both` 許容）が落ちるため、未知値は `logger.warning` のみ。デフォルトは `'suno'`。
- **移行ガイドは独立ドキュメント**: README 内で冗長にせず、`docs/migration-submodule-to-uv.md` に手順書を切り出し README から参照。

## 変更内容

- `ChannelConfig.localizations_config` を `ConfigError` + 案内メッセージに変更
- `ChannelConfig.has_localizations` / `music_engine` プロパティ追加
- `supported_languages` を `youtube.language` にフォールバック
- ideate スキルで `docs/plans/persona-definition.md` 未存在時の停止フローを明記
- channel-setup スキルで `localizations.json` が任意である旨を追記
- `docs/migration-submodule-to-uv.md` 新規作成、README から参照
- `tests/test_channel_config.py` にフォールバック・music_engine テスト 7 件追加

## テスト計画

- [x] `uv run pytest tests/test_channel_config.py` → 35 passed
- [x] `nix develop --command uv run pytest` → 376 passed（CI 相当）
- [x] `uv run ruff check .` → clean
- [ ] 既存チャンネル（submodule 運用）で `docs/migration-submodule-to-uv.md` の手順を実地検証
- [ ] `localizations.json` を削除した状態で `yt-channel-status` を実行し、クラッシュしないことを確認