### PR TITLE
[#1210] issue-1210-suno-helper-dir-mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側 `/collections` `/suno-prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
+
 ## [5.5.11] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側 `/collections` `/suno-prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
+- `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 
 ## [5.5.11] - 2026-06-22
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -243,6 +243,17 @@ export function pickInitialCollectionId(
   return collections.find((c) => c.has_prompts)?.id ?? null;
 }
 
+export function resolvePromptCollectionId(
+  collections: CollectionSummary[],
+  selectedId: string,
+): string | null {
+  const selected = collections.find((c) => c.id === selectedId);
+  if (selected?.has_prompts) {
+    return selected.id;
+  }
+  return pickInitialCollectionId(collections);
+}
+
 /** collection id 末尾の接尾辞。剥がしてから日付・channel・theme を解釈する。 */
 const COLLECTION_SUFFIX = "-collection";
 

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -84,9 +84,7 @@ interface RunnerState {
   stop: () => Promise<void>;
 }
 
-type PromptSource =
-  | { kind: "collection"; collectionId: string | null }
-  | { kind: "single-file" };
+type PromptSource = { kind: "collection"; collectionId: string | null } | { kind: "single-file" };
 
 async function fetchCollectionEntries(baseUrl: string, collectionId: string | null): Promise<PromptEntry[]> {
   if (collectionId === null) {

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -12,8 +12,8 @@ import {
   fetchCollectionPrompts,
   fetchCollections,
   fetchPrompts,
-  pickInitialCollectionId,
   type PromptEntry,
+  resolvePromptCollectionId,
   resolveCompatibilityWarning,
 } from "../../shared/api";
 import { type ItemState, PHASE, type SpeedPresetId } from "../../shared/constants";
@@ -84,8 +84,19 @@ interface RunnerState {
   stop: () => Promise<void>;
 }
 
+type PromptSource =
+  | { kind: "collection"; collectionId: string | null }
+  | { kind: "single-file" };
+
+async function fetchCollectionEntries(baseUrl: string, collectionId: string | null): Promise<PromptEntry[]> {
+  if (collectionId === null) {
+    throw new Error("prompts を取得できる collection がありません。");
+  }
+  return fetchCollectionPrompts(baseUrl, collectionId);
+}
+
 export function useSunoRunner(): RunnerState {
-  const [url, setUrl] = useState("");
+  const [url, setUrlState] = useState("");
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
   // fetchCollections が非空だが全件 mapped で filter 後 0 件になったか (#893 要件 B)。placeholder 表示用。
   const [allMapped, setAllMapped] = useState(false);
@@ -239,26 +250,78 @@ export function useSunoRunner(): RunnerState {
     setResumeDismissed(true);
   }, []);
 
-  const loadCollections = useCallback(async (baseUrl: string) => {
-    try {
-      const fetched = await fetchCollections(baseUrl);
-      // 既にマッピング済み collection をドロップダウンから外す (#893 追加要件 B)。prefix 未指定の
-      // 旧サーバーは mapped を返さず全件残る（後方互換）。fetched 非空 + filter 後空 = 全件マッピング済み。
-      const list = excludeMappedCollections(fetched);
-      setCollections(list);
-      setAllMapped(fetched.length > 0 && list.length === 0);
-      setSelectedCollectionId(pickInitialCollectionId(list) ?? "");
-    } catch {
-      // 単一ファイル mode サーバーは `/collections` が 404。ドロップダウンを出さず単一 mode へ fallback。
-      setCollections([]);
-      setAllMapped(false);
-      setSelectedCollectionId("");
-    }
+  const clearLoadedRunState = useCallback(() => {
+    setEntries([]);
+    setItemStates([]);
+    setRestoredPlaylistName(undefined);
+    setRestoredFailedIndex(undefined);
+    setRestoredFailedIndices(undefined);
+    setRestoredSubmittedClipIds(undefined);
+    setRestoredPlaylistExpectedClipCount(undefined);
   }, []);
+
+  const updateUrl = useCallback(
+    (nextUrl: string) => {
+      setUrlState(nextUrl);
+      clearLoadedRunState();
+    },
+    [clearLoadedRunState],
+  );
+
+  const selectCollection = useCallback(
+    (id: string) => {
+      setSelectedCollectionId(id);
+      clearLoadedRunState();
+    },
+    [clearLoadedRunState],
+  );
+
+  const applySingleFileMode = useCallback(() => {
+    setCollections([]);
+    setAllMapped(false);
+    setSelectedCollectionId("");
+  }, []);
+
+  const syncCollections = useCallback(
+    async (baseUrl: string, currentSelectedId: string): Promise<PromptSource> => {
+      try {
+        const fetched = await fetchCollections(baseUrl);
+        // 既にマッピング済み collection をドロップダウンから外す (#893 追加要件 B)。prefix 未指定の
+        // 旧サーバーは mapped を返さず全件残る（後方互換）。fetched 非空 + filter 後空 = 全件マッピング済み。
+        const list = excludeMappedCollections(fetched);
+        const nextSelectedId = resolvePromptCollectionId(list, currentSelectedId);
+        setCollections(list);
+        setAllMapped(fetched.length > 0 && list.length === 0);
+        setSelectedCollectionId(nextSelectedId ?? "");
+        return { kind: "collection", collectionId: nextSelectedId };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === "HTTP 404") {
+          // 単一ファイル mode サーバーは `/collections` が 404。ドロップダウンを出さず単一 mode へ fallback。
+          applySingleFileMode();
+          return { kind: "single-file" };
+        }
+        throw err;
+      }
+    },
+    [applySingleFileMode],
+  );
+
+  const loadCollections = useCallback(
+    async (baseUrl: string) => {
+      try {
+        await syncCollections(baseUrl, "");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        report(`コレクション一覧取得失敗: ${message}`, true);
+      }
+    },
+    [report, syncCollections],
+  );
 
   useEffect(() => {
     void serverUrlItem.getValue().then((stored) => {
-      setUrl(stored);
+      setUrlState(stored);
       const trimmed = stored.trim();
       if (trimmed) {
         void loadCollections(trimmed);
@@ -320,10 +383,11 @@ export function useSunoRunner(): RunnerState {
     const extensionVersion = browser.runtime.getManifest().version;
     setCompatibilityWarning(await resolveCompatibilityWarning(trimmed, extensionVersion));
     try {
-      // collection を選択している場合は dir mode の個別配信、未選択なら単一ファイル mode へ fallback。
-      const data = selectedCollectionId
-        ? await fetchCollectionPrompts(trimmed, selectedCollectionId)
-        : await fetchPrompts(trimmed);
+      const promptSource = await syncCollections(trimmed, selectedCollectionId);
+      const data =
+        promptSource.kind === "single-file"
+          ? await fetchPrompts(trimmed)
+          : await fetchCollectionEntries(trimmed, promptSource.collectionId);
       setEntries(data);
       setItemStates(data.map(() => "idle"));
       report(`${data.length} パターンを取得しました。`);
@@ -333,7 +397,7 @@ export function useSunoRunner(): RunnerState {
       setItemStates([]);
       report(`取得失敗: ${message}\nyt-collection-serve が起動しているか確認してください。`, true);
     }
-  }, [url, selectedCollectionId, report]);
+  }, [url, selectedCollectionId, syncCollections, report]);
 
   const run = useCallback(
     async (overrides?: RunOverrides) => {
@@ -435,11 +499,11 @@ export function useSunoRunner(): RunnerState {
 
   return {
     url,
-    setUrl,
+    setUrl: updateUrl,
     collections,
     allMapped,
     selectedCollectionId,
-    selectCollection: setSelectedCollectionId,
+    selectCollection,
     entries,
     itemStates,
     status,

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -294,8 +294,9 @@ export function useSunoRunner(): RunnerState {
         return { kind: "collection", collectionId: nextSelectedId };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        if (message === "HTTP 404") {
-          // 単一ファイル mode サーバーは `/collections` が 404。ドロップダウンを出さず単一 mode へ fallback。
+        if (message === "HTTP 404" || err instanceof TypeError) {
+          // 単一ファイル mode サーバーは `/collections` が 404。CORS ヘッダーなしの 404 は
+          // ブラウザが TypeError (Failed to fetch) として reject するため両方を捕捉する。
           applySingleFileMode();
           return { kind: "single-file" };
         }

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -16,6 +16,7 @@ import {
   fetchServerVersion,
   formatCompatibilityWarning,
   pickInitialCollectionId,
+  resolvePromptCollectionId,
   resolveCompatibilityWarning,
 } from "../../shared/api";
 
@@ -321,6 +322,41 @@ describe("shared/api pickInitialCollectionId: 初期選択ルール", () => {
 
   it("Given 空配列 When 初期値を選ぶ Then null を返す", () => {
     expect(pickInitialCollectionId([])).toBeNull();
+  });
+});
+
+describe("shared/api resolvePromptCollectionId: prompts 取得対象 collection の解決", () => {
+  it("Given 選択中 id が最新一覧に存在し prompts あり When 解決 Then 選択中 id を返す", () => {
+    const collections: CollectionSummary[] = [
+      { id: "c1", name: "c1", has_prompts: true, pattern_count: 1 },
+      { id: "c2", name: "c2", has_prompts: true, pattern_count: 2 },
+    ];
+
+    expect(resolvePromptCollectionId(collections, "c2")).toBe("c2");
+  });
+
+  it("Given 選択中 id が最新一覧に無い When 解決 Then 初期選択 id を返す", () => {
+    const collections: CollectionSummary[] = [
+      { id: "c1", name: "c1", has_prompts: true, pattern_count: 1 },
+      { id: "c2", name: "c2", has_prompts: true, pattern_count: 2 },
+    ];
+
+    expect(resolvePromptCollectionId(collections, "old-url-c9")).toBe("c1");
+  });
+
+  it("Given 選択中 id が prompts 無し When 解決 Then 最初の prompts あり id を返す", () => {
+    const collections: CollectionSummary[] = [
+      { id: "c1", name: "c1", has_prompts: false, pattern_count: null },
+      { id: "c2", name: "c2", has_prompts: true, pattern_count: 2 },
+    ];
+
+    expect(resolvePromptCollectionId(collections, "c1")).toBe("c2");
+  });
+
+  it("Given prompts あり collection が無い When 解決 Then null を返す", () => {
+    const collections: CollectionSummary[] = [{ id: "c1", name: "c1", has_prompts: false, pattern_count: null }];
+
+    expect(resolvePromptCollectionId(collections, "c1")).toBeNull();
   });
 });
 

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -10,6 +10,16 @@ import { App } from "../components/App";
 const BASE_URL = "http://localhost:7873";
 const MANIFEST_VERSION = "0.1.9";
 
+const messagingMocks = vi.hoisted(() => ({
+  onMessage: vi.fn(() => () => undefined),
+  sendMessage: vi.fn(),
+}));
+
+const storageMocks = vi.hoisted(() => ({
+  getValue: vi.fn(async () => ""),
+  setValue: vi.fn(async () => undefined),
+}));
+
 vi.mock("wxt/browser", () => ({
   browser: {
     runtime: {
@@ -19,18 +29,17 @@ vi.mock("wxt/browser", () => ({
 }));
 
 vi.mock("../lib/storage", () => ({
-  serverUrlItem: {
-    getValue: vi.fn(async () => ""),
-    setValue: vi.fn(async () => undefined),
-  },
+  serverUrlItem: storageMocks,
 }));
 
-vi.mock("../lib/messaging", () => ({
-  onMessage: vi.fn(() => () => undefined),
-  sendMessage: vi.fn(async () => {
+vi.mock("../lib/messaging", () => messagingMocks);
+
+function defaultSendMessage(message: string): Promise<unknown> {
+  if (message === "queryProgress") {
     throw new Error("runner unavailable");
-  }),
-}));
+  }
+  return Promise.resolve({ ok: true });
+}
 
 vi.mock("../lib/preset-state", async () => {
   const actual = await vi.importActual<typeof import("../lib/preset-state")>("../lib/preset-state");
@@ -66,6 +75,25 @@ function setInputValue(input: HTMLInputElement, value: string): void {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+function setSelectValue(select: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+  if (!setter) {
+    throw new Error("HTMLSelectElement.value setter is unavailable");
+  }
+  setter.call(select, value);
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!button) {
+    throw new Error(`button not found: ${text}`);
+  }
+  return button;
+}
+
 async function waitFor(assertion: () => void): Promise<void> {
   for (let i = 0; i < 20; i += 1) {
     try {
@@ -92,6 +120,7 @@ describe("Suno popup compatibility check", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     fetchMock = vi.fn();
+    messagingMocks.sendMessage.mockImplementation(defaultSendMessage);
     vi.stubGlobal("fetch", fetchMock);
 
     await act(async () => {
@@ -106,30 +135,13 @@ describe("Suno popup compatibility check", () => {
     container.remove();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    storageMocks.getValue.mockResolvedValue("");
+    storageMocks.setValue.mockResolvedValue(undefined);
   });
 
   it("データ取得時に manifest version で /version を先に呼び、非互換警告を表示して prompts 取得を継続する", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: "0.2.0" }))
-      .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
-
-    await act(async () => {
-      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>("button")!.click();
-    });
-
-    await waitFor(() => {
-      expect(container.textContent).toContain(`拡張を更新してください（拡張 ${MANIFEST_VERSION}`);
-      expect(container.textContent).toContain("1 パターンを取得しました。");
-    });
-    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
-    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/suno/prompts.json`);
-  });
-
-  it("旧サーバーの /version 404 は警告なしで prompts 取得を継続する", async () => {
-    fetchMock
       .mockResolvedValueOnce(jsonResponse(404, {}))
       .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
 
@@ -137,7 +149,29 @@ describe("Suno popup compatibility check", () => {
       setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
     });
     await act(async () => {
-      container.querySelector<HTMLButtonElement>("button")!.click();
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(`拡張を更新してください（拡張 ${MANIFEST_VERSION}`);
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/collections`);
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/suno/prompts.json`);
+  });
+
+  it("旧サーバーの /version 404 は警告なしで prompts 取得を継続する", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
     });
 
     await waitFor(() => {
@@ -145,6 +179,141 @@ describe("Suno popup compatibility check", () => {
     });
     expect(container.textContent).not.toContain("拡張を更新してください");
     expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
-    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/suno/prompts.json`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/collections`);
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/suno/prompts.json`);
+  });
+
+  it("dir mode で URL 入力後にデータ取得すると collection endpoint の entries を run payload に渡す", async () => {
+    const entries = [{ name: "p1", style: "lofi", lyrics: "" }];
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          { id: "20260601-clm-theme-a-collection", name: "theme-a-collection", has_prompts: true, pattern_count: 1 },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, entries));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+
+    await act(async () => {
+      buttonByText(container, "全パターンを連続実行").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("連続実行を開始しました。");
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/collections`);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      `${BASE_URL}/collections/20260601-clm-theme-a-collection/suno/prompts.json`,
+    );
+    expect(messagingMocks.sendMessage).toHaveBeenCalledWith("run", {
+      entries,
+      playlistName: "clm | theme-a",
+      range: undefined,
+      collectionId: "20260601-clm-theme-a-collection",
+      indices: undefined,
+      submittedClipIds: undefined,
+      playlistExpectedClipCount: undefined,
+    });
+  });
+
+  it("dir mode でデータ取得後に collection を変更すると再取得まで連続実行できない", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          { id: "20260601-clm-theme-a-collection", name: "theme-a-collection", has_prompts: true, pattern_count: 1 },
+          { id: "20260602-clm-theme-b-collection", name: "theme-b-collection", has_prompts: true, pattern_count: 1 },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+
+    messagingMocks.sendMessage.mockClear();
+    await act(async () => {
+      setSelectValue(container.querySelector<HTMLSelectElement>("select")!, "20260602-clm-theme-b-collection");
+    });
+
+    const runButton = buttonByText(container, "全パターンを連続実行");
+    expect(runButton.disabled).toBe(true);
+
+    await act(async () => {
+      runButton.click();
+    });
+    expect(messagingMocks.sendMessage).not.toHaveBeenCalledWith("run", expect.anything());
+  });
+
+  it("dir mode の collection 一覧に実行可能候補が無い場合は single-file endpoint へフォールバックしない", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(jsonResponse(200, []));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("取得失敗: prompts を取得できる collection がありません。");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/collections`);
+  });
+
+  it("popup 起動時の collection 一覧同期では全件 mapped を取得失敗にしない", async () => {
+    act(() => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    fetchMock.mockReset();
+    storageMocks.getValue.mockResolvedValue(BASE_URL);
+    messagingMocks.sendMessage.mockImplementation(defaultSendMessage);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, [
+        {
+          id: "20260601-clm-theme-a-collection",
+          name: "theme-a-collection",
+          has_prompts: true,
+          pattern_count: 1,
+          mapped: true,
+        },
+      ]),
+    );
+
+    await act(async () => {
+      root.render(createElement(App));
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("未マッピング collection はありません。");
+    });
+    expect(container.textContent).not.toContain("コレクション一覧取得失敗");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/collections`);
   });
 });

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -265,6 +265,41 @@ describe("Suno popup compatibility check", () => {
     expect(messagingMocks.sendMessage).not.toHaveBeenCalledWith("run", expect.anything());
   });
 
