### PR TITLE
[#737] issue-737-core-utils-metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./config": "./src/config/index.ts",
+    "./metadata": "./src/metadata.ts",
+    "./paths": "./src/paths.ts",
     "./skills-sync": "./skills-sync/index.ts"
   },
   "dependencies": {

--- a/packages/core/src/config/content.ts
+++ b/packages/core/src/config/content.ts
@@ -151,7 +151,7 @@ export const tagsForCollection = (
 
 // Python `str.title()` 相当: 連続する英字ランの先頭を大文字・残りを小文字化する。
 // 例 "8-bit" → "8-Bit"（数字直後の英字も語頭として扱われる）。
-const titleCase = (s: string): string =>
+export const titleCase = (s: string): string =>
   s.replaceAll(
     /[A-Za-z]+/gu,
     (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,0 +1,32 @@
+// metadata 生成 API の公開バレル（Python `utils/metadata_generator.py` の pure 部分）。
+//
+// tags（config/content）と loadTemplate（templates）もこのサブパスから再 export し、
+// 呼び出し側が metadata 関連を 1 か所から import できるようにする。
+
+export { tagsForCollection } from "./config/content.ts";
+export {
+  buildCompleteCollectionDescription,
+  formatSceneTitleViolations,
+  generateCompleteCollectionTitle,
+  generateLocalizations,
+  type SceneTitleViolation,
+  validateScenePhrases,
+} from "./metadata/collection.ts";
+export {
+  formatTitleTemplate,
+  referencedPlaceholders,
+} from "./metadata/format.ts";
+export {
+  buildShortDescription,
+  buildShortLocalizations,
+  formatShortDurationPhrase,
+} from "./metadata/shorts.ts";
+export {
+  buildTimestampsText,
+  cleanTrackTitle,
+  extractPatternKey,
+  type PatternKey,
+  type ThemeInline,
+  type TimestampTrack,
+} from "./metadata/tracks.ts";
+export { loadTemplate } from "./templates.ts";

--- a/packages/core/src/metadata/collection.ts
+++ b/packages/core/src/metadata/collection.ts
@@ -1,0 +1,308 @@
+// Complete Collection のタイトル・説明文・多言語ローカライゼーション生成
+// （metadata_generator.py の `_generate_title` / `generate_complete_collection_metadata`
+// の説明文組み立て / `generate_localizations` / `validate_scene_phrases` の pure 部分）。
+//
+// section_headers / usage_lines / duration / tracks など workflow-state / skill_config
+// 由来の値は引数で受け取り、ここでは fs I/O・subprocess を持たない純関数に保つ。
+
+import type { ChannelConfig } from "../config/config.ts";
+import { hashtagLine, renderOpening, titleCase } from "../config/content.ts";
+import { ValidationError } from "../errors.ts";
+import {
+  codepointLength,
+  DESCRIPTION_CODEPOINT_LIMIT,
+  formatTitleTemplate,
+  pyFormat,
+  truncateCodepoints,
+} from "./format.ts";
+import { rawLocalizations } from "./loc-data.ts";
+
+const TITLE_CODEPOINT_LIMIT = 100;
+
+// generate_localizations が全言語共通で埋める usage 行（Python 版と同一文面）。
+const LOCALIZED_USAGE_LINES = [
+  "• Original AI composition",
+  "• Free for personal & non-commercial use",
+  "• For commercial use, check the platform's AI content policy",
+  "• Redistribution prohibited",
+].join("\n");
+
+/** 多言語タイトルの codepoint 超過違反（100 codepoint 上限）。 */
+export interface SceneTitleViolation {
+  readonly lang: string;
+  readonly length: number;
+  readonly title: string;
+  readonly template: string;
+}
+
+const metadataString = (
+  metadata: Readonly<Record<string, unknown>>,
+  key: string,
+  fallback: string
+): string => (metadata[key] as string | undefined) ?? fallback;
+
+/**
+ * scene_phrases を localizations の全言語で試算し、100 codepoint 超過を一括検出する。
+ *
+ * @throws {ValidationError} scene_phrases が一部言語で欠落、または `title_template` が
+ *   無い言語があるとき。
+ */
+export const validateScenePhrases = (
+  scenePhrases: Readonly<Record<string, string>>,
+  config: ChannelConfig,
+  sceneEmoji: string
+): SceneTitleViolation[] => {
+  const loc = rawLocalizations(config);
+  const supported = loc.supported_languages ?? [];
+
+  const missing = supported.filter((lang) => !scenePhrases[lang]);
+  if (missing.length > 0) {
+    throw new ValidationError(
+      `scene_phrases に翻訳が不足しています。不足言語: ${JSON.stringify(missing)}\n` +
+        "→ コレクションの workflow-state.json に scene_phrases: {en, ja, ...} を populate してください。"
+    );
+  }
+
+  const bestForLine = metadataString(
+    config.content.descriptions.metadata,
+    "best_for",
+    "Study, Focus, Late Night"
+  );
+
+  const violations: SceneTitleViolation[] = [];
+  for (const lang of supported) {
+    const langData = loc.languages?.[lang] ?? {};
+    const titleTpl = langData.title_template;
+    if (!titleTpl) {
+      throw new ValidationError(
+        `localizations.json: language '${lang}' に title_template が無い`
+      );
+    }
+    const activities = langData.activities ?? bestForLine;
+    // missing チェック通過済みのため scenePhrases[lang] は必ず存在する。
+    const scene = scenePhrases[lang] as string;
+    const title = formatTitleTemplate(
+      titleTpl,
+      { activities, scene_emoji: sceneEmoji, scene_phrase: scene },
+      `localizations.json: language '${lang}' の title_template`
+    );
+    const length = codepointLength(title);
+    if (length > TITLE_CODEPOINT_LIMIT) {
+      violations.push({ lang, length, template: titleTpl, title });
+    }
+  }
+  return violations;
+};
+
+/** 違反リストを人間可読な複数行テキストへ整形する（CLI / エラーメッセージ共通）。 */
+export const formatSceneTitleViolations = (
+  violations: readonly SceneTitleViolation[]
+): string =>
+  violations
+    .map(
+      (v) =>
+        `  - [${v.lang}] ${v.length} codepoints (+${
+          v.length - TITLE_CODEPOINT_LIMIT
+        }): ${v.title}`
+    )
+    .join("\n");
+
+interface CompleteCollectionTitleOptions {
+  readonly theme: string;
+  readonly activity: string;
+  readonly activities: string;
+  readonly scenePhrase: string;
+  readonly sceneEmoji: string;
+  readonly durationDisplay: string;
+  readonly durationShort: string;
+}
+
+/**
+ * content.json の title.template から Complete Collection タイトルを生成する（100 codepoint 制限）。
+ *
+ * @throws {ValidationError} タイトルが 100 codepoint を超過したとき（silent slice 禁止）。
+ */
+export const generateCompleteCollectionTitle = (
+  config: ChannelConfig,
+  options: CompleteCollectionTitleOptions
+): string => {
+  const title = formatTitleTemplate(
+    config.content.title.template,
+    {
+      activities: options.activities,
+      activity: options.activity,
+      duration_display: options.durationDisplay,
+      duration_short: options.durationShort,
+      scene_emoji: options.sceneEmoji,
+      scene_phrase: options.scenePhrase,
+      style: titleCase(config.content.genre.style),
+      theme: options.theme,
+    },
+    "content.json: title.template"
+  );
+  const length = codepointLength(title);
+  if (length > TITLE_CODEPOINT_LIMIT) {
+    throw new ValidationError(
+      `生成したタイトルが ${length} codepoint と ${TITLE_CODEPOINT_LIMIT} を超過: \n  ${title}\n` +
+        "→ config/channel/content.json の title.theme_scenes の scene を短く書き直してください"
+    );
+  }
+  return title;
+};
+
+interface CompleteDescriptionSectionHeaders {
+  readonly channelLinkTemplate: string;
+  readonly perfectFor: string;
+  readonly usageAttribution: string;
+}
+
+interface CompleteDescriptionOptions {
+  readonly title: string;
+  readonly timestampBody: string;
+  readonly usageLines: readonly string[];
+  readonly sectionHeaders: CompleteDescriptionSectionHeaders;
+}
+
+/** Complete Collection の説明文を組み立てる（Python 版の構造順を踏襲）。 */
+export const buildCompleteCollectionDescription = (
+  config: ChannelConfig,
+  options: CompleteDescriptionOptions
+): string => {
+  const { sectionHeaders, timestampBody, title, usageLines } = options;
+  const { descriptions } = config.content;
+
+  const parts: string[] = [`🎵 ${title}`, ""];
+  if (timestampBody) {
+    parts.push(timestampBody);
+  }
+
+  const perfectForLines = descriptions.perfectFor
+    .map((item) => `• ${item}`)
+    .join("\n");
+  const channelLinkHeader = pyFormat(sectionHeaders.channelLinkTemplate, {
+    channel_name: config.meta.channelName,
+  });
+
+  parts.push(
+    "",
+    renderOpening(descriptions),
+    descriptions.subOpening,
+    "",
+    sectionHeaders.usageAttribution,
+    ...usageLines,
+    "",
+    `${sectionHeaders.perfectFor}\n${perfectForLines}`,
+    "",
+    channelLinkHeader,
+    config.meta.ctaSubscribe,
+    config.meta.tagline,
+    "",
+    hashtagLine(descriptions)
+  );
+  return parts.join("\n");
+};
+
+interface LocalizationsSectionHeaders {
+  readonly channelLinkTemplate: string;
+  readonly trackList: string;
+  readonly usageAttribution: string;
+}
+
+interface GenerateLocalizationsOptions {
+  readonly scenePhrases: Readonly<Record<string, string>>;
+  readonly timestampBody: string;
+  readonly sceneEmoji: string;
+  readonly sectionHeaders: LocalizationsSectionHeaders;
+}
+
+interface LocalizedText {
+  readonly title: string;
+  readonly description: string;
+}
+
+/**
+ * 各言語のローカライズされたタイトル・説明文を生成する（TTP ハイブリッド方式）。
+ *
+ * 100 codepoint 超過は全言語まとめて検出し、1 件でもあれば throw する。
+ *
+ * @throws {ValidationError} scene_phrases 欠落・title_template 欠落・codepoint 超過時。
+ */
+export const generateLocalizations = (
+  config: ChannelConfig,
+  options: GenerateLocalizationsOptions
+): Record<string, LocalizedText> => {
+  const { sceneEmoji, scenePhrases, sectionHeaders, timestampBody } = options;
+  const loc = rawLocalizations(config);
+  const { metadata } = config.content.descriptions;
+  const genreLine = metadataString(metadata, "genre", "Jazz");
+  const vibeLine = metadataString(metadata, "vibe", "Rainy night, Cozy");
+  const bestForLine = metadataString(
+    metadata,
+    "best_for",
+    "Study, Focus, Late Night"
+  );
+
+  const violations = validateScenePhrases(scenePhrases, config, sceneEmoji);
+  if (violations.length > 0) {
+    throw new ValidationError(
+      `localizations の ${violations.length} 言語でタイトルが ${TITLE_CODEPOINT_LIMIT} codepoint を超過:\n` +
+        `${formatSceneTitleViolations(violations)}\n` +
+        "→ workflow-state.json の該当 scene_phrases を短縮してください"
+    );
+  }
+
+  const result: Record<string, LocalizedText> = {};
+  for (const lang of loc.supported_languages ?? []) {
+    const langData = loc.languages?.[lang] ?? {};
+    const descData = langData.description ?? {};
+    // validateScenePhrases 通過済みのため scene と title_template は必ず存在する。
+    const scene = scenePhrases[lang] as string;
+    const titleTpl = langData.title_template as string;
+    const activities = langData.activities ?? bestForLine;
+    const title = formatTitleTemplate(
+      titleTpl,
+      { activities, scene_emoji: sceneEmoji, scene_phrase: scene },
+      `localizations.json: language '${lang}' の title_template`
+    );
+
+    const openingPoem = descData.opening_poem ?? "";
+    const cta = descData.cta_subscribe ?? config.meta.ctaSubscribe;
+    const tagline = descData.tagline ?? config.meta.tagline;
+    const hashtags =
+      descData.hashtags ?? hashtagLine(config.content.descriptions);
+    const channelLinkHeader = pyFormat(sectionHeaders.channelLinkTemplate, {
+      channel_name: config.meta.channelName,
+    });
+
+    const descParts: string[] = [];
+    if (openingPoem) {
+      descParts.push(openingPoem, "");
+    }
+    descParts.push(
+      `- Genre : ${genreLine}`,
+      `- Vibe : ${vibeLine}`,
+      `- Best for : ${bestForLine}`,
+      "",
+      sectionHeaders.trackList,
+      timestampBody,
+      "",
+      sectionHeaders.usageAttribution,
+      LOCALIZED_USAGE_LINES,
+      "",
+      channelLinkHeader,
+      cta,
+      tagline,
+      "",
+      hashtags
+    );
+
+    result[lang] = {
+      description: truncateCodepoints(
+        descParts.join("\n"),
+        DESCRIPTION_CODEPOINT_LIMIT
+      ),
+      title,
+    };
+  }
+  return result;
+};

--- a/packages/core/src/metadata/format.ts
+++ b/packages/core/src/metadata/format.ts
@@ -1,0 +1,144 @@
+// Python `string.Formatter` 系ミニ言語の TS 移植（metadata_generator.py の
+// `_referenced_placeholders` / `format_title_template` 周辺）。
+//
+// `str.format()` 互換を全面実装するのではなく、本リポジトリの title / description
+// テンプレートが使う範囲（`{field}` 置換、`{{` `}}` エスケープ、`{a.b}` / `{c[0]}`
+// の root 名抽出）に限定して faithfully に再現する。
+
+import { ValidationError } from "../errors.ts";
+
+interface FormatToken {
+  readonly literal: string;
+  readonly field: string | null;
+}
+
+// Python `string.Formatter().parse()` 相当。`{{`/`}}` を literal brace に畳み、
+// 置換フィールドは中身（`field!conv:spec`）をそのまま field として持つトークン列を返す。
+const parseFormat = (template: string): FormatToken[] => {
+  const tokens: FormatToken[] = [];
+  let literal = "";
+  let i = 0;
+  while (i < template.length) {
+    const ch = template[i];
+    if (ch === "{") {
+      if (template[i + 1] === "{") {
+        literal += "{";
+        i += 2;
+        continue;
+      }
+      const end = template.indexOf("}", i + 1);
+      if (end === -1) {
+        throw new ValidationError(
+          `テンプレートに対応する '}' が無い '{' があります: ${template}`
+        );
+      }
+      tokens.push({ field: template.slice(i + 1, end), literal });
+      literal = "";
+      i = end + 1;
+      continue;
+    }
+    if (ch === "}") {
+      if (template[i + 1] === "}") {
+        literal += "}";
+        i += 2;
+        continue;
+      }
+      throw new ValidationError(
+        `テンプレートに単独の '}' があります: ${template}`
+      );
+    }
+    literal += ch;
+    i += 1;
+  }
+  if (literal) {
+    tokens.push({ field: null, literal });
+  }
+  return tokens;
+};
+
+// `field!conv:spec` から root フィールド名を取り出す（`a.b` -> `a`, `c[0]` -> `c`）。
+const baseName = (field: string): string => {
+  const head = field.split(/[!:]/u)[0] ?? "";
+  return (head.split(".")[0] ?? "").split("[")[0] ?? "";
+};
+
+/** format テンプレートが参照するフィールド名の集合（`{a.b}` / `{c[0]}` は root に正規化）。 */
+export const referencedPlaceholders = (template: string): Set<string> => {
+  const referenced = new Set<string>();
+  for (const { field } of parseFormat(template)) {
+    if (field === null) {
+      continue;
+    }
+    const base = baseName(field);
+    if (base) {
+      referenced.add(base);
+    }
+  }
+  return referenced;
+};
+
+/**
+ * Python `str.format(**values)` の限定移植。
+ *
+ * 参照フィールドの root 名で `values` を引く。`values` に無いキーは Fail Fast。
+ * `format_title_template` は事前に未知プレースホルダを弾くため、こちらに到達する
+ * 経路では常にキーが揃っている前提。
+ */
+export const pyFormat = (
+  template: string,
+  values: Readonly<Record<string, string>>
+): string => {
+  let out = "";
+  for (const { field, literal } of parseFormat(template)) {
+    out += literal;
+    if (field === null) {
+      continue;
+    }
+    const base = baseName(field);
+    if (!(base in values)) {
+      throw new ValidationError(
+        `テンプレートのプレースホルダ '${base}' に対応する値がありません: ${template}`
+      );
+    }
+    out += values[base];
+  }
+  return out;
+};
+
+/**
+ * title テンプレートを整形する。未知プレースホルダは actionable な ValidationError にする。
+ *
+ * `str.format()` を直接呼ぶと提供キー外のプレースホルダ（例: `{adjective}`）で opaque な
+ * KeyError を投げて upload 全体が深部でクラッシュする（Python #574）。事前検出して
+ * 「使用不可プレースホルダ名 + 許可キー一覧」を含む ValidationError に変換する。
+ */
+export const formatTitleTemplate = (
+  template: string,
+  values: Readonly<Record<string, string>>,
+  context: string
+): string => {
+  const allowed = new Set(Object.keys(values));
+  const unknown = [...referencedPlaceholders(template)]
+    .filter((name) => !allowed.has(name))
+    .toSorted();
+  if (unknown.length > 0) {
+    throw new ValidationError(
+      `${context}: 使用できないプレースホルダ ${JSON.stringify(unknown)} が含まれています。\n` +
+        `→ 使用可能なキー: ${JSON.stringify([...allowed].toSorted())}\n` +
+        `→ テンプレート: ${template}`
+    );
+  }
+  return pyFormat(template, values);
+};
+
+/** YouTube 概要欄の codepoint 上限（description 系の単一の事実源）。 */
+export const DESCRIPTION_CODEPOINT_LIMIT = 5000;
+
+/** 文字列の codepoint 長（UTF-16 単位ではなく Python `len(str)` 相当）。 */
+export const codepointLength = (value: string): number => [...value].length;
+
+/** Python `value[:max]` 相当の codepoint 単位スライス。 */
+export const truncateCodepoints = (value: string, max: number): string => {
+  const codepoints = [...value];
+  return codepoints.length <= max ? value : codepoints.slice(0, max).join("");
+};

--- a/packages/core/src/metadata/loc-data.ts
+++ b/packages/core/src/metadata/loc-data.ts
@@ -1,0 +1,33 @@
+// `config/localizations.json` の raw 構造への型付きアクセサ。
+//
+// Python 版は `config.localizations.data`（dict そのもの）を `.get(...)` で読んでいた。
+// TS でも parse 済みの `Localizations.data`（raw JSON）を直接読むため、metadata 生成が
+// 参照するキー群だけを構造として宣言する。
+
+import type { ChannelConfig } from "../config/config.ts";
+
+/** 言語別 `description` ブロック（全キー optional）。 */
+interface RawLangDescription {
+  readonly tagline?: string;
+  readonly opening_poem?: string;
+  readonly cta_subscribe?: string;
+  readonly hashtags?: string;
+}
+
+/** 言語別エントリ（`languages[<lang>]`）。 */
+interface RawLangData {
+  readonly short_title_template?: string;
+  readonly short_description_template?: string;
+  readonly title_template?: string;
+  readonly activities?: string;
+  readonly description?: RawLangDescription;
+}
+
+/** `localizations.json` の参照キー群。 */
+export interface RawLocalizations {
+  readonly supported_languages?: readonly string[];
+  readonly languages?: Readonly<Record<string, RawLangData>>;
+}
+
+export const rawLocalizations = (config: ChannelConfig): RawLocalizations =>
+  config.localizations.data as RawLocalizations;

--- a/packages/core/src/metadata/shorts.ts
+++ b/packages/core/src/metadata/shorts.ts
@@ -1,0 +1,128 @@
+// Shorts 用メタデータの pure 組み立て（metadata_generator.py の module-level
+// helper `_format_short_duration_phrase` / `build_short_description` /
+// `build_short_localizations` の移植）。
+//
+// description / localizations は複数経路から呼ばれるため単一の事実源にする。
+
+import type { Audio } from "../config/audio.ts";
+import type { ChannelConfig } from "../config/config.ts";
+import {
+  DESCRIPTION_CODEPOINT_LIMIT,
+  pyFormat,
+  truncateCodepoints,
+} from "./format.ts";
+import { rawLocalizations } from "./loc-data.ts";
+
+// Python 組み込み `round()` 相当の round-half-to-even（banker's rounding）。
+// `Math.round` は half-up のため 2.5 → 3 となり Python（2.5 → 2）と乖離する。
+// 30 分の奇数倍（例 150 分）で差が出るため、faithful port では Python と揃える。
+const roundHalfToEven = (value: number): number => {
+  const floor = Math.floor(value);
+  const diff = value - floor;
+  if (diff < 0.5) {
+    return floor;
+  }
+  if (diff > 0.5) {
+    return floor + 1;
+  }
+  return floor % 2 === 0 ? floor : floor + 1;
+};
+
+/**
+ * `audio.target_duration_min` から「2 hours」等の表示文字列を組み立てる。
+ * null のときは "Full collection" にフォールバック（TypeError 回避）。
+ */
+export const formatShortDurationPhrase = (audio: Audio): string => {
+  const targetMin = audio.targetDurationMin;
+  if (targetMin === null) {
+    return "Full collection";
+  }
+  const hours = roundHalfToEven(targetMin / 60);
+  return hours === 1 ? "1 hour" : `${hours} hours`;
+};
+
+interface ShortDescriptionOptions {
+  readonly collectionName: string;
+  readonly ccVideoUrl: string;
+}
+
+/**
+ * Shorts デフォルト description（fallback と default 両方で使う共通組み立て）。
+ * `ccVideoUrl` が空なら `♫` 行を含めない。末尾に必ず `#Shorts` を付ける。
+ */
+export const buildShortDescription = (
+  config: ChannelConfig,
+  { collectionName, ccVideoUrl }: ShortDescriptionOptions
+): string => {
+  const durationPhrase = formatShortDurationPhrase(config.audio);
+  const parts = [
+    `${collectionName} (${durationPhrase}) | ${config.meta.channelName}`,
+    "",
+  ];
+  if (ccVideoUrl) {
+    parts.push(`♫ Full → ${ccVideoUrl}`, "");
+  }
+  parts.push("#Shorts");
+  return parts.join("\n");
+};
+
+interface ShortLocalizationsOptions {
+  readonly collectionName: string;
+  readonly theme: string;
+  readonly ccVideoUrl: string;
+}
+
+interface LocalizedText {
+  readonly title: string;
+  readonly description: string;
+}
+
+/**
+ * Shorts 用 localizations を生成する。
+ *
+ * - `short_title_template` を持たない言語は skip。
+ * - `short_description_template` が無い言語は `buildShortDescription` フォールバック。
+ * - `theme` を必須にして、初回 upload タイトル破壊事故を構造的に防ぐ。
+ */
+export const buildShortLocalizations = (
+  config: ChannelConfig,
+  { collectionName, theme, ccVideoUrl }: ShortLocalizationsOptions
+): Record<string, LocalizedText> => {
+  if (Object.keys(config.localizations.data).length === 0) {
+    return {};
+  }
+  const loc = rawLocalizations(config);
+  const { channelName, tagline: defaultTagline } = config.meta;
+  const result: Record<string, LocalizedText> = {};
+
+  for (const lang of loc.supported_languages ?? []) {
+    const langData = loc.languages?.[lang] ?? {};
+    const titleTpl = langData.short_title_template;
+    if (!titleTpl) {
+      continue;
+    }
+    const title = pyFormat(titleTpl, {
+      channel_name: channelName,
+      collection_name: collectionName,
+      theme,
+    });
+
+    const descData = langData.description ?? {};
+    const tagline = descData.tagline ?? defaultTagline;
+    const descTpl = langData.short_description_template;
+    const description = descTpl
+      ? pyFormat(descTpl, {
+          cc_video_url: ccVideoUrl,
+          channel_name: channelName,
+          collection_name: collectionName,
+          tagline,
+        })
+      : buildShortDescription(config, { ccVideoUrl, collectionName });
+
+    result[lang] = {
+      description: truncateCodepoints(description, DESCRIPTION_CODEPOINT_LIMIT),
+      title,
+    };
+  }
+  return result;
+};

--- a/packages/core/src/metadata/tracks.ts
+++ b/packages/core/src/metadata/tracks.ts
@@ -1,0 +1,104 @@
+// トラック名サニタイズと構造化タイムスタンプ整形（metadata_generator.py の
+// `_extract_pattern_key` / `_clean_track_title` / `generate_timestamps` +
+// `format_timestamps_text` の pure 部分）。
+//
+// afinfo / workflow-state.json への I/O は呼び出し側の責務とし、ここでは解析済みの
+// トラック列とテーマ表示名・装飾を引数で受け取る純関数として移植する。
+
+import { titleCase } from "../config/content.ts";
+
+export type PatternKey = "a" | "b" | "c" | "d";
+
+// `pattern-b1-` のような variation 接尾辞も許容する。末尾 `(?![a-z])` で
+// `pattern-e-`（範囲外）や `pattern-ab-`（2 文字目あり）を明示的に reject する。
+const PATTERN_KEY_RE = /^\d+-pattern-([a-d])(?![a-z])/iu;
+
+/** ファイル名から pattern_key（'a'|'b'|'c'|'d'）を抽出する。マッチしなければ null。 */
+export const extractPatternKey = (filename: string): PatternKey | null => {
+  const match = PATTERN_KEY_RE.exec(filename);
+  const letter = match?.[1];
+  if (letter === undefined) {
+    return null;
+  }
+  return letter.toLowerCase() as PatternKey;
+};
+
+// 冠詞・前置詞は小文字維持（先頭語は常に大文字）。Python 版 SMALL_WORDS と同一。
+const SMALL_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "and",
+  "but",
+  "or",
+  "for",
+  "nor",
+]);
+
+/** ファイル名から表示用トラックタイトルへサニタイズする。 */
+export const cleanTrackTitle = (filename: string): string => {
+  let title = filename
+    .replace(/^8bit\s+/iu, "")
+    .replace(/^\d{2}-/u, "")
+    .replace(/^pattern-[a-z]\d?-/iu, "")
+    .replace(/\s*\([^)]+\)\s*$/u, "")
+    .replaceAll("_", " ")
+    .replaceAll("-", " ");
+  title = title.split(/\s+/u).filter(Boolean).join(" ");
+  const words = titleCase(title).split(" ");
+  return words
+    .map((word, index) =>
+      index > 0 && SMALL_WORDS.has(word.toLowerCase())
+        ? word.toLowerCase()
+        : word
+    )
+    .join(" ");
+};
+
+/** タイムスタンプ整形の入力トラック（解析済み）。 */
+export interface TimestampTrack {
+  readonly patternKey?: string | null;
+  readonly timestamp: string;
+  readonly title: string;
+}
+
+/** テーマ見出し行の装飾（`section_headers.theme_inline` 由来）。 */
+export interface ThemeInline {
+  readonly prefix: string;
+  readonly suffix: string;
+}
+
+/**
+ * 構造化トラック列を YouTube 概要欄用テキストへ整形する。
+ *
+ * pattern_key の切り替わりごとにテーマ見出し行を挿入する。見出し行は
+ * YouTube チャプター仕様（timestamps が strictly ascending）を壊さないよう
+ * leading timestamp を載せない。トラックが無ければ空文字。
+ */
+export const buildTimestampsText = (
+  tracks: readonly TimestampTrack[],
+  themeNames: Readonly<Record<string, string>>,
+  themeInline: ThemeInline
+): string => {
+  if (tracks.length === 0) {
+    return "";
+  }
+  const lines: string[] = [];
+  let lastPattern: string | null = null;
+  for (const track of tracks) {
+    const pattern = track.patternKey ?? null;
+    if (pattern && pattern !== lastPattern) {
+      const label = themeNames[pattern] ?? `Pattern ${pattern.toUpperCase()}`;
+      lines.push(`${themeInline.prefix}${label}${themeInline.suffix}`);
+      lastPattern = pattern;
+    }
+    lines.push(`${track.timestamp} ${track.title}`);
+  }
+  return lines.join("\n");
+};

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,0 +1,270 @@
+// コレクションディレクトリ構造のパス解決（Python `utils/collection_paths.py` の移植）。
+//
+// ディレクトリ構造:
+//   NNN-collection-name/
+//   ├── 01-master/           # マスター音声・動画 + 番号付き shorts/
+//   ├── 02-Individual-music/ # 個別音声ファイル
+//   ├── 03-Individual-movie/ # 個別動画ファイル
+//   ├── 10-assets/           # 静止画・ループ動画素材
+//   ├── 20-documentation/    # 作業文書・プロンプト
+//   └── workflow-state.json  # 進捗トラッキング
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, extname, join, resolve } from "node:path";
+
+import { ValidationError } from "./errors.ts";
+
+const SHORT_THUMBNAIL_EXTENSIONS = ["jpg", "png"] as const;
+const SHORT_LOOP_INPUT_NAMES = ["short.png", "short.jpg"] as const;
+
+// サムネイル候補ファイルの優先順。アップロード経路と統一し、呼び出し経路によらず
+// 同一コレクションで同じ画像が選ばれることを保証する。
+const THUMBNAIL_CANDIDATES = [
+  "thumbnail.jpg",
+  "thumbnail.png",
+  "main.jpg",
+  "main.png",
+] as const;
+
+const isDir = (path: string): boolean =>
+  existsSync(path) && statSync(path).isDirectory();
+
+// 指定ディレクトリ直下の、拡張子が一致するファイルを sorted（Python `sorted(glob)` 相当）。
+// JS の既定文字列比較は UTF-16 code unit 順で、ASCII ファイル名では Python sorted() と一致する。
+const sortedByExt = (dir: string, ext: string): string[] => {
+  if (!existsSync(dir)) {
+    return [];
+  }
+  return readdirSync(dir)
+    .filter((name) => extname(name).toLowerCase() === ext)
+    .toSorted()
+    .map((name) => join(dir, name));
+};
+
+const pad2 = (value: number): string => String(value).padStart(2, "0");
+
+// 番号付き Shorts 動画を探す glob パターン（文字列）と、それに対応する実ファイル名 RegExp。
+const shortVideoGlob = (shortNum: number): string =>
+  `short-${pad2(shortNum)}-*.mp4`;
+const shortVideoNameRe = (shortNum: number): RegExp =>
+  new RegExp(`^short-${pad2(shortNum)}-.*\\.mp4$`, "u");
+
+// Python `str.split(sep, maxsplit)` 相当（JS の limit 引数は残りを捨てるため自前実装）。
+const splitMax = (value: string, sep: string, maxsplit: number): string[] => {
+  const parts: string[] = [];
+  let rest = value;
+  for (let i = 0; i < maxsplit; i += 1) {
+    const idx = rest.indexOf(sep);
+    if (idx === -1) {
+      break;
+    }
+    parts.push(rest.slice(0, idx));
+    rest = rest.slice(idx + sep.length);
+  }
+  parts.push(rest);
+  return parts;
+};
+
+const isAllDigits = (value: string): boolean =>
+  value.length > 0 && /^\d+$/u.test(value);
+
+/** 標準コレクションディレクトリ構造のパスリゾルバ。 */
+export class CollectionPaths {
+  readonly root: string;
+
+  constructor(collectionDir: string) {
+    this.root = resolve(collectionDir);
+  }
+
+  get masterDir(): string {
+    return join(this.root, "01-master");
+  }
+
+  get musicDir(): string {
+    return join(this.root, "02-Individual-music");
+  }
+
+  get movieDir(): string {
+    return join(this.root, "03-Individual-movie");
+  }
+
+  get assetsDir(): string {
+    return join(this.root, "10-assets");
+  }
+
+  get docsDir(): string {
+    return join(this.root, "20-documentation");
+  }
+
+  get workflowStatePath(): string {
+    return join(this.root, "workflow-state.json");
+  }
+
+  get trackingPath(): string {
+    return join(this.docsDir, "upload_tracking.json");
+  }
+
+  get descriptionsMdPath(): string {
+    return join(this.docsDir, "descriptions.md");
+  }
+
+  get thumbnailPromptsPath(): string {
+    return join(this.docsDir, "thumbnail-prompts.md");
+  }
+
+  /** 番号付き Shorts 動画を格納する実ディレクトリ。 */
+  get shortsDir(): string {
+    return join(this.masterDir, "shorts");
+  }
+
+  /** Shorts ループ動画の出力実ファイルパス。 */
+  get shortLoop(): string {
+    return join(this.assetsDir, "short-loop.mp4");
+  }
+
+  /** コレクション名（ディレクトリ名から日付・チャンネルプレフィックスを除去）。 */
+  get collectionName(): string {
+    const name = basename(this.root);
+    // "20260310-clm-some-name" → "some-name"
+    const parts = splitMax(name, "-", 2);
+    if (parts.length >= 3 && isAllDigits(parts[0] ?? "")) {
+      return parts[2] ?? name;
+    }
+    return name;
+  }
+
+  private get shortVideoPath(): string {
+    return join(this.masterDir, "short.mp4");
+  }
+
+  private shortThumbnailPath(
+    ext: (typeof SHORT_THUMBNAIL_EXTENSIONS)[number]
+  ): string {
+    return join(this.assetsDir, `short-thumbnail.${ext}`);
+  }
+
+  /** 01-master/ からマスター動画（.mp4）を探す。 */
+  findMasterVideo(): string | null {
+    return sortedByExt(this.masterDir, ".mp4")[0] ?? null;
+  }
+
+  /** 01-master/ からマスター音声（.mp3）を探す。 */
+  findMasterAudio(): string | null {
+    return sortedByExt(this.masterDir, ".mp3")[0] ?? null;
+  }
+
+  /** 10-assets/ からサムネイル画像を優先順（thumbnail.jpg > thumbnail.png > main.jpg > main.png）で探す。 */
+  findThumbnail(): string | null {
+    for (const name of THUMBNAIL_CANDIDATES) {
+      const path = join(this.assetsDir, name);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  /** 10-assets/ からメイン画像を探す（main.png > main.jpg）。 */
+  findMainImage(): string | null {
+    for (const name of ["main.png", "main.jpg"]) {
+      const path = join(this.assetsDir, name);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  /** 10-assets/ からループ動画を探す。 */
+  findLoopVideo(): string | null {
+    const path = join(this.assetsDir, "loop.mp4");
+    return existsSync(path) ? path : null;
+  }
+
+  /** 番号付き Shorts 動画を優先し、無ければ単一 Shorts 動画を探す。 */
+  findShortVideo(shortNum: number | null): string | null {
+    if (shortNum !== null && existsSync(this.shortsDir)) {
+      const pattern = shortVideoNameRe(shortNum);
+      const [first] = readdirSync(this.shortsDir)
+        .filter((name) => pattern.test(name))
+        .toSorted();
+      if (first !== undefined) {
+        return join(this.shortsDir, first);
+      }
+    }
+    const fallback = this.shortVideoPath;
+    return existsSync(fallback) ? fallback : null;
+  }
+
+  /** Shorts 動画探索時に確認する実パスまたは glob パターン（文字列）を返す。 */
+  shortVideoSearchPaths(shortNum: number | null): string[] {
+    if (shortNum === null) {
+      return [this.shortVideoPath];
+    }
+    return [
+      join(this.shortsDir, shortVideoGlob(shortNum)),
+      this.shortVideoPath,
+    ];
+  }
+
+  /** Shorts サムネイルの実ファイルを jpg、png の順に探す。 */
+  findShortThumbnail(): string | null {
+    for (const ext of SHORT_THUMBNAIL_EXTENSIONS) {
+      const path = this.shortThumbnailPath(ext);
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  /** Shorts ループ動画入力画像の探索候補実パス（png、jpg の順）。 */
+  shortLoopInputImageSearchPaths(): string[] {
+    return SHORT_LOOP_INPUT_NAMES.map((name) => join(this.assetsDir, name));
+  }
+
+  /** Shorts ループ動画入力画像の実ファイルを png、jpg の順に探す。 */
+  findShortLoopInputImage(): string | null {
+    for (const path of this.shortLoopInputImageSearchPaths()) {
+      if (existsSync(path)) {
+        return path;
+      }
+    }
+    return null;
+  }
+
+  /** 02-Individual-music/ の音声ファイル一覧（ソート済み）。 */
+  individualMusicFiles(): string[] {
+    return sortedByExt(this.musicDir, ".mp3");
+  }
+
+  /** 03-Individual-movie/ の動画ファイル一覧（ソート済み）。 */
+  individualMovieFiles(): string[] {
+    return sortedByExt(this.movieDir, ".mp4");
+  }
+}
+
+/**
+ * CLI 引数から collection ディレクトリを解決する（CWD フォールバック）。
+ *
+ * `arg` 指定時はそのパスを resolve して返す。未指定時は CWD が `01-master/` と
+ * `02-Individual-music/` を持つコレクションディレクトリであることを検証して返す。
+ *
+ * @throws {ValidationError} 判定に失敗したとき（Fail Fast）。
+ */
+export const resolveCollectionDir = (arg: string | null): string => {
+  if (arg) {
+    return resolve(arg);
+  }
+
+  const cwd = process.cwd();
+  const paths = new CollectionPaths(cwd);
+  if (isDir(paths.masterDir) && isDir(paths.musicDir)) {
+    return cwd;
+  }
+
+  throw new ValidationError(
+    "コレクションディレクトリを解決できません。引数で指定するか、" +
+      "01-master/ と 02-Individual-music/ を持つディレクトリで実行してください。"
+  );
+};

--- a/packages/core/src/templates.ts
+++ b/packages/core/src/templates.ts
@@ -1,0 +1,24 @@
+// 説明文テンプレートローダー（Python `src/youtube_automation/templates/` の移植）。
+//
+// テンプレートは `packages/core/templates/` に配置し、`import.meta.url` 基準で解決する
+// （process.cwd() に依存しないため、呼び出し側の作業ディレクトリに関係なく読める）。
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { ValidationError } from "./errors.ts";
+
+const TEMPLATES_DIR = join(import.meta.dirname, "..", "templates");
+
+// 配布する既知テンプレート名。未知名は Fail Fast で弾く。
+const TEMPLATE_NAMES = new Set(["complete_collection", "individual_track"]);
+
+/** `<name>.md` テンプレートを文字列で読み込む。未知名は ValidationError。 */
+export const loadTemplate = (name: string): string => {
+  if (!TEMPLATE_NAMES.has(name)) {
+    throw new ValidationError(
+      `未知のテンプレート名: ${name}（既知: ${[...TEMPLATE_NAMES].join(", ")}）`
+    );
+  }
+  return readFileSync(join(TEMPLATES_DIR, `${name}.md`), "utf-8");
+};

--- a/packages/core/templates/complete_collection.md
+++ b/packages/core/templates/complete_collection.md
@@ -1,0 +1,23 @@
+# Complete Collection Description Template
+
+🎵 {bit_depth} {collection_name} - {track_count} tracks, {total_duration}
+
+{timestamp_list}
+
+{description_opening}
+{description_sub_opening}
+
+📝 Usage & Attribution:
+• This music is original AI composition
+• Free to use for personal & commercial projects
+• Attribution appreciated but not required
+• Redistribution as-is prohibited
+
+🎮 Perfect for:
+{perfect_for_list}
+
+🔗 {channel_name}:
+{cta_subscribe}
+{tagline}
+
+{hashtag_line}

--- a/packages/core/templates/individual_track.md
+++ b/packages/core/templates/individual_track.md
@@ -1,0 +1,25 @@
+# Individual Track Description Template
+
+🎵 {track_title}
+From: {bit_depth} {collection_name}
+
+{description_opening}
+{description_sub_opening}
+
+📝 Usage & Attribution:
+• This music is original AI composition
+• Free to use for personal & commercial projects
+• Attribution appreciated but not required
+• Redistribution as-is prohibited
+
+🎮 Perfect for:
+{perfect_for_list}
+
+🔗 More from this collection:
+🎵 Complete Collection: {collection_url}
+
+🔗 {channel_name}:
+{cta_subscribe}
+{tagline}
+
+{hashtag_line}

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -1,0 +1,695 @@
+// Tests for packages/core/src/metadata.ts — the TS port of the pure
+// generation helpers from Python `utils/metadata_generator.py`.
+//
+// Per plan §2, only the *pure* surface is ported: title/description/localization
+// /shorts/track-string generation. The audio-analysis (afinfo), workflow-state
+// fs I/O, skill_config YAML and report orchestration are deferred. Functions
+// that need section headers / usage lines / durations / tracks receive them as
+// arguments (plan §4-B), so these tests pass them explicitly rather than reading
+// a skill_config or running subprocesses.
+//
+// Signature contract (the test-first spec the draft implements), from plan §4-B:
+//   referencedPlaceholders(template) -> Set<string>
+//   formatTitleTemplate(template, values, context) -> string
+//   cleanTrackTitle(filename) -> string
+//   extractPatternKey(filename) -> "a"|"b"|"c"|"d"|null
+//   buildTimestampsText(tracks, themeNames, themeInline) -> string
+//   formatShortDurationPhrase(audio) -> string
+//   buildShortDescription(config, {collectionName, ccVideoUrl}) -> string
+//   buildShortLocalizations(config, {collectionName, theme, ccVideoUrl}) -> record
+//   validateScenePhrases(scenePhrases, config, sceneEmoji) -> SceneTitleViolation[]
+//   formatSceneTitleViolations(violations) -> string
+//   generateCompleteCollectionTitle(config, {...}) -> string
+//   buildCompleteCollectionDescription(config, {...}) -> string
+//   generateLocalizations(config, {...}) -> record
+//   tagsForCollection(tags, name) -> string[]  (re-exported through metadata)
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { ValidationError } from "@youtube-automation/core";
+import { loadConfig, reset } from "@youtube-automation/core/config";
+import type { ChannelConfig } from "@youtube-automation/core/config";
+import {
+  buildCompleteCollectionDescription,
+  buildShortDescription,
+  buildShortLocalizations,
+  buildTimestampsText,
+  cleanTrackTitle,
+  extractPatternKey,
+  formatSceneTitleViolations,
+  formatShortDurationPhrase,
+  formatTitleTemplate,
+  generateCompleteCollectionTitle,
+  generateLocalizations,
+  referencedPlaceholders,
+  tagsForCollection,
+  validateScenePhrases,
+} from "@youtube-automation/core/metadata";
+
+import {
+  cleanupChannels,
+  minimalSections,
+  restoreChannelDirEnv,
+  saveChannelDirEnv,
+  setupChannel,
+} from "./config-fixtures.ts";
+import type { Sections } from "./config-fixtures.ts";
+
+beforeAll(saveChannelDirEnv);
+afterAll(restoreChannelDirEnv);
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  reset();
+});
+
+afterEach(() => {
+  reset();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  cleanupChannels();
+});
+
+// Loads a ChannelConfig from inline fixture sections + optional localizations.
+const loadFrom = (
+  sections: Sections,
+  localizations?: Record<string, unknown>
+): ChannelConfig => {
+  const dir = setupChannel(sections, localizations);
+  process.env.CHANNEL_DIR = dir;
+  return loadConfig();
+};
+
+// A localizations fixture with two render languages and one language that lacks
+// a short_title_template (to exercise the skip branch).
+const LOCALIZATIONS = {
+  languages: {
+    de: {
+      // No short_title_template -> skipped by buildShortLocalizations.
+      title_template: "{scene_phrase} - {activities}",
+    },
+    en: {
+      activities: "Study, Focus",
+      description: { opening_poem: "Rainy night", tagline: "EN tagline" },
+      short_title_template: "{theme} ✦ {channel_name} #Shorts",
+      title_template: "{scene_phrase} {activities}",
+    },
+    ja: {
+      activities: "勉強, 集中",
+      description: { opening_poem: "雨の夜", tagline: "JAタグライン" },
+      short_title_template: "{theme} ✦ {channel_name} #Shorts",
+      title_template: "{scene_phrase}｜{activities}",
+    },
+  },
+  supported_languages: ["en", "ja", "de"],
+};
+
+// --- referencedPlaceholders ------------------------------------------------
+
+describe("referencedPlaceholders", () => {
+  test("collects the field names a template references", () => {
+    expect(
+      [...referencedPlaceholders("{theme} - {activity}")].toSorted()
+    ).toEqual(["activity", "theme"]);
+  });
+
+  test("normalizes attribute and index access to the base name", () => {
+    // {a.b} and {c[0]} both reduce to their root field name
+    expect([...referencedPlaceholders("{a.b} {c[0]}")].toSorted()).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  test("returns an empty set for a template with no fields", () => {
+    expect([...referencedPlaceholders("no placeholders here")]).toEqual([]);
+  });
+
+  test("treats doubled braces as escaped literals, not fields", () => {
+    // Python string.Formatter parses {{ }} as a literal brace, not a field.
+    expect([...referencedPlaceholders("{{literal}}")]).toEqual([]);
+  });
+});
+
+// --- formatTitleTemplate ---------------------------------------------------
+
+describe("formatTitleTemplate", () => {
+  test("substitutes allowed placeholders", () => {
+    expect(
+      formatTitleTemplate(
+        "{theme} - {activity}",
+        { activity: "Study", theme: "Village" },
+        "content.json: title.template"
+      )
+    ).toBe("Village - Study");
+  });
+
+  test("throws ValidationError naming an unknown placeholder", () => {
+    // Given a template referencing a key absent from the values dict
+    expect(() =>
+      formatTitleTemplate(
+        "{theme} {adjective}",
+        { theme: "Village" },
+        "content.json: title.template"
+      )
+    ).toThrow(ValidationError);
+  });
+
+  test("includes the offending key and context in the error message", () => {
+    expect(() =>
+      formatTitleTemplate(
+        "{theme} {adjective}",
+        { theme: "Village" },
+        "content.json: title.template"
+      )
+    ).toThrow(/adjective/u);
+  });
+});
+
+// --- cleanTrackTitle -------------------------------------------------------
+
+describe("cleanTrackTitle", () => {
+  test("strips an 8bit prefix and title-cases", () => {
+    expect(cleanTrackTitle("8bit village town")).toBe("Village Town");
+  });
+
+  test("strips a two-digit number prefix and converts separators", () => {
+    expect(cleanTrackTitle("01-rainy-night")).toBe("Rainy Night");
+  });
+
+  test("strips a pattern prefix with a variation suffix", () => {
+    expect(cleanTrackTitle("pattern-a1-deep_focus")).toBe("Deep Focus");
+  });
+
+  test("removes a trailing parenthetical suffix", () => {
+    expect(cleanTrackTitle("midnight drive (Remix)")).toBe("Midnight Drive");
+  });
+
+  test("keeps small words lowercase except the first word", () => {
+    expect(cleanTrackTitle("a-tale-of-two-cities")).toBe(
+      "A Tale of Two Cities"
+    );
+  });
+});
+
+// --- extractPatternKey -----------------------------------------------------
+
+describe("extractPatternKey", () => {
+  test("extracts the lowercase pattern letter", () => {
+    expect(extractPatternKey("01-pattern-a-foo.mp3")).toBe("a");
+  });
+
+  test("tolerates a variation digit after the letter", () => {
+    expect(extractPatternKey("03-pattern-B1-x.mp3")).toBe("b");
+  });
+
+  test("returns null for an out-of-range letter", () => {
+    expect(extractPatternKey("01-pattern-e-x.mp3")).toBeNull();
+  });
+
+  test("returns null when a second letter follows (negative lookahead)", () => {
+    expect(extractPatternKey("01-pattern-ab-x.mp3")).toBeNull();
+  });
+
+  test("returns null without a leading numeric prefix", () => {
+    expect(extractPatternKey("pattern-a-x.mp3")).toBeNull();
+  });
+
+  test("returns null for a non-pattern filename", () => {
+    expect(extractPatternKey("midnight-drive.mp3")).toBeNull();
+  });
+});
+
+// --- buildTimestampsText ---------------------------------------------------
+
+describe("buildTimestampsText", () => {
+  const themeInline = { prefix: "── ", suffix: " ──" };
+
+  test("returns an empty string for no tracks", () => {
+    expect(buildTimestampsText([], {}, themeInline)).toBe("");
+  });
+
+  test("emits theme headers on pattern switches and track lines otherwise", () => {
+    // Given three tracks spanning two patterns, with one named theme
+    const tracks = [
+      { patternKey: "a", timestamp: "0:00", title: "Song A" },
+      { patternKey: "a", timestamp: "2:00", title: "Song B" },
+      { patternKey: "b", timestamp: "4:00", title: "Song C" },
+    ];
+    const themeNames = { a: "Morning" };
+
+    // When building the timestamp body
+    const text = buildTimestampsText(tracks, themeNames, themeInline);
+
+    // Then the named header decorates pattern a, the fallback labels pattern b,
+    // and header lines carry no leading timestamp (YouTube chapter rule).
+    expect(text).toBe(
+      [
+        "── Morning ──",
+        "0:00 Song A",
+        "2:00 Song B",
+        "── Pattern B ──",
+        "4:00 Song C",
+      ].join("\n")
+    );
+  });
+
+  test("renders a flat track list when no pattern keys are present", () => {
+    const tracks = [
+      { timestamp: "0:00", title: "One" },
+      { timestamp: "1:30", title: "Two" },
+    ];
+
+    expect(buildTimestampsText(tracks, {}, themeInline)).toBe(
+      "0:00 One\n1:30 Two"
+    );
+  });
+});
+
+// --- formatShortDurationPhrase ---------------------------------------------
+
+describe("formatShortDurationPhrase", () => {
+  test("falls back to 'Full collection' when target_duration_min is null", () => {
+    const config = loadFrom(minimalSections());
+    expect(formatShortDurationPhrase(config.audio)).toBe("Full collection");
+  });
+
+  test("renders a singular hour for 60 minutes", () => {
+    const sections = minimalSections();
+    sections["audio.json"] = { audio: { target_duration_min: 60 } };
+    const config = loadFrom(sections);
+    expect(formatShortDurationPhrase(config.audio)).toBe("1 hour");
+  });
+
+  test("renders plural hours for a multi-hour duration", () => {
+    const sections = minimalSections();
+    sections["audio.json"] = { audio: { target_duration_min: 120 } };
+    const config = loadFrom(sections);
+    expect(formatShortDurationPhrase(config.audio)).toBe("2 hours");
+  });
+
+  // Python `round()` は round-half-to-even。30 分の奇数倍（.5 境界）で
+  // half-up な `Math.round` と乖離するため、Python と一致することを担保する。
+  // 90→1.5→even 2 / 150→2.5→even 2（Math.round なら 3）/ 210→3.5→even 4。
+  test.each([
+    [90, "2 hours"],
+    [150, "2 hours"],
+    [210, "4 hours"],
+  ])(
+    "rounds %d minutes half-to-even like Python round()",
+    (targetMin, expected) => {
+      const sections = minimalSections();
+      sections["audio.json"] = { audio: { target_duration_min: targetMin } };
+      const config = loadFrom(sections);
+      expect(formatShortDurationPhrase(config.audio)).toBe(expected);
+    }
+  );
+});
+
+// --- buildShortDescription -------------------------------------------------
+
+describe("buildShortDescription", () => {
+  test("includes the CC link line when a url is supplied", () => {
+    const config = loadFrom(minimalSections());
+
+    const desc = buildShortDescription(config, {
+      ccVideoUrl: "https://youtu.be/abc",
+      collectionName: "Rainy Night",
+    });
+
+    expect(desc.split("\n")).toEqual([
+      "Rainy Night (Full collection) | Test Channel",
+      "",
+      "♫ Full → https://youtu.be/abc",
+      "",
+      "#Shorts",
+    ]);
+  });
+
+  test("omits the CC link line when the url is empty", () => {
+    const config = loadFrom(minimalSections());
+
+    const desc = buildShortDescription(config, {
+      ccVideoUrl: "",
+      collectionName: "Rainy Night",
+    });
+
+    expect(desc.split("\n")).toEqual([
+      "Rainy Night (Full collection) | Test Channel",
+      "",
+      "#Shorts",
+    ]);
+  });
+});
+
+// --- buildShortLocalizations -----------------------------------------------
+
+describe("buildShortLocalizations", () => {
+  test("returns an empty record when no localizations are configured", () => {
+    const config = loadFrom(minimalSections());
+
+    expect(
+      buildShortLocalizations(config, {
+        ccVideoUrl: "https://youtu.be/abc",
+        collectionName: "Rainy Night",
+        theme: "village",
+      })
+    ).toEqual({});
+  });
+
+  test("formats per-language titles and skips languages without a template", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    const loc = buildShortLocalizations(config, {
+      ccVideoUrl: "https://youtu.be/abc",
+      collectionName: "Rainy Night",
+      theme: "Village",
+    });
+
+    // en/ja have short_title_template; de does not and is skipped
+    expect(Object.keys(loc).toSorted()).toEqual(["en", "ja"]);
+    expect(loc.en?.title).toBe("Village ✦ Test Channel #Shorts");
+  });
+
+  test("falls back to the default short description body when no template", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    const loc = buildShortLocalizations(config, {
+      ccVideoUrl: "https://youtu.be/abc",
+      collectionName: "Rainy Night",
+      theme: "Village",
+    });
+
+    // en lacks short_description_template -> shared build_short_description body
+    expect(loc.en?.description).toContain("#Shorts");
+    expect(loc.en?.description?.length).toBeLessThanOrEqual(5000);
+  });
+
+  // Regression guard (family: magic-number-dup): the short-localization
+  // description must be truncated at the SAME codepoint ceiling that the
+  // complete-collection description uses (DESCRIPTION_CODEPOINT_LIMIT = 5000,
+  // single-sourced in metadata/format.ts). A template that overflows 5000
+  // codepoints must clamp to exactly 5000 — if shorts re-introduced a divergent
+  // literal, this boundary would drift.
+  test("truncates an overflowing short description at the shared 5000 limit", () => {
+    const overflowTagline = "x".repeat(6000);
+    const localizations = {
+      languages: {
+        en: {
+          description: { tagline: overflowTagline },
+          short_description_template: "{tagline}",
+          short_title_template: "{theme} #Shorts",
+        },
+        // ja is required by the default content_model.languages but lacks a
+        // short_title_template, so buildShortLocalizations skips it.
+        ja: { title_template: "{scene_phrase}" },
+      },
+      supported_languages: ["en", "ja"],
+    };
+    const config = loadFrom(minimalSections(), localizations);
+
+    const loc = buildShortLocalizations(config, {
+      ccVideoUrl: "https://youtu.be/abc",
+      collectionName: "Rainy Night",
+      theme: "Village",
+    });
+
+    expect([...(loc.en?.description ?? "")].length).toBe(5000);
+  });
+});
+
+// --- scene phrase validation ----------------------------------------------
+
+describe("validateScenePhrases", () => {
+  test("returns no violations when every localized title fits 100 codepoints", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    const violations = validateScenePhrases(
+      { de: "Stiller Regen", en: "Quiet Rain", ja: "静かな雨" },
+      config,
+      ""
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  test("flags a language whose localized title exceeds 100 codepoints", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+    const longPhrase = "x".repeat(120);
+
+    const violations = validateScenePhrases(
+      { de: "Stiller Regen", en: longPhrase, ja: "静かな雨" },
+      config,
+      ""
+    );
+
+    expect(violations.map((v) => v.lang)).toContain("en");
+    const enViolation = violations.find((v) => v.lang === "en");
+    expect(enViolation?.length).toBeGreaterThan(100);
+  });
+
+  test("throws when a supported language is missing a scene phrase", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    expect(() =>
+      validateScenePhrases({ en: "Quiet Rain", ja: "静かな雨" }, config, "")
+    ).toThrow(/de/u);
+  });
+});
+
+describe("formatSceneTitleViolations", () => {
+  test("renders one indented line per violation with the overflow delta", () => {
+    const text = formatSceneTitleViolations([
+      {
+        lang: "ja",
+        length: 105,
+        template: "{scene_phrase}",
+        title: "超過タイトル",
+      },
+    ]);
+
+    expect(text).toBe("  - [ja] 105 codepoints (+5): 超過タイトル");
+  });
+});
+
+// --- generateCompleteCollectionTitle ---------------------------------------
+
+describe("generateCompleteCollectionTitle", () => {
+  const baseOptions = {
+    activities: "Study, Focus",
+    activity: "Study",
+    durationDisplay: "2 hours",
+    durationShort: "2h",
+    sceneEmoji: "",
+    scenePhrase: "Quiet Rain",
+    theme: "Village",
+  };
+
+  test("formats the configured title template", () => {
+    const config = loadFrom(minimalSections());
+
+    expect(generateCompleteCollectionTitle(config, baseOptions)).toBe(
+      "Village - Study"
+    );
+  });
+
+  test("injects the title-cased genre style for {style}", () => {
+    const sections = minimalSections();
+    (sections["content.json"] as { title: Record<string, unknown> }).title = {
+      template: "{style} {theme}",
+    };
+    const config = loadFrom(sections);
+
+    // genre.style "8-bit" -> Python str.title() -> "8-Bit"
+    expect(generateCompleteCollectionTitle(config, baseOptions)).toBe(
+      "8-Bit Village"
+    );
+  });
+
+  test("counts length in codepoints, not UTF-16 units (no false overflow)", () => {
+    const sections = minimalSections();
+    (sections["content.json"] as { title: Record<string, unknown> }).title = {
+      template: "{scene_phrase}",
+    };
+    const config = loadFrom(sections);
+    // 60 astral emoji = 60 codepoints (120 UTF-16 units). Must NOT throw.
+    const phrase = "😀".repeat(60);
+
+    expect(
+      generateCompleteCollectionTitle(config, {
+        ...baseOptions,
+        scenePhrase: phrase,
+      })
+    ).toBe(phrase);
+  });
+
+  test("throws when the title exceeds 100 codepoints", () => {
+    const sections = minimalSections();
+    (sections["content.json"] as { title: Record<string, unknown> }).title = {
+      template: "{scene_phrase}",
+    };
+    const config = loadFrom(sections);
+    const phrase = "😀".repeat(101);
+
+    expect(() =>
+      generateCompleteCollectionTitle(config, {
+        ...baseOptions,
+        scenePhrase: phrase,
+      })
+    ).toThrow(/100/u);
+  });
+});
+
+// --- buildCompleteCollectionDescription (AC: structure parity) -------------
+
+describe("buildCompleteCollectionDescription", () => {
+  const sectionHeaders = {
+    channelLinkTemplate: "🔗 {channel_name}:",
+    perfectFor: "🎮 Perfect for:",
+    usageAttribution: "📝 Usage & Attribution:",
+  };
+  const usageLines = ["• Original AI composition", "• Free for personal use"];
+
+  test("opens with the 🎵 title header followed by a blank line", () => {
+    const config = loadFrom(minimalSections());
+
+    const desc = buildCompleteCollectionDescription(config, {
+      sectionHeaders,
+      timestampBody: "0:00 Song A\n2:00 Song B",
+      title: "8-Bit Village - Study",
+      usageLines,
+    });
+    const lines = desc.split("\n");
+
+    expect(lines[0]).toBe("🎵 8-Bit Village - Study");
+    expect(lines[1]).toBe("");
+  });
+
+  test("embeds the timestamp body when supplied", () => {
+    const config = loadFrom(minimalSections());
+
+    const desc = buildCompleteCollectionDescription(config, {
+      sectionHeaders,
+      timestampBody: "0:00 Song A\n2:00 Song B",
+      title: "Title",
+      usageLines,
+    });
+
+    expect(desc).toContain("0:00 Song A\n2:00 Song B");
+  });
+
+  test("orders opening, usage, perfect-for, channel link and hashtags", () => {
+    const config = loadFrom(minimalSections());
+
+    const desc = buildCompleteCollectionDescription(config, {
+      sectionHeaders,
+      timestampBody: "0:00 Song A",
+      title: "Title",
+      usageLines,
+    });
+
+    // The rendered opening, usage block, perfect-for items, channel link
+    // (with channel name interpolated), cta/tagline and hashtag line all appear.
+    expect(desc).toContain("8-Bit chiptune for RPG");
+    expect(desc).toContain("📝 Usage & Attribution:");
+    expect(desc).toContain("• Original AI composition");
+    expect(desc).toContain("🎮 Perfect for:");
+    expect(desc).toContain("• Studying");
+    expect(desc).toContain("🔗 Test Channel:");
+    expect(desc).toContain("Test tagline");
+    expect(desc).toContain("#ChiptuneMusic");
+
+    // And they appear in the documented order (plan §5 parity).
+    const order = [
+      "🎵 Title",
+      "0:00 Song A",
+      "8-Bit chiptune for RPG",
+      "📝 Usage & Attribution:",
+      "🎮 Perfect for:",
+      "🔗 Test Channel:",
+      "#ChiptuneMusic",
+    ].map((needle) => desc.indexOf(needle));
+    const sorted = [...order].toSorted((a, b) => a - b);
+    expect(order).toEqual(sorted);
+    expect(order.every((idx) => idx >= 0)).toBe(true);
+  });
+});
+
+// --- generateLocalizations -------------------------------------------------
+
+describe("generateLocalizations", () => {
+  const sectionHeaders = {
+    channelLinkTemplate: "🔗 {channel_name}:",
+    trackList: "🎶 Tracklist",
+    usageAttribution: "📝 Usage",
+  };
+
+  test("produces a localized title + description per supported language", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    const loc = generateLocalizations(config, {
+      sceneEmoji: "",
+      scenePhrases: { de: "Stiller Regen", en: "Quiet Rain", ja: "静かな雨" },
+      sectionHeaders,
+      timestampBody: "0:00 Song A",
+    });
+
+    // Each supported language is rendered with a title formatted from its template
+    expect(Object.keys(loc).toSorted()).toEqual(["de", "en", "ja"]);
+    expect(loc.en?.title).toBe("Quiet Rain Study, Focus");
+  });
+
+  test("embeds the shared timestamp body and per-language tagline", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    const loc = generateLocalizations(config, {
+      sceneEmoji: "",
+      scenePhrases: { de: "Stiller Regen", en: "Quiet Rain", ja: "静かな雨" },
+      sectionHeaders,
+      timestampBody: "0:00 Song A",
+    });
+
+    expect(loc.en?.description).toContain("0:00 Song A");
+    expect(loc.en?.description).toContain("EN tagline");
+    expect(loc.en?.description?.length).toBeLessThanOrEqual(5000);
+  });
+
+  test("throws when a scene phrase overflows 100 codepoints", () => {
+    const config = loadFrom(minimalSections(), LOCALIZATIONS);
+
+    expect(() =>
+      generateLocalizations(config, {
+        sceneEmoji: "",
+        scenePhrases: {
+          de: "Stiller Regen",
+          en: "x".repeat(120),
+          ja: "静かな雨",
+        },
+        sectionHeaders,
+        timestampBody: "0:00 Song A",
+      })
+    ).toThrow();
+  });
+});
+
+// --- tags re-export --------------------------------------------------------
+
+describe("tagsForCollection (re-exported through metadata)", () => {
+  test("returns base + channel + matched theme tags", () => {
+    const config = loadFrom(minimalSections());
+
+    const tags = tagsForCollection(config.content.tags, "battle royale");
+
+    // base tags + lowercased channel name + the matched "battle" theme tags
+    expect(tags).toContain("chiptune music");
+    expect(tags).toContain("battle music");
+    expect(tags.length).toBeLessThanOrEqual(50);
+  });
+});

--- a/packages/core/test/paths.test.ts
+++ b/packages/core/test/paths.test.ts
@@ -1,0 +1,365 @@
+// Tests for packages/core/src/paths.ts — the TS port of the Python
+// `utils/collection_paths.py` (CollectionPaths + resolveCollectionDir).
+//
+// The contract under test mirrors plan §4-A: directory getters, priority-ordered
+// image/thumbnail resolution, glob+sorted master/individual lookups, numbered
+// Shorts resolution with single-file fallback, collection-name prefix stripping,
+// and the CWD-fallback resolver. Paths are absolute strings (path.resolve),
+// matching Python `Path.resolve()`.
+//
+// Imported by the published package subpath so the test also exercises the
+// `exports` map entry the implementation adds for "./paths".
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ValidationError } from "@youtube-automation/core";
+import {
+  CollectionPaths,
+  resolveCollectionDir,
+} from "@youtube-automation/core/paths";
+
+const tempRoots: string[] = [];
+
+// Creates an empty temp directory and registers it for teardown. An optional
+// `name` produces a deterministically named child dir (for collectionName tests).
+const makeDir = (name?: string): string => {
+  const base = mkdtempSync(join(tmpdir(), "paths-fixture-"));
+  tempRoots.push(base);
+  if (name === undefined) {
+    return base;
+  }
+  const dir = join(base, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const touch = (path: string): void => {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, "", "utf-8");
+};
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const dir = tempRoots.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+// --- directory getters -----------------------------------------------------
+
+describe("CollectionPaths — directory getters", () => {
+  test("derive the standard subdirectories from the resolved root", () => {
+    // Given a collection root
+    const root = makeDir("collection");
+    const paths = new CollectionPaths(root);
+
+    // Then every getter is the root joined with the documented subpath
+    expect(paths.masterDir).toBe(join(paths.root, "01-master"));
+    expect(paths.musicDir).toBe(join(paths.root, "02-Individual-music"));
+    expect(paths.movieDir).toBe(join(paths.root, "03-Individual-movie"));
+    expect(paths.assetsDir).toBe(join(paths.root, "10-assets"));
+    expect(paths.docsDir).toBe(join(paths.root, "20-documentation"));
+    expect(paths.workflowStatePath).toBe(
+      join(paths.root, "workflow-state.json")
+    );
+  });
+
+  test("derive doc-scoped and shorts paths", () => {
+    // Given a collection root
+    const paths = new CollectionPaths(makeDir("collection"));
+
+    // Then doc artifacts hang off 20-documentation/
+    expect(paths.trackingPath).toBe(
+      join(paths.docsDir, "upload_tracking.json")
+    );
+    expect(paths.descriptionsMdPath).toBe(
+      join(paths.docsDir, "descriptions.md")
+    );
+    expect(paths.thumbnailPromptsPath).toBe(
+      join(paths.docsDir, "thumbnail-prompts.md")
+    );
+
+    // And shorts artifacts hang off 01-master/ and 10-assets/
+    expect(paths.shortsDir).toBe(join(paths.masterDir, "shorts"));
+    expect(paths.shortLoop).toBe(join(paths.assetsDir, "short-loop.mp4"));
+  });
+});
+
+// --- collectionName prefix stripping --------------------------------------
+
+describe("CollectionPaths — collectionName", () => {
+  test("strips a numeric date + channel prefix (split maxsplit 2)", () => {
+    // Given a directory named with the date-channel-name convention
+    const paths = new CollectionPaths(makeDir("20260310-clm-some-name"));
+
+    // Then only the trailing name segment remains
+    expect(paths.collectionName).toBe("some-name");
+  });
+
+  test("keeps the name verbatim when the first segment is not numeric", () => {
+    const paths = new CollectionPaths(makeDir("abc-def-ghi"));
+    expect(paths.collectionName).toBe("abc-def-ghi");
+  });
+
+  test("keeps the name verbatim when there are fewer than three segments", () => {
+    const paths = new CollectionPaths(makeDir("plain-name"));
+    expect(paths.collectionName).toBe("plain-name");
+  });
+});
+
+// --- thumbnail / main image priority --------------------------------------
+
+describe("CollectionPaths — findThumbnail", () => {
+  test("prefers thumbnail.jpg over thumbnail.png over main.* ", () => {
+    // Given all four candidates present
+    const root = makeDir("collection");
+    const assets = join(root, "10-assets");
+    for (const name of [
+      "thumbnail.jpg",
+      "thumbnail.png",
+      "main.jpg",
+      "main.png",
+    ]) {
+      touch(join(assets, name));
+    }
+    const paths = new CollectionPaths(root);
+
+    // Then the highest-priority candidate wins
+    expect(paths.findThumbnail()).toBe(join(paths.assetsDir, "thumbnail.jpg"));
+  });
+
+  test("falls through the priority list to main.png", () => {
+    // Given only the lowest-priority candidate present
+    const root = makeDir("collection");
+    touch(join(root, "10-assets", "main.png"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.findThumbnail()).toBe(join(paths.assetsDir, "main.png"));
+  });
+
+  test("returns null when no candidate exists", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.findThumbnail()).toBeNull();
+  });
+});
+
+describe("CollectionPaths — findMainImage", () => {
+  test("prefers main.png over main.jpg", () => {
+    const root = makeDir("collection");
+    touch(join(root, "10-assets", "main.png"));
+    touch(join(root, "10-assets", "main.jpg"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.findMainImage()).toBe(join(paths.assetsDir, "main.png"));
+  });
+
+  test("returns null when neither main image exists", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.findMainImage()).toBeNull();
+  });
+});
+
+describe("CollectionPaths — findLoopVideo", () => {
+  test("resolves loop.mp4 only when present", () => {
+    const root = makeDir("collection");
+    const paths = new CollectionPaths(root);
+    expect(paths.findLoopVideo()).toBeNull();
+
+    touch(join(root, "10-assets", "loop.mp4"));
+    expect(paths.findLoopVideo()).toBe(join(paths.assetsDir, "loop.mp4"));
+  });
+});
+
+// --- master / individual glob + sort --------------------------------------
+
+describe("CollectionPaths — master lookups", () => {
+  test("returns the first sorted .mp4 from 01-master/", () => {
+    // Given two master videos out of lexical order on disk
+    const root = makeDir("collection");
+    touch(join(root, "01-master", "b-second.mp4"));
+    touch(join(root, "01-master", "a-first.mp4"));
+    const paths = new CollectionPaths(root);
+
+    // Then the lexicographically first one is chosen (Python sorted())
+    expect(paths.findMasterVideo()).toBe(join(paths.masterDir, "a-first.mp4"));
+  });
+
+  test("returns the first sorted .mp3 from 01-master/", () => {
+    const root = makeDir("collection");
+    touch(join(root, "01-master", "master.mp3"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.findMasterAudio()).toBe(join(paths.masterDir, "master.mp3"));
+  });
+
+  test("returns null when 01-master/ has no matching file", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.findMasterVideo()).toBeNull();
+    expect(paths.findMasterAudio()).toBeNull();
+  });
+});
+
+describe("CollectionPaths — individual file listings", () => {
+  test("lists 02-Individual-music/*.mp3 sorted", () => {
+    const root = makeDir("collection");
+    touch(join(root, "02-Individual-music", "02-b.mp3"));
+    touch(join(root, "02-Individual-music", "01-a.mp3"));
+    touch(join(root, "02-Individual-music", "note.txt"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.individualMusicFiles()).toEqual([
+      join(paths.musicDir, "01-a.mp3"),
+      join(paths.musicDir, "02-b.mp3"),
+    ]);
+  });
+
+  test("lists 03-Individual-movie/*.mp4 sorted", () => {
+    const root = makeDir("collection");
+    touch(join(root, "03-Individual-movie", "01-a.mp4"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.individualMovieFiles()).toEqual([
+      join(paths.movieDir, "01-a.mp4"),
+    ]);
+  });
+
+  test("returns an empty list when the directory is absent", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.individualMusicFiles()).toEqual([]);
+    expect(paths.individualMovieFiles()).toEqual([]);
+  });
+});
+
+// --- Shorts resolution -----------------------------------------------------
+
+describe("CollectionPaths — findShortVideo", () => {
+  test("prefers a numbered shorts file when short_num is given", () => {
+    // Given a numbered shorts file under 01-master/shorts/
+    const root = makeDir("collection");
+    touch(join(root, "01-master", "shorts", "short-01-intro.mp4"));
+    const paths = new CollectionPaths(root);
+
+    // Then the numbered match is returned for that number
+    expect(paths.findShortVideo(1)).toBe(
+      join(paths.shortsDir, "short-01-intro.mp4")
+    );
+  });
+
+  test("falls back to the single 01-master/short.mp4", () => {
+    // Given only the single-file short present
+    const root = makeDir("collection");
+    touch(join(root, "01-master", "short.mp4"));
+    const paths = new CollectionPaths(root);
+
+    // Then the fallback is used both with and without a number
+    expect(paths.findShortVideo(2)).toBe(join(paths.masterDir, "short.mp4"));
+    expect(paths.findShortVideo(null)).toBe(join(paths.masterDir, "short.mp4"));
+  });
+
+  test("returns null when neither numbered nor single short exists", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.findShortVideo(1)).toBeNull();
+  });
+});
+
+describe("CollectionPaths — shortVideoSearchPaths", () => {
+  test("lists only the single-file path when short_num is null", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.shortVideoSearchPaths(null)).toEqual([
+      join(paths.masterDir, "short.mp4"),
+    ]);
+  });
+
+  test("lists the numbered glob then the single-file fallback", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.shortVideoSearchPaths(1)).toEqual([
+      join(paths.shortsDir, "short-01-*.mp4"),
+      join(paths.masterDir, "short.mp4"),
+    ]);
+  });
+});
+
+describe("CollectionPaths — short thumbnail + loop input", () => {
+  test("finds the short thumbnail jpg before png", () => {
+    const root = makeDir("collection");
+    touch(join(root, "10-assets", "short-thumbnail.jpg"));
+    touch(join(root, "10-assets", "short-thumbnail.png"));
+    const paths = new CollectionPaths(root);
+
+    expect(paths.findShortThumbnail()).toBe(
+      join(paths.assetsDir, "short-thumbnail.jpg")
+    );
+  });
+
+  test("lists short loop input image candidates png before jpg", () => {
+    const paths = new CollectionPaths(makeDir("collection"));
+    expect(paths.shortLoopInputImageSearchPaths()).toEqual([
+      join(paths.assetsDir, "short.png"),
+      join(paths.assetsDir, "short.jpg"),
+    ]);
+  });
+
+  test("finds the short loop input image png before jpg", () => {
+    const root = makeDir("collection");
+    touch(join(root, "10-assets", "short.jpg"));
+    const paths = new CollectionPaths(root);
+    expect(paths.findShortLoopInputImage()).toBe(
+      join(paths.assetsDir, "short.jpg")
+    );
+  });
+});
+
+// --- resolveCollectionDir --------------------------------------------------
+
+describe("resolveCollectionDir", () => {
+  test("resolves an explicit argument to an absolute path", () => {
+    // Given an explicit, already-absolute collection path
+    const root = makeDir("collection");
+
+    // When resolving with the argument
+    // Then path.resolve leaves an absolute input unchanged
+    expect(resolveCollectionDir(root)).toBe(root);
+  });
+
+  test("returns cwd when it is a valid collection and no arg is given", () => {
+    // Given a cwd holding both 01-master/ and 02-Individual-music/
+    const root = makeDir("collection");
+    mkdirSync(join(root, "01-master"), { recursive: true });
+    mkdirSync(join(root, "02-Individual-music"), { recursive: true });
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(root);
+
+      // When resolving with no argument
+      // Then the cwd is accepted as the collection dir
+      expect(realpathSync(resolveCollectionDir(null))).toBe(realpathSync(root));
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  test("throws ValidationError when cwd is not a collection and no arg is given", () => {
+    // Given a cwd missing the required subdirectories
+    const root = makeDir("collection");
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(root);
+
+      // When/Then resolution fails fast
+      expect(() => resolveCollectionDir(null)).toThrow(ValidationError);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/packages/core/test/templates.test.ts
+++ b/packages/core/test/templates.test.ts
@@ -1,0 +1,50 @@
+// Tests for the template loader (plan §4-C). The description templates live in
+// packages/core/templates/ and are resolved relative to the module via
+// import.meta — NOT via process.cwd() — so the loader works regardless of the
+// caller's working directory. loadTemplate is re-exported through the metadata
+// subpath (plan §4-C), which this import also exercises.
+//
+// These assertions pin the *machine* contract (the {placeholder} tokens the
+// str.format pipeline consumes), not the prose of the template, so they remain
+// valid even if the surrounding copy is reworded.
+
+import { describe, expect, test } from "bun:test";
+
+import { loadTemplate } from "@youtube-automation/core/metadata";
+
+describe("loadTemplate", () => {
+  test("loads the complete-collection template with its format placeholders", () => {
+    const tpl = loadTemplate("complete_collection");
+
+    expect(tpl).toContain("{collection_name}");
+    expect(tpl).toContain("{timestamp_list}");
+    expect(tpl).toContain("{hashtag_line}");
+  });
+
+  test("loads the individual-track template with its format placeholders", () => {
+    const tpl = loadTemplate("individual_track");
+
+    expect(tpl).toContain("{track_title}");
+    expect(tpl).toContain("{collection_url}");
+  });
+
+  test("resolves the same content regardless of process.cwd()", () => {
+    // Given a different working directory than the package root
+    const original = process.cwd();
+    try {
+      process.chdir("/");
+
+      // When loading the template from an unrelated cwd
+      // Then import.meta-based resolution still finds the resource
+      expect(loadTemplate("complete_collection")).toContain(
+        "{collection_name}"
+      );
+    } finally {
+      process.chdir(original);
+    }
+  });
+
+  test("throws for an unknown template name (fail fast)", () => {
+    expect(() => loadTemplate("does_not_exist")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

## Parent
#727

## What to build
Python `utils/metadata_generator.py` (タイトル・説明文・タグ・ローカライゼーション生成) と `utils/collection_paths.py` (コレクションディレクトリ構造の解決) を TS に移植する。テンプレ管理 (`src/youtube_automation/templates/`) も TS 側で読み込めるよう `packages/core/templates/` に配置。

## Acceptance criteria
- [ ] `packages/core/metadata.ts` で title / description / tags / localizations 生成 API
- [ ] `packages/core/paths.ts` で collection ディレクトリ解決
- [ ] テンプレ resource は `import.meta.url` ベースで解決
- [ ] 既存 Python 版と semantic 等価な smoke test (説明文の構造一致)

## Blocked by
- #736

## Execution Report

Workflow `default` completed successfully.

Closes #737