### PR TITLE
fix(suno-helper): popup エラーメッセージにハードリロード案内を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(suno-helper)`: popup の「開始失敗」「停止リクエスト失敗」エラーで Chrome の `Could not establish connection. Receiving end does not exist.`（拡張リロード後に Suno タブが古い content script のままで残っているときに出る）を検知し、対処法「Suno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R)」を案内に追記するようにした。従来は汎用の「Custom Mode 画面を開いた状態で実行してください」のみで、実際の原因と異なる対処を案内していた。検知は case-insensitive substring match、整形は `components/runner-errors.ts` の純関数 (`isContentScriptMissingError` / `formatRunError` / `formatStopError`) に分離して `wxt/browser` 非依存とし、Vitest（`tests/content-script-missing-hint.test.ts`）で 11 ケース担保する
+
 ### Added
 
 - `feat(distrokid)`: `yt-collection-serve` に `--distrokid-source` を追加し、30-distrokid 構造（disc 単位提出 + `cover_art_3000.jpg` + `metadata.md`）に対応した（#819）。`yt-collection-serve <collection> --distrokid-source 30-distrokid/disc1-coding-focus-vol1` 指定時、`/distrokid/release.json` の payload を `<collection>/<source>/` を 1 アルバムとして組み立てる: `tracks` は `<source>/*.mp3` をファイル名ソート順で、`track[].title` は `<source>/metadata.md` のトラック表から（未マッチ行は filename stem へ救済）、`cover` は `<collection>/30-distrokid/cover_art_3000.jpg` 優先（無ければ既存サムネイルへフォールバック）、`album_title` は metadata.md のアルバム情報枠（空なら disc dirname を kebab→Title 化）、`profile.language` は metadata.md の言語があれば override（無ければ profile 値）で解決する。release.json の schema（#815 で確定した拡張側契約）は不変で、サーバ側の payload 値だけが変わる。新規パーサ `youtube_automation.utils.distrokid_metadata`（`parse_album_metadata` / `parse_track_table`、HTML コメント枠 `<!-- ... -->` と空セルは None、ファイル名のバッククォート除去、md 不在は `ConfigError` で fail-loud）に切り出し、payload 組立は `distrokid_release.py::build_release_payload(..., distrokid_source=...)` に集約。指定 source の不在・metadata.md 欠落・コレクション外への `..` トラバーサルは `ConfigError`（明示指定は 30-distrokid 構造前提で degrade しない）。`distrokid_source` 未指定/`None` は従来の `02-Individual-music/` 経路で不変（後方互換）。`distrokid_source` は CLI → `create_server` → `_serve_distrokid_release` → `build_release_payload` まで keyword で伝搬する。新規テスト `tests/test_distrokid_metadata.py`（パーサ unit）/ `tests/test_distrokid_disc_source.py`（disc-source payload + エンドポイント結合）で担保する

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -1,0 +1,28 @@
+// useSunoRunner のエラー整形ヘルパ純関数（テスタビリティのため wxt 依存を排して分離）。
+// 拡張をリロードした後 Suno タブをハードリロードしないと出る Chrome 標準エラー
+// (`Could not establish connection. Receiving end does not exist.`) を検知して、
+// popup の案内に対処法（⌘+Shift+R）を含める。
+
+/**
+ * content script 未注入の典型エラーを検知する。
+ * 拡張をリロードした後に Suno タブをハードリロードしないと、古い content script が落ちた
+ * まま新しい script が注入されず、popup → tab の sendMessage が
+ * `Could not establish connection. Receiving end does not exist.` で失敗する。
+ */
+export function isContentScriptMissingError(message: string): boolean {
+  return /receiving end does not exist|could not establish connection/i.test(message);
+}
+
+export function formatRunError(message: string): string {
+  if (isContentScriptMissingError(message)) {
+    return `開始失敗: ${message}\nSuno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R) してから再度実行してください。`;
+  }
+  return `開始失敗: ${message}\nSuno の Custom Mode 画面を開いた状態で実行してください。`;
+}
+
+export function formatStopError(message: string): string {
+  if (isContentScriptMissingError(message)) {
+    return `停止リクエスト失敗: ${message}\nSuno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R) してから再度実行してください。`;
+  }
+  return `停止リクエスト失敗: ${message}`;
+}

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -13,6 +13,7 @@ import {
 import { PHASE } from "../../shared/constants";
 import { onMessage, sendMessage } from "../lib/messaging";
 import { serverUrlItem } from "../lib/storage";
+import { formatRunError, formatStopError } from "./runner-errors";
 
 export type ItemState = "idle" | "active" | "done";
 
@@ -149,7 +150,7 @@ export function useSunoRunner(): RunnerState {
       report("連続実行を開始しました。");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      report(`開始失敗: ${message}\nSuno の Custom Mode 画面を開いた状態で実行してください。`, true);
+      report(formatRunError(message), true);
     }
   }, [entries, report]);
 
@@ -159,7 +160,7 @@ export function useSunoRunner(): RunnerState {
       await sendMessage("stop", undefined, tabId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      report(`停止リクエスト失敗: ${message}`, true);
+      report(formatStopError(message), true);
     }
   }, [report]);
 

