### PR TITLE
[#807] issue-807-fix-suno-suno-custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno)`: Suno Custom Mode の Style/Lyrics 識別を data-testid ベースに変更し、日本語 UI 破損を修正した（#807）。実 DOM（`suno.com/create`・日本語 UI）検証で、`SELECTORS.stylePlaceholder` の placeholder 正規表現が日本語ロケールの Style 欄（ジャンル語彙の例）にヒットせず、fallback の `areas[0]=Lyrics` を Style に返して Lyrics 欄を上書きする致命バグが判明していた。`extensions/shared/dom.ts` で Lyrics を `data-testid="lyrics-textarea"`（UI 言語非依存）で最優先識別し、Style は「Lyrics 以外の strict visible textarea」として解決、Style 解決不能または Style==Lyrics の衝突時は throw（silent な上書きを禁ずる）。`isVisible` を `offsetParent !== null` から bbox 0 除外 + 親要素 walk（display:none / visibility:hidden / opacity:0 排除）の strict 版に強化し、Simple Mode の隠し textarea を拾わないようにした。Vitest unit テスト（`tests/dom.test.ts`）と Playwright e2e mock（`data-testid="lyrics-textarea"` を含む）で担保する
+
 ### Migration
 
 - `#698`: `yt-suno-serve` を実行しているスクリプト・運用手順は `yt-collection-serve` に置き換える。配信 URL は `http://localhost:<PORT>/prompts.json` → `http://localhost:<PORT>/suno/prompts.json` に変わる（suno-helper 拡張は本リリースで追従済み）

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -2,10 +2,11 @@
 // 旧 `content.js` の振る舞いを 1:1 で保持しつつ純関数化する。
 // Suno の DOM は変わりうるため、セレクタはこの 1 箇所に集約する（壊れたら README 参照で更新）。
 
+// Suno の DOM セレクタ SSOT。#807 で判明したとおり placeholder は UI ロケールで変わるため、
+// Lyrics は言語非依存の data-testid で識別する（Style は「Lyrics でない可視 textarea」）。
 const SELECTORS = {
   textareas: "textarea",
-  stylePlaceholder: /style|genre|描述|スタイル/i,
-  lyricsPlaceholder: /lyric|歌詞|歌词/i,
+  lyrics: '[data-testid="lyrics-textarea"]',
   generateLabel: /^(create|generate|生成)$/i,
   recaptcha:
     'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]',
@@ -36,8 +37,28 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * strict 可視判定。`offsetParent !== null` だけでは Simple Mode の隠し textarea を拾うため、
+ * bbox 0 を除外し、自身〜祖先を walk して display:none / visibility:hidden / opacity:0 を排除する。
+ */
 function isVisible(el: HTMLElement): boolean {
-  return el.offsetParent !== null;
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return false;
+  }
+  let node: Element | null = el;
+  while (node) {
+    const style = getComputedStyle(node);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.opacity === "0"
+    ) {
+      return false;
+    }
+    node = node.parentElement;
+  }
+  return true;
 }
 
 /** React 互換のネイティブ値セット + input/change イベント発火。 */
@@ -63,7 +84,12 @@ export function detectRecaptcha(): boolean {
   return document.querySelector(SELECTORS.recaptcha) !== null;
 }
 
-/** Style / Lyrics の textarea を解決する。可視 textarea が無ければ throw（fail-loud）。 */
+/**
+ * Style / Lyrics の textarea を解決する（#807）。
+ *   - Lyrics: `data-testid="lyrics-textarea"` を最優先で識別（UI 言語非依存）。無ければ null。
+ *   - Style:  Lyrics 以外の strict visible textarea（この述語が Style==Lyrics の silent 上書きを構造的に禁ずる）。
+ *   - Style が解決できない場合は throw（silent スキップを禁ずる）。
+ */
 export function resolveFields(): ResolvedFields {
   const areas = Array.from(
     document.querySelectorAll<HTMLTextAreaElement>(SELECTORS.textareas),
@@ -74,15 +100,14 @@ export function resolveFields(): ResolvedFields {
     );
   }
 
-  const byPlaceholder = (re: RegExp): HTMLTextAreaElement | undefined =>
-    areas.find((el) =>
-      re.test(el.placeholder || el.getAttribute("aria-label") || ""),
+  const lyrics = areas.find((el) => el.matches(SELECTORS.lyrics)) ?? null;
+  // Style は「Lyrics でない可視 textarea」。この述語が silent な上書き（Style==Lyrics）を構造的に禁ずる。
+  const style = areas.find((el) => el !== lyrics);
+  if (!style) {
+    throw new Error(
+      "Style 欄が見つかりません。Lyrics 以外の可視 textarea を検出できませんでした。",
     );
-
-  const style = byPlaceholder(SELECTORS.stylePlaceholder) ?? areas[0];
-  const lyrics =
-    byPlaceholder(SELECTORS.lyricsPlaceholder) ??
-    (areas.length > 1 ? areas[1] : null);
+  }
 
   return { style, lyrics };
 }

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -1,29 +1,58 @@
 // @vitest-environment jsdom
 //
 // content script の Suno UI 注入ロジックを純関数化した `shared/dom.ts` の回帰テスト。
-// 旧 `content.js` の振る舞いを 1:1 で保持することを保証する:
+// 旧 `content.js` の振る舞いを保持しつつ、#807 で判明した日本語 UI 破損を修正した仕様を担保する:
 //   - setNativeValue: prototype の native setter + input/change の bubbling 発火 (React 互換)
-//   - resolveFields: 可視 textarea を placeholder/aria-label で判別、fallback は表示順、不在で throw
+//   - resolveFields: lyrics は `data-testid="lyrics-textarea"` で最優先識別 (UI 言語非依存)、
+//                    style は lyrics 以外の strict visible textarea、解決不能なら throw (fail-loud)
 //   - resolveGenerateButton: 可視 button をラベル正規表現で判別、不在で throw
 //   - detectRecaptcha: recaptcha/hcaptcha iframe の存在検知
 //
-// jsdom はレイアウトを行わず `offsetParent` が常に null になるため、可視判定の対象要素は
-// `markVisible` で offsetParent を擬似的に与える (production は content.js と同じ
-// `offsetParent !== null` フィルタを維持する前提)。
+// jsdom はレイアウトを行わず `getBoundingClientRect()` が常に全 0 を返すため、可視判定の
+// 対象要素は `setRect` で bbox を擬似的に与える (production の strict isVisible は
+// `getBoundingClientRect` の width/height と親要素の display/visibility/opacity を見る前提)。
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detectRecaptcha, resolveFields, resolveGenerateButton, setNativeValue } from "../../shared/dom";
 
