### PR TITLE
[#732] issue-732-first-tracer-bunx-yt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,9 @@
     "packages/core": {
       "name": "@youtube-automation/core",
       "version": "0.1.0-alpha.0",
+      "dependencies": {
+        "zod": "^4.1.13",
+      },
     },
   },
   "packages": {

--- a/knip.json
+++ b/knip.json
@@ -7,8 +7,8 @@
       "ignoreDependencies": ["takt"]
     },
     "packages/*": {
-      "entry": ["src/index.ts", "src/cli/*.ts", "bin/*.ts"],
-      "project": ["src/**/*.ts", "test/**/*.ts"]
+      "entry": ["src/index.ts", "src/cli/*.ts", "bin/*.ts", "*/index.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts", "*/*.ts"]
     }
   },
   "ignore": [

--- a/packages/cli/_skills
+++ b/packages/cli/_skills
@@ -1,0 +1,1 @@
+../../.claude/skills

--- a/packages/cli/bin/yt-skills.ts
+++ b/packages/cli/bin/yt-skills.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+import process from "node:process";
+
+import { runSkillsCli } from "../skills-sync/cli.ts";
+
+try {
+  await runSkillsCli(process.argv.slice(2));
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "yt-* command line entry points for the youtube-channels-automation TS rewrite (skeleton).",
   "bin": {
-    "yt": "./bin/yt.ts"
+    "yt": "./bin/yt.ts",
+    "yt-skills": "./bin/yt-skills.ts"
   },
   "type": "module",
   "dependencies": {

--- a/packages/cli/skills-sync/cli.ts
+++ b/packages/cli/skills-sync/cli.ts
@@ -1,0 +1,43 @@
+import process from "node:process";
+
+import { listSkillsService } from "@youtube-automation/core/skills-sync";
+import type { SkillListOutput } from "@youtube-automation/core/skills-sync";
+
+// ADR 0002 thin wrapper: 引数 parse → service 呼び出し → 整形出力 のみ。
+// business logic と重い依存は packages/core 側に置く。
+
+type OutputFormat = "json" | "text";
+
+const parseFormat = (flags: string[]): OutputFormat => {
+  let format: OutputFormat = "text";
+  for (const flag of flags) {
+    if (flag === "--json") {
+      format = "json";
+    } else {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+  return format;
+};
+
+const renderText = (output: SkillListOutput): string => {
+  const header = `同梱スキル ${output.skills.length} 件 (source: ${output.source})`;
+  const bullets = output.skills.map((name) => `  - ${name}`);
+  return [header, ...bullets].join("\n");
+};
+
+export const runSkillsCli = async (argv: string[]): Promise<void> => {
+  const [subcommand, ...flags] = argv;
+  if (subcommand !== "list") {
+    throw new Error(
+      `Unknown subcommand: ${subcommand ?? "(none)"}. Supported: list`
+    );
+  }
+
+  const format = parseFormat(flags);
+  const output = await listSkillsService({});
+
+  const rendered =
+    format === "json" ? JSON.stringify(output) : renderText(output);
+  process.stdout.write(`${rendered}\n`);
+};

--- a/packages/cli/test/skills-list.test.ts
+++ b/packages/cli/test/skills-list.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { resolve } from "node:path";
+import process from "node:process";
+
+// Importing core by its package name + ADR 0002 subpath from the *cli* package
+// is the real cli→core `workspace:*` resolution under test. Broken workspace or
+// subpath wiring fails here instead of silently degrading.
+import { listSkillsService } from "@youtube-automation/core/skills-sync";
+
+import { runSkillsCli } from "../skills-sync/cli.ts";
+
+// Repo root is three levels up from packages/cli/test/.
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+// Captures everything written to stdout (console.log routes through here too)
+// for the duration of `fn`, then restores the original writer.
+const captureStdout = async (fn: () => Promise<void>): Promise<string> => {
+  const writes: string[] = [];
+  const spy = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writes.push(
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)
+    );
+    return true;
+  });
+
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+
+  return writes.join("");
+};
+
+describe("runSkillsCli — text output (default)", () => {
+  test("prints the count header matching the Python `yt-skills list` format", async () => {
+    // Given the `list` subcommand with no format flag
+    // When the cli wrapper runs
+    const output = await captureStdout(() => runSkillsCli(["list"]));
+
+    // Then the header line matches `同梱スキル <N> 件 (source: <path>)`.
+    expect(output).toMatch(/^同梱スキル \d+ 件 \(source: .+\)$/mu);
+  });
+
+  test("prints each skill as an indented bullet line", async () => {
+    // Given the `list` subcommand
+    // When the cli wrapper runs
+    const output = await captureStdout(() => runSkillsCli(["list"]));
+
+    // Then at least one skill appears as a `  - <name>` line, and every listed
+    // skill from the service is present in the rendered text.
+    const expected = await listSkillsService({});
+    expect(output).toMatch(/^ {2}- .+$/mu);
+    for (const skill of expected.skills) {
+      expect(output).toContain(`  - ${skill}`);
+    }
+  });
+});
+
+describe("runSkillsCli — json output (--json)", () => {
+  test("prints valid JSON carrying source and skills", async () => {
+    // Given the `list` subcommand with --json
+    // When the cli wrapper runs
+    const output = await captureStdout(() => runSkillsCli(["list", "--json"]));
+
+    // Then stdout is parseable JSON with the service's output shape.
+    const parsed = JSON.parse(output) as { source: string; skills: string[] };
+    expect(typeof parsed.source).toBe("string");
+    expect(Array.isArray(parsed.skills)).toBe(true);
+  });
+
+  test("json skills match the service output exactly", async () => {
+    // Given --json output
+    const output = await captureStdout(() => runSkillsCli(["list", "--json"]));
+    const parsed = JSON.parse(output) as { source: string; skills: string[] };
+
+    // When compared with the service result
+    const expected = await listSkillsService({});
+
+    // Then the cli does no reshaping of the service contract.
+    expect(parsed.skills).toEqual(expected.skills);
+  });
+});
+
+describe("runSkillsCli — usage errors (fail fast)", () => {
+  test("rejects an unknown subcommand", async () => {
+    // Given an unsupported subcommand
+    // When/Then the wrapper surfaces a usage error instead of guessing.
+    await expect(runSkillsCli(["sync"])).rejects.toThrow();
+  });
+
+  test("rejects when no subcommand is provided", async () => {
+    // Given empty argv
+    // When/Then the wrapper surfaces a usage error.
+    await expect(runSkillsCli([])).rejects.toThrow();
+  });
+});
+
+describe("yt-skills bin — end-to-end (bunx entry)", () => {
+  test("`yt-skills list` exits 0 and prints the header", () => {
+    // Given the bin invoked exactly as `bunx yt-skills list` would
+    const proc = Bun.spawnSync(
+      ["bun", "packages/cli/bin/yt-skills.ts", "list"],
+      { cwd: repoRoot }
+    );
+
+    // Then it exits cleanly and prints the count header.
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("同梱スキル");
+  });
+
+  test("`yt-skills list --json` exits 0 and prints a skills array", () => {
+    // Given the bin invoked with --json
+    const proc = Bun.spawnSync(
+      ["bun", "packages/cli/bin/yt-skills.ts", "list", "--json"],
+      { cwd: repoRoot }
+    );
+
+    // Then it exits cleanly and stdout is JSON with a skills array.
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(proc.stdout.toString()) as { skills: string[] };
+    expect(Array.isArray(parsed.skills)).toBe(true);
+  });
+
+  test("`yt-skills <unknown>` exits non-zero", () => {
+    // Given an unsupported subcommand at the bin layer
+    const proc = Bun.spawnSync(
+      ["bun", "packages/cli/bin/yt-skills.ts", "bogus"],
+      { cwd: repoRoot }
+    );
+
+    // Then the process fails (usage error propagates to a non-zero exit).
+    expect(proc.exitCode).not.toBe(0);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,10 @@
   "description": "Pure domain logic for the youtube-channels-automation TS rewrite (skeleton).",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./skills-sync": "./skills-sync/index.ts"
+  },
+  "dependencies": {
+    "zod": "^4.1.13"
   }
 }

--- a/packages/core/skills-sync/index.ts
+++ b/packages/core/skills-sync/index.ts
@@ -1,0 +1,4 @@
+// ADR 0002 canonical template: feature の公開面は schema + service のみ。
+export { SkillListInputSchema, SkillListOutputSchema } from "./schema.ts";
+export type { SkillListInput, SkillListOutput } from "./schema.ts";
+export { listSkillsService } from "./service.ts";

--- a/packages/core/skills-sync/schema.ts
+++ b/packages/core/skills-sync/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+// ADR 0002: zod schema が input/output の正。型は z.infer で導出し interface と並書しない。
+export const SkillListInputSchema = z.object({
+  // 省略時は packages/cli/_skills の同梱 resource を読む (service.ts で解決)。
+  skillsDir: z.string().optional(),
+});
+
+export const SkillListOutputSchema = z.object({
+  skills: z.array(z.string()),
+  source: z.string(),
+});
+
+export type SkillListInput = z.infer<typeof SkillListInputSchema>;
+export type SkillListOutput = z.infer<typeof SkillListOutputSchema>;

--- a/packages/core/skills-sync/service.ts
+++ b/packages/core/skills-sync/service.ts
@@ -1,0 +1,32 @@
+import { readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { SkillListInputSchema, SkillListOutputSchema } from "./schema.ts";
+import type { SkillListInput, SkillListOutput } from "./schema.ts";
+
+// 同梱 skills resource の既定パス。import.meta 基点で packages/cli/_skills を解決する
+// (packages/core/skills-sync/service.ts → ../../cli/_skills)。_skills は .claude/skills への symlink。
+const DEFAULT_SKILLS_DIR = resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "cli",
+  "_skills"
+);
+
+// 1 skill = 1 ディレクトリ。非ディレクトリは除外し、Python `sorted(...)` と同じ
+// code-point 昇順で返す。存在しない source は readdir が reject して fail fast する。
+export const listSkillsService = async (
+  input: SkillListInput
+): Promise<SkillListOutput> => {
+  const { skillsDir } = SkillListInputSchema.parse(input);
+  const source = skillsDir === undefined ? DEFAULT_SKILLS_DIR : skillsDir;
+
+  const entries = await readdir(source, { withFileTypes: true });
+  const skills = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .toSorted();
+
+  return SkillListOutputSchema.parse({ skills, source });
+};

--- a/packages/core/test/skills-sync.test.ts
+++ b/packages/core/test/skills-sync.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Imported by the published package name + ADR 0002 subpath, so the test
+// exercises the core `exports` map ("./skills-sync") rather than a relative
+// path. A missing/broken subpath export fails resolution here, not in tsc.
+import {
+  listSkillsService,
+  SkillListInputSchema,
+} from "@youtube-automation/core/skills-sync";
+import type { SkillListInput } from "@youtube-automation/core/skills-sync";
+
+// Repo root is three levels up from packages/core/test/.
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+describe("listSkillsService — explicit skillsDir (golden / fixture)", () => {
+  // A throwaway fixture with directories created out of order plus a stray
+  // file, so one fixture can assert sorting AND directory-only filtering.
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "skills-fixture-"));
+    for (const name of ["zebra", "alpha", "mango"]) {
+      mkdirSync(join(fixtureDir, name));
+    }
+    writeFileSync(join(fixtureDir, "README.md"), "not a skill directory");
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { force: true, recursive: true });
+  });
+
+  test("returns skill directory names in code-point ascending order", async () => {
+    // Given a fixture dir whose subdirectories were created out of order
+    // When listSkillsService is called with that dir
+    const output = await listSkillsService({ skillsDir: fixtureDir });
+
+    // Then names come back sorted with the default (code-point) comparator,
+    // matching the Python `sorted(...)` contract.
+    expect(output.skills).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  test("excludes non-directory entries (a skill is a directory)", async () => {
+    // Given a fixture dir containing a stray README.md file
+    // When listSkillsService is called
+    const output = await listSkillsService({ skillsDir: fixtureDir });
+
+    // Then the file is omitted; only directories are reported.
+    expect(output.skills).not.toContain("README.md");
+    expect(output.skills).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  test("echoes the resolved source directory in the output", async () => {
+    // Given an explicit skillsDir
+    // When listSkillsService is called
+    const output = await listSkillsService({ skillsDir: fixtureDir });
+
+    // Then `source` reports the directory that was read.
+    expect(output.source).toBe(fixtureDir);
+  });
+
+  test("returns an empty skills array for an empty directory", async () => {
+    // Given a freshly created empty directory
+    const emptyDir = mkdtempSync(join(tmpdir(), "skills-empty-"));
+    try {
+      // When listSkillsService is called
+      const output = await listSkillsService({ skillsDir: emptyDir });
+
+      // Then skills is an empty array (boundary value), not an error.
+      expect(output.skills).toEqual([]);
+    } finally {
+      rmSync(emptyDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("listSkillsService — default resolution (import.meta.url)", () => {
+  test("default source resolves to the cli _skills resource", async () => {
+    // Given no skillsDir input (default resolution path)
+    // When listSkillsService is called
+    const output = await listSkillsService({});
+
+    // Then the resolved source points at the packages/cli/_skills resource.
+    expect(output.source).toContain("_skills");
+  });
+
+  test("default skills match the real .claude/skills directories", async () => {
+    // Given the repo's canonical skill source (.claude/skills, reached via the
+    // packages/cli/_skills symlink) — read dynamically so the assertion stays
+    // correct as skills are added or removed.
+    const realSkillsDir = join(repoRoot, ".claude", "skills");
+    const expected = readdirSync(realSkillsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .toSorted();
+
+    // When listSkillsService is called with default resolution
+    const output = await listSkillsService({});
+
+    // Then the listing semantically matches the Python `yt-skills list`.
+    expect(output.skills).toEqual(expected);
+    expect(output.skills.length).toBeGreaterThan(0);
+  });
+});
+
+describe("listSkillsService — boundary validation", () => {
+  test("rejects when skillsDir is not a string (boundary parse())", async () => {
+    // Given an input whose skillsDir violates the schema
+    const badInput = { skillsDir: 123 } as unknown as SkillListInput;
+
+    // When/Then the service must reject at the schema boundary, not coerce.
+    await expect(listSkillsService(badInput)).rejects.toThrow();
+  });
+
+  test("rejects when the target directory does not exist (fail fast)", async () => {
+    // Given a path that does not exist
+    const missingDir = join(tmpdir(), "skills-does-not-exist-xyz-732");
+
+    // When/Then the service surfaces the error rather than returning empty.
+    await expect(
+      listSkillsService({ skillsDir: missingDir })
+    ).rejects.toThrow();
+  });
+});
+
+describe("SkillListInputSchema — contract", () => {
+  test("accepts an empty object (skillsDir is optional)", () => {
+    // Given an empty input object
+    // When parsed
+    const parsed = SkillListInputSchema.parse({});
+
+    // Then it is valid and skillsDir is absent.
+    expect(parsed.skillsDir).toBeUndefined();
+  });
+
+  test("accepts an explicit string skillsDir", () => {
+    // Given an input with a string skillsDir
+    // When parsed
+    const parsed = SkillListInputSchema.parse({ skillsDir: "/tmp/skills" });
+
+    // Then the value is preserved.
+    expect(parsed.skillsDir).toBe("/tmp/skills");
+  });
+
+  test("rejects a non-string skillsDir", () => {
+    // Given an input with a numeric skillsDir
+    // When/Then parse throws.
+    expect(() => SkillListInputSchema.parse({ skillsDir: 123 })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

## Parent
#727

## What to build
最初の tracer bullet として、TS 版 `yt-skills list` を実装し `bunx yt-skills list` (もしくは `bun packages/cli/bin/yt-skills list`) が動作する状態を作る。skills resource は `packages/cli/_skills/` (将来の npm package `files`) から読み取る。

**本 issue は [ADR 0002 (service-first architecture)](https://github.com/daiki-beppu/youtube-automation/blob/main/docs/adr/0002-service-first-architecture.md) の canonical template を最初に適用する issue**。後続 60+ child issue が本 issue の構造を copy-paste で踏襲できるよう、ADR 本文の雛形に従って `packages/core/skills-sync/{schema,service}.ts` + `packages/cli/skills-sync/cli.ts` の三層に分離して実装する。

## Acceptance criteria

### ADR 0002 template 適用 (必須、本 issue が canonical 起点)
- [ ] `packages/core/skills-sync/schema.ts`: zod schema (`SkillListInputSchema` / `SkillListOutputSchema`) を定義し、型は `z.infer` で導出
- [ ] `packages/core/skills-sync/service.ts`: `listSkillsService(input): Promise<SkillListOutput>` を export。境界で `Schema.parse()` を通す。skills resource の読み取りロジックはここに集約 (`packages/cli/_skills/` glob)
- [ ] `packages/cli/skills-sync/cli.ts`: thin wrapper。引数 parse → `listSkillsService` 呼び出し → 整形出力 (text / json) のみ。重い依存 (`googleapis` 等) の直 import なし
- [ ] `packages/core/package.json::dependencies` に `zod` を追加 (本 epic 初回の zod 依存追加)

### CLI 動作
- [ ] `packages/cli/bin/yt-skills.ts` を bun script として実装、subcommand `list` をサポート
- [ ] `bun packages/cli/bin/yt-skills.ts list` 実行で skill 一覧が現行 Python 版 (`uv run yt-skills list`) と semantic に一致
- [ ] resource path 解決は `import.meta.url` ベース (`packages/core/skills-sync/service.ts` 内)

### 品質ゲート
- [ ] smoke test (`bun test`) で `listSkillsService` の出力を golden 比較 + cli wrapper の出力を end-to-end 検証
- [ ] `oxlint` で `packages/cli/skills-sync/cli.ts` から重い依存の直 import がないこと (ADR 0002 の `no-restricted-imports` rule で機械担保)
- [ ] `tsc -b --noEmit` exit 0
- [ ] `bun run ci` (lint + format:check + typecheck + test + knip) すべて exit 0

## Blocked by
- #731 (済、PR #794 で feat/ts-rewrite に landed)

## Related

- ADR 0002 (`docs/adr/0002-service-first-architecture.md`): 本 issue が canonical template 起点
- `feat/ts-rewrite::oxlint.config.ts::overrides[].rules["no-restricted-imports"]`: mechanical enforcement (commit `77c0b6a`)

## Execution Report

Workflow `default` completed successfully.

Closes #732