### PR TITLE
fix(metadata-generator): M4A 尺取得を ffprobe fallback する (#1323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(cost)`: Windows 環境で `fcntl` がない場合も `cost_tracker` と `yt-generate-image` が起動できるよう、`msvcrt` / プロセス内 lock fallback を追加（#1315）
 - `fix(upload)`: upload preflight が `audio.target_duration_min/max` を秒単位として誤判定していた master 動画尺チェックを無効化（#1313）
+- `fix(metadata-generator)`: `BAHMetadataGenerator` の音声尺取得に `ffprobe` fallback を追加し、Suno 由来の `.m4a` が `afinfo` 失敗だけで 0 秒扱いされないようにした（#1323）
 
 ### Migration
 

--- a/src/youtube_automation/utils/metadata_generator.py
+++ b/src/youtube_automation/utils/metadata_generator.py
@@ -4,7 +4,7 @@ YouTube メタデータ自動生成ユーティリティ
 collections/ ディレクトリの構造を解析し、YouTube用メタデータを自動生成
 
 Features:
-- WAVファイル自動解析（afinfo使用）
+- 音声ファイル自動解析（afinfo / ffprobe 使用）
 - タイムスタンプ自動計算
 - config/channel/*.json ベースのテンプレート適用
 """
@@ -21,14 +21,14 @@ from typing import Dict, List
 
 import yaml
 
+from youtube_automation.utils.audio_formats import AUDIO_EXTS
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
 from youtube_automation.utils.exceptions import ValidationError
-
-from .audio_formats import AUDIO_EXTS
-from .skill_config import load_skill_config
-from .time_utils import format_duration_display, format_duration_short, format_timestamp
-from .youtube_tag import normalize_youtube_tags
+from youtube_automation.utils.probe import probe_duration
+from youtube_automation.utils.skill_config import load_skill_config
+from youtube_automation.utils.time_utils import format_duration_display, format_duration_short, format_timestamp
+from youtube_automation.utils.youtube_tag import normalize_youtube_tags
 
 logger = logging.getLogger(__name__)
 
@@ -381,10 +381,10 @@ class BAHMetadataGenerator:
 
     def _get_audio_duration(self, wav_file: Path) -> int:
         """
-        afinfo コマンドで音声ファイルの長さを取得
+        afinfo / ffprobe で音声ファイルの長さを取得
 
         Args:
-            wav_file (Path): WAVファイルパス
+            wav_file (Path): 音声ファイルパス
 
         Returns:
             int: 長さ（秒）
@@ -395,21 +395,35 @@ class BAHMetadataGenerator:
             ValueError: duration 文字列の数値変換に失敗した場合
             IndexError: afinfo 出力のパースに失敗した場合
         """
-        result = subprocess.run(
-            ["afinfo", str(wav_file)],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        )
+        afinfo_error: Exception | None = None
+        try:
+            result = subprocess.run(
+                ["afinfo", str(wav_file)],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
 
-        # "estimated duration: XXX.XXX seconds" を抽出
-        for line in result.stdout.split("\n"):
-            if "estimated duration" in line:
-                duration_str = line.split(":")[1].strip().split()[0]
-                return int(float(duration_str))
+            # "estimated duration: XXX.XXX seconds" を抽出
+            for line in result.stdout.split("\n"):
+                if "estimated duration" in line:
+                    duration_str = line.split(":")[1].strip().split()[0]
+                    afinfo_duration = float(duration_str)
+                    if afinfo_duration > 0:
+                        return max(1, int(afinfo_duration))
+                    break
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, IndexError, OSError) as e:
+            afinfo_error = e
 
-        logger.warning(f"afinfo 出力に 'estimated duration' が見つかりません: {wav_file.name}")
+        duration = probe_duration(wav_file)
+        if duration is not None and duration > 0:
+            return max(1, int(duration))
+
+        if afinfo_error is not None:
+            raise afinfo_error
+
+        logger.warning(f"音声 duration を取得できませんでした: {wav_file.name}")
         return 0
 
     def _clean_track_title(self, filename: str) -> str:

--- a/src/youtube_automation/utils/probe.py
+++ b/src/youtube_automation/utils/probe.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+DEFAULT_FFPROBE_TIMEOUT_SECONDS = 30
+
 
 def probe_duration(path: Path) -> float | None:
     """ffprobe で動画/音声ファイルの再生秒数を取得する。失敗時は None."""
@@ -24,9 +26,10 @@ def probe_duration(path: Path) -> float | None:
             capture_output=True,
             text=True,
             check=True,
+            timeout=DEFAULT_FFPROBE_TIMEOUT_SECONDS,
         )
         return float(result.stdout.strip())
-    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, FileNotFoundError):
         return None
 
 
@@ -52,7 +55,8 @@ def probe_bitrate(path: Path) -> float | None:
             capture_output=True,
             text=True,
             check=True,
+            timeout=DEFAULT_FFPROBE_TIMEOUT_SECONDS,
         )
         return float(result.stdout.strip())
-    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, FileNotFoundError):
         return None

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 import yaml
 
+from youtube_automation.utils import metadata_generator as metadata_generator_module
 from youtube_automation.utils.config import load_config
 from youtube_automation.utils.exceptions import ValidationError
 from youtube_automation.utils.metadata_generator import (
@@ -1300,6 +1301,7 @@ class TestAnalyzeAudioFilesSkipDetection:
             return _original_run(cmd, **kwargs)
 
         monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: None)
 
         import logging
 
@@ -1310,6 +1312,133 @@ class TestAnalyzeAudioFilesSkipDetection:
         assert "トラックをスキップ" in caplog.text
         assert "02-broken.wav" in caplog.text
         assert "ファイル解析エラー" in caplog.text
+
+    def test_m4a_uses_probe_duration_when_afinfo_fails(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-circuit-door.m4a").write_bytes(b"\x00" * 100)
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                raise _subprocess.CalledProcessError(1, "afinfo", "unsupported file")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: 121.9)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-circuit-door.m4a"
+        assert tracks[0]["duration"] == 121
+        assert "再生時間が 0 秒" not in caplog.text
+        assert "入力 1 ファイル → 出力 0 タイムスタンプ" not in caplog.text
+
+    def test_m4a_probe_duration_subsecond_is_kept_as_one_second(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-circuit-door.m4a").write_bytes(b"\x00" * 100)
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                raise _subprocess.CalledProcessError(1, "afinfo", "unsupported file")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: 0.9)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-circuit-door.m4a"
+        assert tracks[0]["duration"] == 1
+        assert "再生時間が 0 秒" not in caplog.text
+        assert "入力 1 ファイル → 出力 0 タイムスタンプ" not in caplog.text
+
+    def test_m4a_uses_probe_duration_when_afinfo_has_no_estimated_duration(
+        self, gen_with_audio_dir, caplog, monkeypatch
+    ):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-circuit-door.m4a").write_bytes(b"\x00" * 100)
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                return _subprocess.CompletedProcess(cmd, 0, stdout="no estimated duration\n", stderr="")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: 121.9)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-circuit-door.m4a"
+        assert tracks[0]["duration"] == 121
+        assert "再生時間が 0 秒" not in caplog.text
+        assert "入力 1 ファイル → 出力 0 タイムスタンプ" not in caplog.text
+
+    def test_m4a_uses_probe_duration_when_afinfo_duration_is_malformed(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-circuit-door.m4a").write_bytes(b"\x00" * 100)
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                return _subprocess.CompletedProcess(cmd, 0, stdout="estimated duration: unknown seconds\n", stderr="")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: 121.9)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-circuit-door.m4a"
+        assert tracks[0]["duration"] == 121
+        assert "再生時間が 0 秒" not in caplog.text
+        assert "入力 1 ファイル → 出力 0 タイムスタンプ" not in caplog.text
+
+    def test_m4a_uses_probe_duration_when_afinfo_reports_zero(self, gen_with_audio_dir, caplog, monkeypatch):
+        gen, audio_dir = gen_with_audio_dir
+        (audio_dir / "01-circuit-door.m4a").write_bytes(b"\x00" * 100)
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                return _subprocess.CompletedProcess(cmd, 0, stdout="estimated duration: 0.0 seconds\n", stderr="")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", lambda path: 121.9)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            tracks = gen.analyze_audio_files()
+
+        assert len(tracks) == 1
+        assert tracks[0]["filename"] == "01-circuit-door.m4a"
+        assert tracks[0]["duration"] == 121
+        assert "再生時間が 0 秒" not in caplog.text
+        assert "入力 1 ファイル → 出力 0 タイムスタンプ" not in caplog.text
 
     def test_count_mismatch_warning(self, gen_with_audio_dir, caplog, monkeypatch):
         gen, audio_dir = gen_with_audio_dir

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -10,11 +10,15 @@ from youtube_automation.utils import probe
 
 
 def test_returns_float_on_success(monkeypatch) -> None:
+    captured: dict = {}
+
     def fake_run(cmd, **kwargs):
+        captured["kwargs"] = kwargs
         return SimpleNamespace(stdout="123.45\n")
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
     assert probe.probe_duration(Path("/fake.mp3")) == 123.45
+    assert captured["kwargs"]["timeout"] == probe.DEFAULT_FFPROBE_TIMEOUT_SECONDS
 
 
 def test_returns_none_when_ffprobe_missing(monkeypatch) -> None:
@@ -28,6 +32,14 @@ def test_returns_none_when_ffprobe_missing(monkeypatch) -> None:
 def test_returns_none_on_subprocess_error(monkeypatch) -> None:
     def fake_run(cmd, **kwargs):
         raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) is None
+
+
+def test_returns_none_on_timeout(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, timeout=kwargs.get("timeout"))
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
     assert probe.probe_duration(Path("/fake.mp3")) is None
@@ -53,6 +65,7 @@ def test_probe_bitrate_returns_bps_on_success(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
         return SimpleNamespace(stdout="4000000\n")
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
@@ -60,6 +73,7 @@ def test_probe_bitrate_returns_bps_on_success(monkeypatch) -> None:
     assert got == 4_000_000.0
     # 正しい ffprobe entry を要求していること
     assert "format=bit_rate" in " ".join(captured["cmd"])
+    assert captured["kwargs"]["timeout"] == probe.DEFAULT_FFPROBE_TIMEOUT_SECONDS
 
 
 def test_probe_bitrate_returns_none_when_ffprobe_missing(monkeypatch) -> None:
@@ -83,6 +97,14 @@ def test_probe_bitrate_returns_none_on_subprocess_error(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_bitrate(Path("/fake.mp4")) is None
+
+
+def test_probe_bitrate_returns_none_on_timeout(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, timeout=kwargs.get("timeout"))
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
     assert probe.probe_bitrate(Path("/fake.mp4")) is None

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -737,6 +737,82 @@ class TestUploadCompleteCollectionDedup:
         assert result["video_id"] == "VID_NEW"
         assert result["upload_source"] == "new_upload"
 
+    def test_prebuilt_upload_keeps_localization_timestamps_when_m4a_needs_probe_fallback(self, tmp_path, monkeypatch):
+        """#1323: prebuilt upload 経路でも `.m4a` fallback 後の timestamp を localizations に渡す."""
+        from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+        from youtube_automation.utils import metadata_generator as metadata_generator_module
+        from youtube_automation.utils.config import load_config
+        from youtube_automation.utils.metadata_generator import BAHMetadataGenerator
+
+        col_dir = tmp_path / "20990101-live-circuit-collection"
+        (col_dir / "01-master").mkdir(parents=True)
+        (col_dir / "01-master" / "video-master.mp4").write_bytes(b"\x00")
+        (col_dir / "02-Individual-music").mkdir()
+        (col_dir / "02-Individual-music" / "01-circuit-door.m4a").write_bytes(b"\x00")
+        (col_dir / "10-assets").mkdir()
+        (col_dir / "10-assets" / "thumbnail.jpg").write_bytes(b"\x00")
+        (col_dir / "20-documentation").mkdir()
+        (col_dir / "20-documentation" / "descriptions.md").write_text(
+            "\n".join(
+                [
+                    "## タイトル案",
+                    "```",
+                    "Circuit Collection",
+                    "```",
+                    "",
+                    "## Complete Collection 概要欄",
+                    "```",
+                    "00:00 Curated Circuit Door",
+                    "```",
+                    "",
+                    "## タグ（YouTube タグ欄）",
+                    "```",
+                    "circuit music, focus music",
+                    "```",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        config = load_config()
+        scene_phrases = {lang: f"quiet circuit room {lang}" for lang in config.localizations.supported_languages}
+        (col_dir / "workflow-state.json").write_text(
+            json.dumps({"scene_phrases": scene_phrases}),
+            encoding="utf-8",
+        )
+
+        import subprocess as _subprocess
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if cmd and cmd[0] == "afinfo":
+                raise _subprocess.CalledProcessError(1, "afinfo", "unsupported file")
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        probe_calls: list[Path] = []
+
+        def fake_probe_duration(path: Path) -> float:
+            probe_calls.append(path)
+            return 121.9
+
+        monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(metadata_generator_module, "probe_duration", fake_probe_duration)
+
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        metadata_gen = BAHMetadataGenerator(str(col_dir))
+        with (
+            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader, "upload_video", return_value="VID_NEW") as mock_upload_video,
+        ):
+            result = uploader._upload_complete_collection(col_dir, metadata_gen, publish_at=None)
+
+        assert result["video_id"] == "VID_NEW"
+        assert probe_calls == [col_dir / "02-Individual-music" / "01-circuit-door.m4a"]
+        metadata = mock_upload_video.call_args.args[1]
+        assert metadata["description"] == "00:00 Curated Circuit Door"
+        assert "localizations" in metadata
+        assert metadata["localizations"]
+        for loc in metadata["localizations"].values():
+            assert "00:00 Curated Circuit Door" in loc["description"]
+
     def test_should_fail_loud_when_upload_thumbnail_missing(self, tmp_path):
         """#1310: main.* は動画背景なので upload thumbnail 欠落を隠さない。"""
         from youtube_automation.utils.exceptions import ValidationError


### PR DESCRIPTION
## Summary
- `BAHMetadataGenerator` の duration 取得で `afinfo` 失敗時に `probe_duration()` / ffprobe fallback を使うように変更
- `.m4a` が `afinfo` 失敗だけで 0 秒扱いされない回帰テストを追加
- Unreleased changelog に修正内容を追記

## Tests
- `uv run pytest tests/test_metadata_generator.py -q`
- `uv run pytest -q`
- `uv run ruff check src/youtube_automation/utils/metadata_generator.py tests/test_metadata_generator.py`
- `uv run ruff format --check src/youtube_automation/utils/metadata_generator.py tests/test_metadata_generator.py`

Fixes #1323