### PR TITLE
fix: DistroKid サブジャンル選択の非同期待機を追加

### DIFF
--- a/extensions/distrokid-helper/lib/content-injector.ts
+++ b/extensions/distrokid-helper/lib/content-injector.ts
@@ -35,7 +35,7 @@ export function createDocumentInjector(doc: Document): Injector {
 
       // 新規リリース前提を assert（過去公開対応はスコープ外）。
       assertNewRelease(doc);
-      injectProfile(doc, profile);
+      await injectProfile(doc, profile);
       injectAlbumTitle(doc, release.album_title);
       injectReleaseDate(doc, release.release_date);
 

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -297,6 +297,19 @@ function findSelectOptionIndex(el: HTMLSelectElement, payloadValue: string): num
   return idx;
 }
 
+// 依存 dropdown の readiness 判定は曖昧な部分一致を使わない。
+// "テクノ" を待っている途中に "ハードコア／ハードテクノ" が先に出ても、完全一致の
+// option が現れるまで待つ必要がある。
+function findExactSelectOptionIndex(el: HTMLSelectElement, payloadValue: string): number {
+  const target = normalizeOptionText(payloadValue);
+  const opts = Array.from(el.options);
+  let idx = opts.findIndex((o) => o.value === payloadValue);
+  if (idx === -1) {
+    idx = opts.findIndex((o) => normalizeOptionText(o.text) === target);
+  }
+  return idx;
+}
+
 // <select> に対して payload 値で option を選ぶ。
 function setSelectValue(el: HTMLSelectElement, payloadValue: string): void {
   const idx = findSelectOptionIndex(el, payloadValue);
@@ -332,13 +345,13 @@ function findVisibleSelectWithOption(
   if (!(el instanceof HTMLSelectElement)) {
     return null;
   }
-  return findSelectOptionIndex(el, payloadValue) === -1 ? null : el;
+  return findExactSelectOptionIndex(el, payloadValue) === -1 ? null : el;
 }
 
 // 依存 dropdown の option 再生成を待つ（#1407）。
 // #genrePrimary の change 後、#genreSecondary は非同期に populate されるため、
 // payload と一致する option が現れてから setNativeValue する。
-export function waitForSelectOption(
+function waitForSelectOption(
   root: ParentNode,
   selector: string,
   payloadValue: string,

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -40,6 +40,9 @@ export const PROFILE_SELECTORS = {
   sub_genre: "#genreSecondary",
 } as const;
 
+// main genre 変更後、DistroKid が secondary genre の option を再生成するまでの待ち上限（ms）（#1407）。
+export const GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS = 10_000;
+
 // アルバム名（アルバム時のみ存在。シングルモードでは要素不在 → skip）。
 export const ALBUM_SELECTORS = {
   album_title: "#albumTitleInput",
@@ -191,8 +194,12 @@ export class FieldNotFoundError extends Error {
 // `.trim()` で crash するため、silent skip せず fail-loud にして config と実機 UI の不整合を
 // 即座に検知する（#888 第2回 retest で判明）。
 export class OptionNotFoundError extends Error {
-  constructor(selector: string, payloadValue: string) {
-    super(`<select> に該当 option がありません: ${selector} / payload="${payloadValue}"`);
+  constructor(selector: string, payloadValue: string, optionLabels?: readonly string[]) {
+    const options =
+      optionLabels === undefined
+        ? ""
+        : ` / options=[${optionLabels.length === 0 ? "(empty)" : optionLabels.join(" / ")}]`;
+    super(`<select> に該当 option がありません: ${selector} / payload="${payloadValue}"${options}`);
     this.name = "OptionNotFoundError";
   }
 }
@@ -263,10 +270,17 @@ function normalizeOptionText(s: string): string {
   return s.normalize("NFKC").replace(/／/g, "/").toLowerCase().trim();
 }
 
-// <select> に対して payload 値で option を選ぶ。
+function selectSelector(el: HTMLSelectElement): string {
+  return el.id ? `#${el.id}` : el.tagName.toLowerCase();
+}
+
+function selectOptionLabels(el: HTMLSelectElement): string[] {
+  return Array.from(el.options).map((o) => o.text.trim() || o.value || "(blank)");
+}
+
 // 優先順: option.value 完全一致 → option.text 完全一致（normalize）→ option.text 部分一致
 // （normalize、placeholder value="" は除外）。一致無しなら OptionNotFoundError で fail-loud。
-function setSelectValue(el: HTMLSelectElement, payloadValue: string): void {
+function findSelectOptionIndex(el: HTMLSelectElement, payloadValue: string): number {
   const target = normalizeOptionText(payloadValue);
   const opts = Array.from(el.options);
   let idx = opts.findIndex((o) => o.value === payloadValue);
@@ -280,8 +294,14 @@ function setSelectValue(el: HTMLSelectElement, payloadValue: string): void {
       return t.includes(target) || target.includes(t);
     });
   }
+  return idx;
+}
+
+// <select> に対して payload 値で option を選ぶ。
+function setSelectValue(el: HTMLSelectElement, payloadValue: string): void {
+  const idx = findSelectOptionIndex(el, payloadValue);
   if (idx === -1) {
-    throw new OptionNotFoundError(el.id ? `#${el.id}` : el.tagName.toLowerCase(), payloadValue);
+    throw new OptionNotFoundError(selectSelector(el), payloadValue, selectOptionLabels(el));
   }
   el.selectedIndex = idx;
   el.dispatchEvent(new Event("input", { bubbles: true }));
@@ -303,15 +323,70 @@ function requireVisibleField(root: ParentNode, selector: string): ValueElement {
   return el;
 }
 
+function findVisibleSelectWithOption(
+  root: ParentNode,
+  selector: string,
+  payloadValue: string,
+): HTMLSelectElement | null {
+  const el = findVisibleField(root, selector);
+  if (!(el instanceof HTMLSelectElement)) {
+    return null;
+  }
+  return findSelectOptionIndex(el, payloadValue) === -1 ? null : el;
+}
+
+// 依存 dropdown の option 再生成を待つ（#1407）。
+// #genrePrimary の change 後、#genreSecondary は非同期に populate されるため、
+// payload と一致する option が現れてから setNativeValue する。
+export function waitForSelectOption(
+  root: ParentNode,
+  selector: string,
+  payloadValue: string,
+  timeoutMs: number,
+): Promise<HTMLSelectElement> {
+  const initial = requireVisibleField(root, selector);
+  if (!(initial instanceof HTMLSelectElement)) {
+    throw new FieldNotFoundError(selector);
+  }
+  const existing = findVisibleSelectWithOption(root, selector, payloadValue);
+  if (existing !== null) {
+    return Promise.resolve(existing);
+  }
+  const observeRoot = ownerDocumentOf(root).body ?? ownerDocumentOf(root);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      observer.disconnect();
+      const current = findVisibleField(root, selector);
+      const options = current instanceof HTMLSelectElement ? selectOptionLabels(current) : [];
+      reject(new OptionNotFoundError(selector, payloadValue, options));
+    }, timeoutMs);
+    const observer = new MutationObserver(() => {
+      const found = findVisibleSelectWithOption(root, selector, payloadValue);
+      if (found !== null) {
+        clearTimeout(timer);
+        observer.disconnect();
+        resolve(found);
+      }
+    });
+    observer.observe(observeRoot, { childList: true, subtree: true, characterData: true });
+  });
+}
+
 // 静的プロファイル（artist / sub_genre は任意、language / main_genre は必須）を注入する。
-export function injectProfile(root: ParentNode, profile: DistrokidProfile): void {
+export async function injectProfile(root: ParentNode, profile: DistrokidProfile): Promise<void> {
   if (profile.artist.trim() !== "") {
     setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.artist), profile.artist.trim());
   }
   setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.language), profile.language);
   setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.main_genre), profile.main_genre);
   if (profile.sub_genre !== null) {
-    setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.sub_genre), profile.sub_genre);
+    const subGenre = await waitForSelectOption(
+      root,
+      PROFILE_SELECTORS.sub_genre,
+      profile.sub_genre,
+      GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS,
+    );
+    setNativeValue(subGenre, profile.sub_genre);
   }
 }
 

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -41,7 +41,7 @@ export const PROFILE_SELECTORS = {
 } as const;
 
 // main genre 変更後、DistroKid が secondary genre の option を再生成するまでの待ち上限（ms）（#1407）。
