### PR TITLE
[#810] issue-810-fix-suno-hcaptcha-pu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(suno)`: Suno Custom Mode の Style/Lyrics 識別を data-testid ベースに変更し、日本語 UI 破損を修正した（#807）。実 DOM（`suno.com/create`・日本語 UI）検証で、`SELECTORS.stylePlaceholder` の placeholder 正規表現が日本語ロケールの Style 欄（ジャンル語彙の例）にヒットせず、fallback の `areas[0]=Lyrics` を Style に返して Lyrics 欄を上書きする致命バグが判明していた。`extensions/shared/dom.ts` で Lyrics を `data-testid="lyrics-textarea"`（UI 言語非依存）で最優先識別し、Style は「Lyrics 以外の strict visible textarea」として解決、Style 解決不能または Style==Lyrics の衝突時は throw（silent な上書きを禁ずる）。`isVisible` を `offsetParent !== null` から bbox 0 除外 + 親要素 walk（display:none / visibility:hidden / opacity:0 排除）の strict 版に強化し、Simple Mode の隠し textarea を拾わないようにした。Vitest unit テスト（`tests/dom.test.ts`）と Playwright e2e mock（`data-testid="lyrics-textarea"` を含む）で担保する
+- `fix(suno)`: hCaptcha プリロード iframe の誤検知で連続実行が Create 直後に中断する問題を修正した（#810）。Suno は hCaptcha challenge UI を非表示プリロード iframe（`display:none` / `visibility:hidden`）として常駐させるため、`extensions/shared/dom.ts::detectRecaptcha` が `querySelector` の hit だけで判定すると常に true になり、`waitForGeneration` の poll が最初の Create 押下直後に「reCAPTCHA を検知しました」で必ず中断していた。判定を #807 で strict 化済みの `isVisible`（bbox 非ゼロ + 親 walk で `display:none`/`visibility:hidden`/`opacity:0` を排除）に統一し、実 challenge UI が表示された時のみ検知する。selector は不変（hCaptcha は `src*="hcaptcha"` で既にカバー済み）。回帰ガードとして `extensions/suno-helper/tests/dom.test.ts` に非表示プリロード iframe で false / 可視 challenge で true を検証する Vitest を追加し、Playwright e2e（`tests/e2e/suno-inject.spec.ts`）の Suno mock に常駐 hCaptcha iframe を含めた
 
 ### Migration
 

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -79,9 +79,17 @@ export function setNativeValue(
   el.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
-/** recaptcha / hcaptcha iframe の存在を検知する。 */
+/**
+ * 可視な recaptcha / hcaptcha challenge iframe を検知する（#810）。
+ * Suno は hCaptcha challenge を非表示プリロード iframe として常駐させるため、
+ * querySelector の hit だけでは常に true になってしまう。strict 可視判定で
+ * 実 challenge UI が表示された時のみ true を返す。
+ */
 export function detectRecaptcha(): boolean {
-  return document.querySelector(SELECTORS.recaptcha) !== null;
+  const iframes = document.querySelectorAll<HTMLIFrameElement>(
+    SELECTORS.recaptcha,
+  );
+  return Array.from(iframes).some((f) => isVisible(f));
 }
 
 /**

--- a/extensions/suno-helper/tests/_helpers.ts
+++ b/extensions/suno-helper/tests/_helpers.ts
@@ -1,0 +1,50 @@
+// jsdom 用テストヘルパ。
+//
+// jsdom はレイアウトを行わず `getBoundingClientRect` が常に 0×0 を返すため、strict 可視判定
+// (`detectRecaptcha`, #810) を検証するには bbox を擬似的に与える必要がある。`markBbox` /
+// `addCaptchaIframe` は dom.test.ts と wait-for-generation.test.ts の双方が同一ロジックで
+// 必要とするため、ここに 1 箇所だけ定義して両者から import する (DRY)。
+
+/** strict 可視判定用に getBoundingClientRect を擬似的に与える (jsdom は常に 0×0 を返すため)。 */
+export function markBbox(el: HTMLElement, width: number, height: number): void {
+  Object.defineProperty(el, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      width,
+      height,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+/**
+ * recaptcha/hcaptcha 類似 iframe を body に挿入する。
+ * `width`/`height` は strict 可視判定が見る bbox、`display`/`visibility`/`opacity` は親 walk が見る
+ * インライン style。order.md の実 DOM 表 (iframe[0] display:none/0×0, iframe[4] visibility:hidden/300×150)
+ * を写像できるよう、bbox と style を独立に指定できる。
+ */
+export function addCaptchaIframe(opts: {
+  src?: string;
+  title?: string;
+  display?: string;
+  visibility?: string;
+  opacity?: string;
+  width?: number;
+  height?: number;
+}): HTMLIFrameElement {
+  const f = document.createElement("iframe");
+  if (opts.src !== undefined) f.src = opts.src;
+  if (opts.title !== undefined) f.title = opts.title;
+  if (opts.display !== undefined) f.style.display = opts.display;
+  if (opts.visibility !== undefined) f.style.visibility = opts.visibility;
+  if (opts.opacity !== undefined) f.style.opacity = opts.opacity;
+  document.body.appendChild(f);
+  markBbox(f, opts.width ?? 300, opts.height ?? 150);
+  return f;
+}

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment jsdom
 //
 // content script の Suno UI 注入ロジックを純関数化した `shared/dom.ts` の回帰テスト。
-// 旧 `content.js` の振る舞いを保持しつつ、#807 で判明した日本語 UI 破損を修正した仕様を担保する:
+// 旧 `content.js` の振る舞いを保持しつつ、#807 で判明した日本語 UI 破損および #810 で判明した
+// hCaptcha プリロード iframe 誤検知を修正した仕様を担保する:
 //   - setNativeValue: prototype の native setter + input/change の bubbling 発火 (React 互換)
 //   - resolveFields: lyrics は `data-testid="lyrics-textarea"` で最優先識別 (UI 言語非依存)、
 //                    style は lyrics 以外の strict visible textarea、解決不能なら throw (fail-loud)
 //   - resolveGenerateButton: 可視 button をラベル正規表現で判別、不在で throw
-//   - detectRecaptcha: recaptcha/hcaptcha iframe の存在検知
+//   - detectRecaptcha: 可視な recaptcha/hcaptcha iframe のみ検知 (#810、#807 と同じ strict isVisible を共有)
 //
-// jsdom はレイアウトを行わず `getBoundingClientRect()` が常に全 0 を返すため、可視判定の
-// 対象要素は `setRect` で bbox を擬似的に与える (production の strict isVisible は
-// `getBoundingClientRect` の width/height と親要素の display/visibility/opacity を見る前提)。
+// jsdom はレイアウトを行わず `getBoundingClientRect()` が常に 0×0 を返すため、可視判定の対象要素は
+// `setRect` (textarea/button) または `markBbox` (iframe, _helpers.ts) で bbox を擬似的に与える。
+// production の strict isVisible は bbox 非ゼロ + 親 walk で `display:none`/`visibility:hidden`/
+// `opacity:0` を排除する前提。display/visibility/opacity はインライン style で表現する
+// (jsdom の getComputedStyle はインライン style を反映する)。
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detectRecaptcha, resolveFields, resolveGenerateButton, setNativeValue } from "../../shared/dom";
+import { addCaptchaIframe, markBbox } from "./_helpers";
 
 const VISIBLE_RECT = {
   x: 0,
@@ -238,24 +242,133 @@ describe("resolveGenerateButton: Generate ボタンの解決", () => {
   });
 });
 
-describe("detectRecaptcha: チャレンジ検知", () => {
-  it("Given recaptcha iframe (src) When 検知する Then true", () => {
-    document.body.innerHTML = '<iframe src="https://www.google.com/recaptcha/api2/anchor"></iframe>';
-    expect(detectRecaptcha()).toBe(true);
+describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
+  describe("可視な challenge iframe は true", () => {
+    it("Given 可視 recaptcha iframe (src) When 検知する Then true", () => {
+      addCaptchaIframe({ src: "https://www.google.com/recaptcha/api2/anchor" });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given 可視 recaptcha iframe (title) When 検知する Then true", () => {
+      addCaptchaIframe({ title: "reCAPTCHA challenge" });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given 可視 hcaptcha iframe (src) When 検知する Then true", () => {
+      addCaptchaIframe({ src: "https://newassets.hcaptcha.com/captcha/v1" });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given 可視 hcaptcha iframe (title=hCaptchaチャレンジ) When 検知する Then true (実 challenge 表示時)", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+        title: "hCaptchaチャレンジ",
+      });
+      expect(detectRecaptcha()).toBe(true);
+    });
   });
 
-  it("Given recaptcha iframe (title) When 検知する Then true", () => {
-    document.body.innerHTML = '<iframe title="reCAPTCHA challenge"></iframe>';
-    expect(detectRecaptcha()).toBe(true);
+  describe("非表示のプリロード hCaptcha iframe は false (誤検知防止)", () => {
+    it("Given display:none かつ 0×0 の hCaptcha iframe (実 DOM iframe[0]) When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+        display: "none",
+        width: 0,
+        height: 0,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given visibility:hidden だが 300×150 の hCaptcha iframe (実 DOM iframe[4]) When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+        title: "hCaptchaチャレンジ",
+        visibility: "hidden",
+        width: 300,
+        height: 150,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given opacity:0 の hCaptcha iframe When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+        opacity: "0",
+        width: 300,
+        height: 150,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given bbox が 0×0 の hCaptcha iframe (style は可視) When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+        width: 0,
+        height: 150,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
   });
 
-  it("Given hcaptcha iframe When 検知する Then true", () => {
-    document.body.innerHTML = '<iframe src="https://newassets.hcaptcha.com/captcha/v1"></iframe>';
-    expect(detectRecaptcha()).toBe(true);
+  describe("親要素の非表示も親 walk で排除する", () => {
+    it("Given 親 div が display:none の hCaptcha iframe When 検知する Then false", () => {
+      const parent = document.createElement("div");
+      parent.style.display = "none";
+      document.body.appendChild(parent);
+      const f = document.createElement("iframe");
+      f.src = "https://hcaptcha-assets-prod.suno.com/captcha/v1/x";
+      parent.appendChild(f);
+      markBbox(f, 300, 150);
+
+      expect(detectRecaptcha()).toBe(false);
+    });
   });
 
-  it("Given チャレンジ無し When 検知する Then false", () => {
-    document.body.innerHTML = '<iframe src="https://suno.com/embed"></iframe>';
+  describe("order.md 実 DOM シナリオの回帰ガード", () => {
+    it("Given 非表示プリロード iframe 2 個 (display:none + visibility:hidden) のみ When 検知する Then false (challenge 未表示時)", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/0",
+        display: "none",
+        width: 0,
+        height: 0,
+      });
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/4",
+        title: "hCaptchaチャレンジ",
+        visibility: "hidden",
+        width: 300,
+        height: 150,
+      });
+
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given 非表示プリロード 2 個 + 可視 challenge 1 個 When 検知する Then true (実 challenge 表示時のみ検知)", () => {
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/0",
+        display: "none",
+        width: 0,
+        height: 0,
+      });
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/4",
+        visibility: "hidden",
+        width: 300,
+        height: 150,
+      });
+      addCaptchaIframe({
+        src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/visible",
+        title: "hCaptchaチャレンジ",
+        width: 300,
+        height: 150,
+      });
+
+      expect(detectRecaptcha()).toBe(true);
+    });
+  });
+
+  it("Given challenge 類似 iframe 無し When 検知する Then false", () => {
+    addCaptchaIframe({ src: "https://suno.com/embed" });
     expect(detectRecaptcha()).toBe(false);
   });
 });

