### PR TITLE
[#1369] issue-1369-github-actionsno-st

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main, feat/ts-rewrite, feat/1143-suno-bulk-download]
-  pull_request:
-    branches: [main, feat/ts-rewrite, feat/1143-suno-bulk-download]
+  pull_request: {}
 
 jobs:
   lint:
@@ -13,8 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - run: nix develop --command uv sync --extra dev
-      - run: nix develop --command uv run ruff check .
-      - run: nix develop --command uv run ruff format --check .
+      - parallel:
+          - name: Ruff check
+            run: nix develop --command uv run ruff check .
+          - name: Ruff format check
+            run: nix develop --command uv run ruff format --check .
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -7,7 +7,6 @@ on:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
   pull_request:
-    branches: [main, feat/1143-suno-bulk-download]
     paths:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
@@ -30,16 +29,20 @@ jobs:
           cache-dependency-path: extensions/suno-helper/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-workspace
-      - name: Lint
-        run: pnpm lint
-      - name: Format check
-        run: pnpm format:check
-      - name: Type check
-        run: pnpm compile
-      - name: Unit tests (Vitest)
-        run: pnpm test
-      - name: Build
-        run: pnpm build
+      - parallel:
+          - name: Lint
+            run: pnpm lint
+          - name: Format check
+            run: pnpm format:check
+          - name: Type check
+            run: pnpm compile
+          - name: Unit tests (Vitest)
+            run: pnpm test
+      - parallel:
+          - name: Build
+            run: pnpm build
+          - name: Install Playwright browser
+            run: pnpm exec playwright install --with-deps chromium
       - name: Verify generated manifest permissions (least-privilege)
         run: |
           node --input-type=module -e '
@@ -57,8 +60,6 @@ jobs:
               process.exit(1);
             }
           '
-      - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps chromium
       - name: E2E tests (Playwright)
         run: pnpm test:e2e
 
@@ -79,17 +80,19 @@ jobs:
           cache-dependency-path: extensions/distrokid-helper/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-workspace
-      - name: Lint
-        run: pnpm lint
-      - name: Format check
-        run: pnpm format:check
-      - name: Typecheck
-        run: pnpm compile
-      - name: Build
-        run: pnpm build
-      - name: Unit tests (Vitest)
-        run: pnpm test
-      - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps chromium
+      - parallel:
+          - name: Lint
+            run: pnpm lint
+          - name: Format check
+            run: pnpm format:check
+          - name: Typecheck
+            run: pnpm compile
+          - name: Unit tests (Vitest)
+            run: pnpm test
+      - parallel:
+          - name: Build
+            run: pnpm build
+          - name: Install Playwright browser
+            run: pnpm exec playwright install --with-deps chromium
       - name: E2E (Playwright)
         run: pnpm test:e2e

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -25,16 +25,17 @@ jobs:
           cache-dependency-path: |
             extensions/suno-helper/pnpm-lock.yaml
             extensions/distrokid-helper/pnpm-lock.yaml
