### PR TITLE
[#1099] issue-1099-release-1-3-rebrand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,19 +17,18 @@
       },
     },
     "packages/cli": {
-      "name": "@youtube-automation/cli",
+      "name": "tayk",
       "version": "0.1.0-alpha.0",
       "bin": {
-        "yt": "./bin/yt.ts",
-        "yt-skills": "./bin/yt-skills.ts",
+        "tayk": "./bin/tayk.ts",
       },
       "dependencies": {
-        "@youtube-automation/core": "workspace:*",
+        "@tayk/core": "workspace:*",
         "citty": "^0.2.2",
       },
     },
     "packages/core": {
-      "name": "@youtube-automation/core",
+      "name": "@tayk/core",
       "version": "0.1.0-alpha.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
@@ -401,6 +400,8 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
+    "@tayk/core": ["@tayk/core@workspace:packages/core"],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -408,10 +409,6 @@
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
-
-    "@youtube-automation/cli": ["@youtube-automation/cli@workspace:packages/cli"],
-
-    "@youtube-automation/core": ["@youtube-automation/core@workspace:packages/core"],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -824,6 +821,8 @@
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
     "takt": ["takt@0.43.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.119", "@openai/codex-sdk": "^0.125.0", "@opencode-ai/sdk": "^1.14.24", "@opentelemetry/api": "^1.9.1", "@opentelemetry/sdk-node": "^0.217.0", "ajv": "^6.12.6", "chalk": "^5.3.0", "commander": "^12.1.0", "faceted-prompting": "^0.1.0", "traced-config": "^0.3.0", "update-notifier": "^7.3.1", "wanakana": "^5.3.1", "yaml": "^2.8.3", "zod": "^4.3.6" }, "bin": { "takt": "bin/takt", "takt-cli": "dist/app/cli/index.js", "takt-dev": "bin/takt" } }, "sha512-41dJCyZWhzTbaAOepHyeLw/eXY0aL8e2+Xai/bKlgrT7rY3Mqip0KyldzKcJxCOTO+oY8xuVLkeR/o5LTYSRSw=="],
+
+    "tayk": ["tayk@workspace:packages/cli"],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -50,23 +50,23 @@ const OP_SPAWN_BANNED_IN_CORE = [
 // ADR 0003 §5 / Enforcement: interactiveAuthService は browser open + local server を
 // 起動する CLI 専用 service。MCP サーバプロセスは browser を開けず boot 時に hang する
 // ため、packages/mcp/** からの `**/oauth/interactive*` import を path-based で error 化
-// する (CLI は許可)。subpath import (@youtube-automation/core/oauth/interactive) と相対
+// する (CLI は許可)。subpath import (@tayk/core/oauth/interactive) と相対
 // import の両方を捕捉する。
 const INTERACTIVE_OAUTH_BANNED_IN_MCP = "**/oauth/interactive*";
 
 // ADR 0004: cli と mcp は互いに独立 (依存方向は core ← cli / core ← mcp のみ)。
-// registry は @youtube-automation/core/registry を使い、相互 import を禁止する。
+// registry は @tayk/core/registry を使い、相互 import を禁止する。
 const ADR0004_MUTUAL_BAN_MESSAGE =
-  "ADR 0004: cli と mcp は互いに独立。共有したいものは packages/core (例: @youtube-automation/core/registry) に置いてください。";
+  "ADR 0004: cli と mcp は互いに独立。共有したいものは packages/core (例: @tayk/core/registry) に置いてください。";
 
 const MCP_BANNED_IN_CLI = {
   message: ADR0004_MUTUAL_BAN_MESSAGE,
-  name: "@youtube-automation/mcp",
+  name: "@tayk/mcp",
 };
 
 const CLI_BANNED_IN_MCP = {
   message: ADR0004_MUTUAL_BAN_MESSAGE,
-  name: "@youtube-automation/cli",
+  name: "tayk",
 };
 
 const FFI_BANNED_IN_CORE = {
@@ -106,7 +106,7 @@ export default defineConfig({
             ],
             patterns: [
               ...HEAVY_DEPS_BANNED_IN_THIN_CLIENTS.patterns,
-              "@youtube-automation/mcp/*",
+              "@tayk/mcp/*",
             ],
           },
         ],
@@ -124,7 +124,7 @@ export default defineConfig({
             ],
             patterns: [
               ...HEAVY_DEPS_BANNED_IN_THIN_CLIENTS.patterns,
-              "@youtube-automation/cli/*",
+              "tayk/*",
               INTERACTIVE_OAUTH_BANNED_IN_MCP,
             ],
           },

--- a/packages/cli/lib/oauth.ts
+++ b/packages/cli/lib/oauth.ts
@@ -8,17 +8,17 @@
 
 import { join } from "node:path";
 
-import { channelDir } from "@youtube-automation/core/config";
+import { channelDir } from "@tayk/core/config";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
-} from "@youtube-automation/core/oauth/client";
+} from "@tayk/core/oauth/client";
 import type {
   YouTubeAnalyticsClient,
   YouTubeClient,
-} from "@youtube-automation/core/oauth/client";
-import { interactiveAuthService } from "@youtube-automation/core/oauth/interactive";
-import { refreshTokenService } from "@youtube-automation/core/oauth/refresh";
+} from "@tayk/core/oauth/client";
+import { interactiveAuthService } from "@tayk/core/oauth/interactive";
+import { refreshTokenService } from "@tayk/core/oauth/refresh";
 
 import { resolveClientSecretsJson } from "./secrets.ts";
 import { readTokenJson, writeTokenJson } from "./token.ts";

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -7,12 +7,12 @@
 //
 // MCP 到着時は env token + refresh のみの別 adapter を作る（interactive flow を持たない）。
 
-import { channelDir, loadConfig } from "@youtube-automation/core/config";
+import { channelDir, loadConfig } from "@tayk/core/config";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
-} from "@youtube-automation/core/oauth/client";
-import type { DepsMap } from "@youtube-automation/core/registry";
+} from "@tayk/core/oauth/client";
+import type { DepsMap } from "@tayk/core/registry";
 
 import { resolveTokenJson } from "./oauth.ts";
 

