### PR TITLE
fix(suno-helper): Exclude styles 誤検知の解消と slider 注入の fail-soft 化

### DIFF
--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -154,7 +154,7 @@ export async function setSliderValue(
   }
   throw new Error(
     `slider 値の注入に失敗しました（target=${target}, actual=${slider.getAttribute("aria-valuenow")}, ` +
-      `aria-label=${slider.getAttribute("aria-label") ?? "?"}）。Suno の UI 変更の可能性があります。`,
+      `aria-label=${slider.getAttribute("aria-label") ?? "?"}）。Suno が合成イベントを弾いている可能性が高いです（chrome.debugger 化は別 issue で対応予定）。`,
   );
 }
 
@@ -173,23 +173,36 @@ export interface AdvancedFieldValues {
 }
 
 /**
- * Custom Mode > More Options の 3 フィールドを strict visible で解決する（#900）。
+ * 候補から「visible 優先、なければ最初の要素」を返す（#900 改）。
+ * Suno は More Options collapsed 時に祖先を display:none で隠す。input には setNativeValue
+ * で値を入れれば React props まで更新されること、slider は visible でも合成イベントが効かないこと
+ * を実機検証で確認済み。strict visible 必須を緩めて collapsed 時も DOM 上の要素を掴むことで、
+ * input は値が入り（解決）、slider は注入時に fail-soft で skip（injectAdvancedFields 側）になる。
+ */
+function pickPreferVisible<T extends HTMLElement>(els: T[]): T | null {
+  return els.find(isVisible) ?? els[0] ?? null;
+}
+
+/**
+ * Custom Mode > More Options の 3 フィールドを解決する（#900）。
+ * visible 優先、なければ DOM 上の最初の要素を返す（collapsed 時の null 化を回避）。
  * 3 要素すべて不在でも throw しない（fail-soft）。throw / skip の非対称契約は呼び出し側
  * (injectAdvancedFields) が entry の値有無と突き合わせて判定する。
  */
 export function resolveAdvancedFields(): ResolvedAdvancedFields {
-  const excludeStyles =
+  const excludeStyles = pickPreferVisible(
     Array.from(
       document.querySelectorAll<HTMLInputElement>(SELECTORS.excludeStyles),
-    ).find(isVisible) ?? null;
-  const weirdness =
-    Array.from(
-      document.querySelectorAll<HTMLElement>(SELECTORS.weirdness),
-    ).find(isVisible) ?? null;
-  const styleInfluence =
+    ),
+  );
+  const weirdness = pickPreferVisible(
+    Array.from(document.querySelectorAll<HTMLElement>(SELECTORS.weirdness)),
+  );
+  const styleInfluence = pickPreferVisible(
     Array.from(
       document.querySelectorAll<HTMLElement>(SELECTORS.styleInfluence),
-    ).find(isVisible) ?? null;
+    ),
+  );
   return { excludeStyles, weirdness, styleInfluence };
 }
 
