### PR TITLE
[#736] issue-736-core-utils-config-lo

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./config": "./src/config/index.ts",
     "./skills-sync": "./skills-sync/index.ts"
   },
   "dependencies": {

--- a/packages/core/src/config/analytics.ts
+++ b/packages/core/src/config/analytics.ts
@@ -1,0 +1,29 @@
+// Analytics・Benchmark（Python `utils/config/analytics.py` の移植）。
+
+import { asRecord } from "./internal.ts";
+
+/** `benchmark` セクション（optional）。channels は JSON 構造を verbatim 保持。 */
+interface Benchmark {
+  readonly channels: readonly Record<string, unknown>[];
+}
+
+/** `analytics` + `benchmark` の合成（どちらも optional）。 */
+export interface Analytics {
+  readonly collectionFilterKeywords: readonly string[];
+  readonly benchmark: Benchmark;
+}
+
+export const parseAnalytics = (merged: Record<string, unknown>): Analytics => {
+  const an = asRecord(merged.analytics, "analytics");
+  const bm = asRecord(merged.benchmark, "benchmark");
+  return {
+    benchmark: {
+      channels: [
+        ...((bm.channels as Record<string, unknown>[] | undefined) ?? []),
+      ],
+    },
+    collectionFilterKeywords: [
+      ...((an.collection_filter_keywords as string[] | undefined) ?? []),
+    ],
+  };
+};

--- a/packages/core/src/config/audio.ts
+++ b/packages/core/src/config/audio.ts
@@ -1,0 +1,19 @@
+// オーディオ設定（Python `utils/config/audio.py` の移植・optional）。
+
+import { asRecord } from "./internal.ts";
+
+/** `audio` セクション（optional）。 */
+export interface Audio {
+  readonly targetDurationMin: number | null;
+  readonly targetDurationMax: number | null;
+  readonly chapterMax: number;
+}
+
+export const parseAudio = (merged: Record<string, unknown>): Audio => {
+  const ad = asRecord(merged.audio, "audio");
+  return {
+    chapterMax: (ad.chapter_max as number | undefined) ?? 100,
+    targetDurationMax: (ad.target_duration_max as number | undefined) ?? null,
+    targetDurationMin: (ad.target_duration_min as number | undefined) ?? null,
+  };
+};

--- a/packages/core/src/config/comments.ts
+++ b/packages/core/src/config/comments.ts
@@ -1,0 +1,183 @@
+// コメント自動返信設定（Python `utils/config/comments.py` + loader の移植・optional）。
+
+import { ConfigError } from "../errors.ts";
+import { asRecord, isRecord } from "./internal.ts";
+
+const PROVIDER_CODEX = "codex";
+const PROVIDER_GEMINI = "gemini";
+const VALID_PROVIDERS = [PROVIDER_GEMINI, PROVIDER_CODEX];
+
+const FALLBACK_SKIP = "skip";
+const FALLBACK_RETRY = "retry";
+const VALID_FALLBACK_VALUES = [FALLBACK_SKIP, FALLBACK_RETRY];
+
+// CommentRule.scope: コメント階層（top-level / reply）でマッチ対象を絞る (#524)。
+const SCOPE_TOP_LEVEL = "top_level";
+const SCOPE_REPLY = "reply";
+const SCOPE_ANY = "any";
+const VALID_SCOPES = [SCOPE_TOP_LEVEL, SCOPE_REPLY, SCOPE_ANY];
+
+const MAX_LENGTH_DEFAULT = 280;
+const CHANNEL_PERSONA_DEFAULT = "";
+const REQUESTS_PER_MINUTE_DEFAULT = 30;
+
+/** `comments.generator` セクション。 */
+interface GeneratorConfig {
+  readonly provider: string;
+  readonly model: string | null;
+  readonly channelPersona: string;
+  readonly maxLength: number;
+  readonly fallbackOnError: string;
+  readonly requestsPerMinute: number;
+}
+
+/** コメント返信ルール 1 件。 */
+interface CommentRule {
+  readonly name: string;
+  readonly keywords: readonly string[];
+  readonly pattern: string | null;
+  readonly language: string | null;
+  readonly priority: number;
+  readonly provider: string | null;
+  readonly scope: string;
+}
+
+/** `comments` セクション（optional）。 */
+export interface Comments {
+  readonly enabled: boolean;
+  readonly rules: readonly CommentRule[];
+  readonly ngWords: readonly string[];
+  readonly maxRepliesPerRun: number;
+  readonly delayBetweenRepliesSec: number;
+  readonly historyFile: string;
+  readonly skipHeldForReview: boolean;
+  readonly generator: GeneratorConfig;
+}
+
+const defaultGenerator = (): GeneratorConfig => ({
+  channelPersona: CHANNEL_PERSONA_DEFAULT,
+  fallbackOnError: FALLBACK_SKIP,
+  maxLength: MAX_LENGTH_DEFAULT,
+  model: null,
+  provider: PROVIDER_CODEX,
+  requestsPerMinute: REQUESTS_PER_MINUTE_DEFAULT,
+});
+
+const parseGeneratorConfig = (
+  raw: Record<string, unknown>
+): GeneratorConfig => {
+  if ("type" in raw) {
+    throw new ConfigError(
+      "comments.generator.type は廃止されました。comments.generator.provider を使用してください"
+    );
+  }
+  const provider = (raw.provider as string | undefined) ?? PROVIDER_CODEX;
+  if (!VALID_PROVIDERS.includes(provider)) {
+    throw new ConfigError(
+      `comments.generator.provider は ${VALID_PROVIDERS.join(" / ")} のいずれかでなければなりません: ${provider}`
+    );
+  }
+  const model = (raw.model as string | undefined) ?? null;
+  if (provider === PROVIDER_GEMINI && !model) {
+    throw new ConfigError(
+      "comments.generator.provider='gemini' の場合 model は必須です"
+    );
+  }
+  const fallback =
+    (raw.fallback_on_error as string | undefined) ?? FALLBACK_SKIP;
+  if (!VALID_FALLBACK_VALUES.includes(fallback)) {
+    throw new ConfigError(
+      `comments.generator.fallback_on_error は ${VALID_FALLBACK_VALUES.join(" / ")} のいずれかでなければなりません: ${fallback}`
+    );
+  }
+  return {
+    channelPersona:
+      (raw.channel_persona as string | undefined) ?? CHANNEL_PERSONA_DEFAULT,
+    fallbackOnError: fallback,
+    maxLength: (raw.max_length as number | undefined) ?? MAX_LENGTH_DEFAULT,
+    model,
+    provider,
+    requestsPerMinute:
+      (raw.requests_per_minute as number | undefined) ??
+      REQUESTS_PER_MINUTE_DEFAULT,
+  };
+};
+
+const parseRule = (raw: unknown, index: number): CommentRule => {
+  if (!isRecord(raw)) {
+    throw new ConfigError(
+      `comments.rules[${index}] は object でなければなりません`
+    );
+  }
+  const { name } = raw;
+  if (!name) {
+    throw new ConfigError(`comments.rules[${index}].name が必須です`);
+  }
+  if ("template_key" in raw) {
+    throw new ConfigError(
+      `comments.rules[${index}].template_key は廃止されました`
+    );
+  }
+  if ("generator" in raw) {
+    throw new ConfigError(
+      `comments.rules[${index}].generator は廃止されました。provider を使用してください`
+    );
+  }
+  const ruleProvider = (raw.provider as string | undefined) ?? null;
+  if (ruleProvider !== null && !VALID_PROVIDERS.includes(ruleProvider)) {
+    throw new ConfigError(
+      `comments.rules[${index}].provider は ${VALID_PROVIDERS.join(" / ")} のいずれかでなければなりません: ${ruleProvider}`
+    );
+  }
+  const ruleScope = (raw.scope as string | undefined) ?? SCOPE_ANY;
+  if (!VALID_SCOPES.includes(ruleScope)) {
+    throw new ConfigError(
+      `comments.rules[${index}].scope は ${VALID_SCOPES.join(" / ")} のいずれかでなければなりません: ${ruleScope}`
+    );
+  }
+  return {
+    keywords: [...((raw.keywords as string[] | undefined) ?? [])],
+    language: (raw.language as string | undefined) ?? null,
+    name: name as string,
+    pattern: (raw.pattern as string | undefined) ?? null,
+    priority: (raw.priority as number | undefined) ?? 0,
+    provider: ruleProvider,
+    scope: ruleScope,
+  };
+};
+
+export const parseComments = (merged: Record<string, unknown>): Comments => {
+  const cm = asRecord(merged.comments, "comments");
+  if ("templates" in cm) {
+    throw new ConfigError(
+      "comments.templates は廃止されました。LLM provider で返信を生成してください"
+    );
+  }
+
+  const rulesRaw = (cm.rules as unknown[] | undefined) ?? [];
+  const rules = rulesRaw.map((raw, i) => parseRule(raw, i));
+
+  const genRaw = cm.generator;
+  let generator = defaultGenerator();
+  if (genRaw !== undefined && genRaw !== null) {
+    if (!isRecord(genRaw)) {
+      throw new ConfigError(
+        "comments.generator は object でなければなりません"
+      );
+    }
+    generator = parseGeneratorConfig(genRaw);
+  }
+
+  return {
+    delayBetweenRepliesSec:
+      (cm.delay_between_replies_sec as number | undefined) ?? 2,
+    enabled: (cm.enabled as boolean | undefined) ?? false,
+    generator,
+    historyFile:
+      (cm.history_file as string | undefined) ?? "comment_reply_history.json",
+    maxRepliesPerRun: (cm.max_replies_per_run as number | undefined) ?? 20,
+    ngWords: [...((cm.ng_words as string[] | undefined) ?? [])],
+    rules,
+    skipHeldForReview: (cm.skip_held_for_review as boolean | undefined) ?? true,
+  };
+};

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,0 +1,30 @@
+// ChannelConfig 合成ルート型（Python `utils/config/config.py` の移植）。
+
+import type { Analytics } from "./analytics.ts";
+import type { Audio } from "./audio.ts";
+import type { Comments } from "./comments.ts";
+import type { Content } from "./content.ts";
+import type { Distrokid } from "./distrokid.ts";
+import type { Localizations } from "./localizations.ts";
+import type { ChannelMeta } from "./meta.ts";
+import type { PinnedComment } from "./pinned-comment.ts";
+import type { Playlists } from "./playlists.ts";
+import type { Shorts } from "./shorts.ts";
+import type { Workflow } from "./workflow.ts";
+import type { YoutubeSection } from "./youtube.ts";
+
+/** チャンネル設定の合成ルート（責務別ネームスペースでアクセスする）。 */
+export interface ChannelConfig {
+  readonly meta: ChannelMeta;
+  readonly content: Content;
+  readonly youtube: YoutubeSection;
+  readonly analytics: Analytics;
+  readonly playlists: Playlists;
+  readonly workflow: Workflow;
+  readonly shorts: Shorts;
+  readonly audio: Audio;
+  readonly localizations: Localizations;
+  readonly comments: Comments;
+  readonly pinnedComment: PinnedComment;
+  readonly distrokid: Distrokid;
+}

--- a/packages/core/src/config/content.ts
+++ b/packages/core/src/config/content.ts
@@ -1,0 +1,227 @@
+// コンテンツ責務（genre / tags / descriptions / title）の型 + parser + ヘルパー。
+// Python `utils/config/content.py` の dataclass メソッドは co-located 純関数として移植。
+
+/** `genre` セクション。 */
+interface Genre {
+  readonly primary: string;
+  readonly style: string;
+  readonly context: string;
+}
+
+/** `tags` セクション。`channelName` は loader が合成時に注入する。 */
+export interface Tags {
+  readonly base: readonly string[];
+  readonly themes: Readonly<Record<string, readonly string[]>>;
+  readonly channelSpecific: readonly string[];
+  readonly channelName: string;
+  readonly minCount: number | null;
+}
+
+/** `title.theme_scenes` の各エントリ（TTP 形式）。 */
+interface ThemeScene {
+  readonly scene?: string;
+  readonly activities?: string;
+}
+
+/** `title` セクション。 */
+export interface Title {
+  readonly template: string;
+  readonly defaultActivity: string;
+  readonly themeScenes: Readonly<Record<string, ThemeScene>>;
+  readonly themeActivities: Readonly<Record<string, string>>;
+  readonly templateCheck: Readonly<Record<string, unknown>>;
+}
+
+/** `descriptions` セクション。`genre` は loader が合成時に注入する。 */
+export interface Descriptions {
+  readonly opening: string;
+  readonly subOpening: string;
+  readonly perfectFor: readonly string[];
+  readonly hashtags: readonly string[];
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly genre: Genre;
+}
+
+/** コンテンツ責務の合成。 */
+export interface Content {
+  readonly genre: Genre;
+  readonly tags: Tags;
+  readonly descriptions: Descriptions;
+  readonly title: Title;
+}
+
+const parseGenre = (merged: Record<string, unknown>): Genre => {
+  const gn = merged.genre as Record<string, unknown>;
+  return {
+    context: gn.context as string,
+    primary: gn.primary as string,
+    style: gn.style as string,
+  };
+};
+
+const parseTags = (
+  merged: Record<string, unknown>,
+  channelName: string
+): Tags => {
+  const tg = merged.tags as Record<string, unknown>;
+  const themesRaw = tg.themes as Record<string, string[]>;
+  return {
+    base: [...(tg.base as string[])],
+    channelName,
+    channelSpecific: [...((tg.channel_specific as string[] | undefined) ?? [])],
+    minCount: (tg.min_count as number | undefined) ?? null,
+    themes: Object.fromEntries(
+      Object.entries(themesRaw).map(([k, v]) => [k, [...v]])
+    ),
+  };
+};
+
+const parseDescriptions = (
+  merged: Record<string, unknown>,
+  genre: Genre
+): Descriptions => {
+  const dp = merged.descriptions as Record<string, unknown>;
+  return {
+    genre,
+    hashtags: [...(dp.hashtags as string[])],
+    metadata: { ...(dp.metadata as Record<string, unknown> | undefined) },
+    opening: dp.opening as string,
+    perfectFor: [...(dp.perfect_for as string[])],
+    subOpening: (dp.sub_opening as string | undefined) ?? "",
+  };
+};
+
+const parseTitle = (merged: Record<string, unknown>): Title => {
+  const tl = merged.title as Record<string, unknown>;
+  // 旧実装が default_activities（タイポ）も許容していたので踏襲。
+  const defaultActivity =
+    (tl.default_activity as string | undefined) ??
+    (tl.default_activities as string | undefined) ??
+    "Study";
+  return {
+    defaultActivity,
+    template: tl.template as string,
+    templateCheck: {
+      ...(tl.template_check as Record<string, unknown> | undefined),
+    },
+    themeActivities: {
+      ...(tl.theme_activities as Record<string, string> | undefined),
+    },
+    themeScenes: {
+      ...(tl.theme_scenes as Record<string, ThemeScene> | undefined),
+    },
+  };
+};
+
+export const parseContent = (
+  merged: Record<string, unknown>,
+  channelName: string
+): Content => {
+  const genre = parseGenre(merged);
+  return {
+    descriptions: parseDescriptions(merged, genre),
+    genre,
+    tags: parseTags(merged, channelName),
+    title: parseTitle(merged),
+  };
+};
+
+/** チャンネル名（小文字）を含むデフォルトタグリスト。 */
+export const tagsDefault = (tags: Tags): string[] => [
+  ...tags.base,
+  tags.channelName.toLowerCase(),
+];
+
+/** コレクション名からタグリストを生成（最大 50 件）。 */
+export const tagsForCollection = (
+  tags: Tags,
+  collectionName: string
+): string[] => {
+  const result = tagsDefault(tags);
+  result.push(...tags.channelSpecific);
+  const lowered = collectionName.toLowerCase();
+  for (const [theme, themeTagList] of Object.entries(tags.themes)) {
+    if (lowered.includes(theme)) {
+      result.push(...themeTagList);
+      break;
+    }
+  }
+  return result.slice(0, 50);
+};
+
+// Python `str.title()` 相当: 連続する英字ランの先頭を大文字・残りを小文字化する。
+// 例 "8-bit" → "8-Bit"（数字直後の英字も語頭として扱われる）。
+const titleCase = (s: string): string =>
+  s.replaceAll(
+    /[A-Za-z]+/gu,
+    (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+  );
+
+/** `{style}` / `{primary}` / `{context}` を format 展開した冒頭行を返す。 */
+export const renderOpening = (d: Descriptions): string =>
+  d.opening
+    .replaceAll("{style}", titleCase(d.genre.style))
+    .replaceAll("{primary}", d.genre.primary)
+    .replaceAll("{context}", d.genre.context);
+
+/** ハッシュタグ行（スペース区切り）。 */
+export const hashtagLine = (d: Descriptions): string => d.hashtags.join(" ");
+
+// 長いキーから順に評価するため entries を key 長 降順でソートして返す（longest-match, #80）。
+const byLengthDesc = <T>(obj: Readonly<Record<string, T>>): [string, T][] =>
+  Object.entries(obj).sort((a, b) => b[0].length - a[0].length);
+
+/**
+ * テーマ名からアクティビティキーワードを取得。
+ *
+ * `theme_scenes` 優先（TTP 形式）、未定義なら `theme_activities`（レガシー形式）。
+ * 解決順序: (1) 完全一致 → (2) longest-match substring → (3) `defaultActivity`。
+ */
+export const activityForTheme = (title: Title, theme: string): string => {
+  const lowered = theme.toLowerCase();
+  if (Object.keys(title.themeScenes).length > 0) {
+    const exact = title.themeScenes[lowered];
+    if (exact !== undefined) {
+      return exact.activities ?? title.defaultActivity;
+    }
+    for (const [keyword, scene] of byLengthDesc(title.themeScenes)) {
+      if (lowered.includes(keyword)) {
+        return scene.activities ?? title.defaultActivity;
+      }
+    }
+    return title.defaultActivity;
+  }
+  if (Object.keys(title.themeActivities).length > 0) {
+    const exact = title.themeActivities[lowered];
+    if (exact !== undefined) {
+      return exact;
+    }
+    for (const [keyword, activity] of byLengthDesc(title.themeActivities)) {
+      if (lowered.includes(keyword)) {
+        return activity;
+      }
+    }
+  }
+  return title.defaultActivity;
+};
+
+/**
+ * テーマ名から英語シーンフレーズを取得（longest-match）。
+ * 未定義なら空文字列を返す（呼び出し側が `--en` フォールバックを判定する）。
+ */
+export const sceneForTheme = (title: Title, theme: string): string => {
+  if (Object.keys(title.themeScenes).length === 0) {
+    return "";
+  }
+  const lowered = theme.toLowerCase();
+  const exact = title.themeScenes[lowered];
+  if (exact !== undefined) {
+    return exact.scene ?? "";
+  }
+  for (const [keyword, scene] of byLengthDesc(title.themeScenes)) {
+    if (lowered.includes(keyword)) {
+      return scene.scene ?? "";
+    }
+  }
+  return "";
+};

--- a/packages/core/src/config/distrokid.ts
+++ b/packages/core/src/config/distrokid.ts
@@ -1,0 +1,75 @@
+// DistroKid 配信プロファイル設定（Python `distrokid.py` + loader の移植・optional/opt-in）。
+
+import { ConfigError } from "../errors.ts";
+import { asRecord, isRecord } from "./internal.ts";
+
+// distrokid.enabled === true のとき profile に必須となるフィールド（条件付き必須）。
+const REQUIRED_PROFILE_FIELDS = [
+  "artist_name",
+  "language",
+  "main_genre",
+  "songwriter",
+  "apple_music_credit",
+  "track_type",
+] as const;
+
+/** `distrokid.profile` セクション（distrokid.com/new フォーム項目に対応）。 */
+interface DistrokidProfile {
+  readonly artistName: string;
+  readonly language: string;
+  readonly mainGenre: string;
+  readonly songwriter: string;
+  readonly appleMusicCredit: string;
+  readonly trackType: string;
+}
+
+/** `distrokid` セクション（optional・opt-in）。 */
+export interface Distrokid {
+  readonly enabled: boolean;
+  readonly profile: DistrokidProfile;
+}
+
+const emptyProfile = (): DistrokidProfile => ({
+  appleMusicCredit: "",
+  artistName: "",
+  language: "",
+  mainGenre: "",
+  songwriter: "",
+  trackType: "",
+});
+
+export const parseDistrokid = (merged: Record<string, unknown>): Distrokid => {
+  const raw = merged.distrokid;
+  if (raw === undefined || raw === null) {
+    return { enabled: false, profile: emptyProfile() };
+  }
+  if (!isRecord(raw)) {
+    throw new ConfigError("distrokid セクションは object でなければなりません");
+  }
+
+  const enabled = (raw.enabled as boolean | undefined) ?? false;
+  const profileRoot = asRecord(raw.profile, "distrokid.profile");
+
+  // enabled=true のときのみ profile の必須 6 フィールドを条件付き検証（Fail Fast）。
+  if (enabled) {
+    const missing = REQUIRED_PROFILE_FIELDS.filter((f) => !profileRoot[f]);
+    if (missing.length > 0) {
+      throw new ConfigError(
+        `distrokid.enabled=true のとき distrokid.profile に必須フィールドがありません: ${missing.join(", ")}`
+      );
+    }
+  }
+
+  return {
+    enabled,
+    profile: {
+      appleMusicCredit:
+        (profileRoot.apple_music_credit as string | undefined) ?? "",
+      artistName: (profileRoot.artist_name as string | undefined) ?? "",
+      language: (profileRoot.language as string | undefined) ?? "",
+      mainGenre: (profileRoot.main_genre as string | undefined) ?? "",
+      songwriter: (profileRoot.songwriter as string | undefined) ?? "",
+      trackType: (profileRoot.track_type as string | undefined) ?? "",
+    },
+  };
+};

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,21 @@
+// 責務別に分割されたチャンネル設定 API（Python `utils/config/__init__.py` の移植）。
+//
+// 公開 API:
+//   loadConfig() -> ChannelConfig   シングルトン取得（初回に glob ロード）
+//   channelDir() -> string          チャンネルディレクトリ解決
+//   reset() -> void                 シングルトン state をリセット（テスト用）
+//   ChannelConfig                   合成ルート型
+//   + content / branding ヘルパー（Python dataclass メソッドの純関数移植）
+
+export {
+  activityForTheme,
+  hashtagLine,
+  renderOpening,
+  sceneForTheme,
+  tagsDefault,
+  tagsForCollection,
+} from "./content.ts";
+export { channelDir, loadConfig, reset } from "./loader.ts";
+export { brandingAsApiDict } from "./meta.ts";
+
+export type { ChannelConfig } from "./config.ts";

--- a/packages/core/src/config/internal.ts
+++ b/packages/core/src/config/internal.ts
@@ -1,0 +1,28 @@
+// config セクション parser 群が共有する構造ガード。
+// Python 版が `isinstance(x, dict)` / `x or {}` で行っていた object 判定を、
+// 配列を object 扱いしない厳密な形で TS へ移植する。
+
+import { ConfigError } from "../errors.ts";
+
+/** 配列を除外した plain object 判定（Python の `isinstance(x, dict)` 相当）。 */
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * optional セクションを object として読む。
+ *
+ * Python の `merged.get(key) or {}` を踏襲し、未設定（`undefined` / `null`）は
+ * 空 object へ畳む。非 object（配列・スカラー）は `label` を文脈に Fail Fast する。
+ */
+export const asRecord = (
+  value: unknown,
+  label: string
+): Record<string, unknown> => {
+  if (value === undefined || value === null) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    throw new ConfigError(`${label} は object でなければなりません`);
+  }
+  return value;
+};

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,0 +1,259 @@
+// `config/channel/*.json` を glob ロード・バリデーションし `ChannelConfig` を組み立てる。
+// Python `utils/config/loader.py` の移植（singleton + reset + channelDir + cross-file 検証）。
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+import { ConfigError } from "../errors.ts";
+import { parseAnalytics } from "./analytics.ts";
+import { parseAudio } from "./audio.ts";
+import { parseComments } from "./comments.ts";
+import type { ChannelConfig } from "./config.ts";
+import { parseContent } from "./content.ts";
+import type { Content } from "./content.ts";
+import { parseDistrokid } from "./distrokid.ts";
+import { isRecord } from "./internal.ts";
+import { localizationsAbsent, parseLocalizations } from "./localizations.ts";
+import type { Localizations } from "./localizations.ts";
+import { parseMeta } from "./meta.ts";
+import { parsePinnedComment } from "./pinned-comment.ts";
+import { parsePlaylists } from "./playlists.ts";
+import { parseShorts } from "./shorts.ts";
+import { parseWorkflow } from "./workflow.ts";
+import { parseYoutube } from "./youtube.ts";
+import type { YoutubeSection } from "./youtube.ts";
+
+let instance: ChannelConfig | null = null;
+let channelDirCache: string | null = null;
+
+// 必須キー（ドット区切り）。分割前の `_REQUIRED_KEYS` を新構造へ分配。
+const REQUIRED_KEYS_BY_SECTION: Record<string, string[]> = {
+  "content.json": [
+    "genre.primary",
+    "genre.style",
+    "genre.context",
+    "tags.base",
+    "tags.themes",
+    "descriptions.opening",
+    "descriptions.perfect_for",
+    "descriptions.hashtags",
+    "title.template",
+  ],
+  "meta.json": [
+    "channel.name",
+    "channel.short",
+    "channel.youtube_handle",
+    "channel.url",
+  ],
+  "youtube.json": [
+    "youtube.category_id",
+    "youtube.privacy_status",
+    "youtube.language",
+  ],
+};
+
+const isDir = (path: string): boolean =>
+  existsSync(path) && statSync(path).isDirectory();
+
+// CHANNEL_DIR 環境変数を優先し、未設定なら CWD 祖先を辿って config/channel/ を探す。
+const resolveChannelDir = (): string => {
+  const env = process.env.CHANNEL_DIR;
+  if (env) {
+    return env;
+  }
+  let current = process.cwd();
+  for (;;) {
+    if (isDir(join(current, "config", "channel"))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  throw new ConfigError(
+    "CHANNEL_DIR 環境変数を設定するか、config/channel/ を持つディレクトリ配下で実行してください"
+  );
+};
+
+/** チャンネルディレクトリを返す（シングルトン解決）。 */
+export const channelDir = (): string => {
+  if (channelDirCache === null) {
+    channelDirCache = resolveChannelDir();
+  }
+  return channelDirCache;
+};
+
+/** シングルトン state をリセット（テスト用）。 */
+export const reset = (): void => {
+  instance = null;
+  channelDirCache = null;
+};
+
+// 各ファイルを parse し、トップレベルキー重複を検出しつつ 1 つの object へマージ。
+const loadAndMerge = (files: string[]): Record<string, unknown> => {
+  const merged: Record<string, unknown> = {};
+  const keyOrigin: Record<string, string> = {};
+  for (const path of files) {
+    let data: unknown;
+    try {
+      data = JSON.parse(readFileSync(path, "utf-8"));
+    } catch (error) {
+      throw new ConfigError(`JSON パース失敗: ${path}: ${String(error)}`);
+    }
+    if (!isRecord(data)) {
+      throw new ConfigError(
+        `${path} のトップレベルは object でなければなりません`
+      );
+    }
+    for (const [key, value] of Object.entries(data)) {
+      if (key in merged) {
+        throw new ConfigError(
+          `トップレベルキー '${key}' が ${keyOrigin[key]} と ${basename(path)} の両方に存在します`
+        );
+      }
+      merged[key] = value;
+      keyOrigin[key] = basename(path);
+    }
+  }
+  return merged;
+};
+
+// 必須キーをドット区切りパスで検証し、欠落をまとめて報告。
+const validateRequired = (merged: Record<string, unknown>): void => {
+  const missing: string[] = [];
+  for (const keys of Object.values(REQUIRED_KEYS_BY_SECTION)) {
+    for (const keyPath of keys) {
+      let current: unknown = merged;
+      for (const part of keyPath.split(".")) {
+        if (!isRecord(current) || !(part in current)) {
+          missing.push(keyPath);
+          break;
+        }
+        current = current[part];
+      }
+    }
+  }
+  if (missing.length > 0) {
+    throw new ConfigError(
+      `config/channel/ に必須キーがありません: ${missing.join(", ")}`
+    );
+  }
+};
+
+const loadLocalizations = (
+  channelRoot: string,
+  fallbackLanguage: string
+): Localizations => {
+  const locPath = join(channelRoot, "config", "localizations.json");
+  if (!existsSync(locPath)) {
+    return localizationsAbsent(fallbackLanguage);
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(readFileSync(locPath, "utf-8"));
+  } catch (error) {
+    throw new ConfigError(
+      `localizations.json の JSON パース失敗: ${locPath}: ${String(error)}`
+    );
+  }
+  return parseLocalizations(data);
+};
+
+// ファイル跨ぎ整合性チェック（違反はすべて ConfigError）。
+const validateCrossFile = (
+  youtube: YoutubeSection,
+  content: Content,
+  localizations: Localizations
+): void => {
+  // 1. content_model.languages ⊆ localizations.supported_languages（localizations 存在時）
+  if (localizations.exists) {
+    const unknownLangs = youtube.contentModel.languages.filter(
+      (lang) => !localizations.supportedLanguages.includes(lang)
+    );
+    if (unknownLangs.length > 0) {
+      throw new ConfigError(
+        `content_model.languages に localizations.supported_languages へ未登録の言語があります: ${JSON.stringify(unknownLangs)}`
+      );
+    }
+  }
+
+  // 2. title.theme_scenes のキー ⊆ tags.themes のキー
+  const themeKeys = new Set(Object.keys(content.tags.themes));
+  const unknownScenes = Object.keys(content.title.themeScenes)
+    .filter((key) => !themeKeys.has(key))
+    .toSorted();
+  if (unknownScenes.length > 0) {
+    throw new ConfigError(
+      `title.theme_scenes に tags.themes で定義されていないテーマキーがあります: ${JSON.stringify(unknownScenes)}`
+    );
+  }
+};
+
+const assemble = (
+  merged: Record<string, unknown>,
+  channelRoot: string
+): ChannelConfig => {
+  const meta = parseMeta(merged);
+  const content = parseContent(merged, meta.channelName);
+  const youtube = parseYoutube(merged);
+  const localizations = loadLocalizations(channelRoot, youtube.api.language);
+
+  validateCrossFile(youtube, content, localizations);
+
+  return {
+    analytics: parseAnalytics(merged),
+    audio: parseAudio(merged),
+    comments: parseComments(merged),
+    content,
+    distrokid: parseDistrokid(merged),
+    localizations,
+    meta,
+    pinnedComment: parsePinnedComment(merged),
+    playlists: parsePlaylists(merged),
+    shorts: parseShorts(merged),
+    workflow: parseWorkflow(merged),
+    youtube,
+  };
+};
+
+const build = (channelRoot: string): ChannelConfig => {
+  const channelSubdir = join(channelRoot, "config", "channel");
+  const legacyPath = join(channelRoot, "config", "channel_config.json");
+
+  if (existsSync(legacyPath)) {
+    throw new ConfigError(
+      `旧 channel_config.json が残っています: ${legacyPath}\nyt-config-migrate で新構造 (config/channel/*.json) へ変換してください`
+    );
+  }
+  if (!isDir(channelSubdir)) {
+    throw new ConfigError(
+      `config/channel/ ディレクトリが見つかりません: ${channelSubdir}`
+    );
+  }
+
+  const files = readdirSync(channelSubdir)
+    .filter((name) => name.endsWith(".json"))
+    .toSorted()
+    .map((name) => join(channelSubdir, name));
+  if (files.length === 0) {
+    throw new ConfigError(
+      `config/channel/ に JSON ファイルが 1 つもありません: ${channelSubdir}`
+    );
+  }
+
+  const merged = loadAndMerge(files);
+  validateRequired(merged);
+  return assemble(merged, channelRoot);
+};
+
+/** `config/channel/*.json` を glob ロードし `ChannelConfig` を返す（シングルトン）。 */
+export const loadConfig = (): ChannelConfig => {
+  if (instance !== null) {
+    return instance;
+  }
+  channelDirCache = resolveChannelDir();
+  instance = build(channelDirCache);
+  return instance;
+};

--- a/packages/core/src/config/localizations.ts
+++ b/packages/core/src/config/localizations.ts
@@ -1,0 +1,43 @@
+// ローカライゼーション設定（Python `utils/config/localizations.py` + loader の移植）。
+
+import { ConfigError } from "../errors.ts";
+import { isRecord } from "./internal.ts";
+
+/**
+ * `config/localizations.json`（`config/` 直下、`config/channel/` の外）の内容。
+ *
+ * - exists=true: `data` に JSON 全量、`supportedLanguages` / `defaultLanguage` も埋める
+ * - exists=false: `data={}`、`supportedLanguages=[youtube.api.language]`、`defaultLanguage=""`
+ */
+export interface Localizations {
+  readonly data: Readonly<Record<string, unknown>>;
+  readonly exists: boolean;
+  readonly supportedLanguages: readonly string[];
+  readonly defaultLanguage: string;
+}
+
+/** localizations.json が存在しないチャンネルのフォールバック値。 */
+export const localizationsAbsent = (
+  fallbackLanguage: string
+): Localizations => ({
+  data: {},
+  defaultLanguage: "",
+  exists: false,
+  supportedLanguages: [fallbackLanguage],
+});
+
+export const parseLocalizations = (data: unknown): Localizations => {
+  if (!isRecord(data)) {
+    throw new ConfigError(
+      "localizations.json のトップレベルは object でなければなりません"
+    );
+  }
+  return {
+    data,
+    defaultLanguage: (data.default_language as string | undefined) ?? "",
+    exists: true,
+    supportedLanguages: [
+      ...((data.supported_languages as string[] | undefined) ?? []),
+    ],
+  };
+};

--- a/packages/core/src/config/meta.ts
+++ b/packages/core/src/config/meta.ts
@@ -1,0 +1,92 @@
+// チャンネルメタ情報とブランディング設定（Python `utils/config/meta.py` の移植）。
+
+import { isRecord } from "./internal.ts";
+
+/** `youtube_channel` セクション（YouTube チャンネル本体設定・任意）。 */
+export interface Branding {
+  readonly description: string;
+  readonly keywords: readonly string[];
+  readonly country: string;
+  readonly defaultLanguage: string;
+  readonly unsubscribedTrailer: string;
+  // 未設定は null。`false` は明示的な「子供向けでない」申告として保持する。
+  readonly madeForKids: boolean | null;
+}
+
+/** `channel` セクション + `youtube_channel`（Branding）の合成。 */
+export interface ChannelMeta {
+  readonly channelName: string;
+  readonly channelShort: string;
+  readonly youtubeHandle: string;
+  readonly channelUrl: string;
+  readonly coreMessage: string;
+  readonly ctaSubscribe: string;
+  readonly tagline: string;
+  // YouTube チャンネル ID（`UC...`）。未設定（空文字）時は照合をスキップ (#561)。
+  readonly channelId: string;
+  readonly branding: Branding;
+}
+
+const parseBranding = (data: unknown): Branding => {
+  if (!isRecord(data)) {
+    return {
+      country: "",
+      defaultLanguage: "",
+      description: "",
+      keywords: [],
+      madeForKids: null,
+      unsubscribedTrailer: "",
+    };
+  }
+  return {
+    country: (data.country as string | undefined) ?? "",
+    defaultLanguage: (data.default_language as string | undefined) ?? "",
+    description: (data.description as string | undefined) ?? "",
+    keywords: [...((data.keywords as string[] | undefined) ?? [])],
+    madeForKids: (data.made_for_kids as boolean | undefined) ?? null,
+    unsubscribedTrailer:
+      (data.unsubscribed_trailer as string | undefined) ?? "",
+  };
+};
+
+export const parseMeta = (merged: Record<string, unknown>): ChannelMeta => {
+  const ch = merged.channel as Record<string, unknown>;
+  return {
+    branding: parseBranding(merged.youtube_channel),
+    channelId: (ch.channel_id as string | undefined) ?? "",
+    channelName: ch.name as string,
+    channelShort: ch.short as string,
+    channelUrl: ch.url as string,
+    coreMessage: (ch.core_message as string | undefined) ?? "",
+    ctaSubscribe: (ch.cta_subscribe as string | undefined) ?? "",
+    tagline: (ch.tagline as string | undefined) ?? "",
+    youtubeHandle: ch.youtube_handle as string,
+  };
+};
+
+/**
+ * Branding を YouTube API / yt-channel-settings が扱う dict 形式に戻す。
+ * 未設定キーは省略するが、`made_for_kids=false` は明示申告のため省略しない。
+ */
+export const brandingAsApiDict = (b: Branding): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  if (b.description) {
+    out.description = b.description;
+  }
+  if (b.keywords.length > 0) {
+    out.keywords = [...b.keywords];
+  }
+  if (b.country) {
+    out.country = b.country;
+  }
+  if (b.defaultLanguage) {
+    out.default_language = b.defaultLanguage;
+  }
+  if (b.unsubscribedTrailer) {
+    out.unsubscribed_trailer = b.unsubscribedTrailer;
+  }
+  if (b.madeForKids !== null) {
+    out.made_for_kids = b.madeForKids;
+  }
+  return out;
+};

--- a/packages/core/src/config/pinned-comment.ts
+++ b/packages/core/src/config/pinned-comment.ts
@@ -1,0 +1,51 @@
+// 固定コメント（オーナーコメント）自動投稿設定（Python `pinned_comment.py` + loader の移植）。
+
+import { ConfigError } from "../errors.ts";
+import { isRecord } from "./internal.ts";
+
+const DEFAULT_HISTORY_FILE = "pinned_comment_history.json";
+const DEFAULT_DELAY_SEC = 2.5;
+const DEFAULT_LANGUAGE = "en";
+
+/** `pinned_comment` セクション（optional・オプトイン）。 */
+export interface PinnedComment {
+  readonly enabled: boolean;
+  readonly historyFile: string;
+  readonly delayBetweenPostsSec: number;
+  readonly defaultLanguage: string;
+  readonly templates: Readonly<Record<string, string>>;
+}
+
+export const parsePinnedComment = (
+  merged: Record<string, unknown>
+): PinnedComment => {
+  const raw = merged.pinned_comment;
+  const pc = raw === undefined || raw === null ? {} : raw;
+  if (!isRecord(pc)) {
+    throw new ConfigError(
+      "pinned_comment セクションは object でなければなりません"
+    );
+  }
+  const templatesRaw = pc.templates;
+  const templatesRoot =
+    templatesRaw === undefined || templatesRaw === null ? {} : templatesRaw;
+  if (!isRecord(templatesRoot)) {
+    throw new ConfigError(
+      "pinned_comment.templates は {言語: テンプレート文字列} の object でなければなりません"
+    );
+  }
+  const templates: Record<string, string> = {};
+  for (const [lang, text] of Object.entries(templatesRoot)) {
+    templates[lang] = String(text);
+  }
+  return {
+    defaultLanguage:
+      (pc.default_language as string | undefined) ?? DEFAULT_LANGUAGE,
+    delayBetweenPostsSec:
+      (pc.delay_between_posts_sec as number | undefined) ?? DEFAULT_DELAY_SEC,
+    enabled: (pc.enabled as boolean | undefined) ?? false,
+    historyFile:
+      (pc.history_file as string | undefined) ?? DEFAULT_HISTORY_FILE,
+    templates,
+  };
+};

--- a/packages/core/src/config/playlists.ts
+++ b/packages/core/src/config/playlists.ts
@@ -1,0 +1,41 @@
+// プレイリスト設定（Python `utils/config/playlists.py` + loader `_build_playlists` の移植）。
+
+import { ConfigError } from "../errors.ts";
+import { isRecord } from "./internal.ts";
+
+/**
+ * `playlists` セクション（optional）。
+ *
+ * `items` は `{ key: { playlist_id, auto_add, title, ... } }` の dict-of-dict。
+ * 入力 JSON は string 形式 (`{"main": "PL..."}`) と dict 形式の両方を許容し、
+ * loader で必ず dict 形式へ正規化する。string は
+ * `{ playlist_id: <値>, auto_add: true, title: null }` へ展開（#275）。
+ * 内部エントリは snake_case キーを verbatim 保持する。
+ */
+export interface Playlists {
+  readonly items: Readonly<Record<string, Record<string, unknown>>>;
+}
+
+export const parsePlaylists = (merged: Record<string, unknown>): Playlists => {
+  const raw = merged.playlists;
+  if (raw === undefined || raw === null) {
+    return { items: {} };
+  }
+  if (!isRecord(raw)) {
+    throw new ConfigError("playlists セクションは object でなければなりません");
+  }
+  const items: Record<string, Record<string, unknown>> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "string") {
+      items[key] = { auto_add: true, playlist_id: value, title: null };
+    } else if (isRecord(value)) {
+      items[key] = { ...value };
+    } else {
+      // list / number / null など想定外型は Fail Fast で弾く（#419）。
+      throw new ConfigError(
+        `playlists.${key} は string または object でなければなりません`
+      );
+    }
+  }
+  return { items };
+};

