### PR TITLE
[#379] issue-379-p0-3-upload-policy-r

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,6 +1,4 @@
 # automation リポジトリの takt 設定
 # provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
 draft_pr: false
-
-# release/v5.5.1 へのバッチ投入用に base_branch を一時切替（全 PR merge 後に削除して main 既定に戻す）
-base_branch: release/v5.5.1
+base_branch: main

--- a/src/youtube_automation/utils/exceptions.py
+++ b/src/youtube_automation/utils/exceptions.py
@@ -38,6 +38,18 @@ class YouTubeAPIError(AutomationError):
         )
 
 
+class QuotaExhaustedError(YouTubeAPIError):
+    """quota 切れ / レート制限超過（HTTP 429）。
+
+    時間をおいて再実行することで resume 可能であることを呼び出し側に明示する。
+    ``retry_after_seconds`` は Retry-After header から抽出した推奨待機秒数（取得失敗時 None）。
+    """
+
+    def __init__(self, message: str, retry_after_seconds: float | None = None):
+        super().__init__(message, status_code=429)
+        self.retry_after_seconds = retry_after_seconds
+
+
 class AuthError(AutomationError):
     """OAuth 2.0 認証関連のエラー
 

--- a/src/youtube_automation/utils/upload_core.py
+++ b/src/youtube_automation/utils/upload_core.py
@@ -13,11 +13,26 @@ from typing import Optional
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload
 
-from youtube_automation.utils.exceptions import UploadError, YouTubeAPIError
+from youtube_automation.utils.exceptions import QuotaExhaustedError, UploadError, YouTubeAPIError
 from youtube_automation.utils.upload_policy import RetryDecision, ThumbnailCompression
 from youtube_automation.utils.youtube_service import get_youtube
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_retry_after(resp) -> float | None:
+    """httplib2 Response から Retry-After header（秒数）を抽出する。
+
+    HTTP-date 形式や解析不能な値の場合は None を返し、呼び出し側で
+    指数 backoff にフォールバックさせる。
+    """
+    raw = resp.get("retry-after") if resp is not None else None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
 
 
 class YouTubeUploadCore:
@@ -118,11 +133,18 @@ class YouTubeUploadCore:
                     logger.info(f"   進捗: {progress}%")
 
             except HttpError as e:
-                decision = RetryDecision.for_http_error(e.resp.status, attempt)
+                status_code = e.resp.status
+                retry_after = _parse_retry_after(e.resp)
+                decision = RetryDecision.for_http_error(status_code, attempt, retry_after_seconds=retry_after)
                 if decision.should_retry:
-                    logger.warning(f"再試行可能エラー: {e}")
+                    logger.warning(f"再試行可能エラー (HTTP {status_code}, 待機 {decision.delay_seconds}s): {e}")
                     time.sleep(decision.delay_seconds)
                     attempt += 1
+                elif status_code == 429:
+                    raise QuotaExhaustedError(
+                        f"YouTube API の quota 超過/レート制限。時間をおいて再実行してください: {e}",
+                        retry_after_seconds=retry_after,
+                    ) from e
                 else:
                     logger.error(f"致命的エラー: {e}")
                     return None

--- a/src/youtube_automation/utils/upload_policy.py
+++ b/src/youtube_automation/utils/upload_policy.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass
 MAX_THUMBNAIL_BYTES = 2_097_152
 COMPRESSION_QUALITIES = (2, 5)
 MAX_RETRY_ATTEMPTS = 5
-RETRYABLE_HTTP_STATUSES = frozenset({500, 502, 503, 504})
+# 429 (Too Many Requests / quota) も再試行対象。Retry-After header があれば尊重し、
+# なければ指数 backoff にフォールバックする。
+RETRYABLE_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
 
 
 @dataclass(frozen=True)
@@ -44,10 +46,22 @@ class RetryDecision:
     delay_seconds: float = 0.0
 
     @classmethod
-    def for_http_error(cls, status_code: int, current_attempt: int) -> RetryDecision:
-        """HTTP ステータスとリトライ回数に基づいてリトライ判断を返す。"""
+    def for_http_error(
+        cls,
+        status_code: int,
+        current_attempt: int,
+        retry_after_seconds: float | None = None,
+    ) -> RetryDecision:
+        """HTTP ステータスとリトライ回数に基づいてリトライ判断を返す。
+
+        ``retry_after_seconds`` は Retry-After header から抽出した待機秒数。
+        正の値が与えられた場合はそれを優先し、なければ ``2 ** current_attempt`` の
+        指数 backoff にフォールバックする。
+        """
         if status_code not in RETRYABLE_HTTP_STATUSES:
             return cls(should_retry=False)
         if current_attempt >= MAX_RETRY_ATTEMPTS:
             return cls(should_retry=False)
+        if retry_after_seconds is not None and retry_after_seconds > 0:
+            return cls(should_retry=True, delay_seconds=float(retry_after_seconds))
         return cls(should_retry=True, delay_seconds=float(2**current_attempt))

--- a/tests/integration/test_upload_core.py
+++ b/tests/integration/test_upload_core.py
@@ -11,7 +11,7 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from youtube_automation.utils.exceptions import UploadError, YouTubeAPIError
+from youtube_automation.utils.exceptions import QuotaExhaustedError, UploadError, YouTubeAPIError
 
 # ---------------------------------------------------------------------------
 # ヘルパー
@@ -32,9 +32,16 @@ def _make_core_with_mock_youtube():
         return core, mock_youtube
 
 
-def _make_http_error(status: int, message: bytes = b"error") -> HttpError:
+def _make_http_error(
+    status: int,
+    message: bytes = b"error",
+    retry_after: str | None = None,
+) -> HttpError:
     """指定ステータスの HttpError を生成する。"""
-    resp = Response({"status": status})
+    info: dict = {"status": status}
+    if retry_after is not None:
+        info["retry-after"] = retry_after
+    resp = Response(info)
     return HttpError(resp, message)
 
 
@@ -161,3 +168,62 @@ class TestRetryBehavior:
             result = core.upload_video(str(video), {"snippet": {}})
 
         assert result == "retry_ok"
+
+    def test_retries_on_rate_limit_and_succeeds(self, tmp_path):
+        """429 エラー後にリトライし、最終的に成功する"""
+        core, mock_youtube = _make_core_with_mock_youtube()
+
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"video content")
+
+        mock_insert = MagicMock()
+        mock_youtube.videos.return_value.insert.return_value = mock_insert
+        mock_insert.next_chunk.side_effect = [
+            _make_http_error(429),
+            (None, {"id": "rate_limited_then_ok"}),
+        ]
+
+        with patch("youtube_automation.utils.upload_core.time.sleep"):
+            result = core.upload_video(str(video), {"snippet": {}})
+
+        assert result == "rate_limited_then_ok"
+
+    def test_honors_retry_after_header_on_rate_limit(self, tmp_path):
+        """Retry-After header の秒数を sleep に渡す"""
+        core, mock_youtube = _make_core_with_mock_youtube()
+
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"video content")
+
+        mock_insert = MagicMock()
+        mock_youtube.videos.return_value.insert.return_value = mock_insert
+        mock_insert.next_chunk.side_effect = [
+            _make_http_error(429, retry_after="12"),
+            (None, {"id": "after_wait"}),
+        ]
+
+        with patch("youtube_automation.utils.upload_core.time.sleep") as mock_sleep:
+            result = core.upload_video(str(video), {"snippet": {}})
+
+        assert result == "after_wait"
+        mock_sleep.assert_called_once_with(12.0)
+
+    def test_raises_quota_exhausted_after_max_retries(self, tmp_path):
+        """429 リトライ枯渇時は QuotaExhaustedError を raise する"""
+        core, mock_youtube = _make_core_with_mock_youtube()
+
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"video content")
+
+        mock_insert = MagicMock()
+        mock_youtube.videos.return_value.insert.return_value = mock_insert
+        # MAX_RETRY_ATTEMPTS=5 → attempt 0..4 でリトライ、attempt=5 で枯渇
+        # 合計 6 回 429 を返せば必ず exhausted
+        mock_insert.next_chunk.side_effect = [_make_http_error(429, retry_after="1")] * 6
+
+        with patch("youtube_automation.utils.upload_core.time.sleep"):
+            with pytest.raises(QuotaExhaustedError) as exc_info:
+                core.upload_video(str(video), {"snippet": {}})
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.retry_after_seconds == 1.0

--- a/tests/unit/test_upload_policy.py
+++ b/tests/unit/test_upload_policy.py
@@ -58,7 +58,7 @@ class TestRetryDecision:
         assert decision.should_retry is True
         assert decision.delay_seconds > 0
 
-    @pytest.mark.parametrize("status", [400, 403, 404, 429])
+    @pytest.mark.parametrize("status", [400, 403, 404])
     def test_gives_up_on_client_error(self, status):
         decision = RetryDecision.for_http_error(status, current_attempt=0)
         assert decision.should_retry is False
@@ -83,3 +83,38 @@ class TestRetryDecision:
     def test_applies_exponential_backoff(self, attempt, expected_delay):
         decision = RetryDecision.for_http_error(503, current_attempt=attempt)
         assert decision.delay_seconds == expected_delay
+
+    def test_retries_on_rate_limit(self):
+        """429 (Too Many Requests / quota) は再試行対象。"""
+        decision = RetryDecision.for_http_error(429, current_attempt=0)
+        assert decision.should_retry is True
+        assert decision.delay_seconds > 0
+
+    def test_respects_retry_after_header(self):
+        """Retry-After で与えられた秒数をそのまま delay として採用する。"""
+        decision = RetryDecision.for_http_error(429, current_attempt=0, retry_after_seconds=10.0)
+        assert decision.should_retry is True
+        assert decision.delay_seconds == 10.0
+
+    def test_falls_back_to_exponential_when_no_retry_after(self):
+        """Retry-After が無ければ ``2 ** attempt`` の指数 backoff。"""
+        decision = RetryDecision.for_http_error(429, current_attempt=2)
+        assert decision.should_retry is True
+        assert decision.delay_seconds == 4.0
+
+    def test_retry_after_applies_to_5xx_too(self):
+        """Retry-After は 5xx にも一律適用される（指数 backoff を上書き）。"""
+        decision = RetryDecision.for_http_error(503, current_attempt=0, retry_after_seconds=7.0)
+        assert decision.should_retry is True
+        assert decision.delay_seconds == 7.0
+
+    def test_falls_back_to_exponential_when_retry_after_non_positive(self):
+        """Retry-After が 0 以下なら指数 backoff にフォールバック。"""
+        decision = RetryDecision.for_http_error(429, current_attempt=1, retry_after_seconds=0.0)
+        assert decision.should_retry is True
+        assert decision.delay_seconds == 2.0
+
+    def test_gives_up_on_rate_limit_after_max_attempts(self):
+        """429 でも MAX_RETRY_ATTEMPTS を超えれば諦める。"""
+        decision = RetryDecision.for_http_error(429, current_attempt=MAX_RETRY_ATTEMPTS)
+        assert decision.should_retry is False


### PR DESCRIPTION
## Summary

quota 切れ寸前で `/video-upload` を叩くと resume 不可能な panic 終了。429 (Too Many Requests) を re-tryable にしておく必要がある。

## 出典
- `src/youtube_automation/utils/upload_policy.py:14`
- `src/youtube_automation/utils/upload_policy.py:47-50`

## 推奨アクション
1. `RETRYABLE_HTTP_STATUSES` に 429 を追加
2. 429 時は backoff （Retry-After header 尊重 or 指数 backoff）
3. quota exhaustion 用の専用 error class を導入し、再開可能性を明示

## 関連監査
- PR #375 (P0-3)

---
Milestone: `skill-audit-2026-05`
Source PRs: #367 (汎用化・整合性) / #375 (運用リスク)

## Execution Report

Workflow `default-mini` completed successfully.

Closes #379