### PR TITLE
fix: description スキルに references/ を追加して構造を統一

### DIFF
--- a/.claude/skills/description/SKILL.md
+++ b/.claude/skills/description/SKILL.md
@@ -46,52 +46,9 @@ $ARGUMENTS
 
 ### Complete Collection テンプレート
 
-BGM チャンネル向けにアダプトした概要欄テンプレート。
+BGM チャンネル向けにアダプトした概要欄テンプレート（情景フック＋タイムスタンプ＋Perfect for 構成）を使用する。
 
-```
-[絵文字装飾]. [情景フック — 詩的な1行。コレクションの世界に引き込む]
-[音楽の誘い — リスナーへの語りかけ1行] [絵文字]
-
-[音楽の特徴 — 2行で楽器・ムード・雰囲気を描写]
-
-- Genre : [ジャンル名, サブジャンル]
-- Vibe : [形容詞4つ]
-- Best for : [用途4つ]
-
-
-
-⎯⎯⎯⎯⎯✦ ⋆˚ 𝙈𝙪𝙨𝙞𝙘 𝙏𝙞𝙢𝙚 ⋆˚✦⎯⎯⎯⎯⎯
-
-💽 [コレクション名 — 英語ボールド Unicode]
-
-00:00 [Track/Chapter 1]
-XX:XX [Track/Chapter 2]
-...
-
-
-🎧 If you enjoyed the vibe, feel free to save and subscribe for more 🌧️
-🔔 {channel_config: channel.cta_subscribe}
-
-{channel_config: channel.url}
-
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-🎨 𝐀𝐫𝐭 & 🎹 𝐌𝐮𝐬𝐢𝐜 𝐛𝐲 {channel_config: channel.name}
-• Original AI composition • Free for personal use
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-
-
-
-{channel_config: descriptions.hashtags}
-```
-
-**テンプレートのポイント:**
-- 冒頭は **詩的な情景** + **リスナーへの語りかけ**（YouTube の折りたたみ前に表示される）
-- メタデータは `Genre / Vibe / Best for` の3行（検索性 + 一目で内容がわかる）
-- タイムスタンプセクションは装飾付きヘッダー（`⎯⎯✦ ⋆˚ Music Time ⋆˚✦⎯⎯`）
-- CTA は短く温かい語調（「保存＆登録」をさりげなく）
-- クレジットは最小限（Art & Music by）
-- ハッシュタグは最後にまとめて配置
+テンプレート本文・ポイント解説は `references/description-templates.md` の「Complete Collection 概要欄テンプレート」セクションを参照すること。
 
 ### タイムスタンプ生成手順
 
