### PR TITLE
fix(suno-helper): overlay パネルにスクロールを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(suno-helper)`: auto-capture が Suno の URL 構造変更（`/me` → `/me/playlists`）に追従していなかったため、playlist mapping が `suno-playlists.json` に書き込まれず処理済みコレクションがドロップダウンに残り続けていた問題を修正した。併せて `captureFromTab` で SPA 未描画の空結果もリトライ対象にした。
+- `fix(suno-helper)`: overlay パネルのコンテンツが画面外にはみ出してスクロールできなかった問題を修正した。`max-height: calc(100vh - 120px)` + `overflow-y: auto` を追加。
 - `fix(suno-helper)`: SKILL.md のサーバー起動コマンドに `--playlist-capture-root` / `--playlist-capture-prefix` フラグが欠落しており、auto-mapping（mapped 全件 false）と手動 playlist sync（POST 404）が機能しなかった問題を修正した。
 - `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。
 

--- a/extensions/suno-helper/components/Overlay.tsx
+++ b/extensions/suno-helper/components/Overlay.tsx
@@ -138,7 +138,14 @@ function OverlayShell({ initial }: { initial: OverlayState | null }) {
         </button>
       </div>
       {/* 最小化中は panel を display:none + pointer-events:none で Suno UI 操作を邪魔しない (要件4)。 */}
-      <div style={{ pointerEvents: minimized ? "none" : "auto", display: minimized ? "none" : "block" }}>
+      <div
+        className="overflow-y-auto"
+        style={{
+          pointerEvents: minimized ? "none" : "auto",
+          display: minimized ? "none" : "block",
+          maxHeight: "calc(100vh - 120px)",
+        }}
+      >
         <App />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- overlay のコンテンツが長くなると画面外にはみ出してスクロールできなかった
- パネル部に `max-height: calc(100vh - 120px)` + `overflow-y: auto` を追加

## Test plan
- [x] `pnpm test` 全 578 件パス
- [ ] 実機: Playlist Capture リスト等が長い状態で overlay 内がスクロールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)