### PR TITLE
[#193] issue-193-refactor-analytics-s

### DIFF
--- a/src/youtube_automation/scripts/analytics_system.py
+++ b/src/youtube_automation/scripts/analytics_system.py
@@ -13,8 +13,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from youtube_automation.utils.analytics_collector import YouTubeAnalyticsCollector  # noqa: E402
-from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
+from googleapiclient.errors import HttpError
+
+from youtube_automation.utils.analytics_collector import YouTubeAnalyticsCollector
+from youtube_automation.utils.config import channel_dir, load_config
+from youtube_automation.utils.exceptions import AuthError, ConfigError, YouTubeAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +73,8 @@ class AnalyticsSystem:
                 logger.error("❌ 認証失敗 - 接続テストに失敗")
                 return False
 
-        except Exception as e:
-            logger.error(f"❌ 認証エラー: {e}")
+        except (AuthError, YouTubeAPIError, ConfigError) as e:
+            logger.error("❌ 認証エラー: %s", e)
             return False
 
     def collect_analytics_data(self, days=30, save_data=True, include_reporting=False):
@@ -146,14 +149,26 @@ class AnalyticsSystem:
                         },
                         "動画×日次データ",
                     )
-                except Exception as e:
-                    logger.warning(f"⚠️ 動画×日次データ保存失敗（続行）: {e}")
+                except HttpError as e:
+                    api_err = YouTubeAPIError.from_http_error(e, "動画×日次データ取得")
+                    logger.warning(
+                        "⚠️ 動画×日次データ取得失敗（続行）: %s (status=%s)",
+                        api_err,
+                        api_err.status_code,
+                        exc_info=True,
+                    )
+                except (OSError, ValueError, KeyError) as e:
+                    logger.warning("⚠️ 動画×日次データ処理失敗（続行）: %s", e, exc_info=True)
 
             logger.info("✅ アナリティクスデータ収集完了")
             return analytics_data
 
-        except Exception as e:
-            logger.error(f"❌ データ収集エラー: {e}")
+        except HttpError as e:
+            api_err = YouTubeAPIError.from_http_error(e, "アナリティクス収集")
+            logger.exception("❌ データ収集 API エラー: %s (status=%s)", api_err, api_err.status_code)
+            return None
+        except (YouTubeAPIError, ConfigError, OSError, ValueError, KeyError) as e:
+            logger.exception("❌ データ収集エラー: %s", e)
             return None
 
     def run_data_collection(self, days=30, include_reporting=False):
@@ -176,15 +191,10 @@ class AnalyticsSystem:
             results["error"] = "Authentication failed"
             return results
 
-        try:
-            analytics_data = self.collect_analytics_data(days=days, include_reporting=include_reporting)
-            if not analytics_data:
-                results["error"] = "Data collection failed"
-                logger.error("🛑 データ収集に失敗したため処理を終了します")
-                return results
-        except Exception as e:
-            results["error"] = f"Data collection error: {e}"
-            logger.error("🛑 データ収集エラーのため処理を終了します")
+        analytics_data = self.collect_analytics_data(days=days, include_reporting=include_reporting)
+        if not analytics_data:
+            results["error"] = "Data collection failed"
+            logger.error("🛑 データ収集に失敗したため処理を終了します")
             return results
 
         logger.info("✅ YouTube Analyticsデータ収集完了")

--- a/tests/test_analytics_system.py
+++ b/tests/test_analytics_system.py
@@ -12,6 +12,12 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
+from googleapiclient.errors import HttpError
+
+# `patch("youtube_automation.scripts.analytics_system.X")` がモジュール属性として
+# 解決できるよう、トップレベルで submodule を import しておく。
+import youtube_automation.scripts.analytics_system  # noqa: F401
+from youtube_automation.utils.exceptions import AuthError, YouTubeAPIError
 
 # ---------------------------------------------------------------------------
 # フィクスチャ
@@ -111,18 +117,32 @@ class TestAuthenticate:
             assert system.authenticated is False
 
     def test_authenticate_exception(self, system):