-export const GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS = 10_000;
+const GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS = 10_000;
 
 // アルバム名（アルバム時のみ存在。シングルモードでは要素不在 → skip）。
 export const ALBUM_SELECTORS = {
@@ -283,10 +283,7 @@ function selectOptionLabels(el: HTMLSelectElement): string[] {
 function findSelectOptionIndex(el: HTMLSelectElement, payloadValue: string): number {
   const target = normalizeOptionText(payloadValue);
   const opts = Array.from(el.options);
-  let idx = opts.findIndex((o) => o.value === payloadValue);
-  if (idx === -1) {
-    idx = opts.findIndex((o) => normalizeOptionText(o.text) === target);
-  }
+  let idx = findExactSelectOptionIndex(el, payloadValue);
   if (idx === -1) {
     idx = opts.findIndex((o) => {
       if (o.value === "") return false;

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -345,6 +345,25 @@ function findVisibleSelectWithOption(
   return findExactSelectOptionIndex(el, payloadValue) === -1 ? null : el;
 }
 
+function mutationTouchesSelector(mutation: MutationRecord, selector: string, current: Element | null): boolean {
+  const target = mutation.target;
+  if (current !== null && (target === current || current.contains(target) || target.contains(current))) {
+    return true;
+  }
+  for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
+    if (!(node instanceof Element)) {
+      continue;
+    }
+    if (node.matches(selector) || node.querySelector(selector) !== null) {
+      return true;
+    }
+    if (current !== null && (node === current || node.contains(current) || current.contains(node))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // 依存 dropdown の option 再生成を待つ（#1407）。
 // #genrePrimary の change 後、#genreSecondary は非同期に populate されるため、
 // payload と一致する option が現れてから setNativeValue する。
@@ -353,14 +372,17 @@ function waitForSelectOption(
   selector: string,
   payloadValue: string,
   timeoutMs: number,
+  options: { requireSelectorMutation?: boolean } = {},
 ): Promise<HTMLSelectElement> {
   const initial = requireVisibleField(root, selector);
   if (!(initial instanceof HTMLSelectElement)) {
     throw new FieldNotFoundError(selector);
   }
-  const existing = findVisibleSelectWithOption(root, selector, payloadValue);
-  if (existing !== null) {
-    return Promise.resolve(existing);
+  if (options.requireSelectorMutation !== true) {
+    const existing = findVisibleSelectWithOption(root, selector, payloadValue);
+    if (existing !== null) {
+      return Promise.resolve(existing);
+    }
   }
   const observeRoot = ownerDocumentOf(root).body ?? ownerDocumentOf(root);
   return new Promise((resolve, reject) => {
@@ -370,7 +392,13 @@ function waitForSelectOption(
       const options = current instanceof HTMLSelectElement ? selectOptionLabels(current) : [];
       reject(new OptionNotFoundError(selector, payloadValue, options));
     }, timeoutMs);
-    const observer = new MutationObserver(() => {
+    const observer = new MutationObserver((mutations) => {
+      if (
+        options.requireSelectorMutation === true &&
+        !mutations.some((mutation) => mutationTouchesSelector(mutation, selector, findVisibleField(root, selector)))
+      ) {
+        return;
+      }
       const found = findVisibleSelectWithOption(root, selector, payloadValue);
       if (found !== null) {
         clearTimeout(timer);
@@ -378,7 +406,7 @@ function waitForSelectOption(
         resolve(found);
       }
     });
-    observer.observe(observeRoot, { childList: true, subtree: true, characterData: true });
+    observer.observe(observeRoot, { childList: true, subtree: true, characterData: true, attributes: true });
   });
 }
 
@@ -395,6 +423,7 @@ export async function injectProfile(root: ParentNode, profile: DistrokidProfile)
       PROFILE_SELECTORS.sub_genre,
       profile.sub_genre,
       GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS,
+      { requireSelectorMutation: true },
     );
     setNativeValue(subGenre, profile.sub_genre);
   }

--- a/extensions/distrokid-helper/tests/content-injector.test.ts
+++ b/extensions/distrokid-helper/tests/content-injector.test.ts
@@ -114,6 +114,22 @@ function mountStaticForm(trackCount: number, fallbackArtist: string): void {
   }
 }
 
+function wireGenreSecondaryPopulate(options: ReadonlyArray<{ value: string; text: string }>): void {
+  const genre = document.querySelector<HTMLSelectElement>("#genrePrimary")!;
+  const subGenre = document.querySelector<HTMLSelectElement>("#genreSecondary")!;
+  genre.addEventListener("change", () => {
+    setTimeout(() => {
+      subGenre.innerHTML = "";
+      for (const option of options) {
+        const opt = document.createElement("option");
+        opt.value = option.value;
+        opt.textContent = option.text;
+        subGenre.appendChild(opt);
+      }
+    }, 0);
+  });
+}
+
 function payload(profile: DistrokidProfile): ReleasePayload {
   return {
     profile,
@@ -140,6 +156,7 @@ describe("createDocumentInjector", () => {
   it("injectStaticFields が profile.artist を Apple Music credits へ渡す", async () => {
     // Given
     mountStaticForm(1, "Soulful Grooves");
+    wireGenreSecondaryPopulate([{ value: "Ambient", text: "Ambient" }]);
 
     // When
     await createDocumentInjector(document).injectStaticFields(payload(BASE_PROFILE));
@@ -153,21 +170,13 @@ describe("createDocumentInjector", () => {
   it("injectStaticFields が main_genre change 後の非同期 sub_genre populate を待ってから後続注入する", async () => {
     // Given
     mountStaticForm(1, "Soulful Grooves");
-    const genre = document.querySelector<HTMLSelectElement>("#genrePrimary")!;
     const subGenre = document.querySelector<HTMLSelectElement>("#genreSecondary")!;
     subGenre.innerHTML = "";
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "サブジャンルを選択";
-    subGenre.appendChild(placeholder);
-    genre.addEventListener("change", () => {
-      setTimeout(() => {
-        const option = document.createElement("option");
-        option.value = "Ambient";
-        option.textContent = "Ambient";
-        subGenre.appendChild(option);
-      }, 0);
-    });
+    const staleOption = document.createElement("option");
+    staleOption.value = "old-ambient";
+    staleOption.textContent = "Ambient";
+    subGenre.appendChild(staleOption);
+    wireGenreSecondaryPopulate([{ value: "Ambient", text: "Ambient" }]);
     let subGenreAtAlbumTitleInjection: string | null = null;
     document.querySelector<HTMLInputElement>("#albumTitleInput")!.addEventListener("input", () => {
       subGenreAtAlbumTitleInjection = subGenre.value;
@@ -176,7 +185,7 @@ describe("createDocumentInjector", () => {
     // When
     await createDocumentInjector(document).injectStaticFields(payload(BASE_PROFILE));
 
-    // Then: await が外れると album title 注入時点ではまだ placeholder のままになる。
+    // Then: await が外れると album title 注入時点では stale option のままになる。
     expect(subGenre.value).toBe("Ambient");
     expect(subGenreAtAlbumTitleInjection).toBe("Ambient");
   });
@@ -184,6 +193,7 @@ describe("createDocumentInjector", () => {
   it("profile.artist が空なら content 実配線でも #artistName fallback を使う", async () => {
     // Given
     mountStaticForm(1, "Soulful Grooves");
+    wireGenreSecondaryPopulate([{ value: "Ambient", text: "Ambient" }]);
 
     // When
     await createDocumentInjector(document).injectStaticFields(

--- a/extensions/distrokid-helper/tests/content-injector.test.ts
+++ b/extensions/distrokid-helper/tests/content-injector.test.ts
@@ -150,6 +150,37 @@ describe("createDocumentInjector", () => {
     expect(document.querySelector<HTMLInputElement>("#track-1-producer-1-name")!.value).toBe("ABYSS MI");
   });
 
+  it("injectStaticFields が main_genre change 後の非同期 sub_genre populate を待ってから後続注入する", async () => {
+    // Given
+    mountStaticForm(1, "Soulful Grooves");
+    const genre = document.querySelector<HTMLSelectElement>("#genrePrimary")!;
+    const subGenre = document.querySelector<HTMLSelectElement>("#genreSecondary")!;
+    subGenre.innerHTML = "";
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "サブジャンルを選択";
+    subGenre.appendChild(placeholder);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        const option = document.createElement("option");
+        option.value = "Ambient";
+        option.textContent = "Ambient";
+        subGenre.appendChild(option);
+      }, 0);
+    });
+    let subGenreAtAlbumTitleInjection: string | null = null;
+    document.querySelector<HTMLInputElement>("#albumTitleInput")!.addEventListener("input", () => {
+      subGenreAtAlbumTitleInjection = subGenre.value;
+    });
+
+    // When
+    await createDocumentInjector(document).injectStaticFields(payload(BASE_PROFILE));
+
+    // Then: await が外れると album title 注入時点ではまだ placeholder のままになる。
+    expect(subGenre.value).toBe("Ambient");
+    expect(subGenreAtAlbumTitleInjection).toBe("Ambient");
+  });
+
   it("profile.artist が空なら content 実配線でも #artistName fallback を使う", async () => {
     // Given
     mountStaticForm(1, "Soulful Grooves");

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -30,7 +30,6 @@ import {
   waitForElementCount,
   waitForRemoval,
   waitForElementVisible,
-  waitForSelectOption,
   checkAllStores,
   acceptImportantTerms,
   scrollToDoneButton,
@@ -562,18 +561,62 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     expect(sub.value).toBe("テクノ");
   });
 
+  it("sub_genre option 待機は部分一致では resolve せず完全一致の option を待つ（#1407）", async () => {
+    // Given
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    const genre = mountSelect("genrePrimary", ["エレクトロニック"]);
+    const sub = mountSelectWithOptions("genreSecondary", [
+      { value: "", text: "サブジャンルを選択" },
+      { value: "hardcore-techno", text: "ハードコア／ハードテクノ" },
+    ]);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        const opt = document.createElement("option");
+        opt.value = "techno";
+        opt.textContent = "テクノ";
+        sub.appendChild(opt);
+      }, 0);
+    });
+
+    // When
+    await injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+
+    // Then: 部分一致の "ハードコア／ハードテクノ" ではなく、後から出た完全一致を選ぶ。
+    expect(sub.value).toBe("techno");
+  });
+
   it("sub_genre option 待機の no-match error には候補一覧を含める（#1407）", async () => {
     // Given
+    vi.useFakeTimers();
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    mountSelect("genrePrimary", ["エレクトロニック"]);
     const sub = mountSelectWithOptions("genreSecondary", [
       { value: "", text: "サブジャンルを選択" },
       { value: "house", text: "ハウス" },
     ]);
 
     // Then
-    await expect(waitForSelectOption(document, "#genreSecondary", "テクノ", 1)).rejects.toThrow(
-      /options=\[サブジャンルを選択 \/ ハウス\]/,
-    );
-    expect(sub.value).toBe("");
+    const promise = injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+    try {
+      const rejection = expect(promise).rejects.toThrow(/options=\[サブジャンルを選択 \/ ハウス\]/);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejection;
+      expect(sub.value).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -646,7 +689,14 @@ describe("setNativeValue（<select>）— option の value / text 一致 + norma
       { value: "25", text: "R&B／ソウル" },
     ]);
 
-    expect(() => setNativeValue(sel, "存在しないジャンル名")).toThrow(OptionNotFoundError);
+    let thrown: unknown;
+    try {
+      setNativeValue(sel, "存在しないジャンル名");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(OptionNotFoundError);
+    expect((thrown as Error).message).toMatch(/options=\[Electronic \/ R&B／ソウル\]/);
     // 一致が無いので selectedIndex も初期のまま
     expect(sel.selectedIndex).toBe(0);
   });

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -30,6 +30,7 @@ import {
   waitForElementCount,
   waitForRemoval,
   waitForElementVisible,
+  waitForSelectOption,
   checkAllStores,
   acceptImportantTerms,
   scrollToDoneButton,
@@ -455,7 +456,7 @@ describe("setNativeValue", () => {
 });
 
 describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisible 排除）", () => {
-  it("artist/language/main_genre/sub_genre を可視フィールドに注入する", () => {
+  it("artist/language/main_genre/sub_genre を可視フィールドに注入する", async () => {
     // Given
     const artist = mountInput({ name: "bandname" });
     const language = mountSelect("language", ["ja", "en"]);
@@ -463,7 +464,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     const sub = mountSelect("genreSecondary", ["House", "Techno"]);
 
     // When
-    injectProfile(document, SAMPLE_PROFILE);
+    await injectProfile(document, SAMPLE_PROFILE);
 
     // Then
     expect(artist.value).toBe("ABYSS MI");
@@ -472,7 +473,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     expect(sub.value).toBe("House");
   });
 
-  it("sub_genre が null なら genreSecondary を触らない（skip）", () => {
+  it("sub_genre が null なら genreSecondary を触らない（skip）", async () => {
     // Given
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
@@ -484,35 +485,35 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     });
 
     // When
-    injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null });
+    await injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null });
 
     // Then: skip されるため change は一切発火しない
     expect(subChanges).toBe(0);
   });
 
-  it("artist が空なら bandname を触らない（後方互換）", () => {
+  it("artist が空なら bandname を触らない（後方互換）", async () => {
     // Given
     const artist = mountInput({ name: "bandname", value: "Soulful Grooves" });
     mountSelect("language", ["ja"]);
     mountSelect("genrePrimary", ["Electronic"]);
 
     // When
-    injectProfile(document, { ...SAMPLE_PROFILE, artist: "", sub_genre: null });
+    await injectProfile(document, { ...SAMPLE_PROFILE, artist: "", sub_genre: null });
 
     // Then
     expect(artist.value).toBe("Soulful Grooves");
   });
 
-  it("artist が非空で bandname 欄が無ければ FieldNotFoundError", () => {
+  it("artist が非空で bandname 欄が無ければ FieldNotFoundError", async () => {
     // Given: bandname 以外は存在
     mountSelect("language", ["ja"]);
     mountSelect("genrePrimary", ["Electronic"]);
 
     // Then
-    expect(() => injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).toThrow(FieldNotFoundError);
+    await expect(injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).rejects.toThrow(FieldNotFoundError);
   });
 
-  it("language が hidden（bbox 0）なら FieldNotFoundError で fail-loud", () => {
+  it("language が hidden（bbox 0）なら FieldNotFoundError で fail-loud", async () => {
     // Given: language は存在するが type=hidden 相当（bbox 0）
     mountInput({ name: "bandname" });
     const language = mountSelect("language", ["ja"]);
@@ -520,16 +521,59 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     mountSelect("genrePrimary", ["Electronic"]);
 
     // Then
-    expect(() => injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).toThrow(FieldNotFoundError);
+    await expect(injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).rejects.toThrow(FieldNotFoundError);
   });
 
-  it("language 欄が存在しなければ FieldNotFoundError", () => {
+  it("language 欄が存在しなければ FieldNotFoundError", async () => {
     // Given: main_genre だけ存在
     mountInput({ name: "bandname" });
     mountSelect("genrePrimary", ["Electronic"]);
 
     // Then
-    expect(() => injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).toThrow(FieldNotFoundError);
+    await expect(injectProfile(document, { ...SAMPLE_PROFILE, sub_genre: null })).rejects.toThrow(FieldNotFoundError);
+  });
+
+  it("main_genre の change 後に非同期 populate された sub_genre option を待って選択する（#1407）", async () => {
+    // Given: primary change 直後の secondary は placeholder のみ。
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    const genre = mountSelect("genrePrimary", ["エレクトロニック", "ポップ"]);
+    const sub = mountSelectWithOptions("genreSecondary", [{ value: "", text: "サブジャンルを選択" }]);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        for (const text of ["ハウス", "テクノ", "トランス"]) {
+          const opt = document.createElement("option");
+          opt.value = text;
+          opt.textContent = text;
+          sub.appendChild(opt);
+        }
+      }, 0);
+    });
+
+    // When
+    await injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+
+    // Then
+    expect(sub.value).toBe("テクノ");
+  });
+
+  it("sub_genre option 待機の no-match error には候補一覧を含める（#1407）", async () => {
+    // Given
+    const sub = mountSelectWithOptions("genreSecondary", [
+      { value: "", text: "サブジャンルを選択" },
+      { value: "house", text: "ハウス" },
+    ]);
+
+    // Then
+    await expect(waitForSelectOption(document, "#genreSecondary", "テクノ", 1)).rejects.toThrow(
+      /options=\[サブジャンルを選択 \/ ハウス\]/,
+    );
+    expect(sub.value).toBe("");
   });
 });
 

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -461,6 +461,17 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     const language = mountSelect("language", ["ja", "en"]);
     const genre = mountSelect("genrePrimary", ["Electronic", "Pop"]);
     const sub = mountSelect("genreSecondary", ["House", "Techno"]);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        sub.innerHTML = "";
+        for (const value of ["House", "Techno"]) {
+          const opt = document.createElement("option");
+          opt.value = value;
+          opt.textContent = value;
+          sub.appendChild(opt);
+        }
+      }, 0);
+    });
 
     // When
     await injectProfile(document, SAMPLE_PROFILE);
@@ -589,6 +600,42 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
 
     // Then: 部分一致の "ハードコア／ハードテクノ" ではなく、後から出た完全一致を選ぶ。
     expect(sub.value).toBe("techno");
+  });
+
+  it("sub_genre option 待機は既存の完全一致 stale option では resolve しない（#1407）", async () => {
+    // Given
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    const genre = mountSelect("genrePrimary", ["エレクトロニック"]);
+    const sub = mountSelectWithOptions("genreSecondary", [
+      { value: "", text: "サブジャンルを選択" },
+      { value: "old-techno", text: "テクノ" },
+    ]);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        sub.innerHTML = "";
+        for (const option of [
+          { value: "", text: "サブジャンルを選択" },
+          { value: "new-techno", text: "テクノ" },
+        ]) {
+          const opt = document.createElement("option");
+          opt.value = option.value;
+          opt.textContent = option.text;
+          sub.appendChild(opt);
+        }
+      }, 0);
+    });
+
+    // When
+    await injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+
+    // Then: primary change 前から存在した stale option ではなく、再生成後の option を選ぶ。
+    expect(sub.value).toBe("new-techno");
   });
 
   it("sub_genre option 待機の no-match error には候補一覧を含める（#1407）", async () => {


### PR DESCRIPTION
## Summary
- #genrePrimary 変更後に #genreSecondary の option が populate されるまで待機してから sub_genre を選択
- select option の no-match error に現時点の候補一覧を追加
- 非同期 populate と候補一覧付き error の Vitest coverage を追加

## Verification
- pnpm install --frozen-lockfile --ignore-workspace
- pnpm lint
- pnpm format:check
- pnpm compile
- pnpm test
- pnpm build
- pnpm test:e2e

Closes #1407