### PR TITLE
feat(skills): ext-install スキル追加

### DIFF
--- a/.claude/skills/ext-install/SKILL.md
+++ b/.claude/skills/ext-install/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: ext-install
+description: "Use when Chrome 拡張（suno-helper / distrokid-helper）の初回インストールまたは更新を行いたいとき。GitHub Release から zip をダウンロードし、Chrome に Load unpacked で読み込む手順をガイドする。「拡張入れて」「extension インストール」「suno-helper 更新」「distrokid-helper アップデート」などで発動する"
+---
+
+## Overview
+
+automation リポジトリの GitHub Release (`ext-v*` タグ) に添付された Chrome 拡張 zip をダウンロードし、Chrome にインストール（または更新）する operator ガイドスキル。
+
+対象拡張:
+- **suno-helper** — Suno UI 上で曲の連続生成 + playlist 追加を自動化
+- **distrokid-helper** — DistroKid 登録フォームへの自動入力
+
+## When to Use
+
+- Chrome 拡張を初めてインストールするとき
+- 新しいバージョンの拡張に更新したいとき
+- 「拡張入れて」「extension 更新して」「suno-helper インストール」などと user が言ったとき
+
+## Instructions
+
+### Step 1: 最新リリースの確認
+
+```bash
+gh release view --repo daiki-beppu/youtube-automation $(gh release list --repo daiki-beppu/youtube-automation --limit 10 --json tagName --jq '[.[] | select(.tagName | startswith("ext-v"))][0].tagName') --json tagName,assets --jq '{tag:.tagName, assets:[.assets[] | {name, url:.url}]}'
+```
+
+user に最新バージョンと含まれる拡張を提示する。
+
+### Step 2: 既存バージョンの確認
+
+Chrome で拡張がすでにインストール済みか user に確認する:
+
+- **初回インストール**: Step 3 へ
+- **更新**: Step 4 へ
+
+### Step 3: 初回インストール
+
+1. zip をダウンロードする（user が必要な拡張を選択）:
+
+```bash
+# suno-helper の場合
+gh release download --repo daiki-beppu/youtube-automation <tag> --pattern 'suno-helper-*.zip' --dir ~/Downloads
+
+# distrokid-helper の場合
+gh release download --repo daiki-beppu/youtube-automation <tag> --pattern 'distrokid-helper-*.zip' --dir ~/Downloads
+```
+
+2. zip を展開する:
+
+```bash
+# suno-helper の場合
+mkdir -p ~/chrome-extensions/suno-helper && cd ~/chrome-extensions/suno-helper && unzip -o ~/Downloads/suno-helper-*.zip
+
+# distrokid-helper の場合
+mkdir -p ~/chrome-extensions/distrokid-helper && cd ~/chrome-extensions/distrokid-helper && unzip -o ~/Downloads/distrokid-helper-*.zip
+```
+
+3. user に以下の手順を案内する:
+   - Chrome で `chrome://extensions` を開く
+   - 右上の **デベロッパーモード** を ON にする
+   - **パッケージ化されていない拡張機能を読み込む**（Load unpacked）をクリック
+   - 展開したフォルダ（`~/chrome-extensions/<name>/`）を選択する
+
+4. 拡張アイコンが Chrome ツールバーに表示されたことを確認する。
+
+### Step 4: 更新
+
+1. 新しい zip をダウンロードする:
+
+```bash
+gh release download --repo daiki-beppu/youtube-automation <tag> --pattern '<name>-*.zip' --dir ~/Downloads
+```
+
+2. 既存フォルダを置き換える:
+
+```bash
+# suno-helper の場合
+cd ~/chrome-extensions/suno-helper && rm -rf * && unzip -o ~/Downloads/suno-helper-*.zip
+
+# distrokid-helper の場合
+cd ~/chrome-extensions/distrokid-helper && rm -rf * && unzip -o ~/Downloads/distrokid-helper-*.zip
+```
+
+3. user に以下を案内する:
+   - Chrome で `chrome://extensions` を開く
+   - 対象拡張の **リロード**（更新アイコン 🔄）をクリックする
+
+### Step 5: 動作確認
+
+インストールした拡張に応じた確認を案内する:
+
+- **suno-helper**: Suno (suno.com/create) を開き、拡張アイコンをクリックして popup が表示されることを確認
+- **distrokid-helper**: DistroKid のアップロードページを開き、拡張アイコンをクリックして popup が表示されることを確認
+
+## Notes
+
+- 展開先は `~/chrome-extensions/<name>/` を推奨するが、user が別の場所を希望すればそれに従う
+- `gh` CLI が未インストールの場合は、GitHub Release ページ (`https://github.com/daiki-beppu/youtube-automation/releases`) から手動ダウンロードを案内する
+- リポジトリがプライベートの場合、`gh auth login` で認証済みであることが前提

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **45 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **46 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -112,6 +112,7 @@ YouTube Analytics と動画本体の解析。
 |---|---|
 | /automation-release | 本リポジトリの新規リリースを作成（prepare → publish の 2 フェーズ） |
 | /automation-update | 下流チャンネルを upstream 最新版に追従（pin bump + `yt-skills sync` + 動作確認） |
+| /ext-install | Chrome 拡張（suno-helper / distrokid-helper）の初回インストールまたは更新ガイド |
 
 ---
 


### PR DESCRIPTION
## Summary

- Chrome 拡張（suno-helper / distrokid-helper）の初回インストールと更新をガイドする `ext-install` スキルを追加
- GitHub Release (`ext-v*`) から `gh release download` で zip 取得 → 展開 → Load unpacked の手順を案内
- 初回 / 更新の分岐、動作確認まで一貫サポート

## Test plan

- [ ] `/ext-install` でスキルが発動することを確認
- [ ] `yt-skills list` に `ext-install` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)