### PR TITLE
fix: ベンチマーク未取得時に空データで黙って完走する fallback を是正 (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `fix(benchmark)`: ベンチマーク未取得・空・取得失敗時に空データ/デフォルト値（`[]` / `{}` / `avg_views=0`）のまま黙って完走する fallback を是正した（#619）。`load_benchmark_videos()` は JSON 未検出 / フィルタ後 0 件で `ConfigError`、`collect_channel()` はチャンネル欠落で `YouTubeAPIError`・API 失敗（`HttpError`）を `YouTubeAPIError.from_http_error` でドメイン例外化、`collect_all()` は欠落チャンネルを `if data:` で暗黙スキップせず明示検知して `YouTubeAPIError`、`ensure_benchmark_fresh()` は取得失敗・`benchmark.channels` 未設定で黙って `return` せずドメイン例外で通知する。いずれも原因と次アクション（`/benchmark` 再実行・設定確認）をメッセージに含め、下流（サムネ比較・分析）が無効データに基づいて成功扱いされる経路を塞ぐ
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -28,6 +28,8 @@ from collections import Counter
 from datetime import date, datetime
 from pathlib import Path
 
+from googleapiclient.errors import HttpError  # noqa: E402
+
 from youtube_automation.utils.benchmark_analyzer import (  # noqa: E402
     compute_daily_views,
     compute_engagement_rate,
@@ -37,7 +39,7 @@ from youtube_automation.utils.benchmark_analyzer import (  # noqa: E402
 )
 from youtube_automation.utils.config import channel_dir as _channel_dir  # noqa: E402
 from youtube_automation.utils.config import load_config
-from youtube_automation.utils.exceptions import ConfigError  # noqa: E402
+from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError  # noqa: E402
 from youtube_automation.utils.profile import section
 from youtube_automation.utils.skill_config import load_skill_config  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
@@ -115,14 +117,17 @@ class BenchmarkCollector:
         for i in range(0, len(channel_ids), _CHANNELS_BATCH_SIZE):
             batch = channel_ids[i : i + _CHANNELS_BATCH_SIZE]
             with section("benchmark.channels_list", batch_size=len(batch)):
-                resp = (
-                    self.youtube.channels()
-                    .list(
-                        part="snippet,statistics,contentDetails",
-                        id=",".join(batch),
+                try:
+                    resp = (
+                        self.youtube.channels()
+                        .list(
+                            part="snippet,statistics,contentDetails",
+                            id=",".join(batch),
+                        )
+                        .execute()
                     )
-                    .execute()
-                )
+                except HttpError as e:
+                    raise YouTubeAPIError.from_http_error(e, f"benchmark.channels_list (id={','.join(batch)})") from e
             for item in resp.get("items", []):
                 items_by_id[item["id"]] = item
         return items_by_id
@@ -137,15 +142,21 @@ class BenchmarkCollector:
 
         Returns:
             チャンネルデータ辞書（概要 + 動画リスト + 派生指標）。
-            `ch_item` が空のときは空辞書を返す
+
+        Raises:
+            YouTubeAPIError: `ch_item` が空（チャンネルが API レスポンスに存在しない）のとき。
+                空辞書で握りつぶさず、欠落を呼び出し側へ伝播させる
         """
         channel_id = channel_info["id"]
         scan_recent = self.benchmark_config.get("scan_recent", 50)
         min_views = self.benchmark_config.get("min_views", 10000)
 
         if not ch_item:
-            logger.error("チャンネルが見つかりません: %s", channel_id)
-            return {}
+            raise YouTubeAPIError(
+                f"ベンチマーク対象チャンネルが見つかりません: {channel_info.get('name', channel_id)} "
+                f"(id={channel_id})。削除・非公開・ID 誤りの可能性があります。"
+                "config/channel/analytics.json の benchmark.channels の id を確認してください。"
+            )
 
         uploads_playlist_id = ch_item["contentDetails"]["relatedPlaylists"]["uploads"]
 
@@ -166,16 +177,21 @@ class BenchmarkCollector:
         remaining = scan_recent
         while remaining > 0:
             with section("benchmark.playlist_items", page_size=min(50, remaining)):
-                playlist_resp = (
-                    self.youtube.playlistItems()
-                    .list(
-                        part="contentDetails",
-                        playlistId=uploads_playlist_id,
-                        maxResults=min(50, remaining),
-                        pageToken=page_token,
+                try:
+                    playlist_resp = (
+                        self.youtube.playlistItems()
+                        .list(
+                            part="contentDetails",
+                            playlistId=uploads_playlist_id,
+                            maxResults=min(50, remaining),
+                            pageToken=page_token,
+                        )
+                        .execute()
                     )
-                    .execute()
-                )
+                except HttpError as e:
+                    raise YouTubeAPIError.from_http_error(
+                        e, f"benchmark.playlist_items ({channel_info.get('name', channel_id)})"
+                    ) from e
             batch_ids = [item["contentDetails"]["videoId"] for item in playlist_resp.get("items", [])]
             video_ids.extend(batch_ids)
             page_token = playlist_resp.get("nextPageToken")
@@ -200,14 +216,19 @@ class BenchmarkCollector:
         for i in range(0, len(video_ids), 50):
             batch = video_ids[i : i + 50]
             with section("benchmark.videos_list", batch_size=len(batch)):
-                videos_resp = (
-                    self.youtube.videos()
-                    .list(
-                        part="snippet,statistics,contentDetails",
-                        id=",".join(batch),
+                try:
+                    videos_resp = (
+                        self.youtube.videos()
+                        .list(
+                            part="snippet,statistics,contentDetails",
+                            id=",".join(batch),
+                        )
+                        .execute()
                     )
-                    .execute()
-                )
+                except HttpError as e:
+                    raise YouTubeAPIError.from_http_error(
+                        e, f"benchmark.videos_list ({channel_info.get('name', channel_id)})"
+                    ) from e
 
             for video in videos_resp.get("items", []):
                 snippet = video["snippet"]
@@ -287,12 +308,18 @@ class BenchmarkCollector:
 
         Returns:
             全チャンネルの収集結果
+
+        Raises:
+            ConfigError: 指定 `channel_slug` が benchmark.channels に存在しないとき
+            YouTubeAPIError: 収集対象の一部が API レスポンスに存在しない（欠落）とき
         """
         if channel_slug:
             targets = [ch for ch in self.config.analytics.benchmark.channels if ch["slug"] == channel_slug]
             if not targets:
-                logger.error("チャンネルが見つかりません: %s", channel_slug)
-                return {"channels": [], "collected_at": self.today.isoformat()}
+                raise ConfigError(
+                    f"指定されたチャンネルが見つかりません: {channel_slug}。"
+                    "config/channel/analytics.json の benchmark.channels に slug を登録してください。"
+                )
         elif force:
             targets = list(self.config.analytics.benchmark.channels)
         else:
@@ -304,12 +331,21 @@ class BenchmarkCollector:
 
         ch_items = self._fetch_channels_metadata(targets)
 
+        # API レスポンスに含まれないチャンネル（削除・非公開・ID 誤り）を明示検知。
+        # 空辞書を黙ってスキップせず、欠落があれば収集失敗として停止する。
+        missing = [ch for ch in targets if ch["id"] not in ch_items]
+        if missing:
+            detail = ", ".join(f"{ch.get('name', ch['id'])} (id={ch['id']})" for ch in missing)
+            raise YouTubeAPIError(
+                f"ベンチマーク対象チャンネルが YouTube API レスポンスに見つかりません: {detail}。"
+                "削除・非公開・ID 誤りの可能性があります。"
+                "config/channel/analytics.json の benchmark.channels の id を確認してください。"
+            )
+
         results = []
         for ch in targets:
             logger.info("収集中: %s (%s)", ch["name"], ch["id"])
-            data = self.collect_channel(ch, ch_items.get(ch["id"], {}))
-            if data:
-                results.append(data)
+            results.append(self.collect_channel(ch, ch_items[ch["id"]]))
 
         return {
             "channels": results,
@@ -1092,10 +1128,18 @@ def load_benchmark_videos(data_dir: Path, min_views: int = 10000, require_thumbn
 
     Returns:
         動画情報リスト（再生数降順）
+
+    Raises:
+        ConfigError: ベンチマーク JSON が未取得、または抽出条件
+            （min_views / require_thumbnail）を満たす動画が 0 件のとき。
+            空リストを黙って返さず、下流の無効データ完走を防ぐ
     """
     benchmark_path = find_latest_benchmark_json(data_dir)
     if not benchmark_path:
-        return []
+        raise ConfigError(
+            f"ベンチマーク JSON が見つかりません ({data_dir})。"
+            "先に `/benchmark`（uv run yt-benchmark-collect）を実行して競合データを収集してください。"
+        )
 
     with open(benchmark_path) as f:
         data = json.load(f)
@@ -1128,6 +1172,14 @@ def load_benchmark_videos(data_dir: Path, min_views: int = 10000, require_thumbn
                 }
             )
 
+    if not targets:
+        thumb_note = "（かつサムネイル URL あり）" if require_thumbnail else ""
+        raise ConfigError(
+            f"ベンチマーク JSON に {min_views:,} 再生以上の動画{thumb_note}が 1 件もありません "
+            f"({benchmark_path.name})。min_views しきい値を見直すか、"
+            "`/benchmark`（uv run yt-benchmark-collect）で最新データを再収集してください。"
+        )
+
     targets.sort(key=lambda x: x["views"], reverse=True)
     return targets
 
@@ -1136,10 +1188,21 @@ def ensure_benchmark_fresh(data_dir: Path | None = None):
     """ベンチマークデータの鮮度を確認し、全チャンネルが1つの JSON に揃った状態を保証する。
 
     1つでも古い or 欠けているチャンネルがあれば --force で全チャンネル一括更新。
+
+    Raises:
+        ConfigError: benchmark.channels が未設定のとき
+        YouTubeAPIError: 最新化を試みたが 1 チャンネルも収集できなかったとき。
+            黙って return せず、最新化失敗を呼び出し側へ通知する
     """
     collector = BenchmarkCollector()
     if data_dir is None:
         data_dir = collector.data_dir
+
+    if not collector.config.analytics.benchmark.channels:
+        raise ConfigError(
+            "ベンチマーク対象チャンネルが未設定です。"
+            "config/channel/analytics.json の benchmark.channels を設定してください。"
+        )
 
     # 最新 JSON に全チャンネルが含まれているか検証
     need_update = False
@@ -1172,7 +1235,11 @@ def ensure_benchmark_fresh(data_dir: Path | None = None):
     data = collector.collect_all(force=True)
 
     if data.get("skipped") or not data.get("channels"):
-        return
+        raise YouTubeAPIError(
+            "ベンチマークの最新化に失敗しました（収集結果が空）。"
+            "API 認証・クォータ・benchmark.channels の設定を確認のうえ "
+            "`/benchmark`（uv run yt-benchmark-collect）を再実行してください。"
+        )
 
     if collector.benchmark_config.get("analyze_thumbnails", True):
         analyzer = BenchmarkThumbnailAnalyzer(collector.benchmarks_dir)
@@ -1266,7 +1333,11 @@ def main():
     collector.initialize()
 
     # 収集
-    data = collector.collect_all(force=args.force, channel_slug=args.channel)
+    try:
+        data = collector.collect_all(force=args.force, channel_slug=args.channel)
+    except (ConfigError, YouTubeAPIError) as e:
+        print(f"[ERROR] ベンチマーク収集に失敗しました: {e}")
+        sys.exit(1)
 
     if data.get("skipped"):
         print("すべてのベンチマークは最新です。--force で強制更新できます。")

--- a/tests/test_benchmark_collector_channels_batch.py
+++ b/tests/test_benchmark_collector_channels_batch.py
@@ -16,11 +16,14 @@ from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from youtube_automation.scripts.benchmark_collector import (
     _CHANNELS_BATCH_SIZE,
     BenchmarkCollector,
     BenchmarkReportGenerator,
 )
+from youtube_automation.utils.exceptions import YouTubeAPIError
 
 
 def _make_collector(youtube_mock: MagicMock, *, benchmark_channels: list[dict] | None = None) -> BenchmarkCollector:
@@ -160,16 +163,16 @@ class TestFetchChannelsMetadata:
 
 
 class TestCollectChannelWithPrefetchedItem:
-    def test_returns_empty_dict_when_ch_item_is_empty(self):
+    def test_raises_when_ch_item_is_empty(self):
         # Given: 上位で API レスポンスに含まれていなかったケースを模倣
         youtube = MagicMock()
         collector = _make_collector(youtube)
 
-        # When
-        result = collector.collect_channel({"id": "UC_X", "name": "x", "slug": "x"}, {})
+        # When / Then: 空辞書で握りつぶさず欠落を例外で伝播（issue #619）
+        with pytest.raises(YouTubeAPIError, match="UC_X"):
+            collector.collect_channel({"id": "UC_X", "name": "x", "slug": "x"}, {})
 
-        # Then: 空辞書 + channels.list を再呼び出ししない（プリフェッチ済みの契約）
-        assert result == {}
+        # channels.list は再呼び出ししない（プリフェッチ済みの契約）
         youtube.channels.return_value.list.assert_not_called()
 
     def test_does_not_call_channels_list_when_ch_item_provided(self):
@@ -251,7 +254,7 @@ class TestCollectAllPrefetchesChannels:
         assert len(data["channels"]) == 2
         assert {c["channel_id"] for c in data["channels"]} == {"UC_A", "UC_B"}
 
-    def test_collect_all_skips_channels_missing_from_api(self):
+    def test_collect_all_raises_when_channel_missing_from_api(self):
         # Given: 設定上は 2 件だが API は 1 件のみ返す（片方は削除済み等）
         channels_cfg = [
             {"id": "UC_OK", "name": "ok", "slug": "ok"},
@@ -267,11 +270,9 @@ class TestCollectAllPrefetchesChannels:
         }
         collector = _make_collector(youtube, benchmark_channels=channels_cfg)
 
-        # When
-        data = collector.collect_all(force=True)
-
-        # Then: 削除済みは結果に含まれず、生存分のみ返る
-        assert [c["channel_id"] for c in data["channels"]] == ["UC_OK"]
+        # When / Then: 欠落を黙ってスキップせず収集失敗として停止（issue #619）
+        with pytest.raises(YouTubeAPIError, match="UC_DEL"):
+            collector.collect_all(force=True)
 
 
 class TestBenchmarkReportGeneratorDescriptionSamples:

--- a/tests/test_benchmark_collector_no_fallback.py
+++ b/tests/test_benchmark_collector_no_fallback.py
@@ -1,0 +1,169 @@
+"""ベンチマーク未取得・空・取得失敗時の fallback 是正（issue #619）のユニットテスト
+
+検証対象（「実データが無いなら止まる／明示的に知らせる」原則）:
+- `load_benchmark_videos`: JSON 未検出 / フィルタ後 0 件 → `ConfigError`
+- `collect_channel`: チャンネル欠落 → `YouTubeAPIError` / API 失敗 → `YouTubeAPIError`
+- `collect_all`: 欠落チャンネルを黙殺せず `YouTubeAPIError` / 未登録 slug → `ConfigError`
+- `_fetch_channels_metadata`: HttpError → `YouTubeAPIError`
+- `ensure_benchmark_fresh`: benchmark.channels 未設定 → `ConfigError`
+
+ネットワークも YouTube API も呼ばない（MagicMock / HttpError で差し込み）。
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from youtube_automation.scripts.benchmark_collector import (
+    BenchmarkCollector,
+    load_benchmark_videos,
+)
+from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError
+
+
+def _http_error(status: int = 403, reason: str = "quotaExceeded") -> HttpError:
+    """`from_http_error` が解釈できる最小の HttpError を組み立てる。"""
+    resp = SimpleNamespace(status=status, reason="Forbidden")
+    content = json.dumps({"error": {"errors": [{"reason": reason}]}}).encode("utf-8")
+    return HttpError(resp, content)
+
+
+def _make_collector(youtube_mock: MagicMock, *, benchmark_channels: list[dict] | None = None) -> BenchmarkCollector:
+    collector = BenchmarkCollector()
+    collector.youtube = youtube_mock
+    if benchmark_channels is not None:
+        collector.config = SimpleNamespace(
+            analytics=SimpleNamespace(benchmark=SimpleNamespace(channels=benchmark_channels)),
+        )
+    return collector
+
+
+def _ch_item(channel_id: str, *, uploads: str = "UU_DUMMY") -> dict:
+    return {
+        "id": channel_id,
+        "snippet": {"title": channel_id},
+        "statistics": {"subscriberCount": "1000", "videoCount": "10"},
+        "contentDetails": {"relatedPlaylists": {"uploads": uploads}},
+    }
+
+
+def _write_benchmark_json(data_dir, channels: list[dict]) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    path = data_dir / "benchmark_20260531.json"
+    path.write_text(json.dumps({"channels": channels}), encoding="utf-8")
+
+
+class TestLoadBenchmarkVideos:
+    def test_raises_when_json_missing(self, tmp_path):
+        # Given: data_dir に benchmark JSON が存在しない
+        # When / Then: 空リストを返さず ConfigError で停止（次アクションを案内）
+        with pytest.raises(ConfigError, match="benchmark"):
+            load_benchmark_videos(tmp_path)
+
+    def test_raises_when_no_video_meets_threshold(self, tmp_path):
+        # Given: 動画はあるが min_views 未満ばかり
+        _write_benchmark_json(
+            tmp_path,
+            [{"name": "ch", "slug": "ch", "videos": [{"video_id": "v1", "views": 500}]}],
+        )
+
+        # When / Then: フィルタ後 0 件は空リストを返さず ConfigError
+        with pytest.raises(ConfigError, match="再生以上"):
+            load_benchmark_videos(tmp_path, min_views=10000)
+
+    def test_returns_videos_when_data_present(self, tmp_path):
+        # Given: しきい値以上の動画がある（正常系は従来どおりリストを返す）
+        _write_benchmark_json(
+            tmp_path,
+            [
+                {
+                    "name": "ch",
+                    "slug": "ch",
+                    "videos": [
+                        {"video_id": "v1", "views": 50000, "title": "A", "thumbnail_url": "u"},
+                        {"video_id": "v2", "views": 20000, "title": "B", "thumbnail_url": "u"},
+                    ],
+                }
+            ],
+        )
+
+        result = load_benchmark_videos(tmp_path, min_views=10000)
+
+        assert [v["video_id"] for v in result] == ["v1", "v2"]
+
+
+class TestCollectChannelFailures:
+    def test_raises_when_channel_missing(self):
+        # Given: API レスポンスに該当チャンネルが含まれなかった（空 ch_item）
+        collector = _make_collector(MagicMock())
+
+        # When / Then: 空辞書ではなく YouTubeAPIError
+        with pytest.raises(YouTubeAPIError, match="UC_MISS"):
+            collector.collect_channel({"id": "UC_MISS", "name": "miss", "slug": "miss"}, {})
+
+    def test_wraps_http_error_from_playlist_items(self):
+        # Given: playlistItems 取得で HttpError（クォータ超過等）
+        youtube = MagicMock()
+        youtube.playlistItems.return_value.list.return_value.execute.side_effect = _http_error()
+        collector = _make_collector(youtube)
+
+        # When / Then: 生 HttpError ではなくドメイン例外に変換して伝播
+        with pytest.raises(YouTubeAPIError) as exc:
+            collector.collect_channel({"id": "UC_OK", "name": "ok", "slug": "ok"}, _ch_item("UC_OK"))
+        assert exc.value.status_code == 403
+        assert exc.value.reason == "quotaExceeded"
+
+
+class TestCollectAllFailures:
+    def test_raises_config_error_when_slug_not_registered(self):
+        # Given: 指定 slug が benchmark.channels に存在しない
+        collector = _make_collector(
+            MagicMock(),
+            benchmark_channels=[{"id": "UC_A", "name": "A", "slug": "a"}],
+        )
+
+        # When / Then: 空辞書を返さず ConfigError
+        with pytest.raises(ConfigError, match="unknown"):
+            collector.collect_all(channel_slug="unknown")
+
+    def test_wraps_http_error_from_channels_list(self):
+        # Given: channels.list 自体が HttpError
+        youtube = MagicMock()
+        youtube.channels.return_value.list.return_value.execute.side_effect = _http_error(
+            status=429, reason="rateLimitExceeded"
+        )
+        collector = _make_collector(
+            youtube,
+            benchmark_channels=[{"id": "UC_A", "name": "A", "slug": "a"}],
+        )
+
+        # When / Then: _fetch_channels_metadata 経由でドメイン例外に変換
+        with pytest.raises(YouTubeAPIError) as exc:
+            collector.collect_all(force=True)
+        assert exc.value.status_code == 429
+
+
+class TestEnsureBenchmarkFresh:
+    def test_raises_when_no_channels_configured(self, monkeypatch):
+        # Given: benchmark.channels が空
+        from youtube_automation.scripts import benchmark_collector as mod
+
+        def _fake_init(self):
+            self.config = SimpleNamespace(analytics=SimpleNamespace(benchmark=SimpleNamespace(channels=[])))
+            self.youtube = None
+            self.benchmark_config = {}
+            self.channel_dir = SimpleNamespace()
+            self.benchmarks_dir = SimpleNamespace()
+            self.data_dir = SimpleNamespace()
+            self.today = SimpleNamespace()
+
+        monkeypatch.setattr(mod.BenchmarkCollector, "__init__", _fake_init)
+
+        # When / Then: 黙って return せず ConfigError
+        with pytest.raises(ConfigError, match="benchmark.channels"):
+            mod.ensure_benchmark_fresh(data_dir=SimpleNamespace())


### PR DESCRIPTION
## 概要

ベンチマークデータが未取得・空・取得失敗のとき、エラーで停止せず空データ/デフォルト値（`[]` / `{}` / `avg_views=0`）のまま処理が完走し、下流（サムネ比較・分析）が無効データに基づいて成功扱いされる問題を是正する。「実データが無いなら止まる／明示的に知らせる」を原則とし、ダミーで動く経路を塞ぐ。

## 変更内容

`src/youtube_automation/scripts/benchmark_collector.py`:

- **`load_benchmark_videos()`**: JSON 未検出 / フィルタ後 0 件で空リストを返さず `ConfigError`（次アクション: `/benchmark` 再実行・しきい値見直し）
- **`collect_channel()`**: チャンネル欠落（空 `ch_item`）で空辞書を返さず `YouTubeAPIError`。playlistItems / videos の `HttpError` を `YouTubeAPIError.from_http_error` でドメイン例外化
- **`collect_all()`**: 欠落チャンネルを `if data:` で暗黙スキップせず明示検知して `YouTubeAPIError`。未登録 slug 指定は `ConfigError`。`channels.list` の `HttpError` も `_fetch_channels_metadata` でドメイン例外化
- **`ensure_benchmark_fresh()`**: 取得失敗（収集結果が空）・`benchmark.channels` 未設定で黙って `return` せずドメイン例外で通知
- **`main()`**: 上記ドメイン例外を捕捉しクリーンなエラー終了（exit 1）

いずれも例外メッセージに原因と次アクションを含める。

## テスト

- `tests/test_benchmark_collector_no_fallback.py`（新規）: 未取得 / 空 / API 失敗 / チャンネル欠落 / 未設定の各ケースで例外が上がることを担保
- `tests/test_benchmark_collector_channels_batch.py`: 旧「空辞書を返す／黙ってスキップ」前提のテストを新挙動（例外）に更新
- `uv run pytest` 全 2437 件 green、`ruff check` / `ruff format` 通過

## スコープ外（別 issue）

- `strategic_analytics.py` の 0 補完黙殺の是正
- 下流スキル（`compare_thumbnails.py` 等）の呼び出し箇所ごとのガード追加

Closes #619