### PR TITLE
feat: takt 配布インフラ + channel-new-pipeline workflow (PoC)

### DIFF
--- a/.takt-templates/README.md
+++ b/.takt-templates/README.md
@@ -1,0 +1,45 @@
+# `.takt-templates/` — downstream 配布用 takt テンプレ置き場
+
+このディレクトリは upstream（youtube-channels-automation）で管理し、`yt-skills sync --asset takt` で downstream のチャンネルリポジトリに `.takt/` として展開するための **テンプレ集** を置く場所です。
+
+## 配布の流れ
+
+```
+upstream                                        downstream
+─────────────────────────────────────────       ─────────────────────────
+.takt-templates/                                .takt/
+├── config.yaml          ─── wheel 同梱 ───►   ├── config.yaml
+├── workflows/           ─── _takt/ へ ────►   ├── workflows/
+└── ...                                        └── ...
+                                               (yt-skills sync で展開)
+```
+
+| 項目 | 値 |
+|------|-----|
+| wheel 内パス | `youtube_automation/_takt/` |
+| force-include 設定 | `pyproject.toml` `[tool.hatch.build.targets.wheel.force-include]` |
+| 配布コマンド | `yt-skills sync --asset takt --target <downstream-repo>` |
+
+## 何を置くか
+
+- **downstream のチャンネルリポで起動する workflow**（例: 将来の wf-new / wf-next 等）
+- **複数チャンネルで再利用する facet**（persona / instruction / policy / knowledge）
+
+## 何を置かないか
+
+- **upstream でのみ起動する workflow**（例: `channel-new-pipeline`） → upstream の `.takt/workflows/` に直置き
+- **個人マシン依存の設定**（例: API キー） → `~/.takt/config.yaml`
+- **チャンネル固有の override** → downstream `.takt/workflows/`（takt の解決順序で project が最優先）
+
+## 解決順序（takt 0.38.x）
+
+```
+project (.takt/) → user (~/.takt/) → builtin
+```
+
+downstream に `yt-skills sync --asset takt` で展開された `.takt/` は project 扱いになり、user / builtin より優先される。
+
+## issue 参照
+
+- #86 takt PoC: channel-new 4 スキルパイプラインの workflow 化（配布インフラの初期化）
+- #64 takt OSS 導入可否の技術調査

