### PR TITLE
Release/v5.5.2

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -2,5 +2,5 @@
 # provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
 draft_pr: false
 
-# release/v5.5.1 へのバッチ投入用に base_branch を一時切替（全 PR merge 後に削除して main 既定に戻す）
-base_branch: release/v5.5.1
+# release/v5.5.2 へのバッチ投入用に base_branch を一時切替（全 PR merge 後に削除して main 既定に戻す）
+base_branch: release/v5.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/youtube_automation/__init__.py
+++ b/src/youtube_automation/__init__.py
@@ -1,3 +1,3 @@
 """YouTube channels automation toolkit."""
 
-__version__ = "5.5.1"
+__version__ = "5.5.2"


### PR DESCRIPTION
## 概要

v5.5.2 リリース PR。`release/v5.5.2` を `main` にマージする。

## 経緯

v5.5.1 リリース PR #368 のバッチで処理しきれなかった後発 6 件（並列 takt 実行中に tasks.yaml 競合で entry が消失したため、v5.5.1 締めには間に合わず）を v5.5.2 にまとめて取り込む。

実装方針は **takt の自動生成 PR を使わず、各 worktree branch の auto-commit を `release/v5.5.2` に cherry-pick** する形を採用（tasks.yaml 競合・別タブ作業との衝突を回避するため）。

## Closes

本 PR を main にマージした時点で以下を自動 close する（後発 6 件）：

- Closes #275 — `PlaylistManager.resolve_playlists` string-shaped `playlists.json` 対応（cherry-pick: TBD）
- Closes #156 — `utils/streaming_archive.py` を `utils/streaming/` パッケージへ統合（cherry-pick: TBD）
- Closes #196 — `youtube-stream.service` に systemd hardening directives 追加（cherry-pick: TBD）
- Closes #195 — `/opt/youtube-stream/{videos,logs,bin}` パスを Terraform variable に集約（cherry-pick: TBD）
- Closes #164 — Terraform `connection` に `host_key` 検証追加（cherry-pick: TBD）
- Closes #165 — tfstate を暗号化 remote backend に移行 + README sensitive 表記訂正（cherry-pick: TBD）

> takt run 完了 → cherry-pick → push 完了時に各行の `TBD` を実 commit SHA に置換する。

## 変更内容

- `pyproject.toml` と `src/youtube_automation/__init__.py` の version を 5.5.2 へ bump
- `.takt/config.yaml` の `base_branch` を `release/v5.5.2` に切替（後発 6 件の takt 自動生成 PR の base 用）

## tag / Release

本 PR マージ後、`v5.5.2` tag と GitHub Release を別途作成する（`release-notes` スキル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)