### PR TITLE
test: playlist初期化契約のレビュー残件を固定する (#1314)

### DIFF
--- a/tests/test_skill_docs_consistency.py
+++ b/tests/test_skill_docs_consistency.py
@@ -183,6 +183,9 @@ def test_first_post_playlist_initialization_contract_is_documented() -> None:
         assert command in wf_next
         assert command in checklist
 
+    assert "/playlist" in channel_new
+    assert "`yt-playlist-status` → `yt-playlist-manager --init --dry-run` → `--init`" in channel_new
+
     for text in (playlist, video_upload, wf_next, channel_new, checklist):
         assert "playlist_id" in text
         assert "自動 assign" in text
@@ -194,6 +197,8 @@ def test_first_post_playlist_initialization_contract_is_documented() -> None:
     assert "確認を省略しない" in wf_next
     assert "ユーザーが playlist 初期化を却下した場合" in wf_next
     assert "`/video-upload` を実行せず停止" in wf_next
+    assert "`config/channel/playlists.json` が無い" in wf_next
+    assert "全 playlist に `playlist_id` がある場合はスキップ" in wf_next
     assert "初投稿プレイリスト初期化ゲート" in wf_next
     assert "`upload.video_id = null`" in wf_next
     assert "初回動画の追加は `/video-upload` 内部の自動 assign に任せる" in checklist


### PR DESCRIPTION
## Summary
- PR #1316 の takt review final follow-up で指摘された契約テスト不足を補強
- `/channel-new` の初投稿前 `/playlist` 導線と playlist init コマンドを直接 assert
- `/wf-next` の playlist 設定なし / 全 `playlist_id` 設定済み時の skip 契約を直接 assert

## Verification
- `uv run pytest tests/test_skill_docs_consistency.py tests/test_skill_frontmatter_yaml.py`
- `git diff --check`

Refs #1314