### PR TITLE
[#875] issue-875-feat-suno-helper-pur

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -51,6 +51,71 @@ export const INJECT_ACK_TIMEOUT_MS = 30000;
  * これを超えても in-flight が増えなければ fail-loud で ERROR phase に落とす。 */
 export const MAX_INJECT_RETRY = 2;
 
+/** 速度プリセットの選択値を保存する chrome.storage.local の key (#875)。
+ * popup（書込）と content（読込）が同一 key を参照するため、契約文字列としてここを SSOT とする。 */
+export const SPEED_PRESET_STORAGE_KEY = "sunoSpeedPreset";
+
+/** 速度プリセットの識別子 (#875)。SPEED_PRESETS の key と 1:1 で対応する。 */
+export type SpeedPresetId = "fast" | "balanced" | "safe";
+
+/**
+ * 連続実行のペーシング 1 段分の設定 (#875)。Cloudflare bot management + hCaptcha 連動による
+ * silent drop / ban リスクを、間隔・並列数・retry 回数の保守度で調整する。
+ *   - interCreateDelayMs: Create 投入間の基準待機。jitterMs で散らして bot 判定の固定間隔シグナルを消す
+ *   - jitterMs: 待機の振れ幅 (±)。0 なら固定間隔（Fast）
+ *   - maxInflightRequests: 同時に積む生成リクエスト上限。低いほど人間らしい
+ *   - maxInjectRetry: silent drop 時の同一 entry 再投入上限。0 なら即諦めて分割実行へ委ねる
+ *   - injectAckTimeoutMs: inject 受理（in-flight 増分）待ちの上限
+ *   - label / riskNote: popup の実行モード選択 UI 表示用（要件6: 選択時のリスク認識を促す）
+ */
+export interface SpeedPreset {
+  interCreateDelayMs: number;
+  jitterMs: number;
+  maxInflightRequests: number;
+  maxInjectRetry: number;
+  injectAckTimeoutMs: number;
+  label: string;
+  riskNote: string;
+}
+
+/**
+ * 速度プリセット 3 段 (#875)。値の SSOT は order.md の表。
+ * Fast は現状定数 (INTER_CREATE_DELAY_MS / MAX_INFLIGHT_REQUESTS / MAX_INJECT_RETRY / INJECT_ACK_TIMEOUT_MS)
+ * を参照し「現状と同等の所要時間」を担保する（残置定数と preset 値の drift を回避）。
+ */
+export const SPEED_PRESETS: Record<SpeedPresetId, SpeedPreset> = {
+  fast: {
+    interCreateDelayMs: INTER_CREATE_DELAY_MS,
+    jitterMs: 0,
+    maxInflightRequests: MAX_INFLIGHT_REQUESTS,
+    maxInjectRetry: MAX_INJECT_RETRY,
+    injectAckTimeoutMs: INJECT_ACK_TIMEOUT_MS,
+    label: "⚡ Fast",
+    riskNote:
+      "〜10 entries の小 collection 向け。現状値。連続実行が長引くと bot 判定で silent drop しやすい。",
+  },
+  balanced: {
+    interCreateDelayMs: 10000,
+    jitterMs: 3000,
+    maxInflightRequests: 5,
+    maxInjectRetry: 1,
+    injectAckTimeoutMs: 45000,
+    label: "⚖️ Balanced",
+    riskNote:
+      "20-30 entries の標準 collection 向け。10s ±3s 間隔で自然化したデフォルト。",
+  },
+  safe: {
+    interCreateDelayMs: 20000,
+    jitterMs: 5000,
+    maxInflightRequests: 3,
+    maxInjectRetry: 0,
+    injectAckTimeoutMs: 60000,
+    label: "🐢 Safe",
+    riskNote:
+      "30+ entries / 過去に hCaptcha challenge を踏んだ場合向け。20s ±5s と保守的で時間はかかる。",
+  },
+};
+
 /** ローカル配信元の既定 URL。 */
 export const DEFAULT_URL = "http://localhost:7873";
 

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -234,16 +234,33 @@ export async function injectAdvancedFields(
 }
 
 /**
- * 可視な recaptcha / hcaptcha challenge iframe を検知する（#810）。
+ * active な recaptcha / hcaptcha challenge iframe を検知する（#810, #875）。
  * Suno は hCaptcha challenge を非表示プリロード iframe として常駐させるため、
- * querySelector の hit だけでは常に true になってしまう。strict 可視判定で
- * 実 challenge UI が表示された時のみ true を返す。
+ * querySelector の hit だけでは常に true になってしまう。
+ *
+ * #875 で判明した中間状態: silent drop タイミングで iframe の `title` が `""` →
+ * `"hCaptchaチャレンジ"` に変化するが `visibility:hidden` は維持される。従来の strict
+ * `isVisible()` だけでは visibility:hidden で false となり silent drop に流れていた。
+ * そこで bbox を持つ（プリロードでない）iframe の `title` が non-empty なら、visibility に
+ * 関わらず active challenge とみなす。title が空のときのみ従来の strict 可視判定へ fallback する。
  */
 export function detectRecaptcha(): boolean {
   const iframes = document.querySelectorAll<HTMLIFrameElement>(
     SELECTORS.recaptcha,
   );
-  return Array.from(iframes).some((f) => isVisible(f));
+  return Array.from(iframes).some((f) => {
+    // bbox 0 のプリロード iframe は title を持っていても active ではない（title 判定より優先）。
+    const rect = f.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      return false;
+    }
+    // title が non-empty = challenge が起動した中間状態。visibility:hidden を許容して捕捉する (#875)。
+    if (f.title.trim().length > 0) {
+      return true;
+    }
+    // title 空はプリロード iframe。従来通り strict 可視判定で実 challenge 表示時のみ true (#810)。
+    return isVisible(f);
+  });
 }
 
 /**

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -1,6 +1,9 @@
-import { DEFAULT_URL } from "../../shared/constants";
+import { DEFAULT_URL, SPEED_PRESETS, type SpeedPresetId } from "../../shared/constants";
 import { PatternList } from "./PatternList";
 import { useSunoRunner } from "./useSunoRunner";
+
+// 実行モード selector の表示順 (#875)。Fast → Balanced → Safe で速度順に並べる。
+const SPEED_PRESET_ORDER: SpeedPresetId[] = ["fast", "balanced", "safe"];
 
 export function App() {
   const {
@@ -22,6 +25,8 @@ export function App() {
     setRangeStart,
     rangeEnd,
     setRangeEnd,
+    speedPresetId,
+    setSpeedPreset,
     resumeBanner,
     acceptResume,
     dismissResume,
@@ -131,6 +136,28 @@ export function App() {
             />
           </div>
         )}
+      </fieldset>
+
+      <fieldset className="flex flex-col gap-2 rounded border border-gray-200 px-2 py-2 text-sm">
+        <legend className="px-1 text-xs text-gray-600">実行モード</legend>
+        {SPEED_PRESET_ORDER.map((id) => {
+          const preset = SPEED_PRESETS[id];
+          return (
+            <label key={id} className="flex items-start gap-2">
+              <input
+                type="radio"
+                name="speed-preset"
+                className="mt-1"
+                checked={speedPresetId === id}
+                onChange={() => setSpeedPreset(id)}
+              />
+              <span className="flex flex-col">
+                <span className="font-medium">{preset.label}</span>
+                <span className="text-xs text-gray-500">{preset.riskNote}</span>
+              </span>
+            </label>
+          );
+        })}
       </fieldset>
 
       <div className="flex gap-2">

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -13,8 +13,9 @@ import {
   pickInitialCollectionId,
   type PromptEntry,
 } from "../../shared/api";
-import { type ItemState, PHASE } from "../../shared/constants";
+import { type ItemState, PHASE, type SpeedPresetId } from "../../shared/constants";
 import { onMessage, sendMessage } from "../lib/messaging";
+import { DEFAULT_SPEED_PRESET_ID, readSpeedPresetId, writeSpeedPresetId } from "../lib/preset-state";
 import {
   readResumeState,
   type ResumeBanner,
@@ -53,6 +54,9 @@ interface RunnerState {
   setRangeStart: (value: string) => void;
   rangeEnd: string;
   setRangeEnd: (value: string) => void;
+  // 速度プリセット (#875)。実行モード selector の選択値。永続化は setSpeedPreset 内で行う。
+  speedPresetId: SpeedPresetId;
+  setSpeedPreset: (id: SpeedPresetId) => void;
   // 再開バナー (#872)。chrome.storage / content snapshot いずれか有効なソース、無ければ null。
   resumeBanner: ResumeBanner | null;
   acceptResume: () => void;
@@ -82,6 +86,8 @@ export function useSunoRunner(): RunnerState {
   const [rangeMode, setRangeMode] = useState<RangeMode>("all");
   const [rangeStart, setRangeStart] = useState("");
   const [rangeEnd, setRangeEnd] = useState("");
+  // 速度プリセット (#875)。マウント時に storage から復元し、選択時に永続化する。初期値は既定 (Balanced)。
+  const [speedPresetId, setSpeedPresetId] = useState<SpeedPresetId>(DEFAULT_SPEED_PRESET_ID);
   // chrome.storage から読んだ前回の ERROR 停止 state (#872)。表示可否は selectedCollectionId と時刻で判定する。
   const [persistedResume, setPersistedResume] = useState<ResumeState | null>(null);
   // resume state を読んだ popup 起動時刻 (#872)。stale 判定の基準 now をここで一度だけ確定し、
@@ -143,6 +149,17 @@ export function useSunoRunner(): RunnerState {
       setPersistedResume(state);
       setResumeCheckedAt(Date.now());
     });
+  }, []);
+
+  // popup 起動時に永続化済みの速度プリセットを復元する (#875 要件2)。
+  useEffect(() => {
+    void readSpeedPresetId().then(setSpeedPresetId);
+  }, []);
+
+  // 速度プリセットの選択を即時永続化する (#875 要件2)。content は run 開始時に storage から読む。
+  const setSpeedPreset = useCallback((id: SpeedPresetId) => {
+    setSpeedPresetId(id);
+    void writeSpeedPresetId(id);
   }, []);
 
   const dismissResume = useCallback(() => {
@@ -327,6 +344,8 @@ export function useSunoRunner(): RunnerState {
     setRangeStart,
     rangeEnd,
     setRangeEnd,
+    speedPresetId,
+    setSpeedPreset,
     resumeBanner,
     acceptResume,
     dismissResume,

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -3,10 +3,6 @@
 import type { PromptEntry } from "../../shared/api";
 import {
   CLIPS_PER_REQUEST,
-  INJECT_ACK_TIMEOUT_MS,
-  INTER_CREATE_DELAY_MS,
-  MAX_INFLIGHT_REQUESTS,
-  MAX_INJECT_RETRY,
   PHASE,
   type ProgressPayload,
   QUEUE_ERROR_WAIT_MS,
@@ -15,6 +11,7 @@ import {
   SUNO_MATCHES,
 } from "../../shared/constants";
 import { applyProgress, initSnapshot } from "../lib/snapshot";
+import { applyJitter, readSpeedPresetId, resolveSpeedPreset } from "../lib/preset-state";
 import { clearResumeStateForCollection, type RunRange, writeResumeState } from "../lib/resume-state";
 import { injectWithVerification } from "../lib/inject-retry";
 import {
@@ -42,9 +39,6 @@ import {
   waitForPlaylistDialogClose,
 } from "../../shared/playlist-dom";
 import { onMessage, sendMessage } from "../lib/messaging";
-
-/** Suno 同時生成キューに積める clip 数の上限（10 リクエスト × 2 clip = 20）。 */
-const MAX_GENERATING_CLIPS = MAX_INFLIGHT_REQUESTS * CLIPS_PER_REQUEST;
 
 export default defineContentScript({
   matches: [...SUNO_MATCHES],
@@ -148,6 +142,11 @@ export default defineContentScript({
 
     async function runAll(entries: PromptEntry[], options: RunOptions): Promise<void> {
       const { range, collectionId, playlistName } = options;
+      // 速度プリセット (#875) を run 開始時に確定する。以降のペーシング（間隔/並列数/retry/ack）は
+      // 既存定数の代わりにこの preset 値を使う。未選択でも storage fallback で Balanced になる。
+      const preset = resolveSpeedPreset(await readSpeedPresetId());
+      // Suno 同時生成キューに積める clip 数の上限（preset の並列リクエスト数 × 2 clip）。
+      const maxGeneratingClips = preset.maxInflightRequests * CLIPS_PER_REQUEST;
       const total = entries.length;
       const startIndex = range ? range.start : 0;
       const endIndex = range ? range.end : total - 1;
@@ -169,7 +168,7 @@ export default defineContentScript({
         try {
           // Suno のキュー上限（20 clip）を超えると後続が silent fail するため、投入前に空きを待つ。
           emitProgress({ phase: PHASE.WAITING_SLOT, index: i, total });
-          await waitForQueueSlot(MAX_GENERATING_CLIPS, {
+          await waitForQueueSlot(maxGeneratingClips, {
             isAborted: () => aborted,
             pollIntervalMs: POLL_INTERVAL_MS,
             // queue 空き待ちは single clip 完了待ち (GENERATE_TIMEOUT_MS) とは別系統の 5 分 (#864 root cause 1)。
@@ -189,8 +188,8 @@ export default defineContentScript({
             waitForInFlightIncrease,
             isAborted: () => aborted,
             clipsPerRequest: CLIPS_PER_REQUEST,
-            maxRetry: MAX_INJECT_RETRY,
-            ackTimeoutMs: INJECT_ACK_TIMEOUT_MS,
+            maxRetry: preset.maxInjectRetry,
+            ackTimeoutMs: preset.injectAckTimeoutMs,
             pollIntervalMs: POLL_INTERVAL_MS,
             describeEntry: () => `entry ${i} (${entries[i].title ?? entries[i].name})`,
           });
@@ -201,7 +200,8 @@ export default defineContentScript({
           }
           emitProgress({ phase: PHASE.DONE, index: i, total });
           // Create→clip-row DOM 反映ラグによる過剰投入 (race) を避けるため、次の投入前に間隔を空ける (#847)。
-          await abortableSleep(INTER_CREATE_DELAY_MS, () => aborted);
+          // preset の基準間隔に ±jitter を加えて bot 判定の固定間隔シグナルを消す (#875)。毎回 fresh 算出する。
+          await abortableSleep(applyJitter(preset.interCreateDelayMs, preset.jitterMs), () => aborted);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           emitProgress({ phase: PHASE.ERROR, index: i, total, message });

--- a/extensions/suno-helper/lib/preset-state.ts
+++ b/extensions/suno-helper/lib/preset-state.ts
@@ -1,0 +1,65 @@
+// 速度プリセット (#875) の解決・jitter 算出・chrome.storage I/O を 1 箇所に集約する。
+//
+// 純関数 (resolveSpeedPreset / applyJitter) と既定 id (DEFAULT_SPEED_PRESET_ID) は content / popup の
+// 双方が import する SSOT。I/O (readSpeedPresetId / writeSpeedPresetId) は @wxt-dev/storage の型付き
+// wrapper で chrome.storage.local を読み書きする。storage.defineItem は呼ぶと内部で chrome.runtime へ
+// アクセスするため、node 環境 (vitest) で純関数だけを import したときに副作用を起こさないよう遅延生成する
+// (純関数テスト preset-state.test.ts を壊さないため。resume-state.ts と同方針)。
+import { storage } from "wxt/utils/storage";
+
+import { SPEED_PRESET_STORAGE_KEY, SPEED_PRESETS, type SpeedPreset, type SpeedPresetId } from "../../shared/constants";
+
+export type { SpeedPresetId };
+
+/** 既定の速度プリセット (要件2: デフォルトは Balanced)。 */
+export const DEFAULT_SPEED_PRESET_ID: SpeedPresetId = "balanced";
+
+/**
+ * preset id を SpeedPreset へ解決する (要件3)。
+ * 未知の id は silent に既定 preset へ落とさず throw する（設定取り違えを fail-loud で検出）。
+ */
+export function resolveSpeedPreset(id: SpeedPresetId): SpeedPreset {
+  const preset = SPEED_PRESETS[id];
+  if (!preset) {
+    throw new Error(`不正な速度プリセット id: ${id}`);
+  }
+  return preset;
+}
+
+/**
+ * 基準待機 baseMs に ±jitterMs の振れを加える (要件3/7)。
+ * `baseMs + (random()*2-1)*jitterMs` で [base-jitter, base+jitter] に分布させる。jitterMs=0 なら base 固定。
+ * random は DI 可能（テストで min/max を pin する）。production の content からは省略呼び出しで Math.random を使う。
+ */
+export function applyJitter(baseMs: number, jitterMs: number, random: () => number = Math.random): number {
+  return baseMs + (random() * 2 - 1) * jitterMs;
+}
+
+// --- chrome.storage.local I/O（storage item は遅延生成。理由はファイル冒頭コメント参照） ---
+
+// fallback 付き defineItem の型は実呼び出しから推論する（getValue が SpeedPresetId を返す
+// fallback 版オーバーロードに解決させるため。型引数 + ReturnType だと null 込みの版に解決してしまう）。
+function createPresetItem() {
+  return storage.defineItem<SpeedPresetId>(`local:${SPEED_PRESET_STORAGE_KEY}`, {
+    fallback: DEFAULT_SPEED_PRESET_ID,
+  });
+}
+
+let cachedItem: ReturnType<typeof createPresetItem> | null = null;
+
+function presetItem(): ReturnType<typeof createPresetItem> {
+  if (!cachedItem) {
+    cachedItem = createPresetItem();
+  }
+  return cachedItem;
+}
+
+/** 永続化済みの preset id を読む。未設定は既定 (Balanced)。 */
+export async function readSpeedPresetId(): Promise<SpeedPresetId> {
+  return presetItem().getValue();
+}
+
+/** popup の選択を永続化する (要件2)。 */
+export async function writeSpeedPresetId(id: SpeedPresetId): Promise<void> {
+  await presetItem().setValue(id);
+}

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -18,6 +18,8 @@ import {
   PROMPTS_ROUTE,
   QUEUE_ERROR_WAIT_MS,
   QUEUE_SLOT_WAIT_TIMEOUT_MS,
+  SPEED_PRESET_STORAGE_KEY,
+  SPEED_PRESETS,
   STORAGE_KEY,
 } from "../../shared/constants";
 
@@ -117,5 +119,77 @@ describe("shared/constants: inject 検証 + queue 待機 timeout 独立化 (#864
   it("Given MAX_INJECT_RETRY When 読む Then silent drop 時の最大 retry 回数 2 である", () => {
     // #864 root cause 3: ack されなければ同じ entry を最大 2 回 retry、それでも増えなければ fail-loud。
     expect(MAX_INJECT_RETRY).toBe(2);
+  });
+});
+
+describe("shared/constants: 速度プリセット (#875)", () => {
+  // 契約 (draft が実装する public API, shared/constants.ts):
+  //   - SPEED_PRESET_STORAGE_KEY: string = "sunoSpeedPreset"
+  //   - SPEED_PRESETS: Record<"fast"|"balanced"|"safe", SpeedPreset>
+  //     SpeedPreset = { interCreateDelayMs; jitterMs; maxInflightRequests;
+  //                     maxInjectRetry; injectAckTimeoutMs; label; riskNote }
+  // 値の SSOT は order.md L23-27 の表。Fast は現状定数を残置し参照する（現状と同等を担保）。
+
+  it("Given SPEED_PRESET_STORAGE_KEY When 読む Then chrome.storage.local の preset key である", () => {
+    expect(SPEED_PRESET_STORAGE_KEY).toBe("sunoSpeedPreset");
+  });
+
+  it("Given SPEED_PRESETS When key を読む Then fast / balanced / safe の 3 preset を持つ", () => {
+    expect(Object.keys(SPEED_PRESETS).sort()).toEqual(["balanced", "fast", "safe"]);
+  });
+
+  it("Given fast preset When 数値を読む Then 現状定数と一致する（現状と同等, jitter なし）", () => {
+    // 受け入れ基準「Fast 選択時の所要時間が現状と同等」。既存定数を Fast から参照する設計を pin し、
+    // 残置定数と preset 値の drift を回帰ガードする。
+    expect(SPEED_PRESETS.fast.interCreateDelayMs).toBe(INTER_CREATE_DELAY_MS);
+    expect(SPEED_PRESETS.fast.jitterMs).toBe(0);
+    expect(SPEED_PRESETS.fast.maxInflightRequests).toBe(MAX_INFLIGHT_REQUESTS);
+    expect(SPEED_PRESETS.fast.maxInjectRetry).toBe(MAX_INJECT_RETRY);
+    expect(SPEED_PRESETS.fast.injectAckTimeoutMs).toBe(INJECT_ACK_TIMEOUT_MS);
+  });
+
+  it("Given balanced preset When 数値を読む Then 10s / ±3s / inflight 5 / retry 1 / ack 45s", () => {
+    expect(SPEED_PRESETS.balanced).toMatchObject({
+      interCreateDelayMs: 10000,
+      jitterMs: 3000,
+      maxInflightRequests: 5,
+      maxInjectRetry: 1,
+      injectAckTimeoutMs: 45000,
+    });
+  });
+
+  it("Given safe preset When 数値を読む Then 20s / ±5s / inflight 3 / retry 0 / ack 60s", () => {
+    expect(SPEED_PRESETS.safe).toMatchObject({
+      interCreateDelayMs: 20000,
+      jitterMs: 5000,
+      maxInflightRequests: 3,
+      maxInjectRetry: 0,
+      injectAckTimeoutMs: 60000,
+    });
+  });
+
+  it.each(["fast", "balanced", "safe"] as const)(
+    "Given %s preset When label / riskNote を読む Then 非空文字列を持つ（UI 表示用, 要件6）",
+    (id) => {
+      // label/riskNote が write-only な空フィールドへ退行しないことを担保（文言そのものは pin しない）。
+      expect(typeof SPEED_PRESETS[id].label).toBe("string");
+      expect(SPEED_PRESETS[id].label.length).toBeGreaterThan(0);
+      expect(typeof SPEED_PRESETS[id].riskNote).toBe("string");
+      expect(SPEED_PRESETS[id].riskNote.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("Given balanced preset When jitter 適用域を求める Then 7000〜13000ms（受け入れ基準 7-13s）", () => {
+    // applyJitter の min/max は preset-state.test.ts で検証。ここでは preset 値が
+    // 受け入れ基準の範囲を表現できることだけを確認する。
+    const { interCreateDelayMs: base, jitterMs } = SPEED_PRESETS.balanced;
+    expect(base - jitterMs).toBe(7000);
+    expect(base + jitterMs).toBe(13000);
+  });
+
+  it("Given safe preset When jitter 適用域を求める Then 15000〜25000ms（受け入れ基準 15-25s）", () => {
+    const { interCreateDelayMs: base, jitterMs } = SPEED_PRESETS.safe;
+    expect(base - jitterMs).toBe(15000);
+    expect(base + jitterMs).toBe(25000);
   });
 });

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -386,10 +386,11 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
       expect(detectRecaptcha()).toBe(false);
     });
 
-    it("Given visibility:hidden だが 300×150 の hCaptcha iframe (実 DOM iframe[4]) When 検知する Then false", () => {
+    it("Given visibility:hidden + title 無しの hCaptcha プリロード iframe (300×150) When 検知する Then false (誤検知防止の核心)", () => {
+      // #875: title が空のプリロード iframe は active challenge ではない。従来 strict isVisible で false。
+      // title が non-empty になった瞬間だけ active 判定する遷移は別 describe (title 判定の 4 組合せ) で検証。
       addCaptchaIframe({
         src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
-        title: "hCaptchaチャレンジ",
         visibility: "hidden",
         width: 300,
         height: 150,
@@ -432,7 +433,9 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
   });
 
   describe("order.md 実 DOM シナリオの回帰ガード", () => {
-    it("Given 非表示プリロード iframe 2 個 (display:none + visibility:hidden) のみ When 検知する Then false (challenge 未表示時)", () => {
+    it("Given 非表示プリロード iframe 2 個 (display:none + visibility:hidden, title 無し) のみ When 検知する Then false (challenge 未表示時)", () => {
+      // #875: title 無しのプリロード iframe は active challenge ではない。title が non-empty に
+      // なった瞬間の active 判定 (visibility:hidden 許容) は「title 判定の 4 組合せ」describe で担保する。
       addCaptchaIframe({
         src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/0",
         display: "none",
@@ -441,7 +444,6 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
       });
       addCaptchaIframe({
         src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/4",
-        title: "hCaptchaチャレンジ",
         visibility: "hidden",
         width: 300,
         height: 150,
@@ -471,6 +473,49 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
       });
 
       expect(detectRecaptcha()).toBe(true);
+    });
+  });
+
+  describe("title 判定による active challenge 検知の 4 組合せ (#875)", () => {
+    // #875: hCaptcha iframe の title が non-empty になった瞬間を active challenge とみなし、
+    // visibility:hidden の中間状態でも捕捉する。title 空のときのみ従来 strict isVisible へ fallback。
+    // 真因: silent drop タイミングで title が "" → "hCaptchaチャレンジ" に変化するが visibility:hidden は
+    // 維持されるため、従来 strict isVisible では false で素通りしていた。
+    const HCAPTCHA_SRC = "https://hcaptcha-assets-prod.suno.com/captcha/v1/x";
+
+    it("Given title 空 × visible When 検知する Then true (従来 strict isVisible 経路)", () => {
+      addCaptchaIframe({ src: HCAPTCHA_SRC, width: 300, height: 150 });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given title 空 × visibility:hidden When 検知する Then false (プリロード誤検知防止)", () => {
+      addCaptchaIframe({ src: HCAPTCHA_SRC, visibility: "hidden", width: 300, height: 150 });
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given title 非空 × visible When 検知する Then true (active challenge)", () => {
+      addCaptchaIframe({ src: HCAPTCHA_SRC, title: "hCaptchaチャレンジ", width: 300, height: 150 });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given title 非空 × visibility:hidden When 検知する Then true (#875 隠れ challenge を捕捉)", () => {
+      // 本 issue の核心ケース: title="hCaptchaチャレンジ" だが visibility:hidden の中間状態。
+      // 従来 false で silent drop に流れていたのを true で ack timeout 前に捕捉して即停止する。
+      addCaptchaIframe({
+        src: HCAPTCHA_SRC,
+        title: "hCaptchaチャレンジ",
+        visibility: "hidden",
+        width: 300,
+        height: 150,
+      });
+      expect(detectRecaptcha()).toBe(true);
+    });
+
+    it("Given title 非空 だが bbox 0×0 When 検知する Then false (bbox 判定を title より優先)", () => {
+      // bbox 0 チェックを title 判定より前に置く。0×0 のプリロード iframe が title を持っていても
+      // 誤検知しない（既存 bbox 0×0 ケースと整合）。
+      addCaptchaIframe({ src: HCAPTCHA_SRC, title: "hCaptchaチャレンジ", width: 0, height: 0 });
+      expect(detectRecaptcha()).toBe(false);
     });
   });
 

--- a/extensions/suno-helper/tests/e2e/suno-speed-preset.spec.ts
+++ b/extensions/suno-helper/tests/e2e/suno-speed-preset.spec.ts
@@ -1,0 +1,46 @@
+// 要件8 (#875): Safe preset 選択時の連続実行 INTER_CREATE_DELAY が 15s 以上であることを
+// 実ブラウザ文脈で検証する E2E スモーク (実 Suno 非依存)。
+//
+// content script は manifest の matches (`https://suno.com/*`) でしか注入されず、Playwright の
+// page.evaluate は本番モジュール (`lib/preset-state.ts` / `entrypoints/content.ts`) を import
+// できない（既存 suno-range.spec.ts / suno-inject.spec.ts と同じ制約）。よってここでは
+// applyJitter (baseMs + (random()*2-1)*jitterMs) と SPEED_PRESETS.safe 値、および runAll の
+// 「毎 iteration で applyJitter(preset.interCreateDelayMs, preset.jitterMs) を fresh 算出する」
+// 手法を inline 再現し、Safe preset の delay が常に 15s 以上（15000〜25000ms）になることを示す。
+// 本番関数自体の回帰は unit (preset-state.test.ts / constants.test.ts) が担う。
+import { expect, test } from "@playwright/test";
+
+test("Safe preset の連続実行 INTER_CREATE_DELAY が常に 15s 以上である (#875 受け入れ基準)", async ({ page }) => {
+  await page.setContent("<!doctype html><html><body></body></html>");
+
+  const result = await page.evaluate(() => {
+    // --- 本番 shared/constants.ts SPEED_PRESETS.safe と同値を inline 再現 ---
+    const safe = { interCreateDelayMs: 20000, jitterMs: 5000 };
+
+    // --- 本番 lib/preset-state.ts applyJitter と同手法を inline 再現 ---
+    const applyJitter = (baseMs: number, jitterMs: number, random: () => number = Math.random): number =>
+      baseMs + (random() * 2 - 1) * jitterMs;
+
+    // --- 本番 content.ts runAll の「毎 iteration で delay を fresh 算出」を inline 再現 ---
+    // 各 entry 投入後に abortableSleep(applyJitter(preset.interCreateDelayMs, preset.jitterMs)) を呼ぶ。
+    const delays: number[] = [];
+    for (let i = 0; i < 200; i++) {
+      delays.push(applyJitter(safe.interCreateDelayMs, safe.jitterMs));
+    }
+
+    // 境界の確定値も併せて検証用に算出する（random の DI で min/max を pin）。
+    const min = applyJitter(safe.interCreateDelayMs, safe.jitterMs, () => 0);
+    const max = applyJitter(safe.interCreateDelayMs, safe.jitterMs, () => 1);
+
+    return { delays, min, max };
+  });
+
+  // 受け入れ基準: Safe 選択時の INTER_CREATE_DELAY が 15s 以上。jitter 下限でも 15000ms を割らない。
+  for (const delay of result.delays) {
+    expect(delay).toBeGreaterThanOrEqual(15000);
+    expect(delay).toBeLessThanOrEqual(25000);
+  }
+  // jitter 域の確定境界: random=0 → 15000ms（15s 以上の下限）、random=1 → 25000ms。
+  expect(result.min).toBe(15000);
+  expect(result.max).toBe(25000);
+});

--- a/extensions/suno-helper/tests/preset-state.test.ts
+++ b/extensions/suno-helper/tests/preset-state.test.ts
@@ -1,0 +1,97 @@
+// lib/preset-state.ts の純ロジック回帰テスト (#875)。
+//
+// preset-state は「速度設定の解決・jitter 算出・永続化」を集約する。Vitest env は node
+// (chrome モック無し, vitest.config.ts) のため、storage.defineItem を包む I/O
+// (readSpeedPresetId / writeSpeedPresetId) はここでは検証せず、node でテスト可能な純関数のみを
+// tester surface とする（既存 resume-state.test.ts / storage.ts が storage I/O を untested とする
+// のと同方針）。
+//   - DEFAULT_SPEED_PRESET_ID: 既定 preset（要件2: デフォルトは Balanced）
+//   - resolveSpeedPreset: id → SpeedPreset の解決（不正 id は fail-loud で throw）。要件3
+//   - applyJitter: baseMs + (random()*2-1)*jitterMs の純関数。random を DI して min/max を pin。要件3/7
+//
+// 契約 (draft が実装する public API, suno-helper/lib/preset-state.ts):
+//   type SpeedPresetId = "fast" | "balanced" | "safe";
+//   const DEFAULT_SPEED_PRESET_ID: SpeedPresetId;  // = "balanced"
+//   function resolveSpeedPreset(id: SpeedPresetId): SpeedPreset;  // = SPEED_PRESETS[id]、不正 id は throw
+//   function applyJitter(baseMs: number, jitterMs: number, random?: () => number): number;
+//     = baseMs + (random()*2-1)*jitterMs。random 既定は Math.random（content から省略呼び出し）。
+import { describe, expect, it } from "vitest";
+
+import { SPEED_PRESETS } from "../../shared/constants";
+import { applyJitter, DEFAULT_SPEED_PRESET_ID, resolveSpeedPreset, type SpeedPresetId } from "../lib/preset-state";
+
+describe("DEFAULT_SPEED_PRESET_ID: 既定 preset (要件2)", () => {
+  it("Given 定数 When 読む Then balanced である（デフォルトは Balanced）", () => {
+    expect(DEFAULT_SPEED_PRESET_ID).toBe("balanced");
+  });
+});
+
+describe("resolveSpeedPreset: id → SpeedPreset の解決 (要件3)", () => {
+  it.each(["fast", "balanced", "safe"] as const)("Given id '%s' When 解決する Then SPEED_PRESETS[id] を返す", (id) => {
+    expect(resolveSpeedPreset(id)).toEqual(SPEED_PRESETS[id]);
+  });
+
+  it("Given 不正な id When 解決する Then throw する（fail-loud, silent fallback しない）", () => {
+    // 設定取り違えを silent に既定 preset へ落とさず、即エラーにする。
+    expect(() => resolveSpeedPreset("turbo" as SpeedPresetId)).toThrow();
+  });
+});
+
+describe("applyJitter: jitter 範囲の算出 (要件3/7)", () => {
+  describe("balanced (base=10000, jitter=±3000) → 受け入れ基準 7-13s", () => {
+    it("Given random=()=>0 When 算出 Then min = base - jitter = 7000", () => {
+      expect(applyJitter(10000, 3000, () => 0)).toBe(7000);
+    });
+
+    it("Given random=()=>1 When 算出 Then max = base + jitter = 13000", () => {
+      expect(applyJitter(10000, 3000, () => 1)).toBe(13000);
+    });
+
+    it("Given random=()=>0.5 When 算出 Then 中央 = base = 10000（jitter 0 寄与）", () => {
+      expect(applyJitter(10000, 3000, () => 0.5)).toBe(10000);
+    });
+  });
+
+  describe("safe (base=20000, jitter=±5000) → 受け入れ基準 15-25s", () => {
+    it("Given random=()=>0 When 算出 Then min = 15000", () => {
+      expect(applyJitter(20000, 5000, () => 0)).toBe(15000);
+    });
+
+    it("Given random=()=>1 When 算出 Then max = 25000", () => {
+      expect(applyJitter(20000, 5000, () => 1)).toBe(25000);
+    });
+  });
+
+  describe("fast (jitter=0) → 固定値（現状と同等）", () => {
+    it.each([0, 0.5, 1])("Given jitter=0, random=()=>%s When 算出 Then random によらず base を返す", (r) => {
+      expect(applyJitter(3000, 0, () => r)).toBe(3000);
+    });
+  });
+
+  describe("既定 random (Math.random) → jitter 域に収まる", () => {
+    // content.ts は applyJitter(preset.interCreateDelayMs, preset.jitterMs) を random 省略で呼ぶ
+    // （production 呼び出しは random を渡さない＝デフォルト引数の許容ケース）。
+    it("Given random 省略 When safe preset 値で多数サンプル Then 全て 15000〜25000ms に収まる", () => {
+      for (let i = 0; i < 1000; i++) {
+        const delay = applyJitter(20000, 5000);
+        expect(delay).toBeGreaterThanOrEqual(15000);
+        expect(delay).toBeLessThanOrEqual(25000);
+      }
+    });
+
+    it("Given random 省略 When balanced preset 値で多数サンプル Then 全て 7000〜13000ms に収まる", () => {
+      for (let i = 0; i < 1000; i++) {
+        const delay = applyJitter(10000, 3000);
+        expect(delay).toBeGreaterThanOrEqual(7000);
+        expect(delay).toBeLessThanOrEqual(13000);
+      }
+    });
+  });
+
+  it("Given SPEED_PRESETS.safe を直接渡す When applyJitter Then preset 値から 15000〜25000ms を生成する", () => {
+    // preset → applyJitter の配線（content.ts が runAll で行う計算）を preset 値そのもので検証する。
+    const preset = SPEED_PRESETS.safe;
+    expect(applyJitter(preset.interCreateDelayMs, preset.jitterMs, () => 0)).toBe(15000);
+    expect(applyJitter(preset.interCreateDelayMs, preset.jitterMs, () => 1)).toBe(25000);
+  });
+});

--- a/extensions/suno-helper/tests/ssot-dedup.test.ts
+++ b/extensions/suno-helper/tests/ssot-dedup.test.ts
@@ -24,7 +24,9 @@ describe("ssot-drift: popup の placeholder は DEFAULT_URL を参照する", ()
   });
 
   it("Given App.tsx When placeholder を読む Then 定数 DEFAULT_URL を参照する", () => {
-    expect(appSource).toMatch(/import \{ DEFAULT_URL \} from "\.\.\/\.\.\/shared\/constants"/);
+    // #875 で同 import に SPEED_PRESETS / SpeedPresetId が同居するため、named import の並びに
+    // 依存せず「DEFAULT_URL が shared/constants から来ている」ことだけを担保する（ガードの intent を保持）。
+    expect(appSource).toMatch(/import \{[^}]*\bDEFAULT_URL\b[^}]*\} from "\.\.\/\.\.\/shared\/constants"/);
     expect(appSource).toMatch(/placeholder=\{DEFAULT_URL\}/);
   });
 });


### PR DESCRIPTION
## Summary

## 概要

Cloudflare bot management + hCaptcha 連動による silent drop および将来の ban リスクを軽減するため、popup に 3 段速度プリセット (Fast/Balanced/Safe) を追加し、隠れた hCaptcha challenge（title=非空 + visibility:hidden の中間状態）を検知可能にする。

## 背景・目的

実機調査（本セッション）で entry 25 silent drop の真因が **Cloudflare bot management + hCaptcha 連動** であることを確定した。

決定的所見:
- silent drop タイミングで `challenges.cloudflare.com/cdn-cgi/...` POST 発火、`401` → `auth.suno.com/v1/client/verify` で token refresh
- 3 試行とも `/api/generate/v2-web/` が **1 件も発射されていない**(Suno React app が hCaptcha solve 待ちで API call を保留)
- hCaptcha iframe の `title` が `""` → `"hCaptchaチャレンジ"` に変化(baseline では空)
- ただし `visibility: hidden` は維持 → 現行 `detectRecaptcha()` の strict `isVisible()` で **false 判定** → throw されず silent drop に流れる

連続実行が長引くほど Suno+Cloudflare の bot score が下がり、challenge 発火率が上昇する。**ban されないこと** を最優先にすると、技術的な「silent drop が起きないこと」より「retry を強引にしないこと + pacing を保守的にすること」が本質。

## 提案する仕様

### 1. 速度プリセット 3 段（popup で選択 + chrome.storage に永続化）

| preset | INTER_CREATE_DELAY | jitter | MAX_INFLIGHT | MAX_RETRY | ACK_TIMEOUT | 想定用途 |
|---|---|---|---|---|---|---|
| ⚡ Fast | 3s | なし | 10 | 2 | 30s | 〜10 entries 小 collection。現状値 |
| ⚖️ Balanced（デフォルト） | 10s | ±3s | 5 | 1 | 45s | 20-30 entries 標準 |
| 🐢 Safe | 20s | ±5s | 3 | 0 | 60s | 30+ entries / ban 警告履歴あり |

各値の根拠:
- **INTER_CREATE_DELAY 3s → 10s/20s + jitter**: 固定 3s 間隔は bot 判定の典型シグナル。人間の最小操作間隔は ~10s。jitter で散らして自然化
- **MAX_INFLIGHT 10 → 5/3**: Suno UI 上限 10 を使い切るのは bot しかしない。並列 3 で「もたつくが普通の人間」
- **MAX_RETRY 2 → 1/0**: silent drop は Suno からの警告。強引な retry が ban トリガー。即諦めて分割実行に委ねる

### 2. hCaptcha challenge active 検知強化（preset 関係なく一律）

現行 `detectRecaptcha()` (extensions/shared/dom.ts:118) を拡張:

```ts
// 現行: visibility が hidden だと false
// 新規: iframe title が non-empty かつ bbox > 0 なら active 判定 (visibility:hidden を許容)
export function detectRecaptcha(): boolean {
  const iframes = document.querySelectorAll<HTMLIFrameElement>(SELECTORS.recaptcha);
  return Array.from(iframes).some((f) => {
    const rect = f.getBoundingClientRect();
    if (rect.width === 0 || rect.height === 0) return false;
    const hasTitle = (f.title ?? "").trim().length > 0;
    if (hasTitle) return true; // active challenge (visibility:hidden を許容)
    return isVisible(f); // 従来の strict 可視判定 (fallback)
  });
}
```

これで「title="hCaptchaチャレンジ" だが visibility:hidden」の中間状態を ack timeout 前に捕捉して即停止できる。

## ユースケース

1. **Fast**: 〜10 entries の試運用、過去 ban 履歴なし、急ぎ
2. **Balanced** (デフォルト): 20-30 entries の通常 collection
3. **Safe**: 30+ entries の大 collection、または過去に hCaptcha challenge を踏んだ user
4. **隠れ challenge 検知**: 連続実行中に hCaptcha が visibility:hidden で active になった瞬間に「hCaptcha challenge を検知しました。Suno タブで解決してから再開してください」を popup 表示（fail-loud 維持）

## 参照資料

- extensions/shared/constants.ts (既存タイマー定数、storage key 集約)
- extensions/shared/dom.ts (detectRecaptcha 拡張)
- extensions/shared/visibility.ts (isVisible 関数、参照のみ)
- extensions/suno-helper/lib/inject-retry.ts (maxRetry を runtime 値で受ける改修)
- extensions/suno-helper/entrypoints/content.ts (preset 値を runAll で適用、jitter 処理)
- extensions/suno-helper/entrypoints/popup/main.tsx (preset selector UI)
- extensions/suno-helper/lib/resume-state.ts (#872 で新規作成された storage 抽象化、preset key の同居)
- extensions/suno-helper/tests/

## 影響ファイル

- **変更**: extensions/shared/constants.ts (SPEED_PRESETS, SPEED_PRESET_STORAGE_KEY 追加。既存 INTER_CREATE_DELAY_MS / MAX_INFLIGHT_REQUESTS / MAX_INJECT_RETRY / INJECT_ACK_TIMEOUT_MS は Fast preset の値として残置 or 削除)
- **変更**: extensions/shared/dom.ts (detectRecaptcha を title 判定拡張)
- **変更**: extensions/suno-helper/entrypoints/popup/main.tsx (preset selector UI 追加 + 復元)
- **変更**: extensions/suno-helper/entrypoints/content.ts (preset 適用、jitter 処理)
- **変更**: extensions/suno-helper/lib/inject-retry.ts (maxRetry を引数経由で受ける、ハードコーディング撤廃)
- **変更**: extensions/suno-helper/lib/resume-state.ts (preset 読み書きを同居 / または新規 lib/preset-state.ts)
- **新規 or 変更**: extensions/suno-helper/tests/ (preset 適用、jitter 範囲、detectRecaptcha title 判定の単体テスト)

## 要件

1. `extensions/shared/constants.ts` に `SPEED_PRESETS` (Fast / Balanced / Safe) と `SPEED_PRESET_STORAGE_KEY` を追加し、各 preset は `{ interCreateDelayMs, jitterMs, maxInflightRequests, maxInjectRetry, injectAckTimeoutMs, label, riskNote }` を保持する
2. popup に「実行モード」セクションを追加し、3 ラジオ (Fast/Balanced/Safe) を選択可能にする。デフォルトは Balanced。選択は `chrome.storage.local` に永続化
3. content.ts は `runAll` 開始時に preset を読み込み、既存定数の代わりに preset 値を使う。`INTER_CREATE_DELAY_MS` は `preset.interCreateDelayMs + (Math.random() * 2 - 1) * preset.jitterMs` で jitter 化（jitter 0 なら固定値）
4. `inject-retry.ts::injectWithVerification` の `maxRetry` は引数で受ける（ハードコーディング撤廃、既に opts.maxRetry はあるが定数経由のためそのまま）
5. `dom.ts::detectRecaptcha()` を拡張: iframe `title` が non-empty かつ bbox > 0 なら true（visibility 不問）。title 空のときは従来通り strict `isVisible()` で判定
6. popup の「実行モード」セクションには各 preset の `label` + `riskNote` を表示（user が選択時のリスク認識を促す）
7. 単体テスト: 各 preset 適用、jitter 範囲（min/max）、`detectRecaptcha` の title 判定（title 空 / non-empty × visible / hidden の 4 組合せ）
8. e2e: Safe preset 選択 → 連続実行で INTER_CREATE_DELAY が 15s 以上であることを Playwright mock で 1 件追加

## スコープ外

- **collection サイズの上限警告**（20+ で popup 警告、分割推奨表示）は別 issue（複雑な UX 設計が必要）
- **silent drop / challenge 検知後の自動 cooldown**（再開ブロック、`chrome.storage.local` に `lastChallengeAt` timestamp 等）は別 issue（要件膨らみ大）
- **preset の advanced mode**（個別パラメータ fine-tuning UI）は別 issue（一般ユーザー要望が不明）
- **ban 対策の根本**（Suno との利用規約準拠交渉、別アカウント運用）は本 issue 対象外
- **#872 の範囲指定 UI**（PR #873 で merge 済み）と機能的に独立。preset で予防 + 検知強化、range UI で回復、の 3 段構えのうち本 issue は予防 + 検知

## 受け入れ基準

- [ ] popup で 3 preset を切替できる（デフォルト Balanced）
- [ ] preset 選択が popup を閉じても永続化される
- [ ] Fast 選択時の所要時間が現状と同等であること
- [ ] Balanced 選択時の INTER_CREATE_DELAY が 7-13s 範囲（±3s jitter）
- [ ] Safe 選択時の INTER_CREATE_DELAY が 15-25s 範囲（±5s jitter）
- [ ] hCaptcha iframe の title が non-empty になった瞬間に `detectRecaptcha()` が true を返す（実機検証）
- [ ] 既存単体テスト + 新規テスト全 pass

## 実装方針（takt）

- workflow: default
- 理由: feature 追加 + UI 改修 + 複数ファイル変更（shared/constants, shared/dom, popup, content, inject-retry, tests）。テスト先行で進めたい中規模タスク

## 関連

- silent drop 真因確定: 本セッションの調査結果
- 範囲指定 UI / 途中再開: #872 (PR #873, merge 済み)
- inject ack + retry 実装: #864
- queue-limit toast: #847
- DOM 検知再実装: #870 (merge 済み)
- captcha 検知: #810 (#870 で hCaptcha 含む selector 化済み)

## Execution Report

Workflow `default` completed successfully.

Closes #875