### PR TITLE
feat(comments-reply): LLM 駆動の返信生成バックエンドを追加 (#366)

### DIFF
--- a/src/youtube_automation/scripts/comment_reply.py
+++ b/src/youtube_automation/scripts/comment_reply.py
@@ -66,16 +66,20 @@ def _print_summary(plan, *, dry_run: bool, as_json: bool) -> None:
     for row in plan.planned:
         print(
             f"  [planned] video={row['video_id']} comment_id={row['comment_id']} "
-            f"rule={row.get('rule')} lang={row.get('language')}"
+            f"rule={row.get('rule')} generator={row.get('generator')} lang={row.get('language')}"
         )
         print(f"    author: {row.get('comment_author')}")
         print(f"    text  : {row.get('comment_text', '')[:80]}")
+        if row.get("prompt"):
+            print(f"    prompt: {row.get('prompt', '')[:120]}")
         print(f"    reply : {row.get('reply_text', '')[:120]}")
     for row in plan.replied:
         print(
             f"  [replied] video={row['video_id']} comment_id={row['comment_id']} "
-            f"rule={row.get('rule')} lang={row.get('language')}"
+            f"rule={row.get('rule')} generator={row.get('generator')} lang={row.get('language')}"
         )
+        if row.get("prompt"):
+            print(f"    prompt: {row.get('prompt', '')[:120]}")
         print(f"    reply : {row.get('reply_text', '')[:120]}")
     for row in plan.skipped:
         print(f"  [skipped] video={row['video_id']} comment_id={row['comment_id']} reason={row.get('reason')}")

--- a/src/youtube_automation/utils/comments/__init__.py
+++ b/src/youtube_automation/utils/comments/__init__.py
@@ -1,6 +1,7 @@
 """自チャンネルのコメント自動返信モジュール群."""
 
 from youtube_automation.utils.comments.fetcher import fetch_top_level_comments
+from youtube_automation.utils.comments.generator.base import GeneratedReply, ReplyContext
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.replier import CommentReplier, ReplyPlan
 from youtube_automation.utils.comments.rule_engine import RuleEngine, RuleMatch
@@ -8,8 +9,10 @@ from youtube_automation.utils.comments.template import render_template
 
 __all__ = [
     "CommentReplier",
+    "GeneratedReply",
     "ReplyHistory",
     "ReplyPlan",
+    "ReplyContext",
     "RuleEngine",
     "RuleMatch",
     "fetch_top_level_comments",

--- a/src/youtube_automation/utils/comments/generator/__init__.py
+++ b/src/youtube_automation/utils/comments/generator/__init__.py
@@ -1,0 +1,21 @@
+"""コメント返信 generator の factory."""
+
+from __future__ import annotations
+
+from youtube_automation.utils.comments.generator.base import ReplyGenerator
+from youtube_automation.utils.comments.generator.gemini import GeminiGenerator
+from youtube_automation.utils.comments.generator.template import TemplateGenerator
+from youtube_automation.utils.config.comments import Comments
+
+
+def build_generators(config: Comments) -> dict[str, ReplyGenerator]:
+    generators: dict[str, ReplyGenerator] = {
+        "template": TemplateGenerator(),
+    }
+    needs_gemini = config.generator.type == "gemini" or any(rule.generator == "gemini" for rule in config.rules)
+    if needs_gemini:
+        generators["gemini"] = GeminiGenerator(
+            model=config.generator.model,
+            min_interval_sec=config.generator.min_interval_sec,
+        )
+    return generators

--- a/src/youtube_automation/utils/comments/generator/base.py
+++ b/src/youtube_automation/utils/comments/generator/base.py
@@ -1,0 +1,39 @@
+"""コメント返信 generator の共通型."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from youtube_automation.utils.comments.fetcher import FetchedComment
+
+
+@dataclass(frozen=True)
+class ReplyContext:
+    """1 件分の返信生成に必要な解決済み入力."""
+
+    video_id: str
+    video_title: str
+    comment_id: str
+    comment_text: str
+    comment_author: str
+    language: str | None
+    channel_persona: str
+    max_length: int
+    parent_thread: list[FetchedComment] | None
+    template_text: str | None = None
+
+
+@dataclass(frozen=True)
+class GeneratedReply:
+    """1 件分の返信生成結果."""
+
+    text: str
+    prompt: str | None
+
+
+@runtime_checkable
+class ReplyGenerator(Protocol):
+    """返信 generator の最小契約."""
+
+    def generate(self, ctx: ReplyContext) -> GeneratedReply: ...

--- a/src/youtube_automation/utils/comments/generator/gemini.py
+++ b/src/youtube_automation/utils/comments/generator/gemini.py
@@ -1,0 +1,71 @@
+"""Gemini でコメント返信を動的生成する generator."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from youtube_automation.utils.comments.generator.base import GeneratedReply, ReplyContext
+from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.genai_client import create_genai_client
+from youtube_automation.utils.image_provider.base import RETRY_BACKOFF, RETRY_MAX
+
+logger = logging.getLogger(__name__)
+
+
+def _build_prompt(ctx: ReplyContext) -> str:
+    prompt_lines = [
+        "You are replying to a YouTube comment as the channel host.",
+        f"Channel persona: {ctx.channel_persona}",
+        f"Video title: {ctx.video_title}",
+        f"Comment author: {ctx.comment_author}",
+        f"Comment text: {ctx.comment_text}",
+        f"Max length: {ctx.max_length} characters",
+        "Write 1-3 sentences, warm and sincere, no emoji spam, no pushy CTA.",
+    ]
+    if ctx.language is not None:
+        prompt_lines.append(f"Reply in language: {ctx.language}")
+    else:
+        prompt_lines.append("Detect the comment language and reply in the same language.")
+    return "\n".join(prompt_lines)
+
+
+def _truncate_reply(text: str, *, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    logger.warning("generated reply exceeded max_length=%d and was truncated", max_length)
+    return text[:max_length]
+
+
+class GeminiGenerator:
+    """Vertex AI Gemini backend."""
+
+    def __init__(self, *, model: str, min_interval_sec: float):
+        self._client = create_genai_client()
+        self._model = model
+        self._min_interval_sec = min_interval_sec
+
+    def generate(self, ctx: ReplyContext) -> GeneratedReply:
+        if not self._model:
+            raise ValidationError("gemini generator requires model")
+
+        prompt = _build_prompt(ctx)
+        last_error: Exception | None = None
+        for attempt in range(RETRY_MAX):
+            try:
+                response = self._client.models.generate_content(model=self._model, contents=prompt)
+                text = (response.text or "").strip()
+                if not text:
+                    raise ValidationError("gemini generator returned empty text")
+                return GeneratedReply(
+                    text=_truncate_reply(text, max_length=ctx.max_length),
+                    prompt=prompt,
+                )
+            except Exception as error:  # noqa: BLE001
+                last_error = error
+                if attempt == RETRY_MAX - 1:
+                    break
+                time.sleep(RETRY_BACKOFF[min(attempt, len(RETRY_BACKOFF) - 1)])
+
+        assert last_error is not None
+        raise last_error

--- a/src/youtube_automation/utils/comments/generator/template.py
+++ b/src/youtube_automation/utils/comments/generator/template.py
@@ -1,0 +1,27 @@
+"""既存テンプレート返信を wrap する generator."""
+
+from __future__ import annotations
+
+from youtube_automation.utils.comments.generator.base import GeneratedReply, ReplyContext
+from youtube_automation.utils.comments.template import render_template
+from youtube_automation.utils.exceptions import ValidationError
+
+
+class TemplateGenerator:
+    """`render_template` を generator 契約へ合わせる薄い adapter."""
+
+    def generate(self, ctx: ReplyContext) -> GeneratedReply:
+        if ctx.template_text is None:
+            raise ValidationError("template generator requires template_text")
+        return GeneratedReply(
+            text=render_template(
+                ctx.template_text,
+                context={
+                    "video_title": ctx.video_title,
+                    "video_id": ctx.video_id,
+                    "comment_author": ctx.comment_author,
+                    "comment_text": ctx.comment_text,
+                },
+            ),
+            prompt=None,
+        )

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -12,9 +12,10 @@ from typing import Iterator
 from googleapiclient.errors import HttpError
 
 from youtube_automation.utils.comments.fetcher import FetchedComment, fetch_top_level_comments
+from youtube_automation.utils.comments.generator import build_generators
+from youtube_automation.utils.comments.generator.base import GeneratedReply, ReplyContext, ReplyGenerator
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.rule_engine import RuleEngine, RuleMatch
-from youtube_automation.utils.comments.template import render_template
 from youtube_automation.utils.config.comments import Comments
 from youtube_automation.utils.exceptions import YouTubeAPIError
 
@@ -37,8 +38,8 @@ def _iter_uploaded_video_ids(youtube) -> Iterator[str]:
     """自チャンネルのアップロード動画 ID を generator で返す（早期 break 可能）."""
     try:
         channel_resp = youtube.channels().list(part="contentDetails", mine=True).execute()
-    except HttpError as e:
-        raise YouTubeAPIError.from_http_error(e, "channels.list (mine=True) 失敗") from e
+    except HttpError as error:
+        raise YouTubeAPIError.from_http_error(error, "channels.list (mine=True) 失敗") from error
 
     items = channel_resp.get("items") or []
     if not items:
@@ -58,13 +59,20 @@ def _iter_uploaded_video_ids(youtube) -> Iterator[str]:
                 )
                 .execute()
             )
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "playlistItems.list 失敗") from e
+        except HttpError as error:
+            raise YouTubeAPIError.from_http_error(error, "playlistItems.list 失敗") from error
         for item in resp.get("items", []):
             yield item["contentDetails"]["videoId"]
         page_token = resp.get("nextPageToken")
         if not page_token:
             return
