### PR TITLE
feat(thumbnail): Codex既定プロンプトをTTP上位互換にする

### DIFF
--- a/.claude/skills/channel-setup/references/config-template/skills/thumbnail.yaml
+++ b/.claude/skills/channel-setup/references/config-template/skills/thumbnail.yaml
@@ -19,6 +19,15 @@ image_generation:
   # ADC / GCP 課金が有効なことを確認する。
   # provider: codex
 
+  codex:
+    # 参照サムネを winning template として扱い、{title} だけを差し替える
+    # 「TTPを徹底して上位互換の生成」用の短い既定プロンプト。
+    default_prompt_template: |
+      TTP this reference thumbnail, then improve it into a stronger original thumbnail.
+      Keep the winning layout, typography feel, character scale, color mood, texture, and energy.
+      Make it cleaner, more readable on mobile, stronger face impact, no logos, no watermarks, no broken hands.
+      Use the title {title}.
+
   gemini:
     # チャンネル統一の背景色（channel-direction の「ビジュアルアイデンティティ」
     # から転写）

--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -254,23 +254,7 @@ if [ "$PROVIDER" = "codex" ]; then
   # codex は image_generation.codex.default_prompt_template を必ず使う。
   # 参照画像を winning template として扱い、{title} だけを差し替える短い TTP 上位互換プロンプトにする。
   build_codex_prompt() {
-    local title="$1"
-    TITLE="$title" uv run python3 -c "
-import os
-from youtube_automation.utils.skill_config import load_skill_config
-
-template = (
-    load_skill_config('thumbnail')
-    .get('image_generation', {})
-    .get('codex', {})
-    .get('default_prompt_template')
-)
-if not isinstance(template, str) or not template.strip():
-    raise SystemExit('thumbnail image_generation.codex.default_prompt_template is required')
-if template.count('{title}') != 1:
-    raise SystemExit('thumbnail image_generation.codex.default_prompt_template must contain exactly one {title}')
-print(template.replace('{title}', os.environ['TITLE']))
-"
+    uv run python3 .claude/skills/thumbnail/references/codex-prompt.py "$1"
   }
   bash .claude/skills/thumbnail/references/codex-image.sh "$(build_codex_prompt "<企画Aタイトル>")" collections/planning/_plan-previews/<dir>/plan-a-<slug>.png "${REF_PATHS[@]}"
   bash .claude/skills/thumbnail/references/codex-image.sh "$(build_codex_prompt "<企画Bタイトル>")" collections/planning/_plan-previews/<dir>/plan-b-<slug>.png "${REF_PATHS[@]}"
@@ -350,22 +334,7 @@ PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider impor
 if [ "$PROVIDER" = "codex" ]; then
   # codex は image_generation.codex.default_prompt_template を必ず使う。
   # 参照画像を winning template として扱い、{title} だけを差し替える短い TTP 上位互換プロンプトにする。
