### PR TITLE
docs(claude): skill 編集は takt 経由で行わない運用ルールを CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,11 @@ collections/            # コンテンツ成果物
 - **commit 規約**: 日本語 Conventional Commits + タイトル末尾に `(#<N>)`。`commit-convention` スキル参照
 - **takt 設定**: リポジトリ固有 `.takt/config.yaml`（`draft_pr: false`）、グローバル `~/.takt/config.yaml`（`provider: claude`, `language: ja`）
 - workflow は組み込み **default**（plan → review → ... → reviewers の 9 step）
+
+### skill 編集は takt 経由で行わない
+
+`.claude/skills/**` を含む `.claude/` 配下は Claude Code の **protected paths**（`acceptEdits` モードでも write 時に必ず prompt が出る領域）に該当する。takt は Claude Agent SDK を `settingSources: ['project']` + `permissionMode: 'acceptEdits'` で呼ぶため prompt に答える人間がおらず、`.claude/skills/<name>/SKILL.md` 等への Edit/Write は必ず `Claude requested permissions to write to ..., but you haven't granted it yet.` で deny される（`permissions.allow` ルールでは bypass 不可、`bypassPermissions` のみが bypass）。
+
+そのため **skill 関連の修正は takt にやらせず、通常の Claude Code 対話セッション（cmux pane 等）で直接行う**。Claude Code 対話セッションでは prompt に手動 Allow できるため、`.claude/skills/**` への編集が通る。コミット・PR 作成は `commit-convention` / `pr` スキル経由で実施する。
+
+例外: `.claude/skills/` 配下を一切編集しない issue（純粋にコードや config のみ触る）は takt 経由で問題なく回せる。


### PR DESCRIPTION
## Summary

- `.claude/skills/**` を含む `.claude/` 配下は Claude Code の **protected paths** で、`acceptEdits` モードでも書き込みに prompt が出る。
- takt は SDK モードで Claude を spawn し prompt に応答できないため、`.claude/skills/<name>/SKILL.md` 等の編集が必ず deny される。
- `permissions.allow` ルールでは bypass 不可 (#304 で実機検証済み)。
- → **skill 関連の修正は takt にやらせず、Claude Code 対話セッションで直接行う**運用ルールを CLAUDE.md「開発ワークフロー」節に追記する。

## 背景: 経緯まとめ

| step | 内容 |
|---|---|
| 1 | ユーザー報告「takt で skill が修正できない」を受け原因調査 |
| 2 | takt の `settingSources: ['project']` 固定 + automation に `.claude/settings.json` 未配置を仮説に PR #304 で `Edit(.claude/skills/**)` allow rule を追加 |
| 3 | 実 session log で issue #212 (7 件) / #229 (12 件) の denial を確認 — `.claude/skills/**` のみが対象 |
| 4 | issue #305 で fix を実機検証 → **同じく 13 件 denial で failed** |
| 5 | Claude Code 公式ドキュメントで `.claude/` が **protected paths** であり `acceptEdits` でも保護される旨を確認 |
| 6 | PR #304 / issue #305 を close、本 PR で運用ルール明文化 |

## Test plan

- [ ] CLAUDE.md の追加節がレンダリング上違和感ないか目視確認
- [ ] takt 経由で skill 以外（コードのみ）の issue を回したとき、追加節が影響しないことを確認 (informational change のため挙動変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)