### PR TITLE
feat(videoup): 静止画 fallback の ffmpeg を keyint/crf/preset で最適化 (#579)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -177,10 +177,12 @@ if [[ -n "$LOOP_VIDEO" ]]; then
         "$MASTER_OUTPUT" &
 else
     # 静止画背景モード（従来）
+    # I-frame を 5 分間隔（1fps なので 300 フレーム）に間引き、変化のないフレームを P-frame で
+    # 圧縮することで master.mp4 を大幅に小型化する（#579）。keyint=1 全 I-frame 化は容量が膨らむため廃止。
     ffmpeg -y -framerate 1 -loop 1 -i "$THUMBNAIL" -i "$MASTER_AUDIO" \
-        -c:v libx264 -tune stillimage -preset ultrafast -crf 23 -pix_fmt yuv420p \
+        -c:v libx264 -tune stillimage -preset medium -crf 28 -pix_fmt yuv420p \
         -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
-        -x264opts keyint=1:min-keyint=1 \
+        -g 300 \
         -r 1 \
         "${AUDIO_OUT_OPTS[@]}" \
         -t "$duration" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(loop-video)`: skill-config にトップレベル `enabled`（default: `true`）を追加し、channel 単位でループ動画化を停止可能にした（#577）。`config/skills/loop-video.yaml::enabled: false` のチャンネルでは `yt-generate-loop-video` を fail-loud で停止（`--smooth` / `--skip-existing` 含む全経路をブロック）し、取り消し不可な Veo 課金のうっかり実行を防ぐ。`comments-reply` / `pinned-comment` の `enabled` semantic と統一（`compression.enabled` の FFmpeg 圧縮 on/off とは別概念）。`videoup` skill の Step 3 は `enabled: false` のとき `/loop-video` を案内せず `10-assets/main.png` を静止背景にフォールバックする
 
+### Changed
+
+- `feat(videoup)`: 静止画 fallback 経路（`loop.mp4` 不在時）の master.mp4 生成 ffmpeg オプションを最適化（#579）。`generate_videos.sh` の静止画モードで全フレームを I-frame 化していた `-x264opts keyint=1:min-keyint=1` を廃止し `-g 300`（1fps で 5 分間隔）へ、`-preset ultrafast` → `-preset medium`、`-crf 23` → `-crf 28` に変更。変化のないフレームを P-frame で圧縮し容量を大幅削減する（rjn / 2h17m 公開実績 3.35GB に対し ~450-500MB の試算。実機ベンチは未取得で rjn 次回コレクション公開時に取得予定）。ループ動画背景モード（`-c:v copy` の stream copy 経路）は変更なし
+
 ## [5.5.4] - 2026-05-25
 
 ### Added


### PR DESCRIPTION
## 概要

`generate_videos.sh` の静止画背景モード（`loop.mp4` 不在時の fallback）で生成される master.mp4 が、全フレーム I-frame 化により静止画にしては不釣り合いに肥大していた問題を最適化する。

closes #579

## 変更内容（lines 180-191 の静止画モード ffmpeg）

| 変更点 | 効果 |
|---|---|
| `-x264opts keyint=1:min-keyint=1` 削除 → `-g 300` | 1fps なので 5 分間隔で I-frame を打ち、残り全フレームを「変化なし」P-frame で数バイトに圧縮 |
| `-preset ultrafast` → `-preset medium` | エントロピー符号化最適化・参照フレーム増で容量さらに削減 |
| `-crf 23` → `-crf 28` | 静止画なら知覚品質変わらず容量半減 |

ループ動画背景モード（`-c:v copy` の stream copy 経路, lines 168-177）は無変更。

## 期待効果（試算）

| | 現状 | 提案後 |
|---|---|---|
| 出力 MP4 合計 | 3.35 GB | ~450-500 MB |
| 削減率 | — | 約 1/7 |

観測元: rjn / Mochi Cloud Hours 公開時（2026-05-25, 1920×1080 PNG + 2h17m57s 音声）。

## ⚠️ 検証ステータス

- **実機ベンチは未取得**。上記は issue 記載の試算値。rjn 次回コレクション公開時に実測を取得し #579 / 本 PR に追記する想定。
- マージ前に 1 件実機エンコードして数値・エンコード時間を確認するのが望ましい。

## 影響範囲

静止画 fallback を使う全チャンネル（`loop.mp4` を生成しない / `/loop-video` 無効化チャンネル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)