### PR TITLE
feat(video-upload): アップロード preflight に公開タイトルの TTP 鋳型準拠チェックを追加 (#602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(video-upload)`: アップロード preflight に公開タイトルの TTP 鋳型準拠チェックを追加した（#602）。`preflight_checks.check_title_template_compliance()` が「鋳型逸脱（` | ` で LHS/RHS に分割でき RHS が `N Hours of ...` 系に一致）」「巻数表記（`Vol.` / `Vol N` / `Part N` / 末尾ローマ数字 / `#N`）」「既存 live タイトルとの RHS 完全重複」「核語彙欠落（任意）」を機械検出し、`youtube_auto_uploader._preflight_check` で違反時にアップロードを block する。soulful-grooves で発生した `Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves`（コレクション内部名の公開タイトル流用）を巻数表記 + RHS 重複で停止できる。鋳型語彙・パターン・セパレータは `content.json::title.template_check` から導出し、`title.template` に ` | ` を含まないチャンネルは自動スキップ（既定値はフォールバック、ハードコードなし）。既存 live タイトルは `collections/live/*/20-documentation/descriptions.md` の `## タイトル案` から収集する
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/agents/youtube_auto_uploader.py
+++ b/src/youtube_automation/agents/youtube_auto_uploader.py
@@ -35,6 +35,7 @@ from youtube_automation.utils.preflight_checks import (  # noqa: E402
     check_required_localization_languages,
     check_tags_count,
     check_tags_yt_chars,
+    check_title_template_compliance,
     extract_descriptions_md_tags,
 )
 from youtube_automation.utils.probe import probe_duration  # noqa: E402
@@ -255,6 +256,31 @@ class YouTubeAutoUploader(YouTubeUploadCore):
         m = re.search(pattern, text, re.DOTALL)
         return m.group(1).strip() if m else None
 
+    def _collect_live_titles(self, exclude_dir: Path | None = None) -> list[str]:
+        """既存 live コレクションの公開タイトル（`## タイトル案`）を収集する (#602).
+
+        収集元は `collections/live/*/20-documentation/descriptions.md`。RHS 重複検出の
+        比較対象に使う。live ディレクトリ不在・descriptions.md 不在・セクション欠落は
+        スキップする。`exclude_dir` で指定したコレクション自身は除外する。
+        """
+        titles: list[str] = []
+        live_root = self.collections_root / "live"
+        if not live_root.exists():
+            return titles
+        exclude_resolved = exclude_dir.resolve() if exclude_dir else None
+        for col in sorted(live_root.iterdir()):
+            if not col.is_dir() or col.name.startswith("."):
+                continue
+            if exclude_resolved and col.resolve() == exclude_resolved:
+                continue
+            desc_path = CollectionPaths(col).descriptions_md_path
+            if not desc_path.exists():
+                continue
+            title = self._extract_md_section(desc_path.read_text(encoding="utf-8"), "タイトル案")
+            if title:
+                titles.append(title.strip())
+        return titles
+
     def _preflight_check(self, collection_dir: Path) -> None:
         """アップロード前メタデータ品質チェック (fail-loud)。
 
@@ -265,7 +291,8 @@ class YouTubeAutoUploader(YouTubeUploadCore):
         3. タイムスタンプ件数が `audio.chapter_max` 以内かつ chapter 名に
            パターン展開接尾辞（v1〜v6 / ロマン数字 I〜VIII）を含まないこと
            （個別トラック = 1 chapter の per-track 命名はデフォルトで許容）
-        4. タイトルが 100 codepoint 以内（YouTube 制限）
+        4. タイトルが 100 codepoint 以内（YouTube 制限）、かつ TTP 鋳型に準拠
+           （巻数表記なし・RHS が鋳型一致・既存 live タイトルと RHS 非重複, #602）
         5. タグ件数が `tags.min_count` を満たすこと（戦略書違反防止）
         6. タグの quotation 込み文字数が YouTube の 500 制限内
         7. master 動画尺が `audio.target_duration_min/max` 範囲内
@@ -287,6 +314,20 @@ class YouTubeAutoUploader(YouTubeUploadCore):
             raise RuntimeError(f"❌ タイトルが {len(title)} codepoint。YouTube 制限 100 を超過。\n  {title}")
 
         config = load_config()
+
+        # タイトル鋳型準拠チェック（巻数表記・RHS 重複・鋳型逸脱を機械検出）。
+        # 鋳型語彙・パターンは config 駆動、` | ` 鋳型を使うチャンネルでのみ適用。
+        title_cfg = config.content.title
+        template_check_cfg = {**dict(title_cfg.template_check), "template": title_cfg.template}
+        existing_titles = self._collect_live_titles(exclude_dir=collection_dir)
+        msg = check_title_template_compliance(title, existing_titles, template_check_cfg)
+        if msg:
+            raise RuntimeError(
+                f"❌ タイトル鋳型違反: {msg}\n"
+                f"  title={title!r}\n"
+                f"  → コレクション名の流用ではなく鋳型に沿った公開タイトルを /video-description で再生成してください。"
+            )
+
         msg = check_required_localization_languages(config.localizations.supported_languages)
         if msg:
             raise RuntimeError(f"❌ {msg}。config/localizations.json を見直してください。")

--- a/src/youtube_automation/utils/config/content.py
+++ b/src/youtube_automation/utils/config/content.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -73,6 +73,10 @@ class Title:
     default_activity: str
     theme_scenes: dict
     theme_activities: dict
+    # アップロード preflight のタイトル鋳型準拠チェック設定 (#602)。
+    # `separator` / `rhs_pattern` / `volume_patterns` / `core_vocabulary` を任意指定。
+    # 未設定（空 dict）のチャンネルは `template` にセパレータが含まれなければ自動スキップ。
+    template_check: dict = field(default_factory=dict)
 
     def activity_for_theme(self, theme: str) -> str:
         """テーマ名からアクティビティキーワードを取得.

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -241,6 +241,7 @@ def _build_content(merged: dict, meta: ChannelMeta) -> Content:
         default_activity=default_activity,
         theme_scenes=dict(tl.get("theme_scenes", {})),
         theme_activities=dict(tl.get("theme_activities", {})),
+        template_check=dict(tl.get("template_check", {})),
     )
 
     return Content(genre=genre, tags=tags, descriptions=descriptions, title=title)

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Collection
+from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 
 from youtube_automation.utils.youtube_tag import youtube_tag_chars
