### PR TITLE
release: v2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "2.0.0"
+version = "2.0.1"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
## Summary

v2.0.1 リリース（patch）

### Changes since v2.0.0

- fix: yt-generate-suno の `--help` フラグが YAML パスとして誤解釈される問題を修正 (#41)
- chore: wf-* / status スキルの triggering 競合を解消

## Version bump

- pyproject.toml: `2.0.0` → `2.0.1`
- src/youtube_automation/__init__.py: `2.0.0` → `2.0.1`