### PR TITLE
fix(suno-helper): popup 起動時に collection name suffix で crash するバグ修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: popup 起動時に `/collections` レスポンスの `name` field 値（server 側で末尾 `-collection` が剥がされておらず例えば `dawn-cloud-fold-collection` 形式で返ってくる）をそのまま theme として `extractPlaylistName(id, theme)` に渡していたため、id 末尾 `-<theme>` 照合が常に失敗して fail-loud で throw → useMemo で React component が crash し popup が起動しないバグを修正した。`components/useSunoRunner.ts` の derivedPlaylistName 計算で `selected.name.replace(/-collection$/, "")` を挟んで theme から末尾 `-collection` を剥がしてから渡す。`extractPlaylistName` 側の契約 (theme は接尾辞なしの slug) は維持しスペックを通す位置だけ修正。サーバ側 (`utils.collection_paths.CollectionPaths.collection_name`) が将来 suffix を剥がして返すよう修正されても剥がし処理は冪等で無害
 - `fix(suno-helper)`: popup の「開始失敗」「停止リクエスト失敗」エラーで Chrome の `Could not establish connection. Receiving end does not exist.`（拡張リロード後に Suno タブが古い content script のままで残っているときに出る）を検知し、対処法「Suno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R)」を案内に追記するようにした。従来は汎用の「Custom Mode 画面を開いた状態で実行してください」のみで、実際の原因と異なる対処を案内していた。検知は case-insensitive substring match、整形は `components/runner-errors.ts` の純関数 (`isContentScriptMissingError` / `formatRunError` / `formatStopError`) に分離して `wxt/browser` 非依存とし、Vitest（`tests/content-script-missing-hint.test.ts`）で 11 ケース担保する
 
 ### Changed

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -61,9 +61,16 @@ export function useSunoRunner(): RunnerState {
   // collection id は server 契約上 `<date>-<channel>-<theme>-collection` 形式。channel が
   // 複数 word (例: `soulful-grooves`) を含む場合があり id 単体では境界判定不能なため、
   // `/collections` の `name` field (theme) を渡して逆向きに境界を確定する。
+  // 既知の server 仕様: `name` は現在 dir 名 parts[2] をそのまま返すため末尾 `-collection`
+  // を含む。extractPlaylistName 側の `endsWith("-" + theme)` 照合を通すため、ここで剥がす
+  // (server 側の修正は別 issue、剥がし処理は冪等なので将来 server 修正後も無害)。
   const derivedPlaylistName = useMemo(() => {
     const selected = collections.find((c) => c.id === selectedCollectionId);
-    return selected ? extractPlaylistName(selected.id, selected.name) : undefined;
+    if (!selected) {
+      return undefined;
+    }
+    const theme = selected.name.replace(/-collection$/, "");
+    return extractPlaylistName(selected.id, theme);
   }, [collections, selectedCollectionId]);
   const playlistName = derivedPlaylistName ?? restoredPlaylistName;
 


### PR DESCRIPTION
## Summary

`#857` で `extractPlaylistName(id, theme)` の 2 引数化を行った際、theme には `/collections` レスポンスの `name` field 値をそのまま渡していました。しかし server 側 (`CollectionPaths.collection_name`) は `parts[2]` を返すだけで **末尾 `-collection` を剥がしていない** ため、実際の値は:

- `dawn-cloud-fold-collection` (suffix 残り) ← 期待値: `dawn-cloud-fold`

これを theme として渡すと:
- `id` 末尾 `-<theme>` 照合が失敗 (id 末尾は `-dawn-cloud-fold-collection`、theme で組み立てた suffix は `-dawn-cloud-fold-collection`)
- 実は theme `dawn-cloud-fold-collection` の場合: `themeSuffix = "-dawn-cloud-fold-collection"`、stripped = `"20260601-rjn-dawn-cloud-fold"` (元 id から `-collection` 剥がし済) で、`stripped.endsWith(themeSuffix)` = false → **throw "theme と collection id が不整合"**
- useMemo で throw → React component が crash → **popup 全体が起動しない**

## 修正内容

`components/useSunoRunner.ts` の derivedPlaylistName 計算で `selected.name.replace(/-collection$/, "")` を挟んで theme から末尾 `-collection` を剥がしてから渡す。

```ts
const derivedPlaylistName = useMemo(() => {
  const selected = collections.find((c) => c.id === selectedCollectionId);
  if (!selected) {
    return undefined;
  }
  const theme = selected.name.replace(/-collection$/, "");
  return extractPlaylistName(selected.id, theme);
}, [collections, selectedCollectionId]);
```

`extractPlaylistName` の契約 (theme は接尾辞なしの slug) は維持し、呼び出し位置だけ修正。剥がし処理は冪等なので、将来 server 側 (`collection_paths.py`) が修正されても無害です。

## 長期 fix の方向 (別 issue)

サーバ側 (`src/youtube_automation/utils/collection_paths.py::CollectionPaths.collection_name`) で `-collection` suffix を剥がして返すよう修正するのが本質的な解決。ただし影響範囲確認が必要 (他の caller が suffix 込みの値に依存している可能性) なので、別 issue で慎重に進めます。

## ローカル検証

- `pnpm test` 229 passed
- `pnpm compile` exit 0
- `pnpm lint` exit 0
- `pnpm format:check` All matched files use Prettier code style
- `pnpm build` content.js 23.53 kB

## Test plan

- [ ] CI 5 jobs pass
- [ ] extension reload 後、popup が正常起動 (collection ドロップダウン表示)
- [ ] `dawn-cloud-fold` 選択 → 「Playlist: rjn | dawn-cloud-fold」表示
- [ ] 全実行 → 完了後に Suno で `rjn | dawn-cloud-fold` 名の playlist 作成

## 関連

- 直接の原因 PR: #857 (extractPlaylistName 2 引数化)
- 本実装 PR: #855 (Suno playlist 一括追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)