### PR TITLE
fix(veo): ループ生成を自動スムース化 + 音声ループ時の音割れ防止 (#1057)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -433,6 +433,7 @@ if [[ -z "$TARGET_VIDEO_DURATION_MIN" ]]; then
 fi
 
 AUDIO_INPUT_OPTS=()
+AUDIO_LOOP_ACTIVE=0
 video_duration="$duration"
 if [[ -n "$TARGET_VIDEO_DURATION_MIN" ]]; then
     target_video_duration_sec="$(awk "BEGIN{printf \"%.2f\", $TARGET_VIDEO_DURATION_MIN * 60}")"
@@ -440,11 +441,18 @@ if [[ -n "$TARGET_VIDEO_DURATION_MIN" ]]; then
     master_duration_for_compare="${duration:-0}"
     if awk "BEGIN{exit !($target_video_duration_sec > $master_duration_for_compare)}"; then
         AUDIO_INPUT_OPTS=(-stream_loop -1)
+        AUDIO_LOOP_ACTIVE=1
         video_duration="$target_video_duration_sec"
         echo "  Target   : ${TARGET_VIDEO_DURATION_MIN} min ($(format_duration "$video_duration")) — audio loop enabled"
     else
         echo "  Target   : ${TARGET_VIDEO_DURATION_MIN} min ignored (master ≥ target; master 尺が支配)"
     fi
+fi
+
+# 音声ループ時は再エンコード必須 + loudnorm で音割れ防止 (#1057)
+if [[ "$AUDIO_LOOP_ACTIVE" -eq 1 ]]; then
+    AUDIO_OUT_OPTS=(-c:a "$AUDIO_ENCODER" -b:a 384k -ar 48000 -af "loudnorm=I=-14:TP=-1:LRA=11")
+    echo "  Audio    : re-encode + loudnorm (loop boundary clipping prevention)"
 fi
 
 echo "  Duration : $(format_duration "$video_duration")"

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -434,12 +434,18 @@ fi
 
 AUDIO_INPUT_OPTS=()
 AUDIO_LOOP_ACTIVE=0
+AUDIO_LOUDNORM=""
 video_duration="$duration"
 if [[ -n "$TARGET_VIDEO_DURATION_MIN" ]]; then
-    target_video_duration_sec="$(awk "BEGIN{printf \"%.2f\", $TARGET_VIDEO_DURATION_MIN * 60}")"
+    # 数値バリデーション: 整数 or 小数のみ許容
+    if ! [[ "$TARGET_VIDEO_DURATION_MIN" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        echo "ERROR: invalid target_video_duration_min value: '${TARGET_VIDEO_DURATION_MIN}' (must be numeric)"
+        exit 1
+    fi
+    target_video_duration_sec="$(awk -v target="$TARGET_VIDEO_DURATION_MIN" 'BEGIN{printf "%.2f", target * 60}')"
     # duration が取得できない (空 / 数値でない) ケースは fail-safe で従来動作にフォールバック
     master_duration_for_compare="${duration:-0}"
-    if awk "BEGIN{exit !($target_video_duration_sec > $master_duration_for_compare)}"; then
+    if awk -v target="$target_video_duration_sec" -v master="$master_duration_for_compare" 'BEGIN{exit !(target > master)}'; then
         AUDIO_INPUT_OPTS=(-stream_loop -1)
         AUDIO_LOOP_ACTIVE=1
         video_duration="$target_video_duration_sec"
@@ -450,8 +456,12 @@ if [[ -n "$TARGET_VIDEO_DURATION_MIN" ]]; then
 fi
 
 # 音声ループ時は再エンコード必須 + loudnorm で音割れ防止 (#1057)
+# loudnorm は AUDIO_OUT_OPTS ではなく別変数に保持する。
+# overlay 経路では filter_complex に統合し、非 overlay 経路では -af で適用する。
+# (-af と filter_complex は同一ストリームに併用不可)
 if [[ "$AUDIO_LOOP_ACTIVE" -eq 1 ]]; then
-    AUDIO_OUT_OPTS=(-c:a "$AUDIO_ENCODER" -b:a 384k -ar 48000 -af "loudnorm=I=-14:TP=-1:LRA=11")
+    AUDIO_OUT_OPTS=(-c:a "$AUDIO_ENCODER" -b:a 384k -ar 48000)
+    AUDIO_LOUDNORM="loudnorm=I=-14:TP=-1:LRA=11"
     echo "  Audio    : re-encode + loudnorm (loop boundary clipping prevention)"
 fi
 
@@ -514,7 +524,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
     else
         INPUTS+=(-framerate "$enc_framerate" -loop 1 -i "$THUMBNAIL")
     fi
-    INPUTS+=(-i "$MASTER_AUDIO")
+    INPUTS+=("${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO")
 
     sp_input_idx=""
     if [[ "$sp_enabled" == "true" ]]; then
@@ -566,6 +576,12 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
         CURRENT_LABEL="vout"
     fi
 
+    # loudnorm を filter_complex に統合 (overlay 経路では -af 併用不可)
+    if [[ -n "$AUDIO_LOUDNORM" ]]; then
+        FILTER+="[${AUDIO_LABEL}]${AUDIO_LOUDNORM}[a_norm];"
+        AUDIO_LABEL="a_norm"
+    fi
+
     # 末尾ラベル統一: 最終 video ラベルが CURRENT_LABEL
     ffmpeg -y "${INPUTS[@]}" \
         -filter_complex "$FILTER" \
@@ -575,7 +591,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
         -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt" \
         -r "$enc_framerate" \
         "${AUDIO_OUT_OPTS[@]}" \
-        -t "$duration" \
+        -t "$video_duration" \
         -movflags +faststart \
         -shortest \
         -loglevel error \
@@ -693,11 +709,13 @@ else
         # Stream copy 経路（effect ベイク / loop 背景 共通）: ビデオは完全無損失（ビット単位コピー）。
         # AUDIO_INPUT_OPTS は target_video_duration_min 設定時のみ -stream_loop -1 を持つ (#545)
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (stream copy)"
+        AUDIO_AF_ARGS=()
+        [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")
         ffmpeg -y -stream_loop -1 -i "$STREAM_SOURCE" \
             "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
             -map 0:v:0 -map 1:a:0 \
             -c:v copy \
-            "${AUDIO_OUT_OPTS[@]}" \
+            "${AUDIO_OUT_OPTS[@]}" "${AUDIO_AF_ARGS[@]}" \
             -t "$video_duration" \
             -movflags +faststart \
             -shortest \
@@ -707,13 +725,15 @@ else
     elif [[ "$EFFECT" != "none" && -n "$LOOP_SOURCE" ]]; then
         # フォールバック: loop + effect を全尺再エンコード（従来 mode C）
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (loop + ${EFFECT} effect, full encode fallback)"
+        AUDIO_AF_ARGS=()
+        [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")
         ffmpeg -y -stream_loop -1 -i "$LOOP_SOURCE" \
             "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
             -filter_complex "$EFFECT_FILTER_LOOP" \
             -map "[vout]" -map 1:a:0 \
             -c:v libx264 -preset medium -crf 22 -maxrate "$LOOP_MAX_BITRATE" -bufsize "$LOOP_BUFSIZE" -pix_fmt yuv420p \
             -r "$LOOP_OUTPUT_FRAME_RATE" \
-            "${AUDIO_OUT_OPTS[@]}" \
+            "${AUDIO_OUT_OPTS[@]}" "${AUDIO_AF_ARGS[@]}" \
             -t "$video_duration" \
             -movflags +faststart \
             -shortest \
@@ -723,13 +743,15 @@ else
     elif [[ "$EFFECT" != "none" ]]; then
         # フォールバック: 静止画 + effect を全尺再エンコード（従来 mode D）
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (still image + ${EFFECT} effect, full encode fallback)"
+        AUDIO_AF_ARGS=()
+        [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")
         ffmpeg -y -framerate "$STILL_EFFECT_FPS" -loop 1 -i "$THUMBNAIL" \
             "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
             -filter_complex "$EFFECT_FILTER_STATIC" \
             -map "[vout]" -map 1:a:0 \
             -c:v libx264 -preset medium -crf "$STILL_EFFECT_CRF" -pix_fmt yuv420p \
             -r "$STILL_EFFECT_FPS" \
-            "${AUDIO_OUT_OPTS[@]}" \
+            "${AUDIO_OUT_OPTS[@]}" "${AUDIO_AF_ARGS[@]}" \
             -t "$video_duration" \
             -movflags +faststart \
             -shortest \
@@ -740,13 +762,15 @@ else
         # 静止画背景モード（従来 mode A）。エンコード値は config 駆動（fallback=現行値）。
         # I-frame を STILL_GOP フレーム間隔に間引き、変化のないフレームを P-frame で圧縮して小型化（#579）。
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (still image)"
+        AUDIO_AF_ARGS=()
+        [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")
         ffmpeg -y -framerate "$STILL_FPS" -loop 1 -i "$THUMBNAIL" \
             "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
             -c:v libx264 -tune stillimage -preset medium -crf "$STILL_CRF" -pix_fmt yuv420p \
             -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
             -g "$STILL_GOP" \
             -r "$STILL_FPS" \
-            "${AUDIO_OUT_OPTS[@]}" \
+            "${AUDIO_OUT_OPTS[@]}" "${AUDIO_AF_ARGS[@]}" \
             -t "$video_duration" \
             -movflags +faststart \
             -shortest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(masterup)`: Suno CDN ダウンロードに `--fail` + `--retry 3` + 検証ステップを追加し、部分ダウンロードや破損ファイルを検出・警告するようにした。Content-Type 検証・UUID バリデーション・期待ファイル突合チェック・検証ゲート・リトライ設定の外部化も追加（#1090）
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
 - `fix(tags)`: `parse_youtube_tags()` を新設し、descriptions.md タグ分割+正規化を一元化。全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）で統一的に quote 除去（#1096）
+- `fix(veo)`: Veo 生成後に `smooth_loop()` を自動適用し、ループの継ぎ目をクロスフェードで滑らかにする。`generate_videos.sh` で音声ループ時に `loudnorm` フィルターを適用し音割れを防止（#1057）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/src/youtube_automation/utils/veo_generator.py
+++ b/src/youtube_automation/utils/veo_generator.py
@@ -280,18 +280,21 @@ def _finalize_generated_video(
 ) -> None:
     """保存済み動画の後処理と課金ログ出力を行う。
 
-    compression が有効なら libx264 再エンコードで音声除去も同時に行うため
-    `strip_audio` の stream copy パスを skip し、ffmpeg 起動を 1 回に集約する。
+    smooth_loop で末尾ノイズ除去 + クロスフェード結合を行い、シームレスな
+    ループを生成する。compression 設定があれば smooth_loop が同一 crf/preset で
+    再エンコードするため compress_loop は不要（ffmpeg 起動 1 回に集約）。
+    smooth_loop が失敗した場合は従来の compress/strip_audio にフォールバック。
     """
-    print(f"  {progress_fmt.format_step(3, 3, '後処理（圧縮 / 音声除去）')}")
-    if compression and compression.get("enabled", True):
-        compress_loop(
-            output_path,
-            crf=int(compression.get("crf", 22)),
-            preset=str(compression.get("preset", "slow")),
-        )
-    else:
-        strip_audio(output_path)
+    print(f"  {progress_fmt.format_step(3, 3, '後処理（スムースループ / 圧縮 / 音声除去）')}")
+    crf = int(compression.get("crf", 22)) if compression and compression.get("enabled", True) else 18
+    preset = str(compression.get("preset", "slow")) if compression and compression.get("enabled", True) else "slow"
+    smoothed = smooth_loop(output_path, crossfade_sec=0.5, trim_tail_sec=1.0, crf=crf, preset=preset)
+    if not smoothed:
+        print("  [Warn]   smooth_loop 失敗 → compress/strip_audio にフォールバック")
+        if compression and compression.get("enabled", True):
+            compress_loop(output_path, crf=crf, preset=preset)
+        else:
+            strip_audio(output_path)
     size_mb = output_path.stat().st_size / (1024 * 1024)
     print(f"  [Done]   完成 → {output_path} ({size_mb:.1f} MB)")
 


### PR DESCRIPTION
## Summary

- `_finalize_generated_video()` で `smooth_loop()` を自動適用（末尾 1.0s トリム + 0.5s クロスフェード）。失敗時は従来の compress/strip_audio にフォールバック
- `generate_videos.sh` で音声ループ（`-stream_loop -1`）時に `loudnorm=I=-14:TP=-1:LRA=11` を適用し、ループ境界の音割れを防止
- smooth_loop は compress_loop と同じ crf/preset で再エンコードするため、追加のエンコードパスなし

Closes #1057

## Test plan

- [x] 既存 `test_generate_loop_video_cli.py` 49 テスト全通過
- [ ] Veo 生成後の loop.mp4 が `_raw` バックアップ付きでスムース化されることを目視確認
- [ ] 音声ループ有効時に `re-encode + loudnorm` ログが出力されることを確認
- [ ] 長尺マスター動画で音割れが発生しないことを聴覚確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK