### PR TITLE
[#780] issue-780-cli-yt-generate-imag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(ts-rewrite/cli)`: Python `yt-generate-image` 相当の導線を TS dispatcher の `tayk generate-image` として追加した（#780）。core registry entry `image.generate` は `imageProvider` dependency を宣言し、CLI adapter は `config/skills/thumbnail.yaml` から Gemini / OpenAI provider を構築して `generateImageService` を呼び出す。per-CLI bin は追加しない。
 - `feat(ts-rewrite/core)`: Traffic source 内訳（search / browse / external / suggested 等）を期間集計する `collectTrafficSourceService` を ADR-0003 準拠で実装した（#832）。`packages/core/src/analytics/traffic-source/`（schema / service / index）を新設し、Python `utils/traffic_source_analytics.py` Mixin を翻訳せず TS で新規記述。あわせて analytics 共通のエラー分類を `analytics/query-error.ts`（`toAnalyticsQueryError` / `shouldRetryAnalyticsQuery`）へ集約し、video / channel / video-daily / traffic-source の各 service から参照する。quota（429）は `withRetry` で retry せず `domain: "quota"` の Result で返す
 - `feat(ts-rewrite/core)`: resumable upload + thumbnail 圧縮 + metadata update を 1 atomic service に集約した `uploadVideoService` を ADR-0003 準拠で実装した（#837）
 - `feat(ts-rewrite/core)`: Per-video metrics（views / likes / comments / shares 等 8 指標）を YouTube Analytics API から収集する analytics video service を ADR-0003 準拠で実装した（#829）

--- a/bun.lock
+++ b/bun.lock
@@ -20,8 +20,7 @@
       "name": "@youtube-automation/cli",
       "version": "0.1.0-alpha.0",
       "bin": {
-        "yt": "./bin/yt.ts",
-        "yt-skills": "./bin/yt-skills.ts",
+        "tayk": "./bin/tayk.ts",
       },
       "dependencies": {
         "@youtube-automation/core": "workspace:*",
@@ -41,6 +40,11 @@
         "zod": "^4.1.13",
       },
     },
+  },
+  "overrides": {
+    "@opentelemetry/core": "2.8.0",
+    "hono": "4.12.26",
+    "protobufjs": "8.6.4",
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
@@ -167,7 +171,7 @@
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
-    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
 
     "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/sdk-logs": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ=="],
 
@@ -381,26 +385,6 @@
 
     "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.2", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA=="],
 
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
-
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -609,7 +593,7 @@
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.26", "", {}, "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -741,7 +725,7 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
-    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
+    "protobufjs": ["protobufjs@8.6.4", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -902,8 +886,6 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "youtube-channels-automation",
-      "dependencies": {
-        "takt": "^0.43.0",
-      },
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "knip": "^6.15.0",
@@ -44,28 +41,6 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
-
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g=="],
-
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141", "", { "os": "darwin", "cpu": "x64" }, "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ=="],
-
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q=="],
-
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ=="],
-
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A=="],
-
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ=="],
-
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w=="],
-
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
-
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
-
-    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
-
     "@clack/core": ["@clack/core@1.4.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw=="],
 
     "@clack/prompts": ["@clack/prompts@1.5.0", "", { "dependencies": { "@clack/core": "1.4.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA=="],
@@ -77,10 +52,6 @@
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@google/genai": ["@google/genai@2.7.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g=="],
-
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
-
-    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -136,87 +107,9 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
-    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
-
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@openai/codex": ["@openai/codex@0.125.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.125.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.125.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.125.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.125.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.125.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.125.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q=="],
-
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.125.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ=="],
-
-    "@openai/codex-darwin-x64": ["@openai/codex@0.125.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg=="],
-
-    "@openai/codex-linux-arm64": ["@openai/codex@0.125.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA=="],
-
-    "@openai/codex-linux-x64": ["@openai/codex@0.125.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ=="],
-
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.125.0", "", { "dependencies": { "@openai/codex": "0.125.0" } }, "sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg=="],
-
-    "@openai/codex-win32-arm64": ["@openai/codex@0.125.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ=="],
-
-    "@openai/codex-win32-x64": ["@openai/codex@0.125.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw=="],
-
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw=="],
-
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A=="],
-
-    "@opentelemetry/configuration": ["@opentelemetry/configuration@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "yaml": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw=="],
-
-    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
-
-    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/sdk-logs": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ=="],
-
-    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/sdk-logs": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ=="],
-
-    "@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.217.0", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ=="],
-
-    "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-metrics-otlp-http": "0.217.0", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-0GpJKnCoVaVA1rKBMVPHziznfOQlXgH72S9ktjBAF1AnAVPzX7vVEBGrhwiSxxHDAiefXk+J8znApsMb/K6Z3w=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q=="],
-
-    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-metrics-otlp-http": "0.217.0", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ=="],
-
-    "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw=="],
-
-    "@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fPZs2fw7veLH3pEKu8vSepUa2fQpAE2P7al6qU10aH9GrEJJ8YaPgsd5xON7by5rbcEVS71FOU2aWyK6nzB7VQ=="],
-
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ=="],
-
-    "@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-nPV8gKHUiSuTZpQcnZU3/pBlK7crSyEGpZuh5MtWySB0vv6NNG0QvvfKitQt+Fc2Mc6qfyU54KlZcurwoTbrVg=="],
-
-    "@opentelemetry/exporter-zipkin": ["@opentelemetry/exporter-zipkin@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg=="],
-
-    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w=="],
-
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ=="],
-
-    "@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag=="],
-
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.217.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "protobufjs": "8.0.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA=="],
-
-    "@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A=="],
-
-    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q=="],
-
-    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
-
-    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A=="],
-
-    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
-
-    "@opentelemetry/sdk-node": ["@opentelemetry/sdk-node@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/configuration": "0.217.0", "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-logs-otlp-grpc": "0.217.0", "@opentelemetry/exporter-logs-otlp-http": "0.217.0", "@opentelemetry/exporter-logs-otlp-proto": "0.217.0", "@opentelemetry/exporter-metrics-otlp-grpc": "0.217.0", "@opentelemetry/exporter-metrics-otlp-http": "0.217.0", "@opentelemetry/exporter-metrics-otlp-proto": "0.217.0", "@opentelemetry/exporter-prometheus": "0.217.0", "@opentelemetry/exporter-trace-otlp-grpc": "0.217.0", "@opentelemetry/exporter-trace-otlp-http": "0.217.0", "@opentelemetry/exporter-trace-otlp-proto": "0.217.0", "@opentelemetry/exporter-zipkin": "2.7.1", "@opentelemetry/instrumentation": "0.217.0", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/propagator-b3": "2.7.1", "@opentelemetry/propagator-jaeger": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.217.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "@opentelemetry/sdk-trace-node": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q=="],
-
-    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
-
-    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.7.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.133.0", "", { "os": "android", "cpu": "arm" }, "sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA=="],
 
@@ -376,12 +269,6 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
-
-    "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
-
-    "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.2", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA=="],
-
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -393,8 +280,6 @@
     "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
 
     "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
 
     "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
 
@@ -416,23 +301,15 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
-
-    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
-
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
-    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -441,8 +318,6 @@
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
-    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
@@ -456,27 +331,13 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
-
-    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
-
-    "configstore": ["configstore@7.1.0", "", { "dependencies": { "atomically": "^2.0.3", "dot-prop": "^9.0.0", "graceful-fs": "^4.2.11", "xdg-basedir": "^5.1.0" } }, "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -494,15 +355,11 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -512,7 +369,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -521,10 +378,6 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escape-goat": ["escape-goat@4.0.0", "", {}, "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -540,11 +393,7 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "faceted-prompting": ["faceted-prompting@0.1.0", "", {}, "sha512-nFXVRwIvIWgVMLGlY2XO83D/BRSJ177ecIqyARisxHsUWBnJXpGSRIIe/O+Nbp+YMRRCaMwC04bxUaRFRpM4kw=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
@@ -578,10 +427,6 @@
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
-
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -589,8 +434,6 @@
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
-
-    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
@@ -601,8 +444,6 @@
     "googleapis-common": ["googleapis-common@8.0.2", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "7.1.3", "google-auth-library": "10.5.0", "google-logging-utils": "1.1.3", "qs": "^6.7.0", "url-template": "^2.0.8" } }, "sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
@@ -618,25 +459,13 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
-
-    "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
-
-    "is-npm": ["is-npm@6.1.0", "", {}, "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA=="],
-
-    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -650,9 +479,7 @@
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
-    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
-
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
@@ -663,12 +490,6 @@
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "knip": ["knip@6.15.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.133.0", "oxc-resolver": "^11.20.0", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-uBaKFEGcu/HG4EY2gWFBMr+fBF43Jftoc2riJX51TKME1Z46C8UQIbNEusenYbEWihphxe2PY0Kns0yPvPYz4A=="],
-
-    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
-
-    "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
-
-    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -689,8 +510,6 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
-    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -722,8 +541,6 @@
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
-    "package-json": ["package-json@10.0.1", "", { "dependencies": { "ky": "^1.2.0", "registry-auth-token": "^5.0.2", "registry-url": "^6.0.1", "semver": "^7.6.0" } }, "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg=="],
-
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
@@ -740,15 +557,9 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
-
     "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "pupa": ["pupa@3.3.0", "", { "dependencies": { "escape-goat": "^4.0.0" } }, "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
@@ -756,17 +567,7 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
-    "registry-auth-token": ["registry-auth-token@5.1.1", "", { "dependencies": { "@pnpm/npm-conf": "^3.0.2" } }, "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q=="],
-
-    "registry-url": ["registry-url@6.0.1", "", { "dependencies": { "rc": "1.2.8" } }, "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -810,7 +611,7 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -820,12 +621,6 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
-    "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
-
-    "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
-
-    "takt": ["takt@0.43.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.119", "@openai/codex-sdk": "^0.125.0", "@opencode-ai/sdk": "^1.14.24", "@opentelemetry/api": "^1.9.1", "@opentelemetry/sdk-node": "^0.217.0", "ajv": "^6.12.6", "chalk": "^5.3.0", "commander": "^12.1.0", "faceted-prompting": "^0.1.0", "traced-config": "^0.3.0", "update-notifier": "^7.3.1", "wanakana": "^5.3.1", "yaml": "^2.8.3", "zod": "^4.3.6" }, "bin": { "takt": "bin/takt", "takt-cli": "dist/app/cli/index.js", "takt-dev": "bin/takt" } }, "sha512-41dJCyZWhzTbaAOepHyeLw/eXY0aL8e2+Xai/bKlgrT7rY3Mqip0KyldzKcJxCOTO+oY8xuVLkeR/o5LTYSRSw=="],
-
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
@@ -834,13 +629,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "traced-config": ["traced-config@0.3.0", "", { "dependencies": { "yaml": "^2.8.1" } }, "sha512-6aHTniO7iTl5ydAx1D8ZJpaf2V6DNwI1TXP+bSafkNVCs5iFPd1vsM7GkD1hyBGJ/Qyj0Pg6GdYQ04hicrYUaQ=="],
-
-    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -854,27 +643,17 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
-    "update-notifier": ["update-notifier@7.3.1", "", { "dependencies": { "boxen": "^8.0.1", "chalk": "^5.3.0", "configstore": "^7.0.0", "is-in-ci": "^1.0.0", "is-installed-globally": "^1.0.0", "is-npm": "^6.0.0", "latest-version": "^9.0.0", "pupa": "^3.1.0", "semver": "^7.6.3", "xdg-basedir": "^5.1.0" } }, "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA=="],
-
-    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
-
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
-    "wanakana": ["wanakana@5.3.1", "", {}, "sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw=="],
-
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
-
-    "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
-
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -882,15 +661,7 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -898,35 +669,9 @@
 
     "@google/genai/google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
-
-    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
-
-    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
     "googleapis/google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
 
     "googleapis-common/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
-
-    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -936,8 +681,6 @@
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "takt/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -945,24 +688,6 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -974,17 +699,9 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "dependencies": {
         "@youtube-automation/core": "workspace:*",
         "citty": "^0.2.2",
+        "yaml": "^2.9.0",
       },
     },
     "packages/core": {
@@ -40,11 +41,6 @@
         "zod": "^4.1.13",
       },
     },
-  },
-  "overrides": {
-    "@opentelemetry/core": "2.8.0",
-    "hono": "4.12.26",
-    "protobufjs": "8.6.4",
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
@@ -171,7 +167,7 @@
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
-    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
     "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/sdk-logs": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ=="],
 
@@ -384,6 +380,26 @@
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
 
     "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.2", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -725,7 +741,7 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
-    "protobufjs": ["protobufjs@8.6.4", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg=="],
+    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -886,6 +902,8 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "dependencies": {
         "@youtube-automation/core": "workspace:*",
         "citty": "^0.2.2",
+        "openai": "^6.41.0",
         "yaml": "^2.9.0",
       },
     },

--- a/knip.json
+++ b/knip.json
@@ -3,8 +3,7 @@
   "workspaces": {
     ".": {
       "entry": [],
-      "project": [],
-      "ignoreDependencies": ["takt"]
+      "project": []
     },
     "packages/*": {
       "entry": ["src/index.ts", "src/cli/*.ts", "bin/*.ts", "*/index.ts"],

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "knip": "knip-bun",
     "ci": "bun run lint && bun run format:check && bun run typecheck && bun run test && bun run knip"
   },
-  "dependencies": {
-    "takt": "^0.43.0"
-  },
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "knip": "^6.15.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,6 @@
   "dependencies": {
     "takt": "^0.43.0"
   },
-  "overrides": {
-    "@opentelemetry/core": "2.8.0",
-    "hono": "4.12.26",
-    "protobufjs": "8.6.4"
-  },
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "knip": "^6.15.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
   "dependencies": {
     "takt": "^0.43.0"
   },
+  "overrides": {
+    "@opentelemetry/core": "2.8.0",
+    "hono": "4.12.26",
+    "protobufjs": "8.6.4"
+  },
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "knip": "^6.15.0",

--- a/packages/cli/bin/tayk.ts
+++ b/packages/cli/bin/tayk.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 
+import { generateImageCommand } from "../src/commands/generate-image/cli.ts";
 import { generateSunoCommand } from "../src/commands/generate-suno/cli.ts";
 import { skillsCommand } from "../src/commands/skills/cli.ts";
 
@@ -9,7 +10,11 @@ const main = defineCommand({
     description: "youtube-channels-automation CLI (TS rewrite)",
     name: "tayk",
   },
-  subCommands: { "generate-suno": generateSunoCommand, skills: skillsCommand },
+  subCommands: {
+    "generate-image": generateImageCommand,
+    "generate-suno": generateSunoCommand,
+    skills: skillsCommand,
+  },
 });
 
 await runMain(main);

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -11,9 +11,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { channelDir, loadConfig } from "@youtube-automation/core/config";
-import type { ImageGenerationConfig } from "@youtube-automation/core/image";
+import type {
+  ImageGenerationConfig,
+  OpenAIProviderDeps,
+} from "@youtube-automation/core/image";
 import {
   getProvider,
+  OpenAIImageProvider,
   parseImageGenerationConfig,
 } from "@youtube-automation/core/image";
 import {
@@ -24,6 +28,7 @@ import type { DepsMap } from "@youtube-automation/core/registry";
 import { parse as parseYaml } from "yaml";
 
 import { resolveTokenJson } from "./oauth.ts";
+import { resolveSecret } from "./secrets.ts";
 
 const THUMBNAIL_SKILL_CONFIG_PATH = ["config", "skills", "thumbnail.yaml"];
 
@@ -34,6 +39,26 @@ const loadThumbnailSkillConfig = (root: string): ImageGenerationConfig => {
   }
   const text = readFileSync(path, "utf-8");
   return parseImageGenerationConfig(parseYaml(text));
+};
+
+const createOpenAIClientFromSecret: OpenAIProviderDeps["createClient"] =
+  async () => {
+    const apiKey = await resolveSecret("OPENAI_API_KEY");
+    const { default: OpenAI } = await import("openai");
+    return new OpenAI({ apiKey }) as unknown as Awaited<
+      ReturnType<OpenAIProviderDeps["createClient"]>
+    >;
+  };
+
+const buildImageProvider = (
+  config: ImageGenerationConfig
+): DepsMap["imageProvider"] => {
+  if (config.provider !== "openai") {
+    return getProvider(config);
+  }
+  return new OpenAIImageProvider(config.openai, {
+    createClient: createOpenAIClientFromSecret,
+  });
 };
 
 /**
@@ -62,7 +87,7 @@ export const resolveDeps = async <D extends keyof DepsMap>(
   if (requested.has("imageProvider")) {
     const root = channelDir();
     const config = loadThumbnailSkillConfig(root);
-    resolved.imageProvider = getProvider(config);
+    resolved.imageProvider = buildImageProvider(config);
   }
 
   const needsYt = requested.has("yt");

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -7,7 +7,16 @@
 //
 // MCP 到着時は env token + refresh のみの別 adapter を作る（interactive flow を持たない）。
 
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { channelDir, loadConfig } from "@youtube-automation/core/config";
+import type { ImageGenerationConfig } from "@youtube-automation/core/image";
+import {
+  getProvider,
+  parseImageGenerationConfig,
+  parseImageGenerationConfigYaml,
+} from "@youtube-automation/core/image";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
@@ -16,10 +25,22 @@ import type { DepsMap } from "@youtube-automation/core/registry";
 
 import { resolveTokenJson } from "./oauth.ts";
 
+const THUMBNAIL_SKILL_CONFIG_PATH = ["config", "skills", "thumbnail.yaml"];
+
+const loadThumbnailSkillConfig = (root: string): ImageGenerationConfig => {
+  const path = join(root, ...THUMBNAIL_SKILL_CONFIG_PATH);
+  if (!existsSync(path)) {
+    return parseImageGenerationConfig({});
+  }
+  const text = readFileSync(path, "utf-8");
+  return parseImageGenerationConfigYaml(text);
+};
+
 /**
  * entry.deps を見て、要求された依存だけを lazy に構築した DepsMap slice を返す。
  *
  * - `config`      → loadConfig()（singleton loader の起動はここだけ）
+ * - `imageProvider` → config/skills/thumbnail.yaml から Gemini / OpenAI provider を構築
  * - `yt` /
  *   `ytAnalytics` → 同一 token（resolveTokenJson の 1 回 dance）から該当 client を構築
  * - 空 deps       → 副作用ゼロで `{}` を返す
@@ -36,6 +57,12 @@ export const resolveDeps = async <D extends keyof DepsMap>(
 
   if (requested.has("channelDir")) {
     resolved.channelDir = channelDir();
+  }
+
+  if (requested.has("imageProvider")) {
+    const root = channelDir();
+    const config = loadThumbnailSkillConfig(root);
+    resolved.imageProvider = getProvider(config);
   }
 
   const needsYt = requested.has("yt");

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -85,7 +85,7 @@ export const resolveDeps = async <D extends keyof DepsMap>(
   }
 
   if (requested.has("imageProvider")) {
-    const root = channelDir();
+    const root = resolved.channelDir ?? channelDir();
     const config = loadThumbnailSkillConfig(root);
     resolved.imageProvider = buildImageProvider(config);
   }

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -15,13 +15,13 @@ import type { ImageGenerationConfig } from "@youtube-automation/core/image";
 import {
   getProvider,
   parseImageGenerationConfig,
-  parseImageGenerationConfigYaml,
 } from "@youtube-automation/core/image";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
 } from "@youtube-automation/core/oauth/client";
 import type { DepsMap } from "@youtube-automation/core/registry";
+import { parse as parseYaml } from "yaml";
 
 import { resolveTokenJson } from "./oauth.ts";
 
@@ -33,7 +33,7 @@ const loadThumbnailSkillConfig = (root: string): ImageGenerationConfig => {
     return parseImageGenerationConfig({});
   }
   const text = readFileSync(path, "utf-8");
-  return parseImageGenerationConfigYaml(text);
+  return parseImageGenerationConfig(parseYaml(text));
 };
 
 /**

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -13,11 +13,10 @@ import { join } from "node:path";
 import { channelDir, loadConfig } from "@youtube-automation/core/config";
 import type {
   ImageGenerationConfig,
-  OpenAIProviderDeps,
+  ImageProviderFactoryDeps,
 } from "@youtube-automation/core/image";
 import {
-  getProvider,
-  OpenAIImageProvider,
+  createImageProvider,
   parseImageGenerationConfig,
 } from "@youtube-automation/core/image";
 import {
@@ -41,25 +40,22 @@ const loadThumbnailSkillConfig = (root: string): ImageGenerationConfig => {
   return parseImageGenerationConfig(parseYaml(text));
 };
 
-const createOpenAIClientFromSecret: OpenAIProviderDeps["createClient"] =
-  async () => {
-    const apiKey = await resolveSecret("OPENAI_API_KEY");
-    const { default: OpenAI } = await import("openai");
-    return new OpenAI({ apiKey }) as unknown as Awaited<
-      ReturnType<OpenAIProviderDeps["createClient"]>
-    >;
-  };
+const createOpenAIClientFromSecret: NonNullable<
+  ImageProviderFactoryDeps["createOpenAIClient"]
+> = async () => {
+  const apiKey = await resolveSecret("OPENAI_API_KEY");
+  const { default: OpenAI } = await import("openai");
+  return new OpenAI({ apiKey }) as Awaited<
+    ReturnType<NonNullable<ImageProviderFactoryDeps["createOpenAIClient"]>>
+  >;
+};
 
 const buildImageProvider = (
   config: ImageGenerationConfig
-): DepsMap["imageProvider"] => {
-  if (config.provider !== "openai") {
-    return getProvider(config);
-  }
-  return new OpenAIImageProvider(config.openai, {
-    createClient: createOpenAIClientFromSecret,
+): DepsMap["imageProvider"] =>
+  createImageProvider(config, {
+    createOpenAIClient: createOpenAIClientFromSecret,
   });
-};
 
 /**
  * entry.deps を見て、要求された依存だけを lazy に構築した DepsMap slice を返す。

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@youtube-automation/core": "workspace:*",
-    "citty": "^0.2.2"
+    "citty": "^0.2.2",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@youtube-automation/core": "workspace:*",
     "citty": "^0.2.2",
+    "openai": "^6.41.0",
     "yaml": "^2.9.0"
   }
 }

--- a/packages/cli/src/commands/generate-image/cli.ts
+++ b/packages/cli/src/commands/generate-image/cli.ts
@@ -19,9 +19,6 @@ export const referencesFromArg = (value: unknown): string[] | undefined => {
   if (typeof value === "string") {
     return [value];
   }
-  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
-    return value;
-  }
   throw new Error("validation: --reference は文字列で指定してください");
 };
 
@@ -53,7 +50,7 @@ export const generateImageCommand = defineCommand({
       type: "string",
     },
     reference: {
-      description: "参照画像パス。複数指定可",
+      description: "参照画像パス",
       type: "string",
     },
   },

--- a/packages/cli/src/commands/generate-image/cli.ts
+++ b/packages/cli/src/commands/generate-image/cli.ts
@@ -12,24 +12,16 @@ type GenerateImageEntry = typeof generateImageEntry;
 type ResolveGenerateImageDeps = (
   entryDeps: GenerateImageEntry["deps"]
 ) => Promise<Parameters<GenerateImageEntry["run"]>[1]>;
-type EmitResult = typeof emitResult;
 
 const renderText = (output: GenerateImageOutput): string =>
   `saved: ${output.savedPath}`;
 
-export const referencesFromArg = (value: unknown): string[] | undefined => {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value === "string") {
-    return [value];
-  }
-  throw new Error("validation: --reference は文字列で指定してください");
-};
+export const referencesFromArg = (
+  value: string | undefined
+): string[] | undefined => (value === undefined ? undefined : [value]);
 
 export const createGenerateImageCommand = (
   deps: {
-    emitResult?: EmitResult;
     entry?: GenerateImageEntry;
     resolveDeps?: ResolveGenerateImageDeps;
   } = {}
@@ -38,7 +30,6 @@ export const createGenerateImageCommand = (
   const resolveCommandDeps =
     deps.resolveDeps ??
     ((entryDeps: GenerateImageEntry["deps"]) => resolveDeps(entryDeps));
-  const emitCommandResult = deps.emitResult ?? emitResult;
 
   return defineCommand({
     args: {
@@ -92,7 +83,7 @@ export const createGenerateImageCommand = (
           return err(toServiceError(error));
         }
       })();
-      emitCommandResult(result, {
+      emitResult(result, {
         json: args.json === true,
         renderText,
       });

--- a/packages/cli/src/commands/generate-image/cli.ts
+++ b/packages/cli/src/commands/generate-image/cli.ts
@@ -1,0 +1,85 @@
+import { err, toServiceError } from "@youtube-automation/core";
+import type { GenerateImageOutput } from "@youtube-automation/core/image";
+import { REGISTRY } from "@youtube-automation/core/registry";
+import { defineCommand } from "citty";
+
+import { resolveDeps } from "../../../lib/resolve-deps.ts";
+import { emitResult } from "../../../lib/run-command.ts";
+
+const generateImageEntry = REGISTRY["image.generate"];
+const DEFAULT_IMAGE_SIZE = "2K";
+
+const renderText = (output: GenerateImageOutput): string =>
+  `saved: ${output.savedPath}`;
+
+export const referencesFromArg = (value: unknown): string[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+  throw new Error("validation: --reference は文字列で指定してください");
+};
+
+export const generateImageCommand = defineCommand({
+  args: {
+    "aspect-ratio": {
+      default: "16:9",
+      description: "生成画像のアスペクト比",
+      type: "string",
+    },
+    "image-size": {
+      default: DEFAULT_IMAGE_SIZE,
+      description: "Provider に渡す解像度ヒント",
+      type: "string",
+    },
+    json: {
+      default: false,
+      description: "JSON で出力する",
+      type: "boolean",
+    },
+    output: {
+      description: "画像の保存先パス",
+      required: true,
+      type: "string",
+    },
+    prompt: {
+      description: "画像生成プロンプト",
+      required: true,
+      type: "string",
+    },
+    reference: {
+      description: "参照画像パス。複数指定可",
+      type: "string",
+    },
+  },
+  meta: {
+    description: generateImageEntry.description,
+    name: "generate-image",
+  },
+  async run({ args }) {
+    const result = await (async () => {
+      try {
+        const input = generateImageEntry.inputSchema.parse({
+          aspect_ratio: args["aspect-ratio"],
+          image_size: args["image-size"],
+          output_path: args.output,
+          prompt: args.prompt,
+          references: referencesFromArg(args.reference),
+        });
+        const deps = await resolveDeps(generateImageEntry.deps);
+        return await generateImageEntry.run(input, deps);
+      } catch (error) {
+        return err(toServiceError(error));
+      }
+    })();
+    emitResult(result, {
+      json: args.json === true,
+      renderText,
+    });
+  },
+});

--- a/packages/cli/src/commands/generate-image/cli.ts
+++ b/packages/cli/src/commands/generate-image/cli.ts
@@ -8,6 +8,11 @@ import { emitResult } from "../../../lib/run-command.ts";
 
 const generateImageEntry = REGISTRY["image.generate"];
 const DEFAULT_IMAGE_SIZE = "2K";
+type GenerateImageEntry = typeof generateImageEntry;
+type ResolveGenerateImageDeps = (
+  entryDeps: GenerateImageEntry["deps"]
+) => Promise<Parameters<GenerateImageEntry["run"]>[1]>;
+type EmitResult = typeof emitResult;
 
 const renderText = (output: GenerateImageOutput): string =>
   `saved: ${output.savedPath}`;
@@ -22,61 +27,77 @@ export const referencesFromArg = (value: unknown): string[] | undefined => {
   throw new Error("validation: --reference は文字列で指定してください");
 };
 
-export const generateImageCommand = defineCommand({
-  args: {
-    "aspect-ratio": {
-      default: "16:9",
-      description: "生成画像のアスペクト比",
-      type: "string",
+export const createGenerateImageCommand = (
+  deps: {
+    emitResult?: EmitResult;
+    entry?: GenerateImageEntry;
+    resolveDeps?: ResolveGenerateImageDeps;
+  } = {}
+) => {
+  const entry = deps.entry ?? generateImageEntry;
+  const resolveCommandDeps =
+    deps.resolveDeps ??
+    ((entryDeps: GenerateImageEntry["deps"]) => resolveDeps(entryDeps));
+  const emitCommandResult = deps.emitResult ?? emitResult;
+
+  return defineCommand({
+    args: {
+      "aspect-ratio": {
+        default: "16:9",
+        description: "生成画像のアスペクト比",
+        type: "string",
+      },
+      "image-size": {
+        default: DEFAULT_IMAGE_SIZE,
+        description: "Provider に渡す解像度ヒント",
+        type: "string",
+      },
+      json: {
+        default: false,
+        description: "JSON で出力する",
+        type: "boolean",
+      },
+      output: {
+        description: "画像の保存先パス",
+        required: true,
+        type: "string",
+      },
+      prompt: {
+        description: "画像生成プロンプト",
+        required: true,
+        type: "string",
+      },
+      reference: {
+        description: "参照画像パス",
+        type: "string",
+      },
     },
-    "image-size": {
-      default: DEFAULT_IMAGE_SIZE,
-      description: "Provider に渡す解像度ヒント",
-      type: "string",
+    meta: {
+      description: entry.description,
+      name: "generate-image",
     },
-    json: {
-      default: false,
-      description: "JSON で出力する",
-      type: "boolean",
+    async run({ args }) {
+      const result = await (async () => {
+        try {
+          const input = entry.inputSchema.parse({
+            aspect_ratio: args["aspect-ratio"],
+            image_size: args["image-size"],
+            output_path: args.output,
+            prompt: args.prompt,
+            references: referencesFromArg(args.reference),
+          });
+          const entryDeps = await resolveCommandDeps(entry.deps);
+          return await entry.run(input, entryDeps);
+        } catch (error) {
+          return err(toServiceError(error));
+        }
+      })();
+      emitCommandResult(result, {
+        json: args.json === true,
+        renderText,
+      });
     },
-    output: {
-      description: "画像の保存先パス",
-      required: true,
-      type: "string",
-    },
-    prompt: {
-      description: "画像生成プロンプト",
-      required: true,
-      type: "string",
-    },
-    reference: {
-      description: "参照画像パス",
-      type: "string",
-    },
-  },
-  meta: {
-    description: generateImageEntry.description,
-    name: "generate-image",
-  },
-  async run({ args }) {
-    const result = await (async () => {
-      try {
-        const input = generateImageEntry.inputSchema.parse({
-          aspect_ratio: args["aspect-ratio"],
-          image_size: args["image-size"],
-          output_path: args.output,
-          prompt: args.prompt,
-          references: referencesFromArg(args.reference),
-        });
-        const deps = await resolveDeps(generateImageEntry.deps);
-        return await generateImageEntry.run(input, deps);
-      } catch (error) {
-        return err(toServiceError(error));
-      }
-    })();
-    emitResult(result, {
-      json: args.json === true,
-      renderText,
-    });
-  },
-});
+  });
+};
+
+export const generateImageCommand = createGenerateImageCommand();

--- a/packages/cli/src/commands/generate-image/cli.ts
+++ b/packages/cli/src/commands/generate-image/cli.ts
@@ -7,7 +7,6 @@ import { resolveDeps } from "../../../lib/resolve-deps.ts";
 import { emitResult } from "../../../lib/run-command.ts";
 
 const generateImageEntry = REGISTRY["image.generate"];
-const DEFAULT_IMAGE_SIZE = "2K";
 type GenerateImageEntry = typeof generateImageEntry;
 type ResolveGenerateImageDeps = (
   entryDeps: GenerateImageEntry["deps"]
@@ -34,12 +33,10 @@ export const createGenerateImageCommand = (
   return defineCommand({
     args: {
       "aspect-ratio": {
-        default: "16:9",
         description: "生成画像のアスペクト比",
         type: "string",
       },
       "image-size": {
-        default: DEFAULT_IMAGE_SIZE,
         description: "Provider に渡す解像度ヒント",
         type: "string",
       },

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -159,6 +159,34 @@ describe("resolveDeps — channelDir", () => {
   });
 });
 
+// --- imageProvider -------------------------------------------------------
+
+describe("resolveDeps — imageProvider", () => {
+  test("builds the configured image provider from thumbnail skill config without auth", async () => {
+    const dir = makeChannelDir();
+    mkdirSync(join(dir, "config", "skills"), { recursive: true });
+    writeFileSync(
+      join(dir, "config", "skills", "thumbnail.yaml"),
+      ["image_generation:", "  provider: openai"].join("\n"),
+      "utf-8"
+    );
+    process.env.CHANNEL_DIR = dir;
+    reset();
+    const spawnSpy = spyOn(Bun, "spawn");
+
+    const deps = await resolveDeps(["imageProvider"]);
+
+    expect(deps.imageProvider).toBeDefined();
+    expect(deps.imageProvider.name).toBe("openai");
+    expect("config" in deps).toBe(false);
+    expect("yt" in deps).toBe(false);
+    expect("ytAnalytics" in deps).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
+  });
+});
+
 // --- yt (network-free) ---------------------------------------------------
 
 describe("resolveDeps — yt", () => {

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -11,7 +11,15 @@
 // one Bun.spawn becomes a countable proof that yt + ytAnalytics resolved the
 // token together rather than each running its own dance.
 
-import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -24,9 +32,46 @@ import { resolveDeps } from "../lib/resolve-deps.ts";
 
 // --- env harness ---------------------------------------------------------
 
-const managedKeys = ["CHANNEL_DIR", "CLIENT_SECRETS_JSON"] as const;
+const managedKeys = [
+  "CHANNEL_DIR",
+  "CLIENT_SECRETS_JSON",
+  "OPENAI_API_KEY",
+] as const;
 let savedEnv: Record<string, string | undefined> = {};
 const tmpDirs: string[] = [];
+const openAiConstructorApiKeys: string[] = [];
+const openAiGenerateCalls: unknown[] = [];
+
+mock.module("openai", () => ({
+  default: class FakeOpenAI {
+    readonly images = {
+      edit: (params: unknown) => {
+        openAiGenerateCalls.push(params);
+        return Promise.resolve({
+          data: [
+            {
+              b64_json: Buffer.from(new Uint8Array([1, 2])).toString("base64"),
+            },
+          ],
+        });
+      },
+      generate: (params: unknown) => {
+        openAiGenerateCalls.push(params);
+        return Promise.resolve({
+          data: [
+            {
+              b64_json: Buffer.from(new Uint8Array([1, 2])).toString("base64"),
+            },
+          ],
+        });
+      },
+    };
+
+    constructor(options: { apiKey: string }) {
+      openAiConstructorApiKeys.push(options.apiKey);
+    }
+  },
+}));
 
 beforeEach(() => {
   savedEnv = {};
@@ -34,6 +79,8 @@ beforeEach(() => {
     savedEnv[key] = process.env[key];
     Reflect.deleteProperty(process.env, key);
   }
+  openAiConstructorApiKeys.length = 0;
+  openAiGenerateCalls.length = 0;
   reset();
 });
 
@@ -181,6 +228,35 @@ describe("resolveDeps — imageProvider", () => {
     expect("config" in deps).toBe(false);
     expect("yt" in deps).toBe(false);
     expect("ytAnalytics" in deps).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
+  });
+
+  test("injects the CLI secret resolver into the OpenAI image provider", async () => {
+    const dir = makeChannelDir();
+    mkdirSync(join(dir, "config", "skills"), { recursive: true });
+    writeFileSync(
+      join(dir, "config", "skills", "thumbnail.yaml"),
+      ["image_generation:", "  provider: openai"].join("\n"),
+      "utf-8"
+    );
+    process.env.CHANNEL_DIR = dir;
+    process.env.OPENAI_API_KEY = "env-openai-key";
+    reset();
+    const spawnSpy = spyOn(Bun, "spawn");
+
+    const deps = await resolveDeps(["imageProvider"]);
+    const bytes = await deps.imageProvider.generate({
+      aspectRatio: "16:9",
+      imageSize: "2K",
+      outputPath: "collections/planning/demo/main.png",
+      prompt: "a square cafe thumbnail",
+    });
+
+    expect([...bytes]).toEqual([1, 2]);
+    expect(openAiConstructorApiKeys).toEqual(["env-openai-key"]);
+    expect(openAiGenerateCalls).toHaveLength(1);
     expect(spawnSpy).not.toHaveBeenCalled();
 
     spawnSpy.mockRestore();

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -261,6 +261,33 @@ describe("resolveDeps — imageProvider", () => {
 
     spawnSpy.mockRestore();
   });
+
+  test("uses thumbnail config defaults when generate-image flags are omitted", async () => {
+    const dir = makeChannelDir();
+    mkdirSync(join(dir, "config", "skills"), { recursive: true });
+    writeFileSync(
+      join(dir, "config", "skills", "thumbnail.yaml"),
+      [
+        "image_generation:",
+        "  provider: openai",
+        "  openai:",
+        "    aspect_ratio: '9:16'",
+      ].join("\n"),
+      "utf-8"
+    );
+    process.env.CHANNEL_DIR = dir;
+    process.env.OPENAI_API_KEY = "env-openai-key";
+    reset();
+
+    const deps = await resolveDeps(["imageProvider"]);
+    await deps.imageProvider.generate({
+      outputPath: "collections/planning/demo/main.png",
+      prompt: "a square cafe thumbnail",
+    });
+
+    expect(openAiGenerateCalls).toHaveLength(1);
+    expect(openAiGenerateCalls[0]).toMatchObject({ size: "1024x1536" });
+  });
 });
 
 // --- yt (network-free) ---------------------------------------------------

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -94,10 +94,9 @@ describe("tayk generate-image — smoke", () => {
     expect(referencesFromArg("ref.png")).toEqual(["ref.png"]);
   });
 
-  test("rejects invalid reference argument values before service execution", () => {
-    expect(() => referencesFromArg([123])).toThrow(
-      "validation: --reference は文字列で指定してください"
-    );
+  test("leaves omitted reference arguments undefined", () => {
+    const args: { reference?: string } = {};
+    expect(referencesFromArg(args.reference)).toBeUndefined();
   });
 
   test("prints the success result from the CLI adapter", async () => {

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -101,10 +101,8 @@ describe("tayk generate-image — smoke", () => {
   });
 
   test("formats provider config errors through the command helper", () => {
-    // Given an OpenAI-backed channel config and a request ratio OpenAI rejects
     const channelDir = writeOpenAIChannel();
 
-    // When the dispatcher invokes the generate-image subcommand
     const proc = runTayk(
       { env: { CHANNEL_DIR: channelDir, OPENAI_API_KEY: undefined } },
       "generate-image",
@@ -117,8 +115,6 @@ describe("tayk generate-image — smoke", () => {
       "--json"
     );
 
-    // Then the command reaches the shared Result -> exit-code helper without
-    // creating a per-CLI bin or making an external API request.
     expect(proc.exitCode).toBe(1);
     expect(proc.stderr.toString()).toStartWith("[config] ");
     expect(proc.stderr.toString()).toContain("aspect_ratio");

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -13,7 +13,7 @@ import { ok } from "@youtube-automation/core";
 import { REGISTRY } from "@youtube-automation/core/registry";
 
 import {
-  generateImageCommand,
+  createGenerateImageCommand,
   referencesFromArg,
 } from "../src/commands/generate-image/cli.ts";
 
@@ -102,27 +102,34 @@ describe("tayk generate-image — smoke", () => {
 
   test("prints the success result from the CLI adapter", async () => {
     const channelDir = makeTempDir("cli-image-success-");
-    const entry = REGISTRY["image.generate"];
-    const originalRun = entry.run;
-    const originalChannelDir = process.env.CHANNEL_DIR;
-    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
-      () => true
-    );
-
-    try {
-      process.env.CHANNEL_DIR = channelDir;
-      (
-        entry as unknown as {
-          run: typeof originalRun;
-        }
-      ).run = () =>
+    const registryEntry = REGISTRY["image.generate"];
+    const entry = {
+      ...registryEntry,
+      run: (() =>
         Promise.resolve(
           ok({
             savedPath: join(channelDir, "collections/planning/demo/main.png"),
           })
-        );
+        )) as typeof registryEntry.run,
+    };
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
+    const command = createGenerateImageCommand({
+      entry,
+      resolveDeps: () =>
+        Promise.resolve({
+          channelDir,
+          imageProvider: {
+            generate: () => Promise.resolve(new Uint8Array([1])),
+            name: "fake",
+            supportedAspectRatios: [],
+          },
+        }),
+    });
 
-      await generateImageCommand.run?.({
+    try {
+      await command.run?.({
         args: {
           "aspect-ratio": "16:9",
           "image-size": "2K",
@@ -137,16 +144,6 @@ describe("tayk generate-image — smoke", () => {
         `saved: ${join(channelDir, "collections/planning/demo/main.png")}\n`
       );
     } finally {
-      (
-        entry as unknown as {
-          run: typeof originalRun;
-        }
-      ).run = originalRun;
-      if (originalChannelDir === undefined) {
-        Reflect.deleteProperty(process.env, "CHANNEL_DIR");
-      } else {
-        process.env.CHANNEL_DIR = originalChannelDir;
-      }
       stdoutSpy.mockRestore();
     }
   });

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -9,9 +9,13 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
+import { ok } from "@youtube-automation/core";
 import { REGISTRY } from "@youtube-automation/core/registry";
 
-import { referencesFromArg } from "../src/commands/generate-image/cli.ts";
+import {
+  generateImageCommand,
+  referencesFromArg,
+} from "../src/commands/generate-image/cli.ts";
 
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
 const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
@@ -80,7 +84,7 @@ describe("core registry — image.generate entry visible from cli package", () =
     if (entry === undefined) {
       throw new Error("image.generate registry entry is required");
     }
-    expect(entry.deps).toEqual(["imageProvider"]);
+    expect(entry.deps).toEqual(["channelDir", "imageProvider"]);
     expect(entry.description.length).toBeGreaterThan(0);
   });
 });
@@ -90,14 +94,61 @@ describe("tayk generate-image — smoke", () => {
     expect(referencesFromArg("ref.png")).toEqual(["ref.png"]);
   });
 
-  test("keeps multiple reference arguments as the service input array", () => {
-    expect(referencesFromArg(["a.png", "b.png"])).toEqual(["a.png", "b.png"]);
-  });
-
   test("rejects invalid reference argument values before service execution", () => {
     expect(() => referencesFromArg([123])).toThrow(
       "validation: --reference は文字列で指定してください"
     );
+  });
+
+  test("prints the success result from the CLI adapter", async () => {
+    const channelDir = makeTempDir("cli-image-success-");
+    const entry = REGISTRY["image.generate"];
+    const originalRun = entry.run;
+    const originalChannelDir = process.env.CHANNEL_DIR;
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
+
+    try {
+      process.env.CHANNEL_DIR = channelDir;
+      (
+        entry as unknown as {
+          run: typeof originalRun;
+        }
+      ).run = () =>
+        Promise.resolve(
+          ok({
+            savedPath: join(channelDir, "collections/planning/demo/main.png"),
+          })
+        );
+
+      await generateImageCommand.run?.({
+        args: {
+          "aspect-ratio": "16:9",
+          "image-size": "2K",
+          json: false,
+          output: "collections/planning/demo/main.png",
+          prompt: "a square cafe thumbnail",
+          reference: undefined,
+        },
+      } as never);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        `saved: ${join(channelDir, "collections/planning/demo/main.png")}\n`
+      );
+    } finally {
+      (
+        entry as unknown as {
+          run: typeof originalRun;
+        }
+      ).run = originalRun;
+      if (originalChannelDir === undefined) {
+        Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+      } else {
+        process.env.CHANNEL_DIR = originalChannelDir;
+      }
+      stdoutSpy.mockRestore();
+    }
   });
 
   test("formats provider config errors through the command helper", () => {
@@ -109,7 +160,7 @@ describe("tayk generate-image — smoke", () => {
       "--prompt",
       "a square cafe thumbnail",
       "--output",
-      join(channelDir, "out.png"),
+      "collections/planning/demo/out.png",
       "--aspect-ratio",
       "1:1",
       "--json"

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -147,6 +147,59 @@ describe("tayk generate-image — smoke", () => {
     }
   });
 
+  test("omits aspect and image size from service input when flags are omitted", async () => {
+    const channelDir = makeTempDir("cli-image-defaults-");
+    const registryEntry = REGISTRY["image.generate"];
+    const inputs: unknown[] = [];
+    const entry = {
+      ...registryEntry,
+      run: ((input) => {
+        inputs.push(input);
+        return Promise.resolve(
+          ok({
+            savedPath: join(channelDir, "collections/planning/demo/main.png"),
+          })
+        );
+      }) as typeof registryEntry.run,
+    };
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
+    const command = createGenerateImageCommand({
+      entry,
+      resolveDeps: () =>
+        Promise.resolve({
+          channelDir,
+          imageProvider: {
+            generate: () => Promise.resolve(new Uint8Array([1])),
+            name: "fake",
+            supportedAspectRatios: [],
+          },
+        }),
+    });
+
+    try {
+      await command.run?.({
+        args: {
+          json: false,
+          output: "collections/planning/demo/main.png",
+          prompt: "a square cafe thumbnail",
+          reference: undefined,
+        },
+      } as never);
+
+      expect(inputs).toEqual([
+        {
+          outputPath: "collections/planning/demo/main.png",
+          prompt: "a square cafe thumbnail",
+          references: undefined,
+        },
+      ]);
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
   test("formats provider config errors through the command helper", () => {
     const channelDir = writeOpenAIChannel();
 

--- a/packages/cli/test/yt-generate-image.test.ts
+++ b/packages/cli/test/yt-generate-image.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+import { referencesFromArg } from "../src/commands/generate-image/cli.ts";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
+const tmpDirs: string[] = [];
+
+const makeTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const realDir = realpathSync(dir);
+  tmpDirs.push(realDir);
+  return realDir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const runTayk = (
+  options: { env: Record<string, string | undefined> },
+  ...argv: string[]
+) => {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(options.env)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(env, key);
+    } else {
+      env[key] = value;
+    }
+  }
+
+  return Bun.spawnSync(["bun", taykBin, ...argv], {
+    cwd: repoRoot,
+    env,
+  });
+};
+
+const writeOpenAIChannel = (): string => {
+  const channelDir = makeTempDir("cli-image-channel-");
+  mkdirSync(join(channelDir, "config", "skills"), { recursive: true });
+  writeFileSync(
+    join(channelDir, "config", "skills", "thumbnail.yaml"),
+    ["image_generation:", "  provider: openai"].join("\n"),
+    "utf-8"
+  );
+  return channelDir;
+};
+
+describe("core registry — image.generate entry visible from cli package", () => {
+  test("should expose the registry entry consumed by the CLI adapter", () => {
+    const registry = REGISTRY as Record<
+      string,
+      { deps: readonly string[]; description: string }
+    >;
+    const entry = registry["image.generate"];
+
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("image.generate registry entry is required");
+    }
+    expect(entry.deps).toEqual(["imageProvider"]);
+    expect(entry.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe("tayk generate-image — smoke", () => {
+  test("wraps a single reference argument into the service input array", () => {
+    expect(referencesFromArg("ref.png")).toEqual(["ref.png"]);
+  });
+
+  test("keeps multiple reference arguments as the service input array", () => {
+    expect(referencesFromArg(["a.png", "b.png"])).toEqual(["a.png", "b.png"]);
+  });
+
+  test("rejects invalid reference argument values before service execution", () => {
+    expect(() => referencesFromArg([123])).toThrow(
+      "validation: --reference は文字列で指定してください"
+    );
+  });
+
+  test("formats provider config errors through the command helper", () => {
+    // Given an OpenAI-backed channel config and a request ratio OpenAI rejects
+    const channelDir = writeOpenAIChannel();
+
+    // When the dispatcher invokes the generate-image subcommand
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: channelDir, OPENAI_API_KEY: undefined } },
+      "generate-image",
+      "--prompt",
+      "a square cafe thumbnail",
+      "--output",
+      join(channelDir, "out.png"),
+      "--aspect-ratio",
+      "1:1",
+      "--json"
+    );
+
+    // Then the command reaches the shared Result -> exit-code helper without
+    // creating a per-CLI bin or making an external API request.
+    expect(proc.exitCode).toBe(1);
+    expect(proc.stderr.toString()).toStartWith("[config] ");
+    expect(proc.stderr.toString()).toContain("aspect_ratio");
+    expect(proc.stderr.toString()).not.toContain("at ");
+  });
+});

--- a/packages/core/src/image/base.ts
+++ b/packages/core/src/image/base.ts
@@ -7,11 +7,13 @@
 // 値のみを `Request` に保持し、API 固有の `size` 文字列・`quality` 等は Provider
 // 実装側で `aspectRatio` から導出する。
 
-// 1 件分の画像生成リクエストは service 境界の入力 schema を単一の真実とする
-// （ADR-0003 §8: zod を source of truth）。provider はその検証済みの値を受け取る。
-import type { GenerateImageInput } from "./schema.ts";
-
-export type ImageGenerationRequest = GenerateImageInput;
+export interface ImageGenerationRequest {
+  readonly aspectRatio: string;
+  readonly imageSize: string;
+  readonly outputPath: string;
+  readonly prompt: string;
+  readonly references?: readonly string[];
+}
 
 /**
  * 画像生成プロバイダーの最小契約。

--- a/packages/core/src/image/base.ts
+++ b/packages/core/src/image/base.ts
@@ -7,13 +7,9 @@
 // 値のみを `Request` に保持し、API 固有の `size` 文字列・`quality` 等は Provider
 // 実装側で `aspectRatio` から導出する。
 
-export interface ImageGenerationRequest {
-  readonly aspectRatio: string;
-  readonly imageSize: string;
-  readonly outputPath: string;
-  readonly prompt: string;
-  readonly references?: readonly string[];
-}
+import type { GenerateImageRequest } from "./schema.ts";
+
+export type ImageGenerationRequest = GenerateImageRequest;
 
 /**
  * 画像生成プロバイダーの最小契約。

--- a/packages/core/src/image/config.ts
+++ b/packages/core/src/image/config.ts
@@ -9,6 +9,8 @@
 // provider 値（"codex" / "gemini_cli" を含む）は `config:` prefix Error で fail fast する。
 // 入力キーは snake_case（既存 config パーサと同様）、出力は camelCase。
 
+import { parse as parseYaml } from "yaml";
+
 import { isRecord } from "./internal.ts";
 
 // サポートする provider 識別子。`getProvider` の dispatch キーと一致させる。
@@ -147,3 +149,7 @@ export const parseImageGenerationConfig = (
       `許容値: ${JSON.stringify(SUPPORTED_PROVIDERS)}`
   );
 };
+
+export const parseImageGenerationConfigYaml = (
+  text: string
+): ImageGenerationConfig => parseImageGenerationConfig(parseYaml(text));

--- a/packages/core/src/image/config.ts
+++ b/packages/core/src/image/config.ts
@@ -11,7 +11,7 @@
 
 import { isRecord } from "./internal.ts";
 
-// サポートする provider 識別子。`getProvider` の dispatch キーと一致させる。
+// サポートする provider 識別子。`createImageProvider` の dispatch キーと一致させる。
 const SUPPORTED_PROVIDERS = ["gemini", "openai"] as const;
 
 /** OpenAI が受理するアスペクト比（16:9 と 9:16 のみ）。 */

--- a/packages/core/src/image/config.ts
+++ b/packages/core/src/image/config.ts
@@ -9,8 +9,6 @@
 // provider 値（"codex" / "gemini_cli" を含む）は `config:` prefix Error で fail fast する。
 // 入力キーは snake_case（既存 config パーサと同様）、出力は camelCase。
 
-import { parse as parseYaml } from "yaml";
-
 import { isRecord } from "./internal.ts";
 
 // サポートする provider 識別子。`getProvider` の dispatch キーと一致させる。
@@ -149,7 +147,3 @@ export const parseImageGenerationConfig = (
       `許容値: ${JSON.stringify(SUPPORTED_PROVIDERS)}`
   );
 };
