### PR TITLE
[#1034] issue-1034-distrokid-helper-no

### DIFF
--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -13,9 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "lint": "cd .. && eslint -c distrokid-helper/eslint.config.js distrokid-helper",
+    "lint": "cd .. && eslint -c distrokid-helper/eslint.config.js distrokid-helper shared",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check . ../shared"
   },
   "dependencies": {
     "@webext-core/messaging": "^2.1.0",

--- a/tests/test_distrokid_helper_package_scripts.py
+++ b/tests/test_distrokid_helper_package_scripts.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGE_JSON = _REPO_ROOT / "extensions" / "distrokid-helper" / "package.json"
+
+
+def _load_distrokid_helper_package() -> dict[str, object]:
+    return json.loads(_PACKAGE_JSON.read_text(encoding="utf-8"))
+
+
+def _scripts() -> dict[str, str]:
+    package = _load_distrokid_helper_package()
+    scripts = package["scripts"]
+    assert isinstance(scripts, dict)
+    return scripts
+
+
+def test_should_lint_shared_package_when_distrokid_helper_lint_runs() -> None:
+    scripts = _scripts()
+
+    assert (
+        scripts["lint"]
+        == "cd .. && eslint -c distrokid-helper/eslint.config.js distrokid-helper shared"
+    )
+
+
+def test_should_check_shared_formatting_when_distrokid_helper_format_check_runs() -> None:
+    scripts = _scripts()
+
+    assert scripts["format:check"] == "prettier --check . ../shared"


### PR DESCRIPTION
## Summary

## 背景

Plan 005 (`plans/005-distrokid-lint-format-shared-scope.md`) に基づく。

suno-helper の lint / format:check は `shared/` を対象に含めているが、distrokid-helper は含めていない。Plan 003（#955、DONE）で lint/format ゲートは追加されたが、shared/ スコープの追加が漏れている。

## タスク

- `distrokid-helper/package.json` の `lint` に `shared` を追加
- `distrokid-helper/package.json` の `format:check` に `../shared` を追加

## 詳細

- **Effort**: S
- **Priority**: P1
- **Plan**: `plans/005-distrokid-lint-format-shared-scope.md`

## Execution Report

Workflow `default` completed successfully.

Closes #1034