--- a/.takt-templates/workflows/collection-pipeline.yaml
+++ b/.takt-templates/workflows/collection-pipeline.yaml
@@ -1,0 +1,337 @@
+name: collection-pipeline
+description: |
+  YouTube コレクション制作の単一 workflow。`/ideate` から `/upload` まで全工程を
+  step として表現し、各 step は idempotent (完了済みは skip して次 step へ)。
+  進行状態は workflow-state.json を持たず、ファイル位置・存在 + .takt/tasks.yaml
+  (takt の resume_point) で表現する。
+
+  人手作業 (mastering 等) で workflow を抜ける場合は COMPLETE / ABORT で正常終了し、
+  ユーザーは作業後に同じ task で `takt -t "<collection>"` を再起動する。各 step が
+  idempotent なので、最初から起動しても完了済み step は skip される。
+
+  人手介入は 3 箇所:
+  - select_plan (interactive gate 1: 企画選択)
+  - thumbnail_approve (interactive gate 2: サムネ承認)
+  - master_gate (interactive gate 3: Suno のみ、プレイリスト URL 入力)
+
+initial_step: detect
+max_steps: 16
+
+steps:
+  # ─────────────────────────────────────────────────────────────
+  # Step 1: detect — collection 特定 + 前提確認
+  # ─────────────────────────────────────────────────────────────
+  - name: detect
+    edit: false
+    persona: planner
+    required_permission_mode: readonly
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Bash
+    rules:
+      - condition: 進行中の collection (planning 配下) を 1 つ特定できた
+        next: ideate_select
+      - condition: 進行中 collection が無く新規制作が必要
+        next: ideate_select
+      - condition: config/channel/ が無い
+        next: ABORT
+        appendix: |
+          先に /channel-new (新規) / /channel-import (既存運営中) で
+          config/channel/ を生成してください。
+      - condition: 進行中 collection が複数あって特定不能
+        next: ABORT
+        appendix: |
+          collections/planning/ に複数あります。task 引数で対象を指定してください
+          (例: takt -w collection-pipeline -t "20260427-bri-brigid-hearth-collection")。
+    instruction: |
+      ## Goal
+      task 引数 `<task>` を手がかりに対象 collection を特定する。新規制作の場合は
+      collection ディレクトリが無い状態で next: ideate_select に進む。
+
+      ## Steps
+      1. `Bash` で `ls config/channel/*.json` を確認 (0 件なら ABORT)
+      2. `Bash` で `find collections/planning -maxdepth 2 -type d -name "*-collection"`
+         を実行
+         - 0 件: 新規制作。任意 (task 引数があれば候補名としてメモ)
+         - 1 件: その collection を採用
+         - 2 件以上: task 引数に部分一致する 1 件を採用、それでも複数なら ABORT
+      3. report に collection path (新規時は "new") + ディレクトリ内 artifact 一覧
+         (`ls -la <col>/10-assets/ <col>/01-master/` など) を 8 行以内で書く
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 2: ideate_select — 候補生成 + ユーザー選択
+  # ─────────────────────────────────────────────────────────────
+  - name: ideate_select
+    edit: true
+    persona: planner
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Edit
+          - Write
+          - Bash
+    rules:
+      - condition: collection が既に初期化済み (planning 配下にディレクトリ存在)
+        next: init
+      - condition: ユーザーが新規企画を選択した
+        next: init
+        requires_user_input: true
+        interactive_only: true
+      - condition: ユーザーが中断を指示した
+        next: ABORT
+        requires_user_input: true
+        interactive_only: true
+      - condition: 候補生成不能 (分析データ不足)
+        next: ABORT
+        appendix: |
+          /collect でデータ収集 → /channel-research などで補完してください。
+      - condition: 自動進行不可 (新規企画選択を pipeline では扱えない)
+        next: ABORT
+        appendix: |
+          collection-pipeline は interactive モードで起動してください
+          (例: takt -w collection-pipeline -t "次のコレクション")。
+    instruction: |
+      ## Goal
+      新規制作の場合のみ `/ideate` skill 相当で候補を生成し、ユーザーに選んでもらう。
+      既存 collection が detect 済みの場合は何もせず次 step へ進む。
+
+      ## Steps (新規時のみ)
+      1. `data/` `docs/benchmarks/` を確認
+      2. `/ideate` skill 相当で 3 候補を生成、preview 画像を tmp/preview/<theme-slug>/main.png に保存
+      3. ユーザーに候補と preview を提示し選択を求める
+      4. 選択結果 (id / theme-slug / track_count / music_engine) を report に明記
+
+      既存 collection の場合は report に "既に初期化済み、skip" の 1 行のみ。
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 3: init — yt-init-collection + thumbnail + music_prompts
+  # ─────────────────────────────────────────────────────────────
+  - name: init
+    edit: true
+    persona: coder
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Edit
+          - Write
+          - Bash
+    rules:
+      - condition: thumbnail.jpg と music_prompts (suno-prompts.md / composition.json) がともに揃っている
+        next: thumbnail_approve
+      - condition: 致命的失敗 (yt-init-collection エラー等)
+        next: ABORT
+    instruction: |
+      ## Goal
+      collection ディレクトリ・サムネイル・音楽プロンプトを揃える。各 artifact は
+      存在チェックして既にあれば skip。
+
+      ## Steps
+      1. collection ディレクトリ未生成の場合のみ:
+         `Bash` で `uv run yt-init-collection "<Collection Name>" "<theme-slug>" \
+         --track-count <N> --selected-plan <A-E> --music-engine <suno|lyria>`
+         (引数は ideate_select の選択結果)
+      2. preview 画像が `<col>/10-assets/main.png` に未配置なら配置
+      3. `<col>/10-assets/thumbnail.jpg` が未生成なら `/thumbnail` skill 相当で生成
+      4. 音楽プロンプト未生成なら:
+         - Suno: `/suno <theme>` で `<col>/20-documentation/suno-prompts.md`
+         - Lyria: `/lyria <theme>` で `<col>/20-documentation/composition.json`
+      5. report に各 artifact の状況 (作成 / skip) を明記
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 4: thumbnail_approve — サムネ承認 (interactive gate 2)
+  # ─────────────────────────────────────────────────────────────
+  - name: thumbnail_approve
+    edit: true
+    persona: planner
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Edit
+          - Write
+          - Bash
+    rules:
+      - condition: 10-assets/.thumbnail-approved フラグファイルが既に存在する
+        next: loop_video
+      - condition: ユーザーが承認した (フラグファイルを作成)
+        next: loop_video
+        requires_user_input: true
+        interactive_only: true
+      - condition: ユーザーが再生成を指示した
+        next: thumbnail_approve
+        requires_user_input: true
+        interactive_only: true
+      - condition: ユーザーが中断を指示した
+        next: ABORT
+        requires_user_input: true
+        interactive_only: true
+      - condition: 自動進行不可
+        next: ABORT
+        appendix: |
+          collection-pipeline は interactive モードで起動してください。
+    instruction: |
+      ## Goal
+      サムネを表示し、ユーザーの承認を flag file で永続化する。既に承認済みなら skip。
+
+      ## Steps
+      1. `<col>/10-assets/.thumbnail-approved` が存在するなら何もせず report に skip と書く
+      2. `Bash` で `open <col>/10-assets/thumbnail.jpg` でプレビュー
+      3. ユーザーに「承認 / 再生成 / 中断」を問う
+      4. 承認 → `Bash` で `touch <col>/10-assets/.thumbnail-approved` → 次 step へ
+      5. 再生成 → diff_prompt 修正 + generate_image.py 再実行 → 同 step を再度
+      6. 中断 → ABORT
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 5: loop_video — loop.mp4 生成 (失敗 OK)
+  # ─────────────────────────────────────────────────────────────
+  - name: loop_video
+    edit: true
+    persona: coder
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Edit
+          - Write
+          - Bash
+    rules:
+      - condition: loop.mp4 が存在する、または .loop_video.failed フラグがある
+        next: master_gate
+      - condition: 致命的失敗 (Bash 自体が動かない等)
+        next: ABORT
+    instruction: |
+      ## Goal
+      ループ動画を生成。失敗時は失敗フラグを残して次 step に進める (続行可能)。
+
+      ## Steps
+      1. `<col>/10-assets/loop.mp4` が存在するなら何もせず次へ
+      2. `<col>/10-assets/.loop_video.failed` が存在するならスキップして次へ
+      3. `/loop-video` skill 相当で `<col>/10-assets/main.png` → `loop.mp4` を生成
+      4. 失敗時は `Bash` で `touch <col>/10-assets/.loop_video.failed`
+      5. report に成功 / 失敗 (フラグファイル作成) を明記
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 6: master_gate — raw_master 生成 (Suno: URL 入力 / Lyria: 自動)
+  # ─────────────────────────────────────────────────────────────
+  - name: master_gate
+    edit: true
+    persona: coder
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Edit
+          - Write
+          - Bash
+    rules:
+      - condition: 00-master-raw/ に raw_master ファイルが存在する
+        next: master_check
+      - condition: Suno で URL 入力が必要
+        next: master_gate
+        requires_user_input: true
+        interactive_only: true
+      - condition: 自動進行不可 (pipeline で Suno URL 入力不能)
+        next: ABORT
+        appendix: |
+          Suno フローは interactive モードが必須です。
+      - condition: 致命的失敗
+        next: ABORT
+    instruction: |
+      ## Goal
+      raw_master 音源を生成。既に存在するなら skip。
+
+      ## Steps
+      1. `<col>/00-master-raw/` に音声ファイルが既に存在するなら何もせず次 step へ
+      2. config/channel/youtube.json から `music_engine` を読む
+      3. Suno フロー:
+         - rule "URL 入力が必要" を発火、ユーザーから Suno プレイリスト URL を取得
+         - `/masterup <URL>` skill 相当で DL → `<col>/00-master-raw/<filename>.mp3`
+      4. Lyria フロー:
+         - `/lyria <theme>` skill 相当で composition.json → セグメント生成 →
+           `<col>/00-master-raw/<filename>.wav` 自動生成
+      5. report に raw_master ファイル名を明記
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 7: master_check — 最終マスター検出 (配置待ちなら抜ける)
+  # ─────────────────────────────────────────────────────────────
+  - name: master_check
+    edit: false
+    persona: planner
+    required_permission_mode: readonly
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Bash
+    rules:
+      - condition: 01-master/ に raw_master と異なるファイルが配置されている
+        next: publish_live
+      - condition: 最終マスター未配置 (ユーザー作業待ち)
+        next: COMPLETE
+        appendix: |
+          raw master をミキシング+マスタリング後 <col>/01-master/ に配置し、
+          再度 takt -w collection-pipeline -t "<col>" を実行してください。
+    instruction: |
+      ## Goal
+      最終マスター音源 (`01-master/` 配下) が配置されているかチェック。未配置なら
+      workflow を一旦正常終了し、ユーザー作業後の再実行を待つ。
+
+      ## Steps
+      1. `<col>/01-master/` 内のファイルを `Bash` で列挙
+      2. `<col>/00-master-raw/` のファイル名と比較し、異なる名前のファイルが 1 つ以上
+         あれば最終マスターとみなす
+      3. 配置済 → 次 step へ
+      4. 未配置 → COMPLETE (rule 2)、appendix のとおり再実行を案内
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 8: publish_live — videoup + description + upload + live 移動
+  # ─────────────────────────────────────────────────────────────
+  - name: publish_live
+    edit: true
+    persona: coder
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Edit
+          - Write
+          - Bash
+        sandbox:
+          allow_unsandboxed_commands: true
+    rules:
+      - condition: collections/live/<col>/ にディレクトリが移動済み
+        next: COMPLETE
+        appendix: |
+          全工程完了。/analyze で初週パフォーマンスを確認してください (T+7 日後推奨)。
+      - condition: upload 失敗 / video_id 取得不能
+        next: ABORT
+        appendix: |
+          失敗箇所を確認後、再実行で続きから再開できます (idempotent)。
+    instruction: |
+      ## Goal
+      動画化・概要欄・YouTube アップロード・live 移動を実行する。各 sub-step は
+      対応 artifact が既に存在するなら skip (idempotent)。
+
+      ## Steps
+      1. **並列**: 以下を `Bash` で並行起動して wait:
+         - `/videoup` 相当 (`<col>/40-master-video/<filename>.mp4` 未生成時のみ)
+         - `/description` 相当 (`<col>/30-publish/description.txt` 未生成時のみ)
+      2. **順次**: `/upload` skill 相当で YouTube アップロード + live 移行
+         (`<col>/30-publish/youtube-url.txt` が無ければ実行、あれば skip)
+         - 成功時は upload 結果を `<col>/30-publish/youtube-url.txt` に保存
+         - `collections/planning/<col>/` を `collections/live/<col>/` に移動
+      3. report に動画 URL + 公開ステータス を明記

