### PR TITLE
feat(veo,videoup): 動画生成の進捗表示にスピナー / ETA / ステップを追加 (#641)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -149,6 +149,15 @@ video_bitrate_bps() {
     bitrate_to_bps "$bitrate"
 }
 
+# ─── TTY 判定 (Issue #641) ───────────────────────────────
+# 非 TTY 環境（CI / log redirect）では \r アニメを抑止し、行ごとの出力に
+# フォールバックする。-t 1 は stdout が TTY のときだけ true を返す。
+if [[ -t 1 ]]; then
+    IS_TTY=1
+else
+    IS_TTY=0
+fi
+
 # ─── Main ────────────────────────────────────────────────
 echo ""
 echo "  generate_videos.sh v12.1 — ${COLLECTION_NAME}"
@@ -168,6 +177,16 @@ echo ""
 start=$SECONDS
 PROGRESS_FILE="$(mktemp)"
 trap 'rm -f "$PROGRESS_FILE"' EXIT
+
+# ─── Step 表示 (Issue #641) ──────────────────────────────
+# Veo / ffmpeg 双方で「生成中 → 保存 → 後処理」のステップ感を共通化する。
+# ffmpeg 経路は (1) 入力正規化 (loop モードのみ) → (2) マスター動画生成
+# の 2 ステップ構成。静止画モードは (1) を skip。
+if [[ -n "$LOOP_VIDEO" ]]; then
+    FF_TOTAL_STEPS=2
+else
+    FF_TOTAL_STEPS=1
+fi
 
 # ─── FFmpeg (background) ─────────────────────────────────
 if [[ -n "$LOOP_VIDEO" ]]; then
@@ -196,7 +215,7 @@ if [[ -n "$LOOP_VIDEO" ]]; then
             normalized_bitrate_bps="$(video_bitrate_bps "$LOOP_SOURCE")"
         fi
         if [[ ! -f "$LOOP_SOURCE" || "$LOOP_VIDEO" -nt "$LOOP_SOURCE" || ( -n "$normalized_bitrate_bps" && "$normalized_bitrate_bps" -gt "$max_bitrate_bps" ) ]]; then
-            echo "  Normalizing loop source (1 回だけ実行) → loop_normalized.mp4"
+            echo "  [Step 1/${FF_TOTAL_STEPS}] Normalizing loop source (1 回だけ実行) → loop_normalized.mp4"
             if [[ -n "$loop_bitrate_bps" && "$loop_bitrate_bps" -gt "$max_bitrate_bps" ]]; then
                 echo "  Loop bitrate exceeds ${LOOP_MAX_BITRATE}; re-encoding with maxrate guard"
             fi
@@ -214,6 +233,7 @@ if [[ -n "$LOOP_VIDEO" ]]; then
         fi
     fi
 
+    echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (stream copy)"
     # Stream copy 経路: ビデオは完全無損失（ビット単位コピー）、音声は AUDIO_OUT_OPTS に従う
     ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" -i "$MASTER_AUDIO" \
         -map 0:v:0 -map 1:a:0 \
@@ -226,6 +246,7 @@ if [[ -n "$LOOP_VIDEO" ]]; then
         -progress "$PROGRESS_FILE" \
         "$MASTER_OUTPUT" &
 else
+    echo "  [Step 1/1] Generating master video (still image)"
     # 静止画背景モード（従来）
     # I-frame を 5 分間隔（1fps なので 300 フレーム）に間引き、変化のないフレームを P-frame で
     # 圧縮することで master.mp4 を大幅に小型化する（#579）。keyint=1 全 I-frame 化は容量が膨らむため廃止。
@@ -249,6 +270,7 @@ total_us=$(awk "BEGIN{printf \"%.0f\", $duration * 1000000}")
 spinner=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 si=0
 BAR_WIDTH=30
+last_logged_pct=-1  # 非 TTY 用、最後に行出力した進捗率
 
 while kill -0 "$ffmpeg_pid" 2>/dev/null; do
     out_time_us=$(grep -o 'out_time_us=[0-9]*' "$PROGRESS_FILE" 2>/dev/null | tail -1 | cut -d= -f2)
@@ -258,12 +280,28 @@ while kill -0 "$ffmpeg_pid" 2>/dev/null; do
     if [[ -n "$out_time_us" && "$total_us" -gt 0 ]]; then
         pct=$((out_time_us * 100 / total_us))
         [[ $pct -gt 100 ]] && pct=100
