### PR TITLE
release: v3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "3.1.0"
+version = "3.1.1"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "3.0.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

v3.1.1 パッチリリース。v3.1.0 後の 1 コミットをまとめて出す。

### 変更内容（v3.1.0 以降のコミット）

- aa2c85d tune(generate-music-dj): DEFAULT_SEGMENT_SEC を 180 に引き上げ (#60)

Lyria 3 Pro モデルの 1 リクエスト上限 (~184 秒) にほぼフィットする 180 秒をサブ分割のデフォルトに変更。長尺コレクションの API コール数が約 1/1.5 に減少し、セグメント境界のクロスフェード数も減って音楽的な連続性が向上する。`phase.duration_hint_sec` による個別上書きは従来どおり。

### 破壊的変更

なし。既存 composition.json で `phase.duration_hint_sec` を明示指定している場合はその値が優先されるため挙動変化なし。未指定の phase だけが新デフォルト 180 秒の影響を受ける。

### 残り対応

- Lyria 3 API 高度機能 (参照画像 / BPM / intensity / vocal-instrumental / lyrics) の配線: #59 で追跡

## Test plan

- [x] `uv run ruff check .` 通過
- [x] `uv run pytest` 通過（432 passed）
- [x] `pyproject.toml` / `src/youtube_automation/__init__.py` / `uv.lock` が v3.1.1 に揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)