### PR TITLE
fix: containsSyntheticMedia を true に是正し AI 開示に対応 (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `fix(video-upload)`: 動画アップロード時の `status.containsSyntheticMedia` を `False` 固定から `True` に是正した（#603）。本ツールは AI 生成音楽（Lyria / Suno）を主軸とするため、YouTube の AI 開示（altered or synthetic content）ポリシー上 `true` の申告が正しい。`YouTubeAutoUploader.upload_video()` を経由する全アップロード経路（Auto / Short / Collection は同メソッドへ委譲）に反映され、`.claude/skills/video-upload/SKILL.md` の記載（`true`）とも整合する。値の config 外出し（#605）と公開済み動画への遡及対応（#606）は別 issue
+
 ## [5.5.5] - 2026-05-30
 
 ### Added

--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -109,7 +109,9 @@ class YouTubeAutoUploader(YouTubeUploadCore):
         status_body = {
             "privacyStatus": metadata.get("privacy_status", "private"),
             "selfDeclaredMadeForKids": False,
-            "containsSyntheticMedia": False,
+            # AI 生成音楽（Lyria / Suno）を主軸とするため、YouTube の AI 開示
+            # （altered or synthetic content）ポリシー上 true を申告する (#603)
+            "containsSyntheticMedia": True,
         }
 
         # スケジュール公開: publishAt 指定時は private 必須

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -196,6 +196,26 @@ class TestUploadVideoForwarding:
         assert call_kwargs.get("on_session_uri_changed") is on_session
         assert call_kwargs.get("on_upload_complete") is on_complete
 
+    def test_should_declare_contains_synthetic_media_true(self, tmp_path):
+        """#603: AI 生成音楽を主軸とするため status.containsSyntheticMedia を true で申告する."""
+        # Given
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path / "collections"))
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"\x00")
+
+        with patch(
+            "youtube_automation.agents.youtube_auto_uploader.YouTubeUploadCore.upload_video",
+            return_value="VID_SYNTHETIC",
+        ) as mock_core_upload:
+            # When
+            uploader.upload_video(str(video), _make_metadata())
+
+        # Then: super().upload_video(video_path, body, ...) の body[status] を検証
+        body = mock_core_upload.call_args.args[1]
+        assert body["status"]["containsSyntheticMedia"] is True
+
     def test_should_default_resume_kwargs_to_none_when_omitted(self, tmp_path):
         """resume kwargs を渡さなければコアにも None 相当が渡る（後方互換）."""
         # Given

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.4"
+version = "5.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## 概要

AI 生成音楽（Lyria / Suno）を主軸とするチャンネルにもかかわらず、動画アップロード時の `status.containsSyntheticMedia` が `False` 固定になっており、YouTube の AI 開示（altered or synthetic content）ポリシー上の実態と矛盾していた。`True` に是正する。

closes #603

## 背景

YouTube は「完全 AI 生成の楽曲」を AI 開示対象としている（https://support.google.com/youtube/answer/14328491 ）。本チャンネルの動画は AI 生成音楽を含むため開示対象に該当する。加えて実装 (`False`) と `.claude/skills/video-upload/SKILL.md`（`true` 記載）が食い違っていたが、本修正で整合する。

## 変更内容

- `src/youtube_automation/agents/youtube_auto_uploader.py` の `status_body` を `containsSyntheticMedia: True` に是正
  - `YouTubeAutoUploader.upload_video()` を経由する全アップロード（Auto / Short / Collection は同メソッドへ委譲）に反映
- `containsSyntheticMedia=True` を検証するユニットテストを追加

## テスト

- `uv run pytest tests/test_youtube_auto_uploader.py` → 20 passed（新規テスト含む）
- `uv run pytest tests/test_short_uploader.py tests/test_collection_uploader.py` → 48 passed
- `ruff check` → All checks passed

## スコープ外（別 issue）

- `containsSyntheticMedia` / `selfDeclaredMadeForKids` の config 外出し（audit 要件 R-5）
- 既にアップロード済み動画への遡及的な開示設定変更（YouTube Studio 手動対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)