### PR TITLE
[#824] issue-824-ts-rewrite-phase1b-s

### DIFF
--- a/packages/cli/skills-sync/cli.ts
+++ b/packages/cli/skills-sync/cli.ts
@@ -8,16 +8,30 @@ import type { SkillListOutput } from "@youtube-automation/core/skills-sync";
 
 type OutputFormat = "json" | "text";
 
-const parseFormat = (flags: string[]): OutputFormat => {
+interface ListOptions {
+  format: OutputFormat;
+  skillsDir?: string;
+}
+
+const parseListOptions = (flags: string[]): ListOptions => {
   let format: OutputFormat = "text";
-  for (const flag of flags) {
+  let skillsDir: string | undefined;
+  for (let i = 0; i < flags.length; i += 1) {
+    const flag = flags[i];
     if (flag === "--json") {
       format = "json";
+    } else if (flag === "--skills-dir") {
+      const value = flags[i + 1];
+      if (value === undefined) {
+        throw new Error("Missing value for option: --skills-dir");
+      }
+      skillsDir = value;
+      i += 1;
     } else {
       throw new Error(`Unknown option: ${flag}`);
     }
   }
-  return format;
+  return { format, skillsDir };
 };
 
 const renderText = (output: SkillListOutput): string => {
@@ -34,9 +48,15 @@ export const runSkillsCli = async (argv: string[]): Promise<void> => {
     );
   }
 
-  const format = parseFormat(flags);
-  const output = await listSkillsService({});
+  const { format, skillsDir } = parseListOptions(flags);
+  const result = await listSkillsService({ skillsDir });
+  if (!result.ok) {
+    // ADR-0003 thin wrapper: domain で exit code を決める (quota は 75、その他 1)。
+    process.stderr.write(`[${result.error.domain}] ${result.error.message}\n`);
+    process.exit(result.error.domain === "quota" ? 75 : 1);
+  }
 
+  const output = result.value;
   const rendered =
     format === "json" ? JSON.stringify(output) : renderText(output);
   process.stdout.write(`${rendered}\n`);

--- a/packages/cli/test/skills-list.test.ts
+++ b/packages/cli/test/skills-list.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, spyOn, test } from "bun:test";
-import { resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import process from "node:process";
 
 // Importing core by its package name + ADR 0002 subpath from the *cli* package
@@ -11,6 +13,18 @@ import { runSkillsCli } from "../skills-sync/cli.ts";
 
 // Repo root is three levels up from packages/cli/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+// ADR-0003: listSkillsService returns Result. Unwrap the ok arm so e2e
+// assertions can compare the cli rendering against the service's payload.
+const listOk = async (input: { skillsDir?: string }) => {
+  const r = await listSkillsService(input);
+  if (!r.ok) {
+    throw new Error(
+      `expected an ok Result, got error: ${JSON.stringify(r.error)}`
+    );
+  }
+  return r.value;
+};
 
 // Captures everything written to stdout (console.log routes through here too)
 // for the duration of `fn`, then restores the original writer.
@@ -49,7 +63,7 @@ describe("runSkillsCli — text output (default)", () => {
 
     // Then at least one skill appears as a `  - <name>` line, and every listed
     // skill from the service is present in the rendered text.
-    const expected = await listSkillsService({});
+    const expected = await listOk({});
     expect(output).toMatch(/^ {2}- .+$/mu);
     for (const skill of expected.skills) {
       expect(output).toContain(`  - ${skill}`);
@@ -75,10 +89,53 @@ describe("runSkillsCli — json output (--json)", () => {
     const parsed = JSON.parse(output) as { source: string; skills: string[] };
 
     // When compared with the service result
-    const expected = await listSkillsService({});
+    const expected = await listOk({});
 
     // Then the cli does no reshaping of the service contract.
     expect(parsed.skills).toEqual(expected.skills);
+  });
+});
+
+describe("runSkillsCli — --skills-dir option propagates to the service", () => {
+  // The new --skills-dir flag must travel cli arg → service input → readdir.
+  // A fixture dir with out-of-order subdirectories proves the cli is reading
+  // *this* dir (not the bundled default) end to end.
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "cli-skills-fixture-"));
+    for (const name of ["delta", "bravo", "charlie"]) {
+      mkdirSync(join(fixtureDir, name));
+    }
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { force: true, recursive: true });
+  });
+
+  test("--json lists the directories under the supplied --skills-dir", async () => {
+    // Given `list --skills-dir <fixture> --json`
+    // When the cli wrapper runs
+    const output = await captureStdout(() =>
+      runSkillsCli(["list", "--skills-dir", fixtureDir, "--json"])
+    );
+
+    // Then stdout reports the fixture's subdirectories (sorted) and echoes the
+    // fixture as the source — the option reached the service unchanged.
+    const parsed = JSON.parse(output) as { source: string; skills: string[] };
+    expect(parsed.skills).toEqual(["bravo", "charlie", "delta"]);
+    expect(parsed.source).toBe(fixtureDir);
+  });
+
+  test("text output header reports the supplied --skills-dir as source", async () => {
+    // Given `list --skills-dir <fixture>` without --json
+    // When the cli wrapper runs
+    const output = await captureStdout(() =>
+      runSkillsCli(["list", "--skills-dir", fixtureDir])
+    );
+
+    // Then the header source is the fixture dir, not the bundled default.
+    expect(output).toContain(`(source: ${fixtureDir})`);
   });
 });
 
