### PR TITLE
[codex] Suno prompts の collection ID をURLデコードする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: `yt-collection-serve` の `/collections/<id>/suno/prompts.json` で URL エンコード済み collection ID をデコードし、スペースを含むフォルダ名でも prompts を取得できるようにした（#1338）
 - `fix(cost)`: Windows 環境で `fcntl` がない場合も `cost_tracker` と `yt-generate-image` が起動できるよう、`msvcrt` / プロセス内 lock fallback を追加（#1315）
 - `fix(upload)`: upload preflight が `audio.target_duration_min/max` を秒単位として誤判定していた master 動画尺チェックを無効化（#1313）
 

--- a/extensions/distrokid-helper/tests/api.test.ts
+++ b/extensions/distrokid-helper/tests/api.test.ts
@@ -137,6 +137,21 @@ describe("fetchCollectionRelease", () => {
     );
   });
 
+  it("スペース入り collection id を path segment encode して fetch する", async () => {
+    // Given
+    fetchMock.mockResolvedValue(jsonResponse(200, SAMPLE_PAYLOAD));
+
+    // When
+    const result = await fetchCollectionRelease("http://localhost:7873", "20260526-rainy jazz-collection", "disc1");
+
+    // Then
+    expect(result).toEqual(SAMPLE_PAYLOAD);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:7873/collections/20260526-rainy%20jazz-collection/distrokid/disc1/release.json",
+      expect.anything(),
+    );
+  });
+
   it("404 のとき ReleaseUnavailableError を throw する", async () => {
     // Given
     fetchMock.mockResolvedValue(jsonResponse(404, {}));

--- a/extensions/distrokid-helper/tests/distrokid-collections.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-collections.test.ts
@@ -71,6 +71,12 @@ describe("distrokidReleaseRoute", () => {
       "/collections/20261001-rjn-dawn-collection/distrokid/disc1/release.json",
     );
   });
+
+  it("スペース入り collection_id は path segment encode する", () => {
+    expect(distrokidReleaseRoute("20260526-rainy jazz-collection", "disc1")).toBe(
+      "/collections/20260526-rainy%20jazz-collection/distrokid/disc1/release.json",
+    );
+  });
 });
 
 // --- fetchDistrokidCollections ---

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -219,7 +219,7 @@ export function distrokidReleaseRoute(
   collectionId: string,
   disc: string,
 ): string {
-  return `/collections/${collectionId}/distrokid/${disc}/release.json`;
+  return `/collections/${encodeURIComponent(collectionId)}/distrokid/${disc}/release.json`;
 }
 
 /** ローカル配信元の既定 URL。 */

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -39,7 +39,7 @@ export const VERSION_ROUTE = "/version";
 
 /** 個別 collection の prompts 配信サブパス `/collections/<id>/suno/prompts.json` を組み立てる (#816)。 */
 export function collectionPromptsRoute(id: string): string {
-  return `${COLLECTIONS_ROUTE}/${id}${PROMPTS_ROUTE}`;
+  return `${COLLECTIONS_ROUTE}/${encodeURIComponent(id)}${PROMPTS_ROUTE}`;
 }
 
 /** 個別 collection の download 完了通知 POST サブパス `/collections/<id>/downloaded` を組み立てる。 */

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -323,6 +323,18 @@ describe("shared/api fetchCollectionPrompts: 配信元 URL の組み立て", () 
 
     expect(fetchFn).toHaveBeenCalledWith(`${BASE_URL}/collections/20260601-clm-aaa-collection/suno/prompts.json`);
   });
