### PR TITLE
feat(distrokid-helper): Roblox / Snapchat を配信先から除外 (#928)

### DIFF
--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -157,6 +157,10 @@ export const STORE_SELECTORS = {
   distribution: 'input[type="checkbox"][name="store"][id^="chk"]',
 } as const;
 
+// 配信除外ストア（#928）。check 時に確認ポップアップが表示され自動フィルを阻害するため、
+// check せず、checked なら uncheck して配信外を保証する（運用上もこの 2 ストアへは配信しない）。
+export const EXCLUDED_STORE_IDS = ["chksnap", "chkroblox"] as const;
+
 // オプション（upsell）checkbox 群（#923）。
 // name="store" は実配信先 26 個と共有されるが、実配信先は id^="chk" を持つため
 // :not([id^="chk"]) で shazam（ディスカバリーパック）/ audiomack のみ対象にする（#923）。
@@ -394,11 +398,18 @@ export function uncheckUpsells(root: ParentNode): void {
   }
 }
 
-// 配信先ストア 26 個をすべて check する（#923）。
+// 配信先ストア checkbox を check する（#923 / #928）。
 // DistroKid のデフォルトは全ストア check だが、過去のバグで uncheck 状態になることがある。
 // Apple Music が checked でないと credit 入力欄が不可視になり、後続の injectAppleMusicCredits が
 // 失敗する原因になる（順序依存あり）（#923）。
 // 対象が 0 件なら FieldNotFoundError で fail-loud（DistroKid UI 変更の即検知）。
