### PR TITLE
feat(skills): /community-draft スキルを新設し day-of-reminder と weekly-feedback テンプレを汎用形で追加 (#309)

### DIFF
--- a/.claude/skills/community-draft/SKILL.md
+++ b/.claude/skills/community-draft/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: community-draft
+description: Use when YouTube コミュニティ投稿の下書きを生成したいとき。`--type` で behind-the-scenes / next-teaser / poll (deprecated) / day-of-reminder / weekly-feedback を切り替え、本文を生成して `pbcopy` でクリップボードに送る。「コミュニティ投稿作って」「community post」「day-of reminder」「sunday vote」「weekly feedback」「視聴者投票」「公開当日リマインダー」など、YouTube Studio に手動投稿するコミュニティ投稿の下書きが必要な場面で使用すること
+---
+
+## Overview
+
+YouTube コミュニティ投稿の **下書き** を生成するスキル。
+YouTube Data API v3 は Community 投稿に未対応のため、生成した本文を **`pbcopy` でクリップボードへ送り、YouTube Studio から人手で投稿する** 半自動運用を前提とする。
+
+設定は `config/skills/community-draft.yaml`（任意。未指定なら同梱 `config.default.yaml`）と `config/channel/community-draft.json`（チャンネル固有のテンプレ上書き）を併用する。
+
+## 前提
+
+- `config/channel/` が存在すること（`load_config()` でロード可能）
+- macOS 専用（`pbcopy` / `open` を利用）
+  - Linux で動かす場合はクリップボード連携部分のみ無効化し、`30-promo/community-post-draft.md` の保存だけ行う
+- YouTube Studio で投稿する想定（API 連携・自動投稿は本スキルの対象外）
+
+`config/channel/` が存在しない場合、ユーザーに確認:
+- **新規チャンネル** → `/channel-new` を案内
+- **既存チャンネル**（YouTube で既に運営中）→ `/channel-import` を案内
+
+## When to Use
+
+- 公開当日のリマインダー投稿を作りたいとき
+- 週次フィードバック（Sunday Vote 系）の投票投稿を作りたいとき
+- 次コレクションの予告投稿を作りたいとき
+- 公開後の制作裏側を共有したいとき
+
+## `--type` フラグ
+
+| `--type` | 状態 | 用途 |
+|---|---|---|
+| `behind-the-scenes` | 既存 | 公開当日 or 翌日の制作意図を一人称で共有 |
+| `next-teaser` | 既存 | 次コレクションの予告（公開時期は曖昧に） |
+| `poll` | **deprecated** | 旧 4 択投票（drink × animal_object 等）。`weekly-feedback` に置き換え |
+| `day-of-reminder` | **新規** | 公開当日（数時間前）の視聴予約 + 通知設定リマインダー |
+| `weekly-feedback` | **新規** | 週次 Sunday Vote。`theme_axis_pool` から N 軸を 4 択化して翌週テーマを投票 |
+
+既存 type（behind-the-scenes / next-teaser / poll）の細かい構造は **先行ダウンストリーム実装**（rjn の `config/channel/community-draft.json` 等）を参照し、本スキルは MVP として「同 type を扱える」フックを提供する。フル仕様化は別 issue。
+
+## 新規 type の表記ルール（重要）
+
+issue #309 で確定した 2 表記の分離ルール:
+
+- **投稿本文の時刻表記**: **24h 表記**
+  - 例: `𝟏𝟖:𝟎𝟎 𝐄𝐃𝐓 / 𝟎𝟕:𝟎𝟎 𝐉𝐒𝐓`
+  - 視聴者向け簡潔さ優先、jazzgak. 原典 `𝟏𝟖:𝟎𝟎 (𝐊𝐒𝐓/𝐉𝐒𝐓)` 形式を踏襲
+  - 変数名: `{publish_time_24h_primary}` / `{publish_time_24h_secondary}`
+- **draft 内の運用メモ・予約時刻**: **AM/PM 表記**
+  - 例: `投稿 8:00-10:00 AM EDT`
+  - YouTube Studio の予約投稿 UI が AM/PM 表記のためコピペ運用しやすくする
+  - 変数名: `{schedule_window_local_ampm}` / `{schedule_time_ampm}`
+
+skill 実装側で **必ず 2 表記を別変数として扱い、生成時点で分離** すること。本文中に AM/PM が混ざる、運用メモに 24h が混ざるのは NG。
+
+## 出力先
+
+```
+<collection_dir>/30-promo/community-post-draft.md   # コレクション紐づき（day-of-reminder / behind-the-scenes / next-teaser）
+branding/community-templates/<type>.md              # コレクション非紐づき（weekly-feedback）
+```
+
+保存後、`pbcopy < <出力ファイル>` で本文をクリップボードに送り、`open https://studio.youtube.com/channel/<channel_id>/community` で Studio を開く誘導を出す。
+
+## `day-of-reminder` の構造
+
+公開数時間前に投稿するリマインダー。`config.default.yaml::templates.day_of_reminder.structure` の順:
+
+1. **headline** — 装飾フォント or プレーン文字で「今日公開 + 24h 時刻」を告知
+   - 例（装飾）: `📢 𝐍𝐞𝐰 𝐝𝐫𝐨𝐩 𝐭𝐨𝐝𝐚𝐲 — 𝟏𝟖:𝟎𝟎 𝐄𝐃𝐓 / 𝟎𝟕:𝟎𝟎 𝐉𝐒𝐓`
+   - 例（プレーン）: `📢 New drop today — 18:00 EDT / 07:00 JST`
+2. **personal_mood** — 今日の天候・感覚的描写（1-2 行）
+3. **creative_intent** — このコレクションで目指した雰囲気・小物の組み合わせ
+4. **listening_cta** — 「今夜こんな風に聴いてほしい」の柔らかい誘導
+5. **notification_cta** — 通知設定（🔔 + 😘）
+6. **gratitude** — 感謝（🤍）
+7. **signature** — チャンネル署名（装飾フォント可）
+
+末尾に Premiere URL を貼ると Studio が自動でカード化する（別途「動画を添付」操作不要）。
+
+## `weekly-feedback` の構造
+
+毎週日曜に投稿する 4 択ポール。`config.default.yaml::templates.weekly_feedback`:
+
+- `theme_axis_pool`: チャンネルの主要 theme 軸を N 個定義（rjn は 5 軸、汎用では `[]` 空配列スタート）
+- `rotation_rule.present_count`: 毎週提示する選択肢数（`auto` = `axis_count - 1`）
+- `rotation_rule.cycle_weeks`: 1 周にかかる週数（`auto` = `axis_count`）
+- `schedule_window_local_ampm`: Studio 予約時刻ガイド（AM/PM 表記）
+
+本文構造:
+
+1. **headline** — 装飾フォント or プレーン（例: `📢 Sunday vote — what's next week?`）
+2. **opener** — 週末オープナー 1 文 + theme emoji
+3. **intent** — 「あなたの mood を追いかけたい」型の制作意図
+4. **poll** — N-1 択（`theme_axis_pool` から `rotation_rule` で選定）
+5. **promise** — 「投票結果が来週の制作に反映される」約束
+6. **notification_cta** — 通知設定（🔔 + 😘）
+7. **gratitude** — 感謝（🤍）
+8. **signature** — チャンネル署名
+
+> Studio 側で「アンケート付き投稿」を選択し、`poll` 段落の 4 択を **手動で** ポール選択肢に入力する。本文には選択肢を含めない or 重複表示してもよい（運用判断）。
+
+## 実行フロー（概要）
+
+1. `--type` を判定（未指定なら interactive にユーザーに尋ねる）
+2. 該当 type の `config.default.yaml` ブロックと `config/channel/community-draft.json` の override をマージ
+3. テンプレ変数を解決
+   - `day-of-reminder`: コレクション `workflow-state.json` から公開日時 / scene_phrase / drink 等を引く
+   - `weekly-feedback`: `data/community/weekly-vote-log.json`（存在すれば）の直近履歴から提示 4 択を選定
+4. 本文を生成し `30-promo/community-post-draft.md` または `branding/community-templates/<type>.md` に保存
+5. `pbcopy` でクリップボードへ送り、Studio を `open` で開く案内を出す
+
+## 配布されるサンプル
+
+`examples/community-draft-rjn/` に rjn 実例を **reference のみ** として収録（デフォルト config には反映されない）:
+
+- `rain-5-axis.yaml` — rjn の 5 軸 axis_pool 構造
+- `day-of-reminder-cloudwalk.md` — 当日リマインダー本文例
+
+ダウンストリームが「真似て自分のチャンネル軸に書き換える」ためのテンプレ。
+
+## スコープ外（follow-up #339 で扱う）
+
+- `/collection-ideate` への vote-log hook（`data/community/weekly-vote-log.json` の `top_axis` を theme weight に取り込む）
+- `data/community/weekly-vote-log.json` スキーマの正式化
+- 既存 type（behind-the-scenes / next-teaser / poll）のフル仕様化
+
+## 参考
+
+- issue #309（本スキル新設）
+- rjn 実装: `config/channel/community-draft.json` / `branding/community-templates/weekly-feedback.md` / `collections/live/20260515-rjn-cloudwalk-collection/30-promo/community-post-draft.md`
+- 流派: jazzgak. TTP（韓国系 lo-fi jazz × 雨音、ER 平均 2.68%）

--- a/.claude/skills/community-draft/config.default.yaml
+++ b/.claude/skills/community-draft/config.default.yaml
@@ -1,0 +1,99 @@
+# community-draft skill default config
+#
+# YouTube コミュニティ投稿の下書き生成テンプレ。
+# チャンネル側で config/skills/community-draft.yaml に上書き可能（deep-merge）。
+# チャンネル固有のテキスト・軸定義は config/channel/community-draft.json で扱う。
+
+community_draft:
+  # 投稿全体のトーンガイド（任意 / 上書き想定）
+  tone: ""
+  length_target_chars: 200
+
+  templates:
+    # ---------------- 既存 type（MVP では薄い記述、フル仕様化は follow-up） ----------------
+
+    behind_the_scenes:
+      enabled: true
+      # 構造・例文は config/channel/community-draft.json で定義する。
+      # 既存ダウンストリーム実装は rjn を参照: examples/community-draft-rjn/ (将来追加)
+
+    next_teaser:
+      enabled: true
+
+    poll:
+      enabled: false
+      _status: "DEPRECATED: weekly_feedback を使うこと（後方互換のため残置）"
+
+    # ---------------- 新規 type（issue #309 で追加） ----------------
+
+    day_of_reminder:
+      enabled: true
+      # 装飾フォント（Mathematical Bold sans-serif）on/off。
+      # true にすると 𝐍𝐞𝐰 𝐝𝐫𝐨𝐩 𝐭𝐨𝐝𝐚𝐲 のような Unicode 数式文字で出力。
+      decorative_font: false
+      # 見出しテンプレ。{publish_time_24h_*} は 24h 表記（視聴者向け本文）で扱う。
+      headline_template: "📢 New drop today — {publish_time_24h_primary} {primary_tz} / {publish_time_24h_secondary} {secondary_tz}"
+      timezone:
+        # チャンネル config で上書き想定。primary 必須、secondary 任意。
+        primary: "UTC"
+        secondary: null
+      # 本文セクション順
+      structure:
+        - "headline"
+        - "personal_mood"
+        - "creative_intent"
+        - "listening_cta"
+        - "notification_cta"
+        - "gratitude"
+        - "signature"
+      # 末尾に Premiere URL を貼って Studio に自動カード化させる
+      append_premiere_url: true
+      # 出力先（コレクション紐づき）
+      output_path: "collections/<live_dir>/30-promo/community-post-draft.md"
+
+    weekly_feedback:
+      enabled: false
+      # 投稿スケジュール（人間向けガイド表記）
+      schedule: "Every Sunday"
+      # 運用メモ用の AM/PM 表記（Studio 予約 UI と整合）。
+      # 投稿本文の時刻 (24h) とは別変数で扱うこと。
+      schedule_window_local_ampm: "9:00 AM - 12:00 PM"
+      schedule_timezone: "UTC"
+      decorative_font: false
+      headline_template: "📢 Sunday vote — what's next week?"
+      # チャンネル config（config/channel/community-draft.json）で N 軸を定義。
+      # upstream デフォルトは空。各軸は {key: {label, poll_emoji}} の形式。
+      # 実例は examples/community-draft-rjn/rain-5-axis.yaml を参照。
+      theme_axis_pool: []
+      # ローテーション規則
+      rotation_rule:
+        # 毎週提示する選択肢数。"auto" の場合 axis_count - 1 を採用（rjn は 5 軸 → 4 択）。
+        present_count: "auto"
+        # 1 周にかかる週数。"auto" の場合 axis_count を採用（rjn は 5 週 1 周）。
+        cycle_weeks: "auto"
+      # 投票履歴ログ（vote-log hook の follow-up issue で正式化予定）
+      vote_log_path: "data/community/weekly-vote-log.json"
+      # 本文セクション順
+      structure:
+        - "headline"
+        - "opener"
+        - "intent"
+        - "poll"
+        - "promise"
+        - "notification_cta"
+        - "gratitude"
+        - "signature"
+      # 出力先（コレクション非紐づき / 週次運用）
+      output_path: "branding/community-templates/weekly-feedback.md"
+      # 参考実装（デフォルトには反映されない）
+      example_reference: "examples/community-draft-rjn/rain-5-axis.yaml"
+
+  # クリップボード連携（macOS 専用）
+  clipboard:
+    enabled: true
+    command: "pbcopy"
+
+  # Studio 自動オープン（macOS 専用）
+  studio_open:
+    enabled: true
+    url_template: "https://studio.youtube.com/channel/{channel_id}/community"

--- a/.claude/skills/community-draft/references/templates.md
+++ b/.claude/skills/community-draft/references/templates.md
@@ -1,0 +1,61 @@
+# community-draft テンプレ参照メモ
+
+`community-draft` skill が生成する本文テンプレの詳細メモ。
+各 type の構造は `SKILL.md` 本文と `config.default.yaml` に集約してあり、ここではダウンストリームが
+実装する際に陥りやすい注意点だけ補足する。
+
+## 表記ルールの分離（必読）
+
+issue #309 で確定した **2 表記分離** ルール:
+
+| 用途 | 表記 | 変数名 | 例 |
+|---|---|---|---|
+| 投稿本文の時刻 | **24h** | `{publish_time_24h_primary}` / `{publish_time_24h_secondary}` | `18:00 EDT / 07:00 JST` |
+| 運用メモ・予約時刻 | **AM/PM** | `{schedule_window_local_ampm}` / `{schedule_time_ampm}` | `6:00 PM EDT` |
+
+skill 実装で 2 表記が混ざると視聴者向け簡潔さ（24h）と Studio UI 整合（AM/PM）の両立が崩れるので、
+**生成時点で別変数として扱う** こと。
+
+## 装飾フォント（Mathematical Bold sans-serif）
+
+`decorative_font: true` のとき、見出しと署名を Unicode の数式文字に変換する想定。
+
+- 例: `New drop today` → `𝐍𝐞𝐰 𝐝𝐫𝐨𝐩 𝐭𝐨𝐝𝐚𝐲`
+- 注意: YouTube Studio のテキストエディタで一部欠ける可能性あり。プレビューで欠けていたら
+  生成 md からコピペし直すか、`decorative_font: false` で再生成する運用フォールバックを案内する
+
+## `day-of-reminder` のオフセット
+
+公開時刻の何時間前に投稿するかは **チャンネルの投稿運用リズム** に依存する:
+
+- rjn: 公開 12h 前固定（毎日投稿の場合、視聴者の期待リズムを定着させるため）
+- 週 1 投稿チャンネル: 公開 2-6h 前で十分
+
+upstream デフォルトでは強制せず、ダウンストリーム側で `config/channel/community-draft.json` 経由で
+`offset_hours` 等を持たせる想定（フル仕様化は follow-up）。
+
+## `weekly-feedback` のローテ規則
+
+`rotation_rule.present_count: "auto"` の場合の挙動:
+
+- `axis_count - 1` 択を毎週提示
+- 各週 1 軸ずつ除外して回す → `axis_count` 週で 1 周
+- 例: 5 軸 → 4 択 × 5 週 1 周
+
+`vote_log_path`（`data/community/weekly-vote-log.json`）の正式スキーマと
+`/collection-ideate` への hook 実装は **follow-up #339** で扱う。
+
+## 投稿頻度の上限ガイド
+
+YouTube コミュニティ投稿は週 2-3 本が推奨上限（多すぎると視聴者ホーム画面でうるさい）。
+
+- 毎日投稿チャンネル: 公開当日リマインダー + 日曜 vote の **週 2 本運用**
+- 週 1 投稿チャンネル: 公開当日リマインダーのみ or 隔週で次予告
+
+これは skill 側で強制せず、ユーザーへの注意として SKILL.md に記載するに留める。
+
+## 関連
+
+- issue #309: 本スキル新設
+- rjn 実装: `branding/community-templates/weekly-feedback.md`
+- TTP 元: jazzgak.（韓国系 lo-fi jazz × 雨音、ER 平均 2.68%）

--- a/examples/community-draft-rjn/day-of-reminder-cloudwalk.md
+++ b/examples/community-draft-rjn/day-of-reminder-cloudwalk.md
@@ -1,0 +1,72 @@
+# day-of-reminder 実例 — Rain Jazz Night / Cloudwalking Pavlova Hours
+
+> このファイルは upstream のデフォルトには反映されない **reference**。
+> ダウンストリームが `/community-draft --type day-of-reminder` の出力を
+> 「真似て自分のチャンネル文脈に書き換える」ための雛形。
+>
+> 流派: jazzgak. TTP（海外向け英語版）
+> 装飾フォント: Mathematical Bold sans-serif (`decorative_font: true`)
+> 投稿タイミング: 公開 **12h 前** 固定（毎日投稿運用のリズム化）
+>   - 例: 公開 5/16 6:00 PM EDT → 投稿 5/16 6:00 AM EDT
+> 投稿先: YouTube Studio（API 非対応のため手動）
+
+---
+
+## 投稿本文（コピペ用、24h 表記）
+
+```
+📢 𝐍𝐞𝐰 𝐝𝐫𝐨𝐩 𝐭𝐨𝐝𝐚𝐲 — 𝟏𝟖:𝟎𝟎 𝐄𝐃𝐓 / 𝟎𝟕:𝟎𝟎 𝐉𝐒𝐓
+
+The sky's been doing that soft, cotton-candy drift all day, and I couldn't help but pour it into a track. ☁️
+
+This one's for the kind of evening where you'd rather float than push — a pavlova nest on the table, a butterfly-pea soda fizzing slowly, and rain tapping just gently enough to keep you company.
+
+Save this post as a quiet little reminder. When tonight rolls around, brew something warm, open the page you've been meaning to read, and let the Rhodes carry you a few inches above the ground.
+
+(Turn on Notifications 🔔 so it finds you the moment it goes live — and if it takes you somewhere good, a Like and a Subscribe mean the world. 😘)
+
+Thank you for staying with me, always. 🤍
+
+– 𝐑𝐚𝐢𝐧 𝐉𝐚𝐳𝐳 𝐍𝐢𝐠𝐡𝐭
+
+▶ Premiere link: https://www.youtube.com/watch?v=XXXXXXXXXXX
+```
+
+---
+
+## 運用メモ（AM/PM 表記、Studio UI 整合）
+
+- **投稿予約時刻**: 公開 12h 前の **6:00 AM EDT** = **7:00 PM JST**
+  - 毎日投稿運用なら投稿時刻も固定し、視聴者の期待リズムを定着させる
+- **Studio 操作手順**:
+  1. YouTube Studio → 左メニュー「コミュニティ」→「投稿を作成」
+  2. 上記本文をコピペ（`pbcopy` で自動化される）
+  3. 本文末尾の Premiere URL は **自動でカード化される**（別途「動画を添付」は不要）
+  4. 投稿時刻を指定したい場合は公開予約を有効化
+- **装飾フォントの注意**: Mathematical Bold sans-serif は Studio エディタで一部欠ける可能性あり。
+  プレビューで欠けていたらこの md からコピペし直すか、`decorative_font: false` で再生成する
+
+---
+
+## 構造解説（テンプレ流用時に保持すべき骨格）
+
+| セクション | 役割 | 装飾 |
+|---|---|---|
+| `headline` | 当日 + 24h 時刻告知 | 装飾フォント + 📢 + 24h 表記 |
+| `personal_mood` | 今日の天候・身体感覚（1-2 行） | プレーン + 1 絵文字 |
+| `creative_intent` | 楽曲で目指した雰囲気・小物（pavlova / butterfly-pea soda 等） | プレーン |
+| `listening_cta` | 「今夜こんな風に聴いてほしい」誘導 | プレーン |
+| `notification_cta` | 通知設定（🔔 + 😘） | カッコ書きで控えめに |
+| `gratitude` | 感謝（🤍） | 短く |
+| `signature` | 署名 + Premiere URL | 装飾フォント可 |
+
+中央 3 段落（mood / intent / cta）だけコレクション別に差し替え、冒頭ヘッダーと末尾 2 段落は固定テンプレ
+として毎日流用するのがリズム化のコツ。
+
+---
+
+## TTP 元
+
+jazzgak. の `𝐒𝐞𝐞 𝐲𝐨𝐮 𝐭𝐨𝐝𝐚𝐲! 𝟏𝟖:𝟎𝟎 (𝐊𝐒𝐓/𝐉𝐒𝐓)` 当日告知型を、
+Maya 北米想定向けに EDT 主軸へ翻訳。CTA 構造
+（時刻告知 → 個人的気分 → 制作意図 → 視聴 CTA → 通知設定 CTA → 感謝 → 署名）はそのまま継承。

--- a/examples/community-draft-rjn/rain-5-axis.yaml
+++ b/examples/community-draft-rjn/rain-5-axis.yaml
@@ -1,0 +1,54 @@
+# Rain Jazz Night - weekly_feedback theme_axis_pool 実例
+#
+# このファイルは upstream のデフォルト config には反映されない reference。
+# `/community-draft --type weekly-feedback` でダウンストリームが
+# `config/channel/community-draft.json::templates.weekly_feedback.theme_axis_pool` を
+# 自前定義するときの「真似て書き換える」雛形として参照する。
+#
+# 流派: jazzgak. TTP（韓国系 lo-fi jazz × 雨音）
+# チャンネル特性: 海外 (北米) 想定、Maya 31 歳ペルソナ、雨題材 5 軸
+# ローテ: 5 軸 → 4 択 × 5 週 1 周
+
+community_draft:
+  templates:
+    weekly_feedback:
+      enabled: true
+      decorative_font: true
+      headline_template: "📢 𝐒𝐮𝐧𝐝𝐚𝐲 𝐯𝐨𝐭𝐞 — 𝐰𝐡𝐚𝐭'𝐬 𝐧𝐞𝐱𝐭 𝐰𝐞𝐞𝐤?"
+      schedule: "Every Sunday EDT (≒ JST Monday early morning)"
+      schedule_window_local_ampm: "9:00 AM - 12:00 PM"
+      schedule_timezone: "EDT"
+
+      theme_axis_pool:
+        pillowy-rain:
+          label: "Pillowy Rain — soft, cloud-financier hours"
+          poll_emoji: "☁️"
+        melting-warmth:
+          label: "Melting Warmth — matcha drizzle evenings"
+          poll_emoji: "🍵"
+        bright-after-rain:
+          label: "Bright After Rain — lemon-hour mornings"
+          poll_emoji: "🍋"
+        hushed-marble:
+          label: "Hushed Marble — quiet drip nights"
+          poll_emoji: "🌧️"
+        cloudwalk:
+          label: "Cloudwalk — sky-cotton-candy afternoons"
+          poll_emoji: "🪶"
+
+      rotation_rule:
+        # 5 軸 → 毎週 4 択提示 → 5 週 1 周
+        present_count: 4
+        cycle_weeks: 5
+        # 5 週 1 周ローテ仕様の補足:
+        # | 週 | 除外軸             | 提示 4 択                                            |
+        # | -- | ------------------ | ---------------------------------------------------- |
+        # | 1  | cloudwalk          | pillowy / melting / bright / hushed                  |
+        # | 2  | hushed-marble      | pillowy / melting / bright / cloudwalk               |
+        # | 3  | bright-after-rain  | pillowy / melting / hushed / cloudwalk               |
+        # | 4  | melting-warmth     | pillowy / bright / hushed / cloudwalk                |
+        # | 5  | pillowy-rain       | melting / bright / hushed / cloudwalk                |
+        # → 各軸は 5 週中 4 週登場。除外週は次々週に再登場で平均化。
+
+      vote_log_path: "data/community/weekly-vote-log.json"
+      output_path: "branding/community-templates/weekly-feedback.md"


### PR DESCRIPTION
## Summary

rjn (Rain Jazz Night) で確立した 2 種のコミュニティ投稿テンプレ（公開当日リマインダー / 週次 Sunday Vote）を、
任意の BGM チャンネルで流用できる **汎用形 + config スキーマ** として upstream に取り込む。

- 新規 skill `.claude/skills/community-draft/` を新設（SKILL.md / config.default.yaml / references）
- `--type` に `day-of-reminder` / `weekly-feedback` を追加（既存 `behind-the-scenes` / `next-teaser` / `poll(deprecated)` は MVP では薄い記述のまま）
- rjn 固有実装は `examples/community-draft-rjn/` に **reference のみ** で同梱

## Changes

| 種別 | パス | 概要 |
|---|---|---|
| 新規 | `.claude/skills/community-draft/SKILL.md` | スキル本体ドキュメント |
| 新規 | `.claude/skills/community-draft/config.default.yaml` | 汎用テンプレ設定（`theme_axis_pool` 等） |
| 新規 | `.claude/skills/community-draft/references/templates.md` | 表記ルール・装飾フォント・ローテ規則の補足 |
| 新規 | `examples/community-draft-rjn/rain-5-axis.yaml` | rjn の 5 軸 axis_pool 実例 |
| 新規 | `examples/community-draft-rjn/day-of-reminder-cloudwalk.md` | 当日リマインダー本文実例 |

### 設計ポイント

- **24h 表記（投稿本文）と AM/PM 表記（運用メモ・Studio 予約 UI）を別変数として明示分離**（issue #309 C 項）
- `decorative_font` フラグで Mathematical Bold sans-serif の on/off
- `theme_axis_pool` を空配列スタートの **汎用 N 軸スキーマ**（rjn 固有の雨 5 軸 / Maya ペルソナ / 英語前提を剥がす）
- `rotation_rule.present_count` / `cycle_weeks` を `auto` 解決可（`auto` → axis_count - 1 / axis_count）

## Out of scope（follow-up）

以下は **#339** に切り出し:

- `/collection-ideate` への vote-log hook
- `data/community/weekly-vote-log.json` スキーマの正式化
- 既存 type（`behind-the-scenes` / `next-teaser` / `poll`）のフル仕様化

## Packaging

- `.claude/skills/community-draft/` は `pyproject.toml` の `[tool.hatch.build.targets.wheel.force-include]` 既存ルール (`.claude/skills` → `youtube_automation/_skills`) により **自動で wheel に同梱される**。`pyproject.toml` の変更は不要
- `examples/community-draft-rjn/` は wheel には同梱されない（リポジトリ参照用 reference）

## Test plan

- [x] `uv run yt-skills list` で `community-draft` が表示されること（38 件中に確認済み）
- [x] `uv run yt-skills diff` がエラーなく実行できること（差分なし表示確認済み）
- [x] `git diff release/v5.5.1...HEAD --stat` が想定範囲（`.claude/skills/community-draft/` + `examples/community-draft-rjn/`）のみ
- [ ] レビューア視点で SKILL.md の発動キーワードに過不足がないか
- [ ] ダウンストリーム (rjn) で `config/channel/community-draft.json` の `weekly_feedback` ブロックがそのまま動くか（merge 後に確認）

Closes #309
Refs #339

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>