### PR TITLE
[#1158] issue-1158-fix-preflight-en-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(preflight)`: en-only / チャプター無し運用を阻む 3 つのハードゲートを緩和した（#1158）。`REQUIRED_LOCALIZATION_LANGUAGES` のハードコード撤廃、タイムスタンプ ≥3 必須チェック撤廃、`scene_phrases` を `supported_languages` のみ要求に変更。Closes #867, #1157
+
 ### Changed
 
 - `refactor(ts-rewrite/core)`: ChannelConfig の出力構造を 12 フラット名前空間から 4 bucket（identity / publishing / engagement / integrations）へ再編成した（#827）。入力 JSON 形式・パース挙動・エラーメッセージは不変。Phase 2 service が統一的な bucket API で config にアクセスする基盤

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -18,7 +18,6 @@ from youtube_automation.utils.preflight_checks import (
     check_chapter_variation_suffix,
     check_duration,
     check_low_cpm_localization_languages,
-    check_required_localization_languages,
     check_tags_count,
     check_tags_yt_chars,
     check_title_template_compliance,
@@ -62,7 +61,7 @@ class PreflightMixin:
 
         過去事例の再発防止:
         1. descriptions.md が存在すること（Track 01 仮名フォールバックを防ぐ）
-        2. workflow-state.json.scene_phrases に EN + 全 supported_languages が
+        2. workflow-state.json.scene_phrases に supported_languages が
            揃っていること（多言語タイトルが EN ベタコピーになる事故を防ぐ）
         3. タイムスタンプ件数が `audio.chapter_max` 以内かつ chapter 名に
            パターン展開接尾辞（v1〜v6 / ロマン数字 I〜VIII）を含まないこと
@@ -71,7 +70,7 @@ class PreflightMixin:
         5. タグ件数が `tags.min_count` を満たすこと（戦略書違反防止）
         6. タグの quotation 込み文字数が YouTube の 500 制限内
         7. master 動画尺が `audio.target_duration_min/max` 範囲内
-        8. supported_languages が高 CPM 必須言語 ja/en/de を含むこと
+        8. supported_languages に低 CPM 警告対象言語が含まれる場合は warning を出すこと
         """
         paths = CollectionPaths(collection_dir)
         desc_path = paths.descriptions_md_path
@@ -103,17 +102,11 @@ class PreflightMixin:
                 f"  → コレクション名の流用ではなく鋳型に沿った公開タイトルを /video-description で再生成してください。"
             )
 
-        msg = check_required_localization_languages(config.localizations.supported_languages)
-        if msg:
-            raise RuntimeError(f"❌ {msg}。config/localizations.json を見直してください。")
         msg = check_low_cpm_localization_languages(config.localizations.supported_languages)
         if msg:
             logger.warning(f"⚠️  {msg}。意図的な例外でなければ config/localizations.json を見直してください。")
 
-        # タイムスタンプ粒度検証
         ts_lines = [line for line in description.split("\n") if re.match(r"^\d{1,2}:\d{2}", line.strip())]
-        if len(ts_lines) < 3:
-            raise RuntimeError(f"❌ タイムスタンプ {len(ts_lines)} 個 (最低 3 必要)")
         msg = check_chapter_count(len(ts_lines), config.audio.chapter_max)
         if msg:
             raise RuntimeError(f"❌ {msg}。config.audio.chapter_max を見直してください。")
@@ -126,7 +119,7 @@ class PreflightMixin:
         state = json.loads(ws_path.read_text(encoding="utf-8")) if ws_path.exists() else {}
         scene_phrases = state.get("scene_phrases") or {}
 
-        required_langs = ["en"] + list(config.localizations.supported_languages)
+        required_langs = list(dict.fromkeys(config.localizations.supported_languages))
         missing = [lang for lang in required_langs if not scene_phrases.get(lang)]
         if missing:
             raise RuntimeError(

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -78,22 +78,19 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
         issues.append("missing 'Complete Collection 概要欄' section")
     else:
         ts_lines = [line for line in description.split("\n") if TS_RE.match(line.strip())]
-        if len(ts_lines) < 3:
-            issues.append(f"too few timestamps: {len(ts_lines)} (<3)")
-        else:
-            for msg in (
-                check_chapter_count(len(ts_lines), config.audio.chapter_max),
-                check_chapter_variation_suffix(ts_lines),
-            ):
-                if msg:
-                    issues.append(msg)
+        for msg in (
+            check_chapter_count(len(ts_lines), config.audio.chapter_max),
+            check_chapter_variation_suffix(ts_lines),
+        ):
+            if msg:
+                issues.append(msg)
 
     # workflow-state.json scene_phrases
     ws = paths.workflow_state_path
     if ws.exists():
         state = json.loads(ws.read_text(encoding="utf-8"))
         sp = state.get("scene_phrases") or {}
-        required = ["en"] + supported_langs
+        required = list(dict.fromkeys(supported_langs))
         missing = [lang for lang in required if not sp.get(lang)]
         if missing:
             issues.append(f"workflow-state.scene_phrases missing langs: {missing[:6]}{'…' if len(missing) > 6 else ''}")

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -39,10 +39,7 @@ DEFAULT_TITLE_VOLUME_PATTERNS = (
 
 
 def check_chapter_count(ts_count: int, chapter_max: int) -> str | None:
-    """chapter 件数が上限超過なら issue 文字列、範囲内なら None.
-
-    下限 (< 3) は別途呼び出し側でチェックする。
-    """
+    """chapter 件数が上限超過なら issue 文字列、範囲内なら None."""
     if ts_count > chapter_max:
         return f"too many timestamps: {ts_count} (> chapter_max={chapter_max})"
     return None

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -6,8 +6,10 @@ issue #82 の再発防止として、旧コード (`zh-Hans` / `zh-Hant`) を期
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # metadata_audit.py は module-level で channel_dir() を呼ぶため、import 前に
@@ -18,7 +20,7 @@ os.environ.setdefault("CHANNEL_DIR", str(_FIXTURE))
 
 import pytest  # noqa: E402
 
-from youtube_automation.scripts.metadata_audit import audit_remote  # noqa: E402
+from youtube_automation.scripts.metadata_audit import audit_local, audit_remote  # noqa: E402
 
 _ZH_ISSUE_TOKEN = "zh codes"  # `metadata_audit.py` のエラー文言 "YT zh codes are ..." に対応
 
@@ -40,6 +42,67 @@ def _patched_yt(response: dict) -> MagicMock:
     yt = MagicMock()
     yt.videos.return_value.list.return_value.execute.return_value = response
     return yt
+
+
+def _audit_config(supported_languages: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(
+        audio=SimpleNamespace(
+            chapter_max=12,
+            target_duration_min=None,
+            target_duration_max=None,
+        ),
+        content=SimpleNamespace(
+            tags=SimpleNamespace(
+                min_count=None,
+                for_collection=lambda _name: ["fallback"],
+            )
+        ),
+        localizations=SimpleNamespace(supported_languages=supported_languages),
+    )
+
+
+def _write_local_collection(tmp_path: Path, *, scene_phrases: dict[str, str], description: str) -> Path:
+    collection_dir = tmp_path / "20260622-test-collection"
+    docs_dir = collection_dir / "20-documentation"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "descriptions.md").write_text(
+        f"""## タイトル案
+```
+Continuous Focus Mix
+```
+
+## Complete Collection 概要欄
+```
+{description}
+```
+""",
+        encoding="utf-8",
+    )
+    (collection_dir / "workflow-state.json").write_text(
+        json.dumps({"scene_phrases": scene_phrases}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return collection_dir
+
+
+class TestAuditLocalPreflightContract:
+    def test_en_only_channel_without_timestamps_passes(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={"en": "continuous focus mix"},
+            description="A continuous BGM mix without chapter markers.",
+        )
+
+        assert audit_local(collection_dir, _audit_config(["en"])) == []
+
+    def test_scene_phrases_require_only_supported_languages(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={"ja": "連続作業用ミックス"},
+            description="A continuous BGM mix without chapter markers.",
+        )
+
+        assert audit_local(collection_dir, _audit_config(["ja"])) == []
 
 
 class TestAuditRemoteZhCodes:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,150 @@
+"""PreflightMixin の collection upload 前チェックの回帰テスト."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.agents._preflight import PreflightMixin
+
+
+class _PreflightHarness(PreflightMixin):
+    def __init__(self, collections_root: Path) -> None:
+        self.collections_root = collections_root
+
+    @staticmethod
+    def _extract_md_section(text: str, header: str) -> str | None:
+        pattern = rf"^## {re.escape(header)}\n```(?:\w+)?\n(.*?)\n```"
+        match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+        return match.group(1) if match else None
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_minimal_channel(tmp_path: Path, *, youtube_language: str, supported_languages: list[str]) -> Path:
+    channel_dir = tmp_path / "channel"
+    _write_json(
+        channel_dir / "config" / "channel" / "meta.json",
+        {
+            "channel": {
+                "name": "Test Channel",
+                "short": "TC",
+                "youtube_handle": "@testchannel",
+                "url": "https://youtube.com/@testchannel",
+            }
+        },
+    )
+    _write_json(
+        channel_dir / "config" / "channel" / "content.json",
+        {
+            "genre": {"primary": "ambient", "style": "quiet", "context": "work"},
+            "tags": {
+                "base": ["ambient music", "focus music"],
+                "themes": {"continuous": ["continuous music"]},
+            },
+            "descriptions": {
+                "opening": "{style} {primary} for {context}",
+                "perfect_for": ["Work", "Focus"],
+                "hashtags": ["#AmbientMusic"],
+            },
+            "title": {"template": "{theme} - {activity}"},
+        },
+    )
+    _write_json(
+        channel_dir / "config" / "channel" / "youtube.json",
+        {
+            "youtube": {
+                "category_id": "10",
+                "privacy_status": "public",
+                "language": youtube_language,
+            }
+        },
+    )
+    _write_json(
+        channel_dir / "config" / "localizations.json",
+        {"supported_languages": supported_languages, "languages": {}},
+    )
+    return channel_dir
+
+
+def _write_collection(channel_dir: Path, *, scene_phrases: dict[str, str], description: str) -> Path:
+    collection_dir = channel_dir / "collections" / "planning" / "20260622-tc-continuous"
+    docs_dir = collection_dir / "20-documentation"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "descriptions.md").write_text(
+        f"""## タイトル案
+```
+Continuous Focus Mix
+```
+
+## Complete Collection 概要欄
+```
+{description}
+```
+""",
+        encoding="utf-8",
+    )
+    _write_json(collection_dir / "workflow-state.json", {"scene_phrases": scene_phrases})
+    return collection_dir
+
+
+def _run_preflight(channel_dir: Path, collection_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+    _PreflightHarness(channel_dir / "collections")._preflight_check(collection_dir)
+
+
+def test_en_only_channel_without_timestamps_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en"])
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "continuous focus mix"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_scene_phrases_require_only_supported_languages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="ja", supported_languages=["ja"])
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"ja": "連続作業用ミックス"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_missing_supported_scene_phrase_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "ja", "de"])
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "continuous focus mix"},
+        description="00:00 Opening\n10:00 Middle\n20:00 Ending",
+    )
+
+    with pytest.raises(RuntimeError, match="workflow-state.json.scene_phrases"):
+        _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_low_cpm_localization_warning_still_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "ko"])
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "continuous focus mix", "ko": "continuous focus mix"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+    assert "low CPM localization languages included: ko" in caplog.text

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -117,7 +117,7 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
 
 
 class TestPreflightLocalizationLanguages:
