### PR TITLE
fix(comments-reply): 履歴保存を 3 回リトライし二重返信余地を縮小 (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加。痕跡検出を `ls | head` パイプから配列ベースのファイル存在チェックに修正（pipefail 非依存化）。テスト 3 件追加（#868）
 - `fix(suno-helper)`: Cmd+P によるプレイリスト dialog の起動を最大 3 回リトライし、大規模 collection の multi-select verify タイムアウトを 50→100ms/row に倍増して安定性を改善（#1050）
 - `fix(thumbnail)`: Gemini 参照画像生成時に variation guard プロンプトを自動プリペンドし、参照画像の丸パクリを抑制（#1049）
-- `fix(comments-reply)`: `comments.insert` 成功後の履歴 `save()` を最大 3 回リトライし、insert→save 間の二重返信余地を縮小（#382）
+- `fix(comments-reply)`: `comments.insert` 成功後の履歴 `save()` を最大 3 回リトライし、insert→save 間の二重返信余地を縮小。全 save 失敗時は `plan.replied` に `save_failed` フラグを付与（#382）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: `generate_videos.sh` で loop.mp4 不在時に静止画フォールバックを明示的にログ出力し、loop 生成失敗の痕跡（`loop_raw.mp4` / `loop-v*.mp4`）がある場合は警告を表示。静止画 + effect 経路にもループ不在ログを追加。痕跡検出を `ls | head` パイプから配列ベースのファイル存在チェックに修正（pipefail 非依存化）。テスト 3 件追加（#868）
 - `fix(suno-helper)`: Cmd+P によるプレイリスト dialog の起動を最大 3 回リトライし、大規模 collection の multi-select verify タイムアウトを 50→100ms/row に倍増して安定性を改善（#1050）
 - `fix(thumbnail)`: Gemini 参照画像生成時に variation guard プロンプトを自動プリペンドし、参照画像の丸パクリを抑制（#1049）
+- `fix(comments-reply)`: `comments.insert` 成功後の履歴 `save()` を最大 3 回リトライし、insert→save 間の二重返信余地を縮小（#382）
 - `fix(collection-serve)`: `send_error()` 26 箇所を CORS 付き `_send_json_error()` に統一し、suno-helper 拡張が CORS ポリシーでブロックされる問題を修正（#1209）
 - `fix(suno-helper)`: dir mode で collection 切り替え・URL 変更時に前回の prompts が残留する問題を修正（#1210）。`syncCollections` で最新 collection 一覧を再取得してから prompts を fetch するフローに変更し、サーバー側で single-file mode の `/collections` と dir mode の `/suno/prompts.json` 直アクセスに JSON 404 レスポンスを返すよう修正。`resolvePromptCollectionId` を shared に新設
 

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -432,6 +432,7 @@ class CommentReplier:
         }
         self._history.mark_replied(comment.comment_id, metadata)
         # insert→save 間で save が失敗すると次回実行で二重返信するため、リトライで確実に永続化 (#382)
+        save_failed = False
         for save_attempt in range(3):
             try:
                 self._history.save()
@@ -444,11 +445,15 @@ class CommentReplier:
                     e,
                 )
         else:
+            save_failed = True
             logger.error(
                 "⚠️  履歴保存が 3 回失敗 (comment_id=%s) — 次回実行で二重返信の可能性あり",
                 comment.comment_id,
             )
-        plan.replied.append({"comment_id": comment.comment_id, **metadata})
+        record = {"comment_id": comment.comment_id, **metadata}
+        if save_failed:
+            record["save_failed"] = True
+        plan.replied.append(record)
         return True
 
     @staticmethod

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -450,6 +450,12 @@ class CommentReplier:
                 "⚠️  履歴保存が 3 回失敗 (comment_id=%s) — 次回実行で二重返信の可能性あり",
                 comment.comment_id,
             )
+            plan.errors.append(
+                self._error_record(
+                    comment,
+                    f"履歴保存が 3 回失敗 (comment_id={comment.comment_id}) — 次回実行で二重返信の可能性あり",
+                )
+            )
         record = {"comment_id": comment.comment_id, **metadata}
         if save_failed:
             record["save_failed"] = True

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -431,8 +431,23 @@ class CommentReplier:
             "reply_text": reply_text,
         }
         self._history.mark_replied(comment.comment_id, metadata)
