### PR TITLE
fix: title format() で scene_emoji 未渡しの KeyError を修正

### DIFF
--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -293,9 +293,10 @@ class YouTubeAutoUploader(YouTubeUploadCore):
             # ローカライゼーションにもキュレーション済みのタイムスタンプを使用
             curated_timestamps = self._extract_body_for_localizations(prebuilt["description"])
             scene_phrases = getattr(metadata_gen, "_last_scene_phrases", {})
+            scene_emoji = metadata_gen._load_scene_emoji()
             if curated_timestamps:
                 metadata["localizations"] = metadata_gen.generate_localizations(
-                    metadata["title"], curated_timestamps, scene_phrases
+                    metadata["title"], curated_timestamps, scene_phrases, scene_emoji=scene_emoji
                 )
 
         if publish_at:

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -40,6 +40,7 @@ class SceneTitleViolation:
 def validate_scene_phrases(
     scene_phrases: Dict[str, str],
     config,
+    scene_emoji: str = "",
 ) -> List[SceneTitleViolation]:
     """scene_phrases を localizations の全言語で試算し、100 codepoint 超過を一括検出する.
 
@@ -81,7 +82,7 @@ def validate_scene_phrases(
             raise ValueError(f"localizations.json: language '{lang}' に title_template が無い")
         activities = lang_data.get("activities", best_for_line)
         scene = scene_phrases[lang]
-        title = title_tpl.format(scene_phrase=scene, activities=activities)
+        title = title_tpl.format(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji)
         if len(title) > 100:
             violations.append(
                 SceneTitleViolation(
@@ -366,14 +367,21 @@ class BAHMetadataGenerator:
         # jazzgak. TTP 形式: theme_scenes から scene_phrase と activities を取得
         theme_scenes = self.config.content.title.theme_scenes
         scene_phrase = ""
+        scene_emoji = ""
         activities = activity
         if theme_scenes:
             theme_lower = theme.lower()
             for keyword, scene_data in theme_scenes.items():
                 if keyword in theme_lower:
                     scene_phrase = scene_data.get("scene", "")
+                    scene_emoji = scene_data.get("scene_emoji", "")
                     activities = scene_data.get("activities", activity)
                     break
+
+        # workflow-state.json の planning.scene_emoji を優先採用（コレクション固有の絵文字）
+        ws_scene_emoji = self._load_scene_emoji()
+        if ws_scene_emoji:
+            scene_emoji = ws_scene_emoji
 
         title = self.config.content.title.template.format(
             style=self.config.content.genre.style.title(),
@@ -381,6 +389,7 @@ class BAHMetadataGenerator:
             activity=activity,
             activities=activities,
             scene_phrase=scene_phrase,
+            scene_emoji=scene_emoji,
             duration_display=duration_display,
             duration_short=duration_short,
         )
@@ -410,8 +419,24 @@ class BAHMetadataGenerator:
                 pass
         return {}
 
+    def _load_scene_emoji(self) -> str:
+        """workflow-state.json から planning.scene_emoji を読み込み"""
+        ws_path = self.collection_path / "workflow-state.json"
+        if ws_path.exists():
+            try:
+                with open(ws_path, "r", encoding="utf-8") as f:
+                    state = json.load(f)
+                return state.get("planning", {}).get("scene_emoji", "")
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return ""
+
     def generate_localizations(
-        self, english_title: str, timestamp_body: str, scene_phrases: Dict[str, str] = None
+        self,
+        english_title: str,
+        timestamp_body: str,
+        scene_phrases: Dict[str, str] = None,
+        scene_emoji: str = "",
     ) -> Dict:
         """各言語のローカライズされたタイトル・説明文を生成（jazzgak. TTP ハイブリッド方式）
 
@@ -443,7 +468,7 @@ class BAHMetadataGenerator:
 
         # 欠落チェック + 100 codepoint 超過を全言語まとめて検出する
         # （従来は 1 言語ずつ fail していたため多言語対応チャンネルで再アップロードを繰り返していた）
