### PR TITLE
refactor: scripts のコレクションサブパスを CollectionPaths 経由に統一 (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `fix(video-upload)`: 動画アップロード時の `status.containsSyntheticMedia` を `False` 固定から `True` に是正した（#603）。本ツールは AI 生成音楽（Lyria / Suno）を主軸とするため、YouTube の AI 開示（altered or synthetic content）ポリシー上 `true` の申告が正しい。`YouTubeAutoUploader.upload_video()` を経由する全アップロード経路（Auto / Short / Collection は同メソッドへ委譲）に反映され、`.claude/skills/video-upload/SKILL.md` の記載（`true`）とも整合する。値の config 外出し（#605）と公開済み動画への遡及対応（#606）は別 issue
+- `refactor(scripts)`: `metadata_audit` / `playlist_manager` に残っていたコレクションサブパスリテラル（`20-documentation` / `descriptions.md` / `workflow-state.json` / `upload_tracking.json`）を `CollectionPaths` のプロパティ（`docs_dir` / `descriptions_md_path` / `workflow_state_path` / `tracking_path`）経由に統一した（#536）。挙動は不変
 
 ## [5.5.5] - 2026-05-30
 

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -53,9 +53,10 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     """Return a list of issue descriptions for this collection."""
     issues: list[str] = []
     supported_langs = list(config.localizations.supported_languages)
+    paths = CollectionPaths(col)
 
-    desc_md = col / "20-documentation" / "descriptions.md"
-    stray = list((col / "20-documentation").glob("description*"))
+    desc_md = paths.descriptions_md_path
+    stray = list(paths.docs_dir.glob("description*"))
     stray = [p for p in stray if p.name != "descriptions.md"]
     if stray:
         issues.append(f"stray description file(s): {[p.name for p in stray]}")
@@ -88,7 +89,7 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
                     issues.append(msg)
 
     # workflow-state.json scene_phrases
-    ws = col / "workflow-state.json"
+    ws = paths.workflow_state_path
     if ws.exists():
         state = json.loads(ws.read_text(encoding="utf-8"))
         sp = state.get("scene_phrases") or {}
@@ -112,7 +113,7 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     # 動画尺チェック（master mp4 がローカルに残っている場合のみ。
     # /live-clean 後のコレクションでは skip して偽陽性を防ぐ）
     if config.audio.target_duration_min is not None or config.audio.target_duration_max is not None:
-        master_video = CollectionPaths(col).find_master_video()
+        master_video = paths.find_master_video()
         if master_video:
             dur = probe_duration(master_video)
             if dur is None:
@@ -177,7 +178,7 @@ def collect_video_ids() -> dict[str, str]:
     for col in sorted(COLLECTIONS_DIR.iterdir()):
         if not col.is_dir():
             continue
-        tracking = col / "20-documentation" / "upload_tracking.json"
+        tracking = CollectionPaths(col).tracking_path
         if not tracking.exists():
             continue
         try:

--- a/src/youtube_automation/scripts/playlist_manager.py
+++ b/src/youtube_automation/scripts/playlist_manager.py
@@ -17,6 +17,7 @@ import logging
 import sys
 from pathlib import Path
 
+from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config, reset
 from youtube_automation.utils.youtube_service import get_youtube
 
@@ -189,7 +190,7 @@ class PlaylistManager:
         ファイル欠落・JSON 壊れ・キー欠落はいずれも `None` を返して呼び出し側に
         `activity_for_theme` fallback させる（プレイリスト追加は非致命的機能のため）。
         """
-        ws_path = collection_path / "workflow-state.json"
+        ws_path = CollectionPaths(collection_path).workflow_state_path
         if not ws_path.exists():
             return None
         try:
@@ -288,8 +289,10 @@ class PlaylistManager:
             if not col_path.is_dir() or col_path.name.startswith("."):
                 continue
 
+            paths = CollectionPaths(col_path)
+
             # workflow-state.json からテーマ取得
-            ws_path = col_path / "workflow-state.json"
+            ws_path = paths.workflow_state_path
             if not ws_path.exists():
                 logger.warning(f"  {col_path.name}: workflow-state.json なし — スキップ")
                 continue
@@ -303,7 +306,7 @@ class PlaylistManager:
                 continue
 
             # upload_tracking.json から video_id 取得
-            tracking_path = col_path / "20-documentation" / "upload_tracking.json"
+            tracking_path = paths.tracking_path
             if not tracking_path.exists():
                 logger.warning(f"  {col_path.name}: upload_tracking.json なし — スキップ")
                 continue


### PR DESCRIPTION
## 概要

`metadata_audit.py` / `playlist_manager.py` に残っていたコレクションサブパスのリテラル構築を `CollectionPaths` プロパティへ統一した（#536）。

## 変更内容

### `metadata_audit.py`
- `audit_local` の先頭で `paths = CollectionPaths(col)` を 1 度生成し再利用
  - `col / "20-documentation" / "descriptions.md"` → `paths.descriptions_md_path`
  - `(col / "20-documentation").glob(...)` → `paths.docs_dir.glob(...)`
  - `col / "workflow-state.json"` → `paths.workflow_state_path`
  - 既存の `CollectionPaths(col).find_master_video()` も `paths` 再利用に統一
- `collect_video_ids`: `col / "20-documentation" / "upload_tracking.json"` → `CollectionPaths(col).tracking_path`

### `playlist_manager.py`
- `CollectionPaths` を import 追加
- `_planning_activities`: `collection_path / "workflow-state.json"` → `CollectionPaths(collection_path).workflow_state_path`
- `sync_existing_videos`: 先頭で `paths = CollectionPaths(col_path)` を生成し `workflow_state_path` / `tracking_path` で統一

既存挙動は不変（パス構築箇所のみ置換、コメント・ログ・docstring は不変）。

## テスト

`uv run pytest tests/test_metadata_audit.py tests/test_playlist_manager.py` → 27 passed

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)