### PR TITLE
feat(skills-sync): skills 配布時に .agents/skills symlink を併設 (#617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `feat(scripts)`: 公開済み動画の `status.containsSyntheticMedia` を遡及的に `True` へ一括是正する `yt-bulk-update-synthetic-media` を追加した（#606、#603 の遡及対応）。#603 是正前にアップロードされた公開動画は `False` のまま残るため、チャンネルの uploads playlist から全公開動画を列挙し、`videos().list(part="status")` で現状 `True` でないものを抽出して `videos().update(part="status")` で反映する。`videos.update(part="status")` は status リソース全体を置換するため、現 status をコピーして read-only キー（`uploadStatus` / `madeForKids` 等）を除去し `containsSyntheticMedia` だけ差し替える read-modify-write で `privacyStatus` / `publishAt` / `selfDeclaredMadeForKids` 等を保持する。デフォルト dry-run（read のみ）、`--apply` で実反映、`--include-private` で private も対象化。冪等（再実行で対象 0 件なら遡及完了）。手動 fallback 手順は `docs/investigations/2026-05-30-606-bulk-update-synthetic-media.md`
+- `feat(skills-sync)`: `yt-skills sync`（`skills` asset）を標準レイアウト（`.claude/skills`）へ展開すると、下流チャンネルリポジトリにも `.agents/skills -> ../.claude/skills` の相対 symlink を併設するようにした（#617）。upstream リポと同じ Codex CLI 探索パス規約（`$REPO_ROOT/.agents/skills`）を下流でも成立させ、これまで `.claude/skills` だけが配布され下流の Codex が同期済みスキルを発見できなかった問題を解消する。既存の正しい symlink は冪等にスキップ、張り直しは `--force`、`--dry-run` では作成予定のみ表示、symlink 非対応環境では警告のみで sync 全体は継続する。`--target` で非標準パスを指定した場合は `.agents` 規約が成立しないため対象外（`_ops.py::_ensure_agents_skills_symlink`）
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ config/channel/         # 責務別分割設定（v2.0.0 以降）
 config/localizations.json
 auth/{client_secrets,token}.json
 .claude/skills/         # yt-skills sync で展開
+.agents/skills          # → ../.claude/skills の symlink。skills sync が併設（Codex 探索パス）
 collections/            # コンテンツ成果物
 assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下に画像 + .meta.json
 ```
@@ -119,6 +120,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 - `.claude/skills/` は `[tool.hatch.build.targets.wheel.force-include]` で wheel 内 `_skills/` に同梱され、`yt-skills sync` が `importlib.resources` で参照する
 - `.claude/CLAUDE.template.md` も同様に `[tool.hatch.build.targets.wheel.force-include]` で wheel 内 `_claude_md/CLAUDE.template.md` に同梱され、`yt-skills sync --asset claude-md` で `.claude/CLAUDE.md` として展開される
 - 配布アセットの追加は `src/youtube_automation/cli/skills_sync.py::_ASSET_SPECS` に entry を追加するだけで `list/sync/diff` が自動的にサポートされる（`kind="dir" | "file"` を選ぶ）
+- `skills` asset を標準レイアウト（`.claude/skills`）へ sync すると、下流リポにも `.agents/skills -> ../.claude/skills` の相対 symlink を併設する（Codex CLI 探索パス規約）。既存の正しい symlink は冪等にスキップし、張り直しは `--force`、symlink 非対応環境では警告のみで sync は継続する（`_ops.py::_ensure_agents_skills_symlink`）
 - バージョン bump は `pyproject.toml::version` のみを更新する（`src/youtube_automation/__init__.py::__version__` は `importlib.metadata` 経由で動的に読み込むため触らない）。リリース運用全体は `/automation-release` スキルで一気通貫に実行する
 
 ## セキュリティ

--- a/src/youtube_automation/cli/skills_sync/_ops.py
+++ b/src/youtube_automation/cli/skills_sync/_ops.py
@@ -3,6 +3,7 @@
 `pathlib` / `shutil` / `filecmp` のラッパー責務に閉じる。
 - `_ensure_target_parent`: 親ディレクトリの作成
 - `_copy_entry` / `_symlink_entry`: 単一 entry の配置
+- `_ensure_agents_skills_symlink`: Codex 探索パス `.agents/skills` の symlink を張る
 - `_prune_orphans`: 同梱外 entry の列挙・削除
 - `_has_diff`: `filecmp.dircmp` の再帰的差分検出
 """
@@ -12,6 +13,11 @@ from __future__ import annotations
 import filecmp
 import shutil
 from pathlib import Path
+
+# Codex CLI が探索する `.agents/skills` から `.claude/skills` への相対リンク先。
+# upstream リポの `.agents/skills -> ../.claude/skills` と同じ相対表現を用いる
+# ことで、リポジトリをどこに clone しても壊れないリンクにする。
+_AGENTS_SKILLS_LINK_TARGET = Path("..") / ".claude" / "skills"
 
 
 def _ensure_target_parent(target: Path) -> None:
@@ -53,6 +59,50 @@ def _symlink_entry(src: Path, dst: Path, force: bool, dry_run: bool) -> str:
         return "linked"
     dst.parent.mkdir(parents=True, exist_ok=True)
     dst.symlink_to(src.resolve())
+    return "linked"
+
+
+def _ensure_agents_skills_symlink(target_dir: Path, *, force: bool, dry_run: bool) -> str | None:
+    """skills を同期した downstream リポに `.agents/skills -> ../.claude/skills` を張る。
+
+    Codex CLI は `$REPO_ROOT/.agents/skills` をスキル探索パスとする規約のため、
+    `.claude/skills` を配布しただけでは Codex が同期済みスキルを発見できない。
+    標準レイアウト (`<repo>/.claude/skills`) で sync したときに限り、Codex 用の
+    `.agents/skills` symlink を併設する。
+
+    戻り値:
+        'linked'      : symlink を作成した (dry-run 時は作成予定)
+        'skipped'     : 既存があり --force なしのため触らなかった
+        'unsupported' : symlink 非対応環境で作成できなかった (警告のみ、sync は継続)
+        None          : 標準レイアウトでない target のため対象外 (`.agents` 規約が成立しない)
+    """
+    # `.agents` 規約は `<repo>/.claude/skills` レイアウト前提。--target で別パスを
+    # 指定した場合は repo root を推定できないため、副作用を出さず対象外として返す。
+    if not (target_dir.name == "skills" and target_dir.parent.name == ".claude"):
+        return None
+
+    link = target_dir.parent.parent / ".agents" / "skills"
+
+    if link.exists() or link.is_symlink():
+        # 既存 (正しい symlink 含む) は冪等にスキップ。張り直しは --force のみ。
+        if not force:
+            return "skipped"
+        if not dry_run:
+            if link.is_symlink() or link.is_file():
+                link.unlink()
+            else:
+                shutil.rmtree(link)
+
+    if dry_run:
+        return "linked"
+
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(_AGENTS_SKILLS_LINK_TARGET)
+    except OSError:
+        # Windows の非特権ユーザー等、symlink を張れない環境では sync 全体を
+        # 失敗させず警告に留める (呼び出し側が stderr に出す)。
+        return "unsupported"
     return "linked"
 
 

--- a/src/youtube_automation/cli/skills_sync/_sync.py
+++ b/src/youtube_automation/cli/skills_sync/_sync.py
@@ -14,6 +14,7 @@ from youtube_automation.cli.skills_sync import (
 )
 from youtube_automation.cli.skills_sync._ops import (
     _copy_entry,
+    _ensure_agents_skills_symlink,
     _ensure_target_parent,
     _prune_orphans,
     _symlink_entry,
@@ -140,6 +141,20 @@ def _sync_dir_asset(
         prune_counts = _prune_orphans(target_dir, bundled, do_delete=do_delete)
         for key, val in prune_counts.items():
             counts[key] = counts.get(key, 0) + val
+
+    # skills 配布時は Codex CLI の探索パス `.agents/skills` も併設する。
+    # 標準レイアウト (`.claude/skills`) でないときは対象外 (None) でスキップ。
+    if args.asset == "skills":
+        mirror = _ensure_agents_skills_symlink(target_dir, force=args.force, dry_run=args.dry_run)
+        prefix = "[dry-run] " if args.dry_run else ""
+        if mirror == "unsupported":
+            print(
+                "  [warn] .agents/skills の symlink を作成できませんでした (symlink 非対応環境)",
+                file=sys.stderr,
+            )
+        elif mirror is not None:
+            print(f"  {prefix}{mirror:>8}: .agents/skills -> ../.claude/skills")
+            counts[mirror] = counts.get(mirror, 0) + 1
 
     print()
     print(f"完了: {sum(counts.values())} 件処理 — {counts}")

--- a/tests/test_skills_sync.py
+++ b/tests/test_skills_sync.py
@@ -254,6 +254,176 @@ def test_cmd_sync_only_filters_entries(fake_repo: Path, tmp_path: Path) -> None:
     assert not (target / "channel-direction").exists()
 
 
+# ---------- .agents/skills symlink (Codex 探索パス) ----------
+
+
+def test_cmd_sync_skills_creates_agents_symlink(fake_repo: Path, tmp_path: Path) -> None:
+    # Given: 標準レイアウトの target
+    target = tmp_path / "out" / ".claude" / "skills"
+
+    # When: skills を sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: .claude の隣に .agents/skills が ../.claude/skills を指す symlink として作られる
+    assert rc == 0
+    link = tmp_path / "out" / ".agents" / "skills"
+    assert link.is_symlink()
+    assert os.readlink(link) == str(Path("..") / ".claude" / "skills")
+    # 相対リンクが実体の skills ディレクトリに解決する
+    assert (link / "channel-research" / "SKILL.md").read_text(encoding="utf-8") == "# research\n"
+
+
+def test_cmd_sync_skills_agents_symlink_in_summary_and_stdout(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "linked: .agents/skills -> ../.claude/skills" in out
+    assert "'linked': 1" in out
+
+
+def test_cmd_sync_skills_agents_symlink_is_idempotent(
+    fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+
+    # 1 回目: linked
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    assert args.func(args) == 0
+    capsys.readouterr()
+
+    link = tmp_path / "out" / ".agents" / "skills"
+    before = os.readlink(link)
+
+    # 2 回目 (--force なし): 既存の正しい symlink は skipped で触らない
+    args2 = parser.parse_args(["sync", "--asset", "skills", "--target", str(target)])
+    assert args2.func(args2) == 0
+    out = capsys.readouterr().out
+
+    assert link.is_symlink()
+    assert os.readlink(link) == before
+    assert "skipped: .agents/skills -> ../.claude/skills" in out
+
+
+def test_cmd_sync_skills_agents_symlink_dry_run_does_not_write(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--dry-run"])
+    rc = args.func(args)
+
+    assert rc == 0
+    assert not (tmp_path / "out" / ".agents").exists()
+
+
+def test_cmd_sync_skills_force_relinks_wrong_agents_symlink(fake_repo: Path, tmp_path: Path) -> None:
+    # Given: 既存の .agents/skills が誤った場所を指している
+    agents_dir = tmp_path / "out" / ".agents"
+    agents_dir.mkdir(parents=True)
+    wrong = agents_dir / "skills"
+    wrong.symlink_to(tmp_path / "somewhere-else")
+    assert os.readlink(wrong) == str(tmp_path / "somewhere-else")
+
+    # When: --force 付きで sync
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: 正しい相対リンクに張り直される
+    assert rc == 0
+    assert os.readlink(wrong) == str(Path("..") / ".claude" / "skills")
+
+
+def test_cmd_sync_skills_keeps_wrong_agents_symlink_without_force(fake_repo: Path, tmp_path: Path) -> None:
+    # Given: 既存の誤 symlink (--force なし)
+    agents_dir = tmp_path / "out" / ".agents"
+    agents_dir.mkdir(parents=True)
+    wrong = agents_dir / "skills"
+    wrong.symlink_to(tmp_path / "somewhere-else")
+
+    # When: --force なしで sync
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target)])
+    rc = args.func(args)
+
+    # Then: 既存は冪等に温存される (上書きには --force が必要)
+    assert rc == 0
+    assert os.readlink(wrong) == str(tmp_path / "somewhere-else")
+
+
+def test_cmd_sync_skills_non_standard_target_skips_agents(fake_repo: Path, tmp_path: Path) -> None:
+    # Given: `.claude/skills` レイアウトでない target
+    target = tmp_path / "custom" / "skills"
+
+    # When: skills を sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: .agents 規約が成立しないので symlink は作られない
+    assert rc == 0
+    assert (target / "channel-research").exists()
+    assert not (tmp_path / "custom" / ".agents").exists()
+    assert not (tmp_path / ".agents").exists()
+
+
+def test_ensure_agents_skills_symlink_unsupported_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given: symlink 非対応環境を模す (symlink_to が OSError)
+    from youtube_automation.cli.skills_sync import _ops
+
+    def raise_oserror(self: Path, *a: object, **k: object) -> None:
+        raise OSError("symlink not supported")
+
+    monkeypatch.setattr(Path, "symlink_to", raise_oserror)
+
+    target = tmp_path / "out" / ".claude" / "skills"
+    target.mkdir(parents=True)
+
+    # When/Then: 例外を握りつぶし 'unsupported' を返す (sync 全体は失敗させない)
+    result = _ops._ensure_agents_skills_symlink(target, force=False, dry_run=False)
+    assert result == "unsupported"
+
+
+def test_ensure_agents_skills_symlink_unsupported_warns_but_sync_succeeds(
+    fake_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Given: symlink 非対応環境
+    def raise_oserror(self: Path, *a: object, **k: object) -> None:
+        raise OSError("symlink not supported")
+
+    monkeypatch.setattr(Path, "symlink_to", raise_oserror)
+
+    target = tmp_path / "out" / ".claude" / "skills"
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+
+    # When: sync (symlink だけ失敗)
+    rc = args.func(args)
+
+    # Then: skills 本体は配布され、rc は 0、stderr に警告
+    assert rc == 0
+    assert (target / "channel-research" / "SKILL.md").exists()
+    err = capsys.readouterr().err
+    assert ".agents/skills" in err
+
+
+def test_ensure_agents_skills_symlink_returns_none_for_non_standard_layout(tmp_path: Path) -> None:
+    from youtube_automation.cli.skills_sync import _ops
+
+    target = tmp_path / "custom" / "skills"
+    target.mkdir(parents=True)
+    assert _ops._ensure_agents_skills_symlink(target, force=False, dry_run=False) is None
+
+
 # ---------- cmd_diff ----------
 
 


### PR DESCRIPTION
## 概要
`yt-skills sync`（`skills` asset）を標準レイアウト（`.claude/skills`）へ展開する際、下流チャンネルリポジトリにも `.agents/skills -> ../.claude/skills` の相対 symlink を併設するようにした。これにより upstream と同じ Codex CLI 探索パス規約（`$REPO_ROOT/.agents/skills`）が下流でも成立し、これまで `.claude/skills` だけが配布され下流の Codex が同期済みスキルを発見できなかった問題（#617）を解消する。

Closes #617

## 実装方針（案 A）
`skills` dir asset の sync 完了後に `.agents/skills` symlink を ensure する副作用を追加。symlink を動的生成するため `pyproject.toml`（force-include / exclude）の変更は不要。

## 挙動
- 既存の正しい symlink → **冪等にスキップ**（`skipped`）
- 張り直しは `--force` のみ
- `--dry-run` → 作成予定（`linked`）を表示するだけで書き込まない
- symlink 非対応環境（Windows 非特権等）→ `OSError` を握りつぶし `unsupported` を返し、**警告のみで sync 全体は継続**
- `--target` で非標準パス（`.claude/skills` 以外）を指定 → `.agents` 規約が成立しないため**対象外**（`None`、副作用なし）

## 変更
- `_ops.py::_ensure_agents_skills_symlink` を追加
- `_sync.py::_sync_dir_asset` の skills 配布時に呼び出し、summary に `linked` を計上
- `tests/test_skills_sync.py` に 10 件のテストを追加（作成 / 冪等 / dry-run / force 張り直し / 非標準レイアウトスキップ / symlink 非対応 warn）
- `CLAUDE.md`（下流構造図 + パッケージング節）/ `CHANGELOG.md`（Unreleased / Added）を更新

## テスト
- `tests/test_skills_sync*.py` 計 136 件 + フルスイート 2408 件 pass
- 実 CLI スモークテスト: `.agents/skills` 生成・相対リンク解決・2 回目 skipped・dry-run 非作成 を確認

## スコープ外（issue 準拠）
- `.agents/` 配下の skills 以外のサブディレクトリ配布
- upstream 側 `.agents` 構成変更
- Codex CLI 自体の設定変更
- 他 asset（`claude-md` / `workflow-cheatsheet` / `features`）の配布仕様変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)