### PR TITLE
[#123] issue-123-terraform-purojekuto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ build/
 
 # pytest 副作用: cost_tracker / lyria 系テストが sample_channel/data/ に書き残す（レビュー AI-NOTE-fixtures-data-leak）
 tests/fixtures/sample_channel/data/
+
+# Terraform
+terraform.tfvars
+*.tfstate
+*.tfstate.*
+.terraform/

--- a/infra/terraform/streaming/cloud-init.yaml
+++ b/infra/terraform/streaming/cloud-init.yaml
@@ -1,0 +1,18 @@
+#cloud-config
+package_update: true
+
+packages:
+  - ffmpeg
+
+write_files:
+  - path: /etc/systemd/system/youtube-stream.service
+    owner: 'root:root'
+    permissions: '0644'
+    content: |
+      ${indent(6, youtube_stream_service)}
+
+runcmd:
+  - install -d -o root -g root -m 0755 /opt/youtube-stream
+  - install -d -o root -g root -m 0755 /opt/youtube-stream/videos
+  - install -d -o root -g root -m 0755 /opt/youtube-stream/logs
+  - systemctl daemon-reload

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -12,4 +12,8 @@ resource "vultr_instance" "this" {
   tags     = ["youtube-stream"]
 
   ssh_key_ids = [vultr_ssh_key.this.id]
+
+  user_data = templatefile("${path.module}/cloud-init.yaml", {
+    youtube_stream_service = file("${path.module}/templates/youtube-stream.service.tftpl")
+  })
 }

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -1,0 +1,15 @@
+resource "vultr_ssh_key" "this" {
+  name    = "youtube-stream"
+  ssh_key = file(pathexpand(var.ssh_pub_key_path))
+}
+
+resource "vultr_instance" "this" {
+  region   = var.region
+  plan     = var.plan
+  os_id    = var.os_id
+  hostname = "youtube-stream"
+  label    = "youtube-stream"
+  tags     = ["youtube-stream"]
+
+  ssh_key_ids = [vultr_ssh_key.this.id]
+}

--- a/infra/terraform/streaming/outputs.tf
+++ b/infra/terraform/streaming/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_ip" {
+  description = "起動した Vultr VPS のパブリック IPv4 アドレス（ssh 接続先）"
+  value       = vultr_instance.this.main_ip
+}
+
+output "instance_id" {
+  description = "Vultr インスタンス ID（destroy / 個別操作時の識別子）"
+  value       = vultr_instance.this.id
+}

--- a/infra/terraform/streaming/templates/youtube-stream.service.tftpl
+++ b/infra/terraform/streaming/templates/youtube-stream.service.tftpl
@@ -1,0 +1,16 @@
+[Unit]
+Description=YouTube Live 24/7 streaming via FFmpeg
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/youtube-stream.env
+ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -c copy -f flv $RTMP_URL
+Restart=always
+RestartSec=5
+StandardOutput=append:/opt/youtube-stream/logs/ffmpeg.log
+StandardError=append:/opt/youtube-stream/logs/ffmpeg.log
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/terraform/streaming/terraform.tfvars.example
+++ b/infra/terraform/streaming/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# 使い方:
+#   cp terraform.tfvars.example terraform.tfvars
+#   <必要に応じて任意項目を有効化>
+#   export TF_VAR_vultr_api_key=$(op read 'op://Personal/Vultr/api_key')
+#   terraform -chdir=infra/terraform/streaming init
+#   terraform -chdir=infra/terraform/streaming apply
+#
+# 注意:
+#   vultr_api_key はこのファイルに書かない（terraform.tfvars は gitignore 対象だが
+#   うっかりコピーや bak が漏洩する事故を防ぐため、必ず環境変数 TF_VAR_vultr_api_key
+#   経由で渡す。1Password CLI からの注入を推奨）。
+
+# 任意（デフォルト値で運用するならコメントアウトのまま）
+# ssh_pub_key_path = "~/.ssh/yt_stream_key.pub"
+# region           = "nrt"
+# plan             = "vc2-1c-2gb"
+# os_id            = 2284

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -1,0 +1,29 @@
+variable "vultr_api_key" {
+  type        = string
+  description = "Vultr API key. TF_VAR_vultr_api_key 経由で 1Password から注入する想定（state にも残らないよう sensitive=true）"
+  sensitive   = true
+}
+
+variable "ssh_pub_key_path" {
+  type        = string
+  description = "Vultr に登録する SSH 公開鍵ファイルのパス（~ は pathexpand で展開される）"
+  default     = "~/.ssh/yt_stream_key.pub"
+}
+
+variable "region" {
+  type        = string
+  description = "Vultr リージョンコード（例: nrt = 東京）"
+  default     = "nrt"
+}
+
+variable "plan" {
+  type        = string
+  description = "Vultr プランコード（vc2-1c-2gb = $10/月, 1 vCPU, 2GB RAM, 55GB SSD, 2TB 帯域）"
+  default     = "vc2-1c-2gb"
+}
+
+variable "os_id" {
+  type        = number
+  description = "Ubuntu 24.04 LTS x64 の Vultr OS ID。Vultr API は integer を要求するため number 型で扱う"
+  default     = 2284
+}

--- a/infra/terraform/streaming/versions.tf
+++ b/infra/terraform/streaming/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "vultr" {
+  api_key = var.vultr_api_key
+}

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -3274,5 +3274,161 @@
       "segment": "seg_002",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_parallel_partial_failure0/seg_002.wav"
     }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:56.803474+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:56.876888+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.062733+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.235486+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.302476+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.463778+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.530657+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.693773+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.758375+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.924776+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:57.924850+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-01T01:41:58.089401+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-115/test_parallel_partial_failure0/seg_001.wav"
+    }
   }
 ]

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -2806,5 +2806,473 @@
       "segment": "seg_001",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-108/test_parallel_partial_failure0/seg_001.wav"
     }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:23.598019+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:23.665085+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:23.834672+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:23.996152+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.061289+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.227627+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.295084+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.459143+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.523952+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.687889+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.687993+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:07:24.849259+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-112/test_parallel_partial_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:18.851057+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:18.914978+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.077468+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.242753+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.306568+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.470806+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.534044+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.705673+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.770625+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.940414+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:19.940474+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:19:20.104443+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-113/test_parallel_partial_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:50.334454+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:50.400778+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:50.570790+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:50.730810+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:50.836284+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.031490+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.099005+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.263176+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.327094+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.497682+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.497737+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-04-30T14:21:51.665396+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-114/test_parallel_partial_failure0/seg_002.wav"
+    }
   }
 ]

