### PR TITLE
fix: descriptions.md 見出し不一致時の案内を改善 (#1340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(upload)`: `descriptions.md` の見出し不一致時に、期待する見出し一覧・不足/不一致の見出し・検出済み見出し・修正例を表示するよう改善（#1340）
 - `fix(cost)`: Windows 環境で `fcntl` がない場合も `cost_tracker` と `yt-generate-image` が起動できるよう、`msvcrt` / プロセス内 lock fallback を追加（#1315）
 - `fix(upload)`: upload preflight が `audio.target_duration_min/max` を秒単位として誤判定していた master 動画尺チェックを無効化（#1313）
 

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -41,10 +41,20 @@ def _format_heading_list(headings: Sequence[str]) -> str:
     return "\n".join(f"  - ## {heading}" for heading in headings)
 
 
-def _build_descriptions_md_parse_diagnostics(text: str, missing_headings: Sequence[str]) -> str:
+def _missing_descriptions_md_headings(text: str) -> list[str]:
+    """期待する `descriptions.md` 見出しのうち、抽出できないものを返す."""
+    return [
+        heading
+        for heading in _DESCRIPTIONS_MD_EXPECTED_HEADINGS
+        if extract_descriptions_md_section(text, heading) is None
+    ]
+
+
+def _build_descriptions_md_parse_diagnostics(text: str, missing_headings: Sequence[str] | None = None) -> str:
     """descriptions.md の見出し不一致を人間が直せる形で説明する."""
     found_headings = _extract_level2_headings(text)
-    missing = list(dict.fromkeys(missing_headings))
+    missing_source = missing_headings if missing_headings is not None else _missing_descriptions_md_headings(text)
+    missing = list(dict.fromkeys(missing_source))
     return "\n".join(
         [
             "期待する見出し（完全一致）:",
@@ -99,22 +109,14 @@ class DescriptionsMdMixin:
 
         text = desc_path.read_text(encoding="utf-8")
 
-        title = self._extract_md_section(text, "タイトル案")
-        description = self._extract_md_section(text, "Complete Collection 概要欄")
-        tags_raw = self._extract_md_section(text, "タグ（YouTube タグ欄）")
+        title = extract_descriptions_md_section(text, "タイトル案")
+        description = extract_descriptions_md_section(text, "Complete Collection 概要欄")
+        tags_raw = extract_descriptions_md_section(text, "タグ（YouTube タグ欄）")
 
         if not (title and description):
-            parsed_sections = {
-                "タイトル案": title,
-                "Complete Collection 概要欄": description,
-                "タグ（YouTube タグ欄）": tags_raw,
-            }
-            missing_headings = [
-                heading for heading in _DESCRIPTIONS_MD_EXPECTED_HEADINGS if parsed_sections.get(heading) is None
-            ]
             logger.warning(
                 "⚠️  descriptions.md のパースに失敗 — 正規フォーマットとして読み込めません\n%s",
-                _build_descriptions_md_parse_diagnostics(text, missing_headings),
+                _build_descriptions_md_parse_diagnostics(text),
             )
             return None
 
@@ -137,6 +139,11 @@ class DescriptionsMdMixin:
     @staticmethod
     def _extract_md_section(text: str, heading: str) -> str | None:
         """Markdown の ## heading 直後のコードフェンス内容を抽出"""
-        pattern = rf"## {re.escape(heading)}\s*\n+```\n(.*?)```"
-        m = re.search(pattern, text, re.DOTALL)
-        return m.group(1).strip() if m else None
+        return extract_descriptions_md_section(text, heading)
+
+
+def extract_descriptions_md_section(text: str, heading: str) -> str | None:
+    """Markdown の ## heading 直後のコードフェンス内容を抽出する."""
+    pattern = rf"## {re.escape(heading)}\s*\n+```\n(.*?)```"
+    m = re.search(pattern, text, re.DOTALL)
+    return m.group(1).strip() if m else None

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -7,78 +7,17 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Sequence
 from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
+from youtube_automation.utils.descriptions_md import (
+    DESCRIPTIONS_MD_RECREATE_GUIDE,
+    build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.youtube_tag import parse_youtube_tags
 
 logger = logging.getLogger(__name__)
-
-_DESCRIPTIONS_MD_EXPECTED_HEADINGS = (
-    "タイトル案",
-    "Complete Collection 概要欄",
-    "タグ（YouTube タグ欄）",
-)
-
-_DESCRIPTIONS_MD_RECREATE_GUIDE = (
-    "→ 手書きファイルを直接直すのではなく、正規フローで作り直してください:\n"
-    "  1. /video-description を再実行する\n"
-    "  2. 生成された 20-documentation/descriptions.md を確認する\n"
-    "  3. 必要なら生成後の本文だけを調整してから再アップロードする\n"
-    "  必須セクション: `## タイトル案` / `## Complete Collection 概要欄` / `## タグ（YouTube タグ欄）`"
-)
-
-
-def _extract_level2_headings(text: str) -> list[str]:
-    """descriptions.md 内の `##` 見出しを出現順で返す."""
-    return [match.group(1).strip() for match in re.finditer(r"^##\s+(.+?)\s*$", text, re.MULTILINE)]
-
-
-def _format_heading_list(headings: Sequence[str]) -> str:
-    if not headings:
-        return "  - (なし)"
-    return "\n".join(f"  - ## {heading}" for heading in headings)
-
-
-def _missing_descriptions_md_headings(text: str) -> list[str]:
-    """期待する `descriptions.md` 見出しのうち、抽出できないものを返す."""
-    return [
-        heading
-        for heading in _DESCRIPTIONS_MD_EXPECTED_HEADINGS
-        if extract_descriptions_md_section(text, heading) is None
-    ]
-
-
-def _build_descriptions_md_parse_diagnostics(text: str, missing_headings: Sequence[str] | None = None) -> str:
-    """descriptions.md の見出し不一致を人間が直せる形で説明する."""
-    found_headings = _extract_level2_headings(text)
-    missing_source = missing_headings if missing_headings is not None else _missing_descriptions_md_headings(text)
-    missing = list(dict.fromkeys(missing_source))
-    return "\n".join(
-        [
-            "期待する見出し（完全一致）:",
-            _format_heading_list(_DESCRIPTIONS_MD_EXPECTED_HEADINGS),
-            "不足/不一致の見出し:",
-            _format_heading_list(missing),
-            "検出した ## 見出し:",
-            _format_heading_list(found_headings),
-            "修正例:",
-            "  ## タイトル案",
-            "  ```",
-            "  公開タイトル",
-            "  ```",
-            "  ## Complete Collection 概要欄",
-            "  ```",
-            "  概要欄本文",
-            "  ```",
-            "  ## タグ（YouTube タグ欄）",
-            "  ```",
-            "  tag one, tag two",
-            "  ```",
-            _DESCRIPTIONS_MD_RECREATE_GUIDE,
-        ]
-    )
 
 
 class DescriptionsMdMixin:
@@ -103,7 +42,7 @@ class DescriptionsMdMixin:
                     f"descriptions.md が無いのに別名ファイルが存在します: "
                     f"{[p.name for p in stray]}\n"
                     f"→ ファイル名は `descriptions.md` 固定です。\n"
-                    f"{_DESCRIPTIONS_MD_RECREATE_GUIDE}"
+                    f"{DESCRIPTIONS_MD_RECREATE_GUIDE}"
                 )
             return None
 
@@ -116,7 +55,7 @@ class DescriptionsMdMixin:
         if not (title and description):
             logger.warning(
                 "⚠️  descriptions.md のパースに失敗 — 正規フォーマットとして読み込めません\n%s",
-                _build_descriptions_md_parse_diagnostics(text),
+                build_descriptions_md_parse_diagnostics(text),
             )
             return None
 
@@ -140,10 +79,3 @@ class DescriptionsMdMixin:
     def _extract_md_section(text: str, heading: str) -> str | None:
         """Markdown の ## heading 直後のコードフェンス内容を抽出"""
         return extract_descriptions_md_section(text, heading)
-
-
-def extract_descriptions_md_section(text: str, heading: str) -> str | None:
-    """Markdown の ## heading 直後のコードフェンス内容を抽出する."""
-    pattern = rf"## {re.escape(heading)}\s*\n+```\n(.*?)```"
-    m = re.search(pattern, text, re.DOTALL)
-    return m.group(1).strip() if m else None

--- a/src/youtube_automation/agents/_descriptions_md.py
+++ b/src/youtube_automation/agents/_descriptions_md.py
@@ -7,12 +7,19 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Sequence
 from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.youtube_tag import parse_youtube_tags
 
 logger = logging.getLogger(__name__)
+
+_DESCRIPTIONS_MD_EXPECTED_HEADINGS = (
+    "タイトル案",
+    "Complete Collection 概要欄",
+    "タグ（YouTube タグ欄）",
+)
 
 _DESCRIPTIONS_MD_RECREATE_GUIDE = (
     "→ 手書きファイルを直接直すのではなく、正規フローで作り直してください:\n"
@@ -21,6 +28,47 @@ _DESCRIPTIONS_MD_RECREATE_GUIDE = (
     "  3. 必要なら生成後の本文だけを調整してから再アップロードする\n"
     "  必須セクション: `## タイトル案` / `## Complete Collection 概要欄` / `## タグ（YouTube タグ欄）`"
 )
+
+
+def _extract_level2_headings(text: str) -> list[str]:
+    """descriptions.md 内の `##` 見出しを出現順で返す."""
+    return [match.group(1).strip() for match in re.finditer(r"^##\s+(.+?)\s*$", text, re.MULTILINE)]
+
+
+def _format_heading_list(headings: Sequence[str]) -> str:
+    if not headings:
+        return "  - (なし)"
+    return "\n".join(f"  - ## {heading}" for heading in headings)
+
+
+def _build_descriptions_md_parse_diagnostics(text: str, missing_headings: Sequence[str]) -> str:
+    """descriptions.md の見出し不一致を人間が直せる形で説明する."""
+    found_headings = _extract_level2_headings(text)
+    missing = list(dict.fromkeys(missing_headings))
+    return "\n".join(
+        [
+            "期待する見出し（完全一致）:",
+            _format_heading_list(_DESCRIPTIONS_MD_EXPECTED_HEADINGS),
+            "不足/不一致の見出し:",
+            _format_heading_list(missing),
+            "検出した ## 見出し:",
+            _format_heading_list(found_headings),
+            "修正例:",
+            "  ## タイトル案",
+            "  ```",
+            "  公開タイトル",
+            "  ```",
+            "  ## Complete Collection 概要欄",
+            "  ```",
+            "  概要欄本文",
+            "  ```",
+            "  ## タグ（YouTube タグ欄）",
+            "  ```",
+            "  tag one, tag two",
+            "  ```",
+            _DESCRIPTIONS_MD_RECREATE_GUIDE,
+        ]
+    )
 
 
 class DescriptionsMdMixin:
@@ -56,9 +104,17 @@ class DescriptionsMdMixin:
         tags_raw = self._extract_md_section(text, "タグ（YouTube タグ欄）")
 
         if not (title and description):
+            parsed_sections = {
+                "タイトル案": title,
+                "Complete Collection 概要欄": description,
+                "タグ（YouTube タグ欄）": tags_raw,
+            }
+            missing_headings = [
+                heading for heading in _DESCRIPTIONS_MD_EXPECTED_HEADINGS if parsed_sections.get(heading) is None
+            ]
             logger.warning(
                 "⚠️  descriptions.md のパースに失敗 — 正規フォーマットとして読み込めません\n%s",
-                _DESCRIPTIONS_MD_RECREATE_GUIDE,
+                _build_descriptions_md_parse_diagnostics(text, missing_headings),
             )
             return None
 

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from youtube_automation.agents._descriptions_md import (
     _build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
 )
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
@@ -78,19 +79,19 @@ class PreflightMixin:
             raise RuntimeError(f"❌ {desc_path} が存在しません。/video-description を実行してください。")
 
         text = desc_path.read_text(encoding="utf-8")
-        title = (self._extract_md_section(text, "タイトル案") or "").strip()
-        description = (self._extract_md_section(text, "Complete Collection 概要欄") or "").strip()
+        title_raw = extract_descriptions_md_section(text, "タイトル案")
+        description_raw = extract_descriptions_md_section(text, "Complete Collection 概要欄")
 
-        if not title or not description:
-            missing_headings = []
-            if not title:
-                missing_headings.append("タイトル案")
-            if not description:
-                missing_headings.append("Complete Collection 概要欄")
+        if title_raw is None or description_raw is None:
             raise RuntimeError(
                 f"❌ {desc_path}: descriptions.md のパースに失敗\n"
-                f"{_build_descriptions_md_parse_diagnostics(text, missing_headings)}"
+                f"{_build_descriptions_md_parse_diagnostics(text)}"
             )
+
+        title = title_raw.strip()
+        description = description_raw.strip()
+        if not title or not description:
+            raise RuntimeError(f"❌ {desc_path}: タイトル案 / Complete Collection 概要欄 が空")
 
         if len(title) > 100:
             raise RuntimeError(f"❌ タイトルが {len(title)} codepoint。YouTube 制限 100 を超過。\n  {title}")

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -11,6 +11,9 @@ import logging
 import re
 from pathlib import Path
 
+from youtube_automation.agents._descriptions_md import (
+    _build_descriptions_md_parse_diagnostics,
+)
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
 from youtube_automation.utils.preflight_checks import (
@@ -79,7 +82,15 @@ class PreflightMixin:
         description = (self._extract_md_section(text, "Complete Collection 概要欄") or "").strip()
 
         if not title or not description:
-            raise RuntimeError(f"❌ {desc_path}: タイトル案 / Complete Collection 概要欄 が空")
+            missing_headings = []
+            if not title:
+                missing_headings.append("タイトル案")
+            if not description:
+                missing_headings.append("Complete Collection 概要欄")
+            raise RuntimeError(
+                f"❌ {desc_path}: descriptions.md のパースに失敗\n"
+                f"{_build_descriptions_md_parse_diagnostics(text, missing_headings)}"
+            )
 
         if len(title) > 100:
             raise RuntimeError(f"❌ タイトルが {len(title)} codepoint。YouTube 制限 100 を超過。\n  {title}")

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -11,12 +11,12 @@ import logging
 import re
 from pathlib import Path
 
-from youtube_automation.agents._descriptions_md import (
-    _build_descriptions_md_parse_diagnostics,
-    extract_descriptions_md_section,
-)
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
+from youtube_automation.utils.descriptions_md import (
+    build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.preflight_checks import (
     check_chapter_count,
     check_chapter_variation_suffix,
@@ -84,7 +84,7 @@ class PreflightMixin:
 
         if title_raw is None or description_raw is None:
             raise RuntimeError(
-                f"❌ {desc_path}: descriptions.md のパースに失敗\n{_build_descriptions_md_parse_diagnostics(text)}"
+                f"❌ {desc_path}: descriptions.md のパースに失敗\n{build_descriptions_md_parse_diagnostics(text)}"
             )
 
         title = title_raw.strip()

--- a/src/youtube_automation/agents/_preflight.py
+++ b/src/youtube_automation/agents/_preflight.py
@@ -84,8 +84,7 @@ class PreflightMixin:
 
         if title_raw is None or description_raw is None:
             raise RuntimeError(
-                f"❌ {desc_path}: descriptions.md のパースに失敗\n"
-                f"{_build_descriptions_md_parse_diagnostics(text)}"
+                f"❌ {desc_path}: descriptions.md のパースに失敗\n{_build_descriptions_md_parse_diagnostics(text)}"
             )
 
         title = title_raw.strip()

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import time
 
+from youtube_automation.agents._descriptions_md import (
+    _build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.config import channel_dir
 from youtube_automation.utils.youtube_service import get_youtube
 from youtube_automation.utils.youtube_tag import parse_youtube_tags
@@ -51,9 +54,7 @@ def discover_collections() -> list[str]:
 
 
 def extract_md_section(md_text: str, header: str) -> str | None:
-    pattern = rf"## {re.escape(header)}\s*\n+```\n(.*?)```"
-    m = re.search(pattern, md_text, re.DOTALL)
-    return m.group(1).strip() if m else None
+    return extract_descriptions_md_section(md_text, header)
 
 
 def utf16_units(s: str) -> int:
@@ -77,7 +78,10 @@ def load_collection(col: str) -> dict:
         tags = parse_youtube_tags(tags_raw)
 
     if not (description and title):
-        raise RuntimeError(f"missing description or title section in {col}")
+        raise RuntimeError(
+            f"descriptions.md parse failed in {col}\n"
+            f"{_build_descriptions_md_parse_diagnostics(desc_md)}"
+        )
 
     return {
         "collection": col,

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -79,8 +79,7 @@ def load_collection(col: str) -> dict:
 
     if not (description and title):
         raise RuntimeError(
-            f"descriptions.md parse failed in {col}\n"
-            f"{_build_descriptions_md_parse_diagnostics(desc_md)}"
+            f"descriptions.md parse failed in {col}\n{_build_descriptions_md_parse_diagnostics(desc_md)}"
         )
 
     return {

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -22,11 +22,11 @@ import argparse
 import json
 import time
 
-from youtube_automation.agents._descriptions_md import (
-    _build_descriptions_md_parse_diagnostics,
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.descriptions_md import (
+    build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
 )
-from youtube_automation.utils.config import channel_dir
 from youtube_automation.utils.youtube_service import get_youtube
 from youtube_automation.utils.youtube_tag import parse_youtube_tags
 
@@ -78,9 +78,7 @@ def load_collection(col: str) -> dict:
         tags = parse_youtube_tags(tags_raw)
 
     if not (description and title):
-        raise RuntimeError(
-            f"descriptions.md parse failed in {col}\n{_build_descriptions_md_parse_diagnostics(desc_md)}"
-        )
+        raise RuntimeError(f"descriptions.md parse failed in {col}\n{build_descriptions_md_parse_diagnostics(desc_md)}")
 
     return {
         "collection": col,

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -23,13 +23,13 @@ import re
 import sys
 from pathlib import Path
 
-from youtube_automation.agents._descriptions_md import (  # noqa: E402
-    _build_descriptions_md_parse_diagnostics,
-    extract_descriptions_md_section,
-)
 from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.config.config import ChannelConfig  # noqa: E402
+from youtube_automation.utils.descriptions_md import (  # noqa: E402
+    build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.preflight_checks import (  # noqa: E402
     check_chapter_count,
     check_chapter_variation_suffix,
@@ -69,18 +69,21 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     title_raw = extract_section(text, "タイトル案")
     description_raw = extract_section(text, "Complete Collection 概要欄")
     if title_raw is None or description_raw is None:
-        issues.append("descriptions.md parse failed\n" + _build_descriptions_md_parse_diagnostics(text))
-        return issues
+        issues.append("descriptions.md parse failed\n" + build_descriptions_md_parse_diagnostics(text))
 
-    title = title_raw.strip()
-    description = description_raw.strip()
+    title = title_raw.strip() if title_raw is not None else ""
+    description = description_raw.strip() if description_raw is not None else ""
 
-    if not title:
+    if title_raw is None:
+        pass
+    elif not title:
         issues.append("missing 'タイトル案' section")
     elif len(title) > 100:
         issues.append(f"title too long: {len(title)} codepoints (>100)")
 
-    if not description:
+    if description_raw is None:
+        pass
+    elif not description:
         issues.append("missing 'Complete Collection 概要欄' section")
     else:
         ts_lines = [line for line in description.split("\n") if TS_RE.match(line.strip())]

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -23,6 +23,10 @@ import re
 import sys
 from pathlib import Path
 
+from youtube_automation.agents._descriptions_md import (  # noqa: E402
+    _build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
 from youtube_automation.utils.config.config import ChannelConfig  # noqa: E402
@@ -39,14 +43,10 @@ from youtube_automation.utils.probe import probe_duration  # noqa: E402
 COLLECTIONS_DIR = channel_dir() / "collections" / "live"
 
 TS_RE = re.compile(r"^\d{1,2}:\d{2}")
-SECTION_RE = lambda h: re.compile(  # noqa: E731
-    rf"## {re.escape(h)}\s*\n+```\n(.*?)```", re.DOTALL
-)
 
 
 def extract_section(text: str, header: str) -> str | None:
-    m = SECTION_RE(header).search(text)
-    return m.group(1).strip() if m else None
+    return extract_descriptions_md_section(text, header)
 
 
 def audit_local(col: Path, config: ChannelConfig) -> list[str]:
@@ -66,8 +66,14 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
         return issues
 
     text = desc_md.read_text(encoding="utf-8")
-    title = (extract_section(text, "タイトル案") or "").strip()
-    description = (extract_section(text, "Complete Collection 概要欄") or "").strip()
+    title_raw = extract_section(text, "タイトル案")
+    description_raw = extract_section(text, "Complete Collection 概要欄")
+    if title_raw is None or description_raw is None:
+        issues.append("descriptions.md parse failed\n" + _build_descriptions_md_parse_diagnostics(text))
+        return issues
+
+    title = title_raw.strip()
+    description = description_raw.strip()
 
     if not title:
         issues.append("missing 'タイトル案' section")

--- a/src/youtube_automation/scripts/title_duplicate_check.py
+++ b/src/youtube_automation/scripts/title_duplicate_check.py
@@ -4,30 +4,31 @@
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config
+from youtube_automation.utils.descriptions_md import (
+    build_descriptions_md_parse_diagnostics,
+    extract_descriptions_md_section,
+)
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.preflight_checks import check_title_duplicate_warnings
 
-SECTION_RE = lambda h: re.compile(  # noqa: E731
-    rf"## {re.escape(h)}\s*\n+```\n(.*?)```", re.DOTALL
-)
-
 
 def extract_section(text: str, header: str) -> str | None:
-    m = SECTION_RE(header).search(text)
-    return m.group(1).strip() if m else None
+    return extract_descriptions_md_section(text, header)
 
 
 def read_descriptions_title(collection_dir: Path) -> str:
     desc_path = CollectionPaths(collection_dir).descriptions_md_path
     if not desc_path.exists():
         raise FileNotFoundError(f"{desc_path} not found. Pass --title to check a title before saving descriptions.md.")
-    title = extract_section(desc_path.read_text(encoding="utf-8"), "タイトル案")
+    text = desc_path.read_text(encoding="utf-8")
+    title = extract_section(text, "タイトル案")
+    if title is None:
+        raise ValueError(f"{desc_path}: descriptions.md parse failed\n{build_descriptions_md_parse_diagnostics(text)}")
     if not title:
         raise ValueError(f"{desc_path}: missing 'タイトル案' section")
     return title.strip()

--- a/src/youtube_automation/utils/descriptions_md.py
+++ b/src/youtube_automation/utils/descriptions_md.py
@@ -1,0 +1,78 @@
+"""Shared parser and diagnostics for generated ``descriptions.md`` files."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+DESCRIPTIONS_MD_EXPECTED_HEADINGS = (
+    "タイトル案",
+    "Complete Collection 概要欄",
+    "タグ（YouTube タグ欄）",
+)
+
+DESCRIPTIONS_MD_RECREATE_GUIDE = (
+    "→ 手書きファイルを直接直すのではなく、正規フローで作り直してください:\n"
+    "  1. /video-description を再実行する\n"
+    "  2. 生成された 20-documentation/descriptions.md を確認する\n"
+    "  3. 必要なら生成後の本文だけを調整してから再アップロードする\n"
+    "  必須セクション: `## タイトル案` / `## Complete Collection 概要欄` / `## タグ（YouTube タグ欄）`"
+)
+
+
+def extract_level2_headings(text: str) -> list[str]:
+    """Return level-2 Markdown headings from ``descriptions.md`` in file order."""
+    return [match.group(1).strip() for match in re.finditer(r"^##\s+(.+?)\s*$", text, re.MULTILINE)]
+
+
+def extract_descriptions_md_section(text: str, heading: str) -> str | None:
+    """Extract the fenced body immediately below an exact level-2 heading."""
+    pattern = rf"^##[ \t]+{re.escape(heading)}[ \t]*\n+```\n(.*?)```"
+    m = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def missing_descriptions_md_headings(text: str) -> list[str]:
+    """Return expected headings that cannot be parsed from ``descriptions.md``."""
+    return [
+        heading
+        for heading in DESCRIPTIONS_MD_EXPECTED_HEADINGS
+        if extract_descriptions_md_section(text, heading) is None
+    ]
+
+
+def format_heading_list(headings: Sequence[str]) -> str:
+    if not headings:
+        return "  - (なし)"
+    return "\n".join(f"  - ## {heading}" for heading in headings)
+
+
+def build_descriptions_md_parse_diagnostics(text: str, missing_headings: Sequence[str] | None = None) -> str:
+    """Explain a ``descriptions.md`` heading mismatch in a user-actionable form."""
+    found_headings = extract_level2_headings(text)
+    missing_source = missing_headings if missing_headings is not None else missing_descriptions_md_headings(text)
+    missing = list(dict.fromkeys(missing_source))
+    return "\n".join(
+        [
+            "期待する見出し（完全一致）:",
+            format_heading_list(DESCRIPTIONS_MD_EXPECTED_HEADINGS),
+            "不足/不一致の見出し:",
+            format_heading_list(missing),
+            "検出した ## 見出し:",
+            format_heading_list(found_headings),
+            "修正例:",
+            "  ## タイトル案",
+            "  ```",
+            "  公開タイトル",
+            "  ```",
+            "  ## Complete Collection 概要欄",
+            "  ```",
+            "  概要欄本文",
+            "  ```",
+            "  ## タグ（YouTube タグ欄）",
+            "  ```",
+            "  tag one, tag two",
+            "  ```",
+            DESCRIPTIONS_MD_RECREATE_GUIDE,
+        ]
+    )

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -10,13 +10,12 @@ import re
 from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 
+from youtube_automation.utils.descriptions_md import extract_descriptions_md_section
 from youtube_automation.utils.youtube_tag import parse_youtube_tags, youtube_tag_chars
 
 YT_TAG_CHAR_LIMIT = 500
 REQUIRED_LOCALIZATION_LANGUAGES = ("ja", "en", "de")
 LOW_CPM_LOCALIZATION_LANGUAGES = ("ko", "es", "pt", "zh-CN")
-
-_DESC_TAGS_RE = re.compile(r"## タグ（YouTube タグ欄）\s*\n+```\n(.*?)```", re.DOTALL)
 
 # v1〜v9 もしくは末尾のロマン数字 (I/II/III/IV/V/VI/VII/VIII) を検出する。
 # chapter 名末尾にこれが現れる場合、1 パターンを複数バリエーションに展開した事故とみなす。
@@ -239,10 +238,9 @@ def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
     """
     if not desc_md.exists():
         return None
-    m = _DESC_TAGS_RE.search(desc_md.read_text(encoding="utf-8"))
-    if not m:
+    raw = extract_descriptions_md_section(desc_md.read_text(encoding="utf-8"), "タグ（YouTube タグ欄）")
+    if raw is None:
         return None
-    raw = m.group(1).strip()
     tags = parse_youtube_tags(raw)
     return tags or None
 

--- a/tests/test_bulk_update_descriptions_from_md.py
+++ b/tests/test_bulk_update_descriptions_from_md.py
@@ -616,10 +616,7 @@ class TestLoadCollection:
         message = str(excinfo.value)
         assert "descriptions.md parse failed in alpha" in message
         assert "期待する見出し（完全一致）" in message
-        assert (
-            "不足/不一致の見出し:\n"
-            "  - ## Complete Collection 概要欄"
-        ) in message
+        assert ("不足/不一致の見出し:\n  - ## Complete Collection 概要欄") in message
         assert "検出した ## 見出し" in message
         assert "修正例" in message
         assert "/video-description を再実行" in message
@@ -641,10 +638,7 @@ class TestLoadCollection:
         message = str(excinfo.value)
         assert "descriptions.md parse failed in alpha" in message
         assert "期待する見出し（完全一致）" in message
-        assert (
-            "不足/不一致の見出し:\n"
-            "  - ## タイトル案"
-        ) in message
+        assert ("不足/不一致の見出し:\n  - ## タイトル案") in message
         assert "検出した ## 見出し" in message
         assert "修正例" in message
         assert "/video-description を再実行" in message

--- a/tests/test_bulk_update_descriptions_from_md.py
+++ b/tests/test_bulk_update_descriptions_from_md.py
@@ -610,8 +610,19 @@ class TestLoadCollection:
         reset()
 
         # When/Then
-        with pytest.raises(RuntimeError, match="missing description or title section"):
+        with pytest.raises(RuntimeError) as excinfo:
             mod.load_collection("alpha")
+
+        message = str(excinfo.value)
+        assert "descriptions.md parse failed in alpha" in message
+        assert "期待する見出し（完全一致）" in message
+        assert (
+            "不足/不一致の見出し:\n"
+            "  - ## Complete Collection 概要欄"
+        ) in message
+        assert "検出した ## 見出し" in message
+        assert "修正例" in message
+        assert "/video-description を再実行" in message
 
     def test_should_raise_when_title_section_missing(self, tmp_path, monkeypatch):
         """`タイトル案` セクション欠落で `RuntimeError`."""
@@ -624,8 +635,19 @@ class TestLoadCollection:
         reset()
 
         # When/Then
-        with pytest.raises(RuntimeError, match="missing description or title section"):
+        with pytest.raises(RuntimeError) as excinfo:
             mod.load_collection("alpha")
+
+        message = str(excinfo.value)
+        assert "descriptions.md parse failed in alpha" in message
+        assert "期待する見出し（完全一致）" in message
+        assert (
+            "不足/不一致の見出し:\n"
+            "  - ## タイトル案"
+        ) in message
+        assert "検出した ## 見出し" in message
+        assert "修正例" in message
+        assert "/video-description を再実行" in message
 
     def test_should_strip_double_quotes_from_tags(self, tmp_path, monkeypatch):
         """ダブルクォートで囲まれたタグから引用符を除去する (#1096)."""

--- a/tests/test_descriptions_md_quote_strip.py
+++ b/tests/test_descriptions_md_quote_strip.py
@@ -76,6 +76,34 @@ class TestDescriptionsMdQuoteStrip:
         assert "必須セクション" in messages
         assert "## Complete Collection 概要欄" in messages
 
+    def test_warns_with_expected_missing_and_detected_headings_when_heading_mismatches(
+        self,
+        tmp_path: Path,
+        caplog,
+    ) -> None:
+        """見出し typo 時は期待値・不足値・検出値・修正例を表示する."""
+        doc_dir = tmp_path / "20-documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "descriptions.md").write_text(
+            "## タイトル\n\n```\nTest Title\n```\n\n## Complete Collection 概要\n\n```\nTest description body.\n```\n",
+            encoding="utf-8",
+        )
+
+        mixin = DescriptionsMdMixin()
+        with caplog.at_level(logging.WARNING):
+            result = mixin._load_descriptions_md(tmp_path)
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert result is None
+        assert "期待する見出し（完全一致）" in messages
+        assert "不足/不一致の見出し" in messages
+        assert "検出した ## 見出し" in messages
+        assert "## タイトル案" in messages
+        assert "## Complete Collection 概要欄" in messages
+        assert "## タイトル" in messages
+        assert "修正例" in messages
+        assert "/video-description を再実行" in messages
+
     def test_raises_with_recreate_guide_when_stray_description_file_exists(self, tmp_path: Path) -> None:
         """別名 description ファイル検出時も再作成ガイドを含める."""
         doc_dir = tmp_path / "20-documentation"

--- a/tests/test_descriptions_md_quote_strip.py
+++ b/tests/test_descriptions_md_quote_strip.py
@@ -104,6 +104,26 @@ class TestDescriptionsMdQuoteStrip:
         assert "修正例" in messages
         assert "/video-description を再実行" in messages
 
+    def test_rejects_level3_heading_for_required_section(self, tmp_path: Path, caplog) -> None:
+        """`### タイトル案` は `## タイトル案` の完全一致として扱わない."""
+        doc_dir = tmp_path / "20-documentation"
+        doc_dir.mkdir(parents=True)
+        (doc_dir / "descriptions.md").write_text(
+            "### タイトル案\n\n```\nTest Title\n```\n\n"
+            "## Complete Collection 概要欄\n\n```\nTest description body.\n```\n\n"
+            "## タグ（YouTube タグ欄）\n\n```\nlofi, jazz\n```\n",
+            encoding="utf-8",
+        )
+
+        mixin = DescriptionsMdMixin()
+        with caplog.at_level(logging.WARNING):
+            result = mixin._load_descriptions_md(tmp_path)
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert result is None
+        assert "不足/不一致の見出し:\n  - ## タイトル案" in messages
+        assert "検出した ## 見出し:\n  - ## Complete Collection 概要欄\n  - ## タグ（YouTube タグ欄）" in messages
+
     def test_raises_with_recreate_guide_when_stray_description_file_exists(self, tmp_path: Path) -> None:
         """別名 description ファイル検出時も再作成ガイドを含める."""
         doc_dir = tmp_path / "20-documentation"

--- a/tests/test_descriptions_md_quote_strip.py
+++ b/tests/test_descriptions_md_quote_strip.py
@@ -96,10 +96,13 @@ class TestDescriptionsMdQuoteStrip:
         messages = "\n".join(record.getMessage() for record in caplog.records)
         assert result is None
         assert "期待する見出し（完全一致）" in messages
-        assert "不足/不一致の見出し" in messages
+        assert (
+            "不足/不一致の見出し:\n"
+            "  - ## タイトル案\n"
+            "  - ## Complete Collection 概要欄\n"
+            "  - ## タグ（YouTube タグ欄）"
+        ) in messages
         assert "検出した ## 見出し" in messages
-        assert "## タイトル案" in messages
-        assert "## Complete Collection 概要欄" in messages
         assert "## タイトル" in messages
         assert "修正例" in messages
         assert "/video-description を再実行" in messages

--- a/tests/test_descriptions_md_quote_strip.py
+++ b/tests/test_descriptions_md_quote_strip.py
@@ -97,10 +97,7 @@ class TestDescriptionsMdQuoteStrip:
         assert result is None
         assert "期待する見出し（完全一致）" in messages
         assert (
-            "不足/不一致の見出し:\n"
-            "  - ## タイトル案\n"
-            "  - ## Complete Collection 概要欄\n"
-            "  - ## タグ（YouTube タグ欄）"
+            "不足/不一致の見出し:\n  - ## タイトル案\n  - ## Complete Collection 概要欄\n  - ## タグ（YouTube タグ欄）"
         ) in messages
         assert "検出した ## 見出し" in messages
         assert "## タイトル" in messages

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -67,6 +67,7 @@ def _write_local_collection(
     scene_phrases: dict[str, str],
     description: str,
     title_heading: str = "タイトル案",
+    write_workflow_state: bool = True,
 ) -> Path:
     collection_dir = tmp_path / "20260622-test-collection"
     docs_dir = collection_dir / "20-documentation"
@@ -84,10 +85,11 @@ Continuous Focus Mix
 """,
         encoding="utf-8",
     )
-    (collection_dir / "workflow-state.json").write_text(
-        json.dumps({"scene_phrases": scene_phrases}, ensure_ascii=False),
-        encoding="utf-8",
-    )
+    if write_workflow_state:
+        (collection_dir / "workflow-state.json").write_text(
+            json.dumps({"scene_phrases": scene_phrases}, ensure_ascii=False),
+            encoding="utf-8",
+        )
     return collection_dir
 
 
@@ -129,6 +131,23 @@ class TestAuditLocalPreflightContract:
         assert "## タイトル" in message
         assert "修正例" in message
         assert "/video-description を再実行" in message
+
+    def test_parse_failure_keeps_independent_local_audits(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={},
+            description="A continuous BGM mix without chapter markers.",
+            title_heading="タイトル",
+            write_workflow_state=False,
+        )
+        cfg = _audit_config(["en"])
+        cfg.content.tags.min_count = 2
+
+        issues = audit_local(collection_dir, cfg)
+
+        assert any("descriptions.md parse failed" in issue for issue in issues)
+        assert any("workflow-state.json missing" in issue for issue in issues)
+        assert any("tags count: 1 (min 2)" in issue for issue in issues)
 
 
 class TestAuditRemoteZhCodes:

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -124,11 +124,7 @@ class TestAuditLocalPreflightContract:
         message = issues[0]
         assert "descriptions.md parse failed" in message
         assert "期待する見出し（完全一致）" in message
-        assert (
-            "不足/不一致の見出し:\n"
-            "  - ## タイトル案\n"
-            "  - ## タグ（YouTube タグ欄）"
-        ) in message
+        assert ("不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）") in message
         assert "検出した ## 見出し" in message
         assert "## タイトル" in message
         assert "修正例" in message

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -61,12 +61,18 @@ def _audit_config(supported_languages: list[str]) -> SimpleNamespace:
     )
 
 
-def _write_local_collection(tmp_path: Path, *, scene_phrases: dict[str, str], description: str) -> Path:
+def _write_local_collection(
+    tmp_path: Path,
+    *,
+    scene_phrases: dict[str, str],
+    description: str,
+    title_heading: str = "タイトル案",
+) -> Path:
     collection_dir = tmp_path / "20260622-test-collection"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True)
     (docs_dir / "descriptions.md").write_text(
-        f"""## タイトル案
+        f"""## {title_heading}
 ```
 Continuous Focus Mix
 ```
@@ -103,6 +109,30 @@ class TestAuditLocalPreflightContract:
         )
 
         assert audit_local(collection_dir, _audit_config(["ja"])) == []
+
+    def test_heading_mismatch_reports_descriptions_md_diagnostics(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={"en": "continuous focus mix"},
+            description="A continuous BGM mix without chapter markers.",
+            title_heading="タイトル",
+        )
+
+        issues = audit_local(collection_dir, _audit_config(["en"]))
+
+        assert len(issues) == 1
+        message = issues[0]
+        assert "descriptions.md parse failed" in message
+        assert "期待する見出し（完全一致）" in message
+        assert (
+            "不足/不一致の見出し:\n"
+            "  - ## タイトル案\n"
+            "  - ## タグ（YouTube タグ欄）"
+        ) in message
+        assert "検出した ## 見出し" in message
+        assert "## タイトル" in message
+        assert "修正例" in message
+        assert "/video-description を再実行" in message
 
 
 class TestAuditRemoteZhCodes:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -107,6 +107,37 @@ def _run_preflight(channel_dir: Path, collection_dir: Path, monkeypatch: pytest.
     _PreflightHarness(channel_dir / "collections")._preflight_check(collection_dir)
 
 
+def test_heading_mismatch_reports_expected_missing_detected_and_fix_example(tmp_path: Path) -> None:
+    collection_dir = tmp_path / "collections" / "planning" / "20260630-heading-typo"
+    docs_dir = collection_dir / "20-documentation"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "descriptions.md").write_text(
+        """## タイトル
+```
+Continuous Focus Mix
+```
+
+## Complete Collection 概要欄
+```
+A continuous BGM mix without chapter markers.
+```
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _PreflightHarness(tmp_path / "collections")._preflight_check(collection_dir)
+
+    message = str(excinfo.value)
+    assert "期待する見出し（完全一致）" in message
+    assert "不足/不一致の見出し" in message
+    assert "検出した ## 見出し" in message
+    assert "## タイトル案" in message
+    assert "## タイトル" in message
+    assert "修正例" in message
+    assert "/video-description を再実行" in message
+
+
 def test_en_only_channel_without_timestamps_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en"])
     collection_dir = _write_collection(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -130,12 +130,41 @@ A continuous BGM mix without chapter markers.
 
     message = str(excinfo.value)
     assert "期待する見出し（完全一致）" in message
-    assert "不足/不一致の見出し" in message
+    assert (
+        "不足/不一致の見出し:\n"
+        "  - ## タイトル案\n"
+        "  - ## タグ（YouTube タグ欄）"
+    ) in message
     assert "検出した ## 見出し" in message
-    assert "## タイトル案" in message
     assert "## タイトル" in message
     assert "修正例" in message
     assert "/video-description を再実行" in message
+
+
+def test_empty_sections_keep_empty_section_error(tmp_path: Path) -> None:
+    collection_dir = tmp_path / "collections" / "planning" / "20260630-empty-title"
+    docs_dir = collection_dir / "20-documentation"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "descriptions.md").write_text(
+        """## タイトル案
+```
+
+```
+
+## Complete Collection 概要欄
+```
+A continuous BGM mix without chapter markers.
+```
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _PreflightHarness(tmp_path / "collections")._preflight_check(collection_dir)
+
+    message = str(excinfo.value)
+    assert "タイトル案 / Complete Collection 概要欄 が空" in message
+    assert "不足/不一致の見出し" not in message
 
 
 def test_en_only_channel_without_timestamps_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -130,11 +130,7 @@ A continuous BGM mix without chapter markers.
 
     message = str(excinfo.value)
     assert "期待する見出し（完全一致）" in message
-    assert (
-        "不足/不一致の見出し:\n"
-        "  - ## タイトル案\n"
-        "  - ## タグ（YouTube タグ欄）"
-    ) in message
+    assert ("不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）") in message
     assert "検出した ## 見出し" in message
     assert "## タイトル" in message
     assert "修正例" in message

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -245,6 +245,22 @@ class TestExtractDescriptionsMdTags:
         p.write_text("## タグ（YouTube タグ欄）\n```\n\n```\n", encoding="utf-8")
         assert extract_descriptions_md_tags(p) is None
 
+    def test_returns_none_for_level3_tag_heading(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text(
+            "### タグ（YouTube タグ欄）\n```\nlofi beats, jazz\n```\n",
+            encoding="utf-8",
+        )
+        assert extract_descriptions_md_tags(p) is None
+
+    def test_returns_none_for_tag_heading_typo(self, tmp_path: Path) -> None:
+        p = tmp_path / "descriptions.md"
+        p.write_text(
+            "## タグ\n```\nlofi beats, jazz\n```\n",
+            encoding="utf-8",
+        )
+        assert extract_descriptions_md_tags(p) is None
+
 
 class TestCheckTitleTemplateCompliance:
     """`check_title_template_compliance` の鋳型逸脱・巻数表記・RHS 重複検出 (#602)."""

--- a/tests/test_title_duplicate_check.py
+++ b/tests/test_title_duplicate_check.py
@@ -1,0 +1,71 @@
+"""title_duplicate_check の descriptions.md 読み込み契約テスト."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.scripts.title_duplicate_check import read_descriptions_title
+
+
+def _write_descriptions_md(collection_dir: Path, text: str) -> None:
+    docs_dir = collection_dir / "20-documentation"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "descriptions.md").write_text(text, encoding="utf-8")
+
+
+def test_read_descriptions_title_reports_heading_mismatch_diagnostics(tmp_path: Path) -> None:
+    _write_descriptions_md(
+        tmp_path,
+        """## タイトル
+```
+Continuous Focus Mix
+```
+
+## Complete Collection 概要欄
+```
+A continuous BGM mix without chapter markers.
+```
+""",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        read_descriptions_title(tmp_path)
+
+    message = str(excinfo.value)
+    assert "descriptions.md parse failed" in message
+    assert "期待する見出し（完全一致）" in message
+    assert "不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）" in message
+    assert "検出した ## 見出し" in message
+    assert "## タイトル" in message
+    assert "修正例" in message
+    assert "/video-description を再実行" in message
+
+
+def test_read_descriptions_title_rejects_level3_heading(tmp_path: Path) -> None:
+    _write_descriptions_md(
+        tmp_path,
+        """### タイトル案
+```
+Continuous Focus Mix
+```
+
+## Complete Collection 概要欄
+```
+A continuous BGM mix without chapter markers.
+```
+
+## タグ（YouTube タグ欄）
+```
+ambient, focus
+```
+""",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        read_descriptions_title(tmp_path)
+
+    message = str(excinfo.value)
+    assert "不足/不一致の見出し:\n  - ## タイトル案" in message
+    assert "検出した ## 見出し:\n  - ## Complete Collection 概要欄\n  - ## タグ（YouTube タグ欄）" in message


### PR DESCRIPTION
## Summary

- descriptions.md のパース失敗時に期待する `##` 見出し一覧を表示
- 不足/不一致の見出しと、実際に検出した `##` 見出しを診断文に追加
- 通常読み込みと preflight の両方で修正例と `/video-description` 再生成手順を案内

## Root Cause

`descriptions.md` の見出しは完全一致で抽出しているが、失敗時の警告は再生成ガイドだけで、どの見出しが期待値と違うのか判断しづらかった。

## Tests

- `uv run ruff check .`
- `uv run pytest`

Closes #1340
