### PR TITLE
[#866] issue-866-fix-suno-helper-remi

### DIFF
--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -17,10 +17,15 @@ const SELECTORS = {
     'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]',
 } as const;
 
-/** Suno 生成キューの 1 clip 行を示す安定識別子（#816、実 DOM 検証: 1 タブで 16 件確認）。 */
-export const CLIP_ROW_SELECTOR = '[data-testid="clip-row"]';
-/** clip-row が「生成中」を示すスピナー（#816、完了 row には現れず duration テキストになる）。 */
-const CLIP_SPINNER_SELECTOR = "svg.animate-spin";
+/**
+ * clip カードの in-flight マーカー（#866、実機検証で確定）。Suno が `data-testid="clip-row"` と
+ * `svg.animate-spin` を撤去したため、音源が揃わない限り押せない Remix btn の `disabled` を軸にする。
+ * UI 装飾（spinner/testid）と違い「音源未完成なら Remix 不可」という Suno のドメインルール由来で変更されにくい。
+ */
+export const REMIX_BTN_SELECTOR = 'button[aria-label="Remix clip"]';
+/** clip card root を構造的に解決するための同伴ボタン（#866）。Remix btn と合わせ 3 種が各 1 つ揃う祖先が card。 */
+const SELECT_CLIP_BTN_SELECTOR = 'button[aria-label="Select clip"]';
+const EDIT_TITLE_BTN_SELECTOR = 'button[aria-label="Edit title"]';
 
 /**
  * queue 上限エラー toast の安定識別子（#847、実 DOM 検証）。testid/aria-label を持たないため
@@ -121,7 +126,7 @@ export function detectRecaptcha(): boolean {
  * queue 上限エラー toast が表示中かを検知する（#847）。
  * 可視な `[role="dialog"]` のうち英語見出し "generation in progress" を case-insensitive
  * substring match で含むものがあれば true。detectRecaptcha (#810) と同じ strict isVisible で
- * 非表示の toast 残骸を弾く。Create→clip-row 反映ラグで Suno が投入を reject した時に出る toast を
+ * 非表示の toast 残骸を弾く。Create→clip card DOM 反映ラグで Suno が投入を reject した時に出る toast を
  * 検知し、空きスロットがあっても投入を止めるために使う。
  */
 export function isQueueLimitErrorVisible(): boolean {
@@ -226,18 +231,70 @@ export interface WaitForQueueSlotOptions {
 }
 
 /**
- * 1 行の clip が「生成中」か判定する（#816）。
- * strict isVisible() で row 自体を filter したうえで `svg.animate-spin` を含むか見る。
- * 非可視 row（display:none / bbox 0 / 親 walk で隠れ）は生成中とみなさない。
+ * Remix btn（anchor）から clip card root を構造的に解決する（#866）。
+ * 親方向へ walk し、「Select clip / Remix clip / Edit title を各 1 つずつ含む最寄り祖先」を返す。
+ * Emotion class hash（`.e1yitp9f1` 等）には依存しない。複数 card を内包する container は各ボタンが
+ * 2 つ以上になるため exactly-one 判定で除外され、各 card 境界で確定する。
+ * 3 ボタンが揃う祖先が無ければ throw（fail-loud, req 8: silent に親 root を返さない）。
  */
-export function isClipGenerating(row: HTMLElement): boolean {
-  return isVisible(row) && row.querySelector(CLIP_SPINNER_SELECTOR) !== null;
+export function findCardRoot(anchor: HTMLElement): HTMLElement {
+  let el: HTMLElement | null = anchor;
+  while (el) {
+    if (
+      el.querySelectorAll(SELECT_CLIP_BTN_SELECTOR).length === 1 &&
+      el.querySelectorAll(REMIX_BTN_SELECTOR).length === 1 &&
+      el.querySelectorAll(EDIT_TITLE_BTN_SELECTOR).length === 1
+    ) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  throw new Error(
+    "clip card root を解決できません。Select/Remix/Edit が各 1 つ揃う祖先が見つかりませんでした（Suno の DOM 変更の可能性）。",
+  );
 }
 
-/** 可視な clip-row のうち生成中（in-flight）な clip 数を数える（#816）。 */
+/**
+ * 1 つの clip card が「生成中」か判定する（#866）。
+ * card 内 Remix btn が `disabled`（または `aria-disabled="true"`）なら生成中。音源が揃って初めて
+ * Remix が押せるようになる Suno のドメインルールを利用する。strict isVisible() で card 自体も filter し、
+ * 非可視 card（display:none / bbox 0 / 親 walk で隠れ）は生成中とみなさない。
+ * Remix btn が card 内に無い場合は throw（fail-loud, req 8: silent に false を返さない）。
+ */
+export function isClipGenerating(card: HTMLElement): boolean {
+  const remix = card.querySelector<HTMLButtonElement>(REMIX_BTN_SELECTOR);
+  if (!remix) {
+    throw new Error(
+      "clip card 内に Remix btn がありません。card root の解決が誤っているか Suno の DOM 変更の可能性があります。",
+    );
+  }
+  return (
+    isVisible(card) &&
+    (remix.disabled || remix.getAttribute("aria-disabled") === "true")
+  );
+}
+
+/**
+ * 生成中（in-flight）な clip 数を数える（#866）。
+ * 全 Remix btn から findCardRoot で card root を解決して重複排除し、`isClipGenerating(card)`
+ * （内部で `isVisible(card)` も判定）が true な distinct card 数を返す。
+ * Remix btn が 0 件 = DOM 構造が壊れている → silent に 0 を返さず throw（fail-loud, req 8）。
+ * silent 0 を返すと「常に空き」と誤判定し queue 上限まで過剰投入してしまうのが本 issue のバグ本体。
+ */
 export function getInFlightClipCount(): number {
-  const rows = document.querySelectorAll<HTMLElement>(CLIP_ROW_SELECTOR);
-  return Array.from(rows).filter(isClipGenerating).length;
+  const anchors = document.querySelectorAll<HTMLButtonElement>(
+    REMIX_BTN_SELECTOR,
+  );
+  if (anchors.length === 0) {
+    throw new Error(
+      "Remix btn が 1 件も見つかりません。in-flight 検知が不能です（Suno の DOM 変更の可能性）。",
+    );
+  }
+  const cards = new Set<HTMLElement>();
+  for (const anchor of anchors) {
+    cards.add(findCardRoot(anchor));
+  }
+  return Array.from(cards).filter(isClipGenerating).length;
 }
 
 export interface WaitForInFlightIncreaseOptions {
@@ -252,7 +309,7 @@ export interface WaitForInFlightIncreaseOptions {
  *   - isAborted() が true なら未達でも最優先で即 resolve `true`（停止優先。waitForQueueSlot と同じ中断優先）
  *   - getInFlightClipCount() >= beforeCount + delta になったら resolve `true`（受理確認）
  *   - deadline 超過で resolve `false`（throw しない。retry 判断は caller=injectWithVerification 側に委ねる）
- * waitForQueueSlot と異なり throw せず boolean を返す。Create→clip-row 反映ラグで Suno が inject を
+ * waitForQueueSlot と異なり throw せず boolean を返す。Create→clip card DOM 反映ラグで Suno が inject を
  * silent drop しても Generate ボタンは再 enabled になるため、実際に clip が受理されたかを増分で検証する。
  */
 export async function waitForInFlightIncrease(
@@ -282,7 +339,7 @@ export async function waitForInFlightIncrease(
  *   - in-flight < maxClips になったら resolve（投入再開）
  *   - deadline 超過で timeout throw
  * Suno は同時 10 リクエスト = 20 clip までしか積めず、超過すると後続が silent fail するため、
- * 各リクエスト投入前にこの関数で空きスロットを待つ。Create→clip-row 反映ラグで Suno が投入を
+ * 各リクエスト投入前にこの関数で空きスロットを待つ。Create→clip card DOM 反映ラグで Suno が投入を
  * reject すると toast が出るため、toast 検知中は投入を止め、消失後に buffer を取ってから再開する。
  */
 export async function waitForQueueSlot(

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -282,9 +282,8 @@ export function isClipGenerating(card: HTMLElement): boolean {
  * silent 0 を返すと「常に空き」と誤判定し queue 上限まで過剰投入してしまうのが本 issue のバグ本体。
  */
 export function getInFlightClipCount(): number {
-  const anchors = document.querySelectorAll<HTMLButtonElement>(
-    REMIX_BTN_SELECTOR,
-  );
+  const anchors =
+    document.querySelectorAll<HTMLButtonElement>(REMIX_BTN_SELECTOR);
   if (anchors.length === 0) {
     throw new Error(
       "Remix btn が 1 件も見つかりません。in-flight 検知が不能です（Suno の DOM 変更の可能性）。",

--- a/extensions/suno-helper/tests/_helpers.ts
+++ b/extensions/suno-helper/tests/_helpers.ts
@@ -64,6 +64,81 @@ export function addCaptchaIframe(opts: {
   return f;
 }
 
+/** aria-label 付き <button> を生成する。findCardRoot の構造判定 (Select/Remix/Edit) に使う。 */
+function makeAriaButton(
+  label: string,
+  opts: { disabled?: boolean; ariaDisabled?: boolean } = {},
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.setAttribute("aria-label", label);
+  if (opts.disabled) btn.disabled = true;
+  if (opts.ariaDisabled) btn.setAttribute("aria-disabled", "true");
+  return btn;
+}
+
+/**
+ * Suno の clip カード (#866) を模した DOM を生成する（body には append しない detached 要素）。
+ * order.md 実機検証で確定した「Select clip / Remix clip / Edit title を各 1 つずつ含む card root」を
+ * 写像する。findCardRoot のネスト構造テスト（複数カードを 1 つの container に入れる）では本関数で
+ * detached card を組んでから任意の親へ append する。
+ *   - generating=true: Remix btn を disabled にする（= 生成中。音源未完成で Remix 不可）
+ *   - generating=false: Remix btn enabled（= 完了。Remix 可能）
+ *   - generatingVia="aria-disabled": disabled 属性ではなく aria-disabled="true" で生成中を表す
+ *   - visible=false: display:none + bbox 0×0（strict isVisible で除外される card）
+ */
+export function buildClipCard(
+  opts: {
+    generating?: boolean;
+    visible?: boolean;
+    generatingVia?: "disabled" | "aria-disabled";
+  } = {},
+): HTMLElement {
+  const via = opts.generatingVia ?? "disabled";
+  const card = document.createElement("div");
+  card.append(
+    makeAriaButton("Select clip"),
+    makeAriaButton("Remix clip", {
+      disabled: opts.generating === true && via === "disabled",
+      ariaDisabled: opts.generating === true && via === "aria-disabled",
+    }),
+    makeAriaButton("Edit title"),
+  );
+  const title = document.createElement("span");
+  title.textContent = opts.generating ? "Untitled" : "Orchestral Test Verification";
+  card.appendChild(title);
+
+  if (opts.visible === false) {
+    card.style.display = "none";
+    markBbox(card, 0, 0);
+  } else {
+    markBbox(card, 240, 80);
+  }
+  return card;
+}
+
+/** buildClipCard で作った clip カードを body に挿入して返す（単純な単一カード用）。 */
+export function addClipCard(
+  opts: {
+    generating?: boolean;
+    visible?: boolean;
+    generatingVia?: "disabled" | "aria-disabled";
+  } = {},
+): HTMLElement {
+  const card = buildClipCard(opts);
+  document.body.appendChild(card);
+  return card;
+}
+
+/** generating な card の Remix btn を enabled に戻し「完了」状態にする（poll 中に slot が空く状況を作る）。 */
+export function completeClipCard(card: HTMLElement): void {
+  const remix = card.querySelector<HTMLButtonElement>('button[aria-label="Remix clip"]');
+  if (!remix) {
+    throw new Error("test fixture 不整合: card 内に Remix btn がありません。");
+  }
+  remix.disabled = false;
+  remix.removeAttribute("aria-disabled");
+}
+
 /**
  * Suno の queue 上限エラー toast (#847) を模した `[role="dialog"]` を body に挿入する。
  * order.md 実 DOM 検証の構造 (H2.sr-only + P.sr-only + H3 可視見出し + SPAN 補足) を写像する。

--- a/extensions/suno-helper/tests/_helpers.ts
+++ b/extensions/suno-helper/tests/_helpers.ts
@@ -65,10 +65,7 @@ export function addCaptchaIframe(opts: {
 }
 
 /** aria-label 付き <button> を生成する。findCardRoot の構造判定 (Select/Remix/Edit) に使う。 */
-function makeAriaButton(
-  label: string,
-  opts: { disabled?: boolean; ariaDisabled?: boolean } = {},
-): HTMLButtonElement {
+function makeAriaButton(label: string, opts: { disabled?: boolean; ariaDisabled?: boolean } = {}): HTMLButtonElement {
   const btn = document.createElement("button");
   btn.setAttribute("aria-label", label);
   if (opts.disabled) btn.disabled = true;

--- a/extensions/suno-helper/tests/e2e/suno-queue.spec.ts
+++ b/extensions/suno-helper/tests/e2e/suno-queue.spec.ts
@@ -1,15 +1,17 @@
-// 要件 (#816): Suno 生成キュー監視と collection 選択 UI の E2E スモーク (実 Suno 非依存)。
+// 要件 (#816 → #866 で再実装): Suno 生成キュー監視と collection 選択 UI の E2E スモーク (実 Suno 非依存)。
 //
 // content script は manifest の matches (`https://suno.com/*`) でしか注入されず、Playwright の
 // page.evaluate に渡す関数はシリアライズされブラウザ文脈で実行されるため本番 `shared/dom.ts` を
 // 直接 import できない (既存 suno-inject.spec.ts と同じ制約)。よってここでは
-// isClipGenerating / getInFlightClipCount / waitForQueueSlot と同手法を inline 再現し、
+// findCardRoot / isClipGenerating / getInFlightClipCount / waitForQueueSlot と同手法を inline 再現し、
 // 「11 件目は queue 待ちで停止 → 1 完了で投入される」が実ブラウザの layout 上で成立することを示す。
+// #866: Suno が clip-row testid と svg.animate-spin を撤去したため、in-flight マーカーを
+// `button[aria-label="Remix clip"]` の disabled に切り替えた新 DOM 構造で検証する。
 // 本番関数自体の回帰は jsdom 上で `shared/dom.ts` を import する unit (`tests/queue.test.ts`) が担う。
 import { expect, test } from "@playwright/test";
 
-// clip-row を 20 行 (= 10 リクエスト in-flight = 上限) 並べた Suno 生成キューの mock。
-// 各 row は生成中を表す svg.animate-spin を持つ。
+// clip card を 20 枚 (= 10 リクエスト in-flight = 上限) 並べた Suno 生成キューの mock。
+// 各 card は Select clip / Remix clip / Edit title を 1 つずつ持ち、生成中は Remix btn を disabled にする。
 const MOCK_QUEUE_HTML = `<!doctype html>
 <html>
   <body>
@@ -17,8 +19,11 @@ const MOCK_QUEUE_HTML = `<!doctype html>
       ${Array.from({ length: 20 })
         .map(
           (_, i) =>
-            `<div data-testid="clip-row" id="clip-${i}" style="width:200px;height:60px">` +
-            `<svg class="animate-spin" width="16" height="16"></svg></div>`,
+            `<div class="clip-card" id="clip-${i}" style="width:200px;height:60px">` +
+            `<button aria-label="Select clip"></button>` +
+            `<button aria-label="Remix clip" disabled></button>` +
+            `<button aria-label="Edit title"></button>` +
+            `</div>`,
         )
         .join("\n")}
     </div>
@@ -29,7 +34,10 @@ test("11 件目は in-flight 上限 (20 clip) で待機し、1 clip 完了で投
   await page.setContent(MOCK_QUEUE_HTML);
 
   const result = await page.evaluate(async () => {
-    // 本番 shared/dom.ts と同じ strict 可視判定 / 生成中判定 / queue 待機を inline 再現する。
+    // 本番 shared/dom.ts と同じ strict 可視判定 / card root 解決 / 生成中判定 / queue 待機を inline 再現する。
+    const REMIX_BTN_SELECTOR = 'button[aria-label="Remix clip"]';
+    const SELECT_CLIP_SELECTOR = 'button[aria-label="Select clip"]';
+    const EDIT_TITLE_SELECTOR = 'button[aria-label="Edit title"]';
     const isVisible = (el: HTMLElement): boolean => {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0) return false;
@@ -43,10 +51,34 @@ test("11 件目は in-flight 上限 (20 clip) で待機し、1 clip 完了で投
       }
       return true;
     };
-    const isClipGenerating = (row: HTMLElement): boolean =>
-      isVisible(row) && row.querySelector("svg.animate-spin") !== null;
-    const getInFlightClipCount = (): number =>
-      Array.from(document.querySelectorAll<HTMLElement>('[data-testid="clip-row"]')).filter(isClipGenerating).length;
+    // 親方向に walk して Select/Remix/Edit を各 1 つずつ含む最寄り祖先 (card root) を返す。
+    const findCardRoot = (anchor: HTMLElement): HTMLElement => {
+      let node: HTMLElement | null = anchor;
+      while (node) {
+        if (
+          node.querySelectorAll(SELECT_CLIP_SELECTOR).length === 1 &&
+          node.querySelectorAll(REMIX_BTN_SELECTOR).length === 1 &&
+          node.querySelectorAll(EDIT_TITLE_SELECTOR).length === 1
+        ) {
+          return node;
+        }
+        node = node.parentElement;
+      }
+      throw new Error("clip card root を解決できません。");
+    };
+    const isClipGenerating = (card: HTMLElement): boolean => {
+      if (!isVisible(card)) return false;
+      const remix = card.querySelector<HTMLButtonElement>(REMIX_BTN_SELECTOR);
+      if (!remix) throw new Error("card 内に Remix btn が見つかりません。");
+      return remix.disabled || remix.getAttribute("aria-disabled") === "true";
+    };
+    const getInFlightClipCount = (): number => {
+      const anchors = Array.from(document.querySelectorAll<HTMLButtonElement>(REMIX_BTN_SELECTOR));
+      if (anchors.length === 0) throw new Error("Remix btn が 0 件です。");
+      const cards = new Set<HTMLElement>();
+      for (const a of anchors) cards.add(findCardRoot(a));
+      return Array.from(cards).filter(isClipGenerating).length;
+    };
     const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
     const waitForQueueSlot = async (maxClips: number): Promise<void> => {
       const deadline = Date.now() + 5000;
@@ -68,8 +100,8 @@ test("11 件目は in-flight 上限 (20 clip) で待機し、1 clip 完了で投
     await sleep(80);
     const blockedWhileFull = !resolved;
 
-    // 1 clip 完了 (spinner 除去) → in-flight 19 < 20 → 投入再開。
-    document.querySelector('[data-testid="clip-row"] svg.animate-spin')?.remove();
+    // 1 clip 完了 (Remix btn enabled) → in-flight 19 < 20 → 投入再開。
+    document.querySelector<HTMLButtonElement>(REMIX_BTN_SELECTOR)?.removeAttribute("disabled");
     await pending;
 
     return { before, blockedWhileFull, resolvedAfterFree: resolved, after: getInFlightClipCount() };
@@ -138,7 +170,11 @@ const MOCK_TOAST_HTML = `<!doctype html>
 <html>
   <body>
     <div id="grid">
-      <div data-testid="clip-row" id="clip-0" style="width:200px;height:60px"><span>2:02</span></div>
+      <div class="clip-card" id="clip-0" style="width:200px;height:60px">
+        <button aria-label="Select clip"></button>
+        <button aria-label="Remix clip"></button>
+        <button aria-label="Edit title"></button>
+      </div>
     </div>
     <div id="toast" role="dialog" style="width:360px;height:120px">
       <h3>Generation in progress</h3>
@@ -151,7 +187,10 @@ test("queue 上限 toast 検知中は空きスロットでも待機し、toast �
   await page.setContent(MOCK_TOAST_HTML);
 
   const result = await page.evaluate(async () => {
-    // 本番 shared/dom.ts と同じ strict 可視判定 / toast 検知 / queue 待機を inline 再現する。
+    // 本番 shared/dom.ts と同じ strict 可視判定 / card root 解決 / toast 検知 / queue 待機を inline 再現する。
+    const REMIX_BTN_SELECTOR = 'button[aria-label="Remix clip"]';
+    const SELECT_CLIP_SELECTOR = 'button[aria-label="Select clip"]';
+    const EDIT_TITLE_SELECTOR = 'button[aria-label="Edit title"]';
     const isVisible = (el: HTMLElement): boolean => {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0) return false;
@@ -165,10 +204,33 @@ test("queue 上限 toast 検知中は空きスロットでも待機し、toast �
       }
       return true;
     };
-    const isClipGenerating = (row: HTMLElement): boolean =>
-      isVisible(row) && row.querySelector("svg.animate-spin") !== null;
-    const getInFlightClipCount = (): number =>
-      Array.from(document.querySelectorAll<HTMLElement>('[data-testid="clip-row"]')).filter(isClipGenerating).length;
+    const findCardRoot = (anchor: HTMLElement): HTMLElement => {
+      let node: HTMLElement | null = anchor;
+      while (node) {
+        if (
+          node.querySelectorAll(SELECT_CLIP_SELECTOR).length === 1 &&
+          node.querySelectorAll(REMIX_BTN_SELECTOR).length === 1 &&
+          node.querySelectorAll(EDIT_TITLE_SELECTOR).length === 1
+        ) {
+          return node;
+        }
+        node = node.parentElement;
+      }
+      throw new Error("clip card root を解決できません。");
+    };
+    const isClipGenerating = (card: HTMLElement): boolean => {
+      if (!isVisible(card)) return false;
+      const remix = card.querySelector<HTMLButtonElement>(REMIX_BTN_SELECTOR);
+      if (!remix) throw new Error("card 内に Remix btn が見つかりません。");
+      return remix.disabled || remix.getAttribute("aria-disabled") === "true";
+    };
+    const getInFlightClipCount = (): number => {
+      const anchors = Array.from(document.querySelectorAll<HTMLButtonElement>(REMIX_BTN_SELECTOR));
+      if (anchors.length === 0) throw new Error("Remix btn が 0 件です。");
+      const cards = new Set<HTMLElement>();
+      for (const a of anchors) cards.add(findCardRoot(a));
+      return Array.from(cards).filter(isClipGenerating).length;
+    };
     const isQueueLimitErrorVisible = (): boolean =>
       Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"]')).some(
         (el) => isVisible(el) && (el.textContent ?? "").toLowerCase().includes("generation in progress"),

--- a/extensions/suno-helper/tests/queue.test.ts
+++ b/extensions/suno-helper/tests/queue.test.ts
@@ -34,12 +34,7 @@ import {
   waitForInFlightIncrease,
   waitForQueueSlot,
 } from "../../shared/dom";
-import {
-  addClipCard,
-  addQueueErrorDialog,
-  buildClipCard,
-  completeClipCard,
-} from "./_helpers";
+import { addClipCard, addQueueErrorDialog, buildClipCard, completeClipCard } from "./_helpers";
 
 /** card 内の Remix btn (findCardRoot の anchor) を取り出す。 */
 function remixBtnOf(card: HTMLElement): HTMLButtonElement {

--- a/extensions/suno-helper/tests/queue.test.ts
+++ b/extensions/suno-helper/tests/queue.test.ts
@@ -1,63 +1,51 @@
 // @vitest-environment jsdom
 //
-// Suno 生成キュー監視 (#816) の回帰テスト。実 DOM 検証 (order.md) で確定した仕様を担保する:
-//   - clip-row は `[data-testid="clip-row"]` で識別 (1 タブで 16 件確認)
-//   - 生成中判定 = row 内に `svg.animate-spin` を含む。strict isVisible() で row 自体も filter
-//   - 完了判定 = duration テキストあり / spinner なし → 生成中ではない
-//   - getInFlightClipCount() = 全 visible clip-row のうち生成中の数
+// Suno 生成キュー監視 (#816 → #866 で再実装) の回帰テスト。
+// Suno が `data-testid="clip-row"` と `svg.animate-spin` を撤去したため、実機検証 (order.md) で
+// 「生成中→完了」を 100% 追跡できると確定した `button[aria-label="Remix clip"]` の disabled を軸に
+// in-flight 検知を再構築する。音源が揃わない限り Remix できないという Suno のドメインルール由来の
+// 状態であり、UI 装飾 (spinner/testid) より変更されにくい。
+//
+//   - clip カードは「Select clip / Remix clip / Edit title を各 1 つずつ含む最寄り祖先」で識別
+//     (findCardRoot による構造的解決。Emotion class hash には依存しない)
+//   - 生成中判定 = card 内 Remix btn が disabled (または aria-disabled="true")。strict isVisible() で
+//     card 自体も filter
+//   - 完了判定 = Remix btn enabled → 生成中ではない
+//   - getInFlightClipCount() = 全 Remix btn からカードルートを解決し in-flight な distinct card 数
+//   - fail-loud (req 8): Remix btn が 0 件 = DOM 構造が壊れている → silent に 0 を返さず throw
 //   - waitForQueueSlot(maxClips, opts) = in-flight < maxClips になるまで poll
 //
 // 契約 (draft が実装すべき public API、shared/dom.ts):
-//   - CLIP_ROW_SELECTOR: string
-//   - isClipGenerating(row: HTMLElement): boolean
-//   - getInFlightClipCount(): number
+//   - REMIX_BTN_SELECTOR: string
+//   - findCardRoot(anchor: HTMLElement): HTMLElement
+//   - isClipGenerating(card: HTMLElement): boolean
+//   - getInFlightClipCount(): number   // Remix btn 0 件で throw
 //   - waitForQueueSlot(maxClips: number, options: { isAborted; pollIntervalMs; timeoutMs; queueErrorWaitMs }): Promise<void>
-//     #847 で queueErrorWaitMs（toast 消失後の安全マージン）を必須オプションに追加。
 //
 // jsdom はレイアウトを行わず getBoundingClientRect が常に 0×0 を返すため、strict 可視判定
-// 対象の row には markBbox (_helpers.ts) で bbox を擬似的に与える (dom.test.ts と同方針)。
+// 対象の card には markBbox (_helpers.ts) で bbox を擬似的に与える (dom.test.ts と同方針)。
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  CLIP_ROW_SELECTOR,
+  REMIX_BTN_SELECTOR,
+  findCardRoot,
   getInFlightClipCount,
   isClipGenerating,
   waitForInFlightIncrease,
   waitForQueueSlot,
 } from "../../shared/dom";
-import { addQueueErrorDialog, markBbox } from "./_helpers";
+import {
+  addClipCard,
+  addQueueErrorDialog,
+  buildClipCard,
+  completeClipCard,
+} from "./_helpers";
 
-/**
- * clip-row を body に挿入する。
- *   - generating=true: row 内に `svg.animate-spin` を置く (生成中)
- *   - generating=false: duration テキストのみ (完了)
- *   - visible=false: display:none + bbox 0×0 (strict isVisible で除外される行)
- */
-function addClipRow(opts: { generating?: boolean; visible?: boolean } = {}): HTMLElement {
-  const row = document.createElement("div");
-  row.setAttribute("data-testid", "clip-row");
-  if (opts.generating) {
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svg.setAttribute("class", "animate-spin");
-    row.appendChild(svg);
-  } else {
-    const duration = document.createElement("span");
-    duration.textContent = "2:02";
-    row.appendChild(duration);
-  }
-  document.body.appendChild(row);
-  if (opts.visible === false) {
-    row.style.display = "none";
-    markBbox(row, 0, 0);
-  } else {
-    markBbox(row, 200, 60);
-  }
-  return row;
-}
-
-/** generating な row から spinner を取り除き「完了」状態にする (poll 中に slot が空く状況を作る)。 */
-function completeClip(row: HTMLElement): void {
-  row.querySelector("svg.animate-spin")?.remove();
+/** card 内の Remix btn (findCardRoot の anchor) を取り出す。 */
+function remixBtnOf(card: HTMLElement): HTMLButtonElement {
+  const btn = card.querySelector<HTMLButtonElement>(REMIX_BTN_SELECTOR);
+  if (!btn) throw new Error("test fixture 不整合: card に Remix btn がありません。");
+  return btn;
 }
 
 // queueErrorWaitMs は poll (10ms) と明確に分離して buffer 待機の途中経過を pin できるよう 200ms。
@@ -67,64 +55,100 @@ beforeEach(() => {
   document.body.innerHTML = "";
 });
 
-describe("CLIP_ROW_SELECTOR: 実 DOM 検証で確定した安定識別子", () => {
-  it('Given 定数 When 読む Then `[data-testid="clip-row"]` である', () => {
-    expect(CLIP_ROW_SELECTOR).toBe('[data-testid="clip-row"]');
+describe("REMIX_BTN_SELECTOR: 実 DOM 検証で確定した in-flight マーカー", () => {
+  it('Given 定数 When 読む Then `button[aria-label="Remix clip"]` である', () => {
+    expect(REMIX_BTN_SELECTOR).toBe('button[aria-label="Remix clip"]');
   });
 });
 
-describe("isClipGenerating: 1 行の生成中判定", () => {
-  it("Given 可視 row 内に svg.animate-spin When 判定する Then true", () => {
-    const row = addClipRow({ generating: true });
-    expect(isClipGenerating(row)).toBe(true);
+describe("findCardRoot: Remix btn から clip card root を構造的に解決する", () => {
+  it("Given Select/Remix/Edit を各 1 つ持つ card の Remix btn When 解決する Then その card root を返す", () => {
+    const card = addClipCard({ generating: true });
+    expect(findCardRoot(remixBtnOf(card))).toBe(card);
   });
 
-  it("Given 可視 row だが spinner 無し (duration のみ) When 判定する Then false (完了)", () => {
-    const row = addClipRow({ generating: false });
-    expect(isClipGenerating(row)).toBe(false);
+  it("Given 複数 card を内包する container When 各 Remix btn から解決する Then 上位 container ではなく最寄りの card を返す", () => {
+    // 上位 container は Select/Remix/Edit を 2 つずつ持つ。exactly-one 判定が container で止まらず
+    // 各カード境界 (各ボタン 1 個ずつ) で確定することを担保する。
+    const container = document.createElement("div");
+    const card1 = buildClipCard({ generating: true });
+    const card2 = buildClipCard({ generating: false });
+    container.append(card1, card2);
+    document.body.appendChild(container);
+
+    expect(findCardRoot(remixBtnOf(card1))).toBe(card1);
+    expect(findCardRoot(remixBtnOf(card2))).toBe(card2);
   });
 
-  it("Given spinner はあるが row が非可視 (display:none/bbox0) When 判定する Then false (strict isVisible で除外)", () => {
-    const row = addClipRow({ generating: true, visible: false });
-    expect(isClipGenerating(row)).toBe(false);
+  it("Given anchor から祖先を辿っても 3 ボタンが揃う card root が無い When 解決する Then throw する (fail-loud)", () => {
+    // Select/Edit を伴わない孤立した Remix btn。構造解決できないので silent に返さず throw。
+    const lone = document.createElement("button");
+    lone.setAttribute("aria-label", "Remix clip");
+    document.body.appendChild(lone);
+
+    expect(() => findCardRoot(lone)).toThrow();
+  });
+});
+
+describe("isClipGenerating: 1 card の生成中判定 (Remix btn disabled)", () => {
+  it("Given 可視 card の Remix btn が disabled When 判定する Then true (生成中)", () => {
+    const card = addClipCard({ generating: true });
+    expect(isClipGenerating(card)).toBe(true);
   });
 
-  it("Given 親が display:none の row When 判定する Then false (親 walk で除外)", () => {
+  it("Given 可視 card の Remix btn が aria-disabled=true When 判定する Then true (生成中)", () => {
+    const card = addClipCard({ generating: true, generatingVia: "aria-disabled" });
+    expect(isClipGenerating(card)).toBe(true);
+  });
+
+  it("Given 可視 card の Remix btn が enabled When 判定する Then false (完了)", () => {
+    const card = addClipCard({ generating: false });
+    expect(isClipGenerating(card)).toBe(false);
+  });
+
+  it("Given Remix btn は disabled だが card が非可視 (display:none/bbox0) When 判定する Then false (strict isVisible で除外)", () => {
+    const card = addClipCard({ generating: true, visible: false });
+    expect(isClipGenerating(card)).toBe(false);
+  });
+
+  it("Given 親が display:none の card When 判定する Then false (親 walk で除外)", () => {
     const wrapper = document.createElement("div");
     wrapper.style.display = "none";
     document.body.appendChild(wrapper);
-    const row = document.createElement("div");
-    row.setAttribute("data-testid", "clip-row");
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svg.setAttribute("class", "animate-spin");
-    row.appendChild(svg);
-    wrapper.appendChild(row);
-    markBbox(row, 200, 60); // bbox は非 0。除外理由は親の display:none のみに限定する。
+    const card = buildClipCard({ generating: true }); // bbox は非 0。除外理由は親の display:none のみに限定。
+    wrapper.appendChild(card);
 
-    expect(isClipGenerating(row)).toBe(false);
+    expect(isClipGenerating(card)).toBe(false);
+  });
+
+  it("Given card 内に Remix btn が無い When 判定する Then throw する (fail-loud, req 8)", () => {
+    const card = document.createElement("div");
+    document.body.appendChild(card);
+    expect(() => isClipGenerating(card)).toThrow();
   });
 });
 
-describe("getInFlightClipCount: 可視 clip-row のうち生成中の数", () => {
+describe("getInFlightClipCount: in-flight な distinct card 数", () => {
   it("Given 生成中 3 / 完了 1 / 非可視生成中 1 When 数える Then 可視生成中の 3 を返す", () => {
-    addClipRow({ generating: true });
-    addClipRow({ generating: true });
-    addClipRow({ generating: true });
-    addClipRow({ generating: false });
-    addClipRow({ generating: true, visible: false });
+    addClipCard({ generating: true });
+    addClipCard({ generating: true });
+    addClipCard({ generating: true });
+    addClipCard({ generating: false });
+    addClipCard({ generating: true, visible: false });
 
     expect(getInFlightClipCount()).toBe(3);
   });
 
-  it("Given clip-row が 1 件も無い When 数える Then 0 を返す", () => {
+  it("Given 全て完了 card (Remix enabled) When 数える Then 0 を返す (Remix btn は存在するので throw しない)", () => {
+    addClipCard({ generating: false });
+    addClipCard({ generating: false });
+
     expect(getInFlightClipCount()).toBe(0);
   });
 
-  it("Given 全て完了 row When 数える Then 0 を返す", () => {
-    addClipRow({ generating: false });
-    addClipRow({ generating: false });
-
-    expect(getInFlightClipCount()).toBe(0);
+  it("Given Remix btn が 1 件も無い When 数える Then throw する (fail-loud, req 8: silent 0 を返さない)", () => {
+    // これが本 issue のバグ本体: selector 0 hit を silent に 0 と返すと上限まで過剰投入する。
+    expect(() => getInFlightClipCount()).toThrow();
   });
 });
 
@@ -138,7 +162,7 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
   });
 
   it("Given in-flight が既に上限未満 When 待機する Then 即 resolve する", async () => {
-    addClipRow({ generating: true }); // in-flight 1 < 20
+    addClipCard({ generating: true }); // in-flight 1 < 20
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
     await vi.advanceTimersByTimeAsync(0);
 
@@ -146,8 +170,8 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
   });
 
   it("Given in-flight が上限ちょうど When 1 clip 完了で空く Then 投入を再開 (resolve) する", async () => {
-    // 20 clip 生成中 = 10 リクエスト in-flight = 上限。11 件目はここで待たされる。
-    const rows = Array.from({ length: 20 }, () => addClipRow({ generating: true }));
+    // 20 card 生成中 = 10 リクエスト in-flight = 上限。11 件目はここで待たされる。
+    const cards = Array.from({ length: 20 }, () => addClipCard({ generating: true }));
     expect(getInFlightClipCount()).toBe(20);
 
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
@@ -160,8 +184,8 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
     await vi.advanceTimersByTimeAsync(FAST_OPTIONS.pollIntervalMs * 3);
     expect(settled).toBe(false);
 
-    // 1 clip 完了 → in-flight 19 < 20 → 次の poll で resolve。
-    completeClip(rows[0]);
+    // 1 clip 完了 (Remix btn enabled) → in-flight 19 < 20 → 次の poll で resolve。
+    completeClipCard(cards[0]);
     await vi.advanceTimersByTimeAsync(FAST_OPTIONS.pollIntervalMs);
 
     await expect(pending).resolves.toBeUndefined();
@@ -169,7 +193,7 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
   });
 
   it("Given isAborted が true When 待機する Then 上限超でも即 resolve する (throw しない)", async () => {
-    Array.from({ length: 20 }, () => addClipRow({ generating: true }));
+    Array.from({ length: 20 }, () => addClipCard({ generating: true }));
 
     const pending = waitForQueueSlot(20, { isAborted: () => true, ...FAST_OPTIONS });
     await vi.advanceTimersByTimeAsync(0);
@@ -178,7 +202,7 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
   });
 
   it("Given 上限のまま空かない When deadline 超過 Then timeout throw する", async () => {
-    Array.from({ length: 20 }, () => addClipRow({ generating: true }));
+    Array.from({ length: 20 }, () => addClipCard({ generating: true }));
 
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
     const expectation = expect(pending).rejects.toThrow();
@@ -188,10 +212,9 @@ describe("waitForQueueSlot: in-flight < maxClips まで待機", () => {
 });
 
 describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
-  // race condition (Create→clip-row DOM 反映ラグ) で Suno が 21 件目を reject すると
-  // 「Generation in progress」toast が出る。slot が空いていても toast 中は投入を止め、
-  // toast 消失後に queueErrorWaitMs の安全マージンを待ってから再開する。
-  // toast が一度も出ない経路（既存 4 ケース）は挙動不変であること（回帰）も上記で担保済み。
+  // race condition (Create→DOM 反映ラグ) で Suno が 21 件目を reject すると「Generation in progress」
+  // toast が出る。slot が空いていても toast 中は投入を止め、消失後に queueErrorWaitMs の安全マージンを
+  // 待ってから再開する。toast が一度も出ない経路（既存 4 ケース）は挙動不変であること（回帰）も担保済み。
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -201,7 +224,7 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
   });
 
   it("Given toast 可視中 When 空きスロットがあっても Then resolve せず待機を継続する", async () => {
-    addClipRow({ generating: true }); // in-flight 1 < 20（スロットは空いている）
+    addClipCard({ generating: true }); // in-flight 1 < 20（スロットは空いている）
     const toast = addQueueErrorDialog(); // だが queue 上限 toast が出ている
 
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
@@ -220,7 +243,7 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
   });
 
   it("Given toast 消失 When queueErrorWaitMs buffer 経過 Then 投入を再開 (resolve) する", async () => {
-    addClipRow({ generating: true }); // slot は空き
+    addClipCard({ generating: true }); // slot は空き
     const toast = addQueueErrorDialog();
 
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
@@ -244,7 +267,7 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
   });
 
   it("Given toast が一度も出ない When 空きスロットあり Then 即 resolve する (toast 無し経路は挙動不変)", async () => {
-    addClipRow({ generating: true }); // in-flight 1 < 20、toast なし
+    addClipCard({ generating: true }); // in-flight 1 < 20、toast なし
 
     const pending = waitForQueueSlot(20, { isAborted: () => false, ...FAST_OPTIONS });
     await vi.advanceTimersByTimeAsync(0);
@@ -253,7 +276,7 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
   });
 
   it("Given toast 可視中でも isAborted=true When 待機する Then 即 resolve する (中断優先)", async () => {
-    addClipRow({ generating: true });
+    addClipCard({ generating: true });
     addQueueErrorDialog();
 
     const pending = waitForQueueSlot(20, { isAborted: () => true, ...FAST_OPTIONS });
@@ -267,7 +290,7 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
     // 受け入れ条件「停止後 3 秒以内」を満たさない。abortableSleep の poll(250ms)で中断検知されることを、
     // poll 粒度より十分長い buffer(1000ms)を与え、満了前の停止で resolve することで確認する。
     const SLOW_BUFFER = { pollIntervalMs: 10, timeoutMs: 5000, queueErrorWaitMs: 1000 } as const;
-    addClipRow({ generating: true }); // slot は空き（待機要因は buffer のみ）
+    addClipCard({ generating: true }); // slot は空き（待機要因は buffer のみ）
     const toast = addQueueErrorDialog();
 
     let aborted = false;
@@ -299,6 +322,10 @@ describe("waitForQueueSlot: queue 上限エラー toast 検知 (#847)", () => {
 //     - isAborted() が true なら未達でも即 resolve true（停止優先。waitForQueueSlot と同じ中断優先）
 //     - 絶対値 beforeCount + delta 比較（相対追跡しない。order.md 契約どおり）
 // waitForQueueSlot と異なり throw せず boolean を返す点が本質的な差分。
+//
+// #866 注: getInFlightClipCount() は Remix btn 0 件で throw するため、「in-flight 0 から増える」
+// シナリオは完了 card（Remix btn enabled = in-flight には数えない）を seed して表現する。
+// 実機でも library には過去の完了 clip が常駐するため、これが現実的な前提。
 describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)", () => {
   const FAST = { pollIntervalMs: 10, timeoutMs: 1000 } as const;
 
@@ -311,8 +338,8 @@ describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)",
   });
 
   it("Given 既に beforeCount+delta 以上 (before=0, delta=2, in-flight=2) When 待機 Then 即 resolve true", async () => {
-    addClipRow({ generating: true });
-    addClipRow({ generating: true }); // in-flight 2 >= 0 + 2
+    addClipCard({ generating: true });
+    addClipCard({ generating: true }); // in-flight 2 >= 0 + 2
 
     const pending = waitForInFlightIncrease(0, 2, { isAborted: () => false, ...FAST });
     await vi.advanceTimersByTimeAsync(0);
@@ -320,8 +347,10 @@ describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)",
     await expect(pending).resolves.toBe(true);
   });
 
-  it("Given 投入直後はまだ反映されない→後から delta 分 clip-row 出現 When poll Then resolve true", async () => {
-    // inject 直後は clip-row DOM 反映ラグで 0 件。poll 中に 2 件出現したら受理確認。
+  it("Given 投入直後はまだ反映されない→後から delta 分 card が生成中になる When poll Then resolve true", async () => {
+    // inject 直後は DOM 反映ラグで in-flight 0（完了 card のみ）。poll 中に 2 card が生成中になったら受理確認。
+    addClipCard({ generating: false }); // 過去の完了 clip（Remix btn 存在 → throw しない、in-flight には数えない）
+
     const pending = waitForInFlightIncrease(0, 2, { isAborted: () => false, ...FAST });
     let settled: boolean | undefined;
     void pending.then((v) => {
@@ -329,34 +358,36 @@ describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)",
     });
 
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs * 3);
-    expect(settled).toBeUndefined(); // 0 件のうちは未達
+    expect(settled).toBeUndefined(); // in-flight 0 のうちは未達
 
-    addClipRow({ generating: true });
-    addClipRow({ generating: true });
+    addClipCard({ generating: true });
+    addClipCard({ generating: true });
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs);
 
     await expect(pending).resolves.toBe(true);
   });
 
   it("Given delta=2 を 1 件ずつ満たす When 各 poll で再評価 Then 全 delta 到達後にのみ resolve true", async () => {
+    addClipCard({ generating: false }); // in-flight 0 の起点（完了 card を seed）
+
     const pending = waitForInFlightIncrease(0, 2, { isAborted: () => false, ...FAST });
     let settled: boolean | undefined;
     void pending.then((v) => {
       settled = v;
     });
 
-    addClipRow({ generating: true }); // in-flight 1 < 2
+    addClipCard({ generating: true }); // in-flight 1 < 2
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs);
     expect(settled).toBeUndefined(); // 1 件では未達（部分受理では通さない）
 
-    addClipRow({ generating: true }); // in-flight 2 >= 2
+    addClipCard({ generating: true }); // in-flight 2 >= 2
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs);
     await expect(pending).resolves.toBe(true);
   });
 
   it("Given 既存 in-flight 4 / before=4 / delta=2 When 6 まで増える Then resolve true (絶対値 before+delta 比較)", async () => {
     // before を明示的に渡し、絶対値 before+delta で判定する契約を pin する。
-    Array.from({ length: 4 }, () => addClipRow({ generating: true }));
+    Array.from({ length: 4 }, () => addClipCard({ generating: true }));
     expect(getInFlightClipCount()).toBe(4);
 
     const pending = waitForInFlightIncrease(4, 2, { isAborted: () => false, ...FAST });
@@ -365,17 +396,20 @@ describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)",
       settled = v;
     });
 
-    addClipRow({ generating: true }); // 5 < 6
+    addClipCard({ generating: true }); // 5 < 6
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs);
     expect(settled).toBeUndefined();
 
-    addClipRow({ generating: true }); // 6 >= 6
+    addClipCard({ generating: true }); // 6 >= 6
     await vi.advanceTimersByTimeAsync(FAST.pollIntervalMs);
     await expect(pending).resolves.toBe(true);
   });
 
   it("Given 増分が達しないまま deadline 超過 When 待機 Then resolve false (throw しない)", async () => {
     // silent drop を表現。waitForQueueSlot と違い throw せず false を返し、retry 判断は caller に委ねる。
+    // 完了 card を seed し getInFlightClipCount() の throw を避けつつ in-flight は 0 のまま据え置く。
+    addClipCard({ generating: false });
+
     const pending = waitForInFlightIncrease(0, 2, { isAborted: () => false, ...FAST });
 
     await vi.advanceTimersByTimeAsync(FAST.timeoutMs + FAST.pollIntervalMs + 50);
@@ -384,7 +418,8 @@ describe("waitForInFlightIncrease: inject 後の in-flight 増分検証 (#864)",
   });
 
   it("Given isAborted=true When 増分未達でも待機 Then 即 resolve true (停止優先)", async () => {
-    // clip-row は 1 件も無い（未達）が、停止押下中は受理判定より中断を優先して true で抜ける。
+    // card は 1 件も無い（未達）が、停止押下中は受理判定より中断を優先して true で抜ける
+    // （isAborted を先に評価するため getInFlightClipCount() の throw 経路にも入らない）。
     const pending = waitForInFlightIncrease(0, 2, { isAborted: () => true, ...FAST });
     await vi.advanceTimersByTimeAsync(0);
 


### PR DESCRIPTION
## Summary

## 概要

Suno が DOM 仕様を変更し `data-testid="clip-row"` と `svg.animate-spin` を撤去したため、`extensions/shared/dom.ts` の in-flight clip 検知が構造的に死亡。実機検証で代替マーカーとして `button[aria-label="Remix clip"]` の `disabled` 属性が「生成中→完了」を 100% 追跡できることを確認したので、これを軸に再実装する。

## 背景・目的

Suno UI の DOM 仕様変更を実機検証で確定（本セッション中、Chrome DevTools MCP 経由で `https://suno.com/create` を観察）。

- `data-testid` がほぼ全廃: ページ全体で testid を持つ要素は 4 件のみ (`profile-menu-button`, `navbar-library-tab`, `lyrics-textarea`, `create-form-styles-wrapper`)。`clip-row` は撤去
- `svg.animate-spin` が clip カードに付かなくなった: 「生成中」スピナーは Create ボタン自身に一瞬出る送信中表示のみで、clip カード単位では機能しない
- `Play X from start` aria-label のボタンは `<button>` ではなく `<div role="button">` に変更

#816 / #847 / #864 で積み上げた queue 制御ロジックが構造的に壊れている状態。

## 再現手順

1. `pnpm -C extensions/suno-helper build` 後に `.output/chrome-mv3/` を unpacked load
2. `https://suno.com/create` を開く
3. `/suno` でプロンプト JSON を生成し、`uv run yt-collection-serve collections/planning/<theme>` を起動
4. 拡張 popup を開いてサーバー URL 設定 → 全パターン連続実行
5. 11 リクエスト以上を連続投入 (= queue 上限超過) を試みる

## 期待される動作

- 各リクエスト投入前に `getInFlightClipCount()` が現在の生成中 clip 数を正しく返し、空きスロットを待つ
- 投入後 `waitForInFlightIncrease()` が受理確認を行い、silent drop されたら retry する
- queue 上限を踏んだら `isQueueLimitErrorVisible()` で検知して投入を一時停止する

## 実際の動作

- `getInFlightClipCount()` が常に 0 を返す（`CLIP_ROW_SELECTOR = '[data-testid="clip-row"]'` が 0 件 hit）
- `waitForQueueSlot()` は「常に空き」と誤判定し、上限超過まで投入し続ける
- `waitForInFlightIncrease()` は常に false で受理検証が機能しない
- `isClipGenerating()` は `svg.animate-spin` を見ているため常に false

## 影響範囲

`extensions/suno-helper/` の連続実行フロー全体。#816 / #847 / #864 で導入した queue 制御ロジック。

## 新マーカーの実機実証データ

時系列観察（Create 押下 → 1秒粒度サンプリング 120秒）:

\`\`\`
transitions:
  cardIdx=0: t=2500ms  false→true ("Untitled...")
  cardIdx=0: t=90501ms true→false ("Orchestral Test Verification...")
  cardIdx=1: t=2500ms  false→true ("Untitled...")
  cardIdx=1: t=68500ms true→false ("Orchestral Test Verification...")

concurrencyTrace (1秒/文字):
  0 → 222...22 (66秒間 2個同時) → 111...1 (22秒間 1個) → 000... (両方完了)

summary:
  cardIdx=0: in-flight 入り 2.5s, 完了 90.5s, 所要 88s
  cardIdx=1: in-flight 入り 2.5s, 完了 68.5s, 所要 66s
\`\`\`

**意味論的根拠**: 音源データが揃わない限り Remix できないという Suno のドメインルール由来の状態。UI 装飾（spinner）と違い変更されにくい。

queue-limit toast 構造（11 連続 push の実機検証）:

\`\`\`
finalDialogs[0]:
  text: "Generation in progressリクエストが多すぎます。"
  role: "dialog"
  aria-modal: "false"
  childButtonLabels: ["Dismiss"]
\`\`\`

→ 既存の `isQueueLimitErrorVisible()` (#847) のロジック `[role="dialog"]` + lowercase substring `"generation in progress"` は現行 UI でも hit する（**書き換え不要**）。

## 参照資料

- extensions/shared/dom.ts
- extensions/shared/visibility.ts
- extensions/suno-helper/entrypoints/content.ts
- extensions/suno-helper/tests/
- extensions/suno-helper/README.md

## 影響ファイル

- **変更**: extensions/shared/dom.ts
- **変更**: extensions/suno-helper/tests/ （新 selector に合わせた unit + e2e fixture）

## 要件

1. `extensions/shared/dom.ts` から `CLIP_ROW_SELECTOR` と `CLIP_SPINNER_SELECTOR` を廃止する
2. 新セレクタ `REMIX_BTN_SELECTOR = 'button[aria-label="Remix clip"]'` を定義する
3. `findCardRoot(anchor)` を新規追加: 親方向に walk して「Select clip / Remix clip / Edit title が 1 つずつ含まれる最寄り祖先」を返す構造的解決（Emotion class hash `.e1yitp9f1` には依存しない）
4. `isClipGenerating(card)` を再実装: card 内 Remix btn の `disabled` で判定
5. `getInFlightClipCount()` を再実装: 全 Remix btn からカードルートを解決し、`isVisible(card) && isClipGenerating(card)` で in-flight 判定（重複排除）
6. `waitForGeneration()` / `waitForQueueSlot()` / `waitForInFlightIncrease()` のロジック本体は変更しない（新関数を呼ぶだけで shape 不変）
7. `resolveFields()` / `resolveGenerateButton()` / `isQueueLimitErrorVisible()` / `detectRecaptcha()` は変更しない（実機検証で現行 UI でも hit することを確認済み）
8. fail-loud 方針を継続: Remix btn が 0 件など解決不能なら throw（silent 続行禁止）
9. 単体テスト (Vitest) で新 `findCardRoot` / `isClipGenerating` / `getInFlightClipCount` のロジックを fixture HTML で検証する
10. e2e テスト (Playwright) の Suno UI mock を新 DOM 構造（Remix btn 含む card root）に合わせて更新する
11. `pnpm -C extensions/suno-helper build` が通り、unpacked load → `/suno` プロンプトサーバー → 連続実行で in-flight 制御が機能することを実機確認する

## スコープ外

- `Play X from start` の `<div role="button">` 化は in-flight 判定には不要なため対応しない（別 issue 候補）
- 「2 clip 別完了」最適化（片方完了で次投入許可）は別 issue 候補
- captcha 検知は実機再現できなかったため selector 維持のみ（DOM 変更が確認されてから別 issue で対応）
- `waitForInFlightIncrease()` の timeout 値見直しは、現行値が十分なら本 issue でカバー、不足なら別 issue へ切り出す

## 受け入れ基準

- [ ] \`pnpm -C extensions/suno-helper test\` (Vitest) が新セレクタ単体テストで全 pass
- [ ] \`pnpm -C extensions/suno-helper test:e2e\` (Playwright) が更新済み mock で全 pass
- [ ] \`pnpm -C extensions/suno-helper build\` が通る
- [ ] unpacked load 状態で 11+ リクエスト連続投入を試みても queue 上限を踏まずに自動制御される
- [ ] queue 上限を踏んだ場合は \`isQueueLimitErrorVisible()\` で検知して投入を一時停止し、popup に警告が出る

## 関連

- 元々の testid 導入: #816
- queue limit toast 対応: #847
- in-flight 増分検証: #864
- 直前の suno-helper fix: #862 / #859 / #858

## 実装方針（takt）

- workflow: \`default\`
- 理由: 複数ファイル変更（shared/dom.ts + tests）。新セレクタの unit test 先行で書いて挙動を検証してから content.ts 側の動作確認をする流れが妥当。fail-loud + 実機検証が必要なため fail-safe 寄りで default を選択

## Execution Report

Workflow `default` completed successfully.

Closes #866