--- a/packages/core/src/config/shorts.ts
+++ b/packages/core/src/config/shorts.ts
@@ -1,0 +1,53 @@
+// ショート設定（Python `utils/config/shorts.py` + loader `_build_shorts` の移植）。
+
+import { asRecord } from "./internal.ts";
+
+const DEFAULT_PUBLISH_TIME = "08:00";
+const DEFAULT_MIN_HOURS_BETWEEN_SHORTS = 24;
+
+/** collection 型（`/short`）固有の生成設定。 */
+interface ShortsCollection {
+  readonly defaultCount: number;
+  readonly chapterOffsetSec: number;
+}
+
+/** release 型（`/short-release`）固有の生成設定。 */
+interface ShortsRelease {
+  readonly languages: readonly string[];
+  readonly startSec: number;
+  readonly durationSec: number;
+}
+
+/** `shorts` セクション（optional・オプトイン）。 */
+export interface Shorts {
+  readonly enabled: boolean;
+  readonly publishTime: string;
+  readonly minHoursBetweenShortsPerCollection: number;
+  readonly mode: string;
+  readonly collection: ShortsCollection;
+  readonly release: ShortsRelease;
+}
+
+export const parseShorts = (merged: Record<string, unknown>): Shorts => {
+  const sh = asRecord(merged.shorts, "shorts");
+  const col = asRecord(sh.collection, "shorts.collection");
+  const rel = asRecord(sh.release, "shorts.release");
+  return {
+    collection: {
+      chapterOffsetSec: (col.chapter_offset_sec as number | undefined) ?? 30,
+      defaultCount: (col.default_count as number | undefined) ?? 3,
+    },
+    enabled: (sh.enabled as boolean | undefined) ?? false,
+    minHoursBetweenShortsPerCollection:
+      (sh.min_hours_between_shorts_per_collection as number | undefined) ??
+      DEFAULT_MIN_HOURS_BETWEEN_SHORTS,
+    mode: (sh.mode as string | undefined) ?? "auto",
+    publishTime:
+      (sh.publish_time as string | undefined) ?? DEFAULT_PUBLISH_TIME,
+    release: {
+      durationSec: (rel.duration_sec as number | undefined) ?? 40,
+      languages: [...((rel.languages as string[] | undefined) ?? ["jp", "en"])],
+      startSec: (rel.start_sec as number | undefined) ?? 30,
+    },
+  };
+};