+
+
+def _truncate_reply_text(text: str, *, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    logger.warning("generated reply exceeded max_length=%d and was truncated", max_length)
+    return text[:max_length]
 
 
 class CommentReplier:
@@ -86,6 +94,8 @@ class CommentReplier:
         self._sleep = sleep_fn
         self._history = ReplyHistory(channel_dir / config.history_file)
         self._title_cache: dict[str, str] = {}
+        self._generators = build_generators(config)
+        self._last_generation_at: float | None = None
 
     @property
     def history(self) -> ReplyHistory:
@@ -109,17 +119,18 @@ class CommentReplier:
             templates=self._config.templates,
             default_language=self._default_language,
             ng_words=self._config.ng_words,
+            default_generator_name=self._config.generator.type,
         )
         plan = ReplyPlan()
         limit = self._config.max_replies_per_run
 
         video_source: Iterator[str] = iter(video_ids) if video_ids else _iter_uploaded_video_ids(self._youtube)
 
-        for vid in video_source:
+        for video_id in video_source:
             if len(plan.planned) >= limit:
                 break
             for comment in fetch_top_level_comments(
-                self._youtube, video_id=vid, max_results=per_video_limit, since=since
+                self._youtube, video_id=video_id, max_results=per_video_limit, since=since
             ):
                 if len(plan.planned) >= limit:
                     break
@@ -132,8 +143,8 @@ class CommentReplier:
             return self._title_cache[video_id]
         try:
             resp = self._youtube.videos().list(part="snippet", id=video_id).execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, f"videos.list 失敗 (video_id={video_id})") from e
+        except HttpError as error:
+            raise YouTubeAPIError.from_http_error(error, f"videos.list 失敗 (video_id={video_id})") from error
         title = ""
         for item in resp.get("items", []):
             title = item["snippet"].get("title", "")
@@ -159,39 +170,115 @@ class CommentReplier:
             return
 
         video_title = self._get_title(comment.video_id)
