### PR TITLE
tune(generate-music-dj): DEFAULT_SEGMENT_SEC を 180 に引き上げ

### DIFF
--- a/.claude/skills/lyria/SKILL.md
+++ b/.claude/skills/lyria/SKILL.md
@@ -118,8 +118,8 @@ $ARGUMENTS
 | total_duration_min | `audio.target_duration_min` + `lyria.duration_padding_min` |
 
 **セグメント分割の仕組み**:
-- `generate_music_dj.py` は各 phase を `duration_hint_sec`（デフォルト **120 秒**）単位でサブ分割し、1 サブセグメント＝1 API コール（`lyria-3-pro-preview` の ~184 秒上限内）として生成する
-- Pro モデルの上限は約 184 秒/リクエストなので、**`duration_hint_sec` を 180 以内** に収めること（推奨は 120 秒前後）
+- `generate_music_dj.py` は各 phase を `duration_hint_sec`（デフォルト **180 秒**）単位でサブ分割し、1 サブセグメント＝1 API コール（`lyria-3-pro-preview` の ~184 秒上限内）として生成する
+- Pro モデルの上限は約 184 秒/リクエストなので、**`duration_hint_sec` を 180 以内** に収めること（既定値 180 がほぼ上限フィット、長尺コンテンツでは API コール数が最小化される）
 - サブセグメント間は `crossfade_sec`（デフォルト 5 秒）でクロスフェード結合される
 - `phase.duration_hint_sec` を個別指定すれば phase ごとにサブ分割単位を変えられる
 
@@ -161,7 +161,7 @@ $ARGUMENTS
 | `phases[].name` | Yes | フェーズ名（日本語、進捗表示用） |
 | `phases[].name_en` | Yes | フェーズ名（英語、ファイル名に使用） |
 | `phases[].prompt` | Yes | 主役楽器の演奏指示 + 最小限の情景（英語） |
-| `phases[].duration_hint_sec` | No | サブ分割の秒数（default 120。Pro モデル上限 184 を超えないこと） |
+| `phases[].duration_hint_sec` | No | サブ分割の秒数（default 180。Pro モデル上限 184 を超えないこと） |
 | `phases[].section_tag` | No | プロンプト末尾に追加される補足タグ（例: `"intro"`）|
 | `crossfade_sec` | No | サブセグメント間クロスフェード秒数（default: 5）|
 | `shuffle_passes` | No | N>0 で shuffle モード（各 phase を 1 セグメントとして N 回シャッフル連結）|
@@ -243,7 +243,7 @@ uv run yt-generate-music-dj \
 > **`.env` は自動ロード**: スクリプト内で `dotenv` により自動読み込みされる。
 
 **セグメント分割生成**:
-- 各 phase を `duration_hint_sec`（default 120s）単位のサブセグメントに分割し、1 サブセグメント＝1 API コール（`lyria-3-pro-preview` の ~184 秒上限内）で生成
+- 各 phase を `duration_hint_sec`（default 180s）単位のサブセグメントに分割し、1 サブセグメント＝1 API コール（`lyria-3-pro-preview` の ~184 秒上限内）で生成
 - `--workers N` で並列生成数を指定（推奨: `--workers 10`、または `-1` で全セグメント同時）
 - 生成中に `seg_001.wav`, `seg_002.wav`, ... が作成される
 - 全セグメント完了後にクロスフェード結合して master.wav を出力
@@ -294,7 +294,7 @@ composition.json の品質チェック:
 - [ ] `ng_words` に含まれる語がプロンプトに使われていないこと
 - [ ] 環境音系の語（`rain beginning to tap` 等）が使用されていないこと
 - [ ] 最初の phase が `at_min: 0` であること
-- [ ] `duration_hint_sec`（省略時 120）が 184 を超えていないこと（Pro モデル API 上限）
+- [ ] `duration_hint_sec`（省略時 180）が 184 を超えていないこと（Pro モデル API 上限）
 - [ ] `total_duration_min` が最後のフェーズ以降に十分な再生時間を確保していること
 - [ ] `base.bpm` / `base.brightness` 等、現行 `lyria_client.py` が API に渡さないキーを composition.json に書いていないこと（書いても無視されるだけだが混乱の元）
 - [ ] `--preview` でプレビュー生成し、音楽の方向性を確認済み

--- a/src/youtube_automation/scripts/generate_music_dj.py
+++ b/src/youtube_automation/scripts/generate_music_dj.py
@@ -21,7 +21,7 @@ CHANNELS = 2
 SAMPLE_WIDTH = 2  # 16-bit
 DEFAULT_MODEL = "lyria-3-pro-preview"
 PREVIEW_MODEL = "lyria-3-clip-preview"
