### PR TITLE
fix(suno-helper): overlay hidden=true で OverlayShell unmount → 拡張アイコンで復帰不能を修正 (#897)

### DIFF
--- a/extensions/suno-helper/components/Overlay.tsx
+++ b/extensions/suno-helper/components/Overlay.tsx
@@ -6,8 +6,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { onMessage } from "../lib/messaging";
 import {
   clampPosition,
+  hiddenStyle,
   type OverlayState,
   readOverlayState,
+  toggleHidden,
   topRightPosition,
   writeOverlayState,
 } from "../lib/overlay-state";
@@ -83,12 +85,14 @@ function OverlayShell({ initial }: { initial: OverlayState | null }) {
   }, [position]);
 
   // action クリック（background → toggleOverlay）で表示を切り替える (要件5)。
+  // hidden=true でも OverlayShell は unmount せず CSS で隠すため（要件1/3）、この effect は
+  // 表示状態に関わらず常に生存し、hidden→visible への復帰メッセージを受け取れる (#897)。
   useEffect(() => {
     const unwatch = onMessage("toggleOverlay", () => {
       setHidden((prev) => {
-        const next = !prev;
-        persist({ position: positionRef.current, minimized: minimizedRef.current, hidden: next });
-        return next;
+        const next = toggleHidden({ position: positionRef.current, minimized: minimizedRef.current, hidden: prev });
+        persist(next);
+        return next.hidden;
       });
     });
     return () => unwatch();
@@ -102,15 +106,19 @@ function OverlayShell({ initial }: { initial: OverlayState | null }) {
     });
   }, [persist]);
 
-  if (hidden) {
-    return null;
-  }
-
+  // hidden は unmount でなく display:none で表現する (要件1/3)。unmount すると toggleOverlay
+  // リスナーが消え拡張アイコンで復帰不能になるため (#897)、DOM に残したまま CSS で隠す。
   return (
     <div
       ref={containerRef}
       className="fixed overflow-hidden rounded-lg border border-gray-300 bg-white shadow-xl"
-      style={{ left: position.x, top: position.y, width: OVERLAY_WIDTH, zIndex: 2147483647 }}
+      style={{
+        left: position.x,
+        top: position.y,
+        width: OVERLAY_WIDTH,
+        zIndex: 2147483647,
+        ...hiddenStyle(hidden),
+      }}
     >
       {/* handle: 常に pointer-events:auto。最小化中もここだけ残り再展開を受け付ける (要件4)。 */}
       <div

--- a/extensions/suno-helper/lib/overlay-state.ts
+++ b/extensions/suno-helper/lib/overlay-state.ts
@@ -52,6 +52,23 @@ export function topRightPosition(viewport: Size, size: Size): Point {
   return clampPosition({ x: viewport.width - size.width - OVERLAY_MARGIN, y: OVERLAY_MARGIN }, viewport, size);
 }
 
+/**
+ * toggleOverlay 受信時の hidden 反転 (#897 要件2/5)。position / minimized は保持し、
+ * 入力を変異させず新オブジェクトを返す純関数。拡張アイコンクリックで hidden:true → false に戻す本丸。
+ */
+export function toggleHidden(state: OverlayState): OverlayState {
+  return { ...state, hidden: !state.hidden };
+}
+
+/**
+ * hidden を unmount でなく CSS（display）で表現する (#897 要件1/3)。
+ * `if (hidden) return null;` で OverlayShell を unmount すると toggleOverlay リスナーごと消えるため、
+ * DOM に残したまま display:none で隠す。Suno UI への pointer-events 干渉も起こさない。
+ */
+export function hiddenStyle(hidden: boolean): { display: "none" | "block" } {
+  return { display: hidden ? "none" : "block" };
+}
+
 // --- chrome.storage.local I/O（storage item は遅延生成。理由はファイル冒頭コメント参照） ---
 
 let cachedItem: ReturnType<typeof storage.defineItem<OverlayState | null>> | null = null;

--- a/extensions/suno-helper/tests/overlay-toggle.test.ts
+++ b/extensions/suno-helper/tests/overlay-toggle.test.ts
@@ -1,0 +1,83 @@
+// lib/overlay-state.ts の overlay 表示 toggle 純ロジック回帰テスト (#897)。
+//
+// #892 (PR #895) の overlay 実装は `if (hidden) return null;` で hidden=true 時に OverlayShell を
+// unmount していたため、toggleOverlay リスナーごと消滅し「一度 hide すると復帰不能」な片方向 bug を
+// 生んでいた (#897)。修正は (1) unmount せず CSS で隠す, (2) hidden の状態遷移を純関数化して
+// toggleOverlay 受信時の hidden:true → false 遷移を機械担保する、の 2 点。
+//
+// Vitest env は node（chrome モック無し, vitest.config.ts）のため、storage.defineItem を包む
+// I/O (read/write) は検証せず、node でテスト可能な純関数のみを tester surface とする
+// （既存 overlay-state.test.ts / resume-state.test.ts と同方針）。
+//   - toggleHidden: toggleOverlay 受信時の hidden 反転。position/minimized は保持（要件2/4/5）。
+//   - hiddenStyle: hidden を unmount でなく CSS（display）で表現（要件1/3）。
+//
+// 想定インターフェース（draft step で lib/overlay-state.ts に実装すること）:
+//   export function toggleHidden(state: OverlayState): OverlayState
+//   export function hiddenStyle(hidden: boolean): { display: "none" | "block" }
+import { describe, expect, it } from "vitest";
+
+import { hiddenStyle, toggleHidden } from "../lib/overlay-state";
+import type { OverlayState } from "../lib/overlay-state";
+
+function makeOverlayState(overrides: Partial<OverlayState> = {}): OverlayState {
+  return {
+    position: { x: 230, y: 2 },
+    minimized: false,
+    hidden: false,
+    ...overrides,
+  };
+}
+
+describe("toggleHidden: toggleOverlay 受信時の hidden 反転 (要件2/5)", () => {
+  it("Given hidden=true When toggle Then hidden=false（拡張アイコンで復帰する経路 = #897 の本丸）", () => {
+    const state = makeOverlayState({ hidden: true });
+    expect(toggleHidden(state).hidden).toBe(false);
+  });
+
+  it("Given hidden=false When toggle Then hidden=true（visible → hide）", () => {
+    const state = makeOverlayState({ hidden: false });
+    expect(toggleHidden(state).hidden).toBe(true);
+  });
+
+  it("Given 任意 state When toggle 2 回 Then 元の hidden に戻る（反転の冪等性）", () => {
+    const state = makeOverlayState({ hidden: true });
+    expect(toggleHidden(toggleHidden(state)).hidden).toBe(true);
+  });
+});
+
+describe("toggleHidden: hidden 以外のフィールド保持 (要件4 回帰防止)", () => {
+  it("Given position/minimized を持つ state When toggle Then position は保持される（位置永続化に回帰なし）", () => {
+    const state = makeOverlayState({ position: { x: 230, y: 2 }, hidden: true });
+    expect(toggleHidden(state).position).toEqual({ x: 230, y: 2 });
+  });
+
+  it("Given minimized=true When toggle Then minimized は保持される（最小化状態に回帰なし）", () => {
+    const state = makeOverlayState({ minimized: true, hidden: true });
+    expect(toggleHidden(state).minimized).toBe(true);
+  });
+
+  it("Given hidden=true 以外フル指定 When toggle Then hidden だけが反転し他は完全一致", () => {
+    const state = makeOverlayState({ position: { x: 11, y: 22 }, minimized: true, hidden: true });
+    expect(toggleHidden(state)).toEqual({ position: { x: 11, y: 22 }, minimized: true, hidden: false });
+  });
+});
+
+describe("toggleHidden: 純関数性（入力非破壊）", () => {
+  it("Given state When toggle Then 入力 state を変異しない（新オブジェクトを返す）", () => {
+    const state = makeOverlayState({ hidden: true });
+
+    toggleHidden(state);
+
+    expect(state.hidden).toBe(true);
+  });
+});
+
+describe("hiddenStyle: hidden を unmount でなく CSS で表現 (要件1/3)", () => {
+  it("Given hidden=true When style 算出 Then display:none（DOM に残しつつ非表示 = unmount しない）", () => {
+    expect(hiddenStyle(true)).toEqual({ display: "none" });
+  });
+
+  it("Given hidden=false When style 算出 Then display:block（visible・pointer 干渉なし）", () => {
+    expect(hiddenStyle(false)).toEqual({ display: "block" });
+  });
+});


### PR DESCRIPTION
## Summary

## 概要

#892 (PR #895) の overlay 実装 `components/Overlay.tsx:105` で `if (hidden) return null;` を返すため、`hidden=true` 状態で `OverlayShell` 全体が unmount される → L86-95 の `useEffect` cleanup が走り `onMessage("toggleOverlay")` の `unwatch()` が実行されてリスナーが消滅。次に拡張アイコンをクリックしても `background.ts:20` の `sendMessage("toggleOverlay")` に受け手がいないため何も起きない。仕様上「toggle」のはずが「一度 hide すると visible に戻せない」片方向 bug。

## 背景・目的

#892 の要件 5「`chrome.action.onClicked` で overlay 表示を toggle」を満たすには、hidden 状態でも toggleOverlay メッセージを受け取れる必要がある。現状は片方向しか動かず、復帰のための storage 手動削除は一般ユーザーには到達不能 (`chrome.storage.local` は SW DevTools 経由でしか触れない)。

## 再現手順

1. suno.com で overlay 表示確認
2. SW DevTools console から `chrome.storage.local.set({sunoOverlayState: {hidden: true, minimized: false, position: {x: 230, y: 2}}})` を実行 (拡張アイコンのトグル動作で hidden=true に遷移しても同じ最終状態)
3. suno.com tab を reload
4. 拡張アイコンをクリック → overlay 復帰せず、`<suno-helper-overlay>` host element も DOM に存在しない

## 期待される動作

`hidden=true` 状態でも host element と React tree は DOM 上に存在 (visibility だけ false) し、`onMessage("toggleOverlay")` リスナーが生存しているため、拡張アイコンクリックで即 visible に戻る。

## 実際の動作

`if (hidden) return null;` で React が `OverlayShell` を unmount → `useEffect` cleanup でリスナー消滅 → toggleOverlay メッセージ受信者ゼロ → 復帰不能。storage 手動削除以外に戻す術がない。

## 影響範囲

- 一般 operator: 一度 hide してしまうと storage 手動削除なしには復帰不能 (致命的 UX 回帰)
- Load unpacked / CWS 配布いずれの運用でも同じく踏む

## 参照資料

- `extensions/suno-helper/components/Overlay.tsx` (`OverlayShell` の `if (hidden) return null;` L105, useEffect L86-95)
- `extensions/suno-helper/entrypoints/background.ts` (`action.onClicked.addListener` L15-21)
- `extensions/suno-helper/lib/overlay-state.ts` (`readOverlayState` / `writeOverlayState`)
- `extensions/suno-helper/lib/messaging.ts` (`toggleOverlay` ProtocolMap)
- `extensions/suno-helper/tests/overlay-state.test.ts` (純関数テスト網)
- 関連 PR: #895

## 影響ファイル

- **変更**: `extensions/suno-helper/components/Overlay.tsx` (`if (hidden) return null;` の削除と CSS 化、または親への listener 持ち上げ)
- **新規 or 変更**: `extensions/suno-helper/tests/overlay-toggle.test.ts` (フェーズ別 toggle 受信テスト) or `overlay-state.test.ts` 拡張
- **変更**: `extensions/suno-helper/tests/e2e/overlay-drag.spec.ts` に toggle 復帰の e2e を追記 (任意)

## 要件

1. `hidden=true` 状態でも `OverlayShell` がアンマウントされず、`<suno-helper-overlay>` host element と Shadow root の React tree が DOM に存在し続ける
2. `hidden=true` 状態で `chrome.action.onClicked` 由来の `toggleOverlay` メッセージを受信し、`hidden=false` に遷移して overlay が visible になる
3. hidden の表現は CSS (`display: none` / `visibility: hidden` / `pointer-events: none` のいずれか妥当な組み合わせ) で行い、Suno UI への pointer-events 干渉を起こさない
4. 既存の drag / 最小化 / 位置永続化挙動に回帰なし
5. unit test を追加: hidden=true → toggleOverlay 受信 → hidden=false 遷移が機械担保される

## スコープ外

- overlay 表示の UI レイアウト全面リデザイン
- hidden 状態の persist スキーマ変更
- 拡張アイコンの badge / icon 切り替え

## 受け入れ基準

- [ ] `chrome.storage.local.set({sunoOverlayState: {hidden: true, ...}})` 状態で tab を reload → 拡張アイコンを 1 クリックで overlay が右上に visible になる
- [ ] hidden 状態でも `document.querySelector('suno-helper-overlay')` が non-null
- [ ] hidden 状態で Suno UI への pointer events が wedge されない (textarea 入力可能)
- [ ] 既存の e2e (`overlay-drag.spec.ts` / `resume-autorun.spec.ts`) が pass

## 実装方針（takt）

- workflow: `default`
- 理由: 単純な置き換えに見えるが state machine の戻り経路に関わる回帰防止テストが必須。テスト先行で進めるのが正しい

## Execution Report

Workflow `default` completed successfully.

Closes #897