--- a/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
+++ b/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
@@ -15,6 +15,12 @@
 // `shared/dom.ts` を直接 import する unit テスト (`tests/dom.test.ts`) が担う。
 import { expect, test } from "@playwright/test";
 
+// recaptcha/hcaptcha 検知 selector。Playwright は shared/dom.ts を import できないため再掲する
+// (既存の setNativeValue 同様 inline 再現)。本番 SELECTORS.recaptcha と一致させること。
+const RECAPTCHA_SELECTOR = 'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]';
+
+// Suno は hCaptcha challenge UI をプリロード iframe として常駐させる (#810)。
+// display:none / visibility:hidden の 2 種を含め、可視判定で弾かれることを担保する。
 const MOCK_SUNO_HTML = `<!doctype html>
 <html>
   <body>
@@ -22,6 +28,8 @@ const MOCK_SUNO_HTML = `<!doctype html>
     <textarea id="style" placeholder="地下の罠, コントラルト, リズミカルなベース"></textarea>
     <textarea id="lyrics" data-testid="lyrics-textarea" placeholder="What do you want your lyrics to be about?"></textarea>
     <button id="generate">Create</button>
+    <iframe id="hcaptcha-none" src="https://hcaptcha-assets-prod.suno.com/captcha/v1/0" style="display:none;width:0;height:0;border:0"></iframe>
+    <iframe id="hcaptcha-hidden" src="https://hcaptcha-assets-prod.suno.com/captcha/v1/4" title="hCaptchaチャレンジ" style="visibility:hidden;width:300px;height:150px;border:0"></iframe>
     <div id="captured-style">-</div>
     <div id="captured-lyrics">-</div>
     <div id="input-events">0</div>
