### PR TITLE
feat(claude): プロジェクト共有 hooks を .claude/settings.json に導入 (#518)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *auth/client_secrets.json|*auth/token.json|*.env|*/uv.lock|*/flake.lock) echo \"BLOCKED: $f は AI から直接編集禁止。専用ツール（uv lock / op など）経由で更新してください\" >&2; exit 2;; esac; done"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "files=$(echo \"$CLAUDE_FILE_PATHS\" | tr ' ' '\\n' | grep '\\.py$' || true); if [ -n \"$files\" ]; then uv run ruff format $files >/dev/null 2>&1 && uv run ruff check --fix $files >/dev/null 2>&1 || true; fi"
+          },
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *src/youtube_automation/*|*.claude/skills/*|*.claude/CLAUDE.template.md|*pyproject.toml) echo \"NOTE: $f は CHANGELOG 必須エリア。PR 出す前に CHANGELOG.md [Unreleased] に追記すること（skip-changelog ラベルで escape 可）\" >&2; break;; esac; done; exit 0"
+          },
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *.claude/skills/*) echo \"NOTE: .claude/skills/ を編集しました。下流配布対象なのでマージ後は下流リポジトリ側で /automation-update での追従を忘れずに\" >&2; break;; esac; done; exit 0"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || true); branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); if [ \"$root\" = \"/Users/mba/02-yt/automation\" ] && [ \"$branch\" = \"main\" ]; then echo '⚠️  main tree の main branch にいます。コード編集を始める前に worktree（takt or .worktrees/<slug>/）へ移動してください'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #518

## Summary

`.claude/settings.json` を新規追加し、本リポジトリ固有の hooks を 5 件まとめて導入する（現状 hooks は 0 件）。`/claude-code-setup:claude-automation-recommender` の分析結果に基づき、CI lint 失敗削減・機密事故防止・CLAUDE.md 遵守の 3 観点で選定。

## Hooks 一覧

| # | Type | Matcher | 動作 |
|---|---|---|---|
| 1 | PreToolUse | Edit/Write | 機密ファイル (`auth/client_secrets.json` / `auth/token.json` / `.env` / `uv.lock` / `flake.lock`) の AI 直接編集を **exit 2 でブロック** |
| 2 | PostToolUse | Edit/Write/NotebookEdit | `.py` 編集後に `uv run ruff format` + `ruff check --fix` を自動実行 |
| 3 | PostToolUse | Edit/Write/NotebookEdit | CHANGELOG 必須エリア (`src/youtube_automation/`, `.claude/skills/`, `.claude/CLAUDE.template.md`, `pyproject.toml`) 編集時にリマインダー出力 |
| 4 | PostToolUse | Edit/Write/NotebookEdit | `.claude/skills/` 編集時は下流配布の `/automation-update` 追従リマインダー |
| 5 | UserPromptSubmit | (全プロンプト) | main tree かつ main branch にいる場合、worktree 移動を促す警告をコンテキストに注入 |

## 検証済み

- [x] `python3 -c 'import json; json.load(open(".claude/settings.json"))'` で JSON 構文 OK
- [x] secret block: `CLAUDE_FILE_PATHS=auth/token.json` で exit 2 確認
- [x] CHANGELOG notice: `CLAUDE_FILE_PATHS=src/...` で stderr に通知出力 + exit 0
- [x] ruff hook: `src/youtube_automation/utils/secrets.py` 相当で `ruff format` + `ruff check --fix` がエラーなく完走

## Notes

- 既存の `.claude/settings.local.json` は個人 permission 用なのでそのまま残置。本 PR は **チーム共有用** の `.claude/settings.json` を追加するだけ。
- CHANGELOG 更新対象外（`.claude/settings.json` は CI の必須エリアに含まれない）。

## Test Plan

- [ ] PR マージ後、ローカルで Claude Code を再起動して `.py` ファイル編集時に ruff format が走ることを確認
- [ ] `auth/token.json` の編集を試して BLOCKED が出ることを確認
- [ ] main tree の main branch で何かプロンプトを送って警告が出ることを確認