### PR TITLE
feat(thumbnail): single_step を default 化し参照画像ローテーション/プリフライトを追加 (#356)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -71,10 +71,9 @@ uv run python -c "from youtube_automation.utils.skill_config import load_skill_c
 
 | モード | 説明 |
 |---|---|
-| `ttp_swap` | 競合サムネ + 自キャラアイコンの 2 参照でキャラ置換 |
-| `single_step` | テキスト付き参照画像から差分のみ指示、1 ステップで完成 |
+| `single_step`（**デフォルト**・TTP 推奨）| テキスト付き参照画像から差分のみ指示、1 ステップで完成。ベンチマーク模倣（TTP）の標準実装 |
 | `diff_from_reference` | 既存キャラ画像を参照に差分指示 |
-| `two_phase`（未指定時のフォールバック）| 従来の 2 フェーズ（背景 → テキストオーバーレイ）|
+| `two_phase` | 従来の 2 フェーズ（背景 → テキストオーバーレイ）|
 
 ### 参照画像モード（`reference_images` が定義されている場合）
 
@@ -145,66 +144,55 @@ illustration touches. Widescreen 16:9 aspect ratio.
 
 ## ワークフロー
 
-### TTP Swap モード（`generation_mode: "ttp_swap"`）
+### Single-Step / TTP モード（`generation_mode: "single_step"`、デフォルト・推奨）
 
-ベンチマーク競合の高再生サムネを **構図リファレンス**、自チャンネルのアイコンを **キャラリファレンス**
-として 2 枚同時に渡し、「キャラだけ差し替える」手法。
+ベンチマーク模倣（**TTP**: trace / imitate）の標準実装。テキスト付き参照画像（テキストレイアウト・背景テクスチャ・オブジェクト配置を含む）を参照にして、**変更点だけ**をプロンプトで指示する。背景生成とテキストオーバーレイが 1 回の生成で完了する。
 
-**前提**:
-- `data/thumbnail_compare/benchmark/<channel>-<video_id>.jpg` に競合サムネがキャッシュ済み
-  （未取得なら `uv run yt-thumbnail-compare --no-open` で取得）
-- `branding/icon.png` に自チャンネルキャラのアイコンが配置済み
+**重要**: 参照画像と同じ要素（レイアウト、固定オブジェクト、テキスト配置）はプロンプトに含めない。差分のみを指示することで、参照画像のクオリティを維持しつつ変更が正しく反映される。コピーではなくバリエーションを作るのがゴール。
 
-**プロンプトは短く保つのが重要**（長文はノイズ）。3 段階テンプレ:
+#### プリフライト
 
-```
-# 1. キャラ置換（必須・これだけでも動く）
-Replace the character in the first image with the character from the second image.
+`generation_mode: "single_step"` で `--reference` を指定せずに `yt-generate-image` を起動するとエラー中断する。次の対処が必要:
 
-# 2. リブランド（任意）
-Remove the copyright text in the top-right corner. Remove the logo icon and
-tagline text in the bottom-left corner. Both corners should be clean empty background.
+1. **skill-config に `reference_images.default` が未設定** → `config/skills/thumbnail.yaml` の `image_generation.gemini.reference_images.default` にベンチマークサムネのパス（文字列 1 件 or list 複数件）を設定
+2. **設定はあるが CLI 引数に展開していない** → `--reference <path>` で渡す。list なら `--reference A --reference B --reference C` のように複数指定
 
-# 3. オリジナリティ（任意）
-Change the action: <自チャンネル固有の動作>. Change the <小道具のディテール> to <固有要素>.
-```
+#### 参照画像（複数 + ローテーション）
 
-**コマンド**:
+`reference_images.default` は文字列 1 件 / list 複数件の両方を受け付ける。list 指定時は同一ベンチマークチャンネル内の複数サムネ候補を並べておくことで、attempt 毎にローテーションして雰囲気が出る組合せを探れる。
 
-```bash
-uv run yt-generate-image \
-  --reference data/thumbnail_compare/benchmark/<benchmark-thumb>.jpg \
-  --reference branding/icon.png \
-  --prompt "<上記テンプレ>" \
-  --output collections/planning/<collection>/10-assets/main-v1.jpg -y
-```
+| CLI 引数 | 用途 |
+|---|---|
+| `--max-attempts N` | 試行回数。各 attempt で参照を切替、出力は `-vN` で別保存 |
+| `--no-rotate` | 切替を無効化（先頭固定） |
+| `--reference-index N` | 特定の参照のみ使用（ローテーション無効、attempt=1） |
 
-**運用上の注意**:
-- **リトライ前提**: 画像生成プロバイダーは同一プロンプトでも瞬発的にエラーを返す。2〜3 回リトライで通る
-- **テキスト継承**: 参照画像内のキャッチコピー・ジャンルタグ・フォントはデフォルトで完全継承される。変えたい部分だけ明示指示
-- **ブランド置換**: `Replace every occurrence of the word 'X' with 'Y'` で文字列差し替え可
-- **キャラサイズ**: 縮小傾向がある場合は `fills about 55% of the frame, bust-up portrait` を追記
-- **コスト**: 事前見積もりは `config/skills/thumbnail.yaml` の `image_generation.<provider>.cost_per_image_usd` を指定したときのみ CLI 表示に出る。未指定なら「不明」と表示され、実コストは GCP Cloud Console > Billing で確認する（最大 3 回試行込み = 初回 + 最大 2 回リトライ）
+config 側のデフォルトは `image_generation.gemini.single_step.{max_attempts, rotate}` で設定可能。
 
-### Single-Step モード（`generation_mode: "single_step"`）
-
-テキスト付き参照画像（テキストレイアウト・背景テクスチャ・オブジェクト配置を含む）を参照にして、
-**変更点だけ**をプロンプトで指示する。背景生成とテキストオーバーレイが 1 回の生成で完了する。
-
-**重要**: 参照画像と同じ要素（レイアウト、固定オブジェクト、テキスト配置）はプロンプトに含めない。
-差分のみを指示することで、参照画像のクオリティを維持しつつ変更が正しく反映される。
+#### プロンプト構築
 
 1. `image_generation.gemini.color_themes` からテーマのカラー設定を取得
 2. `image_generation.gemini.diff_prompt_template` のプレースホルダーを置換してプロンプト構築:
    - `{background}`: カラーテーマの背景色（未指定時は `image_generation.gemini.brand_background` を使用）
    - `{candle}`, `{cocktail_description}` などオブジェクト系プレースホルダ: `ideate.objects` や `color_themes` 配下の値
    - `{title_line1}`, `{title_line2}`: コレクションタイトル
+3. 共通ガイダンス clause（`single_step.variation_clause` / `style_lock_clause` / `text_strip_clause`）をチャンネル側 `diff_prompt_template` で必要に応じて挿入
 
-3. 生成:
+#### 生成コマンド
 
 ```bash
+# 単一参照（従来通り）
 uv run yt-generate-image \
   --reference <channel_dir>/<reference_images.default> \
+  --prompt "<diff_prompt_template を置換したプロンプト>" \
+  --output <collection-path>/10-assets/thumbnail-v1.jpg -y
+
+# 複数参照ローテーション（list の reference_images.default をすべて展開）
+uv run yt-generate-image \
+  --reference <channel_dir>/path/to/ref1.jpg \
+  --reference <channel_dir>/path/to/ref2.jpg \
+  --reference <channel_dir>/path/to/ref3.jpg \
+  --max-attempts 3 \
   --prompt "<diff_prompt_template を置換したプロンプト>" \
   --output <collection-path>/10-assets/thumbnail-v1.jpg -y
 ```
@@ -212,7 +200,21 @@ uv run yt-generate-image \
 4. `open` でプレビュー → ユーザー承認 → `cp thumbnail-v1.jpg thumbnail.jpg`
 5. 背景画像（テキストなし）も必要な場合は、テキストなしの参照画像で別途生成
 
-差分プロンプトの具体例は skill-config の `image_generation.gemini.diff_prompt_template` を参照し、チャンネル固有のオブジェクト・カラーを埋める。
+#### 運用上の注意
+
+- **リトライ前提**: 画像生成プロバイダーは同一プロンプトでも瞬発的にエラーを返す。各 attempt 内で内蔵リトライ最大 2 回が走る
+- **テキスト継承**: 参照画像内のキャッチコピー・ジャンルタグ・フォントはデフォルトで継承される。変えたい部分だけ明示指示
+- **コスト**: 事前見積もりは `config/skills/thumbnail.yaml` の `image_generation.<provider>.cost_per_image_usd` を指定したときのみ CLI 表示に出る。未指定なら「不明」と表示され、実コストは GCP Cloud Console > Billing で確認する（`max_attempts × 1 リクエスト` ＋ 各 attempt で内蔵リトライ最大 2 回）
+
+#### 失敗時の対処
+
+雰囲気が出ない場合、ChatGPT 等の外部ツールで手動生成して `main.png` にコピーする運用は廃止。ツール内で完結する代替策:
+
+1. `--reference-index N` で特定のベンチマーク参照に固定して試す
+2. `reference_images.default` の list を見直し、別のベンチマーク候補を追加
+3. `diff_prompt_template` の差分指示を見直し（特に `variation_clause` / `style_lock_clause` のオン/オフ）
+
+差分プロンプトの具体例は skill-config の `image_generation.gemini.diff_prompt_template` を参照し、チャンネル固有のオブジェクト・カラーを埋める。実装事例として `daiki-beppu/rjn` の `config/skills/thumbnail.yaml` が参考になる（jazzgak チャンネルの 5 サムネを `color_themes.<theme>.reference_image` で多軸切替）。
 
 ### Two-Phase モード（従来方式・フォールバック）
 

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -18,11 +18,34 @@ image_generation:
     model: gemini-3.1-flash-image-preview
 
     # 生成モード:
-    #   single_step   : テキスト付き参照画像から差分のみ指示し 1 ステップで完成
-    #   ttp_swap      : 競合サムネ + 自キャラアイコンの 2 参照でキャラ置換
+    #   single_step   : ベンチマーク模倣 (TTP) の推奨実装。テキスト付き参照画像から
+    #                   差分のみ指示し 1 ステップで完成。reference_images.default が必須。
     #   two_phase     : 従来の 2 フェーズ (背景 → テキストオーバーレイ)
     #   diff_from_reference : 既存キャラ画像を参照に差分のみ指示
-    generation_mode: two_phase
+    generation_mode: single_step
+
+    # single_step モード (推奨 TTP 構成) の挙動制御
+    single_step:
+      # 試行回数。複数参照画像 + max_attempts > 1 のとき attempt 毎に参照画像を
+      # ローテーションし、2 回目以降の出力は -vN で別保存する。
+      # CLI の --max-attempts で都度上書き可。
+      max_attempts: 1
+      # 複数参照画像のとき attempt 毎に切り替えるか (false で先頭固定)
+      rotate: true
+      # diff_prompt_template に挿入できる共通ガイダンス clause。
+      # チャンネル側で diff_prompt_template を組み立てる際に必要に応じて
+      # ${variation_clause} のように展開する想定。空文字に上書きで無効化可。
+      variation_clause: |
+        The reference image is a style guide — produce a variation, not a copy.
+        Vary specific objects, framing details, and decorative elements while
+        preserving the overall aesthetic. The output must clearly differ from
+        the reference in subject details, not be a near-duplicate.
+      style_lock_clause: |
+        Match the lighting direction, color temperature, and overall mood of
+        the reference image.
+      text_strip_clause: |
+        Do not include any text, captions, watermarks, logos, or typography
+        from the reference unless explicitly described in the diff prompt.
 
     # スタイル説明文 (生成時のスタイル意図、ドキュメンテーション用)
     style: ""
@@ -31,9 +54,14 @@ image_generation:
     # 未定義の場合は single_step の差分指示で背景色指示を省略する
     brand_background: ""
 
-    # 参照画像の定義 (省略時はプロンプトベースモード)
+    # 参照画像の定義 (single_step / diff_from_reference モードで必須)
+    # default は文字列 1 件、または list で複数件指定可。list 指定時は
+    # single_step.rotate=true で attempt 毎にローテーション。
     # reference_images:
-    #   default: branding/character-reference/main-ref.png
+    #   default:
+    #     - data/thumbnail_compare/benchmark/<channel>-<vid1>.jpg
+    #     - data/thumbnail_compare/benchmark/<channel>-<vid2>.jpg
+    #     - data/thumbnail_compare/benchmark/<channel>-<vid3>.jpg
     #   path_base: channel_dir  # channel_dir からの相対パス
     #   notes: ""
 

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -220,10 +220,7 @@ def main():
             print("[ERROR] --reference-index 指定には参照画像が必要です（--reference で指定してください）")
             sys.exit(1)
         if not (0 <= args.reference_index < len(reference_images)):
-            print(
-                f"[ERROR] --reference-index={args.reference_index} は参照画像範囲外 "
-                f"(0..{len(reference_images) - 1})"
-            )
+            print(f"[ERROR] --reference-index={args.reference_index} は参照画像範囲外 (0..{len(reference_images) - 1})")
             sys.exit(1)
         reference_images = [reference_images[args.reference_index]]
         cli_max_attempts = 1

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -31,6 +31,9 @@ from youtube_automation.utils.image_provider.composition import (
     resolve_composition_source,
     resolve_cost_per_image,
     resolve_reference_paths,
+    resolve_unique_path,
+    select_reference,
+    validate_single_step_references,
 )
 from youtube_automation.utils.image_provider.config import replace_model
 from youtube_automation.utils.profile import section
@@ -78,6 +81,27 @@ def main():
     )
     parser.add_argument("--no-composition", action="store_true", help="composition_prefix の自動付加をスキップ")
     parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=None,
