### PR TITLE
[#186] issue-186-low-rino-ffprobe-arg

### DIFF
--- a/src/youtube_automation/scripts/fix_per_theme_timestamps.py
+++ b/src/youtube_automation/scripts/fix_per_theme_timestamps.py
@@ -63,6 +63,7 @@ def get_duration(mp3: Path) -> float:
             "format=duration",
             "-of",
             "default=noprint_wrappers=1:nokey=1",
+            "--",
             str(mp3),
         ],
         check=True,

--- a/src/youtube_automation/utils/veo_generator.py
+++ b/src/youtube_automation/utils/veo_generator.py
@@ -138,6 +138,7 @@ def trim_tail(video_path: Path, trim_sec: float = 1.0) -> bool:
         "format=duration",
         "-of",
         "default=noprint_wrappers=1:nokey=1",
+        "--",
         str(video_path),
     ]
     try:
@@ -184,6 +185,7 @@ def smooth_loop(video_path: Path, crossfade_sec: float = 0.5, trim_tail_sec: flo
         "format=duration",
         "-of",
         "default=noprint_wrappers=1:nokey=1",
+        "--",
         str(video_path),
     ]
     try:

--- a/src/youtube_automation/utils/video_validator.py
+++ b/src/youtube_automation/utils/video_validator.py
@@ -186,7 +186,17 @@ class VideoValidator:
     def _get_video_metadata(self, video_path: Path) -> Optional[Dict]:
         """ffprobe で動画メタデータを取得"""
         try:
-            cmd = ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", str(video_path)]
+            cmd = [
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
+                "--",
+                str(video_path),
+            ]
 
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 

--- a/tests/fixtures/sample_channel/data/audio_costs.json
+++ b/tests/fixtures/sample_channel/data/audio_costs.json
@@ -3118,5 +3118,161 @@
       "segment": "seg_002",
       "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-179/test_parallel_partial_failure0/seg_002.wav"
     }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:07.743381+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:07.812758+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_generates_all_segments_an0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:07.985153+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_skips_existing_segments0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.149712+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_retries_on_failure0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.214912+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_retries_on_failure0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.377473+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_renames_segment_files_by_0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.444046+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_renames_segment_files_by_0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.604821+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_cleans_up_segment_files_w0/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.676996+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_cleans_up_segment_files_w0/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.841061+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_parallel_generates_all_se0/01-master/seg_001.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:08.841128+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_2",
+      "segment": "seg_002",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_parallel_generates_all_se0/01-master/seg_002.wav"
+    }
+  },
+  {
+    "timestamp": "2026-05-08T13:57:09.005850+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/df/2dv2pvsx255_n6hg5wklcryc0000gn/T/pytest-of-mba/pytest-28/test_parallel_partial_failure0/seg_001.wav"
+    }
   }
 ]

