### PR TITLE
[#1114] issue-1114-video-daily-nohaado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `refactor(ts-rewrite/core)`: `collectVideoDailyAnalyticsService` の列マッピングをハードコード位置参照から `columnHeaders` ベースの動的解決（`requireHeaders` / `resolveColumnIndex`）へ移行した（#1114）。API レスポンスの列順変更に対する堅牢性を向上
 - `fix(ts-rewrite/core)`: `readReferenceFiles` の参照画像読み込み失敗時エラーに対象パスを含め、元の filesystem error を `cause` に保持するよう修正した（#1121）。
 - `fix(suno-helper)`: auto-capture が Suno の URL 構造変更（`/me` → `/me/playlists`）に追従していなかったため、playlist mapping が `suno-playlists.json` に書き込まれず処理済みコレクションがドロップダウンに残り続けていた問題を修正した。併せて `captureFromTab` で SPA 未描画の空結果もリトライ対象にした。
 - `fix(suno-helper)`: overlay パネルのコンテンツが画面外にはみ出してスクロールできなかった問題を修正した。`max-height: calc(100vh - 120px)` + `overflow-y: auto` を追加。

--- a/packages/core/src/analytics/video-daily/service.ts
+++ b/packages/core/src/analytics/video-daily/service.ts
@@ -3,7 +3,7 @@
 // `VideoDailyAnalyticsMixin` を翻訳せず TS で新規記述したもの（ADR-0003）。
 //
 // 構築済みの YouTube Analytics クライアントを `deps` で受け取り（ADR-0003 §7 / DI
-// seam）、`reports.query` の行列（[video, day, views]）を `{ date, videoId, views }`
+// seam）、`reports.query` の行列を `{ date, videoId, views }`
 // レコードへ map して `Result` で返す。core 内部（query / map）は throw OK。境界の
 // try/catch で `toServiceError` 経由に集約し、CLI/MCP は `if (!r.ok)` で discriminate
 // する。マッピング:
@@ -27,6 +27,12 @@ import type { Result } from "../../result.ts";
 import { withRetry } from "../../retry.ts";
 import type { SleepMs } from "../../retry.ts";
 import {
+  readNumberCell,
+  readStringCell,
+  requireHeaders,
+  resolveColumnIndex,
+} from "../column-helpers.ts";
+import {
   shouldRetryAnalyticsQuery,
   toAnalyticsQueryError,
 } from "../query-error.ts";
@@ -44,15 +50,17 @@ const CHANNEL_ID_PREFIX = "channel==";
 const VIDEO_FILTER_PREFIX = "video==";
 const VIDEO_FILTER_SEPARATOR = ",";
 
-// 行の列順は上の `dimensions=video,day` + `metrics=views` クエリ契約で固定されるため、
-// columnHeaders に頼らず位置で引く（API はこの dimension/metric 組では常にこの順で返す）。
-const VIDEO_COLUMN = 0;
-const DAY_COLUMN = 1;
-const VIEWS_COLUMN = 2;
-
 type QueryParams = youtubeAnalytics_v2.Params$Resource$Reports$Query;
 type QueryResponse = youtubeAnalytics_v2.Schema$QueryResponse;
 type VideoDailyRecord = CollectVideoDailyAnalyticsOutput["metrics"][number];
+
+const readViewsCell = (row: readonly unknown[], viewsIndex: number): number => {
+  const value = row[viewsIndex];
+  if (value === null) {
+    return 0;
+  }
+  return readNumberCell(row, viewsIndex, "views", QUERY_CONTEXT);
+};
 
 const buildQueryParams = (
   input: CollectVideoDailyAnalyticsInput
@@ -75,17 +83,19 @@ const buildQueryParams = (
   return baseParams;
 };
 
-const mapRows = (rows: QueryResponse["rows"]): VideoDailyRecord[] => {
+const mapRows = (data: QueryResponse): VideoDailyRecord[] => {
   // データ無しの期間は API が `rows` を省く（v2.d.ts contract）→ 空配列で ok。
-  if (!rows) {
+  if (!data.rows) {
     return [];
   }
-  return rows.map((row) => ({
-    date: String(row[DAY_COLUMN]),
-    videoId: String(row[VIDEO_COLUMN]),
-    // この dimension では views セルが欠落し得る（0 視聴の日）。null/undefined は
-    // 0 視聴として正規化する（NaN を生まない）。
-    views: Number(row[VIEWS_COLUMN] ?? 0),
+  const headers = requireHeaders(data, QUERY_CONTEXT);
+  const videoIndex = resolveColumnIndex(headers, "video", QUERY_CONTEXT);
+  const dayIndex = resolveColumnIndex(headers, "day", QUERY_CONTEXT);
+  const viewsIndex = resolveColumnIndex(headers, "views", QUERY_CONTEXT);
+  return data.rows.map((row) => ({
+    date: readStringCell(row, dayIndex, "day", QUERY_CONTEXT),
+    videoId: readStringCell(row, videoIndex, "video", QUERY_CONTEXT),
+    views: readViewsCell(row, viewsIndex),
   }));
 };
 
@@ -115,7 +125,7 @@ export const collectVideoDailyAnalyticsService = async (
     );
     return ok(
       CollectVideoDailyAnalyticsOutput.parse({
-        metrics: mapRows(data.rows),
+        metrics: mapRows(data),
       })
     );
   } catch (error) {

--- a/packages/core/src/analytics/video-daily/service.ts
+++ b/packages/core/src/analytics/video-daily/service.ts
@@ -84,8 +84,7 @@ const buildQueryParams = (
 };
 
 const mapRows = (data: QueryResponse): VideoDailyRecord[] => {
-  // データ無しの期間は API が `rows` を省く（v2.d.ts contract）→ 空配列で ok。
-  if (!data.rows) {
+  if (!data.rows || data.rows.length === 0) {
     return [];
   }
   const headers = requireHeaders(data, QUERY_CONTEXT);

--- a/packages/core/test/analytics-video-daily.test.ts
+++ b/packages/core/test/analytics-video-daily.test.ts
@@ -54,6 +54,12 @@ const baseInput: CollectVideoDailyAnalyticsInput = {
   startDate: "2025-01-01",
 };
 
+const videoDailyColumnHeaders = [
+  { name: "video" },
+  { name: "day" },
+  { name: "views" },
+];
+
 // --- success path ----------------------------------------------------------
 
 describe("collectVideoDailyAnalyticsService success", () => {
@@ -61,6 +67,7 @@ describe("collectVideoDailyAnalyticsService success", () => {
     // Given a mock returning sample Analytics API rows (video, day, views)
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
+        columnHeaders: videoDailyColumnHeaders,
         rows: [
           ["vid1", "2025-01-01", 100],
           ["vid1", "2025-01-02", 150],
@@ -75,7 +82,7 @@ describe("collectVideoDailyAnalyticsService success", () => {
       ytAnalytics: mock,
     });
 
-    // Then the result is ok with one metrics record per row, mapped by position
+    // Then the result is ok with one metrics record per row, mapped by header
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -101,7 +108,7 @@ describe("collectVideoDailyAnalyticsService success", () => {
   test("passes the fixed query contract for channel-wide collection", async () => {
     // Given a mock we can inspect for the query parameters
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
-      data: { rows: [] },
+      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
 
     // When collecting without a videoIds filter
@@ -122,10 +129,13 @@ describe("collectVideoDailyAnalyticsService success", () => {
     expect(params.filters).toBeUndefined();
   });
 
-  test("coerces an absent views value to 0", async () => {
-    // Given a row whose views cell is null (API can omit a value)
+  test("preserves a numeric zero views value", async () => {
+    // Given a row whose views cell is the API's numeric zero value
     const { mock } = makeMockYtAnalytics(() => ({
-      data: { rows: [["vid1", "2025-01-01", null]] },
+      data: {
+        columnHeaders: videoDailyColumnHeaders,
+        rows: [["vid1", "2025-01-01", 0]],
+      },
     }));
 
     // When calling the service
@@ -134,7 +144,7 @@ describe("collectVideoDailyAnalyticsService success", () => {
       ytAnalytics: mock,
     });
 
-    // Then the missing metric is normalized to a numeric 0 (not NaN/null)
+    // Then the zero metric is preserved as a numeric 0
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -145,6 +155,129 @@ describe("collectVideoDailyAnalyticsService success", () => {
       views: 0,
     });
   });
+
+  test("normalizes null views values to 0", async () => {
+    // Given a row whose views cell is the API's null zero-value representation
+    const { mock } = makeMockYtAnalytics(() => ({
+      data: {
+        columnHeaders: videoDailyColumnHeaders,
+        rows: [["vid1", "2025-01-01", null]],
+      },
+    }));
+
+    // When calling the service
+    const r = await collectVideoDailyAnalyticsService(baseInput, {
+      sleep: noSleep,
+      ytAnalytics: mock,
+    });
+
+    // Then the API's null zero-value representation is normalized to numeric 0
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.metrics).toEqual([
+      { date: "2025-01-01", videoId: "vid1", views: 0 },
+    ]);
+  });
+
+  test("maps rows by columnHeaders when API column order changes", async () => {
+    // Given a response whose day and video columns are not in request order
+    const { mock } = makeMockYtAnalytics(() => ({
+      data: {
+        columnHeaders: [{ name: "day" }, { name: "video" }, { name: "views" }],
+        rows: [["2025-01-01", "vid1", 100]],
+      },
+    }));
+
+    // When calling the service
+    const r = await collectVideoDailyAnalyticsService(baseInput, {
+      sleep: noSleep,
+      ytAnalytics: mock,
+    });
+
+    // Then each output field uses the matching header, not the original index
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(r.value.metrics).toEqual([
+      { date: "2025-01-01", videoId: "vid1", views: 100 },
+    ]);
+  });
+});
+
+// --- malformed API response ------------------------------------------------
+
+describe("collectVideoDailyAnalyticsService malformed API response", () => {
+  test("returns io error when the views column header is missing", async () => {
+    // Given rows with columnHeaders that omit the required views metric
+    const { mock } = makeMockYtAnalytics(() => ({
+      data: {
+        columnHeaders: [{ name: "video" }, { name: "day" }],
+        rows: [["vid1", "2025-01-01", 100]],
+      },
+    }));
+
+    // When calling the service
+    const r = await collectVideoDailyAnalyticsService(baseInput, {
+      sleep: noSleep,
+      ytAnalytics: mock,
+    });
+
+    // Then the boundary returns a fail-fast mapping error
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
+    expect(r.error.message).toContain('missing the "views" column');
+  });
+
+  test("returns io error when rows are present without columnHeaders", async () => {
+    // Given rows but no columnHeaders to define the response contract
+    const { mock } = makeMockYtAnalytics(() => ({
+      data: { rows: [["vid1", "2025-01-01", 100]] },
+    }));
+
+    // When calling the service
+    const r = await collectVideoDailyAnalyticsService(baseInput, {
+      sleep: noSleep,
+      ytAnalytics: mock,
+    });
+
+    // Then the boundary returns a fail-fast mapping error
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
+    expect(r.error.message).toContain("response has rows but no columnHeaders");
+  });
+
+  test("returns io error when a row is missing the views cell", async () => {
+    // Given columnHeaders that require views but a row whose views cell is absent
+    const { mock } = makeMockYtAnalytics(() => ({
+      data: {
+        columnHeaders: videoDailyColumnHeaders,
+        rows: [["vid1", "2025-01-01"]],
+      },
+    }));
+
+    // When calling the service
+    const r = await collectVideoDailyAnalyticsService(baseInput, {
+      sleep: noSleep,
+      ytAnalytics: mock,
+    });
+
+    // Then the boundary returns a fail-fast mapping error
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("io");
+    expect(r.error.message).toContain('non-numeric "views" value');
+  });
 });
 
 // --- video filter ----------------------------------------------------------
@@ -153,7 +286,10 @@ describe("collectVideoDailyAnalyticsService with videoIds filter", () => {
   test("passes filters param when videoIds is provided", async () => {
     // Given a mock we can inspect for query params
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
-      data: { rows: [["vid1", "2025-01-01", 50]] },
+      data: {
+        columnHeaders: videoDailyColumnHeaders,
+        rows: [["vid1", "2025-01-01", 50]],
+      },
     }));
 
     // When calling with specific videoIds
@@ -175,7 +311,7 @@ describe("collectVideoDailyAnalyticsService with videoIds filter", () => {
   test("omits filters param when videoIds is an empty array", async () => {
     // Given an explicit empty videoIds (no video restriction intended)
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
-      data: { rows: [] },
+      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
 
     // When calling with an empty videoIds array
@@ -298,7 +434,12 @@ describe("collectVideoDailyAnalyticsService retry behavior", () => {
       if (attempt === 1) {
         throw gaxiosError("server error", { data: {}, status: 500 });
       }
-      return { data: { rows: [["vid1", "2025-01-01", 42]] } };
+      return {
+        data: {
+          columnHeaders: videoDailyColumnHeaders,
+          rows: [["vid1", "2025-01-01", 42]],
+        },
+      };
     });
 
     // When calling the service (with backoff stubbed out)
@@ -354,7 +495,7 @@ describe("collectVideoDailyAnalyticsService empty response", () => {
   test("returns ok with empty metrics when API returns no data rows", async () => {
     // Given a mock returning an empty rows array
     const { mock } = makeMockYtAnalytics(() => ({
-      data: { rows: [] },
+      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
 
     // When calling the service
@@ -398,7 +539,7 @@ describe("collectVideoDailyAnalyticsService input validation", () => {
   test("returns err with domain validation when input has extra keys", async () => {
     // Given a valid mock that would succeed if reached
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
-      data: { rows: [] },
+      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
 
     // When the input carries an unexpected key the `.strict()` schema rejects
@@ -425,7 +566,7 @@ describe("collectVideoDailyAnalyticsService input validation", () => {
   test("returns err with domain validation when date format is invalid", async () => {
     // Given a mock that would succeed if reached
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
-      data: { rows: [] },
+      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
 
     // When the startDate is not YYYY-MM-DD

--- a/packages/core/test/analytics-video-daily.test.ts
+++ b/packages/core/test/analytics-video-daily.test.ts
@@ -64,7 +64,6 @@ const videoDailyColumnHeaders = [
 
 describe("collectVideoDailyAnalyticsService success", () => {
   test("returns ok Result with one metrics record per API row", async () => {
-    // Given a mock returning sample Analytics API rows (video, day, views)
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: videoDailyColumnHeaders,
@@ -75,14 +74,10 @@ describe("collectVideoDailyAnalyticsService success", () => {
         ],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the result is ok with one metrics record per row, mapped by header
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -106,18 +101,13 @@ describe("collectVideoDailyAnalyticsService success", () => {
   });
 
   test("passes the fixed query contract for channel-wide collection", async () => {
-    // Given a mock we can inspect for the query parameters
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
       data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
-
-    // When collecting without a videoIds filter
     await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the Analytics query uses the video×day contract and no filter
     expect(queryCalls).toHaveLength(1);
     const params = queryCalls[0] as Record<string, unknown>;
     expect(params.dimensions).toBe("video,day");
@@ -130,21 +120,16 @@ describe("collectVideoDailyAnalyticsService success", () => {
   });
 
   test("preserves a numeric zero views value", async () => {
-    // Given a row whose views cell is the API's numeric zero value
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: videoDailyColumnHeaders,
         rows: [["vid1", "2025-01-01", 0]],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the zero metric is preserved as a numeric 0
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -157,21 +142,16 @@ describe("collectVideoDailyAnalyticsService success", () => {
   });
 
   test("normalizes null views values to 0", async () => {
-    // Given a row whose views cell is the API's null zero-value representation
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: videoDailyColumnHeaders,
         rows: [["vid1", "2025-01-01", null]],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the API's null zero-value representation is normalized to numeric 0
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -182,21 +162,16 @@ describe("collectVideoDailyAnalyticsService success", () => {
   });
 
   test("maps rows by columnHeaders when API column order changes", async () => {
-    // Given a response whose day and video columns are not in request order
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: [{ name: "day" }, { name: "video" }, { name: "views" }],
         rows: [["2025-01-01", "vid1", 100]],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then each output field uses the matching header, not the original index
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -211,21 +186,16 @@ describe("collectVideoDailyAnalyticsService success", () => {
 
 describe("collectVideoDailyAnalyticsService malformed API response", () => {
   test("returns io error when the views column header is missing", async () => {
-    // Given rows with columnHeaders that omit the required views metric
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: [{ name: "video" }, { name: "day" }],
         rows: [["vid1", "2025-01-01", 100]],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the boundary returns a fail-fast mapping error
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -235,18 +205,13 @@ describe("collectVideoDailyAnalyticsService malformed API response", () => {
   });
 
   test("returns io error when rows are present without columnHeaders", async () => {
-    // Given rows but no columnHeaders to define the response contract
     const { mock } = makeMockYtAnalytics(() => ({
       data: { rows: [["vid1", "2025-01-01", 100]] },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the boundary returns a fail-fast mapping error
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -256,21 +221,16 @@ describe("collectVideoDailyAnalyticsService malformed API response", () => {
   });
 
   test("returns io error when a row is missing the views cell", async () => {
-    // Given columnHeaders that require views but a row whose views cell is absent
     const { mock } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: videoDailyColumnHeaders,
         rows: [["vid1", "2025-01-01"]],
       },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the boundary returns a fail-fast mapping error
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -284,21 +244,16 @@ describe("collectVideoDailyAnalyticsService malformed API response", () => {
 
 describe("collectVideoDailyAnalyticsService with videoIds filter", () => {
   test("passes filters param when videoIds is provided", async () => {
-    // Given a mock we can inspect for query params
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
       data: {
         columnHeaders: videoDailyColumnHeaders,
         rows: [["vid1", "2025-01-01", 50]],
       },
     }));
-
-    // When calling with specific videoIds
     const r = await collectVideoDailyAnalyticsService(
       { ...baseInput, videoIds: ["vid1", "vid2"] },
       { sleep: noSleep, ytAnalytics: mock }
     );
-
-    // Then it succeeds and the filters param was passed correctly
     expect(r.ok).toBe(true);
     expect(queryCalls).toHaveLength(1);
     const params = queryCalls[0] as Record<string, unknown>;
@@ -309,18 +264,13 @@ describe("collectVideoDailyAnalyticsService with videoIds filter", () => {
   });
 
   test("omits filters param when videoIds is an empty array", async () => {
-    // Given an explicit empty videoIds (no video restriction intended)
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
       data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
-
-    // When calling with an empty videoIds array
     const r = await collectVideoDailyAnalyticsService(
       { ...baseInput, videoIds: [] },
       { sleep: noSleep, ytAnalytics: mock }
     );
-
-    // Then no filters param is sent — an empty list is not "video==" with no ids
     expect(r.ok).toBe(true);
     const params = queryCalls[0] as Record<string, unknown>;
     expect(params.filters).toBeUndefined();
@@ -331,18 +281,13 @@ describe("collectVideoDailyAnalyticsService with videoIds filter", () => {
 
 describe("collectVideoDailyAnalyticsService quota error", () => {
   test("returns err with domain quota on QuotaExhaustedError", async () => {
-    // Given a mock that throws a QuotaExhaustedError (not retried per ADR-0003)
     const { mock } = makeMockYtAnalytics(() => {
       throw new QuotaExhaustedError("quota exceeded", 3600);
     });
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then it returns an err with domain "quota" — never throws
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -351,34 +296,24 @@ describe("collectVideoDailyAnalyticsService quota error", () => {
   });
 
   test("does not retry a quota error (single API call)", async () => {
-    // Given a quota error on every attempt
     const { mock, queryCalls } = makeMockYtAnalytics(() => {
       throw new QuotaExhaustedError("quota exceeded", 3600);
     });
-
-    // When calling the service
     await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the API was called exactly once — quota is returned, not retried
     expect(queryCalls).toHaveLength(1);
   });
 
   test("surfaces retryAfterSeconds on the quota ServiceError", async () => {
-    // Given a quota error carrying a Retry-After hint
     const { mock } = makeMockYtAnalytics(() => {
       throw new QuotaExhaustedError("quota exceeded", 1800);
     });
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the quota arm carries the resumable retry hint through the boundary
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -391,9 +326,6 @@ describe("collectVideoDailyAnalyticsService quota error", () => {
   });
 
   test("converts a raw gaxios 429 into a quota ServiceError without retrying", async () => {
-    // Given a realistic Gaxios-shaped 429 (status + Retry-After header), NOT a
-    // pre-built QuotaExhaustedError — this exercises fromGaxiosError +
-    // parseRetryAfterSeconds, the real production conversion chain.
     const { mock, queryCalls } = makeMockYtAnalytics(() => {
       throw gaxiosError("rate limit exceeded", {
         data: { error: { errors: [{ reason: "quotaExceeded" }] } },
@@ -401,15 +333,10 @@ describe("collectVideoDailyAnalyticsService quota error", () => {
         status: 429,
       });
     });
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the 429 maps to domain "quota" with the header's retry hint, and the
-    // quota arm is never retried (single API call)
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -427,7 +354,6 @@ describe("collectVideoDailyAnalyticsService quota error", () => {
 
 describe("collectVideoDailyAnalyticsService retry behavior", () => {
   test("retries a transient 5xx and succeeds on the next attempt", async () => {
-    // Given a mock that fails once with a 500 then returns data
     let attempt = 0;
     const { mock, queryCalls } = makeMockYtAnalytics(() => {
       attempt += 1;
@@ -441,14 +367,10 @@ describe("collectVideoDailyAnalyticsService retry behavior", () => {
         },
       };
     });
-
-    // When calling the service (with backoff stubbed out)
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the 5xx is retried and the second attempt's data is returned
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -460,22 +382,16 @@ describe("collectVideoDailyAnalyticsService retry behavior", () => {
   });
 
   test("does not retry a permanent 4xx and returns an api ServiceError", async () => {
-    // Given a mock that always fails with a 403 (forbidden — permanent)
     const { mock, queryCalls } = makeMockYtAnalytics(() => {
       throw gaxiosError("forbidden", {
         data: { error: { errors: [{ reason: "forbidden" }] } },
         status: 403,
       });
     });
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then it maps to domain "api" with the 403 status + reason, and is not
-    // retried (single API call)
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected failure");
@@ -493,18 +409,13 @@ describe("collectVideoDailyAnalyticsService retry behavior", () => {
 
 describe("collectVideoDailyAnalyticsService empty response", () => {
   test("returns ok with empty metrics when API returns no data rows", async () => {
-    // Given a mock returning an empty rows array
     const { mock } = makeMockYtAnalytics(() => ({
-      data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
+      data: { rows: [] },
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then it succeeds with an empty metrics array
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -513,18 +424,13 @@ describe("collectVideoDailyAnalyticsService empty response", () => {
   });
 
   test("returns ok with empty metrics when the response has no rows field", async () => {
-    // Given a mock returning a response without a rows field at all
     const { mock } = makeMockYtAnalytics(() => ({
       data: {},
     }));
-
-    // When calling the service
     const r = await collectVideoDailyAnalyticsService(baseInput, {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then it gracefully returns empty metrics
     expect(r.ok).toBe(true);
     if (!r.ok) {
       throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
@@ -537,12 +443,9 @@ describe("collectVideoDailyAnalyticsService empty response", () => {
 
 describe("collectVideoDailyAnalyticsService input validation", () => {
   test("returns err with domain validation when input has extra keys", async () => {
-    // Given a valid mock that would succeed if reached
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
       data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
-
-    // When the input carries an unexpected key the `.strict()` schema rejects
     const malformed = {
       ...baseInput,
       unexpected: true,
@@ -552,9 +455,6 @@ describe("collectVideoDailyAnalyticsService input validation", () => {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then the boundary parses first: a validation ServiceError, and the API
-    // is never called
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected validation failure");
@@ -564,12 +464,9 @@ describe("collectVideoDailyAnalyticsService input validation", () => {
   });
 
   test("returns err with domain validation when date format is invalid", async () => {
-    // Given a mock that would succeed if reached
     const { mock, queryCalls } = makeMockYtAnalytics(() => ({
       data: { columnHeaders: videoDailyColumnHeaders, rows: [] },
     }));
-
-    // When the startDate is not YYYY-MM-DD
     const badInput = {
       channelId: "UC_test",
       endDate: "2025-01-31",
@@ -580,8 +477,6 @@ describe("collectVideoDailyAnalyticsService input validation", () => {
       sleep: noSleep,
       ytAnalytics: mock,
     });
-
-    // Then it returns a validation error without calling the API
     expect(r.ok).toBe(false);
     if (r.ok) {
       throw new Error("expected validation failure");


### PR DESCRIPTION
## Summary

# Plan 006: video-daily のハードコード列 index をヘッダー lookup に統一する

> **Executor instructions**: Follow this plan step by step. Run every
> verification command and confirm the expected result before moving to the
> next step. If anything in the "STOP conditions" section occurs, stop and
> report — do not improvise. When done, update the status row for this plan
> in `plans/README.md` — unless a reviewer dispatched you and told you they
> maintain the index.
>
> **Drift check (run first)**: `git diff --stat 62fd1f3..HEAD -- packages/core/src/analytics/video-daily/`
> If any in-scope file changed since this plan was written, compare the
> "Current state" excerpts against the live code before proceeding; on a
> mismatch, treat it as a STOP condition.

## Status

- **Priority**: P1
- **Effort**: M
- **Risk**: LOW
- **Depends on**: plans/005-extract-analytics-column-helpers.md
- **Category**: correctness
- **Planned at**: commit `62fd1f3`, 2026-06-19

## Why this matters

video-daily サービスだけがハードコード列 index（`VIDEO_COLUMN = 0`, `DAY_COLUMN = 1`, `VIEWS_COLUMN = 2`）を使っており、他 4 サービスはすべて `resolveColumnIndex` でヘッダー名から列位置を解決している。API が列順を変更した場合、video-daily のみサイレントにデータが壊れる。また `String(row[DAY_COLUMN])` は `undefined` を `"undefined"` 文字列に変換するため、列不足時のエラーが検出されない。

## Current state

- `packages/core/src/analytics/video-daily/service.ts:47-51`:
  ```typescript
  // API はこの dimension/metric 組では常にこの順で返す
  const VIDEO_COLUMN = 0;
  const DAY_COLUMN = 1;
  const VIEWS_COLUMN = 2;
  ```
- `packages/core/src/analytics/video-daily/service.ts:78-90` (`mapRows`):
  ```typescript
  const mapRows = (rows: QueryResponse["rows"]): VideoDailyRecord[] => {
    if (!rows) { return []; }
    return rows.map((row) => ({
      date: String(row[DAY_COLUMN]),
      videoId: String(row[VIDEO_COLUMN]),
      views: Number(row[VIEWS_COLUMN] ?? 0),
    }));
  };
  ```
- 他サービス（audience, traffic-source, channel）は Plan 005 で抽出した `column-helpers.ts` の `resolveColumnIndex` + `readStringCell` + `readNumberCell` を使用する。

## Commands you will need

| Purpose   | Command                                                    | Expected on success |
|-----------|------------------------------------------------------------|---------------------|
| Typecheck | `bun run typecheck`                                        | exit 0              |
| Tests     | `bun test packages/core/test/analytics-video-daily.test.ts` | all pass            |
| Lint      | `bun run lint`                                             | exit 0              |

## Scope

**In scope**:
- `packages/core/src/analytics/video-daily/service.ts`
- `packages/core/test/analytics-video-daily.test.ts`

**Out of scope**:
- `packages/core/src/analytics/video-daily/schema.ts` — スキーマ変更不要
- 他の analytics サービス — Plan 005 で対応済み

## Git workflow

- Branch: `advisor/006-video-daily-header-lookup`
- Commit style: `fix(analytics): video-daily のハードコード列 index をヘッダー lookup に移行`
- Do NOT push or open a PR unless the operator instructed it.

## Steps

### Step 1: mapRows を columnHeaders ベースに書き換え

`mapRows` のシグネチャを `(data: QueryResponse)` に変更し、Plan 005 の `column-helpers.ts` から `resolveColumnIndex`, `requireHeaders`, `readStringCell`, `readNumberCell` を import する。ハードコード定数 `VIDEO_COLUMN`, `DAY_COLUMN`, `VIEWS_COLUMN` を削除。

変更後のイメージ:
```typescript
import {
  readNumberCell,
  readStringCell,
  requireHeaders,
  resolveColumnIndex,
} from "../column-helpers.ts";

const mapRows = (data: QueryResponse): VideoDailyRecord[] => {
  if (!data.rows) { return []; }
  const headers = requireHeaders(data, QUERY_CONTEXT);
  const videoIndex = resolveColumnIndex(headers, "video", QUERY_CONTEXT);
  const dayIndex = resolveColumnIndex(headers, "day", QUERY_CONTEXT);
  const viewsIndex = resolveColumnIndex(headers, "views", QUERY_CONTEXT);
  return data.rows.map((row) => ({
    date: readStringCell(row, dayIndex, "day", QUERY_CONTEXT),
    videoId: readStringCell(row, videoIndex, "video", QUERY_CONTEXT),
    views: readNumberCell(row, viewsIndex, "views", QUERY_CONTEXT),
  }));
};
```

views セルの `?? 0` フォールバックは `readNumberCell` の型チェックに置き換える（`undefined` は `Number.isFinite` で弾かれる）。0 視聴の日のセル値が API 上 `0`（数値）であるか `null` であるかをテストで確認し、`null` なら `readNumberCell` の前に明示的なフォールバックを入れる。

呼び出し元 `collectVideoDailyAnalyticsService` の `mapRows(data.rows)` を `mapRows(data)` に変更。

**Verify**: `bun run typecheck` → exit 0

### Step 2: テストに列順変更・列不足のケースを追加

`analytics-video-daily.test.ts` に以下のテストケースを追加:

1. **列順が入れ替わったレスポンス**: `columnHeaders` を `[day, video, views]` 順で返す mock → 正しくマッピングされることを確認
2. **列が不足したレスポンス**: `columnHeaders` に `views` が含まれない mock → エラーが throw されることを確認
3. **columnHeaders 無しのレスポンス**: `rows` はあるが `columnHeaders` がない → エラーが throw されることを確認

既存テストのパターン（`analytics-video-daily.test.ts` の `fakeYouTubeAnalytics` ヘルパー）を踏襲すること。

**Verify**: `bun test packages/core/test/analytics-video-daily.test.ts` → all pass, 新規テスト 3 件含む

### Step 3: 全体検証

**Verify**: `bun run typecheck && bun test packages/core/test/analytics-*.test.ts && bun run lint` → all pass

## Test plan

- 新規テスト 3 件を `analytics-video-daily.test.ts` に追加（Step 2 参照）
- 既存テストパターン: `analytics-video-daily.test.ts` の `describe("collectVideoDailyAnalyticsService")` ブロックをモデルにする
- `bun test packages/core/test/analytics-video-daily.test.ts` → all pass

## Done criteria

- [ ] `bun run typecheck` exits 0
- [ ] `bun test packages/core/test/analytics-video-daily.test.ts` all pass（新規 3 件含む）
- [ ] `rg "VIDEO_COLUMN|DAY_COLUMN|VIEWS_COLUMN" packages/core/src/analytics/video-daily/service.ts` returns no matches
- [ ] `rg "resolveColumnIndex" packages/core/src/analytics/video-daily/service.ts` returns matches（ヘッダー lookup を使用）
- [ ] No files outside the in-scope list are modified

## STOP conditions

- Plan 005 が未完了（`column-helpers.ts` が存在しない）
- 0 視聴の日の API レスポンスで views セルが `null` であり、`readNumberCell` のバリデーションに引っかかる場合 → STOP して報告（`null` フォールバック追加が必要）
- テストで mock API レスポンスの `columnHeaders` フォーマットが不明

## Maintenance notes

- YouTube Analytics API v2 の `columnHeaders` フォーマットは `{ name, columnType, dataType }` オブジェクト配列。dimension 名は小文字（`"video"`, `"day"`）、metric 名も小文字（`"views"`）
- 将来 metrics を追加する場合（例: `estimatedMinutesWatched`）、`resolveColumnIndex` で追加の列を解決するだけでよい

## Execution Report

Workflow `default` completed successfully.

Closes #1114