### PR TITLE
[#150] issue-150-critical-client-secr

### DIFF
--- a/src/youtube_automation/utils/secrets.py
+++ b/src/youtube_automation/utils/secrets.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 import shutil
 import subprocess
@@ -101,10 +102,20 @@ def get_client_secrets_path() -> Path:
         return _client_secrets_tempfile
 
     json_content = get_secret("CLIENT_SECRETS_JSON")
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", prefix="client_secrets_", delete=False)
-    tmp.write(json_content)
-    tmp.close()
-    _client_secrets_tempfile = Path(tmp.name)
+    # mkstemp → chmod → fdopen の順序を厳守: 書き込み前に 0o600 を確定させ
+    # OS umask に依存せず world-readable な状態を経由しないことを保証する
+    fd, path = tempfile.mkstemp(prefix="client_secrets_", suffix=".json")
+    os.chmod(path, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(json_content)
+
+    def _cleanup(p: str = path) -> None:
+        # idempotent: ファイルが既に消えていても atexit 連鎖を止めない
+        if os.path.exists(p):
+            os.unlink(p)
+
+    atexit.register(_cleanup)
+    _client_secrets_tempfile = Path(path)
     return _client_secrets_tempfile
 
 

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -2962,5 +2962,161 @@
       "segment": "seg_001",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-204/test_parallel_partial_failure0/seg_001.wav"
     }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.334490+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.400882+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.564395+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.726392+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.792859+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:34.956746+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.026217+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.187893+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.253504+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.418946+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.419010+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-06T09:37:35.585679+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-224/test_parallel_partial_failure0/seg_002.wav"
+    }
   }
 ]

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from youtube_automation.utils import secrets as secrets_module
 from youtube_automation.utils.exceptions import ConfigError
-from youtube_automation.utils.secrets import _SECRET_REFS, get_secret, reset_cache
+from youtube_automation.utils.secrets import (
+    _SECRET_REFS,
+    get_client_secrets_path,
+    get_secret,
+    reset_cache,
+)
 
 _TEST_SECRET = "CLIENT_SECRETS_JSON"
 _MANAGED_SECRETS = ("CLIENT_SECRETS_JSON", "OPENAI_API_KEY")
@@ -220,3 +227,214 @@ class TestStreamingSecretsRegistered:
         with patch("youtube_automation.utils.secrets.shutil.which", return_value=None):
             with pytest.raises(ConfigError, match=name):
                 get_secret(name)
