### PR TITLE
[#734] issue-734-core-utils-exception

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,190 @@
+// The domain exception hierarchy is one cohesive unit (order.md targets a
+// single packages/core errors module), so the per-file class cap is relaxed
+// here rather than scattering the hierarchy across files.
+/* eslint-disable max-classes-per-file */
+
+// Domain exception hierarchy, ported from the Python `utils/exceptions.py`.
+// `AutomationError` is the base every domain error extends, so a single
+// `catch (e instanceof AutomationError)` site captures all of them while
+// `instanceof` on the concrete class still discriminates.
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const parseJson = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // An error payload that is not JSON (e.g. an HTML 502 page) carries no
+    // machine-readable reason; degrading to undefined is the intended contract,
+    // not a swallowed failure — the HTTP status is still surfaced separately.
+    return undefined;
+  }
+};
+
+// Mirrors the Python `_payload_reason`: prefer the first `errors[].reason`,
+// then fall back to the legacy top-level `error.reason`.
+const extractReason = (data: unknown): string | undefined => {
+  const payload = typeof data === "string" ? parseJson(data) : data;
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  const { error } = payload;
+  if (!isRecord(error)) {
+    return undefined;
+  }
+  if (Array.isArray(error.errors)) {
+    for (const item of error.errors) {
+      if (isRecord(item) && typeof item.reason === "string") {
+        return item.reason;
+      }
+    }
+  }
+  return typeof error.reason === "string" ? error.reason : undefined;
+};
+
+/** Base exception for youtube-channels-automation. */
+export class AutomationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AutomationError";
+  }
+}
+
+/**
+ * Config file load / validation error.
+ *
+ * - missing required keys in config/channel/*.json
+ * - config file not found
+ * - JSON parse error
+ */
+export class ConfigError extends AutomationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * OAuth 2.0 authentication error.
+ *
+ * - client_secrets.json load failure
+ * - run_local_server flow failure
+ * - GoogleAuthError family roll-up
+ */
+export class AuthError extends AutomationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+/**
+ * Input data validation error.
+ *
+ * - invalid metadata values
+ * - invalid file paths
+ * - invalid collection names
+ */
+export class ValidationError extends AutomationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+/**
+ * Video / thumbnail upload failure.
+ *
+ * - retry limit reached
+ * - file missing
+ * - thumbnail compression failure
+ */
+export class UploadError extends AutomationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UploadError";
+  }
+}
+
+/** Reply-generation backend failure (API error, malformed response, etc.). */
+export class GeneratorError extends AutomationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "GeneratorError";
+  }
+}
+
+/** Optional metadata carried by a {@link YouTubeAPIError}. */
+export interface YouTubeAPIErrorOptions {
+  /** Operation name (and any argument hint) the call was made under. */
+  readonly context?: string;
+  /** Machine-readable reason extracted from the API error payload. */
+  readonly reason?: string;
+  /** HTTP status code from the failing API response. */
+  readonly statusCode?: number;
+}
+
+/**
+ * YouTube Data API / Analytics API call error.
+ *
+ * - quota exceeded
+ * - authentication failure
+ * - malformed response
+ */
+export class YouTubeAPIError extends AutomationError {
+  readonly statusCode?: number;
+  readonly reason?: string;
+  readonly context?: string;
+
+  constructor(message: string, options?: YouTubeAPIErrorOptions) {
+    super(message);
+    this.name = "YouTubeAPIError";
+    this.statusCode = options?.statusCode;
+    this.reason = options?.reason;
+    this.context = options?.context;
+  }
+
+  /**
+   * Convert a googleapis Gaxios-shaped error into a {@link YouTubeAPIError},
+   * mirroring the Python `from_http_error` duck typing.
+   *
+   * Pulls the HTTP status and the machine-readable reason out of the
+   * `response` payload and prefixes the message with `context`. Does NOT
+   * auto-upgrade a 429 to {@link QuotaExhaustedError} — that branch is the
+   * caller's decision, matching Python parity.
+   */
+  static fromGaxiosError(error: unknown, context: string): YouTubeAPIError {
+    const body = error instanceof Error ? error.message : String(error);
+    const response = isRecord(error) ? error.response : undefined;
+    const statusCode =
+      isRecord(response) && typeof response.status === "number"
+        ? response.status
+        : undefined;
+    const reason = extractReason(
+      isRecord(response) ? response.data : undefined
+    );
+    return new YouTubeAPIError(`${context}: ${body}`, {
+      context,
+      reason,
+      statusCode,
+    });
+  }
+}
+
+/**
+ * Quota exhausted / rate-limit exceeded (HTTP 429).
+ *
+ * Signals to callers that the operation is resumable after a delay.
+ * `retryAfterSeconds` is the suggested wait derived from the Retry-After
+ * header (undefined when unavailable).
+ */
+export class QuotaExhaustedError extends YouTubeAPIError {
+  readonly retryAfterSeconds?: number;
+
+  constructor(message: string, retryAfterSeconds?: number) {
+    super(message, { statusCode: 429 });
+    this.name = "QuotaExhaustedError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,15 @@
 // Skeleton entry for the core package. Real domain logic is migrated in later #727 issues.
 export const greeting = (): string =>
   "youtube-channels-automation core (TS rewrite skeleton)";
+
+export {
+  AuthError,
+  AutomationError,
+  ConfigError,
+  GeneratorError,
+  QuotaExhaustedError,
+  UploadError,
+  ValidationError,
+  YouTubeAPIError,
+  type YouTubeAPIErrorOptions,
+} from "./errors.ts";

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+
+// Imports by the published package name (not a relative path) so the tests
+// exercise the package `exports` map / barrel re-export, not just the source
+// file. A broken `exports` or missing barrel entry fails resolution here
+// instead of slipping past tsc.
+import {
+  AuthError,
+  AutomationError,
+  ConfigError,
+  GeneratorError,
+  QuotaExhaustedError,
+  UploadError,
+  ValidationError,
+  YouTubeAPIError,
+} from "@youtube-automation/core";
+
+// Builds a gaxios-shaped error: a real Error (so `error instanceof Error`
+// holds and `.message` is read for the wrapped message) with a `response`
+// carrying `status` and parsed/raw `data`, mirroring the Google API client
+// surface the Python `from_http_error` consumed via duck typing.
+const gaxiosError = (message: string, response: unknown): Error =>
+  Object.assign(new Error(message), { response });
+
+describe("AutomationError (base)", () => {
+  test("extends the native Error so generic catch sites still work", () => {
+    // Given a base AutomationError
+    const error = new AutomationError("boom");
+    // Then it is a native Error and an AutomationError
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AutomationError);
+  });
+
+  test("preserves the message and exposes the subclass name", () => {
+    // Given a base AutomationError with a message
+    const error = new AutomationError("boom");
+    // Then the message round-trips and name reflects the concrete class
+    expect(error.message).toBe("boom");
+    expect(error.name).toBe("AutomationError");
+  });
+});
+
+describe("plain domain subclasses extend AutomationError", () => {
+  // Each entry: concrete class paired with its expected `name`.
+  const cases: readonly (readonly [
+    new (m: string) => AutomationError,
+    string,
+  ])[] = [
+    [ConfigError, "ConfigError"],
+    [AuthError, "AuthError"],
+    [ValidationError, "ValidationError"],
+    [UploadError, "UploadError"],
+    [GeneratorError, "GeneratorError"],
+  ];
+
+  for (const [Ctor, name] of cases) {
+    test(`${name} instanceof AutomationError and Error`, () => {
+      // Given an instance of the domain subclass
+      const error = new Ctor("nope");
+      // Then it sits under AutomationError in the hierarchy
+      expect(error).toBeInstanceOf(AutomationError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(Ctor);
+    });
+
+    test(`${name} carries its message and class name`, () => {
+      // Given an instance with a message
+      const error = new Ctor("nope");
+      // Then message and name are preserved
+      expect(error.message).toBe("nope");
+      expect(error.name).toBe(name);
+    });
+  }
+});
+
+describe("YouTubeAPIError", () => {
+  test("instanceof AutomationError and Error", () => {
+    // Given a bare YouTubeAPIError
+    const error = new YouTubeAPIError("api failed");
+    // Then it is part of the AutomationError hierarchy
+    expect(error).toBeInstanceOf(AutomationError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("YouTubeAPIError");
+  });
+
+  test("statusCode and reason default to undefined when omitted", () => {
+    // Given a YouTubeAPIError constructed with only a message
+    const error = new YouTubeAPIError("api failed");
+    // Then the optional fields are absent
+    expect(error.statusCode).toBeUndefined();
+    expect(error.reason).toBeUndefined();
+  });
+
+  test("retains statusCode and reason when supplied", () => {
+    // Given a YouTubeAPIError with status + reason options
+    const error = new YouTubeAPIError("api failed", {
+      reason: "forbidden",
+      statusCode: 403,
+    });
+    // Then both fields are stored
+    expect(error.statusCode).toBe(403);
+    expect(error.reason).toBe("forbidden");
+  });
+});
+
+describe("YouTubeAPIError.fromGaxiosError", () => {
+  test("extracts statusCode, reason (errors[0]) and prefixes context", () => {
+    // Given a gaxios error with status and an errors[] reason
+    const raw = gaxiosError("quota exceeded", {
+      data: {
+        error: {
+          errors: [{ domain: "youtube.quota", reason: "quotaExceeded" }],
+          reason: "legacyReason",
+        },
+      },
+      status: 403,
+    });
+    // When converting it for a named operation
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.insert");
+    // Then it is a YouTubeAPIError with extracted fields and context-prefixed message
+    expect(error).toBeInstanceOf(YouTubeAPIError);
+    expect(error.statusCode).toBe(403);
+    expect(error.reason).toBe("quotaExceeded");
+    expect(error.context).toBe("videos.insert");
+    expect(error.message).toBe("videos.insert: quota exceeded");
+  });
+
+  test("falls back to the legacy error.reason when errors[] is absent", () => {
+    // Given a gaxios error whose payload carries only the legacy top-level reason
+    const raw = gaxiosError("bad request", {
+      data: { error: { reason: "badRequest" } },
+      status: 400,
+    });
+    // When converting it
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.list");
+    // Then the legacy reason is used
+    expect(error.statusCode).toBe(400);
+    expect(error.reason).toBe("badRequest");
+  });
+
+  test("parses a JSON string payload (data is not pre-parsed)", () => {
+    // Given a gaxios error whose data is a raw JSON string
+    const raw = gaxiosError("forbidden", {
+      data: JSON.stringify({
+        error: { errors: [{ reason: "quotaExceeded" }] },
+      }),
+      status: 403,
+    });
+    // When converting it
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.insert");
+    // Then the reason is extracted from the parsed string
+    expect(error.statusCode).toBe(403);
+    expect(error.reason).toBe("quotaExceeded");
+  });
+
+  test("reason is undefined when the data string is not valid JSON", () => {
+    // Given a gaxios error whose data is an unparseable string
+    const raw = gaxiosError("gateway error", {
+      data: "<html>502 Bad Gateway</html>",
+      status: 502,
+    });
+    // When converting it
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.insert");
+    // Then status survives but reason degrades to undefined
+    expect(error.statusCode).toBe(502);
+    expect(error.reason).toBeUndefined();
+  });
+
+  test("statusCode and reason are undefined when response is missing", () => {
+    // Given a bare error with no gaxios response attached
+    const raw = new Error("network down");
+    // When converting it
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.insert");
+    // Then both fields degrade to undefined but the message is still prefixed
+    expect(error.statusCode).toBeUndefined();
+    expect(error.reason).toBeUndefined();
+    expect(error.message).toBe("videos.insert: network down");
+  });
+
+  test("non-Error input is stringified into the message", () => {
+    // Given a non-Error value as the failure
+    const error = YouTubeAPIError.fromGaxiosError("raw string failure", "op");
+    // Then String(error) is used for the message body
+    expect(error.message).toBe("op: raw string failure");
+    expect(error.statusCode).toBeUndefined();
+    expect(error.reason).toBeUndefined();
+  });
+
+  test("never auto-upgrades a 429 to QuotaExhaustedError (Python parity)", () => {
+    // Given a gaxios error with HTTP 429
+    const raw = gaxiosError("rate limited", {
+      data: { error: { errors: [{ reason: "rateLimitExceeded" }] } },
+      status: 429,
+    });
+    // When converting it
+    const error = YouTubeAPIError.fromGaxiosError(raw, "videos.insert");
+    // Then it stays a plain YouTubeAPIError (no automatic 429 branch)
+    expect(error).toBeInstanceOf(YouTubeAPIError);
+    expect(error).not.toBeInstanceOf(QuotaExhaustedError);
+    expect(error.statusCode).toBe(429);
+  });
+});
+
+describe("QuotaExhaustedError", () => {
+  test("nests under YouTubeAPIError, AutomationError and Error", () => {
+    // Given a QuotaExhaustedError
+    const error = new QuotaExhaustedError("quota gone");
+    // Then the full hierarchy holds
+    expect(error).toBeInstanceOf(YouTubeAPIError);
+    expect(error).toBeInstanceOf(AutomationError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("QuotaExhaustedError");
+  });
+
+  test("pins statusCode to 429", () => {
+    // Given a QuotaExhaustedError
+    const error = new QuotaExhaustedError("quota gone");
+    // Then the status is the fixed 429
+    expect(error.statusCode).toBe(429);
+  });
+
+  test("retains retryAfterSeconds when provided", () => {
+    // Given a QuotaExhaustedError with a retry hint
+    const error = new QuotaExhaustedError("quota gone", 30);
+    // Then the hint is stored
+    expect(error.retryAfterSeconds).toBe(30);
+  });
+
+  test("retryAfterSeconds is undefined when omitted", () => {
+    // Given a QuotaExhaustedError without a retry hint
+    const error = new QuotaExhaustedError("quota gone");
+    // Then the hint is absent
+    expect(error.retryAfterSeconds).toBeUndefined();
+  });
+});
+
+describe("throw / catch round-trips", () => {
+  // Each domain class must be catchable both as itself and as AutomationError.
+  const throwers: readonly (readonly [string, () => never])[] = [
+    [
+      "ConfigError",
+      () => {
+        throw new ConfigError("c");
+      },
+    ],
+    [
+      "YouTubeAPIError",
+      () => {
+        throw new YouTubeAPIError("y");
+      },
+    ],
+    [
+      "QuotaExhaustedError",
+      () => {
+        throw new QuotaExhaustedError("q");
+      },
+    ],
+    [
+      "AuthError",
+      () => {
+        throw new AuthError("a");
+      },
+    ],
+    [
+      "ValidationError",
+      () => {
+        throw new ValidationError("v");
+      },
+    ],
+    [
+      "UploadError",
+      () => {
+        throw new UploadError("u");
+      },
+    ],
+    [
+      "GeneratorError",
+      () => {
+        throw new GeneratorError("g");
+      },
+    ],
+  ];
+
+  for (const [name, thrower] of throwers) {
+    test(`${name} is catchable as AutomationError`, () => {
+      // When the domain error is thrown
+      // Then a generic AutomationError catch site captures it
+      let caught: unknown;
+      try {
+        thrower();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(AutomationError);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

## Parent
#727

## What to build
Python `utils/exceptions.py` のドメイン例外階層 (`AutomationError` 基底, `ConfigError` / `YouTubeAPIError` / `ValidationError` / `UploadError`) を TS class hierarchy として `packages/core/errors.ts` に移植する。`YouTubeAPIError.from_http_error()` 相当の googleapis Error 変換 helper も含む。

## Acceptance criteria
- [ ] 全例外 class が TS で実装、`instanceof` 階層が Python 版と等価
- [ ] `YouTubeAPIError.fromGaxiosError()` (googleapis の Gaxios エラー変換) helper
- [ ] context フィールド (operation 名, 引数 hint) を保持
- [ ] unit test で例外スロー + 階層判定が green

## Blocked by
- #732

## Execution Report

Workflow `default` completed successfully.

Closes #734