### PR TITLE
release: v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "3.0.0"
+version = "3.1.0"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"


### PR DESCRIPTION
## Summary

v3.1.0 minor リリース。v3.0.0 以降に入った 1 feat + PR #52 の 1 feat + 4 fix + スキル追随修正をまとめて出す。

### 変更内容（v3.0.0 以降のコミット）

- 959f1a9 feat: 画像・動画・音楽生成のコスト追跡とレポート機能を追加 (#57)
- f913555 fix: Vertex AI 移行後の Analytics / Veo / Lyria 不具合をまとめて修正 (#52)
  - Analytics API 2026-01-15 仕様変更で CTR / impressions が取れない問題を修正 (#50)
  - `create_genai_client` に `location` override 引数を追加し画像=global / Veo=us-central1 を両立 (#56)
  - Veo `DEFAULT_MODEL` を discontinued preview から GA `veo-3.1-fast-generate-001` に更新 (#54)
  - Veo を Vertex AI 専用の `video_bytes` 直書きに純粋化 (#55)
  - Lyria 3 を `interactions` エンドポイント REST 経由で呼び出し (#53)
  - `loop-video` / `lyria` スキル記述を現行実装（GA Veo モデル / REST interactions）に追随

### 破壊的変更

なし。`create_genai_client(location=...)` 引数は default 付きの additive 追加、`impressions_available` フラグ撤廃は下流データキー (`impressions` / `impression_ctr` / `ctr`) を維持しているため下流無改修で移行可能。

### ダウンストリーム取り込み

- bobble: https://github.com/daiki-beppu/bobble/issues/31
- rjn (実 API 検証対象): https://github.com/daiki-beppu/youtube-rain-jazz-night/issues/25

## Test plan

- [x] `uv run ruff check .` 通過
- [x] `uv run pytest` 通過（PR #52 の CI で 432 tests pass）
- [x] `pyproject.toml` / `src/youtube_automation/__init__.py` が v3.1.0 に揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)