### PR TITLE
release: v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-04-29
+
 ### Added
 
 #### `yt-generate-master`: `--shuffle` / `--shuffle-seed` で MP3 連結順をランダム化する
@@ -86,6 +88,30 @@ skill-config (`.claude/skills/masterup/config.default.yaml` または
 - `tests/test_generate_master.py`: `TestCliSkillConfigTargetDuration` 5 ケース
   （CLI 未指定時の採用 / CLI 上書き優先 / `--loop` 指定時の skill-config 無視 /
   `< 1` バリデーション / キー欠落時の既存挙動保持）
+
+### Fixed
+
+#### 画像生成コストの skill ドキュメント表記を `cost_tracker.PRICING` ベースに揃える
+
+`thumbnail` / `ideate` skill のドキュメント上の `$0.04` ハードコーディングを削除し、
+`cost_tracker.PRICING` を single source of truth として参照する形に揃えた (#102)。
+従来は `gemini-3.1-flash-image-preview` 等の現行モデル価格 (1K で $0.067〜) と乖離した
+古い見積りが表示されていた。
+
+- `.claude/skills/thumbnail/SKILL.md`: ttp_swap モードのコスト表記を
+  `cost_tracker.PRICING` 参照に変更。例示値は `gemini-3.1-flash-image-preview`
+  の 2K で `$0.101 〜 $0.303`（最大 3 回試行込み = 初回 + 最大 2 回リトライ）に更新
+- `.claude/skills/ideate/SKILL.md`: Phase 4-2 の静的コスト見積りを
+  `cost_tracker.estimate_cost` + `load_skill_config` + `image_generator.DEFAULT_MODEL`
+  / `DEFAULT_IMAGE_SIZE` を使う動的算出ワンライナーに置換。`cost_per_image_usd`
+  カスタム単価優先 (`if per is None:` 判定で `generate_image.py:90-94` と整合)
+- `.claude/skills/thumbnail/config.default.yaml`: `cost_per_image_usd: 0.04` の
+  数値例を削除し、「PRICING の値を上書きしたい場合のみ指定（用途例: エンタープライズ
+  割引価格や予算上限値の固定）」に置換
+- `tests/test_skill_cost_documentation.py`: 14 テスト追加。3 対象ファイルへの
+  旧ハードコード不在検証 + `cost_tracker.PRICING` / `estimate_cost` /
+  `load_skill_config` 参照の存在検証 + `.claude/skills/**/*.{md,yaml,yml}`
+  横断走査リグレッションガード
 
 ## [5.1.1] - 2026-04-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.1.1"
+version = "5.2.0"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.1.1"
+__version__ = "5.2.0"


### PR DESCRIPTION
## Summary

v5.1.1 → **v5.2.0** リリース。`yt-generate-master` の skill-config 連携拡張 2 件と画像コストドキュメント整備。

### Added (`yt-generate-master` skill-config 連携)
- **#98**: `audio.target_duration_min` を CLI `--target-duration` 未指定時のデフォルトとして読み取り
- **#99**: `--shuffle` / `--shuffle-seed` フラグ追加 + `audio.shuffle` / `audio.shuffle_seed` skill-config 連携

### Fixed (画像コストドキュメント)
- **#102**: `thumbnail` / `ideate` skill ドキュメントの `$0.04` ハードコーディングを削除し、`cost_tracker.PRICING` を single source of truth として参照する形に整備

## バージョン bump

- `pyproject.toml`: 5.1.1 → 5.2.0
- `src/youtube_automation/__init__.py`: `__version__` 同上

## 後方互換

すべて加算的変更。既存の CLI 呼び出し / config なし環境では従来通り動作する。

## ダウンストリームへの影響

各チャンネルリポジトリでの作業（任意 / opt-in）:

1. `yt-skills sync` を再実行し、`thumbnail` / `ideate` / `masterup` の最新 SKILL.md を反映
2. 必要に応じて `config/skills/masterup.yaml` に以下を追加して新機能を有効化:
   ```yaml
   audio:
     target_duration_min: 120  # 自動で 2h 以上にループ (#98)
     shuffle: true             # MP3 連結順をランダム化 (#99)
     shuffle_seed: 42          # 再現性が必要なら seed 指定 (オプション)
   ```
3. `youtube-rain-jazz-night` 等で SKILL.md にローカル追記したワークアラウンド（config 読んで CLI フラグ自動付与する Step 5 拡張など）は不要になるので、`yt-skills sync` で同梱版に戻すこと