### PR TITLE
feat!: GCP / Vertex AI セットアップを自動化、AI Studio モードを廃止

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -47,10 +47,9 @@ uv run yt-skills sync
 
 ### Step 3: 認証セットアップ
 
-OAuth クライアントはユーザーが自分で作成する。Google Cloud Console で OAuth 2.0 認証情報を作成し `auth/client_secrets.json` に配置すること。
-チャンネル固有トークンは `auth/token.json` に保存され、初回実行時に自動生成される。
+`/channel-new` 段階では **リサーチ用の最低限認証** のみ整える（競合ベンチマーク収集のため）。本番用 GCP プロジェクトと OAuth クライアントは `/channel-setup` の GCP / Vertex AI ブートストラップ step で自動化する。
 
-リサーチ段階では既存チャンネルのトークンをコピーして使用可能（YouTube Data API はチャンネル所有権に関係なく動作）:
+**リサーチ用ショートカット**: 既存チャンネルのトークンをコピーして使用可能（YouTube Data API はチャンネル所有権に関係なく動作）:
 
 ```bash
 cp /path/to/existing-channel-repo/auth/token.json auth/token.json
@@ -58,11 +57,7 @@ cp /path/to/existing-channel-repo/auth/token.json auth/token.json
 
 デフォルトのコピー元は `youtube-fantasy-celtic-music`。他のチャンネルを使いたい場合はユーザーに確認。
 
-**AI 生成系 API（Gemini/Veo/Lyria）の認証について**:
-
-新規 GCP アカウントで $300 クレジットを使いたい場合は **Vertex AI モード** を推奨する（2026 年以降、Google AI Studio の API キー経路では $300 クレジットが利用不可のため）。具体的な切替手順とトレードオフ（Lyria は Vertex 提供状況が流動的で AI Studio 推奨）は `automation/auth/SETUP.md` の「Vertex AI モードを使う場合」セクションを参照。
-
-既存の Google アカウント / GCP プロジェクトを流用できる場合は従来どおり AI Studio モード（`GEMINI_API_KEY`）で問題ない。
+本番用の GCP プロジェクト作成 / API 有効化 / Vertex AI 設定 / `.env` 書き出しは `/channel-setup` の GCP ブートストラップ step で AI セッション内完結させる（判断フローは `channel-setup/references/gcp-bootstrap.md`）。
 
 ### Step 4: 最小 config 作成
 

--- a/.claude/skills/channel-setup/SKILL.md
+++ b/.claude/skills/channel-setup/SKILL.md
@@ -49,12 +49,23 @@ Phase 1 で `/channel-new` が作成した最小 config を完全版に拡張。
 | `config/localizations.json` | `references/localizations-template.json` をコピーし、ジャンル情報を反映した具体的な文言に調整。多言語展開しないチャンネルは省略可（`load_config().localizations.supported_languages` は `youtube.api.language` へフォールバック）。`config/localizations.json` が唯一の Canonical ソース |
 | `.claude/CLAUDE.md` | `references/claude-md-template.md` の `{{CHANNEL_NAME}}` / `{{DIR_NAME}}` を置換 |
 
-### Step 6: 検証
+### Step 6: GCP / Vertex AI ブートストラップ
+
+新チャンネルの GCP プロジェクト + API + IAM + `.env` をセットアップする。判断基準・コマンド・リカバリ手順は **`references/gcp-bootstrap.md`** を参照。
+
+ユーザーに以下を確認してから実行する:
+- 既存プロジェクトを流用するか / 新規作成するか
+- terraform ルート（IaC 管理）を使うか / bootstrap.sh（最速）か
+- Billing account ID（新規作成時のみ必要）
+
+実行後、スクリプト出力の Console URL を開き OAuth 2.0 クライアント ID を **手動で 1 回作成**して `auth/client_secrets.json` に配置するよう案内する（gcloud / terraform 双方この手順だけ未サポート）。
+
+### Step 7: 検証
 
 JSON 構文検証・config ロードテスト・channel_id 自動取得コマンドは **`references/verification.md`** を参照。
 検証後、生成された全ファイルを一覧で確認する。
 
-### Step 7: 次ステップ案内
+### Step 8: 次ステップ案内
 
 1. **YouTube チャンネル作成**（まだの場合）→ `config/channel/meta.json` の `channel.youtube_handle`、`channel.url`、`channel.channel_id` を更新
 2. **OAuth 認証と channel_id 取得**: 手順は `references/verification.md`（「OAuth 認証」「channel_id の自動取得」）を参照

--- a/.claude/skills/channel-setup/references/gcp-bootstrap.md
+++ b/.claude/skills/channel-setup/references/gcp-bootstrap.md
@@ -1,0 +1,94 @@
+# GCP / Vertex AI ブートストラップ
+
+新チャンネル用の GCP プロジェクト + API + 認証情報を用意するためのリファレンス。
+`/channel-new` / `/channel-setup` から共通参照する。
+
+上流リポジトリ (youtube-channels-automation) の `auth/SETUP.md` と `infra/terraform/gcp/README.md` が詳細版。このリファレンスは **スキルが実行するときの判断材料** に絞ってある。
+
+## 意思決定: どのルートで立ち上げるか
+
+```
+┌─ 既存 GCP プロジェクトをそのまま流用したい?
+│  ├─ Yes → ルート A (bootstrap.sh、--create なし)
+│  └─ No
+│     ├─ tfstate で構成管理したい or Organization 統制必須?
+│     │  ├─ Yes → ルート B (terraform)
+│     │  └─ No → ルート A (bootstrap.sh、--create 付き)
+```
+
+- **ルート A** (`scripts/gcp-bootstrap.sh`): 最速。gcloud を順次叩くだけの冪等シェル。
+- **ルート B** (`infra/terraform/gcp/`): 宣言的 IaC。複数環境・多人数運用向け。
+
+## 実行コマンド
+
+### ルート A: bootstrap.sh
+
+チャンネルリポジトリから実行する場合（yt-skills sync 配布後のパスを使う）:
+
+```bash
+SKILL_REF="$(git rev-parse --show-toplevel)/.claude/skills/channel-setup/references"
+
+# 新規作成 (Billing account を渡す)
+bash "$SKILL_REF/gcp-bootstrap.sh" \
+  --create \
+  --billing-account <BILLING_ACCOUNT_ID> \
+  <PROJECT_ID>
+
+# 既存流用
+bash "$SKILL_REF/gcp-bootstrap.sh" <PROJECT_ID>
+```
+
+automation リポジトリ側で開発中なら `scripts/gcp-bootstrap.sh` を直接叩いてもよい（中身は同じ）。冪等なので何度再実行しても安全。ドライランは `--dry-run`。
+
+### ルート B: terraform
+
+```bash
+SKILL_REF="$(git rev-parse --show-toplevel)/.claude/skills/channel-setup/references"
+
+# tfvars を用意 (初回のみ)
+cp "$SKILL_REF/terraform-gcp/terraform.tfvars.example" \
+   "$SKILL_REF/terraform-gcp/terraform.tfvars"
+# → project_id, adc_email, billing_account を編集
+
+bash "$SKILL_REF/gcp-terraform-apply.sh" \
+  --tf-dir "$SKILL_REF/terraform-gcp"
+```
+
+`gcp-terraform-apply.sh` が `terraform init && apply` → `.env` への値反映までラップする。
+
+automation リポジトリ側では `infra/terraform/gcp/` を canonical ディレクトリとして利用できる。
+
+## 残る手動ステップ: OAuth クライアント ID
+
+いずれのルートでも **OAuth 2.0 クライアント ID の作成だけは Console での 1 クリックが残る**（gcloud / Terraform 双方未サポート）。
+
+スクリプト実行後に出力される URL を開き:
+1. 「認証情報を作成」→「OAuth クライアント ID」
+2. アプリケーションの種類: 「デスクトップ」
+3. ダウンロード JSON を **チャンネルリポジトリの `auth/client_secrets.json`** に配置
+
+## 前提チェック
+
+実行前に確認すべき点:
+
+- [ ] `gcloud` コマンドがインストール済み
+- [ ] `gcloud auth login` 済み（`gcloud auth list` で ACTIVE な account がある）
+- [ ] 新規作成する場合: Billing Account に対する `roles/billing.user` 以上
+- [ ] 新規作成する場合: Organization or 個人アカウントでのプロジェクト作成権限
+
+terraform ルートの場合は追加で:
+- [ ] `terraform` >= 1.5
+- [ ] `jq`
+- [ ] `gcloud auth application-default login` で ADC も取得済み
+
+## 失敗時のリカバリ
+
+| 症状 | 対処 |
+|------|------|
+| `billingEnabled` エラーで API 有効化失敗 | `--billing-account` を付けて再実行。Console で billing 紐付けを直接確認 |
+| `Permission denied` / IAM 付与で 403 | 別アカウントでログインしているケース。`gcloud auth list` で ACTIVE を確認 |
+| プロジェクト作成上限エラー | 不要 project を削除、または緩和申請 |
+| ADC の quota project がズレている | `gcloud auth application-default set-quota-project <id>` |
+| tfstate が壊れた | `terraform.tfstate*` を削除して `terraform import` からやり直すか、bootstrap.sh ルートに切替 |
+
+その他詳細は上流の `auth/SETUP.md` の「トラブルシューティング」節。

--- a/.claude/skills/channel-setup/references/gcp-bootstrap.sh
+++ b/.claude/skills/channel-setup/references/gcp-bootstrap.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# gcp-bootstrap.sh — 新チャンネル用 GCP プロジェクトの半自動セットアップ
+#
+# 何をするか:
+#   1. gcloud / ログイン状態の前提チェック
+#   2. プロジェクト作成 (--create) or 既存流用
+#   3. Billing account の紐付け (任意)
+#   4. 必要 API の有効化 (冪等)
+#        - youtube.googleapis.com
+#        - youtubeanalytics.googleapis.com
+#        - aiplatform.googleapis.com
+#        - generativelanguage.googleapis.com
+#   5. Application Default Credentials (ADC) ログイン + quota project 設定
+#   6. roles/aiplatform.user を ADC ユーザーに付与
+#   7. .env に GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION / GOOGLE_GENAI_USE_VERTEXAI を書き出し
+#   8. OAuth クライアント ID 作成のための Console URL を案内 (この 1 クリックだけ手動)
+#
+# Usage:
+#   scripts/gcp-bootstrap.sh [OPTIONS] <project-id>
+#
+# Options:
+#   --create                      プロジェクトが存在しなければ作成する
+#   --billing-account <ID>        billing account を紐付ける (例: 012345-6789AB-CDEF01)
+#   --adc-email <EMAIL>           IAM 付与対象の Google アカウント (未指定なら gcloud config account)
+#   --env-file <PATH>             書き込む .env のパス (既定: ./.env)
+#   --location <REGION>           Vertex AI リージョン (既定: us-central1)
+#   --skip-adc                    `gcloud auth application-default login` を省略
+#   --dry-run                     変更せず何をするか表示
+#   -h, --help                    このヘルプを表示
+#
+# Examples:
+#   scripts/gcp-bootstrap.sh my-yt-channel
+#   scripts/gcp-bootstrap.sh --create --billing-account 01ABCD-234567-89EFGH my-new-channel
+#   scripts/gcp-bootstrap.sh --env-file .env.local --location asia-northeast1 my-proj
+
+set -euo pipefail
+
+CREATE_PROJECT=false
+BILLING_ACCOUNT=""
+ADC_EMAIL=""
+ENV_FILE="./.env"
+LOCATION="us-central1"
+SKIP_ADC=false
+DRY_RUN=false
+PROJECT_ID=""
+
+REQUIRED_APIS=(
+    "youtube.googleapis.com"
+    "youtubeanalytics.googleapis.com"
+    "aiplatform.googleapis.com"
+    "generativelanguage.googleapis.com"
+)
+
+log()   { printf '\033[0;36m[bootstrap]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+warn()  { printf '\033[0;33m[warn]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() {
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --create) CREATE_PROJECT=true; shift ;;
+        --billing-account) BILLING_ACCOUNT="$2"; shift 2 ;;
+        --billing-account=*) BILLING_ACCOUNT="${1#*=}"; shift ;;
+        --adc-email) ADC_EMAIL="$2"; shift 2 ;;
+        --adc-email=*) ADC_EMAIL="${1#*=}"; shift ;;
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --env-file=*) ENV_FILE="${1#*=}"; shift ;;
+        --location) LOCATION="$2"; shift 2 ;;
+        --location=*) LOCATION="${1#*=}"; shift ;;
+        --skip-adc) SKIP_ADC=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) error "未知のオプション: $1"; usage; exit 2 ;;
+        *)
+            if [[ -z "$PROJECT_ID" ]]; then
+                PROJECT_ID="$1"
+            else
+                error "project-id が複数指定されました: $PROJECT_ID, $1"
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PROJECT_ID" ]]; then
+    error "project-id は必須です"
+    usage
+    exit 2
+fi
+
+run() {
+    if $DRY_RUN; then
+        printf '\033[0;35m[dry-run]\033[0m %s\n' "$*"
+    else
+        log "$*"
+        "$@"
+    fi
+}
+
+log "Step 1: 前提チェック"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+    error "gcloud CLI が見つかりません。https://cloud.google.com/sdk/docs/install を参照してインストールしてください"
+    exit 1
+fi
+ok "gcloud: $(gcloud --version | head -n1)"
+
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '@'; then
+    error "gcloud にログインしていません。先に \`gcloud auth login\` を実行してください"
+    exit 1
+fi
+CURRENT_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" | head -n1)
+ok "gcloud active account: ${CURRENT_ACCOUNT}"
+
+if [[ -z "$ADC_EMAIL" ]]; then
+    ADC_EMAIL="$CURRENT_ACCOUNT"
+fi
+log "ADC email (IAM 付与対象): ${ADC_EMAIL}"
+
+log "Step 2: プロジェクト確認"
+
+project_exists() {
+    gcloud projects describe "$PROJECT_ID" --format="value(projectId)" >/dev/null 2>&1
+}
+
+if project_exists; then
+    ok "プロジェクト ${PROJECT_ID} は既に存在します (流用)"
+else
+    if $CREATE_PROJECT; then
+        run gcloud projects create "$PROJECT_ID" --name="$PROJECT_ID"
+        ok "プロジェクト ${PROJECT_ID} を作成しました"
+    else
+        error "プロジェクト ${PROJECT_ID} が存在しません。--create を付けて作成するか、既存の project-id を指定してください"
+        exit 1
+    fi
+fi
+
+# 以降の gcloud コマンドで project を固定
+run gcloud config set project "$PROJECT_ID"
+
+if [[ -n "$BILLING_ACCOUNT" ]]; then
+    log "Step 3: Billing account 紐付け"
+    CURRENT_BILLING=$(gcloud beta billing projects describe "$PROJECT_ID" \
+        --format="value(billingAccountName)" 2>/dev/null || echo "")
+    if [[ "$CURRENT_BILLING" == *"$BILLING_ACCOUNT"* ]]; then
+        ok "Billing account ${BILLING_ACCOUNT} は既に紐付け済み"
+    else
+        run gcloud beta billing projects link "$PROJECT_ID" \
+            --billing-account="$BILLING_ACCOUNT"
+        ok "Billing account ${BILLING_ACCOUNT} を紐付けました"
+    fi
+else
+    warn "Step 3: --billing-account 未指定のため billing 紐付けはスキップ (aiplatform 等の有料 API は billing 未紐付けだと利用できません)"
+fi
+
+log "Step 4: 必要 API の有効化"
+
+ENABLED_APIS=$(gcloud services list --enabled --project="$PROJECT_ID" \
+    --format="value(config.name)" 2>/dev/null || echo "")
+
+for api in "${REQUIRED_APIS[@]}"; do
+    if echo "$ENABLED_APIS" | grep -qx "$api"; then
+        ok "${api}: 既に有効"
+    else
+        run gcloud services enable "$api" --project="$PROJECT_ID"
+        ok "${api}: 有効化しました"
+    fi
+done
+
+if $SKIP_ADC; then
+    warn "Step 5: --skip-adc のため ADC ログインをスキップ"
+else
+    log "Step 5: ADC ログイン (ブラウザが開きます)"
+    run gcloud auth application-default login
+    run gcloud auth application-default set-quota-project "$PROJECT_ID"
+    ok "ADC ログイン完了 & quota project を ${PROJECT_ID} に設定"
+fi
+
+log "Step 6: IAM 付与 (roles/aiplatform.user → ${ADC_EMAIL})"
+
+HAS_ROLE=$(gcloud projects get-iam-policy "$PROJECT_ID" \
+    --flatten="bindings[].members" \
+    --filter="bindings.role:roles/aiplatform.user AND bindings.members:user:${ADC_EMAIL}" \
+    --format="value(bindings.role)" 2>/dev/null || echo "")
+
+if [[ -n "$HAS_ROLE" ]]; then
+    ok "user:${ADC_EMAIL} は既に roles/aiplatform.user を保持"
+else
+    run gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+        --member="user:${ADC_EMAIL}" \
+        --role="roles/aiplatform.user" \
+        --condition=None \
+        --quiet
+    ok "roles/aiplatform.user を付与しました"
+fi
+
+log "Step 7: ${ENV_FILE} へ書き出し"
+
+# gcp-terraform-apply.sh の write_env_var と awk コア部分は同一 (ドリフト時は両方揃えること)
+write_env_var() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    if $DRY_RUN; then
+        printf '\033[0;35m[dry-run]\033[0m %s=%s → %s\n' "$key" "$value" "$file"
+        return
+    fi
+
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+
+    local tmp
+    tmp=$(mktemp)
+    awk -v k="$key" -v v="$value" '
+        BEGIN { done = 0 }
+        $0 ~ "^" k "=" { print k "=" v; done = 1; next }
+        { print }
+        END { if (!done) print k "=" v }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
+write_env_var "GOOGLE_GENAI_USE_VERTEXAI" "true" "$ENV_FILE"
+write_env_var "GOOGLE_CLOUD_PROJECT" "$PROJECT_ID" "$ENV_FILE"
+write_env_var "GOOGLE_CLOUD_LOCATION" "$LOCATION" "$ENV_FILE"
+ok "${ENV_FILE} に Vertex AI 用環境変数を書き出しました"
+
+cat <<EOF
+
+---- 最後に手動で 1 ステップ必要 ----
+gcloud からは OAuth 2.0 クライアント ID を作成できないため、Console で作成してください:
+
+  https://console.cloud.google.com/apis/credentials?project=${PROJECT_ID}
+
+手順:
+  1. 「認証情報を作成」→「OAuth クライアント ID」
+  2. アプリケーションの種類: 「デスクトップ」
+  3. ダウンロードした JSON を auth/client_secrets.json として配置
+     (チャンネルリポジトリ側の auth/ ディレクトリ)
+
+詳細は auth/SETUP.md を参照。
+-----------------------------------
+
+EOF
+
+ok "GCP ブートストラップ完了: project=${PROJECT_ID}, location=${LOCATION}"

--- a/.claude/skills/channel-setup/references/gcp-terraform-apply.sh
+++ b/.claude/skills/channel-setup/references/gcp-terraform-apply.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# gcp-terraform-apply.sh — Terraform apply → .env 書き出しまでを 1 コマンドで
+#
+# Usage:
+#   scripts/gcp-terraform-apply.sh [--tf-dir DIR] [--env-file PATH] [--auto-approve]
+#
+# Options:
+#   --tf-dir DIR       Terraform モジュールパス (既定: infra/terraform/gcp)
+#   --env-file PATH    書き出す .env (既定: ./.env)
+#   --auto-approve     terraform apply に -auto-approve を付ける
+#   -h, --help         このヘルプ
+
+set -euo pipefail
+
+TF_DIR="infra/terraform/gcp"
+ENV_FILE="./.env"
+AUTO_APPROVE=false
+
+log()   { printf '\033[0;36m[tf-apply]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() { sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tf-dir) TF_DIR="$2"; shift 2 ;;
+        --tf-dir=*) TF_DIR="${1#*=}"; shift ;;
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --env-file=*) ENV_FILE="${1#*=}"; shift ;;
+        --auto-approve) AUTO_APPROVE=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) error "未知のオプション: $1"; usage; exit 2 ;;
+    esac
+done
+
+command -v terraform >/dev/null 2>&1 || {
+    error "terraform が見つかりません: https://developer.hashicorp.com/terraform/install"
+    exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+    error "jq が見つかりません (brew install jq)"
+    exit 1
+}
+
+[[ -d "$TF_DIR" ]] || { error "tf-dir が存在しません: $TF_DIR"; exit 1; }
+
+if [[ "$ENV_FILE" = /* ]]; then
+    ENV_FILE_ABS="$ENV_FILE"
+else
+    ENV_FILE_ABS="$(pwd)/$ENV_FILE"
+fi
+
+# gcp-bootstrap.sh の write_env_var と同一実装 (ドリフト時は両方揃えること)
+write_env_var() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+
+    local tmp
+    tmp=$(mktemp)
+    awk -v k="$key" -v v="$value" '
+        BEGIN { done = 0 }
+        $0 ~ "^" k "=" { print k "=" v; done = 1; next }
+        { print }
+        END { if (!done) print k "=" v }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
+log "Terraform apply: $TF_DIR"
+pushd "$TF_DIR" >/dev/null
+terraform init -upgrade
+if $AUTO_APPROVE; then
+    terraform apply -auto-approve
+else
+    terraform apply
+fi
+
+ENV_JSON=$(terraform output -json env_vars)
+OAUTH_URL=$(terraform output -raw oauth_console_url)
+PROJECT_ID=$(terraform output -raw project_id)
+popd >/dev/null
+
+while IFS=$'\t' read -r key value; do
+    write_env_var "$key" "$value" "$ENV_FILE_ABS"
+done < <(echo "$ENV_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
+
+ok ".env updated: $ENV_FILE_ABS (project=$PROJECT_ID)"
+
+cat <<EOF
+
+---- 最後に手動で 1 ステップ必要 ----
+OAuth 2.0 クライアント ID を Console で作成:
+
+  $OAUTH_URL
+
+手順:
+  1. 「認証情報を作成」→「OAuth クライアント ID」
+  2. アプリケーションの種類: 「デスクトップ」
+  3. ダウンロード JSON を auth/client_secrets.json に配置
+
+詳細は auth/SETUP.md を参照。
+-----------------------------------
+
+EOF

--- a/.claude/skills/channel-setup/references/terraform-gcp/.gitignore
+++ b/.claude/skills/channel-setup/references/terraform-gcp/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/.claude/skills/channel-setup/references/terraform-gcp/README.md
+++ b/.claude/skills/channel-setup/references/terraform-gcp/README.md
@@ -1,0 +1,79 @@
+# infra/terraform/gcp
+
+新チャンネル用の GCP プロジェクト + 必要 API + IAM を Terraform で IaC 管理するモジュール。
+
+`scripts/gcp-bootstrap.sh` が gcloud ベースの半自動化ルートなら、こちらは **本命の宣言的セットアップ**。プロジェクトの構成を tfstate として管理したい場合はこちらを使う。
+
+## 管理するリソース
+
+- `google_project`（`create_project=true` 時のみ）
+- `google_project_service` × 4
+  - `youtube.googleapis.com`
+  - `youtubeanalytics.googleapis.com`
+  - `aiplatform.googleapis.com`
+  - `generativelanguage.googleapis.com`
+- `google_project_iam_member` = `roles/aiplatform.user` → `var.adc_email`
+
+**OAuth 2.0 クライアント ID は google provider で未サポート** のため、別途 Console から作成する（この 1 ステップだけ手動）。
+
+## 前提
+
+- `terraform` >= 1.5 インストール済み
+- `gcloud auth application-default login` 実行済み（Terraform は ADC 経由で認証）
+- Project を新規作成する場合: Organization / Billing Account に対する権限保持
+
+## 使い方
+
+```bash
+# 1. tfvars を用意
+cd infra/terraform/gcp
+cp terraform.tfvars.example terraform.tfvars
+# → project_id, adc_email, billing_account を実値に書き換え
+
+# 2. apply
+terraform init
+terraform plan
+terraform apply
+
+# 3. outputs から .env を更新 (ラッパー推奨)
+bash ../../../scripts/gcp-terraform-apply.sh --tf-dir . --env-file ../../../.env
+```
+
+`scripts/gcp-terraform-apply.sh` は `terraform apply` → `terraform output -json env_vars` → `.env` へマージまで一気通貫で実行する。
+
+## 既存プロジェクトを流用する場合
+
+`terraform.tfvars`:
+
+```hcl
+project_id     = "existing-project-id"
+create_project = false
+adc_email      = "you@example.com"
+# billing_account は不要 (既存で設定済み前提)
+```
+
+`data.google_project` で既存を参照するため、API 有効化と IAM 付与のみ反映される。
+
+## Outputs
+
+| 名前 | 内容 |
+|------|------|
+| `project_id` | 確定した project ID |
+| `location` | Vertex AI リージョン |
+| `env_vars` | `.env` 用 key/value map (`GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) |
+| `oauth_console_url` | OAuth クライアント ID 作成用 Console URL |
+| `enabled_apis` | 有効化した API 一覧 |
+
+## トラブルシューティング
+
+### `Error 403: The caller does not have permission`
+ADC ユーザーが Organization / Billing Account に対する必要な権限を持っていない。`roles/resourcemanager.projectCreator` と `roles/billing.user` が最低必要。
+
+### `Error: googleapi: Error 400: ... billingEnabled`
+`aiplatform.googleapis.com` を有効化するには Billing が必要。`billing_account` を正しく指定すること。
+
+### `Error: project ... already exists but is not managed by this terraform configuration`
+プロジェクト ID がグローバルで衝突している。`project_id` を別名に変えるか、既存流用なら `create_project = false` に。
+
+### `Permission denied` (apply 後の実行時)
+ADC を更新してから実行: `gcloud auth application-default login && gcloud auth application-default set-quota-project <project-id>`

--- a/.claude/skills/channel-setup/references/terraform-gcp/apis.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/apis.tf
@@ -1,0 +1,9 @@
+resource "google_project_service" "apis" {
+  for_each = toset(var.apis)
+
+  project = local.project_id
+  service = each.key
+
+  # terraform destroy でも API は無効化しない (他の資産が残るケースを考慮)
+  disable_on_destroy = false
+}

--- a/.claude/skills/channel-setup/references/terraform-gcp/iam.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/iam.tf
@@ -1,0 +1,5 @@
+resource "google_project_iam_member" "aiplatform_user" {
+  project = local.project_id
+  role    = "roles/aiplatform.user"
+  member  = "user:${var.adc_email}"
+}

--- a/.claude/skills/channel-setup/references/terraform-gcp/main.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/main.tf
@@ -1,0 +1,23 @@
+# プロジェクト: create_project=true なら resource で作成、そうでなければ data source で既存参照
+resource "google_project" "this" {
+  count = var.create_project ? 1 : 0
+
+  project_id      = var.project_id
+  name            = coalesce(var.project_name, var.project_id)
+  billing_account = var.billing_account
+  org_id          = var.org_id
+  folder_id       = var.folder_id
+
+  # terraform destroy 時にプロジェクトを本当に削除する
+  # (共有プロジェクトを Terraform 管理下に置きたくない場合は create_project=false で)
+  deletion_policy = "DELETE"
+}
+
+data "google_project" "this" {
+  count      = var.create_project ? 0 : 1
+  project_id = var.project_id
+}
+
+locals {
+  project_id = var.create_project ? google_project.this[0].project_id : data.google_project.this[0].project_id
+}

