### PR TITLE
[#1111] issue-1111-refactor-config-loa

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -16,13 +16,17 @@ import { z } from "zod";
 import { Engagement } from "./engagement.ts";
 import { Identity } from "./identity.ts";
 import { Integrations } from "./integrations.ts";
-import { isPlainObject } from "./internal.ts";
+import { addIssues, isPlainObject } from "./internal.ts";
 import { Localizations, localizationsAbsent } from "./localizations.ts";
 import { Publishing } from "./publishing.ts";
 
 const LOCALIZATIONS_KEY = "localizations";
 
-const parseLocalizations = (locRaw: unknown, fallbackLanguage: string) => {
+const parseLocalizations = (
+  locRaw: unknown,
+  fallbackLanguage: string,
+  ctx: z.RefinementCtx
+) => {
   if (locRaw === undefined) {
     return localizationsAbsent(fallbackLanguage);
   }
@@ -32,44 +36,64 @@ const parseLocalizations = (locRaw: unknown, fallbackLanguage: string) => {
     return localizations.data;
   }
 
-  throw new z.ZodError(
-    localizations.error.issues.map((issue) => ({
-      ...issue,
-      path: [LOCALIZATIONS_KEY, ...issue.path],
-    }))
-  );
+  addIssues(ctx, localizations.error.issues, [LOCALIZATIONS_KEY]);
+  return z.NEVER;
 };
 
-const assemble = (merged: unknown) => {
-  const identity = Identity.parse(merged);
-  const publishing = Publishing.parse(merged);
-  const engagement = Engagement.parse(merged);
+const assemble = (merged: unknown, ctx: z.RefinementCtx) => {
+  const identity = Identity.safeParse(merged);
+  const publishing = Publishing.safeParse(merged);
+  const engagement = Engagement.safeParse(merged);
+  const integrations = Integrations.safeParse(merged);
+
+  if (!identity.success) {
+    addIssues(ctx, identity.error.issues);
+  }
+  if (!publishing.success) {
+    addIssues(ctx, publishing.error.issues);
+  }
+  if (!engagement.success) {
+    addIssues(ctx, engagement.error.issues);
+  }
+  if (!integrations.success) {
+    addIssues(ctx, integrations.error.issues);
+  }
+  if (
+    !identity.success ||
+    !publishing.success ||
+    !engagement.success ||
+    !integrations.success
+  ) {
+    return z.NEVER;
+  }
+
   const locRaw = isPlainObject(merged) ? merged[LOCALIZATIONS_KEY] : undefined;
   const localizations = parseLocalizations(
     locRaw,
-    publishing.youtube.api.language
+    publishing.data.youtube.api.language,
+    ctx
   );
 
   // tags.channelName は content 単体では決まらないため meta（identity）から注入する。
   const content = {
-    ...publishing.content,
+    ...publishing.data.content,
     tags: {
-      ...publishing.content.tags,
-      channelName: identity.meta.channelName,
+      ...publishing.data.content.tags,
+      channelName: identity.data.meta.channelName,
     },
   };
   return {
-    engagement: { ...engagement, localizations },
-    identity,
-    integrations: Integrations.parse(merged),
-    publishing: { ...publishing, content },
+    engagement: { ...engagement.data, localizations },
+    identity: identity.data,
+    integrations: integrations.data,
+    publishing: { ...publishing.data, content },
   };
 };
 
 /** merged config を 4 バケット ChannelConfig へ組み立てる schema。 */
 export const ChannelConfigSchema = z
   .unknown()
-  .transform(assemble)
+  .transform((merged, ctx) => assemble(merged, ctx))
   .superRefine((config, ctx) => {
     // title.theme_scenes のキー ⊆ tags.themes のキー
     const themeKeys = new Set(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -5,24 +5,51 @@
 // バケット構成（Issue #827）:
 //   identity     → { meta }
 //   publishing   → { audio, content, shorts, workflow, youtube }
-//   engagement   → { comments, pinnedComment, playlists }（localizations は loader 注入）
+//   engagement   → { comments, pinnedComment, playlists, localizations }
 //   integrations → { analytics, distrokid }
 //
 // content.tags.channelName は identity.meta 由来のセクション横断値のため、合成ルートで注入する。
-// cross-section 検証（title.theme_scenes ⊆ tags.themes）は superRefine で行う。
-// localizations は別ファイル（`config/localizations.json`）由来のため loader が engagement へ合成する。
+// cross-section / cross-file 検証は superRefine で行う。
 
 import { z } from "zod";
 
 import { Engagement } from "./engagement.ts";
 import { Identity } from "./identity.ts";
 import { Integrations } from "./integrations.ts";
-import type { Localizations } from "./localizations.ts";
+import { isPlainObject } from "./internal.ts";
+import { Localizations, localizationsAbsent } from "./localizations.ts";
 import { Publishing } from "./publishing.ts";
+
+const LOCALIZATIONS_KEY = "localizations";
+
+const parseLocalizations = (locRaw: unknown, fallbackLanguage: string) => {
+  if (locRaw === undefined) {
+    return localizationsAbsent(fallbackLanguage);
+  }
+
+  const localizations = Localizations.safeParse(locRaw);
+  if (localizations.success) {
+    return localizations.data;
+  }
+
+  throw new z.ZodError(
+    localizations.error.issues.map((issue) => ({
+      ...issue,
+      path: [LOCALIZATIONS_KEY, ...issue.path],
+    }))
+  );
+};
 
 const assemble = (merged: unknown) => {
   const identity = Identity.parse(merged);
   const publishing = Publishing.parse(merged);
+  const engagement = Engagement.parse(merged);
+  const locRaw = isPlainObject(merged) ? merged[LOCALIZATIONS_KEY] : undefined;
+  const localizations = parseLocalizations(
+    locRaw,
+    publishing.youtube.api.language
+  );
+
   // tags.channelName は content 単体では決まらないため meta（identity）から注入する。
   const content = {
     ...publishing.content,
@@ -32,14 +59,14 @@ const assemble = (merged: unknown) => {
     },
   };
   return {
-    engagement: Engagement.parse(merged),
+    engagement: { ...engagement, localizations },
     identity,
     integrations: Integrations.parse(merged),
     publishing: { ...publishing, content },
   };
 };
 
-/** merged config を 4 バケット ChannelConfig（localizations を除く）へ組み立てる schema。 */
+/** merged config を 4 バケット ChannelConfig へ組み立てる schema。 */
 export const ChannelConfigSchema = z
   .unknown()
   .transform(assemble)
@@ -59,17 +86,23 @@ export const ChannelConfigSchema = z
         message: `title.theme_scenes に tags.themes で定義されていないテーマキーがあります: ${JSON.stringify(unknownScenes)}`,
       });
     }
+
+    if (config.engagement.localizations.exists) {
+      const supported = new Set(
+        config.engagement.localizations.supportedLanguages
+      );
+      const unknownLangs =
+        config.publishing.youtube.contentModel.languages.filter(
+          (lang) => !supported.has(lang)
+        );
+      if (unknownLangs.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: `content_model.languages に localizations.supported_languages へ未登録の言語があります: ${JSON.stringify(unknownLangs)}`,
+        });
+      }
+    }
   });
 