-        """認証中に例外が発生した場合 False を返す"""
+        """認証中にドメイン例外（AuthError）が発生した場合 False を返す"""
         with patch.dict(
             "sys.modules",
             {
                 "youtube_automation.auth": MagicMock(),
                 "youtube_automation.auth.oauth_handler": MagicMock(
-                    YouTubeOAuthHandler=MagicMock(side_effect=Exception("Token expired"))
+                    YouTubeOAuthHandler=MagicMock(side_effect=AuthError("Token expired"))
                 ),
             },
         ):
             result = system.authenticate()
             assert result is False
+
+    def test_authenticate_unexpected_exception_propagates(self, system):
+        """narrow catch 範囲外の例外は伝播する（fail-fast）"""
+        with patch.dict(
+            "sys.modules",
+            {
+                "youtube_automation.auth": MagicMock(),
+                "youtube_automation.auth.oauth_handler": MagicMock(
+                    YouTubeOAuthHandler=MagicMock(side_effect=RuntimeError("unexpected"))
+                ),
+            },
+        ):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                system.authenticate()
 
 
 # ---------------------------------------------------------------------------
@@ -179,12 +199,75 @@ class TestCollectAnalyticsData:
         result = system.collect_analytics_data(days=14, save_data=False)
         assert result == expected_data
 
-    def test_collector_exception(self, system):
-        """コレクター例外時に None を返す"""
+    def test_collector_domain_exception(self, system):
+        """ドメイン例外（YouTubeAPIError）発生時に None を返す"""
         system.authenticated = True
-        system.collector.collect_basic_analytics.side_effect = Exception("API quota exceeded")
+        system.collector.collect_basic_analytics.side_effect = YouTubeAPIError("API quota exceeded")
 
         result = system.collect_analytics_data(days=30)
+        assert result is None
+
+    def test_collector_unexpected_exception_propagates(self, system):
+        """narrow catch 範囲外の例外は伝播する（fail-fast）"""
+        system.authenticated = True
+        system.collector.collect_basic_analytics.side_effect = RuntimeError("unexpected")
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            system.collect_analytics_data(days=30)
+
+    def test_video_daily_failure_continues(self, system, tmp_path):
+        """動画×日次データ取得失敗時は warning ログ + 続行（analytics_data は返す）"""
+        system.authenticated = True
+        expected_data = {"views": 1000}
+        system.collector.collect_basic_analytics.return_value = expected_data
+        # 動画一覧取得は成功、日次取得で KeyError（データ整合性エラー）
+        system.collector.get_all_channel_videos.return_value = [{"video_id": "vid_A"}]
+        system.collector.get_video_daily_analytics.side_effect = KeyError("missing field")
+
+        with patch("youtube_automation.scripts.analytics_system.channel_dir", return_value=tmp_path):
+            result = system.collect_analytics_data(days=7, save_data=True)
+
+        # 失敗しても analytics_data 本体は返る（fail-open）
+        assert result == expected_data
+        # 動画×日次ファイルは保存されていない
+        daily_files = list((tmp_path / "data" / "analytics" / "daily_per_video").glob("*.json"))
+        assert len(daily_files) == 0
+
+    def test_video_daily_httperror_continues(self, system, tmp_path):
+        """動画×日次データ取得で HttpError 発生時は warning + 続行（fail-open）。
+
+        HttpError 専用分岐（`YouTubeAPIError.from_http_error` ラップ + warning + 続行）の検証。
+        """
+        system.authenticated = True
+        expected_data = {"views": 1000}
+        system.collector.collect_basic_analytics.return_value = expected_data
+        system.collector.get_all_channel_videos.return_value = [{"video_id": "vid_A"}]
+        # 内側ブロックで HttpError 発生 → 専用 catch で warning + 続行
+        system.collector.get_video_daily_analytics.side_effect = HttpError(
+            MagicMock(status=403), b"quotaExceeded"
+        )
+
+        with patch("youtube_automation.scripts.analytics_system.channel_dir", return_value=tmp_path):
+            result = system.collect_analytics_data(days=7, save_data=True)
+
+        # fail-open: analytics_data 本体は返る
+        assert result == expected_data
+        # 動画×日次ファイルは保存されていない
+        daily_files = list((tmp_path / "data" / "analytics" / "daily_per_video").glob("*.json"))
+        assert len(daily_files) == 0
+
+    def test_collector_httperror_returns_none(self, system):
+        """外周 HttpError 発生時は None を返す（fail-stop）。
+
+        外周 HttpError 専用分岐（`YouTubeAPIError.from_http_error` ラップ + logger.exception + None 返却）の検証。
+        """
+        system.authenticated = True
+        system.collector.collect_basic_analytics.side_effect = HttpError(
+            MagicMock(status=500), b"internalError"
+        )
+
+        result = system.collect_analytics_data(days=30)
+        # fail-stop: None が返る
         assert result is None
 
 
@@ -228,14 +311,12 @@ class TestRunDataCollection:
         assert result["success"] is False
         assert "error" in result
 
-    def test_data_collection_exception(self, system, mock_config):
-        """データ収集中に例外が発生した場合"""
+    def test_data_collection_exception_propagates(self, system, mock_config):
+        """collect_analytics_data からの例外は run_data_collection で握りつぶさず伝播する"""
         with patch("youtube_automation.scripts.analytics_system.load_config", return_value=mock_config):
             with (
                 patch.object(system, "authenticate", return_value=True),
-                patch.object(system, "collect_analytics_data", side_effect=Exception("Network error")),
+                patch.object(system, "collect_analytics_data", side_effect=RuntimeError("Network error")),
             ):
-                result = system.run_data_collection(days=30)
-
-        assert result["success"] is False
-        assert "error" in result
+                with pytest.raises(RuntimeError, match="Network error"):
+                    system.run_data_collection(days=30)


### PR DESCRIPTION
## Summary

## 概要

`src/youtube_automation/scripts/analytics_system.py` の 4 箇所で `except Exception as e: logger.error(f"... {e}")` 包括 catch + f-string ログが残存。CLAUDE.md「ドメイン例外を使う」規約違反、`AuthError` / `YouTubeAPIError` / `HttpError` が一律「文字列」に潰されてリトライ・分類が困難。

issue #171 (`oauth_handler`) と同パターンの hygiene 違反だが、対象ファイルが違うため別 issue として独立対応する。

## 該当箇所

- `src/youtube_automation/scripts/analytics_system.py:73-75`（`authenticate` 内）
- `src/youtube_automation/scripts/analytics_system.py:149-150`（動画×日次データ保存）
- `src/youtube_automation/scripts/analytics_system.py:155-157`（`collect_analytics_data` 全体）
- `src/youtube_automation/scripts/analytics_system.py:185-187`（results 集計）

```python
# 例: L73-75
except Exception as e:
    logger.error(f"❌ 認証エラー: {e}")
    return False
```

## 推奨対応

### 1. `authenticate` (L73)

```python
except (AuthError, YouTubeAPIError, ConfigError) as e:
    logger.error("認証エラー: %s", e)
    return False
```

`AuthError` は #171 で `utils/exceptions.py` に追加済み。

### 2. データ収集 (L149 / L155 / L185)

YouTube Data API / Analytics API の `HttpError` を catch し、既存パターン `YouTubeAPIError.from_http_error(e, ctx) from e` でラップ + `logger.exception` でスタックトレース保持。データ整合性エラー（`ValueError` / `KeyError`）は別 except に分離。

### 3. f-string → `%s` lazy 評価

`logger.error(f"... {e}")` は logger 評価対象なので `logger.error("... %s", e)` に統一（既存 `analytics_collector` パターン）。

## 参考
- 本 issue は #171 の `plan.md §スコープ外` で「同種の hygiene 違反だが別 issue 案件」として識別された箇所
- 既存パターン参照: `src/youtube_automation/utils/competitor_discovery.py:58` / `src/youtube_automation/utils/comments/fetcher.py:70`

### Labels
refactor

## Execution Report

Workflow `default-mini` completed successfully.

Closes #193