### PR TITLE
chore(release): v5.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.13] - 2026-06-29
+
 ### Changed
 
 - `refactor(shared)`: CollectionSummary を boolean fields (`has_prompts` / `mapped`) から status enum (`needs_prompts` | `ready` | `downloaded`) に置換。`downloaded_count` フィールド追加、`playlist_name` 廃止。POST `/collections/<id>/downloaded` エンドポイント新設（#1216）**BREAKING**
@@ -38,6 +40,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(upload)`: descriptions.md の必須セクション不備時に再作成手順を含むエラーを表示（#1051）
+
+### Migration
+
+所要時間の目安: 10〜20 分
+
+local fix 衝突注意:
+- suno-helper: 拡張 version が 0.2.0 になり、`yt-collection-serve` の `/version` も `min_extension_version=0.2.0` を返す。古い拡張を使っている下流は更新が必要。
+
+サマリ:
+
+- `suno-helper` 0.2.0 を前提に、Playlist 追加後の Download all 操作、chrome.downloads 連携、dir mode の collection 切り替え安定化を含めた運用へ更新。
+- `yt-channel-init` をフルパッケージ生成へ拡張し、初期チャンネルセットアップで config / localization / schedule / upload settings / skill config をまとめて生成可能にした。
+- `/channel-new` と関連スキルを TTP ベンチマークから config・ペルソナ・branding までの end-to-end フローに刷新。
+- CollectionSummary の status enum 化と `/collections/<id>/downloaded` 追加により、Suno 生成後の DL 完了状態を明示的に扱う。
+- `/setup` へのリネーム、`yt-doctor` bootstrap カテゴリ追加、初回チャンネル向け benchmark fallback / minimal mode を追加。
 
 ## [5.5.12] - 2026-06-25
 
@@ -1193,6 +1210,8 @@ uv run yt-config-migrate verify                  # 新 loader で読めるか検
 未マップキー（例: `suno` 等のチャンネル独自拡張）は `yt-config-migrate` が warning を出力し、
 `--strict` 指定時は `ConfigError` で中止する。
 
+[5.5.13]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.13
+[5.5.12]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.12
 [5.5.11]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.11
 [5.5.10]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.10
 [5.5.9]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.9
@@ -1206,8 +1225,6 @@ uv run yt-config-migrate verify                  # 新 loader で読めるか検
 [5.5.1]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.1
 [5.5.0]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.0
 [5.4.0]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.4.0
-[5.5.12]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.12
-[5.5.11]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.5.11
 [5.3.0]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.3.0
 [5.2.0]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.2.0
 [5.1.1]: https://github.com/daiki-beppu/youtube-automation/releases/tag/v5.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "youtube-channels-automation"
-version = "5.5.12"
+version = "5.5.13"
 description = "YouTube channel automation toolkit - analytics, AI content generation, and auto-upload"
 requires-python = ">=3.11"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1640,7 +1640,7 @@ wheels = [
 
 [[package]]
 name = "youtube-channels-automation"
-version = "5.5.12"
+version = "5.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

v5.5.13 のリリース PR。

- `pyproject.toml::version` を v5.5.13 に bump
- `uv.lock` の `youtube-channels-automation` version を v5.5.13 に同期
- `CHANGELOG.md` の `[Unreleased]` を `[5.5.13] - 2026-06-29` に昇格
- `suno-helper` 0.2.0 / `min_extension_version=0.2.0` を含むリリースとして整理

## Release notes preview

## [5.5.13] - 2026-06-29

### Changed

- `refactor(shared)`: CollectionSummary を boolean fields (`has_prompts` / `mapped`) から status enum (`needs_prompts` | `ready` | `downloaded`) に置換。`downloaded_count` フィールド追加、`playlist_name` 廃止。POST `/collections/<id>/downloaded` エンドポイント新設（#1216）**BREAKING**
- `feat(suno-helper)`: Playlist 追加後の Download all DOM 操作 + chrome.downloads 連携を実装 (#1146)
- `feat(serve)`: POST `/collections/<id>/downloaded` に冪等更新ロジックを追加（playlist URL 記録 + DL 完了マーク）(#1145)
- `deprecate`: `read_mapped_slugs()` / `write_suno_playlists()` / `normalize_suno_title()` / `POST /suno/playlists` を deprecated 化 (#1145)
- `feat(upload)`: チャンネル設定の既定予約投稿時刻をアップロード時に適用（#1054）
- `feat(upload)`: アップロード完了後に YouTube Studio で確認すべき手動チェックリストを表示（#1052）
- `feat(upload)`: アップロード実行時に操作対象のチャンネル名と channel ID を表示（#1053）
- `feat(thumbnail)`: サムネイル生成で primary provider が失敗した場合の fallback provider 設定と手順を追加（#1097）
- `feat(preflight)`: タイトル重複を公開前に検出する早期警告 CLI と preflight 連携を追加（#1055）
- `feat(metadata)`: Suno パターン名をトラック表示名へ反映する生成ロジックを追加（#1092）
- `feat(masterup)`: Suno 音源の後処理 CLI `yt-suno-audio-cleanup` を追加（#1048）
- `feat(masterup)`: `generate-master` に尺プレビューと `--no-loop` を追加（#1091）
- `docs(masterup)`: Suno ショート URL からの楽曲解決手順を追加（#1094）
- `docs(automation-update)`: GitHub CLI が使えない環境向けに curl での release 取得手順を追加（#1098）
- `docs(short)`: short / short-release の workflow-state schema 記述を実運用の状態ファイルに合わせて修正（#1171）
- `docs(short-release)`: short-release スキルの手順をショート生成までの責務に整理（#1170）
- `docs(short)`: short / short-release の dry-run 手順を現行の `--plan` フラグ表記に修正（#1169）
- `docs(channel-setup)`: Terraform GCP reference を現行テンプレートと同期（#1172）
- `docs(channel-setup)`: benchmark 取得手順で参照する CLI 名を現行名に修正（#1168）
- `feat(channel-init)`: `yt-channel-init` を最小 config 生成からフルパッケージ生成に拡張。`--music-engine` / `--benchmark-channel` / `--branding-description` / `--channel-keyword` / `--target-duration-min` / `--target-duration-max` / `--supported-language` / `--default-language` / `--core-message` / `--country` 引数を追加し、`config/channel/*.json` に加えて `config/localizations.json` / `config/schedule_config.json` / `config/upload_settings.json` / `config/skills/{suno,thumbnail}.yaml` / `.env` / `.gitignore` / `auth/client_secrets.template.json` を一括生成する。テンプレート群を `channel_init_templates.py` に分離（#1271）
- `feat(channel-settings)`: `yt-channel-settings pull --channel-id-only --apply` を追加。YouTube API から `channel_id` のみを取得して `config/channel/meta.json::channel.channel_id` に書き込む。通常の `pull --apply` でも `channel_id` を自動反映するよう `_write_channel_settings` に統合（#1271）
- `docs(skills)`: `/channel-new` を TTP ベンチマーク → config → ペルソナ → branding の end-to-end スキルに刷新。`/audience-persona` / `/channel-direction` / `/channel-research` / `/channel-setup` の description・前提条件・Cross References を新フローに合わせて更新（#1271）
- `refactor(doctor)`: `/onboard` スキルを `/setup` にリネームしツール設定特化に責務整理。`yt-doctor` に `bootstrap` カテゴリを新設（#1273）
- `docs(setup)`: `/setup` の GCP プロジェクト新規作成手順でチャンネル名由来の project ID / 表示名を推奨し、OAuth 同意画面のアプリ名とクライアント ID 名も HUMAN STEP に提示するよう更新（#1277, #1278）
- `docs(wf-new)`: アナリティクス未収集の初回チャンネルでも `/wf-new` から企画生成を開始できるよう、`collection-ideate` / `wf-new` の入力モードに benchmark fallback mode と minimal mode を追加。`yt-doctor` の readiness 判定も analytics 不在をブロッカーにしない契約へ更新（#1272）

### Fixed

- `fix(upload)`: descriptions.md の必須セクション不備時に再作成手順を含むエラーを表示（#1051）

### Migration

所要時間の目安: 10〜20 分

local fix 衝突注意:
- suno-helper: 拡張 version が 0.2.0 になり、`yt-collection-serve` の `/version` も `min_extension_version=0.2.0` を返す。古い拡張を使っている下流は更新が必要。

サマリ:

- `suno-helper` 0.2.0 を前提に、Playlist 追加後の Download all 操作、chrome.downloads 連携、dir mode の collection 切り替え安定化を含めた運用へ更新。
- `yt-channel-init` をフルパッケージ生成へ拡張し、初期チャンネルセットアップで config / localization / schedule / upload settings / skill config をまとめて生成可能にした。
- `/channel-new` と関連スキルを TTP ベンチマークから config・ペルソナ・branding までの end-to-end フローに刷新。
- CollectionSummary の status enum 化と `/collections/<id>/downloaded` 追加により、Suno 生成後の DL 完了状態を明示的に扱う。
- `/setup` へのリネーム、`yt-doctor` bootstrap カテゴリ追加、初回チャンネル向け benchmark fallback / minimal mode を追加。

## Next steps

1. このリリース PR をレビュー → マージ
2. マージ後、`/automation-release` を再実行して publish フェーズに進む（tag + GitHub Release 自動作成）
3. publish 後、各チャンネルリポジトリで `/automation-update` を実行すると CHANGELOG.md / Release 本文を読み取って追従できる

