### PR TITLE
[#1130] issue-1130-google-auth-library-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `chore(ts-rewrite/core)`: `google-auth-library` の direct dependency 指定を `10.5.0` の exact pin から `^10.5.0` に変更し、10.x の patch/minor 更新を取り込めるようにした（#1130）。
 - `feat(ts-rewrite/core)`: Audience analytics の demographics / country / subscribedStatus 3 クエリを並列開始するよう変更した（#1115）。失敗時は開始済み retry が settled になるまで待ってから Result へ変換し、service 戻り後に API retry が残らないようにした。
 - `refactor(ts-rewrite/core)`: analytics service の列ヘッダー解決とセル読み取り処理を `analytics/column-helpers.ts` に共通化し、channel / audience / traffic-source の重複実装を整理した（#1113）。
 - `feat(skills)`: dogfood ライフサイクルが踏む 12 skill（wf-new / wf-next / suno / suno-helper / masterup / videoup / video-upload / thumbnail / video-description / analytics-collect / playlist / distrokid-prep）の `uv run yt-*` 呼び出しを `bunx tayk <cmd>`（ADR-0007 rebrand / ADR-0004 単一 dispatcher）へ置換した（#965）。TS 版を pin した下流でも skill 経由で Python が実行され dogfood が始まらない問題を解消する。対象 skill の `uv run` 残骸ゼロを `tests/test_lifecycle_skills_no_uv_run.py` で機械担保。lifecycle 外の skill の置換は #966 で対応予定。

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
       "version": "0.1.0-alpha.0",
       "dependencies": {
         "@google/genai": "^2.7.0",
-        "google-auth-library": "10.5.0",
+        "google-auth-library": "^10.5.0",
         "googleapis": "^173.0.0",
         "openai": "^6.41.0",
         "sharp": "^0.34.0",
@@ -591,7 +591,7 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
-    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+    "google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
@@ -919,9 +919,9 @@
 
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "googleapis/google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
-
     "googleapis-common/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "googleapis-common/google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -962,6 +962,8 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "googleapis-common/google-auth-library/gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@google/genai": "^2.7.0",
-    "google-auth-library": "10.5.0",
+    "google-auth-library": "^10.5.0",
     "googleapis": "^173.0.0",
     "openai": "^6.41.0",
     "sharp": "^0.34.0",

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -7,7 +7,6 @@
 // 文字列で throw し、空 credentials のクライアントを黙って作らない（fail fast）。各
 // domain service はここで構築したクライアントを deps で受け取る。
 
-import { OAuth2Client } from "google-auth-library";
 import type { Credentials } from "google-auth-library";
 import { google } from "googleapis";
 import type { youtube_v3, youtubeAnalytics_v2 } from "googleapis";
@@ -17,9 +16,11 @@ export type YouTubeClient = youtube_v3.Youtube;
 /** YouTube Analytics API v2 クライアントの型。 */
 export type YouTubeAnalyticsClient = youtubeAnalytics_v2.Youtubeanalytics;
 
-const authFromTokenJson = (tokenJson: string): OAuth2Client => {
+type GoogleApisOAuth2Client = InstanceType<typeof google.auth.OAuth2>;
+
+const authFromTokenJson = (tokenJson: string): GoogleApisOAuth2Client => {
   const credentials = JSON.parse(tokenJson) as Credentials;
-  const auth = new OAuth2Client();
+  const auth = new google.auth.OAuth2();
   auth.setCredentials(credentials);
   return auth;
 };


### PR DESCRIPTION
## Summary

## 背景

`packages/core/package.json` で `google-auth-library` だけが exact pin (`"10.5.0"`) になっている。他の依存はすべてカレット (`^`) 付き。

git history 調査の結果、takt が初回追加時に resolve した版をそのまま exact pin したもので、意図的な固定ではない。10.x 内で breaking change の報告はなく、deprecated でもない。

## 作業内容

1. `packages/core/package.json` で `"google-auth-library": "10.5.0"` → `"google-auth-library": "^10.5.0"` に変更
2. `bun install` で lockfile 更新
3. `bun run ci` で全テスト通過を確認

## 受入基準

- [ ] `packages/core/package.json` の `google-auth-library` がカレット付き
- [ ] `bun run ci` exit 0
- [ ] CHANGELOG `[Unreleased]` に追記

## Execution Report

Workflow `default` completed successfully.

Closes #1130