### PR TITLE
fix(benchmark): サムネイル分析を Gemini → エージェントに移行し課金解消

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -19,7 +19,7 @@ description: "Use when 競合チャンネルのベンチマークデータを最
 
 ## 取得データ（拡充版）
 
-| 基本データ (YouTube API) | 派生指標 (自動算出) | サムネイル分析 (Gemini) |
+| 基本データ (YouTube API) | 派生指標 (自動算出) | サムネイル分析 (エージェント) |
 |---|---|---|
 | 再生数・高評価・コメント数 | 日次再生数 (views/日数) | 構図・配色 |
 | タイトル・タグ・説明文 | エンゲージメント率 (ER%) | テキスト配置 |
@@ -27,19 +27,18 @@ description: "Use when 競合チャンネルのベンチマークデータを最
 
 ## 実行フロー
 
-### Step 1: スクリプト実行
+### Step 1: データ収集
 
 ```bash
 # チャンネルディレクトリから実行（鮮度チェック → 古いもののみ更新）
-uv run yt-benchmark-collect
+uv run yt-benchmark-collect -y
 
 # オプション
-uv run yt-benchmark-collect --force            # 全チャンネル強制更新
-uv run yt-benchmark-collect --no-thumbnails    # サムネイル分析スキップ（高速）
-uv run yt-benchmark-collect --keep-thumbnails  # サムネイル画像を保持
-uv run yt-benchmark-collect --json-only        # JSON のみ（Markdown スキップ）
-uv run yt-benchmark-collect --channel <slug>   # 単一チャンネル指定
-uv run yt-benchmark-collect -v                 # 詳細ログ
+uv run yt-benchmark-collect --force -y       # 全チャンネル強制更新
+uv run yt-benchmark-collect --no-thumbnails  # サムネイルDLスキップ（高速）
+uv run yt-benchmark-collect --json-only      # JSON のみ（Markdown スキップ）
+uv run yt-benchmark-collect --channel <slug> # 単一チャンネル指定
+uv run yt-benchmark-collect -v               # 詳細ログ
 ```
 
 スクリプトが自動で以下を実行:
@@ -47,14 +46,27 @@ uv run yt-benchmark-collect -v                 # 詳細ログ
 2. `docs/benchmarks/*.md` の更新日時で鮮度チェック（`freshness_days` 日以上前なら更新）
 3. YouTube Data API で**直近 `scan_recent` 本（既定 50）** を走査し、**`min_views` 以上（既定 10,000）** の動画だけを抽出
 4. 派生指標算出（日次再生数・ER%・投稿間隔トレンド）
-5. サムネイルDL → Gemini API で構図・配色・テキスト配置を分析
+5. サムネイル画像を `docs/benchmarks/thumbnails/` にダウンロード
 6. `data/benchmark_YYYYMMDD.json` に中間データ保存
 7. `docs/benchmarks/*.md`（個別 + common-patterns + README）を自動生成
    - 該当動画が 0 件のチャンネルは「該当動画なし」注記付きの空レポートになる
 
-### Step 2: 結果確認・戦略的評価
+### Step 2: サムネイル分析（エージェント）
 
-スクリプト完了後、Claude が以下を実施:
+スクリプト完了後、エージェントが以下を実施:
+
+1. 各チャンネルのレポート（`docs/benchmarks/{slug}.md`）を読み、再生数上位 5 本の動画を特定
+2. 該当動画のサムネイル画像を `docs/benchmarks/thumbnails/{slug}_{video_id}.jpg` から Read ツールで読み込み
+3. 各サムネイルを以下の観点で分析:
+   - **構図**: レイアウト・焦点・キャラクター配置
+   - **配色**: 支配色・全体のムード/トーン
+   - **テキスト配置**: タイトルテキストの位置・スタイル
+   - **キャラ活動**: キャラクターの動作（いなければ 'none'）
+   - **雰囲気**: 全体のムード・ライティング・環境効果
+   - **強み**: 効果的な要素のリスト
+4. 分析結果を `docs/benchmarks/{slug}.md` の末尾に `## サムネイル分析` セクションとして追記
+
+### Step 3: 結果確認・戦略的評価
 
 1. 生成された `docs/benchmarks/*.md` を Read ツールで確認
 2. 高パフォーマンス動画のパターンを分析
