### PR TITLE
refactor: AI 開示 / 子供向け申告フラグを config 外出し (#605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `refactor(video-upload)`: 動画アップロード時の AI 開示フラグ `status.containsSyntheticMedia` と子供向け申告 `status.selfDeclaredMadeForKids` を `youtube_auto_uploader.py` のハードコードから config 解決へ外出しした（#605、audit R-5）。`config/channel/youtube.json` の `youtube.contains_synthetic_media` / `youtube.self_declared_made_for_kids` で上書きでき、`YoutubeApi` dataclass の任意フィールド（デフォルト `True` / `False`）として `channel_settings.build_upload_status_flags()` 経由で解決する。未設定時は現行の振る舞い（`containsSyntheticMedia: True` / `selfDeclaredMadeForKids: False`）を維持するため挙動は不変。YouTube 側ポリシー変更や下流チャンネルごとの開示要否差異への追従が容易になる
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/examples/channel_config.example/youtube.json
+++ b/examples/channel_config.example/youtube.json
@@ -2,7 +2,9 @@
   "youtube": {
     "category_id": "10",
     "privacy_status": "public",
-    "language": "ja"
+    "language": "ja",
+    "contains_synthetic_media": true,
+    "self_declared_made_for_kids": false
   },
   "content_model": {
     "type": "collection",

--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -24,6 +24,7 @@ from googleapiclient.errors import HttpError
 logger = logging.getLogger(__name__)
 
 
+from youtube_automation.utils.channel_settings import build_upload_status_flags  # noqa: E402
 from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.metadata_generator import BAHMetadataGenerator  # noqa: E402
@@ -106,12 +107,14 @@ class YouTubeAutoUploader(YouTubeUploadCore):
             raise ValueError(f"タイトルが100文字を超えています（{len(title)}文字）: {title}")
 
         # リクエストボディ作成
+        # AI 開示（containsSyntheticMedia）/ 子供向け申告（selfDeclaredMadeForKids）は
+        # config/channel/youtube.json で上書き可能。未設定時は現行の振る舞い
+        # （synthetic=True / made_for_kids=False）を維持する (#605)。
+        # AI 生成音楽（Lyria / Suno）を主軸とするチャンネルは YouTube の AI 開示
+        # （altered or synthetic content）ポリシー上 true を申告する (#603)。
         status_body = {
             "privacyStatus": metadata.get("privacy_status", "private"),
-            "selfDeclaredMadeForKids": False,
-            # AI 生成音楽（Lyria / Suno）を主軸とするため、YouTube の AI 開示
-            # （altered or synthetic content）ポリシー上 true を申告する (#603)
-            "containsSyntheticMedia": True,
+            **build_upload_status_flags(load_config().youtube.api),
         }
 
         # スケジュール公開: publishAt 指定時は private 必須

--- a/src/youtube_automation/utils/channel_settings.py
+++ b/src/youtube_automation/utils/channel_settings.py
@@ -46,6 +46,25 @@ _FIELD_MAP: dict[str, str] = {
 }
 
 
+def build_upload_status_flags(youtube_api: Any) -> dict[str, bool]:
+    """動画アップロード時の `status` 用 AI 開示・子供向け申告フラグを解決する。
+
+    `config.youtube.api` の `contains_synthetic_media` / `self_declared_made_for_kids`
+    を YouTube `videos.insert` の `status` キーへマッピングする。未設定時のデフォルトは
+    dataclass 側で現行の振る舞い（synthetic=True / made_for_kids=False）に固定されている。
+
+    Args:
+        youtube_api: `config.youtube.api`（`YoutubeApi` dataclass）
+
+    Returns:
+        `{"selfDeclaredMadeForKids": bool, "containsSyntheticMedia": bool}`
+    """
+    return {
+        "selfDeclaredMadeForKids": bool(youtube_api.self_declared_made_for_kids),
+        "containsSyntheticMedia": bool(youtube_api.contains_synthetic_media),
+    }
+
+
 def _keywords_to_api(keywords: list[str]) -> str:
     """['bgm', 'lo fi beats'] → 'bgm "lo fi beats"' (YouTube 仕様のスペース区切り)。"""
     return " ".join(shlex.quote(k) if " " in k else k for k in keywords)

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -252,6 +252,8 @@ def _build_youtube(merged: dict) -> YoutubeSection:
         category_id=yt["category_id"],
         privacy_status=yt["privacy_status"],
         language=yt["language"],
+        contains_synthetic_media=bool(yt.get("contains_synthetic_media", True)),
+        self_declared_made_for_kids=bool(yt.get("self_declared_made_for_kids", False)),
     )
 
     cm_data = merged.get("content_model") or {}

--- a/src/youtube_automation/utils/config/youtube.py
+++ b/src/youtube_automation/utils/config/youtube.py
@@ -7,11 +7,19 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class YoutubeApi:
-    """`youtube` セクション（API 基本設定）."""
+    """`youtube` セクション（API 基本設定）.
+
+    `contains_synthetic_media`: アップロード時に申告する AI 開示フラグ
+        (`status.containsSyntheticMedia`)。未設定時は現行の振る舞いに合わせ `True`。
+    `self_declared_made_for_kids`: 子供向け申告 (`status.selfDeclaredMadeForKids`)。
+        未設定時は現行の振る舞いに合わせ `False`。
+    """
 
     category_id: str
     privacy_status: str
     language: str
+    contains_synthetic_media: bool = True
+    self_declared_made_for_kids: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_channel_settings.py
+++ b/tests/test_channel_settings.py
@@ -12,11 +12,44 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from youtube_automation.scripts import channel_settings_cli
 from youtube_automation.utils.channel_settings import (
     build_update_body,
+    build_upload_status_flags,
     diff_settings,
     fetch_channel,
     parse_api_response,
 )
+from youtube_automation.utils.config.youtube import YoutubeApi
 from youtube_automation.utils.exceptions import YouTubeAPIError
+
+# ---------------------------------------------------------------------------
+# build_upload_status_flags (#605)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUploadStatusFlags:
+    def test_defaults_preserve_current_behavior(self):
+        """未設定時のデフォルトは現行の振る舞い（synthetic=True / made_for_kids=False）。"""
+        api = YoutubeApi(category_id="10", privacy_status="public", language="ja")
+        flags = build_upload_status_flags(api)
+        assert flags == {
+            "selfDeclaredMadeForKids": False,
+            "containsSyntheticMedia": True,
+        }
+
+    def test_config_override(self):
+        """config で上書きした値が status フラグへ反映される。"""
+        api = YoutubeApi(
+            category_id="10",
+            privacy_status="public",
+            language="ja",
+            contains_synthetic_media=False,
+            self_declared_made_for_kids=True,
+        )
+        flags = build_upload_status_flags(api)
+        assert flags == {
+            "selfDeclaredMadeForKids": True,
+            "containsSyntheticMedia": False,
+        }
+
 
 # ---------------------------------------------------------------------------
 # build_update_body

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -129,6 +129,31 @@ def test_load_minimal_sections(tmp_path, monkeypatch):
     assert config.pinned_comment.default_language == "en"
 
 
+def test_synthetic_media_flags_default(tmp_path, monkeypatch):
+    """#605: youtube.json 未設定時は現行の振る舞い（synthetic=True / made_for_kids=False）。"""
+    ch = _setup_channel(tmp_path, _minimal_sections())
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+
+    assert config.youtube.api.contains_synthetic_media is True
+    assert config.youtube.api.self_declared_made_for_kids is False
+
+
+def test_synthetic_media_flags_override(tmp_path, monkeypatch):
+    """#605: youtube.json で AI 開示 / 子供向け申告を上書きできる。"""
+    sections = _minimal_sections()
+    sections["youtube.json"]["youtube"]["contains_synthetic_media"] = False
+    sections["youtube.json"]["youtube"]["self_declared_made_for_kids"] = True
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+
+    assert config.youtube.api.contains_synthetic_media is False
+    assert config.youtube.api.self_declared_made_for_kids is True
+
+
 def test_load_pinned_comment_section(tmp_path, monkeypatch):
     sections = _minimal_sections()
     sections["pinned-comment.json"] = {

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -216,6 +216,62 @@ class TestUploadVideoForwarding:
         body = mock_core_upload.call_args.args[1]
         assert body["status"]["containsSyntheticMedia"] is True
 
+    def test_should_default_self_declared_made_for_kids_false(self, tmp_path):
+        """#605: config 未設定時は selfDeclaredMadeForKids=False の現行挙動を維持する."""
+        # Given
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path / "collections"))
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"\x00")
+
+        with patch(
+            "youtube_automation.agents.youtube_auto_uploader.YouTubeUploadCore.upload_video",
+            return_value="VID_KIDS",
+        ) as mock_core_upload:
+            # When
+            uploader.upload_video(str(video), _make_metadata())
+
+        # Then
+        body = mock_core_upload.call_args.args[1]
+        assert body["status"]["selfDeclaredMadeForKids"] is False
+
+    def test_should_resolve_synthetic_media_flags_from_config(self, tmp_path):
+        """#605: status フラグを config（youtube.api）から解決する."""
+        # Given
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path / "collections"))
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"\x00")
+
+        fake_config = SimpleNamespace(
+            youtube=SimpleNamespace(
+                api=SimpleNamespace(
+                    contains_synthetic_media=False,
+                    self_declared_made_for_kids=True,
+                )
+            )
+        )
+
+        with (
+            patch(
+                "youtube_automation.agents.youtube_auto_uploader.load_config",
+                return_value=fake_config,
+            ),
+            patch(
+                "youtube_automation.agents.youtube_auto_uploader.YouTubeUploadCore.upload_video",
+                return_value="VID_CONFIG",
+            ) as mock_core_upload,
+        ):
+            # When
+            uploader.upload_video(str(video), _make_metadata())
+
+        # Then: config の値が status へ反映される
+        body = mock_core_upload.call_args.args[1]
+        assert body["status"]["containsSyntheticMedia"] is False
+        assert body["status"]["selfDeclaredMadeForKids"] is True
+
     def test_should_default_resume_kwargs_to_none_when_omitted(self, tmp_path):
         """resume kwargs を渡さなければコアにも None 相当が渡る（後方互換）."""
         # Given


