### PR TITLE
fix(videoup): ループ動画不在時のサイレント静止画フォールバックを警告化 (#868)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -132,11 +132,10 @@ if [[ -f "${ASSETS_DIR}/loop.mp4" ]]; then
     LOOP_VIDEO="${ASSETS_DIR}/loop.mp4"
     echo "  Loop     : ${LOOP_VIDEO} (detected)"
 else
-    # loop.mp4 が存在しない場合、静止画フォールバックになることを明示 (#868)
     echo "  Loop     : not found — 静止画モードで出力します"
-    if [[ -f "${ASSETS_DIR}/loop_raw.mp4" || -f "${ASSETS_DIR}/loop-v1.mp4" ]]; then
-        echo "  ⚠️  loop_raw.mp4 or loop-v1.mp4 が存在します — loop.mp4 が生成途中で失敗した可能性があります"
-        echo "     → yt-generate-loop-video --smooth で再生成するか、手動で loop.mp4 を配置してください"
+    if ls "${ASSETS_DIR}"/loop-v*.mp4 "${ASSETS_DIR}"/loop_raw.mp4 2>/dev/null | head -1 > /dev/null; then
+        echo "  ⚠️  loop_raw.mp4 or loop-v*.mp4 が存在します — loop.mp4 が生成途中で失敗した可能性があります"
+        echo "     → yt-generate-loop-video で再生成するか、手動で loop.mp4 を配置してください"
     fi
 fi
 
@@ -750,6 +749,7 @@ else
             "$MASTER_OUTPUT" &
     elif [[ "$EFFECT" != "none" ]]; then
         # フォールバック: 静止画 + effect を全尺再エンコード（従来 mode D）
+        echo "  ℹ️  ループ動画なし → 静止画 + ${EFFECT} effect で出力 (loop.mp4 を配置すればループ動画になります)"
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (still image + ${EFFECT} effect, full encode fallback)"
         AUDIO_AF_ARGS=()
         [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -130,6 +130,14 @@ COLLECTION_NAME="$(echo "$dir_basename" \
 LOOP_VIDEO=""
 if [[ -f "${ASSETS_DIR}/loop.mp4" ]]; then
     LOOP_VIDEO="${ASSETS_DIR}/loop.mp4"
+    echo "  Loop     : ${LOOP_VIDEO} (detected)"
+else
+    # loop.mp4 が存在しない場合、静止画フォールバックになることを明示 (#868)
+    echo "  Loop     : not found — 静止画モードで出力します"
+    if [[ -f "${ASSETS_DIR}/loop_raw.mp4" || -f "${ASSETS_DIR}/loop-v1.mp4" ]]; then
+        echo "  ⚠️  loop_raw.mp4 or loop-v1.mp4 が存在します — loop.mp4 が生成途中で失敗した可能性があります"
+        echo "     → yt-generate-loop-video --smooth で再生成するか、手動で loop.mp4 を配置してください"
+    fi
 fi
 
 THUMBNAIL=""
@@ -764,6 +772,7 @@ else
         echo "  [Step ${FF_TOTAL_STEPS}/${FF_TOTAL_STEPS}] Generating master video (still image)"
         AUDIO_AF_ARGS=()
         [[ -n "$AUDIO_LOUDNORM" ]] && AUDIO_AF_ARGS=(-af "$AUDIO_LOUDNORM")
+        echo "  ℹ️  ループ動画なし → 静止画背景で出力 (loop.mp4 を配置すればループ動画になります)"
         ffmpeg -y -framerate "$STILL_FPS" -loop 1 -i "$THUMBNAIL" \
             "${AUDIO_INPUT_OPTS[@]}" -i "$MASTER_AUDIO" \
             -c:v libx264 -tune stillimage -preset medium -crf "$STILL_CRF" -pix_fmt yuv420p \

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -133,8 +133,12 @@ if [[ -f "${ASSETS_DIR}/loop.mp4" ]]; then
     echo "  Loop     : ${LOOP_VIDEO} (detected)"
 else
     echo "  Loop     : not found — 静止画モードで出力します"
-    if ls "${ASSETS_DIR}"/loop-v*.mp4 "${ASSETS_DIR}"/loop_raw.mp4 2>/dev/null | head -1 > /dev/null; then
-        echo "  ⚠️  loop_raw.mp4 or loop-v*.mp4 が存在します — loop.mp4 が生成途中で失敗した可能性があります"
+    loop_artifacts=()
+    for f in "${ASSETS_DIR}"/loop_raw.mp4 "${ASSETS_DIR}"/loop-v*.mp4; do
+        [[ -f "$f" ]] && loop_artifacts+=("$f")
+    done
+    if [[ ${#loop_artifacts[@]} -gt 0 ]]; then
+        echo "  ⚠️  生成途中の痕跡が存在します: ${loop_artifacts[*]##*/}"
         echo "     → yt-generate-loop-video で再生成するか、手動で loop.mp4 を配置してください"
     fi
 fi

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -130,7 +130,7 @@ COLLECTION_NAME="$(echo "$dir_basename" \
 LOOP_VIDEO=""
 if [[ -f "${ASSETS_DIR}/loop.mp4" ]]; then
     LOOP_VIDEO="${ASSETS_DIR}/loop.mp4"
-    echo "  Loop     : ${LOOP_VIDEO} (detected)"
+    echo "  Loop     : $(basename "${LOOP_VIDEO}") (detected)"
 else
     echo "  Loop     : not found — 静止画モードで出力します"
     loop_artifacts=()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
 - `fix(tags)`: `parse_youtube_tags()` を新設し、descriptions.md タグ分割+正規化を一元化。全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）で統一的に quote 除去（#1096）
 - `fix(veo)`: Veo 生成後に `smooth_loop()` を自動適用し、ループの継ぎ目をクロスフェードで滑らかにする。`generate_videos.sh` で音声ループ時に `loudnorm` フィルターを適用し音割れを防止（#1057）
-- `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加（#868）
+- `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加。痕跡検出を `ls | head` パイプから配列ベースのファイル存在チェックに修正（pipefail 非依存化）。テスト 3 件追加（#868）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
 - `fix(tags)`: `parse_youtube_tags()` を新設し、descriptions.md タグ分割+正規化を一元化。全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）で統一的に quote 除去（#1096）
 - `fix(veo)`: Veo 生成後に `smooth_loop()` を自動適用し、ループの継ぎ目をクロスフェードで滑らかにする。`generate_videos.sh` で音声ループ時に `loudnorm` フィルターを適用し音割れを防止（#1057）
+- `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v1.mp4`）がある場合は警告を表示（#868）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(metadata-generator)`: `analyze_audio_files()` でトラックがサイレントにスキップされる問題を修正。duration が 0 以下や例外発生時にスキップ理由を明示的に警告し、入力数と出力数の不一致を検出するサマリーを追加。`_get_audio_duration()` の内部 try/except を除去し例外を呼び出し元へ伝播させることで skip reason に実際のエラー詳細が含まれるよう改善（#1093）
 - `fix(tags)`: `parse_youtube_tags()` を新設し、descriptions.md タグ分割+正規化を一元化。全 5 経路（`Tags.for_collection()` / `_descriptions_md.py` / `preflight_checks.py` / `bulk_update_descriptions_from_md.py` / Shorts タグ生成）で統一的に quote 除去（#1096）
 - `fix(veo)`: Veo 生成後に `smooth_loop()` を自動適用し、ループの継ぎ目をクロスフェードで滑らかにする。`generate_videos.sh` で音声ループ時に `loudnorm` フィルターを適用し音割れを防止（#1057）
-- `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v1.mp4`）がある場合は警告を表示（#868）
+- `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加（#868）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -460,6 +460,62 @@ def test_static_image_with_effect_uses_filter_complex(tmp_path: Path) -> None:
     assert "scale=1920:1080:force_original_aspect_ratio=decrease" in final_cmd
 
 
+# ─── Loop artifact warning (#868) ────────────────────────
+
+
+def test_loop_absent_with_loop_raw_shows_warning(tmp_path: Path) -> None:
+    """loop.mp4 が無いが loop_raw.mp4 が残っていれば警告を出力する."""
+    collection = _create_collection(tmp_path)
+    # loop.mp4 を消して loop_raw.mp4 を残す
+    (collection / "10-assets" / "loop.mp4").unlink()
+    (collection / "10-assets" / "loop_raw.mp4").write_bytes(b"fake-raw")
+
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        collection=collection,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "生成途中の痕跡が存在します" in result.stdout
+    assert "loop_raw.mp4" in result.stdout
+
+
+def test_loop_absent_with_loop_version_shows_warning(tmp_path: Path) -> None:
+    """loop.mp4 が無いが loop-v*.mp4 が残っていれば警告を出力する."""
+    collection = _create_collection(tmp_path)
+    (collection / "10-assets" / "loop.mp4").unlink()
+    (collection / "10-assets" / "loop-v1.mp4").write_bytes(b"fake-v1")
+    (collection / "10-assets" / "loop-v2.mp4").write_bytes(b"fake-v2")
+
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        collection=collection,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "生成途中の痕跡が存在します" in result.stdout
+    assert "loop-v1.mp4" in result.stdout
+    assert "loop-v2.mp4" in result.stdout
+
+
+def test_loop_absent_no_artifacts_no_warning(tmp_path: Path) -> None:
+    """loop.mp4 も痕跡ファイルも無い場合は警告を出さない."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        with_loop=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "生成途中の痕跡が存在します" not in result.stdout
+    assert "loop_raw.mp4" not in result.stdout
+
+
 def test_invalid_effect_name_fails_loud(tmp_path: Path) -> None:
     """未知のエフェクト名は fail-loud で停止する。"""
     result, _ = _run_generate_videos(

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -466,7 +466,6 @@ def test_static_image_with_effect_uses_filter_complex(tmp_path: Path) -> None:
 def test_loop_absent_with_loop_raw_shows_warning(tmp_path: Path) -> None:
     """loop.mp4 が無いが loop_raw.mp4 が残っていれば警告を出力する."""
     collection = _create_collection(tmp_path)
-    # loop.mp4 を消して loop_raw.mp4 を残す
     (collection / "10-assets" / "loop.mp4").unlink()
     (collection / "10-assets" / "loop_raw.mp4").write_bytes(b"fake-raw")
 
@@ -514,6 +513,45 @@ def test_loop_absent_no_artifacts_no_warning(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "生成途中の痕跡が存在します" not in result.stdout
     assert "loop_raw.mp4" not in result.stdout
+
+
+def test_loop_detected_log_shows_basename(tmp_path: Path) -> None:
+    """loop.mp4 検出時のログに basename のみ表示される (フルパスではない)."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Loop     : loop.mp4 (detected)" in result.stdout
+    assert "10-assets/loop.mp4 (detected)" not in result.stdout
+
+
+def test_loop_not_found_log(tmp_path: Path) -> None:
+    """loop.mp4 が存在しない場合は not found ログを出力する."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        with_loop=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Loop     : not found" in result.stdout
+
+
+def test_static_image_effect_fallback_shows_no_loop_log(tmp_path: Path) -> None:
+    """静止画 + effect fallback 時に not found ログが出力される."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"VIDEOUP_EFFECT": "particles"},
+        with_loop=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Loop     : not found" in result.stdout
 
 
 def test_invalid_effect_name_fails_loud(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `generate_videos.sh` で loop.mp4 存在/不在を明示的にログ出力
- loop.mp4 不在時に静止画フォールバックを明記し、`loop_raw.mp4` / `loop-v1.mp4` が残っている場合は「生成途中で失敗した可能性」を警告
- 最終出力が静止画モードの場合にも「ループ動画なし → 静止画背景で出力」を明記

Refs #868

## Test plan

- [ ] loop.mp4 なしのコレクションで `Loop : not found — 静止画モードで出力します` ログが出ることを確認
- [ ] loop_raw.mp4 が残っているケースで追加警告が出ることを確認
- [ ] loop.mp4 ありのコレクションで `Loop : ... (detected)` ログが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK