### PR TITLE
[#137] issue-137-feat-intro-sukirutos

### DIFF
--- a/.claude/skills/intro/SKILL.md
+++ b/.claude/skills/intro/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: intro
+description: Use when チャンネル共通 30 秒 intro 動画 (`branding/intro.mp4`) を新規作成 / 刷新するとき。チャンネル開設時 / ブランド刷新時の 1 回限りの作業で、コレクション制作毎には呼ばない。サムネ世界観に整合した photoreal video-only intro (4 Veo ショット + drawtext + 雫 PNG overlay) をビルドする。
+---
+
+## Overview
+
+チャンネル共通の **30 秒 intro 動画** (`branding/intro.mp4`) を新規生成 / 刷新する。
+
+- **作成タイミング**: チャンネル開設時 / ブランド刷新時に **1 回だけ**
+- **配置**: `branding/intro.mp4`（チャンネルブランディング素材、video-only）
+- **連携**: コレクション制作時は `/videoup` が本編に concat する。SFX + rain ambience の合流は `/masterup` の `finalize_master.py` が `branding/intro_sfx/*.wav` + `branding/rain_layers/*.wav` から直接 amix する（intro.mp4 自体は無音）
+
+### 設計の核（v7.1 photoreal video-only / 設計 D）
+
+サムネで集まった視聴者の冒頭離脱を防ぐ動画側施策。サムネ世界観 ⇄ intro 世界観 ⇄ 楽曲世界観の 3 段整合が retention を決める。
+
+- intro.mp4 は **video-only**（`-an`、音声なし、1920×1080、24fps、libx264 high CRF 18、30s 固定）
+- drawtext / 雫 PNG overlay / drawbox は `config.default.yaml` で text / logo / font / color を上書き可能
+- intro.mp4 タイムラインの 5 segment 構造（0/5/10/15/25/30s 境界）は設計 D の本質定数で `generate_intro.py` の module 定数に固定（config 化しない）
+- SFX (cup/vinyl/paper) と rain ambience は `/masterup` の `finalize_master.py` が直接合成。`/videoup` の concat は pure video stream copy 経路で audio mix を持たない
+
+## 設定
+
+動作パラメータは skill-config (`.claude/skills/intro/config.default.yaml`) で管理。
+チャンネル側で上書きする場合は `config/skills/intro.yaml`:
+
+| 項目 | 既定 | 説明 |
+|---|---|---|
+| `segments[*].text_en` / `text_ja` | RJN サンプル文 | 各 segment 上に焼き込む drawtext。空文字列で drawtext 抑止 |
+| `text.fontsize_en` / `fontsize_ja` / `fontsize_logo` / `fontsize_tagline` | 84 / 42 / 96 / 32 | drawtext のフォントサイズ (EN 主文 / JA 副文 / logo heading / tagline) |
+| `text.fade_seconds` | 0.7 | drawtext 両端 alpha フェード秒（segment 境界で in/out） |
+| `text.shadow_color` / `shadow_x` / `shadow_y` | `black@0.35` / 1 / 2 | drawtext 影色 / オフセット |
+| `font.en` / `font.ja` | macOS 既定パス | drawtext のフォントパス。Linux / Windows では override 必須 |
+| `color.drawtext` | `#3A4A55`（ダークティール） | drawtext / drawbox の塗り色（サムネ整合） |
+| `color.droplet` | `#3A4A55` | 雫 PNG (`05_droplet.png`) の塗り色 |
+| `logo.heading_left` / `heading_right` / `tagline` | RJN サンプル文 | 15-25s logo segment 用テキスト 3 行（左右 heading + tagline） |
+| `droplet.size` / `super_sampling` | 96 / 4 | 雫 PNG の出力サイズとアンチエイリアス倍率 |
+
+## When to Use
+
+- チャンネル開設時にブランド共通 intro.mp4 を作るとき
+- 既存 intro の世界観を刷新するとき（サムネ更新と歩調を揃える）
+
+コレクション制作毎の呼び出しは不要。`branding/intro.mp4` が存在すれば `/videoup` が自動検出する。
+
+## 制作手順
+
+### Step 1. Gemini で 4 still を順次生成
+
+サムネ参照画像（`branding/thumbnail-references/*.jpg` 等）と整合する photoreal still を 4 枚生成し、`branding/intro_assets/{01_rain_cu,02_lamp_steam,03_room_ws,04_cinemagraph}.png` に配置する。03_room_ws は **上 2/3 を空けてロゴ drawtext 配置領域を担保**（オブジェクトを下 1/3 に）。
+
+```bash
+uv run yt-generate-image -y --aspect-ratio 16:9 --size 2K --no-composition \
+  --output branding/intro_assets/01_rain_cu.png --prompt "..."
+# 02_lamp_steam, 03_room_ws, 04_cinemagraph を同様に
+```
+
+### Step 2. Veo で 4 loop を順次生成
+
+各 still を一時 collection の `main.png` に配置して `yt-generate-loop-video` を実行、出力 `loop.mp4` を `branding/intro_assets/<name>_loop.mp4` にコピー。
+
+### Step 3. 雫 PNG を生成
+
+```bash
+uv run python .claude/skills/intro/references/generate_droplet_png.py
+```
+
+`branding/intro_assets/05_droplet.png` (96×96 RGBA, 透明背景, color.droplet 塗り) が生成される。
+
+### Step 4. intro.mp4 をビルド
+
+```bash
+uv run python .claude/skills/intro/references/generate_intro.py --force
+```
+
+出力: `branding/intro.mp4` (30s, 1920x1080, 24fps, libx264 high CRF 18, **音声なし**, `-an`)。
+
+### Step 5. 検証
+
+QuickTime で再生し、サムネとの世界観整合 / drawtext 視認性 / 雫 PNG の中央配置を確認。NG なら Step 1-3 のいずれかに戻る。OK ならコミット。
+
+## アセット配置
+
+```
+.claude/skills/intro/
+├── SKILL.md                    # このファイル
+├── config.default.yaml         # text / logo / font / color の default
+└── references/
+    ├── generate_intro.py       # ffmpeg ビルダー (video-only 出力)
+    ├── generate_droplet_png.py # 雫 PNG ビルダー
+    └── README.md               # 詳細仕様 + 過去版経緯
+
+branding/                       # チャンネルブランディング素材
+├── intro.mp4                   # 最終生成物 (video-only, 30s)
+├── intro_sfx/                  # /masterup が読む SFX 配置先
+│   ├── cup_v3.wav
+│   ├── paper.wav
+│   └── vinyl_v4.wav
+├── rain_layers/                # /masterup が読む rain N レイヤー
+│   └── rain_*.wav
+└── intro_assets/
+    ├── 01_rain_cu.png / _loop.mp4
+    ├── 02_lamp_steam.png / _loop.mp4
+    ├── 03_room_ws.png / _loop.mp4
+    ├── 04_cinemagraph.png / _loop.mp4
+    └── 05_droplet.png          # 雫マーク (heading overlay 用)
+```
+
+## 関連スキル
+
+- `/videoup` — `branding/intro.mp4` 検出時に Intro 統合モード（pure concat、audio mix を持たない）で本編に concat
+- `/masterup` — `finalize_master.py` が `branding/intro_sfx/*.wav` + `branding/rain_layers/*.wav` を直接読んで master.mp3 に統合（設計 D の音声側施策）
+- `/thumbnail` — サムネ世界観のソース。intro はサムネと整合させること

--- a/.claude/skills/intro/config.default.yaml
+++ b/.claude/skills/intro/config.default.yaml
@@ -1,0 +1,70 @@
+# intro skill default config
+#
+# チャンネル共通 30 秒 intro 動画 (`branding/intro.mp4`) ビルダーの設定。
+# RJN (Rain Jazz Night) を default 値の見本として記述。各チャンネルは
+# `config/skills/intro.yaml` で `text` / `logo` / `font` / `color` を上書きすること。
+#
+# 設計 D の本質的タイムライン (30s, 5 segments, 1920x1080, 24fps) は本ファイルでは
+# 上書き不可。`generate_intro.py` の module 定数に固定。
+
+# 5 segments のタイムライン (start/end は秒、設計 D 固定の 30s 境界)。
+# text_en / text_ja は drawtext 表示文。空文字列で drawtext を抑止できる。
+segments:
+  - name: "01_rain_cu"
+    start: 0
+    end: 5
+    text_en: "Rest in the sound of rain."
+    text_ja: "雨の音に、心を預ける。"
+  - name: "02_lamp_steam"
+    start: 5
+    end: 10
+    text_en: "Tonight, your own hideaway."
+    text_ja: "今夜は、あなただけの隠れ家で。"
+  - name: "04_cinemagraph_a"
+    start: 10
+    end: 15
+    text_en: ""
+    text_ja: ""
+  - name: "03_room_ws"
+    start: 15
+    end: 25
+    text_en: ""
+    text_ja: ""
+  - name: "04_cinemagraph_b"
+    start: 25
+    end: 30
+    text_en: ""
+    text_ja: ""
+
+# drawtext のフォントサイズ / シャドウ等の共通スタイル。segment の text_en / text_ja
+# は segments[*] 側で指定する (このブロックは「全 segment 共通の見た目パラメータ」用)。
+text:
+  fontsize_en: 84
+  fontsize_ja: 42
+  fontsize_logo: 96
+  fontsize_tagline: 32
+  fade_seconds: 0.7
+  shadow_color: "black@0.35"
+  shadow_x: 1
+  shadow_y: 2
+
+# drawtext で参照されるフォント (macOS 既定)。Linux / Windows では override 必須。
+font:
+  en: "/System/Library/Fonts/Supplemental/Times New Roman.ttf"
+  ja: "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc"
+
+# drawtext / droplet PNG / drawbox の塗り色。サムネ世界観と整合させる。
+color:
+  drawtext: "#3A4A55"  # ダークティール (drawtext + drawbox)
+  droplet: "#3A4A55"   # 雫 PNG の RGB
+
+# 15-25s の logo segment 用テキスト 3 行。
+logo:
+  heading_left: "Rain"
+  heading_right: "Jazz Night"
+  tagline: "Your rainy night jazz bar escape"
+
+# 雫 PNG (05_droplet.png) の生成パラメータ。
+droplet:
+  size: 96             # 出力 PNG の正方形ピクセル
+  super_sampling: 4    # アンチエイリアス倍率

--- a/.claude/skills/intro/references/README.md
+++ b/.claude/skills/intro/references/README.md
@@ -1,0 +1,88 @@
+# intro skill — references
+
+チャンネル共通の **30 秒 intro 動画** (`branding/intro.mp4`) ビルダー一式。
+
+## 配置
+
+```
+.claude/skills/intro/
+├── SKILL.md                    # チャンネル開設 / ブランド刷新時の 4-step 手順
+├── config.default.yaml         # text / logo / font / color の default
+└── references/
+    ├── generate_intro.py       # ffmpeg ビルダー (video-only 出力)
+    ├── generate_droplet_png.py # 雫 PNG ビルダー
+    └── README.md               # このファイル
+```
+
+## 設計の経緯（v6 → v7.1）
+
+| 観点 | v6 (2026-05-05 archive) | v7.1 (現行) |
+|---|---|---|
+| `intro.mp4` 構造 | 環境音 SFX + 楽曲 amix を内蔵 | **video-only**（`-an`、音声なし） |
+| 設計 D（10s afade-in 合流）の実行場所 | `generate_videos.sh` で amix 実装 | `/masterup` の `finalize_master.py` で amix 実装 |
+| `generate_videos.sh` の役割 | amix 担当 | pure concat + audio map（v13） |
+| 雫 PNG overlay | なし（v6 は `05_logo.png` color-key で焼き込み） | あり（`05_droplet.png` overlay + drawtext logo） |
+
+v7.1 採用の根拠:
+
+- intro.mp4 を pure video asset に整理することで、`/videoup` を audio mix から解放（pure concat に集中）
+- 音声合流は `/masterup` で実機検証された設計 D（10s 遅延 + 2s afade-in、N-layer rain + 3 SFX + loudnorm two-pass）に集約
+- `branding/intro.mp4` がビット単位 reuse 可能 → 既存コレクションへの影響なし
+
+## ビルド手順
+
+詳細は `SKILL.md` を参照。要約:
+
+1. **Gemini で 4 still 生成** → `branding/intro_assets/{01_rain_cu,02_lamp_steam,03_room_ws,04_cinemagraph}.png`
+2. **Veo で 4 loop 生成** → 同ディレクトリの `<name>_loop.mp4`
+3. **雫 PNG ビルド**: `uv run python .claude/skills/intro/references/generate_droplet_png.py`
+4. **intro.mp4 ビルド**: `uv run python .claude/skills/intro/references/generate_intro.py --force`
+
+各 still / loop / 雫 PNG / intro.mp4 はチャンネル開設 / ブランド刷新時に **1 回**だけ生成すれば、以降のコレクション制作で再利用される。
+
+## SFX / rain ambience の配置（`/masterup` 側で読まれる）
+
+intro.mp4 自体には音声を焼き込まないが、設計 D の音声側施策のために以下を別途用意する:
+
+```
+branding/intro_sfx/
+├── cup_v3.wav      # 6 秒目に -3dB で配置 (ceramic コーヒーカップを置く音)
+├── paper.wav       # 18 秒目に -12dB で配置 (柔らかな紙ページめくり)
+└── vinyl_v4.wav    # 10 秒目に -6dB で配置 (vinyl 針落ち)
+
+branding/rain_layers/
+└── rain_*.wav      # N-layer rain ambience。各 layer -19dB / 0.5s fadein で amix
+```
+
+これらは `/masterup` の `finalize_master.py` が自動検出して master.mp3 に統合する。各ファイル名・dB・配置 ms は `.claude/skills/masterup/config.default.yaml` の `intro_audio:` namespace で channel ごとに上書き可能。
+
+## チャンネル上書き
+
+`config/skills/intro.yaml`（channel 側）で以下を上書き:
+
+```yaml
+font:
+  en: "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"
+  ja: "/usr/share/fonts/opentype/noto/NotoSerifCJK-Regular.ttc"
+
+color:
+  drawtext: "#3A4A55"   # サムネ整合カラー (RJN は dark teal、他チャンネルは要調整)
+  droplet: "#3A4A55"
+
+logo:
+  heading_left: "Sleep"        # チャンネル名の左半分
+  heading_right: "Lullaby"     # チャンネル名の右半分
+  tagline: "Drift into deep sleep with gentle melodies"
+
+segments:
+  - {name: "01_rain_cu", start: 0, end: 5, text_en: "Drift away.", text_ja: "穏やかな夜へ。"}
+  # ... 5 segments すべてを書き直す (deep-merge は dict のみ。list は置換)
+```
+
+`segments` はリスト全体が上書き対象。部分更新は不可。
+
+## 関連ドキュメント
+
+- `.claude/skills/intro/SKILL.md` — `/intro` Claude command 起動時のガイド
+- `.claude/skills/masterup/SKILL.md` — Step 5.5 で `finalize_master.py` を案内
+- `.claude/skills/videoup/SKILL.md` — Intro 統合モード（`branding/intro.mp4` 検出時の concat 経路）

--- a/.claude/skills/intro/references/_common.py
+++ b/.claude/skills/intro/references/_common.py
@@ -1,0 +1,33 @@
+"""intro skill の references スクリプトが共有する小さなヘルパー群。
+
+スクリプトが配布物 (`yt-skills sync`) 経由でチャンネル側に置かれた状態でも、
+ローカル開発から `python <script>.py` で直接実行された状態でも、または
+`tests/_skill_loader.load_skill_script` 経由で unit test から import された
+状態でも、同じ import 経路で読めるようにするため、この module を 1 箇所に
+集約する。各スクリプトは自身の親ディレクトリを `sys.path` に追加した上で
+`from _common import resolve_repo_root` する (アーキテクチャレビュー
+ARCH-NEW-resolve-repo-root-dry の修正案に従う実装)。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_repo_root(start: Path) -> Path:
+    """`config/channel/meta.json` を持つディレクトリを祖先探索で解決する。
+
+    Args:
+        start: 探索の起点 (通常は呼び出し側スクリプトの `__file__` の親)
+
+    Returns:
+        `config/channel/meta.json` を含む最も近い祖先ディレクトリ
+
+    Raises:
+        FileNotFoundError: 起点から祖先方向に `config/channel/meta.json` が
+            見つからなかったとき
+    """
+    cur = start.resolve()
+    for ancestor in [cur, *cur.parents]:
+        if (ancestor / 'config' / 'channel' / 'meta.json').exists():
+            return ancestor
+    raise FileNotFoundError(f'config/channel/meta.json not found upward from {start}')

--- a/.claude/skills/intro/references/generate_droplet_png.py
+++ b/.claude/skills/intro/references/generate_droplet_png.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate the droplet symbol PNG used in intro v7.1+ logo segment.
+
+`branding/intro_assets/05_droplet.png` を生成する (96×96 RGBA, 透明背景,
+config.color.droplet 塗り)。`generate_intro.py` の logo segment (15-25s) で
+heading 中央に overlay される。
+
+Run once during intro asset preparation; the PNG is committed.
+
+Usage:
+    python generate_droplet_png.py
+    python generate_droplet_png.py --output <path>  # 出力先を明示指定
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+# `_common` は隣接モジュール (`.claude/skills/intro/references/_common.py`) で、
+# `yt-skills sync` 後の配布形態でもテストの `load_skill_script` 経由でも同様に
+# 解決できるよう、自スクリプトの親ディレクトリを sys.path に登録してから import する。
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import resolve_repo_root  # noqa: E402
+from PIL import Image, ImageDraw  # noqa: E402
+
+from youtube_automation.utils.exceptions import ConfigError, ValidationError  # noqa: E402
+from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
+
+# 設計 D の本質的定数
+SIZE = 96
+SUPER = 4  # 既定の super sampling
+
+_DROPLET_FILENAME = "05_droplet.png"
+
+
+def _hex_to_rgba(hex_str: str) -> tuple[int, int, int, int]:
+    """`#RRGGBB` → `(R, G, B, 255)`。"""
+    s = hex_str.strip().lstrip("#")
+    if len(s) != 6:
+        raise ConfigError(f"color は #RRGGBB 形式である必要があります: {hex_str!r}")
+    try:
+        r = int(s[0:2], 16)
+        g = int(s[2:4], 16)
+        b = int(s[4:6], 16)
+    except ValueError as e:
+        raise ConfigError(f"color のパースに失敗: {hex_str!r}") from e
+    return (r, g, b, 255)
+
+
+def _teardrop_polygon(width: int, height: int, samples: int = 240) -> list[tuple[float, float]]:
+    """Return points tracing a classic teardrop outline (tip points up)."""
+    points: list[tuple[float, float]] = []
+    cx = width / 2.0
+    for i in range(samples + 1):
+        t = i / samples
+        theta = 2.0 * math.pi * t
+        x_norm = math.sin(theta) * math.sin(theta / 2.0)
+        y_norm = -math.cos(theta)
+        x = cx + x_norm * (width / 2.0)
+        y = (y_norm + 1.0) / 2.0 * height
+        points.append((x, y))
+    return points
+
+
+def render_droplet(
+    out_path: Path,
+    *,
+    color: tuple[int, int, int, int],
+    size: int = SIZE,
+    super_sampling: int = SUPER,
+) -> None:
+    """Render the teardrop PNG at `out_path` with the given RGBA color.
+
+    Args:
+        out_path: 出力先 PNG パス (親ディレクトリは自動で mkdir される)
+        color: RGBA 4-tuple (各値 0-255)
+        size: 出力 PNG の正方形ピクセル
+        super_sampling: アンチエイリアス用の超描画倍率
+
+    Raises:
+        ValidationError: color tuple の長さが 4 でない
+    """
+    if not (isinstance(color, tuple) and len(color) == 4):
+        raise ValidationError(
+            f"color は RGBA 4-tuple である必要があります: {color!r}"
+        )
+
+    big = size * super_sampling
+    img = Image.new("RGBA", (big, big), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    pts = _teardrop_polygon(big, big)
+    draw.polygon(pts, fill=color)
+
+    img = img.resize((size, size), Image.LANCZOS)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path)
+
+
+def _resolve_output_path() -> Path:
+    """default 出力先 (`<repo>/branding/intro_assets/05_droplet.png`)。"""
+    skill_dir = Path(__file__).resolve().parent
+    repo = resolve_repo_root(skill_dir)
+    return repo / "branding" / "intro_assets" / _DROPLET_FILENAME
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=None,
+                        help="出力先 PNG パス (default: <repo>/branding/intro_assets/05_droplet.png)")
+    args = parser.parse_args()
+
+    cfg = load_skill_config("intro", use_cache=False)
+    color = _hex_to_rgba(cfg["color"]["droplet"])
+    droplet_cfg = cfg.get("droplet", {})
+    size = int(droplet_cfg.get("size", SIZE))
+    super_sampling = int(droplet_cfg.get("super_sampling", SUPER))
+
+    out = args.output if args.output else _resolve_output_path()
+    render_droplet(out, color=color, size=size, super_sampling=super_sampling)
+    print(f"Wrote {out} ({size}x{size} px, transparent bg)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/intro/references/generate_intro.py
+++ b/.claude/skills/intro/references/generate_intro.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Generate the channel-wide intro.mp4 (one-time, brand-level asset).
+
+Design D / v7.1 photoreal video-only: intro.mp4 は **音声を一切含まない
+video-only mp4** として出力する。背景は 4 Veo loop の 5 segments concat
+(0/5/10/15/25/30s) で、サムネ参照画像と整合する photoreal キャラ + 雨の
+曇りガラス。drawtext / 雫 PNG overlay / drawbox の text / font / color は
+`config.default.yaml` で channel が上書き可能。設計 D の本質的タイムライン
+(30s, 5 segments, 1920×1080, 24fps) は module 定数として固定する。
+
+Audio (SFX cup/vinyl/paper および rain ambience) は **intro.mp4 には焼き込まない**。
+すべて `/masterup` の `finalize_master.py` が `branding/intro_sfx/*.wav` および
+`branding/rain_layers/*.wav` から直接読んで最終 master.mp3 に統合する。
+intro.mp4 は video のみのブランド素材なので、`/videoup` の concat 段階でも
+audio map を持たず、master.mp3 が単一の audio source となる。
+
+Usage:
+    python generate_intro.py
+    python generate_intro.py --force            # overwrite existing intro.mp4
+    python generate_intro.py --repo-root <path> # 明示指定 (auto-detect で十分)
+"""
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+# `_common` は隣接モジュール (`.claude/skills/intro/references/_common.py`) で、
+# `yt-skills sync` 後の配布形態でもテストの `load_skill_script` 経由でも同様に
+# 解決できるよう、自スクリプトの親ディレクトリを sys.path に登録してから import する。
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import resolve_repo_root  # noqa: E402
+
+from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
+from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
+
+# 設計 D の本質的定数 (config 化しない)
+DURATION = 30
+W, H = 1920, 1080
+FPS = 24
+
+# 各 segment の Veo loop ファイル名 (segment.name → 実体ファイル名)。
+# 04_cinemagraph は a/b の 2 セグで同じ Veo 出力を 2 度 input する。
+_SEGMENT_VIDEO_FILES = {
+    "01_rain_cu": "01_rain_cu_loop.mp4",
+    "02_lamp_steam": "02_lamp_steam_loop.mp4",
+    "04_cinemagraph_a": "04_cinemagraph_loop.mp4",
+    "03_room_ws": "03_room_ws_loop.mp4",
+    "04_cinemagraph_b": "04_cinemagraph_loop.mp4",
+}
+
+_DROPLET_FILE = "05_droplet.png"
+
+
+def _hex_to_ffmpeg_color(hex_str: str) -> str:
+    """`#RRGGBB` → `0xRRGGBB` (大文字で正規化)。ffmpeg drawtext fontcolor 形式。"""
+    s = hex_str.strip().lstrip("#").upper()
+    if len(s) != 6:
+        raise ConfigError(f"color は #RRGGBB 形式である必要があります: {hex_str!r}")
+    return f"0x{s}"
+
+
+def _write_textfile(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+_TEXT_REQUIRED_KEYS: tuple[str, ...] = (
+    "fontsize_en",
+    "fontsize_ja",
+    "fontsize_logo",
+    "fontsize_tagline",
+    "fade_seconds",
+    "shadow_color",
+    "shadow_x",
+    "shadow_y",
+)
+
+
+def _validate_text_config(text: dict) -> None:
+    missing = [k for k in _TEXT_REQUIRED_KEYS if k not in text]
+    if missing:
+        raise ConfigError(
+            f"intro/config の text に必須キーが欠落: {missing} "
+            "(intro/config.default.yaml の text: namespace を確認してください)"
+        )
+
+
+def build_filter_complex(
+    *,
+    segments: list[dict],
+    text: dict,
+    font: dict,
+    color: dict,
+    logo: dict,
+    tmp: Path,
+) -> tuple[str, str]:
+    """Build the giant filter_complex graph for intro.mp4.
+
+    Args:
+        segments: list of segment dicts with `name`/`start`/`end`/`text_en`/`text_ja`
+        text: drawtext 共通スタイル dict (fontsize_en/ja/logo/tagline,
+              fade_seconds, shadow_color/x/y)。channel が config/skills/intro.yaml
+              で上書きすると ffmpeg cmd に伝搬する。
+        font: dict with `en` / `ja` font paths
+        color: dict with `drawtext` / `droplet` hex strings
+        logo: dict with `heading_left` / `heading_right` / `tagline`
+        tmp: 一時ディレクトリ (drawtext textfile= の永続化先)
+
+    Returns:
+        (filter_complex 文字列, 最終 video label 名)
+
+    Raises:
+        ConfigError: segments が空 (concat=n=0 を防ぐ) / text の必須キー欠落
+    """
+    if not segments:
+        raise ConfigError("intro segments が空です。少なくとも 1 segment が必要")
+    _validate_text_config(text)
+
+    font_en = font["en"]
+    font_ja = font["ja"]
+    drawtext_color = _hex_to_ffmpeg_color(color["drawtext"])
+
+    fontsize_en = text["fontsize_en"]
+    fontsize_ja = text["fontsize_ja"]
+    fontsize_logo = text["fontsize_logo"]
+    fontsize_tagline = text["fontsize_tagline"]
+    fade_s = text["fade_seconds"]
+    shadow_color = text["shadow_color"]
+    shadow_x = text["shadow_x"]
+    shadow_y = text["shadow_y"]
+    shadow_suffix = (
+        f"shadowcolor={shadow_color}:shadowx={shadow_x}:shadowy={shadow_y}"
+    )
+
+    parts: list[str] = []
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    # ── Video segments: trim each Veo loop to its time slot, scale, fps ──
+    for idx, seg in enumerate(segments):
+        seg_dur = int(seg["end"]) - int(seg["start"])
+        parts.append(
+            f"[{idx}:v]trim=duration={seg_dur},setpts=PTS-STARTPTS,"
+            f"scale={W}:{H}:force_original_aspect_ratio=increase,"
+            f"crop={W}:{H},format=yuv420p,fps={FPS}[v{idx}]"
+        )
+
+    # Concat all segments
+    n = len(segments)
+    concat_inputs = "".join(f"[v{i}]" for i in range(n))
+    parts.append(f"{concat_inputs}concat=n={n}:v=1:a=0[vconcat]")
+
+    # ── Drawtext for text-bearing segments (EN main + JA sub) ──
+    # alpha {fade_s}s in/out fade (config 駆動)。segment 境界の両端でフェード。
+    alpha_template = (
+        f"if(lt(t-{{start}},{fade_s}),(t-{{start}})/{fade_s},"
+        f"if(lt(t-{{start}},{{seg_dur_minus_fade}}),1,max(0,({{end}}-t)/{fade_s})))"
+    )
+    drawtext_chain = "vconcat"
+    text_idx = 0
+    for idx, seg in enumerate(segments):
+        en = seg.get("text_en", "")
+        ja = seg.get("text_ja", "")
+        if not en:
+            continue
+        start, end = int(seg["start"]), int(seg["end"])
+        seg_dur = end - start
+        a = alpha_template.format(start=start, seg_dur_minus_fade=seg_dur - fade_s, end=end)
+        # 0-5s segment: center に置く (mug 中心被り回避のため -50px)
+        # それ以外 (5-10s 等): upper-third
+        y_en = "(h-text_h)/2-50" if start == 0 else "h/3-text_h/2"
+        y_ja = "(h-text_h)/2+50" if start == 0 else "h/3+text_h+10"
+
+        en_file = tmp / f"text_en_{idx}.txt"
+        _write_textfile(en_file, en)
+        next_label = f"d{text_idx}"
+        parts.append(
+            f"[{drawtext_chain}]drawtext=fontfile='{font_en}':"
+            f"textfile='{en_file}':"
+            f"fontsize={fontsize_en}:fontcolor={drawtext_color}@1:"
+            f"x=(w-text_w)/2:y={y_en}:"
+            f"alpha='{a}':enable='between(t,{start},{end})':"
+            f"{shadow_suffix}[{next_label}]"
+        )
+        drawtext_chain = next_label
+        text_idx += 1
+
+        ja_file = tmp / f"text_ja_{idx}.txt"
+        _write_textfile(ja_file, ja)
+        next_label = f"d{text_idx}"
+        parts.append(
+            f"[{drawtext_chain}]drawtext=fontfile='{font_ja}':"
+            f"textfile='{ja_file}':"
+            f"fontsize={fontsize_ja}:fontcolor={drawtext_color}@0.85:"
+            f"x=(w-text_w)/2:y={y_ja}:"
+            f"alpha='{a}':enable='between(t,{start},{end})':"
+            f"{shadow_suffix}[{next_label}]"
+        )
+        drawtext_chain = next_label
+        text_idx += 1
+
+    # ── Logo drawtext 15-25s (heading 左右 + 雫 PNG overlay + rule + tagline) ──
+    logo_alpha = (
+        "if(lt(t-15,0.8),(t-15)/0.8,"
+        "if(lt(t-15,9.2),1,max(0,(25-t)/0.8)))"
+    )
+
+    # 左 heading: 中央から左 50px gap
+    heading_left = logo["heading_left"]
+    heading_right = logo["heading_right"]
+    tagline = logo["tagline"]
+
+    rain_file = tmp / "text_logo_left.txt"
+    _write_textfile(rain_file, heading_left)
+    next_label = f"d{text_idx}"
+    parts.append(
+        f"[{drawtext_chain}]drawtext=fontfile='{font_en}':"
+        f"textfile='{rain_file}':"
+        f"fontsize={fontsize_logo}:fontcolor={drawtext_color}@1:"
+        f"x=w/2-50-text_w:y=(h-text_h)/2-80:"
+        f"alpha='{logo_alpha}':enable='between(t,15,25)':"
+        f"{shadow_suffix}[{next_label}]"
+    )
+    drawtext_chain = next_label
+    text_idx += 1
+
+    # 右 heading: 中央から右 50px gap
+    jazz_file = tmp / "text_logo_right.txt"
+    _write_textfile(jazz_file, heading_right)
+    next_label = f"d{text_idx}"
+    parts.append(
+        f"[{drawtext_chain}]drawtext=fontfile='{font_en}':"
+        f"textfile='{jazz_file}':"
+        f"fontsize={fontsize_logo}:fontcolor={drawtext_color}@1:"
+        f"x=w/2+50:y=(h-text_h)/2-80:"
+        f"alpha='{logo_alpha}':enable='between(t,15,25)':"
+        f"{shadow_suffix}[{next_label}]"
+    )
+    drawtext_chain = next_label
+    text_idx += 1
+
+    # 雫 PNG overlay (heading 左右の中央)。input index = len(segments)
+    droplet_idx = n
+    parts.append(
+        f"[{droplet_idx}:v]scale=60:60,format=rgba,"
+        f"fade=t=in:st=15:d=0.8:alpha=1,"
+        f"fade=t=out:st=24.2:d=0.8:alpha=1[droplet_keyed]"
+    )
+    next_label = f"d{text_idx}"
+    parts.append(
+        f"[{drawtext_chain}][droplet_keyed]overlay=x=(W-60)/2:y=H/2-110:"
+        f"enable='between(t,15,25)'[{next_label}]"
+    )
+    drawtext_chain = next_label
+    text_idx += 1
+
+    # Rule line (heading と tagline の間の罫線)
+    next_label = f"d{text_idx}"
+    parts.append(
+        f"[{drawtext_chain}]drawbox=x=(w-600)/2:y=(h/2)-12:w=600:h=1:"
+        f"color={drawtext_color}@0.5:t=fill:"
+        f"enable='between(t,15.8,24.2)'[{next_label}]"
+    )
+    drawtext_chain = next_label
+    text_idx += 1
+
+    # Tagline (heading の下 / rule の下に置く 32pt italic 風)
+    tagline_file = tmp / "text_logo_tagline.txt"
+    _write_textfile(tagline_file, tagline)
+    next_label = f"d{text_idx}"
+    parts.append(
+        f"[{drawtext_chain}]drawtext=fontfile='{font_en}':"
+        f"textfile='{tagline_file}':"
+        f"fontsize={fontsize_tagline}:fontcolor={drawtext_color}@0.85:"
+        f"x=(w-text_w)/2:y=(h/2)+8:"
+        f"alpha='{logo_alpha}':enable='between(t,15,25)':"
+        f"{shadow_suffix}[{next_label}]"
+    )
+    drawtext_chain = next_label
+    text_idx += 1
+
+    return ";".join(parts), drawtext_chain
+
+
+def _resolve_segment_video(intro_dir: Path, name: str) -> Path:
+    """segment 名から実体 mp4 ファイルパスを解決する。"""
+    if name not in _SEGMENT_VIDEO_FILES:
+        raise ConfigError(f"unknown segment name: {name!r} (expected one of {list(_SEGMENT_VIDEO_FILES)})")
+    return intro_dir / _SEGMENT_VIDEO_FILES[name]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=None,
+                        help="リポジトリルート (default: 起動位置から auto-detect)")
+    parser.add_argument("--force", action="store_true",
+                        help="既存の branding/intro.mp4 を上書きする")
+    args = parser.parse_args()
+
+    skill_dir = Path(__file__).resolve().parent
+    repo_root = (args.repo_root.resolve() if args.repo_root
+                 else resolve_repo_root(skill_dir))
+    intro_dir = repo_root / "branding" / "intro_assets"
+    output_path = repo_root / "branding" / "intro.mp4"
+
+    if output_path.exists() and not args.force:
+        print(f"intro.mp4 exists at {output_path}. Use --force to overwrite.")
+        return 0
+
+    cfg = load_skill_config("intro", use_cache=False)
+    segments = cfg["segments"]
+    text = cfg["text"]
+    font = cfg["font"]
+    color = cfg["color"]
+    logo = cfg["logo"]
+
+    # 必要 input ファイル (segments 順 + 雫 PNG)
+    required: list[Path] = []
+    for seg in segments:
+        required.append(_resolve_segment_video(intro_dir, seg["name"]))
+    required.append(intro_dir / _DROPLET_FILE)
+    missing = [p for p in required if not p.exists()]
+    if missing:
+        print("ERROR: missing inputs:", file=sys.stderr)
+        for p in missing:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    tmp = skill_dir / "_tmp"
+    tmp.mkdir(parents=True, exist_ok=True)
+    try:
+        filter_complex, vfinal = build_filter_complex(
+            segments=segments, text=text, font=font, color=color, logo=logo, tmp=tmp,
+        )
+
+        # ffmpeg cmd 組み立て: 5 video inputs (in segments order) + 雫 PNG。
+        # 音声は出力に含めない (-an)。設計 D の音声合流は /masterup 側。
+        cmd: list[str] = ["ffmpeg", "-y"]
+        for seg in segments:
+            cmd += [
+                "-stream_loop", "-1",
+                "-i", str(_resolve_segment_video(intro_dir, seg["name"])),
+            ]
+        cmd += [
+            "-loop", "1", "-i", str(intro_dir / _DROPLET_FILE),
+            "-filter_complex", filter_complex,
+            "-map", f"[{vfinal}]",
+            "-c:v", "libx264", "-preset", "slow", "-crf", "18",
+            "-profile:v", "high", "-pix_fmt", "yuv420p",
+            "-r", str(FPS),
+            "-an",
+            "-t", str(DURATION),
+            "-movflags", "+faststart",
+            str(output_path),
+        ]
+
+        print("$ " + " ".join(shlex.quote(c) for c in cmd))
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(f"ERROR: ffmpeg failed (exit {result.returncode})", file=sys.stderr)
+            return result.returncode
+
+        print(f"\nSuccess: {output_path}")
+        return 0
+    finally:
+        for f in tmp.glob("*.txt"):
+            f.unlink()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -117,6 +117,30 @@ yt-generate-master --shuffle-seed 42        # 再現性 seed 指定（--shuffle 
 
 **シャッフル時の注意**: `--shuffle` はループ展開の**前**に 1 回だけ実行され、シャッフルされた順序がループごとに同じ並びで N 回繰り返される（ループごとに独立してシャッフルし直すわけではない）。再現性が必要な場合は `--shuffle-seed N` を指定するか、`--shuffle` 単独実行時に stdout に出る `[Shuffle] seed=<N>` の値を控えておけば後で同じ並びを再現できる。再現性ログは `--quiet` 指定時も常に出力される。
 
+### Step 5.5: マスター後処理（intro audio 統合 / 設計 D）
+
+`branding/intro.mp4` を持つチャンネルでは、`yt-generate-master` の出力 `master_raw.mp3` をそのまま使わず、`finalize_master.py` で intro 区間の SFX + rain ambience + 楽曲を amix し、loudnorm two-pass で整音した `master.mp3` を最終出力する。
+
+```bash
+uv run python .claude/skills/masterup/references/finalize_master.py <collection-path>
+uv run python .claude/skills/masterup/references/finalize_master.py <collection-path> --keep-raw
+```
+
+設計 D の核（`config.default.yaml` の `intro_audio:` namespace で channel が上書き可能）:
+
+- 楽曲を `song_delay_ms` (default 10000 = 10s) 遅延 + `song_fadein_s` (default 2 秒) で afade-in
+- 雨 N-layer (`branding/rain_layers/rain_*.wav`) を `rain_volume_db` で amix
+- SFX 3 種 (`branding/intro_sfx/{cup_v3,paper,vinyl_v4}.wav`) を 6000ms / 18000ms / 10000ms に配置
+- 最終 mix は `[song][sfx][rain]amix=inputs=3:duration=first:normalize=0,loudnorm=I=-14:LRA=11:TP=-1.5[aout]`
+
+前提:
+
+- `01-master/master_raw.mp3` が存在すること（Step 5 の出力をそのまま使う）
+- `<repo-root>/branding/intro_sfx/{cup_v3,paper,vinyl_v4}.wav` 3 種が配置済み
+- `<repo-root>/branding/rain_layers/rain_*.wav` が 1 件以上配置済み
+
+成功時、デフォルトで `master_raw.mp3` は削除される（`--keep-raw` で保持可）。`/intro` スキルで `branding/intro.mp4` を作っていない channel では本ステップ自体を実行しない（`master_raw.mp3` をそのまま `master.mp3` にリネームする運用）。
+
 ### Step 6: ワークツリー実行時のメインへのコピー
 
 git worktree 内で実行している場合（パスに `.claude/worktrees/` を含む場合）、生成した音源ファイルをメインワークツリーにもコピーする。

--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -119,11 +119,10 @@ yt-generate-master --shuffle-seed 42        # 再現性 seed 指定（--shuffle 
 
 ### Step 5.5: マスター後処理（intro audio 統合 / 設計 D）
 
-`branding/intro.mp4` を持つチャンネルでは、`yt-generate-master` の出力 `master_raw.mp3` をそのまま使わず、`finalize_master.py` で intro 区間の SFX + rain ambience + 楽曲を amix し、loudnorm two-pass で整音した `master.mp3` を最終出力する。
+Step 5 完了後に必ず呼び出す（intro 素材の有無は `finalize_master.py` 側で自動検出する）。intro 素材が揃ったチャンネルでは `01-master/master.mp3` に対して intro 区間の SFX + rain ambience + 楽曲を amix し、loudnorm two-pass で整音した結果を atomic rename で同じ `master.mp3` に in-place 上書きする。intro 素材が揃っていないチャンネルでは pass-through で終了し `master.mp3` には触れない（`/videoup` の `branding/intro.mp4` 自動検出と対称）。
 
 ```bash
 uv run python .claude/skills/masterup/references/finalize_master.py <collection-path>
-uv run python .claude/skills/masterup/references/finalize_master.py <collection-path> --keep-raw
 ```
 
 設計 D の核（`config.default.yaml` の `intro_audio:` namespace で channel が上書き可能）:
@@ -133,13 +132,17 @@ uv run python .claude/skills/masterup/references/finalize_master.py <collection-
 - SFX 3 種 (`branding/intro_sfx/{cup_v3,paper,vinyl_v4}.wav`) を 6000ms / 18000ms / 10000ms に配置
 - 最終 mix は `[song][sfx][rain]amix=inputs=3:duration=first:normalize=0,loudnorm=I=-14:LRA=11:TP=-1.5[aout]`
 
+intro モードの起動条件（自動検出）:
+
+- `<repo-root>/branding/intro_sfx/` ディレクトリと `<repo-root>/branding/rain_layers/` ディレクトリが両方存在する → intro モードで amix（このとき SFX 3 種または `rain_*.wav` のどれかが欠けていれば fail-fast で `exit 1`）
+- どちらか一方でもディレクトリ自体が無い → pass-through で `exit 0`（`master.mp3` 不変、stderr に `INFO:` ログ）
+
 前提:
 
-- `01-master/master_raw.mp3` が存在すること（Step 5 の出力をそのまま使う）
-- `<repo-root>/branding/intro_sfx/{cup_v3,paper,vinyl_v4}.wav` 3 種が配置済み
-- `<repo-root>/branding/rain_layers/rain_*.wav` が 1 件以上配置済み
+- `01-master/master.mp3` が存在すること（Step 5 の出力）
+- intro モードを使う場合は `<repo-root>/branding/intro_sfx/{cup_v3,paper,vinyl_v4}.wav` 3 種と `<repo-root>/branding/rain_layers/rain_*.wav` 1 件以上が配置済み
 
-成功時、デフォルトで `master_raw.mp3` は削除される（`--keep-raw` で保持可）。`/intro` スキルで `branding/intro.mp4` を作っていない channel では本ステップ自体を実行しない（`master_raw.mp3` をそのまま `master.mp3` にリネームする運用）。
+成功時、`01-master/master.mp3` が intro 区間込みの最終マスターに置き換わる（atomic rename で in-place 上書き）。pass2 失敗時は元の `master.mp3` を保護したまま rc を伝播する。
 
 ### Step 6: ワークツリー実行時のメインへのコピー
 

--- a/.claude/skills/masterup/config.default.yaml
+++ b/.claude/skills/masterup/config.default.yaml
@@ -1,6 +1,6 @@
 # masterup skill default config
 #
-# マスター音源生成 + Suno CDN ダウンロードの設定。
+# マスター音源生成 + Suno CDN ダウンロード + 設計 D の音声合流の設定。
 # チャンネル側では config/skills/masterup.yaml に上書き値を置く。
 
 audio:
@@ -31,3 +31,41 @@ audio:
 # Suno CDN ダウンロード設定
 suno_download:
   cdn_url_template: "https://cdn1.suno.ai/{song_id}.mp3"
+
+# 設計 D の音声合流設定 (intro 区間の楽曲遅延 + 雨 N-layer + SFX 3 種を amix し
+# loudnorm two-pass で整音する `finalize_master.py` 専用)。
+intro_audio:
+  # 楽曲を intro 開始から何 ms 遅延させて合流させるか (設計 D の核: 10000 = 10s)。
+  song_delay_ms: 10000
+  # 楽曲合流時の afade-in 秒数 (設計 D の核: 2 秒)。
+  song_fadein_s: 2
+  # 楽曲全体の音量補正 dB (-8 = intro 区間で雨 + SFX に席を譲るため少し抑える)。
+  song_volume_db: -8
+
+  # 雨 N-layer の各レイヤー音量 dB (RJN は -19 を 5 layer 重ねている前提)。
+  rain_volume_db: -19
+  # 雨レイヤー fadein 秒数 (頭の不連続を抑える)。
+  rain_fadein_s: 0.5
+
+  # loudnorm two-pass の target 値 (I=integrated / LRA=loudness range / TP=true peak)。
+  loudnorm:
+    I: -14
+    LRA: 11
+    TP: -1.5
+
+  # SFX 3 種の配置タイミングと音量 (設計 D 固定タイミング)。
+  # branding/intro_sfx/<file> から読まれる。channel が wav 名を変えたい場合は
+  # `file:` を上書きする (start_ms / volume_db は設計 D の核なので原則固定)。
+  sfx:
+    cup:
+      file: "cup_v3.wav"
+      start_ms: 6000
+      volume_db: -3
+    paper:
+      file: "paper.wav"
+      start_ms: 18000
+      volume_db: -12
+    vinyl:
+      file: "vinyl_v4.wav"
+      start_ms: 10000
+      volume_db: -6

--- a/.claude/skills/masterup/references/finalize_master.py
+++ b/.claude/skills/masterup/references/finalize_master.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """設計 D の音声側施策を実行する master.mp3 ファイナライズ。
 
-`master_raw.mp3` (本編楽曲) + `branding/intro_sfx/{cup,paper,vinyl}.wav` (3 SFX)
-+ `branding/rain_layers/rain_*.wav` (N レイヤー) を ffmpeg で amix し、
-loudnorm two-pass で整音した最終 `master.mp3` を出力する。
+`01-master/master.mp3` (Step 5 出力の本編楽曲) + `branding/intro_sfx/{cup,paper,vinyl}.wav`
+(3 SFX) + `branding/rain_layers/rain_*.wav` (N レイヤー) を ffmpeg で amix し、
+loudnorm two-pass で整音した最終 `master.mp3` を atomic rename で in-place 上書きする。
+
+intro 素材ディレクトリ (`branding/intro_sfx/` または `branding/rain_layers/`) が
+存在しないチャンネルでは pass-through で rc=0 終了する (`/videoup` の自動検出と対称)。
 
 設計 D の核:
 - 楽曲は `song_delay_ms` ms 遅延 + `song_fadein_s` 秒 afade-in (intro 区間を雨 + SFX に譲る)
@@ -13,7 +16,6 @@ loudnorm two-pass で整音した最終 `master.mp3` を出力する。
 
 Usage:
     python finalize_master.py <collection-path>
-    python finalize_master.py <collection-path> --keep-raw
 """
 from __future__ import annotations
 
@@ -44,6 +46,10 @@ _REQUIRED_KEYS: tuple[str, ...] = (
 )
 
 _RAIN_GLOB = "rain_*.wav"
+
+# ファイル名定数: master.mp3 を atomic rename で上書きするため temp は同一ディレクトリに置く
+_MASTER_FILENAME = "master.mp3"
+_MASTER_TMP_FILENAME = "master.tmp.mp3"
 
 
 def _validate_intro_audio(config: dict[str, Any]) -> None:
@@ -78,7 +84,7 @@ def _format_seconds(value: float | int) -> str:
 
 def build_common_parts(config: dict[str, Any], *, n_rain: int) -> list[str]:
     """SFX + rain + song の filter graph parts を組み立てる (loudnorm / 最終 amix
-    は含まない)。input layout は [0]=master_raw, [1..3]=SFX (cup/paper/vinyl 固定順),
+    は含まない)。input layout は [0]=master, [1..3]=SFX (cup/paper/vinyl 固定順),
     [4..N+3]=rain_*.wav。
 
     Returns:
@@ -219,11 +225,27 @@ def parse_loudnorm_json(stderr: str) -> dict[str, Any]:
     )
 
 
-def finalize(collection: Path, *, keep_raw: bool = False) -> int:
-    """`<collection>/01-master/master_raw.mp3` を入力に master.mp3 を生成する。
+def _intro_mode_enabled(repo: Path) -> bool:
+    """intro 素材ディレクトリの有無で intro モード適用可否を判定する。
+
+    `branding/intro_sfx/` または `branding/rain_layers/` のどちらか一方でも
+    存在しないチャンネルは intro モード非対応として扱う (pass-through トリガー)。
+    `is_dir()` を使うのは file/symlink での誤検出を避けるため。
+    """
+    sfx_dir = repo / "branding" / "intro_sfx"
+    rain_dir = repo / "branding" / "rain_layers"
+    return sfx_dir.is_dir() and rain_dir.is_dir()
+
+
+def finalize(collection: Path) -> int:
+    """`<collection>/01-master/master.mp3` に intro 区間 SFX + rain + 楽曲を amix し、
+    atomic rename で `master.mp3` を in-place 上書きする。
+
+    intro 素材ディレクトリ (`branding/intro_sfx/` / `branding/rain_layers/`) が存在
+    しないチャンネルでは pass-through で rc=0 終了する (master.mp3 不変)。
 
     Returns:
-        exit code (0=成功 / 1=入力検証失敗 / その他=ffmpeg 伝播)
+        exit code (0=成功 or pass-through / 1=入力検証失敗 / その他=ffmpeg 伝播)
     """
     config_full = load_skill_config("masterup", use_cache=False)
     intro_audio = config_full.get("intro_audio")
@@ -234,14 +256,24 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
     _validate_intro_audio(intro_audio)
 
     repo = channel_dir()
-    master_raw = collection / "01-master" / "master_raw.mp3"
-    output = collection / "01-master" / "master.mp3"
+    master = collection / "01-master" / _MASTER_FILENAME
 
     # 入力検証 (Fail Fast)
-    if not master_raw.exists():
-        print(f"ERROR: master_raw.mp3 が見つかりません: {master_raw}", file=sys.stderr)
+    if not master.exists():
+        print(f"ERROR: {_MASTER_FILENAME} が見つかりません: {master}", file=sys.stderr)
         return 1
 
+    # intro モード自動検出: ディレクトリ自体が無いチャンネルは pass-through
+    if not _intro_mode_enabled(repo):
+        print(
+            f"INFO: intro 素材ディレクトリ (branding/intro_sfx/ または "
+            f"branding/rain_layers/) が見つかりません。pass-through で終了します "
+            f"({master})",
+            file=sys.stderr,
+        )
+        return 0
+
+    # ハーフ実装防止 (dir はあるが中身欠落 = fail-fast)
     sfx_dir = repo / "branding" / "intro_sfx"
     sfx_files: list[Path] = []
     for name in _SFX_ORDER:
@@ -253,7 +285,7 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
         sfx_files.append(path)
 
     rain_dir = repo / "branding" / "rain_layers"
-    rain_files = sorted(rain_dir.glob(_RAIN_GLOB)) if rain_dir.exists() else []
+    rain_files = sorted(rain_dir.glob(_RAIN_GLOB))
     if not rain_files:
         print(
             f"ERROR: rain layer (rain_*.wav) が {rain_dir} に存在しません",
@@ -262,6 +294,7 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
         return 1
 
     n_rain = len(rain_files)
+    temp_out = collection / "01-master" / _MASTER_TMP_FILENAME
 
     # ── pass1: loudnorm 測定 ──
     pass1_filter = build_filter(
@@ -269,7 +302,7 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
         n_rain=n_rain,
         measured=None,
     )
-    cmd1: list[str] = ["ffmpeg", "-y", "-i", str(master_raw)]
+    cmd1: list[str] = ["ffmpeg", "-y", "-i", str(master)]
     for s in sfx_files:
         cmd1 += ["-i", str(s)]
     for r in rain_files:
@@ -291,13 +324,13 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
 
     measured = parse_loudnorm_json(result1.stderr or "")
 
-    # ── pass2: linear loudnorm + 出力 ──
+    # ── pass2: linear loudnorm + temp 書き出し ──
     pass2_filter = build_filter(
         intro_audio,
         n_rain=n_rain,
         measured=measured,
     )
-    cmd2: list[str] = ["ffmpeg", "-y", "-i", str(master_raw)]
+    cmd2: list[str] = ["ffmpeg", "-y", "-i", str(master)]
     for s in sfx_files:
         cmd2 += ["-i", str(s)]
     for r in rain_files:
@@ -306,7 +339,7 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
         "-filter_complex", pass2_filter,
         "-map", "[aout]",
         "-c:a", "libmp3lame", "-b:a", "192k",
-        str(output),
+        str(temp_out),
     ]
     result2 = subprocess.run(cmd2, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
     if result2.returncode != 0:
@@ -316,29 +349,25 @@ def finalize(collection: Path, *, keep_raw: bool = False) -> int:
         )
         if result2.stderr:
             print(result2.stderr, file=sys.stderr)
+        # temp の best-effort 削除 (元 master.mp3 は os.replace を呼ばない限り無傷)
+        try:
+            os.remove(temp_out)
+        except OSError:
+            pass
         return result2.returncode
 
-    # 中間成果物クリーンアップ (--keep-raw で抑止)
-    if not keep_raw:
-        try:
-            os.remove(master_raw)
-        except OSError as e:
-            print(f"WARN: master_raw.mp3 削除に失敗 ({e})", file=sys.stderr)
+    # ── atomic rename: temp_out → master (同一 fs 内で os.replace) ──
+    os.replace(temp_out, master)
 
-    print(f"Success: {output}")
+    print(f"Success: {master}")
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("collection", type=Path, help="コレクションディレクトリ")
-    parser.add_argument(
-        "--keep-raw",
-        action="store_true",
-        help="master_raw.mp3 を削除せず残す (debug 用)",
-    )
     args = parser.parse_args()
-    return finalize(args.collection, keep_raw=args.keep_raw)
+    return finalize(args.collection)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/masterup/references/finalize_master.py
+++ b/.claude/skills/masterup/references/finalize_master.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""設計 D の音声側施策を実行する master.mp3 ファイナライズ。
+
+`master_raw.mp3` (本編楽曲) + `branding/intro_sfx/{cup,paper,vinyl}.wav` (3 SFX)
++ `branding/rain_layers/rain_*.wav` (N レイヤー) を ffmpeg で amix し、
+loudnorm two-pass で整音した最終 `master.mp3` を出力する。
+
+設計 D の核:
+- 楽曲は `song_delay_ms` ms 遅延 + `song_fadein_s` 秒 afade-in (intro 区間を雨 + SFX に譲る)
+- 雨 N レイヤー: 各 layer `rain_volume_db` dB / `rain_fadein_s` 秒 fadein → amix
+- SFX 3 種: 配置 ms / dB を `intro_audio.sfx.{cup,paper,vinyl}` から組み立て → amix
+- 最終 mix: `[song][sfx][rain]amix=inputs=3:duration=first:normalize=0,loudnorm[aout]`
+
+Usage:
+    python finalize_master.py <collection-path>
+    python finalize_master.py <collection-path> --keep-raw
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.skill_config import load_skill_config
+
+# SFX 並びは config["sfx"] のキーから固定取得する。順序は名前 → input index に決定する
+_SFX_ORDER = ("cup", "paper", "vinyl")
+
+_REQUIRED_KEYS: tuple[str, ...] = (
+    "song_delay_ms",
+    "song_fadein_s",
+    "song_volume_db",
+    "rain_volume_db",
+    "rain_fadein_s",
+    "loudnorm",
+    "sfx",
+)
+
+_RAIN_GLOB = "rain_*.wav"
+
+
+def _validate_intro_audio(config: dict[str, Any]) -> None:
+    """intro_audio dict (= load_skill_config('masterup')['intro_audio'] 部分)
+    の必須キーを検証する。欠落で ConfigError。"""
+    missing = [k for k in _REQUIRED_KEYS if k not in config]
+    if missing:
+        raise ConfigError(
+            f"intro_audio config に必須キーが欠落: {missing} "
+            "(masterup/config.default.yaml の intro_audio: namespace を確認してください)"
+        )
+    sfx = config["sfx"]
+    if not isinstance(sfx, dict):
+        raise ConfigError(f"intro_audio.sfx は dict である必要があります: {type(sfx)!r}")
+    sfx_missing = [name for name in _SFX_ORDER if name not in sfx]
+    if sfx_missing:
+        raise ConfigError(
+            f"intro_audio.sfx に必須エントリが欠落: {sfx_missing} "
+            f"(必要: {list(_SFX_ORDER)})"
+        )
+
+
+def _format_seconds(value: float | int) -> str:
+    """ffmpeg 引数用に秒値を文字列化。整数なら整数表記、小数なら小数のまま。"""
+    if isinstance(value, bool):  # bool は int の subclass なので明示分岐
+        raise TypeError(f"秒値に bool は使えません: {value!r}")
+    f = float(value)
+    if f.is_integer():
+        return str(int(f))
+    return f"{f:g}"
+
+
+def build_common_parts(config: dict[str, Any], *, n_rain: int) -> list[str]:
+    """SFX + rain + song の filter graph parts を組み立てる (loudnorm / 最終 amix
+    は含まない)。input layout は [0]=master_raw, [1..3]=SFX (cup/paper/vinyl 固定順),
+    [4..N+3]=rain_*.wav。
+
+    Returns:
+        ffmpeg `-filter_complex` の各 part を区切りなしで並べたリスト
+        (`;`.join() で連結する想定)。
+
+    Raises:
+        ConfigError: 必須キー欠落 / sfx エントリ欠落
+    """
+    _validate_intro_audio(config)
+    if n_rain < 1:
+        raise ConfigError(f"n_rain は 1 以上である必要があります: {n_rain}")
+
+    sfx_cfg = config["sfx"]
+    parts: list[str] = []
+
+    # ── SFX: cup=[1:a], paper=[2:a], vinyl=[3:a] ──
+    for idx, name in enumerate(_SFX_ORDER, start=1):
+        entry = sfx_cfg[name]
+        start_ms = int(entry["start_ms"])
+        volume_db = entry["volume_db"]
+        # intro 30s 全体に届かせるため apad で尾部を埋める
+        parts.append(
+            f"[{idx}:a]adelay={start_ms}|{start_ms},"
+            f"volume={volume_db}dB,apad[{name}]"
+        )
+
+    parts.append(
+        f"[{_SFX_ORDER[0]}][{_SFX_ORDER[1]}][{_SFX_ORDER[2]}]"
+        f"amix=inputs=3:duration=first:normalize=0[sfx]"
+    )
+
+    # ── rain N-layer: input index 4..N+3 ──
+    rain_volume = config["rain_volume_db"]
+    rain_fadein = _format_seconds(config["rain_fadein_s"])
+    rain_labels: list[str] = []
+    for i in range(n_rain):
+        in_idx = 4 + i
+        label = f"r{i}"
+        rain_labels.append(f"[{label}]")
+        parts.append(
+            f"[{in_idx}:a]volume={rain_volume}dB,"
+            f"afade=t=in:st=0:d={rain_fadein},"
+            f"aloop=loop=-1:size=2147483647[{label}]"
+        )
+    if n_rain == 1:
+        parts.append("[r0]anull[rain]")
+    else:
+        parts.append(
+            f"{''.join(rain_labels)}amix=inputs={n_rain}:"
+            "duration=first:normalize=0[rain]"
+        )
+
+    # ── song: 設計 D の核 (10s 遅延 + 2s afade-in + volume) ──
+    delay_ms = int(config["song_delay_ms"])
+    fadein_s = _format_seconds(config["song_fadein_s"])
+    fadein_start_s = _format_seconds(delay_ms / 1000.0)
+    song_volume = config["song_volume_db"]
+    parts.append(
+        f"[0:a]adelay={delay_ms}|{delay_ms},"
+        f"afade=t=in:st={fadein_start_s}:d={fadein_s},"
+        f"volume={song_volume}dB[song]"
+    )
+
+    return parts
+
+
+def _loudnorm_filter(loudnorm: dict[str, Any], *, measured: dict[str, str] | None) -> str:
+    """loudnorm filter 文字列を組み立てる。
+
+    Args:
+        loudnorm: `{I: -14, LRA: 11, TP: -1.5}` 相当の target 値 dict
+        measured: pass1 の測定値を渡すと pass2 の linear モードを使う
+    """
+    target_i = loudnorm["I"]
+    target_lra = loudnorm["LRA"]
+    target_tp = loudnorm["TP"]
+    base = f"loudnorm=I={target_i}:LRA={target_lra}:TP={target_tp}"
+    if measured is None:
+        return f"{base}:print_format=json"
+    return (
+        f"{base}:"
+        f"measured_I={measured['input_i']}:"
+        f"measured_LRA={measured['input_lra']}:"
+        f"measured_TP={measured['input_tp']}:"
+        f"measured_thresh={measured['input_thresh']}:"
+        f"offset={measured.get('target_offset', '0')}:"
+        "linear=true:print_format=summary"
+    )
+
+
+def build_filter(
+    config: dict[str, Any],
+    *,
+    n_rain: int = 1,
+    measured: dict[str, str] | None = None,
+) -> str:
+    """完全な filter_complex 文字列 (末尾 `[aout]`) を組み立てる。
+
+    Args:
+        config: `intro_audio` namespace dict
+        n_rain: rain layer 件数
+        measured: pass1 の loudnorm 測定値。None=pass1 (measurement) モード
+    """
+    parts = list(build_common_parts(config, n_rain=n_rain))
+    final = (
+        f"[song][sfx][rain]amix=inputs=3:duration=first:normalize=0,"
+        f"{_loudnorm_filter(config['loudnorm'], measured=measured)}[aout]"
+    )
+    parts.append(final)
+    return ";".join(parts)
+
+
+_LOUDNORM_KEYS = ("input_i", "input_tp", "input_lra", "input_thresh")
+
+
+def parse_loudnorm_json(stderr: str) -> dict[str, Any]:
+    """ffmpeg pass1 の stderr から loudnorm の JSON ブロックを抽出する。
+
+    Returns:
+        dict (input_i / input_tp / input_lra / input_thresh / target_offset 含む)
+
+    Raises:
+        RuntimeError: stderr に loudnorm JSON ブロックが見つからない
+    """
+    # `{ ... }` 形式の JSON ブロックを greedy に抽出 (loudnorm が最後に出すのが本命)
+    blocks = re.findall(r"\{[^{}]*\}", stderr, flags=re.DOTALL)
+    for block in reversed(blocks):
+        try:
+            data = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and all(k in data for k in _LOUDNORM_KEYS):
+            return data
+    raise RuntimeError(
+        "ffmpeg stderr に loudnorm JSON ブロック (input_i/input_tp/input_lra/"
+        "input_thresh を含む) が見つかりません"
+    )
+
+
+def finalize(collection: Path, *, keep_raw: bool = False) -> int:
+    """`<collection>/01-master/master_raw.mp3` を入力に master.mp3 を生成する。
+
+    Returns:
+        exit code (0=成功 / 1=入力検証失敗 / その他=ffmpeg 伝播)
+    """
+    config_full = load_skill_config("masterup", use_cache=False)
+    intro_audio = config_full.get("intro_audio")
+    if not isinstance(intro_audio, dict):
+        raise ConfigError(
+            "masterup/config.default.yaml に intro_audio: namespace が必要です"
+        )
+    _validate_intro_audio(intro_audio)
+
+    repo = channel_dir()
+    master_raw = collection / "01-master" / "master_raw.mp3"
+    output = collection / "01-master" / "master.mp3"
+
+    # 入力検証 (Fail Fast)
+    if not master_raw.exists():
+        print(f"ERROR: master_raw.mp3 が見つかりません: {master_raw}", file=sys.stderr)
+        return 1
+
+    sfx_dir = repo / "branding" / "intro_sfx"
+    sfx_files: list[Path] = []
+    for name in _SFX_ORDER:
+        entry = intro_audio["sfx"][name]
+        path = sfx_dir / entry["file"]
+        if not path.exists():
+            print(f"ERROR: SFX wav が見つかりません: {path}", file=sys.stderr)
+            return 1
+        sfx_files.append(path)
+
+    rain_dir = repo / "branding" / "rain_layers"
+    rain_files = sorted(rain_dir.glob(_RAIN_GLOB)) if rain_dir.exists() else []
+    if not rain_files:
+        print(
+            f"ERROR: rain layer (rain_*.wav) が {rain_dir} に存在しません",
+            file=sys.stderr,
+        )
+        return 1
+
+    n_rain = len(rain_files)
+
+    # ── pass1: loudnorm 測定 ──
+    pass1_filter = build_filter(
+        intro_audio,
+        n_rain=n_rain,
+        measured=None,
+    )
+    cmd1: list[str] = ["ffmpeg", "-y", "-i", str(master_raw)]
+    for s in sfx_files:
+        cmd1 += ["-i", str(s)]
+    for r in rain_files:
+        cmd1 += ["-i", str(r)]
+    cmd1 += [
+        "-filter_complex", pass1_filter,
+        "-map", "[aout]",
+        "-f", "null", "-",
+    ]
+    result1 = subprocess.run(cmd1, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    if result1.returncode != 0:
+        print(
+            f"ERROR: ffmpeg pass1 (loudnorm 測定) が失敗 (exit {result1.returncode})",
+            file=sys.stderr,
+        )
+        if result1.stderr:
+            print(result1.stderr, file=sys.stderr)
+        return result1.returncode
+
+    measured = parse_loudnorm_json(result1.stderr or "")
+
+    # ── pass2: linear loudnorm + 出力 ──
+    pass2_filter = build_filter(
+        intro_audio,
+        n_rain=n_rain,
+        measured=measured,
+    )
+    cmd2: list[str] = ["ffmpeg", "-y", "-i", str(master_raw)]
+    for s in sfx_files:
+        cmd2 += ["-i", str(s)]
+    for r in rain_files:
+        cmd2 += ["-i", str(r)]
+    cmd2 += [
+        "-filter_complex", pass2_filter,
+        "-map", "[aout]",
+        "-c:a", "libmp3lame", "-b:a", "192k",
+        str(output),
+    ]
+    result2 = subprocess.run(cmd2, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    if result2.returncode != 0:
+        print(
+            f"ERROR: ffmpeg pass2 (final mix) が失敗 (exit {result2.returncode})",
+            file=sys.stderr,
+        )
+        if result2.stderr:
+            print(result2.stderr, file=sys.stderr)
+        return result2.returncode
+
+    # 中間成果物クリーンアップ (--keep-raw で抑止)
+    if not keep_raw:
+        try:
+            os.remove(master_raw)
+        except OSError as e:
+            print(f"WARN: master_raw.mp3 削除に失敗 ({e})", file=sys.stderr)
+
+    print(f"Success: {output}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("collection", type=Path, help="コレクションディレクトリ")
+    parser.add_argument(
+        "--keep-raw",
+        action="store_true",
+        help="master_raw.mp3 を削除せず残す (debug 用)",
+    )
+    args = parser.parse_args()
+    return finalize(args.collection, keep_raw=args.keep_raw)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -58,6 +58,27 @@ $ARGUMENTS
 - ユーザーが DAW でミックスした `master-mix.{wav,m4a}` がある場合、`yt-generate-master` は不要
 - `set -e` は使用しない（明示的エラーハンドリング）
 
+## Intro 統合モード（`branding/intro.mp4` 自動検出 / 設計 D 動画側施策）
+
+`<repo-root>/branding/intro.mp4` が存在し、かつ `10-assets/loop.mp4` も配置されている場合、`generate_videos.sh` は **Intro 統合モード（v13 pure concat）** で動作する:
+
+1. `intro_video_only.mp4` — `branding/intro.mp4` を `-an -c:v copy` で stream copy（音声なしを保証）
+2. `body_video.mp4` — `loop_normalized.mp4` を `master_duration - 30` 秒分ループ（`-c:v copy`）
+3. `concat demuxer + stream copy` で intro + body を結合し、最終的に master 音声を `-map` で合成
+
+`loop_normalized.mp4` 生成時は intro と fps を揃えるため `-r 24` を強制する（concat demuxer + stream copy が成立する前提条件）。
+
+### 責務分界（音声 / 動画）
+
+- **音声合成（SFX + rain + 楽曲 amix + loudnorm）** は **`/masterup` の `finalize_master.py`** が担当する。`master.mp3` には設計 D の音声合流が既に焼き込まれている前提
+- **`generate_videos.sh` の Intro 統合モードは pure video concat に徹する** — intro.mp4 から audio を読まない、master.mp3 をそのまま全長 audio source として `-map` する
+- intro.mp4 は **video-only**（`-an`）で `/intro` スキルが生成するため、concat demuxer 段階で audio stream の食い違いは起きない
+
+### 制約
+
+- Intro 統合モードは **loop モード必須**。静止画モード（`10-assets/loop.mp4` なし）では intro 統合非対応で早期エラー終了する
+- intro.mp4 が無い channel は従来通りの loop モード（intro なし stream copy）にフォールバックする
+
 ## Next Step
 
 動画生成後:

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# generate_videos.sh v12.0 — Master video generator
-# Static image + master audio → MP4 (macOS optimized)
+# generate_videos.sh v13.0 — Master video generator
+# (Previous: generate_videos.sh v12.0 — ループモード stream copy + 正規化キャッシュ)
+# Static image / Loop background + master audio → MP4
+# v13: Intro 統合モード追加（`branding/intro.mp4` 自動検出時に pure concat 経路）
 # v12: ループモードを正規化キャッシュ + stream copy 化（クオリティ完全保持で大幅高速化）
 #
 # Usage:
@@ -29,6 +31,21 @@ COLLECTION_NAME="$(echo "$dir_basename" \
     | sed -E 's/^[0-9]+-[a-z]+-//; s/-collection$//' \
     | awk -F'-' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}' OFS='-')"
 
+# ─── Repo root resolution (for branding/intro.mp4 auto-detection) ─
+REPO_ROOT=""
+candidate="$COLLECTION_DIR"
+while [[ "$candidate" != "/" && -n "$candidate" ]]; do
+    if [[ -d "${candidate}/config/channel" || -d "${candidate}/branding" || -d "${candidate}/.git" ]]; then
+        REPO_ROOT="$candidate"
+        break
+    fi
+    candidate="$(dirname "$candidate")"
+done
+if [[ -z "$REPO_ROOT" ]]; then
+    # collection の祖先方向で見つからなければ collection 直上をフォールバック扱い
+    REPO_ROOT="$(dirname "$(dirname "$COLLECTION_DIR")")"
+fi
+
 # ─── Auto-detect Assets ─────────────────────────────────
 LOOP_VIDEO=""
 if [[ -f "${ASSETS_DIR}/loop.mp4" ]]; then
@@ -55,14 +72,15 @@ done
 
 MASTER_OUTPUT="${MASTER_DIR}/${COLLECTION_NAME}-Master.mp4"
 
-# ─── Audio encoder 自動選択 (macOS は AudioToolbox 優先) ─
-if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
-    AUDIO_ENCODER="aac_at"
-else
-    AUDIO_ENCODER="aac"
+# ─── Intro mode auto-detection ───────────────────────────
+INTRO_VIDEO="${REPO_ROOT}/branding/intro.mp4"
+INTRO_MODE=0
+if [[ -f "$INTRO_VIDEO" ]]; then
+    INTRO_MODE=1
 fi
 
-# ─── 音声出力オプション (m4a/aac はストリームコピー、それ以外は再エンコード) ─
+# ─── 音声出力オプション (m4a/aac はストリームコピー、それ以外は AAC 再エンコード) ─
+# m4a/aac 系は encoder 検出 ffmpeg 呼び出し自体を省略する (-c:a copy で再エンコード不要)
 if [[ -n "$MASTER_AUDIO" ]]; then
     master_ext="${MASTER_AUDIO##*.}"
     case "$master_ext" in
@@ -70,6 +88,12 @@ if [[ -n "$MASTER_AUDIO" ]]; then
             AUDIO_OUT_OPTS=(-c:a copy)
             ;;
         *)
+            # AAC エンコーダ自動選択 (macOS は AudioToolbox 優先)
+            if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
+                AUDIO_ENCODER="aac_at"
+            else
+                AUDIO_ENCODER="aac"
+            fi
             AUDIO_OUT_OPTS=(-c:a "$AUDIO_ENCODER" -b:a 384k -ar 48000)
             ;;
     esac
@@ -89,6 +113,12 @@ if ! ffprobe -v error "$MASTER_AUDIO" &>/dev/null; then
     echo "ERROR: Corrupted file: $MASTER_AUDIO"; exit 1
 fi
 
+# Intro 統合モードは loop モード必須 (静止画 + intro は別仕様)
+if [[ $INTRO_MODE -eq 1 && -z "$LOOP_VIDEO" ]]; then
+    echo "ERROR: 静止画モードでは intro 統合非対応 (Intro 統合モードは 10-assets/loop.mp4 が必要)"
+    exit 1
+fi
+
 # ─── Duration (macOS: afinfo, fallback: ffprobe) ─────────
 get_duration() {
     local file="$1"
@@ -106,13 +136,20 @@ format_duration() {
 
 # ─── Main ────────────────────────────────────────────────
 echo ""
-echo "  generate_videos.sh v12.0 — ${COLLECTION_NAME}"
+if [[ $INTRO_MODE -eq 1 ]]; then
+    echo "  generate_videos.sh v13.0 — ${COLLECTION_NAME} (Intro 統合モード)"
+else
+    echo "  generate_videos.sh v13.0 — ${COLLECTION_NAME}"
+fi
 echo "  ──────────────────────────────────────────"
 echo ""
 if [[ -n "$LOOP_VIDEO" ]]; then
     echo "  Video BG : $(basename "$LOOP_VIDEO") (loop)"
 else
     echo "  Thumbnail: $(basename "$THUMBNAIL")"
+fi
+if [[ $INTRO_MODE -eq 1 ]]; then
+    echo "  Intro    : $(basename "$INTRO_VIDEO") (concat 先頭)"
 fi
 echo "  Audio    : $(basename "$MASTER_AUDIO")"
 echo "  Output   : $(basename "$MASTER_OUTPUT")"
@@ -122,31 +159,33 @@ echo "  Duration : $(format_duration "$duration")"
 echo ""
 start=$SECONDS
 PROGRESS_FILE="$(mktemp)"
-trap 'rm -f "$PROGRESS_FILE"' EXIT
 
-# ─── FFmpeg (background) ─────────────────────────────────
+# 一時中間成果物 (Intro 統合モード用) は trap でまとめて掃除
+TS="$$"
+INTRO_TMP="/tmp/intro_video_only_${COLLECTION_NAME}_${TS}.mp4"
+BODY_TMP="/tmp/body_video_${COLLECTION_NAME}_${TS}.mp4"
+CONCAT_LIST="/tmp/concat_${COLLECTION_NAME}_${TS}.txt"
+trap 'rm -f "$PROGRESS_FILE" "$INTRO_TMP" "$BODY_TMP" "$CONCAT_LIST"' EXIT
+
+# ─── Loop 正規化キャッシュ (loop モードのみ) ─────────────
 if [[ -n "$LOOP_VIDEO" ]]; then
-    # ループ動画背景モード: loop.mp4 を無限ループで背景に使用
-    # 戦略: ソースを 1 度だけ yuv420p / 1920x1080 に正規化キャッシュし、
-    # 以降のマスター動画生成は -c:v copy で stream copy する（音声のみエンコード）
     loop_specs="$(ffprobe -v error -select_streams v:0 \
         -show_entries stream=width,height,pix_fmt -of csv=p=0 "$LOOP_VIDEO" 2>/dev/null)"
-    # csv=p=0 出力は "width,height,pix_fmt" の順
     loop_w="$(echo "$loop_specs" | cut -d, -f1)"
     loop_h="$(echo "$loop_specs" | cut -d, -f2)"
     loop_pix="$(echo "$loop_specs" | cut -d, -f3)"
 
     if [[ "$loop_w" == "1920" && "$loop_h" == "1080" && "$loop_pix" == "yuv420p" ]]; then
-        # 既に正規化済み: そのまま使う
         LOOP_SOURCE="$LOOP_VIDEO"
     else
-        # 正規化キャッシュを使用
         LOOP_SOURCE="${ASSETS_DIR}/loop_normalized.mp4"
         if [[ ! -f "$LOOP_SOURCE" || "$LOOP_VIDEO" -nt "$LOOP_SOURCE" ]]; then
             echo "  Normalizing loop source (1 回だけ実行) → loop_normalized.mp4"
+            # -r 24 で intro.mp4 と fps を揃える (concat demuxer + stream copy 互換の前提)
             ffmpeg -y -i "$LOOP_VIDEO" \
                 -c:v libx264 -preset slow -crf 18 -profile:v high -pix_fmt yuv420p \
                 -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,format=yuv420p" \
+                -r 24 \
                 -an -movflags +faststart \
                 -loglevel error \
                 "$LOOP_SOURCE"
@@ -156,8 +195,50 @@ if [[ -n "$LOOP_VIDEO" ]]; then
             fi
         fi
     fi
+fi
 
-    # Stream copy 経路: ビデオは完全無損失（ビット単位コピー）、音声は AUDIO_OUT_OPTS に従う
+# ─── FFmpeg 本処理 ───────────────────────────────────────
+if [[ $INTRO_MODE -eq 1 ]]; then
+    # ─── Intro 統合モード v13 (3 段ビルド + concat demuxer) ──
+    # Step 1: intro_video_only.mp4 (intro.mp4 を audio 抜き stream copy)
+    ffmpeg -y -i "$INTRO_VIDEO" -an -c:v copy \
+        -movflags +faststart \
+        -loglevel error \
+        "$INTRO_TMP"
+    rc=$?
+    if [[ $rc -ne 0 || ! -f "$INTRO_TMP" ]]; then
+        echo "  ERROR: intro_video_only.mp4 の生成に失敗 (exit ${rc})"
+        exit ${rc:-1}
+    fi
+
+    # Step 2: body_video.mp4 (loop を duration - 30s 分ループ、stream copy)
+    body_dur=$(awk "BEGIN{printf \"%.2f\", ${duration} - 30}")
+    ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" \
+        -an -c:v copy \
+        -t "$body_dur" \
+        -movflags +faststart \
+        -loglevel error \
+        "$BODY_TMP"
+    rc=$?
+    if [[ $rc -ne 0 || ! -f "$BODY_TMP" ]]; then
+        echo "  ERROR: body_video.mp4 の生成に失敗 (exit ${rc})"
+        exit ${rc:-1}
+    fi
+
+    # Step 3: concat demuxer で intro + body を結合し、master.mp3 を audio として map
+    printf "file '%s'\nfile '%s'\n" "$INTRO_TMP" "$BODY_TMP" > "$CONCAT_LIST"
+    ffmpeg -y -f concat -safe 0 -i "$CONCAT_LIST" -i "$MASTER_AUDIO" \
+        -map 0:v:0 -map 1:a:0 \
+        -c:v copy \
+        "${AUDIO_OUT_OPTS[@]}" \
+        -t "$duration" \
+        -movflags +faststart \
+        -shortest \
+        -loglevel error \
+        -progress "$PROGRESS_FILE" \
+        "$MASTER_OUTPUT" &
+elif [[ -n "$LOOP_VIDEO" ]]; then
+    # ─── 通常 loop モード (intro 無し / 既存挙動) ─
     ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" -i "$MASTER_AUDIO" \
         -map 0:v:0 -map 1:a:0 \
         -c:v copy \
@@ -169,7 +250,7 @@ if [[ -n "$LOOP_VIDEO" ]]; then
         -progress "$PROGRESS_FILE" \
         "$MASTER_OUTPUT" &
 else
-    # 静止画背景モード（従来）
+    # ─── 静止画背景モード (従来) ─
     ffmpeg -y -framerate 1 -loop 1 -i "$THUMBNAIL" -i "$MASTER_AUDIO" \
         -c:v libx264 -tune stillimage -preset ultrafast -crf 23 -pix_fmt yuv420p \
         -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
@@ -215,7 +296,6 @@ wait "$ffmpeg_pid"
 exit_code=$?
 elapsed=$((SECONDS - start))
 
-# Final bar
 printf "\r  ✓ Generated    %s 100%% (%dm%02ds)    \n" \
     "$(printf '%0.s█' $(seq 1 $BAR_WIDTH))" $((elapsed/60)) $((elapsed%60))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,9 @@ collections/            # コンテンツ成果物
 | `auth.oauth_handler` | OAuth 2.0 トークン管理 |
 | `utils.secrets` | シークレット解決（`_SECRET_REFS` で参照定義） |
 | `cli.skills_sync` | `yt-skills` 本体 |
+| `/intro` skill | チャンネル共通 30 秒 intro 動画 (`branding/intro.mp4`) ビルダー。チャンネル開設 / ブランド刷新時の 1 回限り。設計 D（10s afade-in 合流）の動画側施策。`config/skills/intro.yaml` で text / logo / font / color を上書き可能 |
+| `/masterup` skill | `finalize_master.py` で SFX (cup/paper/vinyl) + rain N-layer + 設計 D 楽曲合流（10s 遅延 + 2s afade-in）を amix し、loudnorm two-pass で master.mp3 を最終整音 |
+| `/videoup` skill | `branding/intro.mp4` 検出時の Intro 統合モード v13（pure concat + audio map）。loop モード必須。intro 24fps と揃えるため `loop_normalized.mp4` 生成時に `-r 24` を強制 |
 
 ## 開発規約
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.4.0"
+version = "5.5.0"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.4.0"
+__version__ = "5.5.0"

--- a/tests/_skill_loader.py
+++ b/tests/_skill_loader.py
@@ -1,0 +1,40 @@
+"""skill 配下の Python スクリプトをモジュールとしてロードするヘルパー。
+
+`.claude/skills/<skill>/references/<script>.py` は package 配下に置かれていない
+ため、通常の `from youtube_automation...` 形式では import できない。
+本ヘルパーは Issue #137 で追加される `intro` / `masterup` の references スクリプト
+を unit test から import するためだけに使う。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
+
+
+def load_skill_script(skill: str, script_name: str) -> ModuleType:
+    """`.claude/skills/<skill>/references/<script>` を import する。
+
+    Args:
+        skill: スキル名 (例: "intro" / "masterup")
+        script_name: 拡張子なしのスクリプトファイル名 (例: "generate_intro")
+
+    Returns:
+        ロード済みモジュール
+    """
+    script_path = _SKILLS_DIR / skill / "references" / f"{script_name}.py"
+    if not script_path.exists():
+        raise FileNotFoundError(script_path)
+    module_name = f"_skill_{skill}_{script_name}"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to build spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,35 @@ def _reset_config_singleton():
     reset_config()
     yield
     reset_config()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cost_tracker_writes(tmp_path_factory, monkeypatch):
+    """sample_channel fixture への cost_tracker 書き込みを構造的に隔離する。
+
+    `cost_tracker.log_generation` は `<channel_dir>/data/{image,video,audio}_costs.json` に
+    append する設計のため、CHANNEL_DIR を sample_channel fixture に向けたまま
+    pytest を実行すると lyria 系等のテスト経由で `tests/fixtures/sample_channel/data/`
+    配下が毎回上書きされる。`git checkout` の単発 revert では durable に解決できないため、
+    `_log_path` 解決を一時ディレクトリへリダイレクトし fixture を不可触に保つ。
+
+    `tmp_channel` fixture などテスト側で CHANNEL_DIR を tmp_path に上書きする場合は
+    元の解決パス（テスト固有 tmp_path 配下）を尊重し、テストの read 側 helper との
+    整合を維持する。
+    """
+    from youtube_automation.utils import cost_tracker as _ct
+
+    isolated_dir = tmp_path_factory.mktemp("cost_tracker_isolated")
+
+    def _isolated_log_path(category):
+        try:
+            from youtube_automation.utils.config import channel_dir as _channel_dir
+
+            current = _channel_dir()
+        except Exception:
+            return isolated_dir / _ct._LOG_FILENAMES[category]
+        if current == _CHANNEL_DIR:
+            return isolated_dir / _ct._LOG_FILENAMES[category]
+        return current / "data" / _ct._LOG_FILENAMES[category]
+
+    monkeypatch.setattr("youtube_automation.utils.cost_tracker._log_path", _isolated_log_path)

--- a/tests/integration/test_generate_videos_intro_mode.py
+++ b/tests/integration/test_generate_videos_intro_mode.py
@@ -1,0 +1,342 @@
+"""Issue #137: `.claude/skills/videoup/references/generate_videos.sh` Intro 統合モード v13 (G 節)。
+
+bash スクリプトを偽 ffmpeg / ffprobe stub と共に実行し、
+- branding/intro.mp4 検知時の 3 段ビルド (intro_video_only → body → concat)
+- 通常 loop モード (intro 無し) のリグレッション
+- loop_normalized.mp4 生成時の `-r 24` 強制
+- 静止画モード + intro.mp4 ありの組み合わせの早期 fail
+- 中間 ffmpeg 失敗時の exit code 伝播
+を検証する。
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / ".claude" / "skills" / "videoup" / "references" / "generate_videos.sh"
+
+
+def _make_ffmpeg_stub(stub_dir: Path, log_path: Path, *, exit_codes: list[int] | None = None) -> None:
+    """偽 ffmpeg/ffprobe を `stub_dir` に書く。
+
+    引数はすべて `log_path` に追記し、出力ファイル (cmd 末尾) を空ファイルとして
+    生成する。`exit_codes` で呼び出しごとの exit code を制御 (default: 全て 0)。
+    """
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    counter_file = stub_dir / ".counter"
+    counter_file.write_text("0", encoding="utf-8")
+
+    exit_seq = ":".join(str(c) for c in (exit_codes or [0] * 10))
+    ffmpeg_body = f"""#!/usr/bin/env bash
+echo "$@" >> '{log_path}'
+# 出力先 (cmd 末尾) を空ファイルとして touch する
+output="${{!#}}"
+case "$output" in
+    *.mp4|*.txt|*.wav|*.m4a)
+        mkdir -p "$(dirname "$output")" 2>/dev/null
+        : > "$output"
+        ;;
+esac
+# 呼び出しカウントで exit code を切り替え
+n=$(cat '{counter_file}')
+n=$((n + 1))
+echo $n > '{counter_file}'
+codes='{exit_seq}'
+IFS=':' read -ra arr <<< "$codes"
+exit_code="${{arr[$((n - 1))]}}"
+exit "${{exit_code:-0}}"
+"""
+    ffmpeg_path = stub_dir / "ffmpeg"
+    ffmpeg_path.write_text(ffmpeg_body, encoding="utf-8")
+    ffmpeg_path.chmod(ffmpeg_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # ffprobe: 1920x1080 / yuv420p を返す stub (loop 正規化スキップを許可)
+    ffprobe_body = f"""#!/usr/bin/env bash
+echo "$@" >> '{log_path}'
+# `-show_entries stream=width,height,pix_fmt -of csv=p=0` を要求された場合
+case "$*" in
+    *show_entries*stream=width,height,pix_fmt*)
+        echo "1920,1080,yuv420p"
+        ;;
+    *show_entries*format=duration*)
+        echo "60.00"
+        ;;
+    *)
+        ;;
+esac
+exit 0
+"""
+    ffprobe_path = stub_dir / "ffprobe"
+    ffprobe_path.write_text(ffprobe_body, encoding="utf-8")
+    ffprobe_path.chmod(ffprobe_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # afinfo: macOS 環境で生 afinfo が PATH に出てしまうのを防ぐため、stub PATH に
+    # 偽 afinfo を置いて固定 duration (60s) を返す。
+    afinfo_body = f"""#!/usr/bin/env bash
+echo "$@" >> '{log_path}'
+echo "estimated duration: 60.00 sec"
+exit 0
+"""
+    afinfo_path = stub_dir / "afinfo"
+    afinfo_path.write_text(afinfo_body, encoding="utf-8")
+    afinfo_path.chmod(afinfo_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_ffprobe_returns_unnormalized(stub_dir: Path, log_path: Path) -> None:
+    """ffprobe が 1280x720 / yuv422p を返すよう書き換える (= loop 正規化が必要)。"""
+    ffprobe_body = f"""#!/usr/bin/env bash
+echo "$@" >> '{log_path}'
+case "$*" in
+    *show_entries*stream=width,height,pix_fmt*)
+        echo "1280,720,yuv422p"
+        ;;
+    *show_entries*format=duration*)
+        echo "60.00"
+        ;;
+    *)
+        ;;
+esac
+exit 0
+"""
+    ffprobe_path = stub_dir / "ffprobe"
+    ffprobe_path.write_text(ffprobe_body, encoding="utf-8")
+    ffprobe_path.chmod(ffprobe_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _setup_collection_repo(
+    tmp_path: Path,
+    *,
+    with_intro: bool,
+    with_loop: bool,
+    with_thumbnail: bool = True,
+    with_master: bool = True,
+) -> tuple[Path, Path]:
+    """tmp_path に repo + collection ツリーを組む。
+
+    Returns:
+        (repo_root, collection_dir)
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # git rev-parse 相当に依存しないよう、collection の上位パスから直接解決させる
+    # generate_videos.sh は `branding/intro.mp4` を repo-root 起点で読む想定
+    collection = repo / "collections" / "planning" / "20260101-test-collection"
+    (collection / "01-master").mkdir(parents=True)
+    (collection / "10-assets").mkdir()
+
+    if with_thumbnail:
+        (collection / "10-assets" / "main.png").write_bytes(b"\x89PNG\x00")
+    if with_master:
+        (collection / "01-master" / "master-mix.m4a").write_bytes(b"\x00")
+    if with_loop:
+        (collection / "10-assets" / "loop.mp4").write_bytes(b"\x00")
+    if with_intro:
+        (repo / "branding").mkdir()
+        (repo / "branding" / "intro.mp4").write_bytes(b"\x00")
+    return repo, collection
+
+
+def _run_script(
+    collection: Path,
+    stub_dir: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """generate_videos.sh を stub PATH 限定で実行する (実 ffmpeg / afinfo を排除)。"""
+    env = {
+        "PATH": f"{stub_dir}:/bin:/usr/bin",
+        "HOME": str(stub_dir.parent),
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        ["bash", str(_SCRIPT_PATH), str(collection)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+@pytest.fixture
+def script_exists() -> None:
+    if not _SCRIPT_PATH.exists():
+        pytest.skip(f"generate_videos.sh が無い: {_SCRIPT_PATH}")
+
+
+# ---------- G-1: intro mode (intro.mp4 + loop.mp4) ----------
+
+
+def test_intro_mode_runs_3stage_concat_when_intro_and_loop_present(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given branding/intro.mp4 + 10-assets/loop.mp4 が両方存在
+    When generate_videos.sh を実行
+    Then 3 段ビルド (intro_video_only → body → concat) のために ffmpeg が
+        複数回呼ばれ、かつ concat demuxer の `-f concat` か
+        `concat:` プロトコル相当が cmd ログに出る。
+    """
+    repo, collection = _setup_collection_repo(tmp_path, with_intro=True, with_loop=True)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    _make_ffmpeg_stub(stub_dir, log)
+
+    result = _run_script(collection, stub_dir)
+    assert result.returncode == 0, (
+        f"intro mode で失敗:\nrc={result.returncode}\nstderr={result.stderr}\nstdout={result.stdout}"
+    )
+
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+    assert log_text, "ffmpeg stub が呼ばれていない"
+
+    # 3 段ビルド経路: intro_video_only.mp4 / body_video.mp4 / concat 連結のいずれかが見える
+    assert (
+        "intro_video_only" in log_text
+        or "body_video" in log_text
+        or "-f concat" in log_text
+    ), (
+        f"intro mode の 3 段ビルド痕跡が ffmpeg cmd ログに無い:\n{log_text}"
+    )
+
+
+# ---------- G-2: loop mode (intro.mp4 なし) — 既存挙動リグレッション ----------
+
+
+def test_loop_mode_falls_back_to_single_pass_stream_copy_when_intro_absent(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given branding/intro.mp4 が存在せず loop.mp4 のみ
+    When generate_videos.sh を実行
+    Then 既存の単発 stream copy 経路 (`-c:v copy`) が cmd ログに出る。
+    """
+    _, collection = _setup_collection_repo(tmp_path, with_intro=False, with_loop=True)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    _make_ffmpeg_stub(stub_dir, log)
+
+    result = _run_script(collection, stub_dir)
+    assert result.returncode == 0, (
+        f"loop mode (intro 無し) で失敗:\nrc={result.returncode}\nstderr={result.stderr}"
+    )
+
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+    assert "-c:v copy" in log_text, (
+        f"既存 stream copy 経路が消えた:\n{log_text}"
+    )
+
+
+# ---------- G-3: loop_normalized 生成時に `-r 24` が強制される ----------
+
+
+def test_loop_normalize_pass_includes_r_24(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given loop.mp4 が 1280x720 / yuv422p (= 正規化キャッシュが必要)
+    When generate_videos.sh を実行
+    Then loop_normalized.mp4 生成 ffmpeg cmd に `-r 24` が含まれる
+        (intro.mp4 と fps を揃え concat demuxer + stream copy を可能にするため)。
+    """
+    _, collection = _setup_collection_repo(tmp_path, with_intro=True, with_loop=True)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    _make_ffmpeg_stub(stub_dir, log)
+    _make_ffprobe_returns_unnormalized(stub_dir, log)
+
+    result = _run_script(collection, stub_dir)
+    # 失敗してもログは見たいので、fail 内容を含めて assert
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+
+    # loop_normalized.mp4 への出力を含む cmd 行を抽出
+    normalize_lines = [
+        line for line in log_text.splitlines() if "loop_normalized.mp4" in line
+    ]
+    assert normalize_lines, (
+        f"loop_normalized.mp4 生成 cmd が記録されていない (rc={result.returncode}):\n"
+        f"stderr={result.stderr}\nlog={log_text}"
+    )
+    joined = " ".join(normalize_lines)
+    assert "-r 24" in joined, (
+        f"loop_normalized.mp4 生成に `-r 24` 強制が無い:\n  cmds={normalize_lines}"
+    )
+
+
+# ---------- G-4: loop.mp4 が既に正規化済みなら正規化スキップ ----------
+
+
+def test_loop_normalize_skipped_when_loop_already_normalized(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given loop.mp4 が 1920x1080 / yuv420p (= 正規化不要)
+    When generate_videos.sh を実行
+    Then loop_normalized.mp4 を作る ffmpeg cmd は呼ばれない
+        (既存最適化のリグレッション防止)。
+    """
+    _, collection = _setup_collection_repo(tmp_path, with_intro=False, with_loop=True)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    _make_ffmpeg_stub(stub_dir, log)  # ffprobe は 1920x1080/yuv420p を返す
+
+    result = _run_script(collection, stub_dir)
+    assert result.returncode == 0
+
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+    normalize_lines = [
+        line for line in log_text.splitlines() if "loop_normalized.mp4" in line
+    ]
+    assert not normalize_lines, (
+        f"既に正規化済みの loop.mp4 で loop_normalized.mp4 を再生成している:\n  {normalize_lines}"
+    )
+
+
+# ---------- G-5: intro.mp4 あり + loop.mp4 なし → exit 1 ----------
+
+
+def test_intro_with_static_only_exits_1(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given branding/intro.mp4 はあるが loop.mp4 が無い (= 静止画モード)
+    When generate_videos.sh を実行
+    Then exit 1 + 「静止画モードでは intro 統合非対応」相当のエラー文。
+    """
+    _, collection = _setup_collection_repo(tmp_path, with_intro=True, with_loop=False)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    _make_ffmpeg_stub(stub_dir, log)
+
+    result = _run_script(collection, stub_dir)
+    assert result.returncode != 0, (
+        f"静止画モード + intro.mp4 で rc=0 で抜けた:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "intro" in combined.lower() or "静止画" in combined, (
+        f"intro 統合非対応のエラー文が出ていない:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+# ---------- G-6: 中間 ffmpeg 失敗時に exit code が伝播される ----------
+
+
+def test_intro_mode_propagates_intermediate_ffmpeg_failure(
+    script_exists, tmp_path: Path,
+) -> None:
+    """Given intro mode で 1 回目の ffmpeg (intro_video_only) が exit 5 で失敗
+    When generate_videos.sh を実行
+    Then exit code が 0 でない (中間ステップ失敗が呼び出し側に伝播)。
+    """
+    _, collection = _setup_collection_repo(tmp_path, with_intro=True, with_loop=True)
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "ffmpeg.log"
+    # ffmpeg 1 回目は exit 5、後続は 0 (実装が早期 return しなければ呼ばれてしまう)
+    _make_ffmpeg_stub(stub_dir, log, exit_codes=[5, 0, 0, 0, 0])
+
+    result = _run_script(collection, stub_dir)
+    assert result.returncode != 0, (
+        f"中間 ffmpeg 失敗が伝播していない (rc=0 で返った):\nstderr={result.stderr}"
+    )

--- a/tests/test_finalize_master.py
+++ b/tests/test_finalize_master.py
@@ -1,0 +1,204 @@
+"""Issue #137: `.claude/skills/masterup/references/finalize_master.py` 純粋関数 (E 節)。
+
+設計 D の filter graph 組み立て (`build_common_parts` / `build_filter`) を
+単体検証する。subprocess は呼ばず、文字列 assert のみ。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests._skill_loader import load_skill_script
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+from youtube_automation.utils.exceptions import ConfigError
+
+# 設計 D の本質的定数 (これらは固定)
+_EXPECTED_SONG_DELAY_MS = 10000
+_EXPECTED_SONG_FADEIN_S = 2
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+@pytest.fixture
+def finalize_module():
+    return load_skill_script("masterup", "finalize_master")
+
+
+def _make_intro_audio_config(**overrides: Any) -> dict[str, Any]:
+    """plan で定義された intro_audio config の最小完全版。"""
+    config = {
+        "song_delay_ms": _EXPECTED_SONG_DELAY_MS,
+        "song_fadein_s": _EXPECTED_SONG_FADEIN_S,
+        "song_volume_db": -8,
+        "rain_volume_db": -19,
+        "rain_fadein_s": 0.5,
+        "loudnorm": {"I": -14, "LRA": 11, "TP": -1.5},
+        "sfx": {
+            "cup": {"file": "cup_v3.wav", "start_ms": 6000, "volume_db": -3},
+            "paper": {"file": "paper.wav", "start_ms": 18000, "volume_db": -12},
+            "vinyl": {"file": "vinyl_v4.wav", "start_ms": 10000, "volume_db": -6},
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+# ---------- E-1〜E-3: build_common_parts の核 ----------
+
+
+def test_build_common_parts_emits_sfx_adelay_volume_apad(finalize_module) -> None:
+    """Given intro_audio.sfx の cup/paper/vinyl 各 entry
+    When build_common_parts(config, n_rain=3) を呼ぶ
+    Then 各 SFX に adelay+volume+apad を含むフィルタが生成される。
+    """
+    cfg = _make_intro_audio_config()
+    parts = finalize_module.build_common_parts(cfg, n_rain=3)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    for name, expected in [
+        ("cup", 6000), ("paper", 18000), ("vinyl", 10000),
+    ]:
+        assert f"adelay={expected}|{expected}" in joined, (
+            f"{name} の adelay={expected} が見つからない"
+        )
+    assert "apad" in joined, "apad (尾部 padding) が無い"
+
+
+def test_build_common_parts_amix_combines_three_sfx(finalize_module) -> None:
+    """Given build_common_parts
+    When 結果 filter graph を確認
+    Then `[cup][paper][vinyl]amix=inputs=3` が出現する。
+    """
+    cfg = _make_intro_audio_config()
+    parts = finalize_module.build_common_parts(cfg, n_rain=3)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    # SFX label の amix (順序は実装依存だが 3 入力であることは固定)
+    assert "amix=inputs=3" in joined, "[cup][paper][vinyl] の 3-input amix が無い"
+
+
+def test_build_common_parts_rain_layer_chain_with_3_inputs(finalize_module) -> None:
+    """Given n_rain=3
+    When build_common_parts を呼ぶ
+    Then rain layer は 4..6 の input index で volume チェーンされて amix される。
+    """
+    cfg = _make_intro_audio_config()
+    parts = finalize_module.build_common_parts(cfg, n_rain=3)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    # input index: 0=master, 1=cup, 2=paper, 3=vinyl, 4..6=rain
+    # 各 rain layer に volume= が当たる
+    assert "[4:a]" in joined and "[5:a]" in joined and "[6:a]" in joined, (
+        f"rain layer の input index 4..6 が見つからない:\n{joined}"
+    )
+
+
+# ---------- E-4: 設計 D の核 (10s 遅延 + 2s afade-in) ----------
+
+
+def test_build_common_parts_emits_song_with_10s_delay_and_2s_fadein(
+    finalize_module,
+) -> None:
+    """Given intro_audio.song_delay_ms=10000 / song_fadein_s=2 / song_volume_db=-8
+    When build_common_parts を呼ぶ
+    Then `[0:a]adelay=10000|10000,afade=t=in:st=10:d=2,volume=-8dB[song]` 相当が出る。
+    """
+    cfg = _make_intro_audio_config()
+    parts = finalize_module.build_common_parts(cfg, n_rain=3)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    assert "adelay=10000|10000" in joined, "song の 10s 遅延が見つからない"
+    assert "afade=t=in:st=10:d=2" in joined, (
+        "設計 D の 2s afade-in (st=10:d=2) が見つからない"
+    )
+    assert "volume=-8dB" in joined or "volume=-8.0dB" in joined, (
+        "song_volume_db=-8 の volume 指定が見つからない"
+    )
+    assert "[song]" in joined, "song label が無い"
+
+
+# ---------- E-5: build_filter で 3-source 合成 + loudnorm ----------
+
+
+def test_build_filter_appends_song_sfx_rain_amix_with_loudnorm(
+    finalize_module,
+) -> None:
+    """Given build_common_parts の結果に build_filter で総合 mix を加える
+    When build_filter(config) を呼ぶ
+    Then `[song][sfx][rain]amix=inputs=3:duration=first:normalize=0,loudnorm=...[aout]`
+        相当の 3 source amix + loudnorm が末尾に出る。
+    """
+    cfg = _make_intro_audio_config()
+    filter_str = finalize_module.build_filter(cfg)
+
+    # [song][sfx][rain] の最終 amix
+    assert "amix=inputs=3" in filter_str
+    assert "loudnorm" in filter_str, "loudnorm filter が無い"
+    assert filter_str.rstrip().endswith("[aout]"), (
+        f"最終 label が [aout] でない:\n...{filter_str[-200:]}"
+    )
+
+
+# ---------- E-6: 単一 rain layer 境界 ----------
+
+
+def test_build_common_parts_works_with_single_rain_layer(finalize_module) -> None:
+    """Given n_rain=1 (rain layer が 1 つだけ)
+    When build_common_parts を呼ぶ
+    Then [4:a] のみで rain チェーンが組まれ、エラーにならない。
+    """
+    cfg = _make_intro_audio_config()
+    parts = finalize_module.build_common_parts(cfg, n_rain=1)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    assert "[4:a]" in joined
+    # [5:a] は出ない
+    assert "[5:a]" not in joined, (
+        f"n_rain=1 のはずなのに [5:a] が出ている:\n{joined}"
+    )
+
+
+# ---------- E-7: config 駆動の伝搬 (override) ----------
+
+
+def test_build_common_parts_uses_overridden_song_delay_and_fadein(
+    finalize_module,
+) -> None:
+    """Given config を `song_delay_ms=5000 / song_fadein_s=1` で override
+    When build_common_parts を呼ぶ
+    Then adelay=5000|5000, afade=t=in:st=5:d=1 が反映される (config 駆動の証跡)。
+    """
+    cfg = _make_intro_audio_config(song_delay_ms=5000, song_fadein_s=1)
+    parts = finalize_module.build_common_parts(cfg, n_rain=3)
+    joined = ";".join(parts) if isinstance(parts, list) else parts
+
+    assert "adelay=5000|5000" in joined, (
+        f"override した song_delay_ms=5000 が反映されていない:\n{joined}"
+    )
+    assert "afade=t=in:st=5:d=1" in joined, (
+        f"override した song_fadein_s=1 が反映されていない (st=5:d=1):\n{joined}"
+    )
+
+
+# ---------- E-8: 必須 namespace 欠落で ConfigError ----------
+
+
+def test_build_common_parts_raises_config_error_when_intro_audio_missing(
+    finalize_module,
+) -> None:
+    """Given config に必須キーが欠落 (sfx も song_delay_ms も無い)
+    When build_common_parts を呼ぶ
+    Then ConfigError (境界での解決原則 = Fail Fast)。
+    """
+    with pytest.raises(ConfigError):
+        finalize_module.build_common_parts({}, n_rain=3)

--- a/tests/test_finalize_master_main.py
+++ b/tests/test_finalize_master_main.py
@@ -1,11 +1,15 @@
-"""Issue #137: `.claude/skills/masterup/references/finalize_master.py` CLI / 副作用層 (F 節)。
+"""Issue #210: `.claude/skills/masterup/references/finalize_master.py` CLI / 副作用層 (F 節)。
 
 `finalize` (CLI) と `parse_loudnorm_json` の振る舞いを subprocess.run mock
 で検証する。ffmpeg バイナリは呼ばない。
+
+A2 (atomic rename) / B (intro モード自動切替) / C (SKILL.md 整合) の
+新しい振る舞いを担保する。
 """
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -37,8 +41,19 @@ def _setup_finalize_collection(
     n_rain: int = 3,
     with_master: bool = True,
     with_sfx: bool = True,
+    with_sfx_dir: bool = True,
+    with_rain_dir: bool = True,
+    master_content: bytes = b"\x00",
 ) -> tuple[Path, Path]:
     """tmp_path に repo + collection ツリーを組む。
+
+    Args:
+        n_rain: rain_*.wav の生成件数 (with_rain_dir=False のときは無視)。
+        with_master: 01-master/master.mp3 を作成するか。
+        with_sfx: SFX 3 wav を全て配置するか (with_sfx_dir 必要)。
+        with_sfx_dir: branding/intro_sfx/ ディレクトリ自体を作成するか。
+        with_rain_dir: branding/rain_layers/ ディレクトリ自体を作成するか。
+        master_content: master.mp3 の初期 bytes (atomic rename の同一性検証用)。
 
     Returns:
         (repo_root, collection_dir)
@@ -48,23 +63,25 @@ def _setup_finalize_collection(
     (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
 
     # SFX wav
-    if with_sfx:
+    if with_sfx_dir:
         sfx_dir = repo / "branding" / "intro_sfx"
         sfx_dir.mkdir(parents=True)
-        for name in ["cup_v3.wav", "paper.wav", "vinyl_v4.wav"]:
-            (sfx_dir / name).write_bytes(b"\x00")
+        if with_sfx:
+            for name in ["cup_v3.wav", "paper.wav", "vinyl_v4.wav"]:
+                (sfx_dir / name).write_bytes(b"\x00")
 
     # rain layers
-    rain_dir = repo / "branding" / "rain_layers"
-    rain_dir.mkdir(parents=True)
-    for i in range(n_rain):
-        (rain_dir / f"rain_{i:02d}.wav").write_bytes(b"\x00")
+    if with_rain_dir:
+        rain_dir = repo / "branding" / "rain_layers"
+        rain_dir.mkdir(parents=True)
+        for i in range(n_rain):
+            (rain_dir / f"rain_{i:02d}.wav").write_bytes(b"\x00")
 
-    # collection + master_raw
+    # collection + master
     collection = repo / "collections" / "planning" / "20260101-test"
     (collection / "01-master").mkdir(parents=True)
     if with_master:
-        (collection / "01-master" / "master_raw.mp3").write_bytes(b"\x00")
+        (collection / "01-master" / "master.mp3").write_bytes(master_content)
     return repo, collection
 
 
@@ -87,93 +104,59 @@ def _make_pass1_stderr() -> str:
     )
 
 
+def make_fake_run(
+    *,
+    pass1_stderr: str,
+    pass2_rc: int,
+    pass2_payload: bytes | None,
+    temp_path: Path,
+):
+    """subprocess.run の fake を組み立てる。
+
+    pass1 (1 回目): rc=0、`pass1_stderr` を stderr に返す。
+    pass2 (2 回目): `pass2_payload` が None でなければ `temp_path` に書き込み、
+        `pass2_rc` を返す。
+    """
+    state = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
+        if pass2_payload is not None:
+            temp_path.write_bytes(pass2_payload)
+        return SimpleNamespace(returncode=pass2_rc, stderr="", stdout="")
+
+    fake_run.state = state  # type: ignore[attr-defined]
+    return fake_run
+
+
 # ---------- F-1: pass1 + pass2 が両方走る ----------
 
 
 def test_finalize_runs_pass1_and_pass2_when_inputs_complete(
     finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given 全 input (master_raw.mp3 + sfx + rain) が揃った状態
+    """Given 全 input (master.mp3 + sfx + rain) が揃った状態
     When finalize() を実行
     Then ffmpeg subprocess.run が 2 回 (pass1 + pass2) 呼ばれる。
     """
     repo, collection = _setup_finalize_collection(tmp_path, n_rain=3)
     monkeypatch.setenv("CHANNEL_DIR", str(repo))
 
-    pass1_stderr = _make_pass1_stderr()
-    call_count: dict[str, int] = {"n": 0}
+    temp = collection / "01-master" / "master.tmp.mp3"
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=0,
+        pass2_payload=b"\x00",
+        temp_path=temp,
+    )
 
-    def fake_run(cmd, **kwargs):
-        call_count["n"] += 1
-        # 1 回目は loudnorm pass1 -> stderr に JSON
-        # 2 回目は実 mix -> 出力ファイルを書く
-        if call_count["n"] == 1:
-            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
-        return SimpleNamespace(returncode=0, stderr="", stdout="")
-
-    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
-        rc = finalize_module.finalize(collection, keep_raw=True)
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        rc = finalize_module.finalize(collection)
 
     assert rc == 0, f"finalize が失敗: {rc}"
-    assert call_count["n"] == 2, f"ffmpeg が 2 回 呼ばれていない: {call_count['n']}"
-
-
-# ---------- F-2: master_raw のクリーンアップ / --keep-raw 保持 ----------
-
-
-def test_finalize_removes_master_raw_by_default(
-    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Given finalize 成功
-    When keep_raw=False (default)
-    Then master_raw.mp3 は削除される。
-    """
-    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
-    monkeypatch.setenv("CHANNEL_DIR", str(repo))
-    raw_path = collection / "01-master" / "master_raw.mp3"
-    assert raw_path.exists()
-
-    pass1_stderr = _make_pass1_stderr()
-    state = {"n": 0}
-
-    def fake_run(cmd, **kwargs):
-        state["n"] += 1
-        if state["n"] == 1:
-            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
-        return SimpleNamespace(returncode=0, stderr="", stdout="")
-
-    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
-        rc = finalize_module.finalize(collection, keep_raw=False)
-
-    assert rc == 0
-    assert not raw_path.exists(), "keep_raw=False で master_raw.mp3 が消えていない"
-
-
-def test_finalize_keeps_master_raw_with_keep_raw_flag(
-    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Given finalize 成功 + keep_raw=True
-    When 完了後
-    Then master_raw.mp3 は残る。
-    """
-    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
-    monkeypatch.setenv("CHANNEL_DIR", str(repo))
-    raw_path = collection / "01-master" / "master_raw.mp3"
-
-    pass1_stderr = _make_pass1_stderr()
-    state = {"n": 0}
-
-    def fake_run(cmd, **kwargs):
-        state["n"] += 1
-        if state["n"] == 1:
-            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
-        return SimpleNamespace(returncode=0, stderr="", stdout="")
-
-    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
-        rc = finalize_module.finalize(collection, keep_raw=True)
-
-    assert rc == 0
-    assert raw_path.exists(), "keep_raw=True なのに master_raw.mp3 が消えた"
+    assert fake.state["n"] == 2, f"ffmpeg が 2 回 呼ばれていない: {fake.state['n']}"
 
 
 # ---------- F-3: rain layer 1 件で -i count が 5 ----------
@@ -189,22 +172,26 @@ def test_finalize_accepts_exactly_one_rain_layer(
     repo, collection = _setup_finalize_collection(tmp_path, n_rain=1)
     monkeypatch.setenv("CHANNEL_DIR", str(repo))
 
-    pass1_stderr = _make_pass1_stderr()
-    state: dict[str, list] = {"cmds": []}
+    temp = collection / "01-master" / "master.tmp.mp3"
+    cmds: list[list[str]] = []
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=0,
+        pass2_payload=b"\x00",
+        temp_path=temp,
+    )
 
-    def fake_run(cmd, **kwargs):
-        state["cmds"].append(list(cmd))
-        if len(state["cmds"]) == 1:
-            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
-        return SimpleNamespace(returncode=0, stderr="", stdout="")
+    def fake_run_with_capture(cmd, **kwargs):
+        cmds.append(list(cmd))
+        return fake(cmd, **kwargs)
 
-    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
-        rc = finalize_module.finalize(collection, keep_raw=True)
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run_with_capture):
+        rc = finalize_module.finalize(collection)
 
     assert rc == 0
     # pass2 cmd を見る (どちらでも -i count は同じはず)
-    assert state["cmds"], "ffmpeg が呼ばれていない"
-    inputs = _input_files_in_cmd(state["cmds"][-1])
+    assert cmds, "ffmpeg が呼ばれていない"
+    inputs = _input_files_in_cmd(cmds[-1])
     # master + cup + paper + vinyl + 1 rain = 5
     assert len(inputs) == 5, f"-i 数が 5 でない: {len(inputs)}\n  inputs={inputs}"
 
@@ -229,13 +216,13 @@ def test_parse_loudnorm_json_extracts_last_json_block(finalize_module) -> None:
     assert result.get("input_i") == "-21.5"
 
 
-# ---------- F-5: master_raw 不在で exit 1 ----------
+# ---------- F-5: master.mp3 不在で exit 1 ----------
 
 
-def test_finalize_exits_1_when_master_raw_missing(
+def test_finalize_exits_1_when_master_missing(
     finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given master_raw.mp3 が存在しない
+    """Given master.mp3 が存在しない
     When finalize() を呼ぶ
     Then ffmpeg を呼ばずに rc=1。
     """
@@ -243,34 +230,34 @@ def test_finalize_exits_1_when_master_raw_missing(
     monkeypatch.setenv("CHANNEL_DIR", str(repo))
 
     with patch.object(finalize_module.subprocess, "run") as mock_run:
-        rc = finalize_module.finalize(collection, keep_raw=True)
+        rc = finalize_module.finalize(collection)
 
     assert rc == 1
     mock_run.assert_not_called()
 
 
-# ---------- F-6: SFX wav 不在で exit 1 ----------
+# ---------- F-6: SFX wav 不在で exit 1 (dir はあるが中身欠落 = ハーフ実装) ----------
 
 
 def test_finalize_exits_1_when_sfx_wav_missing(
     finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given branding/intro_sfx/cup_v3.wav が存在しない
+    """Given branding/intro_sfx/ ディレクトリは存在するが cup_v3.wav が欠ける
     When finalize() を呼ぶ
-    Then ffmpeg を呼ばずに rc=1。
+    Then ffmpeg を呼ばずに rc=1 (fail-fast、ハーフ実装防止)。
     """
     repo, collection = _setup_finalize_collection(tmp_path, n_rain=3, with_sfx=True)
     monkeypatch.setenv("CHANNEL_DIR", str(repo))
     (repo / "branding" / "intro_sfx" / "cup_v3.wav").unlink()
 
     with patch.object(finalize_module.subprocess, "run") as mock_run:
-        rc = finalize_module.finalize(collection, keep_raw=True)
+        rc = finalize_module.finalize(collection)
 
     assert rc == 1
     mock_run.assert_not_called()
 
 
-# ---------- F-7: rain_*.wav 0 件で exit 1 ----------
+# ---------- F-7: rain_*.wav 0 件で exit 1 (dir はあるが中身欠落 = ハーフ実装) ----------
 
 
 def test_finalize_exits_1_when_rain_layers_empty(
@@ -278,13 +265,13 @@ def test_finalize_exits_1_when_rain_layers_empty(
 ) -> None:
     """Given branding/rain_layers/ ディレクトリは存在するが rain_*.wav が 0 件
     When finalize() を呼ぶ
-    Then ffmpeg を呼ばずに rc=1。
+    Then ffmpeg を呼ばずに rc=1 (fail-fast、ハーフ実装防止)。
     """
     repo, collection = _setup_finalize_collection(tmp_path, n_rain=0)
     monkeypatch.setenv("CHANNEL_DIR", str(repo))
 
     with patch.object(finalize_module.subprocess, "run") as mock_run:
-        rc = finalize_module.finalize(collection, keep_raw=True)
+        rc = finalize_module.finalize(collection)
 
     assert rc == 1
     mock_run.assert_not_called()
@@ -310,7 +297,7 @@ def test_finalize_propagates_pass1_nonzero_exit_and_skips_pass2(
         return SimpleNamespace(returncode=5, stderr="ffmpeg failed", stdout="")
 
     with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
-        rc = finalize_module.finalize(collection, keep_raw=True)
+        rc = finalize_module.finalize(collection)
 
     assert rc != 0, f"pass1 失敗時に rc=0 で返した: {rc}"
     assert state["n"] == 1, f"pass2 が呼ばれてしまった (call count={state['n']})"
@@ -328,3 +315,331 @@ def test_parse_loudnorm_json_raises_runtime_error_when_no_json_block(
     """
     with pytest.raises(RuntimeError):
         finalize_module.parse_loudnorm_json("plain text without any json")
+
+
+# ====================================================================
+# A2: atomic rename (#1, #2, #7, #8, #15)
+# ====================================================================
+
+
+# ---------- A2-1 (#1): in-place replace via atomic rename ----------
+
+
+def test_finalize_replaces_master_in_place_with_pass2_output(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given 既知 bytes b"ORIG" を master.mp3 に書き、intro 素材が完全に揃った repo
+    When pass2 fake が temp_out (master.tmp.mp3) に b"FINAL" を書いて rc=0 を返す
+    Then rc=0、master.mp3 の中身が b"FINAL" に置換される (atomic rename)。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path, n_rain=2, master_content=b"ORIG"
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    temp = collection / "01-master" / "master.tmp.mp3"
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=0,
+        pass2_payload=b"FINAL",
+        temp_path=temp,
+    )
+    # When
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0
+    assert master.read_bytes() == b"FINAL", (
+        "master.mp3 が pass2 出力 (b'FINAL') に置き換わっていない"
+    )
+
+
+# ---------- A2-2 (#2): temp ファイルが残らない (success path) ----------
+
+
+def test_finalize_does_not_leave_temp_file_on_success(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given pass2 が成功して master.tmp.mp3 に書く
+    When finalize() を実行
+    Then 完了後 master.tmp.mp3 は残らない (atomic rename で master.mp3 に昇格)。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path, n_rain=2, master_content=b"ORIG"
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    temp = collection / "01-master" / "master.tmp.mp3"
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=0,
+        pass2_payload=b"FINAL",
+        temp_path=temp,
+    )
+    # When
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0
+    assert not temp.exists(), f"成功後に temp ファイルが残っている: {temp}"
+
+
+# ---------- A2-3 (#7): pass2 失敗時に元 master.mp3 が無傷 ----------
+
+
+def test_finalize_does_not_clobber_master_when_pass2_fails(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given pass2 fake が temp に b"GARBAGE" を書いて rc=7 で失敗
+    When finalize() を呼ぶ
+    Then rc=7 が伝播し、元 master.mp3 (b"ORIG") は無傷のまま残る。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path, n_rain=2, master_content=b"ORIG"
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    temp = collection / "01-master" / "master.tmp.mp3"
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=7,
+        pass2_payload=b"GARBAGE",
+        temp_path=temp,
+    )
+    # When
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 7, f"pass2 の rc=7 が伝播していない: {rc}"
+    assert master.read_bytes() == b"ORIG", (
+        "pass2 失敗時に元 master.mp3 が壊れた (atomic rename の本質を破壊)"
+    )
+
+
+# ---------- A2-3 (#8): pass2 失敗時に temp ファイルが後始末される ----------
+
+
+def test_finalize_cleans_up_temp_file_when_pass2_fails(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given pass2 fake が temp に書いて rc=7 で失敗
+    When finalize() を呼ぶ
+    Then 抜けた後に temp (master.tmp.mp3) は best-effort 削除される。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path, n_rain=2, master_content=b"ORIG"
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    temp = collection / "01-master" / "master.tmp.mp3"
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=7,
+        pass2_payload=b"GARBAGE",
+        temp_path=temp,
+    )
+    # When
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        finalize_module.finalize(collection)
+    # Then
+    assert not temp.exists(), (
+        f"pass2 失敗後に temp ファイルが残っている: {temp}"
+    )
+
+
+# ---------- A2 edge (#15): stale temp を再実行で必ず上書きする ----------
+
+
+def test_finalize_overwrites_stale_temp_with_fresh_pass2_output(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given 前回失敗で残置された master.tmp.mp3 (b"STALE") が事前に存在
+    When pass2 が temp に b"FRESH" を書き直して rc=0 を返す
+    Then master.mp3 の中身は b"FRESH" になる (stale 内容を昇格させない順序保証)。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path, n_rain=2, master_content=b"ORIG"
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    temp = collection / "01-master" / "master.tmp.mp3"
+    temp.write_bytes(b"STALE")  # 前回失敗の残置を再現
+    fake = make_fake_run(
+        pass1_stderr=_make_pass1_stderr(),
+        pass2_rc=0,
+        pass2_payload=b"FRESH",
+        temp_path=temp,
+    )
+    # When
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake):
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0
+    assert master.read_bytes() == b"FRESH", (
+        "stale temp 内容が master に昇格してしまった (pass2 が temp を上書きしていない)"
+    )
+
+
+# ====================================================================
+# B: intro モード自動切替 (#3, #4, #5, #6)
+# ====================================================================
+
+
+# ---------- B-1 (#3): intro_sfx/ 非存在で pass-through ----------
+
+
+def test_finalize_pass_through_when_intro_sfx_dir_missing(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given branding/intro_sfx/ ディレクトリが存在しない (rain_layers/ のみ作成)
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=0、master.mp3 の中身は不変。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path,
+        n_rain=2,
+        with_sfx_dir=False,
+        master_content=b"ORIG",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    # When
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0, f"pass-through で rc=0 を返さない: {rc}"
+    mock_run.assert_not_called()
+    assert master.read_bytes() == b"ORIG", (
+        "pass-through 経路で master.mp3 が変更された (何もしないのが正解)"
+    )
+
+
+# ---------- B-2 (#4): rain_layers/ 非存在で pass-through ----------
+
+
+def test_finalize_pass_through_when_rain_layers_dir_missing(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given branding/rain_layers/ ディレクトリが存在しない (intro_sfx/ のみ作成)
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=0、master.mp3 の中身は不変。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path,
+        with_rain_dir=False,
+        master_content=b"ORIG",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    # When
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0, f"pass-through で rc=0 を返さない: {rc}"
+    mock_run.assert_not_called()
+    assert master.read_bytes() == b"ORIG", (
+        "pass-through 経路で master.mp3 が変更された (何もしないのが正解)"
+    )
+
+
+# ---------- B-1+B-2 OR 短絡 (#5): 両 dir 非存在でも pass-through ----------
+
+
+def test_finalize_pass_through_when_both_intro_dirs_missing(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given branding/intro_sfx/ も branding/rain_layers/ も存在しない
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=0、master.mp3 の中身は不変 (OR 短絡境界)。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path,
+        with_sfx_dir=False,
+        with_rain_dir=False,
+        master_content=b"ORIG",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    master = collection / "01-master" / "master.mp3"
+    # When
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection)
+    # Then
+    assert rc == 0
+    mock_run.assert_not_called()
+    assert master.read_bytes() == b"ORIG"
+
+
+# ---------- #6: pass-through ログを stderr に出す ----------
+
+
+def test_finalize_emits_pass_through_log_to_stderr(
+    finalize_module,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Given intro 素材ディレクトリが存在しない (pass-through 条件)
+    When finalize() を呼ぶ
+    Then stderr に INFO:/WARN:/WARNING: いずれかの prefix と
+        intro/pass を示すワードが出る (寛容検証)。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(
+        tmp_path,
+        with_sfx_dir=False,
+        master_content=b"ORIG",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    # When
+    with patch.object(finalize_module.subprocess, "run"):
+        finalize_module.finalize(collection)
+    # Then
+    err = capsys.readouterr().err
+    assert any(prefix in err for prefix in ("INFO:", "WARN:", "WARNING:")), (
+        f"pass-through ログ prefix (INFO:/WARN:/WARNING:) が stderr に無い:\n{err!r}"
+    )
+    # pass-through を示すワードのいずれかが含まれていれば OK (実装の表記揺れ吸収)
+    assert "intro" in err.lower() or "pass" in err.lower(), (
+        f"pass-through を示すワードが stderr に無い:\n{err!r}"
+    )
+
+
+# ====================================================================
+# CLI surface: --keep-raw 削除リグレッション (#10)
+# ====================================================================
+
+
+def test_main_rejects_removed_keep_raw_flag(
+    finalize_module,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Given finalize_master.py main() に --keep-raw フラグは存在しない
+    When sys.argv に --keep-raw を渡して main() を呼ぶ
+    Then argparse が SystemExit(rc=2) で拒否し、エラー出力に `--keep-raw` が含まれる。
+    """
+    # Given
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["finalize_master.py", str(collection), "--keep-raw"],
+    )
+    # When / Then
+    with pytest.raises(SystemExit) as exc_info:
+        finalize_module.main()
+    assert exc_info.value.code == 2, (
+        f"argparse の --keep-raw 拒否で rc=2 が出ていない: {exc_info.value.code}"
+    )
+    err = capsys.readouterr().err
+    assert "--keep-raw" in err, (
+        f"argparse のエラー出力に `--keep-raw` が含まれていない (任意の unknown オプションで通る検証になっている):\n{err!r}"
+    )

--- a/tests/test_finalize_master_main.py
+++ b/tests/test_finalize_master_main.py
@@ -1,0 +1,330 @@
+"""Issue #137: `.claude/skills/masterup/references/finalize_master.py` CLI / 副作用層 (F 節)。
+
+`finalize` (CLI) と `parse_loudnorm_json` の振る舞いを subprocess.run mock
+で検証する。ffmpeg バイナリは呼ばない。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests._skill_loader import load_skill_script
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+@pytest.fixture
+def finalize_module():
+    return load_skill_script("masterup", "finalize_master")
+
+
+def _setup_finalize_collection(
+    tmp_path: Path,
+    *,
+    n_rain: int = 3,
+    with_master: bool = True,
+    with_sfx: bool = True,
+) -> tuple[Path, Path]:
+    """tmp_path に repo + collection ツリーを組む。
+
+    Returns:
+        (repo_root, collection_dir)
+    """
+    repo = tmp_path / "repo"
+    (repo / "config" / "channel").mkdir(parents=True)
+    (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+
+    # SFX wav
+    if with_sfx:
+        sfx_dir = repo / "branding" / "intro_sfx"
+        sfx_dir.mkdir(parents=True)
+        for name in ["cup_v3.wav", "paper.wav", "vinyl_v4.wav"]:
+            (sfx_dir / name).write_bytes(b"\x00")
+
+    # rain layers
+    rain_dir = repo / "branding" / "rain_layers"
+    rain_dir.mkdir(parents=True)
+    for i in range(n_rain):
+        (rain_dir / f"rain_{i:02d}.wav").write_bytes(b"\x00")
+
+    # collection + master_raw
+    collection = repo / "collections" / "planning" / "20260101-test"
+    (collection / "01-master").mkdir(parents=True)
+    if with_master:
+        (collection / "01-master" / "master_raw.mp3").write_bytes(b"\x00")
+    return repo, collection
+
+
+def _input_files_in_cmd(cmd: list[str]) -> list[str]:
+    inputs: list[str] = []
+    for i, token in enumerate(cmd):
+        if token == "-i":
+            inputs.append(cmd[i + 1])
+    return inputs
+
+
+def _make_pass1_stderr() -> str:
+    """ffmpeg loudnorm pass1 stderr (loudnorm JSON 部) のサンプル。"""
+    return (
+        "Some unrelated log lines\n"
+        '{"input_i": "-21.5", "input_tp": "-3.2", "input_lra": "9.4", '
+        '"input_thresh": "-31.7", "output_i": "-14.0", "output_tp": "-1.5", '
+        '"output_lra": "11.0", "output_thresh": "-24.5", "normalization_type": '
+        '"dynamic", "target_offset": "0.10"}\n'
+    )
+
+
+# ---------- F-1: pass1 + pass2 が両方走る ----------
+
+
+def test_finalize_runs_pass1_and_pass2_when_inputs_complete(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given 全 input (master_raw.mp3 + sfx + rain) が揃った状態
+    When finalize() を実行
+    Then ffmpeg subprocess.run が 2 回 (pass1 + pass2) 呼ばれる。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=3)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+
+    pass1_stderr = _make_pass1_stderr()
+    call_count: dict[str, int] = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_count["n"] += 1
+        # 1 回目は loudnorm pass1 -> stderr に JSON
+        # 2 回目は実 mix -> 出力ファイルを書く
+        if call_count["n"] == 1:
+            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 0, f"finalize が失敗: {rc}"
+    assert call_count["n"] == 2, f"ffmpeg が 2 回 呼ばれていない: {call_count['n']}"
+
+
+# ---------- F-2: master_raw のクリーンアップ / --keep-raw 保持 ----------
+
+
+def test_finalize_removes_master_raw_by_default(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given finalize 成功
+    When keep_raw=False (default)
+    Then master_raw.mp3 は削除される。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    raw_path = collection / "01-master" / "master_raw.mp3"
+    assert raw_path.exists()
+
+    pass1_stderr = _make_pass1_stderr()
+    state = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
+        rc = finalize_module.finalize(collection, keep_raw=False)
+
+    assert rc == 0
+    assert not raw_path.exists(), "keep_raw=False で master_raw.mp3 が消えていない"
+
+
+def test_finalize_keeps_master_raw_with_keep_raw_flag(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given finalize 成功 + keep_raw=True
+    When 完了後
+    Then master_raw.mp3 は残る。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    raw_path = collection / "01-master" / "master_raw.mp3"
+
+    pass1_stderr = _make_pass1_stderr()
+    state = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 0
+    assert raw_path.exists(), "keep_raw=True なのに master_raw.mp3 が消えた"
+
+
+# ---------- F-3: rain layer 1 件で -i count が 5 ----------
+
+
+def test_finalize_accepts_exactly_one_rain_layer(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given rain layer が 1 件 + sfx 3 + master = 合計 5 input
+    When finalize() を実行
+    Then ffmpeg cmd の `-i` は 5 回出現する。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=1)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+
+    pass1_stderr = _make_pass1_stderr()
+    state: dict[str, list] = {"cmds": []}
+
+    def fake_run(cmd, **kwargs):
+        state["cmds"].append(list(cmd))
+        if len(state["cmds"]) == 1:
+            return SimpleNamespace(returncode=0, stderr=pass1_stderr, stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 0
+    # pass2 cmd を見る (どちらでも -i count は同じはず)
+    assert state["cmds"], "ffmpeg が呼ばれていない"
+    inputs = _input_files_in_cmd(state["cmds"][-1])
+    # master + cup + paper + vinyl + 1 rain = 5
+    assert len(inputs) == 5, f"-i 数が 5 でない: {len(inputs)}\n  inputs={inputs}"
+
+
+# ---------- F-4: parse_loudnorm_json の堅牢性 ----------
+
+
+def test_parse_loudnorm_json_extracts_last_json_block(finalize_module) -> None:
+    """Given stderr に JSON ブロックが複数含まれる
+    When parse_loudnorm_json(stderr) を呼ぶ
+    Then 最後の JSON ブロックが返る (loudnorm 自体の出力は最後のもの)。
+    """
+    stderr = (
+        '{"unrelated": "first"}\n'
+        'log line\n'
+        '{"input_i": "-21.5", "input_tp": "-3.2", "input_lra": "9.4", '
+        '"input_thresh": "-31.7", "target_offset": "0.10"}\n'
+    )
+    result = finalize_module.parse_loudnorm_json(stderr)
+    assert isinstance(result, dict)
+    # loudnorm 由来の最後の JSON が選ばれていること
+    assert result.get("input_i") == "-21.5"
+
+
+# ---------- F-5: master_raw 不在で exit 1 ----------
+
+
+def test_finalize_exits_1_when_master_raw_missing(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given master_raw.mp3 が存在しない
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=1。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=3, with_master=False)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 1
+    mock_run.assert_not_called()
+
+
+# ---------- F-6: SFX wav 不在で exit 1 ----------
+
+
+def test_finalize_exits_1_when_sfx_wav_missing(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given branding/intro_sfx/cup_v3.wav が存在しない
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=1。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=3, with_sfx=True)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+    (repo / "branding" / "intro_sfx" / "cup_v3.wav").unlink()
+
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 1
+    mock_run.assert_not_called()
+
+
+# ---------- F-7: rain_*.wav 0 件で exit 1 ----------
+
+
+def test_finalize_exits_1_when_rain_layers_empty(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given branding/rain_layers/ ディレクトリは存在するが rain_*.wav が 0 件
+    When finalize() を呼ぶ
+    Then ffmpeg を呼ばずに rc=1。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=0)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+
+    with patch.object(finalize_module.subprocess, "run") as mock_run:
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc == 1
+    mock_run.assert_not_called()
+
+
+# ---------- F-8: pass1 失敗時 exit code 伝播 (pass2 未実行) ----------
+
+
+def test_finalize_propagates_pass1_nonzero_exit_and_skips_pass2(
+    finalize_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given pass1 ffmpeg が exit code 5 で失敗
+    When finalize() を呼ぶ
+    Then pass2 は呼ばれず、rc != 0 で抜ける。
+    """
+    repo, collection = _setup_finalize_collection(tmp_path, n_rain=2)
+    monkeypatch.setenv("CHANNEL_DIR", str(repo))
+
+    state = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        state["n"] += 1
+        return SimpleNamespace(returncode=5, stderr="ffmpeg failed", stdout="")
+
+    with patch.object(finalize_module.subprocess, "run", side_effect=fake_run):
+        rc = finalize_module.finalize(collection, keep_raw=True)
+
+    assert rc != 0, f"pass1 失敗時に rc=0 で返した: {rc}"
+    assert state["n"] == 1, f"pass2 が呼ばれてしまった (call count={state['n']})"
+
+
+# ---------- F-9: parse_loudnorm_json — JSON 不在で RuntimeError ----------
+
+
+def test_parse_loudnorm_json_raises_runtime_error_when_no_json_block(
+    finalize_module,
+) -> None:
+    """Given stderr に loudnorm JSON ブロックが含まれない
+    When parse_loudnorm_json(stderr) を呼ぶ
+    Then RuntimeError (パース失敗を握りつぶさない)。
+    """
+    with pytest.raises(RuntimeError):
+        finalize_module.parse_loudnorm_json("plain text without any json")

--- a/tests/test_intro_config.py
+++ b/tests/test_intro_config.py
@@ -1,0 +1,146 @@
+"""Issue #137: `.claude/skills/intro/config.default.yaml` のロード可能性 (A 節)。
+
+upstream に新規追加される intro skill の config.default.yaml を
+`load_skill_config("intro")` 経由でロードできること、設計 D の本質的な構造
+(5 segments / 30s) と RJN サンプルとして load されるデフォルト値、
+channel 上書きが deep-merge される運用を担保する。
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+
+# 設計 D の本質的タイムライン (30s, 5 区間)
+_EXPECTED_SEGMENT_BOUNDARIES = [0, 5, 10, 15, 25, 30]
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+# ---------- A-1: ロード可能性 + 主要キーの存在 ----------
+
+
+def test_load_skill_config_intro_returns_dict_with_expected_keys() -> None:
+    """Given upstream 同梱の intro/config.default.yaml
+    When load_skill_config("intro") を呼ぶ
+    Then segments / text / color / font / logo / droplet が dict として取れる。
+    """
+    cfg = skill_config.load_skill_config("intro", use_cache=False)
+
+    expected_keys = {"segments", "text", "color", "font", "logo", "droplet"}
+    missing = expected_keys - set(cfg.keys())
+    assert not missing, f"intro/config.default.yaml に欠落しているキー: {missing}"
+
+
+# ---------- A-2: 5 segments / v7.1 timeline ----------
+
+
+def test_load_skill_config_intro_exposes_5_segments_with_v7_timeline() -> None:
+    """Given intro config の `segments`
+    When 値を確認
+    Then 設計 D の 5 区間 (0/5/10/15/25/30s 境界) を持つ list である。
+    """
+    cfg = skill_config.load_skill_config("intro", use_cache=False)
+    segments = cfg["segments"]
+    assert isinstance(segments, list), f"segments が list でない: {type(segments)}"
+    assert len(segments) == 5, f"segments 数が 5 でない: {len(segments)}"
+
+    # 各 segment の start / end を抽出して timeline 境界を確認
+    boundaries: list[int] = []
+    for i, seg in enumerate(segments):
+        assert isinstance(seg, dict), f"segments[{i}] が dict でない: {type(seg)}"
+        assert "start" in seg, f"segments[{i}] に `start` キーが無い"
+        assert "end" in seg, f"segments[{i}] に `end` キーが無い"
+        boundaries.append(int(seg["start"]))
+    boundaries.append(int(segments[-1]["end"]))
+    assert boundaries == _EXPECTED_SEGMENT_BOUNDARIES, (
+        f"timeline 境界が v7.1 と不一致: {boundaries} (expected {_EXPECTED_SEGMENT_BOUNDARIES})"
+    )
+
+
+# ---------- A-3: drawtext 色 #3A4A55 ----------
+
+
+def test_load_skill_config_intro_exposes_drawtext_color_3a4a55() -> None:
+    """Given intro config の `color`
+    When drawtext 用カラーを確認
+    Then dark teal `#3A4A55` (sammune-aligned) が default として記述されている。
+    """
+    cfg = skill_config.load_skill_config("intro", use_cache=False)
+    color = cfg["color"]
+    assert isinstance(color, dict), f"color が dict でない: {type(color)}"
+    # 想定: drawtext or text or main などのキー名で hex 文字列を保持
+    serialized = yaml.safe_dump(color)
+    assert "3A4A55" in serialized.upper(), (
+        f"`#3A4A55` (dark teal) が color block に無い:\n{serialized}"
+    )
+
+
+# ---------- A-4: channel override (font.en) ----------
+
+
+def test_channel_override_replaces_font_en_via_deep_merge(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given channel override `config/skills/intro.yaml` で `font.en` のみ指定
+    When load_skill_config("intro") を呼ぶ
+    Then default の他キーは残り、`font.en` のみ Linux パスへ書き換わる。
+    """
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    override_path = channel_dir / "config" / "skills" / "intro.yaml"
+    linux_font = "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"
+    override_path.write_text(
+        yaml.safe_dump({"font": {"en": linux_font}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("intro", use_cache=False)
+    font = cfg["font"]
+    assert isinstance(font, dict), f"font が dict でない: {type(font)}"
+    assert font.get("en") == linux_font, (
+        f"font.en が override されていない: {font.get('en')!r}"
+    )
+    # default の他キー (font.ja 等) は残っているはず
+    assert "ja" in font, f"font.ja が override で失われた: {font}"
+
+
+# ---------- A-5: channel override (logo.heading_left の単一 text 行) ----------
+
+
+def test_channel_override_replaces_single_text_line_via_deep_merge(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given channel override で `logo.heading_left` のみ指定
+    When load_skill_config("intro") を呼ぶ
+    Then RJN 固有 default ("Rain") を Sleep 等の別 channel ブランドへ
+        差し替えできる (運用上の上書き経路担保)。
+    """
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    override_path = channel_dir / "config" / "skills" / "intro.yaml"
+    override_path.write_text(
+        yaml.safe_dump({"logo": {"heading_left": "Sleep"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("intro", use_cache=False)
+    logo = cfg["logo"]
+    assert logo.get("heading_left") == "Sleep", (
+        f"logo.heading_left が override されていない: {logo.get('heading_left')!r}"
+    )
+    # 同階層の他キー (heading_right / tagline 等) が override で消えていない
+    other_keys = set(logo.keys()) - {"heading_left"}
+    assert other_keys, f"logo の他キーが deep-merge で失われた: {logo}"

--- a/tests/test_intro_droplet.py
+++ b/tests/test_intro_droplet.py
@@ -1,0 +1,137 @@
+"""Issue #137: `.claude/skills/intro/references/generate_droplet_png.py` (C 節)。
+
+雫 PNG ビルダーの純粋関数 `render_droplet` の振る舞いを Pillow 実呼びで検証。
+config から渡された `color.droplet` が PNG ピクセルに反映される伝搬チェーンと、
+親ディレクトリ自動作成、不正入力の検証も併せて担保する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tests._skill_loader import load_skill_script
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+from youtube_automation.utils.exceptions import ValidationError
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+@pytest.fixture
+def droplet_module():
+    return load_skill_script("intro", "generate_droplet_png")
+
+
+# ---------- C-1: 96x96 RGBA PNG が指定 color で出力される ----------
+
+
+def test_render_droplet_writes_96x96_rgba_png_with_given_color(
+    droplet_module, tmp_path: Path
+) -> None:
+    """Given 出力先 path と RGBA color tuple (#3A4A55)
+    When render_droplet(out_path, color=(58, 74, 85, 255)) を呼ぶ
+    Then 96x96 の RGBA PNG が出力され、塗り pixel が指定 color に一致する。
+    """
+    out_path = tmp_path / "droplet.png"
+    color = (58, 74, 85, 255)  # #3A4A55
+
+    droplet_module.render_droplet(out_path, color=color)
+
+    assert out_path.exists()
+    img = Image.open(out_path)
+    assert img.mode == "RGBA"
+    assert img.size == (96, 96)
+
+    # 中央付近 (teardrop の bottom round 部分) が指定色である
+    # 96x96 中央 (48, 60) — teardrop の下部 (丸い部分) を確実に外さない座標
+    pixels = img.load()
+    cx, cy = 48, 60
+    sample = pixels[cx, cy]
+    assert sample[:3] == color[:3], (
+        f"中央付近 ({cx},{cy}) の RGB が指定色と異なる: {sample[:3]} != {color[:3]}"
+    )
+    assert sample[3] > 0, f"中央付近 ({cx},{cy}) のアルファが 0 (透明): {sample}"
+
+
+# ---------- C-2: config 由来の色が main() 経由で反映される ----------
+
+
+def test_main_derives_color_from_skill_config(
+    droplet_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given channel config で `color.droplet` を上書き
+    When main() を実行
+    Then 出力 PNG に override した色が反映される。
+    """
+    # channel override の color.droplet に派手な赤を仕込み、main() がそれを採用するか確認
+    import yaml
+
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    override = channel_dir / "config" / "skills" / "intro.yaml"
+    override.write_text(
+        yaml.safe_dump({"color": {"droplet": "#FF0000"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    out_dir = tmp_path / "out"
+    out_path = out_dir / "05_droplet.png"
+    monkeypatch.setattr(droplet_module, "_resolve_output_path", lambda: out_path, raising=False)
+    # `main()` が `--output` フラグでパス指定できる前提で argv を設定
+    monkeypatch.setattr("sys.argv", ["generate_droplet_png", "--output", str(out_path)])
+
+    rc = droplet_module.main()
+
+    assert rc == 0
+    assert out_path.exists()
+    img = Image.open(out_path)
+    pixels = img.load()
+    sample = pixels[48, 60]
+    assert sample[:3] == (255, 0, 0), (
+        f"channel override した色が反映されていない: {sample[:3]} (expected (255,0,0))"
+    )
+
+
+# ---------- C-3: 親ディレクトリの自動作成 ----------
+
+
+def test_render_droplet_creates_parent_dirs_when_missing(
+    droplet_module, tmp_path: Path
+) -> None:
+    """Given 親ディレクトリが存在しない出力 path
+    When render_droplet を呼ぶ
+    Then mkdir(parents=True) で親が作られ、PNG が出力される。
+    """
+    nested = tmp_path / "deeply" / "nested" / "branding" / "intro_assets"
+    out_path = nested / "05_droplet.png"
+    assert not nested.exists()
+
+    droplet_module.render_droplet(out_path, color=(58, 74, 85, 255))
+
+    assert out_path.exists()
+
+
+# ---------- C-4: 不正な color tuple は ValidationError ----------
+
+
+def test_render_droplet_rejects_invalid_color_tuple_length(
+    droplet_module, tmp_path: Path
+) -> None:
+    """Given color tuple が長さ 3 (RGBA でなく RGB)
+    When render_droplet を呼ぶ
+    Then ValidationError が出る (RGBA 必須の入力検証)。
+    """
+    out_path = tmp_path / "droplet.png"
+    with pytest.raises(ValidationError):
+        droplet_module.render_droplet(out_path, color=(58, 74, 85))  # type: ignore[arg-type]

--- a/tests/test_intro_generate.py
+++ b/tests/test_intro_generate.py
@@ -1,0 +1,449 @@
+"""Issue #137: `.claude/skills/intro/references/generate_intro.py` (B 節)。
+
+設計 D の filter graph 組み立て (`build_filter_complex`) と CLI (`main`) の
+振る舞いを検証する。subprocess.run は mock し、ffmpeg は呼ばない。
+
+config 駆動化のチェーン:
+  load_skill_config("intro") -> SEGMENTS / FONT_EN / FONT_JA / drawtext color
+  -> build_filter_complex(segments, text, font, color)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests._skill_loader import load_skill_script
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+from youtube_automation.utils.exceptions import ConfigError
+
+# 設計 D の本質的タイムライン (30s, 5 区間)
+_EXPECTED_SEGMENT_BOUNDARIES = [0, 5, 10, 15, 25, 30]
+_EXPECTED_DURATION = 30
+_EXPECTED_FPS = 24
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+@pytest.fixture
+def intro_module():
+    return load_skill_script("intro", "generate_intro")
+
+
+def _make_segments(*, all_with_text: bool = False) -> list[dict]:
+    """テスト用の標準 segments list (v7.1 通り)。"""
+    base = [
+        {"name": "01_rain_cu", "start": 0, "end": 5,
+         "text_en": "Rest in the sound of rain.", "text_ja": "雨の音に、心を預ける。"},
+        {"name": "02_lamp_steam", "start": 5, "end": 10,
+         "text_en": "Tonight, your own hideaway.", "text_ja": "今夜は、あなただけの隠れ家で。"},
+        {"name": "04_cinemagraph_a", "start": 10, "end": 15, "text_en": "", "text_ja": ""},
+        {"name": "03_room_ws", "start": 15, "end": 25, "text_en": "", "text_ja": ""},
+        {"name": "04_cinemagraph_b", "start": 25, "end": 30, "text_en": "", "text_ja": ""},
+    ]
+    if all_with_text:
+        for s in base:
+            s["text_en"] = s["text_en"] or "filler"
+            s["text_ja"] = s["text_ja"] or "fillerJA"
+    return base
+
+
+def _make_font() -> dict:
+    return {
+        "en": "/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+        "ja": "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc",
+    }
+
+
+def _make_color() -> dict:
+    return {"drawtext": "#3A4A55", "droplet": "#3A4A55"}
+
+
+def _make_logo() -> dict:
+    return {
+        "heading_left": "Rain",
+        "heading_right": "Jazz Night",
+        "tagline": "Your rainy night jazz bar escape",
+    }
+
+
+def _make_text() -> dict:
+    return {
+        "fontsize_en": 84,
+        "fontsize_ja": 42,
+        "fontsize_logo": 96,
+        "fontsize_tagline": 32,
+        "fade_seconds": 0.7,
+        "shadow_color": "black@0.35",
+        "shadow_x": 1,
+        "shadow_y": 2,
+    }
+
+
+# ---------- B-1: concat=n=5 chain ----------
+
+
+def test_build_filter_complex_concat_chain_has_5_inputs(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given 5 segments を渡す
+    When build_filter_complex(segments, ...) を呼ぶ
+    Then concat フィルタが `concat=n=5:v=1:a=0` を含む。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    assert "concat=n=5:v=1:a=0" in filter_str, (
+        f"5 input concat が見つからない:\n{filter_str}"
+    )
+
+
+# ---------- B-2: drawtext は text 非空 segment のみに適用される ----------
+
+
+def test_build_filter_complex_drawtext_only_for_text_nonempty_segments(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given segments の最初 2 つだけ text 持ち、残り 3 つは空
+    When build_filter_complex を呼ぶ
+    Then drawtext は text を持つ 2 segment 分 (EN+JA = 4 命令) のみ生成される
+        (他 3 segment への drawtext は出ない)。
+    """
+    segments = _make_segments()
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=segments,
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    # text 非空の segment 2 つから EN/JA で 4 つの drawtext 命令が出る
+    # logo segment 用の drawtext (heading_left / heading_right / tagline) も別途出るため
+    # 「text segment 由来」の drawtext のみカウントする目的で textfile= の出現箇所を検査
+    assert filter_str.count("textfile=") >= 4, (
+        f"text 非空 segment x 2 の drawtext (EN+JA) が出ていない:\n{filter_str}"
+    )
+
+
+# ---------- B-3: droplet PNG overlay 15-25s ----------
+
+
+def test_build_filter_complex_droplet_overlay_active_15_to_25s(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given logo segment 15-25s
+    When build_filter_complex を呼ぶ
+    Then droplet PNG overlay が 15-25s 区間でのみ enable される。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    assert "overlay" in filter_str, "droplet PNG overlay フィルタが無い"
+    # `enable='between(t,15,25)'` が overlay 句のいずれかに付与されているはず
+    assert "between(t,15,25)" in filter_str, (
+        f"droplet overlay の enable 区間 (15-25s) が見つからない:\n{filter_str}"
+    )
+
+
+# ---------- B-4: drawtext color が config 値で fontcolor=0x... に展開される ----------
+
+
+def test_build_filter_complex_encodes_drawtext_color_from_config(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given color.drawtext = "#3A4A55"
+    When build_filter_complex を呼ぶ
+    Then `fontcolor=0x3A4A55` (大文字) が drawtext 句に含まれる。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color={"drawtext": "#3A4A55", "droplet": "#3A4A55"},
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    # ffmpeg は `0xRRGGBB` 形式を要求 (`#` プレフィックスは不可)
+    assert "0x3A4A55" in filter_str.upper().replace("0X", "0x"), (
+        f"drawtext fontcolor が config 値 (#3A4A55) を反映していない:\n{filter_str}"
+    )
+
+
+# ---------- B-5: text_en_*.txt / text_ja_*.txt が tmp に書かれる ----------
+
+
+def test_build_filter_complex_writes_text_en_and_text_ja_files(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given build_filter_complex を呼ぶ
+    Then text 非空 segment 用の text_en_*.txt / text_ja_*.txt が tmp に書かれる。
+    """
+    intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    en_files = list(tmp_path.glob("text_en_*.txt"))
+    ja_files = list(tmp_path.glob("text_ja_*.txt"))
+    assert len(en_files) >= 1, "text_en_*.txt が生成されていない"
+    assert len(ja_files) >= 1, "text_ja_*.txt が生成されていない"
+
+
+# ---------- B-6: y_offset が segment.start でセンター/上 1/3 に分岐 ----------
+
+
+def test_build_filter_complex_y_offset_switches_at_5s_segment(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given 0-5s (mug 中心被り回避のため center) と 5-10s (upper-third)
+    When build_filter_complex を呼ぶ
+    Then y 式に center 系 (h-text_h)/2 と upper-third 系 (h/3) の両方が出現する。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    assert "(h-text_h)/2" in filter_str, "center 系 y 式が無い"
+    assert "h/3" in filter_str, "upper-third 系 y 式が無い"
+
+
+# ---------- B-7: alpha 式が segment 境界で 0.7s フェード ----------
+
+
+def test_build_filter_complex_alpha_has_07_seconds_fade(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given segments に text 非空がある
+    When build_filter_complex を呼ぶ
+    Then alpha 式に 0.7s フェード ((t-start)/0.7) と end-out (max(0,(end-t)/0.7))
+        の両端境界が現れる。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    # 0-5s segment のフェード: (t-0)/0.7 と (5-t)/0.7 が両方含まれる
+    assert "/0.7" in filter_str, (
+        f"alpha フェード (0.7s) が無い:\n{filter_str}"
+    )
+
+
+# ---------- B-8: logo heading が左右に分割され、中央 50px gap ----------
+
+
+def test_build_filter_complex_logo_heading_split_with_50px_center_gap(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given logo segment (15-25s) で heading_left/heading_right + droplet PNG overlay
+    When build_filter_complex を呼ぶ
+    Then heading は左右 2 つの drawtext (中央から ±50px gap) に分割されている。
+    """
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=_make_text(),
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    # 左 (heading_left): x = w/2 - 50 - text_w
+    # 右 (heading_right): x = w/2 + 50
+    assert "w/2-50-text_w" in filter_str, (
+        f"heading_left (中央から左 50px) の x 式が無い:\n{filter_str}"
+    )
+    assert "w/2+50" in filter_str, (
+        f"heading_right (中央から右 50px) の x 式が無い:\n{filter_str}"
+    )
+
+
+# ---------- B-9: 空 segments で ConfigError ----------
+
+
+def test_build_filter_complex_raises_config_error_for_empty_segments(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given segments が空 list
+    When build_filter_complex を呼ぶ
+    Then ConfigError (`concat=n=0` を防ぐ early fail)。
+    """
+    with pytest.raises(ConfigError):
+        intro_module.build_filter_complex(
+            segments=[],
+            text=_make_text(),
+            font=_make_font(),
+            color=_make_color(),
+            logo=_make_logo(),
+            tmp=tmp_path,
+        )
+
+
+# ---------- B-13: text config の override 値が drawtext fontsize に伝搬 ----------
+
+
+def test_build_filter_complex_propagates_text_fontsize_overrides(
+    intro_module, tmp_path: Path
+) -> None:
+    """Given text dict を override (fontsize_en=64 / fontsize_logo=80)
+    When build_filter_complex を呼ぶ
+    Then drawtext 句に `fontsize=64` (EN) と `fontsize=80` (logo) が反映される
+        (channel が config/skills/intro.yaml で text.* を上書きできる証跡)。
+    """
+    text = _make_text()
+    text["fontsize_en"] = 64
+    text["fontsize_logo"] = 80
+    filter_str, _ = intro_module.build_filter_complex(
+        segments=_make_segments(),
+        text=text,
+        font=_make_font(),
+        color=_make_color(),
+        logo=_make_logo(),
+        tmp=tmp_path,
+    )
+    assert "fontsize=64" in filter_str, (
+        f"text.fontsize_en=64 (EN drawtext) が反映されていない:\n{filter_str}"
+    )
+    assert "fontsize=80" in filter_str, (
+        f"text.fontsize_logo=80 (logo drawtext) が反映されていない:\n{filter_str}"
+    )
+
+
+# ---------- B-10: main() — input 不在時 stderr 出力 + exit 1 ----------
+
+
+def test_main_lists_missing_inputs_and_exits_1_when_assets_absent(
+    intro_module, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given branding/intro_assets/ が存在せず必要 mp4 もない repo
+    When main() を実行
+    Then stderr に missing inputs リストが出て exit code 1。
+    """
+    # repo 構造: config/channel/meta.json (resolve_repo_root の根拠) のみ
+    repo = tmp_path / "repo"
+    (repo / "config" / "channel").mkdir(parents=True)
+    (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sys.argv", ["generate_intro", "--repo-root", str(repo)]
+    )
+
+    rc = intro_module.main()
+    err = capsys.readouterr().err
+    assert rc == 1, f"exit code が 1 でない: {rc}"
+    assert "missing" in err.lower() or "見つかり" in err, (
+        f"stderr に missing inputs の説明が無い:\n{err}"
+    )
+
+
+# ---------- B-11: main() — output 存在 + --force 無しでスキップ ----------
+
+
+def test_main_skips_ffmpeg_when_output_exists_without_force(
+    intro_module, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given branding/intro.mp4 が既に存在し、--force なし
+    When main() を実行
+    Then ffmpeg を呼ばずに rc=0 で抜ける。
+    """
+    repo = tmp_path / "repo"
+    (repo / "config" / "channel").mkdir(parents=True)
+    (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+    (repo / "branding").mkdir()
+    out_path = repo / "branding" / "intro.mp4"
+    out_path.write_bytes(b"\x00")  # 既存
+
+    monkeypatch.setattr(
+        "sys.argv", ["generate_intro", "--repo-root", str(repo)]
+    )
+
+    with patch.object(intro_module.subprocess, "run") as mock_run:
+        rc = intro_module.main()
+
+    assert rc == 0
+    mock_run.assert_not_called()
+
+
+# ---------- B-12: main() — ffmpeg cmd に -r 24 と -an が含まれる ----------
+
+
+def test_main_passes_r24_and_an_to_ffmpeg(
+    intro_module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given 全 input 揃った状態で main() を呼ぶ
+    When ffmpeg subprocess を mock 観測
+    Then cmd に `-r 24` と `-an` (audio なし、video-only) が含まれる。
+    """
+    repo = tmp_path / "repo"
+    (repo / "config" / "channel").mkdir(parents=True)
+    (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+    intro_dir = repo / "branding" / "intro_assets"
+    intro_dir.mkdir(parents=True)
+    # 必要 input ファイルをすべて作る (空でも exists() チェックを通せばよい)
+    for name in [
+        "01_rain_cu_loop.mp4",
+        "02_lamp_steam_loop.mp4",
+        "04_cinemagraph_loop.mp4",
+        "03_room_ws_loop.mp4",
+        "05_droplet.png",
+    ]:
+        (intro_dir / name).write_bytes(b"\x00")
+
+    monkeypatch.setattr(
+        "sys.argv", ["generate_intro", "--repo-root", str(repo), "--force"]
+    )
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(intro_module.subprocess, "run", side_effect=fake_run):
+        rc = intro_module.main()
+
+    assert rc == 0, f"main が成功しない: {rc}"
+    cmd = captured.get("cmd")
+    assert cmd is not None, "ffmpeg subprocess が呼ばれていない"
+    assert "-r" in cmd, f"-r フラグが cmd に無い: {cmd}"
+    r_idx = cmd.index("-r")
+    assert cmd[r_idx + 1] == str(_EXPECTED_FPS), (
+        f"-r 値が {_EXPECTED_FPS} でない: {cmd[r_idx + 1]}"
+    )
+    assert "-an" in cmd, f"`-an` (no audio) が cmd に無い (video-only でない): {cmd}"
+    # 出力長 (-t) も 30s
+    assert "-t" in cmd
+    t_idx = cmd.index("-t")
+    assert cmd[t_idx + 1] == str(_EXPECTED_DURATION)

--- a/tests/test_intro_skill_common.py
+++ b/tests/test_intro_skill_common.py
@@ -1,0 +1,110 @@
+"""Issue #137: intro skill 内 `_common.resolve_repo_root` の単一ソース性 (J 節)。
+
+`resolve_repo_root` は `.claude/skills/intro/references/_common.py` に 1 箇所
+だけ定義され、`generate_intro.py` と `generate_droplet_png.py` の両方が
+`from _common import resolve_repo_root` で **同じオブジェクト** を再利用する。
+本テストは architect-review の指摘 `ARCH-NEW-resolve-repo-root-dry`
+(family_tag: `dry-violation`) の再発防止として、
+
+  - 重複定義の禁止
+  - 両スクリプトが同一 import 経路を経由していること
+  - resolve_repo_root の探索ロジックが意図通り動作すること
+
+を担保する。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests._skill_loader import load_skill_script
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INTRO_REFS = _REPO_ROOT / ".claude" / "skills" / "intro" / "references"
+
+
+# ---------- J-1: `def resolve_repo_root` が _common.py 1 箇所のみ ----------
+
+
+def test_resolve_repo_root_is_defined_only_in_common_module() -> None:
+    """Given `.claude/skills/intro/references/` 配下の Python ソース
+    When `def (?:_)?resolve_repo_root` を全件 grep
+    Then 定義は `_common.py` の 1 箇所だけで、generate_intro.py /
+        generate_droplet_png.py には残存しない (DRY 違反の再発防止)。
+    """
+    pattern = re.compile(r"^def\s+(?:_)?resolve_repo_root\b", re.MULTILINE)
+    definitions: list[tuple[str, int]] = []
+    for py in sorted(_INTRO_REFS.glob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        for m in pattern.finditer(text):
+            line_no = text[: m.start()].count("\n") + 1
+            definitions.append((py.name, line_no))
+
+    assert len(definitions) == 1, (
+        f"resolve_repo_root の定義が複数箇所に存在する (DRY 違反): {definitions}"
+    )
+    assert definitions[0][0] == "_common.py", (
+        f"resolve_repo_root の定義が _common.py 以外にある: {definitions}"
+    )
+
+
+# ---------- J-2: 両スクリプトが _common.resolve_repo_root を共有する ----------
+
+
+def test_generate_intro_and_droplet_share_the_same_resolve_repo_root() -> None:
+    """Given generate_intro / generate_droplet_png の両モジュールを load
+    When それぞれの `resolve_repo_root` を比較
+    Then `_common.resolve_repo_root` 1 つに収束していること
+        (= 同一関数オブジェクトが両モジュールから参照される)。
+    """
+    intro_mod = load_skill_script("intro", "generate_intro")
+    droplet_mod = load_skill_script("intro", "generate_droplet_png")
+
+    assert intro_mod.resolve_repo_root is droplet_mod.resolve_repo_root, (
+        "resolve_repo_root が両モジュールで異なる object になっている "
+        "(再 import / 再定義が発生していないか確認)"
+    )
+    # 同モジュール由来であることも明示的にチェック
+    assert intro_mod.resolve_repo_root.__module__.endswith("_common"), (
+        f"resolve_repo_root の __module__ が _common 由来でない: "
+        f"{intro_mod.resolve_repo_root.__module__}"
+    )
+
+
+# ---------- J-3: resolve_repo_root の探索ロジック ----------
+
+
+def test_resolve_repo_root_finds_meta_json_ancestor(tmp_path: Path) -> None:
+    """Given 入れ子ディレクトリの上位に `config/channel/meta.json` がある状態
+    When _common.resolve_repo_root(<深い nested dir>) を呼ぶ
+    Then `meta.json` を持つ祖先 dir が返る。
+    """
+    intro_mod = load_skill_script("intro", "generate_intro")
+
+    repo = tmp_path / "repo"
+    (repo / "config" / "channel").mkdir(parents=True)
+    (repo / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+
+    deep = repo / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+
+    resolved = intro_mod.resolve_repo_root(deep)
+    assert resolved == repo.resolve(), (
+        f"resolve_repo_root が想定 ancestor を返さない: {resolved} != {repo.resolve()}"
+    )
+
+
+def test_resolve_repo_root_raises_when_meta_json_absent(tmp_path: Path) -> None:
+    """Given 祖先方向に `config/channel/meta.json` が一切存在しない
+    When resolve_repo_root を呼ぶ
+    Then FileNotFoundError が raise される (Fail Fast)。
+    """
+    intro_mod = load_skill_script("intro", "generate_intro")
+    isolated = tmp_path / "no_repo_marker"
+    isolated.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        intro_mod.resolve_repo_root(isolated)

--- a/tests/test_intro_skill_distribution.py
+++ b/tests/test_intro_skill_distribution.py
@@ -1,0 +1,60 @@
+"""Issue #137: intro skill の `yt-skills sync` 自動列挙と config 配布 (I 節)。
+
+`pyproject.toml` の force-include は `.claude/skills` を自動同梱するため
+新規ディレクトリ追加に追加設定は不要だが、配布失敗の早期検出として
+新規 intro skill が `_list_entries` に拾われ、`_default_path("intro")` で
+config.default.yaml が解決可能であることを検証する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.cli import skills_sync
+from youtube_automation.cli.skills_sync import _asset_root, _list_entries
+from youtube_automation.utils import skill_config
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def real_skills_root(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """test_skills_sync.py の fake_repo を使わず、実 .claude/skills/ を見る fixture。
+
+    editable fallback が `_editable_root() = repo_root` を返す前提を維持して
+    実際にリポジトリ配下の `.claude/skills/intro/` がスキルとして列挙されるかを確認する。
+    """
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: _REPO_ROOT)
+    return _REPO_ROOT
+
+
+# ---------- I-1: yt-skills sync が新規 intro skill を列挙する ----------
+
+
+def test_list_entries_includes_intro_skill(real_skills_root: Path) -> None:
+    """Given .claude/skills/intro/ ディレクトリが追加されている
+    When yt-skills sync の自動列挙ロジック (_list_entries) を呼ぶ
+    Then `intro` がリストに含まれる (= wheel 同梱経路で自動配布される)。
+    """
+    root = _asset_root("skills")
+    entries = _list_entries(root)
+    assert "intro" in entries, (
+        f"`intro` が _list_entries の結果に無い (skill ディレクトリが未配置): "
+        f"{entries}"
+    )
+
+
+# ---------- I-2: skill_config._default_path("intro") で config.default.yaml が解決される ----------
+
+
+def test_intro_config_default_yaml_is_discoverable() -> None:
+    """Given upstream に同梱される `intro/config.default.yaml`
+    When skill_config._default_path("intro") を呼ぶ
+    Then config.default.yaml の Path が返り、ファイルが存在する
+        (wheel / editable いずれでも解決可能であること)。
+    """
+    path = skill_config._default_path("intro")
+    assert path.exists(), f"intro/config.default.yaml が解決できない: {path}"
+    assert path.name == "config.default.yaml"

--- a/tests/test_intro_skill_documentation.py
+++ b/tests/test_intro_skill_documentation.py
@@ -104,6 +104,80 @@ def test_masterup_skill_md_step_5_5_appears_after_step_5() -> None:
     assert pos55 > pos5, "`Step 5.5` は `Step 5` の後に来るべき"
 
 
+# ---------- H-3c (#11): Issue #210 SKILL.md から master_raw.mp3 が消えている ----------
+
+
+def test_masterup_skill_md_does_not_mention_master_raw_mp3() -> None:
+    """Given Issue #210 (A2) で `master_raw.mp3` 中間ファイル概念が廃止された
+    When masterup/SKILL.md 全文を読む
+    Then `master_raw.mp3` の文字列が一切出現しない (C-2 リグレッション防止)。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    assert "master_raw.mp3" not in text, (
+        "masterup/SKILL.md に `master_raw.mp3` の記述が残存している "
+        "(Issue #210 で中間ファイル概念は廃止)"
+    )
+
+
+# ---------- H-3d (#12): Issue #210 SKILL.md から --keep-raw が消えている ----------
+
+
+def test_masterup_skill_md_does_not_mention_keep_raw_flag() -> None:
+    """Given Issue #210 (A3) で `--keep-raw` フラグが削除された
+    When masterup/SKILL.md 全文を読む
+    Then `--keep-raw` の文字列が一切出現しない (C-2 リグレッション防止)。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    assert "--keep-raw" not in text, (
+        "masterup/SKILL.md に `--keep-raw` の記述が残存している "
+        "(Issue #210 でフラグ削除済み)"
+    )
+
+
+# ---------- H-3e (#13): Issue #210 SKILL.md が pass-through 自動検出を明記 ----------
+
+
+def test_masterup_skill_md_describes_pass_through_auto_detection() -> None:
+    """Given Issue #210 (B) で intro 素材無しチャンネルでは pass-through する
+    When masterup/SKILL.md 全文を読む
+    Then 自動検出 / pass-through の挙動と「常に呼ぶ」運用契約が明記されている。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    detection_needles = [
+        "pass-through",
+        "自動検出",
+        "intro 素材が揃っていない",
+        "intro 素材",
+    ]
+    assert any(n in text for n in detection_needles), (
+        "masterup/SKILL.md に pass-through 自動検出の言及が無い "
+        f"(needles={detection_needles})"
+    )
+    runtime_needles = ["常に呼ぶ", "常時実行", "Step 5 完了後に必ず"]
+    assert any(n in text for n in runtime_needles), (
+        "masterup/SKILL.md に「常に呼ぶ」運用契約の記述が無い "
+        f"(needles={runtime_needles})"
+    )
+
+
+# ---------- H-3f (#14): Issue #210 SKILL.md が検出キーを明記 ----------
+
+
+def test_masterup_skill_md_mentions_intro_detection_keys() -> None:
+    """Given Issue #210 (B) で `branding/intro_sfx/` と `branding/rain_layers/` が
+        検出キーになる
+    When masterup/SKILL.md 全文を読む
+    Then 両ディレクトリパスが言及されている (利用者が前提条件を理解できる)。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    assert "branding/intro_sfx" in text, (
+        "masterup/SKILL.md が `branding/intro_sfx/` (検出キー 1) を明記していない"
+    )
+    assert "branding/rain_layers" in text, (
+        "masterup/SKILL.md が `branding/rain_layers/` (検出キー 2) を明記していない"
+    )
+
+
 # ---------- H-4: videoup/SKILL.md Intro 統合モード ----------
 
 

--- a/tests/test_intro_skill_documentation.py
+++ b/tests/test_intro_skill_documentation.py
@@ -1,0 +1,210 @@
+"""Issue #137: SKILL.md / CLAUDE.md ドキュメント整合性テスト (H 節)。
+
+`/intro` 自動登録、`/masterup` Step 5.5、`/videoup` Intro 統合モード、
+project root CLAUDE.md の主要モジュール表、version 整合 (pyproject.toml /
+__version__) — 利用者の到達経路と運用契約を担保するドキュメント側の検証。
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
+
+INTRO_SKILL_MD = _SKILLS_DIR / "intro" / "SKILL.md"
+MASTERUP_SKILL_MD = _SKILLS_DIR / "masterup" / "SKILL.md"
+VIDEOUP_SKILL_MD = _SKILLS_DIR / "videoup" / "SKILL.md"
+PROJECT_CLAUDE_MD = _REPO_ROOT / "CLAUDE.md"
+PYPROJECT_TOML = _REPO_ROOT / "pyproject.toml"
+PACKAGE_INIT = _REPO_ROOT / "src" / "youtube_automation" / "__init__.py"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _frontmatter(text: str) -> str:
+    """SKILL.md の先頭 frontmatter (`---` 区切り) のみ抽出する。"""
+    match = re.match(r"^---\n(.*?)\n---", text, flags=re.DOTALL)
+    if not match:
+        raise AssertionError("SKILL.md frontmatter (--- ... ---) が見つかりません")
+    return match.group(1)
+
+
+# ---------- H-1: intro/SKILL.md frontmatter ----------
+
+
+def test_intro_skill_md_exists() -> None:
+    """Given Issue #137 で追加される intro skill
+    When .claude/skills/intro/SKILL.md を探す
+    Then ファイルが存在する。
+    """
+    assert INTRO_SKILL_MD.exists(), f"{INTRO_SKILL_MD} が存在しない (intro skill 未配置)"
+
+
+def test_intro_skill_md_declares_name_intro() -> None:
+    """Given intro/SKILL.md
+    When frontmatter を読む
+    Then `name: intro` が宣言されている (/intro Claude command 自動登録の入口)。
+    """
+    fm = _frontmatter(_read(INTRO_SKILL_MD))
+    assert re.search(r"^name:\s*intro\s*$", fm, flags=re.MULTILINE), (
+        f"frontmatter に `name: intro` が無い:\n{fm}"
+    )
+
+
+# ---------- H-2: intro/SKILL.md 4-step 手順 ----------
+
+
+def test_intro_skill_md_describes_4_step_flow() -> None:
+    """Given intro/SKILL.md 本文
+    When 4-step 手順を探す
+    Then Gemini 静止画 → Veo loop → 雫 PNG → intro.mp4 ビルドの 4 段階に
+        対応するキーワードが揃っている。
+    """
+    text = _read(INTRO_SKILL_MD)
+    # 必須キーワード (大文字小文字無視)
+    needles = ["Gemini", "Veo", "droplet", "intro.mp4"]
+    missing = [n for n in needles if n.lower() not in text.lower()]
+    assert not missing, f"intro/SKILL.md に欠落したキーワード: {missing}"
+
+
+# ---------- H-3: masterup/SKILL.md Step 5.5 ----------
+
+
+def test_masterup_skill_md_adds_step_5_5_finalize_master() -> None:
+    """Given masterup/SKILL.md
+    When 既存 Step 5 の後ろを探す
+    Then `Step 5.5` セクションが追加され、`finalize_master.py` を案内する。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    assert re.search(r"Step\s*5\.5", text), (
+        "masterup/SKILL.md に `Step 5.5` セクションが無い"
+    )
+    assert "finalize_master.py" in text, (
+        "masterup/SKILL.md が `finalize_master.py` を案内していない"
+    )
+
+
+def test_masterup_skill_md_step_5_5_appears_after_step_5() -> None:
+    """Given masterup/SKILL.md
+    When Step 番号の出現順を確認
+    Then `Step 5` の後に `Step 5.5` が出現する (順序リグレッション防止)。
+    """
+    text = _read(MASTERUP_SKILL_MD)
+    pos5 = text.find("Step 5")
+    pos55 = text.find("Step 5.5")
+    assert pos5 != -1, "`Step 5` が見つからない"
+    assert pos55 != -1, "`Step 5.5` が見つからない"
+    assert pos55 > pos5, "`Step 5.5` は `Step 5` の後に来るべき"
+
+
+# ---------- H-4: videoup/SKILL.md Intro 統合モード ----------
+
+
+def test_videoup_skill_md_declares_intro_mode_section() -> None:
+    """Given videoup/SKILL.md
+    When Intro 統合モード節を探す
+    Then `branding/intro.mp4` 検知の説明が含まれる。
+    """
+    text = _read(VIDEOUP_SKILL_MD)
+    # "Intro 統合モード" or "intro mode" のいずれかを許容 (実装の表記ゆれを吸収)
+    assert re.search(r"(Intro\s*統合モード|intro\s*mode)", text, flags=re.IGNORECASE), (
+        "videoup/SKILL.md に Intro 統合モード節が無い"
+    )
+    assert "branding/intro.mp4" in text, (
+        "videoup/SKILL.md が `branding/intro.mp4` 検知の前提条件を明記していない"
+    )
+
+
+def test_videoup_skill_md_separates_audio_video_responsibility() -> None:
+    """Given videoup/SKILL.md Intro 統合モード節
+    When 責務分界の記述を探す
+    Then 「音声合成は finalize_master.py / videoup は pure concat (video のみ)」の
+        意図が読み取れる (音声 mix を videoup が担当しないことの明示)。
+    """
+    text = _read(VIDEOUP_SKILL_MD)
+    assert "finalize_master" in text, (
+        "videoup/SKILL.md に finalize_master.py 側の責務分界が書かれていない"
+    )
+
+
+# ---------- H-5: project CLAUDE.md ----------
+
+
+def test_claude_md_lists_intro_skill_in_main_modules() -> None:
+    """Given project root の CLAUDE.md 「主要モジュール」表
+    When intro skill のエントリを探す
+    Then `/intro` (もしくは intro skill) が明示的に列挙されている。
+    """
+    text = _read(PROJECT_CLAUDE_MD)
+    # intro skill への言及があること (他 skill 一覧と同じ流儀で書かれているはず)
+    assert re.search(r"`?/?intro`?", text), (
+        "CLAUDE.md に intro skill への言及が無い"
+    )
+    # 設計 D / 30s intro の言及で、単なる文字列衝突 (e.g. "introduction") を排除
+    has_design_d = "設計 D" in text or "10s afade-in" in text
+    has_30s = "30s" in text or "30 秒" in text
+    assert has_design_d or has_30s, (
+        "CLAUDE.md に設計 D もしくは 30s intro の言及が無い (単なる文字列衝突の可能性)"
+    )
+
+
+# ---------- H-6: version 整合性 ----------
+
+
+def _pyproject_version() -> str:
+    with PYPROJECT_TOML.open("rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["version"]
+
+
+def _package_version() -> str:
+    """`__version__ = "x.y.z"` を AST 経由で取得 (import を避ける)。"""
+    text = _read(PACKAGE_INIT)
+    match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']\s*$', text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError("__init__.py に `__version__ = '...'` が見つからない")
+    return match.group(1)
+
+
+def test_version_bumped_to_5_5_0() -> None:
+    """Given Issue #137 の plan
+    When pyproject.toml と __version__ を読む
+    Then どちらも `5.5.0` に bump されている。
+    """
+    assert _pyproject_version() == "5.5.0", (
+        f"pyproject.toml の version が 5.5.0 でない: {_pyproject_version()!r}"
+    )
+    assert _package_version() == "5.5.0", (
+        f"src/youtube_automation/__init__.py の __version__ が 5.5.0 でない: {_package_version()!r}"
+    )
+
+
+def test_pyproject_version_matches_package_version() -> None:
+    """Given CLAUDE.md:113-114 の規約 (両方を更新する)
+    When 両ファイルを読む
+    Then 値が完全一致する。
+    """
+    assert _pyproject_version() == _package_version(), (
+        f"version 不整合: pyproject.toml={_pyproject_version()!r}, "
+        f"__version__={_package_version()!r}"
+    )
+
+
+# ---------- 補助: 修正対象ファイル一覧の sanity check ----------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [INTRO_SKILL_MD, MASTERUP_SKILL_MD, VIDEOUP_SKILL_MD, PROJECT_CLAUDE_MD],
+    ids=["intro/SKILL.md", "masterup/SKILL.md", "videoup/SKILL.md", "CLAUDE.md"],
+)
+def test_target_documentation_files_exist(path: Path) -> None:
+    """前提: 本テスト対象のドキュメントファイルが存在すること。"""
+    assert path.exists(), f"{path} が存在しない"

--- a/tests/test_masterup_intro_audio_config.py
+++ b/tests/test_masterup_intro_audio_config.py
@@ -1,0 +1,160 @@
+"""Issue #137: `.claude/skills/masterup/config.default.yaml` の `intro_audio` 名前空間 (D 節)。
+
+新規追加される `intro_audio:` namespace が
+`load_skill_config("masterup")["intro_audio"]` で取得できること、
+設計 D の SFX タイミング (cup=6000ms / paper=18000ms / vinyl=10000ms) と
+既存の `audio.*` / `suno_download.*` キーへのリグレッション、
+channel 上書きの deep-merge 経路を担保する。
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from youtube_automation.utils import skill_config
+from youtube_automation.utils.config import reset as reset_config
+
+# 設計 D の SFX タイミング (ms) と音量 (dB) — 設計の核となる固定値
+_EXPECTED_SFX_TIMING = {
+    "cup": {"start_ms": 6000, "volume_db": -3},
+    "paper": {"start_ms": 18000, "volume_db": -12},
+    "vinyl": {"start_ms": 10000, "volume_db": -6},
+}
+
+_EXPECTED_INTRO_AUDIO_TOP_KEYS = {
+    "song_delay_ms",
+    "song_fadein_s",
+    "song_volume_db",
+    "rain_volume_db",
+    "rain_fadein_s",
+    "loudnorm",
+    "sfx",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    skill_config.reset()
+    reset_config()
+    yield
+    skill_config.reset()
+    reset_config()
+
+
+# ---------- D-1: intro_audio namespace 全 7 キー ----------
+
+
+def test_load_skill_config_masterup_exposes_intro_audio_namespace() -> None:
+    """Given upstream 同梱の masterup/config.default.yaml
+    When load_skill_config("masterup") を呼ぶ
+    Then intro_audio が dict として取れ、7 つのトップキーを持つ。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    intro_audio = cfg.get("intro_audio")
+    assert isinstance(intro_audio, dict), (
+        f"intro_audio が dict でない (namespace 未追加の可能性): {type(intro_audio)}"
+    )
+    missing = _EXPECTED_INTRO_AUDIO_TOP_KEYS - set(intro_audio.keys())
+    assert not missing, f"intro_audio に欠落しているキー: {missing}"
+
+
+def test_intro_audio_song_delay_is_10000_ms() -> None:
+    """Given intro_audio.song_delay_ms
+    When 値を確認
+    Then 設計 D の 10s 遅延に対応する 10000 ms である。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    assert cfg["intro_audio"]["song_delay_ms"] == 10000
+
+
+def test_intro_audio_song_fadein_is_2_seconds() -> None:
+    """Given intro_audio.song_fadein_s
+    When 値を確認
+    Then 設計 D の 2 秒 fadein である。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    assert cfg["intro_audio"]["song_fadein_s"] == 2
+
+
+# ---------- D-2: SFX 3 entries (cup / paper / vinyl) ----------
+
+
+def test_intro_audio_sfx_has_three_entries_with_design_d_timing() -> None:
+    """Given intro_audio.sfx
+    When cup / paper / vinyl のタイミングと音量を確認
+    Then plan 通りの設計 D タイミングで定義されている。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    sfx = cfg["intro_audio"]["sfx"]
+    assert isinstance(sfx, dict), f"intro_audio.sfx が dict でない: {type(sfx)}"
+    for name, expected in _EXPECTED_SFX_TIMING.items():
+        assert name in sfx, f"intro_audio.sfx.{name} が無い"
+        entry = sfx[name]
+        assert isinstance(entry, dict), f"intro_audio.sfx.{name} が dict でない: {type(entry)}"
+        assert entry.get("start_ms") == expected["start_ms"], (
+            f"intro_audio.sfx.{name}.start_ms が {expected['start_ms']} でない: "
+            f"{entry.get('start_ms')!r}"
+        )
+        assert entry.get("volume_db") == expected["volume_db"], (
+            f"intro_audio.sfx.{name}.volume_db が {expected['volume_db']} でない: "
+            f"{entry.get('volume_db')!r}"
+        )
+        assert entry.get("file"), (
+            f"intro_audio.sfx.{name}.file が空 (file 名 default が無い): {entry}"
+        )
+
+
+# ---------- D-3: 既存 audio / suno_download キーへのリグレッション ----------
+
+
+def test_existing_audio_namespace_keys_preserved() -> None:
+    """Given masterup/config.default.yaml の既存 `audio:` namespace
+    When intro_audio 追加後にロード
+    Then crossfade_duration / bitrate などの既存キーは消えていない。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    audio = cfg.get("audio")
+    assert isinstance(audio, dict), f"audio namespace が消えた: {audio!r}"
+    assert "crossfade_duration" in audio
+    assert "bitrate" in audio
+
+
+def test_existing_suno_download_namespace_keys_preserved() -> None:
+    """Given masterup/config.default.yaml の既存 `suno_download:` namespace
+    When intro_audio 追加後にロード
+    Then cdn_url_template が残っている (既存 CLI のリグレッション防止)。
+    """
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    suno = cfg.get("suno_download")
+    assert isinstance(suno, dict), f"suno_download namespace が消えた: {suno!r}"
+    assert "cdn_url_template" in suno
+
+
+# ---------- D-4: channel override (intro_audio.sfx.cup.file) ----------
+
+
+def test_channel_override_replaces_intro_audio_sfx_cup_file_via_deep_merge(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given channel override で `intro_audio.sfx.cup.file` のみ指定
+    When load_skill_config("masterup") を呼ぶ
+    Then default の他キー (start_ms / volume_db) は残り、`file` のみ書き換わる。
+    """
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    override_path = channel_dir / "config" / "skills" / "masterup.yaml"
+    override_path.write_text(
+        yaml.safe_dump({"intro_audio": {"sfx": {"cup": {"file": "ceramic_v9.wav"}}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+    cup = cfg["intro_audio"]["sfx"]["cup"]
+    assert cup["file"] == "ceramic_v9.wav"
+    # default の他キーが merge で消えていない
+    assert cup.get("start_ms") == 6000, (
+        f"override で start_ms が消えた (deep-merge ではなく list 置換になっている可能性): {cup}"
+    )
+    assert cup.get("volume_db") == -3

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.4.0"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## Context

[#136](https://github.com/daiki-beppu/youtube-automation/issues/136) の epic「サムネ ⇄ 楽曲 ⇄ intro 整合性ガード」のうち、**サブタスク 3 (`generate_intro.py` パッケージ同梱)** と **サブタスク 4 (`generate_videos.sh` Intro 統合モード)** を、RJN 側で実装 + 検証完了 → upstream にスキル `/intro` として組み込む提案。

#136 起票時の設計から以下が進化したため、独立 issue としてトラッキング:

| 項目 | #136 起票時 | 現在（v6 採用版） |
|---|---|---|
| intro 配置 | `videoup` スキル配下の references | **独立スキル `/intro`**（`.claude/skills/intro/`） |
| 音声合流 | 2s クロスフェード | **設計 D**: 10s 目から 2s afade-in、雨音と amix |
| 最終尺 | master + 28s（30s 延長） | master_audio_duration（**延長なし**、本編楽曲が 10s 目から始まる扱い） |
| 雨音 | `intro_ambient.m4a` 分離 | **intro.mp4 内蔵** + Logic Pro 由来 30s ループ |
| 多バージョン運用 | 言及なし | **archive 配下で世界観バージョン併存**（dark / sweet / mixed-touch 等） |

## RJN 検証データ（現行 v6 採用版）

`Rain Jazz Night` で 4 ベース画像 → 4 Veo ショット → ffmpeg ビルドの全工程を稼働させ、`branding/intro.mp4` (30s, 14.6MB) を生成済み。サムネ参照画像と整合（pale ice blue + 雨 streak texture + photoreal 物体 + brass turntable）。

世界観バージョンは過去 5 案を archive 退避:
- `2026-05-05-dark-jazzbar/` — teal-amber / Miles Davis / whisky（旧 bar 軸時代）
- `2026-05-05-sweet-strawberry-photoreal/` — pink lampshade + strawberry milk（specific すぎ）
- `2026-05-05-v3-photoreal-bokeh/` — 街並み bokeh ありの photoreal（サムネ不整合）
- `2026-05-05-v4-illustration-chibi/` — 完全 chibi cartoon（サムネ不整合）
- `2026-05-05-v5b-03-rejected/` — 03 ショット品質低の rejected 版
- **採用 (v6 mixed-touch)**: photoreal kitten/mug/turntable + flat illustrated 雨背景

## 提案する upstream パッケージ統合

### A. スキル独立化

```
.claude/skills/intro/
├── SKILL.md                    # チャンネル開設時 1 回限り、4-step 手順
└── references/
    ├── generate_intro.py       # ffmpeg ビルダー (RJN 実装ベース)
    ├── README.md               # 詳細仕様 + 過去版経緯
    └── raw/                    # SFX 配置場所 (cup/paper/vinyl + rain)
```

`yt-skills sync` で配布対象に追加。CLAUDE.md スキル一覧 (channel-setup 系列) にも追加推奨。

### B. CLI（オプション）

`yt-generate-intro` CLI を `youtube_channels_automation` パッケージに追加し、上記スクリプトを呼び出す薄いラッパーにする（既存 `yt-generate-thumbnail` 等と同列）。

### C. `generate_videos.sh` Intro 統合モード（設計 D）

```bash
# Step 1: intro_30s.mp4
# 動画: intro.mp4 stream copy
# 音声: intro 環境音 (rain + SFX) + master[0-30s] amix
# ただし master は 0-10s mute → 10s 目から 2s フェードイン
ffmpeg -y \
  -i \"\$INTRO_VIDEO\" \
  -ss 0 -t 30 -i \"\$MASTER_AUDIO\" \
  -filter_complex \"[1:a]afade=t=in:st=10:d=2[master_faded];[0:a][master_faded]amix=inputs=2:duration=first:dropout_transition=0:normalize=0[aout]\" \
  -map 0:v:0 -map \"[aout]\" \
  -c:v copy -c:a \"\$AUDIO_ENCODER\" -b:a 384k -ar 48000 -t 30 \
  -movflags +faststart \"\$INTRO_30S\"
```

タイムライン:
- 0-10s: intro 雨音 + SFX のみ（楽曲無音）
- 10-12s: 楽曲 2s フェードイン
- 12-27s: 雨 + SFX + 楽曲 amix
- 27-30s: 雨フェードアウト + 楽曲継続
- 30s〜: 本編 loop + 楽曲のみ

最終尺は master_audio_duration（変わらず）。

### D. ドキュメント追従

CLAUDE.md / SKILL.md テンプレに「冒頭離脱対策の動画側施策（設計 D）」を追加。/intro スキルが `branding/intro.mp4` を作り、`/videoup` が自動 concat する明確な責務分離。

## 連携

- Closes #136 (一部、サブタスク 3 + 4)
- 設計 D は #136 の 2s クロスフェード設計から更新済み
- サブタスク 1 (`sweet-warm-lofi` 軸) と 2 (`deprecated_variants` ガード) は #136 で継続トラック

## RJN 側の参考実装パス

- `.claude/skills/intro/SKILL.md` — チャンネル開設時 1 回限りの 4-step 手順
- `.claude/skills/intro/references/generate_intro.py` — ffmpeg ビルダー（rain layer + SFX timing 内蔵）
- `.claude/skills/intro/references/README.md` — 詳細仕様
- `.claude/skills/videoup/references/generate_videos.sh` — Intro 統合モード設計 D
- `.claude/CLAUDE.md` — 設計 D 学習記録

## Execution Report

Workflow `default-extended` completed successfully.

Closes #137

---

## 追加コミット (issue #210)

PR #209 のレビュー過程で発見した masterup 側の課題を本 PR に積み上げ:

- Step 5 → Step 5.5 の output 名不整合（`yt-generate-master` 出力 `master.mp3` vs `finalize_master.py` 入力 `master_raw.mp3`）の解消
- intro 無しチャンネルへの自動切替（`branding/intro_sfx/` / `rain_layers/` 不在時の pass-through モード）
- masterup SKILL.md の更新

Closes #210