--- a/packages/core/src/config/workflow.ts
+++ b/packages/core/src/config/workflow.ts
@@ -1,0 +1,37 @@
+// ワークフロー設定（Python `utils/config/workflow.py` + loader `_build_workflow` の移植）。
+
+import { asRecord } from "./internal.ts";
+
+/** `/wf-next` の承認ゲート設定（既定は両方 false で全自動進行）。 */
+interface ApprovalGates {
+  readonly audio: boolean;
+  readonly upload: boolean;
+}
+
+/** `/wf-next` 関連設定（`wf_next` セクション）。 */
+interface WfNext {
+  readonly approvalGates: ApprovalGates;
+}
+
+/** ワークフロー責務の合成（`workflow` セクション）。 */
+export interface Workflow {
+  readonly wfNext: WfNext;
+}
+
+export const parseWorkflow = (merged: Record<string, unknown>): Workflow => {
+  // 旧 top-level `post_upload` / `short` キーは必須登録していないため silently ignore。
+  const wf = asRecord(merged.workflow, "workflow");
+  const wfNext = asRecord(wf.wf_next, "workflow.wf_next");
+  const gates = asRecord(
+    wfNext.approval_gates,
+    "workflow.wf_next.approval_gates"
+  );
+  return {
+    wfNext: {
+      approvalGates: {
+        audio: (gates.audio as boolean | undefined) ?? false,
+        upload: (gates.upload as boolean | undefined) ?? false,
+      },
+    },
+  };
+};

