### PR TITLE
[#178] issue-178-chore-thumbnail-feat

### DIFF
--- a/src/youtube_automation/utils/thumbnail_features.py
+++ b/src/youtube_automation/utils/thumbnail_features.py
@@ -47,12 +47,12 @@ def extract_features(img: Image.Image) -> Dict[str, float]:
 
 
 def _mean(band: Image.Image) -> float:
-    pixels = list(band.getdata())
+    pixels = list(band.get_flattened_data())
     return sum(pixels) / len(pixels) if pixels else 0.0
 
 
 def _stdev(band: Image.Image) -> float:
-    pixels = list(band.getdata())
+    pixels = list(band.get_flattened_data())
     if not pixels:
         return 0.0
     m = sum(pixels) / len(pixels)
@@ -60,8 +60,8 @@ def _stdev(band: Image.Image) -> float:
 
 
 def _abs_diff(band_a: Image.Image, band_b: Image.Image) -> Image.Image:
-    a = list(band_a.getdata())
-    b = list(band_b.getdata())
+    a = list(band_a.get_flattened_data())
+    b = list(band_b.get_flattened_data())
     out = Image.new("L", band_a.size)
     out.putdata([abs(x - y) for x, y in zip(a, b)])
     return out
@@ -69,9 +69,9 @@ def _abs_diff(band_a: Image.Image, band_b: Image.Image) -> Image.Image:
 
 def _abs_diff_half_sum(r: Image.Image, g: Image.Image, b: Image.Image) -> Image.Image:
     """|0.5*(R+G) - B| を計算する (Hasler-Süsstrunk の yb)"""
-    rp = list(r.getdata())
-    gp = list(g.getdata())
-    bp = list(b.getdata())
+    rp = list(r.get_flattened_data())
+    gp = list(g.get_flattened_data())
+    bp = list(b.get_flattened_data())
     out = Image.new("L", r.size)
     out.putdata([min(255, int(abs(0.5 * (rr + gg) - bb))) for rr, gg, bb in zip(rp, gp, bp)])
     return out


### PR DESCRIPTION
## Summary

## 概要

`src/youtube_automation/utils/thumbnail_features.py` 内で `band.getdata()` を 7 箇所使用しており、Pillow 12.x で `DeprecationWarning` を発生させる。Pillow 14 (2027-10-15) で削除予定。`uv run pytest`（リポジトリ全体）実行時に **78 件**の DeprecationWarning が出ている状態。

## 警告メッセージ

```
DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
```

確認手順:
```
uv run python -W error::DeprecationWarning -c "from PIL import Image; img = Image.new('RGB',(10,10)); list(img.getdata())"
```

## 該当箇所

`src/youtube_automation/utils/thumbnail_features.py`

| 行 | 現状 |
|----|------|
| L50 | `pixels = list(band.getdata())` |
| L55 | `pixels = list(band.getdata())` |
| L63 | `a = list(band_a.getdata())` |
| L64 | `b = list(band_b.getdata())` |
| L72 | `rp = list(r.getdata())` |
| L73 | `gp = list(g.getdata())` |
| L74 | `bp = list(b.getdata())` |

## 推奨対応

- `getdata()` を `get_flattened_data()` に置換
- 後方互換維持が必要なら try/except で `getattr(band, 'get_flattened_data', band.getdata)()` のフォールバックを 1 箇所にラップ

## 検出経緯

issue #150（`_client_secrets_tempfile` の atexit クリーンアップ化）の supervisor-validation で `uv run pytest` 実行時に 78 件の Pillow `getdata` deprecation warnings が継続的に発生していることを確認。本タスクはスコープ外につき別 issue 化。

参照: `.takt/runs/20260506-090810-issue-150-critical-client-secr/reports/supervisor-validation.md`

## Execution Report

Workflow `default-mini` completed successfully.

Closes #178