### PR TITLE
chore(suno-helper): ext-v0.2.1

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

Suno Helper extension release prep for ext-v0.2.1.

- Bump `extensions/suno-helper/package.json` from `0.2.0` to `0.2.1`
- Verified local `nr build` and `nr zip`
- Generated manifest reports version `0.2.1`

## Release

After merge, tag `ext-v0.2.1` on main and push it to trigger `.github/workflows/release-extensions.yml`.