-        try:
-            reply_text = render_template(
-                match.template_text,
-                context={
-                    "video_title": video_title,
-                    "video_id": comment.video_id,
-                    "comment_author": comment.author,
-                    "comment_text": comment.text,
-                },
-            )
-        except Exception as e:  # noqa: BLE001
-            plan.errors.append(self._error_record(comment, f"template_error: {e}"))
+        context = self._build_reply_context(comment, match, video_title)
+        generated = self._generate_reply(context, match, comment, plan)
+        if generated is None:
             return
+        reply, generator_name = generated
 
-        plan.planned.append(
-            {
-                "comment_id": comment.comment_id,
-                "video_id": comment.video_id,
-                "video_title": video_title,
-                "comment_author": comment.author,
-                "comment_text": comment.text,
-                "rule": match.rule.name,
-                "template_key": match.rule.template_key,
-                "language": match.template_language,
-                "reply_text": reply_text,
-            }
-        )
+        metadata = self._reply_metadata(comment, match, video_title, reply, generator_name)
+        plan.planned.append({"comment_id": comment.comment_id, **metadata})
 
         if dry_run:
             return
 
-        if self._post_reply(comment, reply_text, match, video_title, plan):
+        if self._post_reply(comment, metadata, plan):
             self._sleep(self._config.delay_between_replies_sec)
+
+    def _build_reply_context(self, comment: FetchedComment, match: RuleMatch, video_title: str) -> ReplyContext:
+        return ReplyContext(
+            video_id=comment.video_id,
+            video_title=video_title,
+            comment_id=comment.comment_id,
+            comment_text=comment.text,
+            comment_author=comment.author,
+            language=match.template_language if match.generator_name == "template" else None,
+            channel_persona=self._config.generator.channel_persona,
+            max_length=self._config.generator.max_length,
+            parent_thread=None,
+            template_text=match.template_text,
+        )
+
+    def _generate_reply(
+        self,
+        context: ReplyContext,
+        match: RuleMatch,
+        comment: FetchedComment,
+        plan: ReplyPlan,
+    ) -> tuple[GeneratedReply, str] | None:
+        try:
+            reply = self._generate_with_generator(match.generator_name, context)
+        except Exception as error:  # noqa: BLE001
+            return self._handle_generator_error(error, context, match, comment, plan)
+        return self._normalized_reply(reply, max_length=context.max_length), match.generator_name
+
+    def _generate_with_generator(self, generator_name: str, context: ReplyContext) -> GeneratedReply:
+        generator = self._get_generator(generator_name)
+        self._sleep_for_generation_interval(generator_name)
+        reply = generator.generate(context)
+        self._last_generation_at = time.monotonic()
+        return reply
+
+    def _get_generator(self, generator_name: str) -> ReplyGenerator:
+        generator = self._generators.get(generator_name)
+        if generator is None:
+            raise RuntimeError(f"generator not configured: {generator_name}")
+        return generator
+
+    def _sleep_for_generation_interval(self, generator_name: str) -> None:
+        if generator_name == "template":
+            return
+        interval = self._config.generator.min_interval_sec
+        if interval <= 0 or self._last_generation_at is None:
+            return
+        self._sleep(interval)
+
+    def _handle_generator_error(
+        self,
+        error: Exception,
+        context: ReplyContext,
+        match: RuleMatch,
+        comment: FetchedComment,
+        plan: ReplyPlan,
+    ) -> tuple[GeneratedReply, str] | None:
+        if match.generator_name != "template" and self._config.generator.fallback_on_error == "template":
+            if "template" in self._generators and context.template_text is not None:
+                reply = self._generate_with_generator("template", context)
+                return self._normalized_reply(reply, max_length=context.max_length), "template"
+        if self._config.generator.fallback_on_error == "skip":
+            plan.skipped.append(self._skip_record(comment, f"generator_error: {error}"))
+            return None
+        plan.errors.append(self._error_record(comment, f"generator_error: {error}"))
+        return None
+
+    def _normalized_reply(self, reply: GeneratedReply, *, max_length: int) -> GeneratedReply:
+        return GeneratedReply(
+            text=_truncate_reply_text(reply.text, max_length=max_length),
+            prompt=reply.prompt,
+        )
+
+    def _reply_metadata(
+        self,
+        comment: FetchedComment,
+        match: RuleMatch,
+        video_title: str,
+        reply: GeneratedReply,
+        generator_name: str,
+    ) -> dict:
+        template_key = match.rule.template_key if generator_name == "template" else None
+        language = match.template_language if generator_name == "template" else None
+        return {
+            "video_id": comment.video_id,
+            "video_title": video_title,
+            "comment_author": comment.author,
+            "comment_text": comment.text,
+            "rule": match.rule.name,
+            "generator": generator_name,
+            "template_key": template_key,
+            "language": language,
+            "reply_text": reply.text,
+            "prompt": reply.prompt,
+        }
 
     def _skip_reason(self, comment: FetchedComment) -> str | None:
         if not comment.can_reply:
@@ -202,48 +289,29 @@ class CommentReplier:
             return "already_replied"
         return None
 
-    def _post_reply(
-        self,
-        comment: FetchedComment,
-        reply_text: str,
-        match: RuleMatch,
-        video_title: str,
-        plan: ReplyPlan,
-    ) -> bool:
+    def _post_reply(self, comment: FetchedComment, metadata: dict, plan: ReplyPlan) -> bool:
         try:
             self._youtube.comments().insert(
                 part="snippet",
                 body={
                     "snippet": {
                         "parentId": comment.comment_id,
-                        "textOriginal": reply_text,
+                        "textOriginal": metadata["reply_text"],
                     }
                 },
             ).execute()
-        except HttpError as e:
-            status = getattr(getattr(e, "resp", None), "status", None)
-            plan.errors.append(
-                self._error_record(
-                    comment,
-                    f"comments.insert 失敗: status={status} {e}",
-                )
-            )
+        except HttpError as error:
+            status = getattr(getattr(error, "resp", None), "status", None)
+            plan.errors.append(self._error_record(comment, f"comments.insert 失敗: status={status} {error}"))
             return False
 
