### PR TITLE
fix: Reporting API を Reach レポートに切替えて thumbnail impressions/CTR を実取得

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### Reporting API: Reach レポートに切り替えて thumbnail impressions / CTR を実取得する
+
+`ReportingAPIClient.select_report_type()` が選定する `_REPORT_TYPE_PRIORITIES` を
+`channel_basic_*` から **Reach 系**（`channel_reach_basic_a1` /
+`channel_reach_combined_a1`）に変更した。
+
+問題: `channel_basic_a3` には views / engaged_views / card_impressions /
+annotation_impressions しか含まれず、`video_thumbnail_impressions` /
+`video_thumbnail_impressions_ctr` を **CSV カラムとして提供しない**
+（[公式ドキュメント](https://developers.google.com/youtube/reporting/v1/reports/channel_reports)）。
+そのため `--include-reporting` を実行しても全レポートで「impressions / ctr 列が
+見つかりません」のパース警告が発生し、`per_video` / `per_day` が常に空になっていた。
+
+修正:
+
+- `_REPORT_TYPE_PRIORITIES`: `channel_reach_basic_a1` を 1 番目、
+  `channel_reach_combined_a1` を 2 番目に変更
+- `_CTR_COLUMNS`: 公式名 `video_thumbnail_impressions_ctr` を 1 番目に
+  （旧版 `video_thumbnail_impressions_click_through_rate` は将来の version suffix
+  揺れに備え互換のため残す）
+- モジュール docstring・`select_report_type` docstring・エラーメッセージを
+  Reach レポート前提の表現に更新
+- ユニットテスト・フィクスチャ CSV を Reach レポートのスキーマに合わせて更新
+  (`tests/fixtures/reporting_api/channel_basic_a2_sample.csv` →
+  `channel_reach_basic_a1_sample.csv`)
+
+**移行手順** (各チャンネルリポジトリ):
+
+旧バージョンで作成された `channel_basic_a3` ジョブは無害な状態で残るが、新版起動時に
+`channel_reach_basic_a1` の新規ジョブが自動作成される。最初のレポート生成までは
+**最大 48 時間**（backfill で過去 30 日分）、以降は D+2 ラグで日次レポートが届く。
+
+```bash
+uv run yt-analytics --reporting-create-job   # 新ジョブ作成（冪等）
+# 24-48h 待機
+uv run yt-analytics --include-reporting --days 28
+```
+
+- `src/youtube_automation/utils/reporting_api.py`: `_REPORT_TYPE_PRIORITIES` /
+  `_CTR_COLUMNS` / docstring / エラーメッセージ更新
+- `tests/test_reporting_api.py`: 期待 reportType を `channel_reach_basic_a1` 系に変更
+- `tests/fixtures/reporting_api/channel_reach_basic_a1_sample.csv`: Reach レポート
+  スキーマ（dimensions: date / channel_id / video_id, metrics:
+  video_thumbnail_impressions / video_thumbnail_impressions_ctr）に合わせて更新
+
 ## [5.0.0] - 2026-04-26
 
 ### Changed (BREAKING)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,27 @@ uv run yt-analytics --include-reporting --days 28
   スキーマ（dimensions: date / channel_id / video_id, metrics:
   video_thumbnail_impressions / video_thumbnail_impressions_ctr）に合わせて更新
 
+#### Reporting API: CTR 集計を impression 加重平均に変更
+
+`_aggregate_rows` の CTR 計算を **単純平均** から **impression 加重平均** に変更
+（`weighted_ctr = Σ(imp × ctr) / Σ(imp)`）。
+
+旧実装は segment / 日 / video の CTR を単純平均していたため、`channel_reach_combined_a1`
+にフォールバックして 1 (video, date) に traffic_source / country / device 等の複数
+dimension 行が含まれた場合、impression が大きい segment が過小評価され統計的に
+正しくない値になっていた（例: search 1000imp/CTR5% と suggest 500imp/CTR10% の真の
+CTR は 6.67% だが、旧実装は 7.5% を返していた）。
+
+`channel_reach_basic_a1` 単一行ケースでも `aggregated_ctr_percentage` の値が変わる
+（impression が大きい video の重みが正しく反映される）。
+
+- `src/youtube_automation/utils/reporting_api.py`: `_aggregate_rows` を加重平均化
+- `tests/fixtures/reporting_api/channel_reach_combined_a1_sample.csv`: 新規追加
+  （1 video × 1 date に複数 segment を持つサンプル）
+- `tests/test_reporting_api.py`: `test_collect_impressions_summary_aggregates` を
+  basic / combined の parametrize 化、加重平均の期待値で書き直し +
+  `test_collect_impressions_summary_combined_uses_weighted_ctr` 追加
+
 ## [5.0.0] - 2026-04-26
 
 ### Changed (BREAKING)

--- a/src/youtube_automation/utils/reporting_api.py
+++ b/src/youtube_automation/utils/reporting_api.py
@@ -5,6 +5,13 @@ YouTube Analytics API では `videoThumbnailImpressions` /
 全パターンで 400 拒否されるため、Reporting API v1 (非同期 CSV bulk download) で
 取得する基盤を提供する。
 
+レポートタイプは **Reach 系**（`channel_reach_basic_a1` /
+`channel_reach_combined_a1`）を使用する。これらの metrics に
+`video_thumbnail_impressions` / `video_thumbnail_impressions_ctr` が含まれる
+（公式: https://developers.google.com/youtube/reporting/v1/reports/channel_reports#reach-reports）。
+`channel_basic_*` には thumbnail impressions / CTR は含まれていない（views や
+card_impressions / annotation_impressions のみ）ため使用しない。
+
 仕様上の制約:
 - ジョブ作成後 **最大 48 時間**以内に最初のレポートが取得可能になる
 - 初回取得時はジョブ作成日からさかのぼって **過去 30 日分**が backfill される
@@ -45,18 +52,19 @@ logger = logging.getLogger(__name__)
 # CSV 列名候補（reportType の version で揺れる可能性に備え複数を許容）
 _IMPRESSIONS_COLUMNS = ("video_thumbnail_impressions",)
 _CTR_COLUMNS = (
-    "video_thumbnail_impressions_click_through_rate",
-    "video_thumbnail_impressions_ctr",  # 旧版互換
+    "video_thumbnail_impressions_ctr",  # Reach レポート公式カラム名
+    "video_thumbnail_impressions_click_through_rate",  # 将来の version suffix 揺れ向け
 )
 _VIDEO_ID_COLUMNS = ("video_id",)
 _DATE_COLUMNS = ("date", "day")
 
-# reportType ID 候補（version suffix 順、a3 > a2 > a1 を優先）
-# `videoThumbnailImpressions` を含む可能性が高いチャンネルレベル基本レポートを優先する。
+# reportType ID 候補。`video_thumbnail_impressions` / `video_thumbnail_impressions_ctr`
+# を metrics として持つのは Reach 系のみ（channel_basic_* は views と card/annotation
+# 系の impressions しか含まない）。
+# basic レポートより詳細な dimensions（traffic_source 等）を持つ combined を後段に置く。
 _REPORT_TYPE_PRIORITIES = (
-    "channel_basic_a3",
-    "channel_basic_a2",
-    "channel_basic_a1",
+    "channel_reach_basic_a1",
+    "channel_reach_combined_a1",
 )
 
 
@@ -81,7 +89,7 @@ class ReportingAPIClient:
     # reportType 選定
     # ------------------------------------------------------------------
     def select_report_type(self) -> str:
-        """`videoThumbnailImpressions` を含むレポートタイプの ID を返す。
+        """`video_thumbnail_impressions` を含む Reach レポートの ID を返す。
 
         `reportTypes.list()` で利用可能なレポートタイプ ID を列挙し、
         `_REPORT_TYPE_PRIORITIES` のうち最初に見つかったものを返す。
@@ -102,7 +110,7 @@ class ReportingAPIClient:
                 return candidate
 
         raise ConfigError(
-            "Reporting API: videoThumbnailImpressions を含む reportType が見つかりません。"
+            "Reporting API: video_thumbnail_impressions を含む Reach reportType が見つかりません。"
             f" 利用可能: {sorted(available)}"
         )
 

--- a/src/youtube_automation/utils/reporting_api.py
+++ b/src/youtube_automation/utils/reporting_api.py
@@ -429,18 +429,21 @@ def _aggregate_rows(
     window_days: int,
     report_count: int,
 ) -> dict[str, Any]:
-    """行データを per_video / per_day / aggregated に集計する。"""
+    """行データを per_video / per_day / aggregated に集計する。
+
+    CTR は **impression 加重平均** で計算する (`weighted_ctr = Σ(imp × ctr) / Σ(imp)`)。
+    Reach combined レポートでは 1 (video, date) に traffic_source / country / device 等
+    複数 dimension の行が含まれるため、単純平均だと impression が大きい segment が
+    過小評価され統計的に正しくない。Reach basic 単一行ケースでも結果は変わらない。
+    """
     per_video_imp: dict[str, int] = defaultdict(int)
-    per_video_ctr_sum: dict[str, float] = defaultdict(float)
-    per_video_ctr_n: dict[str, int] = defaultdict(int)
+    per_video_weighted: dict[str, float] = defaultdict(float)
 
     per_day_imp: dict[str, int] = defaultdict(int)
-    per_day_ctr_sum: dict[str, float] = defaultdict(float)
-    per_day_ctr_n: dict[str, int] = defaultdict(int)
+    per_day_weighted: dict[str, float] = defaultdict(float)
 
     total_impressions = 0
-    total_ctr_sum = 0.0
-    total_ctr_n = 0
+    total_weighted = 0.0
 
     for row in rows:
         imp = row.get("impressions")
@@ -448,37 +451,40 @@ def _aggregate_rows(
         vid = row.get("video_id")
         day = row.get("date")
 
-        if imp is not None:
-            total_impressions += imp
-            if vid:
-                per_video_imp[vid] += imp
-            if day:
-                per_day_imp[day] += imp
-        if ctr is not None:
-            total_ctr_sum += ctr
-            total_ctr_n += 1
-            if vid:
-                per_video_ctr_sum[vid] += ctr
-                per_video_ctr_n[vid] += 1
-            if day:
-                per_day_ctr_sum[day] += ctr
-                per_day_ctr_n[day] += 1
+        if imp is None:
+            continue
+
+        total_impressions += imp
+        if vid:
+            per_video_imp[vid] += imp
+        if day:
+            per_day_imp[day] += imp
+
+        if ctr is None:
+            continue
+
+        weighted = imp * ctr
+        total_weighted += weighted
+        if vid:
+            per_video_weighted[vid] += weighted
+        if day:
+            per_day_weighted[day] += weighted
 
     per_video = [
         {
             "video_id": vid,
-            "impressions": per_video_imp[vid] if vid in per_video_imp else None,
-            "ctr_percentage": (per_video_ctr_sum[vid] / per_video_ctr_n[vid] if per_video_ctr_n.get(vid) else None),
+            "impressions": per_video_imp[vid],
+            "ctr_percentage": (per_video_weighted[vid] / per_video_imp[vid]) if per_video_imp[vid] > 0 else None,
         }
-        for vid in sorted(set(per_video_imp) | set(per_video_ctr_sum))
+        for vid in sorted(per_video_imp)
     ]
     per_day = [
         {
             "date": day,
-            "impressions": per_day_imp[day] if day in per_day_imp else None,
-            "ctr_percentage": (per_day_ctr_sum[day] / per_day_ctr_n[day] if per_day_ctr_n.get(day) else None),
+            "impressions": per_day_imp[day],
+            "ctr_percentage": (per_day_weighted[day] / per_day_imp[day]) if per_day_imp[day] > 0 else None,
         }
-        for day in sorted(set(per_day_imp) | set(per_day_ctr_sum))
+        for day in sorted(per_day_imp)
     ]
 
     return {
@@ -487,7 +493,7 @@ def _aggregate_rows(
         "window_days": window_days,
         "report_count": report_count,
         "aggregated_impressions": total_impressions if total_impressions else None,
-        "aggregated_ctr_percentage": (total_ctr_sum / total_ctr_n) if total_ctr_n else None,
+        "aggregated_ctr_percentage": (total_weighted / total_impressions) if total_impressions else None,
         "per_video": per_video,
         "per_day": per_day,
     }

--- a/tests/fixtures/reporting_api/channel_basic_a2_sample.csv
+++ b/tests/fixtures/reporting_api/channel_basic_a2_sample.csv
@@ -1,6 +1,0 @@
-date,channel_id,video_id,views,video_thumbnail_impressions,video_thumbnail_impressions_click_through_rate
-2026-04-20,UCabc,vid001,100,2000,0.05
-2026-04-20,UCabc,vid002,250,5000,0.08
-2026-04-21,UCabc,vid001,120,2200,0.06
-2026-04-21,UCabc,vid002,300,5500,0.10
-2026-04-22,UCabc,vid003,80,1500,0.04

--- a/tests/fixtures/reporting_api/channel_reach_basic_a1_sample.csv
+++ b/tests/fixtures/reporting_api/channel_reach_basic_a1_sample.csv
@@ -1,0 +1,6 @@
+date,channel_id,video_id,video_thumbnail_impressions,video_thumbnail_impressions_ctr
+2026-04-20,UCabc,vid001,2000,0.05
+2026-04-20,UCabc,vid002,5000,0.08
+2026-04-21,UCabc,vid001,2200,0.06
+2026-04-21,UCabc,vid002,5500,0.10
+2026-04-22,UCabc,vid003,1500,0.04

--- a/tests/fixtures/reporting_api/channel_reach_combined_a1_sample.csv
+++ b/tests/fixtures/reporting_api/channel_reach_combined_a1_sample.csv
@@ -1,0 +1,6 @@
+date,channel_id,video_id,live_or_on_demand,subscribed_status,country_code,traffic_source_type,video_thumbnail_impressions,video_thumbnail_impressions_ctr
+2026-04-20,UCabc,vid001,ON_DEMAND,SUBSCRIBED,JP,3,1000,0.05
+2026-04-20,UCabc,vid001,ON_DEMAND,UNSUBSCRIBED,JP,3,1500,0.06
+2026-04-20,UCabc,vid001,ON_DEMAND,SUBSCRIBED,US,5,500,0.10
+2026-04-21,UCabc,vid001,ON_DEMAND,UNSUBSCRIBED,JP,3,2000,0.07
+2026-04-21,UCabc,vid002,ON_DEMAND,UNSUBSCRIBED,JP,5,800,0.04

--- a/tests/test_reporting_api.py
+++ b/tests/test_reporting_api.py
@@ -14,7 +14,7 @@ import pytest
 from youtube_automation.utils.exceptions import ConfigError, ValidationError, YouTubeAPIError
 from youtube_automation.utils.reporting_api import ReportingAPIClient
 
-_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "reporting_api" / "channel_basic_a2_sample.csv"
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "reporting_api" / "channel_reach_basic_a1_sample.csv"
 
 
 def _make_service(report_types: list[dict] | None = None, jobs: list[dict] | None = None):
@@ -28,34 +28,35 @@ def _make_service(report_types: list[dict] | None = None, jobs: list[dict] | Non
 # ---------------------------------------------------------------------------
 # select_report_type
 # ---------------------------------------------------------------------------
-def test_select_report_type_prefers_a3_over_a2():
+def test_select_report_type_prefers_reach_basic_over_combined():
     service = _make_service(
         report_types=[
-            {"id": "channel_basic_a2", "name": "Channel basic"},
-            {"id": "channel_basic_a3", "name": "Channel basic v3"},
-            {"id": "channel_demographics_a1", "name": "Demographics"},
+            {"id": "channel_reach_combined_a1", "name": "Reach combined"},
+            {"id": "channel_reach_basic_a1", "name": "Reach basic"},
+            {"id": "channel_basic_a3", "name": "User activity"},
         ]
     )
     client = ReportingAPIClient(service)
-    assert client.select_report_type() == "channel_basic_a3"
+    assert client.select_report_type() == "channel_reach_basic_a1"
 
 
-def test_select_report_type_falls_back_to_a2():
+def test_select_report_type_falls_back_to_reach_combined():
     service = _make_service(
         report_types=[
-            {"id": "channel_basic_a2", "name": "Channel basic"},
-            {"id": "channel_demographics_a1", "name": "Demographics"},
+            {"id": "channel_reach_combined_a1", "name": "Reach combined"},
+            {"id": "channel_basic_a3", "name": "User activity"},
         ]
     )
     client = ReportingAPIClient(service)
-    assert client.select_report_type() == "channel_basic_a2"
+    assert client.select_report_type() == "channel_reach_combined_a1"
 
 
 def test_select_report_type_raises_when_no_match():
     service = _make_service(
         report_types=[
+            {"id": "channel_basic_a3", "name": "User activity"},
             {"id": "channel_demographics_a1", "name": "Demographics"},
-            {"id": "channel_traffic_source_a2", "name": "Traffic"},
+            {"id": "channel_traffic_source_a3", "name": "Traffic"},
         ]
     )
     client = ReportingAPIClient(service)
@@ -69,13 +70,13 @@ def test_select_report_type_raises_when_no_match():
 def test_ensure_job_reuses_existing():
     service = _make_service(
         jobs=[
-            {"id": "job-existing", "reportTypeId": "channel_basic_a2", "name": "yt-automation"},
+            {"id": "job-existing", "reportTypeId": "channel_reach_basic_a1", "name": "yt-automation"},
             {"id": "job-other", "reportTypeId": "channel_demographics_a1", "name": "other"},
         ]
     )
     client = ReportingAPIClient(service)
 
-    job_id = client.ensure_job("channel_basic_a2")
+    job_id = client.ensure_job("channel_reach_basic_a1")
 
     assert job_id == "job-existing"
     service.jobs.return_value.create.assert_not_called()
@@ -86,11 +87,11 @@ def test_ensure_job_creates_when_missing():
     service.jobs.return_value.create.return_value.execute.return_value = {"id": "job-new"}
     client = ReportingAPIClient(service)
 
-    job_id = client.ensure_job("channel_basic_a2")
+    job_id = client.ensure_job("channel_reach_basic_a1")
 
     assert job_id == "job-new"
     service.jobs.return_value.create.assert_called_once_with(
-        body={"reportTypeId": "channel_basic_a2", "name": "yt-automation"}
+        body={"reportTypeId": "channel_reach_basic_a1", "name": "yt-automation"}
     )
 
 
@@ -176,8 +177,8 @@ def test_collect_impressions_summary_aggregates(monkeypatch):
     csv_text = _FIXTURE.read_text(encoding="utf-8")
 
     service = _make_service(
-        report_types=[{"id": "channel_basic_a2", "name": "Channel basic"}],
-        jobs=[{"id": "job-1", "reportTypeId": "channel_basic_a2", "name": "yt-automation"}],
+        report_types=[{"id": "channel_reach_basic_a1", "name": "Reach basic"}],
+        jobs=[{"id": "job-1", "reportTypeId": "channel_reach_basic_a1", "name": "yt-automation"}],
     )
     service.jobs.return_value.reports.return_value.list.return_value.execute.return_value = {
         "reports": [{"id": "r1", "downloadUrl": "https://example.com/r1.csv"}]
@@ -194,7 +195,7 @@ def test_collect_impressions_summary_aggregates(monkeypatch):
     client = ReportingAPIClient(service, credentials=MagicMock())
     summary = client.collect_impressions_summary(days=7)
 
-    assert summary["selected_report_type"] == "channel_basic_a2"
+    assert summary["selected_report_type"] == "channel_reach_basic_a1"
     assert summary["report_count"] == 1
     assert summary["aggregated_impressions"] == 2000 + 5000 + 2200 + 5500 + 1500
     assert summary["aggregated_ctr_percentage"] == pytest.approx((5 + 8 + 6 + 10 + 4) / 5)
@@ -204,8 +205,8 @@ def test_collect_impressions_summary_aggregates(monkeypatch):
 
 def test_collect_impressions_summary_returns_empty_when_no_reports():
     service = _make_service(
-        report_types=[{"id": "channel_basic_a2", "name": "Channel basic"}],
-        jobs=[{"id": "job-1", "reportTypeId": "channel_basic_a2", "name": "yt-automation"}],
+        report_types=[{"id": "channel_reach_basic_a1", "name": "Reach basic"}],
+        jobs=[{"id": "job-1", "reportTypeId": "channel_reach_basic_a1", "name": "yt-automation"}],
     )
     service.jobs.return_value.reports.return_value.list.return_value.execute.return_value = {"reports": []}
 

--- a/tests/test_reporting_api.py
+++ b/tests/test_reporting_api.py
@@ -14,7 +14,9 @@ import pytest
 from youtube_automation.utils.exceptions import ConfigError, ValidationError, YouTubeAPIError
 from youtube_automation.utils.reporting_api import ReportingAPIClient
 
-_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "reporting_api" / "channel_reach_basic_a1_sample.csv"
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "reporting_api"
+_FIXTURE = _FIXTURE_DIR / "channel_reach_basic_a1_sample.csv"
+_FIXTURE_COMBINED = _FIXTURE_DIR / "channel_reach_combined_a1_sample.csv"
 
 
 def _make_service(report_types: list[dict] | None = None, jobs: list[dict] | None = None):
@@ -173,12 +175,46 @@ def test_download_report_csv_raises_on_http_error(monkeypatch):
 # ---------------------------------------------------------------------------
 # collect_impressions_summary
 # ---------------------------------------------------------------------------
-def test_collect_impressions_summary_aggregates(monkeypatch):
-    csv_text = _FIXTURE.read_text(encoding="utf-8")
+@pytest.mark.parametrize(
+    "fixture_path, report_type, expected_total_imp, expected_total_weighted, expected_video_ids, expected_dates",
+    [
+        # Reach basic: 1 (video, date) ごとに 1 行
+        # weighted CTR: (2000×5 + 5000×8 + 2200×6 + 5500×10 + 1500×4) / 16200 = 124200/16200
+        (
+            _FIXTURE,
+            "channel_reach_basic_a1",
+            16200,
+            124200.0,
+            {"vid001", "vid002", "vid003"},
+            {"2026-04-20", "2026-04-21", "2026-04-22"},
+        ),
+        # Reach combined: 1 (video, date) に traffic_source / country / subscribed_status の組合せで複数行
+        # weighted CTR: (1000×5 + 1500×6 + 500×10 + 2000×7 + 800×4) / 5800 = 36200/5800
+        (
+            _FIXTURE_COMBINED,
+            "channel_reach_combined_a1",
+            5800,
+            36200.0,
+            {"vid001", "vid002"},
+            {"2026-04-20", "2026-04-21"},
+        ),
+    ],
+    ids=["reach_basic", "reach_combined"],
+)
+def test_collect_impressions_summary_aggregates(
+    monkeypatch,
+    fixture_path,
+    report_type,
+    expected_total_imp,
+    expected_total_weighted,
+    expected_video_ids,
+    expected_dates,
+):
+    csv_text = fixture_path.read_text(encoding="utf-8")
 
     service = _make_service(
-        report_types=[{"id": "channel_reach_basic_a1", "name": "Reach basic"}],
-        jobs=[{"id": "job-1", "reportTypeId": "channel_reach_basic_a1", "name": "yt-automation"}],
+        report_types=[{"id": report_type, "name": report_type}],
+        jobs=[{"id": "job-1", "reportTypeId": report_type, "name": "yt-automation"}],
     )
     service.jobs.return_value.reports.return_value.list.return_value.execute.return_value = {
         "reports": [{"id": "r1", "downloadUrl": "https://example.com/r1.csv"}]
@@ -195,12 +231,53 @@ def test_collect_impressions_summary_aggregates(monkeypatch):
     client = ReportingAPIClient(service, credentials=MagicMock())
     summary = client.collect_impressions_summary(days=7)
 
-    assert summary["selected_report_type"] == "channel_reach_basic_a1"
+    assert summary["selected_report_type"] == report_type
     assert summary["report_count"] == 1
-    assert summary["aggregated_impressions"] == 2000 + 5000 + 2200 + 5500 + 1500
-    assert summary["aggregated_ctr_percentage"] == pytest.approx((5 + 8 + 6 + 10 + 4) / 5)
-    assert {row["video_id"] for row in summary["per_video"]} == {"vid001", "vid002", "vid003"}
-    assert {row["date"] for row in summary["per_day"]} == {"2026-04-20", "2026-04-21", "2026-04-22"}
+    assert summary["aggregated_impressions"] == expected_total_imp
+    assert summary["aggregated_ctr_percentage"] == pytest.approx(expected_total_weighted / expected_total_imp)
+    assert {row["video_id"] for row in summary["per_video"]} == expected_video_ids
+    assert {row["date"] for row in summary["per_day"]} == expected_dates
+
+
+def test_collect_impressions_summary_combined_uses_weighted_ctr(monkeypatch):
+    """Reach combined で 1 video × 1 date に複数 segment がある場合、CTR が impression
+    加重平均になっていることを per_video / per_day の数値で確認する。
+
+    単純平均だと segment 数で割ってしまい、impression が大きい segment が過小評価される。
+    """
+    csv_text = _FIXTURE_COMBINED.read_text(encoding="utf-8")
+
+    service = _make_service(
+        report_types=[{"id": "channel_reach_combined_a1", "name": "Reach combined"}],
+        jobs=[{"id": "job-1", "reportTypeId": "channel_reach_combined_a1", "name": "yt-automation"}],
+    )
+    service.jobs.return_value.reports.return_value.list.return_value.execute.return_value = {
+        "reports": [{"id": "r1", "downloadUrl": "https://example.com/r1.csv"}]
+    }
+
+    fake_response = MagicMock(status_code=200, content=csv_text.encode("utf-8"))
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_response
+    monkeypatch.setattr(
+        "youtube_automation.utils.reporting_api.AuthorizedSession",
+        lambda *_a, **_k: fake_session,
+    )
+
+    client = ReportingAPIClient(service, credentials=MagicMock())
+    summary = client.collect_impressions_summary(days=7)
+
+    # vid001: 4 segments を加重平均
+    # impressions = 1000+1500+500+2000 = 5000
+    # weighted CTR = (1000×5 + 1500×6 + 500×10 + 2000×7) / 5000 = 33000/5000 = 6.6%
+    vid001 = next(row for row in summary["per_video"] if row["video_id"] == "vid001")
+    assert vid001["impressions"] == 5000
+    assert vid001["ctr_percentage"] == pytest.approx(6.6)
+
+    # 2026-04-20: vid001 の 3 segments のみ
+    # impressions = 3000, weighted CTR = (5000+9000+5000)/3000 = 19000/3000 ≈ 6.333%
+    day0 = next(row for row in summary["per_day"] if row["date"] == "2026-04-20")
+    assert day0["impressions"] == 3000
+    assert day0["ctr_percentage"] == pytest.approx(19000 / 3000)
 
 
 def test_collect_impressions_summary_returns_empty_when_no_reports():

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.0.0"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

`channel_basic_a3` には `video_thumbnail_impressions` / `video_thumbnail_impressions_ctr` が含まれず、`--include-reporting` 実行時に全レポートでパース警告が発生し `per_video` / `per_day` が常に空になっていた問題を修正。

`_REPORT_TYPE_PRIORITIES` を **Reach 系**（`channel_reach_basic_a1` / `channel_reach_combined_a1`）に変更。これらの metrics に thumbnail impressions / CTR が含まれる（[公式ドキュメント](https://developers.google.com/youtube/reporting/v1/reports/channel_reports)）。

## Background

ダウンストリームのチャンネルリポジトリで `uv run yt-analytics --include-reporting` を実行すると、ログに以下の警告が大量に出ていた:

```
WARNING: Reporting API: レポート 1 件のパースに失敗（続行）: Reporting API CSV: impressions / ctr 列が見つかりません
header=['date', 'channel_id', 'video_id', 'live_or_on_demand', 'subscribed_status', 'country_code', 'views', 'engaged_views', 'comments', 'likes', 'dislikes', 'shares', 'watch_time_minutes', ...,
'card_impressions', 'card_clicks', ..., 'subscribers_gained', ...]
```

調査の結果、`channel_basic_a3` の metrics には `video_thumbnail_impressions` / `video_thumbnail_impressions_ctr` が**そもそも提供されていない**ことが判明した（views / engaged_views / card_impressions / annotation_impressions のみ）。

これらの metric を含むのは Reach 系レポート（`channel_reach_basic_a1` / `channel_reach_combined_a1`）のみ。

## Changes

- **`_REPORT_TYPE_PRIORITIES`**: `channel_basic_a3` → `channel_reach_basic_a1`, `channel_reach_combined_a1`
- **`_CTR_COLUMNS`**: 公式名 `video_thumbnail_impressions_ctr` を 1 番目、旧 `video_thumbnail_impressions_click_through_rate` は将来の version suffix 揺れ向け互換として 2 番目に残す
- **モジュール docstring / `select_report_type` docstring / エラーメッセージ**: Reach レポート前提の表現に更新
- **ユニットテスト**: 期待 reportType を `channel_reach_basic_a1` 系に変更（`a3 vs a2` → `reach_basic vs reach_combined`）
- **フィクスチャ CSV**: `channel_basic_a2_sample.csv` → `channel_reach_basic_a1_sample.csv` にリネーム + Reach レポートのスキーマ（dimensions: date / channel_id / video_id, metrics: video_thumbnail_impressions / video_thumbnail_impressions_ctr）に更新

## Migration

旧バージョンで作成された `channel_basic_a3` ジョブは無害に残るが、新版起動時に `channel_reach_basic_a1` の新規ジョブが自動作成される。最初のレポート生成までは **最大 48 時間**（backfill で過去 30 日分）、以降は D+2 ラグで日次レポートが届く。

```bash
uv run yt-analytics --reporting-create-job   # 新ジョブ作成（冪等）
# 24-48h 待機
uv run yt-analytics --include-reporting --days 28
```

## Test plan

- [x] `uv run pytest tests/test_reporting_api.py -v` → 15/15 pass
- [x] `uv run pytest` → 621/621 pass
- [x] `uv run ruff check src/youtube_automation/utils/reporting_api.py tests/test_reporting_api.py` → All checks passed
- [ ] 各チャンネルリポジトリで新版を取り込み、`--reporting-create-job` で新ジョブ作成
- [ ] 24-48h 後に `--include-reporting` 実行して `per_video` / `per_day` に impressions / CTR が入ることを確認