### PR TITLE
feat(image_provider): Codex CLI 経由のサブスク認証で画像生成できる provider を追加 (#472)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -39,8 +39,21 @@ description: Use when コレクションのサムネイル画像が必要で、C
 |---|---|---|
 | `gemini` | Gemini Image (Nano Banana 系) | ADC (`GOOGLE_CLOUD_PROJECT` は任意で上書き可) |
 | `openai` | OpenAI gpt-image 系（CJK 文字描画が綺麗、16:9/9:16 ネイティブ対応） | `OPENAI_API_KEY` |
+| `codex` | Codex CLI 経由（ChatGPT サブスク認証、API 課金なし、agent 経路で遅め） | `codex login` 済みであること（API key 不要） |
 
 OpenAI provider 使用時は `image_generation.openai.aspect_ratio` を `"16:9"` または `"9:16"` のいずれかに設定（thumbnail スキルは内部で 16:9 固定）。
+
+Codex provider 使用時は事前に `codex login status` を実行し `Logged in using ChatGPT` 表示を確認すること。`imagegen` ツール経由のため Gemini/OpenAI 直 API より生成時間が長く、ChatGPT サブスクの fair-use 上限に当たる可能性もあるため、大量生成時は他 provider にフォールバックする運用を推奨。サポート aspect_ratio は `"16:9"` / `"9:16"` / `"1:1"` の 3 種。設定例:
+
+```yaml
+image_generation:
+  provider: codex
+  codex:
+    model: "gpt-image-1"
+    image_size: "1024x1024"
+    aspect_ratio: "16:9"     # "16:9" / "9:16" / "1:1"
+    timeout_seconds: 300     # `codex exec` 1 回あたりの上限
+```
 
 ## Channel Adaptation
 

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -163,3 +163,12 @@ image_generation:
     # 事前見積もりに使う 1 枚あたり単価を固定したい場合のみ指定する。
     # 未指定なら CLI 表示は「不明」となり、実コストは GCP Cloud Console > Billing で確認する。
     # cost_per_image_usd: null
+
+  # codex:
+  #   # Codex CLI 経由（ChatGPT サブスク認証）。API 課金 0 だが `codex exec` の
+  #   # agent 経路で遅め。事前に `codex login status` で
+  #   # "Logged in using ChatGPT" 表示を確認してから provider を切り替えること。
+  #   model: "gpt-image-1"
+  #   image_size: "1024x1024"
+  #   aspect_ratio: "16:9"      # "16:9" / "9:16" / "1:1" のみ
+  #   timeout_seconds: 300      # codex exec 1 回あたりの上限秒数

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(image_provider)`: Codex CLI 経由のサブスク認証で画像を生成する `CodexImageProvider` を追加（#472）。`utils/image_provider/codex.py` と `tests/test_image_provider_codex.py`、対応する `parse_image_generation_config()` 拡張・`thumbnail` skill 設定（`config.default.yaml` / `SKILL.md`）の Codex provider 切り替え対応を含む
+
 ## [5.5.2] - 2026-05-20
 
 ### Added

--- a/src/youtube_automation/utils/image_provider/__init__.py
+++ b/src/youtube_automation/utils/image_provider/__init__.py
@@ -54,6 +54,13 @@ def get_provider(cfg: ImageGenerationConfig) -> ImageProvider:
             raise ConfigError("provider=openai だが openai 設定が見つかりません")
         return OpenAIImageProvider(cfg.openai)
 
+    if cfg.provider == "codex":
+        from youtube_automation.utils.image_provider.codex import CodexImageProvider
+
+        if cfg.codex is None:
+            raise ConfigError("provider=codex だが codex 設定が見つかりません")
+        return CodexImageProvider(cfg.codex)
+
     raise ConfigError(f"未対応の provider={cfg.provider!r}")
 
 

--- a/src/youtube_automation/utils/image_provider/codex.py
+++ b/src/youtube_automation/utils/image_provider/codex.py
@@ -1,0 +1,174 @@
+"""Codex CLI（ChatGPT サブスク認証）経由の画像生成プロバイダー。
+
+`codex exec "..."` でエージェントに `imagegen` ツールを呼ばせ、プロンプト内で
+保存パスを指定して PNG を書き出させる。サブスク枠での生成のため API 課金は
+発生しない（事前に `codex login` 済みが前提）。
+
+`codex login status` をコンストラクタ初期化時に 1 回だけ実行して認証を確認する。
+画像生成 1 回ごとにこのチェックを走らせると agent 起動コストが嵩むため、
+プロバイダーインスタンスのライフタイム単位（通常 1 リクエスト = 1 インスタンス）で
+確認する設計とする。
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from youtube_automation.utils import cost_tracker
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.base import (
+    RETRY_MAX,
+    ImageGenerationRequest,
+    ImageGenerationResult,
+)
+from youtube_automation.utils.image_provider.composition import log_image_cost, persist_image
+from youtube_automation.utils.image_provider.config import CodexConfig
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+# Codex は agent 経路で 1 回あたり数十秒〜分単位で遅いため、共通 RETRY_BACKOFF
+# (10, 30, 60) より短いリトライ間隔を採用する。
+_CODEX_RETRY_BACKOFF: tuple[int, ...] = (5, 10, 20)
+
+# `codex login status` 自体は通常 1 秒以内で完了する軽量チェック。
+_LOGIN_STATUS_TIMEOUT = 30
+
+
+class CodexImageProvider:
+    """Codex CLI 経由で画像を 1 枚生成して保存する。"""
+
+    name = "codex"
+    supported_aspect_ratios: tuple[str, ...] = ("16:9", "9:16", "1:1")
+
+    def __init__(self, config: CodexConfig) -> None:
+        self._config = config
+        self._codex_bin = shutil.which("codex") or "codex"
+        self._ensure_logged_in()
+
+    def _ensure_logged_in(self) -> None:
+        try:
+            result = subprocess.run(
+                [self._codex_bin, "login", "status"],
+                text=True,
+                capture_output=True,
+                timeout=_LOGIN_STATUS_TIMEOUT,
+                check=False,
+            )
+        except FileNotFoundError as e:
+            raise ConfigError(
+                f"codex CLI が見つかりません ({self._codex_bin})。"
+                "Homebrew / nix 等でインストールし PATH を通してください。"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise ConfigError(
+                f"`codex login status` が {_LOGIN_STATUS_TIMEOUT} 秒以内に応答しません"
+            ) from e
+
+        output = (result.stdout or "") + (result.stderr or "")
+        if "Logged in" not in output:
+            raise ConfigError(
+                "codex login されていません。`codex login` を実行して ChatGPT アカウントで認証してください。"
+            )
+
+    def generate(self, req: ImageGenerationRequest) -> ImageGenerationResult:
+        """req に従って画像を生成して保存する。"""
+        from PIL import Image as PILImage
+
+        if req.aspect_ratio not in self.supported_aspect_ratios:
+            raise ConfigError(
+                f"Codex image_generation の aspect_ratio={req.aspect_ratio!r} は未対応。"
+                f"許容値: {self.supported_aspect_ratios}"
+            )
+
+        req.output_path.parent.mkdir(parents=True, exist_ok=True)
+        # 前回生成画像が残っていると「ファイル存在」だけでは成功判定できないため事前に削除
+        if req.output_path.exists():
+            req.output_path.unlink()
+
+        prompt = self._build_prompt(req)
+        cmd = [self._codex_bin, "exec", prompt]
+        timeout = self._config.timeout_seconds
+        model = self._config.model
+        save_as_png = req.output_path.suffix.lower() == ".png"
+
+        for attempt in range(RETRY_MAX):
+            ref_label = ""
+            if req.references:
+                names = ", ".join(r.name for r in req.references)
+                ref_label = f" + 参照画像={names}"
+            print(
+                f"  [Submit] codex exec model={model} size={self._config.image_size} "
+                f"aspect={req.aspect_ratio}{ref_label}"
+            )
+
+            failure_reason: str | None = None
+            try:
+                result = subprocess.run(
+                    cmd,
+                    text=True,
+                    capture_output=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired:
+                failure_reason = f"timeout ({timeout}s)"
+                result = None
+
+            if result is not None:
+                if result.returncode != 0:
+                    stderr_tail = (result.stderr or "")[-200:].strip()
+                    failure_reason = f"rc={result.returncode} {stderr_tail}"
+                elif not self._is_valid_png(req.output_path):
+                    failure_reason = "出力ファイルなし or PNG ヘッダ不正"
+
+            if failure_reason is None:
+                pil_image = PILImage.open(io.BytesIO(req.output_path.read_bytes()))
+                saved_path = persist_image(pil_image, req.output_path, save_as_png=save_as_png)
+                entry = log_image_cost(
+                    model=model,
+                    image_size=self._config.image_size,
+                    aspect_ratio=req.aspect_ratio,
+                    output_file=saved_path,
+                    reference_count=len(req.references),
+                )
+                cost_tracker.print_last_report(entry)
+                return ImageGenerationResult(success=True, saved_path=saved_path)
+
+            print(f"  [Retry]  attempt {attempt + 1}/{RETRY_MAX}: {failure_reason}")
+            # 失敗時は中途半端な出力ファイルを残さない（次回リトライの誤判定を防ぐ）
+            if req.output_path.exists():
+                req.output_path.unlink()
+
+            if attempt < RETRY_MAX - 1:
+                backoff = _CODEX_RETRY_BACKOFF[attempt]
+                print(f"  [Wait]   {backoff}秒待機...")
+                time.sleep(backoff)
+
+        return ImageGenerationResult(success=False, saved_path=None)
+
+    def _build_prompt(self, req: ImageGenerationRequest) -> str:
+        reference_block = ""
+        if req.references:
+            paths = "\n".join(f"- {p}" for p in req.references)
+            reference_block = f"\nReference images (read for style and composition):\n{paths}\n"
+        return (
+            "Use the imagegen tool to generate exactly one image.\n"
+            f"Save the result as PNG to: {req.output_path}\n"
+            f"Size: {self._config.image_size}\n"
+            f"Aspect ratio: {req.aspect_ratio}\n"
+            f"Model: {self._config.model}\n"
+            f"{reference_block}"
+            "Description:\n"
+            f"{req.prompt}\n"
+        )
+
+    @staticmethod
+    def _is_valid_png(path: Path) -> bool:
+        if not path.exists() or path.stat().st_size < len(_PNG_MAGIC):
+            return False
+        with path.open("rb") as f:
+            return f.read(len(_PNG_MAGIC)) == _PNG_MAGIC

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -17,8 +17,8 @@ from typing import Any, Literal
 from youtube_automation.utils.exceptions import ConfigError
 
 # プロバイダー識別子。`get_provider` の dispatch キーと一致させる。
-ProviderName = Literal["gemini", "openai"]
-SUPPORTED_PROVIDERS: tuple[str, ...] = ("gemini", "openai")
+ProviderName = Literal["gemini", "openai", "codex"]
+SUPPORTED_PROVIDERS: tuple[str, ...] = ("gemini", "openai", "codex")
 
 # OpenAI が受理するアスペクト比（order.md "期待する動作 1": 16:9 と 9:16 のみ）
 OPENAI_SUPPORTED_ASPECT_RATIOS: tuple[str, ...] = ("16:9", "9:16")
@@ -26,6 +26,12 @@ OPENAI_SUPPORTED_ASPECT_RATIOS: tuple[str, ...] = ("16:9", "9:16")
 # 既定値（skill-config 不在時のフォールバック）
 _DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-image-preview"
 _DEFAULT_GEMINI_IMAGE_SIZE = "2K"
+
+# Codex CLI 既定値（imagegen tool のデフォルトに合わせる）
+_DEFAULT_CODEX_MODEL = "gpt-image-1"
+_DEFAULT_CODEX_IMAGE_SIZE = "1024x1024"
+_DEFAULT_CODEX_ASPECT_RATIO = "16:9"
+_DEFAULT_CODEX_TIMEOUT = 300
 
 
 @dataclass(frozen=True)
@@ -65,6 +71,21 @@ class OpenAIConfig:
 
 
 @dataclass(frozen=True)
+class CodexConfig:
+    """Codex CLI（ChatGPT サブスク認証）経由の画像生成プロバイダー設定。
+
+    `codex exec` 経由で `imagegen` ツールを呼ぶため、追加の API key は不要
+    （事前に `codex login` 済みであることが前提）。サブスク枠での生成のため
+    cost_tracker への金額計上は 0 扱い。
+    """
+
+    model: str = _DEFAULT_CODEX_MODEL
+    image_size: str = _DEFAULT_CODEX_IMAGE_SIZE
+    aspect_ratio: str = _DEFAULT_CODEX_ASPECT_RATIO
+    timeout_seconds: int = _DEFAULT_CODEX_TIMEOUT
+
+
+@dataclass(frozen=True)
 class ImageGenerationConfig:
     """provider 切り替え可能な画像生成設定の親 dataclass。
 
@@ -75,6 +96,7 @@ class ImageGenerationConfig:
     provider: ProviderName
     gemini: GeminiConfig | None = None
     openai: OpenAIConfig | None = None
+    codex: CodexConfig | None = None
 
     @classmethod
     def default(cls) -> "ImageGenerationConfig":
@@ -83,6 +105,7 @@ class ImageGenerationConfig:
             provider="gemini",
             gemini=GeminiConfig(model=_DEFAULT_GEMINI_MODEL, image_size=_DEFAULT_GEMINI_IMAGE_SIZE),
             openai=None,
+            codex=None,
         )
 
 
@@ -123,10 +146,14 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
 
     if provider == "gemini":
         gemini_cfg = _build_gemini(section.get("gemini") or {})
-        return ImageGenerationConfig(provider="gemini", gemini=gemini_cfg, openai=None)
+        return ImageGenerationConfig(provider="gemini", gemini=gemini_cfg, openai=None, codex=None)
 
-    openai_cfg = _build_openai(section.get("openai") or {})
-    return ImageGenerationConfig(provider="openai", gemini=None, openai=openai_cfg)
+    if provider == "openai":
+        openai_cfg = _build_openai(section.get("openai") or {})
+        return ImageGenerationConfig(provider="openai", gemini=None, openai=openai_cfg, codex=None)
+
+    codex_cfg = _build_codex(section.get("codex") or {})
+    return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
 
 def _build_from_legacy_gemini(legacy: dict[str, Any]) -> ImageGenerationConfig:
@@ -135,6 +162,7 @@ def _build_from_legacy_gemini(legacy: dict[str, Any]) -> ImageGenerationConfig:
         provider="gemini",
         gemini=_build_gemini(legacy),
         openai=None,
+        codex=None,
     )
 
 
@@ -155,6 +183,15 @@ def _build_openai(d: dict[str, Any]) -> OpenAIConfig:
     )
 
 
+def _build_codex(d: dict[str, Any]) -> CodexConfig:
+    return CodexConfig(
+        model=d.get("model", _DEFAULT_CODEX_MODEL),
+        image_size=d.get("image_size", _DEFAULT_CODEX_IMAGE_SIZE),
+        aspect_ratio=d.get("aspect_ratio", _DEFAULT_CODEX_ASPECT_RATIO),
+        timeout_seconds=int(d.get("timeout_seconds", _DEFAULT_CODEX_TIMEOUT)),
+    )
+
+
 def replace_model(cfg: ImageGenerationConfig, model: str) -> ImageGenerationConfig:
     """``ImageGenerationConfig`` の active provider 側のモデル ID を差し替えた複製を返す。
 
@@ -169,4 +206,8 @@ def replace_model(cfg: ImageGenerationConfig, model: str) -> ImageGenerationConf
         if cfg.openai is None:
             raise ConfigError("provider=openai だが openai 設定が見つかりません")
         return replace(cfg, openai=replace(cfg.openai, model=model))
+    if cfg.provider == "codex":
+        if cfg.codex is None:
+            raise ConfigError("provider=codex だが codex 設定が見つかりません")
+        return replace(cfg, codex=replace(cfg.codex, model=model))
     raise ConfigError(f"未対応の provider={cfg.provider!r}")

--- a/tests/test_image_provider_codex.py
+++ b/tests/test_image_provider_codex.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import io
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_image_provider_codex.py
+++ b/tests/test_image_provider_codex.py
@@ -1,0 +1,399 @@
+"""CodexImageProvider の単体テスト（codex CLI 経由のサブスク認証）。
+
+`subprocess.run` をモックして以下を検証する:
+
+1. コンストラクタで `codex login status` が実行される
+2. 未ログイン状態は `ConfigError`
+3. codex CLI が見つからない場合は `ConfigError`
+4. 正常系で `codex exec` が呼ばれ PNG + JPG 派生が保存される
+5. タイムアウト時はリトライ、後続で成功
+6. 出力ファイル未生成 / PNG ヘッダ不正はリトライして最終失敗
+7. プロンプトに output_path / size / aspect_ratio / reference が含まれる
+8. 成功時に `log_image_cost` が呼ばれる
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.base import ImageGenerationRequest
+from youtube_automation.utils.image_provider.codex import CodexImageProvider
+from youtube_automation.utils.image_provider.config import CodexConfig
+
+# ---------- ヘルパー ----------
+
+
+def _png_bytes() -> bytes:
+    """16x16 のダミー PNG バイナリ。"""
+    from PIL import Image as PILImage
+
+    buf = io.BytesIO()
+    PILImage.new("RGB", (16, 16), color=(200, 220, 255)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _login_ok_result(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=cmd, returncode=0, stdout="Logged in using ChatGPT (sub@example.com)", stderr=""
+    )
+
+
+def _login_not_logged_result(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=cmd, returncode=1, stdout="", stderr="Not logged in. Run `codex login`."
+    )
+
+
+def _extract_save_path_from_prompt(prompt: str) -> Path | None:
+    """`Save the result as PNG to: <path>` 行から保存パスを抽出する。"""
+    for line in prompt.splitlines():
+        if line.startswith("Save the result as PNG to:"):
+            return Path(line.split(":", 1)[1].strip())
+    return None
+
+
+class _ExecRunner:
+    """`codex exec` 呼び出し時の挙動を制御する side_effect ファクトリ。
+
+    sequence で複数回呼び出しの挙動を順次切り替える。各エントリは:
+      - "ok"      : PNG を書いて rc=0
+      - "no-file" : ファイル書かずに rc=0（出力ファイル未生成シナリオ）
+      - "bad-png" : PNG マジック以外を書いて rc=0（ヘッダ不正シナリオ）
+      - "rc-fail" : ファイル書かずに rc=1（rc != 0 シナリオ）
+      - "timeout" : `subprocess.TimeoutExpired` を raise
+    """
+
+    def __init__(self, login_ok: bool, sequence: list[str]):
+        self.login_ok = login_ok
+        self.sequence = list(sequence)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        # cmd は ["codex", "login", "status"] または ["codex", "exec", <prompt>]
+        if len(cmd) >= 2 and cmd[1] == "login":
+            return _login_ok_result(cmd) if self.login_ok else _login_not_logged_result(cmd)
+
+        # exec 呼び出し
+        action = self.sequence.pop(0) if self.sequence else "ok"
+        prompt = cmd[2] if len(cmd) >= 3 else ""
+        save_path = _extract_save_path_from_prompt(prompt)
+
+        if action == "timeout":
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+        if action == "rc-fail":
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="imagegen error")
+        if action == "no-file":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="done", stderr="")
+        if action == "bad-png":
+            if save_path is not None:
+                save_path.parent.mkdir(parents=True, exist_ok=True)
+                save_path.write_bytes(b"NOT_A_PNG_FILE_CONTENT" + b"\x00" * 64)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="done", stderr="")
+        # "ok"
+        if save_path is not None:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            save_path.write_bytes(_png_bytes())
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="done", stderr="")
+
+
+# ---------- フィクスチャ ----------
+
+
+@pytest.fixture
+def codex_config() -> CodexConfig:
+    return CodexConfig(
+        model="gpt-image-1",
+        image_size="1024x1024",
+        aspect_ratio="16:9",
+        timeout_seconds=60,
+    )
+
+
+@pytest.fixture
+def request_factory(tmp_path: Path):
+    def _make(
+        *,
+        prompt: str = "a quiet cafe with steaming coffee",
+        references: list[Path] | None = None,
+        aspect_ratio: str = "16:9",
+        image_size: str = "1024x1024",
+        output_name: str = "out.png",
+    ) -> ImageGenerationRequest:
+        return ImageGenerationRequest(
+            prompt=prompt,
+            output_path=tmp_path / output_name,
+            aspect_ratio=aspect_ratio,
+            image_size=image_size,
+            references=list(references or []),
+        )
+
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """リトライバックオフを高速化。"""
+    monkeypatch.setattr(
+        "youtube_automation.utils.image_provider.codex.time.sleep",
+        lambda s: None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_codex_which(monkeypatch):
+    """`shutil.which("codex")` を fake パスに固定。"""
+    monkeypatch.setattr(
+        "youtube_automation.utils.image_provider.codex.shutil.which",
+        lambda _name: "/fake/codex",
+    )
+
+
+def _patch_subprocess(runner: _ExecRunner):
+    return patch(
+        "youtube_automation.utils.image_provider.codex.subprocess.run",
+        side_effect=runner,
+    )
+
+
+# ---------- 認証チェック ----------
+
+
+class TestLoginStatusCheck:
+    def test_login_status_checked_in_constructor(self, codex_config: CodexConfig):
+        # Given
+        runner = _ExecRunner(login_ok=True, sequence=[])
+
+        # When
+        with _patch_subprocess(runner):
+            CodexImageProvider(codex_config)
+
+        # Then: 最初の subprocess 呼び出しが `codex login status`
+        assert runner.calls, "subprocess.run が呼ばれていない"
+        first_call = runner.calls[0]
+        assert first_call[0] == "/fake/codex"
+        assert first_call[1:] == ["login", "status"]
+
+    def test_unauthenticated_raises_config_error(self, codex_config: CodexConfig):
+        # Given: `codex login status` が Not logged in を返す
+        runner = _ExecRunner(login_ok=False, sequence=[])
+
+        # When / Then
+        with _patch_subprocess(runner), pytest.raises(ConfigError, match="codex login"):
+            CodexImageProvider(codex_config)
+
+    def test_codex_binary_not_found_raises_config_error(self, codex_config: CodexConfig):
+        # Given: subprocess.run が FileNotFoundError を投げる
+        with patch(
+            "youtube_automation.utils.image_provider.codex.subprocess.run",
+            side_effect=FileNotFoundError("codex"),
+        ):
+            # When / Then
+            with pytest.raises(ConfigError, match="codex CLI が見つかりません"):
+                CodexImageProvider(codex_config)
+
+    def test_login_status_timeout_raises_config_error(self, codex_config: CodexConfig):
+        # Given: subprocess.run が TimeoutExpired を投げる
+        with patch(
+            "youtube_automation.utils.image_provider.codex.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="codex login status", timeout=30),
+        ):
+            # When / Then
+            with pytest.raises(ConfigError, match="codex login status"):
+                CodexImageProvider(codex_config)
+
+
+# ---------- 生成成功系 ----------
+
+
+class TestGenerateSuccess:
+    def test_generate_success_creates_png_and_jpg(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given
+        runner = _ExecRunner(login_ok=True, sequence=["ok"])
+        req = request_factory(output_name="out.png")
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is True
+        assert result.saved_path == req.output_path
+        # PNG が存在
+        assert req.output_path.exists()
+        # JPG 派生も生成（既存 persist_image の挙動）
+        jpg_path = req.output_path.with_suffix(".jpg")
+        assert jpg_path.exists(), f"JPG 派生 {jpg_path} が生成されていない"
+
+    def test_generate_timeout_then_success(self, codex_config: CodexConfig, request_factory):
+        # Given: 1 回目 timeout → 2 回目 ok
+        runner = _ExecRunner(login_ok=True, sequence=["timeout", "ok"])
+        req = request_factory()
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is True
+        # exec が 2 回呼ばれている（login 1 回 + exec 2 回 = 計 3 回）
+        exec_calls = [c for c in runner.calls if len(c) >= 2 and c[1] == "exec"]
+        assert len(exec_calls) == 2
+
+
+# ---------- 生成失敗系 ----------
+
+
+class TestGenerateFailures:
+    def test_generate_no_output_file_retries_then_fails(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given: 全リトライで exec rc=0 だが出力ファイル未生成
+        runner = _ExecRunner(login_ok=True, sequence=["no-file", "no-file", "no-file"])
+        req = request_factory()
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is False
+        assert result.saved_path is None
+        # 3 回 exec を試行
+        exec_calls = [c for c in runner.calls if len(c) >= 2 and c[1] == "exec"]
+        assert len(exec_calls) == 3
+
+    def test_generate_invalid_png_header_fails(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given: PNG マジック以外のバイトを書く
+        runner = _ExecRunner(login_ok=True, sequence=["bad-png", "bad-png", "bad-png"])
+        req = request_factory()
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is False
+
+    def test_generate_rc_nonzero_retries_then_fails(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given: 全リトライで rc != 0
+        runner = _ExecRunner(login_ok=True, sequence=["rc-fail", "rc-fail", "rc-fail"])
+        req = request_factory()
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is False
+
+    def test_generate_rejects_unsupported_aspect_ratio(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given: imagegen は 16:9 / 9:16 / 1:1 のみ
+        runner = _ExecRunner(login_ok=True, sequence=[])
+        req = request_factory(aspect_ratio="4:3")
+
+        # When / Then
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            with pytest.raises(ConfigError, match="aspect_ratio"):
+                provider.generate(req)
+
+
+# ---------- プロンプト構築 ----------
+
+
+class TestPromptConstruction:
+    def test_prompt_contains_output_path_size_and_aspect_ratio(
+        self, codex_config: CodexConfig, request_factory
+    ):
+        # Given
+        runner = _ExecRunner(login_ok=True, sequence=["ok"])
+        req = request_factory(prompt="MAGIC_PROMPT_TOKEN_123", aspect_ratio="9:16")
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            provider.generate(req)
+
+        # Then: exec 呼び出しのプロンプト引数に必須要素が含まれる
+        exec_calls = [c for c in runner.calls if len(c) >= 2 and c[1] == "exec"]
+        assert exec_calls, "codex exec が呼ばれていない"
+        prompt_arg = exec_calls[0][2]
+        assert str(req.output_path) in prompt_arg
+        assert codex_config.image_size in prompt_arg
+        assert "9:16" in prompt_arg
+        assert "MAGIC_PROMPT_TOKEN_123" in prompt_arg
+        assert codex_config.model in prompt_arg
+        # 保存パス指示行を明示
+        assert "Save the result as PNG to:" in prompt_arg
+
+    def test_prompt_includes_reference_images_when_provided(
+        self, codex_config: CodexConfig, request_factory, tmp_path: Path
+    ):
+        # Given: 参照画像 2 枚
+        ref1 = tmp_path / "ref-a.png"
+        ref2 = tmp_path / "ref-b.png"
+        ref1.write_bytes(_png_bytes())
+        ref2.write_bytes(_png_bytes())
+        runner = _ExecRunner(login_ok=True, sequence=["ok"])
+        req = request_factory(references=[ref1, ref2])
+
+        # When
+        with _patch_subprocess(runner):
+            provider = CodexImageProvider(codex_config)
+            provider.generate(req)
+
+        # Then
+        exec_calls = [c for c in runner.calls if len(c) >= 2 and c[1] == "exec"]
+        prompt_arg = exec_calls[0][2]
+        assert "Reference images" in prompt_arg
+        assert str(ref1) in prompt_arg
+        assert str(ref2) in prompt_arg
+
+
+# ---------- コスト記録 ----------
+
+
+class TestCostLogging:
+    def test_log_image_cost_called_on_success(self, codex_config: CodexConfig, request_factory):
+        # Given
+        runner = _ExecRunner(login_ok=True, sequence=["ok"])
+        req = request_factory()
+
+        # When
+        with _patch_subprocess(runner), patch(
+            "youtube_automation.utils.image_provider.codex.log_image_cost",
+            return_value={"category": "image", "cost_usd": 0.0},
+        ) as mock_log, patch(
+            "youtube_automation.utils.image_provider.codex.cost_tracker.print_last_report",
+        ):
+            provider = CodexImageProvider(codex_config)
+            result = provider.generate(req)
+
+        # Then
+        assert result.success is True
+        assert mock_log.call_count == 1
+        call_kwargs = mock_log.call_args.kwargs
+        assert call_kwargs["model"] == codex_config.model
+        assert call_kwargs["image_size"] == codex_config.image_size
+        assert call_kwargs["aspect_ratio"] == req.aspect_ratio
+        assert call_kwargs["reference_count"] == 0

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -14,7 +14,6 @@ import pytest
 
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider.config import (
-    CodexConfig,
     GeminiConfig,
     ImageGenerationConfig,
     OpenAIConfig,

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -14,6 +14,7 @@ import pytest
 
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider.config import (
+    CodexConfig,
     GeminiConfig,
     ImageGenerationConfig,
     OpenAIConfig,
@@ -119,6 +120,71 @@ class TestParseImageGenerationConfig:
         assert cfg.provider == "openai"
         assert cfg.openai.model == "gpt-image-2"
 
+    def test_parses_image_generation_namespace_for_codex(self):
+        # Given: 新 namespace + provider=codex（全フィールド明示）
+        skill_cfg = {
+            "image_generation": {
+                "provider": "codex",
+                "codex": {
+                    "model": "gpt-image-1",
+                    "image_size": "1024x1024",
+                    "aspect_ratio": "9:16",
+                    "timeout_seconds": 600,
+                },
+            }
+        }
+
+        # When
+        cfg = parse_image_generation_config(skill_cfg)
+
+        # Then
+        assert cfg.provider == "codex"
+        assert cfg.codex is not None
+        assert cfg.codex.model == "gpt-image-1"
+        assert cfg.codex.image_size == "1024x1024"
+        assert cfg.codex.aspect_ratio == "9:16"
+        assert cfg.codex.timeout_seconds == 600
+        # 他 provider 側は None
+        assert cfg.gemini is None
+        assert cfg.openai is None
+
+    def test_codex_config_uses_defaults_when_fields_missing(self):
+        # Given: codex セクションが空 dict（既定値フォールバックを期待）
+        skill_cfg = {
+            "image_generation": {
+                "provider": "codex",
+                "codex": {},
+            }
+        }
+
+        # When
+        cfg = parse_image_generation_config(skill_cfg)
+
+        # Then: CodexConfig の既定値が適用される
+        assert cfg.provider == "codex"
+        assert cfg.codex is not None
+        assert cfg.codex.model == "gpt-image-1"
+        assert cfg.codex.image_size == "1024x1024"
+        assert cfg.codex.aspect_ratio == "16:9"
+        assert cfg.codex.timeout_seconds == 300
+
+    def test_codex_config_casts_timeout_seconds_to_int(self):
+        # Given: timeout_seconds が文字列で渡される（YAML パーサーが str を返すケース）
+        skill_cfg = {
+            "image_generation": {
+                "provider": "codex",
+                "codex": {"timeout_seconds": "450"},
+            }
+        }
+
+        # When
+        cfg = parse_image_generation_config(skill_cfg)
+
+        # Then: int にキャストされる
+        assert cfg.codex is not None
+        assert cfg.codex.timeout_seconds == 450
+        assert isinstance(cfg.codex.timeout_seconds, int)
+
     def test_unknown_provider_raises_config_error(self):
         # Given: 未対応 provider 名
         skill_cfg = {
@@ -129,6 +195,14 @@ class TestParseImageGenerationConfig:
 
         # When / Then
         with pytest.raises(ConfigError, match="midjourney"):
+            parse_image_generation_config(skill_cfg)
+
+    def test_unknown_provider_error_lists_codex_in_supported_values(self):
+        # Given: 未対応 provider 名
+        skill_cfg = {"image_generation": {"provider": "midjourney"}}
+
+        # When / Then: エラーメッセージ内に "codex" を含む（SUPPORTED_PROVIDERS に追加されたこと）
+        with pytest.raises(ConfigError, match="codex"):
             parse_image_generation_config(skill_cfg)
 
     def test_empty_skill_cfg_returns_default_config(self):

--- a/tests/test_image_provider_factory.py
+++ b/tests/test_image_provider_factory.py
@@ -1,16 +1,20 @@
 """image_provider のファクトリ関数 `get_provider()` の単体テスト。
 
 `ImageGenerationConfig.provider` の値に応じて
-`GeminiImageProvider` / `OpenAIImageProvider` の正しい実装が返されることを検証する。
+`GeminiImageProvider` / `OpenAIImageProvider` / `CodexImageProvider` の
+正しい実装が返されることを検証する。
 """
 
 from __future__ import annotations
+
+import subprocess
 
 import pytest
 
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider import get_provider
 from youtube_automation.utils.image_provider.config import (
+    CodexConfig,
     GeminiConfig,
     ImageGenerationConfig,
     OpenAIConfig,
@@ -24,6 +28,7 @@ def _gemini_config() -> ImageGenerationConfig:
         provider="gemini",
         gemini=GeminiConfig(model="gemini-3.1-flash-image-preview", image_size="2K"),
         openai=None,
+        codex=None,
     )
 
 
@@ -38,7 +43,39 @@ def _openai_config() -> ImageGenerationConfig:
             thinking="medium",
             batch=1,
         ),
+        codex=None,
     )
+
+
+def _codex_config() -> ImageGenerationConfig:
+    return ImageGenerationConfig(
+        provider="codex",
+        gemini=None,
+        openai=None,
+        codex=CodexConfig(
+            model="gpt-image-1",
+            image_size="1024x1024",
+            aspect_ratio="16:9",
+            timeout_seconds=300,
+        ),
+    )
+
+
+@pytest.fixture
+def stub_codex_login(monkeypatch):
+    """`CodexImageProvider` のコンストラクタが走らせる `codex login status` を mock する。"""
+    import youtube_automation.utils.image_provider.codex as codex_mod
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="Logged in using ChatGPT",
+            stderr="",
+        )
+
+    monkeypatch.setattr(codex_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(codex_mod.shutil, "which", lambda _: "/fake/codex")
 
 
 class TestGetProvider:
@@ -63,6 +100,27 @@ class TestGetProvider:
         # Then
         assert isinstance(provider, OpenAIImageProvider)
         assert provider.name == "openai"
+
+    def test_returns_codex_provider_when_provider_is_codex(self, stub_codex_login):
+        # Given: codex CLI が "Logged in" を返す状態（fixture で mock 済み）
+        from youtube_automation.utils.image_provider.codex import CodexImageProvider
+
+        cfg = _codex_config()
+
+        # When
+        provider = get_provider(cfg)
+
+        # Then
+        assert isinstance(provider, CodexImageProvider)
+        assert provider.name == "codex"
+
+    def test_get_provider_raises_when_codex_config_missing(self):
+        # Given: provider=codex なのに codex sub-config が None
+        cfg = ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=None)
+
+        # When / Then
+        with pytest.raises(ConfigError, match="provider=codex"):
+            get_provider(cfg)
 
     def test_unknown_provider_raises_config_error(self):
         # Given: 強制的に provider 名を破壊（ImageGenerationConfig は frozen でも
@@ -122,3 +180,10 @@ class TestSupportedAspectRatios:
         # When / Then: Gemini は branding/icon.png 用途で 1:1 等を受け付ける
         # supported_aspect_ratios は空タプル or 全許可マーカーで表現
         assert len(provider.supported_aspect_ratios) == 0 or "16:9" in provider.supported_aspect_ratios
+
+    def test_codex_supports_16_9_9_16_and_1_1(self, stub_codex_login):
+        # Given / When
+        provider = get_provider(_codex_config())
+
+        # Then: imagegen ツール出力の安定性確保のため 3 比率に制限
+        assert set(provider.supported_aspect_ratios) == {"16:9", "9:16", "1:1"}


### PR DESCRIPTION
## Summary

- ChatGPT サブスクで認証済みの `codex` CLI を `subprocess` で呼び、`imagegen` ツールに直接 PNG を書かせる新 image provider `CodexImageProvider` を追加。
- `image_generation.provider: codex` で選択可能にし、API key 不要・追加課金 0 の経路を提供。
- thumbnail スキルの「プロバイダー切り替え」表と `config.default.yaml` に使い方を記述（デフォルトは `gemini` のまま据え置き）。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `src/youtube_automation/utils/image_provider/codex.py` | `CodexImageProvider` 新規実装（`codex login status` チェック、`codex exec` 呼び出し、PNG マジック検証、`persist_image` で JPG 派生生成、`log_image_cost` でメタ記録） |
| `src/youtube_automation/utils/image_provider/config.py` | `CodexConfig` 追加、`ProviderName`/`SUPPORTED_PROVIDERS` 拡張、`_build_codex` / `replace_model` の codex 分岐 |
| `src/youtube_automation/utils/image_provider/__init__.py` | `get_provider()` に codex 分岐追加 |
| `tests/test_image_provider_codex.py` | 13 ケース（認証チェック / 生成成功 / リトライ / 失敗 / プロンプト構築 / コスト記録） |
| `tests/test_image_provider_factory.py` | codex provider の factory 分岐 3 ケース追加 |
| `tests/test_image_provider_config.py` | `CodexConfig` パーステスト 4 ケース追加 |
| `.claude/skills/thumbnail/SKILL.md` | プロバイダー切り替え表に `codex` 行と注意書きを追記 |
| `.claude/skills/thumbnail/config.default.yaml` | コメントアウトされた `codex:` セクションのサンプルを追加 |

## 設計上のポイント

- 認証チェック (`codex login status`) はコンストラクタで 1 回。未ログインや CLI 不在は `ConfigError` で fail fast。
- リトライは共通 `RETRY_MAX=3` 流用 + 独自バックオフ `(5, 10, 20)` 秒（agent 経路は遅いので 60s 待つ意味が薄い）。
- `subprocess.TimeoutExpired` / rc != 0 / 出力ファイルなし / PNG マジック不正をすべて failure として扱いリトライ対象。
- `supported_aspect_ratios = ("16:9", "9:16", "1:1")` に制限（imagegen 出力の安定性確保）。
- 成功時は `PIL.Image.open(...)` で読み直し `persist_image(..., save_as_png=True)` を介して JPG 派生も生成（既存 Gemini/OpenAI と挙動統一）。
- cost_tracker への記録はサブスク枠のため metadata のみ（金額計上 0）。

## スコープ外

- skill 側のデフォルト切り替え（`provider: gemini` 据え置き）
- API key 経由の codex 認証サポート（サブスク特化）
- コスト計測（`log_image_cost` の cost_usd は 0 固定）

## Test plan

- [x] `uv run pytest tests/test_image_provider_codex.py -v` → 13 件 green
- [x] `uv run pytest tests/test_image_provider_factory.py tests/test_image_provider_config.py -v` → 既存 + 新規 ケース全 green
- [x] `uv run pytest tests/test_image_provider_gemini.py tests/test_image_provider_openai.py` → リグレッションなし
- [ ] E2E: `codex login status` で Logged in を確認後、`config/skills/thumbnail.yaml` で `provider: codex` に切り替え `yt-generate-image` で実生成（リリース前の手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)