### PR TITLE
test(streaming): カスタム値の systemd テンプレート条件分岐テストを追加 (#1221)

### DIFF
--- a/tests/streaming/test_systemd_unit.py
+++ b/tests/streaming/test_systemd_unit.py
@@ -225,6 +225,34 @@ class TestSystemdUnitTemplate:
             "（RuntimeMaxSec なしで RestartSec が長時間だとクラッシュ復旧が遅延する）"
         )
 
+    def test_service_custom_cycle_values(self):
+        """Given stream_hours=8, break_hours=2
+        When テンプレートを展開する
+        Then RuntimeMaxSec=8h, RestartSec=2h が出力される。
+        """
+        service = self._section(self._render_cycle_template(8, 2), "Service")
+        assert service is not None
+        assert re.search(r"^RuntimeMaxSec=8h\s*$", service, flags=re.MULTILINE), (
+            "stream_hours=8 で RuntimeMaxSec=8h が出力されない"
+        )
+        assert re.search(r"^RestartSec=2h\s*$", service, flags=re.MULTILINE), (
+            "break_hours=2 で RestartSec=2h が出力されない"
+        )
+
+    def test_service_custom_cycle_no_break(self):
+        """Given stream_hours=6, break_hours=0
+        When テンプレートを展開する
+        Then RuntimeMaxSec=6h が出力され、RestartSec=10s（クラッシュ再起動）になる。
+        """
+        service = self._section(self._render_cycle_template(6, 0), "Service")
+        assert service is not None
+        assert re.search(r"^RuntimeMaxSec=6h\s*$", service, flags=re.MULTILINE), (
+            "stream_hours=6 で RuntimeMaxSec=6h が出力されない"
+        )
+        assert re.search(r"^RestartSec=10s\s*$", service, flags=re.MULTILINE), (
+            "stream_hours=6, break_hours=0 で RestartSec=10s が出力されない"
+        )
+
     def test_install_section_wanted_by_multi_user(self):
         """Given .tftpl
         When [Install] セクションを読む


### PR DESCRIPTION
## Summary

- `stream_hours=8, break_hours=2` と `stream_hours=6, break_hours=0` のカスタム値テストを追加
- 24/7 モード (0,0) と従来モード (11,1) に加え、任意の設定値での動作を検証

## Test plan

- [x] 41 テスト pass（既存 39 + 新規 2）
- [ ] CI 全 pass

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbvMchy2jU419oanvRw2dS