@@ -21,6 +21,21 @@ _DESC_TAGS_RE = re.compile(r"## タグ（YouTube タグ欄）\s*\n+```\n(.*?)```
 # v1〜v9 もしくは末尾のロマン数字 (I/II/III/IV/V/VI/VII/VIII) を検出する。
 # chapter 名末尾にこれが現れる場合、1 パターンを複数バリエーションに展開した事故とみなす。
 _VARIATION_SUFFIX_RE = re.compile(r"\b(I{1,3}|IV|V|VI{0,3}|v[1-9])\b\s*$")
+
+# --- タイトル鋳型準拠チェック（#602）の既定値 ----------------------------------
+# いずれもチャンネル config (`content.json::title.template_check`) で上書き可能。
+# ハードコードではなく「config 未設定チャンネル向けの汎用フォールバック」。
+DEFAULT_TITLE_SEPARATOR = " | "
+# RHS（セパレータ以降）が満たすべき鋳型。既定は `N Hours of ...` 系。
+DEFAULT_TITLE_RHS_PATTERN = r"^\d+\s+Hours?\s+of\s+\S.*$"
+# 巻数表記（コレクション名の公開タイトル流用事故）の検出パターン。LHS に対して適用。
+DEFAULT_TITLE_VOLUME_PATTERNS = (
+    r"\bVol\.?\s*\d+",  # Vol.2 / Vol 2 / Vol2
+    r"\bPart\s*\d+",  # Part 2
+    r"#\s*\d+",  # #2
+    r"\bVol\.?\s*[IVXLCDM]+\b",  # Vol. II
+    r"\b(?:I{2,3}|IV|VI{0,3}|IX|X)\b\s*$",  # 末尾ローマ数字 (II〜X)
+)
 
 
 def check_chapter_count(ts_count: int, chapter_max: int) -> str | None:
@@ -42,6 +57,85 @@ def check_chapter_variation_suffix(ts_lines: list[str]) -> str | None:
     if hits:
         return f"chapter names contain variation suffix (v1〜v9 / I〜VIII): {len(hits)} lines"
     return None
+
+
+def check_title_template_compliance(
+    title: str,
+    existing_titles: Collection[str] = (),
+    title_template_cfg: Mapping[str, object] | None = None,
+) -> str | None:
+    """公開タイトルがチャンネルの TTP 鋳型に準拠しているか検証する (#602).
+
+    検出した逸脱を `; ` で連結した理由文字列を返し、問題なければ None を返す:
+
+    - **鋳型形式**: セパレータ（既定 ` | `）で LHS/RHS に分割でき、RHS が
+      チャンネル鋳型（既定 `N Hours of ...`）に一致するか
+    - **巻数表記**: LHS に `Vol.` / `Vol N` / `Part N` / ローマ数字巻数 / `#N` を
+      含まないか（コレクション名＝内部管理ラベルの公開タイトル流用事故を検出）
+    - **RHS 重複**: 既存 live タイトル群と RHS（セパレータ以降）が完全一致しないか
+    - **ジャンル核語彙**（任意）: `core_vocabulary` 設定時、LHS にいずれかを含むか
+
+    鋳型語彙・パターンは `title_template_cfg`（チャンネル config 由来）から導出し、
+    未指定キーは既定値にフォールバックする。`title_template_cfg["template"]` に
+    セパレータを含まないチャンネル（` | ` 鋳型を使わない）では適用せず None を返す
+    （後方互換・誤検出防止のための自動 opt-in）。
+    """
+    cfg: Mapping[str, object] = title_template_cfg or {}
+    separator = str(cfg.get("separator") or DEFAULT_TITLE_SEPARATOR)
+    rhs_pattern = str(cfg.get("rhs_pattern") or DEFAULT_TITLE_RHS_PATTERN)
+    volume_patterns = cfg.get("volume_patterns") or DEFAULT_TITLE_VOLUME_PATTERNS
+    core_vocabulary = cfg.get("core_vocabulary") or ()
+
+    # 鋳型がセパレータ運用でないチャンネルには適用しない（template から自動判定）。
+    template = str(cfg.get("template") or "")
+    if template and separator not in template:
+        return None
+
+    normalized = title.strip()
+    parts = normalized.split(separator)
+    if len(parts) != 2:
+        return f"鋳型形式逸脱: '{separator.strip()}' で LHS/RHS に分割できません: {normalized!r}"
+    lhs, rhs = parts[0].strip(), parts[1].strip()
+
+    issues: list[str] = []
+
+    if not re.match(rhs_pattern, rhs):
+        issues.append(f"RHS が鋳型に一致しません（要 /{rhs_pattern}/）: {rhs!r}")
+
+    vol_hit = _first_pattern_hit(lhs, volume_patterns)
+    if vol_hit:
+        issues.append(f"巻数表記を検出: {vol_hit!r}（コレクション名の公開タイトル流用を疑ってください）")
+
+    if _has_duplicate_rhs(rhs, existing_titles, separator):
+        issues.append(f"RHS が既存 live タイトルと完全重複: {rhs!r}")
+
+    if core_vocabulary and not _contains_any_vocab(lhs, core_vocabulary):
+        issues.append(f"LHS に鋳型語彙 {list(core_vocabulary)} が含まれません: {lhs!r}")
+
+    return "; ".join(issues) if issues else None
+
+
+def _first_pattern_hit(text: str, patterns: Sequence[str] | Collection[str]) -> str | None:
+    for pattern in patterns:
+        m = re.search(str(pattern), text)
+        if m:
+            return m.group(0).strip()
+    return None
+
+
+def _has_duplicate_rhs(rhs: str, existing_titles: Collection[str], separator: str) -> bool:
+    if not rhs:
+        return False
+    for other in existing_titles:
+        other_parts = str(other).split(separator)
+        other_rhs = other_parts[-1].strip() if len(other_parts) >= 2 else ""
+        if other_rhs and other_rhs == rhs:
+            return True
+    return False
+
+
+def _contains_any_vocab(text: str, vocabulary: Collection[str]) -> bool:
+    return any(re.search(rf"\b{re.escape(str(word))}\b", text, re.IGNORECASE) for word in vocabulary)
 
 
 def check_required_localization_languages(

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -12,6 +12,7 @@ from youtube_automation.utils.preflight_checks import (
     check_required_localization_languages,
     check_tags_count,
     check_tags_yt_chars,
+    check_title_template_compliance,
     extract_descriptions_md_tags,
 )
 
@@ -233,3 +234,94 @@ class TestExtractDescriptionsMdTags:
         p = tmp_path / "descriptions.md"
         p.write_text("## タグ（YouTube タグ欄）\n```\n\n```\n", encoding="utf-8")
         assert extract_descriptions_md_tags(p) is None
+
+
+class TestCheckTitleTemplateCompliance:
+    """`check_title_template_compliance` の鋳型逸脱・巻数表記・RHS 重複検出 (#602)."""
+
+    # soulful-grooves チャンネルを想定した鋳型設定
+    CFG = {
+        "template": "{adjective} Soul/Funk {noun} | {hours} Hours of {mood}",
+        "core_vocabulary": ["Soul", "Funk"],
+    }
+    EXISTING = [
+        "Pure Soul & Funk Infinity | 3 Hours of Soulful Retro Funk Grooves",
+        "Golden Hour Soul Flow | 4 Hours of Smooth City Funk",
+    ]
+
+    def test_compliant_title_passes(self) -> None:
+        title = "Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves"
+        assert check_title_template_compliance(title, self.EXISTING, self.CFG) is None
+
+    def test_volume_notation_rejected(self) -> None:
+        title = "Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "巻数表記" in msg
+
+    def test_part_notation_rejected(self) -> None:
+        title = "Funky Soul Spirit Part 3 | 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "巻数表記" in msg
+
+    def test_hash_number_rejected(self) -> None:
+        title = "Funky Soul Spirit #2 | 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "巻数表記" in msg
+
+    def test_trailing_roman_numeral_rejected(self) -> None:
+        title = "Funky Soul Spirit III | 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "巻数表記" in msg
+
+    def test_rhs_duplicate_rejected(self) -> None:
+        title = "Brand New Soul Funk Energy | 3 Hours of Soulful Retro Funk Grooves"
+        msg = check_title_template_compliance(title, self.EXISTING, self.CFG)
+        assert msg is not None
+        assert "RHS が既存 live タイトルと完全重複" in msg
+
+    def test_volume_and_rhs_duplicate_both_reported(self) -> None:
+        # issue の事故事例: 巻数表記 + RHS 重複の両方を検出して block
+        title = "Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves"
+        msg = check_title_template_compliance(title, self.EXISTING, self.CFG)
+        assert msg is not None
+        assert "巻数表記" in msg
+        assert "RHS が既存 live タイトルと完全重複" in msg
+
+    def test_rhs_not_matching_template_rejected(self) -> None:
+        title = "Bright Funk & Soul Spirit | A Cozy Funk Mix"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "RHS が鋳型に一致しません" in msg
+
+    def test_missing_separator_rejected(self) -> None:
+        title = "Bright Funk & Soul Spirit 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "鋳型形式逸脱" in msg
+
+    def test_missing_core_vocabulary_rejected(self) -> None:
+        title = "Bright Mellow Spirit | 3 Hours of Feel-Good Retro Grooves"
+        msg = check_title_template_compliance(title, [], self.CFG)
+        assert msg is not None
+        assert "鋳型語彙" in msg
+
+    def test_skips_when_template_has_no_separator(self) -> None:
+        # ` | ` 鋳型を使わないチャンネル（例: RPG BGM）は自動スキップ
+        cfg = {"template": "{style} {theme} RPG Music - {activity} BGM [{duration_display}]"}
+        title = "Epic Battle RPG Music - Gaming BGM [3:00:00]"
+        assert check_title_template_compliance(title, [], cfg) is None
+
+    def test_no_config_uses_defaults(self) -> None:
+        # config 未指定でも既定鋳型（N Hours of ...）で検証できる
+        title = "Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves"
+        assert check_title_template_compliance(title) is None
+
+    def test_existing_live_titles_pass(self) -> None:
+        # 既存 live タイトルは自分自身を比較対象に含めなければ全て pass（回帰確認）
+        for i, title in enumerate(self.EXISTING):
+            others = [t for j, t in enumerate(self.EXISTING) if j != i]
+            assert check_title_template_compliance(title, others, self.CFG) is None

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -66,6 +66,11 @@ def _make_preflight_config(supported_languages: list[str]) -> SimpleNamespace:
                 min_count=None,
                 for_collection=lambda _name: ["fallback"],
             ),
+            # ` | ` を使わない鋳型 → タイトル鋳型準拠チェックは自動スキップ (#602)
+            title=SimpleNamespace(
+                template="{style} {theme} for {activity}",
+                template_check={},
+            ),
         ),
         localizations=SimpleNamespace(supported_languages=supported_languages),
     )