-      - name: Build and zip suno-helper
-        working-directory: extensions/suno-helper
-        run: |
-          pnpm install --frozen-lockfile --ignore-workspace
-          pnpm zip
-      - name: Build and zip distrokid-helper
-        working-directory: extensions/distrokid-helper
-        run: |
-          pnpm install --frozen-lockfile --ignore-workspace
-          pnpm zip
+      - parallel:
+          - name: Build and zip suno-helper
+            working-directory: extensions/suno-helper
+            run: |
+              pnpm install --frozen-lockfile --ignore-workspace
+              pnpm zip
+          - name: Build and zip distrokid-helper
+            working-directory: extensions/distrokid-helper
+            run: |
+              pnpm install --frozen-lockfile --ignore-workspace
+              pnpm zip
       - name: Attach zips to Release
         uses: softprops/action-gh-release@v2
         with:

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -1,0 +1,174 @@
+"""GitHub Actions step 並列化の workflow 契約を静的に検証する。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CI_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_EXTENSIONS_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "extensions.yml"
+_RELEASE_EXTENSIONS_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "release-extensions.yml"
+
+_CI_LINT_PARALLEL_STEPS = {
+    "Ruff check": "nix develop --command uv run ruff check .",
+    "Ruff format check": "nix develop --command uv run ruff format --check .",
+}
+
+_SUNO_FAST_PARALLEL_STEPS = {
+    "Lint": "pnpm lint",
+    "Format check": "pnpm format:check",
+    "Type check": "pnpm compile",
+    "Unit tests (Vitest)": "pnpm test",
+}
+_SUNO_BUILD_PARALLEL_STEPS = {
+    "Build": "pnpm build",
+    "Install Playwright browser": "pnpm exec playwright install --with-deps chromium",
+}
+_DISTROKID_FAST_PARALLEL_STEPS = {
+    "Lint": "pnpm lint",
+    "Format check": "pnpm format:check",
+    "Typecheck": "pnpm compile",
+    "Unit tests (Vitest)": "pnpm test",
+}
+_DISTROKID_BUILD_PARALLEL_STEPS = _SUNO_BUILD_PARALLEL_STEPS
+
+_RELEASE_BUILD_PARALLEL_STEPS = {
+    "Build and zip suno-helper": ("extensions/suno-helper", "pnpm zip"),
+    "Build and zip distrokid-helper": ("extensions/distrokid-helper", "pnpm zip"),
+}
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        pytest.fail(f"必須ファイルが存在しない: {path.relative_to(_REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_workflow(path: Path) -> dict[str, object]:
+    return yaml.safe_load(_read_text(path))
+
+
+def _on_section(workflow: dict[str, object]) -> dict[str, object]:
+    section = workflow.get("on", workflow.get(True))
+    assert isinstance(section, dict), "on トリガーが存在しない"
+    return section
+
+
+def _job_steps(workflow: dict[str, object], job_name: str) -> list[dict[str, object]]:
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"{job_name} job が存在しない"
+    steps = job.get("steps")
+    assert isinstance(steps, list) and steps, f"{job_name} job に steps が存在しない"
+    return steps
+
+
+def _parallel_groups(steps: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+    groups: list[list[dict[str, object]]] = []
+    for step in steps:
+        if "parallel" not in step:
+            continue
+        parallel_steps = step.get("parallel")
+        assert isinstance(parallel_steps, list) and parallel_steps, "parallel step が空"
+        groups.append(parallel_steps)
+    return groups
+
+
+def _parallel_group_with_names(steps: list[dict[str, object]], expected_names: set[str]) -> list[dict[str, object]]:
+    for group in _parallel_groups(steps):
+        names = {str(step.get("name", "")) for step in group}
+        if names == expected_names:
+            return group
+    pytest.fail(f"expected parallel group が存在しない: {sorted(expected_names)}")
+
+
+def _assert_named_parallel_commands(steps: list[dict[str, object]], expected: dict[str, str]) -> None:
+    group = _parallel_group_with_names(steps, set(expected))
+    commands_by_name = {str(step["name"]): str(step.get("run", "")) for step in group}
+    assert commands_by_name == expected
+
+
+def _top_level_step_index(steps: list[dict[str, object]], name: str) -> int:
+    for index, step in enumerate(steps):
+        if step.get("name") == name:
+            return index
+    pytest.fail(f"{name} step が top-level に存在しない")
+
+
+def _parallel_group_index_containing(steps: list[dict[str, object]], name: str) -> int:
+    for index, step in enumerate(steps):
+        parallel_steps = step.get("parallel")
+        if not isinstance(parallel_steps, list):
+            continue
+        if any(parallel_step.get("name") == name for parallel_step in parallel_steps):
+            return index
+    pytest.fail(f"{name} step を含む parallel group が存在しない")
+
+
+def test_extensions_pull_request_trigger_allows_stacked_pr_base_branches() -> None:
+    """Given stacked PR, When workflow trigger is evaluated, Then base branch allowlist is absent."""
+    workflow = _load_workflow(_EXTENSIONS_WORKFLOW_PATH)
+    pull_request = _on_section(workflow).get("pull_request")
+
+    assert isinstance(pull_request, dict), "Extensions pull_request トリガーが存在しない"
+    assert "branches" not in pull_request
+
+
+def test_extensions_pull_request_trigger_keeps_path_filter() -> None:
+    """Given extension PR, When branch allowlist is removed, Then paths filter remains scoped."""
+    workflow = _load_workflow(_EXTENSIONS_WORKFLOW_PATH)
+    pull_request = _on_section(workflow).get("pull_request")
+
+    assert isinstance(pull_request, dict), "pull_request トリガーが存在しない"
+    assert pull_request.get("paths") == ["extensions/**", ".github/workflows/extensions.yml"]
+
+
+def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:
+    """Given CI lint job, When dependencies are installed, Then independent ruff checks run in parallel."""
+    steps = _job_steps(_load_workflow(_CI_WORKFLOW_PATH), "lint")
+
+    _assert_named_parallel_commands(steps, _CI_LINT_PARALLEL_STEPS)
+
+
+def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:
+    """Given suno-helper CI, When install completes, Then independent checks run in parallel batches."""
+    steps = _job_steps(_load_workflow(_EXTENSIONS_WORKFLOW_PATH), "check")
+
+    _assert_named_parallel_commands(steps, _SUNO_FAST_PARALLEL_STEPS)
+    _assert_named_parallel_commands(steps, _SUNO_BUILD_PARALLEL_STEPS)
+    assert _parallel_group_index_containing(steps, "Build") < _top_level_step_index(
+        steps, "Verify generated manifest permissions (least-privilege)"
+    )
+    assert _parallel_group_index_containing(steps, "Install Playwright browser") < _top_level_step_index(
+        steps, "E2E tests (Playwright)"
+    )
+
+
+def test_distrokid_helper_checks_use_dependency_safe_parallel_groups() -> None:
+    """Given distrokid-helper CI, When install completes, Then independent checks run in parallel batches."""
+    steps = _job_steps(_load_workflow(_EXTENSIONS_WORKFLOW_PATH), "distrokid-helper")
+
+    _assert_named_parallel_commands(steps, _DISTROKID_FAST_PARALLEL_STEPS)
+    _assert_named_parallel_commands(steps, _DISTROKID_BUILD_PARALLEL_STEPS)
+    assert _parallel_group_index_containing(steps, "Install Playwright browser") < _top_level_step_index(
+        steps, "E2E (Playwright)"
+    )
+
+
+def test_release_extensions_builds_both_zips_before_release_attachment() -> None:
+    """Given extension release, When zips are built, Then both builds share one parallel group before attach."""
+    steps = _job_steps(_load_workflow(_RELEASE_EXTENSIONS_WORKFLOW_PATH), "release")
+    group = _parallel_group_with_names(steps, set(_RELEASE_BUILD_PARALLEL_STEPS))
+
+    for step in group:
+        working_directory, required_command = _RELEASE_BUILD_PARALLEL_STEPS[str(step["name"])]
+        assert step.get("working-directory") == working_directory
+        assert required_command in str(step.get("run", ""))
+        assert "pnpm install --frozen-lockfile --ignore-workspace" in str(step.get("run", ""))
+    assert _parallel_group_index_containing(steps, "Build and zip suno-helper") < _top_level_step_index(
+        steps, "Attach zips to Release"
+    )

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -99,6 +99,10 @@ def _top_level_step_index(steps: list[dict[str, object]], name: str) -> int:
     pytest.fail(f"{name} step が top-level に存在しない")
 
 
+def _top_level_step(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    return steps[_top_level_step_index(steps, name)]
+
+
 def _top_level_step_index_with_run(steps: list[dict[str, object]], run: str) -> int:
     for index, step in enumerate(steps):
         if step.get("run") == run:
@@ -121,6 +125,21 @@ def _parallel_group_index_containing(steps: list[dict[str, object]], name: str) 
         if any(parallel_step.get("name") == name for parallel_step in parallel_steps):
             return index
     pytest.fail(f"{name} step を含む parallel group が存在しない")
+
+
+def _assert_run_has_no_shell_backgrounding(run_script: str) -> None:
+    for line in run_script.splitlines():
+        command = line.strip()
+        assert not command.endswith("&"), f"shell backgrounding is not allowed: {command}"
+        assert command != "wait" and not command.startswith("wait "), f"shell wait is not allowed: {command}"
+
+
+def _assert_parallel_runs_do_not_use_shell_backgrounding(steps: list[dict[str, object]]) -> None:
+    for group in _parallel_groups(steps):
+        for parallel_step in group:
+            run_script = parallel_step.get("run")
+            assert isinstance(run_script, str), f"{parallel_step.get('name')} parallel step に run が存在しない"
+            _assert_run_has_no_shell_backgrounding(run_script)
 
 
 def test_extensions_pull_request_trigger_allows_stacked_pr_base_branches() -> None:
@@ -149,6 +168,7 @@ def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:
     assert _top_level_step_index_with_run(
         steps, "nix develop --command uv sync --extra dev"
     ) < _parallel_group_index_containing(steps, "Ruff check")
+    _assert_parallel_runs_do_not_use_shell_backgrounding(steps)
 
 
 def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:
@@ -168,6 +188,20 @@ def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:
     assert _parallel_group_index_containing(steps, "Install Playwright browser") < _top_level_step_index(
         steps, "E2E tests (Playwright)"
     )
+    _assert_parallel_runs_do_not_use_shell_backgrounding(steps)
+
+
+def test_suno_helper_manifest_permission_check_preserves_least_privilege_contract() -> None:
+    """Given suno-helper CI, When manifest is built, Then permission verification remains meaningful."""
+    steps = _job_steps(_load_workflow(_EXTENSIONS_WORKFLOW_PATH), "check")
+    manifest_step = _top_level_step(steps, "Verify generated manifest permissions (least-privilege)")
+    run_script = str(manifest_step.get("run", ""))
+
+    assert ".output/chrome-mv3/manifest.json" in run_script
+    assert 'const expected = ["storage", "activeTab", "tabs", "downloads", "debugger"];' in run_script
+    assert "const actual = manifest.permissions ?? [];" in run_script
+    assert "expected.every((p) => actual.includes(p))" in run_script
+    assert "process.exit(1);" in run_script
 
 
 def test_distrokid_helper_checks_use_dependency_safe_parallel_groups() -> None:
@@ -184,6 +218,7 @@ def test_distrokid_helper_checks_use_dependency_safe_parallel_groups() -> None:
     assert _parallel_group_index_containing(steps, "Install Playwright browser") < _top_level_step_index(
         steps, "E2E (Playwright)"
     )
+    _assert_parallel_runs_do_not_use_shell_backgrounding(steps)
 
 
 def test_release_extensions_builds_both_zips_before_release_attachment() -> None:
@@ -201,3 +236,4 @@ def test_release_extensions_builds_both_zips_before_release_attachment() -> None
     assert _top_level_step_index_with_uses(steps, "pnpm/action-setup@v4") < build_parallel_index
     assert _top_level_step_index_with_uses(steps, "actions/setup-node@v4") < build_parallel_index
     assert build_parallel_index < _top_level_step_index(steps, "Attach zips to Release")
+    _assert_parallel_runs_do_not_use_shell_backgrounding(steps)

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -99,6 +99,20 @@ def _top_level_step_index(steps: list[dict[str, object]], name: str) -> int:
     pytest.fail(f"{name} step が top-level に存在しない")
 
 
+def _top_level_step_index_with_run(steps: list[dict[str, object]], run: str) -> int:
+    for index, step in enumerate(steps):
+        if step.get("run") == run:
+            return index
+    pytest.fail(f"{run} run step が top-level に存在しない")
+
+
+def _top_level_step_index_with_uses(steps: list[dict[str, object]], uses: str) -> int:
+    for index, step in enumerate(steps):
+        if step.get("uses") == uses:
+            return index
+    pytest.fail(f"{uses} uses step が top-level に存在しない")
+
+
 def _parallel_group_index_containing(steps: list[dict[str, object]], name: str) -> int:
     for index, step in enumerate(steps):
         parallel_steps = step.get("parallel")
@@ -132,6 +146,9 @@ def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:
     steps = _job_steps(_load_workflow(_CI_WORKFLOW_PATH), "lint")
 
     _assert_named_parallel_commands(steps, _CI_LINT_PARALLEL_STEPS)
+    assert _top_level_step_index_with_run(
+        steps, "nix develop --command uv sync --extra dev"
+    ) < _parallel_group_index_containing(steps, "Ruff check")
 
 
 def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:
@@ -140,6 +157,11 @@ def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:
 
     _assert_named_parallel_commands(steps, _SUNO_FAST_PARALLEL_STEPS)
     _assert_named_parallel_commands(steps, _SUNO_BUILD_PARALLEL_STEPS)
+    install_index = _top_level_step_index(steps, "Install dependencies")
+    fast_parallel_index = _parallel_group_index_containing(steps, "Lint")
+    build_parallel_index = _parallel_group_index_containing(steps, "Build")
+
+    assert install_index < fast_parallel_index < build_parallel_index
     assert _parallel_group_index_containing(steps, "Build") < _top_level_step_index(
         steps, "Verify generated manifest permissions (least-privilege)"
     )
@@ -154,6 +176,11 @@ def test_distrokid_helper_checks_use_dependency_safe_parallel_groups() -> None:
 
     _assert_named_parallel_commands(steps, _DISTROKID_FAST_PARALLEL_STEPS)
     _assert_named_parallel_commands(steps, _DISTROKID_BUILD_PARALLEL_STEPS)
+    install_index = _top_level_step_index(steps, "Install dependencies")
+    fast_parallel_index = _parallel_group_index_containing(steps, "Lint")
+    build_parallel_index = _parallel_group_index_containing(steps, "Build")
+
+    assert install_index < fast_parallel_index < build_parallel_index
     assert _parallel_group_index_containing(steps, "Install Playwright browser") < _top_level_step_index(
         steps, "E2E (Playwright)"
     )
@@ -163,12 +190,14 @@ def test_release_extensions_builds_both_zips_before_release_attachment() -> None
     """Given extension release, When zips are built, Then both builds share one parallel group before attach."""
     steps = _job_steps(_load_workflow(_RELEASE_EXTENSIONS_WORKFLOW_PATH), "release")
     group = _parallel_group_with_names(steps, set(_RELEASE_BUILD_PARALLEL_STEPS))
+    build_parallel_index = _parallel_group_index_containing(steps, "Build and zip suno-helper")
 
     for step in group:
         working_directory, required_command = _RELEASE_BUILD_PARALLEL_STEPS[str(step["name"])]
         assert step.get("working-directory") == working_directory
         assert required_command in str(step.get("run", ""))
         assert "pnpm install --frozen-lockfile --ignore-workspace" in str(step.get("run", ""))
-    assert _parallel_group_index_containing(steps, "Build and zip suno-helper") < _top_level_step_index(
-        steps, "Attach zips to Release"
-    )
+    assert _top_level_step_index_with_uses(steps, "actions/checkout@v4") < build_parallel_index
+    assert _top_level_step_index_with_uses(steps, "pnpm/action-setup@v4") < build_parallel_index
+    assert _top_level_step_index_with_uses(steps, "actions/setup-node@v4") < build_parallel_index
+    assert build_parallel_index < _top_level_step_index(steps, "Attach zips to Release")

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,7 @@ _RELEASE_BUILD_PARALLEL_STEPS = {
     "Build and zip suno-helper": ("extensions/suno-helper", "pnpm zip"),
     "Build and zip distrokid-helper": ("extensions/distrokid-helper", "pnpm zip"),
 }
+_SHELL_BACKGROUND_OPERATOR = re.compile(r"(?<!&)&(?!&)")
 
 
 def _read_text(path: Path) -> str:
@@ -130,7 +132,7 @@ def _parallel_group_index_containing(steps: list[dict[str, object]], name: str) 
 def _assert_run_has_no_shell_backgrounding(run_script: str) -> None:
     for line in run_script.splitlines():
         command = line.strip()
-        assert not command.endswith("&"), f"shell backgrounding is not allowed: {command}"
+        assert _SHELL_BACKGROUND_OPERATOR.search(command) is None, f"shell backgrounding is not allowed: {command}"
         assert command != "wait" and not command.startswith("wait "), f"shell wait is not allowed: {command}"
 
 
@@ -169,6 +171,25 @@ def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:
         steps, "nix develop --command uv sync --extra dev"
     ) < _parallel_group_index_containing(steps, "Ruff check")
     _assert_parallel_runs_do_not_use_shell_backgrounding(steps)
+
+
+@pytest.mark.parametrize(
+    "run_script",
+    [
+        "pnpm zip & echo ok",
+        "pnpm zip & # background",
+        "pnpm zip &\nwait",
+    ],
+)
+def test_parallel_run_contract_rejects_shell_backgrounding(run_script: str) -> None:
+    """Given parallel child run, When shell backgrounding is used, Then contract test rejects it."""
+    with pytest.raises(AssertionError):
+        _assert_run_has_no_shell_backgrounding(run_script)
+
+
+def test_parallel_run_contract_allows_shell_and_operator() -> None:
+    """Given parallel child run, When commands use shell AND, Then it is not treated as backgrounding."""
+    _assert_run_has_no_shell_backgrounding("pnpm install && pnpm zip")
 
 
 def test_suno_helper_checks_use_dependency_safe_parallel_groups() -> None:

--- a/tests/test_changelog_ci_contract.py
+++ b/tests/test_changelog_ci_contract.py
@@ -17,8 +17,8 @@ _PATH_FILTER_PATTERN = (
     "^(src/youtube_automation/|\\.claude/skills/|\\.claude/CLAUDE\\.template\\.md$"
     "|pyproject\\.toml$|packages/|package\\.json$)"
 )
-# CI トリガーで CI を回す対象 branch。#790 cutover で feat/ts-rewrite を外す。
-_TRIGGER_BRANCHES = ["main", "feat/ts-rewrite", "feat/1143-suno-bulk-download"]
+# push で CI を回す対象 branch。PR は stacked PR base でも発火するよう branch 制限しない。
+_PUSH_TRIGGER_BRANCHES = ["main", "feat/ts-rewrite", "feat/1143-suno-bulk-download"]
 _CHANGELOG_FILE_PATTERN = "^CHANGELOG\\.md$"
 _LABELS_JOIN_EXPRESSION = "${{ join(github.event.pull_request.labels.*.name, ',') }}"
 _PR_EVENT_GUARD = "github.event_name == 'pull_request'"
@@ -116,8 +116,8 @@ def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
     )
 
 
-def test_ci_workflow_triggers_run_on_feat_ts_rewrite_branch() -> None:
-    """#964: feat/ts-rewrite base の子 PR / push でも CI が走る必要がある。
+def test_ci_workflow_keeps_push_branch_allowlist() -> None:
+    """#964: feat/ts-rewrite branch への push でも CI が走る必要がある。
 
     #790 cutover で feat/ts-rewrite を branches から外したら本テストも更新する。
     """
