### PR TITLE
fix(suno-helper): grid view テストの未使用変数 lint エラーを修正 (#1237)

### DIFF
--- a/extensions/suno-helper/tests/dom-playlist.test.ts
+++ b/extensions/suno-helper/tests/dom-playlist.test.ts
@@ -1466,7 +1466,7 @@ describe("grid view (#1237): .multi-select-button / a[href*='/song/'] 不在の 
       const id0 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
       const id1 = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
       const id2 = "c3d4e5f6-a7b8-9012-cdef-123456789012";
-      const scroller = getOrCreateScroller();
+      getOrCreateScroller();
       const wrapper = getOrCreateClipList();
       const gridContainer = document.createElement("div");
       wrapper.appendChild(gridContainer);
@@ -1482,12 +1482,12 @@ describe("grid view (#1237): .multi-select-button / a[href*='/song/'] 不在の 
     });
 
     it("Given grid view row に data-songId も存在する When target ID で取得する Then data-songId を優先し image fallback は走らない", async () => {
-      const scroller = getOrCreateScroller();
+      getOrCreateScroller();
       const wrapper = getOrCreateClipList();
       const gridContainer = document.createElement("div");
       wrapper.appendChild(gridContainer);
       const card0 = addGridViewCard(gridContainer, "a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-      const card1 = addGridViewCard(gridContainer, "b2c3d4e5-f6a7-8901-bcde-f12345678901");
+      addGridViewCard(gridContainer, "b2c3d4e5-f6a7-8901-bcde-f12345678901");
       card0.row.dataset.songId = "primary-id";
 
       const pending = ensureClipRowsLoadedByIds(["primary-id"], {


### PR DESCRIPTION
## Summary

- #1239 で混入した `@typescript-eslint/no-unused-vars` lint エラー 3 件を修正
  - `scroller` 変数 2 箇所 → `getOrCreateScroller()` 呼び出しのみに
  - `card1` → `addGridViewCard()` の戻り値を捨てるだけに

## Test plan

- [x] 全 693 テストパス
- [x] lint エラー解消（CI の `check` ジョブが通ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwJkeDcBL3QCnh51bXjzve