### PR TITLE
[#1037] distrokid-helper に @types/chrome を追加

### DIFF
--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@eslint/js": "9.39.4",
     "@playwright/test": "1.60.0",
+    "@types/chrome": "0.1.42",
     "@types/react": "19.0.2",
     "@types/react-dom": "19.0.2",
     "@wxt-dev/module-react": "1.2.2",

--- a/extensions/distrokid-helper/pnpm-lock.yaml
+++ b/extensions/distrokid-helper/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
+      '@types/chrome':
+        specifier: 0.1.42
+        version: 0.1.42
       '@types/react':
         specifier: 19.0.2
         version: 19.0.2
@@ -729,6 +732,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/chrome@0.1.42':
+    resolution: {integrity: sha512-tdT2roFqGecZZDjA9fUEAINb2STxSPifHMDvY6EfRjNRCjdrs/0FwKt5RCIA9MKMd1arAYZZL3nwEkp6ZLZu2w==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3465,6 +3471,11 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/chrome@0.1.42':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
 
   '@types/deep-eql@4.0.2': {}
 


### PR DESCRIPTION
## Summary

- distrokid-helper の devDependencies に `@types/chrome@0.1.42` を追加（suno-helper と統一）
- `chrome.*` API 呼び出し箇所の型安全性を向上

Closes #1037

## Verification

- `pnpm compile` — exit 0（型エラーなし）
- `pnpm test` — 10 files, 159 tests all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)