--- a/tests/test_cloud_init.py
+++ b/tests/test_cloud_init.py
@@ -1,0 +1,563 @@
+"""infra/terraform/streaming/cloud-init.yaml と systemd unit テンプレートの構造検証テスト。
+
+issue #124 の order.md と plan.md に基づき、以下を検証する:
+
+- ``cloud-init.yaml``: ``#cloud-config`` 先頭 / ``package_update`` / ``packages`` /
+  ``runcmd`` での ``/opt/youtube-stream/{videos,logs}`` 作成 / ``daemon-reload`` /
+  ``write_files`` での systemd unit 配置 / ``${youtube_stream_service}`` プレースホルダ /
+  ``enable --now`` 不在 / secret 不在
+- ``templates/youtube-stream.service.tftpl``: 3 セクション存在 /
+  ``EnvironmentFile=/etc/youtube-stream.env`` / ``ExecStart`` リテラル一致 /
+  ``Restart=always`` / ``RestartSec=5`` / ``StandardOutput``/``StandardError`` /
+  ``WantedBy=multi-user.target`` / リテラル stream key / RTMP URL 不在
+- 結合: ``${youtube_stream_service}`` を unit テキストで実置換した結果が
+  PyYAML でパース可能（インデント破綻検出）
+
+terraform バイナリに依存せず、ファイルテキストを正規表現と PyYAML で
+構造検証する。実 ``terraform validate`` / ``apply`` は手動検証。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------- パス定数 ----------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_STREAMING_DIR = _REPO_ROOT / "infra" / "terraform" / "streaming"
+
+_CLOUD_INIT_YAML = _STREAMING_DIR / "cloud-init.yaml"
+_TEMPLATES_DIR = _STREAMING_DIR / "templates"
+_UNIT_TFTPL = _TEMPLATES_DIR / "youtube-stream.service.tftpl"
+
+
+# ---------- ヘルパー ----------
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        pytest.fail(f"必須ファイルが存在しない: {path.relative_to(_REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _render_terraform_indent(template_text: str, var_name: str, content: str) -> str:
+    """``${indent(N, var_name)}`` プレースホルダを Terraform 互換に展開する。
+
+    Terraform の ``indent(N, str)`` は ``str`` の 2 行目以降に N 個の空白を
+    プレフィックスする（1 行目はそのまま）。テンプレ側でプレースホルダ自体が
+    既にインデントされている前提で、結果として全行が同じ列に揃う。
+
+    本ヘルパーは ``${indent(<N>, <var_name>)}`` および ``${<var_name>}`` の
+    両方の記法を 1 度だけ展開する（テストとしての厳密さを保ちつつ、
+    実装側の細かな書き方差を吸収する）。
+    """
+
+    def _indent_replacer(match: re.Match[str]) -> str:
+        n = int(match.group(1))
+        first, *rest = content.splitlines()
+        if not rest:
+            return first
+        prefix = " " * n
+        return "\n".join([first, *[prefix + line for line in rest]])
+
+    pattern_indent = re.compile(r"\$\{\s*indent\(\s*(\d+)\s*,\s*" + re.escape(var_name) + r"\s*\)\s*\}")
+    rendered, replacements = pattern_indent.subn(_indent_replacer, template_text)
+    if replacements:
+        return rendered
+
+    # indent() を使わず素の ${var} 形式で書かれている場合のフォールバック
+    pattern_plain = re.compile(r"\$\{\s*" + re.escape(var_name) + r"\s*\}")
+    return pattern_plain.sub(content, template_text)
+
+
+# ---------- フィクスチャ ----------
+
+
+@pytest.fixture
+def cloud_init_text() -> str:
+    return _read(_CLOUD_INIT_YAML)
+
+
+@pytest.fixture
+def unit_text() -> str:
+    return _read(_UNIT_TFTPL)
+
+
+# ============================================================================
+# cloud-init.yaml: 先頭 / トップレベル構造
+# ============================================================================
+
+
+class TestCloudInitTopLevel:
+    """``cloud-init.yaml`` のトップレベル構造（cloud-config の必須要素）。"""
+
+    def test_cloud_init_yaml_exists(self):
+        """Given infra/terraform/streaming/
+        When cloud-init.yaml を探す
+        Then 存在する。
+        """
+        assert _CLOUD_INIT_YAML.exists(), f"必須ファイルが存在しない: {_CLOUD_INIT_YAML.relative_to(_REPO_ROOT)}"
+
+    def test_starts_with_cloud_config_header(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When 先頭行を読む
+        Then ``#cloud-config`` で始まる（cloud-init が user_data を YAML として認識する条件）。
+        """
+        first_line = cloud_init_text.splitlines()[0] if cloud_init_text else ""
+        assert first_line.strip() == "#cloud-config", f"先頭行が #cloud-config でない: {first_line!r}"
+
+    def test_package_update_is_true(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``package_update`` を探す
+        Then ``true`` に設定されている（apt update を実行）。
+        """
+        assert re.search(r"^\s*package_update\s*:\s*true\b", cloud_init_text, flags=re.MULTILINE), (
+            "package_update: true が宣言されていない"
+        )
+
+    def test_packages_includes_ffmpeg(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``packages:`` リストを読む
+        Then ``ffmpeg`` が含まれている。
+        """
+        # PyYAML でパースして packages を取り出す（template 部分を除いてパースできる箇所のみ確認）
+        # 実テンプレ展開後の検証は別テストで行うため、ここではパース不要な文字列レベルで確認する。
+        assert re.search(r"^\s*-\s*ffmpeg\b", cloud_init_text, flags=re.MULTILINE), (
+            "packages リストに ffmpeg が含まれていない"
+        )
+
+
+# ============================================================================
+# cloud-init.yaml: write_files / runcmd
+# ============================================================================
+
+
+class TestCloudInitWriteFiles:
+    """``write_files`` で systemd unit を ``/etc/systemd/system/youtube-stream.service`` に配置。"""
+
+    def test_write_files_targets_systemd_unit_path(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``write_files`` 配下の path を探す
+        Then ``/etc/systemd/system/youtube-stream.service`` が宣言されている。
+        """
+        assert re.search(
+            r"^\s*-?\s*path\s*:\s*/etc/systemd/system/youtube-stream\.service\b",
+            cloud_init_text,
+            flags=re.MULTILINE,
+        ), "write_files で /etc/systemd/system/youtube-stream.service が指定されていない"
+
+    def test_write_files_owner_root_root(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``write_files`` のエントリを読む
+        Then owner = ``root:root`` が設定されている（systemd unit の所有者）。
+        """
+        assert re.search(
+            r"^\s*owner\s*:\s*['\"]?root:root['\"]?\b",
+            cloud_init_text,
+            flags=re.MULTILINE,
+        ), "write_files の owner が root:root で設定されていない"
+
+    def test_write_files_permissions_0644(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``write_files`` の permissions を読む
+        Then ``0644``（systemd unit の標準パーミッション）。
+        """
+        assert re.search(
+            r"^\s*permissions\s*:\s*['\"]0644['\"]",
+            cloud_init_text,
+            flags=re.MULTILINE,
+        ), "write_files の permissions が '0644' でない"
+
+    def test_unit_content_uses_youtube_stream_service_placeholder(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``content:`` 配下のテキストを読む
+        Then ``${...youtube_stream_service...}`` プレースホルダで unit を流し込んでいる
+             （unit テキストを直書きしていない）。
+        """
+        # ${indent(6, youtube_stream_service)} もしくは ${youtube_stream_service} のいずれか
+        assert re.search(
+            r"\$\{[^}]*\byoutube_stream_service\b[^}]*\}",
+            cloud_init_text,
+        ), "${...youtube_stream_service...} プレースホルダが存在しない（unit が直書きされている可能性）"
+
+
+class TestCloudInitRuncmd:
+    """``runcmd`` で 3 ディレクトリ作成 + ``daemon-reload`` を実行。"""
+
+    def test_runcmd_creates_videos_directory(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``runcmd`` を読む
+        Then ``/opt/youtube-stream/videos`` を root:root, 0755 で作成するコマンドがある。
+        """
+        # `install -d` でも `mkdir -p && chown && chmod` でも、`/opt/youtube-stream/videos`
+        # を作成する行があれば良い（最終状態で root:root 0755 になっていること）
+        assert re.search(
+            r"/opt/youtube-stream/videos\b",
+            cloud_init_text,
+        ), "runcmd で /opt/youtube-stream/videos を作成していない"
+
+    def test_runcmd_creates_logs_directory(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``runcmd`` を読む
+        Then ``/opt/youtube-stream/logs`` を作成するコマンドがある。
+        """
+        assert re.search(
+            r"/opt/youtube-stream/logs\b",
+            cloud_init_text,
+        ), "runcmd で /opt/youtube-stream/logs を作成していない"
+
+    def test_runcmd_directories_are_root_owned_with_0755(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``runcmd`` のディレクトリ作成コマンドを読む
+        Then root 所有 + mode 0755 の指示が含まれている。
+
+        ``install -d -o root -g root -m 0755 ...`` 形式、
+        または ``mkdir -p ... && chown root:root ... && chmod 0755 ...`` 形式の
+        いずれかが許容される。
+        """
+        # `install -d` を 1 行でも使っていれば owner/group/mode が同時指定されているはず
+        has_install_form = re.search(
+            r"install\s+-d\s+(?:-[ogm]\s+\S+\s+){2,}",
+            cloud_init_text,
+        )
+        # フォールバック: mkdir + chown + chmod の組み合わせ
+        has_explicit_mode = "0755" in cloud_init_text and re.search(
+            r"chown\s+root:root\b",
+            cloud_init_text,
+        )
+        assert has_install_form or has_explicit_mode, "ディレクトリ作成で root:root / 0755 を保証する指示がない"
+
+    def test_runcmd_calls_daemon_reload(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``runcmd`` を読む
+        Then ``systemctl daemon-reload`` を呼んでいる（unit 配置後の必須手順）。
+        """
+        assert re.search(
+            r"systemctl\s+daemon-reload\b",
+            cloud_init_text,
+        ), "runcmd に systemctl daemon-reload が無い"
+
+
+# ============================================================================
+# cloud-init.yaml: スコープ外項目の不在 / secret 不在
+# ============================================================================
+
+
+class TestCloudInitOutOfScopeAbsence:
+    """次 issue 担当の項目が混入していないこと。"""
+
+    def test_does_not_enable_youtube_stream_service(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``systemctl enable`` の文字列を探す
+        Then 存在しない（``enable --now`` は次 issue で追加する）。
+
+        本 issue で enable してしまうと .env / 動画未配置のまま起動失敗ループに入る。
+        """
+        # `systemctl enable` も `enable --now` も書かない
+        assert not re.search(
+            r"systemctl\s+enable\b",
+            cloud_init_text,
+        ), "systemctl enable が含まれている（次 issue 担当項目を先取りしてはならない）"
+        assert "--now" not in cloud_init_text, "--now が含まれている（次 issue 担当項目を先取りしてはならない）"
+
+    def test_does_not_write_youtube_stream_env(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When ``/etc/youtube-stream.env`` への ``write_files`` を探す
+        Then 存在しない（.env 配置は次 issue 担当）。
+
+        write_files の path として ``/etc/youtube-stream.env`` が出現してはいけない。
+        unit 内の ``EnvironmentFile=/etc/youtube-stream.env`` は宣言なので OK。
+        """
+        assert not re.search(
+            r"^\s*-?\s*path\s*:\s*/etc/youtube-stream\.env\b",
+            cloud_init_text,
+            flags=re.MULTILINE,
+        ), "write_files で /etc/youtube-stream.env を書いている（次 issue 担当）"
+
+
+class TestCloudInitNoSecrets:
+    """``user_data`` に secret が含まれないこと（plan 差分でも露出しない要件）。"""
+
+    def test_does_not_contain_rtmp_url(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When 本文を走査する
+        Then ``rtmp://`` / ``rtmps://`` で始まる URL が含まれない。
+        """
+        assert "rtmp://" not in cloud_init_text, "rtmp:// URL が含まれている（secret 漏洩リスク）"
+        assert "rtmps://" not in cloud_init_text, "rtmps:// URL が含まれている（secret 漏洩リスク）"
+
+    def test_does_not_contain_youtube_live_endpoint(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When 本文を走査する
+        Then YouTube Live RTMP のエンドポイント（``a.rtmp.youtube.com`` 等）が含まれない。
+        """
+        assert "rtmp.youtube.com" not in cloud_init_text, "rtmp.youtube.com が含まれている（secret 漏洩リスク）"
+
+    def test_does_not_contain_stream_key_assignment(self, cloud_init_text: str):
+        """Given cloud-init.yaml
+        When 本文を走査する
+        Then ``stream_key=`` / ``STREAM_KEY=`` 形式の代入が含まれない。
+        """
+        assert not re.search(
+            r"\b(stream[_-]?key|STREAM[_-]?KEY)\s*[:=]\s*\S",
+            cloud_init_text,
+        ), "stream_key 代入が含まれている（secret 漏洩リスク）"
+
+
+# ============================================================================
+# youtube-stream.service.tftpl: セクション構造
+# ============================================================================
+
+
+class TestUnitTftplSections:
+    """systemd unit の ``[Unit]`` / ``[Service]`` / ``[Install]`` セクション。"""
+
+    def test_unit_tftpl_exists(self):
+        """Given infra/terraform/streaming/templates/
+        When youtube-stream.service.tftpl を探す
+        Then 存在する。
+        """
+        assert _UNIT_TFTPL.exists(), f"必須ファイルが存在しない: {_UNIT_TFTPL.relative_to(_REPO_ROOT)}"
+
+    def test_unit_section_exists(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Unit]`` セクションを探す
+        Then 存在する。
+        """
+        assert re.search(r"^\[Unit\]\s*$", unit_text, flags=re.MULTILINE), "[Unit] セクションが存在しない"
+
+    def test_service_section_exists(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを探す
+        Then 存在する。
+        """
+        assert re.search(r"^\[Service\]\s*$", unit_text, flags=re.MULTILINE), "[Service] セクションが存在しない"
+
+    def test_install_section_exists(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Install]`` セクションを探す
+        Then 存在する。
+        """
+        assert re.search(r"^\[Install\]\s*$", unit_text, flags=re.MULTILINE), "[Install] セクションが存在しない"
+
+
+class TestUnitTftplUnitDirectives:
+    """``[Unit]`` セクションのディレクティブ。"""
+
+    def test_unit_has_description(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Unit]`` セクションを読む
+        Then ``Description=`` が宣言されている（systemd ベストプラクティス）。
+        """
+        assert re.search(r"^Description=.+$", unit_text, flags=re.MULTILINE), "Description= が無い"
+
+    def test_unit_after_network_online(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Unit]`` セクションを読む
+        Then ``After=network-online.target`` が宣言されている（NW 待機）。
+        """
+        assert re.search(
+            r"^After=.*\bnetwork-online\.target\b",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "After=network-online.target が無い"
+
+    def test_unit_wants_network_online(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Unit]`` セクションを読む
+        Then ``Wants=network-online.target`` が宣言されている。
+
+        ``After`` だけだとターゲットが pulled in されない場合があるため
+        ``Wants`` でも要求する。
+        """
+        assert re.search(
+            r"^Wants=.*\bnetwork-online\.target\b",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "Wants=network-online.target が無い"
+
+
+class TestUnitTftplServiceDirectives:
+    """``[Service]`` セクションのディレクティブ。"""
+
+    def test_service_type_simple(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``Type=simple`` が宣言されている（fork しない長期プロセス）。
+        """
+        assert re.search(r"^Type=simple\s*$", unit_text, flags=re.MULTILINE), "Type=simple が無い"
+
+    def test_service_environment_file_path(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``EnvironmentFile=/etc/youtube-stream.env`` が宣言されている
+             （stream key を unit 内に直書きしないための要）。
+        """
+        assert re.search(
+            r"^EnvironmentFile=/etc/youtube-stream\.env\s*$",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "EnvironmentFile=/etc/youtube-stream.env が無い（secret 隔離が機能しない）"
+
+    def test_service_exec_start_literal(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -c copy -f flv $RTMP_URL``
+             がリテラル一致する（order.md で明示された形）。
+        """
+        expected = "ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -c copy -f flv $RTMP_URL"
+        # 行末の余分な空白は許容するが本体はリテラル一致
+        assert re.search(
+            r"^" + re.escape(expected) + r"\s*$",
+            unit_text,
+            flags=re.MULTILINE,
+        ), f"ExecStart が指定リテラルと一致しない（期待: {expected!r}）"
+
+    def test_service_restart_always(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``Restart=always`` が宣言されている（プロセス死活で自動再起動）。
+        """
+        assert re.search(r"^Restart=always\s*$", unit_text, flags=re.MULTILINE), "Restart=always が無い"
+
+    def test_service_restart_sec_5(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``RestartSec=5`` が宣言されている（リトライ間隔）。
+        """
+        assert re.search(r"^RestartSec=5\s*$", unit_text, flags=re.MULTILINE), "RestartSec=5 が無い"
+
+    def test_service_standard_output_appends_log(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``StandardOutput=append:/opt/youtube-stream/logs/ffmpeg.log`` が宣言されている。
+        """
+        assert re.search(
+            r"^StandardOutput=append:/opt/youtube-stream/logs/ffmpeg\.log\s*$",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "StandardOutput=append:/opt/youtube-stream/logs/ffmpeg.log が無い"
+
+    def test_service_standard_error_appends_log(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Service]`` セクションを読む
+        Then ``StandardError=append:/opt/youtube-stream/logs/ffmpeg.log`` が宣言されている。
+        """
+        assert re.search(
+            r"^StandardError=append:/opt/youtube-stream/logs/ffmpeg\.log\s*$",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "StandardError=append:/opt/youtube-stream/logs/ffmpeg.log が無い"
+
+
+class TestUnitTftplInstallDirectives:
+    """``[Install]`` セクションのディレクティブ。"""
+
+    def test_install_wanted_by_multi_user(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When ``[Install]`` セクションを読む
+        Then ``WantedBy=multi-user.target`` が宣言されている。
+        """
+        assert re.search(
+            r"^WantedBy=multi-user\.target\s*$",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "WantedBy=multi-user.target が無い"
+
+
+class TestUnitTftplNoSecrets:
+    """unit テンプレに secret が含まれないこと（``ExecStart`` 直書き禁止の検証）。"""
+
+    def test_no_rtmp_url_literal(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When 本文を走査する
+        Then ``rtmp://`` / ``rtmps://`` URL が含まれない。
+        """
+        assert "rtmp://" not in unit_text, "unit に rtmp:// URL がリテラル含まれている"
+        assert "rtmps://" not in unit_text, "unit に rtmps:// URL がリテラル含まれている"
+
+    def test_no_youtube_live_endpoint(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When 本文を走査する
+        Then ``rtmp.youtube.com`` が含まれない。
+        """
+        assert "rtmp.youtube.com" not in unit_text, "unit に rtmp.youtube.com がリテラル含まれている"
+
+    def test_no_stream_key_value(self, unit_text: str):
+        """Given youtube-stream.service.tftpl
+        When 本文を走査する
+        Then ``$VIDEO`` / ``$RTMP_URL`` 以外の変数代入や stream key 値が含まれない。
+
+        ``Environment=KEY=VALUE`` 形式での値直書きは EnvironmentFile 方針に反する。
+        """
+        # `Environment=` で値を直接設定していないこと（EnvironmentFile= は別キーなので OK）
+        assert not re.search(
+            r"^Environment=\S",
+            unit_text,
+            flags=re.MULTILINE,
+        ), "Environment= で値を直書きしている（EnvironmentFile= に統一すべき）"
+
+
+# ============================================================================
+# 結合: cloud-init.yaml + unit を実置換した結果が valid YAML
+# ============================================================================
+
+
+class TestCloudInitWithUnitRendersValidYaml:
+    """``${...youtube_stream_service...}`` を unit テキストで置換した結果が PyYAML でパース可能。"""
+
+    def test_rendered_cloud_init_is_valid_yaml(self, cloud_init_text: str, unit_text: str):
+        """Given cloud-init.yaml + youtube-stream.service.tftpl
+        When ``${indent(6, youtube_stream_service)}`` を unit で置換する
+        Then PyYAML で構文エラーなくパースできる（インデント破綻が無い）。
+        """
+        rendered = _render_terraform_indent(cloud_init_text, "youtube_stream_service", unit_text)
+        try:
+            data = yaml.safe_load(rendered)
+        except yaml.YAMLError as exc:
+            pytest.fail(f"render 後の cloud-init.yaml が valid YAML でない: {exc}")
+        assert isinstance(data, dict), "render 後のトップレベルが mapping でない"
+
+    def test_rendered_yaml_packages_includes_ffmpeg(self, cloud_init_text: str, unit_text: str):
+        """Given render 済み cloud-init.yaml
+        When ``packages`` フィールドを読む
+        Then list 形式で ``ffmpeg`` を含む。
+        """
+        rendered = _render_terraform_indent(cloud_init_text, "youtube_stream_service", unit_text)
+        data = yaml.safe_load(rendered)
+        packages = data.get("packages")
+        assert isinstance(packages, list), "packages が list でない"
+        assert "ffmpeg" in packages, f"packages に ffmpeg が含まれない: {packages!r}"
+
+    def test_rendered_yaml_write_files_contains_unit_content(self, cloud_init_text: str, unit_text: str):
+        """Given render 済み cloud-init.yaml
+        When ``write_files`` の content フィールドを読む
+        Then ``ExecStart=/usr/bin/ffmpeg ...`` が完全な行として含まれる。
+
+        プレースホルダ展開後に unit の中身が破損なく流し込まれていることの最終チェック。
+        """
+        rendered = _render_terraform_indent(cloud_init_text, "youtube_stream_service", unit_text)
+        data = yaml.safe_load(rendered)
+        write_files = data.get("write_files")
+        assert isinstance(write_files, list) and write_files, "write_files が list でないか空"
+        # /etc/systemd/system/youtube-stream.service エントリを探す
+        unit_entry = next(
+            (
+                entry
+                for entry in write_files
+                if isinstance(entry, dict) and entry.get("path") == "/etc/systemd/system/youtube-stream.service"
+            ),
+            None,
+        )
+        assert unit_entry is not None, "write_files に /etc/systemd/system/youtube-stream.service エントリが無い"
+        content = unit_entry.get("content", "")
+        assert "ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -c copy -f flv $RTMP_URL" in content, (
+            "render 後の unit content に ExecStart リテラルが含まれない（インデント破綻の可能性）"
+        )
+        assert "EnvironmentFile=/etc/youtube-stream.env" in content, (
+            "render 後の unit content に EnvironmentFile= が含まれない"
+        )

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -322,6 +322,66 @@ class TestMainTf:
         assert block is not None
         assert re.search(r'hostname\s*=\s*"youtube-stream"', block), 'hostname = "youtube-stream" が設定されていない'
 
+    def test_vultr_instance_user_data_uses_templatefile_for_cloud_init(self):
+        """Given main.tf
+        When vultr_instance.this.user_data を読む
+        Then ``templatefile("${path.module}/cloud-init.yaml", {...})`` 経由で
+             cloud-init.yaml が渡されている（issue #124 要件）。
+
+        ``${path.module}`` を必ず付け、``-chdir`` 実行で相対パスが崩れないようにする。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None, 'resource "vultr_instance" "this" が存在しない'
+        assert re.search(
+            r"user_data\s*=\s*templatefile\(\s*\"\$\{path\.module\}/cloud-init\.yaml\"",
+            block,
+        ), 'user_data が templatefile("${path.module}/cloud-init.yaml", ...) で結線されていない'
+
+    def test_vultr_instance_user_data_passes_unit_via_file_function(self):
+        """Given main.tf
+        When vultr_instance.this.user_data の templatefile 第 2 引数を読む
+        Then ``youtube_stream_service = file("${path.module}/templates/youtube-stream.service.tftpl")``
+             で systemd unit テンプレを読み込んで cloud-init に渡している。
+
+        unit 側に Terraform 補間 (``${...}``) は無いため ``templatefile`` ではなく
+        ``file`` を使う（補間を持たない静的ファイルは ``file`` で読む原則）。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(
+            r"youtube_stream_service\s*=\s*file\(\s*\"\$\{path\.module\}/templates/youtube-stream\.service\.tftpl\"\s*\)",
+            block,
+        ), 'youtube_stream_service が file("${path.module}/templates/youtube-stream.service.tftpl") で渡されていない'
+
+    def test_vultr_instance_user_data_does_not_inline_cloud_init_yaml(self):
+        """Given main.tf
+        When vultr_instance.this.user_data を読む
+        Then ``<<EOT ... EOT`` / ``<<-EOT ... EOT`` のヒアドキュメントで cloud-init を
+             直書きしていない（order.md「templatefile 経由」要件違反の検出）。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert not re.search(
+            r"user_data\s*=\s*<<-?[A-Z]+",
+            block,
+        ), "user_data がヒアドキュメントで直書きされている（templatefile 経由でなければならない）"
+
+    def test_vultr_instance_user_data_does_not_contain_secret_strings(self):
+        """Given main.tf
+        When vultr_instance.this.user_data 周辺を読む
+        Then secret（rtmp URL / stream key）が直書きされていない
+             （plan 差分でも露出しない要件）。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert "rtmp://" not in block, "main.tf の vultr_instance に rtmp:// URL が含まれている"
+        assert "rtmps://" not in block, "main.tf の vultr_instance に rtmps:// URL が含まれている"
+        assert "rtmp.youtube.com" not in block, "main.tf の vultr_instance に rtmp.youtube.com が含まれている"
+
 
 # ============================================================================
 # outputs.tf

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -1,0 +1,442 @@
+"""infra/terraform/streaming の Terraform 構成のスペック準拠テスト。
+
+issue #123 の order.md と plan.md に基づき、以下を検証する:
+
+- ``versions.tf``: ``vultr/vultr`` provider 宣言と provider ブロック
+- ``variables.tf``: 5 変数の型/default/sensitive
+- ``main.tf``: ``vultr_ssh_key`` + ``vultr_instance`` の構造と紐付け
+- ``outputs.tf``: ``instance_ip`` / ``instance_id`` の expose
+- ``terraform.tfvars.example``: secret を平文で含まない
+- ルート ``.gitignore``: Terraform 系の ignore エントリ
+
+terraform バイナリに依存せず、``.tf`` ファイルのテキストを正規表現で
+構造検証する。実 ``terraform validate`` / ``apply`` は手動検証。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------- パス定数 ----------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_STREAMING_DIR = _REPO_ROOT / "infra" / "terraform" / "streaming"
+
+_VERSIONS_TF = _STREAMING_DIR / "versions.tf"
+_VARIABLES_TF = _STREAMING_DIR / "variables.tf"
+_MAIN_TF = _STREAMING_DIR / "main.tf"
+_OUTPUTS_TF = _STREAMING_DIR / "outputs.tf"
+_TFVARS_EXAMPLE = _STREAMING_DIR / "terraform.tfvars.example"
+_ROOT_GITIGNORE = _REPO_ROOT / ".gitignore"
+
+
+# ---------- ヘルパー ----------
+
+
+def _strip_hcl_comments(text: str) -> str:
+    """行コメント (``#`` / ``//``) と ``/* ... */`` ブロックコメントを除去する。
+
+    HCL の構文解析はせず、コメント行で false-positive のマッチを起こさないための前処理。
+    文字列リテラル内の ``#`` などは想定しない（本テスト対象の HCL は素直な構造のみ）。
+    """
+    # ブロックコメント (greedy にならないよう非貪欲)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    # 行コメント
+    cleaned_lines: list[str] = []
+    for line in text.splitlines():
+        # `#` が文字列内にあるケースは本テストの対象 HCL では発生しないため単純に切る
+        for marker in ("#", "//"):
+            idx = line.find(marker)
+            if idx >= 0:
+                line = line[:idx]
+        cleaned_lines.append(line)
+    return "\n".join(cleaned_lines)
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        pytest.fail(f"必須ファイルが存在しない: {path.relative_to(_REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_block(text: str, header_pattern: str) -> str | None:
+    """``header { ... }`` または ``header = { ... }`` のトップレベルブロックを 1 つ抜き出す。
+
+    ``header_pattern`` は header 行（``{`` 直前まで）にマッチする正規表現。
+    ネストした ``{ }`` を 1 段までカウントしてマッチ範囲を確定する。
+    HCL の ``required_providers`` 内は ``name = { ... }``（オブジェクトリテラル）
+    形式のため、ヘッダーと ``{`` の間に任意で ``=`` を許容する。
+    """
+    match = re.search(header_pattern + r"\s*=?\s*\{", text)
+    if not match:
+        return None
+    start = match.end()  # `{` の直後
+    depth = 1
+    for i in range(start, len(text)):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i]
+    return None
+
+
+# ============================================================================
+# versions.tf
+# ============================================================================
+
+
+class TestVersionsTf:
+    """``versions.tf`` の terraform / required_providers / provider 宣言。"""
+
+    def test_required_version_is_at_least_1_5(self):
+        """Given versions.tf
+        When terraform ブロックを読む
+        Then required_version は ">= 1.5" を含む（既存 gcp/versions.tf と同じ最低保証）。
+        """
+        text = _strip_hcl_comments(_read(_VERSIONS_TF))
+        terraform_block = _extract_block(text, r"terraform")
+        assert terraform_block is not None, "terraform { ... } ブロックが存在しない"
+        assert re.search(r'required_version\s*=\s*"[^"]*>=\s*1\.5', terraform_block), (
+            "required_version が >= 1.5 を含んでいない"
+        )
+
+    def test_required_providers_declares_vultr_source(self):
+        """Given versions.tf
+        When required_providers ブロックを読む
+        Then vultr.source = "vultr/vultr" が宣言されている。
+        """
+        text = _strip_hcl_comments(_read(_VERSIONS_TF))
+        terraform_block = _extract_block(text, r"terraform")
+        assert terraform_block is not None
+        rp_block = _extract_block(terraform_block, r"required_providers")
+        assert rp_block is not None, "required_providers ブロックが存在しない"
+        vultr_block = _extract_block(rp_block, r"vultr")
+        assert vultr_block is not None, "required_providers.vultr が宣言されていない"
+        assert re.search(r'source\s*=\s*"vultr/vultr"', vultr_block), (
+            'required_providers.vultr.source が "vultr/vultr" でない'
+        )
+
+    def test_required_providers_vultr_version_at_least_2(self):
+        """Given versions.tf
+        When required_providers.vultr.version を読む
+        Then ">= 2" を含む制約が宣言されている（order.md「>= 2.x」）。
+        """
+        text = _strip_hcl_comments(_read(_VERSIONS_TF))
+        terraform_block = _extract_block(text, r"terraform")
+        assert terraform_block is not None
+        rp_block = _extract_block(terraform_block, r"required_providers")
+        assert rp_block is not None
+        vultr_block = _extract_block(rp_block, r"vultr")
+        assert vultr_block is not None
+        assert re.search(r'version\s*=\s*"[^"]*>=\s*2', vultr_block), (
+            "required_providers.vultr.version が >= 2 を満たしていない"
+        )
+
+    def test_provider_vultr_block_uses_var_api_key(self):
+        """Given versions.tf
+        When provider "vultr" ブロックを読む
+        Then api_key = var.vultr_api_key が結線されている。
+
+        secret を hardcode せず変数経由で受け取る最重要要件。
+        """
+        text = _strip_hcl_comments(_read(_VERSIONS_TF))
+        provider_block = _extract_block(text, r'provider\s+"vultr"')
+        assert provider_block is not None, 'provider "vultr" ブロックが存在しない'
+        assert re.search(r"api_key\s*=\s*var\.vultr_api_key", provider_block), (
+            "provider.vultr.api_key が var.vultr_api_key を参照していない"
+        )
+
+
+# ============================================================================
+# variables.tf
+# ============================================================================
+
+
+class TestVariablesTf:
+    """``variables.tf`` の 5 変数定義。"""
+
+    def test_vultr_api_key_is_sensitive_and_has_no_default(self):
+        """Given variables.tf
+        When vultr_api_key 変数定義を読む
+        Then sensitive = true でかつ default は宣言されていない（Fail Fast）。
+        """
+        text = _strip_hcl_comments(_read(_VARIABLES_TF))
+        block = _extract_block(text, r'variable\s+"vultr_api_key"')
+        assert block is not None, 'variable "vultr_api_key" が存在しない'
+        assert re.search(r"type\s*=\s*string", block), "vultr_api_key.type が string でない"
+        assert re.search(r"sensitive\s*=\s*true", block), "vultr_api_key.sensitive = true が無い"
+        assert re.search(r"description\s*=", block), "vultr_api_key.description が無い"
+        assert not re.search(r"\bdefault\s*=", block), (
+            "vultr_api_key には default を設定してはならない（Fail Fast 原則）"
+        )
+
+    def test_ssh_pub_key_path_default_is_yt_stream_key_pub(self):
+        """Given variables.tf
+        When ssh_pub_key_path 変数定義を読む
+        Then default が "~/.ssh/yt_stream_key.pub"。
+        """
+        text = _strip_hcl_comments(_read(_VARIABLES_TF))
+        block = _extract_block(text, r'variable\s+"ssh_pub_key_path"')
+        assert block is not None, 'variable "ssh_pub_key_path" が存在しない'
+        assert re.search(r"type\s*=\s*string", block), "ssh_pub_key_path.type が string でない"
+        assert re.search(r'default\s*=\s*"~/\.ssh/yt_stream_key\.pub"', block), (
+            'ssh_pub_key_path.default が "~/.ssh/yt_stream_key.pub" でない'
+        )
+        assert re.search(r"description\s*=", block), "ssh_pub_key_path.description が無い"
+
+    def test_region_default_is_nrt(self):
+        """Given variables.tf
+        When region 変数定義を読む
+        Then default が "nrt"（東京）。
+        """
+        text = _strip_hcl_comments(_read(_VARIABLES_TF))
+        block = _extract_block(text, r'variable\s+"region"')
+        assert block is not None, 'variable "region" が存在しない'
+        assert re.search(r"type\s*=\s*string", block), "region.type が string でない"
+        assert re.search(r'default\s*=\s*"nrt"', block), 'region.default が "nrt" でない'
+        assert re.search(r"description\s*=", block), "region.description が無い"
+
+    def test_plan_default_is_vc2_1c_2gb(self):
+        """Given variables.tf
+        When plan 変数定義を読む
+        Then default が "vc2-1c-2gb"（$10/月、2GB RAM）。
+        """
+        text = _strip_hcl_comments(_read(_VARIABLES_TF))
+        block = _extract_block(text, r'variable\s+"plan"')
+        assert block is not None, 'variable "plan" が存在しない'
+        assert re.search(r"type\s*=\s*string", block), "plan.type が string でない"
+        assert re.search(r'default\s*=\s*"vc2-1c-2gb"', block), 'plan.default が "vc2-1c-2gb" でない'
+        assert re.search(r"description\s*=", block), "plan.description が無い"
+
+    def test_os_id_is_number_type_with_ubuntu_24_04_default(self):
+        """Given variables.tf
+        When os_id 変数定義を読む
+        Then type が number でかつ default が 2284（Ubuntu 24.04 LTS x64 の Vultr OS ID）。
+        """
+        text = _strip_hcl_comments(_read(_VARIABLES_TF))
+        block = _extract_block(text, r'variable\s+"os_id"')
+        assert block is not None, 'variable "os_id" が存在しない'
+        assert re.search(r"type\s*=\s*number", block), "os_id.type が number でない（API は integer）"
+        assert re.search(r"default\s*=\s*2284\b", block), "os_id.default が 2284 でない"
+        assert re.search(r"description\s*=", block), "os_id.description が無い（マジックナンバー禁止）"
+
+
+# ============================================================================
+# main.tf
+# ============================================================================
+
+
+class TestMainTf:
+    """``main.tf`` の vultr_ssh_key + vultr_instance 定義。"""
+
+    def test_vultr_ssh_key_resource_uses_pathexpand(self):
+        """Given main.tf
+        When vultr_ssh_key.this を読む
+        Then ssh_key = file(pathexpand(var.ssh_pub_key_path))。
+
+        ``~`` 展開のため file() の前段に pathexpand() を必ず噛ませる必要がある。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_ssh_key"\s+"this"')
+        assert block is not None, 'resource "vultr_ssh_key" "this" が存在しない'
+        assert re.search(
+            r"ssh_key\s*=\s*file\(\s*pathexpand\(\s*var\.ssh_pub_key_path\s*\)\s*\)",
+            block,
+        ), "ssh_key が file(pathexpand(var.ssh_pub_key_path)) でない（~ 未展開のリスク）"
+
+    def test_vultr_instance_resource_exists(self):
+        """Given main.tf
+        When vultr_instance.this を探す
+        Then 定義されている。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None, 'resource "vultr_instance" "this" が存在しない'
+
+    def test_vultr_instance_references_variables(self):
+        """Given main.tf
+        When vultr_instance.this の region/plan/os_id を読む
+        Then すべて var.* で結線されている（ハードコード禁止）。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(r"region\s*=\s*var\.region", block), "instance.region が var.region でない"
+        assert re.search(r"plan\s*=\s*var\.plan", block), "instance.plan が var.plan でない"
+        assert re.search(r"os_id\s*=\s*var\.os_id", block), "instance.os_id が var.os_id でない"
+
+    def test_vultr_instance_ssh_key_ids_links_ssh_key_resource(self):
+        """Given main.tf
+        When vultr_instance.this.ssh_key_ids を読む
+        Then [vultr_ssh_key.this.id] で SSH 鍵リソースに結線されている。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(
+            r"ssh_key_ids\s*=\s*\[\s*vultr_ssh_key\.this\.id\s*\]",
+            block,
+        ), "ssh_key_ids が [vultr_ssh_key.this.id] でない（SSH 鍵未紐付け）"
+
+    def test_vultr_instance_uses_plural_tags_not_deprecated_tag(self):
+        """Given main.tf
+        When vultr_instance.this を読む
+        Then 単数 tag ではなく複数 tags を使い、"youtube-stream" を含む。
+
+        Vultr provider v2.x で単数 tag は非推奨。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(r"\btags\s*=\s*\[", block), "tags 属性（複数形）が無い"
+        assert re.search(r'tags\s*=\s*\[\s*"youtube-stream"\s*\]', block), 'tags = ["youtube-stream"] の形式でない'
+        # 旧属性 `tag = "..."`（単一文字列）を使っていないこと
+        assert not re.search(r'(?<!s)\btag\s*=\s*"', block), "旧形式の単数 tag を使っている（Vultr v2.x で非推奨）"
+
+    def test_vultr_instance_label_is_youtube_stream(self):
+        """Given main.tf
+        When vultr_instance.this.label を読む
+        Then "youtube-stream" が設定されている（運用識別用）。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(r'label\s*=\s*"youtube-stream"', block), 'label = "youtube-stream" が設定されていない'
+
+    def test_vultr_instance_hostname_is_youtube_stream(self):
+        """Given main.tf
+        When vultr_instance.this.hostname を読む
+        Then "youtube-stream" が設定されている（運用識別用、label/tags と網羅対称）。
+
+        plan §実装アプローチ 4 / coder-decisions §3 で確定された運用識別子であり、
+        誤って削除・改変された場合のリグレッションを検出する。
+        """
+        text = _strip_hcl_comments(_read(_MAIN_TF))
+        block = _extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        assert re.search(r'hostname\s*=\s*"youtube-stream"', block), 'hostname = "youtube-stream" が設定されていない'
+
+
+# ============================================================================
+# outputs.tf
+# ============================================================================
+
+
+class TestOutputsTf:
+    """``outputs.tf`` の instance_ip / instance_id expose。"""
+
+    def test_instance_ip_outputs_main_ip_with_description(self):
+        """Given outputs.tf
+        When output "instance_ip" を読む
+        Then value = vultr_instance.this.main_ip でかつ description が付いている。
+        """
+        text = _strip_hcl_comments(_read(_OUTPUTS_TF))
+        block = _extract_block(text, r'output\s+"instance_ip"')
+        assert block is not None, 'output "instance_ip" が存在しない'
+        assert re.search(r"value\s*=\s*vultr_instance\.this\.main_ip", block), (
+            "instance_ip.value が vultr_instance.this.main_ip でない"
+        )
+        assert re.search(r"description\s*=", block), "instance_ip.description が無い"
+
+    def test_instance_id_outputs_instance_id_with_description(self):
+        """Given outputs.tf
+        When output "instance_id" を読む
+        Then value = vultr_instance.this.id でかつ description が付いている。
+        """
+        text = _strip_hcl_comments(_read(_OUTPUTS_TF))
+        block = _extract_block(text, r'output\s+"instance_id"')
+        assert block is not None, 'output "instance_id" が存在しない'
+        assert re.search(r"value\s*=\s*vultr_instance\.this\.id\b", block), (
+            "instance_id.value が vultr_instance.this.id でない"
+        )
+        assert re.search(r"description\s*=", block), "instance_id.description が無い"
+
+
+# ============================================================================
+# terraform.tfvars.example
+# ============================================================================
+
+
+class TestTfvarsExample:
+    """``terraform.tfvars.example`` の secret 漏洩防止。"""
+
+    def test_example_file_exists(self):
+        """Given infra/terraform/streaming/
+        When terraform.tfvars.example を探す
+        Then 存在する（cp して使うサンプル）。
+        """
+        assert _TFVARS_EXAMPLE.exists(), "terraform.tfvars.example が存在しない"
+
+    def test_does_not_contain_vultr_api_key_assignment(self):
+        """Given terraform.tfvars.example
+        When ファイル内容を読む
+        Then ``vultr_api_key = "..."`` の代入が（コメントを除いて）存在しない。
+
+        secret は TF_VAR_vultr_api_key 経由で渡す前提で、サンプルにも値を書かない。
+        """
+        text = _strip_hcl_comments(_read(_TFVARS_EXAMPLE))
+        # コメント除去後に `vultr_api_key = ...` が残っていないこと
+        assert not re.search(r"^\s*vultr_api_key\s*=", text, flags=re.MULTILINE), (
+            "vultr_api_key の代入がアクティブ行に存在する（secret 漏洩リスク）"
+        )
+
+    def test_mentions_tf_var_vultr_api_key_in_comments(self):
+        """Given terraform.tfvars.example
+        When ファイル内容（コメント込み）を読む
+        Then TF_VAR_vultr_api_key の使い方がコメントに記載されている。
+        """
+        raw = _read(_TFVARS_EXAMPLE)
+        assert "TF_VAR_vultr_api_key" in raw, (
+            "TF_VAR_vultr_api_key の案内コメントが無い（運用者が secret 注入方法を発見できない）"
+        )
+
+
+# ============================================================================
+# ルート .gitignore
+# ============================================================================
+
+
+class TestRootGitignoreTerraformEntries:
+    """ルート ``.gitignore`` に Terraform 系の ignore エントリ。"""
+
+    @pytest.fixture
+    def gitignore_lines(self) -> list[str]:
+        """空白除去・空行除外した非コメント行のリスト。"""
+        text = _read(_ROOT_GITIGNORE)
+        return [line.strip() for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+    def test_ignores_terraform_tfvars(self, gitignore_lines: list[str]):
+        """Given root .gitignore
+        When 行を走査する
+        Then terraform.tfvars が ignore 対象。
+        """
+        assert "terraform.tfvars" in gitignore_lines, (
+            "terraform.tfvars が .gitignore に追加されていない（secret 漏洩リスク）"
+        )
+
+    def test_ignores_tfstate_files(self, gitignore_lines: list[str]):
+        """Given root .gitignore
+        When 行を走査する
+        Then *.tfstate / *.tfstate.* （または *.tfstate*）が ignore 対象。
+
+        state には secret が含まれうるためコミット禁止。
+        """
+        # 「*.tfstate*」（wildcard 末尾）または個別に「*.tfstate」+「*.tfstate.*」のどちらでも可
+        has_wildcard = "*.tfstate*" in gitignore_lines
+        has_split = "*.tfstate" in gitignore_lines and "*.tfstate.*" in gitignore_lines
+        assert has_wildcard or has_split, "*.tfstate / *.tfstate.* が .gitignore に追加されていない"
+
+    def test_ignores_terraform_dot_dir(self, gitignore_lines: list[str]):
+        """Given root .gitignore
+        When 行を走査する
+        Then .terraform/ が ignore 対象。
+
+        provider バイナリ・cache をコミットしない。
+        """
+        assert ".terraform/" in gitignore_lines, ".terraform/ が .gitignore に追加されていない"


### PR DESCRIPTION
## Summary

## 概要

`infra/terraform/streaming/` 配下に Terraform プロジェクトを作成し、Vultr Provider を使って 24/7 配信用 VPS を宣言的に定義する。

## 構成

| ファイル | 責務 |
|---|---|
| `versions.tf` | `required_providers` で `vultr/vultr` を declare |
| `variables.tf` | `vultr_api_key` (sensitive), `ssh_pub_key_path`, `region`, `plan`, `os_id` |
| `main.tf` | `vultr_ssh_key` + `vultr_instance` リソース |
| `outputs.tf` | `instance_ip`, `instance_id` |
| `terraform.tfvars.example` | サンプル変数定義 |
| `.gitignore`（リポジトリ側） | `terraform.tfvars` / `*.tfstate*` / `.terraform/` を追加 |

## VPS プラン

| 項目 | 値 |
|---|---|
| Provider | `vultr/vultr` (>= 2.x) |
| リージョン | `nrt`（東京） |
| プラン | `vc2-1c-2gb`（$10/月） |
| OS | Ubuntu 24.04 LTS |
| RAM | 2GB |
| SSD | 55GB |
| 帯域 | 2TB/月 |

## タスク

- [ ] `infra/terraform/streaming/versions.tf` で `vultr/vultr` provider を declare
- [ ] `variables.tf` で必須変数を定義
  - [ ] `vultr_api_key` (sensitive)
  - [ ] `ssh_pub_key_path` (default: `~/.ssh/yt_stream_key.pub`)
  - [ ] `region` (default: `nrt`)
  - [ ] `plan` (default: `vc2-1c-2gb`)
  - [ ] `os_id` (default: Ubuntu 24.04 LTS の OS ID)
- [ ] `main.tf` で `vultr_ssh_key` + `vultr_instance` を定義
  - [ ] `vultr_instance.ssh_key_ids` に上記 SSH 鍵を紐付け
  - [ ] `tag` / `label` に `youtube-stream` を付与（運用識別用）
- [ ] `outputs.tf` で `instance_ip` / `instance_id` を expose
- [ ] `terraform.tfvars.example` を追加（実体は gitignore）
- [ ] ルート `.gitignore` に `terraform.tfvars` / `*.tfstate*` / `.terraform/` を追加
- [ ] `terraform init && terraform plan` で構文・diff を確認
- [ ] `terraform apply` で VPS 起動 → SSH 接続確認

## secret 注入方式

```bash
export TF_VAR_vultr_api_key=$(op read 'op://Personal/Vultr/api_key')
terraform -chdir=infra/terraform/streaming init
terraform -chdir=infra/terraform/streaming apply
ssh -i ~/.ssh/yt_stream_key root@$(terraform -chdir=infra/terraform/streaming output -raw instance_ip)
```

## 完了条件

- `terraform apply` で VPS が Active 状態で立ち上がる
- 既存インスタンスが state にあれば再作成しない（冪等）
- SSH 公開鍵が自動登録され、`ssh` で root ログインできる
- `terraform destroy` で綺麗に消せる
- secret はコード・state ファイルにも平文で残らない（`sensitive = true` を確認）

## 関連

- 依存: #104
- Tracks: #112
- 旧 issue: 本 issue は #105 を Terraform 版に置き換えたもの

## Execution Report

Workflow `default` completed successfully.

Closes #123

Closes #124
