### PR TITLE
[#183] issue-183-chore-gitignore-ni-t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ tests/fixtures/sample_channel/data/
 terraform.tfvars
 *.tfstate
 *.tfstate.*
+*.tfplan
 .terraform/

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -468,6 +468,19 @@ class TestRootGitignoreTerraformEntries:
         """
         assert ".terraform/" in gitignore_lines, ".terraform/ が .gitignore に追加されていない"
 
+    def test_ignores_tfplan_files(self, gitignore_lines: list[str]):
+        """Given root .gitignore
+        When 行を走査する
+        Then *.tfplan が ignore 対象。
+
+        `terraform plan -out=` で生成される binary plan ファイルの誤コミット防止
+        （defense-in-depth: #154 で採用した ssh-agent 切替の fallback layer）。
+        """
+        assert "*.tfplan" in gitignore_lines, (
+            "*.tfplan が .gitignore に追加されていない"
+            "（terraform plan -out= ファイルの誤コミット保護が外れている）"
+        )
+
 
 # ============================================================================
 # cloud-init.yaml (#124)


### PR DESCRIPTION
## Summary

## 概要

`.gitignore` に `*.tfplan` パターンを追加し、`terraform plan -out=<file>` で生成される binary plan ファイルが誤って commit されることを防ぐ defense-in-depth として整備したい。

## 経緯

Issue #154（`null_resource.deploy.connection` を `agent = true` の ssh-agent 経由に切替）で、SSH 秘密鍵 PEM が Terraform graph 経由で `*.tfplan` に取り込まれる経路は排除済み。ただし、order.md には R2（ssh-agent 切替）の代替案として以下が併記されており、#154 では R2 採用を選択したため R3（gitignore 化）はスコープ外として明示除外した:

> または `agent = true` を採用できない事情がある場合、README に「`terraform plan -out=` / `TF_LOG=DEBUG` 出力ファイルの作成・保管を禁止する」旨を運用ルールとして明記し、`.gitignore` で `*.tfplan` を ignore 化する。

#154 の plan.md（スコープ外テーブル）抜粋:

| 項目 | 除外理由 |
|------|---------|
| `.gitignore` への `*.tfplan` 追加 | order.md R3（代替案）。`agent = true` 採用時は不要。スコープ規律 |

## なぜ今 issue 化するか（defense-in-depth）

- `agent = true` で PEM が graph に乗らないのは `null_resource.deploy.connection` ブロックに限定された保証。将来別の resource で `private_key` 系が混入した場合や、誤って `agent = true` が revert された場合のフォールバック layer がほしい。
- `*.tfplan` は基本的にローカル debug 用途で、commit する実用ケースがない。ignore 化のデメリットは皆無。
- 既存の `.gitignore` には `*.tfstate` / `*.tfstate.*` / `.terraform/` は登録されているが `*.tfplan` だけ抜けている → 整合性の観点でも揃えたい。

## 推奨対応

`.gitignore` の Terraform セクション（現状）:

\`\`\`gitignore
# Terraform
terraform.tfvars
*.tfstate
*.tfstate.*
.terraform/
\`\`\`

に `*.tfplan` を追記:

\`\`\`gitignore
# Terraform
terraform.tfvars
*.tfstate
*.tfstate.*
*.tfplan
.terraform/
\`\`\`

## スコープ外

- `terraform plan -out=` / `TF_LOG=DEBUG` 出力禁止の運用ルール明記（README）: ssh-agent 切替で graph 自体に PEM が乗らなくなったため、運用ルール化までは過剰。本 issue は `.gitignore` 1 行追加に限定する。
- `terraform plan` の出力先制御や CI での plan 取り扱い: 別 issue。

## 検証

- `.gitignore` に `*.tfplan` が含まれていることを確認するテスト追加（`tests/test_gitignore.py` 系の既存パターンがあれば踏襲、なければ最小の存在チェック）

## 出典

- Issue #154 (`takt/154/issue-154-critical-terraform-c`) の plan.md スコープ外テーブル
- order.md R3 代替案

## Execution Report

Workflow `default-mini` completed successfully.

Closes #183