### PR TITLE
[#359] issue-359-refactor-agents-work

### DIFF
--- a/src/youtube_automation/agents/collection_uploader.py
+++ b/src/youtube_automation/agents/collection_uploader.py
@@ -17,7 +17,6 @@ import logging
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 import schedule  # noqa: E402
 from googleapiclient.errors import HttpError  # noqa: E402
@@ -29,6 +28,7 @@ from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader 
 from youtube_automation.scripts.playlist_manager import PlaylistManager  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError  # noqa: E402
+from youtube_automation.utils.schedule import get_schedule_timezone  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
 
 
@@ -114,9 +114,8 @@ class CollectionUploader:
         if not schedule_cfg.get("auto_schedule_enabled", False):
             return None
 
-        tz_name = schedule_cfg.get("timezone", "Asia/Tokyo")
         publish_time = schedule_cfg.get("publish_time", schedule_cfg.get("day1_time", "17:00"))
-        tz = ZoneInfo(tz_name)
+        tz = get_schedule_timezone(self.config)
         hour, minute = map(int, publish_time.split(":"))
 
         # cadence 曜日を isoweekday に変換（未設定なら全曜日許可）
@@ -153,8 +152,7 @@ class CollectionUploader:
         if not self.youtube_service:
             self.initialize_youtube_service()
 
-        tz_name = self.config.get("schedule", {}).get("timezone", "Asia/Tokyo")
-        tz = ZoneInfo(tz_name)
+        tz = get_schedule_timezone(self.config)
         dates = set()
 
         try:
@@ -336,7 +334,7 @@ class CollectionUploader:
                 tracking["complete_collection"] = {
                     "video_id": complete_video["video_id"],
                     "video_url": complete_video["video_url"],
-                    "upload_time": datetime.now().isoformat(),
+                    "upload_time": datetime.now(get_schedule_timezone(self.config)).isoformat(),
                     "publish_at": publish_at,
                     "status": "completed",
                 }

--- a/src/youtube_automation/agents/short_uploader.py
+++ b/src/youtube_automation/agents/short_uploader.py
@@ -41,6 +41,7 @@ ACTION_UPLOADED = "short_uploaded"
 ACTION_BLOCKED = "short_upload_blocked"
 ACTION_FAILED = "short_upload_failed"
 
+
 class ShortUploader:
     """Shorts 投稿エージェント — `YouTubeAutoUploader` 委譲版.
 

--- a/src/youtube_automation/agents/short_uploader.py
+++ b/src/youtube_automation/agents/short_uploader.py
@@ -25,12 +25,12 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
-from zoneinfo import ZoneInfo
 
 from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
 from youtube_automation.utils.config import channel_dir, load_config
 from youtube_automation.utils.exceptions import UploadError
 from youtube_automation.utils.metadata_generator import BAHMetadataGenerator
+from youtube_automation.utils.schedule import get_schedule_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +40,6 @@ logger = logging.getLogger(__name__)
 ACTION_UPLOADED = "short_uploaded"
 ACTION_BLOCKED = "short_upload_blocked"
 ACTION_FAILED = "short_upload_failed"
-
-DEFAULT_TIMEZONE = "Asia/Tokyo"
-
 
 class ShortUploader:
     """Shorts 投稿エージェント — `YouTubeAutoUploader` 委譲版.
@@ -93,7 +90,7 @@ class ShortUploader:
             (ok, msg): ok=True なら投稿可、False なら blocked。
         """
         min_hours = self.config.shorts.min_hours_between_shorts_per_collection
-        tz = ZoneInfo(self.schedule_config.get("schedule", {}).get("timezone", DEFAULT_TIMEZONE))
+        tz = get_schedule_timezone(self.schedule_config)
         now = datetime.now(tz)
 
         live_dir = self.channel_dir / "collections" / "live"
@@ -157,7 +154,7 @@ class ShortUploader:
         if not base_str:
             return None
 
-        tz = ZoneInfo(self.schedule_config.get("schedule", {}).get("timezone", DEFAULT_TIMEZONE))
+        tz = get_schedule_timezone(self.schedule_config)
         short_publish_time = self.config.shorts.publish_time
         try:
             hour, minute = (int(x) for x in short_publish_time.split(":"))
@@ -344,7 +341,7 @@ class ShortUploader:
         entry = {
             "short_num": short_num,
             "video_id": video_id,
-            "uploaded_at": datetime.now().isoformat(),
+            "uploaded_at": datetime.now(get_schedule_timezone(self.schedule_config)).isoformat(),
             "publish_at": publish_at,
         }
 

--- a/src/youtube_automation/utils/schedule.py
+++ b/src/youtube_automation/utils/schedule.py
@@ -1,0 +1,26 @@
+"""Schedule-related helpers shared by upload agents."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from youtube_automation.utils.exceptions import ConfigError
+
+SCHEDULE_SECTION = "schedule"
+TIMEZONE_KEY = "timezone"
+DEFAULT_SCHEDULE_TIMEZONE = "Asia/Tokyo"
+
+
+def get_schedule_timezone(schedule_config: Mapping[str, Any]) -> ZoneInfo:
+    """Resolve the configured schedule timezone."""
+    schedule = schedule_config.get(SCHEDULE_SECTION, {})
+    if not isinstance(schedule, Mapping):
+        raise ConfigError("schedule_config.json の schedule は object である必要があります")
+
+    timezone_name = schedule.get(TIMEZONE_KEY, DEFAULT_SCHEDULE_TIMEZONE)
+    if not isinstance(timezone_name, str) or not timezone_name:
+        raise ConfigError("schedule_config.json の schedule.timezone は空でない文字列である必要があります")
+
+    return ZoneInfo(timezone_name)

--- a/tests/test_collection_uploader.py
+++ b/tests/test_collection_uploader.py
@@ -9,6 +9,7 @@ CollectionUploader のユニットテスト
 
 import json
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -164,6 +165,24 @@ def _make_uploader_with_collection_mock(tmp_path: Path):
         return uploader, mock_inner
 
 
+def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
+    """schedule_config.json を指定して CollectionUploader を構築する."""
+    from youtube_automation.agents.collection_uploader import CollectionUploader
+
+    config_path = tmp_path / "schedule_config.json"
+    config_path.write_text(json.dumps(schedule_config), encoding="utf-8")
+
+    with patch("youtube_automation.agents.collection_uploader.YouTubeAutoUploader") as mock_cls:
+        mock_inner = MagicMock()
+        mock_cls.return_value = mock_inner
+        uploader = CollectionUploader(
+            collections_root=str(tmp_path / "collections"),
+            config_path=str(config_path),
+        )
+        uploader.config["collections_management"]["auto_move_to_live"] = False
+        return uploader, mock_inner
+
+
 def _read_resume_uri(tracking_path: Path) -> str | None:
     data = json.loads(tracking_path.read_text(encoding="utf-8"))
     return data.get("complete_collection", {}).get("resume_session_uri")
@@ -220,6 +239,31 @@ class TestExecuteCompleteCollectionResume:
         # Then
         call_kwargs = mock_inner.upload_collection.call_args.kwargs
         assert call_kwargs.get("resume_session_uri") is None
+
+    def test_should_write_timezone_aware_upload_time(self, tmp_path):
+        """Complete Collection 成功時の upload_time は schedule timezone 付き ISO 8601."""
+        col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
+        uploader, mock_inner = _make_uploader_with_schedule_config(
+            tmp_path,
+            {"schedule": {"timezone": "UTC"}},
+        )
+        mock_inner.upload_collection.return_value = {
+            "complete_video": {
+                "video_id": "V_TZ",
+                "video_url": "u",
+                "title": "t",
+                "file_path": "p",
+            }
+        }
+
+        tracking = uploader._load_tracking(col)
+        uploader._execute_complete_collection(col, tracking, publish_at=None)
+
+        saved = json.loads(tracking_path.read_text(encoding="utf-8"))
+        upload_time = saved["complete_collection"]["upload_time"]
+        dt = datetime.fromisoformat(upload_time)
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(0)
 
     def test_should_persist_uri_to_tracking_when_on_session_uri_changed_is_invoked(self, tmp_path):
         """plan 要件 #1 + #2: コールバック発火直後に URI が tracking JSON に永続化される.

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.schedule import get_schedule_timezone
+
+
+def test_get_schedule_timezone_uses_configured_timezone():
+    tz = get_schedule_timezone({"schedule": {"timezone": "America/New_York"}})
+
+    assert tz.key == "America/New_York"
+    assert datetime(2026, 1, 1, tzinfo=tz).utcoffset() == timedelta(hours=-5)
+
+
+def test_get_schedule_timezone_defaults_to_tokyo_when_schedule_is_missing():
+    tz = get_schedule_timezone({})
+
+    assert datetime(2026, 1, 1, tzinfo=tz).utcoffset() == timedelta(hours=9)
+
+
+def test_get_schedule_timezone_rejects_non_mapping_schedule():
+    with pytest.raises(ConfigError, match="schedule"):
+        get_schedule_timezone({"schedule": "Asia/Tokyo"})
+
+
+def test_get_schedule_timezone_rejects_empty_timezone():
+    with pytest.raises(ConfigError, match="schedule.timezone"):
+        get_schedule_timezone({"schedule": {"timezone": ""}})

--- a/tests/test_short_uploader.py
+++ b/tests/test_short_uploader.py
@@ -685,6 +685,18 @@ class TestUpdateWorkflowState:
         assert shorts[0]["short_num"] == 1
         assert shorts[0]["video_id"] == "V1"
 
+    def test_uploaded_at_is_schedule_timezone_aware(self, tmp_path):
+        """uploaded_at は schedule timezone 付き ISO 8601 で書かれる."""
+        col = _setup_collection(tmp_path)
+        with _make_short_uploader(schedule_config={"schedule": {"timezone": "UTC"}}) as (uploader, _):
+            uploader._update_workflow_state(col, short_num=1, video_id="V1", publish_at=None)
+
+        ws = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
+        uploaded_at = ws["post_upload"]["shorts"][0]["uploaded_at"]
+        dt = datetime.fromisoformat(uploaded_at)
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(0)
+
     def test_same_short_num_replaces_existing_entry(self, tmp_path):
         """同じ `short_num` を再 upsert したら既存 entry が置換される."""
         # Given: 既に short_num=1 で V1 を書いた状態

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 背景

#287 (Shorts v5 ゼロベース再実装) の AI Antipattern review iteration 1 で `AI-WARN-001`（非ブロッキング warning）として残った「`uploaded_at` 書き込みが TZ-naive」問題を別 issue に切り出す。

`src/youtube_automation/agents/short_uploader.py::_update_workflow_state` で `workflow-state.json` に書き込む `uploaded_at`:

```python
"uploaded_at": datetime.now().isoformat(),
```

これは TZ-naive な ISO 8601 となる（`Asia/Tokyo` 仮定）。読み手側 `_check_upload_interval` は `if dt.tzinfo is None: dt = dt.replace(tzinfo=tz)` で `schedule_config.json::schedule.timezone` を補完するため動作上のバグはない。ただし:

- 書き手・読み手の対称検証はテストでカバーされているが、ファイルに残るログとしては TZ 情報なしの ISO 8601 が混じる
- `CollectionUploader` 等の既存実装も同じ TZ-naive パターンで書いているため、agents 全体が混在状態
- 新規コードであれば `datetime.now(tz).isoformat()` の方が望ましい

## AI レビュー指摘の原文

`reports/ai-review.md.20260518T074214Z`（#287 run）より:

> ### AI-WARN-001: `_update_workflow_state` の `uploaded_at` 書き込みが TZ-naive
>
> 書き込み側は naive datetime（`Asia/Tokyo` 仮定）だが、`_check_upload_interval` の読み込み側
> （line 116-117）は `if dt.tzinfo is None: dt = dt.replace(tzinfo=tz)` で schedule_config の TZ を補完している。
> 書き手と読み手の対称検証はテストでカバーされているが、ファイルに残るログとしては TZ 情報なしの
> ISO 8601 が混じる。
>
> `CollectionUploader` 等の既存実装と整合する書き方ではあるので REJECT しないが、
> 新規コードなので `datetime.now(tz).isoformat()` の方が望ましい

## 提案

1. `tz` 取得ヘルパを agents 共通モジュール（例: `utils/schedule.py::get_schedule_timezone()`）に抽出
2. `agents/short_uploader.py::_update_workflow_state` を `datetime.now(tz).isoformat()` に切り替え
3. `agents/collection_uploader.py` 等の既存 agents 系も同様に TZ-aware に揃える
4. 読み手側の `if dt.tzinfo is None: dt = dt.replace(tzinfo=tz)` 補正は、レガシーデータ救済のため当面残す（warning ログを出すか検討）
5. 書き込み側に TZ-naive 検出の防御コードを追加するかは別途検討

## スコープ判定

- `#287` の PR タイトル「feat(short): Shorts スキル群を v5 でゼロベース再実装」は変わらない
- 修正範囲が agents 横断（`collection_uploader.py` 等）に及ぶため #287 単独では完結しない

## 関連

- 親 issue: #287 (close 後に follow-up として扱う)
- 影響範囲: `agents/short_uploader.py`, `agents/collection_uploader.py` ほか `workflow-state.json` を書き出す箇所全般

## Labels
refactor, priority: low

## Execution Report

Workflow `default-mini` completed successfully.

Closes #359