### PR TITLE
feat: ObservedClip に duration と feed v3 定数を追加 (#1258)

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -162,6 +162,12 @@ export const FEED_ENDPOINT_PATH = "/api/feed/";
 /** active feed poll に使う具体 endpoint（#948）。 */
 export const FEED_V2_PATH = "/api/feed/v2";
 
+/** duration 取得に使う feed v3 endpoint（#1258）。後続の yield guard 実装で POST する。 */
+export const FEED_V3_PATH = "/api/feed/v3";
+
+/** feed v3 の request method（#1258）。v2 の GET poll と区別するため契約値として固定する。 */
+export const FEED_V3_METHOD = "POST";
+
 /** MAIN world bridge ⇄ ISOLATED content script の window.postMessage 識別マーカー（#948）。 */
 export const BRIDGE_SOURCE = "suno-helper-bridge";
 
@@ -175,6 +181,10 @@ export const BRIDGE_MSG = {
   FEED_POLL_REQUEST: "feed-poll-request",
   /** bridge → content: active poll の応答（requestId + clips | null）。 */
   FEED_POLL_RESPONSE: "feed-poll-response",
+  /** content → bridge: feed/v3 の active poll 要求（requestId + ids）。 */
+  FEED_V3_POLL_REQUEST: "feed-v3-poll-request",
+  /** bridge → content: feed/v3 active poll の応答（requestId + clips | null）。 */
+  FEED_V3_POLL_RESPONSE: "feed-v3-poll-response",
   /** content → bridge: slider 値注入要求（requestId + ariaLabel + target）（#973）。 */
   SLIDER_SET_REQUEST: "slider-set-request",
   /** bridge → content: slider 値注入の応答（requestId + ok + actual | null）（#973）。 */
@@ -201,6 +211,7 @@ export const FEED_POLL_RESPONSE_TIMEOUT_MS = 10000;
 export interface ObservedClip {
   id: string;
   status: string;
+  duration?: number;
 }
 
 /** yt-collection-serve の DistroKid collection 列挙サブパス（#934、dir mode のみ。単一 mode では 404）。

--- a/extensions/suno-helper/lib/bridge-listener.ts
+++ b/extensions/suno-helper/lib/bridge-listener.ts
@@ -28,13 +28,17 @@ interface BridgeMessage {
 function isObservedClipArray(value: unknown): value is ObservedClip[] {
   return (
     Array.isArray(value) &&
-    value.every(
-      (item) =>
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as { id?: unknown }).id === "string" &&
-        typeof (item as { status?: unknown }).status === "string",
-    )
+    value.every((item) => {
+      if (typeof item !== "object" || item === null) {
+        return false;
+      }
+      const clip = item as { duration?: unknown; id?: unknown; status?: unknown };
+      return (
+        typeof clip.id === "string" &&
+        typeof clip.status === "string" &&
+        (clip.duration === undefined || typeof clip.duration === "number")
+      );
+    })
   );
 }
 

--- a/extensions/suno-helper/tests/bridge-listener.test.ts
+++ b/extensions/suno-helper/tests/bridge-listener.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BRIDGE_MSG, BRIDGE_SOURCE } from "../../shared/constants";
-import { attachBridgeListener, createFeedPoller, requestSliderSet } from "../lib/bridge-listener";
+import { attachBridgeListener, createFeedPoller, requestFeedPoll, requestSliderSet } from "../lib/bridge-listener";
 import { createClipTracker } from "../lib/clip-tracker";
 
 /** bridge からの postMessage を模した MessageEvent を同期 dispatch する。 */
@@ -24,7 +24,7 @@ describe("attachBridgeListener: 観測イベントの tracker 配線", () => {
       source: BRIDGE_SOURCE,
       type: BRIDGE_MSG.GENERATE_CLIPS,
       clips: [
-        { id: "c1", status: "submitted" },
+        { id: "c1", status: "submitted", duration: 241.2 },
         { id: "c2", status: "submitted" },
       ],
     });
@@ -95,6 +95,12 @@ describe("attachBridgeListener: 観測イベントの tracker 配線", () => {
     // clips の形崩れ
     dispatchBridgeMessage({ source: BRIDGE_SOURCE, type: BRIDGE_MSG.GENERATE_CLIPS, clips: [{ id: 1 }] });
     dispatchBridgeMessage({ source: BRIDGE_SOURCE, type: BRIDGE_MSG.GENERATE_CLIPS });
+    // duration は optional だが、存在する場合は number のみ受け入れる
+    dispatchBridgeMessage({
+      source: BRIDGE_SOURCE,
+      type: BRIDGE_MSG.GENERATE_CLIPS,
+      clips: [{ id: "x", status: "submitted", duration: "241.2" }],
+    });
 
     expect(tracker.hasObservedAnyTraffic()).toBe(false);
     expect(tracker.getInFlightCount()).toBe(0);
@@ -112,6 +118,55 @@ describe("attachBridgeListener: 観測イベントの tracker 配線", () => {
       clips: [{ id: "c1", status: "submitted" }],
     });
     expect(tracker.hasObservedAnyTraffic()).toBe(false);
+  });
+});
+
+describe("requestFeedPoll: active poll 応答の ObservedClip 境界検証", () => {
+  async function captureFeedPollRequestId(): Promise<number> {
+    return new Promise<number>((resolve) => {
+      const probe = (event: MessageEvent): void => {
+        const data = event.data as { requestId?: number; type?: string };
+        if (data?.type === BRIDGE_MSG.FEED_POLL_REQUEST && typeof data.requestId === "number") {
+          window.removeEventListener("message", probe);
+          resolve(data.requestId);
+        }
+      };
+      window.addEventListener("message", probe);
+    });
+  }
+
+  it("Given duration あり / なしの poll 応答 When 受信する Then ObservedClip[] として resolve する", async () => {
+    const pending = requestFeedPoll(["c1", "c2"]);
+    const requestId = await captureFeedPollRequestId();
+
+    dispatchBridgeMessage({
+      source: BRIDGE_SOURCE,
+      type: BRIDGE_MSG.FEED_POLL_RESPONSE,
+      requestId,
+      clips: [
+        { id: "c1", status: "streaming", duration: 241.2 },
+        { id: "c2", status: "complete" },
+      ],
+    });
+
+    await expect(pending).resolves.toEqual([
+      { id: "c1", status: "streaming", duration: 241.2 },
+      { id: "c2", status: "complete" },
+    ]);
+  });
+
+  it("Given duration が number ではない poll 応答 When 受信する Then null で resolve する", async () => {
+    const pending = requestFeedPoll(["c1"]);
+    const requestId = await captureFeedPollRequestId();
+
+    dispatchBridgeMessage({
+      source: BRIDGE_SOURCE,
+      type: BRIDGE_MSG.FEED_POLL_RESPONSE,
+      requestId,
+      clips: [{ id: "c1", status: "streaming", duration: "241.2" }],
+    });
+
+    await expect(pending).resolves.toBeNull();
   });
 });
 

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -5,10 +5,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BRIDGE_MSG,
   CLIPS_PER_REQUEST,
   COLLECTIONS_ROUTE,
   collectionPromptsRoute,
   DEFAULT_URL,
