### PR TITLE
feat(videoup): 映像エフェクトプリセット 3 種（光の粒子・ボケ・グラデーション）を追加 (#648)

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -74,6 +74,46 @@ $ARGUMENTS
 - master 尺 ≥ `target_video_duration_min × 60` のときは無視され従来動作になる (master 尺が支配)
 - 音声 loop seam の crossfade は本機能のスコープ外 (将来拡張)
 
+## 映像エフェクト (#648)
+
+ループ動画背景・静止画背景のどちらでも、画面に **光の粒子**・**ボケ**・**グラデーション流れ** などのエフェクトを重ねられる。動画編集ソフトの「画面を彩るレイヤー効果」を ffmpeg filtergraph だけで再現する MVP 機構。
+
+### エフェクト一覧
+
+| `VIDEOUP_EFFECT` | 効果 | 想定用途 |
+|---|---|---|
+| `none` (デフォルト) | エフェクトなし。ループは stream copy、静止画は従来 libx264 経路 | 既存挙動の温存。コスト・容量を最小化したいとき |
+| `particles` | 光の粒子（淡い白点が画面をゆっくり流れる） | 落ち着いた BGM・夜景・キラキラ系のサムネ |
+| `bokeh` | ボケ（柔らかな円形グラデーションがゆらぐ） | カフェ系・暖色系ジャズ・ロウソク系のサムネ |
+| `gradient` | グラデーション流れ（半透明のカラーグラデーションが上下にうごく） | ローファイヒップホップ・シティポップ・夜の街並み |
+
+強度は `VIDEOUP_EFFECT_INTENSITY` で `subtle` / `medium` / `strong` から選ぶ（デフォルト `subtle`）。BGM 視聴の邪魔をしないよう **subtle 推奨**。`strong` は短時間のテイスター動画やショート向け。
+
+### 使い方
+
+```bash
+# 例 1: ループ動画背景に「光の粒子（控えめ）」を重ねる
+VIDEOUP_EFFECT=particles VIDEOUP_EFFECT_INTENSITY=subtle \
+  bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh"
+
+# 例 2: 静止画背景に「ボケ（中程度）」を重ねる
+VIDEOUP_EFFECT=bokeh VIDEOUP_EFFECT_INTENSITY=medium \
+  bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" \
+  collections/planning/20260601-001-lofi-jazz-collection
+```
+
+### 挙動と注意点
+
+- **エフェクト有効時はループモードでも stream copy ではなく libx264 再エンコードに切り替わる**。ファイルサイズは数% 増えるが、CRF 22 / `LOOP_MAX_BITRATE` ガードで肥大化を抑える
+- 静止画モードもエフェクト有効時は 24fps で書き出すため、ファイルサイズが従来（1fps）より大きくなる。**長尺の場合は静止画 + エフェクトより、ループ動画 + エフェクトを推奨**
+- 不正な値（例: `VIDEOUP_EFFECT=sparkle`）は **fail-loud で停止**。ffmpeg が走り始める前にエラーとなる
+- 値検証は bash で完結しているため、`set -e` を使わずとも安全
+- エフェクトをチャンネルデフォルトにしたい場合は、当面はチャンネル側ラッパースクリプトや shell alias で `export VIDEOUP_EFFECT=...` を呼ぶ運用とする（skill-config 化は follow-up）
+
+### 動作確認
+
+実コレクションで生成した動画は YouTube Studio のプレビュー（モバイル・PC）と実機 YouTube 視聴で粒子・ボケ・グラデーションが**音楽の邪魔にならない強度で乗っているか**を必ず確認すること。BGM チャンネルのコア視聴体験を壊さないことが優先事項。
+
 ## 長時間処理の取り扱い
 
 `generate_videos.sh` は ffmpeg を走らせるため **1〜10 分程度**（コレクション尺次第）かかる。**必ず Bash ツールを `run_in_background=true` で起動する**。これによりユーザーは処理中も同じセッションで質問できる（Claude Code は完了時に自動でメッセージ通知するため、`sleep` ループや `until` での自前ポーリングは禁止）。
@@ -81,7 +121,13 @@ $ARGUMENTS
 spawn 例:
 
 ```bash
+# エフェクト無しの基本パターン
 bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" \
+  > /tmp/videoup-$(date +%s).log 2>&1
+
+# エフェクト付き（#648）
+VIDEOUP_EFFECT=particles VIDEOUP_EFFECT_INTENSITY=subtle \
+  bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" \
   > /tmp/videoup-$(date +%s).log 2>&1
 ```
 

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -4,17 +4,30 @@
 # v12.1: ループモードの高ビットレート入力を上限付き正規化に退避
 # v12.2: 短尺 master を音声側 stream_loop で動画尺に伸ばす opt-in 経路を追加 (#545)
 # v12.3: master-mix.* に加えて lyria/masterup 出力の master.* も検出 (#507)
+# v12.4: 映像エフェクト (光の粒子 / ボケ / グラデーション流れ) のオプション追加 (#648)
 #
 # Usage:
 #   bash .claude/skills/videoup/references/generate_videos.sh <collection-path>
 #   cd <collection-dir> && bash <repo-root>/.claude/skills/videoup/references/generate_videos.sh
 #
-# Opt-in env var:
+# Opt-in env vars (#545):
 #   VIDEOUP_AUDIO_TARGET_VIDEO_DURATION_MIN
 #     動画側ターゲット尺 (分)。設定時は音声入力にも -stream_loop -1 を適用し
 #     -t で動画長を強制する。チャンネル側で config/skills/videoup.yaml に
 #     audio.target_video_duration_min を置いても同等 (env が優先)。
 #     master 尺 ≥ target のときは従来動作 (master 尺が支配)。
+#
+# Environment variables (#648):
+#   VIDEOUP_EFFECT            none | particles | bokeh | gradient   (default: none)
+#       none      : エフェクトなし（ループ動画は stream copy、静止画は従来の libx264 経路）
+#       particles : 光の粒子（淡い白点が画面をゆっくり流れる）
+#       bokeh     : ボケ（柔らかな円形グラデーションがゆらぐ）
+#       gradient  : グラデーション流れ（半透明のカラーグラデーションが上下にうごく）
+#   VIDEOUP_EFFECT_INTENSITY  subtle | medium | strong               (default: subtle)
+#       透明度・密度をコントロール。基本は subtle 推奨（BGM 視聴の邪魔をしない）
+#
+# エフェクト有効時、ループ動画背景モードは stream copy ではなく libx264 再エンコードに切り替わる。
+# 詳細は .claude/skills/videoup/SKILL.md を参照。
 
 # ─── Collection Path Resolution ──────────────────────────
 COLLECTION_DIR="${1:-}"
@@ -75,6 +88,81 @@ LOOP_TARGET_FRAME_RATE="24/1"
 LOOP_OUTPUT_FRAME_RATE="24"
 LOOP_MAX_BITRATE="6000k"
 LOOP_BUFSIZE="12000k"
+
+# ─── Video Effects (#648) ────────────────────────────────
+# VIDEOUP_EFFECT / VIDEOUP_EFFECT_INTENSITY を読み取り、ffmpeg filtergraph を構築する
+EFFECT="${VIDEOUP_EFFECT:-none}"
+EFFECT_INTENSITY="${VIDEOUP_EFFECT_INTENSITY:-subtle}"
+
+# 値検証
+case "$EFFECT" in
+    none|particles|bokeh|gradient) ;;
+    *)
+        echo "ERROR: Unknown VIDEOUP_EFFECT='$EFFECT' (allowed: none, particles, bokeh, gradient)"
+        exit 1
+        ;;
+esac
+case "$EFFECT_INTENSITY" in
+    subtle|medium|strong) ;;
+    *)
+        echo "ERROR: Unknown VIDEOUP_EFFECT_INTENSITY='$EFFECT_INTENSITY' (allowed: subtle, medium, strong)"
+        exit 1
+        ;;
+esac
+
+# intensity → 透明度 (低いほど目立たない)
+# particles: 粒の密度・明度に効く / bokeh: 円のコントラストに効く / gradient: alpha に効く
+case "$EFFECT_INTENSITY" in
+    subtle) EFFECT_ALPHA="0.10" ;;
+    medium) EFFECT_ALPHA="0.20" ;;
+    strong) EFFECT_ALPHA="0.35" ;;
+esac
+
+# 1920x1080 / 24fps を前提とした filtergraph を組み立てる
+# 第 1 引数 = 入力ビデオストリームのラベル（例: "0:v" や "scaled"）
+# 出力は [vout] 固定
+build_effect_filter() {
+    local input_label="$1"
+    case "$EFFECT" in
+        none)
+            echo ""
+            ;;
+        particles)
+            # 光の粒子: ランダムドットを生成 → 上下に slow scroll → 元映像へオーバーレイ
+            echo "[${input_label}]format=yuv420p,setsar=1[bg];\
+color=c=black:s=1920x2160:r=24:d=1,format=yuv420p,\
+noise=alls=80:allf=t+u,\
+geq=lum='if(gt(lum(X,Y),230),255,0)':a='if(gt(lum(X,Y),230),${EFFECT_ALPHA}*255,0)',\
+loop=loop=-1:size=1:start=0,\
+crop=1920:1080:0:'mod(t*30,1080)'[fx];\
+[bg][fx]overlay=0:0:format=auto,format=yuv420p[vout]"
+            ;;
+        bokeh)
+            # ボケ: 色付きドットを巨大スケール + gblur で円形ぼかし → ゆっくり揺れる動き
+            # noise alls は 0-100 範囲制約があるため上限内に収める
+            echo "[${input_label}]format=yuv420p,setsar=1[bg];\
+color=c=0xffe8b0:s=240x135:r=24:d=1,format=yuv420p,\
+noise=alls=100:allf=t+u,\
+geq=lum='if(gt(lum(X,Y),240),255,0)':a='if(gt(lum(X,Y),240),${EFFECT_ALPHA}*255,0)',\
+loop=loop=-1:size=1:start=0,\
+scale=1920:1080:flags=lanczos,\
+gblur=sigma=18[fx];\
+[bg][fx]overlay='40*sin(t/3)':'30*cos(t/4)':format=auto,format=yuv420p[vout]"
+            ;;
+        gradient)
+            # グラデーション流れ: カラーグラデーションを上下にゆっくり流す
+            echo "[${input_label}]format=yuv420p,setsar=1[bg];\
+gradients=s=1920x2160:c0=0x1a3a8a:c1=0xff8a3a:r=24:duration=120:type=linear,\
+crop=1920:1080:0:'mod(t*15,1080)',\
+format=yuva420p,\
+geq=r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':a='${EFFECT_ALPHA}*255'[fx];\
+[bg][fx]overlay=0:0:format=auto,format=yuv420p[vout]"
+            ;;
+    esac
+}
+
+EFFECT_FILTER_LOOP="$(build_effect_filter "0:v")"
+EFFECT_FILTER_STATIC="scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2[scaled];$(build_effect_filter "scaled")"
 
 # ─── Audio encoder 自動選択 (macOS は AudioToolbox 優先) ─
 if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
