### PR TITLE
chore: デバッグ用 .tmp/ を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 # Pytest temp（--basetemp などで生成される一時ディレクトリ）
 .tmp_test/
 
+# デバッグ用一時ファイル（chrome-devtools の DOM スナップショット等）
+.tmp/
+
 # Nix / tooling caches (do not commit eval / fetcher / tarball caches)
 .cache/
 


### PR DESCRIPTION
## 概要

chrome-devtools での DOM スナップショット等のデバッグ一時ファイル置き場として `.tmp/` を使っており、untracked のまま `git status` を汚していたため ignore 対象に追加する。

## 変更内容

- `.gitignore` に `.tmp/` を追記（`.tmp_test/` の隣）

## 備考

- main 作業ツリーに残っていた `.tmp/`（DistroKid/Suno デバッグ残骸 404K、内容は #919 等で対応済み）は削除済み
- src 外の変更のため CHANGELOG ゲート対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)