### PR TITLE
feat(comments-reply): 返信スレッドを走査対象に追加 (#365)

### DIFF
--- a/src/youtube_automation/utils/comments/fetcher.py
+++ b/src/youtube_automation/utils/comments/fetcher.py
@@ -1,4 +1,4 @@
-"""自チャンネル動画のコメント取得（YouTube Data API v3 commentThreads.list）."""
+"""自チャンネル動画のコメント取得（YouTube Data API v3 commentThreads.list / comments.list）."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class FetchedComment:
-    """commentThreads.list から取得したトップレベルコメント 1 件."""
+    """YouTube コメント 1 件（top-level または reply）."""
 
     comment_id: str
     video_id: str
@@ -26,6 +26,48 @@ class FetchedComment:
     moderation_status: str | None
     can_reply: bool
     total_reply_count: int
+    parent_id: str | None = None
+
+
+_THREAD_PART = "snippet,replies"
+_REPLY_PART = "snippet"
+_TEXT_FORMAT = "plainText"
+_INLINE_REPLY_LIMIT = 5
+
+
+def _passed_since(*, published_at: str, since: datetime | None) -> bool:
+    if since is None or not published_at:
+        return True
+    try:
+        published_dt = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return published_dt >= since
+
+
+def _iter_all_replies(youtube, *, parent_id: str) -> Iterator[dict]:
+    next_page_token: str | None = None
+    while True:
+        try:
+            response = (
+                youtube.comments()
+                .list(
+                    part=_REPLY_PART,
+                    parentId=parent_id,
+                    maxResults=100,
+                    pageToken=next_page_token,
+                    textFormat=_TEXT_FORMAT,
+                )
+                .execute()
+            )
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(e, f"comments.list 失敗 (parent_id={parent_id})") from e
+
+        yield from response.get("items", [])
+
+        next_page_token = response.get("nextPageToken")
+        if not next_page_token:
+            return
 
 
 def fetch_top_level_comments(
@@ -58,11 +100,11 @@ def fetch_top_level_comments(
             response = (
                 youtube.commentThreads()
                 .list(
-                    part="snippet",
+                    part=_THREAD_PART,
                     videoId=video_id,
                     maxResults=min(page_size, max_results - yielded),
                     pageToken=next_page_token,
-                    textFormat="plainText",
+                    textFormat=_TEXT_FORMAT,
                 )
                 .execute()
             )
@@ -70,29 +112,55 @@ def fetch_top_level_comments(
             raise YouTubeAPIError.from_http_error(e, f"commentThreads.list 失敗 (video_id={video_id})") from e
 
         for item in response.get("items", []):
-            top = item["snippet"]["topLevelComment"]
+            thread_snippet = item["snippet"]
+            top = thread_snippet["topLevelComment"]
             snippet = top["snippet"]
             published = snippet.get("publishedAt", "")
-            if since is not None and published:
-                try:
-                    pub_dt = datetime.fromisoformat(published.replace("Z", "+00:00"))
-                except ValueError:
-                    pub_dt = None
-                if pub_dt is not None and pub_dt < since:
+            top_passed = _passed_since(published_at=published, since=since)
+            can_reply = bool(thread_snippet.get("canReply", True))
+            total_reply_count = int(thread_snippet.get("totalReplyCount", 0))
+            if top_passed:
+                yield FetchedComment(
+                    comment_id=top["id"],
+                    video_id=video_id,
+                    author=snippet.get("authorDisplayName", ""),
+                    text=snippet.get("textOriginal", snippet.get("textDisplay", "")),
+                    published_at=published,
+                    moderation_status=snippet.get("moderationStatus"),
+                    can_reply=can_reply,
+                    total_reply_count=total_reply_count,
+                    parent_id=None,
+                )
+                yielded += 1
+                if yielded >= max_results:
+                    return
+
+            if total_reply_count == 0:
+                continue
+            if total_reply_count > _INLINE_REPLY_LIMIT:
+                replies = _iter_all_replies(youtube, parent_id=top["id"])
+            else:
+                replies = item.get("replies", {}).get("comments", [])
+
+            for reply in replies:
+                reply_snippet = reply["snippet"]
+                reply_published = reply_snippet.get("publishedAt", "")
+                if not _passed_since(published_at=reply_published, since=since):
                     continue
-            yield FetchedComment(
-                comment_id=top["id"],
-                video_id=video_id,
-                author=snippet.get("authorDisplayName", ""),
-                text=snippet.get("textOriginal", snippet.get("textDisplay", "")),
-                published_at=published,
-                moderation_status=snippet.get("moderationStatus"),
-                can_reply=bool(item["snippet"].get("canReply", True)),
-                total_reply_count=int(item["snippet"].get("totalReplyCount", 0)),
-            )
-            yielded += 1
-            if yielded >= max_results:
-                return
+                yield FetchedComment(
+                    comment_id=reply["id"],
+                    video_id=video_id,
+                    author=reply_snippet.get("authorDisplayName", ""),
+                    text=reply_snippet.get("textOriginal", reply_snippet.get("textDisplay", "")),
+                    published_at=reply_published,
+                    moderation_status=reply_snippet.get("moderationStatus"),
+                    can_reply=can_reply,
+                    total_reply_count=0,
+                    parent_id=top["id"],
+                )
+                yielded += 1
+                if yielded >= max_results:
+                    return
 
         next_page_token = response.get("nextPageToken")
         if not next_page_token:

--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -1,0 +1,289 @@
+"""comment fetcher の top-level / reply 取得テスト."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
+
+from youtube_automation.utils.comments.fetcher import fetch_top_level_comments
+from youtube_automation.utils.exceptions import YouTubeAPIError
+
+
+def _top_level_item(
+    *,
+    comment_id: str,
+    text: str,
+    author: str = "Top Author",
+    published_at: str = "2026-05-01T00:00:00Z",
+    can_reply: bool = True,
+    total_reply_count: int = 0,
+    moderation_status: str | None = None,
+    replies: list[dict] | None = None,
+) -> dict:
+    item = {
+        "snippet": {
+            "canReply": can_reply,
+            "totalReplyCount": total_reply_count,
+            "topLevelComment": {
+                "id": comment_id,
+                "snippet": {
+                    "authorDisplayName": author,
+                    "textOriginal": text,
+                    "publishedAt": published_at,
+                    "moderationStatus": moderation_status,
+                },
+            },
+        }
+    }
+    if replies is not None:
+        item["replies"] = {"comments": replies}
+    return item
+
+
+def _reply_item(
+    *,
+    comment_id: str,
+    text: str,
+    author: str = "Reply Author",
+    published_at: str = "2026-05-01T00:00:00Z",
+    moderation_status: str | None = None,
+) -> dict:
+    return {
+        "id": comment_id,
+        "snippet": {
+            "authorDisplayName": author,
+            "textOriginal": text,
+            "publishedAt": published_at,
+            "moderationStatus": moderation_status,
+        },
+    }
+
+
+def _http_error(status: int, message: str) -> HttpError:
+    return HttpError(Response({"status": str(status)}), f'{{"error": {{"message": "{message}"}}}}'.encode())
+
+
+def _mock_youtube(*, thread_pages: list[dict], reply_pages_by_parent: dict[str, list[dict]] | None = None) -> MagicMock:
+    yt = MagicMock()
+    thread_calls: list[dict] = []
+    reply_calls: list[dict] = []
+    reply_pages_by_parent = reply_pages_by_parent or {}
+
+    def _thread_list(**kwargs):
+        thread_calls.append(kwargs)
+        response = thread_pages[len(thread_calls) - 1]
+        result = MagicMock()
+        if isinstance(response, Exception):
+            result.execute.side_effect = response
+        else:
+            result.execute.return_value = response
+        return result
+
+    def _reply_list(**kwargs):
+        reply_calls.append(kwargs)
+        parent_id = kwargs["parentId"]
+        pages = reply_pages_by_parent[parent_id]
+        index = sum(1 for call in reply_calls if call["parentId"] == parent_id) - 1
+        response = pages[index]
+        result = MagicMock()
+        if isinstance(response, Exception):
+            result.execute.side_effect = response
+        else:
+            result.execute.return_value = response
+        return result
+
+    yt.commentThreads.return_value.list.side_effect = _thread_list
+    yt.comments.return_value.list.side_effect = _reply_list
+    yt._thread_calls = thread_calls
+    yt._reply_calls = reply_calls
+    return yt
+
+
+def test_fetch_top_level_comments_requests_snippet_and_replies():
+    yt = _mock_youtube(
+        thread_pages=[
+            {"items": [_top_level_item(comment_id="top-1", text="hello")]}
+        ]
+    )
+
+    comments = list(fetch_top_level_comments(yt, video_id="vid-1"))
+
+    assert [comment.comment_id for comment in comments] == ["top-1"]
+    assert yt._thread_calls[0]["part"] == "snippet,replies"
+
+
+def test_fetch_top_level_comments_yields_inline_replies_after_top_level():
+    yt = _mock_youtube(
+        thread_pages=[
+            {
+                "items": [
+                    _top_level_item(
+                        comment_id="top-1",
+                        text="top text",
+                        can_reply=False,
+                        total_reply_count=2,
+                        replies=[
+                            _reply_item(comment_id="reply-1", text="reply one"),
+                            _reply_item(comment_id="reply-2", text="reply two"),
+                        ],
+                    )
+                ]
+            }
+        ]
+    )
+
+    comments = list(fetch_top_level_comments(yt, video_id="vid-1"))
+
+    assert [comment.comment_id for comment in comments] == ["top-1", "reply-1", "reply-2"]
+    assert comments[0].parent_id is None
+    assert comments[1].parent_id == "top-1"
+    assert comments[2].parent_id == "top-1"
+    assert comments[1].can_reply is False
+    assert comments[1].total_reply_count == 0
+    assert comments[2].total_reply_count == 0
+
+
+def test_fetch_top_level_comments_uses_comments_list_when_total_reply_count_exceeds_inline_limit():
+    yt = _mock_youtube(
+        thread_pages=[
+            {
+                "items": [
+                    _top_level_item(
+                        comment_id="top-1",
+                        text="top text",
+                        total_reply_count=6,
+                        replies=[_reply_item(comment_id="inline-ignored", text="inline")],
+                    )
+                ]
+            }
+        ],
+        reply_pages_by_parent={
+            "top-1": [
+                {
+                    "items": [
+                        _reply_item(comment_id="reply-1", text="reply one"),
+                        _reply_item(comment_id="reply-2", text="reply two"),
+                    ],
+                    "nextPageToken": "page-2",
+                },
+                {
+                    "items": [
+                        _reply_item(comment_id="reply-3", text="reply three"),
+                    ]
+                },
+            ]
+        },
+    )
+
+    comments = list(fetch_top_level_comments(yt, video_id="vid-1"))
+
+    assert [comment.comment_id for comment in comments] == ["top-1", "reply-1", "reply-2", "reply-3"]
+    assert [call["parentId"] for call in yt._reply_calls] == ["top-1", "top-1"]
+    assert yt._reply_calls[0]["part"] == "snippet"
+    assert yt._reply_calls[0]["textFormat"] == "plainText"
+    assert yt._reply_calls[1]["pageToken"] == "page-2"
+
+
+def test_fetch_top_level_comments_applies_since_filter_to_top_level_and_replies():
+    yt = _mock_youtube(
+        thread_pages=[
+            {
+                "items": [
+                    _top_level_item(
+                        comment_id="top-old",
+                        text="old top",
+                        published_at="2026-05-01T00:00:00Z",
+                        total_reply_count=1,
+                        replies=[
+                            _reply_item(
+                                comment_id="reply-on-old-thread-new",
+                                text="reply on old thread",
+                                published_at="2026-05-04T12:00:00Z",
+                            )
+                        ],
+                    ),
+                    _top_level_item(
+                        comment_id="top-new",
+                        text="new top",
+                        published_at="2026-05-03T00:00:00Z",
+                        total_reply_count=2,
+                        replies=[
+                            _reply_item(
+                                comment_id="reply-old",
+                                text="old reply",
+                                published_at="2026-05-01T12:00:00Z",
+                            ),
+                            _reply_item(
+                                comment_id="reply-new",
+                                text="new reply",
+                                published_at="2026-05-04T00:00:00Z",
+                            ),
+                        ],
+                    ),
+                ]
+            }
+        ]
+    )
+
+    comments = list(
+        fetch_top_level_comments(
+            yt,
+            video_id="vid-1",
+            since=datetime(2026, 5, 2, tzinfo=timezone.utc),
+        )
+    )
+
+    assert [comment.comment_id for comment in comments] == [
+        "reply-on-old-thread-new",
+        "top-new",
+        "reply-new",
+    ]
+
+
+def test_fetch_top_level_comments_stops_at_max_results_even_mid_replies():
+    yt = _mock_youtube(
+        thread_pages=[
+            {
+                "items": [
+                    _top_level_item(
+                        comment_id="top-1",
+                        text="top text",
+                        total_reply_count=3,
+                        replies=[
+                            _reply_item(comment_id="reply-1", text="reply one"),
+                            _reply_item(comment_id="reply-2", text="reply two"),
+                            _reply_item(comment_id="reply-3", text="reply three"),
+                        ],
+                    )
+                ]
+            }
+        ]
+    )
+
+    comments = list(fetch_top_level_comments(yt, video_id="vid-1", max_results=3))
+
+    assert [comment.comment_id for comment in comments] == ["top-1", "reply-1", "reply-2"]
+
+
+def test_fetch_top_level_comments_wraps_comments_list_http_error():
+    yt = _mock_youtube(
+        thread_pages=[
+            {
+                "items": [
+                    _top_level_item(
+                        comment_id="top-1",
+                        text="top text",
+                        total_reply_count=6,
+                    )
+                ]
+            }
+        ],
+        reply_pages_by_parent={"top-1": [_http_error(500, "reply boom")]},
+    )
+
+    with pytest.raises(YouTubeAPIError, match="comments.list 失敗 \\(parent_id=top-1\\)"):
+        list(fetch_top_level_comments(yt, video_id="vid-1"))

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- `utils/comments/fetcher.py::fetch_top_level_comments` を `part="snippet,replies"` で取得するよう変更
- `item["replies"]["comments"][*]` も `FetchedComment` として yield
- `totalReplyCount > 5` の場合は `comments().list(parentId=...)` でページングして全件取得
- `FetchedComment` に `parent_id: str | None` フィールドを追加（top-level なら None、reply なら親 top-level の comment_id）
- `tests/test_comments_fetcher.py` を新規追加

## Note: takt workflow の状態

> [!IMPORTANT]
> takt の自動 workflow は実装ステップまで完了したが、その後の `self_review` ステップで Codex usage limit に当たり中断した。
> 実装コードは worktree に未コミット状態で残っていたものを手動で commit/push/PR 化したもの。
> takt の `self_review` / `ci_verify` ステップは未実施のため、CI とレビューで品質確認をお願いします。

#366 (LLM 駆動返信生成) は `ReplyContext.parent_thread` を本 PR の `parent_id` 機構の前提としている。

Closes #365
