### PR TITLE
feat: yt-video-analyze で Gemini 動画コンテンツ分析 CLI を追加

### DIFF
--- a/.claude/skills/alignment-check/SKILL.md
+++ b/.claude/skills/alignment-check/SKILL.md
@@ -78,6 +78,7 @@ AskUserQuestion で新タイトルフォーマットを確認。
 - `collections/live/*/10-assets/thumbnail.jpg` — サムネイル
 - `collections/live/*/20-documentation/` — 音楽プロンプト
 - `collections/live/*/workflow-state.json` — タイトル・テーマ
+- `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の `thumbnail_alignment` 出力（サムネ vs 本編の整合性監査の根拠）
 
 ## Next Step
 

--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -96,3 +96,7 @@ $ARGUMENTS
 
 分析完了後:
 → `/ideate` でデータに基づくコレクション企画を生成
+
+## 関連ファイル
+
+- `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の `scene_timeline` 出力（retention drop と動画展開のクロス参照に使う）

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -105,3 +105,7 @@ uv run yt-benchmark-collect -v                 # 詳細ログ
 - YouTube API: 1チャンネルあたり約 4 ユニット（channels 1 + playlistItems 1 + videos 約 2）
 - Gemini サムネイル分析: 5秒間隔でレート制限回避（`--no-thumbnails` でスキップ可）
 - `common-patterns.md` の手書きパターン分析は「運用ベンチマーク」セクションより上に維持される