--- a/packages/core/src/config/youtube.ts
+++ b/packages/core/src/config/youtube.ts
@@ -1,0 +1,171 @@
+// YouTube API 設定・music_engine・content_model・overlays（Python `youtube.py` の移植）。
+
+import { ConfigError } from "../errors.ts";
+import { asRecord, isRecord } from "./internal.ts";
+
+/** `youtube` セクション（API 基本設定）。 */
+interface YoutubeApi {
+  readonly categoryId: string;
+  readonly privacyStatus: string;
+  readonly language: string;
+  // 未設定時は現行の振る舞いに合わせ true（AI 開示フラグ）。
+  readonly containsSyntheticMedia: boolean;
+  // 未設定時は現行の振る舞いに合わせ false（子供向け申告）。
+  readonly selfDeclaredMadeForKids: boolean;
+}
+
+/** `content_model` セクション（optional）。 */
+interface ContentModel {
+  readonly type: string;
+  readonly languages: readonly string[];
+}
+
+/** `overlays.audio_visualizer` セクション（optional, #511）。 */
+interface OverlayAudioVisualizer {
+  readonly enabled: boolean;
+  readonly mode: string;
+  readonly size: string;
+  readonly rate: string;
+  readonly fscale: string;
+  readonly winSize: number;
+  readonly winFunc: string;
+  readonly colors: string;
+  readonly position: string;
+  readonly opacity: number;
+  readonly glowEnabled: boolean;
+  readonly glowSigma: number;
+  readonly glowOpacity: number;
+}
+
+/** `overlays.subscribe_popup` セクション（optional, #511）。 */
+interface OverlaySubscribePopup {
+  readonly enabled: boolean;
+  readonly image: string;
+  readonly startSec: number;
+  readonly durationSec: number;
+  readonly fadeSec: number;
+  readonly position: string;
+  readonly opacity: number;
+}
+
+/** `overlays.encoder` セクション（optional, #511）。 */
+interface OverlayEncoder {
+  readonly codec: string;
+  readonly preset: string;
+  readonly crf: number;
+  readonly pixFmt: string;
+  readonly maxrate: string;
+  readonly bufsize: string;
+  readonly profile: string;
+  readonly framerate: number;
+}
+
+/** `overlays` セクション（optional, #511）。 */
+interface Overlays {
+  readonly enabled: boolean;
+  readonly audioVisualizer: OverlayAudioVisualizer;
+  readonly subscribePopup: OverlaySubscribePopup;
+  readonly encoder: OverlayEncoder;
+}
+
+/** YouTube 責務の合成。 */
+export interface YoutubeSection {
+  readonly api: YoutubeApi;
+  readonly musicEngine: string;
+  readonly contentModel: ContentModel;
+  readonly overlays: Overlays;
+}
+
+const parseAudioVisualizer = (raw: unknown): OverlayAudioVisualizer => {
+  const av = asRecord(raw, "overlays.audio_visualizer");
+  return {
+    colors: (av.colors as string | undefined) ?? "white",
+    enabled: (av.enabled as boolean | undefined) ?? false,
+    fscale: (av.fscale as string | undefined) ?? "log",
+    glowEnabled: (av.glow_enabled as boolean | undefined) ?? true,
+    glowOpacity: (av.glow_opacity as number | undefined) ?? 0.45,
+    glowSigma: (av.glow_sigma as number | undefined) ?? 12,
+    mode: (av.mode as string | undefined) ?? "bar",
+    opacity: (av.opacity as number | undefined) ?? 0.85,
+    position: (av.position as string | undefined) ?? "(W-w)/2:H-h-40",
+    rate: (av.rate as string | undefined) ?? "24",
+    size: (av.size as string | undefined) ?? "1280x180",
+    winFunc: (av.win_func as string | undefined) ?? "hann",
+    winSize: (av.win_size as number | undefined) ?? 2048,
+  };
+};
+
+const parseSubscribePopup = (raw: unknown): OverlaySubscribePopup => {
+  const sp = asRecord(raw, "overlays.subscribe_popup");
+  return {
+    durationSec: (sp.duration_sec as number | undefined) ?? 8,
+    enabled: (sp.enabled as boolean | undefined) ?? false,
+    fadeSec: (sp.fade_sec as number | undefined) ?? 0.6,
+    image: (sp.image as string | undefined) ?? "subscribe-popup.png",
+    opacity: (sp.opacity as number | undefined) ?? 1,
+    position: (sp.position as string | undefined) ?? "W-w-40:40",
+    startSec: (sp.start_sec as number | undefined) ?? 5,
+  };
+};
+
+const parseEncoder = (raw: unknown): OverlayEncoder => {
+  const enc = asRecord(raw, "overlays.encoder");
+  return {
+    bufsize: (enc.bufsize as string | undefined) ?? "8M",
+    codec: (enc.codec as string | undefined) ?? "libx264",
+    crf: (enc.crf as number | undefined) ?? 20,
+    framerate: (enc.framerate as number | undefined) ?? 24,
+    maxrate: (enc.maxrate as string | undefined) ?? "4M",
+    pixFmt: (enc.pix_fmt as string | undefined) ?? "yuv420p",
+    preset: (enc.preset as string | undefined) ?? "medium",
+    profile: (enc.profile as string | undefined) ?? "high",
+  };
+};
+
+const parseOverlays = (raw: unknown): Overlays => {
+  const root = raw === undefined || raw === null ? {} : raw;
+  if (!isRecord(root)) {
+    throw new ConfigError("overlays セクションは object でなければなりません");
+  }
+  return {
+    audioVisualizer: parseAudioVisualizer(root.audio_visualizer),
+    enabled: (root.enabled as boolean | undefined) ?? false,
+    encoder: parseEncoder(root.encoder),
+    subscribePopup: parseSubscribePopup(root.subscribe_popup),
+  };
+};
+
+export const parseYoutube = (
+  merged: Record<string, unknown>
+): YoutubeSection => {
+  const yt = merged.youtube as Record<string, unknown>;
+  const api: YoutubeApi = {
+    categoryId: yt.category_id as string,
+    containsSyntheticMedia:
+      (yt.contains_synthetic_media as boolean | undefined) ?? true,
+    language: yt.language as string,
+    privacyStatus: yt.privacy_status as string,
+    selfDeclaredMadeForKids:
+      (yt.self_declared_made_for_kids as boolean | undefined) ?? false,
+  };
+
+  const cm = asRecord(merged.content_model, "content_model");
+  const contentModel: ContentModel = {
+    languages: [...((cm.languages as string[] | undefined) ?? [api.language])],
+    type: (cm.type as string | undefined) ?? "release",
+  };
+
+  const musicEngine = (merged.music_engine as string | undefined) ?? "suno";
+  if (musicEngine !== "suno" && musicEngine !== "lyria") {
+    console.warn(
+      `music_engine='${musicEngine}' は未知の値です（既知: 'suno' / 'lyria'）`
+    );
+  }
+
+  return {
+    api,
+    contentModel,
+    musicEngine,
+    overlays: parseOverlays(merged.overlays),
+  };
+};

