### PR TITLE
[#1119] issue-1119-claude-md-ni-ts-rei

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,48 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 - `skills` asset を標準レイアウト（`.claude/skills`）へ sync すると、下流リポにも `.agents/skills -> ../.claude/skills` の相対 symlink を併設する（Codex CLI 探索パス規約）。既存の正しい symlink は冪等にスキップし、張り直しは `--force`、symlink 非対応環境では警告のみで sync は継続する（`_ops.py::_ensure_agents_skills_symlink`）
 - バージョン bump は `pyproject.toml::version` のみを更新する（`src/youtube_automation/__init__.py::__version__` は `importlib.metadata` 経由で動的に読み込むため触らない）。リリース運用全体は `/automation-release` スキルで一気通貫に実行する
 
+### TS レイヤー（packages/）
+
+Python → TypeScript 書き換え（ADR-0001）の TS コードは `packages/` に配置する。runtime は Bun、型チェックは `tsc -b --noEmit`、lint は oxlint、formatter は oxfmt、dead code 検出は knip。
+
+#### パッケージ構成
+
+- `packages/core/` — ドメインロジック（analytics, config, image, oauth, upload, metadata, suno-prompts, skills-sync）。`@youtube-automation/core` として export
+- `packages/cli/` — CLI コマンド（`tayk` エントリポイント）。core の service を呼び出す adapter 層
+
+#### コマンド追加手順
+
+1. `packages/core/src/<domain>/service.ts` に service 関数を作成。`Result<Output, ServiceError>` を返す。入力は zod schema で `.parse()` する
+2. `packages/core/src/<domain>/schema.ts` に入出力の zod schema を定義
+3. `packages/core/src/<domain>/index.ts` で public API を re-export
+4. `packages/core/src/registry.ts` に service entry を登録（`deps` / `run` を定義）
+5. `packages/cli/src/commands/<name>/cli.ts` に CLI adapter を作成
+6. テストは `packages/core/test/<name>.test.ts` に配置。DI seam（`deps`）経由で fake を注入
+
+#### service 境界契約（ADR-0003）
+
+- service 関数は `async (input, deps) => Result<Output, ServiceError>` のシグネチャ
+- `deps` で外部依存を注入（YouTube API client, sleep, persist 等）— テスト時に fake に差し替え可能
+- core 内部は throw OK。境界の `try/catch` で `toServiceError` に集約
+- retry は `withRetry` に委譲。quota は retry せず `err(domain: "quota")` で返す
+
+#### 検証コマンド
+
+```bash
+bun run typecheck          # tsc -b --noEmit
+bun test                   # bun test（全パッケージ）
+bun run lint               # oxlint
+bun run format:check       # oxfmt
+bun run knip               # dead code 検出
+bun run ci                 # 上記すべて一括
+```
+
+#### エラーハンドリング
+
+- `packages/core/src/errors.ts` のドメインエラーを使用: `YouTubeAPIError`, `QuotaExhaustedError`, `toServiceError`
+- `Result` 型（`ok(value)` / `err(serviceError)`）で caller にエラーを伝搬。throw しない
+- service error の `domain` フィールド: `"validation"` / `"quota"` / `"api"` / `"auth"` / `"io"` / `"config"`
+
 ### extensions（Chrome 拡張開発）
 
 `extensions/` 配下の Chrome 拡張は **WXT + React + TypeScript + Tailwind CSS** スタックで開発する（Python 本体とは独立した Node ツールチェーン）。詳細は `extensions/README.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,9 @@ Python → TypeScript 書き換え（ADR-0001）の TS コードは `packages/` 
 3. `packages/core/src/<domain>/index.ts` で public API を re-export
 4. `packages/core/src/registry.ts` に service entry を登録（`deps` / `run` を定義）
 5. `packages/cli/src/commands/<name>/cli.ts` に CLI adapter を作成
-6. テストは `packages/core/test/<name>.test.ts` に配置。DI seam（`deps`）経由で fake を注入
+6. `packages/cli/bin/tayk.ts` で command を import し、`subCommands` に登録
+7. service のテストは `packages/core/test/<name>.test.ts` に配置。DI seam（`deps`）経由で fake を注入
+8. CLI adapter の smoke test は `packages/cli/test/<command>.test.ts` に配置。dispatcher 経由で args / output / exit code / error path / deps 解決を検証
 
 #### service 境界契約（ADR-0003）
 


### PR DESCRIPTION
## Summary

# Plan 011: CLAUDE.md に TS レイヤーの開発ガイドを追加する

> **Executor instructions**: Follow this plan step by step. Run every
> verification command and confirm the expected result before moving to the
> next step. If anything in the "STOP conditions" section occurs, stop and
> report — do not improvise. When done, update the status row for this plan
> in `plans/README.md` — unless a reviewer dispatched you and told you they
> maintain the index.
>
> **Drift check (run first)**: `git diff --stat 62fd1f3..HEAD -- CLAUDE.md`
> If any in-scope file changed since this plan was written, compare the
> "Current state" excerpts against the live code before proceeding; on a
> mismatch, treat it as a STOP condition.

## Status

- **Priority**: P2
- **Effort**: S
- **Risk**: LOW
- **Depends on**: none
- **Category**: dx
- **Planned at**: commit `62fd1f3`, 2026-06-19

## Why this matters

CLAUDE.md の「開発規約」セクションは Python レイヤーのみを文書化しており、TS レイヤー（`packages/core`, `packages/cli`）の開発パターン — コマンド追加手順、registry 登録、service 境界契約、テストパターン — が一切記載されていない。AI エージェント（takt）や新規貢献者が TS コマンドをポートする際、アーキテクチャをコード読みから推測する必要があり、誤ったパターンの採用やレビュー負荷増大を招く。

## Current state

`CLAUDE.md` の「開発規約」セクション:
- 設定アクセス（Python `load_config` 経由）
- エラーハンドリング（Python `utils/exceptions.py`）
- Import 規約（Python fully-qualified）
- スクリプト配置
- テスト（Python pytest）
- パッケージング（Python hatchling）

TS 関連の記述: `extensions/` セクションのみ（Chrome 拡張開発）。`packages/` の記述なし。

## Commands you will need

| Purpose | Command | Expected on success |
|---------|---------|---------------------|
| N/A     | なし    | CLAUDE.md の内容確認のみ |

## Scope

**In scope**:
- `CLAUDE.md`

**Out of scope**:
- `AGENTS.md` — 別途更新が必要だが、このプランでは CLAUDE.md のみ
- ソースコード — ドキュメント変更のみ

## Git workflow

- Branch: `advisor/011-claudemd-ts-guide`
- Commit style: `docs: CLAUDE.md に TS レイヤー開発ガイドを追加`
- Do NOT push or open a PR unless the operator instructed it.

## Steps

### Step 1: CLAUDE.md に TS 開発セクションを追加

「### extensions（Chrome 拡張開発）」セクションの**前**に以下のセクションを挿入:

```markdown
### TS レイヤー（packages/）

Python → TypeScript 書き換え（ADR-0001）の TS コードは `packages/` に配置する。runtime は Bun、型チェックは `tsc -b --noEmit`、lint は oxlint、formatter は oxfmt、dead code 検出は knip。

#### パッケージ構成

- `packages/core/` — ドメインロジック（analytics, config, image, oauth, upload, metadata, suno-prompts, skills-sync）。`@youtube-automation/core` として export
- `packages/cli/` — CLI コマンド（`tayk` エントリポイント）。core の service を呼び出す adapter 層

#### コマンド追加手順

1. `packages/core/src/<domain>/service.ts` に service 関数を作成。`Result<Output, ServiceError>` を返す。入力は zod schema で `.parse()` する
2. `packages/core/src/<domain>/schema.ts` に入出力の zod schema を定義
3. `packages/core/src/<domain>/index.ts` で public API を re-export
4. `packages/core/src/registry.ts` に service entry を登録（`deps` / `run` を定義）
5. `packages/cli/src/commands/<name>/cli.ts` に CLI adapter を作成
6. テストは `packages/core/test/<name>.test.ts` に配置。DI seam（`deps`）経由で fake を注入

#### service 境界契約（ADR-0003）

- service 関数は `async (input, deps) => Result<Output, ServiceError>` のシグネチャ
- `deps` で外部依存を注入（YouTube API client, sleep, persist 等）— テスト時に fake に差し替え可能
- core 内部は throw OK。境界の `try/catch` で `toServiceError` に集約
- retry は `withRetry` に委譲。quota は retry せず `err(domain: "quota")` で返す

#### 検証コマンド

```bash
bun run typecheck          # tsc -b --noEmit
bun test                   # bun test（全パッケージ）
bun run lint               # oxlint
bun run format:check       # oxfmt
bun run knip               # dead code 検出
bun run ci                 # 上記すべて一括
```

#### エラーハンドリング

- `packages/core/src/errors.ts` のドメインエラーを使用: `YouTubeAPIError`, `QuotaExhaustedError`, `toServiceError`
- `Result` 型（`ok(value)` / `err(serviceError)`）で caller にエラーを伝搬。throw しない
- service error の `domain` フィールド: `"validation"` / `"quota"` / `"api"` / `"io"` / `"config"`
```

**Verify**: `CLAUDE.md` の変更箇所を目視確認。TS 開発ガイドが「extensions」セクションの前に配置されていること

## Test plan

- テスト不要（ドキュメント変更のみ）

## Done criteria

- [ ] `CLAUDE.md` に「### TS レイヤー（packages/）」セクションが存在する
- [ ] セクションにコマンド追加手順、service 境界契約、検証コマンド、エラーハンドリングが含まれる
- [ ] No files outside the in-scope list are modified

## STOP conditions

- CLAUDE.md に既に TS レイヤーの記述が追加されていた場合

## Maintenance notes

- TS レイヤーに新しいドメインモジュール（例: data store）が追加された場合、パッケージ構成セクションを更新する
- registry パターンが変わった場合（ADR-0004 の evolution）、コマンド追加手順を更新する

## Execution Report

Workflow `default` completed successfully.

Closes #1119