### PR TITLE
fix(distrokid-helper): 配信先ストア全クリアの解消と重要事項チェック・リロード案内の追加 (#923)

### DIFF
--- a/extensions/distrokid-helper/entrypoints/content.ts
+++ b/extensions/distrokid-helper/entrypoints/content.ts
@@ -9,8 +9,9 @@
 // 「続ける」等の送信系操作は一切行わない（規約遵守・スコープ外）。
 
 import {
-  acceptTermsAgreement,
+  acceptImportantTerms,
   assertNewRelease,
+  checkAllStores,
   injectAiDisclosure,
   injectAlbumTitle,
   injectAppleMusicCredits,
@@ -20,6 +21,7 @@ import {
   injectSongwriter,
   injectTrackFile,
   injectTrackTitle,
+  RELOAD_GUIDANCE,
   resolveTrackUuids,
   scrollToDoneButton,
   setTrackCount,
@@ -48,7 +50,7 @@ const documentInjector: Injector = {
     const uuids = resolveTrackUuids(document);
     if (uuids.length !== release.tracks.length) {
       throw new Error(
-        `track 数が DOM と一致しません: DOM=${uuids.length}, payload=${release.tracks.length}`,
+        `track 数が DOM と一致しません: DOM=${uuids.length}, payload=${release.tracks.length}。${RELOAD_GUIDANCE}`,
       );
     }
     release.tracks.forEach((track, i) => {
@@ -58,13 +60,14 @@ const documentInjector: Injector = {
       }
     });
 
-    // (C) Apple Music クレジット（演奏者 / プロデューサー）を全 track に注入する（#888 / #919）。
-    // name 欄に #artistName を、role 欄に profile.credits.performer_role / producer_role を入れる。
-    injectAppleMusicCredits(document, release.tracks.length, profile.credits);
-
-    // (D) 利用規約同意 + upsell 強制 uncheck（#919）。送信前提条件と請求額 \$0 保証。
-    acceptTermsAgreement(document);
+    // Apple Music check が credits 可視化の前提になるため、ストア check を先に行う（#923）。
+    checkAllStores(document);
+    // chk* 除外済みなので配信先は巻き込まない（#923）。
     uncheckUpsells(document);
+    // ストア check 後に可視化されるため await（#923）。
+    await injectAppleMusicCredits(document, release.tracks.length, profile.credits);
+    // ストア check 後でないと条件付き areyousure が不可視のため、ストア check 後に実行（#923）。
+    acceptImportantTerms(document);
   },
   injectTrackFile(trackIndex: number, file: File): void {
     // injector は 0-indexed、DOM の file input は 1-indexed。

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -141,20 +141,27 @@ export const APPLE_CREDIT_SELECTORS = {
   producerRoleByTrack: (track1: number) => `#track-${track1}-producer-1-role`,
 } as const;
 
-// 利用規約同意 checkbox（#919）。「DistroKid ディストリビューション規約を読み、同意しました」。
-// unchecked のままだと送信時に validation で止まるため、フィル完了時点で強制 check する。
-export const TERMS_AGREEMENT_SELECTOR = "#areyousuretandc";
+// credit trigger（「クレジットを追加」）の可視化待ち上限（ms）（#923）。
+// checkAllStores() 後、DistroKid 側が Apple Music ストア check に応じて credit trigger を
+// re-render するまでの待ち上限。既存定数（AI_MODAL_WAIT_TIMEOUT_MS / TRACK_ROW_WAIT_TIMEOUT_MS）
+// に合わせ 10_000 ms とし、実機の遅延に対して安全側を取る。
+export const CREDIT_TRIGGER_WAIT_TIMEOUT_MS = 10_000;
 
 // 続けるボタン（#919）。フィル完了後、確認ボタンが視界に入るよう scrollIntoView する。
 // 規約遵守でクリックは行わない（送信は必ず人間が押す）。
 export const DONE_BUTTON_SELECTOR = "#doneButton";
 
-// オプション（upsell）checkbox 群（#919）。レガシーパック / ディスカバリーパック /
-// ストアマキシマイザー / DistroVid / 音量正規化 等の有料オプションを誤クリックから守るため、
-// フィル時に強制 uncheck して請求額が 0 ドルになる状態を保証する。
-// `name="store"` はディスカバリーパック専用、`name="extras"` がそれ以外の upsell 全部。
+// 実配信先ストア checkbox 群（#923）。DistroKid のデフォルトは全ストア check。
+// name="store" は upsell（shazam / audiomack）と共有されるため id^="chk" で区別する（#923）。
+export const STORE_SELECTORS = {
+  distribution: 'input[type="checkbox"][name="store"][id^="chk"]',
+} as const;
+
+// オプション（upsell）checkbox 群（#923）。
+// name="store" は実配信先 26 個と共有されるが、実配信先は id^="chk" を持つため
+// :not([id^="chk"]) で shazam（ディスカバリーパック）/ audiomack のみ対象にする（#923）。
 export const UPSELL_SELECTORS = {
-  store: 'input[type="checkbox"][name="store"]',
+  store: 'input[type="checkbox"][name="store"]:not([id^="chk"])',
   extras: 'input[type="checkbox"][name="extras"]',
 } as const;
 
@@ -164,6 +171,10 @@ export const NEW_RELEASE_RADIO_SELECTOR = '[name^="previouslyReleased_"][value="
 // track タイトル input の name 接頭辞（DOM order で uuid を列挙する基点）。
 const TITLE_NAME_PREFIX = "title_";
 const TITLE_NAME_SELECTOR = `[name^="${TITLE_NAME_PREFIX}"]`;
+
+// リロードで直るエラーへのリロード案内（#923）。VisibilityTimeoutError / ModalTimeoutError /
+// TrackCountTimeoutError の message 末尾に付加し、ユーザーがリロードで再試行できるようにする。
+export const RELOAD_GUIDANCE = "ページをリロードして最初からやり直してください。";
 
 // 注入先フィールドが見つからないことを表す専用エラー。
 // silent skip せず fail-loud にすることで DistroKid の UI 変更を即座に検知する。
@@ -190,7 +201,7 @@ export class OptionNotFoundError extends Error {
 // silent skip せず fail-loud にすることで DistroKid の UI 変更を即座に検知する。
 export class ModalTimeoutError extends Error {
   constructor(selector: string) {
-    super(`AI 開示 modal の状態変化を待てませんでした: ${selector}`);
+    super(`AI 開示 modal の状態変化を待てませんでした: ${selector}。${RELOAD_GUIDANCE}`);
     this.name = "ModalTimeoutError";
   }
 }
@@ -199,8 +210,17 @@ export class ModalTimeoutError extends Error {
 // silent skip せず fail-loud にすることで DistroKid の UI 変更を即座に検知する。
 export class TrackCountTimeoutError extends Error {
   constructor(selector: string, expected: number) {
-    super(`track 行の生成を待てませんでした: ${selector}（期待数=${expected}）`);
+    super(`track 行の生成を待てませんでした: ${selector}（期待数=${expected}）。${RELOAD_GUIDANCE}`);
     this.name = "TrackCountTimeoutError";
+  }
+}
+
+// 要素の可視化が制限時間内に観測できなかったことを表す専用エラー（#923）。
+// silent skip せず fail-loud にすることで DistroKid の UI 変更を即座に検知する。
+export class VisibilityTimeoutError extends Error {
+  constructor(selector: string) {
+    super(`要素の可視化を待てませんでした: ${selector}。${RELOAD_GUIDANCE}`);
+    this.name = "VisibilityTimeoutError";
   }
 }
 
@@ -317,11 +337,34 @@ export function injectReleaseDate(root: ParentNode, releaseDate: string | null):
   setNativeValue(requireInput(root, RELEASE_DATE_SELECTOR), releaseDate);
 }
 
-// DistroKid 利用規約同意 checkbox を強制 check する（#919）。
-// `#areyousuretandc` が unchecked のままだと送信時に validation で止まるため、フィル時に
-// 必ず check する。要素不在は FieldNotFoundError（fail-loud）で UI 変更を即座に検知する。
-export function acceptTermsAgreement(root: ParentNode): void {
-  setChecked(requireInput(root, TERMS_AGREEMENT_SELECTOR), true);
+// 重要事項 checkbox の id 一覧（常時可視・rect 0×0 レースを回避するため id 直接取得）（#923）。
+const IMPORTANT_TERMS_REQUIRED_IDS = [
+  "#areyousurepromoservices",
+  "#areyousurerecorded",
+  "#areyousureotherartist",
+  "#areyousuretandc",
+] as const;
+
+// 条件付き重要事項 checkbox のセレクタ（ストア選択に連動して可視化）（#923）。
+const IMPORTANT_TERMS_CONDITIONAL_SELECTOR = 'input[type="checkbox"].areyousure';
+
+// 重要事項 checkbox（重要事項・利用規約等）を check する（#923）。
+// required 4 個は id 直接取得（isVisible 非依存）で確実に check する（bbox 0 レース回避）。
+// conditional は .areyousure を列挙し required id を除外した上で可視のもののみ check する
+// （不可視はストア未選択等で DistroKid が要求していない状態なので触らない）。
+export function acceptImportantTerms(root: ParentNode): void {
+  // required 4 個を id で直接 check（bbox 0 レース回避）
+  for (const id of IMPORTANT_TERMS_REQUIRED_IDS) {
+    setChecked(requireInput(root, id), true);
+  }
+  // conditional: .areyousure を列挙し、required id を除外した上で可視のもののみ check
+  const requiredIds = new Set(IMPORTANT_TERMS_REQUIRED_IDS.map((id) => id.slice(1)));
+  const conditionals = Array.from(
+    root.querySelectorAll<HTMLInputElement>(IMPORTANT_TERMS_CONDITIONAL_SELECTOR),
+  ).filter((cb) => !requiredIds.has(cb.id) && isVisible(cb));
+  for (const cb of conditionals) {
+    setChecked(cb, true);
+  }
 }
 
 // 続けるボタン（`#doneButton`）を視界へスクロールする（#919）。
@@ -348,6 +391,23 @@ export function uncheckUpsells(root: ParentNode): void {
   ];
   for (const cb of all) {
     setChecked(cb, false);
+  }
+}
+
+// 配信先ストア 26 個をすべて check する（#923）。
+// DistroKid のデフォルトは全ストア check だが、過去のバグで uncheck 状態になることがある。
+// Apple Music が checked でないと credit 入力欄が不可視になり、後続の injectAppleMusicCredits が
+// 失敗する原因になる（順序依存あり）（#923）。
+// 対象が 0 件なら FieldNotFoundError で fail-loud（DistroKid UI 変更の即検知）。
+export function checkAllStores(root: ParentNode): void {
+  const checkboxes = Array.from(
+    root.querySelectorAll<HTMLInputElement>(STORE_SELECTORS.distribution),
+  );
+  if (checkboxes.length === 0) {
+    throw new FieldNotFoundError(STORE_SELECTORS.distribution);
+  }
+  for (const cb of checkboxes) {
+    setChecked(cb, true);
   }
 }
 
@@ -542,6 +602,34 @@ export function waitForElementCount(
   });
 }
 
+// 指定要素が可視になるのを待つ（既に可視なら即解決）。制限時間超過で VisibilityTimeoutError。
+// checkAllStores() 後に credit trigger が visible 化するまでの待機に使用する（#923）。
+export function waitForElementVisible(el: HTMLElement, timeoutMs: number): Promise<void> {
+  if (isVisible(el)) {
+    return Promise.resolve();
+  }
+  const observeRoot = el.ownerDocument.body ?? el.ownerDocument;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      observer.disconnect();
+      reject(new VisibilityTimeoutError(el.id ? `#${el.id}` : el.tagName.toLowerCase()));
+    }, timeoutMs);
+    const observer = new MutationObserver(() => {
+      if (isVisible(el)) {
+        clearTimeout(timer);
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(observeRoot, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["style", "class", "hidden"],
+    });
+  });
+}
+
 // トラック数 select に曲数を set し、track 行（title_<uuid>）の生成完了を待つ（#888）。
 // value 変更だけでは onchange handler が動かないため change を bubbles:true で発火する。
 // 行生成を待ってから後続の注入（プロファイル / タイトル / credit）へ進む（順序保証）。
@@ -577,7 +665,7 @@ function requireCreditTrigger(root: ParentNode): HTMLElement {
   return trigger;
 }
 
-// Apple Music クレジット（演奏者 / プロデューサー）を全 track に注入する（#888 / #919）。
+// Apple Music クレジット（演奏者 / プロデューサー）を全 track に注入する（#888 / #919 / #923）。
 //
 // トップレベルの「クレジットを追加」を 1 回 click して全 track の入力欄を visible 化し、
 // 各 track の performer / producer に以下を注入する:
@@ -586,13 +674,18 @@ function requireCreditTrigger(root: ParentNode): HTMLElement {
 // role 欄は `dk-searchable-select__native` クラスで display:none に隠れたネイティブ select だが、
 // `setSelectValue` でネイティブ側に setSelectedIndex + change dispatch すれば DistroKid 独自 UI
 // （`.dk-searchable-select__input`）の表示テキストも同期される（実 DOM 検証済み・#919）。
-export function injectAppleMusicCredits(
+// Apple Music ストア check 後に credit trigger が可視化されるまで待つ（#923）。
+// checkAllStores() でストアを check してから本関数が呼ばれる順序依存（content.ts で保証）。
+export async function injectAppleMusicCredits(
   root: ParentNode,
   trackCount: number,
   credits: DistrokidProfileCredits,
-): void {
+): Promise<void> {
   const artistName = requireArtistName(root);
-  requireCreditTrigger(root).click();
+  const trigger = requireCreditTrigger(root);
+  // Apple Music ストア check 後に credit trigger が可視化されるまで待つ（#923）。
+  await waitForElementVisible(trigger, CREDIT_TRIGGER_WAIT_TIMEOUT_MS);
+  trigger.click();
   for (let track1 = 1; track1 <= trackCount; track1 += 1) {
     setNativeValue(
       requireInput(root, APPLE_CREDIT_SELECTORS.performerNameByTrack(track1)),

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -29,6 +29,11 @@ import {
   waitForElement,
   waitForElementCount,
   waitForRemoval,
+  waitForElementVisible,
+  checkAllStores,
+  acceptImportantTerms,
+  scrollToDoneButton,
+  uncheckUpsells,
   PROFILE_SELECTORS,
   ALBUM_SELECTORS,
   RELEASE_DATE_SELECTOR,
@@ -39,18 +44,16 @@ import {
   APPLE_CREDIT_SELECTORS,
   AI_DISCLOSURE_SELECTORS,
   AI_MODAL_SELECTORS,
+  STORE_SELECTORS,
+  DONE_BUTTON_SELECTOR,
+  UPSELL_SELECTORS,
+  CREDIT_TRIGGER_WAIT_TIMEOUT_MS,
   FieldNotFoundError,
   ModalTimeoutError,
   TrackCountTimeoutError,
   OptionNotFoundError,
-} from "../lib/distrokid-injector";
-import {
-  acceptTermsAgreement,
-  scrollToDoneButton,
-  uncheckUpsells,
-  TERMS_AGREEMENT_SELECTOR,
-  DONE_BUTTON_SELECTOR,
-  UPSELL_SELECTORS,
+  VisibilityTimeoutError,
+  RELOAD_GUIDANCE,
 } from "../lib/distrokid-injector";
 import type {
   DistrokidProfile,
@@ -963,6 +966,7 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     const trigger = document.createElement("div");
     trigger.className = "requirements-item-title";
     trigger.textContent = "クレジットを追加";
+    makeVisible(trigger as HTMLElement);
     document.body.appendChild(trigger);
     let triggerClicks = 0;
     trigger.addEventListener("click", () => {
@@ -991,12 +995,12 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     return { getTriggerClicks: () => triggerClicks };
   }
 
-  it("trigger を 1 回 click し、全 track の name / role を注入する", () => {
+  it("trigger を 1 回 click し、全 track の name / role を注入する", async () => {
     // Given
     const { getTriggerClicks } = mountCreditDom(3, { artist: "Soulful Grooves" });
 
     // When
-    injectAppleMusicCredits(document, 3, SAMPLE_CREDITS);
+    await injectAppleMusicCredits(document, 3, SAMPLE_CREDITS);
 
     // Then: トリガーは 1 回だけ click され、全 track の name + role が注入される
     expect(getTriggerClicks()).toBe(1);
@@ -1016,7 +1020,7 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     }
   });
 
-  it("role select の change event が dispatch される（独自 UI 同期のため）", () => {
+  it("role select の change event が dispatch される（独自 UI 同期のため）", async () => {
     // Given: change event を観測する
     mountCreditDom(1, { artist: "X" });
     const perfRole = document.querySelector<HTMLSelectElement>("#track-1-performer-1-role")!;
@@ -1031,7 +1035,7 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     });
 
     // When
-    injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
+    await injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
 
     // Then: setSelectValue は input + change を bubbles:true で 1 回ずつ dispatch する。
     // 実機 DistroKid の `dk-searchable-select` 独自 UI は change を listen して表示テキストを同期する。
@@ -1039,7 +1043,7 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     expect(prodChanges).toBe(1);
   });
 
-  it("複数の .requirements-item-title から「クレジットを追加」を textContent で選ぶ", () => {
+  it("複数の .requirements-item-title から「クレジットを追加」を textContent で選ぶ", async () => {
     // Given: 無関係な requirements-item-title が先に存在する
     const decoy = document.createElement("div");
     decoy.className = "requirements-item-title";
@@ -1052,14 +1056,14 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     const { getTriggerClicks } = mountCreditDom(1, { artist: "X" });
 
     // When
-    injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
+    await injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
 
     // Then: 「クレジットを追加」のみ click され、decoy は触らない
     expect(getTriggerClicks()).toBe(1);
     expect(decoyClicks).toBe(0);
   });
 
-  it("#artistName が無ければ FieldNotFoundError", () => {
+  it("#artistName が無ければ FieldNotFoundError", async () => {
     // Given: trigger と入力欄はあるが #artistName が無い
     const trigger = document.createElement("div");
     trigger.className = "requirements-item-title";
@@ -1068,18 +1072,18 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     mountInput({ id: "track-1-performer-1-name", name: "performer-name" });
     mountInput({ id: "track-1-producer-1-name", name: "producer-name" });
 
-    // Then
-    expect(() => injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).toThrow(FieldNotFoundError);
+    // Then: async function → rejected promise
+    await expect(injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).rejects.toBeInstanceOf(FieldNotFoundError);
   });
 
-  it("#artistName が空なら fail-loud（FieldNotFoundError ではない）", () => {
+  it("#artistName が空なら fail-loud（FieldNotFoundError ではない）", async () => {
     // Given: #artistName はあるが値が空
     mountCreditDom(1, { artist: "" });
 
     // Then: 未検出ではないため FieldNotFoundError とは区別される
     let caught: unknown;
     try {
-      injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
+      await injectAppleMusicCredits(document, 1, SAMPLE_CREDITS);
     } catch (e) {
       caught = e;
     }
@@ -1087,7 +1091,7 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     expect(caught).not.toBeInstanceOf(FieldNotFoundError);
   });
 
-  it("trigger が無ければ FieldNotFoundError", () => {
+  it("trigger が無ければ FieldNotFoundError", async () => {
     // Given: #artistName と入力欄はあるが trigger が無い
     const artist = document.createElement("input");
     artist.id = "artistName";
@@ -1097,11 +1101,11 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     mountInput({ id: "track-1-performer-1-name", name: "performer-name" });
     mountInput({ id: "track-1-producer-1-name", name: "producer-name" });
 
-    // Then
-    expect(() => injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).toThrow(FieldNotFoundError);
+    // Then: async function → rejected promise
+    await expect(injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).rejects.toBeInstanceOf(FieldNotFoundError);
   });
 
-  it("performer name 欄が無ければ FieldNotFoundError", () => {
+  it("performer name 欄が無ければ FieldNotFoundError", async () => {
     // Given: trigger と #artistName はあるが producer のみで performer name 欄が無い
     const artist = document.createElement("input");
     artist.id = "artistName";
@@ -1111,69 +1115,36 @@ describe("injectAppleMusicCredits（#888 / #919 Apple Music クレジット・ro
     const trigger = document.createElement("div");
     trigger.className = "requirements-item-title";
     trigger.textContent = "クレジットを追加";
+    makeVisible(trigger as HTMLElement);
     document.body.appendChild(trigger);
     mountInput({ id: "track-1-producer-1-name", name: "producer-name" });
     mountSelectWithOptions("track-1-producer-1-role", [{ value: "Producer", text: "プロデューサー" }]);
 
     // Then
-    expect(() => injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).toThrow(FieldNotFoundError);
+    await expect(injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).rejects.toBeInstanceOf(FieldNotFoundError);
   });
 
-  it("performer role select が無ければ FieldNotFoundError", () => {
+  it("performer role select が無ければ FieldNotFoundError", async () => {
     // Given: role select だけが欠落している（name 欄は揃っている）
     mountCreditDom(1, { artist: "X", mountRole: false });
 
     // Then
-    expect(() => injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).toThrow(FieldNotFoundError);
+    await expect(injectAppleMusicCredits(document, 1, SAMPLE_CREDITS)).rejects.toBeInstanceOf(FieldNotFoundError);
   });
 
-  it("role が option に無ければ OptionNotFoundError", () => {
+  it("role が option に無ければ OptionNotFoundError", async () => {
     // Given: performer_role に "NonExistent" を指定し、option に無い値を要求する
     mountCreditDom(1, { artist: "X" });
 
     // Then: setSelectValue が fail-loud
-    expect(() =>
+    await expect(
       injectAppleMusicCredits(document, 1, { performer_role: "NonExistent", producer_role: "Producer" }),
-    ).toThrow(OptionNotFoundError);
-  });
-});
-
-describe("acceptTermsAgreement（#919 利用規約同意の強制 check）", () => {
-  it("unchecked なら check に切り替える", () => {
-    // Given
-    const cb = makeCheckbox(document.body, { id: "areyousuretandc" });
-    expect(cb.checked).toBe(false);
-
-    // When
-    acceptTermsAgreement(document);
-
-    // Then
-    expect(cb.checked).toBe(true);
+    ).rejects.toBeInstanceOf(OptionNotFoundError);
   });
 
-  it("既に checked なら no-op（click せず checked を維持）", () => {
-    // Given
-    const cb = makeCheckbox(document.body, { id: "areyousuretandc" });
-    cb.checked = true;
-    let clicks = 0;
-    cb.addEventListener("click", () => {
-      clicks += 1;
-    });
-
-    // When
-    acceptTermsAgreement(document);
-
-    // Then: setChecked は目標と一致なら click しない
-    expect(clicks).toBe(0);
-    expect(cb.checked).toBe(true);
-  });
-
-  it("要素不在なら FieldNotFoundError", () => {
-    expect(() => acceptTermsAgreement(document)).toThrow(FieldNotFoundError);
-  });
-
-  it("セレクタ定数は #areyousuretandc を保証する（DistroKid native id）", () => {
-    expect(TERMS_AGREEMENT_SELECTOR).toBe("#areyousuretandc");
+  it("CREDIT_TRIGGER_WAIT_TIMEOUT_MS は 10_000 ms（既存定数群と同値）", () => {
+    // #923: checkAllStores() 後の DistroKid 側 re-render で credit trigger が可視化されるまでの待ち上限
+    expect(CREDIT_TRIGGER_WAIT_TIMEOUT_MS).toBe(10_000);
   });
 });
 
@@ -1233,9 +1204,231 @@ describe("uncheckUpsells（#919 オプション強制 $0 保証）", () => {
     expect(terms.checked).toBe(true);
   });
 
-  it("セレクタ定数は実機 DOM の name 属性を保証する", () => {
-    expect(UPSELL_SELECTORS.store).toBe('input[type="checkbox"][name="store"]');
+  it("セレクタ定数は実機 DOM の name 属性を保証する（#923 chk* 除外版）", () => {
+    expect(UPSELL_SELECTORS.store).toBe('input[type="checkbox"][name="store"]:not([id^="chk"])');
     expect(UPSELL_SELECTORS.extras).toBe('input[type="checkbox"][name="extras"]');
+  });
+});
+
+describe("checkAllStores（#923 配信先ストア全 check）", () => {
+  it("chk* id を持つ store checkbox を全部 check する", () => {
+    // Given
+    const cb1 = makeCheckbox(document.body, { id: "chkspotify", name: "store" });
+    const cb2 = makeCheckbox(document.body, { id: "chkapplemusic", name: "store" });
+    expect(cb1.checked).toBe(false);
+    expect(cb2.checked).toBe(false);
+
+    // When
+    checkAllStores(document);
+
+    // Then: 全部 check される
+    expect(cb1.checked).toBe(true);
+    expect(cb2.checked).toBe(true);
+  });
+
+  it("chk* id なし（shazam / audiomack）は check しない", () => {
+    // Given: id^="chk" を持つ配信先と id なし upsell が混在
+    const real = makeCheckbox(document.body, { id: "chkspotify", name: "store" });
+    const shazam = makeCheckbox(document.body, { name: "store" });
+    shazam.setAttribute("value", "shazam");
+    shazam.checked = false;
+
+    // When
+    checkAllStores(document);
+
+    // Then: 配信先は check、shazam は untouched
+    expect(real.checked).toBe(true);
+    expect(shazam.checked).toBe(false);
+  });
+
+  it("対象 0 件で FieldNotFoundError（fail-loud）", () => {
+    // Given: name=store の checkbox が一切無い
+    // Then: UI 変更検知のため fail-loud
+    expect(() => checkAllStores(document)).toThrow(FieldNotFoundError);
+  });
+
+  it("STORE_SELECTORS.distribution は id^=chk の配信先だけ対象にする", () => {
+    expect(STORE_SELECTORS.distribution).toBe(
+      'input[type="checkbox"][name="store"][id^="chk"]',
+    );
+  });
+});
+
+describe("uncheckUpsells（#923 chk* 配信先を巻き込まない回帰）", () => {
+  it("chk* id を持つ store は uncheck しない（#923 回帰防止）", () => {
+    // Given: 配信先 checkbox（id^="chk"）が checked
+    const spotify = makeCheckbox(document.body, { id: "chkspotify", name: "store" });
+    spotify.checked = true;
+    let spotifyClicks = 0;
+    spotify.addEventListener("click", () => {
+      spotifyClicks += 1;
+    });
+
+    // When
+    uncheckUpsells(document);
+
+    // Then: 配信先は touch しない（UPSELL_SELECTORS.store は :not([id^="chk"]) を含む）
+    expect(spotifyClicks).toBe(0);
+    expect(spotify.checked).toBe(true);
+  });
+
+  it("shazam（id なし name=store）は uncheck する", () => {
+    // Given: Discovery Pack（shazam）は id なし
+    const shazam = makeCheckbox(document.body, { name: "store" });
+    shazam.setAttribute("value", "shazam");
+    shazam.checked = true;
+
+    // When
+    uncheckUpsells(document);
+
+    // Then: shazam は uncheck される
+    expect(shazam.checked).toBe(false);
+  });
+
+  it("extras は uncheck する", () => {
+    // Given
+    const legacy = makeCheckbox(document.body, { name: "extras" });
+    legacy.checked = true;
+
+    // When
+    uncheckUpsells(document);
+
+    // Then
+    expect(legacy.checked).toBe(false);
+  });
+});
+
+describe("acceptImportantTerms（#923 重要事項 4 個 + 条件付き）", () => {
+  // required 4 個を mount（bbox=0 でも check されることを確認するため getBoundingClientRect をモックしない）
+  function mountRequiredTerms(): HTMLInputElement[] {
+    return [
+      "#areyousurepromoservices",
+      "#areyousurerecorded",
+      "#areyousureotherartist",
+      "#areyousuretandc",
+    ].map((id) => {
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.id = id.slice(1);
+      cb.className = "areyousure";
+      document.body.appendChild(cb);
+      return cb;
+    });
+  }
+
+  it("required 4 個を bbox=0 でも check する（rect 0×0 レース回避）", () => {
+    // Given: 4 個は bbox=0（isVisible で false だが id 直接取得で check される）
+    const cbs = mountRequiredTerms();
+    // bbox=0 のまま（makeVisible しない）
+
+    // When
+    acceptImportantTerms(document);
+
+    // Then: 全部 check される
+    for (const cb of cbs) {
+      expect(cb.checked).toBe(true);
+    }
+  });
+
+  it("conditional の可視のもののみ check する（不可視は skip）", () => {
+    // Given: required 4 個 + 可視 conditional 1 個 + 不可視 conditional 1 個
+    mountRequiredTerms();
+    const visibleCond = document.createElement("input");
+    visibleCond.type = "checkbox";
+    visibleCond.id = "areyousureyoutube";
+    visibleCond.className = "areyousure";
+    makeVisible(visibleCond);
+    document.body.appendChild(visibleCond);
+    const hiddenCond = document.createElement("input");
+    hiddenCond.type = "checkbox";
+    hiddenCond.id = "areyousuresnap";
+    hiddenCond.className = "areyousure";
+    // bbox=0 → isVisible false → skip
+    document.body.appendChild(hiddenCond);
+
+    // When
+    acceptImportantTerms(document);
+
+    // Then: visible は check、hidden は skip
+    expect(visibleCond.checked).toBe(true);
+    expect(hiddenCond.checked).toBe(false);
+  });
+
+  it("required id のいずれかが不在なら FieldNotFoundError", () => {
+    // Given: areyousuretandc だけない
+    for (const id of ["areyousurepromoservices", "areyousurerecorded", "areyousureotherartist"]) {
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.id = id;
+      document.body.appendChild(cb);
+    }
+
+    // Then
+    expect(() => acceptImportantTerms(document)).toThrow(FieldNotFoundError);
+  });
+
+  it("#areyousuretandc が既に checked なら no-op（click せず checked を維持）", () => {
+    // Given: required 4 個を mount し、#areyousuretandc だけ事前 check
+    const cbs = mountRequiredTerms();
+    const tandc = cbs.find((cb) => cb.id === "areyousuretandc")!;
+    tandc.checked = true;
+    let clicks = 0;
+    tandc.addEventListener("click", () => {
+      clicks += 1;
+    });
+
+    // When
+    acceptImportantTerms(document);
+
+    // Then: setChecked は目標と一致なら click しない
+    expect(clicks).toBe(0);
+    expect(tandc.checked).toBe(true);
+  });
+});
+
+describe("VisibilityTimeoutError / waitForElementVisible（#923）", () => {
+  it("既に可視なら即解決する", async () => {
+    // Given: bbox 非 0 の要素
+    const el = document.createElement("div");
+    el.id = "test-visible";
+    makeVisible(el as HTMLElement);
+    document.body.appendChild(el);
+
+    // Then: 即解決
+    await expect(waitForElementVisible(el, 1000)).resolves.toBeUndefined();
+  });
+
+  it("後から可視化される要素を解決する", async () => {
+    // Given: 最初は bbox=0
+    const el = document.createElement("div");
+    el.id = "test-late-visible";
+    document.body.appendChild(el);
+    const promise = waitForElementVisible(el, 1000);
+    // 後から可視化（getBoundingClientRect を mock して MutationObserver をトリガー）
+    setTimeout(() => {
+      makeVisible(el as HTMLElement);
+      // attribute 変更で MutationObserver をトリガー
+      el.setAttribute("style", "display:block");
+    }, 0);
+
+    // Then
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("制限時間内に可視化されなければ VisibilityTimeoutError", async () => {
+    // Given: bbox=0 のまま
+    const el = document.createElement("div");
+    el.id = "test-never-visible";
+    document.body.appendChild(el);
+
+    // Then
+    await expect(waitForElementVisible(el, 20)).rejects.toBeInstanceOf(VisibilityTimeoutError);
+  });
+
+  it("RELOAD_GUIDANCE が ModalTimeoutError / TrackCountTimeoutError / VisibilityTimeoutError の message に含まれる", () => {
+    expect(new ModalTimeoutError("#foo").message).toContain(RELOAD_GUIDANCE);
+    expect(new TrackCountTimeoutError("#foo", 2).message).toContain(RELOAD_GUIDANCE);
+    expect(new VisibilityTimeoutError("#foo").message).toContain(RELOAD_GUIDANCE);
   });
 });
 

--- a/extensions/distrokid-helper/tests/e2e/fixtures/distrokid-new.html
+++ b/extensions/distrokid-helper/tests/e2e/fixtures/distrokid-new.html
@@ -79,16 +79,24 @@
       <!-- track 行はここに生成される。 -->
       <div id="tracks"></div>
 
-      <!-- Apple Music クレジット（#888）。 -->
-      <div class="requirements-item">
+      <!-- Apple Music クレジット（#888 / #923）。初期は hidden（Apple Music unchecked なので）。 -->
+      <div class="requirements-item" hidden>
         <div class="requirements-item-title">クレジットを追加</div>
         <div id="credit-containers"></div>
       </div>
 
-      <!-- オプション (upsell) checkbox 群（#919）。フィル時に強制 uncheck で \$0 保証。 -->
-      <label
-        ><input type="checkbox" name="store" />ディスカバリーパック（24.75ドル／年）</label
-      >
+      <!-- 配信先ストア（実 DOM 準拠 #923）。実配信先は id^="chk"、upsell は id なし。初期は unchecked（クリア済み最悪状態再現）。 -->
+      <label><input type="checkbox" name="store" id="chkspotify" value="spotify" class="distroStore" />Spotify</label>
+      <label><input type="checkbox" name="store" id="chkapplemusic" value="applemusic" class="distroStore" />Apple Music</label>
+      <label><input type="checkbox" name="store" id="chkitunes" value="itunes" class="distroStore" />iTunes</label>
+      <label><input type="checkbox" name="store" id="chkgoogle" value="google" class="distroStore" />YouTube Music</label>
+      <label><input type="checkbox" name="store" id="chksnap" value="snap" class="distroStore" />Snapchat</label>
+      <label><input type="checkbox" name="store" id="chktiktok" value="tiktok" class="distroStore" />TikTok</label>
+      <!-- upsell（id なし）: Discovery Pack（shazam）/ Audiomack -->
+      <label><input type="checkbox" name="store" value="shazam" class="distroStore" />ディスカバリーパック（24.75ドル／年）</label>
+      <label><input type="checkbox" name="store" value="audiomack" class="distroStore js-audiomackExtraCheckbox" />Audiomack（無料）</label>
+
+      <!-- オプション (upsell) extras checkbox 群（#919）。フィル時に強制 uncheck で \$0 保証。 -->
       <label
         ><input type="checkbox" name="extras" />レガシーパック（49ドル）</label
       >
@@ -96,9 +104,17 @@
         ><input type="checkbox" name="extras" />ストアマキシマイザー（7.95ドル／年）</label
       >
 
+      <!-- 重要事項 checkbox（#923）。required 4 個は常時可視。conditional は ストア連動で可視化。 -->
+      <label><input type="checkbox" class="areyousure" id="areyousurepromoservices" />再生回数増加サービスを利用しません</label>
+      <label><input type="checkbox" class="areyousure" id="areyousurerecorded" />自己レコーディングです</label>
+      <label><input type="checkbox" class="areyousure" id="areyousureotherartist" />他アーティスト名は使いません</label>
+      <!-- conditional: areyousureyoutube (hidden initially, shown when chkgoogle checked) -->
+      <label id="label-areyousureyoutube" hidden><input type="checkbox" class="areyousure" id="areyousureyoutube" />YouTube Music 配信同意</label>
+      <label id="label-areyousuresnap" hidden><input type="checkbox" class="areyousure" id="areyousuresnap" />Snapchat 配信同意</label>
+
       <!-- DistroKid 利用規約同意 checkbox（#919）。フィル時に強制 check。 -->
       <label
-        ><input type="checkbox" id="areyousuretandc" />DistroKid
+        ><input type="checkbox" class="areyousure" id="areyousuretandc" />DistroKid
         ディストリビューション規約に同意します</label
       >
 
@@ -317,6 +333,21 @@
 
       // 初期描画（既定は 1 曲 = シングル）。
       changedSongCount();
+
+      // chkapplemusic check/uncheck で credit section の visibility を連動する（#923）。
+      document.querySelector('#chkapplemusic').addEventListener('change', function() {
+        document.querySelector('.requirements-item').hidden = !this.checked;
+      });
+
+      // chkgoogle check で areyousureyoutube を visible 化
+      document.querySelector('#chkgoogle').addEventListener('change', function() {
+        document.querySelector('#label-areyousureyoutube').hidden = !this.checked;
+      });
+
+      // chksnap check で areyousuresnap を visible 化
+      document.querySelector('#chksnap').addEventListener('change', function() {
+        document.querySelector('#label-areyousuresnap').hidden = !this.checked;
+      });
     </script>
   </body>
 </html>

--- a/extensions/distrokid-helper/tests/e2e/inject.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/inject.spec.ts
@@ -181,6 +181,61 @@ test("AI 開示 modal は full check で persona radio を dynamic inject し、
   expect(continueClicked).toBe(false);
 });
 
+test("配信先ストア全 check + upsell uncheck + credits 可視化 + areyousure check (#923)", async ({
+  page,
+}) => {
+  // Given: fixture（初期状態: ストア全 unchecked、credits hidden）
+  await page.goto(fixtureUrl);
+  await setNativeValue(page, "#howManySongsOnThisAlbum", "2");
+
+  // storesが全部 unchecked であることを確認（最悪ケース再現）
+  await expect(page.locator("#chkspotify")).not.toBeChecked();
+  await expect(page.locator("#chkapplemusic")).not.toBeChecked();
+
+  // credits section は hidden（Apple Music unchecked なので）
+  await expect(page.locator(".requirements-item")).toBeHidden();
+
+  // When: 配信先ストアを全 check（checkAllStores の模擬）
+  for (const id of ["chkspotify", "chkapplemusic", "chkitunes", "chkgoogle", "chksnap", "chktiktok"]) {
+    await page.locator(`#${id}`).check();
+  }
+
+  // Then: 配信先 chk* は全 checked
+  await expect(page.locator("#chkspotify")).toBeChecked();
+  await expect(page.locator("#chkapplemusic")).toBeChecked();
+
+  // Then: credits section が visible 化（Apple Music checked → trigger 表示）
+  await expect(page.locator(".requirements-item")).toBeVisible();
+
+  // When: upsell uncheck（shazam / audiomack は name=store だが id なし）
+  await page.evaluate(() => {
+    document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="store"]:not([id^="chk"])').forEach(cb => { if (cb.checked) cb.click(); });
+    document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="extras"]').forEach(cb => { if (cb.checked) cb.click(); });
+  });
+
+  // Then: shazam / audiomack は unchecked、配信先は維持
+  const shazamChecked = await page.evaluate(() => document.querySelector<HTMLInputElement>('input[name="store"][value="shazam"]')?.checked);
+  expect(shazamChecked).toBe(false);
+  await expect(page.locator("#chkspotify")).toBeChecked(); // 配信先は維持
+
+  // When: 「クレジットを追加」click → credit 入力欄 visible
+  await page.getByText("クレジットを追加").click();
+  await expect(page.locator("#track-1-performer-1-name")).toBeVisible();
+
+  // When: areyousure required 4 個を check
+  for (const id of ["areyousurepromoservices", "areyousurerecorded", "areyousureotherartist", "areyousuretandc"]) {
+    await page.locator(`#${id}`).check();
+  }
+  // Then: required 4 個が checked
+  for (const id of ["areyousurepromoservices", "areyousurerecorded", "areyousureotherartist", "areyousuretandc"]) {
+    await expect(page.locator(`#${id}`)).toBeChecked();
+  }
+
+  // Then: 送信ボタンは押されていない
+  const continueClicked = await page.evaluate(() => (window as unknown as { __continueClicked: boolean }).__continueClicked);
+  expect(continueClicked).toBe(false);
+});
+
 test("Apple Music「クレジットを追加」click で全 track の credit 入力欄が visible 化し、注入できる (#888)", async ({
   page,
 }) => {
@@ -192,6 +247,11 @@ test("Apple Music「クレジットを追加」click で全 track の credit 入
     await expect(page.locator(`#track-${n}-producer-1-name`)).toHaveCount(1);
     await expect(page.locator(`#track-${n}-performer-1-name`)).toBeHidden();
   }
+
+  // Given: Apple Music checkbox を check して credit section を visible 化する（#923 fixture 変更対応）。
+  // 初期は unchecked のため、credit trigger も hidden になっている。
+  await page.locator("#chkapplemusic").check();
+  await expect(page.locator(".requirements-item")).toBeVisible();
 
   // When: 「クレジットを追加」を 1 回 click → 全 track の入力欄が visible 化する
   await page.getByText("クレジットを追加").click();


### PR DESCRIPTION
Closes #923

## 概要

DistroKid /new 自動入力拡張の実機運用で報告された 3 バグを修正する。

1. **配信先ストアが全てクリアされる**（→ Apple Music クレジット入力欄が不可視になり入力できない）
2. **重要事項（必須）の上 3 つが未チェック**（利用規約同意のみチェックされていた）
3. **リロードで直るエラーにリロード案内がない**

## 根本原因（実機 DOM 検証済み）

実配信先 26 ストア（Spotify / Apple Music 等）は `name="store"` + `id="chk*"` だが、upsell のディスカバリーパック（`value="shazam"`）と Audiomack も**同じ `name="store"`**（id なし）。`uncheckUpsells()` の `input[name="store"]` 一括 uncheck が実配信先まで巻き込んでいた。

## 変更内容

- `UPSELL_SELECTORS.store` を `:not([id^="chk"])` で upsell のみに限定（バグ修正の核心）
- `checkAllStores()` 新設: `input[name="store"][id^="chk"]` を全 check（DistroKid デフォルト準拠 + クリア済み状態からの復旧）。0 件は `FieldNotFoundError` で fail-loud
- `acceptTermsAgreement` → `acceptImportantTerms` に一般化:
  - 常時可視の必須 4 個（`#areyousurepromoservices` / `#areyousurerecorded` / `#areyousureotherartist` / `#areyousuretandc`）は id 直接 check（#919 の rect 0×0 レース回避）
  - ストア連動の条件付き（youtube / snap / tiktokcml / nonstandardscaps）は `isVisible` で可視のもののみ check
- `injectAppleMusicCredits` を async 化し、credit trigger の可視化を `waitForElementVisible`（`CREDIT_TRIGGER_WAIT_TIMEOUT_MS = 10s`）で待機
- `injectStaticFields` の順序を **ストア check → upsell uncheck → credits → 重要事項** に再設計（順序依存をコメントで明文化）
- `RELOAD_GUIDANCE` を新設し、`ModalTimeoutError` / `TrackCountTimeoutError` / `VisibilityTimeoutError` / track 数不一致エラーの message に付加（popup は message をそのまま表示するため変更不要）

## テスト

- Vitest: **135/135 green**（checkAllStores / uncheckUpsells 回帰（chk* を uncheck しない）/ acceptImportantTerms / waitForElementVisible / リロード文言）
- Playwright e2e: **4/4 green**（fixture を実 DOM 追従し、「全ストア check → upsell uncheck → credits 可視化 → 重要事項 check」の順序シナリオを追加。`__continueClicked === false` ガード維持）
- `pnpm compile` / `pnpm build` green
- 実機 DOM 照合（distrokid.com/new、read-only）: `[id^="chk"]` = 26 件、`:not([id^="chk"])` = shazam / audiomack のみ、必須 areyousure 4 id 存在、credit trigger 存在 — 全セレクタ一致を確認済み

## スコープ外

- 「続ける」等の送信系操作（規約遵守・既存方針どおり一切触れない）
- ストア選択の config 化（全 check 固定。必要なら別 issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)