-        metadata = {
-            "video_id": comment.video_id,
-            "video_title": video_title,
-            "comment_author": comment.author,
-            "rule": match.rule.name,
-            "template_key": match.rule.template_key,
-            "language": match.template_language,
+        persisted = {
+            **metadata,
             "replied_at": datetime.now(timezone.utc).isoformat(),
-            "reply_text": reply_text,
         }
-        self._history.mark_replied(comment.comment_id, metadata)
-        # 途中断絶時の二重返信を防ぐため、返信成功ごとに履歴を永続化する
+        self._history.mark_replied(comment.comment_id, persisted)
         self._history.save()
-        plan.replied.append({"comment_id": comment.comment_id, **metadata})
+        plan.replied.append({"comment_id": comment.comment_id, **persisted})
         return True
 
     @staticmethod

--- a/src/youtube_automation/utils/comments/rule_engine.py
+++ b/src/youtube_automation/utils/comments/rule_engine.py
@@ -13,8 +13,9 @@ class RuleMatch:
     """ルールマッチ結果."""
 
     rule: CommentRule
-    template_language: str
-    template_text: str
+    generator_name: str
+    template_language: str | None
+    template_text: str | None
 
 
 class RuleEngine:
@@ -34,12 +35,14 @@ class RuleEngine:
         *,
         default_language: str,
         ng_words: list[str] | None = None,
+        default_generator_name: str,
     ):
         self._rules = sorted(enumerate(rules), key=lambda iv: (-iv[1].priority, iv[0]))
         self._templates = templates
         self._default_language = default_language
         self._ng_words = [w.lower() for w in (ng_words or []) if w]
         self._pattern_cache: dict[str, re.Pattern[str]] = {}
+        self._default_generator_name = default_generator_name
 
     def _compiled(self, pattern: str) -> re.Pattern[str]:
         if pattern not in self._pattern_cache:
@@ -73,9 +76,28 @@ class RuleEngine:
         for _, rule in self._rules:
             if not self._rule_matches(rule, text, lowered):
                 continue
+            generator_name = rule.generator or self._default_generator_name
+            if generator_name != "template":
+                resolved = self._resolve_template(rule)
+                if resolved is None:
+                    template_language = None
+                    template_text = None
+                else:
+                    template_language, template_text = resolved
+                return RuleMatch(
+                    rule=rule,
+                    generator_name=generator_name,
+                    template_language=template_language,
+                    template_text=template_text,
+                )
             resolved = self._resolve_template(rule)
             if resolved is None:
                 continue
             language, template_text = resolved
-            return RuleMatch(rule=rule, template_language=language, template_text=template_text)
+            return RuleMatch(
+                rule=rule,
+                generator_name="template",
+                template_language=language,
+                template_text=template_text,
+            )
         return None

--- a/src/youtube_automation/utils/config/comments.py
+++ b/src/youtube_automation/utils/config/comments.py
@@ -4,6 +4,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+SUPPORTED_REPLY_GENERATORS = ("template", "gemini")
+SUPPORTED_GENERATOR_ERROR_FALLBACKS = ("template", "skip")
+
+
+@dataclass(frozen=True)
+class GeneratorConfig:
+    """返信 generator の既定設定."""
+
+    type: str = "template"
+    model: str = ""
+    channel_persona: str = ""
+    max_length: int = 280
+    fallback_on_error: str = "template"
+    min_interval_sec: float = 0.0
+
 
 @dataclass(frozen=True)
 class CommentRule:
@@ -22,6 +37,7 @@ class CommentRule:
     template_key: str = "default"
     language: str | None = None
     priority: int = 0
+    generator: str | None = None
 
 
 @dataclass(frozen=True)
@@ -46,3 +62,4 @@ class Comments:
     delay_between_replies_sec: float = 2.0
     history_file: str = "comment_reply_history.json"
     skip_held_for_review: bool = True
+    generator: GeneratorConfig = field(default_factory=GeneratorConfig)

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -9,7 +9,13 @@ from pathlib import Path
 
 from youtube_automation.utils.config.analytics import Analytics, Benchmark
 from youtube_automation.utils.config.audio import Audio
-from youtube_automation.utils.config.comments import CommentRule, Comments
+from youtube_automation.utils.config.comments import (
+    SUPPORTED_GENERATOR_ERROR_FALLBACKS,
+    SUPPORTED_REPLY_GENERATORS,
+    CommentRule,
+    Comments,
+    GeneratorConfig,
+)
 from youtube_automation.utils.config.config import ChannelConfig
 from youtube_automation.utils.config.content import Content, Descriptions, Genre, Tags, Title
 from youtube_automation.utils.config.localizations import Localizations
@@ -323,6 +329,16 @@ def _build_audio(merged: dict) -> Audio:
 
 def _build_comments(merged: dict) -> Comments:
     cm = merged.get("comments") or {}
+    generator_raw = cm.get("generator") or {}
+    generator_type = str(generator_raw.get("type", "template"))
+    if generator_type not in SUPPORTED_REPLY_GENERATORS:
+        raise ConfigError(f"comments.generator.type は {SUPPORTED_REPLY_GENERATORS} のいずれかでなければなりません")
+    fallback_on_error = str(generator_raw.get("fallback_on_error", "template"))
+    if fallback_on_error not in SUPPORTED_GENERATOR_ERROR_FALLBACKS:
+        raise ConfigError(
+            "comments.generator.fallback_on_error は "
+            f"{SUPPORTED_GENERATOR_ERROR_FALLBACKS} のいずれかでなければなりません"
+        )
     rules_raw = cm.get("rules") or []
     rules: list[CommentRule] = []
     for i, raw in enumerate(rules_raw):
