### PR TITLE
feat(skills-sync): import.meta リソース解決 + npm files 同梱 + .agents/skills symlink (#742)

### DIFF
--- a/packages/cli/_claude_md/CLAUDE.template.md
+++ b/packages/cli/_claude_md/CLAUDE.template.md
@@ -1,0 +1,1 @@
+../../../.claude/CLAUDE.template.md

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,18 @@
   "bin": {
     "yt": "./bin/yt.ts"
   },
+  "files": [
+    "bin",
+    "lib",
+    "src",
+    "_skills",
+    "_claude_md"
+  ],
   "type": "module",
+  "scripts": {
+    "prepack": "bun run scripts/bundle-symlinks.ts materialize",
+    "postpack": "bun run scripts/bundle-symlinks.ts restore"
+  },
   "dependencies": {
     "@youtube-automation/core": "workspace:*",
     "citty": "^0.2.2"

--- a/packages/cli/scripts/bundle-symlinks.ts
+++ b/packages/cli/scripts/bundle-symlinks.ts
@@ -1,0 +1,83 @@
+// Pack-time materialization of the CLI's bundled assets (#742).
+//
+// `_skills` and `_claude_md/CLAUDE.template.md` are committed as symlinks into
+// the repo's single source of truth (`.claude/`), so the working tree never
+// duplicates skill content and dev/tests resolve real files through the links.
+// `npm`/`bun` `pack` strip symlinks from the tarball, so a package built
+// straight from the links would ship neither asset (verified: pack emits 8
+// files, both assets absent). `prepack` replaces each link with a dereferenced
+// real copy; `postpack` restores the link, leaving the working tree unchanged.
+
+import { cp, lstat, rm, symlink } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+
+// packages/cli/scripts → packages/cli → packages → repo root.
+const CLI_DIR = resolve(import.meta.dirname, "..");
+const REPO_ROOT = resolve(CLI_DIR, "..", "..");
+
+// Each bundled asset: the link path inside the CLI package and the canonical
+// source under .claude/. The relative symlink target is derived from these two
+// (see restore), so the link's shape is declared in exactly one place.
+const ASSETS = [
+  {
+    link: resolve(CLI_DIR, "_skills"),
+    source: resolve(REPO_ROOT, ".claude", "skills"),
+  },
+  {
+    link: resolve(CLI_DIR, "_claude_md", "CLAUDE.template.md"),
+    source: resolve(REPO_ROOT, ".claude", "CLAUDE.template.md"),
+  },
+] as const;
+
+// lstat that returns null for a missing path and re-throws any other I/O error
+// (Fail Fast — an unexpected error must not be mistaken for "absent").
+const lstatOrNull = async (path: string) => {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+// Replace each committed symlink with a dereferenced real copy of its source so
+// the tarball ships real files. Idempotent: an already-materialized asset (real
+// path, not a symlink) is left untouched.
+const materialize = async (): Promise<void> => {
+  for (const { link, source } of ASSETS) {
+    const stat = await lstatOrNull(link);
+    if (stat && !stat.isSymbolicLink()) {
+      continue;
+    }
+    if (stat) {
+      await rm(link, { force: true, recursive: true });
+    }
+    await cp(source, link, { dereference: true, recursive: true });
+  }
+};
+
+// Restore each asset to its committed relative symlink regardless of the current
+// on-disk shape (self-healing — works even if materialize ran only partially).
+const restore = async (): Promise<void> => {
+  for (const { link, source } of ASSETS) {
+    await rm(link, { force: true, recursive: true });
+    await symlink(relative(dirname(link), source), link);
+  }
+};
+
+const [mode] = process.argv.slice(2);
+if (mode === "materialize") {
+  await materialize();
+} else if (mode === "restore") {
+  await restore();
+} else {
+  throw new Error(
+    `usage: bundle-symlinks <materialize|restore> (got ${String(mode)})`
+  );
+}

--- a/packages/cli/src/commands/skills/cli.ts
+++ b/packages/cli/src/commands/skills/cli.ts
@@ -1,5 +1,11 @@
+import process from "node:process";
+
 import { REGISTRY } from "@youtube-automation/core/registry";
-import type { SkillListOutput } from "@youtube-automation/core/skills-sync";
+import { SYNC_ASSETS } from "@youtube-automation/core/skills-sync";
+import type {
+  SkillListOutput,
+  SkillSyncOutput,
+} from "@youtube-automation/core/skills-sync";
 import { defineCommand } from "citty";
 
 import { resolveDeps } from "../../../lib/resolve-deps.ts";
@@ -10,11 +16,28 @@ import { emitResult } from "../../../lib/run-command.ts";
 // lib/resolve-deps.ts、出力整形と exit code は lib/run-command.ts の共通 helper に集約する。
 
 const skillsListEntry = REGISTRY["skills.list"];
+const skillsSyncEntry = REGISTRY["skills.sync"];
 
-const renderText = (output: SkillListOutput): string => {
+// CLI 限定 sugar。全資産を既定ターゲットへ配布する (service enum には載らない / #742)。
+const ASSET_ALL = "all";
+// usage error の終了コード (sysexits EX_USAGE)。Result→exit の共通 helper とは別系統。
+const EXIT_USAGE = 2;
+
+const renderListText = (output: SkillListOutput): string => {
   const header = `同梱スキル ${output.skills.length} 件 (source: ${output.source})`;
   const bullets = output.skills.map((name) => `  - ${name}`);
   return [header, ...bullets].join("\n");
+};
+
+const renderSyncText = (output: SkillSyncOutput): string => {
+  const lines = [`[${output.asset}] → ${output.target}`];
+  for (const entry of output.entries) {
+    lines.push(`  ${entry.result}: ${entry.name}`);
+  }
+  if (output.agentsSkillsLink !== null) {
+    lines.push(`  .agents/skills: ${output.agentsSkillsLink}`);
+  }
+  return lines.join("\n");
 };
 
 const listCommand = defineCommand({
@@ -36,11 +59,76 @@ const listCommand = defineCommand({
     });
     const deps = await resolveDeps(skillsListEntry.deps);
     const result = await skillsListEntry.run(input, deps);
-    emitResult(result, { json: args.json, renderText });
+    emitResult(result, { json: args.json, renderText: renderListText });
+  },
+});
+
+// 1 資産を配布する。target は省略時 service が資産ごとの既定を埋める。
+const syncOneAsset = async (
+  asset: string,
+  target: string | undefined,
+  force: boolean,
+  json: boolean
+): Promise<void> => {
+  const input = skillsSyncEntry.inputSchema.parse({ asset, force, target });
+  const deps = await resolveDeps(skillsSyncEntry.deps);
+  const result = await skillsSyncEntry.run(input, deps);
+  emitResult(result, { json, renderText: renderSyncText });
+};
+
+const syncCommand = defineCommand({
+  args: {
+    asset: {
+      default: ASSET_ALL,
+      description: "配布する資産 (skills | claude-md | all)",
+      type: "string",
+    },
+    force: {
+      default: false,
+      description: "既存ファイル/シンボリックリンクを上書きする",
+      type: "boolean",
+    },
+    json: {
+      default: false,
+      description: "JSON で出力する",
+      type: "boolean",
+    },
+    target: {
+      description: "配布先パス (省略時は資産ごとの既定)",
+      type: "string",
+    },
+  },
+  meta: { description: skillsSyncEntry.description, name: "sync" },
+  async run({ args }) {
+    const { asset, force, json, target } = args;
+
+    if (asset === ASSET_ALL) {
+      // 資産ごとに既定ターゲットが異なるため、単一 --target との併用は誤配置を招く。
+      // 書き込み前に弾く (usage error)。
+      if (target !== undefined) {
+        process.stderr.write(
+          "--asset all は --target と併用できません (資産ごとに既定ターゲットが異なります)\n"
+        );
+        process.exit(EXIT_USAGE);
+      }
+      for (const one of SYNC_ASSETS) {
+        await syncOneAsset(one, undefined, force, json);
+      }
+      return;
+    }
+
+    if (!(SYNC_ASSETS as readonly string[]).includes(asset)) {
+      process.stderr.write(
+        `未知の --asset: ${asset} (${SYNC_ASSETS.join(" | ")} | ${ASSET_ALL})\n`
+      );
+      process.exit(EXIT_USAGE);
+    }
+
+    await syncOneAsset(asset, target, force, json);
   },
 });
 
 export const skillsCommand = defineCommand({
   meta: { description: "同梱スキル資産の操作", name: "skills" },
-  subCommands: { list: listCommand },
+  subCommands: { list: listCommand, sync: syncCommand },
 });

--- a/packages/cli/test/skills-bundle-pack.test.ts
+++ b/packages/cli/test/skills-bundle-pack.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Guards the #742 distribution contract end-to-end: `_skills` / `_claude_md` are
+// committed as symlinks into `.claude/`, and pack strips symlinks — so without
+// the prepack materialization the published tarball ships neither asset (the
+// original REJECT: pack emitted 8 files, both assets absent). This test packs
+// the real package and asserts both assets land as real files.
+
+// packages/cli/test → packages/cli, and two more up → repo root.
+const cliDir = resolve(import.meta.dir, "..");
+const repoRoot = resolve(cliDir, "..", "..");
+
+// The canonical skill source. Every entry must reach the tarball as a real
+// directory — read dynamically so the assertion tracks skills being added or
+// removed (mirrors the listSkillsService default-resolution test).
+const expectedSkills = readdirSync(join(repoRoot, ".claude", "skills"), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .toSorted();
+
+// npm/bun roots every tarball entry under `package/`.
+const PKG_PREFIX = "package/";
+
+const tmpDirs: string[] = [];
+const makeTmp = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+};
+
+// Pack the CLI package into `destination` (runs prepack/postpack, which
+// materialize the bundled symlinks into real files and restore the links
+// afterward) and return the tarball's entry paths.
+const packEntries = (destination: string): string[] => {
+  const pack = Bun.spawnSync(
+    ["bun", "pm", "pack", "--destination", destination, "--quiet"],
+    { cwd: cliDir }
+  );
+  if (pack.exitCode !== 0) {
+    throw new Error(`bun pm pack failed: ${pack.stderr.toString()}`);
+  }
+  const tarball = readdirSync(destination).find((f) => f.endsWith(".tgz"));
+  if (tarball === undefined) {
+    throw new Error("bun pm pack produced no tarball");
+  }
+  const list = Bun.spawnSync(["tar", "-tzf", join(destination, tarball)]);
+  if (list.exitCode !== 0) {
+    throw new Error(`tar -tzf failed: ${list.stderr.toString()}`);
+  }
+  return list.stdout
+    .toString()
+    .split("\n")
+    .filter((line) => line.length > 0);
+};
+
+afterAll(() => {
+  // bun's postpack restores the symlinks; re-run restore defensively so the
+  // working tree is clean even if pack aborted mid-run (restore is idempotent).
+  Bun.spawnSync(["bun", "run", "scripts/bundle-symlinks.ts", "restore"], {
+    cwd: cliDir,
+  });
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("cli package — published tarball bundles the sync assets (#742 AC#1/#2/#5)", () => {
+  // One pack, shared across the assertions below.
+  let entries: string[] = [];
+  beforeAll(() => {
+    entries = packEntries(makeTmp("cli-pack-"));
+  });
+
+  test("ships the CLAUDE.template.md asset as a real file (AC#5)", () => {
+    // The claude-md source resolves through the _claude_md symlink; its presence
+    // here proves the symlink was dereferenced into the tarball.
+    expect(entries).toContain(`${PKG_PREFIX}_claude_md/CLAUDE.template.md`);
+  });
+
+  test("ships every bundled skill directory as real, dereferenced content (AC#1/#2)", () => {
+    // Each .claude/skills/<name> must appear under package/_skills/<name>/.
+    // A stripped symlink would contribute nothing, so a populated subtree per
+    // skill is the materialization proof.
+    for (const skill of expectedSkills) {
+      const prefix = `${PKG_PREFIX}_skills/${skill}/`;
+      expect(entries.some((entry) => entry.startsWith(prefix))).toBe(true);
+    }
+  });
+
+  test("contains real files under both bundled-asset prefixes (regression guard)", () => {
+    // The original defect packed `_skills` / `_claude_md` as bare symlinks that
+    // vanished from the tarball. Real entries under both prefixes prove the
+    // regression cannot recur silently.
+    expect(
+      entries.some((entry) => entry.startsWith(`${PKG_PREFIX}_skills/`))
+    ).toBe(true);
+    expect(
+      entries.some((entry) => entry.startsWith(`${PKG_PREFIX}_claude_md/`))
+    ).toBe(true);
+  });
+});

--- a/packages/cli/test/yt-skills-sync.test.ts
+++ b/packages/cli/test/yt-skills-sync.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Importing core by its package name + ADR-0004 registry subpath from the *cli*
+// package is the real cli→core `workspace:*` resolution under test. The
+// skills.sync entry lands in the registry as part of #742.
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+// Repo root is three levels up from packages/cli/test/.
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+// `bunx yt ...` 相当の e2e。citty dispatcher (bin/yt.ts) を実プロセスで起動する。
+// runYt は repoRoot を cwd にする (既存 yt-skills.test.ts と同じ)。runYtIn は
+// --asset all のデフォルト target (cwd 相対) を temp ディレクトリで検証するため、
+// 任意の cwd で起動する変種。
+const runYt = (...argv: string[]) =>
+  Bun.spawnSync(["bun", "packages/cli/bin/yt.ts", ...argv], { cwd: repoRoot });
+
+const runYtIn = (cwd: string, ...argv: string[]) =>
+  Bun.spawnSync(["bun", join(repoRoot, "packages/cli/bin/yt.ts"), ...argv], {
+    cwd,
+  });
+
+// Per-test temp dirs, torn down after each case.
+const tmpDirs: string[] = [];
+const makeTmp = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("core registry — skills.sync entry (ADR-0004 contract)", () => {
+  test("declares no deps and a human-readable description", () => {
+    // Given the registry entry
+    const entry = REGISTRY["skills.sync"];
+
+    // Then deps is the empty declaration and the description lives in core next
+    // to the schema (locality).
+    expect(entry.deps).toEqual([]);
+    expect(entry.description.length).toBeGreaterThan(0);
+  });
+
+  test("inputSchema parses an asset + target and run returns an ok Result", async () => {
+    // Given an input parsed through the entry's own schema (target → a temp dir)
+    const tmp = makeTmp("cli-skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+    const input = REGISTRY["skills.sync"].inputSchema.parse({
+      asset: "skills",
+      target,
+    });
+
+    // When the entry runs (deps-free, so {} is the full slice)
+    const result = await REGISTRY["skills.sync"].run(input, {});
+
+    // Then it succeeds and the payload matches the outputSchema contract.
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.asset).toBe("skills");
+      expect(Array.isArray(result.value.entries)).toBe(true);
+      expect(result.value.agentsSkillsLink).toBe("linked");
+    }
+  });
+});
+
+describe("yt skills sync --asset skills --target <dir>", () => {
+  test("exits 0, copies skills, and creates the .agents/skills symlink", () => {
+    // Given a standard-layout target under a temp dir
+    const tmp = makeTmp("yt-skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+
+    // When `yt skills sync --asset skills --target <dir>` runs
+    const proc = runYt(
+      "skills",
+      "sync",
+      "--asset",
+      "skills",
+      "--target",
+      target
+    );
+
+    // Then it exits cleanly, the skills land in the target, and the Codex
+    // discovery mirror is a relative symlink to ../.claude/skills.
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(target)).toBe(true);
+    const link = join(tmp, ".agents", "skills");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe("../.claude/skills");
+  });
+
+  test("--json prints a parseable SkillSyncOutput payload", () => {
+    // Given the same sync with --json
+    const tmp = makeTmp("yt-skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+
+    // When run with --json
+    const proc = runYt(
+      "skills",
+      "sync",
+      "--asset",
+      "skills",
+      "--target",
+      target,
+      "--json"
+    );
+
+    // Then stdout is the service output as JSON, with no cli reshaping.
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(proc.stdout.toString()) as {
+      agentsSkillsLink: string | null;
+      asset: string;
+      entries: { name: string; result: string }[];
+      target: string;
+    };
+    expect(parsed.asset).toBe("skills");
+    expect(Array.isArray(parsed.entries)).toBe(true);
+    expect(parsed.agentsSkillsLink).toBe("linked");
+  });
+});
+
+describe("yt skills sync --asset claude-md --target <file>", () => {
+  test("exits 0 and writes the CLAUDE.md file (AC#5)", () => {
+    // Given a target file path under a temp dir
+    const tmp = makeTmp("yt-claude-md-sync-");
+    const target = join(tmp, ".claude", "CLAUDE.md");
+
+    // When `yt skills sync --asset claude-md --target <file>` runs
+    const proc = runYt(
+      "skills",
+      "sync",
+      "--asset",
+      "claude-md",
+      "--target",
+      target
+    );
+
+    // Then it exits cleanly and the template is written to the target path.
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(target)).toBe(true);
+  });
+});
+
+describe("yt skills sync --asset all — guard against --target", () => {
+  test("exits 2 with a stderr message and writes nothing", () => {
+    // Given `--asset all` combined with `--target` (ambiguous: per-asset default
+    // targets differ, so a single target would silently misplace an asset).
+    const tmp = makeTmp("yt-skills-sync-");
+    const target = join(tmp, "x");
+
+    // When run
+    const proc = runYt("skills", "sync", "--asset", "all", "--target", target);
+
+    // Then it is a usage error (exit 2) with a non-empty stderr, and the target
+    // is never created (the guard fires before any write).
+    expect(proc.exitCode).toBe(2);
+    expect(proc.stderr.toString().length).toBeGreaterThan(0);
+    expect(existsSync(target)).toBe(false);
+  });
+});
+
+describe("yt skills sync — default asset 'all' resolves per-asset default targets", () => {
+  test("bare `skills sync` syncs both skills and claude-md under the working dir", () => {
+    // Given a temp working dir (so the cwd-relative default targets are safe to
+    // write). `yt skills sync` with no flags defaults asset to 'all'.
+    const cwd = makeTmp("yt-skills-sync-all-");
+
+    // When run from that working dir
+    const proc = runYtIn(cwd, "skills", "sync");
+
+    // Then both assets reach their per-asset defaults: skills → .claude/skills
+    // (+ the .agents/skills mirror) and claude-md → .claude/CLAUDE.md.
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(join(cwd, ".claude", "skills"))).toBe(true);
+    expect(existsSync(join(cwd, ".claude", "CLAUDE.md"))).toBe(true);
+    expect(lstatSync(join(cwd, ".agents", "skills")).isSymbolicLink()).toBe(
+      true
+    );
+  });
+});
+
+describe("yt skills sync — usage errors", () => {
+  test("an unknown --asset exits non-zero", () => {
+    // Given an asset value outside { all, skills, claude-md }
+    const tmp = makeTmp("yt-skills-sync-");
+    const proc = runYt(
+      "skills",
+      "sync",
+      "--asset",
+      "bogus",
+      "--target",
+      join(tmp, "x")
+    );
+
+    // Then the process fails (usage / validation error → non-zero exit).
+    expect(proc.exitCode).not.toBe(0);
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -8,6 +8,9 @@ import {
   listSkillsService,
   SkillListInputSchema,
   SkillListOutputSchema,
+  SkillSyncInputSchema,
+  SkillSyncOutputSchema,
+  syncAssetService,
 } from "./skills-sync/index.ts";
 
 // ADR-0004: core feature registry。feature 名 → {description, schema, deps, run} の
@@ -64,6 +67,13 @@ export const REGISTRY = {
     inputSchema: SkillListInputSchema,
     outputSchema: SkillListOutputSchema,
     run: listSkillsService,
+  }),
+  "skills.sync": defineRegistryEntry({
+    deps: [],
+    description: "同梱資産 (skills / CLAUDE.md) を対象リポジトリへ配布する",
+    inputSchema: SkillSyncInputSchema,
+    outputSchema: SkillSyncOutputSchema,
+    run: syncAssetService,
   }),
 } as const;
 

--- a/packages/core/src/skills-sync/index.ts
+++ b/packages/core/src/skills-sync/index.ts
@@ -1,4 +1,15 @@
 // ADR 0002 canonical template: feature の公開面は schema + service のみ。
-export { SkillListInputSchema, SkillListOutputSchema } from "./schema.ts";
-export type { SkillListInput, SkillListOutput } from "./schema.ts";
-export { listSkillsService } from "./service.ts";
+export {
+  SkillListInputSchema,
+  SkillListOutputSchema,
+  SkillSyncInputSchema,
+  SkillSyncOutputSchema,
+  SYNC_ASSETS,
+} from "./schema.ts";
+export type {
+  SkillListInput,
+  SkillListOutput,
+  SkillSyncInput,
+  SkillSyncOutput,
+} from "./schema.ts";
+export { listSkillsService, syncAssetService } from "./service.ts";

--- a/packages/core/src/skills-sync/schema.ts
+++ b/packages/core/src/skills-sync/schema.ts
@@ -17,3 +17,42 @@ export const SkillListOutputSchema = z
 
 export type SkillListInput = z.infer<typeof SkillListInputSchema>;
 export type SkillListOutput = z.infer<typeof SkillListOutputSchema>;
+
+// service が配布する資産の契約値。CLI の "all" sugar はこの集合を展開する
+// (展開は CLI の責務 — service は "all" を受け取らない / #742)。enum の単一情報源。
+export const SYNC_ASSETS = ["skills", "claude-md"] as const;
+
+// .agents/skills mirror の状態。標準レイアウト (.claude/skills) でのみ試行し、
+// それ以外は null。symlink 非対応環境では握りつぶさず "unsupported" として surface する。
+const AGENTS_SKILLS_LINK_STATES = ["linked", "skipped", "unsupported"] as const;
+
+// 1 資産あたりの配布結果。skills は skill ディレクトリ単位、claude-md は単一ファイル。
+const SyncEntrySchema = z
+  .object({
+    name: z.string(),
+    result: z.enum(["created", "skipped"]),
+  })
+  .strict();
+
+export const SkillSyncInputSchema = z
+  .object({
+    // service が扱う資産は skills | claude-md のみ ("all" は CLI sugar で弾く)。
+    asset: z.enum(SYNC_ASSETS),
+    // 既存ファイル/シンボリックリンクを上書きするか。CLI は常に明示し service が既定を埋める。
+    force: z.boolean().default(false),
+    // 省略時は資産ごとの既定ターゲット (skills→.claude/skills, claude-md→.claude/CLAUDE.md) を service が埋める。
+    target: z.string().optional(),
+  })
+  .strict();
+
+export const SkillSyncOutputSchema = z
+  .object({
+    agentsSkillsLink: z.enum(AGENTS_SKILLS_LINK_STATES).nullable(),
+    asset: z.string(),
+    entries: z.array(SyncEntrySchema),
+    target: z.string(),
+  })
+  .strict();
+
+export type SkillSyncInput = z.infer<typeof SkillSyncInputSchema>;
+export type SkillSyncOutput = z.infer<typeof SkillSyncOutputSchema>;

--- a/packages/core/src/skills-sync/service.ts
+++ b/packages/core/src/skills-sync/service.ts
@@ -1,12 +1,32 @@
-import { readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import {
+  cp,
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+} from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 
 import { toServiceError } from "../errors.ts";
 import type { ServiceError } from "../errors.ts";
 import { err, ok } from "../result.ts";
 import type { Result } from "../result.ts";
-import { SkillListInputSchema, SkillListOutputSchema } from "./schema.ts";
-import type { SkillListInput, SkillListOutput } from "./schema.ts";
+import {
+  SkillListInputSchema,
+  SkillListOutputSchema,
+  SkillSyncInputSchema,
+  SkillSyncOutputSchema,
+} from "./schema.ts";
+import type {
+  SkillListInput,
+  SkillListOutput,
+  SkillSyncInput,
+  SkillSyncOutput,
+} from "./schema.ts";
 
 // 同梱 skills resource の既定パス。import.meta 基点で packages/cli/_skills を解決する
 // (packages/core/src/skills-sync/service.ts → ../../../cli/_skills)。_skills は .claude/skills への symlink。
@@ -18,6 +38,34 @@ const DEFAULT_SKILLS_DIR = resolve(
   "cli",
   "_skills"
 );
+
+// 同梱 CLAUDE.md テンプレートの既定パス (#742)。_skills と同じく import.meta 基点で
+// packages/cli/_claude_md/CLAUDE.template.md を解決する。_claude_md は .claude/CLAUDE.template.md への symlink。
+const CLAUDE_MD_SOURCE = resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "cli",
+  "_claude_md",
+  "CLAUDE.template.md"
+);
+
+// 配布レイアウトの契約パスセグメント。複数箇所で参照するため 1 箇所で定義する。
+const CLAUDE_DIR = ".claude";
+const SKILLS_DIRNAME = "skills";
+const CLAUDE_MD_FILENAME = "CLAUDE.md";
+const AGENTS_DIR = ".agents";
+
+// 資産ごとの既定ターゲット (CWD 相対)。CLI が --target を渡さないとき service が埋める。
+const DEFAULT_TARGETS = {
+  "claude-md": join(CLAUDE_DIR, CLAUDE_MD_FILENAME),
+  skills: join(CLAUDE_DIR, SKILLS_DIRNAME),
+} as const;
+
+// Codex 探索パス <repo>/.agents/skills が指す相対 symlink ターゲット
+// (Python `_AGENTS_SKILLS_LINK_TARGET` と一致)。POSIX 区切りで固定する。
+const AGENTS_SKILLS_LINK_TARGET = `../${CLAUDE_DIR}/${SKILLS_DIRNAME}`;
 
 // 1 skill = 1 ディレクトリ。非ディレクトリは除外し、Python `sorted(...)` と同じ
 // code-point 昇順で返す。内部は throw OK で、境界の try/catch で `toServiceError`
@@ -38,6 +86,151 @@ export const listSkillsService = async (
       .toSorted();
 
     return ok(SkillListOutputSchema.parse({ skills, source }));
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};
+
+const resolveSyncTarget = (
+  asset: "claude-md" | "skills",
+  target: string | undefined
+): string => resolve(target ?? DEFAULT_TARGETS[asset]);
+
+// 配布先が標準レイアウト <repo>/.claude/skills か。ここでのみ .agents/skills mirror を試行する
+// (それ以外は repo root を特定できないため mirror しない)。
+const isStandardSkillsLayout = (targetDir: string): boolean =>
+  basename(targetDir) === SKILLS_DIRNAME &&
+  basename(dirname(targetDir)) === CLAUDE_DIR;
+
+// 存在チェック付き lstat。symlink を辿らず、存在しなければ null。ENOENT 以外は
+// 握りつぶさず再 throw する (Fail Fast — 想定外の I/O エラーは呼び出し側へ伝播)。
+const lstatOrNull = async (path: string) => {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+// skill ディレクトリを deep copy する (Python `copytree(symlinks=False)` 相当で
+// dereference)。既存かつ非 force なら skip。
+const copyDirEntry = async (
+  src: string,
+  dest: string,
+  force: boolean
+): Promise<"created" | "skipped"> => {
+  if (!force && existsSync(dest)) {
+    return "skipped";
+  }
+  await cp(src, dest, { dereference: true, force: true, recursive: true });
+  return "created";
+};
+
+// 単一ファイルをコピーする。既存かつ非 force なら skip。
+const copyFileEntry = async (
+  src: string,
+  dest: string,
+  force: boolean
+): Promise<"created" | "skipped"> => {
+  if (!force && existsSync(dest)) {
+    return "skipped";
+  }
+  await copyFile(src, dest);
+  return "created";
+};
+
+// <repo>/.agents/skills を ../.claude/skills への相対 symlink として冪等に作成する。
+//   - 既存の正しい symlink + 非 force → "skipped"
+//   - 不在 / force / 不整合       → 張り直して "linked"
+//   - 作成不能 (.agents が通常ファイル等) → "unsupported" (AC#4: 警告のみで sync 継続)
+const ensureAgentsSkillsLink = async (
+  repoRoot: string,
+  force: boolean
+): Promise<"linked" | "skipped" | "unsupported"> => {
+  const linkPath = join(repoRoot, AGENTS_DIR, SKILLS_DIRNAME);
+  try {
+    await mkdir(join(repoRoot, AGENTS_DIR), { recursive: true });
+    const existing = await lstatOrNull(linkPath);
+    if (
+      existing &&
+      !force &&
+      existing.isSymbolicLink() &&
+      (await readlink(linkPath)) === AGENTS_SKILLS_LINK_TARGET
+    ) {
+      return "skipped";
+    }
+    if (existing) {
+      await rm(linkPath, { force: true, recursive: true });
+    }
+    await symlink(AGENTS_SKILLS_LINK_TARGET, linkPath);
+    return "linked";
+  } catch {
+    return "unsupported";
+  }
+};
+
+const syncSkillsAsset = async (
+  targetDir: string,
+  force: boolean
+): Promise<SkillSyncOutput> => {
+  await mkdir(targetDir, { recursive: true });
+  const dirents = await readdir(DEFAULT_SKILLS_DIR, { withFileTypes: true });
+  const names = dirents
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .toSorted();
+
+  const entries: SkillSyncOutput["entries"] = [];
+  for (const name of names) {
+    const result = await copyDirEntry(
+      join(DEFAULT_SKILLS_DIR, name),
+      join(targetDir, name),
+      force
+    );
+    entries.push({ name, result });
+  }
+
+  const agentsSkillsLink = isStandardSkillsLayout(targetDir)
+    ? await ensureAgentsSkillsLink(dirname(dirname(targetDir)), force)
+    : null;
+
+  return { agentsSkillsLink, asset: "skills", entries, target: targetDir };
+};
+
+const syncClaudeMdAsset = async (
+  targetFile: string,
+  force: boolean
+): Promise<SkillSyncOutput> => {
+  await mkdir(dirname(targetFile), { recursive: true });
+  const result = await copyFileEntry(CLAUDE_MD_SOURCE, targetFile, force);
+  return {
+    agentsSkillsLink: null,
+    asset: "claude-md",
+    entries: [{ name: basename(targetFile), result }],
+    target: targetFile,
+  };
+};
+
+// 同梱資産 (skills / claude-md) を対象リポジトリへ配布する (#742)。"all" は CLI sugar の
+// ため schema enum で弾かれ validation error になる。境界の try/catch で Result に集約する。
+export const syncAssetService = async (
+  input: SkillSyncInput
+): Promise<Result<SkillSyncOutput, ServiceError>> => {
+  try {
+    const { asset, force, target } = SkillSyncInputSchema.parse(input);
+    const resolved = resolveSyncTarget(asset, target);
+    const output =
+      asset === "skills"
+        ? await syncSkillsAsset(resolved, force)
+        : await syncClaudeMdAsset(resolved, force);
+    return ok(SkillSyncOutputSchema.parse(output));
   } catch (error) {
     return err(toServiceError(error));
   }

--- a/packages/core/test/skills-sync-asset.test.ts
+++ b/packages/core/test/skills-sync-asset.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Imported by the published package name + ADR-0002 subpath so the test
+// exercises the core `exports` map ("./skills-sync") rather than a relative
+// path — a missing/broken subpath export fails resolution here, not in tsc.
+// syncAssetService / the Sync schemas land in skills-sync as part of #742.
+import {
+  SkillSyncInputSchema,
+  SkillSyncOutputSchema,
+  syncAssetService,
+} from "@youtube-automation/core/skills-sync";
+import type { SkillSyncInput } from "@youtube-automation/core/skills-sync";
+
+// Repo root is three levels up from packages/core/test/.
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+// The canonical skill source (.claude/skills, reached via the packages/cli/_skills
+// symlink). Read dynamically so the assertions stay correct as skills are added
+// or removed — mirrors the listSkillsService default-resolution test.
+const expectedSkills = readdirSync(join(repoRoot, ".claude", "skills"), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .toSorted();
+
+// The source of truth for the claude-md asset; the synced file must be a
+// byte-for-byte copy of it.
+const claudeTemplate = join(repoRoot, ".claude", "CLAUDE.template.md");
+
+// ADR-0003: the service returns Result, never throws. Unwrap the ok arm here so
+// happy-path assertions stay focused on the payload; a failed Result is itself a
+// test failure (the service was expected to succeed).
+const syncOk = async (input: SkillSyncInput) => {
+  const r = await syncAssetService(input);
+  if (!r.ok) {
+    throw new Error(
+      `expected an ok Result, got error: ${JSON.stringify(r.error)}`
+    );
+  }
+  return r.value;
+};
+
+// Per-test temp dirs, torn down after each case.
+const tmpDirs: string[] = [];
+const makeTmp = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("syncAssetService — skills asset (standard .claude/skills layout)", () => {
+  test("copies every bundled skill directory into the target and reports them created", async () => {
+    // Given a fresh standard-layout target (<tmp>/.claude/skills)
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+
+    // When the skills asset is synced there
+    const value = await syncOk({ asset: "skills", force: false, target });
+
+    // Then the output echoes the asset + resolved target, and every bundled
+    // skill directory is reported as a created entry.
+    expect(value.asset).toBe("skills");
+    expect(value.target).toBe(resolve(target));
+    expect(value.entries.map((e) => e.name).toSorted()).toEqual(expectedSkills);
+    expect(value.entries.every((e) => e.result === "created")).toBe(true);
+  });
+
+  test("materializes each entry as a real directory (deep copy, not a symlink)", async () => {
+    // Given a standard-layout target
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+
+    // When the skills asset is synced
+    await syncOk({ asset: "skills", force: false, target });
+
+    // Then a sample skill exists on disk as a real directory — the bundled
+    // _skills symlink was dereferenced, matching Python copytree(symlinks=False).
+    const [sample] = expectedSkills;
+    const copied = join(target, sample as string);
+    expect(existsSync(copied)).toBe(true);
+    expect(lstatSync(copied).isDirectory()).toBe(true);
+    expect(lstatSync(copied).isSymbolicLink()).toBe(false);
+  });
+
+  test("creates the .agents/skills mirror as a symlink to ../.claude/skills", async () => {
+    // Given a standard-layout target
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+
+    // When the skills asset is synced
+    const value = await syncOk({ asset: "skills", force: false, target });
+
+    // Then the Codex discovery path <repo>/.agents/skills is a relative symlink
+    // pointing at ../.claude/skills (matches Python _AGENTS_SKILLS_LINK_TARGET).
+    const link = join(tmp, ".agents", "skills");
+    expect(value.agentsSkillsLink).toBe("linked");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe("../.claude/skills");
+  });
+});
+
+describe("syncAssetService — skills idempotency and --force", () => {
+  test("a second sync without force skips existing entries and the mirror", async () => {
+    // Given a target already populated by a first sync
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+    await syncOk({ asset: "skills", force: false, target });
+
+    // When syncing again without force
+    const second = await syncOk({ asset: "skills", force: false, target });
+
+    // Then nothing is rewritten: every entry and the mirror report skipped.
+    expect(second.entries.every((e) => e.result === "skipped")).toBe(true);
+    expect(second.agentsSkillsLink).toBe("skipped");
+  });
+
+  test("force re-copies entries and re-links the mirror", async () => {
+    // Given a target already populated by a first sync
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+    await syncOk({ asset: "skills", force: false, target });
+
+    // When syncing again with force: true
+    const second = await syncOk({ asset: "skills", force: true, target });
+
+    // Then entries are re-created and the mirror is re-linked, still pointing at
+    // ../.claude/skills.
+    expect(second.entries.every((e) => e.result === "created")).toBe(true);
+    expect(second.agentsSkillsLink).toBe("linked");
+    expect(readlinkSync(join(tmp, ".agents", "skills"))).toBe(
+      "../.claude/skills"
+    );
+  });
+});
+
+describe("syncAssetService — skills mirror only on the standard layout", () => {
+  test("skips the .agents/skills mirror for a non-standard target", async () => {
+    // Given a target that is NOT <repo>/.claude/skills (repo root unknowable)
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, "custom-skills");
+
+    // When the skills asset is synced
+    const value = await syncOk({ asset: "skills", force: false, target });
+
+    // Then skills are still copied, but no .agents mirror is attempted (null),
+    // and no .agents directory is created as a side effect.
+    expect(value.entries.length).toBeGreaterThan(0);
+    expect(value.agentsSkillsLink).toBeNull();
+    expect(existsSync(join(tmp, ".agents"))).toBe(false);
+  });
+});
+
+describe("syncAssetService — symlink failure is non-fatal (AC#4)", () => {
+  test("returns 'unsupported' and keeps Result ok when the mirror cannot be created", async () => {
+    // Given a standard-layout target whose <repo>/.agents path is already a
+    // regular file — symlink creation under it fails (ENOTDIR), standing in for
+    // a symlink-incapable environment without mocking or chmod/root concerns.
+    const tmp = makeTmp("skills-sync-");
+    const target = join(tmp, ".claude", "skills");
+    writeFileSync(join(tmp, ".agents"), "blocks the mirror");
+
+    // When the skills asset is synced
+    const value = await syncOk({ asset: "skills", force: false, target });
+
+    // Then the skills copy still succeeds and the failed mirror degrades to
+    // 'unsupported' (warning-only) rather than failing the whole sync.
+    expect(value.entries.length).toBeGreaterThan(0);
+    expect(value.entries.every((e) => e.result === "created")).toBe(true);
+    expect(value.agentsSkillsLink).toBe("unsupported");
+  });
+});
+
+describe("syncAssetService — claude-md asset (single file, AC#5)", () => {
+  test("copies CLAUDE.template.md to the target file path and reports it created", async () => {
+    // Given a target file path (<tmp>/.claude/CLAUDE.md)
+    const tmp = makeTmp("claude-md-sync-");
+    const target = join(tmp, ".claude", "CLAUDE.md");
+
+    // When the claude-md asset is synced
+    const value = await syncOk({ asset: "claude-md", force: false, target });
+
+    // Then the output echoes the asset + resolved target, the file is a
+    // byte-for-byte copy of the bundled template, and no skills mirror applies.
+    expect(value.asset).toBe("claude-md");
+    expect(value.target).toBe(resolve(target));
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, "utf-8")).toBe(
+      readFileSync(claudeTemplate, "utf-8")
+    );
+    expect(value.entries).toEqual([{ name: "CLAUDE.md", result: "created" }]);
+    expect(value.agentsSkillsLink).toBeNull();
+  });
+
+  test("a second claude-md sync without force skips the file", async () => {
+    // Given a target already written by a first sync
+    const tmp = makeTmp("claude-md-sync-");
+    const target = join(tmp, ".claude", "CLAUDE.md");
+    await syncOk({ asset: "claude-md", force: false, target });
+
+    // When syncing again without force
+    const second = await syncOk({ asset: "claude-md", force: false, target });
+
+    // Then the single entry is skipped (idempotent).
+    expect(second.entries).toEqual([{ name: "CLAUDE.md", result: "skipped" }]);
+  });
+});
+
+describe("syncAssetService — error contract (Result, never throws)", () => {
+  test("resolves (does not reject) even on invalid input", async () => {
+    // Given an asset outside the schema enum
+    // When/Then the call settles with a value instead of rejecting — failure is
+    // surfaced through Result, not by throwing (ADR-0003 §1).
+    await expect(
+      syncAssetService({ asset: "bogus" } as unknown as SkillSyncInput)
+    ).resolves.toBeDefined();
+  });
+
+  test("returns a validation-domain error for an unknown asset", async () => {
+    // Given an asset value the schema does not allow
+    const r = await syncAssetService({
+      asset: "workflow-cheatsheet",
+    } as unknown as SkillSyncInput);
+
+    // Then the boundary parse() fails into a validation-domain error.
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.domain).toBe("validation");
+    }
+  });
+
+  test("rejects asset 'all' at the service boundary (expansion is a CLI concern)", async () => {
+    // Given asset 'all' — the CLI expands it; the service contract never sees it
+    const r = await syncAssetService({
+      asset: "all",
+    } as unknown as SkillSyncInput);
+
+    // Then it is a validation-domain error, not a silent no-op.
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.domain).toBe("validation");
+    }
+  });
+
+  test("returns a validation-domain error when target is not a string", async () => {
+    // Given a non-string target
+    const r = await syncAssetService({
+      asset: "skills",
+      target: 123,
+    } as unknown as SkillSyncInput);
+
+    // Then the boundary parse() rejects it (ZodError → domain "validation").
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.domain).toBe("validation");
+    }
+  });
+});
+
+describe("SkillSyncInputSchema — contract", () => {
+  test("defaults force to false and leaves target undefined when omitted", () => {
+    // Given only an asset
+    // When parsed
+    const parsed = SkillSyncInputSchema.parse({ asset: "skills" });
+
+    // Then force defaults to false and target stays absent (CLI forwards both;
+    // the service fills the per-asset default target).
+    expect(parsed.force).toBe(false);
+    expect(parsed.target).toBeUndefined();
+  });
+
+  test("accepts the claude-md asset (AC#5: claude-md is a supported asset)", () => {
+    // Given the claude-md asset
+    // When parsed
+    const parsed = SkillSyncInputSchema.parse({ asset: "claude-md" });
+
+    // Then it is valid.
+    expect(parsed.asset).toBe("claude-md");
+  });
+
+  test("preserves an explicit target and force", () => {
+    // Given an explicit target + force
+    // When parsed
+    const parsed = SkillSyncInputSchema.parse({
+      asset: "skills",
+      force: true,
+      target: "/tmp/skills",
+    });
+
+    // Then the values are preserved.
+    expect(parsed.force).toBe(true);
+    expect(parsed.target).toBe("/tmp/skills");
+  });
+
+  test("rejects asset 'all' (the service enum is skills | claude-md)", () => {
+    // Given asset 'all' (a CLI-only sugar, not a service asset)
+    // When/Then parse throws.
+    expect(() => SkillSyncInputSchema.parse({ asset: "all" })).toThrow();
+  });
+
+  test("rejects an unknown asset value", () => {
+    // Given an asset outside the enum
+    // When/Then parse throws.
+    expect(() =>
+      SkillSyncInputSchema.parse({ asset: "workflow-cheatsheet" })
+    ).toThrow();
+  });
+
+  test("rejects a non-boolean force", () => {
+    // Given a non-boolean force
+    // When/Then parse throws (no coercion).
+    expect(() =>
+      SkillSyncInputSchema.parse({ asset: "skills", force: "yes" })
+    ).toThrow();
+  });
+
+  test("rejects unknown keys (.strict())", () => {
+    // Given an input carrying a key outside the schema
+    // When/Then the strict object rejects it (ADR-0003 §8).
+    expect(() =>
+      SkillSyncInputSchema.parse({ asset: "skills", extra: true })
+    ).toThrow();
+  });
+});
+
+describe("SkillSyncOutputSchema — contract", () => {
+  // A well-formed baseline payload reused across the rejection cases.
+  const validOutput = {
+    agentsSkillsLink: "linked",
+    asset: "skills",
+    entries: [{ name: "alpha", result: "created" }],
+    target: "/tmp/.claude/skills",
+  };
+
+  test("accepts a well-formed payload with a linked mirror", () => {
+    // Given an output matching the schema shape
+    // When parsed
+    const parsed = SkillSyncOutputSchema.parse(validOutput);
+
+    // Then it round-trips unchanged.
+    expect(parsed.agentsSkillsLink).toBe("linked");
+    expect(parsed.entries).toEqual([{ name: "alpha", result: "created" }]);
+  });
+
+  test("accepts a null agentsSkillsLink (file asset / non-standard layout)", () => {
+    // Given an output whose mirror is not applicable
+    // When parsed
+    const parsed = SkillSyncOutputSchema.parse({
+      ...validOutput,
+      agentsSkillsLink: null,
+    });
+
+    // Then null is a valid mirror state.
+    expect(parsed.agentsSkillsLink).toBeNull();
+  });
+
+  test("rejects an invalid agentsSkillsLink value", () => {
+    // Given an out-of-domain mirror state
+    // When/Then parse throws.
+    expect(() =>
+      SkillSyncOutputSchema.parse({ ...validOutput, agentsSkillsLink: "bogus" })
+    ).toThrow();
+  });
+
+  test("rejects an invalid entry result value", () => {
+    // Given an entry with a result outside created | skipped
+    // When/Then parse throws.
+    expect(() =>
+      SkillSyncOutputSchema.parse({
+        ...validOutput,
+        entries: [{ name: "alpha", result: "bogus" }],
+      })
+    ).toThrow();
+  });
+
+  test("rejects unknown keys (.strict())", () => {
+    // Given an output carrying a key outside the schema
+    // When/Then the strict object rejects it (both Input and Output are strict).
+    expect(() =>
+      SkillSyncOutputSchema.parse({ ...validOutput, extra: true })
+    ).toThrow();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "packages/*/src/**/*.ts",
     "packages/*/lib/**/*.ts",
     "packages/*/bin/**/*.ts",
+    "packages/*/scripts/**/*.ts",
     "packages/*/test/**/*.ts",
     "oxlint.config.ts",
     "oxfmt.config.ts"


### PR DESCRIPTION
## Summary

- `syncAssetService` で `import.meta.resolve` 基点のリソース解決を実装（旧 Python `importlib.resources` の置き換え）
- `packages/cli/package.json` の `files` に `_skills` / `_claude_md` を登録し npm package に同梱
- `prepack/postpack` で symlink を実体化→復元する `bundle-symlinks.ts` を追加（tarball に実体同梱）
- `ensureAgentsSkillsLink` で `.agents/skills` symlink を冪等併設（Codex CLI 探索パス規約）
- `syncClaudeMdAsset` で `CLAUDE.template.md` 配布を実装
- core 21 テスト + cli 8 テスト + pack 回帰テスト追加（計 36 新規テスト）

## Test plan

- [ ] `bun test` 全 green（365 pass / 0 fail 確認済み）
- [ ] `tsc -b` / `oxlint` / `oxfmt --check` / `knip` 全 clean
- [ ] 実プロセス e2e で `yt skills sync` の exit code・ファイル生成を確認
- [ ] `bun pm pack` tarball に `_skills` / `_claude_md` の実体が含まれることを確認

Closes #742

<!-- takt:managed -->