+  FEED_V2_PATH,
+  FEED_V3_METHOD,
+  FEED_V3_PATH,
   INJECT_ACK_TIMEOUT_MS,
   INTER_CREATE_DELAY_MS,
   MAX_INFLIGHT_REQUESTS,
@@ -21,6 +25,7 @@ import {
   SPEED_PRESET_STORAGE_KEY,
   SPEED_PRESETS,
   STORAGE_KEY,
+  type ObservedClip,
 } from "../../shared/constants";
 
 describe("shared/constants: サーバー互換の契約値", () => {
@@ -99,6 +104,29 @@ describe("shared/constants: Suno queue 上限 (#816)", () => {
 
   it("Given 上限定数 When 積で最大 clip を求める Then 20 clip になる", () => {
     expect(MAX_INFLIGHT_REQUESTS * CLIPS_PER_REQUEST).toBe(20);
+  });
+});
+
+describe("shared/constants: Suno feed bridge 契約 (#1258)", () => {
+  it("Given feed endpoint constants When 読む Then v2 GET poll と v3 POST 用 path/method を固定する", () => {
+    expect(FEED_V2_PATH).toBe("/api/feed/v2");
+    expect(FEED_V3_PATH).toBe("/api/feed/v3");
+    expect(FEED_V3_METHOD).toBe("POST");
+  });
+
+  it("Given BRIDGE_MSG When feed v3 poll の message type を読む Then v2 と別名で固定されている", () => {
+    expect(BRIDGE_MSG.FEED_POLL_REQUEST).toBe("feed-poll-request");
+    expect(BRIDGE_MSG.FEED_POLL_RESPONSE).toBe("feed-poll-response");
+    expect(BRIDGE_MSG.FEED_V3_POLL_REQUEST).toBe("feed-v3-poll-request");
+    expect(BRIDGE_MSG.FEED_V3_POLL_RESPONSE).toBe("feed-v3-poll-response");
+  });
+
+  it("Given ObservedClip When duration を持つ clip / 持たない clip を扱う Then optional field として型付けできる", () => {
+    const withDuration = { id: "clip-1", status: "complete", duration: 241.2 } satisfies ObservedClip;
+    const withoutDuration = { id: "clip-2", status: "queued" } satisfies ObservedClip;
+
+    expect(withDuration.duration).toBe(241.2);
+    expect("duration" in withoutDuration).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `duration?: number` to the shared `ObservedClip` contract.
- Add feed v3 bridge contract constants for `/api/feed/v3` POST and dedicated feed v3 poll message names.
- Pin the new shared contract values with Suno Helper constants tests.

Closes #1258

## Validation

- `pnpm format:check` (extensions/suno-helper)
- `pnpm compile` (extensions/suno-helper)
- `pnpm test -- constants.test.ts` (extensions/suno-helper)
- `pnpm lint` (extensions/suno-helper)
- `pnpm build` (extensions/suno-helper)
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun test`
- `bun run knip`

Note: initial `bun run ci` hit a local 5s timeout in unrelated skill sync tests during first-run I/O; rerunning `bun test` separately passed all 433 tests.