-        # 途中断絶時の二重返信を防ぐため、返信成功ごとに履歴を永続化する
-        self._history.save()
+        # insert→save 間で save が失敗すると次回実行で二重返信するため、リトライで確実に永続化 (#382)
+        for save_attempt in range(3):
+            try:
+                self._history.save()
+                break
+            except OSError as e:
+                logger.warning(
+                    "履歴保存リトライ %d/3 (comment_id=%s): %s",
+                    save_attempt + 1,
+                    comment.comment_id,
+                    e,
+                )
+        else:
+            logger.error(
+                "⚠️  履歴保存が 3 回失敗 (comment_id=%s) — 次回実行で二重返信の可能性あり",
+                comment.comment_id,
+            )
         plan.replied.append({"comment_id": comment.comment_id, **metadata})
         return True
 

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -34,6 +34,9 @@ _HELD_FOR_REVIEW = "heldForReview"
 _COMMENTS_DISABLED_API_REASON = "commentsDisabled"
 _COMMENTS_DISABLED_SKIP_REASON = "comments_disabled"
 
+# 履歴 save リトライ回数（insert→save 間の永続化失敗を許容するリトライ上限）
+_SAVE_MAX_RETRIES = 3
+
 # videos.list の id 上限（1 リクエストあたり 50 件）
 _VIDEOS_LIST_CHUNK = 50
 _PRIVACY_STATUS_PRIVATE = "private"
@@ -400,6 +403,13 @@ class CommentReplier:
         video_title: str,
         plan: ReplyPlan,
     ) -> bool:
