### PR TITLE
fix: コメント無効動画を skip して返信処理を継続する (#590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(comments-reply)`: コメント無効動画で `yt-comments-reply` の全動画走査が停止する問題を修正（#590）。`commentThreads.list` の 403 `commentsDisabled` は動画単位で `skipped(reason=comments_disabled)` に記録して次の動画へ継続し、quota/auth など他の API エラーは従来どおり伝播する。`--video-id` 明示指定時も同じ skip 挙動に統一
 - `fix(videoup)`: `generate_videos.sh` の loop 背景モードで高ビットレート `loop.mp4` を `-c:v copy` して長尺 master.mp4 が肥大化する問題を修正（#592）。正規化済み判定に実測ビットレート上限（6Mbps）を追加し、超過時は `loop_normalized.mp4` を CRF22 / maxrate 6000k / bufsize 12000k で再エンコードしてから stream copy する
 - `fix(videoup)`: `generate_videos.sh` の loop 正規化判定に `r_frame_rate` を追加し、24fps 以外の `loop.mp4` を `-r 24` 付き `loop_normalized.mp4` 経路へ強制するよう修正。30fps loop と 24fps 系アセットの concat/stream copy 不整合を予防
 

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -33,6 +33,8 @@ from youtube_automation.utils.exceptions import ConfigError, GeneratorError, You
 logger = logging.getLogger(__name__)
 
 _HELD_FOR_REVIEW = "heldForReview"
+_COMMENTS_DISABLED_API_REASON = "commentsDisabled"
+_COMMENTS_DISABLED_SKIP_REASON = "comments_disabled"
 
 
 @dataclass
@@ -170,12 +172,32 @@ class CommentReplier:
         for vid in video_source:
             if len(plan.planned) >= limit:
                 break
-            for comment in fetch_comments(self._youtube, video_id=vid, max_results=per_video_limit, since=since):
-                if len(plan.planned) >= limit:
-                    break
-                self._process_comment(comment, engine, plan, dry_run)
+            self._process_video_comments(vid, engine, plan, dry_run, per_video_limit, since, limit)
 
         return plan
+
+    def _process_video_comments(
+        self,
+        video_id: str,
+        engine: RuleEngine,
+        plan: ReplyPlan,
+        dry_run: bool,
+        per_video_limit: int,
+        since: datetime | None,
+        limit: int,
+    ) -> None:
+        comments = fetch_comments(self._youtube, video_id=video_id, max_results=per_video_limit, since=since)
+        while len(plan.planned) < limit:
+            try:
+                comment = next(comments)
+            except StopIteration:
+                return
+            except YouTubeAPIError as e:
+                if not _is_comments_disabled_error(e):
+                    raise
+                plan.skipped.append(self._video_skip_record(video_id, _COMMENTS_DISABLED_SKIP_REASON))
+                return
+            self._process_comment(comment, engine, plan, dry_run)
 
     def _get_title(self, video_id: str) -> str:
         if video_id in self._title_cache:
@@ -386,6 +408,15 @@ class CommentReplier:
         }
 
     @staticmethod
+    def _video_skip_record(video_id: str, reason: str) -> dict:
+        return {
+            "comment_id": None,
+            "video_id": video_id,
+            "comment_author": None,
+            "reason": reason,
+        }
+
+    @staticmethod
     def _error_record(comment: FetchedComment, message: str) -> dict:
         return {
             "comment_id": comment.comment_id,
@@ -393,3 +424,7 @@ class CommentReplier:
             "comment_author": comment.author,
             "error": message,
         }
+
+
+def _is_comments_disabled_error(error: YouTubeAPIError) -> bool:
+    return error.status_code == 403 and error.reason == _COMMENTS_DISABLED_API_REASON

--- a/src/youtube_automation/utils/exceptions.py
+++ b/src/youtube_automation/utils/exceptions.py
@@ -3,6 +3,8 @@
 アプリケーション全体で一貫したエラーハンドリングを提供する。
 """
 
+import json
+
 
 class AutomationError(Exception):
     """youtube-channels-automation の基底例外"""
@@ -25,9 +27,10 @@ class YouTubeAPIError(AutomationError):
     - レスポンス不正
     """
 
-    def __init__(self, message: str, status_code: int | None = None):
+    def __init__(self, message: str, status_code: int | None = None, reason: str | None = None):
         super().__init__(message)
         self.status_code = status_code
+        self.reason = reason
 
     @classmethod
     def from_http_error(cls, error, context: str) -> "YouTubeAPIError":
@@ -35,6 +38,7 @@ class YouTubeAPIError(AutomationError):
         return cls(
             f"{context}: {error}",
             status_code=int(status) if status is not None else None,
+            reason=_http_error_reason(error),
         )
 
 
@@ -79,3 +83,29 @@ class UploadError(AutomationError):
 
 class GeneratorError(AutomationError):
     """返信生成バックエンドの失敗（API エラー・レスポンス不正等）"""
+
+
+def _http_error_reason(error) -> str | None:
+    content = getattr(error, "content", b"")
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(content)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return _payload_reason(payload)
+
+
+def _payload_reason(payload: object) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    errors = error.get("errors")
+    if isinstance(errors, list):
+        for item in errors:
+            if isinstance(item, dict) and isinstance(item.get("reason"), str):
+                return item["reason"]
+    reason = error.get("reason")
+    return reason if isinstance(reason, str) else None

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from googleapiclient.errors import HttpError
 
 from youtube_automation.utils.comments.history import ReplyHistory
 from youtube_automation.utils.comments.replier import CommentReplier
