### PR TITLE
release: v5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.2.0"
+version = "5.3.0"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.2.0"
+__version__ = "5.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.2.0"
+version = "5.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

v5.2.0 → **v5.3.0** リリース。Gemini で YouTube 動画本体を解析する CLI とスキルを追加。

### Added (`yt-video-analyze` + `/video-analyze` skill)

- **#103**: 新規 CLI `yt-video-analyze` を追加。Gemini に YouTube URL を直接渡してフック構造（`hook_structure`）・BGM 展開（`bgm_arc`）・シーンタイムライン（`scene_timeline`）・サムネ整合性（`thumbnail_alignment`）・編集指標（`editing_metrics`）を JSON で抽出する
  - 入力経路: `--source benchmark`（`data/benchmarks/<slug>.json` Top N） / `--source own`（`collections/live/<name>/`） / `--url <youtube_url>`（単発）
  - 出力: `data/video_analysis/<slug>/<videoId>.json` + `reports/video_analysis/<slug>.md`
  - 制約: Gemini API 仕様により対象動画は **Public または Unlisted** のみ
- 新規スキル `/video-analyze`（`.claude/skills/video-analyze/`）
- 既存スキル 5 件に `data/video_analysis/<slug>/<video_id>.json` を入力に使える旨の参照追記
  - `/alignment-check` `thumbnail_alignment` をサムネ整合性監査の根拠に
  - `/analyze` `scene_timeline` を retention drop とのクロス参照に
  - `/benchmark` 動画本体スコアリングを競合スコアの追加入力に
  - `/thumbnail-compare` `signature_elements` / `hook_structure` を競合サムネ実装パターン抽出の補強に
  - `/viewer-voice` `scene_timeline` をコメント言及シーンのタイムスタンプマッピングに

## バージョン bump

- `pyproject.toml`: 5.2.0 → 5.3.0
- `src/youtube_automation/__init__.py`: `__version__` 同上
- `uv.lock`: 自動更新

## 後方互換

すべて加算的変更。新規 CLI / 新規スキル / 既存スキル SKILL.md への参照追記のみ。既存挙動・設定スキーマ・依存パッケージに変更なし。

## ダウンストリームへの影響

各チャンネルリポジトリでの作業（任意 / opt-in）:

1. youtube-channels-automation を v5.3.0 に bump（`uv sync`）
2. `uv run yt-skills sync` で新スキル `/video-analyze` と既存スキル 5 件の参照追記を反映
3. `data/video_analysis/` 配下の生成物を `.gitignore` に追加することを推奨
4. `GEMINI_API_KEY`（既に必須）が利用可能であることを確認