### PR TITLE
chore(takt): 全 persona を claude/opus に固定する

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -3,15 +3,23 @@
 draft_pr: false
 base_branch: main
 
-# coder の provider はグローバル設定の codex を継承する（通常はここに persona_providers を書かない）。
-# Codex の rate limit 等で一時的に coder を Claude へ逃がしたいときだけ、
-# global を触らず以下のような override をこのファイルに足す:
-#   persona_providers:
-#     coder:
-#       provider: claude
-#       model: sonnet
-# rate limit が解消したら、その override ブロックを削除して codex 継承に戻す。
+# 全 persona を Claude/opus に固定する（本リポジトリは品質側に振り、Codex への依存を切る）。
+# - planner / 各 reviewer はグローバル設定でもともと claude/opus
+# - coder はグローバル設定では codex 継承だが、本リポジトリでは Claude/opus に統一
+# rate limit や保守判断で Codex 継承へ戻したい場合は、`coder:` ブロックを削除すれば global の codex に戻る。
 persona_providers:
+  planner:
+    provider: claude
+    model: opus
   coder:
     provider: claude
-    model: sonnet
+    model: opus
+  architecture-reviewer:
+    provider: claude
+    model: opus
+  ai-antipattern-reviewer:
+    provider: claude
+    model: opus
+  supervisor:
+    provider: claude
+    model: opus


### PR DESCRIPTION
## Summary

`.takt/config.yaml` の `persona_providers` を全 persona Claude/opus に明示固定する。
issue #650 / PR #651 の takt 実行で一時的に override したものを永続化する。

## 背景

- グローバル設定 (`~/.takt/config.yaml`) では `coder` のみ Codex 継承、planner / reviewer 系は Claude/opus。
- 本リポジトリは Codex の skill protected paths deny を避け、品質側に振る方針へ移行する。
- PR #651 の実行実績で Claude/opus でも skill 配下の Edit が通ることを確認済み（30m35s, 全 reviewer APPROVE）。

## 変更内容

- `.takt/config.yaml` の persona_providers を全 5 persona（planner / coder / architecture-reviewer / ai-antipattern-reviewer / supervisor）に展開し、すべて `claude/opus` 指定
- 旧 "Codex 継承前提・一時 override 用テンプレ" のコメントを「永続化方針」のコメントに置き換え
- Codex 継承に戻したい場合の戻し方も新コメントに記載

## Test plan

- [ ] ruff / pytest は無関係（設定ファイルのみの変更）
- [ ] 次回 takt 実行時に全 persona が Claude/opus で動くことを確認
- [ ] `tasks.yaml` poll → Workflow completed まで PR #651 と同様に走ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)