### PR TITLE
[#1139] issue-1139-fix-oauth-service-i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `refactor(ts-rewrite/core)`: OAuth service（`interactiveAuthService` / `refreshTokenService`）を `createService` フレームに移行し、ADR-0003 の構造的不整合を解消した（#1139）。output schema を `oauth/schema.ts` に追加し、OAuth callback の `state` 生成・検証を追加。boundary テスト（input validation / success / failure）も追加。
 - `refactor(ts-rewrite/core)`: ADR-0003 の service 境界 frame（try/catch → Result 変換）を `createService` ヘルパ（`service-frame.ts`）に抽出し、対象 10 service（analytics 5 + image / skills-sync 2 / suno-prompts / upload）を移行した（#1109）。新規 service は core function + schemas だけ書けば frame を正しく適用できるようになり、手書き frame のレビュー負荷と誤実装 fail mode を除去。
 - `refactor(ts-rewrite/core)`: analytics 5 service の共通クエリ実行を `analytics/query.ts::executeQuery` に、列ヘッダー解決を `analytics/columns.ts` に集約し、各 service の try/catch/ok/err ボイラープレートを `service.ts::createService` ラッパーで除去した（#1110）。`column-helpers.ts` → `columns.ts` リネーム、`analytics/query.ts` / `service.ts` 新設。テスト追加: `analytics-query.test.ts` / `service.test.ts`
 - `feat(ts-rewrite/core)`: Audience analytics の demographics / country / subscribedStatus 3 クエリを並列開始するよう変更した（#1115）。失敗時は開始済み retry が settled になるまで待ってから Result へ変換し、service 戻り後に API retry が残らないようにした。

--- a/packages/core/src/oauth/interactive-internal.ts
+++ b/packages/core/src/oauth/interactive-internal.ts
@@ -4,11 +4,72 @@
 // 相対 import で直接検証する。公開 API 面に出るのは interactiveAuthService のみに保つ
 // （internal.ts / refresh.ts の確立済み規約と同形）。
 
+import { randomBytes } from "node:crypto";
+
 import type { Credentials, OAuth2Client } from "google-auth-library";
 
+const OAUTH_CALLBACK_CODE_PARAM = "code";
+const OAUTH_CALLBACK_ERROR_PARAM = "error";
+const OAUTH_CALLBACK_STATE_PARAM = "state";
+export const OAUTH_STATE_MISMATCH_MESSAGE =
+  "auth: OAuth callback state mismatch";
+
+export type OAuthCallbackResult =
+  | { code: string; status: "code" }
+  | { error: Error; status: "error" }
+  | { status: "not_found" };
+
+/** CSRF 防止用の OAuth callback state を生成する。 */
+export const generateOAuthState = (): string =>
+  randomBytes(32).toString("base64url");
+
+/** OAuth callback の state が consent URL 発行時の値と一致することを検証する。 */
+const validateOAuthCallbackState = (
+  actualState: string | null,
+  expectedState: string
+): void => {
+  if (actualState !== expectedState) {
+    throw new Error(OAUTH_STATE_MISMATCH_MESSAGE);
+  }
+};
+
 /** generateAuthUrl で offline access（refresh_token 発行）を要求する consent URL を作る。 */
-export const buildAuthUrl = (client: OAuth2Client, scopes: string[]): string =>
-  client.generateAuthUrl({ access_type: "offline", scope: scopes });
+export const buildAuthUrl = (
+  client: OAuth2Client,
+  scopes: string[],
+  state: string
+): string =>
+  client.generateAuthUrl({ access_type: "offline", scope: scopes, state });
+
+export const parseOAuthCallback = (
+  request: Request,
+  expectedState: string
+): OAuthCallbackResult => {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get(OAUTH_CALLBACK_CODE_PARAM);
+  const denied = searchParams.get(OAUTH_CALLBACK_ERROR_PARAM);
+  if (!code && !denied) {
+    return { status: "not_found" };
+  }
+  try {
+    validateOAuthCallbackState(
+      searchParams.get(OAUTH_CALLBACK_STATE_PARAM),
+      expectedState
+    );
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      status: "error",
+    };
+  }
+  if (code) {
+    return { code, status: "code" };
+  }
+  return {
+    error: new Error(`auth: consent denied: ${denied}`),
+    status: "error",
+  };
+};
 
 /** authorization code を発行済み credentials に交換する。失敗は呼び出し側へ伝播する。 */
 export const exchangeCode = async (

--- a/packages/core/src/oauth/interactive.ts
+++ b/packages/core/src/oauth/interactive.ts
@@ -12,14 +12,54 @@
 import { spawn } from "node:child_process";
 
 import { OAuth2Client } from "google-auth-library";
+import type { Credentials } from "google-auth-library";
 
-import { toServiceError } from "../errors.ts";
 import type { ServiceError } from "../errors.ts";
-import { err, ok } from "../result.ts";
 import type { Result } from "../result.ts";
-import { buildAuthUrl, exchangeCode } from "./interactive-internal.ts";
+import { createService } from "../service.ts";
+import {
+  buildAuthUrl,
+  exchangeCode as defaultExchangeCode,
+  generateOAuthState,
+  parseOAuthCallback,
+} from "./interactive-internal.ts";
 import { parseClientSecrets } from "./internal.ts";
-import { InteractiveAuthInput } from "./schema.ts";
+import { InteractiveAuthInput, OAuthTokenOutput } from "./schema.ts";
+
+interface InteractiveOAuthClient {
+  generateAuthUrl(options: {
+    access_type: "offline";
+    scope: string[];
+    state: string;
+  }): string;
+  getToken(code: string): Promise<{ tokens: Credentials }>;
+}
+
+interface OAuthCallbackServer {
+  readonly port?: number;
+  stop(force: boolean): Promise<void> | void;
+}
+
+interface OAuthCallbackServerOptions {
+  fetch: (request: Request) => Response | Promise<Response>;
+  hostname: string;
+  port: number;
+}
+
+interface InteractiveDeps {
+  createOAuthClient: (config: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+  }) => InteractiveOAuthClient;
+  exchangeCode: (
+    client: InteractiveOAuthClient,
+    code: string
+  ) => Promise<Credentials>;
+  generateState: () => string;
+  openBrowser: (url: string) => void;
+  serve: (options: OAuthCallbackServerOptions) => OAuthCallbackServer;
+}
 
 // OS のブラウザを開くコマンド（pure JS では開けないため subprocess を起動する）。
 // interactive は CLI 専用で、lint が MCP からの import を遮断しているため許容する。