-        violations = validate_scene_phrases(scene_phrases, self.config)
+        violations = validate_scene_phrases(scene_phrases, self.config, scene_emoji=scene_emoji)
         if violations:
             raise ValueError(
                 f"localizations の {len(violations)} 言語でタイトルが 100 codepoint を超過:\n"
@@ -459,7 +484,7 @@ class BAHMetadataGenerator:
             scene = scene_phrases[lang]
             title_tpl = lang_data["title_template"]
             activities = lang_data.get("activities", best_for_line)
-            loc_title = title_tpl.format(scene_phrase=scene, activities=activities)
+            loc_title = title_tpl.format(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji)
 
             # --- 概要欄（ハイブリッド方式）---
             opening_poem = desc_data.get("opening_poem", "")
@@ -560,8 +585,11 @@ class BAHMetadataGenerator:
 
         # ローカライゼーション生成
         scene_phrases = self._load_scene_phrases()
+        scene_emoji = self._load_scene_emoji()
         self._last_scene_phrases = scene_phrases
-        localizations = self.generate_localizations(title, timestamp_body, scene_phrases)
+        localizations = self.generate_localizations(
+            title, timestamp_body, scene_phrases, scene_emoji=scene_emoji
+        )
 
         return {
             "title": title,


### PR DESCRIPTION
## Summary

- `config/channel/content.json` の `title.template` と `config/localizations.json` の `title_template` に `{scene_emoji}` プレースホルダーが含まれているが、`format()` 呼び出しが `scene_emoji` 引数を渡しておらず `KeyError('scene_emoji')` で Complete Collection アップロードが失敗していた
- 4 箇所の `format()` 呼び出しに `scene_emoji` を伝播し、`workflow-state.json` の `planning.scene_emoji` をコレクション固有値として参照するヘルパー `_load_scene_emoji()` を追加
- `descriptions.md` 経由の再生成パス（`youtube_auto_uploader`）も同様に伝播

## 修正内容

| 場所 | 修正 |
|---|---|
| `metadata_generator._load_scene_emoji()` | 新設。`workflow-state.json` の `planning.scene_emoji` を返す |
| `metadata_generator._generate_title` | `theme_scenes[*].scene_emoji` → `planning.scene_emoji` の優先順で取得し `format()` へ渡す |
| `metadata_generator.validate_scene_phrases` | `scene_emoji: str = ""` 引数追加 + format に伝播 |
| `metadata_generator.generate_localizations` | 同上（kwarg 追加 + format に伝播） |
| `metadata_generator.generate_complete_collection_metadata` | `_load_scene_emoji()` で取得して `generate_localizations` へ渡す |
| `youtube_auto_uploader._merge_with_descriptions_md` | descriptions.md 経由の再生成 path でも `scene_emoji` を伝播 |

## 再現手順

1. `config/channel/content.json` の `title.template` に `{scene_emoji}` を含む（v5.0.0 のテンプレート例: `𝐏𝐥𝐚𝐲𝐥𝐢𝐬𝐭 🎧 {scene_phrase} Lo-fi Jazz {scene_emoji} {activities} BGM`）
2. `config/localizations.json` の各言語 `title_template` も `{scene_emoji}` を含む
3. `uv run yt-upload-collection -c <collection>` を実行
4. `❌ Complete Collection エラー: 'scene_emoji'`（KeyError）で停止

## Test plan

- [ ] `{scene_emoji}` 入りテンプレート × `workflow-state.json` の `planning.scene_emoji` あり: タイトルに絵文字が埋め込まれる
- [ ] `{scene_emoji}` 入りテンプレート × `planning.scene_emoji` なし: 空文字で format され、KeyError は出ない（後方互換）
- [ ] `{scene_emoji}` を含まない既存テンプレート: 何も変化なし
- [ ] descriptions.md がある状態でのアップロード（再生成パス）でも scene_emoji が伝播

🤖 Generated with [Claude Code](https://claude.com/claude-code)