@@ -153,6 +158,110 @@ class TestPreflightLocalizationLanguages:
             uploader._preflight_check(col_dir)
 
         assert any("ko" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Issue #602: `_preflight_check` タイトル鋳型準拠ゲート
+# ---------------------------------------------------------------------------
+
+
+def _make_title_template_config(supported_languages: list[str]) -> SimpleNamespace:
+    cfg = _make_preflight_config(supported_languages)
+    # ` | ` 鋳型 + 核語彙を持つチャンネル（soulful-grooves 想定）に差し替え
+    cfg.content.title = SimpleNamespace(
+        template="{adjective} Soul/Funk {noun} | {hours} Hours of {mood}",
+        template_check={"core_vocabulary": ["Soul", "Funk"]},
+    )
+    return cfg
+
+
+def _write_title_collection(tmp_path: Path, title: str, *, status: str = "ready") -> Path:
+    col_dir = tmp_path / status / "20990101-foo-collection"
+    doc_dir = col_dir / "20-documentation"
+    doc_dir.mkdir(parents=True)
+    (doc_dir / "descriptions.md").write_text(
+        "\n".join(
+            [
+                "## タイトル案",
+                "```",
+                title,
+                "```",
+                "",
+                "## Complete Collection 概要欄",
+                "```",
+                "00:00 Opening Groove",
+                "10:00 Midnight Funk",
+                "20:00 Last Call Soul",
+                "```",
+                "",
+                "## タグ（YouTube タグ欄）",
+                "```",
+                "soul funk, retro groove, study music",
+                "```",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    scene_phrases = {lang: {"title": f"title-{lang}"} for lang in ["en", "ja", "de"]}
+    (col_dir / "workflow-state.json").write_text(
+        json.dumps({"scene_phrases": scene_phrases}),
+        encoding="utf-8",
+    )
+    return col_dir
+
+
+def _write_live_title(tmp_path: Path, slug: str, title: str) -> None:
+    doc_dir = tmp_path / "live" / slug / "20-documentation"
+    doc_dir.mkdir(parents=True)
+    (doc_dir / "descriptions.md").write_text(
+        f"## タイトル案\n```\n{title}\n```\n",
+        encoding="utf-8",
+    )
+
+
+class TestPreflightTitleTemplateCompliance:
+    """#602: 鋳型逸脱・巻数表記・RHS 重複を preflight で block する."""
+
+    def test_should_fail_on_volume_and_rhs_duplicate(self, tmp_path):
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+
+        _write_live_title(
+            tmp_path,
+            "20250101-vol1",
+            "Pure Soul & Funk Infinity | 3 Hours of Soulful Retro Funk Grooves",
+        )
+        col_dir = _write_title_collection(
+            tmp_path,
+            "Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves",
+        )
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+
+        with patch(
+            "youtube_automation.agents.youtube_auto_uploader.load_config",
+            return_value=_make_title_template_config(["ja", "en", "de"]),
+        ):
+            with pytest.raises(RuntimeError, match="タイトル鋳型違反"):
+                uploader._preflight_check(col_dir)
+
+    def test_should_pass_on_compliant_title(self, tmp_path):
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+
+        _write_live_title(
+            tmp_path,
+            "20250101-vol1",
+            "Pure Soul & Funk Infinity | 3 Hours of Soulful Retro Funk Grooves",
+        )
+        col_dir = _write_title_collection(
+            tmp_path,
+            "Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves",
+        )
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+
+        with patch(
+            "youtube_automation.agents.youtube_auto_uploader.load_config",
+            return_value=_make_title_template_config(["ja", "en", "de"]),
+        ):
+            uploader._preflight_check(col_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.5"
+version = "5.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## 概要

アップロード preflight に「公開タイトルが TTP 鋳型に準拠しているか」を決定論的に検証する `check_title_template_compliance()` を新設し、`youtube_auto_uploader._preflight_check` に組み込んで違反時はアップロードを **block** する（`check_chapter_variation_suffix` が chapter 事故を機械検出するのと同じ思想）。

soulful-grooves で起きた `Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves`（コレクション内部管理名の公開タイトル流用）を、巻数表記 + RHS 重複で物理的に止められる。

## 検出する逸脱

既存 `check_*` の規約（問題なら理由文字列 / 正常なら `None`）に従う:

- **鋳型形式**: ` | ` で LHS/RHS に分割でき、RHS がチャンネル鋳型（既定 `N Hours of ...`）に一致するか
- **巻数表記**: `Vol.` / `Vol N` / `Part N` / 末尾ローマ数字 / `#N`
- **RHS 重複**: 既存 live タイトル群と RHS（` | ` 以降）が完全一致
- **核語彙欠落**（任意）: `core_vocabulary` 設定時、LHS にいずれかを含むか

## 設計

- 鋳型語彙・パターン・セパレータは **チャンネル config（`content.json::title.template_check`）から導出** し、未指定キーは汎用既定値にフォールバック（チャンネル固有値のハードコードなし）。
- `title.template` に ` | ` を含まないチャンネル（例: RPG BGM の `... - ... BGM [...]`）は **自動スキップ**（後方互換・誤検出防止）。
- 既存 live タイトルは `collections/live/*/20-documentation/descriptions.md` の `## タイトル案` から収集（`_collect_live_titles`）。

## 受け入れ基準

- [x] `Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves` が「巻数表記」+「RHS 重複」で reject
- [x] `Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves` は pass
- [x] 既存 live タイトルは RHS 比較対象から自身を除けば pass（回帰確認）

## テスト

- `tests/test_preflight_checks.py`: 鋳型逸脱・巻数表記（Vol./Part/#N/ローマ数字）・RHS 重複・核語彙・スキップ・既定値の各ケース
- `tests/test_youtube_auto_uploader.py`: `_preflight_check` 経由の block / pass 統合テスト
- `uv run --extra dev pytest` green、`ruff check` / `ruff format` clean

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)