@@ -44,59 +84,101 @@ const openBrowser = (url: string): void => {
   child.unref();
 };
 
+const defaultDeps: InteractiveDeps = {
+  createOAuthClient: ({ clientId, clientSecret, redirectUri }) =>
+    new OAuth2Client({ clientId, clientSecret, redirectUri }),
+  exchangeCode: (client, code) =>
+    defaultExchangeCode(client as OAuth2Client, code),
+  generateState: generateOAuthState,
+  openBrowser,
+  serve: (options) => Bun.serve(options),
+};
+
+const requireCallbackServerPort = (server: OAuthCallbackServer): number => {
+  if (server.port === undefined) {
+    throw new Error("io: OAuth callback server did not expose a port");
+  }
+  return server.port;
+};
+
+const exchangeAuthCode = async (
+  deps: InteractiveDeps,
+  client: InteractiveOAuthClient,
+  code: string
+): Promise<Credentials> => {
+  try {
+    return await deps.exchangeCode(client, code);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`auth: code exchange failed: ${message}`, { cause: error });
+  }
+};
+
+const handleOAuthCallback = (
+  request: Request,
+  expectedState: string,
+  resolve: (code: string) => void,
+  reject: (error: Error) => void
+): Response => {
+  const callback = parseOAuthCallback(request, expectedState);
+  if (callback.status === "not_found") {
+    return new Response(null, { status: 404 });
+  }
+  if (callback.status === "error") {
+    reject(callback.error);
+    return new Response("認証に失敗しました。このタブを閉じてください。");
+  }
+  resolve(callback.code);
+  return new Response("認証が完了しました。このタブを閉じてください。");
+};
+
 // ローカルコールバックサーバを ephemeral port で起動し、redirect の code を 1 回受け
 // 取って token.json 文字列を返す。consent 拒否（error param）は auth エラーへ寄せる。
 const runInteractiveFlow = async (
   clientSecretsJson: string,
-  scopes: string[]
+  scopes: string[],
+  deps: InteractiveDeps
 ): Promise<string> => {
   const { clientId, clientSecret } = parseClientSecrets(clientSecretsJson);
   const { promise, reject, resolve } = Promise.withResolvers<string>();
+  const state = deps.generateState();
 
-  const server = Bun.serve({
-    fetch: (request) => {
-      const { searchParams } = new URL(request.url);
-      const code = searchParams.get("code");
-      const denied = searchParams.get("error");
-      if (code) {
-        resolve(code);
-        return new Response("認証が完了しました。このタブを閉じてください。");
-      }
-      if (denied) {
-        reject(new Error(`auth: consent denied: ${denied}`));
-        return new Response("認証に失敗しました。このタブを閉じてください。");
-      }
-      return new Response(null, { status: 404 });
-    },
+  const server = deps.serve({
+    fetch: (request) => handleOAuthCallback(request, state, resolve, reject),
     hostname: "127.0.0.1",
     port: 0,
   });
 
   try {
-    const redirectUri = `http://localhost:${server.port}/`;
-    const client = new OAuth2Client({ clientId, clientSecret, redirectUri });
-    openBrowser(buildAuthUrl(client, scopes));
+    const redirectUri = `http://localhost:${requireCallbackServerPort(server)}/`;
+    const client = deps.createOAuthClient({
+      clientId,
+      clientSecret,
+      redirectUri,
+    });
+    deps.openBrowser(buildAuthUrl(client as OAuth2Client, scopes, state));
     const code = await promise;
-    const tokens = await exchangeCode(client, code);
+    const tokens = await exchangeAuthCode(deps, client, code);
     return JSON.stringify(tokens);
   } finally {
     await server.stop(true);
   }
 };
 
+const interactiveAuthBoundary = createService(
+  InteractiveAuthInput,
+  OAuthTokenOutput,
+  async ({ clientSecretsJson, scopes }, deps: InteractiveDeps) => ({
+    tokenJson: await runInteractiveFlow(clientSecretsJson, scopes, deps),
+  })
+);
+
 /**
  * ブラウザ consent でユーザーを認証し、発行された credentials を token.json 文字列で
- * 返す（CLI 専用）。入力は `.strict()` schema で先に検証し、失敗は境界の `toServiceError`
- * 経由で `Result` に変換する（throw しない）。
+ * 返す（CLI 専用）。入力・出力検証と Result 変換は `createService` に集約する。
  */
-export const interactiveAuthService = async (
-  input: InteractiveAuthInput
-): Promise<Result<{ tokenJson: string }, ServiceError>> => {
-  try {
-    const { clientSecretsJson, scopes } = InteractiveAuthInput.parse(input);
-    const tokenJson = await runInteractiveFlow(clientSecretsJson, scopes);
-    return ok({ tokenJson });
-  } catch (error) {
-    return err(toServiceError(error));
-  }
-};
+export const interactiveAuthService = (
+  input: InteractiveAuthInput,
+  deps: InteractiveDeps = defaultDeps
+): Promise<Result<OAuthTokenOutput, ServiceError>> =>
+  interactiveAuthBoundary(input, deps);

--- a/packages/core/src/oauth/refresh.ts
+++ b/packages/core/src/oauth/refresh.ts
@@ -14,12 +14,11 @@
 import { OAuth2Client } from "google-auth-library";
 import type { Credentials } from "google-auth-library";
 
-import { toServiceError } from "../errors.ts";
 import type { ServiceError } from "../errors.ts";
-import { err, ok } from "../result.ts";
 import type { Result } from "../result.ts";
+import { createService } from "../service.ts";
 import { parseClientSecrets } from "./internal.ts";
-import { RefreshTokenInput } from "./schema.ts";
+import { OAuthTokenOutput, RefreshTokenInput } from "./schema.ts";
 
 /** refresh が必要とする OAuth2Client の最小シェイプ（注入 seam）。 */
 interface RefreshOAuthClient {
@@ -59,21 +58,23 @@ const refreshCredentials = async (
  * 保存済み token を refresh し、更新後の credentials を token.json 文字列で返す。
  *
  * client_secrets から clientId / clientSecret を取り出して OAuth2Client を構築し、stored
- * refresh_token を seed してから refresh する。入力は `.strict()` schema で先に検証する
- * ため、未知キーは refresh に到達せず validation エラーになる。
+ * refresh_token を seed してから refresh する。入力・出力検証と Result 変換は
+ * `createService` に集約する。
  */
-export const refreshTokenService = async (
-  input: RefreshTokenInput,
-  deps: RefreshDeps = defaultDeps
-): Promise<Result<{ tokenJson: string }, ServiceError>> => {
-  try {
-    const { clientSecretsJson, tokenJson } = RefreshTokenInput.parse(input);
+const refreshTokenBoundary = createService(
+  RefreshTokenInput,
+  OAuthTokenOutput,
+  async ({ clientSecretsJson, tokenJson }, deps: RefreshDeps) => {
     const { clientId, clientSecret } = parseClientSecrets(clientSecretsJson);
     const client = deps.createOAuthClient({ clientId, clientSecret });
     client.setCredentials(JSON.parse(tokenJson) as Credentials);
     const credentials = await refreshCredentials(client);
-    return ok({ tokenJson: JSON.stringify(credentials) });
-  } catch (error) {
-    return err(toServiceError(error));
+    return { tokenJson: JSON.stringify(credentials) };
   }
-};
+);
+
+export const refreshTokenService = (
+  input: RefreshTokenInput,
+  deps: RefreshDeps = defaultDeps
+): Promise<Result<OAuthTokenOutput, ServiceError>> =>
+  refreshTokenBoundary(input, deps);

--- a/packages/core/src/oauth/schema.ts
+++ b/packages/core/src/oauth/schema.ts
@@ -24,3 +24,11 @@ export const InteractiveAuthInput = z
   })
   .strict();
 export type InteractiveAuthInput = z.infer<typeof InteractiveAuthInput>;
+
+/** OAuth service 共通の出力。CLI 層が token.json として永続化する文字列のみ返す。 */
+export const OAuthTokenOutput = z
+  .object({
+    tokenJson: z.string(),
+  })
+  .strict();
+export type OAuthTokenOutput = z.infer<typeof OAuthTokenOutput>;

--- a/packages/core/test/oauth-interactive.test.ts
+++ b/packages/core/test/oauth-interactive.test.ts
@@ -8,21 +8,35 @@
 // off the public oauth subpath.
 //
 // Seam contract (the helpers delegate to a google-auth-library OAuth2Client):
-//   buildAuthUrl(client, scopes) -> client.generateAuthUrl({ access_type, scope })
+//   buildAuthUrl(client, scopes, state) -> generateAuthUrl({ access_type, scope, state })
 //   exchangeCode(client, code)   -> (await client.getToken(code)).tokens
 
 import { describe, expect, test } from "bun:test";
 
 import {
+  OAUTH_STATE_MISMATCH_MESSAGE,
   buildAuthUrl,
   exchangeCode,
+  generateOAuthState,
+  parseOAuthCallback,
 } from "../src/oauth/interactive-internal.ts";
 import * as interactiveModule from "../src/oauth/interactive.ts";
+import { interactiveAuthService } from "../src/oauth/interactive.ts";
 
 const scopes = [
   "https://www.googleapis.com/auth/youtube",
   "https://www.googleapis.com/auth/yt-analytics.readonly",
 ];
+
+describe("generateOAuthState", () => {
+  test("returns a URL-safe unpadded 32-byte state token", () => {
+    const state = generateOAuthState();
+
+    expect(state).toHaveLength(43);
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/u);
+    expect(state).not.toContain("=");
+  });
+});
 
 describe("buildAuthUrl", () => {
   test("requests offline access for every scope so a refresh_token is issued", () => {
@@ -36,7 +50,7 @@ describe("buildAuthUrl", () => {
     } as unknown as Parameters<typeof buildAuthUrl>[0];
 
     // When building the consent URL
-    const url = buildAuthUrl(client, scopes);
+    const url = buildAuthUrl(client, scopes, "state-123");
 
     // Then the generated URL is returned verbatim ...
     expect(url).toBe("https://accounts.google.com/o/oauth2/v2/auth?mock=1");
@@ -50,6 +64,58 @@ describe("buildAuthUrl", () => {
     expect(JSON.stringify(captured[0])).toContain(
       "https://www.googleapis.com/auth/yt-analytics.readonly"
     );
+    // ... and the CSRF state is attached for callback verification
+    expect(captured[0]?.state).toBe("state-123");
+  });
+});
+
+describe("parseOAuthCallback", () => {
+  test("returns the code when callback state matches", () => {
+    const result = parseOAuthCallback(
+      new Request("http://localhost/?code=auth-code&state=expected-state"),
+      "expected-state"
+    );
+
+    expect(result).toEqual({ code: "auth-code", status: "code" });
+  });
+
+  test("returns an auth error when state is missing", () => {
+    const result = parseOAuthCallback(
+      new Request("http://localhost/?code=auth-code"),
+      "expected-state"
+    );
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") {
+      throw new Error("expected callback error");
+    }
+    expect(result.error.message).toBe(OAUTH_STATE_MISMATCH_MESSAGE);
+  });
+
+  test("returns an auth error when state is mismatched", () => {
+    const result = parseOAuthCallback(
+      new Request("http://localhost/?code=auth-code&state=attacker-state"),
+      "expected-state"
+    );
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") {
+      throw new Error("expected callback error");
+    }
+    expect(result.error.message).toBe(OAUTH_STATE_MISMATCH_MESSAGE);
+  });
+
+  test("returns an auth error when consent is denied", () => {
+    const result = parseOAuthCallback(
+      new Request("http://localhost/?error=access_denied&state=expected-state"),
+      "expected-state"
+    );
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") {
+      throw new Error("expected callback error");
+    }
+    expect(result.error.message).toBe("auth: consent denied: access_denied");
   });
 });
 
@@ -88,6 +154,160 @@ describe("exchangeCode", () => {
     await expect(exchangeCode(client, "bad-code")).rejects.toThrow(
       "invalid_grant"
     );
+  });
+});
+
+type InteractiveDeps = NonNullable<
+  Parameters<typeof interactiveAuthService>[1]
+>;
+type InteractiveInput = Parameters<typeof interactiveAuthService>[0];
+
+const clientSecretsJson = JSON.stringify({
+  installed: {
+    client_id: "cid.apps.googleusercontent.com",
+    client_secret: "the-client-secret",
+  },
+});
+
+const makeInteractiveDeps = (
+  callbackState: "match" | "mismatch",
+  exchangeBehavior: () => Promise<Record<string, unknown>>
+) => {
+  let fetchHandler:
+    | ((request: Request) => Response | Promise<Response>)
+    | undefined;
+  const exchangedCodes: string[] = [];
+  const openedUrls: string[] = [];
+  const stopped: boolean[] = [];
+
+  const deps: InteractiveDeps = {
+    createOAuthClient: () =>
+      ({
+        generateAuthUrl: (options: {
+          access_type: "offline";
+          scope: string[];
+          state: string;
+        }) =>
+          `https://accounts.google.com/mock?state=${encodeURIComponent(
+            options.state
+          )}`,
+        getToken: () => Promise.reject(new Error("unused")),
+      }) as ReturnType<InteractiveDeps["createOAuthClient"]>,
+    exchangeCode: (_client, code) => {
+      exchangedCodes.push(code);
+      return exchangeBehavior() as ReturnType<InteractiveDeps["exchangeCode"]>;
+    },
+    generateState: () => "expected-state",
+    openBrowser: (url) => {
+      openedUrls.push(url);
+      const state =
+        callbackState === "match" ? "expected-state" : "attacker-state";
+      if (!fetchHandler) {
+        throw new Error("test setup: callback server was not started");
+      }
+      void fetchHandler(
+        new Request(`http://localhost/?code=auth-code-123&state=${state}`)
+      );
+    },
+    serve: (options) => {
+      fetchHandler = options.fetch;
+      return {
+        port: 34_567,
+        stop: (force: boolean) => {
+          stopped.push(force);
+        },
+      };
+    },
+  };
+  return { deps, exchangedCodes, openedUrls, stopped };
+};
+
+describe("interactiveAuthService boundary", () => {
+  test("returns issued credentials as token.json when callback state matches", async () => {
+    const { deps, exchangedCodes, openedUrls, stopped } = makeInteractiveDeps(
+      "match",
+      () =>
+        Promise.resolve({
+          access_token: "issued-access",
+          refresh_token: "issued-refresh",
+        })
+    );
+
+    const r = await interactiveAuthService({ clientSecretsJson, scopes }, deps);
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      throw new Error(`expected ok, got ${r.error.domain}: ${r.error.message}`);
+    }
+    expect(JSON.parse(r.value.tokenJson)).toEqual({
+      access_token: "issued-access",
+      refresh_token: "issued-refresh",
+    });
+    expect(openedUrls[0]).toContain("state=expected-state");
+    expect(exchangedCodes).toEqual(["auth-code-123"]);
+    expect(stopped).toEqual([true]);
+  });
+
+  test("returns an auth ServiceError when callback state mismatches", async () => {
+    const { deps, exchangedCodes, stopped } = makeInteractiveDeps(
+      "mismatch",
+      () => Promise.resolve({ access_token: "unused" })
+    );
+
+    const r = await interactiveAuthService({ clientSecretsJson, scopes }, deps);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("auth");
+    expect(r.error.message).toBe(OAUTH_STATE_MISMATCH_MESSAGE);
+    expect(exchangedCodes).toEqual([]);
+    expect(stopped).toEqual([true]);
+  });
+
+  test("maps code exchange failure to an auth ServiceError", async () => {
+    const { deps, stopped } = makeInteractiveDeps("match", () =>
+      Promise.reject(new Error("invalid_grant: bad verification code"))
+    );
+
+    const r = await interactiveAuthService({ clientSecretsJson, scopes }, deps);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected failure");
+    }
+    expect(r.error.domain).toBe("auth");
+    expect(r.error.message).toContain("code exchange failed");
+    expect(stopped).toEqual([true]);
+  });
+
+  test("rejects malformed input before starting the callback server", async () => {
+    let serveCalls = 0;
+    const { deps } = makeInteractiveDeps("match", () =>
+      Promise.resolve({ access_token: "unused" })
+    );
+    const guardedDeps: InteractiveDeps = {
+      ...deps,
+      serve: (options) => {
+        serveCalls += 1;
+        return deps.serve(options);
+      },
+    };
+    const malformed = {
+      clientSecretsJson,
+      scopes,
+      unexpected: true,
+    } as unknown as InteractiveInput;
+
+    const r = await interactiveAuthService(malformed, guardedDeps);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) {
+      throw new Error("expected validation failure");
+    }
+    expect(r.error.domain).toBe("validation");
+    expect(serveCalls).toBe(0);
   });
 });
 