@@ -331,6 +347,11 @@ def _build_comments(merged: dict) -> Comments:
         name = raw.get("name")
         if not name:
             raise ConfigError(f"comments.rules[{i}].name が必須です")
+        rule_generator = raw.get("generator")
+        if rule_generator is not None and rule_generator not in SUPPORTED_REPLY_GENERATORS:
+            raise ConfigError(
+                f"comments.rules[{i}].generator は {SUPPORTED_REPLY_GENERATORS} のいずれかでなければなりません"
+            )
         rules.append(
             CommentRule(
                 name=name,
@@ -339,6 +360,7 @@ def _build_comments(merged: dict) -> Comments:
                 template_key=raw.get("template_key", "default"),
                 language=raw.get("language"),
                 priority=int(raw.get("priority", 0)),
+                generator=rule_generator,
             )
         )
     templates_raw = cm.get("templates") or {}
@@ -359,6 +381,14 @@ def _build_comments(merged: dict) -> Comments:
         delay_between_replies_sec=float(cm.get("delay_between_replies_sec", 2.0)),
         history_file=str(cm.get("history_file", "comment_reply_history.json")),
         skip_held_for_review=bool(cm.get("skip_held_for_review", True)),
+        generator=GeneratorConfig(
+            type=generator_type,
+            model=str(generator_raw.get("model", "")),
+            channel_persona=str(generator_raw.get("channel_persona", "")),
+            max_length=int(generator_raw.get("max_length", 280)),
+            fallback_on_error=fallback_on_error,
+            min_interval_sec=float(generator_raw.get("min_interval_sec", 0.0)),
+        ),
     )
 
 

--- a/tests/integration/test_comments_reply_generator_flow.py
+++ b/tests/integration/test_comments_reply_generator_flow.py
@@ -1,0 +1,149 @@
+"""comments.generator 設定が loader → replier → history まで伝搬する統合テスト."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from youtube_automation.utils.comments.generator.base import GeneratedReply
+from youtube_automation.utils.comments.replier import CommentReplier
+from youtube_automation.utils.config import load_config, reset
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _channel_sections() -> dict[str, dict]:
+    return {
+        "meta.json": {
+            "channel": {
+                "name": "Test Channel",
+                "short": "TC",
+                "youtube_handle": "@testchannel",
+                "url": "https://youtube.com/@testchannel",
+            }
+        },
+        "content.json": {
+            "genre": {"primary": "jazz", "style": "lo-fi", "context": "rainy night"},
+            "tags": {
+                "base": ["jazz"],
+                "themes": {"night": ["night jazz"]},
+            },
+            "descriptions": {
+                "opening": "opening",
+                "perfect_for": ["studying"],
+                "hashtags": ["#Jazz"],
+            },
+            "title": {"template": "{theme} - {activity}"},
+        },
+        "youtube.json": {
+            "youtube": {
+                "category_id": "10",
+                "privacy_status": "public",
+                "language": "ja",
+            }
+        },
+        "comments.json": {
+            "comments": {
+                "enabled": True,
+                "generator": {
+                    "type": "gemini",
+                    "model": "gemini-2.5-flash",
+                    "channel_persona": "Rain Jazz Night host",
+                    "max_length": 180,
+                    "fallback_on_error": "template",
+                    "min_interval_sec": 2.5,
+                },
+                "rules": [
+                    {
+                        "name": "default_ai",
+                        "pattern": ".+",
+                        "generator": "gemini",
+                    }
+                ],
+                "templates": {
+                    "ja": {
+                        "default": "ありがとうございます！",
+                    }
+                },
+            }
+        },
+    }
+
+
+def _setup_channel(tmp_path: Path) -> Path:
+    channel_dir = tmp_path / "channel"
+    for filename, data in _channel_sections().items():
+        _write_json(channel_dir / "config" / "channel" / filename, data)
+    return channel_dir
+
+
+def _mock_youtube() -> MagicMock:
+    yt = MagicMock()
+    yt.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "v1", "snippet": {"title": "Night Rain Jazz"}}]
+    }
+
+    def _list(**_kwargs):
+        result = MagicMock()
+        result.execute.return_value = {
+            "items": [
+                {
+                    "snippet": {
+                        "canReply": True,
+                        "totalReplyCount": 0,
+                        "topLevelComment": {
+                            "id": "c1",
+                            "snippet": {
+                                "authorDisplayName": "Alice",
+                                "textOriginal": "first!",
+                                "publishedAt": "2026-04-01T00:00:00Z",
+                            },
+                        },
+                    }
+                }
+            ]
+        }
+        return result
+
+    yt.commentThreads.return_value.list.side_effect = _list
+    yt.comments.return_value.insert.return_value.execute.return_value = {"id": "reply1"}
+    return yt
+
+
+def test_loader_configured_generator_reaches_replier_and_history(tmp_path, monkeypatch):
+    class _Generator:
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, ctx):
+            self.calls.append(ctx)
+            return GeneratedReply(text="AI reply", prompt="generated prompt")
+
+    generator = _Generator()
+    channel_dir = _setup_channel(tmp_path)
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": generator},
+    )
+    reset()
+
+    config = load_config()
+    replier = CommentReplier(
+        _mock_youtube(),
+        config=config.comments,
+        channel_dir=channel_dir,
+        default_language=config.youtube.api.language,
+    )
+
+    plan = replier.run(dry_run=False, video_ids=["v1"])
+
+    assert len(plan.replied) == 1
+    assert plan.replied[0]["generator"] == "gemini"
+    assert plan.replied[0]["prompt"] == "generated prompt"
+    assert generator.calls[0].channel_persona == "Rain Jazz Night host"
+    assert generator.calls[0].max_length == 180

--- a/tests/test_comments_generator_gemini.py
+++ b/tests/test_comments_generator_gemini.py
@@ -1,0 +1,85 @@
+"""GeminiGenerator の単体テスト."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from youtube_automation.utils.comments.generator.base import ReplyContext
+from youtube_automation.utils.comments.generator.gemini import GeminiGenerator
+
+
+def _reply_context(*, max_length: int = 280) -> ReplyContext:
+    return ReplyContext(
+        video_id="v1",
+        video_title="Night Rain Jazz",
+        comment_id="c1",
+        comment_text="first!",
+        comment_author="Alice",
+        language=None,
+        channel_persona="Rain Jazz Night host",
+        max_length=max_length,
+        parent_thread=None,
+    )
+
+
+def test_generate_returns_text_and_prompt(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = SimpleNamespace(text="Warm reply from Gemini")
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.generator.gemini.create_genai_client",
+        lambda location=None: mock_client,
+    )
+
+    generator = GeminiGenerator(model="gemini-2.5-flash", min_interval_sec=0.0)
+
+    reply = generator.generate(_reply_context())
+
+    assert reply.text == "Warm reply from Gemini"
+    assert "Rain Jazz Night host" in reply.prompt
+    assert "Night Rain Jazz" in reply.prompt
+    assert "first!" in reply.prompt
+    kwargs = mock_client.models.generate_content.call_args.kwargs
+    assert kwargs["model"] == "gemini-2.5-flash"
+
+
+def test_generate_retries_after_transient_error(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = [
+        RuntimeError("temporary timeout"),
+        SimpleNamespace(text="Recovered reply"),
+    ]
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.generator.gemini.create_genai_client",
+        lambda location=None: mock_client,
+    )
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.generator.gemini.time.sleep",
+        sleep_calls.append,
+    )
+
+    generator = GeminiGenerator(model="gemini-2.5-flash", min_interval_sec=0.0)
+
+    reply = generator.generate(_reply_context())
+
+    assert reply.text == "Recovered reply"
+    assert mock_client.models.generate_content.call_count == 2
+    assert sleep_calls
+
+
+def test_generate_truncates_to_max_length_and_warns(monkeypatch, caplog):
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = SimpleNamespace(text="ABCDEFGHIJKLMN")
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.generator.gemini.create_genai_client",
+        lambda location=None: mock_client,
+    )
+
+    generator = GeminiGenerator(model="gemini-2.5-flash", min_interval_sec=0.0)
+
+    with caplog.at_level("WARNING"):
+        reply = generator.generate(_reply_context(max_length=10))
+
+    assert reply.text == "ABCDEFGHIJ"
+    assert any("max_length" in record.message for record in caplog.records)