@@ -126,9 +126,20 @@ def test_ci_workflow_triggers_run_on_feat_ts_rewrite_branch() -> None:
     triggers = workflow.get("on", workflow.get(True))
     assert isinstance(triggers, dict), "on トリガーが存在しない"
 
-    for event in ("push", "pull_request"):
-        branches = triggers.get(event, {}).get("branches")
-        assert branches == _TRIGGER_BRANCHES, f"{event} の branches が契約と不一致: {branches}"
+    push = triggers.get("push")
+    assert isinstance(push, dict), "push トリガーが存在しない"
+    assert push.get("branches") == _PUSH_TRIGGER_BRANCHES
+
+
+def test_ci_workflow_pull_requests_allow_stacked_pr_base_branches() -> None:
+    """stacked PR の base branch を allowlist で遮断しない。"""
+    workflow = _load_ci_workflow()
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "on トリガーが存在しない"
+
+    pull_request = triggers.get("pull_request")
+    assert isinstance(pull_request, dict), "pull_request トリガーが存在しない"
+    assert "branches" not in pull_request
 
 
 def test_ci_changelog_gate_covers_ts_packages() -> None:

--- a/tests/test_release_extensions_workflow.py
+++ b/tests/test_release_extensions_workflow.py
@@ -44,7 +44,7 @@ def _on_section(workflow: dict[str, object]) -> dict[str, object]:
     return section
 
 
