### PR TITLE
release: v2.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "2.0.1"
+version = "2.0.2"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "2.0.0"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

v2.0.2 パッチリリース

### 変更内容（v2.0.1 以降のコミット）

- 9875fcf chore(skills): channel-setup スキルの references から v2.0.0 移行残骸を除去 (#47)
- 3b47c0e refactor(ideate): 前提スキル鮮度判定ロジックを references/ に分離 (#46)
- 00d425a docs(skills): suno / lyria / masterup の description を前後工程明記で再分担 (#45)
- c6835dc refactor(short): FFmpeg パイプラインを scripts/ へ抽出して非推奨コードを削除 (#44)

いずれも chore / refactor / docs のみのため patch バンプ。

## Test plan

- [x] `pyproject.toml` の version 更新
- [x] `src/youtube_automation/__init__.py` の `__version__` 更新
- [x] `uv.lock` 再生成
- [ ] マージ後に `gh release create v2.0.2 --target main --generate-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)