--- a/.takt/.gitignore
+++ b/.takt/.gitignore
@@ -1,0 +1,23 @@
+# Ignore everything by default
+*
+
+# This file itself
+!.gitignore
+
+# Project configuration
+!config.yaml
+
+# Facets and workflows (version-controlled)
+!workflows/
+!workflows/**
+!facets/
+!facets/personas/
+!facets/personas/**
+!facets/policies/
+!facets/policies/**
+!facets/knowledge/
+!facets/knowledge/**
+!facets/instructions/
+!facets/instructions/**
+!facets/output-contracts/
+!facets/output-contracts/**

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,0 +1,26 @@
+# takt config for youtube-channels-automation (upstream).
+#
+# - downstream channel repo に配るテンプレは `.takt-templates/` に置き、
+#   `yt-skills sync --asset takt --target <repo>` で展開する。
+# - 本ファイル (.takt/config.yaml) は upstream で起動する workflow 専用設定。
+#   個人マシン依存の設定 (API キー等) は `~/.takt/config.yaml` に書くこと。
+
+language: ja
+
+# claude-sdk: @anthropic-ai/claude-agent-sdk を直叩き (CLI サブプロセスではない)
+provider: claude-sdk
+model: sonnet
+
+base_branch: main
+concurrency: 1
+
+# channel-setup step が gcloud / terraform を呼ぶため unsandboxed 実行を許可。
+# 最小化は将来 (excluded_commands で部分許可) で検討。
+provider_options:
+  claude:
+    sandbox:
+      allow_unsandboxed_commands: true
+
+provider_profiles:
+  claude:
+    default_permission_mode: edit

--- a/.takt/workflows/channel-new-pipeline.yaml
+++ b/.takt/workflows/channel-new-pipeline.yaml
@@ -105,6 +105,7 @@ steps:
       - condition: ユーザーが決定事項テーブルを最終承認した
         next: setup
         requires_user_input: true
+        interactive_only: true
       - condition: ユーザーが修正を指示した (ポジショニング再検討、項目修正等)
         next: direction
         requires_user_input: true

--- a/.takt/workflows/channel-new-pipeline.yaml
+++ b/.takt/workflows/channel-new-pipeline.yaml
@@ -1,0 +1,280 @@
+name: channel-new-pipeline
+description: |
+  新規 YouTube チャンネル開設の 3 段パイプライン (research → direction → setup)。
+  channel-new (新規 repo 作成 + 競合発掘) は前段で人手 or 既存スキルで完了済みの前提。
+  既存スキル `.claude/skills/channel-{research,direction,setup}` を takt workflow に
+  写像し、step / rule / 人手承認の表現力を検証する PoC。
+
+initial_step: research
+max_steps: 12
+
+steps:
+  # ─────────────────────────────────────────────────────────────
+  # Step 1: research — 競合ベンチマークデータの徹底分析
+  # ─────────────────────────────────────────────────────────────
+  - name: research
+    edit: true
+    persona: planner
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+    rules:
+      - condition: docs/channel-research.md が生成され分析が完了している
+        next: direction
+      - condition: 必須データ (data/benchmark_*.json or comments_*.json) が見つからない
+        next: ABORT
+        appendix: |
+          channel-new で benchmark/comments を収集してから再実行してください。
+    output_contracts:
+      report:
+        - name: summary.md
+          format: summary
+          use_judge: false
+    instruction: |
+      ## Goal
+      `/channel-new` で収集したベンチマークデータ + コメントデータを読み込み、
+      徹底的に分析して `docs/channel-research.md` を生成する。
+
+      ## 前提
+      以下のいずれかが存在することを最初に確認する。なければ ABORT:
+      - `data/benchmark_YYYYMMDD.json` (競合チャンネルの動画データ)
+      - `data/comments_YYYYMMDD.json` (競合動画のコメント)
+      - `docs/benchmarks/*.md` (各チャンネルの個別レポート)
+      - `docs/benchmarks/thumbnails/` (サムネイル画像、任意)
+
+      ## Steps
+      ### Step 1: データ読み込み
+      - `data/` 内の最新の `benchmark_*.json` / `comments_*.json`
+      - `docs/benchmarks/` 内の全 `.md`
+
+      ### Step 2: 競合マトリクス作成
+      テーブルで全チャンネルを比較:
+      `| チャンネル | 登録者 | 動画数 | 平均再生数 | 日次再生 | ER% | 投稿間隔 | 動画尺 |`
+      加えて: 成長段階 (立ち上げ/成長/安定/停滞)、投稿トレンド (加速/減速/安定)、勝ちパターン。
+
+      ### Step 3: コンテンツ戦略分析
+      - **タイトル**: フォーマットパターン、頻出ワード、成功 vs 平均
+      - **動画尺**: チャンネル別平均、尺と再生数の相関
+      - **テーマ・世界観**: 頻出タグ、世界観マッピング、ブルーオーシャン
+      - **投稿スケジュール**: 曜日・時間帯の傾向
+
+      ### Step 4: サムネイル分析
+      `docs/benchmarks/thumbnails/` の画像を Read ツールで読む (画像対応):
+      構図 / 色使い / テキスト / 共通成功パターン / 差別化の余地。
+      画像がない場合は `docs/benchmarks/*.md` の `thumbnail_analysis` セクションで代替。
+
+      ### Step 5: 視聴者インサイト
+      コメントデータから抽出:
+      利用シーン / 感情反応 / リクエスト / 言語分布 / エンゲージメント。
+
+      ### Step 6: レポート生成
+      `docs/channel-research.md` に以下のセクションで保存:
+      - 競合マトリクス
+      - コンテンツ戦略
+      - サムネイルパターン
+      - 視聴者インサイト
+      - 機会領域 (ブルーオーシャン)
+      - 推奨事項 (ポジショニング案 3 件 + リスクと機会)
+
+      ### Step 7: 完了報告
+      レポートのパスとサマリー (機会領域・推奨事項) を簡潔に出力する。
+      これが direction step の入力になる。
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 2: direction — ユーザー対話でポジショニング確定
+  # ─────────────────────────────────────────────────────────────
+  - name: direction
+    edit: true
+    persona: planner
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+    rules:
+      - condition: ユーザーが決定事項テーブルを最終承認した
+        next: setup
+        requires_user_input: true
+      - condition: ユーザーが修正を指示した (ポジショニング再検討、項目修正等)
+        next: direction
+        requires_user_input: true
+        interactive_only: true
+      - condition: 議論が膠着し前提データが不足している
+        next: ABORT
+        appendix: |
+          channel-research に戻って必要なデータを補完してください。
+    output_contracts:
+      report:
+        - name: summary.md
+          format: summary
+          use_judge: false
+    instruction: |
+      ## Goal
+      `docs/channel-research.md` をもとに、ユーザーと対話で新チャンネルの方向性を
+      決定し、`docs/channel-direction.md` に保存する。**常にデータ根拠を示しながら**
+      議論を進める。
+
+      ## Steps
+      ### Step 1: 分析レポートのサマリー提示
+      `docs/channel-research.md` を読み、以下をユーザーに 1 回提示:
+      - 競合の全体像 (登録者レンジ、投稿頻度、平均再生数)
+      - ロールモデル候補 (最も参考になるチャンネル)
+      - 機会領域 (ブルーオーシャン)
+      - 視聴者が求めているもの
+
+      ### Step 2: ポジショニング議論 (6 領域)
+      対話で以下を順に確定する。各論点でユーザー回答を待ち、確定したら次へ:
+      1. **ジャンル & スタイル**: 競合の空白ポジション、ユーザー好みとのマッチ
+         (`genre.primary` / `genre.style` / `genre.context` を確定)
+      2. **差別化ポイント**: 競合にないテーマ・スタイル・世界観・品質。持続可能か
+      3. **ターゲット視聴者**: コメント分析からの視聴者像、利用シーン
+      4. **コンテンツ戦略**: 動画尺 (`audio.target_duration_min`)、投稿頻度、テーマ幅
+      5. **ビジュアルアイデンティティ**: サムネイル方向性、トーン＆マナー
+      6. **チャンネル名**: 仮名見直し、SEO + ブランド観点
+
+      ### Step 3: 決定事項テーブルで最終承認
+      議論の結果を以下のテーブルでユーザーに最終確認:
+      | 項目 | 決定内容 | データ根拠 |
+      |------|---------|-----------|
+      | チャンネル名 (確定) | | |
+      | 短縮名 (3-5 文字) | | |
+      | リポジトリ名 | | |
+      | genre.primary / style / context | | 空白ポジション |
+      | コアメッセージ | | 視聴者インサイト |
+      | 差別化ポイント | | 競合にない要素 |
+      | ターゲット視聴者 | | コメント分析 |
+      | 動画尺 (分) | | 競合の傾向 |
+      | 投稿頻度 | | 競合の投稿間隔 |
+      | 音楽エンジン (suno/lyria) | | ジャンル適性・API 可用性 |
+      | サムネイル方針 | | 競合サムネイル分析 |
+
+      ユーザーが承認したら次 step へ。修正指示なら direction を再度回す。
+
+      ### Step 4: 方向性ドキュメント保存
+      承認後、`docs/channel-direction.md` に以下のフォーマットで保存:
+      - 基本情報 (channel name / short / genre / コアメッセージ)
+      - ポジショニング (差別化 / ターゲット / 利用シーン)
+      - コンテンツ戦略 (動画尺 / 頻度 / テーマ幅)
+      - ビジュアルアイデンティティ (サムネイル / トーン)
+      - 決定の根拠 (各決定のデータ根拠)
+
+      リポジトリ名が変更された場合、ユーザーにリポジトリのリネームも案内する
+      (本 step ではリネームは実行しない、setup step に渡さず upstream で人手対応)。
+
+  # ─────────────────────────────────────────────────────────────
+  # Step 3: setup — 設定ファイル生成 + GCP bootstrap (人手承認ゲート付き)
+  # ─────────────────────────────────────────────────────────────
+  - name: setup
+    edit: true
+    persona: coder
+    required_permission_mode: edit
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+        sandbox:
+          allow_unsandboxed_commands: true
+    rules:
+      - condition: GCP bootstrap (gcloud / terraform 実行) を行う直前で確認待ち
+        next: setup
+        requires_user_input: true
+        interactive_only: true
+      - condition: OAuth クライアント ID 手動作成のためユーザー作業待ち
+        next: setup
+        requires_user_input: true
+        interactive_only: true
+      - condition: config + ディレクトリ + GCP + 検証がすべて完了した
+        next: COMPLETE
+      - condition: 必須情報 (Billing Account ID 等) が不足し進行不能
+        next: ABORT
+        appendix: |
+          ユーザーに必要情報を確認した上で再実行してください。
+    output_contracts:
+      report:
+        - name: summary.md
+          format: summary
+          use_judge: false
+    instruction: |
+      ## Goal
+      `docs/channel-direction.md` で確定した方向性をもとに、`config/channel/*.json`
+      を完成させ、ディレクトリ構造 + GCP/Vertex AI ブートストラップ + 検証までを
+      一気通貫で実行する。
+
+      ## 重要な制約 (review rule で人手承認ゲート)
+      - **GCP bootstrap (gcloud / terraform 実行) の直前**に必ずユーザーに確認:
+        - 既存 GCP プロジェクト流用 vs 新規作成
+        - terraform vs bootstrap.sh
+        - Billing Account ID (新規作成時のみ)
+      - **OAuth 2.0 クライアント ID** は gcloud / terraform 双方未対応。
+        Console URL を案内し、ユーザーが手動で 1 回作成 → `auth/client_secrets.json`
+        に配置する。これも人手承認ゲートで受け渡す。
+
+      ## Steps
+      ### Step 1: 方向性ドキュメント読み込み
+      `docs/channel-direction.md` から:
+      - チャンネル名 / 短縮名 / ジャンル (primary / style / context)
+      - コアメッセージ / 差別化ポイント
+      - 動画尺 / 投稿頻度 / 音楽エンジン
+
+      ### Step 2: config 内容の提案と承認
+      `docs/channel-research.md` の分析データも参照し、方向性に沿った config を提案。
+      生成ルールは `.claude/skills/channel-setup/references/config-generation-rules.md`、
+      雛形は `.claude/skills/channel-setup/references/config-template/*.json`
+      (責務別 4 ファイル: meta / content / youtube / analytics)。
+      ユーザーに見せて承認 or 修正指示を受ける。
+
+      ### Step 3: config/channel/*.json の完成
+      `/channel-new` が作った最小 config を完全版に拡張。
+      `references/config-template/` を `config/channel/` 配下に配置し、全フィールドを埋める。
+      `benchmark.channels` は `/channel-new` で設定済み (`config/channel/analytics.json`)。
+
+      ### Step 4: 残りディレクトリの作成
+      正準ディレクトリ構造: `.claude/skills/channel-setup/references/directory-structure.md`
+      を参照して全ディレクトリを作成。
+
+      ### Step 5: 残りファイル生成
+      | ファイル | 生成方法 |
+      |---------|---------|
+      | `config/schedule_config.json` | `references/schedule-template.json` をコピー、頻度調整 |
+      | `config/upload_settings.json` | `references/upload-settings-template.json` をコピー |
+      | `config/localizations.json` | `references/localizations-template.json` を方向性に合わせ調整 |
+      | `.claude/CLAUDE.md` | `references/claude-md-template.md` の placeholder を置換 |
+
+      ### Step 6: GCP / Vertex AI ブートストラップ
+      判断基準・コマンド・リカバリ: `.claude/skills/channel-setup/references/gcp-bootstrap.md`。
+      **必ず実行直前にユーザー承認** (`requires_user_input: true` rule で次 iteration を待つ):
+      - 既存プロジェクト流用 / 新規作成
+      - terraform / bootstrap.sh
+      - Billing Account ID (新規時)
+
+      実行後、Console URL を案内し OAuth クライアント ID を手動作成 →
+      `auth/client_secrets.json` に配置するようユーザーに依頼。
+      ここでも `requires_user_input: true` で待つ。
+
+      ### Step 7: 検証
+      JSON 構文 / config ロード / channel_id 自動取得は
+      `.claude/skills/channel-setup/references/verification.md` を参照。
+      生成全ファイルの一覧を最後に出力。
+
+      ### Step 8: 次ステップ案内
+      1. YouTube チャンネル作成 (まだなら) → `config/channel/meta.json` 更新
+      2. OAuth 認証 + channel_id 取得 (`references/verification.md`)
+      3. ブランディング素材 (`references/verification.md`)
+      4. 初回コレクション制作 → `/wf-new`
+
+      すべて完了したら本 step を抜け、workflow を COMPLETE する。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,11 @@ packages = ["src/youtube_automation"]
 
 [tool.hatch.build.targets.wheel.force-include]
 # Claude Code スキルファイルをパッケージ内 _skills/ として同梱
-# (yt-skills sync コマンドが importlib.resources で参照する)
+# (yt-skills sync --asset skills が importlib.resources で参照する)
 ".claude/skills" = "youtube_automation/_skills"
+# downstream チャンネルリポへ配布する takt テンプレ集
+# (yt-skills sync --asset takt が importlib.resources で参照する)
+".takt-templates" = "youtube_automation/_takt"
 
 # templates/*.md はパッケージディレクトリ内なので packages 設定で同梱される
 
@@ -86,6 +89,7 @@ include = [
     "src/",
     "tests/",
     ".claude/skills/",
+    ".takt-templates/",
     "scripts/",
     "auth/SETUP.md",
     "auth/client_secrets_template.json",

--- a/src/youtube_automation/cli/skills_sync.py
+++ b/src/youtube_automation/cli/skills_sync.py
@@ -1,13 +1,17 @@
-"""yt-skills — Claude Code スキルファイルを cwd の .claude/skills/ に同期する。
+"""yt-skills — Claude Code スキル / takt テンプレを downstream リポに同期する。
 
 `uv add git+https://github.com/daiki-beppu/youtube-automation` で本パッケージを
-インストールしたあと、`yt-skills sync` を実行することで、パッケージに同梱された
-.claude/skills/ 28 個を任意のチャンネルリポジトリに展開できる。
+インストールしたあと、`yt-skills sync` を実行することで、wheel に同梱された
+配布物 (Claude Code スキル / takt テンプレ) を任意のチャンネルリポジトリへ展開できる。
 
 Subcommands:
-    list   : 同梱スキル一覧を表示
-    sync   : .claude/skills/ にコピー (--symlink でシンボリックリンク, --force で上書き)
+    list   : 同梱アセット一覧を表示
+    sync   : --target に展開 (--symlink でシンボリックリンク, --force で上書き)
     diff   : 同梱版と target の差分を表示
+
+Asset 種別 (`--asset`):
+    skills : Claude Code スキル (`.claude/skills/`、ディレクトリ単位で 1 entry)
+    takt   : takt テンプレ (`.takt-templates/` → downstream `.takt/`、dir + file を entry)
 """
 
 from __future__ import annotations
@@ -20,16 +24,40 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Iterable
 
+# asset ごとの wheel resource 名・開発時 fallback・デフォルト target を集約。
+# (pyproject.toml の force-include で source_subdir が resource_name/ に同梱される)
+_ASSET_SPECS: dict[str, dict[str, str]] = {
+    "skills": {
+        "resource_name": "_skills",
+        "source_subdir": ".claude/skills",
+        "default_target": ".claude/skills",
+        "label": "スキル",
+    },
+    "takt": {
+        "resource_name": "_takt",
+        "source_subdir": ".takt-templates",
+        "default_target": ".takt",
+        "label": "takt テンプレ",
+    },
+}
 
-def _skills_root() -> Path:
-    """パッケージ同梱のスキルディレクトリを実体パスとして取得する。
+
+def _editable_root() -> Path:
+    """開発時の repo root を返す。テストでは monkeypatch で差し替える。"""
+    return Path(__file__).resolve().parents[3]
+
+
+def _asset_root(asset: str) -> Path:
+    """指定 asset の同梱ディレクトリを実体パスとして取得する。
 
     解決順:
-        1. インストール済み wheel の `youtube_automation/_skills/` (force-include 同梱)
-        2. ソースツリー直下の `.claude/skills/` (editable install / 開発時)
+        1. インストール済み wheel の `youtube_automation/<resource_name>/`
+        2. リポジトリルート直下の `<source_subdir>/` (editable / 開発時)
     """
+    spec = _ASSET_SPECS[asset]  # KeyError on unknown asset
+
     try:
-        resource = files("youtube_automation").joinpath("_skills")
+        resource = files("youtube_automation").joinpath(spec["resource_name"])
         with as_file(resource) as p:
             path = Path(p)
             if path.exists():
@@ -37,39 +65,48 @@ def _skills_root() -> Path:
     except (ModuleNotFoundError, FileNotFoundError):
         pass
 
-    # Fallback: ソースツリー (.../src/youtube_automation/cli/skills_sync.py から 4 階層上)
-    src_fallback = Path(__file__).resolve().parents[3] / ".claude" / "skills"
+    src_fallback = _editable_root() / spec["source_subdir"]
     if src_fallback.exists():
         return src_fallback
 
     raise FileNotFoundError(
-        "youtube_automation の skills データが見つかりません。"
-        "wheel が壊れているか editable install のソースツリーから実行してください。"
+        f"youtube_automation の {asset} データが見つかりません "
+        f"(wheel 同梱: {spec['resource_name']}, ソース: {spec['source_subdir']})。"
     )
 
 
-def _list_skills(root: Path) -> list[str]:
-    return sorted(d.name for d in root.iterdir() if d.is_dir())
+def _list_entries(root: Path) -> list[str]:
+    """root 直下の全エントリ (dir / file) を名前ソートで返す。"""
+    return sorted(p.name for p in root.iterdir())
 
 
 def _ensure_target_parent(target: Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _copy_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
-    """単一スキルをコピーする。戻り値: 'created' | 'updated' | 'skipped'."""
-    if dst.exists():
-        if not force:
-            return "skipped"
-        if not dry_run:
-            shutil.rmtree(dst)
+def _copy_entry(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
+    """単一 entry (ディレクトリ or ファイル) をコピーする。
+
+    戻り値: 'created' | 'skipped'.
+    """
+    if dst.exists() and not force:
+        return "skipped"
     if dry_run:
-        return "created" if not dst.exists() else "updated"
-    shutil.copytree(src, dst, symlinks=False)
+        return "created"
+    if dst.exists():
+        if dst.is_dir() and not dst.is_symlink():
+            shutil.rmtree(dst)
+        else:
+            dst.unlink()
+    if src.is_dir():
+        shutil.copytree(src, dst, symlinks=False)
+    else:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
     return "created"
 
 
-def _symlink_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
+def _symlink_entry(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
     if dst.exists() or dst.is_symlink():
         if not force:
             return "skipped"
@@ -80,36 +117,38 @@ def _symlink_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
                 shutil.rmtree(dst)
     if dry_run:
         return "linked"
+    dst.parent.mkdir(parents=True, exist_ok=True)
     dst.symlink_to(src.resolve())
     return "linked"
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    root = _skills_root()
-    skills = _list_skills(root)
-    print(f"同梱スキル {len(skills)} 件 (source: {root})")
-    for name in skills:
+    spec = _ASSET_SPECS[args.asset]
+    root = _asset_root(args.asset)
+    entries = _list_entries(root)
+    print(f"同梱{spec['label']} {len(entries)} 件 (source: {root})")
+    for name in entries:
         print(f"  - {name}")
     return 0
 
 
 def cmd_sync(args: argparse.Namespace) -> int:
-    root = _skills_root()
+    root = _asset_root(args.asset)
     target_dir = Path(args.target).resolve()
     _ensure_target_parent(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    skills = _list_skills(root)
+    entries = _list_entries(root)
     if args.only:
         only = set(args.only)
-        skills = [s for s in skills if s in only]
-        missing = only - set(skills)
+        entries = [s for s in entries if s in only]
+        missing = only - set(entries)
         for m in sorted(missing):
-            print(f"  [warn] 同梱スキルに含まれません: {m}", file=sys.stderr)
+            print(f"  [warn] 同梱版に含まれません: {m}", file=sys.stderr)
 
-    op = _symlink_skill if args.symlink else _copy_skill
+    op = _symlink_entry if args.symlink else _copy_entry
     counts: dict[str, int] = {"created": 0, "updated": 0, "skipped": 0, "linked": 0}
-    for name in skills:
+    for name in entries:
         src = root / name
         dst = target_dir / name
         result = op(src, dst, force=args.force, dry_run=args.dry_run)
@@ -120,19 +159,19 @@ def cmd_sync(args: argparse.Namespace) -> int:
     print()
     print(f"完了: {sum(counts.values())} 件処理 — {counts}")
     if counts.get("skipped"):
-        print("  (skipped されたスキルを上書きするには --force を指定してください)")
+        print("  (skipped を上書きするには --force を指定してください)")
     return 0
 
 
 def cmd_diff(args: argparse.Namespace) -> int:
-    root = _skills_root()
+    root = _asset_root(args.asset)
     target_dir = Path(args.target).resolve()
     if not target_dir.exists():
         print(f"target が存在しません: {target_dir}", file=sys.stderr)
         return 1
 
-    bundled = set(_list_skills(root))
-    on_disk = set(d.name for d in target_dir.iterdir() if d.is_dir())
+    bundled = set(_list_entries(root))
+    on_disk = set(p.name for p in target_dir.iterdir())
 
     only_bundled = sorted(bundled - on_disk)
     only_disk = sorted(on_disk - bundled)
@@ -149,11 +188,20 @@ def cmd_diff(args: argparse.Namespace) -> int:
 
     differing: list[str] = []
     for name in common:
-        cmp = filecmp.dircmp(root / name, target_dir / name)
-        if _has_diff(cmp):
+        src = root / name
+        dst = target_dir / name
+        if src.is_dir() and dst.is_dir():
+            cmp = filecmp.dircmp(src, dst)
+            if _has_diff(cmp):
+                differing.append(name)
+        elif src.is_file() and dst.is_file():
+            if not filecmp.cmp(src, dst, shallow=False):
+                differing.append(name)
+        else:
+            # 種別不一致 (片方が dir、もう片方が file 等) も差分扱い
             differing.append(name)
     if differing:
-        print("内容が異なるスキル:")
+        print("内容が異なる entry:")
         for n in differing:
             print(f"  ~ {n}")
     if not (only_bundled or only_disk or differing):
@@ -167,21 +215,38 @@ def _has_diff(cmp: filecmp.dircmp) -> bool:
     return any(_has_diff(sub) for sub in cmp.subdirs.values())
 
 
+def _add_asset_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--asset",
+        choices=sorted(_ASSET_SPECS.keys()),
+        default="skills",
+        help="配布対象 (default: skills)。takt テンプレ配布は --asset takt を指定",
+    )
+
+
+def _resolve_default_target(args: argparse.Namespace) -> None:
+    """`--target` 未指定 (None) 時に `--asset` 別のデフォルトを埋める。"""
+    if getattr(args, "target", None) is None:
+        args.target = _ASSET_SPECS[args.asset]["default_target"]
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="yt-skills",
-        description="Claude Code スキルファイルの同期ツール (youtube-channels-automation)",
+        description=("Claude Code スキル / takt テンプレの同期ツール (youtube-channels-automation)"),
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_list = sub.add_parser("list", help="同梱スキル一覧を表示")
+    p_list = sub.add_parser("list", help="同梱 asset 一覧を表示")
+    _add_asset_argument(p_list)
     p_list.set_defaults(func=cmd_list)
 
-    p_sync = sub.add_parser("sync", help="スキルを target に展開")
+    p_sync = sub.add_parser("sync", help="asset を target に展開")
+    _add_asset_argument(p_sync)
     p_sync.add_argument(
         "--target",
-        default=".claude/skills",
-        help="展開先ディレクトリ (default: .claude/skills)",
+        default=None,
+        help=("展開先ディレクトリ (default: skills は .claude/skills, takt は .takt)"),
     )
     p_sync.add_argument(
         "--symlink",
@@ -191,7 +256,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument(
         "--force",
         action="store_true",
-        help="既存スキルを上書きする",
+        help="既存を上書きする",
     )
     p_sync.add_argument(
         "--dry-run",
@@ -201,16 +266,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument(
         "--only",
         nargs="+",
-        metavar="SKILL",
-        help="指定したスキルだけ同期 (省略時は全件)",
+        metavar="ENTRY",
+        help="指定した entry だけ同期 (省略時は全件)",
     )
     p_sync.set_defaults(func=cmd_sync)
 
     p_diff = sub.add_parser("diff", help="同梱版と target の差分を表示")
+    _add_asset_argument(p_diff)
     p_diff.add_argument(
         "--target",
-        default=".claude/skills",
-        help="比較先ディレクトリ (default: .claude/skills)",
+        default=None,
+        help=("比較先ディレクトリ (default: skills は .claude/skills, takt は .takt)"),
     )
     p_diff.set_defaults(func=cmd_diff)
 
@@ -220,6 +286,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
+    _resolve_default_target(args)
     return args.func(args)
 
 

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -1,0 +1,269 @@
+"""yt-skills CLI の汎化動作テスト。
+
+skill 配布と takt テンプレ配布の両方を `--asset` フラグで切り替えるパイプラインを
+検証する。importlib.resources ベースの wheel 解決ではなく、editable install 相当の
+fallback (リポジトリルート直下の `.claude/skills/` / `.takt-templates/`) を
+tmp_path で偽装する。
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.cli import skills_sync
+from youtube_automation.cli.skills_sync import (
+    _ASSET_SPECS,
+    _asset_root,
+    _list_entries,
+    build_parser,
+)
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path にダミーの skills / takt-templates ツリーを仕込む。
+
+    `_asset_root` が importlib.resources で解決を試みた直後に拾われる editable
+    fallback を、`_editable_root()` を monkeypatch で差し替えて tmp_path に向ける。
+    importlib.resources のモックは行わず、wheel resource を意図的に欠落させる。
+    """
+    skills_dir = tmp_path / ".claude" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "channel-research").mkdir()
+    (skills_dir / "channel-research" / "SKILL.md").write_text("# research\n", encoding="utf-8")
+    (skills_dir / "channel-direction").mkdir()
+    (skills_dir / "channel-direction" / "SKILL.md").write_text("# direction\n", encoding="utf-8")
+
+    takt_dir = tmp_path / ".takt-templates"
+    takt_dir.mkdir()
+    (takt_dir / "README.md").write_text("# templates\n", encoding="utf-8")
+    (takt_dir / "workflows").mkdir()
+    (takt_dir / "workflows" / "sample.yaml").write_text("name: sample\n", encoding="utf-8")
+
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+
+    # wheel resource が拾われないように force-include 同梱の `_skills` / `_takt`
+    # が **存在しない** ようにする。importlib.resources は ModuleNotFoundError か
+    # FileNotFoundError を投げる経路で fallback に流れるため、副作用なしで
+    # 「resource なし」の状態を作るには `youtube_automation/_skills` / `_takt`
+    # に対する `as_file` の戻り値が tmp_path 配下に向くように _editable_root を
+    # 上書きするだけで十分（実 path に存在チェックが入る）。
+    return tmp_path
+
+
+# ---------- _asset_root ----------
+
+
+def test_asset_root_skills_falls_back_to_editable(fake_repo: Path) -> None:
+    assert _asset_root("skills") == fake_repo / ".claude" / "skills"
+
+
+def test_asset_root_takt_falls_back_to_editable(fake_repo: Path) -> None:
+    assert _asset_root("takt") == fake_repo / ".takt-templates"
+
+
+def test_asset_root_unknown_asset_raises(fake_repo: Path) -> None:
+    with pytest.raises(KeyError):
+        _asset_root("nope")
+
+
+def test_asset_specs_has_skills_and_takt() -> None:
+    assert "skills" in _ASSET_SPECS
+    assert "takt" in _ASSET_SPECS
+
+
+def test_asset_root_missing_source_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+    with pytest.raises(FileNotFoundError):
+        _asset_root("skills")
+
+
+# ---------- _list_entries ----------
+
+
+def test_list_entries_skills_lists_directories_only(fake_repo: Path) -> None:
+    root = _asset_root("skills")
+    assert _list_entries(root) == ["channel-direction", "channel-research"]
+
+
+def test_list_entries_takt_lists_dirs_and_files(fake_repo: Path) -> None:
+    root = _asset_root("takt")
+    # takt asset は dir + file を entry として扱う
+    assert _list_entries(root) == ["README.md", "workflows"]
+
+
+# ---------- cmd_list ----------
+
+
+def test_cmd_list_default_asset_is_skills(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["list"])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "channel-research" in out
+    assert "channel-direction" in out
+
+
+def test_cmd_list_takt_lists_template_entries(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["list", "--asset", "takt"])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "README.md" in out
+    assert "workflows" in out
+
+
+# ---------- cmd_sync ----------
+
+
+def test_cmd_sync_default_target_skills(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--dry-run"])
+    skills_sync._resolve_default_target(args)
+    assert args.target == ".claude/skills"
+    assert args.asset == "skills"
+
+
+def test_cmd_sync_default_target_takt(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "takt", "--dry-run"])
+    skills_sync._resolve_default_target(args)
+    assert args.target == ".takt"
+    assert args.asset == "takt"
+
+
+def test_cmd_sync_skills_dry_run_does_not_write(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "downstream" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--dry-run", "--target", str(target)])
+    rc = args.func(args)
+    assert rc == 0
+    # dry-run なので channel-research がコピーされていない
+    assert not (target / "channel-research").exists()
+
+
+def test_cmd_sync_takt_copies_dir_and_file(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "downstream" / ".takt"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "takt", "--target", str(target), "--force"])
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "README.md").read_text(encoding="utf-8") == "# templates\n"
+    assert (target / "workflows" / "sample.yaml").read_text(encoding="utf-8") == ("name: sample\n")
+
+
+def test_cmd_sync_skills_copies_skill_dirs(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target), "--force"])
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "# research\n"
+    assert (target / "channel-direction" / "SKILL.md").exists()
+
+
+def test_cmd_sync_force_overwrites_existing_skill(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    existing = target / "channel-research"
+    existing.mkdir()
+    (existing / "SKILL.md").write_text("OLD\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target), "--force"])
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "# research\n"
+
+
+def test_cmd_sync_skips_existing_without_force(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    existing = target / "channel-research"
+    existing.mkdir()
+    (existing / "SKILL.md").write_text("OLD\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target)])
+    rc = args.func(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "skipped" in out
+    # 既存ファイルが温存される
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "OLD\n"
+
+
+def test_cmd_sync_only_filters_entries(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "sync",
+            "--target",
+            str(target),
+            "--force",
+            "--only",
+            "channel-research",
+        ]
+    )
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research").exists()
+    assert not (target / "channel-direction").exists()
+
+
+# ---------- cmd_diff ----------
+
+
+def test_cmd_diff_skills_no_diff(fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    src = _asset_root("skills")
+    for entry in src.iterdir():
+        shutil.copytree(entry, target / entry.name)
+
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--target", str(target)])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "差分なし" in out
+
+
+def test_cmd_diff_takt_detects_change(fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "out" / ".takt"
+    target.mkdir(parents=True)
+    (target / "README.md").write_text("DIFFERENT\n", encoding="utf-8")
+    (target / "workflows").mkdir()
+    (target / "workflows" / "sample.yaml").write_text("DIFFERENT\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--asset", "takt", "--target", str(target)])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    # README.md か workflows のどちらかが「内容が異なる」セクションに出る
+    assert "内容が異なる" in out
+
+
+def test_cmd_diff_default_asset_is_skills(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["diff"])
+    skills_sync._resolve_default_target(args)
+    assert args.asset == "skills"
+    assert args.target == ".claude/skills"
+
+
+def test_cmd_diff_takt_default_target(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--asset", "takt"])
+    skills_sync._resolve_default_target(args)
+    assert args.asset == "takt"
+    assert args.target == ".takt"


### PR DESCRIPTION
## 概要

issue #86 の takt OSS PoC を実施。channel-new 系 4 スキルのうち
research → direction → setup の 3 step を takt workflow に写像し、
同時に将来 wf-new / wf-next 等を downstream に配るための配布インフラを整備した。

issue #88 (PoC 続編) も本 PR に同居:
- direction 承認 rule への `interactive_only` 追加で pipeline 挙動を整合化
- collection 制作の全工程を 1 workflow に統合した `collection-pipeline.yaml` を新規追加 (skill 1:1 写像案を撤回し takt 流の idempotent + ファイル位置ベース設計へ)

Closes #86
Closes #88

## 設計判断

- **配布アーキテクチャを 2 段に分割**: PoC 本体の `.takt/` (upstream 専用) と将来配布する `.takt-templates/` (wheel 同梱 → `_takt/` → downstream `.takt/`) を分離。channel-new pipeline は新規 repo を **作る** workflow なので物理的に upstream にしか置けない、という特殊事情を明示するため。
- **`yt-skills sync` を汎化** (新規コマンド分離ではなく `--asset` フラグ追加): 既存ユーザーへの後方互換維持を優先 (default `skills`)。内部に `_ASSET_SPECS` dict を導入し、wheel resource 名 / editable fallback / default target を集約。
- **persona は最小、instruction は SKILL.md を inline 写経**: PoC 完走を優先し、Faceted Prompting の persona 切り出しは避けた。inline で書くことで workflow YAML だけ見れば挙動が読める。
- **rule の `requires_user_input: true` + `interactive_only: true` で人手承認ゲートを表現**: direction の最終承認 + setup の GCP bootstrap 前 / OAuth 手動作成のゲートを宣言的に記述。両 flag 併用で pipeline モードで誤発火しないよう整合化 (#88 で確定)。
- **`collection-pipeline.yaml` は 1 workflow + 8 step + idempotent 設計** (#88): 当初検討した `wf-new.yaml` / `wf-next.yaml` の 2 workflow 案 + `workflow-state.json` 共存案は撤回。collection の進行状態はファイル位置・存在 + 軽量 flag file (`.thumbnail-approved` / `.loop_video.failed`) で表現し、workflow-state.json レイヤー自体を不要化。中断点では `COMPLETE` で抜けてユーザー作業後に再起動 → 各 step が idempotent なので最初から走らせても完了済み step は skip される。

## 変更内容

### #86 本体 (ca273c6)

- `pyproject.toml`: `[tool.hatch.build.targets.wheel.force-include]` と sdist `include` に `.takt-templates/` 追加
- `src/youtube_automation/cli/skills_sync.py`: `_ASSET_SPECS` 導入、`_asset_root` / `_list_entries` / `_copy_entry` / `_symlink_entry` を asset-agnostic 化、`--asset {skills,takt}` フラグ追加、デフォルト target を asset 別に解決
- `.takt/config.yaml` 新規 (provider: claude-sdk, model: sonnet, language: ja, sandbox 設定)
- `.takt/workflows/channel-new-pipeline.yaml` 新規 (research → direction → setup の 3 step、各 step に `output_contracts` の summary、人手承認 rule)
- `.takt-templates/README.md` 新規 (downstream 配布用テンプレ置き場のスケルトン)
- `tests/test_skills_sync.py` 新規 (21 件 TDD: asset_root / list_entries / cmd_list / cmd_sync / cmd_diff の skills + takt 両系統)

### #88 続編 (c8ae54e + b0e10df)

- `.takt/workflows/channel-new-pipeline.yaml`: direction step rule 1 (承認 → setup) に `interactive_only: true` を追加。rule 2 (修正指示, 元々両 flag) と対称化し、pipeline モードで誤発火しないよう整合化
- `.takt-templates/workflows/collection-pipeline.yaml` 新規 (8 step / 337 行): YouTube コレクション制作の全工程を 1 workflow に統合。idempotent + ファイル位置ベース。人手介入は select_plan / thumbnail_approve / master_gate (Suno URL) の 3 箇所のみ

## テスト計画

### #86 本体

- [x] `uv run pytest` 600 件 全 pass (回帰なし)
- [x] `uv run ruff check . / ruff format --check` 全 OK
- [x] `uv build` 後、wheel 内に `youtube_automation/_takt/README.md` を確認
- [x] `uv run yt-skills list` 既存挙動 (skills 29 件) 維持確認
- [x] `uv run yt-skills list --asset takt` 新挙動確認
- [x] `uv run yt-skills sync --asset takt --dry-run --target /tmp/dummy` で takt 配布の dry-run 動作確認
- [x] `takt workflow doctor channel-new-pipeline` で YAML 妥当性確認
- [x] `takt prompt channel-new-pipeline` で各 step のプロンプト合成確認
- [x] **実 PoC 完走**: bobble の benchmark/comments で `--pipeline --skip-git` 実行 → 7m 00s で research 完走 + direction 入口 まで進行 → 仕様通り abort

### #88 続編

- [x] `uv run pytest` 600 件 全 pass (回帰なし)
- [x] `uv run ruff check .` All checks passed
- [x] `takt workflow doctor` で channel-new-pipeline.yaml + collection-pipeline.yaml の syntax 検証 OK
- [x] **takt rule semantics 実機検証** (mock provider + source 解析): `interactive_only: true` rule が `--pipeline` モードで AI judge の Decision Criteria から除外されることを確認
- [x] **downstream 配布実証**: rjn リポで `yt-skills sync --asset takt --target .takt --force` → `takt prompt collection-pipeline` が 8 step として認識されることを確認
- [x] **`--pipeline` 実走** (clean test env): `detect → ideate_select` の 2 step が走り、ideate_select で interactive_only rule (rule 2/3) が filter され rule 5 (自動進行不可) で意図通り ABORT (2m 56s, 副作用なし)
- [ ] (user 手動) interactive 完走テストは user の terminal で `takt -w collection-pipeline -t "..."` を実走

詳細な観察結果は #88 にコメントで残す。