### PR TITLE
[#365] issue-365-feat-comments-reply

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -2,3 +2,11 @@
 # provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
 draft_pr: false
 base_branch: main
+
+# Codex rate limit 回避のため coder persona を Claude に一時上書き
+# （グローバルの persona_providers.coder.provider: codex を override）
+# Codex の rate limit が解消したら本ブロックを削除してグローバル設定に戻す
+persona_providers:
+  coder:
+    provider: claude
+    model: sonnet

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -2,11 +2,3 @@
 # provider / model / language はグローバル設定 (~/.takt/config.yaml) を継承
 draft_pr: false
 base_branch: main
-
-# Codex rate limit 回避のため coder persona を Claude に一時上書き
-# （グローバルの persona_providers.coder.provider: codex を override）
-# Codex の rate limit が解消したら本ブロックを削除してグローバル設定に戻す
-persona_providers:
-  coder:
-    provider: claude
-    model: sonnet

--- a/src/youtube_automation/utils/comments/__init__.py
+++ b/src/youtube_automation/utils/comments/__init__.py
@@ -1,6 +1,6 @@
 """自チャンネルのコメント自動返信モジュール群."""
 
-from youtube_automation.utils.comments.fetcher import fetch_top_level_comments
+from youtube_automation.utils.comments.fetcher import fetch_comments
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.replier import CommentReplier, ReplyPlan
 from youtube_automation.utils.comments.rule_engine import RuleEngine, RuleMatch
@@ -12,6 +12,6 @@ __all__ = [
     "ReplyPlan",
     "RuleEngine",
     "RuleMatch",
-    "fetch_top_level_comments",
+    "fetch_comments",
     "render_template",
 ]

--- a/src/youtube_automation/utils/comments/fetcher.py
+++ b/src/youtube_automation/utils/comments/fetcher.py
@@ -97,9 +97,7 @@ def _fetch_replies_paginated(
                 .execute()
             )
         except HttpError as e:
-            raise YouTubeAPIError.from_http_error(
-                e, f"comments.list 失敗 (parentId={top_comment_id})"
-            ) from e
+            raise YouTubeAPIError.from_http_error(e, f"comments.list 失敗 (parentId={top_comment_id})") from e
 
         for item in response.get("items", []):
             if _after_since(item["snippet"].get("publishedAt", ""), since):

--- a/src/youtube_automation/utils/comments/fetcher.py
+++ b/src/youtube_automation/utils/comments/fetcher.py
@@ -1,8 +1,7 @@
-"""自チャンネル動画のコメント取得（YouTube Data API v3 commentThreads.list）."""
+"""自チャンネル動画のコメント取得（YouTube Data API v3 commentThreads.list + comments.list）."""
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterator
@@ -11,24 +10,177 @@ from googleapiclient.errors import HttpError
 
 from youtube_automation.utils.exceptions import YouTubeAPIError
 
-logger = logging.getLogger(__name__)
+# YouTube API が commentThreads.list の replies.comments に含める最大件数
+_INLINE_REPLY_LIMIT = 5
 
 
 @dataclass(frozen=True)
 class FetchedComment:
-    """commentThreads.list から取得したトップレベルコメント 1 件."""
+    """commentThreads.list / comments.list から取得したコメント 1 件."""
 
     comment_id: str
     video_id: str
     author: str
+    author_channel_id: str | None
     text: str
     published_at: str
     moderation_status: str | None
     can_reply: bool
     total_reply_count: int
+    parent_id: str | None  # top-level なら None、reply なら親 comment_id
 
 
-def fetch_top_level_comments(
+def _parse_published_at(published: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(published.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _after_since(published: str, since: datetime | None) -> bool:
+    """since が未設定、またはコメントが since 以降かどうかを返す.
+
+    日付パース失敗・空文字列は True を返す（スキップしない方向に倒す）。
+    """
+    if since is None or not published:
+        return True
+    pub_dt = _parse_published_at(published)
+    return pub_dt is None or pub_dt >= since
+
+
+def _build_reply_comment(
+    item: dict,
+    *,
+    video_id: str,
+    can_reply: bool,
+    parent_id: str,
+) -> FetchedComment:
+    snippet = item["snippet"]
+    return FetchedComment(
+        comment_id=item["id"],
+        video_id=video_id,
+        author=snippet.get("authorDisplayName", ""),
+        author_channel_id=snippet.get("authorChannelId", {}).get("value"),
+        text=snippet.get("textOriginal", snippet.get("textDisplay", "")),
+        published_at=snippet.get("publishedAt", ""),
+        moderation_status=snippet.get("moderationStatus"),
+        can_reply=can_reply,
+        total_reply_count=0,
+        parent_id=parent_id,
+    )
+
+
+def _fetch_replies_paginated(
+    youtube,
+    *,
+    top_comment_id: str,
+    video_id: str,
+    can_reply: bool,
+    since: datetime | None,
+) -> Iterator[FetchedComment]:
+    """comments.list で返信を全件ページングして yield する.
+
+    totalReplyCount > 5 で API が replies を最大 5 件に切り詰める場合に呼ぶ。
+    """
+    page_token: str | None = None
+    while True:
+        try:
+            response = (
+                youtube.comments()
+                .list(
+                    part="snippet",
+                    parentId=top_comment_id,
+                    maxResults=100,
+                    pageToken=page_token,
+                    textFormat="plainText",
+                )
+                .execute()
+            )
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(
+                e, f"comments.list 失敗 (parentId={top_comment_id})"
+            ) from e
+
+        for item in response.get("items", []):
+            if _after_since(item["snippet"].get("publishedAt", ""), since):
+                yield _build_reply_comment(
+                    item,
+                    video_id=video_id,
+                    can_reply=can_reply,
+                    parent_id=top_comment_id,
+                )
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            return
+
+
+def _iter_inline_replies(
+    reply_items: list[dict],
+    *,
+    video_id: str,
+    can_reply: bool,
+    parent_id: str,
+    since: datetime | None,
+) -> Iterator[FetchedComment]:
+    """commentThreads.list の replies.comments から返信を yield する."""
+    for item in reply_items:
+        if _after_since(item["snippet"].get("publishedAt", ""), since):
+            yield _build_reply_comment(
+                item,
+                video_id=video_id,
+                can_reply=can_reply,
+                parent_id=parent_id,
+            )
+
+
+def _iter_thread(
+    youtube,
+    item: dict,
+    *,
+    video_id: str,
+    since: datetime | None,
+) -> Iterator[FetchedComment]:
+    """1 つのスレッドアイテムから top-level + replies を yield する."""
+    top = item["snippet"]["topLevelComment"]
+    snippet = top["snippet"]
+    thread_can_reply = bool(item["snippet"].get("canReply", True))
+    total_reply_count = int(item["snippet"].get("totalReplyCount", 0))
+    published = snippet.get("publishedAt", "")
+
+    if _after_since(published, since):
+        yield FetchedComment(
+            comment_id=top["id"],
+            video_id=video_id,
+            author=snippet.get("authorDisplayName", ""),
+            author_channel_id=snippet.get("authorChannelId", {}).get("value"),
+            text=snippet.get("textOriginal", snippet.get("textDisplay", "")),
+            published_at=published,
+            moderation_status=snippet.get("moderationStatus"),
+            can_reply=thread_can_reply,
+            total_reply_count=total_reply_count,
+            parent_id=None,
+        )
+
+    if total_reply_count > _INLINE_REPLY_LIMIT:
+        yield from _fetch_replies_paginated(
+            youtube,
+            top_comment_id=top["id"],
+            video_id=video_id,
+            can_reply=thread_can_reply,
+            since=since,
+        )
+    else:
+        yield from _iter_inline_replies(
+            item.get("replies", {}).get("comments", []),
+            video_id=video_id,
+            can_reply=thread_can_reply,
+            parent_id=top["id"],
+            since=since,
+        )
+
+
+def fetch_comments(
     youtube,
     *,
     video_id: str,
@@ -36,17 +188,17 @@ def fetch_top_level_comments(
     since: datetime | None = None,
     page_size: int = 100,
 ) -> Iterator[FetchedComment]:
-    """指定動画のトップレベルコメントを generator で返す.
+    """指定動画のコメントスレッドを generator で返す（top-level + replies）.
 
     Args:
         youtube: `youtube_service.get_youtube()` / `ServiceRegistry.youtube`
         video_id: 対象動画 ID
-        max_results: 返却上限（total で）。None 不可
+        max_results: トップレベルコメントの返却上限（スレッド数）
         since: これより新しいコメントのみ対象（`publishedAt` 比較）
-        page_size: 1 ページあたりの取得件数（YouTube API 最大 100）
+        page_size: 1 ページあたりのスレッド取得件数（YouTube API 最大 100）
 
     Yields:
-        FetchedComment
+        FetchedComment（top-level は parent_id=None、reply は parent_id=top_comment_id）
 
     Raises:
         YouTubeAPIError: HttpError を status_code 付きでラップ
@@ -58,7 +210,7 @@ def fetch_top_level_comments(
             response = (
                 youtube.commentThreads()
                 .list(
-                    part="snippet",
+                    part="snippet,replies",
                     videoId=video_id,
                     maxResults=min(page_size, max_results - yielded),
                     pageToken=next_page_token,
@@ -70,27 +222,10 @@ def fetch_top_level_comments(
             raise YouTubeAPIError.from_http_error(e, f"commentThreads.list 失敗 (video_id={video_id})") from e
 
         for item in response.get("items", []):
-            top = item["snippet"]["topLevelComment"]
-            snippet = top["snippet"]
-            published = snippet.get("publishedAt", "")
-            if since is not None and published:
-                try:
-                    pub_dt = datetime.fromisoformat(published.replace("Z", "+00:00"))
-                except ValueError:
-                    pub_dt = None
-                if pub_dt is not None and pub_dt < since:
-                    continue
-            yield FetchedComment(
-                comment_id=top["id"],
-                video_id=video_id,
-                author=snippet.get("authorDisplayName", ""),
-                text=snippet.get("textOriginal", snippet.get("textDisplay", "")),
-                published_at=published,
-                moderation_status=snippet.get("moderationStatus"),
-                can_reply=bool(item["snippet"].get("canReply", True)),
-                total_reply_count=int(item["snippet"].get("totalReplyCount", 0)),
-            )
-            yielded += 1
+            for comment in _iter_thread(youtube, item, video_id=video_id, since=since):
+                yield comment
+                if comment.parent_id is None:
+                    yielded += 1
             if yielded >= max_results:
                 return
 

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -11,7 +11,7 @@ from typing import Iterator
 
 from googleapiclient.errors import HttpError
 
-from youtube_automation.utils.comments.fetcher import FetchedComment, fetch_top_level_comments
+from youtube_automation.utils.comments.fetcher import FetchedComment, fetch_comments
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.rule_engine import RuleEngine, RuleMatch
 from youtube_automation.utils.comments.template import render_template
@@ -33,40 +33,6 @@ class ReplyPlan:
     errors: list[dict] = field(default_factory=list)
 
 
-def _iter_uploaded_video_ids(youtube) -> Iterator[str]:
-    """自チャンネルのアップロード動画 ID を generator で返す（早期 break 可能）."""
-    try:
-        channel_resp = youtube.channels().list(part="contentDetails", mine=True).execute()
-    except HttpError as e:
-        raise YouTubeAPIError.from_http_error(e, "channels.list (mine=True) 失敗") from e
-
-    items = channel_resp.get("items") or []
-    if not items:
-        return
-    uploads_playlist_id = items[0]["contentDetails"]["relatedPlaylists"]["uploads"]
-
-    page_token: str | None = None
-    while True:
-        try:
-            resp = (
-                youtube.playlistItems()
-                .list(
-                    part="contentDetails",
-                    playlistId=uploads_playlist_id,
-                    maxResults=50,
-                    pageToken=page_token,
-                )
-                .execute()
-            )
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "playlistItems.list 失敗") from e
-        for item in resp.get("items", []):
-            yield item["contentDetails"]["videoId"]
-        page_token = resp.get("nextPageToken")
-        if not page_token:
-            return
-
-
 class CommentReplier:
     """コメント自動返信の実行司令塔."""
 
@@ -77,12 +43,14 @@ class CommentReplier:
         config: Comments,
         channel_dir: Path,
         default_language: str,
+        owner_channel_id: str | None = None,
         sleep_fn=time.sleep,
     ):
         self._youtube = youtube
         self._config = config
         self._channel_dir = channel_dir
         self._default_language = default_language
+        self._owner_channel_id = owner_channel_id
         self._sleep = sleep_fn
         self._history = ReplyHistory(channel_dir / config.history_file)
         self._title_cache: dict[str, str] = {}
@@ -90,6 +58,53 @@ class CommentReplier:
     @property
     def history(self) -> ReplyHistory:
         return self._history
+
+    def _resolve_owner_channel_id(self) -> None:
+        """owner_channel_id が未解決の場合に channels.list API で取得しキャッシュする."""
+        if self._owner_channel_id is not None:
+            return
+        try:
+            resp = self._youtube.channels().list(part="id", mine=True).execute()
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(e, "channels.list (owner channel ID) 失敗") from e
+        items = resp.get("items") or []
+        if not items:
+            raise YouTubeAPIError("channels.list が空を返しました — チャンネルが見つかりません")
+        self._owner_channel_id = items[0]["id"]
+
+    def _fetch_channel_info(self) -> tuple[str, str]:
+        """channels().list(part="contentDetails") から (owner_id, uploads_playlist_id) を返す."""
+        try:
+            resp = self._youtube.channels().list(part="contentDetails", mine=True).execute()
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(e, "channels.list (mine=True) 失敗") from e
+        items = resp.get("items") or []
+        if not items:
+            raise YouTubeAPIError("channels.list が空を返しました — チャンネルが見つかりません")
+        return items[0]["id"], items[0]["contentDetails"]["relatedPlaylists"]["uploads"]
+
+    def _iter_uploaded_video_ids(self, uploads_playlist_id: str) -> Iterator[str]:
+        """自チャンネルのアップロード動画 ID を generator で返す（早期 break 可能）."""
+        page_token: str | None = None
+        while True:
+            try:
+                resp = (
+                    self._youtube.playlistItems()
+                    .list(
+                        part="contentDetails",
+                        playlistId=uploads_playlist_id,
+                        maxResults=50,
+                        pageToken=page_token,
+                    )
+                    .execute()
+                )
+            except HttpError as e:
+                raise YouTubeAPIError.from_http_error(e, "playlistItems.list 失敗") from e
+            for item in resp.get("items", []):
+                yield item["contentDetails"]["videoId"]
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                return
 
     def run(
         self,
@@ -113,12 +128,19 @@ class CommentReplier:
         plan = ReplyPlan()
         limit = self._config.max_replies_per_run
 
-        video_source: Iterator[str] = iter(video_ids) if video_ids else _iter_uploaded_video_ids(self._youtube)
+        if video_ids is not None:
+            # 明示指定時: uploads playlist 解決は不要だが owner_channel_id は別途解決する
+            self._resolve_owner_channel_id()
+            video_source: Iterator[str] = iter(video_ids)
+        else:
+            owner_id, uploads_playlist_id = self._fetch_channel_info()
+            self._owner_channel_id = self._owner_channel_id or owner_id
+            video_source = self._iter_uploaded_video_ids(uploads_playlist_id)
 
         for vid in video_source:
             if len(plan.planned) >= limit:
                 break
-            for comment in fetch_top_level_comments(
+            for comment in fetch_comments(
                 self._youtube, video_id=vid, max_results=per_video_limit, since=since
             ):
                 if len(plan.planned) >= limit:
@@ -200,6 +222,9 @@ class CommentReplier:
             return f"moderationStatus={_HELD_FOR_REVIEW}"
         if self._history.has_replied(comment.comment_id):
             return "already_replied"
+        # reply 走査時に履歴外の自分のコメントを拾わないよう authorChannelId で除外する
+        if self._owner_channel_id and comment.author_channel_id == self._owner_channel_id:
+            return "own_comment"
         return None
 
     def _post_reply(

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -140,9 +140,7 @@ class CommentReplier:
         for vid in video_source:
             if len(plan.planned) >= limit:
                 break
-            for comment in fetch_comments(
-                self._youtube, video_id=vid, max_results=per_video_limit, since=since
-            ):
+            for comment in fetch_comments(self._youtube, video_id=vid, max_results=per_video_limit, since=since):
                 if len(plan.planned) >= limit:
                     break
                 self._process_comment(comment, engine, plan, dry_run)

--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from youtube_automation.utils.comments.fetcher import fetch_comments
 
 
@@ -200,7 +198,6 @@ def test_paginated_replies_handles_multiple_pages():
 
 
 def test_since_filter_excludes_old_top_level_comments():
-    from datetime import timezone
 
     since = "2026-05-10T00:00:00+00:00"
     # Given: 新旧混在のコメント

--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -1,0 +1,337 @@
+"""fetch_comments のユニットテスト."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from youtube_automation.utils.comments.fetcher import fetch_comments
+
+
+def _make_thread_item(
+    *,
+    thread_id: str,
+    text: str,
+    can_reply: bool = True,
+    total_reply_count: int = 0,
+    published_at: str = "2026-05-01T00:00:00Z",
+    author: str = "Author",
+    author_channel_id: str | None = "UCauthor",
+    moderation_status: str | None = None,
+    replies: list[dict] | None = None,
+) -> dict:
+    item: dict = {
+        "snippet": {
+            "canReply": can_reply,
+            "totalReplyCount": total_reply_count,
+            "topLevelComment": {
+                "id": thread_id,
+                "snippet": {
+                    "authorDisplayName": author,
+                    "authorChannelId": {"value": author_channel_id} if author_channel_id else {},
+                    "textOriginal": text,
+                    "publishedAt": published_at,
+                    "moderationStatus": moderation_status,
+                },
+            },
+        }
+    }
+    if replies is not None:
+        item["replies"] = {"comments": replies}
+    return item
+
+
+def _make_reply_item(
+    *,
+    reply_id: str,
+    text: str,
+    parent_id: str,
+    published_at: str = "2026-05-02T00:00:00Z",
+    author: str = "Replier",
+    author_channel_id: str | None = "UCreplier",
+) -> dict:
+    return {
+        "id": reply_id,
+        "snippet": {
+            "authorDisplayName": author,
+            "authorChannelId": {"value": author_channel_id} if author_channel_id else {},
+            "textOriginal": text,
+            "publishedAt": published_at,
+            "parentId": parent_id,
+        },
+    }
+
+
+def _mock_youtube_threads(items: list[dict], next_page_token: str | None = None) -> MagicMock:
+    yt = MagicMock()
+    yt.commentThreads.return_value.list.return_value.execute.return_value = {
+        "items": items,
+        **({"nextPageToken": next_page_token} if next_page_token else {}),
+    }
+    return yt
+
+
+def test_top_level_comment_has_parent_id_none():
+    # Given: 返信なしのトップレベルコメント 1 件
+    yt = _mock_youtube_threads([_make_thread_item(thread_id="t1", text="hello")])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: parent_id は None
+    assert len(comments) == 1
+    assert comments[0].comment_id == "t1"
+    assert comments[0].parent_id is None
+    assert comments[0].video_id == "v1"
+
+
+def test_top_level_comment_includes_author_channel_id():
+    # Given: author_channel_id を持つコメント
+    yt = _mock_youtube_threads(
+        [_make_thread_item(thread_id="t1", text="hi", author_channel_id="UCfoo")]
+    )
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then
+    assert comments[0].author_channel_id == "UCfoo"
+
+
+def test_inline_replies_are_yielded_with_parent_id():
+    # Given: totalReplyCount=2 で replies.comments に 2 件含まれるスレッド
+    thread = _make_thread_item(
+        thread_id="t1",
+        text="top",
+        total_reply_count=2,
+        replies=[
+            _make_reply_item(reply_id="r1", text="reply1", parent_id="t1"),
+            _make_reply_item(reply_id="r2", text="reply2", parent_id="t1"),
+        ],
+    )
+    yt = _mock_youtube_threads([thread])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: top-level + 2 replies
+    assert len(comments) == 3
+    top = next(c for c in comments if c.comment_id == "t1")
+    assert top.parent_id is None
+
+    replies = [c for c in comments if c.comment_id in {"r1", "r2"}]
+    assert len(replies) == 2
+    assert all(r.parent_id == "t1" for r in replies)
+    assert all(r.video_id == "v1" for r in replies)
+
+
+def test_inline_replies_inherit_thread_can_reply():
+    # Given: canReply=False のスレッドに返信あり
+    thread = _make_thread_item(
+        thread_id="t1",
+        text="top",
+        can_reply=False,
+        total_reply_count=1,
+        replies=[_make_reply_item(reply_id="r1", text="reply", parent_id="t1")],
+    )
+    yt = _mock_youtube_threads([thread])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: reply も can_reply=False を引き継ぐ
+    reply = next(c for c in comments if c.comment_id == "r1")
+    assert reply.can_reply is False
+
+
+def test_paginated_replies_fetched_when_total_reply_count_exceeds_five():
+    # Given: totalReplyCount=7 (>5) のスレッド → comments.list でページング
+    thread = _make_thread_item(
+        thread_id="t1",
+        text="top",
+        total_reply_count=7,
+        # inline replies は含まれない（API は最大5件しか返さない）
+    )
+    yt = _mock_youtube_threads([thread])
+
+    # comments().list() モック：7件を1ページで返す
+    paginated_replies = [
+        _make_reply_item(reply_id=f"r{i}", text=f"reply{i}", parent_id="t1")
+        for i in range(7)
+    ]
+    yt.comments.return_value.list.return_value.execute.return_value = {
+        "items": paginated_replies,
+    }
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: top + 7 replies
+    assert len(comments) == 8
+    reply_ids = {c.comment_id for c in comments if c.parent_id == "t1"}
+    assert reply_ids == {f"r{i}" for i in range(7)}
+
+    # comments().list が parentId=t1 で呼ばれたことを確認
+    yt.comments.return_value.list.assert_called_once()
+    call_kwargs = yt.comments.return_value.list.call_args.kwargs
+    assert call_kwargs["parentId"] == "t1"
+
+
+def test_paginated_replies_handles_multiple_pages():
+    # Given: totalReplyCount=6 で comments.list が 2ページに分かれる
+    thread = _make_thread_item(thread_id="t1", text="top", total_reply_count=6)
+    yt = _mock_youtube_threads([thread])
+
+    page1_replies = [_make_reply_item(reply_id=f"r{i}", text=f"r{i}", parent_id="t1") for i in range(3)]
+    page2_replies = [_make_reply_item(reply_id=f"r{i}", text=f"r{i}", parent_id="t1") for i in range(3, 6)]
+
+    yt.comments.return_value.list.return_value.execute.side_effect = [
+        {"items": page1_replies, "nextPageToken": "page2token"},
+        {"items": page2_replies},
+    ]
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: top + 6 replies
+    assert len(comments) == 7
+    assert yt.comments.return_value.list.call_count == 2
+
+
+def test_since_filter_excludes_old_top_level_comments():
+    from datetime import timezone
+
+    since = "2026-05-10T00:00:00+00:00"
+    # Given: 新旧混在のコメント
+    items = [
+        _make_thread_item(thread_id="old", text="old", published_at="2026-05-01T00:00:00Z"),
+        _make_thread_item(thread_id="new", text="new", published_at="2026-05-11T00:00:00Z"),
+    ]
+    yt = _mock_youtube_threads(items)
+
+    # When
+    from datetime import datetime
+
+    since_dt = datetime.fromisoformat(since)
+    comments = list(fetch_comments(yt, video_id="v1", since=since_dt))
+
+    # Then: 古いコメントはスキップ
+    ids = {c.comment_id for c in comments}
+    assert "old" not in ids
+    assert "new" in ids
+
+
+def test_since_filter_applies_to_inline_replies():
+    from datetime import datetime
+
+    since_dt = datetime.fromisoformat("2026-05-10T00:00:00+00:00")
+    thread = _make_thread_item(
+        thread_id="t1",
+        text="top",
+        total_reply_count=2,
+        replies=[
+            _make_reply_item(reply_id="old_reply", text="old", parent_id="t1", published_at="2026-05-01T00:00:00Z"),
+            _make_reply_item(reply_id="new_reply", text="new", parent_id="t1", published_at="2026-05-11T00:00:00Z"),
+        ],
+    )
+    yt = _mock_youtube_threads([thread])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1", since=since_dt))
+
+    # Then: 古い返信はスキップ
+    ids = {c.comment_id for c in comments}
+    assert "old_reply" not in ids
+    assert "new_reply" in ids
+
+
+def test_max_results_limits_top_level_count():
+    # Given: 5 件のスレッド
+    items = [
+        _make_thread_item(thread_id=f"t{i}", text=f"text{i}")
+        for i in range(5)
+    ]
+    yt = _mock_youtube_threads(items)
+
+    # When: max_results=3
+    comments = list(fetch_comments(yt, video_id="v1", max_results=3))
+
+    # Then: top-level は 3 件まで
+    top_level = [c for c in comments if c.parent_id is None]
+    assert len(top_level) == 3
+
+
+def test_uses_snippet_replies_part():
+    # Given
+    yt = _mock_youtube_threads([])
+
+    # When
+    list(fetch_comments(yt, video_id="v1"))
+
+    # Then: part="snippet,replies" で呼ばれていること
+    call_kwargs = yt.commentThreads.return_value.list.call_args.kwargs
+    assert call_kwargs["part"] == "snippet,replies"
+
+
+def test_no_replies_when_total_reply_count_zero():
+    # Given: 返信なし
+    thread = _make_thread_item(thread_id="t1", text="hello", total_reply_count=0)
+    yt = _mock_youtube_threads([thread])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: top-level のみ。comments.list は呼ばれない
+    assert len(comments) == 1
+    yt.comments.assert_not_called()
+
+
+def test_reply_has_correct_fields():
+    # Given
+    thread = _make_thread_item(
+        thread_id="t1",
+        text="top",
+        total_reply_count=1,
+        replies=[
+            _make_reply_item(
+                reply_id="r1",
+                text="nice!",
+                parent_id="t1",
+                author="Viewer",
+                author_channel_id="UCviewer",
+                published_at="2026-05-05T12:00:00Z",
+            )
+        ],
+    )
+    yt = _mock_youtube_threads([thread])
+
+    # When
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    # Then: reply フィールドを確認
+    reply = next(c for c in comments if c.comment_id == "r1")
+    assert reply.text == "nice!"
+    assert reply.author == "Viewer"
+    assert reply.author_channel_id == "UCviewer"
+    assert reply.published_at == "2026-05-05T12:00:00Z"
+    assert reply.parent_id == "t1"
+    assert reply.total_reply_count == 0
+    assert reply.video_id == "v1"
+
+
+# --- リグレッション防止テスト ---
+
+
+def test_fetch_top_level_comments_name_does_not_exist():
+    """旧名 fetch_top_level_comments がエイリアスとして残存しないことを確認."""
+    import youtube_automation.utils.comments.fetcher as fetcher
+
+    assert not hasattr(fetcher, "fetch_top_level_comments")
+
+
+def test_fetcher_module_has_no_unused_logger():
+    """未使用の logger が fetcher モジュールに残存しないことを確認."""
+    import youtube_automation.utils.comments.fetcher as fetcher
+
+    assert not hasattr(fetcher, "logger")

--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -86,9 +86,7 @@ def test_top_level_comment_has_parent_id_none():
 
 def test_top_level_comment_includes_author_channel_id():
     # Given: author_channel_id を持つコメント
-    yt = _mock_youtube_threads(
-        [_make_thread_item(thread_id="t1", text="hi", author_channel_id="UCfoo")]
-    )
+    yt = _mock_youtube_threads([_make_thread_item(thread_id="t1", text="hi", author_channel_id="UCfoo")])
 
     # When
     comments = list(fetch_comments(yt, video_id="v1"))
@@ -154,10 +152,7 @@ def test_paginated_replies_fetched_when_total_reply_count_exceeds_five():
     yt = _mock_youtube_threads([thread])
 
     # comments().list() モック：7件を1ページで返す
-    paginated_replies = [
-        _make_reply_item(reply_id=f"r{i}", text=f"reply{i}", parent_id="t1")
-        for i in range(7)
-    ]
+    paginated_replies = [_make_reply_item(reply_id=f"r{i}", text=f"reply{i}", parent_id="t1") for i in range(7)]
     yt.comments.return_value.list.return_value.execute.return_value = {
         "items": paginated_replies,
     }
@@ -245,10 +240,7 @@ def test_since_filter_applies_to_inline_replies():
 
 def test_max_results_limits_top_level_count():
     # Given: 5 件のスレッド
-    items = [
-        _make_thread_item(thread_id=f"t{i}", text=f"text{i}")
-        for i in range(5)
-    ]
+    items = [_make_thread_item(thread_id=f"t{i}", text=f"text{i}") for i in range(5)]
     yt = _mock_youtube_threads(items)
 
     # When: max_results=3

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -21,8 +21,9 @@ def _mock_youtube(
     yt = MagicMock()
 
     # channels().list(part=..., mine=True).execute()
+    # id は part に関わらず常に返るため両方のユースケース（part="id" / "contentDetails"）に対応
     yt.channels.return_value.list.return_value.execute.return_value = {
-        "items": [{"contentDetails": {"relatedPlaylists": {"uploads": "PLuploads"}}}]
+        "items": [{"id": "UCtest", "contentDetails": {"relatedPlaylists": {"uploads": "PLuploads"}}}]
     }
 
     # playlistItems().list().execute() — 全動画一発返却
@@ -42,6 +43,14 @@ def _mock_youtube(
         raw = comments_by_video.get(video_id, [])
         items = []
         for c in raw:
+            top_snippet: dict = {
+                "authorDisplayName": c.get("author", "Unknown"),
+                "textOriginal": c["text"],
+                "publishedAt": c.get("published_at", "2026-04-01T00:00:00Z"),
+                "moderationStatus": c.get("moderation_status"),
+            }
+            if c.get("author_channel_id"):
+                top_snippet["authorChannelId"] = {"value": c["author_channel_id"]}
             items.append(
                 {
                     "snippet": {
@@ -49,12 +58,7 @@ def _mock_youtube(
                         "totalReplyCount": c.get("total_reply_count", 0),
                         "topLevelComment": {
                             "id": c["comment_id"],
-                            "snippet": {
-                                "authorDisplayName": c.get("author", "Unknown"),
-                                "textOriginal": c["text"],
-                                "publishedAt": c.get("published_at", "2026-04-01T00:00:00Z"),
-                                "moderationStatus": c.get("moderation_status"),
-                            },
+                            "snippet": top_snippet,
                         },
                     }
                 }
@@ -243,7 +247,7 @@ def test_ng_word_excludes_comment(tmp_path):
     assert any(row["reason"] == "no_rule_matched" for row in plan.skipped if row["comment_id"] == "c1")
 
 
-def test_explicit_video_ids_skip_channel_resolution(tmp_path):
+def test_explicit_video_ids_skip_playlist_items_lookup(tmp_path):
     yt = _mock_youtube(
         video_ids=["v1", "v2"],
         comments_by_video={"v2": [{"comment_id": "c2", "text": "こんにちは！", "author": "B"}]},
@@ -253,8 +257,8 @@ def test_explicit_video_ids_skip_channel_resolution(tmp_path):
 
     assert len(plan.planned) == 1
     assert plan.planned[0]["video_id"] == "v2"
-    # mine=True 解決は呼ばれない
-    yt.channels.return_value.list.assert_not_called()
+    # video_ids 指定時は uploads playlist（playlistItems）は解決されない
+    yt.playlistItems.return_value.list.assert_not_called()
 
 
 def test_api_error_recorded_in_errors(tmp_path):
@@ -301,3 +305,158 @@ def test_no_match_reasons(tmp_path, reason_text, expected_reason):
     plan = replier.run(dry_run=True)
     assert plan.planned == []
     assert any(row["reason"] == expected_reason for row in plan.skipped)
+
+
+def test_own_comment_is_skipped_when_owner_channel_id_provided(tmp_path):
+    # Given: owner_channel_id が設定されており、同じ channel_id のコメントが混在
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                # チャンネルオーナー自身のコメント（自分の返信に視聴者が反応したケース等）
+                {
+                    "comment_id": "c_own",
+                    "text": "こんにちは！",
+                    "author": "Owner",
+                    "author_channel_id": owner_id,
+                },
+                # 視聴者のコメント
+                {
+                    "comment_id": "c_viewer",
+                    "text": "こんにちは！",
+                    "author": "Viewer",
+                    "author_channel_id": "UCviewer",
+                },
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+    plan = replier.run(dry_run=True)
+
+    # Then: オーナーのコメントはスキップ、視聴者のは計画に含まれる
+    planned_ids = [row["comment_id"] for row in plan.planned]
+    assert "c_own" not in planned_ids
+    assert "c_viewer" in planned_ids
+    assert any(row["comment_id"] == "c_own" and row["reason"] == "own_comment" for row in plan.skipped)
+
+
+def test_resolve_owner_channel_id_returns_and_caches(tmp_path):
+    """正常系: channels().list(part="id") から channel_id を取得してキャッシュする."""
+    yt = MagicMock()
+    yt.channels.return_value.list.return_value.execute.return_value = {"items": [{"id": "UC12345"}]}
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    replier._resolve_owner_channel_id()
+
+    assert replier._owner_channel_id == "UC12345"
+    yt.channels.return_value.list.assert_called_once_with(part="id", mine=True)
+
+
+def test_resolve_owner_channel_id_raises_on_empty_items(tmp_path):
+    """空 items 系: YouTubeAPIError が送出される."""
+    from youtube_automation.utils.exceptions import YouTubeAPIError
+
+    yt = MagicMock()
+    yt.channels.return_value.list.return_value.execute.return_value = {"items": []}
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    with pytest.raises(YouTubeAPIError, match="チャンネルが見つかりません"):
+        replier._resolve_owner_channel_id()
+
+
+def test_resolve_owner_channel_id_raises_on_http_error(tmp_path):
+    """HttpError 系: YouTubeAPIError に変換される."""
+    from googleapiclient.errors import HttpError
+
+    from youtube_automation.utils.exceptions import YouTubeAPIError
+
+    class _FakeResp:
+        status = 403
+        reason = "Forbidden"
+
+        def __getitem__(self, _key):
+            return "application/json"
+
+        def get(self, _key, default=None):
+            return default
+
+    err = HttpError(_FakeResp(), b'{"error": "forbidden"}')
+    yt = MagicMock()
+    yt.channels.return_value.list.return_value.execute.side_effect = err
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    with pytest.raises(YouTubeAPIError):
+        replier._resolve_owner_channel_id()
+
+
+def test_resolve_owner_channel_id_skips_if_already_set(tmp_path):
+    """既設定時: API を呼ばずキャッシュ値を維持する."""
+    yt = MagicMock()
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id="UCpre",
+    )
+
+    replier._resolve_owner_channel_id()
+
+    yt.channels.assert_not_called()
+    assert replier._owner_channel_id == "UCpre"
+
+
+def test_own_comment_not_skipped_when_owner_channel_id_is_none(tmp_path):
+    # Given: owner_channel_id が未設定（デフォルト）
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "c1",
+                    "text": "こんにちは！",
+                    "author": "Anyone",
+                    "author_channel_id": "UCsomeone",
+                }
+            ]
+        },
+    )
+    # owner_channel_id を渡さない
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    plan = replier.run(dry_run=True)
+
+    # Then: own_comment スキップは働かない
+    assert any(row["comment_id"] == "c1" for row in plan.planned)
+    assert not any(row.get("reason") == "own_comment" for row in plan.skipped)
+
+
+# --- リグレッション防止テスト（SRP: _fetch_channel_info / _iter_uploaded_video_ids） ---
+
+
+def test_fetch_channel_info_returns_owner_and_uploads_playlist_id(tmp_path):
+    """_fetch_channel_info が (owner_id, uploads_playlist_id) タプルを返すことを確認."""
+    yt = _mock_youtube(video_ids=[], comments_by_video={})
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    owner_id, uploads_id = replier._fetch_channel_info()
+
+    assert owner_id == "UCtest"
+    assert uploads_id == "PLuploads"
+
+
+def test_iter_uploaded_video_ids_does_not_mutate_owner_channel_id(tmp_path):
+    """_iter_uploaded_video_ids が _owner_channel_id を変更せず channels.list を呼ばないことを確認（SRP）."""
+    yt = _mock_youtube(video_ids=["v1", "v2"], comments_by_video={})
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    assert replier._owner_channel_id is None
+    list(replier._iter_uploaded_video_ids("PLuploads"))
+    assert replier._owner_channel_id is None
+    yt.channels.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.1"
+version = "5.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

## 背景

`yt-comments-reply` は現状、`commentThreads.list(part="snippet")` でトップレベルコメントしか取得していない。
このため、以下のシナリオに反応できない:

- チャンネル所有者の返信に対する視聴者の返信
- 視聴者同士の返信
- 既存スレッドに後から追加された返信全般

YouTube のコメント構造は「top-level → replies (フラット 1 階層)」なので、
**replies スレッド全体を走査対象に含める**だけで上記すべてに対応できる。

## 現状

`utils/comments/fetcher.py::fetch_top_level_comments` は以下の通り
top-level のみを yield する:

```python
response = (
    youtube.commentThreads()
    .list(
        part="snippet",           # ← replies が含まれない
        videoId=video_id,
        ...
        textFormat="plainText",
    )
    .execute()
)

for item in response.get("items", []):
    top = item["snippet"]["topLevelComment"]
    ...
    yield FetchedComment(comment_id=top["id"], ...)
    # ← item["replies"]["comments"][*] が捨てられている
```

## 期待する動作

1. `part="snippet,replies"` で取得し、`item["replies"]["comments"][*]` も `FetchedComment` として yield する
2. `totalReplyCount > 5`（API が `replies` を最大 5 件しか含めない）の場合は
   別途 `comments().list(parentId=top["id"])` でページングして全件取得
3. `FetchedComment` に `parent_id: str | None` フィールドを追加し、
   top-level なら `None`、reply なら親 top-level の comment_id を入れる
   - rule engine 側で「reply には反応しない」等の制御を可能にするため

## 実装メモ

- 既存 `comment_id` がユニーク（top-level と reply で衝突しない）なので `comment_reply_history.json` の format は変更不要
- `comments.insert(parentId=...)` は reply の id を渡しても OK（YouTube が thread の末尾に追加してくれる）
- 自分（channel owner）の返信を skip するロジックは既に `already_replied` で機能しているはずだが、
  reply 走査時に履歴外の自分の返信を拾わないよう、`authorChannelId` ベースの skip も追加検討
- ルール側互換性: 既存 keyword rule は top-level / reply の区別なくマッチする。
  分けたい場合は `CommentRule` に `scope: "top_level" | "reply" | "any"` 等を任意追加

## スコープ外

- YouTube が UI 上サポートしない深い nest（top-level → reply → reply の "深さ 2"）
  → API は parentId が reply の場合も flat にする仕様なので考慮不要
- LLM 駆動の返信生成（別 issue で議論したい）

## 影響範囲

- 既存 `yt-comments-reply --dry-run / --apply` の top-level 動作は不変
- 新規取得対象が増えるので `--limit` / `max_replies_per_run` の挙動を確認したい

## 検出経路

rjn 運用中（[rain-jazz-night](https://github.com/daiki-beppu/youtube-rain-jazz-night)）、
動画への自分の返信に視聴者から返信がついても `yt-comments-reply --dry-run` が拾えないことに気付いた。

## Execution Report

Workflow `default-mini` completed successfully.

Closes #365