@@ -94,16 +106,20 @@ uv run yt-benchmark-collect -v                 # 詳細ログ
 | `scan_recent` | 50 | チャンネルあたりの走査プール本数（直近 N 投稿） |
 | `min_views` | 10000 | ベンチマーク対象の視聴数しきい値 |
 | `freshness_days` | 3 | レポート更新間隔（日） |
-| `analyze_thumbnails` | true | Gemini によるサムネイル分析を実行するか |
-| `thumbnail_analysis.model` | gemini-2.5-pro | サムネイル分析モデル |
+| `gemini_thumbnail_analysis` | false | Gemini API によるサムネイル分析（Vertex AI 課金あり、通常は不要） |
+| `thumbnail_analysis.model` | gemini-2.5-flash | Gemini 分析モデル（`gemini_thumbnail_analysis: true` 時のみ） |
 | `thumbnail_analysis.delay_sec` | 5 | API レート制限対策の待機秒数 |
 | `thumbnail_analysis.prompt` | 汎用プロンプト | ジャンル/世界観に合わせて上書き推奨 |
+
+## コストに関する注意
+
+- **YouTube Data API**: 無料枠内（10,000 units/day）。1チャンネルあたり約 4 ユニット
+- **サムネイル分析**: デフォルトではエージェントが実行（追加コストなし）
+- **Gemini サムネイル分析** (`gemini_thumbnail_analysis: true`): Vertex AI 課金が発生する。10チャンネル × 各 20 本 = 200 回の API 呼び出しで数千円になる可能性があるため、通常は OFF のままにすること
 
 ## 注意事項
 
 - OAuth 認証は `auth/token.json` を使用
-- YouTube API: 1チャンネルあたり約 4 ユニット（channels 1 + playlistItems 1 + videos 約 2）
-- Gemini サムネイル分析: 5秒間隔でレート制限回避（`--no-thumbnails` でスキップ可）
 - `common-patterns.md` の手書きパターン分析は「運用ベンチマーク」セクションより上に維持される
 
 ## 関連ファイル

--- a/.claude/skills/benchmark/config.default.yaml
+++ b/.claude/skills/benchmark/config.default.yaml
@@ -15,12 +15,14 @@ min_views: 10000
 # レポート鮮度（この日数を超えたら更新対象）
 freshness_days: 3
 
-# Gemini によるサムネイル分析を実行するか
-analyze_thumbnails: true
+# Gemini API によるサムネイル分析（Vertex AI 課金あり）。
+# 既定 false — エージェントが Read ツールで分析するため Gemini は不要。
+# 明示的に true にすると Gemini でも分析する（エージェント分析と併用）。
+gemini_thumbnail_analysis: false
 
-# サムネイル分析の詳細設定
+# Gemini サムネイル分析の詳細設定（gemini_thumbnail_analysis: true 時のみ使用）
 thumbnail_analysis:
-  model: gemini-2.5-pro
+  model: gemini-2.5-flash
   delay_sec: 5  # API レート制限対策の待機秒数
   # Gemini に渡すプロンプト。チャンネルのジャンル/世界観に合わせて
   # config/skills/benchmark.yaml で上書きを推奨。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。
+
 ### Changed
 
 - `perf(videoup)`: 映像エフェクト (#648) をループ・ベイク方式へ刷新し、エフェクト有効時の動画書き出しを高速化した（generate_videos.sh v14）。従来はエフェクト ON でモード C（loop.mp4 + effect）/ モード D（静止画 + effect）ともに 2 時間尺を libx264 で全フレーム再エンコードしており 8〜15 分かかっていたが、エフェクト込みで 1 周期分だけ `10-assets/fx_baked.mp4` に焼き、あとは `-stream_loop -1 -c:v copy` で連結する方式へ変更して約 1〜2 分に短縮した（継ぎ目は closed GOP の stream copy で原理的に無損失）。これに伴いエフェクトの周期を整数固定にした: particles=36s（既存の `mod(t*30,1080)` のまま）/ bokeh=60s（overlay の揺れを `40*sin(2*PI*t/60)` / `30*cos(2*PI*t/60)` に整数周期化）/ gradient=72s（`gradients` を `speed=0` で静的化し、`crop` の `mod(t*15,1080)`=72s 周期だけに motion を限定）。背景が loop.mp4 のときは `lcm(round(loop 尺), 周期)` の長さを焼いて背景・エフェクト双方の継ぎ目を揃える。ベイク尺 ≥ 動画尺、または上限 `BAKE_MAX_LEN=900s` 超のときは従来の全尺再エンコードへ自動フォールバックし、短尺動画でも破綻しない。`fx_baked.params`（effect / intensity / 周期 / 元画像 mtime / maxrate）でキャッシュし、サムネ差し替え時のみ再ベイク（10〜40 秒）するためサムネ試行錯誤が軽い。あわせて静止画の fps/CRF/GOP・loop のビットレート上限/bufsize・effect の種別/強度・生成後の容量最適化（shrink）を **`config/skills/videoup.yaml` から取得する config 駆動**へ統一した（新規 env override は追加せず、`yaml_get` の 2-level flat YAML reader で読み、キー欠落時は現行固定値へフォールバック=無回帰。既存 `VIDEOUP_EFFECT` / `VIDEOUP_EFFECT_INTENSITY` env と `VIDEOUP_AUDIO_TARGET_VIDEO_DURATION_MIN` env は legacy fallback として存置）。新設の `shrink.enabled` + `maxrate`/`crf` を指定すると生成済み出力を 2 パス目で再エンコードして容量を絞れるが、全尺再エンコードのため stream copy の速度メリットは相殺される（最終版向け。上流の `loop_maxrate` 低減での容量制御を推奨、ファイル削除は `/live-clean` が担当）。SKILL.md に videoup.yaml スキーマ・所要時間目安・shrink/`/live-clean` 相互参照を追記。

--- a/src/youtube_automation/cli/channel_init.py
+++ b/src/youtube_automation/cli/channel_init.py
@@ -121,7 +121,7 @@ def _render_analytics(_ctx: Context) -> dict:
             "scan_recent": 50,
             "min_views": 10000,
             "freshness_days": 3,
-            "analyze_thumbnails": True,
+            "gemini_thumbnail_analysis": False,
         }
     }
 

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -557,6 +557,38 @@ class BenchmarkCollector:
                 return thumbnails[key]["url"]
         return ""
 
+    def download_thumbnails(self, data: dict, *, force: bool = False) -> None:
+        """サムネイル画像を docs/benchmarks/thumbnails/ にダウンロードする。
+
+        Args:
+            data: collect_all() の結果
+            force: True なら既存ファイルも再ダウンロード
+        """
+        thumbnails_dir = self.benchmarks_dir / "thumbnails"
+        thumbnails_dir.mkdir(parents=True, exist_ok=True)
+
+        downloaded = 0
+        skipped = 0
+        for channel in data.get("channels", []):
+            slug = channel["slug"]
+            for video in channel.get("videos", []):
+                url = video.get("thumbnail_url")
+                if not url:
+                    continue
+
+                dest = thumbnails_dir / f"{slug}_{video['video_id']}.jpg"
+                if dest.exists() and not force:
+                    skipped += 1
+                    continue
+
+                try:
+                    urllib.request.urlretrieve(url, dest)
+                    downloaded += 1
+                except Exception as e:
+                    logger.warning("サムネイルDL失敗 [%s]: %s", video["title"][:30], e)
+
+        logger.info("サムネイルDL: %d 件（スキップ: %d 件）→ %s", downloaded, skipped, thumbnails_dir)
+
 
 class BenchmarkThumbnailAnalyzer:
     """ベンチマークサムネイルの Gemini 分析"""
