### PR TITLE
fix(claude): takt 経由の .claude/skills 編集が permission denied になる問題を修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Edit(.claude/skills/**)",
+      "Write(.claude/skills/**)",
+      "MultiEdit(.claude/skills/**)",
+      "Edit(.claude/CLAUDE.template.md)",
+      "Write(.claude/CLAUDE.template.md)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- takt セッションで `.claude/skills/<name>/SKILL.md` 等への Edit/Write が `Claude requested permissions to write to ... but you haven't granted it yet.` で拒否される問題を修正。
- project スコープの `.claude/settings.json` を新設し、`.claude/skills/**` と `.claude/CLAUDE.template.md` への Edit/Write/MultiEdit を allow に追加。

## 根本原因

takt は Claude Agent SDK を `settingSources: ['project']` 固定で呼び出すため (`takt/dist/infra/claude/options-builder.js:48`)、global `~/.claude/settings.json` の blanket allow (`Edit(//**)` / `Write(//**)`) は読まれない。本リポジトリには project 共通設定の `.claude/settings.json` が存在せず、`.claude/settings.local.json` も narrow allow しか持たなかったため、`acceptEdits` モードでも `.claude/` 配下は SDK の built-in 保護で必ず拒否されていた。

## 証拠 (実セッションログ)

| issue | session jsonl | `.claude/skills/**` への denial 件数 |
|---|---|---|
| #212 | `55e85c92-...jsonl` | 7 件 (SKILL.md, SKILL.md.new) |
| #229 | `c014d0ba-...jsonl` | 12 件 (SKILL.md, references/, references/.gitkeep, references/swap_video.sh) |

denial 対象はすべて `.claude/skills/streaming/...` のみ。同コミットで変更された `infra/terraform/streaming/main.tf` 等は denial 一切なし → `.claude/` 限定保護が裏付けられる。

## 修正内容

`.claude/settings.json` を新規追加:

```json
{
  "permissions": {
    "allow": [
      "Edit(.claude/skills/**)",
      "Write(.claude/skills/**)",
      "MultiEdit(.claude/skills/**)",
      "Edit(.claude/CLAUDE.template.md)",
      "Write(.claude/CLAUDE.template.md)"
    ]
  }
}
```

`settingSources: ['project']` 経由で takt セッション (worktree) でも読まれるため、`.claude/skills/**` への編集が allow される。

## Test plan

- [ ] takt の dummy issue で `.claude/skills/<name>/SKILL.md` を編集するワークフローを回し、denial が出ないことを確認
- [ ] 既存の通常 Claude Code セッションでも skill 編集に regression が無いか確認
- [ ] 下流チャンネルリポジトリへの `yt-skills sync` 配布対象に影響しないことを確認 (`_skills/` には `.claude/settings.json` は含めない想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)