### PR TITLE
feat(streaming): 配信元動画のプリフライト検証を追加

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -11,7 +11,7 @@ description: "Use when YouTube ライブ配信用の Vultr VPS を Terraform で
 
 ## 前提
 
-- `terraform` >= 1.5 / `uv` / 1Password CLI (`op`)
+- `terraform` >= 1.5 / `python3` / `uv` / 1Password CLI (`op`)
 - SSH 鍵 `~/.ssh/yt_stream_key{,.pub}`（無ければ `ssh-keygen -t ed25519 -f ~/.ssh/yt_stream_key`）
 - ssh-agent に秘密鍵を登録済み（`ssh-add ~/.ssh/yt_stream_key`）。`null_resource.deploy.connection` は `agent = true` で ssh-agent 経由に接続するため、未登録だと apply 時に `Permission denied (publickey)` で失敗する。`ssh-add -l` で登録済み鍵を確認できる。**OS 再起動・再ログイン時に agent は空に戻る（毎セッション再登録が必要）**。**`ssh -i ~/.ssh/yt_stream_key` 経由の手動 SSH は agent 状態と独立で検証手段にならない**（詳細は README §前提）
 - 1Password に以下が登録済み:

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -27,6 +27,7 @@ description: "Use when YouTube ライブ配信用の Vultr VPS を Terraform で
 | 初回構築 | §1 |
 | 動画差し替え | `$(git rev-parse --show-toplevel)/.claude/skills/streaming/references/swap_video.sh ./new_video.mp4` |
 | 帯域チェック | `uv run yt-stream-bandwidth --check-threshold --terraform-dir infra/terraform/streaming` |
+| 配信元 MP4 の実測 | `uv run yt-stream-bandwidth --probe-bitrate ./stream.mp4` |
 | アーカイブ件数確認（11h+1h 運用時） | `uv run yt-stream-archive-check --expected 2` |
 | サービス状態 | `ssh -i ~/.ssh/yt_stream_key root@$(terraform -chdir=infra/terraform/streaming output -raw instance_ip) systemctl status youtube-stream` |
 | ログ追跡 | 同上 + `journalctl -u youtube-stream -f` |
@@ -57,6 +58,21 @@ terraform apply
 ```
 
 apply 完了で 1 本目の配信が即開始。`terraform output -raw instance_ip` で IP を確認。
+
+`terraform plan` / `apply` は、ローカルに `ffprobe` があれば配信元 MP4 をプリフライト検証する。`run-ffmpeg.sh` は `-c:v copy` で映像をストリームコピーするため、ソース動画のキーフレーム間隔・ビットレート・H.264 profile が YouTube Live 品質をそのまま決める。キーフレーム最大間隔 > 4 秒、または 1080p で 4,500 Kbps 未満 / 720p で 2,500 Kbps 未満なら plan 時点で止まる。H.264 High profile 以外は warning。`ffprobe` が無い場合は soft skip される。
+
+1080p30 の推奨再エンコード例:
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -profile:v high -level:v 4.1 \
+  -b:v 4500k -maxrate 4500k -bufsize 9000k \
+  -g 60 -keyint_min 60 \
+  -preset slow -pix_fmt yuv420p -an \
+  output.mp4
+```
+
+24/7 配信では 4,500 Kbps + 音声 200 Kbps で月約 1.52 TB。`vc2-1c-2gb` の 2 TB/月に収めるため、6,800 Kbps 級へ上げる場合はプランアップか運用時間短縮を先に検討する。
 
 配信サイクルを変える場合は `terraform.tfvars` で `stream_hours` / `break_hours` を指定する。0 は無制限を意味し、`stream_hours=0` では `RuntimeMaxSec` を出力しない。`break_hours=0` では `RestartSec=10s` を出力する。
 

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -27,7 +27,7 @@ description: "Use when YouTube ライブ配信用の Vultr VPS を Terraform で
 | 初回構築 | §1 |
 | 動画差し替え | `$(git rev-parse --show-toplevel)/.claude/skills/streaming/references/swap_video.sh ./new_video.mp4` |
 | 帯域チェック | `uv run yt-stream-bandwidth --check-threshold --terraform-dir infra/terraform/streaming` |
-| 配信元 MP4 の実測 | `uv run yt-stream-bandwidth --probe-bitrate ./stream.mp4` |
+| 月間帯域見積もり用の MP4 実測 | `uv run yt-stream-bandwidth --probe-bitrate ./stream.mp4` |
 | アーカイブ件数確認（11h+1h 運用時） | `uv run yt-stream-archive-check --expected 2` |
 | サービス状態 | `ssh -i ~/.ssh/yt_stream_key root@$(terraform -chdir=infra/terraform/streaming output -raw instance_ip) systemctl status youtube-stream` |
 | ログ追跡 | 同上 + `journalctl -u youtube-stream -f` |
@@ -73,6 +73,8 @@ ffmpeg -i input.mp4 \
 ```
 
 24/7 配信では 4,500 Kbps + 音声 200 Kbps で月約 1.52 TB。`vc2-1c-2gb` の 2 TB/月に収めるため、6,800 Kbps 級へ上げる場合はプランアップか運用時間短縮を先に検討する。
+
+`yt-stream-bandwidth --probe-bitrate` は container 全体の平均 bitrate を見る月間帯域見積もり用。配信元 MP4 の preflight 合否は `terraform plan` / `apply` の stream-level 検証を正とする。
 
 配信サイクルを変える場合は `terraform.tfvars` で `stream_hours` / `break_hours` を指定する。0 は無制限を意味し、`stream_hours=0` では `RuntimeMaxSec` を出力しない。`break_hours=0` では `RestartSec=10s` を出力する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ local fix 衝突注意:
 ### Changed
 
 - `feat(thumbnail)`: Codex サムネイル生成の既定プロンプトを、参照画像を winning template として扱う短い TTP 上位互換型に変更。`image_generation.codex.default_prompt_template` を追加し、`/collection-ideate` と channel-setup テンプレートの Codex 導線を同方針へ更新（#1300）
+- `feat(streaming)`: Terraform streaming module に配信元 MP4 の ffprobe プリフライトを追加。キーフレーム間隔と最低ビットレートを plan/apply 前に hard fail し、H.264 High profile は warning として通知する。README / `/streaming` skill に `-c:v copy` 前提の動画要件と推奨再エンコード例を追記（#1299）
 - `refactor(shared)`: CollectionSummary を boolean fields (`has_prompts` / `mapped`) から status enum (`needs_prompts` | `ready` | `downloaded`) に置換。`downloaded_count` フィールド追加、`playlist_name` 廃止。POST `/collections/<id>/downloaded` エンドポイント新設（#1216）**BREAKING**
 - `feat(suno-helper)`: Playlist 追加後の Download all DOM 操作 + chrome.downloads 連携を実装 (#1146)
 - `feat(serve)`: POST `/collections/<id>/downloaded` に冪等更新ロジックを追加（playlist URL 記録 + DL 完了マーク）(#1145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `docs(skills)`: 初投稿前に `/playlist` で未作成プレイリストを初期化し、`/video-upload` の自動 assign に引き継ぐ導線を追加（#1314）
+- `feat(streaming)`: Terraform streaming module に配信元 MP4 の ffprobe プリフライトを追加。キーフレーム間隔と最低ビットレートを plan/apply 前に hard fail し、H.264 High profile は warning として通知する。README / `/streaming` skill に `-c:v copy` 前提の動画要件と推奨再エンコード例を追記（#1299）
 - `docs(skills)`: wf-next / wf-status / analytics-analyze / wf-new / channel-setup / video-upload / community-post / collection-ideate の記述を現行実装に同期し、optional config 一覧を README / AGENTS / CLAUDE に追記（#1173, #1174, #1175, #1176, #1177, #1178, #1179, #1180）
 - `feat(masterup)`: Suno 生成後の 2 clip を `20-documentation/suno-prompts.json` の歌詞有無で整理する `yt-suno-select-tracks` を追加。歌詞あり prompt は 1 clip 採用、instrumental は 2 clip 採用とし、極端に短い/長い失敗生成を stock 退避または削除できるようにした（#1308）
 - `docs(wf-new)`: `/wf-new` を子スキル順次実行のオーケストレーターとして整理し、Suno チャンネルでは `yt-collection-serve` 起動と疎通確認まで行って `/suno-helper` に引き継ぐ導線を追加（#1308）
@@ -37,7 +38,6 @@ local fix 衝突注意:
 ### Changed
 
 - `feat(thumbnail)`: Codex サムネイル生成の既定プロンプトを、参照画像を winning template として扱う短い TTP 上位互換型に変更。`image_generation.codex.default_prompt_template` を追加し、`/collection-ideate` と channel-setup テンプレートの Codex 導線を同方針へ更新（#1300）
-- `feat(streaming)`: Terraform streaming module に配信元 MP4 の ffprobe プリフライトを追加。キーフレーム間隔と最低ビットレートを plan/apply 前に hard fail し、H.264 High profile は warning として通知する。README / `/streaming` skill に `-c:v copy` 前提の動画要件と推奨再エンコード例を追記（#1299）
 - `refactor(shared)`: CollectionSummary を boolean fields (`has_prompts` / `mapped`) から status enum (`needs_prompts` | `ready` | `downloaded`) に置換。`downloaded_count` フィールド追加、`playlist_name` 廃止。POST `/collections/<id>/downloaded` エンドポイント新設（#1216）**BREAKING**
 - `feat(suno-helper)`: Playlist 追加後の Download all DOM 操作 + chrome.downloads 連携を実装 (#1146)
 - `feat(serve)`: POST `/collections/<id>/downloaded` に冪等更新ロジックを追加（playlist URL 記録 + DL 完了マーク）(#1145)

--- a/infra/terraform/streaming/.terraform.lock.hcl
+++ b/infra/terraform/streaming/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.0"
+  constraints = ">= 2.3.0"
+  hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
+    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
+    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
+    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
+    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
+    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
+    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
+    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
+    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
+    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
+    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
+    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
   constraints = ">= 3.2.0"

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -16,6 +16,7 @@ Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に
 ## 前提
 
 - `terraform` >= 1.5 インストール済み
+- `python3` が PATH 上にある（配信元 MP4 のプリフライト検証を Terraform `external` data source から実行するため）
 - Vultr API キーを 1Password に保管済み（または環境変数で渡せる状態）
 - `yt-fetch-stream-key --vault=Personal --item=YouTube` でストリームキーを 1Password に保管済み（初回のみ）
 - Terraform state 用の GCS bucket を `infra/terraform/bootstrap` で作成済み
@@ -67,7 +68,7 @@ terraform apply
 - 映像ビットレート: 1080p 以上は 4,500 Kbps 以上、720p 以上は 2,500 Kbps 以上（未満は hard fail）
 - コーデック / プロファイル: H.264 High profile 推奨（Baseline などは Terraform `check` の warning）
 
-`ffprobe` が無い環境では検証を `skipped` として通す。明示的に止めたい場合のみ `source_video_preflight_enabled = false` を指定する。
+`ffprobe` が無い環境では検証を `skipped` として通す。検証自体を無効化したい場合のみ `source_video_preflight_enabled = false` を指定する。
 
 推奨再エンコード例（1080p30 / `vc2-1c-2gb` の 2 TB/月を想定）:
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -68,7 +68,7 @@ terraform apply
 - 映像ビットレート: 1080p 以上は 4,500 Kbps 以上、720p 以上は 2,500 Kbps 以上（未満は hard fail）
 - コーデック / プロファイル: H.264 High profile 推奨（Baseline などは Terraform `check` の warning）
 
-`ffprobe` が無い環境では検証を `skipped` として通す。検証自体を無効化したい場合のみ `source_video_preflight_enabled = false` を指定する。
+`ffprobe` が無い環境では検証を `skipped` として通す。
 
 推奨再エンコード例（1080p30 / `vc2-1c-2gb` の 2 TB/月を想定）:
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -81,7 +81,7 @@ ffmpeg -i input.mp4 \
   output.mp4
 ```
 
-帯域目安: 映像 4,500 Kbps + 音声 200 Kbps の 24/7 配信は月約 1.52 TB。6,800 Kbps 級に上げると 2 TB/月を超えうるため、画質改善時は `yt-stream-bandwidth --probe-bitrate` と月次帯域レポートを併用する。
+帯域目安: 映像 4,500 Kbps + 音声 200 Kbps の 24/7 配信は月約 1.52 TB。6,800 Kbps 級に上げると 2 TB/月を超えうるため、画質改善時は `yt-stream-bandwidth --probe-bitrate` と月次帯域レポートを併用する。`--probe-bitrate` は container 全体の平均 bitrate を見る月間帯域見積もり用であり、preflight の合否確認は `terraform plan` / `apply` の stream-level 検証を正とする。
 
 > **tfstate と secret の関係（誤解しやすいので明記）**
 >
@@ -292,7 +292,8 @@ uv run yt-stream-bandwidth --report --terraform-dir infra/terraform/streaming
 # 80% 閾値アラート (未超は静黙)
 uv run yt-stream-bandwidth --check-threshold --terraform-dir infra/terraform/streaming
 
-# 配信元 MP4 のビットレートを ffprobe で実測 (想定 4 Mbps と比較)
+# 配信元 MP4 の container 全体 bitrate を ffprobe で実測し、月間帯域を概算する
+# preflight の合否確認は terraform plan/apply の stream-level 検証を使う
 uv run yt-stream-bandwidth --probe-bitrate /path/to/stream.mp4
 ```
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -26,6 +26,7 @@ Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に
     - **`ssh -i ~/.ssh/yt_stream_key root@<ip>` で SSH できることは agent 登録の検証にならない**: `-i` 指定は鍵ファイルを直接読むため agent 状態と無関係に成功する。Terraform provisioner は `agent = true` のみで動作するため、検証は **必ず `ssh-add -l`** で行う
 - `null_resource.deploy.connection` は `host_key` 検証を有効化している。host 鍵は Terraform が `tls_private_key.ssh_host` として生成し、cloud-init の `ssh_keys` で `/etc/ssh/ssh_host_ed25519_key{,.pub}` に固定配置するため、初回 apply でも TOFU に依存せず接続先ホストを検証できる
 - 配信対象の MP4 ファイルがローカルにある（絶対パス）
+- `ffprobe` が PATH 上にある場合、`terraform plan` / `apply` 時に配信元 MP4 の YouTube 要件をプリフライト検証する（無い場合は soft skip）
 - operator のグローバル IP（`curl -s ifconfig.me` で取得）を `/32` 付き CIDR 形式で `allowed_ssh_cidr` に渡せる状態（Vultr ファイアウォールで SSH 22/tcp を operator IP からのみ許可するため）
 
 ## 配置 root
@@ -57,6 +58,29 @@ terraform apply
 ```
 
 `terraform.tfvars` には secret 値を書かない（`stream_key` / `vultr_api_key` は `TF_VAR_*` のみ）。