@@ -564,7 +596,7 @@ class BenchmarkThumbnailAnalyzer:
     def __init__(self, benchmarks_dir: Path):
         self.benchmarks_dir = benchmarks_dir
         cfg = load_skill_config("benchmark").get("thumbnail_analysis", {})
-        self.model = cfg.get("model", "gemini-2.5-pro")
+        self.model = cfg.get("model", "gemini-2.5-flash")
         self.delay_sec = float(cfg.get("delay_sec", 5))
         self.prompt = cfg.get("prompt", "").strip()
 
@@ -635,6 +667,15 @@ class BenchmarkThumbnailAnalyzer:
                         text = re.sub(r"\s*```$", "", text)
                         video["thumbnail_analysis"] = json.loads(text)
                         logger.info("サムネイル分析完了: %s", video["title"][:40])
+                        from youtube_automation.utils.cost_tracker import log_generation
+
+                        log_generation(
+                            "analysis",
+                            self.model,
+                            quantity=1,
+                            unit="call",
+                            metadata={"video_id": video["video_id"], "channel_slug": slug},
+                        )
                     except json.JSONDecodeError as e:
                         logger.warning("サムネイル分析JSONパース失敗 [%s]: %s", video["title"][:30], e)
                         video["thumbnail_analysis"] = {"raw": response.text[:500] if "response" in dir() else str(e)}
@@ -1241,9 +1282,11 @@ def ensure_benchmark_fresh(data_dir: Path | None = None):
             "`/benchmark`（uv run yt-benchmark-collect）を再実行してください。"
         )
 
-    if collector.benchmark_config.get("analyze_thumbnails", True):
+    collector.download_thumbnails(data, force=True)
+
+    if collector.benchmark_config.get("gemini_thumbnail_analysis", False):
         analyzer = BenchmarkThumbnailAnalyzer(collector.benchmarks_dir)
-        data = analyzer.analyze_thumbnails(data, keep=False)
+        data = analyzer.analyze_thumbnails(data, keep=True)
 
     collector.save_json(data)
     reporter = BenchmarkReportGenerator(collector.config, collector.benchmarks_dir, collector.today)
@@ -1256,8 +1299,9 @@ def main():
     parser = argparse.ArgumentParser(description="競合チャンネルのベンチマークデータ収集・分析")
     parser.add_argument("--force", action="store_true", help="鮮度に関わらず全チャンネル更新")
     parser.add_argument("--json-only", action="store_true", help="JSON のみ出力（Markdown 生成スキップ）")
