### PR TITLE
[#165] issue-165-medium-tfstate-wo-re

### DIFF
--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -17,6 +17,7 @@ Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に
 - `terraform` >= 1.5 インストール済み
 - Vultr API キーを 1Password に保管済み（または環境変数で渡せる状態）
 - `yt-fetch-stream-key --vault=Personal --item=YouTube` でストリームキーを 1Password に保管済み（初回のみ）
+- Terraform state 用の S3 bucket `youtube-automation-tfstate`、KMS key `alias/tfstate`、DynamoDB lock table `tfstate-lock` を AWS `ap-northeast-1` に作成済み
 - SSH 鍵ペア `~/.ssh/yt_stream_key` / `~/.ssh/yt_stream_key.pub` を生成済み
 - ssh-agent が起動済み（`SSH_AUTH_SOCK` が設定されている）かつ秘密鍵が登録済み（`ssh-add ~/.ssh/yt_stream_key`）。`null_resource.deploy.connection` は `agent = true` で ssh-agent 経由に接続するため、ssh-agent 未起動 / 鍵未登録 のいずれでも apply 時に `Permission denied (publickey)` で失敗する。`ssh-add -l` で登録済み鍵を確認できる（`Could not open a connection to your authentication agent.` が返れば agent 未起動）
     - **ssh-agent への登録は OS 起動時に自動では行われない**: macOS の launchd keychain 連携を別途設定していない限り、再起動・再ログインで agent は空になる。毎セッションで `ssh-add ~/.ssh/yt_stream_key` を実行する必要がある
@@ -40,17 +41,21 @@ export TF_VAR_vultr_api_key=$(op read 'op://Personal/Vultr/api_key')
 export TF_VAR_stream_key=$(op read 'op://Personal/YouTube/stream_key')
 export TF_VAR_discord_webhook_url=$(op read 'op://Personal/YouTube_Stream_Discord_Webhook/url')
 
-# 3. apply
+# 3. backend を初期化
 terraform init
+
+# 4. apply
 terraform plan
 terraform apply
 ```
 
-`terraform.tfvars` および環境変数いずれにも secret 値を書かない（`stream_key` / `vultr_api_key` は `TF_VAR_*` のみ）。
+`terraform.tfvars` には secret 値を書かない（`stream_key` / `vultr_api_key` は `TF_VAR_*` のみ）。
 
 > **tfstate と secret の関係（誤解しやすいので明記）**
 >
-> Terraform の `sensitive = true` は `terraform plan` / `apply` の **CLI 出力マスクのみ** で、`*.tfstate` JSON 自体は **平文**である。本モジュールでは `stream_key` を `triggers` に保存する際 `nonsensitive(sha256(var.stream_key))` で SHA256 ラップしているため、tfstate を取得されても元のストリームキーは復元できない（SHA256 は不可逆）。`*.tfstate*` は `.gitignore` 済みだが、ローカル / バックアップ / 共有時もファイルパーミッションでアクセス制御すること。
+> Terraform の `sensitive = true` は `terraform plan` / `apply` の **CLI 出力マスクのみ**で、tfstate JSON の値を暗号化しない。本モジュールは `backend "s3"` を使い、S3 server-side encryption（KMS）と DynamoDB lock で `streaming/terraform.tfstate` をリモート管理する。`triggers` に保存する `stream_key` / Discord Webhook URL は `nonsensitive(sha256(...))` で高エントロピー値の不可逆ハッシュだけを残すため、元値は復元できない。この扱いは高エントロピーの secret に限る。低エントロピー値や IP アドレスなどを hash 化しても secret 保護にはならない。
+>
+> 既存のローカル state がある環境で初回 `terraform init` を実行すると backend 移行確認が出る。移行する場合は state の保存先が `youtube-automation-tfstate` bucket / `streaming/terraform.tfstate` に変わることを確認してから承認する。
 
 ## 配信サイクル（11h + 1h）
 
@@ -201,7 +206,7 @@ Discord Webhook URL を `/etc/youtube-stream-healthcheck.env` から読み、`cu
 `var.allowed_ssh_cidr` が空 `[]` のまま `terraform plan` / `apply` を実行している（`validation { condition = length(var.allowed_ssh_cidr) > 0 }` で fail-fast）。`terraform.tfvars` の `allowed_ssh_cidr` に operator の IP/32 を 1 件以上記入する。`curl -s ifconfig.me` で自分のグローバル IP を取得し、`["203.0.113.5/32"]` 形式で渡す。
 
 ### `Error: Output refers to sensitive values`
-`triggers.stream_key` を `sha256(var.stream_key)` のまま書くとこのエラーが出る。本モジュールでは `nonsensitive(sha256(...))` でラップ済み（SHA256 は不可逆なので脱 sensitive 安全）。
+`triggers.stream_key` を `sha256(var.stream_key)` のまま書くとこのエラーが出る。本モジュールでは高エントロピーの secret だけを `nonsensitive(sha256(...))` で不可逆ハッシュ化し、変更検知用の値として state に保存している。
 
 ### `Permission denied (publickey)`（provisioner SSH 失敗）
 `null_resource.deploy.connection` は `agent = true` で ssh-agent 経由に接続する（鍵を Terraform graph に持ち込まないため）。**`ssh -i ~/.ssh/yt_stream_key root@<ip>` 経由の手動 SSH が通っても agent 状態とは独立で原因切り分けにならない**（`-i` は鍵ファイル直読み、provisioner は agent 経由）。判定は `ssh-add -l` の出力のみで行う。失敗時は以下を順に確認する:

--- a/infra/terraform/streaming/versions.tf
+++ b/infra/terraform/streaming/versions.tf
@@ -1,6 +1,15 @@
 terraform {
   required_version = ">= 1.5"
 
+  backend "s3" {
+    bucket         = "youtube-automation-tfstate"
+    key            = "streaming/terraform.tfstate"
+    region         = "ap-northeast-1"
+    kms_key_id     = "alias/tfstate"
+    encrypt        = true
+    dynamodb_table = "tfstate-lock"
+  }
+
   required_providers {
     vultr = {
       source  = "vultr/vultr"

--- a/tests/test_terraform_streaming.py
+++ b/tests/test_terraform_streaming.py
@@ -47,6 +47,12 @@ _SCRIPTS_STREAMING_DIR = _REPO_ROOT / ".claude" / "skills" / "streaming" / "refe
 _SWAP_VIDEO_SCRIPT = _SCRIPTS_STREAMING_DIR / "swap_video.sh"
 _RUN_FFMPEG_SCRIPT = _SCRIPTS_STREAMING_DIR / "run-ffmpeg.sh"
 
+_TFSTATE_BACKEND_BUCKET = "youtube-automation-tfstate"
+_TFSTATE_BACKEND_KEY = "streaming/terraform.tfstate"
+_TFSTATE_BACKEND_REGION = "ap-northeast-1"
+_TFSTATE_BACKEND_KMS_KEY_ID = "alias/tfstate"
+_TFSTATE_BACKEND_LOCK_TABLE = "tfstate-lock"
+
 
 # ---------- ヘルパー ----------
 
@@ -84,6 +90,33 @@ class TestVersionsTf:
         assert terraform_block is not None, "terraform { ... } ブロックが存在しない"
         assert re.search(r'required_version\s*=\s*"[^"]*>=\s*1\.5', terraform_block), (
             "required_version が >= 1.5 を含んでいない"
+        )
+
+    def test_backend_uses_encrypted_s3_remote_state(self):
+        """Given versions.tf
+        When terraform backend を読む
+        Then S3 backend は KMS 暗号化と DynamoDB lock を宣言している。
+        """
+        text = strip_hcl_comments(read_file(_VERSIONS_TF))
+        terraform_block = extract_block(text, r"terraform")
+        assert terraform_block is not None, "terraform { ... } ブロックが存在しない"
+        backend_block = extract_block(terraform_block, r'backend\s+"s3"')
+        assert backend_block is not None, 'backend "s3" ブロックが存在しない'
+        assert re.search(rf'bucket\s*=\s*"{re.escape(_TFSTATE_BACKEND_BUCKET)}"', backend_block), (
+            "S3 backend bucket が tfstate 専用 bucket でない"
+        )
+        assert re.search(rf'key\s*=\s*"{re.escape(_TFSTATE_BACKEND_KEY)}"', backend_block), (
+            "S3 backend key が streaming/terraform.tfstate でない"
+        )
+        assert re.search(rf'region\s*=\s*"{re.escape(_TFSTATE_BACKEND_REGION)}"', backend_block), (
+            "S3 backend region が ap-northeast-1 でない"
+        )
+        assert re.search(r'encrypt\s*=\s*true', backend_block), "S3 backend encrypt = true が宣言されていない"
+        assert re.search(rf'kms_key_id\s*=\s*"{re.escape(_TFSTATE_BACKEND_KMS_KEY_ID)}"', backend_block), (
+            "S3 backend kms_key_id が alias/tfstate でない"
+        )
+        assert re.search(rf'dynamodb_table\s*=\s*"{re.escape(_TFSTATE_BACKEND_LOCK_TABLE)}"', backend_block), (
+            "S3 backend dynamodb_table が tfstate-lock でない"
         )
 
     def test_required_providers_declares_vultr_source(self):
@@ -2806,6 +2839,47 @@ class TestStreamingReadme:
         """
         text = read_file(_STREAMING_README)
         assert re.search(r"terraform[^\n]*apply", text), "README に terraform apply の実行コマンドが書かれていない"
+
+    def test_documents_encrypted_remote_tfstate_backend(self):
+        """Given README
+        When tfstate の説明を読む
+        Then remote backend と暗号化 state の保存先が説明されている。
+        """
+        text = read_file(_STREAMING_README)
+        assert 'backend "s3"' in text, 'README に backend "s3" の説明が無い'
+        assert _TFSTATE_BACKEND_BUCKET in text, "README に tfstate bucket 名の説明が無い"
+        assert _TFSTATE_BACKEND_KEY in text, "README に streaming tfstate key の説明が無い"
+        assert "KMS" in text, "README に KMS 暗号化の説明が無い"
+        assert "DynamoDB lock" in text, "README に DynamoDB lock の説明が無い"
+
+    def test_documents_sensitive_is_cli_mask_only(self):
+        """Given README
+        When sensitive と tfstate の説明を読む
+        Then sensitive=true は CLI 出力マスクのみであると説明されている。
+        """
+        text = read_file(_STREAMING_README)
+        assert "CLI 出力マスクのみ" in text, (
+            "README に sensitive=true が CLI マスクのみである説明が無い"
+        )
+        assert "tfstate JSON の値を暗号化しない" in text, (
+            "README に sensitive=true が tfstate JSON を暗号化しない説明が無い"
+        )
+
+    def test_does_not_describe_nonsensitive_hash_as_unconditionally_safe(self):
+        """Given README
+        When nonsensitive(sha256(...)) の説明を読む
+        Then hash 化の安全性を高エントロピー secret に限定している。
+        """
+        text = read_file(_STREAMING_README)
+        assert "脱 sensitive 安全" not in text, (
+            "README が nonsensitive(sha256(...)) を常に安全と誤読させる"
+        )
+        assert "高エントロピー" in text, (
+            "README に hash 化の前提が高エントロピー secret である説明が無い"
+        )
+        assert "低エントロピー値" in text, (
+            "README に低エントロピー値の hash 化が secret 保護でない説明が無い"
+        )
 
     def test_mentions_systemctl_status_for_verification(self):
         """Given README

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 概要

`infra/terraform/streaming/main.tf` 全体 + `versions.tf` で tfstate がローカル backend のままになっている。`triggers` の SHA256 hash・`main_ip` が平文 JSON で残存し、README の「sensitive 扱い」表記は CLI マスクのみで誤解を招く（`audit-#10`, `audit-#23`）。

## 推奨対応

### backend 移行（いずれか）

```hcl
# S3 + KMS
terraform {
  backend "s3" {
    bucket         = "youtube-automation-tfstate"
    key            = "streaming/terraform.tfstate"
    region         = "ap-northeast-1"
    kms_key_id     = "alias/tfstate"
    encrypt        = true
    dynamodb_table = "tfstate-lock"
  }
}

# または GCS + CMEK
terraform {
  backend "gcs" {
    bucket         = "youtube-automation-tfstate"
    prefix         = "streaming"
    encryption_key = "<base64-encoded-key>"
  }
}

# または Terraform Cloud
terraform {
  cloud {
    organization = "..."
    workspaces { name = "youtube-stream" }
  }
}
```

### README 訂正

「tfstate JSON は平文。stream_key のような高エントロピー値に限り SHA256 ラップが安全」と明記し、`nonsensitive(sha256(...))` を「常に安全」と誤読される表現を削除。
$(footer "audit-#10, audit-#23")

## Execution Report

Workflow `default-mini` completed successfully.

Closes #165