--- a/packages/core/test/config-comments.test.ts
+++ b/packages/core/test/config-comments.test.ts
@@ -1,0 +1,320 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { loadConfig, reset } from "@youtube-automation/core/config";
+
+import {
+  cleanupChannels,
+  minimalSections,
+  restoreChannelDirEnv,
+  saveChannelDirEnv,
+  setupChannel,
+} from "./config-fixtures.ts";
+import type { Sections } from "./config-fixtures.ts";
+
+beforeAll(saveChannelDirEnv);
+afterAll(restoreChannelDirEnv);
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  reset();
+});
+
+afterEach(() => {
+  reset();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  cleanupChannels();
+});
+
+const load = (sections: Sections) => {
+  const dir = setupChannel(sections);
+  process.env.CHANNEL_DIR = dir;
+  return loadConfig();
+};
+
+// Builds a comments.json wrapping a single catch-all gemini rule + the given
+// generator block (mirrors the Python `_comments_with_generator` helper).
+const commentsWithGenerator = (
+  generator: Record<string, unknown>
+): Sections => {
+  const sections = minimalSections();
+  sections["comments.json"] = {
+    comments: {
+      enabled: true,
+      generator,
+      rules: [
+        { name: "catch_all", pattern: ".+", priority: 0, provider: "gemini" },
+      ],
+    },
+  };
+  return sections;
+};
+
+// --- defaults --------------------------------------------------------------
+
+describe("comments — defaults", () => {
+  test("absent comments.json yields a disabled codex default", () => {
+    // Given no comments.json
+    const config = load(minimalSections());
+
+    // Then the section is disabled with codex generator + documented defaults
+    expect(config.comments.enabled).toBe(false);
+    expect(config.comments.rules).toEqual([]);
+    expect(config.comments.generator.provider).toBe("codex");
+    expect(config.comments.maxRepliesPerRun).toBe(20);
+    expect(config.comments.generator.maxLength).toBe(280);
+    expect(config.comments.generator.requestsPerMinute).toBe(30);
+  });
+
+  test("comments with no generator block defaults to codex", () => {
+    // Given comments.json without a generator section
+    const sections = minimalSections();
+    sections["comments.json"] = { comments: { enabled: true, rules: [] } };
+
+    // Then the generator defaults to codex/skip
+    const { generator } = load(sections).comments;
+    expect(generator.provider).toBe("codex");
+    expect(generator.fallbackOnError).toBe("skip");
+  });
+});
+
+// --- full happy path -------------------------------------------------------
+
+describe("comments — full configuration", () => {
+  test("maps enabled comments, rules and generator to camelCase", () => {
+    // Given a fully-specified comments block
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        delay_between_replies_sec: 1,
+        enabled: true,
+        generator: {
+          channel_persona: "Warm lo-fi jazz host",
+          fallback_on_error: "retry",
+          max_length: 300,
+          model: "gemini-2.5-pro",
+          provider: "gemini",
+          requests_per_minute: 10,
+        },
+        max_replies_per_run: 5,
+        ng_words: ["spam"],
+        rules: [
+          {
+            keywords: ["こんにちは"],
+            language: "ja",
+            name: "greet_ja",
+            priority: 10,
+            provider: "gemini",
+          },
+        ],
+      },
+    };
+
+    // Then every field is mapped through (snake JSON → camel field)
+    const { comments } = load(sections);
+    expect(comments.enabled).toBe(true);
+    expect(comments.maxRepliesPerRun).toBe(5);
+    expect(comments.delayBetweenRepliesSec).toBe(1);
+    expect(comments.ngWords).toEqual(["spam"]);
+    expect(comments.rules).toHaveLength(1);
+    const [rule] = comments.rules;
+    expect(rule?.name).toBe("greet_ja");
+    expect(rule?.keywords).toEqual(["こんにちは"]);
+    expect(rule?.priority).toBe(10);
+    expect(rule?.provider).toBe("gemini");
+    const { generator } = comments;
+    expect(generator.provider).toBe("gemini");
+    expect(generator.model).toBe("gemini-2.5-pro");
+    expect(generator.channelPersona).toBe("Warm lo-fi jazz host");
+    expect(generator.maxLength).toBe(300);
+    expect(generator.fallbackOnError).toBe("retry");
+    expect(generator.requestsPerMinute).toBe(10);
+  });
+});
+
+// --- generator validation --------------------------------------------------
+
+describe("comments.generator — validation", () => {
+  test("codex provider is valid with a null model", () => {
+    // Given an explicit codex generator
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: { enabled: true, generator: { provider: "codex" }, rules: [] },
+    };
+
+    // Then it loads with model null and documented defaults
+    const { generator } = load(sections).comments;
+    expect(generator.provider).toBe("codex");
+    expect(generator.model).toBeNull();
+    expect(generator.fallbackOnError).toBe("skip");
+  });
+
+  test("rejects an unknown provider", () => {
+    // Given an unsupported provider
+    // When/Then load fails naming the provider key
+    expect(() => load(commentsWithGenerator({ provider: "openai" }))).toThrow(
+      /comments\.generator\.provider/u
+    );
+  });
+
+  test("rejects gemini provider without a model", () => {
+    // Given gemini with no model
+    // When/Then the model-required rule fires
+    expect(() => load(commentsWithGenerator({ provider: "gemini" }))).toThrow(
+      /model/u
+    );
+  });
+
+  test("rejects an invalid fallback_on_error", () => {
+    // Given an unsupported fallback value
+    const sections = commentsWithGenerator({
+      fallback_on_error: "template",
+      model: "gemini-2.5-pro",
+      provider: "gemini",
+    });
+
+    // When/Then the fallback enum guard fires
+    expect(() => load(sections)).toThrow(/fallback_on_error/u);
+  });
+
+  test("rejects a non-object generator", () => {
+    // Given generator declared as a string
+    const sections = minimalSections();
+    sections["comments.json"] = { comments: { generator: "gemini" } };
+
+    // When/Then the object-shape guard fires
+    expect(() => load(sections)).toThrow(/comments\.generator/u);
+  });
+});
+
+// --- rule validation -------------------------------------------------------
+
+describe("comments.rules — validation", () => {
+  test("rejects a rule with no name", () => {
+    // Given a rule missing its name
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: { enabled: true, rules: [{ keywords: ["hi"] }] },
+    };
+
+    // When/Then the rule index + name is reported
+    expect(() => load(sections)).toThrow(/comments\.rules\[0\]\.name/u);
+  });
+
+  test("rejects an invalid rule provider", () => {
+    // Given a rule with an unsupported provider override
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        enabled: true,
+        rules: [{ keywords: ["hi"], name: "bad_rule", provider: "openai" }],
+      },
+    };
+
+    // When/Then the rule provider guard fires
+    expect(() => load(sections)).toThrow(/comments\.rules\[0\]\.provider/u);
+  });
+
+  test("defaults rule scope to 'any' (#524)", () => {
+    // Given a rule with no scope
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: { enabled: true, rules: [{ keywords: ["hi"], name: "g" }] },
+    };
+
+    // Then the scope defaults to 'any' (backward-compatible)
+    expect(load(sections).comments.rules[0]?.scope).toBe("any");
+  });
+
+  test("reads explicit rule scope overrides (#524)", () => {
+    // Given rules with explicit scopes
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        enabled: true,
+        rules: [
+          { keywords: ["hi"], name: "top", scope: "top_level" },
+          { keywords: ["bye"], name: "rep", scope: "reply" },
+        ],
+      },
+    };
+
+    // Then both scopes are preserved
+    const { rules } = load(sections).comments;
+    expect(rules[0]?.scope).toBe("top_level");
+    expect(rules[1]?.scope).toBe("reply");
+  });
+
+  test("rejects an invalid rule scope (#524)", () => {
+    // Given a rule with an unsupported scope
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        enabled: true,
+        rules: [{ keywords: ["hi"], name: "bad", scope: "thread" }],
+      },
+    };
+
+    // When/Then the scope enum guard fires
+    expect(() => load(sections)).toThrow(/comments\.rules\[0\]\.scope/u);
+  });
+});
+
+// --- deprecated keys -------------------------------------------------------
+
+describe("comments — deprecated keys are rejected, not migrated", () => {
+  test("rejects comments.generator.type", () => {
+    // Given the retired generator.type key
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: { generator: { type: "template" } },
+    };
+
+    // When/Then it is rejected rather than auto-converted
+    expect(() => load(sections)).toThrow(/comments\.generator\.type/u);
+  });
+
+  test("rejects comments.templates", () => {
+    // Given the retired comments.templates key
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: { templates: { ja: { default: "hello" } } },
+    };
+
+    // When/Then it is rejected
+    expect(() => load(sections)).toThrow(/comments\.templates/u);
+  });
+
+  test("rejects comments.rules[].template_key", () => {
+    // Given a rule carrying the retired template_key
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        rules: [{ keywords: ["hi"], name: "legacy", template_key: "default" }],
+      },
+    };
+
+    // When/Then the rule-level deprecation guard fires
+    expect(() => load(sections)).toThrow(/template_key/u);
+  });
+
+  test("rejects comments.rules[].generator", () => {
+    // Given a rule carrying the retired generator key
+    const sections = minimalSections();
+    sections["comments.json"] = {
+      comments: {
+        rules: [{ generator: "gemini", keywords: ["hi"], name: "legacy" }],
+      },
+    };
+
+    // When/Then the rule-level deprecation guard fires
+    expect(() => load(sections)).toThrow(/comments\.rules\[0\]\.generator/u);
+  });
+});

--- a/packages/core/test/config-fixtures.ts
+++ b/packages/core/test/config-fixtures.ts
@@ -1,0 +1,110 @@
+// Shared fixtures for the config loader tests. Mirrors the Python
+// `tests/test_config_loader.py` helpers (`_minimal_sections` / `_setup_channel`)
+// so the TS port is verified against the same matrix of inputs.
+//
+// Not a `*.test.ts` file, so bun does not run it directly; it is imported by the
+// config-*.test.ts suites. It deliberately avoids importing the (not-yet-built)
+// config API — it only writes JSON fixtures and manages temp dirs — so it stays
+// type-clean while the implementation is still pending.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+// JSON object written verbatim as one `config/channel/<name>.json` file. Values
+// are `unknown` so a test can also write a deliberately malformed top level
+// (e.g. an array) to exercise the object-shape guards.
+export type Sections = Record<string, unknown>;
+
+// Temp channel dirs created during a run, torn down by `cleanupChannels()`.
+const createdDirs: string[] = [];
+
+// The minimal meta/content/youtube trio that satisfies every required key.
+// Returned fresh each call so a test can mutate its copy without bleed-through.
+export const minimalSections = (): Sections => ({
+  "content.json": {
+    descriptions: {
+      hashtags: ["#ChiptuneMusic"],
+      opening: "{style} {primary} for {context}",
+      perfect_for: ["Studying", "Gaming"],
+    },
+    genre: { context: "RPG", primary: "chiptune", style: "8-bit" },
+    tags: {
+      base: ["chiptune music", "8-bit"],
+      themes: {
+        battle: ["battle music", "boss battle"],
+        village: ["village music"],
+      },
+    },
+    title: { template: "{theme} - {activity}" },
+  },
+  "meta.json": {
+    channel: {
+      name: "Test Channel",
+      short: "TC",
+      tagline: "Test tagline",
+      url: "https://youtube.com/@testchannel",
+      youtube_handle: "@testchannel",
+    },
+  },
+  "youtube.json": {
+    youtube: { category_id: "10", language: "ja", privacy_status: "public" },
+  },
+});
+
+export const writeJson = (path: string, data: unknown): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data), "utf-8");
+};
+
+// Writes `sections` into `<tmp>/config/channel/` and (optionally) a
+// `<tmp>/config/localizations.json`, returning the channel root to point
+// `CHANNEL_DIR` at. Registers the dir for `cleanupChannels()`.
+export const setupChannel = (
+  sections: Sections,
+  localizations?: Record<string, unknown>
+): string => {
+  const dir = mkdtempSync(join(tmpdir(), "config-fixture-"));
+  createdDirs.push(dir);
+  for (const [filename, data] of Object.entries(sections)) {
+    writeJson(join(dir, "config", "channel", filename), data);
+  }
+  if (localizations !== undefined) {
+    writeJson(join(dir, "config", "localizations.json"), localizations);
+  }
+  return dir;
+};
+
+// Creates a channel root whose `config/channel/` directory exists but is empty
+// (the "no JSON files" boundary case).
+export const setupEmptyChannel = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "config-fixture-"));
+  createdDirs.push(dir);
+  mkdirSync(join(dir, "config", "channel"), { recursive: true });
+  return dir;
+};
+
+export const cleanupChannels = (): void => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+};
+
+// Snapshot/restore of CHANNEL_DIR so config tests cannot leak the env var into
+// sibling test files run in the same bun process.
+let savedChannelDir: string | undefined;
+
+export const saveChannelDirEnv = (): void => {
+  savedChannelDir = process.env.CHANNEL_DIR;
+};
+
+export const restoreChannelDirEnv = (): void => {
+  if (savedChannelDir === undefined) {
+    Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  } else {
+    process.env.CHANNEL_DIR = savedChannelDir;
+  }
+};

