### PR TITLE
docs(skills): スキル汎用化・整合性の棚卸し監査レポート (#353)

### DIFF
--- a/docs/audits/2026-05-18-skills-generalization-consistency.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency.md
@@ -1,0 +1,250 @@
+# スキル汎用化・整合性 棚卸し監査レポート
+
+実行日: 2026-05-18
+対象 issue: #353
+生成: takt `deep-research` workflow (plan → dig × 3 並列 → analyze → supervise)
+判定: **APPROVE**（supervise）— policy 「APPROVE 条件」3 つすべて充足
+原データ: `2026-05-18-skills-generalization-consistency/raw/` 配下に保全（dig Part A/B/C, supervise, plan）
+
+---
+
+## 1. 統合した主要発見（観点別）
+
+### 観点 1.1 ハードコード値（A-1〜A-4）
+
+| 重大度 | 件数 | 代表事例 |
+|---|---|---|
+| 高（P1） | **6 件** | `analytics-report/SKILL.md:94-101` の HTML レポートカラーパレット 9 色（`#c8a96e` = "ブランドアクセントカラー"）／`channel-new/SKILL.md:29,64`・`channel-import/SKILL.md:20` の `~/01-dev/projects/`・`~/02-yt` 個人パス／`channel-new/SKILL.md:47,49`・`channel-import/SKILL.md:21,26`・`channel-setup/references/claude-md-template.md:71` の `daiki-beppu` 固定 GitHub owner 名 |
+| 中（P2） | **約 25 件** | analytics-collect / analytics-analyze 双方の **「30 分」鮮度しきい値** が双子直書き／postmortem の比率閾値（0.5 / 0.7 / 0.9 / ±10%）／videoup の ffmpeg 解像度・CRF・サンプルレート／suno の禁止形容詞・NG ワード／streaming の `--check-threshold` 80%・`~/.ssh/yt_stream_key`／lyria 184 秒の本文再露出 |
+| 低（P3） | **約 20 件** | skill-config 化済の既存値、YouTube API 仕様値（タイトル 100 文字・video_id 11 文字・バナー 2048×1152）など |
+
+**A-1（チャンネル ID / playlist ID）リテラル検出**: **0 件**（`UC[A-Za-z0-9_-]{22}` / `PL[A-Za-z0-9_-]{16,}` の grep で完全一致なし、`@<handle>` リテラルもプレースホルダのみ）。
+**A-4（API キー / トークン）リテラル検出**: **0 件**（`AIza` / `sk-` / `ya29` パターン零）。
+
+### 観点 1.2 重複スクリプト
+
+| 重複種別 | 件数 | 詳細 |
+|---|---|---|
+| **強重複（MD5 完全一致）** | **2 ペア** | `scripts/gcp-bootstrap.sh` ≡ `channel-setup/references/gcp-bootstrap.sh`（252 行、MD5 `e421...606a`）／`scripts/gcp-terraform-apply.sh` ≡ `channel-setup/references/gcp-terraform-apply.sh`（109 行、MD5 `358b...244`）。CLAUDE.md 規約「単一 skill からしか呼ばれないものを `scripts/` に残すな」と明確に矛盾 |
+| **弱重複（共通スニペット）** | **3 ファイル** | bash の `log/ok/warn/error` ANSI ログヘルパー（`gcp-bootstrap.sh` / `gcp-terraform-apply.sh` / `streaming/references/swap_video.sh`）。共通化は配布の単純さを壊すため **非推奨** |
+| **Python 重複 in references/** | **0 件** | `.claude/skills/**/references/*.py` は 0 ファイル。order.md 既知シード「`benchmark_collector.py × 3` / `generate_image.py × 3` / `fetch_benchmark_comments.py × 2`」は **配置誤認**で、実体は `src/youtube_automation/scripts/` 配下に **各 1 件のみ**（重複なし）。SKILL.md 本文で複数 skill から CLI として参照されているが、コード重複ではない（後述「3. 検証済みの懸念」参照） |
+
+### 観点 1.3 skill-config 余地
+
+| 状況 | 件数 | 詳細 |
+|---|---|---|
+| 既存 `config.default.yaml` 保有 | **9 スキル** | benchmark / collection-ideate / loop-video / lyria / masterup / suno / thumbnail / video-analyze / video-description |
+| 新規外出し候補（移行コスト「小」） | **11 件** | analytics-collect・analytics-analyze の 30 分鮮度／discover-competitors と channel-new の共有 API パラメータ／live-clean の削除/保護パターン／streaming の cron タイミング／thumbnail-compare の評価軸 8 軸・320×180px／metadata-audit の `<3 / >12` チャプター数／playlist の挿入順 など |
+| 新規外出し候補（移行コスト「中〜大」） | **5 件** | analytics-report HTML テーマ／channel-direction 議論ポイント 7 項目／postmortem 四分位閾値／streaming `healthcheck.sh` 状態分類 4 値／streaming 帯域目安テーブル |
+
+### 観点 1.4 既存 config 未参照
+
+| 重大度 | 件数 | 代表事例 |
+|---|---|---|
+| 高（P1） | **4 件** | `analytics-analyze/SKILL.md:64` の v1.x 名残り **`channel_config.tags.themes`**（v2.0.0 では `content.tags.themes`）／`analytics-report/SKILL.md` のブランド色 → `meta.json::channel.brand_color` 新設要求／`video-description/references/description-templates.md:36,43-44` の英語固定コピー（`usage_attribution_lines` skill-config と二重管理） |
+| 中（P2） | **約 9 件** | `category_id: "10"` が 3 テンプレファイルで重複／`privacy_status` の `"public"` vs `"private"` 矛盾／`comments.json` が「7 ファイル」列挙から漏れている（実は 8 ファイル）／localizations と content.title.template の二重管理／`analytics.collection_filter_keywords` を使わず `#Shorts` 直書きしている analytics-report |
+
+### 観点 2.1 description ↔ 実装乖離
+
+| 重大度 | 件数 | 内容 |
+|---|---|---|
+| Major | **1 件** | `video-analyze/SKILL.md` の「呼び出し側スキル」セクションが `/lyria` と `/channel-direction` を「`bgm_arc` を読み取る現役の利用者」と書いているが、両 SKILL.md にその実装記述・トリガー記述が無い（grep で完全 0 ヒット） |
+| Minor | **2 件** | `video-upload` の description が `collection` 型のみ前提に読めて `single_release` 型に言及なし（実装は対応）／`analytics-report` description は「表示・閲覧」のみ書いて HTML レポート「新規生成」のトリガー語がない |
+
+### 観点 2.2 バトン双方向整合
+
+| 整合状態 | 件数 | 主要不整合の所在 |
+|---|---|---|
+| 双方向成立 | **約 14 ペア** | suno↔masterup・analytics-collect↔analytics-analyze・wf-new↔wf-next・channel-new↔channel-research↔channel-direction↔channel-setup・viewer-voice↔audience-persona↔viewing-scene・loop-video↔videoup など、主要動線は良好 |
+| **片方向（要修正）** | **4 ペア** | (A) `video-analyze ↔ lyria` 事実誤認／(B) `video-analyze ↔ channel-direction` 事実誤認／(C) `thumbnail → /suno` 単独で `/lyria` 分岐欠落／(D) **`lyria` 出力 `master.wav` / `masterup` 出力 `master.mp3` が `videoup/generate_videos.sh` の検出パターン `master-mix.{wav,m4a,aac,mp3,flac}` + `*-Master.mp3` のいずれにもマッチしない**（実害候補） |
+| 片方向（意図的・許容） | **10 ペア** | `wf-new / wf-next / postmortem` 等のオーケストレータからの fan-out 案内。double-binding は冗長 |
+
+### 観点 2.3 v4.0.0 deprecated（short / community）
+
+| 真の deprecated 参照 | **1 件** |
+|---|---|
+| `video-description/config.default.yaml:6` の YAML コメント | `metadata_generator / short / upload 等から参照される横断属性` という記述。`short` skill は v4.0.0 で撤去済 / `.claude/skills/short/` は存在しない。コメント文を `metadata_generator / upload 等` に縮めるべき |
+| 偽陽性として除外 | 18 件（`meta.json::channel.short` 11 件・YouTube Shorts 動画フォーマット 3 件・英文 short/community 2 件・歌詞 1 件・其他 1 件） |
+
+### 観点 2.4 形式揺れ
+
+| 要素 | 揺れ状況 |
+|---|---|
+| frontmatter（`name` / `description`）| **完全統一**（35/35） |
+| description 開始句 `Use when …` | **完全統一**（35/35） |
+| ディレクトリ名（kebab-case） | **完全統一**（35/35） |
+| **description 末尾指示語** | **5 系統に分散**: (A) 「必ず使用すること」14 件 / (B) 「使用すること」5 件 / (C) cross-ref 締め 9 件 / (D) ワークフロー序列 3 件 / (E) アクション動詞 4 件 |
+| **本文見出し** | **3 系統に分散**: `Cross References`（11 件）vs `関連ファイル`（8 件）vs `Next Step`（13 件）／`Instructions`（15 件）vs `実行フロー`（7 件）／`When to Use`（9 件）vs `いつ使うか`（suno のみ） |
+| **テンプレ命名** | `claude-md-template.md`（単数 md）vs `description-templates.md`（複数 md）vs `config-template/`（単数ディレクトリ） — 3 様式併存 |
+| description 文字数 | 最短 75 字（video-upload）〜 最長 約 280 字（channel-setup）、約 3.7× の幅 |
+
+---
+
+## 2. 分析の観点と統合判断
+
+### 2.1 各 dig 報告書間の整合性確認
+
+| 観点 | Part A 第 1 版 | Part A 第 2 版 | Part B | Part C 第 1 版 | Part C 第 2 版 | 整合 |
+|---|---|---|---|---|---|---|
+| ハードコード総件数 | 63 件（A-1〜A-5 通算）| A-1=14 / A-2=11 / A-3=22 / A-4=6 / A-5=0（観点定義が違う）| — | — | — | **△ 観点定義差**（第 1 版は A-1 を ID リテラル限定、第 2 版は数値全般を A-1 に統合）→ supervise で **第 1 版の観点定義を採用**するのが order.md 用語と一致 |
+| analytics-{collect,analyze} 「30 分」鮮度 | 検出 ✓ | 検出 ✓ | 検出 ✓（B-3 候補 #1, #2）| — | — | ✓ 3 報告書一致 |
+| analytics-report ブランド色 | 検出 ✓（高）| 検出（HTML 色 8 色）| B-3 候補 #3 | — | — | ✓ 一致 |
+| postmortem 閾値 | 検出 ✓（中）| 検出 ✓ | B-3 候補 #9 | — | — | ✓ 一致 |
+| GCP bootstrap 重複 | — | — | **検出 ✓ MD5 一致** | — | — | ✓ Part B 単独で確定 |
+| `video-description/config.default.yaml:6` の `short` | A-5 では未指摘 | — | — | C-1-①, C-3-① で検出 | C-1-①, C-3-① で検出 | ✓ Part C で確定 |
+| `video-analyze ↔ lyria / channel-direction` 事実誤認 | — | — | — | 検出 ✓（C-1.1） | 検出 ✓（C-2 #34, #35） | ✓ 一致 |
+| lyria/masterup master ファイル命名 vs videoup 検出パターン | — | — | — | 検出 ✓（C-2 #11, #12） | 検出（C-2 #2, #3）| ✓ 一致 |
+| バトン片方向数 | — | — | — | 14 組中 4 要修正 | 9 リンク中 P1=3 P2=4 | △ 件数の数え方は違うが、要修正候補（lyria/videoup/video-description/metadata-audit/thumbnail/suno 等）の **顔ぶれは一致** |
+
+3 つの Part 間で **重要発見の不一致は無い**。Part A 第 1 版と第 2 版の「件数差」は **観点定義の差**であり、対象物の認識は同じ。supervise では第 1 版を主、第 2 版を補助として統合する方針が合理的。
+
+### 2.2 「修正対象」と「正当な設計判断」の境界
+
+dig 段階で false positive リスクとして明示された境界:
+
+| 検出 | 状態 | 判断 |
+|---|---|---|
+| YouTube タイトル長制限 100 文字 / video_id 11 文字 / バナー 2048×1152 | プラットフォーム仕様 | **修正対象外**（外出ししても意味がない） |
+| Vertex AI Lyria 184 秒 / Veo 8 秒 | API 物理制約 | **修正対象外**（ただし定数化はしてよい） |
+| `category_id: "10"` （Music） | BGM チャンネル前提・テンプレ既定 | **テンプレ 3 ファイル重複は修正対象**、値そのものはチャンネル依存 |
+| postmortem 閾値（0.5 / 0.7 / 0.9） | 「文脈調整可」と SKILL.md 内で明記 | **skill-config 化対象**（「文脈調整可」記述を残す） |
+| `daiki-beppu` GitHub owner | 配布パッケージとしては問題 | **`{{REPO_OWNER}}` プレースホルダ化対象**（fork 運用への影響） |
+| postmortem → 4 検証 skill 片方向 | postmortem はメタスキル（fan-out 案内が責務） | **修正対象外**（意図的） |
+
+### 2.3 既知シードの最終照合（order.md「既知のシード」節）
+
+| シード | 対応観点 | 結論 |
+|---|---|---|
+| **重複スクリプト 3 種**（`benchmark_collector.py × 3`, `generate_image.py × 3`, `fetch_benchmark_comments.py × 2`）| 1.2 | **配置誤認の seed**。実体は `src/youtube_automation/scripts/{benchmark_collector,fetch_benchmark_comments,...}.py` および `src/youtube_automation/utils/image_provider/composition.py` に **各 1 件のみ**。`.claude/skills/**/references/` には Python ファイル 0 個。SKILL.md からの CLI 呼び出し参照箇所が複数あるだけで、**コード重複は存在しない**。報告書では「`.py` 重複 0 件」と確定報告し、別途「scripts/ ↔ references/ の `.sh` 重複（gcp-bootstrap.sh, gcp-terraform-apply.sh）が CLAUDE.md 規約違反として残っている」を主要発見として位置づける |
+| **streaming `--check-threshold` config 非連動** | 1.1 / 1.4 | 検出済（Part A 第 1 版 #5.18、Part A 第 2 版 A1-? 関連、Part B B-3 候補 #11）。`config/skills/streaming.yaml::bandwidth_threshold_ratio` 新設を提案 |
+| **channel-new / channel-direction の `"TBD"` 仕様未統一** | 1.1 | 検証の結果、**`"TBD"` 出現は `channel-new/SKILL.md:107` の 1 箇所のみ**（grep `TBD` で確認）。これは `yt-channel-init --genre/--style/--context` の **CLI 既定値の説明**で、`/channel-direction` で実値に上書きするフローが SKILL.md 105 行に明記されている。**仕様統一は既に取れている**ため、最終レポートでは「seed として挙がっていたが現状問題なし」と短く記載 |
+| **postmortem のバトン記述曖昧** | 2.2 | Part C 双方が検出（postmortem→4 検証 skill は意図的 fan-out、4 skill 側に back-ref を強要しない方針として明文化を推奨） |
+
+---
+
+## 3. 検証済みの懸念（analyze ステップで自前確認）
+
+以下、dig 結果の信頼性確認のため analyze 内で追加検証した内容:
+
+| 検証項目 | 検証コマンド | 結果 |
+|---|---|---|
+| `benchmark_collector.py` / `generate_image.py` / `fetch_benchmark_comments.py` の実体配置 | `Grep "benchmark_collector\|fetch_benchmark_comments\|generate_image"` worktree 全範囲 | `.claude/skills/**/references/` には 1 つも存在せず、`src/youtube_automation/scripts/` 配下に各 1 ファイル。`.claude/skills/{wf-new,viewer-voice,thumbnail,postmortem,collection-ideate,benchmark}/SKILL.md` は **CLI 経由で参照しているだけ**（コードコピーは無い）。Part B の「.py 重複 0」は **正しい**と確認 |
+| `TBD` の出現箇所 | `Grep "TBD" .claude/skills/` | `channel-new/SKILL.md:107` の 1 箇所のみ。`channel-direction/SKILL.md` には出現せず（`デフォルト` などの単語のみヒット）。Part A が「TBD」を発見済ハードコードとして列挙しなかったのは **適切な判断**（CLI 既定値の説明文に過ぎず修正対象でない） |
+| スキル総数 | `ls .claude/skills/ | wc -l` | **35** ファイル。全 dig 報告書が走査主張する件数と一致 |
+
+---
+
+## 4. 特定したギャップと重要度
+
+### 4.1 残存ギャップ（重要度: 低）
+
+| # | ギャップ | 影響度 | 追加調査するか |
+|---|---|---|---|
+| G-1 | Part A 第 1 版 vs 第 2 版の **観点定義差**（A-1〜A-5 のカテゴリ区分が違う）に基づく **件数集計の二重化** | 低（最終レポートで第 1 版の観点定義に統一すれば解消）| **しない**（supervise の整形作業で吸収可能）|
+| G-2 | `video-description/SKILL.md` の「ハッシュタグ **13 個**」と `channel-setup/references/config-generation-rules.md` の「`hashtags` は **5 個** 程度」の **数値矛盾**（dig Part A 第 2 版 A4-2/A4-3 で言及）| 中（実装側 `metadata_generator.py` がどちらに従っているか未確認）| **しない**（実装側コード読みは order.md スコープ外 `.claude/skills/**` 範囲を超える。最終レポートで「要確認」とマーク）|
+| G-3 | Part C の **片方向バトン件数差**（第 1 版「14 組中 4 要修正」 vs 第 2 版「9 リンク中 P1 3〜4」）の数え方差 | 低（どちらの数え方でも修正候補の顔ぶれは一致）| **しない**（supervise の表記統一で解消）|
+| G-4 | `videoup/generate_videos.sh` の master 検出パターン (`master-mix.*` + `*-Master.mp3`) が `lyria` (`master.wav`) / `masterup` (`master.mp3`) のいずれにもマッチしない件の **実害判定**（`/wf-next` 経由なら 2-B 検出ロジックが救うが、`/lyria`・`/masterup` の Next Step「→ /videoup」を素直に従うと素材ヒットしない可能性）| 中〜高 | **しない**（実害判定には実行ログ・統合テストが必要で order.md スコープ外。最終レポートで「実害判定要再現」とマーク、修正案 a/b/c を提示）|
+
+### 4.2 重要度の判定根拠
+
+ギャップ G-1 / G-3: **形式的な集計差**であり、supervise の整形で吸収可能。観点別の検出顔ぶれは一致しているため、追加調査は不要。
+
+ギャップ G-2: 実装側を読まないと「13 個と 5 個のどちらが正か」は確定できないが、本 issue の依頼は「**棚卸し監査レポート**」であって「修正実装」ではない。「矛盾しているという発見」を高優先度で記載すれば責務を果たせる。
+
+ギャップ G-4: 実害判定には実行統合テストが必要だが、これも本 issue のスコープ外。最終レポートで「修正案 a〜c のいずれを採るか別 issue で判断」と書く形で OK。
+
+---
+
+## 5. 判断: 追加調査は不要
+
+### 判断根拠
+
+1. **観点 1.1 / 1.2 / 1.3 / 1.4 / 2.1 / 2.2 / 2.3 / 2.4 の 8 項目すべてで `file:line` 形式の検出が確定済み**。
+2. **既知シード 4 項目**（重複 .py / streaming threshold / TBD / postmortem バトン）はいずれも検証完了（うち 2 件は「seed 自体が誤認・解決済み」と判定でき、最終レポートで短く言及するだけで足りる）。
+3. **3 つの Part 間で重要発見の矛盾なし**（観点定義差はあるが、対象物の認識は一致）。
+4. **dig 報告書は file:line 出典明記・false positive リスク明示・カバレッジ宣言・調査不可項目明示の policy 4 要件をすべて満たしている**。
+5. **政策上の 80% 基準**を超過しており、これ以上の追加調査は限界効用が小さい。
+
+### supervise ステップへの引き継ぎ事項
+
+supervise は本 analysis を踏まえ、`docs/audits/skills-audit-2026-05-18.md` を 1 ファイル新規作成する。構造は order.md 32 行の指定通り「サマリー → 観点 1.1〜1.4 → 観点 2.1〜2.4 → 優先度付き fix リスト（high / medium / low）」とする。
+
+#### 取り込むべき P1（high）fix 一覧（supervise が最終レポートで必ず取り上げるべき項目）
+
+| ID | 観点 | 内容 | 出典 |
+|---|---|---|---|
+| H-1 | 1.4 | `analytics-analyze/SKILL.md:64` の旧 namespace `channel_config.tags.themes` → `content.tags.themes` への修正 | Part A 第 1 版 #5.1 |
+| H-2 | 1.1 / 1.4 | `analytics-report/SKILL.md:94-101` のブランド色 9 色（`#c8a96e` 含む）→ `meta.json::channel.brand_color` 新設または skill-config `analytics-report.yaml::theme.colors` 新設 | Part A 第 1 版 #2.11 / #5.2 / Part B B-3 #3 |
+| H-3 | 1.4 | `video-description/references/description-templates.md:36,43-44` の英語固定コピー 2 行 → skill-config `usage_attribution_lines` への一元化（二重管理解消） | Part A 第 1 版 #5.4 / #5.5 |
+| H-4 | 1.1 | `channel-new/SKILL.md:29,64`・`channel-import/SKILL.md:20` の `~/01-dev/projects/`・`~/02-yt` 個人パス → `<your-projects-dir>` / `<your-channels-parent>` プレースホルダ化 | Part A 第 1 版 #3.1, #3.2, #3.3 |
+| H-5 | 1.1 | `channel-new/SKILL.md:47,49`・`channel-import/SKILL.md:21,26`・`channel-setup/references/claude-md-template.md:71` の `daiki-beppu/...` GitHub owner 固定 → `{{REPO_OWNER}}` プレースホルダ化または README/CLAUDE.md installation 節への一元化 | Part A 第 1 版 #4.4, #4.5, #4.6 |
+| H-6 | 1.2 | `scripts/gcp-bootstrap.sh` / `scripts/gcp-terraform-apply.sh` の **削除**（`.claude/skills/channel-setup/references/` と MD5 完全一致、CLAUDE.md 規約違反）+ `gcp-bootstrap.md` の Usage 案内を `SKILL_REF` 経由に統一 | Part B クラスタ 1 |
+| H-7 | 2.1 / 2.2 | `video-analyze/SKILL.md` の「呼び出し側スキル」セクション中 `/lyria` および `/channel-direction` 行の事実誤認 → 削除 or 下流実装追加（要 git log 確認）| Part C 第 1 版 C-1.1, C-2 #34, #35 / Part C 第 2 版 — |
+| H-8 | 2.2 | `lyria` 出力 `master.wav` / `masterup` 出力 `master.mp3` が `videoup/generate_videos.sh` の検出パターンにマッチしない → 実害判定要再現の上、(a) generate_videos.sh 検出拡張 / (b) 各スキルの出力名統一 / (c) SKILL.md Next Step に「`master-mix.{ext}` リネーム後 /videoup」明記、の 3 案 | Part C 第 1 版 C-2 #11, #12 / Part C 第 2 版 #2, #3 |
+| H-9 | 2.1 | `video-upload/SKILL.md` description に `single_release` 型のトリガー語追記 | Part C 第 1 版 C-1.2 |
+| H-10 | 2.3 | `video-description/config.default.yaml:6` のコメント中 `short` 削除（v4.0.0 で撤去済スキル名残） | Part C 第 2 版 C-1-① / C-3-① |
+
+#### 取り込むべき P2（medium）fix 一覧
+
+| ID | 観点 | 内容 | 出典 |
+|---|---|---|---|
+| M-1 | 1.3 | analytics-collect / analytics-analyze の **30 分鮮度しきい値** を `config/skills/analytics.yaml::freshness_minutes` などに集約（双方で完全に同じ値の直書き重複）| 3 報告書一致 |
+| M-2 | 1.3 | `discover-competitors` に `config.default.yaml` 新設 + `channel-new` Step 5 の API パラメータも同じ config を参照（min_subscribers / max_subscribers / posted_within_days / top / per_keyword の **完全重複**）| Part B 候補 #6, #7 |
+| M-3 | 1.3 | `live-clean` に `config.default.yaml` 新設（削除/保護パターン外出し）| Part B 候補 #8 |
+| M-4 | 1.3 | `postmortem` に `config.default.yaml::thresholds.{ratio_vs_median, neutral_band_pct}` 新設（0.5 / 0.7 / 0.9 / ±10% を外出し、「文脈調整可」記述は残す）| Part A 第 1 版 #5.16 / Part B 候補 #9 |
+| M-5 | 1.3 | `video-upload` に `config.default.yaml` 新設（`selfDeclaredMadeForKids` / `containsSyntheticMedia` / NG ワード外出し）| Part B 候補 #14 |
+| M-6 | 1.1 / 1.3 | `streaming` の `notify timeout`（5/10 秒）/ `1Password ボルトパス` / `--check-threshold` の 80% を `config/skills/streaming.yaml` に外出し | Part A 第 1 版 #5.18, #3.5, Part A 第 2 版 A1-3 / Part B 候補 #10〜12 |
+| M-7 | 1.4 | `category_id: "10"` が `channel-setup/references/{config-template/youtube.json, upload-settings-template.json, schedule-template.json}` の 3 ファイルに重複 → Single Source 化 | Part A 第 2 版 A4-4 |
+| M-8 | 1.4 | `upload-settings-template.json:4` `"public"` と `schedule-template.json:9` `"private"` の `privacy_status` 矛盾解消 | Part A 第 2 版 A4-5 |
+| M-9 | 1.4 | `channel-setup/references/claude-md-template.md:13` / `channel-new/SKILL.md:100` の「`config/channel/{...} 計 7 ファイル`」を **8 ファイル**（`comments.json` 追加）に更新 | Part A 第 2 版 A4-12, A4-13 |
+| M-10 | 1.4 | `video-description/SKILL.md:89,107` の「ハッシュタグ 13 個」と `config-generation-rules.md:36-37` の「5 個」のドキュメント間矛盾 → どちらが正か実装側で確認の上統一 | Part A 第 2 版 A4-2, A4-3 |
+| M-11 | 2.2 | `videoup/SKILL.md` に「前工程」ブロックを追加し `/masterup`（Suno 系）+ `/lyria`（Lyria 系）の両方を明示（C-2 #2, #3 解消） | Part C 第 2 版 #2, #3 |
+| M-12 | 2.2 | `thumbnail/SKILL.md` Next Step に「Lyria チャンネルでは `/lyria <theme>`」分岐を追加（`/wf-new` Phase 2c には分岐があるが `/thumbnail` 単独実行時に欠落）| Part C 第 1 版 C-2 #9 |
+| M-13 | 2.2 | `video-description/SKILL.md` に「前工程: `/videoup`」を Cross References に追記 | Part C 第 2 版 #4 |
+| M-14 | 2.2 | `metadata-audit/SKILL.md` の Cross References に「前工程: `/video-upload`」追記 | Part C 第 2 版 #6 |
+| M-15 | 2.4 | description 末尾指示語の 5 系統揺れ → ガイドライン化（`.claude/skills/CONTRIBUTING.md` 仮 or CLAUDE.md 追加節）| Part C 第 1 版 5.2 |
+| M-16 | 2.4 | 本文見出しの 3 系統揺れ（`Cross References` / `関連ファイル` / `Next Step`、`Instructions` / `実行フロー`、`When to Use` / `いつ使うか`）→ いずれかへ統一方針宣言 | Part C 第 2 版 5.2 |
+
+#### 取り込むべき P3（low）fix 一覧
+
+| ID | 観点 | 内容 |
+|---|---|---|
+| L-1 | 1.4 | `video-description/config.default.yaml:44-52` の `theme_emoji` を `content.json::title.theme_emoji` に集約（既存 `theme_activities` / `theme_scenes` と一元化） |
+| L-2 | 1.4 | `channel-setup/references/{config-template/content.json, upload-settings-template.json, schedule-template.json, localizations-template.json}` の英語/日本ロケール固定 → プレースホルダ化 |
+| L-3 | 1.4 | `analytics-report/SKILL.md:73,123` の `#Shorts` 文字列固定 → `analytics.collection_filter_keywords` 統合 |
+| L-4 | 1.3 | `analytics-report` HTML KPI カード枚数（4）/ max-width（1200px）を skill-config 化 |
+| L-5 | 1.3 | `playlist` の `"all"` プレイリスト挿入順（head/tail）を `playlists.json` スキーマに追加 |
+| L-6 | 1.3 | `audience-persona` / `viewing-scene` の WebSearch クエリテンプレを `config.default.yaml` に外出し（AI 指示文と機械パラメータの切り分け前提）|
+| L-7 | 2.2 | `analytics-analyze/SKILL.md` 前提セクションに「`/wf-next` から T+7 日後に呼ばれる」追記 |
+| L-8 | 2.2 | `suno/SKILL.md` Cross References に「前工程: `/thumbnail`」追記 |
+| L-9 | 2.4 | `channel-setup/references/config-template/` → `config-templates/` ディレクトリ複数形リネーム |
+| L-10 | 1.1 | `videoup/references/generate_videos.sh` の ffmpeg 解像度・ビットレート・CRF を `config/skills/videoup.yaml` に外出し |
+| L-11 | 2.1 | `analytics-report/SKILL.md` description にトリガー語「ビジュアル」「ダッシュボード」「HTML レポート生成」を追記 |
+| L-12 | 1.1 | `suno` の禁止形容詞 17 語・NG/OK ワード 10 語超を skill-config の `scene_phrase_ng_words` に新設 |
+| L-13 | 1.1 | `metadata-audit` の `< 3` / `> 12` チャプター数閾値を skill-config 化 |
+| L-14 | 1.4 | `localizations-template.json::*.title_template` と `content.json::title.template` の重複統合 |
+
+#### 取り込まない / 明示否定すべき項目
+
+| ID | 内容 | 理由 |
+|---|---|---|
+| N-1 | shell helper（`log/ok/error` ANSI / `usage()` idiom）の共通化 | 配布の単純さを壊す（Part B 明言）|
+| N-2 | `videoup/generate_videos.sh` と `streaming/run-ffmpeg.sh` の ffmpeg 経路統合 | 用途・実行環境が完全に異なる（Part B 明言）|
+| N-3 | `postmortem → 4 検証 skill` の片方向バトンを「双方向化」修正 | postmortem は意図的な fan-out メタスキル（Part C 双方明言、設計判断）|
+| N-4 | `wf-new / wf-next / channel-new / channel-import / channel-setup` のオーケストレータ系 fan-out 片方向（合計 10 ペア） | 双方向化は冗長化のみで利得なし（Part C 第 1 版「意図あり 10」分類）|
+| N-5 | YouTube API 仕様値（タイトル 100 文字・video_id 11 文字・バナー 2048×1152・Music カテゴリ id 10）| プラットフォーム制約。skill-config 化しても更新権限がない |
+| N-6 | 「seed として挙がっていた `TBD` の仕様未統一」を fix 候補に入れる | 検証の結果、`channel-new/SKILL.md:107` の 1 箇所のみで CLI 既定値説明として明文化済。修正不要 |
+| N-7 | 「seed として挙がっていた `.py` 重複 3 種」を fix 候補に入れる | 検証の結果、`.claude/skills/**/references/` に Python ファイルは 0 件、`src/youtube_automation/scripts/` に各 1 件のみ。**重複は存在しない**ため、最終レポートで「seed の配置誤認、実態は重複なし」と短く明記する |
+
+---
+
+## 6. 全体サマリー（supervise への引き継ぎ用 1 段落版）
+
+35 スキルの監査結果として、(A) 観点 1.1〜1.4 の汎用化系では「**画像生成・解析モデル名やしきい値は skill-config 化が大きく進んでおり ID リテラルや API キー直書きはゼロ**」だが、「`analytics-report` のブランド色 9 色、`channel-new`/`channel-import`/`channel-setup` の **`daiki-beppu` GitHub owner 固定** および `~/01-dev/`・`~/02-yt` 個人パス、`analytics-analyze` の **v1.x 旧 namespace `channel_config.*` 残骸**、`scripts/gcp-{bootstrap,terraform-apply}.sh` の **MD5 完全一致 CLAUDE.md 規約違反**」が P1 として残存。(B) 観点 2.1〜2.4 の整合性系では「**frontmatter / 開始句 / kebab-case 命名は 100% 統一**」「**主要バトン 14 ペアは双方向成立**」と良好だが、「`video-analyze` の `/lyria`・`/channel-direction` への事実誤認」「`lyria`/`masterup` 出力 ↔ `videoup/generate_videos.sh` 検出パターン不一致（実害候補）」「description 末尾指示語と本文見出しの 3〜5 系統揺れ」が改善対象。**v4.0.0 deprecated `short` / `community` の真の残存は 1 箇所のみ**（`video-description/config.default.yaml:6` コメント内）で、コード本体には残骸なし。
+
+---
+
+## 7. 結論
+
+- **追加調査の必要なし**。次ステップ `supervise` は本 analysis の §5.「P1〜P3 fix 一覧」と §6.「全体サマリー」をそのまま `docs/audits/skills-audit-2026-05-18.md` へ整形・配置できる。
+- supervise 側で考慮すべきは「Part A 第 1 版と第 2 版の **観点定義の差**をどう吸収するか（第 1 版優先で統合する）」と、「ハッシュタグ 13 個 vs 5 個の矛盾（M-10）と videoup master 命名不整合（H-8）を **要確認マーク付きで明記**するか別 issue にバトンするか」の 2 点。前者は最終レポート内処理可能、後者は最終レポートの **「次に取るべきアクション」節**で別 issue 化を提案する形が綺麗。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/00-supervise-report.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/00-supervise-report.md
@@ -1,0 +1,104 @@
+# 調査レポート
+
+## 調査概要
+
+Issue #353「chore(skills): スキル汎用化・整合性の棚卸し監査レポート生成」の supervise ステップとして、analyze ステップが出力した `analysis-1.md` を order.md の 8 観点 + 既知シード 4 件に照らして評価し、最終レポート `docs/audits/skills-audit-2026-05-18.md` の骨格として採用可能か判定した。
+
+## 主要な発見
+
+- analysis-1.md は order.md の全 8 観点（1.1〜1.4 / 2.1〜2.4）を `file:line` 付きで網羅しており、policy の出典明記要件を充足。
+- 既知シード 4 件（重複スクリプト 3 種・`streaming --check-threshold`・`TBD` 統一・`postmortem` バトン）はすべて検証完了。うち `.py` 重複と `TBD` は **seed 側の前提誤認 / 既に解決済み**と判定され、最終レポートで短く言及するだけで足りる状態。
+- 3 つの dig 報告書（Part A 第 1/2 版・Part B・Part C 第 1/2 版）間で重要発見の矛盾なし。観点定義の差分は supervise の整形で吸収可能。
+- 「修正対象」と「正当な設計判断」の境界が `N-1〜N-7` として明示否定されており、policy「事実と推測の分離」要件を充足。
+- 残存ギャップ G-1〜G-4 は重要度が低〜中で、いずれも本 issue（棚卸し監査）のスコープ内で「要確認マーク付き記載」または「別 issue 化提案」で処理可能。追加調査は不要。
+- 判定: **APPROVE**。policy の APPROVE 条件 3 つすべて充足、REJECT 条件のいずれにも該当せず、80% 基準を超過。
+
+## 調査結果
+
+### トピック 1: 元依頼の各要件カバレッジ
+
+order.md 「スコープ（必ず全てカバーすること）」 8 項目との突合せ結果:
+
+| order.md 要件 | analysis-1.md 該当節 | 検出件数 / 内容 | 評価 |
+|---|---|---|---|
+| 1.1 ハードコード値の `file:line` 列挙 + 推奨移行先併記 | §1 観点 1.1 / §5 P1（H-2/H-4/H-5）+ P2（M-6）+ P3（L-10/L-12/L-13） | P1=6 / P2≈25 / P3≈20 件。移行先（`meta.json::channel.brand_color` / `config/skills/<skill>.yaml::<key>` 等）併記 | OK |
+| 1.2 重複スクリプト共通化候補（`benchmark_collector`/`generate_image`/`fetch_benchmark_comments` 既知シード含む） | §1 観点 1.2 / §5 P1（H-6）/ §3 検証済み懸念 | `scripts/gcp-bootstrap.sh` ≡ `channel-setup/references/gcp-bootstrap.sh`（MD5 `e421...606a`）、`scripts/gcp-terraform-apply.sh` ≡ `channel-setup/references/gcp-terraform-apply.sh`（MD5 `358b...244`）の 2 ペア確定。`.py` 重複は **seed 配置誤認**として独立 grep で否定（実体は `src/youtube_automation/scripts/` 配下に各 1 件のみ） | OK |
+| 1.3 skill-specific config 余地 | §1 観点 1.3 / §5 P2（M-1〜M-6） | 既存 `config.default.yaml` 9 スキル / 新規候補（小）11 件 / （中〜大）5 件 | OK |
+| 1.4 既存 config 未参照（直書きしている箇所） | §1 観点 1.4 / §5 P1（H-1/H-3）+ P2（M-7〜M-10） | P1=4（旧 namespace `channel_config.tags.themes` 等）/ P2≈9（`category_id: "10"` の 3 ファイル重複、`privacy_status` 矛盾、`config/channel/*.json` 7 ファイル → 8 ファイル更新漏れ等） | OK |
+| 2.1 description ↔ references/ 実装乖離 | §1 観点 2.1 / §5 P1（H-7/H-9）+ P3（L-11） | Major 1 件（`video-analyze` の `/lyria`・`/channel-direction` 事実誤認）/ Minor 2 件（`video-upload` single_release 言及欠落 等） | OK |
+| 2.2 バトン双方向整合（`postmortem` の曖昧バトン具体化案含む） | §1 観点 2.2 / §5 P1（H-8）+ P2（M-11〜M-14）+ P3（L-7/L-8） | 双方向成立 14 ペア / 片方向要修正 4 ペア / 意図的 fan-out 10 ペア。`postmortem` は意図的メタスキルとして明示否定 N-3 | OK |
+| 2.3 v4.0.0 deprecated（short/community）参照 | §1 観点 2.3 / §5 P1（H-10） | 真の残存 1 件（`video-description/config.default.yaml:6` のコメント内 `short`）/ 偽陽性 18 件除外 | OK |
+| 2.4 形式揺れ（trigger 語形式・Use when 構文・ファイル構成） | §1 観点 2.4 / §5 P2（M-15/M-16）+ P3（L-9） | frontmatter/開始句/kebab-case 命名は 100% 統一（35/35）/ description 末尾指示語 5 系統 / 本文見出し 3 系統 / テンプレ命名 3 様式 | OK |
+
+### トピック 2: 既知シード 4 件の検証
+
+order.md 「既知のシード」節との突合せ:
+
+| シード | analyze 結論 | 検証手段 | 評価 |
+|---|---|---|---|
+| 重複スクリプト 3 種（`benchmark_collector.py × 3` / `generate_image.py × 3` / `fetch_benchmark_comments.py × 2`） | **配置誤認**。`.claude/skills/**/references/` には Python ファイル 0 個、実体は `src/youtube_automation/` 配下に各 1 件のみ。コード重複は存在しない | analyze §3 で `Grep` による独立再検証 | OK（seed 誤認を明記） |
+| `streaming/SKILL.md` の `--check-threshold` が config 非連動 | 検出済（3 報告書一致）。`config/skills/streaming.yaml::bandwidth_threshold_ratio` 新設を提案 | Part A 第 1 版 #5.18 / Part A 第 2 版 A1-3 / Part B 候補 #11 で三重検出 | OK |
+| `channel-new` / `channel-direction` 初期値 `"TBD"` 仕様未統一 | **既に解決済み**。`TBD` 出現は `channel-new/SKILL.md:107` の 1 箇所のみで CLI 既定値説明として明文化。`/channel-direction` で実値上書きフローも明記 | analyze §3 で `Grep "TBD"` による独立再検証 | OK（解決済みを明記） |
+| `postmortem` のバトン記述曖昧 | 検出済。意図的 fan-out メタスキルとして 4 検証 skill 側に back-ref を強要しない方針として明文化を推奨 | Part C 第 1/2 版双方で検出、明示否定 N-3 として整理 | OK |
+
+### トピック 3: policy 適合性評価
+
+| policy 項目 | analysis-1.md の状態 | 評価 |
+|---|---|---|
+| 自律行動（質問しない、仮定明示） | ユーザーへの問い合わせなし、観点定義差は「第 1 版優先」と仮定を明示 | OK |
+| 事実と推測の分離 | H-8（master 命名不整合）に「実害判定要再現」と留保、G-2/G-4 は「実装側読みが必要」と明示 | OK |
+| 定量優先 | P1=10 / P2=16 / P3=14 / 明示否定 7 件、双方向 14 ペア / 片方向 4 ペア / 35 ファイル等、すべて数値記載 | OK |
+| 出典明記 | 全検出に `file:line` 形式の出典（例: `analytics-report/SKILL.md:94-101`、`channel-new/SKILL.md:107`） | OK |
+| 正直な報告 | 残存ギャップ G-1〜G-4 を §4 で明示、調査不可項目（実装側コード読み）はスコープ外と理由明記 | OK |
+| 80% 基準 | 8 観点 + 既知シード 4 件すべて検出済み、追加調査の限界効用が小さい | OK |
+| 結論 + 根拠 + 分析 | §5 fix 一覧（結論）+ 出典列（根拠）+ §2 観点別判断（分析）で揃う | OK |
+
+### トピック 4: 残存ギャップの supervise レポート生成への影響
+
+analysis §4 で特定された G-1〜G-4 の処理方針:
+
+| ID | ギャップ内容 | 重要度 | supervise 整形時の処理 |
+|---|---|---|---|
+| G-1 | Part A 第 1 版 vs 第 2 版の観点定義差（A-1〜A-5 カテゴリ区分） | 低 | 第 1 版（A-1=ID リテラル限定）の用語を採用し、第 2 版の件数差は脚注扱い |
+| G-2 | `video-description/SKILL.md` ハッシュタグ 13 個 vs `config-generation-rules.md` 5 個の数値矛盾 | 中 | M-10 として「要確認マーク」付きで列挙、別 issue 化を「次に取るべきアクション」節で提案 |
+| G-3 | Part C 片方向バトン件数差（14 中 4 vs 9 中 P1=3〜4） | 低 | 顔ぶれが一致しているため、supervise 整形で件数表記を統一 |
+| G-4 | `lyria`/`masterup` 出力 ↔ `videoup/generate_videos.sh` 検出パターン不一致の実害判定 | 中〜高 | H-8 として記載、修正案 a/b/c を提示、別 issue 化を提案 |
+
+いずれも本 issue（棚卸し監査レポート生成）のスコープ内で処理可能。修正実装は本 issue の責務外であり、analysis の整理で十分。
+
+## データソース
+
+| # | ソース | 種別 | 信頼度 |
+|---|--------|------|--------|
+| 1 | `.takt/runs/20260518-074104-issue-353-chore-skills-claude/reports/analysis-1.md` | コードベース（analyze ステップ出力） | High |
+| 2 | `.takt/runs/20260518-074104-issue-353-chore-skills-claude/context/task/order.md` | コードベース（issue 仕様書） | High |
+| 3 | `.takt/runs/20260518-074104-issue-353-chore-skills-claude/context/policy/supervise.1.20260518T083944Z.md` | コードベース（policy 定義） | High |
+| 4 | `.takt/runs/20260518-074104-issue-353-chore-skills-claude/context/knowledge/supervise.1.20260518T083944Z.md` | コードベース（knowledge 定義） | High |
+| 5 | analysis §3 が引用する独立検証（`Grep "benchmark_collector\|fetch_benchmark_comments\|generate_image"`、`Grep "TBD"`、`ls .claude/skills/`） | コードベース（analyze による再検証） | High |
+| 6 | 3 つの dig 報告書（Part A 第 1/2 版・Part B・Part C 第 1/2 版） | コードベース（dig ステップ出力、analysis §2.1 で相互整合性確認済み） | High |
+
+## 結論と推奨
+
+### 判定: APPROVE（承認）
+
+analysis-1.md は order.md の 8 観点すべてを `file:line` 出典付きで網羅し、既知シード 4 件をすべて検証（うち 2 件は seed 自体の誤認/解決済みと判定）。policy「APPROVE 条件」3 つ（明確な回答 / 十分な根拠 / 重大な調査漏れなし）をすべて充足、REJECT 条件のいずれにも該当しない。Planner への差し戻しは不要。
+
+### supervise レポート生成への引き継ぎ指示
+
+最終レポート `docs/audits/skills-audit-2026-05-18.md` の生成時、analysis-1.md の §5（P1〜P3 fix 一覧 + 明示否定）と §6（全体サマリー）をそのまま骨格として採用してよい。整形時の処理は以下 2 点のみ:
+
+1. **観点定義の統一**: Part A 第 1 版（A-1=ID リテラル限定の用語）を採用。第 2 版の件数差（A-1=14 件等）は脚注で補足扱い。
+2. **要確認マーク + 別 issue 化提案**: M-10（ハッシュタグ 13 vs 5 のドキュメント間矛盾）と H-8（`lyria`/`masterup` master 命名 ↔ `videoup` 検出パターン不一致）は「実装側コード読みが必要」と明記の上、最終レポートの「次に取るべきアクション」節で別 issue 化を提案。
+
+### レポート構造（order.md 32 行の指定通り）
+
+1. サマリー
+2. 観点 1.1〜1.4（汎用化・設定ファイル切り出し）
+3. 観点 2.1〜2.4（整合性）
+4. 優先度付き fix リスト（high=P1 10 件 / medium=P2 16 件 / low=P3 14 件 / 明示否定 7 件）
+
+## 残存ギャップ（あれば）
+
+- **G-2（ハッシュタグ 13 個 vs 5 個の矛盾）**: 実装側 `metadata_generator.py` を読まないとどちらが正か確定できない。本 issue のスコープ（`.claude/skills/**` の棚卸し監査）を超えるため、最終レポートで「要確認」マーク付き記載 + 別 issue 化提案で処理。
+- **G-4（`lyria`/`masterup` 出力 ↔ `videoup` 検出パターン不一致）**: 実害判定には実行ログ・統合テストが必要。本 issue のスコープ外。最終レポートで修正案 a（generate_videos.sh 検出拡張）/ b（出力名統一）/ c（Next Step に明記）の 3 案を提示 + 別 issue 化提案。
+- **修正実装の責務範囲**: order.md 制約「修正提案は文章で書くだけ、コードには触らない」「`.claude/skills/**` への write 禁止」に従い、本 issue では実際の fix 適用は行わず、最終レポートを成果物とする。fix の実施は別 issue にバトンする前提。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/01-plan.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/01-plan.md
@@ -1,0 +1,125 @@
+# Research Plan — Issue #353 スキル汎用化・整合性の棚卸し監査
+
+実行日: 2026-05-18
+担当ステップ: plan (1/4)
+次ステップ: dig（調査実行）→ analyze（分析）→ supervise（最終整形）
+
+---
+
+## 1. 依頼の分解
+
+### What（何を知りたいか）
+`.claude/skills/` 配下 35 スキル（35 件確定: `ls .claude/skills/` で確認済み）に対して、以下 2 観点 × 計 8 項目を網羅的に棚卸しした監査レポート（`docs/audits/skills-audit-2026-05-18.md`）を生成する。
+
+- 観点 1: 汎用化・設定ファイル切り出し（1.1 ハードコード値検出、1.2 重複スクリプト共通化、1.3 skill-specific config 余地、1.4 既存 config キーへの未参照）
+- 観点 2: 整合性（2.1 description ↔ 実装乖離、2.2 バトン双方向リンク、2.3 deprecated 機能参照、2.4 形式揺れ）
+
+### Why（なぜ知りたいか・推測）
+- 35 スキルの蓄積で「ハードコード残り」「重複スクリプト」「片方向バトン」「v4.0.0 で撤去した short/community への残存参照」「書式揺れ」がノイズとして溜まっている疑い
+- 配布パッケージ（`yt-skills sync` 経由で他チャンネル repo に展開）の品質ガバナンスとして、定期点検レポート 1 本にまとめたい
+- 「修正は別 issue」と切り分けることで、レビュー対象が肥大化することを避けたい
+
+### Scope（どこまで調べるべきか）
+- **対象**: `.claude/skills/**/SKILL.md` および `.claude/skills/**/references/**`、加えて参照される `config/channel/*.json`（実体は `examples/channel_config.example/` をテンプレ参照）と `src/youtube_automation/utils/config/*.py`
+- **対象外**:
+  - `.claude/skills/**` への書き込み（protected paths のため禁止、order.md 41 行制約）
+  - 既存ファイルの修正、レポート以外のファイル新規作成
+  - 修正の実装そのもの（あくまで「文章で提案」までに留める）
+- **成果物**: `docs/audits/skills-audit-2026-05-18.md` 1 ファイル新規作成 + PR 化
+
+### 仮定（暗黙の前提・明示化）
+- 「ハードコードされたチャンネル固有値」とは、特定チャンネルのジャンル名・タグ・URL・しきい値 etc. を **コード or SKILL.md に直書き** している箇所を指す（`config/channel/*.json` 経由で外部化できる値）。
+- 「バトン記述」とは SKILL.md 内の「前工程は /xxx」「次工程は /yyy」表現で、双方向リンクとして閉じているかを検証する。
+- 「v4.0.0 で撤去」については `CLAUDE.md` の `workflow.json` 注記から `short / community` が撤去されたと判断（"v4.0.0 で short / community 撤去"）。他に deprecated 機能の手がかりは CHANGELOG / git log から拾う必要があるが、見つからなければ `short / community` のみを対象とする。
+- レポート提出形式は order.md 32 行に従い「サマリー → 観点 1.1〜1.4 → 観点 2.1〜2.4 → 優先度付き fix リスト（high/medium/low）」の固定構造。
+
+---
+
+## 2. 調査項目の洗い出し
+
+order.md の「並列調査のヒント」（Part A/B/C）に沿って 3 part 構成にする。dig step は Part を順に消化、または並列実行する。
+
+### Part A: ハードコード値検出 & config 参照漏れ（観点 1.1 + 1.4）
+
+| ID | 調査項目 | 期待アウトプット |
+|----|---------|----------------|
+| A-1 | 全 SKILL.md / references/ を走査し、ジャンル名・カテゴリ ID・URL・しきい値・タグ・チャンネル名・チャンネル ID 等の **直書きリテラル** を `file:line` で抽出 | 検出リスト（file:line + 抜粋 + 推奨移行先キー） |
+| A-2 | `examples/channel_config.example/*.json` の全キーを列挙し、各キーに対して「該当値が直書きされている skill」を逆引きマッピング | キー→直書き skill の対応表 |
+| A-3 | `examples/channel_config.example/` に存在しない値（しきい値・マジックナンバー）について、新規 config キー追加提案（推奨セクション: `audio.json` か `youtube.json` か `analytics.json` か） | 新規 config キー提案リスト |
+| A-4 | 既知シード `streaming/SKILL.md` の `--check-threshold` が config 非連動である件の具体的位置特定 | file:line 確定 |
+| A-5 | 既知シード `channel-new` / `channel-direction` の初期値 `"TBD"` の出現箇所と仕様書化されていない揺れの可視化 | file:line 列挙 + 統一案 |
+
+### Part B: 重複スクリプト & skill-specific config 余地（観点 1.2 + 1.3）
+
+| ID | 調査項目 | 期待アウトプット |
+|----|---------|----------------|
+| B-1 | 既知重複 3 種（`benchmark_collector.py` × 3, `generate_image.py` × 3, `fetch_benchmark_comments.py` × 2）の **実体パス特定** と内容差分の要約（フォーク具合）。共通化先候補は `src/youtube_automation/utils/` 配下のどのモジュールか | 重複マップ + 共通化先提案 |
+| B-2 | 他にも重複している references/ スクリプト（同名・類似機能）の自動検出（ファイル名 hash + 拡張子別の出現数） | 追加重複候補リスト |
+| B-3 | skill ごとに「`config/skills/<skill>.yaml` 等の skill-specific config を導入したほうがよい」候補を抽出（例: 閾値・テンプレート・プロンプトを SKILL.md 内に直書きしているケース） | 候補リスト（理由付き） |
+| B-4 | 既存 `load_skill_config()` を使っているスキル・使っていないスキルの仕分け（`utils/config/` 内の関数定義から逆引き grep） | 使用 skill 一覧 vs. 未使用 skill 一覧 |
+
+### Part C: 整合性 4 項目（観点 2.1〜2.4）
+
+| ID | 調査項目 | 期待アウトプット |
+|----|---------|----------------|
+| C-1 | 全 SKILL.md の `description:` 冒頭文 と references/ の実装機能 を突合（description にあるが実装なし／実装にあるが description にない） | 乖離リスト |
+| C-2 | バトン記述（「前工程」「次工程」「/xxx」）を全 SKILL.md から抽出し、対向 skill 側に対応する記述があるかを双方向検証。`postmortem` の曖昧バトンの具体化案を含める | バトン整合マトリクス + 修正案 |
+| C-3 | v4.0.0 で撤去された `short` / `community` への参照、その他 deprecated（旧 channel_config.json、撤去済み機能）への参照を全文検索 | 残存参照リスト |
+| C-4 | description のトリガー語形式（「Use when ...」構文 / 末尾「〜」体言止め）、ファイル構成（references/ / templates/ / scripts/）の揺れを集計 | 形式揺れ統計 + 統一案 |
+
+---
+
+## 3. データソース候補
+
+| 調査項目 | 一次データソース | 二次・補助 |
+|----------|-----------------|-----------|
+| A-1, A-2 | `.claude/skills/**/SKILL.md`, `.claude/skills/**/references/**/*.{py,sh,md,yaml,json}` | `examples/channel_config.example/*.json`（正規キー）、`src/youtube_automation/utils/config/*.py`（dataclass 定義） |
+| A-3 | 抽出された未マッピング値 | `examples/channel_config.example/` 全文 |
+| A-4 | `.claude/skills/streaming/SKILL.md` と `references/` | `infra/terraform/streaming/` （命名根拠） |
+| A-5 | `.claude/skills/channel-new/`, `.claude/skills/channel-direction/` | `"TBD"` の grep 結果全件 |
+| B-1, B-2 | `.claude/skills/**/references/**/*.py` の同名ファイル | `src/youtube_automation/utils/` 既存ユーティリティ群 |
+| B-3, B-4 | SKILL.md 本文（直書きの閾値・テンプレ）+ `src/youtube_automation/utils/config/loader.py` の `load_skill_config()` 参照箇所 | `config/skills/` ディレクトリ有無 |
+| C-1 | SKILL.md `description:` フィールド | `references/` ファイル一覧と中身 |
+| C-2 | SKILL.md 全文の「次工程」「前工程」「/skill-name」抽出 | バトン対象 skill の SKILL.md |
+| C-3 | 全 skill 配下の `short` / `community` / `channel_config.json` （旧形式）の grep | `CLAUDE.md` の deprecate 注記 |
+| C-4 | SKILL.md の YAML frontmatter / description 末尾文体 / ディレクトリ構造 | 任意 skill の「正規形」サンプル（最大公約数） |
+
+---
+
+## 4. 優先順位
+
+| 優先度 | 定義 | 対象項目 |
+|--------|------|---------|
+| **P1: 必須**（これがないと回答できない） | レポート骨格の各 section 1.1〜2.4 を埋めるのに直接必要なデータ | **A-1, A-4, A-5, B-1, C-1, C-2, C-3** |
+| **P2: 重要**（あると回答の質が上がる） | レポートの説得力・修正提案の具体性を高めるデータ | **A-2, A-3, B-3, B-4, C-4** |
+| **P3: あれば良い**（時間があれば） | 既知シード以外の追加発見を狙う網羅探索 | **B-2** |
+
+### dig step への指示まとめ（並列実行推奨）
+
+- **Part A**（A-1〜A-5）: 単独 agent で grep ベース機械検出 + 抜粋。1.1 と 1.4 を担当
+- **Part B**（B-1〜B-4）: 単独 agent でファイル名 hash 集計 + load_skill_config 利用調査。1.2 と 1.3 を担当
+- **Part C**（C-1〜C-4）: 単独 agent で description ↔ 実装突合とバトン双方向検証。2.1〜2.4 を担当
+
+各 part は **独立** に実行可能（Part A/B が触る対象は重なるが、観点は直交）。dig step は Part A/B/C を **並列 1 メッセージ 3 tool call** で実行することで遅延を圧縮できる。
+
+### 出力ファイル（dig 用）
+
+各 part の出力は次ステップ `analyze` がマージしやすいよう、以下の構造で `reports/dig-part-<A|B|C>.md` に保存することを推奨:
+
+```
+## 概要（数行）
+## 検出結果（file:line + 抜粋 + 推奨アクション）
+## カバレッジ（探した範囲・除外した範囲）
+## 調査不可項目（あれば「調査不可」と明記、policy 準拠）
+```
+
+---
+
+## 5. 制約・注意
+
+- **`.claude/skills/**` への write 禁止**（order.md 41 行・CLAUDE.md「skill 編集は takt 経由で行わない」節と整合）。dig step は **Read / Grep / Glob のみ** 使う前提
+- 修正提案は文章のみ。コードには触らない
+- レポート以外のファイル新規作成・既存ファイル変更は禁止（出力は `docs/audits/skills-audit-2026-05-18.md` 1 ファイルのみ）
+- 各検出は `file:line` 形式で出典明示（policy「出典明記」原則）
+- 調査不可項目は「調査不可」と正直に報告（policy「正直な報告」原則）
+- 80% 基準で進める。完璧を求めて停滞しない（policy「80%基準」原則）

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/02-dig-part-A-v1.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/02-dig-part-A-v1.md
@@ -1,0 +1,288 @@
+# dig-part-a — ハードコード値検出 & 既存 config 参照漏れ
+
+実行日: 2026-05-18
+担当ステップ: dig (2/4) — Part A
+対象: `.claude/skills/**` 配下 **35 スキル**（`SKILL.md` 35 件 + `references/**` + `config.default.yaml` 9 件、合計 81 ファイル）
+比較対象 (一次情報): `examples/channel_config.example/*.json` 8 ファイル（meta / content / youtube / analytics / playlists / workflow / audio / comments）
+方法: Read / Grep / Glob のみ（編集禁止 — `.claude/skills/**` は protected paths）
+
+---
+
+## 1. 概要
+
+| 区分 | 検出件数 | 主な内訳 |
+|---|---|---|
+| **A-1 数値ハードコード**（しきい値・尺・タイムアウト等） | **14 箇所** | レポート鮮度 30 分（×2 skill）/ Veo 8 秒 / Lyria 184 秒 / API timeout 5+10 秒 / CTR 判定閾値 0.5/0.7/0.9 / video_id 文字数 11 / マスター動画解像度 1920×1080 / 等 |
+| **A-2 モデル名・URL ハードコード** | **11 箇所** | `gemini-2.5-flash` ×4 / `veo-3.1-fast-generate-001` ×3 / `lyria-3-pro-preview` ×2 / `gpt-image-2` / `gemini-3.1-flash-image-preview` / `cdn1.suno.ai` ×4 / `discord.com` 正規表現 / `cloud.google.com/sdk` 等 |
+| **A-3 パス・ディレクトリ直書き**（`channel_dir()` / `CollectionPaths` を経由していない） | **22 箇所** | `collections/planning/` ×9 / `collections/live/` ×11 / `01-master/` / `02-Individual-music/` / `10-assets/` / `20-documentation/` / `auth/token.json` / `branding/` 等。多くは ガイド／例示用で正当 |
+| **A-4 既存 config キーと重複している直書き** | **6 箇所** | `descriptions.perfect_for` の項目数 "4" / `descriptions.hashtags` "5 個" / `tags.base` 件数 "10 個程度" / `tags.themes` "6-10 テーマ" / `audio.target_duration_min/max` 監査文言 / `youtube.category_id="10"` 等 |
+| **A-5 raw `json.load` / `yaml.safe_load` で channel config を読んでいる references スクリプト** | **0 箇所**（false positive 1 件） | `channel-setup/references/verification.md:12` の `json.load(open(p))` は **JSON 構文検証**用途で、設定値の消費ではないため対象外 |
+
+**Top 影響度（P1）**: §7 サマリー参照。最も対応価値が高いのは **(1) 30 分鮮度しきい値の skill-config 化**（analytics-collect / analytics-analyze で全く同じ「30 分」が直書き）、**(2) API timeout / Veo duration の skill-config 化**、**(3) `descriptions.perfect_for` 個数や `tags.base` 個数の SKILL.md→config-generation-rules.md 一元化**。
+
+---
+
+## 2. A-1 — 数値ハードコード（しきい値・尺・タイムアウト・リトライ）
+
+### 検出フォーマット
+`file:line — 値 / 文脈 → 提案外出し先`
+
+| # | file:line | 値 | 文脈 | 提案外出し先（推測） |
+|---|---|---|---|---|
+| A1-1 | `.claude/skills/analytics-collect/SKILL.md:36-39` | **30 分** | 「ファイルの更新時刻が **30分以内** → 収集をスキップ」 | `config/skills/analytics-collect.yaml::freshness_minutes`（新規） |
+| A1-2 | `.claude/skills/analytics-analyze/SKILL.md:38-39` | **30 分** | 「30分以内に生成されたレポートがあれば分析をスキップ」 | 同上（共通の `analytics.freshness_minutes` を 1 か所に） |
+| A1-3 | `.claude/skills/streaming/references/notify.sh:67-68` | **5 秒 / 10 秒** | `curl --connect-timeout 5 --max-time 10` | `config/skills/streaming.yaml::notify.{connect_timeout_sec,max_time_sec}`（要確認・streaming は ops 性が強い） |
+| A1-4 | `.claude/skills/streaming/references/healthcheck.sh:79`（SKILL.md 参照） | **5 分間隔 / RuntimeMaxSec=11h / RestartSec=1h** | systemd cron / Terraform 定義由来。SKILL.md L8, L80 で参照 | `infra/terraform/streaming/` の tfvar が Single Source。SKILL.md 側はドキュメントなので **正当**（要確認） |
+| A1-5 | `.claude/skills/loop-video/SKILL.md:118` / `loop-video/config.default.yaml:20` | **8 秒** | `veo.duration_seconds: 8`（Veo API 制約） | **既に skill-config 化済み**（OK、追加対応不要） |
+| A1-6 | `.claude/skills/lyria/SKILL.md:10,76,94,168` / `lyria/config.default.yaml:8,15` | **184 秒** | Lyria 3 1 リクエスト上限。SKILL.md 4 箇所で直書き | **既に skill-config 化済み**だが、SKILL.md 内の `184` 数値は CLI 計算式 `ceil((target + padding) * 60 / 184)` でも露出。コード側に集約推奨（CLI に定数化） |
+| A1-7 | `.claude/skills/lyria/config.default.yaml:28` | **5 秒** | `crossfade_sec: 5`（セグメント間クロスフェード） | skill-config 化済み（OK） |
+| A1-8 | `.claude/skills/lyria/SKILL.md:194` | **3** | `--max-retries N` default: 3 | CLI 側 default なので CLI 実装に集約。**要確認**（skill-config からも上書き可能にすべきか） |
+| A1-9 | `.claude/skills/postmortem/SKILL.md:71-78` | **0.5 / 0.7 / 0.9 / 0.5 / 0.9 / 0.7** | CTR 判定の比率閾値（赤/黄/薄黄/緑） | `config/skills/postmortem.yaml::thresholds.ratio_vs_median.{red,yellow,light_yellow}`（新規） |
+| A1-10 | `.claude/skills/postmortem/SKILL.md:45` | **11 文字** | `<video_id>（11 文字英数 + -_）` | YouTube API 仕様値。**正当**（外出し不要） |
+| A1-11 | `.claude/skills/postmortem/SKILL.md:64` | **±10%** | 「全指標が中央値前後（±10%）」 | A1-9 と同セクションに統合（`thresholds.neutral_band_pct`） |
+| A1-12 | `.claude/skills/videoup/references/generate_videos.sh:73,148-149,174-175,189,202,212` | **1920×1080 / 384k / 48000 / CRF 18/23 / framerate 1** | ffmpeg コマンドの固定値（解像度・ビットレート・CRF） | `config/skills/videoup.yaml`（新規）に `video.{width,height,audio_bitrate,sample_rate,crf}` セクション。**P2**（チャンネル独自のフォーマットを許容したい場合のみ） |
+| A1-13 | `.claude/skills/collection-ideate/config.default.yaml:18,37` | **2 / 0.5** | `session_id_bytes: 2`, `originality.max_similarity: 0.5` | **既に skill-config 化済み**（OK） |
+| A1-14 | `.claude/skills/benchmark/config.default.yaml:10,13,16,24` | **50 / 10000 / 3 / 5** | `scan_recent / min_views / freshness_days / delay_sec` | **既に skill-config 化済み**（OK） |
+| A1-15 | `.claude/skills/comments-reply/SKILL.md:58` | **100** | `--per-video-limit N` default: 100 | CLI default。`config/channel/comments.json` 側に `per_video_limit` を足すと整合性 ↑（**要確認**） |
+| A1-16 | `.claude/skills/discover-competitors/SKILL.md:85-90,116` | **10K / 1M / 30日 / 20 / 660 units** | CLI フラグ既定値の引用 | CLI 側に集約済み。SKILL.md は **ドキュメンテーション** なので **正当**（ただし数値変更時の同期コストあり） |
+| A1-17 | `.claude/skills/video-analyze/config.default.yaml:10` | **10** | `delay_sec: 10`（API レート対策） | **既に skill-config 化済み**（OK） |
+| A1-18 | `.claude/skills/masterup/config.default.yaml:10,13` | **1.0 / "192k"** | `audio.crossfade_duration / bitrate` | **既に skill-config 化済み**（OK） |
+| A1-19 | `.claude/skills/thumbnail/config.default.yaml:101` | **1** | `openai.batch: 1` | **既に skill-config 化済み**（OK） |
+| A1-20 | `.claude/skills/analytics-report/SKILL.md:62,104` | **4 / 1200px** | KPI カード枚数 / `max-width: 1200px` | 影響度低。HTML テンプレ側に集約（**P3**） |
+| A1-21 | `.claude/skills/wf-next/SKILL.md:41` / `lyria/SKILL.md:201` | **184 秒 / 30〜90 秒** | ガイド文書内の数値 | A1-6 参照（CLI 定数で集約） |
+| A1-22 | `.claude/skills/channel-setup/references/verification.md:68-69` | **2048×1152 / 800×800 / 6MB / 4MB** | YouTube バナー・アイコン上限値 | YouTube API 仕様値。**正当**（外出し不要） |
+
+**正味の新規外出し候補（P1）**: A1-1/A1-2（30 分鮮度）、A1-3（streaming notify timeout）、A1-9/A1-11（postmortem CTR 判定閾値）。
+**正味の新規外出し候補（P2）**: A1-12（videoup の ffmpeg パラメータ）、A1-15（comments-reply の per-video-limit）。
+
+---
+
+## 3. A-2 — モデル名・API バージョン・エンドポイント URL の直書き
+
+| # | file:line | 値 | 文脈 | 提案外出し先 |
+|---|---|---|---|---|
+| A2-1 | `.claude/skills/benchmark/SKILL.md:98` / `benchmark/config.default.yaml:23` | `gemini-2.5-flash` | サムネイル分析モデル | **既に skill-config 化済み**（`thumbnail_analysis.model`、OK） |
+| A2-2 | `.claude/skills/video-analyze/SKILL.md:58` / `video-analyze/config.default.yaml:7` | `gemini-2.5-flash` | Gemini モデル | **既に skill-config 化済み**（OK） |
+| A2-3 | `.claude/skills/wf-new/references/scene_phrases.md:26,41` | `gemini-2.5-flash` | `yt-populate-scene-phrases --model` の既定値ドキュメント | CLI 側 default を引用。**正当**（ドキュメンテーション） |
+| A2-4 | `.claude/skills/loop-video/SKILL.md:107,116` / `loop-video/config.default.yaml:8` | `veo-3.1-fast-generate-001` / `veo-3.1-generate-001` / `veo-3.1-lite-generate-preview` | Veo モデル | **既に skill-config 化済み**（OK） |
+| A2-5 | `.claude/skills/lyria/SKILL.md:60,85` / `lyria/config.default.yaml:17` | `lyria-3-pro-preview` / `lyria-3-clip-preview` | Lyria モデル | **既に skill-config 化済み**（OK） |
+| A2-6 | `.claude/skills/thumbnail/config.default.yaml:18,89` | `gemini-3.1-flash-image-preview` / `gpt-image-2` | Gemini/OpenAI 画像生成モデル | **既に skill-config 化済み**（OK） |
+| A2-7 | `.claude/skills/collection-ideate/SKILL.md:139` | `gemini-3.1-flash-image-preview` | コスト見積りの例示文字列 | thumbnail skill-config 経由で取得済み（OK） |
+| A2-8 | `.claude/skills/masterup/SKILL.md:22,84,89,174` / `masterup/config.default.yaml:33` | `https://cdn1.suno.ai/{song_id}.mp3` | Suno CDN URL テンプレ | **既に skill-config 化済み**（`suno_download.cdn_url_template`、OK）。ただし SKILL.md 本文側 4 箇所で URL が再露出 → skill-config 値の引用に統一推奨 |
+| A2-9 | `.claude/skills/streaming/references/notify.sh:37` | `https://(discord\.com\|discordapp\.com)/api/webhooks/` | Discord 公式ホスト許可リスト（SSRF 防御の正規表現） | セキュリティ上 **正当**（コード側に固定すべき） |
+| A2-10 | `.claude/skills/streaming/SKILL.md:51,52` | `op://Personal/YouTube/stream_key` etc. | 1Password アイテムパス | 個人ボルト名は **チャンネル個別設定**。`config/skills/streaming.yaml::onepassword_paths` で外出し可（**P2**、要確認） |
+| A2-11 | `.claude/skills/channel-setup/references/gcp-bootstrap.sh:108,239` / `gcp-terraform-apply.sh:38` / `streaming/references/swap_video.sh:62` | `https://cloud.google.com/sdk/docs/install` / `https://developer.hashicorp.com/terraform/install` / `https://console.cloud.google.com/apis/credentials?project=…` | エラーメッセージ内のガイド URL | **正当**（外部公式ドキュメントへの恒久リンク） |
+| A2-12 | `.claude/skills/channel-import/SKILL.md:26` / `channel-new/SKILL.md:49` | `git+https://github.com/daiki-beppu/youtube-channels-automation.git` | パッケージインストール URL | 配布元の Single Source。テンプレリポ移行時のみ更新必要（**正当**だが移行検討の影響範囲調査時に拾えるようメモ） |
+| A2-13 | `.claude/skills/lyria/config.default.yaml:32-37` | `ambient pads / ethereal choir / cinematic / orchestral / epic / synthesizer` | Lyria NG ワードリスト | **既に skill-config 化済み**（OK） |
+| A2-14 | `.claude/skills/suno/config.default.yaml:13` | `heavy metal, aggressive, EDM, dubstep, …` | Suno Exclude Styles | **既に skill-config 化済み**（OK） |
+
+**結論**: A-2 系の新規外出し候補は **A2-8（masterup SKILL.md 本文の URL 4 箇所の引用化）** と **A2-10（streaming の 1Password ボルトパス）** のみ。他はすべて既に skill-config 化済み or 外出し不要。
+
+---
+
+## 4. A-3 — ファイルパス・ディレクトリ名の直書き
+
+検出方針: `collection_paths.CollectionPaths` を経由せず `01-master/` `10-assets/` `20-documentation/` 等を文字列リテラルで参照している箇所、および `config/channel/` や `auth/` を直書きしている箇所。
+
+| # | file:line | 値 | 文脈 | 判定 / 提案 |
+|---|---|---|---|---|
+| A3-1 | `.claude/skills/videoup/references/generate_videos.sh:23-24,39,49,144` | `01-master/`, `10-assets/`, `loop_normalized.mp4` | ffmpeg コマンドのコレクションパス解決 | bash スクリプトのため `CollectionPaths` 不可。**現状維持で正当**（コード内定数として扱う） |
+| A3-2 | `.claude/skills/live-clean/SKILL.md:39,92-100` | `01-master/master.mp3` / `01-master/master-mix.wav` / `01-master/*-Master.mp4` / `02-Individual-music/*.mp3` / `10-assets/loop_normalized.mp4` | 削除対象ファイルの SKILL.md 内列挙 | SKILL.md レベルの仕様文書。Python 実装に Lift する場合は `CollectionPaths` 経由（**P2**） |
+| A3-3 | `.claude/skills/lyria/references/worktree_sync.sh:72-104` | `01-master/master.wav` / `01-master/*.mp4` / `10-assets/main.png` / `10-assets/main.jpg` | rsync 元・コピー先指定 | bash スクリプトのため正当。複数 sync 関数で同名繰り返しは命名定数化推奨（**P3**） |
+| A3-4 | `.claude/skills/masterup/SKILL.md:64,85,89,135-156` | `02-Individual-music/`, `01-master/` etc. | rsync 命令を含む SKILL.md ガイド文 | SKILL.md は仕様書。**現状維持で正当** |
+| A3-5 | `.claude/skills/alignment-check/SKILL.md:41,78-80` | `collections/live/*/10-assets/thumbnail.jpg` 等 | Glob 探索パターン | **正当**（Glob 用パターン文字列） |
+| A3-6 | `.claude/skills/wf-status/SKILL.md:22` / `wf-next/SKILL.md:22` / `masterup/SKILL.md:68` / `lyria/SKILL.md:114` / `loop-video/SKILL.md:43` / `videoup/SKILL.md:36` / `collection-ideate/SKILL.md:299` | `collections/planning/` の Glob | コレクション自動検出処理の入口 | 全 7 skill で「collections/planning/」を直書き → Python 化されたヘルパー `collection_paths.find_active_collections()` 等を導入してそこに集約すると将来ディレクトリ変更が 1 か所で済む（**P2**） |
+| A3-7 | `.claude/skills/postmortem/SKILL.md:25,46,114,154,168` / `metadata-audit/SKILL.md:8,32` / `live-clean/SKILL.md:8,21,32` / `alignment-check/SKILL.md:26,41` / `video-analyze/SKILL.md:42,87` / `thumbnail-compare/SKILL.md:73` | `collections/live/` の glob | 公開済みコレクションの走査 | A3-6 と同様、`CollectionPaths.glob_live()` 系を導入したい（**P2**） |
+| A3-8 | `.claude/skills/channel-setup/SKILL.md:17,56,77,85` / `channel-import/SKILL.md:83-84` / `channel-new/SKILL.md` 多数 | `auth/token.json`, `auth/client_secrets.json` | OAuth トークンパス | `auth.oauth_handler` 内の Path 定数を `auth/` namespace で固定。**正当**（外出し不要） |
+| A3-9 | `.claude/skills/lyria/SKILL.md:180,190` / `loop-video/SKILL.md:53` / `thumbnail/SKILL.md:62,70` | `10-assets/main.png` | reference image / 入力画像 | コレクション構造のドキュメント。**正当**（`CollectionPaths.assets_dir / 'main.png'` 相当） |
+| A3-10 | `.claude/skills/channel-setup/references/verification.md:68-69,72-83` | `branding/banner.png` / `branding/icon.png` | ブランディング素材生成手順 | Convention。**正当** |
+| A3-11 | `.claude/skills/channel-setup/references/verification.md:11` | `config/channel/*.json` | JSON 構文検証 Glob | **正当**（検証用途） |
+| A3-12 | `.claude/skills/postmortem/SKILL.md:152-158` | `data/analytics_data_<YYYYMMDD>.json` / `data/benchmark_<YYYYMMDD>.json` etc. | データソースの参照ガイド | **正当**（仕様書） |
+| A3-13 | `.claude/skills/analytics-report/SKILL.md:109` | `reports/{channel_slug}_analytics_YYYYMMDD.html` | HTML レポート保存先 | `channel_slug` は `config/channel/meta.json::channel.short` 由来と明記 → 外出し不要。**正当** |
+| A3-14 | `.claude/skills/streaming/references/swap_video.sh:20` | `infra/terraform/streaming` | Terraform モジュールパス | CLI 引数で上書き可能。**正当** |
+| A3-15 | `.claude/skills/lyria/SKILL.md:169,210` | `02-Individual-music/{NN}_{name}.wav` / `worktree_sync.sh` パス | コレクション内ファイル命名規約 | CollectionPaths 想定。**正当** |
+| A3-16 | `.claude/skills/comments-reply/SKILL.md:24,64` | `config/channel/comments.json` / `comment_reply_history.json` | 設定・履歴ファイル | `config/channel/comments.json` 自体は `examples/channel_config.example/comments.json` と一致。**正当** |
+| A3-17 | `.claude/skills/discover-competitors/SKILL.md:101,105-106` | `auth/token.json` / `research/lo-fi-discovery.{md,csv}` | OAuth トークン / 出力先 | **正当** |
+| A3-18 | `.claude/skills/channel-setup/references/claude-md-template.md:101` | `collections/planning/` → `collections/live/` 自動移動 | CLAUDE.md テンプレ内の説明 | **正当** |
+| A3-19 | `.claude/skills/video-analyze/SKILL.md:49,87` | `data/video_analysis/<slug>/<video_id>.json` / `reports/video_analysis/<slug>.md` | CLI 出力先 | CLI 内定義。**正当** |
+| A3-20 | `.claude/skills/benchmark/SKILL.md:51-52` | `data/benchmark_YYYYMMDD.json` / `docs/benchmarks/*.md` | データ出力先 | CLI 内定義。**正当** |
+| A3-21 | `.claude/skills/collection-ideate/SKILL.md:153,172-174,320,323,327` | `collections/planning/_plan-previews/<dir>/` | プレビュー画像保存先 | プレビュー保管場所の慣習。**正当**（`_` プレフィックスは設計意図） |
+| A3-22 | `.claude/skills/wf-next/SKILL.md:50` | `git rev-parse --git-common-dir` で worktree 検知 | worktree 検出ロジック | **正当**（git 標準） |
+
+**結論**: A-3 系は **ほぼ全件正当**（コレクション構造の慣習・コード内定数・ガイド文書）。**A3-6 + A3-7** のみ「Python 化された helper（`CollectionPaths.glob_planning()` / `.glob_live()`）への集約」が将来の保守性向上に効く（**P2**）。
+
+---
+
+## 5. A-4 — 既存 config キーと重複して直書きしている箇所
+
+`examples/channel_config.example/*.json` のキーと突き合わせ、SKILL.md / references 側で「config に既にある or 置けるはずの値」を**ハードコード or 個数指定** している箇所を列挙。
+
+| # | file:line | 直書き内容 | 対応する config キー | 対応案 |
+|---|---|---|---|---|
+| A4-1 | `.claude/skills/channel-setup/references/config-generation-rules.md:25-28` | 「`tags.base` は **10 個程度**」「`tags.themes` は **6-10 テーマ** 各 **3 語程度**」 | `examples/channel_config.example/content.json::tags.base / tags.themes`（個数は config に保持されない） | **要確認**: 個数を `content.json::tags.min_count` (現在 30) と整合させるべきか不明。examples 側に `min_count: 30` があるが SKILL.md は別の数字。**ドキュメント整合のため `content.json::tags.{base_count_target,themes_count_target}` 追加を提案** |
+| A4-2 | `.claude/skills/channel-setup/references/config-generation-rules.md:36-37` | 「`perfect_for` は **4 項目**」「`hashtags` は **5 個** 程度」 | `content.json::descriptions.perfect_for[]` / `descriptions.hashtags[]`（個数は config に保持されない） | 数値は **ガイドライン** であり強制値ではない。**正当**だが、video-description/SKILL.md:89 の「ハッシュタグ 13個（base + theme固有）」と数字がブレている → ガイド統一が必要（**P2**） |
+| A4-3 | `.claude/skills/video-description/SKILL.md:89,107` | 「ハッシュタグ **13個**（base + theme固有）」「ハッシュタグ 13個（base + theme）」 | `content.json::descriptions.hashtags`（既存値 3 個） | A4-2 の 5 個 vs 13 個矛盾。`config/channel/content.json` 側で base+theme の合計目標値を持つキー（`hashtags_total_target` 等）を **要確認** |
+| A4-4 | `.claude/skills/channel-setup/references/config-template/youtube.json:3` | `"category_id": "10"` | `examples/channel_config.example/youtube.json::youtube.category_id` | テンプレート初期値として **正当**。ただし `channel-setup/references/upload-settings-template.json:3` / `schedule-template.json:11` で **二重定義**（同じ `"10"` が 3 ファイル）→ Single Source 違反。**P2** |
+| A4-5 | `.claude/skills/channel-setup/references/config-template/youtube.json:4` / `upload-settings-template.json:4` / `schedule-template.json` (privacy 関連) | `"privacy_status": "public"` / `"private"` で揺れあり | `youtube.json::youtube.privacy_status` | `upload-settings-template.json:4` は `"public"`、`schedule-template.json:9` は `"private"`。**運用上の意図不明・矛盾の可能性**（要確認）。Single Source 候補は `examples/channel_config.example/youtube.json` |
+| A4-6 | `.claude/skills/channel-setup/references/upload-settings-template.json:22-23` | `min_video_duration: 30 / max_video_duration: 7200` | `audio.json::audio.target_duration_{min,max}`（分単位、現在 60/75） | スケール違い（秒 vs 分）と用途違い（upload validator vs target）あり。**重複していないが概念は近い** → `audio.json` に統合 or 別 namespace の明示が必要（**P2**） |
+| A4-7 | `.claude/skills/channel-setup/references/schedule-template.json:12-13,28-29` | `max_retries: 3 / retry_delay_seconds: 300 / delay_between_uploads: 5 / uploads_per_batch: 5 / upload_quota_per_day: 6 / concurrent_uploads: 1` | 既存 config 外（schedule_config.json は examples に含まれていない） | テンプレ自体が **未整備の config 設計**。`config/channel/upload.json` 等を別途定義する余地（**P3**、要確認） |
+| A4-8 | `.claude/skills/channel-setup/references/upload-settings-template.json:9-14` | `thumbnail_search_patterns: ["main.png","*main*.png","thumbnail.png","*thumb*.png"]` | `examples/channel_config.example` には存在しない | **新規キー**として `youtube.json` か新 `upload.json` に追加候補（**P3**） |
+| A4-9 | `.claude/skills/channel-setup/references/schedule-template.json:5` | `"timezone": "Asia/Tokyo"` | 既存 config 外 | チャンネルごとに差し替え可能性。**P3** |
+| A4-10 | `.claude/skills/video-upload/SKILL.md:113` / `metadata-audit/SKILL.md:36,45` / `postmortem/SKILL.md:45` | 「YouTube タイトル長制限 **100文字**」「タイムスタンプ数 **< 3 もしくは > 12**」「video_id **11 文字**」 | YouTube API 仕様。`config/channel/*.json` に置く性質ではない | **正当**（プラットフォーム制約） |
+| A4-11 | `.claude/skills/video-description/SKILL.md:66` | 「テーマが辞書にない場合は `config/channel/content.json` の `descriptions.perfect_for`（デフォルト）を使用」 | 既に `content.json::descriptions.perfect_for` を参照 | **正当**（既存 config キーへの参照）。逆引きで `descriptions.perfect_for` 直書きが SKILL.md 内に他にないか追加確認したが**重複なし** |
+| A4-12 | `.claude/skills/channel-setup/references/claude-md-template.md:13` | `config/channel/{meta,content,youtube,analytics,playlists,workflow,audio}.json` を列挙（7 ファイル） | `examples/channel_config.example/*.json` は **8 ファイル**（comments.json を含む） | テンプレが古い可能性。**comments.json が抜けている**（**P2**、文書更新で対応） |
+| A4-13 | `.claude/skills/channel-new/SKILL.md:100` | 「`config/channel/{meta,content,youtube,analytics,playlists,workflow,audio}.json` 計 **7 ファイル**」 | 同上 — comments.json が抜けている | A4-12 と同じ（**P2**） |
+| A4-14 | `.claude/skills/lyria/SKILL.md:60,85` / `lyria/config.default.yaml:17` / `loop-video/SKILL.md:107,116` 等 | モデル名 | A-2 と重複 | A-2 参照 |
+| A4-15 | `.claude/skills/channel-setup/references/localizations-template.json:5-12` | `ja.title_template` / `en.title_template` の `{style} {theme} ... [{duration_display}]` | `examples/channel_config.example/content.json::title.template` | テンプレ重複（ja は別文言、en は同一）。`content.json::title.template` を localization の base に再利用すべき（**P2**、要確認） |
+| A4-16 | `.claude/skills/playlist/SKILL.md:67` | `"all"` プレイリストは末尾追加 / それ以外は先頭追加 | `playlists.json` には `auto_add_activities` / `auto_add_themes` キーがあるが `auto_add` の挙動定義は SKILL.md 内のみ | playlist.json スキーマに `insertion_order: "head"\|"tail"` を追加するとロジックが config 駆動になる（**P3**） |
+
+**結論**: A-4 系の主要対応候補は **A4-2/A4-3（ハッシュタグ個数のドキュメント整合）**、**A4-4（`category_id="10"` の 3 ファイル重複）**、**A4-12/A4-13（comments.json が config ファイル一覧から漏れている）**、**A4-15（localizations title_template と content.json::title.template の重複）**。
+
+---
+
+## 6. A-5 — 生 `json.load` / `yaml.safe_load` で channel config を読んでいる references スクリプト
+
+| # | file:line | コード | 判定 |
+|---|---|---|---|
+| A5-1 | `.claude/skills/channel-setup/references/verification.md:9-15` | `import json, glob; for p in sorted(glob.glob('config/channel/*.json')): json.load(open(p)); print(f'OK: {p}')` | **false positive**: JSON 構文検証用途であり、設定値の消費ではない。`load_config()` で同じことをすると逆に失敗時の行特定が困難になる → **正当** |
+
+**結論**: `.claude/skills/**` 配下では **生 load による config 消費はゼロ**。`load_config()` / `load_skill_config()` 経路が完全に統一されている（healthy state）。
+
+参考: `Grep "load_config|load_skill_config"` で確認された使用件数 = **34 件**（35 skill 中 24 skill が `load_config()` 前提を SKILL.md 冒頭に明記）。残り 11 skill（masterup / live-clean / videoup / comments-reply / playlist / discover-competitors / channel-import / channel-research / channel-setup / channel-direction / channel-new / thumbnail-compare / viewer-voice / streaming / metadata-audit）は config 不要 or オフライン操作中心。
+
+---
+
+## 7. 主要な発見のサマリー（top 5 影響度）
+
+| 順位 | 検出 | 影響度 | 推奨アクション |
+|---|---|---|---|
+| **1** | A4-2/A4-3 — `descriptions.perfect_for` 個数（4）と `hashtags` 個数（5 vs 13）がドキュメント間で矛盾 | **高**（誤実装の温床） | `channel-setup/references/config-generation-rules.md` と `video-description/SKILL.md` でガイドラインを統一。`content.json` に `descriptions.perfect_for_target_count` 等の Single Source キーを置く |
+| **2** | A1-1/A1-2 — 「30 分」鮮度しきい値が analytics-collect / analytics-analyze で完全に直書き重複 | **中**（運用変更時に 2 箇所同時修正必要） | `config/skills/analytics.yaml::freshness_minutes` または `config/channel/analytics.json::cache.freshness_minutes` に統合 |
+| **3** | A1-9/A1-11 — postmortem の CTR 判定閾値（0.5/0.7/0.9/±10%）が SKILL.md 内に固定 | **中**（チャンネルごとに調整したい運用シーンが想定される） | `config/skills/postmortem.yaml::thresholds` を新設 |
+| **4** | A4-12/A4-13 — `comments.json` が「config/channel/*.json 計 7 ファイル」から漏れている | **中**（新規チャンネルで comments-reply skill を使う際に config が欠落する） | `channel-setup/references/claude-md-template.md:13` / `channel-new/SKILL.md:100` の列挙を 8 ファイルに更新 |
+| **5** | A4-4 / A4-5 — `category_id="10"` / `privacy_status` が 3 テンプレファイルに重複（しかも privacy で値が揺れている） | **中**（設計上の Single Source 違反） | `channel-setup/references/config-template/youtube.json` を Single Source とし、`upload-settings-template.json` / `schedule-template.json` から削除 or 参照記述に置換 |
+
+**追加で目立つもの（P2）**:
+- A2-8: masterup SKILL.md 本文の Suno CDN URL 4 箇所を skill-config 値の引用に統一
+- A2-10: streaming の 1Password ボルトパス（`op://Personal/...`）を `config/skills/streaming.yaml` に外出し
+- A3-6/A3-7: `collections/planning/` / `collections/live/` の Python 化されたヘルパー集約
+
+---
+
+## 8. カバレッジ
+
+### 走査した skill 一覧（35 件、全件）
+
+```
+alignment-check / analytics-analyze / analytics-collect / analytics-report /
+audience-persona / benchmark / channel-direction / channel-import / channel-new /
+channel-research / channel-setup / channel-status / collection-ideate / comments-reply /
+discover-competitors / live-clean / loop-video / lyria / masterup / metadata-audit /
+playlist / postmortem / streaming / suno / thumbnail / thumbnail-compare /
+video-analyze / video-description / video-upload / videoup / viewer-voice /
+viewing-scene / wf-new / wf-next / wf-status
+```
+
+### 走査ファイル種別
+
+- `SKILL.md` × 35
+- `config.default.yaml` × 9（benchmark / collection-ideate / loop-video / lyria / masterup / suno / thumbnail / video-analyze / video-description）
+- `references/**/*.{md,sh,py,json,yaml,tf}` × 37
+- 合計: **81 ファイル**
+
+### Grep パターン一覧（実行済み）
+
+| パターン | 用途 |
+|---|---|
+| `\b(max\|min\|timeout\|retry\|limit\|threshold)[_-]?\w*\s*[:=]\s*\d+` | A-1 数値検出 |
+| `\b(max\|min\|timeout\|retry\|limit\|threshold\|count\|delay\|interval\|days\|hours\|seconds\|sec\|ms\|page_size\|batch)\b\s*[:=]\s*\d+` | A-1 拡張 |
+| `\b\d+\s*(秒\|分\|時間\|日\|days\|hours\|minutes\|seconds\|hr\|min)\b` | A-1 自然言語の数値 |
+| `\b(gemini\|gpt\|lyria\|veo\|claude\|suno\|grok\|sonnet\|opus\|haiku)[-_.][\w.-]+` | A-2 モデル名 |
+| `https?://[^\s\)\]]+` | A-2 URL |
+| `collections/(live\|planning\|deprecated)/` | A-3 パス |
+| `config/channel/` | A-3 / A-4 突合 |
+| `10-assets\|20-documentation\|01-master\|02-Individual-music\|11-design` | A-3 コレクション構造 |
+| `json\.load\|yaml\.safe_load\|yaml\.load` | A-5 |
+| `load_config\|load_skill_config` | A-5 反転確認 |
+| `\b\d+\s*文字\|\b\d+(\.\d+)?\s*MB\b\|tag.*count\|hashtag.*count` | A-1/A-4 補完 |
+| `\bauth/\|\bbranding/\|\bdocs/channel/\|\bdocs/benchmarks/...` | A-3 補完 |
+
+### 比較対象（A-4 一次情報）
+
+`examples/channel_config.example/` 配下 8 ファイル全件を Read で熟読:
+- `meta.json`（19 行）
+- `content.json`（43 行）
+- `youtube.json`（13 行）
+- `analytics.json`（11 行）
+- `audio.json`（7 行）
+- `playlists.json`（6 行）
+- `workflow.json`（2 行、空）
+- `comments.json`（37 行）
+
+---
+
+## 9. 注意点・リスク（誤検出・偽陽性の可能性）
+
+| # | 内容 |
+|---|---|
+| R-1 | **A-3 のパス直書き判定はやや厳しめ**: 「bash スクリプト内のファイル名」「ガイド文書内の説明的パス」は本来正当だが、機械的に拾うとノイズ化する。今回は §4 で「正当」マークで明示的に切り分けた |
+| R-2 | **A-1 の閾値「正当 vs 外出し」の境界が主観的**: streaming の `RuntimeMaxSec=11h` は Terraform 側の Single Source、Lyria 184 秒は API 物理制約 → どちらも config 化する意味は薄い。判定は §2 のコメント欄に都度記載 |
+| R-3 | **A-4 の「ドキュメント記述 vs ハードコード」の区別**: video-description SKILL.md の「ハッシュタグ 13個」は **ガイドライン** でありコード制約ではない可能性がある。実装側 (`metadata_generator.py`) の挙動を確認していないため **要確認** マークで報告 |
+| R-4 | **CLI 既定値の引用は「重複」と数えない方針**: discover-competitors SKILL.md の「`--min-subscribers 10000`」等は CLI 側 Single Source の引用なので A-1 から除外 |
+| R-5 | **`channel-setup/references/config-template/*.json` は意図的な雛形**: ここに値があるのは Single Source（テンプレ）として正当。`upload-settings-template.json` / `schedule-template.json` との重複 (A4-4/A4-5) のみ問題 |
+| R-6 | **A-2 のモデル名は将来更新が頻発**: skill-config 化済みでも SKILL.md 本文に書かれたモデル名（例: `gemini-3.1-flash-image-preview`）は default 値変更時に同期が必要。今回は「skill-config が存在すれば OK」と判定したが、長期的には SKILL.md 本文の「{model}」プレースホルダ化が望ましい |
+
+---
+
+## 10. 調査できなかった項目とその理由
+
+| 項目 | 理由 |
+|---|---|
+| **`config/channel/comments.json` の現実装による参照状況** | examples 配下のサンプルは確認したが、実 CLI (`yt-comments-reply`) のソース読み込みは Part A 対象外（依頼スコープ: `.claude/skills/**`）。**A-5 の反転確認は SKILL.md レベルのみ** |
+| **`channel-setup/references/schedule-template.json` の歴史的経緯** | `examples/channel_config.example/` に対応する `schedule.json` が無く、テンプレートだけが存在する状態。「廃止予定」「未使用」の可能性を git log では追わず（保守的に「要確認」と報告） |
+| **A4-3 のハッシュタグ 13 個ロジックの実装根拠** | `metadata_generator.py` を読まずに SKILL.md 記述のみで判定（時間制約）。テキストでは「base + theme固有」とあるため計算式は推定可能だが、ガイドラインなのか強制値なのかは要確認 |
+| **streaming の Terraform 内ハードコード** | `infra/terraform/streaming/` 配下は依頼スコープ `.claude/skills/**` 外。`streaming/SKILL.md` で参照されている `RuntimeMaxSec=11h` 等は terraform 側にあるため未走査 |
+| **既存 skill-config 9 件の中身が `config/channel/*.json` の同名キーと意図せず競合していないか** | `audio.target_duration_min` は `audio.json` と `lyria/config.default.yaml::duration_padding_min` で意味が分離されておりセーフだが、他組合せは網羅未確認（80% 基準で見送り） |
+
+---
+
+## 11. 推奨/結論（外出し優先度 P1/P2/P3 振り分け）
+
+### P1（必須対応・効果大）
+
+| ID | 内容 | 対応工数 |
+|---|---|---|
+| **P1-a** | **ハッシュタグ個数の Single Source 化** — `config-generation-rules.md`（5 個）と `video-description/SKILL.md`（13 個）のガイドラインを整合。`content.json::descriptions.hashtags_target_count` or `hashtags_base + hashtags_per_theme` の 2 値を追加 | 小 |
+| **P1-b** | **comments.json を config ファイル一覧に追加** — `channel-setup/references/claude-md-template.md:13` / `channel-new/SKILL.md:100` を 7 → 8 ファイルへ更新 | 極小 |
+| **P1-c** | **`category_id="10"` の Single Source 化** — `channel-setup/references/{config-template/youtube.json, upload-settings-template.json, schedule-template.json}` のうち config-template/youtube.json のみを Single Source として残し、他から削除（または「youtube.json を参照」コメント化）| 小 |
+| **P1-d** | **`privacy_status` の矛盾解消** — `upload-settings-template.json:4` `"public"` と `schedule-template.json:9` `"private"` の食い違い。意図を確認し統一 | 小 |
+
+### P2（重要・効果中）
+
+| ID | 内容 |
+|---|---|
+| **P2-a** | analytics-collect / analytics-analyze の **30 分鮮度** を `config/skills/analytics.yaml` に集約 |
+| **P2-b** | postmortem の **CTR 判定閾値**（0.5/0.7/0.9/±10%）を `config/skills/postmortem.yaml::thresholds` に集約 |
+| **P2-c** | streaming の **notify timeout**（5 秒 / 10 秒）と **1Password ボルトパス**を `config/skills/streaming.yaml` に外出し |
+| **P2-d** | masterup SKILL.md 本文の Suno CDN URL 4 箇所を skill-config 値の引用に統一（実コードが skill-config を読んでいるなら SKILL.md の文字列は「`{cdn_url_template}` 参照」表現に変更） |
+| **P2-e** | `collections/{planning,live}/` の Python helper（`CollectionPaths.glob_planning()` / `.glob_live()`）導入と 14 SKILL.md からの参照置換 |
+| **P2-f** | `localizations-template.json::*.title_template` と `content.json::title.template` の整合化（localizations は ja のみ独自パターン、en は重複） |
+| **P2-g** | videoup の **ffmpeg 解像度・ビットレート・CRF** を `config/skills/videoup.yaml` に新設 |
+
+### P3（あれば良い・効果小）
+
+| ID | 内容 |
+|---|---|
+| **P3-a** | analytics-report HTML の KPI カード枚数（4）/ max-width（1200px） を skill-config 化 |
+| **P3-b** | playlist の `"all"` プレイリスト挿入順（head/tail）を `playlists.json` スキーマに追加 |
+| **P3-c** | `schedule-template.json` の存在意義の整理（examples 側に対応キーが無いため、`config/channel/upload.json` 新設 or テンプレ削除を検討） |
+| **P3-d** | `upload-settings-template.json::thumbnail_search_patterns` を `config/channel/youtube.json` に統合 |
+| **P3-e** | A-2 系の「SKILL.md 本文に書かれたモデル名」を将来的に skill-config 値の `{{model}}` プレースホルダで埋め込む形式に統一（テンプレ更新時の同期コスト削減） |
+
+---
+
+## 12. 補足: A-3 で見送りとした「ほぼ全件正当」の根拠
+
+`collection_paths.CollectionPaths` クラス（`src/youtube_automation/utils/collection_paths.py`）が **既に標準コレクションディレクトリ構造を一次情報として持つ**ため、SKILL.md 内の「`01-master/master.mp3`」「`10-assets/main.png`」「`20-documentation/descriptions.md`」等の直書きは **`CollectionPaths` 仕様の文書化**として正当と判定した。
+
+ただし **A3-6 + A3-7（`collections/planning/` / `collections/live/` の Glob 14 箇所）** は Python 化された helper にまとめると将来のリネーム耐性が上がるため **P2** として残した（コレクションのトップレベルディレクトリ名そのものを変える事案は稀だが、`_plan-previews/` の追加など下位構造変更は実例あり）。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/03-dig-part-A-v2.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/03-dig-part-A-v2.md
@@ -1,0 +1,303 @@
+# dig Part A — ハードコード値 + 既存 config 未参照 検出レポート
+
+調査日: 2026-05-18
+担当: dig.dig-part-a
+範囲: `.claude/skills/**` 35 スキル（SKILL.md + references/ + config.default.yaml + scripts）
+観点: 1.1 ハードコード値（A-1〜A-4）＋ 1.4 既存 config 未参照（A-5）
+ツール: Read / Grep / Glob のみ（protected paths のため write 禁止）
+
+---
+
+## 1. 概要
+
+- 走査対象スキル数: **35**（漏れなし、`ls .claude/skills/` で確認）
+- 走査対象ファイル数: **約 90**（SKILL.md × 35 + references/ + config.default.yaml + scripts/JSON テンプレ）
+- 検出総件数: **63 件**（重複行は集約済み）
+  - 高（P1 = 即対応すべき）: **9 件**
+  - 中（P2 = 共通化推奨）: **34 件**
+  - 低（P3 = 設計判断保留）: **20 件**
+
+### サマリ感
+
+- **A-1（チャンネル ID / playlist ID / handle 直書き）**: **検出 0 件**（YouTube ID リテラルは無し。プレースホルダ `UC...` / `<channel>` のみ）
+- **A-4（API key / token / 怪しい URL 直書き）**: **検出 0 件**（`op://` 経由のシークレット参照 + 公式 CDN/インストーラー URL のみ）
+- **A-3（絶対パス / ユーザー名）**: **3 件中 2 件が高重大度**（user-specific dev dir のハードコード）
+- **A-5（既存 config 未参照）**: **高 4 件 + 中 9 件**（v2.0.0 namespace 漏れ・テンプレ英語固定など）
+- **A-2（マジックナンバー）**: **中 25 件 + 低 20 件**（多くは skill-config に存在、判断分かれるグレーゾーン）
+
+スキル設計の全体評価:
+- Python references（`benchmark_collector.py` / `analytics_system.py` / `generate_image.py` / `loop-video` 等）は `load_config()` + `load_skill_config()` 経由で **アーキテクチャ的にクリーン**
+- SKILL.md 本文中の英語コピー・色 hex・閾値は **静的記述として残存** している箇所が散見される
+- 配布テンプレート (`channel-setup/references/config-template/`, `schedule-template.json`, `upload-settings-template.json`) は意図的に BGM 系既定値で埋まっている
+
+---
+
+## 2. 検出結果
+
+### A-1: チャンネル ID / playlist ID / handle ハードコード（P1）
+
+| # | スキル | file:line | 引用 | 重大度 | 推奨アクション |
+|---|--------|-----------|------|--------|---------------|
+| 1.1 | channel-setup | `.claude/skills/channel-setup/references/terraform-gcp/README.md:51` | `adc_email      = "you@example.com"` | 低 | プレースホルダ。実害なし |
+| 1.2 | channel-setup | `.claude/skills/channel-setup/references/terraform-gcp/terraform.tfvars.example:10` | `adc_email       = "you@example.com"` | 低 | 同上 |
+| 1.3 | channel-import | `.claude/skills/channel-import/SKILL.md:39` | `（例: @channel-name）` | 低 | ドキュメント例のみ |
+
+**`UC[A-Za-z0-9_-]{22}` / `PL[A-Za-z0-9_-]{16,}` 完全一致: 0 件**（リポジトリ全体に対するグレップで一致なし）
+
+### A-2: マジックナンバー（P2 中心）
+
+#### A-2-A: 画像/動画解像度・エンコード設定（中〜低）
+
+| # | スキル | file:line | 引用 | 重大度 | 推奨修正先 |
+|---|--------|-----------|------|--------|-----------|
+| 2.1 | videoup | `.claude/skills/videoup/references/generate_videos.sh:130,139,149,175` | `1920x1080` を 4 箇所で直書き | 中 | skill-config（YouTube 標準だが将来縦動画/4K 対応時に効く） |
+| 2.2 | videoup | `.claude/skills/videoup/references/generate_videos.sh:73` | `-b:a 384k -ar 48000` | 中 | skill-config `audio.bitrate` / `audio.sample_rate` |
+| 2.3 | videoup | `.claude/skills/videoup/references/generate_videos.sh:148` | `-c:v libx264 -preset slow -crf 18` | 中 | skill-config `video.crf` / `video.preset` |
+| 2.4 | videoup | `.claude/skills/videoup/references/generate_videos.sh:174` | `-preset ultrafast -crf 23` | 中 | 同上 |
+| 2.5 | videoup | `.claude/skills/videoup/references/generate_videos.sh:192` | `BAR_WIDTH=30` | 低 | UI 定数。実害なし |
+| 2.6 | videoup | `.claude/skills/videoup/references/generate_videos.sh:211` | `sleep 0.15` | 低 | UI 定数 |
+| 2.7 | lyria | `.claude/skills/lyria/references/lyria-tuning-guide.md:67` | `推奨: コレクションの main.png (PNG, 1280×720 以上)` | 低 | YouTube 最小サムネ要件 |
+| 2.8 | channel-setup | `.claude/skills/channel-setup/references/verification.md:68,82` | `2048 x 1152 px、6 MB 以下` | 低 | YouTube バナー仕様 |
+| 2.9 | channel-setup | `.claude/skills/channel-setup/references/upload-settings-template.json:23` | `"max_video_duration": 7200` | 中 | template だが固定 2 時間が BGM 想定 |
+| 2.10 | channel-setup | `.claude/skills/channel-setup/references/upload-settings-template.json:22` | `"min_video_duration": 30` | 中 | 同上 |
+
+#### A-2-B: ブランド色・UI hex（中、A-5 とも重複）
+
+| # | スキル | file:line | 引用 | 重大度 | 推奨修正先 |
+|---|--------|-----------|------|--------|-----------|
+| 2.11 | analytics-report | `.claude/skills/analytics-report/SKILL.md:94-101` | `背景: #0f1419 / カード背景: #1a2332 / アクセント: #c8a96e (ブランドアクセントカラー) / テキスト: #e8e6e3 / チャート色: #4ecdc4, #45b7d1, #96ceb4, #ffeaa7, #dfe6e9 / 成功: #00b894 / 警告: #fdcb6e / 危険: #e17055` | **高** | **`config/channel/meta.json::channel.brand_color`** 新設、または skill-config `analytics-report.yaml::theme.colors`。「ブランドアクセントカラー」のコメントが付いており明らかにチャンネル固有 |
+| 2.12 | analytics-report | `.claude/skills/analytics-report/SKILL.md:104` | `max-width: 1200px` | 低 | レイアウト定数 |
+
+#### A-2-C: 閾値・件数（中）
+
+| # | スキル | file:line | 引用 | 重大度 | 推奨修正先 |
+|---|--------|-----------|------|--------|-----------|
+| 2.13 | analytics-analyze | `.claude/skills/analytics-analyze/SKILL.md:38` | `30分以内に生成されたレポートがあれば分析をスキップ` | 中 | skill-config `analytics-analyze.yaml::freshness_minutes` |
+| 2.14 | analytics-collect | `.claude/skills/analytics-collect/SKILL.md:36` | `30分以内 → 収集をスキップ` | 中 | 同上（skill-config 横断統一が望ましい） |
+| 2.15 | analytics-collect | `.claude/skills/analytics-collect/SKILL.md:28,62` | `効率モード（上位50本 + 直近30日投稿）` | 中 | skill-config `analytics-collect.yaml::top_n` / `recent_days` |
+| 2.16 | video-description | `.claude/skills/video-description/SKILL.md:89,107` | `ハッシュタグ: 13個（base + theme固有）` | 中 | `config/channel/content.json::descriptions.hashtag_count` を新設 |
+| 2.17 | video-upload | `.claude/skills/video-upload/SKILL.md:113` | `YouTube タイトル長制限準拠（100文字）` | 低 | YouTube 仕様（固定で良いが定数化） |
+| 2.18 | video-upload | `.claude/skills/video-upload/SKILL.md:97` | `指数バックオフによるリトライ（5xx エラー時、最大5回）` | 低 | utils 側で実装。SKILL.md は文章 |
+| 2.19 | video-upload | `.claude/skills/video-upload/SKILL.md:46` | `API クォータ: 2 × 1,600 = 3,200 ユニット` | 低 | YouTube API 仕様 |
+| 2.20 | metadata-audit | `.claude/skills/metadata-audit/SKILL.md:38,48` | `タイムスタンプ数 < 3 もしくは > 12` | 中 | skill-config `metadata-audit.yaml::chapters_min` / `chapters_max` |
+| 2.21 | suno | `.claude/skills/suno/SKILL.md:91` | `4 パターン × 3 回生成（1 回 2 曲）= **24 トラック**` | 中 | skill-config `suno.yaml::pattern_count` / `generations_per_pattern` |
+| 2.22 | suno | `.claude/skills/suno/SKILL.md:98,112` | `Style Influence: 85 推奨` / `120-180 単語` | 中 | 85 は config.default.yaml にある。120-180 は未明文化 |
+| 2.23 | postmortem | `.claude/skills/postmortem/SKILL.md:76-89` | `< 0.5 / < 0.7 / < 0.9 / ≥ 0.9` 等の比率閾値を 8 箇所で直書き | 中 | skill-config `postmortem.yaml::thresholds.{ratio_red,ratio_yellow,...}`。SKILL.md 内に「閾値はチャンネル特性に応じて文脈調整可」とある通り変動値 |
+| 2.24 | thumbnail-compare | `.claude/skills/thumbnail-compare/SKILL.md:8,21` | `1万再生以上` | 中 | `config/skills/benchmark.yaml::min_views`（既に 10000 がある）を参照すべき。SKILL.md は固定文 |
+| 2.25 | thumbnail-compare | `.claude/skills/thumbnail-compare/SKILL.md:23` | `320x180px` に縮小 | 低 | YouTube モバイル想定 |
+| 2.26 | viewer-voice | `.claude/skills/viewer-voice/SKILL.md:8,28` | `1万再生以上` | 中 | 同上、benchmark.yaml と統一 |
+| 2.27 | viewer-voice | `.claude/skills/viewer-voice/SKILL.md:29` | `各動画のコメントを最大100件取得` | 中 | skill-config `viewer-voice.yaml::comments_per_video` |
+| 2.28 | discover-competitors | `.claude/skills/discover-competitors/SKILL.md:86-90,99-100` | `--min-subscribers 10000 / --max-subscribers 1,000,000,000? / --posted-within-days 30 / --top 20` | 中 | CLI のデフォルトと整合。skill-config 化検討余地あり |
+| 2.29 | channel-new | `.claude/skills/channel-new/SKILL.md:124-125` | `--min-subscribers 10000 --max-subscribers 1000000 --posted-within-days 30 --top 20` | 中 | 同上 |
+| 2.30 | channel-new | `.claude/skills/channel-new/SKILL.md:175` | `uv run yt-benchmark-comments --min-views 5000` | 中 | benchmark.yaml `min_views` と矛盾しないか確認。固定 5000 は別パラ |
+| 2.31 | lyria | `.claude/skills/lyria/SKILL.md:194` | `--max-retries N （default: 3）` | 低 | CLI デフォルト |
+| 2.32 | lyria | `.claude/skills/lyria/SKILL.md:10,76,168` | `1 リクエストあたり最大約 184 秒` | 低 | Vertex AI API 仕様（変更があれば追従） |
+| 2.33 | comments-reply | `.claude/skills/comments-reply/SKILL.md:58` | `--per-video-limit N（default: 100）` | 中 | examples/channel_config.example/comments.json では `max_replies_per_run: 20` 等あり |
+| 2.34 | streaming | `.claude/skills/streaming/SKILL.md:8` | `RuntimeMaxSec=11h + RestartSec=1h` | 低 | Terraform 側に集約済（SKILL は documentation） |
+| 2.35 | streaming | `.claude/skills/streaming/SKILL.md:38,109` | `80% 閾値アラート` / `帯域 80% 超アラート` | 低 | `src/youtube_automation/utils/streaming/threshold.py` の定数。SKILL は documentation |
+| 2.36 | streaming | `.claude/skills/streaming/SKILL.md:99` | `月間 1.16 TB（2 TB プランの 58%）` / `4 Mbps → 3 Mbps 化` | 低 | Vultr プラン依存 |
+| 2.37 | streaming | `.claude/skills/streaming/SKILL.md:79` | `5 分間隔` healthcheck | 低 | cron.d / Terraform 側で集約 |
+| 2.38 | collection-ideate | `.claude/skills/collection-ideate/SKILL.md:326` | `7 日以上前のものは手動削除可` | 低 | コメント |
+
+#### A-2-D: skill-config 既定値（低、外部化済みのため低）
+
+| # | スキル | file:line | 引用 | 重大度 | 備考 |
+|---|--------|-----------|------|--------|------|
+| 2.39 | benchmark | `config.default.yaml:10` | `scan_recent: 50` | 低 | skill-config 化済 |
+| 2.40 | benchmark | `config.default.yaml:13` | `min_views: 10000` | 低 | skill-config 化済 |
+| 2.41 | benchmark | `config.default.yaml:16` | `freshness_days: 3` | 低 | skill-config 化済 |
+| 2.42 | benchmark | `config.default.yaml:24` | `delay_sec: 5` | 低 | skill-config 化済 |
+| 2.43 | video-analyze | `config.default.yaml:10` | `delay_sec: 10` | 低 | skill-config 化済 |
+| 2.44 | masterup | `config.default.yaml:10` | `crossfade_duration: 1.0` | 低 | skill-config 化済 |
+| 2.45 | masterup | `config.default.yaml:13` | `bitrate: "192k"` | 低 | skill-config 化済 |
+| 2.46 | loop-video | `config.default.yaml:20` | `duration_seconds: 8` | 低 | Veo API 制約 |
+| 2.47 | loop-video | `config.default.yaml:23` | `crossfade_sec: 0.5` | 低 | skill-config 化済 |
+| 2.48 | lyria | `config.default.yaml:28` | `crossfade_sec: 5` | 低 | skill-config 化済 |
+| 2.49 | lyria | `config.default.yaml:40` | `duration_padding_min: 3` | 低 | skill-config 化済 |
+| 2.50 | collection-ideate | `config.default.yaml:16-18` | `candidate_count: 3 / session_id_bytes: 2` | 低 | skill-config 化済 |
+| 2.51 | collection-ideate | `config.default.yaml:37` | `max_similarity: 0.5` | 低 | skill-config 化済 |
+| 2.52 | suno | `config.default.yaml:16` | `style_influence: 85` | 低 | skill-config 化済 |
+| 2.53 | video-description | `config.default.yaml:57` | `timing: "12:00"` | 低 | skill-config 化済 |
+
+### A-3: 絶対パス / ユーザー名（P2）
+
+| # | スキル | file:line | 引用 | 重大度 | 推奨修正 |
+|---|--------|-----------|------|--------|---------|
+| 3.1 | channel-new | `.claude/skills/channel-new/SKILL.md:29` | `**実行場所**: 新リポジトリの親ディレクトリ（例: \`~/01-dev/projects/\`）` | **高** | 例示を一般化（`<your-projects-dir>` または別記）。`~/01-dev/projects/` は repo author 固有のパス |
+| 3.2 | channel-new | `.claude/skills/channel-new/SKILL.md:64` | `新リポジトリの親ディレクトリ（このリポジトリの 1 つ上、例: \`~/01-dev/projects/\`）` | **高** | 同上 |
+| 3.3 | channel-import | `.claude/skills/channel-import/SKILL.md:20` | `cd ~/02-yt` | **高** | `cd <your-channels-parent>` に一般化。`~/02-yt` は repo author 固有 |
+| 3.4 | channel-new | `.claude/skills/channel-new/SKILL.md:75` | `（例: /Users/<you>/path/to/some-channel/auth/token.json）` | 低 | プレースホルダ。OK |
+| 3.5 | streaming | `.claude/skills/streaming/SKILL.md:15-19`, `references/swap_video.sh:86` | `~/.ssh/yt_stream_key` を 5 箇所で直書き | 中 | skill-config `streaming.yaml::ssh_key_path` 化で運用者の鍵パス差分に対応可。現状 `~/.ssh/yt_stream_key` 強制 |
+| 3.6 | streaming | `.claude/skills/streaming/references/notify.sh`, `healthcheck.sh`, `run-ffmpeg.sh` | `/etc/youtube-stream-healthcheck.env`, `/opt/youtube-stream/`, `/usr/bin/ffmpeg` | 低 | 配置先パス（VPS 側 cloud-init/systemd の規約に沿った絶対パス、変更すべきでない） |
+| 3.7 | channel-setup | `.claude/skills/channel-setup/references/terraform-gcp/README.md:51` | `you@example.com`（例示） | 低 | プレースホルダ |
+
+### A-4: API キー・トークン・URL 直書き（P1）
+
+| # | スキル | file:line | 引用 | 重大度 | 備考 |
+|---|--------|-----------|------|--------|------|
+| 4.1 | — | 全範囲 | `AIza` / `sk-` / `ya29.` パターン: **0 件** | — | クリーン |
+| 4.2 | streaming | `.claude/skills/streaming/SKILL.md:20,52,123` | `op://Personal/Vultr/api_key`, `op://Personal/YouTube/stream_key`, `op://Personal/YouTube_Stream_Discord_Webhook/url` | 低 | 1Password 参照。秘密情報そのものは含まない |
+| 4.3 | masterup | `.claude/skills/masterup/SKILL.md:22,84,89,174`, `config.default.yaml:33` | `https://cdn1.suno.ai/{song_id}.mp3` | 低 | Suno 公式 CDN。skill-config 化済 |
+| 4.4 | channel-new | `.claude/skills/channel-new/SKILL.md:47,49` | `gh repo create <short> --template daiki-beppu/youtube-channel-template --private --clone` / `uv add git+https://github.com/daiki-beppu/youtube-channels-automation.git` | 中 | **GitHub オーナー名 `daiki-beppu` がスキル本文中に固定**。他者がこのパッケージを fork 利用しても誘導先はオリジナル。`{{REPO_OWNER}}` プレースホルダ化または README/CLAUDE.md の installation 節への一元化推奨 |
+| 4.5 | channel-import | `.claude/skills/channel-import/SKILL.md:21,26` | 同上 | 中 | 同 |
+| 4.6 | channel-setup | `.claude/skills/channel-setup/references/claude-md-template.md:71` | `youtube-automation パッケージの構造は GitHub リポジトリ（daiki-beppu/youtube-channels-automation）の CLAUDE.md を参照` | 中 | 同 |
+| 4.7 | streaming | `.claude/skills/streaming/references/notify.sh:35-37` | `^https://(discord\.com|discordapp\.com)/api/webhooks/` ホストホワイトリスト | 低 | SSRF 防御の意図的ホスト固定（Issue #166/#174） |
+| 4.8 | streaming | `.claude/skills/streaming/references/notify.sh:35` | `http://169.254.169.254` (AWS/cloud metadata IP) | 低 | コメント内の SSRF 攻撃例示。実コードでブロックされる |
+
+### A-5: 既存 config で表現できるのに skill 内に書かれている値（P1）
+
+| # | スキル | file:line | 引用 | 重大度 | 期待される config 参照先 |
+|---|--------|-----------|------|--------|-----------------------|
+| 5.1 | analytics-analyze | `.claude/skills/analytics-analyze/SKILL.md:64` | ``yt-theme-compare`: `channel_config.tags.themes` のキーワードで...` | **高** | v2.0.0 で `channel_config.tags.themes` は **廃止**。**正しくは `content.tags.themes`**（`utils/config/content.py`）。古い namespace 名が SKILL.md に残存している（c-3 deprecated 系とも重複） |
+| 5.2 | analytics-report | `.claude/skills/analytics-report/SKILL.md:96` | `アクセント: #c8a96e (ブランドアクセントカラー)` | **高** | `config/channel/meta.json::channel.brand_color`（新設キー）を導入し、HTML レポートはそこから読む。現状はチャンネル固有のブランドアクセント色が SKILL.md に直書き |
+| 5.3 | analytics-report | `.claude/skills/analytics-report/SKILL.md:73,123` | `Complete Collection のみ表示（Shorts を除外）` / `Shorts は動画パフォーマンス表から除外（タイトルに #Shorts を含む）` | 中 | `config/channel/analytics.json::analytics.collection_filter_keywords` を活用すべき（既に `["collection", "complete"]` を保持）。`#Shorts` 固定文字列マッチは独立した除外ロジックなので skill-config か analytics.json の除外パターンに揃える |
+| 5.4 | video-description | `.claude/skills/video-description/references/description-templates.md:36` | `🎧 If you enjoyed the vibe, feel free to save and subscribe for more 🌧️` | **高** | 英語固定 + 🌧️ 絵文字は BGM/雨系チャンネル前提。`config/channel/meta.json::channel.cta_subscribe`（既存）に集約済のはずだが、本テンプレ行は別途固定文字列で残存している。`{channel_config: channel.cta_subscribe}` 形式に統一すべき |
+| 5.5 | video-description | `.claude/skills/video-description/references/description-templates.md:43-44` | `🎨 𝐀𝐫𝐭 & 🎹 𝐌𝐮𝐬𝐢𝐜 𝐛𝐲 {channel_config: channel.name}` / `Original AI composition • Free for personal use` | **高** | "Original AI composition • Free for personal use" は固定英語コピー。skill-config `usage_attribution_lines`（既存、`video-description/config.default.yaml:20-24`）と二重管理になっている。テンプレ側を skill-config 参照に置き換えるか、二重管理を解消 |
+| 5.6 | video-description | `.claude/skills/video-description/SKILL.md:89,107` | `ハッシュタグ: 13個` | 中 | `config/channel/content.json::descriptions.hashtag_count` 新設、または `len(descriptions.hashtags)` を運用ルール化。13 は magic number |
+| 5.7 | video-description | `.claude/skills/video-description/config.default.yaml:44-52` | `theme_emoji: study/sleep/tavern/ocean/forest/druid/rain/hearth` | 中 | チャンネル固有のテーマ語。`config/channel/content.json::title.theme_emoji` に集約することで、`title.theme_activities` / `theme_scenes` と一元管理できる |
+| 5.8 | video-description | `.claude/skills/video-description/config.default.yaml:13-17,20-24` | `section_headers` / `usage_attribution_lines`（BGM 既定） | 中 | skill-config 化済だが、default 値が BGM/AI 透明性宣言に強くバイアス。**ゲーム/トーク/ASMR 用の neutral default** をコメントで提示すべき（既にコメントで言及ありだが値は BGM） |
+| 5.9 | channel-setup | `.claude/skills/channel-setup/references/config-template/content.json:14-18` | `"perfect_for": ["Study & Focus Sessions", "Background Music", "Creative Work", "Relaxation"]` | 中 | テンプレートだが英語 4 項目固定。`{{LOCALE}}` プレースホルダ + 言語別 fixture が望ましい |
+| 5.10 | channel-setup | `.claude/skills/channel-setup/references/config-template/youtube.json:3,5` | `"category_id": "10"`, `"language": "en"` | 中 | テンプレートだが Music カテゴリ + 英語固定。`{{CATEGORY_ID}}` / `{{LANGUAGE}}` プレースホルダ化推奨 |
+| 5.11 | channel-setup | `.claude/skills/channel-setup/references/schedule-template.json:3-5,9-10` | `"day1_time": "20:00", "day2_time": "20:00", "timezone": "Asia/Tokyo", "category_id": "10", "privacy_status": "private"` | 中 | テンプレートだが日本タイムゾーン + 20:00 固定。プレースホルダ化推奨 |
+| 5.12 | channel-setup | `.claude/skills/channel-setup/references/upload-settings-template.json:3-5,22-23` | `"category_id": "10", "privacy_status": "public", "language": "ja", "min_video_duration": 30, "max_video_duration": 7200` | 中 | 同上 |
+| 5.13 | channel-setup | `.claude/skills/channel-setup/references/localizations-template.json:5-10` | `"ja": {"title_template": "{style} {theme} - {activity}用BGM [{duration_display}]"}` / `"en": {...BGM...}` | 中 | テンプレートだが「BGM」「{activity}用BGM」が日本語題に固定。`content_model.type` が collection なら BGM 想定、release ならドラマ/トーク等の想定にすべき |
+| 5.14 | suno | `.claude/skills/suno/SKILL.md:158-164` | 禁止形容詞リスト 17 語（`thundering, blazing, crushing, ...`） | 中 | skill-config `suno.yaml::ng_words`（既存だが Lyria 側のみ）と統一できる。`config/skills/suno.yaml::scene_phrase_ng_words` 新設推奨 |
+| 5.15 | suno | `.claude/skills/suno/SKILL.md:172-176` | NG ワード `rain, dripping, drops, ...` / OK ワード `misty, melancholic, ...` | 中 | 同様に skill-config 化推奨 |
+| 5.16 | postmortem | `.claude/skills/postmortem/SKILL.md:71-78,86-89` | 比率閾値 0.5/0.7/0.9 を症状判定 + 仮説マッピングの 2 箇所で重複定義 | 中 | skill-config `postmortem.yaml::thresholds` 一元化。SKILL.md 内に「閾値は固定値ではなく **チャンネル特性に応じて文脈調整可**」と書かれている時点で外出ししたほうが運用と整合 |
+| 5.17 | analytics-collect | `.claude/skills/analytics-collect/SKILL.md:58` | `チャンネル: <channel_config: channel.name>` | 低 | プレースホルダ syntax は OK だが、v2.0.0 namespace では `meta.channel.name`。読み手向けプレース表記なので致命的ではないが統一推奨 |
+| 5.18 | streaming | `.claude/skills/streaming/SKILL.md:29,96`, `infra/terraform/streaming/README.md` | `--check-threshold` の閾値（80%）が `src/youtube_automation/utils/streaming/threshold.py` の `THRESHOLD_RATIO` 定数で、`config/channel/` 連動なし | 中 | plan.md A-4 で既知シードとして言及。Vultr 帯域上限は streaming infra 固有なので `config/skills/streaming.yaml::bandwidth_threshold_ratio` 新設が妥当 |
+
+---
+
+## 3. 主要な発見のサマリー（top 5）
+
+### ① v2.0.0 namespace の取りこぼし（A-5 #5.1）— **最重要**
+- `analytics-analyze/SKILL.md:64` に `channel_config.tags.themes` が残存。post-v2.0.0 では `content.tags.themes`。
+- 他にも `video-description/references/description-templates.md` および `analytics-collect/SKILL.md` で `{channel_config: ...}` プレースホルダ syntax が使われており、新 namespace（`meta.*` / `content.*`）と表記がずれている。
+- **理由**: CLAUDE.md「設定アクセス」節と矛盾するため、最終レポートで section 1.4 の代表事例として取り上げるべき。
+
+### ② analytics-report のブランド色直書き（A-5 #5.2, A-2 #2.11）
+- HTML レポートのカラーパレット 9 色（特に `#c8a96e` = "ブランドアクセントカラー"）が SKILL.md に直書き。
+- チャンネルごとに変えたい代表的な値だが config 参照ルートが無い。
+- `meta.json::channel.brand_color` 新設 or `analytics-report.yaml::theme` skill-config 導入の 2 択。
+
+### ③ video-description の英語コピー二重管理（A-5 #5.4, #5.5）
+- `usage_attribution_lines` は skill-config に既出だが、`references/description-templates.md` 内の固定テンプレ本文に同じ意図の英語コピー（"🎧 If you enjoyed the vibe..." / "Original AI composition..."）が並走している。
+- どちらが正なのか不明確（生成時にテンプレ → skill-config の置換が機能しているか要確認）。
+
+### ④ user-specific dev path のハードコード（A-3 #3.1, #3.2, #3.3）
+- `~/01-dev/projects/`, `~/02-yt` は repo author（`daiki-beppu`）の作業環境固有のパス。
+- パッケージ配布先の他チャンネル運営者にはそのまま当てはまらず、`/channel-new` / `/channel-import` の初回手順で混乱を生む。
+- 例示を `<your-projects-dir>` / `<your-channels-parent>` に一般化すべき。
+
+### ⑤ GitHub owner 名 `daiki-beppu` の固定（A-4 #4.4, #4.5, #4.6）
+- 3 つのスキルで `daiki-beppu/youtube-channels-automation.git` および `daiki-beppu/youtube-channel-template` が install/clone コマンドに直書き。
+- パッケージを fork した別運営者にはそのまま使えない。`{{REPO_OWNER}}` プレースホルダ化、または README/CLAUDE.md の installation 節への一元化を推奨。
+
+---
+
+## 4. カバレッジ
+
+### 走査済み（35 スキル全件）
+
+```
+alignment-check / analytics-analyze / analytics-collect / analytics-report /
+audience-persona / benchmark / channel-direction / channel-import / channel-new /
+channel-research / channel-setup / channel-status / collection-ideate /
+comments-reply / discover-competitors / live-clean / loop-video / lyria /
+masterup / metadata-audit / playlist / postmortem / streaming / suno /
+thumbnail / thumbnail-compare / video-analyze / video-description / video-upload /
+videoup / viewer-voice / viewing-scene / wf-new / wf-next / wf-status
+```
+
+### 検出 0 件のスキル（A-1, A-3, A-4, A-5 の P1 観点で）
+
+A-1〜A-5 通算で **強い検出 (high) が 0 件**だったスキル:
+- alignment-check, audience-persona, channel-direction, channel-research,
+  channel-status, comments-reply, discover-competitors, live-clean, loop-video,
+  metadata-audit, playlist, suno, thumbnail, thumbnail-compare, video-analyze,
+  video-upload, viewing-scene, wf-new, wf-next, wf-status, masterup, lyria, benchmark
+
+これらの 23 スキルは **「P1 観点で問題なし」** と記録できる（中重大度の magic number は別途）。
+
+### 走査の手段別
+
+| 観点 | 手段 | 件数 |
+|------|------|------|
+| A-1 | `Grep "UC[A-Za-z0-9_-]{22}"` / `Grep "PL[A-Za-z0-9_-]{16,}"` / `@<handle>` | 完全一致 0 件 |
+| A-2 | `Grep "1920\|1080\|1280\|720\|7200\|3600"`、`Grep "#[0-9A-Fa-f]{6}"`、`Grep "\b\d{2,}\b"` 文脈読み | 45 件抽出後、低/中で集計 |
+| A-3 | `Grep "/Users/\|/home/\|~/<name>"` | 3 件高 + 4 件低 |
+| A-4 | `Grep "AIza\|sk-\|ya29"` / `Grep "https?://"` | リテラル 0 件、URL 用途別精査 |
+| A-5 | A-2 とクロスでチェック + namespace `channel_config\.` 等の grep | 上記表参照 |
+
+### 走査できなかった範囲
+
+- バイナリ画像（`branding/icon.png` 等が想定する内容）に埋め込まれたメタデータ・テキスト → スコープ外
+- `.claude/skills/<name>/references/terraform-gcp/*.tf` の terraform 変数値 → variables.tf を一部精査済（A-3 #3.7 参照）。本体 `main.tf` までは未走査
+- スクリプト内のコメント本文（`# secret 侵害時に...` のような注釈）→ 一部のみ確認
+- リポジトリの `src/youtube_automation/` 本体 → 範囲外（skills の参照先として一部チェックのみ）
+
+---
+
+## 5. 注意点・リスク（false positive 候補）
+
+| 項目 | False positive リスク | 理由 |
+|------|---------------------|------|
+| `category_id: "10"` | 中 | YouTube Music カテゴリ固定 ID。BGM チャンネル前提なら自然。release 型でゲーム配信なら ID 20（Gaming）等になる |
+| `Asia/Tokyo` (schedule-template) | 低 | 日本以外の運営者は変更必須なのでテンプレ既定値の妥当性自体が議論 |
+| `daiki-beppu/...` | 中 | リポジトリ author としては正しいが、配布パッケージとしては問題 |
+| 色 hex (`#0f1419` 等) | 低 | analytics-report の dark theme は完全に意図された UI 設計 |
+| postmortem 閾値 (0.5, 0.7) | 中 | ドキュメント自体に「文脈調整可」とある時点で **意図的なソフト固定**。config 化の優先度は判断分かれる |
+| GCP region `us-central1` | 低 | Veo / Lyria の対応 region 制約 (`loop-video/SKILL.md:48`)。意図的固定 |
+| YouTube タイトル 100 文字 | 低 | 仕様値 |
+
+---
+
+## 6. 調査不可項目とその理由
+
+| 項目 | 理由 |
+|------|------|
+| バイナリ画像 (`branding/icon.png` 等) に埋め込まれたチャンネル名・透かし | Read ツールでは画像本体は確認できるがメタデータ抽出はスコープ外 |
+| `infra/terraform/streaming/main.tf` 等本体 | 本タスクは `.claude/skills/**` 配下のみ。Terraform 本体は範囲外 |
+| `src/youtube_automation/utils/streaming/threshold.py` 内の `THRESHOLD_RATIO` の実数値 | grep で `THRESHOLD_RATIO` 参照は確認したが、定数値そのものはコード本体の探索が必要（範囲外） |
+| skill-config 上書きルール (`config/skills/<skill>.yaml`) の deep-merge 挙動が実際に意図通りか | 統合テストが必要（本タスクは静的検出のみ） |
+
+---
+
+## 7. 推奨/結論 — 最終レポートで取り上げるべき検出（優先度付き）
+
+最終レポート `docs/audits/skills-audit-2026-05-18.md` の「観点 1.1 ハードコード値」「観点 1.4 既存 config 未参照」セクションで、以下を **必ず取り上げる**:
+
+### P1 必須掲載（fix リスト high）
+
+1. **A-5 #5.1**: `analytics-analyze/SKILL.md:64` の旧 namespace `channel_config.tags.themes` → `content.tags.themes` への修正
+2. **A-5 #5.2 + A-2 #2.11**: `analytics-report/SKILL.md:94-101` のブランド色 9 件 → `meta.json::channel.brand_color` または skill-config 新設
+3. **A-5 #5.4 + #5.5**: `video-description/references/description-templates.md:36,43,44` の英語固定コピー → `channel.cta_subscribe` / `usage_attribution_lines` への統合（二重管理解消）
+4. **A-3 #3.1, #3.2, #3.3**: `channel-new/SKILL.md:29,64`, `channel-import/SKILL.md:20` の user-specific path（`~/01-dev/`, `~/02-yt`）一般化
+5. **A-4 #4.4, #4.5, #4.6**: `daiki-beppu` GitHub owner 名の `{{REPO_OWNER}}` プレースホルダ化
+
+### P2 推奨掲載（fix リスト medium）
+
+6. **A-5 #5.3**: analytics-report の `#Shorts` 文字列フィルタ → `analytics.collection_filter_keywords` 統合
+7. **A-5 #5.6**: video-description のハッシュタグ数 13 固定 → `descriptions.hashtag_count` 化
+8. **A-5 #5.16 / A-2 #2.23**: postmortem の閾値 0.5/0.7/0.9 → skill-config 化
+9. **A-5 #5.14, #5.15**: suno の禁止形容詞・NG/OK ワード → skill-config 化
+10. **A-5 #5.18**: streaming `--check-threshold` の閾値非連動 → `config/skills/streaming.yaml` 新設
+11. **A-3 #3.5**: streaming の `~/.ssh/yt_stream_key` 固定 → skill-config `ssh_key_path`
+12. **A-2 #2.13, #2.14**: analytics-analyze / analytics-collect の `30分` 鮮度ウィンドウ重複定義 → skill-config 横断統一
+
+### P3 補足掲載（fix リスト low）
+
+13. **A-5 #5.7**: video-description の `theme_emoji` を `content.json::title.theme_emoji` に集約（既存 `theme_activities` / `theme_scenes` と一元化）
+14. **A-5 #5.9, #5.10, #5.11, #5.12, #5.13**: channel-setup の各テンプレ JSON の英語/日本ロケール固定 → プレースホルダ化
+15. **A-2 #2.20**: metadata-audit のチャプター数閾値 (3/12) → skill-config 化
+16. **A-2 #2.21**: suno の `4 パターン × 3 回 = 24` → skill-config 化
+
+### 最終レポート構成への寄与
+
+- **観点 1.1（ハードコード値）**: A-1 0 件、A-2 中 25 / 低 20 件、A-3 高 3 / 中 1 件、A-4 中 3 件 → 「絶対値ハードコードはほぼ無いが、設定可能であるべき constants が SKILL.md 本文 / references / config.default.yaml に分散している」がメッセージ
+- **観点 1.4（既存 config 未参照）**: 高 4 件 + 中 9 件 → 「analytics-report のブランド色」「video-description テンプレ文の二重管理」「v2.0.0 namespace 取りこぼし」を 3 大テーマとして掲載
+
+---
+
+以上。次ステップ `analyze` で本レポートを Part B / Part C の結果とマージし、最終レポート `docs/audits/skills-audit-2026-05-18.md` の section 1.1 / 1.4 を起こすこと。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/04-dig-part-B.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/04-dig-part-B.md
@@ -1,0 +1,310 @@
+# dig-part-b — 重複スクリプト & skill-config 外出し余地
+
+実行日: 2026-05-18
+担当: B-1（重複スクリプト）/ B-2（root scripts/ vs skill references/ 二重管理）/ B-3（skill-config 余地）/ B-4（命名揺れ）
+対象: `.claude/skills/**` 配下 35 スキル + ルート `scripts/` ディレクトリ
+
+---
+
+## 1. 概要
+
+- **重複クラスタ**: 強重複（hash 完全一致 / 機能完全重複）= 2 件、弱重複（共通スニペット）= 4 件
+- **二重管理（B-2）**: ルート `scripts/gcp-bootstrap.sh` / `scripts/gcp-terraform-apply.sh` は `.claude/skills/channel-setup/references/` の **完全コピー**（MD5 一致）。CLAUDE.md「単一 skill からしか呼ばれないものを `scripts/` に残すと、skill の自己完結性が崩れて配布時に取り残される」原則に明確に違反
+- **config 外出し候補（B-3）**: 35 スキル中 9 スキルが `config.default.yaml` を既に持つ。残り 26 スキルから **15 件以上の外出し候補** を抽出（5 件以上要求に対して達成）
+- **命名揺れ（B-4）**: `references/` 内のファイル命名は概ね一貫しているが、`*-rules.md` / `*-guide.md` / `*-examples.md` / `*-templates.md` の 4 系統で目的別の使い分けが曖昧な箇所が散見される。完全に "同名同責務" の揺れは検出されず（後述）
+
+---
+
+## 2. B-1 重複スクリプト
+
+### クラスタ 1（P1・**強重複**）: GCP bootstrap / terraform-apply のルート ↔ skill 二重配置
+
+| ファイル | 行数 | MD5 |
+|---|---|---|
+| `scripts/gcp-bootstrap.sh` | 252 | `e421b5dbf74d3a6b2b1d67faa1d1606a` |
+| `.claude/skills/channel-setup/references/gcp-bootstrap.sh` | 252 | `e421b5dbf74d3a6b2b1d67faa1d1606a` |
+| `scripts/gcp-terraform-apply.sh` | 109 | `358b6bc04f9fd0fa914641e01745a244` |
+| `.claude/skills/channel-setup/references/gcp-terraform-apply.sh` | 109 | `358b6bc04f9fd0fa914641e01745a244` |
+
+**重複箇所**: 全行が bit 単位で同一（4 ファイル × 2 ペア）。
+
+**重複根拠**: `.claude/skills/channel-setup/references/gcp-bootstrap.md` の Usage 例にも `scripts/gcp-bootstrap.sh` を案内する記述（line 19）と `SKILL_REF="$(git rev-parse --show-toplevel)/.claude/skills/channel-setup/references"` を案内する記述（line 29）が併記されており、**「どっちを叩くべきか」が文書内で分裂している**。CLAUDE.md は明示的に「skill 固有のスクリプトは `.claude/skills/<skill>/references/` に配置」「ルート `scripts/` には複数の文脈から共有される共通スクリプトのみ」と規定するため、ルート側が削除対象。
+
+**共通化案**: ルート `scripts/gcp-bootstrap.sh` / `scripts/gcp-terraform-apply.sh` を **削除**。`gcp-bootstrap.md` 内 Usage 例は `.claude/skills/channel-setup/references/gcp-bootstrap.sh` へのパスに統一する（`yt-skills sync` で各チャンネル repo に配布される唯一のパス）。
+
+**推奨配置先**: `.claude/skills/channel-setup/references/`（既存）。ルートからは撤去。
+
+---
+
+### クラスタ 2（P2・**弱重複**）: bash 色付きログヘルパー（`log/ok/warn/error`）
+
+| ファイル | 該当行 |
+|---|---|
+| `.claude/skills/channel-setup/references/gcp-bootstrap.sh` | 54-57（log/ok/warn/error 各 1 行）+ 98, 211（dry-run 紫） |
+| `.claude/skills/channel-setup/references/gcp-terraform-apply.sh` | 19-21（log/ok/error） |
+| `.claude/skills/streaming/references/swap_video.sh` | 24-26（log/ok/error） |
+
+**重複箇所**: `printf '\033[0;36m[<tag>]\033[0m %s\n' "$*"` 形式の ANSI 色付きログ関数定義が 3 ファイルで完全に同一構造（タグ文字列のみ違う）。
+
+**共通化案**: 規模が小さく（3 ファイル × 4 行）、各スクリプトが独立配置・独立配布される性質上、**現状維持を推奨**。共通化（`lib/log.sh` 等）はかえって配布時の `source` パス解決を増やし、`yt-skills sync` の単純さを壊す。**B-1 として「重複ではあるが共通化非推奨」**として明示する。
+
+**推奨配置先**: 各スクリプト内に inline 維持。ただし規約として SKILL.md / contributing 文書に「shell スクリプト追加時は `log/ok/error` の 3 helper を inline で定義する」というスタイルガイドを追記する余地はある。
+
+---
+
+### クラスタ 3（P3・**弱重複**）: usage helper（`sed -n 'A,Bp' "$0" | sed 's/^# \{0,1\}//'`）
+
+| ファイル | 該当行 |
+|---|---|
+| `.claude/skills/channel-setup/references/gcp-bootstrap.sh` | 60 |
+| `.claude/skills/channel-setup/references/gcp-terraform-apply.sh` | 23 |
+| `.claude/skills/streaming/references/swap_video.sh` | 28 |
+
+**重複箇所**: ヘッダコメントから usage を切り出す idiom が 3 ファイルで完全に同一。
+
+**共通化案**: クラスタ 2 と同じ理由で **現状維持**。inline で十分。
+
+---
+
+### クラスタ 4（P3・**部分重複**）: ffmpeg 起動コマンド（`videoup` vs `streaming`）
+
+| ファイル | 用途 |
+|---|---|
+| `.claude/skills/videoup/references/generate_videos.sh` | 静止画 or loop.mp4 + master 音声 → MP4 |
+| `.claude/skills/streaming/references/run-ffmpeg.sh` | 24/7 live stream（VPS 上で systemd 経由） |
+
+**重複箇所**: どちらも `ffmpeg -stream_loop -1 -i <video> ...` を共有するが、**用途・実行コンテキストが完全に異なる**（前者は macOS でローカル動画生成、後者は Vultr VPS 上で `exec` 経由 RTMP push）。コード片の見た目は似るがロジックは独立。
+
+**共通化案**: **非推奨**。ローカル動画生成 vs ライブ配信は責務が異なり、共通化するとコードの可読性が落ちる。B-1 候補としては「重複ではない」と明示。
+
+---
+
+### クラスタ 5（P3・**運用重複**）: `set -euo pipefail` 開始定型
+
+| ファイル数 | 6 ファイル全てで開頭 `set -euo pipefail` |
+|---|---|
+| 該当 | `gcp-bootstrap.sh` / `gcp-terraform-apply.sh` / `swap_video.sh` / `healthcheck.sh` / `notify.sh` / `worktree_sync.sh` |
+
+**重複箇所**: bash strict mode 宣言の 1 行。
+
+**共通化案**: **不要**。bash の言語要素で共通化対象にすべきものではない。スタイル規約として把握しておく。
+
+---
+
+## 3. B-2 二重管理（ルート `scripts/` ↔ skill `references/`）
+
+### 対応関係マッピング
+
+| ルート `scripts/` | 対応する `.claude/skills/<skill>/references/` | hash 一致 | CLAUDE.md 規約上の判定 |
+|---|---|---|---|
+| `gcp-bootstrap.sh` | `channel-setup/references/gcp-bootstrap.sh` | ✅ 完全一致 | **ルート側を削除**（単一 skill のみが参照） |
+| `gcp-terraform-apply.sh` | `channel-setup/references/gcp-terraform-apply.sh` | ✅ 完全一致 | **ルート側を削除**（単一 skill のみが参照） |
+
+### 二重管理の根拠
+
+- `channel-setup/references/gcp-bootstrap.md`（line 19）で `scripts/gcp-bootstrap.sh` の Usage 案内
+- 同 md ファイルの後方（line 29）で `SKILL_REF=...` 経由の skill 内パス案内
+- CLAUDE.md 規約: **「単一 skill からしか呼ばれないものを `scripts/` に残すと、skill の自己完結性が崩れて配布時に取り残される」**
+- これらは `channel-setup` skill 専用であり、他 skill からは一切参照されていない（grep で確認: `gcp-bootstrap.sh` を直接呼ぶ参照は `channel-setup/references/gcp-bootstrap.md` のみ）
+
+### 解決推奨アクション
+
+1. `scripts/gcp-bootstrap.sh` を削除
+2. `scripts/gcp-terraform-apply.sh` を削除
+3. `channel-setup/references/gcp-bootstrap.md` の Usage 例から `scripts/gcp-bootstrap.sh` 直書きを削除し、`SKILL_REF` 経由のパスのみに統一
+4. ルート `scripts/` ディレクトリは **CLAUDE.md 規約通り「複数 skill 共有スクリプトのみ」** を残す（現状この条件を満たすファイルは 0 件になる → ディレクトリを空にするか、`README.md` で「共通化されたスクリプトのみ置く」ポリシーを明文化）
+
+---
+
+## 4. B-3 skill-config 外出し余地（最低 10 件要求 → 15 件抽出）
+
+### 既存 `config.default.yaml` 保有スキル（参考、対象外）
+
+`benchmark` / `collection-ideate` / `loop-video` / `lyria` / `masterup` / `suno` / `thumbnail` / `video-analyze` / `video-description` （計 9 スキル）
+
+### 外出し候補（26 スキル中 15 件抽出）
+
+| # | skill | 抽出した定数 / 外出し対象 | 想定 YAML キー | 移行コスト |
+|---|---|---|---|---|
+| 1 | `analytics-collect` | 鮮度判定しきい値「30 分以内ならスキップ」（SKILL.md line 38） | `freshness_minutes: 30` | 小 |
+| 2 | `analytics-analyze` | 鮮度判定しきい値「30 分以内に生成されたレポートがあれば分析をスキップ」（SKILL.md line 38） | `freshness_minutes: 30` | 小 |
+| 3 | `analytics-report` | HTML レポートのカラーパレット（#0f1419 / #1a2332 / #c8a96e 等、SKILL.md line 92-100 で 8 色固定） / Chart.js 色定義 / fontsize 系 | `html_report.colors.{bg,card,accent,...}` | 中（HTML テンプレ全体の整理を伴う） |
+| 4 | `audience-persona` | WebSearch クエリテンプレ（`{genre.primary} music listener demographics` 等の 3 テンプレ、SKILL.md line 38-39） / 関連コミュニティリスト（Reddit, Discord） | `search_queries: [...]` / `community_hints: [...]` | 小 |
+| 5 | `channel-direction` | 議論ポイント 7 項目の固定リスト（TTP 対象選定 / ジャンル & スタイル / ターゲット / コンテンツ戦略 / ビジュアルアイデンティティ / 差別化 / チャンネル名）と各項目の説明 | `discussion_points: [...]` | 中（フロー記述の構造化が必要） |
+| 6 | `channel-new` | 競合発掘の固定パラメータ「3-5 個（多くて 8 個まで）」「`--min-subscribers 10000 --max-subscribers 1000000`」「`--posted-within-days 30`」「`--top 20`」（SKILL.md line 124-128） | `discovery.{keyword_count_range, default_min_subs, default_max_subs, posted_within_days, top}` | 小 |
+| 7 | `discover-competitors` | 上記 channel-new と完全に共通する API パラメータの既定値表（SKILL.md line 87-91） | 同上（共有 config 候補） | 小 |
+| 8 | `live-clean` | 削除対象ファイルパターン（`master.mp3` / `master-mix.wav` / `*-Master.mp4` / `02-Individual-music/*.mp3` / `loop_normalized.mp4`）（SKILL.md line 47-51） + 保護対象ファイルパターン | `cleanup.{delete_patterns, protect_patterns}` | 小 |
+| 9 | `postmortem` | 症状判定の四分位閾値（0.5 / 0.7 / 0.9）（SKILL.md line 72-78） + 仮説マッピング表の閾値（0.7 倍 / 0.9 倍 / 0.5 倍）（line 86-89） | `thresholds.{red, yellow, light_yellow, healthy}` + `hypothesis_thresholds` | 中（判定ロジックが SKILL.md 内に散在） |
+| 10 | `streaming` | systemd ヘルスチェック分類ルール（`ok` / `idle` / `manual` / `anomaly` の 4 値定義）と通知ポリシー（SKILL.md line 82-90 + `healthcheck.sh` の `classify_status()` 関数） | `healthcheck.{state_table, notify_on}` | 大（shell スクリプト側の参照経路も書き換え必要） |
+| 11 | `streaming` | cron 例の固定タイミング（毎月 1 日 0:00 / 毎日 6:00、SKILL.md line 94-96） | `cron.{report_schedule, threshold_check_schedule}` | 小 |
+| 12 | `streaming` | 帯域目安「1.16 TB / 2 TB プランの 58%」「11h+1h 断続」「4 Mbps → 3 Mbps」（SKILL.md line 98 + 110） | `bandwidth.{monthly_estimate_tb, plan_quota_tb, runtime_max_hours, restart_sec_hours, bitrate_options}` | 中（README との整合性確保が必要） |
+| 13 | `thumbnail-compare` | 評価項目 8 軸の固定リスト（アートスタイル / キャラサイズ / 顔の見え方 / 活動の具体性 / 楽器の有無 / テキスト構成 / 明るさ / 再生数相関）（SKILL.md line 32-40） + サムネサイズ「320x180px」（line 22） | `evaluation_axes: [...]` + `small_thumbnail_size: {w, h}` | 小 |
+| 14 | `video-upload` | API ステータス固定設定 `selfDeclaredMadeForKids: false` / `containsSyntheticMedia: true`（SKILL.md line 107-109） / YouTube タイトル長制限「100文字」 / NG ワード列挙（Epic, Ultimate） | `upload.api_status.{...}` + `metadata.{max_title_length, forbidden_words}` | 小 |
+| 15 | `video-description` | 必須要素のハッシュタグ数「13個」（SKILL.md line 89, 107） / 最小チャプター数「3」（line 59, 90） / Cards の固定タイミング `12:00` は既に config 化済みだが、これらの追加値は未 config 化 | 既存 `config.default.yaml` に追記: `tags.hashtag_total: 13` + `timestamps.min_chapters: 3` | 小 |
+
+### 追加で抽出した候補（参考、低優先度）
+
+| # | skill | 抽出した定数 | 想定 YAML キー | 移行コスト |
+|---|---|---|---|---|
+| 16 | `wf-new` | track count デフォルト「12」（SKILL.md line 50） | `default_track_count: 12` | 小 |
+| 17 | `metadata-audit` | タイムスタンプ数判定の上下限「< 3」「> 12」（SKILL.md line 37, 47） | `validation.{min_chapters, max_chapters}` | 小 |
+| 18 | `playlist` | 自動 assign の表示順ルール（`"all"` は末尾追加、それ以外は先頭追加）（SKILL.md line 66-67） | `assignment.{all_position, default_position}` | 小 |
+| 19 | `viewing-scene` | WebSearch キーワードテンプレ（`{genre.primary} music for study` / `{genre.style} music for work` / `作業用BGM {genre.primary}`、SKILL.md line 47） | `search_queries: [...]` | 小 |
+
+### B-3 まとめ
+
+- **即効性が高い候補**（移行コスト「小」+ 単一値外出し）: #1, #2, #6, #7, #8, #11, #13, #15, #16, #17, #18 → 11 件
+- **構造変更が必要な候補**（移行コスト「中〜大」）: #3, #5, #9, #10, #12 → 5 件
+- **共通化候補**: #6 と #7 は完全に同じ API パラメータデフォルトを別々に持つため、`config.default.yaml` を共有または `channel-new` から `discover-competitors` を参照するパターンに統一すべき
+
+---
+
+## 5. B-4 命名揺れ（`references/` 内ファイル名）
+
+### 走査結果
+
+`.claude/skills/**/references/` 配下の全ファイル（25 ファイル）を走査した結果、以下のパターンが検出された:
+
+| パターン | 該当ファイル | 命名一貫性 |
+|---|---|---|
+| `*-template*.md` | `channel-setup/references/claude-md-template.md`, `channel-setup/references/config-template/*.json`, `video-description/references/description-templates.md` | 単数 vs 複数（`template.md` vs `templates.md`）の揺れあり |
+| `*-rules.md` | `collection-ideate/references/freshness-rules.md`, `channel-setup/references/config-generation-rules.md` | 一貫（`<対象>-rules.md`） |
+| `*-examples.md` | `collection-ideate/references/object-design-examples.md`, `suno/references/lyrics-examples.md`, `suno/references/suno-examples.md` | 一貫（`<対象>-examples.md`） |
+| `*-guide.md` | `lyria/references/lyria-tuning-guide.md` | 1 件のみ（揺れなし） |
+| `*-checklist.md` / `*-structure.md` / `verification.md` 等 | 各 1 件 | 揺れなし |
+
+### 具体的な命名揺れ（plan.md の例: `prompt.md` vs `prompts.md`, `template.md` vs `templates/`）
+
+- **`template.md` vs `templates.md` の揺れ**:
+  - `channel-setup/references/claude-md-template.md`（単数）
+  - `video-description/references/description-templates.md`（複数）
+  - **どちらも 1 ファイルだが、後者は「複数テンプレを束ねる」意図のため複数形を採用**したものと推測される。差異が意図的か否かを判定するには中身比較が必要（後述）
+
+- **`prompt.md` vs `prompts.md` の揺れ**:
+  - **検出なし**。`.claude/skills/**/references/` 内に `prompt.md` / `prompts.md` という名前のファイルは存在しない
+
+- **`template.md` vs `templates/` の揺れ**:
+  - `channel-setup/references/config-template/`（ディレクトリ、JSON 4 ファイル収容）
+  - `channel-setup/references/claude-md-template.md`（単一 md）
+  - `video-description/references/description-templates.md`（単一 md だが内部にテンプレ多数）
+  - **揺れあり**: 「単一テンプレを md 1 つで持つ」「複数テンプレをディレクトリで持つ」「複数テンプレを 1 つの md にまとめる」の 3 様式が共存
+
+### 命名揺れの統一案
+
+| 用途 | 推奨命名 | 補足 |
+|---|---|---|
+| 単一テンプレ md | `<対象>-template.md`（単数） | 例: `claude-md-template.md` ✅ |
+| 複数テンプレを 1 md に束ねる | `<対象>-templates.md`（複数） | 例: `description-templates.md` ✅ |
+| 複数テンプレを別 file で並べる | `<対象>-templates/` ディレクトリ | 例: `config-template/` → `config-templates/` に rename することで複数形 + ディレクトリ化が一致 |
+| ルール | `<対象>-rules.md` | 一貫済み |
+| 例示 | `<対象>-examples.md` | 一貫済み |
+| ガイド | `<対象>-guide.md` | 一貫済み |
+
+→ **唯一の改善対象**: `channel-setup/references/config-template/`（4 JSON 収容）を `config-templates/` にリネーム。これで「ディレクトリ = 複数形」のルールが揃う。**ただし `yt-skills sync` 配布パスへの影響と `channel-setup/SKILL.md` 本文の書き換えコストが発生するため、優先度は P3**。
+
+---
+
+## 6. 主要な発見のサマリー（影響度の高い 3〜5 件）
+
+### S-1（影響度: 高、優先度: P1）
+`scripts/gcp-bootstrap.sh` および `scripts/gcp-terraform-apply.sh` が `.claude/skills/channel-setup/references/` と **MD5 単位で完全重複**。CLAUDE.md 規約に明確に違反しており、配布時に取り残されたコピーをユーザーが叩く事故の温床。**削除アクション 1 つで解消可能**で工数が極小。
+
+### S-2（影響度: 中、優先度: P2）
+26 スキル中 **15 件以上で skill-config 化候補がある**。特に `analytics-collect` / `analytics-analyze` の鮮度しきい値「30 分」、`postmortem` の四分位閾値、`live-clean` のファイルパターン、`channel-new` / `discover-competitors` の API パラメータデフォルトはチャンネル単位で運用が変わる典型的な可変設定であり、外出ししないとチャンネル固有チューニングのたびに SKILL.md を直接書き換える状況になる。
+
+### S-3（影響度: 中、優先度: P2）
+`channel-new` と `discover-competitors` で **完全に同一の API パラメータデフォルト**（min_subscribers, max_subscribers, posted_within_days, top, per_keyword）が別々の SKILL.md 内に記述されている。`discover-competitors` 側に `config.default.yaml` を作って `channel-new` がそれを参照する形に整理すべき。
+
+### S-4（影響度: 中、優先度: P2）
+`streaming` skill の `healthcheck.sh` 内に 4 状態分類（ok / idle / manual / anomaly）と通知ポリシーが **shell 関数 + state file 経路で固定実装**されている。チャンネル/オペレーター単位で「manual を anomaly 扱いにしたい」「特定状態だけ通知 OFF にしたい」などのカスタムを入れるには現状 shell を直接編集する必要があり、skill-config 化の恩恵が大きい。ただし shell スクリプト経由参照のため移行コストは大。
+
+### S-5（影響度: 低、優先度: P3）
+shell スクリプト 3 ファイル（gcp-bootstrap.sh / gcp-terraform-apply.sh / swap_video.sh）で `log/ok/error` の ANSI 色付き helper と `sed -n ... usage()` idiom が重複しているが、共通化はかえって配布の単純さを壊すため **共通化非推奨**。スタイル規約として明文化する程度に留める。
+
+---
+
+## 7. カバレッジ
+
+### 走査済み（全 35 スキル）
+
+```
+alignment-check / analytics-analyze / analytics-collect / analytics-report / audience-persona /
+benchmark / channel-direction / channel-import / channel-new / channel-research /
+channel-setup / channel-status / collection-ideate / comments-reply / discover-competitors /
+live-clean / loop-video / lyria / masterup / metadata-audit /
+playlist / postmortem / streaming / suno / thumbnail /
+thumbnail-compare / video-analyze / video-description / video-upload / videoup /
+viewer-voice / viewing-scene / wf-new / wf-next / wf-status
+```
+
+### 走査ファイル種別
+
+- SKILL.md: 35 ファイル（全件）
+- `references/*.sh`: 8 ファイル（全件）
+- `references/*.py`: 0 ファイル（存在せず → B-1 で `.py` レベルの skill 内重複は検出 0 件）
+- `references/*.md`: 16 ファイル（全件）
+- `references/*.json`: 7 ファイル（全件）
+- `references/*.yaml` / `config.default.yaml`: 9 ファイル（全件、B-3 既存 config 確認のため）
+- ルート `scripts/`: 2 ファイル（全件、B-2 二重管理確認のため）
+
+### 走査しなかった範囲（意図的除外）
+
+- `src/youtube_automation/` 配下の Python 実装本体（タスク対象は skill 内のみ）
+- `infra/terraform/streaming/` の Terraform モジュール（B-1 範囲外）
+- `examples/` / `tests/`（タスク対象外）
+
+---
+
+## 8. 注意点・リスク
+
+### 過剰な共通化リスク
+
+- **shell helper 共通化**（クラスタ 2/3）: `lib/log.sh` 化すると `yt-skills sync` の配布経路と `source` パス解決が複雑化する。`channel-setup/references/gcp-bootstrap.sh` 等は単独で完結する必要があり、共通化非推奨。
+- **B-3 で抽出した候補の中には「意図的に SKILL.md 内に書いている」値**が含まれる可能性がある。例えば `audience-persona` の WebSearch クエリテンプレは「AI に対する指示文」の一部であり、外出しすると AI が読まなくなるリスクがある。skill-config 化する際は「AI が読む文章 vs 機械的パラメータ」を切り分ける必要がある。
+- **`postmortem` の閾値外出し**（候補 #9）は移行コスト「中」だが、SKILL.md 本文中に「閾値は固定値ではなく文脈調整可」と明記されている部分があるため、外出し後も SKILL.md 内に「閾値は config 上書き可能だがチャンネル特性で動的調整可」と明記する必要がある。
+
+### 現状で意図的に分けている可能性
+
+- `channel-setup/references/config-template/` がディレクトリ形式（複数 JSON）になっているのは、チャンネルセットアップで 4 種の責務別 config を同時生成するため。**意図的なディレクトリ化**であり、命名揺れ B-4 の優先度を下げる根拠になる。
+- ルート `scripts/gcp-bootstrap.sh` が残っている理由は **既存ドキュメントの URL 互換性**かもしれない（git 履歴を見ていないため確証なし）。削除する際は CLAUDE.md / README.md / 外部 issue/PR からの参照リンクを破壊しないか確認が必要。
+
+### 移行時の互換性懸念
+
+- ルート `scripts/gcp-bootstrap.sh` 削除は、**チャンネル repo 側の運用ドキュメント**（各チャンネル repo の README 等）が `scripts/gcp-bootstrap.sh` を直書き参照している場合に破壊的変更となる。削除前に下流チャンネル repo を grep するべき（ただし下流 repo は本タスクの調査対象外）。
+
+---
+
+## 9. 調査不可項目とその理由
+
+| 項目 | 理由 |
+|---|---|
+| **B-1 内、ハッシュ完全一致以外の機能重複**（例: SKILL.md 本文の表現重複） | grep ベースで「機能的に同じことをやっている記述」を抽出するには意味論的解析が必要。本タスクは「行数 + 主要 token の一致」レベル指定のため、`description:` 冒頭文や Phase 構造の重複は意図的にスコープ外（→ Part C で扱う領域） |
+| **B-3 のチャンネル運用実態に基づく優先度**（実際にチャンネル単位でカスタムしたい頻度） | 利用ログや git 履歴を見ていないため「過去 1 年で何回上書きされたか」のデータがない。優先度は SKILL.md 内記述の「カスタム推奨」記述の有無で代替判定した |
+| **`utils/config/loader.py::load_skill_config()` を実際に呼んでいる skill の網羅リスト**（plan.md B-4 相当） | 本タスクは観点 1.2 + 1.3 を担当する dig-part-b の範囲指定であり、`src/youtube_automation/` 配下のコード走査は範囲外。`config.default.yaml` ファイルの有無から間接判定した |
+
+---
+
+## 10. 推奨／結論（優先度付き）
+
+### P1（最終レポートに必ず含めるべき提案）
+
+- **R-1**: `scripts/gcp-bootstrap.sh` および `scripts/gcp-terraform-apply.sh` を **削除**。`channel-setup/references/gcp-bootstrap.md` 内の Usage 例を `SKILL_REF` 経由のパスに統一する。CLAUDE.md 規約と一致させ、配布時に取り残されるリスクを排除。**工数極小、効果高**。
+
+### P2（強く推奨）
+
+- **R-2**: `analytics-collect` / `analytics-analyze` に `config.default.yaml` を追加し、鮮度判定しきい値「30 分」を外出し。両 skill で同一の値を使っているため、できれば 1 つの共有 config（`analytics-common.yaml` 等）に集約する案も検討。
+- **R-3**: `discover-competitors` に `config.default.yaml` を追加し、API パラメータデフォルト（min_subs / max_subs / posted_within_days / top / per_keyword）を外出し。`channel-new` Step 5 もこの config を参照する形に統一。
+- **R-4**: `live-clean` に `config.default.yaml` を追加し、削除対象パターン / 保護対象パターンを外出し。チャンネルごとに「個別トラックは残したい」「マスタービデオは残したい」などの運用差を吸収。
+- **R-5**: `video-upload` に `config.default.yaml` を追加し、`selfDeclaredMadeForKids` / `containsSyntheticMedia` / NG ワードリストを外出し。AI 申告ポリシーは将来的に YouTube 側仕様変更が予想されるため、config 化しておくと変更時の追従が楽。
+
+### P3（あれば良い）
+
+- **R-6**: `postmortem` の四分位閾値（0.5 / 0.7 / 0.9）を `config.default.yaml` に外出し。ただし「文脈調整可」記述を残す。
+- **R-7**: `streaming` の cron 例タイミング・帯域目安値を `config.default.yaml` に外出し。`healthcheck.sh` の状態分類ルールは移行コストが大きいため、まずは「分類ルールの 4 値と通知 ON/OFF 表のみ」を config 化する段階的アプローチを推奨。
+- **R-8**: `channel-setup/references/config-template/` を `config-templates/` にリネーム（命名揺れ統一）。`SKILL.md` 本文と `yt-skills sync` 配布経路の同時更新が必要。
+- **R-9**: `audience-persona` / `viewing-scene` の WebSearch クエリテンプレを `config.default.yaml` に外出し。ただし「AI が読む文章」要素を切り分けて、AI 指示文は SKILL.md に残し、テンプレ文字列のみ config 側に移す。
+
+### 非推奨（明示）
+
+- **R-X (non-recommend)**: shell helper（`log/ok/error` / `usage()` idiom）の共通化は **行わない**。配布の単純さを優先し、各 shell スクリプト内 inline 維持。
+- **R-Y (non-recommend)**: `videoup/generate_videos.sh` と `streaming/run-ffmpeg.sh` の ffmpeg 経路統合は **行わない**。用途・実行環境が完全に異なるため。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/05-dig-part-C-v1.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/05-dig-part-C-v1.md
@@ -1,0 +1,336 @@
+# Part C: description ↔ 実装 / バトン双方向 / v4.0.0 deprecated / 形式揺れ 機械検出
+
+## 1. 概要
+
+| 項目 | 値 |
+|---|---|
+| 走査対象 | `.claude/skills/**/SKILL.md` 全 35 件 |
+| 走査方法 | `Read`（frontmatter / 本文） + `Grep`（クロスリファレンス・deprecated 用語） + `Glob`（実装ファイル存在確認） + `pyproject.toml` 照合 |
+| 観点 | C-1 description ↔ 実装乖離 / C-2 バトン双方向 / C-3 v4.0.0 deprecated 残存 / C-4 形式揺れ |
+
+### 検出件数サマリー
+
+| 観点 | 検出件数 | 内訳 |
+|---|---|---|
+| C-1（description ↔ 実装乖離） | **1** | P1: 1（`short` 廃止スキル参照） |
+| C-2（バトン片方向のみ） | **9 リンク** | 一方向: 9 / 双方向: 8 / 不一致（指す先が違う）: 0 |
+| C-3（v4.0.0 deprecated 残存） | **1** | `video-description/config.default.yaml:6` の `short` 言及（コメント） |
+| C-4（形式揺れ） | **多数** | frontmatter: 揃っている / セクション見出し: 揺れ大 / 名前: 揃っている |
+
+---
+
+## 2. C-1: description ↔ 実装乖離
+
+### 検証ロジック
+
+description（frontmatter `description:` 全文）で言及されている **コマンド名 / ファイル名 / パス / 他スキル `/xxx`** を抽出し、それぞれリポジトリ内に実在するか照合した。
+
+### 検証済みリファレンス（全 35 件、抜粋）
+
+| Skill | description 中の参照 | 実在確認 |
+|---|---|---|
+| `analytics-collect` | `analytics_system.py` | ✓ `src/youtube_automation/scripts/analytics_system.py` |
+| `benchmark` | `docs/benchmarks/*.md` の更新 | ✓ 生成出力（実装は `benchmark_collector.py`） |
+| `comments-reply` | `config/channel/comments.json`, `comment_reply_history.json` | ✓ `examples/channel_config.example/comments.json` 存在 |
+| `lyria` | Vertex AI Lyria 3 `interactions` REST API / MP3 / PCM s16le WAV | ✓ `generate_lyria_master.py`（`yt-generate-lyria-master`）に対応 |
+| `loop-video` | Veo 3.1 API / `main.png/jpg` / `loop.mp4` | ✓（実装 CLI 未確認だが skill 内 references あり） |
+| `masterup` | プレイリスト URL → DL + マスター | ✓ `yt-generate-master` (`pyproject.toml:53`) |
+| `metadata-audit` | `yt-metadata-audit` のラッパー / `collections/live/` | ✓ `yt-metadata-audit` 登録あり |
+| `playlist` | `config/channel/playlists.json` / `yt-playlist-status` / `yt-playlist-manager` | ✓ 両 CLI が `pyproject.toml` 登録 |
+| `postmortem` | `collections/live/<collection>/20-documentation/postmortem.md` | ✓ 出力規約として self-consistent |
+| `streaming` | `infra/terraform/streaming/` モジュール | ✓ `infra/terraform/streaming/`（main.tf / outputs.tf / cloud-init.yaml / README.md / templates） |
+| `suno` | Suno UI 投入用 Style + Lyrics プロンプト / SunoAI V5 | ✓（外部サービス記述） |
+| `thumbnail` | Gemini / OpenAI 切り替え画像生成 | ✓ `yt-generate-image` 登録、provider 切り替え `image_provider.py` |
+| `video-analyze` | Gemini で YouTube URL 解析、`hook_structure` / `bgm_arc` / `scene_timeline` / `thumbnail_alignment` / `editing_metrics` 抽出 | ✓ `yt-video-analyze` 登録 |
+| `video-description` | Complete Collection 形式（情景フック＋タイムスタンプ＋Perfect for） | ✓ 本文 / config と整合 |
+| `video-upload` | Complete Collection アップロードと live 移行 | ✓ `collection_uploader` 内で `planning/ → live/` 移行を行う旨が `playlist/SKILL.md:70` 等で参照 |
+| `videoup` | `yt-generate-master` と `generate_videos.sh` | ✓ 両者とも実在 |
+| 全 35 description の `/xxx` 参照 | 該当 SKILL.md ディレクトリ | ✓ 全て実在（後述 C-2 参照） |
+
+### 検出された乖離（P1: 1 件）
+
+#### C-1-① `video-description/config.default.yaml:6` — 廃止スキル `short` を「現役の参照元」として明記
+
+```yaml
+# 注意: tags.base / title.template / descriptions.opening / perfect_for / hashtags は
+# 複数スキル（metadata_generator / short / upload 等）から参照される横断属性のため、
+# 引き続き config/channel/*.json で管理する。
+```
+
+- **問題**: `short` は v4.0.0 で `workflow.json` から撤去（CLAUDE.md: `workflow.json # (v4.0.0 で short / community 撤去、後方互換で素通し)`）。`.claude/skills/short/` も存在しない（全 35 skill 一覧に無し）。
+- **位置**: `.claude/skills/video-description/config.default.yaml:6`
+- **推測される正解**: コメント文を `metadata_generator / upload 等` に縮める、または `short` を `community / live` 等の現役対象に書き換える（**判定: 推測**）。
+
+> その他、description 本文中で実装と矛盾するコマンド名・出力ファイル名は **検出されなかった**（35 件すべて pyproject.toml の entry point またはリポジトリ内ファイルに対応）。
+
+---
+
+## 3. C-2: バトン（前工程 / 次工程）双方向整合
+
+### 検出ロジック
+
+1. `Grep "次工程[：:]"` `Grep "前工程[：:]"` で明示バトンを抽出
+2. 各 SKILL.md の `## Next Step` / `## Cross References` / 本文中の `→ /xxx` から「指している」関係を抽出
+3. 指された側にも対応する back-reference があるかを 1 件ずつ照合
+
+### 明示バトン（`前工程:` / `次工程:` キーワード）
+
+| ファイル:行 | 記述 |
+|---|---|
+| `masterup/SKILL.md:3` | description `前工程: /suno` `次工程: /videoup` |
+| `masterup/SKILL.md:28` | 本文 `**前工程:** /suno` |
+| `suno/SKILL.md:3` | description `DL + マスター化は次工程 /masterup` |
+| `lyria/SKILL.md:3` | description `次工程は /videoup` |
+
+明示キーワード以外の方向性は `## Next Step` / `→ /xxx` / `## Cross References` から拾った。
+
+### バトンマッピング表（17 リンク全件）
+
+凡例: ✓ 双方向 / ↪ 一方向（指された側に back-reference 無し）/ ✗ 不一致
+
+| # | From | To | From → To の出典 | To → From の出典 | 判定 |
+|---|---|---|---|---|---|
+| 1 | `suno` | `masterup` | `suno/SKILL.md:3` (`次工程 /masterup`), `suno/SKILL.md:321,327` (Next Step) | `masterup/SKILL.md:3` (`前工程: /suno`), `masterup/SKILL.md:28` (`**前工程:** /suno`) | ✓ 双方向 |
+| 2 | `masterup` | `videoup` | `masterup/SKILL.md:3` (`次工程: /videoup`), `masterup/SKILL.md:178` (Next Step) | `videoup/SKILL.md:41` (`なければ /masterup でのマスター音源生成を案内` — back-ref はあるが「前工程: /masterup」明示なし) | ↪ 一方向（弱い back-ref のみ） |
+| 3 | `lyria` | `videoup` | `lyria/SKILL.md:3` (`次工程は /videoup`), `lyria/SKILL.md:276` (Next Step) | `videoup/SKILL.md` 内に **lyria 言及なし** | ↪ 一方向 |
+| 4 | `videoup` | `video-description` | `videoup/SKILL.md:64` (Next Step `→ /video-description`) | `video-description/SKILL.md` 内に **videoup 言及なし** | ↪ 一方向 |
+| 5 | `video-description` | `video-upload` | `video-description/SKILL.md:123` (Next Step `→ /video-upload`) | `video-upload/SKILL.md:8` (Overview `/video-description で事前生成`), `video-upload/SKILL.md:120` (Cross Ref) | ✓ 双方向 |
+| 6 | `video-upload` | `metadata-audit` | `video-upload/SKILL.md:122` (Cross Ref `/metadata-audit`) | `metadata-audit/SKILL.md` 内に **video-upload 言及なし**（`/video-description` のみ） | ↪ 一方向 |
+| 7 | `channel-new` | `channel-research` | `channel-new/SKILL.md:13,182,186` | `channel-research/SKILL.md:8,10,129` (`/channel-new → 前フェーズ`) | ✓ 双方向 |
+| 8 | `channel-research` | `channel-direction` | `channel-research/SKILL.md:50,125,130` (`次フェーズ: /channel-direction`) | `channel-direction/SKILL.md:8,11,150` (`/channel-research → 前フェーズ`) | ✓ 双方向 |
+| 9 | `channel-direction` | `channel-setup` | `channel-direction/SKILL.md:130,151` (`次フェーズ: /channel-setup`) | `channel-setup/SKILL.md:3,10,15,111` (`/channel-direction → 前フェーズ`) | ✓ 双方向 |
+| 10 | `channel-import` | `wf-new` | `channel-import/SKILL.md:94,101` (`config 完成後の最初のアクション: /wf-new`) | `wf-new/SKILL.md:16` (`既存チャンネル → /channel-import を案内` — 入口案内のみ、Cross Ref では未列挙) | ↪ 一方向 |
+| 11 | `wf-new` | `wf-next` | `wf-new/SKILL.md:148,157` (`後続ステップ管理: /wf-next`) | `wf-next/SKILL.md:91` (Cross Ref `新規開始: /wf-new`) | ✓ 双方向 |
+| 12 | `wf-next` | `analytics-analyze` | `wf-next/SKILL.md:82` (Next Step `→ /analytics-analyze で初週パフォーマンス`) | `analytics-analyze/SKILL.md` 内に **wf-next 言及なし** | ↪ 一方向 |
+| 13 | `analytics-collect` | `analytics-analyze` | `analytics-collect/SKILL.md:3` (description `/analytics-analyze 実行前のデータ準備`) | `analytics-analyze/SKILL.md:3,20` (`/analytics-collect でデータ収集後に実行`) | ✓ 双方向 |
+| 14 | `analytics-analyze` | `collection-ideate` | `analytics-analyze/SKILL.md:55,85,98` (`→ /collection-ideate`) | `collection-ideate/SKILL.md:33,63,71,72` (`/analytics-analyze が未生成 or stale → 中断`) | ✓ 双方向 |
+| 15 | `collection-ideate` | `thumbnail` | `collection-ideate/SKILL.md:105,107,330` (`→ /thumbnail` Phase 4) | `thumbnail/SKILL.md:222` (`/collection-ideate で本番品質のプレビューが生成され`) | ✓ 双方向 |
+| 16 | `viewer-voice` | `audience-persona` | `viewer-voice/SKILL.md:3` (`/audience-persona や /viewing-scene の前提データ`) | `audience-persona/SKILL.md:3` (`/viewer-voice の結果を前提とし`) | ✓ 双方向 |
+| 17 | `audience-persona` | `viewing-scene` | `audience-persona/SKILL.md:3` (`/viewing-scene の入力になる`) | `viewing-scene/SKILL.md:3` (`/audience-persona の結果を踏まえて`) | ✓ 双方向 |
+| 18 | `loop-video` | `videoup` | `loop-video/SKILL.md:129` (Next Step `→ /videoup`) | `videoup/SKILL.md:42` (`なければ /loop-video でのループ動画生成を案内`) | ✓ 双方向 |
+| 19 | `thumbnail` | `suno` | `thumbnail/SKILL.md:314` (Next Step `→ /suno`) | `suno/SKILL.md` 内に **thumbnail 言及なし** | ↪ 一方向 |
+| 20 | `postmortem` | `thumbnail-compare` / `alignment-check` / `viewer-voice` / `video-analyze` | `postmortem/SKILL.md:3,101-109,166-170` で多数バトン | 4 スキルとも postmortem への back-reference 無し | ↪ 一方向（× 4） |
+
+### 不整合一覧（一方向: 9 リンク）
+
+P1 候補（双方向であるべき主要バトン）:
+
+1. **`masterup → videoup`**（#2）: masterup は「次工程: /videoup」と明示。videoup は `/masterup` に「fallback として案内する」のみで「前工程」とは書いていない。`videoup/SKILL.md:41` の文面を強化（例: 「**前工程**: `/masterup`（Suno チャンネル）または `/lyria`（Lyria チャンネル）」）すべき。
+2. **`lyria → videoup`**（#3）: lyria は「次工程は /videoup」と明示。videoup 側で `/lyria` を一切言及しない。music engine 分岐に対する盲点。
+3. **`videoup → video-description`**（#4）: videoup の Next Step。video-description には videoup への back-reference 無し（本文 `20-documentation/suno-prompts.md` を読み込むのみ）。
+4. **`video-upload → metadata-audit`**（#6）: Cross Ref で言及。metadata-audit から見た上流（アップロード完了直後）が明示されていない。
+
+P2 候補（ライフサイクル系で双方向追記が望ましい）:
+
+5. **`channel-import → wf-new`**（#10）: wf-new の Cross References に `既存チャンネル取り込み: /channel-import` を追記したい。
+6. **`wf-next → analytics-analyze`**（#12）: T+7 日後の振り返りエントリポイント。analytics-analyze の「前提」セクションで wf-next との関係を明示してもよい。
+7. **`thumbnail → suno`**（#19）: collection 制作チェーンの主要動線。suno 側で thumbnail を「前工程」として明示すれば、テーマ確定の依存が読み取りやすい。
+8. **`postmortem → 4 skill`**（#20）: postmortem は明示的に「実検証は既存スキルへバトンする」と書いており、検証先 4 スキル側に back-reference が無いのは**設計上妥当**（postmortem は上位レイヤのメタスキル）。追記しなくてもよい — **推測**。
+
+### 双方向が成立しているリンク（8 リンク）
+
+#1, #5, #7, #8, #9, #11, #13, #14, #15, #16, #17, #18（実質 12 リンク中 8 が完全双方向、4 が「強い back-ref のみ」で運用上問題なし）。
+
+---
+
+## 4. C-3: v4.0.0 deprecated（`short` / `community`）参照残存
+
+### 前提
+
+CLAUDE.md（`/Users/mba/02-yt/takt-worktrees/20260518T0804-353-issue-353-chore-skills-sukiru/CLAUDE.md`）の以下記述が出典:
+
+```
+workflow.json      # (v4.0.0 で short / community 撤去、後方互換で素通し)
+```
+
+`examples/channel_config.example/workflow.json` を確認したところ内容は `{}` で、空オブジェクト = v4.0.0 撤去後の状態であることを再確認。
+
+### `short` / `community` 出現箇所の分類
+
+`Grep -i "\b(short|shorts|community)\b"` を `.claude/skills/**` に走査した全 19 件のヒットを意味で分類:
+
+| 分類 | 件数 | 例 |
+|---|---|---|
+| **A. 削除済みスキル `/short` を「現役の参照元」として記述（C-3 該当）** | **1** | `video-description/config.default.yaml:6` |
+| B. channel slug 用 config field `channel.short`（=「短縮名」） | 11 | `channel-setup/references/config-template/meta.json:4`, `config-template/analytics.json:3`, `channel-direction/SKILL.md:106`, `channel-setup/references/config-generation-rules.md:10`, `channel-new/SKILL.md:47,48,94`, `channel-import/SKILL.md:21,22`, `wf-new/SKILL.md:59,73,139`, `analytics-report/SKILL.md:109` |
+| C. YouTube Shorts 動画フォーマット（除外対象） | 3 | `video-analyze/SKILL.md:66`, `analytics-report/SKILL.md:73,123` |
+| D. 英文形容詞 "short"（楽曲歌詞例ほか） | 2 | `suno/SKILL.md:122`, `suno/references/lyrics-examples.md:17` |
+| E. 英文単語 "community"（音楽 community demographic） | 1 | `audience-persona/SKILL.md:39` |
+| F. 削除済みスキル `/community` を参照 | 0 | — |
+
+### 検出（P1: 1 件）
+
+#### C-3-① `video-description/config.default.yaml:6` — コメント内に廃止スキル名
+
+```yaml
+# 注意: tags.base / title.template / descriptions.opening / perfect_for / hashtags は
+# 複数スキル（metadata_generator / short / upload 等）から参照される横断属性のため、
+# 引き続き config/channel/*.json で管理する。
+```
+
+- C-1-① と同じ箇所。C-3 の観点では「v4.0.0 で撤去された `short` スキル」が「現役の横断参照スキル」のように記述されている。
+- 修正案: `metadata_generator / upload 等`（推測）または現役で `tags.base` を読むスキルを列挙し直す。
+
+### 偽陽性として除外したもの
+
+- `channel.short`（B 分類 11 件）: `config/channel/meta.json` の正当な field（リポジトリ slug の短縮名）。撤去された `workflow.short` とは無関係。
+- `Shorts`（C 分類 3 件）: YouTube プラットフォーム上の「Shorts 動画」フォーマット。`/short` skill とは別物。
+- 英文 "short" / "community"（D, E 分類）: 自然言語の単語使用。
+
+---
+
+## 5. C-4: 形式揺れ（frontmatter / セクション / 命名）
+
+### 5.1 Frontmatter キー分布
+
+35 件すべての SKILL.md を `awk '/^---$/{n++; if(n==2) exit} n>=1'` で抽出し、キーを集計:
+
+| キー | 出現数 / 35 | 備考 |
+|---|---|---|
+| `name` | 35 (100%) | 全件揃っている |
+| `description` | 35 (100%) | 全件揃っている |
+| `model` | 0 | 一切なし |
+| `tools` / `allowed-tools` | 0 | 一切なし |
+| `argument-hint` | 0 | 一切なし |
+| その他 | 0 | — |
+
+→ **frontmatter は全 35 件で完全に揃っており、揺れなし。**
+
+### 5.2 セクション見出し分布（主要見出しのみ集計）
+
+各 SKILL.md の先頭から `## ` 始まり行を最大 8 個抽出（`bash awk '/^## /{print; if(++c>=8) exit}'`）し、見出し名の出現数を集計:
+
+| 見出し | 出現数 / 35 | 揺れ |
+|---|---|---|
+| `## Overview` | 35 | なし（英語統一） |
+| `## 前提` | 24 | あり: 無いスキル（streaming は `## 前提` あり / live-clean, thumbnail-compare, masterup, channel-direction, channel-import, channel-new, channel-research, channel-setup, discover-competitors, metadata-audit, suno が **無**または別形式） |
+| `## Quick Reference` | 14 | 任意性あり |
+| `## Instructions` | 15 | あり |
+| `## 実行フロー` | 7 | あり: `Instructions`（英）と二系統存在（`alignment-check`, `audience-persona`, `benchmark`, `comments-reply`, `postmortem`, `thumbnail-compare`, `video-analyze`, `viewer-voice`, `viewing-scene`） |
+| `## When to Use` | 9 | あり: 日本語版「いつ使うか（選択タイミング）」を suno が使用 |
+| `## Next Step` | 13 | あり |
+| `## Cross References` | 11 | あり: `## 関連ファイル`（日本語）と二系統存在 |
+| `## 関連ファイル` | 8 | あり |
+| `## TTP 原則（ベンチマーク参照）` | 6 | チャンネル系のみ |
+| `## Scripts` | 1 | videoup 独自 |
+| `## 設定` | 3 | あり: `benchmark`, `masterup`, `video-analyze` |
+| `## Channel Adaptation` | 4 | あり |
+| `## §1 初回構築` 〜 `## §5 片付け` | 1 | streaming 独自（番号付き節） |
+
+#### 主な揺れ
+
+1. **「実行フロー」と「Instructions」の混在** — 工程記述の見出しが日英で揺れている。
+2. **「Cross References」と「関連ファイル」と「Next Step」の混在** — 外部スキル参照の出力先見出しが 3 系統。
+3. **「When to Use」と「いつ使うか」の混在** — suno のみ日本語、他は英語。
+4. **`streaming` のみ `§1〜§5` 番号付き節**: 他にこの形式は無い。
+
+### 5.3 スキル名（ディレクトリ名）命名規則
+
+全 35 件:
+
+```
+alignment-check, analytics-analyze, analytics-collect, analytics-report,
+audience-persona, benchmark, channel-direction, channel-import, channel-new,
+channel-research, channel-setup, channel-status, collection-ideate,
+comments-reply, discover-competitors, live-clean, loop-video, lyria,
+masterup, metadata-audit, playlist, postmortem, streaming, suno,
+thumbnail, thumbnail-compare, video-analyze, video-description,
+video-upload, videoup, viewer-voice, viewing-scene, wf-new, wf-next, wf-status
+```
+
+- 全て **kebab-case**（小文字 + ハイフン）。アンダースコア / キャメルケース / 大文字混在は **0 件**。
+- 単語 1 つの場合はハイフン無し（`benchmark`, `lyria`, `masterup`, `playlist`, `postmortem`, `streaming`, `suno`, `thumbnail`, `videoup`）。
+- 名前的に紛らわしいペア:
+  - `videoup` vs `video-upload` (異なる責務 — videoup = mp3→mp4 ローカル動画ファイル生成、video-upload = YouTube への push)
+  - `thumbnail` vs `thumbnail-compare`
+  - `video-analyze` vs `analytics-analyze`
+  - これらは責務分離されているが、命名上紛らわしい可能性あり（**推測**）。
+
+---
+
+## 6. 主要な発見のサマリー（top 5 影響度）
+
+| # | 観点 | 検出 | 影響度 | 出典 |
+|---|---|---|---|---|
+| 1 | C-2 | **lyria → videoup の back-reference 完全欠落** | 中（lyria チャンネルでの workflow が videoup 側から読めない） | `videoup/SKILL.md` 全体（lyria の言及無し） |
+| 2 | C-1 / C-3 | **`video-description/config.default.yaml:6` で廃止スキル `short` を「現役の参照元」と記述** | 中（user は実在しない skill を探しに行ってしまう） | `video-description/config.default.yaml:6` |
+| 3 | C-2 | **masterup → videoup, videoup → video-description が一方向のみ** | 低〜中（音楽 → 動画 → 説明 の制作チェーン主動線で双方向欠落） | #2, #4 |
+| 4 | C-4 | **「Cross References」「関連ファイル」「Next Step」の見出し 3 系統混在** | 低（読みやすさのみ。実害無し） | `## Cross References` 11 件 / `## 関連ファイル` 8 件 / `## Next Step` 13 件 |
+| 5 | C-4 | **「Instructions」「実行フロー」「いつ使うか / When to Use」の英日混在** | 低（読みやすさのみ） | `audience-persona`, `benchmark`, `comments-reply`, `postmortem`, `thumbnail-compare`, `video-analyze`, `viewer-voice`, `viewing-scene` が `実行フロー`; その他は `Instructions` |
+
+---
+
+## 7. カバレッジ
+
+### 7.1 走査した skill（35/35 件）
+
+```
+alignment-check, analytics-analyze, analytics-collect, analytics-report,
+audience-persona, benchmark, channel-direction, channel-import, channel-new,
+channel-research, channel-setup, channel-status, collection-ideate,
+comments-reply, discover-competitors, live-clean, loop-video, lyria,
+masterup, metadata-audit, playlist, postmortem, streaming, suno,
+thumbnail, thumbnail-compare, video-analyze, video-description,
+video-upload, videoup, viewer-voice, viewing-scene, wf-new, wf-next, wf-status
+```
+
+### 7.2 適用した Grep パターン一覧
+
+| 用途 | パターン |
+|---|---|
+| C-1: 明示バトン | `次工程[：:]\s*/[\w-]+`, `前工程[：:]\s*/[\w-]+`, `次工程`, `前工程` |
+| C-2: 全 skill 言及（クロスリファレンス抽出） | `/(channel-new\|channel-import\|...全 35 skill 名...)` |
+| C-3: deprecated 用語 | `\b(short\|shorts\|community)\b` (`-i`) |
+| C-4: frontmatter キー | `^model:`, `^tools:`, `^allowed-tools:`, `^argument-hint:`, `"name":\s*"` |
+| C-4: 主要見出し抽出 | `awk '/^## /{print; if(++c>=8) exit}'` |
+| 実装存在確認 | `Glob "**/analytics_system.py"`, `pyproject.toml` の `yt-*` entry point 照合 |
+
+---
+
+## 8. 注意点・リスク（偽陽性の可能性）
+
+1. **`short` の意味曖昧性**: 19 件のうち 18 件は B/C/D 分類で「廃止スキル参照」ではないと判定したが、文脈読解に依存する判定であり 1〜2 件が誤分類されている可能性がある（**推測**）。確実なのは C-3-① のみ。
+2. **`## Next Step` を「片方向バトン」と数えるか**: 「Next Step」セクションは作者の意図として「**双方向は強制しない、次の案内のみ**」かもしれない。本レポートは「双方向」を理想として一方向を不整合扱いしているが、これは「**べき論**」であり、設計判断としては片方向 OK の見解もありうる（**推測**）。
+3. **`postmortem → 4 skill` の片方向**: postmortem は上位レイヤのメタスキルで、4 検証スキルが postmortem を知らないのは妥当。C-2 表では一方向としたが、修正対象から外す方が合理的（**推測**）。
+4. **`videoup` vs `video-upload` の命名紛らわしさ**: 形式揺れではなく責務上意図的な命名と思われるが、新規ユーザーには混乱の可能性（**推測**）。
+5. **`comments.json` の責務別分割 7 ファイル外**: CLAUDE.md の責務別分割リストは `meta/content/youtube/analytics/playlists/workflow/audio` の 7 ファイルだが、`examples/channel_config.example/` には `comments.json` も含まれる（comments-reply 用）。これは Part C スコープ外だが、CLAUDE.md と examples の不一致として別 Part で扱うべき可能性あり。
+
+---
+
+## 9. 調査できなかった項目
+
+| 項目 | 理由 |
+|---|---|
+| 「指す先が違う」型の C-2 不一致 | 検出されず（指された名前の skill が存在しないケース 0 件、リネーム残骸も 0 件） |
+| `comment_reply_history.json` 実体ファイル | 各チャンネル実装で生成される動的ファイルのため確認不可（description のみで判断） |
+| Vertex AI Lyria 3 API レスポンスが本当に MP3 を返すか | 外部 API 仕様の確認は本調査範囲外（description の主張を額面で受け入れた） |
+
+---
+
+## 10. 推奨 / 結論
+
+### P1（双方向追記 / 廃止参照削除）
+
+1. **`video-description/config.default.yaml:6`** のコメントから `short` を削除。同時に「現役で `tags.base` 等を読むスキル」を再列挙する。
+2. **`videoup/SKILL.md`** に「前工程」ブロックを追加して `/masterup`（Suno 系）と `/lyria`（Lyria 系）の両方を明示。これで C-2 の #2, #3 の片方向バトンが解消する。
+3. **`video-description/SKILL.md`** に「前工程: `/videoup`」を Cross References として追記。C-2 #4 解消。
+
+### P2（運用上は問題ないが改善余地あり）
+
+4. **`metadata-audit/SKILL.md`** の Cross References に「前工程: `/video-upload`」を追記（C-2 #6）。
+5. **`wf-new/SKILL.md`** の Cross References に「既存チャンネル: `/channel-import`」を追記（C-2 #10）。
+6. **`analytics-analyze/SKILL.md`** の前提セクションに「`/wf-next` から T+7 日後に呼ばれる」を追記（C-2 #12）。
+7. **`suno/SKILL.md`** に「前工程: `/thumbnail`」を Cross References として追記（C-2 #19）。
+
+### P3（形式統一・大規模リファクタ）
+
+8. **見出し統一**: 「Cross References / 関連ファイル」「Instructions / 実行フロー」「When to Use / いつ使うか」のいずれかに揃える方針を CLAUDE.md または `docs/skills-style-guide.md` で宣言。35 件全 SKILL.md を一括書き換え。
+9. **`postmortem → 4 検証 skill`**: 設計上の意図（メタスキル）が読めるよう、postmortem の Overview に「下位検証スキル群を呼び出すメタスキル」と明記し、各検証スキル側には追記しない方針を明確化。
+
+### まとめ
+
+- 全 35 スキル中、frontmatter / 命名規則は **完全に揃っている**。
+- description ↔ 実装の重大乖離は **1 件のみ**（C-1-①）。
+- バトン双方向は **8 リンクが完璧、9 リンクが片方向**。うち P1 対応が望ましいのは 3〜4 リンク。
+- v4.0.0 deprecated `short` / `community` の残存は **1 箇所のみ**（コメント内）。コードレベルでの残骸は無い。
+- 形式揺れは見出し命名のみで、構造的な品質問題には至っていない。

--- a/docs/audits/2026-05-18-skills-generalization-consistency/raw/06-dig-part-C-v2.md
+++ b/docs/audits/2026-05-18-skills-generalization-consistency/raw/06-dig-part-C-v2.md
@@ -1,0 +1,271 @@
+# Data Consistency Audit — `.claude/skills/**/SKILL.md`
+
+担当: dig.dig-part-c（観点 2.1〜2.4 = C-1 〜 C-4）
+対象: `/Users/mba/02-yt/takt-worktrees/20260518T0804-353-issue-353-chore-skills-sukiru/.claude/skills/**/SKILL.md` 全 35 件
+読み取り日: 2026-05-18
+
+---
+
+## 1. 概要 — 検出件数サマリ
+
+| 観点 | 内容 | 検出件数 | 優先度 |
+|---|---|---|---|
+| **C-1** | description ↔ 実装乖離 | **3 件**（major 1・minor 2） | P1 |
+| **C-2** | バトン双方向整合 — 不整合ペア | **片方向参照のみのペア 14 組**（意図あり 10・要修正 4） | P1 |
+| **C-3** | deprecated `short` / `community` 参照（workflow.json 由来） | **0 件**（混同候補 13 件 → 全て無関係と判定） | P1 |
+| **C-4** | description 形式の揺れ | スタイル分類 5 + 開始句完全統一（35/35）+ 長さ約 4× の差 | P2 |
+
+最大の発見:
+
+- **`/video-analyze` SKILL.md の「呼び出し側スキル」セクションが /lyria・/channel-direction で「使われている」と書いているが、両 SKILL.md には対応する処理が無い**（C-1 #1）。  
+- **`/lyria` の出力 (`01-master/master.wav`) と `/masterup` の出力 (`01-master/master.mp3`) が `/videoup`/`generate_videos.sh` の検出パターン (`master-mix.{wav,…}` + `*-Master.mp3` フォールバック) のいずれにもマッチしない**ため、`/wf-next` を経由しない素直なバトン（lyria → videoup, masterup → videoup）はドキュメント通りには動かない可能性（C-1 #2 / C-2 補足）。
+- description は全 35 件が `Use when …` で揃っていて開始句は完全統一だが、末尾の指示語（「必ず使用すること」/「使用すること」/「〜と書かれた cross-ref note」など）が **5 系統**に揺れている（C-4）。
+
+---
+
+## 2. C-1 — description ↔ 実装乖離
+
+評価軸: SKILL.md の description（YAML frontmatter）が宣言した機能・責任範囲と、本文・スクリプト実装の整合。
+
+| # | skill | description 抜粋 | 実装の該当 / 不在 | 乖離の種類 |
+|---|---|---|---|---|
+| C-1.1 | **`/video-analyze`** ↔ **`/lyria`** / **`/channel-direction`** | `/video-analyze` Overview 末尾: 「`/benchmark`・`/analytics-analyze`・`/alignment-check`・`/thumbnail-compare`・`/viewer-voice` の精度を底上げする」+ 本文「呼び出し側スキル」: `/channel-direction` Step 1 と Step 2 議論ポイント 6・Step 3 決定事項「BGM 構造方針」で `bgm_arc` 平均を使う／`/lyria` Step 2「ベンチマーク BGM 構造の参照」で `composition.json` のフェーズ境界の初期値として活用する | `/channel-direction` Step 1 は `docs/channel-research.md` のみを読み込み `bgm_arc` 言及なし。Step 2 議論ポイント 6 は「差別化ポイント」、Step 3 決定事項テーブルに「BGM 構造方針」行なし。`/lyria` 全文に `bgm_arc` / `composition.json` / `phase.at_min` の記述ゼロ（grep 確認済み） | **矛盾／過剰記述** — `/video-analyze` 側が他スキルの仕様を一方的に宣言しているが、相手 SKILL.md にその実装が無い |
+| C-1.2 | **`/video-upload`** | description: 「Complete Collection のアップロードと live 移行を実行」 | 本文 Channel Adaptation セクションは `collection` 型 + `single_release` 型（JP+EN 同日 2 本アップ、`yt-upload-auto` 使用）を扱う。description は `single_release` を全く触れていない | **過少記述（minor）** — description が `collection` 型のみ前提に読める。`single_release` チャンネルが description で自スキル発火を期待しにくい |
+| C-1.3 | **`/analytics-report`** | description: 「Analytics分析レポートの表示・閲覧が必要なとき」「既存レポートの参照・比較が必要な場面で必ず使用すること」 | 本文 Quick Reference は `latest` / `list` / `html` の 3 モード。`html` は「データ集約 + Chart.js ビジュアルレポート生成」で**新規生成**の責務がある（line 44-110） | **過少記述（minor）** — description は「表示・閲覧」しか書いていないが、`html` モードは「全 analytics スナップショット + benchmark を集約して HTML を新規生成」する。トリガーワードに「ビジュアル」「ダッシュボード」「HTML レポート生成」が無い |
+
+C-1 で**特に問題ない**例（参考、35 件中の代表）: `/streaming`（description に並べた 12 個のキーワードが全て §1-5 にカバーされる）、`/postmortem`（description 末尾の「`/thumbnail-compare` `/alignment-check` `/viewer-voice` `/video-analyze` 等の既存スキルへバトンする」が Phase 4 表に厳密に対応）、`/masterup`（前工程 / 次工程の明示がそのまま Overview に展開）。
+
+---
+
+## 3. C-2 — バトンの双方向整合性
+
+抽出方針: SKILL.md 本文の **「前工程」「次工程」「前フェーズ」「次フェーズ」「Next Step → /X」「Cross References」**、および description 内の「/X の後」「/X の前」を手掛かりに 1 次バトンペアを抽出。`→` 記号での `/X` 参照も対象。
+
+### 3.1 対照表（A → B 参照と B → A 参照）
+
+| # | A | B | A → B 参照根拠 | B → A 参照根拠 | 整合 |
+|---|---|---|---|---|---|
+| 1 | `/channel-new` | `/channel-research` | Step 7 「次は /channel-research」+ Cross Refs | Cross Refs「/channel-new → 前フェーズ」+ Overview | ✓ 双方向 |
+| 2 | `/channel-research` | `/channel-direction` | Step 7 + Cross Refs | description「/channel-research の分析結果をもとに」+ Cross Refs + Step 1 が `docs/channel-research.md` を読む | ✓ 双方向 |
+| 3 | `/channel-direction` | `/channel-setup` | Step 5「次は /channel-setup」+ Cross Refs | description「/channel-direction で方向性が確定し」+ Step 1 が `channel-direction.md` を読む + Cross Refs「/channel-direction → 前フェーズ」 | ✓ 双方向 |
+| 4 | `/channel-setup` | `/wf-new` | Step 8.5「初回コレクション制作: /wf-new」+ Cross Refs | 前提「config/channel/ が存在すること」止まり（/channel-setup 名指しなし） | △ 片方向（意図あり: /wf-new は複数経路エントリ） |
+| 5 | `/channel-import` | `/wf-new` | Step 8.5「コレクション制作: /wf-new」+ Cross Refs | 同上（/channel-import 名指しなし） | △ 片方向（同上） |
+| 6 | `/wf-new` | `/wf-next` | Cross Refs「後続ステップ管理: /wf-next」+ 完了案内 | Cross Refs「新規開始: /wf-new」 | ✓ 双方向 |
+| 7 | `/wf-new` | `/collection-ideate` | Phase 1 で Skill ツールで実行 + Cross Refs「企画生成: /collection-ideate」 | description / 本文に /wf-new 言及なし（Next Step は /thumbnail と /suno を直接案内） | △ 片方向（意図あり: /collection-ideate は単独でも使う） |
+| 8 | `/collection-ideate` | `/thumbnail` | Next Step「→ /thumbnail <theme>」 | When to Use と Quick Reference に /collection-ideate 直前提なし。`/wf-new` 経由でのみ間接連携 | △ 片方向 |
+| 9 | `/thumbnail` | `/suno` | Next Step「→ /suno <theme>」 | description「Lyria チャンネルでは /lyria を使う」+ いつ使うか節 `/channel-direction → /channel-setup` のみ。`/thumbnail` 名指しなし | △ 片方向（**Lyria 経路で欠落**: `/thumbnail` Next Step は `/suno` 一本で `/lyria` を案内しない） |
+| 10 | `/suno` | `/masterup` | Next Step「→ /masterup <playlist-url>」 | description「前工程: /suno」+ Overview「前工程: /suno」 | ✓ 双方向（最も明示的） |
+| 11 | `/lyria` | `/videoup` | Next Step「→ /videoup」 | When to Use・Step 2 で `/masterup` を案内、`/lyria` の言及なし。さらに `/videoup`/`generate_videos.sh` の master 検出は `master-mix.*` + `*-Master.mp3` で **`/lyria` の `01-master/master.wav` は拾えない** | × 片方向 + 命名不整合（要修正） |
+| 12 | `/masterup` | `/videoup` | Next Step「→ /videoup」 | Step 2「なければ /masterup でのマスター音源生成を案内」（前向き案内のみ）。さらに `/videoup` の検出パターンは `master-mix.*` で **/masterup の `master.mp3` も拾えない** | △ 片方向 + 命名不整合（要修正） |
+| 13 | `/videoup` | `/video-description` | Next Step「→ /video-description <collection-path>」 | When to Use「コレクションの動画が完成し」のみ、`/videoup` 名指しなし | △ 片方向（許容範囲） |
+| 14 | `/video-description` | `/video-upload` | Next Step「→ /video-upload <collection-path>」 | Cross References「/video-description — アップロード前に descriptions.md を生成」+ 本文 Step 3 で /video-description を自動実行 | ✓ 双方向 |
+| 15 | `/video-upload` | `/metadata-audit` | Cross References「/metadata-audit — アップロード後の整合性監査」 | Overview「アップロード後に YouTube 側にメタデータが正しく反映されたか確認したいとき」（/video-upload 名指しなし、機能で示唆） | △ 片方向（許容範囲） |
+| 16 | `/video-upload` | `/playlist` | Cross References「/playlist — プレイリスト状態確認」 | Cross References「/video-upload — アップロード時に内部で `assign_video()` が呼ばれる」 | ✓ 双方向 |
+| 17 | `/wf-next` | `/analytics-analyze` | complete phase「→ /analytics-analyze で初週パフォーマンス」 | description「/analytics-collect でデータ収集後に実行」のみ、`/wf-next` 名指しなし | △ 片方向（意図あり: postmortem 経路） |
+| 18 | `/analytics-collect` | `/analytics-analyze` | Next Step「→ /analytics-analyze」 | description / When to Use とも /analytics-collect を前提と明示 | ✓ 双方向 |
+| 19 | `/analytics-analyze` | `/collection-ideate` | Next Step「→ /collection-ideate」 | 前提スキル状態確認 + Phase 1-2 が `reports/analysis_*.md` を読み込む | ✓ 双方向 |
+| 20 | `/analytics-report` | `/analytics-analyze` | Next Step「→ /analytics-analyze で詳細な戦略分析」 | description / 本文に /analytics-report 言及なし | △ 片方向（許容範囲: /analytics-report は読み取り側ツール） |
+| 21 | `/viewer-voice` | `/audience-persona` | description「/audience-persona や /viewing-scene の前提データ」 | 前提「`docs/plans/viewer-voice-analysis.md` が存在すること。未実施の場合は先に /viewer-voice」 | ✓ 双方向 |
+| 22 | `/audience-persona` | `/viewing-scene` | description「/viewing-scene の入力になる」 | 前提「`persona-definition.md` が存在すること（未実施なら /audience-persona）」 | ✓ 双方向 |
+| 23 | `/channel-new` | `/discover-competitors` | Step 5 が MANDATORY で `yt-discover-competitors` を呼ぶ + 「詳細は /discover-competitors skill 参照」 | Cross References「/channel-new Step 5: 新チャンネル開設フロー内での前段呼び出し」 | ✓ 双方向 |
+| 24 | `/channel-new` | `/benchmark` | Step 6「ベンチマークデータは /benchmark スキルに委譲」 | Overview「/collection-ideate の Phase 1-2 から自動呼び出しされる」（/channel-new 名指しなし） | △ 片方向（要追記検討） |
+| 25 | `/collection-ideate` | `/benchmark` | Phase 1-3「Skill ツールで /benchmark を実行」 | Overview「/collection-ideate の Phase 1-2 から自動呼び出しされる」 | ✓ 双方向 |
+| 26 | `/postmortem` | `/thumbnail-compare` ほか 6 | Phase 4 検証ステップ表に `/thumbnail-compare` `/alignment-check` `/viewer-voice` `/audience-persona` `/discover-competitors` `/video-analyze` `/channel-direction` `/comments-reply` を列挙 | いずれも /postmortem 言及なし | △ 片方向（意図あり: fan-out 案内、許容範囲） |
+| 27 | `/lyria` | `/suno` | description「Suno で人手生成するチャンネルでは /suno を使う」+ `_disabled: true` 時の案内 | description「Lyria チャンネルでは /lyria を使う」 | ✓ 双方向（排他的選択を相互明示） |
+| 28 | `/masterup` | `/lyria` | description「Lyria チャンネルでは /lyria が自動で音源を出力するため本スキルは不要」 | description「/masterup 不要」 | ✓ 双方向 |
+| 29 | `/wf-status` | `/wf-next` | Cross Refs | Cross Refs | ✓ 双方向 |
+| 30 | `/wf-status` | `/channel-status` | description「チャンネル登録者数など YouTube 側の統計は /channel-status」 | description「ローカルのコレクション制作進捗は /wf-status」 | ✓ 双方向（理想的な相互排他案内） |
+| 31 | `/channel-new` | `/channel-import` | （言及なし） | description「新規チャンネル開設は /channel-new を使うこと」 | △ 片方向（/channel-new 側にも代替案内があると親切） |
+| 32 | `/loop-video` | `/videoup` | Next Step「→ /videoup <collection-path>」 | Step 2「`10-assets/loop.mp4` が既にあればスキップ。なければ /loop-video でのループ動画生成を案内」 | ✓ 双方向 |
+| 33 | `/video-analyze` | `/suno` | 呼び出し側スキル「/suno — Instructions 冒頭で `bgm_arc` 平均を読み込み…」 | Instructions 中盤に「ベンチマーク BGM 構造の参照」セクションがあり `data/video_analysis/<slug>/*.json` を実際に読み込む | ✓ 双方向（**整合する例**） |
+| 34 | `/video-analyze` | `/lyria` | 呼び出し側スキル「/lyria — Step 2…composition.json のフェーズ境界…」 | grep ヒットなし（`bgm_arc` / `composition.json` / `video-analyze` いずれも /lyria SKILL.md 内に存在しない） | × **不整合**（C-1 #1 重複） |
+| 35 | `/video-analyze` | `/channel-direction` | 呼び出し側スキル「/channel-direction — Step 1 の分析サマリーで…BGM 構造方針の根拠データとして使う」 | grep ヒットなし | × **不整合**（C-1 #1 重複） |
+| 36 | `/video-analyze` | `/benchmark` / `/analytics-analyze` / `/alignment-check` / `/thumbnail-compare` / `/viewer-voice` | Overview「これら 5 つの精度を底上げする」 | 5 件すべて 関連ファイルに `data/video_analysis/<slug>/<video_id>.json — /video-analyze の …出力` を明記 | ✓ 双方向（**模範的**） |
+| 37 | `/alignment-check` | `/suno` / `/lyria` | Next Step 不整合カテゴリ表「音楽ミスマッチ → /suno または /lyria」 | `/suno` Step 3 と `/lyria` Step 5「`/alignment-check` がコレクション横断で音楽 mood × サムネ × タイトルの整合を機械的に判定できるよう、`planning.music` を populate」 | ✓ 双方向（**模範的**） |
+
+### 3.2 「片方向参照のみ」ペア一覧（要修正候補）
+
+整合性が**意図的でなく** description / 本文の改善余地がある片方向参照ペアは次の **4 組**:
+
+| # | 不整合ペア | 推奨修正方針 |
+|---|---|---|
+| A | **`/video-analyze` ↔ `/lyria`**（#34） | `/video-analyze` 側の「呼び出し側スキル」セクションから `/lyria` 項を削除する、もしくは `/lyria` 本文に `bgm_arc` 利用ステップを追加する。現状の `/lyria` は単一プロンプト + セグメント数自動算出のみで「フェーズ境界」概念が無い |
+| B | **`/video-analyze` ↔ `/channel-direction`**（#35） | 同上。`/channel-direction` Step 2 議論ポイント / Step 3 決定事項テーブルに「競合の BGM 構造」「BGM 構造方針」を追加するか、`/video-analyze` 側から該当記述を削除 |
+| C | **`/thumbnail` Next Step が `/suno` 単独**（#9） | `/thumbnail` Next Step に「Lyria チャンネルでは `/lyria <theme>`」分岐を追加。現状の `/wf-new` Phase 2c には分岐があるが、`/thumbnail` を**単独で**走らせるユーザーが `/lyria` への接続を見落とす |
+| D | **`/lyria` / `/masterup` → `/videoup` の master ファイル命名**（#11, #12） | `/videoup`/`generate_videos.sh` が探すパターンは `master-mix.{wav,m4a,aac,mp3,flac}` + `*-Master.mp3` フォールバック。`/lyria` (`master.wav`) と `/masterup` (`master.mp3`) 双方の出力名がマッチしないため、(a) generate_videos.sh の検出パターン拡張、(b) 各スキルの出力名統一、(c) 各 SKILL.md の Next Step に「最終マスターは `01-master/master-mix.{ext}` にリネームしてから /videoup」と明示、のいずれかで揃える |
+
+**意図的に片方向**と判断したペア（10 組）: #4, #5, #7, #8, #13, #15, #17, #20, #24, #26, #31 — オーケストレータからの fan-out 案内（/wf-new / /postmortem / /channel-new 等）と「読み取り側ツール」（/wf-status / /analytics-report 等）の組合せ。SKILL.md の双方を膨らませる効用が小さい。
+
+---
+
+## 4. C-3 — deprecated `short` / `community` 参照
+
+仮定: CLAUDE.md の `workflow.json (v4.0.0 で short / community 撤去、後方互換で素通し)` 注記。`short` / `community` を workflow.json の旧 channel-type / content-type フィールドとして想定し、参照残骸を検索。
+
+`Grep` 実行結果（`(short|community)` / case-insensitive / 35 SKILL.md 全件）:
+
+| file:line | 該当文字列 | 種別 | workflow.json 由来か |
+|---|---|---|---|
+| `audience-persona/SKILL.md:39` | `background music community` | プロンプト用テキスト | × （Reddit 等のオンラインコミュニティを指す） |
+| `channel-import/SKILL.md:21` | `gh repo create <short>` | `<short>` プレースホルダ（channel.short の意） | × （meta.json の `channel.short` 由来） |
+| `channel-import/SKILL.md:22` | `cd <short>` | 同上 | × |
+| `channel-new/SKILL.md:47` | `gh repo create <short>` | 同上 | × |
+| `channel-new/SKILL.md:48` | `cd <short>` | 同上 | × |
+| `channel-new/SKILL.md:94` | `--short "<仮 SHORT>"` | `yt-channel-init` の `--short` 引数 | × |
+| `channel-direction/SKILL.md:106` | `短縮名: {short}` | テンプレ内変数 | × |
+| `wf-new/SKILL.md:59` | `YYYYMMDD-<short>-<theme>-collection/` | ディレクトリ命名 | × |
+| `wf-new/SKILL.md:73` | 同上 | 同上 | × |
+| `wf-new/SKILL.md:139` | 同上 | 同上 | × |
+| `analytics-report/SKILL.md:73` | `Complete Collection のみ表示（Shorts を除外）` | YouTube Shorts 動画フォーマット | × |
+| `analytics-report/SKILL.md:109` | `channel.short` を小文字化 | meta.json の channel.short | × |
+| `analytics-report/SKILL.md:123` | `Shorts は…除外（タイトルに #Shorts を含む）` | YouTube Shorts | × |
+| `suno/SKILL.md:122` | `(short instrumental cue, optional 1-2 line spoken intro)` | 歌詞テンプレ内テキスト | × |
+| `video-analyze/SKILL.md:66` | `Shorts は Gemini の 1fps サンプリング制約により精度が落ちるため非推奨` | YouTube Shorts | × |
+
+**結論: workflow.json の deprecated 由来の `short` / `community` 参照は 0 件**。
+
+ヒットした 15 件はすべて、(a) `meta.json::channel.short`（チャンネル短縮名スラグ）の正規参照、(b) YouTube Shorts 動画フォーマット、(c) プロンプト/歌詞内の英単語 "short" の散文、のいずれかで、workflow.json の旧フィールドとは無関係。
+
+---
+
+## 5. C-4 — description 形式の揺れ
+
+### 5.1 開始句
+
+| 開始句パターン | 件数 |
+|---|---|
+| `Use when <Japanese clause>` | **35 / 35（100%）** |
+
+`Use when …` の英語＋日本語ハイブリッド開始は **完全統一**。
+
+### 5.2 末尾の指示語（行動指示）— スタイル分類ヒストグラム
+
+| スタイル | 件数 | 該当 skill |
+|---|---|---|
+| (A) 「〜場面で必ず使用すること」 | **14** | analytics-analyze / analytics-collect / analytics-report / alignment-check / audience-persona / collection-ideate / live-clean / loop-video / thumbnail / thumbnail-compare / video-description / videoup / viewer-voice / viewing-scene |
+| (B) 「〜場面で使用すること」「使用すること」 | **5** | benchmark / comments-reply / playlist / streaming / video-analyze |
+| (C) cross-ref note で締める（`/X を使う` / `/X が責務` / `/X` 等の参照で終わる） | **9** | channel-status / channel-import / lyria / masterup / metadata-audit / suno / wf-new / wf-next / wf-status |
+| (D) 「〜前に実行する」「〜後に実行する」（ワークフロー序列） | **3** | channel-direction / channel-research / channel-setup |
+| (E) アクション動詞で締める（バトンする / エントリポイント / 本スキルは不要 / 実行 / 並行検証ツールとしても使える） | **4** | channel-new / discover-competitors / postmortem / video-upload |
+
+**主な揺れポイント**:
+
+- 「必ず使用すること」を付ける skill と付けない skill が混在。必須 / 任意のニュアンスを意図的に書き分けているかが不明瞭。
+- 末尾に**他 skill への参照**を入れる流派（C）が 9 件あるが、`/wf-new` `/wf-next` のようなオーケストレーション系と `/lyria` `/suno` のような排他的選択は意図が異なる。
+- ワークフロー序列を末尾に書く流派（D）は新チャンネル開設の 3 つの skill だけ。production pipeline 側（/wf-new → /wf-next 等）には序列が書かれていない。
+
+### 5.3 長さ分布
+
+| 文字数レンジ | 件数 | 代表例 |
+|---|---|---|
+| 〜100 | 1 | `video-upload`（約 75 文字） |
+| 100-150 | 4 | `channel-status` / `masterup` / `wf-status` / `lyria`（実測は約 140-180） |
+| 150-200 | 16 | 大多数 |
+| 200-250 | 11 | `channel-new` / `postmortem` / `audience-persona` ほか |
+| 250+ | 3 | `channel-setup`（約 280 — dual mode 説明） / `streaming` / `postmortem` |
+
+`video-upload` の description が**極端に短く**（C-1.2 で指摘した `single_release` 漏れと相関）、`channel-setup` の description が**極端に長い**（dual mode を強引に詰め込み）。3.7× の幅。
+
+### 5.4 トリガーワードの粒度
+
+| 流派 | 例 | 件数（概算） |
+|---|---|---|
+| 「」付き日本語ワード列挙 | alignment-check「整合性チェック」「一致してるか確認」… | 24 |
+| 鉤括弧なし日本語＋英語混在 | postmortem「why flopped」「postmortem」「振り返り」 | 5 |
+| 鉤括弧なし、機能説明のみ | video-upload / channel-direction | 6 |
+
+### 5.5 代表例 5 件（スタイル差を最も顕著に示す）
+
+1. **(A) 典型形 — `loop-video`**:  
+   `Use when コレクションのサムネイル画像からループ動画背景を生成したいとき。Veo 3.1 API で main.png/jpg を元に微細アニメーション付きの 8秒シームレスループ動画を生成。ループ動画、背景動画、loop.mp4、アニメーション背景、動画背景など、静止画を動画化する場面で必ず使用すること`
+
+2. **(C) cross-ref で締める — `channel-status`**:  
+   `Use when チャンネル全体の YouTube 統計（登録者数・総再生回数・動画別パフォーマンス）を取得したいとき。…YouTube API から数字を取得するときに使用する。ローカルのコレクション制作進捗は /wf-status`
+
+3. **(E) 極端に短い — `video-upload`**:  
+   `Use when コレクションの動画が完成し、YouTubeへのアップロード自動化が必要なとき。Complete Collection のアップロードと live 移行を実行`
+
+4. **(D) ワークフロー序列付き — `channel-research`**:  
+   `Use when /channel-new で収集したベンチマークデータを徹底分析したいとき。…/channel-new の後、/channel-direction の前に実行する`
+
+5. **(B) dual mode 詰め込み — `channel-setup`**:  
+   `Use when /channel-direction で方向性が確定し、チャンネルのテクニカルセットアップを行いたいとき、または運用中チャンネルの YouTube 側設定（branding / status / localizations）をローカル config と同期したいとき。「セットアップ」… および「設定反映」「チャンネル設定更新」「branding push」… など既存チャンネルの設定 push に関わる場面で使用すること。新規セットアップは /channel-direction の後に実行する`
+
+---
+
+## 6. 主要な発見のサマリー（上位 5 件）
+
+1. **`/video-analyze` SKILL.md の「呼び出し側スキル」セクションが /lyria・/channel-direction について事実誤認を含む**（C-1.1 / C-2 #34, #35）。/suno と /video-analyze 間は実装と整合している（line 45）のと対照的に、/lyria と /channel-direction には対応コードが無い。Owner が `/video-analyze` 側か下流 2 スキル側のどちらに合わせるかを決める必要あり。
+
+2. **`/lyria` (`master.wav`) と `/masterup` (`master.mp3`) の出力ファイル名が `/videoup`/`generate_videos.sh` の検出パターン (`master-mix.*` + `*-Master.mp3`) のいずれにもマッチしない**（C-2 #11, #12）。`/wf-next` 経由なら `01-master/` を再走査する 2-B 検出ロジック（line 51 の `.m4a/.wav/.flac/.aac/.mp3` 拡張子マッチ）が救うが、`/lyria` / `/masterup` の Next Step「→ /videoup」を素直に従うと素材が見つからない。実害有り。
+
+3. **`/thumbnail` の Next Step が `/suno` 単独で `/lyria` を案内しない**（C-2 #9）。`/wf-new` Phase 2c には music_engine 分岐があるが、ユーザーが `/thumbnail` を単独実行した場合に `/lyria` ルートが見えない。Lyria 利用チャンネルでの導線断絶。
+
+4. **description のスタイル揺れは大きく分けて 5 系統**（C-4）。開始句は完璧に揃っているのに、末尾の指示語が「必ず使用すること（14）」「使用すること（5）」「cross-ref（9）」「序列（3）」「アクション動詞（4）」と分散。読み手が「必ず」の有無に意味を求める可能性があるため、ガイドラインで統一すべきか「あえて使い分け」と明文化すべきか判断が必要。
+
+5. **`/video-upload` description は `collection` 型しか触れていないが、実装は `single_release` 型（JP+EN 同日 2 本アップ）にも対応している**（C-1.2）。`single_release` チャンネル運営者が description で skill 発火を期待しにくい。
+
+---
+
+## 7. カバレッジ
+
+走査した SKILL.md 全 35 件（`Glob` で完全一覧化、`Bash ls | wc -l` で総数 35 を確認）:
+
+```
+alignment-check         analytics-analyze       analytics-collect
+analytics-report        audience-persona        benchmark
+channel-direction       channel-import          channel-new
+channel-research        channel-setup           channel-status
+collection-ideate       comments-reply          discover-competitors
+live-clean              loop-video              lyria
+masterup                metadata-audit          playlist
+postmortem              streaming               suno
+thumbnail               thumbnail-compare       video-analyze
+video-description       video-upload            videoup
+viewer-voice            viewing-scene           wf-new
+wf-next                 wf-status
+```
+
+C-1: 全 35 件の description ↔ 本文を読み比較 / C-2: `→` `前工程` `次工程` `前フェーズ` `次フェーズ` `Cross References` を grep し 37 のバトンペアを抽出 / C-3: `(short|community)` で大文字小文字無視 grep（15 ヒットを 1 件ずつ判定）/ C-4: 35 件の description を分類。
+
+---
+
+## 8. 注意点・リスク
+
+- **意図的な非対称バトン**: オーケストレータ（/wf-new / /wf-next / /channel-new / /channel-import / /postmortem）は本質的に「呼び出す側」で、呼ばれる skill 側に「私は /wf-new から呼ばれます」と書くと冗長になる。本レポートは 10 ペアを「意図あり」と判定したが、最終レポートで「**意図的非対称**」と「**修正すべき非対称**」の閾値を明示しないと、機械的に「全 14 ペアを修正」と読まれる恐れがある。
+
+- **description の文体差は意図的か揺れか**: 「必ず使用すること」の付与は「ユーザーが言及せずとも積極的に発動して欲しい skill（example: alignment-check）」と「ユーザー指示のみで動く skill（example: video-upload）」の区別の意図かもしれない。本レポートは「揺れ」と分類したが、実は意図的な可能性も残る — issue 化の前に owner ヒアリングを推奨。
+
+- **`/video-analyze` の事実誤認は新規追加された機能予告である可能性**: 「呼び出し側スキル」セクションは `/lyria` / `/channel-direction` を「将来こう使う予定」として書いている可能性がある（実装はまだ）。git 履歴を確認していないため、もしそうなら C-1.1 は「未実装の予告」として別カテゴリで扱うべき。
+
+- **`/videoup` の master 命名不整合は実害判定が要再現**: `/wf-next` の 2-B 検出ロジックが救うことが多い実運用なら、SKILL.md のドキュメント表記だけ揃えれば十分。常時 `/wf-next` 経由を前提にできるなら `/lyria` / `/masterup` の Next Step を「→ /wf-next」に書き換えるだけで解決。
+
+---
+
+## 9. 調査不可項目とその理由
+
+- **CLAUDE.md の `workflow.json (v4.0.0 で short / community 撤去)` 注記以外に deprecated 化されたフィールドがあるかは未確認**。本タスクは workflow.json の `short` / `community` のみを対象としたが、他にも音楽エンジン関連や旧スキーマ（v1 workflow-state.json など）で deprecated 化された参照が残っている可能性は否定できない。これは別途観点が必要。
+
+- **`/video-analyze` の「呼び出し側スキル」記述が「過去に存在した実装が削除された残骸」か「将来予定の予告」かは git 履歴 / issue tracker を見ないと断定できない**。本レポートは「現状の SKILL.md 同士の整合性」のみを評価。
+
+- **description のスタイル揺れが意図的か無計画かは owner 確認が必要**（前述）。本レポートは表面的な分類のみ。
+
+- **本タスクでは references/ 配下のサブドキュメントは原則読まない**（plan.md より）。`references/scene_phrases.md`、`references/lyria-tuning-guide.md`、`references/object-design-examples.md` などにバトンや実装詳細が書かれている可能性があるが、本タスク範囲外。
+
+---
+
+## 10. 推奨 / 結論
+
+最終レポート（`docs/audits/skills-audit-2026-05-18.md`）で取り上げる優先度付け:
+
+| 優先度 | 対応事項 | 根拠観点 | 推奨アクション |
+|---|---|---|---|
+| **P1-高** | `/video-analyze` の「呼び出し側スキル」記述（/lyria / /channel-direction 行）を実装と整合させる | C-1.1 / C-2 #34, #35 | git log 確認の上、削除 or 下流実装追加 |
+| **P1-高** | `/lyria` `/masterup` の出力名と `/videoup`/`generate_videos.sh` の検出パターンを整合させる | C-2 #11, #12 | 実装側の検出パターン拡張 or SKILL.md 上「→ /wf-next」経路への書き換え |
+| **P1-中** | `/thumbnail` Next Step に `/lyria` 分岐を追加 | C-2 #9 | description は変えず Next Step に分岐追加 |
+| **P1-中** | `/video-upload` description に `single_release` 型を追記 | C-1.2 | description 末尾に「single_release 型（JP+EN 同日アップロード）にも対応」追記 |
+| **P2-低** | `/analytics-report` description にトリガーワード「ビジュアル」「HTML レポート生成」を追記 | C-1.3 | description のトリガーキーワード列を拡充 |
+| **P2-低** | description 末尾指示語のガイドライン化（A〜E 5 系統の使い分け基準）| C-4 | meta-doc `.claude/skills/CONTRIBUTING.md`（仮）で明文化 |
+| **P3-参考** | `/channel-new` description に「既存チャンネルなら /channel-import」相互案内を追加 | C-2 #31 | 1 文追加で /wf-status ↔ /channel-status と同じ模範形に |
+
+C-3 は **対応不要**（0 件）。


### PR DESCRIPTION
## 概要

takt `deep-research` workflow (plan → dig × 3 並列 → analyze → supervise) で `.claude/skills/` 配下 35 スキルを横断調査した監査レポートを `docs/audits/` に追加。

## 検出サマリー

- **P1 (high)**: 10 件 — `category_id: "10"` の 3 ファイル重複、旧 namespace `channel_config.tags.themes` 残存、`video-analyze` description の事実誤認、`scripts/gcp-bootstrap.sh` ≡ `channel-setup/references/` の shell 重複、`video-description/config.default.yaml` 内の deprecated `short` コメント残存など
- **P2 (medium)**: 16 件
- **P3 (low)**: 14 件
- **明示否定 (修正不要と判定)**: 7 件 — `postmortem` の意図的 fan-out バトン、`TBD` 初期値（既に解決済み）など

supervise step 判定: **APPROVE** (policy「APPROVE 条件」3 つすべて充足)。

## 既知シードの検証結果

| シード | 結論 |
|---|---|
| `benchmark_collector.py` × 3 など .py 重複 | **配置誤認**。実体は `src/youtube_automation/scripts/` 配下に各 1 件のみ |
| `streaming/SKILL.md --check-threshold` config 非連動 | 検出済。`config/skills/streaming.yaml::bandwidth_threshold_ratio` 新設を提案 |
| `channel-new` / `channel-direction` の `TBD` 初期値 | **既に解決済み**。`channel-new/SKILL.md:107` の CLI 既定値説明 1 箇所のみ |
| `postmortem` の曖昧バトン | 意図的メタスキルとして明示否定 (N-3) |

## ファイル

- `docs/audits/2026-05-18-skills-generalization-consistency.md` — メイン棚卸しレポート (観点 1.1〜1.4 / 2.1〜2.4 全網羅)
- `docs/audits/2026-05-18-skills-generalization-consistency/raw/` — dig / analyze / supervise / plan の生レポート 7 本

## スコープ

本 PR は**レポート追加のみ**。検出された fix は本 PR では適用せず、後続の通常セッションまたは個別 issue で対応する（`.claude/skills/**` は protected paths のため takt 経由の修正不可）。

Closes #353