### PR TITLE
feat(shared): Download 定数 + postDownloaded() 追加（非破壊）(#1215)

### DIFF
--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -394,3 +394,30 @@ export async function recordDistrokidRelease(
     throw new Error(`HTTP ${resp.status}`);
   }
 }
+
+/** POST /collections/:id/downloaded の body (#1215)。ダウンロード完了通知ペイロード。 */
+export interface DownloadedPayload {
+  file_count: number;
+  format: "mp3" | "m4a" | "wav";
+  suno_playlist_url: string;
+}
+
+/**
+ * ダウンロード完了をサーバーに通知する (#1215)。POST /collections/:id/downloaded。
+ * 非 2xx は fail-loud で throw する。
+ */
+export async function postDownloaded(
+  baseUrl: string,
+  collectionId: string,
+  payload: DownloadedPayload,
+): Promise<void> {
+  const url = `${baseUrl}/collections/${encodeURIComponent(collectionId)}/downloaded`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`POST downloaded failed: ${res.status} ${res.statusText}`);
+  }
+}

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -15,6 +15,17 @@ export const RESUME_STATE_KEY = "sunoResumeState";
  * Suno は 1 タブ運用前提のため global 単一 key とする。lib/overlay-state.ts が SSOT として参照する。 */
 export const OVERLAY_STATE_KEY = "sunoOverlayState";
 
+/** yt-collection-serve の download 完了通知サブパス (#1215、POST)。
+ * SSOT: src/youtube_automation/scripts/collection_serve.py DOWNLOADED_ROUTE。 */
+export const DOWNLOADED_ROUTE = "/collections/:id/downloaded" as const;
+
+/** Suno ダウンロード形式を保存する chrome.storage.local の key (#1215)。
+ * popup（書込）と content（読込）が同一 key を参照するため、契約文字列としてここを SSOT とする。 */
+export const DOWNLOAD_FORMAT_KEY = "sunoDownloadFormat" as const;
+
+/** Suno ダウンロード形式のデフォルト値 (#1215)。 */
+export const DOWNLOAD_FORMAT_DEFAULT = "mp3" as const;
+
 /** yt-collection-serve が prompts を配信するサブパス (#698 で `/prompts.json` から分離)。 */
 export const PROMPTS_ROUTE = "/suno/prompts.json";
 
@@ -236,6 +247,8 @@ export const PHASE = {
   // entry 単位の失敗 (#948)。リトライ上限まで失敗した entry をスキップして次へ進むときに emit する。
   // 非終了 phase（run 全体は継続する）。失敗 index は snapshot の failedIndices に蓄積される。
   ENTRY_FAILED: "entry-failed",
+  // 全 entry の生成 DONE 後、playlist 追加完了後に Suno playlist を一括ダウンロードする phase (#1215)。非終了 phase。
+  DOWNLOADING: "downloading",
   // 全 entry の生成 DONE 後、FINISHED 直前に挟む clip 一括 playlist 追加 phase (#854)。非終了 phase。
   ADDING_TO_PLAYLIST: "adding-to-playlist",
   FINISHED: "finished",

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -51,6 +51,8 @@ export function phaseToStatus(
     case PHASE.ENTRY_FAILED:
       // entry 単位の失敗スキップ (#948)。run 全体は継続するため error フラグは立てない（status は黄信号扱い）。
       return { text: `[${n}/${total}] 失敗のためスキップ: ${message ?? ""}` };
+    case PHASE.DOWNLOADING:
+      return { text: `ダウンロード中…${message ? `（${message}）` : ""}` };
     case PHASE.ADDING_TO_PLAYLIST:
       // playlist 名は ProgressPayload.message で運ぶ（専用フィールドを足さず既存経路で表示する）。
       return { text: `Playlist '${message ?? ""}' へ追加中…` };

--- a/extensions/suno-helper/lib/storage.ts
+++ b/extensions/suno-helper/lib/storage.ts
@@ -2,9 +2,20 @@
 // 書き換える (要件4)。key は shared/constants の STORAGE_KEY を SSOT とする。
 import { storage } from "wxt/utils/storage";
 
-import { DEFAULT_URL, STORAGE_KEY } from "../../shared/constants";
+import {
+  DEFAULT_URL,
+  DOWNLOAD_FORMAT_DEFAULT,
+  DOWNLOAD_FORMAT_KEY,
+  STORAGE_KEY,
+} from "../../shared/constants";
 
 /** サーバー URL の型付き storage item。未設定時は DEFAULT_URL を返す。 */
 export const serverUrlItem = storage.defineItem<string>(`local:${STORAGE_KEY}`, {
   fallback: DEFAULT_URL,
 });
+
+/** Suno ダウンロード形式の型付き storage item (#1215)。未設定時は "mp3" を返す。 */
+export const downloadFormatItem = storage.defineItem<string>(
+  `local:${DOWNLOAD_FORMAT_KEY}`,
+  { fallback: DOWNLOAD_FORMAT_DEFAULT },
+);

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -50,7 +50,7 @@ describe("shared/constants: サーバー互換の契約値", () => {
 });
 
 describe("shared/constants: 進捗フェーズ (PHASE)", () => {
-  it("Given PHASE When 全フェーズを読む Then 既存値に加え waiting-slot / adding-to-playlist / waiting-captcha / entry-failed を保持する (#816, #854, #948)", () => {
+  it("Given PHASE When 全フェーズを読む Then 既存値に加え waiting-slot / adding-to-playlist / waiting-captcha / entry-failed / downloading を保持する (#816, #854, #948, #1215)", () => {
     expect(PHASE).toEqual({
       INJECTING: "injecting",
       GENERATING: "generating",
@@ -58,6 +58,7 @@ describe("shared/constants: 進捗フェーズ (PHASE)", () => {
       WAITING_CAPTCHA: "waiting-captcha",
       DONE: "done",
       ENTRY_FAILED: "entry-failed",
+      DOWNLOADING: "downloading",
       ADDING_TO_PLAYLIST: "adding-to-playlist",
       FINISHED: "finished",
       STOPPED: "stopped",


### PR DESCRIPTION
## Summary

- `extensions/shared/constants.ts`: `DOWNLOADED_ROUTE`, `DOWNLOAD_FORMAT_KEY`, `DOWNLOAD_FORMAT_DEFAULT` の3定数と `PHASE.DOWNLOADING` を追加
- `extensions/shared/api.ts`: `DownloadedPayload` interface と `postDownloaded()` 関数を追加（ダウンロード完了をサーバーに通知する POST クライアント）
- `extensions/suno-helper/lib/storage.ts`: `downloadFormatItem` storage wrapper を追加（既存 `serverUrlItem` と同パターン）
- `extensions/suno-helper/components/runner-errors.ts`: `DOWNLOADING` phase の exhaustive switch case を追加（型安全性維持）
- `extensions/suno-helper/tests/constants.test.ts`: PHASE 全フェーズテストを更新

既存の interface / 関数シグネチャは一切変更なし（非破壊）。

## Test plan

- [x] `nr compile` -- 新規の型エラーなし（既存の2件は base branch と同一）
- [x] `nr test` -- 新規のテスト失敗なし（既存の3件は base branch と同一）

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbvMchy2jU419oanvRw2dS