### PR TITLE
[#738] issue-738-core-utils-image-pro

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,8 @@
       "name": "@youtube-automation/core",
       "version": "0.1.0-alpha.0",
       "dependencies": {
+        "@google/genai": "^2.7.0",
+        "openai": "^6.41.0",
         "zod": "^4.1.13",
       },
     },
@@ -66,6 +68,8 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@google/genai": ["@google/genai@2.7.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
@@ -343,6 +347,8 @@
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@youtube-automation/cli": ["@youtube-automation/cli@workspace:packages/cli"],
 
     "@youtube-automation/core": ["@youtube-automation/core@workspace:packages/core"],
@@ -352,6 +358,8 @@
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -367,11 +375,17 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -415,6 +429,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
@@ -426,6 +442,8 @@
     "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -455,6 +473,8 @@
 
     "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "faceted-prompting": ["faceted-prompting@0.1.0", "", {}, "sha512-nFXVRwIvIWgVMLGlY2XO83D/BRSJ177ecIqyARisxHsUWBnJXpGSRIIe/O+Nbp+YMRRCaMwC04bxUaRFRpM4kw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -473,15 +493,23 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -497,6 +525,10 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -508,6 +540,8 @@
     "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -539,6 +573,8 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
@@ -546,6 +582,10 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "knip": ["knip@6.15.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.133.0", "oxc-resolver": "^11.20.0", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-uBaKFEGcu/HG4EY2gWFBMr+fBF43Jftoc2riJX51TKME1Z46C8UQIbNEusenYbEWihphxe2PY0Kns0yPvPYz4A=="],
 
@@ -581,6 +621,10 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "nypm": ["nypm@0.6.6", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.1.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -591,6 +635,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openai": ["openai@6.41.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-IGWPopZq6Rjoynjfb3NSLf/z2MTw7UiOsm9TAjPGAjUESH7Uq41Trg4QWehBEn58p74i+m7uoRPV2vXcpPXhyA=="],
+
     "oxc-parser": ["oxc-parser@0.133.0", "", { "dependencies": { "@oxc-project/types": "^0.133.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.133.0", "@oxc-parser/binding-android-arm64": "0.133.0", "@oxc-parser/binding-darwin-arm64": "0.133.0", "@oxc-parser/binding-darwin-x64": "0.133.0", "@oxc-parser/binding-freebsd-x64": "0.133.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.133.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.133.0", "@oxc-parser/binding-linux-arm64-gnu": "0.133.0", "@oxc-parser/binding-linux-arm64-musl": "0.133.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.133.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.133.0", "@oxc-parser/binding-linux-riscv64-musl": "0.133.0", "@oxc-parser/binding-linux-s390x-gnu": "0.133.0", "@oxc-parser/binding-linux-x64-gnu": "0.133.0", "@oxc-parser/binding-linux-x64-musl": "0.133.0", "@oxc-parser/binding-openharmony-arm64": "0.133.0", "@oxc-parser/binding-wasm32-wasi": "0.133.0", "@oxc-parser/binding-win32-arm64-msvc": "0.133.0", "@oxc-parser/binding-win32-ia32-msvc": "0.133.0", "@oxc-parser/binding-win32-x64-msvc": "0.133.0" } }, "sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw=="],
 
     "oxc-resolver": ["oxc-resolver@11.20.0", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.20.0", "@oxc-resolver/binding-android-arm64": "11.20.0", "@oxc-resolver/binding-darwin-arm64": "11.20.0", "@oxc-resolver/binding-darwin-x64": "11.20.0", "@oxc-resolver/binding-freebsd-x64": "11.20.0", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0", "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0", "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0", "@oxc-resolver/binding-linux-arm64-musl": "11.20.0", "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0", "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0", "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0", "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0", "@oxc-resolver/binding-linux-x64-gnu": "11.20.0", "@oxc-resolver/binding-linux-x64-musl": "11.20.0", "@oxc-resolver/binding-openharmony-arm64": "11.20.0", "@oxc-resolver/binding-wasm32-wasi": "11.20.0", "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0", "@oxc-resolver/binding-win32-x64-msvc": "11.20.0" } }, "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g=="],