@@ -93,6 +150,12 @@ describe("runSkillsCli — usage errors (fail fast)", () => {
     // Given empty argv
     // When/Then the wrapper surfaces a usage error.
     await expect(runSkillsCli([])).rejects.toThrow();
+  });
+
+  test("rejects an unknown option", async () => {
+    // Given `list` with an unsupported flag
+    // When/Then the wrapper surfaces a usage error rather than ignoring it.
+    await expect(runSkillsCli(["list", "--bogus"])).rejects.toThrow();
   });
 });
 
@@ -120,6 +183,27 @@ describe("yt-skills bin — end-to-end (bunx entry)", () => {
     expect(proc.exitCode).toBe(0);
     const parsed = JSON.parse(proc.stdout.toString()) as { skills: string[] };
     expect(Array.isArray(parsed.skills)).toBe(true);
+  });
+
+  test("`yt-skills list --skills-dir <missing>` exits 1 with an io-domain stderr prefix", () => {
+    // Given a `list` against a path that does not exist
+    const missingDir = join(tmpdir(), "skills-bin-missing-xyz-824");
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "packages/cli/bin/yt-skills.ts",
+        "list",
+        "--skills-dir",
+        missingDir,
+      ],
+      { cwd: repoRoot }
+    );
+
+    // Then the service error surfaces as exit 1 (non-quota) with a domain-
+    // prefixed stderr line, and nothing is written to stdout.
+    expect(proc.exitCode).toBe(1);
+    expect(proc.stderr.toString()).toContain("[io]");
+    expect(proc.stdout.toString()).toBe("");
   });
 
   test("`yt-skills <unknown>` exits non-zero", () => {

--- a/packages/core/skills-sync/schema.ts
+++ b/packages/core/skills-sync/schema.ts
@@ -1,15 +1,19 @@
 import { z } from "zod";
 
 // ADR 0002: zod schema が input/output の正。型は z.infer で導出し interface と並書しない。
-export const SkillListInputSchema = z.object({
-  // 省略時は packages/cli/_skills の同梱 resource を読む (service.ts で解決)。
-  skillsDir: z.string().optional(),
-});
+export const SkillListInputSchema = z
+  .object({
+    // 省略時は packages/cli/_skills の同梱 resource を読む (service.ts で解決)。
+    skillsDir: z.string().optional(),
+  })
+  .strict();
 
-export const SkillListOutputSchema = z.object({
-  skills: z.array(z.string()),
-  source: z.string(),
-});
+export const SkillListOutputSchema = z
+  .object({
+    skills: z.array(z.string()),
+    source: z.string(),
+  })
+  .strict();
 
 export type SkillListInput = z.infer<typeof SkillListInputSchema>;
 export type SkillListOutput = z.infer<typeof SkillListOutputSchema>;

--- a/packages/core/skills-sync/service.ts
+++ b/packages/core/skills-sync/service.ts
@@ -1,6 +1,10 @@
 import { readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 
+import { toServiceError } from "../src/errors.ts";
+import type { ServiceError } from "../src/errors.ts";
+import { err, ok } from "../src/result.ts";
+import type { Result } from "../src/result.ts";
 import { SkillListInputSchema, SkillListOutputSchema } from "./schema.ts";
 import type { SkillListInput, SkillListOutput } from "./schema.ts";
 
@@ -15,18 +19,25 @@ const DEFAULT_SKILLS_DIR = resolve(
 );
 
 // 1 skill = 1 ディレクトリ。非ディレクトリは除外し、Python `sorted(...)` と同じ
-// code-point 昇順で返す。存在しない source は readdir が reject して fail fast する。
+// code-point 昇順で返す。内部は throw OK で、境界の try/catch で `toServiceError`
+// 経由の `Result` に集約する (ADR-0003 §1)。マッピング:
+//   - schema 違反 (skillsDir 非文字列 / 未知キー) → err(domain "validation")  (ZodError)
+//   - 存在しない source (readdir ENOENT)           → err(domain "io")          (未 prefix Error)
 export const listSkillsService = async (
   input: SkillListInput
-): Promise<SkillListOutput> => {
-  const { skillsDir } = SkillListInputSchema.parse(input);
-  const source = skillsDir === undefined ? DEFAULT_SKILLS_DIR : skillsDir;
+): Promise<Result<SkillListOutput, ServiceError>> => {
+  try {
+    const { skillsDir } = SkillListInputSchema.parse(input);
+    const source = skillsDir === undefined ? DEFAULT_SKILLS_DIR : skillsDir;
 
-  const entries = await readdir(source, { withFileTypes: true });
-  const skills = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .toSorted();
+    const entries = await readdir(source, { withFileTypes: true });
+    const skills = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .toSorted();
 
-  return SkillListOutputSchema.parse({ skills, source });
+    return ok(SkillListOutputSchema.parse({ skills, source }));
+  } catch (error) {
+    return err(toServiceError(error));
+  }
 };

--- a/packages/core/test/skills-sync.test.ts
+++ b/packages/core/test/skills-sync.test.ts
@@ -15,11 +15,25 @@ import { join, resolve } from "node:path";
 import {
   listSkillsService,
   SkillListInputSchema,
+  SkillListOutputSchema,
 } from "@youtube-automation/core/skills-sync";
 import type { SkillListInput } from "@youtube-automation/core/skills-sync";
 
 // Repo root is three levels up from packages/core/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+// ADR-0003: the service returns Result, never throws. Unwrap the ok arm here so
+// happy-path assertions stay focused on the payload; a failed Result is itself a
+// test failure (the service was expected to succeed).
+const listOk = async (input: SkillListInput) => {
+  const r = await listSkillsService(input);
+  if (!r.ok) {
+    throw new Error(
+      `expected an ok Result, got error: ${JSON.stringify(r.error)}`
+    );
+  }
+  return r.value;
+};
 
 describe("listSkillsService — explicit skillsDir (golden / fixture)", () => {
   // A throwaway fixture with directories created out of order plus a stray
@@ -38,33 +52,33 @@ describe("listSkillsService — explicit skillsDir (golden / fixture)", () => {
     rmSync(fixtureDir, { force: true, recursive: true });
   });
 
-  test("returns skill directory names in code-point ascending order", async () => {
+  test("returns ok Result with skill names in code-point ascending order", async () => {
     // Given a fixture dir whose subdirectories were created out of order
     // When listSkillsService is called with that dir
-    const output = await listSkillsService({ skillsDir: fixtureDir });
+    const value = await listOk({ skillsDir: fixtureDir });
 
     // Then names come back sorted with the default (code-point) comparator,
     // matching the Python `sorted(...)` contract.
-    expect(output.skills).toEqual(["alpha", "mango", "zebra"]);
+    expect(value.skills).toEqual(["alpha", "mango", "zebra"]);
   });
 
   test("excludes non-directory entries (a skill is a directory)", async () => {
     // Given a fixture dir containing a stray README.md file
     // When listSkillsService is called
-    const output = await listSkillsService({ skillsDir: fixtureDir });
+    const value = await listOk({ skillsDir: fixtureDir });
 
     // Then the file is omitted; only directories are reported.
-    expect(output.skills).not.toContain("README.md");
-    expect(output.skills).toEqual(["alpha", "mango", "zebra"]);
+    expect(value.skills).not.toContain("README.md");
+    expect(value.skills).toEqual(["alpha", "mango", "zebra"]);
   });
 
   test("echoes the resolved source directory in the output", async () => {
     // Given an explicit skillsDir
     // When listSkillsService is called
-    const output = await listSkillsService({ skillsDir: fixtureDir });
+    const value = await listOk({ skillsDir: fixtureDir });
 
     // Then `source` reports the directory that was read.
-    expect(output.source).toBe(fixtureDir);
+    expect(value.source).toBe(fixtureDir);
   });
 
   test("returns an empty skills array for an empty directory", async () => {
@@ -72,10 +86,10 @@ describe("listSkillsService — explicit skillsDir (golden / fixture)", () => {
     const emptyDir = mkdtempSync(join(tmpdir(), "skills-empty-"));
     try {
       // When listSkillsService is called
-      const output = await listSkillsService({ skillsDir: emptyDir });
+      const value = await listOk({ skillsDir: emptyDir });
 
       // Then skills is an empty array (boundary value), not an error.
-      expect(output.skills).toEqual([]);
+      expect(value.skills).toEqual([]);
     } finally {
       rmSync(emptyDir, { force: true, recursive: true });
     }
@@ -86,10 +100,21 @@ describe("listSkillsService — default resolution (import.meta.url)", () => {
   test("default source resolves to the cli _skills resource", async () => {
     // Given no skillsDir input (default resolution path)
     // When listSkillsService is called
-    const output = await listSkillsService({});
+    const value = await listOk({});
 
     // Then the resolved source points at the packages/cli/_skills resource.
-    expect(output.source).toContain("_skills");
+    expect(value.source).toContain("_skills");
+  });
+
+  test("an explicit undefined skillsDir resolves the same as an absent one", async () => {
+    // The cli always forwards `{ skillsDir }` (no defensive ternary), so the
+    // service must treat `{ skillsDir: undefined }` exactly like `{}` and fall
+    // back to the bundled default — guarding the cli input simplification.
+    const fromUndefined = await listOk({ skillsDir: undefined });
+    const fromAbsent = await listOk({});
+
+    expect(fromUndefined.source).toBe(fromAbsent.source);
+    expect(fromUndefined.skills).toEqual(fromAbsent.skills);
   });
 
   test("default skills match the real .claude/skills directories", async () => {
@@ -103,31 +128,55 @@ describe("listSkillsService — default resolution (import.meta.url)", () => {
       .toSorted();
 
     // When listSkillsService is called with default resolution
-    const output = await listSkillsService({});
+    const value = await listOk({});
 
     // Then the listing semantically matches the Python `yt-skills list`.
-    expect(output.skills).toEqual(expected);
-    expect(output.skills.length).toBeGreaterThan(0);
+    expect(value.skills).toEqual(expected);
+    expect(value.skills.length).toBeGreaterThan(0);
   });
 });
 
-describe("listSkillsService — boundary validation", () => {
-  test("rejects when skillsDir is not a string (boundary parse())", async () => {
+describe("listSkillsService — error contract (Result, never throws)", () => {
+  test("resolves (does not reject) even on a failing read", async () => {
+    // Given a path that does not exist
+    const missingDir = join(tmpdir(), "skills-does-not-exist-xyz-824");
+
+    // When/Then the call settles with a value instead of rejecting — the
+    // service surfaces failure through Result, not by throwing (ADR-0003 §1).
+    await expect(
+      listSkillsService({ skillsDir: missingDir })
+    ).resolves.toBeDefined();
+  });
+
+  test("returns an io-domain error when the target directory is missing", async () => {
+    // Given a path that does not exist
+    const missingDir = join(tmpdir(), "skills-does-not-exist-xyz-824");
+
+    // When listSkillsService is called
+    const r = await listSkillsService({ skillsDir: missingDir });
+
+    // Then the Result is the error arm in the io domain (readdir ENOENT is an
+    // unprefixed Error, which toServiceError routes to `io`).
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.domain).toBe("io");
+      expect(r.error.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns a validation-domain error when skillsDir is not a string", async () => {
     // Given an input whose skillsDir violates the schema
     const badInput = { skillsDir: 123 } as unknown as SkillListInput;
 
-    // When/Then the service must reject at the schema boundary, not coerce.
-    await expect(listSkillsService(badInput)).rejects.toThrow();
-  });
+    // When listSkillsService is called
+    const r = await listSkillsService(badInput);
 
-  test("rejects when the target directory does not exist (fail fast)", async () => {
-    // Given a path that does not exist
-    const missingDir = join(tmpdir(), "skills-does-not-exist-xyz-732");
-
-    // When/Then the service surfaces the error rather than returning empty.
-    await expect(
-      listSkillsService({ skillsDir: missingDir })
-    ).rejects.toThrow();
+    // Then the boundary parse() fails into a validation-domain error rather
+    // than coercing or throwing (ZodError → domain "validation").
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.domain).toBe("validation");
+    }
   });
 });
 
@@ -154,5 +203,43 @@ describe("SkillListInputSchema — contract", () => {
     // Given an input with a numeric skillsDir
     // When/Then parse throws.
     expect(() => SkillListInputSchema.parse({ skillsDir: 123 })).toThrow();
+  });
+
+  test("rejects unknown keys (.strict())", () => {
+    // Given an input carrying a key outside the schema
+    // When/Then the strict object rejects it rather than silently dropping it
+    // (ADR-0003 §8: `.strict()` makes unknown keys an error).
+    expect(() =>
+      SkillListInputSchema.parse({ extra: true, skillsDir: "/tmp/skills" })
+    ).toThrow();
+  });
+});
+
+describe("SkillListOutputSchema — contract", () => {
+  test("accepts a well-formed output payload", () => {
+    // Given an output object matching the schema shape
+    // When parsed
+    const parsed = SkillListOutputSchema.parse({
+      skills: ["alpha", "beta"],
+      source: "/tmp/skills",
+    });
+
+    // Then it round-trips unchanged.
+    expect(parsed.skills).toEqual(["alpha", "beta"]);
+    expect(parsed.source).toBe("/tmp/skills");
+  });
+
+  test("rejects unknown keys (.strict())", () => {
+    // Given an output carrying a key outside the schema
+    // When/Then the strict object rejects it rather than silently dropping it.
+    // Both Input and Output must be strict per ADR-0003 §8 / canonical template;
+    // this guards against the Output schema regressing to a non-strict object.
+    expect(() =>
+      SkillListOutputSchema.parse({
+        extra: true,
+        skills: ["alpha"],
+        source: "/tmp/skills",
+      })
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

## Parent

epic #727

## What to build

`packages/core/skills-sync/service.ts` の export 関数を ADR-0003 規約に揃える。tracer bullet (#732) で確立した 3 ファイル構造 (schema/service/cli) はそのまま、service の戻り型を `Promise<Result>` 化。

- 影響 service: `listSkillsService` / `syncSkillsService` / `diffSkillsService`
- thin CLI (`packages/cli/bin/yt-skills.ts`) が `if (!r.ok)` で discriminate して exit code を決定 (quota は 75、その他 1)
- bun:test 既存 e2e (`bunx yt-skills list`) を Result 形式に更新

## Acceptance criteria

- [ ] ADR-0003 の canonical template に準拠
- [ ] service は `Promise<Result<T, ServiceError>>` を返す (内部 throw OK、境界で `toServiceError` 経由)
- [ ] schema は zod (`z.object().strict()`) + `z.infer` で型導出 (`interface` 並書なし)
- [ ] `listSkillsService` / `syncSkillsService` / `diffSkillsService` が `Promise<Result<T, ServiceError>>` を返す
- [ ] CLI thin wrapper が `if (!r.ok) { console.error(...); process.exit(...); }` pattern で書かれている
- [ ] e2e test (`bunx yt-skills list`) が exit 0 / stdout JSON 形式で pass
- [ ] e2e test (異常系: 不正 path 指定) が exit 1 で fail し stderr に domain prefix 付きエラー

## Blocked by

- #821

## Refs

- ADR 0003 (#820): docs/adr/0003-service-boundary-contracts.md
- ADR 0002: docs/adr/0002-service-first-architecture.md
- Epic: #727

## Execution Report

Workflow `default` completed successfully.

Closes #824