### PR TITLE
refactor(skills-sync): asset 抽象化 (_ASSET_SPECS + --asset フラグ)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ packages = ["src/youtube_automation"]
 
 [tool.hatch.build.targets.wheel.force-include]
 # Claude Code スキルファイルをパッケージ内 _skills/ として同梱
-# (yt-skills sync コマンドが importlib.resources で参照する)
+# (yt-skills sync --asset skills が importlib.resources で参照する)
 ".claude/skills" = "youtube_automation/_skills"
 
 # templates/*.md はパッケージディレクトリ内なので packages 設定で同梱される

--- a/src/youtube_automation/cli/skills_sync.py
+++ b/src/youtube_automation/cli/skills_sync.py
@@ -1,13 +1,19 @@
-"""yt-skills — Claude Code スキルファイルを cwd の .claude/skills/ に同期する。
+"""yt-skills — Claude Code スキルを downstream リポに同期する。
 
 `uv add git+https://github.com/daiki-beppu/youtube-automation` で本パッケージを
-インストールしたあと、`yt-skills sync` を実行することで、パッケージに同梱された
-.claude/skills/ 28 個を任意のチャンネルリポジトリに展開できる。
+インストールしたあと、`yt-skills sync` を実行することで、wheel に同梱された
+配布物 (Claude Code スキル) を任意のチャンネルリポジトリへ展開できる。
 
 Subcommands:
-    list   : 同梱スキル一覧を表示
-    sync   : .claude/skills/ にコピー (--symlink でシンボリックリンク, --force で上書き)
+    list   : 同梱アセット一覧を表示
+    sync   : --target に展開 (--symlink でシンボリックリンク, --force で上書き)
     diff   : 同梱版と target の差分を表示
+
+Asset 種別 (`--asset`):
+    skills : Claude Code スキル (`.claude/skills/`、ディレクトリ単位で 1 entry)
+
+将来別種類の配布物を追加する場合は `_ASSET_SPECS` に entry を追加するだけで
+list/sync/diff の各 subcommand が自動的にサポートする。
 """
 
 from __future__ import annotations
@@ -20,16 +26,34 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Iterable
 
+# asset ごとの wheel resource 名・開発時 fallback・デフォルト target を集約。
+# (pyproject.toml の force-include で source_subdir が resource_name/ に同梱される)
+_ASSET_SPECS: dict[str, dict[str, str]] = {
+    "skills": {
+        "resource_name": "_skills",
+        "source_subdir": ".claude/skills",
+        "default_target": ".claude/skills",
+        "label": "スキル",
+    },
+}
 
-def _skills_root() -> Path:
-    """パッケージ同梱のスキルディレクトリを実体パスとして取得する。
+
+def _editable_root() -> Path:
+    """開発時の repo root を返す。テストでは monkeypatch で差し替える。"""
+    return Path(__file__).resolve().parents[3]
+
+
+def _asset_root(asset: str) -> Path:
+    """指定 asset の同梱ディレクトリを実体パスとして取得する。
 
     解決順:
-        1. インストール済み wheel の `youtube_automation/_skills/` (force-include 同梱)
-        2. ソースツリー直下の `.claude/skills/` (editable install / 開発時)
+        1. インストール済み wheel の `youtube_automation/<resource_name>/`
+        2. リポジトリルート直下の `<source_subdir>/` (editable / 開発時)
     """
+    spec = _ASSET_SPECS[asset]  # KeyError on unknown asset
+
     try:
-        resource = files("youtube_automation").joinpath("_skills")
+        resource = files("youtube_automation").joinpath(spec["resource_name"])
         with as_file(resource) as p:
             path = Path(p)
             if path.exists():
@@ -37,39 +61,48 @@ def _skills_root() -> Path:
     except (ModuleNotFoundError, FileNotFoundError):
         pass
 
-    # Fallback: ソースツリー (.../src/youtube_automation/cli/skills_sync.py から 4 階層上)
-    src_fallback = Path(__file__).resolve().parents[3] / ".claude" / "skills"
+    src_fallback = _editable_root() / spec["source_subdir"]
     if src_fallback.exists():
         return src_fallback
 
     raise FileNotFoundError(
-        "youtube_automation の skills データが見つかりません。"
-        "wheel が壊れているか editable install のソースツリーから実行してください。"
+        f"youtube_automation の {asset} データが見つかりません "
+        f"(wheel 同梱: {spec['resource_name']}, ソース: {spec['source_subdir']})。"
     )
 
 
