### PR TITLE
refactor: localizations フィクスチャを symlink から実体ファイル化 (#513)

### DIFF
--- a/tests/fixtures/sample_channel/config/localizations.json
+++ b/tests/fixtures/sample_channel/config/localizations.json
@@ -1,1 +1,35 @@
-../../../../examples/localizations.example.json
+{
+  "supported_languages": ["ja", "en", "de"],
+  "languages": {
+    "ja": {
+      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "activities": "ゲーム · 勉強 · 集中",
+      "description": {
+        "opening_poem": "ピクセルの夜、冒険の調べ",
+        "cta_subscribe": "チャンネル登録お願いします！",
+        "tagline": "チップチューンアドベンチャーをお届けします！",
+        "hashtags": "#chiptune #8bit #BGM"
+      }
+    },
+    "en": {
+      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "activities": "Gaming · Study · Focus",
+      "description": {
+        "opening_poem": "Pixel nights, melodies of adventure",
+        "cta_subscribe": "Subscribe for more adventures!",
+        "tagline": "Chiptune adventures await you!",
+        "hashtags": "#chiptune #8bit #BGM"
+      }
+    },
+    "de": {
+      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "activities": "Gaming · Lernen · Fokus",
+      "description": {
+        "opening_poem": "Pixelnacht, Melodie des Abenteuers",
+        "cta_subscribe": "Abonniere für neue Abenteuer!",
+        "tagline": "Chiptune-Abenteuer für dich!",
+        "hashtags": "#chiptune #8bit #BGM"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

`tests/fixtures/sample_channel/config/localizations.json` は `examples/localizations.example.json` への symlink になっており、配布サンプルとテストフィクスチャの進化が強制同期されていた。この symlink を解除し、解除時点の内容そのままの独立した実体 JSON にする。

## 変更内容

- symlink を解除し、解除時点の symlink 先（`examples/localizations.example.json`）の内容をそのままコピーした実体ファイルに置き換え
- 中身・テスト期待値は変更なし
- `examples/localizations.example.json` 本体は変更なし（別 issue の責務）

## 検証

- `ls -l` で symlink 記号（`->`）が消え、通常ファイルになったことを確認
- `config/` 配下に他の symlink が残っていないことを確認
- `uv run pytest tests/test_metadata_generator.py` 全 20 件 pass

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)