### PR TITLE
style(config): loader.py の ruff format 崩れを修正

### DIFF
--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -605,9 +605,7 @@ def _build_credits(raw: object) -> DistrokidProfileCredits:
     if raw is None:
         return DistrokidProfileCredits()
     if not isinstance(raw, dict):
-        raise ConfigError(
-            f"distrokid.profile.credits は object でなければなりません（got {type(raw).__name__}）"
-        )
+        raise ConfigError(f"distrokid.profile.credits は object でなければなりません（got {type(raw).__name__}）")
     return DistrokidProfileCredits(
         performer_role=str(raw.get("performer_role", "Audio")),
         producer_role=str(raw.get("producer_role", "Producer")),


### PR DESCRIPTION
## 概要

#911 で `src/youtube_automation/utils/config/loader.py` に ruff format 崩れが混入し、main の CI lint ジョブ（`ruff format --check .`）が落ちている。`uv run ruff format` を適用して修正する（挙動変更なし・1 箇所のみ）。

#925 のマージがこの lint 失敗でブロックされているため先行してマージする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)