### PR TITLE
docs(deps): google-auth-httplib2 deprecated 運用規約を明文化 (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(short-upload)`: `ShortUploader.upload_short` に resumable upload session URI 永続化を適用し、Shorts 投稿の中断→再実行時の video_id 重複（二重 publish）の余地を解消した（#466、CC 経路 #381 と同等）。これまで `upload_video` を `resume_session_uri=None` のまま呼んでいたが、`workflow-state.json` の `post_upload.shorts[].resume_session_uri` に session URI を読み書きするクロージャ（`on_session_uri_changed` / `on_upload_complete`）を配線。開始前に保存済み URI を読んで再開し、成功時はクリア、中断時は残して次回再開する。tracking 媒体は CC の `upload_tracking.json` ではなく Shorts 専用の `workflow-state.json`（既存 entry には key を増やさず書込み時のみ append する schema 互換）。再開不要な単発投稿は従来どおり `resume_session_uri=None` で挙動不変
 - `fix(uploader)`: サムネ候補の優先順を `CollectionPaths.find_thumbnail()` に集約して統一した（#535）。従来 `find_thumbnail()`（`thumbnail.jpg > main.png > main.jpg`）と `_upload_complete_collection` のインライン候補（`thumbnail.jpg > thumbnail.png > main.jpg > main.png`）で順序が食い違っており、将来 `find_thumbnail()` へ統一する際に拾われる画像が変わるリスクがあった。実際にアップロードで使われていた後者の順を正とし、`find_thumbnail()` を `thumbnail.jpg > thumbnail.png > main.jpg > main.png`（`_THUMBNAIL_CANDIDATES`）に揃え、`_upload_complete_collection` は `find_thumbnail()` へ委譲。全候補組み合わせで統一前のアップロード経路と同一ファイルを指すことを回帰テストで担保（既存コレクションのサムネ選択は不変）
 
+### Deprecated
+
+- `docs(deps)`: `google-auth-httplib2`（PyPI 0.4.0 / 2026-05-07 で deprecated 表明）を依存ポリシーとして明文化した（#475、#408 follow-up・監査 R-04）。CLAUDE.md「依存ポリシー: deprecated 表明済み依存の取り扱い」節で `src/youtube_automation/` への直 import 新規追加を禁止し（現状 0 件）、回帰テスト `tests/test_no_google_auth_httplib2_direct_import.py` で `ast` ベースに機械担保する。既存の transitive 依存は `googleapiclient.discovery.build(..., credentials=...)` 経由で残置し、上流が non-httplib2 transport をサポートした際の移行手順は `docs/migration/google-auth-httplib2.md` を参照。`pyproject.toml::dependencies` の直接宣言撤去は transport 切替完了後に別 issue で再検証（外部依存待ち）。リリース時は `/automation-release` が `[Unreleased]` を整える流れで本節をそのまま `Deprecated` として転記する
+
 ## [5.5.6] - 2026-05-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,14 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 
 - パッケージ内コードは必ず `from youtube_automation.xxx import ...` の fully-qualified import を使う
 
+### 依存ポリシー: deprecated 表明済み依存の取り扱い
+
+- **`google-auth-httplib2`（PyPI 0.4.0 で deprecated 表明）**:
+  - `src/youtube_automation/` / `tests/` 配下に `google_auth_httplib2` の **直 import を新規追加しない**（現状 0 件、回帰テスト `tests/test_no_google_auth_httplib2_direct_import.py` で機械担保）
+  - 既存の transitive 依存は `googleapiclient.discovery.build(..., credentials=credentials)` 経由で残置する（上流 `google-api-python-client` が内部で `google_auth_httplib2.AuthorizedHttp` を要求しているため、即時撤去不可）
+  - 上流が non-httplib2 transport（`google.auth.transport.requests` など）を正式サポートした際の移行手順・撤去判断は `docs/migration/google-auth-httplib2.md` を参照
+  - `pyproject.toml::dependencies` の `"google-auth-httplib2"` 直接宣言の撤去は transport 切替完了後に別 issue で再検証する
+
 ### スクリプト配置
 
 - **skill 固有のスクリプト**は `.claude/skills/<skill>/references/` に配置する（例: `.claude/skills/videoup/references/generate_videos.sh`）

--- a/tests/test_no_google_auth_httplib2_direct_import.py
+++ b/tests/test_no_google_auth_httplib2_direct_import.py
@@ -1,0 +1,91 @@
+"""`google_auth_httplib2` の直 import 0 件を機械的に維持する回帰テスト.
+
+PyPI `google-auth-httplib2 0.4.0` (2026-05-07) で deprecated 表明されたため、
+`docs/migration/google-auth-httplib2.md` と CLAUDE.md「依存ポリシー」節に基づき、
+`src/youtube_automation/` 配下に `google_auth_httplib2` の直 import を新規追加しない。
+
+`googleapiclient.discovery.build(..., credentials=...)` 経由の transitive 依存は
+上流が non-httplib2 transport をサポートするまで残置する (移行計画書 Step 2)。
+本テストは「直 import」のみを禁止し、transitive 依存への影響は与えない。
+
+関連 issue: #475 / 親 #408 / 監査 R-04
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src" / "youtube_automation"
+
+_FORBIDDEN_MODULE = "google_auth_httplib2"
+
+
+def _iter_python_files() -> list[Path]:
+    """`src/youtube_automation/` 配下の `.py` ファイルを列挙する."""
+    return sorted(SRC_DIR.rglob("*.py"))
+
+
+def _direct_imports(path: Path) -> list[tuple[int, str]]:
+    """`path` の `.py` から `google_auth_httplib2` への直 import を抽出する.
+
+    Returns:
+        `(行番号, 該当 import 表現)` のリスト。空なら 0 件。
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root == _FORBIDDEN_MODULE:
+                    hits.append((node.lineno, f"import {alias.name}"))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            root = module.split(".", 1)[0]
+            if root == _FORBIDDEN_MODULE:
+                names = ", ".join(alias.name for alias in node.names)
+                hits.append((node.lineno, f"from {module} import {names}"))
+    return hits
+
+
+def test_src_has_no_direct_google_auth_httplib2_import() -> None:
+    """`src/youtube_automation/` 配下に `google_auth_httplib2` の直 import が無いこと.
+
+    違反を検出した場合は (1) `googleapiclient.discovery.build(..., credentials=...)`
+    経由の transitive 依存への切替、または (2) `docs/migration/google-auth-httplib2.md`
+    の移行計画 Step 2 への明示的合流を検討すること。
+    """
+    violations: list[tuple[Path, int, str]] = []
+    for path in _iter_python_files():
+        for lineno, expression in _direct_imports(path):
+            violations.append((path, lineno, expression))
+
+    if violations:
+        rendered = "\n".join(
+            f"  {path.relative_to(REPO_ROOT)}:{lineno}: {expression}" for path, lineno, expression in violations
+        )
+        pytest.fail(
+            "src/youtube_automation/ 配下で google_auth_httplib2 の直 import を検出しました。\n"
+            "CLAUDE.md「依存ポリシー: deprecated 表明済み依存の取り扱い」および\n"
+            "docs/migration/google-auth-httplib2.md を参照してください。\n"
+            f"検出箇所:\n{rendered}"
+        )
+
+
+def test_regression_test_scans_actual_source_tree() -> None:
+    """テストが実在する `src/` を走査していることを保証する (空走査の防止)."""
+    assert SRC_DIR.is_dir(), f"src/ が見つかりません: {SRC_DIR}"
+    files = _iter_python_files()
+    assert files, "src/youtube_automation/ 配下の .py が 0 件です (テスト自身の保護)"


### PR DESCRIPTION
## Summary

#408 で作成した移行計画書（`docs/migration/google-auth-httplib2.md`）を踏まえ、PyPI 0.4.0 で deprecated 表明された `google-auth-httplib2` の取り扱いを **CLAUDE.md / 回帰テスト / CHANGELOG** の 3 点で運用規約化する（#408 follow-up・監査 R-04）。

- **CLAUDE.md**: 「依存ポリシー: deprecated 表明済み依存の取り扱い」節を Import 規約直後に追加し、`src/` / `tests/` への直 import 新規追加禁止・transitive 依存残置の例外運用（`googleapiclient.discovery.build(..., credentials=...)` 経由）・移行計画書への参照を明文化
- **`tests/test_no_google_auth_httplib2_direct_import.py`**: `ast` ベースで `src/youtube_automation/` 配下の `import google_auth_httplib2` / `from google_auth_httplib2 import ...` を機械検出し、現状 0 件を維持する回帰テスト。空走査防止のサブテストも併設
- **CHANGELOG.md**: `[Unreleased]` に `### Deprecated` 節を新設し、本 deprecated 表明を記録。リリース運用（`/automation-release`）で本節をそのまま転記する想定

## Out of scope（issue 本文どおり、本 PR では実施しない）

- `pyproject.toml::dependencies` の `google-auth-httplib2` 直接宣言の撤去 → transport 切替完了後に別 issue で再検証（外部依存待ち）
- `googleapiclient` → `google-auth` + transport の実コード移行 → 上流対応待ち
- `pyproject.toml` の上限 pin 追加（#407 の責務）

## Test plan

- [x] `uv run pytest tests/test_no_google_auth_httplib2_direct_import.py -v` → 2 passed
- [x] `uv run ruff check tests/test_no_google_auth_httplib2_direct_import.py` → All checks passed
- [x] `uv run ruff format --check tests/test_no_google_auth_httplib2_direct_import.py` → already formatted
- [x] pre-commit (ruff) / pre-push (changelog-gate) ともに green
- [x] CLAUDE.md / CHANGELOG.md / 新規テストの編集スコープを #475 本文の「推奨アクション」3 項目に厳密一致

Closes #475

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)