### PR TITLE
feat: アップロード preflight にタグ件数・動画尺・タグ文字数チェックを追加

### DIFF
--- a/examples/channel_config.example/audio.json
+++ b/examples/channel_config.example/audio.json
@@ -1,5 +1,6 @@
 {
   "audio": {
-    "target_duration_min": 60
+    "target_duration_min": 60,
+    "target_duration_max": 75
   }
 }

--- a/examples/channel_config.example/content.json
+++ b/examples/channel_config.example/content.json
@@ -5,6 +5,7 @@
     "context": "RPG"
   },
   "tags": {
+    "min_count": 30,
     "base": ["chiptune music", "8-bit music", "RPG music", "game music"],
     "themes": {
       "adventure": ["adventure music", "journey music"],

--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -22,8 +22,16 @@ from typing import Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.metadata_generator import BAHMetadataGenerator  # noqa: E402
+from youtube_automation.utils.preflight_checks import (  # noqa: E402
+    check_duration,
+    check_tags_count,
+    check_tags_yt_chars,
+    extract_descriptions_md_tags,
+)
+from youtube_automation.utils.probe import probe_duration  # noqa: E402
 from youtube_automation.utils.upload_core import YouTubeUploadCore  # noqa: E402
 
 
@@ -171,6 +179,9 @@ class YouTubeAutoUploader(YouTubeUploadCore):
         3. タイムスタンプが per-theme 粒度であること（パターンバリエーション
            を v1〜v6 ごとに別チャプターに展開していないことを確認）
         4. タイトルが 100 codepoint 以内（YouTube 制限）
+        5. タグ件数が `tags.min_count` を満たすこと（戦略書違反防止）
+        6. タグの quotation 込み文字数が YouTube の 500 制限内
+        7. master 動画尺が `audio.target_duration_min/max` 範囲内
         """
         doc_dir = collection_dir / "20-documentation"
         desc_path = doc_dir / "descriptions.md"
@@ -214,6 +225,38 @@ class YouTubeAutoUploader(YouTubeUploadCore):
                 f"→ /description で多言語翻訳を含めて再生成してください。\n"
                 f"→ 既存例: collections/live/20260322-rjn-city-collection/workflow-state.json"
             )
+
+        # タグ件数 / quotation 文字数チェック
+        # descriptions.md の「タグ（YouTube タグ欄）」が _upload_complete_collection で
+        # for_collection() を上書きするため、本番と同じソースを検証する。
+        prebuilt_tags = extract_descriptions_md_tags(desc_path)
+        tags = prebuilt_tags if prebuilt_tags is not None else config.content.tags.for_collection(collection_dir.name)
+        issues: list[str] = []
+        for msg in (
+            check_tags_count(tags, config.content.tags.min_count),
+            check_tags_yt_chars(tags),
+        ):
+            if msg:
+                issues.append(msg)
+
+        # 動画尺チェック（target_duration が設定済みかつ master mp4 が存在する場合のみ）
+        if config.audio.target_duration_min is not None or config.audio.target_duration_max is not None:
+            master_video = CollectionPaths(collection_dir).find_master_video()
+            if master_video:
+                dur = probe_duration(master_video)
+                if dur is None:
+                    issues.append(f"duration probe failed for {master_video.name}")
+                else:
+                    msg = check_duration(
+                        dur,
+                        config.audio.target_duration_min,
+                        config.audio.target_duration_max,
+                    )
+                    if msg:
+                        issues.append(msg)
+
+        if issues:
+            raise RuntimeError("❌ preflight failed:\n  - " + "\n  - ".join(issues))
 
         logger.info(f"✅ preflight OK — title={len(title)}c, chapters={len(ts_lines)}, langs={len(scene_phrases)}")
 

--- a/src/youtube_automation/scripts/generate_master.py
+++ b/src/youtube_automation/scripts/generate_master.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.probe import probe_duration
 from youtube_automation.utils.skill_config import load_skill_config
 
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
@@ -58,7 +59,7 @@ def _sum_track_duration(files: list[Path]) -> float:
     """個別トラックの尺を合算する。probe に失敗したファイルがあれば ValidationError。"""
     total = 0.0
     for f in files:
-        dur = _probe_duration(f)
+        dur = probe_duration(f)
         if dur is None:
             raise ValidationError(f"トラック尺の probe に失敗: {f}")
         total += dur
@@ -85,28 +86,6 @@ def _resolve_loop_count(
         loops = math.ceil((target_sec - crossfade) / span)
         return max(1, loops)
     return 1
-
-
-def _probe_duration(path: Path) -> float | None:
-    try:
-        result = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "csv=p=0",
-                str(path),
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return float(result.stdout.strip())
-    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
-        return None
 
 
 def _format_duration(seconds: float) -> str:
@@ -237,7 +216,7 @@ def generate_master(
         sys.stderr.flush()
 
         size = _format_size(output.stat().st_size)
-        dur = _probe_duration(output)
+        dur = probe_duration(output)
         dur_fmt = _format_duration(dur) if dur is not None else "?"
 
         print()

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -23,7 +23,16 @@ import re
 import sys
 from pathlib import Path
 
+from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
+from youtube_automation.utils.config.config import ChannelConfig  # noqa: E402
+from youtube_automation.utils.preflight_checks import (  # noqa: E402
+    check_duration,
+    check_tags_count,
+    check_tags_yt_chars,
+    extract_descriptions_md_tags,
+)
+from youtube_automation.utils.probe import probe_duration  # noqa: E402
 
 COLLECTIONS_DIR = channel_dir() / "collections" / "live"
 
@@ -38,9 +47,10 @@ def extract_section(text: str, header: str) -> str | None:
     return m.group(1).strip() if m else None
 
 
-def audit_local(col: Path, supported_langs: list[str]) -> list[str]:
+def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     """Return a list of issue descriptions for this collection."""
     issues: list[str] = []
+    supported_langs = list(config.localizations.supported_languages)
 
     desc_md = col / "20-documentation" / "descriptions.md"
     stray = list((col / "20-documentation").glob("description*"))
@@ -86,6 +96,33 @@ def audit_local(col: Path, supported_langs: list[str]) -> list[str]:
             issues.append(f"workflow-state.scene_phrases missing langs: {missing[:6]}{'…' if len(missing) > 6 else ''}")
     else:
         issues.append("workflow-state.json missing")
+
+    # タグ件数 / quotation 文字数（preflight と同じく descriptions.md 優先）
+    prebuilt_tags = extract_descriptions_md_tags(desc_md)
+    tags = prebuilt_tags if prebuilt_tags is not None else config.content.tags.for_collection(col.name)
+    for msg in (
+        check_tags_count(tags, config.content.tags.min_count),
+        check_tags_yt_chars(tags),
+    ):
+        if msg:
+            issues.append(msg)
+
+    # 動画尺チェック（master mp4 がローカルに残っている場合のみ。
+    # /live-clean 後のコレクションでは skip して偽陽性を防ぐ）
+    if config.audio.target_duration_min is not None or config.audio.target_duration_max is not None:
+        master_video = CollectionPaths(col).find_master_video()
+        if master_video:
+            dur = probe_duration(master_video)
+            if dur is None:
+                issues.append(f"duration probe failed for {master_video.name}")
+            else:
+                msg = check_duration(
+                    dur,
+                    config.audio.target_duration_min,
+                    config.audio.target_duration_max,
+                )
+                if msg:
+                    issues.append(msg)
 
     return issues
 
@@ -175,7 +212,7 @@ def main() -> None:
         for col in sorted(COLLECTIONS_DIR.iterdir()):
             if not col.is_dir():
                 continue
-            issues = audit_local(col, supported_langs)
+            issues = audit_local(col, config)
             if issues:
                 total_issues += len(issues)
                 print(f"❌ {col.name}")

--- a/src/youtube_automation/utils/config/audio.py
+++ b/src/youtube_automation/utils/config/audio.py
@@ -10,3 +10,4 @@ class Audio:
     """`audio` セクション（optional、bobble のみ）."""
 
     target_duration_min: float | None = None
+    target_duration_max: float | None = None

--- a/src/youtube_automation/utils/config/content.py
+++ b/src/youtube_automation/utils/config/content.py
@@ -22,6 +22,7 @@ class Tags:
     themes: dict[str, list[str]]
     channel_specific: list[str]
     channel_name: str
+    min_count: int | None = None
 
     def default(self) -> list[str]:
         """チャンネル名を含むデフォルトタグリスト."""

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -203,6 +203,7 @@ def _build_content(merged: dict, meta: ChannelMeta) -> Content:
         themes={k: list(v) for k, v in tg["themes"].items()},
         channel_specific=list(tg.get("channel_specific", [])),
         channel_name=meta.channel_name,
+        min_count=tg.get("min_count"),
     )
 
     dp = merged["descriptions"]
@@ -272,7 +273,10 @@ def _build_workflow(merged: dict) -> Workflow:
 
 def _build_audio(merged: dict) -> Audio:
     ad = merged.get("audio") or {}
-    return Audio(target_duration_min=ad.get("target_duration_min"))
+    return Audio(
+        target_duration_min=ad.get("target_duration_min"),
+        target_duration_max=ad.get("target_duration_max"),
+    )
 
 
 def _build_comments(merged: dict) -> Comments:

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -1,0 +1,87 @@
+"""アップロード preflight / metadata audit 共通の品質チェック関数群.
+
+各関数は問題があれば人間向けの issue 文字列を返し、なければ None を返す。
+呼び出し側は戻り値を集約して fail-loud するか、audit のリスト追加に使う。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from youtube_automation.utils.youtube_tag import youtube_tag_chars
+
+YT_TAG_CHAR_LIMIT = 500
+
+_DESC_TAGS_RE = re.compile(r"## タグ（YouTube タグ欄）\s*\n+```\n(.*?)```", re.DOTALL)
+
+
+def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
+    """`descriptions.md` の「タグ（YouTube タグ欄）」セクションからタグリストを抽出.
+
+    実アップロード時 `_load_descriptions_md` がここを優先採用するため、preflight も
+    本番と同じソースを検証する必要がある。ファイル不在 / セクション不在 / 空なら None。
+    """
+    if not desc_md.exists():
+        return None
+    m = _DESC_TAGS_RE.search(desc_md.read_text(encoding="utf-8"))
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    tags = [t.strip() for t in raw.replace("\n", ",").split(",") if t.strip()]
+    return tags or None
+
+
+def check_tags_count(tags: list[str], min_count: int | None) -> str | None:
+    """件数下限を満たさない場合 issue 文字列、満たせば None."""
+    if min_count is None:
+        return None
+    if len(tags) < min_count:
+        return f"tags count: {len(tags)} (min {min_count})"
+    return None
+
+
+def check_tags_yt_chars(tags: list[str], limit: int = YT_TAG_CHAR_LIMIT) -> str | None:
+    """quotation 込み文字数が limit 超なら issue 文字列、満たせば None."""
+    chars = youtube_tag_chars(tags)
+    if chars > limit:
+        return f"tags YT chars (quoted): {chars} / {limit}"
+    return None
+
+
+def _format_duration(seconds: float) -> str:
+    total = int(seconds)
+    h, rem = divmod(total, 3600)
+    m, _ = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m"
+    return f"{m}m"
+
+
+def check_duration(
+    seconds: float,
+    min_sec: float | None,
+    max_sec: float | None,
+) -> str | None:
+    """動画尺が target_duration の範囲外なら issue 文字列、満たせば None.
+
+    両方 None なら無効化（None を返す）。
+    """
+    if min_sec is None and max_sec is None:
+        return None
+    actual = _format_duration(seconds)
+    if min_sec is not None and seconds < min_sec:
+        target = _target_label(min_sec, max_sec)
+        return f"duration: {actual} (target {target})"
+    if max_sec is not None and seconds > max_sec:
+        target = _target_label(min_sec, max_sec)
+        return f"duration: {actual} (target {target})"
+    return None
+
+
+def _target_label(min_sec: float | None, max_sec: float | None) -> str:
+    if min_sec is not None and max_sec is not None:
+        return f"{_format_duration(min_sec)}〜{_format_duration(max_sec)}"
+    if min_sec is not None:
+        return f"≥{_format_duration(min_sec)}"
+    return f"≤{_format_duration(max_sec)}"  # type: ignore[arg-type]

--- a/src/youtube_automation/utils/probe.py
+++ b/src/youtube_automation/utils/probe.py
@@ -1,0 +1,29 @@
+"""ffprobe ラッパー."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def probe_duration(path: Path) -> float | None:
+    """ffprobe で動画/音声ファイルの再生秒数を取得する。失敗時は None."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "csv=p=0",
+                str(path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return float(result.stdout.strip())
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+        return None

--- a/src/youtube_automation/utils/youtube_tag.py
+++ b/src/youtube_automation/utils/youtube_tag.py
@@ -1,0 +1,14 @@
+"""YouTube タグ関連のユーティリティ."""
+
+from __future__ import annotations
+
+
+def youtube_tag_chars(tags: list[str]) -> int:
+    """YouTube が判定する真のタグ文字数を計算する.
+
+    YouTube はスペースを含むタグを引用符で囲んだ上で `,` 結合した長さで
+    500 文字制限を判定する（実測で確認）。`len(','.join(tags))` だけでは
+    `400 The request metadata specifies invalid video keywords` を取りこぼす。
+    """
+    parts = [f'"{t}"' if " " in t else t for t in tags]
+    return len(",".join(parts))

--- a/tests/test_generate_master.py
+++ b/tests/test_generate_master.py
@@ -52,7 +52,7 @@ class TestSumTrackDuration:
     def test_sums_successful_probes(self):
         files = [Path("/fake/a.mp3"), Path("/fake/b.mp3"), Path("/fake/c.mp3")]
         with patch(
-            "youtube_automation.scripts.generate_master._probe_duration",
+            "youtube_automation.scripts.generate_master.probe_duration",
             side_effect=[100.0, 200.5, 50.25],
         ):
             assert _sum_track_duration(files) == pytest.approx(350.75)
@@ -60,7 +60,7 @@ class TestSumTrackDuration:
     def test_raises_on_probe_failure(self):
         files = [Path("/fake/a.mp3"), Path("/fake/b.mp3")]
         with patch(
-            "youtube_automation.scripts.generate_master._probe_duration",
+            "youtube_automation.scripts.generate_master.probe_duration",
             side_effect=[100.0, None],
         ):
             with pytest.raises(ValidationError, match="probe に失敗"):
@@ -154,7 +154,7 @@ class TestGenerateMasterLoops:
         monkeypatch.setattr(generate_master.shutil, "which", lambda _: "/usr/bin/ffmpeg")
 
         # 各ファイル 2300s → 1 ループ 4600s、target 150 min = 9000s → 2 ループ
-        monkeypatch.setattr(generate_master, "_probe_duration", lambda p: 2300.0)
+        monkeypatch.setattr(generate_master, "probe_duration", lambda p: 2300.0)
 
         captured = {}
 

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -1,0 +1,111 @@
+"""preflight_checks の各 check_* 関数の挙動検証."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.utils.preflight_checks import (
+    check_duration,
+    check_tags_count,
+    check_tags_yt_chars,
+    extract_descriptions_md_tags,
+)
+
+
+class TestCheckTagsCount:
+    def test_none_skips_check(self) -> None:
+        assert check_tags_count(["a"], None) is None
+
+    def test_under_min_returns_message(self) -> None:
+        msg = check_tags_count(["a", "b"], 5)
+        assert msg == "tags count: 2 (min 5)"
+
+    def test_at_min_passes(self) -> None:
+        assert check_tags_count(["a", "b", "c"], 3) is None
+
+    def test_over_min_passes(self) -> None:
+        assert check_tags_count(["a"] * 50, 10) is None
+
+
+class TestCheckTagsYtChars:
+    def test_below_limit_passes(self) -> None:
+        assert check_tags_yt_chars(["short"]) is None
+
+    def test_exactly_at_limit_passes(self) -> None:
+        # 9 文字 × 50 + カンマ 49 = 499 → 500 制限内
+        tags = ["123456789"] * 50
+        assert check_tags_yt_chars(tags) is None
+
+    def test_over_limit_returns_message(self) -> None:
+        # スペース付き 11 文字 → quotation 込み 13、× 50 + カンマ 49 = 699
+        tags = ["lofi  beats"] * 50
+        msg = check_tags_yt_chars(tags)
+        assert msg is not None
+        assert msg.startswith("tags YT chars (quoted):")
+        assert "/ 500" in msg
+
+    def test_custom_limit(self) -> None:
+        assert check_tags_yt_chars(["abc"], limit=2) == "tags YT chars (quoted): 3 / 2"
+
+
+class TestCheckDuration:
+    def test_both_none_skips(self) -> None:
+        assert check_duration(123.0, None, None) is None
+
+    def test_within_range_passes(self) -> None:
+        # 2h30m
+        assert check_duration(9000, 8520, 9240) is None
+
+    def test_under_min_fails(self) -> None:
+        # 1h17m vs target 2h22m〜2h34m
+        msg = check_duration(4620, 8520, 9240)
+        assert msg is not None
+        assert "1h17m" in msg
+        assert "2h22m〜2h34m" in msg
+
+    def test_over_max_fails(self) -> None:
+        # 2h46m vs target 2h22m〜2h34m
+        msg = check_duration(9960, 8520, 9240)
+        assert msg is not None
+        assert "2h46m" in msg
+        assert "2h22m〜2h34m" in msg
+
+    def test_only_min_set(self) -> None:
+        # min のみ。下回るときは fail、上回るときは pass
+        assert check_duration(60, 100, None) is not None
+        assert check_duration(200, 100, None) is None
+
+    def test_only_max_set(self) -> None:
+        assert check_duration(200, None, 100) is not None
+        assert check_duration(50, None, 100) is None
+
+
+class TestExtractDescriptionsMdTags:
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        assert extract_descriptions_md_tags(tmp_path / "missing.md") is None
+
+    def test_returns_none_when_section_missing(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text("## タイトル案\n```\nFoo\n```\n", encoding="utf-8")
+        assert extract_descriptions_md_tags(p) is None
+
+    def test_extracts_comma_separated_tags(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text(
+            "## タグ（YouTube タグ欄）\n```\nlofi beats, jazz, study music\n```\n",
+            encoding="utf-8",
+        )
+        assert extract_descriptions_md_tags(p) == ["lofi beats", "jazz", "study music"]
+
+    def test_extracts_newline_separated_tags(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text(
+            "## タグ（YouTube タグ欄）\n```\nlofi beats\njazz\nstudy\n```\n",
+            encoding="utf-8",
+        )
+        assert extract_descriptions_md_tags(p) == ["lofi beats", "jazz", "study"]
+
+    def test_returns_none_for_empty_section(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text("## タグ（YouTube タグ欄）\n```\n\n```\n", encoding="utf-8")
+        assert extract_descriptions_md_tags(p) is None

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,41 @@
+"""utils.probe.probe_duration の挙動検証."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from youtube_automation.utils import probe
+
+
+def test_returns_float_on_success(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(stdout="123.45\n")
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) == 123.45
+
+
+def test_returns_none_when_ffprobe_missing(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("ffprobe not found")
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) is None
+
+
+def test_returns_none_on_subprocess_error(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) is None
+
+
+def test_returns_none_on_unparseable_stdout(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(stdout="not a number\n")
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) is None

--- a/tests/test_youtube_tag.py
+++ b/tests/test_youtube_tag.py
@@ -1,0 +1,29 @@
+"""youtube_tag.youtube_tag_chars の挙動検証."""
+
+from __future__ import annotations
+
+from youtube_automation.utils.youtube_tag import youtube_tag_chars
+
+
+def test_empty_list_is_zero() -> None:
+    assert youtube_tag_chars([]) == 0
+
+
+def test_no_space_tags_match_naive_join() -> None:
+    tags = ["chiptune", "8bit", "rpg"]
+    assert youtube_tag_chars(tags) == len(",".join(tags))
+
+
+def test_space_tags_quoted_correctly() -> None:
+    # `"lofi beats"` (12 chars) + `,` + `jazz` (4 chars) = 17
+    assert youtube_tag_chars(["lofi beats", "jazz"]) == 17
+
+
+def test_mixed_tags_compute_quoted_length() -> None:
+    tags = ["a b c", "x", "y z"]
+    # `"a b c"` (7) + `,` + `x` (1) + `,` + `"y z"` (5) = 15
+    assert youtube_tag_chars(tags) == 15
+
+
+def test_single_tag_with_space() -> None:
+    assert youtube_tag_chars(["lofi beats"]) == len('"lofi beats"')


### PR DESCRIPTION
## 概要
戦略書違反のコレクション（タグ件数不足・動画尺バラつき・タグ文字数超過）が連続で公開されて伸び悩みを招いていたため、`_preflight_check` と `metadata_audit.py --strict` に 3 種の fail-loud チェックを追加した。
Closes #83

## 設計判断
- タグ quotation 超過は auto-trim ではなく fail-loud（暗黙にタグが消える事故を避けるため）
- `Tags.min_count` デフォルトは None（明示設定済みチャンネルのみチェック、後方互換性優先）
- preflight は `descriptions.md` のタグを優先して本番アップロードと同じソースを検証
- `audit_local` は master mp4 不在のコレクション（/live-clean 後）で偽陽性を出さない
- 公開時刻ずれチェックはスコープ外（必要なら別 issue）

## 変更内容
- `utils/youtube_tag.py`、`utils/probe.py`（generate_master から移動+public 化）、`utils/preflight_checks.py` を新設
- `Tags.min_count` / `Audio.target_duration_max` を追加
- `_preflight_check` と `audit_local` で descriptions.md のタグセクションを優先採用
- examples とトップレベルテスト 28 件を追加

## テスト計画
- [x] `uv run ruff check .` / `uv run pytest`（607 passed）
- [ ] rjn 環境で content.json に `tags.min_count: 35`、audio.json に `target_duration_min/max: 8520/9240` を設定し、既知違反の greenhouse コレクションで `yt-upload-collection` が fail することをドライランで確認
- [ ] `yt-metadata-audit --local --strict` で同じ違反が検出されることを確認