-
-export const parseImageGenerationConfigYaml = (
-  text: string
-): ImageGenerationConfig => parseImageGenerationConfig(parseYaml(text));

--- a/packages/core/src/image/gemini.ts
+++ b/packages/core/src/image/gemini.ts
@@ -116,9 +116,10 @@ export class GeminiImageProvider implements ImageProvider {
     const references = req.references ?? [];
     // req.imageSize が空のときのみ config の既定解像度に委ねる（Python と同じ挙動）。
     const imageSize = req.imageSize || this.config.imageSize;
+    const aspectRatio = req.aspectRatio || "16:9";
     const params = {
       config: {
-        imageConfig: { aspectRatio: req.aspectRatio, imageSize },
+        imageConfig: { aspectRatio, imageSize },
         responseModalities: ["IMAGE", "TEXT"],
       },
       contents: buildContents(req.prompt, references),

--- a/packages/core/src/image/gemini.ts
+++ b/packages/core/src/image/gemini.ts
@@ -48,8 +48,15 @@ const inlineImageBytes = (part: unknown): Uint8Array | null => {
   return null;
 };
 
-const referenceMime = (path: string): string =>
-  /\.jpe?g$/iu.test(path) ? "image/jpeg" : "image/png";
+const referenceMime = (path: string): string => {
+  if (/\.jpe?g$/iu.test(path)) {
+    return "image/jpeg";
+  }
+  if (/\.webp$/iu.test(path)) {
+    return "image/webp";
+  }
+  return "image/png";
+};
 
 // 参照画像を base64 inlineData Part に変換し、末尾に prompt を付ける（参照なしは [prompt]）。
 const buildContents = (

--- a/packages/core/src/image/index.ts
+++ b/packages/core/src/image/index.ts
@@ -26,6 +26,7 @@ export {
   OPENAI_SUPPORTED_ASPECT_RATIOS,
   type OpenAIConfig,
   parseImageGenerationConfig,
+  parseImageGenerationConfigYaml,
 } from "./config.ts";
 export { GeminiImageProvider, type GeminiProviderDeps } from "./gemini.ts";
 export { OpenAIImageProvider, type OpenAIProviderDeps } from "./openai.ts";

--- a/packages/core/src/image/index.ts
+++ b/packages/core/src/image/index.ts
@@ -4,7 +4,7 @@
 // 公開 API:
 // - generateImageService(input, deps): ADR-0003 Result 境界（ImageProvider.generate をラップ）
 // - GenerateImageInput / GenerateImageOutput: service 境界の zod schema（+ z.infer 型）
-// - getProvider(config): ImageGenerationConfig から ImageProvider 実装にディスパッチ
+// - createImageProvider(config, deps): ImageGenerationConfig から ImageProvider 実装にディスパッチ
 // - parseImageGenerationConfig(raw): skill-config から ImageGenerationConfig を構築
 // - ImageProvider / ImageGenerationRequest / PersistImage: 抽象契約（1-attempt、#959。
 //   リトライは core root の withRetry を service が所有する）
@@ -13,7 +13,14 @@
 import type { ImageProvider } from "./base.ts";
 import type { ImageGenerationConfig } from "./config.ts";
 import { GeminiImageProvider } from "./gemini.ts";
+import type { GeminiProviderDeps } from "./gemini.ts";
 import { OpenAIImageProvider } from "./openai.ts";
+import type { OpenAIProviderDeps } from "./openai.ts";
+
+export interface ImageProviderFactoryDeps {
+  readonly createGeminiClient?: GeminiProviderDeps["createClient"];
+  readonly createOpenAIClient?: OpenAIProviderDeps["createClient"];
+}
 
 export {
   type ImageGenerationRequest,
@@ -27,8 +34,6 @@ export {
   type OpenAIConfig,
   parseImageGenerationConfig,
 } from "./config.ts";
-export { GeminiImageProvider, type GeminiProviderDeps } from "./gemini.ts";
-export { OpenAIImageProvider, type OpenAIProviderDeps } from "./openai.ts";
 export { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
 export { generateImageService } from "./service.ts";
 
@@ -37,12 +42,25 @@ export { generateImageService } from "./service.ts";
  *
  * `provider` が {gemini, openai} 以外（手組みの不正値など）なら `config:` prefix Error で fail fast。
  */
-export const getProvider = (config: ImageGenerationConfig): ImageProvider => {
+export const createImageProvider = (
+  config: ImageGenerationConfig,
+  deps: ImageProviderFactoryDeps = {}
+): ImageProvider => {
   if (config.provider === "gemini") {
-    return new GeminiImageProvider(config.gemini);
+    return new GeminiImageProvider(
+      config.gemini,
+      deps.createGeminiClient === undefined
+        ? undefined
+        : { createClient: deps.createGeminiClient }
+    );
   }
   if (config.provider === "openai") {
-    return new OpenAIImageProvider(config.openai);
+    return new OpenAIImageProvider(
+      config.openai,
+      deps.createOpenAIClient === undefined
+        ? undefined
+        : { createClient: deps.createOpenAIClient }
+    );
   }
   const { provider } = config as { provider: string };
   throw new Error(`config: 未対応の provider=${JSON.stringify(provider)}`);

--- a/packages/core/src/image/index.ts
+++ b/packages/core/src/image/index.ts
@@ -26,7 +26,6 @@ export {
   OPENAI_SUPPORTED_ASPECT_RATIOS,
   type OpenAIConfig,
   parseImageGenerationConfig,
-  parseImageGenerationConfigYaml,
 } from "./config.ts";
 export { GeminiImageProvider, type GeminiProviderDeps } from "./gemini.ts";
 export { OpenAIImageProvider, type OpenAIProviderDeps } from "./openai.ts";

--- a/packages/core/src/image/openai.ts
+++ b/packages/core/src/image/openai.ts
@@ -90,11 +90,12 @@ export class OpenAIImageProvider implements ImageProvider {
   }
 
   async generate(req: ImageGenerationRequest): Promise<Uint8Array> {
-    const size = ASPECT_RATIO_TO_SIZE[req.aspectRatio];
+    const aspectRatio = req.aspectRatio || this.config.aspectRatio;
+    const size = ASPECT_RATIO_TO_SIZE[aspectRatio];
     if (size === undefined) {
       // 未対応比率は client 生成・SDK 呼び出し前に fail fast（リトライしない）。
       throw new Error(
-        `config: OpenAI image_generation の aspect_ratio=${JSON.stringify(req.aspectRatio)} は未対応。` +
+        `config: OpenAI image_generation の aspect_ratio=${JSON.stringify(aspectRatio)} は未対応。` +
           `許容値: ${JSON.stringify(Object.keys(ASPECT_RATIO_TO_SIZE))}`
       );
     }

--- a/packages/core/src/image/paths.ts
+++ b/packages/core/src/image/paths.ts
@@ -1,0 +1,200 @@
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+
+const OUTPUT_DIRS = ["branding", "collections"] as const;
+const REFERENCE_DIRS = ["assets", "collections", "references"] as const;
+const OUTPUT_EXTENSIONS = new Set([".jpg", ".jpeg", ".png"]);
+const REFERENCE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
+const MAX_REFERENCE_BYTES = 10 * 1024 * 1024;
+
+const assertRelativePath = (label: string, value: string): void => {
+  if (isAbsolute(value)) {
+    throw new Error(`validation: ${label} は相対パスで指定してください`);
+  }
+  const parts = value.split(/[\\/]+/u);
+  if (parts.includes("..") || parts.includes("")) {
+    throw new Error(`validation: ${label} に不正なパス区切りが含まれています`);
+  }
+};
+
+const assertAllowedDir = (
+  label: string,
+  value: string,
+  allowedDirs: readonly string[]
+): void => {
+  const [head] = value.split(/[\\/]+/u);
+  if (head === undefined || !allowedDirs.some((dir) => dir === head)) {
+    throw new Error(
+      `validation: ${label} は ${allowedDirs.join(" / ")} 配下を指定してください`
+    );
+  }
+};
+
+const assertAllowedExtension = (
+  label: string,
+  value: string,
+  allowedExtensions: ReadonlySet<string>
+): void => {
+  const extension = extname(value).toLowerCase();
+  if (!allowedExtensions.has(extension)) {
+    throw new Error(
+      `validation: ${label} の拡張子は ${[...allowedExtensions].join(" / ")} のいずれかにしてください`
+    );
+  }
+};
+
+const assertUnderRoot = (
+  label: string,
+  rootRealPath: string,
+  targetRealPath: string
+): void => {
+  const rel = relative(rootRealPath, targetRealPath);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) {
+    return;
+  }
+  throw new Error(
+    `validation: ${label} は channel root 配下を指定してください`
+  );
+};
+
+const nearestExistingPath = (path: string): string => {
+  let current = path;
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) {
+      return current;
+    }
+    current = parent;
+  }
+  return current;
+};
+
+const isSymlink = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const assertExistingAncestorUnderRoot = (
+  label: string,
+  rootRealPath: string,
+  targetPath: string
+): void => {
+  const existing = nearestExistingPath(targetPath);
+  assertUnderRoot(label, rootRealPath, realpathSync(existing));
+};
+
+const assertNoSymlinkInExistingPath = (
+  label: string,
+  rootRealPath: string,
+  targetPath: string
+): void => {
+  const rel = relative(rootRealPath, targetPath);
+  const parts = rel.split(sep).filter(Boolean);
+  let current = rootRealPath;
+  for (const part of parts.slice(0, -1)) {
+    current = resolve(current, part);
+    if (isSymlink(current)) {
+      throw new Error(
+        `validation: ${label} に symlink 経由のパスは指定できません`
+      );
+    }
+  }
+};
+
+const detectImageMagic = (bytes: Uint8Array): boolean => {
+  const isPng =
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47;
+  const isJpeg = bytes[0] === 0xff && bytes[1] === 0xd8;
+  const isWebp =
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50;
+  return isPng || isJpeg || isWebp;
+};
+
+const assertImageFile = (label: string, path: string): void => {
+  const bytes = readFileSync(path).subarray(0, 12);
+  if (!detectImageMagic(bytes)) {
+    throw new Error(`validation: ${label} は画像ファイルを指定してください`);
+  }
+};
+
+export const resolveOutputPath = (
+  channelDir: string,
+  outputPath: string
+): string => {
+  assertRelativePath("output_path", outputPath);
+  assertAllowedDir("output_path", outputPath, OUTPUT_DIRS);
+  assertAllowedExtension("output_path", outputPath, OUTPUT_EXTENSIONS);
+
+  const rootRealPath = realpathSync(channelDir);
+  const absolute = resolve(rootRealPath, outputPath);
+  assertUnderRoot("output_path", rootRealPath, absolute);
+  assertExistingAncestorUnderRoot(
+    "output_path",
+    rootRealPath,
+    dirname(absolute)
+  );
+  assertNoSymlinkInExistingPath("output_path", rootRealPath, absolute);
+  if (isSymlink(absolute)) {
+    throw new Error("validation: output_path に symlink は指定できません");
+  }
+  return absolute;
+};
+
+export const resolveReferencePaths = (
+  channelDir: string,
+  references: readonly string[] | undefined
+): string[] | undefined => {
+  if (references === undefined) {
+    return undefined;
+  }
+  const rootRealPath = realpathSync(channelDir);
+  return references.map((reference) => {
+    assertRelativePath("references", reference);
+    assertAllowedDir("references", reference, REFERENCE_DIRS);
+    assertAllowedExtension("references", reference, REFERENCE_EXTENSIONS);
+    const absolute = resolve(rootRealPath, reference);
+    if (!existsSync(absolute)) {
+      throw new Error(`validation: references が存在しません: ${reference}`);
+    }
+    const real = realpathSync(absolute);
+    assertUnderRoot("references", rootRealPath, real);
+    const stat = statSync(real);
+    if (!stat.isFile()) {
+      throw new Error(`validation: references はファイルを指定してください`);
+    }
+    if (stat.size > MAX_REFERENCE_BYTES) {
+      throw new Error("validation: references のファイルサイズが大きすぎます");
+    }
+    assertImageFile("references", real);
+    return real;
+  });
+};

--- a/packages/core/src/image/paths.ts
+++ b/packages/core/src/image/paths.ts
@@ -14,7 +14,6 @@ import {
   sep,
 } from "node:path";
 
-const OUTPUT_DIRS = ["branding", "collections"] as const;
 const REFERENCE_DIRS = ["assets", "collections", "references"] as const;
 const OUTPUT_EXTENSIONS = new Set([".jpg", ".jpeg", ".png"]);
 const REFERENCE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
@@ -151,7 +150,6 @@ export const resolveOutputPath = (
   outputPath: string
 ): string => {
   assertRelativePath("output_path", outputPath);
-  assertAllowedDir("output_path", outputPath, OUTPUT_DIRS);
   assertAllowedExtension("output_path", outputPath, OUTPUT_EXTENSIONS);
 
   const rootRealPath = realpathSync(channelDir);

--- a/packages/core/src/image/paths.ts
+++ b/packages/core/src/image/paths.ts
@@ -183,6 +183,10 @@ export const resolveReferencePaths = (
     if (!existsSync(absolute)) {
       throw new Error(`validation: references が存在しません: ${reference}`);
     }
+    assertNoSymlinkInExistingPath("references", rootRealPath, absolute);
+    if (isSymlink(absolute)) {
+      throw new Error("validation: references に symlink は指定できません");
+    }
     const real = realpathSync(absolute);
     assertUnderRoot("references", rootRealPath, real);
     const stat = statSync(real);

--- a/packages/core/src/image/schema.ts
+++ b/packages/core/src/image/schema.ts
@@ -1,11 +1,13 @@
 // 画像生成サービス境界の入力 / 出力 schema（ADR-0003 §8: zod を source of truth）。
 //
-// 入力はチャンネル config / API レスポンス由来の JSON ではなく、呼び出し側が
-// 組み立てる in-process な値オブジェクトのため、snake_case → camelCase の
-// `.transform()` は不要で camelCase のまま declare する。型は `z.infer` で導出し
-// 並書の `interface` は持たない。`.strict()` で未知キーを reject（fail fast）。
+// registry / CLI から入る raw input は snake_case、provider が consume する内部 shape は
+// camelCase。境界 schema で正規化し、service 内の再 parse では正規化済み shape も受ける。
+// 型は `z.infer` で導出し、並書の `interface` は持たない。`.strict()` で未知キーを reject
+//（fail fast）。
 
 import { z } from "zod";
+
+import { snakeToCamel } from "../../internal/case.ts";
 
 /**
  * 1 件分の画像生成リクエスト。
@@ -16,7 +18,7 @@ import { z } from "zod";
  * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
  * - `references`: 参照画像パス（省略・空なら参照なしモード）
  */
-export const GenerateImageInput = z
+const GenerateImageInputCamel = z
   .object({
     aspectRatio: z.string(),
     imageSize: z.string(),
@@ -25,6 +27,24 @@ export const GenerateImageInput = z
     references: z.array(z.string()).optional(),
   })
   .strict();
+
+const GenerateImageInputSnake = z
+  .object({
+    aspect_ratio: z.string(),
+    image_size: z.string(),
+    output_path: z.string(),
+    prompt: z.string(),
+    references: z.array(z.string()).optional(),
+  })
+  .strict()
+  .transform(
+    (input): z.infer<typeof GenerateImageInputCamel> => snakeToCamel(input)
+  );
+
+export const GenerateImageInput = z.union([
+  GenerateImageInputSnake,
+  GenerateImageInputCamel,
+]);
 export type GenerateImageInput = z.infer<typeof GenerateImageInput>;
 
 /**

--- a/packages/core/src/image/schema.ts
+++ b/packages/core/src/image/schema.ts
@@ -1,9 +1,8 @@
 // 画像生成サービス境界の入力 / 出力 schema（ADR-0003 §8: zod を source of truth）。
 //
-// registry / CLI から入る raw input は snake_case、provider が consume する内部 shape は
-// camelCase。境界 schema で正規化し、service 内の再 parse では正規化済み shape も受ける。
-// 型は `z.infer` で導出し、並書の `interface` は持たない。`.strict()` で未知キーを reject
-//（fail fast）。
+// registry / CLI から入る raw input は snake_case のみ受理し、provider が consume する
+// 内部 shape は camelCase へ正規化する。型は `z.infer` で導出し、並書の `interface` は
+// 持たない。`.strict()` で未知キーを reject（fail fast）。
 
 import { z } from "zod";
 
@@ -18,7 +17,7 @@ import { snakeToCamel } from "../../internal/case.ts";
  * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
  * - `references`: 参照画像パス（省略・空なら参照なしモード）
  */
-const GenerateImageInputCamel = z
+export const GenerateImageRequest = z
   .object({
     aspectRatio: z.string(),
     imageSize: z.string(),
@@ -27,8 +26,9 @@ const GenerateImageInputCamel = z
     references: z.array(z.string()).optional(),
   })
   .strict();
+export type GenerateImageRequest = z.infer<typeof GenerateImageRequest>;
 
-const GenerateImageInputSnake = z
+export const GenerateImageInput = z
   .object({
     aspect_ratio: z.string(),
     image_size: z.string(),
@@ -38,13 +38,9 @@ const GenerateImageInputSnake = z
   })
   .strict()
   .transform(
-    (input): z.infer<typeof GenerateImageInputCamel> => snakeToCamel(input)
+    (input): GenerateImageRequest =>
+      GenerateImageRequest.parse(snakeToCamel(input))
   );
-
-export const GenerateImageInput = z.union([
-  GenerateImageInputSnake,
-  GenerateImageInputCamel,
-]);
 export type GenerateImageInput = z.infer<typeof GenerateImageInput>;
 
 /**

--- a/packages/core/src/image/schema.ts
+++ b/packages/core/src/image/schema.ts
@@ -23,7 +23,7 @@ export const GenerateImageRequest = z
     imageSize: z.string(),
     outputPath: z.string(),
     prompt: z.string(),
-    references: z.array(z.string()).optional(),
+    references: z.array(z.string()).readonly().optional(),
   })
   .strict();
 export type GenerateImageRequest = z.infer<typeof GenerateImageRequest>;

--- a/packages/core/src/image/schema.ts
+++ b/packages/core/src/image/schema.ts
@@ -13,14 +13,14 @@ import { snakeToCamel } from "../../internal/case.ts";
  *
  * - `prompt`: 生成プロンプト
  * - `outputPath`: 出力先（拡張子 .png なら PNG、.jpg なら JPEG として保存）
- * - `aspectRatio`: "16:9" / "9:16" / "1:1" など。OpenAI は 16:9 / 9:16 のみ受理
- * - `imageSize`: Provider 固有の解像度ヒント（Gemini は "1K"/"2K"/"4K" 等）
+ * - `aspectRatio`: "16:9" / "9:16" / "1:1" など。省略時は provider config に委ねる
+ * - `imageSize`: Provider 固有の解像度ヒント。省略時は provider config に委ねる
  * - `references`: 参照画像パス（省略・空なら参照なしモード）
  */
 export const GenerateImageRequest = z
   .object({
-    aspectRatio: z.string(),
-    imageSize: z.string(),
+    aspectRatio: z.string().optional(),
+    imageSize: z.string().optional(),
     outputPath: z.string(),
     prompt: z.string(),
     references: z.array(z.string()).readonly().optional(),
@@ -30,8 +30,8 @@ export type GenerateImageRequest = z.infer<typeof GenerateImageRequest>;
 
 export const GenerateImageInput = z
   .object({
-    aspect_ratio: z.string(),
-    image_size: z.string(),
+    aspect_ratio: z.string().optional(),
+    image_size: z.string().optional(),
     output_path: z.string(),
     prompt: z.string(),
     references: z.array(z.string()).optional(),

--- a/packages/core/src/image/service.ts
+++ b/packages/core/src/image/service.ts
@@ -22,10 +22,14 @@ import type { Result } from "../result.ts";
 import { defaultShouldRetry, withRetry } from "../retry.ts";
 import type { SleepMs } from "../retry.ts";
 import { isContentPolicyError } from "./base.ts";
-import type { ImageProvider, PersistImage } from "./base.ts";
+import type {
+  ImageGenerationRequest,
+  ImageProvider,
+  PersistImage,
+} from "./base.ts";
 import { defaultPersist, defaultSleep } from "./io.ts";
 import { resolveOutputPath, resolveReferencePaths } from "./paths.ts";
-import { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
+import { GenerateImageOutput, GenerateImageRequest } from "./schema.ts";
 
 /**
  * 画像を 1 枚生成して保存し、保存先を `Result` で返す。
@@ -37,7 +41,7 @@ import { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
  * エラーになる。
  */
 export const generateImageService = async (
-  input: GenerateImageInput,
+  input: ImageGenerationRequest,
   deps: {
     channelDir: string;
     persist?: PersistImage;
@@ -46,7 +50,7 @@ export const generateImageService = async (
   }
 ): Promise<Result<GenerateImageOutput, ServiceError>> => {
   try {
-    const request = GenerateImageInput.parse(input);
+    const request = GenerateImageRequest.parse(input);
     const safeRequest = {
       ...request,
       outputPath: resolveOutputPath(deps.channelDir, request.outputPath),

--- a/packages/core/src/image/service.ts
+++ b/packages/core/src/image/service.ts
@@ -24,6 +24,7 @@ import type { SleepMs } from "../retry.ts";
 import { isContentPolicyError } from "./base.ts";
 import type { ImageProvider, PersistImage } from "./base.ts";
 import { defaultPersist, defaultSleep } from "./io.ts";
+import { resolveOutputPath, resolveReferencePaths } from "./paths.ts";
 import { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
 
 /**
@@ -37,18 +38,28 @@ import { GenerateImageInput, GenerateImageOutput } from "./schema.ts";
  */
 export const generateImageService = async (
   input: GenerateImageInput,
-  deps: { persist?: PersistImage; provider: ImageProvider; sleep?: SleepMs }
+  deps: {
+    channelDir: string;
+    persist?: PersistImage;
+    provider: ImageProvider;
+    sleep?: SleepMs;
+  }
 ): Promise<Result<GenerateImageOutput, ServiceError>> => {
   try {
     const request = GenerateImageInput.parse(input);
-    const bytes = await withRetry(() => deps.provider.generate(request), {
+    const safeRequest = {
+      ...request,
+      outputPath: resolveOutputPath(deps.channelDir, request.outputPath),
+      references: resolveReferencePaths(deps.channelDir, request.references),
+    };
+    const bytes = await withRetry(() => deps.provider.generate(safeRequest), {
       // SAFETY / RECITATION はリトライしても通らないため non-retryable に倒す。
       shouldRetry: (error) =>
         defaultShouldRetry(error) && !isContentPolicyError(error),
       sleep: deps.sleep ?? defaultSleep,
     });
     const savedPath = await (deps.persist ?? defaultPersist)(
-      request.outputPath,
+      safeRequest.outputPath,
       bytes
     );
     return ok(GenerateImageOutput.parse({ savedPath }));

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -76,12 +76,15 @@ const defineRegistryEntry = <
 
 export const REGISTRY = {
   "image.generate": defineRegistryEntry({
-    deps: ["imageProvider"],
+    deps: ["channelDir", "imageProvider"],
     description: "Gemini / OpenAI provider で画像を生成して保存する",
     inputSchema: GenerateImageInput,
     outputSchema: GenerateImageOutput,
     run: (input, deps) =>
-      generateImageService(input, { provider: deps.imageProvider }),
+      generateImageService(input, {
+        channelDir: deps.channelDir,
+        provider: deps.imageProvider,
+      }),
   }),
   "skills.list": defineRegistryEntry({
     deps: [],

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2,6 +2,12 @@ import type { z } from "zod";
 
 import type { ChannelConfig } from "./config/index.ts";
 import type { ServiceError } from "./errors.ts";
+import type { ImageProvider } from "./image/index.ts";
+import {
+  GenerateImageInput,
+  GenerateImageOutput,
+  generateImageService,
+} from "./image/index.ts";
 import type { YouTubeAnalyticsClient, YouTubeClient } from "./oauth/client.ts";
 import type { Result } from "./result.ts";
 import {
@@ -30,12 +36,14 @@ import {
 // service が要求しうる重い依存の型対応表 (#993)。各 service は deps 配列で必要な key
 // だけを宣言し、Pick<DepsMap, D> で run の第 2 引数を compile-time に確定させる。
 //   - config:      ChannelConfig (#961 前倒し。service は loadConfig() を内部呼びしない)
+//   - imageProvider: Gemini / OpenAI image provider
 //   - yt:          YouTube Data API v3 client
 //   - ytAnalytics: YouTube Analytics API v2 client (最小権限: analytics service は yt に触れない)
 // 個別 client を載せるのは最小権限の原則。token ではなく構築済み client を注入する。
 export interface DepsMap {
   channelDir: string;
   config: ChannelConfig;
+  imageProvider: ImageProvider;
   yt: YouTubeClient;
   ytAnalytics: YouTubeAnalyticsClient;
 }
@@ -67,6 +75,14 @@ const defineRegistryEntry = <
 ): RegistryEntry<I, O, D> => entry;
 
 export const REGISTRY = {
+  "image.generate": defineRegistryEntry({
+    deps: ["imageProvider"],
+    description: "Gemini / OpenAI provider で画像を生成して保存する",
+    inputSchema: GenerateImageInput,
+    outputSchema: GenerateImageOutput,
+    run: (input, deps) =>
+      generateImageService(input, { provider: deps.imageProvider }),
+  }),
   "skills.list": defineRegistryEntry({
     deps: [],
     description: "同梱スキル一覧を列挙する",

--- a/packages/core/test/image-config.test.ts
+++ b/packages/core/test/image-config.test.ts
@@ -5,7 +5,7 @@
 // Signature contract (test-first spec the draft implements), from plan §6/§7:
 //   OPENAI_SUPPORTED_ASPECT_RATIOS = ["16:9", "9:16"]
 //   parseImageGenerationConfig(raw: unknown): ImageGenerationConfig
-//   getProvider(config: ImageGenerationConfig, deps?): ImageProvider
+//   createImageProvider(config: ImageGenerationConfig, deps?): ImageProvider
 //
 // Scope note (plan §4-D): legacy `gemini_image:` namespace, `gemini_cli`/`codex`
 // providers, `thinking`, and `replace_model` are intentionally NOT ported, so an
@@ -16,7 +16,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  getProvider,
+  createImageProvider,
   OPENAI_SUPPORTED_ASPECT_RATIOS,
   parseImageGenerationConfig,
 } from "@youtube-automation/core/image";
@@ -177,16 +177,16 @@ describe("parseImageGenerationConfig fail-fast", () => {
   });
 });
 
-// --- getProvider dispatch -------------------------------------------------
+// --- createImageProvider dispatch -----------------------------------------
 
-describe("getProvider dispatch", () => {
+describe("createImageProvider dispatch", () => {
   test("returns a gemini provider with no aspect-ratio restriction", () => {
     // Given a parsed gemini config
     const config = parseImageGenerationConfig({
       image_generation: { provider: "gemini" },
     });
     // When dispatching to a provider
-    const provider = getProvider(config);
+    const provider = createImageProvider(config);
     // Then the gemini provider exposes its identifier and an empty (unrestricted)
     // aspect-ratio set (gemini.py:27-29)
     expect(provider.name).toBe("gemini");
@@ -199,7 +199,7 @@ describe("getProvider dispatch", () => {
       image_generation: { provider: "openai" },
     });
     // When dispatching to a provider
-    const provider = getProvider(config);
+    const provider = createImageProvider(config);
     // Then the openai provider advertises its restricted ratios (openai.py:43-44)
     expect(provider.name).toBe("openai");
     expect([...provider.supportedAspectRatios]).toEqual(["16:9", "9:16"]);
@@ -209,7 +209,7 @@ describe("getProvider dispatch", () => {
     // Given a hand-rolled config carrying an unsupported provider (__init__.py:75)
     const bogus = { provider: "codex" } as unknown as ImageGenerationConfig;
     // When dispatching it
-    // Then getProvider raises a config:-prefixed Error rather than returning undefined
-    expect(() => getProvider(bogus)).toThrow(/^config:/u);
+    // Then createImageProvider raises a config:-prefixed Error rather than returning undefined
+    expect(() => createImageProvider(bogus)).toThrow(/^config:/u);
   });
 });

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -33,11 +33,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  GeminiImageProvider,
-  generateImageService,
-} from "@youtube-automation/core/image";
+import { generateImageService } from "@youtube-automation/core/image";
 import type { GenerateImageInput } from "@youtube-automation/core/image";
+
+import { GeminiImageProvider } from "../src/image/gemini.ts";
 
 // Constructor deps type, derived from the provider itself so the test does not
 // hard-code an exported name for the injection bag.
@@ -272,6 +271,26 @@ describe("generateImageService (gemini) success", () => {
     const params = calls[0] as { model?: unknown };
     expect(params.model).toBe("gemini-3.1-flash-image-preview");
     expect(JSON.stringify(calls[0])).toContain("16:9");
+  });
+
+  test("uses the configured image size when the request omits imageSize", async () => {
+    const base64 = Buffer.from(new Uint8Array([1, 2, 3])).toString("base64");
+    const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
+    const provider = new GeminiImageProvider(
+      { ...geminiConfig, imageSize: "4K" },
+      makeDeps(client)
+    );
+
+    await provider.generate({
+      aspectRatio: "16:9",
+      outputPath: "collections/planning/demo/config-size.png",
+      prompt: "a calm lo-fi study room at night",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      config: { imageConfig: { aspectRatio: "16:9", imageSize: "4K" } },
+    });
   });
 
   test("inlines reference image bytes as base64 into the request", async () => {

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -301,6 +301,30 @@ describe("generateImageService (gemini) success", () => {
     const refBase64 = Buffer.from(refBytes).toString("base64");
     expect(JSON.stringify(calls[0])).toContain(refBase64);
   });
+
+  test("uses image/webp MIME for WebP reference images", async () => {
+    const refBytes = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    const refPath = "collections/planning/demo/ref.webp";
+    mkdirSync(channelPath("collections/planning/demo"), { recursive: true });
+    writeFileSync(channelPath(refPath), refBytes);
+    const base64 = Buffer.from(new Uint8Array([9, 9, 9])).toString("base64");
+    const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
+    const recorders = makeRecorders();
+    const provider = new GeminiImageProvider(geminiConfig, makeDeps(client));
+
+    const r = await generateImageService(
+      {
+        ...baseRequest("collections/planning/demo/webp-out.png"),
+        references: [refPath],
+      },
+      serviceDeps(provider, recorders)
+    );
+
+    expect(r.ok).toBe(true);
+    expect(JSON.stringify(calls[0])).toContain('"mimeType":"image/webp"');
+  });
 });
 
 // --- service retry path -----------------------------------------------------

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -23,7 +23,13 @@
 // `inlineData.data` and returns the raw bytes, mirroring the OpenAI b64 path.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -99,11 +105,16 @@ const makeRecorders = () => {
 const makeDeps = (client: unknown): GeminiDeps =>
   ({ createClient: () => client }) as unknown as GeminiDeps;
 
+let workdir: string;
+
+const channelPath = (path: string): string => join(realpathSync(workdir), path);
+
 // Service deps bundling the provider with the fake sleep/persist recorders.
 const serviceDeps = (
   provider: GeminiImageProvider,
   recorders: ReturnType<typeof makeRecorders>
 ) => ({
+  channelDir: workdir,
   persist: recorders.persist,
   provider,
   sleep: recorders.sleep,
@@ -120,10 +131,6 @@ const baseRequest = (outputPath: string): GenerateImageInput => ({
   outputPath,
   prompt: "a calm lo-fi study room at night",
 });
-
-// --- temp dir for reference-image fixtures -------------------------------
-
-let workdir: string;
 
 beforeAll(() => {
   workdir = mkdtempSync(join(tmpdir(), "img-gemini-"));
@@ -157,7 +164,9 @@ describe("GeminiImageProvider 1-attempt contract", () => {
     const provider = new GeminiImageProvider(geminiConfig, makeDeps(client));
 
     // When calling the provider directly
-    const bytes = await provider.generate(baseRequest(join(workdir, "u.png")));
+    const bytes = await provider.generate(
+      baseRequest("collections/planning/demo/u.png")
+    );
 
     // Then the decoded bytes come back from a single SDK call — no retry, no
     // persistence side effect inside the provider
@@ -176,7 +185,7 @@ describe("GeminiImageProvider 1-attempt contract", () => {
     // Then it throws once without retrying internally; the message carries no
     // domain prefix so the service-side withRetry treats it as retryable
     await expect(
-      provider.generate(baseRequest(join(workdir, "miss-unit.png")))
+      provider.generate(baseRequest("collections/planning/demo/miss-unit.png"))
     ).rejects.toThrow("gemini が画像なしレスポンスを返しました");
     expect(calls).toHaveLength(1);
   });
@@ -194,7 +203,9 @@ describe("GeminiImageProvider 1-attempt contract", () => {
     // When calling the provider directly
     let caught: unknown;
     try {
-      await provider.generate(baseRequest(join(workdir, "safety-unit.png")));
+      await provider.generate(
+        baseRequest("collections/planning/demo/safety-unit.png")
+      );
     } catch (error) {
       caught = error;
     }
@@ -216,7 +227,7 @@ describe("generateImageService (gemini) success", () => {
     const { client } = makeGeminiClient([() => imageResponse(base64)]);
     const recorders = makeRecorders();
     const provider = new GeminiImageProvider(geminiConfig, makeDeps(client));
-    const outputPath = join(workdir, "out.png");
+    const outputPath = "collections/planning/demo/out.png";
 
     // When generating through the service boundary
     const r = await generateImageService(
@@ -230,14 +241,14 @@ describe("generateImageService (gemini) success", () => {
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
     }
-    expect(r.value.savedPath).toBe(outputPath);
+    expect(r.value.savedPath).toBe(channelPath(outputPath));
     expect(recorders.persisted).toHaveLength(1);
     const [persisted] = recorders.persisted;
     if (!persisted) {
       throw new Error("expected a persisted image");
     }
     expect([...persisted.bytes]).toEqual([...original]);
-    expect(persisted.path).toBe(outputPath);
+    expect(persisted.path).toBe(channelPath(outputPath));
     expect(recorders.sleeps).toEqual([]);
   });
 
@@ -250,7 +261,7 @@ describe("generateImageService (gemini) success", () => {
 
     // When generating with aspect ratio 16:9 through the service
     const r = await generateImageService(
-      baseRequest(join(workdir, "fwd.png")),
+      baseRequest("collections/planning/demo/fwd.png"),
       serviceDeps(provider, recorders)
     );
 
@@ -265,9 +276,12 @@ describe("generateImageService (gemini) success", () => {
 
   test("inlines reference image bytes as base64 into the request", async () => {
     // Given a reference image on disk and a successful response
-    const refBytes = new Uint8Array([0x10, 0x20, 0x30, 0x40]);
-    const refPath = join(workdir, "ref.png");
-    writeFileSync(refPath, refBytes);
+    const refBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    const refPath = "collections/planning/demo/ref.png";
+    mkdirSync(channelPath("collections/planning/demo"), { recursive: true });
+    writeFileSync(channelPath(refPath), refBytes);
     const base64 = Buffer.from(new Uint8Array([9, 9, 9])).toString("base64");
     const { calls, client } = makeGeminiClient([() => imageResponse(base64)]);
     const recorders = makeRecorders();
@@ -275,7 +289,10 @@ describe("generateImageService (gemini) success", () => {
 
     // When generating with a reference image (gemini.py:45-51)
     const r = await generateImageService(
-      { ...baseRequest(join(workdir, "ref-out.png")), references: [refPath] },
+      {
+        ...baseRequest("collections/planning/demo/ref-out.png"),
+        references: [refPath],
+      },
       serviceDeps(provider, recorders)
     );
 
@@ -299,7 +316,7 @@ describe("generateImageService (gemini) retry", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      baseRequest(join(workdir, "miss.png")),
+      baseRequest("collections/planning/demo/miss.png"),
       serviceDeps(provider, recorders)
     );
 
@@ -333,7 +350,7 @@ describe("generateImageService (gemini) retry", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      baseRequest(join(workdir, "late.png")),
+      baseRequest("collections/planning/demo/late.png"),
       serviceDeps(provider, recorders)
     );
 
@@ -359,7 +376,7 @@ describe("generateImageService (gemini) content policy", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      baseRequest(join(workdir, "safety.png")),
+      baseRequest("collections/planning/demo/safety.png"),
       serviceDeps(provider, recorders)
     );
 
@@ -385,7 +402,7 @@ describe("generateImageService (gemini) content policy", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      baseRequest(join(workdir, "recite.png")),
+      baseRequest("collections/planning/demo/recite.png"),
       serviceDeps(provider, recorders)
     );
 
@@ -408,7 +425,7 @@ describe("generateImageService input validation", () => {
 
     // When the input carries an unexpected key the `.strict()` schema rejects
     const malformed = {
-      ...baseRequest(join(workdir, "bad.png")),
+      ...baseRequest("collections/planning/demo/bad.png"),
       unexpected: true,
     } as unknown as GenerateImageInput;
     const r = await generateImageService(

--- a/packages/core/test/image-openai.test.ts
+++ b/packages/core/test/image-openai.test.ts
@@ -34,11 +34,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  generateImageService,
-  OpenAIImageProvider,
-} from "@youtube-automation/core/image";
+import { generateImageService } from "@youtube-automation/core/image";
 import type { GenerateImageInput } from "@youtube-automation/core/image";
+
+import { OpenAIImageProvider } from "../src/image/openai.ts";
 
 type OpenAIDeps = NonNullable<
   ConstructorParameters<typeof OpenAIImageProvider>[1]
@@ -154,10 +153,10 @@ const openaiConfig = {
 
 const request = (
   outputPath: string,
-  aspectRatio: string,
+  aspectRatio?: string,
   references?: string[]
 ): GenerateImageInput => ({
-  aspectRatio,
+  ...(aspectRatio === undefined ? {} : { aspectRatio }),
   imageSize: "",
   outputPath,
   prompt: "warm acoustic cafe afternoon",
@@ -301,6 +300,27 @@ describe("generateImageService (openai) success", () => {
     expect(params.model).toBe("gpt-image-2");
     expect(params.n).toBe(1);
     expect(recorders.sleeps).toEqual([]);
+  });
+
+  test("uses the configured aspect ratio when the request omits aspectRatio", async () => {
+    const original = new Uint8Array([0xff, 0xd8, 0xff, 5, 6, 7]);
+    const base64 = Buffer.from(original).toString("base64");
+    const { client, generateCalls } = makeOpenAIClient({
+      generate: [() => imageResponse(base64)],
+    });
+    const recorders = makeRecorders();
+    const provider = new OpenAIImageProvider(
+      { ...openaiConfig, aspectRatio: "9:16" },
+      makeDeps(client, recorders)
+    );
+
+    const bytes = await provider.generate(
+      request("collections/planning/demo/config-ratio.png")
+    );
+
+    expect([...bytes]).toEqual([...original]);
+    expect(generateCalls).toHaveLength(1);
+    expect(generateCalls[0]).toMatchObject({ size: "1024x1536" });
   });
 
   test("maps 9:16 → 1024x1536 for the portrait request", async () => {

--- a/packages/core/test/image-openai.test.ts
+++ b/packages/core/test/image-openai.test.ts
@@ -24,7 +24,13 @@
 // and rejects unmapped ratios with a `config:`-prefixed Error WITHOUT retrying.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -124,11 +130,16 @@ const makeDeps = (
     },
   }) as unknown as OpenAIDeps;
 
+let workdir: string;
+
+const channelPath = (path: string): string => join(realpathSync(workdir), path);
+
 // Service deps bundling the provider with the fake sleep/persist recorders.
 const serviceDeps = (
   provider: OpenAIImageProvider,
   recorders: ReturnType<typeof makeRecorders>
 ) => ({
+  channelDir: workdir,
   persist: recorders.persist,
   provider,
   sleep: recorders.sleep,
@@ -152,8 +163,6 @@ const request = (
   prompt: "warm acoustic cafe afternoon",
   ...(references ? { references } : {}),
 });
-
-let workdir: string;
 
 beforeAll(() => {
   workdir = mkdtempSync(join(tmpdir(), "img-openai-"));
@@ -194,7 +203,7 @@ describe("OpenAIImageProvider 1-attempt contract", () => {
 
     // When calling the provider directly
     const bytes = await provider.generate(
-      request(join(workdir, "unit.png"), "16:9")
+      request("collections/planning/demo/unit.png", "16:9")
     );
 
     // Then the decoded bytes come back from a single SDK call — no retry, no
@@ -218,7 +227,9 @@ describe("OpenAIImageProvider 1-attempt contract", () => {
     // Then it throws once without retrying internally; the message carries no
     // domain prefix so the service-side withRetry treats it as retryable
     await expect(
-      provider.generate(request(join(workdir, "empty-unit.png"), "16:9"))
+      provider.generate(
+        request("collections/planning/demo/empty-unit.png", "16:9")
+      )
     ).rejects.toThrow("openai が画像なしレスポンスを返しました");
     expect(generateCalls).toHaveLength(1);
   });
@@ -237,7 +248,9 @@ describe("OpenAIImageProvider 1-attempt contract", () => {
     // When calling the provider directly with 1:1
     // Then it fails fast: config:-prefixed throw, no client, no SDK call
     await expect(
-      provider.generate(request(join(workdir, "square-unit.png"), "1:1"))
+      provider.generate(
+        request("collections/planning/demo/square-unit.png", "1:1")
+      )
     ).rejects.toThrow(/^config:/u);
     expect(recorders.clientCreatedCount()).toBe(0);
     expect(generateCalls).toHaveLength(0);
@@ -259,7 +272,7 @@ describe("generateImageService (openai) success", () => {
       openaiConfig,
       makeDeps(client, recorders)
     );
-    const outputPath = join(workdir, "wide.png");
+    const outputPath = "collections/planning/demo/wide.png";
 
     // When generating at 16:9 through the service
     const r = await generateImageService(
@@ -273,7 +286,7 @@ describe("generateImageService (openai) success", () => {
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
     }
-    expect(r.value.savedPath).toBe(outputPath);
+    expect(r.value.savedPath).toBe(channelPath(outputPath));
     const [persisted] = recorders.persisted;
     if (!persisted) {
       throw new Error("expected a persisted image");
@@ -304,7 +317,7 @@ describe("generateImageService (openai) success", () => {
 
     // When generating at 9:16 through the service
     const r = await generateImageService(
-      request(join(workdir, "tall.png"), "9:16"),
+      request("collections/planning/demo/tall.png", "9:16"),
       serviceDeps(provider, recorders)
     );
 
@@ -329,7 +342,7 @@ describe("generateImageService (openai) success", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      request(join(workdir, "first.png"), "16:9"),
+      request("collections/planning/demo/first.png", "16:9"),
       serviceDeps(provider, recorders)
     );
 
@@ -344,8 +357,12 @@ describe("generateImageService (openai) success", () => {
 
   test("uses images.edit (not generate) when references are supplied", async () => {
     // Given a reference image on disk (openai.py:86-96)
-    const refPath = join(workdir, "ref.png");
-    writeFileSync(refPath, new Uint8Array([0x50, 0x4b]));
+    const refPath = "collections/planning/demo/ref.png";
+    mkdirSync(channelPath("collections/planning/demo"), { recursive: true });
+    writeFileSync(
+      channelPath(refPath),
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    );
     const base64 = Buffer.from(new Uint8Array([8, 8])).toString("base64");
     const { client, editCalls, generateCalls } = makeOpenAIClient({
       edit: [() => imageResponse(base64)],
@@ -358,7 +375,7 @@ describe("generateImageService (openai) success", () => {
 
     // When generating with a reference image through the service
     const r = await generateImageService(
-      request(join(workdir, "edit-out.png"), "16:9", [refPath]),
+      request("collections/planning/demo/edit-out.png", "16:9", [refPath]),
       serviceDeps(provider, recorders)
     );
 
@@ -385,7 +402,7 @@ describe("generateImageService (openai) aspect-ratio guard", () => {
 
     // When generating at an unsupported ratio through the service
     const r = await generateImageService(
-      request(join(workdir, "square.png"), "1:1"),
+      request("collections/planning/demo/square.png", "1:1"),
       serviceDeps(provider, recorders)
     );
 
@@ -420,7 +437,7 @@ describe("generateImageService (openai) retry", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      request(join(workdir, "empty.png"), "16:9"),
+      request("collections/planning/demo/empty.png", "16:9"),
       serviceDeps(provider, recorders)
     );
 
@@ -455,7 +472,7 @@ describe("generateImageService (openai) retry", () => {
 
     // When generating through the service
     const r = await generateImageService(
-      request(join(workdir, "retry-ok.png"), "16:9"),
+      request("collections/planning/demo/retry-ok.png", "16:9"),
       serviceDeps(provider, recorders)
     );
 

--- a/packages/core/test/image-registry.test.ts
+++ b/packages/core/test/image-registry.test.ts
@@ -11,28 +11,24 @@ interface RegistryEntryForTest {
 
 describe("core registry — image.generate", () => {
   test("exposes image generation through a dotted registry entry", () => {
-    // Given the public core registry consumed by CLI/MCP adapters
     const registry = REGISTRY as unknown as Record<
       string,
       RegistryEntryForTest
     >;
 
-    // When resolving the image generation operation
     const entry = registry["image.generate"];
 
-    // Then the entry declares the service contract and its provider dependency
     expect(entry).toBeDefined();
     if (entry === undefined) {
       throw new Error("image.generate registry entry is required");
     }
-    expect(entry.deps).toEqual(["imageProvider"]);
+    expect(entry.deps).toEqual(["channelDir", "imageProvider"]);
     expect(entry.description.length).toBeGreaterThan(0);
     expect(entry.inputSchema).toBeDefined();
     expect(entry.outputSchema).toBeDefined();
   });
 
   test("parses snake_case input at the registry boundary", () => {
-    // Given the registry entry that backs `tayk generate-image`
     const registry = REGISTRY as unknown as Record<
       string,
       RegistryEntryForTest
@@ -43,7 +39,6 @@ describe("core registry — image.generate", () => {
       throw new Error("image.generate registry entry is required");
     }
 
-    // When parsing the raw command/service input
     const parsed = entry.inputSchema.parse({
       aspect_ratio: "9:16",
       image_size: "2K",
@@ -51,7 +46,6 @@ describe("core registry — image.generate", () => {
       prompt: "a vertical rainy city thumbnail",
     });
 
-    // Then the registry passes normalized camelCase input to run()
     expect(parsed).toMatchObject({
       aspectRatio: "9:16",
       imageSize: "2K",

--- a/packages/core/test/image-registry.test.ts
+++ b/packages/core/test/image-registry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+interface RegistryEntryForTest {
+  readonly deps: readonly string[];
+  readonly description: string;
+  readonly inputSchema: { parse(input: unknown): unknown };
+  readonly outputSchema: unknown;
+}
+
+describe("core registry — image.generate", () => {
+  test("exposes image generation through a dotted registry entry", () => {
+    // Given the public core registry consumed by CLI/MCP adapters
+    const registry = REGISTRY as unknown as Record<
+      string,
+      RegistryEntryForTest
+    >;
+
+    // When resolving the image generation operation
+    const entry = registry["image.generate"];
+
+    // Then the entry declares the service contract and its provider dependency
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("image.generate registry entry is required");
+    }
+    expect(entry.deps).toEqual(["imageProvider"]);
+    expect(entry.description.length).toBeGreaterThan(0);
+    expect(entry.inputSchema).toBeDefined();
+    expect(entry.outputSchema).toBeDefined();
+  });
+
+  test("parses snake_case input at the registry boundary", () => {
+    // Given the registry entry that backs `tayk generate-image`
+    const registry = REGISTRY as unknown as Record<
+      string,
+      RegistryEntryForTest
+    >;
+    const entry = registry["image.generate"];
+    expect(entry).toBeDefined();
+    if (entry === undefined) {
+      throw new Error("image.generate registry entry is required");
+    }
+
+    // When parsing the raw command/service input
+    const parsed = entry.inputSchema.parse({
+      aspect_ratio: "9:16",
+      image_size: "2K",
+      output_path: "out.png",
+      prompt: "a vertical rainy city thumbnail",
+    });
+
+    // Then the registry passes normalized camelCase input to run()
+    expect(parsed).toMatchObject({
+      aspectRatio: "9:16",
+      imageSize: "2K",
+      outputPath: "out.png",
+      prompt: "a vertical rainy city thumbnail",
+    });
+  });
+});

--- a/packages/core/test/image-schema.test.ts
+++ b/packages/core/test/image-schema.test.ts
@@ -19,13 +19,10 @@ const rawInput = () => ({
 
 describe("GenerateImageInput schema", () => {
   test("transforms snake_case request fields to the camelCase service shape", () => {
-    // Given a CLI/API-shaped root request that uses snake_case field names
     const input = rawInput();
 
-    // When the core schema parses the request
     const parsed = GenerateImageInput.parse(input);
 
-    // Then providers receive the normalized camelCase shape
     expect(parsed).toEqual({
       aspectRatio: "16:9",
       imageSize: "2K",
@@ -37,27 +34,20 @@ describe("GenerateImageInput schema", () => {
   });
 
   test("rejects unknown request keys instead of silently dropping them", () => {
-    // Given a root request with an unsupported key
     const input = { ...rawInput(), unexpected: true };
 
-    // When parsing it
-    // Then validation fails before the provider can observe ambiguous input
     expect(() => GenerateImageInput.parse(input)).toThrow();
   });
 
   test("rejects response envelopes passed as request input", () => {
-    // Given a response-style envelope instead of the documented root request
     const input = { data: rawInput() };
 
-    // When parsing it as an image generation request
-    // Then the schema does not reinterpret envelope payloads as request fields
     expect(() => GenerateImageInput.parse(input)).toThrow();
   });
 });
 
 describe("generateImageService input normalization", () => {
   test("passes a transformed snake_case request to the injected provider", async () => {
-    // Given a service call at the external boundary with snake_case input
     const seen: ParsedGenerateImageInput[] = [];
     const provider: ImageProvider = {
       generate: (request) => {
@@ -68,7 +58,6 @@ describe("generateImageService input normalization", () => {
       supportedAspectRatios: [],
     };
 
-    // When generating an image through the Result-returning service boundary
     const result = await generateImageService(
       rawInput() as unknown as ParsedGenerateImageInput,
       {
@@ -78,7 +67,6 @@ describe("generateImageService input normalization", () => {
       }
     );
 
-    // Then the service succeeds and the provider only sees camelCase fields
     expect(result.ok).toBe(true);
     expect(seen).toEqual([
       {

--- a/packages/core/test/image-schema.test.ts
+++ b/packages/core/test/image-schema.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  generateImageService,
+  GenerateImageInput,
+} from "@youtube-automation/core/image";
+import type {
+  GenerateImageInput as ParsedGenerateImageInput,
+  ImageProvider,
+} from "@youtube-automation/core/image";
+
+const rawInput = () => ({
+  aspect_ratio: "16:9",
+  image_size: "2K",
+  output_path: "collections/planning/demo/main.png",
+  prompt: "a quiet desk with warm window light",
+  references: ["references/a.png"],
+});
+
+describe("GenerateImageInput schema", () => {
+  test("transforms snake_case request fields to the camelCase service shape", () => {
+    // Given a CLI/API-shaped root request that uses snake_case field names
+    const input = rawInput();
+
+    // When the core schema parses the request
+    const parsed = GenerateImageInput.parse(input);
+
+    // Then providers receive the normalized camelCase shape
+    expect(parsed).toEqual({
+      aspectRatio: "16:9",
+      imageSize: "2K",
+      outputPath: "collections/planning/demo/main.png",
+      prompt: "a quiet desk with warm window light",
+      references: ["references/a.png"],
+    });
+    expect("output_path" in parsed).toBe(false);
+  });
+
+  test("rejects unknown request keys instead of silently dropping them", () => {
+    // Given a root request with an unsupported key
+    const input = { ...rawInput(), unexpected: true };
+
+    // When parsing it
+    // Then validation fails before the provider can observe ambiguous input
+    expect(() => GenerateImageInput.parse(input)).toThrow();
+  });
+
+  test("rejects response envelopes passed as request input", () => {
+    // Given a response-style envelope instead of the documented root request
+    const input = { data: rawInput() };
+
+    // When parsing it as an image generation request
+    // Then the schema does not reinterpret envelope payloads as request fields
+    expect(() => GenerateImageInput.parse(input)).toThrow();
+  });
+});
+
+describe("generateImageService input normalization", () => {
+  test("passes a transformed snake_case request to the injected provider", async () => {
+    // Given a service call at the external boundary with snake_case input
+    const seen: ParsedGenerateImageInput[] = [];
+    const provider: ImageProvider = {
+      generate: (request) => {
+        seen.push(request);
+        return Promise.resolve(new Uint8Array([1, 2, 3]));
+      },
+      name: "fake",
+      supportedAspectRatios: [],
+    };
+
+    // When generating an image through the Result-returning service boundary
+    const result = await generateImageService(
+      rawInput() as unknown as ParsedGenerateImageInput,
+      {
+        persist: (outputPath) => Promise.resolve(outputPath),
+        provider,
+        sleep: () => Promise.resolve(),
+      }
+    );
+
+    // Then the service succeeds and the provider only sees camelCase fields
+    expect(result.ok).toBe(true);
+    expect(seen).toEqual([
+      {
+        aspectRatio: "16:9",
+        imageSize: "2K",
+        outputPath: "collections/planning/demo/main.png",
+        prompt: "a quiet desk with warm window light",
+        references: ["references/a.png"],
+      },
+    ]);
+  });
+});

--- a/packages/core/test/image-schema.test.ts
+++ b/packages/core/test/image-schema.test.ts
@@ -15,7 +15,7 @@ import {
   GenerateImageInput,
 } from "@youtube-automation/core/image";
 import type {
-  GenerateImageInput as ParsedGenerateImageInput,
+  ImageGenerationRequest,
   ImageProvider,
 } from "@youtube-automation/core/image";
 
@@ -54,6 +54,17 @@ describe("GenerateImageInput schema", () => {
 
     expect(() => GenerateImageInput.parse(input)).toThrow();
   });
+
+  test("rejects camelCase input at the public registry boundary", () => {
+    expect(() =>
+      GenerateImageInput.parse({
+        aspectRatio: "16:9",
+        imageSize: "2K",
+        outputPath: "collections/planning/demo/main.png",
+        prompt: "a quiet desk with warm window light",
+      })
+    ).toThrow();
+  });
 });
 
 describe("generateImageService input normalization", () => {
@@ -64,7 +75,7 @@ describe("generateImageService input normalization", () => {
       join(channelDir, "references", "a.png"),
       new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     );
-    const seen: ParsedGenerateImageInput[] = [];
+    const seen: ImageGenerationRequest[] = [];
     const provider: ImageProvider = {
       generate: (request) => {
         seen.push(request);
@@ -75,7 +86,7 @@ describe("generateImageService input normalization", () => {
     };
 
     const result = await generateImageService(
-      rawInput() as unknown as ParsedGenerateImageInput,
+      GenerateImageInput.parse(rawInput()),
       {
         channelDir,
         persist: (outputPath) => Promise.resolve(outputPath),
@@ -112,13 +123,14 @@ describe("generateImageService path validation", () => {
       recursive: true,
     });
     mkdirSync(join(channelDir, "references"), { recursive: true });
+    mkdirSync(join(channelDir, "assets"), { recursive: true });
     writeFileSync(join(channelDir, "references", "ok.png"), pngBytes);
     return channelDir;
   };
 
   const callService = async (
     channelDir: string,
-    input: Partial<ParsedGenerateImageInput>
+    input: Partial<ImageGenerationRequest>
   ) => {
     let calls = 0;
     const provider: ImageProvider = {
@@ -171,12 +183,11 @@ describe("generateImageService path validation", () => {
     rmSync(channelDir, { force: true, recursive: true });
   });
 
-  test("rejects reference files that are not images", async () => {
+  test("rejects invalid output extensions before provider execution", async () => {
     const channelDir = makeChannel();
-    writeFileSync(join(channelDir, "references", "secret.png"), "not image");
 
     const { calls, result } = await callService(channelDir, {
-      references: ["references/secret.png"],
+      outputPath: "collections/planning/demo/main.gif",
     });
 
     expect(result.ok).toBe(false);
@@ -200,5 +211,83 @@ describe("generateImageService path validation", () => {
     expect(calls).toBe(0);
     rmSync(channelDir, { force: true, recursive: true });
     rmSync(outside, { force: true, recursive: true });
+  });
+
+  test.each([
+    {
+      input: { references: ["/tmp/secret.png"] },
+      name: "absolute reference paths",
+    },
+    {
+      input: { references: ["references/../secret.png"] },
+      name: "reference traversal paths",
+    },
+    {
+      input: { references: ["tmp/secret.png"] },
+      name: "references outside allowed directories",
+    },
+    {
+      input: { references: ["references/secret.gif"] },
+      name: "reference extensions outside the allowlist",
+    },
+    {
+      input: { references: ["references/missing.png"] },
+      name: "missing reference files",
+    },
+  ])("rejects $name before provider execution", async ({ input }) => {
+    const channelDir = makeChannel();
+
+    const { calls, result } = await callService(channelDir, input);
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("rejects reference files that are not images", async () => {
+    const channelDir = makeChannel();
+    writeFileSync(join(channelDir, "references", "secret.png"), "not image");
+
+    const { calls, result } = await callService(channelDir, {
+      references: ["references/secret.png"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("rejects reference symlinks that resolve outside the channel root", async () => {
+    const channelDir = makeChannel();
+    const outside = mkdtempSync(join(tmpdir(), "image-ref-outside-"));
+    writeFileSync(join(outside, "secret.png"), pngBytes);
+    symlinkSync(
+      join(outside, "secret.png"),
+      join(channelDir, "references", "linked.png")
+    );
+
+    const { calls, result } = await callService(channelDir, {
+      references: ["references/linked.png"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+    rmSync(outside, { force: true, recursive: true });
+  });
+
+  test("rejects reference files larger than 10 MiB", async () => {
+    const channelDir = makeChannel();
+    const bytes = new Uint8Array(10 * 1024 * 1024 + 1);
+    bytes.set(pngBytes, 0);
+    writeFileSync(join(channelDir, "references", "large.png"), bytes);
+
+    const { calls, result } = await callService(channelDir, {
+      references: ["references/large.png"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
   });
 });

--- a/packages/core/test/image-schema.test.ts
+++ b/packages/core/test/image-schema.test.ts
@@ -276,6 +276,62 @@ describe("generateImageService path validation", () => {
     rmSync(outside, { force: true, recursive: true });
   });
 
+  test("rejects reference symlinks that resolve to disallowed dirs inside the channel root", async () => {
+    const channelDir = makeChannel();
+    mkdirSync(join(channelDir, "config"), { recursive: true });
+    writeFileSync(join(channelDir, "config", "secret.png"), pngBytes);
+    symlinkSync(
+      join(channelDir, "config", "secret.png"),
+      join(channelDir, "references", "linked.png")
+    );
+
+    const { calls, result } = await callService(channelDir, {
+      references: ["references/linked.png"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("returns io error when persist fails after a single provider execution", async () => {
+    const channelDir = makeChannel();
+    let calls = 0;
+    const provider: ImageProvider = {
+      generate: () => {
+        calls += 1;
+        return Promise.resolve(pngBytes);
+      },
+      name: "fake",
+      supportedAspectRatios: [],
+    };
+
+    const result = await generateImageService(
+      {
+        aspectRatio: "16:9",
+        imageSize: "2K",
+        outputPath: "collections/planning/demo/main.png",
+        prompt: "a quiet desk with warm window light",
+      },
+      {
+        channelDir,
+        persist: () => {
+          throw new Error("disk full");
+        },
+        provider,
+        sleep: () => Promise.resolve(),
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected persist failure");
+    }
+    expect(result.error.domain).toBe("io");
+    expect(calls).toBe(1);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
   test("rejects reference files larger than 10 MiB", async () => {
     const channelDir = makeChannel();
     const bytes = new Uint8Array(10 * 1024 * 1024 + 1);

--- a/packages/core/test/image-schema.test.ts
+++ b/packages/core/test/image-schema.test.ts
@@ -1,4 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   generateImageService,
@@ -48,6 +58,12 @@ describe("GenerateImageInput schema", () => {
 
 describe("generateImageService input normalization", () => {
   test("passes a transformed snake_case request to the injected provider", async () => {
+    const channelDir = mkdtempSync(join(tmpdir(), "image-schema-"));
+    mkdirSync(join(channelDir, "references"), { recursive: true });
+    writeFileSync(
+      join(channelDir, "references", "a.png"),
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    );
     const seen: ParsedGenerateImageInput[] = [];
     const provider: ImageProvider = {
       generate: (request) => {
@@ -61,6 +77,7 @@ describe("generateImageService input normalization", () => {
     const result = await generateImageService(
       rawInput() as unknown as ParsedGenerateImageInput,
       {
+        channelDir,
         persist: (outputPath) => Promise.resolve(outputPath),
         provider,
         sleep: () => Promise.resolve(),
@@ -72,10 +89,116 @@ describe("generateImageService input normalization", () => {
       {
         aspectRatio: "16:9",
         imageSize: "2K",
-        outputPath: "collections/planning/demo/main.png",
+        outputPath: join(
+          realpathSync(channelDir),
+          "collections/planning/demo/main.png"
+        ),
         prompt: "a quiet desk with warm window light",
-        references: ["references/a.png"],
+        references: [join(realpathSync(channelDir), "references/a.png")],
       },
     ]);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+});
+
+describe("generateImageService path validation", () => {
+  const pngBytes = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+
+  const makeChannel = (): string => {
+    const channelDir = mkdtempSync(join(tmpdir(), "image-paths-"));
+    mkdirSync(join(channelDir, "collections/planning/demo"), {
+      recursive: true,
+    });
+    mkdirSync(join(channelDir, "references"), { recursive: true });
+    writeFileSync(join(channelDir, "references", "ok.png"), pngBytes);
+    return channelDir;
+  };
+
+  const callService = async (
+    channelDir: string,
+    input: Partial<ParsedGenerateImageInput>
+  ) => {
+    let calls = 0;
+    const provider: ImageProvider = {
+      generate: () => {
+        calls += 1;
+        return Promise.resolve(pngBytes);
+      },
+      name: "fake",
+      supportedAspectRatios: [],
+    };
+    const result = await generateImageService(
+      {
+        aspectRatio: "16:9",
+        imageSize: "2K",
+        outputPath: "collections/planning/demo/main.png",
+        prompt: "a quiet desk with warm window light",
+        ...input,
+      },
+      {
+        channelDir,
+        persist: (outputPath) => Promise.resolve(outputPath),
+        provider,
+        sleep: () => Promise.resolve(),
+      }
+    );
+    return { calls, result };
+  };
+
+  test("rejects absolute output paths before provider execution", async () => {
+    const channelDir = makeChannel();
+
+    const { calls, result } = await callService(channelDir, {
+      outputPath: join(channelDir, "collections/planning/demo/main.png"),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("rejects traversal output paths before provider execution", async () => {
+    const channelDir = makeChannel();
+
+    const { calls, result } = await callService(channelDir, {
+      outputPath: "collections/../outside.png",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("rejects reference files that are not images", async () => {
+    const channelDir = makeChannel();
+    writeFileSync(join(channelDir, "references", "secret.png"), "not image");
+
+    const { calls, result } = await callService(channelDir, {
+      references: ["references/secret.png"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+  });
+
+  test("rejects symlinked output targets", async () => {
+    const channelDir = makeChannel();
+    const outside = mkdtempSync(join(tmpdir(), "image-outside-"));
+    symlinkSync(
+      join(outside, "escape.png"),
+      join(channelDir, "collections/planning/demo/link.png")
+    );
+
+    const { calls, result } = await callService(channelDir, {
+      outputPath: "collections/planning/demo/link.png",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    rmSync(channelDir, { force: true, recursive: true });
+    rmSync(outside, { force: true, recursive: true });
   });
 });

--- a/packages/core/test/registry-deps.test.ts
+++ b/packages/core/test/registry-deps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { ok } from "@youtube-automation/core";
 import type { ChannelConfig } from "@youtube-automation/core/config";
+import type { ImageProvider } from "@youtube-automation/core/image";
 import type {
   YouTubeAnalyticsClient,
   YouTubeClient,
@@ -15,18 +16,25 @@ const fakeConfig = {
 const fakeYt = { videos: {} } as unknown as YouTubeClient;
 const fakeYtAnalytics = { reports: {} } as unknown as YouTubeAnalyticsClient;
 const fakeChannelDir = "/tmp/fake-channel";
+const fakeImageProvider = {
+  generate: () => Promise.resolve(new Uint8Array([1])),
+  name: "fake",
+  supportedAspectRatios: [],
+} satisfies ImageProvider;
 
 describe("DepsMap — type shape", () => {
-  test("maps config / channelDir / yt / ytAnalytics to their declared types", () => {
+  test("maps config / channelDir / imageProvider / yt / ytAnalytics to their declared types", () => {
     const deps: DepsMap = {
       channelDir: fakeChannelDir,
       config: fakeConfig,
+      imageProvider: fakeImageProvider,
       yt: fakeYt,
       ytAnalytics: fakeYtAnalytics,
     };
 
     expect(deps.channelDir).toBe(fakeChannelDir);
     expect(deps.config.identity.meta.channelName).toBe("Fake Channel");
+    expect(deps.imageProvider.name).toBe("fake");
     expect(typeof deps.yt.videos).toBe("object");
     expect(typeof deps.ytAnalytics.reports).toBe("object");
   });


### PR DESCRIPTION
> **2026-06-17 再スコープ**: 本 PR は #780 の happy-path core のみ（**partial**）。残機能は親トラッカー #780 のサブ issue #1065 / #1066 / #1067 / #1068 で実装する。マージしても #780 はクローズしない。

## Summary

> **🔧 2026-06-14 ADR 整合 banner（実装前に必読）**: 本 issue は ADR 制定前の旧 framing。**ADR-0002/0003/0004/0007 準拠**で実装すること —
> - ロジックは **core service**（`packages/core/src/<feature>/{schema,service}.ts`、zod schema、`Result<T, ServiceError>` + `toServiceError`）。trivial でも core 側へ寄せる
> - **registry entry**（`packages/core/src/registry.ts`）に登録（未登録 service は CLI/MCP から不可視）
> - CLI は **thin adapter** = 単一 `tayk` dispatcher の subcommand（`tayk <cmd>`）。**per-CLI bin（`packages/cli/bin/yt-xxx`）は廃止**
> - Python は翻訳でなく **TS で新規記述**（ADR-0003）。`googleapis`/`sharp` 等の重い依存は core service 内のみ
> - 本文の旧 path（`src` なし）・旧 bin・旧 blocked-by は**無効**。最新の依存は epic #727 の Phase 構造を参照

## Parent
#727

## What to build
Python `yt-generate-image` CLI を TS に移植する。サムネイル等の画像を Gemini / OpenAI どちらかで生成する CLI (\`image_provider\` 抽象使用)。

## Acceptance criteria (ADR-0002/0003/0004/0007 準拠)

- [ ] core service を `packages/core/src/<feature>/{schema,service}.ts` に実装 — zod schema (snake_case 入力→`.transform(snakeToCamel)`)、export 境界で `Result<T, ServiceError>` を返し `toServiceError` を通す
- [ ] `packages/core/src/registry.ts` に registry entry を登録 (dotted key、`deps` 宣言)
- [ ] CLI は thin adapter: 単一 `tayk` dispatcher の subcommand (`packages/cli/src/commands/<feature>/cli.ts`、citty `defineCommand`、出力/exit code は `run-command.ts` helper 経由)。**per-CLI bin は作らない**
- [ ] Python を翻訳せず TS で新規記述。重い依存 (`googleapis` / `sharp` / `@google/genai` / ffmpeg subprocess 等) は core service 内のみで import
- [ ] bun:test: schema parse + 主要ロジックの unit test green、CLI smoke 1 件以上
- [ ] CHANGELOG [Unreleased] に migration エントリ追加

## Blocked by

- 最新の依存関係は epic #727 の Phase 構造を参照 (旧 #73x の blocked-by は無効)

## Execution Report

Workflow `default` completed successfully.

Relates to #780