@@ -184,6 +272,9 @@ else
 fi
 echo "  Audio    : $(basename "$MASTER_AUDIO")"
 echo "  Output   : $(basename "$MASTER_OUTPUT")"
+if [[ "$EFFECT" != "none" ]]; then
+    echo "  Effect   : $EFFECT (intensity=$EFFECT_INTENSITY, alpha=$EFFECT_ALPHA)"
+fi
 
 duration="$(get_duration "$MASTER_AUDIO")"
 
@@ -308,39 +399,77 @@ if [[ -n "$LOOP_VIDEO" ]]; then
         fi
     fi
 
-    echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (stream copy)"
-    # Stream copy 経路: ビデオは完全無損失（ビット単位コピー）、音声は AUDIO_OUT_OPTS に従う
-    # AUDIO_INPUT_OPTS は target_video_duration_min 設定時のみ -stream_loop -1 を持つ (#545)
-    ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" \
-        "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
-        -map 0:v:0 -map 1:a:0 \
-        -c:v copy \
-        "${AUDIO_OUT_OPTS[@]}" \
-        -t "$video_duration" \
-        -movflags +faststart \
-        -shortest \
-        -loglevel error \
-        -progress "$PROGRESS_FILE" \
-        "$MASTER_OUTPUT" &
+    if [[ "$EFFECT" == "none" ]]; then
+        echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (stream copy)"
+        # Stream copy 経路: ビデオは完全無損失（ビット単位コピー）、音声は AUDIO_OUT_OPTS に従う
+        # AUDIO_INPUT_OPTS は target_video_duration_min 設定時のみ -stream_loop -1 を持つ (#545)
+        ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" \
+            "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
+            -map 0:v:0 -map 1:a:0 \
+            -c:v copy \
+            "${AUDIO_OUT_OPTS[@]}" \
+            -t "$video_duration" \
+            -movflags +faststart \
+            -shortest \
+            -loglevel error \
+            -progress "$PROGRESS_FILE" \
+            "$MASTER_OUTPUT" &
+    else
+        echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (loop + ${EFFECT} effect)"
+        # エフェクト有効: ループ素材を libx264 で再エンコードしながら filtergraph をオーバーレイ (#648)
+        # 容量増を抑えるため CRF 22 / preset medium / maxrate ガードを共通定数と揃える
+        ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" \
+            "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
+            -filter_complex "$EFFECT_FILTER_LOOP" \
+            -map "[vout]" -map 1:a:0 \
+            -c:v libx264 -preset medium -crf 22 -maxrate "$LOOP_MAX_BITRATE" -bufsize "$LOOP_BUFSIZE" -pix_fmt yuv420p \
+            -r "$LOOP_OUTPUT_FRAME_RATE" \
+            "${AUDIO_OUT_OPTS[@]}" \
+            -t "$video_duration" \
+            -movflags +faststart \
+            -shortest \
+            -loglevel error \
+            -progress "$PROGRESS_FILE" \
+            "$MASTER_OUTPUT" &
+    fi
 else