--- a/tests/test_comments_generator_template.py
+++ b/tests/test_comments_generator_template.py
@@ -1,0 +1,29 @@
+"""TemplateGenerator の単体テスト."""
+
+from __future__ import annotations
+
+from youtube_automation.utils.comments.generator.base import GeneratedReply, ReplyContext
+from youtube_automation.utils.comments.generator.template import TemplateGenerator
+
+
+def test_template_generator_renders_context_fields_from_template_text():
+    generator = TemplateGenerator()
+    ctx = ReplyContext(
+        video_id="v1",
+        video_title="Night Rain Jazz",
+        comment_id="c1",
+        comment_text="first!",
+        comment_author="Alice",
+        language="ja",
+        channel_persona="Rain Jazz Night host",
+        max_length=280,
+        parent_thread=None,
+        template_text="{comment_author}さん、{video_title} へようこそ。『{comment_text}』ありがとう！",
+    )
+
+    reply = generator.generate(ctx)
+
+    assert reply == GeneratedReply(
+        text="Aliceさん、Night Rain Jazz へようこそ。『first!』ありがとう！",
+        prompt=None,
+    )

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
 
+from youtube_automation.utils.comments.generator.base import GeneratedReply
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.replier import CommentReplier
-from youtube_automation.utils.config.comments import CommentRule, Comments
+from youtube_automation.utils.config.comments import CommentRule, Comments, GeneratorConfig
 
 
 def _mock_youtube(
@@ -101,6 +103,14 @@ def _make_config(**overrides) -> Comments:
         delay_between_replies_sec=0.0,
         history_file="comment_reply_history.json",
         skip_held_for_review=True,
+        generator=GeneratorConfig(
+            type="template",
+            model="",
+            channel_persona="",
+            max_length=280,
+            fallback_on_error="template",
+            min_interval_sec=0.0,
+        ),
     )
     base.update(overrides)
     return Comments(**base)
@@ -301,3 +311,284 @@ def test_no_match_reasons(tmp_path, reason_text, expected_reason):
     plan = replier.run(dry_run=True)
     assert plan.planned == []
     assert any(row["reason"] == expected_reason for row in plan.skipped)
