### PR TITLE
refactor(agents): CollectionPaths を agents 全体で採用統一 (#357)

### DIFF
--- a/src/youtube_automation/agents/collection_uploader.py
+++ b/src/youtube_automation/agents/collection_uploader.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader  # noqa: E402
 from youtube_automation.scripts.playlist_manager import PlaylistManager  # noqa: E402
+from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
@@ -217,7 +218,7 @@ class CollectionUploader:
     # ─── Tracking ────────────────────────────────
 
     def _get_tracking_path(self, collection_path: Path) -> Path:
-        return collection_path / "20-documentation" / "upload_tracking.json"
+        return CollectionPaths(collection_path).tracking_path
 
     def _load_tracking(self, collection_path: Path) -> dict | None:
         """tracking ファイル読み込み"""
@@ -381,7 +382,7 @@ class CollectionUploader:
 
     def _assign_to_playlists(self, video_id: str, collection_path: Path):
         """アップロード後にプレイリストへ自動追加（失敗してもアップロードはブロックしない）"""
-        ws_path = collection_path / "workflow-state.json"
+        ws_path = CollectionPaths(collection_path).workflow_state_path
         if not ws_path.exists():
             return
 

--- a/src/youtube_automation/agents/short_uploader.py
+++ b/src/youtube_automation/agents/short_uploader.py
@@ -28,6 +28,7 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 
 from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config
 from youtube_automation.utils.exceptions import UploadError
 from youtube_automation.utils.metadata_generator import BAHMetadataGenerator
@@ -102,7 +103,7 @@ class ShortUploader:
 
         latest_dt: Optional[datetime] = None
         for col_dir in live_dir.iterdir():
-            ws_path = col_dir / "workflow-state.json"
+            ws_path = CollectionPaths(col_dir).workflow_state_path
             if not ws_path.exists():
                 continue
             try:
@@ -143,7 +144,7 @@ class ShortUploader:
         Returns:
             ISO 8601 文字列 or None
         """
-        tracking_path = collection_path / "20-documentation" / "upload_tracking.json"
+        tracking_path = CollectionPaths(collection_path).tracking_path
         if not tracking_path.exists():
             return None
         try:
@@ -192,25 +193,16 @@ class ShortUploader:
         Raises:
             FileNotFoundError: 両方無いとき（plan §171 厳密準拠）
         """
-        master = collection_path / "01-master"
-        numbered_glob = None
-        if short_num is not None:
-            shorts_dir = master / "shorts"
-            numbered_glob = f"shorts/short-{short_num:02d}-*.mp4"
-            if shorts_dir.exists():
-                matches = sorted(shorts_dir.glob(f"short-{short_num:02d}-*.mp4"))
-                if matches:
-                    return matches[0]
-
-        fallback = master / "short.mp4"
-        if fallback.exists():
-            return fallback
+        paths = CollectionPaths(collection_path)
+        video_path = paths.find_short_video(short_num)
+        if video_path is not None:
+            return video_path
 
         # 両方無 → FileNotFoundError（呼び出し側で握り潰す責務）
         searched = []
-        if numbered_glob:
-            searched.append(str(master / numbered_glob))
-        searched.append(str(fallback))
+        if short_num is not None:
+            searched.append(str(paths.shorts_dir / f"short-{short_num:02d}-*.mp4"))
+        searched.append(str(paths.short_video_path))
         raise FileNotFoundError(f"Shorts 動画が見つかりません。探索パス: {', '.join(searched)}")
 
     # ─── upload オーケストレーション (plan 要件 6.4) ──
@@ -226,6 +218,8 @@ class ShortUploader:
             {"action": str, "details": dict}
                 action: "short_uploaded" / "short_upload_blocked" / "short_upload_failed"
         """
+        paths = CollectionPaths(collection_path)
+
         # 1. 投稿間隔チェック（24h 制約）
         ok, msg = self._check_upload_interval()
         if not ok:
@@ -233,7 +227,7 @@ class ShortUploader:
             return {"action": ACTION_BLOCKED, "details": {"reason": msg}}
 
         # 2. tracking 読み込み（CC URL 抽出のため）
-        tracking_path = collection_path / "20-documentation" / "upload_tracking.json"
+        tracking_path = paths.tracking_path
         if not tracking_path.exists():
             logger.error(f"❌ upload_tracking.json が無いため Shorts 投稿不可: {tracking_path}")
             return {"action": ACTION_FAILED, "details": {"error": f"tracking missing: {tracking_path}"}}
@@ -299,12 +293,13 @@ class ShortUploader:
 
     def _find_short_thumbnail(self, collection_path: Path) -> Optional[str]:
         """plan 要件 6.5: `10-assets/short-thumbnail.{jpg,png}` の順に探索。両方無は None."""
-        assets = collection_path / "10-assets"
-        for ext in ("jpg", "png"):
-            candidate = assets / f"short-thumbnail.{ext}"
-            if candidate.exists():
-                return str(candidate)
-        logger.warning(f"short-thumbnail.{{jpg,png}} が見つかりません — サムネ未設定で upload します: {assets}")
+        paths = CollectionPaths(collection_path)
+        thumbnail_path = paths.find_short_thumbnail()
+        if thumbnail_path is not None:
+            return str(thumbnail_path)
+        logger.warning(
+            f"short-thumbnail.{{jpg,png}} が見つかりません — サムネ未設定で upload します: {paths.assets_dir}"
+        )
         return None
 
     # ─── workflow-state 更新 (plan アンチパターン #10) ─
@@ -323,7 +318,7 @@ class ShortUploader:
         書き手（本メソッド）と読み手（`bulk_update_short_localizations.collect_short_videos`）が
         同 PR 内で対称検証されるスキーマ.
         """
-        ws_path = collection_path / "workflow-state.json"
+        ws_path = CollectionPaths(collection_path).workflow_state_path
         if not ws_path.exists():
             logger.warning(f"workflow-state.json が無いため short upload 記録を skip: {ws_path}")
             return

--- a/src/youtube_automation/scripts/bulk_update_short_localizations.py
+++ b/src/youtube_automation/scripts/bulk_update_short_localizations.py
@@ -18,6 +18,7 @@ import logging
 import sys
 import time
 
+from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config
 from youtube_automation.utils.metadata_generator import build_short_localizations
 from youtube_automation.utils.youtube_service import get_youtube
@@ -47,10 +48,11 @@ def collect_short_videos() -> list[dict]:
 
     results: list[dict] = []
     for col_dir in sorted(live_dir.iterdir()):
-        ws_path = col_dir / "workflow-state.json"
+        paths = CollectionPaths(col_dir)
+        ws_path = paths.workflow_state_path
         if not ws_path.exists():
             continue
-        tracking_path = col_dir / "20-documentation" / "upload_tracking.json"
+        tracking_path = paths.tracking_path
         if not tracking_path.exists():
             # tracking 無は CC URL を引けないので Shorts も skip
             continue

--- a/src/youtube_automation/scripts/generate_short_loop.py
+++ b/src/youtube_automation/scripts/generate_short_loop.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
 
+from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.genai_client import create_genai_client
 from youtube_automation.utils.skill_config import load_skill_config
@@ -28,11 +29,6 @@ from youtube_automation.utils.veo_generator import (
     generate_loop_video,
 )
 
-# ファイル名・ディレクトリ名は契約文字列のため定数で 1 箇所に集約
-ASSETS_DIR = "10-assets"
-INPUT_PNG = "short.png"
-INPUT_JPG = "short.jpg"
-OUTPUT_MP4 = "short-loop.mp4"
 SHORT_ASPECT_RATIO = "9:16"
 SHORT_SKILL_NAME = "short"
 
@@ -46,11 +42,11 @@ def resolve_paths(collection_path: Path) -> tuple[Path, Path]:
     Returns:
         (image_path, output_path)
     """
-    assets = collection_path / ASSETS_DIR
-    image_path = assets / INPUT_PNG
-    if not image_path.exists():
-        image_path = assets / INPUT_JPG
-    output_path = assets / OUTPUT_MP4
+    paths = CollectionPaths(collection_path)
+    image_path = paths.find_short_input_image()
+    if image_path is None:
+        image_path = paths.assets_dir / "short.png"
+    output_path = paths.short_loop_path
     return image_path, output_path
 
 
@@ -93,7 +89,7 @@ def main() -> None:
             collection_path = Path.cwd() / collection_path
     else:
         cwd = Path.cwd()
-        if (cwd / ASSETS_DIR).exists():
+        if CollectionPaths(cwd).assets_dir.exists():
             collection_path = cwd
         else:
             parser.error("コレクションパスを指定するか、コレクションディレクトリ内で実行してください")

--- a/src/youtube_automation/utils/collection_paths.py
+++ b/src/youtube_automation/utils/collection_paths.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from youtube_automation.utils.exceptions import ValidationError
 
-
 class CollectionPaths:
     """標準コレクションディレクトリ構造のパスリゾルバ。
 
@@ -55,15 +54,27 @@ class CollectionPaths:
 
     @property
     def tracking_path(self) -> Path:
-        return self.root / "20-documentation" / "upload_tracking.json"
+        return self.docs_dir / "upload_tracking.json"
 
     @property
     def descriptions_md_path(self) -> Path:
-        return self.root / "20-documentation" / "descriptions.md"
+        return self.docs_dir / "descriptions.md"
 
     @property
     def thumbnail_prompts_path(self) -> Path:
-        return self.root / "20-documentation" / "thumbnail-prompts.md"
+        return self.docs_dir / "thumbnail-prompts.md"
+
+    @property
+    def shorts_dir(self) -> Path:
+        return self.master_dir / "shorts"
+
+    @property
+    def short_video_path(self) -> Path:
+        return self.master_dir / "short.mp4"
+
+    @property
+    def short_loop_path(self) -> Path:
+        return self.assets_dir / "short-loop.mp4"
 
     def find_master_video(self) -> Path | None:
         """01-master/ からマスター動画（.mp4）を探す。"""
@@ -97,6 +108,35 @@ class CollectionPaths:
         """10-assets/ からループ動画を探す。"""
         path = self.assets_dir / "loop.mp4"
         return path if path.exists() else None
+
+    def find_short_video(self, short_num: int | None = None) -> Path | None:
+        """Shorts 用動画を探す (`shorts/short-NN-*.mp4` > `short.mp4`)。"""
+        if short_num is not None and self.shorts_dir.exists():
+            pattern = f"short-{short_num:02d}-*.mp4"
+            for path in sorted(self.shorts_dir.glob(pattern)):
+                return path
+
+        if self.short_video_path.exists():
+            return self.short_video_path
+        return None
+
+    def find_short_thumbnail(self) -> Path | None:
+        """Shorts 用サムネイルを探す (`.jpg` > `.png`)。"""
+        for ext in ("jpg", "png"):
+            path = self.assets_dir / f"short-thumbnail.{ext}"
+            if path.exists():
+                return path
+        return None
+
+    def find_short_input_image(self) -> Path | None:
+        """Shorts ループ生成の入力画像を探す (`.png` > `.jpg`)。"""
+        png_path = self.assets_dir / "short.png"
+        if png_path.exists():
+            return png_path
+        jpg_path = self.assets_dir / "short.jpg"
+        if jpg_path.exists():
+            return jpg_path
+        return None
 
     def individual_music_files(self) -> list[Path]:
         """02-Individual-music/ の音声ファイル一覧（ソート済み）。"""

--- a/tests/test_collection_paths.py
+++ b/tests/test_collection_paths.py
@@ -91,6 +91,25 @@ class TestFilePathProperties:
 
 
 # ---------------------------------------------------------------------------
+# Shorts パスプロパティ
+# ---------------------------------------------------------------------------
+
+
+class TestShortsProperties:
+    def test_shorts_dir(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        assert paths.shorts_dir == tmp_path / "01-master" / "shorts"
+
+    def test_short_video_path(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        assert paths.short_video_path == tmp_path / "01-master" / "short.mp4"
+
+    def test_short_loop_path(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        assert paths.short_loop_path == tmp_path / "10-assets" / "short-loop.mp4"
+
+
+# ---------------------------------------------------------------------------
 # find_master_video
 # ---------------------------------------------------------------------------
 
@@ -233,6 +252,132 @@ class TestFindLoopVideo:
         paths = CollectionPaths(tmp_path)
         paths.assets_dir.mkdir()
         assert paths.find_loop_video() is None
+
+
+# ---------------------------------------------------------------------------
+# find_short_video
+# ---------------------------------------------------------------------------
+
+
+class TestFindShortVideo:
+    def test_prefers_numbered_short_when_short_num_provided(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.shorts_dir.mkdir(parents=True)
+        numbered = paths.shorts_dir / "short-01-alpha.mp4"
+        numbered.touch()
+        paths.short_video_path.touch()
+
+        assert paths.find_short_video(1) == numbered
+
+    def test_falls_back_to_short_mp4_when_short_num_is_none(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.short_video_path.parent.mkdir(parents=True)
+        paths.short_video_path.touch()
+
+        assert paths.find_short_video() == paths.short_video_path
+
+    def test_falls_back_to_short_mp4_when_numbered_short_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.shorts_dir.mkdir(parents=True)
+        paths.short_video_path.touch()
+
+        assert paths.find_short_video(2) == paths.short_video_path
+
+    def test_returns_first_sorted_numbered_short(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.shorts_dir.mkdir(parents=True)
+        later = paths.shorts_dir / "short-01-beta.mp4"
+        earlier = paths.shorts_dir / "short-01-alpha.mp4"
+        later.touch()
+        earlier.touch()
+
+        assert paths.find_short_video(1) == earlier
+
+    def test_returns_none_when_numbered_and_fallback_both_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.shorts_dir.mkdir(parents=True)
+
+        assert paths.find_short_video(1) is None
+
+    def test_skips_numbered_search_when_short_num_is_none(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.shorts_dir.mkdir(parents=True)
+        (paths.shorts_dir / "short-01-alpha.mp4").touch()
+        paths.short_video_path.touch()
+
+        assert paths.find_short_video(None) == paths.short_video_path
+
+    def test_returns_none_when_shorts_dir_missing_and_fallback_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+
+        assert paths.find_short_video(1) is None
+
+
+# ---------------------------------------------------------------------------
+# find_short_thumbnail
+# ---------------------------------------------------------------------------
+
+
+class TestFindShortThumbnail:
+    def test_prefers_jpg(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+        jpg = paths.assets_dir / "short-thumbnail.jpg"
+        png = paths.assets_dir / "short-thumbnail.png"
+        jpg.touch()
+        png.touch()
+
+        assert paths.find_short_thumbnail() == jpg
+
+    def test_falls_back_to_png(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+        png = paths.assets_dir / "short-thumbnail.png"
+        png.touch()
+
+        assert paths.find_short_thumbnail() == png
+
+    def test_returns_none_when_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+
+        assert paths.find_short_thumbnail() is None
+
+    def test_returns_none_when_assets_dir_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+
+        assert paths.find_short_thumbnail() is None
+
+
+# ---------------------------------------------------------------------------
+# find_short_input_image
+# ---------------------------------------------------------------------------
+
+
+class TestFindShortInputImage:
+    def test_prefers_png(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+        png = paths.assets_dir / "short.png"
+        jpg = paths.assets_dir / "short.jpg"
+        png.touch()
+        jpg.touch()
+
+        assert paths.find_short_input_image() == png
+
+    def test_falls_back_to_jpg(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+        jpg = paths.assets_dir / "short.jpg"
+        jpg.touch()
+
+        assert paths.find_short_input_image() == jpg
+
+    def test_returns_none_when_missing(self, tmp_path):
+        paths = CollectionPaths(tmp_path)
+        paths.assets_dir.mkdir(parents=True)
+
+        assert paths.find_short_input_image() is None
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- `utils/collection_paths.py::CollectionPaths` に Shorts 関連サブパス（`shorts_dir` / `short_video(short_num=None)` / `short_thumbnail(ext)` / `short_loop` 等）を追加
- `agents/collection_uploader.py` / `agents/short_uploader.py` / `scripts/generate_short_loop.py` / `scripts/bulk_update_short_localizations.py` の 4 ファイルでリテラル参照を `CollectionPaths` ベースに置き換え
- `tests/test_collection_paths.py` で新規ヘルパの回帰テストを追加

## Note: takt workflow の状態

> [!IMPORTANT]
> takt の自動 workflow は実装ステップまで完了したが、その後の `fix` ステップで Codex usage limit に当たり中断した。
> 実装コードは worktree に未コミット状態で残っていたものを手動で commit/push/PR 化したもの。
> takt の `self_review` / `ci_verify` ステップは未実施のため、CI とレビューで品質確認をお願いします。

Closes #357