-def _list_skills(root: Path) -> list[str]:
-    return sorted(d.name for d in root.iterdir() if d.is_dir())
+def _list_entries(root: Path) -> list[str]:
+    """root 直下の全エントリ (dir / file) を名前ソートで返す。"""
+    return sorted(p.name for p in root.iterdir())
 
 
 def _ensure_target_parent(target: Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _copy_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
-    """単一スキルをコピーする。戻り値: 'created' | 'updated' | 'skipped'."""
-    if dst.exists():
-        if not force:
-            return "skipped"
-        if not dry_run:
-            shutil.rmtree(dst)
+def _copy_entry(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
+    """単一 entry (ディレクトリ or ファイル) をコピーする。
+
+    戻り値: 'created' | 'skipped'.
+    """
+    if dst.exists() and not force:
+        return "skipped"
     if dry_run:
-        return "created" if not dst.exists() else "updated"
-    shutil.copytree(src, dst, symlinks=False)
+        return "created"
+    if dst.exists():
+        if dst.is_dir() and not dst.is_symlink():
+            shutil.rmtree(dst)
+        else:
+            dst.unlink()
+    if src.is_dir():
+        shutil.copytree(src, dst, symlinks=False)
+    else:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
     return "created"
 
 
-def _symlink_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
+def _symlink_entry(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
     if dst.exists() or dst.is_symlink():
         if not force:
             return "skipped"
@@ -80,36 +113,38 @@ def _symlink_skill(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
                 shutil.rmtree(dst)
     if dry_run:
         return "linked"
+    dst.parent.mkdir(parents=True, exist_ok=True)
     dst.symlink_to(src.resolve())
     return "linked"
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    root = _skills_root()
-    skills = _list_skills(root)
-    print(f"同梱スキル {len(skills)} 件 (source: {root})")
-    for name in skills:
+    spec = _ASSET_SPECS[args.asset]
+    root = _asset_root(args.asset)
+    entries = _list_entries(root)
+    print(f"同梱{spec['label']} {len(entries)} 件 (source: {root})")
+    for name in entries:
         print(f"  - {name}")
     return 0
 
 
 def cmd_sync(args: argparse.Namespace) -> int:
-    root = _skills_root()
+    root = _asset_root(args.asset)
     target_dir = Path(args.target).resolve()
     _ensure_target_parent(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    skills = _list_skills(root)
+    entries = _list_entries(root)
     if args.only:
         only = set(args.only)
-        skills = [s for s in skills if s in only]
-        missing = only - set(skills)
+        entries = [s for s in entries if s in only]
+        missing = only - set(entries)
         for m in sorted(missing):
-            print(f"  [warn] 同梱スキルに含まれません: {m}", file=sys.stderr)
+            print(f"  [warn] 同梱版に含まれません: {m}", file=sys.stderr)
 
-    op = _symlink_skill if args.symlink else _copy_skill
+    op = _symlink_entry if args.symlink else _copy_entry
     counts: dict[str, int] = {"created": 0, "updated": 0, "skipped": 0, "linked": 0}
-    for name in skills:
+    for name in entries:
         src = root / name
         dst = target_dir / name
         result = op(src, dst, force=args.force, dry_run=args.dry_run)
@@ -120,19 +155,19 @@ def cmd_sync(args: argparse.Namespace) -> int:
     print()
     print(f"完了: {sum(counts.values())} 件処理 — {counts}")
     if counts.get("skipped"):
-        print("  (skipped されたスキルを上書きするには --force を指定してください)")
+        print("  (skipped を上書きするには --force を指定してください)")
     return 0
 
 
 def cmd_diff(args: argparse.Namespace) -> int:
-    root = _skills_root()
+    root = _asset_root(args.asset)
     target_dir = Path(args.target).resolve()
     if not target_dir.exists():
         print(f"target が存在しません: {target_dir}", file=sys.stderr)
         return 1
 
-    bundled = set(_list_skills(root))
-    on_disk = set(d.name for d in target_dir.iterdir() if d.is_dir())
+    bundled = set(_list_entries(root))
+    on_disk = set(p.name for p in target_dir.iterdir())
 
     only_bundled = sorted(bundled - on_disk)
     only_disk = sorted(on_disk - bundled)
@@ -149,11 +184,20 @@ def cmd_diff(args: argparse.Namespace) -> int:
 
     differing: list[str] = []
     for name in common:
-        cmp = filecmp.dircmp(root / name, target_dir / name)
-        if _has_diff(cmp):
+        src = root / name
+        dst = target_dir / name
+        if src.is_dir() and dst.is_dir():
+            cmp = filecmp.dircmp(src, dst)
+            if _has_diff(cmp):
+                differing.append(name)
+        elif src.is_file() and dst.is_file():
+            if not filecmp.cmp(src, dst, shallow=False):
+                differing.append(name)
+        else:
+            # 種別不一致 (片方が dir、もう片方が file 等) も差分扱い
             differing.append(name)
     if differing:
-        print("内容が異なるスキル:")
+        print("内容が異なる entry:")
         for n in differing:
             print(f"  ~ {n}")
     if not (only_bundled or only_disk or differing):
@@ -167,21 +211,38 @@ def _has_diff(cmp: filecmp.dircmp) -> bool:
     return any(_has_diff(sub) for sub in cmp.subdirs.values())
 
 
+def _add_asset_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--asset",
+        choices=sorted(_ASSET_SPECS.keys()),
+        default="skills",
+        help="配布対象 (default: skills)",
+    )
+
+
+def _resolve_default_target(args: argparse.Namespace) -> None:
+    """`--target` 未指定 (None) 時に `--asset` 別のデフォルトを埋める。"""
+    if getattr(args, "target", None) is None:
+        args.target = _ASSET_SPECS[args.asset]["default_target"]
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="yt-skills",
-        description="Claude Code スキルファイルの同期ツール (youtube-channels-automation)",
+        description=("Claude Code スキル の同期ツール (youtube-channels-automation)"),
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_list = sub.add_parser("list", help="同梱スキル一覧を表示")
+    p_list = sub.add_parser("list", help="同梱 asset 一覧を表示")
+    _add_asset_argument(p_list)
     p_list.set_defaults(func=cmd_list)
 
-    p_sync = sub.add_parser("sync", help="スキルを target に展開")
+    p_sync = sub.add_parser("sync", help="asset を target に展開")
+    _add_asset_argument(p_sync)
     p_sync.add_argument(
         "--target",
-        default=".claude/skills",
-        help="展開先ディレクトリ (default: .claude/skills)",
+        default=None,
+        help=("展開先ディレクトリ (default: --asset の default_target に従う)"),
     )
     p_sync.add_argument(
         "--symlink",
@@ -191,7 +252,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument(
         "--force",
         action="store_true",
-        help="既存スキルを上書きする",
+        help="既存を上書きする",
     )
     p_sync.add_argument(
         "--dry-run",
@@ -201,16 +262,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_sync.add_argument(
         "--only",
         nargs="+",
-        metavar="SKILL",
-        help="指定したスキルだけ同期 (省略時は全件)",
+        metavar="ENTRY",
+        help="指定した entry だけ同期 (省略時は全件)",
     )
     p_sync.set_defaults(func=cmd_sync)
 
     p_diff = sub.add_parser("diff", help="同梱版と target の差分を表示")
+    _add_asset_argument(p_diff)
     p_diff.add_argument(
         "--target",
-        default=".claude/skills",
-        help="比較先ディレクトリ (default: .claude/skills)",
+        default=None,
+        help=("比較先ディレクトリ (default: --asset の default_target に従う)"),
     )
     p_diff.set_defaults(func=cmd_diff)
 
@@ -220,6 +282,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
+    _resolve_default_target(args)
     return args.func(args)
 
 

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -1,0 +1,189 @@
+"""yt-skills CLI の汎化動作テスト。
+
+skill 配布パイプラインを `--asset` フラグ経由で動かすことを検証する。
+importlib.resources ベースの wheel 解決ではなく、editable install 相当の
+fallback (リポジトリルート直下の `.claude/skills/`) を tmp_path で偽装する。
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.cli import skills_sync
+from youtube_automation.cli.skills_sync import (
+    _ASSET_SPECS,
+    _asset_root,
+    _list_entries,
+    build_parser,
+)
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path にダミーの skills ツリーを仕込む。
+
+    `_asset_root` が importlib.resources で解決を試みた直後に拾われる editable
+    fallback を、`_editable_root()` を monkeypatch で差し替えて tmp_path に向ける。
+    """
+    skills_dir = tmp_path / ".claude" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "channel-research").mkdir()
+    (skills_dir / "channel-research" / "SKILL.md").write_text("# research\n", encoding="utf-8")
+    (skills_dir / "channel-direction").mkdir()
+    (skills_dir / "channel-direction" / "SKILL.md").write_text("# direction\n", encoding="utf-8")
+
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+    return tmp_path
+
+
+# ---------- _asset_root ----------
+
+
+def test_asset_root_skills_falls_back_to_editable(fake_repo: Path) -> None:
+    assert _asset_root("skills") == fake_repo / ".claude" / "skills"
+
+
+def test_asset_root_unknown_asset_raises(fake_repo: Path) -> None:
+    with pytest.raises(KeyError):
+        _asset_root("nope")
+
+
+def test_asset_specs_has_skills() -> None:
+    assert "skills" in _ASSET_SPECS
+
+
+def test_asset_root_missing_source_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+    with pytest.raises(FileNotFoundError):
+        _asset_root("skills")
+
+
+# ---------- _list_entries ----------
+
+
+def test_list_entries_skills_lists_directories_only(fake_repo: Path) -> None:
+    root = _asset_root("skills")
+    assert _list_entries(root) == ["channel-direction", "channel-research"]
+
+
+# ---------- cmd_list ----------
+
+
+def test_cmd_list_default_asset_is_skills(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["list"])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "channel-research" in out
+    assert "channel-direction" in out
+
+
+# ---------- cmd_sync ----------
+
+
+def test_cmd_sync_default_target_skills(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--dry-run"])
+    skills_sync._resolve_default_target(args)
+    assert args.target == ".claude/skills"
+    assert args.asset == "skills"
+
+
+def test_cmd_sync_skills_dry_run_does_not_write(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "downstream" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--dry-run", "--target", str(target)])
+    rc = args.func(args)
+    assert rc == 0
+    assert not (target / "channel-research").exists()
+
+
+def test_cmd_sync_skills_copies_skill_dirs(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target), "--force"])
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "# research\n"
+    assert (target / "channel-direction" / "SKILL.md").exists()
+
+
+def test_cmd_sync_force_overwrites_existing_skill(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    existing = target / "channel-research"
+    existing.mkdir()
+    (existing / "SKILL.md").write_text("OLD\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target), "--force"])
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "# research\n"
+
+
+def test_cmd_sync_skips_existing_without_force(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    existing = target / "channel-research"
+    existing.mkdir()
+    (existing / "SKILL.md").write_text("OLD\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--target", str(target)])
+    rc = args.func(args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "skipped" in out
+    assert (target / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "OLD\n"
+
+
+def test_cmd_sync_only_filters_entries(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "sync",
+            "--target",
+            str(target),
+            "--force",
+            "--only",
+            "channel-research",
+        ]
+    )
+    rc = args.func(args)
+    assert rc == 0
+    assert (target / "channel-research").exists()
+    assert not (target / "channel-direction").exists()
+
+
+# ---------- cmd_diff ----------
+
+
+def test_cmd_diff_skills_no_diff(fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    src = _asset_root("skills")
+    for entry in src.iterdir():
+        shutil.copytree(entry, target / entry.name)
+
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--target", str(target)])
+    rc = args.func(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "差分なし" in out
+
+
+def test_cmd_diff_default_asset_is_skills(fake_repo: Path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(["diff"])
+    skills_sync._resolve_default_target(args)
+    assert args.asset == "skills"
+    assert args.target == ".claude/skills"


### PR DESCRIPTION
## 概要

`yt-skills` CLI の internals を asset-agnostic に整理し、将来の配布物拡張に備える refactor。動作は `--asset skills` (default) で従来と同等。

issue #86 (takt PoC) の派生として、PR #87 から **skills_sync 改修部分のみ抽出** したもの。 takt 関連 (`.takt/`、`.takt-templates/`、`channel-new-pipeline.yaml`) は採用見送りで本 PR には含まない。skills_sync の asset 抽象化は takt を使わなくても **将来別の配布物 (e.g. hooks templates / config templates) を増やすときの拡張点** として価値があるため main に残す。

## 変更内容

- `src/youtube_automation/cli/skills_sync.py`:
  - `_ASSET_SPECS` dict を導入 (resource_name / source_subdir / default_target / label を 1 entry に集約)
  - `_asset_root` / `_list_entries` / `_copy_entry` / `_symlink_entry` を asset-agnostic 化
  - `list` / `sync` / `diff` の各 subcommand に `--asset` フラグを追加 (default: skills、当面は skills のみ choices)
  - `_resolve_default_target` で `--target` 未指定時は asset の default_target に解決
- `pyproject.toml`: force-include コメントを `--asset skills` 表記に更新
- `tests/test_skills_sync.py`: 新規 14 件 TDD (asset_root / list_entries / cmd_list / cmd_sync / cmd_diff)

## 設計判断

- **新規 subcommand を増やす vs `--asset` フラグ**: フラグ方式を選択。新規 subcommand `yt-takt sync` のような分離だと既存ユーザーへの周知コスト + entry point 分裂のリスクがある。`--asset` 1 つで複数アセット種別を裁ける。
- **`_ASSET_SPECS` を 1 entry のままにする**: choices に skills のみだが dict 構造を残す。将来 entry 追加だけで list/sync/diff が自動対応できる拡張点として保つ。

## テスト計画

- [x] `uv run pytest` 593 件 全 pass (回帰なし、 takt 系 7 件減で 600 → 593)
- [x] `uv run ruff check .` All checks passed
- [x] `uv run yt-skills list` (default skills) で従来と同等の出力
- [x] `uv run yt-skills sync --target /tmp/xxx --dry-run` で従来と同等の挙動
- [x] `uv run yt-skills diff --target ~/02-yt/rjn/.claude/skills` で同梱版との差分が期待通り