-        filled=$((pct * BAR_WIDTH / 100))
-        empty=$((BAR_WIDTH - filled))
-        bar="$(printf '%0.s█' $(seq 1 $filled 2>/dev/null))$(printf '%0.s░' $(seq 1 $empty 2>/dev/null))"
-        printf "\r  %s Generating... %s %3d%% (%s)  " "${spinner[$si]}" "$bar" "$pct" "$elapsed_fmt"
+        eta_sec=0
+        if [[ $pct -gt 0 ]]; then
+            eta_sec=$(( elapsed_now * (100 - pct) / pct ))
+        fi
+        eta_fmt="$(printf "%dm%02ds" $((eta_sec/60)) $((eta_sec%60)))"
+        if [[ $IS_TTY -eq 1 ]]; then
+            filled=$((pct * BAR_WIDTH / 100))
+            empty=$((BAR_WIDTH - filled))
+            bar="$(printf '%0.s█' $(seq 1 $filled 2>/dev/null))$(printf '%0.s░' $(seq 1 $empty 2>/dev/null))"
+            printf "\r  %s Generating... %s %3d%% (%s, ETA %s)  " "${spinner[$si]}" "$bar" "$pct" "$elapsed_fmt" "$eta_fmt"
+        else
+            # 非 TTY: 10% 刻みで 1 行ずつログ出力
+            bucket=$(( pct / 10 ))
+            if [[ $bucket -ne $last_logged_pct ]]; then
+                printf "  Generating... %3d%% (%s, ETA %s)\n" "$pct" "$elapsed_fmt" "$eta_fmt"
+                last_logged_pct=$bucket
+            fi
+        fi
     else
