### PR TITLE
fix(suno-helper): auto-capture の SPA 描画レースコンディションを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: auto-capture が Suno `/me` ページの SPA 描画完了前にスクレイプを実行し、空配列を即 return していたため playlist mapping が `suno-playlists.json` に書き込まれず、処理済みコレクションがドロップダウンに残り続けていた問題を修正した。`captureFromTab` で空結果もリトライ対象にし、React hydration + API fetch を deadline（15s）まで待機するようにした。
 - `fix(suno-helper)`: SKILL.md のサーバー起動コマンドに `--playlist-capture-root` / `--playlist-capture-prefix` フラグが欠落しており、auto-mapping（mapped 全件 false）と手動 playlist sync（POST 404）が機能しなかった問題を修正した。
 - `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。
 

--- a/extensions/suno-helper/lib/auto-capture.ts
+++ b/extensions/suno-helper/lib/auto-capture.ts
@@ -20,19 +20,32 @@ export interface CaptureFromTabDeps {
 /**
  * bg `/me` tab の content script が応答するまでリトライしつつ playlist を scrape する (#893)。
  * tab 生成直後は content script 未注入で sendCapture が reject されるため、deadline まで poll する。
- * deadline 超過時は最後のエラーを throw する（fail-loud。呼び出し側 autoCapturePlaylists が握る）。
+ * SPA 未描画で scrape 結果が空の場合もリトライする（React hydration + API fetch 待ち）。
+ * deadline 超過時:
+ *   - 一度でも空応答があった場合: [] を返す（fail-soft。呼び出し側が POST skip で穏やかに終了する）。
+ *   - 全て throw だった場合: 最後のエラーを throw する（fail-loud）。
  */
 export async function captureFromTab(tabId: number, deps: CaptureFromTabDeps): Promise<CapturedPlaylist[]> {
   const deadline = deps.now() + deps.timeoutMs;
   let lastErr: unknown;
+  let emptyReceived = false;
   while (deps.now() < deadline) {
     try {
-      return await deps.sendCapture(tabId);
+      const items = await deps.sendCapture(tabId);
+      if (items.length > 0) {
+        return items;
+      }
+      // SPA 未描画: content script は応答したが playlist 要素がまだ無い。リトライする。
+      emptyReceived = true;
+      await deps.sleep(deps.pollMs);
     } catch (err) {
       // content script 未注入（tab ロード中）。間隔を空けて再試行する。
       lastErr = err;
       await deps.sleep(deps.pollMs);
     }
+  }
+  if (emptyReceived) {
+    return [];
   }
   throw lastErr ?? new Error("capturePlaylists timed out");
 }

--- a/extensions/suno-helper/tests/auto-capture.test.ts
+++ b/extensions/suno-helper/tests/auto-capture.test.ts
@@ -76,6 +76,78 @@ describe("captureFromTab: content script 応答までリトライする", () => 
     ).rejects.toThrow("capturePlaylists timed out");
     expect(sendCapture).not.toHaveBeenCalled();
   });
+
+  it("Given 最初の N 回 [] → その後 非空 resolve When capture Then SPA 描画待ちリトライ後に scrape 結果を返す", async () => {
+    const sendCapture = vi
+      .fn<(tabId: number) => Promise<CapturedPlaylist[]>>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(ITEMS);
+
+    const result = await captureFromTab(99, {
+      sendCapture,
+      sleep: noSleep,
+      now: () => 0,
+      timeoutMs: 1000,
+      pollMs: 10,
+    });
+
+    expect(result).toEqual(ITEMS);
+    expect(sendCapture).toHaveBeenCalledTimes(3);
+  });
+
+  it("Given reject → [] → reject → 非空 resolve When capture Then 混在リトライ後に結果を返す", async () => {
+    const sendCapture = vi
+      .fn<(tabId: number) => Promise<CapturedPlaylist[]>>()
+      .mockRejectedValueOnce(new Error("no content script"))
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("no content script"))
+      .mockResolvedValueOnce(ITEMS);
+
+    const result = await captureFromTab(99, {
+      sendCapture,
+      sleep: noSleep,
+      now: () => 0,
+      timeoutMs: 1000,
+      pollMs: 10,
+    });
+
+    expect(result).toEqual(ITEMS);
+    expect(sendCapture).toHaveBeenCalledTimes(4);
+  });
+
+  it("Given deadline 超過まで [] 継続 When capture Then 空配列を返す（fail-soft、throw しない）", async () => {
+    const sendCapture = vi
+      .fn<(tabId: number) => Promise<CapturedPlaylist[]>>()
+      .mockResolvedValue([]);
+
+    const result = await captureFromTab(1, {
+      sendCapture,
+      sleep: noSleep,
+      now: steppingNow([0, 0, 200]),
+      timeoutMs: 100,
+      pollMs: 10,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("Given reject と [] が混在して deadline 超過 When capture Then 空応答があったため [] を返す（throw しない）", async () => {
+    const sendCapture = vi
+      .fn<(tabId: number) => Promise<CapturedPlaylist[]>>()
+      .mockRejectedValueOnce(new Error("no content script"))
+      .mockResolvedValueOnce([]);
+
+    const result = await captureFromTab(1, {
+      sendCapture,
+      sleep: noSleep,
+      now: steppingNow([0, 0, 0, 200]),
+      timeoutMs: 100,
+      pollMs: 10,
+    });
+
+    expect(result).toEqual([]);
+  });
 });
 
 // AutoCaptureDeps の各メソッドを typed mock で構築する。各 fn は vi.fn のため


### PR DESCRIPTION
## Summary
- `captureFromTab` が Suno `/me` ページの React 描画完了前にスクレイプを実行し、空配列を即 return していたため `suno-playlists.json` が更新されず、処理済みコレクションがドロップダウンに残り続けていた
- 空結果もリトライ対象にし、deadline（15s）まで SPA 描画を待機するようにした
- テスト 4 件追加（空→非空リトライ / throw+空混在 / deadline 超過 fail-soft）

## Test plan
- [x] `pnpm test` 全 578 件パス
- [ ] 実機: collection 連続実行 → playlist 作成完了後にページリロード → ドロップダウンから消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)