### PR TITLE
[codex] PatternListにentry選択チェックボックスを追加

### DIFF
--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { DEFAULT_URL, DOWNLOAD_FORMAT_DEFAULT, SPEED_PRESETS, type SpeedPresetId } from "../../shared/constants";
 import { downloadFormatItem, readDownloadFormat, type DownloadFormat } from "../lib/storage";
-import { PatternList } from "./PatternList";
+import { PatternList, reconcilePatternSelection } from "./PatternList";
 import { useSunoRunner } from "./useSunoRunner";
 
 // 実行モード selector の表示順 (#875)。Fast → Balanced → Safe で速度順に並べる。
@@ -11,6 +11,7 @@ const DOWNLOAD_FORMAT_OPTIONS: DownloadFormat[] = ["mp3", "m4a", "wav"];
 
 export function App() {
   const [downloadFormat, setDownloadFormat] = useState<DownloadFormat>(DOWNLOAD_FORMAT_DEFAULT);
+  const [selectedEntries, setSelectedEntries] = useState<boolean[]>([]);
   const {
     url,
     setUrl,
@@ -45,6 +46,8 @@ export function App() {
     run,
     stop,
   } = useSunoRunner();
+  const previousEntriesRef = useRef(entries);
+  const previousItemStatesRef = useRef(itemStates);
 
   useEffect(() => {
     let mounted = true;
@@ -61,6 +64,24 @@ export function App() {
   const updateDownloadFormat = (value: DownloadFormat): void => {
     setDownloadFormat(value);
     void downloadFormatItem.setValue(value);
+  };
+
+  useEffect(() => {
+    setSelectedEntries((selection) =>
+      reconcilePatternSelection({
+        selection,
+        previousEntries: previousEntriesRef.current,
+        previousItemStates: previousItemStatesRef.current,
+        entries,
+        itemStates,
+      }),
+    );
+    previousEntriesRef.current = entries;
+    previousItemStatesRef.current = itemStates;
+  }, [entries, itemStates]);
+
+  const toggleEntrySelection = (index: number, checked: boolean): void => {
+    setSelectedEntries((selection) => selection.map((selected, i) => (i === index ? checked : selected)));
   };
 
   return (
@@ -287,7 +308,12 @@ export function App() {
         </div>
       )}
 
-      <PatternList entries={entries} itemStates={itemStates} />
+      <PatternList
+        entries={entries}
+        itemStates={itemStates}
+        selectedEntries={selectedEntries}
+        onToggleEntry={toggleEntrySelection}
+      />
 
       {status && (
         <p className={`whitespace-pre-wrap text-xs ${isError ? "text-red-600" : "text-gray-600"}`}>{status}</p>

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { DEFAULT_URL, DOWNLOAD_FORMAT_DEFAULT, SPEED_PRESETS, type SpeedPresetId } from "../../shared/constants";
 import { downloadFormatItem, readDownloadFormat, type DownloadFormat } from "../lib/storage";
-import { PatternList, reconcilePatternSelection } from "./PatternList";
+import { buildInitialPatternSelection, PatternList, reconcilePatternSelection } from "./PatternList";
 import { useSunoRunner } from "./useSunoRunner";
 
 // 実行モード selector の表示順 (#875)。Fast → Balanced → Safe で速度順に並べる。
@@ -81,8 +81,19 @@ export function App() {
   }, [entries, itemStates]);
 
   const toggleEntrySelection = (index: number, checked: boolean): void => {
-    setSelectedEntries((selection) => selection.map((selected, i) => (i === index ? checked : selected)));
+    setSelectedEntries((selection) =>
+      reconcilePatternSelection({
+        selection,
+        previousEntries: previousEntriesRef.current,
+        previousItemStates: previousItemStatesRef.current,
+        entries,
+        itemStates,
+      }).map((selected, i) => (i === index ? checked : selected)),
+    );
   };
+
+  const resolvedSelectedEntries =
+    selectedEntries.length === entries.length ? selectedEntries : buildInitialPatternSelection(entries, itemStates);
 
   return (
     <div className="flex flex-col gap-3 p-3 text-gray-900">
@@ -311,7 +322,7 @@ export function App() {
       <PatternList
         entries={entries}
         itemStates={itemStates}
-        selectedEntries={selectedEntries}
+        selectedEntries={resolvedSelectedEntries}
         onToggleEntry={toggleEntrySelection}
       />
 

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -67,11 +67,13 @@ export function App() {
   };
 
   useEffect(() => {
+    const previousEntries = previousEntriesRef.current;
+    const previousItemStates = previousItemStatesRef.current;
     setSelectedEntries((selection) =>
       reconcilePatternSelection({
         selection,
-        previousEntries: previousEntriesRef.current,
-        previousItemStates: previousItemStatesRef.current,
+        previousEntries,
+        previousItemStates,
         entries,
         itemStates,
       }),

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -60,7 +60,7 @@ export function PatternList({ entries, itemStates, selectedEntries, onToggleEntr
             <label className="flex items-center gap-2">
               <input
                 type="checkbox"
-                checked={selectedEntries[index] ?? itemState !== "done"}
+                checked={selectedEntries[index]!}
                 onChange={(event) => onToggleEntry(index, event.currentTarget.checked)}
                 aria-label={`entry ${index + 1}: ${entry.name}`}
                 className="h-4 w-4 shrink-0"

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -4,6 +4,8 @@ import type { ItemState } from "../../shared/constants";
 interface PatternListProps {
   entries: PromptEntry[];
   itemStates: ItemState[];
+  selectedEntries: boolean[];
+  onToggleEntry: (index: number, checked: boolean) => void;
 }
 
 const STATE_CLASS: Record<ItemState, string> = {
@@ -14,17 +16,60 @@ const STATE_CLASS: Record<ItemState, string> = {
   failed: "bg-red-50 font-medium text-red-700",
 };
 
-export function PatternList({ entries, itemStates }: PatternListProps) {
+export function buildInitialPatternSelection(entries: PromptEntry[], itemStates: ItemState[]): boolean[] {
+  return entries.map((_, index) => (itemStates[index] ?? "idle") !== "done");
+}
+
+export function reconcilePatternSelection({
+  selection,
+  previousEntries,
+  previousItemStates,
+  entries,
+  itemStates,
+}: {
+  selection: boolean[];
+  previousEntries: PromptEntry[];
+  previousItemStates: ItemState[];
+  entries: PromptEntry[];
+  itemStates: ItemState[];
+}): boolean[] {
+  if (previousEntries !== entries || selection.length !== entries.length) {
+    return buildInitialPatternSelection(entries, itemStates);
+  }
+
+  return entries.map((_, index) => {
+    const previousState = previousItemStates[index] ?? "idle";
+    const nextState = itemStates[index] ?? "idle";
+    if (previousState !== "done" && nextState === "done") {
+      return false;
+    }
+    return selection[index] ?? nextState !== "done";
+  });
+}
+
+export function PatternList({ entries, itemStates, selectedEntries, onToggleEntry }: PatternListProps) {
   if (entries.length === 0) {
     return null;
   }
   return (
     <ul className="max-h-48 overflow-y-auto rounded border border-gray-200">
-      {entries.map((entry, index) => (
-        <li key={`${entry.name}-${index}`} className={`px-2 py-1 text-sm ${STATE_CLASS[itemStates[index] ?? "idle"]}`}>
-          {entry.name}
-        </li>
-      ))}
+      {entries.map((entry, index) => {
+        const itemState = itemStates[index] ?? "idle";
+        return (
+          <li key={`${entry.name}-${index}`} className={`px-2 py-1 text-sm ${STATE_CLASS[itemState]}`}>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selectedEntries[index] ?? itemState !== "done"}
+                onChange={(event) => onToggleEntry(index, event.currentTarget.checked)}
+                aria-label={`entry ${index + 1}: ${entry.name}`}
+                className="h-4 w-4 shrink-0"
+              />
+              <span className="min-w-0 flex-1">{entry.name}</span>
+            </label>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -87,5 +87,37 @@ describe("PatternList checkbox UI", () => {
     });
 
     expect(onToggleEntry).toHaveBeenCalledWith(1, true);
+  });
+
+  it("controlled state 更新後に done entry の手動再チェックを DOM に反映する", () => {
+    const entries = makePromptEntries(3);
+    const itemStates: ItemState[] = ["idle", "done", "failed"];
+
+    function StatefulPatternList() {
+      const [selectedEntries, setSelectedEntries] = useState(() => buildInitialPatternSelection(entries, itemStates));
+      return createElement(PatternList, {
+        entries,
+        itemStates,
+        selectedEntries,
+        onToggleEntry: (index: number, checked: boolean) => {
+          setSelectedEntries((selection) => selection.map((selected, i) => (i === index ? checked : selected)));
+        },
+      });
+    }
+
+    act(() => {
+      root.render(createElement(StatefulPatternList));
+    });
+
+    let checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, false, true]);
+
+    act(() => {
+      checkboxes[1]!.click();
+    });
+
+    checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, true, true]);
+    expect(checkboxes[1]!.closest("li")?.className).toContain("line-through");
   });
 });

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ItemState } from "../../shared/constants";
+import { buildInitialPatternSelection, PatternList, reconcilePatternSelection } from "../components/PatternList";
+import { makePromptEntries } from "./_helpers";
+
+describe("PatternList selection helpers", () => {
+  it("初期 selection は done entry だけ OFF にする", () => {
+    const entries = makePromptEntries(3);
+
+    expect(buildInitialPatternSelection(entries, ["idle", "done", "failed"])).toEqual([true, false, true]);
+  });
+
+  it("同じ entries では手動 selection を保持し、done に遷移した entry だけ OFF にする", () => {
+    const entries = makePromptEntries(3);
+    const previousItemStates: ItemState[] = ["idle", "done", "failed"];
+    const itemStates: ItemState[] = ["done", "done", "failed"];
+
+    expect(
+      reconcilePatternSelection({
+        selection: [true, true, false],
+        previousEntries: entries,
+        previousItemStates,
+        entries,
+        itemStates,
+      }),
+    ).toEqual([false, true, false]);
+  });
+
+  it("entries が差し替わった場合は itemStates から初期 selection を作り直す", () => {
+    const previousEntries = makePromptEntries(3);
+    const entries = makePromptEntries(2);
+
+    expect(
+      reconcilePatternSelection({
+        selection: [false, false, false],
+        previousEntries,
+        previousItemStates: ["done", "done", "done"],
+        entries,
+        itemStates: ["idle", "done"],
+      }),
+    ).toEqual([true, false]);
+  });
+});
+
+describe("PatternList checkbox UI", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("各 entry の checkbox に selection を反映し、done entry は打ち消し線のまま手動で再チェックできる", () => {
+    const onToggleEntry = vi.fn();
+
+    act(() => {
+      root.render(
+        createElement(PatternList, {
+          entries: makePromptEntries(3),
+          itemStates: ["idle", "done", "failed"],
+          selectedEntries: [true, false, true],
+          onToggleEntry,
+        }),
+      );
+    });
+
+    const checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, false, true]);
+    expect(checkboxes[1].closest("li")?.className).toContain("line-through");
+
+    act(() => {
+      checkboxes[1].click();
+    });
+
+    expect(onToggleEntry).toHaveBeenCalledWith(1, true);
+  });
+});

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -5,7 +5,7 @@ import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PHASE, type ProgressPayload, type SnapshotPayload } from "../../shared/constants";
+import { PHASE, type ProgressPayload } from "../../shared/constants";
 import { App } from "../components/App";
 
 const BASE_URL = "http://localhost:7873";
@@ -660,11 +660,12 @@ describe("Suno popup compatibility check", () => {
       { name: "p2", style: "jazz", lyrics: "" },
       { name: "p3", style: "ambient", lyrics: "" },
     ];
-    const snapshot: SnapshotPayload = {
+    const snapshot = {
       entries,
       itemStates: entries.map(() => "idle"),
       isRunning: true,
       progress: { phase: PHASE.INJECTING, total: entries.length },
+      collectionId: null,
     };
     let progressHandler: ((event: { data: ProgressPayload }) => void) | undefined;
 

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -662,11 +662,21 @@ describe("Suno popup compatibility check", () => {
     ];
     let progressHandler: ((event: { data: ProgressPayload }) => void) | undefined;
 
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
-      .mockResolvedValueOnce(jsonResponse(404, {}))
-      .mockResolvedValueOnce(jsonResponse(200, entries));
-    messagingMocks.sendMessage.mockImplementation(defaultSendMessage);
+    messagingMocks.sendMessage.mockImplementation((message: string, payload?: Record<string, string>) => {
+      if (message === "queryProgress") {
+        throw new Error("runner unavailable");
+      }
+      if (message === "fetchCompatibilityWarning") {
+        return Promise.resolve("");
+      }
+      if (message === "fetchCollections") {
+        return Promise.reject(new Error("HTTP 404"));
+      }
+      if (message === "fetchPrompts") {
+        return Promise.resolve(entries);
+      }
+      return defaultSendMessage(message, payload);
+    });
     messagingMocks.onMessage.mockImplementation((message?: unknown, handler?: unknown) => {
       if (message === "progress" && typeof handler === "function") {
         progressHandler = handler as (event: { data: ProgressPayload }) => void;

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -5,7 +5,7 @@ import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PHASE, type ProgressPayload } from "../../shared/constants";
+import { PHASE, type ProgressPayload, type SnapshotPayload } from "../../shared/constants";
 import { App } from "../components/App";
 
 const BASE_URL = "http://localhost:7873";
@@ -660,20 +660,17 @@ describe("Suno popup compatibility check", () => {
       { name: "p2", style: "jazz", lyrics: "" },
       { name: "p3", style: "ambient", lyrics: "" },
     ];
+    const snapshot: SnapshotPayload = {
+      entries,
+      itemStates: entries.map(() => "idle"),
+      isRunning: true,
+      progress: { phase: PHASE.INJECTING, total: entries.length },
+    };
     let progressHandler: ((event: { data: ProgressPayload }) => void) | undefined;
 
     messagingMocks.sendMessage.mockImplementation((message: string, payload?: Record<string, string>) => {
       if (message === "queryProgress") {
-        throw new Error("runner unavailable");
-      }
-      if (message === "fetchCompatibilityWarning") {
-        return Promise.resolve("");
-      }
-      if (message === "fetchCollections") {
-        return Promise.reject(new Error("HTTP 404"));
-      }
-      if (message === "fetchPrompts") {
-        return Promise.resolve(entries);
+        return Promise.resolve(snapshot);
       }
       return defaultSendMessage(message, payload);
     });
@@ -693,22 +690,14 @@ describe("Suno popup compatibility check", () => {
       root.render(createElement(App));
     });
 
-    await act(async () => {
-      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
-    });
-    await act(async () => {
-      buttonByText(container, "データ取得").click();
-    });
-    await waitFor(() => {
-      expect(container.textContent).toContain("3 パターンを取得しました。");
-    });
-
     const checkboxStates = (): boolean[] =>
       Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).map(
         (checkbox) => checkbox.checked,
       );
 
-    expect(checkboxStates()).toEqual([true, true, true]);
+    await waitFor(() => {
+      expect(checkboxStates()).toEqual([true, true, true]);
+    });
 
     await act(async () => {
       progressHandler?.({ data: { phase: PHASE.DONE, index: 1, total: entries.length } });

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -5,6 +5,7 @@ import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { PHASE, type ProgressPayload } from "../../shared/constants";
 import { App } from "../components/App";
 
 const BASE_URL = "http://localhost:7873";
@@ -650,6 +651,77 @@ describe("Suno popup compatibility check", () => {
     if (!select) throw new Error("download format select not found");
     await waitFor(() => {
       expect(select.value).toBe("mp3");
+    });
+  });
+
+  it("App 配線で done entry の自動 OFF と手動再チェック保持を反映する", async () => {
+    const entries = [
+      { name: "p1", style: "lofi", lyrics: "" },
+      { name: "p2", style: "jazz", lyrics: "" },
+      { name: "p3", style: "ambient", lyrics: "" },
+    ];
+    let progressHandler: ((event: { data: ProgressPayload }) => void) | undefined;
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(200, entries));
+    messagingMocks.sendMessage.mockImplementation(defaultSendMessage);
+    messagingMocks.onMessage.mockImplementation((message?: unknown, handler?: unknown) => {
+      if (message === "progress" && typeof handler === "function") {
+        progressHandler = handler as (event: { data: ProgressPayload }) => void;
+      }
+      return () => undefined;
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.innerHTML = "";
+    root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(App));
+    });
+
+    await act(async () => {
+      setInputValue(container.querySelector<HTMLInputElement>('input[type="text"]')!, BASE_URL);
+    });
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("3 パターンを取得しました。");
+    });
+
+    const checkboxStates = (): boolean[] =>
+      Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).map(
+        (checkbox) => checkbox.checked,
+      );
+
+    expect(checkboxStates()).toEqual([true, true, true]);
+
+    await act(async () => {
+      progressHandler?.({ data: { phase: PHASE.DONE, index: 1, total: entries.length } });
+    });
+    await waitFor(() => {
+      expect(checkboxStates()).toEqual([true, false, true]);
+    });
+    expect(
+      Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'))[1]?.closest("li")?.className,
+    ).toContain("line-through");
+
+    await act(async () => {
+      Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'))[1]?.click();
+    });
+    await waitFor(() => {
+      expect(checkboxStates()).toEqual([true, true, true]);
+    });
+
+    await act(async () => {
+      progressHandler?.({ data: { phase: PHASE.DONE, index: 0, total: entries.length } });
+    });
+    await waitFor(() => {
+      expect(checkboxStates()).toEqual([false, true, true]);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add per-entry checkboxes to the Suno helper `PatternList` popup UI.
- Keep `done` entries unchecked by default while preserving the existing line-through state styling.
- Preserve manual re-checks for `done` entries, and only auto-uncheck an entry when it transitions into `done`.

## Validation

- `./node_modules/.bin/vitest run tests/pattern-list.test.ts` in `extensions/suno-helper`
- `./node_modules/.bin/wxt prepare && ./node_modules/.bin/tsc --noEmit` in `extensions/suno-helper`
- `./suno-helper/node_modules/.bin/eslint -c suno-helper/eslint.config.js suno-helper shared` in `extensions`
- `./node_modules/.bin/vitest run` in `extensions/suno-helper`
- `./node_modules/.bin/prettier --check . ../shared` in `extensions/suno-helper`
- `./node_modules/.bin/wxt build` in `extensions/suno-helper`
- manifest permissions check
- `./node_modules/.bin/playwright test` in `extensions/suno-helper`

Closes #1262