-    echo "  [Step 1/1] Generating master video (still image)"
-    # 静止画背景モード（従来）
-    # I-frame を 5 分間隔（1fps なので 300 フレーム）に間引き、変化のないフレームを P-frame で
-    # 圧縮することで master.mp4 を大幅に小型化する（#579）。keyint=1 全 I-frame 化は容量が膨らむため廃止。
-    # AUDIO_INPUT_OPTS は target_video_duration_min 設定時のみ -stream_loop -1 を持つ (#545)
-    ffmpeg -y -framerate 1 -loop 1 -i "$THUMBNAIL" \
-        "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
-        -c:v libx264 -tune stillimage -preset medium -crf 28 -pix_fmt yuv420p \
-        -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
-        -g 300 \
-        -r 1 \
-        "${AUDIO_OUT_OPTS[@]}" \
-        -t "$video_duration" \
-        -movflags +faststart \
-        -shortest \
-        -loglevel error \
-        -progress "$PROGRESS_FILE" \
-        "$MASTER_OUTPUT" &
+    if [[ "$EFFECT" == "none" ]]; then
+        echo "  [Step 1/1] Generating master video (still image)"
+        # 静止画背景モード（従来）
+        # I-frame を 5 分間隔（1fps なので 300 フレーム）に間引き、変化のないフレームを P-frame で
+        # 圧縮することで master.mp4 を大幅に小型化する（#579）。keyint=1 全 I-frame 化は容量が膨らむため廃止。
+        # AUDIO_INPUT_OPTS は target_video_duration_min 設定時のみ -stream_loop -1 を持つ (#545)
+        ffmpeg -y -framerate 1 -loop 1 -i "$THUMBNAIL" \
+            "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
+            -c:v libx264 -tune stillimage -preset medium -crf 28 -pix_fmt yuv420p \
+            -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
+            -g 300 \
+            -r 1 \
+            "${AUDIO_OUT_OPTS[@]}" \
+            -t "$video_duration" \
+            -movflags +faststart \
+            -shortest \
+            -loglevel error \
+            -progress "$PROGRESS_FILE" \
+            "$MASTER_OUTPUT" &
+    else
+        echo "  [Step 1/1] Generating master video (still image + ${EFFECT} effect)"
+        # エフェクト有効: 静止画背景を 24fps で再エンコードしながら filtergraph をオーバーレイ (#648)
+        # 静止画モードは映像が動かないため、エフェクトを目立たせるには 24fps で書き出す必要がある
+        ffmpeg -y -framerate 24 -loop 1 -i "$THUMBNAIL" \
+            "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
+            -filter_complex "$EFFECT_FILTER_STATIC" \
+            -map "[vout]" -map 1:a:0 \
+            -c:v libx264 -preset medium -crf 24 -pix_fmt yuv420p \
+            -r 24 \
+            "${AUDIO_OUT_OPTS[@]}" \
+            -t "$video_duration" \
+            -movflags +faststart \
+            -shortest \
+            -loglevel error \
+            -progress "$PROGRESS_FILE" \
+            "$MASTER_OUTPUT" &
+    fi
 fi
 ffmpeg_pid=$!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(videoup)`: `generate_videos.sh` のマスター音源検出パターンを拡張し、`/lyria` / `/masterup`（`yt-generate-master`）の自動生成出力である `master.{wav,m4a,aac,mp3,flac}` も検出対象に追加した（#507）。従来は `master-mix.{wav,m4a,aac,mp3,flac}` のみだったため、`/lyria` で `master.wav` を出力した直後に `/videoup` を起動すると `ERROR: master-mix.{wav,m4a,aac,mp3,flac} not found` で停止していた問題を解消（採用方針 (a) — skill 単体完結、`src/` 側のファイル名は据え置き）。検出順は `master-mix.*`（DAW バウンス・手動配置を優先）→ `master.*`（自動生成）、拡張子は wav / m4a / aac / mp3 / flac の順。両方存在する場合は `master-mix.*` を優先（テスト `test_master_mix_takes_precedence_over_master` で固定化）。`.claude/skills/videoup/SKILL.md` のステップ・自動検出記述と `src/youtube_automation/utils/audio_formats.py` の docstring も新パターンに合わせて更新
+- `feat(videoup)`: `generate_videos.sh` に映像エフェクトプリセット 3 種（光の粒子 / ボケ / グラデーション流れ）を追加した（#648 / feedback by あおいさん）。環境変数 `VIDEOUP_EFFECT=none|particles|bokeh|gradient` と `VIDEOUP_EFFECT_INTENSITY=subtle|medium|strong` で選択でき、デフォルトは `none` で従来挙動を完全に温存する（ループは stream copy のまま、静止画は 1fps libx264 のまま）。エフェクト有効時はループモードでも libx264 再エンコード（CRF 22 / `LOOP_MAX_BITRATE` ガード継続）に自動で切り替わり、静止画モードも 24fps 出力に切り替わる。filtergraph は ffmpeg 単体で完結（外部依存なし）、不正な値は ffmpeg 起動前に fail-loud で停止する。詳細・使い方・注意点は `.claude/skills/videoup/SKILL.md` 「映像エフェクト」節、テストは `tests/test_generate_videos_script.py` の `test_*_effect_*` を参照。skill-config 化（チャンネル既定値のファイル設定化）は follow-up
 
 ### Changed
 

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -112,9 +112,12 @@ def _run_generate_videos(
     extra_env: dict[str, str] | None = None,
     collection: Path | None = None,
     master_filename: str = "master-mix.wav",
+    with_loop: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     if collection is None:
         collection = _create_collection(tmp_path, master_filename=master_filename)
+    if not with_loop:
+        (collection / "10-assets" / "loop.mp4").unlink()
     bin_dir = _create_stub_bin(tmp_path)
     ffmpeg_log = tmp_path / "ffmpeg.log"
     env = os.environ.copy()
@@ -375,3 +378,107 @@ def test_master_mix_takes_precedence_over_master(tmp_path: Path) -> None:
     assert len(commands) == 1
     assert "01-master/master-mix.wav" in commands[0]
     assert "01-master/master.mp3" not in commands[0]
+
+
+# ─── Video Effects (#648) ────────────────────────────────
+
+
+def test_default_effect_none_uses_stream_copy_for_loop(tmp_path: Path) -> None:
+    """エフェクト未指定（デフォルト=none）ではループモードは stream copy のままで挙動が温存される。"""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+    )
+    assert result.returncode == 0, result.stderr
+    final_cmd = ffmpeg_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert "-c:v copy" in final_cmd
+    assert "-filter_complex" not in final_cmd
+
+
+def test_particles_effect_switches_to_libx264_with_filter_complex(tmp_path: Path) -> None:
+    """particles 指定でループ素材を libx264 再エンコード + filtergraph に切り替わる。"""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={"VIDEOUP_EFFECT": "particles"},
+    )
+    assert result.returncode == 0, result.stderr
+    final_cmd = ffmpeg_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert "-filter_complex" in final_cmd
+    assert "[vout]" in final_cmd
+    assert "-c:v libx264" in final_cmd
+    assert "-c:v copy" not in final_cmd
+    # subtle (default) は alpha=0.10
+    assert "0.10*255" in final_cmd
+
+
+def test_bokeh_effect_uses_gblur(tmp_path: Path) -> None:
+    """bokeh エフェクトでは gblur フィルタが使われる。"""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={"VIDEOUP_EFFECT": "bokeh", "VIDEOUP_EFFECT_INTENSITY": "medium"},
+    )
+    assert result.returncode == 0, result.stderr
+    final_cmd = ffmpeg_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert "gblur" in final_cmd
+    # medium は alpha=0.20
+    assert "0.20*255" in final_cmd
+
+
+def test_gradient_effect_uses_gradients_source(tmp_path: Path) -> None:
+    """gradient エフェクトでは gradients ソースが filtergraph に含まれる。"""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={"VIDEOUP_EFFECT": "gradient", "VIDEOUP_EFFECT_INTENSITY": "strong"},
+    )
+    assert result.returncode == 0, result.stderr
+    final_cmd = ffmpeg_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert "gradients=" in final_cmd
+    # strong は alpha=0.35
+    assert "0.35*255" in final_cmd
+
+
+def test_static_image_with_effect_uses_filter_complex(tmp_path: Path) -> None:
+    """静止画モード + エフェクトでも filter_complex 経路に乗る。"""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"VIDEOUP_EFFECT": "particles"},
+        with_loop=False,
+    )
+    assert result.returncode == 0, result.stderr
+    final_cmd = ffmpeg_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert "-filter_complex" in final_cmd
+    assert "[vout]" in final_cmd
+    # 静止画モード固有の scale+pad 前処理が含まれる
+    assert "scale=1920:1080:force_original_aspect_ratio=decrease" in final_cmd
+
+
+def test_invalid_effect_name_fails_loud(tmp_path: Path) -> None:
+    """未知のエフェクト名は fail-loud で停止する。"""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={"VIDEOUP_EFFECT": "sparkle"},
+    )
+    assert result.returncode != 0
+    assert "Unknown VIDEOUP_EFFECT" in result.stdout + result.stderr
+
+
+def test_invalid_intensity_fails_loud(tmp_path: Path) -> None:
+    """未知の intensity は fail-loud で停止する。"""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={"VIDEOUP_EFFECT": "particles", "VIDEOUP_EFFECT_INTENSITY": "extreme"},
+    )
+    assert result.returncode != 0
+    assert "Unknown VIDEOUP_EFFECT_INTENSITY" in result.stdout + result.stderr


### PR DESCRIPTION
## Summary

- `generate_videos.sh` に映像エフェクトプリセット 3 種（光の粒子 / ボケ / グラデーション流れ）を追加した。動画編集ソフトでできる「画面を彩るレイヤー効果」を ffmpeg filtergraph 単体で再現する MVP 実装
- 環境変数 `VIDEOUP_EFFECT=none|particles|bokeh|gradient` と `VIDEOUP_EFFECT_INTENSITY=subtle|medium|strong` で選択でき、デフォルトは `none` で**従来挙動を完全に温存**（ループは stream copy、静止画は 1fps libx264）
- エフェクト有効時はループモードでも libx264 再エンコード（CRF 22 / `LOOP_MAX_BITRATE` ガード継続）に切り替わり、静止画モードも 24fps 出力に切り替わる
- 不正な値は ffmpeg 起動前に fail-loud で停止
- 外部依存ゼロ（ffmpeg 8.x の標準フィルタのみ使用：`noise` / `geq` / `gradients` / `gblur` / `overlay`）
- ローカル ffmpeg 8.1 で 4 effects × 2 modes = 8 通り全てが MP4 出力を生成できることを実機確認済み

## 受け入れ条件との対応

- [x] 追加する映像エフェクトのパターンを 2〜3 種選定する → **3 種選定**（光の粒子・ボケ・グラデーション流れ）
- [x] 各エフェクトを設定で選択・有効化できるようにする → 環境変数 `VIDEOUP_EFFECT` / `VIDEOUP_EFFECT_INTENSITY`
- [x] 選択したエフェクトが最終出力動画に反映されることを実動画で確認する → ffmpeg 8.1 で 8 通りの実出力確認、テスト 10 件 green
- [x] エフェクトの指定方法をドキュメントに明記する → `.claude/skills/videoup/SKILL.md` に「映像エフェクト」節を新設

## 設計判断

- **MVP として env-var ベース**: skill-config (`config/skills/videoup.yaml`) 経由のチャンネル既定値化は follow-up。bash 単体で yaml をパースしないことで外部依存ゼロを維持
- **ループモードのエフェクト時は stream copy を放棄**: 映像へのフィルタ適用には再エンコードが必須のため、CRF 22 / `LOOP_MAX_BITRATE` ガードは継続して肥大化を抑える
- **subtle がデフォルト alpha=0.10**: BGM チャンネルのコア視聴体験（音楽鑑賞）を邪魔しない強度

## Test plan

- [x] `tests/test_generate_videos_script.py` 既存 3 件が green（後方互換）
- [x] 新規テスト 7 件追加して green:
  - `test_default_effect_none_uses_stream_copy_for_loop` — デフォルトは stream copy 温存
  - `test_particles_effect_switches_to_libx264_with_filter_complex` — particles 指定で libx264 再エンコードに切り替わる
  - `test_bokeh_effect_uses_gblur` — bokeh は gblur フィルタを含む
  - `test_gradient_effect_uses_gradients_source` — gradient は gradients ソースを含む
  - `test_static_image_with_effect_uses_filter_complex` — 静止画モードでもエフェクトが適用される
  - `test_invalid_effect_name_fails_loud` — 不正なエフェクト名は ffmpeg 起動前に停止
  - `test_invalid_intensity_fails_loud` — 不正な intensity は ffmpeg 起動前に停止
- [x] ローカル ffmpeg 8.1 で 4 effects × 2 modes = 8 通りの実 MP4 出力を確認（CI 環境では再現困難なため手動検証）
- [ ] 実コレクションで生成した動画を YouTube Studio プレビュー（モバイル・PC）で視認確認 — マージ後に運用で実施

## Follow-up

- skill-config (`.claude/skills/videoup/config.default.yaml` + `config/skills/videoup.yaml`) でチャンネル既定値化（コレクションごとの上書きも視野）
- コレクションメタ (`workflow-state.json`) からエフェクト選択を引ける拡張
- BGM ジャンル × エフェクト相性表をドキュメント化（lofi → gradient、jazz → bokeh、ambient → particles など）

Closes #648