### PR TITLE
[#775] issue-775-cli-yt-generate-suno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration
 
+- `#775`: Python `yt-generate-suno` 相当の導線は TS dispatcher の `tayk generate-suno <collection-dir> [--json]` に移行する。per-CLI bin は追加せず、core registry entry `suno.generate` 経由で `suno-prompts.md` / `suno-prompts.json` を生成する。
 - `#698`: `yt-suno-serve` を実行しているスクリプト・運用手順は `yt-collection-serve` に置き換える。配信 URL は `http://localhost:<PORT>/prompts.json` → `http://localhost:<PORT>/suno/prompts.json` に変わる（suno-helper 拡張は本リリースで追従済み）
 
 ### Security

--- a/bun.lock
+++ b/bun.lock
@@ -20,8 +20,7 @@
       "name": "@youtube-automation/cli",
       "version": "0.1.0-alpha.0",
       "bin": {
-        "yt": "./bin/yt.ts",
-        "yt-skills": "./bin/yt-skills.ts",
+        "tayk": "./bin/tayk.ts",
       },
       "dependencies": {
         "@youtube-automation/core": "workspace:*",
@@ -36,6 +35,7 @@
         "google-auth-library": "10.5.0",
         "googleapis": "^173.0.0",
         "openai": "^6.41.0",
+        "yaml": "^2.9.0",
         "zod": "^4.1.13",
       },
     },

--- a/packages/cli/bin/tayk.ts
+++ b/packages/cli/bin/tayk.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 
+import { generateSunoCommand } from "../src/commands/generate-suno/cli.ts";
 import { skillsCommand } from "../src/commands/skills/cli.ts";
 
-// ADR-0004: yt は citty dispatcher。subcommand 実体は src/commands/ の adapter が
-// core registry (@youtube-automation/core/registry) を呼ぶ。
 const main = defineCommand({
   meta: {
     description: "youtube-channels-automation CLI (TS rewrite)",
-    name: "yt",
+    name: "tayk",
   },
-  subCommands: { skills: skillsCommand },
+  subCommands: { "generate-suno": generateSunoCommand, skills: skillsCommand },
 });
 
 await runMain(main);

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -7,7 +7,7 @@
 //
 // MCP 到着時は env token + refresh のみの別 adapter を作る（interactive flow を持たない）。
 
-import { loadConfig } from "@youtube-automation/core/config";
+import { channelDir, loadConfig } from "@youtube-automation/core/config";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
@@ -32,6 +32,10 @@ export const resolveDeps = async <D extends keyof DepsMap>(
 
   if (requested.has("config")) {
     resolved.config = loadConfig();
+  }
+
+  if (requested.has("channelDir")) {
+    resolved.channelDir = channelDir();
   }
 
   const needsYt = requested.has("yt");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,9 +2,9 @@
   "name": "@youtube-automation/cli",
   "version": "0.1.0-alpha.0",
   "private": true,
-  "description": "yt command line entry point for the youtube-channels-automation TS rewrite (ADR-0004 citty dispatcher).",
+  "description": "tayk command line entry point for the youtube-channels-automation TS rewrite (ADR-0004 citty dispatcher).",
   "bin": {
-    "yt": "./bin/yt.ts"
+    "tayk": "./bin/tayk.ts"
   },
   "files": [
     "bin",

--- a/packages/cli/src/commands/generate-suno/cli.ts
+++ b/packages/cli/src/commands/generate-suno/cli.ts
@@ -1,0 +1,55 @@
+import process from "node:process";
+
+import { err, toServiceError } from "@youtube-automation/core";
+import { REGISTRY } from "@youtube-automation/core/registry";
+import type { GenerateSunoOutput } from "@youtube-automation/core/suno-prompts";
+import { defineCommand } from "citty";
+
+import { resolveDeps } from "../../../lib/resolve-deps.ts";
+import { emitResult } from "../../../lib/run-command.ts";
+
+const generateSunoEntry = REGISTRY["suno.generate"];
+
+const renderText = (output: GenerateSunoOutput): string =>
+  [
+    `generated: ${output.entryCount}`,
+    `markdown: ${output.markdownPath}`,
+    `json: ${output.jsonPath}`,
+    ...output.warnings.map((warning) => `[WARN] ${warning}`),
+  ].join("\n");
+
+export const generateSunoCommand = defineCommand({
+  args: {
+    json: {
+      default: false,
+      description: "JSON で出力する",
+      type: "boolean",
+    },
+    path: {
+      description:
+        "collection directory または suno-patterns.yaml。省略時は CLI adapter が CWD に解決する",
+      required: false,
+      type: "positional",
+    },
+  },
+  meta: {
+    description: generateSunoEntry.description,
+    name: "generate-suno",
+  },
+  async run({ args }) {
+    const rawPath = typeof args.path === "string" ? args.path : undefined;
+    const json = args.json === true || rawPath === "--json";
+    const path =
+      rawPath === "--json" ? process.cwd() : (rawPath ?? process.cwd());
+    const result = await (async () => {
+      try {
+        const input = generateSunoEntry.inputSchema.parse({ path });
+        const deps = await resolveDeps(generateSunoEntry.deps);
+        return await generateSunoEntry.run(input, deps);
+      } catch (error) {
+        return err(toServiceError(error));
+      }
+    })();
+    emitResult(result, { json, renderText });
+  },
+});

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -104,9 +104,6 @@ const fakeClientSecretsJson = JSON.stringify({
 
 describe("resolveDeps — empty deps", () => {
   test("returns {} without loading config or authenticating", async () => {
-    // Given an environment where BOTH a config load and an auth dance would
-    // fail (a missing channel dir, no client secrets) — so any eager work would
-    // surface as a throw or an op spawn.
     process.env.CHANNEL_DIR = join(
       tmpdir(),
       "resolve-deps-nonexistent-xyz-993"
@@ -114,11 +111,8 @@ describe("resolveDeps — empty deps", () => {
     reset();
     const spawnSpy = spyOn(Bun, "spawn");
 
-    // When resolving an empty dep list
     const deps = await resolveDeps([]);
 
-    // Then nothing is built and no side effect runs (lazy): an empty result and
-    // op was never spawned, despite the deliberately broken environment.
     expect(deps).toEqual({});
     expect(spawnSpy).not.toHaveBeenCalled();
 
@@ -129,23 +123,39 @@ describe("resolveDeps — empty deps", () => {
 // --- config --------------------------------------------------------------
 
 describe("resolveDeps — config", () => {
-  // Repo root is three levels up from packages/cli/test/ (see yt-skills.test).
   const repoRoot = resolve(import.meta.dir, "..", "..", "..");
   const sampleChannel = join(repoRoot, "tests", "fixtures", "sample_channel");
 
   test("loads the channel config via loadConfig and returns it under `config`", async () => {
-    // Given the committed sample channel selected via CHANNEL_DIR
     process.env.CHANNEL_DIR = sampleChannel;
     reset();
 
-    // When resolving the config dependency
     const deps = await resolveDeps(["config"]);
 
-    // Then the loaded ChannelConfig is returned (cross-section value matches the
-    // fixture on disk), and only the requested key is present.
     expect(deps.config.identity.meta.channelName).toBe("Test Channel");
     expect("yt" in deps).toBe(false);
     expect("ytAnalytics" in deps).toBe(false);
+  });
+});
+
+// --- channelDir ----------------------------------------------------------
+
+describe("resolveDeps — channelDir", () => {
+  test("resolves the selected channel root without loading config or auth", async () => {
+    const dir = makeChannelDir();
+    process.env.CHANNEL_DIR = dir;
+    reset();
+    const spawnSpy = spyOn(Bun, "spawn");
+
+    const deps = await resolveDeps(["channelDir"]);
+
+    expect(deps.channelDir).toBe(dir);
+    expect("config" in deps).toBe(false);
+    expect("yt" in deps).toBe(false);
+    expect("ytAnalytics" in deps).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
   });
 });
 
@@ -153,7 +163,6 @@ describe("resolveDeps — config", () => {
 
 describe("resolveDeps — yt", () => {
   test("builds the Data API client from a still-valid stored token without op", async () => {
-    // Given env-supplied secrets and a non-expired token on disk
     const dir = makeChannelDir();
     process.env.CHANNEL_DIR = dir;
     process.env.CLIENT_SECRETS_JSON = fakeClientSecretsJson;
@@ -161,11 +170,8 @@ describe("resolveDeps — yt", () => {
     reset();
     const spawnSpy = spyOn(Bun, "spawn");
 
-    // When resolving only the yt dependency
     const deps = await resolveDeps(["yt"]);
 
-    // Then a youtube_v3 client (exposing `videos`) is built network-free, only
-    // the requested key is present, and op was never consulted.
     expect(typeof deps.yt.videos).toBe("object");
     expect("config" in deps).toBe(false);
     expect("ytAnalytics" in deps).toBe(false);
@@ -179,7 +185,6 @@ describe("resolveDeps — yt", () => {
 
 describe("resolveDeps — ytAnalytics", () => {
   test("builds the Analytics API client from a still-valid stored token without op", async () => {
-    // Given env-supplied secrets and a non-expired token on disk
     const dir = makeChannelDir();
     process.env.CHANNEL_DIR = dir;
     process.env.CLIENT_SECRETS_JSON = fakeClientSecretsJson;
@@ -187,11 +192,8 @@ describe("resolveDeps — ytAnalytics", () => {
     reset();
     const spawnSpy = spyOn(Bun, "spawn");
 
-    // When resolving only the ytAnalytics dependency
     const deps = await resolveDeps(["ytAnalytics"]);
 
-    // Then a youtubeAnalytics_v2 client (exposing `reports`) is built network-
-    // free, only the requested key is present, and op was never consulted.
     expect(typeof deps.ytAnalytics.reports).toBe("object");
     expect("yt" in deps).toBe(false);
     expect(spawnSpy).not.toHaveBeenCalled();
@@ -204,9 +206,6 @@ describe("resolveDeps — ytAnalytics", () => {
 
 describe("resolveDeps — yt + ytAnalytics share a single auth dance", () => {
   test("resolves the token once (op consulted a single time) and builds both clients", async () => {
-    // Given a non-expired token on disk and client_secrets reachable ONLY via op
-    // (no CLIENT_SECRETS_JSON env, no client_secrets.json file), so the secret
-    // resolution is a single countable Bun.spawn.
     const dir = makeChannelDir();
     process.env.CHANNEL_DIR = dir;
     seedValidToken(dir);
@@ -216,14 +215,10 @@ describe("resolveDeps — yt + ytAnalytics share a single auth dance", () => {
       fakeProc(fakeClientSecretsJson, 0)
     );
 
-    // When resolving both client dependencies together
     const deps = await resolveDeps(["yt", "ytAnalytics"]);
 
-    // Then both clients are built from the one resolved token ...
     expect(typeof deps.yt.videos).toBe("object");
     expect(typeof deps.ytAnalytics.reports).toBe("object");
-    // ... and the auth dance ran exactly once (op read called a single time),
-    // proving yt + ytAnalytics did not each resolve the token independently.
     expect(spawnSpy).toHaveBeenCalledTimes(1);
 
     whichSpy.mockRestore();

--- a/packages/cli/test/yt-generate-suno.test.ts
+++ b/packages/cli/test/yt-generate-suno.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
+const tmpDirs: string[] = [];
+
+const makeTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const realDir = realpathSync(dir);
+  tmpDirs.push(realDir);
+  return realDir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const runTayk = (
+  options: { cwd?: string; env: Record<string, string | undefined> },
+  ...argv: string[]
+) => {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(options.env)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(env, key);
+    } else {
+      env[key] = value;
+    }
+  }
+
+  return Bun.spawnSync(["bun", taykBin, ...argv], {
+    cwd: options.cwd ?? repoRoot,
+    env,
+  });
+};
+
+const writeFixture = (): { channelDir: string; collectionDir: string } => {
+  const channelDir = makeTempDir("cli-suno-channel-");
+  mkdirSync(join(channelDir, "config", "skills"), { recursive: true });
+  writeFileSync(
+    join(channelDir, "config", "skills", "suno.yaml"),
+    'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"\n',
+    "utf-8"
+  );
+
+  const collectionDir = join(channelDir, "collections", "planning", "test");
+  const docsDir = join(collectionDir, "20-documentation");
+  mkdirSync(docsDir, { recursive: true });
+  writeFileSync(
+    join(docsDir, "suno-patterns.yaml"),
+    [
+      'title: "CLI Smoke"',
+      "mode: instrumental",
+      "tracks: 2",
+      "patterns:",
+      '  - name_jp: "午後"',
+      '    name_en: "Afternoon"',
+      '    tempo: "slow"',
+      "    scenes:",
+      '      - "sunlight across a quiet desk"',
+    ].join("\n"),
+    "utf-8"
+  );
+
+  return { channelDir, collectionDir };
+};
+
+const writeWarningFixture = (): {
+  channelDir: string;
+  collectionDir: string;
+} => {
+  const channelDir = makeTempDir("cli-suno-warning-channel-");
+  mkdirSync(join(channelDir, "config", "skills"), { recursive: true });
+  writeFileSync(
+    join(channelDir, "config", "skills", "suno.yaml"),
+    [
+      'genre_line: "slow, ambient pad, soft synth, airy textures, subtle bass"',
+      "style_char_limit: 40",
+      "auto_lyrics_structure: false",
+    ].join("\n"),
+    "utf-8"
+  );
+
+  const collectionDir = join(channelDir, "collections", "planning", "warning");
+  const docsDir = join(collectionDir, "20-documentation");
+  mkdirSync(docsDir, { recursive: true });
+  writeFileSync(
+    join(docsDir, "suno-patterns.yaml"),
+    [
+      'title: "CLI Warning"',
+      "mode: instrumental",
+      "tracks: 2",
+      "patterns:",
+      '  - name_jp: "警告"',
+      '    name_en: "Warning"',
+      '    tempo: "slow"',
+      "    scenes:",
+      '      - "a very long descriptive scene with rain on glass and a quiet late night desk lamp"',
+    ].join("\n"),
+    "utf-8"
+  );
+
+  return { channelDir, collectionDir };
+};
+
+describe("core registry — suno.generate entry visible from cli package", () => {
+  test("should expose the registry entry consumed by the CLI adapter", () => {
+    const entry = REGISTRY["suno.generate"];
+
+    expect(entry.deps).toEqual(["channelDir"]);
+    expect(entry.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe("tayk generate-suno — smoke", () => {
+  test("should generate artifacts through the dispatcher and print JSON output", () => {
+    const { channelDir, collectionDir } = writeFixture();
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: channelDir } },
+      "generate-suno",
+      collectionDir,
+      "--json"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(proc.stdout.toString()) as {
+      entryCount: number;
+      jsonPath: string;
+      markdownPath: string;
+    };
+    expect(parsed.entryCount).toBe(1);
+    expect(parsed.markdownPath).toBe(
+      join(collectionDir, "20-documentation", "suno-prompts.md")
+    );
+    expect(parsed.jsonPath).toBe(
+      join(collectionDir, "20-documentation", "suno-prompts.json")
+    );
+    expect(existsSync(parsed.markdownPath)).toBe(true);
+    expect(existsSync(parsed.jsonPath)).toBe(true);
+    expect(readFileSync(parsed.jsonPath, "utf-8")).toContain(
+      "午後 — Afternoon"
+    );
+  });
+
+  test("should accept a collection path relative to CHANNEL_DIR", () => {
+    const { channelDir, collectionDir } = writeFixture();
+    const relativeCollectionDir = collectionDir.slice(channelDir.length + 1);
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: channelDir } },
+      "generate-suno",
+      relativeCollectionDir,
+      "--json"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(proc.stdout.toString()) as {
+      jsonPath: string;
+    };
+    expect(parsed.jsonPath).toBe(
+      join(collectionDir, "20-documentation", "suno-prompts.json")
+    );
+    expect(existsSync(parsed.jsonPath)).toBe(true);
+  });
+
+  test("should use CWD when collection path is omitted", () => {
+    const { channelDir, collectionDir } = writeFixture();
+
+    const proc = runTayk(
+      { cwd: collectionDir, env: { CHANNEL_DIR: channelDir } },
+      "generate-suno",
+      "--json"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(proc.stdout.toString()) as {
+      jsonPath: string;
+    };
+    expect(parsed.jsonPath).toBe(
+      join(collectionDir, "20-documentation", "suno-prompts.json")
+    );
+    expect(existsSync(parsed.jsonPath)).toBe(true);
+  });
+
+  test("should format dependency resolution errors through the command helper", () => {
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: undefined } },
+      "generate-suno",
+      "--json"
+    );
+
+    expect(proc.exitCode).toBe(1);
+    expect(proc.stderr.toString()).toStartWith("[config] ");
+    expect(proc.stderr.toString()).toContain("CHANNEL_DIR");
+    expect(proc.stderr.toString()).not.toContain("at ");
+  });
+
+  test("should list generate-suno in dispatcher help", () => {
+    const proc = runTayk({ env: {} }, "--help");
+
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("generate-suno");
+  });
+
+  test("should print quality warnings in normal text output", () => {
+    const { channelDir, collectionDir } = writeWarningFixture();
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: channelDir } },
+      "generate-suno",
+      collectionDir
+    );
+
+    expect(proc.exitCode).toBe(0);
+    const stdout = proc.stdout.toString();
+    expect(stdout).toContain("generated: 1");
+    expect(stdout).toContain("[WARN]");
+    expect(stdout).toContain("Style text exceeds 40 char limit");
+  });
+});

--- a/packages/cli/test/yt-skills-sync.test.ts
+++ b/packages/cli/test/yt-skills-sync.test.ts
@@ -9,27 +9,20 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-// Importing core by its package name + ADR-0004 registry subpath from the *cli*
-// package is the real cli→core `workspace:*` resolution under test. The
-// skills.sync entry lands in the registry as part of #742.
 import { REGISTRY } from "@youtube-automation/core/registry";
 
-// Repo root is three levels up from packages/cli/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
 
-// `bunx yt ...` 相当の e2e。citty dispatcher (bin/yt.ts) を実プロセスで起動する。
-// runYt は repoRoot を cwd にする (既存 yt-skills.test.ts と同じ)。runYtIn は
-// --asset all のデフォルト target (cwd 相対) を temp ディレクトリで検証するため、
-// 任意の cwd で起動する変種。
-const runYt = (...argv: string[]) =>
-  Bun.spawnSync(["bun", "packages/cli/bin/yt.ts", ...argv], { cwd: repoRoot });
+const runTayk = (...argv: string[]) =>
+  Bun.spawnSync(["bun", "packages/cli/bin/tayk.ts", ...argv], {
+    cwd: repoRoot,
+  });
 
-const runYtIn = (cwd: string, ...argv: string[]) =>
-  Bun.spawnSync(["bun", join(repoRoot, "packages/cli/bin/yt.ts"), ...argv], {
+const runTaykIn = (cwd: string, ...argv: string[]) =>
+  Bun.spawnSync(["bun", join(repoRoot, "packages/cli/bin/tayk.ts"), ...argv], {
     cwd,
   });
 
-// Per-test temp dirs, torn down after each case.
 const tmpDirs: string[] = [];
 const makeTmp = (prefix: string): string => {
   const dir = mkdtempSync(join(tmpdir(), prefix));
@@ -48,17 +41,13 @@ afterEach(() => {
 
 describe("core registry — skills.sync entry (ADR-0004 contract)", () => {
   test("declares no deps and a human-readable description", () => {
-    // Given the registry entry
     const entry = REGISTRY["skills.sync"];
 
-    // Then deps is the empty declaration and the description lives in core next
-    // to the schema (locality).
     expect(entry.deps).toEqual([]);
     expect(entry.description.length).toBeGreaterThan(0);
   });
 
   test("inputSchema parses an asset + target and run returns an ok Result", async () => {
-    // Given an input parsed through the entry's own schema (target → a temp dir)
     const tmp = makeTmp("cli-skills-sync-");
     const target = join(tmp, ".claude", "skills");
     const input = REGISTRY["skills.sync"].inputSchema.parse({
@@ -66,10 +55,8 @@ describe("core registry — skills.sync entry (ADR-0004 contract)", () => {
       target,
     });
 
-    // When the entry runs (deps-free, so {} is the full slice)
     const result = await REGISTRY["skills.sync"].run(input, {});
 
-    // Then it succeeds and the payload matches the outputSchema contract.
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.asset).toBe("skills");
@@ -79,14 +66,12 @@ describe("core registry — skills.sync entry (ADR-0004 contract)", () => {
   });
 });
 
-describe("yt skills sync --asset skills --target <dir>", () => {
+describe("tayk skills sync --asset skills --target <dir>", () => {
   test("exits 0, copies skills, and creates the .agents/skills symlink", () => {
-    // Given a standard-layout target under a temp dir
-    const tmp = makeTmp("yt-skills-sync-");
+    const tmp = makeTmp("tayk-skills-sync-");
     const target = join(tmp, ".claude", "skills");
 
-    // When `yt skills sync --asset skills --target <dir>` runs
-    const proc = runYt(
+    const proc = runTayk(
       "skills",
       "sync",
       "--asset",
@@ -95,8 +80,6 @@ describe("yt skills sync --asset skills --target <dir>", () => {
       target
     );
 
-    // Then it exits cleanly, the skills land in the target, and the Codex
-    // discovery mirror is a relative symlink to ../.claude/skills.
     expect(proc.exitCode).toBe(0);
     expect(existsSync(target)).toBe(true);
     const link = join(tmp, ".agents", "skills");
@@ -105,12 +88,10 @@ describe("yt skills sync --asset skills --target <dir>", () => {
   });
 
   test("--json prints a parseable SkillSyncOutput payload", () => {
-    // Given the same sync with --json
-    const tmp = makeTmp("yt-skills-sync-");
+    const tmp = makeTmp("tayk-skills-sync-");
     const target = join(tmp, ".claude", "skills");
 
-    // When run with --json
-    const proc = runYt(
+    const proc = runTayk(
       "skills",
       "sync",
       "--asset",
@@ -120,7 +101,6 @@ describe("yt skills sync --asset skills --target <dir>", () => {
       "--json"
     );
 
-    // Then stdout is the service output as JSON, with no cli reshaping.
     expect(proc.exitCode).toBe(0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       agentsSkillsLink: string | null;
@@ -134,14 +114,12 @@ describe("yt skills sync --asset skills --target <dir>", () => {
   });
 });
 
-describe("yt skills sync --asset claude-md --target <file>", () => {
+describe("tayk skills sync --asset claude-md --target <file>", () => {
   test("exits 0 and writes the CLAUDE.md file (AC#5)", () => {
-    // Given a target file path under a temp dir
-    const tmp = makeTmp("yt-claude-md-sync-");
+    const tmp = makeTmp("tayk-claude-md-sync-");
     const target = join(tmp, ".claude", "CLAUDE.md");
 
-    // When `yt skills sync --asset claude-md --target <file>` runs
-    const proc = runYt(
+    const proc = runTayk(
       "skills",
       "sync",
       "--asset",
@@ -150,41 +128,37 @@ describe("yt skills sync --asset claude-md --target <file>", () => {
       target
     );
 
-    // Then it exits cleanly and the template is written to the target path.
     expect(proc.exitCode).toBe(0);
     expect(existsSync(target)).toBe(true);
   });
 });
 
-describe("yt skills sync --asset all — guard against --target", () => {
+describe("tayk skills sync --asset all — guard against --target", () => {
   test("exits 2 with a stderr message and writes nothing", () => {
-    // Given `--asset all` combined with `--target` (ambiguous: per-asset default
-    // targets differ, so a single target would silently misplace an asset).
-    const tmp = makeTmp("yt-skills-sync-");
+    const tmp = makeTmp("tayk-skills-sync-");
     const target = join(tmp, "x");
 
-    // When run
-    const proc = runYt("skills", "sync", "--asset", "all", "--target", target);
+    const proc = runTayk(
+      "skills",
+      "sync",
+      "--asset",
+      "all",
+      "--target",
+      target
+    );
 
-    // Then it is a usage error (exit 2) with a non-empty stderr, and the target
-    // is never created (the guard fires before any write).
     expect(proc.exitCode).toBe(2);
     expect(proc.stderr.toString().length).toBeGreaterThan(0);
     expect(existsSync(target)).toBe(false);
   });
 });
 
-describe("yt skills sync — default asset 'all' resolves per-asset default targets", () => {
+describe("tayk skills sync — default asset 'all' resolves per-asset default targets", () => {
   test("bare `skills sync` syncs both skills and claude-md under the working dir", () => {
-    // Given a temp working dir (so the cwd-relative default targets are safe to
-    // write). `yt skills sync` with no flags defaults asset to 'all'.
-    const cwd = makeTmp("yt-skills-sync-all-");
+    const cwd = makeTmp("tayk-skills-sync-all-");
 
-    // When run from that working dir
-    const proc = runYtIn(cwd, "skills", "sync");
+    const proc = runTaykIn(cwd, "skills", "sync");
 
-    // Then both assets reach their per-asset defaults: skills → .claude/skills
-    // (+ the .agents/skills mirror) and claude-md → .claude/CLAUDE.md.
     expect(proc.exitCode).toBe(0);
     expect(existsSync(join(cwd, ".claude", "skills"))).toBe(true);
     expect(existsSync(join(cwd, ".claude", "CLAUDE.md"))).toBe(true);
@@ -194,11 +168,10 @@ describe("yt skills sync — default asset 'all' resolves per-asset default targ
   });
 });
 
-describe("yt skills sync — usage errors", () => {
+describe("tayk skills sync — usage errors", () => {
   test("an unknown --asset exits non-zero", () => {
-    // Given an asset value outside { all, skills, claude-md }
-    const tmp = makeTmp("yt-skills-sync-");
-    const proc = runYt(
+    const tmp = makeTmp("tayk-skills-sync-");
+    const proc = runTayk(
       "skills",
       "sync",
       "--asset",
@@ -207,7 +180,6 @@ describe("yt skills sync — usage errors", () => {
       join(tmp, "x")
     );
 
-    // Then the process fails (usage / validation error → non-zero exit).
     expect(proc.exitCode).not.toBe(0);
   });
 });

--- a/packages/cli/test/yt-skills.test.ts
+++ b/packages/cli/test/yt-skills.test.ts
@@ -3,17 +3,14 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-// Importing core by its package name + ADR-0004 registry subpath from the *cli*
-// package is the real cli→core `workspace:*` resolution under test. Broken
-// workspace or subpath wiring fails here instead of silently degrading.
 import { REGISTRY } from "@youtube-automation/core/registry";
 
-// Repo root is three levels up from packages/cli/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
 
-// `bunx yt ...` 相当の e2e。citty dispatcher (bin/yt.ts) を実プロセスで起動する。
-const runYt = (...argv: string[]) =>
-  Bun.spawnSync(["bun", "packages/cli/bin/yt.ts", ...argv], { cwd: repoRoot });
+const runTayk = (...argv: string[]) =>
+  Bun.spawnSync(["bun", "packages/cli/bin/tayk.ts", ...argv], {
+    cwd: repoRoot,
+  });
 
 // ADR-0003: registry entry の run は Result を返す。ok arm を unwrap して e2e の
 // 期待値 (service が見るのと同じ payload) を得る。
@@ -29,34 +26,26 @@ const listOk = async (input: { skillsDir?: string }) => {
 
 describe("core registry — skills.list entry (ADR-0004 contract)", () => {
   test("declares no deps and a human-readable description", () => {
-    // Given the registry entry
     const entry = REGISTRY["skills.list"];
 
-    // Then deps is the empty declaration (typed Pick<DepsMap, never>) and the
-    // description lives in core next to the schema (locality).
     expect(entry.deps).toEqual([]);
     expect(entry.description.length).toBeGreaterThan(0);
   });
 
   test("inputSchema accepts {} and run returns an ok Result", async () => {
-    // Given an empty input parsed through the entry's own schema
     const input = REGISTRY["skills.list"].inputSchema.parse({});
 
-    // When the entry runs
     const output = await listOk(input);
 
-    // Then the output matches the outputSchema contract.
     expect(Array.isArray(output.skills)).toBe(true);
     expect(typeof output.source).toBe("string");
   });
 });
 
-describe("yt skills list — text output (default)", () => {
-  test("exits 0 and prints the count header matching the Python `yt-skills list` format", () => {
-    // Given `yt skills list` with no format flag
-    const proc = runYt("skills", "list");
+describe("tayk skills list — text output (default)", () => {
+  test("exits 0 and prints the count header matching the skills list format", () => {
+    const proc = runTayk("skills", "list");
 
-    // Then it exits cleanly and the header matches `同梱スキル <N> 件 (source: <path>)`.
     expect(proc.exitCode).toBe(0);
     expect(proc.stdout.toString()).toMatch(
       /^同梱スキル \d+ 件 \(source: .+\)$/mu
@@ -64,11 +53,9 @@ describe("yt skills list — text output (default)", () => {
   });
 
   test("prints each skill as an indented bullet line", async () => {
-    // Given `yt skills list`
-    const proc = runYt("skills", "list");
+    const proc = runTayk("skills", "list");
     const output = proc.stdout.toString();
 
-    // Then every skill from the registry entry appears as a `  - <name>` line.
     const expected = await listOk({});
     expect(output).toMatch(/^ {2}- .+$/mu);
     for (const skill of expected.skills) {
@@ -77,12 +64,10 @@ describe("yt skills list — text output (default)", () => {
   });
 });
 
-describe("yt skills list --json", () => {
+describe("tayk skills list --json", () => {
   test("prints valid JSON carrying source and skills, with no cli reshaping", async () => {
-    // Given `yt skills list --json`
-    const proc = runYt("skills", "list", "--json");
+    const proc = runTayk("skills", "list", "--json");
 
-    // Then stdout is parseable JSON matching the registry entry's output.
     expect(proc.exitCode).toBe(0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       skills: string[];
@@ -94,7 +79,7 @@ describe("yt skills list --json", () => {
   });
 });
 
-describe("yt skills list --skills-dir — option propagates to the service", () => {
+describe("tayk skills list --skills-dir — option propagates to the service", () => {
   // The --skills-dir flag must travel citty arg → registry entry → readdir.
   // A fixture dir with out-of-order subdirectories proves the cli is reading
   // *this* dir (not the bundled default) end to end.
@@ -112,11 +97,14 @@ describe("yt skills list --skills-dir — option propagates to the service", () 
   });
 
   test("--json lists the directories under the supplied --skills-dir", () => {
-    // Given `yt skills list --skills-dir <fixture> --json`
-    const proc = runYt("skills", "list", "--skills-dir", fixtureDir, "--json");
+    const proc = runTayk(
+      "skills",
+      "list",
+      "--skills-dir",
+      fixtureDir,
+      "--json"
+    );
 
-    // Then stdout reports the fixture's subdirectories (sorted) and echoes the
-    // fixture as the source — the option reached the service unchanged.
     expect(proc.exitCode).toBe(0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       skills: string[];
@@ -127,44 +115,35 @@ describe("yt skills list --skills-dir — option propagates to the service", () 
   });
 
   test("text output header reports the supplied --skills-dir as source", () => {
-    // Given `yt skills list --skills-dir <fixture>` without --json
-    const proc = runYt("skills", "list", "--skills-dir", fixtureDir);
+    const proc = runTayk("skills", "list", "--skills-dir", fixtureDir);
 
-    // Then the header source is the fixture dir, not the bundled default.
     expect(proc.exitCode).toBe(0);
     expect(proc.stdout.toString()).toContain(`(source: ${fixtureDir})`);
   });
 });
 
-describe("yt skills list — error path (run-command helper)", () => {
+describe("tayk skills list — error path (run-command helper)", () => {
   test("missing --skills-dir exits 1 with an io-domain stderr prefix and empty stdout", () => {
-    // Given a `list` against a path that does not exist
     const missingDir = join(tmpdir(), "skills-bin-missing-xyz-842");
-    const proc = runYt("skills", "list", "--skills-dir", missingDir);
+    const proc = runTayk("skills", "list", "--skills-dir", missingDir);
 
-    // Then the ServiceError surfaces via lib/run-command.ts as exit 1
-    // (non-quota) with the `[domain] message` stderr line (ADR-0004 §4).
     expect(proc.exitCode).toBe(1);
     expect(proc.stderr.toString()).toContain("[io]");
     expect(proc.stdout.toString()).toBe("");
   });
 });
 
-describe("yt dispatcher — citty usage surface", () => {
-  test("`yt --help` exits 0 and lists the skills subcommand", () => {
-    // Given the dispatcher invoked with --help
-    const proc = runYt("--help");
+describe("tayk dispatcher — citty usage surface", () => {
+  test("`tayk --help` exits 0 and lists the skills subcommand", () => {
+    const proc = runTayk("--help");
 
-    // Then the sub-command tree is shown (AC: `bunx yt --help`).
     expect(proc.exitCode).toBe(0);
     expect(proc.stdout.toString()).toContain("skills");
   });
 
-  test("`yt skills <unknown>` exits non-zero", () => {
-    // Given an unsupported subcommand under skills
-    const proc = runYt("skills", "bogus");
+  test("`tayk skills <unknown>` exits non-zero", () => {
+    const proc = runTayk("skills", "bogus");
 
-    // Then the process fails (usage error propagates to a non-zero exit).
     expect(proc.exitCode).not.toBe(0);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./oauth/refresh": "./src/oauth/refresh.ts",
     "./paths": "./src/paths.ts",
     "./registry": "./src/registry.ts",
+    "./suno-prompts": "./src/suno-prompts/index.ts",
     "./skills-sync": "./src/skills-sync/index.ts"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "google-auth-library": "10.5.0",
     "googleapis": "^173.0.0",
     "openai": "^6.41.0",
+    "yaml": "^2.9.0",
     "zod": "^4.1.13"
   }
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -12,6 +12,11 @@ import {
   SkillSyncOutputSchema,
   syncAssetService,
 } from "./skills-sync/index.ts";
+import {
+  generateSunoPromptsService,
+  GenerateSunoInputSchema,
+  GenerateSunoOutputSchema,
+} from "./suno-prompts/index.ts";
 
 // ADR-0004: core feature registry。feature 名 → {description, schema, deps, run} の
 // data registry を core が所有し、packages/cli (citty defineCommand) と packages/mcp
@@ -19,7 +24,7 @@ import {
 // (依存方向 core ← cli / core ← mcp は不変、cli ⇄ mcp の相互 import は oxlint で禁止)。
 //
 // naming convention: registry キーは dotted ("skills.list")。
-//   - CLI adapter: subcommand 階層 (`yt skills list`)
+//   - CLI adapter: subcommand 階層 (`tayk skills list`)
 //   - MCP adapter: underscore (`skills_list`)
 
 // service が要求しうる重い依存の型対応表 (#993)。各 service は deps 配列で必要な key
@@ -29,6 +34,7 @@ import {
 //   - ytAnalytics: YouTube Analytics API v2 client (最小権限: analytics service は yt に触れない)
 // 個別 client を載せるのは最小権限の原則。token ではなく構築済み client を注入する。
 export interface DepsMap {
+  channelDir: string;
   config: ChannelConfig;
   yt: YouTubeClient;
   ytAnalytics: YouTubeAnalyticsClient;
@@ -74,6 +80,13 @@ export const REGISTRY = {
     inputSchema: SkillSyncInputSchema,
     outputSchema: SkillSyncOutputSchema,
     run: syncAssetService,
+  }),
+  "suno.generate": defineRegistryEntry({
+    deps: ["channelDir"],
+    description: "Suno UI 投入用 Style / Lyrics prompt を生成する",
+    inputSchema: GenerateSunoInputSchema,
+    outputSchema: GenerateSunoOutputSchema,
+    run: generateSunoPromptsService,
   }),
 } as const;
 

--- a/packages/core/src/suno-prompts/builder.ts
+++ b/packages/core/src/suno-prompts/builder.ts
@@ -1,0 +1,229 @@
+import type { SunoPattern, SunoPatternsFile } from "./parser.ts";
+import { SunoPromptEntriesSchema } from "./schema.ts";
+import type { SunoPromptEntry } from "./schema.ts";
+import type {
+  BuildEntriesResult,
+  ResolvedSunoConfig,
+  SunoConfig,
+} from "./types.ts";
+
+const INSTRUMENTAL_LYRICS = "[Instrumental]\n\n[Extended Outro]";
+const INSTRUMENTAL_TAG_PATTERN = /\[Instrumental\]/iu;
+const EXTENDED_OUTRO_TAG_PATTERN = /\[Extended Outro\]/iu;
+const OUTRO_END_PATTERN = /\[(Extended )?Outro\]\s*$/iu;
+const STYLE_SEPARATOR = ",\n";
+const TITLE_SEPARATOR = " — ";
+const TEMPO_WORDS = [
+  "very slow",
+  "slow",
+  "gentle",
+  "moderate",
+  "lively",
+  "fast",
+  "uptempo",
+  "downtempo",
+] as const;
+const VOCAL_KEYWORDS = ["vocals", "vocal", "singing", "rap", "sings", "sung"];
+
+const buildEntryName = (pattern: SunoPattern, sceneIndex: number): string => {
+  const base = `${pattern.nameJp}${TITLE_SEPARATOR}${pattern.nameEn}`;
+  return pattern.scenes.length > 1
+    ? `${base} (Variation ${sceneIndex + 1})`
+    : base;
+};
+
+const withAdvancedFields = (
+  entry: SunoPromptEntry,
+  advancedJsonFields: Partial<SunoPromptEntry>
+): SunoPromptEntry => ({
+  ...entry,
+  ...advancedJsonFields,
+});
+
+const applyAutoLyricsStructure = (lyrics: string, isVocal: boolean): string => {
+  if (lyrics === "") {
+    return isVocal ? lyrics : INSTRUMENTAL_LYRICS;
+  }
+
+  let structured = lyrics.trim();
+  if (!isVocal) {
+    if (!INSTRUMENTAL_TAG_PATTERN.test(structured)) {
+      structured = `[Instrumental]\n\n${structured}`;
+    }
+    if (!EXTENDED_OUTRO_TAG_PATTERN.test(structured)) {
+      structured = `${structured}\n\n[Extended Outro]`;
+    }
+    return structured;
+  }
+
+  if (!OUTRO_END_PATTERN.test(structured)) {
+    structured = `${structured}\n\n[Extended Outro]`;
+  }
+  return structured;
+};
+
+const resolveLyrics = (
+  patternLyrics: string,
+  config: SunoConfig,
+  isVocal: boolean
+): string => {
+  const rawLyrics = isVocal ? patternLyrics : "";
+  return config.autoLyricsStructure
+    ? applyAutoLyricsStructure(rawLyrics, isVocal)
+    : rawLyrics;
+};
+
+const buildEntry = (
+  pattern: SunoPattern,
+  scene: string,
+  sceneIndex: number,
+  config: SunoConfig,
+  advancedJsonFields: Partial<SunoPromptEntry>,
+  mode: "instrumental" | "vocal"
+): SunoPromptEntry => {
+  const variant =
+    pattern.style === undefined
+      ? undefined
+      : config.styleVariants.get(pattern.style);
+  const genreLine = variant?.genreLine ?? config.genreLine;
+  const style = `${pattern.tempo}, ${genreLine}${STYLE_SEPARATOR}${scene}`;
+  const isVocal = mode === "vocal";
+  const lyrics = resolveLyrics(pattern.lyrics, config, isVocal);
+  const entry: SunoPromptEntry = {
+    lyrics,
+    name: buildEntryName(pattern, sceneIndex),
+    style,
+  };
+  return withAdvancedFields(entry, advancedJsonFields);
+};
+
+const validateTrackCount = (tracks: number, entryCount: number): void => {
+  if (Math.ceil(tracks / 2) !== entryCount) {
+    throw new Error(
+      `config: tracks_per_collection と生成エントリ数が一致しません: tracks=${tracks}, entries=${entryCount}`
+    );
+  }
+};
+
+const resolveInstrumentalTracks = (
+  patternsFile: SunoPatternsFile,
+  config: SunoConfig
+): number => {
+  const tracks = patternsFile.tracks ?? config.tracksPerCollection;
+  if (tracks === undefined) {
+    throw new Error(
+      "config: instrumental mode requires tracks or tracks_per_collection"
+    );
+  }
+  return tracks;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+
+const validateBannedArtists = (
+  entries: readonly SunoPromptEntry[],
+  bannedArtists: readonly string[]
+): void => {
+  for (const artist of bannedArtists) {
+    const pattern = new RegExp(`\\b${escapeRegExp(artist)}\\b`, "iu");
+    if (entries.some((entry) => pattern.test(entry.style))) {
+      throw new Error(
+        `config: banned artist is included in style text: ${artist}`
+      );
+    }
+  }
+};
+
+const validateUniqueEntryNames = (
+  entries: readonly SunoPromptEntry[]
+): void => {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.name)) {
+      duplicates.add(entry.name);
+    }
+    seen.add(entry.name);
+  }
+  if (duplicates.size > 0) {
+    throw new Error(
+      `config: entry names must be unique: ${[...duplicates].toSorted().join(", ")}`
+    );
+  }
+};
+
+const validateStyleCharLimit = (
+  style: string,
+  limit: number
+): readonly string[] =>
+  style.length > limit
+    ? [
+        `Style text exceeds ${limit} char limit (${style.length} chars): ${style.slice(0, 80)}...`,
+      ]
+    : [];
+
+const validateFiveElementOrder = (genreLine: string): readonly string[] => {
+  const lowerGenreLine = genreLine.toLowerCase();
+  const threshold = Math.max(Math.floor(lowerGenreLine.length / 3), 10);
+  const tempoWord = TEMPO_WORDS.find((word) => {
+    const index = lowerGenreLine.indexOf(word);
+    return index !== -1 && index < threshold;
+  });
+  return tempoWord === undefined
+    ? []
+    : [
+        `Tempo word '${tempoWord}' appears early in Style text (position ${lowerGenreLine.indexOf(
+          tempoWord
+        )}). 5-element order: genre -> acoustics -> key instrument -> rhythm/bass -> tempo`,
+      ];
+};
+
+const buildQualityWarnings = (
+  entries: readonly SunoPromptEntry[],
+  config: SunoConfig
+): string[] => [
+  ...validateFiveElementOrder(config.genreLine),
+  ...entries.flatMap((entry) =>
+    validateStyleCharLimit(entry.style, config.styleCharLimit)
+  ),
+];
+
+const resolveMode = (
+  patternsFile: SunoPatternsFile,
+  config: SunoConfig
+): "instrumental" | "vocal" => {
+  if (patternsFile.mode !== undefined) {
+    return patternsFile.mode;
+  }
+  const lowerGenreLine = config.genreLine.toLowerCase();
+  return VOCAL_KEYWORDS.some((keyword) => lowerGenreLine.includes(keyword))
+    ? "vocal"
+    : "instrumental";
+};
+
+export const buildEntries = (
+  patternsFile: SunoPatternsFile,
+  resolvedConfig: ResolvedSunoConfig
+): BuildEntriesResult => {
+  const { advancedJsonFields, config } = resolvedConfig;
+  const mode = resolveMode(patternsFile, config);
+  const entries = patternsFile.patterns.flatMap((pattern) =>
+    pattern.scenes.map((scene, index) =>
+      buildEntry(pattern, scene, index, config, advancedJsonFields, mode)
+    )
+  );
+  if (mode === "instrumental") {
+    validateTrackCount(
+      resolveInstrumentalTracks(patternsFile, config),
+      entries.length
+    );
+  }
+  validateBannedArtists(entries, config.bannedArtists);
+  validateUniqueEntryNames(entries);
+  return {
+    entries: SunoPromptEntriesSchema.parse(entries),
+    mode,
+    warnings: buildQualityWarnings(entries, config),
+  };
+};

--- a/packages/core/src/suno-prompts/config.ts
+++ b/packages/core/src/suno-prompts/config.ts
@@ -1,0 +1,263 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parseTopLevelYaml } from "./parser.ts";
+import { SUNO_CONFIG_FILENAME } from "./schema.ts";
+import type { SunoPromptEntry } from "./schema.ts";
+import type {
+  ResolvedSunoConfig,
+  SunoConfig,
+  SunoStyleVariant,
+} from "./types.ts";
+import { collectVideoAnalysisPresets } from "./video-analysis.ts";
+
+const CONFIG_DIR = "config";
+const SKILLS_DIR = "skills";
+const ADVANCED_JSON_KEYS = [
+  "exclude_styles",
+  "style_influence",
+  "vocal_gender",
+  "weirdness",
+] as const;
+
+const DEFAULT_SUNO_CONFIG: Record<string, unknown> = {
+  auto_lyrics_structure: true,
+  banned_artists: [
+    "Drake",
+    "Taylor Swift",
+    "The Weeknd",
+    "Beyonce",
+    "Kanye West",
+    "Eminem",
+    "Rihanna",
+    "Ed Sheeran",
+    "Ariana Grande",
+    "Justin Bieber",
+    "Billie Eilish",
+    "Post Malone",
+    "Dua Lipa",
+    "Bad Bunny",
+    "Travis Scott",
+    "BTS",
+    "Adele",
+    "Bruno Mars",
+    "Lady Gaga",
+    "Coldplay",
+    "Imagine Dragons",
+    "The Beatles",
+    "Pink Floyd",
+    "Led Zeppelin",
+    "Radiohead",
+    "Daft Punk",
+    "Aphex Twin",
+    "Boards of Canada",
+    "Nujabes",
+    "J Dilla",
+  ],
+  exclude_styles:
+    "heavy metal, aggressive, EDM, dubstep, techno, industrial, white noise, orchestral, rain sounds, vinyl crackle, ambient noise",
+  genre_line: "",
+  style_char_limit: 120,
+  style_influence: 95,
+  tracks_per_collection: 20,
+  weirdness: 10,
+};
+
+const stringValue = (data: Record<string, unknown>, key: string): string => {
+  const value = data[key];
+  if (value === undefined) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(`config: ${key} は文字列でなければなりません`);
+  }
+  return value;
+};
+
+const optionalNumber = (
+  data: Record<string, unknown>,
+  key: string
+): number | undefined => {
+  const value = data[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number") {
+    throw new TypeError(`config: ${key} は数値でなければなりません`);
+  }
+  return value;
+};
+
+const optionalBoolean = (
+  data: Record<string, unknown>,
+  key: string
+): boolean | undefined => {
+  const value = data[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new TypeError(`config: ${key} は真偽値でなければなりません`);
+  }
+  return value;
+};
+
+const optionalStringArray = (
+  data: Record<string, unknown>,
+  key: string
+): readonly string[] | undefined => {
+  const value = data[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    throw new TypeError(`config: ${key} は文字列配列でなければなりません`);
+  }
+  return value;
+};
+
+const deepMergeRecords = (
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> =>
+  Object.fromEntries(
+    [...new Set([...Object.keys(base), ...Object.keys(override)])].map(
+      (key) => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+        if (overrideValue === undefined) {
+          return [key, baseValue];
+        }
+        if (
+          typeof baseValue === "object" &&
+          baseValue !== null &&
+          !Array.isArray(baseValue) &&
+          typeof overrideValue === "object" &&
+          overrideValue !== null &&
+          !Array.isArray(overrideValue)
+        ) {
+          return [
+            key,
+            deepMergeRecords(
+              baseValue as Record<string, unknown>,
+              overrideValue as Record<string, unknown>
+            ),
+          ];
+        }
+        return [key, overrideValue];
+      }
+    )
+  );
+
+const readOptionalYamlRecord = async (
+  path: string
+): Promise<Record<string, unknown>> => {
+  if (!existsSync(path)) {
+    return {};
+  }
+  return parseTopLevelYaml(await readFile(path, "utf-8"));
+};
+
+const parseStyleVariants = (
+  data: Record<string, unknown>
+): ReadonlyMap<string, SunoStyleVariant> => {
+  const raw = data.style_variants;
+  if (raw === undefined) {
+    return new Map();
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new TypeError(
+      "config: style_variants は mapping でなければなりません"
+    );
+  }
+  return new Map(
+    Object.entries(raw as Record<string, unknown>).map(([key, value]) => {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new TypeError(
+          `config: style_variants.${key} は mapping でなければなりません`
+        );
+      }
+      const variant = value as Record<string, unknown>;
+      return [
+        key,
+        {
+          genreLine: stringValue(variant, "genre_line"),
+          name: stringValue(variant, "name"),
+        },
+      ];
+    })
+  );
+};
+
+const buildAdvancedJsonFields = (
+  override: Record<string, unknown>
+): Partial<SunoPromptEntry> =>
+  Object.fromEntries(
+    ADVANCED_JSON_KEYS.flatMap((key) => {
+      if (!(key in override)) {
+        return [];
+      }
+      const value = override[key];
+      if (key === "vocal_gender" && value === "") {
+        return [];
+      }
+      if (
+        (key === "exclude_styles" || key === "vocal_gender") &&
+        typeof value !== "string"
+      ) {
+        throw new TypeError(`config: ${key} は文字列でなければなりません`);
+      }
+      if (
+        (key === "style_influence" || key === "weirdness") &&
+        typeof value !== "number"
+      ) {
+        throw new TypeError(`config: ${key} は数値でなければなりません`);
+      }
+      return [[key, value]];
+    })
+  ) as Partial<SunoPromptEntry>;
+
+const buildSunoConfig = (
+  merged: Record<string, unknown>,
+  fallback: { excludeStyles: string; genreLine: string }
+): SunoConfig => {
+  const genreLine = stringValue(merged, "genre_line") || fallback.genreLine;
+  const moodDescriptors = stringValue(merged, "mood_descriptors");
+  const baseGenreLine =
+    moodDescriptors.length > 0 ? `${genreLine}, ${moodDescriptors}` : genreLine;
+  const excludeStyles =
+    stringValue(merged, "exclude_styles") || fallback.excludeStyles;
+  return {
+    autoLyricsStructure:
+      optionalBoolean(merged, "auto_lyrics_structure") ?? false,
+    bannedArtists: optionalStringArray(merged, "banned_artists") ?? [],
+    ...(excludeStyles.length > 0 ? { excludeStyles } : {}),
+    genreLine: baseGenreLine,
+    styleCharLimit: optionalNumber(merged, "style_char_limit") ?? 120,
+    styleInfluence: optionalNumber(merged, "style_influence") ?? 50,
+    styleVariants: parseStyleVariants(merged),
+    tracksPerCollection: optionalNumber(merged, "tracks_per_collection"),
+    vocalGender:
+      typeof merged.vocal_gender === "string" ? merged.vocal_gender : undefined,
+    weirdness: optionalNumber(merged, "weirdness") ?? 10,
+  };
+};
+
+export const readSunoConfig = async (
+  channelDir: string
+): Promise<ResolvedSunoConfig> => {
+  const path = join(channelDir, CONFIG_DIR, SKILLS_DIR, SUNO_CONFIG_FILENAME);
+  const [override, fallback] = await Promise.all([
+    readOptionalYamlRecord(path),
+    collectVideoAnalysisPresets(channelDir),
+  ]);
+  const merged = deepMergeRecords(DEFAULT_SUNO_CONFIG, override);
+  return {
+    advancedJsonFields: buildAdvancedJsonFields(override),
+    config: buildSunoConfig(merged, fallback),
+  };
+};

--- a/packages/core/src/suno-prompts/index.ts
+++ b/packages/core/src/suno-prompts/index.ts
@@ -1,0 +1,3 @@
+export { GenerateSunoInputSchema, GenerateSunoOutputSchema } from "./schema.ts";
+export type { GenerateSunoInput, GenerateSunoOutput } from "./schema.ts";
+export { generateSunoPromptsService } from "./service.ts";

--- a/packages/core/src/suno-prompts/parser.ts
+++ b/packages/core/src/suno-prompts/parser.ts
@@ -1,0 +1,64 @@
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+
+import { snakeToCamel } from "../../internal/case.ts";
+
+export interface SunoPattern {
+  readonly lyrics: string;
+  readonly nameEn: string;
+  readonly nameJp: string;
+  readonly scenes: readonly string[];
+  readonly style?: string;
+  readonly tempo: string;
+}
+
+export interface SunoPatternsFile {
+  readonly mode?: "instrumental" | "vocal";
+  readonly patterns: readonly SunoPattern[];
+  readonly title: string;
+  readonly tracks?: number;
+}
+
+const YamlMappingSchema = z.record(z.string(), z.unknown());
+
+const RawSunoPatternSchema = z
+  .object({
+    lyrics: z.string().optional(),
+    name_en: z.string(),
+    name_jp: z.string(),
+    scenes: z.array(z.string()).nonempty(),
+    style: z.string().optional(),
+    tempo: z.string(),
+  })
+  .strict()
+  .transform(
+    (input): SunoPattern => ({
+      ...snakeToCamel(input),
+      lyrics: input.lyrics?.trimEnd() ?? "",
+    })
+  );
+
+const RawSunoPatternsFileSchema = z
+  .object({
+    mode: z.enum(["instrumental", "vocal"]).optional(),
+    patterns: z.array(RawSunoPatternSchema).nonempty(),
+    title: z.string().optional(),
+    tracks: z.number().int().positive().optional(),
+  })
+  .strict()
+  .transform(
+    (input): SunoPatternsFile => ({
+      ...(input.mode === undefined ? {} : { mode: input.mode }),
+      patterns: input.patterns,
+      title: input.title ?? "Suno Prompts",
+      ...(input.tracks === undefined ? {} : { tracks: input.tracks }),
+    })
+  );
+
+export const parseTopLevelYaml = (text: string): Record<string, unknown> => {
+  const parsed = parseYaml(text) as unknown;
+  return YamlMappingSchema.parse(parsed);
+};
+
+export const parsePatternsYaml = (text: string): SunoPatternsFile =>
+  RawSunoPatternsFileSchema.parse(parseYaml(text) as unknown);

--- a/packages/core/src/suno-prompts/paths.ts
+++ b/packages/core/src/suno-prompts/paths.ts
@@ -1,0 +1,63 @@
+import { existsSync } from "node:fs";
+import { realpath } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { SUNO_DOCS_DIR, SUNO_PATTERNS_FILENAME } from "./schema.ts";
+
+const COLLECTIONS_DIR = "collections";
+const PLANNING_DIR = "planning";
+
+const absoluteInputPath = (channelDir: string, inputPath: string): string =>
+  isAbsolute(inputPath) ? inputPath : resolve(channelDir, inputPath);
+
+const resolvePatternsPath = (channelDir: string, inputPath: string): string => {
+  const absolutePath = absoluteInputPath(channelDir, inputPath);
+  const direct = absolutePath.endsWith(SUNO_PATTERNS_FILENAME);
+  if (direct) {
+    return absolutePath;
+  }
+  return join(absolutePath, SUNO_DOCS_DIR, SUNO_PATTERNS_FILENAME);
+};
+
+const collectionDirFromPatternsPath = (patternsPath: string): string => {
+  if (!patternsPath.endsWith(join(SUNO_DOCS_DIR, SUNO_PATTERNS_FILENAME))) {
+    throw new Error(
+      `config: patterns path must end with ${SUNO_PATTERNS_FILENAME}`
+    );
+  }
+  return patternsPath.slice(
+    0,
+    -join(SUNO_DOCS_DIR, SUNO_PATTERNS_FILENAME).length - 1
+  );
+};
+
+const validateCollectionLocation = (
+  channelDir: string,
+  collectionDir: string
+): void => {
+  const planningRoot = join(channelDir, COLLECTIONS_DIR, PLANNING_DIR);
+  if (!collectionDir.startsWith(`${planningRoot}/`)) {
+    throw new Error(
+      `config: collection path must be under ${join(COLLECTIONS_DIR, PLANNING_DIR)}`
+    );
+  }
+};
+
+export interface ResolvedSunoPaths {
+  readonly collectionDir: string;
+  readonly patternsPath: string;
+}
+
+export const resolveSunoPaths = async (
+  channelDir: string,
+  inputPath: string
+): Promise<ResolvedSunoPaths> => {
+  const patternsPath = resolvePatternsPath(channelDir, inputPath);
+  if (!existsSync(patternsPath)) {
+    throw new Error(`config: suno patterns file not found: ${patternsPath}`);
+  }
+  const canonicalPatternsPath = await realpath(patternsPath);
+  const collectionDir = collectionDirFromPatternsPath(canonicalPatternsPath);
+  validateCollectionLocation(channelDir, collectionDir);
+  return { collectionDir, patternsPath };
+};

--- a/packages/core/src/suno-prompts/renderer.ts
+++ b/packages/core/src/suno-prompts/renderer.ts
@@ -1,0 +1,41 @@
+import type { BuildEntriesResult, SunoConfig } from "./types.ts";
+
+export const renderMarkdown = (
+  title: string,
+  result: BuildEntriesResult,
+  config: SunoConfig
+): string => {
+  const sections = result.entries.map((entry) =>
+    [
+      `## ${entry.name}`,
+      "",
+      "**Styles:**",
+      "```",
+      entry.style,
+      "```",
+      ...(config.excludeStyles === undefined
+        ? []
+        : ["", "**Exclude Styles:**", "```", config.excludeStyles, "```"]),
+      ...(result.mode === "vocal" && entry.lyrics.length > 0
+        ? ["", "**Lyrics:**", "```", entry.lyrics, "```"]
+        : []),
+    ].join("\n")
+  );
+  return [
+    `# Suno Prompts — ${title}`,
+    "",
+    "## SunoAI 推奨設定",
+    "",
+    "| パラメータ | 値 |",
+    "|-----------|-----|",
+    "| Mode | Custom |",
+    `| Weirdness | ${config.weirdness}% |`,
+    `| Style Influence | ${config.styleInfluence}% |`,
+    `| Instrumental | ${result.mode === "vocal" ? "OFF（ボーカルモード）" : "ON（インストモード）"} |`,
+    `| Lyrics | ${result.mode === "vocal" ? "各パターンの Lyrics 欄を投入" : "(空)"} |`,
+    "",
+    "---",
+    "",
+    ...sections,
+  ].join("\n");
+};

--- a/packages/core/src/suno-prompts/schema.ts
+++ b/packages/core/src/suno-prompts/schema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+import { snakeToCamel } from "../../internal/case.ts";
+
+export const SUNO_DOCS_DIR = "20-documentation";
+export const SUNO_PATTERNS_FILENAME = "suno-patterns.yaml";
+export const SUNO_CONFIG_FILENAME = "suno.yaml";
+export const SUNO_PROMPTS_MD_FILENAME = "suno-prompts.md";
+export const SUNO_PROMPTS_JSON_FILENAME = "suno-prompts.json";
+
+const GenerateSunoSnakeInputSchema = z
+  .object({
+    path: z.string(),
+  })
+  .strict();
+
+const GenerateSunoCamelInputSchema = z
+  .object({
+    path: z.string(),
+  })
+  .strict();
+
+export const GenerateSunoInputSchema = z
+  .union([GenerateSunoSnakeInputSchema, GenerateSunoCamelInputSchema])
+  .transform((input): { path: string } => snakeToCamel(input));
+
+const SunoPromptEntrySchema = z
+  .object({
+    exclude_styles: z.string().optional(),
+    lyrics: z.string(),
+    name: z.string(),
+    style: z.string(),
+    style_influence: z.number().optional(),
+    vocal_gender: z.string().optional(),
+    weirdness: z.number().optional(),
+  })
+  .strict();
+
+export const GenerateSunoOutputSchema = z
+  .object({
+    entryCount: z.number().int().nonnegative(),
+    jsonPath: z.string(),
+    markdownPath: z.string(),
+    warnings: z.array(z.string()),
+  })
+  .strict();
+
+export type GenerateSunoInput = z.infer<typeof GenerateSunoInputSchema>;
+export type GenerateSunoOutput = z.infer<typeof GenerateSunoOutputSchema>;
+export type SunoPromptEntry = z.infer<typeof SunoPromptEntrySchema>;
+
+export const SunoPromptEntriesSchema = z.array(SunoPromptEntrySchema);

--- a/packages/core/src/suno-prompts/service.ts
+++ b/packages/core/src/suno-prompts/service.ts
@@ -1,0 +1,48 @@
+import { readFile, realpath } from "node:fs/promises";
+
+import { toServiceError } from "../errors.ts";
+import type { ServiceError } from "../errors.ts";
+import { err, ok } from "../result.ts";
+import type { Result } from "../result.ts";
+import { buildEntries } from "./builder.ts";
+import { readSunoConfig } from "./config.ts";
+import { parsePatternsYaml } from "./parser.ts";
+import { resolveSunoPaths } from "./paths.ts";
+import { renderMarkdown } from "./renderer.ts";
+import { GenerateSunoInputSchema, GenerateSunoOutputSchema } from "./schema.ts";
+import type { GenerateSunoInput, GenerateSunoOutput } from "./schema.ts";
+import { writeSunoPromptFiles } from "./writer.ts";
+
+export const generateSunoPromptsService = async (
+  input: GenerateSunoInput,
+  deps: { channelDir: string }
+): Promise<Result<GenerateSunoOutput, ServiceError>> => {
+  try {
+    const request = GenerateSunoInputSchema.parse(input);
+    const channelDir = await realpath(deps.channelDir);
+    const paths = await resolveSunoPaths(channelDir, request.path);
+    const [patternsText, config] = await Promise.all([
+      readFile(paths.patternsPath, "utf-8"),
+      readSunoConfig(channelDir),
+    ]);
+    const patternsFile = parsePatternsYaml(patternsText);
+    const result = buildEntries(patternsFile, config);
+    const markdown = renderMarkdown(patternsFile.title, result, config.config);
+    const files = await writeSunoPromptFiles(
+      paths.collectionDir,
+      markdown,
+      result.entries
+    );
+
+    return ok(
+      GenerateSunoOutputSchema.parse({
+        entryCount: result.entries.length,
+        jsonPath: files.jsonPath,
+        markdownPath: files.markdownPath,
+        warnings: result.warnings,
+      })
+    );
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/src/suno-prompts/types.ts
+++ b/packages/core/src/suno-prompts/types.ts
@@ -1,0 +1,30 @@
+import type { SunoPromptEntry } from "./schema.ts";
+
+export interface SunoConfig {
+  readonly autoLyricsStructure: boolean;
+  readonly bannedArtists: readonly string[];
+  readonly excludeStyles?: string;
+  readonly genreLine: string;
+  readonly styleCharLimit: number;
+  readonly styleInfluence: number;
+  readonly styleVariants: ReadonlyMap<string, SunoStyleVariant>;
+  readonly tracksPerCollection?: number;
+  readonly vocalGender?: string;
+  readonly weirdness: number;
+}
+
+export interface SunoStyleVariant {
+  readonly genreLine: string;
+  readonly name: string;
+}
+
+export interface ResolvedSunoConfig {
+  readonly advancedJsonFields: Partial<SunoPromptEntry>;
+  readonly config: SunoConfig;
+}
+
+export interface BuildEntriesResult {
+  readonly entries: SunoPromptEntry[];
+  readonly mode: "instrumental" | "vocal";
+  readonly warnings: string[];
+}

--- a/packages/core/src/suno-prompts/video-analysis.ts
+++ b/packages/core/src/suno-prompts/video-analysis.ts
@@ -1,0 +1,78 @@
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const DATA_DIR = "data";
+const TOP_GENRE_PHRASES = 8;
+const VIDEO_ANALYSIS_DIR = "video_analysis";
+
+const splitCsv = (value: string): string[] =>
+  value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+const isNodeReadError = (error: unknown): boolean =>
+  error instanceof Error && "code" in error;
+
+const readVideoAnalysisJson = async (path: string): Promise<unknown> => {
+  try {
+    return JSON.parse(await readFile(path, "utf-8")) as unknown;
+  } catch (error) {
+    if (error instanceof SyntaxError || isNodeReadError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+export const collectVideoAnalysisPresets = async (
+  channelDir: string
+): Promise<{ excludeStyles: string; genreLine: string }> => {
+  const base = join(channelDir, DATA_DIR, VIDEO_ANALYSIS_DIR);
+  if (!existsSync(base)) {
+    return { excludeStyles: "", genreLine: "" };
+  }
+
+  const excludeStyles = new Map<string, null>();
+  const genreCounts = new Map<string, number>();
+  const slugDirs = await readdir(base, { withFileTypes: true });
+  for (const slugDir of slugDirs.filter((item) => item.isDirectory())) {
+    const dir = join(base, slugDir.name);
+    const files = await readdir(dir, { withFileTypes: true });
+    for (const file of files.filter(
+      (item) => item.isFile() && item.name.endsWith(".json")
+    )) {
+      const data = await readVideoAnalysisJson(join(dir, file.name));
+      if (typeof data !== "object" || data === null || Array.isArray(data)) {
+        continue;
+      }
+      const preset = (data as Record<string, unknown>).suno_preset;
+      if (
+        typeof preset !== "object" ||
+        preset === null ||
+        Array.isArray(preset)
+      ) {
+        continue;
+      }
+      const record = preset as Record<string, unknown>;
+      for (const phrase of splitCsv(
+        typeof record.genre_line === "string" ? record.genre_line : ""
+      )) {
+        genreCounts.set(phrase, (genreCounts.get(phrase) ?? 0) + 1);
+      }
+      for (const phrase of splitCsv(
+        typeof record.exclude_styles === "string" ? record.exclude_styles : ""
+      )) {
+        excludeStyles.set(phrase, null);
+      }
+    }
+  }
+
+  const genreLine = [...genreCounts.entries()]
+    .toSorted((a, b) => b[1] - a[1])
+    .slice(0, TOP_GENRE_PHRASES)
+    .map(([phrase]) => phrase)
+    .join(", ");
+  return { excludeStyles: [...excludeStyles.keys()].join(", "), genreLine };
+};

--- a/packages/core/src/suno-prompts/writer.ts
+++ b/packages/core/src/suno-prompts/writer.ts
@@ -1,0 +1,28 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  SUNO_DOCS_DIR,
+  SUNO_PROMPTS_JSON_FILENAME,
+  SUNO_PROMPTS_MD_FILENAME,
+} from "./schema.ts";
+import type { SunoPromptEntry } from "./schema.ts";
+
+export interface WrittenSunoPromptFiles {
+  readonly jsonPath: string;
+  readonly markdownPath: string;
+}
+
+export const writeSunoPromptFiles = async (
+  collectionDir: string,
+  markdown: string,
+  entries: readonly SunoPromptEntry[]
+): Promise<WrittenSunoPromptFiles> => {
+  const docsDir = join(collectionDir, SUNO_DOCS_DIR);
+  await mkdir(docsDir, { recursive: true });
+  const jsonPath = join(docsDir, SUNO_PROMPTS_JSON_FILENAME);
+  const markdownPath = join(docsDir, SUNO_PROMPTS_MD_FILENAME);
+  await writeFile(markdownPath, markdown, "utf-8");
+  await writeFile(jsonPath, `${JSON.stringify(entries, null, 2)}\n`, "utf-8");
+  return { jsonPath, markdownPath };
+};

--- a/packages/core/test/registry-deps.test.ts
+++ b/packages/core/test/registry-deps.test.ts
@@ -1,14 +1,3 @@
-// Tests for the DepsMap contract (ADR-0004 / #993). DepsMap goes from
-// `Record<never, never>` to the real { config, yt, ytAnalytics } map so a
-// registry entry can declare the heavy dependencies it needs and receive them —
-// typed — as run()'s second argument, without loading config or touching the
-// network. These pin two things:
-//   1. the type shape: a full DepsMap literal compiles only with the three keys
-//      mapped to ChannelConfig / YouTubeClient / YouTubeAnalyticsClient (enforced
-//      by tsc; a regression to Record<never, never> fails the typecheck step).
-//   2. the run pass-through: a fake entry with deps ['config', 'yt'] runs with
-//      those fakes injected directly — the AC `entry.run(input, { config, yt })`.
-
 import { describe, expect, test } from "bun:test";
 
 import { ok } from "@youtube-automation/core";
@@ -20,28 +9,23 @@ import type {
 import type { DepsMap, RegistryEntry } from "@youtube-automation/core/registry";
 import { z } from "zod";
 
-// Minimal hand-built stand-ins cast to their DepsMap types. The contract under
-// test is the type wiring + run pass-through, not the internals of a real config
-// or googleapis client, so fakes are injected directly (the AC: no reset() /
-// loadConfig() needed for a service test).
 const fakeConfig = {
   identity: { meta: { channelName: "Fake Channel" } },
 } as unknown as ChannelConfig;
 const fakeYt = { videos: {} } as unknown as YouTubeClient;
 const fakeYtAnalytics = { reports: {} } as unknown as YouTubeAnalyticsClient;
+const fakeChannelDir = "/tmp/fake-channel";
 
 describe("DepsMap — type shape", () => {
-  test("maps config / yt / ytAnalytics to their config + googleapis types", () => {
-    // Given a full DepsMap literal — this only type-checks once DepsMap carries
-    // exactly these three keys (a regression to Record<never, never> would make
-    // every property an excess-property type error at the typecheck step).
+  test("maps config / channelDir / yt / ytAnalytics to their declared types", () => {
     const deps: DepsMap = {
+      channelDir: fakeChannelDir,
       config: fakeConfig,
       yt: fakeYt,
       ytAnalytics: fakeYtAnalytics,
     };
 
-    // Then each key is reachable with its declared type at runtime.
+    expect(deps.channelDir).toBe(fakeChannelDir);
     expect(deps.config.identity.meta.channelName).toBe("Fake Channel");
     expect(typeof deps.yt.videos).toBe("object");
     expect(typeof deps.ytAnalytics.reports).toBe("object");
@@ -52,28 +36,26 @@ describe("RegistryEntry — declared deps reach run, typed", () => {
   const InputSchema = z.object({ value: z.string() }).strict();
   const OutputSchema = z
     .object({
+      channelDir: z.string(),
       channelName: z.string(),
       echoed: z.string(),
       hasVideos: z.boolean(),
     })
     .strict();
 
-  // A throwaway entry that declares deps: ['config', 'yt']. Its run reads
-  // deps.config (ChannelConfig) and deps.yt (YouTubeClient); both accesses only
-  // type-check because DepsMap now maps those keys to real types, and run's deps
-  // arg is the Pick<DepsMap, 'config' | 'yt'> slice (ytAnalytics is absent).
   const fakeEntry: RegistryEntry<
     typeof InputSchema,
     typeof OutputSchema,
-    "config" | "yt"
+    "channelDir" | "config" | "yt"
   > = {
-    deps: ["config", "yt"],
+    deps: ["config", "channelDir", "yt"],
     description: "fake entry exercising the DepsMap contract",
     inputSchema: InputSchema,
     outputSchema: OutputSchema,
     run: (input, deps) =>
       Promise.resolve(
         ok({
+          channelDir: deps.channelDir,
           channelName: deps.config.identity.meta.channelName,
           echoed: input.value,
           hasVideos: typeof deps.yt.videos === "object",
@@ -81,19 +63,18 @@ describe("RegistryEntry — declared deps reach run, typed", () => {
       ),
   };
 
-  test("run executes with { config, yt } injected and uses both deps", async () => {
-    // Given an input parsed through the entry's own schema
+  test("run executes with { channelDir, config, yt } injected and uses each dep", async () => {
     const input = fakeEntry.inputSchema.parse({ value: "hello" });
 
-    // When run is called with the declared deps injected directly
     const result = await fakeEntry.run(input, {
+      channelDir: fakeChannelDir,
       config: fakeConfig,
       yt: fakeYt,
     });
 
-    // Then it returns an ok Result derived from the injected deps + input.
     expect(result.ok).toBe(true);
     if (result.ok) {
+      expect(result.value.channelDir).toBe(fakeChannelDir);
       expect(result.value.channelName).toBe("Fake Channel");
       expect(result.value.hasVideos).toBe(true);
       expect(result.value.echoed).toBe("hello");
@@ -101,10 +82,7 @@ describe("RegistryEntry — declared deps reach run, typed", () => {
   });
 
   test("declares exactly its required deps (no ytAnalytics)", () => {
-    // Given the entry's deps declaration
-    // Then only the keys it consumes are listed — the compile-time mirror is
-    // run's deps arg being Pick<DepsMap, 'config' | 'yt'>, free of ytAnalytics.
-    expect(fakeEntry.deps).toEqual(["config", "yt"]);
+    expect(fakeEntry.deps).toEqual(["config", "channelDir", "yt"]);
     expect(fakeEntry.deps).not.toContain("ytAnalytics");
   });
 });

--- a/packages/core/test/suno-prompts.test.ts
+++ b/packages/core/test/suno-prompts.test.ts
@@ -1,0 +1,926 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { REGISTRY } from "@youtube-automation/core/registry";
+import * as sunoPromptsPublicApi from "@youtube-automation/core/suno-prompts";
+import {
+  generateSunoPromptsService,
+  GenerateSunoInputSchema,
+} from "@youtube-automation/core/suno-prompts";
+import type {
+  GenerateSunoInput,
+  GenerateSunoOutput,
+} from "@youtube-automation/core/suno-prompts";
+
+const tmpDirs: string[] = [];
+
+const makeTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const realDir = realpathSync(dir);
+  tmpDirs.push(realDir);
+  return realDir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const writeSunoOverride = (channelDir: string, yaml: string): void => {
+  const configDir = join(channelDir, "config", "skills");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "suno.yaml"), yaml, "utf-8");
+};
+
+const writeVideoAnalysisPreset = (
+  channelDir: string,
+  preset: Record<string, string>
+): void => {
+  const dir = join(channelDir, "data", "video_analysis", "benchmark-a");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "sample.json"),
+    JSON.stringify({ suno_preset: preset }),
+    "utf-8"
+  );
+};
+
+const writeMalformedVideoAnalysis = (channelDir: string): void => {
+  const dir = join(channelDir, "data", "video_analysis", "benchmark-b");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "broken.json"), "{not-json", "utf-8");
+};
+
+const makeCollection = (channelDir: string, patternsYaml: string): string => {
+  const collectionDir = join(channelDir, "collections", "planning", "test");
+  const docsDir = join(collectionDir, "20-documentation");
+  mkdirSync(docsDir, { recursive: true });
+  writeFileSync(join(docsDir, "suno-patterns.yaml"), patternsYaml, "utf-8");
+  return collectionDir;
+};
+
+const generateOk = async (
+  input: GenerateSunoInput,
+  channelDir: string
+): Promise<GenerateSunoOutput> => {
+  const result = await generateSunoPromptsService(input, {
+    channelDir,
+  });
+  if (!result.ok) {
+    throw new Error(
+      `expected an ok Result, got error: ${JSON.stringify(result.error)}`
+    );
+  }
+  return result.value;
+};
+
+const readGeneratedEntries = (collectionDir: string): unknown[] => {
+  const jsonPath = join(collectionDir, "20-documentation", "suno-prompts.json");
+  return JSON.parse(readFileSync(jsonPath, "utf-8")) as unknown[];
+};
+
+describe("suno-prompts public API — exports map", () => {
+  test("should expose only service boundary runtime symbols", () => {
+    expect(Object.keys(sunoPromptsPublicApi).toSorted()).toEqual([
+      "GenerateSunoInputSchema",
+      "GenerateSunoOutputSchema",
+      "generateSunoPromptsService",
+    ]);
+  });
+});
+
+describe("suno.generate registry deps — contract", () => {
+  test("should require only channelDir from adapters", () => {
+    expect(REGISTRY["suno.generate"].deps).toEqual(["channelDir"]);
+  });
+});
+
+describe("GenerateSunoInputSchema — contract", () => {
+  test("should accept only the collection path as public input", () => {
+    const raw = {
+      path: "/tmp/channel/collections/planning/test",
+    };
+
+    const parsed = GenerateSunoInputSchema.parse(raw);
+
+    expect(parsed).toEqual({
+      path: "/tmp/channel/collections/planning/test",
+    });
+  });
+
+  test("should reject an omitted path because adapters resolve CWD", () => {
+    expect(() => GenerateSunoInputSchema.parse({})).toThrow();
+  });
+
+  test("should reject channel_dir because channelDir is a registry dependency", () => {
+    expect(() =>
+      GenerateSunoInputSchema.parse({
+        channel_dir: "/tmp/channel",
+        path: "/tmp/channel/collections/planning/test",
+      })
+    ).toThrow();
+    expect(() =>
+      GenerateSunoInputSchema.parse({
+        channelDir: "/tmp/channel",
+        path: "/tmp/channel/collections/planning/test",
+      })
+    ).toThrow();
+  });
+
+  test("should reject unknown keys", () => {
+    const raw = { path: "/tmp/patterns.yaml", unexpected: true };
+
+    expect(() => GenerateSunoInputSchema.parse(raw)).toThrow();
+  });
+});
+
+describe("generateSunoPromptsService — file generation", () => {
+  test("should generate markdown and json from a collection directory", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Morning Collection"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "朝霧"',
+        '    name_en: "Morning Haze"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "mist over a quiet river"',
+      ].join("\n")
+    );
+
+    const output = await generateOk({ path: collectionDir }, channelDir);
+
+    const markdownPath = join(
+      collectionDir,
+      "20-documentation",
+      "suno-prompts.md"
+    );
+    const jsonPath = join(
+      collectionDir,
+      "20-documentation",
+      "suno-prompts.json"
+    );
+    expect(output).toMatchObject({
+      entryCount: 1,
+      jsonPath,
+      markdownPath,
+      warnings: [],
+    });
+    expect(existsSync(markdownPath)).toBe(true);
+    expect(existsSync(jsonPath)).toBe(true);
+    expect(readFileSync(markdownPath, "utf-8")).toContain(
+      "# Suno Prompts — Morning Collection"
+    );
+    const markdown = readFileSync(markdownPath, "utf-8");
+    expect(markdown).toContain("## SunoAI 推奨設定");
+    expect(markdown).toContain("Style Influence");
+    expect(markdown).toContain("| Instrumental | ON（インストモード） |");
+    expect(markdown).toContain("**Exclude Styles:**");
+    expect(markdown).toContain("**Styles:**\n```");
+    expect(readGeneratedEntries(collectionDir)).toEqual([
+      {
+        lyrics: "",
+        name: "朝霧 — Morning Haze",
+        style:
+          "slow, lo-fi jazz, soft piano, warm rhodes, mellow drums, slow,\nmist over a quiet river",
+      },
+    ]);
+  });
+
+  test("should parse single-quoted YAML scalars without preserving quote marks", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        "genre_line: 'lo-fi jazz, soft piano, warm rhodes, mellow drums, slow'",
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        "title: 'Single Quote Collection'",
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        "  - name_jp: '朝霧'",
+        "    name_en: 'Morning Haze'",
+        "    tempo: 'slow'",
+        "    scenes:",
+        "      - 'mist over a quiet river'",
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    expect(readGeneratedEntries(collectionDir)).toEqual([
+      {
+        lyrics: "",
+        name: "朝霧 — Morning Haze",
+        style:
+          "slow, lo-fi jazz, soft piano, warm rhodes, mellow drums, slow,\nmist over a quiet river",
+      },
+    ]);
+  });
+
+  test("should suffix variation names when one pattern has multiple scenes", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      'genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow"\n'
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Two Variations"',
+        "mode: instrumental",
+        "tracks: 4",
+        "patterns:",
+        '  - name_jp: "灯り"',
+        '    name_en: "Lantern"',
+        '    tempo: "gentle"',
+        "    scenes:",
+        '      - "paper lanterns in the rain"',
+        '      - "last train lights through glass"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const entries = readGeneratedEntries(collectionDir) as {
+      name: string;
+    }[];
+    expect(entries.map((entry) => entry.name)).toEqual([
+      "灯り — Lantern (Variation 1)",
+      "灯り — Lantern (Variation 2)",
+    ]);
+  });
+
+  test("should use tracks_per_collection when instrumental YAML omits tracks", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow"',
+        "tracks_per_collection: 4",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Config Tracks"',
+        "mode: instrumental",
+        "patterns:",
+        '  - name_jp: "灯り"',
+        '    name_en: "Lantern"',
+        '    tempo: "gentle"',
+        "    scenes:",
+        '      - "paper lanterns in the rain"',
+        '      - "last train lights through glass"',
+      ].join("\n")
+    );
+
+    const output = await generateOk({ path: collectionDir }, channelDir);
+
+    expect(output.entryCount).toBe(2);
+  });
+
+  test("should preserve vocal lyrics from pattern YAML", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "jazzhop vocal, warm piano, brushed drums, slow"',
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Vocal Lyrics"',
+        "mode: vocal",
+        "patterns:",
+        '  - name_jp: "雨音"',
+        '    name_en: "Rain Notes"',
+        '    tempo: "slow"',
+        "    lyrics: |",
+        "      ame no oto dake",
+        "      mada koko ni aru",
+        "    scenes:",
+        '      - "rain at a window"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toBe("ame no oto dake\nmada koko ni aru");
+  });
+
+  test("should include only channel override advanced fields in generated json", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "style_influence: 0",
+        "weirdness: 0",
+        'exclude_styles: ""',
+        'vocal_gender: ""',
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Advanced Fields"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "静寂"',
+        '    name_en: "Stillness"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "a desk lamp after midnight"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as Record<
+      string,
+      unknown
+    >[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.style_influence).toBe(0);
+    expect(entry.weirdness).toBe(0);
+    expect(entry.exclude_styles).toBe("");
+    expect("vocal_gender" in entry).toBe(false);
+  });
+
+  test("should merge default config when channel override is absent", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeVideoAnalysisPreset(channelDir, {
+      exclude_styles: "noise, harsh synth",
+      genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow",
+    });
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Default Merge"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "余白"',
+        '    name_en: "Open Space"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "blank pages beside coffee"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as Record<
+      string,
+      unknown
+    >[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.style).toBe(
+      "slow, ambient pad, soft synth, airy textures, subtle bass, slow,\nblank pages beside coffee"
+    );
+    expect(entry.lyrics).toContain("[Instrumental]");
+    expect("style_influence" in entry).toBe(false);
+    expect("exclude_styles" in entry).toBe(false);
+  });
+
+  test("should use style variant genre_line when pattern declares style", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow"',
+        "auto_lyrics_structure: false",
+        "style_variants:",
+        "  piano:",
+        '    name: "solo piano"',
+        '    genre_line: "solo piano, felt keys, intimate room, soft pedal, slow"',
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Variant"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "鍵盤"',
+        '    name_en: "Felt Keys"',
+        '    tempo: "slow"',
+        '    style: "piano"',
+        "    scenes:",
+        '      - "a quiet piano beside the window"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      style: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.style).toBe(
+      "slow, solo piano, felt keys, intimate room, soft pedal, slow,\na quiet piano beside the window"
+    );
+  });
+
+  test("should use core-owned default tracks_per_collection when patterns omit tracks", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow"',
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const patterns = Array.from({ length: 10 }, (_, index) =>
+      [
+        `  - name_jp: "情景${index + 1}"`,
+        `    name_en: "Scene ${index + 1}"`,
+        '    tempo: "slow"',
+        "    scenes:",
+        `      - "quiet scene ${index + 1}"`,
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Core Defaults"',
+        "mode: instrumental",
+        "patterns:",
+        ...patterns,
+      ].join("\n")
+    );
+
+    const result = await generateSunoPromptsService(
+      { path: collectionDir },
+      { channelDir }
+    );
+
+    expect(result.ok).toBe(true);
+    const entries = readGeneratedEntries(collectionDir);
+    expect(entries).toHaveLength(10);
+  });
+
+  test("should infer instrumental mode from genre_line when mode is omitted", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      'genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow"\n'
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Implicit Instrumental"',
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "静けさ"',
+        '    name_en: "Still Air"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "a quiet room at dawn"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toContain("[Instrumental]");
+  });
+
+  test("should infer vocal mode from genre_line when mode is omitted", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      'genre_line: "jazzhop vocal, warm piano, brushed drums, slow"\n'
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Implicit Vocal"',
+        "patterns:",
+        '  - name_jp: "雨音"',
+        '    name_en: "Rain Notes"',
+        '    tempo: "slow"',
+        "    lyrics: |",
+        "      [Verse]",
+        "      ame no oto dake",
+        "    scenes:",
+        '      - "rain at a window"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toBe("[Verse]\name no oto dake\n\n[Extended Outro]");
+  });
+
+  test("should auto-fill instrumental lyrics when auto_lyrics_structure is enabled", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "auto_lyrics_structure: true",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Auto Lyrics"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "余白"',
+        '    name_en: "Open Space"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "blank pages beside coffee"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toContain("[Instrumental]");
+    expect(entry.lyrics).toContain("[Extended Outro]");
+  });
+
+  test("should ignore instrumental pattern lyrics before adding structure tags", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "auto_lyrics_structure: true",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Instrument Notes"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "余白"',
+        '    name_en: "Open Space"',
+        '    tempo: "slow"',
+        "    lyrics: |",
+        "      Mixing Notes: warm tape saturation",
+        "      Instrument Notes: felt piano lead",
+        "    scenes:",
+        '      - "blank pages beside coffee"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toBe("[Instrumental]\n\n[Extended Outro]");
+  });
+
+  test("should ignore instrumental pattern lyrics when auto lyrics are disabled", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Instrument Notes Disabled"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "余白"',
+        '    name_en: "Open Space"',
+        '    tempo: "slow"',
+        "    lyrics: |",
+        "      Mixing Notes: warm tape saturation",
+        "      Instrument Notes: felt piano lead",
+        "    scenes:",
+        '      - "blank pages beside coffee"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toBe("");
+  });
+
+  test("should append extended outro to vocal lyrics when auto_lyrics_structure is enabled", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "jazzhop vocal, warm piano, brushed drums, slow"',
+        "auto_lyrics_structure: true",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Vocal Auto Lyrics"',
+        "mode: vocal",
+        "patterns:",
+        '  - name_jp: "雨音"',
+        '    name_en: "Rain Notes"',
+        '    tempo: "slow"',
+        "    lyrics: |",
+        "      [Verse]",
+        "      ame no oto dake",
+        "    scenes:",
+        '      - "rain at a window"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      lyrics: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.lyrics).toBe("[Verse]\name no oto dake\n\n[Extended Outro]");
+  });
+
+  test("should return quality warnings for long styles and early tempo words", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "slow, ambient pad, soft synth, airy textures, subtle bass"',
+        "style_char_limit: 40",
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Quality Warning"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "警告"',
+        '    name_en: "Warning"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "a very long descriptive scene with rain on glass and a quiet late night desk lamp"',
+      ].join("\n")
+    );
+
+    const output = await generateOk({ path: collectionDir }, channelDir);
+
+    expect(output.warnings).toHaveLength(2);
+    expect(output.warnings[0]).toContain("5-element order");
+    expect(output.warnings[1]).toContain("Style text exceeds 40 char limit");
+  });
+
+  test("should skip malformed video analysis json while collecting fallback presets", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeVideoAnalysisPreset(channelDir, {
+      exclude_styles: "noise, harsh synth",
+      genre_line: "ambient pad, soft synth, airy textures, subtle bass, slow",
+    });
+    writeMalformedVideoAnalysis(channelDir);
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Malformed Analysis"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "解析"',
+        '    name_en: "Analysis"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "a desk with notes from benchmark analysis"',
+      ].join("\n")
+    );
+
+    await generateOk({ path: collectionDir }, channelDir);
+
+    const [entry] = readGeneratedEntries(collectionDir) as {
+      style: string;
+    }[];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("expected one generated entry");
+    }
+    expect(entry.style).toContain(
+      "ambient pad, soft synth, airy textures, subtle bass, slow"
+    );
+  });
+});
+
+describe("generateSunoPromptsService — error contract", () => {
+  test("should return a config error when tracks_per_collection mismatches entries", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"\n'
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Mismatch"',
+        "mode: instrumental",
+        "tracks: 4",
+        "patterns:",
+        '  - name_jp: "朝"',
+        '    name_en: "Morning"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "one scene only"',
+      ].join("\n")
+    );
+
+    const result = await generateSunoPromptsService(
+      { path: collectionDir },
+      { channelDir }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("tracks_per_collection");
+    }
+  });
+
+  test("should return a config error when style text contains a banned artist", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz like Drake"',
+        "banned_artists:",
+        "  - Drake",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Banned Artist"',
+        "mode: instrumental",
+        "tracks: 2",
+        "patterns:",
+        '  - name_jp: "夜"',
+        '    name_en: "Night"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "quiet neon street"',
+      ].join("\n")
+    );
+
+    const result = await generateSunoPromptsService(
+      { path: collectionDir },
+      { channelDir }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("Drake");
+    }
+  });
+
+  test("should return a config error when final entry names are duplicated", async () => {
+    const channelDir = makeTempDir("suno-channel-");
+    writeSunoOverride(
+      channelDir,
+      [
+        'genre_line: "lo-fi jazz, soft piano, warm rhodes, mellow drums, slow"',
+        "auto_lyrics_structure: false",
+      ].join("\n")
+    );
+    const collectionDir = makeCollection(
+      channelDir,
+      [
+        'title: "Duplicate Names"',
+        "mode: instrumental",
+        "tracks: 4",
+        "patterns:",
+        '  - name_jp: "雨"',
+        '    name_en: "Rain"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "first rain scene"',
+        '  - name_jp: "雨"',
+        '    name_en: "Rain"',
+        '    tempo: "slow"',
+        "    scenes:",
+        '      - "second rain scene"',
+      ].join("\n")
+    );
+
+    const result = await generateSunoPromptsService(
+      { path: collectionDir },
+      { channelDir }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("雨 — Rain");
+    }
+  });
+});
+
+describe("core registry — suno.generate entry", () => {
+  test("should declare channelDir dependency and run through the registry", () => {
+    const entry = REGISTRY["suno.generate"];
+
+    expect(entry.deps).toEqual(["channelDir"]);
+    expect(entry.description.length).toBeGreaterThan(0);
+    expect(() =>
+      entry.inputSchema.parse({ path: "/tmp/collection" })
+    ).not.toThrow();
+    expect(() => entry.inputSchema.parse({})).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

> **🔧 2026-06-14 ADR 整合 banner（実装前に必読）**: 本 issue は ADR 制定前の旧 framing。**ADR-0002/0003/0004/0007 準拠**で実装すること —
> - ロジックは **core service**（`packages/core/src/<feature>/{schema,service}.ts`、zod schema、`Result<T, ServiceError>` + `toServiceError`）。trivial でも core 側へ寄せる
> - **registry entry**（`packages/core/src/registry.ts`）に登録（未登録 service は CLI/MCP から不可視）
> - CLI は **thin adapter** = 単一 `tayk` dispatcher の subcommand（`tayk <cmd>`）。**per-CLI bin（`packages/cli/bin/yt-xxx`）は廃止**
> - Python は翻訳でなく **TS で新規記述**（ADR-0003）。`googleapis`/`sharp` 等の重い依存は core service 内のみ
> - 本文の旧 path（`src` なし）・旧 bin・旧 blocked-by は**無効**。最新の依存は epic #727 の Phase 構造を参照

## Parent
#727

## What to build
Python `yt-generate-suno` CLI を TS に移植する。パターン YAML から Suno UI 投入用 Style + Lyrics prompt を生成する CLI (実楽曲生成は Suno UI 人手)。

## Acceptance criteria (ADR-0002/0003/0004/0007 準拠)

- [ ] core service を `packages/core/src/<feature>/{schema,service}.ts` に実装 — zod schema (snake_case 入力→`.transform(snakeToCamel)`)、export 境界で `Result<T, ServiceError>` を返し `toServiceError` を通す
- [ ] `packages/core/src/registry.ts` に registry entry を登録 (dotted key、`deps` 宣言)
- [ ] CLI は thin adapter: 単一 `tayk` dispatcher の subcommand (`packages/cli/src/commands/<feature>/cli.ts`、citty `defineCommand`、出力/exit code は `run-command.ts` helper 経由)。**per-CLI bin は作らない**
- [ ] Python を翻訳せず TS で新規記述。重い依存 (`googleapis` / `sharp` / `@google/genai` / ffmpeg subprocess 等) は core service 内のみで import
- [ ] bun:test: schema parse + 主要ロジックの unit test green、CLI smoke 1 件以上
- [ ] CHANGELOG [Unreleased] に migration エントリ追加

## Blocked by

- 最新の依存関係は epic #727 の Phase 構造を参照 (旧 #73x の blocked-by は無効)

## Execution Report

Workflow `default` completed successfully.

Closes #775