### PR TITLE
[#833] issue-833-ts-rewrite-phase2-an

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./analytics/audience": "./src/analytics/audience/index.ts",
     "./analytics/channel": "./src/analytics/channel/index.ts",
     "./analytics/video": "./src/analytics/video/index.ts",
     "./analytics/video-daily": "./src/analytics/video-daily/index.ts",

--- a/packages/core/src/analytics/audience/index.ts
+++ b/packages/core/src/analytics/audience/index.ts
@@ -1,0 +1,2 @@
+export { AudienceAnalyticsInput, AudienceAnalyticsOutput } from "./schema.ts";
+export { collectAudienceService } from "./service.ts";

--- a/packages/core/src/analytics/audience/schema.ts
+++ b/packages/core/src/analytics/audience/schema.ts
@@ -15,9 +15,11 @@ export const AUDIENCE_SUBSCRIBED_STATUS_METRICS = [
   "viewSharePercent",
 ] as const;
 
-const isoDate = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/u, "must be a YYYY-MM-DD date");
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
+const YOUTUBE_CHANNEL_ID = /^UC[A-Za-z0-9_-]{22}$/u;
+const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/u;
+
+const isoDate = z.string().regex(ISO_DATE, "must be a YYYY-MM-DD date");
 const AUDIENCE_SEGMENTS = [
   "ageGroup",
   "gender",
@@ -52,12 +54,21 @@ const METRICS_BY_SEGMENT: Record<AudienceSegment, readonly string[]> = {
 
 export const AudienceAnalyticsInput = z
   .object({
-    channelId: z.string().min(1),
+    channelId: z
+      .string()
+      .regex(YOUTUBE_CHANNEL_ID, "must be a valid YouTube channel ID"),
     endDate: isoDate,
     startDate: isoDate,
-    videoId: z.string().min(1).optional(),
+    videoId: z
+      .string()
+      .regex(YOUTUBE_VIDEO_ID, "must be a valid YouTube video ID")
+      .optional(),
   })
-  .strict();
+  .strict()
+  .refine((input) => input.startDate <= input.endDate, {
+    message: "startDate must be on or before endDate",
+    path: ["startDate"],
+  });
 export type AudienceAnalyticsInput = z.infer<typeof AudienceAnalyticsInput>;
 
 const audienceMetricRecord = z

--- a/packages/core/src/analytics/audience/schema.ts
+++ b/packages/core/src/analytics/audience/schema.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+export const AUDIENCE_DEMOGRAPHIC_METRICS = ["viewerPercentage"] as const;
+export const AUDIENCE_COUNTRY_METRICS = [
+  "views",
+  "estimatedMinutesWatched",
+  "averageViewDuration",
+  "subscribersGained",
+  "viewSharePercent",
+] as const;
+export const AUDIENCE_SUBSCRIBED_STATUS_METRICS = [
+  "views",
+  "estimatedMinutesWatched",
+  "averageViewDuration",
+  "viewSharePercent",
+] as const;
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/u, "must be a YYYY-MM-DD date");
+const AUDIENCE_SEGMENTS = [
+  "ageGroup",
+  "gender",
+  "country",
+  "subscribedStatus",
+] as const;
+type AudienceSegment = (typeof AUDIENCE_SEGMENTS)[number];
+const AUDIENCE_METRICS = [
+  ...AUDIENCE_DEMOGRAPHIC_METRICS,
+  ...AUDIENCE_COUNTRY_METRICS,
+  ...AUDIENCE_SUBSCRIBED_STATUS_METRICS,
+] as const;
+
+const isAudienceSegment = (value: string): boolean =>
+  AUDIENCE_SEGMENTS.some((segment) => segment === value);
+const isAudienceMetric = (value: string): boolean =>
+  AUDIENCE_METRICS.some((metric) => metric === value);
+const resolveAudienceSegment = (value: string): AudienceSegment | undefined =>
+  AUDIENCE_SEGMENTS.find((segment) => segment === value);
+const SEGMENT_FIELD_NAMES = [
+  "ageGroup",
+  "country",
+  "gender",
+  "subscribedStatus",
+] as const;
+const METRICS_BY_SEGMENT: Record<AudienceSegment, readonly string[]> = {
+  ageGroup: AUDIENCE_DEMOGRAPHIC_METRICS,
+  country: AUDIENCE_COUNTRY_METRICS,
+  gender: AUDIENCE_DEMOGRAPHIC_METRICS,
+  subscribedStatus: AUDIENCE_SUBSCRIBED_STATUS_METRICS,
+};
+
+export const AudienceAnalyticsInput = z
+  .object({
+    channelId: z.string().min(1),
+    endDate: isoDate,
+    startDate: isoDate,
+    videoId: z.string().min(1).optional(),
+  })
+  .strict();
+export type AudienceAnalyticsInput = z.infer<typeof AudienceAnalyticsInput>;
+
+const audienceMetricRecord = z
+  .object({
+    ageGroup: z.string().optional(),
+    country: z.string().optional(),
+    gender: z.string().optional(),
+    metric: z.string().refine(isAudienceMetric, "unsupported audience metric"),
+    segment: z
+      .string()
+      .refine(isAudienceSegment, "unsupported audience segment"),
+    subscribedStatus: z.string().optional(),
+    value: z.number(),
+  })
+  .strict()
+  .superRefine((record, context) => {
+    const segment = resolveAudienceSegment(record.segment);
+    if (segment === undefined) {
+      return;
+    }
+    const allowedMetrics = METRICS_BY_SEGMENT[segment];
+    if (!allowedMetrics.some((metric) => metric === record.metric)) {
+      context.addIssue({
+        code: "custom",
+        message: `${record.metric} is not valid for ${segment}`,
+        path: ["metric"],
+      });
+    }
+    for (const fieldName of SEGMENT_FIELD_NAMES) {
+      const value = record[fieldName];
+      if (fieldName === segment && value === undefined) {
+        context.addIssue({
+          code: "custom",
+          message: `missing ${segment} value`,
+          path: [segment],
+        });
+      }
+      if (fieldName !== segment && value !== undefined) {
+        context.addIssue({
+          code: "custom",
+          message: `${fieldName} is not valid for ${segment}`,
+          path: [fieldName],
+        });
+      }
+    }
+  });
+
+export const AudienceAnalyticsOutput = z
+  .object({
+    metrics: z.array(audienceMetricRecord),
+  })
+  .strict();
+export type AudienceAnalyticsOutput = z.infer<typeof AudienceAnalyticsOutput>;

--- a/packages/core/src/analytics/audience/service.ts
+++ b/packages/core/src/analytics/audience/service.ts
@@ -1,0 +1,369 @@
+import type { youtubeAnalytics_v2 } from "googleapis";
+
+import { isRecord } from "../../../internal/guards.ts";
+import {
+  QuotaExhaustedError,
+  toServiceError,
+  YouTubeAPIError,
+} from "../../errors.ts";
+import type { ServiceError } from "../../errors.ts";
+import { err, ok } from "../../result.ts";
+import type { Result } from "../../result.ts";
+import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import {
+  AUDIENCE_COUNTRY_METRICS,
+  AUDIENCE_DEMOGRAPHIC_METRICS,
+  AUDIENCE_SUBSCRIBED_STATUS_METRICS,
+  AudienceAnalyticsInput,
+  AudienceAnalyticsOutput,
+} from "./schema.ts";
+
+const QUERY_CONTEXT = "audience analytics query";
+const CHANNEL_ID_PREFIX = "channel==";
+const VIDEO_FILTER_PREFIX = "video==";
+const AGE_GENDER_DIMENSIONS = "ageGroup,gender";
+const COUNTRY_DIMENSION = "country";
+const SUBSCRIBED_STATUS_DIMENSION = "subscribedStatus";
+const VIEWER_PERCENTAGE_METRIC = "viewerPercentage";
+const VIEWS_METRIC = "views";
+const VIEW_SHARE_PERCENT_METRIC = "viewSharePercent";
+const HTTP_SERVER_ERROR_MIN = 500;
+
+type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
+type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
+type ColumnHeaders = NonNullable<QueryResponse["columnHeaders"]>;
+type AudienceQueryParams = readonly [QueryParams, QueryParams, QueryParams];
+type DemographicMetricRecord =
+  | {
+      readonly ageGroup: string;
+      readonly metric: typeof VIEWER_PERCENTAGE_METRIC;
+      readonly segment: "ageGroup";
+      readonly value: number;
+    }
+  | {
+      readonly gender: string;
+      readonly metric: typeof VIEWER_PERCENTAGE_METRIC;
+      readonly segment: "gender";
+      readonly value: number;
+    };
+interface CountryMetricRecord {
+  readonly country: string;
+  readonly metric: (typeof AUDIENCE_COUNTRY_METRICS)[number];
+  readonly segment: typeof COUNTRY_DIMENSION;
+  readonly value: number;
+}
+interface SubscribedStatusMetricRecord {
+  readonly metric: (typeof AUDIENCE_SUBSCRIBED_STATUS_METRICS)[number];
+  readonly segment: typeof SUBSCRIBED_STATUS_DIMENSION;
+  readonly subscribedStatus: string;
+  readonly value: number;
+}
+type AudienceMetricRecord =
+  | DemographicMetricRecord
+  | CountryMetricRecord
+  | SubscribedStatusMetricRecord;
+
+const parseRetryAfterSeconds = (error: unknown): number | undefined => {
+  if (
+    !(
+      isRecord(error) &&
+      isRecord(error.response) &&
+      isRecord(error.response.headers)
+    )
+  ) {
+    return undefined;
+  }
+  const seconds = Number(error.response.headers["retry-after"]);
+  return Number.isFinite(seconds) ? seconds : undefined;
+};
+
+const toQueryError = (error: unknown): YouTubeAPIError => {
+  if (error instanceof YouTubeAPIError) {
+    return error;
+  }
+  const apiError = YouTubeAPIError.fromGaxiosError(error, QUERY_CONTEXT);
+  if (apiError.statusCode === 429) {
+    return new QuotaExhaustedError(
+      apiError.message,
+      parseRetryAfterSeconds(error)
+    );
+  }
+  return apiError;
+};
+
+const shouldRetryQuery = (error: unknown): boolean => {
+  if (!defaultShouldRetry(error)) {
+    return false;
+  }
+  if (error instanceof YouTubeAPIError) {
+    return (
+      error.statusCode === undefined ||
+      error.statusCode >= HTTP_SERVER_ERROR_MIN
+    );
+  }
+  return true;
+};
+
+const queryAudienceReport = async (
+  client: youtubeAnalytics_v2.Youtubeanalytics,
+  params: QueryParams
+): Promise<QueryResponse> => {
+  try {
+    const response = await client.reports.query(params);
+    return response.data;
+  } catch (error) {
+    throw toQueryError(error);
+  }
+};
+
+const baseQueryParams = (input: AudienceAnalyticsInput): QueryParams => ({
+  endDate: input.endDate,
+  ...(input.videoId
+    ? { filters: `${VIDEO_FILTER_PREFIX}${input.videoId}` }
+    : {}),
+  ids: `${CHANNEL_ID_PREFIX}${input.channelId}`,
+  startDate: input.startDate,
+});
+
+const buildAudienceQueries = (
+  input: AudienceAnalyticsInput
+): AudienceQueryParams => {
+  const base = baseQueryParams(input);
+  return [
+    {
+      ...base,
+      dimensions: AGE_GENDER_DIMENSIONS,
+      metrics: AUDIENCE_DEMOGRAPHIC_METRICS.join(","),
+    },
+    {
+      ...base,
+      dimensions: COUNTRY_DIMENSION,
+      metrics: AUDIENCE_COUNTRY_METRICS.filter(
+        (metric) => metric !== VIEW_SHARE_PERCENT_METRIC
+      ).join(","),
+      sort: "-views",
+    },
+    {
+      ...base,
+      dimensions: SUBSCRIBED_STATUS_DIMENSION,
+      metrics: AUDIENCE_SUBSCRIBED_STATUS_METRICS.filter(
+        (metric) => metric !== VIEW_SHARE_PERCENT_METRIC
+      ).join(","),
+      sort: "-views",
+    },
+  ];
+};
+
+const resolveColumnIndex = (headers: ColumnHeaders, name: string): number => {
+  const index = headers.findIndex((header) => header.name === name);
+  if (index === -1) {
+    throw new Error(
+      `${QUERY_CONTEXT}: response is missing the "${name}" column`
+    );
+  }
+  return index;
+};
+
+const requireHeadersForRows = (data: QueryResponse): ColumnHeaders => {
+  if (!data.columnHeaders) {
+    throw new Error(`${QUERY_CONTEXT}: response has rows but no columnHeaders`);
+  }
+  return data.columnHeaders;
+};
+
+const readStringCell = (row: readonly unknown[], index: number): string => {
+  const value = row[index];
+  if (typeof value !== "string") {
+    throw new TypeError(`${QUERY_CONTEXT}: response cell is not a string`);
+  }
+  return value;
+};
+
+const readNumberCell = (row: readonly unknown[], index: number): number => {
+  const value = Number(row[index]);
+  if (!Number.isFinite(value)) {
+    throw new TypeError(
+      `${QUERY_CONTEXT}: response cell is not a finite number`
+    );
+  }
+  return value;
+};
+
+const addToTotals = (
+  totals: Map<string, number>,
+  key: string,
+  value: number
+) => {
+  const current = totals.get(key);
+  totals.set(key, (current === undefined ? 0 : current) + value);
+};
+
+const toTotalRecords = (
+  totals: ReadonlyMap<string, number>,
+  segment: "ageGroup" | "gender"
+): AudienceMetricRecord[] =>
+  [...totals.entries()].map(([key, value]) =>
+    segment === "ageGroup"
+      ? {
+          ageGroup: key,
+          metric: VIEWER_PERCENTAGE_METRIC,
+          segment,
+          value,
+        }
+      : {
+          gender: key,
+          metric: VIEWER_PERCENTAGE_METRIC,
+          segment,
+          value,
+        }
+  );
+
+const reshapeDemographics = (data: QueryResponse): AudienceMetricRecord[] => {
+  if (!data.rows) {
+    return [];
+  }
+  const headers = requireHeadersForRows(data);
+  const ageGroupIndex = resolveColumnIndex(headers, "ageGroup");
+  const genderIndex = resolveColumnIndex(headers, "gender");
+  const valueIndex = resolveColumnIndex(headers, VIEWER_PERCENTAGE_METRIC);
+  const ageGroupTotals = new Map<string, number>();
+  const genderTotals = new Map<string, number>();
+  for (const row of data.rows) {
+    const value = readNumberCell(row, valueIndex);
+    addToTotals(ageGroupTotals, readStringCell(row, ageGroupIndex), value);
+    addToTotals(genderTotals, readStringCell(row, genderIndex), value);
+  }
+  return [
+    ...toTotalRecords(ageGroupTotals, "ageGroup"),
+    ...toTotalRecords(genderTotals, "gender"),
+  ];
+};
+
+const totalViews = (records: readonly AudienceMetricRecord[]): number =>
+  records
+    .filter((record) => record.metric === VIEWS_METRIC)
+    .reduce((total, record) => total + record.value, 0);
+
+const viewSharePercent = (views: number, total: number): number => {
+  if (total === 0) {
+    return 0;
+  }
+  return Math.round((views / total) * 1000) / 10;
+};
+
+const reshapeCountry = (data: QueryResponse): AudienceMetricRecord[] => {
+  if (!data.rows) {
+    return [];
+  }
+  const headers = requireHeadersForRows(data);
+  const countryIndex = resolveColumnIndex(headers, COUNTRY_DIMENSION);
+  const metricColumns = AUDIENCE_COUNTRY_METRICS.filter(
+    (metric) => metric !== VIEW_SHARE_PERCENT_METRIC
+  ).map((metric) => ({ index: resolveColumnIndex(headers, metric), metric }));
+  const records = data.rows.flatMap((row) => {
+    const country = readStringCell(row, countryIndex);
+    return metricColumns.map(
+      (column): CountryMetricRecord => ({
+        country,
+        metric: column.metric,
+        segment: COUNTRY_DIMENSION,
+        value: readNumberCell(row, column.index),
+      })
+    );
+  });
+  const viewsTotal = totalViews(records);
+  return [
+    ...records,
+    ...records
+      .filter((record) => record.metric === VIEWS_METRIC)
+      .map(
+        (record): CountryMetricRecord => ({
+          country: record.country,
+          metric: VIEW_SHARE_PERCENT_METRIC,
+          segment: COUNTRY_DIMENSION,
+          value: viewSharePercent(record.value, viewsTotal),
+        })
+      ),
+  ];
+};
+
+const reshapeSubscribedStatus = (
+  data: QueryResponse
+): AudienceMetricRecord[] => {
+  if (!data.rows) {
+    return [];
+  }
+  const headers = requireHeadersForRows(data);
+  const statusIndex = resolveColumnIndex(headers, SUBSCRIBED_STATUS_DIMENSION);
+  const metricColumns = AUDIENCE_SUBSCRIBED_STATUS_METRICS.filter(
+    (metric) => metric !== VIEW_SHARE_PERCENT_METRIC
+  ).map((metric) => ({ index: resolveColumnIndex(headers, metric), metric }));
+  const records = data.rows.flatMap((row) => {
+    const subscribedStatus = readStringCell(row, statusIndex);
+    return metricColumns.map(
+      (column): SubscribedStatusMetricRecord => ({
+        metric: column.metric,
+        segment: SUBSCRIBED_STATUS_DIMENSION,
+        subscribedStatus,
+        value: readNumberCell(row, column.index),
+      })
+    );
+  });
+  const viewsTotal = totalViews(records);
+  return [
+    ...records,
+    ...records
+      .filter((record) => record.metric === VIEWS_METRIC)
+      .map(
+        (record): SubscribedStatusMetricRecord => ({
+          metric: VIEW_SHARE_PERCENT_METRIC,
+          segment: SUBSCRIBED_STATUS_DIMENSION,
+          subscribedStatus: record.subscribedStatus,
+          value: viewSharePercent(record.value, viewsTotal),
+        })
+      ),
+  ];
+};
+
+const runAudienceQueries = async (
+  client: youtubeAnalytics_v2.Youtubeanalytics,
+  paramsList: AudienceQueryParams
+): Promise<readonly [QueryResponse, QueryResponse, QueryResponse]> => {
+  const demographics = await withRetry(
+    () => queryAudienceReport(client, paramsList[0]),
+    { shouldRetry: shouldRetryQuery }
+  );
+  const country = await withRetry(
+    () => queryAudienceReport(client, paramsList[1]),
+    { shouldRetry: shouldRetryQuery }
+  );
+  const subscribedStatus = await withRetry(
+    () => queryAudienceReport(client, paramsList[2]),
+    { shouldRetry: shouldRetryQuery }
+  );
+  return [demographics, country, subscribedStatus];
+};
+
+export const collectAudienceService = async (
+  input: AudienceAnalyticsInput,
+  deps: { youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics }
+): Promise<Result<AudienceAnalyticsOutput, ServiceError>> => {
+  try {
+    const request = AudienceAnalyticsInput.parse(input);
+    const [demographics, country, subscribedStatus] = await runAudienceQueries(
+      deps.youtubeAnalytics,
+      buildAudienceQueries(request)
+    );
+    return ok(
+      AudienceAnalyticsOutput.parse({
+        metrics: [
+          ...reshapeDemographics(demographics),
+          ...reshapeCountry(country),
+          ...reshapeSubscribedStatus(subscribedStatus),
+        ],
+      })
+    );
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/src/analytics/audience/service.ts
+++ b/packages/core/src/analytics/audience/service.ts
@@ -10,6 +10,7 @@ import type { ServiceError } from "../../errors.ts";
 import { err, ok } from "../../result.ts";
 import type { Result } from "../../result.ts";
 import { defaultShouldRetry, withRetry } from "../../retry.ts";
+import type { SleepMs } from "../../retry.ts";
 import {
   AUDIENCE_COUNTRY_METRICS,
   AUDIENCE_DEMOGRAPHIC_METRICS,
@@ -33,6 +34,10 @@ type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
 type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
 type ColumnHeaders = NonNullable<QueryResponse["columnHeaders"]>;
 type AudienceQueryParams = readonly [QueryParams, QueryParams, QueryParams];
+interface AudienceAnalyticsDeps {
+  readonly sleep?: SleepMs;
+  readonly youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics;
+}
 type DemographicMetricRecord =
   | {
       readonly ageGroup: string;
@@ -73,7 +78,14 @@ const parseRetryAfterSeconds = (error: unknown): number | undefined => {
   ) {
     return undefined;
   }
-  const seconds = Number(error.response.headers["retry-after"]);
+  const raw = error.response.headers["retry-after"];
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return undefined;
+  }
+  if (!/^\d+$/u.test(raw)) {
+    return undefined;
+  }
+  const seconds = Number(raw);
   return Number.isFinite(seconds) ? seconds : undefined;
 };
 
@@ -327,32 +339,34 @@ const reshapeSubscribedStatus = (
 
 const runAudienceQueries = async (
   client: youtubeAnalytics_v2.Youtubeanalytics,
-  paramsList: AudienceQueryParams
+  paramsList: AudienceQueryParams,
+  sleep: SleepMs | undefined
 ): Promise<readonly [QueryResponse, QueryResponse, QueryResponse]> => {
   const demographics = await withRetry(
     () => queryAudienceReport(client, paramsList[0]),
-    { shouldRetry: shouldRetryQuery }
+    { shouldRetry: shouldRetryQuery, sleep }
   );
   const country = await withRetry(
     () => queryAudienceReport(client, paramsList[1]),
-    { shouldRetry: shouldRetryQuery }
+    { shouldRetry: shouldRetryQuery, sleep }
   );
   const subscribedStatus = await withRetry(
     () => queryAudienceReport(client, paramsList[2]),
-    { shouldRetry: shouldRetryQuery }
+    { shouldRetry: shouldRetryQuery, sleep }
   );
   return [demographics, country, subscribedStatus];
 };
 
 export const collectAudienceService = async (
   input: AudienceAnalyticsInput,
-  deps: { youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics }
+  deps: AudienceAnalyticsDeps
 ): Promise<Result<AudienceAnalyticsOutput, ServiceError>> => {
   try {
     const request = AudienceAnalyticsInput.parse(input);
     const [demographics, country, subscribedStatus] = await runAudienceQueries(
       deps.youtubeAnalytics,
-      buildAudienceQueries(request)
+      buildAudienceQueries(request),
+      deps.sleep
     );
     return ok(
       AudienceAnalyticsOutput.parse({

--- a/packages/core/test/analytics-audience.test.ts
+++ b/packages/core/test/analytics-audience.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AudienceAnalyticsInput,
+  AudienceAnalyticsOutput,
+  collectAudienceService,
+} from "@youtube-automation/core/analytics/audience";
+
+type AudienceInput = Parameters<typeof collectAudienceService>[0];
+type AudienceDeps = Parameters<typeof collectAudienceService>[1];
+type AudienceResult = Awaited<ReturnType<typeof collectAudienceService>>;
+
+interface QueryResponse {
+  readonly data: {
+    readonly columnHeaders?: readonly { readonly name?: string }[];
+    readonly rows?: readonly (readonly unknown[])[];
+  };
+}
+
+type QueryBehavior = (params: Record<string, unknown>) => QueryResponse;
+
+const makeAnalyticsClient = (behavior: QueryBehavior) => {
+  const calls: Record<string, unknown>[] = [];
+  const client = {
+    reports: {
+      query: (params: Record<string, unknown>) => {
+        calls.push(params);
+        return Promise.resolve().then(() => behavior(params));
+      },
+    },
+  };
+  return { calls, client };
+};
+
+const makeDeps = (client: unknown): AudienceDeps =>
+  ({ youtubeAnalytics: client }) as unknown as AudienceDeps;
+
+const queryResponse = (
+  columns: readonly string[],
+  rows: readonly (readonly unknown[])[]
+): QueryResponse => ({
+  data: {
+    columnHeaders: columns.map((name) => ({ name })),
+    rows,
+  },
+});
+
+const gaxiosQuotaError = (): Error =>
+  Object.assign(new Error("quota exceeded"), {
+    response: {
+      data: { error: { errors: [{ reason: "quotaExceeded" }] } },
+      headers: { "retry-after": "90" },
+      status: 429,
+    },
+  });
+
+const baseInput: AudienceInput = {
+  channelId: "UC_test_channel",
+  endDate: "2026-06-14",
+  startDate: "2026-06-01",
+};
+
+const audienceResponses = (params: Record<string, unknown>): QueryResponse => {
+  switch (params.dimensions) {
+    case "ageGroup,gender": {
+      return queryResponse(
+        ["ageGroup", "gender", "viewerPercentage"],
+        [
+          ["age18-24", "male", 10],
+          ["age18-24", "female", 15],
+          ["age25-34", "male", 20],
+          ["age25-34", "female", 5],
+        ]
+      );
+    }
+    case "country": {
+      return queryResponse(
+        [
+          "country",
+          "views",
+          "estimatedMinutesWatched",
+          "averageViewDuration",
+          "subscribersGained",
+        ],
+        [
+          ["JP", 80, 400, 300, 8],
+          ["US", 20, 100, 240, 2],
+        ]
+      );
+    }
+    case "subscribedStatus": {
+      return queryResponse(
+        [
+          "subscribedStatus",
+          "views",
+          "estimatedMinutesWatched",
+          "averageViewDuration",
+        ],
+        [
+          ["SUBSCRIBED", 60, 360, 300],
+          ["UNSUBSCRIBED", 40, 140, 210],
+        ]
+      );
+    }
+    default: {
+      throw new Error(`unexpected dimensions: ${String(params.dimensions)}`);
+    }
+  }
+};
+
+const expectOk = (result: AudienceResult) => {
+  if (!result.ok) {
+    throw new Error(
+      `expected ok, got ${result.error.domain}: ${result.error.message}`
+    );
+  }
+  return result.value;
+};
+
+describe("AudienceAnalyticsInput schema", () => {
+  test("parses channel-wide input with an optional videoId", () => {
+    const input = { ...baseInput, videoId: "vidA" };
+
+    expect(AudienceAnalyticsInput.parse(input)).toEqual(input);
+  });
+
+  test("rejects unknown input keys", () => {
+    expect(() =>
+      AudienceAnalyticsInput.parse({ ...baseInput, extra: true })
+    ).toThrow();
+  });
+
+  test("rejects non YYYY-MM-DD dates", () => {
+    expect(() =>
+      AudienceAnalyticsInput.parse({ ...baseInput, startDate: "2026/06/01" })
+    ).toThrow();
+  });
+
+  test("rejects blank channel and video identifiers", () => {
+    expect(() =>
+      AudienceAnalyticsInput.parse({ ...baseInput, channelId: "" })
+    ).toThrow();
+    expect(() =>
+      AudienceAnalyticsInput.parse({ ...baseInput, videoId: "" })
+    ).toThrow();
+  });
+});
+
+describe("AudienceAnalyticsOutput schema", () => {
+  test("parses one metric per record in long format", () => {
+    const payload = {
+      metrics: [
+        {
+          ageGroup: "age18-24",
+          metric: "viewerPercentage",
+          segment: "ageGroup",
+          value: 25,
+        },
+        {
+          country: "JP",
+          metric: "views",
+          segment: "country",
+          value: 80,
+        },
+      ],
+    };
+
+    expect(AudienceAnalyticsOutput.parse(payload)).toEqual(payload);
+  });
+
+  test("rejects wide metric records and unknown output keys", () => {
+    expect(() =>
+      AudienceAnalyticsOutput.parse({
+        metrics: [
+          {
+            country: "JP",
+            metric: "countryMetrics",
+            segment: "country",
+            value: 80,
+            views: 80,
+          },
+        ],
+      })
+    ).toThrow();
+  });
+
+  test("rejects segment and metric mismatches", () => {
+    expect(() =>
+      AudienceAnalyticsOutput.parse({
+        metrics: [
+          {
+            ageGroup: "age18-24",
+            metric: "views",
+            segment: "ageGroup",
+            value: 25,
+          },
+        ],
+      })
+    ).toThrow();
+    expect(() =>
+      AudienceAnalyticsOutput.parse({
+        metrics: [
+          {
+            country: "JP",
+            metric: "viewerPercentage",
+            segment: "country",
+            value: 80,
+          },
+        ],
+      })
+    ).toThrow();
+  });
+
+  test("rejects fields from a different segment", () => {
+    expect(() =>
+      AudienceAnalyticsOutput.parse({
+        metrics: [
+          {
+            ageGroup: "age18-24",
+            country: "JP",
+            metric: "views",
+            segment: "country",
+            value: 80,
+          },
+        ],
+      })
+    ).toThrow();
+  });
+});
+
+describe("collectAudienceService success", () => {
+  test("collects demographics, country, and subscriber breakdown as long metrics", async () => {
+    const { client } = makeAnalyticsClient(audienceResponses);
+
+    const value = expectOk(
+      await collectAudienceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toContainEqual({
+      ageGroup: "age18-24",
+      metric: "viewerPercentage",
+      segment: "ageGroup",
+      value: 25,
+    });
+    expect(value.metrics).toContainEqual({
+      gender: "male",
+      metric: "viewerPercentage",
+      segment: "gender",
+      value: 30,
+    });
+    expect(value.metrics).toContainEqual({
+      country: "JP",
+      metric: "views",
+      segment: "country",
+      value: 80,
+    });
+    expect(value.metrics).toContainEqual({
+      country: "JP",
+      metric: "viewSharePercent",
+      segment: "country",
+      value: 80,
+    });
+    expect(value.metrics).toContainEqual({
+      metric: "viewSharePercent",
+      segment: "subscribedStatus",
+      subscribedStatus: "SUBSCRIBED",
+      value: 60,
+    });
+
+    expect(value.metrics.some((metric) => "views" in metric)).toBe(false);
+  });
+
+  test("uses the documented query contract for all audience dimensions", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(baseInput, makeDeps(client));
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(3);
+    expect(calls.map((call) => call.dimensions)).toEqual([
+      "ageGroup,gender",
+      "country",
+      "subscribedStatus",
+    ]);
+    const [demographicCall, countryCall, subscribedStatusCall] = calls;
+    if (!demographicCall || !countryCall || !subscribedStatusCall) {
+      throw new Error("expected three audience query calls");
+    }
+    expect(demographicCall.metrics).toBe("viewerPercentage");
+    expect(countryCall.metrics).toBe(
+      "views,estimatedMinutesWatched,averageViewDuration,subscribersGained"
+    );
+    expect(countryCall.sort).toBe("-views");
+    expect(subscribedStatusCall.metrics).toBe(
+      "views,estimatedMinutesWatched,averageViewDuration"
+    );
+    expect(subscribedStatusCall.sort).toBe("-views");
+    for (const call of calls) {
+      expect(call.ids).toBe("channel==UC_test_channel");
+      expect(call.startDate).toBe("2026-06-01");
+      expect(call.endDate).toBe("2026-06-14");
+      expect(call.filters).toBeUndefined();
+    }
+  });
+
+  test("rounds country and subscriber view share percentages to one decimal place", async () => {
+    const { client } = makeAnalyticsClient((params) => {
+      switch (params.dimensions) {
+        case "ageGroup,gender": {
+          return queryResponse(["ageGroup", "gender", "viewerPercentage"], []);
+        }
+        case "country": {
+          return queryResponse(
+            [
+              "country",
+              "views",
+              "estimatedMinutesWatched",
+              "averageViewDuration",
+              "subscribersGained",
+            ],
+            [
+              ["JP", 1, 10, 30, 0],
+              ["US", 2, 20, 40, 0],
+            ]
+          );
+        }
+        case "subscribedStatus": {
+          return queryResponse(
+            [
+              "subscribedStatus",
+              "views",
+              "estimatedMinutesWatched",
+              "averageViewDuration",
+            ],
+            [
+              ["SUBSCRIBED", 1, 10, 30],
+              ["UNSUBSCRIBED", 2, 20, 40],
+            ]
+          );
+        }
+        default: {
+          throw new Error(
+            `unexpected dimensions: ${String(params.dimensions)}`
+          );
+        }
+      }
+    });
+
+    const value = expectOk(
+      await collectAudienceService(baseInput, makeDeps(client))
+    );
+
+    expect(value.metrics).toContainEqual({
+      country: "JP",
+      metric: "viewSharePercent",
+      segment: "country",
+      value: 33.3,
+    });
+    expect(value.metrics).toContainEqual({
+      metric: "viewSharePercent",
+      segment: "subscribedStatus",
+      subscribedStatus: "SUBSCRIBED",
+      value: 33.3,
+    });
+  });
+
+  test("adds a video filter to every query when videoId is supplied", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(
+      { ...baseInput, videoId: "vidA" },
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(3);
+    for (const call of calls) {
+      expect(call.ids).toBe("channel==UC_test_channel");
+      expect(call.filters).toBe("video==vidA");
+    }
+  });
+});
+
+describe("collectAudienceService error paths", () => {
+  test("returns a quota ServiceError for a 429 without retrying", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosQuotaError();
+    });
+
+    const result = await collectAudienceService(baseInput, makeDeps(client));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.retryAfterSeconds).toBe(90);
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test("validates input before making an API request", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(
+      { ...baseInput, unexpected: true } as unknown as AudienceInput,
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(result.error.domain).toBe("validation");
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/core/test/analytics-audience.test.ts
+++ b/packages/core/test/analytics-audience.test.ts
@@ -18,6 +18,7 @@ interface QueryResponse {
 }
 
 type QueryBehavior = (params: Record<string, unknown>) => QueryResponse;
+type Sleep = (ms: number) => Promise<void>;
 
 const makeAnalyticsClient = (behavior: QueryBehavior) => {
   const calls: Record<string, unknown>[] = [];
@@ -32,8 +33,13 @@ const makeAnalyticsClient = (behavior: QueryBehavior) => {
   return { calls, client };
 };
 
-const makeDeps = (client: unknown): AudienceDeps =>
-  ({ youtubeAnalytics: client }) as unknown as AudienceDeps;
+const noSleep: Sleep = () => Promise.resolve();
+
+const makeDeps = (client: unknown, sleep?: Sleep): AudienceDeps =>
+  ({
+    youtubeAnalytics: client,
+    ...(sleep === undefined ? {} : { sleep }),
+  }) as unknown as AudienceDeps;
 
 const queryResponse = (
   columns: readonly string[],
@@ -54,11 +60,32 @@ const gaxiosQuotaError = (): Error =>
     },
   });
 
+const gaxiosQuotaErrorWithRetryAfter = (retryAfter: string): Error =>
+  Object.assign(new Error("quota exceeded"), {
+    response: {
+      data: { error: { errors: [{ reason: "quotaExceeded" }] } },
+      headers: { "retry-after": retryAfter },
+      status: 429,
+    },
+  });
+
+const gaxiosStatusError = (status: number): Error =>
+  Object.assign(new Error(`analytics api failed with ${status}`), {
+    response: { status },
+  });
+
+const gaxiosUnknownStatusError = (): Error =>
+  Object.assign(new Error("analytics api failed with unknown status"), {
+    response: {},
+  });
+
 const baseInput: AudienceInput = {
-  channelId: "UC_test_channel",
+  channelId: "UCabcdefghijklmnopqrstuv",
   endDate: "2026-06-14",
   startDate: "2026-06-01",
 };
+
+const validVideoId = "dQw4w9WgXcQ";
 
 const audienceResponses = (params: Record<string, unknown>): QueryResponse => {
   switch (params.dimensions) {
@@ -119,7 +146,7 @@ const expectOk = (result: AudienceResult) => {
 
 describe("AudienceAnalyticsInput schema", () => {
   test("parses channel-wide input with an optional videoId", () => {
-    const input = { ...baseInput, videoId: "vidA" };
+    const input = { ...baseInput, videoId: validVideoId };
 
     expect(AudienceAnalyticsInput.parse(input)).toEqual(input);
   });
@@ -142,6 +169,44 @@ describe("AudienceAnalyticsInput schema", () => {
     ).toThrow();
     expect(() =>
       AudienceAnalyticsInput.parse({ ...baseInput, videoId: "" })
+    ).toThrow();
+  });
+
+  test("rejects channel identifiers containing separators or whitespace", () => {
+    for (const channelId of [
+      "UCabcdefghijklmnopqrstu,",
+      "UCabcdefghijklmnopqrstu;",
+      "UCabcdefghijklmnopqrstu=",
+      "UCabcdefghij klmnopqrstuv",
+    ]) {
+      expect(() =>
+        AudienceAnalyticsInput.parse({ ...baseInput, channelId })
+      ).toThrow();
+    }
+  });
+
+  test("rejects video identifiers containing separators, whitespace, or a non-YouTube shape", () => {
+    for (const videoId of [
+      "dQw4w9WgXc,",
+      "dQw4w9WgXc;",
+      "dQw4w9WgXc=",
+      "dQw4w9W XcQ",
+      "too-short",
+      "too-long-video-id",
+    ]) {
+      expect(() =>
+        AudienceAnalyticsInput.parse({ ...baseInput, videoId })
+      ).toThrow();
+    }
+  });
+
+  test("rejects an input whose startDate is after endDate", () => {
+    expect(() =>
+      AudienceAnalyticsInput.parse({
+        ...baseInput,
+        endDate: "2026-06-01",
+        startDate: "2026-06-14",
+      })
     ).toThrow();
   });
 });
@@ -296,7 +361,7 @@ describe("collectAudienceService success", () => {
     );
     expect(subscribedStatusCall.sort).toBe("-views");
     for (const call of calls) {
-      expect(call.ids).toBe("channel==UC_test_channel");
+      expect(call.ids).toBe("channel==UCabcdefghijklmnopqrstuv");
       expect(call.startDate).toBe("2026-06-01");
       expect(call.endDate).toBe("2026-06-14");
       expect(call.filters).toBeUndefined();
@@ -368,20 +433,114 @@ describe("collectAudienceService success", () => {
     const { calls, client } = makeAnalyticsClient(audienceResponses);
 
     const result = await collectAudienceService(
-      { ...baseInput, videoId: "vidA" },
+      { ...baseInput, videoId: validVideoId },
       makeDeps(client)
     );
 
     expect(result.ok).toBe(true);
     expect(calls).toHaveLength(3);
     for (const call of calls) {
-      expect(call.ids).toBe("channel==UC_test_channel");
-      expect(call.filters).toBe("video==vidA");
+      expect(call.ids).toBe("channel==UCabcdefghijklmnopqrstuv");
+      expect(call.filters).toBe(`video==${validVideoId}`);
     }
   });
 });
 
 describe("collectAudienceService error paths", () => {
+  test("returns a validation ServiceError for an unsafe channelId without querying", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(
+      { ...baseInput, channelId: `${baseInput.channelId},mine==true` },
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(result.error.domain).toBe("validation");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("returns a validation ServiceError for an unsafe videoId without querying", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(
+      { ...baseInput, videoId: `${validVideoId};country==JP` },
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(result.error.domain).toBe("validation");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("returns a validation ServiceError for an inverted date range without querying", async () => {
+    const { calls, client } = makeAnalyticsClient(audienceResponses);
+
+    const result = await collectAudienceService(
+      { ...baseInput, endDate: "2026-06-01", startDate: "2026-06-14" },
+      makeDeps(client)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a validation failure");
+    }
+    expect(result.error.domain).toBe("validation");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("retries a 500 query error and returns success when the retry succeeds", async () => {
+    let attempts = 0;
+    const { calls, client } = makeAnalyticsClient((params) => {
+      if (params.dimensions === "ageGroup,gender" && attempts === 0) {
+        attempts += 1;
+        throw gaxiosStatusError(500);
+      }
+      return audienceResponses(params);
+    });
+
+    const result = await collectAudienceService(
+      baseInput,
+      makeDeps(client, noSleep)
+    );
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(4);
+    expect(calls.map((call) => call.dimensions)).toEqual([
+      "ageGroup,gender",
+      "ageGroup,gender",
+      "country",
+      "subscribedStatus",
+    ]);
+  });
+
+  test("does not retry a 403 query error and returns an API ServiceError", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosStatusError(403);
+    });
+
+    const result = await collectAudienceService(
+      baseInput,
+      makeDeps(client, noSleep)
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected an api failure");
+    }
+    expect(result.error.domain).toBe("api");
+    if (result.error.domain === "api") {
+      expect(result.error.httpStatus).toBe(403);
+    }
+    expect(calls).toHaveLength(1);
+  });
+
   test("returns a quota ServiceError for a 429 without retrying", async () => {
     const { calls, client } = makeAnalyticsClient(() => {
       throw gaxiosQuotaError();
@@ -398,6 +557,61 @@ describe("collectAudienceService error paths", () => {
       expect(result.error.retryAfterSeconds).toBe(90);
     }
     expect(calls).toHaveLength(1);
+  });
+
+  test("leaves retryAfterSeconds undefined when a 429 Retry-After header is empty", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosQuotaErrorWithRetryAfter("");
+    });
+
+    const result = await collectAudienceService(baseInput, makeDeps(client));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.retryAfterSeconds).toBeUndefined();
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test("leaves retryAfterSeconds undefined when a 429 Retry-After header is blank", async () => {
+    const { calls, client } = makeAnalyticsClient(() => {
+      throw gaxiosQuotaErrorWithRetryAfter("   ");
+    });
+
+    const result = await collectAudienceService(baseInput, makeDeps(client));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected a quota failure");
+    }
+    expect(result.error.domain).toBe("quota");
+    if (result.error.domain === "quota") {
+      expect(result.error.retryAfterSeconds).toBeUndefined();
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test("retries an API error whose status is unknown", async () => {
+    let attempts = 0;
+    const { calls, client } = makeAnalyticsClient((params) => {
+      if (params.dimensions === "ageGroup,gender" && attempts === 0) {
+        attempts += 1;
+        throw gaxiosUnknownStatusError();
+      }
+      return audienceResponses(params);
+    });
+
+    const result = await collectAudienceService(
+      baseInput,
+      makeDeps(client, noSleep)
+    );
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(4);
   });
 
   test("validates input before making an API request", async () => {


### PR DESCRIPTION
## Summary

## Parent

epic #727

## What to build

Demographics (age / gender / country) と subscriber/non-subscriber 内訳の service。

`packages/core/src/analytics/audience/` に 3 file (schema / service / index) を追加。Python `utils/audience_analytics.py` Mixin の TS port (ADR-0003 で「Python を翻訳せず TS で新規記述」が確定)。

- `packages/core/src/analytics/audience/schema.ts`: zod `Input` / `Output` schema。input は `channelId` (and/or `videoId`) + `startDate` / `endDate` (YYYY-MM-DD)。output は `z.array(z.object({...}))` で metric 行
- `packages/core/src/analytics/audience/service.ts`: `collectAudienceService(input, deps: { youtubeAnalytics })` が Promise<Result<...>>
- 内部集計は `Array.prototype.reduce` / `Object.groupBy` 等 stdlib で、arquero 等を導入しない
- bun:test: mocked youtubeAnalytics で input/output schema parse + 主要集計が正しい

## Acceptance criteria

- [ ] ADR-0003 の canonical template に準拠
- [ ] service は `Promise<Result<T, ServiceError>>` を返す (内部 throw OK、境界で `toServiceError` 経由)
- [ ] schema は zod (`z.object().strict()`) + `z.infer` で型導出 (`interface` 並書なし)
- [ ] service が `deps: { youtubeAnalytics: youtubeAnalytics_v2.Youtubeanalytics }` を受け取る
- [ ] output schema の `metrics` 配列が 1 メトリクスごとに 1 record
- [ ] arquero / danfo 等 dataframe lib を core に追加しない
- [ ] bun:test: success path (mocked YouTube Analytics API) と quota error path (toServiceError 経由で domain="quota")

## Blocked by

- #826 (buildYouTubeAnalyticsClient + Result + ServiceError)
- #825 (config の zod 化)

## Refs

- ADR 0003 (#820): docs/adr/0003-service-boundary-contracts.md
- ADR 0002: docs/adr/0002-service-first-architecture.md
- Epic: #727

## Retry 規約 (2026-06-12 追記、ADR レビュー所見 4)

API retry / backoff を本 issue 内で自前実装しないこと。`@youtube-automation/core` の `withRetry` (#959) を使う。quota (429) は retry せず `domain: "quota"` + `retryAfterSeconds` の Result で返す (ADR-0003)。

## Execution Report

Workflow `default` completed successfully.

Closes #833