-        printf "\r  %s Generating... (%s)  " "${spinner[$si]}" "$elapsed_fmt"
+        if [[ $IS_TTY -eq 1 ]]; then
+            printf "\r  %s Generating... (%s)  " "${spinner[$si]}" "$elapsed_fmt"
+        fi
     fi
 
     si=$(( (si + 1) % ${#spinner[@]} ))
@@ -275,8 +313,12 @@ exit_code=$?
 elapsed=$((SECONDS - start))
 
 # Final bar
-printf "\r  ✓ Generated    %s 100%% (%dm%02ds)    \n" \
-    "$(printf '%0.s█' $(seq 1 $BAR_WIDTH))" $((elapsed/60)) $((elapsed%60))
+if [[ $IS_TTY -eq 1 ]]; then
+    printf "\r  ✓ Generated    %s 100%% (%dm%02ds)    \n" \
+        "$(printf '%0.s█' $(seq 1 $BAR_WIDTH))" $((elapsed/60)) $((elapsed%60))
+else
+    printf "  ✓ Generated 100%% (%dm%02ds)\n" $((elapsed/60)) $((elapsed%60))
+fi
 
 if [[ $exit_code -ne 0 ]]; then
     echo "  ERROR: FFmpeg failed with exit code $exit_code"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(veo,videoup)`: 動画生成中の進捗表示を改善した（#641）。Veo ループ動画生成（`veo_generator._wait_for_operation`）はドット列のままだったポーリング表示を「スピナー + 経過時間 + 推定進捗率 / ETA」の 1 行更新表示に置き換え、Veo API が真の進捗を返さない制約下で典型生成時間ベースの推定値であることを `≈` prefix で明示する。生成フロー全体を `[Step 1/3] 生成中` → `[Step 2/3] 保存中` → `[Step 3/3] 後処理` の 3 ステップで明示し、`generate_videos.sh` 側も `[Step N/M]` のステップ行と既存スピナーに加え ETA 表示を追加した。進捗フォーマット（経過時間 / ETA / スピナー / 1 行レンダラー）は `utils/progress.py` の純粋関数として切り出し `tests/test_progress.py` で 39 ケースを担保。非 TTY 環境（CI / log redirect）では `\r` アニメを抑止し定期的な行ごとの出力にフォールバックする（Python 側は `progress.is_tty(sys.stdout)`、bash 側は `[[ -t 1 ]]` で判定）
+
 ### Changed
 
 - `refactor(thumbnail)`: imagegen 14 項目 Shared prompt schema の bridge 層を試験導入した（#654、PR #651 / #650 follow-up・差分レポート提案 5 / E-2）。`src/youtube_automation/utils/image_provider/prompt_schema.py` に 14 項目 `PromptSchema` dataclass（`use_case` / `asset_type` / `primary_request` / `input_images` / `scene` / `subject` / `style` / `composition` / `lighting` / `color` / `materials` / `text` / `constraints` / `avoid`）と既存 `image_generation.gemini.*` キーから 14 項目へ機械マッピングする `from_skill_config()` / imagegen 形式 `Label: value` を出力する `render()` を追加し、`image_provider.__init__` の `__all__` に `PromptSchema` / `prompt_schema` を export した。対応マッピング表は `.claude/skills/thumbnail/references/prompt-schema.md`、設計判断と段階移行パスは `docs/skill-design/ADR-001-thumbnail-prompt-schema.md` に明文化（試験導入のみ・実本番フロー未接続）。`composition.py` / `scripts/generate_image.py` / `diff_prompt_template` / TTP / Two-Phase / 視認性検証 / 固定キャラ / stock 退避 / 複数プロバイダー切替の挙動は完全に温存（既存 `tests/test_thumbnail_skill_assets.py` 4 件 + 新規 `tests/test_prompt_schema.py` 8 件 green で担保）。SKILL.md は「## プロンプト構築」節末尾に bridge への参照リンクを 1 行追記したのみで既存セクション順序・固定化テストの対象テキストには触れていない。次フェーズ（opt-in feature flag）は skill-config 管理見直し epic 発火後に別 issue として `takt:default` で再起票する

--- a/src/youtube_automation/utils/progress.py
+++ b/src/youtube_automation/utils/progress.py
@@ -1,0 +1,220 @@
+"""動画生成 / 長時間処理の進捗表示ヘルパー（Issue #641）。
+
+veo_generator / generate_videos.sh の進捗表示で共通利用する純粋関数群。
+
+設計方針:
+    - 副作用ゼロの純粋関数だけを export する（ユニットテスト容易性を最優先）。
+    - 描画 I/O（print / stdout.write）はここでは行わない — 呼び出し側で
+      `is_tty(stream)` を見て `\r` アニメか行ごと出力かを切り替える。
+    - Veo は API が真の進捗を返さないため、典型生成時間ベースの**推定値**を出す。
+      推定値であることは表示文字列に "≈" を付けて明示する。
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import IO
+
+# ─── スピナー文字列 ─────────────────────────────────────
+# Braille spinner（generate_videos.sh と同一の 10 フレーム）。
+SPINNER_FRAMES: tuple[str, ...] = (
+    "⠋",
+    "⠙",
+    "⠹",
+    "⠸",
+    "⠼",
+    "⠴",
+    "⠦",
+    "⠧",
+    "⠇",
+    "⠏",
+)
+
+
+def spinner_frame(tick: int) -> str:
+    """`tick` 番目のスピナーフレームを返す（負数も剰余で安全に丸める）。
+
+    >>> spinner_frame(0)
+    '⠋'
+    >>> spinner_frame(10) == spinner_frame(0)
+    True
+    >>> spinner_frame(-1) == spinner_frame(9)
+    True
+    """
+    return SPINNER_FRAMES[tick % len(SPINNER_FRAMES)]
+
+
+# ─── 時間フォーマット ───────────────────────────────────
+
+
+def format_elapsed(seconds: float) -> str:
+    """経過時間を `Mm SSs` 形式で返す（1 時間未満は分秒、それ以上は時分秒）。
+
+    >>> format_elapsed(0)
+    '0m00s'
+    >>> format_elapsed(65)
+    '1m05s'
+    >>> format_elapsed(3725)
+    '1h02m05s'
+    >>> format_elapsed(-5)  # 負値は 0 にクランプ
+    '0m00s'
+    """
+    if seconds < 0:
+        seconds = 0
+    total = int(seconds)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    if h > 0:
+        return f"{h}h{m:02d}m{s:02d}s"
+    return f"{m}m{s:02d}s"
+
+
+def format_eta(seconds: float | None) -> str:
+    """ETA を `≈Xs` / `≈Mm SSs` で返す（None や非正は `--`）。
+
+    "≈" は推定値であることを明示するための prefix。
+
+    >>> format_eta(None)
+    '--'
+    >>> format_eta(0)
+    '--'
+    >>> format_eta(45)
+    '≈45s'
+    >>> format_eta(125)
+    '≈2m05s'
+    """
+    if seconds is None or seconds <= 0:
+        return "--"
+    total = int(round(seconds))
+    if total < 60:
+        return f"≈{total}s"
+    m, s = divmod(total, 60)
+    return f"≈{m}m{s:02d}s"
+
+
+# ─── 進捗率推定 ─────────────────────────────────────────
+
+
+def estimate_progress(elapsed: float, expected_total: float) -> float:
+    """経過秒と典型総時間から進捗率（0.0〜0.99）を推定する。
+
+    `expected_total` 到達後は 0.99 で頭打ちにする（API 完了通知を待つ間に
+    100% と誤解させないため）。`expected_total <= 0` は 0.0 を返す。
+
+    >>> estimate_progress(0, 60)
+    0.0
+    >>> estimate_progress(30, 60)
+    0.5
+    >>> estimate_progress(60, 60)
+    0.99
+    >>> estimate_progress(120, 60)
+    0.99
+    >>> estimate_progress(10, 0)
+    0.0
+    """
+    if expected_total <= 0:
+        return 0.0
+    if elapsed <= 0:
+        return 0.0
+    ratio = elapsed / expected_total
+    return min(ratio, 0.99)
+
+
+def estimate_eta(elapsed: float, expected_total: float) -> float | None:
+    """経過秒と典型総時間から ETA（残り秒）を推定する。
+
+    `expected_total` を超過したら None を返す（"未確定" の意）。
+
+    >>> estimate_eta(0, 60)
+    60.0
+    >>> estimate_eta(30, 60)
+    30.0
+    >>> estimate_eta(60, 60)
+    >>> estimate_eta(10, 0)
+    """
+    if expected_total <= 0:
+        return None
+    remaining = expected_total - max(elapsed, 0.0)
+    if remaining <= 0:
+        return None
+    return remaining
+
+
+# ─── ステップ表示 ───────────────────────────────────────
+
+
+def format_step(step_index: int, total_steps: int, label: str) -> str:
+    """`[Step 1/3] Generating` のような行を返す。
+
+    >>> format_step(1, 3, "Generating")
+    '[Step 1/3] Generating'
+    >>> format_step(2, 3, "Saving")
+    '[Step 2/3] Saving'
+    """
+    return f"[Step {step_index}/{total_steps}] {label}"
+
+
+# ─── TTY 判定 ───────────────────────────────────────────
+
+
+def is_tty(stream: IO | None = None) -> bool:
+    """`stream` (デフォルト `sys.stdout`) が TTY か判定する。
+
+    非 TTY（CI / log redirect / pipe）では `\\r` アニメを抑止し、
+    呼び出し側は行ごとの定期出力にフォールバックする。
+
+    `isatty()` を持たない fake stream は False 扱い。
+    """
+    s = stream if stream is not None else sys.stdout
+    isatty = getattr(s, "isatty", None)
+    if isatty is None:
+        return False
+    try:
+        return bool(isatty())
+    except (ValueError, OSError):
+        # 閉じた stream / OSError は非 TTY 扱い
+        return False
+
+
+# ─── 進捗 1 行レンダラー ────────────────────────────────
+
+
+def render_progress_line(
+    *,
+    label: str,
+    elapsed: float,
+    expected_total: float | None = None,
+    tick: int = 0,
+) -> str:
+    """進捗 1 行を組み立てて返す（描画はしない）。
+
+    `expected_total` が指定されていれば「スピナー + ラベル + 経過 + 推定 % + ETA」、
+    未指定なら「スピナー + ラベル + 経過」だけを返す。
+
+    >>> render_progress_line(label="Veo 動画生成中", elapsed=30, expected_total=60, tick=0)
+    '⠋ Veo 動画生成中... 0m30s (≈50%, ETA ≈30s)'
+    >>> render_progress_line(label="Veo 動画生成中", elapsed=30, tick=0)
+    '⠋ Veo 動画生成中... 0m30s'
+    """
+    frame = spinner_frame(tick)
+    elapsed_fmt = format_elapsed(elapsed)
+    if expected_total and expected_total > 0:
+        progress = estimate_progress(elapsed, expected_total)
+        eta = estimate_eta(elapsed, expected_total)
+        pct = int(round(progress * 100))
+        eta_fmt = format_eta(eta)
+        return f"{frame} {label}... {elapsed_fmt} (≈{pct}%, ETA {eta_fmt})"
+    return f"{frame} {label}... {elapsed_fmt}"
+
+
+__all__ = [
+    "SPINNER_FRAMES",
+    "estimate_eta",
+    "estimate_progress",
+    "format_elapsed",
+    "format_eta",
+    "format_step",
+    "is_tty",
+    "render_progress_line",
+    "spinner_frame",
+]

--- a/src/youtube_automation/utils/veo_generator.py
+++ b/src/youtube_automation/utils/veo_generator.py
@@ -6,10 +6,12 @@ API 呼び出し・音声除去・クロスフェード補正の関数群。
 
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path
 
 from youtube_automation.utils import cost_tracker
+from youtube_automation.utils import progress as progress_fmt
 from youtube_automation.utils import veo_operation_store as op_store
 from youtube_automation.utils.profile import section
 
@@ -23,6 +25,27 @@ DEFAULT_PROMPT = (
 )
 POLL_INTERVAL_SEC = 5
 MAX_POLL_SEC = 600  # 10分タイムアウト
+
+# Veo 3.1 の典型生成時間（推定 ETA 用のヒューリスティック）。
+# API は真の進捗を返さないため、過去観測から得た典型値で「目安」を出す。
+# 実観測（fast/standard とも 8 秒尺で 60〜120 秒台）の中央値寄りに置く。
+_VEO_TYPICAL_SEC_PER_DURATION = 12.0  # 1 秒尺あたりの推定生成時間
+_VEO_TYPICAL_MIN_SEC = 60.0  # 最低でもこの程度はかかる（推定下限）
+
+# 非 TTY 環境向けに、進捗を行ごと出力するための間隔（秒）。
+# `\r` アニメではなく N 秒ごとに 1 行ずつログを出して CI ログを壊さない。
+_NON_TTY_LOG_INTERVAL_SEC = 30
+
+
+def _estimate_total_veo_seconds(duration_seconds: int | None) -> float:
+    """Veo の典型総生成時間（秒）を推定する。
+
+    `duration_seconds` が None の場合は最低値を返す。
+    """
+    if not duration_seconds or duration_seconds <= 0:
+        return _VEO_TYPICAL_MIN_SEC
+    estimated = duration_seconds * _VEO_TYPICAL_SEC_PER_DURATION
+    return max(estimated, _VEO_TYPICAL_MIN_SEC)
 
 
 def _is_unrecoverable_operation_error(exc: Exception) -> bool:
@@ -156,37 +179,80 @@ def _submit_operation(
     return operation
 
 
-def _wait_for_operation(client, operation, output_path: Path):
-    """operation 完了まで polling し、完了 operation を返す。"""
-    print("  [Wait]   動画生成中...", end="", flush=True)
+def _wait_for_operation(client, operation, output_path: Path, *, duration_seconds: int | None = None):
+    """operation 完了まで polling し、完了 operation を返す。
+
+    Issue #641: ドット列の代わりに「スピナー + 経過時間 + 推定進捗率/ETA」を
+    1 行更新（`\\r`）で表示する。Veo API は `operation.done`（真偽値）しか
+    返さないため、進捗率・ETA は典型生成時間からの**推定値**として表示する。
+    非 TTY 環境（CI / log redirect）では `\\r` アニメを抑止し、定期的な行
+    ごとの出力にフォールバックする。
+    """
+    expected_total = _estimate_total_veo_seconds(duration_seconds)
+    tty = progress_fmt.is_tty(sys.stdout)
+    label = "Veo 動画生成中（推定）"
+
+    print(f"  {progress_fmt.format_step(1, 3, '生成中（Veo polling）')}")
     start = time.monotonic()
+    tick = 0
+    last_log_sec = -1  # 非 TTY 用、最後に行出力した秒
     with section("veo.poll_total", interval_sec=POLL_INTERVAL_SEC):
         try:
             while not operation.done:
                 elapsed = time.monotonic() - start
                 if elapsed > MAX_POLL_SEC:
-                    print(f"\n  [ERROR]  タイムアウト ({MAX_POLL_SEC}秒)")
+                    if tty:
+                        sys.stdout.write("\r" + " " * 80 + "\r")
+                        sys.stdout.flush()
+                    print(f"  [ERROR]  タイムアウト ({MAX_POLL_SEC}秒)")
                     return None
-                print(".", end="", flush=True)
+
+                line = progress_fmt.render_progress_line(
+                    label=label,
+                    elapsed=elapsed,
+                    expected_total=expected_total,
+                    tick=tick,
+                )
+                if tty:
+                    sys.stdout.write("\r  " + line + "   ")
+                    sys.stdout.flush()
+                else:
+                    # 非 TTY: N 秒ごとに 1 行出力（CI ログを壊さない）
+                    bucket = int(elapsed) // _NON_TTY_LOG_INTERVAL_SEC
+                    if bucket != last_log_sec:
+                        print(f"  {line}")
+                        last_log_sec = bucket
+
                 time.sleep(POLL_INTERVAL_SEC)
+                tick += 1
                 try:
                     with section("veo.operations_get"):
                         operation = client.operations.get(operation)
                 except KeyboardInterrupt:
                     raise
                 except Exception as exc:
+                    if tty:
+                        sys.stdout.write("\r" + " " * 80 + "\r")
+                        sys.stdout.flush()
                     _handle_operations_get_error(exc, output_path)
                     return None
         except KeyboardInterrupt:
+            if tty:
+                sys.stdout.write("\r" + " " * 80 + "\r")
+                sys.stdout.flush()
             _print_interrupt_messages(output_path)
             return None
     elapsed = time.monotonic() - start
-    print(f" 完了 ({elapsed:.0f}秒)")
+    if tty:
+        sys.stdout.write("\r" + " " * 80 + "\r")
+        sys.stdout.flush()
+    print(f"  [Wait]   動画生成完了 ({progress_fmt.format_elapsed(elapsed)})")
     return operation
 
 
 def _persist_generated_video(operation, output_path: Path) -> bool:
     """生成済み動画を output_path へ保存する。"""
+    print(f"  {progress_fmt.format_step(2, 3, '保存中（バイト列を MP4 へ書き出し）')}")
     if not operation.response or not operation.response.generated_videos:
         print("  [ERROR]  動画が生成されませんでした")
         op_store.clear(output_path)
@@ -200,6 +266,8 @@ def _persist_generated_video(operation, output_path: Path) -> bool:
         op_store.clear(output_path)
         return False
     output_path.write_bytes(video_bytes)
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+    print(f"  [Save]   保存完了 → {output_path.name} ({size_mb:.1f} MB)")
     return True
 
 
@@ -215,6 +283,7 @@ def _finalize_generated_video(
     compression が有効なら libx264 再エンコードで音声除去も同時に行うため
     `strip_audio` の stream copy パスを skip し、ffmpeg 起動を 1 回に集約する。
     """
+    print(f"  {progress_fmt.format_step(3, 3, '後処理（圧縮 / 音声除去）')}")
     if compression and compression.get("enabled", True):
         compress_loop(
             output_path,
@@ -224,7 +293,7 @@ def _finalize_generated_video(
     else:
         strip_audio(output_path)
     size_mb = output_path.stat().st_size / (1024 * 1024)
-    print(f"  [Done]   保存完了 → {output_path} ({size_mb:.1f} MB)")
+    print(f"  [Done]   完成 → {output_path} ({size_mb:.1f} MB)")
 
     entry = cost_tracker.log_generation(
         "video",
@@ -280,7 +349,7 @@ def generate_loop_video(
         if operation is None:
             return False
 
-    operation = _wait_for_operation(client, operation, output_path)
+    operation = _wait_for_operation(client, operation, output_path, duration_seconds=duration_seconds)
     if operation is None:
         return False
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,200 @@
+"""utils.progress の単体テスト（Issue #641）。
+
+進捗フォーマット純粋関数（spinner / elapsed / ETA / 推定進捗率 /
+1 行レンダラー / TTY 判定）の動作と境界値を担保する。
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from youtube_automation.utils import progress
+
+# ---------- spinner_frame ----------
+
+
+class TestSpinnerFrame:
+    def test_first_frame(self) -> None:
+        assert progress.spinner_frame(0) == progress.SPINNER_FRAMES[0]
+
+    def test_wraps_around(self) -> None:
+        n = len(progress.SPINNER_FRAMES)
+        assert progress.spinner_frame(n) == progress.spinner_frame(0)
+        assert progress.spinner_frame(n + 3) == progress.spinner_frame(3)
+
+    def test_handles_negative_tick(self) -> None:
+        # 負数は modulo で末尾に巻く（Python の % は数学的剰余）
+        n = len(progress.SPINNER_FRAMES)
+        assert progress.spinner_frame(-1) == progress.SPINNER_FRAMES[n - 1]
+
+
+# ---------- format_elapsed ----------
+
+
+class TestFormatElapsed:
+    @pytest.mark.parametrize(
+        "secs,expected",
+        [
+            (0, "0m00s"),
+            (5, "0m05s"),
+            (59, "0m59s"),
+            (60, "1m00s"),
+            (65, "1m05s"),
+            (599, "9m59s"),
+            (3600, "1h00m00s"),
+            (3725, "1h02m05s"),
+        ],
+    )
+    def test_formats_known_durations(self, secs: int, expected: str) -> None:
+        assert progress.format_elapsed(secs) == expected
+
+    def test_clamps_negative_to_zero(self) -> None:
+        assert progress.format_elapsed(-5) == "0m00s"
+
+    def test_accepts_float(self) -> None:
+        # 小数部は切り捨て（int(seconds)）
+        assert progress.format_elapsed(65.9) == "1m05s"
+
+
+# ---------- format_eta ----------
+
+
+class TestFormatEta:
+    def test_none_renders_dashes(self) -> None:
+        assert progress.format_eta(None) == "--"
+
+    def test_zero_or_negative_renders_dashes(self) -> None:
+        assert progress.format_eta(0) == "--"
+        assert progress.format_eta(-3) == "--"
+
+    @pytest.mark.parametrize(
+        "secs,expected",
+        [
+            (1, "≈1s"),
+            (45, "≈45s"),
+            (59, "≈59s"),
+            (60, "≈1m00s"),
+            (125, "≈2m05s"),
+        ],
+    )
+    def test_includes_approximation_prefix(self, secs: int, expected: str) -> None:
+        assert progress.format_eta(secs) == expected
+
+    def test_rounds_float(self) -> None:
+        assert progress.format_eta(44.4) == "≈44s"
+        assert progress.format_eta(44.6) == "≈45s"
+
+
+# ---------- estimate_progress ----------
+
+
+class TestEstimateProgress:
+    def test_zero_elapsed_returns_zero(self) -> None:
+        assert progress.estimate_progress(0, 60) == 0.0
+
+    def test_midway(self) -> None:
+        assert progress.estimate_progress(30, 60) == pytest.approx(0.5)
+
+    def test_caps_at_99_percent_when_at_or_above_expected(self) -> None:
+        # API 完了通知を待つ間に 100% と誤解させないため上限 0.99
+        assert progress.estimate_progress(60, 60) == pytest.approx(0.99)
+        assert progress.estimate_progress(120, 60) == pytest.approx(0.99)
+
+    def test_expected_total_zero_returns_zero(self) -> None:
+        assert progress.estimate_progress(10, 0) == 0.0
+        assert progress.estimate_progress(10, -5) == 0.0
+
+    def test_negative_elapsed_treated_as_zero(self) -> None:
+        assert progress.estimate_progress(-5, 60) == 0.0
+
+
+# ---------- estimate_eta ----------
+
+
+class TestEstimateEta:
+    def test_returns_remaining(self) -> None:
+        assert progress.estimate_eta(0, 60) == 60.0
+        assert progress.estimate_eta(30, 60) == 30.0
+
+    def test_none_when_at_or_above_expected(self) -> None:
+        assert progress.estimate_eta(60, 60) is None
+        assert progress.estimate_eta(120, 60) is None
+
+    def test_none_when_expected_total_zero(self) -> None:
+        assert progress.estimate_eta(10, 0) is None
+        assert progress.estimate_eta(10, -1) is None
+
+
+# ---------- format_step ----------
+
+
+class TestFormatStep:
+    def test_basic(self) -> None:
+        assert progress.format_step(1, 3, "Generating") == "[Step 1/3] Generating"
+
+    def test_arbitrary_step_index(self) -> None:
+        assert progress.format_step(2, 5, "Saving") == "[Step 2/5] Saving"
+
+
+# ---------- is_tty ----------
+
+
+class TestIsTty:
+    def test_stringio_is_not_tty(self) -> None:
+        # io.StringIO は isatty() を持つが False を返す
+        assert progress.is_tty(io.StringIO()) is False
+
+    def test_stream_without_isatty(self) -> None:
+        # `object()` は isatty 属性を持たない
+        assert progress.is_tty(object()) is False  # type: ignore[arg-type]
+
+    def test_stream_whose_isatty_returns_true(self) -> None:
+        class FakeTty:
+            def isatty(self) -> bool:
+                return True
+
+        assert progress.is_tty(FakeTty()) is True  # type: ignore[arg-type]
+
+    def test_stream_with_oserror_isatty(self) -> None:
+        class BrokenStream:
+            def isatty(self) -> bool:
+                raise OSError("closed")
+
+        # OSError は非 TTY 扱いで落ちない
+        assert progress.is_tty(BrokenStream()) is False  # type: ignore[arg-type]
+
+
+# ---------- render_progress_line ----------
+
+
+class TestRenderProgressLine:
+    def test_without_expected_total(self) -> None:
+        line = progress.render_progress_line(label="Veo 動画生成中", elapsed=30, tick=0)
+        # スピナー + ラベル + 経過時間
+        assert line.startswith(progress.SPINNER_FRAMES[0])
+        assert "Veo 動画生成中..." in line
+        assert "0m30s" in line
+        # expected_total なしのときは % / ETA は出さない
+        assert "ETA" not in line
+        assert "%" not in line
+
+    def test_with_expected_total(self) -> None:
+        line = progress.render_progress_line(label="Veo 動画生成中", elapsed=30, expected_total=60, tick=0)
+        assert "0m30s" in line
+        # 進捗率の頭に "≈" が付き、推定値である旨を明示している
+        assert "≈50%" in line or "≈49%" in line or "≈51%" in line
+        assert "ETA" in line
+
+    def test_caps_progress_display_below_100(self) -> None:
+        # expected_total 到達時でも 100% は表示しない（99% 上限）
+        line = progress.render_progress_line(label="Veo 動画生成中", elapsed=120, expected_total=60, tick=0)
+        assert "≈99%" in line
+        # ETA は "--" にフォールバック
+        assert "--" in line
+
+    def test_tick_advances_spinner(self) -> None:
+        line0 = progress.render_progress_line(label="x", elapsed=1, tick=0)
+        line1 = progress.render_progress_line(label="x", elapsed=1, tick=1)
+        assert line0[0] != line1[0]

--- a/tests/test_veo_generator.py
+++ b/tests/test_veo_generator.py
@@ -619,6 +619,49 @@ class TestGenerateLoopVideoKeyboardInterrupt:
         assert state is not None
         assert state["operation_name"] == "projects/veo/interrupt-op"
 
+    def test_displays_spinner_and_estimated_progress_during_polling(
+        self, channel_tmp: Path, output_mp4: Path, monkeypatch, capsys
+    ) -> None:
+        """Issue #641: ポーリング中の表示にステップと推定 ETA が含まれる。
+
+        非 TTY 環境（capsys 経由）では \\r アニメではなく行ごとの出力に
+        フォールバックする経路を踏むため、stdout に `Veo 動画生成中（推定）`
+        を含む 1 行が少なくとも 1 度は出力される。
+        """
+        mock_types = _patch_genai_types(monkeypatch)
+        client = MagicMock()
+        # 1 回 polling して done になる operation
+        submitted_op = MagicMock()
+        submitted_op.name = "projects/veo/progress-op"
+        submitted_op.done = False
+        client.models.generate_videos.return_value = submitted_op
+
+        done_op = _make_done_operation("projects/veo/progress-op")
+        client.operations.get.return_value = done_op
+        mock_types.GenerateVideosOperation.return_value = MagicMock(name="projects/veo/progress-op", done=False)
+
+        with patch.multiple(
+            "youtube_automation.utils.veo_generator",
+            strip_audio=MagicMock(),
+            cost_tracker=MagicMock(),
+        ):
+            with patch("time.sleep"):
+                veo_generator.generate_loop_video(
+                    client,
+                    output_mp4.parent / "main.png",
+                    output_mp4,
+                    model="veo-3.1-fast",
+                    prompt="test prompt",
+                )
+
+        out = capsys.readouterr().out
+        # ステップ表示が含まれる
+        assert "[Step 1/3]" in out
+        assert "[Step 2/3]" in out
+        assert "[Step 3/3]" in out
+        # 動画生成完了メッセージが新フォーマット（progress.format_elapsed）で出る
+        assert "動画生成完了" in out
+
     def test_prints_interrupt_resume_state_messages(
         self, channel_tmp: Path, output_mp4: Path, monkeypatch, capsys
     ) -> None:


### PR DESCRIPTION
## Summary

動画生成時の進捗表示を Veo / ffmpeg 双方で改善した（Closes #641）。

- **Veo ループ動画生成** (`veo_generator._wait_for_operation`): ドット列のままだったポーリング表示を「スピナー + 経過時間 + 推定進捗率 / ETA」の 1 行更新表示に置き換えた。Veo API は `operation.done` 真偽値しか返さないため、進捗率 / ETA は典型生成時間（1 秒尺あたり 12 秒 + 下限 60 秒）からの**推定値**として表示し `≈` prefix で推定であることを明示する。`MAX_POLL_SEC` 到達時の挙動は現状踏襲。
- **ステップ表示**: Veo 生成フロー全体を `[Step 1/3] 生成中（Veo polling）` → `[Step 2/3] 保存中（バイト列を MP4 へ書き出し）` → `[Step 3/3] 後処理（圧縮 / 音声除去）` の 3 ステップで明示。`generate_videos.sh` 側も `[Step N/M]` のステップ行を追加（loop モードは正規化 + 生成の 2 ステップ、静止画モードは 1 ステップ）。
- **`generate_videos.sh`**: 既存スピナー + パーセンテージに加え ETA 表示を追加。
- **進捗フォーマット**: 経過時間 / ETA / スピナー / 推定進捗率 / 1 行レンダラーを `src/youtube_automation/utils/progress.py` の純粋関数として切り出し、`tests/test_progress.py` に 39 ケースのユニットテストを追加（39 件 green）。
- **非 TTY フォールバック**: CI / log redirect 環境では `\r` アニメを抑止し行ごとの出力にフォールバックする。Python 側は `progress.is_tty(sys.stdout)`、bash 側は `[[ -t 1 ]]` で判定。bash の非 TTY 経路は 10% 刻みで 1 行ずつログ出力する。

## Test plan

- [x] `tests/test_progress.py` 39 件 green
- [x] `tests/test_veo_generator.py` 40 件 green（既存 39 件 + 進捗表示の出力検証 1 件追加）
- [x] `tests/test_generate_videos_script.py` 3 件 green
- [x] `bash -n` で `generate_videos.sh` のシンタックスチェック OK
- [x] ruff check / ruff format 適合

## Acceptance criteria

- [x] Veo ループ動画生成中、経過時間とスピナーが 1 行更新で表示される
- [x] Veo の進捗率 / ETA が推定値として表示される（`≈` prefix）
- [x] ffmpeg 生成にスピナー / ステップ表示が追加されている
- [x] 進捗フォーマット純粋関数のユニットテストが追加され green
- [x] 非 TTY 環境で `\r` アニメが抑止される

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)