### PR TITLE
[#832] issue-832-ts-rewrite-phase2-an

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(ts-rewrite/core)`: Traffic source 内訳（search / browse / external / suggested 等）を期間集計する `collectTrafficSourceService` を ADR-0003 準拠で実装した（#832）。`packages/core/src/analytics/traffic-source/`（schema / service / index）を新設し、Python `utils/traffic_source_analytics.py` Mixin を翻訳せず TS で新規記述。あわせて analytics 共通のエラー分類を `analytics/query-error.ts`（`toAnalyticsQueryError` / `shouldRetryAnalyticsQuery`）へ集約し、video / channel / video-daily / traffic-source の各 service から参照する。quota（429）は `withRetry` で retry せず `domain: "quota"` の Result で返す
 - `feat(ts-rewrite/core)`: resumable upload + thumbnail 圧縮 + metadata update を 1 atomic service に集約した `uploadVideoService` を ADR-0003 準拠で実装した（#837）
 - `feat(ts-rewrite/core)`: Per-video metrics（views / likes / comments / shares 等 8 指標）を YouTube Analytics API から収集する analytics video service を ADR-0003 準拠で実装した（#829）
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./analytics/channel": "./src/analytics/channel/index.ts",
+    "./analytics/traffic-source": "./src/analytics/traffic-source/index.ts",
     "./analytics/video": "./src/analytics/video/index.ts",
     "./analytics/video-daily": "./src/analytics/video-daily/index.ts",
     "./config": "./src/config/index.ts",

--- a/packages/core/src/analytics/channel/service.ts
+++ b/packages/core/src/analytics/channel/service.ts
@@ -17,16 +17,15 @@
 
 import type { youtubeAnalytics_v2 } from "googleapis";
 
-import { isRecord } from "../../../internal/guards.ts";
-import {
-  QuotaExhaustedError,
-  toServiceError,
-  YouTubeAPIError,
-} from "../../errors.ts";
+import { toServiceError } from "../../errors.ts";
 import type { ServiceError } from "../../errors.ts";
 import { err, ok } from "../../result.ts";
 import type { Result } from "../../result.ts";
-import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import { withRetry } from "../../retry.ts";
+import {
+  shouldRetryAnalyticsQuery,
+  toAnalyticsQueryError,
+} from "../query-error.ts";
 import {
   CHANNEL_METRICS,
   ChannelAnalyticsInput,
@@ -38,64 +37,11 @@ const QUERY_CONTEXT = "channel analytics query";
 const DAY_DIMENSION = "day";
 const CHANNEL_ID_PREFIX = "channel==";
 const VIDEO_FILTER_PREFIX = "video==";
-const HTTP_SERVER_ERROR_MIN = 500;
 
 type ChannelMetricRecord = ChannelAnalyticsOutput["metrics"][number];
 type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
 type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
 type ColumnHeaders = NonNullable<QueryResponse["columnHeaders"]>;
-
-// gaxios エラーの `response.headers["retry-after"]` を秒数として取り出す。header 不在
-// （quota が日次リセットで Retry-After を返さないケース）では undefined（contract 通り）。
-const parseRetryAfterSeconds = (error: unknown): number | undefined => {
-  if (
-    !(
-      isRecord(error) &&
-      isRecord(error.response) &&
-      isRecord(error.response.headers)
-    )
-  ) {
-    return undefined;
-  }
-  const seconds = Number(error.response.headers["retry-after"]);
-  return Number.isFinite(seconds) ? seconds : undefined;
-};
-
-// gaxios 形状の API エラーを payload 付き throw 型へ変換する。429 のみ
-// `QuotaExhaustedError` へ昇格し（`fromGaxiosError` は昇格しない契約のため caller 判断）、
-// それ以外は `YouTubeAPIError` のまま返す。
-const toQueryError = (error: unknown): YouTubeAPIError => {
-  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
-  if (apiError.statusCode === 429) {
-    return new QuotaExhaustedError(
-      apiError.message,
-      parseRetryAfterSeconds(error)
-    );
-  }
-  return apiError;
-};
-
-// `queryDailyReport` が全エラーを `YouTubeAPIError`（429 は `QuotaExhaustedError`）へ
-// 正規化してから throw するため、ここへ渡るのは常に `YouTubeAPIError`。
-//   - quota(429): `defaultShouldRetry` が false（ADR-0003: quota は Result で caller へ）
-//   - その他の 4xx 恒久エラー: retry しない
-//   - 5xx / status 不明（ネットワーク断などが status なしで正規化される）: 一時障害として retry
-//
-// retry-許可分岐（5xx / status 不明 → true）の回帰を unit test で pin できるよう export
-// する。`index.ts` は意図的に再エクスポートしない（ADR-0003 canonical template: feature の
-// 公開面は schema + service のみ）ため公開 API は不変。
-export const shouldRetryQuery = (error: unknown): boolean => {
-  if (!defaultShouldRetry(error)) {
-    return false;
-  }
-  if (!(error instanceof YouTubeAPIError)) {
-    // 上記の正規化により到達しない。網羅性のための保守的 fallback（retry しない）。
-    return false;
-  }
-  return (
-    error.statusCode === undefined || error.statusCode >= HTTP_SERVER_ERROR_MIN
-  );
-};
 
 const buildQueryParams = (input: ChannelAnalyticsInput): QueryParams => ({
   dimensions: DAY_DIMENSION,
@@ -120,7 +66,7 @@ const queryDailyReport = async (
     const response = await client.reports.query(params);
     return response.data;
   } catch (error) {
-    throw toQueryError(error);
+    throw toAnalyticsQueryError(error, QUERY_CONTEXT);
   }
 };
 
@@ -176,7 +122,7 @@ export const collectChannelAnalyticsService = async (
     const params = buildQueryParams(request);
     const data = await withRetry(
       () => queryDailyReport(deps.youtubeAnalytics, params),
-      { shouldRetry: shouldRetryQuery }
+      { shouldRetry: shouldRetryAnalyticsQuery }
     );
     return ok(
       ChannelAnalyticsOutput.parse({ metrics: reshapeToLongFormat(data) })

--- a/packages/core/src/analytics/query-error.ts
+++ b/packages/core/src/analytics/query-error.ts
@@ -1,0 +1,68 @@
+import { isRecord } from "../../internal/guards.ts";
+import { QuotaExhaustedError, YouTubeAPIError } from "../errors.ts";
+import { defaultShouldRetry } from "../retry.ts";
+
+const HTTP_SERVER_ERROR_MIN = 500;
+const RETRY_AFTER_HEADER = "retry-after";
+
+const findRetryAfterHeader = (
+  headers: Record<string, unknown>
+): unknown | undefined => {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === RETRY_AFTER_HEADER) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export const parseRetryAfterSeconds = (error: unknown): number | undefined => {
+  if (
+    !(
+      isRecord(error) &&
+      isRecord(error.response) &&
+      isRecord(error.response.headers)
+    )
+  ) {
+    return undefined;
+  }
+  const raw = findRetryAfterHeader(error.response.headers);
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  const seconds = Number(trimmed);
+  return Number.isFinite(seconds) ? seconds : undefined;
+};
+
+export const toAnalyticsQueryError = (
+  error: unknown,
+  context: string
+): YouTubeAPIError => {
+  if (error instanceof YouTubeAPIError) {
+    return error;
+  }
+  const apiError = YouTubeAPIError.fromGaxiosError(error, context);
+  if (apiError.statusCode === 429) {
+    return new QuotaExhaustedError(
+      apiError.message,
+      parseRetryAfterSeconds(error)
+    );
+  }
+  return apiError;
+};
+
+export const shouldRetryAnalyticsQuery = (error: unknown): boolean => {
+  if (!defaultShouldRetry(error)) {
+    return false;
+  }
+  if (!(error instanceof YouTubeAPIError)) {
+    return false;
+  }
+  return (
+    error.statusCode === undefined || error.statusCode >= HTTP_SERVER_ERROR_MIN
+  );
+};

--- a/packages/core/src/analytics/traffic-source/index.ts
+++ b/packages/core/src/analytics/traffic-source/index.ts
@@ -1,0 +1,5 @@
+export {
+  TrafficSourceAnalyticsInput,
+  TrafficSourceAnalyticsOutput,
+} from "./schema.ts";
+export { collectTrafficSourceService } from "./service.ts";

--- a/packages/core/src/analytics/traffic-source/schema.ts
+++ b/packages/core/src/analytics/traffic-source/schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
+
+export const TRAFFIC_SOURCE_VIEWS_METRIC = "views";
+
+export const TRAFFIC_SOURCE_API_METRICS = [
+  TRAFFIC_SOURCE_VIEWS_METRIC,
+  "estimatedMinutesWatched",
+  "averageViewDuration",
+] as const;
+
+const TRAFFIC_SOURCE_OUTPUT_METRICS = [
+  ...TRAFFIC_SOURCE_API_METRICS,
+  "viewSharePercent",
+] as const;
+
+const isTrafficSourceMetric = (value: string): boolean =>
+  TRAFFIC_SOURCE_OUTPUT_METRICS.some((metric) => metric === value);
+
+export const TrafficSourceAnalyticsInput = z
+  .object({
+    channelId: z.string().min(1),
+    endDate: z.string().regex(ISO_DATE),
+    startDate: z.string().regex(ISO_DATE),
+    videoId: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine((input) => input.startDate <= input.endDate, {
+    message: "startDate must be on or before endDate",
+    path: ["startDate"],
+  });
+export type TrafficSourceAnalyticsInput = z.infer<
+  typeof TrafficSourceAnalyticsInput
+>;
+
+export const TrafficSourceAnalyticsOutput = z
+  .object({
+    metrics: z.array(
+      z
+        .object({
+          metric: z
+            .string()
+            .refine(isTrafficSourceMetric, "unsupported traffic source metric"),
+          trafficSourceType: z.string(),
+          value: z.number(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+export type TrafficSourceAnalyticsOutput = z.infer<
+  typeof TrafficSourceAnalyticsOutput
+>;

--- a/packages/core/src/analytics/traffic-source/service.ts
+++ b/packages/core/src/analytics/traffic-source/service.ts
@@ -1,0 +1,286 @@
+import type { youtubeAnalytics_v2 } from "googleapis";
+
+import { isRecord } from "../../../internal/guards.ts";
+import {
+  QuotaExhaustedError,
+  toServiceError,
+  YouTubeAPIError,
+} from "../../errors.ts";
+import type { ServiceError } from "../../errors.ts";
+import { err, ok } from "../../result.ts";
+import type { Result } from "../../result.ts";
+import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import type { SleepMs } from "../../retry.ts";
+import {
+  TRAFFIC_SOURCE_API_METRICS,
+  TRAFFIC_SOURCE_VIEWS_METRIC,
+  TrafficSourceAnalyticsInput,
+  TrafficSourceAnalyticsOutput,
+} from "./schema.ts";
+
+const QUERY_CONTEXT = "traffic-source analytics query";
+const CHANNEL_ID_PREFIX = "channel==";
+const VIDEO_FILTER_PREFIX = "video==";
+const TRAFFIC_SOURCE_DIMENSION = "insightTrafficSourceType";
+const SORT_BY_VIEWS_DESC = "-views";
+const VIEW_SHARE_METRIC = "viewSharePercent";
+const HTTP_SERVER_ERROR_MIN = 500;
+
+type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
+type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
+type ColumnHeaders = NonNullable<QueryResponse["columnHeaders"]>;
+type TrafficSourceMetricRecord =
+  TrafficSourceAnalyticsOutput["metrics"][number];
+interface MetricColumn {
+  readonly index: number;
+  readonly metric: (typeof TRAFFIC_SOURCE_API_METRICS)[number];
+}
+interface AggregatedTrafficSource {
+  readonly estimatedMinutesWatched: number;
+  readonly trafficSourceType: string;
+  readonly views: number;
+}
+interface TrafficSourceDeps {
+  readonly sleep?: SleepMs;
+  readonly youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics;
+}
+
+const parseRetryAfterSeconds = (error: unknown): number | undefined => {
+  if (
+    !(
+      isRecord(error) &&
+      isRecord(error.response) &&
+      isRecord(error.response.headers)
+    )
+  ) {
+    return undefined;
+  }
+  const raw = error.response.headers["retry-after"];
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  const seconds = Number(trimmed);
+  return Number.isFinite(seconds) ? seconds : undefined;
+};
+
+const toQueryError = (error: unknown): YouTubeAPIError => {
+  if (error instanceof YouTubeAPIError) {
+    return error;
+  }
+  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
+  if (apiError.statusCode === 429) {
+    return new QuotaExhaustedError(
+      apiError.message,
+      parseRetryAfterSeconds(error)
+    );
+  }
+  return apiError;
+};
+
+const shouldRetryQuery = (error: unknown): boolean => {
+  if (!defaultShouldRetry(error)) {
+    return false;
+  }
+  if (!(error instanceof YouTubeAPIError)) {
+    return false;
+  }
+  return (
+    error.statusCode === undefined || error.statusCode >= HTTP_SERVER_ERROR_MIN
+  );
+};
+
+const buildQueryParams = (input: TrafficSourceAnalyticsInput): QueryParams => ({
+  dimensions: TRAFFIC_SOURCE_DIMENSION,
+  endDate: input.endDate,
+  ...(input.videoId
+    ? { filters: `${VIDEO_FILTER_PREFIX}${input.videoId}` }
+    : {}),
+  ids: `${CHANNEL_ID_PREFIX}${input.channelId}`,
+  metrics: TRAFFIC_SOURCE_API_METRICS.join(","),
+  sort: SORT_BY_VIEWS_DESC,
+  startDate: input.startDate,
+});
+
+const queryTrafficSourceReport = async (
+  client: youtubeAnalytics_v2.Youtubeanalytics,
+  params: QueryParams
+): Promise<QueryResponse> => {
+  try {
+    const response = await client.reports.query(params);
+    return response.data;
+  } catch (error) {
+    throw toQueryError(error);
+  }
+};
+
+const resolveColumnIndex = (headers: ColumnHeaders, name: string): number => {
+  const index = headers.findIndex((header) => header.name === name);
+  if (index === -1) {
+    throw new Error(
+      `${QUERY_CONTEXT}: response is missing the "${name}" column`
+    );
+  }
+  return index;
+};
+
+const readNumberCell = (
+  row: readonly unknown[],
+  index: number,
+  columnName: string
+): number => {
+  const value = row[index];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(
+      `${QUERY_CONTEXT}: response has a non-numeric "${columnName}" value`
+    );
+  }
+  return value;
+};
+
+const readStringCell = (
+  row: readonly unknown[],
+  index: number,
+  columnName: string
+): string => {
+  const value = row[index];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(
+      `${QUERY_CONTEXT}: response has an invalid "${columnName}" value`
+    );
+  }
+  return value;
+};
+
+const roundOneDecimal = (value: number): number => Math.round(value * 10) / 10;
+
+const metricRecordsForRow = (
+  source: AggregatedTrafficSource,
+  totalViews: number
+): TrafficSourceMetricRecord[] => {
+  const averageViewDuration =
+    source.views === 0
+      ? 0
+      : roundOneDecimal((source.estimatedMinutesWatched * 60) / source.views);
+  const viewSharePercent =
+    totalViews === 0 ? 0 : roundOneDecimal((source.views / totalViews) * 100);
+  return [
+    {
+      metric: TRAFFIC_SOURCE_VIEWS_METRIC,
+      trafficSourceType: source.trafficSourceType,
+      value: source.views,
+    },
+    {
+      metric: "estimatedMinutesWatched",
+      trafficSourceType: source.trafficSourceType,
+      value: source.estimatedMinutesWatched,
+    },
+    {
+      metric: "averageViewDuration",
+      trafficSourceType: source.trafficSourceType,
+      value: averageViewDuration,
+    },
+    {
+      metric: VIEW_SHARE_METRIC,
+      trafficSourceType: source.trafficSourceType,
+      value: viewSharePercent,
+    },
+  ];
+};
+
+const aggregateTrafficSources = (
+  rows: readonly (readonly unknown[])[],
+  trafficSourceIndex: number,
+  metricColumns: readonly MetricColumn[]
+): AggregatedTrafficSource[] => {
+  const aggregated = new Map<string, AggregatedTrafficSource>();
+  for (const row of rows) {
+    const trafficSourceType = readStringCell(
+      row,
+      trafficSourceIndex,
+      TRAFFIC_SOURCE_DIMENSION
+    );
+    const previous = aggregated.get(trafficSourceType) ?? {
+      estimatedMinutesWatched: 0,
+      trafficSourceType,
+      views: 0,
+    };
+    const {
+      estimatedMinutesWatched: previousEstimatedMinutesWatched,
+      views: previousViews,
+    } = previous;
+    let views = previousViews;
+    let estimatedMinutesWatched = previousEstimatedMinutesWatched;
+    for (const column of metricColumns) {
+      const value = readNumberCell(row, column.index, column.metric);
+      if (column.metric === TRAFFIC_SOURCE_VIEWS_METRIC) {
+        views += value;
+      } else if (column.metric === "estimatedMinutesWatched") {
+        estimatedMinutesWatched += value;
+      }
+    }
+    aggregated.set(trafficSourceType, {
+      estimatedMinutesWatched,
+      trafficSourceType,
+      views,
+    });
+  }
+  return [...aggregated.values()];
+};
+
+const reshapeToLongFormat = (
+  data: QueryResponse
+): TrafficSourceMetricRecord[] => {
+  const { rows } = data;
+  if (!rows) {
+    return [];
+  }
+  const headers = data.columnHeaders;
+  if (!headers) {
+    throw new Error(`${QUERY_CONTEXT}: response has rows but no columnHeaders`);
+  }
+  const trafficSourceIndex = resolveColumnIndex(
+    headers,
+    TRAFFIC_SOURCE_DIMENSION
+  );
+  const metricColumns = TRAFFIC_SOURCE_API_METRICS.map((metric) => ({
+    index: resolveColumnIndex(headers, metric),
+    metric,
+  }));
+  const aggregated = aggregateTrafficSources(
+    rows,
+    trafficSourceIndex,
+    metricColumns
+  );
+  let totalViews = 0;
+  for (const source of aggregated) {
+    totalViews += source.views;
+  }
+  return aggregated.flatMap((source) =>
+    metricRecordsForRow(source, totalViews)
+  );
+};
+
+export const collectTrafficSourceService = async (
+  input: TrafficSourceAnalyticsInput,
+  deps: TrafficSourceDeps
+): Promise<Result<TrafficSourceAnalyticsOutput, ServiceError>> => {
+  try {
+    const request = TrafficSourceAnalyticsInput.parse(input);
+    const params = buildQueryParams(request);
+    const data = await withRetry(
+      () => queryTrafficSourceReport(deps.youtubeAnalytics, params),
+      { shouldRetry: shouldRetryQuery, sleep: deps.sleep }
+    );
+    return ok(
+      TrafficSourceAnalyticsOutput.parse({
+        metrics: reshapeToLongFormat(data),
+      })
+    );
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/src/analytics/traffic-source/service.ts
+++ b/packages/core/src/analytics/traffic-source/service.ts
@@ -1,16 +1,15 @@
 import type { youtubeAnalytics_v2 } from "googleapis";
 
-import { isRecord } from "../../../internal/guards.ts";
-import {
-  QuotaExhaustedError,
-  toServiceError,
-  YouTubeAPIError,
-} from "../../errors.ts";
+import { toServiceError } from "../../errors.ts";
 import type { ServiceError } from "../../errors.ts";
 import { err, ok } from "../../result.ts";
 import type { Result } from "../../result.ts";
-import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import { withRetry } from "../../retry.ts";
 import type { SleepMs } from "../../retry.ts";
+import {
+  shouldRetryAnalyticsQuery,
+  toAnalyticsQueryError,
+} from "../query-error.ts";
 import {
   TRAFFIC_SOURCE_API_METRICS,
   TRAFFIC_SOURCE_VIEWS_METRIC,
@@ -24,7 +23,6 @@ const VIDEO_FILTER_PREFIX = "video==";
 const TRAFFIC_SOURCE_DIMENSION = "insightTrafficSourceType";
 const SORT_BY_VIEWS_DESC = "-views";
 const VIEW_SHARE_METRIC = "viewSharePercent";
-const HTTP_SERVER_ERROR_MIN = 500;
 
 type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
 type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
@@ -36,6 +34,7 @@ interface MetricColumn {
   readonly metric: (typeof TRAFFIC_SOURCE_API_METRICS)[number];
 }
 interface AggregatedTrafficSource {
+  readonly averageViewDurationWeightedSum: number;
   readonly estimatedMinutesWatched: number;
   readonly trafficSourceType: string;
   readonly views: number;
@@ -44,54 +43,6 @@ interface TrafficSourceDeps {
   readonly sleep?: SleepMs;
   readonly youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics;
 }
-
-const parseRetryAfterSeconds = (error: unknown): number | undefined => {
-  if (
-    !(
-      isRecord(error) &&
-      isRecord(error.response) &&
-      isRecord(error.response.headers)
-    )
-  ) {
-    return undefined;
-  }
-  const raw = error.response.headers["retry-after"];
-  if (typeof raw !== "string") {
-    return undefined;
-  }
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) {
-    return undefined;
-  }
-  const seconds = Number(trimmed);
-  return Number.isFinite(seconds) ? seconds : undefined;
-};
-
-const toQueryError = (error: unknown): YouTubeAPIError => {
-  if (error instanceof YouTubeAPIError) {
-    return error;
-  }
-  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
-  if (apiError.statusCode === 429) {
-    return new QuotaExhaustedError(
-      apiError.message,
-      parseRetryAfterSeconds(error)
-    );
-  }
-  return apiError;
-};
-
-const shouldRetryQuery = (error: unknown): boolean => {
-  if (!defaultShouldRetry(error)) {
-    return false;
-  }
-  if (!(error instanceof YouTubeAPIError)) {
-    return false;
-  }
-  return (
-    error.statusCode === undefined || error.statusCode >= HTTP_SERVER_ERROR_MIN
-  );
-};
 
 const buildQueryParams = (input: TrafficSourceAnalyticsInput): QueryParams => ({
   dimensions: TRAFFIC_SOURCE_DIMENSION,
@@ -113,7 +64,7 @@ const queryTrafficSourceReport = async (
     const response = await client.reports.query(params);
     return response.data;
   } catch (error) {
-    throw toQueryError(error);
+    throw toAnalyticsQueryError(error, QUERY_CONTEXT);
   }
 };
 
@@ -164,7 +115,7 @@ const metricRecordsForRow = (
   const averageViewDuration =
     source.views === 0
       ? 0
-      : roundOneDecimal((source.estimatedMinutesWatched * 60) / source.views);
+      : roundOneDecimal(source.averageViewDurationWeightedSum / source.views);
   const viewSharePercent =
     totalViews === 0 ? 0 : roundOneDecimal((source.views / totalViews) * 100);
   return [
@@ -204,25 +155,35 @@ const aggregateTrafficSources = (
       TRAFFIC_SOURCE_DIMENSION
     );
     const previous = aggregated.get(trafficSourceType) ?? {
+      averageViewDurationWeightedSum: 0,
       estimatedMinutesWatched: 0,
       trafficSourceType,
       views: 0,
     };
     const {
+      averageViewDurationWeightedSum: previousAverageViewDurationWeightedSum,
       estimatedMinutesWatched: previousEstimatedMinutesWatched,
       views: previousViews,
     } = previous;
+    let averageViewDurationWeightedSum = previousAverageViewDurationWeightedSum;
     let views = previousViews;
     let estimatedMinutesWatched = previousEstimatedMinutesWatched;
+    let rowViews = 0;
+    let rowAverageViewDuration = 0;
     for (const column of metricColumns) {
       const value = readNumberCell(row, column.index, column.metric);
       if (column.metric === TRAFFIC_SOURCE_VIEWS_METRIC) {
+        rowViews = value;
         views += value;
       } else if (column.metric === "estimatedMinutesWatched") {
         estimatedMinutesWatched += value;
+      } else if (column.metric === "averageViewDuration") {
+        rowAverageViewDuration = value;
       }
     }
+    averageViewDurationWeightedSum += rowAverageViewDuration * rowViews;
     aggregated.set(trafficSourceType, {
+      averageViewDurationWeightedSum,
       estimatedMinutesWatched,
       trafficSourceType,
       views,
@@ -273,7 +234,7 @@ export const collectTrafficSourceService = async (
     const params = buildQueryParams(request);
     const data = await withRetry(
       () => queryTrafficSourceReport(deps.youtubeAnalytics, params),
-      { shouldRetry: shouldRetryQuery, sleep: deps.sleep }
+      { shouldRetry: shouldRetryAnalyticsQuery, sleep: deps.sleep }
     );
     return ok(
       TrafficSourceAnalyticsOutput.parse({

--- a/packages/core/src/analytics/video-daily/service.ts
+++ b/packages/core/src/analytics/video-daily/service.ts
@@ -19,17 +19,17 @@
 
 import type { youtubeAnalytics_v2 } from "googleapis";
 
-import {
-  QuotaExhaustedError,
-  toServiceError,
-  YouTubeAPIError,
-} from "../../errors.ts";
+import { toServiceError } from "../../errors.ts";
 import type { ServiceError } from "../../errors.ts";
 import type { YouTubeAnalyticsClient } from "../../oauth/client.ts";
 import { err, ok } from "../../result.ts";
 import type { Result } from "../../result.ts";
-import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import { withRetry } from "../../retry.ts";
 import type { SleepMs } from "../../retry.ts";
+import {
+  shouldRetryAnalyticsQuery,
+  toAnalyticsQueryError,
+} from "../query-error.ts";
 import {
   CollectVideoDailyAnalyticsInput,
   CollectVideoDailyAnalyticsOutput,
@@ -43,7 +43,6 @@ const SORT_BY_DAY = "day";
 const CHANNEL_ID_PREFIX = "channel==";
 const VIDEO_FILTER_PREFIX = "video==";
 const VIDEO_FILTER_SEPARATOR = ",";
-const HTTP_SERVER_ERROR_MIN = 500;
 
 // 行の列順は上の `dimensions=video,day` + `metrics=views` クエリ契約で固定されるため、
 // columnHeaders に頼らず位置で引く（API はこの dimension/metric 組では常にこの順で返す）。
@@ -55,62 +54,10 @@ type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
 type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
 type VideoDailyRecord = CollectVideoDailyAnalyticsOutput["metrics"][number];
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-// gaxios エラーの `response.headers["retry-after"]` を秒数として取り出す。header 不在
-// （quota が日次リセットで Retry-After を返さないケース）では undefined（contract 通り）。
-const parseRetryAfterSeconds = (error: unknown): number | undefined => {
-  if (
-    !(
-      isRecord(error) &&
-      isRecord(error.response) &&
-      isRecord(error.response.headers)
-    )
-  ) {
-    return undefined;
-  }
-  const seconds = Number(error.response.headers["retry-after"]);
-  return Number.isFinite(seconds) ? seconds : undefined;
-};
-
-// API エラーを payload 付き throw 型へ正規化する。既に typed なドメインエラー
-// （下位層が投げた QuotaExhaustedError 等）はそのまま通し、再ラップで statusCode /
-// retryAfterSeconds を落とさない。raw な gaxios エラーは YouTubeAPIError へ変換し、
-// 429 のみ QuotaExhaustedError へ昇格する（`fromGaxiosError` は昇格しない契約のため）。
-const toQueryError = (error: unknown): YouTubeAPIError => {
-  if (error instanceof YouTubeAPIError) {
-    return error;
-  }
-  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
-  if (apiError.statusCode === 429) {
-    return new QuotaExhaustedError(
-      apiError.message,
-      parseRetryAfterSeconds(error)
-    );
-  }
-  return apiError;
-};
-
-// quota（共通既定で non-retryable）と 4xx 恒久エラーは retry しない。5xx / status 不明 /
-// 非 API throw（ネットワーク断など）のみ一時障害として retry する。
-const shouldRetryQuery = (error: unknown): boolean => {
-  if (!defaultShouldRetry(error)) {
-    return false;
-  }
-  if (error instanceof YouTubeAPIError) {
-    return (
-      error.statusCode === undefined ||
-      error.statusCode >= HTTP_SERVER_ERROR_MIN
-    );
-  }
-  return true;
-};
-
 const buildQueryParams = (
   input: CollectVideoDailyAnalyticsInput
 ): QueryParams => {
-  const params: QueryParams = {
+  const baseParams: QueryParams = {
     dimensions: VIDEO_DAY_DIMENSIONS,
     endDate: input.endDate,
     ids: `${CHANNEL_ID_PREFIX}${input.channelId}`,
@@ -120,9 +67,12 @@ const buildQueryParams = (
   };
   // 空配列は「絞り込みなし」と解釈する（`video==` で ids が空の filter は不正なため送らない）。
   if (input.videoIds && input.videoIds.length > 0) {
-    params.filters = `${VIDEO_FILTER_PREFIX}${input.videoIds.join(VIDEO_FILTER_SEPARATOR)}`;
+    return {
+      ...baseParams,
+      filters: `${VIDEO_FILTER_PREFIX}${input.videoIds.join(VIDEO_FILTER_SEPARATOR)}`,
+    };
   }
-  return params;
+  return baseParams;
 };
 
 const mapRows = (rows: QueryResponse["rows"]): VideoDailyRecord[] => {
@@ -158,10 +108,10 @@ export const collectVideoDailyAnalyticsService = async (
           const response = await deps.ytAnalytics.reports.query(params);
           return response.data;
         } catch (error) {
-          throw toQueryError(error);
+          throw toAnalyticsQueryError(error, QUERY_CONTEXT);
         }
       },
-      { shouldRetry: shouldRetryQuery, sleep: deps.sleep }
+      { shouldRetry: shouldRetryAnalyticsQuery, sleep: deps.sleep }
     );
     return ok(
       CollectVideoDailyAnalyticsOutput.parse({

--- a/packages/core/src/analytics/video/service.ts
+++ b/packages/core/src/analytics/video/service.ts
@@ -11,17 +11,17 @@
 //   deps.youtubeAnalytics.reports.query(params) -> { data: { columnHeaders?, rows? } }
 //   429 時は gaxios 形状 { response: { status: 429, headers: { "retry-after" } } } で reject。
 
-import {
-  QuotaExhaustedError,
-  toServiceError,
-  YouTubeAPIError,
-} from "../../errors.ts";
+import { toServiceError } from "../../errors.ts";
 import type { ServiceError } from "../../errors.ts";
 import type { YouTubeAnalyticsClient } from "../../oauth/client.ts";
 import { err, ok } from "../../result.ts";
 import type { Result } from "../../result.ts";
 import { withRetry } from "../../retry.ts";
 import type { SleepMs } from "../../retry.ts";
+import {
+  shouldRetryAnalyticsQuery,
+  toAnalyticsQueryError,
+} from "../query-error.ts";
 import {
   CollectVideoAnalyticsInput,
   CollectVideoAnalyticsOutput,
@@ -50,36 +50,6 @@ interface ColumnHeader {
   readonly name?: string | null;
 }
 
-// gaxios 形状のエラーから Retry-After 秒を読む。ヘッダ欠落・空文字列・非数値は undefined を返す
-// （QuotaExhaustedError.retryAfterSeconds は省略可。外部入力の欠落値は undefined が正しい契約）。
-const retryAfterSecondsFrom = (error: unknown): number | undefined => {
-  const headers = (
-    error as { response?: { headers?: Record<string, unknown> } }
-  )?.response?.headers;
-  const raw = headers?.["retry-after"];
-  // 空文字列・空白のみは「ヒントなし」。Number("") === 0 を「0 秒で再試行可」と
-  // 誤読しないよう undefined に倒す（ヘッダ欠落 undefined → Number(undefined)=NaN と同じ扱い）。
-  if (typeof raw === "string" && raw.trim() === "") {
-    return undefined;
-  }
-  const seconds = Number(raw);
-  return Number.isFinite(seconds) ? seconds : undefined;
-};
-
-// reports.query の失敗を分類する。429 は QuotaExhaustedError へ昇格して withRetry に retry を
-// 抑止させ（ADR-0003: quota は Result で caller へ）、それ以外は YouTubeAPIError に変換して
-// withRetry の一時エラー retry に委ねる。
-const toQueryError = (error: unknown): Error => {
-  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
-  if (apiError.statusCode === 429) {
-    return new QuotaExhaustedError(
-      apiError.message,
-      retryAfterSecondsFrom(error)
-    );
-  }
-  return apiError;
-};
-
 // channelId を必須の ids フィルタにエンコードし、videoId 指定時のみ video== フィルタを足す。
 const buildQueryParams = (request: CollectVideoAnalyticsInput) => ({
   dimensions: VIDEO_DIMENSION,
@@ -101,7 +71,7 @@ const runVideoQuery = async (
   try {
     return await deps.youtubeAnalytics.reports.query(buildQueryParams(request));
   } catch (error) {
-    throw toQueryError(error);
+    throw toAnalyticsQueryError(error, QUERY_CONTEXT);
   }
 };
 
@@ -161,6 +131,7 @@ export const collectVideoAnalyticsService = async (
   try {
     const request = CollectVideoAnalyticsInput.parse(input);
     const response = await withRetry(() => runVideoQuery(deps, request), {
+      shouldRetry: shouldRetryAnalyticsQuery,
       sleep: deps.sleep,
     });
     const metrics = meltVideoRows(

--- a/packages/core/test/analytics-channel.test.ts
+++ b/packages/core/test/analytics-channel.test.ts
@@ -28,11 +28,10 @@ import {
   collectChannelAnalyticsService,
 } from "@youtube-automation/core/analytics/channel";
 
-// shouldRetryQuery is not part of the feature's public face (index.ts re-exports
-// only schema + service, ADR-0003 canonical template), so the retry-permit truth
-// table is pinned through a relative import of the service module
-// (oauth-interactive.test.ts:20 pattern).
-import { shouldRetryQuery } from "../src/analytics/channel/service.ts";
+// shouldRetryAnalyticsQuery is a private analytics helper, not part of the
+// package public exports. The retry-permit truth table is pinned through a
+// relative import (oauth-interactive.test.ts:20 pattern).
+import { shouldRetryAnalyticsQuery } from "../src/analytics/query-error.ts";
 
 // Derive the input / deps shapes from the service itself (oauth-refresh.test.ts:25-26)
 // so the test pins behavior, not the exported name of the injection bag.
@@ -421,7 +420,7 @@ describe("collectChannelAnalyticsService api error path", () => {
     await collectChannelAnalyticsService(baseInput, makeDeps(client));
 
     // Then a permanent client error is not retried — only 5xx / unknown-status
-    // failures are transient per shouldRetryQuery (plan §4-2, load-bearing)
+    // failures are transient per shouldRetryAnalyticsQuery (plan §4-2, load-bearing)
     expect(calls).toHaveLength(1);
   });
 });
@@ -544,18 +543,18 @@ describe("ChannelAnalyticsOutput schema", () => {
 });
 
 // --- retry-permit predicate -----------------------------------------------
-// Pins shouldRetryQuery's truth table directly. The service's quota/403 paths
+// Pins shouldRetryAnalyticsQuery's truth table directly. The service's quota/403 paths
 // only assert the *negative* branch (calls === 1); without this, the
 // retry-permit branch (5xx / unknown-status → retry, load-bearing per
 // service.ts:83-94) is unexercised and a regression making 5xx non-retryable
 // would pass silently. Pure predicate calls — no real sleep / API.
 
-describe("shouldRetryQuery", () => {
+describe("shouldRetryAnalyticsQuery", () => {
   test("retries a transient 5xx server error", () => {
     // Given the normalizer produced a 503 YouTubeAPIError
     // Then the failure is treated as transient and retried
     expect(
-      shouldRetryQuery(new YouTubeAPIError("boom", { statusCode: 503 }))
+      shouldRetryAnalyticsQuery(new YouTubeAPIError("boom", { statusCode: 503 }))
     ).toBe(true);
   });
 
@@ -563,35 +562,37 @@ describe("shouldRetryQuery", () => {
     // Given the lowest 5xx status (HTTP_SERVER_ERROR_MIN)
     // Then it is still transient
     expect(
-      shouldRetryQuery(new YouTubeAPIError("boom", { statusCode: 500 }))
+      shouldRetryAnalyticsQuery(new YouTubeAPIError("boom", { statusCode: 500 }))
     ).toBe(true);
   });
 
   test("retries when the status is unknown (network drop normalized without a status)", () => {
     // Given a YouTubeAPIError carrying no statusCode
     // Then it is treated as a transient failure
-    expect(shouldRetryQuery(new YouTubeAPIError("boom"))).toBe(true);
+    expect(shouldRetryAnalyticsQuery(new YouTubeAPIError("boom"))).toBe(true);
   });
 
   test("does not retry a permanent 4xx client error", () => {
     // Given a 403 forbidden
     // Then it is permanent and not retried
     expect(
-      shouldRetryQuery(new YouTubeAPIError("forbidden", { statusCode: 403 }))
+      shouldRetryAnalyticsQuery(
+        new YouTubeAPIError("forbidden", { statusCode: 403 })
+      )
     ).toBe(false);
   });
 
   test("does not retry a quota error (surfaced as a Result instead)", () => {
     // Given a 429 quota error — defaultShouldRetry gates it out (ADR-0003)
     // Then it is not retried
-    expect(shouldRetryQuery(new QuotaExhaustedError("quota exceeded"))).toBe(
-      false
-    );
+    expect(
+      shouldRetryAnalyticsQuery(new QuotaExhaustedError("quota exceeded"))
+    ).toBe(false);
   });
 
   test("does not retry a value the normalizer never emits (defensive guard)", () => {
     // Given a raw Error that is not a YouTubeAPIError — unreachable because
     // queryDailyReport normalizes everything, but the guard must hold
-    expect(shouldRetryQuery(new Error("transient blip"))).toBe(false);
+    expect(shouldRetryAnalyticsQuery(new Error("transient blip"))).toBe(false);
   });
 });

--- a/packages/core/test/analytics-query-error.test.ts
+++ b/packages/core/test/analytics-query-error.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  QuotaExhaustedError,
+  YouTubeAPIError,
+} from "@youtube-automation/core";
+
+import {
+  parseRetryAfterSeconds,
+  shouldRetryAnalyticsQuery,
+  toAnalyticsQueryError,
+} from "../src/analytics/query-error.ts";
+
+const gaxiosError = (message: string, response: unknown): Error =>
+  Object.assign(new Error(message), { response });
+
+describe("parseRetryAfterSeconds", () => {
+  test("parses a numeric Retry-After header", () => {
+    const error = gaxiosError("quota exceeded", {
+      headers: { "retry-after": "1800" },
+      status: 429,
+    });
+
+    expect(parseRetryAfterSeconds(error)).toBe(1800);
+  });
+
+  test("parses Retry-After regardless of header casing", () => {
+    const error = gaxiosError("quota exceeded", {
+      headers: { "Retry-After": "1800" },
+      status: 429,
+    });
+
+    expect(parseRetryAfterSeconds(error)).toBe(1800);
+  });
+
+  test("treats an empty Retry-After header as missing", () => {
+    const error = gaxiosError("quota exceeded", {
+      headers: { "retry-after": "" },
+      status: 429,
+    });
+
+    expect(parseRetryAfterSeconds(error)).toBeUndefined();
+  });
+
+  test("treats a whitespace Retry-After header as missing", () => {
+    const error = gaxiosError("quota exceeded", {
+      headers: { "retry-after": "   " },
+      status: 429,
+    });
+
+    expect(parseRetryAfterSeconds(error)).toBeUndefined();
+  });
+
+  test("treats a non-numeric Retry-After header as missing", () => {
+    const error = gaxiosError("quota exceeded", {
+      headers: { "retry-after": "later" },
+      status: 429,
+    });
+
+    expect(parseRetryAfterSeconds(error)).toBeUndefined();
+  });
+});
+
+describe("toAnalyticsQueryError", () => {
+  test("promotes a gaxios 429 to QuotaExhaustedError with retryAfterSeconds", () => {
+    const error = gaxiosError("quota exceeded", {
+      data: { error: { errors: [{ reason: "quotaExceeded" }] } },
+      headers: { "retry-after": "120" },
+      status: 429,
+    });
+
+    const normalized = toAnalyticsQueryError(error, "analytics query");
+
+    expect(normalized).toBeInstanceOf(QuotaExhaustedError);
+    expect(normalized.statusCode).toBe(429);
+    if (normalized instanceof QuotaExhaustedError) {
+      expect(normalized.retryAfterSeconds).toBe(120);
+    }
+  });
+
+  test("normalizes a non-quota gaxios error to YouTubeAPIError", () => {
+    const error = gaxiosError("forbidden", {
+      data: { error: { errors: [{ reason: "insufficientPermissions" }] } },
+      status: 403,
+    });
+
+    const normalized = toAnalyticsQueryError(error, "analytics query");
+
+    expect(normalized).toBeInstanceOf(YouTubeAPIError);
+    expect(normalized).not.toBeInstanceOf(QuotaExhaustedError);
+    expect(normalized.statusCode).toBe(403);
+    expect(normalized.reason).toBe("insufficientPermissions");
+  });
+
+  test("preserves an existing typed YouTubeAPIError", () => {
+    const error = new YouTubeAPIError("already normalized", {
+      reason: "backendError",
+      statusCode: 503,
+    });
+
+    expect(toAnalyticsQueryError(error, "analytics query")).toBe(error);
+  });
+});
+
+describe("shouldRetryAnalyticsQuery", () => {
+  test("does not retry quota errors", () => {
+    expect(
+      shouldRetryAnalyticsQuery(new QuotaExhaustedError("quota exceeded"))
+    ).toBe(false);
+  });
+
+  test("does not retry permanent 4xx API errors", () => {
+    expect(
+      shouldRetryAnalyticsQuery(
+        new YouTubeAPIError("forbidden", { statusCode: 403 })
+      )
+    ).toBe(false);
+  });
+
+  test("retries server-side 5xx API errors", () => {
+    expect(
+      shouldRetryAnalyticsQuery(
+        new YouTubeAPIError("server error", { statusCode: 500 })
+      )
+    ).toBe(true);
+  });
+
+  test("retries normalized API errors with unknown status", () => {
+    expect(shouldRetryAnalyticsQuery(new YouTubeAPIError("network drop"))).toBe(
+      true
+    );
+  });
+
+  test("does not retry raw errors before query normalization", () => {
+    expect(shouldRetryAnalyticsQuery(new Error("raw failure"))).toBe(false);
+  });
+});

--- a/packages/core/test/analytics-traffic-source.test.ts
+++ b/packages/core/test/analytics-traffic-source.test.ts
@@ -1,0 +1,513 @@
+import { describe, expect, test } from "bun:test";
+
+import { QuotaExhaustedError } from "@youtube-automation/core";
+import {
+  TrafficSourceAnalyticsInput,
+  TrafficSourceAnalyticsOutput,
+  collectTrafficSourceService,
+} from "@youtube-automation/core/analytics/traffic-source";
+
+type TrafficSourceInput = Parameters<typeof collectTrafficSourceService>[0];
+type TrafficSourceDeps = Parameters<typeof collectTrafficSourceService>[1];
+type TrafficSourceResult = Awaited<
+  ReturnType<typeof collectTrafficSourceService>
+>;
+
+interface QueryResponse {
+  readonly data: {
+    readonly columnHeaders?: readonly { readonly name?: string }[];
+    readonly rows?: readonly (readonly unknown[])[] | null;
+  };
+}
+
+const columns = [
+  "insightTrafficSourceType",
+  "views",
+  "estimatedMinutesWatched",
+  "averageViewDuration",
+] as const;
+
+const baseInput: TrafficSourceInput = {
+  channelId: "UC_test_channel",
+  endDate: "2026-06-30",
+  startDate: "2026-06-01",
+};
+
+const makeAnalyticsClient = (behavior: () => QueryResponse) => {
+  const calls: unknown[] = [];
+  const client = {
+    reports: {
+      query: (params: unknown) => {
+        calls.push(params);
+        return Promise.resolve().then(behavior);
+      },
+    },
+  };
+  return { calls, client };
+};
+
+const makeDeps = (client: unknown): TrafficSourceDeps =>
+  ({ youtubeAnalytics: client }) as unknown as TrafficSourceDeps;
+
+const makeDepsWithNoSleep = (client: unknown): TrafficSourceDeps =>
+  ({
+    sleep: () => Promise.resolve(),
+    youtubeAnalytics: client,
+  }) as unknown as TrafficSourceDeps;
+
+const gaxiosError = (message: string, response: unknown): Error =>
+  Object.assign(new Error(message), { response });
+
+const queryResponse = (
+  columnNames: readonly string[],
+  rows: readonly (readonly unknown[])[]
+): QueryResponse => ({
+  data: {
+    columnHeaders: columnNames.map((name) => ({ name })),
+    rows,
+  },
+});
+
+const canonicalResponse = (): QueryResponse =>
+  queryResponse(columns, [
+    ["YT_SEARCH", 150, 600, 240],
+    ["BROWSE", 100, 350, 210],
+    ["RELATED_VIDEO", 50, 125, 150],
+  ]);
+
+const expectOk = (result: TrafficSourceResult) => {
+  if (!result.ok) {
+    throw new Error(
+      `expected ok, got ${result.error.domain}: ${result.error.message}`
+    );
+  }
+  return result.value;
+};
+
+const findMetric = (
+  metrics: readonly {
+    readonly metric: string;
+    readonly trafficSourceType: string;
+    readonly value: number;
+  }[],
+  trafficSourceType: string,
+  metric: string
+) =>
+  metrics.find(
+    (record) =>
+      record.trafficSourceType === trafficSourceType && record.metric === metric
+  );
+
+const expectValidationError = async (
+  input: TrafficSourceInput,
+  client: unknown,
+  calls: readonly unknown[]
+) => {
+  const result = await collectTrafficSourceService(input, makeDeps(client));
+
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("expected validation failure");
+  }
+  expect(result.error.domain).toBe("validation");
+  expect(calls).toHaveLength(0);
+};
+
+describe("collectTrafficSourceService success", () => {
+  test("returns one long-format record per traffic source metric", async () => {
+    const { client } = makeAnalyticsClient(canonicalResponse);
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toHaveLength(12);
+    expect(findMetric(value.metrics, "YT_SEARCH", "views")?.value).toBe(150);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "estimatedMinutesWatched")?.value
+    ).toBe(600);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "averageViewDuration")?.value
+    ).toBe(240);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "viewSharePercent")?.value
+    ).toBe(50);
+    expect(findMetric(value.metrics, "BROWSE", "viewSharePercent")?.value).toBe(
+      33.3
+    );
+    expect(
+      findMetric(value.metrics, "RELATED_VIDEO", "viewSharePercent")?.value
+    ).toBe(16.7);
+  });
+
+  test("resolves source and metric columns by header name", async () => {
+    const { client } = makeAnalyticsClient(() =>
+      queryResponse(
+        [
+          "averageViewDuration",
+          "views",
+          "insightTrafficSourceType",
+          "estimatedMinutesWatched",
+        ],
+        [[240, 150, "YT_SEARCH", 600]]
+      )
+    );
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toContainEqual({
+      metric: "views",
+      trafficSourceType: "YT_SEARCH",
+      value: 150,
+    });
+    expect(value.metrics).toContainEqual({
+      metric: "estimatedMinutesWatched",
+      trafficSourceType: "YT_SEARCH",
+      value: 600,
+    });
+    expect(value.metrics).toContainEqual({
+      metric: "averageViewDuration",
+      trafficSourceType: "YT_SEARCH",
+      value: 240,
+    });
+    expect(value.metrics).toContainEqual({
+      metric: "viewSharePercent",
+      trafficSourceType: "YT_SEARCH",
+      value: 100,
+    });
+  });
+
+  test("returns an empty metrics array when the API omits rows", async () => {
+    const { client } = makeAnalyticsClient(() => ({
+      data: { columnHeaders: columns.map((name) => ({ name })), rows: null },
+    }));
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toEqual([]);
+  });
+
+  test("uses zero share when total views are zero", async () => {
+    const { client } = makeAnalyticsClient(() =>
+      queryResponse(columns, [["YT_SEARCH", 0, 0, 0]])
+    );
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "viewSharePercent")?.value
+    ).toBe(0);
+  });
+
+  test("aggregates duplicate traffic source rows before calculating derived metrics", async () => {
+    const { client } = makeAnalyticsClient(() =>
+      queryResponse(columns, [
+        ["YT_SEARCH", 100, 300, 180],
+        ["BROWSE", 50, 150, 180],
+        ["YT_SEARCH", 50, 300, 360],
+      ])
+    );
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toHaveLength(8);
+    expect(findMetric(value.metrics, "YT_SEARCH", "views")?.value).toBe(150);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "estimatedMinutesWatched")?.value
+    ).toBe(600);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "averageViewDuration")?.value
+    ).toBe(240);
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "viewSharePercent")?.value
+    ).toBe(75);
+    expect(findMetric(value.metrics, "BROWSE", "viewSharePercent")?.value).toBe(
+      25
+    );
+  });
+});
+
+describe("collectTrafficSourceService query construction", () => {
+  test("queries traffic source type breakdown for a channel period", async () => {
+    const { calls, client } = makeAnalyticsClient(canonicalResponse);
+
+    await collectTrafficSourceService(baseInput, makeDeps(client));
+
+    expect(calls).toHaveLength(1);
+    const params = calls[0] as Record<string, unknown>;
+    expect(params.ids).toBe("channel==UC_test_channel");
+    expect(params.startDate).toBe("2026-06-01");
+    expect(params.endDate).toBe("2026-06-30");
+    expect(params.dimensions).toBe("insightTrafficSourceType");
+    expect(params.metrics).toBe(
+      "views,estimatedMinutesWatched,averageViewDuration"
+    );
+    expect(params.sort).toBe("-views");
+    expect(params.filters).toBeUndefined();
+  });
+
+  test("passes videoId as a filter without replacing the channel ids position", async () => {
+    const { calls, client } = makeAnalyticsClient(canonicalResponse);
+
+    await collectTrafficSourceService(
+      { ...baseInput, videoId: "vid_123" },
+      makeDeps(client)
+    );
+
+    const params = calls[0] as Record<string, unknown>;
+    expect(params.ids).toBe("channel==UC_test_channel");
+    expect(params.filters).toBe("video==vid_123");
+  });
+});
+
+describe("collectTrafficSourceService validation", () => {
+  test("returns validation error for unknown input keys before calling the API", async () => {
+    const { calls, client } = makeAnalyticsClient(canonicalResponse);
+
+    await expectValidationError(
+      { ...baseInput, unexpected: true } as unknown as TrafficSourceInput,
+      client,
+      calls
+    );
+  });
+
+  test("returns validation error for non YYYY-MM-DD dates", async () => {
+    const { calls, client } = makeAnalyticsClient(canonicalResponse);
+
+    await expectValidationError(
+      { ...baseInput, startDate: "2026/06/01" } as TrafficSourceInput,
+      client,
+      calls
+    );
+  });
+
+  test("returns validation error for reversed date ranges before calling the API", async () => {
+    const { calls, client } = makeAnalyticsClient(canonicalResponse);
+
+    await expectValidationError(
+      { ...baseInput, endDate: "2026-06-01", startDate: "2026-06-30" },
+      client,
+      calls
+    );
+  });
+});
+
+describe("collectTrafficSourceService quota errors", () => {
+  test("maps a gaxios 429 into quota ServiceError and preserves Retry-After", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosError("quota exceeded", {
+        data: { error: { errors: [{ reason: "quotaExceeded" }] } },
+        headers: { "retry-after": "1800" },
+        status: 429,
+      });
+    });
+
+    const result = await collectTrafficSourceService(
+      baseInput,
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.httpStatus).toBe(429);
+      expect(result.error.retryAfterSeconds).toBe(1800);
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test("leaves Retry-After undefined when a quota response has an empty header", async () => {
+    const { client } = makeAnalyticsClient(() => {
+      throw gaxiosError("quota exceeded", {
+        data: { error: { errors: [{ reason: "quotaExceeded" }] } },
+        headers: { "retry-after": " " },
+        status: 429,
+      });
+    });
+
+    const result = await collectTrafficSourceService(
+      baseInput,
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.retryAfterSeconds).toBeUndefined();
+    }
+  });
+
+  test("preserves typed quota errors without retrying or degrading the domain", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw new QuotaExhaustedError("quota exceeded", 3600);
+    });
+
+    const result = await collectTrafficSourceService(
+      baseInput,
+      makeDepsWithNoSleep(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.retryAfterSeconds).toBe(3600);
+    }
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("collectTrafficSourceService api errors", () => {
+  test("maps a permanent 403 into api ServiceError without retrying", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosError("forbidden", {
+        data: { error: { errors: [{ reason: "insufficientPermissions" }] } },
+        status: 403,
+      });
+    });
+
+    const result = await collectTrafficSourceService(
+      baseInput,
+      makeDepsWithNoSleep(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected api failure");
+    }
+    expect(result.error.domain).toBe("api");
+    if (result.error.domain === "api") {
+      expect(result.error.httpStatus).toBe(403);
+      expect(result.error.reason).toBe("insufficientPermissions");
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test("retries a transient 500 and returns the next successful response", async () => {
+    let attempt = 0;
+    const { calls, client } = makeAnalyticsClient(() => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw gaxiosError("server error", { data: {}, status: 500 });
+      }
+      return queryResponse(columns, [["YT_SEARCH", 42, 120, 180]]);
+    });
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDepsWithNoSleep(client))
+    );
+
+    expect(value.metrics).toContainEqual({
+      metric: "views",
+      trafficSourceType: "YT_SEARCH",
+      value: 42,
+    });
+    expect(calls).toHaveLength(2);
+  });
+
+  test("returns an error Result when a metric cell is null instead of numeric", async () => {
+    const { client } = makeAnalyticsClient(() =>
+      queryResponse(columns, [["YT_SEARCH", null, 120, 180]])
+    );
+
+    const result = await collectTrafficSourceService(
+      baseInput,
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("TrafficSourceAnalyticsInput schema", () => {
+  test("parses channel-only input", () => {
+    expect(TrafficSourceAnalyticsInput.parse(baseInput)).toEqual(baseInput);
+  });
+
+  test("parses input with optional videoId", () => {
+    const input = { ...baseInput, videoId: "vid_123" };
+
+    expect(TrafficSourceAnalyticsInput.parse(input)).toEqual(input);
+  });
+
+  test("rejects unknown keys", () => {
+    expect(() =>
+      TrafficSourceAnalyticsInput.parse({ ...baseInput, extra: true })
+    ).toThrow();
+  });
+
+  test("rejects invalid date format", () => {
+    expect(() =>
+      TrafficSourceAnalyticsInput.parse({
+        ...baseInput,
+        endDate: "06/30/2026",
+      })
+    ).toThrow();
+  });
+
+  test("rejects reversed date ranges", () => {
+    expect(() =>
+      TrafficSourceAnalyticsInput.parse({
+        ...baseInput,
+        endDate: "2026-06-01",
+        startDate: "2026-06-30",
+      })
+    ).toThrow();
+  });
+});
+
+describe("TrafficSourceAnalyticsOutput schema", () => {
+  test("parses a long-format traffic source metric payload", () => {
+    const payload = {
+      metrics: [
+        { metric: "views", trafficSourceType: "YT_SEARCH", value: 150 },
+        {
+          metric: "viewSharePercent",
+          trafficSourceType: "YT_SEARCH",
+          value: 50,
+        },
+      ],
+    };
+
+    expect(TrafficSourceAnalyticsOutput.parse(payload)).toEqual(payload);
+  });
+
+  test("rejects unknown keys on metric records", () => {
+    const payload = {
+      metrics: [
+        {
+          metric: "views",
+          source: "search",
+          trafficSourceType: "YT_SEARCH",
+          value: 150,
+        },
+      ],
+    };
+
+    expect(() => TrafficSourceAnalyticsOutput.parse(payload)).toThrow();
+  });
+
+  test("rejects unsupported metric names", () => {
+    const payload = {
+      metrics: [{ metric: "likes", trafficSourceType: "YT_SEARCH", value: 10 }],
+    };
+
+    expect(() => TrafficSourceAnalyticsOutput.parse(payload)).toThrow();
+  });
+});

--- a/packages/core/test/analytics-traffic-source.test.ts
+++ b/packages/core/test/analytics-traffic-source.test.ts
@@ -205,12 +205,26 @@ describe("collectTrafficSourceService success", () => {
     ).toBe(0);
   });
 
-  test("aggregates duplicate traffic source rows before calculating derived metrics", async () => {
+  test("uses the API averageViewDuration instead of recalculating from watched minutes", async () => {
+    const { client } = makeAnalyticsClient(() =>
+      queryResponse(columns, [["YT_SEARCH", 120, 1000, 321]])
+    );
+
+    const value = expectOk(
+      await collectTrafficSourceService(baseInput, makeDeps(client))
+    );
+
+    expect(
+      findMetric(value.metrics, "YT_SEARCH", "averageViewDuration")?.value
+    ).toBe(321);
+  });
+
+  test("aggregates duplicate traffic source rows with a views-weighted average duration", async () => {
     const { client } = makeAnalyticsClient(() =>
       queryResponse(columns, [
-        ["YT_SEARCH", 100, 300, 180],
+        ["YT_SEARCH", 100, 100, 30],
         ["BROWSE", 50, 150, 180],
-        ["YT_SEARCH", 50, 300, 360],
+        ["YT_SEARCH", 50, 900, 90],
       ])
     );
 
@@ -222,10 +236,10 @@ describe("collectTrafficSourceService success", () => {
     expect(findMetric(value.metrics, "YT_SEARCH", "views")?.value).toBe(150);
     expect(
       findMetric(value.metrics, "YT_SEARCH", "estimatedMinutesWatched")?.value
-    ).toBe(600);
+    ).toBe(1000);
     expect(
       findMetric(value.metrics, "YT_SEARCH", "averageViewDuration")?.value
-    ).toBe(240);
+    ).toBe(50);
     expect(
       findMetric(value.metrics, "YT_SEARCH", "viewSharePercent")?.value
     ).toBe(75);


### PR DESCRIPTION
## Summary

## Parent

epic #727

## What to build

Traffic source 内訳 (search / browse / external / suggested) を期間集計する service。

`packages/core/src/analytics/traffic-source/` に 3 file (schema / service / index) を追加。Python `utils/traffic_source_analytics.py` Mixin の TS port (ADR-0003 で「Python を翻訳せず TS で新規記述」が確定)。

- `packages/core/src/analytics/traffic-source/schema.ts`: zod `Input` / `Output` schema。input は `channelId` (and/or `videoId`) + `startDate` / `endDate` (YYYY-MM-DD)。output は `z.array(z.object({...}))` で metric 行
- `packages/core/src/analytics/traffic-source/service.ts`: `collectTrafficSourceService(input, deps: { youtubeAnalytics })` が Promise<Result<...>>
- 内部集計は `Array.prototype.reduce` / `Object.groupBy` 等 stdlib で、arquero 等を導入しない
- bun:test: mocked youtubeAnalytics で input/output schema parse + 主要集計が正しい

## Acceptance criteria

- [ ] ADR-0003 の canonical template に準拠
- [ ] service は `Promise<Result<T, ServiceError>>` を返す (内部 throw OK、境界で `toServiceError` 経由)
- [ ] schema は zod (`z.object().strict()`) + `z.infer` で型導出 (`interface` 並書なし)
- [ ] service が `deps: { youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics }` を受け取る
- [ ] output schema の `metrics` 配列が 1 メトリクスごとに 1 record
- [ ] arquero / danfo 等 dataframe lib を core に追加しない
- [ ] bun:test: success path (mocked YouTube Analytics API) と quota error path (toServiceError 経由で domain="quota")

## Blocked by

- #826 (buildYouTubeAnalyticsClient + Result + ServiceError)
- #825 (config の zod 化)

## Refs

- ADR 0003 (#820): docs/adr/0003-service-boundary-contracts.md
- ADR 0002: docs/adr/0002-service-first-architecture.md
- Epic: #727

## Retry 規約 (2026-06-12 追記、ADR レビュー所見 4)

API retry / backoff を本 issue 内で自前実装しないこと。`@youtube-automation/core` の `withRetry` (#959) を使う。quota (429) は retry せず `domain: "quota"` + `retryAfterSeconds` の Result で返す (ADR-0003)。

## Execution Report

Workflow `default` completed successfully.

Closes #832