@@ -72,4 +80,35 @@ test("Suno mock へ Style/Lyrics を注入し Generate を押下できる", asyn
   await expect(page.locator("#input-events")).toHaveText("2");
   // Generate 押下が成立
   await expect(page.locator("#clicked")).toHaveText("yes");
+});
+
+test("常駐 hCaptcha プリロード iframe は可視判定で除外され誤検知しない (#810)", async ({ page }) => {
+  await page.setContent(MOCK_SUNO_HTML);
+
+  // 実ブラウザでは layout が走るため、strict 可視判定 (detectRecaptcha と同手法) を inline 再現する。
+  // selector には 2 個マッチするが、いずれも非表示なので可視数は 0 = 中断されない。
+  const counts = await page.evaluate((selector) => {
+    const isVisible = (el: HTMLElement): boolean => {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return false;
+      let node: HTMLElement | null = el;
+      while (node) {
+        const style = getComputedStyle(node);
+        if (style.display === "none" || style.visibility === "hidden" || style.opacity === "0") {
+          return false;
+        }
+        node = node.parentElement;
+      }
+      return true;
+    };
+    const matched = Array.from(document.querySelectorAll<HTMLIFrameElement>(selector));
+    return {
+      matched: matched.length,
+      visible: matched.filter(isVisible).length,
+    };
+  }, RECAPTCHA_SELECTOR);
+
+  // order.md 期待値: recaptcha-like iframes: 2 / visible: 0 (challenge 未表示時)
+  expect(counts.matched).toBe(2);
+  expect(counts.visible).toBe(0);
 });

