### PR TITLE
style(suno-helper): #938 で混入した prettier format 違反を解消 (#937)

### DIFF
--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -106,10 +106,7 @@ export function formatStopError(message: string): string {
  * info に落とし、それ以外は warn で残す。catch せず放置すると未処理 rejection として
  * chrome://extensions のエラーバッジを汚染するため、必ず本関数経由で消費する（#937）。
  */
-export function describeRelayFailure(
-  action: string,
-  message: string,
-): { level: "info" | "warn"; text: string } {
+export function describeRelayFailure(action: string, message: string): { level: "info" | "warn"; text: string } {
   if (isContentScriptMissingError(message)) {
     return {
       level: "info",

--- a/extensions/suno-helper/entrypoints/background.ts
+++ b/extensions/suno-helper/entrypoints/background.ts
@@ -53,10 +53,7 @@ export default defineBackground(() => {
     // overlay 未注入のタブ（suno.com 以外 / 拡張リロード後の stale タブ）では必ず reject するため
     // catch して消費する。放置すると未処理 rejection としてエラーバッジに記録される（#937）。
     sendMessage("toggleOverlay", undefined, tab.id).catch((err: unknown) => {
-      const { level, text } = describeRelayFailure(
-        "toggleOverlay",
-        err instanceof Error ? err.message : String(err),
-      );
+      const { level, text } = describeRelayFailure("toggleOverlay", err instanceof Error ? err.message : String(err));
       console[level](text);
     });
   });

--- a/extensions/suno-helper/tests/relay-failure.test.ts
+++ b/extensions/suno-helper/tests/relay-failure.test.ts
@@ -22,11 +22,7 @@ describe("describeRelayFailure: content script 未注入（想定内）は info 
     expect(text).toMatch(/ハードリロード/);
   });
 
-  it.each([
-    "Receiving end does not exist",
-    "could not establish connection",
-    "RECEIVING END DOES NOT EXIST",
-  ])(
+  it.each(["Receiving end does not exist", "could not establish connection", "RECEIVING END DOES NOT EXIST"])(
     "Given 大文字小文字ゆらぎ %j When 整形 Then level=info（isContentScriptMissingError の i フラグ経路）",
     (message) => {
       expect(describeRelayFailure("toggleOverlay", message).level).toBe("info");


### PR DESCRIPTION
PR #938 が CI の `check` ジョブ（`pnpm format:check`）失敗のままマージされたため、main の extensions CI が落ちる状態になっていた。prettier --write で 3 ファイル（`components/runner-errors.ts` / `entrypoints/background.ts` / `tests/relay-failure.test.ts`）を整形した。行折り返しのみで挙動変更なし。

検証: `pnpm format:check` ✅ / `pnpm compile` ✅ / `pnpm test`（483 件）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)