### PR TITLE
[#1072] issue-1072-scaffold-1-3-tayk-c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(ts-rewrite/core)`: `channel.init` service と `tayk channel-init` を追加し、正準ディレクトリの `.gitkeep` と `config/channel/*.json` 7 ファイルを plan→apply 3-phase で scaffold できるようにした（#1072）。
 - `feat(ts-rewrite/core)`: Traffic source 内訳（search / browse / external / suggested 等）を期間集計する `collectTrafficSourceService` を ADR-0003 準拠で実装した（#832）。`packages/core/src/analytics/traffic-source/`（schema / service / index）を新設し、Python `utils/traffic_source_analytics.py` Mixin を翻訳せず TS で新規記述。あわせて analytics 共通のエラー分類を `analytics/query-error.ts`（`toAnalyticsQueryError` / `shouldRetryAnalyticsQuery`）へ集約し、video / channel / video-daily / traffic-source の各 service から参照する。quota（429）は `withRetry` で retry せず `domain: "quota"` の Result で返す
 - `feat(ts-rewrite/core)`: resumable upload + thumbnail 圧縮 + metadata update を 1 atomic service に集約した `uploadVideoService` を ADR-0003 準拠で実装した（#837）
 - `feat(ts-rewrite/core)`: Per-video metrics（views / likes / comments / shares 等 8 指標）を YouTube Analytics API から収集する analytics video service を ADR-0003 準拠で実装した（#829）

--- a/packages/cli/bin/tayk.ts
+++ b/packages/cli/bin/tayk.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 
+import { channelInitCommand } from "../src/commands/channel-init/cli.ts";
 import { generateSunoCommand } from "../src/commands/generate-suno/cli.ts";
 import { skillsCommand } from "../src/commands/skills/cli.ts";
 
@@ -9,7 +10,11 @@ const main = defineCommand({
     description: "youtube-channels-automation CLI (TS rewrite)",
     name: "tayk",
   },
-  subCommands: { "generate-suno": generateSunoCommand, skills: skillsCommand },
+  subCommands: {
+    "channel-init": channelInitCommand,
+    "generate-suno": generateSunoCommand,
+    skills: skillsCommand,
+  },
 });
 
 await runMain(main);

