### PR TITLE
[#129] issue-129-loop-video-veo-3-1-l

### DIFF
--- a/.claude/skills/loop-video/SKILL.md
+++ b/.claude/skills/loop-video/SKILL.md
@@ -113,7 +113,7 @@ veo:
 
 | 項目 | 既定 | 説明 |
 |---|---|---|
-| `veo.model` | veo-3.1-fast-generate-001 | Veo API モデル（選択肢: veo-3.1-fast-generate-001 / veo-3.1-generate-001） |
+| `veo.model` | veo-3.1-fast-generate-001 | Veo API モデル（選択肢: veo-3.1-fast-generate-001 / veo-3.1-generate-001 / veo-3.1-lite-generate-preview） |
 | `veo.default_prompt` | 汎用微動プロンプト | チャンネルの世界観に合わせて上書き推奨 |
 | `veo.duration_seconds` | 8 | 生成尺（Veo API 制約で 8 秒固定） |
 | `veo.crossfade_sec` | 0.5 | FFmpeg ループ補正のクロスフェード秒数 |

--- a/.claude/skills/loop-video/config.default.yaml
+++ b/.claude/skills/loop-video/config.default.yaml
@@ -4,7 +4,7 @@
 # チャンネル側では config/skills/loop-video.yaml に上書き値を置く。
 
 veo:
-  # Veo モデル ID（API デフォルト: veo-3.1-fast-generate-001 / 選択肢: veo-3.1-fast-generate-001 | veo-3.1-generate-001）
+  # Veo モデル ID（API デフォルト: veo-3.1-fast-generate-001 / 選択肢: veo-3.1-fast-generate-001 | veo-3.1-generate-001 | veo-3.1-lite-generate-preview）
   model: "veo-3.1-fast-generate-001"
 
   # 動画生成プロンプト。コレクションの世界観に合わせてチャンネル側で上書き推奨。

--- a/src/youtube_automation/scripts/generate_loop_video.py
+++ b/src/youtube_automation/scripts/generate_loop_video.py
@@ -68,22 +68,36 @@ def resolve_collection_paths(collection_path: Path) -> tuple[Path, Path]:
     return image_path, output_path
 
 
+def _build_parser() -> argparse.ArgumentParser:
+    # Veo の preview/GA リリースサイクルに追従するため、`--model` は choices で
+    # 縛らず任意文字列を受ける。未知モデルは Vertex AI 側でエラーになる。
+    # RawTextHelpFormatter: help 文字列にハイフン入りモデル名が連なるため、
+    # 80 桁折り返しで `veo-3.1-lite-` / `generate-preview` のように分断されないようにする。
+    parser = argparse.ArgumentParser(
+        description="Veo 3.1 コレクションループ動画生成",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("collection", nargs="?", help="コレクションパス")
+    parser.add_argument("--prompt", help="動画生成プロンプト")
+    parser.add_argument(
+        "--model",
+        help=(
+            "Veo モデル名 (default: skill-config の veo.model, fallback: veo-3.1-fast-generate-001)。"
+            " 例: veo-3.1-fast-generate-001 / veo-3.1-generate-001 / veo-3.1-lite-generate-preview"
+        ),
+    )
+    parser.add_argument("--smooth", action="store_true", help="FFmpeg クロスフェードでループ補正")
+    parser.add_argument("--crossfade", type=float, default=0.5, help="クロスフェード秒数 (デフォルト: 0.5)")
+    parser.add_argument("-y", "--yes", action="store_true", help="確認をスキップ")
+    return parser
+
+
 def main():
     from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv())
 
-    parser = argparse.ArgumentParser(description="Veo 3.1 コレクションループ動画生成")
-    parser.add_argument("collection", nargs="?", help="コレクションパス")
-    parser.add_argument("--prompt", help="動画生成プロンプト")
-    parser.add_argument(
-        "--model",
-        choices=["veo-3.1-fast-generate-001", "veo-3.1-generate-001"],
-        help="Veo モデル名 (default: veo-3.1-fast-generate-001)",
-    )
-    parser.add_argument("--smooth", action="store_true", help="FFmpeg クロスフェードでループ補正")
-    parser.add_argument("--crossfade", type=float, default=0.5, help="クロスフェード秒数 (デフォルト: 0.5)")
-    parser.add_argument("-y", "--yes", action="store_true", help="確認をスキップ")
+    parser = _build_parser()
     args = parser.parse_args()
 
     # 設定読み込み

--- a/tests/test_generate_loop_video_cli.py
+++ b/tests/test_generate_loop_video_cli.py
@@ -1,0 +1,148 @@
+"""scripts/generate_loop_video.py の CLI 引数パーサのユニットテスト
+
+Issue #129 で `--model` の `choices` 制限を撤廃し、`veo-3.1-lite-generate-preview`
+を含む任意のモデル文字列を許容する変更を検証する。
+
+検証対象（plan.md §5 テスト方針）:
+1. `_build_parser`: `--model` が任意文字列（preview モデルを含む）を受け付ける
+2. `_build_parser`: 旧 2 モデルも引き続き受け付ける（regression）
+3. `_build_parser`: `--model` 未指定時は `args.model is None`（main() 側の
+   `args.model or veo_config.get("model", DEFAULT_MODEL)` フォールバック解決を維持）
+4. `_build_parser`: help 文字列に `veo-3.1-lite-generate-preview` が含まれる
+
+外部 IO（Vertex AI / load_skill_config / load_dotenv 等）は touch しない。
+parser のみを切り出してテストする。
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from youtube_automation.scripts.generate_loop_video import _build_parser
+
+
+class TestBuildParser:
+    def test_returns_argument_parser(self):
+        # Given/When
+        parser = _build_parser()
+
+        # Then
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_parser_accepts_lite_preview_model(self):
+        # Given: Issue #129 のメインケース。preview モデルを CLI から指定可能。
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--model", "veo-3.1-lite-generate-preview"])
+
+        # Then
+        assert args.model == "veo-3.1-lite-generate-preview"
+
+    def test_parser_accepts_arbitrary_model_string(self):
+        # Given: choices 撤廃の証跡。Veo の preview/GA リリースサイクルに追従するため
+        # 未知モデル文字列も argparse 段階では弾かない（API 側でエラーになる前提）。
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--model", "some-future-model-id"])
+
+        # Then
+        assert args.model == "some-future-model-id"
+
+    def test_parser_accepts_legacy_fast_model(self):
+        # Given: 旧 model（fast）の regression
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--model", "veo-3.1-fast-generate-001"])
+
+        # Then
+        assert args.model == "veo-3.1-fast-generate-001"
+
+    def test_parser_accepts_legacy_quality_model(self):
+        # Given: 旧 model（quality）の regression
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["--model", "veo-3.1-generate-001"])
+
+        # Then
+        assert args.model == "veo-3.1-generate-001"
+
+    def test_parser_model_default_is_none(self):
+        # Given: --model 未指定時は None。main() 側の
+        # `args.model or veo_config.get("model", DEFAULT_MODEL)` 解決順序を壊さない。
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args([])
+
+        # Then
+        assert args.model is None
+
+    def test_parser_help_lists_lite_preview_model(self):
+        # Given: SKILL.md と config.default.yaml の選択肢列挙と整合する形で
+        # CLI help にも preview モデルを例示する。
+        parser = _build_parser()
+
+        # When
+        help_text = parser.format_help()
+
+        # Then
+        assert "veo-3.1-lite-generate-preview" in help_text
+
+    def test_parser_help_lists_legacy_models(self):
+        # Given: help 文字列で旧 2 モデルも引き続き例示されている（discoverability 維持）。
+        parser = _build_parser()
+
+        # When
+        help_text = parser.format_help()
+
+        # Then
+        assert "veo-3.1-fast-generate-001" in help_text
+        assert "veo-3.1-generate-001" in help_text
+
+    def test_parser_collection_is_optional(self):
+        # Given: collection は positional だが nargs="?" で optional（CWD 解決経路を残す）。
+        # この既存挙動を model 変更で壊さない regression。
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args([])
+
+        # Then
+        assert args.collection is None
+
+    def test_parser_collection_accepted_when_provided(self):
+        # Given: collection 引数を渡すルート
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(["collections/example", "--model", "veo-3.1-lite-generate-preview"])
+
+        # Then
+        assert args.collection == "collections/example"
+        assert args.model == "veo-3.1-lite-generate-preview"
+
+    def test_parser_other_flags_still_parse(self):
+        # Given: --prompt / --smooth / --crossfade / -y は今回触らない。regression。
+        parser = _build_parser()
+
+        # When
+        args = parser.parse_args(
+            [
+                "--prompt",
+                "test prompt",
+                "--smooth",
+                "--crossfade",
+                "0.8",
+                "-y",
+            ]
+        )
+
+        # Then
+        assert args.prompt == "test prompt"
+        assert args.smooth is True
+        assert args.crossfade == 0.8
+        assert args.yes is True


### PR DESCRIPTION
## Summary

## 背景

Veo の preview モデル `veo-3.1-lite-generate-preview` を `loop-video` スキルから利用したい。
コア実装は既に対応済みだが、CLI argparse の `choices` ハードコードと skill 文書の選択肢記述だけがブロックしている。

## 現状

### 既に対応済み
- `src/youtube_automation/utils/cost_tracker.py:108` — `veo-3.1-lite-generate-preview` の pricing 登録済み（$0.15/sec）
- `src/youtube_automation/utils/cost_tracker.py:109` — `veo-3.1-generate-preview` も登録済み
- `src/youtube_automation/utils/veo_generator.py` — モデル文字列を素通しするだけでホワイトリスト検証なし
- `tests/test_cost_tracker.py:60-62, 152-160` — `veo-3.1-lite-generate-preview` 参照済み

### ブロックしている箇所
- `src/youtube_automation/scripts/generate_loop_video.py:79-83` — argparse `--model` の `choices` が古い 2 モデル固定

\`\`\`python
parser.add_argument(
    "--model",
    choices=["veo-3.1-fast-generate-001", "veo-3.1-generate-001"],
    help="Veo モデル名 (default: veo-3.1-fast-generate-001)",
)
\`\`\`

- `.claude/skills/loop-video/SKILL.md:116` — 選択肢記述が古い
- `.claude/skills/loop-video/config.default.yaml:7` — `veo.model` コメントの選択肢列挙が古い

なお、ダウンストリーム（チャンネルリポ）の `config/skills/loop-video.yaml` で `veo.model` を上書きする経路は
今でも動くはず（CLI を介さず skill-config 経由で `veo_generator.py` に直接渡るため）。
ブロックされているのは CLI から `--model` を明示する経路のみ。

## 提案

### 1. argparse \`choices\` を撤廃
Veo の preview/GA リリースサイクルに追従しやすくするため、\`choices\` を外して任意文字列を受け付けるよう変更。
未知モデルは API 側でエラーになるので二重ガードは不要。

\`\`\`python
parser.add_argument(
    "--model",
    help=(
        "Veo モデル名 (default: skill-config の veo.model, fallback: veo-3.1-fast-generate-001)。"
        " 例: veo-3.1-fast-generate-001 / veo-3.1-generate-001 / veo-3.1-lite-generate-preview"
    ),
)
\`\`\`

### 2. SKILL.md / config.default.yaml の選択肢記述を更新
\`veo-3.1-lite-generate-preview\` を例示に追加。

## 検証

- [ ] \`uv run pytest tests/test_cost_tracker.py\` — 既存 pricing テスト pass
- [ ] \`uv run yt-generate-loop-video --help\` — \`--model\` の help が更新され choices 制限がないこと
- [ ] \`uv run ruff check . && uv run ruff format --check .\`
- [ ] （任意・要 Vertex AI 認証）チャンネルリポで \`config/skills/loop-video.yaml\` に \`veo.model: "veo-3.1-lite-generate-preview"\` を入れて実行 → ログに \`[Submit] モデル=veo-3.1-lite-generate-preview\` が出ること

## Execution Report

Workflow `default` completed successfully.

Closes #129