### PR TITLE
fix(skills): /masterup Step 6 を rsync 化しコレクション全体を同期 (#321)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -131,19 +131,31 @@ yt-finalize-master <collection-path>     # 明示指定
 
 ### Step 6: ワークツリー実行時のメインへのコピー
 
-git worktree 内で実行している場合（パスに `.claude/worktrees/` を含む場合）、生成した音源ファイルをメインワークツリーにもコピーする。
+git worktree 内で実行している場合、生成したコレクション成果物をメインリポジトリにも同期する。
+個別ディレクトリだけコピーする方式は将来ファイル種別が増えるたび漏れが発生するため、**コレクションディレクトリ全体を `rsync -a` で同期**する（`01-master/`・`02-Individual-music/`・`03-Individual-movie/`・`10-assets/`・`20-documentation/`・`workflow-state.json` などすべて含む）。
 
-1. ワークツリーのコレクションパスからメインのコレクションパスを算出:
-   - ワークツリー: `.../.claude/worktrees/<name>/collections/...`
-   - メイン: `.../collections/...`（`.claude/worktrees/<name>/` 部分を除去）
-2. メイン側に `01-master/` と `02-Individual-music/` ディレクトリを作成
-3. `01-master/` と `02-Individual-music/` の全ファイルをコピー
+1. ワークツリー検出: `git rev-parse --git-common-dir` を使う。値が `.git` または `<toplevel>/.git` ならメインリポジトリ実行なのでスキップ。
+2. メインリポジトリのルートを算出: `git_common_dir` を起点に `git rev-parse --show-toplevel` を再実行。
+3. ワークツリールートからのカレントコレクション相対パスを使ってメイン側の目的地パスを構築。
+4. `mkdir -p` で目的地を作成し、`rsync -a` でコレクションディレクトリ全体をコピー。
 
 ```bash
-# パス算出例
-WORKTREE_PATH="/path/.claude/worktrees/branch-name/collections/..."
-MAIN_PATH="${WORKTREE_PATH/.claude\/worktrees\/*/collections/...}"
+WORKTREE_COLLECTION="$(pwd)"   # コレクションディレクトリで実行している前提
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+if [[ "$GIT_COMMON_DIR" == ".git" || "$GIT_COMMON_DIR" == "$WORKTREE_ROOT/.git" ]]; then
+    echo "メインリポジトリで実行中。コピーは不要です。"
+else
+    MAIN_REPO="$(cd "$GIT_COMMON_DIR" && git rev-parse --show-toplevel)"
+    REL_PATH="${WORKTREE_COLLECTION#"$WORKTREE_ROOT"/}"
+    MAIN_COLLECTION="$MAIN_REPO/$REL_PATH"
+    mkdir -p "$MAIN_COLLECTION"
+    rsync -a "$WORKTREE_COLLECTION/" "$MAIN_COLLECTION/"
+fi
 ```
+
+**`--delete` を付けない理由**: メイン側で `/thumbnail` や `/loop-video` 等によって先行生成された素材（例: `10-assets/main.png`, `10-assets/loop.mp4`）が worktree 側に存在しないことがあり、`--delete` を付けるとそれらが消えてしまう。worktree 側で新規追加されたファイルだけメインに上書き反映する片方向追加同期で十分。
 
 **この処理は常にマスター生成後に自動実行する（ワークツリー実行時のみ）。**
 


### PR DESCRIPTION
## 概要

`/masterup` Step 6 のワークツリー→メイン同期を、個別ディレクトリコピーから `rsync -a` によるコレクション全体同期に置き換え、`10-assets/` / `20-documentation/` / `workflow-state.json` などが漏れる問題を解消する。

Closes #321

## バグ詳細

- **症状**: worktree 内で `/masterup` を実行すると、メイン側のコレクションに `01-master/` と `02-Individual-music/` しかコピーされず、`10-assets/`（サムネ・ループ動画）、`20-documentation/`（プロンプト類）、`workflow-state.json` が同期されない
- **再現条件**: ダウンストリームチャンネルが `.claude/worktrees/<name>/` 内で `/thumbnail` → `/loop-video` → `/suno` → `/masterup` の順で実行したとき
- **再現方法**: issue #321 の再現手順を参照

## 原因

`.claude/skills/masterup/SKILL.md` Step 6 が `01-master/` と `02-Individual-music/` の 2 ディレクトリだけを列挙してコピーする設計だったため、その後追加された `10-assets/` / `20-documentation/` / `workflow-state.json` がコピー漏れになっていた。将来ディレクトリが増えるたびに SKILL.md を更新する必要があり、漏れが構造的に発生する設計だった。

## 修正内容

- Step 6 をコレクションディレクトリ全体の `rsync -a` 同期に置き換え
- ワークツリー検出は `git rev-parse --git-common-dir` ベース（lyria/references/worktree_sync.sh と整合）。値が `.git` または `<toplevel>/.git` の場合はメイン実行と判定してスキップ
- `--delete` は付けない方針を明示。メイン側で `/thumbnail` や `/loop-video` で先行生成された素材（`10-assets/main.png`, `10-assets/loop.mp4` 等）を保護するため、worktree 側で新規追加されたファイルだけメインに上書き反映する片方向追加同期とする

## 影響範囲

- `.claude/skills/masterup/SKILL.md` の Step 6 セクションのみ
- このスキルは `yt-skills sync` でダウンストリーム全チャンネルに配布されるため、次回 sync 後すべての BGM チャンネル運営に反映される
- 既存のマスター生成・雨音レイヤー（Step 5 / 5.5）フローには変更なし

## テスト計画

- [ ] ダウンストリームチャンネル（例: deepfocus365）で `yt-skills sync` し、Step 6 の rsync 記述が反映されることを確認
- [ ] worktree 内で `/masterup` を実行し、メイン側コレクションに `10-assets/` / `20-documentation/` / `workflow-state.json` が同期されることを確認
- [ ] メイン側で先行生成済みの `10-assets/main.png` が `--delete` で消されないことを確認