### PR TITLE
[#1118] issue-1118-knip-no-stale-pataa

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -6,28 +6,14 @@
       "project": [],
       "ignoreDependencies": ["takt"]
     },
-    "packages/*": {
-      "entry": ["src/index.ts", "src/cli/*.ts", "bin/*.ts", "*/index.ts"],
+    "packages/cli": {
+      "entry": ["src/commands/*/cli.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts", "*/*.ts"]
+    },
+    "packages/core": {
       "project": ["src/**/*.ts", "test/**/*.ts", "*/*.ts"]
     }
   },
-  "ignore": [
-    ".worktrees/**",
-    ".claude/worktrees/**",
-    "src/youtube_automation/**",
-    "tests/**",
-    "extensions/**",
-    "examples/**",
-    "docs/**",
-    "poc/**"
-  ],
-  "ignoreBinaries": [
-    "lefthook",
-    "uv",
-    "nix",
-    "gh",
-    "compile",
-    "build",
-    "playwright"
-  ]
+  "ignore": ["extensions/**"],
+  "ignoreBinaries": ["compile", "build", "playwright"]
 }


### PR DESCRIPTION
## Summary

# Plan 010: Knip 設定の stale/不一致パターンを修正する

> **Executor instructions**: Follow this plan step by step. Run every
> verification command and confirm the expected result before moving to the
> next step. If anything in the "STOP conditions" section occurs, stop and
> report — do not improvise. When done, update the status row for this plan
> in `plans/README.md` — unless a reviewer dispatched you and told you they
> maintain the index.
>
> **Drift check (run first)**: `git diff --stat 62fd1f3..HEAD -- knip.json`
> If any in-scope file changed since this plan was written, compare the
> "Current state" excerpts against the live code before proceeding; on a
> mismatch, treat it as a STOP condition.

## Status

- **Priority**: P2
- **Effort**: S
- **Risk**: LOW
- **Depends on**: none
- **Category**: dx
- **Planned at**: commit `62fd1f3`, 2026-06-19

## Why this matters

`bun run knip` が 17 件の configuration hints を出力しており、`packages/cli` のエントリパターンが実際のファイル構造と一致していない。dead code 検出が CLI パッケージで事実上無効になっている。CI の `ts-knip` ジョブは通過するが、本来検出すべき未使用 export を見逃す。

## Current state

`bun run knip` 出力の主要な hints:

```
src/index.ts               packages/cli   knip.json  Refine entry pattern (no matches)
src/cli/*.ts               packages/cli   knip.json  Refine entry pattern (no matches)
*/index.ts                 packages/cli   knip.json  Refine entry pattern (no matches)
src/cli/*.ts               packages/core  knip.json  Refine entry pattern (no matches)
bin/*.ts                   packages/core  knip.json  Refine entry pattern (no matches)
src/index.ts               packages/core  knip.json  Remove redundant entry pattern
.worktrees/**              knip.json      Remove from ignore
.claude/worktrees/**       knip.json      Remove from ignore
```

CLI の実際のファイル構造:
- `packages/cli/bin/tayk.ts`
- `packages/cli/src/commands/skills/cli.ts`
- `packages/cli/src/commands/generate-suno/cli.ts`
- `packages/cli/lib/*.ts`

## Commands you will need

| Purpose | Command          | Expected on success |
|---------|------------------|---------------------|
| Knip    | `bun run knip`   | exit 0, 0 configuration hints |
| Lint    | `bun run lint`   | exit 0              |

## Scope

**In scope**:
- `knip.json`

**Out of scope**:
- ソースコード — 設定のみの変更

## Git workflow

- Branch: `advisor/010-fix-knip-config`
- Commit style: `fix(dx): knip 設定の stale エントリパターンを修正`
- Do NOT push or open a PR unless the operator instructed it.

## Steps

### Step 1: knip.json を修正

1. `knip.json` を読む
2. 各 hint を解消:
   - **packages/cli**: エントリパターンを実際の構造に合わせる: `bin/tayk.ts` + `src/commands/*/cli.ts`
   - **packages/core**: `src/cli/*.ts` と `bin/*.ts` を削除（存在しない）。`src/index.ts` の冗長パターンを削除
   - **Root ignore**: `.worktrees/**` と `.claude/worktrees/**` を削除（存在しない ignore 対象）
   - 他の stale `ignoreBinaries` / `ignore` パターンも hint に従って削除

**Verify**: `bun run knip` → exit 0, configuration hints が 0 件

### Step 2: knip の実結果を確認

hints が解消された状態で、knip が検出する unused exports / dependencies がないことを確認。もし genuine な dead code が検出された場合、このプランでは修正せず NOTES に記録する。

**Verify**: `bun run knip` → exit 0（ゼロ findings が理想だが、新規検出された genuine findings は記録のみ）

## Test plan

- テスト不要（設定変更のみ）
- `bun run knip` の出力で検証

## Done criteria

- [ ] `bun run knip` exits 0
- [ ] `bun run knip` の出力に `Configuration hints` セクションがないか、0 件
- [ ] No files outside the in-scope list are modified

## STOP conditions

- knip.json の構造が予想と異なる（workspace 設定が複雑で単純な修正では解消しない）
- hint 解消後に大量の genuine dead code findings が出て、exit code が 0 でない場合 → findings を記録して報告

## Maintenance notes

- 新しい package を `packages/` に追加した場合、knip.json にエントリパターンを追加する必要がある
- `bun run knip` は CI の `ts-knip` ジョブで実行される。設定が正しければ dead code の混入を自動検出できる

## Execution Report

Workflow `default` completed successfully.

Closes #1118