-DEFAULT_SEGMENT_SEC = 180  # デフォルトのセグメント長（Pro モデル ~184s 上限にフィット、phase.duration_hint_sec で上書き可）
+DEFAULT_SEGMENT_SEC = 180  # Pro モデル ~184s 上限にフィット / phase.duration_hint_sec で上書き可
 DEFAULT_SHUFFLE_SEGMENT_SEC = 180  # shuffle モード時のデフォルト（3分）
 
 

--- a/src/youtube_automation/scripts/generate_music_dj.py
+++ b/src/youtube_automation/scripts/generate_music_dj.py
@@ -21,7 +21,7 @@ CHANNELS = 2
 SAMPLE_WIDTH = 2  # 16-bit
 DEFAULT_MODEL = "lyria-3-pro-preview"
 PREVIEW_MODEL = "lyria-3-clip-preview"
-DEFAULT_SEGMENT_SEC = 120  # デフォルトのセグメント長（プロンプトで制御可能）
+DEFAULT_SEGMENT_SEC = 180  # デフォルトのセグメント長（Pro モデル ~184s 上限にフィット、phase.duration_hint_sec で上書き可）
 DEFAULT_SHUFFLE_SEGMENT_SEC = 180  # shuffle モード時のデフォルト（3分）
 
 

--- a/tests/test_generate_music_dj.py
+++ b/tests/test_generate_music_dj.py
@@ -47,11 +47,11 @@ def make_pcm(duration_sec: float) -> bytes:
 
 class TestBuildSegmentCompositions:
     def test_auto_subdivides_long_phases(self):
-        """デフォルト120秒超のフェーズが自動サブ分割される。"""
+        """デフォルト180秒超のフェーズが自動サブ分割される。"""
         comp = make_composition(phases_count=2, total_min=10)
-        # 各フェーズ5分 = 300秒 → ceil(300/120) = 3サブセグメント
+        # 各フェーズ5分 = 300秒 → ceil(300/180) = 2サブセグメント
         segments = build_segment_compositions(comp)
-        assert len(segments) == 6  # 2フェーズ × 3サブセグメント
+        assert len(segments) == 4  # 2フェーズ × 2サブセグメント
 
     def test_short_phases_not_subdivided(self):
         """2分以下のフェーズはサブ分割されない。"""
@@ -79,12 +79,11 @@ class TestBuildSegmentCompositions:
     def test_continuation_suffix_on_sub_segments(self):
         """サブセグメントの2番目以降に continuation テキストが付く。"""
         comp = make_composition(phases_count=1, total_min=5)
-        # 5分 = 300秒 → 3サブセグメント
+        # 5分 = 300秒 → ceil(300/180) = 2サブセグメント
         segments = build_segment_compositions(comp)
-        assert len(segments) == 3
+        assert len(segments) == 2
         assert "continuing" not in segments[0]["prompt"]
         assert "continuing" in segments[1]["prompt"]
-        assert "continuing" in segments[2]["prompt"]
 
     def test_uneven_phases(self):
         """at_min が不均等な場合も正しく分割される。"""
@@ -101,8 +100,8 @@ class TestBuildSegmentCompositions:
             "crossfade_sec": 5,
         }
         segments = build_segment_compositions(comp)
-        # intro: 1min (1seg), main: 5min (3seg), outro: 2min (1seg) = 5 segments
-        assert len(segments) == 5
+        # intro: 1min (1seg), main: 5min (ceil(300/180)=2seg), outro: 2min (1seg) = 4 segments
+        assert len(segments) == 4
 
     def test_duration_hint_sec_respected(self):
         """duration_hint_sec がサブ分割の単位として使われる。"""


### PR DESCRIPTION
## Summary

Lyria 3 Pro モデルの 1 リクエスト上限 (~184 秒) にほぼフィットする 180 秒をサブ分割のデフォルトに変更。従来 120 秒からの引き上げで以下のメリット:

- 長尺コレクションの API コール数が約 1/1.5 に減少（例: 120 分コレクションのセグメント数 60 → 40）
- セグメント境界 (クロスフェード) の数も減り音楽的な連続性が向上
- `phase.duration_hint_sec` による個別上書きは従来どおり可能

`DEFAULT_SHUFFLE_SEGMENT_SEC` は元から 180 なので変更なし。

## 変更内容

- `src/youtube_automation/scripts/generate_music_dj.py:24` — `DEFAULT_SEGMENT_SEC = 120` → `180`
- `tests/test_generate_music_dj.py` — サブ分割期待値を 180 基準に更新（`test_auto_subdivides_long_phases` / `test_continuation_suffix_on_sub_segments` / `test_uneven_phases`）
- `.claude/skills/lyria/SKILL.md` — default 120 秒記述を 180 秒に更新

## 非対応（別 issue #59）

Lyria 3 API が受け取れるのに現行 `lyria_client.py` が未配線のパラメータ（参照画像 / BPM / intensity / vocal-instrumental mode / lyrics）は #59 で追跡。

## Test plan

- [x] `uv run pytest tests/test_generate_music_dj.py` (15 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)