### PR TITLE
[#286] issue-286-fix-tests-pytest-de

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ build/
 .coverage
 .worktrees/
 
-# pytest 副作用: cost_tracker / lyria 系テストが sample_channel/data/ に書き残す（レビュー AI-NOTE-fixtures-data-leak）
-tests/fixtures/sample_channel/data/
-
 # Terraform
 terraform.tfvars
 *.tfstate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,25 @@
-"""
-pytest 設定 - テスト環境設定
+"""pytest 設定 - テスト環境設定
 
-テスト実行時に CHANNEL_DIR をテスト用フィクスチャに向ける。
-新 loader (`youtube_automation.utils.config`) のシングルトンを各テスト前後で
-リセットするため、autouse function-scope fixture を提供する。
+テスト実行時に `CHANNEL_DIR` を `tests/fixtures/sample_channel/` を **コピーした**
+tmp 配下に向けることで、`cost_tracker` などの実行ログが git 管理下の fixture を
+汚染しないようにする（issue #286）。
+
+`CHANNEL_DIR` を確定する処理はモジュールトップで実行する。
+session-scope の autouse fixture では、`tests/test_metadata_audit.py` のように
+**import 時点** で `channel_dir()` を呼び出すテストの collection phase に間に合わないため。
+
+ユーザが明示的に `CHANNEL_DIR` を指定している場合（例: 別 fixture をデバッグ用に
+向ける）はその指定を尊重し、コピー処理をスキップする。
+
+新 loader (`youtube_automation.utils.config`) のシングルトンは各テスト前後で
+function-scope の autouse fixture でリセットする。
 """
 
+import atexit
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -18,17 +30,31 @@ _SRC_DIR = _AUTOMATION_DIR / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
-# テスト用フィクスチャディレクトリ
-_CHANNEL_DIR = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
+# テスト用フィクスチャディレクトリ（git 管理下のオリジナル）
+_FIXTURE_CHANNEL_DIR = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
 
 
-@pytest.fixture(autouse=True, scope="session")
-def set_channel_dir():
-    """テストセッション全体で CHANNEL_DIR を設定する"""
-    os.environ.setdefault("CHANNEL_DIR", str(_CHANNEL_DIR))
-    # USD→JPY レートはテストでは固定値にしてネットワーク依存を外す
-    os.environ.setdefault("JPY_PER_USD", "160")
-    yield
+def _prepare_isolated_channel_dir() -> None:
+    """`CHANNEL_DIR` を tmp 配下の sample_channel コピーに向ける。
+
+    既存 env 上書きがあれば尊重する（setdefault 相当）。
+    tmp dir は `atexit` で session 終了時に削除する。
+    """
+    if os.environ.get("CHANNEL_DIR"):
+        return
+
+    tmp_root = Path(tempfile.mkdtemp(prefix="yt-automation-tests-"))
+    atexit.register(shutil.rmtree, tmp_root, ignore_errors=True)
+
+    isolated = tmp_root / "sample_channel"
+    shutil.copytree(_FIXTURE_CHANNEL_DIR, isolated)
+    os.environ["CHANNEL_DIR"] = str(isolated)
+
+
+_prepare_isolated_channel_dir()
+
+# USD→JPY レートはテストでは固定値にしてネットワーク依存を外す
+os.environ.setdefault("JPY_PER_USD", "160")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_generate_music_dj.py
+++ b/tests/test_generate_music_dj.py
@@ -25,19 +25,6 @@ from youtube_automation.scripts.generate_music_dj import (
 from youtube_automation.utils.exceptions import ConfigError
 
 
-@pytest.fixture(autouse=True)
-def _silence_cost_tracker(monkeypatch):
-    """generate_segmented 経由の cost_tracker 副作用を抑止し、sample_channel/data/ への pollution を防ぐ (Issue #170)。"""
-    monkeypatch.setattr(
-        "youtube_automation.scripts.generate_music_dj.cost_tracker.log_generation",
-        lambda *a, **kw: None,
-    )
-    monkeypatch.setattr(
-        "youtube_automation.scripts.generate_music_dj.cost_tracker.print_last_report",
-        lambda *a, **kw: None,
-    )
-
-
 def make_composition(phases_count=6, total_min=60, *, base_extras=None, phase_extras_by_index=None):
     """テスト用 composition を生成。
 

--- a/tests/test_image_provider_gemini.py
+++ b/tests/test_image_provider_gemini.py
@@ -108,19 +108,6 @@ def patched_genai_client():
 
 
 @pytest.fixture(autouse=True)
-def _silence_cost_tracker(monkeypatch):
-    """テスト中の cost_tracker.log_generation 副作用を抑止。"""
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.gemini.cost_tracker.log_generation",
-        lambda *a, **kw: {"estimated_cost_usd": 0.101, "category": "image", "model": kw.get("model", "")},
-    )
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.gemini.cost_tracker.print_last_report",
-        lambda *a, **kw: None,
-    )
-
-
-@pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
     """リトライバックオフを高速化（time.sleep を no-op に）。"""
     monkeypatch.setattr(

--- a/tests/test_image_provider_openai.py
+++ b/tests/test_image_provider_openai.py
@@ -96,19 +96,6 @@ def _stub_openai_api_key(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _silence_cost_tracker(monkeypatch):
-    """テスト中は cost_tracker への書き込みを抑止。"""
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.openai.cost_tracker.log_generation",
-        lambda *a, **kw: {"estimated_cost_usd": 0.21, "category": "image", "model": kw.get("model", "")},
-    )
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.openai.cost_tracker.print_last_report",
-        lambda *a, **kw: None,
-    )
-
-
-@pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
     """リトライバックオフを高速化。"""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

## 症状

`uv run pytest tests/` を実行すると、毎回 `tests/fixtures/sample_channel/data/audio_costs.json` に
コスト追跡レコードが append され、`git status` で modified として検出される。

git diff の例:

```
+  {
+    "timestamp": "2026-05-13T23:08:26.574471+00:00",
+    "category": "audio",
+    "model": "lyria-3-pro-preview",
+    "quantity": 1,
+    "unit": "song",
+    "estimated_cost_usd": 0.08,
+    "metadata": {
+      "phase_name": "phase_1",
+      "segment": "seg_001",
+      "output_file": "/private/var/folders/.../pytest-of-mba/pytest-76/test_generates_all_segments_an0/seg_001.wav"
+    }
+  },
```

PR 作成時に `git add .` で誤って混入し、レビューノイズになる。umbrella #260 の #180 対応中に 2 回ほど
revert が必要だった。

## 原因（推測）

Lyria 関連のコスト追跡を行うテストが、本物の fixture `audio_costs.json` を append モードで書き込んでいる。
本来テストは一時ディレクトリ (`tmp_path`) に書き込むべきだが、設定 or 実装が fixture 実体を見ている。

該当テストの推定: `tests/test_generate_lyria_master.py` 周辺（`phase_1` / `seg_001` のメタデータから推測）。

## 対応案

- **(A) cost 追跡先パスを `tmp_path` 派生にして fixture を汚染しない（テスト側修正）** — 推奨
- (B) `tests/fixtures/sample_channel/data/audio_costs.json` を `.gitignore` に追加（fixture の意味が薄れる）
- (C) 各テストの teardown で fixture を git の状態に restore（hack 寄り）

(A) が筋。`utils/cost_tracker` 系の保存先がチャンネル設定経由で決まるなら、テスト用 `conftest.py` で
`CHANNEL_DIR` 配下の `data/audio_costs.json` を tmp に逃がす形にする。

## 影響

- PR ノイズ（毎 PR で revert 必要）
- CI が clean tree を要求するなら通らない可能性
- レビュー時の誤コミットリスク（fixture に意図せず実行ログが永続化）

## 関連

- umbrella #260 の #180 対応中に発見（PR #285）

## Execution Report

Workflow `default-mini` completed successfully.

Closes #286