### PR TITLE
fix: DistroKidアセット配信でURLデコードする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(doctor)`: `yt-doctor` に `ttp_wf_new_readiness` を追加し、`/channel-setup` の benchmark 反映未完了による TTP 参照データ欠落を検知・案内できるようにした（#1400）
+- `fix(distrokid)`: `yt-collection-serve` の DistroKid asset 配信で URL encode された日本語ファイル名を decode し、single-file / dir mode の両方で 404 にならないようにした（#1401）
 - `fix(masterup)`: `yt-suno-select-tracks` で全候補が `max_song_sec` 超過だけで落ちた prompt を `--allow-best-effort-over-max` で最短候補として例外採用できるようにし、selection log と `workflow-state.json::music_pair_selection` を成功結果に同期するようにした（#1324）
 - `fix(launch-curve)`: `yt-launch-curve` で日次データに `impressions` / `impression_ctr` が無い場合も `daily_impressions=0` / `ctr` unavailable として扱い、初期チャンネルの欠損データで落ちないようにした（#1327）
 - `fix(skills)`: `config.default.yaml` を持つ skill の SKILL.md に設定読み込みゲートを追加し、チャンネル override の読み飛ばしを防ぐ契約テストを追加（#1243）

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -982,7 +982,7 @@ def create_server(
             # `/distrokid/assets/<rel>` → collection-scoped アセット配信
             distrokid_assets_infix = "distrokid/assets/"
             if sub.startswith(distrokid_assets_infix):
-                relpath = sub[len(distrokid_assets_infix) :]
+                relpath = urllib.parse.unquote(sub[len(distrokid_assets_infix) :])
                 # コレクションルートからの相対パスで resolve（30-distrokid 配下も含む）
                 resolved = resolve_asset_path(coll_dir, relpath)
                 if resolved is None:
@@ -1048,7 +1048,7 @@ def create_server(
             if not distrokid_enabled:
                 self.send_error(404, "Not Found")
                 return
-            relpath = self.path[len(DISTROKID_ASSETS_PREFIX) :]
+            relpath = urllib.parse.unquote(self.path[len(DISTROKID_ASSETS_PREFIX) :])
             resolved = resolve_asset_path(collection_dir, relpath)
             if resolved is None:
                 self.send_error(404, "Not Found")

--- a/src/youtube_automation/scripts/distrokid_release.py
+++ b/src/youtube_automation/scripts/distrokid_release.py
@@ -242,14 +242,14 @@ def kebab_to_title(dirname: str) -> str:
 def resolve_asset_path(collection_dir: Path, relpath: str) -> Path | None:
     """assets 相対パスをコレクション配下の実体パスへ解決する.
 
-    トラバーサル（`..` でコレクション外へ脱出）・絶対パス・不在ファイルは None。
+    トラバーサル（`..` でコレクション外へ脱出）・絶対パス・不正 path・不在ファイルは None。
     """
-    root = Path(collection_dir).resolve()
-    candidate = (root / relpath).resolve()
     try:
+        root = Path(collection_dir).resolve()
+        candidate = (root / relpath).resolve()
         candidate.relative_to(root)
-    except ValueError:
-        return None
-    if not candidate.is_file():
+        if not candidate.is_file():
+            return None
+    except (OSError, ValueError):
         return None
     return candidate

--- a/tests/test_distrokid_collections_endpoint.py
+++ b/tests/test_distrokid_collections_endpoint.py
@@ -751,6 +751,27 @@ def test_get_collection_distrokid_asset_decodes_space_in_collection_id(serve_dir
         assert resp.read() == _MP3_BYTES
 
 
+def test_get_collection_distrokid_asset_decodes_percent_encoded_relpath(serve_dir_dk, tmp_path):
+    """Given 日本語ファイル名を percent-encode した collection-scoped asset URL
+    When `GET /collections/<id>/distrokid/assets/<rel>` を呼ぶ
+    Then decode 後の実ファイルを返す。
+    """
+    planning = tmp_path / "planning"
+    coll = planning / "20260526-abc-collection"
+    coll.mkdir(parents=True)
+    disc_dir = _make_disc(coll, "disc1-alpha", mp3_count=1)
+    filename = "01-不屈のビート.mp3"
+    (disc_dir / filename).write_bytes(_MP3_BYTES)
+    base = serve_dir_dk(planning)
+    relpath = urllib.parse.quote(f"30-distrokid/disc1-alpha/{filename}", safe="/")
+
+    url = f"{base}{_COLLECTIONS_ROUTE}/20260526-abc-collection/distrokid/assets/{relpath}"
+    with urllib.request.urlopen(url) as resp:
+        assert resp.status == 200
+        assert resp.headers.get("Content-Type") == "audio/mpeg"
+        assert resp.read() == _MP3_BYTES
+
+
 def test_get_collection_distrokid_asset_traversal_returns_404(serve_dir_dk, tmp_path):
     """Given `../` を含む asset rel
     When `GET /collections/<id>/distrokid/assets/<rel>`

--- a/tests/test_distrokid_collections_endpoint.py
+++ b/tests/test_distrokid_collections_endpoint.py
@@ -772,6 +772,41 @@ def test_get_collection_distrokid_asset_decodes_percent_encoded_relpath(serve_di
         assert resp.read() == _MP3_BYTES
 
 
+@pytest.mark.parametrize(
+    ("encoded_relpath", "outside_filename"),
+    [
+        (urllib.parse.quote("../secret.mp3", safe=""), "secret.mp3"),
+        (None, "absolute-secret.mp3"),
+        (urllib.parse.quote("30-distrokid/disc1-alpha/bad\x00.mp3", safe="/"), None),
+    ],
+)
+def test_get_collection_distrokid_asset_rejects_decoded_invalid_relpath(
+    serve_dir_dk,
+    tmp_path,
+    encoded_relpath,
+    outside_filename,
+):
+    """Given decode 後に traversal / absolute / NUL になる collection-scoped asset URL
+    When `GET /collections/<id>/distrokid/assets/<rel>` を呼ぶ
+    Then 外部ファイルや不正 path は 404。
+    """
+    planning = tmp_path / "planning"
+    collection_id = "20260526-abc-collection"
+    _make_collection(planning, collection_id, discs=["disc1-alpha"])
+    if outside_filename is not None:
+        outside = tmp_path / outside_filename
+        outside.write_bytes(b"secret")
+        if encoded_relpath is None:
+            encoded_relpath = urllib.parse.quote(str(outside), safe="")
+    base = serve_dir_dk(planning)
+
+    req = urllib.request.Request(f"{base}{_COLLECTIONS_ROUTE}/{collection_id}/distrokid/assets/{encoded_relpath}")
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+
+    assert exc_info.value.code == 404
+
+
 def test_get_collection_distrokid_asset_traversal_returns_404(serve_dir_dk, tmp_path):
     """Given `../` を含む asset rel
     When `GET /collections/<id>/distrokid/assets/<rel>`

--- a/tests/test_distrokid_release_endpoint.py
+++ b/tests/test_distrokid_release_endpoint.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import threading
 import urllib.error
+import urllib.parse
 import urllib.request
 
 import pytest
@@ -323,6 +324,25 @@ def test_get_distrokid_asset_serves_binary_with_mime(serve, tmp_path):
     base = serve(collection_dir=collection, distrokid=distrokid)
 
     url = f"{base}{DISTROKID_ASSETS_PREFIX}02-Individual-music/01-foo.mp3"
+    with urllib.request.urlopen(url) as resp:
+        assert resp.status == 200
+        assert resp.headers.get("Content-Type") == "audio/mpeg"
+        assert resp.read() == _MP3_BYTES
+
+
+def test_get_distrokid_asset_decodes_percent_encoded_relpath(serve, tmp_path):
+    """Given 日本語ファイル名を percent-encode した asset URL
+    When `GET /distrokid/assets/<rel>` を呼ぶ
+    Then decode 後の実ファイルを返す。
+    """
+    collection = _make_collection(tmp_path)
+    filename = "01-不屈のビート.mp3"
+    (collection / "02-Individual-music" / filename).write_bytes(_MP3_BYTES)
+    distrokid = Distrokid(enabled=True, profile=_profile())
+    base = serve(collection_dir=collection, distrokid=distrokid)
+    relpath = urllib.parse.quote(f"02-Individual-music/{filename}", safe="/")
+
+    url = f"{base}{DISTROKID_ASSETS_PREFIX}{relpath}"
     with urllib.request.urlopen(url) as resp:
         assert resp.status == 200
         assert resp.headers.get("Content-Type") == "audio/mpeg"

--- a/tests/test_distrokid_release_endpoint.py
+++ b/tests/test_distrokid_release_endpoint.py
@@ -225,6 +225,16 @@ def test_resolve_asset_path_rejects_absolute_path(tmp_path):
     assert resolve_asset_path(collection, "/etc/passwd") is None
 
 
+def test_resolve_asset_path_rejects_nul_path(tmp_path):
+    """Given NUL 文字を含むパス
+    When resolve_asset_path を呼ぶ
+    Then 不正 path として None。
+    """
+    collection = _make_collection(tmp_path)
+
+    assert resolve_asset_path(collection, "02-Individual-music/bad\x00.mp3") is None
+
+
 def test_resolve_asset_path_missing_file_returns_none(tmp_path):
     """Given コレクション配下だが不在のパス
     When resolve_asset_path を呼ぶ
@@ -347,6 +357,40 @@ def test_get_distrokid_asset_decodes_percent_encoded_relpath(serve, tmp_path):
         assert resp.status == 200
         assert resp.headers.get("Content-Type") == "audio/mpeg"
         assert resp.read() == _MP3_BYTES
+
+
+@pytest.mark.parametrize(
+    ("encoded_relpath", "outside_filename"),
+    [
+        (urllib.parse.quote("../secret.mp3", safe=""), "secret.mp3"),
+        (None, "absolute-secret.mp3"),
+        (urllib.parse.quote("02-Individual-music/bad\x00.mp3", safe="/"), None),
+    ],
+)
+def test_get_distrokid_asset_rejects_decoded_invalid_relpath(
+    serve,
+    tmp_path,
+    encoded_relpath,
+    outside_filename,
+):
+    """Given decode 後に traversal / absolute / NUL になる asset URL
+    When `GET /distrokid/assets/<rel>` を呼ぶ
+    Then 外部ファイルや不正 path は 404。
+    """
+    collection = _make_collection(tmp_path)
+    if outside_filename is not None:
+        outside = tmp_path / outside_filename
+        outside.write_bytes(b"secret")
+        if encoded_relpath is None:
+            encoded_relpath = urllib.parse.quote(str(outside), safe="")
+    distrokid = Distrokid(enabled=True, profile=_profile())
+    base = serve(collection_dir=collection, distrokid=distrokid)
+
+    req = urllib.request.Request(f"{base}{DISTROKID_ASSETS_PREFIX}{encoded_relpath}")
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+
+    assert exc_info.value.code == 404
 
 
 def test_get_distrokid_asset_missing_returns_404(serve, tmp_path):


### PR DESCRIPTION
## Summary
- DistroKid asset route の relpath を `urllib.parse.unquote` してからファイル解決するよう修正
- single-file mode と dir mode の両方に日本語ファイル名の percent-encoded URL 回帰テストを追加
- CHANGELOG.md の Unreleased に修正内容を追記

## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_distrokid_release_endpoint.py tests/test_distrokid_collections_endpoint.py`
- `uv run pytest`

Closes #1401