@@ -598,6 +644,8 @@
     "oxfmt": ["oxfmt@0.53.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.53.0", "@oxfmt/binding-android-arm64": "0.53.0", "@oxfmt/binding-darwin-arm64": "0.53.0", "@oxfmt/binding-darwin-x64": "0.53.0", "@oxfmt/binding-freebsd-x64": "0.53.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.53.0", "@oxfmt/binding-linux-arm-musleabihf": "0.53.0", "@oxfmt/binding-linux-arm64-gnu": "0.53.0", "@oxfmt/binding-linux-arm64-musl": "0.53.0", "@oxfmt/binding-linux-ppc64-gnu": "0.53.0", "@oxfmt/binding-linux-riscv64-gnu": "0.53.0", "@oxfmt/binding-linux-riscv64-musl": "0.53.0", "@oxfmt/binding-linux-s390x-gnu": "0.53.0", "@oxfmt/binding-linux-x64-gnu": "0.53.0", "@oxfmt/binding-linux-x64-musl": "0.53.0", "@oxfmt/binding-openharmony-arm64": "0.53.0", "@oxfmt/binding-win32-arm64-msvc": "0.53.0", "@oxfmt/binding-win32-ia32-msvc": "0.53.0", "@oxfmt/binding-win32-x64-msvc": "0.53.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw=="],
 
     "oxlint": ["oxlint@1.68.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.68.0", "@oxlint/binding-android-arm64": "1.68.0", "@oxlint/binding-darwin-arm64": "1.68.0", "@oxlint/binding-darwin-x64": "1.68.0", "@oxlint/binding-freebsd-x64": "1.68.0", "@oxlint/binding-linux-arm-gnueabihf": "1.68.0", "@oxlint/binding-linux-arm-musleabihf": "1.68.0", "@oxlint/binding-linux-arm64-gnu": "1.68.0", "@oxlint/binding-linux-arm64-musl": "1.68.0", "@oxlint/binding-linux-ppc64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-musl": "1.68.0", "@oxlint/binding-linux-s390x-gnu": "1.68.0", "@oxlint/binding-linux-x64-gnu": "1.68.0", "@oxlint/binding-linux-x64-musl": "1.68.0", "@oxlint/binding-openharmony-arm64": "1.68.0", "@oxlint/binding-win32-arm64-msvc": "1.68.0", "@oxlint/binding-win32-ia32-msvc": "1.68.0", "@oxlint/binding-win32-x64-msvc": "1.68.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "package-json": ["package-json@10.0.1", "", { "dependencies": { "ky": "^1.2.0", "registry-auth-token": "^5.0.2", "registry-url": "^6.0.1", "semver": "^7.6.0" } }, "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg=="],
 
@@ -617,7 +665,7 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
-    "protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
+    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -645,7 +693,11 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -725,6 +777,8 @@
 
     "wanakana": ["wanakana@5.3.1", "", {}, "sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -734,6 +788,8 @@
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
@@ -749,9 +805,9 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "@grpc/proto-loader/protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
-
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,11 +7,14 @@
   "exports": {
     ".": "./src/index.ts",
     "./config": "./src/config/index.ts",
+    "./image": "./src/image/index.ts",
     "./metadata": "./src/metadata.ts",
     "./paths": "./src/paths.ts",
     "./skills-sync": "./skills-sync/index.ts"
   },
   "dependencies": {
+    "@google/genai": "^2.7.0",
+    "openai": "^6.41.0",
     "zod": "^4.1.13"
   }
 }

--- a/packages/core/src/image/base.ts
+++ b/packages/core/src/image/base.ts
@@ -1,0 +1,75 @@
+// ImageProvider 抽象の最小契約と共有リトライ定数（Python `utils/image_provider/base.py` の移植）。
+//
+// Gemini / OpenAI の差を吸収する薄い抽象化レイヤ。Provider 実装は `generate(req)`
+// を実装し、`ImageGenerationResult` を返す。Provider 中立の値のみを `Request` に保持し、
+// API 固有の `size` 文字列・`quality` 等は Provider 実装側で `aspectRatio` から導出する。
+
+// 共通リトライ定数（Gemini / OpenAI で共有）。秒単位。
+export const RETRY_MAX = 3;
+export const RETRY_BACKOFF = [10, 30, 60] as const;
+
+/**
+ * `attempt`（0 始まり）に対応するバックオフ待機をミリ秒で返す。
+ *
+ * 呼び出し側は `attempt < RETRY_MAX - 1` の範囲でのみ使う。範囲外は不変条件違反
+ * として throw する（握りつぶさない）。
+ */
+export const backoffMs = (attempt: number): number => {
+  const seconds = RETRY_BACKOFF[attempt];
+  if (seconds === undefined) {
+    throw new Error(
+      `RETRY_BACKOFF に attempt=${attempt} のエントリがありません`
+    );
+  }
+  return seconds * 1000;
+};
+
+/**
+ * 1 件分の画像生成リクエスト。
+ *
+ * - `prompt`: 生成プロンプト
+ * - `outputPath`: 出力先（拡張子 .png なら PNG、.jpg なら JPEG として保存）
+ * - `aspectRatio`: "16:9" / "9:16" / "1:1" など。OpenAI は 16:9 / 9:16 のみ受理
+ * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
+ * - `references`: 参照画像パス（省略・空なら参照なしモード）
+ */
+export interface ImageGenerationRequest {
+  readonly prompt: string;
+  readonly outputPath: string;
+  readonly aspectRatio: string;
+  readonly imageSize: string;
+  readonly references?: readonly string[];
+}
+
+/**
+ * 画像生成の結果。
+ *
+ * - `success`: true なら保存成功
+ * - `savedPath`: 保存先。失敗時は null
+ */
+export interface ImageGenerationResult {
+  readonly success: boolean;
+  readonly savedPath: string | null;
+}
+
+/**
+ * 画像生成プロバイダーの最小契約。
+ *
+ * - `name`: 識別子（"gemini" / "openai"）
+ * - `supportedAspectRatios`: 許容するアスペクト比の列。空配列は「制限なし」を意味する
+ * - `generate(req)`: 1 枚生成して保存する
+ */
+export interface ImageProvider {
+  readonly name: string;
+  readonly supportedAspectRatios: readonly string[];
+  generate(req: ImageGenerationRequest): Promise<ImageGenerationResult>;
+}
+
+/** 生成した画像バイト列を `outputPath` に永続化し、保存先パスを返す注入点。 */
+export type PersistImage = (
+  outputPath: string,
+  bytes: Uint8Array
+) => Promise<string>;
+
+/** リトライ間バックオフのスリープ注入点（ミリ秒）。 */
+export type SleepMs = (ms: number) => Promise<void>;

--- a/packages/core/src/image/config.ts
+++ b/packages/core/src/image/config.ts
@@ -1,0 +1,150 @@
+// 画像生成プロバイダーの設定型と skill-config パーサ（Python
+// `utils/image_provider/config.py` の移植）。
+//
+// skill-config の `image_generation:` namespace を解析し、`provider` 値に応じた
+// `GeminiConfig` / `OpenAIConfig` を保持する discriminated union を構築する。
+//
+// 移植スコープ（plan §4-D）: legacy `gemini_image:` namespace・`gemini_cli` /
+// `codex` provider・`thinking`・`replace_model` は移植しない。よって未対応の
+// provider 値（"codex" / "gemini_cli" を含む）は ConfigError で fail fast する。
+// 入力キーは snake_case（既存 config パーサと同様）、出力は camelCase。
+
+import { ConfigError } from "../errors.ts";
+import { isRecord } from "./internal.ts";
+
+// サポートする provider 識別子。`getProvider` の dispatch キーと一致させる。
+const SUPPORTED_PROVIDERS = ["gemini", "openai"] as const;
+
+/** OpenAI が受理するアスペクト比（16:9 と 9:16 のみ）。 */
+export const OPENAI_SUPPORTED_ASPECT_RATIOS = ["16:9", "9:16"] as const;
+
+const DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-image-preview";
+const DEFAULT_GEMINI_IMAGE_SIZE = "2K";
+const DEFAULT_OPENAI_MODEL = "gpt-image-2";
+const DEFAULT_OPENAI_QUALITY = "high";
+const DEFAULT_OPENAI_ASPECT_RATIO = "16:9";
+const DEFAULT_OPENAI_BATCH = 1;
+
+/**
+ * Gemini 画像生成プロバイダーの設定。
+ *
+ * `aspectRatio` フィールドは持たない。Gemini は branding/icon.png 用途で 1:1 等の
+ * 任意比率を受け付けるため、aspectRatio は `ImageGenerationRequest` 経由で都度渡す。
+ */
+export interface GeminiConfig {
+  readonly model: string;
+  readonly imageSize: string;
+}
+
+/**
+ * OpenAI 画像生成プロバイダー（gpt-image-2 系）の設定。
+ *
+ * `aspectRatio` はパース時に `OPENAI_SUPPORTED_ASPECT_RATIOS` へ制限する（fail fast）。
+ */
+export interface OpenAIConfig {
+  readonly model: string;
+  readonly quality: string;
+  readonly aspectRatio: string;
+  readonly batch: number;
+}
+
+/**
+ * provider 切り替え可能な画像生成設定。`provider` で判別する discriminated union で、
+ * 対応する側の sub-config のみを保持する。
+ */
+export type ImageGenerationConfig =
+  | { readonly provider: "gemini"; readonly gemini: GeminiConfig }
+  | { readonly provider: "openai"; readonly openai: OpenAIConfig };
+
+const readString = (
+  source: Record<string, unknown>,
+  key: string,
+  fallback: string
+): string => {
+  const value = source[key];
+  return typeof value === "string" ? value : fallback;
+};
+
+const readInt = (
+  source: Record<string, unknown>,
+  key: string,
+  fallback: number
+): number => {
+  const value = source[key];
+  return typeof value === "number" ? value : fallback;
+};
+
+const buildGemini = (sub: Record<string, unknown>): GeminiConfig => ({
+  imageSize: readString(sub, "image_size", DEFAULT_GEMINI_IMAGE_SIZE),
+  model: readString(sub, "model", DEFAULT_GEMINI_MODEL),
+});
+
+const buildOpenAI = (sub: Record<string, unknown>): OpenAIConfig => {
+  const aspectRatio = readString(
+    sub,
+    "aspect_ratio",
+    DEFAULT_OPENAI_ASPECT_RATIO
+  );
+  if (
+    !OPENAI_SUPPORTED_ASPECT_RATIOS.includes(
+      aspectRatio as (typeof OPENAI_SUPPORTED_ASPECT_RATIOS)[number]
+    )
+  ) {
+    throw new ConfigError(
+      `OpenAI image_generation.openai.aspect_ratio=${JSON.stringify(aspectRatio)} は未対応。` +
+        `許容値: ${JSON.stringify(OPENAI_SUPPORTED_ASPECT_RATIOS)}`
+    );
+  }
+  return {
+    aspectRatio,
+    batch: readInt(sub, "batch", DEFAULT_OPENAI_BATCH),
+    model: readString(sub, "model", DEFAULT_OPENAI_MODEL),
+    quality: readString(sub, "quality", DEFAULT_OPENAI_QUALITY),
+  };
+};
+
+const defaultConfig = (): ImageGenerationConfig => ({
+  gemini: {
+    imageSize: DEFAULT_GEMINI_IMAGE_SIZE,
+    model: DEFAULT_GEMINI_MODEL,
+  },
+  provider: "gemini",
+});
+
+const subSection = (
+  section: Record<string, unknown>,
+  key: string
+): Record<string, unknown> => {
+  const value = section[key];
+  return isRecord(value) ? value : {};
+};
+
+/**
+ * skill-config（raw）から `ImageGenerationConfig` を組み立てる。
+ *
+ * `image_generation:` namespace が無ければ gemini 既定値を返す。`provider` が
+ * {gemini, openai} 以外なら ConfigError で fail fast する。
+ */
+export const parseImageGenerationConfig = (
+  raw: unknown
+): ImageGenerationConfig => {
+  if (!isRecord(raw)) {
+    return defaultConfig();
+  }
+  const section = raw.image_generation;
+  if (!isRecord(section)) {
+    return defaultConfig();
+  }
+
+  const provider = readString(section, "provider", "gemini");
+  if (provider === "gemini") {
+    return { gemini: buildGemini(subSection(section, "gemini")), provider };
+  }
+  if (provider === "openai") {
+    return { openai: buildOpenAI(subSection(section, "openai")), provider };
+  }
+  throw new ConfigError(
+    `image_generation.provider=${JSON.stringify(provider)} は未対応。` +
+      `許容値: ${JSON.stringify(SUPPORTED_PROVIDERS)}`
+  );
+};

--- a/packages/core/src/image/gemini.ts
+++ b/packages/core/src/image/gemini.ts
@@ -1,0 +1,166 @@
+// Gemini 画像生成プロバイダー（Python `utils/image_provider/gemini.py` の移植）。
+//
+// `@google/genai` SDK でのリクエスト送信・参照画像の inlineData 化・
+// SAFETY/RECITATION 即時失敗・指数バックオフリトライ・画像保存を担う。
+// SDK client / sleep / persist は注入され（テストは fake で差し替え）、ここは
+// orchestration（リトライ・base64 decode・参照画像の inline 化）に集中する。
+
+import { ConfigError } from "../errors.ts";
+import { backoffMs, RETRY_MAX } from "./base.ts";
+import type {
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  ImageProvider,
+  PersistImage,
+  SleepMs,
+} from "./base.ts";
+import type { GeminiConfig } from "./config.ts";
+import { isRecord } from "./internal.ts";
+import { defaultPersist, defaultSleep } from "./io.ts";
+import { readReferenceFiles } from "./references.ts";
+
+// `@google/genai` client の最小シェイプ（注入点の seam）。
+interface GeminiClient {
+  models: {
+    generateContent(params: unknown): Promise<unknown>;
+  };
+}
+
+/** GeminiImageProvider の注入依存。省略時は production default が使われる。 */
+export interface GeminiProviderDeps {
+  createClient: () => GeminiClient | Promise<GeminiClient>;
+  persist: PersistImage;
+  sleep: SleepMs;
+}
+
+// `{ candidates: [{ content: { parts: [...] } }] }` から parts を取り出す。
+// 想定外の形は空配列に落とし、「画像なしレスポンス」としてリトライ経路へ合流させる。
+const extractParts = (response: unknown): unknown[] => {
+  if (!isRecord(response) || !Array.isArray(response.candidates)) {
+    return [];
+  }
+  const [first] = response.candidates;
+  if (!isRecord(first) || !isRecord(first.content)) {
+    return [];
+  }
+  return Array.isArray(first.content.parts) ? first.content.parts : [];
+};
+
+const inlineImageBytes = (part: unknown): Uint8Array | null => {
+  if (
+    isRecord(part) &&
+    isRecord(part.inlineData) &&
+    typeof part.inlineData.data === "string"
+  ) {
+    return new Uint8Array(Buffer.from(part.inlineData.data, "base64"));
+  }
+  return null;
+};
+
+const referenceMime = (path: string): string =>
+  /\.jpe?g$/iu.test(path) ? "image/jpeg" : "image/png";
+
+// 参照画像を base64 inlineData Part に変換し、末尾に prompt を付ける（参照なしは [prompt]）。
+const buildContents = (
+  prompt: string,
+  references: readonly string[]
+): unknown[] => {
+  if (references.length === 0) {
+    return [prompt];
+  }
+  const parts = readReferenceFiles(references).map(({ bytes, path }) => ({
+    inlineData: {
+      data: Buffer.from(bytes).toString("base64"),
+      mimeType: referenceMime(path),
+    },
+  }));
+  return [...parts, prompt];
+};
+
+const isContentPolicyError = (error: unknown): boolean => {
+  const message = (
+    error instanceof Error ? error.message : String(error)
+  ).toUpperCase();
+  return message.includes("SAFETY") || message.includes("RECITATION");
+};
+
+const defaultCreateClient = async (): Promise<GeminiClient> => {
+  const project = process.env.GOOGLE_CLOUD_PROJECT;
+  if (!project) {
+    throw new ConfigError(
+      "GOOGLE_CLOUD_PROJECT が未設定です。Vertex AI の project を指定してください"
+    );
+  }
+  const { GoogleGenAI } = await import("@google/genai");
+  // 画像系モデルは Vertex AI の global location のみサポート（genai_client.py 参照）。
+  return new GoogleGenAI({
+    location: "global",
+    project,
+    vertexai: true,
+  }) as unknown as GeminiClient;
+};
+
+const defaultDeps = (): GeminiProviderDeps => ({
+  createClient: defaultCreateClient,
+  persist: defaultPersist,
+  sleep: defaultSleep,
+});
+
+/** Gemini API（Vertex AI 経由）で画像を 1 枚生成して保存する。 */
+export class GeminiImageProvider implements ImageProvider {
+  readonly name = "gemini";
+  // Gemini はアスペクト比を制限しない（branding/icon.png 用途で 1:1 等を許容）。
+  readonly supportedAspectRatios: readonly string[] = [];
+
+  private readonly config: GeminiConfig;
+  private readonly deps: GeminiProviderDeps;
+
+  // deps はテスト/サービス層が SDK client を差し替えるための注入点。省略時のみ
+  // production default を使う（fallback ではなく明示的な DI 既定）。
+  constructor(config: GeminiConfig, deps?: GeminiProviderDeps) {
+    this.config = config;
+    this.deps = deps ?? defaultDeps();
+  }
+
+  async generate(req: ImageGenerationRequest): Promise<ImageGenerationResult> {
+    const { createClient, persist, sleep } = this.deps;
+    const client = await createClient();
+    const references = req.references ?? [];
+    // req.imageSize が空のときのみ config の既定解像度に委ねる（Python と同じ挙動）。
+    const imageSize = req.imageSize || this.config.imageSize;
+    const params = {
+      config: {
+        imageConfig: { aspectRatio: req.aspectRatio, imageSize },
+        responseModalities: ["IMAGE", "TEXT"],
+      },
+      contents: buildContents(req.prompt, references),
+      model: this.config.model,
+    };
+
+    for (let attempt = 0; attempt < RETRY_MAX; attempt += 1) {
+      try {
+        const response = await client.models.generateContent(params);
+        for (const part of extractParts(response)) {
+          const bytes = inlineImageBytes(part);
+          if (bytes) {
+            const savedPath = await persist(req.outputPath, bytes);
+            return { savedPath, success: true };
+          }
+        }
+        // 画像なしレスポンス → リトライ。
+      } catch (error) {
+        if (isContentPolicyError(error)) {
+          // SAFETY / RECITATION はリトライしても通らないため即時失敗。
+          return { savedPath: null, success: false };
+        }
+        // 一時エラー → リトライ。
+      }
+
+      if (attempt < RETRY_MAX - 1) {
+        await sleep(backoffMs(attempt));
+      }
+    }
+
+    return { savedPath: null, success: false };
+  }
+}

--- a/packages/core/src/image/index.ts
+++ b/packages/core/src/image/index.ts
@@ -1,0 +1,48 @@
+// 画像生成プロバイダー抽象化レイヤの公開 API
+// （Python `utils/image_provider/__init__.py` の移植）。
+//
+// 公開 API:
+// - getProvider(config): ImageGenerationConfig から ImageProvider 実装にディスパッチ
+// - parseImageGenerationConfig(raw): skill-config から ImageGenerationConfig を構築
+// - ImageProvider / ImageGenerationRequest / ImageGenerationResult: 抽象契約
+// - RETRY_MAX / RETRY_BACKOFF: 共通リトライ定数
+// - OPENAI_SUPPORTED_ASPECT_RATIOS: OpenAI が受理するアスペクト比
+
+import { ConfigError } from "../errors.ts";
+import type { ImageProvider } from "./base.ts";
+import type { ImageGenerationConfig } from "./config.ts";
+import { GeminiImageProvider } from "./gemini.ts";
+import { OpenAIImageProvider } from "./openai.ts";
+
+export {
+  type ImageGenerationRequest,
+  type ImageGenerationResult,
+  type ImageProvider,
+  RETRY_BACKOFF,
+  RETRY_MAX,
+} from "./base.ts";
+export {
+  type GeminiConfig,
+  type ImageGenerationConfig,
+  OPENAI_SUPPORTED_ASPECT_RATIOS,
+  type OpenAIConfig,
+  parseImageGenerationConfig,
+} from "./config.ts";
+export { GeminiImageProvider, type GeminiProviderDeps } from "./gemini.ts";
+export { OpenAIImageProvider, type OpenAIProviderDeps } from "./openai.ts";
+
+/**
+ * `ImageGenerationConfig` から対応する provider 実装を返す。
+ *
+ * `provider` が {gemini, openai} 以外（手組みの不正値など）なら ConfigError で fail fast。
+ */
+export const getProvider = (config: ImageGenerationConfig): ImageProvider => {
+  if (config.provider === "gemini") {
+    return new GeminiImageProvider(config.gemini);
+  }
+  if (config.provider === "openai") {
+    return new OpenAIImageProvider(config.openai);
+  }
+  const { provider } = config as { provider: string };
+  throw new ConfigError(`未対応の provider=${JSON.stringify(provider)}`);
+};

--- a/packages/core/src/image/internal.ts
+++ b/packages/core/src/image/internal.ts
@@ -1,0 +1,5 @@
+// image モジュール内部で共有する小さなガード（公開 API ではない）。
+
+/** plain object（非 null の object）かを判定する型ガード。 */
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;

--- a/packages/core/src/image/io.ts
+++ b/packages/core/src/image/io.ts
@@ -1,0 +1,22 @@
+// Provider 共有の default 注入実装（バックオフ sleep と画像の永続化）。
+//
+// テストではこれらを fake で差し替えるため、ここはユニットテストの対象外の
+// production default。`persist` は decode 済みの生バイト列を `outputPath` へ書き出す。
+// Python 版 `composition.persist_image` の PNG/JPEG dual-save・YouTube サムネ 2MB
+// 上限対応は別モジュール（composition の移植）の責務であり、本 provider 抽象の
+// スコープ外なので、ここでは生バイトのロスレス書き出しのみを行う。
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { PersistImage, SleepMs } from "./base.ts";
+
+/** 実時間で待機する default sleep。 */
+export const defaultSleep: SleepMs = (ms) => Bun.sleep(ms);
+
+/** 生バイト列を `outputPath` に書き出して保存先パスを返す default persist。 */
+export const defaultPersist: PersistImage = async (outputPath, bytes) => {
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, bytes);
+  return outputPath;
+};