-  CODEX_PROMPT=$(TITLE="<選択された企画タイトル>" uv run python3 -c "
-import os
-from youtube_automation.utils.skill_config import load_skill_config
-
-template = (
-    load_skill_config('thumbnail')
-    .get('image_generation', {})
-    .get('codex', {})
-    .get('default_prompt_template')
-)
-if not isinstance(template, str) or not template.strip():
-    raise SystemExit('thumbnail image_generation.codex.default_prompt_template is required')
-if template.count('{title}') != 1:
-    raise SystemExit('thumbnail image_generation.codex.default_prompt_template must contain exactly one {title}')
-print(template.replace('{title}', os.environ['TITLE']))
-")
+  CODEX_PROMPT=$(uv run python3 .claude/skills/thumbnail/references/codex-prompt.py "<選択された企画タイトル>")
   bash .claude/skills/thumbnail/references/codex-image.sh \
     "$CODEX_PROMPT" \
     collections/planning/_plan-previews/<dir>/plan-<x>-<slug>.png \

--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -251,10 +251,11 @@ done <<< "$REFS"
 # 違う値の場合は連打数と plan-{a,b,c,...} の採番をその値に合わせて調整する。
 PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
-  # codex は長文 prompt で失敗しやすいため、4-1 の本番プロンプトを短縮して差分だけを書く。
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Aの短縮プロンプト>" collections/planning/_plan-previews/<dir>/plan-a-<slug>.png "${REF_PATHS[@]}"
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Bの短縮プロンプト>" collections/planning/_plan-previews/<dir>/plan-b-<slug>.png "${REF_PATHS[@]}"
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Cの短縮プロンプト>" collections/planning/_plan-previews/<dir>/plan-c-<slug>.png "${REF_PATHS[@]}"
+  # codex は image_generation.codex.default_prompt_template を使う。
+  # 参照画像を winning template として扱い、{title} だけを差し替える短い TTP 上位互換プロンプトにする。
+  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Aタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-a-<slug>.png "${REF_PATHS[@]}"
+  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Bタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-b-<slug>.png "${REF_PATHS[@]}"
+  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Cタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-c-<slug>.png "${REF_PATHS[@]}"
 else
   uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Aプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-a-<slug>.png -y
   uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Bプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-b-<slug>.png -y
@@ -329,7 +330,7 @@ parallel モードでは Next Step で `yt-stock-archive` による不採用 (`c
 PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
   bash .claude/skills/thumbnail/references/codex-image.sh \
-    "<選択された企画の短縮プロンプト>" \
+    "<選択された企画タイトルを入れた TTP 上位互換プロンプト>" \
     collections/planning/_plan-previews/<dir>/plan-<x>-<slug>.png \
     "${REF_PATHS[@]}"
 else

--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -251,11 +251,30 @@ done <<< "$REFS"
 # 違う値の場合は連打数と plan-{a,b,c,...} の採番をその値に合わせて調整する。
 PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
-  # codex は image_generation.codex.default_prompt_template を使う。
+  # codex は image_generation.codex.default_prompt_template を必ず使う。
   # 参照画像を winning template として扱い、{title} だけを差し替える短い TTP 上位互換プロンプトにする。
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Aタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-a-<slug>.png "${REF_PATHS[@]}"
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Bタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-b-<slug>.png "${REF_PATHS[@]}"
-  bash .claude/skills/thumbnail/references/codex-image.sh "<企画Cタイトルを入れた TTP 上位互換プロンプト>" collections/planning/_plan-previews/<dir>/plan-c-<slug>.png "${REF_PATHS[@]}"
+  build_codex_prompt() {
+    local title="$1"
+    TITLE="$title" uv run python3 -c "
+import os
+from youtube_automation.utils.skill_config import load_skill_config
+
+template = (
+    load_skill_config('thumbnail')
+    .get('image_generation', {})
+    .get('codex', {})
+    .get('default_prompt_template')
+)
+if not isinstance(template, str) or not template.strip():
+    raise SystemExit('thumbnail image_generation.codex.default_prompt_template is required')
+if template.count('{title}') != 1:
+    raise SystemExit('thumbnail image_generation.codex.default_prompt_template must contain exactly one {title}')
+print(template.replace('{title}', os.environ['TITLE']))
+"
+  }
+  bash .claude/skills/thumbnail/references/codex-image.sh "$(build_codex_prompt "<企画Aタイトル>")" collections/planning/_plan-previews/<dir>/plan-a-<slug>.png "${REF_PATHS[@]}"
+  bash .claude/skills/thumbnail/references/codex-image.sh "$(build_codex_prompt "<企画Bタイトル>")" collections/planning/_plan-previews/<dir>/plan-b-<slug>.png "${REF_PATHS[@]}"
+  bash .claude/skills/thumbnail/references/codex-image.sh "$(build_codex_prompt "<企画Cタイトル>")" collections/planning/_plan-previews/<dir>/plan-c-<slug>.png "${REF_PATHS[@]}"
 else
   uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Aプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-a-<slug>.png -y
   uv run yt-generate-image "${REF_ARGS[@]}" --prompt "<企画Bプロンプト>" --output collections/planning/_plan-previews/<dir>/plan-b-<slug>.png -y
@@ -329,8 +348,26 @@ parallel モードでは Next Step で `yt-stock-archive` による不採用 (`c
 # <x> は選択された企画の番号（a/b/c）
 PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
+  # codex は image_generation.codex.default_prompt_template を必ず使う。
+  # 参照画像を winning template として扱い、{title} だけを差し替える短い TTP 上位互換プロンプトにする。
+  CODEX_PROMPT=$(TITLE="<選択された企画タイトル>" uv run python3 -c "
+import os
+from youtube_automation.utils.skill_config import load_skill_config
+
+template = (
+    load_skill_config('thumbnail')
+    .get('image_generation', {})
+    .get('codex', {})
+    .get('default_prompt_template')
+)
+if not isinstance(template, str) or not template.strip():
+    raise SystemExit('thumbnail image_generation.codex.default_prompt_template is required')
+if template.count('{title}') != 1:
+    raise SystemExit('thumbnail image_generation.codex.default_prompt_template must contain exactly one {title}')
+print(template.replace('{title}', os.environ['TITLE']))
+")
   bash .claude/skills/thumbnail/references/codex-image.sh \
-    "<選択された企画タイトルを入れた TTP 上位互換プロンプト>" \
+    "$CODEX_PROMPT" \
     collections/planning/_plan-previews/<dir>/plan-<x>-<slug>.png \
     "${REF_PATHS[@]}"
 else

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -99,6 +99,21 @@ bash .claude/skills/thumbnail/references/codex-image.sh \
 
 参照画像つきで雰囲気を寄せたい場合は、3 引数目以降に画像パスを追加する。
 
+TTP 参照画像から上位互換サムネを作る場合は、長い個別指定ではなく
+`image_generation.codex.default_prompt_template` を使う。参照画像は mood reference
+ではなく winning template として扱い、変える要素は `{title}` と品質改善
+（mobile readability / face impact / no logos / no watermarks / no broken hands）に限定する。
+日本語方針は「TTPを徹底して上位互換の生成」。
+
+既定テンプレート:
+
+```text
+TTP this reference thumbnail, then improve it into a stronger original thumbnail.
+Keep the winning layout, typography feel, character scale, color mood, texture, and energy.
+Make it cleaner, more readable on mobile, stronger face impact, no logos, no watermarks, no broken hands.
+Use the title {title}.
+```
+
 内部実装の要約:
 
 - wrapper は `codex exec --json --sandbox workspace-write --add-dir <out_dir> --skip-git-repo-check` で起動する
@@ -111,7 +126,7 @@ bash .claude/skills/thumbnail/references/codex-image.sh \
 
 運用上の注意:
 
-- **prompt は短く保つ**: 長すぎる prompt は agent が `image_generation` tool 呼び出しを skip して path だけ echo する failure mode に陥る。`/tmp/rjn-codex-prompt-short.txt` のように参照画像つきでも 14 行・600〜800 字に収めるとほぼ通る。失敗したら短縮を最優先で試す
+- **prompt は短く保つ**: 長すぎる prompt は agent が `image_generation` tool 呼び出しを skip して path だけ echo する failure mode に陥る。TTP 参照画像つきでは `image_generation.codex.default_prompt_template` を使い、`{title}` だけを差し替える。失敗したら短縮を最優先で試す
 - **reference 画像つきは prompt で「変更点」を明示する**: 「reference を参考に」程度の弱い指示だと agent が `image_generation` tool を skip して reference を `<out>` に cp するだけで終わる failure mode がある。wrapper の自動付与文 + MD5 一致検証で抑止しているが、prompt 側でも reference からの差分（色味の参考 / 構図だけ流用 / 主役を差し替え 等）を明示しておくと安定する
 - 失敗時 wrapper は `agent_message (最終)` と codex stderr の末尾 30 行を診断 dump するので、これを見て prompt 短縮 or 参照画像見直しに切り替える
 

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -186,3 +186,10 @@ image_generation:
     # codex-image.sh 経路は API provider ではないため model / quality は持たない。
     # ChatGPT サブスクの fair-use 上限内で使い、大量生成には使わない。
     # cost_per_image_usd: null
+    # 参照サムネを mood reference ではなく winning template として扱い、
+    # {title} だけを差し替える短い TTP 上位互換プロンプト。
+    default_prompt_template: |
+      TTP this reference thumbnail, then improve it into a stronger original thumbnail.
+      Keep the winning layout, typography feel, character scale, color mood, texture, and energy.
+      Make it cleaner, more readable on mobile, stronger face impact, no logos, no watermarks, no broken hands.
+      Use the title {title}.

--- a/.claude/skills/thumbnail/references/codex-prompt.py
+++ b/.claude/skills/thumbnail/references/codex-prompt.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Render the thumbnail Codex prompt from skill-config."""
+
+from __future__ import annotations
+
+import argparse
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.config import build_codex_prompt
+from youtube_automation.utils.skill_config import load_skill_config
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render image_generation.codex.default_prompt_template")
+    parser.add_argument("title", help="thumbnail title to inject into {title}")
+    args = parser.parse_args()
+
+    try:
+        print(build_codex_prompt(load_skill_config("thumbnail"), args.title))
+    except ConfigError as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(thumbnail)`: Codex サムネイル生成の既定プロンプトを、参照画像を winning template として扱う短い TTP 上位互換型に変更。`image_generation.codex.default_prompt_template` を追加し、`/collection-ideate` と channel-setup テンプレートの Codex 導線を同方針へ更新（#1300）
 - `refactor(shared)`: CollectionSummary を boolean fields (`has_prompts` / `mapped`) から status enum (`needs_prompts` | `ready` | `downloaded`) に置換。`downloaded_count` フィールド追加、`playlist_name` 廃止。POST `/collections/<id>/downloaded` エンドポイント新設（#1216）**BREAKING**
 - `feat(suno-helper)`: Playlist 追加後の Download all DOM 操作 + chrome.downloads 連携を実装 (#1146)
 - `feat(serve)`: POST `/collections/<id>/downloaded` に冪等更新ロジックを追加（playlist URL 記録 + DL 完了マーク）(#1145)

--- a/src/youtube_automation/utils/image_provider/__init__.py
+++ b/src/youtube_automation/utils/image_provider/__init__.py
@@ -19,11 +19,7 @@ from youtube_automation.utils.image_provider.base import (
     ImageGenerationResult,
     ImageProvider,
 )
-from youtube_automation.utils.image_provider.config import (
-    CodexConfig,
-    ImageGenerationConfig,
-    parse_image_generation_config,
-)
+from youtube_automation.utils.image_provider.config import ImageGenerationConfig, parse_image_generation_config
 from youtube_automation.utils.image_provider.prompt_schema import PromptSchema
 
 __all__ = [
@@ -34,7 +30,6 @@ __all__ = [
     "PromptSchema",
     "RETRY_BACKOFF",
     "RETRY_MAX",
-    "CodexConfig",
     "get_provider",
     "load_image_generation_config",
     "parse_image_generation_config",

--- a/src/youtube_automation/utils/image_provider/__init__.py
+++ b/src/youtube_automation/utils/image_provider/__init__.py
@@ -20,6 +20,7 @@ from youtube_automation.utils.image_provider.base import (
     ImageProvider,
 )
 from youtube_automation.utils.image_provider.config import (
+    CodexConfig,
     ImageGenerationConfig,
     parse_image_generation_config,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "PromptSchema",
     "RETRY_BACKOFF",
     "RETRY_MAX",
+    "CodexConfig",
     "get_provider",
     "load_image_generation_config",
     "parse_image_generation_config",

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -94,16 +94,25 @@ class OpenAIConfig:
 
 
 @dataclass(frozen=True)
+class CodexConfig:
+    """Codex shell 経路で使う prompt 設定。"""
+
+    default_prompt_template: str = ""
+
+
+@dataclass(frozen=True)
 class ImageGenerationConfig:
     """provider 切り替え可能な画像生成設定の親 dataclass。
 
     ``provider`` の値に対応する側のみが非 None（例: provider="gemini" なら
-    ``gemini`` のみ）。``codex`` は shell 経路なので API provider sub-config を持たない。
+    ``gemini`` のみ）。``codex`` は shell 経路なので API provider ではないが、
+    prompt template などの実行契約は ``codex`` に保持する。
     """
 
     provider: ProviderName
     gemini: GeminiConfig | None = None
     openai: OpenAIConfig | None = None
+    codex: CodexConfig | None = None
     gemini_cli: GeminiCliConfig | None = None
 
     @classmethod
@@ -163,7 +172,8 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
         gemini_cli_cfg = _build_gemini_cli(section.get("gemini_cli") or {})
         return ImageGenerationConfig(provider="gemini_cli", gemini_cli=gemini_cli_cfg)
 
-    return ImageGenerationConfig(provider="codex", gemini=None, openai=None)
+    codex_cfg = _build_codex(section.get("codex") or {})
+    return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
 
 def _build_from_legacy_gemini(legacy: dict[str, Any]) -> ImageGenerationConfig:
@@ -199,6 +209,10 @@ def _build_openai(d: dict[str, Any]) -> OpenAIConfig:
         thinking=d.get("thinking", "medium"),
         batch=int(d.get("batch", 1)),
     )
+
+
+def _build_codex(d: dict[str, Any]) -> CodexConfig:
+    return CodexConfig(default_prompt_template=str(d.get("default_prompt_template", "")))
 
 
 def replace_model(cfg: ImageGenerationConfig, model: str) -> ImageGenerationConfig:

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -172,7 +172,7 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
         gemini_cli_cfg = _build_gemini_cli(section.get("gemini_cli") or {})
         return ImageGenerationConfig(provider="gemini_cli", gemini_cli=gemini_cli_cfg)
 
-    codex_cfg = _build_codex(section.get("codex") or {})
+    codex_cfg = _build_codex(section.get("codex"))
     return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
 
@@ -211,8 +211,33 @@ def _build_openai(d: dict[str, Any]) -> OpenAIConfig:
     )
 
 
-def _build_codex(d: dict[str, Any]) -> CodexConfig:
-    return CodexConfig(default_prompt_template=str(d.get("default_prompt_template", "")))
+def _build_codex(d: Any) -> CodexConfig:
+    if not isinstance(d, dict):
+        raise ConfigError("image_generation.codex は mapping で指定してください")
+    return CodexConfig(default_prompt_template=_validate_codex_prompt_template(d.get("default_prompt_template")))
+
+
+def _validate_codex_prompt_template(template: Any) -> str:
+    if not isinstance(template, str) or not template.strip():
+        raise ConfigError("image_generation.codex.default_prompt_template は空でない文字列で指定してください")
+    if template.count("{title}") != 1:
+        raise ConfigError("image_generation.codex.default_prompt_template は {title} をちょうど 1 回含めてください")
+    return template
+
+
+def render_codex_prompt(template: str, title: str) -> str:
+    """Codex thumbnail prompt template の `{title}` を差し替える。"""
+    if not isinstance(title, str) or not title.strip():
+        raise ConfigError("Codex thumbnail prompt の title は空でない文字列で指定してください")
+    return _validate_codex_prompt_template(template).replace("{title}", title)
+
+
+def build_codex_prompt(skill_cfg: dict[str, Any], title: str) -> str:
+    """thumbnail skill-config から Codex 用 prompt を生成する。"""
+    cfg = parse_image_generation_config(skill_cfg)
+    if cfg.provider != "codex" or cfg.codex is None:
+        raise ConfigError("image_generation.provider=codex の設定で実行してください")
+    return render_codex_prompt(cfg.codex.default_prompt_template, title)
 
 
 def replace_model(cfg: ImageGenerationConfig, model: str) -> ImageGenerationConfig:

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -172,7 +172,7 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
         gemini_cli_cfg = _build_gemini_cli(section.get("gemini_cli") or {})
         return ImageGenerationConfig(provider="gemini_cli", gemini_cli=gemini_cli_cfg)
 
-    codex_cfg = _build_codex(section.get("codex"))
+    codex_cfg = _build_codex(section.get("codex")) if "codex" in section else CodexConfig()
     return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
 
@@ -214,7 +214,12 @@ def _build_openai(d: dict[str, Any]) -> OpenAIConfig:
 def _build_codex(d: Any) -> CodexConfig:
     if not isinstance(d, dict):
         raise ConfigError("image_generation.codex は mapping で指定してください")
-    return CodexConfig(default_prompt_template=_validate_codex_prompt_template(d.get("default_prompt_template")))
+    template = d.get("default_prompt_template", "")
+    if not isinstance(template, str):
+        raise ConfigError("image_generation.codex.default_prompt_template は文字列で指定してください")
+    if template:
+        template = _validate_codex_prompt_template(template)
+    return CodexConfig(default_prompt_template=template)
 
 
 def _validate_codex_prompt_template(template: Any) -> str:

--- a/tests/test_codex_thumbnail_routing_docs.py
+++ b/tests/test_codex_thumbnail_routing_docs.py
@@ -82,7 +82,9 @@ def test_collection_ideate_codex_parallel_requires_short_prompt() -> None:
     """
     block = _phase_4_4_parallel_block(_read(_IDEATE_SKILL_MD))
 
-    assert "短縮" in block or "短く" in block
+    assert "default_prompt_template" in block
+    assert "TTP 上位互換" in block
+    assert "短い" in block or "短縮" in block or "短く" in block
     assert "prompt" in block or "プロンプト" in block
 
 

--- a/tests/test_codex_thumbnail_routing_docs.py
+++ b/tests/test_codex_thumbnail_routing_docs.py
@@ -48,6 +48,15 @@ def _wf_new_phase_2c_block(text: str) -> str:
     return match.group(1)
 
 
+def _assert_codex_ttp_prompt_policy(block: str) -> None:
+    assert "load_skill_config('thumbnail')" in block
+    assert "default_prompt_template" in block
+    assert "template.count('{title}') != 1" in block
+    assert "template.replace('{title}'" in block
+    assert "TTP 上位互換" in block
+    assert "短い" in block or "短縮" in block or "短く" in block
+
+
 def test_collection_ideate_parallel_generation_branches_to_codex_image_script() -> None:
     """Given collection-ideate Phase 4-4 parallel
     When provider=codex が設定されている
@@ -82,10 +91,7 @@ def test_collection_ideate_codex_parallel_requires_short_prompt() -> None:
     """
     block = _phase_4_4_parallel_block(_read(_IDEATE_SKILL_MD))
 
-    assert "default_prompt_template" in block
-    assert "TTP 上位互換" in block
-    assert "短い" in block or "短縮" in block or "短く" in block
-    assert "prompt" in block or "プロンプト" in block
+    _assert_codex_ttp_prompt_policy(block)
 
 
 def test_collection_ideate_sequential_generation_branches_to_codex_image_script() -> None:
@@ -99,6 +105,16 @@ def test_collection_ideate_sequential_generation_branches_to_codex_image_script(
     assert "codex" in block
     assert ".claude/skills/thumbnail/references/codex-image.sh" in block
     assert "yt-generate-image" in block
+
+
+def test_collection_ideate_codex_sequential_requires_short_prompt() -> None:
+    """Given collection-ideate Phase 4-4 sequential の codex 分岐
+    When codex-image.sh を呼ぶ
+    Then parallel と同じ TTP 上位互換 prompt template 契約を使う。
+    """
+    block = _phase_4_4_sequential_block(_read(_IDEATE_SKILL_MD))
+
+    _assert_codex_ttp_prompt_policy(block)
 
 
 def test_wf_new_treats_codex_preview_as_finished_thumbnail() -> None:

--- a/tests/test_codex_thumbnail_routing_docs.py
+++ b/tests/test_codex_thumbnail_routing_docs.py
@@ -49,10 +49,8 @@ def _wf_new_phase_2c_block(text: str) -> str:
 
 
 def _assert_codex_ttp_prompt_policy(block: str) -> None:
-    assert "load_skill_config('thumbnail')" in block
+    assert ".claude/skills/thumbnail/references/codex-prompt.py" in block
     assert "default_prompt_template" in block
-    assert "template.count('{title}') != 1" in block
-    assert "template.replace('{title}'" in block
     assert "TTP 上位互換" in block
     assert "短い" in block or "短縮" in block or "短く" in block
 

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -15,6 +15,7 @@ import pytest
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider.config import (
     SUPPORTED_PROVIDERS,
+    CodexConfig,
     GeminiConfig,
     ImageGenerationConfig,
     OpenAIConfig,
@@ -73,13 +74,18 @@ class TestParseImageGenerationConfig:
         assert cfg.openai.thinking == "medium"
         assert cfg.openai.batch == 1
 
-    def test_parses_image_generation_namespace_for_codex_without_api_sub_config(self):
+    def test_parses_image_generation_namespace_for_codex_prompt_template(self):
         """Given image_generation.provider が codex
         When skill-config を parse する
-        Then codex は正規 provider として通り、API provider 用 sub-config は作られない。
+        Then codex は正規 provider として通り、prompt template を保持する。
         """
         # Given
-        skill_cfg = {"image_generation": {"provider": "codex"}}
+        skill_cfg = {
+            "image_generation": {
+                "provider": "codex",
+                "codex": {"default_prompt_template": "Use the title {title}."},
+            }
+        }
 
         # When
         cfg = parse_image_generation_config(skill_cfg)
@@ -88,6 +94,19 @@ class TestParseImageGenerationConfig:
         assert cfg.provider == "codex"
         assert cfg.gemini is None
         assert cfg.openai is None
+        assert isinstance(cfg.codex, CodexConfig)
+        assert cfg.codex.default_prompt_template == "Use the title {title}."
+
+    def test_codex_provider_uses_empty_prompt_template_when_subconfig_omitted(self):
+        """Given image_generation.provider=codex
+        When codex sub-config が省略される
+        Then prompt template は空文字の CodexConfig として保持される。
+        """
+        cfg = parse_image_generation_config({"image_generation": {"provider": "codex"}})
+
+        assert cfg.provider == "codex"
+        assert cfg.codex is not None
+        assert cfg.codex.default_prompt_template == ""
 
     def test_supported_providers_declares_codex(self):
         """Given provider 設定の許容値

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -19,7 +19,9 @@ from youtube_automation.utils.image_provider.config import (
     GeminiConfig,
     ImageGenerationConfig,
     OpenAIConfig,
+    build_codex_prompt,
     parse_image_generation_config,
+    render_codex_prompt,
     replace_model,
 )
 
@@ -97,16 +99,70 @@ class TestParseImageGenerationConfig:
         assert isinstance(cfg.codex, CodexConfig)
         assert cfg.codex.default_prompt_template == "Use the title {title}."
 
-    def test_codex_provider_uses_empty_prompt_template_when_subconfig_omitted(self):
+    @pytest.mark.parametrize(
+        "codex_section",
+        [
+            None,
+            "oops",
+            ["oops"],
+        ],
+    )
+    def test_codex_provider_rejects_invalid_subconfig_shape(self, codex_section):
         """Given image_generation.provider=codex
-        When codex sub-config が省略される
-        Then prompt template は空文字の CodexConfig として保持される。
+        When codex sub-config が mapping ではない
+        Then raw AttributeError ではなく ConfigError で fail-fast する。
         """
-        cfg = parse_image_generation_config({"image_generation": {"provider": "codex"}})
+        with pytest.raises(ConfigError, match="image_generation\\.codex"):
+            parse_image_generation_config({"image_generation": {"provider": "codex", "codex": codex_section}})
 
-        assert cfg.provider == "codex"
-        assert cfg.codex is not None
-        assert cfg.codex.default_prompt_template == ""
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "",
+            "No title placeholder.",
+            "{title} and {title}",
+        ],
+    )
+    def test_codex_provider_rejects_invalid_prompt_template(self, template):
+        """Given image_generation.provider=codex
+        When default_prompt_template が空、または `{title}` を exactly once 含まない
+        Then ConfigError で fail-fast する。
+        """
+        with pytest.raises(ConfigError, match="default_prompt_template"):
+            parse_image_generation_config(
+                {
+                    "image_generation": {
+                        "provider": "codex",
+                        "codex": {"default_prompt_template": template},
+                    }
+                }
+            )
+
+    def test_render_codex_prompt_replaces_only_title(self):
+        """Given Codex prompt template
+        When title を渡す
+        Then `{title}` だけが差し替わった prompt を返す。
+        """
+        prompt = render_codex_prompt("Use the title {title}.", "Rain Study")
+
+        assert prompt == "Use the title Rain Study."
+
+    def test_build_codex_prompt_reads_skill_config_shape(self):
+        """Given thumbnail skill-config dict
+        When Codex prompt helper を呼ぶ
+        Then parser 境界検証済み template に title を差し込む。
+        """
+        prompt = build_codex_prompt(
+            {
+                "image_generation": {
+                    "provider": "codex",
+                    "codex": {"default_prompt_template": "Use the title {title}."},
+                }
+            },
+            "Rain Study",
+        )
+
+        assert prompt == "Use the title Rain Study."
 
     def test_supported_providers_declares_codex(self):
         """Given provider 設定の許容値

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -99,6 +99,17 @@ class TestParseImageGenerationConfig:
         assert isinstance(cfg.codex, CodexConfig)
         assert cfg.codex.default_prompt_template == "Use the title {title}."
 
+    def test_parses_image_generation_namespace_for_codex_without_subconfig(self):
+        """Given image_generation.provider=codex の最小設定
+        When skill-config を parse する
+        Then 既存互換として provider-only 設定は成功する。
+        """
+        cfg = parse_image_generation_config({"image_generation": {"provider": "codex"}})
+
+        assert cfg.provider == "codex"
+        assert cfg.codex is not None
+        assert cfg.codex.default_prompt_template == ""
+
     @pytest.mark.parametrize(
         "codex_section",
         [
@@ -118,7 +129,6 @@ class TestParseImageGenerationConfig:
     @pytest.mark.parametrize(
         "template",
         [
-            "",
             "No title placeholder.",
             "{title} and {title}",
         ],
@@ -137,6 +147,45 @@ class TestParseImageGenerationConfig:
                     }
                 }
             )
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            None,
+            123,
+            ["Use the title {title}."],
+        ],
+    )
+    def test_codex_provider_rejects_non_string_prompt_template(self, template):
+        """Given image_generation.provider=codex
+        When default_prompt_template が文字列ではない
+        Then ConfigError で fail-fast する。
+        """
+        with pytest.raises(ConfigError, match="default_prompt_template"):
+            parse_image_generation_config(
+                {
+                    "image_generation": {
+                        "provider": "codex",
+                        "codex": {"default_prompt_template": template},
+                    }
+                }
+            )
+
+    @pytest.mark.parametrize(
+        "skill_cfg",
+        [
+            {"image_generation": {"provider": "codex"}},
+            {"image_generation": {"provider": "codex", "codex": {}}},
+            {"image_generation": {"provider": "codex", "codex": {"default_prompt_template": ""}}},
+        ],
+    )
+    def test_build_codex_prompt_rejects_missing_prompt_template(self, skill_cfg):
+        """Given provider-only Codex config
+        When prompt を build する
+        Then template 欠落は実行入口で ConfigError にする。
+        """
+        with pytest.raises(ConfigError, match="default_prompt_template"):
+            build_codex_prompt(skill_cfg, "Rain Study")
 
     def test_render_codex_prompt_replaces_only_title(self):
         """Given Codex prompt template

--- a/tests/test_image_provider_integration.py
+++ b/tests/test_image_provider_integration.py
@@ -131,6 +131,15 @@ class TestProviderSwitchEndToEnd:
         assert cfg.provider == "codex"
         assert cfg.gemini is None
         assert cfg.openai is None
+        assert cfg.codex is not None
+        assert cfg.codex.default_prompt_template.count("{title}") == 1
+        for required in (
+            "TTP this reference thumbnail",
+            "winning layout",
+            "more readable on mobile",
+            "no broken hands",
+        ):
+            assert required in cfg.codex.default_prompt_template
         with pytest.raises(ConfigError, match="codex-image\\.sh"):
             get_provider(cfg)
 

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -1,5 +1,8 @@
 """thumbnail skill の配布アセット内容を固定化するテスト。"""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -34,8 +37,11 @@ def _read_channel_setup_thumbnail_template() -> str:
 
 
 def _read_codex_prompt_script() -> str:
-    path = _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "codex-prompt.py"
-    return path.read_text(encoding="utf-8")
+    return _codex_prompt_script_path().read_text(encoding="utf-8")
+
+
+def _codex_prompt_script_path() -> Path:
+    return _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "codex-prompt.py"
 
 
 def _load_thumbnail_default_config() -> dict:
@@ -62,6 +68,26 @@ def _slice_between(text: str, start_marker: str, end_marker: str) -> str:
         raise AssertionError(f"{end_marker!r} が見つかりません")
 
     return text[start_idx:end_idx]
+
+
+def _run_codex_prompt_cli(tmp_path: Path, thumbnail_yaml: str, title: str) -> subprocess.CompletedProcess[str]:
+    channel_dir = tmp_path / "channel"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "thumbnail.yaml").write_text(thumbnail_yaml, encoding="utf-8")
+
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(channel_dir)
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+
+    return subprocess.run(
+        [sys.executable, str(_codex_prompt_script_path()), title],
+        cwd=_repo_root(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def test_thumbnail_skill_adds_ttp_preflight_checklist_before_two_phase_section() -> None:
@@ -178,6 +204,56 @@ def test_thumbnail_skill_includes_codex_prompt_helper_script() -> None:
     assert "from youtube_automation.utils.image_provider.config import build_codex_prompt" in script
     assert 'load_skill_config("thumbnail")' in script
     assert 'parser.add_argument("title"' in script
+
+
+def test_codex_prompt_helper_cli_renders_default_template(tmp_path: Path) -> None:
+    """#1300: provider=codex の最小 override で default template を title 差し替えして出力する。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        "image_generation:\n  provider: codex\n",
+        "Rain Study",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "TTP this reference thumbnail" in result.stdout
+    assert "Use the title Rain Study." in result.stdout
+    assert "{title}" not in result.stdout
+
+
+def test_codex_prompt_helper_cli_rejects_non_codex_provider(tmp_path: Path) -> None:
+    """#1300: codex 以外の provider では prompt helper を失敗させる。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        "image_generation:\n  provider: gemini\n",
+        "Rain Study",
+    )
+
+    assert result.returncode != 0
+    assert "provider=codex" in result.stderr
+
+
+def test_codex_prompt_helper_cli_rejects_empty_title(tmp_path: Path) -> None:
+    """#1300: 空 title は title 差し替え入口で失敗させる。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        "image_generation:\n  provider: codex\n",
+        "",
+    )
+
+    assert result.returncode != 0
+    assert "title" in result.stderr
+
+
+def test_codex_prompt_helper_cli_rejects_invalid_template(tmp_path: Path) -> None:
+    """#1300: `{title}` を含まない override template は失敗させる。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        "image_generation:\n  provider: codex\n  codex:\n    default_prompt_template: No placeholder.\n",
+        "Rain Study",
+    )
+
+    assert result.returncode != 0
+    assert "default_prompt_template" in result.stderr
 
 
 def test_thumbnail_default_config_provides_anatomy_clause() -> None:

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -17,6 +17,20 @@ def _read_thumbnail_default_config() -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_channel_setup_thumbnail_template() -> str:
+    path = (
+        _repo_root()
+        / ".claude"
+        / "skills"
+        / "channel-setup"
+        / "references"
+        / "config-template"
+        / "skills"
+        / "thumbnail.yaml"
+    )
+    return path.read_text(encoding="utf-8")
+
+
 def _slice_between(text: str, start_marker: str, end_marker: str) -> str:
     start_idx = text.find(start_marker)
     if start_idx == -1:
@@ -96,6 +110,31 @@ def test_thumbnail_default_config_remains_ttp_aligned() -> None:
     assert 'source_role: "thumbnail_candidate"' in config
     assert "fallback_when_empty: true" in config
     assert 'diff_prompt_template: ""' in config
+
+
+def test_thumbnail_default_config_provides_codex_ttp_upgrade_prompt() -> None:
+    """#1300: Codex 経路の既定プロンプトは短い TTP 上位互換型にする。"""
+    config = _read_thumbnail_default_config()
+
+    assert "default_prompt_template: |" in config
+    assert "TTP this reference thumbnail" in config
+    assert "winning layout" in config
+    assert "more readable on mobile" in config
+    assert "stronger face impact" in config
+    assert "no logos" in config
+    assert "no watermarks" in config
+    assert "no broken hands" in config
+    assert "Use the title {title}." in config
+
+
+def test_channel_setup_thumbnail_template_includes_codex_ttp_upgrade_prompt() -> None:
+    """#1300: channel-setup で生成される thumbnail config も同じ Codex 既定文言を持つ。"""
+    template = _read_channel_setup_thumbnail_template()
+
+    assert "default_prompt_template: |" in template
+    assert "TTP this reference thumbnail" in template
+    assert "winning template" in template
+    assert "Use the title {title}." in template
 
 
 def test_thumbnail_default_config_provides_anatomy_clause() -> None:

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import yaml
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
@@ -29,6 +31,20 @@ def _read_channel_setup_thumbnail_template() -> str:
         / "thumbnail.yaml"
     )
     return path.read_text(encoding="utf-8")
+
+
+def _load_thumbnail_default_config() -> dict:
+    return yaml.safe_load(_read_thumbnail_default_config()) or {}
+
+
+def _load_channel_setup_thumbnail_template() -> dict:
+    return yaml.safe_load(_read_channel_setup_thumbnail_template()) or {}
+
+
+def _codex_prompt_template(config: dict) -> str:
+    template = config["image_generation"]["codex"]["default_prompt_template"]
+    assert isinstance(template, str)
+    return template
 
 
 def _slice_between(text: str, start_marker: str, end_marker: str) -> str:
@@ -114,27 +130,40 @@ def test_thumbnail_default_config_remains_ttp_aligned() -> None:
 
 def test_thumbnail_default_config_provides_codex_ttp_upgrade_prompt() -> None:
     """#1300: Codex 経路の既定プロンプトは短い TTP 上位互換型にする。"""
-    config = _read_thumbnail_default_config()
+    template = _codex_prompt_template(_load_thumbnail_default_config())
 
-    assert "default_prompt_template: |" in config
-    assert "TTP this reference thumbnail" in config
-    assert "winning layout" in config
-    assert "more readable on mobile" in config
-    assert "stronger face impact" in config
-    assert "no logos" in config
-    assert "no watermarks" in config
-    assert "no broken hands" in config
-    assert "Use the title {title}." in config
+    assert template.count("{title}") == 1
+    for required in (
+        "TTP this reference thumbnail",
+        "winning layout",
+        "more readable on mobile",
+        "stronger face impact",
+        "no logos",
+        "no watermarks",
+        "no broken hands",
+        "Use the title {title}.",
+    ):
+        assert required in template
 
 
 def test_channel_setup_thumbnail_template_includes_codex_ttp_upgrade_prompt() -> None:
     """#1300: channel-setup で生成される thumbnail config も同じ Codex 既定文言を持つ。"""
-    template = _read_channel_setup_thumbnail_template()
+    default_template = _codex_prompt_template(_load_thumbnail_default_config())
+    channel_setup_template = _codex_prompt_template(_load_channel_setup_thumbnail_template())
 
-    assert "default_prompt_template: |" in template
-    assert "TTP this reference thumbnail" in template
-    assert "winning template" in template
-    assert "Use the title {title}." in template
+    assert channel_setup_template == default_template
+    assert channel_setup_template.count("{title}") == 1
+    for required in (
+        "TTP this reference thumbnail",
+        "winning layout",
+        "more readable on mobile",
+        "stronger face impact",
+        "no logos",
+        "no watermarks",
+        "no broken hands",
+        "Use the title {title}.",
+    ):
+        assert required in channel_setup_template
 
 
 def test_thumbnail_default_config_provides_anatomy_clause() -> None:

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -33,6 +33,11 @@ def _read_channel_setup_thumbnail_template() -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_codex_prompt_script() -> str:
+    path = _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "codex-prompt.py"
+    return path.read_text(encoding="utf-8")
+
+
 def _load_thumbnail_default_config() -> dict:
     return yaml.safe_load(_read_thumbnail_default_config()) or {}
 
@@ -164,6 +169,15 @@ def test_channel_setup_thumbnail_template_includes_codex_ttp_upgrade_prompt() ->
         "Use the title {title}.",
     ):
         assert required in channel_setup_template
