### PR TITLE
chore: ext-v0.1.1 リリース（suno-helper バグ修正群）

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "/suno が生成した Style/Lyrics を Suno Custom Mode に順次注入し Generate を連続実行する補助拡張 (WXT + React + TS)。",


### PR DESCRIPTION
## Summary

- suno-helper を 0.1.0 → 0.1.1 にバージョン bump
- distrokid-helper は変更なし（0.1.0 のまま同梱）

## ext-v0.1.0 以降の修正内容（suno-helper）

- grid view で playlist 追加が失敗する DOM セレクタ不整合を修正 (#1237)
- プレイリスト操作の安定性改善 (#1050)
- CORS なし 404 (TypeError) でも single-file mode へ fallback (#1210)
- E2E inline 実装コピーを削除し本番 API 経由テストに統合 (#1159)
- レビュー指摘修正・public API export 復元 (#1183, #1184)
- CI テストタイムアウト延長、lint/format 修正

## リリース手順

1. ✅ suno-helper の package.json version bump
2. ⬜ この PR をマージ
3. ⬜ `ext-v0.1.1` タグを push → CI が zip を GitHub Release に添付

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbvMchy2jU419oanvRw2dS