### PR TITLE
[#1117] issue-1117-image-saabisunoooke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
 - `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。
 
-- `test(ts-rewrite/core)`: `generateImageService` のオーケストレーションテストを追加した（#1117）。成功パス / 入力検証エラー / content policy エラー（retry なし） / 一時エラー + retry 成功 / persist 失敗 / retry 上限超過の 6 ケースを `image-service.test.ts` でカバー
-
 ### Changed
 
 - `feat(skills)`: dogfood ライフサイクルが踏む 12 skill（wf-new / wf-next / suno / suno-helper / masterup / videoup / video-upload / thumbnail / video-description / analytics-collect / playlist / distrokid-prep）の `uv run yt-*` 呼び出しを `bunx tayk <cmd>`（ADR-0007 rebrand / ADR-0004 単一 dispatcher）へ置換した（#965）。TS 版を pin した下流でも skill 経由で Python が実行され dogfood が始まらない問題を解消する。対象 skill の `uv run` 残骸ゼロを `tests/test_lifecycle_skills_no_uv_run.py` で機械担保。lifecycle 外の skill の置換は #966 で対応予定。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
 - `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。
 
+- `test(ts-rewrite/core)`: `generateImageService` のオーケストレーションテストを追加した（#1117）。成功パス / 入力検証エラー / content policy エラー（retry なし） / 一時エラー + retry 成功 / persist 失敗 / retry 上限超過の 6 ケースを `image-service.test.ts` でカバー
+
 ### Changed
 
 - `feat(skills)`: dogfood ライフサイクルが踏む 12 skill（wf-new / wf-next / suno / suno-helper / masterup / videoup / video-upload / thumbnail / video-description / analytics-collect / playlist / distrokid-prep）の `uv run yt-*` 呼び出しを `bunx tayk <cmd>`（ADR-0007 rebrand / ADR-0004 単一 dispatcher）へ置換した（#965）。TS 版を pin した下流でも skill 経由で Python が実行され dogfood が始まらない問題を解消する。対象 skill の `uv run` 残骸ゼロを `tests/test_lifecycle_skills_no_uv_run.py` で機械担保。lifecycle 外の skill の置換は #966 で対応予定。

--- a/packages/core/test/image-service.test.ts
+++ b/packages/core/test/image-service.test.ts
@@ -9,7 +9,9 @@ import type {
 } from "@youtube-automation/core/image";
 
 type ProviderBehavior = Uint8Array | Error;
-const baseInput = (overrides: Partial<GenerateImageInput>): GenerateImageInput =>
+const baseInput = (
+  overrides: Partial<GenerateImageInput>
+): GenerateImageInput =>
   ({
     aspectRatio: "16:9",
     imageSize: "2K",
@@ -44,8 +46,7 @@ const fakeProvider = (behaviors: ProviderBehavior[]) => {
 const fakePersist = (): PersistImage =>
   mock((path: string) => Promise.resolve(path));
 
-const recordSleep = (): SleepMs =>
-  mock(() => Promise.resolve());
+const recordSleep = (): SleepMs => mock(() => Promise.resolve());
 
 const enospcPersist: PersistImage = () =>
   Promise.reject(

--- a/packages/core/test/image-service.test.ts
+++ b/packages/core/test/image-service.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SleepMs } from "@youtube-automation/core";
+import { generateImageService } from "@youtube-automation/core/image";
+import type {
+  GenerateImageInput,
+  ImageProvider,
+  PersistImage,
+} from "@youtube-automation/core/image";
+
+type ProviderBehavior = Uint8Array | Error;
+const baseInput = (overrides: Partial<GenerateImageInput>): GenerateImageInput =>
+  ({
+    aspectRatio: "16:9",
+    imageSize: "2K",
+    outputPath: "/tmp/generated-image.png",
+    prompt: "a quiet neon studio at midnight",
+    ...overrides,
+  }) as GenerateImageInput;
+
+const fakeProvider = (behaviors: ProviderBehavior[]) => {
+  let callIndex = 0;
+  const generate = mock((_request: GenerateImageInput) => {
+    const behavior = behaviors[callIndex];
+    callIndex += 1;
+    return Promise.resolve().then(() => {
+      if (behavior === undefined) {
+        throw new Error("fake image provider: no behavior queued");
+      }
+      if (behavior instanceof Error) {
+        throw behavior;
+      }
+      return behavior;
+    });
+  });
+  const provider: ImageProvider = {
+    generate,
+    name: "fake",
+    supportedAspectRatios: [],
+  };
+  return { generate, provider };
+};
+
+const fakePersist = (): PersistImage =>
+  mock((path: string) => Promise.resolve(path));
+
+const recordSleep = (): SleepMs =>
+  mock(() => Promise.resolve());
+
+const enospcPersist: PersistImage = () =>
+  Promise.reject(
+    Object.assign(new Error("ENOSPC: no space left on device"), {
+      code: "ENOSPC",
+    })
+  );
+
+describe("generateImageService orchestration", () => {
+  test("should persist provider bytes and return the saved path when generation succeeds", async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const outputPath = "/tmp/success.png";
+    const { generate, provider } = fakeProvider([bytes]);
+    const persist = fakePersist();
+    const result = await generateImageService(baseInput({ outputPath }), {
+      persist,
+      provider,
+      sleep: recordSleep(),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(`expected ok result, got ${result.error.domain}`);
+    }
+    expect(result.value).toEqual({ savedPath: outputPath });
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith(outputPath, bytes);
+  });
+
+  test("should return a validation error before calling provider when input is invalid", async () => {
+    const { generate, provider } = fakeProvider([
+      new Uint8Array([0xff, 0xd8, 0xff]),
+    ]);
+    const persist = fakePersist();
+    const invalidInput = {
+      aspectRatio: "16:9",
+      imageSize: "2K",
+      prompt: "missing output path",
+    } as unknown as GenerateImageInput;
+    const result = await generateImageService(invalidInput, {
+      persist,
+      provider,
+      sleep: recordSleep(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected validation error result");
+    }
+    expect(result.error.domain).toBe("validation");
+    expect(generate).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test("should not retry provider calls when the error is content policy related", async () => {
+    const { generate, provider } = fakeProvider([
+      new Error("blocked due to SAFETY filters"),
+    ]);
+    const sleep = recordSleep();
+    const result = await generateImageService(baseInput({}), {
+      persist: fakePersist(),
+      provider,
+      sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected content policy error result");
+    }
+    expect(result.error.domain).toBe("io");
+    expect(result.error.message).toContain("SAFETY");
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("should retry a transient provider error when a later attempt succeeds", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const { generate, provider } = fakeProvider([
+      new Error("503 backend unavailable"),
+      bytes,
+    ]);
+    const sleep = recordSleep();
+    const persist = fakePersist();
+    const result = await generateImageService(baseInput({}), {
+      persist,
+      provider,
+      sleep,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(`expected retry success, got ${result.error.domain}`);
+    }
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(10_000);
+    expect(persist).toHaveBeenCalledWith("/tmp/generated-image.png", bytes);
+  });
+
+  test("should map persist failures to an io error when saving fails", async () => {
+    const { generate, provider } = fakeProvider([new Uint8Array([5, 6, 7])]);
+    const result = await generateImageService(baseInput({}), {
+      persist: enospcPersist,
+      provider,
+      sleep: recordSleep(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected persist error result");
+    }
+    expect(result.error.domain).toBe("io");
+    expect(result.error.message).toContain("ENOSPC");
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  test("should return the final provider error when retry attempts are exhausted", async () => {
+    const { generate, provider } = fakeProvider([
+      new Error("first transient error"),
+      new Error("second transient error"),
+      new Error("final transient error"),
+    ]);
+    const sleep = recordSleep();
+    const persist = fakePersist();
+    const result = await generateImageService(baseInput({}), {
+      persist,
+      provider,
+      sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected exhausted retry error result");
+    }
+    expect(result.error.domain).toBe("io");
+    expect(result.error.message).toBe("final transient error");
+    expect(generate).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 10_000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 30_000);
+    expect(persist).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

# Plan 009: Image 生成サービスの E2E テストを追加する

> **Executor instructions**: Follow this plan step by step. Run every
> verification command and confirm the expected result before moving to the
> next step. If anything in the "STOP conditions" section occurs, stop and
> report — do not improvise. When done, update the status row for this plan
> in `plans/README.md` — unless a reviewer dispatched you and told you they
> maintain the index.
>
> **Drift check (run first)**: `git diff --stat 62fd1f3..HEAD -- packages/core/src/image/`
> If any in-scope file changed since this plan was written, compare the
> "Current state" excerpts against the live code before proceeding; on a
> mismatch, treat it as a STOP condition.

## Status

- **Priority**: P2
- **Effort**: M
- **Risk**: LOW
- **Depends on**: none
- **Category**: tests
- **Planned at**: commit `62fd1f3`, 2026-06-19

## Why this matters

`generateImageService` は画像生成パイプラインのオーケストレーション層（入力検証 → retry 付き provider 呼び出し → ディスク永続化 → Result 返却）だが、この関数自体のテストがない。`image-gemini.test.ts` / `image-openai.test.ts` は provider レベルの単体テスト、`image-config.test.ts` は設定テスト。オーケストレーション全体（特に retry + content policy エラーの分類 + persist 失敗のハンドリング）は未検証。

## Current state

`packages/core/src/image/service.ts:38-58`:
```typescript
export const generateImageService = async (
  input: GenerateImageInput,
  deps: { persist?: PersistImage; provider: ImageProvider; sleep?: SleepMs }
): Promise<Result<GenerateImageOutput, ServiceError>> => {
  try {
    const request = GenerateImageInput.parse(input);
    const bytes = await withRetry(() => deps.provider.generate(request), {
      shouldRetry: (error) =>
        defaultShouldRetry(error) && !isContentPolicyError(error),
      sleep: deps.sleep ?? defaultSleep,
    });
    const savedPath = await (deps.persist ?? defaultPersist)(
      request.outputPath,
      bytes
    );
    return ok(GenerateImageOutput.parse({ savedPath }));
  } catch (error) {
    return err(toServiceError(error));
  }
};
```

DI seam: `deps.provider` (ImageProvider), `deps.persist` (PersistImage), `deps.sleep` (SleepMs) — すべて注入可能。テスト容易。

テストパターン参考: `packages/core/test/upload.test.ts` — fake YouTube client + behaviors 配列で成功 / エラーパスをテスト。

## Commands you will need

| Purpose   | Command                                               | Expected on success |
|-----------|-------------------------------------------------------|---------------------|
| Typecheck | `bun run typecheck`                                   | exit 0              |
| Tests     | `bun test packages/core/test/image-service.test.ts`   | all pass            |
| Lint      | `bun run lint`                                        | exit 0              |

## Scope

**In scope**:
- `packages/core/test/image-service.test.ts` (create)

**Out of scope**:
- `packages/core/src/image/service.ts` — 実装変更なし
- 既存テスト `image-gemini.test.ts`, `image-openai.test.ts` — 変更不要

## Git workflow

- Branch: `advisor/009-image-service-e2e-tests`
- Commit style: `test(image): generateImageService のオーケストレーションテスト追加`
- Do NOT push or open a PR unless the operator instructed it.

## Steps

### Step 1: テストファイル作成

`packages/core/test/image-service.test.ts` を新規作成。以下のテストケースを実装:

**fake 設計**:
```typescript
const fakeProvider = (behaviors: Array<Uint8Array | Error>): ImageProvider => {
  let callIndex = 0;
  return {
    generate: async () => {
      const behavior = behaviors[callIndex++];
      if (behavior instanceof Error) throw behavior;
      return behavior;
    },
  };
};

const fakePersist = (saved: Array<{ path: string; bytes: Uint8Array }>): PersistImage =>
  async (path, bytes) => { saved.push({ path, bytes }); return path; };

const noSleep: SleepMs = async () => {};
```

**テストケース**:
1. **成功パス**: provider が bytes を返す → persist が呼ばれる → `ok({ savedPath })` が返る
2. **入力検証エラー**: 不正な input（例: `outputPath` 欠如）→ `err(domain: "validation")` が返る
3. **Content policy エラー（retry しない）**: provider が `isContentPolicyError` に該当するエラーを throw → retry せず即座に `err` が返る → provider が 1 回だけ呼ばれることを確認
4. **一時エラー + retry 成功**: provider が 1 回目にエラー、2 回目に成功 → `ok` が返る → provider が 2 回呼ばれることを確認
5. **persist 失敗**: provider 成功 → persist が ENOSPC エラーを throw → `err(domain: "io")` が返る
6. **retry 上限超過**: provider が全回エラー → 最終エラーが `err` で返る

`isContentPolicyError` の判定条件は `image/base.ts` を確認して、テスト内で正しいエラーメッセージを構築すること。

**Verify**: `bun test packages/core/test/image-service.test.ts` → all pass, 6 tests

### Step 2: 全体検証

**Verify**: `bun run typecheck && bun test packages/core/test/image-*.test.ts && bun run lint` → all pass

## Test plan

- 新規テスト 6 件を `image-service.test.ts` に作成（Step 1 参照）
- テストパターン: `upload.test.ts` の fake + behaviors パターンを参考
- `bun test packages/core/test/image-service.test.ts` → all pass

## Done criteria

- [ ] `bun run typecheck` exits 0
- [ ] `bun test packages/core/test/image-service.test.ts` all pass (6 tests)
- [ ] `bun run lint` exits 0
- [ ] テストが以下をカバー: 成功, validation error, content policy (no retry), transient + retry, persist failure, retry exhaustion
- [ ] No files outside the in-scope list are modified

## STOP conditions

- `ImageProvider` インターフェースが `generate` 以外のメソッドを持つ場合（fake 設計の前提が崩れる）
- `isContentPolicyError` の判定条件が不明（`base.ts` を読んでも分からない場合）
- `withRetry` の retry 上限が設定から読まれ、テスト内で制御できない場合

## Maintenance notes

- 将来 provider が増えた場合（例: Stability AI）、service テストは provider-agnostic なので追加作業不要
- `persist` の DI seam があるため、ディスク I/O をテストから分離できている。実ディスクテストは integration に委ねる

## Execution Report

Workflow `default` completed successfully.

Closes #1117