--- a/packages/cli/lib/resolve-deps.ts
+++ b/packages/cli/lib/resolve-deps.ts
@@ -25,7 +25,8 @@ import { resolveTokenJson } from "./oauth.ts";
  * - 空 deps       → 副作用ゼロで `{}` を返す
  */
 export const resolveDeps = async <D extends keyof DepsMap>(
-  deps: readonly D[]
+  deps: readonly D[],
+  overrides?: Partial<Pick<DepsMap, "channelDir">>
 ): Promise<Pick<DepsMap, D>> => {
   const requested = new Set<keyof DepsMap>(deps);
   const resolved: Partial<DepsMap> = {};
@@ -35,7 +36,7 @@ export const resolveDeps = async <D extends keyof DepsMap>(
   }
 
   if (requested.has("channelDir")) {
-    resolved.channelDir = channelDir();
+    resolved.channelDir = overrides?.channelDir ?? channelDir();
   }
 
   const needsYt = requested.has("yt");

--- a/packages/cli/src/commands/channel-init/cli.ts
+++ b/packages/cli/src/commands/channel-init/cli.ts
@@ -1,0 +1,101 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import process from "node:process";
+
+import { err, toServiceError } from "@youtube-automation/core";
+import type { ChannelInitOutput } from "@youtube-automation/core/channel-init";
+import { REGISTRY } from "@youtube-automation/core/registry";
+import { defineCommand } from "citty";
+
+import { resolveDeps } from "../../../lib/resolve-deps.ts";
+import { emitResult } from "../../../lib/run-command.ts";
+
+const channelInitEntry = REGISTRY["channel.init"];
+
+const resolveTarget = (target: string | undefined): string => {
+  if (target !== undefined) {
+    return target;
+  }
+  const env = process.env.CHANNEL_DIR;
+  if (env !== undefined && env !== "") {
+    return env;
+  }
+  return process.cwd();
+};
+
+const assertDirectory = (path: string): string => {
+  if (!existsSync(path) || !statSync(path).isDirectory()) {
+    throw new Error(`config: channel-init target が存在しません: ${path}`);
+  }
+  return realpathSync(path);
+};
+
+const renderText = (output: ChannelInitOutput): string => {
+  if (output.diff !== "") {
+    process.stderr.write(output.diff);
+  }
+  return output.summary;
+};
+
+export const channelInitCommand = defineCommand({
+  args: {
+    context: {
+      default: "TBD",
+      description: '利用コンテキスト placeholder (default: "TBD")',
+      type: "string",
+    },
+    force: {
+      default: false,
+      description: "既存ファイルを上書きする",
+      type: "boolean",
+    },
+    genre: {
+      default: "TBD",
+      description: 'ジャンル placeholder (default: "TBD")',
+      type: "string",
+    },
+    name: {
+      description: "仮チャンネル名",
+      required: true,
+      type: "string",
+    },
+    short: {
+      description: "仮チャンネルの短縮シンボル",
+      required: true,
+      type: "string",
+    },
+    style: {
+      default: "TBD",
+      description: 'スタイル placeholder (default: "TBD")',
+      type: "string",
+    },
+    target: {
+      description:
+        "ターゲットチャンネルディレクトリ (default: CHANNEL_DIR → CWD)",
+      type: "string",
+    },
+  },
+  meta: {
+    description: channelInitEntry.description,
+    name: "channel-init",
+  },
+  async run({ args }) {
+    const result = await (async () => {
+      try {
+        const input = channelInitEntry.inputSchema.parse({
+          context: args.context,
+          force: args.force,
+          genre: args.genre,
+          name: args.name,
+          short: args.short,
+          style: args.style,
+        });
+        const channelDir = assertDirectory(resolveTarget(args.target));
+        const deps = await resolveDeps(channelInitEntry.deps, { channelDir });
+        return await channelInitEntry.run(input, deps);
+      } catch (error) {
+        return err(toServiceError(error));
+      }
+    })();
+    emitResult(result, { json: false, renderText });
+  },
+});

--- a/packages/cli/test/resolve-deps.test.ts
+++ b/packages/cli/test/resolve-deps.test.ts
@@ -157,6 +157,26 @@ describe("resolveDeps — channelDir", () => {
 
     spawnSpy.mockRestore();
   });
+
+  test("uses an explicit channelDir override without consulting CHANNEL_DIR", async () => {
+    const envDir = makeChannelDir();
+    const overrideDir = makeChannelDir();
+    process.env.CHANNEL_DIR = envDir;
+    reset();
+    const spawnSpy = spyOn(Bun, "spawn");
+
+    const deps = await resolveDeps(["channelDir"], {
+      channelDir: overrideDir,
+    });
+
+    expect(deps.channelDir).toBe(overrideDir);
+    expect("config" in deps).toBe(false);
+    expect("yt" in deps).toBe(false);
+    expect("ytAnalytics" in deps).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    spawnSpy.mockRestore();
+  });
 });
 
 // --- yt (network-free) ---------------------------------------------------

