### PR TITLE
[#275] issue-275-fix-playlist-playlis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### `playlists.json` の string-shape entry で `PlaylistManager` が `AttributeError` で落ちる問題を修正
+
+`config/channel/playlists.json` がシンプル形式（`{"main": "PL..."}`）のとき、
+`PlaylistManager.resolve_playlists` 内の `pl.get("auto_add")` が
+`'str' object has no attribute 'get'` を投げ、`/video-upload` 経由の playlist
+自動追加が失敗していた。loader (`_build_playlists`) で string value を
+`{"playlist_id": <元値>, "auto_add": True, "title": None}` に正規化し、消費側
+（`PlaylistManager` の各メソッド、`PlaylistStatusViewer.show_status`、
+`collection_uploader._assign_to_playlists`）が常に dict shape を仮定できるよう
+contract を確定させた。dict 形式の既存運用は後方互換性を保つ。関連: #275
+
+- `src/youtube_automation/utils/config/loader.py`: `_build_playlists` で string /
+  dict を分岐し、string は 3 キー固定の dict に展開、dict は shallow copy して
+  入力 dict との参照を切る
+- `src/youtube_automation/utils/config/playlists.py`: `Playlists.items` の型注釈を
+  `dict[str, str]` から `dict[str, dict]` へ。docstring に正規化契約を明記
+
 ## [5.5.0] - 2026-05-17
 
 ### Changed

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -263,7 +263,20 @@ def _build_analytics(merged: dict) -> Analytics:
 
 
 def _build_playlists(merged: dict) -> Playlists:
-    return Playlists(items=dict(merged.get("playlists") or {}))
+    # #275: string-shape entry (`{"main": "PL..."}`) を dict shape に正規化する。
+    # 消費側 (`PlaylistManager` / `PlaylistStatusViewer`) が `pl.get(...)` を一律
+    # 呼べるよう、loader 1 箇所で contract を確定させる。dict entry は shallow copy
+    # して入力 dict との参照を切り離す（consumer mutation 漏れ防止）。
+    raw = merged.get("playlists") or {}
+    items: dict[str, dict] = {}
+    for key, value in raw.items():
+        if isinstance(value, str):
+            items[key] = {"playlist_id": value, "auto_add": True, "title": None}
+        elif isinstance(value, dict):
+            items[key] = dict(value)
+        else:
+            items[key] = value
+    return Playlists(items=items)
 
 
 def _build_workflow(merged: dict) -> Workflow:

--- a/src/youtube_automation/utils/config/playlists.py
+++ b/src/youtube_automation/utils/config/playlists.py
@@ -9,7 +9,12 @@ from dataclasses import dataclass, field
 class Playlists:
     """`playlists` セクション（optional）.
 
-    `items` は `{"playlist_key": "playlist_id", ...}` 形式の dict.
+    `items` は `{"playlist_key": {"playlist_id": ..., "auto_add": ..., ...}, ...}`
+    の dict-of-dict. 入力 JSON では string 形式 (`{"main": "PL..."}`) と
+    dict 形式 (`{"main": {"playlist_id": "PL...", ...}}`) の両方を許容するが、
+    loader (`_build_playlists`) で必ず dict 形式へ正規化された後に格納される。
+    string 入力は `{"playlist_id": <元値>, "auto_add": True, "title": None}` に
+    展開される（#275）。
     """
 
-    items: dict[str, str] = field(default_factory=dict)
+    items: dict[str, dict] = field(default_factory=dict)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -183,7 +183,10 @@ def test_load_all_sections(tmp_path, monkeypatch):
 
     assert config.analytics.collection_filter_keywords == ["collection", "complete"]
     assert config.analytics.benchmark.channels == [{"name": "Rival", "id": "UC123"}]
-    assert config.playlists.items == {"main": "PLtest123"}
+    # issue #275: string value は loader で {playlist_id, auto_add, title} に正規化される
+    assert config.playlists.items == {
+        "main": {"playlist_id": "PLtest123", "auto_add": True, "title": None}
+    }
     assert config.audio.target_duration_min == 120.0
     assert config.meta.branding.description == "ch desc"
     assert config.youtube.content_model.type == "collection"
@@ -359,6 +362,102 @@ def test_optional_sections_default(tmp_path, monkeypatch):
     assert config.analytics.benchmark.channels == []
     assert config.playlists.items == {}
     assert config.audio.target_duration_min is None
+
+
+# ----- issue #275: playlists.json string-shape 正規化 ----------------------
+
+
+def test_playlists_string_value_normalized_to_dict(tmp_path, monkeypatch):
+    """#275: string value は {playlist_id, auto_add: True, title: None} に正規化される."""
+    # Given
+    sections = _minimal_sections()
+    sections["playlists.json"] = {"playlists": {"main": "PL_X"}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    # When
+    config = load_config()
+
+    # Then
+    assert config.playlists.items == {
+        "main": {"playlist_id": "PL_X", "auto_add": True, "title": None}
+    }
+
+
+def test_playlists_dict_value_preserved_as_is(tmp_path, monkeypatch):
+    """#275: dict 形式は入力 shape のまま loader を通過する（後方互換）."""
+    # Given
+    sections = _minimal_sections()
+    sections["playlists.json"] = {
+        "playlists": {
+            "battle": {
+                "playlist_id": "PL_B",
+                "title": "Battle Music",
+                "auto_add_themes": ["fight"],
+            }
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    # When
+    config = load_config()
+
+    # Then
+    entry = config.playlists.items["battle"]
+    assert entry["playlist_id"] == "PL_B"
+    assert entry["title"] == "Battle Music"
+    assert entry["auto_add_themes"] == ["fight"]
+
+
+def test_playlists_mixed_string_and_dict_entries(tmp_path, monkeypatch):
+    """#275: string と dict が混在しても両方とも正しい shape で得られる."""
+    # Given
+    sections = _minimal_sections()
+    sections["playlists.json"] = {
+        "playlists": {
+            "main": "PL_MAIN",
+            "battle": {
+                "playlist_id": "PL_B",
+                "title": "Battle Music",
+                "auto_add_themes": ["fight"],
+            },
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    # When
+    config = load_config()
+
+    # Then: string entry は正規化済み
+    assert config.playlists.items["main"] == {
+        "playlist_id": "PL_MAIN",
+        "auto_add": True,
+        "title": None,
+    }
+    # And: dict entry は内容保持
+    assert config.playlists.items["battle"]["playlist_id"] == "PL_B"
+    assert config.playlists.items["battle"]["auto_add_themes"] == ["fight"]
+
+
+def test_playlists_dict_entry_is_shallow_copied():
+    """#275: dict entry は入力 dict と同一参照ではない（consumer mutation 漏れ防止）.
+
+    `_build_playlists` の入力 dict と出力 entry の参照分離を直接 verify する。
+    """
+    from youtube_automation.utils.config.loader import _build_playlists
+
+    # Given
+    raw_entry = {"playlist_id": "PL_B", "auto_add_themes": ["fight"]}
+    merged = {"playlists": {"battle": raw_entry}}
+
+    # When
+    playlists = _build_playlists(merged)
+
+    # Then: 参照は分離されているが内容は等価
+    assert playlists.items["battle"] is not raw_entry
+    assert playlists.items["battle"] == raw_entry
 
 
 def test_localizations_missing(tmp_path, monkeypatch):

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -395,3 +395,161 @@ class TestAddVideoToPlaylist:
 
         body = mock_insert.call_args[1]["body"]
         assert body["snippet"]["position"] == 0
+
+
+# ---------------------------------------------------------------------------
+# issue #275: string-shape playlists.json リグレッション
+# ---------------------------------------------------------------------------
+
+
+PLAYLIST_ID_STRING_SHAPE = "PL_test_string_275"
+
+
+def _string_shape_channel(tmp_path: Path) -> Path:
+    """string-shape playlists.json を持つ最小チャンネル fixture を tmp 配下に作る.
+
+    `_video-upload` → `collection_uploader._assign_to_playlists` →
+    `PlaylistManager` の経路を実 `load_config()` で通すために、
+    meta / content / youtube / playlists の 4 ファイルを書き出す。
+    """
+    ch = tmp_path / "channel"
+    cdir = ch / "config" / "channel"
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / "meta.json").write_text(
+        json.dumps(
+            {
+                "channel": {
+                    "name": "Test Channel",
+                    "short": "TC",
+                    "youtube_handle": "@testchannel",
+                    "url": "https://youtube.com/@testchannel",
+                    "tagline": "Test tagline",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "content.json").write_text(
+        json.dumps(
+            {
+                "genre": {"primary": "chiptune", "style": "8-bit", "context": "RPG"},
+                "tags": {"base": ["chiptune"], "themes": {}},
+                "descriptions": {
+                    "opening": "{style} {primary} for {context}",
+                    "perfect_for": ["Study"],
+                    "hashtags": [],
+                },
+                "title": {"template": "{theme}", "default_activity": "Study"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "youtube.json").write_text(
+        json.dumps(
+            {
+                "youtube": {
+                    "category_id": "10",
+                    "privacy_status": "public",
+                    "language": "ja",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "playlists.json").write_text(
+        json.dumps({"playlists": {"main": PLAYLIST_ID_STRING_SHAPE}}),
+        encoding="utf-8",
+    )
+    return ch
+
+
+# Python 3.14 互換: `patch("youtube_automation.scripts.playlist_manager.X")` は
+# モジュールを attribute 解決するため、事前に submodule を import しておく。
+import youtube_automation.scripts.playlist_manager as _playlist_manager_module  # noqa: E402,F401
+
+
+class TestStringShapePlaylistsRegression:
+    """#275: シンプル形式 `playlists.json` で AttributeError が出ないこと.
+
+    `MagicMock` ではなく実 `load_config()` で組み立てた `ChannelConfig` を
+    `PlaylistManager` に注入することで、loader → consumer の契約を verify する。
+    """
+
+    def test_resolve_playlists_does_not_raise_on_string_shape(self, tmp_path, monkeypatch):
+        """#275: string-shape entry でも AttributeError を出さず ["main"] を返す."""
+        # Given
+        ch = _string_shape_channel(tmp_path)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        with patch.object(
+            _playlist_manager_module, "get_youtube", return_value=MagicMock()
+        ):
+            manager = _playlist_manager_module.PlaylistManager()
+
+            # When
+            result = manager.resolve_playlists("any-theme")
+
+        # Then: string-shape は loader で auto_add=True に正規化されるため常にマッチ
+        assert result == ["main"]
+
+    def test_assign_video_dry_run_does_not_raise_on_string_shape(self, tmp_path, monkeypatch):
+        """#275: `/video-upload` 入口 (collection_uploader._assign_to_playlists) のリグレッション.
+
+        dry_run なので API 呼び出しは発生しない。AttributeError が出ないことが本質。
+        """
+        # Given
+        ch = _string_shape_channel(tmp_path)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        with patch.object(
+            _playlist_manager_module, "get_youtube", return_value=MagicMock()
+        ):
+            manager = _playlist_manager_module.PlaylistManager()
+
+            # When
+            assigned = manager.assign_video("VID_X", "any-theme", dry_run=True)
+
+        # Then
+        assert assigned == ["main"]
+
+    def test_create_all_playlists_dry_run_skips_string_shape(self, tmp_path, monkeypatch):
+        """#275: string-shape entry は playlist_id 既存と判定されてスキップされる."""
+        # Given
+        ch = _string_shape_channel(tmp_path)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        with patch.object(
+            _playlist_manager_module, "get_youtube", return_value=MagicMock()
+        ):
+            manager = _playlist_manager_module.PlaylistManager()
+
+            # When
+            created = manager.create_all_playlists(dry_run=True)
+
+        # Then: playlist_id 既存なので作成対象なし
+        assert created == {}
+
+    def test_clean_deleted_entries_dry_run_does_not_raise_on_string_shape(
+        self, tmp_path, monkeypatch
+    ):
+        """#275: clean_deleted_entries が string-shape entry を iterate しても AttributeError を出さない."""
+        # Given
+        ch = _string_shape_channel(tmp_path)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        mock_youtube = MagicMock()
+        # 削除対象なし: playlistItems().list().execute() が {"items": []} を返す
+        mock_youtube.playlistItems.return_value.list.return_value.execute.return_value = {
+            "items": []
+        }
+
+        with patch.object(
+            _playlist_manager_module, "get_youtube", return_value=mock_youtube
+        ):
+            manager = _playlist_manager_module.PlaylistManager()
+
+            # When
+            result = manager.clean_deleted_entries(dry_run=True)
+
+        # Then: string-shape entry も dict として扱われ、削除対象 0 件
+        assert result == {"main": 0}

--- a/tests/test_playlist_status.py
+++ b/tests/test_playlist_status.py
@@ -1,0 +1,96 @@
+"""PlaylistStatusViewer のリグレッションテスト.
+
+issue #275: string-shape `playlists.json` でも `show_status` が AttributeError を
+出さずに動作することを担保する。`MagicMock` ではなく実 `load_config()` で
+組み立てた `ChannelConfig` を viewer に注入することで、loader → consumer の
+契約を verify する。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Python 3.14 互換: `patch("youtube_automation.scripts.playlist_status.X")` は
+# モジュールを attribute 解決するため、事前に submodule を import しておく。
+import youtube_automation.scripts.playlist_status as _playlist_status_module  # noqa: E402
+
+PLAYLIST_ID_STRING_SHAPE = "PL_test_string_275"
+
+
+def _string_shape_channel(tmp_path: Path) -> Path:
+    """string-shape playlists.json を持つ最小チャンネル fixture を tmp 配下に作る."""
+    ch = tmp_path / "channel"
+    cdir = ch / "config" / "channel"
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / "meta.json").write_text(
+        json.dumps(
+            {
+                "channel": {
+                    "name": "Test Channel",
+                    "short": "TC",
+                    "youtube_handle": "@testchannel",
+                    "url": "https://youtube.com/@testchannel",
+                    "tagline": "Test tagline",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "content.json").write_text(
+        json.dumps(
+            {
+                "genre": {"primary": "chiptune", "style": "8-bit", "context": "RPG"},
+                "tags": {"base": ["chiptune"], "themes": {}},
+                "descriptions": {
+                    "opening": "{style} {primary} for {context}",
+                    "perfect_for": ["Study"],
+                    "hashtags": [],
+                },
+                "title": {"template": "{theme}", "default_activity": "Study"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "youtube.json").write_text(
+        json.dumps(
+            {
+                "youtube": {
+                    "category_id": "10",
+                    "privacy_status": "public",
+                    "language": "ja",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cdir / "playlists.json").write_text(
+        json.dumps({"playlists": {"main": PLAYLIST_ID_STRING_SHAPE}}),
+        encoding="utf-8",
+    )
+    return ch
+
+
+class TestShowStatusStringShape:
+    """#275: `yt-playlist-status` CLI 経由でも string-shape で落ちないこと."""
+
+    def test_show_status_does_not_raise_on_string_shape(self, tmp_path, monkeypatch, capsys):
+        """string-shape entry でも show_status は AttributeError を出さず ID 行を出力する."""
+        # Given
+        ch = _string_shape_channel(tmp_path)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        with patch.object(
+            _playlist_status_module, "get_youtube", return_value=MagicMock()
+        ):
+            viewer = _playlist_status_module.PlaylistStatusViewer()
+
+            # When
+            with patch.object(viewer, "_list_playlist_video_ids", return_value=set()):
+                viewer.show_status()
+
+        # Then
+        out = capsys.readouterr().out
+        assert "[main]" in out
+        assert PLAYLIST_ID_STRING_SHAPE in out


### PR DESCRIPTION
## Summary

関連: #261 (umbrella: skill バグ・前提整理)

## 観測した現象

`/video-upload` 実行時、内蔵の playlist 自動追加が以下のエラーで失敗する:

```
'str' object has no attribute 'get'
```

この結果、Complete Collection の動画はアップロードされても、メイン playlist へは追加されない（`/playlist add` を手動で呼ばないとカバーできない）。

## 再現条件

`config/channel/playlists.json` がシンプル形式（DF365 を含む複数チャンネルで採用されている運用）:

```json
{
  "main": "PL3FsOZwJ0n-FAMlSYooupySGe1kaRLGe-"
}
```

一方、`youtube_automation.scripts.playlist_manager.PlaylistManager.resolve_playlists` は各 value を dict 想定で `pl.get(\"playlist_id\")`, `pl.get(\"auto_add\")` などを呼ぶため、文字列 value だと AttributeError になる。

## 影響範囲

- DF365: 全コレクション（midnight-flow-state / cognitive-flow-state / mental-stamina-mode）で auto-assign が **事実上動いていなかった可能性**
- 他チャンネルも `playlists.json` がシンプル形式なら同様に影響
- ワークアラウンドとして `/playlist add` 手動呼び出しでカバーしている運用が散在しているはず

## 修正案

どちらか一方:

**A. PlaylistManager 側で string value を許容する**（後方互換性が高い）

```python
def _normalize(entry):
    if isinstance(entry, str):
        return {\"playlist_id\": entry, \"auto_add\": True, \"title\": None}
    return entry
```

**B. `config/channel/playlists.json` を dict 形式の正規スキーマに統一する移行スクリプトを提供**

```json
{
  \"main\": {
    \"playlist_id\": \"PL...\",
    \"title\": \"...\",
    \"auto_add\": true
  }
}
```

A の方が既存 config を壊さないので推奨。スキーマバージョンによる分岐を `resolve_playlists` 冒頭に置く実装が最小コスト。

## 検出経緯

DF365 で midnight-flow-state（2026-05-13 公開、video_id `G7ae3snb-Ws`）をアップロードした際、`/video-upload` 内蔵 auto-assign が上記エラーで失敗。`upload_tracking.json` の `post_processing_note` にも残っている。`/playlist add` を直接呼んで補完した。

## Execution Report

Workflow `default-extended` completed successfully.

Closes #275