### PR TITLE
feat: yield guard の純粋判定ロジックを追加する

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -86,6 +86,9 @@ export const INJECT_ACK_TIMEOUT_MS = 30000;
  * これを超えても in-flight が増えなければ fail-loud で ERROR phase に落とす。 */
 export const MAX_INJECT_RETRY = 2;
 
+/** duration 歩留まり NG 時に同じ entry を再生成する最大 retry 回数 (#1266)。 */
+export const MAX_YIELD_RETRY = 2;
+
 /** 速度プリセットの選択値を保存する chrome.storage.local の key (#875)。
  * popup（書込）と content（読込）が同一 key を参照するため、契約文字列としてここを SSOT とする。 */
 export const SPEED_PRESET_STORAGE_KEY = "sunoSpeedPreset";

--- a/extensions/suno-helper/lib/yield-guard.ts
+++ b/extensions/suno-helper/lib/yield-guard.ts
@@ -1,0 +1,40 @@
+import { MAX_YIELD_RETRY } from "../../shared/constants";
+import type { DurationFilter } from "../../shared/api";
+
+export interface DurationClip {
+  id: string;
+  duration?: number;
+}
+
+export interface DurationEvaluation {
+  ok: string[];
+  ng: string[];
+}
+
+export function checkDuration(duration: number, filter: DurationFilter): boolean {
+  if (!Number.isFinite(duration)) {
+    return false;
+  }
+  if (duration < filter.min_sec) {
+    return false;
+  }
+  if (duration > filter.max_sec) {
+    return false;
+  }
+  return true;
+}
+
+export function evaluateClips(clips: DurationClip[], filter: DurationFilter): DurationEvaluation {
+  return {
+    ok: clips
+      .filter((clip) => clip.duration !== undefined && checkDuration(clip.duration, filter))
+      .map((clip) => clip.id),
+    ng: clips
+      .filter((clip) => clip.duration === undefined || !checkDuration(clip.duration, filter))
+      .map((clip) => clip.id),
+  };
+}
+
+export function shouldRetry(attemptCount: number, maxRetry: number = MAX_YIELD_RETRY): boolean {
+  return attemptCount < maxRetry;
+}

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -17,6 +17,7 @@ import {
   INTER_CREATE_DELAY_MS,
   MAX_INFLIGHT_REQUESTS,
   MAX_INJECT_RETRY,
+  MAX_YIELD_RETRY,
   OVERLAY_STATE_KEY,
   PHASE,
   PROMPTS_ROUTE,
@@ -160,6 +161,10 @@ describe("shared/constants: inject 検証 + queue 待機 timeout 独立化 (#864
   it("Given MAX_INJECT_RETRY When 読む Then silent drop 時の最大 retry 回数 2 である", () => {
     // #864 root cause 3: ack されなければ同じ entry を最大 2 回 retry、それでも増えなければ fail-loud。
     expect(MAX_INJECT_RETRY).toBe(2);
+  });
+
+  it("Given MAX_YIELD_RETRY When 読む Then duration NG 時の最大 retry 回数 2 である", () => {
+    expect(MAX_YIELD_RETRY).toBe(2);
   });
 });
 

--- a/extensions/suno-helper/tests/yield-guard.test.ts
+++ b/extensions/suno-helper/tests/yield-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_YIELD_RETRY } from "../../shared/constants";
+import { checkDuration, evaluateClips, shouldRetry } from "../lib/yield-guard";
+import type { DurationFilter } from "../../shared/api";
+
+const FILTER: DurationFilter = { min_sec: 120, max_sec: 300 };
+
+describe("yield-guard: duration 判定", () => {
+  it("Given duration が閾値内 When checkDuration Then true を返す", () => {
+    expect(checkDuration(120, FILTER)).toBe(true);
+    expect(checkDuration(240, FILTER)).toBe(true);
+    expect(checkDuration(300, FILTER)).toBe(true);
+  });
+
+  it("Given duration が閾値外 When checkDuration Then false を返す", () => {
+    expect(checkDuration(119.9, FILTER)).toBe(false);
+    expect(checkDuration(300.1, FILTER)).toBe(false);
+  });
+
+  it("Given 非有限値 When checkDuration Then false を返す", () => {
+    expect(checkDuration(Number.NaN, FILTER)).toBe(false);
+    expect(checkDuration(Number.POSITIVE_INFINITY, FILTER)).toBe(false);
+  });
+});
+
+describe("yield-guard: clips 分類", () => {
+  it("Given duration undefined When evaluateClips Then feed 未取得として NG に分類する", () => {
+    expect(evaluateClips([{ id: "clip-a" }, { id: "clip-b", duration: 180 }], FILTER)).toEqual({
+      ok: ["clip-b"],
+      ng: ["clip-a"],
+    });
+  });
+
+  it("Given 両方 OK When evaluateClips Then ok に 2 clip を分類する", () => {
+    expect(
+      evaluateClips(
+        [
+          { id: "clip-a", duration: 180 },
+          { id: "clip-b", duration: 240 },
+        ],
+        FILTER,
+      ),
+    ).toEqual({
+      ok: ["clip-a", "clip-b"],
+      ng: [],
+    });
+  });
+
+  it("Given 両方 NG When evaluateClips Then ng に 2 clip を分類する", () => {
+    expect(
+      evaluateClips(
+        [
+          { id: "clip-a", duration: 90 },
+          { id: "clip-b", duration: 360 },
+        ],
+        FILTER,
+      ),
+    ).toEqual({
+      ok: [],
+      ng: ["clip-a", "clip-b"],
+    });
+  });
+
+  it("Given 片方だけ OK When evaluateClips Then ok/ng に分けて分類する", () => {
+    expect(
+      evaluateClips(
+        [
+          { id: "clip-a", duration: 180 },
+          { id: "clip-b", duration: 360 },
+        ],
+        FILTER,
+      ),
+    ).toEqual({
+      ok: ["clip-a"],
+      ng: ["clip-b"],
+    });
+  });
+});
+
+describe("yield-guard: retry 判定", () => {
+  it("Given default max retry When shouldRetry Then MAX_YIELD_RETRY 未満だけ true を返す", () => {
+    expect(MAX_YIELD_RETRY).toBe(2);
+    expect(shouldRetry(0)).toBe(true);
+    expect(shouldRetry(1)).toBe(true);
+    expect(shouldRetry(2)).toBe(false);
+  });
+
+  it("Given custom max retry When shouldRetry Then 上限到達で false を返す", () => {
+    expect(shouldRetry(2, 3)).toBe(true);
+    expect(shouldRetry(3, 3)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `DurationFilter` and `MAX_YIELD_RETRY` contract values for yield guard
- add pure suno-helper yield guard helpers for duration classification and retry decisions
- cover undefined duration, OK/NG clip combinations, and retry limit boundaries with Vitest

## Verification
- `pnpm exec vitest run tests/yield-guard.test.ts tests/constants.test.ts`
- `pnpm run compile`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run format:check`

Closes #1266
