### PR TITLE
feat(agents): workflow-state 書き込み側で TZ-naive datetime 混入を検出する防御コードを追加 (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(agents)`: 永続化用 timestamp の TZ-naive 混入を書き込み時点で検出する防御コードを追加した（#533）。`utils/schedule.py` に `now_in_schedule_tz(schedule_config)`（schedule.timezone の現在時刻を TZ-aware datetime として返し生成を一点集約）と `ensure_tz_aware(dt, *, context)`（TZ-naive なら `ValidationError` を送出する防御ヘルパ）を追加し、`short_uploader._update_workflow_state`（`workflow-state.json::uploaded_at`）と `collection_uploader._completed_tracking_record`（`upload_tracking.json::upload_time`）/ `_update_workflow_upload`（`workflow-state.json::updated_at`）の書き込み点を `now_in_schedule_tz()` 経由に統一した。#359 で書き込み側を TZ-aware に統一した後の再リグレッションを、読み手側 backfill で吸収される前に書き込み時点で検知できる
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/src/youtube_automation/agents/collection_uploader.py
+++ b/src/youtube_automation/agents/collection_uploader.py
@@ -32,7 +32,7 @@ from youtube_automation.scripts.playlist_manager import PlaylistManager  # noqa:
 from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError  # noqa: E402
-from youtube_automation.utils.schedule import get_schedule_timezone  # noqa: E402
+from youtube_automation.utils.schedule import get_schedule_timezone, now_in_schedule_tz  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
 
 ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED = "complete_collection_dedup_skipped"
@@ -253,7 +253,7 @@ class CollectionUploader:
         record = {
             "video_id": complete_video["video_id"],
             "video_url": complete_video["video_url"],
-            "upload_time": datetime.now(get_schedule_timezone(self.config)).isoformat(),
+            "upload_time": now_in_schedule_tz(self.config).isoformat(),
             "publish_at": publish_at,
             "status": TRACKING_STATUS_COMPLETED,
         }
@@ -280,7 +280,7 @@ class CollectionUploader:
         updated_state = {
             **state,
             "upload": updated_upload,
-            "updated_at": datetime.now(get_schedule_timezone(self.config)).isoformat(),
+            "updated_at": now_in_schedule_tz(self.config).isoformat(),
         }
         if collection_path.parent.name == WORKFLOW_STAGE_LIVE:
             updated_state = {

--- a/src/youtube_automation/agents/short_uploader.py
+++ b/src/youtube_automation/agents/short_uploader.py
@@ -31,7 +31,7 @@ from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config
 from youtube_automation.utils.exceptions import UploadError
 from youtube_automation.utils.metadata_generator import BAHMetadataGenerator
-from youtube_automation.utils.schedule import get_schedule_timezone
+from youtube_automation.utils.schedule import get_schedule_timezone, now_in_schedule_tz
 
 logger = logging.getLogger(__name__)
 
@@ -330,7 +330,7 @@ class ShortUploader:
         entry = {
             "short_num": short_num,
             "video_id": video_id,
-            "uploaded_at": datetime.now(get_schedule_timezone(self.schedule_config)).isoformat(),
+            "uploaded_at": now_in_schedule_tz(self.schedule_config).isoformat(),
             "publish_at": publish_at,
         }
 

--- a/src/youtube_automation/utils/schedule.py
+++ b/src/youtube_automation/utils/schedule.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.exceptions import ConfigError, ValidationError
 
 SCHEDULE_SECTION = "schedule"
 TIMEZONE_KEY = "timezone"
@@ -24,3 +25,39 @@ def get_schedule_timezone(schedule_config: Mapping[str, Any]) -> ZoneInfo:
         raise ConfigError("schedule_config.json の schedule.timezone は空でない文字列である必要があります")
 
     return ZoneInfo(timezone_name)
+
+
+def ensure_tz_aware(dt: datetime, *, context: str) -> datetime:
+    """永続化対象の datetime が TZ-aware であることを保証する防御ヘルパ.
+
+    workflow-state.json / upload_tracking.json などへ書き込む timestamp が
+    TZ-naive のまま混入する再リグレッション（#359 関連）を *書き込み時点で* 検出する。
+    読み手側 backfill（TZ-naive を schedule TZ で補完）で吸収されると見過ごされるため、
+    書き手側でも自己診断する。
+
+    Args:
+        dt: 検証対象の datetime
+        context: 例外メッセージに含める発生箇所（例: "workflow-state.json::uploaded_at"）
+
+    Returns:
+        dt（TZ-aware であればそのまま）
+
+    Raises:
+        ValidationError: dt.tzinfo が None（TZ-naive）の場合
+    """
+    if dt.tzinfo is None:
+        raise ValidationError(
+            f"TZ-naive datetime を永続化しようとしました ({context}): {dt!r}. "
+            "datetime.now(tz) / now_in_schedule_tz() など TZ-aware な値を使ってください"
+        )
+    return dt
+
+
+def now_in_schedule_tz(schedule_config: Mapping[str, Any]) -> datetime:
+    """schedule.timezone の現在時刻を TZ-aware datetime として返す.
+
+    永続化用 timestamp の生成を一点に集約し、`datetime.now()`（TZ-naive）の混入を防ぐ。
+    返り値は ensure_tz_aware で自己診断してから返す。
+    """
+    tz = get_schedule_timezone(schedule_config)
+    return ensure_tz_aware(datetime.now(tz), context="now_in_schedule_tz")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
-from youtube_automation.utils.exceptions import ConfigError
-from youtube_automation.utils.schedule import get_schedule_timezone
+from youtube_automation.utils.exceptions import ConfigError, ValidationError
+from youtube_automation.utils.schedule import (
+    ensure_tz_aware,
+    get_schedule_timezone,
+    now_in_schedule_tz,
+)
 
 
 def test_get_schedule_timezone_uses_configured_timezone():
@@ -29,3 +34,54 @@ def test_get_schedule_timezone_rejects_non_mapping_schedule():
 def test_get_schedule_timezone_rejects_empty_timezone():
     with pytest.raises(ConfigError, match="schedule.timezone"):
         get_schedule_timezone({"schedule": {"timezone": ""}})
+
+
+# ─── ensure_tz_aware（書き込み側 TZ-naive 検出の防御コード, #533） ───
+
+
+def test_ensure_tz_aware_returns_aware_datetime_unchanged():
+    dt = datetime(2026, 1, 1, 10, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    assert ensure_tz_aware(dt, context="test") is dt
+
+
+def test_ensure_tz_aware_accepts_utc():
+    dt = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+
+    assert ensure_tz_aware(dt, context="test") is dt
+
+
+def test_ensure_tz_aware_raises_on_naive_datetime():
+    naive = datetime(2026, 1, 1, 10, 0)
+
+    with pytest.raises(ValidationError, match="TZ-naive"):
+        ensure_tz_aware(naive, context="workflow-state.json::uploaded_at")
+
+
+def test_ensure_tz_aware_includes_context_in_message():
+    naive = datetime(2026, 1, 1, 10, 0)
+
+    with pytest.raises(ValidationError, match="upload_tracking.json::upload_time"):
+        ensure_tz_aware(naive, context="upload_tracking.json::upload_time")
+
+
+# ─── now_in_schedule_tz（永続化用 timestamp 生成の集約, #533） ───
+
+
+def test_now_in_schedule_tz_returns_tz_aware_datetime():
+    now = now_in_schedule_tz({"schedule": {"timezone": "Asia/Tokyo"}})
+
+    assert now.tzinfo is not None
+    assert now.utcoffset() == timedelta(hours=9)
+
+
+def test_now_in_schedule_tz_defaults_to_tokyo():
+    now = now_in_schedule_tz({})
+
+    assert now.tzinfo is not None
+    assert now.utcoffset() == timedelta(hours=9)
+
+
+def test_now_in_schedule_tz_rejects_invalid_schedule_config():
+    with pytest.raises(ConfigError, match="schedule"):
+        now_in_schedule_tz({"schedule": "Asia/Tokyo"})


### PR DESCRIPTION
## 概要

`workflow-state.json` / `upload_tracking.json` の timestamp 書き込み側に **TZ-naive datetime 混入を検出する防御コード** を追加する（issue #533）。

#359 で書き込み側を `datetime.now(tz).isoformat()` に統一したが、再リグレッションが起きた際に **読み手側 backfill（TZ-naive を schedule TZ で補完）で吸収されると見過ごされる**。書き込み時点で気付けるよう防御策を入れる。

## 実装（提案 B + 防御 assert）

`utils/schedule.py` に共通ヘルパを追加し、書き込み点を集約:

- **`now_in_schedule_tz(schedule_config) -> datetime`** — schedule.timezone の現在時刻を TZ-aware datetime として返す。永続化用 timestamp の生成を一点に集約し、`datetime.now()`（TZ-naive）の混入を構造的に防ぐ。返り値は `ensure_tz_aware` で自己診断。
- **`ensure_tz_aware(dt, *, context) -> datetime`** — TZ-naive を検出したら `ValidationError`（ドメイン例外）を送出する防御ヘルパ。`context` で発生箇所を明示。

書き込み点を `now_in_schedule_tz()` 経由に統一:

| ファイル | メソッド | 書き込み対象 |
|---|---|---|
| `agents/short_uploader.py` | `_update_workflow_state` | `workflow-state.json::uploaded_at` |
| `agents/collection_uploader.py` | `_completed_tracking_record` | `upload_tracking.json::upload_time` |
| `agents/collection_uploader.py` | `_update_workflow_upload` | `workflow-state.json::updated_at` |

`get_schedule_timezone()` は他箇所（公開予定計算等）で引き続き利用するため import は維持。

## テスト

`tests/test_schedule.py` に追加:

- `ensure_tz_aware`: aware（JST / UTC）はそのまま返す / naive は `ValidationError` / メッセージに `context` を含む
- `now_in_schedule_tz`: TZ-aware を返す（明示 TZ / デフォルト Tokyo）/ 不正 schedule_config は `ConfigError`

既存の `test_collection_uploader.py::test_should_write_timezone_aware_upload_time` 等もパス。`uv run pytest` 全 2436 件 green、`uv run ruff check` / `ruff format` クリーン。

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)