--- a/packages/core/test/config-helpers.test.ts
+++ b/packages/core/test/config-helpers.test.ts
@@ -1,0 +1,265 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+// The dataclass methods from the Python config sections are ported as
+// co-located pure functions operating on the parsed sections. They are part of
+// the faithful "whole utils/config" port (plan §5).
+import {
+  activityForTheme,
+  brandingAsApiDict,
+  hashtagLine,
+  loadConfig,
+  renderOpening,
+  reset,
+  sceneForTheme,
+  tagsDefault,
+  tagsForCollection,
+} from "@youtube-automation/core/config";
+
+import {
+  cleanupChannels,
+  minimalSections,
+  restoreChannelDirEnv,
+  saveChannelDirEnv,
+  setupChannel,
+} from "./config-fixtures.ts";
+import type { Sections } from "./config-fixtures.ts";
+
+beforeAll(saveChannelDirEnv);
+afterAll(restoreChannelDirEnv);
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  reset();
+});
+
+afterEach(() => {
+  reset();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  cleanupChannels();
+});
+
+const load = (sections: Sections) => {
+  const dir = setupChannel(sections);
+  process.env.CHANNEL_DIR = dir;
+  return loadConfig();
+};
+
+// --- tags ------------------------------------------------------------------
+
+describe("tagsDefault", () => {
+  test("appends the lowercased channel name to base tags", () => {
+    // Given the minimal content tags + channel "Test Channel"
+    const config = load(minimalSections());
+
+    // Then the default list ends with the lowercased channel name
+    expect(tagsDefault(config.content.tags)).toEqual([
+      "chiptune music",
+      "8-bit",
+      "test channel",
+    ]);
+  });
+});
+
+describe("tagsForCollection", () => {
+  test("adds channel-specific + matched-theme tags, capped at 50", () => {
+    // Given channel-specific tags and themed tag lists
+    const sections = minimalSections();
+    (
+      sections["content.json"] as { tags: Record<string, unknown> }
+    ).tags.channel_specific = ["ch-tag"];
+    const config = load(sections);
+
+    // When building tags for a battle-themed collection name
+    const tags = tagsForCollection(config.content.tags, "Epic Battle BGM");
+
+    // Then default + channel-specific + the matched theme tags are present
+    expect(tags).toContain("ch-tag");
+    // battle is the matched theme
+    expect(tags).toContain("battle music");
+    expect(tags).toContain("boss battle");
+    // village is an unmatched theme
+    expect(tags).not.toContain("village music");
+    // the default list carries the channel name
+    expect(tags).toContain("test channel");
+    expect(tags.length).toBeLessThanOrEqual(50);
+  });
+});
+
+// --- descriptions ----------------------------------------------------------
+
+describe("renderOpening", () => {
+  test("formats {style}/{primary}/{context} with title-cased style", () => {
+    // Given opening "{style} {primary} for {context}" + genre 8-bit/chiptune/RPG
+    const config = load(minimalSections());
+
+    // Then style is title-cased and placeholders are interpolated
+    expect(renderOpening(config.content.descriptions)).toBe(
+      "8-Bit chiptune for RPG"
+    );
+  });
+});
+
+describe("hashtagLine", () => {
+  test("joins the hashtags with a single space", () => {
+    // Given two hashtags
+    const sections = minimalSections();
+    (
+      sections["content.json"] as { descriptions: Record<string, unknown> }
+    ).descriptions.hashtags = ["#ChiptuneMusic", "#8bit"];
+    const config = load(sections);
+
+    // Then they render as a space-joined line
+    expect(hashtagLine(config.content.descriptions)).toBe(
+      "#ChiptuneMusic #8bit"
+    );
+  });
+});
+
+// --- title: activity_for_theme (#80 longest-match) ------------------------
+
+describe("activityForTheme — legacy theme_activities", () => {
+  test("matches a theme substring, else falls back to default_activity", () => {
+    // Given legacy theme_activities mapping battle→Gaming, default Chill
+    const sections = minimalSections();
+    const { title } = sections["content.json"] as {
+      title: Record<string, unknown>;
+    };
+    title.default_activity = "Chill";
+    title.theme_activities = { battle: "Gaming" };
+    const config = load(sections);
+
+    // Then a battle-themed name resolves to Gaming, others to the default
+    expect(activityForTheme(config.content.title, "Epic Battle Scene")).toBe(
+      "Gaming"
+    );
+    expect(activityForTheme(config.content.title, "Ocean Waves")).toBe("Chill");
+  });
+});
+
+// tags.themes must declare the same keys (cross-file subset rule), so cafe and
+// campus-cafe are added to themes alongside the theme_scenes entries.
+const withScenes = (): Sections => {
+  const sections = minimalSections();
+  const content = sections["content.json"] as {
+    tags: { themes: Record<string, unknown> };
+    title: Record<string, unknown>;
+  };
+  content.tags.themes = {
+    cafe: ["cafe music"],
+    "campus-cafe": ["campus cafe music"],
+  };
+  content.title.default_activity = "Study";
+  content.title.theme_scenes = {
+    cafe: { activities: "Study · Work · Reading", scene: "Cafe" },
+    "campus-cafe": {
+      activities: "Study · Work · Late Night",
+      scene: "Campus Cafe",
+    },
+  };
+  return sections;
+};
+
+describe("activityForTheme — theme_scenes longest-match (#80)", () => {
+  test("prefers an exact key match regardless of insertion order", () => {
+    // Given a short key (cafe) registered before the longer campus-cafe
+    const config = load(withScenes());
+
+    // Then an exact "campus-cafe" hits its own entry, not the shorter cafe
+    expect(activityForTheme(config.content.title, "campus-cafe")).toBe(
+      "Study · Work · Late Night"
+    );
+  });
+
+  test("prefers the longest substring match for non-exact names", () => {
+    // Given a name containing both cafe and campus-cafe
+    const config = load(withScenes());
+
+    // Then the longest key wins (campus-cafe over cafe)
+    expect(activityForTheme(config.content.title, "nice-campus-cafe-mix")).toBe(
+      "Study · Work · Late Night"
+    );
+  });
+
+  test("falls back to the shorter key when only it matches", () => {
+    // Given a name that only contains the shorter key
+    const config = load(withScenes());
+
+    // Then the shorter cafe entry is used
+    expect(activityForTheme(config.content.title, "after-midnight-cafe")).toBe(
+      "Study · Work · Reading"
+    );
+  });
+});
+
+// --- title: scene_for_theme -----------------------------------------------
+
+describe("sceneForTheme", () => {
+  test("returns the matched scene phrase via longest-match", () => {
+    // Given theme_scenes with cafe/campus-cafe (+ matching tags.themes keys)
+    const sections = minimalSections();
+    const content = sections["content.json"] as {
+      tags: { themes: Record<string, unknown> };
+      title: Record<string, unknown>;
+    };
+    content.tags.themes = {
+      cafe: ["cafe music"],
+      "campus-cafe": ["campus cafe music"],
+    };
+    content.title.theme_scenes = {
+      cafe: { activities: "Study", scene: "Cafe" },
+      "campus-cafe": { activities: "Late Night", scene: "Campus Cafe" },
+    };
+    const config = load(sections);
+
+    // Then the longest match returns its scene phrase
+    expect(sceneForTheme(config.content.title, "nice-campus-cafe-mix")).toBe(
+      "Campus Cafe"
+    );
+  });
+
+  test("returns an empty string when no theme_scenes are configured", () => {
+    // Given the minimal title with no theme_scenes
+    const config = load(minimalSections());
+
+    // Then scene resolution yields an empty string (caller decides fallback)
+    expect(sceneForTheme(config.content.title, "battle")).toBe("");
+  });
+});
+
+// --- branding: as_api_dict -------------------------------------------------
+
+describe("brandingAsApiDict", () => {
+  test("returns an empty object when youtube_channel is absent", () => {
+    // Given no youtube_channel branding
+    const config = load(minimalSections());
+
+    // Then the api dict is empty (unset keys omitted)
+    expect(brandingAsApiDict(config.meta.branding)).toEqual({});
+  });
+
+  test("emits only the set keys, including made_for_kids=false", () => {
+    // Given a partial branding block (made_for_kids explicitly false)
+    const sections = minimalSections();
+    (sections["meta.json"] as Record<string, unknown>).youtube_channel = {
+      description: "desc",
+      keywords: ["a", "b"],
+      made_for_kids: false,
+    };
+    const config = load(sections);
+
+    // Then only the provided keys appear; made_for_kids=false is NOT dropped
+    expect(brandingAsApiDict(config.meta.branding)).toEqual({
+      description: "desc",
+      keywords: ["a", "b"],
+      made_for_kids: false,
+    });
+  });
+});