+
+
+def test_dry_run_records_llm_prompt_and_generator_metadata(tmp_path, monkeypatch):
+    class _Generator:
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, ctx):
+            self.calls.append(ctx)
+            return GeneratedReply(
+                text="Aliceさん、来てくれてありがとう！",
+                prompt="reply to Alice in rainy jazz tone",
+            )
+
+    generator = _Generator()
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": generator},
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "first!", "author": "Alice"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="default_ai", pattern=r".+", language="en", priority=0, generator="gemini")],
+            templates={},
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=180,
+                fallback_on_error="template",
+                min_interval_sec=0.0,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert len(plan.planned) == 1
+    assert plan.planned[0]["generator"] == "gemini"
+    assert plan.planned[0]["template_key"] is None
+    assert plan.planned[0]["prompt"] == "reply to Alice in rainy jazz tone"
+    assert plan.planned[0]["reply_text"] == "Aliceさん、来てくれてありがとう！"
+    assert plan.planned[0]["language"] is None
+    assert generator.calls[0].language is None
+    assert generator.calls[0].parent_thread is None
+    assert generator.calls[0].channel_persona == "Rain Jazz Night host"
+    assert generator.calls[0].max_length == 180
+    yt._insert_mock.execute.assert_not_called()
+
+
+def test_dry_run_truncates_generated_reply_to_max_length_and_warns(tmp_path, monkeypatch, caplog):
+    class _Generator:
+        def generate(self, _ctx):
+            return GeneratedReply(text="ABCDEFGHIJKLMN", prompt="reply briefly")
+
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": _Generator()},
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "first!", "author": "Alice"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="default_ai", pattern=r".+", priority=0, generator="gemini")],
+            templates={},
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=10,
+                fallback_on_error="template",
+                min_interval_sec=0.0,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    with caplog.at_level("WARNING"):
+        plan = replier.run(dry_run=True)
+
+    assert len(plan.planned) == 1
+    assert plan.planned[0]["reply_text"] == "ABCDEFGHIJ"
+    assert any("max_length" in record.message for record in caplog.records)
+
+
+def test_generator_error_falls_back_to_template(tmp_path, monkeypatch):
+    class _FailingGenerator:
+        def generate(self, _ctx):
+            raise RuntimeError("gemini unavailable")
+
+    class _TemplateGenerator:
+        def __init__(self):
+            self.called = 0
+
+        def generate(self, _ctx):
+            self.called += 1
+            return GeneratedReply(text="Aliceさん、ありがとう！", prompt=None)
+
+    template_generator = _TemplateGenerator()
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {
+            "gemini": _FailingGenerator(),
+            "template": template_generator,
+        },
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "Alice"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="greeting", keywords=["こんにちは"], template_key="greet", generator="gemini")],
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=180,
+                fallback_on_error="template",
+                min_interval_sec=0.0,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert len(plan.planned) == 1
+    assert plan.planned[0]["reply_text"] == "Aliceさん、ありがとう！"
+    assert template_generator.called == 1
+    assert plan.errors == []
+
+
+def test_generator_error_with_skip_fallback_records_skipped_without_insert(tmp_path, monkeypatch):
+    class _FailingGenerator:
+        def generate(self, _ctx):
+            raise RuntimeError("gemini unavailable")
+
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": _FailingGenerator()},
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "Alice"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="greeting", keywords=["こんにちは"], template_key="greet", generator="gemini")],
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=180,
+                fallback_on_error="skip",
+                min_interval_sec=0.0,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    plan = replier.run(dry_run=False)
+
+    assert plan.planned == []
+    assert plan.replied == []
+    assert any(row["comment_id"] == "c1" for row in plan.skipped)
+    yt._insert_mock.execute.assert_not_called()
+
+
+def test_dry_run_rate_limits_llm_generation_separately_from_reply_delay(tmp_path, monkeypatch):
+    class _Generator:
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, ctx):
+            self.calls.append(ctx.comment_id)
+            return GeneratedReply(text=f"reply-{ctx.comment_id}", prompt=f"prompt-{ctx.comment_id}")
+
+    generator = _Generator()
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": generator},
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {"comment_id": "c1", "text": "first!", "author": "Alice"},
+                {"comment_id": "c2", "text": "nice!", "author": "Bob"},
+            ]
+        },
+    )
+    sleep_calls: list[float] = []
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="default_ai", pattern=r".+", priority=0, generator="gemini")],
+            templates={},
+            delay_between_replies_sec=0.0,
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=180,
+                fallback_on_error="template",
+                min_interval_sec=2.5,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+        sleep_fn=sleep_calls.append,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert [row["comment_id"] for row in plan.planned] == ["c1", "c2"]
+    assert generator.calls == ["c1", "c2"]
+    assert sleep_calls == [2.5]
+    yt._insert_mock.execute.assert_not_called()
+
+
+def test_apply_persists_generator_metadata_in_history(tmp_path, monkeypatch):
+    class _Generator:
+        def generate(self, _ctx):
+            return GeneratedReply(text="Custom reply", prompt="custom prompt")
+
+    monkeypatch.setattr(
+        "youtube_automation.utils.comments.replier.build_generators",
+        lambda config: {"gemini": _Generator()},
+    )
+
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "first!", "author": "Alice"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(
+            rules=[CommentRule(name="default_ai", pattern=r".+", priority=0, generator="gemini")],
+            templates={},
+            generator=GeneratorConfig(
+                type="gemini",
+                model="gemini-2.5-flash",
+                channel_persona="Rain Jazz Night host",
+                max_length=180,
+                fallback_on_error="template",
+                min_interval_sec=0.0,
+            ),
+        ),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    plan = replier.run(dry_run=False)
+    history_data = json.loads((tmp_path / "comment_reply_history.json").read_text(encoding="utf-8"))
+
+    assert len(plan.replied) == 1
+    assert plan.replied[0]["generator"] == "gemini"
+    assert plan.replied[0]["template_key"] is None
+    assert history_data["replied"]["c1"]["generator"] == "gemini"
+    assert history_data["replied"]["c1"]["template_key"] is None
+    assert history_data["replied"]["c1"]["prompt"] == "custom prompt"

--- a/tests/test_comments_rule_engine.py
+++ b/tests/test_comments_rule_engine.py
@@ -12,6 +12,7 @@ def _engine(rules, templates, ng_words=None, default_language="ja"):
         templates=templates,
         default_language=default_language,
         ng_words=ng_words,
+        default_generator_name="template",
     )
 
 
@@ -96,3 +97,71 @@ def test_case_insensitive_keyword():
         templates={"ja": {"g": "hi"}},
     )
     assert engine.evaluate("HELLO world") is not None
