### PR TITLE
[#892] issue-892-feat-suno-helper-pop

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -1,4 +1,4 @@
-// popup ⇄ content script ⇄ server 間の契約文字列を 1 箇所に集約する。
+// overlay ⇄ content script ⇄ server 間の契約文字列を 1 箇所に集約する。
 // これらは yt-collection-serve (#692/#698) との互換契約であり、変更すると
 // サーバー側 (`/suno/prompts.json`) と整合しなくなる。
 // SSOT: src/youtube_automation/scripts/suno_artifacts.py SUNO_PROMPTS_ROUTE
@@ -8,8 +8,12 @@ import type { PromptEntry } from "./api";
 export const STORAGE_KEY = "sunoServerUrl";
 
 /** ERROR 停止時の途中再開 state を保存する chrome.storage.local の key (#872)。
- * popup と content が同一 key を参照するため、契約文字列としてここを SSOT とする。 */
+ * overlay と content が同一 key を参照するため、契約文字列としてここを SSOT とする。 */
 export const RESUME_STATE_KEY = "sunoResumeState";
+
+/** overlay の position/minimized/hidden を保存する chrome.storage.local の単一 key (#892)。
+ * Suno は 1 タブ運用前提のため global 単一 key とする。lib/overlay-state.ts が SSOT として参照する。 */
+export const OVERLAY_STATE_KEY = "sunoOverlayState";
 
 /** yt-collection-serve が prompts を配信するサブパス (#698 で `/prompts.json` から分離)。 */
 export const PROMPTS_ROUTE = "/suno/prompts.json";
@@ -77,7 +81,7 @@ export const PHASE = {
 
 export type Phase = (typeof PHASE)[keyof typeof PHASE];
 
-/** content → popup の進捗ペイロード。 */
+/** runner content → overlay の進捗ペイロード。 */
 export interface ProgressPayload {
   phase: Phase;
   total: number;
@@ -85,11 +89,11 @@ export interface ProgressPayload {
   message?: string;
 }
 
-/** popup の各パターン行の表示状態。 */
+/** overlay の各パターン行の表示状態。 */
 export type ItemState = "idle" | "active" | "done";
 
 /** content script が SSOT として保持する進捗スナップショット (#852)。
- * popup を閉じても content が保持し、再 open 時に `queryProgress` で返す。 */
+ * overlay を閉じても content が保持し、再 open 時に `queryProgress` で返す。 */
 export interface SnapshotPayload {
   entries: PromptEntry[];
   itemStates: ItemState[];

--- a/extensions/suno-helper/components/Overlay.tsx
+++ b/extensions/suno-helper/components/Overlay.tsx
@@ -1,0 +1,138 @@
+// Suno UI 上に注入する draggable overlay の shell (#892)。
+// 既存 <App /> をそのまま埋め込み、drag handle・最小化・表示 toggle・位置永続化だけを足す。
+// overlay の実マウント（Shadow DOM）は entrypoints/overlay.content.ts が担う。
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { onMessage } from "../lib/messaging";
+import {
+  clampPosition,
+  type OverlayState,
+  readOverlayState,
+  topRightPosition,
+  writeOverlayState,
+} from "../lib/overlay-state";
+import { App } from "./App";
+import { useDraggable } from "./useDraggable";
+
+/** overlay shell の固定幅 (px)。clamp の初期サイズと top-right 初期位置の算出に使う。 */
+const OVERLAY_WIDTH = 360;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * 永続化状態を読み込むゲート。読み込み完了まで何も描画せず、完了後に初期状態を OverlayShell へ渡す。
+ * useDraggable の初期位置は mount 時に一度だけ確定するため、非同期読み込み後に shell を mount する。
+ */
+export function Overlay() {
+  // undefined=読み込み中 / null=未保存 / OverlayState=復元。
+  const [initial, setInitial] = useState<OverlayState | null | undefined>(undefined);
+
+  useEffect(() => {
+    void readOverlayState().then((state) => setInitial(state ?? null));
+  }, []);
+
+  if (initial === undefined) {
+    return null;
+  }
+  return <OverlayShell initial={initial} />;
+}
+
+function initialPosition(initial: OverlayState | null): Point {
+  const viewport = { width: window.innerWidth, height: window.innerHeight };
+  // 高さは mount 後に getBoundingClientRect で実測されるため、初期 clamp は幅のみ厳密に効かせる。
+  const size = { width: OVERLAY_WIDTH, height: 0 };
+  // 復元時は保存位置を現在 viewport へ clamp する (要件2)。未保存は右上に出す (要件1)。
+  return initial ? clampPosition(initial.position, viewport, size) : topRightPosition(viewport, size);
+}
+
+function OverlayShell({ initial }: { initial: OverlayState | null }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [minimized, setMinimized] = useState(initial?.minimized ?? false);
+  const [hidden, setHidden] = useState(initial?.hidden ?? false);
+
+  const persist = useCallback((state: OverlayState) => {
+    void writeOverlayState(state);
+  }, []);
+
+  // 一度だけ登録する toggle リスナーや非同期 commit から最新値を読むための ref。
+  // ref はレンダー中に書かず commit 後の effect で同期する（react-hooks/refs。読み手は全て非同期ハンドラ）。
+  const minimizedRef = useRef(minimized);
+  const hiddenRef = useRef(hidden);
+  useEffect(() => {
+    minimizedRef.current = minimized;
+    hiddenRef.current = hidden;
+  }, [minimized, hidden]);
+
+  const onCommit = useCallback(
+    (position: Point) => persist({ position, minimized: minimizedRef.current, hidden: hiddenRef.current }),
+    [persist],
+  );
+
+  const { position, dragging, onPointerDown } = useDraggable({
+    initial: initialPosition(initial),
+    elementRef: containerRef,
+    onCommit,
+  });
+  // position も同様にレンダー中ではなく commit 後の effect で ref へ同期する（読み手は非同期ハンドラ）。
+  const positionRef = useRef(position);
+  useEffect(() => {
+    positionRef.current = position;
+  }, [position]);
+
+  // action クリック（background → toggleOverlay）で表示を切り替える (要件5)。
+  useEffect(() => {
+    const unwatch = onMessage("toggleOverlay", () => {
+      setHidden((prev) => {
+        const next = !prev;
+        persist({ position: positionRef.current, minimized: minimizedRef.current, hidden: next });
+        return next;
+      });
+    });
+    return () => unwatch();
+  }, [persist]);
+
+  const toggleMinimize = useCallback(() => {
+    setMinimized((prev) => {
+      const next = !prev;
+      persist({ position: positionRef.current, minimized: next, hidden: hiddenRef.current });
+      return next;
+    });
+  }, [persist]);
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed overflow-hidden rounded-lg border border-gray-300 bg-white shadow-xl"
+      style={{ left: position.x, top: position.y, width: OVERLAY_WIDTH, zIndex: 2147483647 }}
+    >
+      {/* handle: 常に pointer-events:auto。最小化中もここだけ残り再展開を受け付ける (要件4)。 */}
+      <div
+        onPointerDown={onPointerDown}
+        className="flex items-center justify-between rounded-t-lg bg-gray-800 px-3 py-2 text-sm font-semibold text-white select-none"
+        style={{ cursor: dragging ? "grabbing" : "grab", pointerEvents: "auto" }}
+      >
+        <span>Suno Helper</span>
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={toggleMinimize}
+          aria-label={minimized ? "展開" : "最小化"}
+          className="rounded px-2 leading-none hover:bg-gray-700"
+        >
+          {minimized ? "▢" : "—"}
+        </button>
+      </div>
+      {/* 最小化中は panel を display:none + pointer-events:none で Suno UI 操作を邪魔しない (要件4)。 */}
+      <div style={{ pointerEvents: minimized ? "none" : "auto", display: minimized ? "none" : "block" }}>
+        <App />
+      </div>
+    </div>
+  );
+}

--- a/extensions/suno-helper/components/overlay.css
+++ b/extensions/suno-helper/components/overlay.css
@@ -1,0 +1,5 @@
+/* overlay (#892) の Shadow DOM へ注入する Tailwind スタイル。
+   entrypoints/ 外に置くことで CSS が独立 entrypoint 化するのを避ける（overlay.content.ts と名前衝突しない）。 */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/extensions/suno-helper/components/useDraggable.ts
+++ b/extensions/suno-helper/components/useDraggable.ts
@@ -1,0 +1,113 @@
+// overlay (#892) の drag 移動を pointer イベントでカスタム実装する hook（外部 lib 不要）。
+//
+// 規約:
+//   - drag handle 上の pointerdown で開始。ただし起点が input/textarea/contentEditable のときは
+//     drag を開始しない（要件3: Suno 側のフォーム入力を奪わない）。
+//   - pointermove 中は clampPosition で viewport 内へ収める。
+//   - pointerup で確定し onCommit へ最終位置を渡す（永続化は呼び出し側の責務）。
+//   - viewport resize 時も現在位置を再 clamp して onCommit する（要件2: resize clamp 復元）。
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent, RefObject } from "react";
+
+import { clampPosition } from "../lib/overlay-state";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface UseDraggableOptions {
+  /** 初期表示位置（top-left 基準）。 */
+  initial: Point;
+  /** clamp の基準サイズを実測するための overlay 要素 ref。 */
+  elementRef: RefObject<HTMLElement>;
+  /** drag 終了 / resize clamp で確定した位置を通知する（永続化用）。 */
+  onCommit: (position: Point) => void;
+}
+
+interface UseDraggableResult {
+  position: Point;
+  dragging: boolean;
+  onPointerDown: (event: ReactPointerEvent) => void;
+}
+
+/** drag を発火させてはいけない起点（フォーム入力要素）か判定する (要件3)。 */
+function isInteractive(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+}
+
+function viewportSize(): { width: number; height: number } {
+  return { width: window.innerWidth, height: window.innerHeight };
+}
+
+function elementSize(element: HTMLElement | null): { width: number; height: number } {
+  if (!element) {
+    return { width: 0, height: 0 };
+  }
+  const rect = element.getBoundingClientRect();
+  return { width: rect.width, height: rect.height };
+}
+
+export function useDraggable({ initial, elementRef, onCommit }: UseDraggableOptions): UseDraggableResult {
+  const [position, setPosition] = useState<Point>(initial);
+  const [dragging, setDragging] = useState(false);
+
+  // 最新値を pointermove / resize リスナーから参照するための ref（リスナー再登録を避ける）。
+  // ref はレンダー中に書かず commit 後の effect で同期する（react-hooks/refs。読み手は全て非同期ハンドラ）。
+  const positionRef = useRef<Point>(initial);
+  useEffect(() => {
+    positionRef.current = position;
+  }, [position]);
+  const origin = useRef<Point>({ x: 0, y: 0 });
+  const start = useRef<Point>(initial);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent) => {
+    if (isInteractive(event.target)) {
+      return;
+    }
+    origin.current = { x: event.clientX, y: event.clientY };
+    start.current = positionRef.current;
+    setDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) {
+      return;
+    }
+    const handleMove = (event: PointerEvent) => {
+      const next = {
+        x: start.current.x + (event.clientX - origin.current.x),
+        y: start.current.y + (event.clientY - origin.current.y),
+      };
+      setPosition(clampPosition(next, viewportSize(), elementSize(elementRef.current)));
+    };
+    const handleUp = () => {
+      setDragging(false);
+      onCommit(positionRef.current);
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+    };
+  }, [dragging, elementRef, onCommit]);
+
+  // viewport が縮んだとき、現在位置を内側へ再 clamp して確定する (要件2)。
+  useEffect(() => {
+    const handleResize = () => {
+      const clamped = clampPosition(positionRef.current, viewportSize(), elementSize(elementRef.current));
+      if (clamped.x !== positionRef.current.x || clamped.y !== positionRef.current.y) {
+        setPosition(clamped);
+        onCommit(clamped);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [elementRef, onCommit]);
+
+  return { position, dragging, onPointerDown };
+}

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -1,6 +1,8 @@
-// popup の状態管理フック。旧 popup.js の挙動 (取得 / 連続実行 / 停止 / 進捗・エラー表示) を保持する。
+// overlay / popup 共用の状態管理フック。旧 popup.js の挙動 (取得 / 連続実行 / 停止 / 進捗・エラー表示) を保持する。
+// run / stop / queryProgress / progress は tabId を指定せず background 宛に送る（#892）。overlay は
+// content script で `browser.tabs.*` を呼べないため、background が送信元と同一タブの runner content へ中継する
+// （中継ロジックは entrypoints/background.ts + lib/overlay-relay.ts）。
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { browser } from "wxt/browser";
 
 import {
   type CollectionSummary,
@@ -19,6 +21,7 @@ import {
   type ResumeState,
   resolveRunRange,
   resumeBannerRange,
+  resumeRunRange,
   type RunRange,
   shouldShowResumeBanner,
 } from "../lib/resume-state";
@@ -55,16 +58,9 @@ interface RunnerState {
   acceptResume: () => void;
   dismissResume: () => void;
   fetchData: () => Promise<void>;
-  run: () => Promise<void>;
+  // overrides.range があればそれを使う (#892 要件6)。未指定時は range UI の状態から解決する（従来挙動）。
+  run: (overrides?: { range?: RunRange }) => Promise<void>;
   stop: () => Promise<void>;
-}
-
-async function activeTabId(): Promise<number> {
-  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-  if (typeof tab?.id !== "number") {
-    throw new Error("アクティブなタブが見つかりません。");
-  }
-  return tab.id;
 }
 
 export function useSunoRunner(): RunnerState {
@@ -149,18 +145,6 @@ export function useSunoRunner(): RunnerState {
     });
   }, []);
 
-  // バナー承認: range UI に「失敗 entry..末尾」を 1-based で prefill し、範囲指定モードへ切替える (#872)。
-  const acceptResume = useCallback(() => {
-    if (!resumeBanner) {
-      return;
-    }
-    const prefilled = resumeBannerRange(resumeBanner);
-    setRangeMode("range");
-    setRangeStart(String(prefilled.start));
-    setRangeEnd(String(prefilled.end));
-    setResumeDismissed(true);
-  }, [resumeBanner]);
-
   const dismissResume = useCallback(() => {
     setResumeDismissed(true);
   }, []);
@@ -203,13 +187,13 @@ export function useSunoRunner(): RunnerState {
     return () => unwatch();
   }, [entries, report]);
 
-  // popup 再 open 時、content が保持する snapshot から進捗を即時復元する (#852)。
-  // Suno タブでない / content 未注入は queryProgress が失敗 → 復元せず従来表示へ silent fallback。
+  // overlay mount / popup 再 open 時、runner content が保持する snapshot から進捗を即時復元する (#852)。
+  // queryProgress は background 経由で同一タブの runner content へ中継される (#892)。runner 未注入なら
+  // 中継が失敗 → 復元せず従来表示へ silent fallback。
   useEffect(() => {
     void (async () => {
       try {
-        const tabId = await activeTabId();
-        const snapshot = await sendMessage("queryProgress", undefined, tabId);
+        const snapshot = await sendMessage("queryProgress", undefined);
         const restored = buildRestoreState(snapshot);
         if (!restored) {
           return;
@@ -222,7 +206,7 @@ export function useSunoRunner(): RunnerState {
         setRestoredFailedIndex(restored.failedIndex);
         report(restored.status, restored.isError);
       } catch {
-        // Suno タブでない / content 未注入では queryProgress が到達しない。復元を諦め従来表示を維持する。
+        // runner content 未注入（中継先不在）では queryProgress が到達しない。復元を諦め従来表示を維持する。
       }
     })();
   }, [report]);
@@ -251,45 +235,73 @@ export function useSunoRunner(): RunnerState {
     }
   }, [url, selectedCollectionId, report]);
 
-  const run = useCallback(async () => {
-    if (entries.length === 0) {
-      return;
-    }
-    // 範囲指定モードは 1-based 入力を 0-based inclusive range へ解決する (#872)。
-    // 不正入力は resolveRunRange が throw → ここで捕捉し fail-loud で UI に出す（content へ送らない）。
-    let range: RunRange | undefined;
-    if (rangeMode === "range") {
-      try {
-        const start = Number(rangeStart);
-        const end = rangeEnd.trim() === "" ? undefined : Number(rangeEnd);
-        range = resolveRunRange(start, end, entries.length);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        report(message, true);
+  const run = useCallback(
+    async (overrides?: { range?: RunRange }) => {
+      // 二重実行ガード (#892 要件7)。実行中の再入（「再開」連打等）を no-op で弾く。
+      if (isRunning) {
         return;
       }
-    }
-    try {
-      const tabId = await activeTabId();
-      // collection mode は playlistName を伴って送る。単一ファイル mode は undefined で playlist phase を skip (#854)。
-      // collectionId は ERROR 停止時の resume 紐付けに使う。単一ファイル mode（空文字）は undefined で送る (#872)。
-      await sendMessage(
-        "run",
-        { entries, playlistName: derivedPlaylistName, range, collectionId: selectedCollectionId || undefined },
-        tabId,
-      );
+      if (entries.length === 0) {
+        return;
+      }
+      // overrides.range（1-click 自動再開）があればそれを優先する (#892 要件6)。
+      // 無ければ range UI の状態から解決する（従来挙動）。range モードの 1-based 入力は
+      // 0-based inclusive へ変換し、不正入力は resolveRunRange が throw → fail-loud で UI に出す。
+      let range = overrides?.range;
+      if (range === undefined && rangeMode === "range") {
+        try {
+          const start = Number(rangeStart);
+          const end = rangeEnd.trim() === "" ? undefined : Number(rangeEnd);
+          range = resolveRunRange(start, end, entries.length);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          report(message, true);
+          return;
+        }
+      }
+      // 二重実行ガード成立後、送信前に実行中フラグを立てる (#892 要件7: setIsRunning を sendMessage の前へ)。
       setIsRunning(true);
-      report("連続実行を開始しました。");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      report(formatRunError(message), true);
+      try {
+        // collection mode は playlistName を伴って送る。単一ファイル mode は undefined で playlist phase を skip (#854)。
+        // collectionId は ERROR 停止時の resume 紐付けに使う。単一ファイル mode（空文字）は undefined で送る (#872)。
+        // tabId は指定せず background 宛に送り、同一タブの runner content へ中継させる (#892)。
+        await sendMessage("run", {
+          entries,
+          playlistName: derivedPlaylistName,
+          range,
+          collectionId: selectedCollectionId || undefined,
+        });
+        report("連続実行を開始しました。");
+      } catch (err) {
+        // 送信失敗時はフラグを戻して再実行可能にする（実行は始まっていない）。
+        setIsRunning(false);
+        const message = err instanceof Error ? err.message : String(err);
+        report(formatRunError(message), true);
+      }
+    },
+    [isRunning, entries, rangeMode, rangeStart, rangeEnd, derivedPlaylistName, selectedCollectionId, report],
+  );
+
+  // バナー承認 = 1-click 自動再開 (#892 要件6)。range UI を「失敗 entry..末尾」で prefill しつつ、
+  // ローカル構築した 0-based range を引数で run へ渡してそのまま生成を再開する。React state は
+  // 次レンダ反映で closure から読めないため、prefill した state ではなく引数で range を渡す（order.md §2）。
+  // prefill 自体は再開後の UI 表示整合のために残す。run は定義後でないと参照できないためここに置く。
+  const acceptResume = useCallback(() => {
+    if (!resumeBanner) {
+      return;
     }
-  }, [entries, rangeMode, rangeStart, rangeEnd, derivedPlaylistName, selectedCollectionId, report]);
+    const prefilled = resumeBannerRange(resumeBanner);
+    setRangeMode("range");
+    setRangeStart(String(prefilled.start));
+    setRangeEnd(String(prefilled.end));
+    setResumeDismissed(true);
+    void run({ range: resumeRunRange(resumeBanner) });
+  }, [resumeBanner, run]);
 
   const stop = useCallback(async () => {
     try {
-      const tabId = await activeTabId();
-      await sendMessage("stop", undefined, tabId);
+      // tabId は指定せず background 宛に送り、同一タブの runner content へ中継させる (#892)。
+      await sendMessage("stop", undefined);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       report(formatStopError(message), true);

--- a/extensions/suno-helper/entrypoints/background.ts
+++ b/extensions/suno-helper/entrypoints/background.ts
@@ -1,8 +1,41 @@
 // Manifest V3 service worker。
-// popup ⇄ content script は @webext-core/messaging (tabs.sendMessage / runtime.sendMessage)
-// で直接やり取りするため、本 worker は拡張ライフサイクルのログのみを担う。
+// 拡張ライフサイクルのログ、action クリック中継、および overlay ⇄ runner の content↔content 中継を担う。
+// overlay (content script) は `browser.tabs.*` を呼べないため、overlay の no-tabId メッセージを受けて
+// 送信元と同一タブの runner content へ tabs.sendMessage で転送する（#892, 詳細は lib/overlay-relay.ts）。
+import { onMessage, sendMessage } from "../lib/messaging";
+import { relayTabId, requireRelayTab } from "../lib/overlay-relay";
+
 export default defineBackground(() => {
   browser.runtime.onInstalled.addListener((details) => {
     console.info(`[suno-helper] installed/updated: ${details.reason}`);
+  });
+
+  // popup 廃止 (#892): default_popup を持たないため action クリックで onClicked が発火する。
+  // クリックされたタブの overlay content script へ表示 toggle を中継する。
+  browser.action.onClicked.addListener((tab) => {
+    if (typeof tab.id !== "number") {
+      // タブ id が取れないケース（特殊ページ等）は overlay も注入されていないため中継しない。
+      return;
+    }
+    void sendMessage("toggleOverlay", undefined, tab.id);
+  });
+
+  // overlay → runner 中継 (#892)。overlay が送る run / stop / queryProgress を送信元と同一タブの
+  // runner content へ転送し、runner の応答をそのまま overlay へ返す。tab を持たない送信元は中継不能
+  // のため requireRelayTab が fail-loud で throw する（握りつぶさない）。
+  onMessage("run", ({ data, sender }) => sendMessage("run", data, requireRelayTab(sender, "run")));
+  onMessage("stop", ({ sender }) => sendMessage("stop", undefined, requireRelayTab(sender, "stop")));
+  onMessage("queryProgress", ({ sender }) =>
+    sendMessage("queryProgress", undefined, requireRelayTab(sender, "queryProgress")),
+  );
+
+  // runner → overlay 中継 (#892)。runner content が emit する progress 通知を送信元と同一タブへ転送する
+  // （content↔content 直送不可のため）。tab を持たない送信元は転送先が無いため no-op。
+  onMessage("progress", ({ data, sender }) => {
+    const tabId = relayTabId(sender);
+    if (tabId === null) {
+      return;
+    }
+    void sendMessage("progress", data, tabId);
   });
 });

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -48,6 +48,8 @@ export default defineContentScript({
   matches: [...SUNO_MATCHES],
   main() {
     let aborted = false;
+    // 連続実行の二重起動ガード (#892 要件7)。runAll 実行中の run 再着信を弾く。
+    let running = false;
     // popup を閉じても進捗を維持・復元するための SSOT (#852)。run 開始で initSnapshot、
     // 以降は emitProgress が sendMessage より前に同期更新する（queryProgress と race しないため）。
     let currentSnapshot: SnapshotPayload | null = null;
@@ -217,13 +219,20 @@ export default defineContentScript({
     }
 
     onMessage("run", ({ data }) => {
+      // 二重実行ガード (#892 要件7)。実行中の run 再着信は no-op で ack のみ返す（再開連打対策）。
+      if (running) {
+        return { ok: true } as const;
+      }
+      running = true;
       aborted = false;
       // 後方互換: 旧形式の配列 payload は { entries } に wrap する (#854)。range / collectionId は無し。
       const { entries, playlistName, range, collectionId } = Array.isArray(data)
         ? { entries: data, playlistName: undefined, range: undefined, collectionId: undefined }
         : data;
       currentSnapshot = initSnapshot(entries, playlistName);
-      void runAll(entries, { range, collectionId, playlistName });
+      void runAll(entries, { range, collectionId, playlistName }).finally(() => {
+        running = false;
+      });
       return { ok: true } as const;
     });
 

--- a/extensions/suno-helper/entrypoints/overlay.content.ts
+++ b/extensions/suno-helper/entrypoints/overlay.content.ts
@@ -1,0 +1,31 @@
+// Suno UI 上に draggable overlay (#892) をマウントする UI 専用 content script。
+// runner 本体 (entrypoints/content.ts) とは責務分離し、本 script は Shadow DOM 上へ
+// React tree (<Overlay />) をマウントするだけに専念する。messaging 経由で runner と話すため
+// マウント先は問わない。Shadow DOM 隔離で Suno 側 CSS と Tailwind が競合しない (要件8)。
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { SUNO_MATCHES } from "../../shared/constants";
+import { Overlay } from "../components/Overlay";
+import "../components/overlay.css";
+
+export default defineContentScript({
+  matches: [...SUNO_MATCHES],
+  // 生成した CSS を Shadow DOM 内へ注入する（webpage 側へは漏らさない）。
+  cssInjectionMode: "ui",
+  async main(ctx) {
+    const ui = await createShadowRootUi<Root>(ctx, {
+      name: "suno-helper-overlay",
+      position: "overlay",
+      alignment: "top-left",
+      zIndex: 2147483647,
+      onMount: (container) => {
+        const root = createRoot(container);
+        root.render(createElement(Overlay));
+        return root;
+      },
+      onRemove: (root) => root?.unmount(),
+    });
+    ui.mount();
+  },
+});

--- a/extensions/suno-helper/lib/messaging.ts
+++ b/extensions/suno-helper/lib/messaging.ts
@@ -1,5 +1,6 @@
-// background ↔ content ↔ popup の message を @webext-core/messaging で型付けする。
-// payload 定義をここに集約する (要件3)。
+// overlay ⇄ background ⇄ runner の message を @webext-core/messaging で型付けする (#892)。
+// overlay / runner はともに content script で互いに直接 messaging できないため、background が中継する
+// （詳細は lib/overlay-relay.ts）。payload 定義をここに集約する (要件3)。
 import { defineExtensionMessaging } from "@webext-core/messaging";
 
 import type { PromptEntry } from "../../shared/api";
@@ -17,14 +18,16 @@ export type RunPayload =
   | { entries: PromptEntry[]; playlistName?: string; range?: RunRange; collectionId?: string };
 
 interface ProtocolMap {
-  /** popup → content: 連続実行を開始する。 */
+  /** overlay → background → runner: 連続実行を開始する。 */
   run(payload: RunPayload): { ok: true };
-  /** popup → content: 連続実行を中断する。 */
+  /** overlay → background → runner: 連続実行を中断する。 */
   stop(): { ok: true };
-  /** content → popup: 進捗を通知する。 */
+  /** runner → background → overlay: 進捗を通知する。 */
   progress(payload: ProgressPayload): void;
-  /** popup → content: 現在の進捗スナップショットを問い合わせる (#852)。未実行は null。 */
+  /** overlay → background → runner: 現在の進捗スナップショットを問い合わせる (#852)。未実行は null。 */
   queryProgress(): SnapshotPayload | null;
+  /** background → overlay content: action クリックで overlay 表示を toggle する (#892)。 */
+  toggleOverlay(): void;
 }
 
 export const { sendMessage, onMessage } = defineExtensionMessaging<ProtocolMap>();

--- a/extensions/suno-helper/lib/overlay-relay.ts
+++ b/extensions/suno-helper/lib/overlay-relay.ts
@@ -1,0 +1,38 @@
+// overlay (content script) ⇄ runner (content script) の background 中継ロジック (#892)。
+//
+// overlay と runner は同一 Suno タブ上の別 content script だが、content script 同士は直接 messaging
+// できない（@webext-core/messaging: "You cannot message between tabs directly. It must go through the
+// background script."）。runtime.sendMessage は他 content script へ配送されず、tabs.sendMessage は
+// content script から呼べない（`browser.tabs` 未提供）。そのため background が overlay の no-tabId
+// メッセージを受け、送信元と同一タブ (sender.tab.id) へ tabs.sendMessage で転送する。
+//
+// 中継対象は content script 起源（sender.tab.id を持つ）のメッセージに限る。tab を持たない送信元
+// （background 自身 / 廃止済み popup 等）を素通しすると no-tabId のまま runtime へ再送して無限ループに
+// なるため、tab を持たないものは null を返して転送しない。
+
+/** background 中継に必要な sender の最小形（webextension-polyfill Runtime.MessageSender の部分形）。 */
+export interface RelaySender {
+  tab?: { id?: number };
+}
+
+/**
+ * メッセージの中継先タブ id を返す。content script 起源（tab.id を持つ）なら同一タブへ転送するため
+ * その tab.id を、そうでなければ null（転送しない＝loop 防止）を返す。
+ */
+export function relayTabId(sender: RelaySender): number | null {
+  return typeof sender.tab?.id === "number" ? sender.tab.id : null;
+}
+
+/**
+ * 応答が必須な中継（run / stop / queryProgress）の中継先タブ id を解決する。content script 起源で
+ * なければ転送先が無いため fail-loud で throw する（握りつぶさない）。progress のような no-op 折返しは
+ * 中継先不在を許容するため本関数ではなく `relayTabId` を直接使う。
+ * @param action エラー文言に埋め込むメッセージ種別。
+ */
+export function requireRelayTab(sender: RelaySender, action: string): number {
+  const tabId = relayTabId(sender);
+  if (tabId === null) {
+    throw new Error(`${action} の中継先タブを特定できません（content script 起源ではありません）。`);
+  }
+  return tabId;
+}

--- a/extensions/suno-helper/lib/overlay-state.ts
+++ b/extensions/suno-helper/lib/overlay-state.ts
@@ -1,0 +1,74 @@
+// overlay (#892) の「位置・最小化・表示状態の永続化」と「viewport 外に保存された位置の内側 clamp」を
+// 支える純関数 + chrome.storage I/O を 1 箇所に集約する。
+//
+// 純関数のうち clampPosition は Overlay component と useDraggable の双方が、topRightPosition は
+// Overlay component のみが import し、clamp 規約を二重定義しないための SSOT とする。
+// I/O (readOverlayState / writeOverlayState) は
+// @wxt-dev/storage の型付き wrapper で chrome.storage.local を読み書きする。storage.defineItem は
+// 呼ぶと内部で chrome.runtime へアクセスするため、node 環境 (vitest) で純関数だけを import したときに
+// 副作用を起こさないよう遅延生成する（純関数テスト overlay-state.test.ts を壊さないため。
+// 既存 lib/resume-state.ts と同方針）。
+import { storage } from "wxt/utils/storage";
+
+import { OVERLAY_STATE_KEY } from "../../shared/constants";
+
+/** 永続化する overlay の状態 (#892 要件2)。position は top-left 基準の viewport 座標。 */
+export interface OverlayState {
+  position: { x: number; y: number };
+  minimized: boolean;
+  hidden: boolean;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+/** overlay を viewport 端から離す初期マージン (px)。topRightPosition 専用の module-private 定数。 */
+const OVERLAY_MARGIN = 16;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * overlay box (top-left=pos, size) を viewport 内へ収める (#892 要件2)。
+ * 規約: x ∈ [0, max(0, viewport.width - size.width)] / y ∈ [0, max(0, viewport.height - size.height)]。
+ * overlay が viewport より大きい退化ケースは上限が負になるため max(0, ...) で 0 に吸い込む。
+ */
+export function clampPosition(pos: Point, viewport: Size, size: Size): Point {
+  const maxX = Math.max(0, viewport.width - size.width);
+  const maxY = Math.max(0, viewport.height - size.height);
+  return { x: clamp(pos.x, 0, maxX), y: clamp(pos.y, 0, maxY) };
+}
+
+/** 初期表示位置（右上、マージン込み）を算出する (#892 要件1)。 */
+export function topRightPosition(viewport: Size, size: Size): Point {
+  return clampPosition({ x: viewport.width - size.width - OVERLAY_MARGIN, y: OVERLAY_MARGIN }, viewport, size);
+}
+
+// --- chrome.storage.local I/O（storage item は遅延生成。理由はファイル冒頭コメント参照） ---
+
+let cachedItem: ReturnType<typeof storage.defineItem<OverlayState | null>> | null = null;
+
+function overlayStateItem() {
+  if (!cachedItem) {
+    cachedItem = storage.defineItem<OverlayState | null>(`local:${OVERLAY_STATE_KEY}`, { fallback: null });
+  }
+  return cachedItem;
+}
+
+/** 永続化済みの overlay state を読む。未設定は null。 */
+export async function readOverlayState(): Promise<OverlayState | null> {
+  return overlayStateItem().getValue();
+}
+
+/** overlay state を書き込む（既存があれば上書き）。 */
+export async function writeOverlayState(state: OverlayState): Promise<void> {
+  await overlayStateItem().setValue(state);
+}

--- a/extensions/suno-helper/lib/resume-state.ts
+++ b/extensions/suno-helper/lib/resume-state.ts
@@ -88,6 +88,16 @@ export function resumeBannerRange(banner: ResumeBanner): { start: number; end: n
   return { start: banner.failedIndex + 1, end: banner.total };
 }
 
+/**
+ * バナー承認 → 1-click 自動再開で run() へ直接渡す 0-based inclusive range を構築する (#892 要件6)。
+ * 失敗 entry (0-based failedIndex) から末尾 (total-1) まで。React state は次レンダ反映で closure から
+ * 読めないため、acceptResume はこの純関数でローカルに range を組み立てて run({ range }) へ引数で渡す。
+ * 旧経路 resumeBannerRange(1-based prefill) → resolveRunRange と同一の絶対 index を返す（round-trip 一致）。
+ */
+export function resumeRunRange(banner: ResumeBanner): RunRange {
+  return { start: banner.failedIndex, end: banner.total - 1 };
+}
+
 // --- chrome.storage.local I/O（storage item は遅延生成。理由はファイル冒頭コメント参照） ---
 
 let cachedItem: ReturnType<typeof storage.defineItem<ResumeState | null>> | null = null;

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -1,4 +1,4 @@
-// popup ⇄ content script ⇄ server 間の契約文字列を固定する回帰テスト。
+// overlay ⇄ content script ⇄ server 間の契約文字列を固定する回帰テスト。
 // 旧実装 `extensions/suno-helper/constants.js` の値を WXT 移行後も不変に保つ。
 // これらは yt-collection-serve (#692/#698) との互換契約であり、変更すると
 // サーバー側 (`/suno/prompts.json`) と整合しなくなる。
@@ -13,6 +13,7 @@ import {
   INTER_CREATE_DELAY_MS,
   MAX_INFLIGHT_REQUESTS,
   MAX_INJECT_RETRY,
+  OVERLAY_STATE_KEY,
   PHASE,
   PROMPTS_ROUTE,
   QUEUE_ERROR_WAIT_MS,
@@ -32,6 +33,17 @@ describe("shared/constants: サーバー互換の契約値", () => {
 
   it("Given 移行後の定数 When DEFAULT_URL を読む Then 旧実装と同じローカル配信元である", () => {
     expect(DEFAULT_URL).toBe("http://localhost:7873");
+  });
+
+  it("Given overlay 化 (#892) When OVERLAY_STATE_KEY を読む Then overlay 位置・最小化を永続化する key 名である", () => {
+    // overlay の position/minimized/hidden を chrome.storage.local に保存する単一 key (order.md §1)。
+    // lib/overlay-state.ts がこれを SSOT として参照する。
+    expect(OVERLAY_STATE_KEY).toBe("sunoOverlayState");
+  });
+
+  it("Given storage key 群 When OVERLAY_STATE_KEY を他 key と比較 Then 既存 key と衝突しない", () => {
+    // 同一 chrome.storage.local 名前空間で resume / server URL state と key が被らないこと。
+    expect(new Set([STORAGE_KEY, "sunoResumeState", OVERLAY_STATE_KEY]).size).toBe(3);
   });
 });
 

--- a/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
@@ -1,0 +1,158 @@
+// 要件1-4 (#892): Suno UI 上の draggable overlay を実ブラウザ文脈で検証する E2E スモーク (実 Suno 非依存)。
+//
+// content script は manifest の matches (`https://suno.com/*`) でしか注入されず、Playwright の
+// page.evaluate は本番モジュール (`components/useDraggable.ts` / `lib/overlay-state.ts`) を import
+// できない（既存 suno-inject.spec.ts / suno-range.spec.ts と同じ制約）。よってここでは
+// useDraggable の pointer ハンドリングと clampPosition を inline 再現し、
+// 「drag handle で移動できる / input フォーカス中は drag を発火しない / viewport 外は内側へ clamp /
+//  最小化で handle 以外は pointer-events:none」ことを実 DOM / 実 PointerEvent で示す。
+// 本番関数自体の純ロジック回帰は unit (overlay-state.test.ts) が担う。
+import { expect, test } from "@playwright/test";
+
+// useDraggable の本番ロジックと同手法を inline 再現するブートストラップ。
+// handle を pointerdown → pointermove で overlay を移動。focus 中の input/textarea を
+// 起点にした pointerdown では drag を開始しない（要件3）。
+const SETUP = `
+  const clampPosition = (pos, viewport, size) => ({
+    x: Math.min(Math.max(pos.x, 0), Math.max(0, viewport.width - size.width)),
+    y: Math.min(Math.max(pos.y, 0), Math.max(0, viewport.height - size.height)),
+  });
+
+  const overlay = document.getElementById('overlay');
+  const handle = document.getElementById('handle');
+
+  let dragging = false;
+  let originX = 0, originY = 0, startLeft = 0, startTop = 0;
+
+  // 要件3: drag を発火させてはいけない起点（フォーム入力要素）か判定する。
+  const isInteractive = (el) =>
+    !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
+
+  handle.addEventListener('pointerdown', (e) => {
+    if (isInteractive(e.target)) return; // input/textarea 起点では drag を開始しない
+    dragging = true;
+    originX = e.clientX;
+    originY = e.clientY;
+    startLeft = parseFloat(overlay.style.left) || 0;
+    startTop = parseFloat(overlay.style.top) || 0;
+  });
+
+  window.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    overlay.style.left = (startLeft + (e.clientX - originX)) + 'px';
+    overlay.style.top = (startTop + (e.clientY - originY)) + 'px';
+  });
+
+  window.addEventListener('pointerup', () => { dragging = false; });
+
+  window.clampPosition = clampPosition;
+`;
+
+const PAGE = `<!doctype html><html><body>
+  <div id="overlay" style="position:fixed; left:100px; top:100px; width:200px; height:150px;">
+    <div id="handle" style="width:200px; height:24px;">
+      <input id="field" type="text" />
+    </div>
+    <div id="panel">body</div>
+  </div>
+</body></html>`;
+
+test("drag handle を pointerdown→move すると overlay が delta 分だけ移動する (要件1)", async ({ page }) => {
+  await page.setContent(PAGE);
+  await page.addScriptTag({ content: SETUP });
+
+  const result = await page.evaluate(() => {
+    const handle = document.getElementById("handle")!;
+    const overlay = document.getElementById("overlay")!;
+    // handle 自体（input 以外）を起点に pointerdown。
+    handle.dispatchEvent(new PointerEvent("pointerdown", { clientX: 150, clientY: 110, bubbles: true }));
+    window.dispatchEvent(new PointerEvent("pointermove", { clientX: 230, clientY: 170, bubbles: true }));
+    window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    return { left: overlay.style.left, top: overlay.style.top };
+  });
+
+  // 起点 (150,110) → (230,170)、delta=(+80,+60)。初期 (100,100) → (180,160)。
+  expect(result.left).toBe("180px");
+  expect(result.top).toBe("160px");
+});
+
+test("input にフォーカスがある起点では pointerdown しても drag を発火しない (要件3)", async ({ page }) => {
+  await page.setContent(PAGE);
+  await page.addScriptTag({ content: SETUP });
+
+  const result = await page.evaluate(() => {
+    const field = document.getElementById("field") as HTMLInputElement;
+    const overlay = document.getElementById("overlay")!;
+    field.focus();
+    // input 要素を起点にした pointerdown → drag は始まらない。
+    field.dispatchEvent(new PointerEvent("pointerdown", { clientX: 150, clientY: 110, bubbles: true }));
+    window.dispatchEvent(new PointerEvent("pointermove", { clientX: 400, clientY: 400, bubbles: true }));
+    window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    return { left: overlay.style.left, top: overlay.style.top, active: document.activeElement?.id };
+  });
+
+  // overlay は初期位置のまま動かず、フォーカスは input に残る（文字入力を奪わない）。
+  expect(result.left).toBe("100px");
+  expect(result.top).toBe("100px");
+  expect(result.active).toBe("field");
+});
+
+test("viewport の外に出る移動は clampPosition で内側へ引き戻される (要件2)", async ({ page }) => {
+  await page.setContent(PAGE);
+  await page.addScriptTag({ content: SETUP });
+
+  const result = await page.evaluate(() => {
+    type Point = { x: number; y: number };
+    type Size = { width: number; height: number };
+    const clampPosition = (
+      window as unknown as {
+        clampPosition: (pos: Point, viewport: Size, size: Size) => Point;
+      }
+    ).clampPosition;
+    const viewport = { width: 1000, height: 800 };
+    const size = { width: 200, height: 150 };
+    // 右下と左上に大きくはみ出した位置を clamp する。
+    return {
+      bottomRight: clampPosition({ x: 5000, y: 5000 }, viewport, size),
+      topLeft: clampPosition({ x: -300, y: -300 }, viewport, size),
+    };
+  });
+
+  expect(result.bottomRight).toEqual({ x: 800, y: 650 }); // viewport - size
+  expect(result.topLeft).toEqual({ x: 0, y: 0 });
+});
+
+test("最小化すると handle のみ pointer-events:auto、panel は none で Suno 操作を邪魔しない (要件4)", async ({
+  page,
+}) => {
+  await page.setContent(PAGE);
+
+  const result = await page.evaluate(() => {
+    const handle = document.getElementById("handle")!;
+    const panel = document.getElementById("panel")!;
+    // 本番 Overlay.tsx の最小化トグルと同手法: minimized 時は panel を pointer-events:none、
+    // handle は auto を維持して再展開操作だけ受け付ける。
+    const applyMinimized = (minimized: boolean) => {
+      handle.style.pointerEvents = "auto"; // handle は常に操作可能
+      panel.style.pointerEvents = minimized ? "none" : "auto";
+      panel.style.display = minimized ? "none" : "block";
+    };
+
+    applyMinimized(true);
+    const minimized = {
+      handle: handle.style.pointerEvents,
+      panel: panel.style.pointerEvents,
+      display: panel.style.display,
+    };
+    applyMinimized(false);
+    const restored = {
+      handle: handle.style.pointerEvents,
+      panel: panel.style.pointerEvents,
+      display: panel.style.display,
+    };
+    return { minimized, restored };
+  });
+
+  expect(result.minimized).toEqual({ handle: "auto", panel: "none", display: "none" });
+  expect(result.restored).toEqual({ handle: "auto", panel: "auto", display: "block" });
+});

--- a/extensions/suno-helper/tests/e2e/resume-autorun.spec.ts
+++ b/extensions/suno-helper/tests/e2e/resume-autorun.spec.ts
@@ -1,0 +1,116 @@
+// 要件6/7 (#892): ResumeBanner「再開」1 クリックで自動再開し、二重実行を防ぐことを
+// 実ブラウザ文脈で検証する E2E スモーク (実 Suno 非依存)。
+//
+// content script は本番モジュールを page.evaluate へ import できない（既存 spec 群と同制約）。
+// 要件7 の二重実行ガードは run()/runAll の inline closure state として設計されており（plan §5.2）、
+// import 可能な export を持たないため unit 化できない。よってここでは
+// 「acceptResume → run({range}) 自動実行」と「isRunning 中の再入を no-op にするガード」を
+// inline 再現し、要件6/7 の invariant を実 PointerEvent / 実クリックで pin する。
+// range 構築の純ロジック回帰は unit (use-suno-runner-resume.test.ts) が担う。
+import { expect, test } from "@playwright/test";
+
+test("「再開」1 クリックで run({range}) が自動実行される（prefill だけで止まらない, 要件6）", async ({ page }) => {
+  await page.setContent('<!doctype html><html><body><button id="resume">再開</button></body></html>');
+
+  const result = await page.evaluate(() => {
+    type Range = { start: number; end: number };
+    type Banner = { failedIndex: number; total: number };
+
+    // 本番 resumeRunRange と同手法: 失敗 entry(0-based) から末尾(total-1) までの 0-based inclusive range。
+    const resumeRunRange = (b: Banner): Range => ({ start: b.failedIndex, end: b.total - 1 });
+
+    const calls: Array<{ range: Range | undefined }> = [];
+    let isRunning = false;
+    // 本番 run(overrides?) の二重ガード規約: isRunning なら即 return、開始時に true を立ててから実行。
+    const run = (overrides?: { range?: Range }) => {
+      if (isRunning) return;
+      isRunning = true;
+      calls.push({ range: overrides?.range });
+    };
+
+    const banner: Banner = { failedIndex: 19, total: 24 };
+    // 本番 acceptResume: prefill に加えローカル構築した range を引数で run へ渡す（closure stale を避ける）。
+    const acceptResume = () => run({ range: resumeRunRange(banner) });
+
+    document.getElementById("resume")!.addEventListener("click", acceptResume);
+    document.getElementById("resume")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    return { calls, isRunning };
+  });
+
+  // 1 クリックで run が 1 回だけ起動し、失敗 entry 19〜末尾 23 の range が渡る（手動 run ボタン不要）。
+  expect(result.calls).toHaveLength(1);
+  expect(result.calls[0].range).toEqual({ start: 19, end: 23 });
+  expect(result.isRunning).toBe(true);
+});
+
+test("isRunning=true の最中に「再開」を連打しても run は二重に走らない (要件7)", async ({ page }) => {
+  await page.setContent('<!doctype html><html><body><button id="resume">再開</button></body></html>');
+
+  const result = await page.evaluate(() => {
+    type Range = { start: number; end: number };
+    const resumeRunRange = (b: { failedIndex: number; total: number }): Range => ({
+      start: b.failedIndex,
+      end: b.total - 1,
+    });
+
+    let runCount = 0;
+    let isRunning = false;
+    const run = (overrides?: { range?: Range }) => {
+      if (isRunning) return; // 再入ガード（要件7）
+      isRunning = true;
+      runCount++;
+      void overrides;
+    };
+
+    const banner = { failedIndex: 0, total: 5 };
+    const btn = document.getElementById("resume")!;
+    btn.addEventListener("click", () => run({ range: resumeRunRange(banner) }));
+
+    // 実行中に 3 連打。
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const duringRunCount = runCount;
+
+    // 実行が終わって isRunning が降りた後はもう一度実行できる（恒久ロックではない）。
+    isRunning = false;
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    return { duringRunCount, afterReleaseCount: runCount };
+  });
+
+  // 連打中は最初の 1 回のみ。ロック解放後は再度 1 回走り、合計 2 回。
+  expect(result.duringRunCount).toBe(1);
+  expect(result.afterReleaseCount).toBe(2);
+});
+
+test("content 側 runAll も実行中の再入を弾く（同等ガード, 要件7）", async ({ page }) => {
+  await page.setContent("<!doctype html><html><body></body></html>");
+
+  const result = await page.evaluate(() => {
+    // 本番 content.ts runAll の running フラグと同手法を inline 再現。
+    // onMessage('run') が実行中に再着信しても runAll を二重に開始しないこと。
+    let running = false;
+    let startedCount = 0;
+
+    const onRun = () => {
+      if (running) return { ok: true }; // 実行中は no-op で ack のみ
+      running = true;
+      startedCount++;
+      return { ok: true };
+    };
+
+    onRun(); // 1 回目: 開始
+    onRun(); // 2 回目: 実行中なので弾く
+    onRun(); // 3 回目: 実行中なので弾く
+    const duringRunning = startedCount;
+
+    running = false; // 完了相当
+    onRun(); // 再度開始できる
+    return { duringRunning, afterFinish: startedCount };
+  });
+
+  expect(result.duringRunning).toBe(1);
+  expect(result.afterFinish).toBe(2);
+});

--- a/extensions/suno-helper/tests/overlay-relay.test.ts
+++ b/extensions/suno-helper/tests/overlay-relay.test.ts
@@ -1,0 +1,58 @@
+// overlay ⇄ runner の background 中継ロジック回帰テスト (#892)。
+//
+// overlay を content script 化したことで `useSunoRunner` は run / stop / queryProgress / progress を
+// tabId 指定せず background 宛に送るよう変更された。background は relayTabId で送信元タブを解決し、
+// 同一タブの runner content へ転送する。この中継先解決が崩れると overlay 上の run/stop/再開/進捗復元が
+// 実機で非機能になる（AI-NEW-useSunoRunner-L65 の回帰防止）。
+//
+// Vitest env は node（chrome モック無し, vitest.config.ts）。webext-core / browser API そのものではなく、
+// 中継の意思決定を担う純関数 relayTabId を tester surface とする（既存の純関数抽出テスト方針に倣う）。
+import { describe, expect, it } from "vitest";
+
+import { relayTabId, requireRelayTab } from "../lib/overlay-relay";
+
+describe("relayTabId: content script 起源は同一タブへ中継する", () => {
+  it("Given overlay (content script) sender (tab.id=42) When relayTabId Then 同一タブ 42 を返す", () => {
+    // overlay の no-tabId メッセージは送信元と同一タブ（runner content が常駐する Suno タブ）へ転送される。
+    expect(relayTabId({ tab: { id: 42 } })).toBe(42);
+  });
+
+  it("Given runner (content script) sender (tab.id=7) When relayTabId Then 同一タブ 7 を返す（progress 折返し）", () => {
+    expect(relayTabId({ tab: { id: 7 } })).toBe(7);
+  });
+});
+
+describe("relayTabId: tab を持たない送信元は中継しない（loop 防止）", () => {
+  it("Given tab フィールド無し sender When relayTabId Then null（runtime 再送ループを防ぐ）", () => {
+    // background 自身 / 廃止済み popup など content script でない送信元。素通しすると no-tabId 再送で
+    // runtime へ戻り無限ループになるため転送しない。
+    expect(relayTabId({})).toBeNull();
+  });
+
+  it("Given tab はあるが id 欠落 sender When relayTabId Then null", () => {
+    expect(relayTabId({ tab: {} })).toBeNull();
+  });
+
+  it("Given tab.id が number でない sender When relayTabId Then null", () => {
+    expect(relayTabId({ tab: { id: undefined } })).toBeNull();
+  });
+});
+
+// run / stop / queryProgress の3中継ハンドラが「null なら throw」骨格を逐語コピペしていた DRY 違反
+// (ARCH-NEW-background-L26) の再発防止。共通化した requireRelayTab に境界判定を1箇所へ集約したことを担保する。
+describe("requireRelayTab: 応答必須の中継は中継先タブを fail-loud で要求する", () => {
+  it("Given content script 起源 sender (tab.id=42) When requireRelayTab Then 同一タブ 42 を返す", () => {
+    expect(requireRelayTab({ tab: { id: 42 } }, "run")).toBe(42);
+  });
+
+  it("Given tab を持たない sender When requireRelayTab Then action 名を含めて throw する", () => {
+    // content script 起源でない＝転送先が無い場合は握りつぶさず throw（fail-loud）。
+    expect(() => requireRelayTab({}, "queryProgress")).toThrow(/queryProgress/);
+  });
+
+  it("Given tab.id 欠落 sender When requireRelayTab Then throw する", () => {
+    expect(() => requireRelayTab({ tab: {} }, "stop")).toThrow(
+      "stop の中継先タブを特定できません（content script 起源ではありません）。",
+    );
+  });
+});

--- a/extensions/suno-helper/tests/overlay-state.test.ts
+++ b/extensions/suno-helper/tests/overlay-state.test.ts
@@ -1,0 +1,104 @@
+// lib/overlay-state.ts の純ロジック回帰テスト (#892 要件2)。
+//
+// overlay-state は「overlay 位置・最小化状態の永続化」と「viewport 外に保存された位置の
+// 内側 clamp 復元」を支える純関数 + chrome.storage I/O を 1 箇所に集約する想定。
+// Vitest env は node（chrome モック無し, vitest.config.ts）のため、storage.defineItem を包む
+// I/O (read/write) はここでは検証せず、node でテスト可能な純関数のみを tester surface とする
+// （既存 resume-state.test.ts / lib/storage.ts が untested なのと同方針）。
+//   - clampPosition: overlay box (top-left=position, size) を viewport 内へ収める。要件2 の clamp 復元。
+//
+// 想定インターフェース（draft step で lib/overlay-state.ts に実装すること）:
+//   export interface OverlayState { position: { x: number; y: number }; minimized: boolean; hidden: boolean }
+//   export function clampPosition(
+//     pos: { x: number; y: number },
+//     viewport: { width: number; height: number },
+//     size: { width: number; height: number },
+//   ): { x: number; y: number }
+// clamp 規約: x ∈ [0, max(0, viewport.width - size.width)] / y ∈ [0, max(0, viewport.height - size.height)]。
+import { describe, expect, it } from "vitest";
+
+import { clampPosition } from "../lib/overlay-state";
+import type { OverlayState } from "../lib/overlay-state";
+
+// 代表的な viewport / overlay サイズ。overlay は viewport より十分小さい前提。
+const VIEWPORT = { width: 1000, height: 800 };
+const SIZE = { width: 200, height: 150 };
+// 上記から導かれる clamp 上限。位置は top-left 基準なので右下端は (viewport - size)。
+const MAX_X = VIEWPORT.width - SIZE.width; // 800
+const MAX_Y = VIEWPORT.height - SIZE.height; // 650
+
+describe("clampPosition: viewport 内に収まる位置 (no-op)", () => {
+  it("Given 完全に内側の位置 When clamp Then そのまま返す（移動しない）", () => {
+    expect(clampPosition({ x: 300, y: 400 }, VIEWPORT, SIZE)).toEqual({ x: 300, y: 400 });
+  });
+
+  it("Given 左上端 (0,0) When clamp Then そのまま返す（境界 inclusive）", () => {
+    expect(clampPosition({ x: 0, y: 0 }, VIEWPORT, SIZE)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("Given 右下端ちょうど (maxX,maxY) When clamp Then そのまま返す（境界 inclusive）", () => {
+    expect(clampPosition({ x: MAX_X, y: MAX_Y }, VIEWPORT, SIZE)).toEqual({ x: MAX_X, y: MAX_Y });
+  });
+});
+
+describe("clampPosition: viewport 外の位置を内側へ clamp (要件2 復元)", () => {
+  it("Given x が負 When clamp Then x=0 へ寄せる（左にはみ出さない）", () => {
+    expect(clampPosition({ x: -50, y: 400 }, VIEWPORT, SIZE)).toEqual({ x: 0, y: 400 });
+  });
+
+  it("Given y が負 When clamp Then y=0 へ寄せる（上にはみ出さない）", () => {
+    expect(clampPosition({ x: 300, y: -120 }, VIEWPORT, SIZE)).toEqual({ x: 300, y: 0 });
+  });
+
+  it("Given x が右端超過 When clamp Then x=maxX へ寄せる（右にはみ出さない）", () => {
+    expect(clampPosition({ x: 5000, y: 400 }, VIEWPORT, SIZE)).toEqual({ x: MAX_X, y: 400 });
+  });
+
+  it("Given y が下端超過 When clamp Then y=maxY へ寄せる（下にはみ出さない）", () => {
+    expect(clampPosition({ x: 300, y: 5000 }, VIEWPORT, SIZE)).toEqual({ x: 300, y: MAX_Y });
+  });
+
+  it("Given 左上方向に両軸はみ出し When clamp Then (0,0) へ寄せる", () => {
+    expect(clampPosition({ x: -999, y: -999 }, VIEWPORT, SIZE)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("Given 右下方向に両軸はみ出し When clamp Then (maxX,maxY) へ寄せる", () => {
+    expect(clampPosition({ x: 9999, y: 9999 }, VIEWPORT, SIZE)).toEqual({ x: MAX_X, y: MAX_Y });
+  });
+});
+
+describe("clampPosition: overlay が viewport より大きい退化ケース", () => {
+  it("Given overlay 幅 > viewport 幅 When clamp Then x=0（負の上限へ吸い込まれない＝max(0,...)）", () => {
+    const bigWidth = { width: 1200, height: 150 };
+    expect(clampPosition({ x: 300, y: 100 }, VIEWPORT, bigWidth)).toEqual({ x: 0, y: 100 });
+  });
+
+  it("Given overlay 高さ > viewport 高さ When clamp Then y=0", () => {
+    const bigHeight = { width: 200, height: 1200 };
+    expect(clampPosition({ x: 100, y: 300 }, VIEWPORT, bigHeight)).toEqual({ x: 100, y: 0 });
+  });
+});
+
+describe("clampPosition: viewport 縮小（resize）後の再 clamp", () => {
+  it("Given 旧 viewport では内側だった位置 + 縮小後 viewport When clamp Then 縮小後の内側へ寄せる（要件2 resize clamp）", () => {
+    // 以前は (700,600) に置いていたが、ウィンドウが 760x520 まで縮んだ → 内側へ引き戻す。
+    const shrunk = { width: 760, height: 520 };
+    expect(clampPosition({ x: 700, y: 600 }, shrunk, SIZE)).toEqual({
+      x: shrunk.width - SIZE.width, // 560
+      y: shrunk.height - SIZE.height, // 370
+    });
+  });
+});
+
+describe("OverlayState: 永続化する状態の形 (要件2)", () => {
+  it("Given position/minimized/hidden を持つ state When position を clamp Then OverlayState の position 形と互換である", () => {
+    const state: OverlayState = { position: { x: -10, y: 5000 }, minimized: true, hidden: false };
+
+    const clamped = clampPosition(state.position, VIEWPORT, SIZE);
+
+    expect(clamped).toEqual({ x: 0, y: MAX_Y });
+    // minimized / hidden は clamp 対象外（位置のみ補正される）。
+    expect(state.minimized).toBe(true);
+    expect(state.hidden).toBe(false);
+  });
+});

--- a/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
+++ b/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
@@ -1,0 +1,76 @@
+// 1-click 自動再開 (#892 要件6) の range 構築ロジックの回帰テスト。
+//
+// 旧挙動: ResumeBanner「再開」は range UI を 1-based で prefill するだけで止まり、
+//         ユーザーが「連続実行」を再押下して初めて生成が走り出した（2 操作）。
+// 新挙動 (要件6): 「再開」1 クリックで run() まで自動実行する。React state は次レンダ反映で
+//         closure から読めないため、acceptResume は 0-based inclusive な RunRange を
+//         ローカルに構築して run({ range }) へ引数で渡す（order.md §2）。
+//
+// その「0-based RunRange 構築」を純関数 resumeRunRange へ抽出して tester surface とする
+// （@testing-library/react 未導入のため、フック本体ではなく純関数で担保する＝既存 plan §6 の推奨）。
+// 想定インターフェース（draft step で lib/resume-state.ts に追加すること。range SSOT に同居）:
+//   export function resumeRunRange(banner: ResumeBanner): RunRange
+//   // 失敗 entry (0-based failedIndex) から末尾 (total-1) まで。手動経路と同じ絶対 index を返す。
+import { describe, expect, it } from "vitest";
+
+import { resolveRunRange, resumeBannerRange, resumeRunRange } from "../lib/resume-state";
+import type { ResumeBanner } from "../lib/resume-state";
+
+function makeBanner(overrides: Partial<ResumeBanner> = {}): ResumeBanner {
+  return { failedIndex: 19, total: 24, ...overrides };
+}
+
+describe("resumeRunRange: バナー承認 → 自動 run() に渡す 0-based inclusive range (要件6)", () => {
+  it("Given failedIndex=19, total=24 When 構築 Then 0-based inclusive {19, 23}（失敗 entry〜末尾）", () => {
+    expect(resumeRunRange(makeBanner({ failedIndex: 19, total: 24 }))).toEqual({ start: 19, end: 23 });
+  });
+
+  it("Given failedIndex=0 (先頭で失敗), total=3 When 構築 Then {0, 2}（全域を再実行）", () => {
+    expect(resumeRunRange(makeBanner({ failedIndex: 0, total: 3 }))).toEqual({ start: 0, end: 2 });
+  });
+
+  it("Given failedIndex=total-1 (末尾で失敗), total=3 When 構築 Then 単一要素 {2, 2}", () => {
+    expect(resumeRunRange(makeBanner({ failedIndex: 2, total: 3 }))).toEqual({ start: 2, end: 2 });
+  });
+
+  it("Given total=1 の単一 entry が先頭で失敗 When 構築 Then {0, 0}", () => {
+    expect(resumeRunRange(makeBanner({ failedIndex: 0, total: 1 }))).toEqual({ start: 0, end: 0 });
+  });
+});
+
+// 要件6 の核心契約: 1-click 自動再開（resumeRunRange を直接 run へ）と、
+// 旧来の「prefill (resumeBannerRange) → run ボタン (resolveRunRange)」経路が
+// 同一の絶対 index を生むこと。新経路が UI round-trip を飛ばしても挙動が一致する保証。
+describe("整合性: 自動再開 range が prefill→手動 run 経路と同一 index になる (要件6)", () => {
+  it("Given failedIndex=19/total=24 When 両経路で range 算出 Then 0-based {19,23} で一致する", () => {
+    const banner = makeBanner({ failedIndex: 19, total: 24 });
+
+    const auto = resumeRunRange(banner); // 1-click 経路: 直接 0-based
+    const prefilled = resumeBannerRange(banner); // 旧経路: 1-based UI prefill
+    const viaUi = resolveRunRange(prefilled.start, prefilled.end, banner.total); // 旧経路: run で 0-based 化
+
+    expect(auto).toEqual(viaUi);
+    expect(auto).toEqual({ start: 19, end: 23 });
+  });
+
+  it("Given failedIndex=0/total=3 When 両経路で range 算出 Then 一致する（先頭失敗の境界）", () => {
+    const banner = makeBanner({ failedIndex: 0, total: 3 });
+
+    const auto = resumeRunRange(banner);
+    const prefilled = resumeBannerRange(banner);
+    const viaUi = resolveRunRange(prefilled.start, prefilled.end, banner.total);
+
+    expect(auto).toEqual(viaUi);
+  });
+
+  it("Given failedIndex=2/total=3 When 両経路で range 算出 Then 単一要素で一致する（末尾失敗の境界）", () => {
+    const banner = makeBanner({ failedIndex: 2, total: 3 });
+
+    const auto = resumeRunRange(banner);
+    const prefilled = resumeBannerRange(banner);
+    const viaUi = resolveRunRange(prefilled.start, prefilled.end, banner.total);
+
+    expect(auto).toEqual(viaUi);
+    expect(auto).toEqual({ start: 2, end: 2 });
+  });
+});

--- a/extensions/suno-helper/wxt.config.ts
+++ b/extensions/suno-helper/wxt.config.ts
@@ -6,6 +6,10 @@ import { MANIFEST_PERMISSIONS } from "./lib/manifest";
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
+  // popup 廃止 (#892 要件5): popup entrypoint を build 対象から外し manifest の default_popup を未指定化する。
+  // これにより action クリックで chrome.action.onClicked が発火し overlay 表示を toggle できる。
+  // popup のソース (entrypoints/popup/) はファイルとして残置し、物理削除は後続 PR に委ねる (order.md スコープ外)。
+  filterEntrypoints: ["background", "content", "overlay"],
   manifest: {
     name: "Suno Helper (youtube-channels-automation)",
     description: "/suno が生成した Style/Lyrics を Suno Custom Mode に順次注入し Generate を連続実行する補助拡張。",


### PR DESCRIPTION
## Summary

## 概要

`extensions/suno-helper/` の popup UI を Chrome 拡張のネイティブ popup window から Suno ページ上の draggable overlay へ移行する。あわせて ResumeBanner の「再開」ボタンを 1 クリックで自動的に生成再開まで進める挙動に変更する。

## 背景・目的

現状の popup は Chrome がブラウザ右上に固定描画する仕様で、Web 側からは位置制御・ドラッグ移動ができない。長い生成セッション中に popup と Suno UI の見たい部分が被るが避けようがなく、運用フィードバックで「位置を変えたい」「理想はドラッグで動かしたい」と要望が出ている。

また `hooks/useSunoRunner.ts` の `acceptResume` (L153-162) は失敗 entry の範囲を range フィールドにプリフィルするだけで処理を止めており、「連続実行」ボタンを再度押下しないと生成が走り出さない。「再開」を押したら自動で生成が再開されるべき、というのが本来の UX。

## 提案する仕様

### 1. Suno UI 上に draggable overlay を注入

- 2 本目の content script (`entrypoints/overlay.content.ts`) を新設、Shadow DOM 上に React tree をマウントする。
- 既存 `entrypoints/content.ts`（runner 本体）は触らず、UI 専用 entrypoint として分離する（責務分離）。
- 既存 Chrome ネイティブ popup は廃止。`wxt.config.ts` の `manifest.action.default_popup` を未指定にし、`chrome.action.onClicked` で overlay 表示を toggle する。
- `components/App.tsx` / `hooks/useSunoRunner.ts` の中身はそのまま overlay 内で再利用（messaging 経由で content と話すだけなのでマウント先は問わない）。
- ドラッグは `pointerdown` / `pointermove` / `pointerup` でカスタム実装（外部 lib 不要）。textarea / input フォーカス中はドラッグ無効化、viewport resize 時は clamp。
- 位置永続化は `chrome.storage.local` の単一キー `sunoOverlayState: { position, minimized, hidden }`（global、Suno は 1 タブ運用前提）。

### 2. 「再開」押下で自動再開

- `useSunoRunner.run()` のシグネチャを `run(overrides?: { range?: RunRange })` に拡張、`overrides.range` があればそれを使う（既存挙動は維持）。
- `acceptResume` 内で `setRangeMode/Start/End` で UI を prefill した直後、ローカル変数で `RunRange` を組み立てて `void run({ range })` を呼ぶ。**React state は次レンダ反映なので closure 経由ではなく引数で渡す**のがポイント。
- 二重実行ガード: `run()` 冒頭で `if (isRunning) return`、`setIsRunning(true)` を `sendMessage("run", ...)` の **前** に動かす。content script 側 `runAll` にも同等フラグを追加。

## ユースケース

- 長い生成セッション中、Suno UI の playlist / clip 一覧を見るために overlay を左下に動かす → reload しても同じ位置で復元
- 生成途中で失敗 → ページ再読み込み → ResumeBanner の「再開」を 1 クリック → そのまま続きが走り出す（従来は range prefill + 連続実行ボタンの 2 操作必要だった）
- 最小化ボタンで overlay を畳んで Suno UI の操作を邪魔しない

## 参照資料

- extensions/suno-helper/hooks/useSunoRunner.ts （`acceptResume` L153-162, `run` L254-287）
- extensions/suno-helper/components/App.tsx （ResumeBanner L71-94）
- extensions/suno-helper/entrypoints/content.ts （`runAll` L139-217, `onMessage("run")` L219-228）
- extensions/suno-helper/entrypoints/popup/main.tsx
- extensions/suno-helper/lib/messaging.ts
- extensions/suno-helper/lib/manifest.ts （MANIFEST_PERMISSIONS SSOT）
- extensions/suno-helper/wxt.config.ts
- extensions/shared/constants.ts

## 影響ファイル

- **新規**:
  - extensions/suno-helper/entrypoints/overlay.content.ts
  - extensions/suno-helper/components/Overlay.tsx
  - extensions/suno-helper/components/useDraggable.ts
  - extensions/suno-helper/lib/overlay-state.ts
  - extensions/suno-helper/tests/overlay-state.test.ts
  - extensions/suno-helper/tests/use-suno-runner-resume.test.ts
  - extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
- **変更**:
  - extensions/suno-helper/hooks/useSunoRunner.ts
  - extensions/suno-helper/entrypoints/background.ts
  - extensions/suno-helper/lib/messaging.ts
  - extensions/suno-helper/wxt.config.ts
  - extensions/shared/constants.ts （`OVERLAY_STATE_KEY` 追加）

## 要件

1. Suno ページ (`https://suno.com/*`) を開くと右上に overlay が表示され、drag handle を掴んで自由な位置に移動できる。
2. overlay 位置・最小化状態は `chrome.storage.local` に永続化され、ページ再読込／タブ再起動でも復元される。viewport より外側に保存されていた場合は内側に clamp する。
3. drag 中も Suno 側の input / textarea にフォーカスがあれば文字入力を妨げない（drag を発火しない）。
4. 最小化ボタンで overlay を畳むと handle 部分のみ残り、それ以外は `pointer-events: none` で Suno UI 操作を邪魔しない。
5. 既存の Chrome ネイティブ popup window は廃止される（`wxt.config.ts` で `default_popup` 未指定、`chrome.action.onClicked` で overlay 表示を toggle）。
6. ResumeBanner の「再開」ボタンを **1 クリック** すると、range UI への prefill だけでなく `run()` まで自動で実行され、即座に生成が走り出す。
7. `isRunning=true` の状態で「再開」を連打しても二重に `run()` が走らない（content script 側の `runAll` も同等のガードを持つ）。
8. Shadow DOM 隔離により Suno 側 CSS と overlay の Tailwind スタイルが競合しない。
9. `lib/manifest.ts::MANIFEST_PERMISSIONS` は変更なし（追加権限ゼロ、`tests/manifest.test.ts` が機械担保）。

## スコープ外

- Suno playlist capture（POST `/suno/playlists`）の実装は本 issue では扱わない（→ 別 issue で対応）
- overlay 内の UI レイアウト全面リデザイン（既存 `<App />` を overlay shell に埋め込むのみ）
- Suno UI 以外（distrokid 等他拡張）への overlay 化の波及
- popup ディレクトリの物理削除（今回は `default_popup` 未指定で実 UI を切る、ファイルは残置して後続 PR で削除可）

## 受け入れ基準

- [ ] `pnpm dev` で WXT dev build → Chrome に Load unpacked → `https://suno.com/create` で右上に overlay 表示
- [ ] drag → reload → 同位置で復元
- [ ] yt-collection-serve 起動 → 数件 entry を実行 → 途中中断 → 再読込 → ResumeBanner の「再開」1 クリックで即生成再開
- [ ] drag 中も Suno textarea へ文字入力可能
- [ ] 最小化トグルが動作
- [ ] `pnpm test`（Vitest）と `pnpm test:e2e`（Playwright）が green

## 実装方針（takt）

- workflow: default
- 理由: 複数の新規ファイル（overlay content script・Overlay コンポーネント・draggable hook・overlay-state lib）と既存 hook（`useSunoRunner.ts`）の挙動変更が絡む。Shadow DOM + Drag + 永続化のテスト網が無いと回帰検知が効かないため、テスト先行で進めたい

## Execution Report

Workflow `default` completed successfully.

Closes #892