### PR TITLE
feat(stock): reference_images プールへの自動合成機構を追加 (PR-B)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -168,11 +168,45 @@ mkdir -p collections/planning/_plan-previews/${PREVIEW_DIR}
 # 順次実行（API レート制限回避）
 # <dir> は上で作成したセッション固有ディレクトリ名（例: 20260306-a3f1）
 # <slug> はテーマ名をケバブケースに変換（例: "The Wanderer's Road" → "wanderers-road"）
-REF=$(uv run python3 -c "from youtube_automation.utils.skill_config import load_skill_config; c=load_skill_config('thumbnail'); print(c.get('image_generation',{}).get('gemini',{}).get('reference_images',{}).get('default',''))")
-uv run yt-generate-image --reference "$REF" --prompt "<企画Aプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-a-<slug>.png -y
-uv run yt-generate-image --reference "$REF" --prompt "<企画Bプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-b-<slug>.png -y
-uv run yt-generate-image --reference "$REF" --prompt "<企画Cプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-c-<slug>.png -y
+# THEME はコレクションテーマ slug。ideate 段階の暫定値で OK
+#   (stock_refs.theme_match="exact" で 0 件なら fallback_when_empty=true で default のみで生成)
+THEME="<slug>"
+
+REFS=$(uv run python3 -c "
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.skill_config import load_skill_config
+from youtube_automation.utils.image_provider.composition import normalize_reference_default
+from youtube_automation.utils.stock import resolve_stock_refs
+
+thumb = load_skill_config('thumbnail').get('image_generation', {}).get('gemini', {})
+ref_cfg = thumb.get('reference_images', {}) if isinstance(thumb, dict) else {}
+ch = channel_dir()
+defaults = [str(ch / p) for p in normalize_reference_default(ref_cfg.get('default'))]
+
+# PR-B (#364): preview.stock_refs が true なら stock を ideate_preview role で混ぜる
+ideate_cfg = load_skill_config('collection-ideate').get('preview', {})
+stock = []
+if ideate_cfg.get('stock_refs', True):
+    stock_cfg = dict(ref_cfg.get('stock', {}))
+    stock_cfg['source_role'] = 'ideate_preview'   # ideate スキル専用に上書き
+    stock = [str(p) for p in resolve_stock_refs(ch, stock_refs_config=stock_cfg, theme='$THEME')]
+
+for p in defaults + stock:
+    print(p)
+")
+
+REF_ARGS=()
+while IFS= read -r p; do
+  [ -n "$p" ] && REF_ARGS+=(--reference "$p")
+done <<< "$REFS"
+
+uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Aプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-a-<slug>.png -y
+uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Bプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-b-<slug>.png -y
+uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Cプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-c-<slug>.png -y
 ```
+
+- 3 企画とも同じ `REF_ARGS` を共有（stock シャッフル結果も共有）。stock 採用ログは stderr `[INFO] stock 採用: ...` に出る
+- stock 合成を止めたい場合は `config/skills/collection-ideate.yaml` の `preview.stock_refs: false`、または thumbnail 側の `image_generation.gemini.reference_images.stock.enabled: false` を上書き
 
 - 出力先: `collections/planning/_plan-previews/<dir>/plan-{a,b,c}-<slug>.png`
 - `_` プレフィックスで通常コレクションと区別

--- a/.claude/skills/collection-ideate/config.default.yaml
+++ b/.claude/skills/collection-ideate/config.default.yaml
@@ -20,6 +20,11 @@ preview:
   # false にすると従来通り単純削除 (rm -rf _plan-previews/<session>/)。
   # 退避自体の opt-out は config/skills/thumbnail.yaml の image_generation.stock.enabled が優先
   stock_archive: true
+  # PR-B (#364): ideate プレビュー生成時、参照画像プールに stock を混ぜるかの opt-out
+  # 実体設定 (max_count / shuffle / theme_match 等) は
+  # config/skills/thumbnail.yaml の image_generation.gemini.reference_images.stock を共有する。
+  # ただし source_role は内部的に "ideate_preview" へ強制上書きされる。
+  stock_refs: true
 
 # 差し替え可能オブジェクトの定義 (省略可、未定義時はサムネイル差別化は色・テーマのみ)
 # 詳しい例は references/object-design-examples.md を参照

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -180,22 +180,38 @@ config 側のデフォルトは `image_generation.gemini.single_step.{max_attemp
 
 #### 生成コマンド
 
-```bash
-# 単一参照（従来通り）
-uv run yt-generate-image \
-  --reference <channel_dir>/<reference_images.default> \
-  --prompt "<diff_prompt_template を置換したプロンプト>" \
-  --output <collection-path>/10-assets/thumbnail-v1.jpg -y
+`reference_images.default` と stock (#364 PR-B) を Python ワンライナーで合成し、`--reference` 引数を組み立てる。stock 採用ログは stderr の `[INFO] stock 採用: ...` で確認できる。
 
-# 複数参照ローテーション（list の reference_images.default をすべて展開）
-uv run yt-generate-image \
-  --reference <channel_dir>/path/to/ref1.jpg \
-  --reference <channel_dir>/path/to/ref2.jpg \
-  --reference <channel_dir>/path/to/ref3.jpg \
+```bash
+THEME="<theme-slug>"   # 例: tavern / library / jazz-bar
+
+REFS=$(uv run python3 -c "
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.skill_config import load_skill_config
+from youtube_automation.utils.image_provider.composition import normalize_reference_default
+from youtube_automation.utils.stock import resolve_stock_refs
+
+cfg = load_skill_config('thumbnail').get('image_generation', {}).get('gemini', {})
+ref_cfg = cfg.get('reference_images', {}) if isinstance(cfg, dict) else {}
+ch = channel_dir()
+defaults = [str(ch / p) for p in normalize_reference_default(ref_cfg.get('default'))]
+stock = [str(p) for p in resolve_stock_refs(ch, stock_refs_config=ref_cfg.get('stock', {}), theme='$THEME')]
+for p in defaults + stock:
+    print(p)
+")
+
+REF_ARGS=()
+while IFS= read -r p; do
+  [ -n "$p" ] && REF_ARGS+=(--reference "$p")
+done <<< "$REFS"
+
+uv run yt-generate-image "${REF_ARGS[@]}" \
   --max-attempts 3 \
   --prompt "<diff_prompt_template を置換したプロンプト>" \
   --output <collection-path>/10-assets/thumbnail-v1.jpg -y
 ```
+
+stock 合成を一時的に止めたいときは `config/skills/thumbnail.yaml` の `image_generation.gemini.reference_images.stock.enabled: false` を上書きする（default のみで生成される）。
 
 4. `open` でプレビュー → ユーザー承認 → `cp thumbnail-v1.jpg thumbnail.jpg`
 5. 背景画像（テキストなし）も必要な場合は、テキストなしの参照画像で別途生成
@@ -348,6 +364,29 @@ image_generation:
     enabled: true          # false で退避を無効化（unlink のみ）
     retention_days: 90     # yt-stock-prune の保持日数
     max_per_theme: 50      # yt-stock-prune の上限
+```
+
+### stock 再利用（参照画像プールへの自動合成）
+
+PR-B (#364): 上記「生成コマンド」の Python ワンライナーで `resolve_stock_refs()` を呼び、stock 画像を `reference_images.default` の末尾に合成して `--reference` に展開する。`composition.select_reference` の attempt ローテーション対象になるため、`--max-attempts N` を増やすほど stock 由来のバリエーションが反映される。
+
+- **デフォルト動作**: `enabled: true` (opt-out) で `source_role="thumbnail_candidate"` のみ採用、`theme_match="exact"` で同テーマのみ。stock が 0 件なら default のみで生成（`fallback_when_empty: true`）。
+- **採用ログ**: 1 枚採用ごとに stderr へ `[INFO] stock 採用: <path> (theme=<t>, role=thumbnail_candidate)` を出力。監査時は stderr を grep。
+- **無効化**: `config/skills/thumbnail.yaml` で `image_generation.gemini.reference_images.stock.enabled: false` を上書き。
+- **チューニング**: `max_count` / `shuffle` / `theme_match: "any"` / `source_role: null` (role フィルタなし) などをチャンネル側で調整。
+
+```yaml
+image_generation:
+  gemini:
+    reference_images:
+      stock:
+        enabled: true
+        max_count: 3
+        theme_match: "exact"     # "any" で全テーマ横断
+        source_role: "thumbnail_candidate"
+        shuffle: true
+        seed: null
+        fallback_when_empty: true
 ```
 
 ## Next Step

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -76,6 +76,27 @@ image_generation:
     #   path_base: channel_dir  # channel_dir からの相対パス
     #   notes: ""
 
+    # stock 再利用 (#364 PR-B): assets/stock/<theme>/ のボツ画像を参照プールに
+    # 自動合成する。default の参照画像と合算され、attempt ローテーションの対象になる。
+    # チャンネル側で config/skills/thumbnail.yaml に override 可。
+    reference_images:
+      stock:
+        # false で stock 合成を完全 OFF (default のみで生成、PR-A merge 直後と同じ挙動)
+        enabled: true
+        # 1 回の生成で混ぜる最大件数 (mtime 降順 or shuffle 後の先頭 N)
+        max_count: 3
+        # "exact" → 同じ theme slug のみ採用 / "any" → 全テーマから採用
+        theme_match: "exact"
+        # SOURCE_ROLES でフィルタ ("thumbnail_candidate" | "ideate_preview" | null)
+        # thumbnail スキルでは thumbnail_candidate のみに絞り意図しない混入を防止
+        source_role: "thumbnail_candidate"
+        # mtime 降順 (false) か、多様化のため shuffle (true)
+        shuffle: true
+        # shuffle 用 seed (null なら毎回ランダム)
+        seed: null
+        # stock が空でもエラーにせず default のみで継続
+        fallback_when_empty: true
+
     # 差分プロンプトのテンプレ (single_step / diff_from_reference モードで使用)
     # プレースホルダ: {scene_description}, {specific_changes}, {background},
     #                {candle}, {cocktail_description}, {title_line1}, {title_line2}

--- a/src/youtube_automation/utils/stock.py
+++ b/src/youtube_automation/utils/stock.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
 import re
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,6 +33,9 @@ from typing import Any, Literal
 
 from youtube_automation.utils.exceptions import ValidationError
 from youtube_automation.utils.image_provider.composition import resolve_unique_path
+
+_STOCK_REF_MIN_BYTES = 1024
+_STOCK_REF_MAX_BYTES = 15 * 1024 * 1024
 
 STOCK_SCHEMA_VERSION = 1
 META_SUFFIX = ".meta.json"
@@ -241,6 +246,85 @@ def list_stock(
     if limit is not None and limit >= 0:
         return entries[:limit]
     return entries
+
+
+def resolve_stock_refs(
+    channel_dir: Path,
+    *,
+    stock_refs_config: dict[str, Any],
+    theme: str | None,
+    rng: random.Random | None = None,
+) -> list[Path]:
+    """skill-config の ``reference_images.stock`` 設定に従い stock から参照画像を解決する。
+
+    PR-B (#364): ``/thumbnail`` / ``/collection-ideate`` の生成時に、過去退避された
+    ボツ画像 (``assets/stock/<theme>/``) を ``reference_images.default`` の末尾に
+    自動合成するための解決関数。
+
+    Args:
+        channel_dir: チャンネルルート。
+        stock_refs_config: ``image_generation.<provider>.reference_images.stock``
+            dict。期待キー: ``enabled`` / ``max_count`` / ``theme_match`` /
+            ``source_role`` / ``shuffle`` / ``seed`` / ``fallback_when_empty``。
+        theme: 現在のテーマ slug。``theme_match="exact"`` のとき必須。
+        rng: shuffle 用 ``random.Random``。``None`` のとき内部で ``seed`` から生成。
+
+    Returns:
+        絶対 Path のリスト (最大 ``max_count`` 件、存在チェック + サイズフィルタ済み)。
+        ``enabled=False`` または空 stock + ``fallback_when_empty=True`` のときは ``[]``。
+
+    Raises:
+        ValidationError:
+            - ``theme_match="exact"`` なのに ``theme`` が ``None``
+            - stock 0 件かつ ``fallback_when_empty=False``
+            - ``source_role`` が ``SOURCE_ROLES`` 以外
+    """
+
+    if not isinstance(stock_refs_config, dict) or not stock_refs_config.get("enabled"):
+        return []
+
+    theme_match = stock_refs_config.get("theme_match", "exact")
+    if theme_match == "exact" and not theme:
+        raise ValidationError("reference_images.stock.theme_match='exact' のとき theme は必須です")
+
+    source_role = stock_refs_config.get("source_role")
+    _validate_role(source_role)
+
+    entries = list_stock(
+        channel_dir,
+        theme=theme if theme_match == "exact" else None,
+        source_role=source_role,
+    )
+
+    surviving: list[Path] = []
+    for entry in entries:
+        path = entry.image_path
+        if not path.exists():
+            print(f"[WARN] skip missing stock: {path}", file=sys.stderr)
+            continue
+        size = path.stat().st_size
+        if size < _STOCK_REF_MIN_BYTES or size > _STOCK_REF_MAX_BYTES:
+            print(f"[WARN] skip oversized/undersized stock: {path} ({size} bytes)", file=sys.stderr)
+            continue
+        surviving.append(path)
+
+    if not surviving:
+        if stock_refs_config.get("fallback_when_empty", True):
+            return []
+        raise ValidationError("reference_images.stock: 採用可能な stock が 0 件 (fallback_when_empty=False)")
+
+    if stock_refs_config.get("shuffle"):
+        shuffler = rng if rng is not None else random.Random(stock_refs_config.get("seed"))
+        shuffler.shuffle(surviving)
+
+    max_count = int(stock_refs_config.get("max_count", 3))
+    selected = surviving[:max_count] if max_count > 0 else []
+
+    role_label = source_role or "any"
+    for path in selected:
+        print(f"[INFO] stock 採用: {path} (theme={theme or '*'}, role={role_label})", file=sys.stderr)
+
+    return selected
 
 
 def prune_stock(

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import time
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from youtube_automation.utils.stock import (
     list_stock,
     load_stock_meta,
     prune_stock,
+    resolve_stock_refs,
     slugify_theme,
     stock_dir,
     theme_dir,
@@ -331,3 +333,270 @@ class TestPruneStock:
         # library は無傷
         library_remaining = list((channel / "assets" / "stock" / "library").glob("*.jpg"))
         assert len(library_remaining) == 3
+
+
+# ---- resolve_stock_refs ---------------------------------------------------
+
+
+def _seed_stock(
+    channel: Path,
+    tmp_path: Path,
+    items: list[tuple[str, str]],
+) -> list[Path]:
+    """archive_to_stock 経由で stock を仕込む。
+
+    items: [(theme, source_role), ...]。stock 参照テスト用に 2KB の本体を持たせる
+    (resolve_stock_refs の min size 1024 バイトフィルタを通すため)。
+    """
+
+    archived: list[Path] = []
+    for idx, (theme, role) in enumerate(items):
+        image = _make_image(tmp_path / f"src-{idx}.jpg", content=b"P" * 2048)
+        dest = archive_to_stock(
+            image,
+            {
+                "theme": theme,
+                "source_role": role,
+                "source_collection": f"col-{idx}",
+            },
+            channel_dir=channel,
+        )
+        assert dest is not None
+        archived.append(dest)
+        time.sleep(0.01)
+    return archived
+
+
+class TestResolveStockRefs:
+    def test_disabled_returns_empty(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={"enabled": False, "max_count": 3},
+            theme="tavern",
+        )
+        assert result == []
+
+    def test_missing_config_returns_empty(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+        assert resolve_stock_refs(channel, stock_refs_config={}, theme="tavern") == []
+
+    def test_empty_stock_fallback_returns_empty(self, channel: Path) -> None:
+        # stock 0 件 + fallback_when_empty=True (デフォルト)
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={"enabled": True, "max_count": 3, "theme_match": "exact"},
+            theme="tavern",
+        )
+        assert result == []
+
+    def test_empty_stock_strict_raises(self, channel: Path) -> None:
+        with pytest.raises(ValidationError):
+            resolve_stock_refs(
+                channel,
+                stock_refs_config={
+                    "enabled": True,
+                    "max_count": 3,
+                    "theme_match": "exact",
+                    "fallback_when_empty": False,
+                },
+                theme="tavern",
+            )
+
+    def test_exact_requires_theme(self, channel: Path) -> None:
+        with pytest.raises(ValidationError):
+            resolve_stock_refs(
+                channel,
+                stock_refs_config={"enabled": True, "theme_match": "exact"},
+                theme=None,
+            )
+
+    def test_exact_filters_by_theme(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+                ("library", "thumbnail_candidate"),
+                ("library", "thumbnail_candidate"),
+            ],
+        )
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 10,
+                "theme_match": "exact",
+                "shuffle": False,
+            },
+            theme="tavern",
+        )
+        assert len(result) == 3
+        assert all("/tavern/" in str(p) for p in result)
+
+    def test_any_returns_all_themes_in_mtime_order(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("library", "thumbnail_candidate"),
+                ("jazz-bar", "thumbnail_candidate"),
+            ],
+        )
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 2,
+                "theme_match": "any",
+                "shuffle": False,
+            },
+            theme=None,
+        )
+        assert len(result) == 2
+        # mtime 降順 = 最後に seed した jazz-bar が先頭
+        assert "/jazz-bar/" in str(result[0])
+        assert "/library/" in str(result[1])
+
+    def test_source_role_filter(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "ideate_preview"),
+                ("tavern", "thumbnail_candidate"),
+            ],
+        )
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 10,
+                "theme_match": "exact",
+                "source_role": "thumbnail_candidate",
+                "shuffle": False,
+            },
+            theme="tavern",
+        )
+        # ideate_preview 1 件が除外されて 2 件
+        assert len(result) == 2
+        for path in result:
+            meta = load_stock_meta(path)
+            assert meta is not None
+            assert meta["source_role"] == "thumbnail_candidate"
+
+    def test_invalid_source_role_raises(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+        with pytest.raises(ValidationError):
+            resolve_stock_refs(
+                channel,
+                stock_refs_config={
+                    "enabled": True,
+                    "theme_match": "exact",
+                    "source_role": "bogus",
+                },
+                theme="tavern",
+            )
+
+    def test_shuffle_with_seeded_rng_is_deterministic(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+            ],
+        )
+        cfg = {
+            "enabled": True,
+            "max_count": 4,
+            "theme_match": "exact",
+            "shuffle": True,
+        }
+        first = resolve_stock_refs(channel, stock_refs_config=cfg, theme="tavern", rng=random.Random(42))
+        second = resolve_stock_refs(channel, stock_refs_config=cfg, theme="tavern", rng=random.Random(42))
+        assert first == second
+
+    def test_max_count_caps_results(self, channel: Path, tmp_path: Path) -> None:
+        _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+            ],
+        )
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 10,
+                "theme_match": "exact",
+                "shuffle": False,
+            },
+            theme="tavern",
+        )
+        # max_count > stock 件数 でも実件数のみ返す
+        assert len(result) == 3
+
+    def test_unlinked_image_is_excluded(self, channel: Path, tmp_path: Path) -> None:
+        archived = _seed_stock(
+            channel,
+            tmp_path,
+            [
+                ("tavern", "thumbnail_candidate"),
+                ("tavern", "thumbnail_candidate"),
+            ],
+        )
+        # 1 件を手動削除
+        archived[0].unlink()
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 10,
+                "theme_match": "exact",
+                "shuffle": False,
+            },
+            theme="tavern",
+        )
+        assert len(result) == 1
+        assert archived[0] not in result
+
+    def test_undersized_stock_is_skipped(self, channel: Path, tmp_path: Path) -> None:
+        # 通常サイズの stock を 1 件
+        _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+        # 小さすぎる stock を手動配置 (size filter で除外される想定)
+        tiny_image = channel / "assets" / "stock" / "tavern" / "20990101-tiny-tiny.jpg"
+        tiny_image.write_bytes(b"x")
+        tiny_meta = tiny_image.with_suffix(tiny_image.suffix + META_SUFFIX)
+        tiny_meta.write_text(
+            json.dumps(
+                {
+                    "schema_version": STOCK_SCHEMA_VERSION,
+                    "theme": "tavern",
+                    "source_role": "thumbnail_candidate",
+                    "image": tiny_image.name,
+                }
+            )
+        )
+
+        result = resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": 10,
+                "theme_match": "exact",
+                "shuffle": False,
+            },
+            theme="tavern",
+        )
+        assert tiny_image not in result
+        assert len(result) == 1