--- a/.claude/skills/channel-setup/references/terraform-gcp/outputs.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/outputs.tf
@@ -1,0 +1,28 @@
+output "project_id" {
+  description = "確定した GCP project ID"
+  value       = local.project_id
+}
+
+output "location" {
+  description = "Vertex AI リージョン"
+  value       = var.location
+}
+
+output "env_vars" {
+  description = ".env に流し込むキー/値 (ラッパースクリプトが利用)"
+  value = {
+    GOOGLE_GENAI_USE_VERTEXAI = "true"
+    GOOGLE_CLOUD_PROJECT      = local.project_id
+    GOOGLE_CLOUD_LOCATION     = var.location
+  }
+}
+
+output "oauth_console_url" {
+  description = "OAuth クライアント ID を作成する Console URL (手動操作が必要な唯一のステップ)"
+  value       = "https://console.cloud.google.com/apis/credentials?project=${local.project_id}"
+}
+
+output "enabled_apis" {
+  description = "有効化した API 一覧"
+  value       = [for api in google_project_service.apis : api.service]
+}

--- a/.claude/skills/channel-setup/references/terraform-gcp/terraform.tfvars.example
+++ b/.claude/skills/channel-setup/references/terraform-gcp/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# 使い方:
+#   cp terraform.tfvars.example terraform.tfvars
+#   <実値に書き換え>
+#   terraform init
+#   terraform apply
+
+project_id      = "my-youtube-channel-prod"
+create_project  = true
+billing_account = "012345-6789AB-CDEF01"
+adc_email       = "you@example.com"
+location        = "us-central1"
+
+# 任意
+# project_name = "My YouTube Channel"
+# org_id       = "123456789012"
+# folder_id    = "234567890123"
+# apis = [
+#   "youtube.googleapis.com",
+#   "youtubeanalytics.googleapis.com",
+#   "aiplatform.googleapis.com",
+#   "generativelanguage.googleapis.com",
+# ]

--- a/.claude/skills/channel-setup/references/terraform-gcp/variables.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/variables.tf
@@ -1,0 +1,56 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID (作成する or 既存流用する)"
+}
+
+variable "project_name" {
+  type        = string
+  description = "プロジェクト表示名。未指定なら project_id を流用"
+  default     = null
+}
+
+variable "create_project" {
+  type        = bool
+  description = "true の場合 google_project で新規作成。false なら data source で既存を参照"
+  default     = false
+}
+
+variable "billing_account" {
+  type        = string
+  description = "Billing account ID (例: 012345-6789AB-CDEF01)。create_project=true なら必須、aiplatform を使うなら実質必須"
+  default     = null
+}
+
+variable "org_id" {
+  type        = string
+  description = "Organization ID (任意)。folder_id と同時指定不可"
+  default     = null
+}
+
+variable "folder_id" {
+  type        = string
+  description = "Folder ID (任意)"
+  default     = null
+}
+
+variable "location" {
+  type        = string
+  description = "Vertex AI リージョン。.env の GOOGLE_CLOUD_LOCATION へ反映"
+  default     = "us-central1"
+}
+
+variable "adc_email" {
+  type        = string
+  description = "roles/aiplatform.user を付与する Google アカウント (ADC で使うユーザー)"
+}
+
+variable "apis" {
+  type        = list(string)
+  description = "有効化する GCP API 一覧"
+  default = [
+    "youtube.googleapis.com",
+    "youtubeanalytics.googleapis.com",
+    "aiplatform.googleapis.com",
+    "generativelanguage.googleapis.com",
+  ]
+}

--- a/.claude/skills/channel-setup/references/terraform-gcp/versions.tf
+++ b/.claude/skills/channel-setup/references/terraform-gcp/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "google" {
+  # project / region は変数で指定せず、各リソース側で明示する
+  # (既存プロジェクトを data source 越しに参照する場面でも動かすため)
+}

--- a/.claude/skills/loop-video/SKILL.md
+++ b/.claude/skills/loop-video/SKILL.md
@@ -45,7 +45,8 @@ $ARGUMENTS
 ### 前提条件
 
 - `10-assets/main.png` または `main.jpg` が存在すること（サムネイル生成済み）
-- `GEMINI_API_KEY` が `.env` に設定されていること
+- Vertex AI 用環境変数が `.env` に設定されていること (`GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`)
+- `gcloud auth application-default login` で ADC が取得済みであること
 
 ### ステップ
 

--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,12 @@
-# === Google AI プロバイダ選択 ===
+# === Vertex AI (必須) ===
 #
-# 【推奨】新規チャンネルは scripts/gcp-bootstrap.sh または infra/terraform/gcp/ で
-# 自動セットアップすれば、以下の Vertex AI モード用 3 変数が .env に書き出されます。
-# 手作業で設定する場合は下記いずれかの設定を有効化してください。
-# 詳細は auth/SETUP.md を参照。
+# scripts/gcp-bootstrap.sh または infra/terraform/gcp/ を実行すると
+# 下記 3 変数が .env に自動書き出しされます。手作業で設定する場合は
+# コメントを外して値を埋めてください。詳細は auth/SETUP.md を参照。
 
-# --- Vertex AI モード（推奨: 新規 GCP アカウントで $300 クレジットを使う場合）---
 # GOOGLE_GENAI_USE_VERTEXAI=true
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 # GOOGLE_CLOUD_LOCATION=us-central1
-
-# --- Google AI Studio モード（既存アカウント流用時の最速ルート）---
-# Vertex AI モードを使わない場合に有効化。両モードは排他。
-# GEMINI_API_KEY=your_gemini_api_key_here
-
-# Lyria 3 (lyria-3-pro-preview / lyria-3-clip-preview) は Vertex AI 側でも Preview 提供されているため、
-# AI Studio / Vertex AI いずれのモードでも generate_music.py はそのまま動作する。
 
 # Channel directory path (auto-detected if config/channel/ exists in CWD ancestors)
 # CHANNEL_DIR=/path/to/your/channel

--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,21 @@
 # === Google AI プロバイダ選択 ===
-# デフォルト: Google AI Studio (API キー方式)
 #
-# 【新規 GCP アカウントの場合は Vertex AI モードを推奨】
-# 2026 年以降、Google Cloud の新規アカウントは前払い制のみで、
-# $300 無料クレジットは Vertex AI 経由でのみ消費可能になりました。
-# 新規セットアップでは Vertex AI モードを推奨します。
+# 【推奨】新規チャンネルは scripts/gcp-bootstrap.sh または infra/terraform/gcp/ で
+# 自動セットアップすれば、以下の Vertex AI モード用 3 変数が .env に書き出されます。
+# 手作業で設定する場合は下記いずれかの設定を有効化してください。
 # 詳細は auth/SETUP.md を参照。
 
-# --- Google AI Studio モード（デフォルト）---
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# --- Vertex AI モード（任意）---
-# 有効化するには以下 3 変数を設定し、`gcloud auth application-default login` で ADC を準備すること。
-# Lyria は Vertex AI での提供状況が流動的なため、音楽生成は AI Studio モード推奨。
+# --- Vertex AI モード（推奨: 新規 GCP アカウントで $300 クレジットを使う場合）---
 # GOOGLE_GENAI_USE_VERTEXAI=true
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 # GOOGLE_CLOUD_LOCATION=us-central1
+
+# --- Google AI Studio モード（既存アカウント流用時の最速ルート）---
+# Vertex AI モードを使わない場合に有効化。両モードは排他。
+# GEMINI_API_KEY=your_gemini_api_key_here
+
+# Lyria 3 (lyria-3-pro-preview / lyria-3-clip-preview) は Vertex AI 側でも Preview 提供されているため、
+# AI Studio / Vertex AI いずれのモードでも generate_music.py はそのまま動作する。
 
 # Channel directory path (auto-detected if config/channel/ exists in CWD ancestors)
 # CHANNEL_DIR=/path/to/your/channel

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ yt-channel-status
 
 ```bash
 cp .env.example .env
-$EDITOR .env  # GEMINI_API_KEY を書く
+$EDITOR .env  # Vertex AI 用変数 (GOOGLE_CLOUD_PROJECT 等) を書く
 ```
 
-`load_dotenv()` で `os.environ` に読み込まれ、上記 (1) の経路で利用されます。
+`scripts/gcp-bootstrap.sh` または `infra/terraform/gcp/` を実行すれば `.env` に自動書き出しされます。`load_dotenv()` で `os.environ` に読み込まれ、上記 (1) の経路で利用されます。
 
 #### B. 1Password CLI 方式（秘密をディスクに書かない）
 
@@ -135,7 +135,7 @@ op signin
 # 以降、スクリプト実行時に utils/secrets.py が op read を呼ぶ
 ```
 
-シークレット参照は `utils/secrets.py` の `_SECRET_REFS` で定義されています（デフォルト: `op://Personal/GEMINI_API_KEY/credential`）。
+シークレット参照は `utils/secrets.py` の `_SECRET_REFS` で定義されています（デフォルト: `op://Personal/YouTube_OAuth_Client_Secrets/credential`）。AI 系は ADC 経由の認証のため `op` 取得は不要です。
 
 ### 6. (オプション) Nix devShell
 
@@ -169,7 +169,9 @@ nix develop
 
 | 変数名 | 必須 | 説明 |
 |--------|------|------|
-| `GEMINI_API_KEY` | AI生成機能使用時 | Google Gemini API キー |
+| `GOOGLE_CLOUD_PROJECT` | AI 生成機能使用時 | Vertex AI を呼ぶ GCP プロジェクト ID |
+| `GOOGLE_CLOUD_LOCATION` | 任意 | Vertex AI リージョン（既定: `us-central1`） |
+| `GOOGLE_GENAI_USE_VERTEXAI` | 任意 | google-genai SDK の自動検出用フラグ（アプリ側は参照しない） |
 | `CHANNEL_DIR` | 自動検出可 | チャンネルリポジトリのルートパス |
 | `CLIENT_SECRETS_DIR` | 任意 | `client_secrets.json` を置いたディレクトリ（デフォルト: `<channel_dir>/auth/`、フォールバック: `<channel_dir>/automation/auth/`） |
 

