### PR TITLE
chore(release): v5.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.10] - 2026-06-22
+
 ### Fixed
 
 - `fix(preflight)`: en-only / チャプター無し運用を阻む 3 つのハードゲートを緩和した（#1158）。`REQUIRED_LOCALIZATION_LANGUAGES` のハードコード撤廃、タイムスタンプ ≥3 必須チェック撤廃、`scene_phrases` を `supported_languages` のみ要求に変更。Closes #867, #1157
@@ -1133,6 +1135,10 @@ uv run yt-config-migrate verify                  # 新 loader で読めるか検
 未マップキー（例: `suno` 等のチャンネル独自拡張）は `yt-config-migrate` が warning を出力し、
 `--strict` 指定時は `ConfigError` で中止する。
 
+[5.5.10]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.10
+[5.5.9]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.9
+[5.5.8]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.8
+[5.5.7]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.7
 [5.5.6]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.6
 [5.5.5]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.5
 [5.5.4]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.5.9"
+version = "5.5.10"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.9"
+version = "5.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

v5.5.10 のリリース PR。

- `pyproject.toml::version` を v5.5.10 に bump
- `CHANGELOG.md` の `[Unreleased]` を `[5.5.10] - 2026-06-22` に昇格

## Release notes

### Fixed

- `fix(preflight)`: en-only / チャプター無し運用を阻む 3 つのハードゲートを緩和した（#1158）。`REQUIRED_LOCALIZATION_LANGUAGES` のハードコード撤廃、タイムスタンプ ≥3 必須チェック撤廃、`scene_phrases` を `supported_languages` のみ要求に変更。Closes #867, #1157

## Next steps

1. このリリース PR をレビュー → マージ
2. マージ後、`/automation-release` を再実行して publish フェーズに進む（tag + GitHub Release 自動作成）
3. publish 後、各チャンネルリポジトリで `/automation-update` を実行すると追従可能