### PR TITLE
[#1022] issue-1022-feat-extensions-rel

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -1,15 +1,11 @@
 name: Release Extensions
 
-# tag push 時に拡張をビルドして zip を生成し、GitHub Release に添付する。
+# tag push 時に各 Chrome 拡張をビルドして zip を生成し、単一の GitHub Release に添付する。
 # tag 命名は拡張バージョン用の `ext-v*`（Python 本体の release タグと分離する）。
 on:
   push:
     tags:
       - "ext-v*"
-
-defaults:
-  run:
-    working-directory: extensions/suno-helper
 
 permissions:
   contents: write
@@ -26,12 +22,38 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: extensions/suno-helper/pnpm-lock.yaml
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build and zip
-        run: pnpm zip
-      - name: Attach zip to Release
+          cache-dependency-path: |
+            extensions/suno-helper/pnpm-lock.yaml
+            extensions/distrokid-helper/pnpm-lock.yaml
+      - name: Build and zip suno-helper
+        working-directory: extensions/suno-helper
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm zip
+      - name: Build and zip distrokid-helper
+        working-directory: extensions/distrokid-helper
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm zip
+      - name: Attach zips to Release
         uses: softprops/action-gh-release@v2
         with:
-          files: extensions/suno-helper/.output/*.zip
+          files: |
+            extensions/suno-helper/.output/*.zip
+            extensions/distrokid-helper/.output/*.zip
+          body: |
+            ## 収録拡張
+
+            - **Suno Helper** — `suno-helper-*.zip`
+            - **DistroKid Helper** — `distrokid-helper-*.zip`
+
+            ## 初回インストール
+
+            1. 目的の拡張の zip（`*.zip`）をダウンロードして任意のフォルダに展開する。
+            2. Chrome で `chrome://extensions` を開き、右上の **デベロッパーモード** を ON にする。
+            3. **パッケージ化されていない拡張機能を読み込む**（Load unpacked）をクリックし、展開したフォルダを選択する。
+
+            ## 更新
+
+            1. 新しい zip をダウンロードして展開し、既存の展開フォルダを置き換える。
+            2. `chrome://extensions` を開き、対象拡張の **リロード**（更新アイコン）をクリックする。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(extensions)`: `release-extensions.yml` を統一タグ `ext-v*` で suno-helper / distrokid-helper の両 zip を単一 GitHub Release に添付するよう拡張した（#1022）。従来は suno-helper のみ添付され distrokid-helper が配布されていなかった問題を解消。あわせて `softprops/action-gh-release` の `body` に初回インストール（zip 展開 → `chrome://extensions` → Load unpacked）／更新（zip 展開 → リロード）手順テンプレを埋め込み、配布契約を `tests/test_release_extensions_workflow.py` で機械担保した。
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
 - `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。
 

--- a/tests/test_release_extensions_workflow.py
+++ b/tests/test_release_extensions_workflow.py
@@ -1,0 +1,105 @@
+"""`release-extensions.yml` の配布契約を静的に検証する（Issue #1022）。
+
+統一タグ `ext-v*` で suno-helper / distrokid-helper の両 zip を単一 Release に
+添付し、Release 本文にインストール/更新手順テンプレが埋め込まれていることを担保する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "release-extensions.yml"
+
+_RELEASE_TAG_GLOB = "ext-v*"
+_GH_RELEASE_ACTION = "softprops/action-gh-release@v2"
+_EXTENSIONS = ("suno-helper", "distrokid-helper")
+_ZIP_GLOBS = tuple(f"extensions/{name}/.output/*.zip" for name in _EXTENSIONS)
+# order.md が要求する手順アンカー。初回インストール（URL + Load unpacked）と
+# 更新（リロード）の両セクションが本文に埋め込まれていることを最小限で担保する。
+_BODY_REQUIRED_PHRASES = (
+    "chrome://extensions",
+    "Load unpacked",
+    "リロード",
+)
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        pytest.fail(f"必須ファイルが存在しない: {path.relative_to(_REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_workflow() -> dict[str, object]:
+    return yaml.safe_load(_read_text(_WORKFLOW_PATH))
+
+
+def _on_section(workflow: dict[str, object]) -> dict[str, object]:
+    # PyYAML は YAML 1.1 に従い `on:` を真偽値 True キーへ変換する。
+    section = workflow.get("on", workflow.get(True))
+    assert isinstance(section, dict), "on トリガセクションが存在しない"
+    return section
+
+
+def _release_steps() -> list[dict[str, object]]:
+    workflow = _load_workflow()
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+    release_job = jobs.get("release")
+    assert isinstance(release_job, dict), "release job が存在しない"
+    assert release_job.get("runs-on") == "ubuntu-latest"
+    steps = release_job.get("steps")
+    assert isinstance(steps, list) and steps, "release job に steps が存在しない"
+    return steps
+
+
+def test_triggers_on_unified_extension_tag() -> None:
+    """統一タグ `ext-v*` の push のみで起動する契約を固定する。"""
+    on_section = _on_section(_load_workflow())
+    push = on_section.get("push")
+    assert isinstance(push, dict), "push トリガが存在しない"
+    assert push.get("tags") == [_RELEASE_TAG_GLOB]
+
+
+def test_grants_contents_write_permission() -> None:
+    """Release 添付には contents: write が必要。"""
+    workflow = _load_workflow()
+    assert workflow.get("permissions") == {"contents": "write"}
+
+
+@pytest.mark.parametrize("name", _EXTENSIONS)
+def test_builds_and_zips_each_extension(name: str) -> None:
+    """両拡張がそれぞれの作業ディレクトリで install → zip される。"""
+    steps = _release_steps()
+    matched = [
+        step
+        for step in steps
+        if step.get("working-directory") == f"extensions/{name}" and "pnpm zip" in str(step.get("run", ""))
+    ]
+    assert matched, f"{name} の build/zip ステップが存在しない"
+    run_script = str(matched[0]["run"])
+    assert "pnpm install --frozen-lockfile" in run_script
+
+
+def test_attaches_both_zips_to_single_release() -> None:
+    """単一の gh-release ステップで両拡張の zip を添付する。"""
+    steps = _release_steps()
+    release_steps = [step for step in steps if str(step.get("uses", "")).startswith(_GH_RELEASE_ACTION)]
+    assert len(release_steps) == 1, "gh-release ステップは 1 個に集約する"
+
+    files_value = str(release_steps[0].get("with", {}).get("files", ""))
+    for zip_glob in _ZIP_GLOBS:
+        assert zip_glob in files_value, f"{zip_glob} が files に含まれていない"
+
+
+def test_release_body_embeds_install_and_update_template() -> None:
+    """Release 本文に初回インストール/更新手順テンプレが埋め込まれている。"""
+    steps = _release_steps()
+    release_step = next(step for step in steps if str(step.get("uses", "")).startswith(_GH_RELEASE_ACTION))
+    body = str(release_step.get("with", {}).get("body", ""))
+    assert body, "Release 本文テンプレ (body) が未設定"
+    for phrase in _BODY_REQUIRED_PHRASES:
+        assert phrase in body, f"Release 本文テンプレに必須フレーズが欠落: {phrase}"


### PR DESCRIPTION
## Summary

## 背景

ADR-0011 で Chrome 拡張の配布方針を決定した。現行の `release-extensions.yml` は suno-helper の zip しか作っておらず、distrokid-helper が GitHub Release に添付されない。

## やること

1. `.github/workflows/release-extensions.yml` に distrokid-helper の zip 化ステップを追加
   - 統一タグ `ext-v*` で両方を同時ビルド・添付
2. リリースノート本文にインストール/更新手順のテンプレを埋め込む
   - 初回インストール手順（zip 展開 → `chrome://extensions` → Load unpacked）
   - 更新手順（zip 展開 → リロード）
   - `softprops/action-gh-release` の `body` にテンプレを設定

## 参考

- ADR-0011: `docs/adr/0011-extension-distribution.md`
- 現行 workflow: `.github/workflows/release-extensions.yml`

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1022