### PR TITLE
[#211] issue-211-fix-streaming-health

### DIFF
--- a/docs/streaming-healthcheck.md
+++ b/docs/streaming-healthcheck.md
@@ -13,6 +13,21 @@
 | `inactive+dead+success` | `manual` | しない |
 | その他（`Result≠success` 等） | `anomaly` | **送る** |
 
+## 状態変化チェック（連打防止）
+
+`healthcheck.sh` は cron が 5 分間隔で常時走るため、`anomaly` が続く間に毎回通知すると Discord が連打される（5/8 インシデント発覚）。これを抑止するため、前回の classify 結果を `/var/lib/youtube-stream/last_status` に保存し、**状態が変化したときだけ** 通知する:
+
+| 前回 → 今回 | 通知 | メッセージ |
+|---|---|---|
+| `unknown` → `ok`/`idle`/`manual` | しない | （初回起動の通常確認） |
+| `unknown` → `anomaly` | **送る** | `[youtube-stream] anomaly detected: ...` |
+| `ok`/`idle`/`manual` → 同種類 or 別の正常系 | しない | （平常運用） |
+| `ok`/`idle`/`manual` → `anomaly` | **送る** | `[youtube-stream] anomaly detected: ...` |
+| `anomaly` → `anomaly` | しない | （連打防止） |
+| `anomaly` → `ok`/`idle`/`manual` | **送る** | `[youtube-stream] recovered: <new>` |
+
+`unknown` は `last_status` ファイル不在時のフォールバック値（VPS 再構築直後など）。初回 `ok` は無音、初回 `anomaly` は 1 通だけ通知が来る。
+
 ## テストシナリオ
 
 ### シナリオ 1: `kill -9` による異常停止
@@ -109,6 +124,15 @@ ls -l /etc/youtube-stream-healthcheck.env
 # cron が動いているか
 systemctl status cron
 grep CRON /var/log/syslog | tail
+```
+
+### `last_status` ファイルが破損 / 不整合
+
+`/var/lib/youtube-stream/last_status` には `ok` / `idle` / `manual` / `anomaly` のいずれか 1 行が入る。手動編集や破損で値が壊れた場合は削除すれば次回 cron で再生成される（`unknown` フォールバックで動く）:
+
+```bash
+# 強制リセット（次回 cron で classify 結果が ok ならそのまま無音、anomaly なら 1 通通知）
+rm -f /var/lib/youtube-stream/last_status
 ```
 
 ### ログが肥大化している

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -108,6 +108,8 @@ resource "null_resource" "deploy" {
       "chmod 0600 /etc/youtube-stream-healthcheck.env",
       "chown root:root /etc/youtube-stream-healthcheck.env",
       "chmod 0644 /etc/cron.d/youtube-stream-healthcheck /etc/logrotate.d/youtube-stream",
+      # 止血措置として手動 rename された .disabled 残骸を除去（merge 後の cron 自動再開のため）
+      "rm -f /etc/cron.d/youtube-stream-healthcheck.disabled",
       "systemctl daemon-reload",
       "systemctl enable --now youtube-stream",
       "systemctl restart youtube-stream",

--- a/scripts/streaming/healthcheck.sh
+++ b/scripts/streaming/healthcheck.sh
@@ -7,6 +7,9 @@
 #   manual  : inactive+dead+success    （systemctl stop）
 #   anomaly : 上記以外                 （kill -9 / failed / Result≠success など）
 #
+# 状態変化チェック（連打防止）: 前回 classify 結果を $STATE_DIR/last_status に保存し、
+# anomaly 突入時と anomaly からの復帰時のみ通知する。同種類の連続は無音。
+#
 # cron は最小 PATH（/usr/bin:/bin）で実行されるため、systemctl 等が見つかるよう PATH を明示宣言する。
 
 set -euo pipefail
@@ -41,6 +44,57 @@ classify_status() {
   echo "anomaly"
 }
 
+# stdin の `KEY=VALUE` 行（systemctl show -p ... 出力）を読み、
+# ActiveState/SubState/Result を呼び出し元 scope の active/sub/result 変数にセットする。
+# `systemctl show ... --value` は property 引数順序を保証しないため `KEY=VALUE` 形式で
+# パースする（順序非依存）。process substitution `< <(...)` で呼ぶ前提。
+parse_systemctl_kv() {
+  active=""
+  sub=""
+  result=""
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      ActiveState=*) active="${line#*=}" ;;
+      SubState=*)    sub="${line#*=}" ;;
+      Result=*)      result="${line#*=}" ;;
+    esac
+  done
+}
+
+# 前回 classify 結果と今回 classify 結果から通知アクションを決める純関数。
+# 戻り値（stdout に 1 行 echo）:
+#   ""         : 通知しない
+#   "anomaly"  : anomaly 突入（[youtube-stream] anomaly detected: ...）
+#   "recovered": anomaly からの復帰（[youtube-stream] recovered: <new>）
+#
+# 遷移表:
+#   prev\current | ok/idle/manual | anomaly
+#   -------------|----------------|--------
+#   unknown      | ""             | anomaly   (初回は ok/idle/manual を無音、anomaly のみ通知)
+#   ok/idle/manual | ""           | anomaly
+#   anomaly      | recovered      | ""        (連打防止)
+decide_notification() {
+  local prev="$1"
+  local current="$2"
+
+  if [[ "$current" == "anomaly" ]]; then
+    if [[ "$prev" == "anomaly" ]]; then
+      echo ""
+    else
+      echo "anomaly"
+    fi
+    return
+  fi
+
+  # current is ok/idle/manual
+  if [[ "$prev" == "anomaly" ]]; then
+    echo "recovered"
+  else
+    echo ""
+  fi
+}
+
 # source されたとき（bash 関数の単体テスト用）はここで終了する。
 # BASH_SOURCE[0] と $0 が一致する場合のみ「直接実行」。
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
@@ -48,24 +102,33 @@ if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
 fi
 
 readonly UNIT="youtube-stream"
+# STATE_DIR は本番では /var/lib/youtube-stream 固定。テスト時のみ YT_STREAM_STATE_DIR で override。
+readonly STATE_DIR="${YT_STREAM_STATE_DIR:-/var/lib/youtube-stream}"
+readonly LAST_STATUS_FILE="${STATE_DIR}/last_status"
 
-# systemctl show -p ActiveState -p SubState -p Result --value は 3 行を順番に返す
-mapfile -t _values < <(systemctl show "$UNIT" -p ActiveState -p SubState -p Result --value)
-active="${_values[0]}"
-sub="${_values[1]}"
-result="${_values[2]}"
+mkdir -p "$STATE_DIR"
+
+# 順序非依存パース（KEY=VALUE 形式）。process substitution で親 scope に変数を反映させる。
+parse_systemctl_kv < <(systemctl show "$UNIT" -p ActiveState -p SubState -p Result)
 
 status="$(classify_status "$active" "$sub" "$result")"
 
-case "$status" in
-  ok|idle|manual)
-    # 通知しない（cron 出力もしない: 正常時は無音）
-    exit 0
-    ;;
+# 初回・破損時は unknown フォールバック（decide_notification の遷移表に従う）
+prev="$(cat "$LAST_STATUS_FILE" 2>/dev/null || echo unknown)"
+action="$(decide_notification "$prev" "$status")"
+
+case "$action" in
   anomaly)
     msg="[youtube-stream] anomaly detected: ActiveState=${active} SubState=${sub} Result=${result}"
     logger -t youtube-stream-healthcheck -- "$msg" || true
     "$(dirname "$0")/notify.sh" "$msg"
-    exit 0
+    ;;
+  recovered)
+    msg="[youtube-stream] recovered: ${status}"
+    logger -t youtube-stream-healthcheck -- "$msg" || true
+    "$(dirname "$0")/notify.sh" "$msg"
     ;;
 esac
+
+# 通知有無に関わらず毎回保存（次回 cron の prev として使う）
+printf '%s\n' "$status" > "$LAST_STATUS_FILE"

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -271,8 +271,10 @@ class TestHealthcheckShBehavior:
         """偽 systemctl + 偽 notify.sh を配置した tmp 環境を構築する。
 
         ``systemctl`` は ``ActiveState=...\\nSubState=...\\nResult=...`` を
-        ``--value`` 形式で 3 行出力する偽実装にする。値は環境変数経由で差し替える。
-        ``notify.sh`` は呼ばれたら ``called`` ファイルにメッセージを書き込むだけ。
+        ``KEY=VALUE`` 形式で 3 行出力する偽実装にする（順序非依存パースを反映）。値は環境
+        変数経由で差し替える。``notify.sh`` は呼ばれたら ``called`` ファイルにメッセージを
+        書き込むだけ。``state_dir`` は ``YT_STREAM_STATE_DIR`` で healthcheck.sh に渡し、
+        ``last_status`` ファイルを tmp 配下に閉じ込める。
         """
         if not _HEALTHCHECK_SH.exists():
             pytest.skip("healthcheck.sh が未作成のため skip")
@@ -282,16 +284,19 @@ class TestHealthcheckShBehavior:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
 
+        state_dir = tmp_path / "state"
+
         called_marker = tmp_path / "notify_called.log"
 
         # 偽 systemctl（環境変数 FAKE_ACTIVE / FAKE_SUB / FAKE_RESULT を読み出す）
+        # 順序非依存パースに合わせて KEY=VALUE 形式で出力する。
         fake_systemctl = bin_dir / "systemctl"
         fake_systemctl.write_text(
             "#!/usr/bin/env bash\n"
-            "# 偽 systemctl: -p ActiveState -p SubState -p Result --value のとき値を 3 行出力\n"
-            'echo "${FAKE_ACTIVE:-active}"\n'
-            'echo "${FAKE_SUB:-running}"\n'
-            'echo "${FAKE_RESULT:-success}"\n'
+            "# 偽 systemctl: -p ActiveState -p SubState -p Result のとき KEY=VALUE で 3 行出力\n"
+            'echo "ActiveState=${FAKE_ACTIVE:-active}"\n'
+            'echo "SubState=${FAKE_SUB:-running}"\n'
+            'echo "Result=${FAKE_RESULT:-success}"\n'
         )
         fake_systemctl.chmod(0o755)
 
@@ -313,6 +318,7 @@ class TestHealthcheckShBehavior:
             "bin_dir": bin_dir,
             "called_marker": called_marker,
             "healthcheck": shimmed_healthcheck,
+            "state_dir": state_dir,
         }
 
     def _run_with_state(
@@ -330,6 +336,8 @@ class TestHealthcheckShBehavior:
         env["FAKE_ACTIVE"] = active
         env["FAKE_SUB"] = sub
         env["FAKE_RESULT"] = result
+        # last_status を tmp に閉じ込める（本番では /var/lib/youtube-stream/last_status）
+        env["YT_STREAM_STATE_DIR"] = str(fake_env["state_dir"])
         return subprocess.run(
             ["bash", str(fake_env["healthcheck"])],
             capture_output=True,
@@ -386,6 +394,176 @@ class TestHealthcheckShBehavior:
         # メッセージが空でないこと
         called_text = fake_env["called_marker"].read_text()
         assert called_text.strip(), "notify.sh が空メッセージで呼ばれた（Discord 表示が無意味）"
+
+    def test_consecutive_anomaly_does_not_renotify(self, fake_env):
+        """Given 1 回目で anomaly 通知が発火、last_status に "anomaly" が保存された後
+        When 2 回目も anomaly 状態で healthcheck.sh を実行する
+        Then notify.sh は 2 回目では呼ばれない（連打防止）。
+
+        order.md「anomaly → anomaly は無音（連打防止）」要件の core test。
+        """
+        # 1 回目: unknown → anomaly で通知
+        self._run_with_state(fake_env, active="failed", sub="failed", result="core-dump")
+        assert fake_env["called_marker"].exists(), "1 回目の anomaly で notify が呼ばれていない"
+        first_call_size = fake_env["called_marker"].stat().st_size
+
+        # 2 回目: anomaly → anomaly で無音
+        proc = self._run_with_state(fake_env, active="failed", sub="failed", result="core-dump")
+        assert proc.returncode == 0
+        second_call_size = fake_env["called_marker"].stat().st_size
+        assert second_call_size == first_call_size, (
+            "anomaly → anomaly でも notify が再度呼ばれた（5 分ごと連打）"
+        )
+
+    def test_recovered_from_anomaly_calls_notify(self, fake_env):
+        """Given 1 回目で anomaly 状態（last_status に "anomaly" が保存される）
+        When 2 回目に ok 状態（active+running+success）で healthcheck.sh を実行する
+        Then notify.sh が呼ばれ、メッセージに "recovered" が含まれる。
+
+        order.md「anomaly → ok/idle/manual の遷移で "recovered: <new>" 通知」要件。
+        """
+        # 1 回目: anomaly
+        self._run_with_state(fake_env, active="failed", sub="failed", result="core-dump")
+        first_text = fake_env["called_marker"].read_text()
+
+        # 2 回目: anomaly → ok で recovered 通知
+        proc = self._run_with_state(fake_env, active="active", sub="running", result="success")
+        assert proc.returncode == 0
+        assert fake_env["called_marker"].exists(), (
+            "anomaly → ok の復帰で notify が呼ばれていない（recovered 通知欠損）"
+        )
+        full_text = fake_env["called_marker"].read_text()
+        new_text = full_text[len(first_text):]
+        assert "recovered" in new_text, (
+            f"recovered メッセージが notify に渡されていない: {new_text!r}"
+        )
+        assert "ok" in new_text, f"recovered メッセージに復帰先 'ok' が含まれない: {new_text!r}"
+
+    def test_initial_ok_does_not_call_notify(self, fake_env):
+        """Given last_status ファイル不在（VPS 再構築直後など）
+        When healthcheck.sh を初回 ok 状態で実行する
+        Then notify.sh は呼ばれない（unknown → ok は同種類扱い、initial state confirmation）。
+        """
+        assert not (fake_env["state_dir"] / "last_status").exists(), (
+            "前提: last_status が事前に存在してはいけない"
+        )
+        proc = self._run_with_state(fake_env, active="active", sub="running", result="success")
+        assert proc.returncode == 0
+        assert not fake_env["called_marker"].exists(), (
+            "初回 ok で notify が呼ばれた（unknown→ok は無音であるべき）"
+        )
+
+    def test_state_dir_is_created_if_missing(self, fake_env):
+        """Given STATE_DIR が存在しない
+        When healthcheck.sh を実行する
+        Then mkdir -p で STATE_DIR が作成され、last_status が書き込まれる。
+        """
+        assert not fake_env["state_dir"].exists(), "前提: state_dir が事前に存在してはいけない"
+        proc = self._run_with_state(fake_env, active="active", sub="running", result="success")
+        assert proc.returncode == 0, f"healthcheck.sh が non-zero: {proc.stderr}"
+        last_status = fake_env["state_dir"] / "last_status"
+        assert last_status.exists(), "STATE_DIR/last_status が作成されていない"
+        assert last_status.read_text().strip() == "ok", (
+            f"last_status の内容が想定外: {last_status.read_text()!r}"
+        )
+
+
+class TestHealthcheckShOrderIndependentParse:
+    """``parse_systemctl_kv`` 関数の順序非依存性。
+
+    `systemctl show ... --value` の引数順序非保証バグの真因に対する単体検証。
+    全 6 順列（3! = 6）を網羅し、どの順序でも ActiveState/SubState/Result が
+    正しい変数に割り当てられることを担保する。
+    """
+
+    @pytest.mark.parametrize(
+        "lines",
+        [
+            ("ActiveState=active", "SubState=running", "Result=success"),
+            ("ActiveState=active", "Result=success", "SubState=running"),
+            ("SubState=running", "ActiveState=active", "Result=success"),
+            ("SubState=running", "Result=success", "ActiveState=active"),
+            ("Result=success", "ActiveState=active", "SubState=running"),
+            ("Result=success", "SubState=running", "ActiveState=active"),
+        ],
+    )
+    def test_parses_kv_regardless_of_line_order(self, lines: tuple[str, str, str]):
+        """Given KEY=VALUE 形式の 3 行（順序は任意）
+        When parse_systemctl_kv を呼ぶ
+        Then active=active, sub=running, result=success が呼び出し元 scope にセットされる。
+        """
+        if not _HEALTHCHECK_SH.exists():
+            pytest.skip("healthcheck.sh が未作成のため skip")
+        # heredoc に行を流し込んで parse_systemctl_kv を呼び、結果を 3 行 echo する
+        heredoc_body = "\n".join(lines)
+        snippet = (
+            f'source "{_HEALTHCHECK_SH}"\n'
+            f'parse_systemctl_kv <<EOF\n{heredoc_body}\nEOF\n'
+            'echo "active=$active"\n'
+            'echo "sub=$sub"\n'
+            'echo "result=$result"\n'
+        )
+        proc = _run_bash(snippet)
+        assert proc.returncode == 0, f"parse_systemctl_kv が non-zero: {proc.stderr}"
+        out = proc.stdout
+        assert "active=active" in out, f"active が正しく束ねられていない: {out!r}"
+        assert "sub=running" in out, f"sub が正しく束ねられていない: {out!r}"
+        assert "result=success" in out, f"result が正しく束ねられていない: {out!r}"
+
+
+class TestHealthcheckShStateChange:
+    """``decide_notification`` 関数の遷移判定（state-change ロジック）。
+
+    order.md 遷移表:
+      prev\\current | ok/idle/manual | anomaly
+      -------------|----------------|--------
+      unknown      | ""             | anomaly
+      ok/idle/manual | ""           | anomaly
+      anomaly      | recovered      | ""
+    """
+
+    @pytest.mark.parametrize(
+        "prev,current,expected",
+        [
+            # 初回（last_status 不在）
+            ("unknown", "ok", ""),
+            ("unknown", "anomaly", "anomaly"),
+            # 同種類の連続は無音
+            ("ok", "ok", ""),
+            ("idle", "idle", ""),
+            ("manual", "manual", ""),
+            # ok/idle/manual 間の遷移も無音（同 "正常" カテゴリ）
+            ("ok", "idle", ""),
+            ("manual", "ok", ""),
+            # → anomaly は通知
+            ("ok", "anomaly", "anomaly"),
+            ("idle", "anomaly", "anomaly"),
+            ("manual", "anomaly", "anomaly"),
+            # anomaly → 正常系は recovered
+            ("anomaly", "ok", "recovered"),
+            ("anomaly", "idle", "recovered"),
+            ("anomaly", "manual", "recovered"),
+            # anomaly 連打抑止
+            ("anomaly", "anomaly", ""),
+        ],
+    )
+    def test_decide_notification(self, prev: str, current: str, expected: str):
+        """Given (prev, current) の組み合わせ
+        When decide_notification を呼ぶ
+        Then 期待アクション（""/"anomaly"/"recovered"）を 1 行 echo する。
+        """
+        if not _HEALTHCHECK_SH.exists():
+            pytest.skip("healthcheck.sh が未作成のため skip")
+        snippet = (
+            f'source "{_HEALTHCHECK_SH}"\n'
+            f'decide_notification "{prev}" "{current}"\n'
+        )
+        proc = _run_bash(snippet)
+        assert proc.returncode == 0, f"decide_notification が non-zero: {proc.stderr}"
+        assert proc.stdout.strip() == expected, (
+            f"({prev!r}, {current!r}) の判定が期待値と異なる: "
+            f"got={proc.stdout.strip()!r}, expected={expected!r}"
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

## 現象

`scripts/streaming/healthcheck.sh` が `youtube-stream.service` を **常時 anomaly 判定** し、cron (`*/5`) 経由で 5 分ごとに Discord へ誤通知が飛び続ける。実機 (Ubuntu 24.04 / systemd 256) の syslog より:

```
2026-05-08T01:30:01 youtube-stream-healthcheck: [youtube-stream] anomaly detected: ActiveState=success SubState=active Result=running
2026-05-08T01:35:01 youtube-stream-healthcheck: [youtube-stream] anomaly detected: ActiveState=success SubState=active Result=running
```

## 真因

`healthcheck.sh:53` の `systemctl show -p A -p B -p C --value` は **property の引数順序を保証しない**。実機では `Result, ActiveState, SubState` の順で値が返ってくるため、`active` / `sub` / `result` 変数が swap される:

```bash
mapfile -t _values < <(systemctl show "$UNIT" -p ActiveState -p SubState -p Result --value)
active="${_values[0]}"   # 期待: "active" / 実態: "success"
sub="${_values[1]}"      # 期待: "running" / 実態: "active"
result="${_values[2]}"   # 期待: "success" / 実態: "running"
```

→ classify_status は ok / idle / manual のどれにも該当せず常に `anomaly` を返す。

## 影響

- 配信本体 (`ffmpeg → RTMP`) は動き続ける（healthcheck は副作用ない）
- Discord に **5 分ごと** 通知が飛び続け、運用者が気づくまで連打される
- 真の anomaly が来てもオオカミ少年化して埋もれる
- 5/8 のインシデント対応中に発覚（VPS 再構築直後の状態確認で、最初に来た anomaly 通知が偽陽性だった）

## 修正方針

### 1. 順序非依存化

`--value` を外して `KEY=VALUE` 形式で取得し、case でパース:

```bash
mapfile -t _kv < <(systemctl show "$UNIT" -p ActiveState -p SubState -p Result)
for line in "${_kv[@]}"; do
  case "$line" in
    ActiveState=*) active="${line#*=}" ;;
    SubState=*)    sub="${line#*=}" ;;
    Result=*)      result="${line#*=}" ;;
  esac
done
```

### 2. 状態変化チェック追加（連打防止）

5 分ポーリングを保ちつつ、`/var/lib/youtube-stream/last_status` に前回値を保存して **状態が変化したときのみ** 通知:

| 遷移 | 通知 |
|---|---|
| ok/idle/manual ⇄ 同種類 | 無音 |
| → anomaly | "[youtube-stream] anomaly detected: ..." |
| anomaly → ok/idle/manual | "[youtube-stream] recovered: <new>" |
| anomaly → anomaly | 無音（連打防止） |

### 3. テスト

`tests/test_streaming_healthcheck.py` 等で:
- `classify_status` の単体テスト（順序非依存性をパラメタライズで担保）
- state-change の単体テスト（前回値ファイル mock）

## 運用補足

- VPS 再構築時に `last_status` ファイルがリセット → 初回 cron で `unknown → ok` 遷移として 1 通通知が来るが、これは妥当な挙動
- `cloud-init.yaml` で `/var/lib/youtube-stream/` を作成しておくか、healthcheck.sh 内で `mkdir -p` する
- merge 後は `null_resource.deploy.triggers.healthcheck_sh = filemd5(...)` のハッシュ変化で apply 時に再デプロイされる
- 現状本番 VPS の cron は止血措置として `/etc/cron.d/youtube-stream-healthcheck.disabled` にリネーム済み。merge 後の apply で新規配置されて自動再開する想定（または provisioner に `rm -f /etc/cron.d/youtube-stream-healthcheck.disabled` を追加）

## 関連

- 5/8 インシデント対応中に発覚（VPS 再構築 + ストリームキーローテーション）
- `priority: high` 相当: 監視の信頼性が壊れている

## Execution Report

Workflow `default-mini` completed successfully.

Closes #211