### PR TITLE
feat(comment-reply): video status preflight で削除済み/private を dry-run 段階で事前 skip (#576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(comment-reply)`: `yt-comments-reply` にメインループ先頭で動く video status preflight を追加した（#576）。`commentThreads.list` の前に対象 video の `status` を `videos.list`（50 件単位で chunk 化）で一括取得し、API 応答に存在しない（削除済み）video は `plan.skipped` に `reason="video_not_found"`、`privacyStatus="private"` の video は `reason="video_private"` で積んで除外する。これまで apply 段階でしか出なかった 404 / 403 を dry-run プレビューで事前可視化し、無駄な `comments.insert` の quota 消費を避ける。unlisted はオーナーがコメント可能なため通過、quota 節約のため history に返信実績がある video は status check 対象外。dry-run / apply 共通で動作（`utils/comments/replier.py::fetch_video_status` / `_preflight_video_status`、`ReplyHistory.replied_video_ids`）
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/utils/comments/history.py
+++ b/src/youtube_automation/utils/comments/history.py
@@ -45,6 +45,20 @@ class ReplyHistory:
     def has_replied(self, comment_id: str) -> bool:
         return comment_id in self._data["replied"]
 
+    def replied_video_ids(self) -> set[str]:
+        """履歴に記録済みコメントの video_id 集合を返す（preflight の quota 節約用）.
+
+        過去に返信実績がある video は既に到達可能だったとみなし、status preflight の
+        対象から除外する。metadata に video_id を持たない古いレコードは無視する。
+        """
+        ids: set[str] = set()
+        for metadata in self._data["replied"].values():
+            if isinstance(metadata, dict):
+                video_id = metadata.get("video_id")
+                if video_id:
+                    ids.add(video_id)
+        return ids
+
     def mark_replied(self, comment_id: str, metadata: dict[str, Any]) -> None:
         self._data["replied"][comment_id] = metadata
 

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -34,6 +34,38 @@ _HELD_FOR_REVIEW = "heldForReview"
 _COMMENTS_DISABLED_API_REASON = "commentsDisabled"
 _COMMENTS_DISABLED_SKIP_REASON = "comments_disabled"
 
+# videos.list の id 上限（1 リクエストあたり 50 件）
+_VIDEOS_LIST_CHUNK = 50
+_PRIVACY_STATUS_PRIVATE = "private"
+_SKIP_VIDEO_NOT_FOUND = "video_not_found"
+_SKIP_VIDEO_PRIVATE = "video_private"
+
+
+def fetch_video_status(youtube, video_ids: list[str]) -> dict[str, dict | None]:
+    """video_ids の status を videos.list で一括取得する（50 件単位で chunk 化）.
+
+    Args:
+        youtube: `youtube_service.get_youtube()` / `ServiceRegistry.youtube`
+        video_ids: status を確認したい動画 ID のリスト
+
+    Returns:
+        `{video_id: status_dict | None}`。API 応答に存在しない（削除済み等）video は
+        `None`。status_dict は videos.list の `status` part（`privacyStatus` 等）。
+
+    Raises:
+        YouTubeAPIError: HttpError を status_code 付きでラップ（取得失敗は握りつぶさない）
+    """
+    result: dict[str, dict | None] = {vid: None for vid in video_ids}
+    for start in range(0, len(video_ids), _VIDEOS_LIST_CHUNK):
+        chunk = video_ids[start : start + _VIDEOS_LIST_CHUNK]
+        try:
+            resp = youtube.videos().list(part="status", id=",".join(chunk)).execute()
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(e, f"videos.list (status) 失敗 (count={len(chunk)})") from e
+        for item in resp.get("items", []):
+            result[item["id"]] = item.get("status", {})
+    return result
+
 
 @dataclass
 class ReplyPlan:
@@ -170,18 +202,49 @@ class CommentReplier:
         if video_ids is not None:
             # 明示指定時: uploads playlist 解決は不要だが owner_channel_id は別途解決する
             self._resolve_owner_channel_id()
-            video_source: Iterator[str] = iter(video_ids)
+            target_video_ids = list(video_ids)
         else:
             owner_id, uploads_playlist_id = self._fetch_channel_info()
             self._owner_channel_id = self._owner_channel_id or owner_id
-            video_source = self._iter_uploaded_video_ids(uploads_playlist_id)
+            target_video_ids = list(self._iter_uploaded_video_ids(uploads_playlist_id))
 
-        for vid in video_source:
+        # preflight: 削除済み / private video を dry-run / apply 共通で事前 skip する
+        target_video_ids = self._preflight_video_status(target_video_ids, plan)
+
+        for vid in target_video_ids:
             if len(plan.planned) >= limit:
                 break
             self._process_video_comments(vid, engine, plan, dry_run, per_video_limit, since, limit)
 
         return plan
+
+    def _preflight_video_status(self, video_ids: list[str], plan: ReplyPlan) -> list[str]:
+        """video status を一括取得し、削除済み / private を plan.skipped に積んで除外する.
+
+        quota 節約のため、history に返信実績がある video は status check を省く
+        （過去に到達できた video は引き続き存在するとみなす）。
+
+        Returns:
+            preflight を通過した（コメント処理を続行すべき）video_id のリスト。
+        """
+        replied_videos = self._history.replied_video_ids()
+        to_check = [vid for vid in video_ids if vid not in replied_videos]
+        statuses = fetch_video_status(self._youtube, to_check) if to_check else {}
+
+        allowed: list[str] = []
+        for vid in video_ids:
+            if vid in replied_videos:
+                allowed.append(vid)
+                continue
+            status = statuses.get(vid)
+            if status is None:
+                plan.skipped.append(self._video_skip_record(vid, _SKIP_VIDEO_NOT_FOUND))
+                continue
+            if status.get("privacyStatus") == _PRIVACY_STATUS_PRIVATE:
+                plan.skipped.append(self._video_skip_record(vid, _SKIP_VIDEO_PRIVATE))
+                continue
+            allowed.append(vid)
+        return allowed
 
     def _process_video_comments(
         self,

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -740,6 +740,175 @@ def test_rule_provider_override_gemini_requires_explicit_gemini_generator_config
         CommentReplier(yt, config=config, channel_dir=tmp_path, default_language="ja")
 
 
+def _mock_youtube_with_status(
+    *,
+    video_ids: list[str],
+    privacy_by_video: dict[str, str | None],
+    comments_by_video: dict[str, list[dict]] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """videos().list を status preflight 用に side_effect 化した mock を返す.
+
+    privacy_by_video の値が None の video は API 応答に含めない（削除済み扱い）。
+    その他は privacyStatus として返す。`part="snippet"`（title 取得）は従来通り返す。
+    """
+    yt = _mock_youtube(
+        video_ids=video_ids,
+        comments_by_video=comments_by_video or {},
+    )
+
+    status_list_mock = MagicMock()
+
+    def _videos_list(**kwargs):
+        part = kwargs.get("part")
+        if part == "status":
+            requested = kwargs.get("id", "").split(",") if kwargs.get("id") else []
+            items = [
+                {"id": vid, "status": {"privacyStatus": privacy_by_video.get(vid)}}
+                for vid in requested
+                if privacy_by_video.get(vid) is not None
+            ]
+            result = MagicMock()
+            result.execute.return_value = {"items": items}
+            status_list_mock(**kwargs)
+            return result
+        # part="snippet"（title 取得）— video_ids 全件の title を返す
+        result = MagicMock()
+        result.execute.return_value = {
+            "items": [{"id": vid, "snippet": {"title": f"Title of {vid}"}} for vid in video_ids],
+        }
+        return result
+
+    yt.videos.return_value.list.side_effect = _videos_list
+    return yt, status_list_mock
+
+
+def test_preflight_skips_deleted_video(tmp_path):
+    """削除済み video（API 応答に存在しない）は dry-run で video_not_found スキップ."""
+    yt, _ = _mock_youtube_with_status(
+        video_ids=["gone", "alive"],
+        privacy_by_video={"gone": None, "alive": "public"},
+        comments_by_video={"alive": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    plan = replier.run(dry_run=True)
+
+    assert any(
+        row["video_id"] == "gone" and row["comment_id"] is None and row["reason"] == "video_not_found"
+        for row in plan.skipped
+    )
+    # 通過した動画はコメント処理される
+    assert [row["video_id"] for row in plan.planned] == ["alive"]
+
+
+def test_preflight_skips_private_video(tmp_path):
+    """private video は dry-run で video_private スキップ."""
+    yt, _ = _mock_youtube_with_status(
+        video_ids=["secret", "alive"],
+        privacy_by_video={"secret": "private", "alive": "public"},
+        comments_by_video={"alive": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    plan = replier.run(dry_run=True)
+
+    assert any(row["video_id"] == "secret" and row["reason"] == "video_private" for row in plan.skipped)
+    assert [row["video_id"] for row in plan.planned] == ["alive"]
+
+
+def test_preflight_passes_unlisted_video(tmp_path):
+    """unlisted video はオーナーがコメント可能なため通過させる."""
+    yt, _ = _mock_youtube_with_status(
+        video_ids=["hidden"],
+        privacy_by_video={"hidden": "unlisted"},
+        comments_by_video={"hidden": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    plan = replier.run(dry_run=True)
+
+    assert not any(row["reason"] in ("video_not_found", "video_private") for row in plan.skipped)
+    assert [row["video_id"] for row in plan.planned] == ["hidden"]
+
+
+def test_preflight_applies_in_apply_mode(tmp_path):
+    """apply モードでも preflight が動き、private への insert を未然に防ぐ."""
+    yt, _ = _mock_youtube_with_status(
+        video_ids=["secret"],
+        privacy_by_video={"secret": "private"},
+        comments_by_video={"secret": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    plan = replier.run(dry_run=False)
+
+    assert any(row["reason"] == "video_private" for row in plan.skipped)
+    assert plan.replied == []
+    yt._insert_mock.execute.assert_not_called()
+
+
+def test_preflight_skips_status_check_for_history_recorded_video(tmp_path):
+    """history に返信実績がある video は status check 対象外（quota 節約）."""
+    existing = ReplyHistory(tmp_path / "comment_reply_history.json")
+    existing.mark_replied("old", {"video_id": "known"})
+    existing.save()
+
+    yt, status_list_mock = _mock_youtube_with_status(
+        video_ids=["known", "fresh"],
+        privacy_by_video={"known": "public", "fresh": "public"},
+        comments_by_video={
+            "known": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}],
+            "fresh": [{"comment_id": "c2", "text": "こんにちは！", "author": "B"}],
+        },
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    replier.run(dry_run=True)
+
+    # status preflight は履歴未記録の "fresh" のみを問い合わせる
+    assert status_list_mock.call_count == 1
+    requested_ids = status_list_mock.call_args.kwargs["id"].split(",")
+    assert requested_ids == ["fresh"]
+
+
+def test_preflight_chunks_video_ids_in_50s(tmp_path):
+    """videos.list は 50 件単位で chunk 化して呼ばれる."""
+    video_ids = [f"v{i}" for i in range(120)]
+    yt, status_list_mock = _mock_youtube_with_status(
+        video_ids=video_ids,
+        privacy_by_video={vid: "public" for vid in video_ids},
+        comments_by_video={},
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    replier.run(dry_run=True)
+
+    # 120 件 → 50 + 50 + 20 の 3 チャンク
+    assert status_list_mock.call_count == 3
+    chunk_sizes = [len(call.kwargs["id"].split(",")) for call in status_list_mock.call_args_list]
+    assert chunk_sizes == [50, 50, 20]
+
+
+def test_fetch_video_status_returns_none_for_missing_video(tmp_path):
+    """fetch_video_status は API 応答に無い video を None で返す."""
+    from youtube_automation.utils.comments.replier import fetch_video_status
+
+    yt = MagicMock()
+    yt.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "exists", "status": {"privacyStatus": "public"}}],
+    }
+    result = fetch_video_status(yt, ["exists", "missing"])
+
+    assert result["exists"] == {"privacyStatus": "public"}
+    assert result["missing"] is None
+
+
+def test_fetch_video_status_wraps_http_error(tmp_path):
+    """status 取得失敗は YouTubeAPIError に変換され、握りつぶされない."""
+    from youtube_automation.utils.comments.replier import fetch_video_status
+
+    err = _make_http_error(403, "Forbidden", "quotaExceeded")
+    yt = MagicMock()
+    yt.videos.return_value.list.return_value.execute.side_effect = err
+
+    with pytest.raises(YouTubeAPIError):
+        fetch_video_status(yt, ["v1"])
+
+
 def test_legacy_rule_generator_key_rejected_by_loader():
     """旧 rules[].generator は ConfigError で停止する."""
     from youtube_automation.utils.config.loader import _build_comments


### PR DESCRIPTION
## 概要

`yt-comments-reply` のメインループ先頭に **video status preflight** を追加し、削除済み video / private video へのコメント返信を apply 段階の 404/403 ではなく **dry-run 段階で事前 skip** できるようにする（issue #576）。

これまで `comment_reply` は history JSON での二重返信防止のみで、対象 video の存在 / 公開状態を事前確認していなかった。このため削除済み video には apply 段階で 404、private video には 403 が返り、dry-run プレビューでは検出できなかった。

## 実装

- `utils/comments/replier.py`
  - `fetch_video_status(youtube, video_ids) -> dict[str, dict | None]` を追加。`videos.list(part="status")` を **50 件単位で chunk 化**して一括取得。API 応答に存在しない video は `None`。HttpError は `YouTubeAPIError.from_http_error` でラップし握りつぶさない。
  - `CommentReplier._preflight_video_status()` をメインループ先頭に組み込み。
    - 存在しない video → `plan.skipped` に `reason="video_not_found"`
    - `privacyStatus == "private"` → `reason="video_private"`
    - **unlisted は通過**（オーナーはコメント投稿可能）
    - **quota 節約**: history に返信実績がある video は status check 対象外
  - dry-run / apply 共通で動作。
- `utils/comments/history.py`
  - `ReplyHistory.replied_video_ids()` を追加（preflight の quota 節約判定用）。
- 既存の history JSON 二重返信防止ロジックは**無変更**。

## テスト

`tests/test_comments_replier.py` に追加（API は mock 化）:

- 削除済み video → `video_not_found` で dry-run skip
- private video → `video_private` で dry-run skip
- unlisted は通過
- apply モードでも preflight が動き insert を未然に防ぐ
- history 記録済み video は status check 対象外（quota 節約）
- 50 件 chunk 化（120 件 → 50/50/20 の 3 リクエスト）
- `fetch_video_status` の None 返却 / HttpError ラップ

`uv run pytest` 全 2444 件 green、`uv run ruff check` / `ruff format` クリーン。

## 受け入れ基準

- [x] `yt-comments-reply --dry-run` で削除済み video が `video_not_found` 表示
- [x] private video が `video_private` 表示
- [x] 既存の history JSON 二重返信防止ロジックは無変更
- [x] 既存 unit test がパス
- [x] CHANGELOG に preflight 追加を記載

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)