-    parser.add_argument("--no-thumbnails", action="store_true", help="サムネイル分析をスキップ")
-    parser.add_argument("--keep-thumbnails", action="store_true", help="サムネイル画像を保持")
+    parser.add_argument("--no-thumbnails", action="store_true", help="サムネイルDL・分析をスキップ")
+    parser.add_argument("--keep-thumbnails", action="store_true", help="（非推奨: サムネイルは常に保持されます）")
+    parser.add_argument("-y", "--yes", action="store_true", help="確認プロンプトをスキップ")
     parser.add_argument("--channel", type=str, default=None, help="単一チャンネルの slug を指定")
     parser.add_argument(
         "--playlists",
@@ -1324,10 +1368,35 @@ def main():
         print()
         return
 
+    if args.keep_thumbnails:
+        logger.info("--keep-thumbnails: サムネイルは常に保持されるようになりました（このフラグは不要）")
+
+    analyze_thumbnails = collector.benchmark_config.get("gemini_thumbnail_analysis", False)
+    scan_recent = collector.benchmark_config.get("scan_recent", 50)
+    num_channels = len(collector.config.analytics.benchmark.channels)
+
     print("\n=== Benchmark Collector ===")
-    print(f"対象チャンネル: {len(collector.config.analytics.benchmark.channels)}件")
-    print(f"鮮度基準: {collector.benchmark_config.get('freshness_days', 3)}日")
+    print(f"  対象チャンネル: {num_channels} 件")
+    print(f"  走査プール: {scan_recent} 本/ch")
+    print(f"  鮮度基準: {collector.benchmark_config.get('freshness_days', 3)} 日")
+    if args.no_thumbnails:
+        print("  サムネイル分析: OFF（--no-thumbnails）")
+    elif analyze_thumbnails:
+        model = collector.benchmark_config.get("thumbnail_analysis", {}).get("model", "gemini-2.5-flash")
+        print(f"  サムネイル分析: Gemini ({model}) — Vertex AI 課金が発生します")
+    else:
+        print("  サムネイル分析: ON（エージェント — 追加課金なし）")
     print()
+
+    if not args.yes and not args.force:
+        try:
+            answer = input("続行しますか？ [Y/n] ").strip().lower()
+            if answer and answer != "y":
+                print("キャンセルしました")
+                sys.exit(0)
+        except (EOFError, KeyboardInterrupt):
+            print("\nキャンセルしました")
+            sys.exit(0)
 
     # 認証
     collector.initialize()
@@ -1347,12 +1416,15 @@ def main():
         print("[ERROR] データ収集に失敗しました")
         sys.exit(1)
 
-    # サムネイル分析
-    analyze_thumbnails = collector.benchmark_config.get("analyze_thumbnails", True)
+    # サムネイルDL（常時、--no-thumbnails でスキップ）
+    if not args.no_thumbnails:
+        collector.download_thumbnails(data, force=args.force)
+
+    # Gemini 分析（明示的に ON にした場合のみ）
     if analyze_thumbnails and not args.no_thumbnails:
         print("サムネイル分析中（Gemini API）...")
         analyzer = BenchmarkThumbnailAnalyzer(collector.benchmarks_dir)
-        data = analyzer.analyze_thumbnails(data, keep=args.keep_thumbnails)
+        data = analyzer.analyze_thumbnails(data, keep=True)
 
     # JSON 保存
     json_path = collector.save_json(data)

--- a/src/youtube_automation/utils/cost_tracker.py
+++ b/src/youtube_automation/utils/cost_tracker.py
@@ -1,10 +1,11 @@
 """画像・動画・音楽生成のコストを統一的に追跡する。
 
-3 カテゴリを別ファイルに記録しつつ、共通スキーマ・共通 API で扱う:
+4 カテゴリを別ファイルに記録しつつ、共通スキーマ・共通 API で扱う:
 
-- data/image_costs.json   画像生成（Nano Banana / Imagen 系）
-- data/video_costs.json   動画生成（Veo 系）
-- data/audio_costs.json   音楽生成（Lyria 系）
+- data/image_costs.json      画像生成（Nano Banana / Imagen 系）
+- data/video_costs.json      動画生成（Veo 系）
+- data/audio_costs.json      音楽生成（Lyria 系）
+- data/analysis_costs.json   分析（Gemini サムネイル分析等）
 
 エントリ共通スキーマ（Issue #132 で `estimated_cost_usd` は新規エントリで
 `null` 固定。実コストは GCP Cloud Console > Billing で確認する）:
@@ -35,18 +36,20 @@ from typing import Literal
 
 from youtube_automation.utils.profile import section
 
-Category = Literal["image", "video", "audio"]
+Category = Literal["image", "video", "audio", "analysis"]
 
 _LOG_FILENAMES: dict[Category, str] = {
     "image": "image_costs.json",
     "video": "video_costs.json",
     "audio": "audio_costs.json",
+    "analysis": "analysis_costs.json",
 }
 
 _CATEGORY_LABELS: dict[Category, str] = {
     "image": "画像",
     "video": "動画",
     "audio": "音楽",
+    "analysis": "分析",
 }
 
 # 旧エントリで `unit` キーが欠落しているときの読み出しフォールバック。
@@ -56,6 +59,7 @@ _LEGACY_UNIT_BY_CATEGORY: dict[Category, str] = {
     "image": "image",
     "video": "second",
     "audio": "song",
+    "analysis": "call",
 }
 
 
@@ -226,7 +230,8 @@ def print_last_report(last_entry: dict | None = None) -> None:
     print()
     print("=== Generation Cost Report ===")
     print(f"  今回:   [{cat_label}] {last['model']} / {last['quantity']}{last['unit']} / file={output_file}")
-    month_detail = " / ".join(f"{_CATEGORY_LABELS[c]} {month_by_cat.get(c, 0)} 件" for c in ("image", "video", "audio"))
+    cats = ("image", "video", "audio", "analysis")
+    month_detail = " / ".join(f"{_CATEGORY_LABELS[c]} {month_by_cat.get(c, 0)} 件" for c in cats)
     print(f"  今月({month}): {month_total} 件")
     print(f"    内訳: {month_detail}")
     print(f"  累計:   {len(entries)} 件")
@@ -255,7 +260,7 @@ def print_summary(category: Category | None = None) -> None:
     print(f"  総件数:   {len(entries)}")
     print()
     print("  カテゴリ別:")
-    for cat in ("image", "video", "audio"):
+    for cat in ("image", "video", "audio", "analysis"):
         count = by_cat.get(cat)
         if not count:
             continue
@@ -272,6 +277,6 @@ def print_summary(category: Category | None = None) -> None:
     print()
     print(_GCP_BILLING_HINT)
     print("  ログ:")
-    for cat in ("image", "video", "audio"):
+    for cat in ("image", "video", "audio", "analysis"):
         print(f"    {cat}: {_log_path(cat)}")
     print()

--- a/tests/fixtures/skill_config_verify/config/skills/benchmark.yaml
+++ b/tests/fixtures/skill_config_verify/config/skills/benchmark.yaml
@@ -2,7 +2,7 @@
 scan_recent: 77
 min_views: 55555
 freshness_days: 99
-analyze_thumbnails: false
+gemini_thumbnail_analysis: false
 thumbnail_analysis:
   model: "gemini-2.5-pro"
   delay_sec: 12

--- a/tests/test_channel_init.py
+++ b/tests/test_channel_init.py
@@ -188,7 +188,7 @@ def test_analytics_json_has_default_benchmark_parameters(tmp_path):
     assert "scan_recent" in bm
     assert "min_views" in bm
     assert "freshness_days" in bm
-    assert "analyze_thumbnails" in bm
+    assert "gemini_thumbnail_analysis" in bm
 
 
 # ===================== Case 8: playlists / workflow / audio は空テンプレ =====================

--- a/tests/test_channel_seed_cli.py
+++ b/tests/test_channel_seed_cli.py
@@ -35,7 +35,7 @@ def _write_analytics(target: Path, channels: list[dict] | None = None) -> Path:
                     "scan_recent": 10,
                     "min_views": 1000,
                     "freshness_days": 90,
-                    "analyze_thumbnails": True,
+                    "gemini_thumbnail_analysis": False,
                 },
             },
             ensure_ascii=False,


### PR DESCRIPTION
## Summary

- ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で **¥6,000 の課金**が発生していた問題を修正
- サムネイル分析の実行主体を **Gemini API → エージェントの画像読み取り機能（Read ツール）** に移行。追加課金なしで同等の分析を継続
- 設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、意図を明確化

## Changes

| ファイル | 変更 |
|---------|------|
| `config.default.yaml` | `gemini_thumbnail_analysis: false` + モデル Flash |
| `benchmark_collector.py` | サムネイル DL 独立化、Gemini デフォルト OFF、実行前プレビュー、cost_tracker 連携 |
| `SKILL.md` | エージェントによるサムネイル分析ステップ（Step 2）を追加 |
| `cost_tracker.py` | `"analysis"` カテゴリ新設 |
| `channel_init.py` | 新規チャンネルのデフォルト `false` |

## Test plan

- [x] `uv run pytest tests/test_cost_tracker.py tests/test_channel_init.py tests/test_benchmark_analyzer.py` — 207 passed
- [ ] `yt-benchmark-collect -y` でデフォルト実行: Gemini 呼び出しなし、サムネイルが `docs/benchmarks/thumbnails/` に保存
- [ ] `/benchmark` スキル経由: エージェントが Read ツールでサムネイルを分析してレポートに追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)