### PR TITLE
[#369] issue-369-refactor-cli-sync-di

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(cli)`: `cli/skills_sync/_sync.py::_sync_dir_asset` で重複していた `_list_entries` 呼び出しを 1 回に統一（#369）
+
 ## [5.5.2] - 2026-05-20
 
 ### Added

--- a/src/youtube_automation/cli/skills_sync/_sync.py
+++ b/src/youtube_automation/cli/skills_sync/_sync.py
@@ -72,7 +72,8 @@ def _sync_dir_asset(
     """ディレクトリ asset の sync。target は **ディレクトリパス** として扱う。"""
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    entries = _list_entries(root, kind=spec["kind"], source_filename=spec.get("source_filename"))
+    all_entries = _list_entries(root, kind=spec["kind"], source_filename=spec.get("source_filename"))
+    entries = list(all_entries)
     if args.only:
         only = set(args.only)
         entries = [s for s in entries if s in only]
@@ -93,7 +94,7 @@ def _sync_dir_asset(
     if args.prune:
         # bundled は **全集合** で判定する (--only でフィルタしない)。
         # `--only` 集合と混同すると bundled の他 entry が誤って prune される。
-        bundled = set(_list_entries(root, kind=spec["kind"], source_filename=spec.get("source_filename")))
+        bundled = set(all_entries)
         do_delete = args.yes and not args.dry_run
         prune_counts = _prune_orphans(target_dir, bundled, do_delete=do_delete)
         for key, val in prune_counts.items():

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -615,6 +615,45 @@ def test_cmd_sync_prune_only_removes_real_orphan(fake_repo: Path, tmp_path: Path
     assert not (target / "analyze").exists()
 
 
+def test_cmd_sync_prune_only_lists_entries_once(
+    fake_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Given: `--only` と `--prune` を併用しても bundled 判定は初回取得結果を再利用する
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "sync",
+            "--target",
+            str(target),
+            "--force",
+            "--only",
+            "channel-research",
+            "--prune",
+            "--yes",
+        ]
+    )
+
+    import youtube_automation.cli.skills_sync._sync as sync_module
+
+    call_count = 0
+    original_list_entries = sync_module._list_entries
+
+    def counting_list_entries(*args: object, **kwargs: object) -> list[str]:
+        nonlocal call_count
+        call_count += 1
+        return original_list_entries(*args, **kwargs)
+
+    monkeypatch.setattr(sync_module, "_list_entries", counting_list_entries)
+
+    # When: sync を実行
+    rc = args.func(args)
+
+    # Then: `_list_entries` は 1 回だけ呼ばれる
+    assert rc == 0
+    assert call_count == 1
+
+
 def test_cmd_sync_prune_file_asset_warns_on_stderr(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 背景

Issue #327 で `src/youtube_automation/cli/skills_sync.py` を package 分割した際に持ち越された finding（`ARCH-NEW-sync-L75`、architect-review・supervisor-validation 双方で記録）。

`src/youtube_automation/cli/skills_sync/_sync.py::_sync_dir_asset` 内で `_list_entries(...)` が同一引数で 2 回呼ばれている:

- `_sync.py:75` — フィルタ前の entries 取得（`--only` を適用する基準）
- `_sync.py:96` — `--prune` 用に bundled の **全集合** を取得

`_list_entries` は `importlib.resources.as_file(...)` で wheel 内 `_skills/` をマウントしつつ `iterdir()` する関数で、同一引数で 2 回呼ぶと FS 走査も 2 回発生する（軽微なオーバーヘッドだが冗長）。

## 提案

1 回目の呼び出し結果（`--only` フィルタ前）を local 変数に保持し、`--prune` でもそれを再利用する。

```python
all_entries = _list_entries(root, kind=spec[\"kind\"], source_filename=spec.get(\"source_filename\"))
entries = list(all_entries)
if args.only:
    only = set(args.only)
    entries = [s for s in entries if s in only]
    ...

if args.prune:
    bundled = set(all_entries)
    ...
```

## 完了条件

- [ ] `_sync_dir_asset` 内で `_list_entries` の呼び出しが 1 回に統一されている
- [ ] `tests/test_skills_sync.py` / `tests/test_skills_sync_claude_md.py` / `tests/test_skills_sync_package.py` 全 pass
- [ ] `--only` フィルタと `--prune` の挙動は不変

## 関連

- Issue #327（package 分割時に verbatim 移植スコープのため持ち越し）
- `.takt/runs/20260518-060727-issue-327-refactor-cli-skills/reports/architect-review.md` 継続指摘表 #1
- `.takt/runs/20260518-060727-issue-327-refactor-cli-skills/reports/supervisor-validation.md` 継続指摘 #1

## Execution Report

Workflow `default-mini` completed successfully.

Closes #369