### PR TITLE
[#152] issue-152-critical-yt-fetch-st

### DIFF
--- a/src/youtube_automation/scripts/fetch_stream_key.py
+++ b/src/youtube_automation/scripts/fetch_stream_key.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""yt-fetch-stream-key CLI（issue #135）。
+"""yt-fetch-stream-key CLI（issue #135 / issue #152）。
 
 YouTube Data API ``liveStreams.list`` でストリームキーを取得し、
 ``--stdout`` で標準出力、``--vault/--item`` で 1Password に書き込む。
@@ -7,8 +7,12 @@ YouTube Data API ``liveStreams.list`` でストリームキーを取得し、
 専用 token (``auth/token_streaming.json``) を ``YouTubeOAuthHandler`` に渡し、
 既存 upload 用 token (``auth/token.json``) と分離する。
 
+``--stdout`` モードはストリームキーが平文で流れるため、必ず pipe 経由で受けること
+（直接 TTY に出力しようとすると WARNING を stderr に出して exit code 2 で中断する）。
+GitHub Actions 上では ``::add-mask::<value>`` を先行出力してログマスキングを有効化する。
+
 Usage:
-    yt-fetch-stream-key --stdout
+    yt-fetch-stream-key --stdout | <consumer>          # pipe 経由必須
     yt-fetch-stream-key --vault Personal --item YouTube
     yt-fetch-stream-key --vault Personal --item YouTube --stream-id <id>
 """
@@ -16,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from googleapiclient.discovery import build
@@ -49,7 +54,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--stdout",
         action="store_true",
-        help="ストリームキーを標準出力に書き出す（CI / Terraform 用）",
+        help="ストリームキーを標準出力に書き出す（CI / Terraform 用、pipe 経由必須）",
     )
     parser.add_argument(
         "--vault",
@@ -174,6 +179,30 @@ def extract_stream_info(stream: dict) -> str:
 
 
 # ----------------------------------------------------------------------------
+# stdout 出力（GHA マスキング + TTY ガード）
+# ----------------------------------------------------------------------------
+
+
+def _emit_stdout(value: str) -> None:
+    """``--stdout`` 経路の出力を 1 箇所に閉じ込める（issue #152）。
+
+    - ``GITHUB_ACTIONS == "true"`` のとき ``::add-mask::<value>`` 行を先行出力し、
+      GitHub Actions のログマスキングを有効化する。
+    - ``sys.stdout`` が TTY のとき、平文露出（bash history / ``set -x``）を防ぐため
+      stderr に WARNING を出して ``sys.exit(2)`` で中断する。
+    - いずれでもないとき値のみを stdout に出力する（pipe 経由の正常パス）。
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        # GitHub Actions のログマスキング
+        print(f"::add-mask::{value}")
+    if sys.stdout.isatty():
+        # TTY 出力は警告を stderr に出して中断
+        print("WARNING: stream_key を TTY に出力します。pipe で受けてください。", file=sys.stderr)
+        sys.exit(2)
+    print(value)
+
+
+# ----------------------------------------------------------------------------
 # main
 # ----------------------------------------------------------------------------
 
@@ -189,7 +218,7 @@ def main() -> None:
     stream_name = extract_stream_info(stream)
 
     if args.stdout:
-        print(stream_name)
+        _emit_stdout(stream_name)
         return
 
     write_op_secret(args.vault, args.item, args.field, stream_name)

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -2964,7 +2964,7 @@
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:04.918112+00:00",
+    "timestamp": "2026-05-06T09:37:34.334490+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -2973,11 +2973,11 @@
     "metadata": {
       "phase_name": "phase_1",
       "segment": "seg_001",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_generates_all_segments_an0/seg_001.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_generates_all_segments_an0/seg_001.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:04.984003+00:00",
+    "timestamp": "2026-05-06T09:37:34.400882+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -2986,11 +2986,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_generates_all_segments_an0/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_generates_all_segments_an0/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.146729+00:00",
+    "timestamp": "2026-05-06T09:37:34.564395+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -2999,11 +2999,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_skips_existing_segments0/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_skips_existing_segments0/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.314493+00:00",
+    "timestamp": "2026-05-06T09:37:34.726392+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3012,11 +3012,11 @@
     "metadata": {
       "phase_name": "phase_1",
       "segment": "seg_001",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_retries_on_failure0/seg_001.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_retries_on_failure0/seg_001.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.381343+00:00",
+    "timestamp": "2026-05-06T09:37:34.792859+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3025,11 +3025,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_retries_on_failure0/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_retries_on_failure0/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.545396+00:00",
+    "timestamp": "2026-05-06T09:37:34.956746+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3038,11 +3038,11 @@
     "metadata": {
       "phase_name": "phase_1",
       "segment": "seg_001",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_renames_segment_files_by_0/01-master/seg_001.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_renames_segment_files_by_0/01-master/seg_001.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.610361+00:00",
+    "timestamp": "2026-05-06T09:37:35.026217+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3051,11 +3051,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_renames_segment_files_by_0/01-master/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_renames_segment_files_by_0/01-master/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.772613+00:00",
+    "timestamp": "2026-05-06T09:37:35.187893+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3064,11 +3064,11 @@
     "metadata": {
       "phase_name": "phase_1",
       "segment": "seg_001",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_cleans_up_segment_files_w0/seg_001.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_cleans_up_segment_files_w0/seg_001.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:05.842111+00:00",
+    "timestamp": "2026-05-06T09:37:35.253504+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3077,11 +3077,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_cleans_up_segment_files_w0/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_cleans_up_segment_files_w0/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:06.009767+00:00",
+    "timestamp": "2026-05-06T09:37:35.418946+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3090,11 +3090,11 @@
     "metadata": {
       "phase_name": "phase_1",
       "segment": "seg_001",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_generates_all_se0/01-master/seg_001.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_generates_all_se0/01-master/seg_001.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:06.009716+00:00",
+    "timestamp": "2026-05-06T09:37:35.419010+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3103,11 +3103,11 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_generates_all_se0/01-master/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_generates_all_se0/01-master/seg_002.wav"
     }
   },
   {
-    "timestamp": "2026-05-06T09:35:06.171987+00:00",
+    "timestamp": "2026-05-06T09:37:35.585679+00:00",
     "category": "audio",
     "model": "lyria-3-pro-preview",
     "quantity": 1,
@@ -3116,7 +3116,7 @@
     "metadata": {
       "phase_name": "phase_2",
       "segment": "seg_002",
-      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_partial_failure0/seg_002.wav"
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_partial_failure0/seg_002.wav"
     }
   }
 ]

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -2962,5 +2962,161 @@
       "segment": "seg_001",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-204/test_parallel_partial_failure0/seg_001.wav"
     }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:04.918112+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:04.984003+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.146729+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.314493+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.381343+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.545396+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.610361+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.772613+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:05.842111+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:06.009767+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:06.009716+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:35:06.171987+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-223/test_parallel_partial_failure0/seg_002.wav"
+    }
   }
 ]

--- a/tests/test_fetch_stream_key.py
+++ b/tests/test_fetch_stream_key.py
@@ -506,6 +506,24 @@ class TestCli:
         with pytest.raises(SystemExit):
             fsk.main()
 
+    def test_stdout_and_vault_mutually_exclusive(self, monkeypatch):
+        """Given ``--stdout`` と ``--vault/--item`` を同時指定
+        When ``main()``
+        Then ``SystemExit``（mutex 違反: ``_validate_output_target`` 内
+        ``parser.error`` 経由で argparse が exit する）。
+
+        issue #152 で未カバーだった ``stdout=True and has_op_target`` 分岐の回帰テスト。
+        """
+        from youtube_automation.scripts import fetch_stream_key as fsk
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["yt-fetch-stream-key", "--stdout", "--vault", "Personal", "--item", "YouTube"],
+        )
+
+        with pytest.raises(SystemExit):
+            fsk.main()
+
     def test_stream_id_flag_is_passed_to_select_stream(self, monkeypatch):
         """Given ``--stream-id explicit-id``
         When ``main()``
@@ -537,3 +555,122 @@ class TestCli:
         args = call_args.args
         passed_id = kwargs.get("stream_id") if "stream_id" in kwargs else (args[1] if len(args) > 1 else None)
         assert passed_id == "explicit-id", f"stream_id flag not propagated: args={args} kwargs={kwargs}"
+
+    def test_main_emits_add_mask_under_github_actions(self, capsys, monkeypatch):
+        """Given ``GITHUB_ACTIONS=true`` 環境下で ``--stdout``
+        When ``main()``
+        Then stdout に ``::add-mask::<key>`` 行が出る（CLI 入口 → ``_emit_stdout`` 配線確認）。
+
+        到達経路のリグレッション担保: ``main()`` の出力箇所が
+        マスキング対応経路（``_emit_stdout``）を確実に通っていることを保証する。
+        """
+        from youtube_automation.scripts import fetch_stream_key as fsk
+
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        monkeypatch.setattr("sys.argv", ["yt-fetch-stream-key", "--stdout"])
+
+        fake_stream = _make_stream(stream_name="masked-key-42")
+        with (
+            patch.object(fsk, "get_streaming_credentials", return_value=MagicMock()),
+            patch.object(fsk, "list_live_streams", return_value=[fake_stream]),
+        ):
+            fsk.main()
+
+        captured = capsys.readouterr()
+        assert "::add-mask::masked-key-42" in captured.out, (
+            f"GHA mask line missing on main()'s stdout: {captured.out!r}"
+        )
+        assert "masked-key-42" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# _emit_stdout（GHA マスキング / TTY ガード / 通常出力）
+# ---------------------------------------------------------------------------
+
+
+class TestEmitStdout:
+    """``_emit_stdout(value)`` の純関数振る舞い検証（issue #152）。
+
+    挙動仕様（``order.md`` §マスキング）:
+    - ``GITHUB_ACTIONS == "true"`` のとき stdout に ``::add-mask::<value>`` を出す
+    - ``sys.stdout.isatty()`` が True のとき stderr に WARNING を出して ``sys.exit(2)``
+    - いずれにも該当しないとき stdout に ``<value>`` のみを出す
+
+    観測可能な振る舞い（stdout / stderr / exit code）のみを検証し、
+    ``os.environ.get`` の呼び出し回数のような実装詳細には依存しない。
+    """
+
+    def test_emits_add_mask_line_when_github_actions_is_true(self, capsys, monkeypatch):
+        """Given ``GITHUB_ACTIONS="true"`` + 非TTY（capsys デフォルト）
+        When ``_emit_stdout("my-key-1234")``
+        Then stdout に ``::add-mask::my-key-1234`` 行 → ``my-key-1234`` 行 の順で出る。
+
+        順序まで担保するため ``splitlines()`` 一致で検証する。
+        """
+        from youtube_automation.scripts.fetch_stream_key import _emit_stdout
+
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+        _emit_stdout("my-key-1234")
+
+        captured = capsys.readouterr()
+        lines = captured.out.splitlines()
+        assert lines == ["::add-mask::my-key-1234", "my-key-1234"], (
+            f"expected GHA mask line followed by value line, got: {lines!r}"
+        )
+
+    def test_does_not_emit_add_mask_when_github_actions_is_unset(self, capsys, monkeypatch):
+        """Given ``GITHUB_ACTIONS`` 未設定 + 非TTY
+        When ``_emit_stdout("plain-value")``
+        Then ``::add-mask::`` プレフィックス行は出ず、値のみ出る（既存挙動の維持）。
+        """
+        from youtube_automation.scripts.fetch_stream_key import _emit_stdout
+
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+        _emit_stdout("plain-value")
+
+        captured = capsys.readouterr()
+        assert "::add-mask::" not in captured.out, f"unexpected GHA mask prefix when env unset: {captured.out!r}"
+        assert "plain-value" in captured.out
+
+    def test_does_not_emit_add_mask_when_github_actions_is_not_literally_true(self, capsys, monkeypatch):
+        """Given ``GITHUB_ACTIONS="false"``（``"true"`` 完全一致でない）+ 非TTY
+        When ``_emit_stdout("plain-value")``
+        Then ``::add-mask::`` 行は出ない。
+
+        ``order.md`` の ``== "true"`` 仕様の境界検証。誤判定で平文露出するリスクの予防。
+        """
+        from youtube_automation.scripts.fetch_stream_key import _emit_stdout
+
+        monkeypatch.setenv("GITHUB_ACTIONS", "false")
+
+        _emit_stdout("plain-value")
+
+        captured = capsys.readouterr()
+        assert "::add-mask::" not in captured.out, (
+            f"GHA mask prefix should not appear when env != 'true': {captured.out!r}"
+        )
+        assert "plain-value" in captured.out
+
+    def test_exits_with_code_2_when_stdout_is_a_tty(self, capsys, monkeypatch):
+        """Given ``sys.stdout.isatty()`` が True
+        When ``_emit_stdout("tty-key")``
+        Then ``SystemExit(code=2)`` + stderr に WARNING + stdout に値が出ない。
+
+        TTY 経由での平文露出を防止する異常パス。``GITHUB_ACTIONS`` を未設定にして
+        マスク行による偽陽性（stdout に "tty-key" を含む可能性）を排除する。
+        """
+        from youtube_automation.scripts.fetch_stream_key import _emit_stdout
+
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        with pytest.raises(SystemExit) as exc:
+            _emit_stdout("tty-key")
+
+        assert exc.value.code == 2, f"expected exit code 2, got: {exc.value.code!r}"
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err, f"warning must be emitted to stderr on TTY: {captured.err!r}"
+        assert "tty-key" not in captured.out, f"value must not appear on TTY stdout: {captured.out!r}"


### PR DESCRIPTION
## Summary

## 概要

`yt-fetch-stream-key --stdout` モードで stream_key を素の `print()` 出力しており、GitHub Actions ログ・bash history・`set -x` で平文露出する設計欠陥。さらに `--stdout` と `--vault/--item` の排他チェック (`_validate_output_target`) のうち、両方同時指定の分岐がテスト未網羅。

## 該当箇所

- `src/youtube_automation/scripts/fetch_stream_key.py:49-53, 191-193`
- `tests/test_fetch_stream_key.py::TestCli`（mutex テスト未存在）

## 推奨対応

### マスキング

```python
def _emit_stdout(value: str) -> None:
    if os.environ.get("GITHUB_ACTIONS") == "true":
        # GitHub Actions のログマスキング
        print(f"::add-mask::{value}")
    if sys.stdout.isatty():
        # TTY 出力は警告を stderr に出して中断
        print("WARNING: stream_key を TTY に出力します。pipe で受けてください。", file=sys.stderr)
        sys.exit(2)
    print(value)
```

ドキュメントで pipe 利用に限定する旨を明記。

### テスト追加

```python
def test_stdout_and_vault_mutually_exclusive():
    with pytest.raises(SystemExit):
        _validate_output_target(stdout=True, vault="Personal", item="YouTube")
```
$(footer "audit-#4, SUM-NEW-fetch-stream-key-stdout-vault-mutex-uncovered")

## Execution Report

Workflow `default-extended` completed successfully.

Closes #152