### PR TITLE
feat(skills): /community-post スキルと community.json example を共有コアに追加 (#237)

### DIFF
--- a/.claude/skills/community-post/SKILL.md
+++ b/.claude/skills/community-post/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: community-post
+description: Use when YouTube コミュニティ投稿用テキストを生成し、クリップボードコピーと YouTube Studio 起動まで行いたいとき。固定テンプレ運用（動画 1 本 = 投稿 1 本）の Flow365 TTP。「コミュニティ投稿」「community post」「投稿準備」「Studio で投稿」「コミュニティタブ」など、動画公開と前後する投稿準備に関わる場面で使用すること。`/video-upload` の最終ステップから自動で呼ばれる。
+---
+
+## Overview
+
+`config/channel/community.json` の固定テンプレを展開し、対象コレクションの `20-documentation/community-post.txt` に保存、クリップボードへコピー、YouTube Studio のコミュニティ投稿作成ページを開きます。動画添付と投稿ボタン押下はユーザーが Studio 上で手動実行します。
+
+## 制約・前提
+
+- **macOS 専用**: `pbcopy` / `open` を使用。cross-platform 化は YAGNI で見送り（follow-up 候補）。失敗時は stdout フォールバックで運用継続できるようにする。
+- **YouTube Data API にコミュニティ投稿作成エンドポイントは存在しない**: テキスト準備と Studio 起動までを自動化し、添付・投稿は Studio 上で手動。
+- **完全固定テンプレ運用**: バリエーション / 多言語 / Studio 自動入力 / 動画 URL 埋め込みは Non-goals。テンプレ本文に変数展開は行わない（ブランドボイスの反復刷り込みが狙い）。
+- **設定アクセス**: 本スキルでは `config/channel/community.json` を `python3 -c "import json; ..."` で直接読む（簡素化）。`load_config()` への統合は follow-up（CLAUDE.md 開発規約に追従する形で別 issue 化）。
+- `config/channel/community.json` が存在すること。雛形は `examples/channel_config.example/community.example.json`。
+
+## When to Use
+
+- コレクションのアップロード完了後、コミュニティ投稿を貼りたいとき
+- 過去動画に紐づけて単発で投稿したいとき（URL 指定）
+- `/video-upload` の最終ステップから自動で呼ばれる
+
+## Quick Reference
+
+| 引数 | 説明 | 例 |
+|------|------|-----|
+| 動画 URL | テキスト生成のみ（コレクション特定不可なので保存は省略） | `/community-post https://youtu.be/abc123` |
+| コレクションパス | テキスト生成 + `20-documentation/community-post.txt` 保存 | `/community-post collections/live/20260511-xxx` |
+| 引数なし | `collections/live/` 配下から最新（`YYYYMMDD-*` の辞書順最大）を自動検出 | `/community-post` |
+
+## Instructions
+
+### Step 1: 引数解析
+
+- `$ARGUMENTS` が `http` で始まる → URL モード
+- `$ARGUMENTS` がディレクトリパス → コレクションモード
+- `$ARGUMENTS` が空 → 自動検出モード（`collections/live/` 配下の `YYYYMMDD-*` ディレクトリのうち辞書順最大のものを選択）
+
+```bash
+if [ -z "$ARGUMENTS" ]; then
+  COLLECTION_PATH=$(ls -d collections/live/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-* 2>/dev/null | sort | tail -1)
+  if [ -z "$COLLECTION_PATH" ]; then
+    echo "エラー: collections/live/ に公開済みコレクションがありません。"
+    echo "まず /video-upload を実行してコレクションをアップロードしてください。"
+    exit 1
+  fi
+  MODE="collection"
+elif [[ "$ARGUMENTS" == http* ]]; then
+  MODE="url"
+  VIDEO_URL="$ARGUMENTS"
+else
+  MODE="collection"
+  COLLECTION_PATH="$ARGUMENTS"
+fi
+```
+
+### Step 2: テンプレ読み込み
+
+`config/channel/community.json` から `template` と `studio_url` を読み込む。
+
+```bash
+TEMPLATE=$(python3 -c "import json; print(json.load(open('config/channel/community.json'))['template'])")
+STUDIO_URL=$(python3 -c "import json; print(json.load(open('config/channel/community.json'))['studio_url'])")
+```
+
+ファイルが存在しない場合は `examples/channel_config.example/community.example.json` を雛形として案内し、エラー終了する。
+
+### Step 3: テキスト保存（コレクションモード / 自動検出モードのみ）
+
+URL モードでは保存をスキップ。それ以外では Step 1 で確定した `$COLLECTION_PATH` を使う:
+
+```bash
+mkdir -p "$COLLECTION_PATH/20-documentation"
+python3 -c "import json, sys; open(sys.argv[1] + '/20-documentation/community-post.txt', 'w').write(json.load(open('config/channel/community.json'))['template'])" "$COLLECTION_PATH"
+```
+
+### Step 4: クリップボードコピー
+
+```bash
+python3 -c "import json; print(json.load(open('config/channel/community.json'))['template'], end='')" | pbcopy
+```
+
+`pbcopy` が失敗した場合（非 macOS など）はテンプレを stdout に出力してユーザーに手動コピーを促す。
+
+### Step 5: Studio 起動
+
+```bash
+open "$STUDIO_URL"
+```
+
+`open` が失敗した場合は `$STUDIO_URL` を stdout に出力してユーザーに手動オープンを促す。
+
+### Step 6: ユーザーへの案内
+
+下記を提示する:
+
+1. テンプレをクリップボードにコピー済み
+2. Studio で「投稿を作成」→ テキスト貼り付け
+3. 動画を添付（直近アップロード動画を選択）
+4. 投稿ボタンで公開
+
+## エラーハンドリング
+
+| 状況 | 対応 |
+|---|---|
+| `community.json` が存在しない | エラー終了し、`examples/channel_config.example/community.example.json` を雛形として案内する |
+| `pbcopy` 失敗 | テンプレを stdout に出力 |
+| `open` 失敗 | URL を stdout に出力 |
+| 引数なし & `collections/live/` が空 | エラー終了し、`/video-upload` の実行を促す |
+
+## Non-goals（YAGNI）
+
+- バリエーション生成・A/B テスト
+- 多言語投稿（JP / EN 切り替え）
+- Studio 上での自動入力（DOM 操作・ヘッドレスブラウザ）
+- テンプレ内への動画 URL / タイトル / サムネ等の変数展開
+- cross-platform 対応（pbcopy / open 以外の clipboard / open 手段）
+
+これらが必要になったら別 issue で扱う。固定テンプレ運用が崩れると Flow365 TTP の前提（ブランドボイス反復刷り込み）が壊れるため、安易な拡張は避ける。
+
+## Cross References
+
+- `/video-upload` — アップロード完了後の最終ステップから本スキルを呼び出す
+- `/playlist` — プレイリスト assign は別経路

--- a/.claude/skills/community-post/config.default.yaml
+++ b/.claude/skills/community-post/config.default.yaml
@@ -1,0 +1,43 @@
+# community-post skill デフォルト設定（プレースホルダ）
+#
+# このファイルはドキュメント用途。実行時に読み込まれるのは
+# downstream チャンネルリポジトリ側の `config/channel/community.json`。
+# チャンネル開設時は `examples/channel_config.example/community.example.json`
+# をコピー → `config/channel/community.json` に配置し、テンプレ文面と
+# studio_url を自チャンネル向けに書き換える。
+#
+# Flow365 TTP の前提:
+#   - 完全固定テンプレ（動画 1 本 = 投稿 1 本）
+#   - 変数展開なし（ブランドボイスの反復刷り込みが狙い）
+#   - macOS 専用（pbcopy / open）
+
+# ----------------------------------------------------------------------
+# テンプレ本文（5 ブロック構造の例）
+# ----------------------------------------------------------------------
+# 1. オープニングフック（絵文字 + 「New session is live.」相当）
+# 2. ジャンル/コンセプト一行
+# 3. リスナーへの感謝とブランドボイス（discipline / focus 等）
+# 4. アクションを促す短いコール
+# 5. クロージング（Press play 等）
+template: |
+  🎧 New session is live.
+
+  {brand_concept_oneliner}
+
+  Appreciate everyone showing up every day with {brand_name}. {brand_voice_sentence}
+
+  {call_to_action}
+
+  ▶ {closing_line}
+
+# ----------------------------------------------------------------------
+# YouTube Studio のコミュニティ投稿作成ページ URL
+# ----------------------------------------------------------------------
+# 自チャンネルの channel_id を埋める。例:
+#   https://www.youtube.com/channel/UCxxxxxxxxxxxxxxxxxxxxxx/posts
+studio_url: "https://www.youtube.com/channel/{channel_id}/posts"
+
+# ----------------------------------------------------------------------
+# 動画添付のリマインド表示（自動添付は API 制約で不可）
+# ----------------------------------------------------------------------
+attach_video: true

--- a/.claude/skills/video-upload/SKILL.md
+++ b/.claude/skills/video-upload/SKILL.md
@@ -75,6 +75,7 @@ $ARGUMENTS
 
 1. **Complete Collection アップロード** — マスター動画、メタデータ（descriptions.md から読み込み）、サムネイル設定
 2. **live 移動** — `collections/planning/` → `collections/live/`
+3. **コミュニティ投稿準備** — `config/channel/community.json` が存在する場合、`/community-post` を呼び出してテンプレ展開 → pbcopy → YouTube Studio 起動まで自動で行う（投稿ボタン押下は Studio 上で手動）。`community.json` が無いチャンネルではスキップ
 
 メタデータは `descriptions.md` から title / description / tags を優先使用。存在しない場合は `BAHMetadataGenerator` で自動生成にフォールバック。
 
@@ -120,3 +121,4 @@ uv run yt-upload-collection --plan [-c NAME]
 - `/video-description` — アップロード前に descriptions.md を生成
 - `/playlist` — プレイリスト状態確認・手動 assign・クリーンアップ（アップロード時の自動 assign は本スキル内で実行される）
 - `/metadata-audit` — アップロード後のローカル ↔ YouTube 整合性監査
+- `/community-post` — アップロード完了後にコミュニティ投稿テンプレを展開して Studio を起動（`config/channel/community.json` がある場合のみ）

--- a/examples/channel_config.example/community.example.json
+++ b/examples/channel_config.example/community.example.json
@@ -1,0 +1,5 @@
+{
+  "template": "🎧 New session is live.\n\n{brand_concept_oneliner}\n\nAppreciate everyone showing up every day with {brand_name}. {brand_voice_sentence}\n\n{call_to_action}\n\n▶ {closing_line}",
+  "studio_url": "https://www.youtube.com/channel/{channel_id}/posts",
+  "attach_video": true
+}


### PR DESCRIPTION
## Summary

- deepfocus365 で先行 TTP 実装した Flow365 流コミュニティ投稿フロー（固定テンプレ → pbcopy → YouTube Studio 起動）を共有コアに移植
- `/video-upload` の最終ステップから `/community-post` を呼び出す導線を追加
- チャンネル側に置く `community.json` の雛形を `examples/channel_config.example/community.example.json` に同梱

Closes #237

## Changes

| 区分 | パス | 内容 |
|---|---|---|
| 新規 skill | `.claude/skills/community-post/SKILL.md` | 引数解析（URL / コレクションパス / 自動検出）→ テンプレ読込 → `20-documentation/community-post.txt` 保存 → `pbcopy` → `open` で Studio 起動 |
| 新規 skill | `.claude/skills/community-post/config.default.yaml` | デフォルト config（プレースホルダ。実体は downstream の `config/channel/community.json`） |
| 新規 example | `examples/channel_config.example/community.example.json` | チャンネル側に配置する設定の雛形（`{brand_name}` / `{channel_id}` 等のプレースホルダ付き） |
| 既存 skill 拡張 | `.claude/skills/video-upload/SKILL.md` | アップロード完了後の最終ステップに `/community-post` 呼び出しと Cross References を追記 |

## 設計判断（issue 本文に準拠）

- **YouTube Data API にコミュニティ投稿作成 API は存在しない**ため完全自動化は不可。pbcopy + open で Studio を立ち上げるところまでを自動化、添付・投稿は Studio 上で手動
- **macOS 専用**（`pbcopy` / `open`）。失敗時は stdout フォールバック。SKILL.md に明記
- **完全固定テンプレ運用**（Flow365 流の TTP）。バリエーション / 多言語 / Studio 自動入力 / 動画 URL 埋め込みは Non-goals として SKILL.md に列挙
- **load_config() 統合は本 PR では見送り**: `community.json` は skill 内で `python3 -c "import json; ..."` で直接読む。下記 follow-up で対応

## Out of scope / Follow-ups

- **load_config() 統合**: 現状は skill 内で `json.load` 直叩き。`utils/config/community.py` の dataclass 追加 + `_REQUIRED_KEYS_BY_SECTION` 反映 + loader への組み込みは別 issue で（CLAUDE.md 開発規約「設定アクセス」セクションに従う形）
- **cross-platform 対応**: 現状 macOS 専用。Linux / Windows の clipboard / open は YAGNI で見送り
- **studio_url の自動導出**: `meta.json` の `channel_id` から組み立てる案はあるが、現状は雛形のプレースホルダで対応
- **テンプレへの変数展開 / バリエーション / 多言語**: 固定テンプレ運用が崩れると Flow365 TTP の前提（ブランドボイス反復刷り込み）が壊れるため、安易には拡張しない方針

## Test plan

- [x] `PYTHONPATH=src python -c "from youtube_automation.cli.skills_sync import _asset_root, _list_entries; print('community-post' in _list_entries(_asset_root('skills')))"` → True
- [x] `examples/channel_config.example/community.example.json` が `json.load()` でパース可能
- [x] `.claude/skills/video-upload/SKILL.md` のアップロードフロー末尾と Cross References に `/community-post` 言及あり
- [ ] downstream チャンネル（deepfocus365）で `yt-skills sync` 後に `/community-post` が動作することを v5.5.1 公開後に確認