### PR TITLE
fix(thumbnail): 参照画像使用時に variation guard を自動プリペンド (#1049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(veo)`: Veo 生成後に `smooth_loop()` を自動適用し、ループの継ぎ目をクロスフェードで滑らかにする。`generate_videos.sh` で音声ループ時に `loudnorm` フィルターを適用し音割れを防止（#1057）
 - `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加。痕跡検出を `ls | head` パイプから配列ベースのファイル存在チェックに修正（pipefail 非依存化）。テスト 3 件追加（#868）
 - `fix(suno-helper)`: Cmd+P によるプレイリスト dialog の起動を最大 3 回リトライし、大規模 collection の multi-select verify タイムアウトを 50→100ms/row に倍増して安定性を改善（#1050）
+- `fix(thumbnail)`: Gemini 参照画像生成時に variation guard プロンプトを自動プリペンドし、参照画像の丸パクリを抑制（#1049）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -45,6 +45,7 @@ class GeminiConfig:
 
     model: str
     image_size: str = _DEFAULT_GEMINI_IMAGE_SIZE
+    variation_guard_enabled: bool = True
 
 
 @dataclass(frozen=True)
@@ -178,6 +179,7 @@ def _build_gemini(d: dict[str, Any]) -> GeminiConfig:
     return GeminiConfig(
         model=d.get("model", _DEFAULT_GEMINI_MODEL),
         image_size=d.get("image_size", _DEFAULT_GEMINI_IMAGE_SIZE),
+        variation_guard_enabled=d.get("variation_guard_enabled", True),
     )
 
 

--- a/src/youtube_automation/utils/image_provider/gemini.py
+++ b/src/youtube_automation/utils/image_provider/gemini.py
@@ -48,7 +48,14 @@ class GeminiImageProvider:
                 ref_bytes = ref.read_bytes()
                 mime = "image/jpeg" if ref.suffix.lower() in (".jpg", ".jpeg") else "image/png"
                 contents.append(types.Part.from_bytes(data=ref_bytes, mime_type=mime))
-            contents.append(req.prompt)
+            variation_guard = (
+                "IMPORTANT: The reference image(s) above are for style and composition guidance ONLY. "
+                "Create an ORIGINAL image inspired by the reference — do NOT reproduce, copy, or closely "
+                "replicate the reference. Change the subject, colors, specific elements, and details "
+                "while keeping the general mood and layout style. The output must be clearly distinct "
+                "from the reference.\n\n"
+            )
+            contents.append(variation_guard + req.prompt)
         else:
             contents = [req.prompt]
 

--- a/src/youtube_automation/utils/image_provider/gemini.py
+++ b/src/youtube_automation/utils/image_provider/gemini.py
@@ -48,14 +48,17 @@ class GeminiImageProvider:
                 ref_bytes = ref.read_bytes()
                 mime = "image/jpeg" if ref.suffix.lower() in (".jpg", ".jpeg") else "image/png"
                 contents.append(types.Part.from_bytes(data=ref_bytes, mime_type=mime))
-            variation_guard = (
-                "IMPORTANT: The reference image(s) above are for style and composition guidance ONLY. "
-                "Create an ORIGINAL image inspired by the reference — do NOT reproduce, copy, or closely "
-                "replicate the reference. Change the subject, colors, specific elements, and details "
-                "while keeping the general mood and layout style. The output must be clearly distinct "
-                "from the reference.\n\n"
-            )
-            contents.append(variation_guard + req.prompt)
+            if self._config.variation_guard_enabled:
+                variation_guard = (
+                    "IMPORTANT: The reference image(s) above are for style and composition guidance ONLY. "
+                    "Create an ORIGINAL image inspired by the reference — do NOT reproduce, copy, or closely "
+                    "replicate the reference. Change the subject, colors, specific elements, and details "
+                    "while keeping the general mood and layout style. The output must be clearly distinct "
+                    "from the reference.\n\n"
+                )
+                contents.append(variation_guard + req.prompt)
+            else:
+                contents.append(req.prompt)
         else:
             contents = [req.prompt]
 

--- a/tests/test_image_provider_gemini.py
+++ b/tests/test_image_provider_gemini.py
@@ -190,6 +190,70 @@ class TestReferenceImagesForwarding:
         assert len(contents) >= 2
 
 
+# ---------- Variation Guard ----------
+
+
+class TestVariationGuard:
+    """variation_guard_enabled の ON/OFF でプロンプト先頭が変わることを検証する。"""
+
+    def test_variation_guard_prepended_when_references_provided(self, tmp_path, request_factory, patched_genai_client):
+        """参照画像あり + variation_guard_enabled=True → プロンプトに guard テキストが付く。"""
+        # Given
+        ref_path = tmp_path / "ref.png"
+        ref_path.write_bytes(_png_bytes())
+        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=True)
+        provider = GeminiImageProvider(config)
+        req = request_factory(prompt="a calm ocean sunset", references=[ref_path])
+        response = _fake_response([_fake_image_part(_png_bytes())])
+
+        # When
+        with patched_genai_client(response) as client:
+            provider.generate(req)
+
+        # Then: 最後の contents 要素（プロンプト文字列）が "IMPORTANT:" で始まる
+        contents = client.models.generate_content.call_args.kwargs["contents"]
+        prompt_part = contents[-1]
+        assert isinstance(prompt_part, str)
+        assert prompt_part.startswith("IMPORTANT:")
+        assert "a calm ocean sunset" in prompt_part
+
+    def test_variation_guard_skipped_when_disabled(self, tmp_path, request_factory, patched_genai_client):
+        """参照画像あり + variation_guard_enabled=False → プロンプトそのまま。"""
+        # Given
+        ref_path = tmp_path / "ref.png"
+        ref_path.write_bytes(_png_bytes())
+        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=False)
+        provider = GeminiImageProvider(config)
+        req = request_factory(prompt="a calm ocean sunset", references=[ref_path])
+        response = _fake_response([_fake_image_part(_png_bytes())])
+
+        # When
+        with patched_genai_client(response) as client:
+            provider.generate(req)
+
+        # Then: プロンプトがそのまま（guard テキストなし）
+        contents = client.models.generate_content.call_args.kwargs["contents"]
+        prompt_part = contents[-1]
+        assert isinstance(prompt_part, str)
+        assert prompt_part == "a calm ocean sunset"
+
+    def test_no_references_no_guard_regardless_of_config(self, request_factory, patched_genai_client):
+        """参照画像なし → variation_guard_enabled の値にかかわらず guard は付かない。"""
+        # Given
+        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=True)
+        provider = GeminiImageProvider(config)
+        req = request_factory(prompt="a calm ocean sunset", references=[])
+        response = _fake_response([_fake_image_part(_png_bytes())])
+
+        # When
+        with patched_genai_client(response) as client:
+            provider.generate(req)
+
+        # Then: プロンプトがそのまま
+        contents = client.models.generate_content.call_args.kwargs["contents"]
+        assert contents == ["a calm ocean sunset"]
+
+
 # ---------- リトライ・エラーハンドリング ----------
 
 


### PR DESCRIPTION
## Summary

- Gemini プロバイダーで参照画像付き生成時に variation guard プロンプトを自動プリペンド
- 「参照画像はスタイル/構図ガイドのみ — コピーではなくオリジナルを生成せよ」を指示
- ユーザープロンプトの前に挿入されるため、既存の diff_prompt_template と競合しない

Closes #1049

## Test plan

- [ ] 参照画像付きで `/thumbnail` を実行し、出力が参照と明確に異なることを目視確認
- [ ] 参照画像なしの通常生成に影響がないことを確認
- [ ] variation guard がログに表示されないこと（プロンプトの一部として送信されるだけ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK