### PR TITLE
fix(doctor): ffmpeg/ffprobe チェックを追加 + system カテゴリ新設 (#889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(doctor)`: `yt-doctor` に ffmpeg/ffprobe の存在チェックを追加し、新規カテゴリ `system` を導入した。動画パイプラインの中核依存が doctor で事前検証されておらず、未インストール環境では動画処理段で初めて `FileNotFoundError` になっていた問題を解消。`shutil.which` で検出し、見つからない場合は `brew install ffmpeg` / `apt-get install -y ffmpeg` のインストール手順を案内する。
+
 ### Fixed
 
 - `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -34,7 +35,7 @@ class CheckResult:
     id: str
     status: str  # ok / warn / fail / unknown
     message: str
-    category: str = "api"  # api / channel / data / upload
+    category: str = "api"  # system / api / channel / data / upload
     next_action: Optional[dict] = None
 
 
@@ -106,6 +107,47 @@ def _check_data_files(
 
 
 # --- checks ---
+
+
+def check_ffmpeg() -> CheckResult:
+    path = shutil.which("ffmpeg")
+    if not path:
+        return CheckResult(
+            id="ffmpeg",
+            status="fail",
+            category="system",
+            message="ffmpeg が見つからない",
+            next_action={
+                "kind": "human",
+                "instructions": (
+                    "macOS: `brew install ffmpeg` / "
+                    "Ubuntu/Debian: `sudo apt-get install -y ffmpeg` / "
+                    "その他: https://ffmpeg.org/download.html を参照"
+                ),
+            },
+        )
+    return CheckResult(id="ffmpeg", status="ok", category="system", message=f"ffmpeg found: {path}")
+
+
+def check_ffprobe() -> CheckResult:
+    path = shutil.which("ffprobe")
+    if not path:
+        return CheckResult(
+            id="ffprobe",
+            status="fail",
+            category="system",
+            message="ffprobe が見つからない",
+            next_action={
+                "kind": "human",
+                "instructions": (
+                    "ffprobe は通常 ffmpeg に同梱されます。"
+                    "macOS: `brew install ffmpeg` / "
+                    "Ubuntu/Debian: `sudo apt-get install -y ffmpeg` / "
+                    "その他: https://ffmpeg.org/download.html を参照"
+                ),
+            },
+        )
+    return CheckResult(id="ffprobe", status="ok", category="system", message=f"ffprobe found: {path}")
 
 
 def check_gcloud() -> CheckResult:
@@ -655,6 +697,8 @@ def check_upload_ready(channel_dir: Path) -> CheckResult:
 
 def run_all_checks(channel_dir: Path) -> list[CheckResult]:
     return [
+        check_ffmpeg(),
+        check_ffprobe(),
         check_gcloud(),
         check_gcloud_account(),
         check_gcp_project(channel_dir),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -270,13 +270,13 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 11 api + 1 channel + 2 data + 1 upload = 15
-        assert len(payload["checks"]) == 15
+        # 2 system + 11 api + 1 channel + 2 data + 1 upload = 17
+        assert len(payload["checks"]) == 17
         for c in payload["checks"]:
             assert c["status"] in ("ok", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
             assert "category" in c
-            assert c["category"] in ("api", "channel", "data", "upload")
+            assert c["category"] in ("system", "api", "channel", "data", "upload")
 
     def test_human_output(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
@@ -757,11 +757,11 @@ class TestUploadRequiredScopes:
 
 
 class TestRunAllChecksExtended:
-    def test_returns_15_checks(self, monkeypatch, tmp_path):
-        """11 api + 1 channel + 2 data + 1 upload = 計 15 件."""
+    def test_returns_17_checks(self, monkeypatch, tmp_path):
+        """2 system + 11 api + 1 channel + 2 data + 1 upload = 計 17 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 15
+        assert len(results) == 17
 
     def test_existing_11_api_checks_present(self, monkeypatch, tmp_path):
         """既存 11 check が全て api カテゴリで含まれている."""
@@ -780,17 +780,20 @@ class TestRunAllChecksExtended:
         assert "benchmark_data" in ids
         assert "upload_ready" in ids
 
-    def test_category_order_api_then_channel_then_data_then_upload(self, monkeypatch, tmp_path):
-        """runway 順序: api → channel → data → upload."""
+    def test_category_order_system_then_api_then_channel_then_data_then_upload(self, monkeypatch, tmp_path):
+        """runway 順序: system → api → channel → data → upload."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         categories = [r.category for r in results]
 
+        last_system = max(i for i, c in enumerate(categories) if c == "system")
+        first_api = next(i for i, c in enumerate(categories) if c == "api")
         last_api = max(i for i, c in enumerate(categories) if c == "api")
         first_channel = next(i for i, c in enumerate(categories) if c == "channel")
         first_data = next(i for i, c in enumerate(categories) if c == "data")
         first_upload = next(i for i, c in enumerate(categories) if c == "upload")
 
+        assert last_system < first_api
         assert last_api < first_channel
         assert first_channel < first_data
         assert first_data < first_upload
@@ -825,13 +828,14 @@ class TestRunAllChecksExtended:
 
 
 class TestRenderTableCategories:
-    def test_all_four_category_labels_in_output(self, monkeypatch, tmp_path):
-        """render_table 出力に api / channel / data / upload のカテゴリラベルが含まれる."""
+    def test_all_five_category_labels_in_output(self, monkeypatch, tmp_path):
+        """render_table 出力に system / api / channel / data / upload のカテゴリラベルが含まれる."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         summary = doctor.summarize(results)
         output = doctor.render_table(results, summary, tmp_path)
         lower = output.lower()
+        assert "system" in lower
         assert "api" in lower
         assert "channel" in lower
         assert "data" in lower
@@ -849,18 +853,20 @@ class TestRenderTableCategories:
         assert "upload_ready" in output
 
     def test_category_sections_ordered_in_output(self, monkeypatch, tmp_path):
-        """出力内でのカテゴリ出現順: api → channel → data → upload."""
+        """出力内でのカテゴリ出現順: system → api → channel → data → upload."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         summary = doctor.summarize(results)
         output = doctor.render_table(results, summary, tmp_path)
 
         # 各 check id の出現位置で順序を確認する（category label の形式に依存しない）
+        pos_ffmpeg = output.find("ffmpeg")
         pos_gcloud = output.find("gcloud")
         pos_channel_config = output.find("channel_config")
         pos_analytics = output.find("analytics_report")
         pos_upload_ready = output.find("upload_ready")
 
+        assert pos_ffmpeg < pos_gcloud
         assert pos_gcloud < pos_channel_config
         assert pos_channel_config < pos_analytics
         assert pos_analytics < pos_upload_ready

--- a/tests/test_doctor_system_checks.py
+++ b/tests/test_doctor_system_checks.py
@@ -1,0 +1,181 @@
+"""yt-doctor system カテゴリ (ffmpeg/ffprobe) の単体テスト"""
+
+from __future__ import annotations
+
+import json
+
+from youtube_automation.cli import doctor
+
+# ---------------------------------------------------------------------------
+# check_ffmpeg
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFfmpeg:
+    def test_ok_when_installed(self, monkeypatch):
+        """ffmpeg がインストール済みの場合: ok."""
+        monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/local/bin/{cmd}" if cmd == "ffmpeg" else None)
+        r = doctor.check_ffmpeg()
+        assert r.status == "ok"
+        assert r.category == "system"
+        assert r.id == "ffmpeg"
+        assert "/usr/local/bin/ffmpeg" in r.message
+
+    def test_fail_when_missing(self, monkeypatch):
+        """ffmpeg が見つからない場合: fail + インストール手順."""
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        r = doctor.check_ffmpeg()
+        assert r.status == "fail"
+        assert r.category == "system"
+        assert r.id == "ffmpeg"
+        assert r.next_action is not None
+        assert r.next_action["kind"] == "human"
+        assert "brew install ffmpeg" in r.next_action["instructions"]
+        assert "apt-get" in r.next_action["instructions"]
+
+
+# ---------------------------------------------------------------------------
+# check_ffprobe
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFfprobe:
+    def test_ok_when_installed(self, monkeypatch):
+        """ffprobe がインストール済みの場合: ok."""
+        monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/local/bin/{cmd}" if cmd == "ffprobe" else None)
+        r = doctor.check_ffprobe()
+        assert r.status == "ok"
+        assert r.category == "system"
+        assert r.id == "ffprobe"
+        assert "/usr/local/bin/ffprobe" in r.message
+
+    def test_fail_when_missing(self, monkeypatch):
+        """ffprobe が見つからない場合: fail + インストール手順."""
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        r = doctor.check_ffprobe()
+        assert r.status == "fail"
+        assert r.category == "system"
+        assert r.id == "ffprobe"
+        assert r.next_action is not None
+        assert r.next_action["kind"] == "human"
+        assert "brew install ffmpeg" in r.next_action["instructions"]
+
+
+# ---------------------------------------------------------------------------
+# 4 パターン組み合わせテスト
+# ---------------------------------------------------------------------------
+
+
+class TestSystemChecksCombinations:
+    """shutil.which を monkey patch して 4 パターンを検証する."""
+
+    def _make_which(self, *, ffmpeg: bool, ffprobe: bool):
+        """ffmpeg/ffprobe の有無を制御する shutil.which の stub."""
+
+        def fake_which(cmd):
+            if cmd == "ffmpeg" and ffmpeg:
+                return "/usr/local/bin/ffmpeg"
+            if cmd == "ffprobe" and ffprobe:
+                return "/usr/local/bin/ffprobe"
+            return None
+
+        return fake_which
+
+    def test_both_installed(self, monkeypatch):
+        """(a) 両方インストール済み: 両方 ok."""
+        monkeypatch.setattr("shutil.which", self._make_which(ffmpeg=True, ffprobe=True))
+        assert doctor.check_ffmpeg().status == "ok"
+        assert doctor.check_ffprobe().status == "ok"
+
+    def test_ffmpeg_only_missing(self, monkeypatch):
+        """(b) ffmpeg のみ欠落: ffmpeg=fail, ffprobe=ok."""
+        monkeypatch.setattr("shutil.which", self._make_which(ffmpeg=False, ffprobe=True))
+        assert doctor.check_ffmpeg().status == "fail"
+        assert doctor.check_ffprobe().status == "ok"
+
+    def test_ffprobe_only_missing(self, monkeypatch):
+        """(c) ffprobe のみ欠落: ffmpeg=ok, ffprobe=fail."""
+        monkeypatch.setattr("shutil.which", self._make_which(ffmpeg=True, ffprobe=False))
+        assert doctor.check_ffmpeg().status == "ok"
+        assert doctor.check_ffprobe().status == "fail"
+
+    def test_both_missing(self, monkeypatch):
+        """(d) 両方欠落: 両方 fail."""
+        monkeypatch.setattr("shutil.which", self._make_which(ffmpeg=False, ffprobe=False))
+        assert doctor.check_ffmpeg().status == "fail"
+        assert doctor.check_ffprobe().status == "fail"
+
+
+# ---------------------------------------------------------------------------
+# run_all_checks に system カテゴリが含まれること
+# ---------------------------------------------------------------------------
+
+
+class TestRunAllChecksWithSystem:
+    def test_system_checks_present(self, monkeypatch, tmp_path):
+        """run_all_checks に ffmpeg / ffprobe が含まれる."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        ids = {r.id for r in results}
+        assert "ffmpeg" in ids
+        assert "ffprobe" in ids
+
+    def test_system_checks_count(self, monkeypatch, tmp_path):
+        """system カテゴリは ffmpeg + ffprobe の 2 件."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        system_results = [r for r in results if r.category == "system"]
+        assert len(system_results) == 2
+
+    def test_total_checks_is_17(self, monkeypatch, tmp_path):
+        """2 system + 11 api + 1 channel + 2 data + 1 upload = 計 17 件."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        assert len(results) == 17
+
+    def test_system_before_api(self, monkeypatch, tmp_path):
+        """system カテゴリは api カテゴリより前に配置される."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        categories = [r.category for r in results]
+
+        last_system = max(i for i, c in enumerate(categories) if c == "system")
+        first_api = next(i for i, c in enumerate(categories) if c == "api")
+        assert last_system < first_api
+
+
+# ---------------------------------------------------------------------------
+# render_table / JSON 出力に system が含まれること
+# ---------------------------------------------------------------------------
+
+
+class TestSystemInOutput:
+    def test_system_category_in_table(self, monkeypatch, tmp_path):
+        """render_table 出力に system カテゴリラベルが含まれる."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        summary = doctor.summarize(results)
+        output = doctor.render_table(results, summary, tmp_path)
+        assert "system" in output.lower()
+        assert "ffmpeg" in output
+        assert "ffprobe" in output
+
+    def test_system_category_in_json(self, monkeypatch, tmp_path, capsys):
+        """--json 出力に system カテゴリが含まれる."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        monkeypatch.setattr(doctor, "resolve_channel_dir", lambda t: tmp_path)
+        doctor.main(["--json"])
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        categories = {c["category"] for c in payload["checks"]}
+        assert "system" in categories
+
+    def test_system_appears_first_in_table(self, monkeypatch, tmp_path):
+        """render_table で system が api より先に出現する."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        results = doctor.run_all_checks(tmp_path)
+        summary = doctor.summarize(results)
+        output = doctor.render_table(results, summary, tmp_path)
+        pos_ffmpeg = output.find("ffmpeg")
+        pos_gcloud = output.find("gcloud")
+        assert pos_ffmpeg < pos_gcloud


### PR DESCRIPTION
## Summary

- `yt-doctor` に ffmpeg/ffprobe の存在チェック（`shutil.which`）を追加し、新規カテゴリ `system` を導入
- 未インストール環境で動画処理段まで進んで初めて `FileNotFoundError` になる問題を事前検出で解消
- `system` カテゴリは `api` より前（最初）に配置し、環境系チェックを優先表示

## Changes

- `src/youtube_automation/cli/doctor.py`: `check_ffmpeg()` / `check_ffprobe()` 追加、`run_all_checks()` に組み込み
- `tests/test_doctor.py`: チェック件数 15 -> 17、カテゴリ順序・出力テストを `system` 対応に更新
- `tests/test_doctor_system_checks.py`: 新規。4 パターン（両方 ok / ffmpeg 欠 / ffprobe 欠 / 両方欠）+ 出力検証

## Test plan

- [x] `uv run pytest tests/test_doctor.py tests/test_doctor_system_checks.py -x -q` (102 passed)
- [x] 既存 doctor テストが破壊されていない
- [x] 4 パターンの monkey patch テストが green
- [x] render_table / JSON 出力に system カテゴリが正しく含まれる

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)