### PR TITLE
fix(lefthook): ブランチ削除 push を CHANGELOG ゲート対象外にする

### DIFF
--- a/.lefthook/pre-push/changelog-gate.sh
+++ b/.lefthook/pre-push/changelog-gate.sh
@@ -26,6 +26,29 @@ if [ "${SKIP_CHANGELOG:-}" = "1" ]; then
   exit 0
 fi
 
+# pre-push は stdin から "<local ref> <local sha> <remote ref> <remote sha>" を
+# ref ごとに 1 行受け取る（lefthook.yml 側で use_stdin: true が必要）。
+# local sha が全ゼロの行はブランチ削除 push（git push origin :branch）で、
+# push されるコミットが存在しないためゲート対象外。
+# 削除以外の ref が 1 つでもあれば従来通り HEAD 基準で判定する。
+# stdin が空（手動実行など）の場合も従来通り判定にフォールバックする。
+ZERO_SHA="0000000000000000000000000000000000000000"
+if [ ! -t 0 ]; then
+  ref_lines=0
+  non_delete_refs=0
+  while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    [ -z "${local_sha:-}" ] && continue
+    ref_lines=$((ref_lines + 1))
+    if [ "${local_sha}" != "${ZERO_SHA}" ]; then
+      non_delete_refs=$((non_delete_refs + 1))
+    fi
+  done
+  if [ "${ref_lines}" -gt 0 ] && [ "${non_delete_refs}" -eq 0 ]; then
+    echo "changelog-gate: ブランチ削除 push のためスキップします。" >&2
+    exit 0
+  fi
+fi
+
 BASE_REF="origin/main"
 if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
   echo "changelog-gate: ${BASE_REF} が無いためスキップします（CI で判定されます）。" >&2

--- a/.lefthook/pre-push/changelog-gate.sh
+++ b/.lefthook/pre-push/changelog-gate.sh
@@ -36,7 +36,9 @@ ZERO_SHA="0000000000000000000000000000000000000000"
 if [ ! -t 0 ]; then
   ref_lines=0
   non_delete_refs=0
-  while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  # `|| [ -n ... ]` は末尾改行が無い最終行の取りこぼし防止（read が非ゼロを
+  # 返しても変数が埋まっていれば 1 回だけ本体を実行する）
+  while read -r _local_ref local_sha _remote_ref _remote_sha || [ -n "${local_sha:-}" ]; do
     [ -z "${local_sha:-}" ] && continue
     ref_lines=$((ref_lines + 1))
     if [ "${local_sha}" != "${ZERO_SHA}" ]; then

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,10 @@
 # 個別スキップ: `LEFTHOOK=0 git push` で全 hook を無効化。
 # CHANGELOG ゲートのみ省く: `SKIP_CHANGELOG=1 git push`
 
+# use_stdin は lefthook 1.4.11 で追加。古い lefthook は未知 key を黙って無視し
+# ブランチ削除 push 判定が no-op になるため、最低バージョンを明示する
+min_version: 1.4.11
+
 pre-commit:
   parallel: true
   commands:
@@ -34,6 +38,9 @@ pre-push:
   commands:
     changelog-gate:
       # git が stdin に渡す "<local ref> <local sha> <remote ref> <remote sha>" を
-      # スクリプトへ転送する（ブランチ削除 push の判定に必要）
+      # スクリプトへ転送する（ブランチ削除 push の判定に必要）。
+      # 注意: lefthook の仕様で use_stdin を持つコマンドが同一 hook に複数あると
+      # stdin を受け取れるのは 1 つだけ。pre-push に stdin を使うコマンドを
+      # 追加するときはこのゲートの削除 push スキップが壊れないか確認すること
       use_stdin: true
       run: bash .lefthook/pre-push/changelog-gate.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,4 +33,7 @@ pre-commit:
 pre-push:
   commands:
     changelog-gate:
