### PR TITLE
[#1313] issue-1313-upload-preflight-no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(masterup)`: Suno 生成後の 2 clip を `20-documentation/suno-prompts.json` の歌詞有無で整理する `yt-suno-select-tracks` を追加。歌詞あり prompt は 1 clip 採用、instrumental は 2 clip 採用とし、極端に短い/長い失敗生成を stock 退避または削除できるようにした（#1308）
 - `docs(wf-new)`: `/wf-new` を子スキル順次実行のオーケストレーターとして整理し、Suno チャンネルでは `yt-collection-serve` 起動と疎通確認まで行って `/suno-helper` に引き継ぐ導線を追加（#1308）
 
+### Fixed
+
+- `fix(upload)`: upload preflight が `audio.target_duration_min/max` を秒単位として誤判定していた master 動画尺チェックを無効化（#1313）
+
 ### Migration
 
 所要時間の目安: 5〜10 分

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -16,14 +16,12 @@ from youtube_automation.utils.config import load_config
 from youtube_automation.utils.preflight_checks import (
     check_chapter_count,
     check_chapter_variation_suffix,
-    check_duration,
     check_low_cpm_localization_languages,
     check_tags_count,
     check_tags_yt_chars,
     check_title_template_compliance,
     extract_descriptions_md_tags,
 )
-from youtube_automation.utils.probe import probe_duration
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +67,7 @@ class PreflightMixin:
         4. タイトルが 100 codepoint 以内（YouTube 制限）
         5. タグ件数が `tags.min_count` を満たすこと（戦略書違反防止）
         6. タグの quotation 込み文字数が YouTube の 500 制限内
-        7. master 動画尺が `audio.target_duration_min/max` 範囲内
-        8. supported_languages に低 CPM 警告対象言語が含まれる場合は warning を出すこと
+        7. supported_languages に低 CPM 警告対象言語が含まれる場合は warning を出すこと
         """
         paths = CollectionPaths(collection_dir)
         desc_path = paths.descriptions_md_path
@@ -141,21 +138,8 @@ class PreflightMixin:
             if msg:
                 issues.append(msg)
 
-        # 動画尺チェック（target_duration が設定済みかつ master mp4 が存在する場合のみ）
-        if config.audio.target_duration_min is not None or config.audio.target_duration_max is not None:
-            master_video = paths.find_master_video()
-            if master_video:
-                dur = probe_duration(master_video)
-                if dur is None:
-                    issues.append(f"duration probe failed for {master_video.name}")
-                else:
-                    msg = check_duration(
-                        dur,
-                        config.audio.target_duration_min,
-                        config.audio.target_duration_max,
-                    )
-                    if msg:
-                        issues.append(msg)
+        # `audio.target_duration_min/max` は master 生成側では分単位として扱うため、
+        # 秒単位の preflight duration gate には使わない (#1313)。
 
         if issues:
             raise RuntimeError("❌ preflight failed:\n  - " + "\n  - ".join(issues))

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -27,7 +27,13 @@ def _write_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data), encoding="utf-8")
 
 
-def _write_minimal_channel(tmp_path: Path, *, youtube_language: str, supported_languages: list[str]) -> Path:
+def _write_minimal_channel(
+    tmp_path: Path,
+    *,
+    youtube_language: str,
+    supported_languages: list[str],
+    audio: dict[str, float | int] | None = None,
+) -> Path:
     channel_dir = tmp_path / "channel"
     _write_json(
         channel_dir / "config" / "channel" / "meta.json",
@@ -70,6 +76,8 @@ def _write_minimal_channel(tmp_path: Path, *, youtube_language: str, supported_l
         channel_dir / "config" / "localizations.json",
         {"supported_languages": supported_languages, "languages": {}},
     )
+    if audio is not None:
+        _write_json(channel_dir / "config" / "channel" / "audio.json", {"audio": audio})
     return channel_dir
 
 
@@ -148,3 +156,25 @@ def test_low_cpm_localization_warning_still_runs(
     _run_preflight(channel_dir, collection_dir, monkeypatch)
 
     assert "low CPM localization languages included: ko" in caplog.text
+
+
+def test_target_duration_config_does_not_block_upload_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel_dir = _write_minimal_channel(
+        tmp_path,
+        youtube_language="en",
+        supported_languages=["en"],
+        audio={"target_duration_min": 60, "target_duration_max": 120},
+    )
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "continuous focus mix"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+    master_dir = collection_dir / "01-master"
+    master_dir.mkdir(parents=True)
+    (master_dir / "master.mp4").write_bytes(b"not a valid mp4")
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)


### PR DESCRIPTION
## Summary

## 概要
upload preflight の動画尺チェックが `audio.target_duration_min/max` を秒として扱っており、設定値 60〜120 分を 1〜2 分目標として誤判定している。`yt-generate-master` 側は同じ値を分として扱っているため単位が不整合になっており、壊れた preflight チェックを無効化する。

## 背景・目的
78 分程度の BGM に対して、preflight が `target 1m〜2m` のような誤った目標尺を表示して失敗する。既にマスター生成は完了済みであり、問題はアップロード前 preflight の誤検知に限定される。

## 再現手順
1. `config/channel/audio.json` で `target_duration_min: 60` / `target_duration_max: 120` を設定する。
2. 約 78 分の master 動画を用意する。
3. upload preflight を実行する。
4. `PreflightMixin._preflight_check()` が `check_duration(dur, 60, 120)` を呼び、60〜120 秒目標として判定する。

## 期待される動作
60〜120 は分単位の目標尺として扱われるか、少なくとも upload preflight ではこの壊れた尺チェックによりブロックされない。

## 実際の動作
preflight が `audio.target_duration_min/max` を秒として扱い、約 78 分の動画を 1〜2 分目標から外れているとして失敗させる。

## 影響範囲
- `audio.target_duration_min/max` を設定しているチャンネルの upload preflight が誤って失敗する。
- `yt-generate-master` は同じ値を分として扱っているため、master 生成済みの成果物自体には影響しない。

## 参照資料
- src/youtube_automation/agents/_preflight.py
- src/youtube_automation/utils/preflight_checks.py
- src/youtube_automation/scripts/generate_master.py
- tests/test_preflight_checks.py
- examples/channel_config.example/audio.json

## 影響ファイル
- **変更**: src/youtube_automation/agents/_preflight.py
- **変更**: tests/test_preflight_checks.py

## 要件
1. upload preflight から `audio.target_duration_min/max` に基づく master 動画尺チェックを無効化する。
2. `yt-generate-master` 側の `target_duration_min` を分として扱う既存挙動は変更しない。
3. `check_duration()` の既存ユーティリティ挙動は、他用途への影響を避けるため原則変更しない。
4. upload preflight が `target_duration_min/max` 設定済みでも動画尺だけを理由に失敗しないことをテストで確認する。
5. コメントまたは docstring に、当該 preflight チェックを無効化した理由が分かる最低限の説明を残す。

## スコープ外
- `audio.target_duration_min/max` の単位定義を全コードベースで再設計・リネームすることは本 issue では扱わない。
- 既存チャンネル設定の migration は本 issue では扱わない。
- master 生成済みファイルの再生成や動画成果物の修正は本 issue では扱わない。

## 受け入れ基準
- [ ] `audio.target_duration_min/max` が設定されていても upload preflight が動画尺チェックで失敗しない。
- [ ] `yt-generate-master` の分単位解釈に関する既存テストが壊れない。
- [ ] 関連テストが通る。

## 実装方針（takt）
- workflow: default-mini
- 理由: 小規模な bugfix で、影響ファイルは少数。既存 preflight テストに回帰ケースを追加して確認できるため。

## Execution Report

Workflow `default-mini` completed successfully.

Closes #1313