### PR TITLE
docs(skills): wf-new から /suno-helper への連携を明示化

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -116,7 +116,7 @@ Phase 1 の成果物を `20-documentation/` に保存:
         ```
    - それ以外のモード: `/thumbnail <theme>` を Agent で実行（テキストオーバーレイ生成。`/thumbnail` の品質チェック節で同等 QA が走る）
 4. **音楽素材生成**: Agent ツールで音楽エンジンに応じたスキルを実行:
-   - Suno: `/suno <theme>` を Skill ツールで実行（プロンプト生成）
+   - Suno: `/suno <theme>` を Skill ツールで実行（プロンプト生成のみ。実際の楽曲生成は `/suno-helper` で連続実行する）
      - **`/suno` 呼び出し前提条件チェック**（#571）: `config/skills/suno.yaml::genre_line` を読み、空のときは `config/channel/analytics.json::benchmark.channels[].slug` 全件について `data/video_analysis/<slug>/*.json` の存在を確認する。**両方とも未充足**（`genre_line` 空 AND 全 slug で分析結果不在）であれば `/suno` を起動せず、`uv run yt-video-analyze --source benchmark --channel <slug> --top 5` を先行実行するようユーザーに案内して Phase 2c を一旦停止する（`data/benchmark_*.json` が無ければさらにその前段で `/benchmark` を案内）。AI が `genre_line` を手書きで埋めて続行することは禁止
    - Lyria: `/lyria <theme>` を Skill ツールで実行（プロンプト設計のみ。Lyria 3 API 呼び出しは `/wf-next` で実行）
 5. `workflow-state.json` を更新:
@@ -162,10 +162,10 @@ Phase 1 の成果物を `20-documentation/` に保存:
    ```
 
    音楽エンジンに応じた次ステップ案内:
-   - **Suno**: 「`suno-prompts.md` のプロンプトを SunoAI に投入 → プレイリスト作成後 `/wf-next` を実行してください」
+   - **Suno**: 「`/suno-helper` を実行してください。`yt-collection-serve` で `suno-prompts.json` を配信 → suno-helper Chrome 拡張で Suno タブに連続注入 → 全件完了で playlist 一括追加まで自動。完了後に `/wf-next` を実行（plain Suno UI への手動投入は非推奨）」
    - **Lyria**: 「`/wf-next` を実行すると Lyria 3 API が呼ばれ、コレクション尺に応じてセグメントが生成されます → ミキシング+マスタリング後に再度 `/wf-next`」
 
-**重要**: `/wf-next` への自動接続はしない。ユーザーが手動で `/wf-next` を呼ぶ。
+**重要**: `/suno-helper` / `/wf-next` への自動接続はしない（`/suno-helper` は Chrome + Suno ログイン + 拡張ロードの physical 準備、`/wf-next` は次フェーズ進行の意思決定をそれぞれ user に委ねる）。ユーザーが手動で呼ぶ。
 
 ## 障害時ガイダンス
 
@@ -182,6 +182,7 @@ Phase 1 の成果物を `20-documentation/` に保存:
 - サムネイル生成: `/thumbnail` スキル
 - ループ動画生成: `/loop-video` スキル
 - 音楽プロンプト生成: `/suno` スキル
+- Suno UI への連続注入 + playlist 一括追加: `/suno-helper` スキル
 - 音楽プロンプト設計 + Lyria 3 API 呼び出し: `/lyria` スキル
 - 後続ステップ管理: `/wf-next`
 - 進捗確認: `/wf-status`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `docs(skills)`: `/wf-new` Phase 2c の Suno 分岐と Phase 2d 完了ガイダンスを `/suno-helper` 連携に書き換えた。Phase 2c で `/suno` の役割を「プロンプト生成のみ。実際の楽曲生成は `/suno-helper` で連続実行」と明示し、Phase 2d 完了ガイダンスの Suno 分岐を従来の「`suno-prompts.md` のプロンプトを SunoAI に投入 → プレイリスト作成後 `/wf-next`」から「`/suno-helper` を実行 → `yt-collection-serve` で `suno-prompts.json` を配信 → suno-helper Chrome 拡張で連続注入 → 全件完了で playlist 一括追加まで自動。完了後に `/wf-next`」に置き換えた。Cross References にも `/suno-helper` を追記。自動 invoke は引き続き行わない（Chrome + Suno ログイン + 拡張ロードの physical 準備が user 側にあり、`/wf-next` への自動接続を入れていない既存方針と整合）。Lyria 分岐は不変
+
 - `feat(suno-helper)`: `extractPlaylistName` (`shared/api.ts`) の命名規則を `<channel>-<theme>` から `<channel> | <theme>` (`|` の前後にスペース) へ変更し、シグネチャを `(collectionId, theme)` の 2 引数に変えた。channel 部分自体がハイフン区切り (例: `soulful-grooves`) になるチャンネルがあり、id 単体では channel と theme の境界を機械的に判定できなかったため、`/collections` レスポンスの `name` field (= 既に server 側で抽出済みの theme slug) を渡して逆向きに境界を確定する。検証ロジックは「末尾 `-collection` 剥がし → 末尾 `-<theme>` 照合 (不整合は fail-loud) → 残りを `-` 分割し parts[0] が 8 桁日付 + parts>=2 → channel = `parts.slice(1).join("-")` (空ならエラー) → `<channel> | <theme>` を返す」。例: `("20260601-rjn-dawn-cloud-fold-collection", "dawn-cloud-fold")` -> `"rjn | dawn-cloud-fold"`、`("20260520-soulful-grooves-midnight-mood-collection", "midnight-mood")` -> `"soulful-grooves | midnight-mood"`。popup の display only 表示と content script の Suno playlist 名注入はこの新形式をそのまま使う。呼び出し元 (`useSunoRunner.ts`) は collection summary から id + name の両方を渡すように更新。Vitest の `extract-playlist-name.test.ts` を新シグネチャ・新形式の expected に全面更新し、theme 空文字 / id-theme 不整合 / channel 空の新たな fail-loud 経路もカバーする
 
 ### Added


### PR DESCRIPTION
## Summary

`/wf-new` の Suno 経路を `/suno-helper`（PR #883 で追加）に橋渡しする運用ガイダンスへ更新。

## 変更点

- **Phase 2c Step 4 Suno 分岐**: `/suno` の役割を「プロンプト生成のみ。実際の楽曲生成は `/suno-helper` で連続実行」と明示
- **Phase 2d 完了ガイダンスの Suno 分岐**: 従来の「\`suno-prompts.md\` のプロンプトを SunoAI に投入 → プレイリスト作成後 \`/wf-next\`」から「\`/suno-helper\` を実行 → \`yt-collection-serve\` で \`suno-prompts.json\` を配信 → 拡張で連続注入 → playlist 一括追加 → \`/wf-next\`」に書き換え
- **重要事項**: \`/suno-helper\` への自動接続は入れない方針を明記（Chrome + Suno ログイン + 拡張ロードの physical 準備、`/wf-next` への自動接続を入れていない既存方針と整合）
- **Cross References**: \`/suno-helper\` スキルを追記
- Lyria 分岐は不変

## Test plan

- [ ] CI all pass
- [ ] CHANGELOG \`### Changed\` に追記済み（pre-push の changelog-gate を通過確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)