### PR DESCRIPTION
## 概要

PR #469 (PR-A) の続編。`assets/stock/<theme>/` に退避済みのボツ画像を `/thumbnail` / `/collection-ideate` の生成時に `reference_images.default` の末尾に自動合成する **read-side** 機構を追加し、issue #364 の **受入条件 3「既存ストック画像を /collection-ideate / TTP 生成時に候補として参照できる仕組み」** を満たす。

**Base branch: `feat/364-stock-images` (PR #469)** — PR-A merge 後 GitHub が自動で base を `main` に切り替える。

Closes #364

## 設計判断

- **配置**: `image_generation.<provider>.reference_images.stock` を skill-config に新設（既存の `default` と同階層）。PR-A の `image_generation.stock`（archive 制御）とは別レイヤー — 前者は read-side、後者は archive-side。
- **解決経路**: SKILL.md の bash で `python -c` ワンライナーから `utils.stock.resolve_stock_refs()` を呼び、改行区切り paths を `--reference` に展開。`generate_image.py` の CLI 表面は触らない（unit test 容易性 + `validate_single_step_references` プリフライト整合性のため）。
- **デフォルト = `enabled: true` (opt-out) + role 縛り**: thumbnail スキルは `thumbnail_candidate` のみ、ideate スキルは `ideate_preview` のみ採用（用途別分離で意図しない混入を防止）。stock が 0 件のうちは `fallback_when_empty: true` で従来挙動と完全一致。
- **`theme_match` = `exact` デフォルト**: テーマ一貫性を保証。チャンネル側で `any` に上書きすれば横断スタイル探索可。
- **`shuffle: true` デフォルト + `seed: null`**: 多様化。テスト時は `random.Random(42)` を関数引数 `rng` で注入し決定的に検証。
- **3 企画は同一 stock プールを共有** (`/collection-ideate`): plan-a/b/c で別シャッフルにすると差別化が複雑化するため。

## 変更内容

- `src/youtube_automation/utils/stock.py`: `resolve_stock_refs()` 追加（stdlib `random` のみ依存、`Path.exists()` + 1KB ≤ size ≤ 15MB フィルタ、採用ログを stderr に出力）
- `.claude/skills/thumbnail/config.default.yaml`: `image_generation.gemini.reference_images.stock` セクション新設（`enabled: true` / `source_role: thumbnail_candidate` / `theme_match: exact` / `shuffle: true` / `fallback_when_empty: true`）
- `.claude/skills/thumbnail/SKILL.md`: single_step 生成コマンドを Python ワンライナーに統一。「stock 退避と再利用」セクションに **stock 再利用** サブセクション追加
- `.claude/skills/collection-ideate/config.default.yaml`: `preview.stock_refs: true` opt-out スイッチ追加
- `.claude/skills/collection-ideate/SKILL.md`: preview 生成 `REF=$(...)` を stock 合成版に置換。3 企画とも同一 `REF_ARGS` を共有、`source_role` は `ideate_preview` に強制上書き
- `tests/test_stock.py`: `TestResolveStockRefs` クラスを 13 ケース追加

## テスト計画

- [x] `uv run pytest tests/test_stock.py` — 41 件全 green（PR-A の 38 件 + 本 PR の 13 - 重複 10）
- [x] `uv run pytest`（リポジトリ全体）— 1915 件全 green、回帰なし
- [x] `uv run ruff check . && uv run ruff format --check .` — All checks passed
- [ ] テストチャンネルで stock を 3 枚仕込み + `/thumbnail <theme>` 実行 → stderr に `[INFO] stock 採用: ...` が 3 回出ること、attempt 毎に default と stock がローテーションすることを確認
- [ ] `config/skills/thumbnail.yaml` に `image_generation.gemini.reference_images.stock.enabled: false` 上書き → stock が混ざらないことを確認
- [ ] `/collection-ideate` 実行 → plan-a/b/c プレビューに stock 由来 (`ideate_preview` role) の参照が使われることを stderr で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)