### PR TITLE
fix(suno-helper): auto-capture の URL を /me/playlists に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `fix(suno-helper)`: auto-capture が Suno `/me` ページの SPA 描画完了前にスクレイプを実行し、空配列を即 return していたため playlist mapping が `suno-playlists.json` に書き込まれず、処理済みコレクションがドロップダウンに残り続けていた問題を修正した。`captureFromTab` で空結果もリトライ対象にし、React hydration + API fetch を deadline（15s）まで待機するようにした。
+- `fix(suno-helper)`: auto-capture が Suno の URL 構造変更（`/me` → `/me/playlists`）に追従していなかったため、playlist mapping が `suno-playlists.json` に書き込まれず処理済みコレクションがドロップダウンに残り続けていた問題を修正した。併せて `captureFromTab` で SPA 未描画の空結果もリトライ対象にした。
 - `fix(suno-helper)`: SKILL.md のサーバー起動コマンドに `--playlist-capture-root` / `--playlist-capture-prefix` フラグが欠落しており、auto-mapping（mapped 全件 false）と手動 playlist sync（POST 404）が機能しなかった問題を修正した。
 - `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。
 

--- a/extensions/suno-helper/entrypoints/background.ts
+++ b/extensions/suno-helper/entrypoints/background.ts
@@ -9,8 +9,9 @@ import { onMessage, sendMessage } from "../lib/messaging";
 import { relayTabId, requireRelayTab } from "../lib/overlay-relay";
 import { serverUrlItem } from "../lib/storage";
 
-// 自動 capture で開く Suno `/me` の URL（追加要件 A）。
-const SUNO_ME_URL = "https://suno.com/me";
+// 自動 capture で開く Suno playlists ページの URL（追加要件 A）。
+// Suno の URL 構造変更（/me → /me/playlists）に追従。
+const SUNO_ME_URL = "https://suno.com/me/playlists";
 // bg `/me` tab の content script が capturePlaylists に応答するまでの poll 上限と間隔。
 // tab 生成直後は content script 未注入で sendMessage が reject されるためリトライする。
 const CAPTURE_TAB_TIMEOUT_MS = 15000;


### PR DESCRIPTION
## Summary
- Suno の URL 構造変更（`/me` → `/me/playlists`）に auto-capture が追従しておらず、`/me` ページにプレイリストリンクが 0 件のため scrape が常に空だった
- Chrome DevTools MCP で実機確認: `/me` は 0 件、`/me/playlists` は 25 件のプレイリストリンクを確認

## Test plan
- [x] `pnpm test` 全 578 件パス
- [ ] 実機: collection 連続実行 → playlist 作成完了後にページリロード → ドロップダウンから消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)