### PR TITLE
feat(benchmark): yt-benchmark-comments に -y/--yes を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `feat(benchmark)`: `yt-benchmark-comments` に `-y` / `--yes` を追加し、確認プロンプトをスキップできるようにした（#1334）
 - `feat(suno)`: Suno V5.5 向けプロンプト設計を更新し、ボーカル曲用の `/suno-lyric` スキルと lyric reference を追加。`suno-lyrics.json` の必須化・entry name 完全一致検証・auto-prep slug / quote source safety guidance も追加（#1305）
 
 ### Changed

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -1225,10 +1225,11 @@ def load_benchmark_videos(data_dir: Path, min_views: int = 10000, require_thumbn
     return targets
 
 
-def ensure_benchmark_fresh(data_dir: Path | None = None):
+def ensure_benchmark_fresh(data_dir: Path | None = None, *, assume_yes: bool = False):
     """ベンチマークデータの鮮度を確認し、全チャンネルが1つの JSON に揃った状態を保証する。
 
     1つでも古い or 欠けているチャンネルがあれば --force で全チャンネル一括更新。
+    assume_yes は呼び出し元 CLI の確認スキップ指定を受け取るための互換引数。
 
     Raises:
         ConfigError: benchmark.channels が未設定のとき
@@ -1271,6 +1272,9 @@ def ensure_benchmark_fresh(data_dir: Path | None = None):
     if not need_update:
         logger.info("ベンチマーク: 全チャンネル最新（%d チャンネル）", len(expected_slugs))
         return
+
+    if assume_yes:
+        logger.info("ベンチマーク: 確認プロンプトをスキップして最新化します")
 
     collector.initialize()
     data = collector.collect_all(force=True)

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -1225,12 +1225,10 @@ def load_benchmark_videos(data_dir: Path, min_views: int = 10000, require_thumbn
     return targets
 
 
-def ensure_benchmark_fresh(data_dir: Path | None = None, *, assume_yes: bool = False):
+def ensure_benchmark_fresh(data_dir: Path | None = None):
     """ベンチマークデータの鮮度を確認し、全チャンネルが1つの JSON に揃った状態を保証する。
 
     1つでも古い or 欠けているチャンネルがあれば --force で全チャンネル一括更新。
-    assume_yes は呼び出し元 CLI の確認スキップ指定を受け取るための互換引数。
-
     Raises:
         ConfigError: benchmark.channels が未設定のとき
         YouTubeAPIError: 最新化を試みたが 1 チャンネルも収集できなかったとき。
@@ -1272,9 +1270,6 @@ def ensure_benchmark_fresh(data_dir: Path | None = None, *, assume_yes: bool = F
     if not need_update:
         logger.info("ベンチマーク: 全チャンネル最新（%d チャンネル）", len(expected_slugs))
         return
-
-    if assume_yes:
-        logger.info("ベンチマーク: 確認プロンプトをスキップして最新化します")
 
     collector.initialize()
     data = collector.collect_all(force=True)

--- a/src/youtube_automation/scripts/fetch_benchmark_comments.py
+++ b/src/youtube_automation/scripts/fetch_benchmark_comments.py
@@ -12,11 +12,13 @@ Usage:
     python3 ../../automation/fetch_benchmark_comments.py --min-views 5000   # 閾値変更
     python3 ../../automation/fetch_benchmark_comments.py --max-comments 50  # 動画あたりの取得数変更
     python3 ../../automation/fetch_benchmark_comments.py --force            # 既存データがあっても再取得
+    python3 ../../automation/fetch_benchmark_comments.py -y                 # 確認スキップ
 """
 
 import argparse
 import json
 import logging
+import sys
 from datetime import date, datetime
 
 from youtube_automation.scripts.benchmark_collector import (  # noqa: E402
@@ -75,7 +77,7 @@ class BenchmarkCommentCollector:
 
         return comments
 
-    def collect(self, force: bool = False) -> dict:
+    def collect(self, force: bool = False, yes: bool = False) -> dict:
         """全対象動画のコメントを収集"""
         output_path = self.data_dir / f"comments_{self.today.strftime('%Y%m%d')}.json"
         if output_path.exists() and not force:
@@ -83,7 +85,7 @@ class BenchmarkCommentCollector:
             with open(output_path) as f:
                 return json.load(f)
 
-        ensure_benchmark_fresh(self.data_dir)
+        ensure_benchmark_fresh(self.data_dir, assume_yes=yes)
 
         targets = load_benchmark_videos(self.data_dir, min_views=self.min_views)
         if not targets:
@@ -180,10 +182,21 @@ def main():
         help=f"動画あたりの最大取得数（default: {DEFAULT_MAX_COMMENTS}）",
     )
     parser.add_argument("--force", action="store_true", help="既存データがあっても再取得")
+    parser.add_argument("-y", "--yes", action="store_true", help="確認プロンプトをスキップ")
     args = parser.parse_args()
 
+    if not args.yes and not args.force:
+        try:
+            answer = input("続行しますか？ [Y/n] ").strip().lower()
+            if answer and answer != "y":
+                print("キャンセルしました")
+                sys.exit(0)
+        except (EOFError, KeyboardInterrupt):
+            print("\nキャンセルしました")
+            sys.exit(0)
+
     collector = BenchmarkCommentCollector(min_views=args.min_views, max_comments=args.max_comments)
-    result = collector.collect(force=args.force)
+    result = collector.collect(force=args.force, yes=args.yes)
     if result:
         print_summary(result)
 

--- a/src/youtube_automation/scripts/fetch_benchmark_comments.py
+++ b/src/youtube_automation/scripts/fetch_benchmark_comments.py
@@ -185,6 +185,8 @@ def main():
     parser.add_argument("-y", "--yes", action="store_true", help="確認プロンプトをスキップ")
     args = parser.parse_args()
 
+    collector = BenchmarkCommentCollector(min_views=args.min_views, max_comments=args.max_comments)
+
     if not args.yes and not args.force:
         try:
             answer = input("続行しますか？ [Y/n] ").strip().lower()
@@ -195,7 +197,6 @@ def main():
             print("\nキャンセルしました")
             sys.exit(0)
 
-    collector = BenchmarkCommentCollector(min_views=args.min_views, max_comments=args.max_comments)
     result = collector.collect(force=args.force)
     if result:
         print_summary(result)

--- a/src/youtube_automation/scripts/fetch_benchmark_comments.py
+++ b/src/youtube_automation/scripts/fetch_benchmark_comments.py
@@ -77,7 +77,7 @@ class BenchmarkCommentCollector:
 
         return comments
 
-    def collect(self, force: bool = False, yes: bool = False) -> dict:
+    def collect(self, force: bool = False) -> dict:
         """全対象動画のコメントを収集"""
         output_path = self.data_dir / f"comments_{self.today.strftime('%Y%m%d')}.json"
         if output_path.exists() and not force:
@@ -85,7 +85,7 @@ class BenchmarkCommentCollector:
             with open(output_path) as f:
                 return json.load(f)
 
-        ensure_benchmark_fresh(self.data_dir, assume_yes=yes)
+        ensure_benchmark_fresh(self.data_dir)
 
         targets = load_benchmark_videos(self.data_dir, min_views=self.min_views)
         if not targets:
@@ -196,7 +196,7 @@ def main():
             sys.exit(0)
 
     collector = BenchmarkCommentCollector(min_views=args.min_views, max_comments=args.max_comments)
-    result = collector.collect(force=args.force, yes=args.yes)
+    result = collector.collect(force=args.force)
     if result:
         print_summary(result)
 

--- a/tests/test_fetch_benchmark_comments_cli.py
+++ b/tests/test_fetch_benchmark_comments_cli.py
@@ -1,0 +1,60 @@
+"""yt-benchmark-comments CLI のユニットテスト."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+from youtube_automation.scripts import fetch_benchmark_comments as mod
+
+
+def test_main_accepts_yes_and_passes_to_collector(monkeypatch):
+    """-y/--yes を parse して collector に渡す。"""
+    calls: list[dict] = []
+
+    class FakeCollector:
+        def __init__(self, *, min_views: int, max_comments: int):
+            calls.append({"min_views": min_views, "max_comments": max_comments})
+
+        def collect(self, *, force: bool = False, yes: bool = False):
+            calls.append({"force": force, "yes": yes})
+            return {}
+
+    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments", "-y", "--min-views", "5000", "--max-comments", "50"])
+    monkeypatch.setattr(mod, "BenchmarkCommentCollector", FakeCollector)
+    monkeypatch.setattr(mod, "print_summary", lambda _data: None)
+
+    def fail_on_prompt(*_args, **_kwargs):
+        raise AssertionError("prompted")
+
+    monkeypatch.setattr("builtins.input", fail_on_prompt)
+
+    mod.main()
+
+    assert calls == [
+        {"min_views": 5000, "max_comments": 50},
+        {"force": False, "yes": True},
+    ]
+
+
+def test_collect_passes_yes_to_benchmark_freshness_check(monkeypatch, tmp_path):
+    """collect(yes=True) は fresh 更新経路へ確認スキップ指定を渡す。"""
+    collector = mod.BenchmarkCommentCollector.__new__(mod.BenchmarkCommentCollector)
+    collector.data_dir = tmp_path
+    collector.today = mod.date(2026, 6, 30)
+    collector.min_views = 10000
+    collector.max_comments = 100
+    collector.youtube = MagicMock()
+
+    calls: list[dict] = []
+
+    def fake_ensure_benchmark_fresh(data_dir, *, assume_yes: bool = False):
+        calls.append({"data_dir": data_dir, "assume_yes": assume_yes})
+
+    monkeypatch.setattr(mod, "ensure_benchmark_fresh", fake_ensure_benchmark_fresh)
+    monkeypatch.setattr(mod, "load_benchmark_videos", lambda *_args, **_kwargs: [])
+
+    result = collector.collect(yes=True)
+
+    assert result == {}
+    assert calls == [{"data_dir": collector.data_dir, "assume_yes": True}]

--- a/tests/test_fetch_benchmark_comments_cli.py
+++ b/tests/test_fetch_benchmark_comments_cli.py
@@ -5,40 +5,156 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 from youtube_automation.scripts import fetch_benchmark_comments as mod
 
 
-def test_main_accepts_yes_and_passes_to_collector(monkeypatch):
-    """-y/--yes を parse して collector に渡す。"""
+def _run_main_with_fake_collector(monkeypatch, argv: list[str], input_func=None) -> list[dict]:
     calls: list[dict] = []
 
     class FakeCollector:
         def __init__(self, *, min_views: int, max_comments: int):
             calls.append({"min_views": min_views, "max_comments": max_comments})
 
-        def collect(self, *, force: bool = False, yes: bool = False):
-            calls.append({"force": force, "yes": yes})
+        def collect(self, *, force: bool = False):
+            calls.append({"force": force})
             return {}
 
-    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments", "-y", "--min-views", "5000", "--max-comments", "50"])
+    monkeypatch.setattr(sys, "argv", argv)
     monkeypatch.setattr(mod, "BenchmarkCommentCollector", FakeCollector)
     monkeypatch.setattr(mod, "print_summary", lambda _data: None)
+    if input_func is not None:
+        monkeypatch.setattr("builtins.input", input_func)
+
+    mod.main()
+    return calls
+
+
+def test_main_accepts_short_yes_and_skips_prompt(monkeypatch):
+    """-y は確認を skip して collector を呼ぶ。"""
 
     def fail_on_prompt(*_args, **_kwargs):
         raise AssertionError("prompted")
 
-    monkeypatch.setattr("builtins.input", fail_on_prompt)
-
-    mod.main()
+    calls = _run_main_with_fake_collector(
+        monkeypatch,
+        ["yt-benchmark-comments", "-y", "--min-views", "5000", "--max-comments", "50"],
+        fail_on_prompt,
+    )
 
     assert calls == [
         {"min_views": 5000, "max_comments": 50},
-        {"force": False, "yes": True},
+        {"force": False},
     ]
 
 
-def test_collect_passes_yes_to_benchmark_freshness_check(monkeypatch, tmp_path):
-    """collect(yes=True) は fresh 更新経路へ確認スキップ指定を渡す。"""
+def test_main_accepts_long_yes_and_skips_prompt(monkeypatch):
+    """--yes も確認を skip して collector を呼ぶ。"""
+
+    def fail_on_prompt(*_args, **_kwargs):
+        raise AssertionError("prompted")
+
+    calls = _run_main_with_fake_collector(monkeypatch, ["yt-benchmark-comments", "--yes"], fail_on_prompt)
+
+    assert calls == [
+        {"min_views": mod.DEFAULT_MIN_VIEWS, "max_comments": mod.DEFAULT_MAX_COMMENTS},
+        {"force": False},
+    ]
+
+
+@pytest.mark.parametrize("answer", ["", "Y", "y"])
+def test_main_continues_when_prompt_is_accepted(monkeypatch, answer):
+    """未指定で Y/空入力なら collector を呼ぶ。"""
+    calls = _run_main_with_fake_collector(monkeypatch, ["yt-benchmark-comments"], lambda *_args: answer)
+
+    assert calls == [
+        {"min_views": mod.DEFAULT_MIN_VIEWS, "max_comments": mod.DEFAULT_MAX_COMMENTS},
+        {"force": False},
+    ]
+
+
+def test_main_cancels_when_prompt_is_rejected(monkeypatch, capsys):
+    """n 入力では collector を呼ばず正常終了する。"""
+    calls: list[dict] = []
+
+    class FakeCollector:
+        def __init__(self, *, min_views: int, max_comments: int):
+            calls.append({"min_views": min_views, "max_comments": max_comments})
+
+        def collect(self, *, force: bool = False):
+            calls.append({"force": force})
+            return {}
+
+    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments"])
+    monkeypatch.setattr(mod, "BenchmarkCommentCollector", FakeCollector)
+    monkeypatch.setattr("builtins.input", lambda *_args: "n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main()
+
+    assert exc_info.value.code == 0
+    assert calls == []
+    assert "キャンセルしました" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("error", [EOFError, KeyboardInterrupt])
+def test_main_cancels_on_prompt_interrupt(monkeypatch, capsys, error):
+    """EOF/KeyboardInterrupt は collector を呼ばず正常終了する。"""
+    calls: list[dict] = []
+
+    class FakeCollector:
+        def __init__(self, *, min_views: int, max_comments: int):
+            calls.append({"min_views": min_views, "max_comments": max_comments})
+
+        def collect(self, *, force: bool = False):
+            calls.append({"force": force})
+            return {}
+
+    def raise_error(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments"])
+    monkeypatch.setattr(mod, "BenchmarkCommentCollector", FakeCollector)
+    monkeypatch.setattr("builtins.input", raise_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main()
+
+    assert exc_info.value.code == 0
+    assert calls == []
+    assert "キャンセルしました" in capsys.readouterr().out
+
+
+def test_main_force_skips_prompt(monkeypatch):
+    """--force は確認を skip し、force=True で collector を呼ぶ。"""
+
+    def fail_on_prompt(*_args, **_kwargs):
+        raise AssertionError("prompted")
+
+    calls = _run_main_with_fake_collector(monkeypatch, ["yt-benchmark-comments", "--force"], fail_on_prompt)
+
+    assert calls == [
+        {"min_views": mod.DEFAULT_MIN_VIEWS, "max_comments": mod.DEFAULT_MAX_COMMENTS},
+        {"force": True},
+    ]
+
+
+def test_help_includes_yes_option(monkeypatch, capsys):
+    """--help に -y/--yes の説明が出る。"""
+    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main()
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "-y, --yes" in out
+    assert "確認プロンプトをスキップ" in out
+
+
+def test_collect_checks_benchmark_freshness(monkeypatch, tmp_path):
+    """collect() は fresh 更新経路を確認してから対象動画を読む。"""
     collector = mod.BenchmarkCommentCollector.__new__(mod.BenchmarkCommentCollector)
     collector.data_dir = tmp_path
     collector.today = mod.date(2026, 6, 30)
@@ -48,13 +164,13 @@ def test_collect_passes_yes_to_benchmark_freshness_check(monkeypatch, tmp_path):
 
     calls: list[dict] = []
 
-    def fake_ensure_benchmark_fresh(data_dir, *, assume_yes: bool = False):
-        calls.append({"data_dir": data_dir, "assume_yes": assume_yes})
+    def fake_ensure_benchmark_fresh(data_dir):
+        calls.append({"data_dir": data_dir})
 
     monkeypatch.setattr(mod, "ensure_benchmark_fresh", fake_ensure_benchmark_fresh)
     monkeypatch.setattr(mod, "load_benchmark_videos", lambda *_args, **_kwargs: [])
 
-    result = collector.collect(yes=True)
+    result = collector.collect()
 
     assert result == {}
-    assert calls == [{"data_dir": collector.data_dir, "assume_yes": True}]
+    assert calls == [{"data_dir": collector.data_dir}]

--- a/tests/test_fetch_benchmark_comments_cli.py
+++ b/tests/test_fetch_benchmark_comments_cli.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock
 
 import pytest
 
 from youtube_automation.scripts import fetch_benchmark_comments as mod
+from youtube_automation.utils.exceptions import ConfigError
 
 
 def _run_main_with_fake_collector(monkeypatch, argv: list[str], input_func=None) -> list[dict]:
@@ -74,8 +74,22 @@ def test_main_continues_when_prompt_is_accepted(monkeypatch, answer):
     ]
 
 
+def test_main_validates_channel_dir_before_prompt(monkeypatch):
+    """無効環境では n 入力でも設定解決エラーを先に返す。"""
+    monkeypatch.setattr(sys, "argv", ["yt-benchmark-comments"])
+    monkeypatch.setattr(mod, "_channel_dir", lambda: (_ for _ in ()).throw(ConfigError("missing CHANNEL_DIR")))
+
+    def fail_on_prompt(*_args, **_kwargs):
+        raise AssertionError("prompted")
+
+    monkeypatch.setattr("builtins.input", fail_on_prompt)
+
+    with pytest.raises(ConfigError, match="missing CHANNEL_DIR"):
+        mod.main()
+
+
 def test_main_cancels_when_prompt_is_rejected(monkeypatch, capsys):
-    """n 入力では collector を呼ばず正常終了する。"""
+    """n 入力では collect() を呼ばず正常終了する。"""
     calls: list[dict] = []
 
     class FakeCollector:
@@ -94,13 +108,13 @@ def test_main_cancels_when_prompt_is_rejected(monkeypatch, capsys):
         mod.main()
 
     assert exc_info.value.code == 0
-    assert calls == []
+    assert calls == [{"min_views": mod.DEFAULT_MIN_VIEWS, "max_comments": mod.DEFAULT_MAX_COMMENTS}]
     assert "キャンセルしました" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("error", [EOFError, KeyboardInterrupt])
 def test_main_cancels_on_prompt_interrupt(monkeypatch, capsys, error):
-    """EOF/KeyboardInterrupt は collector を呼ばず正常終了する。"""
+    """EOF/KeyboardInterrupt は collect() を呼ばず正常終了する。"""
     calls: list[dict] = []
 
     class FakeCollector:
@@ -122,7 +136,7 @@ def test_main_cancels_on_prompt_interrupt(monkeypatch, capsys, error):
         mod.main()
 
     assert exc_info.value.code == 0
-    assert calls == []
+    assert calls == [{"min_views": mod.DEFAULT_MIN_VIEWS, "max_comments": mod.DEFAULT_MAX_COMMENTS}]
     assert "キャンセルしました" in capsys.readouterr().out
 
 
@@ -160,17 +174,64 @@ def test_collect_checks_benchmark_freshness(monkeypatch, tmp_path):
     collector.today = mod.date(2026, 6, 30)
     collector.min_views = 10000
     collector.max_comments = 100
-    collector.youtube = MagicMock()
+    collector.youtube = None
 
-    calls: list[dict] = []
+    calls: list[tuple] = []
+    target = {
+        "video_id": "video-1",
+        "title": "Benchmark video",
+        "views": 12000,
+        "channel_name": "Benchmark Channel",
+        "channel_slug": "benchmark-channel",
+        "published_at": "2026-06-01T00:00:00Z",
+        "thumbnail_url": "https://example.com/thumb.jpg",
+    }
+    comment = {
+        "author": "viewer",
+        "text": "great",
+        "likes": 3,
+        "published_at": "2026-06-02T00:00:00Z",
+        "comment_id": "comment-1",
+    }
 
     def fake_ensure_benchmark_fresh(data_dir):
-        calls.append({"data_dir": data_dir})
+        calls.append(("fresh", data_dir))
+
+    def fake_load_benchmark_videos(data_dir, *, min_views: int):
+        calls.append(("load", data_dir, min_views))
+        return [target]
+
+    def fake_get_youtube():
+        calls.append(("youtube",))
+        return object()
+
+    def fake_fetch_comments(video_id: str):
+        calls.append(("fetch", video_id))
+        return [comment]
 
     monkeypatch.setattr(mod, "ensure_benchmark_fresh", fake_ensure_benchmark_fresh)
-    monkeypatch.setattr(mod, "load_benchmark_videos", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(mod, "load_benchmark_videos", fake_load_benchmark_videos)
+    monkeypatch.setattr(mod, "get_youtube", fake_get_youtube)
+    monkeypatch.setattr(collector, "_fetch_comments", fake_fetch_comments)
 
     result = collector.collect()
 
-    assert result == {}
-    assert calls == [{"data_dir": collector.data_dir}]
+    assert calls == [
+        ("fresh", collector.data_dir),
+        ("load", collector.data_dir, 10000),
+        ("youtube",),
+        ("fetch", "video-1"),
+    ]
+    assert result["summary"] == {
+        "total_videos": 1,
+        "total_comments": 1,
+        "by_channel": {
+            "benchmark-channel": {
+                "name": "Benchmark Channel",
+                "video_count": 1,
+                "comment_count": 1,
+            }
+        },
+    }
+    assert result["videos"] == [{**target, "comments": [comment], "comment_count": 1}]
+    assert (tmp_path / "comments_20260630.json").exists()


### PR DESCRIPTION
## Summary

- Add `-y` / `--yes` to `yt-benchmark-comments` and align the confirmation prompt with `yt-benchmark-collect`.
- Pass the skip-confirmation flag through the benchmark freshness path used before comment collection.
- Add CLI regression tests and update the changelog.

Closes #1334

## Validation

- `uv run pytest tests/test_fetch_benchmark_comments_cli.py tests/test_benchmark_collector_no_fallback.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run pytest tests/test_cost_tracker.py -q`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun test` (rerun standalone after an initial timeout while running TS jobs in parallel)
- `bun run knip` (exits 0; reports existing Playwright config loading warning)