--- a/extensions/suno-helper/tests/wait-for-generation.test.ts
+++ b/extensions/suno-helper/tests/wait-for-generation.test.ts
@@ -12,6 +12,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GENERATE_TIMEOUT_MS, POLL_INTERVAL_MS, SETTLE_MS, waitForGeneration } from "../../shared/dom";
+import { addCaptchaIframe } from "./_helpers";
 
 const FAST_OPTIONS = { timeoutMs: 1000, pollIntervalMs: 10, settleMs: 10 } as const;
 
@@ -56,14 +57,35 @@ describe("waitForGeneration: 完了検知", () => {
 });
 
 describe("waitForGeneration: reCAPTCHA 検知", () => {
-  it("Given 待機中に reCAPTCHA 出現 When poll する Then throw する", async () => {
+  it("Given 待機中に可視 reCAPTCHA 出現 When poll する Then throw する", async () => {
     const btn = disabledButton();
-    document.body.innerHTML += '<iframe src="https://www.google.com/recaptcha/api2/anchor"></iframe>';
+    addCaptchaIframe({ src: "https://www.google.com/recaptcha/api2/anchor" });
 
     const pending = waitForGeneration(btn, { isAborted: () => false, ...FAST_OPTIONS });
     const expectation = expect(pending).rejects.toThrow(/reCAPTCHA/);
     await vi.advanceTimersByTimeAsync(FAST_OPTIONS.settleMs + FAST_OPTIONS.pollIntervalMs);
     await expectation;
+  });
+});
+
+describe("waitForGeneration: プリロード hCaptcha 誤検知の回帰ガード (#810)", () => {
+  it("Given 非表示プリロード hCaptcha が常駐 (visibility:hidden) When button が enabled に戻る Then 中断せず resolve する", async () => {
+    const btn = disabledButton();
+    // Suno は hCaptcha challenge UI をプリロード iframe として常駐させる。可視判定で弾けないと
+    // detectRecaptcha が常に true になり、生成完了待ち直後に誤って throw していた (#810)。
+    addCaptchaIframe({
+      src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
+      visibility: "hidden",
+      width: 300,
+      height: 150,
+    });
+
+    const pending = waitForGeneration(btn, { isAborted: () => false, ...FAST_OPTIONS });
+    await vi.advanceTimersByTimeAsync(FAST_OPTIONS.settleMs);
+    btn.disabled = false; // 生成完了 = enabled 復帰
+    await vi.advanceTimersByTimeAsync(FAST_OPTIONS.pollIntervalMs);
+
+    await expect(pending).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

## 背景

#807 修正後の suno-helper を実機 (`suno.com/create`・日本語 UI) でテストしたところ、Style/Lyrics 注入と Create クリックは成功するが、**最初のパターンの生成完了待ちに入った直後に `中断: reCAPTCHA を検知しました。手動で解決してから再開してください。` で停止**する。実際には reCAPTCHA も hCaptcha challenge も**画面には表示されていない**。

### 実 DOM (suno.com/create, hCaptcha challenge 非表示状態)

DevTools console での `iframe` 全列挙:

| idx | src | rect | display | visibility |
|---|---|---|---|---|
| 0 | `hcaptcha-assets-prod.suno.com/captcha/v1/...` | 0×0 | **none** | visible |
| 1 | (empty, OneTrust cookie consent) | 0×0 | block | visible |
| 2 | `js.stripe.com/v3/m-outer-...` | 826×1 | block | hidden |
| 3 | `js.stripe.com/v3/m-outer-...` | 826×1 | block | hidden |
| 4 | `hcaptcha-assets-prod.suno.com/captcha/v1/...` (`title="hCaptchaチャレンジ"`) | 300×150 | block | **hidden** |

`SELECTORS.recaptcha = 'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]'` に [0] と [4] の 2 個がマッチするが、**いずれも実際には非表示** ([0] は `display: none`, [4] は `visibility: hidden`)。Suno は hCaptcha challenge UI を**プリロード iframe として常駐**させ、実 challenge 発生時のみ visible にする実装。

## 問題

現状の `extensions/shared/dom.ts::detectRecaptcha`:

```ts
export function detectRecaptcha(): boolean {
  return document.querySelector(SELECTORS.recaptcha) !== null;
}
```

`querySelector` で hit したかしか見ていないため、**プリロード iframe が常駐する Suno UI では常に true**。`waitForGeneration` の poll で即 throw → 連続実行が必ず最初の Create クリック直後に中断。

これは #807 で textarea/button に追加した strict `isVisible()` (bbox 0 除外 + 親 walk で `display:none/visibility:hidden/opacity:0` を排除) を **iframe にも適用していなかった**取りこぼし。

## 修正方針

`detectRecaptcha` を strict `isVisible` ベースに変える。selector はそのまま (hCaptcha も `src*="hcaptcha"` で既にカバー済み)。

```ts
export function detectRecaptcha(): boolean {
  const iframes = document.querySelectorAll<HTMLIFrameElement>(SELECTORS.recaptcha);
  return Array.from(iframes).some((f) => isVisible(f));
}
```

- **タイムアウト追加 (`x 秒待つ`) は不要**: root cause は「常に true」誤検知。可視性で弾けば、実 challenge UI が出た時のみ true になる正しい挙動になる。
- **selector の変更不要**: 現状の selector で hCaptcha もヒットしている。問題は filter 段の可視判定が無いこと。

## 対象ファイル

- `extensions/shared/dom.ts` — `detectRecaptcha` 内部実装変更 (selector 不変)
- `extensions/suno-helper/tests/dom.test.ts` — Vitest 追加:
  - hidden な hCaptcha iframe (display:none / visibility:hidden / 0×0 bbox) では `detectRecaptcha()=false`
  - visible な hCaptcha iframe では `detectRecaptcha()=true`
  - これらの回帰ガードで「querySelector 一発」実装の復活を防ぐ
- `CHANGELOG.md` — `[Unreleased]::Fixed` 追記

## 受け入れ条件

- [ ] `detectRecaptcha()` が **strict `isVisible()` を経由**して判定する (querySelector 一発に戻らない)
- [ ] Suno のプリロード hCaptcha iframe (display:none/visibility:hidden) で false 返す Vitest 追加
- [ ] 可視な hCaptcha iframe で true 返す Vitest 追加
- [ ] Playwright e2e の Suno mock HTML を更新 (常駐 hCaptcha 模擬: visibility:hidden な hCaptcha iframe を含める → 生成完了が中断されないことを担保)
- [ ] CHANGELOG `[Unreleased]::Fixed` に「(suno) hCaptcha プリロード iframe の誤検知で連続実行が即中断する問題を修正」を追記

## 受け入れ確認用 console snippet (実機 verify)

修正後の拡張を unpacked reload して `suno.com/create` で:

```js
// hidden iframe 状態での detect が false になるか確認
const sel = 'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]';
const isVis = (el) => {
  const r = el.getBoundingClientRect();
  if (r.width === 0 || r.height === 0) return false;
  let n = el;
  while (n && n.nodeType === 1) {
    const s = getComputedStyle(n);
    if (s.display === "none" || s.visibility === "hidden" || s.opacity === "0") return false;
    n = n.parentElement;
  }
  return true;
};
console.log("recaptcha-like iframes:", document.querySelectorAll(sel).length);
console.log("visible recaptcha-like iframes:", [...document.querySelectorAll(sel)].filter(isVis).length);
```

期待値: `recaptcha-like iframes: 2` / `visible recaptcha-like iframes: 0` (challenge 未表示時)

## スコープ外

- 実 challenge UI が表示された時の自動解決 / 手動解決後の再開フロー改善 (現状の手動再開で十分)
- hCaptcha の検出 selector の拡張 (現状 `src*="hcaptcha"` でカバー済み)
- distrokid-helper への横展開 (DistroKid に captcha は無い)

## 関連

- #807: 同じ root cause の延長 (緩い `isVisible()` が #807 で strict 化された際、`detectRecaptcha` への適用が漏れていた取りこぼし)

## Execution Report

Workflow `default` completed successfully.

Closes #810