### PR TITLE
[#1077] issue-1077-distrokid-1-3-distr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(ts-rewrite/core)`: `distrokid.migrate` service と `tayk distrokid-migrate` を追加し、旧 flat DistroKid profile を新 nested schema（songwriter / ai_disclosure / credits）へ移行できるようにした（#1077）。既定 dry-run、`--apply`、`--backup` / `--no-backup`、`--target` / `CHANNEL_DIR` / CWD 祖先探索を TS 側で実装し、`config/distrokid.ts` も新 schema（required は `language` / `main_genre` のみ）へ更新した。
 - `feat(ts-rewrite/core)`: Traffic source 内訳（search / browse / external / suggested 等）を期間集計する `collectTrafficSourceService` を ADR-0003 準拠で実装した（#832）。`packages/core/src/analytics/traffic-source/`（schema / service / index）を新設し、Python `utils/traffic_source_analytics.py` Mixin を翻訳せず TS で新規記述。あわせて analytics 共通のエラー分類を `analytics/query-error.ts`（`toAnalyticsQueryError` / `shouldRetryAnalyticsQuery`）へ集約し、video / channel / video-daily / traffic-source の各 service から参照する。quota（429）は `withRetry` で retry せず `domain: "quota"` の Result で返す
 - `feat(ts-rewrite/core)`: resumable upload + thumbnail 圧縮 + metadata update を 1 atomic service に集約した `uploadVideoService` を ADR-0003 準拠で実装した（#837）
 - `feat(ts-rewrite/core)`: Per-video metrics（views / likes / comments / shares 等 8 指標）を YouTube Analytics API から収集する analytics video service を ADR-0003 準拠で実装した（#829）

--- a/packages/cli/bin/tayk.ts
+++ b/packages/cli/bin/tayk.ts
@@ -1,15 +1,33 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 
+import {
+  distrokidMigrateCommandArgs,
+  distrokidMigrateCommandMeta,
+} from "../src/commands/distrokid-migrate/definition.ts";
 import { generateSunoCommand } from "../src/commands/generate-suno/cli.ts";
 import { skillsCommand } from "../src/commands/skills/cli.ts";
+
+const distrokidMigrateCommand = defineCommand({
+  args: distrokidMigrateCommandArgs,
+  meta: distrokidMigrateCommandMeta,
+  async run(context) {
+    const { distrokidMigrateCommand: command } =
+      await import("../src/commands/distrokid-migrate/cli.ts");
+    return command.run?.(context);
+  },
+});
 
 const main = defineCommand({
   meta: {
     description: "youtube-channels-automation CLI (TS rewrite)",
     name: "tayk",
   },
-  subCommands: { "generate-suno": generateSunoCommand, skills: skillsCommand },
+  subCommands: {
+    "distrokid-migrate": distrokidMigrateCommand,
+    "generate-suno": generateSunoCommand,
+    skills: skillsCommand,
+  },
 });
 
 await runMain(main);

--- a/packages/cli/src/commands/distrokid-migrate/cli.ts
+++ b/packages/cli/src/commands/distrokid-migrate/cli.ts
@@ -1,0 +1,45 @@
+import { err, toServiceError } from "@youtube-automation/core";
+import type { DistrokidMigrateOutput } from "@youtube-automation/core/distrokid-migrate";
+import { REGISTRY } from "@youtube-automation/core/registry";
+import { defineCommand } from "citty";
+
+import { resolveDeps } from "../../../lib/resolve-deps.ts";
+import { emitResult } from "../../../lib/run-command.ts";
+import {
+  distrokidMigrateCommandArgs,
+  distrokidMigrateCommandMeta,
+} from "./definition.ts";
+
+const distrokidMigrateEntry = REGISTRY["distrokid.migrate"];
+
+const renderText = (output: DistrokidMigrateOutput): string => {
+  const lines = [
+    output.applied ? "[apply]" : "[dry-run]",
+    `path: ${output.path}`,
+  ];
+  if (output.backupPath !== null) {
+    lines.push(`backup: ${output.backupPath}`);
+  }
+  return lines.join("\n");
+};
+
+export const distrokidMigrateCommand = defineCommand({
+  args: distrokidMigrateCommandArgs,
+  meta: distrokidMigrateCommandMeta,
+  async run({ args }) {
+    const result = await (async () => {
+      try {
+        const input = distrokidMigrateEntry.inputSchema.parse({
+          apply: args.apply,
+          backup: args.backup,
+          target: args.target,
+        });
+        const deps = await resolveDeps(distrokidMigrateEntry.deps);
+        return await distrokidMigrateEntry.run(input, deps);
+      } catch (error) {
+        return err(toServiceError(error));
+      }
+    })();
+    emitResult(result, { json: args.json, renderText });
+  },
+});

--- a/packages/cli/src/commands/distrokid-migrate/definition.ts
+++ b/packages/cli/src/commands/distrokid-migrate/definition.ts
@@ -1,0 +1,26 @@
+export const distrokidMigrateCommandArgs = {
+  apply: {
+    default: false,
+    description: "distrokid.json を更新する",
+    type: "boolean",
+  },
+  backup: {
+    default: true,
+    description: "--apply 時に distrokid.json.bak を作成する",
+    type: "boolean",
+  },
+  json: {
+    default: false,
+    description: "JSON で出力する",
+    type: "boolean",
+  },
+  target: {
+    description: "対象チャンネルディレクトリ",
+    type: "string",
+  },
+} as const;
+
+export const distrokidMigrateCommandMeta = {
+  description: "DistroKid profile config を新 schema へ移行する",
+  name: "distrokid-migrate",
+} as const;

--- a/packages/cli/test/distrokid-migrate.test.ts
+++ b/packages/cli/test/distrokid-migrate.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+const makeTarget = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "cli-distrokid-migrate-"));
+  tmpDirs.push(dir);
+  mkdirSync(join(dir, "config", "channel"), { recursive: true });
+  return dir;
+};
+
+const distrokidPath = (target: string): string =>
+  join(target, "config", "channel", "distrokid.json");
+
+const writeOldDistrokid = (target: string): void => {
+  writeFileSync(
+    distrokidPath(target),
+    `${JSON.stringify(
+      {
+        distrokid: {
+          enabled: true,
+          profile: {
+            apple_music_credit: "Jane Doe",
+            artist_name: "City Nights",
+            language: "ja",
+            main_genre: "Electronic",
+            songwriter: "Jane Doe",
+            track_type: "Instrumental",
+          },
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+};
+
+describe("tayk distrokid-migrate", () => {
+  test("runs as a dry-run subcommand and leaves distrokid.json unchanged", () => {
+    const target = makeTarget();
+    writeOldDistrokid(target);
+    const before = readFileSync(distrokidPath(target), "utf-8");
+
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "packages/cli/bin/tayk.ts",
+        "distrokid-migrate",
+        "--target",
+        target,
+      ],
+      { cwd: repoRoot }
+    );
+
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("[dry-run]");
+    expect(proc.stderr.toString()).toBe("");
+    expect(readFileSync(distrokidPath(target), "utf-8")).toBe(before);
+  }, 30_000);
+
+  test("applies migration without a backup when --no-backup is passed", () => {
+    const target = makeTarget();
+    writeOldDistrokid(target);
+
+    const proc = Bun.spawnSync(
+      [
+        "bun",
+        "packages/cli/bin/tayk.ts",
+        "distrokid-migrate",
+        "--apply",
+        "--no-backup",
+        "--target",
+        target,
+      ],
+      { cwd: repoRoot }
+    );
+
+    const {
+      distrokid: { profile },
+    } = JSON.parse(readFileSync(distrokidPath(target), "utf-8")) as {
+      distrokid: { profile: { songwriter?: unknown } };
+    };
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("[apply]");
+    expect(proc.stdout.toString()).not.toContain("backup:");
+    expect(proc.stderr.toString()).toBe("");
+    expect(profile.songwriter).toEqual({ first: "Jane", last: "Doe" });
+    expect(existsSync(`${distrokidPath(target)}.bak`)).toBe(false);
+  }, 30_000);
+});

--- a/packages/cli/test/yt-skills.test.ts
+++ b/packages/cli/test/yt-skills.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -134,6 +134,46 @@ describe("tayk skills list — error path (run-command helper)", () => {
 });
 
 describe("tayk dispatcher — citty usage surface", () => {
+  test("does not put distrokid-migrate on the skills startup path", () => {
+    const source = readFileSync(
+      join(repoRoot, "packages/cli/bin/tayk.ts"),
+      "utf-8"
+    );
+
+    expect(source).not.toMatch(
+      /^import .*commands\/distrokid-migrate\/cli\.ts/mu
+    );
+    expect(source).toMatch(
+      /await import\(\s*"[^"]*commands\/distrokid-migrate\/cli\.ts"\s*\)/u
+    );
+  });
+
+  test("shares distrokid-migrate CLI surface through the lightweight definition", () => {
+    const taykSource = readFileSync(
+      join(repoRoot, "packages/cli/bin/tayk.ts"),
+      "utf-8"
+    );
+    const commandSource = readFileSync(
+      join(repoRoot, "packages/cli/src/commands/distrokid-migrate/cli.ts"),
+      "utf-8"
+    );
+    const definitionSource = readFileSync(
+      join(
+        repoRoot,
+        "packages/cli/src/commands/distrokid-migrate/definition.ts"
+      ),
+      "utf-8"
+    );
+
+    expect(taykSource).toContain(
+      "../src/commands/distrokid-migrate/definition.ts"
+    );
+    expect(commandSource).toContain("./definition.ts");
+    expect(taykSource).not.toMatch(/\bapply:\s*\{/u);
+    expect(commandSource).not.toMatch(/\bapply:\s*\{/u);
+    expect(definitionSource).not.toContain("@youtube-automation/core");
+  });
+
   test("`tayk --help` exits 0 and lists the skills subcommand", () => {
     const proc = runTayk("--help");
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "./analytics/video": "./src/analytics/video/index.ts",
     "./analytics/video-daily": "./src/analytics/video-daily/index.ts",
     "./config": "./src/config/index.ts",
+    "./distrokid-migrate": "./src/distrokid-migrate/index.ts",
     "./image": "./src/image/index.ts",
     "./metadata": "./src/metadata.ts",
     "./oauth/client": "./src/oauth/client.ts",

--- a/packages/core/src/config/distrokid.ts
+++ b/packages/core/src/config/distrokid.ts
@@ -1,22 +1,76 @@
-// DistroKid 配信プロファイル設定（merged の `distrokid`・optional/opt-in）。
-//
-// 形状検証 + `enabled=true` 時の条件付き必須チェックは superRefine で行い、
-// 既存テストが期待する `config:` prefix のメッセージ（`distrokid.profile は object ...`
-// / 欠落フィールド名）を保持する。
-
 import { z } from "zod";
 
 import { isPlainObject } from "./internal.ts";
 
-// distrokid.enabled === true のとき profile に必須となるフィールド（条件付き必須）。
-const REQUIRED_PROFILE_FIELDS = [
-  "artist_name",
-  "language",
-  "main_genre",
-  "songwriter",
-  "apple_music_credit",
-  "track_type",
-] as const;
+const REQUIRED_PROFILE_FIELDS = ["language", "main_genre"] as const;
+
+const AI_DISCLOSURE_DEFAULTS = {
+  apply_to_all: true,
+  artist_persona: true,
+  enabled: true,
+  lyrics: true,
+  music: true,
+  partial_audio_type: null,
+  recording_scope: "full",
+} as const;
+
+const CREDIT_DEFAULTS = {
+  performer_role: "Synthesizer",
+  producer_role: "Producer",
+} as const;
+
+const Songwriter = z
+  .object({
+    first: z.string().optional(),
+    last: z.string().optional(),
+    middle: z.string().optional(),
+  })
+  .strict();
+
+const AiDisclosure = z
+  .object({
+    apply_to_all: z.boolean().default(AI_DISCLOSURE_DEFAULTS.apply_to_all),
+    artist_persona: z.boolean().default(AI_DISCLOSURE_DEFAULTS.artist_persona),
+    enabled: z.boolean().default(AI_DISCLOSURE_DEFAULTS.enabled),
+    lyrics: z.boolean().default(AI_DISCLOSURE_DEFAULTS.lyrics),
+    music: z.boolean().default(AI_DISCLOSURE_DEFAULTS.music),
+    partial_audio_type: z
+      .enum(["vocals", "instruments"])
+      .nullable()
+      .default(AI_DISCLOSURE_DEFAULTS.partial_audio_type),
+    recording_scope: z
+      .enum(["full", "partial"])
+      .default(AI_DISCLOSURE_DEFAULTS.recording_scope),
+  })
+  .strict()
+  .superRefine((ai, ctx) => {
+    if (ai.partial_audio_type !== null && ai.recording_scope !== "partial") {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "distrokid.profile.ai_disclosure.partial_audio_type requires recording_scope=partial",
+        path: ["recording_scope"],
+      });
+    }
+  });
+
+const Credits = z
+  .object({
+    performer_role: z.string().default(CREDIT_DEFAULTS.performer_role),
+    producer_role: z.string().default(CREDIT_DEFAULTS.producer_role),
+  })
+  .strict();
+
+const Profile = z
+  .object({
+    ai_disclosure: AiDisclosure.prefault({}),
+    credits: Credits.prefault({}),
+    language: z.string().default(""),
+    main_genre: z.string().default(""),
+    songwriter: Songwriter.nullable().default(null),
+    sub_genre: z.string().optional(),
+  })
+  .strict();
 
 const DistrokidInner = z
   .object({
@@ -24,7 +78,8 @@ const DistrokidInner = z
     profile: z.unknown().prefault({}),
   })
   .superRefine((dk, ctx) => {
-    if (!isPlainObject(dk.profile)) {
+    const { profile } = dk;
+    if (!isPlainObject(profile)) {
       ctx.addIssue({
         code: "custom",
         message: "distrokid.profile は object でなければなりません",
@@ -32,10 +87,11 @@ const DistrokidInner = z
       });
       return;
     }
-    const { profile } = dk;
-    // enabled=true のときのみ profile の必須 6 フィールドを条件付き検証（Fail Fast）。
     if (dk.enabled) {
-      const missing = REQUIRED_PROFILE_FIELDS.filter((f) => !profile[f]);
+      const missing = REQUIRED_PROFILE_FIELDS.filter((field) => {
+        const value = profile[field];
+        return typeof value !== "string" || value.length === 0;
+      });
       if (missing.length > 0) {
         ctx.addIssue({
           code: "custom",
@@ -46,26 +102,32 @@ const DistrokidInner = z
     }
   });
 
-const str = (value: unknown): string =>
-  typeof value === "string" ? value : "";
-
-/** `distrokid` セクション（optional・opt-in）。 */
 export const Distrokid = z
   .object({
     distrokid: DistrokidInner.prefault({}),
   })
   .transform((o) => {
-    // superRefine の isPlainObject 検証通過済みのため、transform 到達時は常に plain object。
-    const profile = o.distrokid.profile as Record<string, unknown>;
+    const profile = Profile.parse(o.distrokid.profile);
     return {
       enabled: o.distrokid.enabled,
       profile: {
-        appleMusicCredit: str(profile.apple_music_credit),
-        artistName: str(profile.artist_name),
-        language: str(profile.language),
-        mainGenre: str(profile.main_genre),
-        songwriter: str(profile.songwriter),
-        trackType: str(profile.track_type),
+        aiDisclosure: {
+          applyToAll: profile.ai_disclosure.apply_to_all,
+          artistPersona: profile.ai_disclosure.artist_persona,
+          enabled: profile.ai_disclosure.enabled,
+          lyrics: profile.ai_disclosure.lyrics,
+          music: profile.ai_disclosure.music,
+          partialAudioType: profile.ai_disclosure.partial_audio_type,
+          recordingScope: profile.ai_disclosure.recording_scope,
+        },
+        credits: {
+          performerRole: profile.credits.performer_role,
+          producerRole: profile.credits.producer_role,
+        },
+        language: profile.language,
+        mainGenre: profile.main_genre,
+        songwriter: profile.songwriter,
+        subGenre: profile.sub_genre,
       },
     };
   });

--- a/packages/core/src/distrokid-migrate/index.ts
+++ b/packages/core/src/distrokid-migrate/index.ts
@@ -1,0 +1,9 @@
+export {
+  DistrokidMigrateInputSchema,
+  DistrokidMigrateOutputSchema,
+} from "./schema.ts";
+export type {
+  DistrokidMigrateInput,
+  DistrokidMigrateOutput,
+} from "./schema.ts";
+export { migrateDistrokidService } from "./service.ts";

--- a/packages/core/src/distrokid-migrate/schema.ts
+++ b/packages/core/src/distrokid-migrate/schema.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+import { snakeToCamel } from "../../internal/case.ts";
+
+export const CONFIG_DIRNAME = "config";
+export const CHANNEL_DIRNAME = "channel";
+export const DISTROKID_FILENAME = "distrokid.json";
+export const DISTROKID_BACKUP_FILENAME = "distrokid.json.bak";
+
+const DistrokidMigrateSnakeInputSchema = z
+  .object({
+    apply: z.boolean(),
+    backup: z.boolean(),
+    target: z.string().optional(),
+  })
+  .strict();
+
+const DistrokidMigrateCamelInputSchema = z
+  .object({
+    apply: z.boolean(),
+    backup: z.boolean(),
+    target: z.string().optional(),
+  })
+  .strict();
+
+export const DistrokidMigrateInputSchema = z
+  .union([DistrokidMigrateSnakeInputSchema, DistrokidMigrateCamelInputSchema])
+  .transform((input): { apply: boolean; backup: boolean; target?: string } =>
+    snakeToCamel(input)
+  );
+
+export const DistrokidMigrateOutputSchema = z
+  .object({
+    applied: z.boolean(),
+    backupPath: z.string().nullable(),
+    path: z.string(),
+    target: z.string(),
+  })
+  .strict();
+
+export type DistrokidMigrateInput = z.infer<typeof DistrokidMigrateInputSchema>;
+export type DistrokidMigrateOutput = z.infer<
+  typeof DistrokidMigrateOutputSchema
+>;

--- a/packages/core/src/distrokid-migrate/service.ts
+++ b/packages/core/src/distrokid-migrate/service.ts
@@ -1,0 +1,253 @@
+import { existsSync } from "node:fs";
+import { copyFile, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { toServiceError } from "../errors.ts";
+import type { ServiceError } from "../errors.ts";
+import { err, ok } from "../result.ts";
+import type { Result } from "../result.ts";
+import {
+  CHANNEL_DIRNAME,
+  CONFIG_DIRNAME,
+  DISTROKID_BACKUP_FILENAME,
+  DISTROKID_FILENAME,
+  DistrokidMigrateInputSchema,
+  DistrokidMigrateOutputSchema,
+} from "./schema.ts";
+import type {
+  DistrokidMigrateInput,
+  DistrokidMigrateOutput,
+} from "./schema.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const PROFILE_KEYS = ["language", "main_genre", "sub_genre"] as const;
+
+const SONGWRITER_KEYS = ["first", "last", "middle"] as const;
+
+const AI_DISCLOSURE_KEYS = [
+  "apply_to_all",
+  "artist_persona",
+  "enabled",
+  "lyrics",
+  "music",
+  "partial_audio_type",
+  "recording_scope",
+] as const;
+
+const CREDIT_KEYS = ["performer_role", "producer_role"] as const;
+
+const DEFAULT_AI_DISCLOSURE: JsonRecord = {
+  apply_to_all: true,
+  artist_persona: true,
+  enabled: true,
+  lyrics: true,
+  music: true,
+  partial_audio_type: null,
+  recording_scope: "full",
+};
+
+const isPlainObject = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const distrokidPath = (target: string): string =>
+  join(target, CONFIG_DIRNAME, CHANNEL_DIRNAME, DISTROKID_FILENAME);
+
+const backupPath = (target: string): string =>
+  join(target, CONFIG_DIRNAME, CHANNEL_DIRNAME, DISTROKID_BACKUP_FILENAME);
+
+const hasChannelConfigDir = (path: string): boolean =>
+  existsSync(join(path, CONFIG_DIRNAME, CHANNEL_DIRNAME));
+
+const resolveAncestorTarget = (start: string): string => {
+  let current = resolve(start);
+  for (;;) {
+    if (hasChannelConfigDir(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  throw new Error(
+    "config: CHANNEL_DIR 環境変数を設定するか、config/channel/ を持つディレクトリ配下で実行してください"
+  );
+};
+
+const resolveTarget = (target: string | undefined): string => {
+  if (target !== undefined) {
+    return resolve(target);
+  }
+  if (process.env.CHANNEL_DIR) {
+    return resolve(process.env.CHANNEL_DIR);
+  }
+  return resolveAncestorTarget(process.cwd());
+};
+
+const readJsonObject = async (path: string): Promise<JsonRecord> => {
+  if (!existsSync(path)) {
+    throw new Error(`config: ${DISTROKID_FILENAME} が見つかりません: ${path}`);
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(await readFile(path, "utf-8"));
+  } catch (error) {
+    throw new Error(`config: ${DISTROKID_FILENAME} の JSON パース失敗`, {
+      cause: error,
+    });
+  }
+  if (!isPlainObject(data)) {
+    throw new Error(
+      `config: ${DISTROKID_FILENAME} は object でなければなりません`
+    );
+  }
+  return data;
+};
+
+const profileFrom = (data: JsonRecord): JsonRecord => {
+  if (!isPlainObject(data.distrokid)) {
+    throw new Error("config: distrokid は object でなければなりません");
+  }
+  if (data.distrokid.profile === undefined) {
+    return {};
+  }
+  if (!isPlainObject(data.distrokid.profile)) {
+    throw new Error("config: distrokid.profile は object でなければなりません");
+  }
+  return data.distrokid.profile;
+};
+
+const pickKnownKeys = (
+  source: JsonRecord,
+  keys: readonly string[]
+): JsonRecord => {
+  const next: JsonRecord = {};
+  for (const key of keys) {
+    if (key in source) {
+      next[key] = source[key];
+    }
+  }
+  return next;
+};
+
+const normalizeSongwriter = (value: unknown): unknown => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (isPlainObject(value)) {
+    return pickKnownKeys(value, SONGWRITER_KEYS);
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(
+      "validation: distrokid.profile.songwriter must be string or object"
+    );
+  }
+  const parts = value
+    .trim()
+    .split(/\s+/u)
+    .filter((part) => part.length > 0);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  if (parts.length === 1) {
+    return { first: parts[0], last: "" };
+  }
+  const [first, ...rest] = parts;
+  const last = rest.at(-1);
+  if (last === undefined) {
+    throw new Error(
+      "validation: distrokid.profile.songwriter last name is required"
+    );
+  }
+  const middle = rest.slice(0, -1).join(" ");
+  return middle.length > 0 ? { first, last, middle } : { first, last };
+};
+
+const normalizeAiDisclosure = (value: unknown): JsonRecord => {
+  if (value === undefined || !isPlainObject(value)) {
+    return DEFAULT_AI_DISCLOSURE;
+  }
+  const { composition, ...withoutComposition } = value;
+  const music =
+    withoutComposition.music === undefined
+      ? composition
+      : withoutComposition.music;
+  const withMusic =
+    music === undefined ? withoutComposition : { ...withoutComposition, music };
+  const recordingScope =
+    withMusic.recording_scope === undefined &&
+    withMusic.partial_audio_type !== undefined &&
+    withMusic.partial_audio_type !== null
+      ? "partial"
+      : withMusic.recording_scope;
+  const normalized =
+    recordingScope === undefined
+      ? withMusic
+      : { ...withMusic, recording_scope: recordingScope };
+
+  return {
+    ...DEFAULT_AI_DISCLOSURE,
+    ...pickKnownKeys(normalized, AI_DISCLOSURE_KEYS),
+  };
+};
+
+const migrateProfile = (profile: JsonRecord): JsonRecord => {
+  const next = pickKnownKeys(profile, PROFILE_KEYS);
+  if (isPlainObject(profile.credits)) {
+    next.credits = pickKnownKeys(profile.credits, CREDIT_KEYS);
+  }
+
+  const songwriter = normalizeSongwriter(profile.songwriter);
+  if (songwriter === undefined) {
+    Reflect.deleteProperty(next, "songwriter");
+  } else {
+    next.songwriter = songwriter;
+  }
+  next.ai_disclosure = normalizeAiDisclosure(profile.ai_disclosure);
+  return next;
+};
+
+const migrateDocument = (data: JsonRecord): JsonRecord => {
+  const distrokid = data.distrokid as JsonRecord;
+  const profile = profileFrom(data);
+  return {
+    ...data,
+    distrokid: {
+      ...distrokid,
+      profile: migrateProfile(profile),
+    },
+  };
+};
+
+export const migrateDistrokidService = async (
+  input: DistrokidMigrateInput
+): Promise<Result<DistrokidMigrateOutput, ServiceError>> => {
+  try {
+    const request = DistrokidMigrateInputSchema.parse(input);
+    const target = resolveTarget(request.target);
+    const path = distrokidPath(target);
+    const backup = backupPath(target);
+    const source = await readJsonObject(path);
+    const migrated = migrateDocument(source);
+
+    if (request.apply) {
+      if (request.backup) {
+        await copyFile(path, backup);
+      }
+      await writeFile(path, `${JSON.stringify(migrated, null, 2)}\n`);
+    }
+
+    return ok(
+      DistrokidMigrateOutputSchema.parse({
+        applied: request.apply,
+        backupPath: request.apply && request.backup ? backup : null,
+        path,
+        target,
+      })
+    );
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+};

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,6 +1,11 @@
 import type { z } from "zod";
 
 import type { ChannelConfig } from "./config/index.ts";
+import {
+  DistrokidMigrateInputSchema,
+  DistrokidMigrateOutputSchema,
+  migrateDistrokidService,
+} from "./distrokid-migrate/index.ts";
 import type { ServiceError } from "./errors.ts";
 import type { YouTubeAnalyticsClient, YouTubeClient } from "./oauth/client.ts";
 import type { Result } from "./result.ts";
@@ -67,6 +72,13 @@ const defineRegistryEntry = <
 ): RegistryEntry<I, O, D> => entry;
 
 export const REGISTRY = {
+  "distrokid.migrate": defineRegistryEntry({
+    deps: [],
+    description: "DistroKid profile config を新 schema へ移行する",
+    inputSchema: DistrokidMigrateInputSchema,
+    outputSchema: DistrokidMigrateOutputSchema,
+    run: migrateDistrokidService,
+  }),
   "skills.list": defineRegistryEntry({
     deps: [],
     description: "同梱スキル一覧を列挙する",

--- a/packages/core/test/config-sections.test.ts
+++ b/packages/core/test/config-sections.test.ts
@@ -458,86 +458,174 @@ describe("pinnedComment", () => {
 
 // --- distrokid (#698) ------------------------------------------------------
 
-const fullDistrokidProfile = (): Record<string, string> => ({
-  apple_music_credit: "Jane Doe",
-  artist_name: "City Nights",
+const fullDistrokidProfile = (): Record<string, unknown> => ({
+  ai_disclosure: {
+    apply_to_all: false,
+    artist_persona: false,
+    enabled: true,
+    lyrics: false,
+    music: true,
+    partial_audio_type: "vocals",
+    recording_scope: "partial",
+  },
+  credits: {
+    performer_role: "Piano",
+    producer_role: "Executive Producer",
+  },
   language: "English",
   main_genre: "Electronic",
-  songwriter: "Jane Doe",
-  track_type: "Instrumental",
+  songwriter: { first: "Jane", last: "Doe", middle: "Q" },
+  sub_genre: "Downtempo",
 });
 
 describe("distrokid", () => {
   test("defaults to disabled with empty profile when absent", () => {
-    // Given no distrokid.json
     const config = load(minimalSections());
 
-    // Then the opt-in section is disabled with blank profile fields
     expect(config.integrations.distrokid.enabled).toBe(false);
-    expect(config.integrations.distrokid.profile.artistName).toBe("");
-    expect(config.integrations.distrokid.profile.trackType).toBe("");
+    expect(config.integrations.distrokid.profile.language).toBe("");
+    expect(config.integrations.distrokid.profile.mainGenre).toBe("");
+    expect(config.integrations.distrokid.profile.songwriter).toBeNull();
+    expect(config.integrations.distrokid.profile.aiDisclosure).toEqual({
+      applyToAll: true,
+      artistPersona: true,
+      enabled: true,
+      lyrics: true,
+      music: true,
+      partialAudioType: null,
+      recordingScope: "full",
+    });
+    expect(config.integrations.distrokid.profile.credits).toEqual({
+      performerRole: "Synthesizer",
+      producerRole: "Producer",
+    });
   });
 
-  test("loads an enabled profile through to camelCase fields", () => {
-    // Given enabled distrokid with a complete profile
+  test("loads an enabled profile through to the new camelCase fields", () => {
     const sections = minimalSections();
     sections["distrokid.json"] = {
       distrokid: { enabled: true, profile: fullDistrokidProfile() },
     };
 
-    // Then all six profile fields are mapped
     const dk = load(sections).integrations.distrokid;
     expect(dk.enabled).toBe(true);
-    expect(dk.profile.artistName).toBe("City Nights");
     expect(dk.profile.language).toBe("English");
     expect(dk.profile.mainGenre).toBe("Electronic");
-    expect(dk.profile.songwriter).toBe("Jane Doe");
-    expect(dk.profile.appleMusicCredit).toBe("Jane Doe");
-    expect(dk.profile.trackType).toBe("Instrumental");
+    expect(dk.profile.subGenre).toBe("Downtempo");
+    expect(dk.profile.songwriter).toEqual({
+      first: "Jane",
+      last: "Doe",
+      middle: "Q",
+    });
+    expect(dk.profile.aiDisclosure).toEqual({
+      applyToAll: false,
+      artistPersona: false,
+      enabled: true,
+      lyrics: false,
+      music: true,
+      partialAudioType: "vocals",
+      recordingScope: "partial",
+    });
+    expect(dk.profile.credits).toEqual({
+      performerRole: "Piano",
+      producerRole: "Executive Producer",
+    });
   });
 
-  test("rejects enabled=true with a missing profile field", () => {
-    // Given enabled distrokid missing songwriter (conditional-required)
+  test("accepts enabled=true with only language and main_genre", () => {
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: {
+        enabled: true,
+        profile: { language: "English", main_genre: "Electronic" },
+      },
+    };
+
+    const dk = load(sections).integrations.distrokid;
+    expect(dk.enabled).toBe(true);
+    expect(dk.profile.language).toBe("English");
+    expect(dk.profile.mainGenre).toBe("Electronic");
+    expect(dk.profile.songwriter).toBeNull();
+    expect(dk.profile.aiDisclosure.recordingScope).toBe("full");
+    expect(dk.profile.credits.performerRole).toBe("Synthesizer");
+  });
+
+  test("rejects enabled=true with a missing new required profile field", () => {
     const sections = minimalSections();
     const profile = fullDistrokidProfile();
-    Reflect.deleteProperty(profile, "songwriter");
+    Reflect.deleteProperty(profile, "main_genre");
     sections["distrokid.json"] = { distrokid: { enabled: true, profile } };
 
-    // When/Then the conditional validation names the missing field
-    expect(() => load(sections)).toThrow(/songwriter/u);
+    let message = "";
+    try {
+      load(sections);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("main_genre");
+    expect(message).not.toContain("songwriter");
   });
 
   test("skips profile validation when disabled", () => {
-    // Given disabled distrokid with an incomplete profile
     const sections = minimalSections();
     sections["distrokid.json"] = {
-      distrokid: { enabled: false, profile: { artist_name: "x" } },
+      distrokid: { enabled: false, profile: { language: "English" } },
     };
 
-    // Then it loads without validating the profile
     const dk = load(sections).integrations.distrokid;
     expect(dk.enabled).toBe(false);
-    expect(dk.profile.artistName).toBe("x");
+    expect(dk.profile.language).toBe("English");
+    expect(dk.profile.mainGenre).toBe("");
+  });
+
+  test("rejects partial_audio_type unless recording_scope is partial", () => {
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: {
+        enabled: true,
+        profile: {
+          ai_disclosure: { partial_audio_type: "vocals" },
+          language: "English",
+          main_genre: "Electronic",
+        },
+      },
+    };
+
+    expect(() => load(sections)).toThrow(/recording_scope/u);
+  });
+
+  test("rejects an unknown partial_audio_type", () => {
+    const sections = minimalSections();
+    sections["distrokid.json"] = {
+      distrokid: {
+        enabled: true,
+        profile: {
+          ai_disclosure: {
+            partial_audio_type: "drums",
+            recording_scope: "partial",
+          },
+          language: "English",
+          main_genre: "Electronic",
+        },
+      },
+    };
+
+    expect(() => load(sections)).toThrow(/partial_audio_type/u);
   });
 
   test("rejects a non-object distrokid section", () => {
-    // Given distrokid declared as an array
     const sections = minimalSections();
     sections["distrokid.json"] = { distrokid: ["not", "an", "object"] };
 
-    // When/Then the section guard fires
     expect(() => load(sections)).toThrow(/^config:/u);
   });
 
   test("rejects a non-object distrokid.profile via the shared isPlainObject guard", () => {
-    // Given profile declared as an array (regression guard for the superRefine
-    // boundary check that delegates to internal.isPlainObject)
     const sections = minimalSections();
     sections["distrokid.json"] = {
       distrokid: { enabled: false, profile: ["not", "an", "object"] },
     };
 
-    // When/Then the profile guard fires with the same contextual message
     expect(() => load(sections)).toThrow(
       "distrokid.profile は object でなければなりません"
     );

--- a/packages/core/test/distrokid-migrate-fixtures.ts
+++ b/packages/core/test/distrokid-migrate-fixtures.ts
@@ -1,0 +1,67 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type JsonRecord = Record<string, unknown>;
+
+const tmpDirs: string[] = [];
+
+export const cleanupDistrokidTargets = (): void => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+};
+
+export const makeDistrokidTarget = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "distrokid-migrate-"));
+  tmpDirs.push(dir);
+  mkdirSync(join(dir, "config", "channel"), { recursive: true });
+  return dir;
+};
+
+export const distrokidPath = (target: string): string =>
+  join(target, "config", "channel", "distrokid.json");
+
+export const backupPath = (target: string): string =>
+  join(target, "config", "channel", "distrokid.json.bak");
+
+export const oldDistrokid = (
+  overrides: JsonRecord = {},
+  profileOverrides: JsonRecord = {}
+): JsonRecord => ({
+  distrokid: {
+    enabled: true,
+    profile: {
+      apple_music_credit: "Jane Doe",
+      artist_name: "City Nights",
+      language: "ja",
+      main_genre: "Electronic",
+      songwriter: "Jane Doe",
+      track_type: "Instrumental",
+      ...profileOverrides,
+    },
+    ...overrides,
+  },
+});
+
+export const writeDistrokid = (target: string, data: unknown): void => {
+  writeFileSync(distrokidPath(target), `${JSON.stringify(data, null, 2)}\n`);
+};
+
+export const readDistrokidText = (target: string): string =>
+  readFileSync(distrokidPath(target), "utf-8");
+
+export const readDistrokid = (target: string): JsonRecord =>
+  JSON.parse(readDistrokidText(target)) as JsonRecord;
+
+export const readProfile = (target: string): JsonRecord =>
+  (readDistrokid(target).distrokid as JsonRecord).profile as JsonRecord;

--- a/packages/core/test/distrokid-migrate-io.test.ts
+++ b/packages/core/test/distrokid-migrate-io.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { migrateDistrokidService } from "@youtube-automation/core/distrokid-migrate";
+import { REGISTRY } from "@youtube-automation/core/registry";
+
+import {
+  backupPath,
+  cleanupDistrokidTargets,
+  distrokidPath,
+  makeDistrokidTarget,
+  oldDistrokid,
+  readDistrokidText,
+  readProfile,
+  writeDistrokid,
+} from "./distrokid-migrate-fixtures.ts";
+
+let savedChannelDir: string | undefined;
+let savedCwd: string;
+
+beforeEach(() => {
+  savedChannelDir = process.env.CHANNEL_DIR;
+  savedCwd = process.cwd();
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+});
+
+afterEach(() => {
+  process.chdir(savedCwd);
+  if (savedChannelDir === undefined) {
+    Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  } else {
+    process.env.CHANNEL_DIR = savedChannelDir;
+  }
+  cleanupDistrokidTargets();
+});
+
+const expectOk = async (
+  input: Parameters<typeof migrateDistrokidService>[0]
+): Promise<void> => {
+  const result = await migrateDistrokidService(input);
+  expect(result.ok).toBe(true);
+};
+
+describe("distrokid migrate service — filesystem behavior", () => {
+  test("dry-run keeps the source file unchanged and does not create a backup", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid());
+    const before = readDistrokidText(target);
+
+    await expectOk({ apply: false, backup: true, target });
+
+    expect(readDistrokidText(target)).toBe(before);
+    expect(existsSync(backupPath(target))).toBe(false);
+  });
+
+  test("creates distrokid.json.bak when apply uses backup", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid());
+    const before = readDistrokidText(target);
+
+    await expectOk({ apply: true, backup: true, target });
+
+    expect(readFileSync(backupPath(target), "utf-8")).toBe(before);
+  });
+
+  test("resolves target from CHANNEL_DIR when target is omitted", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid());
+    process.env.CHANNEL_DIR = target;
+
+    await expectOk({ apply: true, backup: false });
+
+    expect(readProfile(target).songwriter).toEqual({
+      first: "Jane",
+      last: "Doe",
+    });
+  });
+
+  test("explicit target takes precedence over CHANNEL_DIR", async () => {
+    const envTarget = makeDistrokidTarget();
+    const explicitTarget = makeDistrokidTarget();
+    writeDistrokid(envTarget, oldDistrokid({}, { songwriter: "Env Writer" }));
+    writeDistrokid(
+      explicitTarget,
+      oldDistrokid({}, { songwriter: "Explicit Writer" })
+    );
+    process.env.CHANNEL_DIR = envTarget;
+
+    await expectOk({ apply: true, backup: false, target: explicitTarget });
+
+    expect(readProfile(explicitTarget).songwriter).toEqual({
+      first: "Explicit",
+      last: "Writer",
+    });
+    expect(readProfile(envTarget).songwriter).toBe("Env Writer");
+  });
+
+  test("resolves target from a current working directory ancestor", async () => {
+    const target = makeDistrokidTarget();
+    const nested = join(target, "work", "nested");
+    mkdirSync(nested, { recursive: true });
+    writeDistrokid(target, oldDistrokid({}, { songwriter: "Ancestor Writer" }));
+    process.chdir(nested);
+
+    await expectOk({ apply: true, backup: false });
+
+    expect(readProfile(target).songwriter).toEqual({
+      first: "Ancestor",
+      last: "Writer",
+    });
+  });
+
+  test("returns a config error for missing distrokid.json", async () => {
+    const target = makeDistrokidTarget();
+
+    const result = await migrateDistrokidService({
+      apply: false,
+      backup: true,
+      target,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("distrokid.json");
+    }
+  });
+
+  test("returns a config error for invalid JSON", async () => {
+    const target = makeDistrokidTarget();
+    writeFileSync(distrokidPath(target), "{broken");
+
+    const result = await migrateDistrokidService({
+      apply: false,
+      backup: true,
+      target,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("JSON");
+    }
+  });
+
+  test("returns a config error for a non-object top-level JSON value", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, ["not", "an", "object"]);
+
+    const result = await migrateDistrokidService({
+      apply: false,
+      backup: true,
+      target,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("object");
+    }
+  });
+
+  test("returns a config error for a non-object distrokid.profile", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, { distrokid: { enabled: true, profile: [] } });
+
+    const result = await migrateDistrokidService({
+      apply: false,
+      backup: true,
+      target,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.domain).toBe("config");
+      expect(result.error.message).toContain("profile");
+    }
+  });
+});
+
+describe("distrokid migrate registry", () => {
+  test("declares no injected deps so config loading is not required", () => {
+    const entry = REGISTRY["distrokid.migrate"];
+
+    expect(entry.deps).toEqual([]);
+  });
+});

--- a/packages/core/test/distrokid-migrate-transform.test.ts
+++ b/packages/core/test/distrokid-migrate-transform.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { migrateDistrokidService } from "@youtube-automation/core/distrokid-migrate";
+
+import { Distrokid } from "../src/config/distrokid.ts";
+import {
+  cleanupDistrokidTargets,
+  makeDistrokidTarget,
+  oldDistrokid,
+  readDistrokid,
+  readProfile,
+  writeDistrokid,
+} from "./distrokid-migrate-fixtures.ts";
+import type { JsonRecord } from "./distrokid-migrate-fixtures.ts";
+
+let savedChannelDir: string | undefined;
+
+beforeEach(() => {
+  savedChannelDir = process.env.CHANNEL_DIR;
+  Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+});
+
+afterEach(() => {
+  if (savedChannelDir === undefined) {
+    Reflect.deleteProperty(process.env, "CHANNEL_DIR");
+  } else {
+    process.env.CHANNEL_DIR = savedChannelDir;
+  }
+  cleanupDistrokidTargets();
+});
+
+const expectOk = async (
+  input: Parameters<typeof migrateDistrokidService>[0]
+): Promise<void> => {
+  const result = await migrateDistrokidService(input);
+  expect(result.ok).toBe(true);
+};
+
+describe("distrokid migrate service — profile conversion", () => {
+  test("apply writes the nested songwriter and default ai_disclosure schema", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid());
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const profile = readProfile(target);
+    expect(profile.language).toBe("ja");
+    expect(profile.main_genre).toBe("Electronic");
+    expect(profile.songwriter).toEqual({ first: "Jane", last: "Doe" });
+    expect(profile.ai_disclosure).toEqual({
+      apply_to_all: true,
+      artist_persona: true,
+      enabled: true,
+      lyrics: true,
+      music: true,
+      partial_audio_type: null,
+      recording_scope: "full",
+    });
+  });
+
+  test("drops legacy flat profile fields from migration output", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid());
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const profile = readProfile(target);
+    expect(profile).not.toHaveProperty("artist_name");
+    expect(profile).not.toHaveProperty("apple_music_credit");
+    expect(profile).not.toHaveProperty("track_type");
+  });
+
+  test("splits a single-word songwriter into first and blank last", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid({}, { songwriter: "Jane" }));
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(readProfile(target).songwriter).toEqual({ first: "Jane", last: "" });
+  });
+
+  test("splits middle songwriter tokens into the middle field", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid({}, { songwriter: "Jane Quincy Doe" }));
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(readProfile(target).songwriter).toEqual({
+      first: "Jane",
+      last: "Doe",
+      middle: "Quincy",
+    });
+  });
+
+  test("preserves known object songwriter fields for idempotency", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(
+      target,
+      oldDistrokid({}, { songwriter: { first: "Jane", last: "Doe" } })
+    );
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(readProfile(target).songwriter).toEqual({
+      first: "Jane",
+      last: "Doe",
+    });
+  });
+
+  test("drops an empty songwriter string", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid({}, { songwriter: "   " }));
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(readProfile(target)).not.toHaveProperty("songwriter");
+  });
+
+  test("renames legacy ai_disclosure.composition to music", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(
+      target,
+      oldDistrokid(
+        {},
+        {
+          ai_disclosure: {
+            composition: false,
+            enabled: true,
+            lyrics: false,
+            partial_audio_type: null,
+          },
+        }
+      )
+    );
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const ai = readProfile(target).ai_disclosure as JsonRecord;
+    expect(ai).not.toHaveProperty("composition");
+    expect(ai.music).toBe(false);
+    expect(ai.lyrics).toBe(false);
+  });
+
+  test("keeps explicit ai_disclosure.music over legacy composition", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(
+      target,
+      oldDistrokid({}, { ai_disclosure: { composition: false, music: true } })
+    );
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const ai = readProfile(target).ai_disclosure as JsonRecord;
+    expect(ai.music).toBe(true);
+    expect(ai).not.toHaveProperty("composition");
+  });
+
+  test("derives partial recording scope when partial_audio_type is present", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(
+      target,
+      oldDistrokid(
+        {},
+        { ai_disclosure: { composition: true, partial_audio_type: "vocals" } }
+      )
+    );
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const ai = readProfile(target).ai_disclosure as JsonRecord;
+    expect(ai.recording_scope).toBe("partial");
+    expect(ai.partial_audio_type).toBe("vocals");
+  });
+
+  test("normalizes non-object ai_disclosure to the default disclosure schema", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid({}, { ai_disclosure: false }));
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(readProfile(target).ai_disclosure).toEqual({
+      apply_to_all: true,
+      artist_persona: true,
+      enabled: true,
+      lyrics: true,
+      music: true,
+      partial_audio_type: null,
+      recording_scope: "full",
+    });
+  });
+
+  test("keeps already-new schema destructive-field-free", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, {
+      distrokid: {
+        enabled: true,
+        profile: {
+          ai_disclosure: { music: true, recording_scope: "full" },
+          language: "ja",
+          main_genre: "Electronic",
+          songwriter: { first: "Jane", last: "Doe" },
+        },
+      },
+    });
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const profile = readProfile(target);
+    expect(profile.songwriter).toEqual({ first: "Jane", last: "Doe" });
+    expect(profile.ai_disclosure as JsonRecord).not.toHaveProperty(
+      "composition"
+    );
+    expect(profile).not.toHaveProperty("artist_name");
+  });
+
+  test("drops null songwriter during new schema remigration", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, {
+      distrokid: {
+        enabled: true,
+        profile: {
+          ai_disclosure: { music: true, recording_scope: "full" },
+          language: "ja",
+          main_genre: "Electronic",
+          songwriter: null,
+        },
+      },
+    });
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const profile = readProfile(target);
+    expect(profile).not.toHaveProperty("songwriter");
+    expect(
+      Distrokid.parse(readDistrokid(target)).profile.songwriter
+    ).toBeNull();
+  });
+
+  test("remigrates new schema with omitted profile", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, {
+      distrokid: {
+        enabled: false,
+      },
+    });
+
+    await expectOk({ apply: true, backup: false, target });
+
+    expect(Distrokid.parse(readDistrokid(target)).profile).toEqual({
+      aiDisclosure: {
+        applyToAll: true,
+        artistPersona: true,
+        enabled: true,
+        lyrics: true,
+        music: true,
+        partialAudioType: null,
+        recordingScope: "full",
+      },
+      credits: {
+        performerRole: "Synthesizer",
+        producerRole: "Producer",
+      },
+      language: "",
+      mainGenre: "",
+      songwriter: null,
+      subGenre: undefined,
+    });
+  });
+
+  test("keeps migrated profile readable by the new config schema", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, {
+      distrokid: {
+        enabled: true,
+        profile: {
+          ai_disclosure: {
+            music: true,
+            recording_scope: "full",
+            unexpected_ai_key: true,
+          },
+          credits: {
+            performer_role: "Piano",
+            producer_role: "Producer",
+            unexpected_credit_key: true,
+          },
+          language: "ja",
+          main_genre: "Electronic",
+          songwriter: {
+            first: "Jane",
+            last: "Doe",
+            unexpected_songwriter_key: true,
+          },
+          unexpected_profile_key: true,
+        },
+      },
+    });
+
+    await expectOk({ apply: true, backup: false, target });
+
+    const profile = readProfile(target);
+    expect(profile.songwriter).toEqual({ first: "Jane", last: "Doe" });
+    expect(profile.songwriter as JsonRecord).not.toHaveProperty(
+      "unexpected_songwriter_key"
+    );
+    expect(profile).not.toHaveProperty("unexpected_profile_key");
+    expect(profile.ai_disclosure as JsonRecord).not.toHaveProperty(
+      "unexpected_ai_key"
+    );
+    expect(profile.credits as JsonRecord).not.toHaveProperty(
+      "unexpected_credit_key"
+    );
+    expect(Distrokid.parse(readDistrokid(target)).profile.songwriter).toEqual({
+      first: "Jane",
+      last: "Doe",
+    });
+  });
+
+  test("returns a validation error for non-string and non-object songwriter", async () => {
+    const target = makeDistrokidTarget();
+    writeDistrokid(target, oldDistrokid({}, { songwriter: 42 }));
+
+    const result = await migrateDistrokidService({
+      apply: true,
+      backup: false,
+      target,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("songwriter");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

> ADR-0002/0003/0004/0007/0009 準拠 / Parent #967 / takt base: `feat/ts-rewrite`

## Parent
#967

## What to build
core service `packages/core/src/distrokid-migrate/{schema,service}.ts` に旧フラット profile → 新 nested schema の純変換を実装。registry `distrokid.migrate`。CLI `tayk distrokid-migrate` thin。**併せて `packages/core/src/config/distrokid.ts` を Python `utils/config/distrokid.py` の新 schema（`songwriter` nested・`ai_disclosure`・`credits`・required=`language`/`main_genre` のみ）へ作り直す**（現 TS は旧フラット schema で migrate 出力を読めず、prepare 港のブロッカーも兼ねるため同 PR で是正）。

## Acceptance criteria
- [ ] flags 全 keep: `--target`（解決順 `--target`→`CHANNEL_DIR`→CWD 祖先探索）/ `--apply`（既定 dry-run）/ `--backup`/`--no-backup`（既定 true、`--apply` 時のみ）
- [ ] 隠れ契約 dry-run 既定 = **keep**（引数なしは `[dry-run]` 表示・無変更・exit 0）
- [ ] 隠れ契約 songwriter パース = **keep**（"First Last"→{first,last}／中間語→middle 連結／単語1→{first,last:""}／object はそのまま冪等／空→drop／非str・非dict→error）
- [ ] 隠れ契約 ai_disclosure 派生 = **keep**（省略→default 付与／旧 `composition`→`music` リネーム（明示 music 優先）／`recording_scope` 未指定＆`partial_audio_type!=null`→`"partial"` 導出／`composition` キー除去）
- [ ] 隠れ契約 legacy drop = **keep**（`artist_name`/`apple_music_credit`/`track_type` 除去）
- [ ] 隠れ契約 backup = **keep**（`--apply --backup` で `distrokid.json.bak`）／冪等（新 schema 再変換で非破壊）／fail-loud（不在/不正 JSON/非 dict 各種）
- [ ] core service（zod snake→camel、`Result`/`toServiceError`）、registry `distrokid.migrate`（loadConfig 呼ばない）、CLI thin（per-CLI bin なし）
- [ ] **config 是正**: `config/distrokid.ts` を新 schema へ。旧 required-6 を前提とする `config-*.test.ts` を**同 PR で更新**
- [ ] bun:test: songwriter 4 ケース・ai_disclosure 派生 3 ケース・冪等・legacy drop・dry-run 無変更・backup 生成＋CLI smoke
- [ ] CHANGELOG [Unreleased]

## Blocked by
- なし（独立・最初。config 是正を含むため prepare 系の前提）

## 出典
`cli/distrokid_migrate.py`, `utils/config/distrokid.py`, `packages/core/src/config/distrokid.ts`, `tests/test_distrokid_migrate.py`

## Execution Report

Workflow `default` completed successfully.

Closes #1077