### PR TITLE
[#823] issue-823-ts-rewrite-phase1b-i

### DIFF
--- a/packages/core/src/image/base.ts
+++ b/packages/core/src/image/base.ts
@@ -4,6 +4,12 @@
 // を実装し、`ImageGenerationResult` を返す。Provider 中立の値のみを `Request` に保持し、
 // API 固有の `size` 文字列・`quality` 等は Provider 実装側で `aspectRatio` から導出する。
 
+// 1 件分の画像生成リクエストは service 境界の入力 schema を単一の真実とする
+// （ADR-0003 §8: zod を source of truth）。provider はその検証済みの値を受け取る。
+import type { GenerateImageInput } from "./schema.ts";
+
+export type ImageGenerationRequest = GenerateImageInput;
+
 // 共通リトライ定数（Gemini / OpenAI で共有）。秒単位。
 export const RETRY_MAX = 3;
 export const RETRY_BACKOFF = [10, 30, 60] as const;
@@ -23,23 +29,6 @@ export const backoffMs = (attempt: number): number => {
   }
   return seconds * 1000;
 };
-
-/**
- * 1 件分の画像生成リクエスト。
- *
- * - `prompt`: 生成プロンプト
- * - `outputPath`: 出力先（拡張子 .png なら PNG、.jpg なら JPEG として保存）
- * - `aspectRatio`: "16:9" / "9:16" / "1:1" など。OpenAI は 16:9 / 9:16 のみ受理
- * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
- * - `references`: 参照画像パス（省略・空なら参照なしモード）
- */
-export interface ImageGenerationRequest {
-  readonly prompt: string;
-  readonly outputPath: string;
-  readonly aspectRatio: string;
-  readonly imageSize: string;
-  readonly references?: readonly string[];
-}
 
 /**
  * 画像生成の結果。

--- a/packages/core/src/image/index.ts
+++ b/packages/core/src/image/index.ts
@@ -2,6 +2,8 @@
 // （Python `utils/image_provider/__init__.py` の移植）。
 //
 // 公開 API:
+// - generateImageService(input, deps): ADR-0003 Result 境界（ImageProvider.generate をラップ）
+// - GenerateImageInput / GenerateImageOutput: service 境界の zod schema（+ z.infer 型）
 // - getProvider(config): ImageGenerationConfig から ImageProvider 実装にディスパッチ
 // - parseImageGenerationConfig(raw): skill-config から ImageGenerationConfig を構築
 // - ImageProvider / ImageGenerationRequest / ImageGenerationResult: 抽象契約
@@ -29,6 +31,8 @@ export {
 } from "./config.ts";
 export { GeminiImageProvider, type GeminiProviderDeps } from "./gemini.ts";
 export { OpenAIImageProvider, type OpenAIProviderDeps } from "./openai.ts";
+export { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
+export { generateImageService } from "./service.ts";
 
 /**
  * `ImageGenerationConfig` から対応する provider 実装を返す。

--- a/packages/core/src/image/schema.ts
+++ b/packages/core/src/image/schema.ts
@@ -1,0 +1,41 @@
+// 画像生成サービス境界の入力 / 出力 schema（ADR-0003 §8: zod を source of truth）。
+//
+// 入力はチャンネル config / API レスポンス由来の JSON ではなく、呼び出し側が
+// 組み立てる in-process な値オブジェクトのため、snake_case → camelCase の
+// `.transform()` は不要で camelCase のまま declare する。型は `z.infer` で導出し
+// 並書の `interface` は持たない。`.strict()` で未知キーを reject（fail fast）。
+
+import { z } from "zod";
+
+/**
+ * 1 件分の画像生成リクエスト。
+ *
+ * - `prompt`: 生成プロンプト
+ * - `outputPath`: 出力先（拡張子 .png なら PNG、.jpg なら JPEG として保存）
+ * - `aspectRatio`: "16:9" / "9:16" / "1:1" など。OpenAI は 16:9 / 9:16 のみ受理
+ * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
+ * - `references`: 参照画像パス（省略・空なら参照なしモード）
+ */
+export const GenerateImageInput = z
+  .object({
+    aspectRatio: z.string(),
+    imageSize: z.string(),
+    outputPath: z.string(),
+    prompt: z.string(),
+    references: z.array(z.string()).optional(),
+  })
+  .strict();
+export type GenerateImageInput = z.infer<typeof GenerateImageInput>;
+
+/**
+ * 画像生成の成功結果。
+ *
+ * - `savedPath`: 保存先パス。service は provider が保存成功した場合にのみ
+ *   この値を `ok` で返し、失敗（保存なし）は `ServiceError` に変換する。
+ */
+export const GenerateImageOutput = z
+  .object({
+    savedPath: z.string(),
+  })
+  .strict();
+export type GenerateImageOutput = z.infer<typeof GenerateImageOutput>;

