### PR TITLE
[#1156] issue-1156-refactor-ts-rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(doctor)`: `yt-doctor accounts` サブコマンドを追加。全チャンネルリポの `auth/client_secrets.json` をスキャンし、GCP プロジェクト・OAuth クライアント ID・トークン有無の対応表を一覧表示する。`--json` で機械可読出力、`--search-root` で探索ルート指定が可能。
 - `docs(adr)`: ADR-0010 全チャンネルを単一 GCP プロジェクトに統合。Billing 枠上限 (5/5) 解消とオペレーションコスト削減のため、チャンネルごとの GCP プロジェクト分離から `yt-channels-automation` への一本化を決定。
 
+- `refactor(ts-rewrite/cli)`: `generate-suno` の `getCwd()` を遅延評価に変更し explicit path 指定時の不要な cwd 解決を排除。`skills-bundle-pack.test.ts` の `beforeAll` 共有 fixture を各テスト独立生成に改善（#1156）
+
 ### Changed
 
 - `fix(ts-rewrite/cli)`: CLI smoke test が Bun デフォルト timeout（5000ms）に当たり REJECT される構造的問題を修正した（#1107）。subprocess smoke test に明示 timeout を設定し、重いロジック検証は `createXxxCommand()` を直接呼ぶ in-process テストに移行。subprocess テストは「dispatcher が subcommand を認識する」確認のみに限定。

--- a/packages/cli/src/commands/generate-suno/cli.ts
+++ b/packages/cli/src/commands/generate-suno/cli.ts
@@ -69,8 +69,8 @@ export const createGenerateSunoCommand = ({
     async run({ args }) {
       const rawPath = typeof args.path === "string" ? args.path : undefined;
       const json = args.json === true || rawPath === "--json";
-      const cwd = getCwd();
-      const path = rawPath === "--json" ? cwd : (rawPath ?? cwd);
+      const path =
+        rawPath === undefined || rawPath === "--json" ? getCwd() : rawPath;
       const result = await (async () => {
         try {
           const input = entry.inputSchema.parse({ path });

--- a/packages/cli/test/skills-bundle-pack.test.ts
+++ b/packages/cli/test/skills-bundle-pack.test.ts
@@ -171,41 +171,43 @@ describe("cli package — published tarball bundles the sync assets (#742 AC#1/#
   test(
     "postpack restores the source asset and package asset link shape",
     () => {
+      const packageUnderTest = createIsolatedPackage();
+      restoreBundledSymlinks(packageUnderTest.cliDir);
+      packEntries(packageUnderTest.cliDir, makeTmp("cli-pack-postpack-"));
+
       // Assert BEFORE manually calling restoreBundledSymlinks so that a postpack
       // failure is not silently masked by the explicit restore (AI-ANTI-001).
       expect(
-        lstatSync(join(isolatedPackage.cliDir, "_skills")).isSymbolicLink()
+        lstatSync(join(packageUnderTest.cliDir, "_skills")).isSymbolicLink()
       ).toBe(true);
       expect(
         lstatSync(
-          join(isolatedPackage.repoRoot, ".claude", "CLAUDE.template.md")
+          join(packageUnderTest.repoRoot, ".claude", "CLAUDE.template.md")
         ).isFile()
       ).toBe(true);
       expect(
-        lstatSync(join(isolatedPackage.cliDir, "_claude_md")).isDirectory()
+        lstatSync(join(packageUnderTest.cliDir, "_claude_md")).isDirectory()
       ).toBe(true);
       expect(
         lstatSync(
-          join(isolatedPackage.cliDir, "_claude_md", "CLAUDE.template.md")
+          join(packageUnderTest.cliDir, "_claude_md", "CLAUDE.template.md")
         ).isSymbolicLink()
       ).toBe(true);
-
-      // Explicit restore for subsequent tests that depend on the symlink state.
-      restoreBundledSymlinks(isolatedPackage.cliDir);
     },
-    CLI_SMOKE_TIMEOUT_MS
+    BEFORE_ALL_TIMEOUT_MS
   );
 
   test("restores idempotently when bundled asset symlinks already exist", () => {
-    restoreBundledSymlinks(isolatedPackage.cliDir);
-    restoreBundledSymlinks(isolatedPackage.cliDir);
+    const packageUnderTest = createIsolatedPackage();
+    restoreBundledSymlinks(packageUnderTest.cliDir);
+    restoreBundledSymlinks(packageUnderTest.cliDir);
 
     expect(
-      lstatSync(join(isolatedPackage.cliDir, "_skills")).isSymbolicLink()
+      lstatSync(join(packageUnderTest.cliDir, "_skills")).isSymbolicLink()
     ).toBe(true);
     expect(
       lstatSync(
-        join(isolatedPackage.cliDir, "_claude_md", "CLAUDE.template.md")
+        join(packageUnderTest.cliDir, "_claude_md", "CLAUDE.template.md")
       ).isSymbolicLink()
     ).toBe(true);
   }, 35_000);

--- a/packages/cli/test/yt-generate-suno.test.ts
+++ b/packages/cli/test/yt-generate-suno.test.ts
@@ -137,6 +137,30 @@ describe("createGenerateSunoCommand — in-process adapter contract", () => {
     expect(emitted.calls[0]?.json).toBe(true);
   });
 
+  test("does not read cwd when an explicit collection path is provided", async () => {
+    const { calls, entry } = makeGenerateEntry();
+    const emitted = makeEmitResult();
+    let getCwdCalls = 0;
+    const command = createGenerateSunoCommand({
+      emitResult: emitted.emitResult,
+      entry,
+      getCwd: () => {
+        getCwdCalls += 1;
+        return "/unused-cwd";
+      },
+      resolveDeps: () => Promise.resolve({ channelDir: "/channel" }),
+    });
+
+    await command.run({
+      args: { path: "/channel/collections/planning/explicit-path" },
+    });
+
+    expect(getCwdCalls).toBe(0);
+    expect(calls.runInputs).toEqual([
+      { path: "/channel/collections/planning/explicit-path" },
+    ]);
+  });
+
   test("reads cwd at command run time when the collection path is omitted", async () => {
     const { calls, entry } = makeGenerateEntry();
     const emitted = makeEmitResult();


### PR DESCRIPTION
## Summary

## 背景

PR #1141 (#1107) の takt review で検出されたスコープ外指摘 2 件。#1107 のスコープ（CLI smoke test timeout 構造的解決）は完了済みのため、別 issue として切り出す。

## 作業内容

### 1. `getCwd()` 遅延評価 (CODE-NEW-generate-suno-cli-L72)

`packages/cli/src/commands/generate-suno/cli.ts:72` で `const cwd = getCwd()` が explicit path 指定時にも必ず実行される。cwd を遅延評価に変更し、explicit path 時に `getCwd` が呼ばれないテストを追加する。

### 2. `skills-bundle-pack.test.ts` テスト独立性 (testing-review-001)

`beforeAll` の共有 fixture を複数テストが変更しており、テスト独立性に問題。状態変更するテストは各テスト内で `createIsolatedPackage()` を独立生成する。

## 関連

- 元 PR: #1141
- 元 issue: #1107
- takt review report: `.takt/runs/20260621-151444-1141/reports/`

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1156

Closes #1156