### PR TITLE
[#163] issue-163-medium-utils-secrets

### DIFF
--- a/src/youtube_automation/utils/secrets.py
+++ b/src/youtube_automation/utils/secrets.py
@@ -68,9 +68,6 @@ def get_secret(name: str) -> str:
             )
             value = result.stdout.strip()
             if value:
-                # SDK ライブラリが暗黙に os.environ を参照するケースに備えて
-                # プロセス内の環境変数にもセットしておく（プロセス終了で消える）
-                os.environ[name] = value
                 return value
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
             pass

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -2,7 +2,7 @@
 
 検証する 3 経路:
 1. os.environ に既にあれば op を呼ばずにそれを返す
-2. os.environ に無く op がある場合は op read で取得し、os.environ にもセットする
+2. os.environ に無く op がある場合は op read で取得して返す（os.environ への書き戻しは行わない）
 3. どちらも失敗したら ConfigError を raise する
 """
 
@@ -67,8 +67,8 @@ class TestGetSecret:
         assert value == "from-op-67890"
         mock_run.assert_called_once()
 
-    def test_op_read_result_is_cached_in_environ(self):
-        """op read で取得した値は os.environ にもセットされる"""
+    def test_op_read_result_is_not_written_to_environ(self):
+        """op read で取得した値は os.environ にセットされない（global env 注入禁止: Issue #163）"""
         with (
             patch("youtube_automation.utils.secrets.shutil.which", return_value="/usr/bin/op"),
             patch("youtube_automation.utils.secrets.subprocess.run") as mock_run,
@@ -76,11 +76,11 @@ class TestGetSecret:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=["op", "read", "..."],
                 returncode=0,
-                stdout="cached-value\n",
+                stdout="op-only-value\n",
                 stderr="",
             )
             get_secret(_TEST_SECRET)
-        assert os.environ.get(_TEST_SECRET) == "cached-value"
+        assert os.environ.get(_TEST_SECRET) is None
 
     def test_raises_config_error_when_op_unavailable_and_environ_empty(self):
         """op が無く os.environ も空なら ConfigError"""


### PR DESCRIPTION
## Summary

## 概要

`utils/secrets.py:72` で取得した secret を `os.environ[name] = value` でプロセス global env に注入しているため、以後 fork される全 subprocess（`terraform`, `op`, `ffprobe` 等）に無関係 secret まで継承される（scope creep / leak）。

## 推奨対応

global 注入を撤去し、必要な subprocess 呼び出し時のみ明示渡し:

```python
# 撤去
- os.environ[name] = value

# 呼び出し側
subprocess.run(
    ["terraform", "apply"],
    env={**os.environ, "TF_VAR_stream_key": get_secret("STREAM_KEY")},
    check=True,
)
```

各 secret が必要な call サイトを `grep -rn 'get_secret\|VULTR_API_KEY\|STREAM_KEY' src/` で洗い出し、明示 env 渡しに置換。
$(footer "audit-#7")

## Execution Report

Workflow `default-extended` completed successfully.

Closes #163