### PR TITLE
docs: ADR-0009 Turso (libSQL) ローカルデータストア導入

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,54 @@
+# tayk
+
+YouTube チャンネル運営を自動化するツールキット (旧 `youtube-channels-automation`、ADR-0007 で `tayk` に rebrand)。Python から TypeScript(bun) へ big-bang 移行中 (epic #727)。本ファイルは実装詳細ではなく、本プロジェクト固有の用語の正書を定める **グロッサリ**である。
+
+## 配布・移行
+
+**tayk**:
+本ツールの公開ブランド = npm package 名 = bin 名。下流からの canonical 起動は `bunx tayk <cmd>`。
+_Avoid_: youtube-channels-automation, yt-automation, yt (旧 bin 名)
+
+**cutover**:
+`feat/ts-rewrite` を Python 一掃済みの状態で main へ **merge commit** で統合し `tayk@0.1.0` を publish する単一イベント (#790)。これ以降 main は TS。
+
+**dogfood**:
+cutover 前に first-party 2 リポ (soulful-grooves / deepfocus365) で各コレクション 1 本のフルライフサイクルを実走させる受け入れ検証 (epic マイルストーン M2)。期間ではなく完走で判定する。
+_Avoid_: ベータ, トライアル, 試運転
+
+**critical regression**:
+cutover をブロックする欠陥。**3 種のみ** — ①誤公開・誤メタデータ ②データ破壊 (analytics 履歴 / collection 成果物) ③auth 破壊。これ以外は cutover をブロックしない bug として issue 化する。
+_Avoid_: 重大バグ (範囲が曖昧)
+
+**first-party (下流)**:
+本ツールを消費する 5 リポ前後のチャンネルリポジトリ。すべて運営者自身のもので第三者 consumer は存在しない (rebrand / 載せ替えコストの判断前提)。
+
+## 計画の 2 軸
+
+**Phase**:
+実行順の見出し (1B / 2 / 3)。「いつ書くか」を表す。Tier とは直交する。
+
+**Tier**:
+マイルストーンゲート所属のバッジ。**[T1]** = dogfood ブロッカー (全完了で M1) / **[T2]** = cutover ブロッカー (合格は smoke のみ) / **[T3]** = port せず削除。「どのゲートに属すか」を表す。
+_Avoid_: 優先度, priority (Tier は priority ではなくゲート所属)
+
+## アーキテクチャ
+
+**service**:
+`packages/core/src/<feature>/service.ts` の単一エントリ関数。input schema を受け `Result` を返す。重い外部依存 (googleapis / sharp 等) を内包してよい唯一の層 (ADR-0002/0003)。
+
+**adapter**:
+core の service を各プロトコルへ橋渡しする薄いラッパ。CLI adapter (`packages/cli/src/commands/<feature>/`) と MCP adapter (将来) があり、registry を介して service を呼ぶ。schema や重い依存を再宣言しない。
+_Avoid_: thin client, thin wrapper (同一概念。canonical は adapter)
+
+**registry**:
+feature 名 → {description, schema, service, deps} の data map。**core が所有**し (`packages/core/src/registry.ts`)、CLI / MCP は import して各自のプロトコルへ変換する (ADR-0004)。cli ↔ mcp は相互 import しない。
+
+**tracer**:
+アーキテクチャ規約を確定させるために最初に end-to-end で通す垂直スライス。本プロジェクトでは `tayk skills list` (旧 `yt-skills list`、#732/#842) が該当。
+_Avoid_: PoC (PoC は撤退判定用の別物 #730)
+
+## データ
+
+**local store**:
+チャンネルリポごとに `<CHANNEL_DIR>/data/local.db` に置く libSQL (Turso) embedded DB。時系列データ (analytics / コスト / 投票 / ベンチマーク) とコレクション状態を保持する SSOT (ADR-0009)。チャンネル設定 (`config/channel/*.json`) は含まない — 設定の SSOT は JSON ファイル。
+_Avoid_: database, SQLite (実体は libSQL。SQLite 互換だが区別する)

--- a/docs/adr/0009-turso-libsql-as-local-data-store.md
+++ b/docs/adr/0009-turso-libsql-as-local-data-store.md
@@ -1,0 +1,76 @@
+# Turso (libSQL) をローカルデータストアとして導入
+
+## Status
+
+accepted (2026-06-15)
+
+## Context
+
+現行の Python 版はすべてのランタイムデータ（analytics スナップショット、コスト追跡、投票ログ、コレクション状態、ベンチマーク）を JSON ファイルで保存している。この方式には 3 つの構造的問題がある:
+
+1. **クロスクエリが高コスト** — 「planning 中の全コレクションで videoup 完了済み」のような横断検索に `find` + `jq` が必要
+2. **LLM トークンの浪費** — skill が JSON を全読みして LLM コンテキストに載せるため、1 回の `/wf-status` で ~34,000 tokens を消費。SQL なら結果行だけで ~2,000 tokens（94% 削減）
+3. **時系列分析の非効率** — pandas DataFrame を毎回 JSON から組み立て直す。日次メトリクスの正規化テーブルがあれば直接集計できる
+
+TS rewrite（epic #727）が進行中であり、Python 側にデータ層を作り込んでも cutover で捨てることになる。
+
+## Decision
+
+`feat/ts-rewrite` ブランチに **Turso（libSQL）** を **ローカル embedded DB** として導入し、**Drizzle ORM** で管理する。
+
+### スコープ
+
+DB に入れるもの:
+
+| データ | テーブル設計 |
+|---|---|
+| Analytics 日次メトリクス | 完全正規化（`video_daily_metrics`）。API レスポンスのスキーマ揺れはインジェスト時に吸収 |
+| コスト追跡 | 正規化（`cost_entries`） |
+| 投票ログ | 正規化（`vote_log`） |
+| コレクション状態 | 状態テーブル（`collections`）+ イベントログ（`collection_events`）の 2 層。ファイルパスが canonical ID |
+| ベンチマーク時系列 | 正規化（`benchmark_snapshots`） |
+
+DB に入れないもの:
+
+- **チャンネル設定**（`config/channel/*.json`）— git 管理・diff 可視性が重要。SSOT は JSON のまま
+
+### 配置
+
+- 1 チャンネル = 1 DB ファイル: `<CHANNEL_DIR>/data/local.db`（`.gitignore` 対象）
+- チャンネル横断クエリは `ATTACH` で対応（頻度が低いため）
+
+### マイグレーション
+
+- Drizzle Kit（`drizzle-kit generate`）が `.sql` マイグレーションファイルを自動生成
+- 言語非依存の `.sql` が git に残るため、将来の技術選定変更時にも参照可能
+
+### 既存データの投入
+
+- 使い捨てインポートスクリプトで既存 JSON を全量投入（数万行規模で処理時間は問題にならない）
+
+### クエリ手段
+
+- `tayk db` CLI サブコマンド（定型レポート）
+- skill からの DB 参照（LLM トークン削減の本命）
+- Drizzle Studio / SQLite 互換クライアント（アドホック探索）
+
+## Why
+
+- **SQLite ではなく Turso (libSQL)**: SQLite 互換のローカル性能を維持しつつ、将来のベクトル類似検索（コレクション重複検出、SEO カニバリ検出）やリモート同期（embedded replica）へのアップグレードパスを確保する。初期はローカル embedded のみで運用し、ベクトル・リモートは具体的ニーズが出てから追加する
+- **Drizzle ORM**: TS rewrite と同じスタック。スキーマ定義が TS 型と DB スキーマの SSOT になり二重管理がない。Drizzle Kit が生成する `.sql` は言語非依存で可読性も保てる
+- **コレクション状態の 2 層モデル（状態 + イベントログ）**: `/wf-status` は最新 phase を即引きしたい（`collections` テーブル）。一方「suno → videoup に何日かかった？」の振り返りにはイベント履歴が要る（`collection_events`）。transaction で atomic 更新すれば整合性は保てる
+- **設定を DB に入れない**: 変更頻度が低く（開設時 1 回 + 微調整）、git diff で履歴を追える価値の方が高い。DB に入れると「直したつもりが反映されてない」事故が起きやすい
+
+## Consequences
+
+- `feat/ts-rewrite` の `packages/core/` に Drizzle 依存が加わる
+- 下流チャンネルリポの `.gitignore` に `data/local.db` 追加が必要
+- analytics 収集スクリプト（TS 版）は JSON 保存から DB INSERT に書き換え
+- skill が DB を参照するためのヘルパー（`tayk db query` 相当）が必要
+- JSON スナップショットの保存は廃止できるが、移行期は並行出力も可
+
+## Related
+
+- ADR-0001 / ADR-0002（TS rewrite アーキテクチャ）
+- ADR-0004（registry — `tayk db` サブコマンドの登録先）
+- Epic #727（TS rewrite）/ #790（cutover）


### PR DESCRIPTION
## Summary

- ADR-0009 起票: Turso (libSQL) を `feat/ts-rewrite` に embedded local DB として導入する設計決定を記録
- CONTEXT.md に「local store」用語を追加

## 背景

grill-with-docs セッションで以下 11 項目の設計判断を解決:

1. DB スコープ: 時系列 + コレクション状態 + ベンチマーク（設定は JSON SSOT のまま）
2. コレクション状態: DB はインデックス兼イベントログ、ファイルパスが canonical ID
3. DB 選定: Turso (libSQL)、将来のベクトル検索・リモート同期オプション
4. 配置: ローカル embedded `<CHANNEL_DIR>/data/local.db`
5. ORM: Drizzle ORM + Drizzle Kit
6. 導入タイミング: `feat/ts-rewrite` ブランチ（Python 側は触らない）
7. コレクションモデリング: 状態テーブル + イベントログの 2 層
8. Analytics 正規化: 完全正規化、スキーマ揺れはインジェスト時に吸収
9. ベクトル検索: 初期スコープ外、将来オプション
10. クエリ手段: `tayk db` CLI + skill DB 参照 + Drizzle Studio
11. 既存データ: JSON 全量インポート

## Test plan

- [ ] ADR-0009 の内容が決定事項と整合していることを確認
- [ ] CONTEXT.md の用語が既存グロッサリと矛盾しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)