+
+  it("Given スペース入り id When fetch する Then id を path segment encode して要求する", async () => {
+    const fetchFn = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => [{ name: "p1", style: "lofi", lyrics: "" }],
+    }));
+
+    await fetchCollectionPrompts(BASE_URL, "20260526-rainy jazz-collection");
+
+    expect(fetchFn).toHaveBeenCalledWith(`${BASE_URL}/collections/20260526-rainy%20jazz-collection/suno/prompts.json`);
+  });
 });
 
 describe("shared/api fetchCollectionPrompts: 正常系", () => {

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -82,6 +82,12 @@ describe("shared/constants: collection 列挙ルート (#816 dir mode)", () => {
       "/collections/20260601-clm-aaa-collection/suno/prompts.json",
     );
   });
+
+  it("Given スペース入り collection id When collectionPromptsRoute(id) Then id を path segment encode する", () => {
+    expect(collectionPromptsRoute("20260526-rainy jazz-collection")).toBe(
+      "/collections/20260526-rainy%20jazz-collection/suno/prompts.json",
+    );
+  });
 });
 
 describe("shared/constants: Suno queue 上限 (#816)", () => {

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -597,6 +597,10 @@ def _decode_collection_id_path_segment(cid: str) -> str:
     return urllib.parse.unquote(cid)
 
 
+def _encode_collection_id_path_segment(cid: str) -> str:
+    return urllib.parse.quote(cid, safe="")
+
+
 def create_server(
     port: int,
     allow_origin: str | None,
@@ -932,7 +936,8 @@ def create_server(
             if len(parts) != 2:
                 self.send_error(404, "Not Found")
                 return
-            coll_id, sub = parts
+            raw_coll_id, sub = parts
+            coll_id = _decode_collection_id_path_segment(raw_coll_id)
 
             # トラバーサル防御: find_collection_dirs のホワイトリストで弾く（#934）。
             known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
@@ -973,7 +978,8 @@ def create_server(
                     self.send_error(404, "Not Found")
                     return
                 # asset_path を collection-scoped 形式にするための prefix を組み立てる（#934）。
-                coll_assets_prefix = f"{COLLECTIONS_ROUTE}/{coll_id}{DISTROKID_COLLECTION_ASSETS_PREFIX}"
+                encoded_coll_id = _encode_collection_id_path_segment(coll_id)
+                coll_assets_prefix = f"{COLLECTIONS_ROUTE}/{encoded_coll_id}{DISTROKID_COLLECTION_ASSETS_PREFIX}"
                 distrokid_source = f"{_DISTROKID_DIRNAME}/{disc}"
                 try:
                     payload = build_release_payload(

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -593,6 +593,10 @@ def build_version_payload() -> dict[str, str]:
     }
 
 
+def _decode_collection_id_path_segment(cid: str) -> str:
+    return urllib.parse.unquote(cid)
+
+
 def create_server(
     port: int,
     allow_origin: str | None,
@@ -684,7 +688,7 @@ def create_server(
                 self.send_error(403, "Forbidden")
                 return
 
-            cid = urllib.parse.unquote(cid)
+            cid = _decode_collection_id_path_segment(cid)
             if ".." in cid:
                 self.send_error(404, "Not Found")
                 return
@@ -883,7 +887,7 @@ def create_server(
                 return
             coll_prefix = f"{COLLECTIONS_ROUTE}/"
             if self.path.startswith(coll_prefix) and self.path.endswith(SUNO_PROMPTS_ROUTE):
-                cid = self.path[len(coll_prefix) : -len(SUNO_PROMPTS_ROUTE)]
+                cid = _decode_collection_id_path_segment(self.path[len(coll_prefix) : -len(SUNO_PROMPTS_ROUTE)])
                 resolved = resolve_collection_prompts_path(collections_root, cid)
                 if resolved is None or not resolved.is_file():
                     self._send_json_error(404, "Not Found")

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -838,7 +838,8 @@ def create_server(
             downloaded_prefix = f"{COLLECTIONS_ROUTE}/"
             if dir_mode and self.path.startswith(downloaded_prefix) and self.path.endswith(DOWNLOADED_ROUTE_SUFFIX):
                 cid = self.path[len(downloaded_prefix) : -len(DOWNLOADED_ROUTE_SUFFIX)]
-                if self.path != collection_downloaded_route(cid):
+                decoded_cid = _decode_collection_id_path_segment(cid)
+                if self.path != collection_downloaded_route(decoded_cid):
                     self.send_error(404, "Not Found")
                     return
                 self._handle_downloaded_post(cid)

--- a/src/youtube_automation/utils/suno_artifact_contracts.py
+++ b/src/youtube_automation/utils/suno_artifact_contracts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import urllib.parse
+
 DOCUMENTATION_DIRNAME = "20-documentation"
 SUNO_PATTERNS_FILENAME = "suno-patterns.yaml"
 SUNO_LYRICS_JSON_FILENAME = "suno-lyrics.json"
@@ -16,4 +18,5 @@ SUNO_PLAYLISTS_ROUTE = "/suno/playlists"
 
 def collection_downloaded_route(collection_id: str) -> str:
     """個別 collection の download 完了通知 POST ルートを組み立てる。"""
-    return f"{COLLECTIONS_ROUTE}/{collection_id}{DOWNLOADED_ROUTE_SUFFIX}"
+    encoded_id = urllib.parse.quote(collection_id, safe="")
+    return f"{COLLECTIONS_ROUTE}/{encoded_id}{DOWNLOADED_ROUTE_SUFFIX}"

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -961,6 +961,26 @@ def test_get_collection_prompts_returns_entries(serve_dir, tmp_path):
     assert body == entries
 
 
+def test_get_collection_prompts_decodes_space_in_collection_id(serve_dir, tmp_path):
+    """Given スペースを含む collection id
+    When `GET /collections/<url-encoded id>/suno/prompts.json`
+    Then 200 で prompts json を返す（#1338）。
+    """
+    planning = tmp_path / "planning"
+    collection_id = "20260601-clm-rainy jazz-collection"
+    entries = [{"name": "A", "style": "slow, jazz", "lyrics": ""}]
+    _make_collection(planning, collection_id, entries=entries)
+    base = serve_dir(planning)
+
+    encoded_id = urllib.parse.quote(collection_id, safe="")
+    url = f"{base}{_collection_prompts_route(encoded_id)}"
+    with urllib.request.urlopen(url) as resp:
+        assert resp.status == 200
+        body = json.loads(resp.read().decode("utf-8"))
+
+    assert body == entries
+
+
 def test_get_collection_prompts_unknown_id_returns_404(serve_dir, tmp_path):
     """Given 存在しない collection id
     When `GET /collections/<id>/suno/prompts.json`
@@ -1178,6 +1198,39 @@ def test_post_downloaded_updates_workflow_state(serve_dir, tmp_path):
     ws = json.loads(ws_path.read_text(encoding="utf-8"))
     assert ws["planning"]["music"]["suno_playlist_url"] == "https://suno.com/playlist/abc"
     assert "assets" not in ws or "music_downloaded" not in ws.get("assets", {})
+
+
+def test_post_downloaded_decodes_space_in_collection_id(serve_dir, tmp_path):
+    """Given スペースを含む collection id
+    When `POST /collections/<url-encoded id>/downloaded`
+    Then 200 で保存し、レスポンスの collection_id は decode 済みで返す（#1338）。
+    """
+    planning = tmp_path / "planning"
+    collection_id = "20260601-clm-rainy jazz-collection"
+    _make_collection(
+        planning,
+        collection_id,
+        entries=[{"name": "A", "style": "s", "lyrics": ""}],
+    )
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
+    token = _fetch_token(base)
+    payload = {"file_count": 0, "format": "mp3", "suno_playlist_url": "https://suno.com/playlist/space"}
+
+    encoded_id = urllib.parse.quote(collection_id, safe="")
+    with _post(
+        f"{base}{_COLLECTIONS_ROUTE}/{encoded_id}/downloaded",
+        payload,
+        headers={"Origin": _EXTENSION_ORIGIN, "X-Serve-Token": token},
+    ) as resp:
+        assert resp.status == 200
+        result = json.loads(resp.read().decode("utf-8"))
+
+    assert result["ok"] is True
+    assert result["collection_id"] == collection_id
+
+    ws_path = planning / collection_id / "workflow-state.json"
+    ws = json.loads(ws_path.read_text(encoding="utf-8"))
+    assert ws["planning"]["music"]["suno_playlist_url"] == "https://suno.com/playlist/space"
 
 
 def test_post_downloaded_unknown_collection_returns_404(serve_dir, tmp_path):

--- a/tests/test_distrokid_collections_endpoint.py
+++ b/tests/test_distrokid_collections_endpoint.py
@@ -536,6 +536,30 @@ def test_get_collection_distrokid_release_json_returns_payload(serve_dir_dk, tmp
     assert len(body["release"]["tracks"]) == 2
 
 
+def test_get_collection_distrokid_release_json_decodes_space_in_collection_id(serve_dir_dk, tmp_path):
+    """Given スペース入り collection_id を URL encode した release.json URL
+    When `GET /collections/<id>/distrokid/<disc>/release.json`
+    Then decode 後の実 collection から payload を返す。
+    """
+    planning = tmp_path / "planning"
+    collection_id = "20260526-rainy jazz-collection"
+    coll = planning / collection_id
+    coll.mkdir(parents=True)
+    _make_disc(coll, "disc1-alpha", mp3_count=1, album_title="Rainy Jazz")
+    base = serve_dir_dk(planning)
+    encoded_id = urllib.parse.quote(collection_id, safe="")
+
+    url = f"{base}{_COLLECTIONS_ROUTE}/{encoded_id}/distrokid/disc1-alpha/release.json"
+    with urllib.request.urlopen(url) as resp:
+        assert resp.status == 200
+        body = json.loads(resp.read().decode("utf-8"))
+
+    assert body["release"]["album_title"] == "Rainy Jazz"
+    track = body["release"]["tracks"][0]
+    assert track["asset_path"].startswith(f"{_COLLECTIONS_ROUTE}/{encoded_id}/distrokid/assets/")
+    assert collection_id not in track["asset_path"]
+
+
 def test_get_collection_distrokid_release_json_asset_path_is_collection_scoped(serve_dir_dk, tmp_path):
     """Given collection-scoped release.json
     When track の asset_path を確認する
@@ -696,6 +720,24 @@ def test_get_collection_distrokid_asset_serves_mp3(serve_dir_dk, tmp_path):
     base = serve_dir_dk(planning)
 
     url = f"{base}{_COLLECTIONS_ROUTE}/20260526-abc-collection/distrokid/assets/30-distrokid/disc1-alpha/track-01.mp3"
+    with urllib.request.urlopen(url) as resp:
+        assert resp.status == 200
+        assert resp.headers.get("Content-Type") == "audio/mpeg"
+        assert resp.read() == _MP3_BYTES
+
+
+def test_get_collection_distrokid_asset_decodes_space_in_collection_id(serve_dir_dk, tmp_path):
+    """Given スペース入り collection_id を URL encode した asset URL
+    When `GET /collections/<id>/distrokid/assets/<rel>`
+    Then decode 後の実 collection から asset を返す。
+    """
+    planning = tmp_path / "planning"
+    collection_id = "20260526-rainy jazz-collection"
+    _make_collection(planning, collection_id, discs=["disc1-alpha"])
+    base = serve_dir_dk(planning)
+    encoded_id = urllib.parse.quote(collection_id, safe="")
+
+    url = f"{base}{_COLLECTIONS_ROUTE}/{encoded_id}/distrokid/assets/30-distrokid/disc1-alpha/track-01.mp3"
     with urllib.request.urlopen(url) as resp:
         assert resp.status == 200
         assert resp.headers.get("Content-Type") == "audio/mpeg"

--- a/tests/test_suno_artifact_contracts.py
+++ b/tests/test_suno_artifact_contracts.py
@@ -1,0 +1,16 @@
+"""Suno artifact route contract tests."""
+
+from __future__ import annotations
+
+from youtube_automation.utils.suno_artifact_contracts import collection_downloaded_route
+
+
+def test_collection_downloaded_route_encodes_collection_id_path_segment():
+    """Given スペース入り collection id
+    When downloaded route を組み立てる
+    Then collection id を path segment encode する。
+    """
+    assert (
+        collection_downloaded_route("20260601-clm-rainy jazz-collection")
+        == "/collections/20260601-clm-rainy%20jazz-collection/downloaded"
+    )


### PR DESCRIPTION
## Summary
- Decode URL-encoded collection IDs on GET `/collections/<id>/suno/prompts.json` before resolving prompts.
- Share the collection ID decode helper with POST `/collections/<id>/downloaded` so GET/POST behavior stays aligned.
- Add regression tests for `%20` collection IDs on both prompts GET and downloaded POST.

Fixes #1338

## Tests
- `uv run pytest tests/test_collection_serve.py -q`
- `uv run pytest -q` (`3861 passed, 19 warnings`)