--- a/packages/cli/lib/run-command.ts
+++ b/packages/cli/lib/run-command.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import type { Result, ServiceError } from "@youtube-automation/core";
+import type { Result, ServiceError } from "@tayk/core";
 
 // ADR-0004 §4: Result→exit-code の CLI 側終端を 1 箇所に集約する共通 helper。
 // 各 command が独自に exit code を決めない。

--- a/packages/cli/lib/secrets.ts
+++ b/packages/cli/lib/secrets.ts
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { channelDir } from "@youtube-automation/core/config";
+import { channelDir } from "@tayk/core/config";
 // 具体キーを保持して既知名の参照を `string` 型に確定させつつ、`satisfies` で
 // 値の型 (URI 文字列) を担保する。
 /** 登録済みシークレット名と 1Password 参照 URI のテーブル (Python `_SECRET_REFS` の移植)。 */

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "@youtube-automation/cli",
+  "name": "tayk",
   "version": "0.1.0-alpha.0",
-  "private": true,
   "description": "tayk command line entry point for the youtube-channels-automation TS rewrite (ADR-0004 citty dispatcher).",
   "bin": {
     "tayk": "./bin/tayk.ts"
@@ -19,7 +18,7 @@
     "postpack": "bun run scripts/bundle-symlinks.ts restore"
   },
   "dependencies": {
-    "@youtube-automation/core": "workspace:*",
+    "@tayk/core": "workspace:*",
     "citty": "^0.2.2"
   }
 }

--- a/packages/cli/src/commands/generate-suno/cli.ts
+++ b/packages/cli/src/commands/generate-suno/cli.ts
@@ -1,8 +1,8 @@
 import process from "node:process";
 
-import { err, toServiceError } from "@youtube-automation/core";
-import { REGISTRY } from "@youtube-automation/core/registry";
-import type { GenerateSunoOutput } from "@youtube-automation/core/suno-prompts";
+import { err, toServiceError } from "@tayk/core";
+import { REGISTRY } from "@tayk/core/registry";
+import type { GenerateSunoOutput } from "@tayk/core/suno-prompts";
 import { defineCommand } from "citty";
 
 import { resolveDeps } from "../../../lib/resolve-deps.ts";

--- a/packages/cli/src/commands/skills/cli.ts
+++ b/packages/cli/src/commands/skills/cli.ts
@@ -1,11 +1,8 @@
 import process from "node:process";
 
-import { REGISTRY } from "@youtube-automation/core/registry";
-import { SYNC_ASSETS } from "@youtube-automation/core/skills-sync";
-import type {
-  SkillListOutput,
-  SkillSyncOutput,
-} from "@youtube-automation/core/skills-sync";
+import { REGISTRY } from "@tayk/core/registry";
+import { SYNC_ASSETS } from "@tayk/core/skills-sync";
+import type { SkillListOutput, SkillSyncOutput } from "@tayk/core/skills-sync";
 import { defineCommand } from "citty";
 
 import { resolveDeps } from "../../../lib/resolve-deps.ts";

--- a/packages/cli/test/oauth.test.ts
+++ b/packages/cli/test/oauth.test.ts
@@ -23,7 +23,7 @@ import { join } from "node:path";
 
 // reset() clears the channelDir singleton between cases so a per-test
 // CHANNEL_DIR actually takes effect (channelDir() memoizes its first resolve).