+
+## 配信元動画のプリフライト
+
+`run-ffmpeg.sh` は映像を `-c:v copy`（ストリームコピー）で YouTube Live へ送るため、**ソース MP4 のエンコード品質がそのまま配信品質になる**。`terraform plan` / `apply` では `external` data source から `video_preflight.py` を呼び、ローカル `ffprobe` で次を検査する。
+
+- キーフレーム最大間隔: 4 秒以下（超過時は hard fail）
+- 映像ビットレート: 1080p 以上は 4,500 Kbps 以上、720p 以上は 2,500 Kbps 以上（未満は hard fail）
+- コーデック / プロファイル: H.264 High profile 推奨（Baseline などは Terraform `check` の warning）
+
+`ffprobe` が無い環境では検証を `skipped` として通す。明示的に止めたい場合のみ `source_video_preflight_enabled = false` を指定する。
+
+推奨再エンコード例（1080p30 / `vc2-1c-2gb` の 2 TB/月を想定）:
+
+```bash
+ffmpeg -i input.mp4 \
+  -c:v libx264 -profile:v high -level:v 4.1 \
+  -b:v 4500k -maxrate 4500k -bufsize 9000k \
+  -g 60 -keyint_min 60 \
+  -preset slow -pix_fmt yuv420p -an \
+  output.mp4
+```
+
+帯域目安: 映像 4,500 Kbps + 音声 200 Kbps の 24/7 配信は月約 1.52 TB。6,800 Kbps 級に上げると 2 TB/月を超えうるため、画質改善時は `yt-stream-bandwidth --probe-bitrate` と月次帯域レポートを併用する。
 
 > **tfstate と secret の関係（誤解しやすいので明記）**
 >

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -3,6 +3,24 @@ locals {
   ssh_host_key_algorithm  = "ED25519"
   ssh_host_public_key     = trimspace(tls_private_key.ssh_host.public_key_openssh)
   ssh_host_public_key_sha = sha256(local.ssh_host_public_key)
+  source_video_preflight  = data.external.source_video_preflight.result
+  source_video_ok         = local.source_video_preflight.ok == "true"
+  source_video_profile_ok = local.source_video_preflight.profile_ok == "true"
+}
+
+data "external" "source_video_preflight" {
+  program = ["python3", "${path.module}/video_preflight.py"]
+
+  query = {
+    video_path = var.video_path
+  }
+}
+
+check "source_video_h264_profile" {
+  assert {
+    condition     = !var.source_video_preflight_enabled || local.source_video_profile_ok
+    error_message = local.source_video_preflight.profile_message
+  }
 }
 
 resource "tls_private_key" "ssh_host" {
@@ -70,6 +88,10 @@ resource "null_resource" "deploy" {
     precondition {
       condition     = var.stream_hours > 0 || var.break_hours == 0
       error_message = "break_hours は stream_hours > 0 のときのみ有効です。24/7 モード (stream_hours=0) では break_hours=0 にしてください。"
+    }
+    precondition {
+      condition     = !var.source_video_preflight_enabled || local.source_video_ok
+      error_message = local.source_video_preflight.message
     }
   }
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -3,12 +3,19 @@ locals {
   ssh_host_key_algorithm  = "ED25519"
   ssh_host_public_key     = trimspace(tls_private_key.ssh_host.public_key_openssh)
   ssh_host_public_key_sha = sha256(local.ssh_host_public_key)
-  source_video_preflight  = data.external.source_video_preflight.result
+  source_video_preflight = var.source_video_preflight_enabled ? data.external.source_video_preflight[0].result : {
+    ok              = "true"
+    status          = "disabled"
+    message         = "source video preflight disabled."
+    profile_ok      = "true"
+    profile_message = "source video preflight disabled."
+  }
   source_video_ok         = local.source_video_preflight.ok == "true"
   source_video_profile_ok = local.source_video_preflight.profile_ok == "true"
 }
 
 data "external" "source_video_preflight" {
+  count   = var.source_video_preflight_enabled ? 1 : 0
   program = ["python3", "${path.module}/video_preflight.py"]
 
   query = {
@@ -18,7 +25,7 @@ data "external" "source_video_preflight" {
 
 check "source_video_h264_profile" {
   assert {
-    condition     = !var.source_video_preflight_enabled || local.source_video_profile_ok
+    condition     = local.source_video_profile_ok
     error_message = local.source_video_preflight.profile_message
   }
 }
@@ -90,7 +97,7 @@ resource "null_resource" "deploy" {
       error_message = "break_hours は stream_hours > 0 のときのみ有効です。24/7 モード (stream_hours=0) では break_hours=0 にしてください。"
     }
     precondition {
-      condition     = !var.source_video_preflight_enabled || local.source_video_ok
+      condition     = local.source_video_ok
       error_message = local.source_video_preflight.message
     }
   }

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -3,19 +3,12 @@ locals {
   ssh_host_key_algorithm  = "ED25519"
   ssh_host_public_key     = trimspace(tls_private_key.ssh_host.public_key_openssh)
   ssh_host_public_key_sha = sha256(local.ssh_host_public_key)
-  source_video_preflight = var.source_video_preflight_enabled ? data.external.source_video_preflight[0].result : {
-    ok              = "true"
-    status          = "disabled"
-    message         = "source video preflight disabled."
-    profile_ok      = "true"
-    profile_message = "source video preflight disabled."
-  }
+  source_video_preflight  = data.external.source_video_preflight.result
   source_video_ok         = local.source_video_preflight.ok == "true"
   source_video_profile_ok = local.source_video_preflight.profile_ok == "true"
 }
 
 data "external" "source_video_preflight" {
-  count   = var.source_video_preflight_enabled ? 1 : 0
   program = ["python3", "${path.module}/video_preflight.py"]
 
   query = {

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -33,6 +33,12 @@ variable "video_path" {
   description = "VPS にアップロードするローカル動画ファイルの絶対パス（環境依存のため必須項目）"
 }
 
+variable "source_video_preflight_enabled" {
+  type        = bool
+  description = "terraform plan/apply 時に ffprobe で配信元 MP4 の YouTube 要件（キーフレーム間隔・最低ビットレート・H.264 High 推奨）を検査する。ffprobe 未インストール時は soft skip"
+  default     = true
+}
+
 variable "install_root" {
   type        = string
   description = "VPS 上で動画・ログ・運用スクリプトを配置する root ディレクトリ"

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -33,12 +33,6 @@ variable "video_path" {
   description = "VPS にアップロードするローカル動画ファイルの絶対パス（環境依存のため必須項目）"
 }
 
-variable "source_video_preflight_enabled" {
-  type        = bool
-  description = "terraform plan/apply 時に ffprobe で配信元 MP4 の YouTube 要件（キーフレーム間隔・最低ビットレート・H.264 High 推奨）を検査する。ffprobe 未インストール時は soft skip"
-  default     = true
-}
-
 variable "install_root" {
   type        = string
   description = "VPS 上で動画・ログ・運用スクリプトを配置する root ディレクトリ"

--- a/infra/terraform/streaming/versions.tf
+++ b/infra/terraform/streaming/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.2"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.3"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0"

--- a/infra/terraform/streaming/video_preflight.py
+++ b/infra/terraform/streaming/video_preflight.py
@@ -56,7 +56,7 @@ def _video_metadata(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
             "-show_entries",
             "stream=codec_name,profile,width,height,bit_rate",
             "-show_entries",
-            "format=bit_rate,duration",
+            "format=duration",
             "-of",
             "json",
             "--",
@@ -159,7 +159,7 @@ def check_video(path: Path) -> dict[str, str]:
     height = _int_or_none(stream.get("height"))
     width = _int_or_none(stream.get("width"))
     duration = _float_or_none(format_info.get("duration"))
-    bitrate_bps = _int_or_none(stream.get("bit_rate")) or _int_or_none(format_info.get("bit_rate"))
+    bitrate_bps = _int_or_none(stream.get("bit_rate"))
     bitrate_kbps = round(bitrate_bps / 1000) if bitrate_bps is not None else None
     required_bitrate_kbps = _required_bitrate_kbps(height)
     max_keyframe_interval = _max_interval(keyframes, duration)

--- a/infra/terraform/streaming/video_preflight.py
+++ b/infra/terraform/streaming/video_preflight.py
@@ -174,7 +174,7 @@ def check_video(path: Path) -> dict[str, str]:
 
     codec = str(stream.get("codec_name") or "")
     profile = str(stream.get("profile") or "")
-    profile_ok = codec == "h264" and "high" in profile.lower()
+    profile_ok = codec == "h264" and profile.lower() == "high"
     profile_message = (
         "source video uses H.264 High profile."
         if profile_ok

--- a/infra/terraform/streaming/video_preflight.py
+++ b/infra/terraform/streaming/video_preflight.py
@@ -100,10 +100,21 @@ def _keyframe_times(path: Path) -> list[float]:
     return sorted(set(times))
 
 
-def _max_interval(times: list[float]) -> float | None:
-    if len(times) < 2:
+def _max_interval(times: list[float], duration: float | None) -> float | None:
+    boundaries = [time for time in times if time >= 0]
+    if duration is not None and duration > 0:
+        boundaries.append(duration)
+    boundaries = sorted(set(boundaries))
+    if not boundaries:
         return None
-    return max(b - a for a, b in zip(times, times[1:], strict=False))
+
+    previous = 0.0
+    intervals: list[float] = []
+    for boundary in boundaries:
+        if boundary >= previous:
+            intervals.append(boundary - previous)
+            previous = boundary
+    return max(intervals) if intervals else None
 
 
 def _int_or_none(value: object) -> int | None:
@@ -147,10 +158,11 @@ def check_video(path: Path) -> dict[str, str]:
 
     height = _int_or_none(stream.get("height"))
     width = _int_or_none(stream.get("width"))
+    duration = _float_or_none(format_info.get("duration"))
     bitrate_bps = _int_or_none(stream.get("bit_rate")) or _int_or_none(format_info.get("bit_rate"))
     bitrate_kbps = round(bitrate_bps / 1000) if bitrate_bps is not None else None
     required_bitrate_kbps = _required_bitrate_kbps(height)
-    max_keyframe_interval = _max_interval(keyframes)
+    max_keyframe_interval = _max_interval(keyframes, duration)
 
     failures: list[str] = []
     if max_keyframe_interval is not None and max_keyframe_interval > MAX_KEYFRAME_INTERVAL_SEC:

--- a/infra/terraform/streaming/video_preflight.py
+++ b/infra/terraform/streaming/video_preflight.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Terraform external data source for streaming source video preflight."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+MAX_KEYFRAME_INTERVAL_SEC = 4.0
+MIN_BITRATE_BY_HEIGHT_KBPS = (
+    (1080, 4500),
+    (720, 2500),
+)
+DEFAULT_MIN_BITRATE_KBPS = 1500
+
+
+def _result(
+    *,
+    ok: bool,
+    status: str,
+    message: str,
+    profile_ok: bool = True,
+    profile_message: str = "",
+    **extra: object,
+) -> dict[str, str]:
+    data: dict[str, str] = {
+        "ok": str(ok).lower(),
+        "status": status,
+        "message": message,
+        "profile_ok": str(profile_ok).lower(),
+        "profile_message": profile_message or message,
+    }
+    data.update({key: str(value) for key, value in extra.items()})
+    return data
+
+
+def _run_ffprobe(args: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(
+        ["ffprobe", "-v", "error", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout or "{}")
+
+
+def _video_metadata(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    data = _run_ffprobe(
+        [
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name,profile,width,height,bit_rate",
+            "-show_entries",
+            "format=bit_rate,duration",
+            "-of",
+            "json",
+            "--",
+            str(path),
+        ]
+    )
+    streams = data.get("streams")
+    stream = streams[0] if isinstance(streams, list) and streams else {}
+    format_info = data.get("format") if isinstance(data.get("format"), dict) else {}
+    return stream if isinstance(stream, dict) else {}, format_info
+
+
+def _keyframe_times(path: Path) -> list[float]:
+    data = _run_ffprobe(
+        [
+            "-select_streams",
+            "v:0",
+            "-skip_frame",
+            "nokey",
+            "-show_entries",
+            "frame=best_effort_timestamp_time,pkt_pts_time,pts_time",
+            "-of",
+            "json",
+            "--",
+            str(path),
+        ]
+    )
+    frames = data.get("frames")
+    if not isinstance(frames, list):
+        return []
+
+    times: list[float] = []
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        raw = frame.get("best_effort_timestamp_time") or frame.get("pkt_pts_time") or frame.get("pts_time")
+        try:
+            times.append(float(raw))
+        except (TypeError, ValueError):
+            continue
+    return sorted(set(times))
+
+
+def _max_interval(times: list[float]) -> float | None:
+    if len(times) < 2:
+        return None
+    return max(b - a for a, b in zip(times, times[1:], strict=False))
+
+
+def _int_or_none(value: object) -> int | None:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_or_none(value: object) -> float | None:
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _required_bitrate_kbps(height: int | None) -> int:
+    if height is None:
+        return DEFAULT_MIN_BITRATE_KBPS
+    for min_height, bitrate in MIN_BITRATE_BY_HEIGHT_KBPS:
+        if height >= min_height:
+            return bitrate
+    return DEFAULT_MIN_BITRATE_KBPS
+
+
+def check_video(path: Path) -> dict[str, str]:
+    if shutil.which("ffprobe") is None:
+        return _result(
+            ok=True,
+            status="skipped",
+            message="ffprobe not found; source video preflight skipped.",
+        )
+    if not path.is_file():
+        return _result(ok=False, status="failed", message=f"source video does not exist: {path}")
+
+    try:
+        stream, format_info = _video_metadata(path)
+        keyframes = _keyframe_times(path)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        return _result(ok=False, status="failed", message=f"ffprobe failed for source video: {exc}")
+
+    height = _int_or_none(stream.get("height"))
+    width = _int_or_none(stream.get("width"))
+    bitrate_bps = _int_or_none(stream.get("bit_rate")) or _int_or_none(format_info.get("bit_rate"))
+    bitrate_kbps = round(bitrate_bps / 1000) if bitrate_bps is not None else None
+    required_bitrate_kbps = _required_bitrate_kbps(height)
+    max_keyframe_interval = _max_interval(keyframes)
+
+    failures: list[str] = []
+    if max_keyframe_interval is not None and max_keyframe_interval > MAX_KEYFRAME_INTERVAL_SEC:
+        failures.append(f"keyframe interval {max_keyframe_interval:.2f}s exceeds {MAX_KEYFRAME_INTERVAL_SEC:.0f}s")
+    if bitrate_kbps is None:
+        failures.append("video bitrate is unavailable")
+    elif bitrate_kbps < required_bitrate_kbps:
+        failures.append(f"video bitrate {bitrate_kbps} Kbps is below {required_bitrate_kbps} Kbps")
+
+    codec = str(stream.get("codec_name") or "")
+    profile = str(stream.get("profile") or "")
+    profile_ok = codec == "h264" and "high" in profile.lower()
+    profile_message = (
+        "source video uses H.264 High profile."
+        if profile_ok
+        else f"source video profile is {codec or 'unknown'} / {profile or 'unknown'}; H.264 High is recommended."
+    )
+
+    interval_summary = f"{max_keyframe_interval:.2f}s" if max_keyframe_interval is not None else "unknown"
+    summary = (
+        f"source video {width or '?'}x{height or '?'}; "
+        f"bitrate={bitrate_kbps or 'unknown'} Kbps; "
+        f"max_keyframe_interval={interval_summary}"
+    )
+    if failures:
+        return _result(
+            ok=False,
+            status="failed",
+            message="; ".join(failures),
+            profile_ok=profile_ok,
+            profile_message=profile_message,
+            width=width or "",
+            height=height or "",
+            bitrate_kbps=bitrate_kbps or "",
+            required_bitrate_kbps=required_bitrate_kbps,
+            max_keyframe_interval_sec=(f"{max_keyframe_interval:.3f}" if max_keyframe_interval is not None else ""),
+        )
+    return _result(
+        ok=True,
+        status="ok",
+        message=summary,
+        profile_ok=profile_ok,
+        profile_message=profile_message,
+        width=width or "",
+        height=height or "",
+        bitrate_kbps=bitrate_kbps or "",
+        required_bitrate_kbps=required_bitrate_kbps,
+        max_keyframe_interval_sec=f"{max_keyframe_interval:.3f}" if max_keyframe_interval is not None else "",
+    )
+
+
+def main() -> int:
+    query = json.load(sys.stdin)
+    video_path = query.get("video_path")
+    if not isinstance(video_path, str) or not video_path:
+        json.dump(_result(ok=False, status="failed", message="video_path is required."), sys.stdout)
+        return 0
+    json.dump(check_video(Path(video_path).expanduser()), sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/terraform/streaming/video_preflight.py
+++ b/infra/terraform/streaming/video_preflight.py
@@ -8,14 +8,12 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 MAX_KEYFRAME_INTERVAL_SEC = 4.0
 MIN_BITRATE_BY_HEIGHT_KBPS = (
     (1080, 4500),
     (720, 2500),
 )
-DEFAULT_MIN_BITRATE_KBPS = 1500
 
 
 def _result(
@@ -38,17 +36,18 @@ def _result(
     return data
 
 
-def _run_ffprobe(args: list[str]) -> dict[str, Any]:
+def _run_ffprobe(args: list[str]) -> dict[str, object]:
     proc = subprocess.run(
         ["ffprobe", "-v", "error", *args],
         check=True,
         capture_output=True,
         text=True,
     )
-    return json.loads(proc.stdout or "{}")
+    data: object = json.loads(proc.stdout or "{}")
+    return data if isinstance(data, dict) else {}
 
 
-def _video_metadata(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+def _video_metadata(path: Path) -> tuple[dict[str, object], dict[str, object]]:
     data = _run_ffprobe(
         [
             "-select_streams",
@@ -131,13 +130,11 @@ def _float_or_none(value: object) -> float | None:
         return None
 
 
-def _required_bitrate_kbps(height: int | None) -> int:
-    if height is None:
-        return DEFAULT_MIN_BITRATE_KBPS
+def _required_bitrate_kbps(height: int | None) -> int | None:
     for min_height, bitrate in MIN_BITRATE_BY_HEIGHT_KBPS:
-        if height >= min_height:
+        if height is not None and height >= min_height:
             return bitrate
-    return DEFAULT_MIN_BITRATE_KBPS
+    return None
 
 
 def check_video(path: Path) -> dict[str, str]:
@@ -162,14 +159,17 @@ def check_video(path: Path) -> dict[str, str]:
     bitrate_bps = _int_or_none(stream.get("bit_rate"))
     bitrate_kbps = round(bitrate_bps / 1000) if bitrate_bps is not None else None
     required_bitrate_kbps = _required_bitrate_kbps(height)
+    required_bitrate_bps = required_bitrate_kbps * 1000 if required_bitrate_kbps is not None else None
     max_keyframe_interval = _max_interval(keyframes, duration)
 
     failures: list[str] = []
-    if max_keyframe_interval is not None and max_keyframe_interval > MAX_KEYFRAME_INTERVAL_SEC:
+    if max_keyframe_interval is None:
+        failures.append("keyframe interval is unavailable")
+    elif max_keyframe_interval > MAX_KEYFRAME_INTERVAL_SEC:
         failures.append(f"keyframe interval {max_keyframe_interval:.2f}s exceeds {MAX_KEYFRAME_INTERVAL_SEC:.0f}s")
     if bitrate_kbps is None:
         failures.append("video bitrate is unavailable")
-    elif bitrate_kbps < required_bitrate_kbps:
+    elif required_bitrate_bps is not None and bitrate_bps is not None and bitrate_bps < required_bitrate_bps:
         failures.append(f"video bitrate {bitrate_kbps} Kbps is below {required_bitrate_kbps} Kbps")
 
     codec = str(stream.get("codec_name") or "")
@@ -197,7 +197,7 @@ def check_video(path: Path) -> dict[str, str]:
             width=width or "",
             height=height or "",
             bitrate_kbps=bitrate_kbps or "",
-            required_bitrate_kbps=required_bitrate_kbps,
+            required_bitrate_kbps=required_bitrate_kbps or "",
             max_keyframe_interval_sec=(f"{max_keyframe_interval:.3f}" if max_keyframe_interval is not None else ""),
         )
     return _result(
@@ -209,7 +209,7 @@ def check_video(path: Path) -> dict[str, str]:
         width=width or "",
         height=height or "",
         bitrate_kbps=bitrate_kbps or "",
-        required_bitrate_kbps=required_bitrate_kbps,
+        required_bitrate_kbps=required_bitrate_kbps or "",
         max_keyframe_interval_sec=f"{max_keyframe_interval:.3f}" if max_keyframe_interval is not None else "",
     )
 

--- a/tests/streaming/_helpers.py
+++ b/tests/streaming/_helpers.py
@@ -26,6 +26,7 @@ _ENV_TFTPL = _STREAMING_DIR / "templates" / "youtube-stream.env.tftpl"
 _LOGROTATE_TFTPL = _STREAMING_DIR / "templates" / "logrotate.conf.tftpl"
 _CRON_D_TFTPL = _STREAMING_DIR / "templates" / "cron.d.tftpl"
 _STREAMING_README = _STREAMING_DIR / "README.md"
+_VIDEO_PREFLIGHT_PY = _STREAMING_DIR / "video_preflight.py"
 _STREAMING_SKILL = _REPO_ROOT / ".claude" / "skills" / "streaming" / "SKILL.md"
 
 _SCRIPTS_STREAMING_DIR = _REPO_ROOT / ".claude" / "skills" / "streaming" / "references"

--- a/tests/streaming/test_main_tf.py
+++ b/tests/streaming/test_main_tf.py
@@ -263,6 +263,9 @@ class TestMainTfSourceVideoPreflight:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'data\s+"external"\s+"source_video_preflight"')
         assert block is not None, 'data "external" "source_video_preflight" が存在しない'
+        assert "count   = var.source_video_preflight_enabled ? 1 : 0" in block, (
+            "source_video_preflight_enabled=false でも external data source が実行される"
+        )
         assert "video_preflight.py" in block, "external data source が video_preflight.py を呼んでいない"
         assert re.search(r"video_path\s*=\s*var\.video_path", block), (
             "external data source query が var.video_path を渡していない"
@@ -276,7 +279,8 @@ class TestMainTfSourceVideoPreflight:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         locals_block = extract_block(text, r"^\s*locals")
         assert locals_block is not None, "main.tf に locals ブロックが存在しない"
-        assert "source_video_preflight  = data.external.source_video_preflight.result" in locals_block
+        assert "data.external.source_video_preflight[0].result" in locals_block
+        assert 'status          = "disabled"' in locals_block
         assert 'source_video_ok         = local.source_video_preflight.ok == "true"' in locals_block
         assert 'source_video_profile_ok = local.source_video_preflight.profile_ok == "true"' in locals_block
 
@@ -290,7 +294,6 @@ class TestMainTfSourceVideoPreflight:
         assert deploy_block is not None
         lifecycle_block = extract_block(deploy_block, r"lifecycle")
         assert lifecycle_block is not None
-        assert "var.source_video_preflight_enabled" in lifecycle_block
         assert "local.source_video_ok" in lifecycle_block
         assert "local.source_video_preflight.message" in lifecycle_block
 

--- a/tests/streaming/test_main_tf.py
+++ b/tests/streaming/test_main_tf.py
@@ -263,9 +263,7 @@ class TestMainTfSourceVideoPreflight:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'data\s+"external"\s+"source_video_preflight"')
         assert block is not None, 'data "external" "source_video_preflight" が存在しない'
-        assert "count   = var.source_video_preflight_enabled ? 1 : 0" in block, (
-            "source_video_preflight_enabled=false でも external data source が実行される"
-        )
+        assert "count" not in block, "source video preflight を optional 化してはならない"
         assert "video_preflight.py" in block, "external data source が video_preflight.py を呼んでいない"
         assert re.search(r"video_path\s*=\s*var\.video_path", block), (
             "external data source query が var.video_path を渡していない"
@@ -279,15 +277,14 @@ class TestMainTfSourceVideoPreflight:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         locals_block = extract_block(text, r"^\s*locals")
         assert locals_block is not None, "main.tf に locals ブロックが存在しない"
-        assert "data.external.source_video_preflight[0].result" in locals_block
-        assert 'status          = "disabled"' in locals_block
+        assert "source_video_preflight  = data.external.source_video_preflight.result" in locals_block
         assert 'source_video_ok         = local.source_video_preflight.ok == "true"' in locals_block
         assert 'source_video_profile_ok = local.source_video_preflight.profile_ok == "true"' in locals_block
 
     def test_deploy_lifecycle_has_source_video_preflight_precondition(self):
         """Given main.tf
         When null_resource.deploy の lifecycle を読む
-        Then source_video_preflight_enabled と external 結果で hard fail する precondition がある。
+        Then external 結果で hard fail する precondition がある。
         """
         text = strip_hcl_comments(read_file(_MAIN_TF))
         deploy_block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')

--- a/tests/streaming/test_main_tf.py
+++ b/tests/streaming/test_main_tf.py
@@ -252,6 +252,60 @@ class TestMainTfStreamCycleConsistencyPrecondition:
         )
 
 
+class TestMainTfSourceVideoPreflight:
+    """``main.tf`` の配信元動画プリフライト（#1299）。"""
+
+    def test_external_data_source_invokes_video_preflight_script(self):
+        """Given main.tf
+        When data.external.source_video_preflight を読む
+        Then video_preflight.py に var.video_path を渡している。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        block = extract_block(text, r'data\s+"external"\s+"source_video_preflight"')
+        assert block is not None, 'data "external" "source_video_preflight" が存在しない'
+        assert "video_preflight.py" in block, "external data source が video_preflight.py を呼んでいない"
+        assert re.search(r"video_path\s*=\s*var\.video_path", block), (
+            "external data source query が var.video_path を渡していない"
+        )
+
+    def test_locals_expose_preflight_result_flags(self):
+        """Given main.tf
+        When locals を読む
+        Then preflight の ok / profile_ok を bool 条件として取り出している。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        locals_block = extract_block(text, r"^\s*locals")
+        assert locals_block is not None, "main.tf に locals ブロックが存在しない"
+        assert "source_video_preflight  = data.external.source_video_preflight.result" in locals_block
+        assert 'source_video_ok         = local.source_video_preflight.ok == "true"' in locals_block
+        assert 'source_video_profile_ok = local.source_video_preflight.profile_ok == "true"' in locals_block
+
+    def test_deploy_lifecycle_has_source_video_preflight_precondition(self):
+        """Given main.tf
+        When null_resource.deploy の lifecycle を読む
+        Then source_video_preflight_enabled と external 結果で hard fail する precondition がある。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        deploy_block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
+        assert deploy_block is not None
+        lifecycle_block = extract_block(deploy_block, r"lifecycle")
+        assert lifecycle_block is not None
+        assert "var.source_video_preflight_enabled" in lifecycle_block
+        assert "local.source_video_ok" in lifecycle_block
+        assert "local.source_video_preflight.message" in lifecycle_block
+
+    def test_h264_profile_check_is_warning_not_precondition(self):
+        """Given main.tf
+        When check source_video_h264_profile を読む
+        Then profile は precondition ではなく Terraform check warning にしている。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        check_block = extract_block(text, r'check\s+"source_video_h264_profile"')
+        assert check_block is not None, 'check "source_video_h264_profile" が存在しない'
+        assert "local.source_video_profile_ok" in check_block
+        assert "local.source_video_preflight.profile_message" in check_block
+
+
 # ============================================================================
 # main.tf user_data (#124)
 # ============================================================================

--- a/tests/streaming/test_skill_streaming.py
+++ b/tests/streaming/test_skill_streaming.py
@@ -100,6 +100,20 @@ class TestStreamingSkillSshAgent:
         assert "yt-stream-archive-check --expected 2" in text
         assert "`stream_hours=11` / `break_hours=1` 運用" in text
 
+    def test_skill_documents_source_video_preflight(self):
+        """Given SKILL.md
+        When 初回構築の操作入口を読む
+        Then 配信元 MP4 の ffprobe preflight と再エンコード例が分かる。
+        """
+        text = read_file(_STREAMING_SKILL)
+
+        assert "配信元 MP4 の実測" in text
+        assert "ffprobe" in text
+        assert "-c:v copy" in text
+        assert "4,500 Kbps" in text
+        assert "-profile:v high" in text
+        assert "1.52 TB" in text
+
 
 # ============================================================================
 # infra/terraform/streaming/README.md — #125 新規ドキュメント
@@ -140,6 +154,21 @@ class TestStreamingReadme:
         assert "TF_VAR_vultr_api_key" in text, (
             "README に TF_VAR_vultr_api_key の言及が無い（運用者が必要 env を網羅できない）"
         )
+
+    def test_documents_source_video_preflight(self):
+        """Given README
+        When 配信元動画のプリフライト説明を読む
+        Then ffprobe / -c:v copy / keyframe / bitrate / 推奨再エンコード例が記載されている。
+        """
+        text = read_file(_STREAMING_README)
+
+        assert "配信元動画のプリフライト" in text
+        assert "ffprobe" in text
+        assert "-c:v copy" in text
+        assert "キーフレーム最大間隔" in text
+        assert "4,500 Kbps" in text
+        assert "-profile:v high" in text
+        assert "1.52 TB" in text
 
     def test_mentions_op_read_for_secret_injection(self):
         """Given README

--- a/tests/streaming/test_skill_streaming.py
+++ b/tests/streaming/test_skill_streaming.py
@@ -107,12 +107,13 @@ class TestStreamingSkillSshAgent:
         """
         text = read_file(_STREAMING_SKILL)
 
-        assert "配信元 MP4 の実測" in text
+        assert "月間帯域見積もり用の MP4 実測" in text
         assert "ffprobe" in text
         assert "-c:v copy" in text
         assert "4,500 Kbps" in text
         assert "-profile:v high" in text
         assert "1.52 TB" in text
+        assert "preflight 合否は `terraform plan` / `apply` の stream-level 検証" in text
 
 
 # ============================================================================
@@ -169,6 +170,8 @@ class TestStreamingReadme:
         assert "4,500 Kbps" in text
         assert "-profile:v high" in text
         assert "1.52 TB" in text
+        assert "container 全体の平均 bitrate" in text
+        assert "preflight の合否確認は `terraform plan` / `apply` の stream-level 検証" in text
 
     def test_mentions_op_read_for_secret_injection(self):
         """Given README

--- a/tests/streaming/test_terraform_meta.py
+++ b/tests/streaming/test_terraform_meta.py
@@ -183,6 +183,42 @@ class TestVersionsTfNullProvider:
         )
 
 
+class TestVersionsTfExternalProvider:
+    """``versions.tf`` の ``required_providers.external`` 宣言（#1299）。"""
+
+    def test_required_providers_declares_external_source(self):
+        """Given versions.tf
+        When required_providers.external を読む
+        Then source = "hashicorp/external" が宣言されている。
+        """
+        text = strip_hcl_comments(read_file(_VERSIONS_TF))
+        terraform_block = extract_block(text, r"terraform")
+        assert terraform_block is not None
+        rp_block = extract_block(terraform_block, r"required_providers")
+        assert rp_block is not None, "required_providers ブロックが存在しない"
+        external_block = extract_block(rp_block, r"external")
+        assert external_block is not None, "required_providers.external が宣言されていない"
+        assert re.search(r'source\s*=\s*"hashicorp/external"', external_block), (
+            'required_providers.external.source が "hashicorp/external" でない'
+        )
+
+    def test_required_providers_external_version_at_least_2_3(self):
+        """Given versions.tf
+        When required_providers.external.version を読む
+        Then ">= 2.3" を含む制約が宣言されている。
+        """
+        text = strip_hcl_comments(read_file(_VERSIONS_TF))
+        terraform_block = extract_block(text, r"terraform")
+        assert terraform_block is not None
+        rp_block = extract_block(terraform_block, r"required_providers")
+        assert rp_block is not None
+        external_block = extract_block(rp_block, r"external")
+        assert external_block is not None
+        assert re.search(r'version\s*=\s*"[^"]*>=\s*2\.3', external_block), (
+            "required_providers.external.version が >= 2.3 を満たしていない"
+        )
+
+
 # ============================================================================
 # outputs.tf
 # ============================================================================

--- a/tests/streaming/test_variables_tf.py
+++ b/tests/streaming/test_variables_tf.py
@@ -118,18 +118,14 @@ class TestVariablesTfNullResource:
             "video_path には default を設定してはならない（環境依存・必須項目）"
         )
 
-    def test_source_video_preflight_enabled_variable_defaults_true(self):
+    def test_source_video_preflight_enabled_variable_does_not_exist(self):
         """Given variables.tf
         When source_video_preflight_enabled 変数定義を読む
-        Then type=bool, default=true, description に ffprobe soft skip が明記されている（#1299）。
+        Then preflight 契約を optional 化する変数は存在しない（#1299）。
         """
         text = strip_hcl_comments(read_file(_VARIABLES_TF))
         block = extract_block(text, r'variable\s+"source_video_preflight_enabled"')
-        assert block is not None, 'variable "source_video_preflight_enabled" が存在しない'
-        assert re.search(r"type\s*=\s*bool", block), "source_video_preflight_enabled.type が bool でない"
-        assert re.search(r"default\s*=\s*true", block), "source_video_preflight_enabled.default が true でない"
-        assert "ffprobe" in block, "description に ffprobe の説明が無い"
-        assert "soft skip" in block, "description に ffprobe 未インストール時の soft skip が明記されていない"
+        assert block is None, 'variable "source_video_preflight_enabled" で preflight を optional 化している'
 
     def test_install_root_is_string_with_default_youtube_stream_root(self):
         """Given variables.tf

--- a/tests/streaming/test_variables_tf.py
+++ b/tests/streaming/test_variables_tf.py
@@ -118,6 +118,19 @@ class TestVariablesTfNullResource:
             "video_path には default を設定してはならない（環境依存・必須項目）"
         )
 
+    def test_source_video_preflight_enabled_variable_defaults_true(self):
+        """Given variables.tf
+        When source_video_preflight_enabled 変数定義を読む
+        Then type=bool, default=true, description に ffprobe soft skip が明記されている（#1299）。
+        """
+        text = strip_hcl_comments(read_file(_VARIABLES_TF))
+        block = extract_block(text, r'variable\s+"source_video_preflight_enabled"')
+        assert block is not None, 'variable "source_video_preflight_enabled" が存在しない'
+        assert re.search(r"type\s*=\s*bool", block), "source_video_preflight_enabled.type が bool でない"
+        assert re.search(r"default\s*=\s*true", block), "source_video_preflight_enabled.default が true でない"
+        assert "ffprobe" in block, "description に ffprobe の説明が無い"
+        assert "soft skip" in block, "description に ffprobe 未インストール時の soft skip が明記されていない"
+
     def test_install_root_is_string_with_default_youtube_stream_root(self):
         """Given variables.tf
         When install_root 変数定義を読む

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -364,6 +364,42 @@ def test_check_video_warns_non_high_profile_without_hard_fail(monkeypatch, tmp_p
     assert "H.264 High is recommended" in result["profile_message"]
 
 
+def test_check_video_warns_h264_high_variant_profiles(monkeypatch, tmp_path):
+    """Given H.264 High 以外の High variant profile
+    When check_video を呼ぶ
+    Then substring match で H.264 High 扱いせず warning を返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    for profile in ("High 10", "High 4:2:2", "High 4:4:4 Predictive"):
+        monkeypatch.setattr(
+            module,
+            "_video_metadata",
+            lambda _path, profile=profile: (
+                {
+                    "codec_name": "h264",
+                    "profile": profile,
+                    "width": 1920,
+                    "height": 1080,
+                    "bit_rate": "4500000",
+                },
+                {"duration": "4.0"},
+            ),
+        )
+
+        result = module.check_video(video)
+
+        assert result["ok"] == "true"
+        assert result["status"] == "ok"
+        assert result["profile_ok"] == "false"
+        assert f"h264 / {profile}" in result["profile_message"]
+        assert "H.264 High is recommended" in result["profile_message"]
+
+
 def test_check_video_does_not_use_container_bitrate_for_video_bitrate(monkeypatch, tmp_path):
     """Given stream.bit_rate が無く format.bit_rate だけある動画
     When check_video を呼ぶ

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -135,10 +135,80 @@ def test_check_video_uses_duration_for_single_keyframe_interval(monkeypatch, tmp
     assert result["max_keyframe_interval_sec"] == "10.000"
 
 
+def test_check_video_fails_when_keyframe_interval_is_unavailable(monkeypatch, tmp_path):
+    """Given keyframe timestamp も duration も取得できない
+    When check_video を呼ぶ
+    Then 判定不能な keyframe 間隔を hard fail する。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "High",
+                "width": 1920,
+                "height": 1080,
+                "bit_rate": "4500000",
+            },
+            {},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "false"
+    assert "keyframe interval is unavailable" in result["message"]
+    assert result["max_keyframe_interval_sec"] == ""
+
+
+def test_check_video_enforces_1080p_bitrate_boundary_in_bps(monkeypatch, tmp_path):
+    """Given 1080p の bitrate 境界
+    When check_video を呼ぶ
+    Then 4,500,000 bps 未満は丸めず fail、以上は ok。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    def set_metadata(bit_rate: str):
+        monkeypatch.setattr(
+            module,
+            "_video_metadata",
+            lambda _path: (
+                {
+                    "codec_name": "h264",
+                    "profile": "High",
+                    "width": 1920,
+                    "height": 1080,
+                    "bit_rate": bit_rate,
+                },
+                {"duration": "4.0"},
+            ),
+        )
+
+    set_metadata("4499999")
+    low_result = module.check_video(video)
+    assert low_result["ok"] == "false"
+    assert "below 4500 Kbps" in low_result["message"]
+
+    set_metadata("4500000")
+    ok_result = module.check_video(video)
+    assert ok_result["ok"] == "true"
+    assert ok_result["required_bitrate_kbps"] == "4500"
+
+
 def test_check_video_enforces_720p_bitrate_boundary(monkeypatch, tmp_path):
     """Given 720p の bitrate 境界
     When check_video を呼ぶ
-    Then 2,500 Kbps 未満は fail、以上は ok。
+    Then 2,500,000 bps 未満は丸めず fail、以上は ok。
     """
     module = _load_module()
     video = tmp_path / "stream.mp4"
@@ -162,7 +232,7 @@ def test_check_video_enforces_720p_bitrate_boundary(monkeypatch, tmp_path):
             ),
         )
 
-    set_metadata("2499000")
+    set_metadata("2499999")
     low_result = module.check_video(video)
     assert low_result["ok"] == "false"
     assert "below 2500 Kbps" in low_result["message"]
@@ -171,6 +241,37 @@ def test_check_video_enforces_720p_bitrate_boundary(monkeypatch, tmp_path):
     ok_result = module.check_video(video)
     assert ok_result["ok"] == "true"
     assert ok_result["required_bitrate_kbps"] == "2500"
+
+
+def test_check_video_does_not_enforce_unlisted_low_resolution_bitrate(monkeypatch, tmp_path):
+    """Given 720p 未満の動画
+    When check_video を呼ぶ
+    Then 未定義の 1,500 Kbps 下限では fail しない。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "High",
+                "width": 854,
+                "height": 480,
+                "bit_rate": "1000000",
+            },
+            {"duration": "4.0"},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "true"
+    assert result["required_bitrate_kbps"] == ""
 
 
 def test_check_video_warns_non_high_profile_without_hard_fail(monkeypatch, tmp_path):

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -171,3 +171,66 @@ def test_check_video_enforces_720p_bitrate_boundary(monkeypatch, tmp_path):
     ok_result = module.check_video(video)
     assert ok_result["ok"] == "true"
     assert ok_result["required_bitrate_kbps"] == "2500"
+
+
+def test_check_video_warns_non_high_profile_without_hard_fail(monkeypatch, tmp_path):
+    """Given bitrate / keyframe は正常だが H.264 High ではない動画
+    When check_video を呼ぶ
+    Then hard fail せず profile warning だけ返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "Constrained Baseline",
+                "width": 1920,
+                "height": 1080,
+                "bit_rate": "4500000",
+            },
+            {"duration": "4.0"},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "true"
+    assert result["status"] == "ok"
+    assert result["profile_ok"] == "false"
+    assert "H.264 High is recommended" in result["profile_message"]
+
+
+def test_check_video_does_not_use_container_bitrate_for_video_bitrate(monkeypatch, tmp_path):
+    """Given stream.bit_rate が無く format.bit_rate だけある動画
+    When check_video を呼ぶ
+    Then container 全体の bitrate では合格させず hard fail する。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "High",
+                "width": 1920,
+                "height": 1080,
+            },
+            {"duration": "4.0", "bit_rate": "4600000"},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "false"
+    assert "video bitrate is unavailable" in result["message"]

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -1,0 +1,103 @@
+"""infra/terraform/streaming/video_preflight.py の判定ロジック検証（#1299）。"""
+
+from __future__ import annotations
+
+import importlib.util
+from types import ModuleType
+
+from tests.streaming._helpers import _VIDEO_PREFLIGHT_PY
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("streaming_video_preflight", _VIDEO_PREFLIGHT_PY)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_video_skips_when_ffprobe_missing(monkeypatch, tmp_path):
+    """Given ffprobe が PATH に無い
+    When check_video を呼ぶ
+    Then Terraform plan を壊さないよう ok=true / status=skipped を返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: None)
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "true"
+    assert result["status"] == "skipped"
+    assert "ffprobe not found" in result["message"]
+
+
+def test_check_video_fails_low_bitrate_and_long_keyframe_interval(monkeypatch, tmp_path):
+    """Given 1080p で bitrate 低すぎ + keyframe 間隔 8.3 秒
+    When check_video を呼ぶ
+    Then hard fail の ok=false を返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "Constrained Baseline",
+                "width": 1920,
+                "height": 1080,
+                "bit_rate": "1518000",
+            },
+            {},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 8.3, 16.6])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "false"
+    assert result["status"] == "failed"
+    assert "keyframe interval 8.30s exceeds 4s" in result["message"]
+    assert "video bitrate 1518 Kbps is below 4500 Kbps" in result["message"]
+    assert result["profile_ok"] == "false"
+    assert "H.264 High is recommended" in result["profile_message"]
+
+
+def test_check_video_accepts_1080p_h264_high_at_recommended_bitrate(monkeypatch, tmp_path):
+    """Given 1080p / H.264 High / 4.5 Mbps / keyframe 2 秒
+    When check_video を呼ぶ
+    Then ok=true を返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "High",
+                "width": 1920,
+                "height": 1080,
+                "bit_rate": "4500000",
+            },
+            {},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "true"
+    assert result["status"] == "ok"
+    assert result["profile_ok"] == "true"
+    assert result["required_bitrate_kbps"] == "4500"
+    assert result["max_keyframe_interval_sec"] == "2.000"

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+from pathlib import Path
 from types import ModuleType
 
 from tests.streaming._helpers import _VIDEO_PREFLIGHT_PY
@@ -32,6 +35,60 @@ def test_check_video_skips_when_ffprobe_missing(monkeypatch, tmp_path):
     assert result["ok"] == "true"
     assert result["status"] == "skipped"
     assert "ffprobe not found" in result["message"]
+
+
+def test_main_rejects_missing_empty_or_non_string_video_path(monkeypatch):
+    """Given Terraform external から不正な video_path が渡る
+    When main を呼ぶ
+    Then stdout JSON で failed を返す。
+    """
+    module = _load_module()
+
+    for query in ({}, {"video_path": ""}, {"video_path": 123}):
+        stdout = io.StringIO()
+        monkeypatch.setattr(module.sys, "stdin", io.StringIO(json.dumps(query)))
+        monkeypatch.setattr(module.sys, "stdout", stdout)
+
+        rc = module.main()
+        result = json.loads(stdout.getvalue())
+
+        assert rc == 0
+        assert result["ok"] == "false"
+        assert result["status"] == "failed"
+        assert result["message"] == "video_path is required."
+
+
+def test_main_passes_expanded_video_path_to_check_video(monkeypatch, tmp_path):
+    """Given Terraform external から valid な video_path が渡る
+    When main を呼ぶ
+    Then expanduser 済み Path を check_video に渡し stdout JSON を返す。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    seen: dict[str, Path] = {}
+
+    def fake_check_video(path: Path) -> dict[str, str]:
+        seen["path"] = path
+        return {
+            "ok": "true",
+            "status": "ok",
+            "message": "checked",
+            "profile_ok": "true",
+            "profile_message": "checked",
+        }
+
+    stdout = io.StringIO()
+    monkeypatch.setattr(module, "check_video", fake_check_video)
+    monkeypatch.setattr(module.sys, "stdin", io.StringIO(json.dumps({"video_path": str(video)})))
+    monkeypatch.setattr(module.sys, "stdout", stdout)
+
+    rc = module.main()
+    result = json.loads(stdout.getvalue())
+
+    assert rc == 0
+    assert seen["path"] == video.expanduser()
+    assert result["ok"] == "true"
+    assert result["message"] == "checked"
 
 
 def test_check_video_fails_low_bitrate_and_long_keyframe_interval(monkeypatch, tmp_path):

--- a/tests/streaming/test_video_preflight.py
+++ b/tests/streaming/test_video_preflight.py
@@ -54,7 +54,7 @@ def test_check_video_fails_low_bitrate_and_long_keyframe_interval(monkeypatch, t
                 "height": 1080,
                 "bit_rate": "1518000",
             },
-            {},
+            {"duration": "20.0"},
         ),
     )
     monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 8.3, 16.6])
@@ -89,7 +89,7 @@ def test_check_video_accepts_1080p_h264_high_at_recommended_bitrate(monkeypatch,
                 "height": 1080,
                 "bit_rate": "4500000",
             },
-            {},
+            {"duration": "4.0"},
         ),
     )
     monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
@@ -101,3 +101,73 @@ def test_check_video_accepts_1080p_h264_high_at_recommended_bitrate(monkeypatch,
     assert result["profile_ok"] == "true"
     assert result["required_bitrate_kbps"] == "4500"
     assert result["max_keyframe_interval_sec"] == "2.000"
+
+
+def test_check_video_uses_duration_for_single_keyframe_interval(monkeypatch, tmp_path):
+    """Given 10 秒尺で keyframe が冒頭 1 つだけ
+    When check_video を呼ぶ
+    Then duration 末尾までの間隔を見て hard fail する。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        module,
+        "_video_metadata",
+        lambda _path: (
+            {
+                "codec_name": "h264",
+                "profile": "High",
+                "width": 1920,
+                "height": 1080,
+                "bit_rate": "4500000",
+            },
+            {"duration": "10.0"},
+        ),
+    )
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0])
+
+    result = module.check_video(video)
+
+    assert result["ok"] == "false"
+    assert "keyframe interval 10.00s exceeds 4s" in result["message"]
+    assert result["max_keyframe_interval_sec"] == "10.000"
+
+
+def test_check_video_enforces_720p_bitrate_boundary(monkeypatch, tmp_path):
+    """Given 720p の bitrate 境界
+    When check_video を呼ぶ
+    Then 2,500 Kbps 未満は fail、以上は ok。
+    """
+    module = _load_module()
+    video = tmp_path / "stream.mp4"
+    video.write_bytes(b"fake")
+    monkeypatch.setattr(module.shutil, "which", lambda _cmd: "/usr/bin/ffprobe")
+    monkeypatch.setattr(module, "_keyframe_times", lambda _path: [0.0, 2.0, 4.0])
+
+    def set_metadata(bit_rate: str):
+        monkeypatch.setattr(
+            module,
+            "_video_metadata",
+            lambda _path: (
+                {
+                    "codec_name": "h264",
+                    "profile": "High",
+                    "width": 1280,
+                    "height": 720,
+                    "bit_rate": bit_rate,
+                },
+                {"duration": "4.0"},
+            ),
+        )
+
+    set_metadata("2499000")
+    low_result = module.check_video(video)
+    assert low_result["ok"] == "false"
+    assert "below 2500 Kbps" in low_result["message"]
+
+    set_metadata("2500000")
+    ok_result = module.check_video(video)
+    assert ok_result["ok"] == "true"
+    assert ok_result["required_bitrate_kbps"] == "2500"


### PR DESCRIPTION
## Summary
- Add Terraform external ffprobe preflight for streaming source MP4s
- Fail plan/apply for long keyframe intervals or bitrate below YouTube baseline thresholds
- Warn on non-H.264 High profile and document source video requirements / re-encode command

## Tests
- `uv run ruff check infra/terraform/streaming/video_preflight.py tests/streaming/test_video_preflight.py`
- `terraform -chdir=infra/terraform/streaming validate`
- `uv run pytest tests/streaming/test_video_preflight.py tests/streaming/test_main_tf.py tests/streaming/test_variables_tf.py tests/streaming/test_terraform_meta.py tests/streaming/test_skill_streaming.py -q`

Closes #1299