--- a/packages/core/src/image/service.ts
+++ b/packages/core/src/image/service.ts
@@ -1,0 +1,45 @@
+// 画像生成サービス境界（ADR-0003 §1）。`ImageProvider.generate` を Result でラップする。
+//
+// core 内部（provider）は throw OK。境界の try/catch で `toServiceError` 経由に集約し、
+// CLI/MCP は `if (!r.ok)` で discriminate する。マッピング:
+//   - schema 違反（未知キー等）       → err(domain "validation")  (zod ZodError)
+//   - provider 成功                    → ok({ savedPath })
+//   - provider が保存なし（success:false）→ 未 prefix Error を throw → err(domain "io")
+//   - provider が `config:` prefix throw（未対応比率など）→ err(domain "config")
+//
+// credentials は service input に含めない。SDK client / API キーは provider が自身の
+// deps（`createClient`）で保持し、service は構築済み provider を `deps` で受け取る
+// （ADR-0003 §7 / DI seam そのまま）。
+
+import { toServiceError } from "../errors.ts";
+import type { ServiceError } from "../errors.ts";
+import { err, ok } from "../result.ts";
+import type { Result } from "../result.ts";
+import type { ImageProvider } from "./base.ts";
+import { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
+
+/**
+ * 画像を 1 枚生成して保存し、保存先を `Result` で返す。
+ *
+ * 構築済み `ImageProvider`（gemini / openai）を `deps` で受け取る（ADR-0003 §7 /
+ * DI seam そのまま）。入力は `.strict()` schema で先に検証してから provider を
+ * 呼ぶため、不正入力は provider に到達せず validation エラーになる。
+ */
+export const generateImageService = async (
+  input: GenerateImageInput,
+  deps: { provider: ImageProvider }
+): Promise<Result<GenerateImageOutput, ServiceError>> => {
+  try {
+    const request = GenerateImageInput.parse(input);
+    const result = await deps.provider.generate(request);
+    if (!result.success || result.savedPath === null) {
+      // 未 prefix の失敗は io ドメインへ（toServiceError の既定経路）。
+      throw new Error(
+        `${deps.provider.name} provider が画像を保存できませんでした`
+      );
+    }
+    return ok(GenerateImageOutput.parse({ savedPath: result.savedPath }));
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -1,9 +1,18 @@
-// Tests for the GeminiImageProvider — TS port of `utils/image_provider/gemini.py`.
+// Tests for `generateImageService` over the Gemini provider — the ADR-0003
+// Result boundary that wraps `GeminiImageProvider.generate` (Issue #823).
 //
-// The SDK client, the backoff sleep, and the image-persist step are injected
-// (plan §6/§8) so these tests exercise the provider's orchestration — retry,
+// The generate-path tests now call `generateImageService(input, { provider })`
+// and assert on the Result discriminant (`r.ok` / `r.value` / `r.error`) instead
+// of the provider's raw `ImageGenerationResult`. The provider is still
+// constructed directly with injected deps (SDK client / backoff sleep /
+// image-persist), so these tests still exercise its orchestration — retry,
 // SAFETY/RECITATION short-circuit, base64 decode, reference-image inlining —
-// against an in-memory fake instead of `@google/genai`, ADC, and the filesystem.
+// against in-memory fakes, but observe it through the service boundary:
+//   - provider success            → ok(value.savedPath)
+//   - provider `{ success: false }`→ err(domain "io")  (unprefixed failure)
+//   - schema violation            → err(domain "validation")
+// The identity test reads provider metadata the service does not expose, so it
+// keeps talking to the provider directly.
 //
 // Faithful SDK shape (verified against @google/genai docs): the client exposes
 // `models.generateContent(params)` and returns
@@ -17,8 +26,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { GeminiImageProvider } from "@youtube-automation/core/image";
-import type { ImageGenerationRequest } from "@youtube-automation/core/image";
+import {
+  GeminiImageProvider,
+  generateImageService,
+} from "@youtube-automation/core/image";
+import type { GenerateImageInput } from "@youtube-automation/core/image";
 
 // Constructor deps type, derived from the provider itself so the test does not
 // hard-code an exported name for the injection bag.
@@ -97,7 +109,7 @@ const geminiConfig = {
   model: "gemini-3.1-flash-image-preview",
 };
 
-const baseRequest = (outputPath: string): ImageGenerationRequest => ({
+const baseRequest = (outputPath: string): GenerateImageInput => ({
   aspectRatio: "16:9",
   imageSize: "2K",
   outputPath,
@@ -131,7 +143,7 @@ describe("GeminiImageProvider identity", () => {
 
 // --- success path ---------------------------------------------------------
 
-describe("GeminiImageProvider.generate success", () => {
+describe("generateImageService (gemini) success", () => {
   test("decodes the base64 image part and persists the raw bytes", async () => {
     // Given a client that returns one inline image part
     const original = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
@@ -144,12 +156,16 @@ describe("GeminiImageProvider.generate success", () => {
     );
     const outputPath = join(workdir, "out.png");
 
-    // When generating
-    const result = await provider.generate(baseRequest(outputPath));
+    // When generating through the service boundary
+    const r = await generateImageService(baseRequest(outputPath), { provider });
 
-    // Then the decoded bytes are persisted and the saved path is returned
-    expect(result.success).toBe(true);
-    expect(result.savedPath).toBe(outputPath);
+    // Then the result is ok, the decoded bytes are persisted, and the saved
+    // path is carried in `value`
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.savedPath).toBe(outputPath);
     expect(recorders.persisted).toHaveLength(1);
     const [persisted] = recorders.persisted;
     if (!persisted) {
@@ -170,10 +186,15 @@ describe("GeminiImageProvider.generate success", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating with aspect ratio 16:9
-    await provider.generate(baseRequest(join(workdir, "fwd.png")));
+    // When generating with aspect ratio 16:9 through the service
+    const r = await generateImageService(
+      baseRequest(join(workdir, "fwd.png")),
+      { provider }
+    );
 
-    // Then the model is passed through and the aspect ratio reaches the call
+    // Then it succeeds, the model is passed through, and the aspect ratio
+    // reaches the SDK call
+    expect(r.ok).toBe(true);
     expect(calls).toHaveLength(1);
     const params = calls[0] as { model?: unknown };
     expect(params.model).toBe("gemini-3.1-flash-image-preview");
@@ -194,13 +215,13 @@ describe("GeminiImageProvider.generate success", () => {
     );
 
     // When generating with a reference image (gemini.py:45-51)
-    const result = await provider.generate({
-      ...baseRequest(join(workdir, "ref-out.png")),
-      references: [refPath],
-    });
+    const r = await generateImageService(
+      { ...baseRequest(join(workdir, "ref-out.png")), references: [refPath] },
+      { provider }
+    );
 
     // Then it still succeeds and the reference bytes are sent as base64 inlineData
-    expect(result.success).toBe(true);
+    expect(r.ok).toBe(true);
     const refBase64 = Buffer.from(refBytes).toString("base64");
     expect(JSON.stringify(calls[0])).toContain(refBase64);
   });
@@ -208,7 +229,7 @@ describe("GeminiImageProvider.generate success", () => {
 
 // --- retry path -----------------------------------------------------------
 
-describe("GeminiImageProvider.generate retry", () => {
+describe("generateImageService (gemini) retry", () => {
   test("retries on an image-less response and fails after RETRY_MAX attempts", async () => {
     // Given a client that only ever returns text (no image part) (gemini.py:94-96)
     const { calls, client } = makeGeminiClient([
@@ -220,14 +241,19 @@ describe("GeminiImageProvider.generate retry", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      baseRequest(join(workdir, "miss.png"))
+    // When generating through the service
+    const r = await generateImageService(
+      baseRequest(join(workdir, "miss.png")),
+      { provider }
     );
 
-    // Then it exhausts all 3 attempts, sleeps between them, and reports failure
-    expect(result.success).toBe(false);
-    expect(result.savedPath).toBeNull();
+    // Then the unprefixed provider failure maps to an `io` ServiceError after
+    // all 3 attempts and two backoff waits
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
     expect(calls).toHaveLength(3);
     // Two waits (between attempt 1→2 and 2→3), in ms = RETRY_BACKOFF seconds × 1000
     expect(recorders.sleeps).toEqual([10_000, 30_000]);
@@ -252,13 +278,14 @@ describe("GeminiImageProvider.generate retry", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      baseRequest(join(workdir, "late.png"))
+    // When generating through the service
+    const r = await generateImageService(
+      baseRequest(join(workdir, "late.png")),
+      { provider }
     );
 
     // Then the third attempt wins after two backoff waits
-    expect(result.success).toBe(true);
+    expect(r.ok).toBe(true);
     expect(calls).toHaveLength(3);
     expect(recorders.sleeps).toEqual([10_000, 30_000]);
   });
@@ -266,7 +293,7 @@ describe("GeminiImageProvider.generate retry", () => {
 
 // --- content-policy short-circuit ----------------------------------------
 
-describe("GeminiImageProvider.generate content policy", () => {
+describe("generateImageService (gemini) content policy", () => {
   test("does not retry when the SDK reports a SAFETY violation", async () => {
     // Given an error whose message contains SAFETY (gemini.py:100-102)
     const { calls, client } = makeGeminiClient([
@@ -280,14 +307,18 @@ describe("GeminiImageProvider.generate content policy", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      baseRequest(join(workdir, "safety.png"))
+    // When generating through the service
+    const r = await generateImageService(
+      baseRequest(join(workdir, "safety.png")),
+      { provider }
     );
 
-    // Then it fails immediately with no retry and no backoff wait
-    expect(result.success).toBe(false);
-    expect(result.savedPath).toBeNull();
+    // Then it fails (domain "io") immediately with no retry and no backoff wait
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
     expect(calls).toHaveLength(1);
     expect(recorders.sleeps).toEqual([]);
   });
@@ -305,14 +336,47 @@ describe("GeminiImageProvider.generate content policy", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      baseRequest(join(workdir, "recite.png"))
+    // When generating through the service
+    const r = await generateImageService(
+      baseRequest(join(workdir, "recite.png")),
+      { provider }
     );
 
     // Then it short-circuits to failure without retrying
-    expect(result.success).toBe(false);
+    expect(r.ok).toBe(false);
     expect(calls).toHaveLength(1);
     expect(recorders.sleeps).toEqual([]);
+  });
+});
+
+// --- schema boundary ------------------------------------------------------
+
+describe("generateImageService input validation", () => {
+  test("maps a strict-schema violation to a validation error without calling the provider", async () => {
+    // Given a provider whose generate would succeed if it were ever reached
+    const base64 = Buffer.from(new Uint8Array([1])).toString("base64");
+    const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(
+      geminiConfig,
+      makeDeps(client, recorders)
+    );
+
+    // When the input carries an unexpected key the `.strict()` schema rejects
+    const malformed = {
+      ...baseRequest(join(workdir, "bad.png")),
+      unexpected: true,
+    } as unknown as GenerateImageInput;
+    const r = await generateImageService(malformed, { provider });
+
+    // Then the boundary parses first: a validation ServiceError, and the
+    // provider is never invoked
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected validation failure");
+    }
+    expect(r.error.domain).toBe("validation");
+    expect(calls).toEqual([]);
+    expect(recorders.persisted).toEqual([]);
   });
 });

--- a/packages/core/test/image-openai.test.ts
+++ b/packages/core/test/image-openai.test.ts
@@ -1,10 +1,18 @@
-// Tests for the OpenAIImageProvider — TS port of `utils/image_provider/openai.py`.
+// Tests for `generateImageService` over the OpenAI provider — the ADR-0003
+// Result boundary that wraps `OpenAIImageProvider.generate` (Issue #823).
 //
-// The SDK client, the backoff sleep, and the image-persist step are injected
-// (plan §6/§8). Because `createClient` is injected, the default factory's
+// The generate-path tests now call `generateImageService(input, { provider })`
+// and assert on the Result discriminant (`r.ok` / `r.value` / `r.error`). The
+// provider is still constructed directly with injected deps (SDK client /
+// backoff sleep / image-persist), so its orchestration — aspect-ratio → size
+// mapping, b64 decode, edit-vs-generate dispatch, retry — is still exercised
+// against in-memory fakes, but observed through the boundary:
+//   - provider success                 → ok(value.savedPath)
+//   - provider `{ success: false }`    → err(domain "io")     (unprefixed)
+//   - provider `config:`-prefixed throw→ err(domain "config")
+// Because `createClient` is injected, the default factory's
 // `process.env.OPENAI_API_KEY` + `new OpenAI(...)` path is bypassed — no env
-// setup is needed. (#822 moved op-based secret resolution to the cli layer, so
-// the core default factory now reads the key from env directly.)
+// setup is needed. (#822 moved op-based secret resolution to the cli layer.)
 //
 // Faithful SDK shape (verified against openai-node docs): the client exposes
 // `images.generate(params)` and `images.edit(params)`, each returning
@@ -18,8 +26,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { OpenAIImageProvider } from "@youtube-automation/core/image";
-import type { ImageGenerationRequest } from "@youtube-automation/core/image";
+import {
+  generateImageService,
+  OpenAIImageProvider,
+} from "@youtube-automation/core/image";
+import type { GenerateImageInput } from "@youtube-automation/core/image";
 
 type OpenAIDeps = NonNullable<
   ConstructorParameters<typeof OpenAIImageProvider>[1]
@@ -122,7 +133,7 @@ const request = (
   outputPath: string,
   aspectRatio: string,
   references?: string[]
-): ImageGenerationRequest => ({
+): GenerateImageInput => ({
   aspectRatio,
   imageSize: "",
   outputPath,
@@ -155,7 +166,7 @@ describe("OpenAIImageProvider identity", () => {
 
 // --- success path ---------------------------------------------------------
 
-describe("OpenAIImageProvider.generate success", () => {
+describe("generateImageService (openai) success", () => {
   test("maps 16:9 → 1536x1024 and persists the decoded b64 image", async () => {
     // Given a generate response with a single b64 image
     const original = new Uint8Array([0xff, 0xd8, 0xff, 5, 6, 7]);
@@ -170,12 +181,18 @@ describe("OpenAIImageProvider.generate success", () => {
     );
     const outputPath = join(workdir, "wide.png");
 
-    // When generating at 16:9
-    const result = await provider.generate(request(outputPath, "16:9"));
+    // When generating at 16:9 through the service
+    const r = await generateImageService(request(outputPath, "16:9"), {
+      provider,
+    });
 
-    // Then the size maps to landscape, bytes decode, and the path returns
-    expect(result.success).toBe(true);
-    expect(result.savedPath).toBe(outputPath);
+    // Then the result is ok, the size maps to landscape, bytes decode, and the
+    // path is carried in `value`
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.savedPath).toBe(outputPath);
     const [persisted] = recorders.persisted;
     if (!persisted) {
       throw new Error("expected a persisted image");
@@ -204,10 +221,14 @@ describe("OpenAIImageProvider.generate success", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating at 9:16
-    await provider.generate(request(join(workdir, "tall.png"), "9:16"));
+    // When generating at 9:16 through the service
+    const r = await generateImageService(
+      request(join(workdir, "tall.png"), "9:16"),
+      { provider }
+    );
 
-    // Then the size maps to portrait (openai.py:36)
+    // Then it succeeds and the size maps to portrait (openai.py:36)
+    expect(r.ok).toBe(true);
     const params = generateCalls[0] as { size?: unknown };
     expect(params.size).toBe("1024x1536");
   });
@@ -225,13 +246,14 @@ describe("OpenAIImageProvider.generate success", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      request(join(workdir, "first.png"), "16:9")
+    // When generating through the service
+    const r = await generateImageService(
+      request(join(workdir, "first.png"), "16:9"),
+      { provider }
     );
 
     // Then the second item supplies the decoded bytes
-    expect(result.success).toBe(true);
+    expect(r.ok).toBe(true);
     const [persisted] = recorders.persisted;
     if (!persisted) {
       throw new Error("expected a persisted image");
@@ -253,13 +275,14 @@ describe("OpenAIImageProvider.generate success", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating with a reference image
-    const result = await provider.generate(
-      request(join(workdir, "edit-out.png"), "16:9", [refPath])
+    // When generating with a reference image through the service
+    const r = await generateImageService(
+      request(join(workdir, "edit-out.png"), "16:9", [refPath]),
+      { provider }
     );
 
-    // Then the edit endpoint is used and the generate endpoint is not
-    expect(result.success).toBe(true);
+    // Then it succeeds via the edit endpoint and the generate endpoint is unused
+    expect(r.ok).toBe(true);
     expect(editCalls).toHaveLength(1);
     expect(generateCalls).toHaveLength(0);
   });
@@ -267,8 +290,8 @@ describe("OpenAIImageProvider.generate success", () => {
 
 // --- fail-fast on aspect ratio -------------------------------------------
 
-describe("OpenAIImageProvider.generate aspect-ratio guard", () => {
-  test("throws a config:-prefixed error for an unmapped aspect ratio without calling the SDK", async () => {
+describe("generateImageService (openai) aspect-ratio guard", () => {
+  test("maps the unmapped-ratio config error to a config ServiceError without calling the SDK", async () => {
     // Given a request whose ratio is not 16:9 or 9:16 (openai.py:63-67)
     const { client, generateCalls } = makeOpenAIClient({
       generate: [() => imageResponse("ignored")],
@@ -279,11 +302,20 @@ describe("OpenAIImageProvider.generate aspect-ratio guard", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating at an unsupported ratio
-    // Then it fails fast: config:-prefixed Error, no client, no SDK call, no retry wait
-    await expect(
-      provider.generate(request(join(workdir, "square.png"), "1:1"))
-    ).rejects.toThrow(/^config:/u);
+    // When generating at an unsupported ratio through the service
+    const r = await generateImageService(
+      request(join(workdir, "square.png"), "1:1"),
+      { provider }
+    );
+
+    // Then the provider's `config:`-prefixed throw becomes a config
+    // ServiceError, and it fails fast: no client, no SDK call, no retry wait
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("config");
+    expect(r.error.message).toMatch(/^config:/u);
     expect(recorders.clientCreatedCount()).toBe(0);
     expect(generateCalls).toHaveLength(0);
     expect(recorders.sleeps).toEqual([]);
@@ -292,7 +324,7 @@ describe("OpenAIImageProvider.generate aspect-ratio guard", () => {
 
 // --- retry path -----------------------------------------------------------
 
-describe("OpenAIImageProvider.generate retry", () => {
+describe("generateImageService (openai) retry", () => {
   test("retries on an image-less response and fails after RETRY_MAX attempts", async () => {
     // Given a response with no decodable image (openai.py:106-108)
     const { client, generateCalls } = makeOpenAIClient({
@@ -304,14 +336,19 @@ describe("OpenAIImageProvider.generate retry", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      request(join(workdir, "empty.png"), "16:9")
+    // When generating through the service
+    const r = await generateImageService(
+      request(join(workdir, "empty.png"), "16:9"),
+      { provider }
     );
 
-    // Then all 3 attempts run with two backoff waits, ending in failure
-    expect(result.success).toBe(false);
-    expect(result.savedPath).toBeNull();
+    // Then the unprefixed provider failure maps to an `io` ServiceError after
+    // all 3 attempts and two backoff waits
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
     expect(generateCalls).toHaveLength(3);
     expect(recorders.sleeps).toEqual([10_000, 30_000]);
     expect(recorders.persisted).toEqual([]);
@@ -334,13 +371,14 @@ describe("OpenAIImageProvider.generate retry", () => {
       makeDeps(client, recorders)
     );
 
-    // When generating
-    const result = await provider.generate(
-      request(join(workdir, "retry-ok.png"), "16:9")
+    // When generating through the service
+    const r = await generateImageService(
+      request(join(workdir, "retry-ok.png"), "16:9"),
+      { provider }
     );
 
     // Then the second attempt wins after a single backoff wait
-    expect(result.success).toBe(true);
+    expect(r.ok).toBe(true);
     expect(generateCalls).toHaveLength(2);
     expect(recorders.sleeps).toEqual([10_000]);
   });


### PR DESCRIPTION
## Summary

## Parent

epic #727

## What to build

`packages/core/image-provider/service.ts` の export 関数を ADR-0003 規約に揃える。現状 `Promise<T>` を返している image provider service を `Promise<Result<T, ServiceError>>` に変更し、内部 throw を境界で `toServiceError` 経由で Result に wrap する。

- 影響 service: `generateImageService` (Gemini / OpenAI 抽象化)
- DI seam (constructor `deps?` injection) はそのまま、Result 化のみが変更
- bun:test: 既存 31 unit test を Result 形式に更新 (`r.ok` / `r.value` / `r.error` を assert)
- credentials は string-in (raw API key) に統一、env / op CLI の resolution は呼び出し元 (CLI 層) の責務

## Acceptance criteria

- [ ] ADR-0003 の canonical template に準拠
- [ ] service は `Promise<Result<T, ServiceError>>` を返す (内部 throw OK、境界で `toServiceError` 経由)
- [ ] schema は zod (`z.object().strict()`) + `z.infer` で型導出 (`interface` 並書なし)
- [ ] `generateImageService` が `Promise<Result<GenerateImageOutput, ServiceError>>` を返す
- [ ] 内部の throw / try-catch が境界で 1 か所に集約され `toServiceError` 経由
- [ ] 既存 31 unit test が green (Result 形式に書換)
- [ ] credentials を service input に含めず `deps` で受け取る (DI seam そのまま)

## Blocked by

- #821 (Result + ServiceError 規約)

## Refs

- ADR 0003 (#820): docs/adr/0003-service-boundary-contracts.md
- ADR 0002: docs/adr/0002-service-first-architecture.md
- Epic: #727

## Execution Report

Workflow `default` completed successfully.

Closes #823