### PR TITLE
docs(skills): preflight 緩和に合わせてスキル記述を更新

### DIFF
--- a/.claude/skills/channel-setup/references/config-generation-rules.md
+++ b/.claude/skills/channel-setup/references/config-generation-rules.md
@@ -21,7 +21,7 @@
 
 - `channel` — name, short, core_message, channel_id, youtube_handle, url
 - `content_model` — collection / release など
-- `localization` — `default_language` + `supported_languages`。`localizations.json.supported_languages` と一致させること（scene_phrases / 概要欄多言語版の対象言語、単一ソース宣言）。`supported_languages` は広告単価が高い 3 言語（`ja` / `en` / `de`）を必ず含め、低 CPM 言語（`ko` / `es` / `pt` / `zh-CN` など）は原則追加しない（issue #272）。**TTP 路線時**は競合の `localizations` エントリ言語を最優先で踏襲する。競合が多言語化していないチャンネル（en 一択など）を TTP 対象にしている場合、自分も同様に絞る選択肢を必ずユーザーに提示する
+- `localization` — `default_language` + `supported_languages`。`localizations.json.supported_languages` と一致させること（scene_phrases / 概要欄多言語版の対象言語、単一ソース宣言）。`supported_languages` は多言語チャンネルなら高 CPM 言語（`ja` / `en` / `de`）を推奨、低 CPM 言語（`ko` / `es` / `pt` / `zh-CN` など）は原則追加しない（issue #272）。en-only 運用も可（preflight は `supported_languages` を尊重し、ハードコード必須言語は無い）。**TTP 路線時**は競合の `localizations` エントリ言語を最優先で踏襲する。競合が多言語化していないチャンネル（en 一択など）を TTP 対象にしている場合、自分も同様に絞る選択肢を必ずユーザーに提示する
 - `music_engine` — `"suno"` または `"lyria"`（チャンネルのデフォルト音楽エンジン）
 - `genre` — primary, style, context
 - `youtube` — デフォルトのアップロード設定

--- a/.claude/skills/wf-new/references/scene_phrases.md
+++ b/.claude/skills/wf-new/references/scene_phrases.md
@@ -66,4 +66,4 @@ $ uv run yt-populate-scene-phrases 20260322-rjn-city-collection --dry-run
 
 - 検証: `yt-metadata-audit` が `scene_phrases` の `en` + `supported_languages` 完全性を検証する
 - メタデータ生成: `metadata_generator.py::_load_scene_phrases` が `workflow-state.json` から読み込んでタイトル・localizations を生成する
-- アップロード時 preflight: `youtube_auto_uploader.py` が `scene_phrases` の言語欠落を検出すると upload が中断する
+- アップロード時 preflight: `youtube_auto_uploader.py` が `scene_phrases` の `supported_languages` 分の言語欠落を検出すると upload が中断する（en-only チャンネルなら en のみで通る）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `docs(skills)`: preflight 緩和（v5.5.10 #1158）に合わせてスキルの記述を更新。`channel-setup` の `supported_languages` 必須言語記述を推奨に変更、`wf-new` の `scene_phrases` preflight 説明を `supported_languages` 準拠に修正
+
 ## [5.5.10] - 2026-06-22
 
 ### Fixed


### PR DESCRIPTION
## Summary

v5.5.10 (#1158) で preflight のハードゲートを緩和したが、スキルの記述が旧仕様のままだった 2 箇所を修正。

- `channel-setup/references/config-generation-rules.md`: `supported_languages` は「ja/en/de を必ず含め」→ 多言語なら推奨、en-only も可
- `wf-new/references/scene_phrases.md`: preflight 説明を `supported_languages` 準拠に修正

## Test plan

- [ ] スキル記述がコード実装（`_preflight.py`）と整合していることを確認

Closes #1158