### PR TITLE
fix(hooks): extensions のみの commit で pre-commit が「対象ファイルなし」exit 1 で落ちる問題を修正 (#1428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(hooks)`: extensions/ 配下のみを変更した commit で lefthook pre-commit の oxlint / oxfmt が「対象ファイルなし」を exit 1 で返し必ず失敗する問題を修正。extensions は自前の ESLint / Prettier / tsc 管理（CI: extensions.yml）のため、`lefthook.yml` の oxlint / oxfmt / typecheck に `exclude: extensions/**` を追加して root ツールチェーンの対象のみに絞った（exclude の glob 配列サポートのため `min_version` を 1.5.0 へ引き上げ、#1428）
 - `fix(channel-new)`: `yt-doctor` に `ttp_wf_new_readiness` を追加し、`/channel-new` が TTP 対象承認・relationship・branding snapshot・thumbnail reference・Suno readiness の不足を残したまま完了扱いにならないようにした（#1397）
 - `fix(skills)`: `/video-upload` と `/wf-next` の公開承認前に `yt-upload-collection --plan` で即時公開/予約公開を確定し、予約時は実際の公開予定時刻を案内するよう明記（#1395）
 - `fix(doctor)`: `yt-doctor` に `ttp_wf_new_readiness` を追加し、`/channel-setup` の benchmark 反映未完了による TTP 参照データ欠落を検知・案内できるようにした（#1400）

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,9 +11,9 @@
 # 個別スキップ: `LEFTHOOK=0 git push` で全 hook を無効化。
 # CHANGELOG ゲートのみ省く: `SKIP_CHANGELOG=1 git push`
 
-# use_stdin は lefthook 1.4.11 で追加。古い lefthook は未知 key を黙って無視し
-# ブランチ削除 push 判定が no-op になるため、最低バージョンを明示する
-min_version: 1.4.11
+# use_stdin は lefthook 1.4.11、exclude の glob 配列は 1.5.0 で追加。古い lefthook は
+# 未知 key / 未対応の値形式を黙って無視し判定が no-op になるため、最低バージョンを明示する
+min_version: 1.5.0
 
 pre-commit:
   parallel: true
@@ -24,14 +24,27 @@ pre-commit:
     ruff-format:
       glob: "*.py"
       run: uv run ruff format --check {staged_files}
+    # oxlint / oxfmt / typecheck は root ツールチェーン（ADR 0001）の対象のみに絞る。
+    # extensions/ は自前の ESLint / Prettier / tsc 管理（CI: extensions.yml）であり、
+    # oxlint.config.ts の ignorePatterns も extensions/** を除外しているため、staged files が
+    # extensions のみだと oxlint / oxfmt が「対象ファイルなし」を exit 1 で返し commit が
+    # 必ず落ちる (#1428)。exclude で staged files から外せば、対象 0 件のとき lefthook が
+    # コマンドごと skip する。
     oxlint:
       glob: "*.{ts,tsx,js,jsx,mjs,cjs}"
+      exclude:
+        - "extensions/**"
       run: bunx oxlint {staged_files}
     oxfmt:
       glob: "*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"
+      exclude:
+        - "extensions/**"
       run: bunx oxfmt --check {staged_files}
     typecheck:
+      # root の tsc -b は extensions を含まないため、extensions のみの変更では起動しない
       glob: "*.{ts,tsx}"
+      exclude:
+        - "extensions/**"
       run: bun run typecheck
 
 pre-push:


### PR DESCRIPTION
Closes #1428

## 問題

extensions/ 配下の TS ファイルのみを staged にして commit すると、lefthook pre-commit が必ず失敗する。

- `lefthook.yml` の oxlint / oxfmt は glob で extensions の staged files もコマンドへ渡す
- 一方 `oxlint.config.ts` の `ignorePatterns`（`extensions/**`）により全件 ignore される
- 結果「No files found to lint / Expected at least one target file」を exit 1 で返し commit がブロックされる（PR #1426 の作業中に遭遇、`LEFTHOOK=0` で回避していた）

## 修正

extensions/ は自前の ESLint / Prettier / tsc 管理（ADR 0001、CI: extensions.yml）のため、oxlint / oxfmt / typecheck に `exclude: extensions/**` を追加して root ツールチェーン（tsc -b / oxlint / oxfmt）の対象のみに絞る。exclude 適用後 0 件になった場合は lefthook がコマンドごと skip する。

exclude の glob 配列は lefthook 1.5.0 で追加のため `min_version` を 1.4.11 → 1.5.0 へ引き上げ（devShell の lefthook は 2.1.1）。

## 検証（lefthook 2.1.1、`lefthook run pre-commit` で実測）

| staged files | 期待 | 結果 |
|---|---|---|
| extensions のみ | oxlint / oxfmt / typecheck を skip | ✅ `(skip) no files for inspection` / exit 0 |
| root TS のみ | 3 コマンド発火 | ✅ すべて green |
| 混在 | コマンド発火、extensions は引数から除外 | ✅ `LEFTHOOK_VERBOSE=1` で `filtered [x]` に root ファイルのみが残り、oxfmt の job 引数が `oxfmt.config.ts` のみになることを確認 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
