### PR TITLE
fix(tags): タグ出力からダブルクォートを自動除去 (#1096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
-- `fix(tags)`: 全タグパース経路（`_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / `Tags.for_collection()`）でダブルクォートを自動除去し、YouTube タグ欄にそのまま貼れるようにした（#1096）
+- `fix(tags)`: タグ quote 除去を `normalize_youtube_tags()` に一元化し、全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）を統一。Shorts 経路の漏れも修正（#1096）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
-- `fix(tags)`: タグ quote 除去を `normalize_youtube_tags()` に一元化し、全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）を統一。Shorts 経路の漏れも修正（#1096）
+- `fix(tags)`: `parse_youtube_tags()` を新設し、descriptions.md タグ分割+正規化を一元化。全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）で統一的に quote 除去（#1096）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
-- `fix(tags)`: `Tags.for_collection()` と `_descriptions_md.py` のタグパーサーでダブルクォートを自動除去し、YouTube タグ欄にそのまま貼れるようにした（#1096）
+- `fix(tags)`: 全タグパース経路（`_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / `Tags.for_collection()`）でダブルクォートを自動除去し、YouTube タグ欄にそのまま貼れるようにした（#1096）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
+- `fix(tags)`: `Tags.for_collection()` と `_descriptions_md.py` のタグパーサーでダブルクォートを自動除去し、YouTube タグ欄にそのまま貼れるようにした（#1096）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
-from youtube_automation.utils.youtube_tag import normalize_youtube_tags
+from youtube_automation.utils.youtube_tag import parse_youtube_tags
 
 logger = logging.getLogger(__name__)
 
@@ -50,11 +50,7 @@ class DescriptionsMdMixin:
             logger.warning("⚠️  descriptions.md のパースに失敗 — BAHMetadataGenerator にフォールバック")
             return None
 
-        tags = (
-            normalize_youtube_tags([t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()])
-            if tags_raw
-            else []
-        )
+        tags = parse_youtube_tags(tags_raw) if tags_raw else []
 
         logger.info("📄 descriptions.md からメタデータを読み込み")
         return {"title": title.strip(), "description": description.strip(), "tags": tags}

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -49,7 +49,7 @@ class DescriptionsMdMixin:
             logger.warning("⚠️  descriptions.md のパースに失敗 — BAHMetadataGenerator にフォールバック")
             return None
 
-        tags = [t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()] if tags_raw else []
+        tags = [t.strip().strip('"') for t in tags_raw.replace("\n", ",").split(",") if t.strip()] if tags_raw else []
 
         logger.info("📄 descriptions.md からメタデータを読み込み")
         return {"title": title.strip(), "description": description.strip(), "tags": tags}

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -10,6 +10,7 @@ import re
 from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,11 @@ class DescriptionsMdMixin:
             logger.warning("⚠️  descriptions.md のパースに失敗 — BAHMetadataGenerator にフォールバック")
             return None
 
-        tags = [t.strip().strip('"') for t in tags_raw.replace("\n", ",").split(",") if t.strip()] if tags_raw else []
+        tags = (
+            normalize_youtube_tags([t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()])
+            if tags_raw
+            else []
+        )
 
         logger.info("📄 descriptions.md からメタデータを読み込み")
         return {"title": title.strip(), "description": description.strip(), "tags": tags}

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -25,6 +25,7 @@ import time
 
 from youtube_automation.utils.config import channel_dir
 from youtube_automation.utils.youtube_service import get_youtube
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags
 
 
 def discover_collections() -> list[str]:
@@ -73,7 +74,7 @@ def load_collection(col: str) -> dict:
     tags_raw = extract_md_section(desc_md, "タグ（YouTube タグ欄）")
     tags = []
     if tags_raw:
-        tags = [t.strip().strip('"') for t in tags_raw.replace("\n", ",").split(",") if t.strip()]
+        tags = normalize_youtube_tags([t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()])
 
     if not (description and title):
         raise RuntimeError(f"missing description or title section in {col}")

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -73,7 +73,7 @@ def load_collection(col: str) -> dict:
     tags_raw = extract_md_section(desc_md, "タグ（YouTube タグ欄）")
     tags = []
     if tags_raw:
-        tags = [t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()]
+        tags = [t.strip().strip('"') for t in tags_raw.replace("\n", ",").split(",") if t.strip()]
 
     if not (description and title):
         raise RuntimeError(f"missing description or title section in {col}")

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -25,7 +25,7 @@ import time
 
 from youtube_automation.utils.config import channel_dir
 from youtube_automation.utils.youtube_service import get_youtube
-from youtube_automation.utils.youtube_tag import normalize_youtube_tags
+from youtube_automation.utils.youtube_tag import parse_youtube_tags
 
 
 def discover_collections() -> list[str]:
@@ -74,7 +74,7 @@ def load_collection(col: str) -> dict:
     tags_raw = extract_md_section(desc_md, "タグ（YouTube タグ欄）")
     tags = []
     if tags_raw:
-        tags = normalize_youtube_tags([t.strip() for t in tags_raw.replace("\n", ",").split(",") if t.strip()])
+        tags = parse_youtube_tags(tags_raw)
 
     if not (description and title):
         raise RuntimeError(f"missing description or title section in {col}")

--- a/src/youtube_automation/utils/config/content.py
+++ b/src/youtube_automation/utils/config/content.py
@@ -37,7 +37,7 @@ class Tags:
             if theme in lowered:
                 tags.extend(theme_tag_list)
                 break
-        return tags[:50]
+        return [t.strip('"') for t in tags[:50]]
 
 
 @dataclass(frozen=True)

--- a/src/youtube_automation/utils/config/content.py
+++ b/src/youtube_automation/utils/config/content.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags
+
 
 @dataclass(frozen=True)
 class Genre:
@@ -37,7 +39,7 @@ class Tags:
             if theme in lowered:
                 tags.extend(theme_tag_list)
                 break
-        return [t.strip('"') for t in tags[:50]]
+        return normalize_youtube_tags(tags[:50])
 
 
 @dataclass(frozen=True)

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -26,6 +26,7 @@ from youtube_automation.utils.exceptions import ValidationError
 from .audio_formats import AUDIO_EXTS
 from .skill_config import load_skill_config
 from .time_utils import format_duration_display, format_duration_short, format_timestamp
+from .youtube_tag import normalize_youtube_tags
 
 logger = logging.getLogger(__name__)
 
@@ -987,7 +988,7 @@ class BAHMetadataGenerator:
         tag_list: List[str] = ["Shorts"]
         tag_list.extend(self.config.content.tags.base)
         tag_list.extend(self.config.content.tags.themes.get(theme, []))
-        tag_list = tag_list[:50]
+        tag_list = normalize_youtube_tags(tag_list[:50])
 
         localizations = build_short_localizations(
             self.config,

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -10,7 +10,7 @@ import re
 from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 
-from youtube_automation.utils.youtube_tag import youtube_tag_chars
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags, youtube_tag_chars
 
 YT_TAG_CHAR_LIMIT = 500
 REQUIRED_LOCALIZATION_LANGUAGES = ("ja", "en", "de")
@@ -168,7 +168,7 @@ def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
     if not m:
         return None
     raw = m.group(1).strip()
-    tags = [t.strip().strip('"') for t in raw.replace("\n", ",").split(",") if t.strip()]
+    tags = normalize_youtube_tags([t.strip() for t in raw.replace("\n", ",").split(",") if t.strip()])
     return tags or None
 
 

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -168,7 +168,7 @@ def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
     if not m:
         return None
     raw = m.group(1).strip()
-    tags = [t.strip() for t in raw.replace("\n", ",").split(",") if t.strip()]
+    tags = [t.strip().strip('"') for t in raw.replace("\n", ",").split(",") if t.strip()]
     return tags or None
 
 

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -10,7 +10,7 @@ import re
 from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 
-from youtube_automation.utils.youtube_tag import normalize_youtube_tags, youtube_tag_chars
+from youtube_automation.utils.youtube_tag import parse_youtube_tags, youtube_tag_chars
 
 YT_TAG_CHAR_LIMIT = 500
 REQUIRED_LOCALIZATION_LANGUAGES = ("ja", "en", "de")
@@ -168,7 +168,7 @@ def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
     if not m:
         return None
     raw = m.group(1).strip()
-    tags = normalize_youtube_tags([t.strip() for t in raw.replace("\n", ",").split(",") if t.strip()])
+    tags = parse_youtube_tags(raw)
     return tags or None
 
 

--- a/src/youtube_automation/utils/youtube_tag.py
+++ b/src/youtube_automation/utils/youtube_tag.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 
+def normalize_youtube_tags(raw_tags: list[str]) -> list[str]:
+    """タグリストから先頭・末尾のダブルクォートを除去する."""
+    return [t.strip('"') for t in raw_tags]
+
+
 def youtube_tag_chars(tags: list[str]) -> int:
     """YouTube が判定する真のタグ文字数を計算する.
 

--- a/src/youtube_automation/utils/youtube_tag.py
+++ b/src/youtube_automation/utils/youtube_tag.py
@@ -8,6 +8,15 @@ def normalize_youtube_tags(raw_tags: list[str]) -> list[str]:
     return [t.strip('"') for t in raw_tags]
 
 
+def parse_youtube_tags(raw: str) -> list[str]:
+    """descriptions.md のタグ欄テキストからタグリストを生成する.
+
+    改行・カンマ混在の生テキストを分割し、空要素を除去した上で
+    ``normalize_youtube_tags`` でダブルクォートを除去して返す。
+    """
+    return normalize_youtube_tags([t.strip() for t in raw.replace("\n", ",").split(",") if t.strip()])
+
+
 def youtube_tag_chars(tags: list[str]) -> int:
     """YouTube が判定する真のタグ文字数を計算する.
 

--- a/tests/test_bulk_update_descriptions_from_md.py
+++ b/tests/test_bulk_update_descriptions_from_md.py
@@ -627,6 +627,27 @@ class TestLoadCollection:
         with pytest.raises(RuntimeError, match="missing description or title section"):
             mod.load_collection("alpha")
 
+    def test_should_strip_double_quotes_from_tags(self, tmp_path, monkeypatch):
+        """ダブルクォートで囲まれたタグから引用符を除去する (#1096)."""
+        from youtube_automation.scripts import bulk_update_descriptions_from_md as mod
+
+        # Given
+        ch = _setup_channel(tmp_path)
+        _make_collection_with_descriptions(
+            ch,
+            "alpha",
+            video_id="V_ALPHA",
+            tags=['"lofi beats"', '"jazz"', '"study music"'],
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+        reset()
+
+        # When
+        result = mod.load_collection("alpha")
+
+        # Then
+        assert result["tags"] == ["lofi beats", "jazz", "study music"]
+
 
 # ---------------------------------------------------------------------------
 # 5. extract_md_section

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -956,6 +956,22 @@ def test_tags_for_collection_matches_theme(tmp_path, monkeypatch):
     assert len(tags) <= 50
 
 
+def test_tags_for_collection_strips_quotes(tmp_path, monkeypatch):
+    """#1096: content.json にクォート付きタグがあっても除去されること."""
+    sections = _minimal_sections()
+    sections["content.json"]["tags"]["base"] = ['"Paris Café Jazz"', "clean tag", '"French Café"']
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+    tags = config.content.tags.for_collection("test-collection")
+
+    assert "Paris Café Jazz" in tags
+    assert "clean tag" in tags
+    assert "French Café" in tags
+    assert not any('"' in t for t in tags)
+
+
 def test_title_activity_for_theme_fallback(tmp_path, monkeypatch):
     sections = _minimal_sections()
     sections["content.json"]["title"]["default_activity"] = "Chill"

--- a/tests/test_descriptions_md_quote_strip.py
+++ b/tests/test_descriptions_md_quote_strip.py
@@ -1,0 +1,58 @@
+"""_descriptions_md.py のタグ quote 除去テスト (#1096).
+
+descriptions.md 経由のタグパーサーでダブルクォートが自動除去されることを担保する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.agents._descriptions_md import DescriptionsMdMixin
+
+
+def _write_descriptions_md(collection_dir: Path, tags_line: str) -> None:
+    """テスト用の descriptions.md を所定パスに作成する."""
+    doc_dir = collection_dir / "20-documentation"
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    (doc_dir / "descriptions.md").write_text(
+        f"## タイトル案\n\n```\nTest Title\n```\n\n"
+        f"## Complete Collection 概要欄\n\n```\nTest description body.\n```\n\n"
+        f"## タグ（YouTube タグ欄）\n\n```\n{tags_line}\n```\n",
+        encoding="utf-8",
+    )
+
+
+class TestDescriptionsMdQuoteStrip:
+    """_load_descriptions_md がタグのダブルクォートを除去する."""
+
+    def test_strips_double_quotes_from_comma_separated_tags(self, tmp_path: Path) -> None:
+        """カンマ区切りのクォート付きタグから引用符を除去する."""
+        _write_descriptions_md(tmp_path, '"lofi beats", "jazz", "study music"')
+        mixin = DescriptionsMdMixin()
+        result = mixin._load_descriptions_md(tmp_path)
+        assert result is not None
+        assert result["tags"] == ["lofi beats", "jazz", "study music"]
+
+    def test_strips_double_quotes_from_newline_separated_tags(self, tmp_path: Path) -> None:
+        """改行区切りのクォート付きタグから引用符を除去する."""
+        _write_descriptions_md(tmp_path, '"lofi beats"\n"jazz"\n"study music"')
+        mixin = DescriptionsMdMixin()
+        result = mixin._load_descriptions_md(tmp_path)
+        assert result is not None
+        assert result["tags"] == ["lofi beats", "jazz", "study music"]
+
+    def test_handles_mixed_quoted_and_unquoted_tags(self, tmp_path: Path) -> None:
+        """クォート有無が混在するタグでも正しく処理する."""
+        _write_descriptions_md(tmp_path, '"lofi beats", jazz, "study music"')
+        mixin = DescriptionsMdMixin()
+        result = mixin._load_descriptions_md(tmp_path)
+        assert result is not None
+        assert result["tags"] == ["lofi beats", "jazz", "study music"]
+
+    def test_handles_unquoted_tags_unchanged(self, tmp_path: Path) -> None:
+        """クォートなしタグはそのまま通過する."""
+        _write_descriptions_md(tmp_path, "lofi beats, jazz, study music")
+        mixin = DescriptionsMdMixin()
+        result = mixin._load_descriptions_md(tmp_path)
+        assert result is not None
+        assert result["tags"] == ["lofi beats", "jazz", "study music"]

--- a/tests/test_metadata_generator_shorts.py
+++ b/tests/test_metadata_generator_shorts.py
@@ -270,6 +270,25 @@ class TestTagsComposition:
         # Then
         assert len(meta["tags"]) <= 50
 
+    def test_tags_quoted_values_are_normalized(self, tmp_path):
+        """回帰 #1096: config のタグにダブルクォートが含まれていても除去される."""
+        from dataclasses import replace as dreplace
+
+        col = _make_collection(tmp_path, "20250907-live-8bit-battle-music", theme="battle")
+        gen = _make_generator(collection_path=col)
+        # base タグにダブルクォートを混入させる
+        quoted_base = ['"chiptune music"', '"8-bit music"', "RPG music"]
+        new_tags = dreplace(gen.config.content.tags, base=quoted_base)
+        new_content = dreplace(gen.config.content, tags=new_tags)
+        gen.config = dreplace(gen.config, content=new_content)
+
+        meta = gen.generate_shorts_metadata("https://youtu.be/abc")
+
+        # ダブルクォートが含まれないことを全タグで検証
+        for tag in meta["tags"]:
+            assert not tag.startswith('"'), f"tag starts with quote: {tag!r}"
+            assert not tag.endswith('"'), f"tag ends with quote: {tag!r}"
+
     def test_tags_order_preserved_shorts_first_then_base_then_themes(self, tmp_path):
         """plan 要件 #4-a/b/c 合成順序: ["Shorts"] + base + themes.get(theme, [])."""
         # Given

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -230,6 +230,15 @@ class TestExtractDescriptionsMdTags:
         )
         assert extract_descriptions_md_tags(p) == ["lofi beats", "jazz", "study"]
 
+    def test_strips_double_quotes_from_tags(self, tmp_path: Path) -> None:
+        """ダブルクォートで囲まれたタグから引用符を除去する (#1096)."""
+        p = tmp_path / "descriptions.md"
+        p.write_text(
+            '## タグ（YouTube タグ欄）\n```\n"lofi beats", "jazz", "study music"\n```\n',
+            encoding="utf-8",
+        )
+        assert extract_descriptions_md_tags(p) == ["lofi beats", "jazz", "study music"]
+
     def test_returns_none_for_empty_section(self, tmp_path: Path) -> None:
         p = tmp_path / "descriptions.md"
         p.write_text("## タグ（YouTube タグ欄）\n```\n\n```\n", encoding="utf-8")

--- a/tests/test_youtube_tag.py
+++ b/tests/test_youtube_tag.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from youtube_automation.utils.youtube_tag import normalize_youtube_tags, youtube_tag_chars
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags, parse_youtube_tags, youtube_tag_chars
 
 # ---------------------------------------------------------------------------
 # normalize_youtube_tags
@@ -31,6 +31,59 @@ class TestNormalizeYoutubeTags:
     def test_strips_only_leading_and_trailing_quotes(self) -> None:
         """内部のダブルクォートは除去しない."""
         assert normalize_youtube_tags(['"say "hello" world"']) == ['say "hello" world']
+
+
+# ---------------------------------------------------------------------------
+# parse_youtube_tags
+# ---------------------------------------------------------------------------
+
+
+class TestParseYoutubeTags:
+    """parse_youtube_tags が生テキストを分割+正規化する."""
+
+    def test_comma_separated(self) -> None:
+        assert parse_youtube_tags("lofi beats, jazz, study music") == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_newline_separated(self) -> None:
+        assert parse_youtube_tags("lofi beats\njazz\nstudy music") == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_mixed_newline_and_comma(self) -> None:
+        assert parse_youtube_tags("lofi beats, jazz\nstudy music") == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_strips_double_quotes(self) -> None:
+        assert parse_youtube_tags('"lofi beats", "jazz", "study music"') == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_strips_quotes_from_newline_separated(self) -> None:
+        assert parse_youtube_tags('"lofi beats"\n"jazz"\n"study music"') == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert parse_youtube_tags("") == []
+
+    def test_whitespace_only_returns_empty(self) -> None:
+        assert parse_youtube_tags("  ,  , \n ") == []
+
+    def test_trims_surrounding_whitespace(self) -> None:
+        assert parse_youtube_tags("  lofi beats ,  jazz  ") == ["lofi beats", "jazz"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_youtube_tag.py
+++ b/tests/test_youtube_tag.py
@@ -1,8 +1,41 @@
-"""youtube_tag.youtube_tag_chars の挙動検証."""
+"""youtube_tag モジュールの挙動検証."""
 
 from __future__ import annotations
 
-from youtube_automation.utils.youtube_tag import youtube_tag_chars
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags, youtube_tag_chars
+
+# ---------------------------------------------------------------------------
+# normalize_youtube_tags
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeYoutubeTags:
+    """normalize_youtube_tags がダブルクォートを正しく除去する."""
+
+    def test_strips_surrounding_double_quotes(self) -> None:
+        assert normalize_youtube_tags(['"lofi beats"', '"jazz"']) == ["lofi beats", "jazz"]
+
+    def test_leaves_unquoted_tags_unchanged(self) -> None:
+        assert normalize_youtube_tags(["chiptune", "8-bit"]) == ["chiptune", "8-bit"]
+
+    def test_handles_mixed_quoted_and_unquoted(self) -> None:
+        assert normalize_youtube_tags(['"lofi beats"', "jazz", '"study music"']) == [
+            "lofi beats",
+            "jazz",
+            "study music",
+        ]
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert normalize_youtube_tags([]) == []
+
+    def test_strips_only_leading_and_trailing_quotes(self) -> None:
+        """内部のダブルクォートは除去しない."""
+        assert normalize_youtube_tags(['"say "hello" world"']) == ['say "hello" world']
+
+
+# ---------------------------------------------------------------------------
+# youtube_tag_chars
+# ---------------------------------------------------------------------------
 
 
 def test_empty_list_is_zero() -> None:


### PR DESCRIPTION
## Summary

- `Tags.for_collection()` で返すタグから先頭・末尾のダブルクォートを `strip('"')` で除去
- `_descriptions_md.py` のタグパーサーでも同様にクォートを除去（descriptions.md 経由のフローにも対応）
- 回帰テスト `test_tags_for_collection_strips_quotes` を追加

Closes #1096

## Test plan

- [x] クォート付きタグが除去されることをユニットテストで確認
- [x] 既存 `test_tags_for_collection_matches_theme` が引き続きパス
- [ ] 実際の content.json にクォート付きタグがある場合に descriptions.md のタグ欄がクリーンであることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK