### PR TITLE
perf(scripts): yt-generate-image の attempt ループを並列化 (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `perf(scripts)`: `yt-generate-image` の attempt ループ（`--max-attempts N`）を `concurrent.futures.ThreadPoolExecutor` で並列化し、複数バリエーション生成の総実行時間を短縮した（#584）。出力パス（`-vN`）と参照画像のローテーション割り当てをループ前に全 attempt ぶん確定（`plan_output_paths` / `plan_reference_assignments`）して `resolve_unique_path` の直列依存を排除し、逐次実行と同一の採番・参照割り当てを保つ。失敗（`ConfigError`）は future の例外として回収して `sys.exit(1)` をループ外に集約（1 件でも失敗ならプロセスを落とす従来挙動を維持）。並列度は CLI `--max-workers`（未指定時はレート制限を考慮した控えめな固定値 3）で制御し、`--max-attempts 1`（単発）の挙動・出力は従来どおり。`cost_tracker.log_generation` は既存の `fcntl.flock` でスレッド間も直列化されるためコスト記録の取りこぼし・重複は起きない
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -13,6 +13,8 @@ Usage:
 """
 
 import argparse
+import concurrent.futures
+import re
 import sys
 import time
 from pathlib import Path
@@ -31,7 +33,6 @@ from youtube_automation.utils.image_provider.composition import (
     resolve_composition_source,
     resolve_cost_per_image,
     resolve_reference_paths,
-    resolve_unique_path,
     select_reference,
     validate_single_step_references,
 )
@@ -42,11 +43,139 @@ from youtube_automation.utils.profile import section
 _GEMINI_VALID_IMAGE_SIZES = ("1K", "2K", "4K")
 _GEMINI_DEFAULT_IMAGE_SIZE = "2K"
 
+# attempt ループ並列化のデフォルト並列度。Gemini / OpenAI のレート制限に
+# 抵触しないよう控えめに固定する（CLI --max-workers で上書き可能）。
+_DEFAULT_MAX_WORKERS = 3
+
+# resolve_unique_path と同じ -vN 採番規則を事前計画でも使うための正規表現。
+_VERSION_RE = re.compile(r"^(.+)-v(\d+)$")
+
 
 def _channel_root() -> Path:
     from youtube_automation.utils.config import channel_dir
 
     return channel_dir()
+
+
+def _next_planned_path(output_path: Path, taken: set[Path]) -> Path:
+    """``resolve_unique_path`` と同一の -vN 採番規則で次の一意パスを返す。
+
+    逐次実行では直前 attempt が生成したファイルが disk 上に存在することを根拠に
+    採番していたが、並列実行ではファイル生成前にパスを確定する必要がある。そこで
+    disk 上の存在に加えて ``taken``（既に計画済みのパス）も「使用済み」とみなす。
+    """
+    stem = output_path.stem
+    suffix = output_path.suffix
+    parent = output_path.parent
+    base_match = _VERSION_RE.match(stem)
+    if base_match:
+        base = base_match.group(1)
+        start = int(base_match.group(2)) + 1
+    else:
+        base = stem
+        start = 2
+    for n in range(start, start + 100):
+        candidate = parent / f"{base}-v{n}{suffix}"
+        if candidate not in taken and not candidate.exists():
+            return candidate
+    return parent / f"{base}-v{start + 100}{suffix}"
+
+
+def plan_output_paths(first_path: Path, count: int) -> list[Path]:
+    """逐次実行の ``resolve_unique_path`` チェーンと同一の出力パス列を事前確定する。
+
+    先頭は ``first_path``（呼び出し側で一意化済み）。2 件目以降は直前のパスを
+    起点に -vN を採番し、計画済みパスを ``taken`` に積むことで逐次時と同じ採番を
+    ファイル生成前に再現する。
+    """
+    if count < 1:
+        return []
+    paths = [first_path]
+    taken = {first_path}
+    current = first_path
+    for _ in range(count - 1):
+        nxt = _next_planned_path(current, taken)
+        paths.append(nxt)
+        taken.add(nxt)
+        current = nxt
+    return paths
+
+
+def plan_reference_assignments(reference_images: list[Path], count: int, rotate: bool) -> list[Path | None]:
+    """各 attempt に割り当てる参照画像を逐次時と同じ規則で確定する。
+
+    参照画像が無い場合は ``None`` を並べる。ある場合は ``select_reference`` で
+    attempt インデックスに応じたローテーション割り当てを再現する。
+    """
+    if not reference_images:
+        return [None] * count
+    return [select_reference(reference_images, attempt, rotate) for attempt in range(count)]
+
+
+def build_requests(
+    prompt: str,
+    planned_paths: list[Path],
+    reference_assignments: list[Path | None],
+    *,
+    aspect_ratio: str,
+    image_size: str,
+) -> list[ImageGenerationRequest]:
+    """確定済みの出力パス・参照割り当てから attempt 順の生成リクエストを組み立てる。"""
+    requests: list[ImageGenerationRequest] = []
+    for output_path, selected_ref in zip(planned_paths, reference_assignments):
+        request_refs = [selected_ref] if selected_ref is not None else []
+        requests.append(
+            ImageGenerationRequest(
+                prompt=prompt,
+                output_path=output_path,
+                aspect_ratio=aspect_ratio,
+                image_size=image_size,
+                references=request_refs,
+            )
+        )
+    return requests
+
+
+def run_requests_parallel(
+    provider,
+    requests: list[ImageGenerationRequest],
+    *,
+    max_workers: int,
+    aspect_ratio: str,
+) -> tuple[list, list[tuple[int, ConfigError]]]:
+    """リクエスト列を ThreadPoolExecutor で並列実行する（API は I/O バウンド）。
+
+    戻り値は ``(results, errors)``。``results`` は attempt 順に整列した結果
+    （失敗 attempt は ``None``）、``errors`` は ``(attempt_index, ConfigError)`` の
+    リスト。失敗は future の例外として回収し、ここでは ``sys.exit`` しない
+    （集約・終了判定は呼び出し側に委ねる）。
+    """
+    results: list = [None] * len(requests)
+    errors: list[tuple[int, ConfigError]] = []
+    if not requests:
+        return results, errors
+
+    effective_workers = max(1, min(max_workers, len(requests)))
+
+    def _run(request: ImageGenerationRequest):
+        with section(
+            "image_provider.generate",
+            provider=provider.__class__.__name__,
+            aspect_ratio=aspect_ratio,
+        ):
+            return provider.generate(request)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=effective_workers) as executor:
+        future_to_index = {executor.submit(_run, req): idx for idx, req in enumerate(requests)}
+        for future in concurrent.futures.as_completed(future_to_index):
+            idx = future_to_index[future]
+            try:
+                results[idx] = future.result()
+            except ConfigError as e:
+                errors.append((idx, e))
+
+    errors.sort(key=lambda item: item[0])
+    return results, errors
 
 
 def main():
@@ -100,6 +229,16 @@ def main():
         type=int,
         default=None,
         help="複数参照画像のうち特定のインデックスのみ使用（attempt ループ無効）",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help=(
+            "複数 attempt を並列生成するときの最大同時実行数。"
+            f"未指定時は {_DEFAULT_MAX_WORKERS}（レート制限を考慮した控えめな固定値）。"
+            "attempt 数より大きい値は attempt 数に丸められる"
+        ),
     )
     parser.add_argument(
         "--costs",
@@ -232,51 +371,55 @@ def main():
         reference_images = [reference_images[args.reference_index]]
         cli_max_attempts = 1
 
+    # 並列度: レート制限を考慮した控えめなデフォルト。1 attempt なら 1。
+    max_workers = args.max_workers if args.max_workers is not None else _DEFAULT_MAX_WORKERS
+    if max_workers < 1:
+        max_workers = 1
+
+    # 出力パス（-vN）と参照画像をループ前に全 attempt ぶん確定し、
+    # resolve_unique_path の直列依存を排除してから並列 submit する。
+    planned_paths = plan_output_paths(output_path, cli_max_attempts)
+    reference_assignments = plan_reference_assignments(reference_images, cli_max_attempts, rotate)
+
+    # attempt>0 のヘッダは並列実行前にまとめて表示し、stdout の交錯を避ける。
+    for attempt in range(1, cli_max_attempts):
+        selected_ref = reference_assignments[attempt]
+        print()
+        print(f"--- attempt {attempt + 1}/{cli_max_attempts} ---")
+        print(f"出力先:       {planned_paths[attempt]}")
+        if selected_ref is not None:
+            print(f"参照画像:     {selected_ref.name}")
+
+    requests = build_requests(
+        prompt,
+        planned_paths,
+        reference_assignments,
+        aspect_ratio=args.aspect_ratio,
+        image_size=image_size,
+    )
+
+    total_start = time.monotonic()
+    results, errors = run_requests_parallel(
+        provider,
+        requests,
+        max_workers=max_workers,
+        aspect_ratio=args.aspect_ratio,
+    )
+    elapsed = time.monotonic() - total_start
+
+    # ConfigError はループ外に集約して終了する（1 件でも失敗ならプロセスを落とす）。
+    if errors:
+        for attempt, error in errors:
+            prefix = f"attempt {attempt + 1}: " if cli_max_attempts > 1 else ""
+            print(f"[ERROR] {prefix}{error}")
+        sys.exit(1)
+
     saved_paths: list[Path] = []
     success_flags: list[bool] = []
-    total_start = time.monotonic()
-    current_output_path = output_path
-
-    for attempt in range(cli_max_attempts):
-        if reference_images:
-            selected_ref = select_reference(reference_images, attempt, rotate)
-            request_refs: list[Path] = [selected_ref]
-        else:
-            selected_ref = None
-            request_refs = []
-
-        if attempt > 0:
-            current_output_path = resolve_unique_path(current_output_path)
-            print()
-            print(f"--- attempt {attempt + 1}/{cli_max_attempts} ---")
-            print(f"出力先:       {current_output_path}")
-            if selected_ref is not None:
-                print(f"参照画像:     {selected_ref.name}")
-
-        request = ImageGenerationRequest(
-            prompt=prompt,
-            output_path=current_output_path,
-            aspect_ratio=args.aspect_ratio,
-            image_size=image_size,
-            references=request_refs,
-        )
-
-        try:
-            with section(
-                "image_provider.generate",
-                provider=provider.__class__.__name__,
-                aspect_ratio=args.aspect_ratio,
-            ):
-                result = provider.generate(request)
-        except ConfigError as e:
-            print(f"[ERROR] {e}")
-            sys.exit(1)
-
+    for attempt, result in enumerate(results):
         if result.success:
-            saved_paths.append(result.saved_path or current_output_path)
+            saved_paths.append(result.saved_path or planned_paths[attempt])
         success_flags.append(result.success)
-
-    elapsed = time.monotonic() - total_start
 
     print()
     print("===========================================")

--- a/tests/test_generate_image_parallel.py
+++ b/tests/test_generate_image_parallel.py
@@ -1,0 +1,215 @@
+"""``generate_image`` の attempt ループ並列化に関するテスト（Issue #584）。
+
+並列化の不変条件を担保する:
+
+- 生成枚数が変わらない（``--max-attempts N`` で N 件）
+- 出力ファイルの -vN 採番が逐次実行と一致する（``plan_output_paths``）
+- 参照画像のローテーション割り当てが逐次実行と一致する（``plan_reference_assignments``）
+- ``--max-attempts 1``（単発）の経路が従来どおり 1 件
+- 失敗（``ConfigError``）は future の例外として回収され、他結果を握りつぶさない
+
+API 呼び出しはフェイク provider で mock 化する。
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.scripts.generate_image import (
+    build_requests,
+    plan_output_paths,
+    plan_reference_assignments,
+    run_requests_parallel,
+)
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.composition import resolve_unique_path
+
+# ---- フェイク provider ------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, *, success: bool, saved_path: Path | None) -> None:
+        self.success = success
+        self.saved_path = saved_path
+
+
+class _FakeProvider:
+    """provider.generate を記録するフェイク。記録は lock 下で安全に追記する。"""
+
+    def __init__(self, *, fail_on: set[Path] | None = None) -> None:
+        self._fail_on = fail_on or set()
+        self._lock = threading.Lock()
+        self.calls: list[Path] = []
+
+    def generate(self, request):  # noqa: ANN001 - テスト用フェイク
+        with self._lock:
+            self.calls.append(request.output_path)
+        if request.output_path in self._fail_on:
+            raise ConfigError(f"forced failure: {request.output_path}")
+        return _FakeResult(success=True, saved_path=request.output_path)
+
+
+# ---- plan_output_paths -----------------------------------------------------
+
+
+class TestPlanOutputPaths:
+    def test_single_attempt_returns_first_only(self, tmp_path: Path) -> None:
+        first = tmp_path / "main.png"
+        assert plan_output_paths(first, 1) == [first]
+
+    def test_zero_count_returns_empty(self, tmp_path: Path) -> None:
+        assert plan_output_paths(tmp_path / "main.png", 0) == []
+
+    def test_three_attempts_clean_dir(self, tmp_path: Path) -> None:
+        first = tmp_path / "main.png"
+        assert plan_output_paths(first, 3) == [
+            first,
+            tmp_path / "main-v2.png",
+            tmp_path / "main-v3.png",
+        ]
+
+    def test_first_path_with_version_suffix(self, tmp_path: Path) -> None:
+        first = tmp_path / "main-v3.png"
+        assert plan_output_paths(first, 3) == [
+            first,
+            tmp_path / "main-v4.png",
+            tmp_path / "main-v5.png",
+        ]
+
+    def test_skips_preexisting_disk_files(self, tmp_path: Path) -> None:
+        first = tmp_path / "main.png"
+        # main-v2.png が既に disk 上に存在する場合はスキップする
+        (tmp_path / "main-v2.png").write_bytes(b"x")
+        assert plan_output_paths(first, 3) == [
+            first,
+            tmp_path / "main-v3.png",
+            tmp_path / "main-v4.png",
+        ]
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 5, 8])
+    def test_matches_serial_resolve_unique_path_chain(self, tmp_path: Path, count: int) -> None:
+        """逐次実行（resolve_unique_path を直列チェーン + ファイル生成）と完全一致する。"""
+        first = tmp_path / "main.png"
+
+        # 逐次実行の再現: 各 attempt で生成したファイルを disk に作り、
+        # 次の attempt は resolve_unique_path(current) で採番する。
+        serial: list[Path] = []
+        current = first
+        for attempt in range(count):
+            if attempt > 0:
+                current = resolve_unique_path(current)
+            current.write_bytes(b"x")  # provider.generate がファイルを生成した想定
+            serial.append(current)
+
+        # plan は disk を汚さない計画なので、別ディレクトリで実行して比較する
+        clean = tmp_path / "clean"
+        clean.mkdir()
+        planned = plan_output_paths(clean / "main.png", count)
+
+        assert [p.name for p in planned] == [p.name for p in serial]
+
+
+# ---- plan_reference_assignments --------------------------------------------
+
+
+class TestPlanReferenceAssignments:
+    def test_no_references_returns_none_list(self) -> None:
+        assert plan_reference_assignments([], 3, rotate=True) == [None, None, None]
+
+    def test_rotate_cycles(self) -> None:
+        refs = [Path("/a.jpg"), Path("/b.jpg")]
+        assert plan_reference_assignments(refs, 4, rotate=True) == [
+            Path("/a.jpg"),
+            Path("/b.jpg"),
+            Path("/a.jpg"),
+            Path("/b.jpg"),
+        ]
+
+    def test_no_rotate_pins_first(self) -> None:
+        refs = [Path("/a.jpg"), Path("/b.jpg")]
+        assert plan_reference_assignments(refs, 3, rotate=False) == [
+            Path("/a.jpg"),
+            Path("/a.jpg"),
+            Path("/a.jpg"),
+        ]
+
+
+# ---- build_requests --------------------------------------------------------
+
+
+class TestBuildRequests:
+    def test_count_and_paths_and_refs(self, tmp_path: Path) -> None:
+        paths = [tmp_path / "main.png", tmp_path / "main-v2.png"]
+        refs: list[Path | None] = [Path("/a.jpg"), Path("/b.jpg")]
+        requests = build_requests(
+            "prompt text",
+            paths,
+            refs,
+            aspect_ratio="16:9",
+            image_size="2K",
+        )
+        assert len(requests) == 2
+        assert [r.output_path for r in requests] == paths
+        assert requests[0].references == [Path("/a.jpg")]
+        assert requests[1].references == [Path("/b.jpg")]
+        assert all(r.prompt == "prompt text" for r in requests)
+
+    def test_none_reference_yields_empty_references(self, tmp_path: Path) -> None:
+        requests = build_requests(
+            "p",
+            [tmp_path / "main.png"],
+            [None],
+            aspect_ratio="16:9",
+            image_size="2K",
+        )
+        assert requests[0].references == []
+
+
+# ---- run_requests_parallel -------------------------------------------------
+
+
+class TestRunRequestsParallel:
+    def test_single_request_runs_once(self, tmp_path: Path) -> None:
+        provider = _FakeProvider()
+        requests = build_requests("p", [tmp_path / "main.png"], [None], aspect_ratio="16:9", image_size="2K")
+        results, errors = run_requests_parallel(provider, requests, max_workers=3, aspect_ratio="16:9")
+        assert errors == []
+        assert len(results) == 1
+        assert results[0].success is True
+        assert provider.calls == [tmp_path / "main.png"]
+
+    def test_all_requests_executed_results_ordered(self, tmp_path: Path) -> None:
+        paths = plan_output_paths(tmp_path / "main.png", 5)
+        provider = _FakeProvider()
+        requests = build_requests("p", paths, [None] * 5, aspect_ratio="16:9", image_size="2K")
+        results, errors = run_requests_parallel(provider, requests, max_workers=3, aspect_ratio="16:9")
+        assert errors == []
+        assert len(results) == 5
+        # results は attempt 順に整列し、各 result.saved_path が対応パスを指す
+        assert [r.saved_path for r in results] == paths
+        # 全リクエストが実行された（順不同なので集合で比較）
+        assert set(provider.calls) == set(paths)
+
+    def test_config_error_is_collected_not_swallowed(self, tmp_path: Path) -> None:
+        paths = plan_output_paths(tmp_path / "main.png", 3)
+        # 2 番目（index 1）の attempt だけ失敗させる
+        provider = _FakeProvider(fail_on={paths[1]})
+        requests = build_requests("p", paths, [None] * 3, aspect_ratio="16:9", image_size="2K")
+        results, errors = run_requests_parallel(provider, requests, max_workers=3, aspect_ratio="16:9")
+        # 失敗は (index, ConfigError) として回収される
+        assert len(errors) == 1
+        assert errors[0][0] == 1
+        assert isinstance(errors[0][1], ConfigError)
+        # 他の attempt の結果は握りつぶされず保持される
+        assert results[0] is not None and results[0].success
+        assert results[1] is None
+        assert results[2] is not None and results[2].success
+
+    def test_empty_requests(self) -> None:
+        provider = _FakeProvider()
+        results, errors = run_requests_parallel(provider, [], max_workers=3, aspect_ratio="16:9")
+        assert results == []
+        assert errors == []