+
+
+def test_thumbnail_skill_includes_codex_prompt_helper_script() -> None:
+    """#1300: collection-ideate から共有する Codex prompt helper を同梱する。"""
+    script = _read_codex_prompt_script()
+
+    assert "from youtube_automation.utils.image_provider.config import build_codex_prompt" in script
+    assert "load_skill_config(\"thumbnail\")" in script
+    assert "parser.add_argument(\"title\"" in script
 
 
 def test_thumbnail_default_config_provides_anatomy_clause() -> None:

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -176,8 +176,8 @@ def test_thumbnail_skill_includes_codex_prompt_helper_script() -> None:
     script = _read_codex_prompt_script()
 
     assert "from youtube_automation.utils.image_provider.config import build_codex_prompt" in script
-    assert "load_skill_config(\"thumbnail\")" in script
-    assert "parser.add_argument(\"title\"" in script
+    assert 'load_skill_config("thumbnail")' in script
+    assert 'parser.add_argument("title"' in script
 
 
 def test_thumbnail_default_config_provides_anatomy_clause() -> None:


### PR DESCRIPTION
## Summary
- Add `image_generation.codex.default_prompt_template` for short TTP upgrade prompts
- Update thumbnail / collection-ideate / channel-setup docs to use the same Codex prompt policy
- Add static tests that pin the Codex prompt contract

## Tests
- `uv run pytest tests/test_thumbnail_skill_assets.py tests/test_codex_thumbnail_routing_docs.py -q`

Closes #1300