### PR TITLE
fix(skills): generate_short_loop.py 実体を復元し short-thumbnail SKILL.md の $0.04 ハードコードも撤廃 (#345)

### DIFF
--- a/.claude/skills/short-thumbnail/SKILL.md
+++ b/.claude/skills/short-thumbnail/SKILL.md
@@ -115,7 +115,7 @@ open <collection-path>/10-assets/short-loop.mp4
 - **`--aspect-ratio "9:16"` 必須**: 省略すると 16:9 で生成される
 - **参照画像 (`--reference`) は使わない**: 16:9 構図に引っ張られるため。シーンを言葉で再描写する
 - **CTA 文言の尺**: `config/channel/audio.json` の `audio.target_duration_min` を 60 で割って「Full N-hour collection」を埋める
-- **コスト**: サムネ ~$0.04（Gemini Flash）、ループ動画は Veo 3.1（別途課金、Vertex AI コンソールで確認）
+- **コスト**: サムネは Gemini Flash 課金（事前見積もりは `config/skills/thumbnail.yaml` の `image_generation.<provider>.cost_per_image_usd` を指定したときのみ CLI 表示に出る。未指定なら GCP Cloud Console > Billing で実コスト確認）、ループ動画は Veo 3.1（別途課金、Vertex AI コンソールで確認）
 - **Veo テキスト安定性**: プロンプトに `Keep all text completely static and unchanged` を含める。`last_frame=image` で開始 / 終了フレームのテキストを固定
 - **Veo 末尾ノイズ**: 末尾 ~1 秒にノイズが入ることがある。`generate_short_loop.py` がデフォルトで末尾 1 秒をトリム
 

--- a/src/youtube_automation/scripts/generate_short_loop.py
+++ b/src/youtube_automation/scripts/generate_short_loop.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""ショート用 9:16 ループ動画を Veo 3.1 API で生成する。
+
+short.png（9:16 縦型サムネイル）を開始・終了フレームに指定し、
+キャラクターアニメーション付きの 8秒シームレスループ動画を生成する。
+
+Usage:
+    # コレクションパス指定
+    python3 generate_short_loop.py <collection-path>
+    python3 generate_short_loop.py <collection-path> --prompt "gentle wind..."
+
+    # CWD がコレクションディレクトリの場合
+    python3 generate_short_loop.py
+
+    # 末尾トリムなし
+    python3 generate_short_loop.py <collection-path> --no-trim
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+
+# --- パス解決 ---
+def _channel_root() -> Path:
+    from youtube_automation.utils.config import channel_dir
+
+    return channel_dir()
+
+
+from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
+from youtube_automation.utils.veo_generator import (  # noqa: E402
+    DEFAULT_MODEL,
+    generate_loop_video,
+    trim_tail,
+)
+
+SHORT_DEFAULT_PROMPT = (
+    "Gentle character animation: the character slowly moves their head, "
+    "hair sways softly in the breeze, clothing ripples with subtle movement, "
+    "hand gently reaches toward a light source. "
+    "Flowers and plants sway gently in the wind. "
+    "Soft flickering light shifts on surfaces. "
+    "Keep all text completely static and unchanged. "
+    "No smoke, no particles, no falling objects."
+)
+
+
+def load_config() -> dict:
+    """loop-video skill-config から veo セクションを読み込む。"""
+    try:
+        from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
+
+        return load_skill_config("loop-video").get("veo", {})
+    except Exception:
+        return {}
+
+
+def resolve_paths(collection_path: Path) -> tuple[Path, Path]:
+    """コレクションパスから short.png と出力動画のパスを解決する。"""
+    image_path = collection_path / "10-assets" / "short.png"
+    output_path = collection_path / "10-assets" / "short-loop.mp4"
+    return image_path, output_path
+
+
+def main():
+    from dotenv import find_dotenv, load_dotenv
+
+    load_dotenv(find_dotenv())
+
+    parser = argparse.ArgumentParser(description="Veo 3.1 ショート用 9:16 ループ動画生成")
+    parser.add_argument("collection", nargs="?", help="コレクションパス")
+    parser.add_argument("--prompt", help="動画生成プロンプト")
+    parser.add_argument(
+        "--model",
+        choices=["veo-3.1-fast-generate-001", "veo-3.1-generate-001"],
+        help="Veo モデル名 (default: veo-3.1-fast-generate-001)",
+    )
+    parser.add_argument("--no-trim", action="store_true", help="末尾トリムをスキップ")
+    parser.add_argument("--trim-tail", type=float, default=1.0, help="末尾トリム秒数 (デフォルト: 1.0)")
+    parser.add_argument("-y", "--yes", action="store_true", help="確認をスキップ")
+    args = parser.parse_args()
+
+    # 設定読み込み
+    veo_config = load_config()
+    model = args.model or veo_config.get("model", DEFAULT_MODEL)
+    prompt = args.prompt or SHORT_DEFAULT_PROMPT
+
+    # パス解決
+    if args.collection:
+        collection_path = Path(args.collection)
+        if not collection_path.is_absolute():
+            collection_path = Path.cwd() / collection_path
+        image_path, output_path = resolve_paths(collection_path)
+    else:
+        cwd = Path.cwd()
+        if (cwd / "10-assets").exists():
+            image_path, output_path = resolve_paths(cwd)
+        else:
+            parser.error("コレクションパスを指定するか、コレクションディレクトリ内で実行してください")
+            return
+
+    # バリデーション
+    if not image_path.exists():
+        print(f"[ERROR] short.png が見つかりません: {image_path}")
+        print("  /short-thumbnail で先に 9:16 サムネイルを生成してください")
+        sys.exit(1)
+
+    # 確認
+    print()
+    print("===========================================")
+    print("  Veo 3.1 ショート用ループ動画生成")
+    print("===========================================")
+    print(f"  入力:   {image_path}")
+    print(f"  出力:   {output_path}")
+    print(f"  モデル: {model}")
+    print("  比率:   9:16（縦型）")
+    print(f"  トリム: {'なし' if args.no_trim else f'末尾 {args.trim_tail}秒カット'}")
+    print("===========================================")
+    print()
+
+    if not args.yes:
+        try:
+            answer = input("  生成しますか？ [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  キャンセルしました。")
+            sys.exit(0)
+        if answer not in ("y", "yes"):
+            print("  キャンセルしました。")
+            sys.exit(0)
+
+    try:
+        from youtube_automation.utils.genai_client import create_genai_client
+    except ImportError:
+        print("[ERROR] google-genai がインストールされていません。")
+        print("  pip3 install google-genai --break-system-packages")
+        sys.exit(1)
+
+    # 生成実行
+    try:
+        client = create_genai_client(location="us-central1")
+    except ConfigError as e:
+        print(f"[ERROR] {e}")
+        sys.exit(1)
+    start_time = time.monotonic()
+    success = generate_loop_video(client, image_path, output_path, model, prompt, aspect_ratio="9:16")
+
+    if success and not args.no_trim:
+        trim_tail(output_path, args.trim_tail)
+
+    elapsed = time.monotonic() - start_time
+
+    # レポート
+    print()
+    print("===========================================")
+    if success:
+        print("  ショートループ動画生成: 完了")
+        try:
+            print(f"  ファイル: {output_path.relative_to(_channel_root())}")
+        except ValueError:
+            print(f"  ファイル: {output_path}")
+        print(f"  時間:     {elapsed:.1f}秒")
+    else:
+        print("  ショートループ動画生成: 失敗")
+        print("  --prompt でプロンプトを変えて再試行してください。")
+    print("===========================================")
+    print()
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

リリース PR #331 の CI が両方とも FAILURE になっていた **2 つの根本原因** を同時に解消する hotfix。

1. **broken symlink による hatchling wheel ビルド失敗** (本 issue #345)
   - PR #287 の v5 Shorts 復活で `.claude/skills/short{,-thumbnail}/references/generate_short_loop.py` の symlink は追加されたが、リンク先実体 `src/youtube_automation/scripts/generate_short_loop.py` は v4.0.0 撤去（commit `f25946b`）のまま **復元されていなかった**
   - `uv sync --extra dev` が `FileNotFoundError: ... generate_short_loop.py` で失敗 → lint / test ジョブの最初のステップで死亡
   - `git show f25946b^:src/youtube_automation/scripts/generate_short_loop.py` で v4.0.0 直前の実体（174 行 / 6.3 KB）を復元
2. **`test_skill_cost_documentation` が `\$0.04` ハードコードを検出して失敗**（hatchling ビルドが通っていれば露呈していた潜在 fail）
   - `.claude/skills/short-thumbnail/SKILL.md:118` に `\$0.04` 直書きが残っていた
   - Issue #132 で `cost_tracker.PRICING` / `estimate_cost` を撤廃した際に追従漏れ
   - `.claude/skills/thumbnail/SKILL.md:187` と同じ `cost_per_image_usd` 駆動表記に揃えた

## Changes

| ファイル | 変更 |
|---|---|
| `src/youtube_automation/scripts/generate_short_loop.py` | **新規（実体復元）**: f25946b^ から 174 行を復元。Veo 3.1 で 9:16 ループ動画を生成する script。`generate_short_loop.py <collection-path>` で動作、`--no-trim` で末尾トリム抑止 |
| `.claude/skills/short-thumbnail/SKILL.md` L118 | `\$0.04` ハードコードを `cost_per_image_usd` 駆動表記に置換（`/thumbnail` と同じ書式） |

symlink 2 件は変更不要（リンク先が解決可能になった）。

## Test plan

- [x] `cd worktree && uv sync --extra dev` が成功
- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run ruff format --check .` → 257 files already formatted
- [x] `uv run pytest -q` → **1681 passed, 18 warnings**（`test_skill_cost_documentation` を含む全件 pass）

## Follow-up

- 復元した `generate_short_loop.py` は v4.0.0 直前の実体そのまま。PR #287 commit メッセージで言及されていた **新命名規約 CLI `yt-generate-shorts-loop`** 化は本 PR では行わない（CI ブロック解除を最優先）。CLI 化と `pyproject.toml [project.scripts]` への登録は別 issue で対応する
- 復元したスクリプトの内容自体が v5 アーキテクチャで動くかの動作検証も別 issue（本 PR は CI 通過と wheel ビルド成功までを保証）

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)