-function markVisible(el: HTMLElement): void {
-  Object.defineProperty(el, "offsetParent", { configurable: true, get: () => document.body });
+const VISIBLE_RECT = {
+  x: 0,
+  y: 0,
+  top: 0,
+  left: 0,
+  right: 100,
+  bottom: 20,
+  width: 100,
+  height: 20,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const ZERO_RECT = {
+  x: 0,
+  y: 0,
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  width: 0,
+  height: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+// strict isVisible は getBoundingClientRect を見るため、jsdom では bbox を明示 stub する。
+function setRect(el: HTMLElement, rect: DOMRect): void {
+  el.getBoundingClientRect = () => rect;
 }
 
-function addTextarea(attrs: { placeholder?: string; ariaLabel?: string; visible?: boolean }): HTMLTextAreaElement {
+function addTextarea(
+  opts: { testId?: string; placeholder?: string; ariaLabel?: string; visible?: boolean } = {},
+): HTMLTextAreaElement {
   const ta = document.createElement("textarea");
-  if (attrs.placeholder !== undefined) ta.placeholder = attrs.placeholder;
-  if (attrs.ariaLabel !== undefined) ta.setAttribute("aria-label", attrs.ariaLabel);
+  if (opts.testId !== undefined) ta.setAttribute("data-testid", opts.testId);
+  if (opts.placeholder !== undefined) ta.placeholder = opts.placeholder;
+  if (opts.ariaLabel !== undefined) ta.setAttribute("aria-label", opts.ariaLabel);
   document.body.appendChild(ta);
-  if (attrs.visible !== false) markVisible(ta);
+  setRect(ta, opts.visible === false ? ZERO_RECT : VISIBLE_RECT);
   return ta;
 }
 
@@ -31,7 +60,7 @@ function addButton(label: string, visible = true): HTMLButtonElement {
   const btn = document.createElement("button");
   btn.textContent = label;
   document.body.appendChild(btn);
-  if (visible) markVisible(btn);
+  setRect(btn, visible ? VISIBLE_RECT : ZERO_RECT);
   return btn;
 }
 
@@ -75,49 +104,51 @@ describe("setNativeValue: React 互換の値注入", () => {
   });
 });
 
-describe("resolveFields: Style / Lyrics の解決", () => {
-  it("Given placeholder 付き 2 欄 When 解決する Then placeholder で style/lyrics を判別する", () => {
+describe("resolveFields: data-testid ベースの Style / Lyrics 解決 (#807)", () => {
+  it("Given lyrics-textarea と別の visible textarea When 解決する Then data-testid で lyrics を、残りを style とする", () => {
+    const lyrics = addTextarea({ testId: "lyrics-textarea", placeholder: "What do you want your lyrics to be about?" });
     const style = addTextarea({ placeholder: "Style description" });
-    const lyrics = addTextarea({ placeholder: "Lyrics" });
 
     const fields = resolveFields();
 
-    expect(fields.style).toBe(style);
     expect(fields.lyrics).toBe(lyrics);
-  });
-
-  it("Given 日本語 placeholder When 解決する Then 日本語ラベルでも判別する", () => {
-    const style = addTextarea({ placeholder: "スタイル" });
-    const lyrics = addTextarea({ placeholder: "歌詞" });
-
-    const fields = resolveFields();
-
     expect(fields.style).toBe(style);
-    expect(fields.lyrics).toBe(lyrics);
   });
 
-  it("Given placeholder 無し aria-label 有り When 解決する Then aria-label で判別する", () => {
-    const style = addTextarea({ ariaLabel: "Genre" });
-    const lyrics = addTextarea({ ariaLabel: "lyric" });
+  it("Given lyrics-textarea が DOM 上で style より先 When 解決する Then 表示順ではなく data-testid で識別する", () => {
+    const lyrics = addTextarea({ testId: "lyrics-textarea" });
+    const style = addTextarea({ placeholder: "Style description" });
 
     const fields = resolveFields();
 
+    // 旧実装は areas[0] を style にしていた。順序 fallback の復活を禁ずる回帰ガード。
+    expect(fields.lyrics).toBe(lyrics);
     expect(fields.style).toBe(style);
-    expect(fields.lyrics).toBe(lyrics);
   });
 
-  it("Given ラベル無し 2 欄 When 解決する Then 表示順 fallback で style=1番目 lyrics=2番目", () => {
-    const first = addTextarea({});
-    const second = addTextarea({});
+  it("Given 日本語 UI (style placeholder がジャンル語彙) When 解決する Then placeholder 非依存で正しく振り分ける", () => {
+    // #807 の再現入力: 日本語ロケールでは style placeholder が「ジャンル例の語彙」になり
+    // 旧 stylePlaceholder regex に一致しない。data-testid 識別ならこの入力でも壊れない。
+    const lyrics = addTextarea({
+      testId: "lyrics-textarea",
+      placeholder: "What do you want your lyrics to be about? Suno will write new lyrics every generation.",
+    });
+    const style = addTextarea({ placeholder: "地下の罠, コントラルト, リズミカルなベース, ソフトパンク, メリスマ" });
 
     const fields = resolveFields();
 
-    expect(fields.style).toBe(first);
-    expect(fields.lyrics).toBe(second);
+    expect(fields.lyrics).toBe(lyrics);
+    expect(fields.style).toBe(style);
   });
 
-  it("Given style のみ 1 欄 When 解決する Then lyrics は null になる (fail-loud の前提)", () => {
-    const only = addTextarea({ placeholder: "Style" });
+  it("Given lyrics-textarea しか可視でない When 解決する Then Style 解決不能で throw する (silent な上書きを禁ずる)", () => {
+    addTextarea({ testId: "lyrics-textarea" });
+
+    expect(() => resolveFields()).toThrow();
+  });
+
+  it("Given data-testid 無しの visible textarea 1 枚 (instrumental) When 解決する Then style に解決し lyrics は null", () => {
+    const only = addTextarea({ placeholder: "地下の罠, コントラルト, リズミカルなベース" });
 
     const fields = resolveFields();
 
@@ -126,9 +157,61 @@ describe("resolveFields: Style / Lyrics の解決", () => {
   });
 
   it("Given 可視 textarea が無い When 解決する Then throw する (silent スキップしない)", () => {
-    addTextarea({ placeholder: "Style", visible: false }); // 非表示は対象外
+    addTextarea({ testId: "lyrics-textarea", visible: false });
+    addTextarea({ placeholder: "Style description", visible: false });
 
     expect(() => resolveFields()).toThrow();
+  });
+
+  it("Given bbox 0 の textarea (Simple Mode) が混在 When 解決する Then strict isVisible が除外する", () => {
+    // bbox 0 の lyrics-textarea は data-testid を持っていても可視集合から除外され、
+    // 可視は style 1 枚のみ → lyrics は null になる (hidden な Simple Mode 要素を拾わない)。
+    addTextarea({ testId: "lyrics-textarea", visible: false });
+    const style = addTextarea({ placeholder: "Style description" });
+
+    const fields = resolveFields();
+
+    expect(fields.style).toBe(style);
+    expect(fields.lyrics).toBeNull();
+  });
+
+  it("Given 自身が visibility:hidden の lyrics-textarea When 解決する Then strict isVisible が除外する", () => {
+    const hiddenLyrics = addTextarea({ testId: "lyrics-textarea" });
+    hiddenLyrics.style.visibility = "hidden";
+    const style = addTextarea({ placeholder: "Style description" });
+
+    const fields = resolveFields();
+
+    expect(fields.style).toBe(style);
+    expect(fields.lyrics).toBeNull();
+  });
+
+  it("Given 自身が opacity:0 の lyrics-textarea When 解決する Then strict isVisible が除外する", () => {
+    const hiddenLyrics = addTextarea({ testId: "lyrics-textarea" });
+    hiddenLyrics.style.opacity = "0";
+    const style = addTextarea({ placeholder: "Style description" });
+
+    const fields = resolveFields();
+
+    expect(fields.style).toBe(style);
+    expect(fields.lyrics).toBeNull();
+  });
+
+  it("Given 親が display:none の lyrics-textarea When 解決する Then 親要素 walk で除外する", () => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "none";
+    document.body.appendChild(wrapper);
+    const hiddenLyrics = document.createElement("textarea");
+    hiddenLyrics.setAttribute("data-testid", "lyrics-textarea");
+    wrapper.appendChild(hiddenLyrics);
+    setRect(hiddenLyrics, VISIBLE_RECT); // bbox は非 0。除外理由は親の display:none のみに限定する。
+
+    const style = addTextarea({ placeholder: "Style description" });
+
+    const fields = resolveFields();
+
+    expect(fields.style).toBe(style);
+    expect(fields.lyrics).toBeNull();
   });
 });
 
@@ -148,7 +231,7 @@ describe("resolveGenerateButton: Generate ボタンの解決", () => {
     expect(() => resolveGenerateButton()).toThrow();
   });
 
-  it("Given Generate ボタンが非表示 When 解決する Then throw する", () => {
+  it("Given Generate ボタンが非表示 (bbox 0) When 解決する Then throw する", () => {
     addButton("Generate", false);
 
     expect(() => resolveGenerateButton()).toThrow();

--- a/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
+++ b/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
@@ -18,8 +18,9 @@ import { expect, test } from "@playwright/test";
 const MOCK_SUNO_HTML = `<!doctype html>
 <html>
   <body>
-    <textarea id="style" placeholder="Style description"></textarea>
-    <textarea id="lyrics" placeholder="Lyrics"></textarea>
+    <!-- 実 Suno (日本語 UI) を模す: style placeholder はジャンル語彙、lyrics は data-testid で識別する (#807)。 -->
+    <textarea id="style" placeholder="地下の罠, コントラルト, リズミカルなベース"></textarea>
+    <textarea id="lyrics" data-testid="lyrics-textarea" placeholder="What do you want your lyrics to be about?"></textarea>
     <button id="generate">Create</button>
     <div id="captured-style">-</div>
     <div id="captured-lyrics">-</div>
@@ -56,9 +57,12 @@ test("Suno mock へ Style/Lyrics を注入し Generate を押下できる", asyn
       el.dispatchEvent(new Event("change", { bubbles: true }));
     }
 
+    // 本番 resolveFields と同じ識別ロジックを再現: lyrics は data-testid 最優先、style は残り。
+    const lyrics = document.querySelector('[data-testid="lyrics-textarea"]') as HTMLTextAreaElement;
     const areas = Array.from(document.querySelectorAll("textarea"));
-    setNativeValue(areas[0] as HTMLTextAreaElement, "lofi, jazzy, rainy night");
-    setNativeValue(areas[1] as HTMLTextAreaElement, "la la la");
+    const style = areas.find((el) => el !== lyrics) as HTMLTextAreaElement;
+    setNativeValue(style, "lofi, jazzy, rainy night");
+    setNativeValue(lyrics, "la la la");
     (document.querySelector("button") as HTMLButtonElement).click();
   });
 


### PR DESCRIPTION
## Summary

## 背景

`/suno と DistroKid 拡張機能を実機テストする`(extensions/) の一環で、suno-helper を Chrome に unpacked load し、本物の `https://suno.com/create` で **実 DOM をブラウザ DevTools console で取得した**。その結果、現状の `extensions/shared/dom.ts` の DOM セレクタが日本語ロケールで壊れる致命バグが判明した。

### 実 DOM (suno.com/create, 日本語 UI)

strict 可視判定 (bbox 0 除外 + 親要素の `display/visibility/opacity` walk) 後の visible textarea は **2 個**:

| idx | data-testid | placeholder |
|---|---|---|
| 0 | **`lyrics-textarea`** | `What do you want your lyrics to be about? Suno will write new lyrics every generation. ...` |
| 1 | (なし) | `地下の罠, コントラルト, リズミカルなベース, ソフトパンク, メリスマ` (ジャンル例の語彙) |

Generate ボタンは visible 1 個、text=`"Create"` (現状 regex でヒット OK)。

`offsetParent !== null` だけの緩い isVisible では textarea **4 個**ヒットしてしまう (Simple Mode の textarea も拾ってしまう)。

## 問題

1. `SELECTORS.stylePlaceholder = /style|genre|描述|スタイル/i` は **日本語ロケールの Style placeholder (ジャンル語彙の例) にヒットせず MISS**
2. `resolveFields()` の fallback `byPlaceholder(stylePlaceholder) ?? areas[0]` が **`areas[0]=Lyrics` を Style に返してしまう** → Style 投入が Lyrics 領域に上書きされる致命バグ (Lyrics が消える / Style が反映されない)
3. `isVisible()` の `offsetParent !== null` チェックが甘く、Simple Mode の textarea も拾う恐れ

## 修正方針

| 項目 | 修正前 | 修正後 |
|---|---|---|
| Lyrics 検出 | placeholder regex `/lyric\|歌詞\|歌词/i` | **`[data-testid="lyrics-textarea"]`** (UI 言語非依存・最優先) |
| Style 検出 | placeholder regex `/style\|genre\|描述\|スタイル/i` → fallback `areas[0]` | **「lyrics-textarea ではない visible textarea」** (残り 1 個が確定) |
| `isVisible` | `offsetParent !== null` のみ | bbox 0 除外 + 親要素 walk で `display/visibility/opacity` 確認 |
| Style == Lyrics 衝突 | silent (上書き) | **同一要素なら throw** (fail-loud) |
| Generate | 既存 regex `/^(create\|generate\|生成)$/i` | そのまま (実 DOM で "Create" にヒット確認済み) |

## 対象ファイル

- `extensions/shared/dom.ts` — `SELECTORS` / `resolveFields` / `isVisible` 書き直し (壊れない単一 SSOT)
- `extensions/suno-helper/tests/dom.test.ts` (or shared test) — data-testid を反映、衝突 throw / strict visible / Simple Mode 排除のテスト追加
- `extensions/suno-helper/playwright.config.ts` 配下 e2e mock の Suno UI fixture HTML — `data-testid="lyrics-textarea"` を含む構造に更新
- `CHANGELOG.md` — `[Unreleased]::Fixed` に追記

## 受け入れ条件

- [ ] `extensions/shared/dom.ts::resolveFields()` が **`data-testid="lyrics-textarea"` を最優先で使う**
- [ ] Style は **lyrics-textarea 以外の strict visible textarea** で識別する
- [ ] **同一 textarea が Lyrics/Style 両方に解決された場合 throw** する (silent な上書きを禁ずる)
- [ ] `isVisible` が **bbox 0 / 親の `display:none / visibility:hidden / opacity:0` を排除**する strict 版になる
- [ ] Vitest unit テスト追加 (data-testid 識別 / 衝突 throw / strict visible)
- [ ] Playwright e2e の Suno mock HTML に `data-testid="lyrics-textarea"` を含めて pass
- [ ] CHANGELOG `[Unreleased]::Fixed` に「(suno) Style/Lyrics 識別を data-testid ベースに変更、日本語 UI 破損を修正」を追記

## 受け入れ確認用 console snippet (再現用、修正後の手動 verify)

修正後の拡張を unpacked reload して `suno.com/create` で DevTools console に貼って実行:

```js
const vis = (el) => {
  const r = el.getBoundingClientRect();
  if (r.width === 0 || r.height === 0) return false;
  let n = el;
  while (n && n.nodeType === 1) {
    const s = getComputedStyle(n);
    if (s.display === "none" || s.visibility === "hidden" || s.opacity === "0") return false;
    n = n.parentElement;
  }
  return true;
};
const lyrics = document.querySelector('[data-testid="lyrics-textarea"]');
const all = [...document.querySelectorAll("textarea")].filter(vis);
const style = all.find(el => el !== lyrics);
console.log({ lyricsOk: !!lyrics, styleOk: !!style, sameElement: lyrics === style, total: all.length });
```

期待値: `{ lyricsOk: true, styleOk: true, sameElement: false, total: 2 }`

## スコープ外

- distrokid-helper の同種問題 (#???) は別 issue で対応 (selectors 全体が想像値、要実 DOM 検証)
- Suno UI が将来 data-testid を消した場合の更新は将来 issue で対応

## Execution Report

Workflow `default` completed successfully.

Closes #807