### PR DESCRIPTION
## 概要

YouTube アップロード時の AI 開示フラグ `containsSyntheticMedia` と子供向け申告 `selfDeclaredMadeForKids` を `youtube_auto_uploader.py` のハードコードから **config 解決へ外出し**する構造改善（audit R-5）。`made_for_kids` 同様に `config/channel/*.json` のキーとして持てるようにし、`channel_settings.py` 経由で解決する。

#603 / PR #604 で `containsSyntheticMedia` の値自体は `True` に是正済み。本 PR はその値を config から解決できるようにする構造改善で、**振る舞いは現状維持**。

## 変更内容

- **`utils/config/youtube.py`**: `YoutubeApi` dataclass に任意フィールド `contains_synthetic_media`（デフォルト `True`）/ `self_declared_made_for_kids`（デフォルト `False`）を追加
- **`utils/config/loader.py`**: `_build_youtube` で `youtube.json` の `youtube.contains_synthetic_media` / `youtube.self_declared_made_for_kids` を組み立て（任意キー。`_REQUIRED_KEYS_BY_SECTION` には登録しない）
- **`utils/channel_settings.py`**: status フラグ解決ヘルパー `build_upload_status_flags(youtube_api)` を追加（`status.selfDeclaredMadeForKids` / `status.containsSyntheticMedia` へマッピングする純粋関数）
- **`agents/youtube_auto_uploader.py`**: `status_body` 構築をハードコードから `build_upload_status_flags(load_config().youtube.api)` 経由の config 解決へ置き換え
- **`examples/channel_config.example/youtube.json`**: サンプルに 2 キーを追加
- **テスト**: 未設定時に現行の振る舞い（`containsSyntheticMedia: True` / `selfDeclaredMadeForKids: False`）が維持される回帰テストと、config 上書きが反映されるテストを `test_channel_settings.py` / `test_config_loader.py` / `test_youtube_auto_uploader.py` に追加
- **`CHANGELOG.md`**: `[Unreleased]` に 1 行追記

## あるべき状態の達成

- [x] `config/channel/youtube.json` に `contains_synthetic_media` / `self_declared_made_for_kids` を持てる
- [x] `channel_settings.py` 経由で解決し `status_body` 構築時に参照する
- [x] 未設定時のデフォルトは現行の振る舞いを維持
- [x] 既存 `made_for_kids` の config 化パターンを踏襲

## テスト

- `uv run pytest` → 2435 passed
- `uv run ruff check` / `uv run ruff format` → クリーン

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)
