### PR TITLE
feat(skills): スキル未対応 CLI の棚卸し対応 (#243)

### DIFF
--- a/.claude/skills/channel-setup/SKILL.md
+++ b/.claude/skills/channel-setup/SKILL.md
@@ -70,10 +70,36 @@ JSON 構文検証・config ロードテスト・channel_id 自動取得コマン
 1. **YouTube チャンネル作成**（まだの場合）→ `config/channel/meta.json` の `channel.youtube_handle`、`channel.url`、`channel.channel_id` を更新
 2. **OAuth 認証と channel_id 取得**: 手順は `references/verification.md`（「OAuth 認証」「channel_id の自動取得」）を参照
 3. **ブランディング素材**: 生成手順は `references/verification.md`（「ブランディング素材生成」）を参照
-4. **初回コレクション制作**: `/wf-new` を実行
+4. **既存チャンネル設定の同期**（オプション）: Step 9 を参照
+5. **初回コレクション制作**: `/wf-new` を実行
+
+### Step 9: 既存チャンネル設定の同期（オプション）
+
+OAuth 認証完了後、`config/channel/meta.json` の `youtube_channel` セクション（description / keywords / country / default_language / unsubscribed_trailer / made_for_kids）と `config/localizations.json` を YouTube チャンネルに反映、もしくは YouTube 側から取り込む。
+
+```bash
+uv run yt-channel-settings diff               # 読み取り専用: local ↔ remote 差分表示
+uv run yt-channel-settings push               # local → YouTube（dry-run）
+uv run yt-channel-settings push --apply       # local → YouTube（実反映）
+uv run yt-channel-settings pull               # YouTube → local（dry-run）
+uv run yt-channel-settings pull --apply       # YouTube → local（実反映: meta.json と localizations.json を書き換え）
+```
+
+**API 制約に関する内部実装ノート**:
+
+- `--apply` 実行時は `brandingSettings` / `localizations` / `status` を **別々の `channels().update()` 呼び出し** として個別に発火する。YouTube Data API は `brandingSettings` を他の part と同時送信すると `branding_settings cannot be used with other parts` で 400 エラーを返すため (#230)。
+- `localizations` セクションを **完全に空** にして送信すると `Required` 400 エラーになる。`config/localizations.json` の `supported_languages` を全削除して全ローカライゼーションを消したい場合は、少なくとも `default_language` の 1 件はエントリを残して push すること（送信しなかったロケールは YouTube 側で自動削除される）。
+- `--no-localizations` を付けると localizations 関連の比較・送信をスキップする。
+
+**運用フロー**:
+
+1. `yt-channel-settings diff` で意図しないずれがないか確認
+2. `yt-channel-settings push` の dry-run 出力をレビュー
+3. 問題なければ `--apply` で実反映
 
 ## Cross References
 
 - `/channel-direction` → 前フェーズ: 方向性決定
 - `references/` → テンプレートファイル（同スキルディレクトリ内）
 - `/wf-new` → チャンネル完成後の最初のアクション
+- `yt-channel-settings` CLI (`src/youtube_automation/scripts/channel_settings_cli.py`) — Step 9 の実装本体

--- a/.claude/skills/metadata-audit/SKILL.md
+++ b/.claude/skills/metadata-audit/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: metadata-audit
+description: Use when ローカル descriptions.md と YouTube 上のメタデータが整合しているかを監査したいとき。「メタデータ監査」「説明欄ずれてない？」「タグ確認」「アップ済み動画の整合性チェック」「/metadata-audit」など、`collections/live/` 配下のドリフト検出に関わる場面で使用すること。修正は対象外（`/video-description` が責務）
+---
+
+## Overview
+
+`yt-metadata-audit` のラッパー。`collections/live/<col>/20-documentation/descriptions.md` と `workflow-state.json` の整合性、および YouTube API 側 snippet/localizations の整合性を読み取り専用で監査する。
+
+**修正は範囲外**。差分検出後の更新は `/video-description` で descriptions.md を再生成し、必要に応じて `yt-bulk-update-desc` 経由で push する。
+
+## When to Use
+
+- 一括アップロード後に YouTube 側にメタデータが正しく反映されたか確認したいとき
+- descriptions.md を手で編集したあと、live 動画と差分が出ていないか調べたいとき
+- 多言語ローカライゼーションが期待通り反映されているか確認したいとき
+- scene_phrases の言語抜けを検出したいとき
+
+## Quick Reference
+
+| コマンド | 説明 |
+|---------|------|
+| `uv run yt-metadata-audit` | local + remote の両方を監査 |
+| `uv run yt-metadata-audit --local` | `descriptions.md` / `workflow-state.json` のみ（API call 不要） |
+| `uv run yt-metadata-audit --remote` | YouTube API 側 snippet/localizations のみ |
+| `uv run yt-metadata-audit --strict` | 1 件でも issue が見つかれば exit 1（CI 用途） |
+
+## Instructions
+
+### Step 1: 監査の実行
+
+引数なしで `uv run yt-metadata-audit` を実行する。`collections/live/` 配下を全件走査し、以下を検出する:
+
+**LOCAL チェック**:
+- `descriptions.md` の `タイトル案` / `Complete Collection 概要欄` セクション欠落
+- タイトル 100 文字超過
+- タイムスタンプ数 < 3 もしくは > 12（後者は variation expansion regression 検出）
+- chapter 名のローマ数字（pattern I / II / III ... = variation expansion）
+- `workflow-state.json` の `scene_phrases` 言語抜け
+- タグ件数・YouTube タグ文字数制限
+- master mp4 が残っている場合の動画尺チェック（target_duration_min/max）
+
+**REMOTE チェック**（OAuth 必要）:
+- video_id が YouTube 上に存在するか
+- YouTube 側 title 100 文字超過
+- `🎧  🌧` のように scene_phrase が脱落して空白だけ残った title
+- description のタイムスタンプ数 > 12
+- ja localized title に日本語文字が含まれていない
+- zh コードが `['zh-CN', 'zh-TW']` 以外の組合せ（旧 `zh-Hans` / `zh-Hant` 残骸検出）
+
+### Step 2: issue がある場合の対応
+
+監査出力に基づき、ユーザーに次のアクションを案内する:
+
+- **`descriptions.md` 側の問題**（タイトル長すぎ、timestamp 過多など） → `/video-description` で再生成
+- **YouTube 側との差分**（local と remote がずれている） → `/video-description` で descriptions.md を最新化したあと、運用者が `yt-bulk-update-desc` で push（一括更新スクリプトは現状チャンネル固有のため別途運用）
+- **scene_phrases 言語抜け** → 該当コレクションの `workflow-state.json` を手動で補完（汎用的な i18n 初期化スクリプトは未整備）
+
+### Step 3: CI 統合（オプション）
+
+GitHub Actions や cron で常時監視する場合は `--strict` を付ける。1 件でも issue があれば exit 1 で失敗するため、定期実行 → 通知パイプラインに組み込める。
+
+## Cross References
+
+- `/video-description` — descriptions.md の生成・更新（修正の入口）
+- `pyproject.toml` の `yt-metadata-audit` entry point
+- `src/youtube_automation/scripts/metadata_audit.py` — 実装本体
+- `src/youtube_automation/utils/preflight_checks.py` — `extract_descriptions_md_tags` / `check_tags_count` / `check_tags_yt_chars` を共有

--- a/.claude/skills/playlist/SKILL.md
+++ b/.claude/skills/playlist/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: playlist
+description: Use when プレイリストの作成・動画割り当て・状態確認をしたいとき。「プレイリスト作って」「プレイリスト整理」「動画をプレイリストに追加」「プレイリスト状況」「削除済み動画を整理」「/playlist」など、`config/channel/playlists.json` に基づくプレイリスト CRUD の場面で使用すること
+---
+
+## Overview
+
+`yt-playlist-status` と `yt-playlist-manager` を 1 スキルに統合し、プレイリストの状態確認・作成・動画割り当て・クリーンアップを案内する。
+
+`config/channel/playlists.json` を Canonical ソースとして読み、定義されたプレイリストを YouTube 上に反映する。テーマ別マッチングルール（`auto_add_activities` / `auto_add_themes`）や全動画自動追加（`auto_add`）に対応。
+
+## 前提
+
+`config/channel/playlists.json` が存在し、`playlists` セクションが定義されていること。未定義の場合は `/channel-setup` を案内する。
+
+## When to Use
+
+- 新チャンネル開設後、`playlists.json` に定義したプレイリストを YouTube 上に初期化したいとき
+- 単一動画を特定テーマのプレイリストに割り当てたいとき
+- 現状どの動画がどのプレイリストに入っているかを確認したいとき
+- YouTube で削除済み / 非公開化された動画のエントリをプレイリストから除去したいとき
+
+## Quick Reference
+
+| モード | コマンド | 説明 |
+|--------|---------|------|
+| **status** | `uv run yt-playlist-status` | 全プレイリストの ID・動画数・マッチングルールを表示（読み取り専用） |
+| **init** | `uv run yt-playlist-manager --init [--dry-run]` | `playlists.json` 定義の全プレイリストを作成 + live/ 配下の全動画を割り当て |
+| **assign** | `uv run yt-playlist-manager --assign VIDEO_ID --theme THEME [--dry-run]` | 単一動画を該当プレイリストに追加（テーマからマッチング） |
+| **clean-deleted** | `uv run yt-playlist-manager --clean-deleted [--dry-run]` | 全プレイリストから削除済み/非公開動画のエントリを除去 |
+
+`yt-playlist-manager --status` も同じ `PlaylistStatusViewer` に委譲するため、`yt-playlist-status` と等価。
+
+## Instructions
+
+### Step 1: 状態確認（必ず最初に実行）
+
+```bash
+uv run yt-playlist-status
+```
+
+- プレイリストごとに `playlist_id`・動画数・マッチングルールを一覧表示
+- `(未作成)` が表示されたら Step 2 の init モードに進む
+
+### Step 2: 初期化（プレイリスト未作成のとき）
+
+`config/channel/playlists.json` の定義に従って全プレイリストを作成 + live/ 配下の動画を一括割り当て:
+
+```bash
+uv run yt-playlist-manager --init --dry-run    # まずプレビュー
+uv run yt-playlist-manager --init              # 実反映
+```
+
+**注意**: `--dry-run` フラグなしが実反映。`yt-channel-settings` のように `--apply` 経由ではないので、dry-run → 確認 → 本番の 2 段階運用を徹底する。
+
+実行後、`playlists.json` の各エントリに `playlist_id` が書き戻される。
+
+### Step 3: 単一動画の追加（運用フェーズ）
+
+新しい動画を YouTube にアップロードしたあと、該当プレイリストに追加:
+
+```bash
+uv run yt-playlist-manager --assign <VIDEO_ID> --theme <THEME>
+```
+
+- `<THEME>` は `workflow-state.json` の `theme` 値（`content.json` の `theme_scenes` で定義されたキー）
+- マッチするプレイリストキーが返り値として表示される
+- `"all"` プレイリストには末尾追加、それ以外は先頭追加（YouTube 表示順制御）
+
+**自動連携**: `/video-upload` から呼ばれる `collection_uploader` 内部でも同じ `assign_video()` が走るため、通常運用では手動 assign は不要。手動 assign が必要なのは: 過去動画の再割り当て / 新テーマ追加後のレトロフィット / マッチングルール変更後の再同期。
+
+### Step 4: 削除動画のクリーンアップ（定期メンテナンス）
+
+YouTube 側で削除された動画が `playlistItems` に残ったままになることがあるため、定期的に除去:
+
+```bash
+uv run yt-playlist-manager --clean-deleted --dry-run    # 影響範囲をプレビュー
+uv run yt-playlist-manager --clean-deleted              # 実反映
+```
+
+## Cross References
+
+- `/video-upload` — アップロード時に内部で `assign_video()` が呼ばれる（手動 assign 不要が基本）
+- `/channel-setup` — `playlists.json` の初期定義
+- `config/channel/playlists.json` — Canonical ソース
+- `src/youtube_automation/scripts/playlist_manager.py` — 実装本体
+- `src/youtube_automation/scripts/playlist_status.py` — 状態表示の読み取り専用 viewer

--- a/.claude/skills/video-upload/SKILL.md
+++ b/.claude/skills/video-upload/SKILL.md
@@ -114,3 +114,9 @@ uv run yt-upload-collection --plan [-c NAME]
 - 誇張表現回避（Epic, Ultimate 等の禁止）
 - SEO 最適化タグ（`config/channel/content.json` の `tags.base` 参照）
 - AI 透明性・Usage & Attribution の記載
+
+## Cross References
+
+- `/video-description` — アップロード前に descriptions.md を生成
+- `/playlist` — プレイリスト状態確認・手動 assign・クリーンアップ（アップロード時の自動 assign は本スキル内で実行される）
+- `/metadata-audit` — アップロード後のローカル ↔ YouTube 整合性監査

--- a/src/youtube_automation/scripts/channel_settings_cli.py
+++ b/src/youtube_automation/scripts/channel_settings_cli.py
@@ -102,11 +102,18 @@ def _cmd_push(args: argparse.Namespace) -> int:
         print("⚠️  no updatable fields in local config; nothing to push.")
         return 0
 
-    try:
-        youtube.channels().update(part=",".join(parts), body=body).execute()
-    except Exception as e:
-        raise YouTubeAPIError(f"channels().update() failed: {e}") from e
-    print(f"✅ pushed {len(lines) // 3} change(s) to YouTube.")
+    # YouTube Data API は `brandingSettings` を他の part と同時に送ると 400 を返す
+    # (`branding_settings cannot be used with other parts`)。part 単位で個別に
+    # channels().update() を呼ぶ。(#230)
+    for part in parts:
+        try:
+            youtube.channels().update(
+                part=part,
+                body={"id": channel_id, part: body[part]},
+            ).execute()
+        except Exception as e:
+            raise YouTubeAPIError(f"channels().update(part={part}) failed: {e}") from e
+    print(f"✅ pushed {len(lines) // 3} change(s) to YouTube ({len(parts)} API call(s)).")
     return 0
 
 

--- a/tests/test_channel_settings.py
+++ b/tests/test_channel_settings.py
@@ -238,10 +238,47 @@ class TestCLIPushDryRun:
         assert rc == 0
         out = capsys.readouterr().out
         assert "pushed" in out
-        youtube.channels().update.assert_called_once()
-        call_kwargs = youtube.channels().update.call_args.kwargs
-        assert "brandingSettings" in call_kwargs["part"]
-        assert call_kwargs["body"]["brandingSettings"]["channel"]["description"] == "Test channel description for sync."
+
+        # `brandingSettings` を他 part と混在させると YouTube API が 400 を返すため (#230)、
+        # part 単位で個別に channels().update() を呼ぶ。
+        update_calls = youtube.channels().update.call_args_list
+        parts_called = [call.kwargs["part"] for call in update_calls]
+        assert len(update_calls) >= 1
+        for part in parts_called:
+            assert "," not in part, f"part must be a single value, got: {part!r}"
+        assert "brandingSettings" in parts_called
+
+        branding_call = next(call for call in update_calls if call.kwargs["part"] == "brandingSettings")
+        body = branding_call.kwargs["body"]
+        assert body["id"] == "UCfixture"
+        assert body["brandingSettings"]["channel"]["description"] == "Test channel description for sync."
+        assert "status" not in body and "localizations" not in body, (
+            "branding push body must contain only brandingSettings"
+        )
+
+    def test_apply_splits_branding_and_status(self, capsys):
+        """`brandingSettings` と `status` が同時に変更されても、個別の API call として発火する。"""
+        youtube = MagicMock()
+        remote = _mock_remote_response(description="old remote")
+        remote["status"] = {"selfDeclaredMadeForKids": True}  # local fixture は False
+        youtube.channels().list().execute.return_value = {"items": [remote]}
+        with patch(
+            "youtube_automation.scripts.channel_settings_cli.get_youtube",
+            return_value=youtube,
+        ):
+            rc = channel_settings_cli.main(["push", "--apply", "--no-localizations"])
+        assert rc == 0
+        update_calls = youtube.channels().update.call_args_list
+        parts_called = [call.kwargs["part"] for call in update_calls]
+        assert "brandingSettings" in parts_called
+        assert "status" in parts_called
+        # 1 つの part 文字列に複数 part が混在しないこと
+        for part in parts_called:
+            assert part in ("brandingSettings", "localizations", "status")
+
+        status_call = next(call for call in update_calls if call.kwargs["part"] == "status")
+        assert status_call.kwargs["body"]["status"]["selfDeclaredMadeForKids"] is False
+        assert "brandingSettings" not in status_call.kwargs["body"]
 
     def test_no_diff_skips_update(self, capsys):
         youtube = MagicMock()


### PR DESCRIPTION
## Summary

Epic #243（スキル未対応 CLI の棚卸し）の umbrella PR。`release/v5.5.0` をマージ先とする。

- /metadata-audit スキル新規追加 (#244) — `yt-metadata-audit` のラッパー
- /playlist スキル新規追加 (#245) — `yt-playlist-manager` + `yt-playlist-status` 統合
- /channel-setup に Step 9「既存チャンネル設定の同期」を追加 (#248) — `yt-channel-settings diff/push/pull` の運用入口を提示
- `yt-channel-settings push --apply` の 400 エラー修正 (#230) — `brandingSettings` / `localizations` / `status` を part 単位で個別 API call に分割

### スコープ外（別 PR で扱う）

- #246 `yt-populate-scene-phrases` 統合
- #247 `yt-bulk-update-desc` 吸収
- #249 `yt-fix-timestamps` 統合

上記 3 CLI は特定コレクション名がコード内にハードコードされた一回限りの移行スクリプトで、汎用化なしではスキル経由の自動実行が成立しないため、汎用化を伴う別 issue/PR として再開する。

廃止 (#250 / #251 / #252) は既に CLOSED 済みで該当 entry point / スクリプトも削除確認済み。

## Test plan

- [x] `uv run pytest tests/test_channel_settings.py` が pass（新規 `test_apply_splits_branding_and_status` を含む 23 件）
- [x] `uv run pytest tests/` 全体が pass（1616 件）
- [x] `uv run ruff check src/ tests/` が pass
- [x] `uv run yt-skills list` で `/metadata-audit` と `/playlist` が一覧に出る
- [ ] 下流チャンネルで `uv run yt-channel-settings push --apply` を実行し、`brandingSettings` / `status` の同時変更が 3 つの API call に分割されて 400 エラーが出ないことを確認（OAuth 必要、運用者検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)