### PR TITLE
fix: RHS重複チェックをタイトル全体の重複チェックに変更

### DIFF
--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -106,8 +106,8 @@ def check_title_template_compliance(
     if vol_hit:
         issues.append(f"巻数表記を検出: {vol_hit!r}（コレクション名の公開タイトル流用を疑ってください）")
 
-    if _has_duplicate_rhs(rhs, existing_titles, separator):
-        issues.append(f"RHS が既存 live タイトルと完全重複: {rhs!r}")
+    if _has_duplicate_full_title(normalized, existing_titles):
+        issues.append(f"タイトル全体が既存 live タイトルと完全重複: {normalized!r}")
 
     if core_vocabulary and not _contains_any_vocab(lhs, core_vocabulary):
         issues.append(f"LHS に鋳型語彙 {list(core_vocabulary)} が含まれません: {lhs!r}")
@@ -123,15 +123,10 @@ def _first_pattern_hit(text: str, patterns: Sequence[str] | Collection[str]) -> 
     return None
 
 
-def _has_duplicate_rhs(rhs: str, existing_titles: Collection[str], separator: str) -> bool:
-    if not rhs:
+def _has_duplicate_full_title(title: str, existing_titles: Collection[str]) -> bool:
+    if not title:
         return False
-    for other in existing_titles:
-        other_parts = str(other).split(separator)
-        other_rhs = other_parts[-1].strip() if len(other_parts) >= 2 else ""
-        if other_rhs and other_rhs == rhs:
-            return True
-    return False
+    return any(title == str(other).strip() for other in existing_titles)
 
 
 def _contains_any_vocab(text: str, vocabulary: Collection[str]) -> bool:

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -277,19 +277,25 @@ class TestCheckTitleTemplateCompliance:
         assert msg is not None
         assert "巻数表記" in msg
 
-    def test_rhs_duplicate_rejected(self) -> None:
+    def test_rhs_duplicate_allowed_when_lhs_differs(self) -> None:
+        # LHS が違えば RHS が同じでも OK（タイトル全体が一意であれば許可）
         title = "Brand New Soul Funk Energy | 3 Hours of Soulful Retro Funk Grooves"
         msg = check_title_template_compliance(title, self.EXISTING, self.CFG)
-        assert msg is not None
-        assert "RHS が既存 live タイトルと完全重複" in msg
+        assert msg is None
 
-    def test_volume_and_rhs_duplicate_both_reported(self) -> None:
-        # issue の事故事例: 巻数表記 + RHS 重複の両方を検出して block
+    def test_full_title_duplicate_rejected(self) -> None:
+        # タイトル全体が既存と完全一致する場合は弾く
+        title = "Pure Soul & Funk Infinity | 3 Hours of Soulful Retro Funk Grooves"
+        msg = check_title_template_compliance(title, self.EXISTING, self.CFG)
+        assert msg is not None
+        assert "タイトル全体が既存 live タイトルと完全重複" in msg
+
+    def test_volume_notation_with_existing_rejected(self) -> None:
+        # 巻数表記は RHS 重複とは独立して検出される
         title = "Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves"
         msg = check_title_template_compliance(title, self.EXISTING, self.CFG)
         assert msg is not None
         assert "巻数表記" in msg
-        assert "RHS が既存 live タイトルと完全重複" in msg
 
     def test_rhs_not_matching_template_rejected(self) -> None:
         title = "Bright Funk & Soul Spirit | A Cozy Funk Mix"


### PR DESCRIPTION
## 問題

現在の実装では `| 1 Hour of Cello & Piano` のような RHS（`|` 以降）が既存のlive動画と一致すると、LHS（`|` より前）が完全に異なっていてもアップロードをブロックしていた。

**実際に発生したケース：**
- 既存: `The 18 Most Beautiful Rachmaninoff-Style Adagios You'll Ever Hear | 1 Hour of Cello & Piano`
- 新規: `The 18 Most Haunting Rachmaninoff-Style Adagios You'll Ever Hear | 1 Hour of Cello & Piano`
- → タイトルは明らかに別の動画なのにブロックされた

## 変更内容

- `_has_duplicate_rhs()` を廃止し、`_has_duplicate_full_title()` に置き換え
- タイトル**全体**が完全一致する場合のみブロックする
- テストを新しい挙動に合わせて更新（50 passed）

## Why

LHSが違えば視聴者には別の動画として認識される。RHSは「1 Hour of Cello & Piano」のようなチャンネルの定型フォーマットであり、毎回変えることを強制するのは運用上の負担が大きく、メリットがない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)