### PR TITLE
[#168] issue-168-test-stream-bandwidt

### DIFF
--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -171,21 +171,22 @@ class TestOpenAIApiKeyRegistered:
 
 
 class TestStreamingSecretsRegistered:
-    """VULTR_API_KEY と STREAM_WEBHOOK_URL が `_SECRET_REFS` に登録され、
-    既存 3 経路 (env / op / fail) がそのまま機能することを確認する。
+    """VULTR_API_KEY / STREAM_WEBHOOK_URL / DISCORD_WEBHOOK_URL の 3 シークレットが
+    `_SECRET_REFS` に登録され、4 経路 (登録確認 / env / op-fallback / fail) が
+    そのまま機能することを確認する。
     """
 
     @pytest.fixture(autouse=True)
     def _clean(self):
-        for name in ("VULTR_API_KEY", "STREAM_WEBHOOK_URL"):
+        for name in ("VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"):
             os.environ.pop(name, None)
         reset_cache()
         yield
-        for name in ("VULTR_API_KEY", "STREAM_WEBHOOK_URL"):
+        for name in ("VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"):
             os.environ.pop(name, None)
         reset_cache()
 
-    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL"])
+    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"])
     def test_secret_is_registered_in_secret_refs(self, name: str):
         """Given _SECRET_REFS
         When 引く
@@ -195,7 +196,7 @@ class TestStreamingSecretsRegistered:
         ref = _SECRET_REFS[name]
         assert ref.startswith("op://"), f"1Password 参照 URI 形式でない: {ref}"
 
-    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL"])
+    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"])
     def test_returns_from_environ_when_present(self, name: str):
         """既に os.environ にあれば op を呼ばずにそれを返す。"""
         os.environ[name] = f"value-of-{name}"
@@ -204,7 +205,7 @@ class TestStreamingSecretsRegistered:
         assert value == f"value-of-{name}"
         mock_run.assert_not_called()
 
-    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL"])
+    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"])
     def test_falls_back_to_op_read(self, name: str):
         """env に無く op が成功すれば op read の値を返す。"""
         with (
@@ -221,7 +222,7 @@ class TestStreamingSecretsRegistered:
         assert value == f"from-op-{name}"
         mock_run.assert_called_once()
 
-    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL"])
+    @pytest.mark.parametrize("name", ["VULTR_API_KEY", "STREAM_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"])
     def test_raises_config_error_when_unavailable(self, name: str):
         """env も op も空なら ConfigError。"""
         with patch("youtube_automation.utils.secrets.shutil.which", return_value=None):

--- a/tests/test_stream_bandwidth_cli.py
+++ b/tests/test_stream_bandwidth_cli.py
@@ -13,8 +13,11 @@ CLI モード:
 
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from youtube_automation.cli import stream_bandwidth
 
@@ -85,18 +88,28 @@ def test_default_mode_prints_summary_no_webhook(capsys):
     """Given 引数なし
     When CLI を実行
     Then 現状サマリが stdout に出力され、webhook 投稿は呼ばれない。
+
+    `today()` を当月 (2026-04) の月末に凍結することで、fixture 由来の
+    100 GB が `monthly_total_gb` に反映されることを保証する。`today()`
+    patch を外すと `"100.0 GB"` assertion が失敗するため、当月不一致
+    fixture による偽陽性 pass を防ぐ。
     """
-    bw = {"2026-04-01": {"incoming_bytes": 1024**3, "outgoing_bytes": 0}}
+    # 当月 100 GB (1024**3 * 100 bytes)
+    bw = {"2026-04-01": {"incoming_bytes": 1024**3 * 100, "outgoing_bytes": 0}}
     mocks = _patch_all(bandwidth=bw)
     enters = _enter(mocks)
     try:
-        rc = stream_bandwidth.main(["--instance-id", "VULTR_X"])
+        with patch(
+            "youtube_automation.cli.stream_bandwidth.today",
+            return_value=date(2026, 4, 30),
+        ):
+            rc = stream_bandwidth.main(["--instance-id", "VULTR_X"])
     finally:
         _exit(mocks)
     assert rc == 0
     out = capsys.readouterr().out
-    # サマリ出力を確認 (GB を含む)
-    assert "GB" in out
+    # patch を外すと "0.0 GB" になり失敗する形にすることでリグレッションを検出
+    assert "100.0 GB" in out
     # notify は呼ばれない
     notify_mock = enters[4]
     notify_mock.assert_not_called()
@@ -130,6 +143,41 @@ def test_report_mode_calls_notify_with_formatted_text():
     assert webhook_url == "https://example.com/hook"
     assert content is not None
     assert "2026-04" in content
+
+
+def test_report_mode_emits_na_when_previous_month_has_no_data():
+    """Given 前月キーを持たない fixture
+    When --report --month 2026-04
+    Then notify content に "N/A" / "前月データなし" が含まれる。
+
+    `cli/stream_bandwidth.py:136-139` の `previous_usage_gb == 0 → None` 変換と、
+    `monthly_report._format_diff_gb` (`utils/streaming/monthly_report.py:20-23`) の
+    `"前月比: N/A (前月データなし)"` 出力経路を結合検証する。前月キー (2026-03-*) を
+    fixture に含めないことで `monthly_total_gb` が 0.0 を返す経路を素直に通す。
+    """
+    # 対象月 2026-04 のキーのみ (前月 2026-03 のキーなし)
+    bw = {"2026-04-15": {"incoming_bytes": 1024**3 * 200, "outgoing_bytes": 0}}
+    mocks = _patch_all(bandwidth=bw)
+    enters = _enter(mocks)
+    # `_run_report` は --month 明示時 today() を経由しないが、_previous_month の
+    # 引数解決と将来の経路変化に備えて凍結し意図を固定する。
+    with patch(
+        "youtube_automation.cli.stream_bandwidth.today",
+        return_value=date(2026, 5, 1),
+    ):
+        try:
+            rc = stream_bandwidth.main(["--report", "--month", "2026-04", "--instance-id", "VULTR_X"])
+        finally:
+            _exit(mocks)
+    assert rc == 0
+    notify_mock = enters[4]
+    notify_mock.assert_called_once()
+    kwargs = notify_mock.call_args.kwargs
+    args = notify_mock.call_args.args
+    content = kwargs.get("content") if "content" in kwargs else (args[0] if args else None)
+    assert content is not None
+    assert "N/A" in content
+    assert "前月データなし" in content
 
 
 def test_report_mode_defaults_to_previous_month_when_month_not_given():
@@ -200,18 +248,35 @@ def test_check_threshold_silent_when_under_threshold():
     """Given usage が閾値未満
     When --check-threshold
     Then notify は呼ばれない (silent)。
+
+    silent モードは stdout を持たないため `notify.assert_not_called()` だけでは
+    0 GB 経路と 100 GB 経路を区別できない。`today()` を当月に凍結したうえで
+    `is_over_threshold` を spy 化し、call_args.usage_gb=100.0 を verify する
+    ことで、fixture 由来の usage が閾値判定に届いていることを白箱検証する。
     """
     # 100 GB (閾値 1638.4 GB を大きく下回る)
     bw = {"2026-04-15": {"incoming_bytes": 1024**3 * 100, "outgoing_bytes": 0}}
     mocks = _patch_all(bandwidth=bw)
     enters = _enter(mocks)
     try:
-        rc = stream_bandwidth.main(["--check-threshold", "--instance-id", "VULTR_X"])
+        with (
+            patch(
+                "youtube_automation.cli.stream_bandwidth.today",
+                return_value=date(2026, 4, 30),
+            ),
+            patch(
+                "youtube_automation.cli.stream_bandwidth.is_over_threshold",
+                return_value=False,
+            ) as mock_threshold,
+        ):
+            rc = stream_bandwidth.main(["--check-threshold", "--instance-id", "VULTR_X"])
     finally:
         _exit(mocks)
     assert rc == 0
     notify_mock = enters[4]
     notify_mock.assert_not_called()
+    # 閾値判定は fixture 由来の 100 GB で評価されている (0 GB 経路の偽陽性ではない)
+    assert mock_threshold.call_args.kwargs["usage_gb"] == pytest.approx(100.0)
 
 
 def test_check_threshold_alerts_when_over_80_percent():
@@ -330,8 +395,6 @@ def test_help_flag_prints_usage_with_zero_exit(capsys):
     `print_help()` を経由して `format_help()` を呼ぶため、内部で
     例外が起きると SystemExit(0) ではなく未捕捉例外で死ぬ。
     """
-    import pytest
-
     with pytest.raises(SystemExit) as exc_info:
         stream_bandwidth.main(["--help"])
 

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -33,15 +33,13 @@
      - ``TF_VAR_discord_webhook_url`` を案内コメントに含む
 10. ``infra/terraform/streaming/README.md``
      - 死活監視セクション / Discord / 4 シナリオ言及
-11. ``src/youtube_automation/utils/secrets.py``
-     - ``DISCORD_WEBHOOK_URL`` が ``_SECRET_REFS`` に登録
-12. ``src/youtube_automation/utils/streaming_archive.py``
+11. ``src/youtube_automation/utils/streaming_archive.py``
      - ``count_archives_for_date`` のモック検証
-13. ``src/youtube_automation/scripts/streaming_archive_check.py``
+12. ``src/youtube_automation/scripts/streaming_archive_check.py``
      - argparse / 件数不足時 exit 1 / Discord 通知
-14. ``pyproject.toml``
+13. ``pyproject.toml``
      - ``yt-stream-archive-check`` entry point 登録
-15. ``docs/streaming-healthcheck.md``
+14. ``docs/streaming-healthcheck.md``
      - 4 シナリオ言及
 
 shell スクリプト系は ``bash`` バイナリに依存するため subprocess で直接実行する。
@@ -940,62 +938,6 @@ class TestStreamingReadmeHealthcheck:
             assert scenario_keyword in text, (
                 f"README に '{scenario_keyword}' シナリオの言及が無い（4 シナリオ運用手順未網羅）"
             )
-
-
-# ============================================================================
-# src/youtube_automation/utils/secrets.py — DISCORD_WEBHOOK_URL 登録
-# ============================================================================
-
-
-class TestSecretsDiscordWebhookUrl:
-    """``secrets.py::_SECRET_REFS`` への ``DISCORD_WEBHOOK_URL`` 登録。"""
-
-    def test_discord_webhook_url_is_registered(self):
-        """Given secrets.py
-        When _SECRET_REFS を読む
-        Then DISCORD_WEBHOOK_URL が登録されている（op:// 参照 URI 形式）。
-        """
-        from youtube_automation.utils.secrets import _SECRET_REFS
-
-        assert "DISCORD_WEBHOOK_URL" in _SECRET_REFS, (
-            "DISCORD_WEBHOOK_URL が _SECRET_REFS に未登録"
-        )
-        ref = _SECRET_REFS["DISCORD_WEBHOOK_URL"]
-        assert ref.startswith("op://"), f"1Password 参照 URI 形式でない: {ref!r}"
-
-    def test_discord_webhook_url_returns_from_environ_when_present(self):
-        """既に os.environ にあれば op を呼ばずにそれを返す。"""
-        from youtube_automation.utils.secrets import get_secret, reset_cache
-
-        reset_cache()
-        original = os.environ.pop("DISCORD_WEBHOOK_URL", None)
-        try:
-            os.environ["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/from-env/abc"
-            with patch("youtube_automation.utils.secrets.subprocess.run") as mock_run:
-                value = get_secret("DISCORD_WEBHOOK_URL")
-            assert value == "https://discord.com/api/webhooks/from-env/abc"
-            mock_run.assert_not_called()
-        finally:
-            reset_cache()
-            os.environ.pop("DISCORD_WEBHOOK_URL", None)
-            if original is not None:
-                os.environ["DISCORD_WEBHOOK_URL"] = original
-
-    def test_discord_webhook_url_raises_config_error_when_unavailable(self):
-        """op が無く os.environ も空なら ConfigError。"""
-        from youtube_automation.utils.exceptions import ConfigError
-        from youtube_automation.utils.secrets import get_secret, reset_cache
-
-        reset_cache()
-        original = os.environ.pop("DISCORD_WEBHOOK_URL", None)
-        try:
-            with patch("youtube_automation.utils.secrets.shutil.which", return_value=None):
-                with pytest.raises(ConfigError, match="DISCORD_WEBHOOK_URL"):
-                    get_secret("DISCORD_WEBHOOK_URL")
-        finally:
-            reset_cache()
-            if original is not None:
-                os.environ["DISCORD_WEBHOOK_URL"] = original
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes #168

---

## 概要

`stream_bandwidth_cli.py` 関連テストに 3 つの未網羅・偽陽性が残存している。

### 1. \`today()\` 未凍結（**リグレッション検出不能の偽陽性**）

`tests/test_stream_bandwidth_cli.py:84, 199` で `today()` が patch されていないため、bandwidth fixture の `2026-04-15` データが当月集計に乗らず「100 GB が閾値未満」を実際には検証していない（0 GB 経路で pass）。

```python
# 修正
with patch("youtube_automation.cli.stream_bandwidth.today",
           return_value=date(2026, 4, 30)):
    # ...
```

### 2. 前月 0 → N/A 変換が未検証

`cli/stream_bandwidth.py:136-139` の `previous_usage_gb == 0 → None` 変換が未検証。統合テストの assertion は `2026-04/1188/58/60` のみで `N/A` 含有を確認していない。

→ 前月データ無し fixture で `assert "N/A" in content` を検証するテストを追加。

### 3. DISCORD_WEBHOOK_URL の op-fallback 経路欠落

他 3 シークレット（VULTR/STREAM/YOUTUBE_STREAM）は env/op/fail の 3 経路網羅、DISCORD_WEBHOOK_URL のみ op-fallback 経路欠落。

→ `tests/test_secrets.py:TestStreamingSecretsRegistered._MANAGED_SECRETS` に DISCORD_WEBHOOK_URL を追加して parametrize 統合、または同等テストを追加。
$(footer "SUM-NEW-stream-bandwidth-cli-today-not-frozen-L84, SUM-NEW-discord-webhook-op-fallback-uncovered, SUM-NEW-stream-bandwidth-prev-zero-to-na-uncovered")