+        help=(
+            "single_step モードかつ複数参照画像のときの試行回数。"
+            "各 attempt で参照画像をローテーションし、2 回目以降の出力は -vN で別保存。"
+            "未指定時は skill-config の image_generation.gemini.single_step.max_attempts を使う"
+        ),
+    )
+    parser.add_argument(
+        "--no-rotate",
+        action="store_true",
+        help="複数参照画像のとき attempt 毎の切替を無効化（先頭固定）",
+    )
+    parser.add_argument(
+        "--reference-index",
+        type=int,
+        default=None,
+        help="複数参照画像のうち特定のインデックスのみ使用（attempt ループ無効）",
+    )
+    parser.add_argument(
         "--costs",
         action="store_true",
         help="data/image_costs.json から累積コストサマリを表示して終了",
@@ -109,6 +133,21 @@ def main():
     skill_cfg = load_skill_config("thumbnail")
     composition_source = resolve_composition_source(skill_cfg, cfg.provider)
 
+    # single_step モードのプリフライト: 参照画像未設定の取り違えを早期検知
+    gemini_section = skill_cfg.get("image_generation", {}).get("gemini", {})
+    generation_mode = gemini_section.get("generation_mode") if isinstance(gemini_section, dict) else None
+    if generation_mode == "single_step" and not args.reference:
+        try:
+            validate_single_step_references(skill_cfg)
+        except ConfigError as e:
+            print(f"[ERROR] {e}")
+            sys.exit(1)
+        print(
+            "[ERROR] single_step モードでは --reference の指定が必須です。"
+            "skill-config の image_generation.gemini.reference_images.default を CLI へ展開してください。"
+        )
+        sys.exit(1)
+
     if args.no_composition or args.reference:
         prompt = args.prompt
     else:
@@ -131,6 +170,17 @@ def main():
     # コスト算出: skill-config の cost_per_image_usd を尊重。未設定なら None。
     cost_per_image = resolve_cost_per_image(skill_cfg, cfg.provider)
 
+    # max_attempts / rotate / reference_index の解決（コスト表示前に出すため早期解決）
+    single_step_section = gemini_section.get("single_step") if isinstance(gemini_section, dict) else None
+    if not isinstance(single_step_section, dict):
+        single_step_section = {}
+    config_max_attempts = int(single_step_section.get("max_attempts", 1) or 1)
+    config_rotate = bool(single_step_section.get("rotate", True))
+    cli_max_attempts = args.max_attempts if args.max_attempts is not None else config_max_attempts
+    if cli_max_attempts < 1:
+        cli_max_attempts = 1
+    rotate = (not args.no_rotate) and config_rotate
+
     print("\nモード:       ダイレクト")
     print(f"プロバイダー: {cfg.provider}")
     print(f"プロンプト:   {prompt[:80]}{'...' if len(prompt) > 80 else ''}")
@@ -138,6 +188,9 @@ def main():
     print(f"解像度:       {image_size}")
     if args.reference:
         print(f"参照画像:     {', '.join(args.reference)}")
+    if cli_max_attempts > 1:
+        rotate_label = " (rotate=ON)" if rotate else " (rotate=OFF)"
+        print(f"試行回数:     {cli_max_attempts} attempts{rotate_label}")
 
     # 既存ファイル確認（上書き or -vN 自動採番）
     resolved_path = prompt_overwrite_or_rename(output_path, yes=args.yes)
@@ -161,46 +214,86 @@ def main():
         print(f"[ERROR] {e}")
         sys.exit(1)
 
-    request = ImageGenerationRequest(
-        prompt=prompt,
-        output_path=output_path,
-        aspect_ratio=args.aspect_ratio,
-        image_size=image_size,
-        references=reference_images,
-    )
+    # --reference-index 指定時は単一参照固定 + attempt=1
+    if args.reference_index is not None:
+        if not reference_images:
+            print("[ERROR] --reference-index 指定には参照画像が必要です（--reference で指定してください）")
+            sys.exit(1)
+        if not (0 <= args.reference_index < len(reference_images)):
+            print(
+                f"[ERROR] --reference-index={args.reference_index} は参照画像範囲外 "
+                f"(0..{len(reference_images) - 1})"
+            )
+            sys.exit(1)
+        reference_images = [reference_images[args.reference_index]]
+        cli_max_attempts = 1
 
-    start_time = time.monotonic()
-    try:
-        with section(
-            "image_provider.generate",
-            provider=provider.__class__.__name__,
+    saved_paths: list[Path] = []
+    success_flags: list[bool] = []
+    total_start = time.monotonic()
+    current_output_path = output_path
+
+    for attempt in range(cli_max_attempts):
+        if reference_images:
+            selected_ref = select_reference(reference_images, attempt, rotate)
+            request_refs: list[Path] = [selected_ref]
+        else:
+            selected_ref = None
+            request_refs = []
+
+        if attempt > 0:
+            current_output_path = resolve_unique_path(current_output_path)
+            print()
+            print(f"--- attempt {attempt + 1}/{cli_max_attempts} ---")
+            print(f"出力先:       {current_output_path}")
+            if selected_ref is not None:
+                print(f"参照画像:     {selected_ref.name}")
+
+        request = ImageGenerationRequest(
+            prompt=prompt,
+            output_path=current_output_path,
             aspect_ratio=args.aspect_ratio,
-        ):
-            result = provider.generate(request)
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-    elapsed = time.monotonic() - start_time
+            image_size=image_size,
+            references=request_refs,
+        )
+
+        try:
+            with section(
+                "image_provider.generate",
+                provider=provider.__class__.__name__,
+                aspect_ratio=args.aspect_ratio,
+            ):
+                result = provider.generate(request)
+        except ConfigError as e:
+            print(f"[ERROR] {e}")
+            sys.exit(1)
+
+        if result.success:
+            saved_paths.append(result.saved_path or current_output_path)
+        success_flags.append(result.success)
+
+    elapsed = time.monotonic() - total_start
 
     print()
     print("===========================================")
-    if result.success:
-        print("  画像生成: 完了")
-        saved = result.saved_path or output_path
-        try:
-            print(f"  ファイル: {saved.relative_to(_channel_root())}")
-        except ValueError:
-            print(f"  ファイル: {saved}")
+    if any(success_flags):
+        succeeded = sum(success_flags)
+        print(f"  画像生成: 完了 ({succeeded}/{cli_max_attempts} 成功)")
+        for path in saved_paths:
+            try:
+                print(f"  ファイル: {path.relative_to(_channel_root())}")
+            except ValueError:
+                print(f"  ファイル: {path}")
         cost_label = f"${cost_per_image:.3f}" if cost_per_image is not None else "不明"
-        print(f"  コスト:   {cost_label}")
+        print(f"  単価:     {cost_label} × {cli_max_attempts}")
         print(f"  時間:     {elapsed:.1f}秒")
     else:
-        print("  画像生成: 失敗")
-        print("  プロンプトを調整して再試行してください。")
+        print(f"  画像生成: 失敗 (0/{cli_max_attempts})")
+        print("  プロンプト・参照画像・config を調整して再試行してください。")
     print("===========================================")
     print()
 
-    sys.exit(0 if result.success else 1)
+    sys.exit(0 if any(success_flags) else 1)
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/utils/image_provider/composition.py
+++ b/src/youtube_automation/utils/image_provider/composition.py
@@ -272,3 +272,69 @@ def resolve_reference_paths(raw_refs: list[str] | None) -> list[Path]:
             raise ConfigError(f"参照画像が見つかりません: {ref_path}")
         resolved.append(ref_path)
     return resolved
+
+
+def select_reference(refs: list[Path], attempt: int, rotate: bool) -> Path:
+    """attempt インデックスに応じて参照画像を 1 枚選択する。
+
+    ``rotate=True`` かつ ``len(refs) > 1`` のときは ``refs[attempt % len(refs)]``、
+    それ以外は ``refs[0]`` を返す。``refs`` が空のときは ``ValueError``。
+    """
+    if not refs:
+        raise ValueError("参照画像リストが空です")
+    if rotate and len(refs) > 1:
+        return refs[attempt % len(refs)]
+    return refs[0]
+
+
+def validate_single_step_references(skill_cfg: dict[str, Any]) -> None:
+    """``generation_mode == "single_step"`` 時に参照画像未設定を検知して ``ConfigError`` を送出する。
+
+    判定:
+      ``image_generation.gemini.generation_mode`` が ``"single_step"`` のとき
+      ``image_generation.gemini.reference_images.default`` が未設定・空文字列・空リスト
+      のいずれかなら ``ConfigError`` を送出する。
+      他モード（``two_phase`` 等）では何もしない。
+    """
+    image_gen = skill_cfg.get("image_generation")
+    if not isinstance(image_gen, dict):
+        return
+    gemini = image_gen.get("gemini")
+    if not isinstance(gemini, dict):
+        return
+    if gemini.get("generation_mode") != "single_step":
+        return
+
+    reference_images = gemini.get("reference_images")
+    default = None
+    if isinstance(reference_images, dict):
+        default = reference_images.get("default")
+
+    is_empty_str = isinstance(default, str) and not default.strip()
+    is_empty_list = isinstance(default, list) and not default
+    if default is None or is_empty_str or is_empty_list:
+        raise ConfigError(
+            "single_step モードには image_generation.gemini.reference_images.default の設定が必須です"
+            "（文字列 1 件、または list で複数件指定）。"
+            "ベンチマークサムネを data/thumbnail_compare/benchmark/ 等に配置し、"
+            "config/skills/thumbnail.yaml で参照してください。"
+        )
+
+
+def normalize_reference_default(default: str | list[str] | None) -> list[str]:
+    """``reference_images.default`` を ``list[str]`` に正規化する。
+
+    - 文字列 → 1 要素リスト
+    - リスト → そのまま
+    - ``None`` / 空 → 空リスト
+
+    パス存在チェックは行わない（``resolve_reference_paths`` 側で実施）。
+    """
+    if default is None:
+        return []
+    if isinstance(default, str):
+        stripped = default.strip()
+        return [stripped] if stripped else []
+    if isinstance(default, list):
+        return [str(item) for item in default if isinstance(item, str) and item.strip()]
+    return []

--- a/tests/test_image_provider_single_step_rotation.py
+++ b/tests/test_image_provider_single_step_rotation.py
@@ -20,7 +20,6 @@ from youtube_automation.utils.image_provider.composition import (
     validate_single_step_references,
 )
 
-
 # ---- select_reference ------------------------------------------------------
 
 

--- a/tests/test_image_provider_single_step_rotation.py
+++ b/tests/test_image_provider_single_step_rotation.py
@@ -1,0 +1,165 @@
+"""``image_provider.composition`` の single_step ローテーション/プリフライト テスト。
+
+Issue #356 で追加された以下を網羅する:
+
+- ``select_reference``: rotate=True で attempt 毎に切替、rotate=False / 1 件で先頭固定、空リストで ValueError
+- ``validate_single_step_references``: single_step モード + reference 未設定 → ConfigError
+- ``normalize_reference_default``: str / list / None / 空文字列 / 混合の正規化
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.composition import (
+    normalize_reference_default,
+    select_reference,
+    validate_single_step_references,
+)
+
+
+# ---- select_reference ------------------------------------------------------
+
+
+class TestSelectReference:
+    def test_rotate_true_cycles_attempts(self) -> None:
+        refs = [Path("/a.jpg"), Path("/b.jpg"), Path("/c.jpg")]
+        assert select_reference(refs, attempt=0, rotate=True) == Path("/a.jpg")
+        assert select_reference(refs, attempt=1, rotate=True) == Path("/b.jpg")
+        assert select_reference(refs, attempt=2, rotate=True) == Path("/c.jpg")
+        assert select_reference(refs, attempt=3, rotate=True) == Path("/a.jpg")
+
+    def test_rotate_false_pins_to_first(self) -> None:
+        refs = [Path("/a.jpg"), Path("/b.jpg"), Path("/c.jpg")]
+        for attempt in (0, 1, 2, 5):
+            assert select_reference(refs, attempt=attempt, rotate=False) == Path("/a.jpg")
+
+    def test_single_item_list_pins_regardless_of_rotate(self) -> None:
+        refs = [Path("/only.jpg")]
+        for rotate in (True, False):
+            for attempt in (0, 1, 5):
+                assert select_reference(refs, attempt=attempt, rotate=rotate) == Path("/only.jpg")
+
+    def test_empty_list_raises(self) -> None:
+        with pytest.raises(ValueError):
+            select_reference([], attempt=0, rotate=True)
+
+
+# ---- validate_single_step_references --------------------------------------
+
+
+class TestValidateSingleStepReferences:
+    def test_non_single_step_mode_passes(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "two_phase",
+                    "reference_images": {"default": None},
+                },
+            },
+        }
+        # 例外を投げないこと
+        validate_single_step_references(skill_cfg)
+
+    def test_missing_image_generation_passes(self) -> None:
+        validate_single_step_references({})
+
+    def test_missing_gemini_passes(self) -> None:
+        validate_single_step_references({"image_generation": {}})
+
+    def test_single_step_with_string_default_passes(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "reference_images": {"default": "branding/ref.png"},
+                },
+            },
+        }
+        validate_single_step_references(skill_cfg)
+
+    def test_single_step_with_list_default_passes(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "reference_images": {"default": ["a.jpg", "b.jpg"]},
+                },
+            },
+        }
+        validate_single_step_references(skill_cfg)
+
+    def test_single_step_without_reference_images_raises(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {"generation_mode": "single_step"},
+            },
+        }
+        with pytest.raises(ConfigError, match="single_step モードには"):
+            validate_single_step_references(skill_cfg)
+
+    def test_single_step_with_none_default_raises(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "reference_images": {"default": None},
+                },
+            },
+        }
+        with pytest.raises(ConfigError):
+            validate_single_step_references(skill_cfg)
+
+    def test_single_step_with_empty_string_default_raises(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "reference_images": {"default": "   "},
+                },
+            },
+        }
+        with pytest.raises(ConfigError):
+            validate_single_step_references(skill_cfg)
+
+    def test_single_step_with_empty_list_default_raises(self) -> None:
+        skill_cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "reference_images": {"default": []},
+                },
+            },
+        }
+        with pytest.raises(ConfigError):
+            validate_single_step_references(skill_cfg)
+
+
+# ---- normalize_reference_default ------------------------------------------
+
+
+class TestNormalizeReferenceDefault:
+    def test_none_returns_empty(self) -> None:
+        assert normalize_reference_default(None) == []
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert normalize_reference_default("") == []
+        assert normalize_reference_default("   ") == []
+
+    def test_string_returns_single_element_list(self) -> None:
+        assert normalize_reference_default("branding/ref.png") == ["branding/ref.png"]
+
+    def test_string_strips_whitespace(self) -> None:
+        assert normalize_reference_default("  branding/ref.png  ") == ["branding/ref.png"]
+
+    def test_list_returns_as_is(self) -> None:
+        assert normalize_reference_default(["a.jpg", "b.jpg"]) == ["a.jpg", "b.jpg"]
+
+    def test_list_filters_empty_strings(self) -> None:
+        assert normalize_reference_default(["a.jpg", "", "  ", "b.jpg"]) == ["a.jpg", "b.jpg"]
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert normalize_reference_default([]) == []


### PR DESCRIPTION
## Summary

- `single_step` モードを TTP（ベンチマーク模倣）の推奨実装として default 化し、`generation_mode` のデフォルトを `two_phase → single_step` に変更
- `--reference` 未指定で `single_step` を起動するとプリフライトで即エラー中断（Issue #356 の FB 原因「参照画像未設定のまま試行」を予防）
- 複数参照画像 + `--max-attempts` で attempt 毎の参照ローテーション + `-vN` 別保存に対応
- 未実装の `ttp_swap` 仕様を SKILL.md / config から撤去

## 背景（Issue #356）

> 何度プロンプトを書き直してもベンチマークの雰囲気にならず、最終的に ChatGPT（手動）でベース画像を作るしかなかった。

調査により判明:

1. SKILL.md の `ttp_swap` モード仕様（L148-187）はコード実装が無い（仕様書のみ）
2. ダウンストリーム `daiki-beppu/rjn` では既に `single_step` + jazzgak ベンチマーク参照画像で TTP に成功
3. FB 元は `reference_images` を未設定のまま試した可能性が高い

→ 新規モードを切らず、既存 `single_step` 拡張で十分。設定漏れはプリフライトで予防する。

## 主な変更

| Path | 変更内容 |
|---|---|
| `.claude/skills/thumbnail/config.default.yaml` | `generation_mode` default を `single_step` へ。`single_step` セクション新設（clause 群 + `max_attempts` + `rotate`）。`ttp_swap` を選択肢から削除 |
| `.claude/skills/thumbnail/SKILL.md` | `TTP Swap` 節削除。`Single-Step / TTP モード` を推奨モードに格上げ。ローテーション運用・プリフライト中断・失敗時のツール内完結フォールバックを追記 |
| `src/youtube_automation/utils/image_provider/composition.py` | `select_reference` / `validate_single_step_references` / `normalize_reference_default` 追加 |
| `src/youtube_automation/scripts/generate_image.py` | `--max-attempts` / `--no-rotate` / `--reference-index` 追加、attempt ループ |
| `tests/test_image_provider_single_step_rotation.py` | 新規 20 件のユニットテスト |

## 後方互換

- `rjn` は `generation_mode: single_step` を明示設定済み → 影響無し
- `deepfocus365` は `generation_mode: two_phase` を明示設定済み → default 変更の影響無し、プリフライトは `single_step` 限定のため対象外
- `generation_mode` を明示していないチャンネルは default が `single_step` に変わるため、`reference_images` 未設定なら起動時にプリフライトで中断する（**意図通り**）

## Test plan

- [x] `uv run pytest tests/test_image_provider_single_step_rotation.py -v` → 20 passed
- [x] `uv run pytest tests/` 全体 → 1864 passed, 18 warnings
- [x] `tests/fixtures/sample_channel` をターゲットに `--reference` 無しで起動 → プリフライト ConfigError + exit 1
- [x] ダミー参照 3 件 + `--max-attempts 3` で「試行回数: 3 attempts (rotate=ON)」表示
- [ ] **Merge 後**: rjn の稼働中チャンネルで実画像生成検証（代表 3 サムネ × 2 シーン）→ 結果を Issue #356 にコメント記録
- [ ] **Merge 後**: deepfocus365 で `two_phase` モードのリグレッション無しを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)