-def _release_steps() -> list[dict[str, object]]:
+def _release_top_level_steps() -> list[dict[str, object]]:
     workflow = _load_workflow()
     jobs = workflow.get("jobs")
     assert isinstance(jobs, dict), "jobs セクションが存在しない"
@@ -53,6 +53,18 @@ def _release_steps() -> list[dict[str, object]]:
     assert release_job.get("runs-on") == "ubuntu-latest"
     steps = release_job.get("steps")
     assert isinstance(steps, list) and steps, "release job に steps が存在しない"
+    return steps
+
+
+def _release_steps_including_parallel() -> list[dict[str, object]]:
+    steps: list[dict[str, object]] = []
+    for step in _release_top_level_steps():
+        if "parallel" not in step:
+            steps.append(step)
+            continue
+        parallel_steps = step.get("parallel")
+        assert isinstance(parallel_steps, list) and parallel_steps, "parallel step が空"
+        steps.extend(parallel_steps)
     return steps
 
 
@@ -73,7 +85,7 @@ def test_grants_contents_write_permission() -> None:
 @pytest.mark.parametrize("name", _EXTENSIONS)
 def test_builds_and_zips_each_extension(name: str) -> None:
     """両拡張がそれぞれの作業ディレクトリで install → zip される。"""
-    steps = _release_steps()
+    steps = _release_steps_including_parallel()
     matched = [
         step
         for step in steps
@@ -86,7 +98,7 @@ def test_builds_and_zips_each_extension(name: str) -> None:
 
 def test_attaches_both_zips_to_single_release() -> None:
     """単一の gh-release ステップで両拡張の zip を添付する。"""
-    steps = _release_steps()
+    steps = _release_top_level_steps()
     release_steps = [step for step in steps if str(step.get("uses", "")).startswith(_GH_RELEASE_ACTION)]
     assert len(release_steps) == 1, "gh-release ステップは 1 個に集約する"
 
@@ -97,7 +109,7 @@ def test_attaches_both_zips_to_single_release() -> None:
 
 def test_release_body_embeds_install_and_update_template() -> None:
     """Release 本文に初回インストール/更新手順テンプレが埋め込まれている。"""
-    steps = _release_steps()
+    steps = _release_top_level_steps()
     release_step = next(step for step in steps if str(step.get("uses", "")).startswith(_GH_RELEASE_ACTION))
     body = str(release_step.get("with", {}).get("body", ""))
     assert body, "Release 本文テンプレ (body) が未設定"


### PR DESCRIPTION
## Summary

## 概要
GitHub Actions の 2026-06-25 更新で追加された step 並列実行構文を使い、既存 CI workflow のうち依存関係のない step を同一 job 内で並列化する。対象は `.github/workflows/*.yml` の CI / extension CI / extension release で、ログ分離と失敗検知を保ったまま実行時間短縮を狙う。

加えて、未 merge の依存 PR に後続 PR を積む stacked PR 運用でも CI が発火するよう、`pull_request.branches` の base branch 制限を見直す。現状は base が `main` / feature branch に限定されているため、base を `codex/...` などの依存ブランチにした PR では check suite が作られない。

## 背景・目的
GitHub Actions は `background`, `wait`, `wait-all`, `cancel`, `parallel` をサポートし、従来の shell backgrounding よりも step ごとのログと実行状態を分離できるようになった。

このリポジトリは public repo なので標準 GitHub-hosted runner の利用自体は無料枠の対象だが、private repo や将来の runner 変更時にコスト増を招かないよう、本 issue では job 分割や runner 追加ではなく、同一 job 内の独立 step 並列化に限定する。

また、依存 issue が未 merge の状態で後続 issue を進める場合、stacked PR の base は `main` ではなく依存 PR の head branch になる。CI の `pull_request.branches` が base branch を allowlist していると、この形の PR では CI が走らず、結局依存 commit を含めた `main` 向け PR に戻す必要が出る。並列化と同時に workflow trigger 契約も整備し、stacked PR でも CI green を確認できるようにする。

参考:
- https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsbackground

## 参照資料
- .github/workflows/ci.yml
- .github/workflows/extensions.yml
- .github/workflows/release-extensions.yml
- tests/test_changelog_ci_contract.py
- tests/test_release_extensions_workflow.py
- package.json
- extensions/suno-helper/package.json
- extensions/distrokid-helper/package.json

## 影響ファイル
- **変更**: .github/workflows/ci.yml
- **変更**: .github/workflows/extensions.yml
- **変更**: .github/workflows/release-extensions.yml
- **変更**: tests/test_changelog_ci_contract.py
- **変更**: tests/test_release_extensions_workflow.py
- **新規**: tests/test_actions_parallel_workflows.py（必要なら）

## 要件
1. `.github/workflows/ci.yml` で、依存関係のない同一 job 内 step を `parallel` などの新構文へ置き換える。例: Python lint job の `ruff check` と `ruff format --check`。
2. `.github/workflows/extensions.yml` の `check` / `distrokid-helper` job で、install 後に独立実行できる lint / format / typecheck / unit test / build / Playwright browser install などを精査し、依存がないものだけ並列化する。
3. `.github/workflows/release-extensions.yml` で、`suno-helper` と `distrokid-helper` の build + zip が独立していることを確認し、同一 job 内で並列化する。
4. `background` step の output / env 依存、失敗検知、`wait` / `wait-all` の位置を公式 syntax に従って明示し、暗黙の shell backgrounding (`&`) は使わない。
5. workflow YAML の構造を静的テストで検証し、並列化対象 step が意図せず直列に戻らないようにする。
6. `pull_request.branches` の base branch allowlist を見直し、stacked PR（例: base が `codex/...` の依存 PR branch）でも CI / Extensions workflow が発火するようにする。`push.branches` の制限は必要に応じて維持してよい。
7. stacked PR で CI が発火しない設定へ戻らないよう、workflow trigger の静的テストを追加または更新する。
8. 既存の changelog gate、release asset 添付、extension manifest 権限検証の意味を変えない。
9. 変更後に関連テストを実行し、最低限 `uv run pytest tests/test_changelog_ci_contract.py tests/test_release_extensions_workflow.py` と新規/更新した workflow 静的テストが通ることを確認する。

## スコープ外
- job 分割、matrix 化、runner 種別変更は本 issue では扱わない。
- 複数 runner を増やす形の高速化は本 issue では扱わない。
- Python / TypeScript 本体の lint・test コマンド内容変更は本 issue では扱わない。
- dependency version 更新、Bun / pnpm / uv / Nix の設定変更は本 issue では扱わない。
- GitHub Actions 以外のローカル hooks / takt workflow の高速化は本 issue では扱わない。

## 受け入れ基準
- [ ] 依存関係のない step のみが `parallel` / `background` 系構文に移行されている。
- [ ] 並列化後も必要な step は `wait` / `wait-all` 後に実行される。
- [ ] job 分割や runner 追加によるコスト増の可能性がある変更を含んでいない。
- [ ] stacked PR の base branch が `main` 以外でも CI / Extensions workflow が発火する trigger 設定になっている。
- [ ] CI workflow の静的テストが追加または更新されている。
- [ ] 関連 pytest が通っている。

## 実装方針（takt）
- workflow: default
- 理由: 複数 workflow と CI 契約テストを変更するため、テスト先行で安全に進める。

## Execution Report

Workflow `default` completed successfully.

Closes #1369