+
+
+def test_non_template_rule_returns_match_without_template_resolution():
+    engine = RuleEngine(
+        rules=[CommentRule(name="catch_all_ai", pattern=r".+", generator="gemini")],
+        templates={},
+        default_language="ja",
+        default_generator_name="template",
+    )
+
+    match = engine.evaluate("first!")
+
+    assert match is not None
+    assert match.rule.name == "catch_all_ai"
+    assert match.generator_name == "gemini"
+    assert match.template_language is None
+    assert match.template_text is None
+
+
+def test_generator_rule_ignores_rule_language_when_matching():
+    engine = RuleEngine(
+        rules=[CommentRule(name="catch_all_ai", pattern=r".+", language="en", generator="gemini")],
+        templates={},
+        default_language="ja",
+        default_generator_name="template",
+    )
+
+    match = engine.evaluate("first!")
+
+    assert match is not None
+    assert match.rule.name == "catch_all_ai"
+    assert match.generator_name == "gemini"
+    assert match.template_language is None
+    assert match.template_text is None
+
+
+def test_default_generator_applies_when_rule_has_no_override():
+    engine = RuleEngine(
+        rules=[CommentRule(name="greet", keywords=["hello"], template_key="missing")],
+        templates={},
+        default_language="en",
+        default_generator_name="gemini",
+    )
+
+    match = engine.evaluate("hello there")
+
+    assert match is not None
+    assert match.rule.name == "greet"
+    assert match.generator_name == "gemini"
+    assert match.template_language is None
+    assert match.template_text is None
+
+
+def test_template_rule_can_override_global_gemini_default():
+    engine = RuleEngine(
+        rules=[CommentRule(name="greet", keywords=["hello"], template_key="greet", generator="template")],
+        templates={"en": {"greet": "Thanks for listening!"}},
+        default_language="en",
+        default_generator_name="gemini",
+    )
+
+    match = engine.evaluate("hello there")
+
+    assert match is not None
+    assert match.rule.name == "greet"
+    assert match.generator_name == "template"
+    assert match.template_language == "en"
+    assert match.template_text == "Thanks for listening!"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -122,6 +122,12 @@ def test_load_minimal_sections(tmp_path, monkeypatch):
     assert config.comments.rules == []
     assert config.comments.templates == {}
     assert config.comments.max_replies_per_run == 20
+    assert config.comments.generator.type == "template"
+    assert config.comments.generator.model == ""
+    assert config.comments.generator.channel_persona == ""
+    assert config.comments.generator.max_length == 280
+    assert config.comments.generator.fallback_on_error == "template"
+    assert config.comments.generator.min_interval_sec == 0.0
 
 
 def test_load_all_sections(tmp_path, monkeypatch):
@@ -149,6 +155,14 @@ def test_load_all_sections(tmp_path, monkeypatch):
             "enabled": True,
             "max_replies_per_run": 5,
             "delay_between_replies_sec": 1.0,
+            "generator": {
+                "type": "gemini",
+                "model": "gemini-2.5-flash",
+                "channel_persona": "Rain Jazz Night host",
+                "max_length": 180,
+                "fallback_on_error": "skip",
+                "min_interval_sec": 3.5,
+            },
             "rules": [
                 {
                     "name": "greet_ja",
@@ -156,6 +170,7 @@ def test_load_all_sections(tmp_path, monkeypatch):
                     "template_key": "greet",
                     "language": "ja",
                     "priority": 10,
+                    "generator": "gemini",
                 }
             ],
             "templates": {"ja": {"greet": "ありがとうございます！"}},
@@ -195,9 +210,16 @@ def test_load_all_sections(tmp_path, monkeypatch):
     assert config.comments.enabled is True
     assert config.comments.max_replies_per_run == 5
     assert config.comments.delay_between_replies_sec == 1.0
+    assert config.comments.generator.type == "gemini"
+    assert config.comments.generator.model == "gemini-2.5-flash"
+    assert config.comments.generator.channel_persona == "Rain Jazz Night host"
+    assert config.comments.generator.max_length == 180
+    assert config.comments.generator.fallback_on_error == "skip"
+    assert config.comments.generator.min_interval_sec == 3.5
     assert len(config.comments.rules) == 1
     assert config.comments.rules[0].name == "greet_ja"
     assert config.comments.rules[0].keywords == ["こんにちは"]
+    assert config.comments.rules[0].generator == "gemini"
     assert config.comments.templates == {"ja": {"greet": "ありがとうございます！"}}
     assert config.comments.ng_words == ["spam"]
     # shorts セクションが全フィールド組み立てられている
@@ -283,6 +305,22 @@ def test_comments_templates_must_be_object(tmp_path, monkeypatch):
     monkeypatch.setenv("CHANNEL_DIR", str(ch))
 
     with pytest.raises(ConfigError, match="comments.templates"):
+        load_config()
+
+
+def test_comments_generator_type_must_be_supported(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["comments.json"] = {
+        "comments": {
+            "generator": {
+                "type": "unknown",
+            }
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match="comments.generator.type"):
         load_config()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- `utils/comments/generator/` パッケージ新規追加（`ReplyGenerator` Protocol、`TemplateGenerator`、`GeminiGenerator`）
- `utils/comments/replier.py` を generator-based に refactor（既存 template ロジックは `TemplateGenerator` で wrap）
- `utils/comments/rule_engine.py` に `RuleMatch.generator` を追加
- `utils/config/comments.py` に `generator` セクション dataclass を追加（後方互換: 省略時は `template`）
- `scripts/comment_reply.py` の wiring を更新
- 安全網: `max_length` 切り詰め / `fallback_on_error` / dry-run 時の prompt 表示
- 多数のテスト追加: `test_comments_generator_gemini.py` / `test_comments_generator_template.py` / `tests/integration/test_comments_reply_generator_flow.py` 他

## Note: takt workflow の状態

> [!IMPORTANT]
> takt の自動 workflow は **`write_tests_review` ステップ（coder-scope.md レポート生成）で Codex usage limit に当たり中断**した。
> 4 task の中で最も早い段階での失敗で、後段の review / fix / self_review / ci_verify はすべて未実施。
> 実装コードは worktree に未コミット状態で残っていたものを手動で commit/push/PR 化したもの。
> 大型機能追加かつ複数 reviewer のチェックが走っていないため、レビュー側で慎重に品質確認をお願いします。

`ReplyContext.parent_thread` は #365 統合後の前提（#365 の `parent_id` 機構を活用）。

Closes #366