-import { reset } from "@youtube-automation/core/config";
+import { reset } from "@tayk/core/config";
 
 import {
   getYouTubeAnalyticsClient,

--- a/packages/cli/test/rebrand-contract.test.ts
+++ b/packages/cli/test/rebrand-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { Glob } from "bun";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const legacyScope = `@youtube${"-automation/"}`;
+
+interface PackageJson {
+  bin?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  name: string;
+  private?: boolean;
+  version: string;
+}
+
+const readText = (relativePath: string): string =>
+  readFileSync(join(repoRoot, relativePath), "utf-8");
+
+const readPackageJson = (relativePath: string): PackageJson =>
+  JSON.parse(readText(relativePath)) as PackageJson;
+
+describe("rebrand contract - package manifests", () => {
+  test("cli package is published as unscoped tayk with the tayk bin", () => {
+    const manifest = readPackageJson("packages/cli/package.json");
+
+    expect(manifest.name).toBe("tayk");
+    expect(Object.hasOwn(manifest, "private")).toBe(false);
+    expect(manifest.bin).toEqual({ tayk: "./bin/tayk.ts" });
+  });
+
+  test("cli depends on the renamed core workspace package", () => {
+    const { dependencies } = readPackageJson("packages/cli/package.json");
+    if (dependencies === undefined) {
+      throw new Error("packages/cli/package.json must declare dependencies");
+    }
+
+    expect(dependencies["@tayk/core"]).toBe("workspace:*");
+    expect(Object.hasOwn(dependencies, `${legacyScope}core`)).toBe(false);
+  });
+
+  test("core keeps private workspace status under the renamed internal scope", () => {
+    const manifest = readPackageJson("packages/core/package.json");
+
+    expect(manifest.name).toBe("@tayk/core");
+    expect(manifest.private).toBe(true);
+  });
+
+  test("root package remains the private workspace root", () => {
+    const manifest = readPackageJson("package.json");
+
+    expect(manifest.name).toBe("youtube-channels-automation");
+    expect(manifest.private).toBe(true);
+  });
+});
+
+describe("rebrand contract - legacy scope removal", () => {
+  test("packages and oxlint config contain no old internal scope references", () => {
+    const glob = new Glob("packages/**/*.{json,ts}");
+    const checkedFiles = [
+      "oxlint.config.ts",
+      ...glob.scanSync({ cwd: repoRoot }),
+    ];
+
+    const offenders = checkedFiles.filter((relativePath) =>
+      readText(relativePath).includes(legacyScope)
+    );
+
+    expect(offenders.toSorted()).toEqual([]);
+  });
+
+  test("bun lock workspace metadata is synchronized with renamed packages", () => {
+    const lockfile = readText("bun.lock");
+
+    expect(lockfile.includes(legacyScope)).toBe(false);
+    expect(lockfile.includes('"name": "tayk"')).toBe(true);
+    expect(lockfile.includes('"name": "@tayk/core"')).toBe(true);
+    expect(lockfile.includes('"@tayk/core": "workspace:*"')).toBe(true);
+  });
+});
+
+describe("rebrand contract - oxlint package boundaries", () => {
+  test("mcp is restricted from importing the published cli package name", () => {
+    const config = readText("oxlint.config.ts");
+
+    expect(config.includes('name: "tayk"')).toBe(true);
+    expect(config.includes('"tayk/*"')).toBe(true);
+    expect(config.includes("@tayk/cli")).toBe(false);
+  });
+});

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -18,7 +18,7 @@ import { join, resolve } from "node:path";
 
 // reset() clears the channelDir / config singletons between cases so a per-test
 // CHANNEL_DIR actually takes effect (both memoize their first resolve).
-import { reset } from "@youtube-automation/core/config";
+import { reset } from "@tayk/core/config";
 
 import { resolveDeps } from "../lib/resolve-deps.ts";
 

--- a/packages/cli/test/run-tayk.ts
+++ b/packages/cli/test/run-tayk.ts
@@ -1,0 +1,84 @@
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+
+const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+interface RunTaykOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+}
+
+const resolveEnv = (
+  overrides: Record<string, string | undefined> | undefined
+): Record<string, string> | undefined => {
+  if (overrides === undefined) {
+    return undefined;
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(env, key);
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+};
+
+export const runTayk = (options: RunTaykOptions, ...argv: string[]) => {
+  const proc = Bun.spawnSync(["bun", taykBin, ...argv], {
+    cwd: options.cwd ?? repoRoot,
+    env: resolveEnv(options.env),
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+
+  if (proc.exitCode === null) {
+    throw new Error(
+      [
+        `tayk subprocess timed out after ${options.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`,
+        `argv: tayk ${argv.join(" ")}`,
+        `cwd: ${options.cwd ?? repoRoot}`,
+        `stdout:\n${proc.stdout.toString()}`,
+        `stderr:\n${proc.stderr.toString()}`,
+      ].join("\n")
+    );
+  }
+
+  return proc;
+};
+
+export const expectExitCode = (
+  proc: ReturnType<typeof runTayk>,
+  expected: number
+): void => {
+  if (proc.exitCode !== expected) {
+    throw new Error(
+      [
+        `expected exit ${expected}, got ${String(proc.exitCode)}`,
+        `stdout:\n${proc.stdout.toString()}`,
+        `stderr:\n${proc.stderr.toString()}`,
+      ].join("\n")
+    );
+  }
+};
+
+export const expectNonZeroExit = (proc: ReturnType<typeof runTayk>): void => {
+  if (proc.exitCode === 0) {
+    throw new Error(
+      [
+        "expected non-zero exit, got 0",
+        `stdout:\n${proc.stdout.toString()}`,
+        `stderr:\n${proc.stderr.toString()}`,
+      ].join("\n")
+    );
+  }
+};

--- a/packages/cli/test/secrets.test.ts
+++ b/packages/cli/test/secrets.test.ts
@@ -5,11 +5,11 @@ import { join } from "node:path";
 
 // `reset()` clears the channelDir singleton between cases so a per-test
 // CHANNEL_DIR actually takes effect (channelDir() memoizes its first resolve).
-import { reset } from "@youtube-automation/core/config";
+import { reset } from "@tayk/core/config";
 
 // Relative import of the cli's own module (#822 move target). The acceptance
 // criteria require cli callsites to reach secrets via the relative path, not a
-// re-export from @youtube-automation/core. `ConfigError` was retired in #821
+// re-export from @tayk/core. `ConfigError` was retired in #821
 // (5 名前タグ class 撤廃) — the `config:` prefix on plain Error is now the
 // single source of domain truth, routed by toServiceError.
 import {

--- a/packages/cli/test/skills-bundle-pack.test.ts
+++ b/packages/cli/test/skills-bundle-pack.test.ts
@@ -1,5 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -33,13 +40,42 @@ const makeTmp = (prefix: string): string => {
   return dir;
 };
 
-// Pack the CLI package into `destination` (runs prepack/postpack, which
-// materialize the bundled symlinks into real files and restore the links
-// afterward) and return the tarball's entry paths.
+const makePackWorkspace = (): string => {
+  const workspace = makeTmp("cli-pack-workspace-");
+  const packageDir = join(workspace, "packages", "cli");
+  const coreDir = join(workspace, "packages", "core");
+  mkdirSync(coreDir, { recursive: true });
+  writeFileSync(
+    join(workspace, "package.json"),
+    JSON.stringify({ private: true, workspaces: ["packages/*"] }, null, 2)
+  );
+  cpSync(join(repoRoot, "bun.lock"), join(workspace, "bun.lock"));
+  cpSync(
+    join(repoRoot, "packages", "core", "package.json"),
+    join(coreDir, "package.json")
+  );
+  cpSync(cliDir, packageDir, {
+    dereference: false,
+    filter: (source) => !source.includes(`${cliDir}/test`),
+    recursive: true,
+    verbatimSymlinks: true,
+  });
+  cpSync(join(repoRoot, ".claude"), join(workspace, ".claude"), {
+    dereference: true,
+    recursive: true,
+  });
+  return packageDir;
+};
+
+// Pack an isolated copy of the CLI package into `destination`. The package's
+// real prepack/postpack scripts still run, but they materialize the copy's
+// `_skills` / `_claude_md` links instead of replacing the shared worktree paths
+// that other parallel tests read.
 const packEntries = (destination: string): string[] => {
+  const packageDir = makePackWorkspace();
   const pack = Bun.spawnSync(
     ["bun", "pm", "pack", "--destination", destination, "--quiet"],
-    { cwd: cliDir }
+    { cwd: packageDir }
   );
   if (pack.exitCode !== 0) {
     throw new Error(`bun pm pack failed: ${pack.stderr.toString()}`);
@@ -59,11 +95,6 @@ const packEntries = (destination: string): string[] => {
 };
 
 afterAll(() => {
-  // bun's postpack restores the symlinks; re-run restore defensively so the
-  // working tree is clean even if pack aborted mid-run (restore is idempotent).
-  Bun.spawnSync(["bun", "run", "scripts/bundle-symlinks.ts", "restore"], {
-    cwd: cliDir,
-  });
   while (tmpDirs.length > 0) {
     const dir = tmpDirs.pop();
     if (dir !== undefined) {

--- a/packages/cli/test/yt-generate-suno.test.ts
+++ b/packages/cli/test/yt-generate-suno.test.ts
@@ -9,12 +9,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
-import { REGISTRY } from "@youtube-automation/core/registry";
+import { REGISTRY } from "@tayk/core/registry";
 
-const repoRoot = resolve(import.meta.dir, "..", "..", "..");
-const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
+import { expectExitCode, runTayk } from "./run-tayk.ts";
+
 const tmpDirs: string[] = [];
 
 const makeTempDir = (prefix: string): string => {
@@ -32,30 +32,6 @@ afterEach(() => {
     }
   }
 });
-
-const runTayk = (
-  options: { cwd?: string; env: Record<string, string | undefined> },
-  ...argv: string[]
-) => {
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) {
-      env[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(options.env)) {
-    if (value === undefined) {
-      Reflect.deleteProperty(env, key);
-    } else {
-      env[key] = value;
-    }
-  }
-
-  return Bun.spawnSync(["bun", taykBin, ...argv], {
-    cwd: options.cwd ?? repoRoot,
-    env,
-  });
-};
 
 const writeFixture = (): { channelDir: string; collectionDir: string } => {
   const channelDir = makeTempDir("cli-suno-channel-");
@@ -146,7 +122,7 @@ describe("tayk generate-suno — smoke", () => {
       "--json"
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       entryCount: number;
       jsonPath: string;
@@ -177,7 +153,7 @@ describe("tayk generate-suno — smoke", () => {
       "--json"
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       jsonPath: string;
     };
@@ -196,7 +172,7 @@ describe("tayk generate-suno — smoke", () => {
       "--json"
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       jsonPath: string;
     };
@@ -213,7 +189,7 @@ describe("tayk generate-suno — smoke", () => {
       "--json"
     );
 
-    expect(proc.exitCode).toBe(1);
+    expectExitCode(proc, 1);
     expect(proc.stderr.toString()).toStartWith("[config] ");
     expect(proc.stderr.toString()).toContain("CHANNEL_DIR");
     expect(proc.stderr.toString()).not.toContain("at ");
@@ -222,7 +198,7 @@ describe("tayk generate-suno — smoke", () => {
   test("should list generate-suno in dispatcher help", () => {
     const proc = runTayk({ env: {} }, "--help");
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(proc.stdout.toString()).toContain("generate-suno");
   });
 
@@ -235,7 +211,7 @@ describe("tayk generate-suno — smoke", () => {
       collectionDir
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const stdout = proc.stdout.toString();
     expect(stdout).toContain("generated: 1");
     expect(stdout).toContain("[WARN]");

--- a/packages/cli/test/yt-skills-sync.test.ts
+++ b/packages/cli/test/yt-skills-sync.test.ts
@@ -7,21 +7,11 @@ import {
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
-import { REGISTRY } from "@youtube-automation/core/registry";
+import { REGISTRY } from "@tayk/core/registry";
 
-const repoRoot = resolve(import.meta.dir, "..", "..", "..");
-
-const runTayk = (...argv: string[]) =>
-  Bun.spawnSync(["bun", "packages/cli/bin/tayk.ts", ...argv], {
-    cwd: repoRoot,
-  });
-
-const runTaykIn = (cwd: string, ...argv: string[]) =>
-  Bun.spawnSync(["bun", join(repoRoot, "packages/cli/bin/tayk.ts"), ...argv], {
-    cwd,
-  });
+import { expectExitCode, expectNonZeroExit, runTayk } from "./run-tayk.ts";
 
 const tmpDirs: string[] = [];
 const makeTmp = (prefix: string): string => {
@@ -72,6 +62,7 @@ describe("tayk skills sync --asset skills --target <dir>", () => {
     const target = join(tmp, ".claude", "skills");
 
     const proc = runTayk(
+      {},
       "skills",
       "sync",
       "--asset",
@@ -80,7 +71,7 @@ describe("tayk skills sync --asset skills --target <dir>", () => {
       target
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(existsSync(target)).toBe(true);
     const link = join(tmp, ".agents", "skills");
     expect(lstatSync(link).isSymbolicLink()).toBe(true);
@@ -92,6 +83,7 @@ describe("tayk skills sync --asset skills --target <dir>", () => {
     const target = join(tmp, ".claude", "skills");
 
     const proc = runTayk(
+      {},
       "skills",
       "sync",
       "--asset",
@@ -101,7 +93,7 @@ describe("tayk skills sync --asset skills --target <dir>", () => {
       "--json"
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       agentsSkillsLink: string | null;
       asset: string;
@@ -120,6 +112,7 @@ describe("tayk skills sync --asset claude-md --target <file>", () => {
     const target = join(tmp, ".claude", "CLAUDE.md");
 
     const proc = runTayk(
+      {},
       "skills",
       "sync",
       "--asset",
@@ -128,7 +121,7 @@ describe("tayk skills sync --asset claude-md --target <file>", () => {
       target
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(existsSync(target)).toBe(true);
   });
 });
@@ -139,6 +132,7 @@ describe("tayk skills sync --asset all — guard against --target", () => {
     const target = join(tmp, "x");
 
     const proc = runTayk(
+      {},
       "skills",
       "sync",
       "--asset",
@@ -147,7 +141,7 @@ describe("tayk skills sync --asset all — guard against --target", () => {
       target
     );
 
-    expect(proc.exitCode).toBe(2);
+    expectExitCode(proc, 2);
     expect(proc.stderr.toString().length).toBeGreaterThan(0);
     expect(existsSync(target)).toBe(false);
   });
@@ -157,9 +151,9 @@ describe("tayk skills sync — default asset 'all' resolves per-asset default ta
   test("bare `skills sync` syncs both skills and claude-md under the working dir", () => {
     const cwd = makeTmp("tayk-skills-sync-all-");
 
-    const proc = runTaykIn(cwd, "skills", "sync");
+    const proc = runTayk({ cwd }, "skills", "sync");
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(existsSync(join(cwd, ".claude", "skills"))).toBe(true);
     expect(existsSync(join(cwd, ".claude", "CLAUDE.md"))).toBe(true);
     expect(lstatSync(join(cwd, ".agents", "skills")).isSymbolicLink()).toBe(
@@ -172,6 +166,7 @@ describe("tayk skills sync — usage errors", () => {
   test("an unknown --asset exits non-zero", () => {
     const tmp = makeTmp("tayk-skills-sync-");
     const proc = runTayk(
+      {},
       "skills",
       "sync",
       "--asset",
@@ -180,6 +175,6 @@ describe("tayk skills sync — usage errors", () => {
       join(tmp, "x")
     );
 
-    expect(proc.exitCode).not.toBe(0);
+    expectNonZeroExit(proc);
   });
 });

--- a/packages/cli/test/yt-skills.test.ts
+++ b/packages/cli/test/yt-skills.test.ts
@@ -1,16 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
-import { REGISTRY } from "@youtube-automation/core/registry";
+import { REGISTRY } from "@tayk/core/registry";
 
-const repoRoot = resolve(import.meta.dir, "..", "..", "..");
-
-const runTayk = (...argv: string[]) =>
-  Bun.spawnSync(["bun", "packages/cli/bin/tayk.ts", ...argv], {
-    cwd: repoRoot,
-  });
+import { expectExitCode, expectNonZeroExit, runTayk } from "./run-tayk.ts";
 
 // ADR-0003: registry entry の run は Result を返す。ok arm を unwrap して e2e の
 // 期待値 (service が見るのと同じ payload) を得る。
@@ -44,16 +39,16 @@ describe("core registry — skills.list entry (ADR-0004 contract)", () => {
 
 describe("tayk skills list — text output (default)", () => {
   test("exits 0 and prints the count header matching the skills list format", () => {
-    const proc = runTayk("skills", "list");
+    const proc = runTayk({}, "skills", "list");
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(proc.stdout.toString()).toMatch(
       /^同梱スキル \d+ 件 \(source: .+\)$/mu
     );
   });
 
   test("prints each skill as an indented bullet line", async () => {
-    const proc = runTayk("skills", "list");
+    const proc = runTayk({}, "skills", "list");
     const output = proc.stdout.toString();
 
     const expected = await listOk({});
@@ -66,9 +61,9 @@ describe("tayk skills list — text output (default)", () => {
 
 describe("tayk skills list --json", () => {
   test("prints valid JSON carrying source and skills, with no cli reshaping", async () => {
-    const proc = runTayk("skills", "list", "--json");
+    const proc = runTayk({}, "skills", "list", "--json");
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       skills: string[];
       source: string;
@@ -98,6 +93,7 @@ describe("tayk skills list --skills-dir — option propagates to the service", (
 
   test("--json lists the directories under the supplied --skills-dir", () => {
     const proc = runTayk(
+      {},
       "skills",
       "list",
       "--skills-dir",
@@ -105,7 +101,7 @@ describe("tayk skills list --skills-dir — option propagates to the service", (
       "--json"
     );
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     const parsed = JSON.parse(proc.stdout.toString()) as {
       skills: string[];
       source: string;
@@ -115,9 +111,9 @@ describe("tayk skills list --skills-dir — option propagates to the service", (
   });
 
   test("text output header reports the supplied --skills-dir as source", () => {
-    const proc = runTayk("skills", "list", "--skills-dir", fixtureDir);
+    const proc = runTayk({}, "skills", "list", "--skills-dir", fixtureDir);
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(proc.stdout.toString()).toContain(`(source: ${fixtureDir})`);
   });
 });
@@ -125,9 +121,9 @@ describe("tayk skills list --skills-dir — option propagates to the service", (
 describe("tayk skills list — error path (run-command helper)", () => {
   test("missing --skills-dir exits 1 with an io-domain stderr prefix and empty stdout", () => {
     const missingDir = join(tmpdir(), "skills-bin-missing-xyz-842");
-    const proc = runTayk("skills", "list", "--skills-dir", missingDir);
+    const proc = runTayk({}, "skills", "list", "--skills-dir", missingDir);
 
-    expect(proc.exitCode).toBe(1);
+    expectExitCode(proc, 1);
     expect(proc.stderr.toString()).toContain("[io]");
     expect(proc.stdout.toString()).toBe("");
   });
@@ -135,15 +131,15 @@ describe("tayk skills list — error path (run-command helper)", () => {
 
 describe("tayk dispatcher — citty usage surface", () => {
   test("`tayk --help` exits 0 and lists the skills subcommand", () => {
-    const proc = runTayk("--help");
+    const proc = runTayk({}, "--help");
 
-    expect(proc.exitCode).toBe(0);
+    expectExitCode(proc, 0);
     expect(proc.stdout.toString()).toContain("skills");
   });
 
   test("`tayk skills <unknown>` exits non-zero", () => {
-    const proc = runTayk("skills", "bogus");
+    const proc = runTayk({}, "skills", "bogus");
 
-    expect(proc.exitCode).not.toBe(0);
+    expectNonZeroExit(proc);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@youtube-automation/core",
+  "name": "@tayk/core",
   "version": "0.1.0-alpha.0",
   "private": true,
   "description": "Pure domain logic for the youtube-channels-automation TS rewrite (skeleton).",

--- a/packages/core/test/analytics-audience.test.ts
+++ b/packages/core/test/analytics-audience.test.ts
@@ -4,7 +4,7 @@ import {
   AudienceAnalyticsInput,
   AudienceAnalyticsOutput,
   collectAudienceService,
-} from "@youtube-automation/core/analytics/audience";
+} from "@tayk/core/analytics/audience";
 
 type AudienceInput = Parameters<typeof collectAudienceService>[0];
 type AudienceDeps = Parameters<typeof collectAudienceService>[1];

--- a/packages/core/test/analytics-channel.test.ts
+++ b/packages/core/test/analytics-channel.test.ts
@@ -21,12 +21,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { QuotaExhaustedError, YouTubeAPIError } from "@youtube-automation/core";
+import { QuotaExhaustedError, YouTubeAPIError } from "@tayk/core";
 import {
   ChannelAnalyticsInput,
   ChannelAnalyticsOutput,
   collectChannelAnalyticsService,
-} from "@youtube-automation/core/analytics/channel";
+} from "@tayk/core/analytics/channel";
 
 // shouldRetryAnalyticsQuery is a private analytics helper, not part of the
 // package public exports. The retry-permit truth table is pinned through a

--- a/packages/core/test/analytics-query-error.test.ts
+++ b/packages/core/test/analytics-query-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { QuotaExhaustedError, YouTubeAPIError } from "@youtube-automation/core";
+import { QuotaExhaustedError, YouTubeAPIError } from "@tayk/core";
 
 import {
   parseRetryAfterSeconds,

--- a/packages/core/test/analytics-traffic-source.test.ts
+++ b/packages/core/test/analytics-traffic-source.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { QuotaExhaustedError } from "@youtube-automation/core";
+import { QuotaExhaustedError } from "@tayk/core";
 import {
   TrafficSourceAnalyticsInput,
   TrafficSourceAnalyticsOutput,
   collectTrafficSourceService,
-} from "@youtube-automation/core/analytics/traffic-source";
+} from "@tayk/core/analytics/traffic-source";
 
 type TrafficSourceInput = Parameters<typeof collectTrafficSourceService>[0];
 type TrafficSourceDeps = Parameters<typeof collectTrafficSourceService>[1];

--- a/packages/core/test/analytics-video-daily.test.ts
+++ b/packages/core/test/analytics-video-daily.test.ts
@@ -13,10 +13,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { QuotaExhaustedError } from "@youtube-automation/core";
-import { collectVideoDailyAnalyticsService } from "@youtube-automation/core/analytics/video-daily";
-import type { CollectVideoDailyAnalyticsInput } from "@youtube-automation/core/analytics/video-daily";
-import type { YouTubeAnalyticsClient } from "@youtube-automation/core/oauth/client";
+import { QuotaExhaustedError } from "@tayk/core";
+import { collectVideoDailyAnalyticsService } from "@tayk/core/analytics/video-daily";
+import type { CollectVideoDailyAnalyticsInput } from "@tayk/core/analytics/video-daily";
+import type { YouTubeAnalyticsClient } from "@tayk/core/oauth/client";
 
 // --- fakes ----------------------------------------------------------------
 

--- a/packages/core/test/analytics-video.test.ts
+++ b/packages/core/test/analytics-video.test.ts
@@ -26,7 +26,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { collectVideoAnalyticsService } from "@youtube-automation/core/analytics/video";
+import { collectVideoAnalyticsService } from "@tayk/core/analytics/video";
 
 // Derive input / deps shapes from the service signature so the test does not
 // hard-code the exported type names (oauth-refresh.test.ts:25-26).

--- a/packages/core/test/config-buckets.test.ts
+++ b/packages/core/test/config-buckets.test.ts
@@ -25,7 +25,7 @@ import {
 import { readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-import { loadConfig, reset } from "@youtube-automation/core/config";
+import { loadConfig, reset } from "@tayk/core/config";
 
 import {
   cleanupChannels,

--- a/packages/core/test/config-comments.test.ts
+++ b/packages/core/test/config-comments.test.ts
@@ -8,7 +8,7 @@ import {
   test,
 } from "bun:test";
 
-import { loadConfig, reset } from "@youtube-automation/core/config";
+import { loadConfig, reset } from "@tayk/core/config";
 
 import {
   cleanupChannels,

--- a/packages/core/test/config-helpers.test.ts
+++ b/packages/core/test/config-helpers.test.ts
@@ -21,7 +21,7 @@ import {
   sceneForTheme,
   tagsDefault,
   tagsForCollection,
-} from "@youtube-automation/core/config";
+} from "@tayk/core/config";
 
 import {
   cleanupChannels,

--- a/packages/core/test/config-loader.test.ts
+++ b/packages/core/test/config-loader.test.ts
@@ -13,7 +13,7 @@ import { join, resolve } from "node:path";
 // Imported by the published package name + "./config" subpath so the test
 // exercises the core `exports` map. A missing/broken subpath export fails
 // resolution here, not in tsc.
-import { channelDir, loadConfig, reset } from "@youtube-automation/core/config";
+import { channelDir, loadConfig, reset } from "@tayk/core/config";
 
 import {
   cleanupChannels,

--- a/packages/core/test/config-sections.test.ts
+++ b/packages/core/test/config-sections.test.ts
@@ -9,7 +9,7 @@ import {
   test,
 } from "bun:test";
 
-import { loadConfig, reset } from "@youtube-automation/core/config";
+import { loadConfig, reset } from "@tayk/core/config";
 
 import {
   cleanupChannels,

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -12,8 +12,8 @@ import {
   ServiceError,
   toServiceError,
   YouTubeAPIError,
-} from "@youtube-automation/core";
-import type { Result } from "@youtube-automation/core";
+} from "@tayk/core";
+import type { Result } from "@tayk/core";
 import { z } from "zod";
 
 // classifyGaxiosError is an internal cross-feature classifier (shared by the

--- a/packages/core/test/image-config.test.ts
+++ b/packages/core/test/image-config.test.ts
@@ -19,8 +19,8 @@ import {
   getProvider,
   OPENAI_SUPPORTED_ASPECT_RATIOS,
   parseImageGenerationConfig,
-} from "@youtube-automation/core/image";
-import type { ImageGenerationConfig } from "@youtube-automation/core/image";
+} from "@tayk/core/image";
+import type { ImageGenerationConfig } from "@tayk/core/image";
 
 // --- shared aspect-ratio constants -----------------------------------------
 // (RETRY_MAX / RETRY_BACKOFF were promoted into the withRetry defaults in

--- a/packages/core/test/image-gemini.test.ts
+++ b/packages/core/test/image-gemini.test.ts
@@ -27,11 +27,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  GeminiImageProvider,
-  generateImageService,
-} from "@youtube-automation/core/image";
-import type { GenerateImageInput } from "@youtube-automation/core/image";
+import { GeminiImageProvider, generateImageService } from "@tayk/core/image";
+import type { GenerateImageInput } from "@tayk/core/image";
 
 // Constructor deps type, derived from the provider itself so the test does not
 // hard-code an exported name for the injection bag.

--- a/packages/core/test/image-openai.test.ts
+++ b/packages/core/test/image-openai.test.ts
@@ -28,11 +28,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  generateImageService,
-  OpenAIImageProvider,
-} from "@youtube-automation/core/image";
-import type { GenerateImageInput } from "@youtube-automation/core/image";
+import { generateImageService, OpenAIImageProvider } from "@tayk/core/image";
+import type { GenerateImageInput } from "@tayk/core/image";
 
 type OpenAIDeps = NonNullable<
   ConstructorParameters<typeof OpenAIImageProvider>[1]

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 // Imports by the published package name (not a relative path) so the test
 // exercises the package `exports` map, not just the source file. A broken
 // `exports` entry would fail resolution here instead of slipping past tsc.
-import { greeting } from "@youtube-automation/core";
+import { greeting } from "@tayk/core";
 
 test("greeting() returns the skeleton banner", () => {
   expect(greeting()).toBe(

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -34,8 +34,8 @@ import {
   test,
 } from "bun:test";
 
-import { loadConfig, reset } from "@youtube-automation/core/config";
-import type { ChannelConfig } from "@youtube-automation/core/config";
+import { loadConfig, reset } from "@tayk/core/config";
+import type { ChannelConfig } from "@tayk/core/config";
 import {
   buildCompleteCollectionDescription,
   buildShortDescription,
@@ -51,7 +51,7 @@ import {
   referencedPlaceholders,
   tagsForCollection,
   validateScenePhrases,
-} from "@youtube-automation/core/metadata";
+} from "@tayk/core/metadata";
 
 import {
   cleanupChannels,

--- a/packages/core/test/oauth-client.test.ts
+++ b/packages/core/test/oauth-client.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildYouTubeAnalyticsClient,
   buildYouTubeClient,
-} from "@youtube-automation/core/oauth/client";
+} from "@tayk/core/oauth/client";
 
 // A placeholder google-auth-library Credentials object. `expiry_date` sits in the
 // year 2100 so nothing here is treated as expired; the factory must not care.

--- a/packages/core/test/oauth-interactive-lint.test.ts
+++ b/packages/core/test/oauth-interactive-lint.test.ts
@@ -42,7 +42,7 @@ test("oxlint errors when a packages/mcp file imports the interactive OAuth servi
   writeFileSync(
     fixtureFile,
     [
-      'import { interactiveAuthService } from "@youtube-automation/core/oauth/interactive";',
+      'import { interactiveAuthService } from "@tayk/core/oauth/interactive";',
       "",
       "export const handler = interactiveAuthService;",
       "",

--- a/packages/core/test/oauth-interactive.test.ts
+++ b/packages/core/test/oauth-interactive.test.ts
@@ -93,7 +93,7 @@ describe("exchangeCode", () => {
 
 // Guards the public oauth surface against re-leaking implementation internals
 // (ADR-0003 §7 public-API minimization). The package.json subpath
-// "@youtube-automation/core/oauth/interactive" maps to interactive.ts, so this
+// "@tayk/core/oauth/interactive" maps to interactive.ts, so this
 // module's own exports ARE the public surface. buildAuthUrl / exchangeCode now
 // live in interactive-internal.ts (relative-only); re-exporting them here would
 // expose internals again.

--- a/packages/core/test/oauth-refresh.test.ts
+++ b/packages/core/test/oauth-refresh.test.ts
@@ -18,7 +18,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { refreshTokenService } from "@youtube-automation/core/oauth/refresh";
+import { refreshTokenService } from "@tayk/core/oauth/refresh";
 
 // Derive the deps bag type from the service itself (image-gemini.test.ts:38-40)
 // so the test does not hard-code the injection shape's exported name.

--- a/packages/core/test/paths.test.ts
+++ b/packages/core/test/paths.test.ts
@@ -21,10 +21,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  CollectionPaths,
-  resolveCollectionDir,
-} from "@youtube-automation/core/paths";
+import { CollectionPaths, resolveCollectionDir } from "@tayk/core/paths";
 
 const tempRoots: string[] = [];
 

--- a/packages/core/test/registry-deps.test.ts
+++ b/packages/core/test/registry-deps.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { ok } from "@youtube-automation/core";
-import type { ChannelConfig } from "@youtube-automation/core/config";
+import { ok } from "@tayk/core";
+import type { ChannelConfig } from "@tayk/core/config";
 import type {
   YouTubeAnalyticsClient,
   YouTubeClient,
-} from "@youtube-automation/core/oauth/client";
-import type { DepsMap, RegistryEntry } from "@youtube-automation/core/registry";
+} from "@tayk/core/oauth/client";
+import type { DepsMap, RegistryEntry } from "@tayk/core/registry";
 import { z } from "zod";
 
 const fakeConfig = {

--- a/packages/core/test/retry.test.ts
+++ b/packages/core/test/retry.test.ts
@@ -10,11 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  defaultShouldRetry,
-  QuotaExhaustedError,
-  withRetry,
-} from "@youtube-automation/core";
+import { defaultShouldRetry, QuotaExhaustedError, withRetry } from "@tayk/core";
 
 // Records every injected sleep so no test waits on real timers.
 const makeSleepRecorder = () => {

--- a/packages/core/test/skills-sync-asset.test.ts
+++ b/packages/core/test/skills-sync-asset.test.ts
@@ -20,8 +20,8 @@ import {
   SkillSyncInputSchema,
   SkillSyncOutputSchema,
   syncAssetService,
-} from "@youtube-automation/core/skills-sync";
-import type { SkillSyncInput } from "@youtube-automation/core/skills-sync";
+} from "@tayk/core/skills-sync";
+import type { SkillSyncInput } from "@tayk/core/skills-sync";
 
 // Repo root is three levels up from packages/core/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");

--- a/packages/core/test/skills-sync.test.ts
+++ b/packages/core/test/skills-sync.test.ts
@@ -16,8 +16,8 @@ import {
   listSkillsService,
   SkillListInputSchema,
   SkillListOutputSchema,
-} from "@youtube-automation/core/skills-sync";
-import type { SkillListInput } from "@youtube-automation/core/skills-sync";
+} from "@tayk/core/skills-sync";
+import type { SkillListInput } from "@tayk/core/skills-sync";
 
 // Repo root is three levels up from packages/core/test/.
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");

--- a/packages/core/test/suno-prompts.test.ts
+++ b/packages/core/test/suno-prompts.test.ts
@@ -11,16 +11,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { REGISTRY } from "@youtube-automation/core/registry";
-import * as sunoPromptsPublicApi from "@youtube-automation/core/suno-prompts";
+import { REGISTRY } from "@tayk/core/registry";
+import * as sunoPromptsPublicApi from "@tayk/core/suno-prompts";
 import {
   generateSunoPromptsService,
   GenerateSunoInputSchema,
-} from "@youtube-automation/core/suno-prompts";
+} from "@tayk/core/suno-prompts";
 import type {
   GenerateSunoInput,
   GenerateSunoOutput,
-} from "@youtube-automation/core/suno-prompts";
+} from "@tayk/core/suno-prompts";
 
 const tmpDirs: string[] = [];
 

--- a/packages/core/test/templates.test.ts
+++ b/packages/core/test/templates.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { loadTemplate } from "@youtube-automation/core/metadata";
+import { loadTemplate } from "@tayk/core/metadata";
 
 describe("loadTemplate", () => {
   test("loads the complete-collection template with its format placeholders", () => {

--- a/packages/core/test/upload.test.ts
+++ b/packages/core/test/upload.test.ts
@@ -41,7 +41,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { uploadVideoService } from "@youtube-automation/core/upload";
+import { uploadVideoService } from "@tayk/core/upload";
 
 // Derive input / deps shapes from the service signature so the test does not
 // hard-code the exported type names (analytics-video.test.ts:33-36).


### PR DESCRIPTION
## Summary

> 親: #968 を 3 分割（rebrand / bundle / publish）。本 issue は **rebrand 部分**。重い publish を autonomous で回さないための分割（外部・不可逆操作の隔離）。

## 背景 (ADR-0006 / ADR-0007 / epic #727)

ADR-0007 で publish 名・bin・内部 scope を **`tayk`** に確定（#980 closed）。現状:

- bin は既に `tayk`（`packages/cli/package.json`）✓
- 内部 scope は **`@youtube-automation/*` のまま**（cli/core 両 package、`.ts` import 多数）
- 両 package とも `private: true`

最初の alpha publish が **name lock point**（#968c）。その前に rebrand を完了させる。

## 作業内容（keep / drop 明示）

- [ ] **keep**: 内部 scope rename `@youtube-automation/core` → `@tayk/core`（`packages/core/package.json::name` ＋ `packages/cli` の dependency key ＋ 全 `.ts` import 文字列 ＋ `core` の `exports` 参照側）
- [ ] **keep**: publish package 名 `@youtube-automation/cli` → **`tayk`**（unscoped、ADR-0007 canonical `bunx tayk`）
- [ ] **keep**: cli の `private: true` を撤去（publish 対象）。**core は `private: true` 維持**（bundle されるため publish 不要）
- [ ] **keep**: `bin` はそのまま（既に `tayk`）。`exports` の path は変更不要
- [ ] **drop（本 issue 範囲外）**: bun build / dist 生成は #968b、publish workflow は #968c
- [ ] **不変**: root `package.json::name` `youtube-channels-automation` は private workspace root のため rename 不要（publish 対象外）。触らない

## 隠れ契約

- `@youtube-automation/` 文字列の **取りこぼし防止**: `packages/**/*.ts` ・ `oxlint.config.ts` ・ test ファイル ・ `package.json::exports`/`dependencies` を一括置換。残存ゼロを grep で機械確認
- workspace 解決: rename 後も `bun install` で `@tayk/core` が workspace link されること（`workspace:*` 維持）

## 受入基準 / 検証

- [ ] `rg "@youtube-automation/" packages oxlint.config.ts` が 0 件
- [ ] `bun run ci`（lint / format / typecheck / test / knip）green
- [ ] `packages/cli/package.json::name` == `tayk`、`private` キーなし
- [ ] `packages/core/package.json::name` == `@tayk/core`、`private: true` 維持

## 出典

- `packages/cli/package.json` / `packages/core/package.json`（現 scope `@youtube-automation/*`）
- ADR-0006 (npm distribution) / ADR-0007 (rebrand → tayk)

## Blocked by

- なし（最初に着手。#968b / #968c の前提）

base branch: `feat/ts-rewrite` / Tier 1

## Execution Report

Workflow `default` completed successfully.

Closes #1099