### PR TITLE
fix(yt-skills): diff 出力で --prune の存在を案内する (#328)

### DIFF
--- a/src/youtube_automation/cli/skills_sync.py
+++ b/src/youtube_automation/cli/skills_sync.py
@@ -321,6 +321,7 @@ def _diff_dir_asset(spec: dict[str, str], root: Path, target_dir: Path) -> int:
         print("target にのみ存在 (sync では削除されません):")
         for n in only_disk:
             print(f"  - {n}")
+        print("  (削除するには yt-skills sync --prune --yes を使ってください)")
 
     differing: list[str] = []
     for name in common:

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -190,6 +190,80 @@ def test_cmd_diff_default_asset_is_skills(fake_repo: Path) -> None:
     assert args.target == ".claude/skills"
 
 
+def test_cmd_diff_skills_only_disk_emits_prune_hint(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Given: target に bundled + 孤児 (only_disk) 1 件
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    src = _asset_root("skills")
+    for entry in src.iterdir():
+        shutil.copytree(entry, target / entry.name)
+    (target / "legacy-skill").mkdir()
+    (target / "legacy-skill" / "SKILL.md").write_text("# legacy\n", encoding="utf-8")
+
+    # When: diff を実行
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--target", str(target)])
+    rc = args.func(args)
+
+    # Then: 孤児リスト直後に --prune の案内が出る
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "target にのみ存在" in out
+    assert "legacy-skill" in out
+    assert "--prune" in out
+    assert "--yes" in out
+
+
+def test_cmd_diff_skills_no_orphans_does_not_emit_prune_hint(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Given: target は bundled と完全一致 (only_disk なし)
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+    src = _asset_root("skills")
+    for entry in src.iterdir():
+        shutil.copytree(entry, target / entry.name)
+
+    # When: diff を実行
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--target", str(target)])
+    rc = args.func(args)
+
+    # Then: 孤児がないので --prune ヒントは出ない
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "--prune" not in out
+
+
+def test_cmd_diff_claude_md_does_not_emit_prune_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Given: claude-md asset の fake_repo と diff 可能な target
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "CLAUDE.template.md").write_text("# template\n", encoding="utf-8")
+    (claude_dir / "skills").mkdir()
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+
+    target_dir = tmp_path / "downstream" / ".claude"
+    target_dir.mkdir(parents=True)
+    target = target_dir / "CLAUDE.md"
+    # 内容を変えて差分を発生させる (only_disk ではなく内容差分)
+    target.write_text("# different\n", encoding="utf-8")
+
+    # When: --asset claude-md で diff
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--asset", "claude-md", "--target", str(target)])
+    rc = args.func(args)
+
+    # Then: file asset では --prune は無関係なのでヒント文字列が出ない
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "--prune" not in out
+
+
 # ---------- cmd_sync --prune ----------
 
 


### PR DESCRIPTION
## Summary

`yt-skills diff` の only_disk 表示直後に `yt-skills sync --prune --yes` の案内行を追加した。

issue #204 で `--prune` フラグを導入したものの、`diff` サブコマンドの「target にのみ存在 (sync では削除されません):」というメッセージはそのままで、ユーザーが孤児 entry の削除手段（`--prune`）の存在に気付けない状態だった。

## Changes

- `src/youtube_automation/cli/skills_sync.py`
  - `_diff_dir_asset` の only_disk 一覧表示後に `  (削除するには yt-skills sync --prune --yes を使ってください)` のヒント行を追加
  - `_diff_dir_asset` は dir 専用関数のため skills asset のみに影響。claude-md (file asset) は `_diff_file_asset` 経由で別経路のため影響なし
- `tests/test_skills_sync.py`
  - `test_cmd_diff_skills_only_disk_emits_prune_hint`: 孤児 entry がある場合に `--prune` ヒントが stdout に出ることを検証
  - `test_cmd_diff_skills_no_orphans_does_not_emit_prune_hint`: 差分なしのときヒントが出ないことを検証
  - `test_cmd_diff_claude_md_does_not_emit_prune_hint`: claude-md asset の diff ではヒントが出ないことを検証

## Test plan

- [x] `uv run pytest -q tests/test_skills_sync.py` で全 36 件パス
- [x] 既存テストにリグレッションなし
- [x] `_diff_file_asset` 経由の claude-md には影響しないことをテストで保証

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)