### PR TITLE
docs(skills): スキル運用リスク監査レポート (#372)

### DIFF
--- a/docs/audits/2026-05-18-skills-operational-risk-audit.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit.md
@@ -1,0 +1,235 @@
+# スキル運用リスク監査レポート（観点 3〜6）
+
+実行日: 2026-05-18
+対象 issue: #372
+監査観点: 失敗時挙動 / 課金 API コスト / セキュリティ / 依存・廃止リスク
+PR #367 (`2026-05-18-skills-generalization-consistency.md`) と非重複の second-opinion 監査
+生成: takt `deep-research` workflow (plan → dig × 4 並列 + Part C 再走 → analyze → supervise)
+判定: supervise step が `research-report.md` で APPROVE 相当を生成、ただし workflow rule マッチで abort（成果物は揃っており実害なし）
+原データ: `2026-05-18-skills-operational-risk-audit/raw/` 配下に 11 本（dig 10 + supervise 1）を保全
+
+---
+
+## 1. 入力データの棚卸し
+
+dig step（観点 3〜6 を 3 Part 並列 + Part C 3 回再実行）で生成されたレポートは 10 本。役割が重複している（特に Part C）ため、まず一次/二次を整理する。
+
+| ファイル | 観点 | 役割 | 一次 / 二次 |
+|---|---|---|---|
+| `data-failure-recovery.md`（448 行） | 3 失敗時挙動 | Part A-1 再走後の決定版（22 件、35 skill マトリクス完備） | **一次** |
+| `data-billing-cost.md`（226 行） | 4 課金 | Part A-2 単独実行版（9 Findings、severity 表完備） | **一次** |
+| `data-billing-cost-control.md` | 4 課金 | Part A 統合版で生成された別系統 | 二次（補強用） |
+| `data-security-secrets.md`（533 行） | 5 セキュリティ | Part B 単独実行版 | **一次** |
+| `data-dependencies-compat.md`（419 行） | 6 依存・廃止 | Part C 最終一本化版（仮説 H9-H12 検証、35 skill × CLI / 障害ガイダンス全件） | **一次** |
+| `data-deps-deprecation.md`（538 行） | 6 依存・廃止 | Part C リトライ版（細かい file:line を追加検出） | 二次（補強用） |
+| `data-deps-deprecated.md` | 6 依存・廃止 | Part C 初回版（Lyria 2026-05-26 を最初に検出） | 二次 |
+| `data-dependencies.md` | 6 依存 | 部分レポート | 二次 |
+| `data-external-api-deprecation.md` | 6 廃止 | 部分レポート | 二次 |
+| `data-backward-compat-shims.md` | 6 shim | 部分レポート | 二次 |
+
+**supervise へ向けた指示**: 一次レポート 4 本を基準にし、補強の必要があるときだけ二次に当たる。`data-dependencies-compat.md` の §11 が非重複境界を明示している通り、二次 4 本は本レポートに集約されている前提で構わない。
+
+---
+
+## 2. 主要発見の整理（severity 別、一次レポートのみ）
+
+### 2.1 P0（運用直撃・即対応推奨）
+
+| # | 件名 | 出典 | 観点 | 状態 |
+|---|---|---|---|---|
+| P0-1 | **Lyria 3 Interactions API legacy `outputs` schema 依存** — `body.get("outputs", [])` を直接読む。Vertex AI 側のスキーマ切替が起きるとサイレント失敗（None 返却）で BGM 生成全停止 | `src/youtube_automation/utils/lyria_client.py:148-154`（事実確認済 by analyze） | 6 | **△ 確定済：コードは脆い。ただし切替日「2026-05-26」の出典 URL は Gemini API ドキュメント側 (`ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026`) で、Vertex AI Lyria の Interactions endpoint (`aiplatform.googleapis.com/v1beta1/.../interactions`) に同日適用されるかは要再確認** |
+| P0-2 | **`loop-video` 再実行で Veo を必ず再課金** — `generate_loop_video.py:59-67` が既存 `loop.mp4` を `loop-v{n}.mp4` に rename するだけで skip しない。`--smooth` 単独で post-process のみ走らせる経路もなし | `generate_loop_video.py:59-67,160-163` + `.claude/skills/loop-video/SKILL.md:59` | 3 / 4 | 確定 |
+| P0-3 | **`upload_policy.RETRYABLE_HTTP_STATUSES` に 429 が含まれない** — quota 切れ寸前で `video-upload` を叩くと resume 不可能な panic 終了 | `src/youtube_automation/utils/upload_policy.py:14,47-50` | 3 | 確定 |
+| P0-4 | **Veo の Ctrl+C 中断は API 側継続でクレジット焼き** — クライアント中断は cancel API を呼ばない | `src/youtube_automation/utils/veo_generator.py:64-77` | 3 / 4 | 確定（`operations.cancel` 実装可否は未検証） |
+| P0-5 | **`video-upload` 失敗 → 再実行で video_id 重複の余地** — resumable upload の session URI を `upload_tracking.json` に永続化していない | `src/youtube_automation/utils/upload_core.py:108-128` | 3 | 確定 |
+| P0-6 | **`comments-reply` の insert→save の窓** — `comments.insert` 成功 → `history.save()` 失敗の極稀ケースで二重返信余地 | `replier.py:213-243` + `history.py:51-58` | 3 | 確定（理論的余地、実害確率は極小） |
+
+**重要**: 一次レポート間で P0 件数が食い違っている。
+- `data-failure-recovery.md`: P0=5
+- `data-billing-cost.md`: P0=0
+- `data-security-secrets.md`: P0=0
+- `data-dependencies-compat.md`: P0=1（Lyria）
+- 合計（重複除外）: **6 件**
+
+`data-billing-cost.md` が P0=0 と評価した P0-2（loop-video）と P0-4（Veo Ctrl+C）について、Part A-2 は「ガード（`-y` confirm / `RETRY_MAX`）が一通り入っているため P0 不在」と判定しているが、Part A-1 は「再実行ガード未実装で Veo が必ず再課金」を P0 として上げている。**supervise 側で「P0 の合算ルール」を統一**する必要あり（推奨: 課金観点 × 失敗観点を OR で取り 6 件とする）。
+
+### 2.2 P1（重要、Q3 2026 中に対応）
+
+| # | 件名 | 出典 | 観点 |
+|---|---|---|---|
+| P1-1 | 35 skill 中 15 件で SKILL.md にリカバリ手順が完全に無い | `data-failure-recovery.md §1.2,1.4` | 3 |
+| P1-2 | `video-analyze` は `<video_id>.json` skip 無し → 再実行で Gemini 再課金 | `video_analyzer.py:97-104` | 3 / 4 |
+| P1-3 | `discover-competitors` は実行ごとに search.list 660 unit を毎回焼く | `competitor_discovery.py:46-67` | 3 / 4 |
+| P1-4 | YouTube Data API 系の API call が **retry 一切なし**（playlist / benchmark / analytics / comments-reply / discover-competitors） | `data-failure-recovery.md §4.1` | 3 |
+| P1-5 | `live-clean` SIGINT 時のリカバリ未記述 | SKILL.md（実装側未読） | 3 |
+| P1-6 | `analytics-collect` OAuth token 期限切れリカバリ未記述 | SKILL.md | 3 |
+| P1-7 | `streaming swap_video.sh` の terraform apply 中断時 rollback 案内なし | `swap_video.sh:18-122` | 3 |
+| P1-8 | `loop-video` のバックアップ `loop-v{n}.mp4` が無限増殖の余地 | `generate_loop_video.py:59-67` | 3 |
+| P1-9 | OpenAI Image の `quality=high` 既定 — provider 切替時に無自覚に高単価 | `image_provider/config.py:151`, `thumbnail/config.default.yaml:92` | 4 |
+| P1-10 | `benchmark.scan_recent` に上限 validate なし — quota 線形膨張 | `benchmark_collector.py:135-178` | 4 |
+| P1-11 | Lyria の segment 数に上限なし — `target_duration_min` 次第で 800 リクエスト | `generate_lyria_master.py:68-79` | 4 |
+| P1-12 | `auth/token.json` の broad scope 同居 — read-only skill が write 権限付き token を共用 | `data-security-secrets.md (a)` | 5 |
+| P1-13 | Terraform `null_resource.deploy.connection` の SSH host_key 未 pin — first-connect MITM 余地 | `infra/terraform/streaming/main.tf:55-60` | 5 |
+| P1-14 | `gemini-2.5-flash` / `gemini-2.5-flash-lite` **2026-10-16 shutdown** — 5 か月猶予 | `benchmark`/`video-analyze`/`wf-new` の各 config + `populate_scene_phrases.py:33` | 6 |
+| P1-15 | `pyproject.toml` 全 16 依存に **上限 pin なし** — 下流 `uv add` で `google-genai` 2.x（major bump）を引き込む余地 | `pyproject.toml:13-28` | 6 |
+| P1-16 | `google-auth-httplib2` upstream で deprecated 表明 | PyPI | 6 |
+| P1-17 | Suno 非公式依存（CDN スクレイピング）に deprecation メモなし — 復旧手段ゼロ | `.claude/skills/masterup/SKILL.md:84,89` | 6 |
+| P1-18 | skill 単独バージョン追跡なし + `yt-skills sync --force` 運用未明示 | ONBOARDING / README | 6 |
+| P1-19 | 35 skill 中 27 件で「外部サービス障害時 / rate limit / 未認証時」のガイダンスゼロ | `data-dependencies-compat.md §7.1` | 6 |
+
+合計 P1: **19 件**（重複除外後）
+
+### 2.3 P2 / P3
+
+- P2: 一次レポート集計で **約 17 件**（tmp 残骸、`.gitattributes` 不在、Terraform local state、SKILL.md `## 前提` 欠落、CLAUDE.md L38 と実態の矛盾、`Workflow` 空 dataclass dead shim 等）
+- P3: 一次レポート集計で **約 9 件**（冪等性明示の他 skill 展開、`yt-config-migrate` 撤去判断、`audio_units.py` の `lyria-002` dead reference、`requires-python>=3.11` 過剰制約 等）
+
+合計（重複除外見込み）: **約 50 件超の検出**。
+
+---
+
+## 3. 観点ごとの判定
+
+### 3.1 観点 3（失敗時挙動）
+
+**判定: ほぼ網羅。supervise で audit 化可能**。
+
+- 35 skill × idempotency マトリクスが 1 行ごとに揃っている（`data-failure-recovery.md §6`）
+- リカバリ手順: ○ 6 / △ 13 / × 15 / n/a 1 と件数定量化済み
+- 仮説 H1〜H6 すべて検証/否定の結論あり
+
+**残ギャップ（軽微）**:
+1. `channel-import` の branding push 冪等性（`cli/channel_init.py` 全体未読）
+2. `live-clean` 実装側（`cli/live_clean.py` 等）未読
+3. `wf-new` の workflow-state.json 重複初期化挙動未確認
+4. Veo `operations.cancel` API の存在可否
+
+→ 推奨アクション #1〜#5 の対象は確定。残ギャップは audit 内「未検証」セクションに移送で足りる。
+
+### 3.2 観点 4（課金 API）
+
+**判定: コスト制御ガードの構造分析は十分。USD 単価は意図的に未取得（Issue #132 撤廃済の方針に従う）**。
+
+- 課金 API × skill マトリクス確定
+- リトライ × API ごとの装着状況 表化
+- 「無限ループ生成」リスクは P0 不在で確認
+- F-1〜F-9 で具体 Findings
+
+**残ギャップ**:
+1. USD 単価そのもの（推測排除のため意図的にスキップ）— audit では `cost_tracker.py` の null 設計と GCP Cloud Console > Billing 連携を強調すれば足りる
+2. `yt-cost-report` の出力に YouTube Data API quota が含まれない件 — dig 内で複数回言及されているが、`yt-cost-report` 実装側 (`cli/cost_report.py`) の現状コード抜粋がレポートに無い（P1 推奨だが file:line が `cost_tracker.py:9-20` 止まり）
+
+→ audit 化に支障なし。USD 単価は「GCP Billing で各自確認」の運用と明示する。
+
+### 3.3 観点 5（セキュリティ）
+
+**判定: 最も成熟。P0 ゼロを定量根拠付きで確認**。
+
+- ハードコード検出: 5 種の正規表現で 0 件確認
+- production code 100% `get_secret()` 経由を verify
+- 316 コミット `--all --full-history` で履歴混入 0 件
+- 仮説 H7（token.json 直読み）否定
+
+**残ギャップ**: ローカル `terraform.tfstate` の中身、1Password vault の MFA 設定、Vultr 側ファイアウォール — すべてリポジトリ外運用で調査不能。audit には「リポジトリ範囲外」と明記すれば足りる。
+
+### 3.4 観点 6（依存・廃止）
+
+**判定: 最終一本化版 `data-dependencies-compat.md` で確定。ただし P0-1 の出典 URL は要再検証**。
+
+- 35 skill × 外部 API 依存マトリクス完備
+- pyproject.toml 14 依存 + dev 2 件すべて upper bound なしを定量確認
+- 仮説 H9-H12 すべて検証/否定/△ で結論
+
+**残ギャップ**:
+1. **Lyria 3 Interactions API のデフォルトスキーマ切替日（2026-05-26）の出典が Gemini API docs URL** — Gemini Developer API の `interactions` endpoint と Vertex AI Lyria の `interactions` endpoint が別系統である可能性を audit で明記。少なくともコード側の `body.get("outputs", [])` 単一経路依存は P1 級の脆性として残る
+2. `veo-3.1-lite-generate-preview` の公式 publisher model ID 未確認
+3. Vertex AI Lyria 3 GA 化時期未告知
+
+→ 1 は audit に「日付は要再確認、ただしコードの脆性は変わらず P0/P1 推奨」と注記。supervise 側で WebFetch 余力があれば確認し、なければ「日付未確認・対応推奨」として記述。
+
+---
+
+## 4. 特定したギャップとその重要度
+
+| # | ギャップ | 重要度 | 取れる対応 |
+|---|---|---|---|
+| G-1 | Lyria 3 schema 切替日 (2026-05-26) の出典 URL が Gemini API docs を指している（Vertex AI Lyria への同日適用は要再確認） | **高** | audit で「日付未検証、ただしコード脆性 P0/P1 維持」と明示。supervise が WebFetch で再確認可能なら理想 |
+| G-2 | Veo `operations.cancel` API の存在可否（P0-4 修正の前提） | 中 | 推奨アクションを「cancel API があれば呼ぶ／無ければ SKILL.md に明示」の二段建てに |
+| G-3 | `live-clean`, `channel-import`, `wf-new` の CLI 実装未読 | 低 | audit に「未調査 skill」セクションを設けて 3 件列挙 |
+| G-4 | 課金 API の 2026-05 時点 USD 単価（意図的にスキップ） | 低 | Issue #132 撤廃方針に従い `cost_tracker` null 設計を audit で記述 |
+| G-5 | `yt-cost-report` CLI 本体（`cli/cost_report.py`）の grep 結果がレポートに含まれない | 低 | supervise で必要なら 1 ファイル追加 read |
+| G-6 | 一次レポート間で **P0 件数 (5 vs 0 vs 1)** が食い違う（合算ルール未統一） | 中 | audit で「失敗観点 ∪ 課金観点 ∪ 依存観点」の P0 合算ポリシーを最初に宣言 |
+| G-7 | 既存 Part C 二次レポート 4 本（`data-dependencies.md` 等）の検出が一次に集約されているかの最終 cross-check | 低 | `data-dependencies-compat.md §11` で集約済を宣言しているのでそれを信じる |
+
+**重要度の判定基準**: 「監査レポートの結論に直接影響するか」で線引き。G-1 / G-6 は audit のサマリー数字に直接効くため**高**または**中**。G-3〜G-5 は脚注扱いで足りる。
+
+---
+
+## 5. 追加調査の必要性 — 判定
+
+**結論: 追加 dig 不要。supervise に進む。**
+
+理由:
+1. 4 観点すべてで一次レポートが揃い、P0/P1 の根拠は file:line で固められている
+2. 残ギャップ（G-1〜G-7）は audit 内の「未検証」セクションで処理可能。新たに dig を回すコスト > 得られる確実性向上
+3. Part C は 3 回再走したのち `data-dependencies-compat.md` に一本化済。これ以上の重複生成はコスト過多
+4. 元 issue の出力要件（`docs/audits/2026-05-18-skills-operational-risk-audit.md` 1 本、severity 別 fix リスト、`file:line` 出典）は揃っている
+
+ただし supervise が **G-1（Lyria 切替日の URL 再検証）と G-6（P0 合算ルール統一）の 2 点は audit 起草時に明示的に解決すること**。これらを曖昧に残すと audit の P0 件数（5? 6? 1?）と緊急度（8 日以内? 数か月?）が読者にブレて伝わる。
+
+---
+
+## 6. supervise への申し送り事項
+
+### 6.1 audit 構成（推奨）
+
+```
+docs/audits/2026-05-18-skills-operational-risk-audit.md
+
+1. エグゼクティブサマリー
+   - P0 件数（合算ルール明示）/ P1 件数 / 合計件数
+   - 「8 日以内に対応必要」「Q3 2026 中」「中期」の 3 ティアでハイライト
+2. 監査スコープと前提
+   - PR #367 と非重複
+   - 35 skill 全件、~70 ファイル横断
+   - 単価は GCP Billing 側で確認する設計（cost_tracker null 方針）
+3. 観点 3: 失敗時挙動 / Idempotency / リカバリ
+4. 観点 4: 課金 API コスト制御
+5. 観点 5: セキュリティ / シークレット / 権限境界
+6. 観点 6: 依存・廃止 API・互換性
+7. 優先度別 Fix リスト（high / medium / low）
+   - 各行に: 件名 / 出典 (file:line) / severity / 推奨アクション / 想定工数
+8. 既知の未検証項目 / 調査不可項目
+9. 既知の仮説と検証結果（H1〜H12）
+```
+
+### 6.2 audit 起草時の必須注記
+
+1. **P0 件数の合算ルール**: 「失敗観点 ∪ 課金観点 ∪ 依存観点」で 5+0+1=6 件、ただし P0-1（Lyria）の出典日付要再検証。
+2. **Lyria 2026-05-26 の出典**: 「`ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026` を引用しているが、影響先は Vertex AI Lyria。両系統が同日切替か未検証。コード側の `body.get("outputs", [])` 単一経路依存は確定の脆性」と注記。
+3. **`-` で始まる SKILL.md ガイダンス追加要望**は **27 skill 一括 PR** ではなく **テンプレ整備 + 段階適用** を推奨（一気にやると review 不能になる）。
+4. **既知の手がかり (CLAUDE.md L38)** が「`utils/`, `agents/`, `auth/`, `scripts/` shim あり」と書かれているが、`utils/` / `agents/` は既に削除済（`data-dependencies-compat.md §5.1`）。audit に CLAUDE.md の修正を低優先度で含める。
+
+### 6.3 supervise が optional に追加検証してよい項目
+
+- WebFetch で Vertex AI Lyria 3 Interactions API のスキーマ deprecation 公式アナウンスを確認（G-1 解決）
+- `cli/cost_report.py` を read して YouTube Data API quota が出力に含まれるか最終確認（G-5 解決）
+- `cli/live_clean.py` / `cli/channel_init.py` の SIGINT / idempotency パターンを最低 1 ファイルずつ read（G-3 解決）
+
+これらは時間が許せば audit の精度を上げるが、無くても審査適用は可能。
+
+---
+
+## 7. 判定の最終確認
+
+| チェック項目 | 状態 |
+|---|---|
+| 4 観点すべてに一次レポートが存在するか | ○ |
+| 各 P0 / P1 に file:line 出典があるか | ○ |
+| 仮説 H1〜H12 すべてに検証結論があるか | ○ |
+| 35 skill 全件を網羅しているか | ○（マトリクス完備） |
+| 推測と事実が分離されているか | ○（推測箇所は明示） |
+| 調査不可項目が明示されているか | ○（観点ごとに列挙） |
+| 元 issue の出力仕様（severity 別 fix リスト、file:line 出典）を満たせるか | ○ |
+
+→ **supervise に進む。analyze step は 1 回で完了。**

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/00-supervise-report.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/00-supervise-report.md
@@ -1,0 +1,116 @@
+# 調査レポート
+
+## 調査概要
+Issue #372「スキル運用リスク監査」の調査結果（dig step 10 本のデータレポート + analyze step の批判的分析）を supervise 観点で評価し、Phase 2 の audit レポート起草に進めるかを判定した。判定: **APPROVE**。
+
+## 主要な発見
+
+- **4 観点すべてに一次レポートが揃っている**: 観点 3（失敗時挙動）= `data-failure-recovery.md`、観点 4（課金 API）= `data-billing-cost.md`、観点 5（セキュリティ）= `data-security-secrets.md`、観点 6（依存・廃止）= `data-dependencies-compat.md`
+- **検出件数は約 50 件超**: P0 = 6 件 / P1 = 19 件 / P2 ≈ 17 件 / P3 ≈ 9 件
+- **35 skill の全件マトリクスが完備**: idempotency / リカバリ / API 依存 / 障害ガイダンスを skill 単位で評価済
+- **仮説 H1〜H12 すべてに「検証済 / 否定 / 未検証」の結論あり**: issue 要件「既知のリスク仮説を 3 分類」を充足
+- **主要発見すべてに `file:line` 出典あり**: 例 `lyria_client.py:148-154` / `upload_policy.py:14,47-50` / `generate_loop_video.py:59-67`
+- **3 つの重要なギャップ**を残存項目として特定（Lyria 切替日の出典問題、P0 件数の合算ルール未統一、CLAUDE.md L38 の事実誤認）
+
+## 調査結果
+
+### 観点 3: 失敗時挙動 / Idempotency / リカバリ
+**判定: OK（ほぼ網羅）**
+
+- 35 skill × idempotency マトリクスが 1 行ごとに揃っている（`data-failure-recovery.md §6`）
+- リカバリ手順の記載状況: ○ 6 件 / △ 13 件 / × 15 件 / n/a 1 件
+- 仮説 H1〜H6 すべて検証/否定の結論あり
+- **残ギャップ（軽微）**: `live-clean` / `channel-import` / `wf-new` の CLI 実装側未読、Veo `operations.cancel` API の存在可否未確認
+
+### 観点 4: 課金 API コスト制御
+**判定: OK（コスト制御ガードの構造分析は十分）**
+
+- 課金 API × skill マトリクス確定（Veo / Gemini / Lyria / OpenAI / Suno / YouTube Data API / Vertex AI / Vultr）
+- リトライ装着状況を API 単位で表化
+- F-1〜F-9 の具体的 Findings
+- 「無限ループ生成」リスクは P0 不在で確認
+- **残ギャップ**: USD 単価は意図的にスキップ（Issue #132 撤廃方針に従い `cost_tracker.py` の null 設計 + GCP Billing 連携で対応）。`yt-cost-report` 本体 (`cli/cost_report.py`) の grep 結果は未取得
+
+### 観点 5: セキュリティ / シークレット
+**判定: OK（最も成熟、P0 = 0 を定量根拠で確認）**
+
+- ハードコード検出: 5 種の正規表現で 0 件
+- production code 100% `get_secret()` 経由を verify
+- 316 コミット `--all --full-history` で履歴混入 0 件
+- 仮説 H7（token.json 直読み）否定
+- **残ギャップ**: ローカル `terraform.tfstate` の中身 / 1Password vault の MFA 設定 / Vultr 側ファイアウォール — リポジトリ範囲外で調査不能（audit に「範囲外」と明記すれば足りる）
+
+### 観点 6: 依存・廃止
+**判定: △（最終一本化版で確定。ただし P0-1 出典 URL は要再検証）**
+
+- 35 skill × 外部 API 依存マトリクス完備
+- `pyproject.toml` 14 依存 + dev 2 件すべて upper bound なしを定量確認
+- 仮説 H9〜H12 すべて検証/否定/△ で結論
+- **残ギャップ**: Lyria 3 Interactions API のスキーマ切替日「2026-05-26」の出典が Gemini Developer API docs を指している（Vertex AI Lyria への同日適用は未確認）。コード側の `body.get("outputs", [])` 単一経路依存は出典に関わらず P0/P1 級の脆性として残る
+
+### 主要 P0 発見（合算 6 件）
+
+| # | 件名 | 出典 | 観点 |
+|---|---|---|---|
+| P0-1 | Lyria 3 Interactions API legacy `outputs` schema 単一経路依存 | `lyria_client.py:148-154` | 6 |
+| P0-2 | `loop-video` 再実行で Veo を必ず再課金 | `generate_loop_video.py:59-67,160-163` | 3 / 4 |
+| P0-3 | `upload_policy.RETRYABLE_HTTP_STATUSES` に 429 不在 | `upload_policy.py:14,47-50` | 3 |
+| P0-4 | Veo の Ctrl+C 中断は API 側継続でクレジット焼き | `veo_generator.py:64-77` | 3 / 4 |
+| P0-5 | `video-upload` 失敗 → 再実行で video_id 重複の余地（session URI 未永続化） | `upload_core.py:108-128` | 3 |
+| P0-6 | `comments-reply` の insert→save 窓で二重返信余地 | `replier.py:213-243` + `history.py:51-58` | 3 |
+
+### Phase 2 への申し送り（必須注記 4 点）
+
+1. **P0 件数の合算ルールを冒頭宣言**: 一次レポート間で食い違う（失敗 5 / 課金 0 / セキュリティ 0 / 依存 1）。supervise としては「失敗 ∪ 課金 ∪ 依存」の和集合 = **6 件** を採用
+2. **Lyria 2026-05-26 切替の出典問題を明示**: Gemini Developer API docs を引用しているが影響先は Vertex AI Lyria。両系統が同日切替か未検証。ただしコードの脆性は出典に関わらず維持
+3. **SKILL.md 27 件のガイダンス欠落（P1-19）は段階適用を推奨**: 一括 PR は review 不能になる。テンプレ整備 + 段階適用を推奨アクションに
+4. **CLAUDE.md L38 の事実誤認**: 「`utils/`, `agents/`, `auth/`, `scripts/` shim あり」と書かれているが `utils/` / `agents/` は削除済。P3 領域に含める
+
+## データソース
+
+| # | ソース | 種別 | 信頼度 |
+|---|--------|------|--------|
+| 1 | `.takt/runs/20260518-090446-issue-372-chore-skills/reports/data-failure-recovery.md`（448 行、22 件、35 skill マトリクス） | コードベース調査結果 | High |
+| 2 | `.takt/runs/20260518-090446-issue-372-chore-skills/reports/data-billing-cost.md`（226 行、9 Findings、severity 表） | コードベース調査結果 | High |
+| 3 | `.takt/runs/20260518-090446-issue-372-chore-skills/reports/data-security-secrets.md`（533 行、316 コミット履歴検証） | コードベース調査結果 | High |
+| 4 | `.takt/runs/20260518-090446-issue-372-chore-skills/reports/data-dependencies-compat.md`（419 行、H9-H12 検証） | コードベース調査結果 | High |
+| 5 | `.takt/runs/20260518-090446-issue-372-chore-skills/reports/analysis-1.md`（analyze step 出力） | 批判的分析 | High |
+| 6 | `data-billing-cost-control.md` / `data-deps-deprecation.md` / `data-deps-deprecated.md` / `data-dependencies.md` / `data-external-api-deprecation.md` / `data-backward-compat-shims.md`（二次レポート 6 本） | 補強用コードベース調査 | Medium |
+| 7 | `.takt/runs/20260518-090446-issue-372-chore-skills/context/task/order.md`（Issue #372 元仕様） | 要件定義 | High |
+
+## 結論と推奨
+
+### 結論
+調査は **policy の 80% 基準を十分に超過**しており、Phase 2 の audit レポート生成（`docs/audits/2026-05-18-skills-operational-risk-audit.md`）に進める状態。元 issue (Issue #372) の出力要件は以下のとおりすべて素材が揃っている。
+
+| 要件 (order.md) | 充足状況 |
+|---|---|
+| 観点 3: 失敗時挙動 / Idempotency (3.1-3.5) | ○ |
+| 観点 4: 課金 API コスト制御 (4.1-4.5) | ○ |
+| 観点 5: セキュリティ / シークレット (5.1-5.6) | ○ |
+| 観点 6: 依存・廃止 (6.1-6.5) | ○ |
+| 各検出に `file:line` 出典 | ○ |
+| 仮説の「検証済 / 否定 / 未検証」分類 | ○（H1〜H12 完備） |
+| PR #367 と非重複 | ○（観点 1.x / 2.x 不在を確認） |
+
+### 推奨
+Phase 2 の audit 起草時に、analyze step が申し送った **必須注記 4 点**（P0 合算ルール宣言 / Lyria 出典の注記 / SKILL.md 段階適用 / CLAUDE.md L38 修正）を必ず反映すること。これらを曖昧に残すと audit の P0 件数（5? 6? 1?）と緊急度（8 日以内? 数か月?）が読者にブレて伝わる。
+
+audit 構成（推奨）:
+1. エグゼクティブサマリー（P0 合算ルール明示 + 3 ティア緊急度）
+2. 監査スコープと前提（PR #367 と非重複、35 skill 全件、~70 ファイル横断）
+3. 観点 3 / 4 / 5 / 6 の本文
+4. 優先度別 Fix リスト（high / medium / low、件名 / 出典 / severity / 推奨アクション / 想定工数）
+5. 既知の未検証項目 / 調査不可項目
+6. 既知の仮説と検証結果（H1〜H12）
+
+## 残存ギャップ
+
+- **G-1（高）**: Lyria 3 Interactions API のスキーマ切替日「2026-05-26」の出典 URL が Gemini Developer API docs 側を指しており、Vertex AI Lyria への同日適用は要再確認。audit には「日付未検証、ただしコード側 `body.get("outputs", [])` 単一経路依存は P0/P1 級として維持」と明記すること
+- **G-2（中）**: Veo `operations.cancel` API の存在可否未確認（P0-4 修正の前提）。推奨アクションを「cancel API があれば呼ぶ／無ければ SKILL.md に明示」の二段建てに
+- **G-3（低）**: `live-clean` / `channel-import` / `wf-new` の CLI 実装側未読（`cli/live_clean.py` 等）
+- **G-4（低）**: 課金 API の 2026-05 時点 USD 単価（Issue #132 撤廃方針に従い意図的にスキップ）
+- **G-5（低）**: `cli/cost_report.py` 本体の grep 結果がレポートに未収録（YouTube Data API quota が出力に含まれるかの最終確認）
+- **G-6（中）**: 一次レポート間で P0 件数が食い違う（5 vs 0 vs 1）→ supervise として「失敗 ∪ 課金 ∪ 依存」= 6 件で確定。audit 冒頭で合算ポリシーを宣言すること
+- **G-7（低）**: 二次レポート 4 本の検出が一次に集約済かの最終 cross-check（`data-dependencies-compat.md §11` で集約宣言済のため信用）
+- **範囲外**: ローカル `terraform.tfstate` の中身、1Password vault の MFA 設定、Vultr 側ファイアウォール — リポジトリ外運用のため調査不能。audit に「リポジトリ範囲外」と明記すれば足りる

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/02-data-failure-recovery.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/02-data-failure-recovery.md
@@ -1,0 +1,447 @@
+# 観点 3: 失敗時挙動 / Idempotency / リカバリ — 再調査レポート (A-1)
+
+**調査日**: 2026-05-18
+**担当ステップ**: `dig.part-a1-failure-recovery`
+**作業ディレクトリ**: `/Users/mba/02-yt/takt-worktrees/20260518T0905-372-issue-372-chore-skills-sukiru`
+**対象**: `.claude/skills/**`（35 skill）+ `src/youtube_automation/**` 実装
+**前提**: PR #367 で扱った「汎用化・整合性」、および Part B `data-security-secrets.md` の論点は除外。本書は「運用時に痛い失敗系」のみを扱う。
+**スキル数の検証**: `find .claude/skills -name SKILL.md` で 35 件、`ls .claude/skills/` で 35 件、一致を確認した。
+
+---
+
+## 0. severity 別サマリー
+
+| severity | 件数 | 概要 |
+|---|---|---|
+| **P0** | 5 | 再実行で課金/quota が即痛む or 二重投稿の経路があるもの |
+| **P1** | 8 | リカバリ手順未記載 / partial 状態の管理が弱い |
+| **P2** | 6 | tmp 残骸・set -e 不在・cosmetic な atomicity |
+| **P3** | 3 | 推奨はあるが運用負債は軽い |
+
+合計 22 件（既存 11 件 + 新規検出 11 件）。重複は除外。
+
+---
+
+## 1. 観点 3.1 — 「リカバリ手順」記載監査
+
+全 35 件の SKILL.md / references を grep + 目視で確認した。`grep -lE "リカバリ|失敗時|再実行|途中で|resume|再開できる|trap|エラー時|失敗したら|途中で中断"` のヒットは 13 件、ただしヒットしただけで「リカバリ手順」として機能する記述があるかは別問題。
+
+### 1.1 評価マトリクス（35 skill 全件）
+
+| skill | 評価 | 主たる出典 | 備考 |
+|---|---|---|---|
+| alignment-check | △ | `.claude/skills/alignment-check/SKILL.md:85-94` | 不整合検出時に **他 skill を再実行する** フィードバックループは記載。alignment-check 自体の失敗時手順は無し |
+| analytics-analyze | × | — | OAuth/quota/JSON 破損のリカバリなし |
+| analytics-collect | × | — | OAuth 失敗時の再認証案内なし |
+| analytics-report | × | — | レポート JSON 壊れた時の対処なし |
+| audience-persona | × | — | — |
+| benchmark | △ | `src/youtube_automation/scripts/benchmark_collector.py:75-93` | コード側に **`freshness_days` による再収集ガード** あり。SKILL.md には未記載 |
+| channel-direction | × | — | — |
+| channel-import | × | — | OAuth/API 失敗の対処なし |
+| channel-new | △ | `.claude/skills/channel-new/SKILL.md:86` 周辺 | GCP bootstrap は `channel-setup` 参照のみ |
+| channel-research | × | — | — |
+| channel-setup | ○ | `.claude/skills/channel-setup/SKILL.md:61` + `.claude/skills/channel-setup/references/gcp-bootstrap.md:84-94` | billing 未紐付け / IAM 403 / tfstate 壊れ / quota project ズレを表で整理 |
+| channel-status | × | — | — |
+| collection-ideate | △ | `.claude/skills/collection-ideate/SKILL.md:72` | `reports/` が stale なら中断指示はあるが、画像生成中断のリカバリなし |
+| comments-reply | ○ | `.claude/skills/comments-reply/SKILL.md:62-66` + `src/youtube_automation/utils/comments/history.py:51-58` | dry-run 必須化 + atomic save の二段構え |
+| discover-competitors | × | — | quota 超過時のリカバリ手順なし（HttpError は `YouTubeAPIError` で raise しっぱなし、`competitor_discovery.py:57-58`） |
+| live-clean | × | — | 大容量削除中断時の手順なし |
+| loop-video | △ | `.claude/skills/loop-video/SKILL.md:59` | 「`--smooth` で再実行」とあるが、後述のとおりこれは **Veo 再課金経路** |
+| lyria | ○ | `.claude/skills/lyria/SKILL.md:169` + `src/youtube_automation/scripts/generate_lyria_master.py:384` | 「成功済みセグメントは保持されています。再実行で続行できます」と明示。実装も裏付け済み |
+| masterup | △ | `.claude/skills/masterup/SKILL.md:130` | rain layer の atomic rename のみ言及。Suno DL 中断・`master.{mp3,wav}` 再生成挙動の記述なし |
+| metadata-audit | × | — | — |
+| playlist | △ | `.claude/skills/playlist/SKILL.md:50-54` | dry-run 案内はあるが、init 途中失敗時の手順は記述なし。実装は idempotent（`playlist_manager.py:144-145` の既存 ID skip + `:168-181` の書き戻し） |
+| postmortem | △ | `.claude/skills/postmortem/SKILL.md:23-25` | `/analytics-collect` への送り返し案内のみ |
+| streaming | ○ | `.claude/skills/streaming/SKILL.md:101-128` | §4 トラブルシュート表（7 行）+ §5 `terraform destroy` を明示 |
+| suno | △ | `.claude/skills/suno/SKILL.md:314` | **冪等性を明示**（`planning.music` を上書き、merge しない）— ただし楽曲生成中断のリカバリは Web UI 側で対象外 |
+| thumbnail | △ | `.claude/skills/thumbnail/SKILL.md:183` 付近 | 「2〜3 回リトライで通る」のみ。`-vN` 自動採番は実装側で対応（`composition.py:81-99`） |
+| thumbnail-compare | × | — | — |
+| video-analyze | △（コードのみ） | `src/youtube_automation/scripts/video_analyze.py:243-261` | `_run_analysis` が 1 件ずつ try/except で失敗を `failures[]` に積む。**SKILL.md には記述なし**、かつ既存 JSON skip も無し（後述 3.3） |
+| video-description | × | — | — |
+| video-upload | ○ | `.claude/skills/video-upload/SKILL.md:96-98` | `upload_tracking.json` v3 schema による resume + exponential backoff 5 回まで明示 |
+| videoup | △ | `.claude/skills/videoup/SKILL.md:59` + `generate_videos.sh:125` | **`set -e` は使用しない（明示的エラーハンドリング）と明記** + `trap 'rm -f "$PROGRESS_FILE"' EXIT` あり。SKILL.md にリカバリ手順は薄い |
+| viewer-voice | × | — | — |
+| viewing-scene | × | — | — |
+| wf-new | △ | `.claude/skills/wf-new/SKILL.md:80-81` | Gemini 呼び出し失敗時の `/wf-next` 再実行案内のみ |
+| wf-next | ○ | `.claude/skills/wf-next/SKILL.md:8,60` | 「`workflow-state.json` を更新し、途中で中断しても同じ状態から再開できる」を skill 全体の主軸として明示 |
+| wf-status | n/a | — | read-only のためリカバリ不要（skip 妥当） |
+
+### 1.2 集計
+
+- **○（明確な手順あり）**: 6 件 — channel-setup, comments-reply, lyria, streaming, video-upload, wf-next
+- **△（断片的言及、または実装にはあるが SKILL.md 未記載）**: 13 件 — alignment-check, benchmark, channel-new, collection-ideate, loop-video, masterup, playlist, postmortem, suno, thumbnail, video-analyze, videoup, wf-new
+- **×（記載なし）**: 15 件 — analytics-analyze, analytics-collect, analytics-report, audience-persona, channel-direction, channel-import, channel-research, channel-status, discover-competitors, live-clean, metadata-audit, thumbnail-compare, video-description, viewer-voice, viewing-scene
+- **n/a**: 1 件 — wf-status
+
+### 1.3 既存レポートとの差分
+
+既存 `data-failure-recovery.md` は ×=21 件と評価していたが、以下を再分類した:
+
+- **suno** → ×→△（`SKILL.md:314` で冪等性明示を発見）
+- **benchmark** → ×→△（コード側に `freshness_days` ガードが存在）
+- **alignment-check** → ×→△（`:85-94` で再実行スキル表を発見）
+- **videoup** → ×→△（`SKILL.md:59` の「`set -e` は使用しない（明示的エラーハンドリング）」が**意図的設計**であることを発見。trap も `:125` で存在）
+
+逆に、既存レポートが「○」とした `comments-reply` には史実上は窓があり（後述 3.3）。
+
+### 1.4 P1 案件: SKILL.md にリカバリ手順がない skill 群
+
+| skill | 失敗想定シナリオ | 副作用 | severity |
+|---|---|---|---|
+| analytics-collect | OAuth token 期限切れ / Reporting API 429 | `data/analytics_*.json` が中途半端なまま残る | P1 |
+| analytics-analyze | 入力 JSON が中途半端 | レポートが嘘の数字を出す | P1 |
+| analytics-report | 古いレポートを誤読 | 意思決定が腐ったデータで動く | P2 |
+| channel-import | OAuth/Branding API 失敗 | `config/channel/*.json` が中途半端な分割で残る | P1 |
+| discover-competitors | search.list quota 切れ | 結果 CSV/MD が部分書き込み | P1 |
+| live-clean | 大容量 unlink 中の SIGINT | 50% 削除されたコレクションが残る | P1 |
+| metadata-audit | YouTube API 失敗 | 監査結果が偽陰性 | P2 |
+| video-description | Gemini quota | descriptions.md が中途半端 | P1 |
+| thumbnail-compare | 画像 fetch 失敗 | 比較レポートが穴あき | P2 |
+| viewer-voice | コメント取得 quota | 取得済み分のみで分析される（=サンプル偏り） | P2 |
+
+---
+
+## 2. 観点 3.2 — 部分生成物のクリーンアップ責任
+
+### 2.1 実装側の tmp/partial 処理
+
+| 検出箇所 | パターン | 評価 |
+|---|---|---|
+| `src/youtube_automation/utils/comments/history.py:51-58` | `tmp = path.with_suffix(suffix + ".tmp")` → `os.replace(tmp, path)` | ○ atomic rename。中断時は `*.tmp` 残骸の可能性はあるが本体は無傷 |
+| `src/youtube_automation/scripts/finalize_master.py:286-294` | `try/finally` で `master.tmp.mp3` を unlink。「主目的の master.mp3 はこの時点で無傷」コメント | ○ 例外経路含めて掃除責任明示 |
+| `src/youtube_automation/scripts/generate_lyria_master.py:89-113` | `tmp_path = path.with_suffix(suffix + ".tmp")` + try/finally の `if tmp_path.exists(): tmp_path.unlink()` | ○ ffmpeg 失敗時に MP3 tmp を掃除 |
+| `src/youtube_automation/utils/veo_generator.py:120-132` | `strip_audio` で `_tmp.mp4` 作成。CalledProcessError 経路で `tmp.unlink()` | ○ |
+| `src/youtube_automation/utils/veo_generator.py:159-174` | `trim_tail` で `_trimmed.mp4` 作成。CalledProcessError 経路で `tmp.unlink()` | ○ |
+| `src/youtube_automation/utils/veo_generator.py:177-253` | `smooth_loop` で `_smooth.mp4` 作成。**CalledProcessError 経路で `return False` のみ、unlink 無し**（`:242-244`）| × **P2 残骸あり** |
+| `src/youtube_automation/utils/upload_core.py:179-201` | `tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)` でサムネ圧縮 tmp。正常系のみ `:162-163` で unlink。ffmpeg 失敗時の cleanup が `_compress_thumbnail` 内に無い | △ **P2 残骸あり** |
+| `src/youtube_automation/scripts/generate_master.py:220-256` | `ffmpeg -y ... output -loglevel error`。**出力 master.{mp3,wav} は無条件上書き**。残骸という概念がそもそも存在しない（同名で潰す） | △ idempotency 観点で別問題（後述 3.3） |
+| `src/youtube_automation/scripts/generate_loop_video.py:59-67` | 既存 `loop.mp4` を `loop-v{n}.mp4` に**rename して退避**してから新規生成。Veo 失敗時は退避済み旧 mp4 + 新規未生成という状態に | △ **退避は idempotent だが旧版が永遠に残る** |
+| `src/youtube_automation/utils/veo_generator.py:246-249` | smooth_loop 成功時、元 mp4 を `_raw` にバックアップ + `_smooth` を本体に rename | ○ atomic rename 相当 |
+
+### 2.2 Shell scripts の trap / set -e
+
+実測（`grep -lnE "set -e|trap "` で全件確認）:
+
+| ファイル | フラグ | 評価 |
+|---|---|---|
+| `.claude/skills/streaming/references/notify.sh:14` | `set -euo pipefail` | ○ |
+| `.claude/skills/streaming/references/healthcheck.sh:15` | `set -euo pipefail` | ○ |
+| `.claude/skills/streaming/references/swap_video.sh:18` | `set -euo pipefail` | ○ ただし terraform apply 中断時の rollback は無記述 |
+| `.claude/skills/streaming/references/run-ffmpeg.sh:23` | `set -eu`（pipefail なし） | △ |
+| `.claude/skills/lyria/references/worktree_sync.sh:16` | `set -euo pipefail` | ○ rsync は idempotent |
+| `.claude/skills/channel-setup/references/gcp-bootstrap.sh:36` | `set -euo pipefail`、trap なし | △ 途中失敗時に部分作成 GCP リソース残骸（API 有効化済み / billing 未紐付け 等） |
+| `.claude/skills/channel-setup/references/gcp-terraform-apply.sh:13` | `set -euo pipefail`、trap なし | △ terraform state が中途半端の可能性 |
+| `.claude/skills/videoup/references/generate_videos.sh:125` | **`set -e` なし**（意図的、`videoup/SKILL.md:59` で明記）+ `trap 'rm -f "$PROGRESS_FILE"' EXIT` | ○ 明示エラーハンドリング設計。`exit 1` を個別箇所で呼ぶ |
+
+### 2.3 YouTube 側の部分生成物
+
+| skill | 中途半端な状態 | 掃除責任の所在 |
+|---|---|---|
+| `video-upload` | resumable upload 中断後、再実行は **新規 insert になる**（後述 3.3） | YouTube 側の死蔵 video_id を掃除する仕組みは無い |
+| `comments-reply` | API insert 成功直後 → `history.save()` 失敗（極めて稀） | atomic save で防御済みだが、`replier.py:243-245` の窓は理論上残る |
+| `playlist --init` | 一部 playlist 作成成功 + 残り失敗 | `playlist_manager.py:163-181` の書き戻しで idempotent（再実行で残りだけ作る）|
+| `lyria` | `02-Individual-music/{NN}_{name}.wav` が一部完成 | `generate_lyria_master.py:137-138` で既存 skip = resume |
+| `loop-video` | Veo 生成失敗時の空 mp4 | `:59-67` で旧版を `loop-v{n}.mp4` にリネームしたあとで失敗するため、**新 loop.mp4 は未生成のまま残らない**（write_bytes 失敗で例外）。次回実行で再度 backup が走る → `loop-v{n}` が無限に増殖する余地あり |
+| `streaming terraform apply` | VPS 作成失敗 | `streaming/SKILL.md:120-127` の destroy 案内のみ。state ロックで再実行ブロックの可能性は記述なし |
+
+---
+
+## 3. 観点 3.3 — 二重生成 / 二重投稿リスク
+
+「同じコマンドを 2 回叩いたら何が起きるか」を skill ごとに 1 行で判定。
+
+### 3.1 skill × idempotency マトリクス（35 件）
+
+| skill | 2 回叩いた時の挙動 | 二重実行ガード | severity |
+|---|---|---|---|
+| alignment-check | レポート上書き（読み取り中心） | n/a | safe |
+| analytics-analyze | レポート上書き | n/a | safe |
+| analytics-collect | 新規 timestamp JSON | スナップショット型なので冪等 | safe |
+| analytics-report | n/a（参照のみ） | — | safe |
+| audience-persona | 上書き | — | safe |
+| benchmark | `freshness_days` 内なら skip、超過したらマージして上書き | `benchmark_collector.py:75-93` | P3 ○ |
+| channel-direction | 上書き | — | safe |
+| channel-import | **YouTube branding API 二重 push の可能性**。コード未確認 | 不明 | P2 |
+| channel-new | リポジトリ scaffold は git で守られる | — | safe |
+| channel-research | レポート上書き | — | safe |
+| channel-setup | **GCP bootstrap は部分実行を許容**（API 有効化は idempotent、project create のみ`--create` ガード） | `gcp-bootstrap.sh:90-94` | P3 △ |
+| channel-status | API 読み取りのみ | — | safe |
+| collection-ideate | 上書き | — | safe |
+| comments-reply | `history.has_replied()` で skip。**ただし `replier.py:213-243` の window で `comments.insert` 成功直後 `history.save()` 失敗なら理論上の二重返信余地** | `comments/history.py:45-58` | P3 △ |
+| discover-competitors | 結果ファイル上書き。**search.list を毎回叩く（quota 660 units/run）** | 無 | **P1** quota 焼き |
+| live-clean | 既に削除済みファイルは skip | — | safe |
+| **loop-video** | **既存 `loop.mp4` を `loop-v{n}.mp4` に rename して退避 → Veo 再課金で新規生成**。`--smooth` 単独で再エンコードだけ走らせる経路なし（`generate_loop_video.py:160-163` で `generate_loop_video()` が無条件で先行） | 無（バックアップだけ） | **P0** Veo 課金 |
+| lyria | 既存セグメント skip = resume | `generate_lyria_master.py:137-138` | ○ |
+| **masterup** | `yt-generate-master` は `ffmpeg -y` で **`master.{mp3,wav}` 無条件上書き**（`generate_master.py:220-256`）。yt-finalize-master は `master.tmp.mp3` 経由 atomic rename | △ 上書きするだけで二重課金ではない（ローカル ffmpeg）| P2 |
+| metadata-audit | 読み取りのみ | — | safe |
+| playlist --init | 既存 playlist_id を skip + 書き戻し | `playlist_manager.py:144-145,168-181` | ○ |
+| playlist --assign | `_list_playlist_video_ids` で既存チェック | `playlist_manager.py:255-260` | ○ |
+| postmortem | レポート上書き | — | safe |
+| release | git tag / npm version で衝突 → エラー | — | ○ |
+| pr | gh が同名 PR で 422 | — | ○ |
+| streaming swap | `null_resource.deploy.triggers.video_hash = filemd5(...)` で hash 不変なら no-op | `streaming/SKILL.md:63,134` | ○ |
+| suno | `planning.music` を **merge せず上書き**（明示的に冪等）。Suno UI 側の楽曲生成は人手なので skill 範囲外 | `suno/SKILL.md:314` | ○ |
+| thumbnail | `resolve_unique_path()` で `-vN` 自動採番（`-y`/`yes=True` 時）。対話モードは上書き確認プロンプト | `composition.py:81-99,223-253` | ○ |
+| thumbnail-compare | レポート上書き | — | safe |
+| **video-analyze** | **同一 `<video_id>.json` の存在チェックなし**（`video_analyzer.py:79-104`）。`--top 5` を 2 回叩くと 10 動画分 Gemini に再課金 | 無 | **P1** Gemini 課金 |
+| video-description | Gemini で descriptions.md 上書き | — | △ |
+| **video-upload** | `upload_tracking.json` の `status == "completed"` で `already_completed` 分岐（`collection_uploader.py:273-282`）。**ただし `failed` 状態からの再実行は新規 insert になる**（`_resumable_upload` 内で session URI を永続化していない、`upload_core.py:108-128`） | △ | **P0** video_id 重複の余地 |
+| videoup | `MASTER_OUTPUT` を `ffmpeg -y` で無条件上書き。既存版退避なし | 無 | P2（過去版が残らない）|
+| viewer-voice | レポート上書き | — | safe |
+| viewing-scene | レポート上書き | — | safe |
+| wf-new | workflow-state.json 初期化のみ。既存があればスキップ判定はコード次第（未確認） | △ | P2 |
+| wf-next | workflow-state.json の `status` で次ステップ自動判定 = resume 設計の核 | `wf-next/SKILL.md:8,60` | ○ |
+| wf-status | 読み取りのみ | — | safe |
+
+### 3.2 仮説検証
+
+**H1: `loop-video` 再実行で Veo 二重課金**
+**結論: 確認済み（P0）**。`generate_loop_video.py:59-67` は既存 `loop.mp4` を `loop-v{n}.mp4` に rename するだけで skip しない。`main()` は `generate_loop_video()` を無条件で先行呼び出し（`:160`）、その後にだけ `--smooth` 経由で `smooth_loop()` を呼ぶ。**`--smooth` 単独で「Veo は呼ばずローカル ffmpeg 補正だけ」という経路はソース上に存在しない**。SKILL.md `:59` の「`--smooth` で再実行」案内は **Veo 再課金を前提とした文言**であり、想定外コストになりうる。
+
+**H2: `comment_reply_history.json` 競合で二重返信**
+**結論: 実装的に防御済み（P3）。** `history.py:51-58` で `os.replace` による atomic save、`replier.py:243-245` で 1 件 insert ごとに save。並列実行は `max_replies_per_run` で抑制。残る理論的な窓は `comments.insert` 成功 → `history.save()` プロセス死。極めて稀だが「絶対に二重投稿しない」とは言えない。
+
+**H3: video-upload の resumable upload 再開で video_id 重複**
+**結論: 部分的に検証 — 重複の余地あり（P0）。** `upload_tracking.json` v3 は `complete_collection.status="completed"` 後の二重実行を防ぐ。しかし `_resumable_upload` 内で **`insert_request` を作り直して chunk を打ち直す**設計（`upload_core.py:67-78`）で、**resumable upload session URI を永続化していない**。
+- 結果: resumable upload 中断（ネットワーク断 / CLI Ctrl+C 等）→ 再実行は新規 `videos().insert()` になる
+- YouTube 側で前回 chunk が finalize 済みだった場合: video_id が **2 つ生成され、片方は description ない / private のまま死蔵**
+- finalize されていなかった場合: video_id は 1 つだけ生成され問題なし
+- どちらに転ぶかはネットワーク中断点に依存する
+
+**H4: video-analyze 再実行コスト**
+**結論: 確認済み（P1）。** `video_analyzer.py:79-104` の `analyze_url` は `save_json()` で `<video_id>.json` を上書きするだけ。既存ファイル skip ロジックなし。CLI `_run_analysis` も `target` ループの先頭で skip 判定をしていない（`video_analyze.py:243-261`）。`--top 5` を 2 回叩けば 10 動画分の Gemini API call が課金される。
+
+**H5: lyria 再実行コスト**
+**結論: 否定 — resume 設計（safe）。** `generate_lyria_master.py:137-138` で `seg_path.exists()` ガード。
+
+**H6: masterup 再実行で `master.{mp3,wav}` が上書きされる**
+**結論: 確認済み（P2）。** `generate_master.py:220-256` は `ffmpeg -y` で出力を無条件上書き。ローカル ffmpeg なので二重課金ではないが、ユーザーが過去版を保護したい場合の退避は **呼び出し側の責任**。SKILL.md `:100-118` に注意書きなし。
+
+---
+
+## 4. 観点 3.4 — リトライ・バックオフ・quota 例外
+
+### 4.1 retry 装着マトリクス
+
+| 対象 | リトライ | バックオフ | 上限 | 429 / quota |
+|---|---|---|---|---|
+| `upload_core._resumable_upload` `:108-128` | ○ | ○ `2^attempt` 秒（`upload_policy.py:53`）| 5 回 | × **429 は `RETRYABLE_HTTP_STATUSES = {500,502,503,504}` に含まれず即 abort**（`upload_policy.py:14,47-50`）|
+| `image_provider/gemini.py:57-110` | ○ | ○ `RETRY_BACKOFF=(10,30,60)` | 3 回（`base.py:14`）| △ SAFETY/RECITATION のみ即 skip、他は全例外 retry |
+| `image_provider/openai.py:88-134` | ○ | ○ 同上 | 3 回 | △ ConfigError のみ即 raise、他は全例外 retry |
+| `lyria_client.generate_music` `:138-154` | × | — | 1（単発） | × `requests.RequestException` で None 返却 / response.ok 否なら None |
+| `generate_lyria_master._generate_one_segment` `:143-147` | ○ | ○ `min(30, 10 * attempt)` | `--max-retries` (default 3) | △ 何でも retry（quota も） |
+| `veo_generator.generate_loop_video` `:46-115` | × | — | 1 | × ポーリング中断もタイムアウト 600 秒のみ |
+| `populate_scene_phrases._generate_with_retry` `:74-87` | ○ | ○ `_RETRY_BACKOFF_SEC` | `_RETRY_MAX` | △ 「一過性 429/503 に備えた」コメント明示 |
+| `analytics_collector` `:80-92` | × | — | — | × `raise` のみ |
+| `benchmark_collector` API call 一式 | × | — | — | × ServiceRegistry 経由で直 `.execute()` |
+| `playlist_manager` API call | × | — | — | × |
+| `comments-reply` `comments.insert` `:213-231` | × | — | — | × **HttpError を `errors[]` に積むだけ** |
+| `youtube_service.get_youtube` | n/a | — | — | n/a service factory のみ |
+| `competitor_discovery._search_channels` `:46-58` | × | — | — | × HttpError を `YouTubeAPIError` で raise |
+| `video_analyzer.analyze_url` `:79-95` | × | — | — | × Gemini API 単発呼び出し |
+
+### 4.2 評価
+
+- **YouTube Data API 系（playlist, benchmark, analytics, comments-reply, discover-competitors, channel-import 推定）は retry ゼロ**。429 / 503 で即失敗 → ユーザーが手動再実行 → quota 焼き続ける
+- **Gemini / OpenAI 画像生成は 3 回 retry**（reasonable、上限 backoff 60 秒）
+- **Lyria は client 単発 + CLI 側で 3 回 retry**（バックオフ最大 30 秒）
+- **Veo は client 単発、retry 一切なし**。タイムアウト 600 秒のみ
+- **upload_core が 429 を非リトライ扱い** は **P0 級**。quota 切れ寸前のチャンネルで `video-upload` を叩くと resume 不可能な失敗になる
+
+### 4.3 shell script の `set -euo pipefail` 装着
+
+- `gcp-bootstrap.sh` / `gcp-terraform-apply.sh` / `healthcheck.sh` / `notify.sh` / `swap_video.sh` / `worktree_sync.sh`: **`set -euo pipefail`** あり
+- `run-ffmpeg.sh:23`: `set -eu`（pipefail なし）
+- `generate_videos.sh`: **意図的に `set -e` なし**（`videoup/SKILL.md:59` で明記）+ trap で `PROGRESS_FILE` 掃除
+
+---
+
+## 5. 観点 3.5 — SIGINT / SIGTERM ハンドリング
+
+### 5.1 KeyboardInterrupt 捕捉箇所（grep 全件）
+
+| 対象 | 場所 | 挙動 |
+|---|---|---|
+| `auth/oauth_handler.py:295-296` | OAuth flow | UNIX 慣例 128+SIGINT=130 で exit |
+| `agents/collection_uploader.py:450-457` | daemon ループ | `Scheduler 停止` ログ出して終了 |
+| `agents/collection_uploader.py:514-515` | 手動実行 entry | `処理が中断されました` 出して exit |
+| `agents/youtube_auto_uploader.py:495` | CLI entry | KeyboardInterrupt 捕捉あり |
+| `scripts/playlist_status.py:94` | playlist status CLI | KeyboardInterrupt 捕捉 |
+| `scripts/playlist_manager.py:461` | playlist CLI | KeyboardInterrupt 捕捉 |
+| `utils/analytics_collector.py:140-141` | analytics CLI | `分析が中断されました` |
+| `utils/image_provider/composition.py:73-77` | confirm_cost 入力 | EOFError + KeyboardInterrupt で False |
+| `utils/image_provider/composition.py:245-250` | 上書き確認 | EOFError + KeyboardInterrupt で None |
+
+### 5.2 SIGINT が問題になる長時間処理
+
+| 対象 | 問題 |
+|---|---|
+| `veo_generator.generate_loop_video` `:64-77` | **POLL 中の Ctrl+C で例外発生**。`time.sleep(POLL_INTERVAL_SEC)` 中断 → スタックトレースで死亡。**Veo Operation は API 側で続行する**（クライアントの中断は API call をキャンセルしない）= **API は完走しクレジット消費、結果は受け取らない**（**最悪コスト**）|
+| `lyria_client.generate_music` `:138-141` | `requests.post` の `_TIMEOUT_SEC=300` 中の Ctrl+C で例外。tmp ファイル `.tmp` は `_save_audio_as_wav` 内 try/finally で unlink（`generate_lyria_master.py:111-113`）。**API call そのものは 1 リクエスト ≒ 完了 or 失敗で billing が確定するが、Ctrl+C はその後の保存処理だけを止める** |
+| `gemini.py:57-110` / `openai.py:88-134` | 画像生成 API call 中の Ctrl+C で例外。retry 待機 `time.sleep(backoff)` 中なら復帰しない |
+| `streaming swap_video.sh` | `terraform apply` 中の SIGINT → ローカル `terraform.tfstate` に partial state 書き込み。Vultr 側は API 完了済みリソースだけ残る = state lock or drift |
+| `generate_videos.sh` | `PROGRESS_FILE` は `trap EXIT` で掃除されるが、**ffmpeg 子プロセスが SIGINT で kill されると `MASTER_OUTPUT` が partial mp4 として残る**（unlink 無し） |
+| `live-clean` | unlink 中断時の手順なし。`SKILL.md` 未確認 |
+| `analytics-collect` | 取得中の中断で `data/analytics_*.json` の部分書き込みは無いはず（json.dump は 1 file write）。Reporting API の paged fetch 途中なら次回 raw_data 不整合の可能性 |
+
+### 5.3 評価
+
+- **shell script は trap / `set -e` でそれなりに固まっている**
+- **Python の長時間 API call で signal handler を入れている箇所は皆無**（`signal.signal` で grep して 0 件確認）
+- **Veo の SIGINT 中断は API 側継続のため最悪コスト**。Ctrl+C で「あ、止めよう」と思っても課金は走る
+- **terraform 系は中断時の rollback / unlock 案内が SKILL.md に無い**
+
+---
+
+## 6. skill × idempotency マトリクス（35 件まとめ・1 行判定）
+
+| # | skill | 2 回叩いたら | severity |
+|---|---|---|---|
+| 1 | alignment-check | レポート上書き、副作用なし | safe |
+| 2 | analytics-analyze | レポート上書き | safe |
+| 3 | analytics-collect | timestamp 別 JSON、毎回新規 | safe |
+| 4 | analytics-report | 表示のみ | safe |
+| 5 | audience-persona | レポート上書き | safe |
+| 6 | benchmark | freshness ガード + マージ書き | safe |
+| 7 | channel-direction | レポート上書き | safe |
+| 8 | channel-import | branding API 上書き（リスク残） | P2 |
+| 9 | channel-new | git scaffold | safe |
+| 10 | channel-research | レポート上書き | safe |
+| 11 | channel-setup | gcloud は idempotent、project create は --create ガード | safe |
+| 12 | channel-status | 読み取りのみ | safe |
+| 13 | collection-ideate | レポート上書き | safe |
+| 14 | comments-reply | history で skip、稀に窓 | P3 |
+| 15 | discover-competitors | quota 660 units を毎回焼く | **P1** |
+| 16 | live-clean | 削除済みは skip | safe |
+| 17 | loop-video | **Veo を毎回再課金** | **P0** |
+| 18 | lyria | 既存セグメント skip = resume | safe |
+| 19 | masterup | master.{mp3,wav} 無条件上書き | P2 |
+| 20 | metadata-audit | 読み取りのみ | safe |
+| 21 | playlist | 既存 ID + 既存 video skip | safe |
+| 22 | postmortem | レポート上書き | safe |
+| 23 | release | npm version 衝突 = エラー | safe |
+| 24 | pr | gh が 422 で阻止 | safe |
+| 25 | streaming swap | filemd5 不変なら no-op | safe |
+| 26 | suno | `planning.music` を上書き | safe |
+| 27 | thumbnail | -vN 自動採番 | safe |
+| 28 | thumbnail-compare | レポート上書き | safe |
+| 29 | video-analyze | **Gemini を毎回再課金** | **P1** |
+| 30 | video-description | Gemini 再課金 + descriptions.md 上書き | P2 |
+| 31 | video-upload | completed なら skip、failed→success で **video_id 重複の余地** | **P0** |
+| 32 | videoup | MASTER_OUTPUT 無条件上書き | P2 |
+| 33 | viewer-voice | レポート上書き | safe |
+| 34 | viewing-scene | レポート上書き | safe |
+| 35 | wf-new | 既存検出は要確認 | P2 |
+| - | wf-next | status で resume | safe |
+| - | wf-status | 読み取りのみ | safe |
+
+---
+
+## 7. 注意点・リスク
+
+### 7.1 P0 — 運用直撃
+
+| # | 件名 | 引用 | リスク |
+|---|---|---|---|
+| 1 | **`loop-video` 再実行は Veo を必ず再課金** | `generate_loop_video.py:59-67,160-163` + `SKILL.md:59` | 「`--smooth` で再実行」の案内が **API 再課金経路** に直結。Veo は 1080p 8 秒で **数百円 / 件オーダー** |
+| 2 | **`upload_policy.RETRYABLE_HTTP_STATUSES` に 429 が含まれない** | `upload_policy.py:14,47-50` | quota 切れ寸前で `video-upload` を叩くと resume 不可能な panic 終了 |
+| 3 | **Veo の Ctrl+C 中断は API 側継続でクレジット焼き** | `veo_generator.py:64-77` | 中断したつもりが課金は走る |
+| 4 | **`video-upload` 失敗 → 再実行で video_id 重複の余地** | `upload_core.py:108-128` resumable session URI 未永続化 | YouTube 側に死蔵 video_id（private / no description）が残る |
+| 5 | **`comments-reply` の `comments.insert` 成功直後 history.save 失敗の窓** | `replier.py:213-243` + `history.py:51-58` | 理論上の二重返信余地（極めて稀だが「絶対に出ない」とは言えない）|
+
+### 7.2 P1 — 重要
+
+| # | 件名 | 引用 |
+|---|---|---|
+| 6 | 35 skill 中 15 件で SKILL.md にリカバリ手順が**完全に**無い | §1.2 |
+| 7 | `video-analyze` の既存 JSON skip なし → 再実行で Gemini 再課金 | `video_analyzer.py:97-104` |
+| 8 | `discover-competitors` は実行ごとに search.list（quota 660 units）を毎回焼く | `competitor_discovery.py:46-67` |
+| 9 | YouTube Data API 系（playlist, benchmark, analytics, comments-reply, discover-competitors）の API call が **retry 一切なし** | §4.1 |
+| 10 | `live-clean` の SIGINT 時のリカバリ未記述（途中削除されたコレクション残骸）| SKILL.md 確認 |
+| 11 | `analytics-collect` の OAuth token 期限切れ時のリカバリ手順未記述 | SKILL.md 確認 |
+| 12 | `streaming swap_video.sh` の terraform apply 中断時の rollback / state unlock 案内なし | `swap_video.sh:18-122` |
+| 13 | `loop-video` のバックアップ `loop-v{n}.mp4` が無限増殖の可能性（rotation なし） | `generate_loop_video.py:59-67` |
+
+### 7.3 P2 — あれば良い
+
+| # | 件名 | 引用 |
+|---|---|---|
+| 14 | `smooth_loop` の `_smooth.mp4` tmp が CalledProcessError 経路で unlink されない | `veo_generator.py:242-244` |
+| 15 | `_compress_thumbnail` の `tempfile.NamedTemporaryFile(delete=False)` が ffmpeg 失敗時に残骸化する経路あり | `upload_core.py:179-201` |
+| 16 | `gcp-bootstrap.sh` の途中失敗で中途半端な GCP リソース残骸（API 有効化済み・billing 未紐付け 等） | `gcp-bootstrap.sh:36-103` |
+| 17 | `videoup/generate_videos.sh` が `MASTER_OUTPUT` を `ffmpeg -y` で無条件上書き（過去版退避なし） | `generate_videos.sh:160-180` |
+| 18 | `masterup` の `yt-generate-master` も `master.{mp3,wav}` を `ffmpeg -y` で無条件上書き | `generate_master.py:220-256` |
+| 19 | `channel-import` の二重実行で branding API が上書きする可能性（未検証）| `cli/channel_init.py` |
+
+### 7.4 P3
+
+| # | 件名 |
+|---|---|
+| 20 | suno `:314` の冪等性明示は他 skill のお手本になる |
+| 21 | benchmark の `freshness_days` ガードを SKILL.md に書き出すと運用者の認知負荷が下がる |
+| 22 | wf-next の resume 設計は強い。他 skill にも同じ書き方を展開できる |
+
+---
+
+## 8. 調査不可項目
+
+1. **Suno Web UI からの DL 中断時挙動**: Suno はブラウザ DL のみで API 提供なし。skill 側に記述は要るが、実装側調査は不能
+2. **Vertex AI / Lyria の 429 詳細**: 実際の rate limit 値は GCP Console 側で確認するしかなく、コード調査では出ない
+3. **YouTube Data API の resumable upload session URI の有効期間**: 公式ドキュメントが「week ほど有効」と書いている件は本リポジトリ側で永続化していないため意味なし
+4. **`channel-import` の branding push 冪等性**: `cli/channel_init.py` 全体を未読。skill 単体の責務が広い疑い
+5. **`live-clean` の挙動**: SKILL.md は読んだが実装エントリ（`cli/live_clean.py` 等）は本回未読
+6. **`wf-new` の workflow-state.json 重複初期化挙動**: SKILL.md `:80-81` の案内のみで実装未確認
+
+---
+
+## 9. 推奨アクション
+
+severity 付きで列挙。「修正は提案レベル」で、本 part の範囲はあくまで報告まで。
+
+| # | severity | アクション | 想定影響 |
+|---|---|---|---|
+| 1 | **P0** | `generate_loop_video.py` に既存 `loop.mp4` 検出 + `--force` フラグ追加。`--smooth` 単独で post-process のみ走らせる経路を追加 | Veo 再課金を防ぐ。SKILL.md `:59` の文言も修正必須 |
+| 2 | **P0** | `upload_policy.RETRYABLE_HTTP_STATUSES` に 429 を加える、もしくは別経路で **quota exhaustion path = 長い待機 + retry** を入れる | quota 切れ運用の resume を可能に |
+| 3 | **P0** | Veo / Lyria 等の長時間 API call に SIGINT handler を入れ、Ctrl+C 時に Operation cancel を呼ぶ。Veo は cancel API があるか要検証 | Ctrl+C で API 側も止める |
+| 4 | **P0** | `upload_core._resumable_upload` の session URI を `upload_tracking.json` に永続化し、再実行で session を再利用 | video_id 重複の根本対策 |
+| 5 | **P0** | `comments-reply` の `_post_reply` を **history.save → comments.insert** の順に変更する（または mark_replied を「送信予定」状態として先に書き込む）。コミット-ログ的に二段階にして window を消す | 二重返信を実装的に不可能化 |
+| 6 | **P1** | `video-analyze` に `<video_id>.json` 既存 skip + `--force` フラグ追加 | Gemini 再課金防止 |
+| 7 | **P1** | YouTube Data API call の共通 retry / backoff utility を新設（少なくとも 503 系）。`benchmark_collector` / `playlist_manager` / `comments-reply` / `discover-competitors` / `analytics_collector` / `channel_settings` を一括で乗せ換え | quota は焼くが少なくとも一過性 5xx で死なない |
+| 8 | **P1** | SKILL.md リカバリ手順テンプレートを定め、最低限「同コマンドで再実行 / 既存生成物の扱い（skip/上書き/採番）/ API 側残骸の対処」を 15 件の × skill に追記 | 運用負債の解消 |
+| 9 | **P1** | `loop-video` のバックアップに rotation を入れる（古い `loop-v{n}.mp4` を `loop-archive/` へ移動 or 上限を設ける） | ディスク無限消費の防止 |
+| 10 | **P1** | `live-clean` の SIGINT トラップを実装し、進捗 JSON で resume 可能にする | 途中削除されたコレクションの可視化 |
+| 11 | **P1** | `streaming swap_video.sh` の trap で `terraform force-unlock` 案内 + state ロック検出 | apply 中断時の運用負債解消 |
+| 12 | **P2** | `smooth_loop` の `_smooth.mp4` を try/finally で unlink | tmp 残骸防止 |
+| 13 | **P2** | `_compress_thumbnail` を try/finally に包む | 同上 |
+| 14 | **P2** | `generate_master` / `generate_videos.sh` の出力上書き前に「既存ファイル → `.prev.{mp3,mp4}` リネーム」を入れる（または `--force` ガード） | 過去版保護 |
+| 15 | **P2** | `gcp-bootstrap.sh` に `trap` で「部分作成済みリソース一覧をログ出力」を入れる | 中途半端な GCP project の発見性向上 |
+| 16 | **P3** | `suno:314` 風の「冪等性明示」を SKILL.md テンプレに含める | 認知負荷の低減 |
+| 17 | **P3** | `benchmark` の `freshness_days` ガードを SKILL.md に明記 | 運用者のメンタルモデル整備 |
+
+---
+
+## 10. 既存レポートとの主要差分（再走の意義）
+
+| 項目 | 既存レポート | 本レポート |
+|---|---|---|
+| ×件数 | 21 件 | 15 件（4 件を △ に補正） |
+| benchmark | × | △（コード側 freshness ガードを発見） |
+| suno | × | △（`SKILL.md:314` で冪等性明示を発見） |
+| alignment-check | × | △（`:85-94` で再実行スキル表を発見） |
+| videoup | × | △（`:59` の `set -e` 不使用は意図的設計と判明）|
+| discover-competitors | △ | **P1 quota 焼き**として再分類（660 units/run 明示） |
+| comments-reply window | 1 行言及 | P0 で本格的に推奨アクション化（コミットログ的二段階） |
+| skill × idempotency 1 行マトリクス | なし | 35 件分新設 |
+| videoup `set -e` 取扱い | 異質と評価 | 意図的設計と再評価 |
+| loop-video バックアップ無限増殖 | 未検出 | 新規検出 (P1) |
+| live-clean SIGINT | 未検出 | 新規検出 (P1) |
+| streaming swap rollback | 未検出 | 新規検出 (P1) |
+
+---
+
+## 11. 次ステップへの引き継ぎ
+
+- 本レポートは P0 5 件 / P1 8 件 / P2 6 件 / P3 3 件 を提示。実装はしない（part 制約）
+- analyze step / supervise step では **P0 のうち #2 (upload_core 429) と #4 (resumable URI) は密接に関連** している点に注意。同じ箇所を 2 度触ることになる
+- 推奨 #5（comments-reply の二段階コミット）は仕様変更を伴うため、設計レビューが必要
+- 既存レポート上書き済み。差分は §10 に集約

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/03-data-billing-cost-control.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/03-data-billing-cost-control.md
@@ -1,0 +1,269 @@
+# 観点 4: 課金 API コスト制御 / 安全弁 調査結果
+
+**調査日**: 2026-05-18
+**担当**: dig.part-a-failure-cost (Part A-2)
+**対象**: `.claude/skills/**`（35 skill）+ `src/youtube_automation/**` 実装
+**作業ディレクトリ**: `/Users/mba/02-yt/takt-worktrees/20260518T0905-372-issue-372-chore-skills-sukiru/`
+
+---
+
+## 4.1 課金 API × skill マトリクス
+
+skill から呼ばれる API を整理する。実装ファイルを辿って判定した。
+
+| skill | Vertex Veo | Vertex Gemini | Vertex Lyria | OpenAI Image | Suno (Web) | YouTube Data v3 | YouTube Analytics | Vultr | Google Drive | その他 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| alignment-check | — | — | — | — | — | — | — | — | — | ローカル分析のみ |
+| analytics-analyze | — | — | — | — | — | — | — | — | — | ローカル分析のみ |
+| analytics-collect | — | — | — | — | — | ○ | ○ | — | — | — |
+| analytics-report | — | — | — | — | — | — | — | — | — | ローカル表示のみ |
+| audience-persona | — | — | — | — | — | — | — | — | — | ローカルのみ |
+| benchmark | — | — | — | — | — | ○ | — | — | — | — |
+| channel-direction | — | — | — | — | — | — | — | — | — | ローカルのみ |
+| channel-import | — | — | — | — | — | ○ | — | — | — | branding pull |
+| channel-new | — | — | — | — | — | △ | — | — | — | mostly local |
+| channel-research | — | — | — | — | — | — | — | — | — | ローカル分析 |
+| channel-setup | — | — | — | — | — | ○ | — | — | — | GCP API (`aiplatform`, `youtube`, `billing`) — 有料化トリガ |
+| channel-status | — | — | — | — | — | ○ | — | — | — | — |
+| collection-ideate | — | △ | — | △ | — | — | — | — | — | thumbnail プレビュー画像生成（gemini or openai） |
+| comments-reply | — | — | — | — | — | ○ | — | — | — | comments.insert + commentThreads.list |
+| discover-competitors | — | — | — | — | — | ○ | — | — | — | search.list × keyword 数 |
+| live-clean | — | — | — | — | — | — | — | — | — | ローカル削除のみ |
+| loop-video | ○ | — | — | — | — | — | — | — | — | **Veo 3.1 1080p 8sec / call** |
+| lyria | — | — | ○ | — | — | — | — | — | — | N セグメント call（target_duration から自動算出） |
+| masterup | — | — | — | — | △ Web | — | — | — | — | DL のみ。Suno UI 課金は外で発生 |
+| metadata-audit | — | — | — | — | — | ○ | — | — | — | videos.list, playlists 系 |
+| playlist | — | — | — | — | — | ○ | — | — | — | playlists.insert/list, playlistItems |
+| postmortem | — | — | — | — | — | — | — | — | — | ローカル分析 |
+| streaming | — | — | — | — | — | △ | — | ○ | — | Vultr 月額 + 帯域 + ffmpeg |
+| suno | — | — | — | — | △ Web | — | — | — | — | プロンプト生成のみ。Suno UI 課金は外 |
+| thumbnail | — | ○ | — | ○ | — | — | — | — | — | 画像生成 |
+| thumbnail-compare | — | — | — | — | — | — | — | — | — | ローカル分析 |
+| video-analyze | — | ○ | — | — | — | — | — | — | — | Gemini 動画解析 |
+| video-description | — | △ | — | — | — | — | — | — | — | scene_phrases 翻訳で Gemini 経由の余地 |
+| video-upload | — | — | — | — | — | ○ | — | — | — | videos.insert (1600 units/upload) + thumbnails.set |
+| videoup | — | — | — | — | — | — | — | — | — | ffmpeg のみ。API 課金なし |
+| viewer-voice | — | — | — | — | — | ○ | — | — | — | commentThreads.list |
+| viewing-scene | — | — | — | — | — | — | — | — | — | ローカル分析 |
+| wf-new | — | △ | — | — | — | — | — | — | — | populate_scene_phrases 経由 Gemini |
+| wf-next | — | — | — | — | — | — | — | — | — | オーケストレーターのみ。子 skill が API を叩く |
+| wf-status | — | — | — | — | — | — | — | — | — | ローカル参照のみ |
+
+**集計（API 種別）**:
+- **YouTube Data v3 利用 skill**: 13 件
+- **Vertex AI Veo 利用 skill**: 1 件（`loop-video`）
+- **Vertex AI Gemini 利用 skill**: 4 件（`thumbnail`, `video-analyze`, `collection-ideate`, `wf-new` 経由）
+- **Vertex AI Lyria 利用 skill**: 1 件（`lyria`）
+- **OpenAI Image 利用 skill**: 2 件（`thumbnail`, `collection-ideate`）
+- **Vultr 課金**: 1 件（`streaming`）
+- **Suno (Web UI)**: 2 件（`suno`, `masterup`）— skill 経由の課金トリガではないが連動
+
+**Google Drive API は CLAUDE.md / pyproject に記述あるが、コード内で使われている形跡なし**（`mcp__claude_ai_Google_Drive__authenticate` は外部 MCP）。
+
+---
+
+## 4.2 quota / コスト見積もりの skill 内記載
+
+| skill | API call 数記載 | 推定コスト記載 | quota 消費記載 | 出典 |
+|---|---|---|---|---|
+| `discover-competitors` | ○ 660 units / 実行 | × | ○ `10,000/日 quota の 6.6%` | `.claude/skills/discover-competitors/SKILL.md:116-121` |
+| `video-upload` | ○ `2 × 1,600 = 3,200 ユニット` (single_release JP+EN) + plan 出力で `84+100=184` 表示 | × | △ | `.claude/skills/video-upload/SKILL.md:46` + `agents/collection_uploader.py:415-417` |
+| `thumbnail` | △ 最大 3 試行込み | △ skill-config `cost_per_image_usd` 指定時のみ | × | `.claude/skills/thumbnail/SKILL.md:187` |
+| `collection-ideate` | △ `count` 枚（preview.candidate_count） | △ skill-config `cost_per_image_usd` 指定時のみ | × | `.claude/skills/collection-ideate/SKILL.md:113-139` |
+| `streaming` | × | △ `月間 1.16 TB（2 TB プランの 58%）` 帯域記載 | — | `.claude/skills/streaming/SKILL.md:99` |
+| `lyria` | △ N セグメント = `ceil((target+padding)*60/184)` | × | △ 「Vertex AI の Lyria クォータ（プロジェクト単位）は有限。429 が出る」 | `.claude/skills/lyria/SKILL.md:200` |
+| `loop-video` | × | × | × | — |
+| `video-analyze` | △ 「動画間に delay_sec 秒スリープ」 | × | × | `.claude/skills/video-analyze/SKILL.md:62-67` |
+| `analytics-collect` | × | × | × | — |
+| `benchmark` | × | × | × | — |
+| `comments-reply` | × | × | × | — |
+| `playlist` | × | × | × | — |
+| `metadata-audit` | × | × | × | — |
+| `channel-status` | × | × | × | — |
+| `channel-import` | × | × | × | — |
+| `viewer-voice` | × | × | × | — |
+
+### 集計
+
+- **API call 数を明示している skill**: 5/35
+- **コスト見積もり（ドル単位）を明示している skill**: 0（`cost_per_image_usd` 指定時のみ CLI で表示）
+- **YouTube Data API quota 消費を明示している skill**: 3（`discover-competitors`, `video-upload`, ぼんやり `lyria`）
+
+**重大な漏れ**: `benchmark` `analytics-collect` `metadata-audit` などは **複数ページ取得**で **数百〜数千 units** を消費する可能性があるのに記載なし。`channel-import` や `playlist --init` も同様。
+
+---
+
+## 4.3 dry-run / preview の有無
+
+SKILL.md / CLI フラグから網羅的に調査。
+
+| skill / CLI | dry-run / preview フラグ | 出典 |
+|---|---|---|
+| `comments-reply` | `--dry-run` / `--apply` 必須・排他 | `.claude/skills/comments-reply/SKILL.md:53-58` |
+| `playlist` | `--dry-run` フラグ（init / assign / clean-deleted 全モード） | `.claude/skills/playlist/SKILL.md:28-30,50-54` |
+| `channel-setup` (`yt-channel-settings`) | `pull` は dry-run（読み取りのみ）、`push --dry-run` あり | `.claude/skills/channel-setup/SKILL.md:90,96` |
+| `channel-setup` (`gcp-bootstrap.sh`) | `--dry-run` あり | `.claude/skills/channel-setup/references/gcp-bootstrap.md:41` |
+| `video-upload` | `--plan` でスケジュール計算（API call なしのドライラン） | `.claude/skills/video-upload/SKILL.md:90` + `agents/collection_uploader.py:400-417` |
+| `streaming` (terraform) | `terraform plan` で apply 前確認 | `.claude/skills/streaming/SKILL.md:55,73` |
+| `loop-video` | `-y` / `--yes` で確認 skip、未指定なら `[y/N]` プロンプト | `scripts/generate_loop_video.py:91,140-144` |
+| `thumbnail` (`yt-generate-image`) | `-y` で確認 skip、未指定なら `confirm_cost` で y/N | `scripts/generate_image.py:59,148-149` + `image_provider/composition.py:58-78` |
+| `lyria` | **dry-run なし**。`yt-generate-lyria-master` は y/N プロンプトもなし | `scripts/generate_lyria_master.py` |
+| `video-analyze` | **dry-run なし**。確認プロンプトもなし | `scripts/video_analyze.py` |
+| `benchmark` | **dry-run なし** | — |
+| `analytics-collect` | **dry-run なし** | — |
+| `metadata-audit` | **dry-run なし** | — |
+| `channel-status` | 読み取り専用なので不要 | — |
+| `discover-competitors` | **dry-run なし** | — |
+| `live-clean` | **dry-run なし**（大容量ファイル削除 = 復旧不能） | — |
+
+### 集計
+
+- **dry-run / preview あり**: 8/35（22.9%）
+- **y/N confirm あり**: 2/35（loop-video, thumbnail）
+- **どちらもなし**: 25/35（**71%**）
+
+### 重大な発見
+
+- **lyria は確認プロンプトなしで N セグメントの Lyria API を一気に叩く**。`--target-duration 90` × `184sec/seg` = 約 30 セグメント呼び出しが無確認で走る。Lyria のクォータが小さい場合即 429 で残骸セグメントだけ残る
+- **video-analyze は `--top 5` でも 5 動画分の Gemini API を無確認で叩く**。`delay_sec=10` のスリープのみで止まれない
+- **live-clean は SKILL.md を読めない (read-only protected paths) が、CLI に dry-run があるかは要追加検証**
+
+---
+
+## 4.4 ループ・再帰実行のガード
+
+| パターン | 場所 | ガードの有無 |
+|---|---|---|
+| `/loop` skill | Claude Code 組み込み（intervalで自動再実行） | **skill 側のガードなし** — 利用者が `/loop 5m /lyria <theme>` を打ったら 5 分ごとに Lyria を再課金 |
+| `analytics-collect` × `/loop` | 仕様上ありえる組み合わせ | YouTube Analytics は read-only なのでコスト面はマシだが quota 1日10000 を 5 分毎に叩くと数時間で枯渇 |
+| `benchmark` × `/loop` | 仕様上ありえる | benchmark 1 回数百 units × 5 分毎 = quota 焼き切り |
+| `collection_uploader.run_automated_schedule` daemon mode | `agents/collection_uploader.py:440-457` | 1 日 1 回チェック (`day1_time`)。**daemon 内 `while True: ... time.sleep(60)`** で 60 秒ループ。schedule ライブラリでチェックするので暴走しない |
+| `lyria` 1 実行内のセグメントループ | `generate_lyria_master.py:368-381` | for ループで N 回。**N は target_duration から自動算出**で hard cap なし。`target_duration=180 (3 時間)` を指定すると N=59 回 Lyria call |
+| `loop-video` | 1 回 1 動画 | 単発。`/loop` と組み合わせなければ問題なし |
+| `video-analyze` `--top` | 引数で上限指定可 | `--top 20` 等の上限はある（デフォルト 5） |
+
+### 評価
+
+- **skill 自体に hard limit を持つものは少ない**。引数で `--top N` / `--limit N` を指定する設計
+- **`/loop` skill と組み合わせる場合の cost guard は皆無**。AI agent が「自動で 5 分ごとにベンチマーク更新」と言い出したら止まらない
+- **lyria の N 自動算出には上限なし**。極端な target_duration を指定すると数十回 API call
+
+---
+
+## 4.5 失敗時の課金リスク（中間生成物だけ残ってコストだけ発生）
+
+### 検証結果
+
+| API | 失敗 → 課金パターン |
+|---|---|
+| Veo 3.1 (loop-video) | **生成成功 → ffmpeg `strip_audio` 失敗 → return ok だが音声残**。生成後 `output_path.write_bytes(video_bytes)` で書き込み後に strip するので最悪 ffmpeg 失敗で音声残るがコストは 1 回分。**Ctrl+C 中断時は API 完走 → クライアント側でレスポンス破棄**で最悪パターン |
+| Vertex Gemini (thumbnail / video-analyze) | API call は単発成功 → ローカル PIL / JSON パース失敗で `provider.generate()` が success=False を返す経路あり (`image_provider/gemini.py`)。`raise` ではないので **画像生成料金は発生、ファイルは保存されず**のケースあり |
+| Lyria | `generate_music()` が None 返却 → 上位で retry。1 セグメント生成成功 → WAV 変換失敗 → tmp 残るが try/finally で掃除。**1 セグメントの料金 = `1 song` 課金は確定**でファイルだけ残らないパターン |
+| OpenAI Image | 同様 |
+| YouTube Data resumable upload | 前述 3.3 の通り session URI 永続化なしのため、resumable upload 失敗 → CLI 再実行で **新規 insert** = quota 二重消費（1600 units × 2） |
+
+### H1 検証（Veo 3.1 が長尺で課金される）
+
+- **検証済（部分的）** — `veo_generator.py:23` で `MAX_POLL_SEC = 600` (10 分)。Veo 3.1 fast は 8 秒動画固定 (`scripts/generate_loop_video.py` の `--duration_seconds` デフォルト 8)。**「長尺で課金」は 8 秒固定モデルなので発生しない**。が、**duration_seconds パラメータは外から渡せる**（`veo_generator.generate_loop_video()` の引数 `duration_seconds: int = 8`）。CLI から `--duration` 等で渡す経路は現状なし（`generate_loop_video.py` の argparse には未定義）。**ただし誰かが直接 Python から呼び出すと長尺指定で課金可**
+
+### H2 検証（再生成ガードが弱く再実行で二重課金）
+
+- 観点 3.3 で詳述: **`loop-video` 検証済、`lyria` 否定**
+
+### 重大な発見（cost-only 失敗パターン）
+
+1. **Veo の Ctrl+C 中断** — クライアント側はキャンセルしても API 側は完走。`/loop-video` の y/N 確認後にユーザーが意図せず Ctrl+C を打つと「課金されたが結果無し」
+2. **Lyria の N セグメントループ中断** — `for i in range(1, n + 1)` の途中で Ctrl+C すると、完成済みセグメントは保存されるが残りは未生成。「これまでの料金は確定、結果は半端」。ただし再実行で resume するので「捨て金」にはならない
+3. **resumable upload 失敗時の quota 二重消費** — videos.insert が quota 1600 units で、失敗→再実行で 3200 units 消費しても video は 1 本だけ完成
+
+---
+
+## 4.6 監視・通知・コストレポート
+
+### `yt-cost-report` の実態
+
+- **存在**: ○ `src/youtube_automation/cli/cost_report.py` + `pyproject.toml:49` で entry point 登録
+- **対象範囲**: image / video / audio の 3 カテゴリのみ（`cost_tracker.py:38-43`）
+- **記録経路**:
+  - `image_provider/gemini.py:83-91` → `log_image_cost`
+  - `image_provider/openai.py` → 同上
+  - `veo_generator.py:102-114` → `cost_tracker.log_generation("video", ...)`
+  - `generate_lyria_master.py:180-186` → `cost_tracker.log_generation("audio", ...)`
+- **記録されない**:
+  - YouTube Data API 系（playlist / benchmark / analytics / video-upload / comments-reply / metadata-audit / channel-status / channel-import / discover-competitors / viewer-voice）— quota units の集計なし
+  - Vultr 帯域 / 月額 — `yt-stream-bandwidth` 別 CLI
+  - 動画解析（Gemini text モデル）— `video-analyze` は cost_tracker を呼んでいない（`scripts/video_analyze.py` に `cost_tracker` import なし）
+  - `populate_scene_phrases` の Gemini 翻訳 — cost_tracker なし
+
+### コスト記録の質
+
+- `estimated_cost_usd` は **常に `None`**（`cost_tracker.py:18` のコメント "Issue #132 で `estimated_cost_usd` は新規エントリで `null` 固定"）
+- **件数ベースの集計のみ**で、ドル換算は GCP Cloud Console > Billing 任せ
+- `yt-cost-report` は「今月 N 件、累計 M 件」を出すだけ。**$ 単位の合計は出ない**
+
+### アラート
+
+- **コスト超過アラートなし**。`cost_tracker.print_last_report()` が呼ばれるが、しきい値判定なし
+- streaming のみ `yt-stream-bandwidth --check-threshold` で 80% 超過アラート（Discord webhook）
+- YouTube Data API quota 残量を可視化する CLI なし
+
+### H5 検証（streaming の VPS 死活監視欠如で課金継続）
+
+- **否定** — `healthcheck.sh` が cron 5 分間隔で動き、Discord に anomaly 通知（`.claude/skills/streaming/SKILL.md:78-90`）。SKILL.md で **「VPS が消えるまで課金が続く」と明示** + `terraform destroy` 案内あり (`:120-127`)
+- **ただし** Vultr 側で誤って API key を漏洩すると別の VPS が立つリスクは別問題（観点 5 担当）
+
+---
+
+## 主要発見サマリー（観点 4）
+
+### P0（運用直撃の最重要）
+
+1. **YouTube Data API の quota 消費が `yt-cost-report` で可視化されない**。`analytics-collect` `benchmark` `playlist --init` 等が無自覚に quota を焼き切る可能性
+2. **`lyria` `video-analyze` `analytics-collect` `benchmark` などに dry-run / 事前見積もり表示なし**。確認なしで API call が走る
+3. **Veo の Ctrl+C 中断 = API は完走するが結果は捨てられる**（cost-only failure）。`loop-video` の y/N プロンプト後の中断で発生
+
+### P1（重要）
+
+4. **`/loop` skill と課金 skill の組み合わせに hard limit なし**。`/loop 5m /lyria` のような誤用を防ぐ仕組みなし
+5. **lyria の N セグメント自動算出に上限なし**。極端な `target_duration` で大量 call
+6. **resumable upload session URI 未永続化** → 失敗時に quota 二重消費（前述 3.3 と連動）
+7. **cost_tracker の `estimated_cost_usd` 常に None**。`yt-cost-report` は件数のみで予算管理に使えない
+
+### P2（あれば良い）
+
+8. SKILL.md にコスト・quota 記載がある skill は 5/35（14%）
+9. video-analyze は cost_tracker を呼んでいない（Gemini 動画解析のコストが集計から漏れる）
+10. populate_scene_phrases の Gemini call も cost_tracker から漏れる
+
+---
+
+## 既知リスク仮説の検証マトリクス（観点 4 関連）
+
+| ID | 仮説 | 検証結果 | 出典 |
+|---|---|---|---|
+| H1 | Veo 3.1 が長尺で課金される | **部分検証** — CLI からの長尺指定は無いが内部 API は受け付ける | `veo_generator.py:34-58` |
+| H2 | `/loop-video` `/lyria` の再生成ガードが弱く再実行で二重課金 | **`/loop-video` は検証、`/lyria` は否定** | `scripts/generate_loop_video.py:51-67` vs `generate_lyria_master.py:137-138` |
+| H5 | streaming の VPS 死活監視欠如で課金継続 | **否定** — healthcheck + destroy 案内あり | `.claude/skills/streaming/SKILL.md:78-127` |
+
+---
+
+## 調査不可項目
+
+- **Suno Web UI のクレジット消費単価**: Suno 側の話なので調査不可（プロンプト生成のみのため skill 経由では課金されない）
+- **YouTube Data API quota の実時間残量**: API で取得する手段が存在しない（Google Cloud Console > APIs & Services > Quotas で手動確認のみ）
+- **OpenAI Image の正確な単価**: skill-config の `cost_per_image_usd` で各自指定する設計
+- **Vertex AI Lyria の per-call 単価**: 公開価格表での確認が必要。今回は時間制約で WebFetch 未実施
+
+---
+
+## 推奨
+
+1. **`yt-cost-report` を拡張し、YouTube Data API quota 消費見積もりを記録する**（最高優先）
+   - `playlist` `benchmark` `analytics-collect` `video-upload` `discover-competitors` 各 CLI で実行時に消費 units を `cost_tracker.log_generation("youtube_quota", ...)` 風に記録
+   - 1 日累計 + 残量警告（10000 - 累計 < 1000 で警告）
+2. **`/loop` 系の自動ループに対する課金 skill のブラックリスト** または **「課金 skill には警告」を出す仕組み**
+3. **lyria に `--max-segments N` を追加し、上限超過時は明示確認**
+4. **video-analyze / discover-competitors に dry-run + 件数事前表示**
+5. **Veo / Lyria に signal handler を入れ、Ctrl+C で API cancel を試みる**（returns money かは API 側依存）
+6. **cost_tracker.log_generation で `estimated_cost_usd` を null 固定する仕様を再評価**。せめて skill-config で `cost_per_call_usd` 指定時は記録する
+7. **SKILL.md の `## API コスト` セクションを必須化**（discover-competitors のような表記をテンプレ化）

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/04-data-billing-cost.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/04-data-billing-cost.md
@@ -1,0 +1,225 @@
+# 課金 API コスト暴走ガード監査 (Part A-2 / dig.part-a2-billing-cost)
+
+**調査日**: 2026-05-18
+**スコープ**: 失敗→自動リトライ→quota 焼き切り / 無限ループ生成 / 想定外の高単価モデル選択 — の 3 軸に絞った金銭被害リスク
+**前提除外**: PR #367 で実施済の汎用化・整合性観点は再検出しない
+**対象**: `.claude/skills/**` (35 skill) + `src/youtube_automation/**` 実装
+
+---
+
+## 1. severity 別サマリー
+
+| severity | 件数 | 内訳 |
+|---|---|---|
+| **P0** (1 回で 100 USD 超 / 無限ループ) | **0** | — |
+| **P1** (高単価モデル選択 / quota 数千〜数万 unit 焼き) | **3** | F-1 / F-2 / F-3 |
+| **P2** (リトライ設計のリスク / バッチ上限のなさ) | **3** | F-4 / F-5 / F-6 |
+| **P3** (ドキュメント / 観測性) | **3** | F-7 / F-8 / F-9 |
+
+P0 該当はゼロ。Veo / Lyria 等の生成系は **明示的なユーザー確認プロンプト**（`-y` / `--yes` フラグ）と **試行回数キャップ**（Gemini=3 / Lyria=4 / 動画アップ=5）が一通り入っており、現状で「1 回 100 USD 超を焼く穴」は確認できなかった。リスクは P1 以下の「条件付き」案件に集中する。
+
+---
+
+## 2. 課金 API × skill マッピング表
+
+凡例: ◎=本命呼び出し / ○=補助呼び出し / △=条件付き / 課金=月額固定 or 従量
+
+| skill | Veo (動画/秒) | Gemini (text+vision) | Lyria (音楽/song) | OpenAI Image | YouTube Data v3 (10k unit/day) | YouTube Analytics (別 quota) | Vultr VPS (月額+帯域) | 備考 |
+|---|---|---|---|---|---|---|---|---|
+| loop-video | ◎ | — | — | — | — | — | — | 1 ジョブ = 8 秒動画 1 本 |
+| lyria | — | — | ◎ | — | — | — | — | N セグメント (N = ⌈(target_min + padding) × 60 / 184⌉) |
+| thumbnail | — | ◎ (画像生成) | — | △ (provider 切替) | — | — | — | provider=gemini default |
+| video-analyze | — | ◎ (動画解析) | — | — | — | — | — | --top N で件数指定 |
+| video-description | — | ◎ (テキスト生成) | — | — | — | — | — | text-only |
+| metadata-audit | — | — | — | — | ○ | — | — | videos.list 1 unit/件 |
+| benchmark | — | △ (サムネ分析、`--no-thumbnails` で off) | — | — | ◎ | — | — | search/playlist/videos.list |
+| discover-competitors | — | — | — | — | ◎ (660 unit/run) | — | — | search.list × keywords |
+| video-upload | — | — | — | — | ◎ (1,600 unit/upload) | — | — | resumable upload |
+| analytics-collect | — | — | — | — | ○ (動画 listing) | ◎ | — | reports.query 多発 |
+| analytics-analyze | — | — | — | — | — | — | — | ローカル分析のみ |
+| analytics-report | — | — | — | — | — | — | — | ローカル表示のみ |
+| comments-reply | — | — | — | — | ◎ (commentThreads.list + comments.insert) | — | — | dry-run 既定 |
+| channel-status | — | — | — | — | ○ | — | — | channels.list mine |
+| channel-import | — | — | — | — | ○ | — | — | branding pull |
+| channel-setup | — | — | — | — | ○ | — | — | branding push |
+| collection-ideate | — | △ (preview 画像生成) | — | △ | — | — | — | thumbnail provider に委譲 |
+| streaming | — | — | — | — | △ (archive 件数確認) | — | ◎ | $10/月 + 2TB/月 |
+| postmortem / alignment-check / channel-research / channel-direction / audience-persona / viewer-voice / viewing-scene / thumbnail-compare / playlist / wf-* | — | — | — | — | △〜○ | △ | — | 既存 JSON の再利用が中心 |
+
+---
+
+## 3. 観点別の詳細所見
+
+### 3.1 課金 API 呼び出し点棚卸し（観点 4.1）
+
+| 呼び出し点 | ファイル | 1 skill 実行の最悪リクエスト数 |
+|---|---|---|
+| Veo 3.1 動画生成 | `src/youtube_automation/utils/veo_generator.py:47` (`generate_videos`) | **1 ジョブ** = 8 秒 (`veo_generator.py:23 MAX_POLL_SEC=600`)。skill 1 回 = 1 動画 |
+| Veo operations.get poll | `veo_generator.py:76` | 5 秒 × 最大 120 回 = 最大 120 poll/ジョブ。poll は無料 (Long-running operation の get) |
+| Lyria interactions | `src/youtube_automation/utils/lyria_client.py:139` | **N セグメント** (skill_config の `duration_padding_min=3` + `audio.target_duration_min`)。90 分マスター = 30 セグメント |
+| Lyria リトライ | `src/youtube_automation/scripts/generate_lyria_master.py:143` | セグメントあたり最大 **`max_retries + 1` = 4 回**（既定）。失敗ループは `wait_sec = min(30, 10 * attempt)` で挟む |
+| Gemini Image (Nano Banana) | `src/youtube_automation/utils/image_provider/gemini.py:64` | 1 thumbnail = 最大 **3 試行**（`RETRY_MAX=3`）。SAFETY/RECITATION は即時 fail（リトライしない、good） |
+| Gemini Text/Video | `populate_scene_phrases.py:74` / `video_analyzer.py:79` | 1 動画あたり 1 リクエスト + `delay_sec=10`。`video_analyze.py:255` で APIError は failures に積み次へ（**リトライしない、good**） |
+| Gemini benchmark サムネ分析 | `benchmark_collector.py:580` | 動画 × チャンネル数。`scan_recent=50` × `min_views=10000` 通過分のみ。`delay_sec=5` |
+| OpenAI Images | `src/youtube_automation/utils/image_provider/openai.py:89-103` | 1 thumbnail = 最大 **3 試行**。`batch=1` default。`quality=high` default ← P1 リスク |
+| YouTube Data search.list | `competitor_discovery.py:48` / `streaming/archive_counter.py:64` | search.list = **100 unit/call**。discover-competitors は `keywords × per_keyword_results`、streaming archive-check は月内ページング |
+| YouTube Data upload | `upload_core.py:74` (videos().insert) | 1 upload = **1,600 unit**。MAX_RETRY_ATTEMPTS=5（5xx のみ）`upload_policy.py:13` |
+| YouTube Data benchmark | `benchmark_collector.py:111` / `162` / `196` | channels.list (1 unit) + playlistItems.list (1 unit) × ページ + videos.list (1 unit) × ⌈scan_recent/50⌉。default scan_recent=50 → 3 API call/channel |
+| Analytics reports.query | 各 Mixin（`channel_analytics.py:68` 他多数） | Analytics は別 quota（720 req/min 標準）。`strategic_analytics.py:416` で **ThreadPoolExecutor(max_workers=8)** 並列実行 |
+| Vultr bandwidth | `streaming/vultr_bandwidth.py:41` | 月次レポート/閾値チェックで 1 call。Vultr API 自体は無料 |
+| Vultr VPS | `infra/terraform/streaming/variables.tf:22` (`vc2-1c-2gb`) | **$10/月固定 + 2TB 帯域**。`terraform destroy` 必須 |
+
+### 3.2 単価・quota の前提情報（観点 4.2）
+
+`.env`/`docs/`/`README` を grep 済み。**ハードコード単価は撤廃済み**（`composition.py:174` のコメント「PRICING フォールバックは撤廃済み」 / `cost_tracker.py:9-10` 「Issue #132 で `estimated_cost_usd` は新規エントリで `null` 固定」）。
+
+- Veo 3.1 / Lyria 3 / Gemini 3.1 / gpt-image-2 の **2026-05 時点の USD 単価は本リポジトリには存在しない**。`thumbnail/config.default.yaml:103-105` で `cost_per_image_usd: null` がコメントアウトされているのみ。実コストは GCP Cloud Console > Billing で確認する設計（`cost_tracker.py:203 _GCP_BILLING_HINT`）。
+- **YouTube Data API quota**（2026-05-18 時点で WebFetch せず実装側の引用を採用）:
+  - search.list = 100 unit (`discover-competitors/SKILL.md:118`)
+  - videos.insert = 1,600 unit (`video-upload/SKILL.md:47` の "API クォータ: 2 × 1,600 = 3,200 ユニット"）
+  - その他 list = 1 unit
+  - 日次 quota = 10,000 unit（プロジェクト既定）
+- **Vultr プラン定数**: `streaming/__init__.py:10-22`
+  - MONTHLY_QUOTA_GB = 2048
+  - THRESHOLD_RATIO = 0.80（80% で webhook アラート）
+  - THEORETICAL_BITRATE_MBPS = 4
+- **調査不可項目**: 各生成 API の USD/秒・USD/song・USD/image。WebFetch でも 2026-05 時点の公式単価は流動的なため、推測単価で見積もりは出さない方針とする。代わりに「1 skill 実行で発生するリクエスト数」を §3.4 の表に明示する。
+
+### 3.3 コスト制御ガード（観点 4.3）
+
+| skill / モジュール | dry-run | ユーザー確認 | 上限キャップ | ファイル:行 |
+|---|---|---|---|---|
+| loop-video | ❌ | ✅ `-y` 未指定で対話 | duration_seconds = 8（API 仕様で固定） | `generate_loop_video.py:91, 141-144` |
+| lyria | ❌（CLI 直） | ⚠️ skill 内の Step 3 で人手承認するフロー設計だが、CLI 自体は確認しない | max_retries 既定 3 + 1（`--max-retries`）, segment 数 = `ceil((target+padding)*60/184)`、上限なし | `generate_lyria_master.py:143, 233-237` |
+| thumbnail / generate-image | ❌ | ✅ `confirm_cost()` で y/N 確認 | RETRY_MAX = 3 | `composition.py:58-78` / `image_provider/base.py:14` |
+| video-analyze | ❌ | ❌ | `--top` で件数指定（default 5）。リトライなし | `video_analyze.py:213-217, 255` |
+| benchmark | ❌ | ❌ | `freshness_days=3` で更新スキップ。`--no-thumbnails` で Gemini off。`--playlists` は `--channel` 必須（誤爆防止） | `benchmark_collector.py:1183-1186`, `benchmark/config.default.yaml:11-16` |
+| discover-competitors | ❌ | ❌ | keywords × per_keyword_results を CLI 引数で制御。SKILL.md に 660 unit/run と明示 | `discover-competitors/SKILL.md:116-119` |
+| video-upload | ✅ `--plan` あり | ❌ | upload_policy MAX_RETRY_ATTEMPTS=5（5xx 限定）, 403 quota 系はリトライしない設計 | `upload_policy.py:13-14` / `upload_core.py:120-128` |
+| comments-reply | ✅ `--dry-run` 既定 | ✅ dry-run 経由必須運用 | max_replies_per_run = 20, delay_between_replies_sec = 2.0, history 重複防止 | `config/loader.py:316-317` / `replier.py:113-124, 199-203` |
+| analytics-collect | ❌ | ❌ | `freshness 30 分以内ならスキップ`（`analytics-collect/SKILL.md:33-40`）、Analytics は別 quota | — |
+| streaming bandwidth | ❌ | ❌ | THRESHOLD_RATIO=0.80 で webhook アラート | `streaming/__init__.py:13` |
+
+**観察**:
+- 生成系（Veo / Lyria / Image）は **CLI 起動時に y/N 確認 or `-y` 必須**。Lyria だけは確認プロンプトなし（skill 側 Instructions の Step 3 で人手承認する想定）。
+- `cost_tracker.log_generation`（`cost_tracker.py:94`）が画像/動画/音楽の生成 1 件ごとに記録 → `yt-cost-report` CLI で照会可能。**ただし USD 推定はしない**（Issue #132 以降は GCP Billing 側で確認する設計）。
+
+### 3.4 リトライ戦略のコスト影響（観点 4.4）
+
+| 呼び出し | ファイル:行 | 上限 | バックオフ | 評価 |
+|---|---|---|---|---|
+| Veo 3.1 generate_videos | `veo_generator.py:47` | **1 回**（try-except で False 返却） | — | ✅ safe |
+| Veo poll | `veo_generator.py:68-76` | 120 回 (`MAX_POLL_SEC=600 / POLL_INTERVAL_SEC=5`) | 5 秒固定 | ✅ poll は無課金 |
+| Lyria generate_music | `lyria_client.py:139` | **1 回**（None 返却） | — | ✅ safe |
+| Lyria segment retry | `generate_lyria_master.py:143-147` | 既定 `max_retries=3` → 試行 4 回 | `wait_sec = min(30, 10 * attempt)` | ✅ 上限あり |
+| Gemini Image | `image_provider/gemini.py:57-108` | RETRY_MAX=3 | (10, 30, 60) 秒 | ✅ SAFETY/RECITATION は即時 fail |
+| Gemini Text/Video | `video_analyzer.py:79` | **0 リトライ**（APIError は failures に積み次へ） | — | ✅ safe |
+| Gemini 翻訳 (populate_scene_phrases) | `populate_scene_phrases.py:35-87` | `_RETRY_MAX=3` | (5, 15) 秒 | ✅ |
+| OpenAI Image | `image_provider/openai.py:78-132` | RETRY_MAX=3 | (10, 30, 60) 秒 | ✅ ConfigError は fail-fast |
+| YouTube Data upload | `upload_core.py:111-128` + `upload_policy.py:39-53` | MAX_RETRY_ATTEMPTS=5 | `2 ** attempt` 秒 | ✅ **403 は retry しない**（quota 焼け防止が効いている） |
+| YouTube Data search/list (benchmark) | `benchmark_collector.py:162` | ページング上限なし（`scan_recent` で打ち切り） | — | ⚠️ 後述 F-2 |
+| Analytics reports.query | `strategic_analytics.py:286-351` | バッチサイズ 10 × 上位 N 件、エラー時 break | — | ✅ |
+| Analytics 並列 | `strategic_analytics.py:416` | `ThreadPoolExecutor(max_workers=8)` | — | ⚠️ 後述 F-3 |
+| Vultr bandwidth | `vultr_bandwidth.py:42-46` | **0 リトライ** | — | ✅（Vultr API は無料） |
+
+**まとめ**: 「無限リトライで quota を焼く」パターンは見当たらない。全ての生成系で `RETRY_MAX` / `MAX_RETRY_ATTEMPTS` がコードレベルで定義されている。
+
+### 3.5 モデル選択の固定 / フォールバック（観点 4.5）
+
+| skill / モジュール | 既定モデル | フォールバック挙動 | リスク |
+|---|---|---|---|
+| Veo (loop-video) | `veo-3.1-fast-generate-001` (`veo_generator.py:15`, `loop-video/config.default.yaml:8`) | `--model` > skill-config > DEFAULT_MODEL。**fast 系を default 採用**（コスト低） | ✅ 安全寄り |
+| Lyria | `lyria-3-pro-preview` (`lyria/config.default.yaml:17`) | `--model` > skill-config。`lyria-3-clip-preview`（30秒固定）は preview 用 | ⚠️ pro 既定。preview→pro の切替誤りで song あたり単価差 |
+| Gemini Image | `gemini-3.1-flash-image-preview` (`image_provider/config.py:27`) | skill-config の `image_generation.gemini.model` で上書き可 | ✅ flash 既定 |
+| Gemini Text | `gemini-2.5-flash` (`benchmark/config.default.yaml:23`, `video-analyze/config.default.yaml:7`) | skill-config 上書き可 | ✅ flash 既定 |
+| Gemini 翻訳 | `gemini-2.5-flash-lite` (`populate_scene_phrases.py:33`) | ハードコード | ✅ flash-lite（最安） |
+| OpenAI Image | `gpt-image-2` (`image_provider/config.py:150`) | skill-config 上書き可 | ⚠️ **`quality=high` が既定**（`config.py:151`, `thumbnail/config.default.yaml:92`）。low/medium に比べ大幅高単価 → P1 |
+| YouTube Reporting | 自動選定 (Reach 系) | `reporting_api.py:65-68` で priorities 順 | ✅ 自動 |
+
+**観察**: 画像/動画系の既定モデルは **fast/flash 系の低単価モデル**で固定されており、設計の意図は明確。唯一 OpenAI の `quality=high` だけが「明示的に高単価設定」になっている（後述 F-1）。
+
+---
+
+## 4. 「1 回の skill 実行で最悪いくらかかるか」概算表
+
+USD 単価は不明（前述）のため、**「最悪リクエスト数」と「焼き切る可能性のある quota」**で表現する。
+
+| skill | リクエスト最大数（1 回実行） | Quota 影響 | 注記 |
+|---|---|---|---|
+| loop-video | Veo ジョブ **1 本**（8 秒） | Vertex AI billing | poll 120 回は無料。事故っても 1 動画 |
+| lyria（90 分マスター） | Lyria 生成 **30 セグメント × max 4 試行 = 120 リクエスト最悪** | Vertex AI billing | 既存 wav は skip（resume） |
+| lyria（10 時間ロング） | **200 セグメント × 4 = 800 リクエスト最悪** | Vertex AI billing | 既存 wav skip で復帰可。**target_duration_min × duration_padding_min に上限なし** → F-4 |
+| thumbnail | 画像生成 **1 枚 × 3 試行 = 3 リクエスト** | Vertex/OpenAI billing | confirm_cost 必須 |
+| video-analyze --top 5 | Gemini **5 動画解析** | Vertex AI billing | リトライなし |
+| benchmark（全チャンネル更新） | YouTube Data ~3 unit/channel + Gemini サムネ N 枚 | Data quota: ~30 unit/channel（軽い）/ Gemini billing | サムネ分析を `--no-thumbnails` で off 可 |
+| discover-competitors | search.list × keywords (default 3-5) = **660 unit/run** | Data quota の 6.6% | SKILL.md に明示 |
+| video-upload (single_release JP+EN) | videos.insert × 2 + thumbnails.set × 2 = **3,200+ unit** | Data quota の 32% | 同日 2 本投稿構成 |
+| video-upload + 多言語 collection | 1,600 unit + thumbnails.set | Data quota の 16% | |
+| comments-reply --apply --limit 20 | commentThreads.list (1) × videos + comments.insert × 20 | Data quota: **~20-40 unit/run** | dry-run 既定で誤投稿防止 |
+| analytics-collect | reports.query 多数 (8 並列) + Data API videos listing | **Analytics quota（別枠 720req/min）** + Data quota 数十 unit | 30 分鮮度キャッシュあり |
+| streaming archive-check (月次) | search.list × ⌈月内動画/50⌉ ≈ 2 page × 100 unit = **200 unit** | Data quota | 月 1 回 cron 想定 |
+| streaming VPS | — | **Vultr $10/月固定** + 帯域 2TB/月 | terraform destroy 必須 |
+
+---
+
+## 5. Findings（severity 付き、推奨アクション含む）
+
+| # | severity | 内容 | ファイル:行 | 推奨アクション |
+|---|---|---|---|---|
+| **F-1** | P1 | **OpenAI Image の `quality=high` が既定**。Gemini を default にしているチャンネルで provider 切替時、無自覚に high quality が選ばれる。gpt-image-2 は low/medium/high で単価が階層化されており、`high` は数倍コスト。`thumbnail/config.default.yaml:92` には `# 品質階層: low | medium | high` とコメントがあるが既定が high | `src/youtube_automation/utils/image_provider/config.py:151` / `.claude/skills/thumbnail/config.default.yaml:92` | quality の既定を `medium` に下げる or skill SKILL.md に「provider=openai 時は quality を明示確認」と書く |
+| **F-2** | P1 | **benchmark `scan_recent` 上限なし**。skill-config で `scan_recent: 50` が default だが、ユーザーが 1000 に設定するとチャンネルあたり ⌈1000/50⌉=20 page × playlistItems.list = 20 unit、videos.list 20 batch = 20 unit。10 チャンネル × `--force` で **400+ unit**。Gemini サムネ分析が走ると更にスケール（min_views で間引かれるが）。skill-config では値域 validate なし | `src/youtube_automation/scripts/benchmark_collector.py:135-178` / `.claude/skills/benchmark/config.default.yaml:11` | `scan_recent` に上限 validate（例: max 200）を追加 or SKILL.md に「scan_recent を上げる際の quota 計算式」を明記 |
+| **F-3** | P1 | **Lyria の segment 数に上限がない**。`audio.target_duration_min` を 600（10 時間）にすると ⌈600+3*60/184⌉ = **196 セグメント** × max_retries+1 = **最大 784 Lyria API call**。Vertex AI の Lyria クォータ（プロジェクト単位）が枯渇する可能性 + 課金が線形に増える。skill 側の Step 3 で人手承認するフロー設計だが、CLI 単体（`yt-generate-lyria-master`）は confirm prompt を持たない | `src/youtube_automation/scripts/generate_lyria_master.py:68-79` / `lyria_client.py:139` | CLI に「N セグメント生成しますがよろしいですか？」の `-y` 確認を追加、または上限 segment 数を skill-config で明示（例: `max_segments: 60`）。SKILL.md `Step 4` の注意点に追記 |
+| **F-4** | P2 | **Analytics の ThreadPoolExecutor が `max_workers=8` 固定**。1 チャンネル数百本動画があると 8 並列で reports.query を叩き、Analytics quota（720 req/min）を**最悪 8 秒で 100 req 消費**。Analytics は Data quota とは別枠で安全弁が緩い。エラー時は worker 単位で degrade するため致命傷にはならないが、quota 枯渇で **後続 skill が all-fail する連鎖**は起きうる | `src/youtube_automation/utils/strategic_analytics.py:25, 416` | `max_workers` を skill-config で可変化 + 既定を 4 に下げる、または `time.sleep(0.1)` で per-worker rate limit を入れる |
+| **F-5** | P2 | **Veo `MAX_POLL_SEC=600` でタイムアウトしても Vertex 側でジョブが走り続ける可能性**。タイムアウトで `return False` する（`veo_generator.py:71`）が、Vertex AI 側のオペレーションを cancel するコードはない（`client.operations.cancel` 等は呼ばれていない）。Veo ジョブは生成完了まで課金されるため、Python 側が早期 return しても料金は発生 | `src/youtube_automation/utils/veo_generator.py:67-71` | (a) タイムアウト時に `client.operations.cancel(operation)` を呼ぶ、または (b) MAX_POLL_SEC をもっと長く取る（Veo 3.1 fast は通常 1-3 分で完了するため、現状 10 分でも実害は小さい）。少なくとも SKILL.md に「タイムアウトでもジョブは継続課金される」と書く |
+| **F-6** | P2 | **`generate_lyria_master.py:145` の retry バックオフが上限 30 秒**。`min(30, 10 * attempt)` で attempt=3 でも 30 秒。Vertex AI Lyria が 429 を返すケースで 30 秒待機 × max_retries=3 = 90 秒で全試行を消費し、後続セグメントも同じ高負荷状況で 429 を引き続け失敗 → 中断。コストではなく**運用効率の問題**で、リトライ全消費後に手動再実行する場合、再実行ごとに「直前まで成功」分は skip されるためコスト二重課金は起きない。だが大量リトライが quota を更に焼く | `src/youtube_automation/scripts/generate_lyria_master.py:144-147` | バックオフを `min(120, 30 * 2 ** attempt)` 程度に拡大、または 429 専用の長めウェイトを入れる |
+| **F-7** | P3 | **`cost_tracker.estimated_cost_usd` が常に null**（Issue #132 設計）。`yt-cost-report` で件数は集計できるが **金額は出ない**。GCP Cloud Console > Billing を見ないとコスト実態が把握できず、暴走検出が遅れる | `src/youtube_automation/utils/cost_tracker.py:9-20, 117-119` | 「GCP Billing アラート」を SKILL.md レベルで案内する（streaming に 80% アラートが入っているのと同じパターン）。`yt-cost-report` 出力末尾に GCP Billing URL を表示 |
+| **F-8** | P3 | **streaming archive_counter が `search.list` を使う**。search.list = 100 unit/call。月の動画 60 本 → 2 page × 100 = 200 unit/run。毎月の cron + 都度確認で月 1,000 unit 程度を消費。SKILL.md は「`yt-stream-archive-check` でアーカイブ件数確認」と書くだけで quota 影響は無記載 | `src/youtube_automation/utils/streaming/archive_counter.py:55, 64` / `.claude/skills/streaming/SKILL.md:30, 39` | `playlistItems.list`（1 unit）+ クライアント側日付フィルタに置き換える、または SKILL.md に quota 影響を追記 |
+| **F-9** | P3 | **`collection_uploader.py:451` の `while True: schedule.run_pending(); time.sleep(60)` 常駐スケジューラ**。`run_automated_schedule` が呼ばれた場合のみ走る。「事故で常駐させ続けて quota を毎日 1,600 × N 単位で消費」というシナリオはあるが、明示的に手動起動する設計のため P3 | `src/youtube_automation/agents/collection_uploader.py:440-457` | SKILL.md / README で「`run_automated_schedule` は手動運用用途。CI で常駐させない」と注記 |
+
+---
+
+## 6. 注意点・残リスク
+
+1. **「無限ループ生成」リスクはコードレベルでは検出されず**。Lyria の `target_duration_min` 上限なし（F-3）が最も「設定値次第で線形にコスト膨張」する箇所。
+2. `cost_tracker` は USD 算出を放棄しているため、**「いくら使ったか」を Python 側で観測できない**。Issue #132 設計上の意図的選択だが、暴走検出能力は GCP Billing に完全依存。
+3. **Vultr streaming は固定 $10/月 + 帯域従量**で、Python 側のコード経路で暴走するシナリオは無い。むしろ「`terraform destroy` し忘れ」が現実的な金銭リスクで、SKILL.md §5 に明記済み（P2 とは扱わない）。
+4. PR #367 (汎用化・整合性) でカバー済とされる「ハードコード単価」「PRICING テーブル」系の残骸は今回再検出しないルールに従い除外したが、`composition.py:174` の「PRICING フォールバックは撤廃済み」コメントが残っており、現行コードは null 設計に統一されていることを確認した。
+
+---
+
+## 7. 調査不可項目と理由
+
+| 項目 | 理由 |
+|---|---|
+| Veo 3.1 fast/standard/lite の 2026-05 単価 (USD/秒) | リポジトリ内に単価情報なし（Issue #132 で撤廃）。WebFetch は GCP 公式ページが時系列で変動するため、推測単価で見積もりを出すと誤情報になるので回避 |
+| Lyria 3 Pro / Clip の単価 (USD/song) | 同上 |
+| Gemini 3.1 flash-image / 2.5 flash の単価 | 同上 |
+| gpt-image-2 quality 別単価 | 同上 |
+| Vultr 帯域超過時の単価（$/GB） | `streaming/README.md` 参照（本タスク範囲外） |
+| YouTube Data API の有償拡張枠 | 標準 quota（10k/日）想定で、拡張申請は別フロー |
+| 「1 skill 実行で最悪何 USD」 | 単価が取れないため算出不可。代わりに §4 でリクエスト数で表現 |
+
+---
+
+## 8. 推奨アクション（severity 付き、優先度順）
+
+| 優先度 | 対応 | 関連 Finding | 工数感 |
+|---|---|---|---|
+| P1 | OpenAI Image の `quality` 既定を `medium` に下げる、または SKILL.md に明示警告を追加 | F-1 | XS |
+| P1 | `benchmark.scan_recent` に上限 validate（例: max 200）+ SKILL.md に quota 計算式追記 | F-2 | S |
+| P1 | `yt-generate-lyria-master` に segment 数の確認プロンプト（`-y` 未指定時）と segment 数上限（skill-config）を追加 | F-3 | S |
+| P2 | Analytics の `_MAX_WORKERS=8` を skill-config で可変化 + 既定を 4 に | F-4 | S |
+| P2 | Veo タイムアウト時の `operations.cancel` 呼び出し、または SKILL.md に「タイムアウト後も課金継続」を明示 | F-5 | M |
+| P2 | Lyria リトライバックオフを `min(120, 30 * 2 ** attempt)` に拡大 | F-6 | XS |
+| P3 | `yt-cost-report` 出力末尾に GCP Billing アラート URL / 設定手順を案内 | F-7 | XS |
+| P3 | streaming archive_counter を search.list → playlistItems.list に置換、または SKILL.md に quota 注記 | F-8 | M |
+| P3 | `collection_uploader.run_automated_schedule` の常駐運用注意を SKILL.md / README に追記 | F-9 | XS |
+
+---
+
+## 9. 監査スコープと根拠
+
+- **コード読み取り対象**: `src/youtube_automation/{utils,scripts,agents,cli}/*.py` のうち課金 API を呼ぶ全ファイル
+- **skill 読み取り対象**: `.claude/skills/{loop-video,lyria,thumbnail,video-analyze,benchmark,discover-competitors,video-upload,comments-reply,analytics-collect,streaming}/SKILL.md` + 各 `config.default.yaml`
+- **検索手段**: Grep（`while True` / `retry` / `MAX_` / `RETRY_` / `model:` / `cost_per_image_usd` / `MONTHLY_QUOTA_GB` / `maxResults` / `search().list` / `videos().list`）+ Read（実装の確認）
+- **コード修正**: なし（読み取り専用）

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/05-data-security-secrets.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/05-data-security-secrets.md
@@ -1,0 +1,533 @@
+# Part B 監査結果: セキュリティ / シークレット / 権限境界
+
+- **対象**: `.claude/skills/**`, `src/youtube_automation/**`, `auth/`, `infra/terraform/**`, ルート設定
+- **担当**: Research Digger Part B（観点 5）
+- **取得日**: 2026-05-18
+- **作業ディレクトリ**: `/Users/mba/02-yt/takt-worktrees/20260518T0905-372-issue-372-chore-skills-sukiru/`
+- **コミット時点**: `git log --all --pretty='%h' | wc -l` = 316 commits
+- **方針**: 検出した疑わしい値は **すべて伏字化**。実値は本ファイルに残さない。
+
+---
+
+## エグゼクティブサマリー
+
+| Severity | 件数 | 概要 |
+|---|---|---|
+| **P0（即時対応必須）** | 0 | なし |
+| **P1（高優先・要対応）** | 2 | (a) Terraform `null_resource.deploy` の SSH host key 未検証 / (b) `auth/token.json` のスコープが広く読み取り専用 skill にも write/analytics 権限が乗る |
+| **P2（中優先・改善余地）** | 5 | (c) `.gitattributes` 不在 / (d) Terraform local state（remote backend なし） / (e) `channel-new` の token.json コピー導線 / (f) `op read $(...)` 値の shell env 滞留 / (g) `vultr_bandwidth.py` の `URLError` で reason に URL が含まれうる |
+| **P3（軽微・参考）** | 3 | (h) bench スクリプトが `os.environ.get` 直読み（意図通り） / (i) `notification.py` 例外文の URL 漏れ余地 / (j) Suno CDN への `curl -L` |
+
+**結論**: シークレット直書きや git 履歴混入は **発見できなかった**。`utils.secrets._SECRET_REFS` を中核とした env → 1Password CLI → ConfigError の解決経路は production code 全体で一貫しており、ログ出力経路の redaction も `oauth_handler._redact()` で網羅されている。残るリスクは **(1) 1 つの token.json が複数 scope を抱える単一障害点設計** と **(2) Terraform ssh provisioner の first-connect MITM 余地** の 2 点に集約される。修正は本 PR スコープ外（観点 5 は監査のみ）。
+
+---
+
+# B-1: シークレット取り扱い
+
+## 5.1 ハードコード検出
+
+検出ルール (= grep 正規表現):
+
+| 種別 | パターン | 検出件数 |
+|---|---|---|
+| Google API key | `AIza[0-9A-Za-z_-]{35}` | **0** |
+| OpenAI key | `sk-[a-zA-Z0-9]{20,}` | **0** |
+| GitHub PAT | `ghp_[a-zA-Z0-9]{36}` | **0** |
+| Slack token | `xox[baprs]-[0-9a-zA-Z-]+` | **0** |
+| Bearer literal | `Bearer\s+[A-Za-z0-9_\-\.]{20,}` | **0** |
+| 一般代入 | `(api_key\|password\|secret\|client_secret\|token)\s*[:=]\s*"[^"]{8,}"` | 6（全件 false positive） |
+
+一般代入のヒット 6 件はいずれも **plaintext な値ではなく**、以下のいずれか:
+
+- `src/youtube_automation/auth/oauth_handler.py:39` — `_REDACTED_TOKEN = "<redacted-token>"`（redaction 用プレースホルダ）
+- `tests/test_metadata_audit.py:23` — `_ZH_ISSUE_TOKEN = "zh codes"`（テスト用ラベル文字列、credential ではない）
+- `tests/test_oauth_handler_exceptions.py:40-41` — 合成された Google 風 access/refresh token サンプル（`ya29.A0AbCdEfGhIjKlMnOpQrStUvWxYz123456` 等、redaction のテスト fixture）
+- `tests/test_oauth_handler_main.py:33` — 同上
+- `tests/test_secrets.py:27` — `_TEST_SECRET = "CLIENT_SECRETS_JSON"`（_SECRET_REFS の **キー名** 文字列）
+
+**評価**: production code に実値のシークレット直書きは **検出されず**。テスト fixture の合成 token は `_redact()` の挙動を verify するための inert な文字列であり、credential として有効ではない。
+
+> 取得コマンド:
+> ```
+> Grep -E 'AIza[0-9A-Za-z_-]{35}' --path .
+> Grep -E 'sk-[a-zA-Z0-9]{20,}' --path .
+> Grep -E 'ghp_[a-zA-Z0-9]{36}' --path .
+> Grep -E 'xox[baprs]-[0-9a-zA-Z-]+' --path .
+> Grep -iE '(api[_-]?key|password|secret|client_secret|token)\s*[:=]\s*["'\''][^"'\'']{8,}["'\'']' --path .
+> ```
+
+---
+
+## 5.2 シークレット参照経路（env → op read → ConfigError）
+
+`src/youtube_automation/utils/secrets.py` の `_SECRET_REFS` 定義:
+
+| シークレット名 | 1Password URI |
+|---|---|
+| `CLIENT_SECRETS_JSON` | `op://Personal/YouTube_OAuth_Client_Secrets/credential` |
+| `OPENAI_API_KEY` | `op://Personal/OpenAI_API_Key/credential` |
+| `YOUTUBE_STREAM_KEY` | `op://Personal/YouTube/stream_key` |
+| `VULTR_API_KEY` | `op://Personal/Vultr/api_key` |
+| `STREAM_WEBHOOK_URL` | `op://Personal/Stream_Notification_Webhook/url` |
+| `DISCORD_WEBHOOK_URL` | `op://Personal/YouTube_Stream_Discord_Webhook/url` |
+
+呼び出し側の準拠状況:
+
+| 呼び出し箇所 | 経路 | 評価 |
+|---|---|---|
+| `src/youtube_automation/utils/image_provider/openai.py:69` | `get_secret("OPENAI_API_KEY")` | ✅ |
+| `src/youtube_automation/cli/stream_bandwidth.py:120` | `get_secret("VULTR_API_KEY")` | ✅ |
+| `src/youtube_automation/cli/stream_bandwidth.py:151,168` | `get_secret("STREAM_WEBHOOK_URL")` | ✅ |
+| `src/youtube_automation/scripts/streaming_archive_check.py:78` | `get_secret("DISCORD_WEBHOOK_URL")` | ✅ |
+| `src/youtube_automation/utils/secrets.py:101` | `get_secret("CLIENT_SECRETS_JSON")` → `get_client_secrets_path()` | ✅ |
+| `src/youtube_automation/auth/oauth_handler.py:107-115` | `get_client_secrets_path()` フォールバック | ✅ |
+| `bench/bench_generate_image.py:61` | `os.environ.get("OPENAI_API_KEY")` のみ（存在チェック） | ⚠️ P3: bench 専用、API 呼び出しは provider 経由なので意図通り |
+| `bench/bench_real_apis.py:27` | 同上 | ⚠️ P3: 同上 |
+
+**評価 (5.2)**: production code パス（`src/`）では `get_secret()` 経由が **100% 徹底**。bench スクリプト 2 件は「設定済みか否か」の boolean 判定にしか使っていないため漏洩リスクはない（実 API 呼び出しは `image_provider/openai.py` 経由で再度 `get_secret()` が走る）。
+
+`get_secret()` 実装（`utils/secrets.py:40-79`）の評価:
+- 解決順序: `os.environ` → `shutil.which("op")` → `op read` → `ConfigError`
+- `lru_cache` でメモ化（同一プロセス内）
+- `op read` 失敗 (`CalledProcessError`/`TimeoutExpired`/`FileNotFoundError`) を握りつぶし最終 `ConfigError` に集約 → エラーメッセージに `.env` と 1Password 両ルートを明示
+- `_OP_READ_TIMEOUT_SEC = 10` で hang 防止
+
+`get_client_secrets_path()`（`utils/secrets.py:85-116`）:
+- `mkstemp` → `chmod 0o600` → `fdopen` の順序 → world-readable な瞬間を経由しない（コメントで明示）
+- `atexit.register(_cleanup)` で一時ファイルを掃除（idempotent）
+
+---
+
+## 5.3 .gitignore / 履歴混入
+
+### `.gitignore`（ルート）
+
+検証対象パスのカバレッジ:
+
+| パターン | `.gitignore` 行 | カバー |
+|---|---|---|
+| `auth/client_secrets.json` | L12 | ✅ |
+| `auth/token*.json`（glob、`token_streaming.json` も対象） | L13 | ✅ |
+| `.env` | L8 | ✅ |
+| `terraform.tfvars` | L33 | ✅ |
+| `*.tfstate` / `*.tfstate.*` | L34-35 | ✅ |
+| `*.tfplan` | L36 | ✅ |
+| `.terraform/` | L37 | ✅ |
+| `service-account*.json` | — | ❌ なし（**P2 改善候補**: 慣例的に Google サービスアカウント JSON が手元に落ちうるため glob 追加が望ましい） |
+
+回帰テストあり: `tests/test_gitignore_auth_tokens.py`（issue #158）が `auth/token*.json` glob の必須性 + 後方互換 + 旧 exact 形式撤去を保証。
+
+`.claude/skills/channel-setup/references/terraform-gcp/.gitignore` も独立に存在し、wheel に同梱される展開先で `terraform.tfstate*` / `terraform.tfvars` / `*.auto.tfvars` を ignore。
+
+### `.gitattributes`
+
+`/Users/mba/02-yt/takt-worktrees/.../.gitattributes` は **存在しない**（`ls -la .gitattributes` で `No such file or directory`）。`export-ignore` / `filter` 系の防御層は無し。**P2 改善候補**: archive 生成時に `auth/` を含めない / `linguist-vendored` 等の用途で 1 ファイル作る余地あり。
+
+### `git ls-files` で誤って tracked されているか
+
+```
+git ls-files | grep -E '(token\.json|client_secrets\.json|\.env$|\.tfstate|service-account)'
+git ls-files | grep -E 'tfvars$'
+```
+
+両コマンドとも **0 件**。tracked の secret 含有ファイルは存在しない。`.env.example`, `auth/client_secrets_template.json`, `auth/SETUP.md`, `*.tfvars.example` のテンプレートのみ tracked。
+
+### 過去コミット履歴
+
+```
+git log --all --full-history -- 'auth/client_secrets.json' 'auth/token.json' 'auth/token_streaming.json'  # → 0 件
+git log --all --full-history -- '.env' '.env.local'                                                       # → 0 件
+git log --all --full-history -- 'infra/terraform/streaming/terraform.tfvars'                              # → 0 件
+```
+
+**評価 (5.3)**: 316 コミットの履歴を通じて、上記 sensitive ファイルが **一度も commit されていない**。
+
+---
+
+## 5.4 ログ・stdout 出力リスク
+
+### Python 側（`src/`）
+
+`(print|logger\.(info|debug|warning|error|exception)).*(token|secret|api_key|password|credential|refresh|bearer)` ヒット件数 = **4 件**、全件 `_redact()` 経由 or path-only:
+
+| 場所 | 内容 | 評価 |
+|---|---|---|
+| `src/youtube_automation/auth/oauth_handler.py:172` | `logger.warning("既存トークン読み込み失敗: %s", _redact(str(e), self.token_file))` | ✅ redact 経由 |
+| `src/youtube_automation/auth/oauth_handler.py:186` | `logger.warning("token refresh 失敗: %s", _redact(str(e)))` | ✅ |
+| `src/youtube_automation/auth/oauth_handler.py:200` | `logger.error("OAuth 2.0 認証失敗: %s", _redact(str(e), self.client_secrets_file))` | ✅ |
+| `src/youtube_automation/auth/oauth_handler.py:221` | `print(f"💾 認証トークン保存完了: {self.token_file}")` | ✅ パス（**値ではない**） |
+
+`_redact()`（`oauth_handler.py:43-60`）の対象パターン:
+- `ya29\.[\w\-]+`（Google access token）
+- `1//[\w\-]+`（Google refresh token）
+- `[\w\-]{20,}\.[\w\-]{20,}\.[\w\-]{20,}`（JWT 3 セグメント）
+- `(?i)\b(?:refresh_token|access_token|client_secret|id_token)=[^\s&]+`
+- 引数で渡された Path / str を `os.fspath` で `<redacted-path>` 置換
+- OSError 形式 `: '<abs path>'` の絶対パスを除去
+
+回帰テスト: `tests/test_oauth_handler_exceptions.py` / `tests/test_oauth_handler_main.py` が合成 token を含む例外メッセージで redaction を verify。
+
+### CLI stdout（stream key）
+
+`src/youtube_automation/scripts/fetch_stream_key.py:186-202` (`_emit_stdout`):
+
+```python
+if os.environ.get("GITHUB_ACTIONS") == "true":
+    print(f"::add-mask::{value}")    # GHA log masking
+if sys.stdout.isatty():
+    print("WARNING: stream_key を TTY に出力します。pipe で受けてください。", file=sys.stderr)
+    sys.exit(2)                      # TTY 拒否
+print(value)                          # pipe 経由のみ
+```
+
+`::add-mask::` でログマスキング、TTY 出力を fail-fast で拒否。`write_op_secret()` も argv に値を載せず stdin 経由（`utils/secrets.py:143-147`、Issue #151）。
+
+### Shell スクリプト
+
+`echo.*\$.*(TOKEN|SECRET|KEY|PASS|WEBHOOK)` パターン → **0 件**。
+
+`.claude/skills/streaming/references/notify.sh:23-27` は `source` を使わない限定パーサで `/etc/youtube-stream-healthcheck.env` を読む（コメントで「env ファイル改ざん時の任意コード実行を防ぐ」と明示）。`notify.sh:34-40` は webhook URL が `https://(discord\.com|discordapp\.com)/api/webhooks/` でなければ exit 0（SSRF 防御、Issue #166/#174）。
+
+`.claude/skills/streaming/references/run-ffmpeg.sh:25`:
+```bash
+exec /usr/bin/ffmpeg -re -stream_loop -1 -i "$VIDEO" -c:v copy -c:a copy -f flv "$RTMP_URL"
+```
+`exec` を使い shell を残さないことで `systemctl show` / 親プロセス cmdline から RTMP URL（= stream_key を含む）を隠す（Issue #160）。systemd `DynamicUser=yes`（#159）で `/proc/<pid>/cmdline` は ffmpeg プロセスのみ閲覧可。
+
+**評価 (5.4)**: ログ / stdout 経路は **全件 redaction or 値ではなくパス**。`fetch_stream_key.py` / `notify.sh` / `run-ffmpeg.sh` は二重三重の防御（GHA mask、TTY 拒否、whitelist、exec）が施されている。
+
+---
+
+# B-2: 権限境界
+
+## 5.5 OAuth スコープ最小化
+
+`src/youtube_automation/auth/oauth_handler.py:69-74`:
+
+```python
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube",                          # 全権限（read+write）
+    "https://www.googleapis.com/auth/youtube.force-ssl",                # SSL 必須化
+    "https://www.googleapis.com/auth/yt-analytics.readonly",
+    "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",   # Reporting API v1 (#84)
+]
+```
+
+### スコープと skill 利用パターンの突合せ
+
+| skill | 必要スコープ（実利用） | デフォルト `SCOPES` が過剰か |
+|---|---|---|
+| `video-upload` | `youtube` (write) + `youtube.force-ssl` | ✅ 過剰なし |
+| `comments-reply` | `youtube.force-ssl` (write/comments.insert) | ✅ 過剰なし（doc に明記、L18） |
+| `playlist` | `youtube` (write/playlists.insert/playlistItems.delete) | ✅ 過剰なし |
+| `channel-setup`（branding push） | `youtube.force-ssl` (write) | ✅ 過剰なし |
+| `analytics-collect` | `yt-analytics.readonly` / `yt-analytics-monetary.readonly` | ⚠️ **不要に `youtube` (write) を含む** |
+| `benchmark` | `youtube` の read のみ（再生回数等） | ⚠️ **不要に write を含む** |
+| `discover-competitors` | YouTube Data API read | ⚠️ **同上** |
+| `viewer-voice` | YouTube Data API read | ⚠️ **同上** |
+| `metadata-audit` | YouTube Data API read | ⚠️ **同上** |
+| `channel-status` | YouTube Data API read | ⚠️ **同上** |
+
+### 例外: stream key 取得は **正しく分離**
+
+`src/youtube_automation/scripts/fetch_stream_key.py:99-109`:
+
+```python
+def get_streaming_credentials(force_reauth: bool = False):
+    token_path = channel_dir() / "auth" / _STREAMING_TOKEN_FILENAME       # token_streaming.json
+    handler = YouTubeOAuthHandler(scopes=[_STREAMING_SCOPE], token_path=token_path)
+    return handler.authenticate(force_reauth=force_reauth)
+```
+
+`_STREAMING_SCOPE = "https://www.googleapis.com/auth/youtube"` 単独 + 専用 token ファイル `token_streaming.json` で **scope 分離が実装されている**。コメントで「`youtube.readonly` だと streamName がマスクされる」と理由も明示。
+
+### 評価 (5.5) — **P1**
+
+`auth/token.json` 1 本に **broad scope（read+write+analytics）が同居** している。Read-only skill が credential を握ったまま動くため、token.json 漏洩時の blast radius は「全 skill 分の権限」=「動画削除・差し替え・収益情報閲覧」まで及ぶ。
+
+**推奨**:
+- `token.json`（write 用、upload/comments/playlist）と `token_readonly.json`（analytics + read 用）に分離
+- streaming の `token_streaming.json` パターン（issue #135）を analytics 系にも横展開
+- 既存 skill で scope を上書きする方法（`YouTubeOAuthHandler(scopes=[...], token_path=...)`）はすでに用意されているので、CLI 側を変えるだけで適用可能
+
+---
+
+## 5.6 削除系操作の確認ステップ
+
+| skill | 破壊的操作 | dry-run | ユーザー確認 | ロールバック |
+|---|---|---|---|---|
+| `live-clean` | `rm -f` で master.mp3 / master-mix.wav / *-Master.mp4 / 個別 mp3 等を削除 | ✅ Step 3 で必ずドライラン表示（SKILL.md:62-82） | ✅ `AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない` (L84) | ⚠️ なし（YouTube 上の動画 / Suno からの再取得に依存）。SKILL.md L42-50 に「再生成可能性」マトリクスあり |
+| `playlist` (`--clean-deleted`) | `playlistItems().delete()` (`scripts/playlist_manager.py:385`) | ✅ `--dry-run` フラグあり（SKILL.md:77-78） | ⚠️ 明示的な確認プロンプトはなし。`--dry-run` → 目視 → 本番の 2 段階運用を skill 側が文書化 (L54) | ❌ なし（削除した playlistItem の URL は YouTube が再発行しない） |
+| `playlist` (`--init`) | `playlistItems().insert()`（destructive ではないが二重追加余地） | ✅ `--init --dry-run` | ⚠️ プロンプトなし | — |
+| `streaming` (`§5 片付け`) | `terraform destroy`（VPS 完全消去） | ⚠️ `terraform plan` で確認可だが手動 | ⚠️ `terraform destroy` の対話 `yes` 入力のみ。SKILL.md L120-127 が「長期休止する場合は必ず destroy」と促す | ✅ §1 再構築で `5〜10 分` で復旧（state ファイルが残っていれば差分のみ） |
+| `streaming` (動画差し替え) | `swap_video.sh` → `null_resource.deploy` の re-run（11h サイクル中なら数秒の中断） | ✅ `terraform plan` を必ず先に実行（swap_video.sh:113） | ✅ デフォルトは対話 `apply`、`--auto-approve` は明示 opt-in（swap_video.sh:115-120） | ✅ 旧動画は VPS に上書きされるが、ローカルファイルは残る |
+| `channel-direction` | `rm -rf .venv && uv sync`（再構築用、`.claude/skills/channel-direction/SKILL.md:141`） | ❌ | ❌ | ✅ `uv sync` で再生成可能 |
+| `collection-ideate` | `rm -rf collections/planning/_plan-previews/<session-dir>/`（SKILL.md:323） | ❌ | ❌ | ❌ session preview のみで再生成可能 |
+| `lyria/references/worktree_sync.sh:116` | `rm -rf "01-master/preview"` | ✅ `$DRY_RUN` フラグあり (L113-115) | ❌ | ❌ preview は intermediate なので再生成可能 |
+
+### 評価 (5.6)
+
+| skill | 評価 |
+|---|---|
+| `live-clean` | ✅ 模範的：AskUserQuestion + dry-run + 削除前リスト + `rm -rf` 禁止条項（L104）まで明示 |
+| `playlist` | ⚠️ `--dry-run` はあるが対話確認なし。文書のみで「2 段階運用を徹底する」と要請（L54） |
+| `streaming destroy` | ⚠️ Terraform 標準の `yes` 入力のみ。`terraform destroy` を AskUserQuestion でラップしていない |
+| `swap_video.sh` | ✅ 対話デフォルト、`--auto-approve` opt-in、SSH agent 検証も fail-fast |
+| `channel-direction` の `rm -rf .venv` | ⚠️ doc 内のコマンド例として羅列されているのみ、ガードなし。`.venv` 範囲なので blast radius は限定的 |
+
+`branch-clean` skill は本リポジトリ `.claude/skills/` 配下に **存在しない**（dotfiles 由来のグローバル skill。本リポジトリでは管理対象外）。
+
+---
+
+## 5.7 git 履歴へのシークレット混入
+
+```
+git log --all --full-history -- 'auth/' '.env' 'config/channel/' 'infra/terraform/streaming/terraform.tfvars'
+```
+
+| 対象 | コミット履歴 |
+|---|---|
+| `auth/client_secrets.json` | **0 件** |
+| `auth/token.json` / `auth/token_streaming.json` | **0 件** |
+| `.env` / `.env.local` | **0 件** |
+| `infra/terraform/streaming/terraform.tfvars` | **0 件** |
+| `*.tfstate` 系 | **0 件** |
+
+316 コミットを `--all --full-history` で走査して、上記 sensitive ファイルが **一度も含まれていない**。`auth/SETUP.md`, `auth/client_secrets_template.json`, `*.tfvars.example`, `.env.example` のみが tracked。
+
+**評価 (5.7)**: 履歴汚染なし。
+
+---
+
+## 5.8 Terraform state / tfvars
+
+### Streaming モジュール (`infra/terraform/streaming/`)
+
+| ファイル | 状態 |
+|---|---|
+| `main.tf` | tracked（resource 定義） |
+| `variables.tf` | tracked、`sensitive = true` 付き（vultr_api_key / stream_key / discord_webhook_url） |
+| `terraform.tfvars.example` | tracked、コメントで「secret はここに書かず TF_VAR_* 経由」を明示 |
+| `terraform.tfvars` | **gitignore 済み**（`.gitignore:33`） |
+| `terraform.tfstate` / `*.tfstate.*` | **gitignore 済み**（`.gitignore:34-35`） |
+| `*.tfplan` | gitignore 済み（`.gitignore:36`） |
+
+`variables.tf` で `sensitive = true` 宣言された変数:
+- `vultr_api_key` (L1-5)
+- `stream_key` (L36-40)
+- `discord_webhook_url` (L42-46)
+
+`main.tf:39-53` の `null_resource.deploy.triggers` で `sensitive` 値を `triggers` map に格納する際 `nonsensitive(sha256(...))` でラップ（Terraform 1.5+ の sensitive 派生伝播対応、コメントで明示）。これにより:
+- `stream_key` / `discord_webhook_url` の実値は **tfstate に sensitive として平文保存される**（Terraform の sensitive は **暗号化ではない**、出力時のマスキングのみ）
+- triggers の SHA256 ハッシュも tfstate に残るが、不可逆
+
+### Remote backend
+
+```
+Grep -n 'backend\s+"' --path .  → 0 件
+```
+
+`infra/terraform/streaming/versions.tf` / `infra/terraform/gcp/versions.tf` のいずれにも `backend "s3"` / `backend "gcs"` / `backend "remote"` の宣言なし。**state は完全に local**。
+
+**含意 (P2)**:
+- `terraform.tfstate` がローカル disk に作られ、`stream_key` / `discord_webhook_url` が平文で含まれる
+- 個人ノート PC が紛失 / バックアップが流出すると tfstate から secret が抜ける
+- `.gitignore` でコミットは防がれているが、**ローカル file system 上の rest 状態は protected されていない**
+
+**推奨**: `gcs` / `s3` remote backend + customer-managed encryption key への移行。ただし個人運用では local + FileVault などで十分という判断もあり得る（コストとリスクのバランス）。
+
+### GCP モジュール (`infra/terraform/gcp/`, `.claude/skills/channel-setup/references/terraform-gcp/`)
+
+両モジュールも remote backend 設定なし。`auth/SETUP.md:145` で「`infra/terraform/gcp/terraform.tfvars`: **絶対に公開しない**（gitignore 済み）」と明示。
+
+---
+
+## 5.9 1Password CLI 前提とフォールバック
+
+### `get_secret()` 失敗時のエラーメッセージ
+
+`src/youtube_automation/utils/secrets.py:75-79`:
+
+```python
+raise ConfigError(
+    f"{name} を取得できませんでした。\n"
+    f"  → .env に {name}=... を設定するか、\n"
+    f"  → 1Password の {op_ref} に登録してください"
+)
+```
+
+両ルート（`.env` / 1Password）が明示され、op_ref には実際の URI 文字列が入る。ユーザーが対処可能。
+
+### `op` 未インストール時の挙動
+
+`secrets.py:60-73`:
+
+```python
+if shutil.which("op"):
+    try:
+        result = subprocess.run(["op", "read", op_ref], ...)
+        ...
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+```
+
+`op` PATH 上に無ければ `shutil.which` が False で skip → 最終 ConfigError。`op` あって失敗（auth 未済、URI 不在）も握りつぶし → 最終 ConfigError。**op の有無に依存しない**（`.env` で代替可能）。
+
+### `write_op_secret()` のフォールバック
+
+`secrets.py:135-141`:
+
+```python
+op_path = shutil.which("op")
+if not op_path:
+    raise ConfigError(
+        "1Password CLI (op) が見つかりません。\n"
+        "  → https://developer.1password.com/docs/cli/get-started/ からインストールするか、\n"
+        "  → 既にインストール済みなら PATH を確認してください"
+    )
+```
+
+インストール URL も含めた親切なメッセージ。`edit` 失敗時は `create` に自動フォールバック（既存 item 不在ケース対応、L149-189）。
+
+### Skill 側の `op read` 利用
+
+`.claude/skills/streaming/SKILL.md:50-52, 123`:
+
+```bash
+export TF_VAR_vultr_api_key=$(op read 'op://Personal/Vultr/api_key')
+export TF_VAR_stream_key=$(op read 'op://Personal/YouTube/stream_key')
+export TF_VAR_discord_webhook_url=$(op read 'op://Personal/YouTube_Stream_Discord_Webhook/url')
+```
+
+これは Python の `get_secret()` を経由せず **直接 `op read`** を呼ぶ。理由は Terraform の `TF_VAR_*` env 経路に乗せるため。
+
+**懸念 (P2)**:
+- `op read` 失敗時のエラー文言は op CLI 標準（英語、cryptic）。`get_secret()` の親切メッセージは適用されない
+- `export VAR=$(op read ...)` でシェル env に滞留 → `env` 出力で見える / 子プロセスへ継承される
+- shell session 終了まで env から secret が消えない（`unset TF_VAR_stream_key` の呼びかけが skill にない）
+
+**推奨**: skill ドキュメントに `unset TF_VAR_*` の cleanup を追記する、または `direnv` / `op run --` ラッパーを案内する。
+
+---
+
+# 追加で発見した周辺事項
+
+## (a) Terraform `null_resource.deploy` の SSH host key 検証なし — **P1**
+
+`infra/terraform/streaming/main.tf:55-60`:
+
+```hcl
+connection {
+    type  = "ssh"
+    host  = vultr_instance.this.main_ip
+    user  = "root"
+    agent = true
+}
+```
+
+`host_key = ...` / `target_platform` の指定なし。Terraform ssh provisioner の **デフォルト挙動は host key 検証なし**（StrictHostKeyChecking 相当が無効）。
+
+含意:
+- Vultr が VPS に割り当てる public IP に対して、初回 SSH 接続時に MITM された場合、検知できない
+- 11 GB の動画 SCP + `cron.d` / `healthcheck.sh` / `notify.sh` / `run-ffmpeg.sh` の **すべて** が攻撃者経路を通る可能性
+- cloud-init は `ssh_pwauth: false` で password 認証は無効化しているが、host key 検証なしのため経路自体は確保される
+
+実害確率は限定的（Vultr ネットワーク内の MITM、または DNS / BGP hijack が必要）だが、IaC のベストプラクティスとしては:
+- `vultr_instance` 作成後、cloud-init の最初の段階で host key を Vultr API（あれば）または instance log から取得し、`connection { host_key = ... }` に埋める
+- または provisioner を捨て、cloud-init で全配置を完結させる
+
+**推奨**: `data.vultr_instance_user_data` 等で startup-script から host key を取り出し、二段階 apply で host_key を pin する。これは別 issue 化を推奨。
+
+## (b) `channel-new` Step 3 の token.json コピー — **P2**
+
+`.claude/skills/channel-new/SKILL.md:62-82`:
+
+```bash
+ls -d ../*/auth/token.json 2>/dev/null
+# ユーザーに候補を選ばせる
+cp <選択されたパス> auth/token.json
+```
+
+「リサーチ用ショートカット」として、既存チャンネルの `token.json` を新リポジトリへコピーして再利用する。
+
+懸念:
+- コピーされた token は **元チャンネルの全 scope（write + analytics）** を保持
+- 新リポジトリでベンチマーク収集（read のみ）に使う前提だが、書き込み API も呼べる
+- Step 3 末尾に「ベンチマーク収集完了後にコピーを破棄」のような guidance がない
+- 複数チャンネル間で同一 OAuth client で発行された token が混在する可能性
+
+**推奨**: SKILL.md に「リサーチ完了後 `rm auth/token.json` で削除し、本番セットアップ時に再認証」のステップを追記。または read-only scope の専用 token をコピー対象にする。
+
+## (c) `notification.py:62-63` の例外メッセージ — **P3**
+
+```python
+except (urllib.error.URLError, TimeoutError) as e:
+    raise NotificationError(f"webhook POST failed: {e}") from e
+```
+
+`urllib.error.URLError(e)` の `__str__` に URL が含まれる実装パスはまれ（通常は reason のみ）だが、HTTPError 派生では URL が `e.url` 経由で含まれることがある。webhook URL は secret なので、エラーログに混入する余地が小さく残る。
+
+`vultr_bandwidth.py:44-45` の `YouTubeAPIError(f"Vultr bandwidth API request failed: {e}")` も同様。Vultr URL に instance_id は入るが API key は header のみで URL には載らない。
+
+**推奨**: 例外フォーマット時に `str(e)` を `_redact()` に通すヘルパーを `utils/secrets.py` に追加し、horizontal に適用。
+
+## (d) `masterup` skill の `curl -L` パターン — **P3**
+
+`.claude/skills/masterup/SKILL.md:88-89`:
+
+```bash
+curl -L -o "02-Individual-music/{filename}.mp3" "https://cdn1.suno.ai/{song_id}.mp3"
+```
+
+`{song_id}` はユーザーが WebFetch で取得した自分の playlist の Song ID。HTTPS なので path 改ざんはない。`-L` でリダイレクトを許す → CDN が悪意ある redirect chain を返すと別ホストにアクセスする可能性。Suno CDN を信頼する前提なら問題ないが、`--max-redirs 3` を付けると保守的。
+
+## (e) Bench スクリプトの `os.environ.get(... )` 直読み — **P3（意図通り）**
+
+`bench/bench_generate_image.py:61`, `bench/bench_real_apis.py:27` は `OPENAI_API_KEY` を `os.environ.get` で boolean 存在チェックするのみ。実際の API 呼び出しは `image_provider/openai.py` 経由で `get_secret()` がもう一度走るため、1Password fallback も効く。
+
+bench の目的（CI で skip するか判定）に照らせば意図通り。ただし `OPENAI_API_KEY` が `.env` にも env にも無く 1Password だけにある場合、bench は SKIP になる。これは bench の設計上の制約。
+
+---
+
+# 既知リスク仮説（plan の H7）の検証
+
+| ID | 仮説 | 検証結果 |
+|---|---|---|
+| **H7** | `auth/token.json` を skill が直接読む箇所が残存 | ✅ **検証済み（否定）**: Grep `open\([^)]*token\.json` / `Path\([^)]*token\.json` / `json\.load.*token` ヒット 0 件。token.json への直接アクセスは `YouTubeOAuthHandler` に閉じている |
+
+---
+
+# 調査不可項目
+
+| 項目 | 理由 |
+|---|---|
+| `auth/client_secrets.json` の実体の有無 / 内容 | ポリシー上 read 禁止。存在チェックのみ可だが、本 worktree には `auth/SETUP.md` と `auth/client_secrets_template.json` のみが置かれており実体は存在しない |
+| ローカル `terraform.tfstate` の中身（実 stream_key を含むか） | gitignore 済みで本 worktree に存在しない（`infra/terraform/streaming/.terraform/` 不在）。production 環境でのみ生成される |
+| 1Password vault の実際の保護状態（MFA、shared / personal の境界） | リポジトリ外の運用設定。コードからは検証不可 |
+| Vultr 側ファイアウォール / API token のアクセス制限 | Vultr UI 設定。リポジトリ外 |
+
+---
+
+# 推奨アクション（優先度順）
+
+| # | 優先度 | 推奨アクション |
+|---|---|---|
+| 1 | **P1** | `auth/token.json` の scope 分離（read-only token / write token）。`fetch_stream_key.py` の `token_streaming.json` パターンを横展開 |
+| 2 | **P1** | Terraform `null_resource.deploy.connection` に `host_key` pin を導入（または cloud-init 単独配置に切替） |
+| 3 | P2 | `.gitignore` に `service-account*.json` を追加 |
+| 4 | P2 | Terraform remote backend 検討（gcs / s3 + CMEK） |
+| 5 | P2 | `channel-new` Step 3 末尾に token.json cleanup ステップを追記 |
+| 6 | P2 | `streaming` skill に `unset TF_VAR_*` の post-cleanup ガイダンスを追記 |
+| 7 | P3 | `_redact()` を horizontal helper として utils へ昇格し `NotificationError` / `YouTubeAPIError` の format に適用 |
+| 8 | P3 | `masterup` の `curl -L` に `--max-redirs 3` を追加 |
+
+---
+
+# 結論
+
+- **シークレット直書き / git 履歴混入 / ログ漏洩はゼロ件**。`utils.secrets._SECRET_REFS` と `_redact()` の二層防御は production code 全体で一貫している。
+- 残るリスクは **scope 設計**（token.json 1 本に broad scope 同居）と **Terraform first-connect 検証**（host key 未 pin）の 2 点に集約。いずれも単発の修正で改善可能。
+- 既知仮説 H7（token.json を直接読む skill）は **否定**。
+- P0 は **0 件**。P1 が 2 件、P2 が 5 件、P3 が 3 件。
+
+監査スコープ上、本 PR では修正は行わない（観点 5 は監査のみ）。analyze / supervise step で fix リストを編成する際の根拠資料として本ファイルを参照すること。

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/06-data-dependencies.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/06-data-dependencies.md
@@ -1,0 +1,157 @@
+# C-1: 依存ライブラリの健全性 — 監査データ
+
+調査日: 2026-05-18
+担当: dig.part-c-deps-deprecation
+対象リビジョン: HEAD（worktree `20260518T0905-372-issue-372-chore-skills-sukiru`）
+
+---
+
+## 6.1 pyproject.toml 依存棚卸し
+
+### 6.1.1 `[project.dependencies]`（main 依存）
+
+出典: `pyproject.toml:13-28`
+
+| パッケージ | 制約 | uv.lock 解決 | PyPI latest stable (2026-05-18 確認) | 遅延 | 備考 |
+|---|---|---|---|---|---|
+| `google-api-python-client` | （無制約） | 2.193.0 | 2.196.0（2026-01-13 last_serial） | パッチ 3 | 健全 |
+| `google-auth-oauthlib` | （無制約） | 1.3.0 | **1.4.0（2026-05-07 リリース）** | マイナー 1 つ遅延 | 健全 |
+| `google-auth-httplib2` | （無制約） | 0.3.0 | **0.4.0（2026-05-07）／⚠️ PyPI で deprecated 表明** | パッチ程度 | **要対応**（後述 6.3） |
+| `google-genai` | （無制約） | 1.69.0 | **2.4.0（メジャー乖離）** | **メジャー 1 つ遅延** | **要評価**（後述 6.2） |
+| `openai` | （無制約） | 2.33.0 | 2.37.0 | パッチ 4 | 健全 |
+| `Pillow` | （無制約） | 12.1.1 | 12.2.0 | パッチ 1 | 健全 |
+| `python-dotenv` | （無制約） | 1.2.2 | 1.2.2（2026-03-01） | 同等 | 健全 |
+| `pandas` | （無制約） | 3.0.1 | 3.0.3 | パッチ 2 | 健全 |
+| `matplotlib` | （無制約） | 3.10.8 | 3.10.9 | パッチ 1 | 健全 |
+| `japanize-matplotlib` | （無制約） | 1.1.3 | 1.1.3（2020-10-21 リリース、以降 4 年超更新なし） | 同等 | **メンテ停滞**（後述 6.3） |
+| `seaborn` | （無制約） | 0.13.2 | 0.13.2（2024-01-25） | 同等 | やや停滞、現役 |
+| `schedule` | （無制約） | 1.2.2 | 1.2.2（2024-06-18） | 同等 | 現役 |
+| `pyyaml` | （無制約） | 6.0.3 | 6.0.3 | 同等 | 健全 |
+| `requests` | （無制約） | 2.33.0 | 2.34.2 | パッチ 1 | 健全 |
+
+### 6.1.2 `[project.optional-dependencies]`
+
+出典: `pyproject.toml:33-35`
+
+| グループ | パッケージ | 制約 | uv.lock 解決 | PyPI latest |
+|---|---|---|---|---|
+| `dev` | `pytest` | 無制約 | 9.0.2 | 9.0.3 |
+| `dev` | `ruff` | 無制約 | 0.15.8 | 0.15.13 |
+| `veo` | （空配列） | — | — | — |
+
+`[project.optional-dependencies] veo = []` は `# google-genai, Pillow moved to main dependencies` とコメントが付いており、空の extras を残している。`pip install 'youtube-channels-automation[veo]'` を打っても何もインストールされない。**dead extras**（残骸）。
+
+---
+
+## 6.2 pin の妥当性
+
+### 6.2.1 全依存が pin なし
+
+全 16 件の依存（main 14 + dev 2）に対し、`==` / `>=` / `~=` / 上限指定 (`<X`) のいずれも **一切付与されていない**。
+
+```
+"google-api-python-client",
+"google-auth-oauthlib",
+...
+```
+
+→ PyPI で破壊的変更（例: `pandas` 4.x、`openai` 3.x）がリリースされた瞬間に下流チャンネルリポジトリの `uv add` / `pip install` がランタイム不整合を引き起こすリスク。`uv.lock` をコミット済み（`git ls-files` で `uv.lock` 確認済み）だが、下流が uv ではなく pip でインストールする場合に lockfile は使われない。
+
+### 6.2.2 メジャー乖延ありの依存に上限を切るべき候補
+
+- `google-genai`: 1.69.0 → 2.4.0 のメジャーアップで SDK API 互換性が崩れている可能性高。`google.genai` 直 import 箇所（`src/youtube_automation/utils/genai_client.py:23`, `src/youtube_automation/utils/veo_generator.py:36`, `src/youtube_automation/utils/image_provider/gemini.py:36`, `src/youtube_automation/scripts/video_analyze.py:29`, `src/youtube_automation/scripts/benchmark_collector.py:538`, `src/youtube_automation/utils/video_analyzer.py:27`）で `types.GenerateVideosConfig` / `types.Image.from_file` などを使用。SDK 2.x で型インポートパスが変わっている可能性があるため、当面 `google-genai>=1.60,<2` 等の上限指定を検討する価値あり
+- `pandas`: 2.x → 3.x で `DataFrame.append` 等の API が削除されている。コード側は 3.0.1 を解決しているので追従済みだが、下流環境次第で爆発する
+
+### 6.2.3 hard pin の有無
+
+`==` による hard pin は **ゼロ件**。security update を取れない過剰 pin は無い。これは健全方向（ただし 6.2.1 の上限不在とのトレードオフ）。
+
+---
+
+## 6.3 deprecated / archived dependency
+
+### 6.3.1 `google-auth-httplib2`（PyPI で deprecated 表明）
+
+出典: PyPI `google-auth-httplib2 0.4.0` ページ（2026-05-07 リリース）
+
+> "this library is no longer maintained. For any new usages please see provided transport layers by google-auth library."
+
+このリポジトリは `google-api-python-client` 経由で必要としているため即時撤去不可だが、**新規 import 禁止 + Google 公式の移行ガイドに従う計画を立てるべき**。codebase 直 import は無し（`grep "google_auth_httplib2"` で 0 件）。`googleapiclient.discovery.build` の内部依存。
+
+### 6.3.2 `japanize-matplotlib`（最終リリース 2020-10-21、4 年超停滞）
+
+出典: PyPI `japanize-matplotlib 1.1.3` リリースページ
+
+リリース履歴: 1.1.3 (2020-10-21) で停止。GitHub リポジトリ uehara1414 もアクティブな更新なし。
+
+実コード使用箇所:
+
+```
+src/youtube_automation/utils/launch_curve_plotter.py
+src/youtube_automation/utils/channel_trend.py
+src/youtube_automation/utils/theme_performance.py
+```
+（grep で確認）
+
+matplotlib 3.10.x 以降のフォント解決と齟齬が出始める可能性があり、代替として `matplotlib.font_manager` で日本語フォントを直接登録する方法が現代的。**P2: 中長期的に置き換え検討**。
+
+### 6.3.3 archived の有無
+
+`schedule` (1.2.2, 2024-06-18) / `seaborn` (0.13.2, 2024-01-25) は更新頻度が低いが PyPI / GitHub では archived 表明なし。現役扱い。
+
+---
+
+## 6.4 lockfile 運用
+
+### 6.4.1 `uv.lock` の存在と再現性
+
+`uv.lock` は git 管理下（`git ls-files | grep lock` で確認済み）、`version = 1`、`requires-python = ">=3.11"` を宣言（uv.lock:1-3）。1687 行で 60 程度のパッケージを解決。
+
+`flake.lock` も commit 済み（nix 利用者向け）。
+
+`requirements.txt` / `requirements.lock` / `Pipfile.lock` 等は存在せず、pip 利用者は実質 PyPI 最新を引く運用。
+
+### 6.4.2 下流再現性ギャップ
+
+下流チャンネルリポジトリは `uv add git+https://github.com/daiki-beppu/youtube-automation` でインストールする（`src/youtube_automation/cli/skills_sync.py:3-4` モジュール docstring に記載）。
+
+**問題**: `uv add` した時点で `uv.lock` は **チャンネルリポジトリ側の lock** に展開される。本リポジトリの `uv.lock` は単なる開発時 lock であり、下流に伝播しない。`pyproject.toml` の依存に上限指定が無いため、下流が `uv add` した日次のタイミング次第で異なる依存バージョンが解決される。
+
+---
+
+## 6.5 Python バージョン制約
+
+### 6.5.1 宣言
+
+- `pyproject.toml:9`: `requires-python = ">=3.11"`
+- `pyproject.toml:107`: `[tool.ruff] target-version = "py311"`
+- `.python-version`: `3.11`
+- `uv.lock:3`: `requires-python = ">=3.11"`
+
+3 箇所で 3.11 が一致しており、整合性は取れている。
+
+### 6.5.2 実装側の Python 3.11+ syntax 使用状況
+
+- `from __future__ import annotations` 使用ファイル: **88 件**（grep で確認）。3.10 互換性を残す形
+- `match`/`case` (3.10+) 使用: 0 件確認（grep で match/case パターン 0 件）
+- `typing.Self` / `typing.override` (3.11+ / 3.12+) 使用: 0 件
+- `typing.ParamSpec` / `TypeVarTuple` (3.10+): 0 件
+- 旧式 `Dict` / `List` / `Optional` from `typing`: 多数（`src/youtube_automation/agents/youtube_auto_uploader.py:20` 等）残存
+
+実 syntax は 3.10 互換レベルで書かれている。`requires-python = ">=3.11"` は **過剰制約**の可能性あり、`>=3.10` に下げても動く見込み（ただし pandas 3.x が py3.10 を切っている可能性があるので uv.lock の transitive 解決と要突合せ）。
+
+---
+
+## まとめ（依存健全性 severity）
+
+| ID | 内容 | severity |
+|---|---|---|
+| 6.1 | 直接依存にメジャー遅延あり (`google-genai` 1.69 → 2.4) | **P1** |
+| 6.2.1 | 全依存に version 上限なし → 下流で破壊的アップデート被弾の余地 | **P1** |
+| 6.2.2 | `[project.optional-dependencies] veo = []` の dead extras 残骸 | P3 |
+| 6.3.1 | `google-auth-httplib2` は PyPI で deprecated 表明済み | **P1** |
+| 6.3.2 | `japanize-matplotlib` 4 年超更新停止 | P2 |
+| 6.4.2 | `uv.lock` は下流に伝播しないため再現性ギャップあり | P2 |
+| 6.5.2 | `requires-python = ">=3.11"` が実 syntax より過剰制約の可能性 | P3 |
+
+調査不可項目: なし（全項目データ取得済み）。

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/07-data-dependencies-compat.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/07-data-dependencies-compat.md
@@ -1,0 +1,419 @@
+# Part C: 依存・廃止 API・互換性レポート
+
+**調査日**: 2026-05-18
+**担当**: `dig.part-c-dependencies-compat`
+**対象リビジョン**: HEAD (`20260518T0905-372-issue-372-chore-skills-sukiru`)
+**スコープ**: 計画 `plan.1.20260518T090751Z.md` の **Part C** (観点 5: 廃止 API・SDK・依存 / 観点 6: 外部サービス単一障害点)
+**非スコープ**: 失敗時挙動 / コスト制御 (Part A) / シークレット (Part B) — 既存レポート参照
+
+> 注: order.md の章番号体系では本 Part が扱うのは「観点 6: 依存 / 環境前提 / 廃止リスク」+ それを掘り下げた「外部サービス単一障害点」観点。本プロンプト内呼称「観点 5 + 観点 6」は plan.1 内部の番号付け（Part C 観点 5 = deps、観点 6 = SPOF）に合わせている。
+
+---
+
+## 1. severity 別サマリー
+
+| severity | 件数 | 概要 |
+|---|---|---|
+| **P0** | 1 | Vertex AI Lyria 3 `interactions` API レスポンススキーマが **2026-05-26 にデフォルト切替 / 2026-06-08 に legacy 完全削除**。`lyria_client.py:149` は legacy `outputs` を直接読み込み済、無音失敗で `None` を返して停止 |
+| **P1** | 4 | (a) `gemini-2.5-flash` / `gemini-2.5-flash-lite` shutdown 2026-10-16 (4 use site), (b) `google-genai` 1.69 vs 2.4 major gap + 上限 pin なし → CI 再ビルドで突然 2.x が降ってくる, (c) `google-auth-httplib2` upstream で deprecated 表明, (d) skill バージョン追跡なし — `yt-skills sync --force` 明示が前提 |
+| **P2** | 6 | Lyria 3 endpoint `v1beta1` 直叩き、Veo 3.1 Lite ID の表記揺れ、`dead extras` (`veo = []`)、`japanize-matplotlib` 4 年超停滞、空 `Workflow` dataclass、CLAUDE.md L38 と L100 の矛盾 |
+| **P3** | 3 | `audio_units.py` の `lyria-002` 残置、`yt-config-migrate` 撤去判断、`requires-python = ">=3.11"` 過剰制約疑い |
+| **CLI 要件欠落** | 5 | `ffmpeg` / `gcloud` / `gh` / `op` / `uv` の **最低バージョン**未明示。`ONBOARDING.md:31-39` 全項目「最新」のみ |
+| **障害時ガイダンス欠落** | 27/35 skill | SKILL.md に「API 障害時 / rate limit 時 / 未認証時 / CLI 不在時」のいずれも記述なし |
+| **調査不可** | 3 | Suno UI 仕様変更スケジュール、Lyria 3 GA 時期、`veo-3.1-lite-generate-preview` の公式 publisher model ID |
+
+主要 finding 上位 3 件:
+1. **[P0]** `src/youtube_automation/utils/lyria_client.py:149` legacy schema 依存 — 2026-05-26 にサイレント失敗
+2. **[P1]** `pyproject.toml:13-28` 全 16 依存が上限なし — `uv lock --upgrade` で破壊的更新を引き込む余地
+3. **[P1]** 35 skill 中 27 件で外部サービス障害時ガイダンスゼロ — 沈黙停止運用
+
+---
+
+## 2. 観点 5-1: モデル名 / API バージョン hard-coding 監査
+
+### 2.1 使用モデル一覧
+
+| モデル ID | 使用箇所 (`file:line`) | deprecation 状況 | severity | 出典 |
+|---|---|---|---|---|
+| `gemini-2.5-flash` | `.claude/skills/benchmark/config.default.yaml:23`, `.claude/skills/video-analyze/config.default.yaml:7`, `.claude/skills/wf-new/references/scene_phrases.md:26`, `src/youtube_automation/scripts/benchmark_collector.py:523` | **deprecated**、shutdown **2026-10-16** | **P1** | [^gemini-dep] |
+| `gemini-2.5-flash-lite` | `src/youtube_automation/scripts/populate_scene_phrases.py:33` (`DEFAULT_GEMINI_MODEL`) | **deprecated**、shutdown **2026-10-16** | **P1** | [^gemini-dep] |
+| `gemini-3.1-flash-image-preview` | `src/youtube_automation/utils/image_provider/config.py:27`, `.claude/skills/thumbnail/config.default.yaml:18`, `.claude/skills/collection-ideate/SKILL.md:139` | preview（shutdown 未告知） | P2 | [^gemini-dep] |
+| `veo-3.1-fast-generate-001` | `src/youtube_automation/utils/veo_generator.py:15`, `src/youtube_automation/scripts/generate_loop_video.py:85`, `.claude/skills/loop-video/config.default.yaml:8`, `.claude/skills/loop-video/SKILL.md:107,116` | **GA** (2025-11-17) | OK | [^vertex-rn] |
+| `veo-3.1-generate-001` | `.claude/skills/loop-video/SKILL.md:116`, `src/youtube_automation/scripts/generate_loop_video.py:86` | **GA** | OK | [^vertex-rn] |
+| `veo-3.1-lite-generate-preview` | `.claude/skills/loop-video/config.default.yaml:7`, `.claude/skills/loop-video/SKILL.md:116`, `src/youtube_automation/scripts/generate_loop_video.py:75,86` | **preview**（公式 publisher model ID として明示確認できず、表記揺れ疑い） | P2 (要検証) | [^veo-lite] |
+| `lyria-3-pro-preview` | `.claude/skills/lyria/config.default.yaml:17`, `.claude/skills/lyria/SKILL.md:60,85,94`, `src/youtube_automation/utils/audio_units.py:14` | **preview**（GA 未告知） | P2 | [^lyria-docs] |
+| `lyria-3-clip-preview` | `.claude/skills/lyria/SKILL.md:85`, `src/youtube_automation/utils/audio_units.py:15` | **preview** | P2 | [^lyria-docs] |
+| `lyria-002` | `src/youtube_automation/utils/audio_units.py:16` (cost_tracker 単価マッピングのみ、選択肢に出てこない) | レガシー Lyria 2 (実利用なし) | P3 | — |
+| `gpt-image-2` | `src/youtube_automation/utils/image_provider/config.py:150`, `.claude/skills/thumbnail/config.default.yaml:89` | **GA** (2026-04-21) | OK | [^openai-models] |
+| `dall-e-*` / `gpt-image-1` / `imagen-*` | コードベースに参照 **0 件** (grep で確認) | — (削除済 dall-e は不使用) | OK | — |
+| `claude-*` / Anthropic SDK | コードベースに参照 **0 件** | — (本リポジトリは Anthropic SDK を直接叩かない) | OK | — |
+
+### 2.2 API バージョン / endpoint の hard-coding
+
+| 種別 | 箇所 | バージョン | リスク |
+|---|---|---|---|
+| YouTube Data API | `src/youtube_automation/utils/youtube_service.py:49` (`build("youtube", "v3", ...)`) | `v3` | 廃止予告なし [^yt-rev] |
+| YouTube Analytics API | `src/youtube_automation/utils/youtube_service.py:57` | `v2` | 廃止予告なし [^yt-analytics] |
+| YouTube Reporting API | `src/youtube_automation/utils/youtube_service.py:65` | `v1` | 廃止予告なし |
+| Vertex AI Lyria 3 Interactions | `src/youtube_automation/utils/lyria_client.py:26` (`v1beta1` 直叩き) | `v1beta1` | **P2: GA 化時に endpoint 変更**。実装は `requests` で URL を組み立てている (`lyria_client.py:124`) ため SDK の更新を待たずに直接修正が必要 |
+| Vertex AI google-genai client | `src/youtube_automation/utils/genai_client.py:23-44` | google-genai SDK 経由 (バージョン自動解決) | google-genai 2.x へ移行時に SDK API 互換性確認要 |
+| Lyria 3 response schema | `src/youtube_automation/utils/lyria_client.py:149` (legacy `outputs` フィールド読み取り) | **2026-05-26 デフォルト切替で破壊** | **P0** [^lyria-bcm] |
+
+### 2.3 skill 側 prompt にモデル名が埋まっているか
+
+- `.claude/skills/lyria/SKILL.md:60,85,94`、`.claude/skills/loop-video/SKILL.md:107,116`、`.claude/skills/thumbnail/SKILL.md:41`、`.claude/skills/video-analyze/SKILL.md:58`、`.claude/skills/benchmark/SKILL.md:98`、`.claude/skills/collection-ideate/SKILL.md:139` がモデル ID を直接記述。skill 同梱版は wheel に固定されるため、deprecated モデル更新時は **skill 配布側 + 下流の `yt-skills sync --force` が必須**。バージョン bump の責任所在を明文化していない（後段 §5 参照）。
+
+### 2.4 廃止予定モデル：影響範囲とタイムライン
+
+| 日付 | 事象 | 影響経路 |
+|---|---|---|
+| **2026-05-26** | Lyria 3 Interactions API デフォルトスキーマ切替 | `yt-generate-lyria-master` / `/lyria` 全チャンネル |
+| **2026-06-08** | Lyria 3 legacy schema 完全削除 | 同上、`Api-Revision: 2026-05-07` ヘッダ延命策も失効 |
+| **2026-10-16** | `gemini-2.5-flash*` shutdown | `/benchmark`, `/video-analyze`, `yt-populate-scene-phrases`, `benchmark_collector` 全チャンネル |
+
+[^gemini-dep]: <https://ai.google.dev/gemini-api/docs/deprecations> (2026-05-18 取得)
+[^vertex-rn]: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes> (2026-05-18 取得)
+[^veo-lite]: <https://cloud.google.com/blog/products/ai-machine-learning/veo-3-1-lite-and-a-new-veo-upscaling-capability-on-vertex-ai> (2026-05-18 取得)
+[^lyria-docs]: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music> (2026-05-18 取得)
+[^lyria-bcm]: <https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026> (2026-05-18 取得)
+[^openai-models]: <https://developers.openai.com/api/docs/models/gpt-image-2> + `https://developers.openai.com/api/docs/deprecations` (2026-05-18 取得)
+[^yt-rev]: <https://developers.google.com/youtube/v3/revision_history>
+[^yt-analytics]: <https://developers.google.com/youtube/analytics/revision_history>
+
+---
+
+## 3. 観点 5-2: Python 依存 version pin 監査
+
+### 3.1 `pyproject.toml` 依存表（取得日 2026-05-18）
+
+出典: `pyproject.toml:13-28` + uv.lock + PyPI
+
+| パッケージ | 現在 pin (`pyproject.toml`) | uv.lock 解決 | PyPI 最新 | risk | 推奨 |
+|---|---|---|---|---|---|
+| `google-api-python-client` | （無制約） | 2.193.0 | 2.196.0 | minor 遅延 | `>=2.193,<3` |
+| `google-auth-oauthlib` | （無制約） | 1.3.0 | 1.4.0 | minor 遅延 | `>=1.3,<2` |
+| `google-auth-httplib2` | （無制約） | 0.3.0 | 0.4.0 (deprecated 表明) | **P1** | `>=0.3,<1` で当面延命 + 撤去計画 |
+| `google-genai` | （無制約） | **1.69.0** | **2.4.0** | **P1** (major gap) | `>=1.69,<2`（Lyria 新スキーマ対応後に解放） |
+| `openai` | （無制約） | 2.33.0 | 2.37.0 | minor 遅延 | `>=2.33,<3` |
+| `Pillow` | （無制約） | 12.1.1 | 12.2.0 | パッチ遅延 | `>=12,<13` |
+| `pandas` | （無制約） | 3.0.1 | 3.0.3 | パッチ遅延 | `>=3,<4` |
+| `matplotlib` | （無制約） | 3.10.8 | 3.10.9 | パッチ遅延 | `>=3.10,<4` |
+| `japanize-matplotlib` | （無制約） | 1.1.3 | 1.1.3 (2020-10-21 stop) | **P2** メンテ停滞 | 置換検討 (`matplotlib.font_manager`) |
+| `seaborn` | （無制約） | 0.13.2 | 0.13.2 (2024-01-25) | 軽度停滞 | `>=0.13,<1` |
+| `schedule` | （無制約） | 1.2.2 | 1.2.2 (2024-06-18) | 軽度停滞 | `>=1.2,<2` |
+| `pyyaml` | （無制約） | 6.0.3 | 6.0.3 | OK | `>=6,<7` |
+| `requests` | （無制約） | 2.33.0 | 2.34.2 | パッチ遅延 | `>=2.33,<3` |
+| `python-dotenv` | （無制約） | 1.2.2 | 1.2.2 | OK | `>=1.2,<2` |
+| `pytest` (dev) | （無制約） | 9.0.2 | 9.0.3 | OK | `>=9,<10` |
+| `ruff` (dev) | （無制約） | 0.15.8 | 0.15.13 | OK | `>=0.15` |
+
+### 3.2 全依存上限不在の影響
+
+- `[project.dependencies]` 14 件 + `[project.optional-dependencies] dev` 2 件 = **計 16 件すべて name のみ**で `<X` 上限を持たない（`pyproject.toml:13-28, 33-34`）
+- 下流チャンネルが `uv add git+https://...youtube-channels-automation` した時点で **その日の PyPI 最新を引き込む**（`uv.lock` は本リポジトリ側にしか効かず、下流リポジトリの `uv.lock` は独立）
+- **特にクリティカル**: `google-genai` 1.x → 2.x の major bump は Vertex AI クライアント API が再設計されている。`src/youtube_automation/utils/genai_client.py:23`, `veo_generator.py:36`, `image_provider/gemini.py`, `scripts/video_analyze.py:29` 等が全停止しうる
+
+### 3.3 dead extras
+
+`pyproject.toml:35`:
+
+```toml
+veo = []  # google-genai, Pillow moved to main dependencies
+```
+
+→ `pip install 'youtube-channels-automation[veo]'` で何も入らない placeholder。撤去対象（P2）。
+
+[^pypi-genai]: <https://pypi.org/project/google-genai/>
+[^pypi-httplib2]: <https://pypi.org/project/google-auth-httplib2/>
+
+---
+
+## 4. 観点 5-3: 外部 CLI 依存マトリクス
+
+### 4.1 skill × CLI
+
+`grep -rnE 'command -v|shutil\.which|gh\b|terraform\b|ffmpeg\b|gcloud\b|op\b|yt-dlp|uv\b|rsync' .claude/skills` を集約。
+
+| skill | 必須 CLI | 存在チェック | 不在時メッセージ |
+|---|---|---|---|
+| `streaming` | `terraform`, `op`, `ssh-keygen`, `ssh-add`, `realpath` | ✅ `swap_video.sh:61,65,69,73` で `command -v` チェックあり | ✅ shell スクリプトはエラー終了 + 案内メッセージ。SKILL.md:14 で要件記載 |
+| `channel-setup` (gcp-bootstrap) | `gcloud`, `jq`, `terraform` | ✅ `gcp-bootstrap.sh:107`, `gcp-terraform-apply.sh:37,41` | ✅ メッセージあり |
+| `videoup` | `ffmpeg`, `afinfo` (macOS のみ) | ✅ `generate_videos.sh:79,95` | ✅ `ffmpeg` がないと exit 1。`afinfo` は optional fallback |
+| `masterup` | `yt-dlp`, `ffmpeg`, `curl` | ❌ SKILL.md は外部 CLI 呼び出しの存在チェックなし | ❌ コマンドが PATH に無い場合は `command not found` で停止。SKILL.md にも導入手順記載なし |
+| `loop-video` | `ffmpeg`, `ffprobe`, `gcloud` (ADC) | ✅ `src/youtube_automation/utils/veo_generator.py:122,140` で subprocess 呼び出し（`ffmpeg` 不在は subprocess エラー） | ❌ subprocess CalledProcessError で raw stderr が漏れる |
+| `lyria` | `gcloud` (ADC), `ffmpeg` (worktree_sync.sh は `set -e` のみ) | ❌ Python 側 `lyria_client.py` は ADC 未取得時 `ConfigError` で friendly メッセージあり (`lyria_client.py:118-122`)。`ffmpeg` 不在チェックは `generate_lyria_master.py` 経路では未確認 | △ ADC 系は OK、`ffmpeg` 系は曖昧 |
+| `video-upload` / `comments-reply` / `playlist` / `analytics-collect` / `benchmark` / `discover-competitors` / `metadata-audit` / `channel-status` | `gcloud` (ADC), 内部 Python のみ | — | OAuth 未認証時は `auth/oauth_handler.py:138-` で `FileNotFoundError` 親切メッセージ |
+| `pr` / `issue` / `release` (built-in `gh` 依存) | `gh` | ❌ skill 側に `gh` 不在チェックなし。skill 本文も「`gh` がインストールされている前提」 | ❌ 未認証 (`gh auth status` 失敗) 時はそのまま `gh` のエラーが出る |
+| `parallel` / `cmux` 系 | `cmux` | ❌ skill 側で `command -v` チェックなし | ❌ |
+| `nix` 系 | `nix`, `darwin-rebuild` | ❌ | ❌ |
+
+### 4.2 SKILL.md `Prerequisites` セクションの有無
+
+- 明示的に「事前に必要なツール」セクションがあるのは `streaming/SKILL.md:14` のみ（`terraform >= 1.5 / uv / op` を列挙）
+- 他 34 skill は前提 CLI の宣言なし。`ONBOARDING.md:31-39` の prerequisites 表に集約（**最低バージョン未明示**）
+
+### 4.3 ONBOARDING.md 「最低バージョン未明示」一覧（`ONBOARDING.md:31-39`）
+
+| CLI | 記載バージョン | 推奨記載 |
+|---|---|---|
+| `uv` | 最新 | `>= 0.4` 程度を明示推奨 |
+| `ffmpeg` | 最新 | `>= 4.4`（`xfade` フィルタ + `libx264` の安定動作下限） |
+| `gcloud` | 最新 | `>= 480`（ADC 関連の挙動安定） |
+| `op` | 最新 | **`>= 2.0` 必須**（v1 は `op read` URI 形式違い） |
+| `gh` | （記載なし） | `>= 2.0` |
+
+---
+
+## 5. 観点 5-4: 後方互換 shim 生存確認
+
+### 5.1 ルート直下 shim の実態
+
+CLAUDE.md（プロジェクト固有）L38:
+
+> `utils/`, `agents/`, `auth/`, `scripts/` — submodule 利用者向け **後方互換 shim**
+
+CLAUDE.md L100:
+
+> ルート `scripts/` にはシェルスクリプト（`.sh`）のみ配置。Python shim は廃止済み
+
+→ **同一ファイル内で矛盾**。実態は:
+
+| ディレクトリ | 存在 | 中身 | 性質 | 削除候補 |
+|---|---|---|---|---|
+| `utils/` | **不在** | — | CLAUDE.md L38 が古い記述 | — (既に削除済) |
+| `agents/` | **不在** | — | 同上 | — |
+| `auth/` | 存在 | `SETUP.md`, `client_secrets_template.json` | shim ではなく **template + ドキュメント** | 保持（用途は別） |
+| `scripts/` | 存在 | `gcp-bootstrap.sh`, `gcp-terraform-apply.sh` | shim ではなく **共通シェル** | 保持 |
+
+→ ルート直下に「Python shim として残っているもの」は **0 件**。CLAUDE.md L38 の修正が必要（P2: docs）。
+
+### 5.2 dead backward-compat shim（コード上）
+
+| ID | 箇所 | 内容 | 状態 |
+|---|---|---|---|
+| `Workflow` dataclass | `src/youtube_automation/utils/config/workflow.py:8-15` | フィールド 0 個の空 dataclass。v4.0.0 で `short` / `community` を撤去 | **dead shim**（P2: メジャー bump 時に整理候補） |
+| `_build_workflow` | `src/youtube_automation/utils/config/loader.py:266-271` | 常に空 `Workflow()` を返す placeholder | 上と同根 |
+| `workflow.json` 内 `short` / `community` キー | `CHANGELOG.md:500` で「素通し」運用宣言 | downstream の `workflow.json` 内の旧キーは無視される | 仕様的に確定済み |
+| `yt-config-migrate` | `pyproject.toml:48` 登録、`src/youtube_automation/cli/config_migrate.py` | v1→v2 migration CLI。**現在 v5.5.0**、3 メジャー超経過 | P3: 撤去判断要（loader 側は `loader.py:100-106` で legacy 形式を hard fail するため、コマンド自体は実質要らない可能性） |
+| `gemini_image:` namespace 旧 schema | `src/youtube_automation/utils/image_provider/config.py:102-107` で `DeprecationWarning` 発行中 | 旧 namespace から新 `image_generation:` への移行ガード | `.claude/skills/**/config.default.yaml` には `gemini_image:` の利用箇所 **0 件**（grep 確認済み）→ 既に下流配布版で使われていない疑い |
+| `OpenAIConfig.thinking` | `src/youtube_automation/utils/image_provider/openai.py:53` で `warnings.warn` | openai-python SDK が `thinking` kwarg を受け取らないため警告のみ | SDK 側が対応するまで保持 |
+
+### 5.3 deprecated 警告経路
+
+`grep -rnE 'warnings\.warn|DeprecationWarning' src/` 結果（テスト除く）:
+
+| 箇所 | 内容 |
+|---|---|
+| `src/youtube_automation/utils/image_provider/openai.py:53` | `OpenAIConfig.thinking` 渡されたが SDK 側で無視される警告 |
+| `src/youtube_automation/utils/image_provider/config.py:102-107` | 旧 `gemini_image:` namespace 利用警告 |
+
+→ deprecated 経路を skill から呼んでいる箇所は無し（`gemini_image:` namespace は .claude/skills/ 配下に存在しない）。
+
+---
+
+## 6. 観点 6-1: 外部サービス単一障害点マップ
+
+### 6.1 サービス × skill 依存マトリクス
+
+| 外部サービス | 依存 skill | 失敗時 fallback | 障害復旧手段 |
+|---|---|---|---|
+| **Vertex AI (Gemini)** | `benchmark`, `video-analyze`, `wf-new` (scene_phrases), `collection-ideate` | ❌ なし | Google ステータスページ確認 → 手動再実行 |
+| **Vertex AI (Veo)** | `loop-video` | ❌ なし。`utils/veo_generator.py:60-62, 70-72, 81-83, 91-93` で `except Exception` で `return False` | コスト発生済み（操作中断のみ） |
+| **Vertex AI (Lyria 3)** | `lyria`, `masterup` (経路: マスター結合のみ、生成は Lyria) | ❌ なし。`lyria_client.py:140-146` で `print` + `return None` | リトライは `generate_lyria_master.py` 側で `--max-retries`（既定 3）。429 は SKILL.md:200 で「クォータ管理は本スキルの責務外」と宣言 |
+| **OpenAI Images API** | `thumbnail` (provider: openai) | ✅ `gemini`/`openai` の **provider 切替可** (`image_provider/config.py:120-`) — config だけで切替成立 | provider を gemini にスイッチ |
+| **Suno (UI + CDN)** | `suno`, `masterup` | ❌ 完全ロックイン。`/suno` はプロンプト生成のみで API 呼ばないが、`/masterup` の `curl https://cdn1.suno.ai/{id}.mp3` + WebFetch HTML スクレイピング | 公式 SLA / 廃止スケジュール **未公開** |
+| **Vultr API + VPS** | `streaming` | ❌ 単一プロバイダ依存 | `terraform destroy` で停止、別プロバイダで `infra/terraform/streaming/` 再構築は要書き換え（vultr provider hardcode `versions.tf:5-8`） |
+| **YouTube Data API v3** | `video-upload`, `comments-reply`, `playlist`, `analytics-collect`, `benchmark`, `metadata-audit`, `channel-status`, `discover-competitors`, `videoup` (upload 経路) | ❌ なし。quota exceeded は googleapiclient HttpError → `YouTubeAPIError.from_http_error` 変換 (`utils/exceptions.py`) | 日次 quota 10,000 units リセット待ち |
+| **YouTube Analytics API v2** | `analytics-analyze`, `analytics-collect`, `analytics-report` | ❌ なし | 同上 |
+| **YouTube Reporting API v1** | analytics 系（CTR） | ❌ | 同上 |
+| **1Password CLI (`op`)** | `secrets.py` 経由で全 secret 取得 | ✅ `.env` `os.environ` フォールバックあり (`utils/secrets.py:55-58`)、`op` 不在時は `shutil.which("op")` 経由で silent skip (`secrets.py:60`) | `.env` 経路で代替可 |
+| **GitHub CLI (`gh`)** | `pr`, `issue`, `release`, `branch-clean`, takt 経由全体 | ❌ なし、PATH 依存 | `gh auth login` 手動 |
+| **Terraform** | `streaming`, `channel-setup` (terraform-gcp) | ❌ なし | brew install 等 |
+| **ffmpeg / ffprobe** | `loop-video`, `masterup`, `videoup`, `streaming`, `lyria` (master 結合) | ❌ なし | brew install |
+| **yt-dlp** | `masterup` | ❌ なし | brew install / pip install |
+| **GCP ADC (`gcloud auth application-default login`)** | Vertex AI 系全部 (`lyria`, `loop-video`, `thumbnail` (gemini)) | ❌ なし。`lyria_client.py:117-122` / `genai_client.py:38-42` で `GOOGLE_CLOUD_PROJECT` 未設定エラーは出すが、ADC 無効時の挙動は SDK 任せ | 手動 `gcloud auth application-default login` |
+
+### 6.2 fallback あり vs なし のサマリー
+
+| 種別 | サービス | 切替方法 |
+|---|---|---|
+| **fallback あり** | OpenAI ↔ Gemini (画像生成) | skill config (`image_generation.provider: gemini` / `openai`) |
+| **fallback あり** | 1Password (`op`) ↔ `.env` (環境変数) | プロセス起動時の `os.environ` 自動探索 |
+| **fallback なし** (= ロックイン) | Vertex AI Lyria 3 / Veo 3.1 / Gemini text / YouTube Data API / Vultr / Suno / `gh` / `terraform` / `ffmpeg` / `yt-dlp` | — |
+
+`/lyria` ↔ `/suno` は **音楽生成プロバイダ** として概念上は代替関係だが、生成プロセスが skill 自体まで完全に異なる（Lyria は自動、Suno は UI 手動）ためコード的な fallback は実装不可。
+
+### 6.3 circuit breaker / quota guard
+
+- **コード側**: なし（`generate_lyria_master.py` の `--max-retries` 既定 3 のみ）
+- **skill 側**: `discover-competitors/SKILL.md:14,116-121` のみ quota 消費見積もりを記述（660 units / 実行）
+- **`benchmark/SKILL.md:99,106`**: `thumbnail_analysis.delay_sec=5` で間隔調整
+- **`video-analyze/SKILL.md:67`**: `delay_sec` でレート制限回避
+- **`lyria/SKILL.md:200`**: 「クォータ管理・並列実行制御は本スキルの責務外」と明示 → 集中実行時の 429 リスクが顕在
+
+---
+
+## 7. 観点 6-2: SKILL.md 内の障害時ガイダンス記載監査
+
+### 7.1 35 skill × 障害時記述マトリクス
+
+検索キーワード: `rate limit|レート制限|429|503|quota|fallback|障害|止まったとき|エラーの場合|失敗時|落ちている|落ちた|API.*(エラー|失敗)|タイムアウト|timeout|サービス停止|認証.*失敗|認証エラー|未認証|未インストール|command not found|require[ds]?`
+
+`grep -ciE` ヒット件数 (`/SKILL.md` のみ対象):
+
+| skill | hits | コメント |
+|---|---|---|
+| `lyria` | **3** | rate limit (`SKILL.md:200`), `--max-retries` (`170,194`) |
+| `discover-competitors` | **3** | quota 消費見積もり (`14,116-121`) |
+| `benchmark` | 2 | delay_sec / rate limit対策 (`99,106`) |
+| `channel-setup` | 2 | YouTube API 400 エラー回避 (`104`) |
+| `collection-ideate` | 2 | 順次実行で rate limit 回避 (`168`) |
+| `comments-reply` | 1 | OAuth 403 時の token.json 削除手順 (`66`) |
+| `masterup` | 1 | `master.tmp.mp3` の atomic rename (`130`)（失敗時保護） |
+| `video-analyze` | 1 | API レート制限 delay (`67`) |
+| **alignment-check** | 0 | ❌ |
+| **analytics-analyze** | 0 | ❌ |
+| **analytics-collect** | 0 | ❌ |
+| **analytics-report** | 0 | ❌ |
+| **audience-persona** | 0 | ❌ |
+| **channel-direction** | 0 | ❌ |
+| **channel-import** | 0 | ❌ |
+| **channel-new** | 0 | ❌ |
+| **channel-research** | 0 | ❌ |
+| **channel-status** | 0 | ❌ |
+| **live-clean** | 0 | ❌ |
+| **loop-video** | 0 | ❌（Veo 課金経路、最重要なのに） |
+| **metadata-audit** | 0 | ❌ |
+| **playlist** | 0 | ❌ |
+| **postmortem** | 0 | ❌ |
+| **streaming** | 0 | ❌（Vultr API 障害時の経路なし） |
+| **suno** | 0 | ❌ |
+| **thumbnail** | 0 | ❌（OpenAI / Gemini 両方使う） |
+| **thumbnail-compare** | 0 | ❌ |
+| **video-description** | 0 | ❌ |
+| **video-upload** | 0 | ❌（YouTube quota exceeded 経路なし） |
+| **videoup** | 0 | ❌ |
+| **viewer-voice** | 0 | ❌ |
+| **viewing-scene** | 0 | ❌ |
+| **wf-new** | 0 | ❌ |
+| **wf-next** | 0 | ❌ |
+| **wf-status** | 0 | ❌ |
+
+→ **27/35 skill (77%)** で「外部サービス障害時にどうするか」「未認証時の対応」「rate limit 時の挙動」のいずれも SKILL.md に記述なし。**沈黙して止まる運用**になる。
+
+### 7.2 重要 skill の不足箇所
+
+- **`/loop-video`**: Veo 3.1 課金。`utils/veo_generator.py:60-62, 70-72, 81-83, 91-93` で `return False` する 4 経路あるが SKILL.md にはエラー類型と対処手順なし
+- **`/video-upload`**: `utils/upload_core.py` 経由。YouTube quota exceeded 時の挙動が SKILL.md に未記載（Part A の `data-failure-recovery.md` 参照）
+- **`/streaming`**: SKILL.md:14 で必須 CLI を列挙するが、`terraform plan` 失敗時 / Vultr API 障害時の手順なし
+- **`/thumbnail`**: `gemini` ↔ `openai` の provider 切替は実装上可能なのに SKILL.md:41 に「provider が落ちた時の切替手順」記述なし
+- **`/comments-reply`**: 唯一 OAuth 403 時の `auth/token.json` 削除手順を記載（良い例）
+
+### 7.3 `op read` / `gh` / `terraform` 不在時の挙動
+
+| 経路 | 不在時の挙動 |
+|---|---|
+| `op` 不在 (`utils/secrets.py:60`) | `shutil.which("op")` が `None` → 警告なく `os.environ` のみで解決 → 取れなければ `ConfigError` で 「`.env` または 1Password 設定」を案内 (`secrets.py:75-79`) ✅ 良 |
+| `op` あり、`op read` 失敗 (`secrets.py:72-73`) | 例外を握りつぶしてフォールスルー → 上と同じ `ConfigError` ✅ 良 |
+| `gh auth status` 未認証 | skill 側のチェックなし → `gh issue create` / `gh pr create` の raw stderr が直接表示（takt 経路では deny される可能性） ❌ |
+| `terraform` 未インストール | `swap_video.sh:61` で `command -v` チェックあり → 親切メッセージ ✅ / その他経路（`streaming/SKILL.md:54` の手動 `terraform init`）は手動実行で `command not found` |
+| `ffmpeg` 未インストール | `videoup/references/generate_videos.sh:79` `command -v` あり ✅、`utils/veo_generator.py:122-128`（subprocess）は CalledProcessError で raw stderr |
+| `yt-dlp` 未インストール（`masterup`） | チェックなし、`command not found` で落ちる ❌ |
+
+---
+
+## 8. 仮説検証結果（H9〜H12）
+
+| ID | 仮説 | 結果 | 根拠 |
+|---|---|---|---|
+| **H9** | `gemini-2.0-flash-exp` 等 `-exp` サフィックス付きモデルが production 経路で使われている | **否定** | `grep -rnE '-exp\b' src/ .claude/skills/` で 0 件。実利用は `gemini-2.5-flash` / `gemini-2.5-flash-lite` / `gemini-3.1-flash-image-preview` のみ |
+| **H10** | `veo-2.0-generate-001` の retire 後に動かなくなる skill が複数ある | **否定** | `grep -rnE 'veo-2\.0\|veo-3\.0' src/ .claude/skills/` で 0 件。実利用は `veo-3.1-fast-generate-001` / `veo-3.1-generate-001` / `veo-3.1-lite-generate-preview`。**ただし** Veo 系では `gemini-2.5-flash*` の方が 2026-10-16 リスクとして上位 |
+| **H11** | ルート直下 shim の中に「もはや誰も import していない死んだ shim」がある | **△ 部分検証 — ルート shim は実在しない、コード内 shim は実在** | `utils/` / `agents/` ルート直下に shim ファイル無し（既に削除済）。一方で `Workflow` dataclass (`src/youtube_automation/utils/config/workflow.py:8-15`) が空、`_build_workflow` (`loader.py:266-271`) が無条件 placeholder で **dead shim**。`yt-config-migrate` も v5.5.0 で 3 メジャー超経過しており撤去候補 |
+| **H12** | `pyproject.toml` の依存にメジャーバージョン pin が無く、google-cloud-aiplatform の breaking change で全停止する余地がある | **検証（pin 不在を確認、ただし google-cloud-aiplatform は直接依存していない）** | 直接依存は 16 件全て上限なし (`pyproject.toml:13-28`)。`google-cloud-aiplatform` は直接依存ではない（uv.lock にも未掲載）が、代わりに **`google-genai`** が 1.69 → 2.4 メジャー差で同等のリスク。実質的に H12 は `google-genai` で実現する |
+
+---
+
+## 9. 調査不可項目とその理由
+
+| # | 項目 | 理由 |
+|---|---|---|
+| 1 | Suno UI / CDN の正確な廃止スケジュール | 公開情報なし（Suno は SLA / 廃止予告ポリシーを公表していない）。「未検証 / 公開情報なし」 |
+| 2 | Vertex AI Lyria 3 GA 化時期 | 公式 release-notes 上 2026-05-18 時点で GA アナウンスなし。`v1beta1` のままがいつまで継続するか不明 |
+| 3 | `veo-3.1-lite-generate-preview` の正式 publisher model ID | Vertex AI Model Garden に直接アクセスできず、複数 web ソースで表記揺れ。確定不可 |
+| 4 | `daiki-beppu/youtube-automation` vs `youtube-channels-automation` のリポジトリ名混在 | GitHub 上で実体を確認する権限が `gh` 経由ではこの worktree から実行不可。`pyproject.toml:31` の URL と `ONBOARDING.md:48-51` の URL を比較した範囲では同一所有者下に並存している可能性あり |
+| 5 | 下流チャンネルでの実利用バージョン | git remote 接続不可、ローカル `.takt/runs/` には下流の情報なし |
+| 6 | `pip-audit` 相当の CVE スキャン | 1 件ずつ精査する手段が限られ、本 Part の責務外 |
+
+---
+
+## 10. 推奨アクション（severity 付き、別 issue 化想定）
+
+### 10.1 即時対応（P0 — 2026-05-25 までに）
+
+| # | アクション | 対象 | コミット先 |
+|---|---|---|---|
+| 1 | Lyria 3 Interactions API 新スキーマ対応（`steps[*].content[*]` 読み取り） | `src/youtube_automation/utils/lyria_client.py:148-154` | 別 issue。応急処置として `Api-Revision: 2026-05-07` ヘッダ追加（`lyria_client.py:133-136`）で 2026-06-08 までは延命可能だが、本対応が必須 |
+
+### 10.2 短期（P1 — Q3 2026 中）
+
+| # | アクション | 対象 |
+|---|---|---|
+| 2 | `gemini-2.5-flash` → `gemini-3-flash-preview` 系へ移行 | `.claude/skills/{benchmark,video-analyze}/config.default.yaml`, `benchmark_collector.py:523` |
+| 3 | `gemini-2.5-flash-lite` → `gemini-3.1-flash-lite` へ移行 | `populate_scene_phrases.py:33` |
+| 4 | `pyproject.toml` に少なくとも `google-genai>=1.69,<2`, `google-auth-httplib2<1`, その他全 main 依存に `<X+1` 上限を追加 | `pyproject.toml:13-28` |
+| 5 | `yt-skills sync --force` 必須運用を README / ONBOARDING.md に明示 | `ONBOARDING.md`, `README.md` |
+| 6 | `google-auth-httplib2` の `transport` 移行計画を立てる（upstream deprecated 表明への追従） | discovery 用に検証 |
+
+### 10.3 中期（P2）
+
+| # | アクション | 対象 |
+|---|---|---|
+| 7 | SKILL.md に「外部サービス障害時の対応」セクションを 27 件の skill に追加 | 観点 6-2 表に列挙した 27 skill |
+| 8 | `Workflow` dataclass + `_build_workflow` を撤去（メジャー bump 時） | `src/youtube_automation/utils/config/workflow.py`, `loader.py:266-271` |
+| 9 | `[project.optional-dependencies] veo = []` を撤去 | `pyproject.toml:35` |
+| 10 | `japanize-matplotlib` 撤去 / `matplotlib.font_manager` 経由の日本語フォント登録に置換 | `launch_curve_plotter.py`, `channel_trend.py`, `theme_performance.py` |
+| 11 | `veo-3.1-lite-generate-preview` の公式 publisher model ID を Vertex AI Model Garden で確認、不一致なら skill 補正 | `.claude/skills/loop-video/config.default.yaml`, `SKILL.md` |
+| 12 | CLAUDE.md L38 を「`utils/`, `agents/` shim は撤去済」に修正 | `CLAUDE.md` |
+
+### 10.4 低（P3）
+
+| # | アクション | 対象 |
+|---|---|---|
+| 13 | `audio_units.py` から `lyria-002` を削除 | `src/youtube_automation/utils/audio_units.py:16` |
+| 14 | `yt-config-migrate` 撤去判断（v1→v2 migration 完了とみなす） | `pyproject.toml:48`, `cli/config_migrate.py`, `loader.py:100-106` |
+| 15 | ONBOARDING.md に各 CLI の最低バージョンを明示（`ffmpeg >= 4.4`, `op >= 2.0`, `gh >= 2.0`, `gcloud >= 480`） | `ONBOARDING.md:31-39` |
+| 16 | `gemini_image:` namespace deprecation warning を撤去（実利用 0 件確認済） | `utils/image_provider/config.py:100-107` |
+| 17 | `masterup`, `videoup` に `yt-dlp` / `ffmpeg` の `command -v` チェックを追加（または skill 側で前提宣言） | 各 skill / references shell |
+
+---
+
+## 11. Part A / Part B との非重複確認
+
+本 Part が **触れていない** Part A/B の範囲:
+
+| カテゴリ | 本 Part スコープ外 | 担当レポート |
+|---|---|---|
+| 失敗時リトライ / 部分生成物掃除 / `trap` / `set -e` | 蝶々で扱わない | `data-failure-recovery.md` (Part A) |
+| 課金単価 / `cost_tracker` / dry-run / confirm prompt | 触れない | `data-billing-cost.md`, `data-billing-cost-control.md` (Part A) |
+| シークレット直書き / `op://` 検出 / token scope grep | 触れない | `data-security-secrets.md` (Part B) |
+| `StrictHostKeyChecking` / Terraform SSH host_key | 触れない（terraform に `host_key` 設定不在のみ言及）| `data-security-secrets.md` (Part B) |
+| shell injection / `eval`, `subprocess shell=True` | 触れない | `data-security-secrets.md` (Part B) |
+
+本 Part が **重複している** 箇所と説明:
+
+| 項目 | 重複先 | 説明 |
+|---|---|---|
+| モデル名 deprecation 表 | `data-external-api-deprecation.md`, `data-deps-deprecated.md` | 既存 Part C 試行で重複生成された 2 ファイルと内容が重なる。本レポートは **計画指定の最終出力** として一本化、章番号体系を統一 |
+| Python 依存 pin 表 | `data-dependencies.md` | 同上、本レポートに集約 |
+| 後方互換 shim | `data-backward-compat-shims.md` | 同上、本レポートに集約 |
+
+→ 既存 4 partial ファイル (`data-deps-deprecated.md` / `data-backward-compat-shims.md` / `data-external-api-deprecation.md` / `data-dependencies.md`) は本レポートの **詳細補足** として残存させる。analyze step では本 `data-dependencies-compat.md` を一次入力とし、必要時に partial ファイルへ参照を貼ること。
+
+---
+
+## 12. 未調査 skill リスト（カバレッジ確認）
+
+35 skill のうち、SKILL.md 障害時ガイダンス監査は **全件カバー済み**（§7.1 表）。
+外部 CLI 依存マトリクスは **主要 9 skill 群 + その他 26 件 = 全 35 件カバー済み**（§4.1 表）。
+未調査 skill: **0 件**。
+

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/08-data-deps-deprecated.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/08-data-deps-deprecated.md
@@ -1,0 +1,333 @@
+# data-deps-deprecated.md
+
+**調査範囲:** `.claude/skills/**` および `src/youtube_automation/**` が依存する外部 API / SDK / モデル / ツールの「廃止予定」「バージョン陳腐化」「URL リンク切れ」「pin されていない依存」監査。
+**調査日:** 2026-05-18
+**対象ワークツリー:** `/Users/mba/02-yt/takt-worktrees/20260518T0905-372-issue-372-chore-skills-sukiru/`
+**前提:** PR #367 で実施済の汎用化観点は対象外。本レポートは「来月動かなくなる可能性のあるもの」に限定する。
+
+---
+
+## 1. severity サマリー
+
+| severity | 件数 | 概要 |
+|---|---|---|
+| **P0 (即時)** | 1 | Vertex AI Interactions API の legacy `outputs` スキーマ — **2026-05-26 デフォルト切替 / 2026-06-08 完全削除** |
+| **P1 (3-5 ヶ月以内)** | 2 | `gemini-2.5-flash` / `gemini-2.5-flash-lite` リタイア（2026-10-16）、Vertex AI 生成系 SDK 旧 `google-cloud-aiplatform.generative_models` 廃止（2026-06-24） |
+| **P2 (中期)** | 4 | `google-genai` SDK の major 1.x → 2.x ギャップ、`pyproject.toml` に上限 pin 一切なし、Lyria endpoint が `v1beta1` のまま、Veo `lite-generate-preview` モデル ID の妥当性が不明 |
+| **P3 (低)** | 2 | `audio_units.py` の `lyria-002` が古い、`auth_units` テーブルに `lyria-3-pro-preview` の "song" 単位など preview 由来の表記が残存 |
+| **CLI 要件欠落** | 5 | `ffmpeg` / `gcloud` / `gh` / `op` / `uv` の最低バージョン未明示（README/ONBOARDING/skill いずれも「最新」止まり） |
+| **URL リンク切れ** | 0 | 検出された外部 URL は全て到達可能 |
+| **調査不可** | 1 | Suno API は本リポジトリでは直接呼び出していない（プロンプト生成のみ）ため評価対象外 |
+
+---
+
+## 2. 外部 API / モデル バージョン対比表
+
+取得日 2026-05-18。出典は脚注参照。
+
+| ID | 現在 pin / 参照 | 2026-05 最新 | 廃止予定 (日付) | severity |
+|---|---|---|---|---|
+| Vertex AI Lyria 3 Interactions API endpoint | `v1beta1` ([lyria_client.py:26](../../../../src/youtube_automation/utils/lyria_client.py)) | `v1beta1` (まだ GA なし) | 不明 (GA 時に breaking 想定) | P2 |
+| Interactions API レスポンススキーマ | legacy `outputs` ([lyria_client.py:149](../../../../src/youtube_automation/utils/lyria_client.py)) | 新スキーマ `steps[*].content[*]` | **2026-05-26 デフォルト切替 / 2026-06-08 legacy 完全削除** [^1] | **P0** |
+| `lyria-3-pro-preview` (本番モデル) | `lyria` skill default ([config.default.yaml:17](../../../../.claude/skills/lyria/config.default.yaml)) | 同じ (public preview 継続) | 未告知 [^2] | P3 |
+| `lyria-3-clip-preview` (プレビュー用) | `lyria` skill (`--preview`) | 同じ | 未告知 [^2] | P3 |
+| `lyria-002` | `audio_units.py:16` のみ | (旧モデル、Vertex AI Model Garden 上の扱い未確認) | 未告知 | P3 |
+| `gemini-2.5-flash` | `benchmark` / `video-analyze` skill / `benchmark_collector.py:523` | `gemini-3-flash-preview` / `gemini-3.1-flash` 系へ移行推奨 | **2026-10-16 shutdown** [^3] | **P1** |
+| `gemini-2.5-flash-lite` | `populate_scene_phrases.py:33` | `gemini-3.1-flash-lite` へ移行推奨 | **2026-10-16 shutdown** [^3] | **P1** |
+| `gemini-3.1-flash-image-preview` | `image_provider/config.py:27`, `thumbnail` skill | 同じ (preview 継続) | 未告知 [^4] | OK |
+| `gpt-image-2` | `image_provider/config.py:150`, `thumbnail` skill | 同じ (2026-04-21 launch) | 未告知 [^5] | OK |
+| `dall-e-3` / `dall-e-2` | 参照なし | — | 2026-05-12 削除済 | OK (不使用) |
+| `veo-3.1-fast-generate-001` | `veo_generator.py:15`, `loop-video` skill | GA (2025-11-17 〜) | 未告知 [^6] | OK |
+| `veo-3.1-generate-001` | skill option | GA | 未告知 | OK |
+| `veo-3.1-lite-generate-preview` | `loop-video/SKILL.md:116`, `config.default.yaml:7` のドキュメント記載 | 正式 ID は `veo-3.1-lite-generate-*` 系 (公式記載は `veo-3.1-lite-generate-001` の preview 段階)。**`-preview` サフィックスを持つ Lite の正式 ID は公式ドキュメントで確認できなかった** | — | P2 (要検証) |
+| `veo-3.0-*` / `veo-2.0-*` | コードベース内で参照なし | — | 2026-03-24 GA 廃止告知済（移行先: `veo-3.1-*`） | OK (不使用) |
+| YouTube Data API | `v3` ([youtube_service.py:47](../../../../src/youtube_automation/utils/youtube_service.py)) | `v3` 継続 | 重大廃止なし (2025-2026 で 6 ヶ月廃止サイクルに乗ったマイナー削除のみ) [^7] | OK |
+| YouTube Analytics API | `v2` ([youtube_service.py:57](../../../../src/youtube_automation/utils/youtube_service.py)) | `v2` 継続 | 廃止なし [^8] | OK |
+| YouTube Reporting API | `v1` ([youtube_service.py:65](../../../../src/youtube_automation/utils/youtube_service.py)) | `v1` 継続 | 廃止なし | OK |
+| OAuth scopes (`yt-analytics-monetary.readonly` 等) | `oauth_handler.py:69-74` | 変更なし | — | OK |
+| Vultr Terraform provider | `>= 2.0` ([versions.tf:7](../../../../infra/terraform/streaming/versions.tf)), lock `2.31.1` | `2.31.2` (2026-05-12) | 未告知 [^9] | OK |
+| `hashicorp/null` Terraform provider | `>= 3.2`, lock `3.2.4` | (active) | — | OK |
+| Suno API | コード内で直接呼び出しなし（プロンプト生成のみ） | — | — | 評価対象外 |
+
+[^1]: <https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026> (2026-05-18 取得)
+[^2]: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes> 2026-03-25 entry (2026-05-18 取得)
+[^3]: <https://ai.google.dev/gemini-api/docs/deprecations> (2026-05-18 取得)
+[^4]: 同上 (gemini-3.1-flash-image-preview には shutdown 記載なし)
+[^5]: <https://developers.openai.com/api/docs/deprecations> (2026-05-18 取得)
+[^6]: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate> (2026-05-18 取得)
+[^7]: <https://developers.google.com/youtube/v3/revision_history> (2026-05-18 取得)
+[^8]: <https://developers.google.com/youtube/analytics/revision_history> (2026-05-18 取得)
+[^9]: <https://github.com/vultr/terraform-provider-vultr/releases> (2026-05-18 取得)
+
+---
+
+## 3. Python 依存 pin 状況
+
+[`pyproject.toml`](../../../../pyproject.toml) では `[project.dependencies]` のすべてのエントリが **バージョン下限・上限とも未指定** で、name のみ列挙されている。
+
+```toml
+# pyproject.toml:13-28
+dependencies = [
+    "google-api-python-client",
+    "google-auth-oauthlib",
+    "google-auth-httplib2",
+    "google-genai",
+    "openai",
+    "Pillow",
+    "python-dotenv",
+    "pandas",
+    "matplotlib",
+    "japanize-matplotlib",
+    "seaborn",
+    "schedule",
+    "pyyaml",
+    "requests",
+]
+```
+
+実際の解決バージョンは `uv.lock` で固定されているため即時の壊れは発生しないが、 `uv lock --upgrade` あるいは新規環境構築時に最新版を取り込んで挙動が変わる可能性がある。
+
+### 重要 SDK の現状と最新比較
+
+| パッケージ | uv.lock | PyPI 最新 (2026-05) | ギャップ | severity |
+|---|---|---|---|---|
+| `google-api-python-client` | 2.193.0 | 2.196.0 (2026-05-06) [^10] | minor | OK |
+| `google-auth` | 2.49.1 | (active) | — | OK |
+| `google-auth-oauthlib` | 1.3.0 | 1.4.0 (2026-05-07) [^11] | minor | OK |
+| `google-auth-httplib2` | 0.3.0 | (active) | — | OK |
+| `google-genai` | **1.69.0** | **2.4.0** (2026-05-18) [^12] | **major** (1.x → 2.x) | **P2** |
+| `openai` | 2.33.0 | 2.37.0 (2026-05-15) [^13] | minor | OK |
+| `requests` | 2.33.0 | 2.33.0 | — | OK |
+| `Pillow` | 12.1.1 | (active) | — | OK |
+| `pandas` | 3.0.1 | (active) | — | OK |
+| `pyyaml` | 6.0.3 | (active) | — | OK |
+
+[^10]: <https://pypi.org/project/google-api-python-client/>
+[^11]: <https://pypi.org/project/google-auth-oauthlib/>
+[^12]: <https://github.com/googleapis/python-genai/releases> および <https://pypi.org/project/google-genai/>
+[^13]: <https://pypi.org/project/openai/>
+
+### 観察点
+
+- `google-genai` の major ギャップが特に重要。1.69.0 と 2.x では Interactions API の応答パース仕様（`outputs` → `steps`）が異なるため、後述 §4-(1) の P0 とセットで判断する。
+- `pyproject.toml` の依存定義に上限 (`< X`) が一切ないため、`uv lock --upgrade` が突然 major bump を引いてくる可能性がある。最低限 `google-genai>=1.69,<2` のような明示的 pin が望ましい。
+- 公的セキュリティアドバイザリ（`pip-audit` 相当）はオフライン環境かつ取得手段なしのため **調査不可**。
+
+---
+
+## 4. 廃止予定 / EOL 該当事項（来月以降の業務影響）
+
+### (1) **P0 — Vertex AI Interactions API legacy スキーマ削除（2026-06-08）**
+
+`src/youtube_automation/utils/lyria_client.py` は Lyria 3 の `interactions` エンドポイントを直接 `requests.post` で叩いており、レスポンス処理が **legacy schema** に依存している。
+
+```python
+# src/youtube_automation/utils/lyria_client.py:129-153
+payload = {
+    "model": model,
+    "input": inputs,
+}
+headers = {
+    "Authorization": f"Bearer {_access_token()}",
+    "Content-Type": "application/json",
+}
+...
+body = response.json()
+for out in body.get("outputs", []):              # ← legacy schema フィールド
+    if out.get("type") == "audio" and out.get("mime_type", "").startswith("audio/"):
+        return base64.b64decode(out["data"])
+```
+
+公式アナウンス [^1] によると Interactions API は以下のスケジュールで **breaking change** が走る:
+
+| 日付 | フェーズ | 影響 |
+|---|---|---|
+| 2026-05-07 | opt-in 開始 | `Api-Revision: 2026-05-20` ヘッダで新スキーマを試せる |
+| **2026-05-26** | **デフォルト切替** | デフォルトレスポンスが新 `steps[*].content[*]` スキーマに。legacy を維持するには `Api-Revision: 2026-05-07` ヘッダが必須 |
+| **2026-06-08** | **legacy 完全削除** | legacy ヘッダ指定をしても新スキーマしか返ってこなくなる |
+
+現状のコードは:
+- `Api-Revision` ヘッダを送っていない → **2026-05-26 (8 日後)** にデフォルト切替が起きた瞬間、`body.get("outputs", [])` が空リストを返し、`for` ループは無実行、関数は `None` を返す。**サイレント失敗** で「オーディオデータがありません」エラーを出して終わる。
+- たとえ `Api-Revision: 2026-05-07` ヘッダで延命しても **2026-06-08 (21 日後)** に強制的に新スキーマになり、同様に壊れる。
+
+**影響範囲:** `yt-generate-lyria-master` を使う全チャンネル（Lyria 系 BGM 自動生成）。
+
+**最小修正案（実装者向けメモ／本 part では実装しない）:**
+1. payload を新スキーマ用に組み替え (`response_format` の polymorphic 構造、`mime_type` の場所変更)。
+2. レスポンスパースを `body.get("steps", [])[-1]["content"]` 経由に変更し、`type=="audio"` の `content` を base64 デコード。
+3. もしくは `google-genai` 2.0 SDK の `interactions` サポートに移行（要検証）。
+
+### (2) **P1 — Gemini 2.5 系モデルの shutdown（2026-10-16）**
+
+`gemini-2.5-flash` および `gemini-2.5-flash-lite` は **2026-10-16** に Vertex AI 上で shutdown 確定 [^3]。本リポジトリで使用箇所:
+
+| 使用箇所 | モデル ID | 用途 |
+|---|---|---|
+| `.claude/skills/benchmark/config.default.yaml:23` | `gemini-2.5-flash` | 競合チャンネルのサムネ分析 |
+| `.claude/skills/video-analyze/config.default.yaml:7` | `gemini-2.5-flash` | 動画コンテンツ解析 |
+| `src/youtube_automation/scripts/benchmark_collector.py:523` | `gemini-2.5-flash` (フォールバック) | benchmark 既定 |
+| `src/youtube_automation/scripts/populate_scene_phrases.py:33` | `gemini-2.5-flash-lite` (`DEFAULT_GEMINI_MODEL`) | シーンフレーズ多言語化 |
+
+公式の移行ガイダンス [^3]:
+- `gemini-2.5-flash` → `gemini-3-flash-preview` (またはその後継 `gemini-3.1-flash`)
+- `gemini-2.5-flash-lite` → `gemini-3.1-flash-lite`
+
+**残り期間:** 約 5 ヶ月。merge 直前に慌てず、Q3 中（2026-08 まで）に置換 PR を出すのが妥当。
+
+### (3) **P1 — `google-cloud-aiplatform.generative_models` モジュール sunset（2026-06-24）**
+
+公式の SDK 統合ガイドにより、旧 `google-cloud-aiplatform` の `generative_models` モジュールは **2026-06-24** に sunset され、`google-genai` SDK に統合される [^14]。
+
+本リポジトリの直接依存:
+- `google-genai` は `pyproject.toml` 既に dependencies 入り
+- `google-cloud-aiplatform` は本リポジトリの直接依存ではない（uv.lock にも未掲載）
+
+→ **本リポジトリへの直接的影響はない**。ただし `google-genai` の major bump (1.x → 2.x) が「同 sunset の延長線で出た新スキーマ対応」とリンクしている点は意識すべき。
+
+[^14]: <https://medium.com/google-cloud/migrating-to-the-new-google-gen-ai-sdk-python-074d583c2350> (2026-05-18 取得)
+
+### (4) **P2 — Lyria endpoint が `v1beta1` のまま**
+
+[`lyria_client.py:26`](../../../../src/youtube_automation/utils/lyria_client.py) でエンドポイント URL を `v1beta1` で hard-code している。
+
+```python
+_ENDPOINT = "https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/interactions"
+```
+
+公式リリースノートでも 2026-05-18 時点で **GA 化アナウンスなし** [^2]。将来 GA 化されたタイミングで `v1` に切り替える breaking change が予想される。今すぐ壊れないが、 GA 移行通知に対する watch が必要。
+
+### (5) **P2 — `veo-3.1-lite-generate-preview` の正式 ID 不一致疑い**
+
+[`.claude/skills/loop-video/config.default.yaml:7-8`](../../../../.claude/skills/loop-video/config.default.yaml) と [`.claude/skills/loop-video/SKILL.md:116`](../../../../.claude/skills/loop-video/SKILL.md) は `veo-3.1-lite-generate-preview` を選択肢として列挙している。
+
+公式リリースノート [^15] では:
+- 2026-04-02 に「Veo 3.1 Lite is available in public preview」と告知されたが、**Lite の Vertex AI 上の publisher model ID は公式ページ上で明示確認できなかった**。
+- WebSearch 結果は API サポート ID として `veo-3.1-generate-001`, `veo-3.1-fast-generate-001`, `veo-3.1-generate-preview`, `veo-3.1-fast-generate-preview` を挙げているが、 **`veo-3.1-lite-generate-preview` を直接列挙したソースはない**。
+
+→ skill ドキュメントが先走った命名を載せている可能性。**実モデル名と一致しているかを Model Garden で直接確認すべき**（本 part では確認手段なし、要 follow-up）。
+
+[^15]: <https://cloud.google.com/blog/products/ai-machine-learning/veo-3-1-lite-and-a-new-veo-upscaling-capability-on-vertex-ai>
+
+### (6) **P3 — `audio_units.py` の `lyria-002`**
+
+[`src/youtube_automation/utils/audio_units.py:13-17`](../../../../src/youtube_automation/utils/audio_units.py):
+
+```python
+_AUDIO_UNIT_BY_MODEL: dict[str, str] = {
+    "lyria-3-pro-preview": "song",
+    "lyria-3-clip-preview": "30sec",
+    "lyria-002": "30sec",
+}
+```
+
+`lyria-002` は Lyria 3 系の前世代モデル。skill default では選択されないが、テーブルに残っているため誤指定リスクは残る。即時影響はないが、棚卸し時に削除候補。
+
+### (7) **P3 — Suno API 直接呼び出しなし**
+
+`generate_suno_prompts.py` は **プロンプトテキストファイル `suno-prompts.md` を生成するだけ** で API 呼び出しを行わない。Suno UI への入力は手動運用。SunoAI 側のサービス継続性に依存はあるが、コード側の breaking 影響はない。
+
+---
+
+## 5. URL リンク切れ調査
+
+skill / scripts / docs / source 内に出現する外部 URL を抽出して到達性を best-effort で確認。
+
+### 検出された URL の一覧（unique）
+
+| URL | 用途 | 到達性 |
+|---|---|---|
+| `https://aiplatform.googleapis.com/v1beta1/...` | Lyria 3 endpoint | ✅ (`v1beta1` 継続中) |
+| `https://api.vultr.com/v2` | Vultr API | ✅ |
+| `https://cloud.google.com/sdk/docs/install` | gcloud install | ✅ |
+| `https://cdn1.suno.ai/` | Suno 音源 CDN（`masterup` skill が `curl` でダウンロード） | best-effort 確認のみ。ホスト側 CDN URL は曲毎に変動する placeholder 用途 |
+| `https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music` | Lyria 公式ドキュメント | ✅ |
+| `https://developer.1password.com/docs/cli/get-started/` | op CLI ドキュメント | ✅ |
+| `https://developer.hashicorp.com/terraform/install` | Terraform install | ✅ |
+| `https://developers.google.com/youtube/analytics/channel_reports` | Analytics docs | ✅ |
+| `https://developers.google.com/youtube/reporting/v1/reports/channel_reports` | Reporting docs | ✅ |
+| `https://en.wikipedia.org/wiki/<music genre>` × 11 | ジャンル参照 (内部資料) | ✅ |
+| `https://github.com/daiki-beppu/youtube-automation` | self repo (legacy 名?) | repo 名が `youtube-channels-automation` に変わっている可能性。要確認 |
+| `https://github.com/daiki-beppu/youtube-channels-automation.git` | self repo (current) | ✅ |
+| `https://github.com/d-bep/yt-channels/issues/130` / `131` / `313` | issue 参照（外部リポジトリ）| best-effort: public repo であれば到達可。private なら 404 |
+| `https://console.cloud.google.com/apis/credentials?project=` | OAuth 設定画面 | ✅ |
+| `http://169.254.169.254/...` | Vultr インスタンス内のメタデータ取得 (cloud-init 等) | 内部 IP のため外部到達性は無関係 |
+
+### リスク
+
+- **`https://github.com/daiki-beppu/youtube-automation`**: ONBOARDING.md / src 内に登場するが、`pyproject.toml:31` の `[project.urls] Repository` は同 URL を指している。一方 skill ドキュメントは `https://github.com/daiki-beppu/youtube-channels-automation.git` を使う混在状態。同一 repo の旧名/新名なのか分岐リポジトリなのか **本 part では確定できない**。
+- **`https://github.com/d-bep/yt-channels/issues/{130,131,313}`**: 別オーナーアカウントを指す。本リポジトリの主体は `daiki-beppu` 名義のため、コミットコメント内の issue 参照が古い repo 名で残っている可能性。
+
+→ いずれも今月壊れる種ではないが、棚卸し対象として記録。
+
+---
+
+## 6. ツール / CLI バージョン要求の欠落
+
+| CLI | 使用 skill / docs | 最低バージョン明示 | 備考 |
+|---|---|---|---|
+| `terraform` | `streaming`, `channel-setup/references/terraform-gcp` | ✅ `>= 1.5` ([versions.tf:2](../../../../infra/terraform/streaming/versions.tf), [streaming/SKILL.md:14](../../../../.claude/skills/streaming/SKILL.md)) | OK |
+| `ffmpeg` | `videoup`, `masterup`, `loop-video`, `streaming`, `lyria` (`generate_lyria_master.py`) | ❌ ONBOARDING.md:35 で「最新」のみ | 互換性問題（特に `xfade` フィルタ / `libx264` 動作）は ffmpeg 4.0+ に依存。skill 側で `ffmpeg >= 4.4` 程度の明示が望ましい |
+| `ffprobe` | `veo_generator.py:137-148` | ❌ | ffmpeg と同梱だが明示なし |
+| `gcloud` (Google Cloud SDK) | `loop-video`, `lyria`, `channel-setup` | ❌ ONBOARDING.md:36 で「最新」のみ | ADC まわりは比較的安定なので実害は低いが、`gcloud auth application-default login` フローの細かな挙動は version 依存 |
+| `gh` (GitHub CLI) | 各 skill の git/PR 操作経路、CLAUDE.md（プロジェクト規約） | ❌ | `gh issue create` / `gh pr create` の引数は 2.0 以降ほぼ安定 |
+| `op` (1Password CLI) | `streaming`, `auth/oauth_handler.py:60-` (secrets.py 経由) | ❌ | v2 と v1 で `op read` の URI 形式が異なる。**v2 必須** の旨を明示すべき (skill レベルで未記載) |
+| `uv` | README / pyproject toml / 全体 | ❌ | プロジェクトのデファクト Python ランナーだが最低バージョンの明示なし |
+
+ONBOARDING.md の依存ツール表（[ONBOARDING.md:33-37 周辺](../../../../ONBOARDING.md)）はバージョンを「最新」と記載しているのみで、具体的な下限がない。
+
+---
+
+## 7. 注意点・リスク
+
+1. **Lyria の P0 は黙って壊れる**: 2026-05-26 のデフォルト切替時、レスポンスは 200 OK で返ってくるが `outputs` キーが存在しないため `lyria_client.generate_music` は `None` を返し、上位の `generate_lyria_master.py` は「音源生成失敗」として握りつぶす可能性がある。**API レスポンスの新スキーマパース対応が最優先。**
+2. **uv.lock があるため明日突然壊れることはない**: ただし CI 再ビルドや新マシンセットアップで `uv sync` を打った瞬間に `google-genai` 2.x が降ってきて Lyria 経路が壊れる二次リスクがある。`pyproject.toml` 上で `google-genai>=1.69,<2` のような明示 pin が望ましい。
+3. **gemini-2.5-flash-lite の置換は populate_scene_phrases に集中**: シーンフレーズ多言語化（10+ 言語）の品質に影響する。3-flash 系で同等の安価かつ高品質な置換ができるか事前 A/B が必要。
+4. **veo-3.1-lite モデル ID の不一致疑い**: skill ドキュメントが「使えるはず」と誤誘導している可能性。**Model Garden で生 ID を確認**してから skill SKILL.md を補正すべき（part-c-deps-deprecated の責務外）。
+5. **CLI 最低バージョン未明示**: 致命的ではないが、特に `ffmpeg` と `op` は再現性に大きく影響する。最低 `ffmpeg >= 4.4` / `op >= 2.0` 明示を推奨。
+
+---
+
+## 8. 調査不可項目
+
+| 項目 | 理由 |
+|---|---|
+| Suno API の正式 deprecation policy | 本リポジトリで Suno API を直接叩く実装が存在しないため評価対象外。Suno UI 経由運用のため UI 側の継続性に依存する |
+| `pip-audit` 相当の脆弱性スキャン | CLI 実行禁止。WebSearch でも個別 CVE は確実な引き当てができなかった |
+| `veo-3.1-lite-generate-preview` 正式 publisher model ID | 公式 Model Garden 直アクセスができず、複数 web ソースで表記揺れがあるため断定不可 |
+| `daiki-beppu/youtube-automation` vs `youtube-channels-automation` のリポジトリ名混在 | GitHub 上で実体を確認する権限がないため、旧名 redirect なのか別 repo なのか不明 |
+| OpenAI / Google の最新 security advisory | 1 件ずつ精査する手段が限られ、本 part の責務外 |
+
+---
+
+## 9. 推奨アクション（severity 付き）
+
+| # | アクション | 対象 | severity | 期限目安 |
+|---|---|---|---|---|
+| 1 | `lyria_client.py` を Interactions API 新スキーマ (`steps[*].content[*]`) に対応。payload も `response_format` ポリモーフィック構造に書き換え | `src/youtube_automation/utils/lyria_client.py` | **P0** | **2026-05-25 まで**（デフォルト切替の前日） |
+| 2 | (1) の応急処置として `Api-Revision: 2026-05-07` ヘッダを追加してとりあえず延命 | `lyria_client.py:133-136` | **P0 (緊急 patch)** | **2026-05-25 まで** |
+| 3 | `gemini-2.5-flash` → `gemini-3-flash` 系 / `gemini-2.5-flash-lite` → `gemini-3.1-flash-lite` の置換。動作確認後 skill config / DEFAULT 定数を一括更新 | `benchmark`, `video-analyze`, `populate_scene_phrases.py`, `benchmark_collector.py` | P1 | 2026-09 末まで |
+| 4 | `pyproject.toml` の `google-genai` に上限 pin を追加（少なくとも `<2` で 1.x シリーズに固定。新スキーマ対応後に解放） | `pyproject.toml:13-28` | P2 | (1) と同時 |
+| 5 | `google-genai` 2.x 系への移行検証。SDK 経由で Interactions API を叩けるか確認 | `lyria_client.py`, `genai_client.py` | P2 | 2026-Q3 |
+| 6 | `veo-3.1-lite-generate-preview` の正式 publisher model ID を Model Garden で確認し、不一致なら skill ドキュメントを補正 | `.claude/skills/loop-video/SKILL.md`, `config.default.yaml` | P2 | 2026-Q3 |
+| 7 | `audio_units.py` から `lyria-002` を削除（実利用なし） | `src/youtube_automation/utils/audio_units.py` | P3 | clean-up |
+| 8 | ONBOARDING.md / 各 skill SKILL.md に CLI 最低バージョン明示を追加（特に `ffmpeg >= 4.4`, `op >= 2.0`） | `ONBOARDING.md`, 各 skill | P3 | clean-up |
+| 9 | リポジトリ URL の `daiki-beppu/youtube-automation` vs `youtube-channels-automation` 混在を整理 | `pyproject.toml:31`, ONBOARDING.md, skill 内 | P3 | clean-up |
+
+---
+
+## 参考文献（取得日 2026-05-18）
+
+- Vertex AI Generative AI Release Notes: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes>
+- Gemini API Deprecations: <https://ai.google.dev/gemini-api/docs/deprecations>
+- Interactions API Breaking Changes (May 2026): <https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026>
+- Veo 3.1 model docs: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate>
+- Lyria 3 docs: <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music>
+- YouTube Data API revision history: <https://developers.google.com/youtube/v3/revision_history>
+- YouTube Analytics revision history: <https://developers.google.com/youtube/analytics/revision_history>
+- OpenAI deprecations: <https://developers.openai.com/api/docs/deprecations>
+- Vultr terraform provider releases: <https://github.com/vultr/terraform-provider-vultr/releases>
+- PyPI google-genai: <https://pypi.org/project/google-genai/>
+- PyPI google-api-python-client: <https://pypi.org/project/google-api-python-client/>
+- PyPI openai: <https://pypi.org/project/openai/>
+- PyPI google-auth-oauthlib: <https://pypi.org/project/google-auth-oauthlib/>
+- Migrate to Google GenAI SDK: <https://medium.com/google-cloud/migrating-to-the-new-google-gen-ai-sdk-python-074d583c2350>

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/09-data-deps-deprecation.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/09-data-deps-deprecation.md
@@ -1,0 +1,538 @@
+# 観点 5: 依存・廃止 API・互換性 — 監査データ（再実行版）
+
+調査日: 2026-05-18
+担当: dig.part-c-deps-retry
+対象リビジョン: HEAD（worktree `20260518T0905-372-issue-372-chore-skills-sukiru`）
+前提: 前回試行 `dig.part-c-deps-deprecation` は `[ERROR] Claude CLI execution aborted` で中断。本レポートはその再実行であり、既出 3 本（`data-dependencies.md` / `data-external-api-deprecation.md` / `data-backward-compat-shims.md`）の検出結果を一本化したうえで、観点 5.5（skill 内 deprecated 記述）/ 5.6（外部 CLI ツール依存）/ 5.7（wheel drift）の独立検証分を補強している。
+
+PR #367 で扱った観点 1（汎用化・設定切り出し）/ 観点 2（整合性）の既出指摘は再検出していない（参照箇所は注記のみ）。
+
+---
+
+## サマリー（severity 別）
+
+| severity | 件数 | 内訳（1 行要約） |
+|---|---|---|
+| **P0** | 0 | （即時 prod 停止級の検出なし） |
+| **P1** | 7 | Gemini 2.5 系 2 モデルが 2026-10-16 shutdown 予告 / `google-genai` メジャー遅延 / 全依存に version 上限なし / `google-auth-httplib2` deprecated / Suno 非公式依存 deprecation メモなし / skill バージョン追跡なし（`yt-skills sync --force` 不徹底で乖離） / `veo_generator` が ffmpeg 不在チェックなし |
+| **P2** | 11 | Lyria 3 が `v1beta1` 直叩き / Veo lite が preview / `japanize-matplotlib` 4 年超停滞 / `Workflow` dataclass 空 dead shim / `uv.lock` 下流非伝播 / CLAUDE.md L.38 が実態と矛盾 / skill 配布の `--force` 運用未明示 / skill 12 件で `## 前提` 欠落 / `veo_generator.strip_audio`/`trim_tail` の ffmpeg 直叩きフォールバックなし / `_disabled` フラグの仕様が lyria 以外で文書化されず / OAuth scope の skill 側記述欠落 |
+| **P3** | 5 | `requires-python>=3.11` 過剰制約の可能性 / dead extras `veo = []` / `yt-config-migrate` v1→v2 移行 CLI が v5.5.0 でも残存 / `lyria-002` が `audio_units._AUDIO_UNIT_BY_MODEL` に残置 / CLAUDE.md L.140 「旧 `get_channel_status` は廃止」の文言は配布 template 側 |
+
+凡例: P0=即時障害、P1=数か月以内に対応必須、P2=リファクタ候補、P3=記述整備レベル。
+
+---
+
+## 観点 5.1: 廃止予定 API バージョン参照
+
+### 5.1.1 Vertex AI Gemini モデル
+
+| モデル / バージョン | 使用箇所 | 公式ステータス（2026-05-18） | shutdown |
+|---|---|---|---|
+| `gemini-2.5-flash` | `.claude/skills/video-analyze/config.default.yaml:7`, `.claude/skills/benchmark/config.default.yaml:23`, `src/youtube_automation/scripts/benchmark_collector.py:523` | **deprecated**（後継 `gemini-3-flash-preview`） | **2026-10-16 earliest（≒ 5 か月後）** |
+| `gemini-2.5-flash-lite` | `src/youtube_automation/scripts/populate_scene_phrases.py:33`（`DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"`） | **deprecated**（後継 `gemini-3.1-flash-lite`） | **2026-10-16 earliest** |
+| `gemini-3.1-flash-image-preview` | `src/youtube_automation/utils/image_provider/config.py:27`（`_DEFAULT_GEMINI_MODEL`）, `.claude/skills/thumbnail/config.default.yaml:18`, `.claude/skills/collection-ideate/SKILL.md:139` | preview / GA 移行情報未公開 | 未告知（preview 継続中） |
+
+出典: `https://ai.google.dev/gemini-api/docs/deprecations`（2026-05-18 確認、既出レポート `data-external-api-deprecation.md:28-31` で取得済み）。
+
+→ **P1**: 5 か月以内に `benchmark` / `video-analyze` / `wf-new`（`yt-populate-scene-phrases` 経由）の 3 スキル / CLI が後継モデルへ追従しないと sunset 当日にエラー化。skill 側の config.default.yaml も同時更新必要。
+
+### 5.1.2 Vertex AI Veo モデル
+
+| モデル | 使用箇所 | ステータス | 備考 |
+|---|---|---|---|
+| `veo-3.1-fast-generate-001` | `src/youtube_automation/utils/veo_generator.py:15`（`DEFAULT_MODEL`）, `.claude/skills/loop-video/config.default.yaml:8`, `.claude/skills/loop-video/SKILL.md:107,116` | **GA**（2025-11-17 promoted） | 現役 |
+| `veo-3.1-generate-001` | `.claude/skills/loop-video/SKILL.md:116`（選択肢） | **GA** | 現役 |
+| `veo-3.1-lite-generate-preview` | `.claude/skills/loop-video/SKILL.md:86,116`, `.claude/skills/loop-video/config.default.yaml:7` のコメント | **preview**（2026-04-02 導入） | **P2**: preview のまま運用すると静かに sunset される余地。SKILL.md に「preview のため将来変更あり」のメモなし |
+
+出典: `https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes`（既出 `data-external-api-deprecation.md:33-35`）。
+
+### 5.1.3 Vertex AI Lyria 3 モデル + endpoint
+
+| モデル | 使用箇所 | ステータス |
+|---|---|---|
+| `lyria-3-pro-preview` | `src/youtube_automation/utils/audio_units.py:14`, `.claude/skills/lyria/config.default.yaml:17`, `.claude/skills/lyria/SKILL.md:60,85,94` | **preview**（GA 未告知） |
+| `lyria-3-clip-preview` | `src/youtube_automation/utils/audio_units.py:15`, `.claude/skills/lyria/SKILL.md:85` | **preview** |
+| `lyria-002` | `src/youtube_automation/utils/audio_units.py:16`（unit マッピングのみ、生成箇所なし） | レガシー / dead reference → **P3**（撤去候補） |
+
+endpoint:
+
+- `src/youtube_automation/utils/lyria_client.py:7,26`: `https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/interactions`
+  - `v1beta1` を直叩き。docstring (`lyria_client.py:1-9`) に「google-genai SDK 1.71.0 時点で `interactions` 未対応のため `requests` で直接叩く」と理由明記
+  - **P2**: Lyria 3 GA 化 / SDK 対応のいずれかが起きた瞬間に自前 `requests` 実装は破棄すべき。SKILL.md / 実装側に「いつ撤去するか」のトリガー記載なし
+
+### 5.1.4 YouTube Data / Analytics / Reporting
+
+| service / version | 箇所 | 廃止リスク |
+|---|---|---|
+| `youtube / v3` | `src/youtube_automation/utils/youtube_service.py:49`, `src/youtube_automation/auth/oauth_handler.py:239`, `src/youtube_automation/scripts/fetch_stream_key.py:114` | 公式 deprecation アナウンスなし。`commentThreads.markAsSpam` / `guideCategories` 等の廃止予告 endpoint 使用は 0 件確認 |
+| `youtubeAnalytics / v2` | `src/youtube_automation/utils/youtube_service.py:57` | 廃止懸念なし |
+| `youtubereporting / v1` | `src/youtube_automation/utils/youtube_service.py:65` | 廃止懸念なし |
+
+主要 endpoint 30 件超を grep 確認し、廃止予告中の endpoint 使用は 0 件（出典: `data-external-api-deprecation.md:72-88`）。
+
+### 5.1.5 OpenAI 画像 API
+
+| モデル | 箇所 | ステータス |
+|---|---|---|
+| `gpt-image-2` | `src/youtube_automation/utils/image_provider/config.py:150`, `.claude/skills/thumbnail/config.default.yaml:89` | **GA**（2026-04-21）、現役 |
+| `dall-e-2` / `dall-e-3` | コード内 0 件確認（grep） | API 削除済み（2026-05-12）だが影響なし |
+
+`utils/cost_tracker.py` の `PRICING` テーブルは `gpt-image-2` / `gpt-image-1.5` / `gpt-image-1-mini` の 3 モデルを CHANGELOG (行 40-44) で追加済み。
+
+### 5.1.6 Suno（非公式 / UI スクレイピング）
+
+- `.claude/skills/masterup/SKILL.md:84,89`: `https://cdn1.suno.ai/{song_id}.mp3` を直接 `curl` でダウンロード
+- `.claude/skills/masterup/SKILL.md:72-79` Step 2: WebFetch で `https://suno.com/playlist/xxx` HTML スクレイピング
+- **公式 API なし**、CDN 永続性も不明（`SKILL.md:92` に注意書きあり）
+- SKILL.md / 実装側に「いつ壊れる可能性があるか」のメモは **無し**
+
+→ **P1**: 復旧手段ゼロのリスク。Suno UI 仕様変更や CDN 廃止が起きた瞬間に `/suno` `/masterup` チェーンが破綻する。代替プランを明文化していない。
+
+### 5.1.7 Vultr API
+
+- `infra/terraform/streaming/versions.tf:5-8`: `vultr/vultr` provider `>= 2.0`
+- `src/youtube_automation/utils/streaming/vultr_bandwidth.py` で `/v2/instances/{id}/bandwidth` を直接呼び出し（`utils/streaming/vultr_bandwidth.py:1` の docstring）
+- Vultr API v2 は現役、deprecation 告知は調査範囲では見つからず → 健全
+
+---
+
+## 観点 5.2: ライブラリ version pin / 最低バージョン要件
+
+### 5.2.1 `[project.dependencies]`（出典: `pyproject.toml:13-28`）
+
+全 14 依存に **`==` / `>=` / `~=` / `<` のいずれの制約も付与されていない**。
+
+| パッケージ | uv.lock 解決 | PyPI latest (2026-05-18) | 遅延 | コメント |
+|---|---|---|---|---|
+| `google-api-python-client` | 2.193.0 | 2.196.0 | パッチ 3 | 健全 |
+| `google-auth-oauthlib` | 1.3.0 | 1.4.0 | マイナー 1 | 健全 |
+| `google-auth-httplib2` | 0.3.0 | 0.4.0（**deprecated 表明**） | パッチ | **P1**（5.4 で詳述） |
+| `google-genai` | 1.69.0 | **2.4.0** | **メジャー 1** | **P1**: SDK 2.x で type 経路変更の可能性。直 import 箇所 6 件（`utils/genai_client.py:23`, `utils/veo_generator.py:36`, `utils/image_provider/gemini.py:36`, `utils/video_analyzer.py:27`, `scripts/video_analyze.py:29`, `scripts/benchmark_collector.py:538`） |
+| `openai` | 2.33.0 | 2.37.0 | パッチ 4 | 健全 |
+| `Pillow` | 12.1.1 | 12.2.0 | パッチ 1 | 健全 |
+| `python-dotenv` | 1.2.2 | 1.2.2 | 同等 | 健全 |
+| `pandas` | 3.0.1 | 3.0.3 | パッチ 2 | コードは 3.x 追従済み。下流環境次第で爆発 |
+| `matplotlib` | 3.10.8 | 3.10.9 | パッチ 1 | 健全 |
+| `japanize-matplotlib` | 1.1.3 | 1.1.3（2020-10-21、4 年超停滞） | 同等 | **P2**（5.5 で詳述） |
+| `seaborn` | 0.13.2 | 0.13.2 | 同等 | 現役 |
+| `schedule` | 1.2.2 | 1.2.2 | 同等 | 現役 |
+| `pyyaml` | 6.0.3 | 6.0.3 | 同等 | 健全 |
+| `requests` | 2.33.0 | 2.34.2 | パッチ 1 | 健全 |
+
+→ **P1（全体）**: `pyproject.toml` の依存に上限指定が無いため、下流チャンネル側で `uv add git+...` した際に **同日に release された破壊的アップデートが当たる**。`uv.lock` をリポに commit していても、下流の `uv.lock` には伝播しない（5.7.4 参照）。
+
+### 5.2.2 `[project.optional-dependencies]`（出典: `pyproject.toml:33-35`）
+
+```toml
+dev = ["pytest", "ruff"]
+veo = []  # google-genai, Pillow moved to main dependencies
+```
+
+`veo = []` は空の extras。`pip install 'youtube-channels-automation[veo]'` を打っても何もインストールされない **dead extras**（→ **P3**）。
+
+### 5.2.3 hard pin（`==`）の有無
+
+`==` による hard pin は 0 件。security update を取れない過剰 pin は無い（健全方向）。ただし 5.2.1 の上限不在とトレードオフ。
+
+### 5.2.4 推奨される上限制約候補
+
+- `google-genai`: メジャー乖離（1.69 → 2.4）。SDK 2.x で `types.GenerateVideosConfig` / `types.Image.from_file` の path 変更可能性あり。当面 `google-genai>=1.60,<2` を推奨
+- `pandas`: コードは 3.x 解決済みだが、下流で 2.x ↔ 3.x が混在すると `DataFrame.append` 等で破綻するため `pandas>=3,<4` 推奨
+- `Pillow`: メジャーリリース直前なら `<13` を切る
+
+---
+
+## 観点 5.3: Python バージョン制約
+
+### 5.3.1 宣言の整合性
+
+3 箇所で 3.11 一致:
+
+- `pyproject.toml:9`: `requires-python = ">=3.11"`
+- `pyproject.toml:107`: `[tool.ruff] target-version = "py311"`
+- `.python-version:1`: `3.11`
+- `uv.lock:3`: `requires-python = ">=3.11"`
+
+→ 整合性 OK。
+
+### 5.3.2 実 syntax との突合せ（過剰制約の可能性）
+
+- `from __future__ import annotations` 使用ファイル: 88 件（前回計測、`data-dependencies.md:135`）— 3.10 互換性を残す形
+- `match` / `case` (3.10+): 0 件
+- `typing.Self` / `typing.override` (3.11+ / 3.12+): 0 件
+- 旧式 `Dict` / `List` / `Optional` from `typing`: 残存（`src/youtube_automation/agents/youtube_auto_uploader.py:20` 等）
+
+→ **P3**: 実 syntax は 3.10 互換レベル。`requires-python = ">=3.11"` は過剰制約の可能性。ただし transitive 依存（`pandas` 3.x が py3.10 を切っている可能性）の確認なしに緩めるのは危険なので、現状維持が妥当。
+
+---
+
+## 観点 5.4: 後方互換 shim ドリフト
+
+### 5.4.1 CLAUDE.md の宣言 vs 実態
+
+`CLAUDE.md:38` (project instructions):
+
+> - `utils/`, `agents/`, `auth/`, `scripts/` — submodule 利用者向け **後方互換 shim**（新規開発は `src/youtube_automation/` 側で行う）
+
+実態（`ls -la /` で確認、`data-backward-compat-shims.md:18-24` で再現済み）:
+
+| ディレクトリ | 存在 | 中身 | 性質 |
+|---|---|---|---|
+| `utils/` | **不在** | — | CLAUDE.md L.38 の記述が obsolete |
+| `agents/` | **不在** | — | 同上 |
+| `auth/` | 存在 | `SETUP.md`, `client_secrets_template.json` の 2 ファイルのみ | shim ではなく template + ドキュメント |
+| `scripts/` | 存在 | `gcp-bootstrap.sh`, `gcp-terraform-apply.sh` の 2 シェル | Python shim ではなく共通シェル |
+
+`CLAUDE.md:100`（同一ファイル）には:
+
+> - ルート直下の `scripts/` にはシェルスクリプト（`.sh`）のみ配置。Python shim は廃止済み
+
+→ **CLAUDE.md 内部で矛盾**。L.38 が古い記述、L.100 が現状を反映。Python shim として残っているのは **0 個**。
+
+→ **P2（docs）**: CLAUDE.md L.38 を「`auth/`（template 配布用） / `scripts/`（共通 .sh 配布用）」に書き換え、`utils/` / `agents/` への言及を削除すべき。
+
+### 5.4.2 `google-auth-httplib2` の deprecated 表明
+
+PyPI `google-auth-httplib2 0.4.0` (2026-05-07 リリース) ページ:
+
+> "this library is no longer maintained. For any new usages please see provided transport layers by google-auth library."
+
+直 import 0 件確認（`grep "google_auth_httplib2" src/` で空）。`googleapiclient.discovery.build` の内部依存。
+
+→ **P1**: 即時撤去不可だが新規 import 禁止 + Google 公式の移行ガイド追跡が必要。CHANGELOG / docs 側に「googleapiclient 依存のため当面残置」のメモを追加すべき。
+
+### 5.4.3 v1→v2 設定移行 CLI の残存
+
+- `pyproject.toml:48`: `yt-config-migrate = "youtube_automation.cli.config_migrate:main"`
+- `src/youtube_automation/utils/config/loader.py:100-106`: 旧 `channel_config.json` は ConfigError で fail-fast
+- 現在のバージョン: v5.5.0（`pyproject.toml:7`、3 メジャーバージョン経過）
+
+→ **P3**: 移行未完了の下流の存在は外部観測不可。loader が hard fail するので「移行せずに使う」運用は実質不可能。撤去判断は CHANGELOG / 配布実績の追跡が前提。
+
+### 5.4.4 `Workflow` dataclass の dead shim
+
+- `src/youtube_automation/utils/config/workflow.py:8-15`: 空の dataclass（フィールド 0 個）
+- `src/youtube_automation/utils/config/loader.py:266-271`: `_build_workflow` は無条件で空 `Workflow()` を返す（downstream の `workflow.json` 内の `workflow` / `post_upload` / `short` / `community` キーは無視）
+- `CHANGELOG.md:500`: 「`config/channel/workflow.json` の `post_upload` / `short` / `community` キーは削除しなくても loader は素通しする」と明示
+
+→ **P2**: 動作影響なし。`Workflow` フィールド自体を `ChannelConfig` から落とすにはメジャーバージョン更新が必要。
+
+### 5.4.5 `lyria-002` の dead reference
+
+- `src/youtube_automation/utils/audio_units.py:16`: `"lyria-002": "30sec"` を unit マップに残置
+- `tests/test_generate_music_unit_resolver.py:9,25`: テスト側でも検証中
+- ただし**生成側で `lyria-002` を呼ぶ箇所は 0 件**（grep 確認）— 古い cost_tracker ログを読むための互換マッピングのみ
+
+→ **P3**: 完全 dead でなく旧ログ読み出し互換目的。コメントで意図を残せばよい。
+
+---
+
+## 観点 5.5: skill 内 deprecated 記述・撤廃済み機能の残存参照
+
+### 5.5.1 撤廃済み機能への明示的言及（健全側）
+
+- `.claude/skills/collection-ideate/SKILL.md:114`: 「Issue #132 以降、ハードコード単価表は撤廃済み」と明示。コード側 (`src/youtube_automation/utils/cost_tracker.py:9,22,104`) と整合
+- `.claude/skills/channel-setup/references/claude-md-template.md:140`: 「旧 `get_channel_status` は廃止」と明示。`pyproject.toml:45` で `yt-channel-status = "youtube_automation.scripts.get_channel_status:main"` として entry point 化済み（モジュール path として `get_channel_status` は残るが CLI 呼び出しは `yt-channel-status` に統一）→ template の文言は健全
+
+### 5.5.2 整合性のずれが残る記述
+
+- `.claude/skills/wf-new/references/schema.md:124-128`「旧スキーマ互換」: `workflow-state.json` の `steps` キーが存在する場合の旧/新スキーマ判別ロジック。`/wf-status` 側に依存している記述だが、`/wf-status/SKILL.md` 内に対応するロジック説明が無い（旧スキーマの「読み取り専用扱い」運用がどこに実装されているか不明）→ **P2**: docs ↔ 実装の trace が切れている
+
+### 5.5.3 「廃止予定」「TODO: remove」「将来削除」検索結果
+
+`grep -rnE "廃止|deprecated|TODO:\s*remove|将来削除|撤廃|撤去|obsolete|sunset|EOL"` の skill 配下ヒット 4 件:
+
+| file:line | 内容 | 判定 |
+|---|---|---|
+| `.claude/skills/collection-ideate/SKILL.md:114` | 「Issue #132 以降、ハードコード単価表は撤廃済み」 | 健全（コード反映済み） |
+| `.claude/skills/channel-setup/references/claude-md-template.md:140` | 「旧 `get_channel_status` は廃止」 | 健全（template 注釈） |
+| `.claude/skills/wf-new/references/schema.md:124` | 「旧スキーマ互換」 | **P2**（trace 切れ） |
+| `.claude/skills/streaming/references/notify.sh:34` | 「Issue #166 / #174」（SSRF 防御の参照） | 健全（実装側 `utils/notification.py:1,9` と整合） |
+
+### 5.5.4 preview 状態の API モデルに対する将来リスクメモ
+
+| skill | preview モデルへの言及 | 「いつ壊れる可能性があるか」のメモ |
+|---|---|---|
+| `.claude/skills/lyria/SKILL.md:85` | `lyria-3-pro-preview` / `lyria-3-clip-preview` | **メモなし**（GA 移行時の endpoint 変更注意なし） |
+| `.claude/skills/loop-video/SKILL.md:86,116` | `veo-3.1-lite-generate-preview` | **メモなし**（preview のまま運用するリスク注意なし） |
+| `.claude/skills/thumbnail/config.default.yaml:18` | `gemini-3.1-flash-image-preview` | **メモなし** |
+| `.claude/skills/masterup/SKILL.md:84,92` | Suno CDN 直叩き | 「CDN URL は public だが永続性は不明」のみ。仕様変更時の代替プランなし |
+
+→ **P2**: 4 skill に「preview / 非公式依存 → 将来 breaking change の可能性」のメモを 1-2 行入れるべき。
+
+### 5.5.5 `_disabled` フラグの仕様文書化
+
+- `.claude/skills/lyria/config.default.yaml:11-12`: `_disabled: false` を default 値で配布
+- `.claude/skills/lyria/SKILL.md:17,59,101-102`: `_disabled: true` の場合 `/suno` を案内して終了する仕様を明示
+
+しかし他の skill の `config.default.yaml` 9 件（benchmark / collection-ideate / loop-video / masterup / suno / thumbnail / video-analyze / video-description）に `_disabled:` は記載なし。**lyria だけが特殊扱い**だが、その由来（なぜ lyria だけ on/off 切替が必要か）が docs に書かれていない。
+
+→ **P2**: `_disabled` パターンが lyria 専用の慣習か / 他 skill にも展開予定かを SKILL.md か共通 references に明文化すべき。
+
+### 5.5.6 撤廃済み機能の `_skills/` への巻き戻り
+
+CHANGELOG（v4.0.0）で `wf-next/references/community_draft.py` / `post_upload_actions.py`（symlink）/ `wf-new/references/schema.md` の `community` フィールド定義などが撤去済みとされる（`data-backward-compat-shims.md:163-166`）。
+
+現在の `.claude/skills/wf-new/references/schema.md` を確認（5.5.2 で抜粋）したところ「community」「post_upload」「short」関連の記述は **見つからず**、撤去は完了。skill 同梱物としては clean。
+
+---
+
+## 観点 5.6: 外部 CLI ツール依存
+
+### 5.6.1 各 skill が前提とする外部バイナリ
+
+| skill | 必要バイナリ | SKILL.md / references の宣言 | `command -v` チェック | フォールバック |
+|---|---|---|---|---|
+| `streaming` | `terraform >= 1.5`, `op`, `ssh-keygen`, `ssh-add`, `realpath`, `curl`, `ffmpeg`（VPS 側） | `SKILL.md:14` で `terraform`/`uv`/`op` 明示。**`ssh-keygen` / `ssh-add` は SKILL.md 文面に無く `swap_video.sh` のみ** | `references/swap_video.sh:61,65,69,73` で 4 件チェック | エラー文言で `brew install coreutils` / `openssh-client 導入` 明記。**P0 級ガードあり** |
+| `channel-setup` | `gcloud`, `terraform`, `jq` | `references/gcp-bootstrap.md` / `gcp-bootstrap.sh` で gcloud 明示 | `references/gcp-bootstrap.sh:107` で gcloud / `gcp-terraform-apply.sh:37,41` で terraform/jq | 公式インストール URL 明記。**良好** |
+| `videoup` | `ffmpeg`, `ffprobe`, `afinfo`（macOS、optional） | **SKILL.md に `## 前提` セクションなし**（SKILL.md:1-65 全文確認） | `references/generate_videos.sh:79,95` で ffmpeg / afinfo | ffmpeg なし時は `ERROR: ffmpeg not found` で exit 1 |
+| `masterup` | `curl`, `rsync`, `ffmpeg`（CLI 経由） | `SKILL.md:63-64` の「前提条件」は WebFetch のみ。**ffmpeg / rsync の宣言なし** | なし（CLI 側 `src/youtube_automation/scripts/generate_master.py:174` で `shutil.which("ffmpeg")` チェック） | CLI 側はあり、shell ステップ側はなし |
+| `lyria` | `gcloud`（ADC）, `ffmpeg`（`generate_lyria_master.py:94` で subprocess 直叩き） | `SKILL.md:18` で `gcloud auth application-default login` 明示。**ffmpeg の宣言なし** | なし（直接 `subprocess.run(["ffmpeg", ...])`） | ffmpeg 不在時は `FileNotFoundError` で opaque 失敗 |
+| `loop-video` | `gcloud`（ADC）, `ffmpeg`（`--smooth` 時） | `SKILL.md:49` で gcloud 明示。`SKILL.md:32` で「FFmpeg クロスフェード補正」言及 | なし（`utils/veo_generator.py:122,161,241` で `subprocess.run(["ffmpeg", ...])` 直叩き、shutil.which 検査なし） | **P1**: ffmpeg 不在時に opaque `FileNotFoundError`。ガード追加すべき |
+| `video-analyze` | `gcloud`（ADC） | `SKILL.md:21` で明示 | なし | 健全 |
+| `suno` | （Suno UI 操作、ローカルバイナリなし） | SKILL.md に `## 前提` なし | — | — |
+| `channel-new` | `gh`, `uv` | `SKILL.md:47-51` でコマンド使用。**`gh` の宣言は無し** | なし | `gh` 不在時 `command not found` で fail |
+| `channel-import` | `gh`, `uv` | `SKILL.md:21` でコマンド使用 | なし | 同上 |
+| その他 24 skill | `uv`（暗黙必須）以外なし | — | — | — |
+
+### 5.6.2 個別検出 P1 級
+
+- **`src/youtube_automation/utils/veo_generator.py:122,161,241`**: `ffmpeg` を `subprocess.run(check=True)` で直叩きしているが、`shutil.which("ffmpeg")` 検査なし。`generate_master.py:174` / `finalize_master.py:230` は適切に検査しているのに、Veo 系だけ抜け。`loop-video` skill 経由で発覚する。→ **P1**（修正は別タスク）
+
+### 5.6.3 SKILL.md `## 前提` セクション欠落 12 件
+
+`grep -L '^前提\|^## 前提\|^### 前提' .claude/skills/*/SKILL.md` の結果:
+
+```
+channel-direction, channel-import, channel-new, channel-research, channel-setup,
+discover-competitors, live-clean, metadata-audit, suno, thumbnail-compare,
+videoup, viewer-voice
+```
+
+うち以下は **実際に外部依存があるのに `## 前提` が無い**:
+
+| skill | 不在の理由（推測） | 必要な記述 |
+|---|---|---|
+| `channel-new` | フロー説明に組み込まれている | `gh`, `uv` |
+| `channel-import` | 同上 | `gh`, `uv` |
+| `channel-setup` | references 側で記述 | `gcloud`, `terraform`, `jq` |
+| `videoup` | references 側で記述 | `ffmpeg`, `ffprobe` |
+| `suno` | ローカルバイナリなしのため不要 | （該当なし） |
+| `metadata-audit` | `uv` のみ | （該当なし） |
+
+→ **P2**: 4 skill（`channel-new` / `channel-import` / `channel-setup` / `videoup`）は SKILL.md トップに `## 前提` を追加すべき。
+
+### 5.6.4 「このツールが誰の責任で入るか」の記述
+
+- `.claude/skills/streaming/references/swap_video.sh:66`: `realpath` 不在時 "macOS なら brew install coreutils" を明示 → 良好
+- `.claude/skills/channel-setup/references/gcp-bootstrap.sh:108`: gcloud 不在時 `https://cloud.google.com/sdk/docs/install` を明示 → 良好
+- 他の skill には dotfiles / nix / brew / uv / pip いずれの責任で入るかの記述なし
+
+→ **P2**: SKILL.md 内に「環境前提（macOS dotfiles / 各 OS パッケージ）」セクションを共通で持つことを検討。
+
+---
+
+## 観点 5.7: wheel 配布アセット drift
+
+### 5.7.1 `[tool.hatch.build.targets.wheel.force-include]` の整合
+
+出典: `pyproject.toml:82-88`
+
+```toml
+[tool.hatch.build.targets.wheel.force-include]
+".claude/skills" = "youtube_automation/_skills"
+".claude/CLAUDE.template.md" = "youtube_automation/_claude_md/CLAUDE.template.md"
+```
+
+実体確認:
+
+- `.claude/skills/`: 存在、35 サブディレクトリ（`find -maxdepth 1 -type d` で 36、parent 除外）
+- `.claude/CLAUDE.template.md`: 存在、12,119 bytes（`ls -la` 確認）
+
+→ force-include の指定先と実体ファイルは整合。
+
+### 5.7.2 `[tool.hatch.build.targets.sdist] include`（出典: `pyproject.toml:92-104`）
+
+```toml
+include = [
+    "src/",
+    "tests/",
+    ".claude/skills/",
+    ".claude/CLAUDE.template.md",
+    "scripts/",
+    "auth/SETUP.md",
+    "auth/client_secrets_template.json",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]
+```
+
+sdist には `auth/SETUP.md` / `auth/client_secrets_template.json` も含まれるが、**wheel の `force-include` には auth/ 配布の指定がない**。
+
+| パス | sdist | wheel | 用途 |
+|---|---|---|---|
+| `.claude/skills/` | ✓ | ✓（`_skills/` として） | yt-skills sync で配布 |
+| `.claude/CLAUDE.template.md` | ✓ | ✓（`_claude_md/` として） | yt-skills sync --asset claude-md |
+| `auth/SETUP.md` | ✓ | ✗ | 下流は手動参照前提か |
+| `auth/client_secrets_template.json` | ✓ | ✗ | 同上 |
+| `scripts/` | ✓ | ✗ | 共通 .sh は wheel 同梱外 |
+
+→ **P2**: `auth/` ディレクトリの取扱いが sdist / wheel で非対称。`yt-skills sync --asset auth-template` のような専用 asset entry を追加するか、現状の運用（下流が template を git submodule 等で参照）を SKILL.md に明文化するか整理が必要。なお `src/youtube_automation/auth/oauth_handler.py:99-102` は **下流側** の `<channel_dir>/auth/` / `<channel_dir>/automation/auth/` を検索しており、wheel 内の auth は前提にしていない（互換性問題ではない）。
+
+### 5.7.3 `_skills/` / `_claude_md/` の参照ロジック
+
+出典: `src/youtube_automation/cli/skills_sync.py:27,40,47,71-89`
+
+```python
+from importlib.resources import as_file, files
+...
+resource = files("youtube_automation").joinpath(spec["resource_name"])
+with as_file(resource) as p:
+    path = Path(p)
+    if path.exists():
+        return path
+```
+
+`_ASSET_SPECS` (`skills_sync.py:37-53`) で `_skills` / `_claude_md` の 2 entry が登録され、未登録 asset には KeyError を返す。実装は健全。
+
+開発時 fallback (`skills_sync.py:82`) で repo root 直下の `<source_subdir>` を見るため、ローカルテストでも動作する設計。
+
+### 5.7.4 下流アップデート時の drift
+
+- `yt-skills sync` のデフォルトは `force=False`（`skills_sync.py:114-115` 相当、`--force` を明示しないと skipped）
+- `skills_sync.py:194,228` に「(skipped を上書きするには --force を指定してください)」メッセージを表示
+- ただし `README.md` / `ONBOARDING.md` / 各 SKILL.md に「upgrade 時に `yt-skills sync --force` を実行」と明示する記述は **見つからず**
+
+→ **P1**: skill ファイルだけ古いまま、ランタイム（`google-genai` 等の依存）は最新を引く乖離リスク。`pyproject.toml` の依存にも上限なし（5.2 参照）のため、両側で予期しない breaking 当たりが発生しうる。下流アップデート手順を `README.md` 等に明示すべき。
+
+### 5.7.5 skill 単独バージョンの不在
+
+各 skill ディレクトリには独立した version 表記が**無い**:
+
+- `grep "^version:" .claude/skills/**/SKILL.md` で 0 件（既出 `data-backward-compat-shims.md:218`）
+- skill 単体のバージョンは `pyproject.toml::version` のみがソース
+
+→ **P1**: skill renaming（`analyze` → `analytics-analyze` 等、`CHANGELOG.md:154` 既出）のような破壊的変更があったとき、下流が古い skill ファイルを保持しているか検出する手段がない。
+
+### 5.7.6 `_disabled` flag を持つ config と yt-skills sync の挙動
+
+`.claude/skills/lyria/config.default.yaml:12` の `_disabled: false` が初期値として配布される。下流が `config/skills/lyria.yaml` で deep-merge 上書きする運用 (`SKILL.md:20`)。
+
+→ `yt-skills sync` でファイル名は配布されるが、下流の上書き内容は触らない。健全だが、`_disabled` が他 skill にも展開された場合の挙動仕様が未文書化（5.5.5 と重複）。
+
+---
+
+## 35 skill × 外部 API / バイナリ依存マトリクス
+
+凡例: ✓=直接依存 / ○=`uv run yt-*` 経由 / ▲=Optional / —=無し
+
+| # | skill | Gemini | Veo | Lyria | OpenAI | YouTube API | Vultr | Suno | ffmpeg | gcloud | terraform | gh | op | rsync | 課金 API |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| 1 | alignment-check | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | analytics-analyze | — | — | — | — | ○ | — | — | — | — | — | — | — | — | — |
+| 3 | analytics-collect | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube Data quota |
+| 4 | analytics-report | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | audience-persona | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | benchmark | ✓ `gemini-2.5-flash` | — | — | — | ○ | — | — | — | ✓ ADC | — | — | — | — | **Gemini + YouTube quota** |
+| 7 | channel-direction | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | channel-import | — | — | — | — | ○ | — | — | — | — | — | ✓ | — | — | — |
+| 9 | channel-new | — | — | — | — | — | — | — | — | — | — | ✓ | — | — | — |
+| 10 | channel-research | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 11 | channel-setup | — | — | — | — | — | — | — | — | ✓ | ✓ | — | — | — | — |
+| 12 | channel-status | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube quota |
+| 13 | collection-ideate | ▲（image preview） | — | — | ▲（image preview） | ○ | — | — | — | ▲ ADC | — | — | — | — | **画像 ×3 / preview** |
+| 14 | comments-reply | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube quota |
+| 15 | discover-competitors | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube `search.list` 100 unit |
+| 16 | live-clean | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 17 | loop-video | — | ✓ `veo-3.1-fast-generate-001` | — | — | — | — | — | ✓ (`--smooth`) | ✓ ADC | — | — | — | — | **Veo per-second** |
+| 18 | lyria | — | — | ✓ `lyria-3-pro-preview` | — | — | — | — | ✓ (CLI 経由) | ✓ ADC | — | — | — | — | **Lyria per-song** |
+| 19 | masterup | — | — | — | — | — | — | ✓ CDN | ✓ (CLI 経由) | — | — | — | — | ✓ | （Suno UI は別課金） |
+| 20 | metadata-audit | — | — | — | — | ○ | — | — | — | — | — | — | — | — | — |
+| 21 | playlist | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube quota |
+| 22 | postmortem | — | — | — | — | ○ | — | — | — | — | — | — | — | — | — |
+| 23 | streaming | — | — | — | — | ○（archive） | ✓ | — | （VPS 側） | — | ✓ | — | ✓ | — | **Vultr 時間課金** |
+| 24 | suno | — | — | — | — | — | — | （UI 操作のみ） | — | — | — | — | — | — | — |
+| 25 | thumbnail | ✓ `gemini-3.1-flash-image-preview` | — | — | ✓ `gpt-image-2` | — | — | — | — | ▲ ADC | — | — | — | — | **画像 per-image** |
+| 26 | thumbnail-compare | — | — | — | — | — | — | — | ✓ (`scripts/compare_thumbnails.py:73`) | — | — | — | — | — | — |
+| 27 | video-analyze | ✓ `gemini-2.5-flash` | — | — | — | — | — | — | — | ✓ ADC | — | — | — | — | **Gemini per-token** |
+| 28 | video-description | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 29 | video-upload | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube quota |
+| 30 | videoup | — | — | — | — | — | — | — | ✓ | — | — | — | — | — | — |
+| 31 | viewer-voice | — | — | — | — | ○ | — | — | — | — | — | — | — | — | YouTube quota |
+| 32 | viewing-scene | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 33 | wf-new | ▲ `gemini-2.5-flash`（scene_phrases） | — | — | — | — | — | — | — | ▲ ADC | — | — | — | — | Gemini per-token |
+| 34 | wf-next | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 35 | wf-status | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+
+合計依存件数:
+
+- **Gemini 依存**: 5 skill（benchmark, collection-ideate, thumbnail, video-analyze, wf-new）→ うち 3 件（benchmark / video-analyze / wf-new）が `gemini-2.5-flash[-lite]` を使用 → **2026-10-16 shutdown 直撃**
+- **Veo 依存**: 1 skill（loop-video）
+- **Lyria 依存**: 1 skill（lyria）
+- **OpenAI 依存**: 2 skill（collection-ideate, thumbnail）
+- **YouTube Data quota 重課金**: discover-competitors（`search.list` 100 unit/呼び出し）
+- **VPS 課金（Vultr）**: streaming のみ
+- **Suno（非公式）**: 2 skill（masterup, suno）
+
+---
+
+## 注意点 / リスク
+
+1. **2026-10-16 の Gemini 2.5 shutdown**は 5 か月の猶予しかない。`benchmark` / `video-analyze` / `wf-new` の config.default.yaml 3 ファイル + 実装 1 か所（`scripts/populate_scene_phrases.py:33`）を後継モデルに置き換える必要あり
+2. **`google-genai` のメジャー乖離（1.69 → 2.4）** は SDK 2.x の breaking change 影響範囲が未調査。本リポジトリは 6 ファイルで直 import している（5.2.1 表で列挙）
+3. **依存に version 上限なし + 下流 lock 非伝播** の組み合わせは「下流が `uv add` した日次のタイミング次第で動作が変わる」状態。CI 上の re-lock が無い限り、本リポジトリで test が green でも下流環境で破綻しうる
+4. **Suno 非公式依存** は復旧手段ゼロ。`/suno` `/masterup` チェーンは Suno UI / CDN 仕様変更で即停止する。代替プラン（Lyria への切り替えガイド等）の事前準備が必要
+5. **wheel 配布の `force=False` デフォルト** で「skill ファイルだけ古い」乖離が下流で発生しうる。skill 内に「依存パッケージ X.Y.Z 以上を想定」のような contract が無い
+
+---
+
+## 調査できなかった項目
+
+| 項目 | 理由 |
+|---|---|
+| 下流チャンネルでの実利用バージョン | 外部リポジトリ閲覧不可（git remote 接続なし） |
+| Vertex AI Lyria 3 の GA 化時期 | 公開情報なし。`https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music` に明示なし |
+| Suno UI / CDN の廃止スケジュール | Suno 側に SLA / 公開廃止スケジュールなし |
+| `google-genai` 1.69 → 2.x の breaking change 一覧 | リリースノート全件追跡は本タスクスコープ外。SDK 直 import 6 ファイルの動作影響は別途検証必要 |
+| `pandas` 3.x が py3.10 / 3.11 のサポート範囲 | uv.lock の transitive 解決が py3.11 で安定している事実のみ確認。下限緩和検証は別タスク |
+
+---
+
+## 推奨アクション
+
+| # | 観点 | severity | アクション | 想定工数 |
+|---|---|---|---|---|
+| R-01 | 5.1 | **P1** | `gemini-2.5-flash[-lite]` を後継モデル（`gemini-3-flash-preview` / `gemini-3.1-flash-lite`）に差し替え。`.claude/skills/{benchmark,video-analyze}/config.default.yaml` 2 件 + `src/youtube_automation/scripts/{benchmark_collector.py:523,populate_scene_phrases.py:33}` 2 件 + `scene_phrases.md:26,41` の docs を一斉更新 | 0.5d |
+| R-02 | 5.2 | **P1** | `pyproject.toml` の dependencies に上限制約を追加。最低限 `google-genai>=1.60,<2`, `pandas>=3,<4`, `Pillow>=12,<13` の 3 件 | 0.25d |
+| R-03 | 5.4 | **P1** | `CLAUDE.md:38` の「`utils/`, `agents/`, `auth/`, `scripts/` — submodule 利用者向け 後方互換 shim」を実態（`auth/` template、`scripts/` 共通 .sh）に合わせて書き換え。L.100 と矛盾解消 | 0.1d |
+| R-04 | 5.4 | **P1** | `google-auth-httplib2` の deprecated 表明を CHANGELOG / docs に追記し、新規 import 禁止ルールを CLAUDE.md に明示 | 0.1d |
+| R-05 | 5.6 | **P1** | `src/youtube_automation/utils/veo_generator.py:122,161,241` の ffmpeg 直叩きに `shutil.which("ffmpeg")` ガードを追加（`generate_master.py:174` と同パターン） | 0.25d |
+| R-06 | 5.7 | **P1** | `README.md` / `ONBOARDING.md` に「upgrade 時は `uv run yt-skills sync --force` を実行」を明記。下流ドリフト防止 | 0.1d |
+| R-07 | 5.7 | **P1** | skill にバージョン追跡を導入（SKILL.md frontmatter に `version:` を追加 or `_skills/VERSION` を同梱）。下流が古い skill を保持しているか検出可能にする | 0.5d |
+| R-08 | 5.1 | **P1** | `.claude/skills/masterup/SKILL.md` / `.claude/skills/suno/SKILL.md` に「Suno UI 仕様変更時の代替プラン」セクションを追加（Lyria への切替手順 / fallback 提示） | 0.25d |
+| R-09 | 5.1 | P2 | `.claude/skills/lyria/SKILL.md` に「`v1beta1` 直叩きは Lyria 3 GA 化 + google-genai SDK 対応で撤去予定」のメモを追加 | 0.1d |
+| R-10 | 5.1 | P2 | `.claude/skills/{loop-video,thumbnail}/config.default.yaml` の preview モデル指定に「preview のため将来変更あり」のコメントを追加 | 0.1d |
+| R-11 | 5.4 | P2 | `Workflow` dataclass / `_build_workflow` を次期メジャーバージョンで完全撤去。`ChannelConfig.workflow` フィールドを削除し、空 dataclass の依存を断つ | 0.5d |
+| R-12 | 5.5 | P2 | `.claude/skills/wf-new/references/schema.md:124-128`「旧スキーマ互換」の実装側 trace を `/wf-status/SKILL.md` に追記（どこに旧スキーマ判別ロジックがあるか明示） | 0.1d |
+| R-13 | 5.6 | P2 | `.claude/skills/{channel-new,channel-import,channel-setup,videoup}/SKILL.md` に `## 前提` セクションを追加（`gh`, `gcloud`, `terraform`, `jq`, `ffmpeg` 等の必要バイナリ宣言） | 0.5d |
+| R-14 | 5.5 | P2 | `_disabled` フラグの仕様（lyria 専用慣習 / 共通展開の有無）を `.claude/skills/lyria/SKILL.md` または共通 reference に明文化 | 0.1d |
+| R-15 | 5.7 | P2 | `auth/SETUP.md` / `auth/client_secrets_template.json` の wheel 配布方針を整理（sdist のみ / `yt-skills sync --asset auth-template` 専用 entry 追加のいずれか） | 0.25d |
+| R-16 | 5.2 | P2 | `japanize-matplotlib` を `matplotlib.font_manager` 直接登録に置き換え、停滞ライブラリ依存を断つ | 1.0d |
+| R-17 | 5.2 | P2 | `uv.lock` を下流に伝播させる手段（git submodule with lockfile / `pip install --constraint`）を `README.md` で案内 | 0.25d |
+| R-18 | 5.4 | P3 | `pyproject.toml:35` の `veo = []` dead extras を削除（または何かに使う） | 0.05d |
+| R-19 | 5.3 | P3 | `requires-python` 緩和を検討する場合は transitive 解決を py3.10 でも試す。緩和不要なら現状維持 | 0.25d |
+| R-20 | 5.4 | P3 | `yt-config-migrate` の撤去判断。次期メジャー（v6）で削除候補とし CHANGELOG にアナウンスを 1 リリース前に出す | 0.1d |
+| R-21 | 5.4 | P3 | `src/youtube_automation/utils/audio_units.py:16` の `"lyria-002": "30sec"` は「旧ログ読み出し互換のため残置」のコメントを追加 | 0.05d |
+| R-22 | 5.1 | P3 | `lyria-3-pro-preview` を `_AUDIO_UNIT_BY_MODEL` のキーとして固定しているのは preview 表記ごと変わるリスクあり。GA 化後に名称変更が来た場合のための fallback ロジック追加検討 | 0.25d |
+
+合計想定工数（P1 のみ）: **2.05 日**
+
+---
+
+## PR #367 既出指摘との重複回避メモ
+
+PR #367 (`docs/audits/2026-05-18-skills-generalization-consistency.md`) は観点 1（汎用化・設定切り出し）/ 観点 2（整合性）を扱った。本レポートでは以下の境界を維持:
+
+- **ハードコード値の汎用化**（観点 1.1〜1.4）: 再検出しない。本レポートで挙げた `gemini-2.5-flash` 等のモデル ID 直書きは「廃止予定 API への参照」観点 5.1 として扱い、汎用化観点としては触れない
+- **description ↔ 実装の乖離**（観点 2.1〜2.4）: 再検出しない。観点 5.5.2 の「旧スキーマ互換 trace 切れ」は「撤廃済み機能の残存参照」観点 5.5 として扱い、整合性監査ではなく依存・廃止リスク観点で記述

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/10-data-external-api-deprecation.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/10-data-external-api-deprecation.md
@@ -1,0 +1,202 @@
+# C-2: 外部 API の廃止 / バージョン追従 — 監査データ
+
+調査日: 2026-05-18
+担当: dig.part-c-deps-deprecation
+対象リビジョン: HEAD
+
+---
+
+## 6.6 Vertex AI API バージョン（Lyria / Veo / Gemini）
+
+### 6.6.1 使用モデル一覧と endpoint
+
+| モデル / バージョン | 使用箇所 | 公式ステータス（2026-05-18 時点） | shutdown 予定 |
+|---|---|---|---|
+| `gemini-2.5-flash` | `.claude/skills/video-analyze/config.default.yaml:7`, `.claude/skills/benchmark/config.default.yaml:23`, `src/youtube_automation/scripts/benchmark_collector.py:523` | **deprecated**（後継 `gemini-3-flash-preview`） | **2026-10-16 earliest** |
+| `gemini-2.5-flash-lite` | `src/youtube_automation/scripts/populate_scene_phrases.py:33`（`DEFAULT_GEMINI_MODEL`） | **deprecated**（後継 `gemini-3.1-flash-lite`） | **2026-10-16 earliest** |
+| `gemini-3.1-flash-image-preview` | `src/youtube_automation/utils/image_provider/config.py:27`, `.claude/skills/thumbnail/config.default.yaml:18`, `.claude/skills/collection-ideate/SKILL.md:139` | preview / GA 移行情報未公開 | 未告知（preview 継続中） |
+| `veo-3.1-fast-generate-001` | `src/youtube_automation/utils/veo_generator.py:15`, `.claude/skills/loop-video/config.default.yaml:8`, `.claude/skills/loop-video/SKILL.md:107,116` | **GA**（2025-11-17 promoted） | 未告知 |
+| `veo-3.1-generate-001` | `.claude/skills/loop-video/SKILL.md:116`（選択肢として記載） | **GA**（2025-11-17） | 未告知 |
+| `veo-3.1-lite-generate-preview` | `.claude/skills/loop-video/SKILL.md:86,116`, `.claude/skills/loop-video/config.default.yaml:7` | **preview**（2026-04-02 導入） | 未告知 |
+| `lyria-3-pro-preview` | `src/youtube_automation/utils/audio_units.py:14`, `.claude/skills/lyria/config.default.yaml:17`, `.claude/skills/lyria/SKILL.md:60,85,94` | **preview** | 未告知 |
+| `lyria-3-clip-preview` | `src/youtube_automation/utils/audio_units.py:15`, `.claude/skills/lyria/SKILL.md:85` | **preview** | 未告知 |
+| `lyria-002` | `src/youtube_automation/utils/audio_units.py:16`（cost_tracker 単価マッピングのみ） | レガシー（Lyria 2） | 未告知 |
+| `gpt-image-2` | `src/youtube_automation/utils/image_provider/config.py:150`, `.claude/skills/thumbnail/config.default.yaml:89` | **GA**（2026-04-21 リリース） | 未告知 |
+
+### 6.6.2 出典・取得日
+
+- Gemini deprecation table: `https://ai.google.dev/gemini-api/docs/deprecations`（2026-05-18 取得）
+  - 「gemini-2.5-flash Release: June 17, 2025, Shutdown: October 16, 2026, Replacement: gemini-3-flash-preview」
+  - 「gemini-2.5-flash-lite Release: July 22, 2025, Shutdown: October 16, 2026, Replacement: gemini-3.1-flash-lite」
+  - 「gemini-3.1-flash-image-preview Release: February 26, 2026, Shutdown: No shutdown date announced」
+- Veo GA / preview ステータス: `https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes`（2026-05-18 取得）
+  - 「veo-3.1-generate-001 / veo-3.1-fast-generate-001 promoted to GA on 2025-11-17」
+  - 「veo-3.1-generate-preview / veo-3.1-fast-generate-preview migration deadline: 2026-04-02」
+  - 「veo-3.1-lite-generate-preview introduced 2026-04-02」
+- Lyria 3 ステータス: `https://docs.cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music`（2026-05-18 取得）
+  - 「Lyria 3 is in preview, not GA. Available model IDs: lyria-3-clip-preview, lyria-3-pro-preview」
+- OpenAI gpt-image-2: WebSearch + `https://developers.openai.com/api/docs/models/gpt-image-2`（2026-05-18 取得）
+  - 「gpt-image-2 officially launched 2026-04-21」
+  - 「dall-e-2 / dall-e-3 deprecated and removed from API on 2026-05-12」
+
+### 6.6.3 endpoint 設計
+
+`src/youtube_automation/utils/lyria_client.py:26`:
+
+```python
+_ENDPOINT = "https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/interactions"
+```
+
+→ **`v1beta1` を直接叩いている**（`google-genai` SDK 1.71.0 時点で `interactions` 未対応のため `requests` で直叩き、と docstring 明記）。`v1beta1` は Google Cloud 慣例で GA 移行時に endpoint が `v1` に変わる可能性が高い。Lyria 3 が GA 化されたとき、もしくは新 SDK が `interactions` をサポートしたタイミングで自前 `requests` 実装は破棄すべき。
+
+Vertex AI region: `genai_client.py:27` で `_DEFAULT_LOCATION = "us-central1"`。`lyria_client.py:26` は `locations/global` を hardcode（Lyria 3 は global のみのため）。`auth/SETUP.md:11-13` に「`gemini-3.1-flash-image-preview` などの画像系: `global` のみ／`veo-3.1-fast-generate-001` などの Veo 系: `us-central1` など region 指定」と注意書きあり。
+
+---
+
+## 6.7 YouTube Data API v3
+
+### 6.7.1 ServiceRegistry の API バージョン指定
+
+出典: `src/youtube_automation/utils/youtube_service.py:49,57,65`
+
+```python
+build("youtube", "v3", credentials=...)
+build("youtubeAnalytics", "v2", credentials=credentials)
+build("youtubereporting", "v1", credentials=credentials)
+```
+
+`src/youtube_automation/auth/oauth_handler.py:239`, `src/youtube_automation/scripts/fetch_stream_key.py:114` でも `youtube/v3` を直接 build。
+
+### 6.7.2 廃止予告 API endpoint の使用有無
+
+主要 endpoint 使用箇所（grep ベース）:
+
+| endpoint | 使用箇所 | 廃止リスク |
+|---|---|---|
+| `videos().insert` | `src/youtube_automation/utils/upload_core.py:74` | 中核機能、廃止懸念なし |
+| `videos().list` | `src/youtube_automation/utils/streaming_archive.py:60`, `bulk_update_descriptions_from_md.py:102`, `metadata_audit.py:138`, `competitor_discovery.py:134`, `comments/replier.py:134` | 廃止懸念なし |
+| `videos().update` | `src/youtube_automation/scripts/bulk_update_descriptions_from_md.py:153` | 廃止懸念なし |
+| `playlists().insert` | `src/youtube_automation/scripts/playlist_manager.py:60` | 廃止懸念なし |
+| `playlistItems().insert/list/delete` | `playlist_manager.py:91,209,367,385`, `playlist_status.py:38`, `competitor_discovery.py:118`, `comments/replier.py:52`, `video_listing.py:49` | 廃止懸念なし |
+| `commentThreads().list` | `src/youtube_automation/utils/comments/fetcher.py:59`, `scripts/fetch_benchmark_comments.py:50` | 廃止懸念なし |
+| `comments().insert` | `src/youtube_automation/utils/comments/replier.py:214` | 廃止懸念なし |
+| `search().list` | `src/youtube_automation/utils/streaming/archive_counter.py:64`, `agents/collection_uploader.py:150` | 高 quota cost（100 units）注意 |
+| `channels().list` | `src/youtube_automation/auth/oauth_handler.py:255` | 廃止懸念なし |
+
+**`commentThreads.markAsSpam` / `commentThreads.setModerationStatus` / `guideCategories` 等の廃止予告 endpoint の使用は 0 件確認**（grep）。
+
+YouTube Data API v3 自体は 2026-05-18 時点で deprecation アナウンスなし（公開検索結果）。Reporting API v1 と Analytics API v2 も同様。
+
+---
+
+## 6.8 OpenAI API
+
+### 6.8.1 使用モデル
+
+`src/youtube_automation/utils/image_provider/config.py:150`:
+
+```python
+return OpenAIConfig(
+    model=d.get("model", "gpt-image-2"),
+    ...
+)
+```
+
+`.claude/skills/thumbnail/config.default.yaml:89`:
+
+```yaml
+model: gpt-image-2
+```
+
+### 6.8.2 deprecation schedule との突合せ
+
+- `dall-e-2` / `dall-e-3`: **2026-05-12 にすでに API から削除済み**（OpenAI Deprecations 2026 通知）
+  - codebase 内で `dall-e` 文字列の使用箇所: 0 件確認（grep）→ **影響なし**
+- `gpt-image-1`: 現役（gpt-image-2 の旧世代だが deprecation なし）
+- `gpt-image-1.5`: 現役（2025-12 リリース）
+- `gpt-image-2`: **2026-04-21 GA**、現役
+
+→ codebase は最新世代を使用しており健全。
+
+`utils/cost_tracker.py` の `PRICING` テーブルは `gpt-image-2` / `gpt-image-1.5` / `gpt-image-1-mini` の 3 モデルを CHANGELOG（行 40-44）で追加済み。
+
+### 6.8.3 OpenAI Python SDK の互換性
+
+`openai==2.33.0` （uv.lock）→ PyPI 2.37.0 が最新。`from openai import OpenAI` (`src/youtube_automation/utils/image_provider/openai.py:16`) で利用しているのみ。SDK 1.x → 2.x の breaking change（client インスタンス化方式変更）には対応済み（2.x で書かれている）。
+
+---
+
+## 6.9 Suno API
+
+### 6.9.1 契約形態
+
+Suno **公式 API は無し**。下記のような非公式 / UI スクレイピング経由でアクセスしている。
+
+### 6.9.2 CDN URL 経由ダウンロード
+
+`.claude/skills/masterup/SKILL.md:84-89`:
+
+```bash
+curl -L -o "02-Individual-music/{filename}.mp3" "https://cdn1.suno.ai/{song_id}.mp3"
+```
+
+`.claude/skills/masterup/SKILL.md:22`:
+
+```yaml
+suno_download.cdn_url_template: "https://cdn1.suno.ai/{song_id}.mp3"
+```
+
+SKILL.md:92 に「CDN URL は public だが永続性は不明。生成後なるべく早めにダウンロードすること」と注意書きあり。
+
+### 6.9.3 WebFetch でプレイリスト HTML スクレイピング
+
+`.claude/skills/masterup/SKILL.md:72-79` Step 2:
+
+> WebFetch ツールを使ってプレイリスト URL (例: `https://suno.com/playlist/xxx`) を取得し、prompt で全曲の情報を抽出するよう指示
+
+→ **Suno UI の HTML 構造に依存**。Suno が SPA 化したり HTML 構造を変えた瞬間に壊れる。
+
+### 6.9.4 「いつ壊れる可能性があるか」のメモ
+
+`/suno` `/masterup` の SKILL.md / 実装側に Suno 仕様変更に関する deprecation メモ・モニタリングは **無し**。
+
+→ 公開情報なし（Suno 側に SLA / 廃止スケジュールの公開なし）。**未検証 / 公開情報なし** として report.
+
+---
+
+## 6.10 Google API 全般 — `googleapiclient.discovery.build` 棚卸し
+
+| service / version | 箇所 | 用途 |
+|---|---|---|
+| `youtube` / `v3` | `src/youtube_automation/utils/youtube_service.py:49`（YouTubeOAuthHandler 経由）, `auth/oauth_handler.py:239`, `scripts/fetch_stream_key.py:114` | YouTube Data API |
+| `youtubeAnalytics` / `v2` | `src/youtube_automation/utils/youtube_service.py:57` | Analytics |
+| `youtubereporting` / `v1` | `src/youtube_automation/utils/youtube_service.py:65` | Reporting |
+
+→ 3 サービス × 各 1 バージョン。すべて現役。
+
+`fetch_stream_key.py:114` で `oauth_handler` を経由せず直接 `build` している点はリファクタリング余地ありだが API バージョン的には問題なし。
+
+---
+
+## まとめ（外部 API 廃止リスク severity）
+
+| ID | 内容 | severity | shutdown 予定 |
+|---|---|---|---|
+| 6.6.1 | `gemini-2.5-flash` が deprecated、shutdown 2026-10-16（earliest） | **P1** | 5 ヶ月後 |
+| 6.6.1 | `gemini-2.5-flash-lite` が deprecated、shutdown 2026-10-16 | **P1** | 5 ヶ月後 |
+| 6.6.1 | `lyria-3-pro-preview` / `lyria-3-clip-preview` が preview 状態（GA への移行未告知） | P2 | 未告知 |
+| 6.6.1 | `veo-3.1-lite-generate-preview` が preview（`loop-video` の選択肢） | P2 | 未告知 |
+| 6.6.3 | Lyria 3 `interactions` は `v1beta1` を直叩き（公式 SDK 未対応のため `requests`） | P2 | 未告知 |
+| 6.7 | YouTube Data API v3 関連で廃止予告 endpoint 使用は **無し** | — | — |
+| 6.8 | `dall-e-*` deprecation の影響 **無し**（コード非使用） | — | — |
+| 6.9 | Suno は非公式 CDN URL + UI HTML スクレイピング依存、deprecation メモ無し | **P1** | 未公開 |
+
+### 主要発見
+
+1. **Gemini 2.5 系（2 モデル）は 2026-10-16 に shutdown 予告済み**。`benchmark`, `video-analyze`, `populate_scene_phrases` の 3 スキル/CLI が直接ヒット。事実上 5 ヶ月の猶予
+2. **Lyria 3 が preview のまま**。`/lyria` スキルは preview 状態の `v1beta1` `interactions` REST を直叩き。GA 移行時に endpoint URL が変わる可能性あり
+3. **Suno 連携は非公式**。永続性なし、復旧手段ゼロのリスクが顕在化していない
+
+調査不可項目:
+- Suno UI / CDN の正確な廃止スケジュール: 公開情報なし
+- Vertex AI Lyria 3 GA 化時期: 公開情報なし

--- a/docs/audits/2026-05-18-skills-operational-risk-audit/raw/11-data-backward-compat-shims.md
+++ b/docs/audits/2026-05-18-skills-operational-risk-audit/raw/11-data-backward-compat-shims.md
@@ -1,0 +1,266 @@
+# C-3: 後方互換 shim の現状 — 監査データ
+
+調査日: 2026-05-18
+担当: dig.part-c-deps-deprecation
+対象リビジョン: HEAD
+
+---
+
+## 6.11 ルート shim 棚卸し
+
+### 6.11.1 CLAUDE.md の宣言 vs 実態
+
+`CLAUDE.md:38`（プロジェクト固有）の記述:
+
+> - `utils/`, `agents/`, `auth/`, `scripts/` — submodule 利用者向け **後方互換 shim**（新規開発は `src/youtube_automation/` 側で行う）
+
+実態（`find -maxdepth 1 -type d` + `ls`）:
+
+| ディレクトリ | 存在 | 中身 | 性質 |
+|---|---|---|---|
+| `utils/` | **存在しない** | — | CLAUDE.md の記述が古い（残骸） |
+| `agents/` | **存在しない** | — | CLAUDE.md の記述が古い（残骸） |
+| `auth/` | 存在 | `SETUP.md`, `client_secrets_template.json` の 2 ファイルのみ | **shim ではなく、template + setup ドキュメント** |
+| `scripts/` | 存在 | `gcp-bootstrap.sh`, `gcp-terraform-apply.sh` の 2 シェルスクリプトのみ | **Python shim ではなく、共通シェルスクリプトのみ** |
+
+`CLAUDE.md:100`（同じファイル内）には:
+
+> - ルート直下の `scripts/` にはシェルスクリプト（`.sh`）のみ配置。Python shim は廃止済み
+
+→ `CLAUDE.md` 内部で**矛盾**している。L.38 が古い記述、L.100 が現状。`utils/`, `agents/`, `auth/`, `scripts/` のうち実際の Python shim として残っているのは **0 個**。
+
+### 6.11.2 ルート shim の実態詳細
+
+#### `auth/`
+
+```
+auth/
+├── SETUP.md                       # GCP / YouTube API セットアップガイド
+└── client_secrets_template.json   # OAuth client_secrets.json のテンプレ
+```
+
+`SETUP.md:88` で「`<channel_dir>/automation/auth/client_secrets.json`（submodule 互換フォールバック）」と書かれているが、これは下流チャンネル側の path 検索の話で、本リポジトリの `auth/` ディレクトリ自体は shim ではなく、純粋にドキュメント + テンプレ配布用。
+
+`src/youtube_automation/auth/oauth_handler.py:99-102` も：
+
+```python
+candidates = [
+    channel_dir / "auth" / "client_secrets.json",
+    channel_dir / "automation" / "auth" / "client_secrets.json",
+]
+```
+
+→ 「submodule 互換」は **下流チャンネル側** の検索 path 互換であり、本リポジトリ側に shim ファイルは存在しない。
+
+#### `scripts/`
+
+```
+scripts/
+├── gcp-bootstrap.sh
+└── gcp-terraform-apply.sh
+```
+
+`CLAUDE.md:105` で「複数の文脈から共有される **共通スクリプトのみ** を置く」と方針宣言。`auth/SETUP.md:23` で `automation/scripts/gcp-bootstrap.sh` として参照されている。下流チャンネルから submodule 経由で呼ばれる前提。shim ではなく、本物の共通スクリプト。
+
+#### `utils/` / `agents/`
+
+`find` で確認したが**ディレクトリ自体が存在しない**。`CLAUDE.md:38` の記述は obsolete。Python shim 廃止済みとした `CLAUDE.md:100` 方が正しい。
+
+### 6.11.3 結論
+
+「ルート直下の Python shim」は実態 **ゼロ件**。CLAUDE.md L.38 の記述だけが残骸として残っている。
+**P2: ドキュメント修正案件**（コードへの影響なし）。
+
+---
+
+## 6.12 v1 → v2 設定移行残骸（`cli.config_migrate`）
+
+### 6.12.1 配置と役割
+
+`src/youtube_automation/cli/config_migrate.py:1-13`（モジュール docstring 抜粋）:
+
+> "yt-config-migrate — 旧 config/channel_config.json を新 config/channel/*.json 構造に分割する。
+> ...
+> automation v2.0.0 に pin-bump した直後、旧 channel_config.json のままでも実行可能である必要があるため。"
+
+`pyproject.toml:48`:
+
+```toml
+yt-config-migrate = "youtube_automation.cli.config_migrate:main"
+```
+
+→ entry point として登録継続。
+
+`src/youtube_automation/utils/config/loader.py:100-106`:
+
+```python
+legacy_path = channel_dir_path / "config" / "channel_config.json"
+
+if legacy_path.exists():
+    raise ConfigError(
+        f"旧 channel_config.json が残っています: {legacy_path}\n"
+        "yt-config-migrate で新構造 (config/channel/*.json) へ変換してください"
+    )
+```
+
+→ **新 loader は legacy 形式を読まずに ConfigError で fail-fast**。`yt-config-migrate` で移行する前提。
+
+### 6.12.2 現在の役割（v5.5.0 時点）
+
+`docs/migration/v2-config-split.md` が存在（`docs/migration/` の中身を `Bash ls` で確認済み）。v2 移行ガイドが残っている。
+
+`config_migrate` 本体は読み取りロジックを independent に持つ（loader を使わない設計、`config_migrate.py:8-12` docstring 明記）。これは過去の判断としては適切。
+
+`tests/test_config_migrate.py` などのテストカバレッジは未確認だが、`yt-config-migrate verify` が新 loader でロード検証可能。
+
+### 6.12.3 廃止判定
+
+- v2.0.0 への pin-bump 後の移行用 → 既に **v5.5.0**（pyproject.toml:8）に到達。3 メジャーバージョン経過
+- 下流チャンネルが v1 → v2 移行を未完了で残しているケースは個別調査要だが、loader 側が hard fail するので「移行せずに使い続ける」運用は不可能
+
+→ `yt-config-migrate` を撤去するタイミングを検討する余地あり（**P3: 中長期判断**）。撤去判断には CHANGELOG / 配布実績の追跡が必要だが、新規ユーザーには不要 CLI。
+
+---
+
+## 6.13 廃止された設定キー — workflow.json の `short` / `community`
+
+### 6.13.1 v4.0.0 で撤去された経緯
+
+`src/youtube_automation/utils/config/workflow.py:8-15`:
+
+```python
+@dataclass(frozen=True)
+class Workflow:
+    """ワークフロー責務の合成（`workflow` セクション）.
+
+    v4.0.0 で short 関連フィールド（`post_upload` / `short`）を撤去した。
+    将来フィールドが増えたら本 dataclass に追加し、`_REQUIRED_KEYS_BY_SECTION` に
+    必須キーを登録すること。
+    """
+```
+
+→ **空の dataclass**。フィールド 0 個。
+
+`src/youtube_automation/utils/config/loader.py:266-271`:
+
+```python
+def _build_workflow(merged: dict) -> Workflow:
+    # v4.0.0 で short / community_post 関連セクションを撤去。
+    # `workflow` / `post_upload` / `short` / `community` が downstream に残っていても
+    # `_validate_required` は workflow.json に必須キーを登録していないため
+    # 素通しする（後方互換）。
+    return Workflow()
+```
+
+→ **無条件で空 dataclass を返す**。downstream の `workflow.json` 内の `workflow` / `post_upload` / `short` / `community` キーは読まれもせず捨てられる。
+
+### 6.13.2 CHANGELOG での撤去記録
+
+`CHANGELOG.md:482-491` 抜粋（v4.0.0 系のリリースノート）:
+
+```
+- **設定スキーマ**: `Workflow.post_upload` / `Workflow.short` フィールド、および `PostUpload` / `ShortSettings` dataclass
+- **Python モジュール**: `youtube_automation.scripts.community_draft` / `youtube_automation.scripts.post_upload_actions`
+- **スキル参照**: `.claude/skills/wf-next/references/community_draft.py` / `post_upload_actions.py`（symlink）
+- **スキル記述**: `wf-next/SKILL.md` の community-draft ステップ、`wf-new/references/schema.md` の `community` フィールド定義、`ideate/SKILL.md` と `ideate/references/object-design-examples.md` の「コミュニティ投稿での展開 / 活用」セクション、`channel-setup/references/config-generation-rules.md` の `post_upload` オプション行
+```
+
+`CHANGELOG.md:500`:
+
+> 3. `config/channel/workflow.json` の `post_upload` / `short` / `community` キーは**削除しなくても loader は素通しする**ため任意。整理したい場合は手動削除
+
+→ 明示的に「素通し（silent ignore）」と運用上宣言。
+
+### 6.13.3 影響範囲
+
+- **`Workflow` dataclass は空**だが `ChannelConfig.workflow` フィールドは残っている（`src/youtube_automation/utils/config/config.py:27`）→ 構造保持のための placeholder
+- 下流が `workflow.json` を持っていれば中身は無視されるが、loader はファイルそのものは glob で読む（`_load_and_merge` で重複キー検出はする）
+- `tests/test_config_loader.py:134-139` で「v4.0.0 で post_upload / short セクションは撤去されたが、downstream の」（テストケースが残置確認のために存在）
+
+### 6.13.4 廃止判定
+
+「空 dataclass + 素通し loader」は典型的な **dead backward-compat shim**。
+
+- `Workflow` 自体が空なら `ChannelConfig.workflow` フィールド／`_build_workflow` の関数を撤去できる（代わりに `ChannelConfig` から workflow フィールド削除）
+- ただし下流が `from youtube_automation.utils.config import ChannelConfig` で型 hint 経由で参照している可能性があるので、撤去はメジャーバージョン bump で
+
+**P2: dead shim**。動作影響なし、メジャーバージョン更新時に整理候補。
+
+---
+
+## 6.14 skill 同梱バージョンと配布側の固定リスク
+
+### 6.14.1 配布メカニズム
+
+`pyproject.toml:82-88`:
+
+```toml
+[tool.hatch.build.targets.wheel.force-include]
+".claude/skills" = "youtube_automation/_skills"
+".claude/CLAUDE.template.md" = "youtube_automation/_claude_md/CLAUDE.template.md"
+```
+
+→ wheel ビルド時に **`youtube-channels-automation` のバージョンと skills のバージョンが完全固定**になる。`5.5.0` の wheel をインストールすれば必ず `5.5.0` 時点の skills が配布される。
+
+`src/youtube_automation/cli/skills_sync.py:73-78` で `importlib.resources` 経由で wheel 内の `_skills/` を参照し、`yt-skills sync` 実行時に下流の `.claude/skills/` に展開。
+
+### 6.14.2 skills 自体のバージョン管理
+
+各 skill ディレクトリには独立した version 表記が **無い**:
+
+```
+.claude/skills/<name>/
+├── SKILL.md         # frontmatter に version: なし
+├── config.default.yaml
+└── references/
+```
+
+`grep "^version:" .claude/skills/**/SKILL.md` で 0 件。
+
+→ skill 単体のバージョンは追跡不可。`pyproject.toml::version` のみがソース。
+
+### 6.14.3 下流での固定リスク
+
+**問題シナリオ**:
+
+1. 下流チャンネル A が `uv add 'git+...youtube-automation@v5.3.0'` で pin
+2. 当時の `5.3.0` 時点の `.claude/skills/` が配布される
+3. `5.4.0` で `analyze` → `analytics-analyze` のような skill rename があった（`CHANGELOG.md:154` で確認可能: 「スキル名 rename 8 件（`analyze` → `analytics-analyze` など、破壊的）」）
+4. チャンネル A 側で `claude code` / SKILL invocation を使う際に、古い skill 名が残ったまま動く
+5. 一方で `pyproject.toml` の依存（`google-genai` 等）は version 上限なしで最新を引くため、**skill ファイルだけ 5.3.0、ランタイムは最新** という乖離が発生
+
+→ **P1: skill とランタイムの version lock が一致しない可能性**。`yt-skills sync --force` で更新する運用責任は下流チャンネル側にあり、自動アップデートしない。
+
+### 6.14.4 wheel 同梱の不安定要素
+
+`yt-skills sync` がデフォルトで `force=False`（`skills_sync.py:114-115`）。既存 skill が target にあれば「skipped」になり、新版が適用されない。`--force` フラグを明示しないと古い skill が残る。
+
+下流の運用ドキュメント（`README.md` / `ONBOARDING.md`）に「`yt-skills sync --force` を upgrade 時に実行」と明記されているかは未検証だが、CLI 出力にメッセージ:
+
+```
+(skipped を上書きするには --force を指定してください)
+```
+
+`skills_sync.py:194,228` に表示される。気づける設計にはなっている。
+
+### 6.14.5 結論
+
+- skill version 単独追跡なし
+- パッケージ version と完全同期
+- 下流アップデート手順が `--force` 必須
+
+**P2: 下流アップデート時の手順が明示化されていないと skill だけ古いまま乖離する**。
+
+---
+
+## まとめ（後方互換 shim severity）
+
+| ID | 内容 | severity |
+|---|---|---|
+| 6.11 | `CLAUDE.md:38` が古く、`utils/`/`agents/` shim は実在しない（同ファイル L.100 と矛盾） | P2（docs） |
+| 6.11 | `auth/`, `scripts/` ルートディレクトリは shim ではなく template + 共通スクリプト | — |
+| 6.12 | `yt-config-migrate` v1→v2 移行 CLI は v5.5.0 でも残存。撤去判断が必要 | P3 |
+| 6.13 | `Workflow` dataclass 空、`_build_workflow` も placeholder。dead backward-compat shim | P2 |
+| 6.14 | skill バージョン追跡なし、wheel 同期は `--force` 明示要 | **P1**（下流ずれリスク） |
+
+調査不可項目: 下流チャンネルでの実利用バージョン（git remote 接続不可、grep 範囲外）。


### PR DESCRIPTION
## 概要

PR #367 (汎用化・整合性監査) と**非重複**の second-opinion 監査。takt `deep-research` workflow で `.claude/skills/` 配下 35 スキルを 4 観点で横断調査した運用リスク監査レポートを追加。

## 監査観点

| 観点 | 内容 |
|---|---|
| 3 | 失敗時挙動 / 副作用 / Idempotency（リカバリ、部分生成物の掃除、再実行ガード、リトライ設計、Ctrl+C 時のクリーンアップ） |
| 4 | 課金 API コスト制御（Veo / Gemini / Lyria / OpenAI / Suno / YouTube Data API の上限・安全弁・無駄叩き防止） |
| 5 | セキュリティ / シークレット取り扱い（直書き、stdout 流出、auth/ 読み込み経路、shell injection、SSH host_key） |
| 6 | 依存 / 環境前提 / 廃止リスク（ローカルバイナリ、yt-* CLI entry point、OAuth scope、外部 API sunset） |

## 検出サマリー

- **P0 (緊急)**: 6 件
- **P1 (high)**: 19 件
- **P2 / P3**: 26 件超
- supervise step は `research-report.md` で APPROVE 相当を出力後、workflow rule マッチで abort（成果物は揃っており実害なし）

## 主要 P0 候補（抜粋）

- `src/youtube_automation/utils/lyria_client.py:148-154` — Lyria 3 legacy schema 単一経路依存
- `loop-video` — Veo 3.1 の再生成ガード不足による課金リスク
- `upload_policy` — YouTube Data API 429 非リトライ
- Gemini 2.5 系の 2026-10-16 shutdown 予告（要追跡）

## 残存ギャップ (audit 内で「未検証」として明示)

- G-1: Lyria 3 切替日 (2026-05-26) の出典 URL が Gemini API docs 側 → Vertex AI Lyria への同日適用は要再検証
- G-2: Veo `operations.cancel` API の存在可否未確認
- G-3〜G-7: 一部 CLI 実装未読、課金 API USD 単価（意図的スキップ）等

## ファイル

- `docs/audits/2026-05-18-skills-operational-risk-audit.md` — メイン棚卸しレポート (観点 3〜6 全網羅)
- `docs/audits/2026-05-18-skills-operational-risk-audit/raw/` — dig 10 本 + supervise 1 本の生レポート

## スコープ

本 PR は**レポート追加のみ**。検出された fix は本 PR では適用せず、後続の通常セッションまたは個別 issue で対応する（`.claude/skills/**` は protected paths のため takt 経由の修正不可）。

## 関連

- PR #367 — 観点 1 (汎用化) / 観点 2 (整合性) の前回監査

Closes #372