### PR TITLE
[#329] issue-329-chore-tests-pytest-d

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ nix develop
 ```bash
 git clone git@github.com:daiki-beppu/youtube-automation.git
 cd youtube-automation
-uv sync --extra dev --extra veo
+uv sync --extra dev
 ```
 
 ### テスト実行
@@ -194,6 +194,12 @@ uv sync --extra dev --extra veo
 ```bash
 uv run pytest
 ```
+
+`uv sync --extra dev` 単独で `uv run pytest tests/` が collection error 0 件で走るために必要な依存がすべて揃います。
+
+- テスト用ツール (`pytest` / `ruff`) は `[project.optional-dependencies].dev` 経由で導入されます。
+- テストが間接的に require する `Pillow` / `pandas` / `pyyaml` / `matplotlib` / `japanize-matplotlib` / `seaborn` / `google-api-python-client` / `google-auth-oauthlib` などは `[project] dependencies`（main deps）に同梱されています。
+- 現時点で optional dependency 扱いの test dep は存在しません（Issue #216 で `pyyaml`、コミット `801ffa8` / v5.5.0 で `Pillow` を main deps へ統合済み。本 Issue #329 はその状態を README に明文化したもの）。
 
 ### Lint
 

--- a/tests/test_readme_dev_install_documentation.py
+++ b/tests/test_readme_dev_install_documentation.py
@@ -1,0 +1,242 @@
+"""README の Development 節が Issue #329 完了条件 3 を満たすかを検証する。
+
+Issue #329: pytest 全実行で optional dependency 未インストール時の collection error を解消
+
+完了条件 3 が「どの optional dep が必要かを README/CONTRIBUTING に明文化」のため、
+本リポジトリでは README.md の Development 節に以下を含めることで満たす:
+
+1. Editable install のコマンド例から空 extra (`--extra veo`) を取り除き、
+   `uv sync --extra dev` 単独で揃うことを示す。
+   - 理由: `pyproject.toml:33-35` で `veo = []` (空 extra) になっており、
+     `--extra veo` を案内し続けるのは「optional dep を明文化」の主旨と矛盾する。
+
+2. テスト実行節に、`uv run pytest` が collection error 0 件で走るために
+   何が揃っている必要があるかを明文化する。
+   - 検索性のため Issue #329 で使われた語彙 (`collection error` / `optional dependency`)
+     を 1 箇所以上含める。
+   - 主因となった `Pillow` が main dependencies に含まれている事実を示す。
+   - `pytest` 自体は `[project.optional-dependencies].dev` 経由で入ることを示す。
+
+参照: `.takt/runs/20260518-060411-issue-329-.../reports/plan.md`
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# リポジトリルート (tests/ の親)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+README = _REPO_ROOT / "README.md"
+
+
+# ---------- 共通ヘルパー ----------
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _development_section(text: str) -> str:
+    """`## Development` 見出しから次の `## ` 見出し直前までを抽出する。"""
+    match = re.search(
+        r"^## Development\b.*?(?=^## |\Z)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError("README.md に `## Development` 節が見つかりません")
+    return match.group(0)
+
+
+def _editable_install_block(dev_section: str) -> str:
+    """Development 節内の Editable install 配下の最初の bash コードブロックを抽出する。"""
+    match = re.search(
+        r"### Editable install\b.*?```bash\n(.*?)```",
+        dev_section,
+        flags=re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("README.md に Editable install の bash コードブロックが見つかりません")
+    return match.group(1)
+
+
+def _test_run_section(dev_section: str) -> str:
+    """Development 節内の `### テスト実行` ブロックを抽出する (次の `### ` まで)。"""
+    match = re.search(
+        r"### テスト実行\b(.*?)(?=^### |\Z)",
+        dev_section,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError("README.md に `### テスト実行` 節が見つかりません")
+    return match.group(1)
+
+
+# ---------- 前提: README とセクションが存在する ----------
+
+
+def test_readme_file_exists() -> None:
+    """Given リポジトリルート
+    When README.md を探す
+    Then ファイルが存在する。
+    """
+    assert README.exists(), f"{README} が存在しません"
+
+
+def test_readme_has_development_section() -> None:
+    """Given README.md
+    When `## Development` を探す
+    Then 節が存在する。
+    """
+    text = _read(README)
+    assert "## Development" in text, "README.md に `## Development` 節がない"
+
+
+# ---------- Editable install: `--extra veo` の撤去 ----------
+
+
+def test_editable_install_drops_empty_veo_extra() -> None:
+    """Given README.md Editable install ブロック
+    When `uv sync` コマンドを読む
+    Then 空 extra `--extra veo` が削除されている (pyproject.toml で `veo = []`)。
+    """
+    block = _editable_install_block(_development_section(_read(README)))
+    assert "--extra veo" not in block, (
+        f"Editable install に空 extra `--extra veo` が残存 "
+        f"(pyproject.toml で `veo = []` なので no-op):\n{block}"
+    )
+
+
+def test_editable_install_uses_uv_sync_extra_dev() -> None:
+    """Given README.md Editable install ブロック
+    When 推奨コマンドを読む
+    Then `uv sync --extra dev` が案内されている。
+    """
+    block = _editable_install_block(_development_section(_read(README)))
+    assert "uv sync --extra dev" in block, (
+        f"Editable install で `uv sync --extra dev` が案内されていない:\n{block}"
+    )
+
+
+# ---------- テスト実行節: Issue #329 完了条件 3 の明文化 ----------
+
+
+def test_test_run_section_mentions_collection_error_term() -> None:
+    """Given README.md `### テスト実行` 節
+    When 本文を読む
+    Then Issue #329 で使われた `collection error` の語彙が含まれている。
+
+    将来同じ症状で `collection error` を grep した開発者がたどり着けるようにするため。
+    """
+    section = _test_run_section(_development_section(_read(README)))
+    assert "collection error" in section, (
+        f"テスト実行節に `collection error` の語彙がない (Issue #329 検索性のため必須):\n{section}"
+    )
+
+
+def test_test_run_section_mentions_optional_dependency_term() -> None:
+    """Given README.md `### テスト実行` 節
+    When 本文を読む
+    Then `optional dependency` (または日本語の "optional 依存") の語彙が含まれている。
+    """
+    section = _test_run_section(_development_section(_read(README)))
+    assert ("optional dependency" in section) or ("optional 依存" in section.lower()), (
+        f"テスト実行節に `optional dependency` の語彙がない:\n{section}"
+    )
+
+
+def test_test_run_section_mentions_pillow_in_main_deps() -> None:
+    """Given README.md `### テスト実行` 節
+    When 本文を読む
+    Then Issue #329 の主因だった `Pillow` への言及がある。
+
+    `Pillow` が main dependencies に含まれている事実 (issue 起票時点と現状の差) を
+    開発者に伝えるため。
+    """
+    section = _test_run_section(_development_section(_read(README)))
+    assert "Pillow" in section, (
+        f"テスト実行節に `Pillow` への言及がない (Issue #329 主因の dep):\n{section}"
+    )
+
+
+def test_test_run_section_explains_extra_dev_is_sufficient() -> None:
+    """Given README.md `### テスト実行` 節
+    When 本文を読む
+    Then `uv sync --extra dev` 単独でテストが揃う旨が案内されている。
+    """
+    section = _test_run_section(_development_section(_read(README)))
+    assert "uv sync --extra dev" in section, (
+        f"テスト実行節に `uv sync --extra dev` で揃う旨の案内がない:\n{section}"
+    )
+
+
+def test_test_run_section_is_expanded_beyond_single_codeblock() -> None:
+    """Given README.md `### テスト実行` 節
+    When 本文の中身を計測する
+    Then 単一の `uv run pytest` コードブロックだけでなく、説明文が追記されている。
+
+    Issue #329 完了条件 3 を満たすには、コマンド例 1 行だけでは「optional dep の明文化」と
+    呼べないため、少なくとも 1 行以上の説明文が追加されているはず。
+    """
+    section = _test_run_section(_development_section(_read(README)))
+    # コードフェンス・空行・見出し以外の散文行を数える
+    prose_lines = [
+        ln.strip()
+        for ln in section.splitlines()
+        if ln.strip()
+        and not ln.strip().startswith("```")
+        and not ln.strip().startswith("#")
+        and not ln.strip().startswith("uv ")  # コードブロック内の `uv run pytest` 等
+    ]
+    assert len(prose_lines) >= 2, (
+        "テスト実行節が単一コードブロックのままで、説明文が追記されていない "
+        f"(prose lines = {len(prose_lines)}):\n{section}"
+    )
+
+
+# ---------- 横断: dev install 説明と pyproject.toml の整合 ----------
+
+
+def test_readme_does_not_advertise_empty_extras() -> None:
+    """Given README.md 全体
+    When `--extra veo` の登場箇所を探す
+    Then 一切登場しない (pyproject.toml で `veo = []` の空 extra のため)。
+
+    Editable install ブロック以外の場所にも残っていないかの横断確認。
+    """
+    text = _read(README)
+    assert "--extra veo" not in text, (
+        "README.md のどこかに `--extra veo` (空 extra) の案内が残存"
+    )
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    ["Pillow", "pandas", "pyyaml"],
+    ids=["Pillow", "pandas", "pyyaml"],
+)
+def test_main_dependency_listed_in_pyproject(package_name: str) -> None:
+    """Given pyproject.toml `[project] dependencies`
+    When テストが import する main dep を列挙する
+    Then 列挙された dep (`Pillow` / `pandas` / `pyyaml`) が含まれている。
+
+    README に「main deps に入っている」と書いた根拠を pyproject.toml 側でも担保する。
+    将来誰かが pyproject.toml から削除した場合、この test と README の説明が同時に乖離する。
+    """
+    pyproject = _REPO_ROOT / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    # `[project] dependencies = [ ... ]` ブロックを抽出
+    match = re.search(
+        r"^dependencies\s*=\s*\[(.*?)\]",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match, "pyproject.toml に `dependencies = [...]` ブロックがない"
+    deps_block = match.group(1)
+    # 大小文字無視で部分一致を検査 (`Pillow` / `pillow` どちらでも許容)
+    assert package_name.lower() in deps_block.lower(), (
+        f"pyproject.toml の main dependencies に `{package_name}` がない:\n{deps_block}"
+    )


### PR DESCRIPTION
## Summary

## 背景

`uv run pytest tests/` をプロジェクトルートで全件実行すると、`PIL` (Pillow) など optional dependency が venv に入っていないとき **collection error** で fail する。

Issue #204 (`--prune` オプション追加) の supervisor-validation でも以下のように記録された。

> 注: フル `pytest tests/` 実行は PIL 等 optional dependency 未インストールで collection error が出るが、本タスク変更とは無関係（pre-existing）と implement レポートに記録あり。
> — `.takt/runs/20260517-032000-issue-204-enhancement-yt-skill/reports/supervisor-validation.md:52`

このため Issue #204 では `tests/test_skills_sync.py` 単体での実行に絞らざるを得ず、CI / 開発者のフル実行体験を損ねている。Issue #216 (`yaml` 不在) と類似だが、PIL 系は別カテゴリで未起票。

該当しそうな対象:

- `tests/test_thumbnail_features.py` 等の Pillow を要求するテスト
- `src/youtube_automation/utils/thumbnail_features.py` の import が conftest 経由で評価される箇所

## 提案

以下のいずれか、または併用:

1. **`pyproject.toml` の `[project.optional-dependencies].dev` に `Pillow` 系を追加**して、`uv sync --extra dev` で自動的に揃うようにする
2. **collection 時に optional dep をガード**（`pytest.importorskip(\"PIL\")` を該当テストファイル先頭に置く）
3. **`tests/conftest.py` で optional テストを動的 skip** する仕組みを入れる

## 完了条件

- [ ] `uv run pytest tests/` を fresh `uv sync --extra dev` 環境で実行して collection error 0 件
- [ ] CI でフル `pytest` が走るようになる（現状は subset 実行）
- [ ] どの optional dep が必要かを README/CONTRIBUTING に明文化

## 関連

- Issue #216（`yaml` 不在 collection error）— CLOSED 済み。同じ系統の別 dependency 版
- Issue #204（`--prune` オプション追加）— supervisor-validation で記録
- Issue #286（`pytest 実行で audio_costs.json fixture が append 汚染される`）— 関連はあるが別問題

## Execution Report

Workflow `backend` completed successfully.

Closes #329