--- a/extensions/suno-helper/tests/content-script-missing-hint.test.ts
+++ b/extensions/suno-helper/tests/content-script-missing-hint.test.ts
@@ -1,0 +1,52 @@
+// useSunoRunner の content script 未注入エラー検知 + メッセージ整形の回帰テスト。
+// 拡張をリロードした後 Suno タブをハードリロードしないと出る Chrome 標準エラー
+// (`Could not establish connection. Receiving end does not exist.`) を検知し、
+// 対処法（⌘+Shift+R）を popup のメッセージに含めるロジックの担保。
+import { describe, expect, it } from "vitest";
+
+import {
+  formatRunError,
+  formatStopError,
+  isContentScriptMissingError,
+} from "../components/runner-errors";
+
+describe("isContentScriptMissingError", () => {
+  it.each([
+    ["Could not establish connection. Receiving end does not exist.", true],
+    ["Receiving end does not exist", true],
+    ["could not establish connection", true],
+    ["RECEIVING END DOES NOT EXIST", true],
+    ["yt-collection-serve に接続できません", false],
+    ["fetch failed", false],
+    ["", false],
+  ])("Given message %j When 判定 Then %s", (message, expected) => {
+    expect(isContentScriptMissingError(message)).toBe(expected);
+  });
+});
+
+describe("formatRunError", () => {
+  it("Given content-script-missing error When formatRunError Then ハードリロード案内を含む", () => {
+    const text = formatRunError("Could not establish connection. Receiving end does not exist.");
+    expect(text).toMatch(/ハードリロード/);
+    expect(text).toMatch(/⌘\+Shift\+R/);
+  });
+
+  it("Given 他のエラー When formatRunError Then Custom Mode 起動案内を返す（従来挙動）", () => {
+    const text = formatRunError("アクティブなタブが見つかりません。");
+    expect(text).toMatch(/Custom Mode 画面を開いた状態/);
+    expect(text).not.toMatch(/ハードリロード/);
+  });
+});
+
+describe("formatStopError", () => {
+  it("Given content-script-missing error When formatStopError Then ハードリロード案内を含む", () => {
+    const text = formatStopError("Receiving end does not exist");
+    expect(text).toMatch(/ハードリロード/);
+    expect(text).toMatch(/⌘\+Shift\+R/);
+  });
+
+  it("Given 他のエラー When formatStopError Then 案内追記なし（従来挙動）", () => {
+    const text = formatStopError("network error");
+    expect(text).toBe("停止リクエスト失敗: network error");
+  });
+});

--- a/extensions/suno-helper/tests/content-script-missing-hint.test.ts
+++ b/extensions/suno-helper/tests/content-script-missing-hint.test.ts
@@ -4,11 +4,7 @@
 // 対処法（⌘+Shift+R）を popup のメッセージに含めるロジックの担保。
 import { describe, expect, it } from "vitest";
 
-import {
-  formatRunError,
-  formatStopError,
-  isContentScriptMissingError,
-} from "../components/runner-errors";
+import { formatRunError, formatStopError, isContentScriptMissingError } from "../components/runner-errors";
 
 describe("isContentScriptMissingError", () => {
   it.each([


### PR DESCRIPTION
## 概要

popup の「開始失敗」「停止リクエスト失敗」エラーで Chrome の `Could not establish connection. Receiving end does not exist.` を検知して、対処法「Suno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R)」を案内に追記する。

## 背景

拡張をリロードした後、Suno タブを **ハードリロード** しないと古い content script が落ちたまま新しい script が注入されず、popup → tab の sendMessage が上記エラーで失敗する。従来は実原因と無関係な「Suno の Custom Mode 画面を開いた状態で実行してください」だけ表示されており、ユーザーが正しい対処法に辿り着けなかった。

## 変更点

- `extensions/suno-helper/components/runner-errors.ts` (新規): 純関数 3 個
  - `isContentScriptMissingError(message)` — case-insensitive substring match (`receiving end does not exist` / `could not establish connection`)
  - `formatRunError(message)` — content-script-missing 検知時はハードリロード案内、それ以外は従来挙動
  - `formatStopError(message)` — 同上 (stop パス)
  - `wxt/browser` 非依存 (テストから直接 import 可能)
- `extensions/suno-helper/components/useSunoRunner.ts`: 上記純関数を import して `report(...)` 呼出を置換
- `extensions/suno-helper/tests/content-script-missing-hint.test.ts` (新規): 11 ケースの unit test (検知マッチ + 整形挙動 + 従来挙動回帰)
- `CHANGELOG.md::[Unreleased]::Fixed` 追記

## 検証

- `pnpm test` (Vitest): **144 passed (9 files)** — 既存 133 + 新規 11 全 pass
- 実 popup 動作確認は merge 後 (extension reload → Suno タブそのままで「全実行」押下 → ハードリロード案内が出ることを確認)

## 関連 PR

- #807 / #810 / #814 / #817 / #844 / #848 / #849: 一連の suno-helper 改善

## Test plan

- [ ] CI 緑 (lint / test / changelog / check / extensions)
- [ ] merge 後、Suno タブ未リロード状態で「全実行」→ ハードリロード案内が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)