--- a/packages/core/test/oauth-refresh.test.ts
+++ b/packages/core/test/oauth-refresh.test.ts
@@ -19,10 +19,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { refreshTokenService } from "@youtube-automation/core/oauth/refresh";
+import type { RefreshDeps } from "@youtube-automation/core/oauth/refresh";
 
-// Derive the deps bag type from the service itself (image-gemini.test.ts:38-40)
-// so the test does not hard-code the injection shape's exported name.
-type RefreshDeps = NonNullable<Parameters<typeof refreshTokenService>[1]>;
 type RefreshInput = Parameters<typeof refreshTokenService>[0];
 
 const clientSecretsJson = JSON.stringify({


### PR DESCRIPTION
## Summary

## 背景

PR #1136 (#1109) で `createService` を抽出し ADR-0003 を更新したが、OAuth service (`interactiveAuthService` / `refreshTokenService`) は旧 `try/catch` + `ok` / `err` / `toServiceError` 実装のまま残っている。ADR が `createService` 必須を宣言しているため構造的不整合がある。

#1136 のレビューで繰り返し指摘されたが、#1109 のスコープ外として切り出し。

## 作業内容

- [ ] `oauth/schema.ts` に output schema 追加
- [ ] `interactiveAuthService` を `createService` 移行
- [ ] `refreshTokenService` を `createService` 移行（default deps 互換維持）
- [ ] OAuth service の boundary テスト追加（input validation / success / failure）
- [ ] OAuth callback の `state` 生成・検証追加（SEC-1136-001）

## 関連

- Closes の ADR 不整合: #1109 / PR #1136
- ADR-0003: `docs/adr/0003-service-boundary-contracts.md`

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1139