### PR TITLE
release: v5.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ tests/fixtures/sample_channel/data/
 terraform.tfvars
 *.tfstate
 *.tfstate.*
+*.tfplan
 .terraform/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.4.0"
+version = "5.4.1"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.4.0"
+__version__ = "5.4.1"

--- a/src/youtube_automation/utils/thumbnail_features.py
+++ b/src/youtube_automation/utils/thumbnail_features.py
@@ -47,12 +47,12 @@ def extract_features(img: Image.Image) -> Dict[str, float]:
 
 
 def _mean(band: Image.Image) -> float:
-    pixels = list(band.getdata())
+    pixels = list(band.get_flattened_data())
     return sum(pixels) / len(pixels) if pixels else 0.0
 
 
 def _stdev(band: Image.Image) -> float:
-    pixels = list(band.getdata())
+    pixels = list(band.get_flattened_data())
     if not pixels:
         return 0.0
     m = sum(pixels) / len(pixels)
@@ -60,8 +60,8 @@ def _stdev(band: Image.Image) -> float:
 
 
 def _abs_diff(band_a: Image.Image, band_b: Image.Image) -> Image.Image:
-    a = list(band_a.getdata())
-    b = list(band_b.getdata())
+    a = list(band_a.get_flattened_data())
+    b = list(band_b.get_flattened_data())
     out = Image.new("L", band_a.size)
     out.putdata([abs(x - y) for x, y in zip(a, b)])
     return out
@@ -69,9 +69,9 @@ def _abs_diff(band_a: Image.Image, band_b: Image.Image) -> Image.Image:
 
 def _abs_diff_half_sum(r: Image.Image, g: Image.Image, b: Image.Image) -> Image.Image:
     """|0.5*(R+G) - B| を計算する (Hasler-Süsstrunk の yb)"""
-    rp = list(r.getdata())
-    gp = list(g.getdata())
-    bp = list(b.getdata())
+    rp = list(r.get_flattened_data())
+    gp = list(g.get_flattened_data())
+    bp = list(b.get_flattened_data())
     out = Image.new("L", r.size)
     out.putdata([min(255, int(abs(0.5 * (rr + gg) - bb))) for rr, gg, bb in zip(rp, gp, bp)])
     return out

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -79,7 +79,6 @@ _CLOUD_INIT_YAML = _INFRA_DIR / "cloud-init.yaml"
 _TFVARS_EXAMPLE = _INFRA_DIR / "terraform.tfvars.example"
 _STREAMING_README = _INFRA_DIR / "README.md"
 
-_SECRETS_PY = _REPO_ROOT / "src" / "youtube_automation" / "utils" / "secrets.py"
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _HEALTHCHECK_DOC = _REPO_ROOT / "docs" / "streaming-healthcheck.md"
 

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -468,6 +468,19 @@ class TestRootGitignoreTerraformEntries:
         """
         assert ".terraform/" in gitignore_lines, ".terraform/ が .gitignore に追加されていない"
 
+    def test_ignores_tfplan_files(self, gitignore_lines: list[str]):
+        """Given root .gitignore
+        When 行を走査する
+        Then *.tfplan が ignore 対象。
+
+        `terraform plan -out=` で生成される binary plan ファイルの誤コミット防止
+        （defense-in-depth: #154 で採用した ssh-agent 切替の fallback layer）。
+        """
+        assert "*.tfplan" in gitignore_lines, (
+            "*.tfplan が .gitignore に追加されていない"
+            "（terraform plan -out= ファイルの誤コミット保護が外れている）"
+        )
+
 
 # ============================================================================
 # cloud-init.yaml (#124)


### PR DESCRIPTION
## Summary

v5.4.0 → v5.4.1 (patch). chore 系 3 件を集約。

## 含まれる変更

- #218 chore(tests): test_streaming_healthcheck.py の未使用定数 `_SECRETS_PY` 削除
- #219 chore: .gitignore に `*.tfplan` 追加 (Terraform plan 誤コミット防止)
- #220 chore(thumbnail_features): Pillow 12.x deprecated `Image.getdata()` を `get_flattened_data()` に置換 (7 箇所)

## バージョン bump

- pyproject.toml: 5.4.0 → 5.4.1
- src/youtube_automation/__init__.py: 5.4.0 → 5.4.1

## Test plan

- [x] #218 / #219 / #220 各 PR で AI レビュー APPROVE 済み (new=0 / persists=0)
- [x] supervisor-validation で要件充足確認済み
- [ ] release/v5.4.1 で CI green 確認
- [ ] main マージ後に v5.4.1 タグ付け (`/release` publish 相当を別途実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)