--- a/tests/test_fix_per_theme_timestamps.py
+++ b/tests/test_fix_per_theme_timestamps.py
@@ -1,0 +1,54 @@
+"""scripts.fix_per_theme_timestamps の ffprobe argv 構成検証.
+
+Issue #186: `get_duration` の ffprobe argv に `"--"` sentinel が含まれている
+ことを検証する。Issue #167 で `utils/probe.py` に導入した argv-injection
+defense-in-depth を `fix_per_theme_timestamps.py` へ横展開した
+リグレッションガード。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _import_module():
+    """`fix_per_theme_timestamps` は import 時に `channel_dir()` を評価する。
+    `set_channel_dir` autouse fixture が `CHANNEL_DIR` を設定したあとで
+    遅延 import することで、collection 時の `ConfigError` を回避する。
+    """
+    from youtube_automation.scripts import fix_per_theme_timestamps
+
+    return fix_per_theme_timestamps
+
+
+def test_get_duration_places_sentinel_before_path(monkeypatch) -> None:
+    fix_per_theme_timestamps = _import_module()
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout="123.45\n", returncode=0)
+
+    monkeypatch.setattr(fix_per_theme_timestamps.subprocess, "run", fake_run)
+
+    fix_per_theme_timestamps.get_duration(Path("/fake.mp3"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "/fake.mp3"
+
+
+def test_get_duration_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
+    fix_per_theme_timestamps = _import_module()
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout="123.45\n", returncode=0)
+
+    monkeypatch.setattr(fix_per_theme_timestamps.subprocess, "run", fake_run)
+
+    fix_per_theme_timestamps.get_duration(Path("-evil.mp3"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "-evil.mp3"

--- a/tests/test_veo_generator.py
+++ b/tests/test_veo_generator.py
@@ -1,0 +1,72 @@
+"""utils.veo_generator の ffprobe argv 構成検証.
+
+Issue #186: `trim_tail` / `smooth_loop` の duration 取得 argv に `"--"` sentinel が
+含まれていることを検証する。Issue #167 で `utils/probe.py` に導入した
+argv-injection defense-in-depth を `veo_generator.py` へ横展開した
+リグレッションガード。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.utils import veo_generator
+
+
+def _install_capture(monkeypatch) -> dict:
+    """`subprocess.check_output` を fake 化し、cmd を捕捉して即座に
+    `ValueError` を発生させる。`trim_tail` / `smooth_loop` は
+    `Exception` 全般を catch して `False` を返すため、これで
+    argv 検証だけに絞った最小テストになる。
+    """
+    captured: dict = {}
+
+    def fake_check_output(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # float() で ValueError を発生させ、関数を早期 False で抜けさせる。
+        return "not-a-number"
+
+    monkeypatch.setattr(veo_generator.subprocess, "check_output", fake_check_output)
+    return captured
+
+
+# ---------- trim_tail ----------
+
+
+def test_trim_tail_places_sentinel_before_path(monkeypatch) -> None:
+    captured = _install_capture(monkeypatch)
+
+    veo_generator.trim_tail(Path("/fake.mp4"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "/fake.mp4"
+
+
+def test_trim_tail_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
+    captured = _install_capture(monkeypatch)
+
+    veo_generator.trim_tail(Path("-evil.mp4"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "-evil.mp4"
+
+
+# ---------- smooth_loop ----------
+
+
+def test_smooth_loop_places_sentinel_before_path(monkeypatch) -> None:
+    captured = _install_capture(monkeypatch)
+
+    veo_generator.smooth_loop(Path("/fake.mp4"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "/fake.mp4"
+
+
+def test_smooth_loop_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
+    captured = _install_capture(monkeypatch)
+
+    veo_generator.smooth_loop(Path("-evil.mp4"))
+
+    assert captured["cmd"][-2] == "--"
+    assert captured["cmd"][-1] == "-evil.mp4"

--- a/tests/test_video_validator.py
+++ b/tests/test_video_validator.py
@@ -4,6 +4,10 @@
 個別楽曲としてカウントすることを検証する。
 """
 
+from pathlib import Path
+from types import SimpleNamespace
+
+from youtube_automation.utils import video_validator as vv_module
 from youtube_automation.utils.video_validator import VideoValidator
 
 
@@ -59,3 +63,45 @@ class TestCheckOverallConsistencyAudioCount:
         issues = VideoValidator()._check_overall_consistency(coll, results)
 
         assert not any("一致しません" in w for w in issues["warnings"])
+
+
+# ---------- argv-injection defense (Issue #186): "--" sentinel ----------
+
+
+class TestGetVideoMetadataSentinel:
+    """`_get_video_metadata` の ffprobe argv に `"--"` sentinel が含まれることを検証する。
+
+    Issue #167 で `utils/probe.py` に導入した defense-in-depth を `video_validator.py`
+    へ横展開したリグレッションガード。`-` 始まりパスがオプションとして
+    誤解釈される余地を遮断する意図を、通常パス・adversarial パスの双方で固定する。
+    """
+
+    def test_places_sentinel_before_path(self, monkeypatch):
+        """通常パスでも argv 末尾は `["--", str(path)]` であること."""
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout='{"streams": [], "format": {}}', returncode=0)
+
+        monkeypatch.setattr(vv_module.subprocess, "run", fake_run)
+
+        VideoValidator()._get_video_metadata(Path("/fake.mp4"))
+
+        assert captured["cmd"][-2] == "--"
+        assert captured["cmd"][-1] == "/fake.mp4"
+
+    def test_keeps_sentinel_for_dash_prefixed_path(self, monkeypatch):
+        """`-` 始まりの adversarial パスでも sentinel が path の直前に保たれること."""
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout='{"streams": [], "format": {}}', returncode=0)
+
+        monkeypatch.setattr(vv_module.subprocess, "run", fake_run)
+
+        VideoValidator()._get_video_metadata(Path("-evil.mp4"))
+
+        assert captured["cmd"][-2] == "--"
+        assert captured["cmd"][-1] == "-evil.mp4"

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.4.0"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 概要

Issue #167 では `utils/probe.py` の `probe_duration` / `probe_bitrate` の `ffprobe` argv に `--` sentinel を追加して argv-injection の defense-in-depth を入れたが、リポジトリ内には他にも `--` sentinel が付いていない `ffprobe` 呼び出しが残っている。Issue #167 のスコープ外として横展開を見送ったため、別 issue として起票する。

## 該当箇所

| ファイル | 行 | 関数 |
|---------|----|------|
| `src/youtube_automation/utils/video_validator.py` | 189 | `_get_video_metadata` |
| `src/youtube_automation/utils/veo_generator.py` | 134 | `trim_tail`（duration_cmd） |
| `src/youtube_automation/utils/veo_generator.py` | 180 | `smooth_loop`（duration_cmd） |
| `src/youtube_automation/scripts/fix_per_theme_timestamps.py` | 59 | `get_duration` |

いずれも `str(path)` を直接 argv 末尾に置いており、`-` 始まりのパスがオプション解釈される余地がある。

## 推奨対応

各箇所で、argv 末尾の `str(path)` の直前に `"--"` を挿入する。Issue #167 と同じパターン:

```python
[
    "ffprobe",
    "-v",
    "error",
    ...,
    "-of",
    "...",
    "--",
    str(path),
]
```

## テスト方針

`tests/test_probe.py` で導入したパターン（`captured[\"cmd\"][-2:] == [\"--\", str(path)]` の位置検証）を流用し、各呼び出し関数に対して同等のリグレッションテストを追加する。

## 参照

- Issue #167（`utils/probe.py` 限定で `--` sentinel を導入したオリジナル）
- 検出元: Issue #167 run の `architect-review.md` 参考情報、`supervisor-validation.md` 補足

## Execution Report

Workflow `default-mini` completed successfully.

Closes #186