@@ -14,6 +15,7 @@ from youtube_automation.utils.config.comments import (
     Comments,
     GeneratorConfig,
 )
+from youtube_automation.utils.exceptions import YouTubeAPIError
 
 _PATCH_GENAI_CLIENT = "youtube_automation.utils.genai_client.create_genai_client"
 
@@ -21,7 +23,7 @@ _PATCH_GENAI_CLIENT = "youtube_automation.utils.genai_client.create_genai_client
 def _mock_youtube(
     *,
     video_ids: list[str],
-    comments_by_video: dict[str, list[dict]],
+    comments_by_video: dict[str, list[dict] | BaseException],
     insert_side_effect=None,
 ) -> MagicMock:
     """youtube.* チェーン呼び出しを MagicMock で構築."""
@@ -48,6 +50,8 @@ def _mock_youtube(
         # videoId はキーワード引数として渡される想定
         video_id = _list_execute.current_video_id
         raw = comments_by_video.get(video_id, [])
+        if isinstance(raw, BaseException):
+            raise raw
         items = []
         for c in raw:
             top_snippet: dict = {
@@ -92,6 +96,23 @@ def _mock_youtube(
     yt.comments.return_value.insert.return_value = insert_mock
     yt._insert_mock = insert_mock
     return yt
+
+
+class _FakeResp:
+    def __init__(self, status: int, reason: str):
+        self.status = status
+        self.reason = reason
+
+    def __getitem__(self, _key):
+        return "application/json"
+
+    def get(self, _key, default=None):
+        return default
+
+
+def _make_http_error(status: int, reason: str, api_reason: str) -> HttpError:
+    content = f'{{"error": {{"errors": [{{"reason": "{api_reason}"}}], "message": "{api_reason}"}}}}'.encode()
+    return HttpError(_FakeResp(status, reason), content)
 
 
 def _make_config(**overrides) -> Comments:
@@ -268,20 +289,58 @@ def test_explicit_video_ids_skip_playlist_items_lookup(tmp_path):
     yt.playlistItems.return_value.list.assert_not_called()
 
 
+def test_comments_disabled_video_is_skipped_and_next_video_is_processed(tmp_path):
+    err = _make_http_error(403, "Forbidden", "commentsDisabled")
+    yt = _mock_youtube(
+        video_ids=["disabled", "enabled"],
+        comments_by_video={
+            "disabled": err,
+            "enabled": [{"comment_id": "c1", "text": "こんにちは！", "author": "Viewer"}],
+        },
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    plan = replier.run(dry_run=True)
+
+    assert len(plan.planned) == 1
+    assert plan.planned[0]["video_id"] == "enabled"
+    assert any(
+        row["video_id"] == "disabled" and row["comment_id"] is None and row["reason"] == "comments_disabled"
+        for row in plan.skipped
+    )
+
+
+def test_comments_disabled_explicit_video_id_is_skipped(tmp_path):
+    err = _make_http_error(403, "Forbidden", "commentsDisabled")
+    yt = _mock_youtube(video_ids=["disabled"], comments_by_video={"disabled": err})
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    plan = replier.run(dry_run=True, video_ids=["disabled"])
+
+    assert plan.planned == []
+    assert plan.skipped == [
+        {
+            "comment_id": None,
+            "video_id": "disabled",
+            "comment_author": None,
+            "reason": "comments_disabled",
+        }
+    ]
+
+
+def test_comment_threads_api_error_other_than_comments_disabled_is_raised(tmp_path):
+    err = _make_http_error(403, "Forbidden", "quotaExceeded")
+    yt = _mock_youtube(video_ids=["v1"], comments_by_video={"v1": err})
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    with pytest.raises(YouTubeAPIError) as exc_info:
+        replier.run(dry_run=True)
+
+    assert "quotaExceeded" in str(exc_info.value)
+
+
 def test_api_error_recorded_in_errors(tmp_path):
-    from googleapiclient.errors import HttpError
-
-    class _FakeResp:
-        status = 403
-        reason = "Forbidden"
-
-        def __getitem__(self, _key):
-            return "application/json"
-
-        def get(self, _key, default=None):
-            return default
-
-    err = HttpError(_FakeResp(), b'{"error": "forbidden"}')
+    err = HttpError(_FakeResp(403, "Forbidden"), b'{"error": "forbidden"}')
     yt = _mock_youtube(
         video_ids=["v1"],
         comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！"}]},


### PR DESCRIPTION
## Summary
- commentsDisabled の YouTube API エラーを動画単位で skip し、他動画のコメント処理を継続
- YouTubeAPIError に structured reason を保持し、commentsDisabled 以外の API エラーは従来どおり伝播
- 全動画走査、明示 video_id、非 commentsDisabled の回帰テストを追加

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m pytest tests/test_comments_replier.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m pytest tests/test_oauth_handler_exceptions.py tests/test_analytics_system.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check src/youtube_automation/utils/exceptions.py src/youtube_automation/utils/comments/replier.py tests/test_comments_replier.py

Closes #590