--- a/packages/cli/test/yt-channel-init.test.ts
+++ b/packages/cli/test/yt-channel-init.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const taykBin = join(repoRoot, "packages", "cli", "bin", "tayk.ts");
+const tmpDirs: string[] = [];
+
+const makeTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const realDir = realpathSync(dir);
+  tmpDirs.push(realDir);
+  return realDir;
+};
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const runTayk = (
+  options: { cwd?: string; env: Record<string, string | undefined> },
+  ...argv: string[]
+) => {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(options.env)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(env, key);
+    } else {
+      env[key] = value;
+    }
+  }
+
+  return Bun.spawnSync(["bun", taykBin, ...argv], {
+    cwd: options.cwd ?? repoRoot,
+    env,
+  });
+};
+
+const readJson = (path: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+
+describe("core registry — channel.init entry visible from cli package", () => {
+  test("should expose the registry entry consumed by the CLI adapter", () => {
+    const entry = REGISTRY["channel.init"];
+
+    expect(entry.deps).toEqual(["channelDir"]);
+    expect(entry.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe("tayk channel-init — smoke", () => {
+  test("should scaffold a target directory through the dispatcher", () => {
+    const channelDir = makeTempDir("cli-channel-init-");
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: undefined } },
+      "channel-init",
+      "--target",
+      channelDir,
+      "--short",
+      "DEMO",
+      "--name",
+      "Demo Channel",
+      "--genre",
+      "ambient",
+      "--style",
+      "soft piano",
+      "--context",
+      "Study"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString()).toBe("");
+    expect(proc.stdout.toString()).toContain(
+      "  created     config/channel/meta.json"
+    );
+    expect(proc.stdout.toString()).toContain("  created     research/");
+    const meta = readJson(join(channelDir, "config", "channel", "meta.json"));
+    expect(meta).toMatchObject({
+      channel: { name: "Demo Channel", short: "DEMO" },
+    });
+    expect(existsSync(join(channelDir, "auth", ".gitkeep"))).toBe(true);
+  });
+
+  test("should resolve target from CHANNEL_DIR when --target is omitted", () => {
+    const channelDir = makeTempDir("cli-channel-init-env-");
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: channelDir } },
+      "channel-init",
+      "--short",
+      "ENV",
+      "--name",
+      "Env Channel"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    const meta = readJson(join(channelDir, "config", "channel", "meta.json"));
+    expect(meta).toMatchObject({
+      channel: { name: "Env Channel", short: "ENV" },
+    });
+  });
+
+  test("should resolve target from CWD when --target and CHANNEL_DIR are omitted", () => {
+    const channelDir = makeTempDir("cli-channel-init-cwd-");
+
+    const proc = runTayk(
+      { cwd: channelDir, env: { CHANNEL_DIR: undefined } },
+      "channel-init",
+      "--short",
+      "CWD",
+      "--name",
+      "Cwd Channel"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(join(channelDir, "config", "channel", "meta.json"))).toBe(
+      true
+    );
+  });
+
+  test("should print unified diff to stderr and not overwrite without force", () => {
+    const channelDir = makeTempDir("cli-channel-init-diff-");
+    const metaPath = join(channelDir, "config", "channel", "meta.json");
+    mkdirSync(join(channelDir, "config", "channel"), { recursive: true });
+    writeFileSync(metaPath, '{"channel":{"name":"Old","short":"OLD"}}\n');
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: undefined } },
+      "channel-init",
+      "--target",
+      channelDir,
+      "--short",
+      "NEW",
+      "--name",
+      "New Channel"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain(
+      "  skipped     config/channel/meta.json"
+    );
+    expect(proc.stderr.toString()).toContain(
+      "--- config/channel/meta.json (existing)"
+    );
+    expect(proc.stderr.toString()).toContain(
+      "+++ config/channel/meta.json (template)"
+    );
+    expect(proc.stderr.toString()).toContain("@@ -1 +1,8 @@");
+    expect(proc.stderr.toString()).not.toContain("-+{");
+    expect(readFileSync(metaPath, "utf-8")).toBe(
+      '{"channel":{"name":"Old","short":"OLD"}}\n'
+    );
+  });
+
+  test("should overwrite with force and keep stderr free of diff output", () => {
+    const channelDir = makeTempDir("cli-channel-init-force-");
+    const initial = runTayk(
+      { env: { CHANNEL_DIR: undefined } },
+      "channel-init",
+      "--target",
+      channelDir,
+      "--short",
+      "OLD",
+      "--name",
+      "Old Channel"
+    );
+    expect(initial.exitCode).toBe(0);
+
+    const proc = runTayk(
+      { env: { CHANNEL_DIR: undefined } },
+      "channel-init",
+      "--target",
+      channelDir,
+      "--short",
+      "NEW",
+      "--name",
+      "New Channel",
+      "--force"
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stderr.toString()).toBe("");
+    expect(proc.stdout.toString()).toContain(
+      "  overwritten config/channel/meta.json"
+    );
+    const meta = readJson(join(channelDir, "config", "channel", "meta.json"));
+    expect(meta).toMatchObject({
+      channel: { name: "New Channel", short: "NEW" },
+    });
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./analytics/traffic-source": "./src/analytics/traffic-source/index.ts",
     "./analytics/video": "./src/analytics/video/index.ts",
     "./analytics/video-daily": "./src/analytics/video-daily/index.ts",
+    "./channel-init": "./src/channel-init/index.ts",
     "./config": "./src/config/index.ts",
     "./image": "./src/image/index.ts",
     "./metadata": "./src/metadata.ts",

--- a/packages/core/src/channel-init/index.ts
+++ b/packages/core/src/channel-init/index.ts
@@ -1,0 +1,7 @@
+export {
+  ChannelInitInputSchema,
+  ChannelInitOutputSchema,
+  type ChannelInitInput,
+  type ChannelInitOutput,
+} from "./schema.ts";
+export { channelInitService } from "./service.ts";

--- a/packages/core/src/channel-init/schema.ts
+++ b/packages/core/src/channel-init/schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const ChannelInitInputSchema = z
+  .object({
+    context: z.string().default("TBD"),
+    force: z.boolean().default(false),
+    genre: z.string().default("TBD"),
+    name: z.string(),
+    short: z.string(),
+    style: z.string().default("TBD"),
+  })
+  .strict();
+
+const ActionKindSchema = z.union([
+  z.literal("created"),
+  z.literal("skipped"),
+  z.literal("overwritten"),
+]);
+
+const FileActionSchema = z.object({
+  kind: ActionKindSchema,
+  rel: z.string(),
+});
+
+const DirectoryActionSchema = z.object({
+  kind: ActionKindSchema,
+  rel: z.string(),
+});
+
+export const ChannelInitOutputSchema = z.object({
+  diff: z.string(),
+  directories: z.array(DirectoryActionSchema),
+  files: z.array(FileActionSchema),
+  summary: z.string(),
+});
+
+export type ChannelInitInput = z.infer<typeof ChannelInitInputSchema>;
+export type ChannelInitOutput = z.infer<typeof ChannelInitOutputSchema>;

--- a/packages/core/src/channel-init/service.ts
+++ b/packages/core/src/channel-init/service.ts
@@ -1,0 +1,303 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { toServiceError } from "../errors.ts";
+import type { ServiceError } from "../errors.ts";
+import { err, ok } from "../result.ts";
+import type { Result } from "../result.ts";
+import { ChannelInitInputSchema, ChannelInitOutputSchema } from "./schema.ts";
+import type { ChannelInitInput, ChannelInitOutput } from "./schema.ts";
+
+const CONFIG_SUBDIR = "config/channel";
+const GITKEEP_NAME = ".gitkeep";
+
+const CONFIG_FILES = [
+  "meta.json",
+  "content.json",
+  "youtube.json",
+  "analytics.json",
+  "playlists.json",
+  "workflow.json",
+  "audio.json",
+] as const;
+
+const GITKEEP_DIRS = [
+  "auth",
+  "collections",
+  "data",
+  "docs/benchmarks",
+  "research",
+] as const;
+
+type ActionKind = "created" | "skipped" | "overwritten";
+
+interface FileAction {
+  readonly diff: string;
+  readonly kind: ActionKind;
+  readonly newText: string;
+  readonly path: string;
+  readonly rel: string;
+}
+
+interface DirectoryAction {
+  readonly kind: ActionKind;
+  readonly path: string;
+  readonly rel: string;
+}
+
+interface Plan {
+  readonly directories: readonly DirectoryAction[];
+  readonly files: readonly FileAction[];
+}
+
+type JsonObject = Record<string, unknown>;
+
+type TemplateRenderer = (input: ChannelInitInput) => JsonObject;
+
+const renderMeta: TemplateRenderer = (input) => ({
+  channel: {
+    name: input.name,
+    short: input.short,
+    url: "",
+    youtube_handle: "",
+  },
+});
+
+const renderContent: TemplateRenderer = (input) => ({
+  descriptions: { hashtags: [], opening: "", perfect_for: [] },
+  genre: {
+    context: input.context,
+    primary: input.genre,
+    style: input.style,
+  },
+  tags: { base: [], themes: {} },
+  title: { template: "" },
+});
+
+const renderYoutube = (): JsonObject => ({
+  youtube: {
+    category_id: "10",
+    language: "en",
+    privacy_status: "public",
+  },
+});
+
+const renderAnalytics = (): JsonObject => ({
+  benchmark: {
+    channels: [],
+  },
+});
+
+const renderEmpty = (): JsonObject => ({});
+
+const TEMPLATES: Record<(typeof CONFIG_FILES)[number], TemplateRenderer> = {
+  "analytics.json": renderAnalytics,
+  "audio.json": renderEmpty,
+  "content.json": renderContent,
+  "meta.json": renderMeta,
+  "playlists.json": renderEmpty,
+  "workflow.json": renderEmpty,
+  "youtube.json": renderYoutube,
+};
+
+const serializeJson = (data: JsonObject): string =>
+  `${JSON.stringify(data, null, 2)}\n`;
+
+const splitLines = (text: string): string[] => {
+  if (text === "") {
+    return [];
+  }
+  const lines = text.split("\n");
+  if (text.endsWith("\n")) {
+    lines.pop();
+  }
+  return lines;
+};
+
+const hunkRange = (lineCount: number): string => {
+  if (lineCount === 0) {
+    return "0,0";
+  }
+  if (lineCount === 1) {
+    return "1";
+  }
+  return `1,${lineCount}`;
+};
+
+const assertDirectoryExists = (path: string): string => {
+  if (!existsSync(path) || !statSync(path).isDirectory()) {
+    throw new Error(
+      `config: channelDir が存在するディレクトリではありません: ${path}`
+    );
+  }
+  return realpathSync(path);
+};
+
+const unifiedDiff = (current: string, next: string, rel: string): string => {
+  const currentLines = splitLines(current);
+  const nextLines = splitLines(next);
+  const lines = [
+    `--- ${rel} (existing)\n`,
+    `+++ ${rel} (template)\n`,
+    `@@ -${hunkRange(currentLines.length)} +${hunkRange(nextLines.length)} @@\n`,
+    ...currentLines.map((line) => `-${line}\n`),
+    ...nextLines.map((line) => `+${line}\n`),
+  ];
+  return lines.join("");
+};
+
+const planFile = (
+  path: string,
+  rel: string,
+  newText: string,
+  force: boolean
+): FileAction => {
+  if (!existsSync(path)) {
+    return { diff: "", kind: "created", newText, path, rel };
+  }
+
+  const current = readFileSync(path, "utf-8");
+  if (current === newText) {
+    return { diff: "", kind: "skipped", newText, path, rel };
+  }
+  if (force) {
+    return { diff: "", kind: "overwritten", newText, path, rel };
+  }
+  return {
+    diff: unifiedDiff(current, newText, rel),
+    kind: "skipped",
+    newText,
+    path,
+    rel,
+  };
+};
+
+const planDirectory = (target: string, rel: string): DirectoryAction => {
+  const path = join(target, rel);
+  const gitkeep = join(path, GITKEEP_NAME);
+  if (
+    existsSync(path) &&
+    statSync(path).isDirectory() &&
+    existsSync(gitkeep) &&
+    statSync(gitkeep).isFile()
+  ) {
+    return { kind: "skipped", path, rel };
+  }
+  return { kind: "created", path, rel };
+};
+
+const planActions = (target: string, input: ChannelInitInput): Plan => {
+  const files = CONFIG_FILES.map((name) => {
+    const rel = `${CONFIG_SUBDIR}/${name}`;
+    return planFile(
+      join(target, rel),
+      rel,
+      serializeJson(TEMPLATES[name](input)),
+      input.force
+    );
+  });
+  const directories = GITKEEP_DIRS.map((rel) => planDirectory(target, rel));
+  return { directories, files };
+};
+
+const assertDirectoryPathAvailable = (target: string, rel: string): void => {
+  let cursor = target;
+  for (const segment of rel.split("/")) {
+    cursor = join(cursor, segment);
+    if (existsSync(cursor) && !statSync(cursor).isDirectory()) {
+      throw new Error(
+        `config: channel-init scaffold path is blocked by a file: ${cursor}`
+      );
+    }
+  }
+};
+
+const preflightPlan = (plan: Plan, target: string): void => {
+  const directoryRels = new Set<string>();
+  for (const action of plan.files) {
+    if (action.kind === "created" || action.kind === "overwritten") {
+      directoryRels.add(dirname(action.rel));
+    }
+  }
+  for (const action of plan.directories) {
+    if (action.kind === "created") {
+      directoryRels.add(action.rel);
+      const gitkeep = join(action.path, GITKEEP_NAME);
+      if (existsSync(gitkeep) && !statSync(gitkeep).isFile()) {
+        throw new Error(
+          `config: channel-init .gitkeep path is blocked by a directory: ${gitkeep}`
+        );
+      }
+    }
+  }
+  for (const rel of directoryRels) {
+    assertDirectoryPathAvailable(target, rel);
+  }
+};
+
+const applyPlan = (plan: Plan): void => {
+  for (const action of plan.files) {
+    if (action.kind === "created" || action.kind === "overwritten") {
+      mkdirSync(dirname(action.path), { recursive: true });
+      writeFileSync(action.path, action.newText, "utf-8");
+    }
+  }
+  for (const action of plan.directories) {
+    if (action.kind === "created") {
+      mkdirSync(action.path, { recursive: true });
+      writeFileSync(join(action.path, GITKEEP_NAME), "", "utf-8");
+    }
+  }
+};
+
+const formatSummary = (plan: Plan): string => {
+  const fileLines = plan.files.map(
+    (action) => `  ${action.kind.padEnd(11, " ")} ${action.rel}`
+  );
+  const directoryLines = plan.directories.map(
+    (action) => `  ${action.kind.padEnd(11, " ")} ${action.rel}/`
+  );
+  return [...fileLines, ...directoryLines].join("\n");
+};
+
+const collectDiffs = (plan: Plan): string =>
+  plan.files.map((action) => action.diff).join("");
+
+export const channelInitService = (
+  input: ChannelInitInput,
+  deps: { channelDir: string }
+): Promise<Result<ChannelInitOutput, ServiceError>> => {
+  try {
+    const request = ChannelInitInputSchema.parse(input);
+    const channelDir = assertDirectoryExists(deps.channelDir);
+    const plan = planActions(channelDir, request);
+    preflightPlan(plan, channelDir);
+    applyPlan(plan);
+
+    return Promise.resolve(
+      ok(
+        ChannelInitOutputSchema.parse({
+          diff: collectDiffs(plan),
+          directories: plan.directories.map((action) => ({
+            kind: action.kind,
+            rel: action.rel,
+          })),
+          files: plan.files.map((action) => ({
+            kind: action.kind,
+            rel: action.rel,
+          })),
+          summary: formatSummary(plan),
+        })
+      )
+    );
+  } catch (error) {
+    return Promise.resolve(err(toServiceError(error)));
+  }
+};

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,5 +1,10 @@
 import type { z } from "zod";
 
+import {
+  channelInitService,
+  ChannelInitInputSchema,
+  ChannelInitOutputSchema,
+} from "./channel-init/index.ts";
 import type { ChannelConfig } from "./config/index.ts";
 import type { ServiceError } from "./errors.ts";
 import type { YouTubeAnalyticsClient, YouTubeClient } from "./oauth/client.ts";
@@ -67,6 +72,14 @@ const defineRegistryEntry = <
 ): RegistryEntry<I, O, D> => entry;
 
 export const REGISTRY = {
+  "channel.init": defineRegistryEntry({
+    deps: ["channelDir"],
+    description:
+      "チャンネルリポジトリの正準ディレクトリと config/channel/*.json を初期化する",
+    inputSchema: ChannelInitInputSchema,
+    outputSchema: ChannelInitOutputSchema,
+    run: channelInitService,
+  }),
   "skills.list": defineRegistryEntry({
     deps: [],
     description: "同梱スキル一覧を列挙する",

--- a/packages/core/test/channel-init.test.ts
+++ b/packages/core/test/channel-init.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import * as channelInitPublicApi from "@youtube-automation/core/channel-init";
+import {
+  channelInitService,
+  ChannelInitInputSchema,
+} from "@youtube-automation/core/channel-init";
+import type {
+  ChannelInitInput,
+  ChannelInitOutput,
+} from "@youtube-automation/core/channel-init";
+import {
+  loadConfig,
+  reset as resetConfig,
+} from "@youtube-automation/core/config";
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+const tmpDirs: string[] = [];
+let savedChannelDir: string | undefined;
+
+const configFiles = [
+  "meta.json",
+  "content.json",
+  "youtube.json",
+  "analytics.json",
+  "playlists.json",
+  "workflow.json",
+  "audio.json",
+] as const;
+
+const gitkeepDirs = [
+  "auth",
+  "collections",
+  "data",
+  "docs/benchmarks",
+  "research",
+] as const;
+
+const makeTempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const realDir = realpathSync(dir);
+  tmpDirs.push(realDir);
+  return realDir;
+};
+
+afterEach(() => {
+  if (savedChannelDir === undefined) {
+    Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  } else {
+    process.env.CHANNEL_DIR = savedChannelDir;
+  }
+  savedChannelDir = undefined;
+  resetConfig();
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const request = (
+  overrides: Partial<ChannelInitInput> = {}
+): ChannelInitInput => ({
+  context: "Study",
+  force: false,
+  genre: "ambient",
+  name: "Demo Channel",
+  short: "DEMO",
+  style: "soft piano",
+  ...overrides,
+});
+
+const runOk = async (
+  input: ChannelInitInput,
+  channelDir: string
+): Promise<ChannelInitOutput> => {
+  const result = await channelInitService(input, { channelDir });
+  if (!result.ok) {
+    throw new Error(
+      `expected an ok Result, got error: ${JSON.stringify(result.error)}`
+    );
+  }
+  return result.value;
+};
+
+const readJson = (path: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+
+describe("channel-init public API — exports map", () => {
+  test("should expose only service boundary runtime symbols", () => {
+    expect(Object.keys(channelInitPublicApi).toSorted()).toEqual([
+      "ChannelInitInputSchema",
+      "ChannelInitOutputSchema",
+      "channelInitService",
+    ]);
+  });
+});
+
+describe("channel.init registry deps — contract", () => {
+  test("should require only channelDir from adapters", () => {
+    expect(REGISTRY["channel.init"].deps).toEqual(["channelDir"]);
+  });
+});
+
+describe("ChannelInitInputSchema — contract", () => {
+  test("should require short and name while defaulting optional flags", () => {
+    const parsed = ChannelInitInputSchema.parse({
+      name: "Demo Channel",
+      short: "DEMO",
+    });
+
+    expect(parsed).toEqual({
+      context: "TBD",
+      force: false,
+      genre: "TBD",
+      name: "Demo Channel",
+      short: "DEMO",
+      style: "TBD",
+    });
+  });
+
+  test("should reject channelDir because channelDir is a registry dependency", () => {
+    expect(() =>
+      ChannelInitInputSchema.parse({
+        channelDir: "/tmp/channel",
+        name: "Demo Channel",
+        short: "DEMO",
+      })
+    ).toThrow();
+  });
+});
+
+describe("channelInitService — scaffold generation", () => {
+  test("should create seven config files and canonical gitkeep directories", async () => {
+    const channelDir = makeTempDir("channel-init-created-");
+
+    const output = await runOk(request(), channelDir);
+
+    for (const name of configFiles) {
+      const path = join(channelDir, "config", "channel", name);
+      expect(existsSync(path)).toBe(true);
+      expect(readFileSync(path, "utf-8").endsWith("\n")).toBe(true);
+    }
+    for (const rel of gitkeepDirs) {
+      expect(existsSync(join(channelDir, rel, ".gitkeep"))).toBe(true);
+    }
+    expect(output.files.map((action) => action.kind)).toEqual(
+      configFiles.map(() => "created")
+    );
+    expect(output.directories.map((action) => action.kind)).toEqual(
+      gitkeepDirs.map(() => "created")
+    );
+    expect(output.summary).toContain("  created     config/channel/meta.json");
+    expect(output.summary).toContain("  created     docs/benchmarks/");
+    expect(output.diff).toBe("");
+  });
+
+  test("should render input values into meta and content config", async () => {
+    const channelDir = makeTempDir("channel-init-render-");
+
+    await runOk(
+      request({
+        context: "RPG maps",
+        genre: "chiptune",
+        name: "Awesome BGM",
+        short: "ABC-01",
+        style: "8-bit",
+      }),
+      channelDir
+    );
+
+    const meta = readJson(join(channelDir, "config", "channel", "meta.json"));
+    const content = readJson(
+      join(channelDir, "config", "channel", "content.json")
+    );
+    expect(meta).toMatchObject({
+      channel: { name: "Awesome BGM", short: "ABC-01" },
+    });
+    expect(content).toMatchObject({
+      genre: { context: "RPG maps", primary: "chiptune", style: "8-bit" },
+    });
+  });
+
+  test("should skip matching files and existing gitkeep directories on a second run", async () => {
+    const channelDir = makeTempDir("channel-init-skipped-");
+    await runOk(request(), channelDir);
+
+    const output = await runOk(request(), channelDir);
+
+    expect(output.files.map((action) => action.kind)).toEqual(
+      configFiles.map(() => "skipped")
+    );
+    expect(output.directories.map((action) => action.kind)).toEqual(
+      gitkeepDirs.map(() => "skipped")
+    );
+    expect(output.summary).toContain("  skipped     config/channel/meta.json");
+    expect(output.diff).toBe("");
+  });
+
+  test("should not overwrite a mismatched existing file without force and should report a diff", async () => {
+    const channelDir = makeTempDir("channel-init-diff-");
+    const metaPath = join(channelDir, "config", "channel", "meta.json");
+    mkdirSync(join(channelDir, "config", "channel"), { recursive: true });
+    writeFileSync(metaPath, '{"channel":{"name":"Old","short":"OLD"}}\n');
+
+    const output = await runOk(request({ name: "New" }), channelDir);
+
+    expect(readFileSync(metaPath, "utf-8")).toBe(
+      '{"channel":{"name":"Old","short":"OLD"}}\n'
+    );
+    expect(
+      output.files.find((action) => action.rel.endsWith("meta.json"))
+    ).toMatchObject({
+      kind: "skipped",
+      rel: "config/channel/meta.json",
+    });
+    expect(output.diff).toContain("--- config/channel/meta.json (existing)");
+    expect(output.diff).toContain("+++ config/channel/meta.json (template)");
+    expect(output.diff).toContain("@@ -1 +1,8 @@");
+    expect(output.diff).toContain('name": "New"');
+    expect(output.diff).not.toContain("-+{");
+  });
+
+  test("should overwrite a mismatched existing file with force and suppress diff output", async () => {
+    const channelDir = makeTempDir("channel-init-force-");
+    await runOk(request({ name: "Old Name" }), channelDir);
+
+    const output = await runOk(
+      request({ force: true, name: "New Name" }),
+      channelDir
+    );
+
+    const meta = readJson(join(channelDir, "config", "channel", "meta.json"));
+    expect(meta).toMatchObject({ channel: { name: "New Name" } });
+    expect(
+      output.files.find((action) => action.rel.endsWith("meta.json"))
+    ).toMatchObject({
+      kind: "overwritten",
+      rel: "config/channel/meta.json",
+    });
+    expect(output.diff).toBe("");
+  });
+
+  test("should be loadable by the channel config loader after scaffolding", async () => {
+    const channelDir = makeTempDir("channel-init-loader-");
+    savedChannelDir = process.env.CHANNEL_DIR;
+    process.env.CHANNEL_DIR = channelDir;
+    resetConfig();
+
+    await runOk(request(), channelDir);
+
+    const config = loadConfig();
+    expect(config.identity.meta.channelName).toBe("Demo Channel");
+    expect(config.identity.meta.channelShort).toBe("DEMO");
+    expect(config.integrations.analytics.benchmark.channels).toEqual([]);
+  });
+});
+
+describe("channelInitService — target validation", () => {
+  test("should return a ServiceError when the injected channelDir does not exist", async () => {
+    const missing = join(
+      makeTempDir("channel-init-missing-parent-"),
+      "missing"
+    );
+
+    const result = await channelInitService(request(), { channelDir: missing });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain(missing);
+    }
+  });
+
+  test("should reject blocked scaffold directories before writing files", async () => {
+    const channelDir = makeTempDir("channel-init-blocked-dir-");
+    const docsPath = join(channelDir, "docs");
+    writeFileSync(docsPath, "not a directory\n");
+
+    const result = await channelInitService(request(), { channelDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain(docsPath);
+    }
+    expect(existsSync(join(channelDir, "config", "channel", "meta.json"))).toBe(
+      false
+    );
+    expect(existsSync(join(channelDir, "auth", ".gitkeep"))).toBe(false);
+    expect(readFileSync(docsPath, "utf-8")).toBe("not a directory\n");
+  });
+});


### PR DESCRIPTION
## Summary

> ADR-0002/0003/0004/0007 準拠 / Parent #748 / takt base: `feat/ts-rewrite`

## Parent
#748

## What to build
core service `packages/core/src/channel-init/{schema,service}.ts`。Python の **parse→plan→apply 3 段分離**を keep（`_plan_actions` 純粋関数＋`_apply` のみ I/O）。7 ファイル（meta/content/youtube/analytics/playlists/workflow/audio.json）テンプレ render を 1 箇所集約、`indent=2`＋末尾改行。正準ディレクトリへ `.gitkeep` 冪等配置。registry `channel.init`（`deps: ["channelDir"]`）。CLI `tayk channel-init`。

## Acceptance criteria
- [ ] flags 全 keep: `--target` / `--short`(必須) / `--name`(必須) / `--genre`(既定 TBD) / `--style`(既定 TBD) / `--context`(既定 TBD) / `--force`
- [ ] 隠れ契約 **plan→apply 3-phase** = **keep**（plan は read のみ・副作用なし。test で担保）
- [ ] 隠れ契約 **`--force` 意味論** = **keep**（一致→skipped、不一致＆force なし→skipped＋**unified diff を stderr**、不一致＆force→overwritten、未存在→created）
- [ ] 隠れ契約 **unified diff 表示** = **keep**（`fromfile=…(existing)` / `tofile=…(template)`）
- [ ] 隠れ契約 **target 解決優先** = **keep**（`--target`→`CHANNEL_DIR`→CWD。明示指定で非存在は `ServiceError`）
- [ ] 隠れ契約 **`.gitkeep` 冪等** / summary stdout 形式 = **keep**
- [ ] core service（zod、`Result`/`toServiceError`）、registry 登録、CLI thin（per-CLI bin なし）
- [ ] bun:test: ①plan 副作用なし ②created/skipped/overwritten 3 分岐 ③force で diff 出さず overwrite ④diff ラベル ⑤.gitkeep 冪等 ⑥CLI smoke
- [ ] CHANGELOG [Unreleased]

## Blocked by
- #827（config 4-bucket）

## 出典
`cli/channel_init.py`, 手本 `packages/core/src/suno-prompts/service.ts`

## Execution Report

Workflow `default` completed successfully.

Closes #1072