### PR TITLE
release: v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.1] - 2026-04-28
+
 ### Fixed
 
 #### Reporting API: Reach レポートに切り替えて thumbnail impressions / CTR を実取得する

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.1.0"
+version = "5.1.1"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.1.0"
+__version__ = "5.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.1.0"
+version = "5.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
v5.1.1 リリース

## 含まれる変更

### Fixed (#95)

- **Reporting API: Reach レポートに切り替えて thumbnail impressions / CTR を実取得**
  - `_REPORT_TYPE_PRIORITIES` を `channel_basic_a3` → `channel_reach_basic_a1` / `channel_reach_combined_a1` に変更
  - `channel_basic_a3` には `video_thumbnail_impressions` 列がそもそも提供されておらず、`--include-reporting` 実行時に `per_video` / `per_day` が常に空になっていた根本バグの修正
- **CTR 集計を impression 加重平均に変更**
  - `_aggregate_rows` の CTR 計算を単純平均から `Σ(imp × ctr) / Σ(imp)` に変更
  - combined フォールバック時の segment バイアス排除 + basic ケースでも統計的に正しい値を返す

## 互換性 / 移行手順

破壊的 API 変更なし。ただし downstream チャンネルリポジトリ側で **新しい Reporting API ジョブ作成が必要**:

```bash
uv run yt-analytics --reporting-create-job   # 新ジョブ作成（冪等）
# 24-48h 待機（初回レポート生成 + 過去 30 日分 backfill）
uv run yt-analytics --include-reporting --days 28
```

旧 `channel_basic_a3` ジョブは無害な状態で残る。

`aggregated_ctr_percentage` の値が過去レポートと若干変わる（旧: 単純平均、新: impression 加重平均、後者の方が統計的に正しい）。

## PRs

- #95 fix: Reporting API を Reach レポートに切替えて thumbnail impressions/CTR を実取得