### PR TITLE
chore: takt 開発ワークフローを導入

### DIFF
--- a/.takt/.gitignore
+++ b/.takt/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything by default
+*
+
+# This file itself
+!.gitignore
+
+# Project configuration
+!config.yaml

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,0 +1,3 @@
+# automation リポジトリの takt 設定
+# provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
+draft_pr: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,16 @@ channel-repo/                  # チャンネル固有リポジトリ
 - API キーは環境変数経由（`.env` または 1Password CLI）
 - OAuth スコープは必要最小限に制限
 - シークレット解決順序: `os.environ` → `op read`（1Password CLI）→ `ConfigError`。参照は `utils/secrets.py` の `_SECRET_REFS` で定義
+
+## 開発ワークフロー
+
+このリポジトリの開発は **takt + GitHub issue** に乗せる。手作業でブランチを切らず、
+`takt-issue` スキル経由で issue → worktree → PR を統一手順化する。手順詳細は
+`~/01-dev/dotfiles/config/.claude/skills/takt-issue/SKILL.md`。
+
+- **issue 起票**: `gh issue create` または `/issue` スキル
+- **takt 起動**: `takt add '#<N>'` → `takt run`（base branch は **main** 固定、PR は通常 PR）
+- **commit 規約**: 日本語 Conventional Commits + タイトル末尾に `(#<N>)`。詳細は `commit-convention` スキル参照
+- **takt 設定**: リポジトリ固有 `.takt/config.yaml`（`draft_pr: false`）、
+  グローバル `~/.takt/config.yaml`（`provider: claude`, `language: ja`）。
+  workflow は組み込み **default**（plan → review → ... → reviewers の 9 step）


### PR DESCRIPTION
## 概要
リポジトリ自身の開発を takt + GitHub issue に乗せるための足場を追加。

- `.takt/config.yaml`: `draft_pr: false`（PR 方針の明示）
- `.takt/.gitignore`: whitelist 方式で `tasks.yaml` 等の動的ファイルを除外
- `CLAUDE.md`: 開発ワークフロー（issue 起票 → `takt add` / `takt run` → cherry-pick で commit 規約準拠 → 通常 PR）を追記

## テスト計画
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest` — 623 passed
- [ ] 軽微な issue を 1 件 `takt add` → `takt run` で完走できる（後続検証）