### PR TITLE
[#1036] distrokid-helper に manifest 権限の SSOT + CI 検証を追加

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -87,6 +87,23 @@ jobs:
         run: pnpm compile
       - name: Build
         run: pnpm build
+      - name: Verify generated manifest permissions (least-privilege)
+        run: |
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const manifest = JSON.parse(
+              readFileSync(".output/chrome-mv3/manifest.json", "utf8"),
+            );
+            const expected = ["storage", "activeTab"];
+            const actual = manifest.permissions ?? [];
+            const same =
+              actual.length === expected.length &&
+              expected.every((p) => actual.includes(p));
+            if (!same) {
+              console.error("生成 manifest の permissions が最小権限と不一致:", actual);
+              process.exit(1);
+            }
+          '
       - name: Unit tests (Vitest)
         run: pnpm test
       - name: Install Playwright browser

--- a/extensions/distrokid-helper/lib/manifest.ts
+++ b/extensions/distrokid-helper/lib/manifest.ts
@@ -1,0 +1,5 @@
+// manifest は wxt.config.ts から自動生成されるため、権限宣言を import 可能な
+// 単一定数に切り出し、wxt.config.ts はこの定数を参照する。
+// 契約: storage（サーバー URL 永続化）+ activeTab（注入対象タブ）。
+// tabs は含めない（distrokid-helper は bg tab 操作を行わない）。
+export const MANIFEST_PERMISSIONS = ["storage", "activeTab"] as const;

--- a/extensions/distrokid-helper/tests/manifest.test.ts
+++ b/extensions/distrokid-helper/tests/manifest.test.ts
@@ -8,13 +8,7 @@ import wxtConfig from "../wxt.config";
 
 const EXPECTED_PERMISSIONS = ["storage", "activeTab"];
 // 混入させたくない広域権限（過剰権限 creep の回帰検知）。
-const FORBIDDEN_PERMISSIONS = [
-  "tabs",
-  "history",
-  "bookmarks",
-  "cookies",
-  "webNavigation",
-];
+const FORBIDDEN_PERMISSIONS = ["tabs", "history", "bookmarks", "cookies", "webNavigation"];
 
 describe("lib/manifest: 最小権限契約", () => {
   it("Given MANIFEST_PERMISSIONS When 中身を読む Then storage / activeTab である", () => {
@@ -40,9 +34,7 @@ describe("wxt.config: manifest 権限の SSOT 一致", () => {
   it("Given wxt.config の manifest When permissions を読む Then MANIFEST_PERMISSIONS と一致する", () => {
     const manifest = wxtConfig.manifest;
     expect(typeof manifest).toBe("object");
-    expect(
-      (manifest as { permissions?: string[] }).permissions,
-    ).toEqual([...MANIFEST_PERMISSIONS]);
+    expect((manifest as { permissions?: string[] }).permissions).toEqual([...MANIFEST_PERMISSIONS]);
   });
 
   it("Given wxt.config の manifest When 過剰権限を探す Then 広域権限を含まない", () => {

--- a/extensions/distrokid-helper/tests/manifest.test.ts
+++ b/extensions/distrokid-helper/tests/manifest.test.ts
@@ -1,0 +1,54 @@
+// manifest 権限の最小権限契約 (#1036)。suno-helper の同等テストに倣い、
+// MANIFEST_PERMISSIONS の中身検証 + wxt.config の SSOT 一致検証 + 禁止権限の不在検証を行う。
+// distrokid-helper は tabs 不要（bg tab 操作を行わない）ため、suno-helper とは権限セットが異なる。
+import { describe, expect, it } from "vitest";
+
+import { MANIFEST_PERMISSIONS } from "../lib/manifest";
+import wxtConfig from "../wxt.config";
+
+const EXPECTED_PERMISSIONS = ["storage", "activeTab"];
+// 混入させたくない広域権限（過剰権限 creep の回帰検知）。
+const FORBIDDEN_PERMISSIONS = [
+  "tabs",
+  "history",
+  "bookmarks",
+  "cookies",
+  "webNavigation",
+];
+
+describe("lib/manifest: 最小権限契約", () => {
+  it("Given MANIFEST_PERMISSIONS When 中身を読む Then storage / activeTab である", () => {
+    expect(new Set(MANIFEST_PERMISSIONS)).toEqual(new Set(EXPECTED_PERMISSIONS));
+  });
+
+  it("Given MANIFEST_PERMISSIONS When 重複の有無を見る Then 2 件ちょうどである", () => {
+    expect(MANIFEST_PERMISSIONS).toHaveLength(EXPECTED_PERMISSIONS.length);
+  });
+
+  it("Given MANIFEST_PERMISSIONS When 過剰権限を探す Then 広域権限を含まない", () => {
+    for (const forbidden of FORBIDDEN_PERMISSIONS) {
+      expect(MANIFEST_PERMISSIONS).not.toContain(forbidden);
+    }
+  });
+});
+
+// 定数だけを検証すると wxt.config.ts:permissions に定数を介さず直接権限を
+// 追記された場合を検知できない。生成 manifest の入力源である wxt.config の
+// manifest.permissions が定数と一致することを表明し、SSOT 迂回を機械的に塞ぐ。
+// (生成成果物 `.output/chrome-mv3/manifest.json` 自体の検証は CI の build 後ステップが担う)
+describe("wxt.config: manifest 権限の SSOT 一致", () => {
+  it("Given wxt.config の manifest When permissions を読む Then MANIFEST_PERMISSIONS と一致する", () => {
+    const manifest = wxtConfig.manifest;
+    expect(typeof manifest).toBe("object");
+    expect(
+      (manifest as { permissions?: string[] }).permissions,
+    ).toEqual([...MANIFEST_PERMISSIONS]);
+  });
+
+  it("Given wxt.config の manifest When 過剰権限を探す Then 広域権限を含まない", () => {
+    const manifest = wxtConfig.manifest as { permissions?: string[] };
+    for (const forbidden of FORBIDDEN_PERMISSIONS) {
+      expect(manifest.permissions).not.toContain(forbidden);
+    }
+  });
+});

--- a/extensions/distrokid-helper/wxt.config.ts
+++ b/extensions/distrokid-helper/wxt.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from "wxt";
 
+import { MANIFEST_PERMISSIONS } from "./lib/manifest";
+
 // WXT 設定。最小権限で Manifest V3 を生成する（要件 #2）。
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   manifest: {
     name: "DistroKid Helper",
     description: "DistroKid 登録フォームに静的プロファイル + 動的データを自動入力する",
-    // 最小権限: storage（サーバー URL 永続化） + activeTab（注入対象タブ）。tabs は含めない。
-    permissions: ["storage", "activeTab"],
+    // 最小権限。SSOT は lib/manifest.ts (tests/manifest.test.ts で機械担保)。
+    permissions: [...MANIFEST_PERMISSIONS],
     // 注入対象を distrokid.com 系に限定する。
     host_permissions: ["*://*.distrokid.com/*"],
   },


### PR DESCRIPTION
## Summary

- `extensions/distrokid-helper/lib/manifest.ts` を新規作成し、最小権限 `["storage", "activeTab"]` を SSOT 定数 `MANIFEST_PERMISSIONS` として宣言
- `extensions/distrokid-helper/wxt.config.ts` をハードコードから定数参照 (`[...MANIFEST_PERMISSIONS]`) に変更
- `extensions/distrokid-helper/tests/manifest.test.ts` を新規作成し、権限の中身検証 + wxt.config との SSOT 一致検証 + 禁止権限 (tabs/history/bookmarks/cookies/webNavigation) の不在検証を機械担保
- `.github/workflows/extensions.yml` の distrokid-helper ジョブに build 後 manifest permissions 検証ステップを追加

suno-helper で確立済みのパターンを distrokid-helper にも適用し、権限の過剰追加を自動検出する。

Closes #1036

## Test plan

- [x] `pnpm compile` -- 型チェック pass
- [x] `pnpm test` -- 全 164 テスト pass（新規 manifest テスト 5 件含む）
- [x] `pnpm build` -- ビルド成功
- [x] 生成 manifest の permissions が `["storage", "activeTab"]` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)