+
+
+# ---------- Issue #150: client_secrets tempfile の atexit クリーンアップ ----------
+
+
+_TEST_JSON_PAYLOAD = '{"installed":{"client_id":"x"}}'
+_EXPECTED_PREFIX = "client_secrets_"
+_EXPECTED_SUFFIX = ".json"
+_EXPECTED_MODE = 0o600
+
+
+class TestGetClientSecretsPath:
+    """`get_client_secrets_path` の振る舞いを検証する。
+
+    plan.md / test-design.md に基づく 12 ケース:
+      1. 初回呼び出しで実在する tempfile への Path を返す
+      2. 同一プロセス内 2 回呼ぶと同じ Path / get_secret 1 回のみ
+      3. キャッシュミス時に atexit.register がちょうど 1 回呼ばれる
+      4. 作成された tempfile のパーミッションは 0o600
+      5. ファイル名が `client_secrets_` prefix / `.json` suffix
+      6. キャッシュヒット時に atexit.register が再度呼ばれない
+      7. tempfile の中身が get_secret の戻り値と一致する
+      8. 登録された atexit ハンドラを実行すると tempfile が削除される
+      9. atexit ハンドラ実行時にファイルが既に消えていても例外を投げない
+     10. キャッシュされたファイルが消失していたら新規作成する
+     11. get_secret が ConfigError を raise したら伝播し、tempfile を作らない
+     12. get_secret が raise したとき atexit.register が呼ばれない
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_client_secrets_tempfile(self):
+        """テスト前後でモジュール変数 `_client_secrets_tempfile` を必ず None に戻し、
+        実 tempfile が残っていれば削除する。テスト独立性確保のため。
+        """
+        prev = secrets_module._client_secrets_tempfile
+        secrets_module._client_secrets_tempfile = None
+        yield
+        leftover = secrets_module._client_secrets_tempfile
+        secrets_module._client_secrets_tempfile = prev
+        if leftover is not None and leftover.exists():
+            try:
+                os.unlink(leftover)
+            except OSError:
+                pass
+
+    # ---- Case 1 ----
+    def test_returns_path_to_existing_tempfile_on_first_call(self):
+        """Given get_secret がモック JSON を返す
+        When get_client_secrets_path() を初めて呼ぶ
+        Then 実在する tempfile への Path を返す
+        """
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
+            path = get_client_secrets_path()
+        assert isinstance(path, Path)
+        assert path.exists()
+
+    # ---- Case 2 ----
+    def test_returns_same_path_and_calls_get_secret_once_on_repeat_calls(self):
+        """Given 同一プロセス内で 2 回呼び出す
+        When 2 回目の get_client_secrets_path()
+        Then 同じ Path が返り、get_secret は 1 回しか呼ばれない
+        """
+        with patch(
+            "youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD
+        ) as mock_get_secret:
+            first = get_client_secrets_path()
+            second = get_client_secrets_path()
+        assert first == second
+        assert mock_get_secret.call_count == 1
+
+    # ---- Case 3 ----
+    def test_registers_exactly_one_atexit_handler_on_cache_miss(self):
+        """Given キャッシュミス（初回呼び出し）
+        When get_client_secrets_path() を呼ぶ
+        Then atexit.register がちょうど 1 回呼ばれる
+        """
+        with (
+            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
+            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
+        ):
+            get_client_secrets_path()
+        assert mock_register.call_count == 1
+
+    # ---- Case 4 ----
+    def test_creates_tempfile_with_owner_only_permissions(self):
+        """Given get_secret がモック JSON を返す
+        When get_client_secrets_path() を呼ぶ
+        Then 作成された tempfile のパーミッションは 0o600
+        """
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
+            path = get_client_secrets_path()
+        mode = os.stat(path).st_mode & 0o777
+        assert mode == _EXPECTED_MODE
+
+    # ---- Case 5 ----
+    def test_tempfile_name_uses_expected_prefix_and_suffix(self):
+        """Given get_secret がモック JSON を返す
+        When get_client_secrets_path() を呼ぶ
+        Then ファイル名は "client_secrets_" prefix / ".json" suffix
+        """
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
+            path = get_client_secrets_path()
+        assert path.name.startswith(_EXPECTED_PREFIX)
+        assert path.name.endswith(_EXPECTED_SUFFIX)
+
+    # ---- Case 6 ----
+    def test_does_not_register_atexit_on_cache_hit(self):
+        """Given 1 回目で tempfile を作成済み
+        When 2 回目の get_client_secrets_path() を呼ぶ
+        Then atexit.register は再度呼ばれない（合計 1 回のまま）
+        """
+        with (
+            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
+            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
+        ):
+            get_client_secrets_path()
+            get_client_secrets_path()
+        assert mock_register.call_count == 1
+
+    # ---- Case 7 ----
+    def test_tempfile_content_matches_get_secret_return_value(self):
+        """Given get_secret がモック JSON を返す
+        When get_client_secrets_path() を呼ぶ
+        Then 書き出された tempfile の中身は get_secret の戻り値と一致する
+        """
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
+            path = get_client_secrets_path()
+        assert path.read_text() == _TEST_JSON_PAYLOAD
+
+    # ---- Case 8 ----
+    def test_registered_cleanup_handler_removes_tempfile(self):
+        """Given get_client_secrets_path() で atexit に登録された cleanup
+        When 登録された callback を手動実行する
+        Then tempfile が削除される
+        """
+        with (
+            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
+            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
+        ):
+            path = get_client_secrets_path()
+            cleanup = mock_register.call_args[0][0]
+        assert path.exists()
+        cleanup()
+        assert not path.exists()
+
+    # ---- Case 9 ----
+    def test_cleanup_handler_is_idempotent_when_file_already_gone(self):
+        """Given 登録された cleanup callback
+        When ファイルを先に削除した状態で cleanup() を呼ぶ
+        Then 例外は投げない（atexit 連鎖を止めない）
+        """
+        with (
+            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
+            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
+        ):
+            path = get_client_secrets_path()
+            cleanup = mock_register.call_args[0][0]
+        # 先に手動で消す
+        path.unlink()
+        assert not path.exists()
+        # ここで例外が出れば pytest がテストを失敗にする
+        cleanup()
+
+    # ---- Case 10 ----
+    def test_recreates_tempfile_when_cached_path_no_longer_exists(self):
+        """Given キャッシュ変数に Path はあるが実ファイルが既に消えている状態
+        When get_client_secrets_path() を呼ぶ
+        Then 新しい tempfile が作成される
+        """
+        # キャッシュをセットしつつファイルは存在させない
+        secrets_module._client_secrets_tempfile = Path("/tmp/__nonexistent_client_secrets__.json")
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
+            path = get_client_secrets_path()
+        assert path.exists()
+        assert path != Path("/tmp/__nonexistent_client_secrets__.json")
+
+    # ---- Case 11 ----
+    def test_propagates_config_error_and_does_not_create_tempfile(self):
+        """Given get_secret が ConfigError を raise する
+        When get_client_secrets_path() を呼ぶ
+        Then ConfigError が伝播し、tempfile は作成されない（mkstemp 未呼出）
+        """
+        with (
+            patch(
+                "youtube_automation.utils.secrets.get_secret",
+                side_effect=ConfigError("test failure"),
+            ),
+            patch("youtube_automation.utils.secrets.tempfile.mkstemp") as mock_mkstemp,
+        ):
+            with pytest.raises(ConfigError, match="test failure"):
+                get_client_secrets_path()
+            mock_mkstemp.assert_not_called()
+        # キャッシュも汚染されていない
+        assert secrets_module._client_secrets_tempfile is None
+
+    # ---- Case 12 ----
+    def test_does_not_register_atexit_when_get_secret_raises(self):
+        """Given get_secret が ConfigError を raise する
+        When get_client_secrets_path() を呼ぶ
+        Then atexit.register は呼ばれない（エラー時の atexit 汚染防止）
+        """
+        with (
+            patch(
+                "youtube_automation.utils.secrets.get_secret",
+                side_effect=ConfigError("test failure"),
+            ),
+            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
+        ):
+            with pytest.raises(ConfigError):
+                get_client_secrets_path()
+        mock_register.assert_not_called()


### PR DESCRIPTION
## Summary

## 概要

`utils/secrets.py:84-108` の `_client_secrets_tempfile` が `delete=False` の `NamedTemporaryFile` で `/tmp/client_secrets_*.json` を生成、クリーンアップ機構なし。OAuth `client_secret` が OS 再起動・バックアップ・フォレンジックに永続露出する。

## 該当箇所

- `src/youtube_automation/utils/secrets.py:84-108`

## 推奨対応

```python
import atexit, os, tempfile

def _client_secrets_tempfile() -> Path:
    fd, path = tempfile.mkstemp(prefix="client_secrets_", suffix=".json")
    os.chmod(path, 0o600)
    with os.fdopen(fd, "w") as f:
        f.write(...)  # 既存の write 内容
    atexit.register(lambda: os.path.exists(path) and os.unlink(path))
    return Path(path)
```

`mkstemp` で生成時から 0o600 を保証し、`atexit` でプロセス終了時に確実に削除。
$(footer "audit-#2")

## Execution Report

Workflow `default-extended` completed successfully.

Closes #150