### PR TITLE
feat(skills): /wf-next 2-B で worktree 実行時に main repo の master-mix も検出する (#323)

### DIFF
--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -47,13 +47,19 @@ description: Use when 既存コレクション（collections/planning/ 配下）
 2. `assets.raw_master != null` + `assets.master_audio = null`:
    - **走査対象**:
      - worktree 内 `01-master/` を必ず走査
-     - **worktree 検知**: `git rev-parse --git-common-dir` がカレント `.git` と異なる絶対パスを返したら worktree 内とみなし、メインリポルート（`git-common-dir` の親ディレクトリ）の `collections/planning/<collection-name>/01-master/` も走査対象に追加（worktree は短命で、ユーザーが DAW 書き出しをメインリポ側に置くケースに対応）
-   - **候補抽出**: raw_master と異なるファイルのうち `.m4a` / `.wav` / `.flac` / `.aac` / `.mp3` を最終マスター候補として列挙
+     - **worktree 検知**: `git rev-parse --git-common-dir` がカレント `.git`（`git rev-parse --git-dir` の絶対パス）と異なる絶対パスを返したら worktree 内とみなす。
+     - **main repo 側パス導出**: worktree 内のときは `git rev-parse --git-common-dir` の親ディレクトリ（= main repo ルート）配下の `collections/planning/<collection-name>/01-master/` も走査対象に追加（worktree は短命で、ユーザーが DAW 書き出しを main repo 側に置くケースに対応）。
+   - **候補抽出**:
+     - 拡張子: `.m4a` / `.wav` / `.flac` / `.aac` / `.mp3` のみ
+     - `raw_master`（典型的には `master.mp3`）と同名のファイルは除外（raw を最終マスターと誤検出しない）
+     - 拡張子が候補に含まれていても raw_master と同一ファイル名のものは候補にしない
    - 検出できた場合:
-     - 複数候補があればユーザーに採用ファイルを確認（worktree 内と main repo 側で同名ファイルが両方ある場合も含む）
-     - 採用ファイルが worktree 外（main repo 側）にあるときは worktree 側 `01-master/` にコピーしてから処理（state 更新後の動画化が worktree 内で完結するように）
-     - `assets.master_audio` にファイル名のみ記録 → `phase: "mastered"` → 自動的に公開フローへ進む
-   - 検出できない場合: ガイダンス「最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
+     - 複数候補があればユーザーに採用ファイルを確認（worktree 内と main repo 側で同名ファイルが両方ある場合は両方提示してどちらを採用するか聞く）
+     - 採用ファイルが worktree 外（main repo 側）にあるときは worktree 側 `01-master/` にコピーしてから処理（state 更新後の動画化・後続 skill が worktree 内で完結するように）
+     - `assets.master_audio` にはコピー後の **ファイル名のみ** 記録 → `phase: "mastered"` → 自動的に公開フローへ進む
+   - 検出できない場合: ガイダンス「最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」（worktree 実行時は「worktree 側 `01-master/` か main repo 側 `01-master/` のいずれかに配置」と案内）
+
+> Note: `/videoup` 側の `generate_videos.sh` も同様に worktree 実行時の main repo 側 master-mix 検出に未対応。別 issue で追従予定（本 skill のスコープ外）。
 
 #### `mastered` → 全自動公開フロー（承認なし）
 


### PR DESCRIPTION
## Summary

`/wf-next` の音源承認ゲート (2-B) は現状 worktree 内の `01-master/` のみを走査するため、DAW 書き出し (`master-mix.m4a` / `.wav` 等) を main repo 側の同名コレクションに置く運用だと最終マスターが検出できず raw_master 採用ルートに誤誘導される。SKILL.md に worktree 検知 → main repo 側走査 → worktree 側へのコピー → `master_audio` セットの流れを明文化する。

Closes #323

## Changes

`.claude/skills/wf-next/SKILL.md` 2-B（マスター音源検出ゲート）の記述を以下のとおり拡張:

- **worktree 検知**: `git rev-parse --git-common-dir` がカレント `.git`（`git rev-parse --git-dir`）と異なる絶対パスを返したら worktree 内と判定
- **main repo 側パス導出**: `git-common-dir` の親ディレクトリ = main repo ルート → `<main_repo>/collections/planning/<collection-name>/01-master/` も走査対象に追加
- **候補拡張子の明示**: `.m4a` / `.wav` / `.flac` / `.aac` / `.mp3` のみ
- **raw_master 除外の明文化**: `raw_master`（典型的には `master.mp3`）と同名ファイルは候補から除外（raw を最終マスターと誤検出しない）
- **採用時の挙動**: 採用ファイルが worktree 外（main repo 側）にあるときは worktree 側 `01-master/` にコピーしてから処理。`assets.master_audio` には**コピー後のファイル名のみ**を記録（state 更新後の動画化・後続 skill が worktree 内で完結するように）
- **検出失敗時のガイダンス**: worktree 実行時は「worktree 側 / main repo 側どちらに置いてもよい」と案内

## Out of scope (follow-up)

- `/videoup` 側 `generate_videos.sh` も `01-master/master-mix.*` を検出するため同様の worktree 拡張が必要。本 PR ではスコープ外、別 issue を切って追従する旨を SKILL.md 内の Note にも明記。
- #321 `/masterup` Step 6 のワークツリー→メイン同期欠落（同系統だが責務違い）。本 PR では masterup には触らない。

## Test plan

- [ ] worktree 内で `/wf-next` 2-B に到達したとき、main repo 側 `collections/planning/<col>/01-master/master-mix.m4a` が候補として提示される
- [ ] main repo 側候補を採用すると worktree 側 `01-master/` にコピーされ、`workflow-state.json` の `assets.master_audio` にファイル名のみがセットされる
- [ ] worktree 内・main repo 側双方に同名ファイルが存在するときユーザーに採用を確認するフローが回る
- [ ] `master.mp3`（raw_master）しか存在しないときは候補が空になり、raw を最終マスターとして誤検出しない
- [ ] 非 worktree 実行（通常リポ）では従来どおり worktree（= cwd）配下のみ走査する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>