### PR TITLE
[#185] issue-185-feat-streaming-wo-fu

### DIFF
--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -53,6 +53,7 @@ systemd unit が以下の挙動を持つ:
 - `RuntimeMaxSec=11h`: 配信開始から 11 時間で `ffmpeg` プロセスを強制停止 → YouTube 側でアーカイブ生成
 - `Restart=always` + `RestartSec=1h`: 停止から 1 時間後に自動再起動 → 2 本目の配信が始まる
 - `EnvironmentFile=/etc/youtube-stream.env` から `VIDEO` / `RTMP_URL` を読み込むため、`ExecStart` に stream key が平文で残らない
+- 音声は動画ファイルの音声トラックを送出（`-c:a copy`、再エンコードなし）
 
 `null_resource.deploy` は `terraform apply` のたびに以下のトリガーを比較し、差分があれば再実行する:
 

--- a/infra/terraform/streaming/templates/youtube-stream.service.tftpl
+++ b/infra/terraform/streaming/templates/youtube-stream.service.tftpl
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/youtube-stream.env
-ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -f lavfi -i anullsrc=r=44100:cl=stereo -c:v copy -c:a aac -b:a 128k -map 0:v -map 1:a -f flv $RTMP_URL
+ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO -c:v copy -c:a copy -f flv $RTMP_URL
 RuntimeMaxSec=11h
 Restart=always
 RestartSec=1h

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -692,15 +692,17 @@ class TestSystemdUnitTemplate:
     def test_service_exec_start_uses_env_vars_not_literals(self):
         """Given .tftpl
         When [Service].ExecStart を読む
-        Then 無音 audio を mux した ffmpeg コマンドが宣言されている (R12 改訂)。
+        Then 動画ファイル自体の音声トラックを ``-c:a copy`` で送出する ffmpeg コマンドが
+        宣言されている (R12 再改訂 / #185)。
 
-        実証: 映像のみ(``-c copy``) で送信すると YouTube Live が
-        ``streamStatus=inactive / healthStatus=noData`` のまま broadcast を認識しない。
-        ``anullsrc`` で無音 AAC を mux すると即座に ``streamStatus=active`` に遷移する。
+        旧仕様 (R12 改訂) では ``-f lavfi -i anullsrc=...`` で仮想無音入力を 2 番目に
+        足し ``-c:a aac -b:a 128k -map 0:v -map 1:a`` で音声を上書きしていたため、
+        動画に音声があっても配信は無音になっていた。#185 で anullsrc 経路を撤去し、
+        ffmpeg の自動マッピング（best v/a 各 1 ストリーム）に任せて
+        ``-c:a copy`` で再エンコードなしに送出する。
 
         ``ExecStart=/usr/bin/ffmpeg -re -stream_loop -1 -i $VIDEO``
-        ``-f lavfi -i anullsrc=r=44100:cl=stereo``
-        ``-c:v copy -c:a aac -b:a 128k -map 0:v -map 1:a -f flv $RTMP_URL``
+        ``-c:v copy -c:a copy -f flv $RTMP_URL``
         """
         text = _read(_SYSTEMD_TFTPL)
         service = self._section(text, "Service")
@@ -708,13 +710,12 @@ class TestSystemdUnitTemplate:
         expected = (
             r"^ExecStart=/usr/bin/ffmpeg\s+-re\s+-stream_loop\s+-1\s+"
             r"-i\s+\$VIDEO\s+"
-            r"-f\s+lavfi\s+-i\s+anullsrc=r=44100:cl=stereo\s+"
-            r"-c:v\s+copy\s+-c:a\s+aac\s+-b:a\s+128k\s+"
-            r"-map\s+0:v\s+-map\s+1:a\s+"
+            r"-c:v\s+copy\s+-c:a\s+copy\s+"
             r"-f\s+flv\s+\$RTMP_URL\s*$"
         )
         assert re.search(expected, service, flags=re.MULTILINE), (
-            "[Service].ExecStart が改訂後の ffmpeg コマンド（anullsrc audio mux つき）と一致しない"
+            "[Service].ExecStart が #185 改訂後の ffmpeg コマンド"
+            "（動画音声をそのまま -c:a copy で送出）と一致しない"
         )
 
     def test_service_runtime_max_sec_11h(self):


### PR DESCRIPTION
## Summary

## Background

`infra/terraform/streaming/templates/youtube-stream.service.tftpl` の `ExecStart` は
`-f lavfi -i anullsrc=r=44100:cl=stereo` で**仮想的な無音入力**を 2 番目に追加し、
`-c:a aac -b:a 128k -map 0:v -map 1:a` で音声トラックを上書きしている。

このため動画ファイルに音声があっても**配信は無音**になり、楽曲付き 24/7 ライブ配信ができない。

## What

`anullsrc` 仮想入力を削除し、動画ファイル自体の音声トラックを送出するよう unit を変更する。

## Acceptance

- `templates/youtube-stream.service.tftpl` の `ExecStart` から `anullsrc` 関連オプション (`-f lavfi -i anullsrc=...` と `-map 0:v -map 1:a`) を削除
- 音声は **`-c:a copy`** で送出（入力動画の AAC をそのまま流す。再エンコード不要、品質劣化なし）
- ffmpeg の自動マッピング（best v/a 各 1 ストリーム）に任せる前提のため `-map` は削除
- `infra/terraform/streaming/README.md` §配信サイクル に「音声は動画ファイルの音声トラックを送出（`-c:a copy`）」記述を追加
- 既存の 11h+1h サイクル動作・healthcheck 動作・帯域試算は影響を受けないこと

## Scope

- 触る: `infra/terraform/streaming/templates/youtube-stream.service.tftpl` / `infra/terraform/streaming/README.md`
- 触らない: `main.tf` / `cloud-init.yaml` / `variables.tf` / 他の cron / 帯域モニタリング / `scripts/streaming/swap_video.sh`

## Verification

- `terraform plan` で `null_resource.deploy` の `triggers` が変わり replace 予定になること（テンプレート変更により `cloud-init` レンダリング結果のハッシュが変わるため）
- 検証 apply は本 issue の PR マージ後、別途実機で実施

## Related

Epic: #112

## Execution Report

Workflow `default` completed successfully.

Closes #185