--- a/packages/core/src/image/openai.ts
+++ b/packages/core/src/image/openai.ts
@@ -1,0 +1,148 @@
+// OpenAI 画像生成プロバイダー（gpt-image-2 系。Python
+// `utils/image_provider/openai.py` の移植）。
+//
+// `openai` SDK の `images.generate` / `images.edit` を呼ぶ。`aspectRatio` を
+// OpenAI Images API の `size` 文字列にマップし、未対応比率は SDK を呼ぶ前に
+// ConfigError で fail fast（リトライしない）。SDK client / sleep / persist は
+// 注入され（テストは fake で差し替え）、API キーは `resolveSecret` 経由で取得する。
+
+import { basename } from "node:path";
+
+import { ConfigError } from "../errors.ts";
+import { resolveSecret } from "../secrets.ts";
+import { backoffMs, RETRY_MAX } from "./base.ts";
+import type {
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  ImageProvider,
+  PersistImage,
+  SleepMs,
+} from "./base.ts";
+import { OPENAI_SUPPORTED_ASPECT_RATIOS } from "./config.ts";
+import type { OpenAIConfig } from "./config.ts";
+import { isRecord } from "./internal.ts";
+import { defaultPersist, defaultSleep } from "./io.ts";
+import { readReferenceFiles } from "./references.ts";
+
+// `openai` client の最小シェイプ（注入点の seam）。
+interface OpenAIClient {
+  images: {
+    generate(params: unknown): Promise<unknown>;
+    edit(params: unknown): Promise<unknown>;
+  };
+}
+
+/** OpenAIImageProvider の注入依存。省略時は production default が使われる。 */
+export interface OpenAIProviderDeps {
+  createClient: () => OpenAIClient | Promise<OpenAIClient>;
+  persist: PersistImage;
+  sleep: SleepMs;
+}
+
+// OpenAI Images API が受け付ける size 文字列へのマッピング。
+const ASPECT_RATIO_TO_SIZE: Record<string, string> = {
+  "16:9": "1536x1024",
+  "9:16": "1024x1536",
+};
+
+// `{ data: [{ b64_json }, ...] }` から先頭の b64_json を持つ要素を decode する。
+// b64_json を持たない要素はスキップする（openai.py:140-143）。
+const decodeFirstImage = (response: unknown): Uint8Array | null => {
+  if (!isRecord(response) || !Array.isArray(response.data)) {
+    return null;
+  }
+  for (const item of response.data) {
+    if (isRecord(item) && typeof item.b64_json === "string") {
+      return new Uint8Array(Buffer.from(item.b64_json, "base64"));
+    }
+  }
+  return null;
+};
+
+const defaultCreateClient = async (): Promise<OpenAIClient> => {
+  const apiKey = await resolveSecret("OPENAI_API_KEY");
+  const { default: OpenAI } = await import("openai");
+  return new OpenAI({ apiKey }) as unknown as OpenAIClient;
+};
+
+const defaultDeps = (): OpenAIProviderDeps => ({
+  createClient: defaultCreateClient,
+  persist: defaultPersist,
+  sleep: defaultSleep,
+});
+
+/** OpenAI Images API（gpt-image-2 系）で画像を 1 枚生成して保存する。 */
+export class OpenAIImageProvider implements ImageProvider {
+  readonly name = "openai";
+  readonly supportedAspectRatios: readonly string[] = [
+    ...OPENAI_SUPPORTED_ASPECT_RATIOS,
+  ];
+
+  private readonly config: OpenAIConfig;
+  private readonly deps: OpenAIProviderDeps;
+
+  // deps はテスト/サービス層が SDK client を差し替えるための注入点。省略時のみ
+  // production default を使う（fallback ではなく明示的な DI 既定）。
+  constructor(config: OpenAIConfig, deps?: OpenAIProviderDeps) {
+    this.config = config;
+    this.deps = deps ?? defaultDeps();
+  }
+
+  async generate(req: ImageGenerationRequest): Promise<ImageGenerationResult> {
+    const size = ASPECT_RATIO_TO_SIZE[req.aspectRatio];
+    if (size === undefined) {
+      // 未対応比率は client 生成・SDK 呼び出し前に fail fast（リトライしない）。
+      throw new ConfigError(
+        `OpenAI image_generation の aspect_ratio=${JSON.stringify(req.aspectRatio)} は未対応。` +
+          `許容値: ${JSON.stringify(Object.keys(ASPECT_RATIO_TO_SIZE))}`
+      );
+    }
+
+    const { createClient, persist, sleep } = this.deps;
+    const client = await createClient();
+    const references = req.references ?? [];
+
+    for (let attempt = 0; attempt < RETRY_MAX; attempt += 1) {
+      try {
+        const response = await this.callApi(client, req, size, references);
+        const bytes = decodeFirstImage(response);
+        if (bytes) {
+          const savedPath = await persist(req.outputPath, bytes);
+          return { savedPath, success: true };
+        }
+        // 画像なしレスポンス → リトライ。
+      } catch {
+        // 一時エラー → リトライ。
+      }
+
+      if (attempt < RETRY_MAX - 1) {
+        await sleep(backoffMs(attempt));
+      }
+    }
+
+    return { savedPath: null, success: false };
+  }
+
+  // 参照画像があれば images.edit、なければ images.generate を呼ぶ。
+  private callApi(
+    client: OpenAIClient,
+    req: ImageGenerationRequest,
+    size: string,
+    references: readonly string[]
+  ): Promise<unknown> {
+    const base = {
+      model: this.config.model,
+      n: this.config.batch,
+      prompt: req.prompt,
+      quality: this.config.quality,
+      size,
+    };
+    if (references.length > 0) {
+      const image = readReferenceFiles(references).map(
+        ({ bytes, path }) => new File([bytes], basename(path))
+      );
+      return client.images.edit({ ...base, image });
+    }
+    return client.images.generate(base);
+  }
+}

