### PR TITLE
[#111] issue-111-no-shi-e-no-no-wo-sh-1

### DIFF
--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -56,6 +56,59 @@ systemd unit が以下の挙動を持つ:
 
 同じ動画 / 同じキーで再 apply すると no-op（冪等）。
 
+## 動画の差し替え手順
+
+`null_resource.deploy` の `triggers.video_hash`（`filemd5(var.video_path)`）が変わると同 resource のみが再実行され、新動画が VPS に転送されて `systemctl restart youtube-stream` まで一気通貫で走る。`vultr_ssh_key` / `vultr_instance` は trigger に含まれないため **VPS は再作成されない**。
+
+```bash
+# 1. 新動画の絶対パスを TF_VAR_video_path に export
+export TF_VAR_video_path=$(realpath ./new_video.mp4)
+
+# 2. 差分計画を確認（null_resource.deploy のみ replace 予定であること）
+terraform -chdir=infra/terraform/streaming plan
+
+# 3. 適用（filemd5 trigger が変わるので null_resource が再実行 → ファイル送信 + systemctl restart）
+terraform -chdir=infra/terraform/streaming apply
+```
+
+`terraform plan` の出力で `null_resource.deploy` の **replace 1 件のみ** であることを確認してから apply する。`vultr_instance` / `vultr_ssh_key` の change/replace 行が混じる場合は、`terraform.tfvars` の `region` / `plan` / `os_id` を意図せず変更している可能性があるため apply しない。
+
+### 視聴者ダウンタイムを 0 秒にする運用 tips
+
+§配信サイクル の 11h+1h サイクル中、毎日 11:00–12:00 / 23:00–0:00 の **休止時間** に apply するのが基本。
+
+| 実施タイミング | 視聴者影響 | 反映タイミング |
+|---|---|---|
+| 休止時間（11:00–12:00 / 23:00–0:00）| 0 秒 | apply 完了直後（休止状態がキャンセルされ即起動。以降のサイクルは apply 時刻基点にシフトする）|
+| 配信中 | `systemctl restart` 実行直後の数秒〜数十秒の中断 | apply 完了直後（即時再起動。以降のサイクルは apply 時刻基点にシフトする）|
+
+中断を 0 秒に抑えたければ必ず休止時間まで待ってから apply する。`null_resource.deploy` の最終 provisioner は `systemctl restart youtube-stream` を無条件で実行する（`main.tf` の `provisioner "remote-exec"` 参照）ため、配信中 apply で「次サイクル待ち」を選ぶ手段は提供されていない。
+
+休止時間の正確な開始時刻は VPS 上で以下を確認できる:
+
+```bash
+ssh -i ~/.ssh/yt_stream_key root@<instance_ip> systemctl show youtube-stream | grep -E 'ExecMainStartTimestamp|RuntimeMaxUSec'
+```
+
+### 同じ動画で再 apply した場合（冪等性）
+
+`filemd5(var.video_path)` が前回と同値なら `triggers` 全体が不変となり、`null_resource.deploy` は no-op。`terraform plan` の差分も 0 件になる（`No changes. Your infrastructure matches the configuration.`）。同じ mp4 で誤って再 apply しても VPS には何も起きないため、運用上は安全に空打ちできる。
+
+### 旧動画の扱い
+
+`provisioner "file"` の `destination` が `/opt/youtube-stream/videos/current.mp4` に固定されており、毎回同一パスへ上書きされる。VPS 上に旧動画は残らないため、明示的な削除手順は不要（単一ファイル方式の自然な振る舞い）。
+
+### トラブルシューティング（差し替え時）
+
+#### `Error: Missing required argument` / `var.video_path is required`
+`TF_VAR_video_path` を export せずに `terraform plan` / `apply` を実行している。`export TF_VAR_video_path=$(realpath ./new_video.mp4)` を当該シェルで再実行する。
+
+#### `terraform plan` で `vultr_instance` まで replace される
+`terraform.tfvars` の `region` / `plan` / `os_id` を意図せず変更している。差分行の resource 名を確認し、必要なら `terraform.tfvars` を元の値に戻してから再 plan する（差替時はこの 3 値を触らない）。
+
+#### apply 後も旧動画のまま見えている
+RTMP セッションの切替遅延（YouTube 側の数秒バッファ）または `ffmpeg` の再起動失敗。`journalctl -u youtube-stream -n 50 -f` で `ffmpeg` 起動時刻と入力ファイルを確認する。新しい時刻で `Stream #0:0` が出ていれば反映済（視聴側のキャッシュ抜けを待つ）。
+
 ## 動作確認
 
 VPS 上で以下を実行する（ホスト名は `terraform output instance_ip` で確認）:

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -73,6 +73,20 @@ terraform -chdir=infra/terraform/streaming apply
 
 `terraform plan` の出力で `null_resource.deploy` の **replace 1 件のみ** であることを確認してから apply する。`vultr_instance` / `vultr_ssh_key` の change/replace 行が混じる場合は、`terraform.tfvars` の `region` / `plan` / `os_id` を意図せず変更している可能性があるため apply しない。
 
+### 1 コマンドラッパー: `swap_video.sh`
+
+上記 3 ステップを 1 コマンドに畳んだラッパー `scripts/streaming/swap_video.sh` を同梱している。引数の動画パスを `realpath` で絶対化し `TF_VAR_video_path` に export してから `terraform -chdir=infra/terraform/streaming plan` → `apply` を順に実行する。
+
+```bash
+# 対話確認あり（既定）
+scripts/streaming/swap_video.sh ./new_video.mp4
+
+# 非対話 apply（CI / 確信があるとき）
+scripts/streaming/swap_video.sh --auto-approve ./new_video.mp4
+```
+
+secret 系（`TF_VAR_stream_key` / `TF_VAR_vultr_api_key`）はラッパーが扱わない方針のため、呼び出し側で事前 export しておくこと（§使い方 の手順 2 と同じ）。`terraform init` も実行しないため、初回のみ手動で `terraform -chdir=infra/terraform/streaming init` を一度走らせる。
+
 ### 視聴者ダウンタイムを 0 秒にする運用 tips
 
 §配信サイクル の 11h+1h サイクル中、毎日 11:00–12:00 / 23:00–0:00 の **休止時間** に apply するのが基本。

--- a/scripts/streaming/swap_video.sh
+++ b/scripts/streaming/swap_video.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# swap_video.sh — 配信中動画を 1 コマンドで差し替えるラッパー
+#
+# Usage:
+#   scripts/streaming/swap_video.sh [--tf-dir DIR] [--auto-approve] <video-path>
+#
+# Options:
+#   --tf-dir DIR       Terraform モジュールパス (既定: infra/terraform/streaming)
+#   --auto-approve     terraform apply に -auto-approve を付ける (既定: 対話確認)
+#   -h, --help         このヘルプ
+#
+# Notes:
+#   - secret 系 (TF_VAR_stream_key / TF_VAR_vultr_api_key) は呼び出し側で事前 export すること。
+#     本ラッパーは video_path のみ扱う。
+#   - terraform init は実行しない (provider バージョンの意図せぬ更新を避けるため)。
+#   - cwd 依存を避けるため pushd ではなく terraform -chdir= を使う。
+
+set -euo pipefail
+
+TF_DIR="infra/terraform/streaming"
+AUTO_APPROVE=false
+VIDEO_PATH=""
+
+log()   { printf '\033[0;36m[swap-video]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() { sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tf-dir) TF_DIR="$2"; shift 2 ;;
+        --tf-dir=*) TF_DIR="${1#*=}"; shift ;;
+        --auto-approve) AUTO_APPROVE=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "未知のオプション: $1"; usage; exit 2 ;;
+        *)
+            if [[ -n "$VIDEO_PATH" ]]; then
+                error "動画パスは 1 つだけ指定してください (既: $VIDEO_PATH / 追加: $1)"
+                exit 2
+            fi
+            VIDEO_PATH="$1"
+            shift
+            ;;
+    esac
+done
+
+# `--` 以降の残余引数を動画パスとして拾う (まだ未設定なら)
+if [[ -z "$VIDEO_PATH" && $# -gt 0 ]]; then
+    VIDEO_PATH="$1"
+    shift
+fi
+
+if [[ -z "$VIDEO_PATH" ]]; then
+    error "動画パスが未指定です"
+    usage
+    exit 2
+fi
+
+command -v terraform >/dev/null 2>&1 || {
+    error "terraform が見つかりません: https://developer.hashicorp.com/terraform/install"
+    exit 1
+}
+command -v realpath >/dev/null 2>&1 || {
+    error "realpath が見つかりません (macOS なら brew install coreutils)"
+    exit 1
+}
+
+[[ -d "$TF_DIR" ]] || { error "tf-dir が存在しません: $TF_DIR"; exit 1; }
+[[ -f "$TF_DIR/main.tf" ]] || { error "tf-dir に main.tf が見当たりません: $TF_DIR"; exit 1; }
+[[ -f "$VIDEO_PATH" ]] || { error "動画ファイルが存在しません: $VIDEO_PATH"; exit 1; }
+
+VIDEO_PATH_ABS="$(realpath "$VIDEO_PATH")"
+export TF_VAR_video_path="$VIDEO_PATH_ABS"
+
+log "video:  $TF_VAR_video_path"
+log "tf-dir: $TF_DIR"
+
+log "terraform plan (差分確認: null_resource.deploy のみ replace 予定)"
+terraform -chdir="$TF_DIR" plan
+
+log "terraform apply"
+if $AUTO_APPROVE; then
+    terraform -chdir="$TF_DIR" apply -auto-approve
+else
+    terraform -chdir="$TF_DIR" apply
+fi
+
+ok "動画差し替え完了: $TF_VAR_video_path"

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -39,6 +39,9 @@ _SYSTEMD_TFTPL = _STREAMING_DIR / "templates" / "youtube-stream.service.tftpl"
 _ENV_TFTPL = _STREAMING_DIR / "templates" / "youtube-stream.env.tftpl"
 _STREAMING_README = _STREAMING_DIR / "README.md"
 
+_SCRIPTS_STREAMING_DIR = _REPO_ROOT / "scripts" / "streaming"
+_SWAP_VIDEO_SCRIPT = _SCRIPTS_STREAMING_DIR / "swap_video.sh"
+
 
 # ---------- ヘルパー ----------
 
@@ -1555,4 +1558,186 @@ class TestStreamingReadmeVideoSwap:
         text = _read(_STREAMING_README)
         assert "current.mp4" in text, (
             "README に current.mp4 への上書きの言及が無い（旧動画が自然消去される根拠が辿れない）"
+        )
+
+    def test_mentions_swap_video_script(self):
+        """Given README
+        When 全文を読む
+        Then ``swap_video.sh`` への到達導線（言及）が存在する。
+
+        order.md「スクリプト化（任意）: ``scripts/streaming/swap_video.sh``」「1 コマンド
+        ラッパーとして提供」要件。ラッパーを追加しても README から発見できなければ運用者は
+        到達できないため、README が `swap_video.sh` という識別子に言及していることを担保する。
+        """
+        text = _read(_STREAMING_README)
+        assert "swap_video.sh" in text, (
+            "README に swap_video.sh の言及が無い"
+            "（1 コマンドラッパーへの到達導線が欠落し、運用者が発見できない）"
+        )
+
+
+# ============================================================================
+# scripts/streaming/swap_video.sh — #111 1 コマンドラッパー
+# ============================================================================
+
+
+class TestSwapVideoScript:
+    """``scripts/streaming/swap_video.sh`` の静的検査（#111 任意要件「1 コマンドラッパー」）。
+
+    本スクリプトは ``TF_VAR_video_path`` を解決して export し、``terraform -chdir=...
+    apply`` を起動するシェルラッパー。``terraform apply`` 単体運用も引き続き有効だが、
+    `swap_video.sh <video-path>` で完了条件「1 コマンドで動画差替が完了」を堅く満たす。
+
+    本テストは terraform バイナリ非依存の方針（既存 ``TestStreamingReadmeVideoSwap``
+    と同様）に従い、ファイルテキスト・実行ビット・主要キーワードを正規表現で検証する。
+    実行時挙動（subprocess での実 terraform 呼び出し / shellcheck 適用）はスコープ外。
+    """
+
+    def test_script_exists(self):
+        """Given リポジトリ
+        When ``scripts/streaming/swap_video.sh`` を探す
+        Then 当該ファイルが存在する。
+
+        order.md「スクリプト化（任意）: ``scripts/streaming/swap_video.sh``」要件の最低条件。
+        ラッパーは README から発見可能であっても、ファイルが無ければ叩けない。
+        """
+        assert _SWAP_VIDEO_SCRIPT.exists(), (
+            f"{_SWAP_VIDEO_SCRIPT.relative_to(_REPO_ROOT)} が存在しない"
+            "（1 コマンドラッパーが未実装）"
+        )
+
+    def test_script_is_executable(self):
+        """Given スクリプトファイル
+        When ファイル属性を確認
+        Then 実行ビット（owner ``x``）が立っている。
+
+        ``./scripts/streaming/swap_video.sh <video>`` 形式で直接叩けるよう、
+        実行属性が必要。``bash scripts/streaming/swap_video.sh`` 経由でしか動かないと
+        運用者が事故る（タブ補完で失敗する）。
+        """
+        if not _SWAP_VIDEO_SCRIPT.exists():
+            pytest.fail(
+                f"{_SWAP_VIDEO_SCRIPT.relative_to(_REPO_ROOT)} が存在しない（先に実装が必要）"
+            )
+        mode = _SWAP_VIDEO_SCRIPT.stat().st_mode
+        # owner execute bit (0o100) が立っていること
+        assert mode & 0o100, (
+            f"{_SWAP_VIDEO_SCRIPT.relative_to(_REPO_ROOT)} に owner 実行ビットが無い"
+            f"（chmod +x 漏れ。現在の mode: {oct(mode)}）"
+        )
+
+    def test_script_uses_strict_mode(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``set -euo pipefail`` が記載されている。
+
+        bash スクリプトの最低限の規律。`-e`（失敗即終了）, `-u`（未定義変数を fail）,
+        `-o pipefail`（pipe 中の失敗を伝播）が無いと、provisioning 系の失敗が握りつぶされる。
+        既存 ``scripts/gcp-terraform-apply.sh:13`` と同方針。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        assert re.search(r"^set\s+-euo\s+pipefail\b", text, flags=re.MULTILINE), (
+            "swap_video.sh に `set -euo pipefail` が無い"
+            "（エラー握りつぶしリスク。Fail Fast 原則に違反）"
+        )
+
+    def test_script_exports_tf_var_video_path(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``TF_VAR_video_path`` の export 行が記載されている。
+
+        order.md 差し替え手順「``export TF_VAR_video_path=$(realpath ./new_video.mp4)``」
+        を 1 コマンド化するのが本ラッパーの中核。env 注入が無ければ ``var.video_path``
+        が解決できず terraform は ``Missing required argument`` で落ちる。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        assert re.search(r"export\s+TF_VAR_video_path\b", text), (
+            "swap_video.sh に `export TF_VAR_video_path` が無い"
+            "（差し替え対象の動画パスを Terraform に渡す経路が欠落）"
+        )
+
+    def test_script_uses_realpath_for_absolute_path(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``realpath`` が呼び出されている。
+
+        order.md「``$(realpath ./new_video.mp4)``」要件。Terraform の ``provisioner "file"``
+        は実行時の cwd に依存するため、相対パスのまま渡すと別ディレクトリから叩いた時に
+        破綻する。``realpath`` で絶対化する経路を必ず通す。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        assert re.search(r"\brealpath\b", text), (
+            "swap_video.sh に `realpath` の呼び出しが無い"
+            "（相対パス渡しで cwd 依存になり、別ディレクトリから叩くと破綻する）"
+        )
+
+    def test_script_runs_terraform_apply_with_chdir(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``terraform`` の ``apply`` を ``-chdir=`` 付きで起動している。
+
+        order.md「``TF_VAR_video_path`` をセットして ``terraform apply -auto-approve``」要件。
+        既存 README が ``terraform -chdir=infra/terraform/streaming apply`` パターンで
+        統一されているため、ラッパー側も ``-chdir=`` を使い記述パターンを揃える
+        （plan.md「pushd ではなく -chdir= を使う」）。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        assert re.search(r"terraform\s+[^\n]*-chdir=", text), (
+            "swap_video.sh に `terraform -chdir=...` が無い"
+            "（既存 README の記述パターン (-chdir=) と不一致 / pushd 等の cwd 依存実装の疑い）"
+        )
+        assert re.search(r"terraform\s+[^\n]*\bapply\b", text), (
+            "swap_video.sh に `terraform apply` 起動行が無い"
+            "（差し替えを実行する本体コマンドが欠落）"
+        )
+
+    def test_script_default_apply_is_interactive(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``-auto-approve`` の付与が条件分岐配下にある（無条件付与ではない）。
+
+        plan.md「``--auto-approve`` は off（対話確認）」要件。デフォルトで
+        ``-auto-approve`` を付けると誤 apply 事故のリスクが上がる。``--auto-approve``
+        フラグを明示した時のみ ``-auto-approve`` を Terraform に渡す分岐構造であること。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        # `--auto-approve` のフラグハンドリング（引数パース）が存在する
+        assert re.search(r"--auto-approve\b", text), (
+            "swap_video.sh に `--auto-approve` 引数の取り扱いが無い"
+            "（plan.md 仕様: フラグ off がデフォルト / 明示時のみ非対話 apply）"
+        )
+        # `terraform ... apply -auto-approve` が無条件に書かれていない
+        # （= 直接 1 行で `terraform apply -auto-approve` を書くのは禁止。条件分岐配下が必須）
+        unconditional = re.search(
+            r"^[ \t]*terraform\s+[^\n]*\bapply\b[^\n]*-auto-approve",
+            text,
+            flags=re.MULTILINE,
+        )
+        # `if` / `case` / `$AUTO_APPROVE` などのガード語が同一スクリプト内にある場合は
+        # 上記マッチが分岐配下にある可能性がある。安全側で「``apply -auto-approve`` の
+        # 行が出現する場合は、その上方に AUTO_APPROVE 系変数のガードがあること」を要求する。
+        if unconditional is not None:
+            head = text[: unconditional.start()]
+            assert re.search(r"AUTO_APPROVE", head), (
+                "swap_video.sh が `terraform apply -auto-approve` を無条件で実行している"
+                "（AUTO_APPROVE 変数等のガードが上方に無い。誤 apply リスク）"
+            )
+
+    def test_script_supports_auto_approve_flag(self):
+        """Given スクリプト本文
+        When 全文を読む
+        Then ``-auto-approve`` を terraform に渡す経路と ``--auto-approve`` 受け取りが対になっている。
+
+        ユーザーが ``--auto-approve`` を渡した時に Terraform 側へ ``-auto-approve``
+        が伝播する経路があること。フラグだけ受け取って何もしない実装になっていないか担保する。
+        """
+        text = _read(_SWAP_VIDEO_SCRIPT)
+        # ユーザー向けフラグ `--auto-approve` の取り回し
+        assert re.search(r"--auto-approve\b", text), (
+            "swap_video.sh が `--auto-approve` 引数を受け取っていない"
+        )
+        # terraform へ渡す `-auto-approve`（シングルダッシュ）
+        assert re.search(r"-auto-approve\b", text), (
+            "swap_video.sh が terraform へ `-auto-approve` を渡していない"
+            "（ユーザーフラグだけ受け取って Terraform 側に伝播していない）"
         )

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -1451,3 +1451,108 @@ class TestStreamingReadme:
             r"rtmp://[\w.]+/live2/[A-Za-z0-9]{8,}",
             text,
         ), "README に実 stream key を含む rtmp URL が書かれている可能性（漏洩リスク）"
+
+
+# ============================================================================
+# infra/terraform/streaming/README.md — #111 動画差し替え手順
+# ============================================================================
+
+
+class TestStreamingReadmeVideoSwap:
+    """``infra/terraform/streaming/README.md`` 「動画の差し替え手順」セクション（#111）。
+
+    依存 #125 で実装済みの ``null_resource.deploy`` (filemd5 trigger / current.mp4 上書き /
+    systemctl restart) を運用フェーズで使うための手順ドキュメントを検証する。
+
+    本テストは README の章立て順序や文章スタイルを問わず、運用上クリティカルなキーワードの
+    包含のみ検証する（執筆の自由度を残す）。order.md「動画差し替え手順」のタスク項目と
+    plan.md §write_tests ステップ指示に対応。
+    """
+
+    def test_has_video_swap_section_heading(self):
+        """Given README
+        When 全文を読む
+        Then 「動画の差し替え」を含む Markdown 見出し（``##`` / ``###``）が存在する。
+
+        運用者が見出しから瞬時に当該手順に到達できるよう、章として独立している必要がある。
+        """
+        text = _read(_STREAMING_README)
+        # ## または ### 行で「動画の差し替え」または「動画差し替え」を含む見出しがあること
+        assert re.search(
+            r"^#{2,3}\s+[^\n]*動画(の)?差し替え",
+            text,
+            flags=re.MULTILINE,
+        ), "README に「動画(の)?差し替え」を含む ## / ### 見出しが無い（運用者が章を辿れない）"
+
+    def test_mentions_tf_var_video_path(self):
+        """Given README
+        When 全文を読む
+        Then ``TF_VAR_video_path`` 環境変数の言及がある。
+
+        差し替え時に新しい動画パスを Terraform に渡すための env 名を運用者が
+        正確に知る必要がある（typo すれば ``var.video_path is required`` で失敗する）。
+        """
+        text = _read(_STREAMING_README)
+        assert "TF_VAR_video_path" in text, (
+            "README に TF_VAR_video_path の言及が無い（差し替え時の env 注入手順が辿れない）"
+        )
+
+    def test_mentions_terraform_plan_for_diff_check(self):
+        """Given README
+        When 全文を読む
+        Then ``terraform ... plan`` の差分確認手順が記載されている。
+
+        order.md「``terraform plan`` で **新動画 only** の差分が出ることの確認手順」要件。
+        apply 前に意図しないリソース（``vultr_instance`` 等）の replace を察知する導線。
+        """
+        text = _read(_STREAMING_README)
+        assert re.search(r"terraform[^\n]*plan", text), (
+            "README に terraform plan の差分確認手順が無い（apply 前の安全確認導線が欠落）"
+        )
+
+    def test_mentions_idle_window_for_zero_downtime(self):
+        """Given README
+        When 全文を読む
+        Then 「休止」または「ダウンタイム」または「0 秒」のいずれかが書かれている。
+
+        order.md「休止時間に実施するのが視聴者には透明」運用 tips 要件。
+        運用者が「いつ apply すべきか」の判断軸を README から得られる必要がある。
+        """
+        text = _read(_STREAMING_README)
+        has_idle = "休止" in text
+        has_downtime = "ダウンタイム" in text
+        has_zero_sec = "0 秒" in text or "0秒" in text
+        assert has_idle or has_downtime or has_zero_sec, (
+            "README に休止時間 / ダウンタイム / 0 秒 のいずれの運用 tips も無い"
+            "（視聴者影響を踏まえた実施タイミングの判断軸が欠落）"
+        )
+
+    def test_mentions_idempotency_with_filemd5(self):
+        """Given README
+        When 全文を読む
+        Then 「filemd5」または「no-op」または「冪等」のいずれかが書かれている。
+
+        order.md テスト第 3 項「同じ動画で再 apply → no-op（filemd5 不変）」の運用根拠。
+        運用者が「動かない」と誤認しないよう、冪等性の仕組みを README から読み取れる必要がある。
+        """
+        text = _read(_STREAMING_README)
+        has_filemd5 = "filemd5" in text
+        has_noop = "no-op" in text
+        has_idempotent = "冪等" in text
+        assert has_filemd5 or has_noop or has_idempotent, (
+            "README に filemd5 / no-op / 冪等 のいずれの言及も無い"
+            "（同一動画で再 apply した時の挙動が運用者に伝わらない）"
+        )
+
+    def test_mentions_current_mp4_overwrite(self):
+        """Given README
+        When 全文を読む
+        Then ``current.mp4`` への上書き（旧動画削除の自然解消）に触れている。
+
+        order.md 完了条件「旧動画は VPS 上に明示的に削除する仕組みを用意」を、
+        単一ファイル方式（``provisioner "file"`` が毎回上書き）で満たす根拠を README に明記する。
+        """
+        text = _read(_STREAMING_README)
+        assert "current.mp4" in text, (
+            "README に current.mp4 への上書きの言及が無い（旧動画が自然消去される根拠が辿れない）"
+        )


### PR DESCRIPTION
## Summary

## 概要

配信中の動画を新しいものに差し替える手順を **Terraform `null_resource.deploy` の triggers ベース** で整備する。`scp` + `systemctl restart` の手動操作ではなく、`terraform apply` 一発で「動画差替 → サービス再起動」までを冪等に実行する。

## 配信パターン前提

- 11h 配信 + 1h 休止 のサイクル中
- **休止時間（毎日 11:00-12:00 / 23:00-0:00）** に差し替えれば視聴者にダウンタイムが見えない
- 配信中に差し替えても次の `RestartSec=1h` 再起動時に新動画が反映される（最大遅延 11h）

## 差し替え手順（Terraform ベース）

```bash
# 1. 新動画を準備
export TF_VAR_video_path=$(realpath ./new_video.mp4)

# 2. 差分計画を確認（null_resource.deploy だけが再実行される予定）
terraform -chdir=infra/terraform/streaming plan

# 3. 適用（filemd5 trigger が変わるので null_resource が再実行 → ファイル送信 + systemctl restart）
terraform -chdir=infra/terraform/streaming apply
```

`null_resource.deploy` の triggers に `filemd5(var.video_path)` が入っているため、video が変わると自動で再実行される。VPS 作成や cloud-init は trigger に含まれないため、**VPS は再作成されない**。

## タスク

- [ ] `infra/terraform/streaming/README.md` に「動画差し替え手順」セクションを追加
  - [ ] 上記コマンド列
  - [ ] 「休止時間に実施するのが視聴者には透明」の運用 tips
  - [ ] `terraform plan` で **新動画 only** の差分が出ることの確認手順
- [ ] スクリプト化（任意）: `scripts/streaming/swap_video.sh`
  - [ ] 引数: 新動画パス
  - [ ] `TF_VAR_video_path` をセットして `terraform apply -auto-approve`
  - [ ] 1 コマンドラッパーとして提供
- [ ] **複数動画を保持するモード**（任意）: 旧動画を残しつつ次回起動時に切り替えたい場合
  - [ ] VPS 上の `/opt/youtube-stream/videos/` に複数 mp4 を `provisioner "file"` で送る
  - [ ] `EnvironmentFile` の `VIDEO=` を切り替えて `systemctl restart`
- [ ] テスト
  - [ ] 配信中に新動画で `apply` → 次の 11h サイクル開始時に新動画になる
  - [ ] 休止中に `apply` → 即座に新動画で配信再開
  - [ ] 同じ動画で再 `apply` → no-op（filemd5 不変）

## 完了条件

- 1 コマンド（`terraform apply` または `swap_video.sh`）で動画差替が完了
- 視聴者から見たダウンタイムが **0 秒**（休止時間に実施する場合）
- 旧動画は VPS 上に明示的に削除する仕組みを用意（誤削除防止のため `terraform destroy` ではなく `null_resource` の cleanup provisioner で限定）
- README に手順とトラブルシューティングが記載されている

## 旧手順との差分

旧 #111 は `scp` + `ssh systemctl restart` の手動 4 ステップだったが、本書き換えでは Terraform の triggers / provisioner に統一し、**チャンネルリポ側でも `terraform apply` のみ覚えれば良い**運用に。

## 関連

- 依存: #125（`null_resource.deploy` 実装）
- 補完: #109（差替後の死活監視で動作確認）
- Tracks: #112
- 旧 issue: 既存 #111 を 24/7 + 手動 scp 前提から 11h+1h 断続 + Terraform 前提に書き換え
- 本書き換え: 2026-05-01 に Terraform `null_resource.deploy` 経由の差替手順に変更

## Execution Report

Workflow `default` completed successfully.

Closes #111