+//
+// EXCLUDED_STORE_IDS（chksnap / chkroblox）に該当する checkbox は check せず、
+// 事前に checked の場合は uncheck して配信外を保証する（#928）。
+// check 時に確認ポップアップが表示されるため自動フィルを阻害し、運用上も配信しない。
+// なお Snapchat（#chksnap）が unchecked のままになるため、条件付き重要事項
+// #areyousuresnap は不可視のまま残り、acceptImportantTerms の isVisible フィルタで
+// 自然にスキップされる（実装変更不要）。
 export function checkAllStores(root: ParentNode): void {
   const checkboxes = Array.from(
     root.querySelectorAll<HTMLInputElement>(STORE_SELECTORS.distribution),
@@ -406,8 +417,13 @@ export function checkAllStores(root: ParentNode): void {
   if (checkboxes.length === 0) {
     throw new FieldNotFoundError(STORE_SELECTORS.distribution);
   }
+  const excluded = new Set<string>(EXCLUDED_STORE_IDS);
   for (const cb of checkboxes) {
-    setChecked(cb, true);
+    if (excluded.has(cb.id)) {
+      setChecked(cb, false);
+    } else {
+      setChecked(cb, true);
+    }
   }
 }
 

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -45,6 +45,7 @@ import {
   AI_DISCLOSURE_SELECTORS,
   AI_MODAL_SELECTORS,
   STORE_SELECTORS,
+  EXCLUDED_STORE_IDS,
   DONE_BUTTON_SELECTOR,
   UPSELL_SELECTORS,
   CREDIT_TRIGGER_WAIT_TIMEOUT_MS,
@@ -1210,20 +1211,41 @@ describe("uncheckUpsells（#919 オプション強制 $0 保証）", () => {
   });
 });
 
-describe("checkAllStores（#923 配信先ストア全 check）", () => {
-  it("chk* id を持つ store checkbox を全部 check する", () => {
+describe("checkAllStores（#923 / #928 配信先ストア check・除外 2 ストア uncheck 保証）", () => {
+  it("除外 2 ストア（chksnap / chkroblox）以外の chk* を check する", () => {
     // Given
     const cb1 = makeCheckbox(document.body, { id: "chkspotify", name: "store" });
     const cb2 = makeCheckbox(document.body, { id: "chkapplemusic", name: "store" });
-    expect(cb1.checked).toBe(false);
-    expect(cb2.checked).toBe(false);
+    const cbSnap = makeCheckbox(document.body, { id: "chksnap", name: "store" });
+    const cbRoblox = makeCheckbox(document.body, { id: "chkroblox", name: "store" });
 
     // When
     checkAllStores(document);
 
-    // Then: 全部 check される
+    // Then: 除外 2 ストア以外は check、除外 2 ストアは unchecked のまま
     expect(cb1.checked).toBe(true);
     expect(cb2.checked).toBe(true);
+    expect(cbSnap.checked).toBe(false);
+    expect(cbRoblox.checked).toBe(false);
+  });
+
+  it("chksnap / chkroblox が事前に checked の場合は uncheck される（DistroKid デフォルト全 check からの配信外保証）", () => {
+    // Given: DistroKid のデフォルト全 check 状態を再現
+    const cbSnap = makeCheckbox(document.body, { id: "chksnap", name: "store" });
+    cbSnap.checked = true;
+    const cbRoblox = makeCheckbox(document.body, { id: "chkroblox", name: "store" });
+    cbRoblox.checked = true;
+    const cbSpotify = makeCheckbox(document.body, { id: "chkspotify", name: "store" });
+    cbSpotify.checked = true;
+
+    // When
+    checkAllStores(document);
+
+    // Then: 除外 2 ストアは uncheck される
+    expect(cbSnap.checked).toBe(false);
+    expect(cbRoblox.checked).toBe(false);
+    // 他ストアは check 維持（no-op）
+    expect(cbSpotify.checked).toBe(true);
   });
 
   it("chk* id なし（shazam / audiomack）は check しない", () => {
@@ -1251,6 +1273,10 @@ describe("checkAllStores（#923 配信先ストア全 check）", () => {
     expect(STORE_SELECTORS.distribution).toBe(
       'input[type="checkbox"][name="store"][id^="chk"]',
     );
+  });
+
+  it("EXCLUDED_STORE_IDS は [\"chksnap\", \"chkroblox\"] の契約を固定する", () => {
+    expect(EXCLUDED_STORE_IDS).toEqual(["chksnap", "chkroblox"]);
   });
 });
 

--- a/extensions/distrokid-helper/tests/e2e/fixtures/distrokid-new.html
+++ b/extensions/distrokid-helper/tests/e2e/fixtures/distrokid-new.html
@@ -91,6 +91,7 @@
       <label><input type="checkbox" name="store" id="chkitunes" value="itunes" class="distroStore" />iTunes</label>
       <label><input type="checkbox" name="store" id="chkgoogle" value="google" class="distroStore" />YouTube Music</label>
       <label><input type="checkbox" name="store" id="chksnap" value="snap" class="distroStore" />Snapchat</label>
+      <label><input type="checkbox" name="store" id="chkroblox" value="roblox" class="distroStore" />Roblox</label>
       <label><input type="checkbox" name="store" id="chktiktok" value="tiktok" class="distroStore" />TikTok</label>
       <!-- upsell（id なし）: Discovery Pack（shazam）/ Audiomack -->
       <label><input type="checkbox" name="store" value="shazam" class="distroStore" />ディスカバリーパック（24.75ドル／年）</label>

--- a/extensions/distrokid-helper/tests/e2e/inject.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/inject.spec.ts
@@ -181,31 +181,54 @@ test("AI 開示 modal は full check で persona radio を dynamic inject し、
   expect(continueClicked).toBe(false);
 });
 
-test("配信先ストア全 check + upsell uncheck + credits 可視化 + areyousure check (#923)", async ({
+test("配信先ストア check（除外 2 ストア uncheck 保証）+ upsell uncheck + credits 可視化 + areyousure check (#923 / #928)", async ({
   page,
 }) => {
   // Given: fixture（初期状態: ストア全 unchecked、credits hidden）
   await page.goto(fixtureUrl);
   await setNativeValue(page, "#howManySongsOnThisAlbum", "2");
 
-  // storesが全部 unchecked であることを確認（最悪ケース再現）
+  // stores が全部 unchecked であることを確認（最悪ケース再現）
   await expect(page.locator("#chkspotify")).not.toBeChecked();
   await expect(page.locator("#chkapplemusic")).not.toBeChecked();
 
   // credits section は hidden（Apple Music unchecked なので）
   await expect(page.locator(".requirements-item")).toBeHidden();
 
-  // When: 配信先ストアを全 check（checkAllStores の模擬）
-  for (const id of ["chkspotify", "chkapplemusic", "chkitunes", "chkgoogle", "chksnap", "chktiktok"]) {
-    await page.locator(`#${id}`).check();
+  // When: checkAllStores の模擬 — 除外 2 ストア（chksnap / chkroblox）以外を check し、
+  // 除外ストアが事前 checked の場合は uncheck する（#928）。
+  // fixture の初期は全 unchecked なので除外 2 ストアは skip（uncheck 保証は事前 checked ケースで確認）。
+  const allStoreIds = await page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="store"][id^="chk"]'),
+    ).map((cb) => cb.id),
+  );
+  const excludedIds = new Set(["chksnap", "chkroblox"]);
+  for (const id of allStoreIds) {
+    if (excludedIds.has(id)) {
+      // 除外ストアが checked なら uncheck、unchecked なら触らない
+      const isChecked = await page.locator(`#${id}`).isChecked();
+      if (isChecked) {
+        await page.locator(`#${id}`).uncheck();
+      }
+    } else {
+      await page.locator(`#${id}`).check();
+    }
   }
 
-  // Then: 配信先 chk* は全 checked
+  // Then: 除外 2 ストアは unchecked のまま
+  await expect(page.locator("#chksnap")).not.toBeChecked();
+  await expect(page.locator("#chkroblox")).not.toBeChecked();
+
+  // Then: 他の配信先 chk* は checked
   await expect(page.locator("#chkspotify")).toBeChecked();
   await expect(page.locator("#chkapplemusic")).toBeChecked();
 
   // Then: credits section が visible 化（Apple Music checked → trigger 表示）
   await expect(page.locator(".requirements-item")).toBeVisible();
+
+  // Then: #areyousuresnap は hidden のまま（Snapchat が check されないため可視化されない）（#928）
+  await expect(page.locator("#label-areyousuresnap")).toBeHidden();
 
   // When: upsell uncheck（shazam / audiomack は name=store だが id なし）
   await page.evaluate(() => {
@@ -233,6 +256,50 @@ test("配信先ストア全 check + upsell uncheck + credits 可視化 + areyous
 
   // Then: 送信ボタンは押されていない
   const continueClicked = await page.evaluate(() => (window as unknown as { __continueClicked: boolean }).__continueClicked);
+  expect(continueClicked).toBe(false);
+});
+
+test("checkAllStores は事前 checked の chksnap / chkroblox を uncheck する（#928 デフォルト全 check からの除外保証）", async ({
+  page,
+}) => {
+  // Given: DistroKid のデフォルト全 check 状態（chksnap / chkroblox も checked）を再現
+  await page.goto(fixtureUrl);
+  await page.evaluate(() => {
+    // 全配信先を強制 checked にする（デフォルト全 check 状態の模倣）
+    document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="store"][id^="chk"]')
+      .forEach((cb) => { cb.checked = true; });
+  });
+  await expect(page.locator("#chksnap")).toBeChecked();
+  await expect(page.locator("#chkroblox")).toBeChecked();
+
+  // When: checkAllStores の模擬 — 除外ストアを uncheck する（#928）
+  await page.evaluate(() => {
+    const excluded = new Set(["chksnap", "chkroblox"]);
+    document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="store"][id^="chk"]')
+      .forEach((cb) => {
+        if (excluded.has(cb.id)) {
+          if (cb.checked) cb.click();
+        } else {
+          if (!cb.checked) cb.click();
+        }
+      });
+  });
+
+  // Then: 除外 2 ストアは uncheck されている
+  await expect(page.locator("#chksnap")).not.toBeChecked();
+  await expect(page.locator("#chkroblox")).not.toBeChecked();
+
+  // Then: #areyousuresnap は hidden のまま（Snapchat が uncheck されたため）（#928）
+  await expect(page.locator("#label-areyousuresnap")).toBeHidden();
+
+  // Then: 他の配信先は checked のまま
+  await expect(page.locator("#chkspotify")).toBeChecked();
+  await expect(page.locator("#chkapplemusic")).toBeChecked();
+
+  // Then: 送信ボタンは押されていない（__continueClicked ガード維持）
+  const continueClicked = await page.evaluate(
+    () => (window as unknown as { __continueClicked: boolean }).__continueClicked,
+  );
   expect(continueClicked).toBe(false);
 });
 


### PR DESCRIPTION
Closes #928

## 概要

#925 の `checkAllStores()` は配信先 26 ストアを全 check するが、**Roblox（`#chkroblox`）と Snapchat（`#chksnap`）は check 時に確認ポップアップが表示され**、自動フィルの進行を妨げる。運用上もこの 2 ストアへは配信しないため、配信先から除外する。

## 変更内容

- `EXCLUDED_STORE_IDS = ["chksnap", "chkroblox"]` を新設（理由コメント付き）
- `checkAllStores`: 除外 id は check せず、**事前に checked なら uncheck**（DistroKid デフォルトは全 check のため、配信外を能動的に保証）
- Snapchat 除外の帰結（条件付き重要事項 `#areyousuresnap` が不可視のまま → `acceptImportantTerms` の isVisible フィルタで自然スキップ）をコメントで明文化。コード変更は不要

## テスト

- Vitest: **137/137 green**（除外 2 ストア以外を check / 事前 checked の uncheck 保証 / `EXCLUDED_STORE_IDS` 契約固定）
- Playwright: **5/5 green**（#923 シナリオを除外対応に更新 + デフォルト全 check からの uncheck シナリオを新規追加。`__continueClicked === false` ガード維持）
- `pnpm compile` / `pnpm build` green

## スコープ外

- 除外ストアの config 化（必要なら別 issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)