### PR TITLE
ci: docs/adr の ADR 番号重複を CI で機械チェック (#1414)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,21 @@ jobs:
           fi
           echo "CHANGELOG.md updated"
 
+  adr-numbering:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check ADR number uniqueness
+        run: |
+          set -eu
+          dups=$(ls docs/adr | cut -d- -f1 | sort | uniq -d)
+          if [ -n "$dups" ]; then
+            echo "::error::Duplicate ADR numbers found: $dups"
+            ls docs/adr | sort
+            exit 1
+          fi
+          echo "ADR numbers are unique"
+
   ts-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` に `adr-numbering` ジョブを追加
- `ls docs/adr | cut -d- -f1 | sort | uniq -d` が空でなければ fail（重複番号と一覧を出力）
- push / pull_request 両トリガーで実行され、takt 並行 PR の番号レースを merge 前に検出する

## 検証

- 現状の `docs/adr` に対してチェックがパスすることをローカルで確認
- 重複ファイル（`0001-a.md` / `0001-b.md`）を含むディレクトリで正しく fail することを確認

Closes #1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)