+
+## 関連ファイル
+
+- `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の動画本体スコアリング出力（競合スコアリングの追加入力）

--- a/.claude/skills/thumbnail-compare/SKILL.md
+++ b/.claude/skills/thumbnail-compare/SKILL.md
@@ -72,3 +72,4 @@ open data/thumbnail_compare/
 - `data/benchmark_YYYYMMDD.json` — ベンチマーク動画データ（サムネURL）
 - `collections/live/*/10-assets/thumbnail.jpg` — 自チャンネルサムネイル
 - `docs/benchmarks/common-patterns.md` — サムネイルチェックリスト v4
+- `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の `signature_elements` / `hook_structure` 出力（競合のサムネ実装パターン抽出を補強）

--- a/.claude/skills/video-analyze/SKILL.md
+++ b/.claude/skills/video-analyze/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: video-analyze
+description: Use when 動画コンテンツ分析・映像解析が必要なとき。Gemini に YouTube URL を直接渡してフック構造・BGM 展開・シーンタイムライン・サムネ整合性・編集指標を抽出する。「signature 要素抽出」「retention drop の構造的原因」「競合動画の冒頭 30 秒解析」「BGM のピーク位置」など、メタデータ・コメント・静止画では届かない動画本体の中身に切り込みたい場面で使用すること
+---
+
+## Overview
+
+`yt-video-analyze` で YouTube 動画を Gemini に直接渡し、以下の構造化データを抽出する:
+
+- `hook_structure` — 0-30 秒のカット割り・テキスト出現タイミング・signature 要素
+- `bgm_arc` — イントロ尺・ピーク位置・アウトロのタイムスタンプ
+- `scene_timeline` — シーン境界 + 一言要約
+- `thumbnail_alignment` — サムネで提示した要素が本編に映っているかの整合性
+- `editing_metrics` — 平均カット長・テキスト出現頻度
+
+既存スキルが扱えていなかった「動画の中身」というドメインを埋め、`/benchmark`・`/analyze`・`/alignment-check`・`/thumbnail-compare`・`/viewer-voice` の精度を底上げする。
+
+## 前提
+
+- `config/channel/` がロード可能であること (`load_config()`)
+- `GOOGLE_CLOUD_PROJECT` 設定済み + `gcloud auth application-default login` 済み (Vertex AI ADC)
+- 解析対象動画が **Public または Unlisted** であること (Gemini API は Private 動画を取得できない)
+
+## 実行フロー
+
+### Step 1: スクリプト実行
+
+```bash
+# ベンチマーク競合の上位動画を解析
+uv run yt-video-analyze --source benchmark --channel <slug> --top 5
+
+# 自チャンネル live コレクションを解析
+uv run yt-video-analyze --source own --collection <name>
+
+# 単発動画 (任意 URL)
+uv run yt-video-analyze --url <youtube_url>
+```
+
+| オプション | 説明 |
+|---|---|
+| `--source benchmark` | `data/benchmark_*.json` から `--channel` slug でフィルタし `--top` 件 (default 5) を解析 |
+| `--source own` | `collections/live/<name>/20-documentation/upload_tracking.json` の `complete_collection.video_id` (および `videos[]`) を解析 |
+| `--url` | 任意 YouTube URL を直接解析 (slug は固定 `url`) |
+
+### Step 2: 出力確認
+
+| 出力先 | 用途 |
+|---|---|
+| `data/video_analysis/<slug>/<video_id>.json` | 構造化データ (1 動画 1 ファイル) |
+| `reports/video_analysis/<slug>.md` | 人間向けサマリー (slug 単位で集約) |
+
+## 設定
+
+skill-config (`.claude/skills/video-analyze/config.default.yaml`):
+
+| 項目 | 既定 | 説明 |
+|---|---|---|
+| `model` | `gemini-2.5-flash` | 動画入力対応 Gemini モデル |
+| `delay_sec` | 10 | 動画間の API レート対策ウェイト (秒) |
+| `prompt` | 汎用プロンプト | ジャンル/世界観に合わせて `config/skills/video-analyze.yaml` で上書き推奨 |
+
+## 注意事項
+
+- Gemini API には YouTube URL を直接渡す (動画ダウンロードしない)
+- Public/Unlisted のみ対応 (Private 動画は API 側で拒否される)
+- Shorts は Gemini の 1fps サンプリング制約により精度が落ちるため非推奨
+- API レート制限対策で動画間に `delay_sec` 秒スリープ
+
+## 関連ファイル
+
+- `yt-video-analyze` (`youtube_automation.scripts.video_analyze`) — CLI 本体
+- `data/video_analysis/<slug>/<video_id>.json` — 動画別構造化データ
+- `reports/video_analysis/<slug>.md` — slug 別 Markdown レポート
+- `data/benchmark_YYYYMMDD.json` — `--source benchmark` の入力
+- `collections/live/<name>/20-documentation/upload_tracking.json` — `--source own` の入力

--- a/.claude/skills/video-analyze/config.default.yaml
+++ b/.claude/skills/video-analyze/config.default.yaml
@@ -1,0 +1,46 @@
+# video-analyze skill default config
+#
+# Gemini で YouTube 動画を直接解析するスキル (Issue #103) の動作パラメータ。
+# チャンネル側では config/skills/video-analyze.yaml に上書き値を置く。
+
+# Gemini モデル名 (動画入力対応モデルを指定)
+model: gemini-2.5-flash
+
+# API レート制限対策の動画間ウェイト (秒)
+delay_sec: 10
+
+# Gemini に渡すプロンプト。チャンネルのジャンル/世界観に合わせて
+# config/skills/video-analyze.yaml で上書きを推奨。
+#
+# 出力 JSON はトップレベルにジャンル横断のドメインキーを置き、CLI 側で
+# video_id / slug / url / title / analyzed_at / model を後付けする。
+prompt: |
+  Analyze this YouTube video as a music channel content audit.
+  Return ONLY valid JSON (no markdown, no code fences) with this exact shape:
+  {
+    "hook_structure": {
+      "intro_sec": <number>,
+      "first_text_at": <number>,
+      "cuts_in_first_30s": <number>,
+      "signature_elements": ["list", "of", "visual", "elements", "shown", "in", "first 30s"]
+    },
+    "bgm_arc": {
+      "intro": "timestamp range (e.g. 0:00-0:15)",
+      "peak": "timestamp (e.g. 1:30)",
+      "outro": "timestamp range (e.g. 9:30-end)",
+      "energy_curve": "brief description of dynamics"
+    },
+    "scene_timeline": [
+      {"start": "0:00", "summary": "one-line description of what changes"}
+    ],
+    "thumbnail_alignment": {
+      "signature_present": <bool>,
+      "color_palette_match": <bool>,
+      "notes": "what was promised by thumbnail vs delivered in video"
+    },
+    "editing_metrics": {
+      "avg_cut_sec": <number>,
+      "text_per_min": <number>,
+      "transition_style": "brief description"
+    }
+  }

--- a/.claude/skills/viewer-voice/SKILL.md
+++ b/.claude/skills/viewer-voice/SKILL.md
@@ -69,3 +69,4 @@ uv run yt-benchmark-comments --force
 - `yt-benchmark-comments` (`youtube_automation.scripts.fetch_benchmark_comments`) — コメント収集スクリプト
 - `data/comments_YYYYMMDD.json` — コメント生データ
 - `data/benchmark_YYYYMMDD.json` — ベンチマーク動画データ（自動更新）
+- `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の `scene_timeline` 出力（コメント言及シーンを動画タイムスタンプにマッピング）

--- a/README.md
+++ b/README.md
@@ -215,11 +215,14 @@ uv run ruff check .
 | `yt-playlist-manager` / `yt-playlist-status` | プレイリスト管理 |
 | `yt-benchmark-collect` / `yt-benchmark-comments` | 競合チャンネル分析 |
 | `yt-thumbnail-compare` | サムネイル比較検証 |
+| `yt-video-analyze` | Gemini で YouTube 動画を直接解析（フック構造・BGM 展開・シーン・サムネ整合性・編集指標） |
 | `yt-channel-status` | チャンネル最新状況 |
 | `yt-upload-collection` / `yt-upload-auto` | YouTube アップロード |
 | `yt-video-uploader` | 動画アップロード補助 |
 
 完全な一覧は `pyproject.toml` の `[project.scripts]` を参照してください。
+
+> **`yt-video-analyze` の動画公開範囲制約**: Gemini API は YouTube URL を直接受け取って動画本体を解析しますが、対象動画は **Public または Unlisted** である必要があります。Private 動画は API 側で取得できず解析できません。
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ yt-populate-scene-phrases = "youtube_automation.scripts.populate_scene_phrases:m
 yt-theme-compare = "youtube_automation.scripts.theme_compare:main"
 yt-thumbnail-compare = "youtube_automation.scripts.compare_thumbnails:main"
 yt-thumbnail-correlate = "youtube_automation.scripts.thumbnail_correlate:main"
+yt-video-analyze = "youtube_automation.scripts.video_analyze:main"
 yt-video-uploader = "youtube_automation.scripts.video_uploader:main"
 
 # Agent entry points

--- a/src/youtube_automation/scripts/video_analyze.py
+++ b/src/youtube_automation/scripts/video_analyze.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""yt-video-analyze CLI
+
+Issue #103: ベンチマーク競合・自チャンネル動画・任意 URL を Gemini で動画解析する。
+
+Usage:
+    yt-video-analyze --source benchmark --channel <slug> --top 5
+    yt-video-analyze --source own --collection <name>
+    yt-video-analyze --url <youtube_url>
+
+Design:
+- 解釈フェーズ (`main`): argparse → skill-config → channel_dir 解決 → target list 構築
+- 実行フェーズ (`VideoAnalyzer.analyze_url` ループ): Gemini 呼出 + JSON 保存
+- 出力フェーズ (`VideoAnalysisReport`): slug 単位で Markdown 集約
+
+skill-config / Gemini Client / data_dir は **境界 (`main`) で 1 回だけ解決し**、
+ループ内で再解決しない (フェーズ分離)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from google.genai import errors as genai_errors
+
+from youtube_automation.scripts.benchmark_collector import load_benchmark_videos
+from youtube_automation.utils.config import channel_dir as _channel_dir
+from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.genai_client import create_genai_client
+from youtube_automation.utils.skill_config import load_skill_config
+from youtube_automation.utils.video_analyzer import (
+    VideoAnalysisReport,
+    VideoAnalyzer,
+    VideoTarget,
+)
+
+logger = logging.getLogger(__name__)
+
+SKILL_NAME = "video-analyze"
+SOURCE_BENCHMARK = "benchmark"
+SOURCE_OWN = "own"
+SOURCE_CHOICES = (SOURCE_BENCHMARK, SOURCE_OWN)
+
+# 任意 URL 経路では slug を一意に持てないため固定名で保存する
+URL_SOURCE_SLUG = "url"
+WATCH_URL_TEMPLATE = "https://www.youtube.com/watch?v={video_id}"
+
+# upload_tracking.json の配置パターン (collections/live/<name>/20-documentation/)
+_COLLECTION_DOC_DIR = "20-documentation"
+_UPLOAD_TRACKING_NAME = "upload_tracking.json"
+
+_SHORTS_PATH_RE = re.compile(r"^/shorts/([A-Za-z0-9_-]+)/?$")
+
+
+# ---------------------------------------------------------------------------
+# URL → video_id
+# ---------------------------------------------------------------------------
+
+
+def _extract_video_id_from_url(url: str) -> str:
+    """YouTube URL から video_id を抽出する。
+
+    対応形式:
+    - https://www.youtube.com/watch?v=<id>
+    - https://youtu.be/<id>
+    - https://www.youtube.com/shorts/<id>
+
+    Raises:
+        ValidationError: URL が空 / YouTube ドメインでない / video_id が取れない
+    """
+    if not url:
+        raise ValidationError("URL が空です")
+
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+
+    if host.endswith("youtu.be"):
+        # 末尾スラッシュ付き ("https://youtu.be/<id>/") も受理する
+        vid = parsed.path.strip("/")
+        if not vid or "/" in vid:
+            raise ValidationError(f"youtu.be URL から video_id を取得できません: {url}")
+        return vid
+
+    if host.endswith("youtube.com"):
+        if parsed.path == "/watch":
+            vid_list = parse_qs(parsed.query).get("v", [])
+            if not vid_list or not vid_list[0]:
+                raise ValidationError(f"watch URL に v パラメータがありません: {url}")
+            return vid_list[0]
+        m = _SHORTS_PATH_RE.match(parsed.path)
+        if m:
+            return m.group(1)
+
+    raise ValidationError(f"YouTube URL ではありません: {url}")
+
+
+# ---------------------------------------------------------------------------
+# Target resolvers (3 経路)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_url_target(url: str) -> VideoTarget:
+    """任意 URL を VideoTarget に変換する (slug は固定 'url')。"""
+    video_id = _extract_video_id_from_url(url)
+    return VideoTarget(video_id=video_id, slug=URL_SOURCE_SLUG, url=url, title="")
+
+
+def _resolve_own_targets(*, channel_dir: Path, collection_name: str) -> list[VideoTarget]:
+    """自チャンネル live コレクションから VideoTarget リストを構築する。
+
+    `complete_collection.video_id` を 1 件、`videos[]` があれば各エントリを追加。
+    """
+    tracking_path = channel_dir / "collections" / "live" / collection_name / _COLLECTION_DOC_DIR / _UPLOAD_TRACKING_NAME
+    if not tracking_path.exists():
+        raise ValidationError(
+            f"upload_tracking.json が見つかりません: collection='{collection_name}' path={tracking_path}"
+        )
+
+    data = json.loads(tracking_path.read_text(encoding="utf-8"))
+
+    targets: list[VideoTarget] = []
+    cc = data.get("complete_collection") or {}
+    cc_video_id = cc.get("video_id")
+    if cc_video_id:
+        targets.append(
+            VideoTarget(
+                video_id=cc_video_id,
+                slug=collection_name,
+                url=cc.get("video_url") or WATCH_URL_TEMPLATE.format(video_id=cc_video_id),
+                title=cc.get("title", ""),
+            )
+        )
+
+    for v in data.get("videos") or []:
+        vid = v.get("video_id")
+        if not vid:
+            continue
+        targets.append(
+            VideoTarget(
+                video_id=vid,
+                slug=collection_name,
+                url=v.get("video_url") or WATCH_URL_TEMPLATE.format(video_id=vid),
+                title=v.get("title", ""),
+            )
+        )
+
+    if not targets:
+        raise ValidationError(f"コレクション '{collection_name}' に有効な video_id が含まれていません")
+    return targets
+
+
+def _resolve_benchmark_targets(*, data_dir: Path, channel_slug: str, top: int) -> list[VideoTarget]:
+    """ベンチマーク JSON から slug でフィルタし、上位 `top` 件を VideoTarget に変換する。"""
+    if top <= 0:
+        raise ValidationError(f"--top は 1 以上を指定してください (received: {top})")
+
+    videos = load_benchmark_videos(data_dir)
+    matched = [v for v in videos if v.get("channel_slug") == channel_slug]
+    if not matched:
+        raise ValidationError(f"benchmark JSON に slug='{channel_slug}' の動画がありません")
+
+    selected = matched[:top]
+    return [
+        VideoTarget(
+            video_id=v["video_id"],
+            slug=channel_slug,
+            url=WATCH_URL_TEMPLATE.format(video_id=v["video_id"]),
+            title=v.get("title", ""),
+        )
+        for v in selected
+    ]
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+
+
+class _VideoAnalyzeParser(argparse.ArgumentParser):
+    """`--source` の値ごとに必須引数の有無を post-parse で検証する parser。"""
+
+    def parse_args(self, args=None, namespace=None):  # type: ignore[override]
+        ns = super().parse_args(args=args, namespace=namespace)
+        if ns.source == SOURCE_BENCHMARK and not ns.channel:
+            self.error("--source benchmark には --channel が必須です")
+        if ns.source == SOURCE_OWN and not ns.collection:
+            self.error("--source own には --collection が必須です")
+        return ns
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """yt-video-analyze の argparse を構築する。
+
+    - `--source` と `--url` は相互排他 (どちらか必須)
+    - `--source benchmark` は `--channel` 必須、`--source own` は `--collection` 必須
+    """
+    parser = _VideoAnalyzeParser(description="Gemini で YouTube 動画を解析 (benchmark / own / url の 3 経路)")
+    entry = parser.add_mutually_exclusive_group(required=True)
+    entry.add_argument(
+        "--source",
+        choices=SOURCE_CHOICES,
+        help="解析対象の入力経路 (benchmark|own)",
+    )
+    entry.add_argument("--url", help="単発動画の YouTube URL")
+
+    parser.add_argument("--channel", help="--source benchmark 用: チャンネル slug")
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="--source benchmark 用: 上位何件を解析するか (default: 5)",
+    )
+    parser.add_argument("--collection", help="--source own 用: コレクション名")
+    parser.add_argument("--verbose", "-v", action="store_true", help="詳細ログ")
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _resolve_targets(args: argparse.Namespace, *, channel_dir: Path, data_dir: Path) -> tuple[str, list[VideoTarget]]:
+    """args の入力経路に応じて (slug, targets) を返す。
+
+    `--source` choices と `add_mutually_exclusive_group(required=True)` により、
+    network 入口は url / benchmark / own の 3 値に網羅性が argparse 側で保証される。
+    """
+    if args.url:
+        target = _resolve_url_target(args.url)
+        return target.slug, [target]
+    if args.source == SOURCE_BENCHMARK:
+        return args.channel, _resolve_benchmark_targets(data_dir=data_dir, channel_slug=args.channel, top=args.top)
+    # SOURCE_OWN: choices と排他制約で他値は到達不能
+    return args.collection, _resolve_own_targets(channel_dir=channel_dir, collection_name=args.collection)
+
+
+def _run_analysis(*, analyzer: VideoAnalyzer, targets: list[VideoTarget]) -> tuple[list[dict], list[dict]]:
+    """targets を順に Gemini で解析し、(成功 results, 失敗 failures) を返す。
+
+    plan「失敗動画はログ + JSON 保存せず次へ」の方針に従い、ValidationError
+    （JSON パース失敗）と Gemini SDK の APIError（rate limit / private 動画 /
+    network 等）を 1 件ずつ failures に積み、N 件ループ全停止を防ぐ。
+    """
+    results: list[dict] = []
+    failures: list[dict] = []
+    for target in targets:
+        try:
+            payload = analyzer.analyze_url(target)
+        except (ValidationError, genai_errors.APIError) as err:
+            logger.warning("動画分析失敗 [%s]: %s", target.video_id, err)
+            failures.append({"video_id": target.video_id, "url": target.url, "error": str(err)})
+            continue
+        analyzer.save_json(target, payload)
+        results.append(payload)
+    return results, failures
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    # 境界での解決: skill-config / channel_dir / data_dir / Gemini Client は一度だけ
+    cfg = load_skill_config(SKILL_NAME)
+    channel_dir = _channel_dir()
+    data_dir = channel_dir / "data"
+    reports_dir = channel_dir / "reports"
+
+    slug, targets = _resolve_targets(args, channel_dir=channel_dir, data_dir=data_dir)
+    logger.info("解析対象: slug='%s' 件数=%d", slug, len(targets))
+
+    analyzer = VideoAnalyzer(
+        client=create_genai_client(),
+        model=cfg["model"],
+        prompt=cfg["prompt"],
+        delay_sec=cfg["delay_sec"],
+        data_dir=data_dir,
+    )
+
+    results, failures = _run_analysis(analyzer=analyzer, targets=targets)
+
+    md = VideoAnalysisReport.render(slug=slug, results=results, failures=failures)
+    VideoAnalysisReport.write(reports_dir=reports_dir, slug=slug, content=md)
+
+    logger.info("動画分析完了: slug='%s' 成功=%d 失敗=%d", slug, len(results), len(failures))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/youtube_automation/utils/video_analyzer.py
+++ b/src/youtube_automation/utils/video_analyzer.py
@@ -1,0 +1,210 @@
+"""Gemini で YouTube 動画を直接解析するユーティリティ。
+
+Issue #103 で追加: ベンチマーク競合・自チャンネル動画・任意 URL を Gemini に
+直接渡し、`hook_structure` / `bgm_arc` / `scene_timeline` / `thumbnail_alignment`
+/ `editing_metrics` を含む構造化 JSON を得る。
+
+責務分割:
+- `VideoTarget`        : 解析対象 1 件分の入力データ (CLI 層で構築)
+- `VideoAnalyzer`      : Gemini 呼出 + JSON パース + ファイル保存
+- `VideoAnalysisReport`: 解析結果を slug 単位で Markdown 集約
+
+Gemini Client は外部から DI する (テスト容易性 + 認証戦略の分裂回避)。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from google import genai
+from google.genai import types
+
+from youtube_automation.utils.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+# data_dir / reports_dir 配下に切るサブディレクトリ名
+VIDEO_ANALYSIS_DIRNAME = "video_analysis"
+
+# Gemini レスポンスのコードフェンス除去用 (benchmark_collector.py:561-563 と同方式)
+_CODE_FENCE_HEAD = re.compile(r"^```(?:json)?\s*")
+_CODE_FENCE_TAIL = re.compile(r"\s*```$")
+
+# Gemini に渡す YouTube URL Part の MIME type
+_VIDEO_MIME_TYPE = "video/*"
+
+
+@dataclass(frozen=True)
+class VideoTarget:
+    """解析対象 1 件分の入力データ。
+
+    benchmark / own / url の 3 経路で CLI 層が組み立て、analyzer に渡す。
+    """
+
+    video_id: str
+    slug: str
+    url: str
+    title: str
+
+
+class VideoAnalyzer:
+    """Gemini に YouTube URL を直接渡して構造化 JSON を得る。
+
+    `client` / `model` / `prompt` / `delay_sec` / `data_dir` は CLI 層 (境界)
+    で 1 度だけ解決して渡す。analyze_url ループ内で再解決しない。
+    """
+
+    def __init__(
+        self,
+        *,
+        client: genai.Client,
+        model: str,
+        prompt: str,
+        delay_sec: int,
+        data_dir: Path,
+    ) -> None:
+        self.client = client
+        self.model = model
+        self.prompt = prompt
+        self.delay_sec = delay_sec
+        self.data_dir = data_dir
+
+    def analyze_url(self, target: VideoTarget) -> dict[str, Any]:
+        """target.url を Gemini に渡し、JSON をパースしてメタデータと併せて返す。
+
+        Raises:
+            ValidationError: Gemini レスポンスが JSON にパースできない場合
+        """
+        logger.info("Gemini 動画解析: %s (%s)", target.title[:40], target.video_id)
+        response = self.client.models.generate_content(
+            model=self.model,
+            contents=[
+                types.Part.from_uri(file_uri=target.url, mime_type=_VIDEO_MIME_TYPE),
+                self.prompt,
+            ],
+        )
+        payload = _parse_json_response(response.text)
+        time.sleep(self.delay_sec)
+        return _attach_metadata(payload, target=target, model=self.model)
+
+    def save_json(self, target: VideoTarget, payload: dict[str, Any]) -> Path:
+        """`data_dir/video_analysis/<slug>/<video_id>.json` に書き出す。"""
+        out_dir = self.data_dir / VIDEO_ANALYSIS_DIRNAME / target.slug
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{target.video_id}.json"
+        out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        logger.info("動画分析 JSON 保存: %s", out_path)
+        return out_path
+
+
+def _parse_json_response(text: str) -> dict[str, Any]:
+    """Gemini レスポンス文字列からコードフェンスを剥がし JSON にパースする。"""
+    stripped = text.strip()
+    stripped = _CODE_FENCE_HEAD.sub("", stripped)
+    stripped = _CODE_FENCE_TAIL.sub("", stripped)
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as err:
+        # 握りつぶさず ValidationError へ昇格 (Fail Fast)
+        raise ValidationError(f"Gemini レスポンスの JSON パースに失敗: {err}") from err
+
+
+def _attach_metadata(payload: dict[str, Any], *, target: VideoTarget, model: str) -> dict[str, Any]:
+    """ドメインキーは payload を保ち、メタデータは target で上書きする (envelope)。"""
+    return {
+        **payload,
+        "video_id": target.video_id,
+        "slug": target.slug,
+        "url": target.url,
+        "title": target.title,
+        "analyzed_at": datetime.now().isoformat(timespec="seconds"),
+        "model": model,
+    }
+
+
+class VideoAnalysisReport:
+    """slug 単位の Markdown 集約レポート。"""
+
+    @staticmethod
+    def render(*, slug: str, results: list[dict[str, Any]], failures: list[dict[str, Any]]) -> str:
+        """成功 results と失敗 failures を 1 つの Markdown にまとめる。"""
+        lines: list[str] = [f"# 動画分析レポート — {slug}", ""]
+        lines.append(f"対象: **{slug}** / 成功 {len(results)} 件 / 失敗 {len(failures)} 件")
+        lines.append("")
+
+        if results:
+            lines.append("## 動画別サマリー")
+            lines.append("")
+            for r in results:
+                lines.extend(_render_video_section(r))
+
+        if failures:
+            lines.append("## 失敗した動画")
+            lines.append("")
+            lines.append(f"全 {len(results) + len(failures)} 件中 {len(failures)} 件が失敗しました。")
+            lines.append("")
+            lines.append("| video_id | URL | エラー |")
+            lines.append("|---|---|---|")
+            for f in failures:
+                vid = f.get("video_id", "")
+                url = f.get("url", "")
+                err = str(f.get("error", "")).replace("|", "\\|")
+                lines.append(f"| {vid} | {url} | {err} |")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def write(*, reports_dir: Path, slug: str, content: str) -> Path:
+        """`reports_dir/video_analysis/<slug>.md` に書き出す。"""
+        out_dir = reports_dir / VIDEO_ANALYSIS_DIRNAME
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{slug}.md"
+        out_path.write_text(content, encoding="utf-8")
+        logger.info("動画分析レポート保存: %s", out_path)
+        return out_path
+
+
+def _render_video_section(result: dict[str, Any]) -> list[str]:
+    """1 動画分の Markdown ブロックを生成する。"""
+    video_id = result.get("video_id", "")
+    title = result.get("title", "")
+    url = result.get("url", "")
+    analyzed_at = result.get("analyzed_at", "")
+
+    block: list[str] = [
+        f"### {title} ({video_id})",
+        "",
+        f"- URL: {url}",
+        f"- analyzed_at: {analyzed_at}",
+        f"- model: {result.get('model', '')}",
+        "",
+        "**Hook (`hook_structure`)**",
+        "",
+        f"```json\n{json.dumps(result.get('hook_structure', {}), ensure_ascii=False, indent=2)}\n```",
+        "",
+        "**BGM (`bgm_arc`)**",
+        "",
+        f"```json\n{json.dumps(result.get('bgm_arc', {}), ensure_ascii=False, indent=2)}\n```",
+        "",
+        "**Scene timeline (`scene_timeline`)**",
+        "",
+        f"```json\n{json.dumps(result.get('scene_timeline', []), ensure_ascii=False, indent=2)}\n```",
+        "",
+        "**Thumbnail alignment (`thumbnail_alignment`)**",
+        "",
+        f"```json\n{json.dumps(result.get('thumbnail_alignment', {}), ensure_ascii=False, indent=2)}\n```",
+        "",
+        "**Editing metrics (`editing_metrics`)**",
+        "",
+        f"```json\n{json.dumps(result.get('editing_metrics', {}), ensure_ascii=False, indent=2)}\n```",
+        "",
+    ]
+    return block

--- a/tests/test_video_analyze_cli.py
+++ b/tests/test_video_analyze_cli.py
@@ -1,0 +1,410 @@
+"""scripts/video_analyze.py の CLI/解決ロジック ユニットテスト
+
+Issue #103 で追加する CLI `yt-video-analyze` の引数解析と target 解決ロジックを検証する。
+
+検証対象:
+1. _extract_video_id_from_url: youtube.com/watch?v= / youtu.be/ / youtube.com/shorts/ + 不正 URL
+2. _resolve_url_target: URL から VideoTarget を構築
+3. _resolve_own_targets: collections/live/<name>/20-documentation/upload_tracking.json から
+   complete_collection.video_id (および videos[]) を解決
+4. _resolve_benchmark_targets: ベンチマーク JSON から slug フィルタ + top N 抽出
+5. _build_parser: --source 排他、各経路の必須引数
+
+ネットワーク・Gemini API は呼ばない (resolver 層は file system / 既存 loader のみ)。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from youtube_automation.scripts.video_analyze import (
+    _build_parser,
+    _extract_video_id_from_url,
+    _resolve_benchmark_targets,
+    _resolve_own_targets,
+    _resolve_url_target,
+)
+from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.video_analyzer import VideoTarget
+
+# ----------------------------------------------------------------------------
+# _extract_video_id_from_url
+# ----------------------------------------------------------------------------
+
+
+class TestExtractVideoIdFromUrl:
+    def test_youtube_watch_url(self):
+        # Given: 標準的な watch?v= URL
+        # When/Then
+        assert _extract_video_id_from_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_youtube_watch_url_with_extra_params(self):
+        # Given: 追加パラメータ付き
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&list=PL123"
+        # When/Then
+        assert _extract_video_id_from_url(url) == "dQw4w9WgXcQ"
+
+    def test_youtu_be_short_url(self):
+        # Given: youtu.be の短縮 URL
+        assert _extract_video_id_from_url("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_youtu_be_with_query(self):
+        # Given: 短縮 URL にクエリ付き
+        assert _extract_video_id_from_url("https://youtu.be/dQw4w9WgXcQ?t=10") == "dQw4w9WgXcQ"
+
+    def test_youtu_be_with_trailing_slash(self):
+        # Given: 末尾スラッシュ付きの youtu.be (コピー時に付くケース)
+        # When/Then: 末尾 / は正規化されて video_id のみが返る
+        assert _extract_video_id_from_url("https://youtu.be/dQw4w9WgXcQ/") == "dQw4w9WgXcQ"
+
+    def test_youtube_shorts_url(self):
+        # Given: shorts 形式
+        assert _extract_video_id_from_url("https://www.youtube.com/shorts/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_youtube_shorts_url_with_trailing_slash(self):
+        # Given: 末尾スラッシュ付きの shorts
+        assert _extract_video_id_from_url("https://www.youtube.com/shorts/dQw4w9WgXcQ/") == "dQw4w9WgXcQ"
+
+    def test_invalid_url_raises_validation_error(self):
+        # Given: YouTube ではない URL
+        with pytest.raises(ValidationError):
+            _extract_video_id_from_url("https://example.com/watch?v=abc")
+
+    def test_empty_url_raises_validation_error(self):
+        # Given: 空文字
+        with pytest.raises(ValidationError):
+            _extract_video_id_from_url("")
+
+    def test_watch_without_v_param_raises(self):
+        # Given: v パラメータが欠けた watch URL
+        with pytest.raises(ValidationError):
+            _extract_video_id_from_url("https://www.youtube.com/watch?list=PL123")
+
+
+# ----------------------------------------------------------------------------
+# _resolve_url_target
+# ----------------------------------------------------------------------------
+
+
+class TestResolveUrlTarget:
+    def test_returns_video_target_with_extracted_id(self):
+        # Given: URL
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+        # When
+        target = _resolve_url_target(url)
+
+        # Then
+        assert isinstance(target, VideoTarget)
+        assert target.video_id == "dQw4w9WgXcQ"
+        assert target.url == url
+
+    def test_invalid_url_raises(self):
+        # Given: 不正 URL
+        with pytest.raises(ValidationError):
+            _resolve_url_target("not-a-url")
+
+
+# ----------------------------------------------------------------------------
+# _resolve_own_targets
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def channel_dir_with_collection(tmp_path: Path) -> Path:
+    """upload_tracking.json を持つ模擬 channel_dir を構築
+
+    - 20260326-rjn-cafe-collection: complete_collection のみ
+    - 20260402-rjn-multi-collection: complete_collection + videos[] (1 シリーズ)
+    - 20260411-rjn-empty: tracking なし
+    """
+    live = tmp_path / "collections" / "live"
+
+    cafe = live / "20260326-rjn-cafe-collection" / "20-documentation"
+    cafe.mkdir(parents=True)
+    (cafe / "upload_tracking.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "collection_name": "20260326-rjn-cafe-collection",
+                "complete_collection": {
+                    "video_id": "ABC123",
+                    "video_url": "https://www.youtube.com/watch?v=ABC123",
+                    "title": "Cafe Complete",
+                },
+            }
+        )
+    )
+
+    multi = live / "20260402-rjn-multi-collection" / "20-documentation"
+    multi.mkdir(parents=True)
+    (multi / "upload_tracking.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "collection_name": "20260402-rjn-multi-collection",
+                "complete_collection": {
+                    "video_id": "DEF456",
+                    "video_url": "https://www.youtube.com/watch?v=DEF456",
+                    "title": "Multi Complete",
+                },
+                "videos": [
+                    {"video_id": "VID001", "title": "Track 1"},
+                    {"video_id": "VID002", "title": "Track 2"},
+                ],
+            }
+        )
+    )
+
+    empty = live / "20260411-rjn-empty" / "20-documentation"
+    empty.mkdir(parents=True)
+
+    return tmp_path
+
+
+class TestResolveOwnTargets:
+    def test_returns_complete_collection_video(self, channel_dir_with_collection):
+        # Given: complete_collection のみのコレクション
+        targets = _resolve_own_targets(
+            channel_dir=channel_dir_with_collection,
+            collection_name="20260326-rjn-cafe-collection",
+        )
+
+        # Then: 1 件の VideoTarget が返る
+        assert len(targets) == 1
+        assert targets[0].video_id == "ABC123"
+        assert targets[0].url == "https://www.youtube.com/watch?v=ABC123"
+        # slug にはコレクション名が入る (own 経路の保存ディレクトリに使う)
+        assert targets[0].slug == "20260326-rjn-cafe-collection"
+
+    def test_includes_per_video_entries(self, channel_dir_with_collection):
+        # Given: complete_collection + videos[] のコレクション
+        targets = _resolve_own_targets(
+            channel_dir=channel_dir_with_collection,
+            collection_name="20260402-rjn-multi-collection",
+        )
+
+        # Then: complete + 各 video が含まれる (合計 3 件)
+        ids = {t.video_id for t in targets}
+        assert "DEF456" in ids
+        assert "VID001" in ids
+        assert "VID002" in ids
+        assert len(targets) == 3
+
+    def test_missing_tracking_raises(self, channel_dir_with_collection):
+        # Given: tracking ファイルがない
+        with pytest.raises(ValidationError):
+            _resolve_own_targets(
+                channel_dir=channel_dir_with_collection,
+                collection_name="20260411-rjn-empty",
+            )
+
+    def test_unknown_collection_raises(self, channel_dir_with_collection):
+        # Given: 存在しないコレクション名
+        with pytest.raises(ValidationError):
+            _resolve_own_targets(
+                channel_dir=channel_dir_with_collection,
+                collection_name="does-not-exist",
+            )
+
+
+# ----------------------------------------------------------------------------
+# _resolve_benchmark_targets
+# ----------------------------------------------------------------------------
+
+
+class TestResolveBenchmarkTargets:
+    def _videos(self) -> list[dict]:
+        # 視聴数降順で load_benchmark_videos が返す想定
+        return [
+            {
+                "video_id": "C1",
+                "title": "Top Celtic",
+                "views": 500000,
+                "channel_name": "CelticCh",
+                "channel_slug": "celtic-music",
+                "published_at": "2026-03-01",
+                "thumbnail_url": "https://i.ytimg.com/c1.jpg",
+            },
+            {
+                "video_id": "C2",
+                "title": "Mid Celtic",
+                "views": 200000,
+                "channel_name": "CelticCh",
+                "channel_slug": "celtic-music",
+                "published_at": "2026-02-15",
+                "thumbnail_url": "https://i.ytimg.com/c2.jpg",
+            },
+            {
+                "video_id": "C3",
+                "title": "Low Celtic",
+                "views": 30000,
+                "channel_name": "CelticCh",
+                "channel_slug": "celtic-music",
+                "published_at": "2026-01-15",
+                "thumbnail_url": "https://i.ytimg.com/c3.jpg",
+            },
+            {
+                "video_id": "J1",
+                "title": "Jazz Night",
+                "views": 1000000,
+                "channel_name": "JazzCh",
+                "channel_slug": "rain-jazz-night",
+                "published_at": "2026-03-01",
+                "thumbnail_url": "https://i.ytimg.com/j1.jpg",
+            },
+        ]
+
+    def test_filters_by_channel_slug_and_takes_top_n(self, tmp_path):
+        # Given: load_benchmark_videos が複数チャンネルの動画を返す
+        with patch(
+            "youtube_automation.scripts.video_analyze.load_benchmark_videos",
+            return_value=self._videos(),
+        ):
+            # When: celtic-music で top=2
+            targets = _resolve_benchmark_targets(
+                data_dir=tmp_path,
+                channel_slug="celtic-music",
+                top=2,
+            )
+
+        # Then: celtic-music の上位 2 件のみ
+        assert [t.video_id for t in targets] == ["C1", "C2"]
+        assert all(t.slug == "celtic-music" for t in targets)
+        assert all(isinstance(t, VideoTarget) for t in targets)
+        # URL は watch?v= 形式で組み立てられる
+        assert targets[0].url.endswith("v=C1")
+
+    def test_top_larger_than_available_returns_all(self, tmp_path):
+        # Given
+        with patch(
+            "youtube_automation.scripts.video_analyze.load_benchmark_videos",
+            return_value=self._videos(),
+        ):
+            targets = _resolve_benchmark_targets(
+                data_dir=tmp_path,
+                channel_slug="celtic-music",
+                top=99,
+            )
+
+        # Then: 該当 slug の全件 (3) が返る
+        assert {t.video_id for t in targets} == {"C1", "C2", "C3"}
+
+    def test_unknown_slug_raises(self, tmp_path):
+        # Given: 該当しない slug
+        with patch(
+            "youtube_automation.scripts.video_analyze.load_benchmark_videos",
+            return_value=self._videos(),
+        ):
+            with pytest.raises(ValidationError):
+                _resolve_benchmark_targets(
+                    data_dir=tmp_path,
+                    channel_slug="nonexistent",
+                    top=5,
+                )
+
+    def test_top_zero_raises(self, tmp_path):
+        # Given: top=0 は意味がない (不整合な値のサイレントスキップ禁止)
+        with patch(
+            "youtube_automation.scripts.video_analyze.load_benchmark_videos",
+            return_value=self._videos(),
+        ):
+            with pytest.raises(ValidationError):
+                _resolve_benchmark_targets(
+                    data_dir=tmp_path,
+                    channel_slug="celtic-music",
+                    top=0,
+                )
+
+
+# ----------------------------------------------------------------------------
+# _build_parser (argparse contract)
+# ----------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_benchmark_path_requires_channel(self):
+        # Given: parser
+        parser = _build_parser()
+
+        # When/Then: --source benchmark で --channel 未指定は SystemExit (parser.error)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--source", "benchmark", "--top", "5"])
+
+    def test_benchmark_path_parses_with_channel_and_top(self):
+        # Given
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--source", "benchmark", "--channel", "celtic-music", "--top", "3"])
+
+        # Then
+        assert args.source == "benchmark"
+        assert args.channel == "celtic-music"
+        assert args.top == 3
+
+    def test_own_path_requires_collection(self):
+        # Given
+        parser = _build_parser()
+
+        # When/Then
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--source", "own"])
+
+    def test_own_path_parses_with_collection(self):
+        # Given
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--source", "own", "--collection", "20260326-cafe-collection"])
+
+        # Then
+        assert args.source == "own"
+        assert args.collection == "20260326-cafe-collection"
+
+    def test_url_path_parses(self):
+        # Given
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--url", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"])
+
+        # Then
+        assert args.url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_source_benchmark_rejects_invalid_value(self):
+        # Given: argparse choices で制限されている想定
+        parser = _build_parser()
+
+        # When/Then: 未知の source 値は SystemExit
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--source", "garbage"])
+
+    def test_source_and_url_are_mutually_exclusive(self):
+        # Given
+        parser = _build_parser()
+
+        # When/Then: --source と --url の併用は SystemExit
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                [
+                    "--source",
+                    "own",
+                    "--collection",
+                    "x",
+                    "--url",
+                    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                ]
+            )
+
+    def test_no_arguments_raises(self):
+        # Given: 何も指定しない
+        parser = _build_parser()
+
+        # When/Then: 入口経路が決まらないので SystemExit
+        with pytest.raises(SystemExit):
+            parser.parse_args([])

--- a/tests/test_video_analyzer.py
+++ b/tests/test_video_analyzer.py
@@ -1,0 +1,354 @@
+"""utils/video_analyzer.py のユニットテスト
+
+Issue #103 で追加する VideoAnalyzer / VideoAnalysisReport / VideoTarget の
+振る舞いを検証する。Gemini Client は全テストでモックする (ネットワーク非依存)。
+
+検証対象:
+1. VideoTarget dataclass: 必須フィールドが保持される
+2. VideoAnalyzer.analyze_url: Gemini レスポンスを JSON にパースし、メタデータを併せて返す
+   - 正常系 (素の JSON)
+   - コードフェンス付き JSON ( ```json ... ``` ) のフェンス除去
+   - JSON パース失敗時に ValidationError を送出 (エラー握りつぶし禁止)
+   - delay_sec が time.sleep に渡される (API レート対策)
+3. VideoAnalyzer.save_json: data/video_analysis/<slug>/<video_id>.json に書き出す
+4. VideoAnalysisReport.render: 必要セクションを含む Markdown を生成する
+5. VideoAnalysisReport.write: reports/video_analysis/<slug>.md に書き出す
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.video_analyzer import (
+    VideoAnalysisReport,
+    VideoAnalyzer,
+    VideoTarget,
+)
+
+
+def _make_target(**overrides) -> VideoTarget:
+    """テスト用 VideoTarget の最小ファクトリ"""
+    base = {
+        "video_id": "ABCDEFGHIJK",
+        "slug": "rain-jazz-night",
+        "url": "https://www.youtube.com/watch?v=ABCDEFGHIJK",
+        "title": "Sample Title",
+    }
+    base.update(overrides)
+    return VideoTarget(**base)
+
+
+def _make_response(text: str) -> MagicMock:
+    response = MagicMock()
+    response.text = text
+    return response
+
+
+def _make_client(response_text: str) -> MagicMock:
+    client = MagicMock()
+    client.models.generate_content.return_value = _make_response(response_text)
+    return client
+
+
+_VALID_PAYLOAD = {
+    "hook_structure": {"intro_sec": 5, "first_text_at": 2.0},
+    "bgm_arc": {"intro": "0-15s", "peak": "1:30", "outro": "9:30-end"},
+    "scene_timeline": [{"start": "0:00", "summary": "fade-in cafe"}],
+    "thumbnail_alignment": {"signature_present": True},
+    "editing_metrics": {"avg_cut_sec": 6.5, "text_per_min": 3},
+}
+
+
+class TestVideoTarget:
+    def test_holds_required_fields(self):
+        # Given: 必要な属性
+        target = VideoTarget(
+            video_id="vid_001",
+            slug="celtic-music",
+            url="https://www.youtube.com/watch?v=vid_001",
+            title="Celtic Forest",
+        )
+
+        # Then: 各属性にアクセスできる
+        assert target.video_id == "vid_001"
+        assert target.slug == "celtic-music"
+        assert target.url == "https://www.youtube.com/watch?v=vid_001"
+        assert target.title == "Celtic Forest"
+
+
+class TestVideoAnalyzerAnalyzeUrl:
+    def test_parses_plain_json_response(self, tmp_path):
+        # Given: 素の JSON を返す Gemini Client
+        client = _make_client(json.dumps(_VALID_PAYLOAD))
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+        target = _make_target()
+
+        # When: analyze_url を呼ぶ
+        result = analyzer.analyze_url(target)
+
+        # Then: パース結果のドメインキーが含まれ、メタも併走している
+        assert result["hook_structure"]["intro_sec"] == 5
+        assert result["bgm_arc"]["peak"] == "1:30"
+        assert result["scene_timeline"][0]["summary"] == "fade-in cafe"
+        assert result["thumbnail_alignment"]["signature_present"] is True
+        assert result["editing_metrics"]["avg_cut_sec"] == 6.5
+
+        # メタデータが上書きされていない (target の値が反映)
+        assert result["video_id"] == target.video_id
+        assert result["slug"] == target.slug
+        assert result["url"] == target.url
+        assert result["title"] == target.title
+        assert result["model"] == "gemini-2.5-flash"
+        # analyzed_at は ISO 文字列で保存される
+        assert isinstance(result["analyzed_at"], str) and result["analyzed_at"]
+
+        # Gemini Client が 1 回だけ呼ばれている
+        assert client.models.generate_content.call_count == 1
+
+    def test_strips_code_fence_wrapped_json(self, tmp_path):
+        # Given: ```json ... ``` で囲まれたレスポンス
+        fenced = "```json\n" + json.dumps(_VALID_PAYLOAD) + "\n```"
+        client = _make_client(fenced)
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+
+        # When: analyze_url を呼ぶ
+        result = analyzer.analyze_url(_make_target())
+
+        # Then: フェンスが除去されてパースできる
+        assert result["hook_structure"]["intro_sec"] == 5
+
+    def test_strips_bare_code_fence(self, tmp_path):
+        # Given: ``` ... ``` (json タグなし)
+        fenced = "```\n" + json.dumps(_VALID_PAYLOAD) + "\n```"
+        client = _make_client(fenced)
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+
+        # When/Then: タグ無しでもパースできる
+        result = analyzer.analyze_url(_make_target())
+        assert result["bgm_arc"]["intro"] == "0-15s"
+
+    def test_raises_validation_error_on_invalid_json(self, tmp_path):
+        # Given: JSON にならないレスポンス
+        client = _make_client("this is not json at all")
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+
+        # When/Then: 握りつぶさず ValidationError を投げる
+        with pytest.raises(ValidationError):
+            analyzer.analyze_url(_make_target())
+
+    def test_uses_target_url_in_request(self, tmp_path):
+        # Given: 解析対象 URL
+        client = _make_client(json.dumps(_VALID_PAYLOAD))
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze the video",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+        target = _make_target(url="https://youtu.be/SHORTID0001")
+
+        # When: analyze_url
+        analyzer.analyze_url(target)
+
+        # Then: generate_content の呼び出し引数に URL とプロンプトが含まれる
+        call = client.models.generate_content.call_args
+        rendered = repr(call)
+        assert "https://youtu.be/SHORTID0001" in rendered
+        assert "analyze the video" in rendered
+
+    def test_sleeps_delay_sec_between_calls(self, tmp_path):
+        # Given: delay_sec を指定
+        client = _make_client(json.dumps(_VALID_PAYLOAD))
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=7,
+            data_dir=tmp_path,
+        )
+
+        # When: analyze_url を呼ぶ
+        with patch("youtube_automation.utils.video_analyzer.time.sleep") as mock_sleep:
+            analyzer.analyze_url(_make_target())
+
+        # Then: sleep が delay_sec で呼ばれる (API レート対策)
+        mock_sleep.assert_called_once_with(7)
+
+
+class TestVideoAnalyzerSaveJson:
+    def test_writes_to_slug_subdirectory(self, tmp_path):
+        # Given: data_dir に紐づく analyzer
+        analyzer = VideoAnalyzer(
+            client=MagicMock(),
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+        )
+        target = _make_target(video_id="VID42", slug="celtic-forest")
+        payload = {"video_id": "VID42", **_VALID_PAYLOAD}
+
+        # When: save_json
+        out_path = analyzer.save_json(target, payload)
+
+        # Then: data/video_analysis/<slug>/<video_id>.json に書かれる
+        expected = tmp_path / "video_analysis" / "celtic-forest" / "VID42.json"
+        assert out_path == expected
+        assert expected.exists()
+
+        loaded = json.loads(expected.read_text(encoding="utf-8"))
+        assert loaded["video_id"] == "VID42"
+        assert loaded["hook_structure"]["intro_sec"] == 5
+
+    def test_creates_intermediate_directories(self, tmp_path):
+        # Given: 存在しないディレクトリ階層
+        nested = tmp_path / "does" / "not" / "exist"
+        analyzer = VideoAnalyzer(
+            client=MagicMock(),
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=nested,
+        )
+        target = _make_target(video_id="V1", slug="ambient")
+
+        # When: save_json
+        out_path = analyzer.save_json(target, {"video_id": "V1"})
+
+        # Then: 中間ディレクトリが自動作成され、ファイルが書かれる
+        assert out_path.exists()
+        assert out_path.parent.is_dir()
+
+
+class TestVideoAnalysisReport:
+    def _sample_results(self) -> list[dict]:
+        return [
+            {
+                "video_id": "VID01",
+                "slug": "celtic-music",
+                "url": "https://www.youtube.com/watch?v=VID01",
+                "title": "Celtic Forest",
+                "analyzed_at": "2026-04-29T10:00:00",
+                "model": "gemini-2.5-flash",
+                **_VALID_PAYLOAD,
+            },
+            {
+                "video_id": "VID02",
+                "slug": "celtic-music",
+                "url": "https://www.youtube.com/watch?v=VID02",
+                "title": "Celtic Lake",
+                "analyzed_at": "2026-04-29T10:01:00",
+                "model": "gemini-2.5-flash",
+                "hook_structure": {"intro_sec": 8},
+                "bgm_arc": {"intro": "0-10s"},
+                "scene_timeline": [],
+                "thumbnail_alignment": {"signature_present": False},
+                "editing_metrics": {"avg_cut_sec": 4.2},
+            },
+        ]
+
+    def test_render_includes_required_sections(self):
+        # Given: 解析結果
+        results = self._sample_results()
+
+        # When: render を呼ぶ
+        md = VideoAnalysisReport.render(slug="celtic-music", results=results, failures=[])
+
+        # Then: 必要セクションが Markdown に含まれる
+        assert "celtic-music" in md
+        assert "VID01" in md
+        assert "VID02" in md
+        assert "Celtic Forest" in md
+        assert "Celtic Lake" in md
+        # 主要キー名は人間向けレポートにラベルとして登場するはず
+        assert "hook_structure" in md or "Hook" in md.title() or "フック" in md
+        assert "bgm_arc" in md or "BGM" in md
+        assert "scene_timeline" in md or "シーン" in md or "Scene" in md
+        assert "thumbnail_alignment" in md or "サムネ" in md or "Thumbnail" in md
+        assert "editing_metrics" in md or "編集" in md or "Editing" in md
+
+    def test_render_reports_failure_count(self):
+        # Given: 一部失敗あり
+        failures = [
+            {"video_id": "BAD1", "url": "https://youtu.be/BAD1", "error": "JSON parse failed"},
+        ]
+        results = self._sample_results()
+
+        # When: render
+        md = VideoAnalysisReport.render(slug="celtic-music", results=results, failures=failures)
+
+        # Then: 失敗が明示される (エラー握りつぶし禁止)
+        assert "BAD1" in md
+        # 失敗件数を示す手がかりがある
+        assert ("失敗" in md) or ("failed" in md.lower())
+
+    def test_render_handles_empty_results(self):
+        # Given: 結果なし、失敗のみ
+        failures = [{"video_id": "X1", "url": "u", "error": "boom"}]
+
+        # When: render
+        md = VideoAnalysisReport.render(slug="celtic-music", results=[], failures=failures)
+
+        # Then: 空でも Markdown を生成できる
+        assert isinstance(md, str)
+        assert "X1" in md
+
+    def test_write_creates_report_file(self, tmp_path):
+        # Given: reports_dir + Markdown
+        content = "# sample report\n"
+
+        # When: write
+        out_path = VideoAnalysisReport.write(
+            reports_dir=tmp_path,
+            slug="rain-jazz-night",
+            content=content,
+        )
+
+        # Then: reports/video_analysis/<slug>.md に書かれる
+        expected = tmp_path / "video_analysis" / "rain-jazz-night.md"
+        assert out_path == expected
+        assert expected.read_text(encoding="utf-8") == content
+
+    def test_write_creates_intermediate_dirs(self, tmp_path):
+        # Given: 存在しないネスト
+        deep = tmp_path / "x" / "y"
+
+        # When: write
+        out_path = VideoAnalysisReport.write(
+            reports_dir=deep,
+            slug="ambient",
+            content="hi",
+        )
+
+        # Then: 中間ディレクトリが作成される
+        assert out_path.exists()
+        assert (deep / "video_analysis").is_dir()

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.1.1"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 背景

YouTube の CTR 戦略上、「サムネ × 音楽 × タイトル」の整合性監査がチャンネル評価を回復する最重要レバーだが、現状の自動化スキル（`/alignment-check` `/thumbnail-compare` `/viewer-voice` 等）は **静止画・メタデータ・コメントテキスト止まり** で、動画本体の中身を分析する経路がない。

具体的に欠けている観点:

- 競合動画の冒頭 30 秒のフック構造（カット割り・テキスト出現タイミング）
- BGM の展開パターン（イントロ尺 / ピーク位置 / アウトロ）
- 自チャンネル動画の retention drop ポイントと映像/音楽展開の対応
- サムネで提示した「signature 要素」が本編に映っているかの整合性検証

Gemini 2.5 系は YouTube URL 直接入力 / File API での動画入力にネイティブ対応しており、タイムスタンプ付きで映像・音声を構造化解析できる。これを当パッケージに組み込みたい。

## 提案

### CLI

新規コマンド `yt-video-analyze` を追加:

```bash
# ベンチマーク競合の上位動画を分析
uv run yt-video-analyze --source benchmark --channel <slug> --top 5

# 自チャンネル live コレクションを分析
uv run yt-video-analyze --source own --collection <name>

# 単発動画（YouTube URL 直指定）
uv run yt-video-analyze --url <youtube_url>
```

### 入力経路

- `--source benchmark`: `data/benchmarks/<slug>.json` から上位動画を取得
- `--source own`: `collections/live/<name>/` の YouTube ID を解決
- `--url`: 任意の YouTube URL を直接指定

Gemini API には YouTube URL を直接渡す（公開動画のみ対応）。Public/Unlisted 制約は README 注記で許容する。

### 出力

```
data/video_analysis/<slug>/<videoId>.json   # 構造化データ
reports/video_analysis/<slug>.md            # 人間向けサマリー
```

JSON の主なフィールド案:

- `hook_structure`: 0–30 秒のカット割り・テキスト出現・signature 要素
- `bgm_arc`: イントロ尺 / ピーク / アウトロのタイムスタンプ
- `scene_timeline`: シーン境界（タイムスタンプ + 一言要約）
- `thumbnail_alignment`: サムネで提示した要素が本編で確認できるかの bool 配列
- `editing_metrics`: 平均カット長・テキスト出現頻度

### 依存

- `GEMINI_API_KEY` は既に必須環境変数として運用済み
- 新規依存なし（`google-genai` は既導入想定）

### 既存スキルとの連携

- `/benchmark`: 動画分析結果を競合スコアリングの入力に追加
- `/analyze`: retention drop と動画分析のタイムラインをクロス参照
- `/alignment-check`: `thumbnail_alignment` を整合性監査の根拠に組み込む
- `/thumbnail-compare`: 競合のサムネ実装パターン抽出を補強
- `/viewer-voice`: コメント言及シーンを動画タイムスタンプにマッピング

## モチベーション

- 競合の「強い signature 要素」を映像レベルで抽出し、自チャンネルのサムネ生成（`config/skills/thumbnail.yaml` の勝ちパターン）にフィードバックできる
- 自チャンネルの retention 30 日プラトーが起きた動画の構造的問題を特定できる
- 既存スキルが扱えていない「動画の中身」という最後のドメインを埋める

## 想定外スコープ

- 動画ダウンロード（YouTube URL 直渡しで完結させる）
- Shorts 専用の超高速カット解析（Gemini の 1fps サンプリング制約のため精度が落ちる）

## 関連

- `youtube-rain-jazz-night` 側の利用想定: `/benchmark` `/analyze` `/alignment-check` の精度向上

## Execution Report

Workflow `default` completed successfully.

Closes #103