### PR TITLE
docs(skills): collection-ideate の freshness 表現を freshness_days 参照に統一

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -73,7 +73,7 @@ uv run yt-channel-status
 
 #### Phase 1-3: 競合ベンチマーク分析
 
-**Skill ツールで `/benchmark` を実行** — 3 日以上未更新のファイルがあれば YouTube Data API (OAuth) で最新データを自動取得・更新する。最新であればスキップされる。
+**Skill ツールで `/benchmark` を実行** — `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より古いファイルがあれば YouTube Data API (OAuth) で最新データを自動取得・更新する。最新であればスキップされる。
 
 更新完了後、`docs/benchmarks/` 配下の全 `.md` ファイルを Read ツールで読み込み、以下を抽出:
 - 競合チャンネルの高パフォーマンステーマ（再生数上位）

--- a/.claude/skills/collection-ideate/references/freshness-rules.md
+++ b/.claude/skills/collection-ideate/references/freshness-rules.md
@@ -53,7 +53,8 @@ if [ -n "$LATEST_DATA" ]; then
 fi
 
 # 1b. benchmark — /benchmark スキル内の鮮度チェックに委譲
-#    （freshness_days より古い md があれば自動更新）
+#    （`config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より
+#     mtime が古い md があれば差分更新）
 
 # 2. persona — 存在チェックのみ
 if [ ! -f docs/channel/personas/persona-definition.md ]; then
@@ -72,7 +73,7 @@ fi
 |---|---|
 | `reports/analysis_*.md` が存在しない | `/collection-ideate` を中断し、`/analytics-collect → /analytics-analyze` の先行実行を案内 |
 | `reports/analysis_*.md` が最新 `data/analytics_data_*.json` より古い日付 | `/collection-ideate` を中断し、`/analytics-analyze` の再実行を案内 |
-| `data/benchmark_*.json` が 3 日より古い | `/benchmark` を Skill ツールで自動実行 |
+| `data/benchmark_*.json` が `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より古い | `/benchmark` を Skill ツールで自動実行 |
 | `persona-definition.md` が存在しない | `/collection-ideate` を中断し、`/audience-persona` の先行実行を案内 |
 | `viewing-scene-matrix.md` が存在しない | `/collection-ideate` を中断し、`/viewing-scene` の先行実行を案内 |
 


### PR DESCRIPTION
## 概要

`/collection-ideate` のドキュメント中にあった更新間隔「3 日」のベタ書きを `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）参照表現に統一。benchmark 側で値を変更したときに collection-ideate のドキュメントが陳腐化する問題を解消する。

Closes #322

## 変更内容

- `.claude/skills/collection-ideate/references/freshness-rules.md`
  - L75 周辺（再実行トリガー表）: 「3 日より古い」→ `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）参照に置換
  - L56 周辺（判定擬似コードのコメント）: 「freshness_days より古い md があれば自動更新」という曖昧表現を `config/skills/benchmark.yaml` を明示する形式に整形
- `.claude/skills/collection-ideate/SKILL.md`
  - L76 周辺: 「3 日以上未更新のファイルがあれば」→ `freshness_days` 参照に置換

`grep` で `.claude/skills/collection-ideate/` 配下に固定値「3 日」「3日」のベタ書きが残っていないこと、`.claude/skills/` 全体にも同種の残存がないことを確認済み。

## テスト計画

- [ ] 該当なし（ドキュメント表現の置換のみ。コード変更・スキル動作変更なし）