### PR TITLE
fix: title.template の未知プレースホルダで upload 全体が KeyError クラッシュする問題を修正 (#574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `fix(metadata-generator)`: `title.template` / `localizations.json::title_template` に metadata_generator が提供しない未知プレースホルダ（例 `{adjective}`）が含まれていても、Complete Collection アップロード全体が `KeyError` でクラッシュしないようにした（#574）。(1) `descriptions.md` の `## タイトル案` が最終タイトルを供給する経路では `generate_complete_collection_metadata(title_override=...)` で本来捨てられる中間タイトル生成（`_generate_title`）をスキップし完走させる。(2) 中間タイトル生成や localizations タイトル整形では新ヘルパー `format_title_template()` を経由し、未知プレースホルダを opaque な `KeyError` ではなく「不正プレースホルダ名 + 許可キー一覧」を含む actionable な `ValidationError` に変換して fail-loud する。`youtube_auto_uploader._upload_complete_collection()` は `descriptions.md` を先に読み込み `title_override` として渡す
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -442,11 +442,18 @@ class YouTubeAutoUploader(YouTubeUploadCore):
 
         master_video = video_files[0]
 
+        # descriptions.md が最終タイトル/概要/タグを供給するなら先に読み込み、
+        # 中間タイトル生成（_generate_title）を title_override でスキップする。
+        # これにより title.template が未知プレースホルダ（例 {adjective}）を含んでも
+        # 本来捨てられる中間タイトル生成で upload 全体がクラッシュしない（#574）。
+        prebuilt = self._load_descriptions_md(collection_dir)
+
         # メタデータ生成（BAHMetadataGenerator — localizations 等）
-        metadata = metadata_gen.generate_complete_collection_metadata()
+        metadata = metadata_gen.generate_complete_collection_metadata(
+            title_override=prebuilt["title"] if prebuilt else None
+        )
 
         # descriptions.md が存在すれば title/description/tags を上書き
-        prebuilt = self._load_descriptions_md(collection_dir)
         if prebuilt:
             metadata["title"] = prebuilt["title"]
             metadata["description"] = prebuilt["description"]

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -12,6 +12,7 @@ Features:
 import json
 import logging
 import re
+import string
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
@@ -20,6 +21,7 @@ from typing import Dict, List
 
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
+from youtube_automation.utils.exceptions import ValidationError
 
 from .audio_formats import AUDIO_EXTS
 from .skill_config import load_skill_config
@@ -38,6 +40,42 @@ def _extract_pattern_key(filename: str) -> str | None:
     if not m:
         return None
     return m.group(1).lower()
+
+
+def _referenced_placeholders(template: str) -> set[str]:
+    """format テンプレートが参照するフィールド名の集合を返す（`{a.b}` / `{a[0]}` は `a` に正規化）."""
+    referenced: set[str] = set()
+    for _literal, field_name, _spec, _conv in string.Formatter().parse(template):
+        if field_name:
+            referenced.add(field_name.split(".")[0].split("[")[0])
+    return referenced
+
+
+def format_title_template(template: str, values: Dict[str, str], *, context: str) -> str:
+    """title テンプレートを整形する。未知プレースホルダは actionable な ValidationError にする.
+
+    `str.format()` をそのまま呼ぶと、テンプレートが提供キー以外のプレースホルダ
+    （例: `{adjective}`）を含むときに opaque な `KeyError` を送出し、upload 全体が
+    深部でクラッシュする（#574）。本ヘルパーは事前に未知プレースホルダを検出し、
+    「使用不可プレースホルダ名 + 許可キー一覧」を含む `ValidationError` に変換する。
+
+    Args:
+        template: format 文字列
+        values: 許可キー → 値の dict（このキー集合のみ許容）
+        context: エラーメッセージに添える文脈（どのテンプレートか）
+
+    Raises:
+        ValidationError: テンプレートが `values` に無いプレースホルダを含むとき。
+    """
+    allowed = set(values)
+    unknown = _referenced_placeholders(template) - allowed
+    if unknown:
+        raise ValidationError(
+            f"{context}: 使用できないプレースホルダ {sorted(unknown)} が含まれています。\n"
+            f"→ 使用可能なキー: {sorted(allowed)}\n"
+            f"→ テンプレート: {template}"
+        )
+    return template.format(**values)
 
 
 @dataclass(frozen=True)
@@ -198,7 +236,11 @@ def validate_scene_phrases(
             raise ValueError(f"localizations.json: language '{lang}' に title_template が無い")
         activities = lang_data.get("activities", best_for_line)
         scene = scene_phrases[lang]
-        title = title_tpl.format(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji)
+        title = format_title_template(
+            title_tpl,
+            {"scene_phrase": scene, "activities": activities, "scene_emoji": scene_emoji},
+            context=f"localizations.json: language '{lang}' の title_template",
+        )
         if len(title) > 100:
             violations.append(
                 SceneTitleViolation(
@@ -624,15 +666,19 @@ class BAHMetadataGenerator:
         if ws_scene_emoji:
             scene_emoji = ws_scene_emoji
 
-        title = self.config.content.title.template.format(
-            style=self.config.content.genre.style.title(),
-            theme=theme,
-            activity=activity,
-            activities=activities,
-            scene_phrase=scene_phrase,
-            scene_emoji=scene_emoji,
-            duration_display=duration_display,
-            duration_short=duration_short,
+        title = format_title_template(
+            self.config.content.title.template,
+            {
+                "style": self.config.content.genre.style.title(),
+                "theme": theme,
+                "activity": activity,
+                "activities": activities,
+                "scene_phrase": scene_phrase,
+                "scene_emoji": scene_emoji,
+                "duration_display": duration_display,
+                "duration_short": duration_short,
+            },
+            context="content.json: title.template",
         )
         # YouTube タイトル制限: 100 codepoint。
         # 過去事例: silent な title[:100] スライスでサロゲート文字接頭辞 +
@@ -727,7 +773,11 @@ class BAHMetadataGenerator:
             scene = scene_phrases[lang]
             title_tpl = lang_data["title_template"]
             activities = lang_data.get("activities", best_for_line)
-            loc_title = title_tpl.format(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji)
+            loc_title = format_title_template(
+                title_tpl,
+                {"scene_phrase": scene, "activities": activities, "scene_emoji": scene_emoji},
+                context=f"localizations.json: language '{lang}' の title_template",
+            )
 
             # --- 概要欄（ハイブリッド方式）---
             opening_poem = desc_data.get("opening_poem", "")
@@ -774,9 +824,16 @@ class BAHMetadataGenerator:
 
         return localizations
 
-    def generate_complete_collection_metadata(self) -> Dict:
+    def generate_complete_collection_metadata(self, title_override: str | None = None) -> Dict:
         """
         Complete Collection 用メタデータ生成
+
+        Args:
+            title_override: 最終タイトルが既に確定している場合に渡す。`descriptions.md` の
+                `## タイトル案` が最終タイトルを供給する経路では、本来捨てられる中間タイトル
+                生成（`_generate_title` = `title.template.format(...)`）をスキップする。
+                これにより `title.template` が未知プレースホルダを含んでいても upload 全体が
+                `KeyError`/`ValidationError` で巻き込まれない（#574）。
 
         Returns:
             Dict: YouTube アップロード用メタデータ
@@ -787,8 +844,10 @@ class BAHMetadataGenerator:
         crossfade = self._crossfade_sec
         total_duration = sum(track["duration"] for track in self.tracks) - max(0, len(self.tracks) - 1) * crossfade
 
-        # タイトル生成（2026リブランド）
-        title = self._generate_title(total_duration)
+        # タイトル生成（2026リブランド）。
+        # title_override がある（descriptions.md で最終タイトルが確定する）場合は
+        # 中間タイトル生成をスキップし、未知プレースホルダ由来のクラッシュを避ける。
+        title = title_override if title_override else self._generate_title(total_duration)
 
         # 説明文生成
         description_parts = []

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -13,10 +13,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 from youtube_automation.utils.config import load_config
+from youtube_automation.utils.exceptions import ValidationError
 from youtube_automation.utils.metadata_generator import (
     BAHMetadataGenerator,
     SceneTitleViolation,
     format_scene_title_violations,
+    format_title_template,
     validate_scene_phrases,
 )
 from youtube_automation.utils.time_utils import format_duration_display
@@ -1014,3 +1016,120 @@ class TestLoadThemeDisplayNames:
         gen.collection_path = tmp_path
         (tmp_path / "workflow-state.json").write_text(_json.dumps({}), encoding="utf-8")
         assert gen._load_theme_display_names() == {}
+
+
+# ===========================================================================
+# 7. title.template / localizations title_template の未知プレースホルダ耐性 (#574)
+# ===========================================================================
+
+
+class TestTitleTemplateUnknownPlaceholder:
+    """#574: 未知プレースホルダで upload 全体が KeyError クラッシュしないことを担保する。
+
+    - `descriptions.md` が最終タイトルを供給する経路（title_override）では中間タイトル
+      生成をスキップして完走する。
+    - override が無い場合は opaque KeyError ではなく actionable な ValidationError
+      （未知プレースホルダ名 + 許可キー一覧）で fail-loud する。
+    - localizations.json::title_template も同じ挙動になる。
+    """
+
+    @pytest.fixture
+    def gen_with_tracks(self):
+        gen = _make_generator("20250907-live-8bit-adventure-music")
+        gen._load_scene_phrases = lambda: {
+            "ja": "8ビット冒険の世界",
+            "en": "World of 8-bit adventure",
+            "de": "Welt des 8-Bit-Abenteuers",
+        }
+        gen.tracks = [
+            {
+                "filename": "01-Hero.wav",
+                "title": "Hero Theme",
+                "duration": 180,
+                "start_time": 0,
+                "end_time": 180,
+                "timestamp": "00:00",
+            },
+            {
+                "filename": "02-Forest.wav",
+                "title": "Forest Path",
+                "duration": 210,
+                "start_time": 180,
+                "end_time": 390,
+                "timestamp": "03:00",
+            },
+            {
+                "filename": "03-Castle.wav",
+                "title": "Castle Gate",
+                "duration": 195,
+                "start_time": 390,
+                "end_time": 585,
+                "timestamp": "06:30",
+            },
+        ]
+        return gen
+
+    @staticmethod
+    def _set_title_template(gen, template: str) -> None:
+        # Title は frozen dataclass のため object.__setattr__ で bypass する
+        object.__setattr__(gen.config.content.title, "template", template)
+
+    # --- helper 単体 -------------------------------------------------------
+
+    def test_format_title_template_ok(self):
+        assert format_title_template("{theme} BGM", {"theme": "Forest"}, context="ctx") == "Forest BGM"
+
+    def test_format_title_template_rejects_unknown_placeholder(self):
+        with pytest.raises(ValidationError) as exc:
+            format_title_template(
+                "{adjective} {theme} BGM",
+                {"theme": "Forest", "duration_display": "3h"},
+                context="content.json: title.template",
+            )
+        msg = str(exc.value)
+        assert "adjective" in msg  # 不正プレースホルダ名
+        assert "theme" in msg  # 許可キー一覧
+        assert "title.template" in msg  # 文脈
+
+    def test_format_title_template_ignores_positional_braces_in_allowed(self):
+        # 提供済みキーのみなら通常通り整形される
+        out = format_title_template(
+            "{scene_phrase} | {activities}", {"scene_phrase": "Rainy", "activities": "Study"}, context="ctx"
+        )
+        assert out == "Rainy | Study"
+
+    # --- _generate_title 経路 ---------------------------------------------
+
+    def test_generate_title_raises_actionable_without_override(self, gen_with_tracks):
+        """未知プレースホルダ + descriptions.md 無し → actionable な ValidationError。"""
+        self._set_title_template(gen_with_tracks, "{adjective} {theme} | {duration_display}")
+        with pytest.raises(ValidationError) as exc:
+            gen_with_tracks.generate_complete_collection_metadata()
+        assert "adjective" in str(exc.value)
+
+    def test_title_override_skips_intermediate_title_generation(self, gen_with_tracks):
+        """未知プレースホルダを含む title.template でも override があれば完走し、最終タイトルが採用される。"""
+        self._set_title_template(gen_with_tracks, "{adjective} {theme} | {duration_display}")
+        meta = gen_with_tracks.generate_complete_collection_metadata(title_override="Curated Final Title")
+        assert meta["title"] == "Curated Final Title"
+        # 概要欄ヘッダーも override タイトルと一致する
+        assert "Curated Final Title" in meta["description"]
+
+    def test_valid_template_still_works(self, gen_with_tracks):
+        """正常系（整形可能なテンプレート）の振る舞いを壊さない。"""
+        meta = gen_with_tracks.generate_complete_collection_metadata()
+        assert len(meta["title"]) > 0
+
+    # --- localizations.json::title_template 経路 ---------------------------
+
+    def test_localizations_unknown_placeholder_raises_actionable(self):
+        config = load_config()
+        supported = config.localizations.supported_languages
+        lang = supported[0]
+        config.localizations.data["languages"][lang]["title_template"] = "{adjective} {scene_phrase}"
+        scene_phrases = {lng: "phrase" for lng in supported}
+        with pytest.raises(ValidationError) as exc:
+            validate_scene_phrases(scene_phrases, config)
+        msg = str(exc.value)
+        assert "adjective" in msg
+        assert lang in msg


### PR DESCRIPTION
## 概要

`yt-upload-collection`（Complete Collection アップロード）が、チャンネルの `content.json::title.template` または `localizations.json::title_template` に metadata_generator が提供しない未知プレースホルダ（例 `{adjective}`）を含むと `KeyError` でアップロード全体が停止する問題を修正する。

最終タイトルは `youtube_auto_uploader._load_descriptions_md()` が `descriptions.md` の `## タイトル案` から読み取って後段で `metadata["title"]` を上書きする設計なのに、`generate_complete_collection_metadata()` がその上書きより**前**に `_generate_title()`（= `title.template.format(...)`）を呼ぶため、本来捨てられる中間タイトルの生成で全体がクラッシュしていた。

## 変更内容

1. **中間タイトル生成のスキップ**: `generate_complete_collection_metadata(title_override=...)` を追加。`youtube_auto_uploader._upload_complete_collection()` は `descriptions.md` を先に読み込み、最終タイトルが供給される場合はそれを `title_override` として渡し、`_generate_title()` をスキップして完走させる。
2. **actionable なエラー化**: 中間タイトル生成（`_generate_title`）・localizations タイトル整形（`validate_scene_phrases` / `generate_localizations`）は新ヘルパー `format_title_template()` を経由。未知プレースホルダを opaque な `KeyError` ではなく「不正プレースホルダ名 + 許可キー一覧 + テンプレート」を含む `ValidationError`（ドメイン例外）に変換し、`descriptions.md` 無しの場合は fail-loud する。
3. localizations.json::title_template も同じ整形経路を通すため同様の堅牢化が効く。

## テスト

`tests/test_metadata_generator.py::TestTitleTemplateUnknownPlaceholder` を追加:

- 未知プレースホルダを含む `title.template` + `title_override`（descriptions.md 相当）→ upload が完走し最終タイトルが採用される
- 未知プレースホルダ + override 無し → `adjective` を含む actionable な `ValidationError`
- `localizations.json::title_template` の未知プレースホルダ → 同じく actionable な `ValidationError`
- 正常系（整形可能なテンプレート）の振る舞いを壊さないことも確認

`uv run pytest` 全 2436 件 green、`ruff check` / `ruff format` クリーン。

## 受け入れ基準

- [x] 未知プレースホルダを含む `title.template` でも `descriptions.md` があれば upload が完走する
- [x] `descriptions.md` が無い場合は actionable なエラー（プレースホルダ名 + 許可キー）で fail-loud する
- [x] `localizations.json::title_template` でも同じ挙動になる

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)