### PR TITLE
[#197] issue-197-chore-tests-test-str

### DIFF
--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -79,7 +79,6 @@ _CLOUD_INIT_YAML = _INFRA_DIR / "cloud-init.yaml"
 _TFVARS_EXAMPLE = _INFRA_DIR / "terraform.tfvars.example"
 _STREAMING_README = _INFRA_DIR / "README.md"
 
-_SECRETS_PY = _REPO_ROOT / "src" / "youtube_automation" / "utils" / "secrets.py"
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _HEALTHCHECK_DOC = _REPO_ROOT / "docs" / "streaming-healthcheck.md"
 


### PR DESCRIPTION
## Summary

## 背景

issue #168 (`stream_bandwidth_cli` テスト偽陽性解消) の対応で `tests/test_streaming_healthcheck.py::TestSecretsDiscordWebhookUrl` を削除した結果、ファイル冒頭の `_SECRETS_PY` 定数（L82）が完全に未使用になった。

## 該当箇所

```python
# tests/test_streaming_healthcheck.py:82
_SECRETS_PY = _REPO_ROOT / "src" / "youtube_automation" / "utils" / "secrets.py"
```

`grep -nr _SECRETS_PY` でリポジトリ全体を確認したところ、L82 の定義以外に参照がない（`TestSecretsDiscordWebhookUrl` が `secrets.py` を直接 import せず動的 path 参照していたが、当該クラスは [#168](https://github.com/daiki-beppu/youtube-channels-automation/issues/168) で削除済）。

## 経緯

- [#168](https://github.com/daiki-beppu/youtube-channels-automation/issues/168) の test-report.md L24 で「`_SECRETS_PY` 定数（L82）は本タスク削除対象クラスからも参照されておらず、削除前から実質未使用。スコープ外の『ついで掃除』を避けるため touch せず残置。」と記録済み。
- 実態は #168 のクラス削除後に死蔵となるため、別 issue として独立した clean-up を切り出す。

## 期待する変更

- `tests/test_streaming_healthcheck.py:82` の `_SECRETS_PY = ...` を削除する。
- 必要なら直前後の空行も整える（L81-83 の段落構造を維持）。

## 確認方法

```bash
uv run pytest tests/test_streaming_healthcheck.py
uv run ruff check tests/test_streaming_healthcheck.py
```

## スコープ外

- `_PYPROJECT` / `_HEALTHCHECK_DOC` 等の隣接定数（L83-84）は他テストで参照されているため触らない。
- 同ファイル内の他の dead constant チェックは別 issue とする（YAGNI）。

## Execution Report

Workflow `default-mini` completed successfully.

Closes #197