### PR TITLE
[#286] fix(tests): conftest を tmp_path 隔離化 (#291 rebase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ build/
 .coverage
 .worktrees/
 
-# pytest 副作用: cost_tracker / lyria 系テストが sample_channel/data/ に書き残す（レビュー AI-NOTE-fixtures-data-leak）
-tests/fixtures/sample_channel/data/
-
 # Terraform
 terraform.tfvars
 *.tfstate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,25 @@
-"""
-pytest 設定 - テスト環境設定
+"""pytest 設定 - テスト環境設定
 
-テスト実行時に CHANNEL_DIR をテスト用フィクスチャに向ける。
-新 loader (`youtube_automation.utils.config`) のシングルトンを各テスト前後で
-リセットするため、autouse function-scope fixture を提供する。
+テスト実行時に `CHANNEL_DIR` を `tests/fixtures/sample_channel/` を **コピーした**
+tmp 配下に向けることで、`cost_tracker` などの実行ログが git 管理下の fixture を
+汚染しないようにする（issue #286）。
+
+`CHANNEL_DIR` を確定する処理はモジュールトップで実行する。
+session-scope の autouse fixture では、`tests/test_metadata_audit.py` のように
+**import 時点** で `channel_dir()` を呼び出すテストの collection phase に間に合わないため。
+
+ユーザが明示的に `CHANNEL_DIR` を指定している場合（例: 別 fixture をデバッグ用に
+向ける）はその指定を尊重し、コピー処理をスキップする。
+
+新 loader (`youtube_automation.utils.config`) のシングルトンは各テスト前後で
+function-scope の autouse fixture でリセットする。
 """
 
+import atexit
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -18,17 +30,31 @@ _SRC_DIR = _AUTOMATION_DIR / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
-# テスト用フィクスチャディレクトリ
-_CHANNEL_DIR = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
+# テスト用フィクスチャディレクトリ（git 管理下のオリジナル）
+_FIXTURE_CHANNEL_DIR = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
 
 
-@pytest.fixture(autouse=True, scope="session")
-def set_channel_dir():
-    """テストセッション全体で CHANNEL_DIR を設定する"""
-    os.environ.setdefault("CHANNEL_DIR", str(_CHANNEL_DIR))
-    # USD→JPY レートはテストでは固定値にしてネットワーク依存を外す
-    os.environ.setdefault("JPY_PER_USD", "160")
-    yield
+def _prepare_isolated_channel_dir() -> None:
+    """`CHANNEL_DIR` を tmp 配下の sample_channel コピーに向ける。
+
+    既存 env 上書きがあれば尊重する（setdefault 相当）。
+    tmp dir は `atexit` で session 終了時に削除する。
+    """
+    if os.environ.get("CHANNEL_DIR"):
+        return
+
+    tmp_root = Path(tempfile.mkdtemp(prefix="yt-automation-tests-"))
+    atexit.register(shutil.rmtree, tmp_root, ignore_errors=True)
+
+    isolated = tmp_root / "sample_channel"
+    shutil.copytree(_FIXTURE_CHANNEL_DIR, isolated)
+    os.environ["CHANNEL_DIR"] = str(isolated)
+
+
+_prepare_isolated_channel_dir()
+
+# USD→JPY レートはテストでは固定値にしてネットワーク依存を外す
+os.environ.setdefault("JPY_PER_USD", "160")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_image_provider_gemini.py
+++ b/tests/test_image_provider_gemini.py
@@ -108,19 +108,6 @@ def patched_genai_client():
 
 
 @pytest.fixture(autouse=True)
-def _silence_cost_tracker(monkeypatch):
-    """テスト中の cost_tracker.log_generation 副作用を抑止。"""
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.gemini.cost_tracker.log_generation",
-        lambda *a, **kw: {"estimated_cost_usd": 0.101, "category": "image", "model": kw.get("model", "")},
-    )
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.gemini.cost_tracker.print_last_report",
-        lambda *a, **kw: None,
-    )
-
-
-@pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
     """リトライバックオフを高速化（time.sleep を no-op に）。"""
     monkeypatch.setattr(

--- a/tests/test_image_provider_openai.py
+++ b/tests/test_image_provider_openai.py
@@ -96,19 +96,6 @@ def _stub_openai_api_key(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _silence_cost_tracker(monkeypatch):
-    """テスト中は cost_tracker への書き込みを抑止。"""
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.openai.cost_tracker.log_generation",
-        lambda *a, **kw: {"estimated_cost_usd": 0.21, "category": "image", "model": kw.get("model", "")},
-    )
-    monkeypatch.setattr(
-        "youtube_automation.utils.image_provider.openai.cost_tracker.print_last_report",
-        lambda *a, **kw: None,
-    )
-
-
-@pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
     """リトライバックオフを高速化。"""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

#291 (CLOSED, base ブランチ takt/170 削除により reopen 不可) を release/v5.5.0 上で再オープン。

- `tests/conftest.py` で `CHANNEL_DIR` を `tests/fixtures/sample_channel/` のコピーした tmp 配下に向ける（cost_tracker が fixture を汚染しないように根本解決）
- `.gitignore` から `tests/fixtures/sample_channel/data/` を削除（#288 で audio_costs.json untrack 済み、隔離化により ignore も不要）
- `test_generate_music_dj.py` の monkeypatch 不要化（release で deprecate 済み、削除採用）
- `test_image_provider_gemini.py` / `test_image_provider_openai.py` の monkeypatch fixture 削除（conftest 隔離化で不要）

Closes #286