### PR TITLE
[#1220] issue-1220-streaming-python-st

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `feat(streaming)`: ライブ配信のデフォルトを 24/7 連続配信に変更（ADR-0014）。Terraform 変数 `stream_hours` / `break_hours`（default=0 = 無制限）を導入し、systemd テンプレートで条件分岐。`yt-stream-archive-check` の `--expected` を必須化（#1219）
+- `refactor(streaming)`: Python streaming 定数を 24/7 デフォルトに更新。`THEORETICAL_HOURS_PER_DAY=24`、`ARCHIVES_EXPECTED=False` を導入し、稼働率計算・月次レポートを `ARCHIVES_EXPECTED` で分岐（#1220）
 
 ### Fixed
 

--- a/src/youtube_automation/cli/stream_bandwidth.py
+++ b/src/youtube_automation/cli/stream_bandwidth.py
@@ -26,6 +26,7 @@ from youtube_automation.utils.notification import notify
 from youtube_automation.utils.probe import probe_bitrate
 from youtube_automation.utils.secrets import get_secret
 from youtube_automation.utils.streaming import (
+    ARCHIVES_EXPECTED,
     MONTHLY_QUOTA_GB,
     THEORETICAL_BITRATE_MBPS,
     THRESHOLD_RATIO,
@@ -121,6 +122,13 @@ def _resolve_bandwidth(args: argparse.Namespace) -> dict[str, dict[str, int]]:
     return fetch_bandwidth(instance_id=instance_id, api_key=api_key)
 
 
+def _resolve_report_archives(args: argparse.Namespace, *, year: int, month: int) -> int | None:
+    """レポート用のアーカイブ実測値を取得する。"""
+    if not ARCHIVES_EXPECTED:
+        return None
+    return count_archives(get_youtube(), channel_id=args.channel_id, year=year, month=month)
+
+
 def _run_report(args: argparse.Namespace) -> int:
     """`--report` モード。"""
     if args.month:
@@ -138,7 +146,7 @@ def _run_report(args: argparse.Namespace) -> int:
         # (0 GB と区別できない場合は N/A の方が誤読を招きにくい)
         previous_usage_gb = None
 
-    archives = count_archives(get_youtube(), channel_id=args.channel_id, year=target_year, month=target_month)
+    archives = _resolve_report_archives(args, year=target_year, month=target_month)
     days_in_month = calendar.monthrange(target_year, target_month)[1]
     text = format_monthly_report(
         year=target_year,

--- a/src/youtube_automation/utils/streaming/__init__.py
+++ b/src/youtube_automation/utils/streaming/__init__.py
@@ -15,8 +15,8 @@ THRESHOLD_RATIO: float = 0.80
 # 想定ビットレート (Mbps)。映像 + 音声 (192 kbps) の合算想定値。
 THEORETICAL_BITRATE_MBPS: int = 4
 
-# 1 日あたりの想定配信時間 (時間)。11h × 2 本 (1h 休止) = 22h。
-THEORETICAL_HOURS_PER_DAY: int = 22
+# 1 日あたりの想定配信時間 (時間)。24/7 連続配信。
+THEORETICAL_HOURS_PER_DAY: int = 24
 
-# 1 ヶ月あたりの想定アーカイブ件数 (本)。22h ÷ 11h × 30 日 ≈ 60 本。
-THEORETICAL_ARCHIVES_PER_MONTH: int = 60
+# 24/7 連続配信では YouTube ライブアーカイブ生成を期待しない。
+ARCHIVES_EXPECTED: bool = False

--- a/src/youtube_automation/utils/streaming/cycle_uptime.py
+++ b/src/youtube_automation/utils/streaming/cycle_uptime.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from youtube_automation.utils.streaming import ARCHIVES_EXPECTED, THEORETICAL_HOURS_PER_DAY
 
 _HOURS_PER_DAY = 24
-_ARCHIVES_PER_DAY = 2  # 11h × 2 本 = 22h
+_ARCHIVES_PER_DAY = 2  # ARCHIVES_EXPECTED=True 時の 1 日あたり理論アーカイブ本数
 
 
 def theoretical_uptime_ratio() -> float:

--- a/src/youtube_automation/utils/streaming/cycle_uptime.py
+++ b/src/youtube_automation/utils/streaming/cycle_uptime.py
@@ -1,24 +1,23 @@
-"""11h+1h サイクルの稼働率計算（Issue #110 / R10）。
+"""配信稼働率計算（Issue #110 / R10, ADR-0014）。
 
-理論値: 1 日 22h 配信 / 24h = 22/24 ≈ 0.9166 (91.7%)
-実測値: actual_archives / (2 * days_in_month)
-       (1 日 2 本のアーカイブが完走するのが理論満額。)
+理論値: 1 日 24h 配信 / 24h = 1.0 (100%)
+実測値: 24/7 デフォルトではアーカイブ数ベースの計算を行わない。
 """
 
 from __future__ import annotations
 
-from youtube_automation.utils.streaming import THEORETICAL_HOURS_PER_DAY
+from youtube_automation.utils.streaming import ARCHIVES_EXPECTED, THEORETICAL_HOURS_PER_DAY
 
 _HOURS_PER_DAY = 24
 _ARCHIVES_PER_DAY = 2  # 11h × 2 本 = 22h
 
 
 def theoretical_uptime_ratio() -> float:
-    """理論稼働率を返す。22 / 24 = 0.9166...。"""
+    """理論稼働率を返す。24 / 24 = 1.0。"""
     return THEORETICAL_HOURS_PER_DAY / _HOURS_PER_DAY
 
 
-def actual_uptime_ratio(*, actual_archives: int, days_in_month: int) -> float:
+def actual_uptime_ratio(*, actual_archives: int, days_in_month: int) -> float | None:
     """実測稼働率を返す。
 
     Args:
@@ -26,11 +25,27 @@ def actual_uptime_ratio(*, actual_archives: int, days_in_month: int) -> float:
         days_in_month: その月の日数
 
     Returns:
-        actual_archives / (2 * days_in_month)
+        ARCHIVES_EXPECTED=True なら actual_archives / (2 * days_in_month)。
+        ARCHIVES_EXPECTED=False なら None。
 
     Raises:
         ValueError: days_in_month が 0 以下の場合 (Fail Fast)
     """
+    _validate_days_in_month(days_in_month)
+    if not ARCHIVES_EXPECTED:
+        return None
+    return actual_archives / (_ARCHIVES_PER_DAY * days_in_month)
+
+
+def theoretical_archive_count(*, days_in_month: int) -> int | None:
+    """理論アーカイブ本数を返す。"""
+    _validate_days_in_month(days_in_month)
+    if not ARCHIVES_EXPECTED:
+        return None
+    return _ARCHIVES_PER_DAY * days_in_month
+
+
+def _validate_days_in_month(days_in_month: int) -> None:
+    """days_in_month の不正値を検出する。"""
     if days_in_month <= 0:
         raise ValueError(f"days_in_month must be positive, got {days_in_month}")
-    return actual_archives / (_ARCHIVES_PER_DAY * days_in_month)

--- a/src/youtube_automation/utils/streaming/monthly_report.py
+++ b/src/youtube_automation/utils/streaming/monthly_report.py
@@ -39,8 +39,6 @@ def _format_archive_count(archives: int | None, theoretical_archives: int | None
     """アーカイブ件数の表示行を返す。"""
     if theoretical_archives is None:
         return "アーカイブ数ベース判定なし"
-    if archives is None:
-        raise ValueError("archives is required when archive-based reporting is enabled")
     return f"アーカイブ件数: 実測 {archives} 本 / 理論 {theoretical_archives} 本"
 
 

--- a/src/youtube_automation/utils/streaming/monthly_report.py
+++ b/src/youtube_automation/utils/streaming/monthly_report.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from youtube_automation.utils.streaming import (
     MONTHLY_QUOTA_GB,
-    THEORETICAL_ARCHIVES_PER_MONTH,
     THRESHOLD_RATIO,
 )
 from youtube_automation.utils.streaming.cycle_uptime import (
     actual_uptime_ratio,
+    theoretical_archive_count,
     theoretical_uptime_ratio,
 )
 
@@ -28,13 +28,29 @@ def _format_diff_gb(usage_gb: float, previous_usage_gb: float | None) -> str:
     return f"前月比: {diff:+.1f} GB"
 
 
+def _format_actual_uptime(actual_uptime: float | None) -> str:
+    """実測稼働率の表示値を返す。"""
+    if actual_uptime is None:
+        return "N/A"
+    return f"{actual_uptime * 100:.1f}%"
+
+
+def _format_archive_count(archives: int | None, theoretical_archives: int | None) -> str:
+    """アーカイブ件数の表示行を返す。"""
+    if theoretical_archives is None:
+        return "アーカイブ数ベース判定なし"
+    if archives is None:
+        raise ValueError("archives is required when archive-based reporting is enabled")
+    return f"アーカイブ件数: 実測 {archives} 本 / 理論 {theoretical_archives} 本"
+
+
 def format_monthly_report(
     *,
     year: int,
     month: int,
     usage_gb: float,
     previous_usage_gb: float | None,
-    archives: int,
+    archives: int | None,
     days_in_month: int,
 ) -> str:
     """月次レポートテキストを整形する。
@@ -44,7 +60,7 @@ def format_monthly_report(
         month: 対象月 (1-12)
         usage_gb: 月間帯域消費量 (GB)
         previous_usage_gb: 前月の帯域消費量 (GB)。データ無しなら None
-        archives: 月間アーカイブ本数 (実測)
+        archives: 月間アーカイブ本数 (実測)。アーカイブ数ベース判定なしなら None
         days_in_month: 対象月の日数
 
     Returns:
@@ -52,7 +68,12 @@ def format_monthly_report(
     """
     quota_pct = (usage_gb / MONTHLY_QUOTA_GB) * 100
     threshold_pct = int(THRESHOLD_RATIO * 100)
-    actual_uptime = actual_uptime_ratio(actual_archives=archives, days_in_month=days_in_month) * 100
+    theoretical_archives = theoretical_archive_count(days_in_month=days_in_month)
+    actual_uptime = None
+    if theoretical_archives is not None:
+        if archives is None:
+            raise ValueError("archives is required when archive-based reporting is enabled")
+        actual_uptime = actual_uptime_ratio(actual_archives=archives, days_in_month=days_in_month)
     theoretical_uptime = theoretical_uptime_ratio() * 100
 
     lines = [
@@ -62,7 +83,7 @@ def format_monthly_report(
         f"  - アラート閾値: {threshold_pct}%",
         f"  - {_format_diff_gb(usage_gb, previous_usage_gb)}",
         "",
-        f"稼働率 (11h+1h サイクル): 実測 {actual_uptime:.1f}% / 理論 {theoretical_uptime:.1f}%",
-        f"アーカイブ件数: 実測 {archives} 本 / 理論 {THEORETICAL_ARCHIVES_PER_MONTH} 本",
+        f"稼働率 (24/7 連続配信): 実測 {_format_actual_uptime(actual_uptime)} / 理論 {theoretical_uptime:.1f}%",
+        _format_archive_count(archives, theoretical_archives),
     ]
     return "\n".join(lines)

--- a/tests/integration/test_stream_bandwidth_flow.py
+++ b/tests/integration/test_stream_bandwidth_flow.py
@@ -40,11 +40,11 @@ def _fake_urlopen_for_vultr(payload: dict):
     return _Resp(json.dumps(payload).encode("utf-8"))
 
 
-def test_report_flow_posts_combined_report(monkeypatch):
-    """Given Vultr API が 2026-04 の合計 1188 GB を返す + アーカイブ 58 本
+def test_report_flow_posts_combined_report_without_youtube_archive_count():
+    """Given Vultr API が 2026-04 の合計 1188 GB を返す
     When CLI --report --month 2026-04 を実行
     Then notification.notify が webhook URL 付きで呼ばれ、
-         content に 2026-04 / 1188 / 58 / 60 が全て含まれる。
+         content に 2026-04 / 1188 / アーカイブ数ベース判定なし が含まれる。
     """
     bandwidth_payload = {
         "bandwidth": {
@@ -71,18 +71,10 @@ def test_report_flow_posts_combined_report(monkeypatch):
             "STREAM_WEBHOOK_URL": "https://discord.com/api/webhooks/123/abc",
         }[name]
 
-    # アーカイブ計数を直接モック (YouTube API は複雑な mock になるため境界で切る)
-    def fake_count_archives(service, *, channel_id, year, month):
-        return 58
-
-    # YouTube サービスはダミー (count_archives モックが service を見ないので無害)
-    def fake_get_youtube():
-        return object()
-
     with (
         patch("youtube_automation.cli.stream_bandwidth.get_secret", side_effect=fake_get_secret),
-        patch("youtube_automation.cli.stream_bandwidth.count_archives", side_effect=fake_count_archives),
-        patch("youtube_automation.cli.stream_bandwidth.get_youtube", side_effect=fake_get_youtube),
+        patch("youtube_automation.cli.stream_bandwidth.count_archives") as count_archives_mock,
+        patch("youtube_automation.cli.stream_bandwidth.get_youtube") as get_youtube_mock,
         patch(
             "youtube_automation.utils.streaming.vultr_bandwidth.urllib.request.urlopen",
             side_effect=fake_urlopen,
@@ -101,8 +93,10 @@ def test_report_flow_posts_combined_report(monkeypatch):
     # レポートに必須の値が全て乗っていること
     assert "2026-04" in content
     assert "1188" in content
-    assert "58" in content
-    assert "60" in content
+    assert "アーカイブ数ベース判定なし" in content
+    assert "アーカイブ件数: 実測" not in content
+    count_archives_mock.assert_not_called()
+    get_youtube_mock.assert_not_called()
 
 
 def test_check_threshold_flow_silent_under_limit():

--- a/tests/test_stream_bandwidth_cli.py
+++ b/tests/test_stream_bandwidth_cli.py
@@ -145,6 +145,30 @@ def test_report_mode_calls_notify_with_formatted_text():
     assert "2026-04" in content
 
 
+def test_report_mode_skips_youtube_archive_count_when_archives_are_not_expected():
+    """Given ARCHIVES_EXPECTED=False
+    When --report を実行
+    Then YouTube API 境界とアーカイブ計数を呼ばずにレポートする。
+    """
+    bw = {"2026-04-15": {"incoming_bytes": 1024**3 * 200, "outgoing_bytes": 0}}
+    mocks = _patch_all(bandwidth=bw)
+    enters = _enter(mocks)
+    try:
+        rc = stream_bandwidth.main(["--report", "--month", "2026-04", "--instance-id", "VULTR_X"])
+    finally:
+        _exit(mocks)
+
+    assert rc == 0
+    count_archives_mock = enters[2]
+    notify_mock = enters[4]
+    get_youtube_mock = enters[5]
+    count_archives_mock.assert_not_called()
+    get_youtube_mock.assert_not_called()
+    content = notify_mock.call_args.kwargs["content"]
+    assert "アーカイブ数ベース判定なし" in content
+    assert "アーカイブ件数: 実測" not in content
+
+
 def test_report_mode_emits_na_when_previous_month_has_no_data():
     """Given 前月キーを持たない fixture
     When --report --month 2026-04

--- a/tests/test_stream_constants.py
+++ b/tests/test_stream_constants.py
@@ -1,8 +1,8 @@
 """utils/streaming/__init__.py の定数集中をテストする。
 
 計画 §「定数集中」: MONTHLY_QUOTA_GB / THRESHOLD_RATIO / THEORETICAL_BITRATE_MBPS /
-THEORETICAL_HOURS_PER_DAY / THEORETICAL_ARCHIVES_PER_MONTH を package __init__ に集約し、
-CLI / レポート / テストで重複定義しないこと。
+THEORETICAL_HOURS_PER_DAY / ARCHIVES_EXPECTED を package __init__ に集約し、CLI / レポート /
+テストで重複定義しないこと。
 """
 
 from __future__ import annotations
@@ -44,17 +44,17 @@ def test_archive_mode_constants_are_not_public_api():
     assert not hasattr(streaming, "ARCHIVE_MODE_ARCHIVES_PER_DAY")
 
 
-def test_theoretical_hours_per_day_is_22():
-    """Given order.md「1 日の配信時間: 22 時間 (11h × 2 本)」
+def test_theoretical_hours_per_day_is_24():
+    """Given ADR-0014「デフォルトを 24/7 連続配信にする」
     When THEORETICAL_HOURS_PER_DAY を引く
-    Then 22 で固定されている。
+    Then 24 で固定されている。
     """
-    assert streaming.THEORETICAL_HOURS_PER_DAY == 22
+    assert streaming.THEORETICAL_HOURS_PER_DAY == 24
 
 
-def test_theoretical_archives_per_month_is_60():
-    """Given order.md「アーカイブ件数 (理論値 60 本/月)」
-    When THEORETICAL_ARCHIVES_PER_MONTH を引く
-    Then 60 で固定されている。
+def test_archives_expected_is_false():
+    """Given ADR-0014「アーカイブは生成されなくなる」
+    When ARCHIVES_EXPECTED を引く
+    Then False で固定されている。
     """
-    assert streaming.THEORETICAL_ARCHIVES_PER_MONTH == 60
+    assert streaming.ARCHIVES_EXPECTED is False

--- a/tests/test_stream_cycle_uptime.py
+++ b/tests/test_stream_cycle_uptime.py
@@ -1,8 +1,8 @@
 """utils/streaming/cycle_uptime.py の純粋計算ロジックをテストする。
 
-要件 R10: 11h+1h サイクル稼働率 (理論 91.7% に対する実測)。
-- 理論値: 22h / 24h = 0.9166...
-- 実測値: actual_archives / (2 * days_in_month)
+要件 R10 / ADR-0014: 24/7 連続配信の稼働率。
+- 理論値: 24h / 24h = 1.0
+- 実測値: ARCHIVES_EXPECTED=False ではアーカイブ数ベース計算を行わない
 """
 
 from __future__ import annotations
@@ -12,66 +12,84 @@ import pytest
 from youtube_automation.utils.streaming import cycle_uptime
 
 
-def test_theoretical_uptime_ratio_is_22_over_24():
-    """Given 1 日 22 時間配信 (11h × 2 本) / 24 時間
+def test_theoretical_uptime_ratio_is_24_over_24():
+    """Given 1 日 24 時間配信 / 24 時間
     When theoretical_uptime_ratio を呼ぶ
-    Then 22/24 = 0.9166... が返る (order.md「理論値 91.7%」)。
+    Then 24/24 = 1.0 が返る。
     """
-    assert cycle_uptime.theoretical_uptime_ratio() == pytest.approx(22 / 24)
+    assert cycle_uptime.theoretical_uptime_ratio() == pytest.approx(1.0)
 
 
-def test_actual_uptime_ratio_full_month_30days():
-    """Given 30 日の月で 60 本のアーカイブ (理論満額)
+def test_actual_uptime_ratio_skips_archive_based_calculation_by_default():
+    """Given ARCHIVES_EXPECTED=False
     When actual_uptime_ratio を呼ぶ
-    Then 60 / (2 * 30) = 1.0 (理論を満たした稼働)。
+    Then アーカイブ本数ベースの実測稼働率は None になる。
     """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=60, days_in_month=30) == pytest.approx(1.0)
+    assert cycle_uptime.actual_uptime_ratio(actual_archives=60, days_in_month=30) is None
 
 
-def test_actual_uptime_ratio_half_month():
-    """Given 30 日の月で 30 本のアーカイブ
+def test_actual_uptime_ratio_validates_days_when_archives_are_not_expected():
+    """Given ARCHIVES_EXPECTED=False かつ days_in_month=0
     When actual_uptime_ratio を呼ぶ
-    Then 30 / 60 = 0.5。
+    Then ValueError を送出する。
     """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=30, days_in_month=30) == 0.5
-
-
-def test_actual_uptime_ratio_zero_archives():
-    """Given アーカイブ 0 本
-    When actual_uptime_ratio を呼ぶ
-    Then 0.0 (境界値)。
-    """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=0, days_in_month=30) == 0.0
-
-
-def test_actual_uptime_ratio_31day_month():
-    """Given 31 日の月で 62 本 (理論満額)
-    When actual_uptime_ratio を呼ぶ
-    Then 1.0。
-    """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=62, days_in_month=31) == pytest.approx(1.0)
-
-
-def test_actual_uptime_ratio_28day_february():
-    """Given 28 日の 2 月で 56 本
-    When actual_uptime_ratio を呼ぶ
-    Then 1.0。
-    """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=56, days_in_month=28) == pytest.approx(1.0)
-
-
-def test_actual_uptime_ratio_partial():
-    """Given 30 日 / 45 本 (理論の 75%)
-    When actual_uptime_ratio を呼ぶ
-    Then 45/60 = 0.75。
-    """
-    assert cycle_uptime.actual_uptime_ratio(actual_archives=45, days_in_month=30) == 0.75
-
-
-def test_actual_uptime_ratio_zero_days_raises():
-    """Given days_in_month=0
-    When actual_uptime_ratio を呼ぶ
-    Then ZeroDivisionError or ValueError (Fail Fast。フォールバック禁止)。
-    """
-    with pytest.raises((ZeroDivisionError, ValueError)):
+    with pytest.raises(ValueError):
         cycle_uptime.actual_uptime_ratio(actual_archives=10, days_in_month=0)
+
+
+@pytest.mark.parametrize(
+    ("archives", "days_in_month", "expected"),
+    [
+        (60, 30, 1.0),
+        (30, 30, 0.5),
+        (0, 30, 0.0),
+        (62, 31, 1.0),
+        (56, 28, 1.0),
+        (45, 30, 0.75),
+    ],
+)
+def test_actual_uptime_ratio_uses_archive_count_when_archives_are_expected(
+    monkeypatch: pytest.MonkeyPatch,
+    archives: int,
+    days_in_month: int,
+    expected: float,
+):
+    """Given ARCHIVES_EXPECTED=True
+    When actual_uptime_ratio を呼ぶ
+    Then actual_archives / (2 * days_in_month) を返す。
+    """
+    monkeypatch.setattr(cycle_uptime, "ARCHIVES_EXPECTED", True)
+
+    assert cycle_uptime.actual_uptime_ratio(
+        actual_archives=archives,
+        days_in_month=days_in_month,
+    ) == pytest.approx(expected)
+
+
+def test_actual_uptime_ratio_zero_days_raises_when_archives_are_expected(monkeypatch: pytest.MonkeyPatch):
+    """Given ARCHIVES_EXPECTED=True かつ days_in_month=0
+    When actual_uptime_ratio を呼ぶ
+    Then ValueError を送出する。
+    """
+    monkeypatch.setattr(cycle_uptime, "ARCHIVES_EXPECTED", True)
+
+    with pytest.raises(ValueError):
+        cycle_uptime.actual_uptime_ratio(actual_archives=10, days_in_month=0)
+
+
+def test_theoretical_archive_count_returns_none_by_default():
+    """Given ARCHIVES_EXPECTED=False
+    When theoretical_archive_count を呼ぶ
+    Then 理論アーカイブ本数は None になる。
+    """
+    assert cycle_uptime.theoretical_archive_count(days_in_month=30) is None
+
+
+def test_theoretical_archive_count_uses_days_when_archives_are_expected(monkeypatch: pytest.MonkeyPatch):
+    """Given ARCHIVES_EXPECTED=True
+    When theoretical_archive_count を呼ぶ
+    Then 2 * days_in_month を返す。
+    """
+    monkeypatch.setattr(cycle_uptime, "ARCHIVES_EXPECTED", True)
+
+    assert cycle_uptime.theoretical_archive_count(days_in_month=31) == 62

--- a/tests/test_stream_monthly_report.py
+++ b/tests/test_stream_monthly_report.py
@@ -4,9 +4,8 @@
 
 整形対象:
 - 月間帯域消費量 (GB) と前月比
-- 11h+1h サイクル稼働率 (理論 91.7% に対する実測)
-- アーカイブ件数 (理論 60 本)
-- back-calc Mbps: usage_gb × 8 × 1024 / (archives × 11h × 3600)
+- 24/7 連続配信稼働率 (理論 100%)
+- アーカイブ数ベース判定なし (24/7 デフォルト)
 """
 
 from __future__ import annotations
@@ -95,13 +94,13 @@ def test_format_monthly_report_handles_no_previous_month():
         days_in_month=30,
     )
     assert "1200" in text
-    assert ("N/A" in text) or ("-" in text) or ("なし" in text)
+    assert "前月比: N/A (前月データなし)" in text
 
 
-def test_format_monthly_report_includes_uptime_actual_and_theoretical():
-    """Given archives=45, days_in_month=30 (理論 60 本)
+def test_format_monthly_report_skips_archive_based_actual_uptime():
+    """Given ARCHIVES_EXPECTED=False
     When format_monthly_report を呼ぶ
-    Then 実測稼働率 75% と理論 91.7% (or 0.917) の両方を含む。
+    Then 実測稼働率 N/A と理論 100.0% の両方を含む。
     """
     text = monthly_report.format_monthly_report(
         year=2026,
@@ -111,27 +110,24 @@ def test_format_monthly_report_includes_uptime_actual_and_theoretical():
         archives=45,
         days_in_month=30,
     )
-    # 実測 = 45 / 60 = 0.75 → 75%
-    assert "75" in text
-    # 理論 = 22/24 ≈ 91.7% → "91.7" あるいは小数で 0.91 系
-    assert ("91.7" in text) or ("91.6" in text)
+    assert "稼働率 (24/7 連続配信): 実測 N/A / 理論 100.0%" in text
 
 
-def test_format_monthly_report_includes_archive_count_actual_and_theoretical():
-    """Given archives=58 (理論 60)
+def test_format_monthly_report_skips_archive_count_line_when_archives_are_not_expected():
+    """Given ARCHIVES_EXPECTED=False
     When format_monthly_report を呼ぶ
-    Then "58" と "60" の両方を含む (実測 vs 理論)。
+    Then 実測アーカイブ件数には依存しない。
     """
     text = monthly_report.format_monthly_report(
         year=2026,
         month=4,
         usage_gb=1188.0,
         previous_usage_gb=1100.0,
-        archives=58,
+        archives=None,
         days_in_month=30,
     )
-    assert "58" in text
-    assert "60" in text
+    assert "アーカイブ数ベース判定なし" in text
+    assert "アーカイブ件数: 実測" not in text
 
 
 def test_format_monthly_report_includes_quota_percentage():

--- a/tests/test_stream_monthly_report.py
+++ b/tests/test_stream_monthly_report.py
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from youtube_automation.utils.streaming import monthly_report
 
 
@@ -162,3 +164,56 @@ def test_format_monthly_report_returns_str():
     )
     assert isinstance(text, str)
     assert len(text) > 0
+
+
+def test_format_monthly_report_archives_expected_true_includes_uptime_and_count(
+    monkeypatch,
+):
+    """Given ARCHIVES_EXPECTED=True, archives=45, days_in_month=30
+    When format_monthly_report を呼ぶ
+    Then 実測稼働率と理論稼働率が数値で表示され、アーカイブ件数行を含む。
+    """
+    import youtube_automation.utils.streaming as streaming_pkg
+    import youtube_automation.utils.streaming.cycle_uptime as cycle_mod
+
+    monkeypatch.setattr(streaming_pkg, "ARCHIVES_EXPECTED", True)
+    monkeypatch.setattr(cycle_mod, "ARCHIVES_EXPECTED", True)
+
+    text = monthly_report.format_monthly_report(
+        year=2026,
+        month=6,
+        usage_gb=1500.0,
+        previous_usage_gb=1400.0,
+        archives=45,
+        days_in_month=30,
+    )
+    # 実測稼働率が N/A ではなく数値 (%) で表示される
+    assert "実測 N/A" not in text
+    assert "実測" in text
+    assert "理論 100.0%" in text
+    # アーカイブ件数行が含まれる
+    assert "アーカイブ件数: 実測 45 本 / 理論 60 本" in text
+
+
+def test_format_monthly_report_archives_expected_true_archives_none_raises(
+    monkeypatch,
+):
+    """Given ARCHIVES_EXPECTED=True, archives=None
+    When format_monthly_report を呼ぶ
+    Then ValueError が送出される。
+    """
+    import youtube_automation.utils.streaming as streaming_pkg
+    import youtube_automation.utils.streaming.cycle_uptime as cycle_mod
+
+    monkeypatch.setattr(streaming_pkg, "ARCHIVES_EXPECTED", True)
+    monkeypatch.setattr(cycle_mod, "ARCHIVES_EXPECTED", True)
+
+    with pytest.raises(ValueError, match="archives is required"):
+        monthly_report.format_monthly_report(
+            year=2026,
+            month=6,
+            usage_gb=1500.0,
+            previous_usage_gb=1400.0,
+            archives=None,
+            days_in_month=30,
+        )


### PR DESCRIPTION
## Summary

## What to build

ADR-0014 に基づき、Python 側の streaming 定数を 24/7 連続配信のデフォルトに合わせて更新する。アーカイブ数ベースの稼働率計算を `ARCHIVES_EXPECTED` boolean で分岐させる。

### 変更対象

- `src/youtube_automation/utils/streaming/__init__.py`:
  - `THEORETICAL_HOURS_PER_DAY = 22` → `24`
  - `THEORETICAL_ARCHIVES_PER_MONTH = 60` → 削除（または残置）
  - `ARCHIVES_EXPECTED = False` を追加
- `src/youtube_automation/utils/streaming/cycle_uptime.py`:
  - `ARCHIVES_EXPECTED=False` 時はアーカイブ数ベースの稼働率計算をスキップ
  - `_ARCHIVES_PER_DAY = 2` のハードコードも `ARCHIVES_EXPECTED` で分岐
- `src/youtube_automation/utils/streaming/monthly_report.py`:
  - `THEORETICAL_ARCHIVES_PER_MONTH` 参照箇所を `ARCHIVES_EXPECTED` で分岐
- `tests/test_stream_constants.py`: 新しい定数値に合わせてテスト修正

### 設計判断

- ADR-0014: `docs/adr/0014-streaming-continuous-default.md`

## Acceptance criteria

- [ ] `THEORETICAL_HOURS_PER_DAY` が 24 に更新されている
- [ ] `ARCHIVES_EXPECTED = False` が定義されている
- [ ] `cycle_uptime.py` が `ARCHIVES_EXPECTED=False` のとき従来のアーカイブ数ベース計算をスキップする
- [ ] `monthly_report.py` が `ARCHIVES_EXPECTED=False` のとき正しく動作する
- [ ] 既存テストが新しい定数値で通る

## Blocked by

None - can start immediately

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1220