### PR TITLE
feat: yt-discover-competitors にチャンネル topic フィルタを追加し非音楽チャンネルの誤検知を抑制 (#120)

### DIFF
--- a/src/youtube_automation/scripts/discover_competitors.py
+++ b/src/youtube_automation/scripts/discover_competitors.py
@@ -91,6 +91,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default=_DEFAULT_PER_KEYWORD,
         help="search.list の maxResults（キーワード毎の取得上限）",
     )
+    parser.add_argument(
+        "--require-music-topic",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "channels.list の topicCategories に音楽トピックを含むチャンネルのみ通すフィルタ。"
+            "既定: ON（topic 不明チャンネルは fail-open で通す）。"
+            "従来挙動に戻すには --no-require-music-topic"
+        ),
+    )
     parser.add_argument("--output", required=True, help="Markdown 出力先（同名 .csv も書き出す）")
     parser.add_argument("-v", "--verbose", action="store_true")
     return parser
@@ -123,6 +133,7 @@ def _build_params(args: argparse.Namespace) -> DiscoveryParams:
         posted_within_days=args.posted_within_days,
         top=args.top,
         per_keyword_results=args.per_keyword,
+        require_music_topic=args.require_music_topic,
     )
 
 

--- a/src/youtube_automation/utils/competitor_discovery.py
+++ b/src/youtube_automation/utils/competitor_discovery.py
@@ -78,7 +78,11 @@ def _fetch_channel_details(
     for i in range(0, len(channel_ids), _CHANNELS_BATCH_SIZE):
         batch = channel_ids[i : i + _CHANNELS_BATCH_SIZE]
         try:
-            resp = youtube.channels().list(part="snippet,statistics,contentDetails", id=",".join(batch)).execute()
+            resp = (
+                youtube.channels()
+                .list(part="snippet,statistics,contentDetails,topicDetails", id=",".join(batch))
+                .execute()
+            )
         except HttpError as e:
             raise YouTubeAPIError.from_http_error(e, "channels.list failed") from e
 
@@ -87,6 +91,7 @@ def _fetch_channel_details(
             snippet = item.get("snippet", {})
             stats = item.get("statistics", {})
             content = item.get("contentDetails", {})
+            topic_details = item.get("topicDetails", {})
             uploads = content.get("relatedPlaylists", {}).get("uploads")
             if uploads:
                 uploads_map[ch_id] = uploads
@@ -100,6 +105,7 @@ def _fetch_channel_details(
                     matched_keywords=set(keyword_map.get(ch_id, set())),
                     recent_videos=[],
                     last_posted_at=None,
+                    topic_categories=tuple(topic_details.get("topicCategories", [])),
                 )
             )
     return fetched, uploads_map

--- a/src/youtube_automation/utils/competitor_scoring.py
+++ b/src/youtube_automation/utils/competitor_scoring.py
@@ -37,6 +37,25 @@ _FACTOR_PHRASES: dict[str, str] = {
     "subscriber_proximity": "近い登録者帯",
 }
 
+# 音楽トピック判定用 Wikipedia URL（freebase 後継の topicCategories と同形式）。
+# `channels.list part=topicDetails` の `topicCategories` を prefix マッチで判定する。
+# Issue #120: 非音楽チャンネルの誤検知（例: "Lo-Fi House" インテリア / DIY 系）を構造的に抑制する。
+_MUSIC_TOPIC_URLS: frozenset[str] = frozenset(
+    {
+        "https://en.wikipedia.org/wiki/Music",
+        "https://en.wikipedia.org/wiki/Electronic_music",
+        "https://en.wikipedia.org/wiki/Hip_hop_music",
+        "https://en.wikipedia.org/wiki/Pop_music",
+        "https://en.wikipedia.org/wiki/Rock_music",
+        "https://en.wikipedia.org/wiki/Classical_music",
+        "https://en.wikipedia.org/wiki/Independent_music",
+        "https://en.wikipedia.org/wiki/Jazz",
+        "https://en.wikipedia.org/wiki/Country_music",
+        "https://en.wikipedia.org/wiki/Soul_music",
+        "https://en.wikipedia.org/wiki/Reggae",
+    }
+)
+
 
 # ----------------------------------------------------------------------------
 # Dataclasses
@@ -53,6 +72,7 @@ class DiscoveryParams:
     posted_within_days: int
     top: int
     per_keyword_results: int
+    require_music_topic: bool = True
 
 
 @dataclass
@@ -77,6 +97,7 @@ class CandidateChannel:
     matched_keywords: set[str]
     recent_videos: list[VideoMetric]
     last_posted_at: date | None
+    topic_categories: tuple[str, ...] = ()
 
 
 @dataclass
@@ -106,11 +127,22 @@ class ScoredCandidate:
 # ----------------------------------------------------------------------------
 
 
+def _is_music_topic_match(topic_categories: tuple[str, ...]) -> bool:
+    """`topic_categories` の URL が `_MUSIC_TOPIC_URLS` のいずれかを prefix に持つか判定する。
+
+    空入力は False を返す（fail-open は呼び出し側 `_apply_filters` の責務）。
+    """
+    return any(topic.startswith(prefix) for topic in topic_categories for prefix in _MUSIC_TOPIC_URLS)
+
+
 def _apply_filters(channels: list[CandidateChannel], params: DiscoveryParams) -> list[CandidateChannel]:
-    """登録者レンジ・動画本数・最終投稿日でフィルタする（入力非破壊）。
+    """登録者レンジ・動画本数・最終投稿日・音楽トピックでフィルタする（入力非破壊）。
 
     `last_posted_at is None` のチャンネルは投稿日フィルタを保留する
     （recent_videos 取得前のため。後段で再フィルタする）。
+
+    `require_music_topic=True` のときのみ topic 判定を作用させ、
+    `topic_categories` が空のチャンネルは fail-open で通す（判定不能 → 除外しない）。
     """
     today = date.today()
     result: list[CandidateChannel] = []
@@ -123,6 +155,8 @@ def _apply_filters(channels: list[CandidateChannel], params: DiscoveryParams) ->
             days_since = (today - ch.last_posted_at).days
             if days_since > params.posted_within_days:
                 continue
+        if params.require_music_topic and ch.topic_categories and not _is_music_topic_match(ch.topic_categories):
+            continue
         result.append(ch)
     return result
 

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -2650,5 +2650,161 @@
       "segment": "seg_001",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-90/test_parallel_partial_failure0/seg_001.wav"
     }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:37.832676+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:37.901782+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.069483+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.231426+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.295943+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.462754+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.527738+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.689984+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.755243+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.929054+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:38.931292+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T08:19:39.095662+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_parallel_partial_failure0/seg_001.wav"
+    }
   }
 ]

--- a/tests/test_competitor_discovery.py
+++ b/tests/test_competitor_discovery.py
@@ -21,6 +21,7 @@ import pytest
 
 from youtube_automation.utils.competitor_discovery import discover_competitors
 from youtube_automation.utils.competitor_scoring import (
+    _MUSIC_TOPIC_URLS,
     CandidateChannel,
     DiscoveryParams,
     ScoreBreakdown,
@@ -33,6 +34,7 @@ from youtube_automation.utils.competitor_scoring import (
     _compute_posting_cadence,
     _compute_subscriber_proximity,
     _format_reason,
+    _is_music_topic_match,
 )
 from youtube_automation.utils.exceptions import YouTubeAPIError
 
@@ -67,10 +69,12 @@ def _make_channel(
     matched_keywords: set[str] | None = None,
     recent_videos: list[VideoMetric] | None = None,
     last_posted_days_ago: int | None = 7,
+    topic_categories: tuple[str, ...] = (),
 ) -> CandidateChannel:
     """テスト用の CandidateChannel を組み立てる。
 
     last_posted_days_ago=None の場合は last_posted_at=None（recent_videos 取得前を模擬）。
+    topic_categories は API 由来の Wikipedia URL タプル（既定は空 = fail-open 対象）。
     """
     last_posted_at = None if last_posted_days_ago is None else date.today() - timedelta(days=last_posted_days_ago)
     return CandidateChannel(
@@ -82,6 +86,7 @@ def _make_channel(
         matched_keywords=set(matched_keywords or set()),
         recent_videos=list(recent_videos or []),
         last_posted_at=last_posted_at,
+        topic_categories=topic_categories,
     )
 
 
@@ -93,6 +98,7 @@ def _make_params(
     posted_within_days: int = 30,
     top: int = 20,
     per_keyword_results: int = 20,
+    require_music_topic: bool = True,
 ) -> DiscoveryParams:
     return DiscoveryParams(
         keywords=keywords,
@@ -101,6 +107,7 @@ def _make_params(
         posted_within_days=posted_within_days,
         top=top,
         per_keyword_results=per_keyword_results,
+        require_music_topic=require_music_topic,
     )
 
 
@@ -170,6 +177,7 @@ class TestModuleResponsibilitySplit:
             competitor_scoring._compute_monthly_uploads,
             competitor_scoring._compute_avg_views,
             competitor_scoring._score_candidate,
+            competitor_scoring._is_music_topic_match,
         ):
             assert fn.__module__ == scoring_module, f"{fn.__name__} は scoring モジュール定義であるべき"
 
@@ -284,6 +292,209 @@ class TestApplyFilters:
         assert original == [keep, drop]
         assert result is not original
         assert result == [keep]
+
+
+# ----------------------------------------------------------------------------
+# require_music_topic フィルタ（Issue #120）
+# ----------------------------------------------------------------------------
+
+
+class TestCandidateChannelTopicCategories:
+    """CandidateChannel.topic_categories の不変条件。"""
+
+    def test_topic_categories_field_exists_with_default_empty_tuple(self):
+        # Given: 明示指定なしで生成
+        ch = _make_channel()
+
+        # Then: API 由来の immutable データなので tuple、既定は空
+        assert isinstance(ch.topic_categories, tuple)
+        assert ch.topic_categories == ()
+
+    def test_topic_categories_accepts_explicit_value(self):
+        # Given: 明示的に音楽 URL を渡す
+        urls = ("https://en.wikipedia.org/wiki/Music",)
+
+        # When
+        ch = _make_channel(topic_categories=urls)
+
+        # Then
+        assert ch.topic_categories == urls
+
+
+class TestDiscoveryParamsRequireMusicTopic:
+    """DiscoveryParams.require_music_topic の既定と保持。"""
+
+    def test_require_music_topic_default_is_true(self):
+        # Given: 明示指定なし（CLI 側 default=True と整合）
+        params = _make_params()
+
+        # Then: 主要ユースケース（音楽系チャンネル発掘）に最適化
+        assert params.require_music_topic is True
+
+    def test_require_music_topic_false_is_preserved(self):
+        # Given: 後方互換のため OFF も指定可能
+        params = _make_params(require_music_topic=False)
+
+        # Then
+        assert params.require_music_topic is False
+
+
+class TestIsMusicTopicMatch:
+    """`_is_music_topic_match` 純粋関数: Wikipedia URL prefix マッチで音楽トピック判定。"""
+
+    def test_empty_input_returns_false(self):
+        # Given: topic_categories が空（fail-open は呼び出し側で制御するため、本関数自体は False）
+        # When/Then
+        assert _is_music_topic_match(()) is False
+
+    def test_music_root_url_returns_true(self):
+        # Given: ルート Music URL のみ
+        # When/Then
+        assert _is_music_topic_match(("https://en.wikipedia.org/wiki/Music",)) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://en.wikipedia.org/wiki/Electronic_music",
+            "https://en.wikipedia.org/wiki/Hip_hop_music",
+            "https://en.wikipedia.org/wiki/Pop_music",
+            "https://en.wikipedia.org/wiki/Rock_music",
+            "https://en.wikipedia.org/wiki/Classical_music",
+            "https://en.wikipedia.org/wiki/Independent_music",
+            "https://en.wikipedia.org/wiki/Jazz",
+            "https://en.wikipedia.org/wiki/Country_music",
+            "https://en.wikipedia.org/wiki/Soul_music",
+            "https://en.wikipedia.org/wiki/Reggae",
+        ],
+    )
+    def test_known_music_subgenre_url_returns_true(self, url: str):
+        # Given: order.md §実装方針 4 で列挙された 11 URL のサブジャンル群
+        # When/Then
+        assert _is_music_topic_match((url,)) is True
+
+    def test_non_music_url_returns_false(self):
+        # Given: 非音楽トピック（Lifestyle / Sports 等）
+        # When/Then
+        assert _is_music_topic_match(("https://en.wikipedia.org/wiki/Lifestyle_(sociology)",)) is False
+        assert _is_music_topic_match(("https://en.wikipedia.org/wiki/Sport",)) is False
+        assert _is_music_topic_match(("https://en.wikipedia.org/wiki/Food",)) is False
+
+    def test_any_match_in_list_returns_true(self):
+        # Given: 音楽 + 非音楽の混在（チャンネル単位 topic は複数返ることがある）
+        topics = (
+            "https://en.wikipedia.org/wiki/Sport",
+            "https://en.wikipedia.org/wiki/Pop_music",
+        )
+
+        # When/Then: 1 つでも音楽トピックがあれば True
+        assert _is_music_topic_match(topics) is True
+
+    def test_prefix_match_against_known_music_url(self):
+        # Given: 既知 Music URL を prefix に持つ URL（仮にサブパスがあってもマッチする）
+        # When/Then: prefix マッチ実装なので True
+        assert _is_music_topic_match(("https://en.wikipedia.org/wiki/Music_of_Japan",)) is True
+
+    def test_music_topic_urls_constant_contains_required_entries(self):
+        # Given: order.md §実装方針 4 が列挙する 11 URL の不変条件
+        required = {
+            "https://en.wikipedia.org/wiki/Music",
+            "https://en.wikipedia.org/wiki/Electronic_music",
+            "https://en.wikipedia.org/wiki/Hip_hop_music",
+            "https://en.wikipedia.org/wiki/Pop_music",
+            "https://en.wikipedia.org/wiki/Rock_music",
+            "https://en.wikipedia.org/wiki/Classical_music",
+            "https://en.wikipedia.org/wiki/Independent_music",
+            "https://en.wikipedia.org/wiki/Jazz",
+            "https://en.wikipedia.org/wiki/Country_music",
+            "https://en.wikipedia.org/wiki/Soul_music",
+            "https://en.wikipedia.org/wiki/Reggae",
+        }
+
+        # Then: 定数は frozenset で必須 URL を全て含む（追加は許容、削除は不可）
+        assert isinstance(_MUSIC_TOPIC_URLS, frozenset)
+        assert required.issubset(_MUSIC_TOPIC_URLS)
+
+
+class TestApplyFiltersMusicTopic:
+    """`_apply_filters` の topic 判定: require_music_topic ON 時のみ作用、空 topic は fail-open。"""
+
+    def test_keeps_music_channel_when_require_music_topic_true(self):
+        # Given: 音楽 topic を持つチャンネル
+        ch = _make_channel(
+            subscribers=100_000,
+            last_posted_days_ago=5,
+            topic_categories=("https://en.wikipedia.org/wiki/Pop_music",),
+        )
+        params = _make_params(require_music_topic=True)
+
+        # When
+        result = _apply_filters([ch], params)
+
+        # Then: 音楽 topic のチャンネルは通る
+        assert result == [ch]
+
+    def test_drops_non_music_channel_when_require_music_topic_true(self):
+        # Given: 非音楽 topic（インテリア/DIY 系の誤検知を想定）
+        ch = _make_channel(
+            subscribers=100_000,
+            last_posted_days_ago=5,
+            topic_categories=("https://en.wikipedia.org/wiki/Lifestyle_(sociology)",),
+        )
+        params = _make_params(require_music_topic=True)
+
+        # When
+        result = _apply_filters([ch], params)
+
+        # Then: 非音楽 topic のみのチャンネルは除外（issue #120 の主要効用）
+        assert result == []
+
+    def test_keeps_channel_with_empty_topic_when_require_music_topic_true(self):
+        # Given: topic_categories が空（新規 / 小規模チャンネル等）
+        ch = _make_channel(
+            subscribers=100_000,
+            last_posted_days_ago=5,
+            topic_categories=(),
+        )
+        params = _make_params(require_music_topic=True)
+
+        # When
+        result = _apply_filters([ch], params)
+
+        # Then: fail-open 設計で通す（判定不能なら除外しない）
+        assert result == [ch]
+
+    def test_keeps_non_music_channel_when_require_music_topic_false(self):
+        # Given: 非音楽 topic でも require_music_topic=False なら従来挙動（topic フィルタなし）
+        ch = _make_channel(
+            subscribers=100_000,
+            last_posted_days_ago=5,
+            topic_categories=("https://en.wikipedia.org/wiki/Lifestyle_(sociology)",),
+        )
+        params = _make_params(require_music_topic=False)
+
+        # When
+        result = _apply_filters([ch], params)
+
+        # Then: フラグ OFF 時は topic 判定をスキップ（後方互換）
+        assert result == [ch]
+
+    def test_keeps_mixed_topic_channel_when_at_least_one_music_topic_present(self):
+        # Given: 音楽 + 非音楽の混在
+        ch = _make_channel(
+            subscribers=100_000,
+            last_posted_days_ago=5,
+            topic_categories=(
+                "https://en.wikipedia.org/wiki/Lifestyle_(sociology)",
+                "https://en.wikipedia.org/wiki/Jazz",
+            ),
+        )
+        params = _make_params(require_music_topic=True)
+
+        # When
+        result = _apply_filters([ch], params)
+
+        # Then: 1 つでも音楽 topic を持てば通る
+        assert result == [ch]
 
 
 # ----------------------------------------------------------------------------
@@ -727,6 +938,191 @@ class TestDiscoverCompetitors:
 
         # Then
         assert len(scored) <= 2
+
+    def test_channels_list_includes_topic_details_part(self):
+        # Given: 最小限の search hit（issue #120: API quota 増やさず part を拡張）
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": "UC_X", "channelTitle": "Channel X"}}],
+            channel_items=[
+                {
+                    "id": "UC_X",
+                    "snippet": {"title": "Channel X", "description": "lo-fi", "customUrl": "@x"},
+                    "statistics": {"subscriberCount": "100000", "videoCount": "10"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_X"}},
+                    "topicDetails": {"topicCategories": ["https://en.wikipedia.org/wiki/Music"]},
+                }
+            ],
+            playlist_items={"UU_X": [{"contentDetails": {"videoId": "VX1"}}]},
+            video_items=[
+                {
+                    "id": "VX1",
+                    "snippet": {"title": "lo-fi", "publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(min_subscribers=10_000, max_subscribers=1_000_000)
+
+        # When
+        discover_competitors(youtube, params)
+
+        # Then: channels.list の part に topicDetails が含まれる（外部契約: API 呼び出し位置）
+        call = youtube.channels.return_value.list.call_args
+        assert call is not None, "channels.list が呼ばれていない"
+        part = call.kwargs.get("part")
+        assert part is not None, "channels.list は part を kwargs で渡す契約"
+        assert "topicDetails" in part, f"part='{part}' に topicDetails が含まれない"
+
+    def test_topic_categories_populated_from_api_response(self):
+        # Given: topicDetails 付きレスポンス、フィルタ通過するチャンネル
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": "UC_X", "channelTitle": "Channel X"}}],
+            channel_items=[
+                {
+                    "id": "UC_X",
+                    "snippet": {"title": "Channel X", "description": "lo-fi", "customUrl": "@x"},
+                    "statistics": {"subscriberCount": "100000", "videoCount": "10"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_X"}},
+                    "topicDetails": {
+                        "topicCategories": [
+                            "https://en.wikipedia.org/wiki/Music",
+                            "https://en.wikipedia.org/wiki/Pop_music",
+                        ]
+                    },
+                }
+            ],
+            playlist_items={"UU_X": [{"contentDetails": {"videoId": "VX1"}}]},
+            video_items=[
+                {
+                    "id": "VX1",
+                    "snippet": {"title": "lo-fi", "publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(
+            min_subscribers=10_000,
+            max_subscribers=1_000_000,
+            require_music_topic=True,
+        )
+
+        # When
+        scored = discover_competitors(youtube, params)
+
+        # Then: API 由来の topicCategories が CandidateChannel.topic_categories に tuple で格納される
+        assert len(scored) == 1
+        topic_categories = scored[0].channel.topic_categories
+        assert isinstance(topic_categories, tuple)
+        assert "https://en.wikipedia.org/wiki/Music" in topic_categories
+        assert "https://en.wikipedia.org/wiki/Pop_music" in topic_categories
+
+    def test_topic_categories_default_empty_when_api_returns_no_topic_details(self):
+        # Given: topicDetails を返さないチャンネル（小規模 / 新規）→ fail-open
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": "UC_X", "channelTitle": "Channel X"}}],
+            channel_items=[
+                {
+                    "id": "UC_X",
+                    "snippet": {"title": "Channel X", "description": "lo-fi", "customUrl": "@x"},
+                    "statistics": {"subscriberCount": "100000", "videoCount": "10"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_X"}},
+                    # NOTE: topicDetails が欠落
+                }
+            ],
+            playlist_items={"UU_X": [{"contentDetails": {"videoId": "VX1"}}]},
+            video_items=[
+                {
+                    "id": "VX1",
+                    "snippet": {"title": "lo-fi", "publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(
+            min_subscribers=10_000,
+            max_subscribers=1_000_000,
+            require_music_topic=True,
+        )
+
+        # When
+        scored = discover_competitors(youtube, params)
+
+        # Then: topicDetails 欠落でも空 tuple として扱い、require_music_topic=True でも fail-open で通す
+        assert len(scored) == 1
+        assert scored[0].channel.topic_categories == ()
+
+    def test_drops_non_music_channel_when_require_music_topic_true(self):
+        # Given: 非音楽 topic（issue #120 の Lo-Fi House 誤検知ケース）
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": "UC_X", "channelTitle": "Lo-Fi House"}}],
+            channel_items=[
+                {
+                    "id": "UC_X",
+                    "snippet": {"title": "Lo-Fi House", "description": "interior DIY", "customUrl": "@lofihouse"},
+                    "statistics": {"subscriberCount": "690000", "videoCount": "100"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_X"}},
+                    "topicDetails": {"topicCategories": ["https://en.wikipedia.org/wiki/Lifestyle_(sociology)"]},
+                }
+            ],
+            playlist_items={"UU_X": [{"contentDetails": {"videoId": "VX1"}}]},
+            video_items=[
+                {
+                    "id": "VX1",
+                    "snippet": {"title": "DIY", "publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(
+            min_subscribers=10_000,
+            max_subscribers=1_000_000,
+            require_music_topic=True,
+        )
+
+        # When
+        scored = discover_competitors(youtube, params)
+
+        # Then: 非音楽 topic のチャンネルは除外（issue #120 の主要効用）
+        assert scored == []
+
+    def test_keeps_non_music_channel_when_require_music_topic_false(self):
+        # Given: 同じ非音楽 topic を、フラグ OFF で通す（後方互換）
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": "UC_X", "channelTitle": "Lo-Fi House"}}],
+            channel_items=[
+                {
+                    "id": "UC_X",
+                    "snippet": {"title": "Lo-Fi House", "description": "interior DIY", "customUrl": "@lofihouse"},
+                    "statistics": {"subscriberCount": "690000", "videoCount": "100"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_X"}},
+                    "topicDetails": {"topicCategories": ["https://en.wikipedia.org/wiki/Lifestyle_(sociology)"]},
+                }
+            ],
+            playlist_items={"UU_X": [{"contentDetails": {"videoId": "VX1"}}]},
+            video_items=[
+                {
+                    "id": "VX1",
+                    "snippet": {"title": "DIY", "publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(
+            min_subscribers=10_000,
+            max_subscribers=1_000_000,
+            require_music_topic=False,
+        )
+
+        # When
+        scored = discover_competitors(youtube, params)
+
+        # Then: --no-require-music-topic 相当で従来挙動（topic 判定なし）
+        assert len(scored) == 1
 
     def test_empty_search_results_returns_empty(self):
         # Given: search hit なし

--- a/tests/test_discover_competitors_cli.py
+++ b/tests/test_discover_competitors_cli.py
@@ -52,6 +52,7 @@ def _make_scored(
     avg_views: int = 120_000,
     score_total: float = 0.92,
     reason: str = "キーワード一致率高、最近の更新活発",
+    topic_categories: tuple[str, ...] = (),
 ) -> ScoredCandidate:
     """テスト用の ScoredCandidate を組み立てる"""
     channel = CandidateChannel(
@@ -63,6 +64,7 @@ def _make_scored(
         matched_keywords={"lo-fi"},
         recent_videos=[],
         last_posted_at=date.today() - timedelta(days=3),
+        topic_categories=topic_categories,
     )
     breakdown = ScoreBreakdown(
         keyword_match=0.9,
@@ -168,6 +170,36 @@ class TestBuildParser:
         # Then
         assert args.verbose is True
 
+    def test_require_music_topic_default_is_true(self):
+        # Given: 主要ユースケース（音楽系発掘）に最適化された既定 ON（issue #120）
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--keywords", "lo-fi", "--output", "out.md"])
+
+        # Then: BooleanOptionalAction + default=True
+        assert args.require_music_topic is True
+
+    def test_require_music_topic_explicit_true(self):
+        # Given: 明示 ON 指定
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--keywords", "lo-fi", "--output", "out.md", "--require-music-topic"])
+
+        # Then
+        assert args.require_music_topic is True
+
+    def test_no_require_music_topic_disables_filter(self):
+        # Given: --no-require-music-topic で従来挙動（topic フィルタ無し）に戻す
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--keywords", "lo-fi", "--output", "out.md", "--no-require-music-topic"])
+
+        # Then: 後方互換確保（issue #120 §効用）
+        assert args.require_music_topic is False
+
 
 # ----------------------------------------------------------------------------
 # _build_params（境界での解決: argparse → DiscoveryParams）
@@ -188,6 +220,7 @@ class TestBuildParams:
             per_keyword=20,
             output="research/out.md",
             verbose=False,
+            require_music_topic=True,
         )
         defaults.update(overrides)
         return Namespace(**defaults)
@@ -250,6 +283,26 @@ class TestBuildParams:
         # When/Then
         with pytest.raises(ValidationError):
             _build_params(args)
+
+    def test_require_music_topic_true_flows_to_params(self):
+        # Given: CLI で --require-music-topic 指定 → args.require_music_topic=True
+        args = self._ns(require_music_topic=True)
+
+        # When
+        params = _build_params(args)
+
+        # Then: 境界での解決原則に沿って args の値がそのまま DiscoveryParams に流れる
+        assert params.require_music_topic is True
+
+    def test_require_music_topic_false_flows_to_params(self):
+        # Given: CLI で --no-require-music-topic 指定 → args.require_music_topic=False
+        args = self._ns(require_music_topic=False)
+
+        # When
+        params = _build_params(args)
+
+        # Then: 後方互換確保（topic フィルタ無し）
+        assert params.require_music_topic is False
 
 
 # ----------------------------------------------------------------------------
@@ -571,4 +624,5 @@ def _make_params_for_render() -> DiscoveryParams:
         posted_within_days=30,
         top=20,
         per_keyword_results=20,
+        require_music_topic=True,
     )


### PR DESCRIPTION
## Summary

## 背景

`yt-discover-competitors`（#114 で追加）は YouTube Data API `search.list type=channel` で
キーワードに合致するチャンネルを発掘するが、ジャンル判定の材料を持たない。
そのためチャンネル名・説明にキーワードが含まれるだけの **非音楽チャンネル** が
ランキング上位に紛れ込む。

## 観測した誤検知

実 API テスト（`--keywords "lofi,focus music,作業用bgm,ambient piano"` / 直近 30 日 / subs 50K-5M）で:

| rank | channel | subs | 推定月再生 | 実態 |
|------|---------|------|-----------|------|
| 5 | [@lofihouse](https://www.youtube.com/@lofihouse) | 690K | 183K | **インテリア / DIY 系**（音楽ではない） |

`Lo-Fi House` というチャンネル名に "lofi" が含まれるだけで音楽系として hit してしまっている。
動画 categoryId による多数決でも、人間が categoryId を雑に付けるため精度に限界がある。

## やりたいこと

`channels.list part=topicDetails` で取得できる `topicCategories`
（freebase / Wikipedia URL ベースのチャンネル単位トピック）を活用して、
音楽トピック (`https://en.wikipedia.org/wiki/Music` および音楽サブジャンル) を含むチャンネルのみ通すフィルタを追加する。

### CLI

```bash
yt-discover-competitors \
  --keywords "lofi,focus music" \
  --require-music-topic \      # 既定: ON（音楽 topic 必須、空 topic は fail-open で通す）
  --no-require-music-topic \   # OFF: 従来挙動（topic フィルタ無し）
  ...
```

### 実装方針

1. 既存 `channels.list` 呼び出し（`utils/competitor_discovery.py:_fetch_channel_details`）の
   `part` に `topicDetails` を追加（API quota 増加なし、既存呼び出しの拡張）
2. `_apply_filters` の段階に `_apply_topic_filter` を追加（`require_music_topic=True` のときのみ作用）
3. **fail-open 設計**: `topicCategories` が空 (新規 / 小規模チャンネル等) の場合は通す。
   音楽トピック有無が判定可能な場合のみフィルタを効かせる
4. 音楽トピック判定は Wikipedia URL の prefix マッチで実装。最低限カバーする URL:
   - `https://en.wikipedia.org/wiki/Music`
   - `https://en.wikipedia.org/wiki/Electronic_music`
   - `https://en.wikipedia.org/wiki/Hip_hop_music`
   - `https://en.wikipedia.org/wiki/Pop_music`
   - `https://en.wikipedia.org/wiki/Rock_music`
   - `https://en.wikipedia.org/wiki/Classical_music`
   - `https://en.wikipedia.org/wiki/Independent_music`
   - `https://en.wikipedia.org/wiki/Jazz`
   - `https://en.wikipedia.org/wiki/Country_music`
   - `https://en.wikipedia.org/wiki/Soul_music`
   - `https://en.wikipedia.org/wiki/Reggae`

   定数として `_MUSIC_TOPIC_URLS: frozenset[str]` を `competitor_scoring.py` に置く。
5. 既定値は `--require-music-topic` ON（音楽系チャンネル発掘という主要ユースケースに最適化）

## 想定変更箇所

- `src/youtube_automation/utils/competitor_scoring.py`: `_MUSIC_TOPIC_URLS` 定数 + `_is_music_topic_match` ヘルパー
- `src/youtube_automation/utils/competitor_discovery.py`: `_fetch_channel_details` に `topicDetails` 追加、`CandidateChannel` に `topic_categories` フィールド追加
- `src/youtube_automation/scripts/discover_competitors.py`: `--require-music-topic` / `--no-require-music-topic` 追加、`_apply_filters` 経由で適用
- `tests/test_competitor_discovery.py` / `tests/test_discover_competitors_cli.py`: 音楽 topic ありなし、fail-open（空 topic は通す）等のテスト追加

## スコープ外

- 音楽以外のジャンル（料理 / ガジェット 等）対応は別 issue
- ジャンル別の重みづけや softer match（topic スコア化）は別 issue
- 動画 `categoryId` ベースのフォールバックは将来案として保留

## 効用

- 主要ユースケース（音楽系チャンネル発掘）での誤検知を構造的に低減
- API quota は増えない（既存 `channels.list` 呼び出しの `part` 拡張のみ）
- `--no-require-music-topic` で従来挙動も保持できるため後方互換あり

## Execution Report

Workflow `default` completed successfully.

Closes #120