### PR TITLE
fix(metadata-generator): トラックのサイレントスキップを検出・警告する (#1093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
+- `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加（#1093）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
-- `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加（#1093）
+- `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -310,6 +310,7 @@ class BAHMetadataGenerator:
             return []
 
         tracks = []
+        skipped: list[tuple[str, str]] = []
         current_time = 0
         crossfade = self._crossfade_sec
 
@@ -321,31 +322,51 @@ class BAHMetadataGenerator:
                 # afinfo コマンドで楽曲長を取得
                 duration = self._get_audio_duration(wav_file)
 
-                if duration > 0:
-                    # タイトル清浄化
-                    title = self._clean_track_title(wav_file.stem)
+                if duration <= 0:
+                    reason = "再生時間が 0 秒（ファイル破損または afinfo 解析失敗の可能性）"
+                    logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
+                    skipped.append((wav_file.name, reason))
+                    continue
 
-                    # タイムスタンプ計算（2曲目以降はクロスフェード分だけ前倒し）
-                    start_time = current_time
-                    end_time = current_time + duration
+                # タイトル清浄化
+                title = self._clean_track_title(wav_file.stem)
 
-                    tracks.append(
-                        {
-                            "filename": wav_file.name,
-                            "title": title,
-                            "duration": duration,
-                            "start_time": start_time,
-                            "end_time": end_time,
-                            "timestamp": self._format_timestamp(start_time),
-                            "pattern_key": _extract_pattern_key(wav_file.name),
-                        }
-                    )
+                # タイムスタンプ計算（2曲目以降はクロスフェード分だけ前倒し）
+                start_time = current_time
+                end_time = current_time + duration
 
-                    current_time = int(end_time - crossfade)
+                tracks.append(
+                    {
+                        "filename": wav_file.name,
+                        "title": title,
+                        "duration": duration,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "timestamp": self._format_timestamp(start_time),
+                        "pattern_key": _extract_pattern_key(wav_file.name),
+                    }
+                )
+
+                current_time = int(end_time - crossfade)
 
             except Exception as e:
-                logger.warning(f"ファイル解析エラー {wav_file.name}: {e}")
+                reason = f"ファイル解析エラー: {e}"
+                logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
+                skipped.append((wav_file.name, reason))
                 continue
+
+        if skipped:
+            logger.warning(
+                f"⚠️  {len(skipped)}/{len(wav_files)} トラックがスキップされました:"
+            )
+            for name, reason in skipped:
+                logger.warning(f"  - {name}: {reason}")
+
+        if len(tracks) != len(wav_files):
+            logger.warning(
+                f"⚠️  入力 {len(wav_files)} ファイル → 出力 {len(tracks)} タイムスタンプ"
+                f"（{len(wav_files) - len(tracks)} 件欠落）"
+            )
 
         self.tracks = tracks
         # LLM がリネームした表示名が workflow-state.json に永続化されていれば再ロード時にも反映する

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -356,9 +356,7 @@ class BAHMetadataGenerator:
                 continue
 
         if skipped:
-            logger.warning(
-                f"⚠️  {len(skipped)}/{len(wav_files)} トラックがスキップされました:"
-            )
+            logger.warning(f"⚠️  {len(skipped)}/{len(wav_files)} トラックがスキップされました:")
             for name, reason in skipped:
                 logger.warning(f"  - {name}: {reason}")
 

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -318,42 +318,38 @@ class BAHMetadataGenerator:
         wav_files = sorted([f for f in audio_dir.iterdir() if f.suffix.lower() in AUDIO_EXTS])
 
         for wav_file in wav_files:
+            # duration 取得のみを try で囲み、track dict 構築の実装バグは素通しさせる
             try:
-                # afinfo コマンドで楽曲長を取得
                 duration = self._get_audio_duration(wav_file)
-
-                if duration <= 0:
-                    reason = "再生時間が 0 秒（ファイル破損または afinfo 解析失敗の可能性）"
-                    logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
-                    skipped.append((wav_file.name, reason))
-                    continue
-
-                # タイトル清浄化
-                title = self._clean_track_title(wav_file.stem)
-
-                # タイムスタンプ計算（2曲目以降はクロスフェード分だけ前倒し）
-                start_time = current_time
-                end_time = current_time + duration
-
-                tracks.append(
-                    {
-                        "filename": wav_file.name,
-                        "title": title,
-                        "duration": duration,
-                        "start_time": start_time,
-                        "end_time": end_time,
-                        "timestamp": self._format_timestamp(start_time),
-                        "pattern_key": _extract_pattern_key(wav_file.name),
-                    }
-                )
-
-                current_time = int(end_time - crossfade)
-
             except Exception as e:
                 reason = f"ファイル解析エラー: {e}"
                 logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
                 skipped.append((wav_file.name, reason))
                 continue
+
+            if duration <= 0:
+                reason = "再生時間が 0 秒（ファイル破損または afinfo 解析失敗の可能性）"
+                logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
+                skipped.append((wav_file.name, reason))
+                continue
+
+            title = self._clean_track_title(wav_file.stem)
+            start_time = current_time
+            end_time = current_time + duration
+
+            tracks.append(
+                {
+                    "filename": wav_file.name,
+                    "title": title,
+                    "duration": duration,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "timestamp": self._format_timestamp(start_time),
+                    "pattern_key": _extract_pattern_key(wav_file.name),
+                }
+            )
+
+            current_time = int(end_time - crossfade)
 
         if skipped:
             logger.warning(f"⚠️  {len(skipped)}/{len(wav_files)} トラックがスキップされました:")

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -318,10 +318,9 @@ class BAHMetadataGenerator:
         wav_files = sorted([f for f in audio_dir.iterdir() if f.suffix.lower() in AUDIO_EXTS])
 
         for wav_file in wav_files:
-            # duration 取得のみを try で囲み、track dict 構築の実装バグは素通しさせる
             try:
                 duration = self._get_audio_duration(wav_file)
-            except Exception as e:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, IndexError, OSError) as e:
                 reason = f"ファイル解析エラー: {e}"
                 logger.warning(f"トラックをスキップ: {wav_file.name} — {reason}")
                 skipped.append((wav_file.name, reason))

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -376,25 +376,28 @@ class BAHMetadataGenerator:
 
         Returns:
             int: 長さ（秒）
+
+        Raises:
+            subprocess.CalledProcessError: afinfo が非ゼロ終了した場合
+            subprocess.TimeoutExpired: afinfo がタイムアウトした場合
+            ValueError: duration 文字列の数値変換に失敗した場合
+            IndexError: afinfo 出力のパースに失敗した場合
         """
-        try:
-            result = subprocess.run(
-                ["afinfo", str(wav_file)],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=30,
-            )
+        result = subprocess.run(
+            ["afinfo", str(wav_file)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
 
-            # "estimated duration: XXX.XXX seconds" を抽出
-            for line in result.stdout.split("\n"):
-                if "estimated duration" in line:
-                    duration_str = line.split(":")[1].strip().split()[0]
-                    return int(float(duration_str))
+        # "estimated duration: XXX.XXX seconds" を抽出
+        for line in result.stdout.split("\n"):
+            if "estimated duration" in line:
+                duration_str = line.split(":")[1].strip().split()[0]
+                return int(float(duration_str))
 
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, IndexError) as e:
-            logger.warning(f"afinfo エラー {wav_file.name}: {e}")
-
+        logger.warning(f"afinfo 出力に 'estimated duration' が見つかりません: {wav_file.name}")
         return 0
 
     def _clean_track_title(self, filename: str) -> str:

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -1133,3 +1133,93 @@ class TestTitleTemplateUnknownPlaceholder:
         msg = str(exc.value)
         assert "adjective" in msg
         assert lang in msg
+
+
+# ===========================================================================
+# analyze_audio_files スキップ検出テスト (#1093)
+# ===========================================================================
+
+
+class TestAnalyzeAudioFilesSkipDetection:
+    """トラックがスキップされた場合に警告ログが出力されることを検証する。"""
+
+    @pytest.fixture
+    def gen_with_audio_dir(self, tmp_path):
+        gen = _make_generator()
+        collection = tmp_path / "collection"
+        audio_dir = collection / "02-Individual-music"
+        audio_dir.mkdir(parents=True)
+        gen.collection_path = collection
+        return gen, audio_dir
+
+    def test_zero_duration_track_is_skipped_with_warning(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-track-a.wav").write_bytes(b"\x00" * 100)
+        (audio_dir / "02-track-b.wav").write_bytes(b"\x00" * 100)
+
+        durations = {"01-track-a.wav": 120, "02-track-b.wav": 0}
+        monkeypatch.setattr(gen, "_get_audio_duration", lambda f: durations[f.name])
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-track-a.wav"
+        assert "トラックをスキップ" in caplog.text
+        assert "02-track-b.wav" in caplog.text
+
+    def test_exception_during_analysis_is_skipped_with_warning(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-good.wav").write_bytes(b"\x00" * 100)
+        (audio_dir / "02-broken.wav").write_bytes(b"\x00" * 100)
+
+        def mock_duration(f):
+            if f.name == "02-broken.wav":
+                raise RuntimeError("corrupt file")
+            return 180
+
+        monkeypatch.setattr(gen, "_get_audio_duration", mock_duration)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert "トラックをスキップ" in caplog.text
+        assert "corrupt file" in caplog.text
+
+    def test_count_mismatch_warning(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        for i in range(5):
+            (audio_dir / f"{i:02d}-track.wav").write_bytes(b"\x00" * 100)
+
+        durations = {f"{i:02d}-track.wav": (120 if i != 2 else 0) for i in range(5)}
+        monkeypatch.setattr(gen, "_get_audio_duration", lambda f: durations[f.name])
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            gen.analyze_audio_files()
+
+        assert "入力 5 ファイル" in caplog.text
+        assert "4 タイムスタンプ" in caplog.text
+        assert "1 件欠落" in caplog.text
+
+    def test_all_tracks_ok_no_warning(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        for i in range(3):
+            (audio_dir / f"{i:02d}-track.wav").write_bytes(b"\x00" * 100)
+
+        monkeypatch.setattr(gen, "_get_audio_duration", lambda f: 120)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 3
+        assert "スキップ" not in caplog.text
+        assert "欠落" not in caplog.text

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -1169,6 +1169,8 @@ class TestAnalyzeAudioFilesSkipDetection:
         assert tracks[0]["filename"] == "01-track-a.wav"
         assert "トラックをスキップ" in caplog.text
         assert "02-track-b.wav" in caplog.text
+        assert "再生時間が 0 秒" in caplog.text
+        assert "ファイル破損または afinfo 解析失敗" in caplog.text
 
     def test_exception_during_analysis_is_skipped_with_warning(self, gen_with_audio_dir, caplog, monkeypatch):
         gen, audio_dir = gen_with_audio_dir
@@ -1189,6 +1191,8 @@ class TestAnalyzeAudioFilesSkipDetection:
 
         assert len(tracks) == 1
         assert "トラックをスキップ" in caplog.text
+        assert "02-broken.wav" in caplog.text
+        assert "ファイル解析エラー" in caplog.text
         assert "corrupt file" in caplog.text
 
     def test_count_mismatch_warning(self, gen_with_audio_dir, caplog, monkeypatch):

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -1188,9 +1188,7 @@ class TestAnalyzeAudioFilesSkipDetection:
                 if "02-broken.wav" in filepath:
                     raise _subprocess.CalledProcessError(1, "afinfo", "corrupt file")
                 # 正常なファイルには afinfo 成功を模擬
-                result = _subprocess.CompletedProcess(
-                    cmd, 0, stdout="estimated duration: 180.0 seconds\n", stderr=""
-                )
+                result = _subprocess.CompletedProcess(cmd, 0, stdout="estimated duration: 180.0 seconds\n", stderr="")
                 return result
             return _original_run(cmd, **kwargs)
 

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -1179,7 +1179,9 @@ class TestAnalyzeAudioFilesSkipDetection:
 
         def mock_duration(f):
             if f.name == "02-broken.wav":
-                raise RuntimeError("corrupt file")
+                import subprocess
+
+                raise subprocess.CalledProcessError(1, "afinfo", "corrupt file")
             return 180
 
         monkeypatch.setattr(gen, "_get_audio_duration", mock_duration)
@@ -1193,7 +1195,6 @@ class TestAnalyzeAudioFilesSkipDetection:
         assert "トラックをスキップ" in caplog.text
         assert "02-broken.wav" in caplog.text
         assert "ファイル解析エラー" in caplog.text
-        assert "corrupt file" in caplog.text
 
     def test_count_mismatch_warning(self, gen_with_audio_dir, caplog, monkeypatch):
         gen, audio_dir = gen_with_audio_dir

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -1177,14 +1177,24 @@ class TestAnalyzeAudioFilesSkipDetection:
         (audio_dir / "01-good.wav").write_bytes(b"\x00" * 100)
         (audio_dir / "02-broken.wav").write_bytes(b"\x00" * 100)
 
-        def mock_duration(f):
-            if f.name == "02-broken.wav":
-                import subprocess
+        import subprocess as _subprocess
 
-                raise subprocess.CalledProcessError(1, "afinfo", "corrupt file")
-            return 180
+        _original_run = _subprocess.run
 
-        monkeypatch.setattr(gen, "_get_audio_duration", mock_duration)
+        def mock_subprocess_run(cmd, **kwargs):
+            # afinfo 呼び出しのみインターセプトする
+            if cmd and cmd[0] == "afinfo":
+                filepath = cmd[1] if len(cmd) > 1 else ""
+                if "02-broken.wav" in filepath:
+                    raise _subprocess.CalledProcessError(1, "afinfo", "corrupt file")
+                # 正常なファイルには afinfo 成功を模擬
+                result = _subprocess.CompletedProcess(
+                    cmd, 0, stdout="estimated duration: 180.0 seconds\n", stderr=""
+                )
+                return result
+            return _original_run(cmd, **kwargs)
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
 
         import logging
 


### PR DESCRIPTION
## Summary

- `analyze_audio_files()` で duration が 0 以下のトラックや例外発生時にスキップ理由を明示的に warning ログで報告
- 入力ファイル数と出力タイムスタンプ数の不一致を検出するサマリー警告を追加
- 4 件のユニットテスト追加（ゼロ duration / 例外 / 数不一致 / 正常系）

Closes #1093

## Test plan

- [x] `TestAnalyzeAudioFilesSkipDetection` 4 テスト全通過
- [ ] 実際の 29 トラックコレクションで 1 ファイル破損時にスキップ警告が出ることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK