### PR TITLE
[#377] issue-377-p0-1-lyria-client-py

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,6 +1,4 @@
 # automation リポジトリの takt 設定
 # provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
 draft_pr: false
-
-# release/v5.5.1 へのバッチ投入用に base_branch を一時切替（全 PR merge 後に削除して main 既定に戻す）
-base_branch: release/v5.5.1
+base_branch: main

--- a/src/youtube_automation/utils/lyria_client.py
+++ b/src/youtube_automation/utils/lyria_client.py
@@ -100,6 +100,77 @@ def _access_token() -> str:
     return credentials.token
 
 
+def _legacy_audio_data(outputs: object) -> str | None:
+    """legacy `outputs` 配列から base64 エンコード済み audio data 文字列を抽出。
+
+    型不正・キー欠落・非 audio mime は skip して次へ進む（例外を投げない）。
+    """
+    if not isinstance(outputs, list):
+        return None
+    for out in outputs:
+        if not isinstance(out, dict) or out.get("type") != "audio":
+            continue
+        mime = out.get("mime_type", "")
+        if not isinstance(mime, str) or not mime.startswith("audio/"):
+            continue
+        data = out.get("data")
+        if isinstance(data, str):
+            return data
+    return None
+
+
+def _audio_data_from_part(part: object) -> str | None:
+    """新 schema `parts[*]` の 1 要素から base64 エンコード済み audio data 文字列を抽出。
+
+    `inline_data` / `inlineData` および `mime_type` / `mimeType` の両表記を defensive に受ける。
+    """
+    if not isinstance(part, dict):
+        return None
+    inline = part.get("inline_data")
+    if not isinstance(inline, dict):
+        inline = part.get("inlineData")
+    if not isinstance(inline, dict):
+        return None
+    mime = inline.get("mime_type") or inline.get("mimeType") or ""
+    if not isinstance(mime, str) or not mime.startswith("audio/"):
+        return None
+    data = inline.get("data")
+    return data if isinstance(data, str) else None
+
+
+def _new_schema_audio_data(candidates: object) -> str | None:
+    """新 schema `candidates[*].content.parts[*].inline_data` から audio data 文字列を抽出。"""
+    if not isinstance(candidates, list):
+        return None
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        content = candidate.get("content")
+        if not isinstance(content, dict):
+            continue
+        parts = content.get("parts")
+        if not isinstance(parts, list):
+            continue
+        for part in parts:
+            data = _audio_data_from_part(part)
+            if data is not None:
+                return data
+    return None
+
+
+def _extract_audio_bytes(body: dict) -> bytes | None:
+    """Lyria レスポンスから audio bytes を抽出。legacy `outputs` と新 schema の両対応。
+
+    走査順序は legacy → 新 schema 固定。両 schema に audio が同居する移行期レスポンスでは
+    legacy を優先して既存挙動互換を保つ。型不正・キー欠落・非 audio mime は skip し、
+    両 schema いずれにも audio が見つからなければ None。
+    """
+    encoded = _legacy_audio_data(body.get("outputs"))
+    if encoded is None:
+        encoded = _new_schema_audio_data(body.get("candidates"))
+    return base64.b64decode(encoded) if encoded is not None else None
+
+
 def generate_music(
     prompt: str,
     model: str,
@@ -140,9 +211,9 @@ def generate_music(
         return None
 
     body = response.json()
-    for out in body.get("outputs", []):
-        if out.get("type") == "audio" and out.get("mime_type", "").startswith("audio/"):
-            return base64.b64decode(out["data"])
+    audio = _extract_audio_bytes(body)
+    if audio is not None:
+        return audio
 
     print(f"\n[ERROR] Lyria レスポンスにオーディオデータがありません: {body}")
     return None

--- a/tests/test_lyria_client.py
+++ b/tests/test_lyria_client.py
@@ -205,6 +205,506 @@ class TestGenerateMusic:
         with pytest.raises(ConfigError, match="参照画像が存在しません"):
             lyria_client.generate_music("p", "lyria-3-pro-preview", reference_image=missing)
 
+    def test_returns_audio_bytes_from_new_schema_response(self, mock_token):
+        # Given: HTTP レスポンスが Gemini 標準の新 schema (candidates[*].content.parts[*].inline_data) のみ
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
+        audio = b"\xff\xfb\x90\x00new-schema-mp3"
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": "audio/mpeg",
+                                    "data": base64.b64encode(audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        from youtube_automation.utils import lyria_client
+
+        # When: generate_music を呼ぶ
+        with patch.object(lyria_client.requests, "post", return_value=resp):
+            result = lyria_client.generate_music("p", "lyria-3-pro-preview")
+
+        # Then: 新 schema からデコード済み audio bytes が返る
+        assert result == audio
+
+    def test_prefers_legacy_when_both_schemas_in_http_response(self, mock_token):
+        # Given: HTTP レスポンスに legacy outputs と新 schema candidates が同居
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
+        legacy_audio = b"\xff\xfb\x90\x00legacy"
+        new_audio = b"\xff\xfb\x90\x00new"
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = {
+            "outputs": [
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(legacy_audio).decode()},
+            ],
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": "audio/mpeg",
+                                    "data": base64.b64encode(new_audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+
+        from youtube_automation.utils import lyria_client
+
+        # When: generate_music を呼ぶ
+        with patch.object(lyria_client.requests, "post", return_value=resp):
+            result = lyria_client.generate_music("p", "lyria-3-pro-preview")
+
+        # Then: 既存挙動互換のため legacy 側が優先される
+        assert result == legacy_audio
+
+
+class TestExtractAudioBytes:
+    def test_returns_audio_from_legacy_outputs(self):
+        # Given: legacy outputs schema の body
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "outputs": [
+                {"type": "text", "text": "lyrics"},
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 原バイト列が返る
+        assert result == audio
+
+    def test_returns_audio_from_new_schema_snake_case(self):
+        # Given: 新 schema (snake_case) の dry-run レスポンス body
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": "audio/mpeg",
+                                    "data": base64.b64encode(audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 原バイト列が返る
+        assert result == audio
+
+    def test_returns_audio_from_new_schema_camel_case(self):
+        # Given: 新 schema (camelCase) の body
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "audio/mpeg",
+                                    "data": base64.b64encode(audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 原バイト列が返る
+        assert result == audio
+
+    def test_returns_audio_when_mixed_snake_and_camel_case(self):
+        # Given: snake_case key (inline_data) と camelCase key (mimeType) が同 part 内で混在
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mimeType": "audio/mpeg",
+                                    "data": base64.b64encode(audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 原バイト列が返る
+        assert result == audio
+
+    def test_prefers_legacy_when_both_schemas_present(self):
+        # Given: legacy outputs と 新 schema candidates が同時に存在する移行期 body
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        legacy_audio = b"\xff\xfb\x90\x00legacy"
+        new_audio = b"\xff\xfb\x90\x00new"
+        body = {
+            "outputs": [
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(legacy_audio).decode()},
+            ],
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": "audio/mpeg",
+                                    "data": base64.b64encode(new_audio).decode(),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 既存挙動互換のため legacy が優先される
+        assert result == legacy_audio
+
+    def test_skips_non_audio_parts_in_new_schema(self):
+        # Given: 新 schema で先頭 part が image, 2 番目が audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mime_type": "image/png", "data": base64.b64encode(b"img").decode()}},
+                            {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: audio 系 mime_type の part が拾われる
+        assert result == audio
+
+    def test_picks_audio_across_multiple_candidates(self):
+        # Given: 複数 candidates のうち 2 つ目に audio がある
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        image_part = {"inline_data": {"mime_type": "image/png", "data": base64.b64encode(b"img").decode()}}
+        audio_part = {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}}
+        body = {
+            "candidates": [
+                {"content": {"parts": [image_part]}},
+                {"content": {"parts": [audio_part]}},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 2 つ目の candidate から audio が拾われる
+        assert result == audio
+
+    def test_skips_legacy_entry_with_non_audio_mime(self):
+        # Given: type=audio だが mime_type が video/mp4 の legacy entry
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {
+            "outputs": [
+                {"type": "audio", "mime_type": "video/mp4", "data": base64.b64encode(b"vid").decode()},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: startswith("audio/") フィルタで skip → None
+        assert result is None
+
+    def test_skips_legacy_entry_with_missing_mime(self):
+        # Given: legacy entry に mime_type キーが欠落、次の entry に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "outputs": [
+                {"type": "audio", "data": base64.b64encode(b"x").decode()},
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: mime_type 欠落の entry は skip し、後続の正常 entry を拾う
+        assert result == audio
+
+    def test_skips_legacy_entry_with_missing_data(self):
+        # Given: legacy entry の data キーが欠落、後続 entry に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "outputs": [
+                {"type": "audio", "mime_type": "audio/mpeg"},
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 例外を投げず skip し、次の audio を返す
+        assert result == audio
+
+    def test_skips_new_schema_entry_with_missing_data(self):
+        # Given: 新 schema で inline_data.data が欠落、後続 part に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mime_type": "audio/mpeg"}},
+                            {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: data 欠落は skip し、次の正常 audio を返す
+        assert result == audio
+
+    def test_returns_none_for_empty_body(self):
+        # Given: 空の body
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes({})
+
+        # Then: None
+        assert result is None
+
+    def test_returns_none_when_no_audio_in_either_schema(self):
+        # Given: legacy outputs に text のみ、新 schema candidates にも image のみ
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {
+            "outputs": [
+                {"type": "text", "text": "no audio"},
+            ],
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mime_type": "image/png", "data": base64.b64encode(b"img").decode()}},
+                        ]
+                    }
+                }
+            ],
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 両 schema いずれにも audio がないため None
+        assert result is None
+
+    def test_returns_none_when_candidates_content_empty(self):
+        # Given: candidates[0].content が空 dict
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {"candidates": [{"content": {}}]}
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: None
+        assert result is None
+
+    def test_returns_none_when_candidates_parts_empty(self):
+        # Given: candidates[0].content.parts が空 list
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {"candidates": [{"content": {"parts": []}}]}
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: None
+        assert result is None
+
+    def test_skips_when_outputs_is_not_list(self):
+        # Given: legacy outputs が dict / 新 schema 側に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "outputs": {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(b"x").decode()},
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}}
+                        ]
+                    }
+                }
+            ],
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 不正型の outputs は型ガードで skip し、新 schema を拾う
+        assert result == audio
+
+    def test_skips_when_candidates_is_not_list(self):
+        # Given: 新 schema candidates が dict（list 以外）
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {"candidates": {"content": {"parts": []}}}
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 型ガードで skip → None
+        assert result is None
+
+    def test_skips_when_candidate_is_not_dict(self):
+        # Given: candidates の要素が None / 文字列
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                None,
+                "not-a-dict",
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}}
+                        ]
+                    }
+                },
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 不正な要素は skip し、有効な candidate から audio を返す
+        assert result == audio
+
+    def test_skips_when_parts_is_not_list(self):
+        # Given: content.parts が list 以外
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        body = {"candidates": [{"content": {"parts": "not-a-list"}}]}
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 型ガードで skip → None
+        assert result is None
+
+    def test_skips_when_inline_data_is_not_dict(self):
+        # Given: inline_data が None / 文字列の part、後続に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"inline_data": None},
+                            {"inline_data": "not-a-dict"},
+                            {"inline_data": {"mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 不正な inline_data は skip し、正常 part から audio を返す
+        assert result == audio
+
+    def test_skips_legacy_entry_that_is_not_dict(self):
+        # Given: outputs の要素が None / 文字列、後続に正常 audio
+        from youtube_automation.utils.lyria_client import _extract_audio_bytes
+
+        audio = b"\xff\xfb\x90\x00fake-mp3"
+        body = {
+            "outputs": [
+                None,
+                "not-a-dict",
+                {"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()},
+            ]
+        }
+
+        # When: ヘルパーで抽出
+        result = _extract_audio_bytes(body)
+
+        # Then: 不正な要素は skip し、後続の正常 entry を返す
+        assert result == audio
+
 
 class TestComposePrompt:
     def test_none_params_returns_base_as_is(self):


### PR DESCRIPTION
## Summary

Lyria 3 Interactions API の legacy `outputs` schema に単一依存。Vertex AI 側のスキーマ切替が起きるとサイレント失敗（None 返却）で BGM 生成全停止。

## 出典
- `src/youtube_automation/utils/lyria_client.py:148-154` (`body.get("outputs", [])` 直読み)

## 切替日
- 公式アナウンス `ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026` で 2026-05-26
- ただし出典は Gemini Developer API ドキュメント側であり、Vertex AI Lyria の `interactions` endpoint に同日適用かは要再確認

## 推奨アクション
1. レスポンス schema を defensive にパース（`outputs` / 新 schema 両対応）
2. 公式アナウンス（Vertex AI 側）の日付を再確認
3. 切替前に dry-run テストを追加

## 関連監査
- PR #375 (P0-1)

---
Milestone: `skill-audit-2026-05`
Source PRs: #367 (汎用化・整合性) / #375 (運用リスク)

## Execution Report

Workflow `default-extended` completed successfully.

Closes #377