### PR TITLE
fix(suno-helper): マルチワード prefix の playlist 名境界分割を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(suno-helper)`: auto-capture が Suno の URL 構造変更（`/me` → `/me/playlists`）に追従していなかったため、playlist mapping が `suno-playlists.json` に書き込まれず処理済みコレクションがドロップダウンに残り続けていた問題を修正した。併せて `captureFromTab` で SPA 未描画の空結果もリトライ対象にした。
 - `fix(suno-helper)`: overlay パネルのコンテンツが画面外にはみ出してスクロールできなかった問題を修正した。`max-height: calc(100vh - 120px)` + `overflow-y: auto` を追加。
+- `fix(suno-helper)`: マルチワード prefix（例: `soulful-grooves`）のチャンネルで playlist 名の境界分割が壊れ、Suno に `soulful | grooves-wah-groove` のような誤った playlist 名で作成されていた問題を修正した。サーバー側で `derive_playlist_name` を使って正しい `<prefix> | <theme>` を算出し、`/collections` API の `playlist_name` フィールドとして返すようにした。拡張はサーバーの値を優先使用し、旧サーバーでは `extractPlaylistName` fallback で後方互換を維持する。
 - `fix(suno-helper)`: SKILL.md のサーバー起動コマンドに `--playlist-capture-root` / `--playlist-capture-prefix` フラグが欠落しており、auto-mapping（mapped 全件 false）と手動 playlist sync（POST 404）が機能しなかった問題を修正した。
 - `fix(benchmark)`: ベンチマーク収集のサムネイル分析で Gemini 2.5 Pro（Vertex AI）をデフォルトで全動画に呼び出しており、2チャンネル分の初回収集で ¥6,000 の課金が発生していた問題を修正した。サムネイル分析の実行主体を Gemini API からエージェントの画像読み取り機能（Read ツール）に移行した（追加課金なし）。設定キーを `analyze_thumbnails` → `gemini_thumbnail_analysis`（既定 `false`）にリネームし、明示的に Gemini を使う場合もデフォルトモデルを Pro → Flash に変更（コスト 1/10〜1/20）。あわせて実行前のコストプレビュー表示、Gemini 呼び出しの cost_tracker 記録（`"analysis"` カテゴリ新設）、`-y` 確認スキップフラグを追加した。
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -45,6 +45,9 @@ export interface CollectionSummary {
   // 既に config/suno-playlists.json にマッピング済みか (#893 追加要件 B)。
   // optional・後方互換: prefix 未設定の旧サーバーは返さず undefined（全件表示の従来挙動）。
   mapped?: boolean;
+  // サーバーが prefix を使って導出した Suno playlist 名 `<prefix> | <theme>`。
+  // マルチワード prefix でも正しい境界分割を保証する。未設定時は extractPlaylistName fallback。
+  playlist_name?: string;
 }
 
 /** Suno `/me` から捕捉した 1 playlist (#893)。POST /suno/playlists の body 要素。 */

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -110,16 +110,15 @@ export function useSunoRunner(): RunnerState {
   const [resumeDismissed, setResumeDismissed] = useState(false);
 
   // collection 選択から導出する playlist 名 (#854)。未選択（単一ファイル mode）は undefined。
-  // collection id は server 契約上 `<date>-<channel>-<theme>-collection` 形式。channel が
-  // 複数 word (例: `soulful-grooves`) を含む場合があり id 単体では境界判定不能なため、
-  // `/collections` の `name` field (theme) を渡して逆向きに境界を確定する。
-  // 既知の server 仕様: `name` は現在 dir 名 parts[2] をそのまま返すため末尾 `-collection`
-  // を含む。extractPlaylistName 側の `endsWith("-" + theme)` 照合を通すため、ここで剥がす
-  // (server 側の修正は別 issue、剥がし処理は冪等なので将来 server 修正後も無害)。
+  // サーバーが playlist_name を返す場合はそれを優先する（prefix を使った正確な境界分割）。
+  // 旧サーバー（playlist_name 未返却）は extractPlaylistName fallback で後方互換を維持する。
   const derivedPlaylistName = useMemo(() => {
     const selected = collections.find((c) => c.id === selectedCollectionId);
     if (!selected) {
       return undefined;
+    }
+    if (selected.playlist_name) {
+      return selected.playlist_name;
     }
     const theme = selected.name.replace(/-collection$/, "");
     return extractPlaylistName(selected.id, theme);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,8 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -152,6 +152,32 @@ def derive_collection_slug(collection_id: str, prefix: str) -> str | None:
     return f"{prefix.lower()}-{theme_slug}"
 
 
+def derive_playlist_name(collection_id: str, prefix: str) -> str | None:
+    """collection dir 名から `<prefix> | <theme>` 形式の Suno playlist 名を導出する。
+
+    `derive_collection_slug` と同じ prefix 剥がしロジックを使い、マルチワード prefix
+    （例: `soulful-grooves`）でも正しく `soulful-grooves | wah-groove` を返す。
+    prefix 未指定や theme 空は None。
+    """
+    name = collection_id
+    if name.endswith(_COLLECTION_DIR_SUFFIX):
+        name = name[: -len(_COLLECTION_DIR_SUFFIX)]
+    parts = name.split("-", 1)
+    if len(parts) == 2 and parts[0].isdigit():
+        name = parts[1]
+    prefix_match = re.match(rf"^{_prefix_pattern(prefix)}-", name, re.IGNORECASE)
+    if prefix_match is not None:
+        theme = name[prefix_match.end() :]
+    elif "-" in name:
+        theme = name.split("-", 1)[1]
+    else:
+        return None
+    theme = theme.strip()
+    if not theme:
+        return None
+    return f"{prefix.lower()} | {theme}"
+
+
 def _playlists_list_to_dict(data: list) -> dict:
     """旧 wf-batch list スキーマ `[{slug, suno_url, suno_title, captured_at}]` を dict へ写像する（#976）。
 
@@ -424,7 +450,7 @@ def build_collections_index(
     mapped_slugs: set[str] | None = None,
     prefix: str | None = None,
 ) -> list[dict]:
-    """各 collection を `{id, name, has_prompts, pattern_count, mapped}` に写像する（#816 dir mode / #893）.
+    """各 collection を index entry に写像する（#816 dir mode / #893）.
 
     - id   = ディレクトリ名（拡張から個別 fetch する際のホワイトリスト key）
     - name = `CollectionPaths.collection_name`（日付＋チャンネル接頭辞を除去した表示名）
@@ -432,6 +458,8 @@ def build_collections_index(
     - pattern_count = json があれば entries 数、無ければ None
     - mapped = `derive_collection_slug(id, prefix)` が `mapped_slugs` に含まれるか（#893 要件 B）。
       prefix 未指定（後方互換・旧運用）は常に False（素通し全件表示）。
+    - playlist_name = `derive_playlist_name(id, prefix)` で導出した Suno playlist 名（`<prefix> | <theme>`）。
+      prefix 未指定時は None（拡張は従来の extractPlaylistName fallback を使う）。
     """
     slugs = mapped_slugs or set()
     index: list[dict] = []
@@ -441,6 +469,7 @@ def build_collections_index(
         pattern_count = len(json.loads(prompts_path.read_text(encoding="utf-8"))) if has_prompts else None
         slug = derive_collection_slug(coll.name, prefix) if prefix else None
         mapped = slug is not None and slug in slugs
+        playlist_name = derive_playlist_name(coll.name, prefix) if prefix else None
         index.append(
             {
                 "id": coll.name,
@@ -448,6 +477,7 @@ def build_collections_index(
                 "has_prompts": has_prompts,
                 "pattern_count": pattern_count,
                 "mapped": mapped,
+                "playlist_name": playlist_name,
             }
         )
     return index

--- a/tests/test_collection_serve_suno_playlists.py
+++ b/tests/test_collection_serve_suno_playlists.py
@@ -41,6 +41,7 @@ from youtube_automation.scripts.collection_serve import (
     build_collections_index,
     create_server,
     derive_collection_slug,
+    derive_playlist_name,
     normalize_suno_title,
     read_mapped_slugs,
     write_suno_playlists,
@@ -162,6 +163,39 @@ def test_derive_collection_slug_matches_normalize_suno_title_for_same_theme():
 # ---------------------------------------------------------------------------
 # #976: prefix の空白/ハイフン無差別マッチと複数トークンチャンネル名の slug 導出
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# derive_playlist_name: collection dir 名 → `<prefix> | <theme>` の playlist 名
+# ---------------------------------------------------------------------------
+
+
+def test_derive_playlist_name_single_word_prefix():
+    assert derive_playlist_name("20260601-df365-morning-mode-collection", "df365") == "df365 | morning-mode"
+
+
+def test_derive_playlist_name_multi_word_prefix():
+    """マルチワード prefix でも正しい境界で分割される。"""
+    assert (
+        derive_playlist_name("20260601-soulful-grooves-wah-groove-collection", "soulful-grooves")
+        == "soulful-grooves | wah-groove"
+    )
+
+
+def test_derive_playlist_name_without_date():
+    assert derive_playlist_name("df365-morning-mode-collection", "df365") == "df365 | morning-mode"
+
+
+def test_derive_playlist_name_without_collection_suffix():
+    assert derive_playlist_name("20260601-rjn-dawn-cloud-fold", "rjn") == "rjn | dawn-cloud-fold"
+
+
+def test_derive_playlist_name_matches_normalize_roundtrip():
+    """derive_playlist_name の出力を normalize_suno_title に通すと derive_collection_slug と同じ slug になる。"""
+    pname = derive_playlist_name("20260601-soulful-grooves-horn-stab-master-collection", "soulful-grooves")
+    slug_from_name = normalize_suno_title(pname, "soulful-grooves")
+    slug_from_id = derive_collection_slug("20260601-soulful-grooves-horn-stab-master-collection", "soulful-grooves")
+    assert slug_from_name == slug_from_id == "soulful-grooves-horn-stab-master"
 
 
 def test_normalize_suno_title_matches_space_separated_prefix_against_hyphen_prefix():
@@ -579,6 +613,45 @@ def test_build_collections_index_defaults_to_unmapped_when_prefix_absent(tmp_pat
     rows = build_collections_index(planning)
 
     assert all(r["mapped"] is False for r in rows)
+
+
+def test_build_collections_index_returns_playlist_name_with_prefix(tmp_path):
+    """Given prefix 付きで build_collections_index を呼ぶ
+    When 結果を取得
+    Then playlist_name にサーバー側で導出した正しい playlist 名が含まれる。
+    """
+    planning = tmp_path / "planning"
+    _make_collection(planning, "20260601-rjn-dawn-fold-collection", entries=[{"name": "A", "style": "s", "lyrics": ""}])
+
+    rows = {r["id"]: r for r in build_collections_index(planning, prefix="rjn")}
+
+    assert rows["20260601-rjn-dawn-fold-collection"]["playlist_name"] == "rjn | dawn-fold"
+
+
+def test_build_collections_index_returns_playlist_name_multi_word_prefix(tmp_path):
+    """Given マルチワード prefix で build_collections_index を呼ぶ
+    Then playlist_name が正しい境界で分割される。
+    """
+    planning = tmp_path / "planning"
+    _make_collection(
+        planning, "20260601-soulful-grooves-wah-groove-collection", entries=[{"name": "A", "style": "s", "lyrics": ""}]
+    )
+
+    rows = {r["id"]: r for r in build_collections_index(planning, prefix="soulful-grooves")}
+
+    assert rows["20260601-soulful-grooves-wah-groove-collection"]["playlist_name"] == "soulful-grooves | wah-groove"
+
+
+def test_build_collections_index_playlist_name_none_without_prefix(tmp_path):
+    """Given prefix なし（後方互換）
+    Then playlist_name は None。
+    """
+    planning = tmp_path / "planning"
+    _make_collection(planning, "20260601-rjn-dawn-collection", entries=[{"name": "A", "style": "s", "lyrics": ""}])
+
+    rows = build_collections_index(planning)
+
+    assert all(r["playlist_name"] is None for r in rows)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1665,6 +1665,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "google-api-python-client", specifier = ">=2,<3" },
@@ -1685,3 +1690,6 @@ requires-dist = [
     { name = "seaborn", specifier = ">=0.13,<1" },
 ]
 provides-extras = ["dev", "veo"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]


### PR DESCRIPTION
## Summary
- `soulful-grooves` のようなマルチワード prefix で playlist 名が `soulful | grooves-wah-groove` と誤分割されていた
- サーバー側に `derive_playlist_name` を追加し、`/collections` API に `playlist_name` フィールドを返すようにした
- 拡張はサーバーの値を優先使用、旧サーバーでは `extractPlaylistName` fallback で後方互換を維持

## Test plan
- [x] Python テスト 54 件パス（新規 8 件: `derive_playlist_name` + `build_collections_index` の `playlist_name` フィールド）
- [x] 拡張テスト 578 件パス
- [ ] 実機: soulful-grooves チャンネルで `curl /collections` の `playlist_name` が `soulful-grooves | <theme>` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)