### PR TITLE
feat(wf-next): worktree 実行時に main repo 側の master-mix も検出対象に追加 (#323)

### DIFF
--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -43,10 +43,16 @@ description: Use when 既存コレクション（collections/planning/ 配下）
    - ガイダンス: 「生成されたセグメントをミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
    - **ここでフロー停止**
 
-**マスター音源検出:**
+**マスター音源検出（音源承認ゲート 2-B）:**
 2. `assets.raw_master != null` + `assets.master_audio = null`:
-   - `01-master/` 内のファイルを走査し、raw_master と異なるファイル（ユーザーが作成した最終マスター）を検出
-   - 検出できた場合: `assets.master_audio` にファイル名記録 → `phase: "mastered"` → 自動的に公開フローへ進む
+   - **走査対象**:
+     - worktree 内 `01-master/` を必ず走査
+     - **worktree 検知**: `git rev-parse --git-common-dir` がカレント `.git` と異なる絶対パスを返したら worktree 内とみなし、メインリポルート（`git-common-dir` の親ディレクトリ）の `collections/planning/<collection-name>/01-master/` も走査対象に追加（worktree は短命で、ユーザーが DAW 書き出しをメインリポ側に置くケースに対応）
+   - **候補抽出**: raw_master と異なるファイルのうち `.m4a` / `.wav` / `.flac` / `.aac` / `.mp3` を最終マスター候補として列挙
+   - 検出できた場合:
+     - 複数候補があればユーザーに採用ファイルを確認（worktree 内と main repo 側で同名ファイルが両方ある場合も含む）
+     - 採用ファイルが worktree 外（main repo 側）にあるときは worktree 側 `01-master/` にコピーしてから処理（state 更新後の動画化が worktree 内で完結するように）
+     - `assets.master_audio` にファイル名のみ記録 → `phase: "mastered"` → 自動的に公開フローへ進む
    - 検出できない場合: ガイダンス「最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
 
 #### `mastered` → 全自動公開フロー（承認なし）


### PR DESCRIPTION
## 概要

`/wf-next` の音源承認ゲート (2-B) は worktree 内の `01-master/` のみを走査して最終マスター候補を検出していたため、ユーザーが DAW 書き出し (`master-mix.m4a` / `.wav` 等) をメインリポジトリ側に置いた場合、worktree からは検出できず誤って raw 採用ルートに進んでしまっていた。worktree 実行時はメインリポ側も走査対象に加え、検出した最終マスターを worktree 側にコピーしてから採用するよう仕様を拡張した。

Closes #323

## 設計判断

- **worktree 検知に `git rev-parse --git-common-dir` を採用**: ファイルシステム上のヒューリスティック（`.git` がディレクトリかファイルか等）よりも、git のメタ情報を信頼するほうが正確。`git-common-dir` がカレント `.git` と異なる絶対パスを返したら worktree 内とみなす
- **採用時に worktree 側へコピーしてから `master_audio` にファイル名のみセット**: state 更新後の動画化が worktree 内で完結するように。フルパス記録だと state を main repo に持ち戻したときに参照が壊れる
- **`/videoup` の `generate_videos.sh` は本 PR の対象外**: 同様の worktree 拡張余地はあるが、スコープ拡大を避けるため別 issue 化候補として残す（本 PR では sync 配布側の wf-next 修正に閉じる）

## 変更内容

- `.claude/skills/wf-next/SKILL.md` のマスター音源検出セクションを更新
  - セクション見出しに「（音源承認ゲート 2-B）」を明示
  - 走査対象に worktree 検知ロジックを追加し、worktree 内なら main repo 側 `collections/planning/<name>/01-master/` も対象に加える
  - 候補抽出の拡張子を明記（`.m4a` / `.wav` / `.flac` / `.aac` / `.mp3`、raw_master 以外）
  - 複数候補時のユーザー確認、worktree 外採用時のコピー処理を仕様化

## テスト計画

- [ ] worktree 内で raw_master のみ + main repo 側に `master-mix.m4a` を置いた状態で `/wf-next` を実行し、main repo 側の `master-mix.m4a` が候補として提示されること
- [ ] 採用後 worktree 側 `01-master/` にコピーされ、`workflow-state.json` の `assets.master_audio` にファイル名のみ記録されること
- [ ] worktree 内と main repo 側の両方に同名 master-mix がある場合に、ユーザーへ採用確認が走ること
- [ ] 非 worktree 実行時は従来通り worktree（=main repo 自身）の `01-master/` だけを走査して回帰しないこと