+      # git が stdin に渡す "<local ref> <local sha> <remote ref> <remote sha>" を
+      # スクリプトへ転送する（ブランチ削除 push の判定に必要）
+      use_stdin: true
       run: bash .lefthook/pre-push/changelog-gate.sh

--- a/tests/test_changelog_ci_contract.py
+++ b/tests/test_changelog_ci_contract.py
@@ -11,6 +11,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
 _CI_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _CHANGELOG_GATE_PATH = _REPO_ROOT / ".lefthook" / "pre-push" / "changelog-gate.sh"
+_LEFTHOOK_CONFIG_PATH = _REPO_ROOT / "lefthook.yml"
 
 _CHANGELOG_LABEL = "skip-changelog"
 _PATH_FILTER_PATTERN = (
@@ -154,3 +155,25 @@ def test_ci_changelog_gate_covers_ts_packages() -> None:
     # lefthook 側 GATED_PATHS は CI と同じ範囲を担保する。
     for token in ('"packages/"', '"package.json"'):
         assert token in gate_script, f"changelog-gate.sh に {token} が無い"
+
+
+def test_lefthook_changelog_gate_skips_branch_deletion_push() -> None:
+    """#1420: ブランチ削除 push（local sha 全ゼロ）は changelog ゲート対象外。
+
+    削除 push スキップは 2 ファイルで 1 つの不変条件:
+    changelog-gate.sh の stdin 判定と lefthook.yml の use_stdin: true。
+    use_stdin が落ちるとスクリプトの空 stdin フォールバックが回帰を隠して
+    削除 push が再びブロックされるため、両側をここで固定する。
+    """
+    gate_script = _read_text(_CHANGELOG_GATE_PATH)
+    for token in (
+        'ZERO_SHA="0000000000000000000000000000000000000000"',
+        "ブランチ削除 push のためスキップします",
+    ):
+        assert token in gate_script, f"changelog-gate.sh に {token} が無い"
+
+    lefthook_config = yaml.safe_load(_read_text(_LEFTHOOK_CONFIG_PATH))
+    gate_command = lefthook_config["pre-push"]["commands"]["changelog-gate"]
+    assert gate_command.get("use_stdin") is True, (
+        "lefthook.yml の changelog-gate に use_stdin: true が無いと削除 push スキップが黙って無効化される"
+    )


### PR DESCRIPTION
## 概要

`git push origin :branch-name` のようなブランチ削除 push が CHANGELOG ゲート違反として止められる問題を修正する。削除 push には新規コミットが存在しないため、そもそもゲート対象外にすべき。

2026-07-02 に `adr-audit` ブランチ削除で実際に発生し、`SKIP_CHANGELOG=1` で回避していた。

## 変更内容

- **`.lefthook/pre-push/changelog-gate.sh`**: pre-push が stdin から受け取る `<local ref> <local sha> <remote ref> <remote sha>` を読み、local sha が全ゼロ（削除）の ref **のみ**の push はスキップする分岐を追加。削除以外の ref が混在する push や stdin が空の場合（手動実行など）は従来通り HEAD 基準で判定する
- **`lefthook.yml`**: `changelog-gate` に `use_stdin: true` を追加。lefthook はデフォルトで stdin を `{push_files}` 計算のため自分で消費しコマンドへ転送しないため、この指定がないとスクリプト側の分岐が機能しない

## 動作確認

stdin をシミュレートして 3 ケースを確認:

| ケース | 期待 | 結果 |
|---|---|---|
| 削除 push のみ（local sha 全ゼロ） | スキップして exit 0 | ✅ 「ブランチ削除 push のためスキップします」 |
| 削除 + 通常 push 混在 | 従来通りゲート判定 | ✅ ゲートが実行される |
| 空 stdin（手動実行） | 従来通りゲート判定 | ✅ ゲートが実行される |

また、本 PR 自体の `git push` で lefthook pre-push（changelog-gate）が実走し pass することを確認済み（`.lefthook/` / `lefthook.yml` はゲート対象パス外のため CHANGELOG 追記は不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)