### PR TITLE
feat(doctor): yt-doctor accounts サブコマンド + ADR-0010 GCP 統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
+- `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。
+
 ### Changed
 
 - `feat(suno)`: 1 pattern = 1 scene 原則を SKILL.md に追加し、`(Variation N)` 機械的接尾辞による曲タイトル生成を回避。各曲が固有の `name_jp` / `name_en` を持つ YAML 設計を強制する NG/OK 例付き。

--- a/docs/adr/0010-unified-gcp-project.md
+++ b/docs/adr/0010-unified-gcp-project.md
@@ -1,0 +1,28 @@
+# 全チャンネルを単一 GCP プロジェクトに統合
+
+## Context
+
+チャンネルごとに個別の GCP プロジェクトを作成する運用で、Billing アカウントあたりのプロジェクト上限（5）に到達した。加えて、プロジェクトごとに OAuth 同意画面・API 有効化・ADC quota project 切り替えが必要で、チャンネル追加・日常管理の両面でオペレーションコストが高かった。Console 上で OAuth クライアント ID にラベルが付いておらず「どのプロジェクトがどのチャンネル用か」が把握困難だった。
+
+## Decision
+
+全チャンネルを **1 つの GCP プロジェクト (`yt-channels-automation`)** に統合する。チャンネルごとの分離は **同一プロジェクト内の OAuth クライアント ID**（チャンネル名で命名）で行う。project_id の解決は ADC quota project に一本化し、`.env` への `GOOGLE_CLOUD_PROJECT` 記載は不要とする。
+
+## Why
+
+- **Billing 枠の解放**: 5/5 → 2/5 に削減。新チャンネル追加が再びブロックされない
+- **セットアップの簡素化**: チャンネル追加 = Console で OAuth クライアント ID を 1 つ作成するだけ（プロジェクト作成・API 有効化・同意画面設定が不要に）
+- **日常管理の簡素化**: ADC quota project が固定。チャンネル間の切り替え操作が消滅
+- **可視性**: OAuth クライアント ID をチャンネル名で命名する規約により、Console 上で対応関係が一目でわかる
+
+## Considered Options
+
+- **チャンネルごとに GCP プロジェクトを維持**: quota（10,000 units/日）が独立する利点があるが、Billing 上限 5 に既に到達しており、Billing アカウント追加は Google 審査が必要で根本解決にならない
+- **既存プロジェクト (bobble-youtube-automation) に統合**: 移行コストは最小だが、プロジェクト名が特定チャンネルに引っ張られ中立性に欠ける
+- **新規プロジェクトを作成して統合** (採用): クリーンな名前で始められる。移行中に Billing 枠を一時的に消費するが、旧プロジェクトの unlink で回復
+
+## Consequences
+
+- YouTube Data API quota (10,000 units/日) が全チャンネルで共有される。17 本バッチアップロードが通った実績から現状は十分だが、チャンネル数増加時に quota 引き上げ申請が必要になる可能性がある
+- `yt-doctor accounts` サブコマンドで全チャンネルの OAuth クライアント対応表を一覧できるようにする
+- 旧プロジェクト (bobble-youtube-automation, rjn-automation, bah-youtube-automation) は Billing unlink 済み。不要と判断した時点で `gcloud projects delete` で完全削除可能

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -780,11 +780,87 @@ def render_table(results: list[CheckResult], summary: dict, channel_dir: Path) -
     return "\n".join(lines)
 
 
+def _find_channel_dirs(search_root: Path) -> list[Path]:
+    """search_root 直下のディレクトリで auth/client_secrets.json を持つものを返す。"""
+    dirs: list[Path] = []
+    if not search_root.is_dir():
+        return dirs
+    for child in sorted(search_root.iterdir()):
+        if child.is_dir() and (child / "auth" / "client_secrets.json").exists():
+            dirs.append(child)
+    return dirs
+
+
+def _extract_oauth_info(channel_dir: Path) -> dict:
+    """client_secrets.json から GCP プロジェクト・クライアント ID を抽出する。"""
+    cs_path = channel_dir / "auth" / "client_secrets.json"
+    info: dict = {"channel": channel_dir.name, "path": str(channel_dir)}
+    try:
+        data = json.loads(cs_path.read_text(encoding="utf-8"))
+        installed = data.get("installed") or data.get("web") or {}
+        info["project_id"] = installed.get("project_id", "?")
+        info["client_id"] = installed.get("client_id", "?")
+    except (json.JSONDecodeError, OSError):
+        info["project_id"] = "read error"
+        info["client_id"] = "read error"
+    info["has_token"] = (channel_dir / "auth" / "token.json").exists()
+    return info
+
+
+def run_accounts(search_root: Path, as_json: bool) -> int:
+    """全チャンネルの GCP プロジェクト + OAuth クライアント対応表を表示する。"""
+    channel_dirs = _find_channel_dirs(search_root)
+    if not channel_dirs:
+        print(f"チャンネルが見つかりません: {search_root}")
+        return 1
+
+    rows = [_extract_oauth_info(d) for d in channel_dirs]
+
+    if as_json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"search_root: {search_root}")
+    print()
+    header = f"{'Channel':<24} {'GCP Project':<28} {'OAuth Client ID':<20} {'Token'}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        client_short = r["client_id"][:16] + "..." if len(r["client_id"]) > 16 else r["client_id"]
+        token_icon = "✓" if r["has_token"] else "✗"
+        print(f"{r['channel']:<24} {r['project_id']:<28} {client_short:<20} {token_icon}")
+
+    projects = {r["project_id"] for r in rows if r["project_id"] not in ("?", "read error")}
+    print()
+    print(f"projects: {len(projects)}  channels: {len(rows)}")
+    return 0
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="yt-doctor", description="API 設定の状態診断")
+    sub = parser.add_subparsers(dest="command")
+
+    # default (no subcommand): 従来の診断
     parser.add_argument("--json", action="store_true", help="JSON 出力 (AI 用)")
     parser.add_argument("--target", help="対象 channel dir (既定: CHANNEL_DIR env → CWD)")
+
+    # accounts subcommand
+    accounts_parser = sub.add_parser("accounts", help="全チャンネルの GCP/OAuth 対応表")
+    accounts_parser.add_argument("--json", action="store_true", help="JSON 出力")
+    accounts_parser.add_argument(
+        "--search-root",
+        help="チャンネルリポ群の親ディレクトリ (既定: CHANNEL_DIR の親 → CWD の親)",
+    )
+
     args = parser.parse_args(argv)
+
+    if args.command == "accounts":
+        if args.search_root:
+            root = Path(args.search_root).resolve()
+        else:
+            channel_dir = resolve_channel_dir(None)
+            root = channel_dir.parent
+        return run_accounts(root, args.json)
 
     channel_dir = resolve_channel_dir(args.target)
     results = run_all_checks(channel_dir)


### PR DESCRIPTION
## Summary

- 全チャンネルの GCP プロジェクト・OAuth クライアント対応表を一覧する `yt-doctor accounts` サブコマンドを追加
- Billing 枠上限 (5/5) 解消のため全チャンネルを `yt-channels-automation` に統合した設計判断を ADR-0010 に記録

## Background

チャンネルごとに個別 GCP プロジェクトを運用していたが、Billing アカウントのプロジェクト上限 5 に到達。新チャンネル追加がブロックされていた。全チャンネルを単一プロジェクトに統合し、OAuth クライアント ID をチャンネル名で命名する運用に切り替えた。

## Test plan

- [x] `yt-doctor accounts --search-root ~/02-yt` で対応表が表示される
- [x] `yt-doctor accounts --json` で JSON 出力される
- [x] 既存の `yt-doctor`（サブコマンドなし）が壊れない
- [x] ruff lint / format パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)