### PR TITLE
[#837] issue-837-ts-rewrite-phase2-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(ts-rewrite/core)`: resumable upload + thumbnail 圧縮 + metadata update を 1 atomic service に集約した `uploadVideoService` を ADR-0003 準拠で実装した（#837）
 - `feat(ts-rewrite/core)`: Per-video metrics（views / likes / comments / shares 等 8 指標）を YouTube Analytics API から収集する analytics video service を ADR-0003 準拠で実装した（#829）
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
 - `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "google-auth-library": "10.5.0",
         "googleapis": "^173.0.0",
         "openai": "^6.41.0",
+        "sharp": "^0.34.0",
         "zod": "^4.1.13",
       },
     },
@@ -80,6 +81,56 @@
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -447,6 +498,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -732,6 +785,8 @@
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,13 +17,15 @@
     "./oauth/refresh": "./src/oauth/refresh.ts",
     "./paths": "./src/paths.ts",
     "./registry": "./src/registry.ts",
-    "./skills-sync": "./src/skills-sync/index.ts"
+    "./skills-sync": "./src/skills-sync/index.ts",
+    "./upload": "./src/upload/index.ts"
   },
   "dependencies": {
     "@google/genai": "^2.7.0",
     "google-auth-library": "10.5.0",
     "googleapis": "^173.0.0",
     "openai": "^6.41.0",
+    "sharp": "^0.34.0",
     "zod": "^4.1.13"
   }
 }

--- a/packages/core/src/analytics/video/service.ts
+++ b/packages/core/src/analytics/video/service.ts
@@ -11,11 +11,7 @@
 //   deps.youtubeAnalytics.reports.query(params) -> { data: { columnHeaders?, rows? } }
 //   429 時は gaxios 形状 { response: { status: 429, headers: { "retry-after" } } } で reject。
 
-import {
-  QuotaExhaustedError,
-  toServiceError,
-  YouTubeAPIError,
-} from "../../errors.ts";
+import { classifyGaxiosError, toServiceError } from "../../errors.ts";
 import type { ServiceError } from "../../errors.ts";
 import type { YouTubeAnalyticsClient } from "../../oauth/client.ts";
 import { err, ok } from "../../result.ts";
@@ -42,43 +38,13 @@ export interface VideoAnalyticsDeps {
   sleep?: SleepMs;
 }
 
-// fromGaxiosError / QuotaExhaustedError の message に載せる操作名。
+// classifyGaxiosError / QuotaExhaustedError の message に載せる操作名。
 const QUERY_CONTEXT = "youtubeAnalytics.reports.query";
 
 /** Analytics クエリで参照する最小の列ヘッダ形状。 */
 interface ColumnHeader {
   readonly name?: string | null;
 }
-
-// gaxios 形状のエラーから Retry-After 秒を読む。ヘッダ欠落・空文字列・非数値は undefined を返す
-// （QuotaExhaustedError.retryAfterSeconds は省略可。外部入力の欠落値は undefined が正しい契約）。
-const retryAfterSecondsFrom = (error: unknown): number | undefined => {
-  const headers = (
-    error as { response?: { headers?: Record<string, unknown> } }
-  )?.response?.headers;
-  const raw = headers?.["retry-after"];
-  // 空文字列・空白のみは「ヒントなし」。Number("") === 0 を「0 秒で再試行可」と
-  // 誤読しないよう undefined に倒す（ヘッダ欠落 undefined → Number(undefined)=NaN と同じ扱い）。
-  if (typeof raw === "string" && raw.trim() === "") {
-    return undefined;
-  }
-  const seconds = Number(raw);
-  return Number.isFinite(seconds) ? seconds : undefined;
-};
-
-// reports.query の失敗を分類する。429 は QuotaExhaustedError へ昇格して withRetry に retry を
-// 抑止させ（ADR-0003: quota は Result で caller へ）、それ以外は YouTubeAPIError に変換して
-// withRetry の一時エラー retry に委ねる。
-const toQueryError = (error: unknown): Error => {
-  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
-  if (apiError.statusCode === 429) {
-    return new QuotaExhaustedError(
-      apiError.message,
-      retryAfterSecondsFrom(error)
-    );
-  }
-  return apiError;
-};
 
 // channelId を必須の ids フィルタにエンコードし、videoId 指定時のみ video== フィルタを足す。
 const buildQueryParams = (request: CollectVideoAnalyticsInput) => ({
@@ -101,7 +67,7 @@ const runVideoQuery = async (
   try {
     return await deps.youtubeAnalytics.reports.query(buildQueryParams(request));
   } catch (error) {
-    throw toQueryError(error);
+    throw classifyGaxiosError(error, QUERY_CONTEXT);
   }
 };
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -128,6 +128,49 @@ export class QuotaExhaustedError extends YouTubeAPIError {
   }
 }
 
+/**
+ * Read the Retry-After hint (in seconds) off a Gaxios-shaped error.
+ *
+ * A missing header, an empty/blank string, or a non-numeric value all yield
+ * undefined: `Number("")` is 0 and must not be misread as "retry in 0 seconds".
+ */
+const retryAfterSecondsFrom = (error: unknown): number | undefined => {
+  const headers = (
+    error as { response?: { headers?: Record<string, unknown> } }
+  )?.response?.headers;
+  const raw = headers?.["retry-after"];
+  if (typeof raw === "string" && raw.trim() === "") {
+    return undefined;
+  }
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) ? seconds : undefined;
+};
+
+/**
+ * Classify a Gaxios-shaped API failure into a payload-carrying throw type,
+ * sitting next to {@link YouTubeAPIError.fromGaxiosError} as the single home for
+ * gaxios-error triage shared by the service boundaries.
+ *
+ * A 429 is promoted to {@link QuotaExhaustedError} (carrying the Retry-After
+ * hint) so `withRetry` stops retrying and the boundary surfaces a quota
+ * ServiceError per the ADR-0003 retry規約; every other status stays a
+ * {@link YouTubeAPIError} for the transient-retry path. `context` names the
+ * failing operation for the message prefix.
+ */
+export const classifyGaxiosError = (
+  error: unknown,
+  context: string
+): YouTubeAPIError => {
+  const apiError = YouTubeAPIError.fromGaxiosError(error, context);
+  if (apiError.statusCode === 429) {
+    return new QuotaExhaustedError(
+      apiError.message,
+      retryAfterSecondsFrom(error)
+    );
+  }
+  return apiError;
+};
+
 // ServiceError (ADR-0003 §2): the wire-shape every service boundary emits. A
 // zod discriminated union on `domain` so MCP can `JSON.stringify` it straight
 // into a JSON-RPC error — a class hierarchy would lose its prototype chain.

--- a/packages/core/src/upload/index.ts
+++ b/packages/core/src/upload/index.ts
@@ -1,0 +1,9 @@
+// 動画アップロード feature の公開 API（ADR-0003 canonical 配置 packages/core/src/<feature>/）。
+//
+// 公開 API:
+// - uploadVideoService(input, deps): ADR-0003 Result 境界（resumable + thumbnail + metadata）
+// - UploadInput / UploadOutput: service 境界の zod schema（+ z.infer 型）
+// - UploadDeps: 構築済み YouTube クライアントを渡す注入 seam の型
+
+export { UploadInput, UploadOutput } from "./schema.ts";
+export { type UploadDeps, uploadVideoService } from "./service.ts";

--- a/packages/core/src/upload/schema.ts
+++ b/packages/core/src/upload/schema.ts
@@ -1,0 +1,98 @@
+// 動画アップロードサービス境界の入力 / 出力 schema（ADR-0003 §8: zod を source of truth）。
+//
+// 入力はチャンネル config / API レスポンス由来の JSON ではなく、呼び出し側（CLI / MCP）が
+// 組み立てる in-process な値オブジェクトのため、snake_case → camelCase の `.transform()`
+// は不要で camelCase のまま declare する（image/schema.ts と同形）。型は `z.infer` で導出し
+// 並書の `interface` は持たない。`.strict()` で未知キーを reject（fail fast）。
+//
+// metadata→YouTube body のマッピングは Python `youtube_auto_uploader.py:144-198` を移植する。
+// `categoryId` / `language` / `privacyStatus` / AI 開示フラグは現行プロダクションの既定値
+// （music=10 / en / private / synthetic=true / made-for-kids=false、#603 / #605）を
+// `.default()` で 1 箇所に解決し、各値を上書きしたい呼び出し元は明示的に渡せる経路を残す。
+
+import { z } from "zod";
+
+// YouTube が許容するサムネイルの最大バイト数（upload_policy.py:11）。超過分はこのサービスが
+// compress し、未満はそのまま透過する。zod schema 外（service の圧縮判断）でも参照する契約値。
+export const MAX_THUMBNAIL_BYTES = 2_097_152;
+
+// YouTube のタイトル長上限。超過は truncate ではなく validation error にする
+// （youtube_auto_uploader.py:146-147 の ValueError 相当）。
+const MAX_TITLE_LENGTH = 100;
+
+// 公開ステータスの許容値。enum 外の値（"semi-public" 等）は境界で validation error になる。
+const PRIVACY_STATUSES = ["public", "private", "unlisted"] as const;
+
+/**
+ * 1 ロケール分のローカライズタイトル / 説明文。YouTube `localizations.<lang>` の形状。
+ * `.strict()` で未知キーを弾き、`videos.insert` の body へそのまま載せる。
+ */
+const Localization = z
+  .object({
+    description: z.string(),
+    title: z.string(),
+  })
+  .strict();
+
+/**
+ * 動画メタデータ。`title` のみ上限超過を reject し、`description` / `tags` は YouTube 上限で
+ * truncate する（service 側のマッピングで実施、Python parity）。既定値を持つフィールドは
+ * 省略可で、未指定時に現行プロダクションの振る舞いへ解決される。
+ */
+const VideoMetadataInput = z
+  .object({
+    // snippet.categoryId。既定は YouTube の Music カテゴリ "10"。
+    categoryId: z.string().default("10"),
+    // AI 開示（status.containsSyntheticMedia）。AI 生成音楽主軸のため既定 true（#603）。
+    containsSyntheticMedia: z.boolean().default(true),
+    description: z.string(),
+    // snippet.defaultLanguage / defaultAudioLanguage の双方に使う言語コード。既定 "en"。
+    language: z.string().default("en"),
+    // YouTube `localizations`。指定時のみ body に載る。
+    localizations: z.record(z.string(), Localization).optional(),
+    privacyStatus: z.enum(PRIVACY_STATUSES).default("private"),
+    // 予約公開時刻。指定時は privacyStatus が private に矯正され UTC(Z) へ正規化される（#647）。
+    publishAt: z.string().optional(),
+    // 子供向け申告（status.selfDeclaredMadeForKids）。既定 false（#605）。
+    selfDeclaredMadeForKids: z.boolean().default(false),
+    tags: z.array(z.string()),
+    title: z.string().max(MAX_TITLE_LENGTH),
+  })
+  .strict();
+
+/**
+ * アップロード 1 件分のリクエスト。
+ *
+ * - `file`: アップロードする動画ファイルのパス（存在しなければ io エラー）
+ * - `metadata`: snippet / status へマップされる動画メタデータ
+ * - `thumbnail`: 省略可。指定時のみ insert 成功後に `thumbnails.set` を実行する
+ * - `resumable`: 省略可（既定 true）。Python `MediaFileUpload(resumable=True)` 相当。
+ *   true は stream を、false は buffer を `media.body` として `videos.insert` へ渡す
+ */
+export const UploadInput = z
+  .object({
+    file: z.string(),
+    metadata: VideoMetadataInput,
+    resumable: z.boolean().default(true),
+    thumbnail: z.string().optional(),
+  })
+  .strict();
+// 解決後（`.parse` 出力）の型。default 付きフィールドは確定値を持つ。service 内部で扱う。
+export type UploadInput = z.infer<typeof UploadInput>;
+// `.parse` 前の入力型。default 付きフィールド（resumable / categoryId 等）は省略可。
+// service の引数型として使い、呼び出し元が既定値を省略できる経路を保つ。
+export type UploadRequest = z.input<typeof UploadInput>;
+
+/**
+ * アップロード結果。
+ *
+ * - `videoId`: 作成された動画 ID（`videos.insert` レスポンス由来）
+ * - `thumbnailSet`: サムネイルを設定したか（thumbnail 未指定なら false）
+ */
+export const UploadOutput = z
+  .object({
+    thumbnailSet: z.boolean(),
+    videoId: z.string(),
+  })
+  .strict();
+export type UploadOutput = z.infer<typeof UploadOutput>;

--- a/packages/core/src/upload/service.ts
+++ b/packages/core/src/upload/service.ts
@@ -1,0 +1,257 @@
+// 動画アップロードサービス境界（ADR-0003 §1）。Python の upload core
+// （`utils/upload_core.py` + `agents/youtube_auto_uploader.py`）を 1 つの atomic service に
+// 集約する。1 回の service call で resumable upload（`videos.insert`）→ thumbnail compress +
+// set（`thumbnails.set`）→ metadata 反映までを順に行う。
+//
+// リトライ・バックオフは service が所有し、共通 `withRetry`（#959）に委譲する。quota（429）は
+// ADR-0003 の retry 規約に従い retry せず、`domain: "quota"` + `retryAfterSeconds` の Result で
+// caller へ返す。5xx 等の一時エラーは `withRetry` の既定予算（3 回）で再試行する。境界の
+// try/catch で `toServiceError` に集約し、CLI/MCP は `if (!r.ok)` で discriminate する。
+//
+// seam contract（テストの fake と一致させる契約）:
+//   deps.youtube.videos.insert(params) -> { data: { id?: string } }
+//     params: { part, requestBody: { snippet, status, localizations? }, media: { body } }
+//   deps.youtube.thumbnails.set(params) -> { data: ... }
+//     params: { videoId, media: { body } }
+//   429 時は gaxios 形状 { response: { status: 429, headers: { "retry-after" } } } で reject。
+
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+
+import sharp from "sharp";
+
+import { classifyGaxiosError, toServiceError } from "../errors.ts";
+import type { ServiceError } from "../errors.ts";
+import type { YouTubeClient } from "../oauth/client.ts";
+import { err, ok } from "../result.ts";
+import type { Result } from "../result.ts";
+import { withRetry } from "../retry.ts";
+import type { SleepMs } from "../retry.ts";
+import { MAX_THUMBNAIL_BYTES, UploadInput, UploadOutput } from "./schema.ts";
+import type { UploadRequest } from "./schema.ts";
+
+/**
+ * uploadVideoService の注入依存。
+ *
+ * - `youtube`: 構築済み YouTube Data API クライアント（DI seam、ADR-0003 §7）
+ * - `sleep`: `withRetry` のバックオフ待機注入点（省略時は実時間待機。テストは no-op を
+ *   注入して 5xx → `domain:"api"` の retry パスを deterministic に検証する）
+ */
+export interface UploadDeps {
+  youtube: YouTubeClient;
+  sleep?: SleepMs;
+}
+
+// classifyGaxiosError / QuotaExhaustedError の message に載せる操作名。
+const INSERT_CONTEXT = "videos.insert";
+
+// 圧縮で試す JPEG 品質（高→低）。最初に上限以下になった結果を採用する。Python は ffmpeg の
+// qscale を使うが scale が異なるため、sharp の品質値として独自に降順列を持つ。
+const THUMBNAIL_JPEG_QUALITIES = [80, 60, 40, 20, 10] as const;
+
+type ParsedMetadata = UploadInput["metadata"];
+
+// 予約公開時刻を YouTube Data API 向けに正規化する（youtube_auto_uploader.py:31-56 移植）。
+// timezone offset 付き（Z / ±HH:MM）は UTC の Z 終端へ変換し、naive・解析不能はそのまま返す
+// （呼び出し側の入力を尊重する）。
+const normalizePublishAt = (value: string): string => {
+  const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/u.test(value);
+  if (!hasTimezone) {
+    return value;
+  }
+  const epochMs = Date.parse(value);
+  if (Number.isNaN(epochMs)) {
+    return value;
+  }
+  return new Date(epochMs).toISOString().replace(/\.\d{3}Z$/u, "Z");
+};
+
+// status body を組み立てる。publishAt 指定時は予約公開要件として privacyStatus を private に
+// 矯正し、正規化済み publishAt を載せる（youtube_auto_uploader.py:160-167）。
+const buildStatus = (metadata: ParsedMetadata) => {
+  const base = {
+    containsSyntheticMedia: metadata.containsSyntheticMedia,
+    privacyStatus: metadata.privacyStatus,
+    selfDeclaredMadeForKids: metadata.selfDeclaredMadeForKids,
+  };
+  if (metadata.publishAt === undefined) {
+    return base;
+  }
+  return {
+    ...base,
+    privacyStatus: "private",
+    publishAt: normalizePublishAt(metadata.publishAt),
+  };
+};
+
+// metadata を videos.insert の requestBody（snippet / status / localizations）へマップする
+// （youtube_auto_uploader.py:176-189）。description / tags は YouTube 上限で truncate する。
+const buildRequestBody = (metadata: ParsedMetadata) => {
+  const snippet = {
+    categoryId: metadata.categoryId,
+    defaultAudioLanguage: metadata.language,
+    defaultLanguage: metadata.language,
+    description: metadata.description.slice(0, 5000),
+    tags: metadata.tags.slice(0, 50),
+    title: metadata.title,
+  };
+  const status = buildStatus(metadata);
+  if (metadata.localizations === undefined) {
+    return { snippet, status };
+  }
+  return { localizations: metadata.localizations, snippet, status };
+};
+
+// 動画ファイルの存在を先に確認する。欠落は insert を呼ばず io エラーへ倒す（fail fast、
+// upload_core.py:107-109 が None を返していた箇所を境界 throw に置き換え）。
+const assertVideoExists = async (file: string): Promise<void> => {
+  try {
+    await stat(file);
+  } catch {
+    throw new Error(`${file}: video file not found`);
+  }
+};
+
+// resumable=true は stream を、false は buffer を media.body に使う（Python の
+// MediaFileUpload(resumable=...) に対応する、実際に渡す body の差）。
+const buildMediaBody = async (
+  file: string,
+  resumable: boolean
+): Promise<NodeJS.ReadableStream | Buffer> =>
+  resumable ? createReadStream(file) : await readFile(file);
+
+// 1 回分の insert を実行し、失敗を domain エラーへ分類して投げ直す（withRetry に渡す 1-attempt
+// 単位）。retry 可否は withRetry / defaultShouldRetry に委ねる。
+const insertVideo = async (
+  deps: UploadDeps,
+  requestBody: ReturnType<typeof buildRequestBody>,
+  mediaBody: NodeJS.ReadableStream | Buffer
+) => {
+  try {
+    return await deps.youtube.videos.insert({
+      media: { body: mediaBody, mimeType: "video/*" },
+      part: Object.keys(requestBody),
+      requestBody,
+    });
+  } catch (error) {
+    throw classifyGaxiosError(error, INSERT_CONTEXT);
+  }
+};
+
+// insert レスポンスから video ID を取り出す。id 欠落は upload 失敗として throw する
+// （upload_core.py:216-219 が None を返していた箇所を境界 throw に置き換え → io）。
+const extractVideoId = (response: {
+  data?: { id?: string | null };
+}): string => {
+  const id = response.data?.id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error(`${INSERT_CONTEXT}: response is missing the video id`);
+  }
+  return id;
+};
+
+// サムネイルを上限以下のバイト列にする。上限未満はそのまま透過し、超過分は JPEG 品質を
+// 段階的に下げて圧縮する（upload_core.py:256-284）。どの品質でも収まらなければ fail fast。
+const compressThumbnail = async (path: string): Promise<Buffer> => {
+  const original = await readFile(path);
+  if (original.byteLength <= MAX_THUMBNAIL_BYTES) {
+    return original;
+  }
+  for (const quality of THUMBNAIL_JPEG_QUALITIES) {
+    const compressed = await sharp(original).jpeg({ quality }).toBuffer();
+    if (compressed.byteLength <= MAX_THUMBNAIL_BYTES) {
+      return compressed;
+    }
+  }
+  throw new Error(
+    `${path}: thumbnail could not be compressed under ${MAX_THUMBNAIL_BYTES} bytes`
+  );
+};
+
+// 圧縮済みサムネイルを作成済み動画に設定する。失敗（compress 不能・`thumbnails.set` reject）は
+// そのまま伝播させ、唯一の呼び出し元 `trySetThumbnail` が best-effort で吸収する（gaxios 分類は
+// `trySetThumbnail` の catch が結果を必ず破棄するため行わない）。retry はしない: thumbnail 設定は
+// insert 成功後の付随処理。
+const setThumbnail = async (
+  deps: UploadDeps,
+  videoId: string,
+  thumbnail: string
+): Promise<void> => {
+  const body = await compressThumbnail(thumbnail);
+  await deps.youtube.thumbnails.set({
+    media: { body, mimeType: "image/*" },
+    videoId,
+  });
+};
+
+// thumbnail を best-effort で設定し、成否を boolean で返す。compress 不能・`thumbnails.set`
+// reject（API エラー含む）はここで吸収し true/false に倒す（握りつぶしではなく、戻り値
+// thumbnailSet で結果を明示する契約）。insert は既に成功＝動画は作成済みのため、thumbnail 失敗で
+// upload 全体を失敗させると作成済み videoId を破棄し再実行で重複アップロードになる。
+//
+// ここは Python から意図的に divergence する。Python `set_thumbnail`（upload_core.py:222-254）は
+// 圧縮失敗（OSError）でのみ False を返して video_id を保持するが、API エラー（HttpError 429/5xx）
+// では `YouTubeAPIError` を raise する。`upload()`（upload_core.py:135-147）の `except HttpError` は
+// この `YouTubeAPIError` を捕捉しないため、thumbnail の API エラー時は video_id を返さず例外が
+// 伝播する。TS は重複アップロード再実行を避けるため API エラーを含む全 thumbnail 失敗で動画を
+// 捨てず videoId を Result へ載せ、状態整合を厳格化する。caller は thumbnailSet=false を見て
+// thumbnail だけ再試行できる。
+const trySetThumbnail = async (
+  deps: UploadDeps,
+  videoId: string,
+  thumbnail: string
+): Promise<boolean> => {
+  try {
+    await setThumbnail(deps, videoId, thumbnail);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * 動画を 1 本アップロードし、結果を Result で返す（ADR-0003 §1）。
+ *
+ * 入力は `.strict()` schema で先に検証し、次に動画ファイルの存在を確認してから upload する
+ * ため、不正入力・欠落ファイルは API に到達しない。`videos.insert`（resumable）→
+ * `thumbnails.set`（thumbnail 指定時のみ）を 1 service call で実行する。
+ *
+ * insert が成功した時点で動画は YouTube 上に作成済みになる。thumbnail は付随処理（best-effort）
+ * で、API エラーを含め失敗しても作成済み動画を捨てずに `ok({ videoId, thumbnailSet: false })` を
+ * 返す。これにより insert 成功後の失敗で videoId を破棄して再実行が重複アップロードを生む状態
+ * 不整合を防ぐ（Python は thumbnail の API エラーで video_id を失う＝意図的 divergence。詳細は
+ * `trySetThumbnail` のコメント参照）。insert 自体の失敗（quota / 5xx / id 欠落等）は従来どおり
+ * err を返す。
+ */
+export const uploadVideoService = async (
+  input: UploadRequest,
+  deps: UploadDeps
+): Promise<Result<UploadOutput, ServiceError>> => {
+  try {
+    const request = UploadInput.parse(input);
+    await assertVideoExists(request.file);
+
+    const body = buildRequestBody(request.metadata);
+    // media は attempt ごとに作り直す。resumable=true の body は一度しか消費できない
+    // fs.ReadStream のため、retry 間で使い回すと 2 回目以降が消費済み（空）の body を再送する。
+    const response = await withRetry(
+      async () =>
+        insertVideo(
+          deps,
+          body,
+          await buildMediaBody(request.file, request.resumable)
+        ),
+      { sleep: deps.sleep }
+    );
+    const videoId = extractVideoId(response);
+
+    const thumbnailSet =
+      request.thumbnail === undefined
+        ? false
+        : await trySetThumbnail(deps, videoId, request.thumbnail);
+
+    return ok(UploadOutput.parse({ thumbnailSet, videoId }));
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -16,6 +16,12 @@ import {
 import type { Result } from "@youtube-automation/core";
 import { z } from "zod";
 
+// classifyGaxiosError is an internal cross-feature classifier (shared by the
+// upload / analytics service boundaries), intentionally NOT re-exported from the
+// public barrel, so it is imported by its source path — the same convention the
+// other internal-symbol tests use (e.g. analytics-channel.test.ts).
+import { classifyGaxiosError } from "../src/errors.ts";
+
 // Builds a gaxios-shaped error: a real Error (so `error instanceof Error`
 // holds and `.message` is read for the wrapped message) with a `response`
 // carrying `status` and parsed/raw `data`, mirroring the Google API client
@@ -199,6 +205,45 @@ describe("QuotaExhaustedError", () => {
     const error = new QuotaExhaustedError("quota gone");
     // Then the hint is absent
     expect(error.retryAfterSeconds).toBeUndefined();
+  });
+});
+
+describe("classifyGaxiosError", () => {
+  test("promotes a 429 to QuotaExhaustedError carrying the Retry-After hint", () => {
+    // Given a gaxios-shaped 429 with a Retry-After header
+    const raw = gaxiosError("rate limited", {
+      headers: { "retry-after": "45" },
+      status: 429,
+    });
+    // When classifying it for a named operation
+    const error = classifyGaxiosError(raw, "videos.insert");
+    // Then it is promoted to a QuotaExhaustedError (so withRetry stops retrying)
+    // carrying the parsed Retry-After hint and a context-prefixed message
+    expect(error).toBeInstanceOf(QuotaExhaustedError);
+    expect(error.statusCode).toBe(429);
+    expect((error as QuotaExhaustedError).retryAfterSeconds).toBe(45);
+    expect(error.message).toBe("videos.insert: rate limited");
+  });
+
+  test("leaves the Retry-After hint undefined when the header is absent", () => {
+    // Given a 429 with no Retry-After header
+    const raw = gaxiosError("rate limited", { status: 429 });
+    // When classifying it
+    const error = classifyGaxiosError(raw, "videos.insert");
+    // Then it is still a quota error, but with no usable retry hint
+    expect(error).toBeInstanceOf(QuotaExhaustedError);
+    expect((error as QuotaExhaustedError).retryAfterSeconds).toBeUndefined();
+  });
+
+  test("leaves a non-429 as a plain YouTubeAPIError for the retry path", () => {
+    // Given a gaxios-shaped 500
+    const raw = gaxiosError("internal error", { status: 500 });
+    // When classifying it
+    const error = classifyGaxiosError(raw, "videos.insert");
+    // Then it stays a retryable YouTubeAPIError, not a quota error
+    expect(error).toBeInstanceOf(YouTubeAPIError);
+    expect(error).not.toBeInstanceOf(QuotaExhaustedError);
+    expect(error.statusCode).toBe(500);
   });
 });
 

--- a/packages/core/test/upload.test.ts
+++ b/packages/core/test/upload.test.ts
@@ -1,0 +1,844 @@
+// Tests for uploadVideoService (issue #837) — the single atomic upload service
+// that ports the Python video-upload core (utils/upload_core.py +
+// agents/youtube_auto_uploader.py) to an ADR-0003 Result boundary.
+//
+// The service returns Promise<Result<UploadOutput, ServiceError>>: it never
+// throws across its boundary and maps every failure to a ServiceError. The
+// googleapis YouTube Data API client (youtube_v3.Youtube) is reached through a
+// `deps` injection seam (mirroring analytics/video/service.ts and
+// image/service.ts), so these unit tests run with a fake client and never touch
+// the network or perform a real upload.
+//
+// Seam contract (documented here so the implementation matches the fakes):
+//   deps.youtube.videos.insert(params) -> { data: { id?: string } }
+//     params: { part, requestBody: { snippet, status, localizations? },
+//               media: { body: <video stream> } }
+//   deps.youtube.thumbnails.set(params) -> { data: ... }
+//     params: { videoId, media: { body: <thumbnail bytes/stream> } }
+//   deps.sleep?: a backoff injection point (no-op in tests) so the 5xx retry
+//     path resolves instantly instead of waiting the real 10s/30s.
+// On a 429 the insert rejects with a gaxios-shaped error
+//   { response: { status: 429, headers: { "retry-after": "<seconds>" } } }
+// which the service promotes to a quota ServiceError (retryAfterSeconds parsed
+// from the Retry-After header) — non-retryable per the ADR-0003 retry規約 (#959).
+//
+// Atomicity: a successful call performs videos.insert (media + metadata) then,
+// only when a thumbnail is supplied, thumbnails.set — in that order, within one
+// service call. The metadata→requestBody mapping (snippet/status/localizations,
+// publishAt UTC normalization, AI-disclosure defaults) ports
+// youtube_auto_uploader.py:144-198 and is asserted directly on the captured
+// insert params.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomFillSync } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { uploadVideoService } from "@youtube-automation/core/upload";
+
+// Derive input / deps shapes from the service signature so the test does not
+// hard-code the exported type names (analytics-video.test.ts:33-36).
+type UploadInput = Parameters<typeof uploadVideoService>[0];
+type UploadDeps = NonNullable<Parameters<typeof uploadVideoService>[1]>;
+
+// YouTube's hard cap on thumbnail size; the service must compress above it and
+// pass smaller files through untouched (upload_policy.py:11).
+const MAX_THUMBNAIL_BYTES = 2_097_152;
+
+// --- fakes ----------------------------------------------------------------
+
+type Behavior = () => unknown;
+
+// A fake youtube_v3 client. `videos.insert` runs the supplied behavior (a
+// value-returning or throwing thunk) and records every params bag; the same
+// behavior repeats so a single "always 500" thunk covers every retry attempt.
+// `thumbnails.set` defaults to success because most tests do not exercise its
+// failure mode. `order` records the call sequence so the atomic insert→thumbnail
+// ordering is assertable.
+const makeYouTubeClient = (opts: {
+  insert: Behavior;
+  thumbnails?: Behavior;
+}) => {
+  const insertCalls: unknown[] = [];
+  const thumbnailCalls: unknown[] = [];
+  const order: string[] = [];
+  const thumbnailBehavior = opts.thumbnails ?? (() => ({ data: {} }));
+  const client = {
+    thumbnails: {
+      set: (params: unknown) => {
+        thumbnailCalls.push(params);
+        order.push("thumbnails.set");
+        return Promise.resolve().then(thumbnailBehavior);
+      },
+    },
+    videos: {
+      insert: (params: unknown) => {
+        insertCalls.push(params);
+        order.push("videos.insert");
+        return Promise.resolve().then(opts.insert);
+      },
+    },
+  };
+  return { client, insertCalls, order, thumbnailCalls };
+};
+
+// A successful insert response carrying the new video id.
+const insertSuccess = (id: string) => () => ({ data: { id } });
+
+// A gaxios-shaped 429 carrying a Retry-After hint, mirroring the rate-limit
+// surface the service promotes to a quota ServiceError.
+const quotaError = (): Error =>
+  Object.assign(new Error("videos.insert: quota exceeded"), {
+    response: { headers: { "retry-after": "30" }, status: 429 },
+  });
+
+// A 429 whose Retry-After header is empty — there is no usable hint, so the
+// service must leave retryAfterSeconds undefined (not coerce "" to 0).
+const quotaErrorEmptyRetryAfter = (): Error =>
+  Object.assign(new Error("videos.insert: quota exceeded"), {
+    response: { headers: { "retry-after": "" }, status: 429 },
+  });
+
+// A gaxios-shaped non-429 server error. defaultShouldRetry classifies it as
+// retryable, so the service maps the exhausted failure to domain "api".
+const serverError = (): Error =>
+  Object.assign(new Error("internal server error"), {
+    response: { status: 500 },
+  });
+
+// A no-op backoff sleep so the retry path resolves instantly instead of waiting
+// the real 10s/30s (analytics-video.test.ts:60).
+const noSleep = (): Promise<void> => Promise.resolve();
+
+const makeDeps = (client: unknown, sleep?: () => Promise<void>): UploadDeps =>
+  ({
+    youtube: client,
+    ...(sleep === undefined ? {} : { sleep }),
+  }) as unknown as UploadDeps;
+
+// Reads the bytes the service handed to videos.insert / thumbnails.set as
+// media.body. A stream (fs.ReadStream / Readable) is drained the same way the
+// real resumable upload would consume it; a Buffer/Uint8Array is also accepted
+// so the assertion pins the byte content, not the container type.
+const collectMediaBytes = async (params: unknown): Promise<Uint8Array> => {
+  const { media } = params as { media?: { body?: unknown } };
+  const body = media?.body;
+  if (body === undefined || body === null) {
+    throw new Error("media.body was missing");
+  }
+  if (Buffer.isBuffer(body)) {
+    return new Uint8Array(body);
+  }
+  if (body instanceof Uint8Array) {
+    return body;
+  }
+  if (
+    typeof (body as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function"
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body as AsyncIterable<Uint8Array>) {
+      chunks.push(Buffer.from(chunk));
+    }
+    return new Uint8Array(Buffer.concat(chunks));
+  }
+  throw new Error("unsupported media.body shape");
+};
+
+// Reads the requestBody (snippet/status/localizations) off a captured insert
+// call so the metadata→body mapping can be asserted directly.
+const insertBody = (insertCalls: readonly unknown[]) => {
+  const params = insertCalls[0] as { part?: unknown; requestBody?: unknown };
+  const requestBody = (params.requestBody ?? {}) as {
+    localizations?: unknown;
+    snippet?: Record<string, unknown>;
+    status?: Record<string, unknown>;
+  };
+  // `part` may be an array (plan: [...Object.keys(body)]) or a comma string
+  // (Python parity); normalize so the assertion tolerates both.
+  const part = Array.isArray(params.part)
+    ? params.part.join(",")
+    : String(params.part ?? "");
+  return {
+    localizations: requestBody.localizations,
+    part,
+    snippet: requestBody.snippet ?? {},
+    status: requestBody.status ?? {},
+  };
+};
+
+// --- fixtures (real temp files; no read seam, per plan) --------------------
+
+let workdir: string;
+let videoPath: string;
+let smallThumbPath: string;
+let smallThumbBytes: Uint8Array;
+
+beforeAll(() => {
+  workdir = mkdtempSync(join(tmpdir(), "upload-"));
+
+  // A real (tiny) video file so the service's existence check passes; the fake
+  // insert never consumes its bytes.
+  videoPath = join(workdir, "complete.mp4");
+  writeFileSync(videoPath, Buffer.from("fake-mp4-bytes"));
+
+  // A thumbnail comfortably under 2MB: the service must pass it through without
+  // re-encoding (upload_policy.py:33-34 needs_compression=False).
+  smallThumbPath = join(workdir, "thumb-small.jpg");
+  smallThumbBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3, 4, 5]);
+  writeFileSync(smallThumbPath, smallThumbBytes);
+});
+
+afterAll(() => {
+  rmSync(workdir, { force: true, recursive: true });
+});
+
+// A minimal valid metadata bag. Values stay well within YouTube's length caps,
+// so the over-limit handling (title rejects; description/tags truncate to the
+// YouTube cap — see schema.ts:37-40) is pinned by the dedicated truncation tests
+// below, never by these.
+const baseMetadata = {
+  description: "calm lo-fi beats for late-night study",
+  tags: ["lofi", "study", "chill"],
+  title: "Late Night Lo-Fi Study Mix",
+};
+
+const baseInput = (overrides?: Partial<UploadInput>): UploadInput =>
+  ({
+    file: videoPath,
+    metadata: baseMetadata,
+    ...overrides,
+  }) as UploadInput;
+
+// --- success: video only ---------------------------------------------------
+
+describe("uploadVideoService success (no thumbnail)", () => {
+  test("inserts the video and returns ok with the new id and thumbnailSet false", async () => {
+    // Given an insert that returns a fresh video id and no thumbnail in the input
+    const { client, insertCalls, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_abc123"),
+    });
+
+    // When uploading
+    const r = await uploadVideoService(baseInput(), makeDeps(client));
+
+    // Then it succeeds, carries the id, and reports no thumbnail was set
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.videoId).toBe("vid_abc123");
+    expect(r.value.thumbnailSet).toBe(false);
+
+    // And the upload is one insert with no thumbnail call (thumbnail optional)
+    expect(insertCalls).toHaveLength(1);
+    expect(thumbnailCalls).toEqual([]);
+  });
+
+  test("maps metadata into the insert requestBody snippet/status and part", async () => {
+    // Given a successful insert
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_1"),
+    });
+
+    // When uploading with the base metadata
+    const r = await uploadVideoService(baseInput(), makeDeps(client));
+
+    // Then it succeeds and the metadata lands on snippet/status (parity with
+    // youtube_auto_uploader.py:176-186)
+    expect(r.ok).toBe(true);
+    const { part, snippet, status } = insertBody(insertCalls);
+    expect(snippet.title).toBe("Late Night Lo-Fi Study Mix");
+    expect(snippet.description).toBe("calm lo-fi beats for late-night study");
+    expect(snippet.tags).toEqual(["lofi", "study", "chill"]);
+
+    // And part declares the body sections being written
+    expect(part).toContain("snippet");
+    expect(part).toContain("status");
+
+    // And the upload is not scheduled, so no publishAt is emitted
+    expect(status.publishAt).toBeUndefined();
+  });
+
+  test("applies the current-behavior defaults when metadata omits them", async () => {
+    // Given a successful insert and metadata with only the required fields
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_def"),
+    });
+
+    // When uploading
+    const r = await uploadVideoService(baseInput(), makeDeps(client));
+
+    // Then the music category, language and privacy defaults apply
+    // (youtube_auto_uploader.py:156,181-183)
+    expect(r.ok).toBe(true);
+    const { snippet, status } = insertBody(insertCalls);
+    expect(snippet.categoryId).toBe("10");
+    expect(snippet.defaultLanguage).toBe("en");
+    expect(snippet.defaultAudioLanguage).toBe("en");
+    expect(status.privacyStatus).toBe("private");
+
+    // And the AI-disclosure defaults reproduce today's behavior: synthetic media
+    // declared true, made-for-kids false (channel_settings.py:176,185-186 / #603)
+    expect(status.containsSyntheticMedia).toBe(true);
+    expect(status.selfDeclaredMadeForKids).toBe(false);
+  });
+
+  test("carries localizations into the insert body when supplied", async () => {
+    // Given metadata that includes per-locale title/description overrides
+    const localizations = {
+      ja: { description: "夜の勉強用 lo-fi", title: "深夜の Lo-Fi" },
+    };
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_loc"),
+    });
+
+    // When uploading
+    const r = await uploadVideoService(
+      baseInput({
+        metadata: { ...baseMetadata, localizations },
+      } as Partial<UploadInput>),
+      makeDeps(client)
+    );
+
+    // Then the localizations ride along on the request body
+    // (youtube_auto_uploader.py:188-189)
+    expect(r.ok).toBe(true);
+    const { localizations: sent, part } = insertBody(insertCalls);
+    expect(sent).toEqual(localizations);
+    expect(part).toContain("localizations");
+  });
+});
+
+// --- over-limit truncation (description / tags) -----------------------------
+
+describe("uploadVideoService over-limit truncation", () => {
+  test("truncates a description longer than 5000 chars to the YouTube cap", async () => {
+    // Given a description that exceeds YouTube's 5000-char snippet cap
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_desc_trunc"),
+    });
+    const input = baseInput({
+      metadata: { ...baseMetadata, description: "d".repeat(5001) },
+    } as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then it succeeds and the description is truncated to exactly 5000 chars
+    // (truncate, not reject — schema.ts:37-40 / youtube_auto_uploader.py parity)
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    const { snippet } = insertBody(insertCalls);
+    expect(String(snippet.description)).toHaveLength(5000);
+  });
+
+  test("truncates a tag list longer than 50 items to the first 50", async () => {
+    // Given more tags than YouTube's 50-tag cap allows
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_tags_trunc"),
+    });
+    const tags = Array.from({ length: 60 }, (_, i) => `tag${i}`);
+    const input = baseInput({
+      metadata: { ...baseMetadata, tags },
+    } as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then it succeeds and only the first 50 tags reach the insert body
+    // (truncate, not reject — schema.ts:37-40)
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    const { snippet } = insertBody(insertCalls);
+    expect(snippet.tags).toEqual(tags.slice(0, 50));
+  });
+});
+
+// --- scheduled publish (publishAt normalization) ---------------------------
+
+describe("uploadVideoService scheduled publish", () => {
+  test("normalizes a TZ-offset publishAt to a UTC Z instant and forces privacy private", async () => {
+    // Given a publishAt with a +09:00 offset and an explicit public privacy
+    // status the scheduler must override (youtube_auto_uploader.py:164-167)
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_sched"),
+    });
+    const input = baseInput({
+      metadata: {
+        ...baseMetadata,
+        privacyStatus: "public",
+        publishAt: "2026-06-15T20:00:00+09:00",
+      },
+    } as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then privacy is forced to private (scheduled publish requirement)
+    expect(r.ok).toBe(true);
+    const { status } = insertBody(insertCalls);
+    expect(status.privacyStatus).toBe("private");
+
+    // And publishAt is the same instant expressed as UTC, Z-terminated (#647)
+    const publishAt = String(status.publishAt);
+    expect(publishAt.endsWith("Z")).toBe(true);
+    expect(new Date(publishAt).getTime()).toBe(
+      new Date("2026-06-15T11:00:00Z").getTime()
+    );
+  });
+
+  test("publishes immediately (public, no publishAt) when no schedule is given", async () => {
+    // Given a public privacy status and no publishAt
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_now"),
+    });
+    const input = baseInput({
+      metadata: { ...baseMetadata, privacyStatus: "public" },
+    } as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then public is preserved and no publishAt is added (immediate publish)
+    expect(r.ok).toBe(true);
+    const { status } = insertBody(insertCalls);
+    expect(status.privacyStatus).toBe("public");
+    expect(status.publishAt).toBeUndefined();
+  });
+});
+
+// --- success: with thumbnail ------------------------------------------------
+
+describe("uploadVideoService thumbnail handling", () => {
+  test("sets a sub-2MB thumbnail after the insert and passes its bytes through unchanged", async () => {
+    // Given a successful insert and a small (sub-2MB) thumbnail on disk
+    const { client, insertCalls, order, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_thumb"),
+    });
+
+    // When uploading with that thumbnail
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: smallThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then it succeeds and reports the thumbnail was set
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.thumbnailSet).toBe(true);
+
+    // And the atomic order is insert first, then thumbnails.set
+    expect(insertCalls).toHaveLength(1);
+    expect(thumbnailCalls).toHaveLength(1);
+    expect(order).toEqual(["videos.insert", "thumbnails.set"]);
+
+    // And, being under 2MB, the file is forwarded untouched (no re-encode)
+    const sent = await collectMediaBytes(thumbnailCalls[0]);
+    expect([...sent]).toEqual([...smallThumbBytes]);
+  });
+
+  test("targets the freshly created video id when setting the thumbnail", async () => {
+    // Given an insert that returns a specific id
+    const { client, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_target"),
+    });
+
+    // When uploading with a thumbnail
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: smallThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then thumbnails.set is scoped to that same video id
+    expect(r.ok).toBe(true);
+    const params = thumbnailCalls[0] as { videoId?: unknown };
+    expect(params.videoId).toBe("vid_target");
+  });
+
+  test("compresses an over-2MB thumbnail below the cap before uploading", async () => {
+    // Given a real >2MB image fixture (sharp is a core dep added by this issue).
+    // High-entropy noise keeps the PNG large while a low-quality JPEG re-encode
+    // brings it well under the cap.
+    const sharpModule = await import("sharp");
+    const sharp = sharpModule.default;
+    const width = 1100;
+    const height = 1100;
+    const raw = Buffer.allocUnsafe(width * height * 3);
+    randomFillSync(raw);
+    const bigPng = await sharp(raw, { raw: { channels: 3, height, width } })
+      .png()
+      .toBuffer();
+    const bigThumbPath = join(workdir, "thumb-big.png");
+    writeFileSync(bigThumbPath, bigPng);
+
+    // Sanity: the source genuinely exceeds the cap, so compression must run
+    expect(statSync(bigThumbPath).size).toBeGreaterThan(MAX_THUMBNAIL_BYTES);
+
+    const { client, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_big"),
+    });
+
+    // When uploading with the oversized thumbnail
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: bigThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then it succeeds and the bytes handed to thumbnails.set are compressed:
+    // at or under the cap, and smaller than the source (compression happened)
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.thumbnailSet).toBe(true);
+    const sent = await collectMediaBytes(thumbnailCalls[0]);
+    expect(sent.byteLength).toBeLessThanOrEqual(MAX_THUMBNAIL_BYTES);
+    expect(sent.byteLength).toBeLessThan(statSync(bigThumbPath).size);
+  });
+});
+
+// --- thumbnail failure is best-effort (insert already succeeded) ------------
+
+describe("uploadVideoService thumbnail failure is best-effort", () => {
+  test("keeps the created video (ok, thumbnailSet false) when thumbnails.set fails, without re-inserting", async () => {
+    // Given an insert that succeeds but a thumbnails.set that rejects (the video
+    // already exists on YouTube once insert returned an id)
+    const { client, insertCalls, order, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_thumb_fail"),
+      thumbnails: () => {
+        throw serverError();
+      },
+    });
+
+    // When uploading with a thumbnail
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: smallThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then the upload still succeeds: the created video id is preserved (never
+    // discarded) and thumbnailSet reports the thumbnail did not take
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.videoId).toBe("vid_thumb_fail");
+    expect(r.value.thumbnailSet).toBe(false);
+
+    // And the video was inserted exactly once — the failed thumbnail must not
+    // trigger a re-insert (which would duplicate the upload)
+    expect(insertCalls).toHaveLength(1);
+    expect(thumbnailCalls).toHaveLength(1);
+    expect(order).toEqual(["videos.insert", "thumbnails.set"]);
+  });
+
+  test("keeps the created video (ok, thumbnailSet false) when the thumbnail cannot be compressed", async () => {
+    // Given an over-2MB thumbnail whose bytes are not a decodable image, so the
+    // sharp compression pass throws before any thumbnails.set call (圧縮不能)
+    const undecodableThumbPath = join(workdir, "thumb-undecodable.bin");
+    writeFileSync(
+      undecodableThumbPath,
+      Buffer.alloc(MAX_THUMBNAIL_BYTES + 1024, 0x7f)
+    );
+    expect(statSync(undecodableThumbPath).size).toBeGreaterThan(
+      MAX_THUMBNAIL_BYTES
+    );
+
+    const { client, insertCalls, thumbnailCalls } = makeYouTubeClient({
+      insert: insertSuccess("vid_compress_fail"),
+    });
+
+    // When uploading with that thumbnail
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: undecodableThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then the video upload still succeeds with the id preserved and the
+    // thumbnail left unset (compression failure is absorbed, not propagated)
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.videoId).toBe("vid_compress_fail");
+    expect(r.value.thumbnailSet).toBe(false);
+
+    // And the failure happened during compression, before thumbnails.set, with
+    // a single insert
+    expect(insertCalls).toHaveLength(1);
+    expect(thumbnailCalls).toEqual([]);
+  });
+});
+
+// --- quota path -------------------------------------------------------------
+
+describe("uploadVideoService quota", () => {
+  test("maps a 429 to a quota ServiceError carrying retryAfterSeconds without retrying", async () => {
+    // Given an insert that rejects with a gaxios-shaped 429 + Retry-After header
+    const { client, insertCalls, thumbnailCalls } = makeYouTubeClient({
+      insert: () => {
+        throw quotaError();
+      },
+    });
+
+    // When uploading
+    const r = await uploadVideoService(
+      baseInput({ thumbnail: smallThumbPath }),
+      makeDeps(client)
+    );
+
+    // Then the boundary returns err(domain "quota") — it never throws across itself
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected a quota failure");
+    }
+    expect(r.error.domain).toBe("quota");
+    if (r.error.domain === "quota") {
+      expect(r.error.httpStatus).toBe(429);
+      expect(r.error.retryAfterSeconds).toBe(30);
+    }
+
+    // And quota is non-retryable: insert ran exactly once and the thumbnail
+    // (which would have followed a successful insert) was never attempted
+    expect(insertCalls).toHaveLength(1);
+    expect(thumbnailCalls).toEqual([]);
+  });
+
+  test("leaves retryAfterSeconds undefined when the Retry-After header is empty", async () => {
+    // Given a 429 whose Retry-After header is an empty string (no usable hint)
+    const { client } = makeYouTubeClient({
+      insert: () => {
+        throw quotaErrorEmptyRetryAfter();
+      },
+    });
+
+    // When uploading
+    const r = await uploadVideoService(baseInput(), makeDeps(client));
+
+    // Then it is still a quota error, but "" is not coerced to 0 seconds
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected a quota failure");
+    }
+    expect(r.error.domain).toBe("quota");
+    if (r.error.domain === "quota") {
+      expect(r.error.retryAfterSeconds).toBeUndefined();
+    }
+  });
+});
+
+// --- api error path (5xx with retry) ---------------------------------------
+
+describe("uploadVideoService api error", () => {
+  test('maps a persistent 5xx to domain "api" after exhausting the default 3 attempts', async () => {
+    // Given an insert that always rejects with a gaxios-shaped 500
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: () => {
+        throw serverError();
+      },
+    });
+
+    // When uploading with a no-op backoff sleep injected
+    const r = await uploadVideoService(baseInput(), makeDeps(client, noSleep));
+
+    // Then the boundary returns err(domain "api") carrying the HTTP status
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected an api failure");
+    }
+    expect(r.error.domain).toBe("api");
+    if (r.error.domain === "api") {
+      expect(r.error.httpStatus).toBe(500);
+    }
+
+    // And unlike quota, a 5xx is retryable: insert ran the default 3 attempts
+    // (withRetry is the single retry owner — no self-rolled backoff loop)
+    expect(insertCalls).toHaveLength(3);
+  });
+
+  test("re-sends the full video body on a 5xx retry instead of an exhausted stream", async () => {
+    // The default upload is resumable=true, so media.body is a one-shot
+    // fs.ReadStream that a real resumable upload consumes on each attempt.
+    // Reusing one stream across retries would re-send an empty body on attempt
+    // 2. This fake drains the body exactly as the real client would and records
+    // the bytes seen per attempt, so a once-consumed stream surfaces as a short
+    // body on the retry rather than hiding behind a fake that never reads it.
+    const videoBytes = new Uint8Array(readFileSync(videoPath));
+    const drainedPerAttempt: Uint8Array[] = [];
+    let attempt = 0;
+    const client = {
+      thumbnails: { set: () => Promise.resolve({ data: {} }) },
+      videos: {
+        insert: async (params: unknown) => {
+          drainedPerAttempt.push(await collectMediaBytes(params));
+          attempt += 1;
+          if (attempt === 1) {
+            throw serverError();
+          }
+          return { data: { id: "vid_retry_body" } };
+        },
+      },
+    };
+
+    // When uploading (5xx on attempt 1, success on attempt 2)
+    const r = await uploadVideoService(baseInput(), makeDeps(client, noSleep));
+
+    // Then the upload retries past the 500 and succeeds
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.videoId).toBe("vid_retry_body");
+
+    // And BOTH attempts received the complete file: the retry is a fresh stream,
+    // not an exhausted one re-sending an empty body
+    expect(drainedPerAttempt).toHaveLength(2);
+    for (const sent of drainedPerAttempt) {
+      expect([...sent]).toEqual([...videoBytes]);
+    }
+  });
+});
+
+// --- io errors --------------------------------------------------------------
+
+describe("uploadVideoService io errors", () => {
+  test('maps a missing video file to domain "io" without calling insert', async () => {
+    // Given a file path that does not exist on disk
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("never"),
+    });
+    const input = baseInput({ file: join(workdir, "does-not-exist.mp4") });
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then the existence check fails fast as an io error and insert is untouched
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected an io failure");
+    }
+    expect(r.error.domain).toBe("io");
+    expect(insertCalls).toEqual([]);
+  });
+
+  test('maps an insert response missing the video id to domain "io"', async () => {
+    // Given an insert that resolves successfully but without an id
+    // (upload_core.py:216-219 treats a missing id as a failure)
+    const { client } = makeYouTubeClient({
+      insert: () => ({ data: {} }),
+    });
+
+    // When uploading
+    const r = await uploadVideoService(baseInput(), makeDeps(client));
+
+    // Then the unprefixed throw surfaces as an io error
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected an io failure");
+    }
+    expect(r.error.domain).toBe("io");
+  });
+});
+
+// --- input validation -------------------------------------------------------
+
+describe("uploadVideoService input validation", () => {
+  test("rejects an unknown input key via the strict schema without uploading", async () => {
+    // Given a client that would succeed if it were ever reached
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("never"),
+    });
+    // And an input carrying an extra key the `.strict()` schema must reject
+    const malformed = {
+      ...baseInput(),
+      unexpected: true,
+    } as unknown as UploadInput;
+
+    // When uploading the malformed input
+    const r = await uploadVideoService(malformed, makeDeps(client));
+
+    // Then the boundary parses first: a validation error, insert never invoked
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(r.error.domain).toBe("validation");
+    expect(insertCalls).toEqual([]);
+  });
+
+  test("rejects a title longer than 100 characters", async () => {
+    // Given a title that exceeds YouTube's 100-char cap
+    // (youtube_auto_uploader.py:146-147 raises ValueError)
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("never"),
+    });
+    const input = baseInput({
+      metadata: { ...baseMetadata, title: "x".repeat(101) },
+    } as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then the over-long title fails validation before any upload
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(r.error.domain).toBe("validation");
+    expect(insertCalls).toEqual([]);
+  });
+
+  test("rejects an unknown privacyStatus value", async () => {
+    // Given a privacyStatus outside the allowed enum
+    const { client, insertCalls } = makeYouTubeClient({
+      insert: insertSuccess("never"),
+    });
+    const input = baseInput({
+      metadata: { ...baseMetadata, privacyStatus: "semi-public" },
+    } as unknown as Partial<UploadInput>);
+
+    // When uploading
+    const r = await uploadVideoService(input, makeDeps(client));
+
+    // Then the enum constraint fails validation before any upload
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(r.error.domain).toBe("validation");
+    expect(insertCalls).toEqual([]);
+  });
+
+  test("accepts resumable: false and still uploads", async () => {
+    // Given a valid input that opts out of resumable upload
+    const { client } = makeYouTubeClient({
+      insert: insertSuccess("vid_nonresumable"),
+    });
+
+    // When uploading with resumable disabled
+    const r = await uploadVideoService(
+      baseInput({ resumable: false }),
+      makeDeps(client)
+    );
+
+    // Then the schema accepts the option and the upload succeeds
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.videoId).toBe("vid_nonresumable");
+  });
+});


### PR DESCRIPTION
## Summary

## Parent

epic #727

## What to build

`packages/core/src/upload/service.ts` を新規追加。Python `utils/upload_core.py` (284 LOC) + `agents/youtube_auto_uploader.py` + `agents/collection_uploader.py` の機能を **1 atomic service** に集約。

- `uploadVideoService(input: UploadInput, deps: { youtube: youtube_v3.Youtube }): Promise<Result<UploadOutput, ServiceError>>`
- input: `{ file: string; metadata: VideoMetadataInput; thumbnail?: string; resumable?: boolean }`
- 動作: resumable upload (`videos.insert`) → thumbnail upload (`thumbnails.set`) → metadata update を atomic 処理
- thumbnail compression は sharp で 2MB 以下に (Python `upload_core::compress_thumbnail` 相当)
- 失敗時の retry: quota error (429) は `retryAfterSeconds` を Result で返す、5xx は exponential backoff 3 回まで内部 retry
- `agents/` ディレクトリは TS に作らない、batch 処理は CLI 側 (`packages/cli/commands/{auto,collection}/cli.ts`、本 issue では skeleton のみ)

## Acceptance criteria

- [ ] ADR-0003 の canonical template に準拠
- [ ] service は `Promise<Result<T, ServiceError>>` を返す (内部 throw OK、境界で `toServiceError` 経由)
- [ ] schema は zod (`z.object().strict()`) + `z.infer` で型導出 (`interface` 並書なし)
- [ ] uploadVideoService が atomic (resumable + thumbnail + metadata update が 1 service call)
- [ ] sharp 経由で thumbnail を 2MB 以下に compress
- [ ] quota error (429) で `{ domain: "quota", retryAfterSeconds }` を Result.err として返す
- [ ] 5xx で exponential backoff 3 回 retry
- [ ] bun:test: mocked youtube client で success / quota / 5xx / file-not-found の 4 ケース

## Blocked by

- #826 (buildYouTubeClient)

## Refs

- ADR 0003 (#820): docs/adr/0003-service-boundary-contracts.md
- ADR 0002: docs/adr/0002-service-first-architecture.md
- Epic: #727

## Retry 規約 (2026-06-12 追記、ADR レビュー所見 4)

API retry / backoff を本 issue 内で自前実装しないこと。`@youtube-automation/core` の `withRetry` (#959) を使う。quota (429) は retry せず `domain: "quota"` + `retryAfterSeconds` の Result で返す (ADR-0003)。

## Execution Report

Workflow `default` completed successfully.

Closes #837