-    def test_should_fail_when_required_high_cpm_language_is_missing(self, tmp_path):
+    def test_should_pass_when_supported_scene_languages_are_present(self, tmp_path):
         from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja"])
@@ -127,8 +127,7 @@ class TestPreflightLocalizationLanguages:
             "youtube_automation.agents._preflight.load_config",
             return_value=_make_preflight_config(["ja", "en"]),
         ):
-            with pytest.raises(RuntimeError, match="de"):
-                uploader._preflight_check(col_dir)
+            uploader._preflight_check(col_dir)
 
     def test_should_pass_when_required_high_cpm_languages_are_present(self, tmp_path):
         from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader


### PR DESCRIPTION
## Summary

## 背景

複数ユーザーから「en-only チャンネル」「連続 BGM・チャプター無し」運用で `yt-upload-collection` の preflight に弾かれ、手動アップロードに戻っている、というフィードバックが上がっている。

YouTube が受け付ける状態であるにもかかわらず、ツール独自のハードゲートが壁になっている。困っている人が多いため、TS 移行中ではあるが先行対応する。

## 問題箇所（3 つのハードゲート）

すべて `src/youtube_automation/agents/_preflight.py` の `_preflight_check()` 内:

### 1. 多言語ローカライズ必須（L106-108）

```python
msg = check_required_localization_languages(config.localizations.supported_languages)
if msg:
    raise RuntimeError(...)
```

`preflight_checks.py:16` の `REQUIRED_LOCALIZATION_LANGUAGES = ("ja", "en", "de")` がハードコードされており、`supported_languages: ["en"]` だと `ja, de missing` で fail。

### 2. タイムスタンプ ≥3 必須（L114-116）

```python
ts_lines = [line for line in description.split("\n") if re.match(r"^\d{1,2}:\d{2}", line.strip())]
if len(ts_lines) < 3:
    raise RuntimeError(f"❌ タイムスタンプ {len(ts_lines)} 個 (最低 3 必要)")
```

連続 BGM・チャプター無し（ベンチマーク TTP 判断）のチャンネルで fail。

### 3. scene_phrases 全言語必須（L126-136）

```python
required_langs = ["en"] + list(config.localizations.supported_languages)
missing = [lang for lang in required_langs if not scene_phrases.get(lang)]
if missing:
    raise RuntimeError(...)
```

多言語 scene_phrases が未入力だと fail。en-only チャンネルでは en だけあれば十分。

## 修正方針

`_preflight.py` のハードゲート 3 つを、チャンネル config の `supported_languages` を正として緩和する:

1. **多言語ハードコード撤廃**: `check_required_localization_languages` の呼び出しを削除（または `supported_languages` を `required` に渡して自己参照＝常に pass にする）。`check_low_cpm_localization_languages`（warning）は現状維持
2. **タイムスタンプ ≥3 必須を撤廃**: `if len(ts_lines) < 3: raise` を削除。上限チェック（`check_chapter_count`）と variation suffix チェックは現状維持
3. **scene_phrases**: `supported_languages` に含まれる言語のみを要求する（現状は `["en"] + supported_languages` で en が重複加算される問題もある）

config トグル化（`require_localization_languages` / `require_chapters` を config で on/off）は過剰設計。ハードコード値を撤廃して config の `supported_languages` を尊重すれば、en-only も多言語も自然に通る。

## 対象ファイル

- `src/youtube_automation/agents/_preflight.py` — ハードゲート 3 箇所の緩和
- `src/youtube_automation/utils/preflight_checks.py` — `REQUIRED_LOCALIZATION_LANGUAGES` 定数の扱い（関数自体は後方互換で残置可）
- `tests/` — preflight 関連テストの更新

## 関連 issue

- #867 — preflight 緩和の元フィードバック（OPEN・未対応）
- #1157 — 多言語ハードコード撤廃（CLOSED だが main 未マージ。ブランチ `fix/1157-en-only-preflight` に修正あり）

## 検証

- `supported_languages: ["en"]` で `yt-upload-collection` の preflight が pass すること
- チャプター無し（タイムスタンプ 0 行）で preflight が pass すること
- 既存の多言語チャンネル（`["en","ja","de"]`）で挙動が変わらないこと
- `check_low_cpm_localization_languages` の warning が引き続き機能すること

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1158

Closes #867
Closes #1157
Closes #1158