--- a/auth/SETUP.md
+++ b/auth/SETUP.md
@@ -1,112 +1,140 @@
-# 🔐 YouTube Data API OAuth 2.0 セットアップガイド
+# 🔐 GCP / YouTube API セットアップガイド
 
-YouTube 自動アップロードシステム用の認証設定手順です。
+新しい YouTube チャンネル用に GCP プロジェクト + API + 認証情報を用意する手順。
+
+**従来は Console クリック中心だったが、本リポジトリはスクリプト / Terraform での半自動化に移行した**。手動クリックが残るのは **OAuth クライアント ID 作成の 1 ステップだけ**。
+
+---
 
 ## 📋 前提条件
-- Googleアカウント（YouTubeチャンネル所有者）
-- Python 3.5+ + 必要ライブラリがインストール済み
+
+- Google アカウント（YouTube チャンネル所有者）
+- `gcloud` CLI インストール済み（[導入手順](https://cloud.google.com/sdk/docs/install)）
+- `gcloud auth login` 済み
+- Terraform ルートを使うなら `terraform` >= 1.5 + `jq`
 
 ## 💳 課金体系の変更について（2026 年〜）
 
 2026 年以降、Google Cloud の新規アカウントは **前払い（プリペイド）制のみ** に変更され、従来の **$300 無料クレジットは Google AI Studio の API キー経由では利用不可** になった。
 
-本リポジトリは YouTube Data API（無料枠で十分）に加えて、Gemini / Veo / Lyria など有料 API を利用する。**新規 GCP アカウントの場合、$300 クレジットは Vertex AI 経由でのみ消費可能** なため、以下の選択肢となる:
+本リポジトリは YouTube Data API（無料枠で十分）に加えて Gemini / Veo / Lyria など有料 API を利用する。**新規 GCP アカウントの場合、$300 クレジットは Vertex AI 経由でのみ消費可能** なため:
 
 | パターン | 推奨度 | 方式 |
 |---------|-------|------|
 | 既存の Google アカウント / GCP プロジェクトを流用 | ⭐⭐⭐ 最簡単 | AI Studio モード（従来通り）|
-| 新規 GCP アカウント + $300 クレジット活用 | ⭐⭐ 推奨 | Vertex AI モード（後述）|
+| 新規 GCP アカウント + $300 クレジット活用 | ⭐⭐ 推奨 | Vertex AI モード |
 | 新規アカウントで AI Studio モード | — | 前払いで入金必要 |
 
 YouTube Data API / Analytics API は OAuth 認証で動作し、この変更の影響を受けない。
 
-## 🚀 セットアップ手順
+---
 
-### Step 1: Google Cloud Console プロジェクト作成
-1. [Google Cloud Console](https://console.cloud.google.com/) にアクセス
-2. 新しいプロジェクトを作成（例: "your-youtube-automation"）
-3. プロジェクトを選択
+## 🚀 セットアップ: 2 つのルート
 
-### Step 2: YouTube Data API v3 有効化
-1. 「APIとサービス」→「ライブラリ」
-2. "YouTube Data API v3" を検索
-3. 「有効にする」をクリック
+### ルート A: `scripts/gcp-bootstrap.sh`（gcloud 半自動化・最速）
 
-### Step 3: OAuth 2.0 認証情報作成
-1. 「APIとサービス」→「認証情報」
-2. 「認証情報を作成」→「OAuth クライアント ID」
-3. 「デスクトップアプリケーション」を選択
-4. 名前を入力（例: "YouTube Auto Uploader"）
-5. 「作成」をクリック
-
-### Step 4: client_secrets.json ダウンロード
-1. 作成された認証情報の「ダウンロード」ボタンをクリック
-2. ダウンロードされたJSONファイルを `client_secrets.json` にリネーム
-3. **チャンネルディレクトリの `auth/` 配下** (例: `~/02-yt/<channel>/auth/client_secrets.json`) に配置
-
-> 検索順:
-> 1. `CLIENT_SECRETS_DIR` 環境変数で指定されたディレクトリ
-> 2. `<channel_dir>/auth/client_secrets.json` (推奨)
-> 3. `<channel_dir>/automation/auth/client_secrets.json` (submodule 互換フォールバック)
-
-### Step 5: 認証テスト実行
-
-`yt-channel-status` などの CLI を初回実行すると OAuth フローが立ち上がります:
+チャンネル単位で気軽に立ち上げたいケース。1 コマンドでプロジェクト作成〜API 有効化〜IAM 付与〜`.env` 書き出しまで完結する。冪等なので再実行しても安全。
 
 ```bash
-yt-channel-status
+# 最小 (既存プロジェクト流用)
+automation/scripts/gcp-bootstrap.sh my-existing-project
+
+# 新規プロジェクト作成 + Billing 紐付け
+automation/scripts/gcp-bootstrap.sh \
+  --create \
+  --billing-account 012345-6789AB-CDEF01 \
+  my-new-yt-channel
 ```
+
+主なオプション:
+
+| オプション | 意味 |
+|-----------|------|
+| `--create` | プロジェクトが存在しなければ作成 |
+| `--billing-account ID` | Billing account を紐付け（有料 API に必須） |
+| `--adc-email EMAIL` | `aiplatform.user` 付与先アカウント（既定: `gcloud config account`） |
+| `--env-file PATH` | 書き出す `.env`（既定: `./.env`） |
+| `--location REGION` | Vertex AI リージョン（既定: `us-central1`） |
+| `--skip-adc` | `gcloud auth application-default login` を省略 |
+| `--dry-run` | 変更せずプレビュー |
+
+完了時に OAuth クライアント ID 作成用の Console URL が表示されるので、そこだけ手動で作成（[Step OAuth](#step-oauth) 参照）。
+
+### ルート B: `infra/terraform/gcp`（宣言的 IaC・本命）
+
+Organization 配下で統制したい、複数プロジェクトを tfstate 管理したい、将来的に変更履歴を残したいケース。
+
+```bash
+cd infra/terraform/gcp
+cp terraform.tfvars.example terraform.tfvars
+# → project_id, adc_email, billing_account を編集
+
+# apply + .env 反映までをラッパーで実行
+cd ../../..
+automation/scripts/gcp-terraform-apply.sh
+```
+
+`terraform.tfvars` の必須キーは `project_id` / `adc_email`。新規作成時は `billing_account` も必要（既存流用なら `create_project = false` にして不要）。
+
+詳細は [`infra/terraform/gcp/README.md`](../infra/terraform/gcp/README.md) を参照。
+
+---
+
+## <a id="step-oauth"></a>🔑 OAuth クライアント ID の作成（手動・1 クリック）
+
+`gcloud` / Terraform いずれも OAuth クライアント ID 作成には対応していないため、ここだけ Console での作業が必要:
+
+1. スクリプト / terraform 出力に表示された URL を開く
+   - 形式: `https://console.cloud.google.com/apis/credentials?project=<PROJECT_ID>`
+2. 「認証情報を作成」→「OAuth クライアント ID」
+3. アプリケーションの種類: **「デスクトップ」**
+4. 名前を入力（例: "YouTube Auto Uploader"）→ 作成
+5. 右側「ダウンロード」で JSON を取得
+6. `client_secrets.json` にリネームし、**チャンネルリポジトリの `auth/` 配下**に配置
+   - 推奨パス: `<channel_dir>/auth/client_secrets.json`
+
+検索順:
+1. `CLIENT_SECRETS_DIR` 環境変数で指定されたディレクトリ
+2. `<channel_dir>/auth/client_secrets.json`（推奨）
+3. `<channel_dir>/automation/auth/client_secrets.json`（submodule 互換フォールバック）
+
+---
+
+## ✅ 動作確認
+
+```bash
+# YouTube OAuth 初回認証（ブラウザ起動）
+yt-channel-status
+
+# Vertex AI での画像生成
+uv run yt-generate-image --prompt "a gentle watercolor forest" --output /tmp/test.png -y
+```
+
+両方成功すれば完了。
 
 ## 📁 ファイル構成
+
 ```
-<channel_dir>/auth/
-├── client_secrets.json          # OAuth 2.0認証情報（要作成・gitignore）
-└── token.json                   # 認証トークン（自動生成・gitignore）
-```
-
-## ⚠️ セキュリティ注意事項
-
-### 重要ファイル
-- `client_secrets.json`: **絶対に公開しない**
-- `token.json`: **絶対に公開しない**
-
-### .gitignore 設定確認
-```gitignore
-# YouTube API認証ファイル
-auth/client_secrets.json
-auth/token.json
+<channel_dir>/
+├── .env                            # GOOGLE_CLOUD_PROJECT 等 (スクリプトが書き出す)
+└── auth/
+    ├── client_secrets.json          # OAuth 2.0 認証情報（要作成・gitignore）
+    └── token.json                   # 認証トークン（自動生成・gitignore）
 ```
 
-## 🌐 Vertex AI モードを使う場合（任意）
+---
 
-新規 GCP アカウントの $300 クレジットで Gemini / Veo を動かす場合、または GCP プロジェクトと AI 利用を一体化したい場合は Vertex AI モードを有効化する。
+## 🌐 AI Studio モード vs Vertex AI モード
 
-### 追加セットアップ手順
+スクリプト / Terraform ルートでセットアップすると `.env` に以下が書き出され、**Vertex AI モードが有効になる**:
 
-1. **Vertex AI API を有効化**
-   Google Cloud Console で「APIとサービス」→「ライブラリ」→ `Vertex AI API` を検索して有効化。
+```bash
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_CLOUD_PROJECT=<your-project-id>
+GOOGLE_CLOUD_LOCATION=us-central1
+```
 
-2. **Application Default Credentials (ADC) の準備**
-   ```bash
-   gcloud auth application-default login
-   gcloud config set project <your-gcp-project-id>
-   ```
-
-3. **IAM ロールの確認**
-   認証したアカウントに最低 `roles/aiplatform.user` が付与されていること（プロジェクトオーナーなら付与済み）。
-
-4. **環境変数で Vertex AI モードに切替**
-   `.env` またはシェルに以下を設定:
-   ```bash
-   GOOGLE_GENAI_USE_VERTEXAI=true
-   GOOGLE_CLOUD_PROJECT=<your-gcp-project-id>
-   GOOGLE_CLOUD_LOCATION=us-central1   # 任意（デフォルト: us-central1）
-   ```
-
-5. **動作確認**
-   ```bash
-   uv run yt-generate-image --prompt "a gentle watercolor forest" --output /tmp/test.png -y
-   ```
+既存アカウントで AI Studio モードに留まりたい場合は、`.env` から上 3 行を削除 or コメントアウトし、代わりに `GEMINI_API_KEY` を設定すること。
 
 ### 対応状況
 
@@ -115,41 +143,63 @@ auth/token.json
 | Gemini 画像生成（サムネイル等）| ✅ | ✅ |
 | Gemini 画像分析（ベンチマーク）| ✅ | ✅ |
 | Veo 動画生成（ループ動画/ショート）| ✅ | ✅ |
-| Lyria 音楽生成 | ✅ | ⚠️ Model Garden の提供状況次第。**Lyria を使う場合は AI Studio モード推奨** |
+| Lyria 3 音楽生成（`lyria-3-pro-preview` / `lyria-3-clip-preview`）| ✅ | ✅ Preview 提供中（[公式ドキュメント](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/lyria/lyria-3)） |
 
-Lyria を使う場合で Vertex AI モードに切り替えているとき、音楽生成ステップだけ `GOOGLE_GENAI_USE_VERTEXAI=false` で実行するか、シェル別で環境変数を分ける運用を推奨。
+`youtube_automation` の `generate_music.py` / `generate_music_dj.py` は `create_genai_client()` 経由で両モードに自動対応。Vertex AI モードの場合は `aiplatform.googleapis.com` が有効化されていれば Lyria 3 も同じクライアントでそのまま呼べる（追加設定不要）。
+
+---
+
+## ⚠️ セキュリティ注意事項
+
+- `auth/client_secrets.json`: **絶対に公開しない**（gitignore 済み）
+- `auth/token.json`: **絶対に公開しない**（gitignore 済み）
+- `infra/terraform/gcp/terraform.tfvars`: **絶対に公開しない**（gitignore 済み）
+- `.env`: **絶対に公開しない**（gitignore 済み）
+
+---
 
 ## 🔧 トラブルシューティング
 
-### エラー: "client_secrets.json が見つかりません"
-→ Step 4 を確認。ファイルが正しい場所に配置されているか確認
+### bootstrap/terraform 共通
 
-### エラー: "Access blocked: This app's request is invalid"
-→ OAuth同意画面の設定が必要。Google Cloud Console で設定
-
-### エラー: "The OAuth client was not found"
-→ client_secrets.json の内容が正しいか確認
-
-### ブラウザが開かない
-→ ファイアウォール設定を確認。ポート接続が許可されているか確認
-
-### Vertex AI モードで `GOOGLE_CLOUD_PROJECT が必須です` エラー
-→ `.env` に `GOOGLE_CLOUD_PROJECT=<project-id>` を設定。
-
-### Vertex AI モードで `Permission denied` / 認証エラー
-→ `gcloud auth application-default login` を実行し、認証済みアカウントに `roles/aiplatform.user` 以上が付与されているか確認
-
-## 💡 使用後の確認事項
-認証が成功すると以下が表示されます：
-```
-✅ OAuth 2.0 認証成功
-💾 認証トークン保存完了
-✅ YouTube Data API サービス接続成功  
-✅ API接続テスト成功
-📺 チャンネル名: Your Channel Name
-👥 登録者数: XX
-🎉 認証・接続テスト完了！YouTube自動アップロードの準備ができました。
+#### `Permission denied` / 認証エラー
+`gcloud auth application-default login` で ADC を更新。必要なら quota project を固定:
+```bash
+gcloud auth application-default set-quota-project <project-id>
 ```
 
-## 📞 サポート
-問題が発生した場合は、エラーメッセージを確認して上記のトラブルシューティングを参照してください。
+#### `roles/aiplatform.user` 付与でエラー
+IAM 付与権限がない。Organization / Project オーナー権限を持つアカウントで実行すること。
+
+#### プロジェクト作成上限に達した
+GCP のプロジェクト作成は 1 アカウントあたり上限あり（初期は少ない）。不要プロジェクトを削除するか、上限緩和申請。
+
+#### `billingEnabled` エラー（Vertex AI / aiplatform 有効化時）
+Billing account が紐付いていない。`--billing-account` を渡して再実行するか、Console で紐付け。
+
+### bootstrap 固有
+
+#### `project-id が複数指定されました`
+位置引数として project-id を渡せるのは 1 つだけ。フラグの前後を確認。
+
+### terraform 固有
+
+#### `already exists but is not managed by this terraform configuration`
+プロジェクト ID がグローバルで衝突している。`project_id` を別名に変えるか、`create_project = false` で既存流用。
+
+#### `Error 400: ... not enabled for billing`
+`aiplatform.googleapis.com` には Billing が必須。`billing_account` を正しく指定。
+
+### YouTube OAuth 固有
+
+#### `client_secrets.json が見つかりません`
+[Step OAuth](#step-oauth) を確認。ファイル配置先を見直し。
+
+#### `Access blocked: This app's request is invalid`
+OAuth 同意画面の設定が必要。Console で OAuth 同意画面を設定（テストユーザーに自分を追加）。
+
+#### `The OAuth client was not found`
+`client_secrets.json` の内容が壊れている。再ダウンロード。
+
+#### ブラウザが開かない
+ファイアウォール設定 / ポート接続を確認。

--- a/auth/SETUP.md
+++ b/auth/SETUP.md
@@ -2,7 +2,7 @@
 
 新しい YouTube チャンネル用に GCP プロジェクト + API + 認証情報を用意する手順。
 
-**従来は Console クリック中心だったが、本リポジトリはスクリプト / Terraform での半自動化に移行した**。手動クリックが残るのは **OAuth クライアント ID 作成の 1 ステップだけ**。
+本リポジトリは Gemini / Veo / Lyria を **Vertex AI 経由で 1 本化** している（AI Studio モードは廃止）。スクリプト / Terraform で半自動化しているため、手動クリックが残るのは **OAuth クライアント ID 作成の 1 ステップだけ**。
 
 ---
 
@@ -11,21 +11,10 @@
 - Google アカウント（YouTube チャンネル所有者）
 - `gcloud` CLI インストール済み（[導入手順](https://cloud.google.com/sdk/docs/install)）
 - `gcloud auth login` 済み
+- Vertex AI API を呼ぶため **Billing account の紐付けが必須**
 - Terraform ルートを使うなら `terraform` >= 1.5 + `jq`
 
-## 💳 課金体系の変更について（2026 年〜）
-
-2026 年以降、Google Cloud の新規アカウントは **前払い（プリペイド）制のみ** に変更され、従来の **$300 無料クレジットは Google AI Studio の API キー経由では利用不可** になった。
-
-本リポジトリは YouTube Data API（無料枠で十分）に加えて Gemini / Veo / Lyria など有料 API を利用する。**新規 GCP アカウントの場合、$300 クレジットは Vertex AI 経由でのみ消費可能** なため:
-
-| パターン | 推奨度 | 方式 |
-|---------|-------|------|
-| 既存の Google アカウント / GCP プロジェクトを流用 | ⭐⭐⭐ 最簡単 | AI Studio モード（従来通り）|
-| 新規 GCP アカウント + $300 クレジット活用 | ⭐⭐ 推奨 | Vertex AI モード |
-| 新規アカウントで AI Studio モード | — | 前払いで入金必要 |
-
-YouTube Data API / Analytics API は OAuth 認証で動作し、この変更の影響を受けない。
+2026 年以降、Google Cloud の新規アカウントは前払い（プリペイド）制に変更されたが、**$300 無料クレジットは Vertex AI 経由で消費可能**。本リポジトリを Vertex AI 1 本に揃えた理由もこのクレジットを活かすため。
 
 ---
 
@@ -51,7 +40,7 @@ automation/scripts/gcp-bootstrap.sh \
 | オプション | 意味 |
 |-----------|------|
 | `--create` | プロジェクトが存在しなければ作成 |
-| `--billing-account ID` | Billing account を紐付け（有料 API に必須） |
+| `--billing-account ID` | Billing account を紐付け（Vertex AI に必須） |
 | `--adc-email EMAIL` | `aiplatform.user` 付与先アカウント（既定: `gcloud config account`） |
 | `--env-file PATH` | 書き出す `.env`（既定: `./.env`） |
 | `--location REGION` | Vertex AI リージョン（既定: `us-central1`） |
@@ -124,9 +113,9 @@ uv run yt-generate-image --prompt "a gentle watercolor forest" --output /tmp/tes
 
 ---
 
-## 🌐 AI Studio モード vs Vertex AI モード
+## 🌐 Vertex AI 前提の環境変数
 
-スクリプト / Terraform ルートでセットアップすると `.env` に以下が書き出され、**Vertex AI モードが有効になる**:
+スクリプト / Terraform ルートでセットアップすると `.env` に以下が書き出される:
 
 ```bash
 GOOGLE_GENAI_USE_VERTEXAI=true
@@ -134,18 +123,18 @@ GOOGLE_CLOUD_PROJECT=<your-project-id>
 GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-既存アカウントで AI Studio モードに留まりたい場合は、`.env` から上 3 行を削除 or コメントアウトし、代わりに `GEMINI_API_KEY` を設定すること。
+アプリ側 (`create_genai_client()`) は `GOOGLE_CLOUD_PROJECT` のみを参照し、常に `vertexai=True` で Client を初期化する。`GOOGLE_GENAI_USE_VERTEXAI` は google-genai SDK の自動検出用に置いておく任意フラグ。
 
-### 対応状況
+### 対応 API
 
-| API | AI Studio モード | Vertex AI モード |
-|-----|-----------------|------------------|
-| Gemini 画像生成（サムネイル等）| ✅ | ✅ |
-| Gemini 画像分析（ベンチマーク）| ✅ | ✅ |
-| Veo 動画生成（ループ動画/ショート）| ✅ | ✅ |
-| Lyria 3 音楽生成（`lyria-3-pro-preview` / `lyria-3-clip-preview`）| ✅ | ✅ Preview 提供中（[公式ドキュメント](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/lyria/lyria-3)） |
+Vertex AI で以下を利用する。`aiplatform.googleapis.com` が有効化されていれば追加設定不要。
 
-`youtube_automation` の `generate_music.py` / `generate_music_dj.py` は `create_genai_client()` 経由で両モードに自動対応。Vertex AI モードの場合は `aiplatform.googleapis.com` が有効化されていれば Lyria 3 も同じクライアントでそのまま呼べる（追加設定不要）。
+| API | 用途 |
+|-----|------|
+| Gemini 画像生成 | サムネイル等 |
+| Gemini 画像分析 | ベンチマーク / 競合調査 |
+| Veo 動画生成 | ループ動画 / ショート |
+| Lyria 3 音楽生成（`lyria-3-pro-preview` / `lyria-3-clip-preview`）| 楽曲生成（[公式ドキュメント](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/lyria/lyria-3)） |
 
 ---
 

--- a/infra/terraform/gcp/.gitignore
+++ b/infra/terraform/gcp/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -1,0 +1,79 @@
+# infra/terraform/gcp
+
+新チャンネル用の GCP プロジェクト + 必要 API + IAM を Terraform で IaC 管理するモジュール。
+
+`scripts/gcp-bootstrap.sh` が gcloud ベースの半自動化ルートなら、こちらは **本命の宣言的セットアップ**。プロジェクトの構成を tfstate として管理したい場合はこちらを使う。
+
+## 管理するリソース
+
+- `google_project`（`create_project=true` 時のみ）
+- `google_project_service` × 4
+  - `youtube.googleapis.com`
+  - `youtubeanalytics.googleapis.com`
+  - `aiplatform.googleapis.com`
+  - `generativelanguage.googleapis.com`
+- `google_project_iam_member` = `roles/aiplatform.user` → `var.adc_email`
+
+**OAuth 2.0 クライアント ID は google provider で未サポート** のため、別途 Console から作成する（この 1 ステップだけ手動）。
+
+## 前提
+
+- `terraform` >= 1.5 インストール済み
+- `gcloud auth application-default login` 実行済み（Terraform は ADC 経由で認証）
+- Project を新規作成する場合: Organization / Billing Account に対する権限保持
+
+## 使い方
+
+```bash
+# 1. tfvars を用意
+cd infra/terraform/gcp
+cp terraform.tfvars.example terraform.tfvars
+# → project_id, adc_email, billing_account を実値に書き換え
+
+# 2. apply
+terraform init
+terraform plan
+terraform apply
+
+# 3. outputs から .env を更新 (ラッパー推奨)
+bash ../../../scripts/gcp-terraform-apply.sh --tf-dir . --env-file ../../../.env
+```
+
+`scripts/gcp-terraform-apply.sh` は `terraform apply` → `terraform output -json env_vars` → `.env` へマージまで一気通貫で実行する。
+
+## 既存プロジェクトを流用する場合
+
+`terraform.tfvars`:
+
+```hcl
+project_id     = "existing-project-id"
+create_project = false
+adc_email      = "you@example.com"
+# billing_account は不要 (既存で設定済み前提)
+```
+
+`data.google_project` で既存を参照するため、API 有効化と IAM 付与のみ反映される。
+
+## Outputs
+
+| 名前 | 内容 |
+|------|------|
+| `project_id` | 確定した project ID |
+| `location` | Vertex AI リージョン |
+| `env_vars` | `.env` 用 key/value map (`GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) |
+| `oauth_console_url` | OAuth クライアント ID 作成用 Console URL |
+| `enabled_apis` | 有効化した API 一覧 |
+
+## トラブルシューティング
+
+### `Error 403: The caller does not have permission`
+ADC ユーザーが Organization / Billing Account に対する必要な権限を持っていない。`roles/resourcemanager.projectCreator` と `roles/billing.user` が最低必要。
+
+### `Error: googleapi: Error 400: ... billingEnabled`
+`aiplatform.googleapis.com` を有効化するには Billing が必要。`billing_account` を正しく指定すること。
+
+### `Error: project ... already exists but is not managed by this terraform configuration`
+プロジェクト ID がグローバルで衝突している。`project_id` を別名に変えるか、既存流用なら `create_project = false` に。
+
+### `Permission denied` (apply 後の実行時)
+ADC を更新してから実行: `gcloud auth application-default login && gcloud auth application-default set-quota-project <project-id>`

--- a/infra/terraform/gcp/apis.tf
+++ b/infra/terraform/gcp/apis.tf
@@ -1,0 +1,9 @@
+resource "google_project_service" "apis" {
+  for_each = toset(var.apis)
+
+  project = local.project_id
+  service = each.key
+
+  # terraform destroy でも API は無効化しない (他の資産が残るケースを考慮)
+  disable_on_destroy = false
+}

--- a/infra/terraform/gcp/iam.tf
+++ b/infra/terraform/gcp/iam.tf
@@ -1,0 +1,5 @@
+resource "google_project_iam_member" "aiplatform_user" {
+  project = local.project_id
+  role    = "roles/aiplatform.user"
+  member  = "user:${var.adc_email}"
+}

--- a/infra/terraform/gcp/main.tf
+++ b/infra/terraform/gcp/main.tf
@@ -1,0 +1,23 @@
+# プロジェクト: create_project=true なら resource で作成、そうでなければ data source で既存参照
+resource "google_project" "this" {
+  count = var.create_project ? 1 : 0
+
+  project_id      = var.project_id
+  name            = coalesce(var.project_name, var.project_id)
+  billing_account = var.billing_account
+  org_id          = var.org_id
+  folder_id       = var.folder_id
+
+  # terraform destroy 時にプロジェクトを本当に削除する
+  # (共有プロジェクトを Terraform 管理下に置きたくない場合は create_project=false で)
+  deletion_policy = "DELETE"
+}
+
+data "google_project" "this" {
+  count      = var.create_project ? 0 : 1
+  project_id = var.project_id
+}
+
+locals {
+  project_id = var.create_project ? google_project.this[0].project_id : data.google_project.this[0].project_id
+}

--- a/infra/terraform/gcp/outputs.tf
+++ b/infra/terraform/gcp/outputs.tf
@@ -1,0 +1,28 @@
+output "project_id" {
+  description = "確定した GCP project ID"
+  value       = local.project_id
+}
+
+output "location" {
+  description = "Vertex AI リージョン"
+  value       = var.location
+}
+
+output "env_vars" {
+  description = ".env に流し込むキー/値 (ラッパースクリプトが利用)"
+  value = {
+    GOOGLE_GENAI_USE_VERTEXAI = "true"
+    GOOGLE_CLOUD_PROJECT      = local.project_id
+    GOOGLE_CLOUD_LOCATION     = var.location
+  }
+}
+
+output "oauth_console_url" {
+  description = "OAuth クライアント ID を作成する Console URL (手動操作が必要な唯一のステップ)"
+  value       = "https://console.cloud.google.com/apis/credentials?project=${local.project_id}"
+}
+
+output "enabled_apis" {
+  description = "有効化した API 一覧"
+  value       = [for api in google_project_service.apis : api.service]
+}

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# 使い方:
+#   cp terraform.tfvars.example terraform.tfvars
+#   <実値に書き換え>
+#   terraform init
+#   terraform apply
+
+project_id      = "my-youtube-channel-prod"
+create_project  = true
+billing_account = "012345-6789AB-CDEF01"
+adc_email       = "you@example.com"
+location        = "us-central1"
+
+# 任意
+# project_name = "My YouTube Channel"
+# org_id       = "123456789012"
+# folder_id    = "234567890123"
+# apis = [
+#   "youtube.googleapis.com",
+#   "youtubeanalytics.googleapis.com",
+#   "aiplatform.googleapis.com",
+#   "generativelanguage.googleapis.com",
+# ]

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -1,0 +1,56 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID (作成する or 既存流用する)"
+}
+
+variable "project_name" {
+  type        = string
+  description = "プロジェクト表示名。未指定なら project_id を流用"
+  default     = null
+}
+
+variable "create_project" {
+  type        = bool
+  description = "true の場合 google_project で新規作成。false なら data source で既存を参照"
+  default     = false
+}
+
+variable "billing_account" {
+  type        = string
+  description = "Billing account ID (例: 012345-6789AB-CDEF01)。create_project=true なら必須、aiplatform を使うなら実質必須"
+  default     = null
+}
+
+variable "org_id" {
+  type        = string
+  description = "Organization ID (任意)。folder_id と同時指定不可"
+  default     = null
+}
+
+variable "folder_id" {
+  type        = string
+  description = "Folder ID (任意)"
+  default     = null
+}
+
+variable "location" {
+  type        = string
+  description = "Vertex AI リージョン。.env の GOOGLE_CLOUD_LOCATION へ反映"
+  default     = "us-central1"
+}
+
+variable "adc_email" {
+  type        = string
+  description = "roles/aiplatform.user を付与する Google アカウント (ADC で使うユーザー)"
+}
+
+variable "apis" {
+  type        = list(string)
+  description = "有効化する GCP API 一覧"
+  default = [
+    "youtube.googleapis.com",
+    "youtubeanalytics.googleapis.com",
+    "aiplatform.googleapis.com",
+    "generativelanguage.googleapis.com",
+  ]
+}

--- a/infra/terraform/gcp/versions.tf
+++ b/infra/terraform/gcp/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "google" {
+  # project / region は変数で指定せず、各リソース側で明示する
+  # (既存プロジェクトを data source 越しに参照する場面でも動かすため)
+}

--- a/scripts/gcp-bootstrap.sh
+++ b/scripts/gcp-bootstrap.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# gcp-bootstrap.sh — 新チャンネル用 GCP プロジェクトの半自動セットアップ
+#
+# 何をするか:
+#   1. gcloud / ログイン状態の前提チェック
+#   2. プロジェクト作成 (--create) or 既存流用
+#   3. Billing account の紐付け (任意)
+#   4. 必要 API の有効化 (冪等)
+#        - youtube.googleapis.com
+#        - youtubeanalytics.googleapis.com
+#        - aiplatform.googleapis.com
+#        - generativelanguage.googleapis.com
+#   5. Application Default Credentials (ADC) ログイン + quota project 設定
+#   6. roles/aiplatform.user を ADC ユーザーに付与
+#   7. .env に GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION / GOOGLE_GENAI_USE_VERTEXAI を書き出し
+#   8. OAuth クライアント ID 作成のための Console URL を案内 (この 1 クリックだけ手動)
+#
+# Usage:
+#   scripts/gcp-bootstrap.sh [OPTIONS] <project-id>
+#
+# Options:
+#   --create                      プロジェクトが存在しなければ作成する
+#   --billing-account <ID>        billing account を紐付ける (例: 012345-6789AB-CDEF01)
+#   --adc-email <EMAIL>           IAM 付与対象の Google アカウント (未指定なら gcloud config account)
+#   --env-file <PATH>             書き込む .env のパス (既定: ./.env)
+#   --location <REGION>           Vertex AI リージョン (既定: us-central1)
+#   --skip-adc                    `gcloud auth application-default login` を省略
+#   --dry-run                     変更せず何をするか表示
+#   -h, --help                    このヘルプを表示
+#
+# Examples:
+#   scripts/gcp-bootstrap.sh my-yt-channel
+#   scripts/gcp-bootstrap.sh --create --billing-account 01ABCD-234567-89EFGH my-new-channel
+#   scripts/gcp-bootstrap.sh --env-file .env.local --location asia-northeast1 my-proj
+
+set -euo pipefail
+
+CREATE_PROJECT=false
+BILLING_ACCOUNT=""
+ADC_EMAIL=""
+ENV_FILE="./.env"
+LOCATION="us-central1"
+SKIP_ADC=false
+DRY_RUN=false
+PROJECT_ID=""
+
+REQUIRED_APIS=(
+    "youtube.googleapis.com"
+    "youtubeanalytics.googleapis.com"
+    "aiplatform.googleapis.com"
+    "generativelanguage.googleapis.com"
+)
+
+log()   { printf '\033[0;36m[bootstrap]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+warn()  { printf '\033[0;33m[warn]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() {
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --create) CREATE_PROJECT=true; shift ;;
+        --billing-account) BILLING_ACCOUNT="$2"; shift 2 ;;
+        --billing-account=*) BILLING_ACCOUNT="${1#*=}"; shift ;;
+        --adc-email) ADC_EMAIL="$2"; shift 2 ;;
+        --adc-email=*) ADC_EMAIL="${1#*=}"; shift ;;
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --env-file=*) ENV_FILE="${1#*=}"; shift ;;
+        --location) LOCATION="$2"; shift 2 ;;
+        --location=*) LOCATION="${1#*=}"; shift ;;
+        --skip-adc) SKIP_ADC=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) error "未知のオプション: $1"; usage; exit 2 ;;
+        *)
+            if [[ -z "$PROJECT_ID" ]]; then
+                PROJECT_ID="$1"
+            else
+                error "project-id が複数指定されました: $PROJECT_ID, $1"
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PROJECT_ID" ]]; then
+    error "project-id は必須です"
+    usage
+    exit 2
+fi
+
+run() {
+    if $DRY_RUN; then
+        printf '\033[0;35m[dry-run]\033[0m %s\n' "$*"
+    else
+        log "$*"
+        "$@"
+    fi
+}
+
+log "Step 1: 前提チェック"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+    error "gcloud CLI が見つかりません。https://cloud.google.com/sdk/docs/install を参照してインストールしてください"
+    exit 1
+fi
+ok "gcloud: $(gcloud --version | head -n1)"
+
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q '@'; then
+    error "gcloud にログインしていません。先に \`gcloud auth login\` を実行してください"
+    exit 1
+fi
+CURRENT_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" | head -n1)
+ok "gcloud active account: ${CURRENT_ACCOUNT}"
+
+if [[ -z "$ADC_EMAIL" ]]; then
+    ADC_EMAIL="$CURRENT_ACCOUNT"
+fi
+log "ADC email (IAM 付与対象): ${ADC_EMAIL}"
+
+log "Step 2: プロジェクト確認"
+
+project_exists() {
+    gcloud projects describe "$PROJECT_ID" --format="value(projectId)" >/dev/null 2>&1
+}
+
+if project_exists; then
+    ok "プロジェクト ${PROJECT_ID} は既に存在します (流用)"
+else
+    if $CREATE_PROJECT; then
+        run gcloud projects create "$PROJECT_ID" --name="$PROJECT_ID"
+        ok "プロジェクト ${PROJECT_ID} を作成しました"
+    else
+        error "プロジェクト ${PROJECT_ID} が存在しません。--create を付けて作成するか、既存の project-id を指定してください"
+        exit 1
+    fi
+fi
+
+# 以降の gcloud コマンドで project を固定
+run gcloud config set project "$PROJECT_ID"
+
+if [[ -n "$BILLING_ACCOUNT" ]]; then
+    log "Step 3: Billing account 紐付け"
+    CURRENT_BILLING=$(gcloud beta billing projects describe "$PROJECT_ID" \
+        --format="value(billingAccountName)" 2>/dev/null || echo "")
+    if [[ "$CURRENT_BILLING" == *"$BILLING_ACCOUNT"* ]]; then
+        ok "Billing account ${BILLING_ACCOUNT} は既に紐付け済み"
+    else
+        run gcloud beta billing projects link "$PROJECT_ID" \
+            --billing-account="$BILLING_ACCOUNT"
+        ok "Billing account ${BILLING_ACCOUNT} を紐付けました"
+    fi
+else
+    warn "Step 3: --billing-account 未指定のため billing 紐付けはスキップ (aiplatform 等の有料 API は billing 未紐付けだと利用できません)"
+fi
+
+log "Step 4: 必要 API の有効化"
+
+ENABLED_APIS=$(gcloud services list --enabled --project="$PROJECT_ID" \
+    --format="value(config.name)" 2>/dev/null || echo "")
+
+for api in "${REQUIRED_APIS[@]}"; do
+    if echo "$ENABLED_APIS" | grep -qx "$api"; then
+        ok "${api}: 既に有効"
+    else
+        run gcloud services enable "$api" --project="$PROJECT_ID"
+        ok "${api}: 有効化しました"
+    fi
+done
+
+if $SKIP_ADC; then
+    warn "Step 5: --skip-adc のため ADC ログインをスキップ"
+else
+    log "Step 5: ADC ログイン (ブラウザが開きます)"
+    run gcloud auth application-default login
+    run gcloud auth application-default set-quota-project "$PROJECT_ID"
+    ok "ADC ログイン完了 & quota project を ${PROJECT_ID} に設定"
+fi
+
+log "Step 6: IAM 付与 (roles/aiplatform.user → ${ADC_EMAIL})"
+
+HAS_ROLE=$(gcloud projects get-iam-policy "$PROJECT_ID" \
+    --flatten="bindings[].members" \
+    --filter="bindings.role:roles/aiplatform.user AND bindings.members:user:${ADC_EMAIL}" \
+    --format="value(bindings.role)" 2>/dev/null || echo "")
+
+if [[ -n "$HAS_ROLE" ]]; then
+    ok "user:${ADC_EMAIL} は既に roles/aiplatform.user を保持"
+else
+    run gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+        --member="user:${ADC_EMAIL}" \
+        --role="roles/aiplatform.user" \
+        --condition=None \
+        --quiet
+    ok "roles/aiplatform.user を付与しました"
+fi
+
+log "Step 7: ${ENV_FILE} へ書き出し"
+
+# gcp-terraform-apply.sh の write_env_var と awk コア部分は同一 (ドリフト時は両方揃えること)
+write_env_var() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    if $DRY_RUN; then
+        printf '\033[0;35m[dry-run]\033[0m %s=%s → %s\n' "$key" "$value" "$file"
+        return
+    fi
+
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+
+    local tmp
+    tmp=$(mktemp)
+    awk -v k="$key" -v v="$value" '
+        BEGIN { done = 0 }
+        $0 ~ "^" k "=" { print k "=" v; done = 1; next }
+        { print }
+        END { if (!done) print k "=" v }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
+write_env_var "GOOGLE_GENAI_USE_VERTEXAI" "true" "$ENV_FILE"
+write_env_var "GOOGLE_CLOUD_PROJECT" "$PROJECT_ID" "$ENV_FILE"
+write_env_var "GOOGLE_CLOUD_LOCATION" "$LOCATION" "$ENV_FILE"
+ok "${ENV_FILE} に Vertex AI 用環境変数を書き出しました"
+
+cat <<EOF
+
+---- 最後に手動で 1 ステップ必要 ----
+gcloud からは OAuth 2.0 クライアント ID を作成できないため、Console で作成してください:
+
+  https://console.cloud.google.com/apis/credentials?project=${PROJECT_ID}
+
+手順:
+  1. 「認証情報を作成」→「OAuth クライアント ID」
+  2. アプリケーションの種類: 「デスクトップ」
+  3. ダウンロードした JSON を auth/client_secrets.json として配置
+     (チャンネルリポジトリ側の auth/ ディレクトリ)
+
+詳細は auth/SETUP.md を参照。
+-----------------------------------
+
+EOF
+
+ok "GCP ブートストラップ完了: project=${PROJECT_ID}, location=${LOCATION}"

