### PR TITLE
fix: loop動画の高ビットレート肥大化を防ぐ

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# generate_videos.sh v12.0 — Master video generator
+# generate_videos.sh v12.1 — Master video generator
 # Static image + master audio → MP4 (macOS optimized)
-# v12: ループモードを正規化キャッシュ + stream copy 化（クオリティ完全保持で大幅高速化）
+# v12.1: ループモードの高ビットレート入力を上限付き正規化に退避
 #
 # Usage:
 #   bash .claude/skills/videoup/references/generate_videos.sh <collection-path>
@@ -59,6 +59,8 @@ LOOP_TARGET_HEIGHT="1080"
 LOOP_TARGET_PIX_FMT="yuv420p"
 LOOP_TARGET_FRAME_RATE="24/1"
 LOOP_OUTPUT_FRAME_RATE="24"
+LOOP_MAX_BITRATE="6000k"
+LOOP_BUFSIZE="12000k"
 
 # ─── Audio encoder 自動選択 (macOS は AudioToolbox 優先) ─
 if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
@@ -109,9 +111,47 @@ format_duration() {
     printf "%dh %02dm %02ds" $((secs/3600)) $((secs%3600/60)) $((secs%60))
 }
 
+bitrate_to_bps() {
+    local value="$1"
+    local unit number
+
+    if [[ -z "$value" || "$value" == "N/A" ]]; then
+        echo ""
+        return
+    fi
+
+    unit="$(echo "${value: -1}" | tr '[:upper:]' '[:lower:]')"
+    case "$unit" in
+        k)
+            number="${value%?}"
+            awk "BEGIN{printf \"%.0f\", $number * 1000}"
+            ;;
+        m)
+            number="${value%?}"
+            awk "BEGIN{printf \"%.0f\", $number * 1000000}"
+            ;;
+        *)
+            awk "BEGIN{printf \"%.0f\", $value}"
+            ;;
+    esac
+}
+
+video_bitrate_bps() {
+    local file="$1"
+    local bitrate
+
+    bitrate="$(ffprobe -v error -select_streams v:0 \
+        -show_entries stream=bit_rate -of default=noprint_wrappers=1:nokey=1 "$file" 2>/dev/null | head -1)"
+    if [[ -z "$bitrate" || "$bitrate" == "N/A" ]]; then
+        bitrate="$(ffprobe -v error \
+            -show_entries format=bit_rate -of default=noprint_wrappers=1:nokey=1 "$file" 2>/dev/null | head -1)"
+    fi
+    bitrate_to_bps "$bitrate"
+}
+
 # ─── Main ────────────────────────────────────────────────
 echo ""
-echo "  generate_videos.sh v12.0 — ${COLLECTION_NAME}"
+echo "  generate_videos.sh v12.1 — ${COLLECTION_NAME}"
 echo "  ──────────────────────────────────────────"
 echo ""
 if [[ -n "$LOOP_VIDEO" ]]; then
@@ -141,17 +181,27 @@ if [[ -n "$LOOP_VIDEO" ]]; then
     loop_h="$(echo "$loop_specs" | cut -d, -f2)"
     loop_pix="$(echo "$loop_specs" | cut -d, -f3)"
     loop_fps="$(echo "$loop_specs" | cut -d, -f4)"
+    loop_bitrate_bps="$(video_bitrate_bps "$LOOP_VIDEO")"
+    max_bitrate_bps="$(bitrate_to_bps "$LOOP_MAX_BITRATE")"
 
-    if [[ "$loop_w" == "$LOOP_TARGET_WIDTH" && "$loop_h" == "$LOOP_TARGET_HEIGHT" && "$loop_pix" == "$LOOP_TARGET_PIX_FMT" && "$loop_fps" == "$LOOP_TARGET_FRAME_RATE" ]]; then
+    if [[ "$loop_w" == "$LOOP_TARGET_WIDTH" && "$loop_h" == "$LOOP_TARGET_HEIGHT" && "$loop_pix" == "$LOOP_TARGET_PIX_FMT" && "$loop_fps" == "$LOOP_TARGET_FRAME_RATE" \
+          && ( -z "$loop_bitrate_bps" || "$loop_bitrate_bps" -le "$max_bitrate_bps" ) ]]; then
         # 既に正規化済み: そのまま使う
         LOOP_SOURCE="$LOOP_VIDEO"
     else
         # 正規化キャッシュを使用
         LOOP_SOURCE="${ASSETS_DIR}/loop_normalized.mp4"
-        if [[ ! -f "$LOOP_SOURCE" || "$LOOP_VIDEO" -nt "$LOOP_SOURCE" ]]; then
+        normalized_bitrate_bps=""
+        if [[ -f "$LOOP_SOURCE" ]]; then
+            normalized_bitrate_bps="$(video_bitrate_bps "$LOOP_SOURCE")"
+        fi
+        if [[ ! -f "$LOOP_SOURCE" || "$LOOP_VIDEO" -nt "$LOOP_SOURCE" || ( -n "$normalized_bitrate_bps" && "$normalized_bitrate_bps" -gt "$max_bitrate_bps" ) ]]; then
             echo "  Normalizing loop source (1 回だけ実行) → loop_normalized.mp4"
