### PR TITLE
fix(suno-helper): grid view で playlist 追加が失敗する DOM セレクタ不整合を修正 (#1237)

### DIFF
--- a/extensions/shared/playlist-dom.ts
+++ b/extensions/shared/playlist-dom.ts
@@ -26,6 +26,10 @@ const CLIP_ROW_SONG_ID_DATA_KEY = "songId";
 const CLIP_ROW_CLIP_ID_DATA_KEY = "clipId";
 const CLIP_ROW_SONG_LINK_SELECTOR = 'a[href*="/song/"]';
 const SONG_HREF_ID_RE = /\/song\/([^/?#]+)/;
+const GRID_IMAGE_SRC_SELECTOR = 'img[src*="cdn2.suno.ai/image_"]';
+const GRID_IMAGE_UUID_RE = /\/image_([0-9a-f-]{36})/;
+const GRID_CARD_MAX_ANCESTOR_DEPTH = 10;
+const GRID_CARD_MIN_SIBLINGS = 2;
 /** Add to Playlist dialog 内の playlist 名入力欄。 */
 export const PLAYLIST_NAME_INPUT_SELECTOR =
   'input[placeholder="Playlist Name"]';
@@ -88,7 +92,42 @@ function resolveClipRowFromSelectButton(
   if (multiSelectRow) {
     return multiSelectRow;
   }
-  return button.closest<HTMLElement>("article");
+  const articleRow = button.closest<HTMLElement>("article");
+  if (articleRow) {
+    return articleRow;
+  }
+  return resolveGridCardFromSelectButton(button);
+}
+
+function resolveGridCardFromSelectButton(
+  button: HTMLElement,
+): HTMLElement | null {
+  let candidate: HTMLElement | null = button.parentElement;
+  for (
+    let depth = 0;
+    candidate && depth < GRID_CARD_MAX_ANCESTOR_DEPTH;
+    depth++
+  ) {
+    const parent = candidate.parentElement;
+    if (!parent) {
+      break;
+    }
+    const siblings = Array.from(parent.children);
+    if (
+      siblings.length >= GRID_CARD_MIN_SIBLINGS &&
+      siblings.every(
+        (sibling) =>
+          sibling.querySelectorAll(SELECT_CLIP_BUTTON_ANY_SELECTOR).length +
+            sibling.querySelectorAll(DESELECT_CLIP_BUTTON_ANY_SELECTOR)
+              .length ===
+          1,
+      )
+    ) {
+      return candidate;
+    }
+    candidate = parent;
+  }
+  return null;
 }
 
 function isScrollableClipContainer(element: HTMLElement): boolean {
@@ -205,6 +244,16 @@ function collectClipRowIds(row: HTMLElement): Set<string> {
     const id = extractSongIdFromHref(link.href);
     if (id) {
       ids.add(id);
+    }
+  }
+  if (ids.size === 0) {
+    for (const img of row.querySelectorAll<HTMLImageElement>(
+      GRID_IMAGE_SRC_SELECTOR,
+    )) {
+      const match = GRID_IMAGE_UUID_RE.exec(img.src);
+      if (match) {
+        ids.add(match[1]);
+      }
     }
   }
   return ids;

--- a/extensions/suno-helper/tests/dom-playlist.test.ts
+++ b/extensions/suno-helper/tests/dom-playlist.test.ts
@@ -185,6 +185,76 @@ function addAlternateViewRow(
 }
 
 /**
+ * Grid view (#1237) の per-card 要素を `.clip-browser-list-scroller` 配下に挿入する。
+ * 実機 DOM:
+ *   .clip-browser-list-scroller > wrapper > gridContainer > per-card × N
+ *   各 per-card > nested divs > button[aria-label="Select clip"]
+ *                              > img[src*="cdn2.suno.ai/image_{UUID}"]
+ */
+function addGridViewCard(
+  gridContainer: HTMLElement,
+  clipId: string,
+  opts: { selectLabel?: string; visible?: boolean } = {},
+): { row: HTMLElement; btn: HTMLButtonElement } {
+  const { selectLabel = "Select clip", visible = true } = opts;
+  const card = document.createElement("div");
+  const inner1 = document.createElement("div");
+  const inner2 = document.createElement("div");
+  const inner3 = document.createElement("div");
+
+  const btn = document.createElement("button");
+  btn.setAttribute("aria-label", selectLabel);
+
+  const img = document.createElement("img");
+  img.src = `https://cdn2.suno.ai/image_${clipId}.jpeg`;
+
+  const titleDiv = document.createElement("div");
+  titleDiv.textContent = `Track ${clipId}`;
+
+  inner3.append(btn, img, titleDiv);
+  inner2.appendChild(inner3);
+  inner1.appendChild(inner2);
+  card.appendChild(inner1);
+  gridContainer.appendChild(card);
+
+  if (visible === false) {
+    card.style.display = "none";
+    markBbox(card, 0, 0);
+  } else {
+    markBbox(card, 200, 200);
+  }
+  markBbox(btn, 20, 20);
+  return { row: card, btn };
+}
+
+function addGridViewRows(
+  count: number,
+  opts: { selectLabel?: string } = {},
+): {
+  scroller: HTMLElement;
+  gridContainer: HTMLElement;
+  rows: HTMLElement[];
+  buttons: HTMLButtonElement[];
+} {
+  const scroller = getOrCreateScroller();
+  const wrapper = getOrCreateClipList();
+  const gridContainer = document.createElement("div");
+  wrapper.appendChild(gridContainer);
+
+  const rows: HTMLElement[] = [];
+  const buttons: HTMLButtonElement[] = [];
+  for (let i = 0; i < count; i++) {
+    const padded = String(i).padStart(8, "0");
+    const { row, btn } = addGridViewCard(gridContainer, `${padded}-0000-0000-0000-000000000000`, {
+      selectLabel: opts.selectLabel,
+    });
+    rows.push(row);
+    buttons.push(btn);
+  }
+  return { scroller, gridContainer, rows, buttons };
+}
+
+/**
  * Add to Playlist dialog を模した `[role="dialog"]` を body に挿入する。
  *   - text: 内部見出しの textContent（判定対象。order.md の span#_r_dg_ 相当）
  *   - ariaLabel / id: cookie 除外フィルタ検証用（"Privacy Preference Center" / "ot-..."）
@@ -1366,5 +1436,79 @@ describe("clickPlaylistRowByName: dialog 内 list の新規 row を click して
 
     expect(observedTarget).not.toBe(wrapper);
     expect((observedTarget as HTMLElement | null)?.textContent).toBe("x");
+  });
+});
+
+describe("grid view (#1237): .multi-select-button / a[href*='/song/'] 不在の DOM でも playlist 追加フローが動作する", () => {
+  describe("ensureClipRowsLoaded: grid view per-card 解決", () => {
+    it("Given grid view DOM When ensureClipRowsLoaded Then sibling cardinality heuristic で per-card を row として返す", async () => {
+      const { rows } = addGridViewRows(3);
+      await expect(ensureClipRowsLoaded(3, { isAborted: () => false })).resolves.toEqual(rows);
+    });
+
+    it("Given grid view で一部 card が非表示 When ensureClipRowsLoaded Then strict isVisible で除外する", async () => {
+      const { gridContainer, rows } = addGridViewRows(2);
+      addGridViewCard(gridContainer, "hidden-uuid", { visible: false });
+      await expect(ensureClipRowsLoaded(2, { isAborted: () => false })).resolves.toEqual(rows);
+    });
+  });
+
+  describe("ensureClipRowsLoadedByIds: grid view image UUID 抽出", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("Given grid view DOM with img[src*='cdn2.suno.ai/image_'] When target ID で取得する Then UUID を抽出して row を返す", async () => {
+      const id0 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+      const id1 = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+      const id2 = "c3d4e5f6-a7b8-9012-cdef-123456789012";
+      const scroller = getOrCreateScroller();
+      const wrapper = getOrCreateClipList();
+      const gridContainer = document.createElement("div");
+      wrapper.appendChild(gridContainer);
+      const card0 = addGridViewCard(gridContainer, id0);
+      addGridViewCard(gridContainer, id1);
+      const card2 = addGridViewCard(gridContainer, id2);
+
+      const pending = ensureClipRowsLoadedByIds([id0, id2], {
+        isAborted: () => false,
+      });
+      await vi.runAllTimersAsync();
+      expect(await pending).toEqual([card0.row, card2.row]);
+    });
+
+    it("Given grid view row に data-songId も存在する When target ID で取得する Then data-songId を優先し image fallback は走らない", async () => {
+      const scroller = getOrCreateScroller();
+      const wrapper = getOrCreateClipList();
+      const gridContainer = document.createElement("div");
+      wrapper.appendChild(gridContainer);
+      const card0 = addGridViewCard(gridContainer, "a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+      const card1 = addGridViewCard(gridContainer, "b2c3d4e5-f6a7-8901-bcde-f12345678901");
+      card0.row.dataset.songId = "primary-id";
+
+      const pending = ensureClipRowsLoadedByIds(["primary-id"], {
+        isAborted: () => false,
+      });
+      await vi.runAllTimersAsync();
+      expect(await pending).toEqual([card0.row]);
+    });
+  });
+
+  describe("multiSelectClips: grid view click + verify", () => {
+    it("Given grid view per-card rows When multiSelectClips Then Select clip button を click して selected 遷移を verify する", async () => {
+      const { rows, buttons } = addGridViewRows(2);
+      const clicks: string[] = [];
+      buttons[0].addEventListener("click", () => clicks.push("a"));
+      buttons[1].addEventListener("click", () => clicks.push("b"));
+      selectOnClick(buttons[0]);
+      selectOnClick(buttons[1]);
+
+      await expect(multiSelectClips(rows)).resolves.toBeUndefined();
+      expect(clicks).toEqual(["a", "b"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `resolveClipRowFromSelectButton()` に grid view フォールバック（sibling cardinality heuristic）を追加し、`.multi-select-button` / `article` 不在の DOM でも per-card 要素を構造的に解決
- `collectClipRowIds()` に `img[src*="cdn2.suno.ai/image_"]` からの UUID 抽出フォールバックを追加し、`data-songId` / `a[href*="/song/"]` 不在の grid view でも clip ID を取得
- list view の既存ロジックは一切変更なし（フォールバックは既存パスが null の場合のみ発動）

Closes #1237

## Test plan

- [x] 既存テスト全 688 件がパス（list view 非破壊を確認）
- [x] 新規 grid view テスト 5 件がパス
  - `ensureClipRowsLoaded`: sibling heuristic で per-card 解決 / 非表示 card 除外
  - `ensureClipRowsLoadedByIds`: image UUID 抽出 / data-songId 優先確認
  - `multiSelectClips`: grid view click + Deselect 遷移 verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwJkeDcBL3QCnh51bXjzve