--- a/scripts/gcp-terraform-apply.sh
+++ b/scripts/gcp-terraform-apply.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# gcp-terraform-apply.sh — Terraform apply → .env 書き出しまでを 1 コマンドで
+#
+# Usage:
+#   scripts/gcp-terraform-apply.sh [--tf-dir DIR] [--env-file PATH] [--auto-approve]
+#
+# Options:
+#   --tf-dir DIR       Terraform モジュールパス (既定: infra/terraform/gcp)
+#   --env-file PATH    書き出す .env (既定: ./.env)
+#   --auto-approve     terraform apply に -auto-approve を付ける
+#   -h, --help         このヘルプ
+
+set -euo pipefail
+
+TF_DIR="infra/terraform/gcp"
+ENV_FILE="./.env"
+AUTO_APPROVE=false
+
+log()   { printf '\033[0;36m[tf-apply]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() { sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tf-dir) TF_DIR="$2"; shift 2 ;;
+        --tf-dir=*) TF_DIR="${1#*=}"; shift ;;
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --env-file=*) ENV_FILE="${1#*=}"; shift ;;
+        --auto-approve) AUTO_APPROVE=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) error "未知のオプション: $1"; usage; exit 2 ;;
+    esac
+done
+
+command -v terraform >/dev/null 2>&1 || {
+    error "terraform が見つかりません: https://developer.hashicorp.com/terraform/install"
+    exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+    error "jq が見つかりません (brew install jq)"
+    exit 1
+}
+
+[[ -d "$TF_DIR" ]] || { error "tf-dir が存在しません: $TF_DIR"; exit 1; }
+
+if [[ "$ENV_FILE" = /* ]]; then
+    ENV_FILE_ABS="$ENV_FILE"
+else
+    ENV_FILE_ABS="$(pwd)/$ENV_FILE"
+fi
+
+# gcp-bootstrap.sh の write_env_var と同一実装 (ドリフト時は両方揃えること)
+write_env_var() {
+    local key="$1"
+    local value="$2"
+    local file="$3"
+
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+
+    local tmp
+    tmp=$(mktemp)
+    awk -v k="$key" -v v="$value" '
+        BEGIN { done = 0 }
+        $0 ~ "^" k "=" { print k "=" v; done = 1; next }
+        { print }
+        END { if (!done) print k "=" v }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
+log "Terraform apply: $TF_DIR"
+pushd "$TF_DIR" >/dev/null
+terraform init -upgrade
+if $AUTO_APPROVE; then
+    terraform apply -auto-approve
+else
+    terraform apply
+fi
+
+ENV_JSON=$(terraform output -json env_vars)
+OAUTH_URL=$(terraform output -raw oauth_console_url)
+PROJECT_ID=$(terraform output -raw project_id)
+popd >/dev/null
+
+while IFS=$'\t' read -r key value; do
+    write_env_var "$key" "$value" "$ENV_FILE_ABS"
+done < <(echo "$ENV_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
+
+ok ".env updated: $ENV_FILE_ABS (project=$PROJECT_ID)"
+
+cat <<EOF
+
+---- 最後に手動で 1 ステップ必要 ----
+OAuth 2.0 クライアント ID を Console で作成:
+
+  $OAUTH_URL
+
+手順:
+  1. 「認証情報を作成」→「OAuth クライアント ID」
+  2. アプリケーションの種類: 「デスクトップ」
+  3. ダウンロード JSON を auth/client_secrets.json に配置
+
+詳細は auth/SETUP.md を参照。
+-----------------------------------
+
+EOF

--- a/src/youtube_automation/utils/genai_client.py
+++ b/src/youtube_automation/utils/genai_client.py
@@ -1,16 +1,12 @@
-"""google-genai Client 生成の抽象化ヘルパー。
+"""google-genai Client 生成の抽象化ヘルパー (Vertex AI 専用)。
 
-呼び出し側は `create_genai_client()` を使うことで、
-Google AI Studio (API キー) と Vertex AI (ADC + GCP project) を
-環境変数で切り替えられる。
+認証は ADC (Application Default Credentials) を前提とする。
+事前に `scripts/gcp-bootstrap.sh` または `infra/terraform/gcp/` で
+GCP プロジェクト / API 有効化 / ADC を整えたうえで使用する。
 
-- デフォルト: Google AI Studio (API キー = GEMINI_API_KEY)
-- GOOGLE_GENAI_USE_VERTEXAI=true で Vertex AI に切替
-  - 認証は ADC (Application Default Credentials)
-  - GOOGLE_CLOUD_PROJECT と GOOGLE_CLOUD_LOCATION (default: us-central1) を参照
-
-新規 GCP アカウント (2026/04~) では $300 無料クレジットが
-Vertex AI 経由でのみ消費可能なため、該当ケースでは Vertex AI モードを推奨。
+必要な環境変数:
+- `GOOGLE_CLOUD_PROJECT` (必須)
+- `GOOGLE_CLOUD_LOCATION` (任意、既定 `us-central1`)
 """
 
 from __future__ import annotations
@@ -20,37 +16,17 @@ import os
 from google import genai
 
 from youtube_automation.utils.exceptions import ConfigError
-from youtube_automation.utils.secrets import get_gemini_api_key
 
-_TRUTHY = {"true", "1", "yes"}
 _DEFAULT_LOCATION = "us-central1"
 
 
-def _use_vertex() -> bool:
-    return os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").strip().lower() in _TRUTHY
-
-
 def create_genai_client() -> genai.Client:
-    """環境変数に応じて google-genai Client を初期化する。
-
-    Returns:
-        genai.Client: 初期化済みクライアント。呼び出し側は
-            `client.models.generate_content(...)` など共通 API をそのまま使える。
-
-    Raises:
-        ConfigError: Vertex AI モードで GOOGLE_CLOUD_PROJECT が未設定の場合、
-            または AI Studio モードで GEMINI_API_KEY が取得できない場合。
-    """
-    if _use_vertex():
-        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
-        location = os.environ.get("GOOGLE_CLOUD_LOCATION", _DEFAULT_LOCATION)
-        if not project:
-            raise ConfigError(
-                "Vertex AI モード (GOOGLE_GENAI_USE_VERTEXAI=true) では "
-                "GOOGLE_CLOUD_PROJECT が必須です。\n"
-                "  → .env に GOOGLE_CLOUD_PROJECT=<gcp-project-id> を設定し、\n"
-                "  → `gcloud auth application-default login` で ADC を準備してください"
-            )
-        return genai.Client(vertexai=True, project=project, location=location)
-
-    return genai.Client(api_key=get_gemini_api_key())
+    """Vertex AI モードで google-genai Client を初期化する。"""
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    location = os.environ.get("GOOGLE_CLOUD_LOCATION", _DEFAULT_LOCATION)
+    if not project:
+        raise ConfigError(
+            "GOOGLE_CLOUD_PROJECT が未設定です。`scripts/gcp-bootstrap.sh` または "
+            "`infra/terraform/gcp/` で .env を書き出し、`gcloud auth application-default login` を実行してください"
+        )
+    return genai.Client(vertexai=True, project=project, location=location)

--- a/src/youtube_automation/utils/secrets.py
+++ b/src/youtube_automation/utils/secrets.py
@@ -23,7 +23,6 @@ from youtube_automation.utils.exceptions import ConfigError
 
 # シークレット名 → 1Password の参照 URI
 _SECRET_REFS: dict[str, str] = {
-    "GEMINI_API_KEY": "op://Personal/GEMINI_API_KEY/credential",
     "CLIENT_SECRETS_JSON": "op://Personal/YouTube_OAuth_Client_Secrets/credential",
 }
 
@@ -96,18 +95,11 @@ def get_client_secrets_path() -> Path:
         return _client_secrets_tempfile
 
     json_content = get_secret("CLIENT_SECRETS_JSON")
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", prefix="client_secrets_", delete=False
-    )
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", prefix="client_secrets_", delete=False)
     tmp.write(json_content)
     tmp.close()
     _client_secrets_tempfile = Path(tmp.name)
     return _client_secrets_tempfile
-
-
-def get_gemini_api_key() -> str:
-    """Google Gemini API キーを取得する。"""
-    return get_secret("GEMINI_API_KEY")
 
 
 def reset_cache() -> None:

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -1,11 +1,10 @@
 """utils/genai_client.py のユニットテスト。
 
-環境変数による AI Studio / Vertex AI 切替ロジックを検証する:
+Vertex AI 1 本化後の検証:
 
-1. デフォルト (GOOGLE_GENAI_USE_VERTEXAI 未設定) → `genai.Client(api_key=...)`
-2. GOOGLE_GENAI_USE_VERTEXAI=true + PROJECT 設定 → `genai.Client(vertexai=True, project, location)`
-3. GOOGLE_GENAI_USE_VERTEXAI=true + PROJECT 未設定 → ConfigError
-4. GOOGLE_CLOUD_LOCATION が反映される
+1. `GOOGLE_CLOUD_PROJECT` が設定されていれば `genai.Client(vertexai=True, project, location)` が呼ばれる
+2. `GOOGLE_CLOUD_PROJECT` 未設定なら `ConfigError`
+3. `GOOGLE_CLOUD_LOCATION` が反映される（既定値 us-central1）
 """
 
 from __future__ import annotations
@@ -17,7 +16,7 @@ import pytest
 
 from youtube_automation.utils.exceptions import ConfigError
 
-_ENV_KEYS = ("GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
+_ENV_KEYS = ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
 
 
 @pytest.fixture(autouse=True)
@@ -33,21 +32,8 @@ def clean_env():
 
 
 class TestCreateGenaiClient:
-    def test_default_uses_api_key(self):
-        """環境変数未設定時は API キーモードで初期化される"""
-        from youtube_automation.utils import genai_client
-
-        with (
-            patch.object(genai_client, "get_gemini_api_key", return_value="test-key"),
-            patch.object(genai_client.genai, "Client") as mock_client,
-        ):
-            genai_client.create_genai_client()
-
-        mock_client.assert_called_once_with(api_key="test-key")
-
-    def test_vertex_mode_true_uses_vertex(self):
-        """GOOGLE_GENAI_USE_VERTEXAI=true で Vertex AI モードに切り替わる"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+    def test_uses_vertex_with_project(self):
+        """GOOGLE_CLOUD_PROJECT が設定されていれば Vertex AI モードで初期化される"""
         os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
 
         from youtube_automation.utils import genai_client
@@ -57,56 +43,15 @@ class TestCreateGenaiClient:
 
         mock_client.assert_called_once_with(vertexai=True, project="my-project", location="us-central1")
 
-    def test_vertex_mode_case_insensitive(self):
-        """GOOGLE_GENAI_USE_VERTEXAI は大文字小文字を問わず真偽を判定する"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
-        os.environ["GOOGLE_CLOUD_PROJECT"] = "p"
-
-        from youtube_automation.utils import genai_client
-
-        with patch.object(genai_client.genai, "Client") as mock_client:
-            genai_client.create_genai_client()
-
-        assert mock_client.call_args.kwargs["vertexai"] is True
-
-    def test_vertex_mode_accepts_numeric_truthy(self):
-        """GOOGLE_GENAI_USE_VERTEXAI=1 も真として扱われる"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "1"
-        os.environ["GOOGLE_CLOUD_PROJECT"] = "p"
-
-        from youtube_automation.utils import genai_client
-
-        with patch.object(genai_client.genai, "Client") as mock_client:
-            genai_client.create_genai_client()
-
-        assert mock_client.call_args.kwargs["vertexai"] is True
-
-    def test_vertex_mode_false_falls_back_to_api_key(self):
-        """GOOGLE_GENAI_USE_VERTEXAI=false は API キーモードのまま"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "false"
-
-        from youtube_automation.utils import genai_client
-
-        with (
-            patch.object(genai_client, "get_gemini_api_key", return_value="test-key"),
-            patch.object(genai_client.genai, "Client") as mock_client,
-        ):
-            genai_client.create_genai_client()
-
-        mock_client.assert_called_once_with(api_key="test-key")
-
-    def test_vertex_mode_without_project_raises_config_error(self):
-        """Vertex AI モードで PROJECT 未設定なら ConfigError"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
-
+    def test_without_project_raises_config_error(self):
+        """GOOGLE_CLOUD_PROJECT 未設定なら ConfigError"""
         from youtube_automation.utils import genai_client
 
         with pytest.raises(ConfigError, match="GOOGLE_CLOUD_PROJECT"):
             genai_client.create_genai_client()
 
-    def test_vertex_mode_respects_custom_location(self):
+    def test_respects_custom_location(self):
         """GOOGLE_CLOUD_LOCATION で location を上書きできる"""
-        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
         os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
         os.environ["GOOGLE_CLOUD_LOCATION"] = "europe-west4"
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -17,26 +17,28 @@ import pytest
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.secrets import get_secret, reset_cache
 
+_TEST_SECRET = "CLIENT_SECRETS_JSON"
+
 
 @pytest.fixture(autouse=True)
 def clean_env():
-    """各テスト前後で GEMINI_API_KEY と lru_cache をクリーンにする"""
-    saved = os.environ.pop("GEMINI_API_KEY", None)
+    """各テスト前後で対象シークレットと lru_cache をクリーンにする"""
+    saved = os.environ.pop(_TEST_SECRET, None)
     reset_cache()
     yield
     reset_cache()
     if saved is not None:
-        os.environ["GEMINI_API_KEY"] = saved
+        os.environ[_TEST_SECRET] = saved
     else:
-        os.environ.pop("GEMINI_API_KEY", None)
+        os.environ.pop(_TEST_SECRET, None)
 
 
 class TestGetSecret:
     def test_returns_from_environ_when_present(self):
         """既に os.environ にあれば op を呼ばずにそれを返す"""
-        os.environ["GEMINI_API_KEY"] = "from-env-12345"
+        os.environ[_TEST_SECRET] = "from-env-12345"
         with patch("youtube_automation.utils.secrets.subprocess.run") as mock_run:
-            value = get_secret("GEMINI_API_KEY")
+            value = get_secret(_TEST_SECRET)
         assert value == "from-env-12345"
         mock_run.assert_not_called()
 
@@ -52,7 +54,7 @@ class TestGetSecret:
                 stdout="from-op-67890\n",
                 stderr="",
             )
-            value = get_secret("GEMINI_API_KEY")
+            value = get_secret(_TEST_SECRET)
         assert value == "from-op-67890"
         mock_run.assert_called_once()
 
@@ -68,14 +70,14 @@ class TestGetSecret:
                 stdout="cached-value\n",
                 stderr="",
             )
-            get_secret("GEMINI_API_KEY")
-        assert os.environ.get("GEMINI_API_KEY") == "cached-value"
+            get_secret(_TEST_SECRET)
+        assert os.environ.get(_TEST_SECRET) == "cached-value"
 
     def test_raises_config_error_when_op_unavailable_and_environ_empty(self):
         """op が無く os.environ も空なら ConfigError"""
         with patch("youtube_automation.utils.secrets.shutil.which", return_value=None):
-            with pytest.raises(ConfigError, match="GEMINI_API_KEY"):
-                get_secret("GEMINI_API_KEY")
+            with pytest.raises(ConfigError, match=_TEST_SECRET):
+                get_secret(_TEST_SECRET)
 
     def test_raises_config_error_when_op_read_fails(self):
         """op はあるが op read が失敗したら ConfigError"""
@@ -83,11 +85,9 @@ class TestGetSecret:
             patch("youtube_automation.utils.secrets.shutil.which", return_value="/usr/bin/op"),
             patch("youtube_automation.utils.secrets.subprocess.run") as mock_run,
         ):
-            mock_run.side_effect = subprocess.CalledProcessError(
-                returncode=1, cmd=["op", "read", "..."]
-            )
-            with pytest.raises(ConfigError, match="GEMINI_API_KEY"):
-                get_secret("GEMINI_API_KEY")
+            mock_run.side_effect = subprocess.CalledProcessError(returncode=1, cmd=["op", "read", "..."])
+            with pytest.raises(ConfigError, match=_TEST_SECRET):
+                get_secret(_TEST_SECRET)
 
     def test_raises_config_error_for_unknown_secret_name(self):
         """未登録のシークレット名は ConfigError"""
@@ -106,6 +106,6 @@ class TestGetSecret:
                 stdout="cached\n",
                 stderr="",
             )
-            get_secret("GEMINI_API_KEY")
-            get_secret("GEMINI_API_KEY")
+            get_secret(_TEST_SECRET)
+            get_secret(_TEST_SECRET)
         mock_run.assert_called_once()


### PR DESCRIPTION
## 概要

新チャンネル立ち上げ時にボトルネックだった GCP プロジェクト作成・API 有効化・IAM 付与・`.env` 書き出しを、`gcloud` ラッパーと Terraform モジュールの 2 ルートで自動化。手動作業は OAuth 2.0 クライアント ID 作成の 1 クリックだけに圧縮。あわせて AI 生成系の認証を **Vertex AI 1 本化** し、Google AI Studio モードと `GEMINI_API_KEY` サポートを廃止した。

Closes #38

## 設計判断

- **2 ルート提供**: `scripts/gcp-bootstrap.sh` (gcloud 半自動・冪等) と `infra/terraform/gcp/` (宣言的 IaC) を並存。issue で両方要望あり・想定ユースケースが異なる (気軽にチャンネル追加 vs Organization 下で tfstate 管理) ため統合せず並置。
- **OAuth クライアント ID は手動のまま**: gcloud / google provider ともに未サポートのため自動化見送り。完了時に Console URL を案内して最短クリックで済む導線に。
- **Vertex AI 1 本化（BREAKING CHANGE）**: 2026 以降の新規 GCP アカウントでは $300 無料クレジットが Vertex AI 経由でのみ消費可能。また Lyria 3 も Vertex AI で Preview 提供されており、AI Studio モードを二重管理する実益が消失したため、`create_genai_client()` を Vertex AI 専用に単純化。`GOOGLE_CLOUD_PROJECT` を必須入力として、AI Studio 用 `GEMINI_API_KEY` 経路とフォールバック分岐 (`_use_vertex()`, `GOOGLE_GENAI_USE_VERTEXAI` 真偽判定) を削除。
- **スキル配布**: 他スキル (`videoup` / `lyria`) と同じく `scripts/*.sh` と Terraform モジュールを `.claude/skills/channel-setup/references/` にもコピーし、yt-skills sync 経由でチャンネルリポジトリから呼び出せるようにした。

## 変更内容

### GCP 自動化

- `scripts/gcp-bootstrap.sh` (新規): project 作成/流用・Billing 紐付け・4 API 有効化・ADC ログイン・IAM 付与・`.env` 書き出しを 1 コマンド冪等実行。`--create` / `--billing-account` / `--adc-email` / `--env-file` / `--location` / `--skip-adc` / `--dry-run` 対応
- `scripts/gcp-terraform-apply.sh` (新規): `terraform init && apply` → `terraform output -json env_vars` を `.env` にマージするラッパー
- `infra/terraform/gcp/` (新規): `google_project` (create 制御) / `google_project_service` × 4 / `google_project_iam_member` / outputs (env_vars map + oauth_console_url) を含む Terraform モジュール + README + tfvars.example
- `.claude/skills/channel-setup/SKILL.md`: Step 6「GCP / Vertex AI ブートストラップ」を追加し、Step 7/8 に番号繰り下げ
- `.claude/skills/channel-setup/references/gcp-bootstrap.md` (新規): ルート A/B 判断フロー・実行コマンド・前提チェック・リカバリ手順
- `.claude/skills/channel-new/SKILL.md` Step 3: 手動 GCP 設定案内を撤去し、`/channel-setup` の自動化 step へリダイレクト
- `.claude/skills/channel-setup/references/` に上記スクリプト + terraform モジュールを配布コピー

### Vertex AI 1 本化（BREAKING CHANGE）

- `src/youtube_automation/utils/genai_client.py`: `_use_vertex()` / `_TRUTHY` / AI Studio 分岐 (`genai.Client(api_key=...)`) を削除し、`GOOGLE_CLOUD_PROJECT` が未設定なら `ConfigError`、それ以外は常に `genai.Client(vertexai=True, ...)` を返すシンプルな実装に
- `src/youtube_automation/utils/secrets.py`: `_SECRET_REFS` から `GEMINI_API_KEY` を削除、`get_gemini_api_key()` 関数を撤去
- `auth/SETUP.md`: Console クリック中心のガイドから bootstrap / terraform ルート中心にフルリライト。AI Studio vs Vertex AI の比較表と「既存アカウントで AI Studio 継続」経路を削除
- `.env.example`: AI Studio セクションを削除し Vertex AI 変数のみに
- `README.md`: 環境変数表から `GEMINI_API_KEY` を外し `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` / `GOOGLE_GENAI_USE_VERTEXAI` に差し替え。1Password シークレット参照を `YouTube_OAuth_Client_Secrets` に更新
- `.claude/skills/loop-video/SKILL.md`: 前提条件を Vertex AI 向けに書き換え
- `tests/test_genai_client.py`: AI Studio 分岐テストを削除、Vertex AI 3 テストに再構成
- `tests/test_secrets.py`: `GEMINI_API_KEY` 依存を `CLIENT_SECRETS_JSON` に差し替え

## BREAKING CHANGE

- `GEMINI_API_KEY` 経由で動かしていた既存セットアップは動作しなくなる
- 移行手順: `scripts/gcp-bootstrap.sh` または `infra/terraform/gcp/` で `.env` に `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` を書き出し、`gcloud auth application-default login` で ADC を準備する
- 1Password CLI 利用者は `op://Personal/GEMINI_API_KEY/credential` エントリが不要になる

## テスト計画

- [ ] 既存アカウント流用ルート: `scripts/gcp-bootstrap.sh <existing-project>` を実行し、4 API 有効化と `.env` 3 変数反映を確認
- [ ] 新規作成ルート: `scripts/gcp-bootstrap.sh --create --billing-account <ID> <new-project>` で project 作成 + billing 紐付け + API + IAM + `.env` までを確認
- [ ] Terraform ルート: `cp infra/terraform/gcp/terraform.tfvars.example terraform.tfvars` → 編集 → `scripts/gcp-terraform-apply.sh` で `terraform init && apply` → `.env` 反映を確認
- [ ] 冪等性: bootstrap.sh を 2 回実行し、2 回目は全 API "既に有効" / IAM "既に保持" / `.env` 変更なしでクリーン終了することを確認
- [ ] `--dry-run`: 実際の変更が入らず操作プレビューだけ出ることを確認
- [ ] Vertex AI モード動作確認: `uv run yt-generate-image --prompt "test" --output /tmp/test.png -y` と Lyria 3 (`yt-generate-music`) が成功
- [ ] `GOOGLE_CLOUD_PROJECT` 未設定時に `create_genai_client()` が `ConfigError` を投げることをテスト実行で確認（`uv run pytest tests/test_genai_client.py`）
- [ ] チャンネルリポジトリ側経由: `yt-skills sync` 後に `bash "$(git rev-parse --show-toplevel)/.claude/skills/channel-setup/references/gcp-bootstrap.sh" --help` がヘルプ表示
- [ ] OAuth Console URL 誘導: スクリプト完了時の URL をブラウザで開き、クライアント ID 作成後 `yt-channel-status` で OAuth フロー完走