@@ -197,10 +210,19 @@ export function resolveAdvancedFields(): ResolvedAdvancedFields {
  * entry の advanced 値を解決済み field へ注入する（#900）。
  * 注入順序は Exclude styles (text, 高速) → Weirdness → Style Influence。
  *
- * 非対称契約（req 4）:
+ * 非対称契約:
  *   - entry に値有 (`!== undefined`) + 対応 selector が null → throw（fail-loud、UI 改装検知）
  *   - entry に値無 (`=== undefined`)                        → skip（fail-soft、後方互換）
- *   - entry に値有 + selector 有                            → 注入する
+ *   - entry に値有 + selector 有 + input                    → setNativeValue で注入（collapsed でも React 反映を実機確認済み）
+ *   - entry に値有 + selector 有 + slider                   → 注入試行し失敗時は warn + skip
+ *
+ * slider fail-soft 化の根拠（実機検証）:
+ *   Suno の Weirdness / Style Influence slider は emotion 自作で onKeyDown 内に isTrusted チェックが
+ *   ある。合成 KeyboardEvent / MouseEvent / PointerEvent はすべて弾かれ、現状の dispatchEvent 方式では
+ *   原理的に値を変えられない。bot 対策で組み込まれていると見られる。throw で連続生成を止めるとユーザー
+ *   体験が大きく劣化するため、本 PR では注入失敗を warn + skip で吸収する。trusted event 経由の真の
+ *   解決は別 issue で chrome.debugger API ベースの設計を予定（manifest permission 拡張が必要）。
+ *
  * 値の有無は `!== undefined` で判定する。0 や "" の falsy 値を truthy 判定で脱落させない。
  */
 export async function injectAdvancedFields(
@@ -210,7 +232,7 @@ export async function injectAdvancedFields(
   if (entry.exclude_styles !== undefined) {
     if (!fields.excludeStyles) {
       throw new Error(
-        "Exclude styles 欄が見つかりません。Custom Mode > More Options を開いているか確認してください。",
+        "Exclude styles 欄が見つかりません。Suno の UI 変更の可能性があります。",
       );
     }
     setNativeValue(fields.excludeStyles, entry.exclude_styles);
@@ -218,18 +240,26 @@ export async function injectAdvancedFields(
   if (entry.weirdness !== undefined) {
     if (!fields.weirdness) {
       throw new Error(
-        "Weirdness slider が見つかりません。Custom Mode > More Options を開いているか確認してください。",
+        "Weirdness slider が見つかりません。Suno の UI 変更の可能性があります。",
       );
     }
-    await setSliderValue(fields.weirdness, entry.weirdness);
+    try {
+      await setSliderValue(fields.weirdness, entry.weirdness);
+    } catch (e) {
+      console.warn("[suno-helper] Weirdness slider 注入を skip:", e);
+    }
   }
   if (entry.style_influence !== undefined) {
     if (!fields.styleInfluence) {
       throw new Error(
-        "Style Influence slider が見つかりません。Custom Mode > More Options を開いているか確認してください。",
+        "Style Influence slider が見つかりません。Suno の UI 変更の可能性があります。",
       );
     }
-    await setSliderValue(fields.styleInfluence, entry.style_influence);
+    try {
+      await setSliderValue(fields.styleInfluence, entry.style_influence);
+    } catch (e) {
+      console.warn("[suno-helper] Style Influence slider 注入を skip:", e);
+    }
   }
 }
 

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -828,14 +828,17 @@ function addExcludeInput(opts: { visible?: boolean } = {}): HTMLInputElement {
 }
 
 describe("resolveAdvancedFields: More Options 3 フィールドの解決 (#900, fail-soft)", () => {
-  // 契約 (draft が実装する public API, shared/dom.ts):
+  // 契約 (shared/dom.ts):
   //   resolveAdvancedFields(): {
-  //     excludeStyles: HTMLInputElement | null;  // input[placeholder="Exclude styles"]、strict visible、不在 null
-  //     weirdness: HTMLElement | null;           // [role="slider"][aria-label="Weirdness"]、strict visible、不在 null
-  //     styleInfluence: HTMLElement | null;      // [role="slider"][aria-label="Style Influence"]、strict visible、不在 null
+  //     excludeStyles: HTMLInputElement | null;
+  //     weirdness: HTMLElement | null;
+  //     styleInfluence: HTMLElement | null;
   //   }
-  //   3 要素すべて不在でも throw しない（fail-soft）。throw / skip の非対称契約は呼び出し側
-  //   (injectAdvancedFields) が entry の値有無と突き合わせて判定する。
+  //   挙動: visible 優先・なければ DOM 上の最初の要素。0 件のみ null（fail-soft、throw しない）。
+  //   実機検証で More Options collapsed 時に 3 要素とも祖先 display:none で isVisible=false になるが
+  //   DOM 自体は残ること、input は閉じてても setNativeValue で React props まで更新されることを確認済み。
+  //   そのため strict visible 必須を緩めて collapsed 時にも要素を掴む。Slider は閉開問わず合成イベントが
+  //   弾かれるため注入時 fail-soft で吸収する（injectAdvancedFields 側）。
 
   it("Given 3 要素すべて visible When 解決する Then すべて解決する", () => {
     const exclude = addExcludeInput();
@@ -878,21 +881,33 @@ describe("resolveAdvancedFields: More Options 3 フィールドの解決 (#900, 
     expect(fields.excludeStyles).toBeNull();
   });
 
-  it("Given bbox 0 の slider When 解決する Then strict isVisible が除外し null", () => {
-    addSlider({ ariaLabel: "Weirdness", value: 0, visible: false });
+  it("Given hidden slider のみ When 解決する Then hidden 要素を返す（collapsed 時の DOM 要素を掴む）", () => {
+    // More Options collapsed 時の挙動。strict visible 必須を撤回した結果、hidden でも DOM 上の要素を返す。
+    const hidden = addSlider({ ariaLabel: "Weirdness", value: 0, visible: false });
 
     const fields = resolveAdvancedFields();
 
-    expect(fields.weirdness).toBeNull();
+    expect(fields.weirdness).toBe(hidden);
   });
 
-  it("Given visibility:hidden の Exclude styles input When 解決する Then strict isVisible が除外し null", () => {
+  it("Given visibility:hidden の Exclude styles input When 解決する Then 該当 input を返す（collapsed 時も値注入できる）", () => {
     const exclude = addExcludeInput();
     exclude.style.visibility = "hidden";
 
     const fields = resolveAdvancedFields();
 
-    expect(fields.excludeStyles).toBeNull();
+    expect(fields.excludeStyles).toBe(exclude);
+  });
+
+  it("Given visible + hidden 混在 When 解決する Then visible を優先する", () => {
+    // 同じ selector に複数 hit する誤検出耐性。実機の Suno UI 改装で visible/hidden が混在した場合に visible を選ぶ。
+    const hidden = addExcludeInput();
+    hidden.style.visibility = "hidden";
+    const visible = addExcludeInput();
+
+    const fields = resolveAdvancedFields();
+
+    expect(fields.excludeStyles).toBe(visible);
   });
 
   it("Given placeholder 不一致の input のみ When 解決する Then excludeStyles は null（厳密 placeholder 一致）", () => {

--- a/extensions/suno-helper/tests/inject-advanced.test.ts
+++ b/extensions/suno-helper/tests/inject-advanced.test.ts
@@ -154,17 +154,11 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
       const weirdness = makeSlider(50, { respond: false });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      const pending = injectAdvancedFields(
-        { weirdness: 30 },
-        { excludeStyles: null, weirdness, styleInfluence: null },
-      );
+      const pending = injectAdvancedFields({ weirdness: 30 }, { excludeStyles: null, weirdness, styleInfluence: null });
       await vi.advanceTimersByTimeAsync(2000);
       await expect(pending).resolves.toBeUndefined();
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Weirdness slider 注入を skip"),
-        expect.any(Error),
-      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Weirdness slider 注入を skip"), expect.any(Error));
       warnSpy.mockRestore();
     });
 

--- a/extensions/suno-helper/tests/inject-advanced.test.ts
+++ b/extensions/suno-helper/tests/inject-advanced.test.ts
@@ -145,6 +145,87 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
     });
   });
 
+  describe("slider 注入失敗 → warn + skip (fail-soft, Suno bot 対策耐性)", () => {
+    // 実機検証で Suno の slider が isTrusted=false の合成イベントを onKeyDown 内で弾くと判明。
+    // dispatchEvent ベースの setSliderValue は原理的に動かず throw する。連続生成を止めると
+    // ユーザー体験が大きく劣化するため、本層では throw を catch して warn + skip に吸収する。
+    // (trusted event 化は chrome.debugger API で別 issue 対応予定)
+    it("Given weirdness slider が反応しない When 注入 Then throw せず console.warn する", async () => {
+      const weirdness = makeSlider(50, { respond: false });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const pending = injectAdvancedFields(
+        { weirdness: 30 },
+        { excludeStyles: null, weirdness, styleInfluence: null },
+      );
+      await vi.advanceTimersByTimeAsync(2000);
+      await expect(pending).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Weirdness slider 注入を skip"),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("Given style_influence slider が反応しない When 注入 Then throw せず console.warn する", async () => {
+      const styleInfluence = makeSlider(50, { respond: false });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const pending = injectAdvancedFields(
+        { style_influence: 85 },
+        { excludeStyles: null, weirdness: null, styleInfluence },
+      );
+      await vi.advanceTimersByTimeAsync(2000);
+      await expect(pending).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Style Influence slider 注入を skip"),
+        expect.any(Error),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("Given weirdness 失敗 + style_influence 反応する When 注入 Then weirdness は skip、style_influence は注入する", async () => {
+      // weirdness 失敗が後続 slider 投入を巻き込んで止めないことを担保（連続生成継続の必要条件）
+      const weirdness = makeSlider(50, { respond: false });
+      const styleInfluence = makeSlider(50);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const pending = injectAdvancedFields(
+        { weirdness: 30, style_influence: 85 },
+        { excludeStyles: null, weirdness, styleInfluence },
+      );
+      await vi.advanceTimersByTimeAsync(3000);
+      await pending;
+
+      expect(weirdness.getAttribute("aria-valuenow")).toBe("50");
+      expect(styleInfluence.getAttribute("aria-valuenow")).toBe("85");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    it("Given exclude_styles + 両 slider 失敗 When 注入 Then exclude_styles は入る、両 slider は warn", async () => {
+      const exclude = makeExcludeInput();
+      const weirdness = makeSlider(50, { respond: false });
+      const styleInfluence = makeSlider(50, { respond: false });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const pending = injectAdvancedFields(
+        { exclude_styles: "hyperpop", weirdness: 30, style_influence: 85 },
+        { excludeStyles: exclude, weirdness, styleInfluence },
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      await pending;
+
+      expect(exclude.value).toBe("hyperpop");
+      expect(weirdness.getAttribute("aria-valuenow")).toBe("50");
+      expect(styleInfluence.getAttribute("aria-valuenow")).toBe("50");
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("注入順序: Exclude styles → Weirdness → Style Influence", () => {
     it("Given 3 フィールド全て設定 When 注入 Then 指定順で副作用が起きる", async () => {
       const order: string[] = [];


### PR DESCRIPTION
## Summary
- More Options collapsed 時に \"Exclude styles 欄が見つかりません\" で連続生成が止まる不具合を解消（実機検証で input は閉じてても setNativeValue で React props まで反映されると確認）
- Style Influence / Weirdness slider の注入失敗を fail-soft 化（throw → \`console.warn\` + skip）。実機検証で Suno が emotion 自作 slider の onKeyDown 内で isTrusted=false の合成イベントを弾いており、現状の dispatchEvent ベースでは原理的に動かないと判明
- chrome.debugger API ベースの本格対応（manifest permission 拡張が必要）は別 issue で改めて設計

## 背景

ユーザーから 2 件の中断エラー報告:

1. \`Exclude styles 欄が見つかりません。Custom Mode > More Options を開いているか確認してください。\`
2. \`slider 値の注入に失敗しました（target=85, actual=52, aria-label=Style Influence）。Suno の UI 変更の可能性があります。\`

chrome-devtools-mcp で Suno DOM を実機検証した結果、2 件の真因は別と判明。

### 真因 1: Exclude styles 誤検知

\`resolveAdvancedFields\` の strict \`isVisible()\` が More Options collapsed 時に祖先 display:none で null 化していたのが原因。input は閉じてても \`setNativeValue\` で **React props (\`__reactProps$.value\`) まで更新される**ことを実機で確証。

修正: \`pickPreferVisible<T>(els)\` を抽出し、visible 優先・なければ DOM 上の最初の要素を返す。collapsed 時も DOM 要素を掴むので throw しない。**More Options 自動展開は不要**だった。

### 真因 2: Slider 注入失敗

Suno の Weirdness / Style Influence は radix-ui ではなく **emotion 自作 slider** (\`css-1d8szr1 e1clmb640\`)。実機検証:

| 試行 | 結果 |
|---|---|
| focus() + dispatchEvent KeyboardEvent ArrowRight×5 | aria-valuenow 変化なし |
| dispatchEvent MouseEvent (mousedown/mouseup/click) | 変化なし |
| dispatchEvent PointerEvent (pointerdown/move/up) | 変化なし |
| \`.click()\` | 変化なし |
| capture phase native listener | isTrusted=false で event は届く |

= **React onKeyDown 内で isTrusted を見て弾いている** と確証（典型的な bot 対策）。dispatchEvent ベースの修正は原理的に不可能。

修正: throw を try/catch で吸収し \`console.warn\` + skip に。連続生成は止めず、slider 値は Suno デフォルト (50) で生成される。

### 比較表

| | 閉じた状態で値注入 | 開いた状態で dispatchEvent |
|---|---|---|
| Exclude styles input | ✅ setNativeValue で動く（React 反映を実機確認） | ✅ |
| Weirdness / Style Influence slider | ❌ 動かない | ❌ 動かない（isTrusted チェック） |

## 変更ファイル

- \`extensions/shared/dom.ts\`: \`pickPreferVisible\` 追加、\`resolveAdvancedFields\` 緩和、\`injectAdvancedFields\` の slider 注入を try/catch + warn、\`setSliderValue\` エラーメッセージ更新
- \`extensions/suno-helper/tests/dom.test.ts\`: 既存 strict isVisible 除外テスト 2 件を新挙動 (hidden でも要素を返す) に書き換え、visible 優先テスト追加
- \`extensions/suno-helper/tests/inject-advanced.test.ts\`: slider fail-soft の挙動 4 ケース追加（weirdness/style_influence 単独失敗、混在、exclude_styles と合わせて）

## Test plan

ローカル検証済み:
- [x] \`pnpm test\` — 447 tests passed (28 files)
- [x] \`pnpm compile\` (tsc --noEmit) — 型エラー無
- [x] \`pnpm lint\` — green
- [x] \`pnpm build\` — chrome-mv3 ビルド成功

実機検証 (Merge 前に Operator が回す):
- [ ] Suno Custom Mode で More Options を **閉じたまま** entry に \`exclude_styles\` を指定 → 値が反映され Generate 時に exclude が効くこと
- [ ] entry に \`style_influence: 85\` を指定 → DevTools console に \`[suno-helper] Style Influence slider 注入を skip\` の warn が出るが**連続生成は止まらない**こと
- [ ] More Options 開いて手動で Style Influence を 85 にしてから連続生成 → 手動設定値で生成されること

## フォロー

別 issue で \`chrome.debugger\` API ベースの slider 注入を設計予定（manifest \`\"debugger\"\` permission 追加、background script から trusted \`Input.dispatchKeyEvent\` 経由）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)