--- a/packages/core/src/image/references.ts
+++ b/packages/core/src/image/references.ts
@@ -1,0 +1,19 @@
+// 参照画像ファイルの読み込みを 1 箇所に集約するヘルパー。
+// Gemini（base64 inlineData 化）と OpenAI（File 化）の双方が生バイト読み込みを共有する。
+
+import { readFileSync } from "node:fs";
+
+/** 読み込んだ参照画像 1 件（パスと生バイト列のペア）。 */
+export interface ReferenceImage {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+}
+
+/** 参照画像パス列を読み込み、パスと生バイト列のペア列に変換する。順序は保つ。 */
+export const readReferenceFiles = (
+  references: readonly string[]
+): ReferenceImage[] =>
+  references.map((path) => ({
+    bytes: new Uint8Array(readFileSync(path)),
+    path,
+  }));

--- a/packages/core/test/image-config.test.ts
+++ b/packages/core/test/image-config.test.ts
@@ -1,0 +1,232 @@
+// Tests for packages/core/src/image config parsing + provider dispatch — the TS
+// port of the pure config surface from Python `utils/image_provider/config.py`
+// and `utils/image_provider/__init__.py::get_provider`.
+//
+// Signature contract (test-first spec the draft implements), from plan §6/§7:
+//   RETRY_MAX = 3
+//   RETRY_BACKOFF = [10, 30, 60]            // seconds
+//   OPENAI_SUPPORTED_ASPECT_RATIOS = ["16:9", "9:16"]
+//   parseImageGenerationConfig(raw: unknown): ImageGenerationConfig
+//   getProvider(config: ImageGenerationConfig, deps?): ImageProvider
+//
+// Scope note (plan §4-D): legacy `gemini_image:` namespace, `gemini_cli`/`codex`
+// providers, `thinking`, and `replace_model` are intentionally NOT ported, so an
+// unsupported `provider` value (including "codex"/"gemini_cli") must fail fast
+// with ConfigError. Input keys are snake_case (matching the existing config
+// parsers); the parsed result is camelCase.
+
+import { describe, expect, test } from "bun:test";
+
+import { ConfigError } from "@youtube-automation/core";
+import {
+  getProvider,
+  OPENAI_SUPPORTED_ASPECT_RATIOS,
+  parseImageGenerationConfig,
+  RETRY_BACKOFF,
+  RETRY_MAX,
+} from "@youtube-automation/core/image";
+import type { ImageGenerationConfig } from "@youtube-automation/core/image";
+
+// --- shared retry constants ----------------------------------------------
+
+describe("retry constants", () => {
+  test("RETRY_MAX is 3 (base.py:14)", () => {
+    // Given the ported retry budget
+    // When reading the exported constant
+    // Then it matches the Python value
+    expect(RETRY_MAX).toBe(3);
+  });
+
+  test("RETRY_BACKOFF is the 10/30/60 second schedule (base.py:15)", () => {
+    // Given the ported backoff schedule (in seconds)
+    // When reading the exported tuple
+    // Then it carries the three documented waits
+    expect([...RETRY_BACKOFF]).toEqual([10, 30, 60]);
+  });
+
+  test("OPENAI_SUPPORTED_ASPECT_RATIOS is exactly 16:9 and 9:16 (config.py:24)", () => {
+    // Given OpenAI's restricted aspect-ratio set
+    // When reading the exported tuple
+    // Then only the two landscape/portrait ratios are allowed
+    expect([...OPENAI_SUPPORTED_ASPECT_RATIOS]).toEqual(["16:9", "9:16"]);
+  });
+});
+
+// --- parseImageGenerationConfig: defaults --------------------------------
+
+describe("parseImageGenerationConfig defaults", () => {
+  test("falls back to the gemini provider when no image_generation namespace exists", () => {
+    // Given a raw config with no image_generation section (config.py:145)
+    const config = parseImageGenerationConfig({});
+    // When parsing it
+    // Then the gemini provider default is selected with its model/size defaults
+    expect(config.provider).toBe("gemini");
+    if (config.provider !== "gemini") {
+      throw new Error("expected gemini provider");
+    }
+    expect(config.gemini.model).toBe("gemini-3.1-flash-image-preview");
+    expect(config.gemini.imageSize).toBe("2K");
+  });
+
+  test("fills gemini defaults when the gemini sub-config is empty", () => {
+    // Given provider=gemini with no sub-keys (config.py:177-181)
+    const config = parseImageGenerationConfig({
+      image_generation: { provider: "gemini" },
+    });
+    // When parsing it
+    // Then the model and image_size defaults are applied
+    if (config.provider !== "gemini") {
+      throw new Error("expected gemini provider");
+    }
+    expect(config.gemini.model).toBe("gemini-3.1-flash-image-preview");
+    expect(config.gemini.imageSize).toBe("2K");
+  });
+
+  test("fills openai defaults when the openai sub-config is empty", () => {
+    // Given provider=openai with no sub-keys (config.py:192-199)
+    const config = parseImageGenerationConfig({
+      image_generation: { provider: "openai" },
+    });
+    // When parsing it
+    // Then model/quality/aspectRatio/batch defaults are applied
+    if (config.provider !== "openai") {
+      throw new Error("expected openai provider");
+    }
+    expect(config.openai.model).toBe("gpt-image-2");
+    expect(config.openai.quality).toBe("high");
+    expect(config.openai.aspectRatio).toBe("16:9");
+    expect(config.openai.batch).toBe(1);
+  });
+});
+
+// --- parseImageGenerationConfig: overrides (snake_case input) -------------
+
+describe("parseImageGenerationConfig overrides", () => {
+  test("reads snake_case image_size into the camelCase gemini field", () => {
+    // Given a gemini override using the snake_case input key
+    const config = parseImageGenerationConfig({
+      image_generation: {
+        gemini: { image_size: "4K", model: "gemini-x" },
+        provider: "gemini",
+      },
+    });
+    // When parsing it
+    // Then the override values land on the camelCase output fields
+    if (config.provider !== "gemini") {
+      throw new Error("expected gemini provider");
+    }
+    expect(config.gemini.model).toBe("gemini-x");
+    expect(config.gemini.imageSize).toBe("4K");
+  });
+
+  test("reads snake_case aspect_ratio + batch into the openai sub-config", () => {
+    // Given an openai override with the portrait ratio and a batch size
+    const config = parseImageGenerationConfig({
+      image_generation: {
+        openai: {
+          aspect_ratio: "9:16",
+          batch: 3,
+          model: "gpt-image-2",
+          quality: "medium",
+        },
+        provider: "openai",
+      },
+    });
+    // When parsing it
+    // Then the camelCase output reflects every override
+    if (config.provider !== "openai") {
+      throw new Error("expected openai provider");
+    }
+    expect(config.openai.quality).toBe("medium");
+    expect(config.openai.aspectRatio).toBe("9:16");
+    expect(config.openai.batch).toBe(3);
+  });
+});
+
+// --- parseImageGenerationConfig: fail-fast --------------------------------
+
+describe("parseImageGenerationConfig fail-fast", () => {
+  test("rejects an OpenAI aspect_ratio outside the supported set", () => {
+    // Given an openai config with an unsupported ratio (config.py:87-92)
+    // When parsing it
+    // Then it fails fast rather than producing an invalid config
+    expect(() =>
+      parseImageGenerationConfig({
+        image_generation: {
+          openai: { aspect_ratio: "1:1" },
+          provider: "openai",
+        },
+      })
+    ).toThrow(ConfigError);
+  });
+
+  test("rejects an unsupported provider name", () => {
+    // Given a provider value outside {gemini, openai} (config.py:150-151)
+    // When parsing it
+    // Then a ConfigError is raised
+    expect(() =>
+      parseImageGenerationConfig({
+        image_generation: { provider: "midjourney" },
+      })
+    ).toThrow(ConfigError);
+  });
+
+  test("rejects the de-scoped codex provider", () => {
+    // Given provider=codex, which is intentionally NOT ported (plan §4-D)
+    // When parsing it
+    // Then it is treated as unsupported, not silently accepted
+    expect(() =>
+      parseImageGenerationConfig({
+        image_generation: { provider: "codex" },
+      })
+    ).toThrow(ConfigError);
+  });
+
+  test("rejects the de-scoped gemini_cli provider", () => {
+    // Given provider=gemini_cli, which is intentionally NOT ported (plan §4-D)
+    // When parsing it
+    // Then it is treated as unsupported
+    expect(() =>
+      parseImageGenerationConfig({
+        image_generation: { provider: "gemini_cli" },
+      })
+    ).toThrow(ConfigError);
+  });
+});
+
+// --- getProvider dispatch -------------------------------------------------
+
+describe("getProvider dispatch", () => {
+  test("returns a gemini provider with no aspect-ratio restriction", () => {
+    // Given a parsed gemini config
+    const config = parseImageGenerationConfig({
+      image_generation: { provider: "gemini" },
+    });
+    // When dispatching to a provider
+    const provider = getProvider(config);
+    // Then the gemini provider exposes its identifier and an empty (unrestricted)
+    // aspect-ratio set (gemini.py:27-29)
+    expect(provider.name).toBe("gemini");
+    expect([...provider.supportedAspectRatios]).toEqual([]);
+  });
+
+  test("returns an openai provider restricted to 16:9 and 9:16", () => {
+    // Given a parsed openai config
+    const config = parseImageGenerationConfig({
+      image_generation: { provider: "openai" },
+    });
+    // When dispatching to a provider
+    const provider = getProvider(config);
+    // Then the openai provider advertises its restricted ratios (openai.py:43-44)
+    expect(provider.name).toBe("openai");
+    expect([...provider.supportedAspectRatios]).toEqual(["16:9", "9:16"]);
+  });
+
+  test("fails fast on an unsupported provider in the config", () => {
+    // Given a hand-rolled config carrying an unsupported provider (__init__.py:75)
+    const bogus = { provider: "codex" } as unknown as ImageGenerationConfig;
+    // When dispatching it
+    // Then getProvider raises ConfigError rather than returning undefined
+    expect(() => getProvider(bogus)).toThrow(ConfigError);
+  });
+});

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -1,0 +1,318 @@
+// Tests for the GeminiImageProvider — TS port of `utils/image_provider/gemini.py`.
+//
+// The SDK client, the backoff sleep, and the image-persist step are injected
+// (plan §6/§8) so these tests exercise the provider's orchestration — retry,
+// SAFETY/RECITATION short-circuit, base64 decode, reference-image inlining —
+// against an in-memory fake instead of `@google/genai`, ADC, and the filesystem.
+//
+// Faithful SDK shape (verified against @google/genai docs): the client exposes
+// `models.generateContent(params)` and returns
+//   { candidates: [{ content: { parts: [ <part>, ... ] } }] }
+// where an image part is `{ inlineData: { data: <base64 string>, mimeType } }`
+// and a text part is `{ text: string }`. The provider base64-decodes
+// `inlineData.data` before persisting, mirroring the OpenAI b64 path.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { GeminiImageProvider } from "@youtube-automation/core/image";
+import type { ImageGenerationRequest } from "@youtube-automation/core/image";
+
+// Constructor deps type, derived from the provider itself so the test does not
+// hard-code an exported name for the injection bag.
+type GeminiDeps = NonNullable<
+  ConstructorParameters<typeof GeminiImageProvider>[1]
+>;
+
+// --- fakes ----------------------------------------------------------------
+
+type Behavior = () => unknown;
+
+// A fake `@google/genai` client. Each generateContent call consumes the next
+// behavior (a value-returning or throwing thunk); the last one repeats so a
+// single "always fails" behavior covers every retry attempt.
+const makeGeminiClient = (behaviors: Behavior[]) => {
+  const calls: unknown[] = [];
+  let index = 0;
+  const client = {
+    models: {
+      generateContent: (params: unknown) => {
+        calls.push(params);
+        const behavior = behaviors[Math.min(index, behaviors.length - 1)];
+        index += 1;
+        return Promise.resolve().then(behavior);
+      },
+    },
+  };
+  return { calls, client };
+};
+
+const imageResponse = (base64: string) => ({
+  candidates: [
+    {
+      content: {
+        parts: [{ inlineData: { data: base64, mimeType: "image/png" } }],
+      },
+    },
+  ],
+});
+
+const textOnlyResponse = (text: string) => ({
+  candidates: [{ content: { parts: [{ text }] } }],
+});
+
+// Captures injected sleeps and persists so retries never wait on real timers
+// and saves never touch disk.
+const makeRecorders = () => {
+  const sleeps: number[] = [];
+  const persisted: { path: string; bytes: Uint8Array }[] = [];
+  return {
+    persist: (outputPath: string, bytes: Uint8Array): Promise<string> => {
+      persisted.push({ bytes, path: outputPath });
+      return Promise.resolve(outputPath);
+    },
+    persisted,
+    sleep: (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    },
+    sleeps,
+  };
+};
+
+const makeDeps = (
+  client: unknown,
+  recorders: ReturnType<typeof makeRecorders>
+): GeminiDeps =>
+  ({
+    createClient: () => client,
+    persist: recorders.persist,
+    sleep: recorders.sleep,
+  }) as unknown as GeminiDeps;
+
+const geminiConfig = {
+  imageSize: "2K",
+  model: "gemini-3.1-flash-image-preview",
+};
+
+const baseRequest = (outputPath: string): ImageGenerationRequest => ({
+  aspectRatio: "16:9",
+  imageSize: "2K",
+  outputPath,
+  prompt: "a calm lo-fi study room at night",
+});
+
+// --- temp dir for reference-image fixtures -------------------------------
+
+let workdir: string;
+
+beforeAll(() => {
+  workdir = mkdtempSync(join(tmpdir(), "img-gemini-"));
+});
+
+afterAll(() => {
+  rmSync(workdir, { force: true, recursive: true });
+});
+
+// --- identity -------------------------------------------------------------
+
+describe("GeminiImageProvider identity", () => {
+  test("reports its name and unrestricted aspect ratios", () => {
+    // Given a constructed gemini provider (gemini.py:27-29)
+    const provider = new GeminiImageProvider(geminiConfig);
+    // When reading its metadata
+    // Then it identifies as gemini with no ratio restriction
+    expect(provider.name).toBe("gemini");
+    expect([...provider.supportedAspectRatios]).toEqual([]);
+  });
+});
+
+// --- success path ---------------------------------------------------------
+
+describe("GeminiImageProvider.generate success", () => {
+  test("decodes the base64 image part and persists the raw bytes", async () => {
+    // Given a client that returns one inline image part
+    const original = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+    const base64 = Buffer.from(original).toString("base64");
+    const { client } = makeGeminiClient([() => imageResponse(base64)]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+    const outputPath = join(workdir, "out.png");
+
+    // When generating
+    const result = await provider.generate(baseRequest(outputPath));
+
+    // Then the decoded bytes are persisted and the saved path is returned
+    expect(result.success).toBe(true);
+    expect(result.savedPath).toBe(outputPath);
+    expect(recorders.persisted).toHaveLength(1);
+    const [persisted] = recorders.persisted;
+    if (!persisted) {
+      throw new Error("expected a persisted image");
+    }
+    expect([...persisted.bytes]).toEqual([...original]);
+    expect(persisted.path).toBe(outputPath);
+    expect(recorders.sleeps).toEqual([]);
+  });
+
+  test("forwards the configured model and request aspect ratio to the SDK", async () => {
+    // Given a successful single-image response
+    const base64 = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating with aspect ratio 16:9
+    await provider.generate(baseRequest(join(workdir, "fwd.png")));
+
+    // Then the model is passed through and the aspect ratio reaches the call
+    expect(calls).toHaveLength(1);
+    const params = calls[0] as { model?: unknown };
+    expect(params.model).toBe("gemini-3.1-flash-image-preview");
+    expect(JSON.stringify(calls[0])).toContain("16:9");
+  });
+
+  test("inlines reference image bytes as base64 into the request", async () => {
+    // Given a reference image on disk and a successful response
+    const refBytes = new Uint8Array([0x10, 0x20, 0x30, 0x40]);
+    const refPath = join(workdir, "ref.png");
+    writeFileSync(refPath, refBytes);
+    const base64 = Buffer.from(new Uint8Array([9, 9, 9])).toString("base64");
+    const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating with a reference image (gemini.py:45-51)
+    const result = await provider.generate({
+      ...baseRequest(join(workdir, "ref-out.png")),
+      references: [refPath],
+    });
+
+    // Then it still succeeds and the reference bytes are sent as base64 inlineData
+    expect(result.success).toBe(true);
+    const refBase64 = Buffer.from(refBytes).toString("base64");
+    expect(JSON.stringify(calls[0])).toContain(refBase64);
+  });
+});
+
+// --- retry path -----------------------------------------------------------
+
+describe("GeminiImageProvider.generate retry", () => {
+  test("retries on an image-less response and fails after RETRY_MAX attempts", async () => {
+    // Given a client that only ever returns text (no image part) (gemini.py:94-96)
+    const { calls, client } = makeGeminiClient([
+      () => textOnlyResponse("no image in response"),
+    ]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      baseRequest(join(workdir, "miss.png"))
+    );
+
+    // Then it exhausts all 3 attempts, sleeps between them, and reports failure
+    expect(result.success).toBe(false);
+    expect(result.savedPath).toBeNull();
+    expect(calls).toHaveLength(3);
+    // Two waits (between attempt 1→2 and 2→3), in ms = RETRY_BACKOFF seconds × 1000
+    expect(recorders.sleeps).toEqual([10_000, 30_000]);
+    expect(recorders.persisted).toEqual([]);
+  });
+
+  test("succeeds on a later attempt after transient SDK errors", async () => {
+    // Given two thrown errors followed by a good image response
+    const base64 = Buffer.from(new Uint8Array([7, 7])).toString("base64");
+    const { calls, client } = makeGeminiClient([
+      () => {
+        throw new Error("503 backend unavailable");
+      },
+      () => {
+        throw new Error("deadline exceeded");
+      },
+      () => imageResponse(base64),
+    ]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      baseRequest(join(workdir, "late.png"))
+    );
+
+    // Then the third attempt wins after two backoff waits
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(3);
+    expect(recorders.sleeps).toEqual([10_000, 30_000]);
+  });
+});
+
+// --- content-policy short-circuit ----------------------------------------
+
+describe("GeminiImageProvider.generate content policy", () => {
+  test("does not retry when the SDK reports a SAFETY violation", async () => {
+    // Given an error whose message contains SAFETY (gemini.py:100-102)
+    const { calls, client } = makeGeminiClient([
+      () => {
+        throw new Error("blocked due to SAFETY filters");
+      },
+    ]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      baseRequest(join(workdir, "safety.png"))
+    );
+
+    // Then it fails immediately with no retry and no backoff wait
+    expect(result.success).toBe(false);
+    expect(result.savedPath).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(recorders.sleeps).toEqual([]);
+  });
+
+  test("does not retry when the SDK reports a RECITATION block", async () => {
+    // Given an error whose message contains RECITATION (gemini.py:100-102)
+    const { calls, client } = makeGeminiClient([
+      () => {
+        throw new Error("output halted: RECITATION");
+      },
+    ]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      baseRequest(join(workdir, "recite.png"))
+    );
+
+    // Then it short-circuits to failure without retrying
+    expect(result.success).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(recorders.sleeps).toEqual([]);
+  });
+});

--- a/packages/core/test/image-openai.test.ts
+++ b/packages/core/test/image-openai.test.ts
@@ -1,0 +1,347 @@
+// Tests for the OpenAIImageProvider — TS port of `utils/image_provider/openai.py`.
+//
+// The SDK client, the backoff sleep, and the image-persist step are injected
+// (plan §6/§8). Because `createClient` is injected, the default factory's
+// `resolveSecret("OPENAI_API_KEY")` + `new OpenAI(...)` path is bypassed — no
+// env or 1Password setup is needed.
+//
+// Faithful SDK shape (verified against openai-node docs): the client exposes
+// `images.generate(params)` and `images.edit(params)`, each returning
+//   { data: [ { b64_json: <base64 string> }, ... ] }
+// The provider decodes the first item carrying `b64_json` (openai.py:137-144),
+// maps aspect ratio → size (16:9→1536x1024, 9:16→1024x1536, openai.py:34-37),
+// and rejects unmapped ratios with ConfigError WITHOUT retrying.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ConfigError } from "@youtube-automation/core";
+import { OpenAIImageProvider } from "@youtube-automation/core/image";
+import type { ImageGenerationRequest } from "@youtube-automation/core/image";
+
+type OpenAIDeps = NonNullable<
+  ConstructorParameters<typeof OpenAIImageProvider>[1]
+>;
+
+// --- fakes ----------------------------------------------------------------
+
+type Behavior = () => unknown;
+
+// Consume the next behavior from a queue; the last entry repeats so a single
+// "always fails" behavior covers every retry attempt.
+const nextBehavior = (queue: Behavior[] | undefined, i: number): unknown => {
+  if (!queue || queue.length === 0) {
+    throw new Error("fake openai client: no behavior queued");
+  }
+  const behavior = queue[Math.min(i, queue.length - 1)];
+  if (!behavior) {
+    throw new Error("fake openai client: behavior index out of range");
+  }
+  return behavior();
+};
+
+// A fake `openai` client tracking generate/edit calls separately. A throwing
+// behavior surfaces synchronously, which the provider's try/catch handles
+// identically to a rejected promise.
+const makeOpenAIClient = (behaviors: {
+  generate?: Behavior[];
+  edit?: Behavior[];
+}) => {
+  const generateCalls: unknown[] = [];
+  const editCalls: unknown[] = [];
+  let gi = 0;
+  let ei = 0;
+  const client = {
+    images: {
+      edit: (params: unknown): Promise<unknown> => {
+        editCalls.push(params);
+        const i = ei;
+        ei += 1;
+        return Promise.resolve(nextBehavior(behaviors.edit, i));
+      },
+      generate: (params: unknown): Promise<unknown> => {
+        generateCalls.push(params);
+        const i = gi;
+        gi += 1;
+        return Promise.resolve(nextBehavior(behaviors.generate, i));
+      },
+    },
+  };
+  return { client, editCalls, generateCalls };
+};
+
+const imageResponse = (...b64s: (string | null)[]) => ({
+  data: b64s.map((b64) => (b64 === null ? {} : { b64_json: b64 })),
+});
+
+const makeRecorders = () => {
+  const sleeps: number[] = [];
+  const persisted: { path: string; bytes: Uint8Array }[] = [];
+  let clientCreated = 0;
+  return {
+    clientCreatedCount: () => clientCreated,
+    countClient: () => {
+      clientCreated += 1;
+    },
+    persist: (outputPath: string, bytes: Uint8Array): Promise<string> => {
+      persisted.push({ bytes, path: outputPath });
+      return Promise.resolve(outputPath);
+    },
+    persisted,
+    sleep: (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    },
+    sleeps,
+  };
+};
+
+const makeDeps = (
+  client: unknown,
+  recorders: ReturnType<typeof makeRecorders>
+): OpenAIDeps =>
+  ({
+    createClient: () => {
+      recorders.countClient();
+      return client;
+    },
+    persist: recorders.persist,
+    sleep: recorders.sleep,
+  }) as unknown as OpenAIDeps;
+
+const openaiConfig = {
+  aspectRatio: "16:9" as const,
+  batch: 1,
+  model: "gpt-image-2",
+  quality: "high",
+};
+
+const request = (
+  outputPath: string,
+  aspectRatio: string,
+  references?: string[]
+): ImageGenerationRequest => ({
+  aspectRatio,
+  imageSize: "",
+  outputPath,
+  prompt: "warm acoustic cafe afternoon",
+  ...(references ? { references } : {}),
+});
+
+let workdir: string;
+
+beforeAll(() => {
+  workdir = mkdtempSync(join(tmpdir(), "img-openai-"));
+});
+
+afterAll(() => {
+  rmSync(workdir, { force: true, recursive: true });
+});
+
+// --- identity -------------------------------------------------------------
+
+describe("OpenAIImageProvider identity", () => {
+  test("reports its name and the two supported aspect ratios", () => {
+    // Given a constructed openai provider (openai.py:43-44)
+    const provider = new OpenAIImageProvider(openaiConfig);
+    // When reading its metadata
+    // Then it identifies as openai with the restricted ratio set
+    expect(provider.name).toBe("openai");
+    expect([...provider.supportedAspectRatios]).toEqual(["16:9", "9:16"]);
+  });
+});
+
+// --- success path ---------------------------------------------------------
+
+describe("OpenAIImageProvider.generate success", () => {
+  test("maps 16:9 → 1536x1024 and persists the decoded b64 image", async () => {
+    // Given a generate response with a single b64 image
+    const original = new Uint8Array([0xff, 0xd8, 0xff, 5, 6, 7]);
+    const base64 = Buffer.from(original).toString("base64");
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [() => imageResponse(base64)],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+    const outputPath = join(workdir, "wide.png");
+
+    // When generating at 16:9
+    const result = await provider.generate(request(outputPath, "16:9"));
+
+    // Then the size maps to landscape, bytes decode, and the path returns
+    expect(result.success).toBe(true);
+    expect(result.savedPath).toBe(outputPath);
+    const [persisted] = recorders.persisted;
+    if (!persisted) {
+      throw new Error("expected a persisted image");
+    }
+    expect([...persisted.bytes]).toEqual([...original]);
+    const params = generateCalls[0] as {
+      size?: unknown;
+      model?: unknown;
+      n?: unknown;
+    };
+    expect(params.size).toBe("1536x1024");
+    expect(params.model).toBe("gpt-image-2");
+    expect(params.n).toBe(1);
+    expect(recorders.sleeps).toEqual([]);
+  });
+
+  test("maps 9:16 → 1024x1536 for the portrait request", async () => {
+    // Given a portrait request and a valid response
+    const base64 = Buffer.from(new Uint8Array([1, 2])).toString("base64");
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [() => imageResponse(base64)],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      { ...openaiConfig, aspectRatio: "9:16" },
+      makeDeps(client, recorders)
+    );
+
+    // When generating at 9:16
+    await provider.generate(request(join(workdir, "tall.png"), "9:16"));
+
+    // Then the size maps to portrait (openai.py:36)
+    const params = generateCalls[0] as { size?: unknown };
+    expect(params.size).toBe("1024x1536");
+  });
+
+  test("skips response items without b64_json and decodes the first that has it", async () => {
+    // Given a response whose first item lacks b64_json (openai.py:140-143)
+    const original = new Uint8Array([4, 2]);
+    const base64 = Buffer.from(original).toString("base64");
+    const { client } = makeOpenAIClient({
+      generate: [() => imageResponse(null, base64)],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      request(join(workdir, "first.png"), "16:9")
+    );
+
+    // Then the second item supplies the decoded bytes
+    expect(result.success).toBe(true);
+    const [persisted] = recorders.persisted;
+    if (!persisted) {
+      throw new Error("expected a persisted image");
+    }
+    expect([...persisted.bytes]).toEqual([...original]);
+  });
+
+  test("uses images.edit (not generate) when references are supplied", async () => {
+    // Given a reference image on disk (openai.py:86-96)
+    const refPath = join(workdir, "ref.png");
+    writeFileSync(refPath, new Uint8Array([0x50, 0x4b]));
+    const base64 = Buffer.from(new Uint8Array([8, 8])).toString("base64");
+    const { client, editCalls, generateCalls } = makeOpenAIClient({
+      edit: [() => imageResponse(base64)],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating with a reference image
+    const result = await provider.generate(
+      request(join(workdir, "edit-out.png"), "16:9", [refPath])
+    );
+
+    // Then the edit endpoint is used and the generate endpoint is not
+    expect(result.success).toBe(true);
+    expect(editCalls).toHaveLength(1);
+    expect(generateCalls).toHaveLength(0);
+  });
+});
+
+// --- fail-fast on aspect ratio -------------------------------------------
+
+describe("OpenAIImageProvider.generate aspect-ratio guard", () => {
+  test("throws ConfigError for an unmapped aspect ratio without calling the SDK", async () => {
+    // Given a request whose ratio is not 16:9 or 9:16 (openai.py:63-67)
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [() => imageResponse("ignored")],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating at an unsupported ratio
+    // Then it fails fast: ConfigError, no client, no SDK call, no retry wait
+    await expect(
+      provider.generate(request(join(workdir, "square.png"), "1:1"))
+    ).rejects.toThrow(ConfigError);
+    expect(recorders.clientCreatedCount()).toBe(0);
+    expect(generateCalls).toHaveLength(0);
+    expect(recorders.sleeps).toEqual([]);
+  });
+});
+
+// --- retry path -----------------------------------------------------------
+
+describe("OpenAIImageProvider.generate retry", () => {
+  test("retries on an image-less response and fails after RETRY_MAX attempts", async () => {
+    // Given a response with no decodable image (openai.py:106-108)
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [() => imageResponse()],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      request(join(workdir, "empty.png"), "16:9")
+    );
+
+    // Then all 3 attempts run with two backoff waits, ending in failure
+    expect(result.success).toBe(false);
+    expect(result.savedPath).toBeNull();
+    expect(generateCalls).toHaveLength(3);
+    expect(recorders.sleeps).toEqual([10_000, 30_000]);
+    expect(recorders.persisted).toEqual([]);
+  });
+
+  test("retries a transient SDK error then succeeds", async () => {
+    // Given one thrown error followed by a valid image (openai.py:125-127)
+    const base64 = Buffer.from(new Uint8Array([3, 3, 3])).toString("base64");
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [
+        () => {
+          throw new Error("429 rate limited");
+        },
+        () => imageResponse(base64),
+      ],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      openaiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When generating
+    const result = await provider.generate(
+      request(join(workdir, "retry-ok.png"), "16:9")
+    );
+
+    // Then the second attempt wins after a single backoff wait
+    expect(result.success).toBe(true);
+    expect(generateCalls).toHaveLength(2);
+    expect(recorders.sleeps).toEqual([10_000]);
+  });
+});


### PR DESCRIPTION
## Summary

## Parent
#727

## What to build
Python `utils/image_provider.py` の画像生成プロバイダー抽象化 (Gemini / OpenAI 切り替え) を TS に移植する。`GeminiImageProvider` `OpenAIImageProvider` を実装し、共通 interface `ImageProvider` で切り替え可能にする。

## Acceptance criteria
- [ ] `ImageProvider` interface 定義 (generate / save / metadata)
- [ ] Gemini 実装 (`@google/generative-ai` SDK)
- [ ] OpenAI 実装 (`openai` SDK)
- [ ] config から provider 選択
- [ ] mock SDK での unit test green

## Blocked by
- #734

## Execution Report

Workflow `default` completed successfully.

Closes #738