+        """YouTube に返信を投稿し履歴を永続化する.
+
+        Returns:
+            True: YouTube への insert が成功した（save 全失敗でも True — 投稿済み返信は
+            取り消せないため replied カウントを減らさない。save 失敗は plan.errors で通知）。
+            False: insert 自体が失敗した。
+        """
         try:
             self._youtube.comments().insert(
                 part="snippet",
@@ -433,27 +443,30 @@ class CommentReplier:
         self._history.mark_replied(comment.comment_id, metadata)
         # insert→save 間で save が失敗すると次回実行で二重返信するため、リトライで確実に永続化 (#382)
         save_failed = False
-        for save_attempt in range(3):
+        for save_attempt in range(_SAVE_MAX_RETRIES):
             try:
                 self._history.save()
                 break
             except OSError as e:
                 logger.warning(
-                    "履歴保存リトライ %d/3 (comment_id=%s): %s",
+                    "履歴保存リトライ %d/%d (comment_id=%s): %s",
                     save_attempt + 1,
+                    _SAVE_MAX_RETRIES,
                     comment.comment_id,
                     e,
                 )
         else:
             save_failed = True
             logger.error(
-                "⚠️  履歴保存が 3 回失敗 (comment_id=%s) — 次回実行で二重返信の可能性あり",
+                "履歴保存が %d 回失敗 (comment_id=%s) — 次回実行で二重返信の可能性あり",
+                _SAVE_MAX_RETRIES,
                 comment.comment_id,
             )
             plan.errors.append(
                 self._error_record(
                     comment,
-                    f"履歴保存が 3 回失敗 (comment_id={comment.comment_id}) — 次回実行で二重返信の可能性あり",
+                    f"履歴保存が {_SAVE_MAX_RETRIES} 回失敗"
+                    f" (comment_id={comment.comment_id}) — 次回実行で二重返信の可能性あり",
                 )
             )
         record = {"comment_id": comment.comment_id, **metadata}

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -9,7 +9,7 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from youtube_automation.utils.comments.history import ReplyHistory
-from youtube_automation.utils.comments.replier import CommentReplier
+from youtube_automation.utils.comments.replier import CommentReplier, _SAVE_MAX_RETRIES
 from youtube_automation.utils.config.comments import (
     CommentRule,
     Comments,
@@ -986,7 +986,7 @@ def test_save_fails_once_then_succeeds_logs_warning(tmp_path, caplog):
 
 
 def test_save_fails_all_3_times_logs_error_and_flags_record(tmp_path, caplog):
-    """save が 3 回とも失敗したとき、エラーログが出て plan.replied に save_failed フラグが付き plan.errors に記録される."""
+    """save 全失敗時: エラーログ + save_failed フラグ + plan.errors 記録."""
     yt = _mock_youtube(
         video_ids=["v1"],
         comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
@@ -1083,3 +1083,61 @@ def test_same_comment_id_in_two_videos_only_inserts_once_when_save_always_fails(
     assert plan.replied[0]["comment_id"] == "c_dup"
     # 2 件目は already_replied でスキップ
     assert any(row["comment_id"] == "c_dup" and row["reason"] == "already_replied" for row in plan.skipped)
+
+
+# ─── save() 呼び出し回数の厳密検証 (#382) ───────────────────────────────────
+
+
+def test_save_call_count_success_first_try(tmp_path):
+    """save 成功時: save() は 1 回だけ呼ばれる."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt, config=_make_config(delay_between_replies_sec=0.0), channel_dir=tmp_path, default_language="ja"
+    )
+
+    with patch.object(replier._history, "save", wraps=replier._history.save) as mock_save:
+        plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert mock_save.call_count == 1
+
+
+def test_save_call_count_one_failure_then_success(tmp_path):
+    """save 1 回失敗 → 2 回目成功: save() は 2 回呼ばれる."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt, config=_make_config(delay_between_replies_sec=0.0), channel_dir=tmp_path, default_language="ja"
+    )
+
+    original_save = replier._history.save
+    effects = [OSError("disk full"), original_save]
+
+    with patch.object(replier._history, "save", side_effect=effects) as mock_save:
+        plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert mock_save.call_count == 2
+
+
+def test_save_call_count_all_retries_exhausted(tmp_path):
+    """save 全失敗: save() は _SAVE_MAX_RETRIES 回呼ばれる."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt, config=_make_config(delay_between_replies_sec=0.0), channel_dir=tmp_path, default_language="ja"
+    )
+
+    with patch.object(replier._history, "save", side_effect=OSError("disk full")) as mock_save:
+        plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert plan.replied[0]["save_failed"] is True
+    assert mock_save.call_count == _SAVE_MAX_RETRIES

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -923,3 +924,86 @@ def test_legacy_rule_generator_key_rejected_by_loader():
 
     with pytest.raises(ConfigError, match="comments.rules\\[0\\].generator"):
         _build_comments(merged)
+
+
+# ─── 履歴 save リトライのテスト (#382) ────────────────────────────────────────
+
+
+def test_save_succeeds_first_try_no_warning(tmp_path, caplog):
+    """save が初回で成功すればリトライ警告が出ない."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(delay_between_replies_sec=0.0),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="youtube_automation.utils.comments.replier"):
+        plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert "save_failed" not in plan.replied[0]
+    assert "履歴保存リトライ" not in caplog.text
+    assert "履歴保存が 3 回失敗" not in caplog.text
+
+
+def test_save_fails_once_then_succeeds_logs_warning(tmp_path, caplog):
+    """save が 1 回失敗して 2 回目で成功したとき、リトライ警告が出るがエラーは出ない."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(delay_between_replies_sec=0.0),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    original_save = replier._history.save
+    call_count = 0
+
+    def _flaky_save():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("disk full")
+        return original_save()
+
+    with patch.object(replier._history, "save", side_effect=_flaky_save):
+        with caplog.at_level(logging.WARNING, logger="youtube_automation.utils.comments.replier"):
+            plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert "save_failed" not in plan.replied[0]
+    assert "履歴保存リトライ 1/3" in caplog.text
+    assert "履歴保存が 3 回失敗" not in caplog.text
+
+
+def test_save_fails_all_3_times_logs_error_and_flags_record(tmp_path, caplog):
+    """save が 3 回とも失敗したとき、エラーログが出て plan.replied に save_failed フラグが付く."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(delay_between_replies_sec=0.0),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    with patch.object(replier._history, "save", side_effect=OSError("disk full")):
+        with caplog.at_level(logging.WARNING, logger="youtube_automation.utils.comments.replier"):
+            plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert plan.replied[0]["save_failed"] is True
+    assert plan.replied[0]["comment_id"] == "c1"
+    # 3 回分のリトライ警告 + 最終エラー
+    assert caplog.text.count("履歴保存リトライ") == 3
+    assert "履歴保存が 3 回失敗" in caplog.text

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -9,7 +9,7 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from youtube_automation.utils.comments.history import ReplyHistory
-from youtube_automation.utils.comments.replier import CommentReplier, _SAVE_MAX_RETRIES
+from youtube_automation.utils.comments.replier import _SAVE_MAX_RETRIES, CommentReplier
 from youtube_automation.utils.config.comments import (
     CommentRule,
     Comments,

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -980,12 +980,13 @@ def test_save_fails_once_then_succeeds_logs_warning(tmp_path, caplog):
 
     assert len(plan.replied) == 1
     assert "save_failed" not in plan.replied[0]
+    assert plan.errors == []
     assert "履歴保存リトライ 1/3" in caplog.text
     assert "履歴保存が 3 回失敗" not in caplog.text
 
 
 def test_save_fails_all_3_times_logs_error_and_flags_record(tmp_path, caplog):
-    """save が 3 回とも失敗したとき、エラーログが出て plan.replied に save_failed フラグが付く."""
+    """save が 3 回とも失敗したとき、エラーログが出て plan.replied に save_failed フラグが付き plan.errors に記録される."""
     yt = _mock_youtube(
         video_ids=["v1"],
         comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
@@ -1004,6 +1005,81 @@ def test_save_fails_all_3_times_logs_error_and_flags_record(tmp_path, caplog):
     assert len(plan.replied) == 1
     assert plan.replied[0]["save_failed"] is True
     assert plan.replied[0]["comment_id"] == "c1"
+    # plan.errors に記録されている（CLI の exit code に反映）
+    assert len(plan.errors) == 1
+    assert "履歴保存が 3 回失敗" in plan.errors[0]["error"]
+    assert plan.errors[0]["comment_id"] == "c1"
     # 3 回分のリトライ警告 + 最終エラー
     assert caplog.text.count("履歴保存リトライ") == 3
     assert "履歴保存が 3 回失敗" in caplog.text
+    # ログレベル検証: WARNING 3 件 + ERROR 1 件
+    replier_records = [r for r in caplog.records if r.name == "youtube_automation.utils.comments.replier"]
+    warning_records = [r for r in replier_records if r.levelno == logging.WARNING]
+    error_records = [r for r in replier_records if r.levelno == logging.ERROR]
+    assert len(warning_records) == 3
+    assert len(error_records) == 1
+
+
+def test_save_fails_once_then_succeeds_log_levels(tmp_path, caplog):
+    """部分失敗（1 回失敗 → 2 回目成功）: WARNING 1 件、ERROR 0 件."""
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={"v1": [{"comment_id": "c1", "text": "こんにちは！", "author": "A"}]},
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(delay_between_replies_sec=0.0),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    original_save = replier._history.save
+    call_count = 0
+
+    def _flaky_save():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("disk full")
+        return original_save()
+
+    with patch.object(replier._history, "save", side_effect=_flaky_save):
+        with caplog.at_level(logging.WARNING, logger="youtube_automation.utils.comments.replier"):
+            plan = replier.run(dry_run=False)
+
+    assert len(plan.replied) == 1
+    assert plan.errors == []
+    replier_records = [r for r in caplog.records if r.name == "youtube_automation.utils.comments.replier"]
+    warning_records = [r for r in replier_records if r.levelno == logging.WARNING]
+    error_records = [r for r in replier_records if r.levelno == logging.ERROR]
+    assert len(warning_records) == 1
+    assert len(error_records) == 0
+
+
+def test_same_comment_id_in_two_videos_only_inserts_once_when_save_always_fails(tmp_path):
+    """save が全失敗しても mark_replied() のメモリ記録で同一実行内の二重返信を防ぐ."""
+    # 同じ comment_id "c_dup" が 2 つの video に出現する fixture
+    yt = _mock_youtube(
+        video_ids=["v1", "v2"],
+        comments_by_video={
+            "v1": [{"comment_id": "c_dup", "text": "こんにちは！", "author": "Alice"}],
+            "v2": [{"comment_id": "c_dup", "text": "こんにちは！", "author": "Alice"}],
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(delay_between_replies_sec=0.0),
+        channel_dir=tmp_path,
+        default_language="ja",
+    )
+
+    with patch.object(replier._history, "save", side_effect=OSError("disk full")):
+        plan = replier.run(dry_run=False)
+
+    # insert は 1 回だけ（v1 の c_dup に対して）
+    assert yt._insert_mock.execute.call_count == 1
+    # replied に 1 件（v1 の c_dup）
+    assert len(plan.replied) == 1
+    assert plan.replied[0]["comment_id"] == "c_dup"
+    # 2 件目は already_replied でスキップ
+    assert any(row["comment_id"] == "c_dup" and row["reason"] == "already_replied" for row in plan.skipped)


### PR DESCRIPTION
## Summary

- `_post_reply()` の `history.save()` を try/except で包み最大 3 回リトライ
- 全回失敗した場合は `logger.error` で「次回実行で二重返信の可能性あり」を明示警告
- `mark_replied()` のメモリ記録は save 失敗でも残るため、同一実行中の二重返信は既に防止済み

Closes #382

## Test plan

- [ ] save が 1 回目で失敗、2 回目で成功するシナリオでリトライログが出ることを確認
- [ ] 正常系で従来通り 1 回の save で完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqsL1dTWHCGeHvrV2qvhJK