+  it("dir mode でデータ取得後に URL を変更すると再取得まで連続実行できない", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          { id: "20260601-clm-theme-a-collection", name: "theme-a-collection", has_prompts: true, pattern_count: 1 },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+
+    messagingMocks.sendMessage.mockClear();
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, `${BASE_URL}/changed`);
+    });
+
+    const runButton = buttonByText(container, "全パターンを連続実行");
+    expect(runButton.disabled).toBe(true);
+
+    await act(async () => {
+      runButton.click();
+    });
+    expect(messagingMocks.sendMessage).not.toHaveBeenCalledWith("run", expect.anything());
+  });
+
   it("dir mode の collection 一覧に実行可能候補が無い場合は single-file endpoint へフォールバックしない", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -351,4 +351,25 @@ describe("Suno popup compatibility check", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/collections`);
   });
+
+  it("CORS なし 404 (TypeError) で /collections が reject されても single-file mode へ fallback する", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "p1", style: "lofi", lyrics: "" }]));
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/version`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/collections`);
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/suno/prompts.json`);
+  });
 });

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -679,6 +679,9 @@ def create_server(
             if self.path.startswith(DISTROKID_ASSETS_PREFIX):
                 self._serve_distrokid_asset()
                 return
+            if self.path == COLLECTIONS_ROUTE:
+                self._send_json_error(404, "Not Found")
+                return
             self.send_error(404, "Not Found")
 
         def _serve_dir_mode(self) -> None:
@@ -694,9 +697,13 @@ def create_server(
                 cid = self.path[len(coll_prefix) : -len(SUNO_PROMPTS_ROUTE)]
                 resolved = resolve_collection_prompts_path(collections_root, cid)
                 if resolved is None or not resolved.is_file():
-                    self.send_error(404, "Not Found")
+                    self._send_json_error(404, "Not Found")
                     return
                 self._send_bytes(resolved.read_bytes(), "application/json; charset=utf-8")
+                return
+
+            if self.path == SUNO_PROMPTS_ROUTE:
+                self._send_json_error(404, "Not Found")
                 return
 
             # --- dir mode DistroKid エンドポイント群（#934）---

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -43,6 +43,7 @@ from youtube_automation.scripts.collection_serve import (
 from youtube_automation.utils.exceptions import ConfigError
 
 _EXTENSION_ORIGIN = "chrome-extension://abcdefghijklmnopabcdefghijklmnop"
+_SUNO_ORIGIN = "https://suno.com"
 
 # 外部 HTTP 契約: 拡張が fetch する suno サブパス（リテラルで pin する）
 _SUNO_PROMPTS_ROUTE = "/suno/prompts.json"
@@ -58,6 +59,13 @@ _VERSION_ROUTE = "/version"
 def _collection_prompts_route(cid: str) -> str:
     """`GET /collections/<id>/suno/prompts.json` ルートを組み立てる（拡張側 collectionPromptsRoute と対）。"""
     return f"{_COLLECTIONS_ROUTE}/{cid}/suno/prompts.json"
+
+
+def _assert_json_404_with_cors(error: urllib.error.HTTPError, origin: str) -> None:
+    assert error.code == 404
+    assert error.headers.get("Access-Control-Allow-Origin") == origin
+    assert error.headers.get_content_type() == "application/json"
+    assert json.loads(error.read().decode("utf-8")) == {"error": "Not Found"}
 
 
 # ---------------------------------------------------------------------------
@@ -622,49 +630,59 @@ def test_get_collection_prompts_returns_entries(serve_dir, tmp_path):
 def test_get_collection_prompts_unknown_id_returns_404(serve_dir, tmp_path):
     """Given 存在しない collection id
     When `GET /collections/<id>/suno/prompts.json`
-    Then 404 を返す（ホワイトリスト弾き）。
+    Then CORS 付き JSON 404 を返す（ホワイトリスト弾き）。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260601-clm-aaa-collection", entries=[{"name": "A", "style": "s", "lyrics": ""}])
     base = serve_dir(planning)
 
-    req = urllib.request.Request(f"{base}{_collection_prompts_route('nope-collection')}")
+    req = urllib.request.Request(
+        f"{base}{_collection_prompts_route('nope-collection')}",
+        headers={"Origin": _SUNO_ORIGIN},
+    )
     with pytest.raises(urllib.error.HTTPError) as exc_info:
         urllib.request.urlopen(req)
 
-    assert exc_info.value.code == 404
+    _assert_json_404_with_cors(exc_info.value, _SUNO_ORIGIN)
 
 
 def test_get_collection_prompts_without_prompts_returns_404(serve_dir, tmp_path):
     """Given prompts json を持たない collection（has_prompts=False）
     When `GET /collections/<id>/suno/prompts.json`
-    Then 404 を返す（受け入れ条件: has_prompts true のみ実行可能）。
+    Then CORS 付き JSON 404 を返す（受け入れ条件: has_prompts true のみ実行可能）。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260601-clm-empty-collection", entries=None)
     base = serve_dir(planning)
 
-    req = urllib.request.Request(f"{base}{_collection_prompts_route('20260601-clm-empty-collection')}")
+    req = urllib.request.Request(
+        f"{base}{_collection_prompts_route('20260601-clm-empty-collection')}",
+        headers={"Origin": _EXTENSION_ORIGIN},
+    )
     with pytest.raises(urllib.error.HTTPError) as exc_info:
         urllib.request.urlopen(req)
 
-    assert exc_info.value.code == 404
+    _assert_json_404_with_cors(exc_info.value, _EXTENSION_ORIGIN)
 
 
-def test_dir_mode_does_not_serve_single_suno_prompts_route(serve_dir, tmp_path):
+@pytest.mark.parametrize("origin", [_SUNO_ORIGIN, _EXTENSION_ORIGIN])
+def test_dir_mode_does_not_serve_single_suno_prompts_route(serve_dir, tmp_path, origin):
     """Given dir mode サーバー
     When `GET /suno/prompts.json`（単一 mode のルート）
-    Then 404 を返す（単一 mode のルートは dir mode で生きない）。
+    Then CORS 付き JSON 404 を返す（単一 mode のルートは dir mode で生きない）。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260601-clm-aaa-collection", entries=[{"name": "A", "style": "s", "lyrics": ""}])
     base = serve_dir(planning)
 
-    req = urllib.request.Request(f"{base}{_SUNO_PROMPTS_ROUTE}")
+    req = urllib.request.Request(
+        f"{base}{_SUNO_PROMPTS_ROUTE}",
+        headers={"Origin": origin},
+    )
     with pytest.raises(urllib.error.HTTPError) as exc_info:
         urllib.request.urlopen(req)
 
-    assert exc_info.value.code == 404
+    _assert_json_404_with_cors(exc_info.value, origin)
 
 
 def test_dir_mode_collections_sets_cors_header_for_extension_origin(serve_dir, tmp_path):
@@ -684,15 +702,19 @@ def test_dir_mode_collections_sets_cors_header_for_extension_origin(serve_dir, t
         assert resp.headers.get("Access-Control-Allow-Origin") == _EXTENSION_ORIGIN
 
 
-def test_single_mode_collections_route_returns_404(serve):
+@pytest.mark.parametrize("origin", [_SUNO_ORIGIN, _EXTENSION_ORIGIN])
+def test_single_mode_collections_route_returns_404(serve, origin):
     """Given 単一ファイル mode サーバー（collections_root 未指定）
     When `GET /collections`
-    Then 404 を返す。popup はこの 404 を fallback トリガーに使う（dir mode 専用ルート）。
+    Then CORS 付き JSON 404 を返す。popup はこの 404 を fallback トリガーに使う（dir mode 専用ルート）。
     """
     base = serve([{"name": "A", "style": "s", "lyrics": ""}])
 
-    req = urllib.request.Request(f"{base}{_COLLECTIONS_ROUTE}")
+    req = urllib.request.Request(
+        f"{base}{_COLLECTIONS_ROUTE}",
+        headers={"Origin": origin},
+    )
     with pytest.raises(urllib.error.HTTPError) as exc_info:
         urllib.request.urlopen(req)
 
-    assert exc_info.value.code == 404
+    _assert_json_404_with_cors(exc_info.value, origin)


### PR DESCRIPTION
## Summary

## 概要

suno-helper 拡張で「連続実行」を押すと「連続実行を開始しました。」と表示されるが、実際の Style/Lyrics 注入や Generate が始まらない。

## 再現手順

1. `yt-collection-serve` を dir mode + capture フラグ付きで起動
2. suno.com/create で Custom Mode を有効化
3. suno-helper popup でコレクションを選択 → 「データ取得」→「連続実行」
4. 「連続実行を開始しました。」と表示されるが、Suno の Style/Lyrics フィールドに何も注入されない

## 関連する問題

### 前提: content script が dir mode のエンドポイントを使っていない可能性

Console に以下の CORS エラーが出ている:

```
Access to fetch at 'http://localhost:7874/suno/prompts.json' from origin 'https://suno.com'
has been blocked by CORS policy
```

`/suno/prompts.json` は single-file mode 専用のエンドポイント。dir mode では `/collections/<id>/suno/prompts.json` を使う必要がある。

content script が popup から受け取った collection ID をもとに dir mode 用のエンドポイント (`/collections/<id>/suno/prompts.json`) にアクセスすべきところ、single-file mode の旧パスにフォールバックしているのが原因と推測。

### 前提 2: CORS ヘッダーが 404 に付かない (#1209)

仮に content script が正しいパスを使ったとしても、ルーティングに失敗した場合の `send_error(404)` が CORS なしで返るため、拡張側ではエラーの内容を判別できない。#1209 の修正が前提。

## 期待動作

popup でコレクションを選択 → content script が `/collections/<selected-id>/suno/prompts.json` から entries を取得 → 各 entry の Style/Lyrics を Suno のフォームに注入 → Generate

## 回避策（現状）

- ~~single-file mode で 1 コレクションずつ起動する~~ (未検証)

## 環境

- `youtube-channels-automation`: v5.5.11
- suno-helper 拡張: Suno (suno.com/create) 上の content script
- サーバー: dir mode (`--playlist-capture-root` + `--playlist-capture-prefix` 付き)
- 発見チャンネル: veluvia

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1210