### PR TITLE
ci: CHANGELOG.md [Unreleased] 更新を PR で必須化 (#485)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## 概要
+
+<!-- 何を、なぜ変更したか。issue があれば `Closes #N` -->
+
+## 変更内容
+
+<!-- 主要な変更点を箇条書きで -->
+
+## チェックリスト
+
+- [ ] `CHANGELOG.md::[Unreleased]` にエントリを追加した
+  - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
+- [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
+  - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)
+- [ ] 必要なテストを追加・更新した
+
+## 関連
+
+<!-- 関連 issue / PR / 参照ドキュメント -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,34 @@ jobs:
         run: nix develop --command uv sync --extra dev
       - name: Test
         run: nix develop --command uv run pytest
+
+  changelog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check CHANGELOG update
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then
+            echo "skip-changelog label present, skipping CHANGELOG check"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          if ! echo "$changed" | grep -qE '^(src/youtube_automation/|\.claude/skills/|\.claude/CLAUDE\.template\.md$|pyproject\.toml$)'; then
+            echo "No significant code changes, skipping CHANGELOG check"
+            exit 0
+          fi
+          if ! echo "$changed" | grep -q '^CHANGELOG\.md$'; then
+            echo "::error::CHANGELOG.md must be updated under [Unreleased]. Add an entry or apply 'skip-changelog' label."
+            exit 1
+          fi
+          echo "CHANGELOG.md updated"

--- a/tests/test_changelog_ci_contract.py
+++ b/tests/test_changelog_ci_contract.py
@@ -1,0 +1,112 @@
+"""CHANGELOG 運用の GitHub 契約を静的に検証する。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+_CI_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+_CHANGELOG_LABEL = "skip-changelog"
+_PATH_FILTER_PATTERN = (
+    "^(src/youtube_automation/|\\.claude/skills/|\\.claude/CLAUDE\\.template\\.md$|pyproject\\.toml$)"
+)
+_CHANGELOG_FILE_PATTERN = "^CHANGELOG\\.md$"
+_LABELS_JOIN_EXPRESSION = "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+_PR_EVENT_GUARD = "github.event_name == 'pull_request'"
+_PR_TEMPLATE_TEXT = """## 概要
+
+<!-- 何を、なぜ変更したか。issue があれば `Closes #N` -->
+
+## 変更内容
+
+<!-- 主要な変更点を箇条書きで -->
+
+## チェックリスト
+
+- [ ] `CHANGELOG.md::[Unreleased]` にエントリを追加した
+  - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
+- [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
+  - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)
+- [ ] 必要なテストを追加・更新した
+
+## 関連
+
+<!-- 関連 issue / PR / 参照ドキュメント -->
+"""
+_EXPECTED_RUN_LINES = [
+    "set -eu",
+    'if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then',
+    'changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")',
+    f"if ! echo \"$changed\" | grep -qE '{_PATH_FILTER_PATTERN}'; then",
+    f"if ! echo \"$changed\" | grep -q '{_CHANGELOG_FILE_PATTERN}'; then",
+    'echo "CHANGELOG.md updated"',
+]
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        pytest.fail(f"必須ファイルが存在しない: {path.relative_to(_REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_ci_workflow() -> dict[str, object]:
+    return yaml.safe_load(_read_text(_CI_WORKFLOW_PATH))
+
+
+def test_pull_request_template_matches_issue_485_contract() -> None:
+    """PR template が issue #485 仕様の本文と一致することを保証する。"""
+    assert _read_text(_PR_TEMPLATE_PATH) == _PR_TEMPLATE_TEXT
+
+
+def test_ci_workflow_declares_changelog_job_for_pull_requests_only() -> None:
+    """changelog job は pull_request のみで動く独立 job である必要がある。"""
+    workflow = _load_ci_workflow()
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+
+    changelog_job = jobs.get("changelog")
+    assert isinstance(changelog_job, dict), "changelog job が存在しない"
+    assert changelog_job.get("runs-on") == "ubuntu-latest"
+    assert changelog_job.get("if") == _PR_EVENT_GUARD
+
+
+def test_ci_workflow_changelog_job_uses_expected_environment_contract() -> None:
+    """ラベル判定と base..head diff の入力は spec の GitHub context に固定する。"""
+    workflow = _load_ci_workflow()
+    changelog_step = workflow["jobs"]["changelog"]["steps"][1]
+
+    env = changelog_step.get("env")
+    assert env == {
+        "PR_LABELS": _LABELS_JOIN_EXPRESSION,
+        "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+        "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+    }
+
+
+def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
+    """要 CHANGELOG path, exempt label, error 文言の契約を固定する。"""
+    workflow = _load_ci_workflow()
+    steps = workflow["jobs"]["changelog"]["steps"]
+
+    checkout_step = steps[0]
+    assert checkout_step == {"uses": "actions/checkout@v4", "with": {"fetch-depth": 0}}
+
+    changelog_step = steps[1]
+    assert changelog_step.get("name") == "Check CHANGELOG update"
+
+    run_script = changelog_step.get("run")
+    assert isinstance(run_script, str), "run スクリプトが存在しない"
+    for expected_line in _EXPECTED_RUN_LINES:
+        assert expected_line in run_script
+
+    assert _CHANGELOG_LABEL in run_script
+    assert _CHANGELOG_FILE_PATTERN in run_script
+    assert (
+        "::error::CHANGELOG.md must be updated under [Unreleased]. Add an entry or apply 'skip-changelog' label."
+        in run_script
+    )


### PR DESCRIPTION
## Summary

`[Unreleased]` を「PR 単位で書き溜める」運用に倒すため、PR template と CI 検証を整備した。著者は普段の PR で `[Unreleased]` に追記し、`/automation-release` prepare はそれを `[VER]` に昇格するだけになる。docs / tests / 内部リファクタのみの PR は `skip-changelog` ラベルで免除可。

- `.github/PULL_REQUEST_TEMPLATE.md` 新規。CHANGELOG / Migration / テストのチェックリスト
- `.github/workflows/ci.yml` に `changelog` job 追加。`pull_request` 限定で base..head の diff から要 CHANGELOG path（`src/youtube_automation/`, `.claude/skills/`, `.claude/CLAUDE.template.md`, `pyproject.toml`）を判定し、未更新なら fail。`skip-changelog` ラベルがあれば skip
- `tests/test_changelog_ci_contract.py` で PR template 本文・workflow 構造・必須メッセージ・環境変数契約を固定
- `skip-changelog` GitHub label は本 PR とは独立に作成済み

Closes #485

## Test plan

- [ ] `changelog` job の動作: 4 ケース確認
  - A: `src/` を変更 + CHANGELOG 未更新 → fail
  - B: `src/` を変更 + `CHANGELOG.md` 更新 → pass
  - C: `tests/` のみ変更 → 即 pass（path filter で skip）
  - D: `src/` を変更 + `skip-changelog` ラベル付与 → 即 pass
- [ ] `pytest tests/test_changelog_ci_contract.py` で 4 件 pass
- [ ] 既存 `lint` / `test` job が green
- [ ] 本 PR 自体: `.github/` のみ変更 + テスト 1 ファイル追加で path filter に該当しないため `changelog` job は「No significant code changes, skipping」で pass する想定

## 補足

- 本 PR は path filter 上 `src/`・`.claude/skills/`・`.claude/CLAUDE.template.md`・`pyproject.toml` のいずれにも該当しないため、`CHANGELOG.md` 更新なしで CI を通る設計
- takt-issue workflow は `skip-changelog` ラベル作成（worktree から remote 不可）で abort したため、commit 以降は手動実行。仕様自体は計画通り
- 関連: `docs/changelog-contract.md` の Migration セクション契約