+            if [[ -n "$loop_bitrate_bps" && "$loop_bitrate_bps" -gt "$max_bitrate_bps" ]]; then
+                echo "  Loop bitrate exceeds ${LOOP_MAX_BITRATE}; re-encoding with maxrate guard"
+            fi
             ffmpeg -y -i "$LOOP_VIDEO" \
-                -c:v libx264 -preset slow -crf 18 -profile:v high -pix_fmt yuv420p \
+                -c:v libx264 -preset slow -crf 22 -maxrate "$LOOP_MAX_BITRATE" -bufsize "$LOOP_BUFSIZE" -profile:v high -pix_fmt yuv420p \
                 -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,format=yuv420p" \
                 -r "$LOOP_OUTPUT_FRAME_RATE" \
                 -an -movflags +faststart \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(videoup)`: `generate_videos.sh` の loop 背景モードで高ビットレート `loop.mp4` を `-c:v copy` して長尺 master.mp4 が肥大化する問題を修正（#592）。正規化済み判定に実測ビットレート上限（6Mbps）を追加し、超過時は `loop_normalized.mp4` を CRF22 / maxrate 6000k / bufsize 12000k で再エンコードしてから stream copy する
 - `fix(videoup)`: `generate_videos.sh` の loop 正規化判定に `r_frame_rate` を追加し、24fps 以外の `loop.mp4` を `-r 24` 付き `loop_normalized.mp4` 経路へ強制するよう修正。30fps loop と 24fps 系アセットの concat/stream copy 不整合を予防
 
 ### Migration

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -43,6 +43,14 @@ if [[ "$args" == *"stream=width,height,pix_fmt,r_frame_rate"* ]]; then
     printf '%s\\n' "${FFPROBE_STREAM_OUTPUT}"
     exit 0
 fi
+if [[ "$args" == *"stream=bit_rate"* ]]; then
+    printf '%s\\n' "${FFPROBE_STREAM_BITRATE_OUTPUT:-}"
+    exit 0
+fi
+if [[ "$args" == *"format=bit_rate"* ]]; then
+    printf '%s\\n' "${FFPROBE_FORMAT_BITRATE_OUTPUT:-}"
+    exit 0
+fi
 exit 0
 """,
     )
@@ -80,13 +88,19 @@ printf 'stub-output' > "$output_path"
     return bin_dir
 
 
-def _run_generate_videos(tmp_path: Path, stream_output: str) -> tuple[subprocess.CompletedProcess[str], Path]:
+def _run_generate_videos(
+    tmp_path: Path,
+    stream_output: str,
+    *,
+    stream_bitrate_output: str = "",
+) -> tuple[subprocess.CompletedProcess[str], Path]:
     collection = _create_collection(tmp_path)
     bin_dir = _create_stub_bin(tmp_path)
     ffmpeg_log = tmp_path / "ffmpeg.log"
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     env["FFPROBE_STREAM_OUTPUT"] = stream_output
+    env["FFPROBE_STREAM_BITRATE_OUTPUT"] = stream_bitrate_output
     env["FFMPEG_LOG"] = str(ffmpeg_log)
     result = subprocess.run(
         ["bash", str(_SCRIPT_PATH), str(collection)],
@@ -99,13 +113,34 @@ def _run_generate_videos(tmp_path: Path, stream_output: str) -> tuple[subprocess
 
 
 def test_24fps_loop_skips_normalization(tmp_path: Path) -> None:
-    result, ffmpeg_log = _run_generate_videos(tmp_path, "1920,1080,yuv420p,24/1")
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+    )
 
     assert result.returncode == 0, result.stderr
     commands = ffmpeg_log.read_text(encoding="utf-8").splitlines()
     assert len(commands) == 1
     assert "loop_normalized.mp4" not in commands[0]
     assert "10-assets/loop.mp4" in commands[0]
+
+
+def test_high_bitrate_24fps_loop_runs_normalization(tmp_path: Path) -> None:
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="15650000",
+    )
+
+    assert result.returncode == 0, result.stderr
+    commands = ffmpeg_log.read_text(encoding="utf-8").splitlines()
+    assert len(commands) == 2
+    assert "loop_normalized.mp4" in commands[0]
+    assert " -crf 22 " in f" {commands[0]} "
+    assert " -maxrate 6000k " in f" {commands[0]} "
+    assert " -bufsize 12000k " in f" {commands[0]} "
+    assert "10-assets/loop_normalized.mp4" in commands[1]
 
 
 def test_non_24fps_loop_runs_normalization_with_fixed_24fps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- loop.mp4 の実測ビットレートを正規化済み判定に追加
- 6Mbps 超過時は loop_normalized.mp4 を CRF22 / maxrate 6000k / bufsize 12000k で再エンコード
- 高ビットレート時と低ビットレート時の分岐テストを追加

## Root Cause
loop モードが解像度 / pix_fmt / fps のみで正規化済み判定し、仕様一致した高ビットレート loop.mp4 を -c:v copy していたため、長尺出力が入力ビットレートに比例して肥大化していました。

## Validation
- bash -n .claude/skills/videoup/references/generate_videos.sh
- uv run pytest tests/test_generate_videos_script.py tests/test_scripts_layout.py -q

Closes #592