### PR TITLE
release: v3.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "3.2.0"
+version = "3.2.1"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"


### PR DESCRIPTION
v3.2.1 リリース

### 修正内容

- **#66 修正**: `yt-analytics` 実行時に `videoThumbnailImpressions*` が `dimensions=video` と組み合わせ不可で 400 を返していた問題を修正。動画別クエリから該当メトリクスを除外し、動画×日次は views のみで保存するようにした。

### 備考

- `videoThumbnailImpressions*` のチャンネル全体取得は Google Analytics API 側の未解決問題（[Looker Studio Connector でも同症状](https://discuss.google.dev/t/impressions-and-click-through-rate-unavailable-in-googles-youtube-analytics-data-source-connector/172291)）のため、本リリースでは実装しない。