### PR DESCRIPTION
## 概要

`yt-generate-image` の attempt ループ（`--max-attempts N`）を `concurrent.futures.ThreadPoolExecutor` で並列化し、Gemini / OpenAI への同期 API 呼び出し（1 枚あたり 10〜30 秒ブロック）の待機時間を重ね合わせて複数バリエーション生成の総実行時間を短縮する（issue #584）。

## 変更点

- **出力パス・参照割り当ての事前確定**: `-vN` 採番と参照画像ローテーションをループ前に全 attempt ぶん確定（`plan_output_paths` / `plan_reference_assignments`）し、`resolve_unique_path` の直列依存を排除。逐次実行と**同一の採番・参照割り当て**を保つ
- **エラー集約**: `ConfigError` は future の例外として回収し `sys.exit(1)` をループ外へ集約（1 件でも失敗ならプロセスを落とす従来挙動を維持。他結果は握りつぶさない）
- **並列度制御**: CLI `--max-workers` を追加（未指定時はレート制限を考慮した控えめな固定値 `3`）。attempt 数より大きい値は attempt 数に丸める
- **stdout 交錯対策**: attempt ヘッダは並列実行前にまとめて出力し、結果サマリは attempt 順に一括出力
- **単発の不変性**: `--max-attempts 1` の挙動・出力は従来どおり

## 不変条件の維持

- ✅ 生成枚数が変わらない
- ✅ 出力ファイル採番（`-vN`）が衝突せず逐次実行と一致（serial チェーンとの完全一致テストあり）
- ✅ 参照画像ローテーション（`select_reference`）の割り当てが従来と同等
- ✅ `cost_tracker.log_generation` は既存の `fcntl.flock` でスレッド間も直列化されるため、コスト記録の取りこぼし・重複は起きない（追加対応不要）

## スコープ

Python の attempt ループ並列化に限定。codex 経路（`codex-image.sh`）や `collection-ideate` SKILL.md の shell レベル並列化は本 PR の対象外（`.claude/skills/**` は不変更）。

## テスト

- `tests/test_generate_image_parallel.py` を追加: 枚数・採番（serial 完全一致 parametrize）・参照ローテーション・並列実行の結果整列・`ConfigError` 回収の各不変条件を検証（API はフェイク provider で mock 化）
- `uv run pytest`（全 2424 件）green、`uv run ruff check .` / `ruff format --check` クリーン

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)