--- a/packages/core/test/config-loader.test.ts
+++ b/packages/core/test/config-loader.test.ts
@@ -1,0 +1,290 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { existsSync, realpathSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { ConfigError } from "@youtube-automation/core";
+// Imported by the published package name + "./config" subpath so the test
+// exercises the core `exports` map. A missing/broken subpath export fails
+// resolution here, not in tsc.
+import { channelDir, loadConfig, reset } from "@youtube-automation/core/config";
+
+import {
+  cleanupChannels,
+  minimalSections,
+  restoreChannelDirEnv,
+  saveChannelDirEnv,
+  setupChannel,
+  setupEmptyChannel,
+  writeJson,
+} from "./config-fixtures.ts";
+
+beforeAll(saveChannelDirEnv);
+afterAll(restoreChannelDirEnv);
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  reset();
+});
+
+afterEach(() => {
+  reset();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  cleanupChannels();
+});
+
+// --- happy path: minimal required sections --------------------------------
+
+describe("loadConfig — minimal sections", () => {
+  test("assembles meta/content/youtube with documented defaults", () => {
+    // Given a channel with only the three required section files
+    const dir = setupChannel(minimalSections());
+    process.env.CHANNEL_DIR = dir;
+
+    // When the config is loaded
+    const config = loadConfig();
+
+    // Then meta is read straight from channel.*
+    expect(config.meta.channelName).toBe("Test Channel");
+    expect(config.meta.channelShort).toBe("TC");
+    expect(config.meta.youtubeHandle).toBe("@testchannel");
+    expect(config.meta.channelUrl).toBe("https://youtube.com/@testchannel");
+    expect(config.meta.tagline).toBe("Test tagline");
+
+    // And content + youtube carry the parsed + defaulted values
+    expect(config.content.genre.primary).toBe("chiptune");
+    expect(config.content.tags.base).toEqual(["chiptune music", "8-bit"]);
+    expect(config.youtube.api.language).toBe("ja");
+    // suno is the default engine
+    expect(config.youtube.musicEngine).toBe("suno");
+    // release is the default content model
+    expect(config.youtube.contentModel.type).toBe("release");
+    // content_model.languages falls back to [api.language] when unspecified
+    expect(config.youtube.contentModel.languages).toEqual(["ja"]);
+
+    // And optional sections collapse to their disabled/empty defaults
+    expect(config.localizations.exists).toBe(false);
+    expect(config.localizations.supportedLanguages).toEqual(["ja"]);
+    expect(config.analytics.collectionFilterKeywords).toEqual([]);
+    expect(config.playlists.items).toEqual({});
+    expect(config.audio.targetDurationMin).toBeNull();
+    expect(config.comments.enabled).toBe(false);
+    expect(config.pinnedComment.enabled).toBe(false);
+    expect(config.shorts.enabled).toBe(false);
+    expect(config.distrokid.enabled).toBe(false);
+  });
+});
+
+// --- required-key validation ----------------------------------------------
+
+describe("loadConfig — required keys", () => {
+  test("throws ConfigError naming a missing dotted key path", () => {
+    // Given a channel missing the required channel.name
+    const sections = minimalSections();
+    const meta = sections["meta.json"] as { channel: Record<string, unknown> };
+    Reflect.deleteProperty(meta.channel, "name");
+    const dir = setupChannel(sections);
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then load fails fast, naming the offending key path
+    expect(() => loadConfig()).toThrow(ConfigError);
+    expect(() => loadConfig()).toThrow(/channel\.name/u);
+  });
+});
+
+// --- top-level merge guards ------------------------------------------------
+
+describe("loadConfig — top-level merge", () => {
+  test("rejects a duplicate top-level key across two files", () => {
+    // Given `youtube` declared in both youtube.json and (wrongly) meta.json
+    const sections = minimalSections();
+    (sections["meta.json"] as Record<string, unknown>).youtube = {
+      category_id: "20",
+    };
+    const dir = setupChannel(sections);
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the collision is reported, not silently last-wins merged
+    expect(() => loadConfig()).toThrow(ConfigError);
+    expect(() => loadConfig()).toThrow(/youtube/u);
+  });
+
+  test("rejects a file whose top level is not an object", () => {
+    // Given an extra file whose root is an array
+    const sections = minimalSections();
+    sections["extra.json"] = ["not", "an", "object"];
+    const dir = setupChannel(sections);
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the non-object top level is rejected at merge time
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+});
+
+// --- structural guards -----------------------------------------------------
+
+describe("loadConfig — structural guards", () => {
+  test("rejects a leftover legacy channel_config.json", () => {
+    // Given the pre-split config file still present alongside the new layout
+    const dir = setupChannel(minimalSections());
+    writeJson(join(dir, "config", "channel_config.json"), { legacy: true });
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then load refuses and points at the migration tool
+    expect(() => loadConfig()).toThrow(/channel_config\.json/u);
+  });
+
+  test("rejects an empty config/channel directory", () => {
+    // Given config/channel/ exists but holds no JSON files
+    const dir = setupEmptyChannel();
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then load fails rather than returning an empty config
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+});
+
+// --- cross-file validation -------------------------------------------------
+
+describe("loadConfig — cross-file validation", () => {
+  test("rejects content_model.languages outside supported_languages", () => {
+    // Given a content language not present in localizations.supported_languages
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).content_model = {
+      languages: ["en"],
+      type: "collection",
+    };
+    const dir = setupChannel(sections, {
+      languages: {},
+      supported_languages: ["ja", "ko"],
+    });
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the subset rule is enforced
+    expect(() => loadConfig()).toThrow(/supported_languages/u);
+  });
+
+  test("rejects theme_scenes keys absent from tags.themes", () => {
+    // Given a title.theme_scenes key that is not a declared tags.themes key
+    const sections = minimalSections();
+    (
+      sections["content.json"] as { title: Record<string, unknown> }
+    ).title.theme_scenes = { unknown_theme: { activities: "Study" } };
+    const dir = setupChannel(sections);
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the dangling theme key is rejected
+    expect(() => loadConfig()).toThrow(/theme_scenes/u);
+  });
+});
+
+// --- singleton + reset -----------------------------------------------------
+
+describe("loadConfig — singleton semantics", () => {
+  test("memoizes and only re-reads after reset()", () => {
+    // Given a loaded config
+    const dir = setupChannel(minimalSections());
+    process.env.CHANNEL_DIR = dir;
+    const first = loadConfig();
+
+    // When loaded again without reset, the same instance is returned
+    expect(loadConfig()).toBe(first);
+
+    // And mutating the file does not invalidate the cached instance
+    const changed = minimalSections();
+    (
+      changed["meta.json"] as { channel: Record<string, unknown> }
+    ).channel.name = "Changed";
+    writeJson(
+      join(dir, "config", "channel", "meta.json"),
+      changed["meta.json"]
+    );
+    expect(loadConfig()).toBe(first);
+
+    // Until reset() clears the singleton, after which the new value is read
+    reset();
+    const third = loadConfig();
+    expect(third).not.toBe(first);
+    expect(third.meta.channelName).toBe("Changed");
+  });
+});
+
+// --- channelDir resolution -------------------------------------------------
+
+describe("channelDir", () => {
+  test("returns the CHANNEL_DIR env value verbatim", () => {
+    // Given CHANNEL_DIR set explicitly
+    const dir = setupChannel(minimalSections());
+    process.env.CHANNEL_DIR = dir;
+
+    // When resolving the channel dir
+    // Then the env value is used directly
+    expect(channelDir()).toBe(dir);
+  });
+
+  test("walks cwd ancestors to find config/channel when env is unset", () => {
+    // Given no env var and a cwd nested under a channel root
+    const dir = setupChannel(minimalSections());
+    const nested = join(dir, "collections", "foo");
+    writeJson(join(nested, ".keep.json"), {});
+    Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(nested);
+
+      // When resolving with ancestor search
+      // Then it climbs to the directory that owns config/channel/
+      expect(realpathSync(channelDir())).toBe(realpathSync(dir));
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});
+
+// --- real sample_channel fixture (acceptance criteria) --------------------
+
+describe("loadConfig — tests/fixtures/sample_channel", () => {
+  // Repo root is three levels up from packages/core/test/ (see skills-sync.test).
+  const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+  const sampleChannel = join(repoRoot, "tests", "fixtures", "sample_channel");
+
+  test("the committed fixture exists with config/channel", () => {
+    // Guards the precondition for the green-load assertion below.
+    expect(existsSync(join(sampleChannel, "config", "channel"))).toBe(true);
+  });
+
+  test("loads the committed fixture green with expected values", () => {
+    // Given the shared Python/TS fixture channel
+    process.env.CHANNEL_DIR = sampleChannel;
+
+    // When loaded through the TS API
+    const config = loadConfig();
+
+    // Then the cross-section values match the fixture on disk
+    expect(config.meta.channelName).toBe("Test Channel");
+    expect(config.meta.branding.description).toBe(
+      "Test channel description for sync."
+    );
+    expect(config.youtube.api.language).toBe("ja");
+    // musicEngine is unset in the fixture, so it falls back to the default
+    expect(config.youtube.musicEngine).toBe("suno");
+    expect(config.youtube.contentModel.type).toBe("collection");
+    expect(config.localizations.exists).toBe(true);
+    expect(config.localizations.supportedLanguages).toEqual(["ja", "en", "de"]);
+    expect(config.shorts.enabled).toBe(true);
+    expect(config.comments.enabled).toBe(false);
+    expect(config.pinnedComment.enabled).toBe(true);
+    expect(config.playlists.items.main).toEqual({
+      auto_add: true,
+      playlist_id: "PLtest123",
+      title: null,
+    });
+  });
+});

--- a/packages/core/test/config-sections.test.ts
+++ b/packages/core/test/config-sections.test.ts
@@ -1,0 +1,572 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+
+import { ConfigError } from "@youtube-automation/core";
+import { loadConfig, reset } from "@youtube-automation/core/config";
+
+import {
+  cleanupChannels,
+  minimalSections,
+  restoreChannelDirEnv,
+  saveChannelDirEnv,
+  setupChannel,
+} from "./config-fixtures.ts";
+import type { Sections } from "./config-fixtures.ts";
+
+beforeAll(saveChannelDirEnv);
+afterAll(restoreChannelDirEnv);
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  reset();
+});
+
+afterEach(() => {
+  reset();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  cleanupChannels();
+});
+
+// Loads a channel built from `sections` (+ optional localizations) in one step.
+const load = (sections: Sections, localizations?: Record<string, unknown>) => {
+  const dir = setupChannel(sections, localizations);
+  process.env.CHANNEL_DIR = dir;
+  return loadConfig();
+};
+
+// --- youtube api flags (#605) ---------------------------------------------
+
+describe("youtube.api synthetic-media flags", () => {
+  test("default to synthetic=true / made_for_kids=false when unset", () => {
+    // Given youtube.json without the AI-disclosure flags
+    const config = load(minimalSections());
+
+    // Then the upload-time defaults preserve current behaviour
+    expect(config.youtube.api.containsSyntheticMedia).toBe(true);
+    expect(config.youtube.api.selfDeclaredMadeForKids).toBe(false);
+  });
+
+  test("can be overridden from youtube.json", () => {
+    // Given explicit overrides in youtube.json
+    const sections = minimalSections();
+    const yt = (
+      sections["youtube.json"] as { youtube: Record<string, unknown> }
+    ).youtube;
+    yt.contains_synthetic_media = false;
+    yt.self_declared_made_for_kids = true;
+
+    // Then both flags flow through to the api section
+    const config = load(sections);
+    expect(config.youtube.api.containsSyntheticMedia).toBe(false);
+    expect(config.youtube.api.selfDeclaredMadeForKids).toBe(true);
+  });
+});
+
+// --- music_engine warning (non-fatal) -------------------------------------
+
+describe("youtube.musicEngine", () => {
+  test("warns but does not throw on an unknown engine", () => {
+    // Given an unrecognised music_engine value
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).music_engine =
+      "fairlight";
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    // When loaded
+    const config = load(sections);
+
+    // Then the value is preserved verbatim and a warning was emitted
+    expect(config.youtube.musicEngine).toBe("fairlight");
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+// --- overlays (#511) -------------------------------------------------------
+
+describe("youtube.overlays", () => {
+  test("default to disabled with nested defaults when unset", () => {
+    // Given youtube.json without an overlays key
+    const config = load(minimalSections());
+
+    // Then overlays is disabled but nested structure is still safe to read
+    expect(config.youtube.overlays.enabled).toBe(false);
+    expect(config.youtube.overlays.audioVisualizer.enabled).toBe(false);
+    expect(config.youtube.overlays.subscribePopup.enabled).toBe(false);
+    expect(config.youtube.overlays.encoder.codec).toBe("libx264");
+    expect(config.youtube.overlays.encoder.framerate).toBe(24);
+    expect(config.youtube.overlays.audioVisualizer.opacity).toBe(0.85);
+  });
+
+  test("full override flows every nested field through", () => {
+    // Given a fully-specified overlays block
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).overlays = {
+      audio_visualizer: {
+        colors: "0xff66ccff",
+        enabled: true,
+        glow_opacity: 0.5,
+        glow_sigma: 14,
+        opacity: 0.9,
+        position: "(W-w)/2:H-h-80",
+        rate: "30",
+        size: "1920x240",
+        win_size: 4096,
+      },
+      enabled: true,
+      encoder: {
+        bufsize: "12M",
+        crf: 18,
+        framerate: 30,
+        maxrate: "6M",
+        preset: "slow",
+      },
+      subscribe_popup: {
+        duration_sec: 10,
+        enabled: true,
+        fade_sec: 0.8,
+        image: "popup.png",
+        opacity: 0.95,
+        position: "W-w-32:32",
+        start_sec: 8.5,
+      },
+    };
+
+    // Then nested fields are mapped (snake JSON → camel field) without loss
+    const ov = load(sections).youtube.overlays;
+    expect(ov.enabled).toBe(true);
+    expect(ov.audioVisualizer.size).toBe("1920x240");
+    expect(ov.audioVisualizer.winSize).toBe(4096);
+    expect(ov.audioVisualizer.glowSigma).toBe(14);
+    expect(ov.subscribePopup.image).toBe("popup.png");
+    expect(ov.subscribePopup.startSec).toBe(8.5);
+    expect(ov.subscribePopup.fadeSec).toBe(0.8);
+    expect(ov.encoder.preset).toBe("slow");
+    expect(ov.encoder.crf).toBe(18);
+    expect(ov.encoder.framerate).toBe(30);
+  });
+
+  test("rejects a non-object overlays section", () => {
+    // Given overlays declared as an array
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).overlays = [
+      "enabled",
+      "true",
+    ];
+
+    // When/Then the object-shape guard fires
+    expect(() => load(sections)).toThrow(/overlays/u);
+  });
+
+  test("rejects a non-object overlays.audio_visualizer", () => {
+    // Given a nested overlay block of the wrong shape
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).overlays = {
+      audio_visualizer: "bar",
+    };
+
+    // When/Then the nested guard fires
+    expect(() => load(sections)).toThrow(/audio_visualizer/u);
+  });
+});
+
+// --- shorts ----------------------------------------------------------------
+
+describe("shorts", () => {
+  test("default to disabled with documented defaults when absent", () => {
+    // Given no shorts.json (opt-in section)
+    const config = load(minimalSections());
+
+    // Then shorts collapses to the opt-out defaults
+    expect(config.shorts.enabled).toBe(false);
+    expect(config.shorts.publishTime).toBe("08:00");
+    expect(config.shorts.minHoursBetweenShortsPerCollection).toBe(24);
+    expect(config.shorts.mode).toBe("auto");
+    expect(config.shorts.collection.defaultCount).toBe(3);
+    expect(config.shorts.release.languages).toEqual(["jp", "en"]);
+  });
+
+  test("full override flows every field through", () => {
+    // Given a fully-specified shorts block
+    const sections = minimalSections();
+    sections["shorts.json"] = {
+      shorts: {
+        collection: { chapter_offset_sec: 45, default_count: 5 },
+        enabled: true,
+        min_hours_between_shorts_per_collection: 12,
+        mode: "collection",
+        publish_time: "09:30",
+        release: { duration_sec: 30, languages: ["jp"], start_sec: 20 },
+      },
+    };
+
+    // Then all fields land in the shorts section
+    const { shorts } = load(sections);
+    expect(shorts.enabled).toBe(true);
+    expect(shorts.publishTime).toBe("09:30");
+    expect(shorts.minHoursBetweenShortsPerCollection).toBe(12);
+    expect(shorts.mode).toBe("collection");
+    expect(shorts.collection.defaultCount).toBe(5);
+    expect(shorts.collection.chapterOffsetSec).toBe(45);
+    expect(shorts.release.languages).toEqual(["jp"]);
+    expect(shorts.release.startSec).toBe(20);
+    expect(shorts.release.durationSec).toBe(30);
+  });
+});
+
+// --- audio -----------------------------------------------------------------
+
+describe("audio", () => {
+  test("defaults to null durations and chapterMax=100", () => {
+    // Given no audio.json
+    const config = load(minimalSections());
+
+    // Then optional durations stay null and chapterMax uses the documented 100
+    expect(config.audio.targetDurationMin).toBeNull();
+    expect(config.audio.targetDurationMax).toBeNull();
+    expect(config.audio.chapterMax).toBe(100);
+  });
+
+  test("reads overrides from audio.json", () => {
+    // Given audio overrides
+    const sections = minimalSections();
+    sections["audio.json"] = {
+      audio: { chapter_max: 50, target_duration_min: 120 },
+    };
+
+    // Then values flow through
+    const { audio } = load(sections);
+    expect(audio.targetDurationMin).toBe(120);
+    expect(audio.chapterMax).toBe(50);
+  });
+});
+
+// --- analytics -------------------------------------------------------------
+
+describe("analytics", () => {
+  test("defaults to empty keywords and benchmark channels", () => {
+    // Given no analytics.json
+    const config = load(minimalSections());
+
+    // Then both collections are empty
+    expect(config.analytics.collectionFilterKeywords).toEqual([]);
+    expect(config.analytics.benchmark.channels).toEqual([]);
+  });
+
+  test("reads keywords and benchmark channels", () => {
+    // Given analytics + benchmark data
+    const sections = minimalSections();
+    sections["analytics.json"] = {
+      analytics: { collection_filter_keywords: ["collection", "complete"] },
+      benchmark: { channels: [{ id: "UC123", name: "Rival" }] },
+    };
+
+    // Then both flow through verbatim
+    const { analytics } = load(sections);
+    expect(analytics.collectionFilterKeywords).toEqual([
+      "collection",
+      "complete",
+    ]);
+    expect(analytics.benchmark.channels).toEqual([
+      { id: "UC123", name: "Rival" },
+    ]);
+  });
+});
+
+// --- playlists (#275 / #419) ----------------------------------------------
+//
+// Inner playlist entries keep snake_case JSON keys: dict entries are passed
+// through verbatim (e.g. `auto_add_themes`), so a string entry must normalise
+// to the SAME snake_case shape — `{ playlist_id, auto_add, title }` — for the
+// items map to stay internally consistent (matches Python `_build_playlists`).
+
+describe("playlists", () => {
+  test("normalises a string entry to a snake_case dict", () => {
+    // Given a string playlist id
+    const sections = minimalSections();
+    sections["playlists.json"] = { playlists: { main: "PL_X" } };
+
+    // Then it expands to the canonical dict shape
+    const config = load(sections);
+    expect(config.playlists.items.main).toEqual({
+      auto_add: true,
+      playlist_id: "PL_X",
+      title: null,
+    });
+  });
+
+  test("passes a dict entry through verbatim", () => {
+    // Given a dict playlist entry with extra keys
+    const sections = minimalSections();
+    sections["playlists.json"] = {
+      playlists: {
+        battle: {
+          auto_add_themes: ["fight"],
+          playlist_id: "PL_B",
+          title: "Battle Music",
+        },
+      },
+    };
+
+    // Then the entry is preserved as-is
+    const entry = load(sections).playlists.items.battle;
+    expect(entry).toEqual({
+      auto_add_themes: ["fight"],
+      playlist_id: "PL_B",
+      title: "Battle Music",
+    });
+  });
+
+  test("rejects a non-object playlists section", () => {
+    // Given playlists declared as an array
+    const sections = minimalSections();
+    sections["playlists.json"] = { playlists: [1] };
+
+    // When/Then the section-shape guard fires
+    expect(() => load(sections)).toThrow(/playlists/u);
+  });
+
+  test("rejects a per-key value that is neither string nor object", () => {
+    // Given a numeric playlist value (silent pass-through is forbidden, #419)
+    const sections = minimalSections();
+    sections["playlists.json"] = { playlists: { main: 42 } };
+
+    // When/Then the per-key guard fires, naming the offending key
+    expect(() => load(sections)).toThrow(/playlists\.main/u);
+  });
+});
+
+// --- workflow (#508) -------------------------------------------------------
+
+describe("workflow.wfNext.approvalGates", () => {
+  test("default both gates to false (fully automatic)", () => {
+    // Given no workflow.json
+    const config = load(minimalSections());
+
+    // Then both approval gates are off
+    expect(config.workflow.wfNext.approvalGates.audio).toBe(false);
+    expect(config.workflow.wfNext.approvalGates.upload).toBe(false);
+  });
+
+  test("read explicit and partial gate overrides", () => {
+    // Given only the audio gate enabled
+    const sections = minimalSections();
+    sections["workflow.json"] = {
+      workflow: { wf_next: { approval_gates: { audio: true } } },
+    };
+
+    // Then audio is on and the unspecified upload defaults off
+    const gates = load(sections).workflow.wfNext.approvalGates;
+    expect(gates.audio).toBe(true);
+    expect(gates.upload).toBe(false);
+  });
+
+  test("silently ignore legacy workflow.post_upload keys", () => {
+    // Given a stale workflow.post_upload.short_publish_time
+    const sections = minimalSections();
+    sections["workflow.json"] = {
+      workflow: { post_upload: { short_publish_time: "09:30" } },
+    };
+
+    // Then it is ignored and shorts.publish_time keeps its default
+    expect(load(sections).shorts.publishTime).toBe("08:00");
+  });
+
+  test("rejects a non-object workflow section", () => {
+    // Given workflow declared as a string
+    const sections = minimalSections();
+    sections["workflow.json"] = { workflow: "not-an-object" };
+
+    // When/Then the section guard fires
+    expect(() => load(sections)).toThrow(/workflow/u);
+  });
+
+  test("rejects a non-object workflow.wf_next", () => {
+    // Given workflow.wf_next of the wrong shape
+    const sections = minimalSections();
+    sections["workflow.json"] = { workflow: { wf_next: ["bad"] } };
+
+    // When/Then the nested guard fires
+    expect(() => load(sections)).toThrow(/wf_next/u);
+  });
+});
+
+// --- pinned comment --------------------------------------------------------
+
+describe("pinnedComment", () => {
+  test("defaults to disabled with empty templates", () => {
+    // Given no pinned-comment.json
+    const config = load(minimalSections());
+
+    // Then the opt-in section collapses to its disabled default
+    expect(config.pinnedComment.enabled).toBe(false);
+    expect(config.pinnedComment.templates).toEqual({});
+    expect(config.pinnedComment.historyFile).toBe(
+      "pinned_comment_history.json"
+    );
+    expect(config.pinnedComment.defaultLanguage).toBe("en");
+  });
+
+  test("reads enabled config with templates", () => {
+    // Given a configured pinned comment block
+    const sections = minimalSections();
+    sections["pinned-comment.json"] = {
+      pinned_comment: {
+        default_language: "ja",
+        delay_between_posts_sec: 1.5,
+        enabled: true,
+        history_file: "pins.json",
+        templates: { en: "{scene_phrase}", ja: "{scene_phrase} {scene_emoji}" },
+      },
+    };
+
+    // Then the fields are mapped to camelCase
+    const pc = load(sections).pinnedComment;
+    expect(pc.enabled).toBe(true);
+    expect(pc.historyFile).toBe("pins.json");
+    expect(pc.delayBetweenPostsSec).toBe(1.5);
+    expect(pc.defaultLanguage).toBe("ja");
+    expect(pc.templates.ja).toBe("{scene_phrase} {scene_emoji}");
+  });
+
+  test("rejects non-object templates", () => {
+    // Given templates declared as an array
+    const sections = minimalSections();
+    sections["pinned-comment.json"] = {
+      pinned_comment: { templates: ["not", "an", "object"] },
+    };
+
+    // When/Then the templates-shape guard fires
+    expect(() => load(sections)).toThrow(/pinned_comment\.templates/u);
+  });
+});
+
+// --- distrokid (#698) ------------------------------------------------------
+
+const fullDistrokidProfile = (): Record<string, string> => ({
+  apple_music_credit: "Jane Doe",
+  artist_name: "City Nights",
+  language: "English",
+  main_genre: "Electronic",
+  songwriter: "Jane Doe",
+  track_type: "Instrumental",
+});
+
+describe("distrokid", () => {
+  test("defaults to disabled with empty profile when absent", () => {
+    // Given no distrokid.json
+    const config = load(minimalSections());
+
+    // Then the opt-in section is disabled with blank profile fields
+    expect(config.distrokid.enabled).toBe(false);
+    expect(config.distrokid.profile.artistName).toBe("");
+    expect(config.distrokid.profile.trackType).toBe("");
+  });
+
+  test("loads an enabled profile through to camelCase fields", () => {
+    // Given enabled distrokid with a complete profile
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: { enabled: true, profile: fullDistrokidProfile() },
+    };
+
+    // Then all six profile fields are mapped
+    const dk = load(sections).distrokid;
+    expect(dk.enabled).toBe(true);
+    expect(dk.profile.artistName).toBe("City Nights");
+    expect(dk.profile.language).toBe("English");
+    expect(dk.profile.mainGenre).toBe("Electronic");
+    expect(dk.profile.songwriter).toBe("Jane Doe");
+    expect(dk.profile.appleMusicCredit).toBe("Jane Doe");
+    expect(dk.profile.trackType).toBe("Instrumental");
+  });
+
+  test("rejects enabled=true with a missing profile field", () => {
+    // Given enabled distrokid missing songwriter (conditional-required)
+    const sections = minimalSections();
+    const profile = fullDistrokidProfile();
+    Reflect.deleteProperty(profile, "songwriter");
+    sections["distrokid.json"] = { distrokid: { enabled: true, profile } };
+
+    // When/Then the conditional validation names the missing field
+    expect(() => load(sections)).toThrow(/songwriter/u);
+  });
+
+  test("skips profile validation when disabled", () => {
+    // Given disabled distrokid with an incomplete profile
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: { enabled: false, profile: { artist_name: "x" } },
+    };
+
+    // Then it loads without validating the profile
+    const dk = load(sections).distrokid;
+    expect(dk.enabled).toBe(false);
+    expect(dk.profile.artistName).toBe("x");
+  });
+
+  test("rejects a non-object distrokid section", () => {
+    // Given distrokid declared as an array
+    const sections = minimalSections();
+    sections["distrokid.json"] = { distrokid: ["not", "an", "object"] };
+
+    // When/Then the section guard fires
+    expect(() => load(sections)).toThrow(ConfigError);
+  });
+
+  test("rejects a non-object distrokid.profile via the shared asRecord guard", () => {
+    // Given profile declared as an array (regression guard for the DRY
+    // refactor that delegated this boundary check to internal.asRecord)
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: { enabled: false, profile: ["not", "an", "object"] },
+    };
+
+    // When/Then the profile guard fires with the same contextual message
+    expect(() => load(sections)).toThrow(
+      "distrokid.profile は object でなければなりません"
+    );
+  });
+});
+
+// --- localizations ---------------------------------------------------------
+
+describe("localizations", () => {
+  test("falls back to [api.language] when the file is absent", () => {
+    // Given no localizations.json
+    const config = load(minimalSections());
+
+    // Then exists=false and supported languages fall back to the api language
+    expect(config.localizations.exists).toBe(false);
+    expect(config.localizations.data).toEqual({});
+    expect(config.localizations.supportedLanguages).toEqual(["ja"]);
+    expect(config.localizations.defaultLanguage).toBe("");
+  });
+
+  test("reads supported + default languages when present", () => {
+    // Given a localizations.json with ja/en and the content languages within it
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).content_model = {
+      languages: ["ja"],
+      type: "collection",
+    };
+    const config = load(sections, {
+      default_language: "ja",
+      languages: { ja: { title_template: "x" } },
+      supported_languages: ["ja", "en"],
+    });
+
+    // Then exists=true and both language lists are read
+    expect(config.localizations.exists).toBe(true);
+    expect(config.localizations.supportedLanguages).toEqual(["ja", "en"]);
+    expect(config.localizations.defaultLanguage).toBe("ja");
+  });
+});


### PR DESCRIPTION
## Summary

## Parent
#727

## What to build
Python `utils/config/` 全体 (`loader.py` 約 700 行 + 9 個の責務別 dataclass: meta / content / youtube / analytics / playlists / workflow / audio / localizations / comments / pinned_comment / shorts) を TS に移植する。`load_config()` / `channelDir()` / `reset()` / `ChannelConfig` を export。glob ロード + バリデーション + 必須キー検証 (`_REQUIRED_KEYS_BY_SECTION`) を保持。

## Acceptance criteria
- [ ] `packages/core/config/{meta,content,youtube,analytics,playlists,workflow,audio,localizations,comments,pinnedComment,shorts}.ts` 各 type + parser
- [ ] `packages/core/config/loader.ts` で全 JSON glob load + validate
- [ ] `packages/core/config/index.ts` で `loadConfig` / `channelDir` / `reset` / `ChannelConfig` を export
- [ ] singleton + reset 機構 (テスト互換)
- [ ] `tests/fixtures/sample_channel/` を bun test fixture として読み込み green
- [ ] `ConfigError` を適切に throw

## Blocked by
- #734, #735

## Execution Report

Workflow `default` completed successfully.

Closes #736