### PR TITLE
[#128] issue-128-suno-duration-prompt

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -58,19 +58,15 @@ $ARGUMENTS
 4 パターン × 3 回生成（1 回 2 曲）= **24 トラック** → ベスト曲を選定。
 プロンプト変更は **4 回のみ**（パターン切替時のみ）。
 
-### 曲の長さ制御（V5）
+### 曲の長さ（V5）
 
-V5 では Styles に時間指定プロンプトが反映されるようになった。`config/skills/suno.yaml` の `duration_prompt` で一元管理:
+Suno V5 では Styles 経由で実楽曲長を制御できない（2026-05 時点）。Styles 末尾に長さ指定文字列を入れてもトークンを浪費するだけで効かないため、リポジトリ側ではこの指定を持たない。望む長さに満たない場合は **Suno UI の Extend** で延長する。
 
-- **Styles に追加**: （例: `long-form performance, over 4 minutes, 4 to 5 minutes`）
 - **Style Influence**: `style_influence` で指定（デフォルト 85 推奨）
 - **Model**: V5 を使用
 
-スクリプトが `duration_prompt` を全パターンの Styles 末尾に自動付加する。
-
 > 注意: 構造タグ（`[Intro]`, `[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]`）は**インストゥルメンタルでは効果なし**だが、
 > **ボーカルモードでは Lyrics 欄に必須**（楽曲構成を Suno に伝える）。
-> Extend は最終手段として使えるが、Styles での時間指定を優先する。
 
 ## ボーカルモード（歌詞あり楽曲）
 
@@ -157,6 +153,10 @@ rain sounds, vinyl crackle, white noise, ambient noise
 
 しっとり感は `misty`, `melancholic`, `nocturnal`, `bittersweet` 等のムード語で表現する。
 
+#### genre_line と exclude_styles の整合性
+
+`exclude_styles` で除外したワードを `genre_line` 側に残すと相殺される。たとえば `exclude_styles` に `vinyl crackle` を含めつつ `genre_line` に `vinyl crackle warmth` のような表現を入れると、Suno には除外したい SE が結局供給されてしまう。`exclude_styles` を更新するときは `genre_line` 側にも同じワードや派生表現が混ざっていないかをセットで確認する。
+
 ### 品質基準プロンプト例
 
 ジャンル別の具体例は `references/suno-examples.md` を参照。新規プロンプト作成時は、該当ジャンルの例を基準として確認する。
@@ -239,7 +239,7 @@ patterns:
 uv run yt-generate-suno <collection-path>
 ```
 
-`config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `duration_prompt` + `style_influence` をパターンに自動付加して `suno-prompts.md` を生成する。設定変更時はスクリプト再実行のみで全プロンプトに反映される。
+`config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `style_influence` をパターンに自動付加して `suno-prompts.md` を生成する。設定変更時はスクリプト再実行のみで全プロンプトに反映される。
 
 **ボーカルモードの出力**: 各パターンに **Style 欄**（情景フレーズ + genre_line）+ **Lyrics 欄**（歌詞そのまま）の 2 ブロックが書き出される。Suno 側で Custom Mode に入って **Instrumental トグル OFF** にした状態で両方をコピペする。
 

--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -12,9 +12,6 @@ genre_line: ""
 # Suno の Exclude Styles 欄に入れる除外語
 exclude_styles: "heavy metal, aggressive, EDM, dubstep, techno, industrial, white noise, orchestral, rain sounds, vinyl crackle, ambient noise"
 
-# 長さ指定プロンプト (V5 の Styles 末尾に追加、-5 分曲用)
-duration_prompt: "long-form performance, over 4 minutes, 4 to 5 minutes"
-
 # Style Influence (0-100、高いほどジャンル指定が強く反映される)
 style_influence: 85
 

--- a/src/youtube_automation/scripts/generate_suno_prompts.py
+++ b/src/youtube_automation/scripts/generate_suno_prompts.py
@@ -16,7 +16,6 @@ def generate(patterns_path: Path) -> str:
     mood_descriptors = suno.get("mood_descriptors", "")
     exclude_styles = suno.get("exclude_styles", "")
     style_variants = suno.get("style_variants", {})
-    duration_prompt = suno.get("duration_prompt", "")
     style_influence = suno.get("style_influence", 50)
 
     base_parts = [genre_line]
@@ -83,8 +82,6 @@ def generate(patterns_path: Path) -> str:
             if tempo:
                 parts.append(tempo)
             parts.append(effective_style)
-            if duration_prompt:
-                parts.append(duration_prompt)
             lines.append(", ".join(parts) + ",")
             lines.append(scene)
             lines.append("```")

--- a/tests/test_generate_suno_prompts.py
+++ b/tests/test_generate_suno_prompts.py
@@ -1,12 +1,71 @@
-"""generate_suno_prompts CLI の挙動テスト."""
+"""generate_suno_prompts CLI / generate() の挙動テスト.
+
+issue #128 で `duration_prompt` を完全削除したため、その回帰防止テストを含む。
+"""
 
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import pytest
+import yaml
 
-from youtube_automation.scripts.generate_suno_prompts import main
+from youtube_automation.scripts.generate_suno_prompts import generate, main
+from youtube_automation.utils import skill_config
+
+# `_skills/<skill>/config.default.yaml` の解決元になる editable install のソースツリー
+_DEFAULT_YAML = (
+    Path(__file__).resolve().parents[1]
+    / ".claude"
+    / "skills"
+    / "suno"
+    / "config.default.yaml"
+)
+_SKILL_MD = (
+    Path(__file__).resolve().parents[1] / ".claude" / "skills" / "suno" / "SKILL.md"
+)
+
+
+@pytest.fixture
+def channel_dir(tmp_path, monkeypatch):
+    """skill_config が参照する CHANNEL_DIR を一時ディレクトリへ向ける."""
+    ch = tmp_path / "channel"
+    (ch / "config" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+    skill_config.reset()
+    yield ch
+    skill_config.reset()
+
+
+def _write_minimal_patterns(dir_: Path) -> Path:
+    """1 パターン × 1 シーンの最小 suno-patterns.yaml を作る."""
+    path = dir_ / "patterns.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "title": "Test Collection",
+                "mode": "instrumental",
+                "patterns": [
+                    {
+                        "name_jp": "テスト",
+                        "name_en": "Test",
+                        "tempo": "slow",
+                        "scenes": ["a quiet scene description"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_suno_override(channel: Path, **overrides) -> None:
+    """channel 側の config/skills/suno.yaml を生成する."""
+    (channel / "config" / "skills" / "suno.yaml").write_text(
+        yaml.safe_dump(overrides), encoding="utf-8"
+    )
 
 
 def test_help_flag_shows_usage_and_exits_zero(monkeypatch, capsys):
@@ -19,3 +78,186 @@ def test_help_flag_shows_usage_and_exits_zero(monkeypatch, capsys):
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "usage" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# issue #128: duration_prompt 完全削除の回帰テスト
+# ---------------------------------------------------------------------------
+
+
+def test_default_yaml_does_not_define_duration_prompt():
+    """同梱の config.default.yaml に duration_prompt キーが存在しないこと."""
+    data = yaml.safe_load(_DEFAULT_YAML.read_text(encoding="utf-8"))
+    assert "duration_prompt" not in data, (
+        "duration_prompt は issue #128 で完全削除された。"
+        "default.yaml から該当行を削除すること。"
+    )
+
+
+def test_generate_output_contains_no_duration_phrases(channel_dir, tmp_path):
+    """生成されたプロンプトに `long-form performance` 系の長さ指定文字列が含まれないこと."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz, soft piano")
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    output = generate(patterns_path)
+
+    assert "long-form performance" not in output
+    assert "4 to 5 minutes" not in output
+    assert "over 4 minutes" not in output
+
+
+def test_generate_styles_block_has_only_tempo_and_style(channel_dir, tmp_path):
+    """Styles 行が `<tempo>, <effective_style>,` のみで構成されること.
+
+    duration_prompt 由来の 3 要素目が付加されていないことを行レベルで固定する。
+    """
+    genre = "lo-fi jazz, soft piano"
+    _write_suno_override(channel_dir, genre_line=genre)
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    output = generate(patterns_path)
+
+    # Styles ブロックの中身は ``` で囲まれた 2 行 (style 行 + scene 行)。
+    # 行頭・行末が完全一致することを行リストレベルで固定 (substring 一致では duration が
+    # 後続に付加されたケースを検出できないため)。
+    expected_style_line = f"slow, {genre},"
+    lines = output.splitlines()
+    assert expected_style_line in lines, (
+        f"Styles 行が想定形式になっていない (完全一致なし). "
+        f"expected line: `{expected_style_line}`"
+    )
+
+
+def test_generate_ignores_legacy_duration_prompt_in_channel_override(
+    channel_dir, tmp_path
+):
+    """チャンネル override に旧 `duration_prompt` キーが残っていても出力に影響しないこと.
+
+    削除前のコードを参照しているチャンネル (rain-jazz-night など) は、暫定対応で
+    `duration_prompt: ""` を override に入れている。今回の削除でキー読み取り自体が
+    無くなるため、override にどんな値が残っていても出力には現れない。
+    """
+    sentinel = "DURATION_PROMPT_LEGACY_MARKER_SHOULD_NOT_APPEAR"
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        duration_prompt=sentinel,
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    output = generate(patterns_path)
+
+    assert sentinel not in output
+
+
+def test_generate_styles_block_no_trailing_duration_token(channel_dir, tmp_path):
+    """Styles 行末尾のカンマ位置に duration_prompt 残骸が紛れ込んでいないこと."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    output = generate(patterns_path)
+
+    # Styles ブロックを 1 つだけ抽出して構造を検査する
+    in_styles = False
+    styles_body: list[str] = []
+    for line in output.splitlines():
+        if line == "**Styles:**":
+            in_styles = True
+            continue
+        if in_styles:
+            if line == "```" and not styles_body:
+                # opening fence
+                continue
+            if line == "```":
+                break
+            styles_body.append(line)
+
+    # 1 行目が `<tempo>, <style>,`、2 行目が scene の 2 行構成
+    assert len(styles_body) == 2, f"Styles ブロックが 2 行ではない: {styles_body!r}"
+    style_line = styles_body[0]
+    # カンマ区切りの要素が tempo + style の 2 個 + 末尾区切りの空要素 = 3 トークン
+    tokens = [t.strip() for t in style_line.split(",")]
+    assert tokens[-1] == "", "末尾カンマ仕様 (`...,` で終わる) が壊れている"
+    non_empty = [t for t in tokens if t]
+    assert len(non_empty) == 2, (
+        f"Styles 1 行目は tempo + style の 2 要素のみ。"
+        f"duration_prompt 残骸の可能性: {non_empty!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md 側のドキュメント変更を固定する回帰テスト
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_does_not_reference_duration_prompt():
+    """SKILL.md から duration_prompt の参照と V5 で長さが効くという誤記が消えていること."""
+    text = _SKILL_MD.read_text(encoding="utf-8")
+
+    assert "duration_prompt" not in text, (
+        "SKILL.md にまだ `duration_prompt` の言及が残っている。"
+        "issue #128 で参照を完全削除すること (L242 のスクリプト説明文を含む)。"
+    )
+    assert "long-form performance, over 4 minutes, 4 to 5 minutes" not in text, (
+        "SKILL.md に旧 duration_prompt の例文が残っている。削除すること。"
+    )
+
+
+def test_skill_md_describes_extend_for_length_control():
+    """SKILL.md の「曲の長さ」記述が Extend 中心に書き換わっていること.
+
+    変更前: 「V5 では Styles に時間指定プロンプトが反映されるようになった」と誤記。
+    変更後: 「V5 では Styles で実楽曲長を制御できない / 短い場合は Extend で延長」へ。
+    """
+    text = _SKILL_MD.read_text(encoding="utf-8")
+
+    # Extend による延長が長さ調整の手段として案内されていること
+    assert "Extend" in text, (
+        "SKILL.md に Extend (Suno の延長機能) の記述が無い。"
+        "曲が短いときの対処として明記すること。"
+    )
+
+    # 旧誤記が削除されていること: V5 で Styles 経由の時間指定が効くという表現
+    forbidden_phrases = (
+        "Styles に時間指定プロンプトが反映",
+        "Styles での時間指定を優先",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in text, (
+            f"SKILL.md に旧誤記 (`{phrase}`) が残っている。"
+            "Suno V5 では Styles 経由で楽曲長を制御できないため、"
+            "該当記述は削除すること。"
+        )
+
+
+def test_skill_md_warns_about_genre_line_exclude_styles_conflict():
+    """SKILL.md に genre_line と exclude_styles の矛盾防止ガイドが追記されていること.
+
+    order.md「提案する変更 2」の趣旨:
+    `exclude_styles` で除外したワードを `genre_line` 側に残すと相殺される、
+    という注意書きを SKILL.md 上に独立した節として追記する。
+
+    別ジャンルへ書き換えても壊れないよう、以下を構造的に検査する:
+
+    1. 専用見出しが存在する（`#### genre_line と exclude_styles の整合性`）
+    2. その節に `genre_line` と `exclude_styles` の両ワードが含まれる
+    """
+    text = _SKILL_MD.read_text(encoding="utf-8")
+
+    heading = "#### genre_line と exclude_styles の整合性"
+    assert heading in text, (
+        f"SKILL.md に専用見出し ({heading!r}) が存在しない。"
+        "order.md 提案の矛盾防止ガイドを独立した節として追記すること。"
+    )
+
+    # 見出しから次の見出しまでをガイド本体として切り出して両概念名の存在を検査する
+    after_heading = text.split(heading, 1)[1]
+    next_heading_idx = after_heading.find("\n#")
+    section_body = (
+        after_heading if next_heading_idx == -1 else after_heading[:next_heading_idx]
+    )
+    for term in ("genre_line", "exclude_styles"):
+        assert term in section_body, (
+            f"`{heading}` 節に `{term}` への言及がない。"
+            "矛盾防止ガイドは genre_line / exclude_styles 双方を扱う必要がある。"
+        )


### PR DESCRIPTION
## Summary

## 背景

`/suno` スキルは生成プロンプトの Style 末尾に
`long-form performance, over 4 minutes, 4 to 5 minutes`
を全パターンへ無条件で付加している。

```python
# youtube_automation/scripts/generate_suno_prompts.py
duration_prompt = suno.get("duration_prompt", "")
...
if duration_prompt:
    parts.append(duration_prompt)
```

しかし Suno V5 で実楽曲長の制御に**効いていない**ことが、2026-05-02 のチャンネル運用（rain-jazz-night）で観測された。プロンプトトークンを浪費し、`style_influence` で効かせたいジャンル指定の重みを薄める副作用もある。

## 提案する変更

### 1. duration_prompt を完全削除（必須）

- `youtube_automation/_skills/suno/config.default.yaml` から `duration_prompt` フィールド削除
- `youtube_automation/scripts/generate_suno_prompts.py` から読み込み + 末尾付加ロジック削除
- `youtube_automation/_skills/suno/SKILL.md` の「曲の長さ制御（V5）」節を「曲の長さは Suno で制御できない（短い場合は Extend で延長）」注記へ書き換え

### 2. genre_line と exclude_styles の矛盾防止ガイド追記（推奨）

`exclude_styles` に `vinyl crackle` を含めつつ、genre_line に `vinyl crackle warmth` のような表現を入れると相殺される。SKILL.md にこの注意書きを追加することを提案。

### 3. style_variants をデフォルト同梱化（議論）

現在の `config.default.yaml` には `style_variants` は同梱されておらず、チャンネル側で定義する想定。rain-jazz-night では過去高評価楽曲（rainy-studio / library-after-hours / rain-nest 系、3-30〜4-04 公開）の Style に共通する 5 軸を採用した:

- `ambient-jazz`: ambient jazz, soft piano pads, gentle saxophone drifting, minimal bass notes, no drums
- `chill-jazz-hop`: chill jazz hop, dusty piano samples, jazzy guitar licks, deep bass groove, lo-fi drum loop
- `late-night-smooth`: late night smooth jazz, Rhodes electric piano, muted trumpet, walking bass, soft brushes
- `lofi-chill`: lo-fi chill jazz, warm piano chords, mellow Rhodes, soft upright bass, gentle brush percussion, tape warmth
- `rainy-cafe-lofi`: rainy cafe lo-fi jazz, warm acoustic guitar, soft piano, light jazz drums, cozy and intimate

lo-fi jazz 系チャンネル汎用なので同梱しても良いかもしれないが、他ジャンル（lyria 系・別ジャンル）への影響もあるため、本 issue では議論として残す（必須対象外）。

## 影響範囲

- `youtube-channels-automation` を依存している全チャンネルで生成される Suno プロンプトが変わる
- 既存 live コレクションの `suno-prompts.md` は再生成しない限り変更されない（プロンプト履歴として保全される）

## チャンネル側の暫定対応

rain-jazz-night では `config/skills/suno.yaml` に `duration_prompt: ""` を追加して override 済み。本 issue が解決して新版がリリースされたら override は撤去できる。

## 関連メモ

- 当該チャンネルの CLAUDE.md にこの学習を記録した
- Suno V5 の Styles 欄で時間指定が効かない理由は不明（公式ドキュメント未確認）

## Execution Report

Workflow `default` completed successfully.

Closes #128