-type Assembled = z.infer<typeof ChannelConfigSchema>;
-
-/**
- * チャンネル設定の合成ルート（4 バケット名前空間でアクセスする）。
- * localizations は loader が engagement バケットへ注入するため、合成スキーマの infer に
- * 後付けする（schema 単体では表現できない cross-file 値のため intersection で合成する）。
- */
-export type ChannelConfig = Omit<Assembled, "engagement"> & {
-  readonly engagement: Assembled["engagement"] & {
-    readonly localizations: Localizations;
-  };
-};
+/** チャンネル設定の合成ルート（4 バケット名前空間でアクセスする）。 */
+export type ChannelConfig = z.infer<typeof ChannelConfigSchema>;

--- a/packages/core/src/config/engagement.ts
+++ b/packages/core/src/config/engagement.ts
@@ -5,12 +5,13 @@
 import { z } from "zod";
 
 import { Comments } from "./comments.ts";
+import { parseWithIssues } from "./internal.ts";
 import { PinnedComment } from "./pinned-comment.ts";
 import { Playlists } from "./playlists.ts";
 
 /** engagement バケット: merged から視聴者接点セクションを取り出して束ねる。 */
-export const Engagement = z.unknown().transform((merged) => ({
-  comments: Comments.parse(merged),
-  pinnedComment: PinnedComment.parse(merged),
-  playlists: Playlists.parse(merged),
+export const Engagement = z.unknown().transform((merged, ctx) => ({
+  comments: parseWithIssues(Comments, merged, ctx),
+  pinnedComment: parseWithIssues(PinnedComment, merged, ctx),
+  playlists: parseWithIssues(Playlists, merged, ctx),
 }));

--- a/packages/core/src/config/engagement.ts
+++ b/packages/core/src/config/engagement.ts
@@ -1,7 +1,6 @@
 // engagement バケット — 視聴者接点（comments / pinnedComment / playlists / localizations）。
 //
-// localizations は `config/channel/` の外（`config/localizations.json`）由来のため、ここでは
-// 束ねず loader が読み込んで engagement バケットへ注入する（Issue #827）。
+// localizations は sidecar 由来の値として ChannelConfigSchema の assemble で engagement に合成する。
 
 import { z } from "zod";
 

--- a/packages/core/src/config/identity.ts
+++ b/packages/core/src/config/identity.ts
@@ -3,9 +3,10 @@
 
 import { z } from "zod";
 
+import { parseWithIssues } from "./internal.ts";
 import { ChannelMeta } from "./meta.ts";
 
 /** identity バケット: merged から meta セクションを取り出して束ねる。 */
-export const Identity = z.unknown().transform((merged) => ({
-  meta: ChannelMeta.parse(merged),
+export const Identity = z.unknown().transform((merged, ctx) => ({
+  meta: parseWithIssues(ChannelMeta, merged, ctx),
 }));

--- a/packages/core/src/config/integrations.ts
+++ b/packages/core/src/config/integrations.ts
@@ -5,9 +5,10 @@ import { z } from "zod";
 
 import { Analytics } from "./analytics.ts";
 import { Distrokid } from "./distrokid.ts";
+import { parseWithIssues } from "./internal.ts";
 
 /** integrations バケット: merged から外部連携セクションを取り出して束ねる。 */
-export const Integrations = z.unknown().transform((merged) => ({
-  analytics: Analytics.parse(merged),
-  distrokid: Distrokid.parse(merged),
+export const Integrations = z.unknown().transform((merged, ctx) => ({
+  analytics: parseWithIssues(Analytics, merged, ctx),
+  distrokid: parseWithIssues(Distrokid, merged, ctx),
 }));

--- a/packages/core/src/config/internal.ts
+++ b/packages/core/src/config/internal.ts
@@ -2,8 +2,36 @@
 // Python 版が `isinstance(x, dict)` で行っていた object 判定を、配列を object 扱いしない
 // 厳密な形で TS へ移植する。
 
+import { z } from "zod";
+
 /** 配列を除外した plain object 判定（Python の `isinstance(x, dict)` 相当）。 */
 export const isPlainObject = (
   value: unknown
 ): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const addIssues = (
+  ctx: z.RefinementCtx,
+  issues: z.ZodIssue[],
+  pathPrefix: z.ZodIssue["path"] = []
+): void => {
+  for (const issue of issues) {
+    ctx.addIssue({
+      ...issue,
+      path: [...pathPrefix, ...issue.path],
+    });
+  }
+};
+
+export const parseWithIssues = <Output>(
+  schema: z.ZodType<Output>,
+  input: unknown,
+  ctx: z.RefinementCtx
+): Output => {
+  const result = schema.safeParse(input);
+  if (result.success) {
+    return result.data;
+  }
+  addIssues(ctx, result.error.issues);
+  return z.NEVER;
+};

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -127,15 +127,20 @@ const loadLocalizationsRaw = (channelRoot: string): unknown | undefined => {
   }
 };
 
-const mergeLocalizations = (
-  merged: Record<string, unknown>,
-  localizationsRaw: unknown | undefined
-): Record<string, unknown> => {
+const assertNoChannelLocalizations = (
+  merged: Record<string, unknown>
+): void => {
   if (LOCALIZATIONS_KEY in merged) {
     throw new Error(
       `config: '${LOCALIZATIONS_KEY}' キーは config/channel/*.json ではなく config/${LOCALIZATIONS_FILENAME} に配置してください`
     );
   }
+};
+
+const mergeLocalizations = (
+  merged: Record<string, unknown>,
+  localizationsRaw: unknown | undefined
+): Record<string, unknown> => {
   if (localizationsRaw === undefined) {
     return merged;
   }
@@ -167,8 +172,10 @@ const build = (channelRoot: string): ChannelConfig => {
     );
   }
 
+  const channelConfig = loadAndMerge(files);
+  assertNoChannelLocalizations(channelConfig);
   const merged = mergeLocalizations(
-    loadAndMerge(files),
+    channelConfig,
     loadLocalizationsRaw(channelRoot)
   );
   try {

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,5 +1,5 @@
 // `config/channel/*.json` を glob ロード・バリデーションし `ChannelConfig` を組み立てる。
-// singleton + reset + channelDir + cross-file 検証（localizations 別ファイル）を担う。
+// singleton + reset + channelDir + localizations sidecar の pre-merge を担う。
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
@@ -9,22 +9,39 @@ import { z } from "zod";
 import { ChannelConfigSchema } from "./config.ts";
 import type { ChannelConfig } from "./config.ts";
 import { isPlainObject } from "./internal.ts";
-import { Localizations, localizationsAbsent } from "./localizations.ts";
 
 let instance: ChannelConfig | null = null;
 let channelDirCache: string | null = null;
+
+const LOCALIZATIONS_FILENAME = "localizations.json";
+const LOCALIZATIONS_KEY = "localizations";
 
 const isDir = (path: string): boolean =>
   existsSync(path) && statSync(path).isDirectory();
 
 // zod の issue 列を `config:` prefix の 1 行メッセージへ整形する（path. + message）。
+const formatIssuePath = (path: z.ZodIssue["path"]): string | null => {
+  if (path.length === 0) {
+    return null;
+  }
+
+  const [first, ...rest] = path;
+  if (first === LOCALIZATIONS_KEY) {
+    if (rest.length === 0) {
+      return LOCALIZATIONS_FILENAME;
+    }
+    return `${LOCALIZATIONS_FILENAME}: ${rest.map(String).join(".")}`;
+  }
+
+  return path.map(String).join(".");
+};
+
 const formatZodError = (error: z.ZodError): string =>
   error.issues
-    .map((issue) =>
-      issue.path.length > 0
-        ? `${issue.path.join(".")}: ${issue.message}`
-        : issue.message
-    )
+    .map((issue) => {
+      const path = formatIssuePath(issue.path);
+      return path === null ? issue.message : `${path}: ${issue.message}`;
+    })
     .join("; ");
 
 // CHANNEL_DIR 環境変数を優先し、未設定なら CWD 祖先を辿って config/channel/ を探す。
@@ -94,35 +111,35 @@ const loadAndMerge = (files: string[]): Record<string, unknown> => {
   return merged;
 };
 
-// localizations.json（config/ 直下・config/channel/ の外）を読み込む。
-const loadLocalizations = (
-  channelRoot: string,
-  fallbackLanguage: string
-): Localizations => {
-  const locPath = join(channelRoot, "config", "localizations.json");
+// localizations.json（config/ 直下・config/channel/ の外）を raw のまま読み込む。
+const loadLocalizationsRaw = (channelRoot: string): unknown | undefined => {
+  const locPath = join(channelRoot, "config", LOCALIZATIONS_FILENAME);
   if (!existsSync(locPath)) {
-    return localizationsAbsent(fallbackLanguage);
+    return undefined;
   }
-  let data: unknown;
   try {
-    data = JSON.parse(readFileSync(locPath, "utf-8"));
+    return JSON.parse(readFileSync(locPath, "utf-8"));
   } catch (error) {
     throw new Error(
-      `config: localizations.json の JSON パース失敗: ${locPath}: ${String(error)}`,
+      `config: ${LOCALIZATIONS_FILENAME} の JSON パース失敗: ${locPath}: ${String(error)}`,
       { cause: error }
     );
   }
-  try {
-    return Localizations.parse(data);
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new TypeError(
-        `config: localizations.json: ${formatZodError(error)}`,
-        { cause: error }
-      );
-    }
-    throw error;
+};
+
+const mergeLocalizations = (
+  merged: Record<string, unknown>,
+  localizationsRaw: unknown | undefined
+): Record<string, unknown> => {
+  if (LOCALIZATIONS_KEY in merged) {
+    throw new Error(
+      `config: '${LOCALIZATIONS_KEY}' キーは config/channel/*.json ではなく config/${LOCALIZATIONS_FILENAME} に配置してください`
+    );
   }
+  if (localizationsRaw === undefined) {
+    return merged;
+  }
+  return { ...merged, [LOCALIZATIONS_KEY]: localizationsRaw };
 };
 
 const build = (channelRoot: string): ChannelConfig => {
@@ -150,41 +167,18 @@ const build = (channelRoot: string): ChannelConfig => {
     );
   }
 
-  const merged = loadAndMerge(files);
-
-  let parsed: z.infer<typeof ChannelConfigSchema>;
+  const merged = mergeLocalizations(
+    loadAndMerge(files),
+    loadLocalizationsRaw(channelRoot)
+  );
   try {
-    parsed = ChannelConfigSchema.parse(merged);
+    return ChannelConfigSchema.parse(merged);
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new TypeError(`config: ${formatZodError(error)}`, { cause: error });
     }
     throw error;
   }
-
-  const localizations = loadLocalizations(
-    channelRoot,
-    parsed.publishing.youtube.api.language
-  );
-
-  // cross-file: content_model.languages ⊆ localizations.supported_languages（存在時）。
-  if (localizations.exists) {
-    const unknownLangs =
-      parsed.publishing.youtube.contentModel.languages.filter(
-        (lang) => !localizations.supportedLanguages.includes(lang)
-      );
-    if (unknownLangs.length > 0) {
-      throw new Error(
-        `config: content_model.languages に localizations.supported_languages へ未登録の言語があります: ${JSON.stringify(unknownLangs)}`
-      );
-    }
-  }
-
-  // localizations は engagement バケットへ注入する（トップレベルには置かない、#827）。
-  return {
-    ...parsed,
-    engagement: { ...parsed.engagement, localizations },
-  };
 };
 
 /** `config/channel/*.json` を glob ロードし `ChannelConfig` を返す（シングルトン）。 */

--- a/packages/core/src/config/publishing.ts
+++ b/packages/core/src/config/publishing.ts
@@ -8,15 +8,16 @@ import { z } from "zod";
 
 import { Audio } from "./audio.ts";
 import { Content } from "./content.ts";
+import { parseWithIssues } from "./internal.ts";
 import { Shorts } from "./shorts.ts";
 import { Workflow } from "./workflow.ts";
 import { Youtube } from "./youtube.ts";
 
 /** publishing バケット: merged から出力系セクションを取り出して束ねる。 */
-export const Publishing = z.unknown().transform((merged) => ({
-  audio: Audio.parse(merged),
-  content: Content.parse(merged),
-  shorts: Shorts.parse(merged),
-  workflow: Workflow.parse(merged),
-  youtube: Youtube.parse(merged),
+export const Publishing = z.unknown().transform((merged, ctx) => ({
+  audio: parseWithIssues(Audio, merged, ctx),
+  content: parseWithIssues(Content, merged, ctx),
+  shorts: parseWithIssues(Shorts, merged, ctx),
+  workflow: parseWithIssues(Workflow, merged, ctx),
+  youtube: parseWithIssues(Youtube, merged, ctx),
 }));

--- a/packages/core/test/config-buckets.test.ts
+++ b/packages/core/test/config-buckets.test.ts
@@ -120,8 +120,8 @@ describe("ChannelConfig — bucket membership", () => {
   });
 
   test("engagement carries comments/pinnedComment/playlists/localizations", () => {
-    // localizations is loader-injected (it lives in config/localizations.json,
-    // outside config/channel/) but is grouped under the engagement bucket.
+    // localizations is assembled from the config/localizations.json sidecar
+    // and grouped under the engagement bucket.
     const config = load(minimalSections());
     expect(Object.keys(config.engagement).toSorted()).toEqual([
       "comments",

--- a/packages/core/test/config-loader.test.ts
+++ b/packages/core/test/config-loader.test.ts
@@ -14,7 +14,9 @@ import { join, resolve } from "node:path";
 // exercises the core `exports` map. A missing/broken subpath export fails
 // resolution here, not in tsc.
 import { channelDir, loadConfig, reset } from "@youtube-automation/core/config";
+import { z } from "zod";
 
+import { ChannelConfigSchema } from "../src/config/config.ts";
 import {
   cleanupChannels,
   minimalSections,
@@ -24,6 +26,7 @@ import {
   setupEmptyChannel,
   writeJson,
 } from "./config-fixtures.ts";
+import type { Sections } from "./config-fixtures.ts";
 
 beforeAll(saveChannelDirEnv);
 afterAll(restoreChannelDirEnv);
@@ -38,6 +41,22 @@ afterEach(() => {
   Reflect.deleteProperty(process.env, "CHANNEL_DIR");
   cleanupChannels();
 });
+
+const mergedSchemaInput = (
+  sections: Sections,
+  localizations?: Record<string, unknown>
+): Record<string, unknown> => {
+  const merged: Record<string, unknown> = {};
+  for (const data of Object.values(sections)) {
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      Object.assign(merged, data);
+    }
+  }
+  if (localizations !== undefined) {
+    merged.localizations = localizations;
+  }
+  return merged;
+};
 
 // --- happy path: minimal required sections --------------------------------
 
@@ -130,6 +149,37 @@ describe("loadConfig — top-level merge", () => {
     // When/Then the non-object top level is rejected at merge time
     expect(() => loadConfig()).toThrow(/^config:/u);
   });
+
+  test("rejects localizations in config/channel when localizations.json exists", () => {
+    // Given localizations is declared in the channel glob and the sidecar file
+    const sections = minimalSections();
+    (sections["meta.json"] as Record<string, unknown>).localizations = {
+      supported_languages: ["ja"],
+    };
+    const dir = setupChannel(sections, {
+      languages: {},
+      supported_languages: ["ja"],
+    });
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the pre-merge boundary rejects the ambiguous source
+    expect(() => loadConfig()).toThrow(/^config:/u);
+    expect(() => loadConfig()).toThrow(/localizations/u);
+  });
+
+  test("rejects localizations in config/channel when localizations.json is absent", () => {
+    // Given localizations is declared in the channel glob without the sidecar file
+    const sections = minimalSections();
+    (sections["meta.json"] as Record<string, unknown>).localizations = {
+      supported_languages: ["ja"],
+    };
+    const dir = setupChannel(sections);
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the pre-merge boundary still rejects the misplaced source
+    expect(() => loadConfig()).toThrow(/^config:/u);
+    expect(() => loadConfig()).toThrow(/localizations/u);
+  });
 });
 
 // --- structural guards -----------------------------------------------------
@@ -175,6 +225,19 @@ describe("loadConfig — cross-file validation", () => {
     expect(() => loadConfig()).toThrow(/supported_languages/u);
   });
 
+  test("reports invalid localizations sidecar with its file boundary", () => {
+    // Given localizations.json has an invalid schema shape
+    const dir = setupChannel(minimalSections(), {
+      supported_languages: "ja",
+    });
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then loadConfig keeps the sidecar filename in the boundary error
+    expect(() => loadConfig()).toThrow(
+      /^config: localizations\.json: supported_languages:/u
+    );
+  });
+
   test("rejects theme_scenes keys absent from tags.themes", () => {
     // Given a title.theme_scenes key that is not a declared tags.themes key
     const sections = minimalSections();
@@ -186,6 +249,84 @@ describe("loadConfig — cross-file validation", () => {
 
     // When/Then the dangling theme key is rejected
     expect(() => loadConfig()).toThrow(/theme_scenes/u);
+  });
+});
+
+// --- ChannelConfigSchema localizations contract ----------------------------
+
+describe("ChannelConfigSchema — localizations", () => {
+  test("places raw localizations input under engagement", () => {
+    // Given merged config input already carrying the sidecar localizations JSON
+    const localizations = {
+      default_language: "ja",
+      languages: { ja: { title_template: "x" } },
+      supported_languages: ["ja", "en"],
+    };
+    const merged = mergedSchemaInput(minimalSections(), localizations);
+
+    // When the schema assembles the channel config
+    const config = ChannelConfigSchema.parse(merged);
+
+    // Then localizations is normalized by the schema into engagement
+    expect(config.engagement.localizations.exists).toBe(true);
+    expect(config.engagement.localizations.supportedLanguages).toEqual([
+      "ja",
+      "en",
+    ]);
+    expect(config).not.toHaveProperty("localizations");
+  });
+
+  test("falls back to api.language when raw localizations input is absent", () => {
+    // Given merged config input without localizations
+    const merged = mergedSchemaInput(minimalSections());
+
+    // When the schema assembles the channel config
+    const config = ChannelConfigSchema.parse(merged);
+
+    // Then the absent state is still represented inside engagement
+    expect(config.engagement.localizations.exists).toBe(false);
+    expect(config.engagement.localizations.supportedLanguages).toEqual(["ja"]);
+  });
+
+  test("rejects content_model.languages outside supported_languages", () => {
+    // Given merged config input whose content language is not localized
+    const sections = minimalSections();
+    (sections["youtube.json"] as Record<string, unknown>).content_model = {
+      languages: ["en"],
+      type: "collection",
+    };
+    const merged = mergedSchemaInput(sections, {
+      languages: {},
+      supported_languages: ["ja", "ko"],
+    });
+
+    // When/Then the schema owns the cross-file subset validation
+    expect(() => ChannelConfigSchema.parse(merged)).toThrow(
+      /content_model\.languages.*supported_languages/u
+    );
+  });
+
+  test("prefixes invalid raw localizations issues under localizations", () => {
+    // Given merged config input carrying an invalid localizations sidecar shape
+    const merged = mergedSchemaInput(minimalSections(), {
+      supported_languages: "ja",
+    });
+
+    // When the schema rejects it
+    let caught: unknown;
+    try {
+      ChannelConfigSchema.parse(merged);
+    } catch (error) {
+      caught = error;
+    }
+
+    // Then callers can identify the sidecar boundary from the issue path
+    expect(caught).toBeInstanceOf(z.ZodError);
+    const error = caught as z.ZodError;
+    expect(error.issues[0]?.path).toEqual([
+      "localizations",
+      "supported_languages",
+    ]);
   });
 });
 

--- a/packages/core/test/config-loader.test.ts
+++ b/packages/core/test/config-loader.test.ts
@@ -7,14 +7,13 @@ import {
   expect,
   test,
 } from "bun:test";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 // Imported by the published package name + "./config" subpath so the test
 // exercises the core `exports` map. A missing/broken subpath export fails
 // resolution here, not in tsc.
 import { channelDir, loadConfig, reset } from "@youtube-automation/core/config";
-import { z } from "zod";
 
 import { ChannelConfigSchema } from "../src/config/config.ts";
 import {
@@ -180,6 +179,22 @@ describe("loadConfig — top-level merge", () => {
     expect(() => loadConfig()).toThrow(/^config:/u);
     expect(() => loadConfig()).toThrow(/localizations/u);
   });
+
+  test("rejects localizations in config/channel before parsing malformed localizations.json", () => {
+    // Given the channel glob contains the forbidden key and the sidecar is invalid JSON
+    const sections = minimalSections();
+    (sections["meta.json"] as Record<string, unknown>).localizations = {
+      supported_languages: ["ja"],
+    };
+    const dir = setupChannel(sections);
+    writeFileSync(join(dir, "config", "localizations.json"), "{", "utf-8");
+    process.env.CHANNEL_DIR = dir;
+
+    // When/Then the source-boundary violation has priority over sidecar syntax
+    expect(() => loadConfig()).toThrow(
+      /config\/channel\/\*\.json ではなく config\/localizations\.json/u
+    );
+  });
 });
 
 // --- structural guards -----------------------------------------------------
@@ -306,24 +321,21 @@ describe("ChannelConfigSchema — localizations", () => {
     );
   });
 
-  test("prefixes invalid raw localizations issues under localizations", () => {
+  test("safeParse prefixes invalid raw localizations issues under localizations", () => {
     // Given merged config input carrying an invalid localizations sidecar shape
     const merged = mergedSchemaInput(minimalSections(), {
       supported_languages: "ja",
     });
 
-    // When the schema rejects it
-    let caught: unknown;
-    try {
-      ChannelConfigSchema.parse(merged);
-    } catch (error) {
-      caught = error;
-    }
+    // When the schema rejects it through the standard safeParse path
+    const result = ChannelConfigSchema.safeParse(merged);
 
     // Then callers can identify the sidecar boundary from the issue path
-    expect(caught).toBeInstanceOf(z.ZodError);
-    const error = caught as z.ZodError;
-    expect(error.issues[0]?.path).toEqual([
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected invalid localizations to fail");
+    }
+    expect(result.error.issues[0]?.path).toEqual([
       "localizations",
       "supported_languages",
     ]);


### PR DESCRIPTION
## Summary

## 背景 (architecture review 2026-06-19)

`ChannelConfig` 型が `z.infer<typeof ChannelConfigSchema>` と一致しない。ADR-0002 の「zod schema が source of truth」原則に対する唯一の例外:

```typescript
// config.ts:64-75 — 手書き型
export type ChannelConfig = Omit<Assembled, "engagement"> & {
  readonly engagement: Assembled["engagement"] & {
    readonly localizations: Localizations;
  };
};
```

### 現状のフロー

1. `loadAndMerge(config/channel/*.json)` → merged object
2. `ChannelConfigSchema.parse(merged)` → Assembled (localizations なし)
3. `loadLocalizations(config/localizations.json)` → Localizations (別ファイル)
4. cross-file validation (imperative、schema 外)
5. `{ ...parsed, engagement: { ...parsed.engagement, localizations } }` — TypeScript intersection で post-inject

### 問題

- `ChannelConfig` 型が schema の `z.infer` と不一致
- cross-file validation (`content_model.languages ⊆ localizations.supported_languages`) が schema 外
- localizations の存在判定 (`exists: true/false`) が schema で表現されていない

## 作業内容

### 1. loader を変更: localizations を merged object に pre-merge

```typescript
// loader.ts (変更後)
const build = (channelRoot: string): ChannelConfig => {
  // ... (既存の glob + loadAndMerge) ...
  const merged = loadAndMerge(files);

  // localizations を merged object に追加（schema が一括 parse する前提）
  const locRaw = loadLocalizationsRaw(channelRoot);
  if (locRaw !== undefined) {
    if ("localizations" in merged) {
      throw new Error("config: 'localizations' キーが config/channel/*.json に存在します（localizations.json と衝突）");
    }
    merged.localizations = locRaw;
  }

  return ChannelConfigSchema.parse(merged); // single-pass
};
```

### 2. config.ts の assemble を変更: localizations を schema 内で処理

```typescript
const assemble = (merged: unknown) => {
  const identity = Identity.parse(merged);
  const publishing = Publishing.parse(merged);
  const engagement = Engagement.parse(merged);
  const integrations = Integrations.parse(merged);

  // localizations は merged object 内に含まれている前提
  const locRaw = isPlainObject(merged) ? (merged as Record<string, unknown>).localizations : undefined;
  const localizations = locRaw !== undefined
    ? Localizations.parse(locRaw)
    : localizationsAbsent(publishing.youtube.api.language);

  const content = { ...publishing.content, tags: { ...publishing.content.tags, channelName: identity.meta.channelName } };
  return {
    engagement: { ...engagement, localizations },
    identity,
    integrations,
    publishing: { ...publishing, content },
  };
};
```

### 3. cross-file validation を superRefine に移す

```typescript
export const ChannelConfigSchema = z.unknown()
  .transform(assemble)
  .superRefine((config, ctx) => {
    // 既存: title.theme_scenes ⊆ tags.themes
    // ...

    // 新規: content_model.languages ⊆ localizations.supported_languages
    if (config.engagement.localizations.exists) {
      const supported = new Set(config.engagement.localizations.supportedLanguages);
      for (const lang of config.publishing.youtube.contentModel.languages) {
        if (!supported.has(lang)) {
          ctx.addIssue({
            code: "custom",
            message: `content_model.languages の "${lang}" が localizations.supported_languages にありません`,
          });
        }
      }
    }
  });
```

### 4. `ChannelConfig` 型を `z.infer` に一致させる

```typescript
// config.ts (変更後)
export type ChannelConfig = z.infer<typeof ChannelConfigSchema>;
// 手書き Omit & intersection を削除
```

### 5. loader から cross-file validation を削除

`build()` 内の `localizations.exists` 判定 + `unknownLangs` チェックを削除（schema に移動済み）。

## リスク

- **低リスク**: glob scope は不変（`config/channel/*.json` + `config/localizations.json` は分離のまま）
- **中リスク**: テストフィクスチャの変更が必要（`ChannelConfigSchema` 単体テストで localizations の存在を前提にする）
- **低リスク**: engagement bucket 内の localizations 位置は不変（下流互換維持）

## 受入基準

- [ ] `ChannelConfig` 型が `z.infer<typeof ChannelConfigSchema>` と一致する（手書き `Omit & intersection` が削除されている）
- [ ] cross-file validation (`content_model.languages ⊆ localizations`) が `ChannelConfigSchema` の `superRefine` 内にある
- [ ] `loader.ts::build()` から imperative な cross-file validation が削除されている
- [ ] localizations の pre-merge で `config/channel/*.json` とのキー衝突を検出する
- [ ] 既存テスト全件 pass
- [ ] `config-loader.test.ts` の cross-file validation テストが schema 経由で検証されている

## 関連

- ADR-0002: Service-first architecture (「zod schema が source of truth」原則)
- ADR-0003 §8: schema は zod に集約、手書き parseX は撤廃
- Epic #727 / umbrella PR #791

base branch: `feat/ts-rewrite` / architecture review candidate #4

## Execution Report

Workflow `default` completed successfully.

Closes #1111