@@ -153,57 +110,9 @@ skill-config (`.claude/skills/description/config.default.yaml` / 上書き `conf
 
 ### 概要欄保存
 
-概要欄は必ずコレクションの `20-documentation/descriptions.md` に以下の構成で保存すること:
-
-```markdown
-# [Collection Name] — YouTube 概要欄
-
-*生成日: YYYY-MM-DD*
-*トラック数: N / 総時間: Xh Xm Xs*
-
----
-
-## Complete Collection 概要欄
-
-\`\`\`
-[概要欄本文]
-\`\`\`
-
----
-
-## タイトル案
-
-\`\`\`
-[タイトル]
-\`\`\`
-
----
-
-## タグ（YouTube タグ欄）
-
-\`\`\`
-[タグリスト]
-\`\`\`
-
----
-
-## Cards (YouTube Studio で手動設定)
-
-\`\`\`
-Card ([タイミング]): "[ティーザーメッセージ]" → [リンク先動画タイトル]
-\`\`\`
-
----
-
-## 品質チェック
-
-- [x] 誇張表現なし
-- [x] AI 透明性あり
-- [x] チャンネル CTA 含む
-- [x] ハッシュタグ 13個
-- [x] モバイル読みやすさ
-- [x] カードセクション含む
-```
+概要欄は必ずコレクションの `20-documentation/descriptions.md` に保存する。
+保存フォーマット（ヘッダー、概要欄本文、タイトル案、タグ、Cards、品質チェック）は
+`references/description-templates.md` の「descriptions.md 保存フォーマット」セクションを参照すること。
 
 保存後、`workflow-state.json` の `description.generated = true` に更新する。
 

--- a/.claude/skills/description/references/description-templates.md
+++ b/.claude/skills/description/references/description-templates.md
@@ -1,0 +1,113 @@
+# description スキル テンプレート集
+
+`description` スキルが出力する YouTube 概要欄のテンプレート本文と、コレクション内 `descriptions.md` の保存フォーマットをまとめる。
+
+テンプレート更新時はこのファイルのみを編集すれば SKILL.md 本体は差し替え不要。
+
+---
+
+## Complete Collection 概要欄テンプレート
+
+BGM チャンネル向けにアダプトした、情景フック＋タイムスタンプ＋Perfect for 構成のテンプレート。
+
+```
+[絵文字装飾]. [情景フック — 詩的な1行。コレクションの世界に引き込む]
+[音楽の誘い — リスナーへの語りかけ1行] [絵文字]
+
+[音楽の特徴 — 2行で楽器・ムード・雰囲気を描写]
+
+- Genre : [ジャンル名, サブジャンル]
+- Vibe : [形容詞4つ]
+- Best for : [用途4つ]
+
+
+
+⎯⎯⎯⎯⎯✦ ⋆˚ 𝙈𝙪𝙨𝙞𝙘 𝙏𝙞𝙢𝙚 ⋆˚✦⎯⎯⎯⎯⎯
+
+💽 [コレクション名 — 英語ボールド Unicode]
+
+00:00 [Track/Chapter 1]
+XX:XX [Track/Chapter 2]
+...
+
+
+🎧 If you enjoyed the vibe, feel free to save and subscribe for more 🌧️
+🔔 {channel_config: channel.cta_subscribe}
+
+{channel_config: channel.url}
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+🎨 𝐀𝐫𝐭 & 🎹 𝐌𝐮𝐬𝐢𝐜 𝐛𝐲 {channel_config: channel.name}
+• Original AI composition • Free for personal use
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+
+
+
+{channel_config: descriptions.hashtags}
+```
+
+### テンプレートのポイント
+
+- 冒頭は **詩的な情景** + **リスナーへの語りかけ**（YouTube の折りたたみ前に表示される）
+- メタデータは `Genre / Vibe / Best for` の3行（検索性 + 一目で内容がわかる）
+- タイムスタンプセクションは装飾付きヘッダー（`⎯⎯✦ ⋆˚ Music Time ⋆˚✦⎯⎯`）
+- CTA は短く温かい語調（「保存＆登録」をさりげなく）
+- クレジットは最小限（Art & Music by）
+- ハッシュタグは最後にまとめて配置
+
+---
+
+## descriptions.md 保存フォーマット
+
+概要欄生成結果はコレクションの `20-documentation/descriptions.md` に以下の構成で保存する。
+
+````markdown
+# [Collection Name] — YouTube 概要欄
+
+*生成日: YYYY-MM-DD*
+*トラック数: N / 総時間: Xh Xm Xs*
+
+---
+
+## Complete Collection 概要欄
+
+```
+[概要欄本文]
+```
+
+---
+
+## タイトル案
+
+```
+[タイトル]
+```
+
+---
+
+## タグ（YouTube タグ欄）
+
+```
+[タグリスト]
+```
+
+---
+
+## Cards (YouTube Studio で手動設定)
+
+```
+Card ([タイミング]): "[ティーザーメッセージ]" → [リンク先動画タイトル]
+```
+
+---
+
+## 品質チェック
+
+- [x] 誇張表現なし
+- [x] AI 透明性あり
+- [x] チャンネル CTA 含む
+- [x] ハッシュタグ 13個
+- [x] モバイル読みやすさ
+- [x] カードセクション含む
+````

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist/
 build/
 *.egg-info/
 .coverage
+.worktrees/


### PR DESCRIPTION
## 概要

skill-config 移行済み 9 スキル（benchmark, ideate, loop-video, lyria, masterup, short, suno, thumbnail, description）のうち、`description` だけが `references/` ディレクトリを持たず構造が不整合になっていた問題を修正する。

Closes #10

## 修正内容

- `.claude/skills/description/references/description-templates.md` を新設し、SKILL.md にインライン記述されていた以下を切り出し:
  - Complete Collection 概要欄テンプレート本文 + ポイント解説
  - descriptions.md 保存フォーマット（ヘッダー、概要欄本文、タイトル案、タグ、Cards、品質チェック）
- SKILL.md 側は該当セクションを削除し、references/ への参照に置き換え

## 影響範囲

- `/description` スキル実行時に references/description-templates.md を読み込む必要があるが、それ以外の挙動は変わらない
- 他スキル・パッケージコード・テストには影響なし

## テスト計画

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest` — 370 passed
- [x] SKILL.md から references ファイルへのリンク整合性を確認