### PR TITLE
feat: Vertex AI モードを追加して新規 GCP アカウントの $300 クレジット活用を可能に

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -58,6 +58,12 @@ cp /path/to/existing-channel-repo/auth/token.json auth/token.json
 
 デフォルトのコピー元は `youtube-fantasy-celtic-music`。他のチャンネルを使いたい場合はユーザーに確認。
 
+**AI 生成系 API（Gemini/Veo/Lyria）の認証について**:
+
+新規 GCP アカウントで $300 クレジットを使いたい場合は **Vertex AI モード** を推奨する（2026 年以降、Google AI Studio の API キー経路では $300 クレジットが利用不可のため）。具体的な切替手順とトレードオフ（Lyria は Vertex 提供状況が流動的で AI Studio 推奨）は `automation/auth/SETUP.md` の「Vertex AI モードを使う場合」セクションを参照。
+
+既存の Google アカウント / GCP プロジェクトを流用できる場合は従来どおり AI Studio モード（`GEMINI_API_KEY`）で問題ない。
+
 ### Step 4: 最小 config 作成
 
 `benchmark_collector.py` 実行に必要な最小限の `channel_config.json` を Write ツールで作成:

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,21 @@
-# Google Gemini API Key (for image/video/music generation)
+# === Google AI プロバイダ選択 ===
+# デフォルト: Google AI Studio (API キー方式)
+#
+# 【新規 GCP アカウントの場合は Vertex AI モードを推奨】
+# 2026 年以降、Google Cloud の新規アカウントは前払い制のみで、
+# $300 無料クレジットは Vertex AI 経由でのみ消費可能になりました。
+# 新規セットアップでは Vertex AI モードを推奨します。
+# 詳細は auth/SETUP.md を参照。
+
+# --- Google AI Studio モード（デフォルト）---
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# --- Vertex AI モード（任意）---
+# 有効化するには以下 3 変数を設定し、`gcloud auth application-default login` で ADC を準備すること。
+# Lyria は Vertex AI での提供状況が流動的なため、音楽生成は AI Studio モード推奨。
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# GOOGLE_CLOUD_LOCATION=us-central1
 
 # Channel directory path (auto-detected if config/channel_config.json exists in CWD ancestors)
 # CHANNEL_DIR=/path/to/your/channel

--- a/auth/SETUP.md
+++ b/auth/SETUP.md
@@ -6,6 +6,20 @@ YouTube 自動アップロードシステム用の認証設定手順です。
 - Googleアカウント（YouTubeチャンネル所有者）
 - Python 3.5+ + 必要ライブラリがインストール済み
 
+## 💳 課金体系の変更について（2026 年〜）
+
+2026 年以降、Google Cloud の新規アカウントは **前払い（プリペイド）制のみ** に変更され、従来の **$300 無料クレジットは Google AI Studio の API キー経由では利用不可** になった。
+
+本リポジトリは YouTube Data API（無料枠で十分）に加えて、Gemini / Veo / Lyria など有料 API を利用する。**新規 GCP アカウントの場合、$300 クレジットは Vertex AI 経由でのみ消費可能** なため、以下の選択肢となる:
+
+| パターン | 推奨度 | 方式 |
+|---------|-------|------|
+| 既存の Google アカウント / GCP プロジェクトを流用 | ⭐⭐⭐ 最簡単 | AI Studio モード（従来通り）|
+| 新規 GCP アカウント + $300 クレジット活用 | ⭐⭐ 推奨 | Vertex AI モード（後述）|
+| 新規アカウントで AI Studio モード | — | 前払いで入金必要 |
+
+YouTube Data API / Analytics API は OAuth 認証で動作し、この変更の影響を受けない。
+
 ## 🚀 セットアップ手順
 
 ### Step 1: Google Cloud Console プロジェクト作成
@@ -63,6 +77,48 @@ auth/client_secrets.json
 auth/token.json
 ```
 
+## 🌐 Vertex AI モードを使う場合（任意）
+
+新規 GCP アカウントの $300 クレジットで Gemini / Veo を動かす場合、または GCP プロジェクトと AI 利用を一体化したい場合は Vertex AI モードを有効化する。
+
+### 追加セットアップ手順
+
+1. **Vertex AI API を有効化**
+   Google Cloud Console で「APIとサービス」→「ライブラリ」→ `Vertex AI API` を検索して有効化。
+
+2. **Application Default Credentials (ADC) の準備**
+   ```bash
+   gcloud auth application-default login
+   gcloud config set project <your-gcp-project-id>
+   ```
+
+3. **IAM ロールの確認**
+   認証したアカウントに最低 `roles/aiplatform.user` が付与されていること（プロジェクトオーナーなら付与済み）。
+
+4. **環境変数で Vertex AI モードに切替**
+   `.env` またはシェルに以下を設定:
+   ```bash
+   GOOGLE_GENAI_USE_VERTEXAI=true
+   GOOGLE_CLOUD_PROJECT=<your-gcp-project-id>
+   GOOGLE_CLOUD_LOCATION=us-central1   # 任意（デフォルト: us-central1）
+   ```
+
+5. **動作確認**
+   ```bash
+   uv run yt-generate-image --prompt "a gentle watercolor forest" --output /tmp/test.png -y
+   ```
+
+### 対応状況
+
+| API | AI Studio モード | Vertex AI モード |
+|-----|-----------------|------------------|
+| Gemini 画像生成（サムネイル等）| ✅ | ✅ |
+| Gemini 画像分析（ベンチマーク）| ✅ | ✅ |
+| Veo 動画生成（ループ動画/ショート）| ✅ | ✅ |
+| Lyria 音楽生成 | ✅ | ⚠️ Model Garden の提供状況次第。**Lyria を使う場合は AI Studio モード推奨** |
+
+Lyria を使う場合で Vertex AI モードに切り替えているとき、音楽生成ステップだけ `GOOGLE_GENAI_USE_VERTEXAI=false` で実行するか、シェル別で環境変数を分ける運用を推奨。
+
 ## 🔧 トラブルシューティング
 
 ### エラー: "client_secrets.json が見つかりません"
@@ -76,6 +132,12 @@ auth/token.json
 
 ### ブラウザが開かない
 → ファイアウォール設定を確認。ポート接続が許可されているか確認
+
+### Vertex AI モードで `GOOGLE_CLOUD_PROJECT が必須です` エラー
+→ `.env` に `GOOGLE_CLOUD_PROJECT=<project-id>` を設定。
+
+### Vertex AI モードで `Permission denied` / 認証エラー
+→ `gcloud auth application-default login` を実行し、認証済みアカウントに `roles/aiplatform.user` 以上が付与されているか確認
 
 ## 💡 使用後の確認事項
 認証が成功すると以下が表示されます：

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -37,7 +37,6 @@ from youtube_automation.utils.benchmark_analyzer import (  # noqa: E402
 )
 from youtube_automation.utils.channel_config import ChannelConfig  # noqa: E402
 from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
 
@@ -479,19 +478,18 @@ class BenchmarkThumbnailAnalyzer:
             thumbnail_analysis が追加された data
         """
         try:
-            get_gemini_api_key()
-        except ConfigError:
-            logger.warning("GEMINI_API_KEY 未設定 — サムネイル分析をスキップ")
-            return data
-
-        try:
-            from google import genai
             from google.genai import types
+
+            from youtube_automation.utils.genai_client import create_genai_client
         except ImportError:
             logger.warning("google-genai 未インストール — サムネイル分析をスキップ")
             return data
 
-        client = genai.Client()
+        try:
+            client = create_genai_client()
+        except ConfigError as e:
+            logger.warning("AI クライアント初期化失敗 — サムネイル分析をスキップ: %s", e)
+            return data
         thumbnails_dir = self.benchmarks_dir / "thumbnails" if keep else None
         if thumbnails_dir:
             thumbnails_dir.mkdir(parents=True, exist_ok=True)

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -119,7 +119,6 @@ def main():
         if not confirm_cost(model, cost_per_image):
             sys.exit(0)
 
-    # SDK インポート & クライアント生成
     try:
         from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -19,6 +19,7 @@ from pathlib import Path
 # --- パス解決 ---
 def _channel_root() -> Path:
     from youtube_automation.utils.channel_config import ChannelConfig
+
     return ChannelConfig.channel_dir()
 
 
@@ -34,7 +35,6 @@ from youtube_automation.utils.image_generator import (  # noqa: E402
     print_cost_summary,
     resolve_unique_path,
 )
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 
 
 def main():
@@ -54,9 +54,7 @@ def main():
         default=None,
         help="参照画像パス（複数指定可。複数指定時はスタイルブレンド/合成）",
     )
-    parser.add_argument(
-        "--aspect-ratio", type=str, default="16:9", help="アスペクト比（例: 16:9, 9:16, 1:1）"
-    )
+    parser.add_argument("--aspect-ratio", type=str, default="16:9", help="アスペクト比（例: 16:9, 9:16, 1:1）")
     parser.add_argument(
         "--size",
         type=str,
@@ -64,9 +62,7 @@ def main():
         default=DEFAULT_IMAGE_SIZE,
         help=f"画像解像度 {VALID_IMAGE_SIZES} （デフォルト: {DEFAULT_IMAGE_SIZE}）",
     )
-    parser.add_argument(
-        "--no-composition", action="store_true", help="composition_prefix の自動付加をスキップ"
-    )
+    parser.add_argument("--no-composition", action="store_true", help="composition_prefix の自動付加をスキップ")
     parser.add_argument(
         "--costs",
         action="store_true",
@@ -123,16 +119,9 @@ def main():
         if not confirm_cost(model, cost_per_image):
             sys.exit(0)
 
-    # API キー取得（os.environ → 1Password の順で試行、副作用で os.environ にもセット）
+    # SDK インポート & クライアント生成
     try:
-        get_gemini_api_key()
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-
-    # SDK インポート
-    try:
-        from google import genai
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  pip3 install google-genai Pillow --break-system-packages")
@@ -150,10 +139,17 @@ def main():
         reference_images.append(ref_path)
 
     # 生成実行
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
     start_time = time.monotonic()
     success = generate_image(
-        client, prompt, model, output_path,
+        client,
+        prompt,
+        model,
+        output_path,
         reference_image=reference_images or None,
         aspect_ratio=args.aspect_ratio,
         image_size=args.size,

--- a/src/youtube_automation/scripts/generate_loop_video.py
+++ b/src/youtube_automation/scripts/generate_loop_video.py
@@ -125,7 +125,6 @@ def main():
             print("  キャンセルしました。")
             sys.exit(0)
 
-    # SDK インポート & クライアント生成
     try:
         from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:

--- a/src/youtube_automation/scripts/generate_loop_video.py
+++ b/src/youtube_automation/scripts/generate_loop_video.py
@@ -25,11 +25,11 @@ from pathlib import Path
 # --- パス解決 ---
 def _channel_root() -> Path:
     from youtube_automation.utils.channel_config import ChannelConfig
+
     return ChannelConfig.channel_dir()
 
 
 from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 from youtube_automation.utils.veo_generator import (  # noqa: E402
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
@@ -42,6 +42,7 @@ def load_config() -> dict:
     """loop-video skill-config から veo セクションを読み込む。"""
     try:
         from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
+
         return load_skill_config("loop-video").get("veo", {})
     except Exception:
         return {}
@@ -69,6 +70,7 @@ def resolve_collection_paths(collection_path: Path) -> tuple[Path, Path]:
 
 def main():
     from dotenv import find_dotenv, load_dotenv
+
     load_dotenv(find_dotenv())
 
     parser = argparse.ArgumentParser(description="Veo 3.1 コレクションループ動画生成")
@@ -123,23 +125,20 @@ def main():
             print("  キャンセルしました。")
             sys.exit(0)
 
-    # API キー取得（os.environ → 1Password の順で試行、副作用で os.environ にもセット）
+    # SDK インポート & クライアント生成
     try:
-        get_gemini_api_key()
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-
-    # SDK インポート
-    try:
-        from google import genai
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  pip3 install google-genai --break-system-packages")
         sys.exit(1)
 
     # 生成実行
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
     start_time = time.monotonic()
     success = generate_loop_video(client, image_path, output_path, model, prompt)
 

--- a/src/youtube_automation/scripts/generate_music.py
+++ b/src/youtube_automation/scripts/generate_music.py
@@ -8,13 +8,11 @@ Usage:
 """
 
 import argparse
-import os
 import sys
 import time
 from pathlib import Path
 
 from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 
 
 def generate_music(client, types, prompt: str, model: str) -> bytes | None:
@@ -46,6 +44,7 @@ def generate_music(client, types, prompt: str, model: str) -> bytes | None:
 def main():
     try:
         from dotenv import find_dotenv, load_dotenv
+
         load_dotenv(find_dotenv())
     except ImportError:
         pass
@@ -58,7 +57,9 @@ def main():
     parser.add_argument("--prompt", "-p", required=True, help="音楽の説明テキスト")
     parser.add_argument("--output", "-o", default="output.mp3", help="出力ファイルパス (default: output.mp3)")
     parser.add_argument(
-        "--model", "-m", default="lyria-3-pro-preview",
+        "--model",
+        "-m",
+        default="lyria-3-pro-preview",
         choices=["lyria-3-pro-preview", "lyria-3-clip-preview"],
         help="モデル (default: lyria-3-pro-preview, clip は 30 秒固定)",
     )
@@ -83,23 +84,20 @@ def main():
             print("中止しました。")
             sys.exit(0)
 
-    # GOOGLE_API_KEY が既に export されていればそれを優先、無ければ get_gemini_api_key()
-    if not os.environ.get("GOOGLE_API_KEY"):
-        try:
-            get_gemini_api_key()
-        except ConfigError as e:
-            print(f"[ERROR] {e}")
-            sys.exit(1)
-
     try:
-        from google import genai
         from google.genai import types
+
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  uv pip install google-genai")
         sys.exit(1)
 
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
     print("\n  [生成中]...", end="", flush=True)
     start_time = time.monotonic()
 

--- a/src/youtube_automation/scripts/generate_music_dj.py
+++ b/src/youtube_automation/scripts/generate_music_dj.py
@@ -4,7 +4,6 @@
 import argparse
 import json
 import math
-import os
 import random
 import struct
 import sys
@@ -14,7 +13,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 from youtube_automation.utils.time_utils import format_duration_mmss  # noqa: E402
 
 SAMPLE_RATE = 48000
@@ -656,22 +654,20 @@ def main():
 
     dry_run(comp)
 
-    if not os.environ.get("GOOGLE_API_KEY"):
-        try:
-            get_gemini_api_key()
-        except ConfigError as e:
-            print(f"[ERROR] {e}")
-            sys.exit(1)
-
     try:
-        from google import genai
         from google.genai import types
+
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  uv pip install google-genai")
         sys.exit(1)
 
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
 
     if args.preview:
         output_dir = Path(args.output).resolve().parent / "preview"

--- a/src/youtube_automation/scripts/generate_short_loop.py
+++ b/src/youtube_automation/scripts/generate_short_loop.py
@@ -126,7 +126,6 @@ def main():
             print("  キャンセルしました。")
             sys.exit(0)
 
-    # SDK インポート & クライアント生成
     try:
         from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:

--- a/src/youtube_automation/scripts/generate_short_loop.py
+++ b/src/youtube_automation/scripts/generate_short_loop.py
@@ -25,11 +25,11 @@ from pathlib import Path
 # --- パス解決 ---
 def _channel_root() -> Path:
     from youtube_automation.utils.channel_config import ChannelConfig
+
     return ChannelConfig.channel_dir()
 
 
 from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 from youtube_automation.utils.veo_generator import (  # noqa: E402
     DEFAULT_MODEL,
     generate_loop_video,
@@ -51,6 +51,7 @@ def load_config() -> dict:
     """loop-video skill-config から veo セクションを読み込む。"""
     try:
         from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
+
         return load_skill_config("loop-video").get("veo", {})
     except Exception:
         return {}
@@ -65,6 +66,7 @@ def resolve_paths(collection_path: Path) -> tuple[Path, Path]:
 
 def main():
     from dotenv import find_dotenv, load_dotenv
+
     load_dotenv(find_dotenv())
 
     parser = argparse.ArgumentParser(description="Veo 3.1 ショート用 9:16 ループ動画生成")
@@ -124,23 +126,20 @@ def main():
             print("  キャンセルしました。")
             sys.exit(0)
 
-    # API キー取得（os.environ → 1Password の順で試行、副作用で os.environ にもセット）
+    # SDK インポート & クライアント生成
     try:
-        get_gemini_api_key()
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-
-    # SDK インポート
-    try:
-        from google import genai
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  pip3 install google-genai --break-system-packages")
         sys.exit(1)
 
     # 生成実行
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
     start_time = time.monotonic()
     success = generate_loop_video(client, image_path, output_path, model, prompt, aspect_ratio="9:16")
 

--- a/src/youtube_automation/scripts/generate_thumbnail.py
+++ b/src/youtube_automation/scripts/generate_thumbnail.py
@@ -25,6 +25,7 @@ from pathlib import Path
 # --- パス解決 ---
 def _channel_root() -> Path:
     from youtube_automation.utils.channel_config import ChannelConfig
+
     return ChannelConfig.channel_dir()
 
 
@@ -37,7 +38,6 @@ from youtube_automation.utils.image_generator import (  # noqa: E402
     load_gemini_config,
     resolve_unique_path,
 )
-from youtube_automation.utils.secrets import get_gemini_api_key  # noqa: E402
 
 
 def extract_prompt(prompts_md: Path, variation: str | None, use_text_overlay: bool = False) -> str:
@@ -189,16 +189,9 @@ def main():
         if not confirm_cost(model, cost_per_image):
             sys.exit(0)
 
-    # API キー取得（os.environ → 1Password の順で試行、副作用で os.environ にもセット）
+    # SDK インポート & クライアント生成
     try:
-        get_gemini_api_key()
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-
-    # SDK インポート
-    try:
-        from google import genai
+        from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:
         print("[ERROR] google-genai がインストールされていません。")
         print("  pip3 install google-genai Pillow --break-system-packages")
@@ -216,7 +209,11 @@ def main():
         reference_images.append(ref_path)
 
     # 生成実行
-    client = genai.Client()
+    try:
+        client = create_genai_client()
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
     start_time = time.monotonic()
     success = generate_image(
         client,

--- a/src/youtube_automation/scripts/generate_thumbnail.py
+++ b/src/youtube_automation/scripts/generate_thumbnail.py
@@ -189,7 +189,6 @@ def main():
         if not confirm_cost(model, cost_per_image):
             sys.exit(0)
 
-    # SDK インポート & クライアント生成
     try:
         from youtube_automation.utils.genai_client import create_genai_client
     except ImportError:

--- a/src/youtube_automation/utils/genai_client.py
+++ b/src/youtube_automation/utils/genai_client.py
@@ -1,0 +1,56 @@
+"""google-genai Client 生成の抽象化ヘルパー。
+
+呼び出し側は `create_genai_client()` を使うことで、
+Google AI Studio (API キー) と Vertex AI (ADC + GCP project) を
+環境変数で切り替えられる。
+
+- デフォルト: Google AI Studio (API キー = GEMINI_API_KEY)
+- GOOGLE_GENAI_USE_VERTEXAI=true で Vertex AI に切替
+  - 認証は ADC (Application Default Credentials)
+  - GOOGLE_CLOUD_PROJECT と GOOGLE_CLOUD_LOCATION (default: us-central1) を参照
+
+新規 GCP アカウント (2026/04~) では $300 無料クレジットが
+Vertex AI 経由でのみ消費可能なため、該当ケースでは Vertex AI モードを推奨。
+"""
+
+from __future__ import annotations
+
+import os
+
+from google import genai
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.secrets import get_gemini_api_key
+
+_TRUTHY = {"true", "1", "yes"}
+_DEFAULT_LOCATION = "us-central1"
+
+
+def _use_vertex() -> bool:
+    return os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").strip().lower() in _TRUTHY
+
+
+def create_genai_client() -> genai.Client:
+    """環境変数に応じて google-genai Client を初期化する。
+
+    Returns:
+        genai.Client: 初期化済みクライアント。呼び出し側は
+            `client.models.generate_content(...)` など共通 API をそのまま使える。
+
+    Raises:
+        ConfigError: Vertex AI モードで GOOGLE_CLOUD_PROJECT が未設定の場合、
+            または AI Studio モードで GEMINI_API_KEY が取得できない場合。
+    """
+    if _use_vertex():
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        location = os.environ.get("GOOGLE_CLOUD_LOCATION", _DEFAULT_LOCATION)
+        if not project:
+            raise ConfigError(
+                "Vertex AI モード (GOOGLE_GENAI_USE_VERTEXAI=true) では "
+                "GOOGLE_CLOUD_PROJECT が必須です。\n"
+                "  → .env に GOOGLE_CLOUD_PROJECT=<gcp-project-id> を設定し、\n"
+                "  → `gcloud auth application-default login` で ADC を準備してください"
+            )
+        return genai.Client(vertexai=True, project=project, location=location)
+
+    return genai.Client(api_key=get_gemini_api_key())

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -1,0 +1,118 @@
+"""utils/genai_client.py のユニットテスト。
+
+環境変数による AI Studio / Vertex AI 切替ロジックを検証する:
+
+1. デフォルト (GOOGLE_GENAI_USE_VERTEXAI 未設定) → `genai.Client(api_key=...)`
+2. GOOGLE_GENAI_USE_VERTEXAI=true + PROJECT 設定 → `genai.Client(vertexai=True, project, location)`
+3. GOOGLE_GENAI_USE_VERTEXAI=true + PROJECT 未設定 → ConfigError
+4. GOOGLE_CLOUD_LOCATION が反映される
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from youtube_automation.utils.exceptions import ConfigError
+
+_ENV_KEYS = ("GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """各テスト前後で関連環境変数をクリーンにする"""
+    saved = {k: os.environ.pop(k, None) for k in _ENV_KEYS}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class TestCreateGenaiClient:
+    def test_default_uses_api_key(self):
+        """環境変数未設定時は API キーモードで初期化される"""
+        from youtube_automation.utils import genai_client
+
+        with (
+            patch.object(genai_client, "get_gemini_api_key", return_value="test-key"),
+            patch.object(genai_client.genai, "Client") as mock_client,
+        ):
+            genai_client.create_genai_client()
+
+        mock_client.assert_called_once_with(api_key="test-key")
+
+    def test_vertex_mode_true_uses_vertex(self):
+        """GOOGLE_GENAI_USE_VERTEXAI=true で Vertex AI モードに切り替わる"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
+
+        from youtube_automation.utils import genai_client
+
+        with patch.object(genai_client.genai, "Client") as mock_client:
+            genai_client.create_genai_client()
+
+        mock_client.assert_called_once_with(vertexai=True, project="my-project", location="us-central1")
+
+    def test_vertex_mode_case_insensitive(self):
+        """GOOGLE_GENAI_USE_VERTEXAI は大文字小文字を問わず真偽を判定する"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "p"
+
+        from youtube_automation.utils import genai_client
+
+        with patch.object(genai_client.genai, "Client") as mock_client:
+            genai_client.create_genai_client()
+
+        assert mock_client.call_args.kwargs["vertexai"] is True
+
+    def test_vertex_mode_accepts_numeric_truthy(self):
+        """GOOGLE_GENAI_USE_VERTEXAI=1 も真として扱われる"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "1"
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "p"
+
+        from youtube_automation.utils import genai_client
+
+        with patch.object(genai_client.genai, "Client") as mock_client:
+            genai_client.create_genai_client()
+
+        assert mock_client.call_args.kwargs["vertexai"] is True
+
+    def test_vertex_mode_false_falls_back_to_api_key(self):
+        """GOOGLE_GENAI_USE_VERTEXAI=false は API キーモードのまま"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "false"
+
+        from youtube_automation.utils import genai_client
+
+        with (
+            patch.object(genai_client, "get_gemini_api_key", return_value="test-key"),
+            patch.object(genai_client.genai, "Client") as mock_client,
+        ):
+            genai_client.create_genai_client()
+
+        mock_client.assert_called_once_with(api_key="test-key")
+
+    def test_vertex_mode_without_project_raises_config_error(self):
+        """Vertex AI モードで PROJECT 未設定なら ConfigError"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+
+        from youtube_automation.utils import genai_client
+
+        with pytest.raises(ConfigError, match="GOOGLE_CLOUD_PROJECT"):
+            genai_client.create_genai_client()
+
+    def test_vertex_mode_respects_custom_location(self):
+        """GOOGLE_CLOUD_LOCATION で location を上書きできる"""
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
+        os.environ["GOOGLE_CLOUD_LOCATION"] = "europe-west4"
+
+        from youtube_automation.utils import genai_client
+
+        with patch.object(genai_client.genai, "Client") as mock_client:
+            genai_client.create_genai_client()
+
+        mock_client.assert_called_once_with(vertexai=True, project="my-project", location="europe-west4")


### PR DESCRIPTION
## 概要

2026 年以降、Google Cloud の新規アカウントは前払い制のみとなり、$300 無料クレジットは Vertex AI 経由でのみ利用可能に変更された。このため既存スクリプトが新規 GCP アカウントで無料枠で動かない問題を解決する。

Closes #33

## 設計判断

- 環境変数 1 つ (`GOOGLE_GENAI_USE_VERTEXAI`) で AI Studio ↔ Vertex AI を切替えられる `create_genai_client()` ファクトリを追加
  - 比較検討: `channel_config.json` に設定キーを追加する案があったが、シークレット系の分岐をコンフィグに持ち込むのは不自然なため env var に統一
  - 比較検討: SDK を別物 (`vertexai` 系) に切り替える案があったが、`google-genai` v1+ は `Client(vertexai=True, ...)` で呼び出しインターフェース共通のため SDK 差し替え不要
- 既存 7 箇所のクライアント初期化を新ヘルパーに統一
- Lyria は Vertex AI での提供状況が流動的なため、ドキュメント側で AI Studio モード推奨を明記（SDK 呼び出し自体は対応済み）
- `generate_music.py` / `generate_music_dj.py` の `GOOGLE_API_KEY` 優先ロジックは破壊的変更として削除し `GEMINI_API_KEY` に統一

## 変更内容

- 新規: `src/youtube_automation/utils/genai_client.py` — 環境変数で AI Studio / Vertex AI を切替
- 新規: `tests/test_genai_client.py` — 7 ケースで切替ロジックを網羅
- 既存 7 スクリプト (`generate_thumbnail/image/loop_video/short_loop/music/music_dj`, `benchmark_collector`) のクライアント初期化を `create_genai_client()` に差し替え
- `.env.example` / `auth/SETUP.md` / `.claude/skills/channel-new/SKILL.md` に課金体系変更と Vertex AI セットアップ手順を追記

## テスト計画

- [ ] AI Studio モード（従来通り）: `GEMINI_API_KEY` を設定して `uv run yt-generate-image --prompt "..." --output /tmp/test.png -y` が成功する
- [ ] Vertex AI モード: `gcloud auth application-default login` 後、`GOOGLE_GENAI_USE_VERTEXAI=true`, `GOOGLE_CLOUD_PROJECT=<id>` を設定して同スクリプトが成功する
- [ ] Vertex AI モードで `GOOGLE_CLOUD_PROJECT` 未設定の場合、ConfigError が `gcloud auth application-default login` の案内付きで表示される
- [ ] `uv run pytest` が 全 pass（405 件 + 新規 7 件）
- [ ] `uv run ruff check .` がクリーン