### PR TITLE
docs(channel-new): ペルソナ生成前に TTP 対象の中間ゲートを追加 (#1517)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -288,6 +288,8 @@ image_generation:
 
 ### Step 7: 簡易ペルソナ導出
 
+**入口ゲート**: 開始前に `config/channel/analytics.json::benchmark.channels` に承認済み TTP 対象が 1 件以上あることを確認する。0 件なら本 Step 以降に進まず Step 5 に戻って候補を再確認するか、ユーザーに停止を確認して終了する（判定基準は冒頭「TTP 完了条件（新規開設モード）」を参照）。
+
 新チャンネルには `/viewer-voice` や `/benchmark` の結果がまだない場合があるため、ここでは軽量版だけ作る。
 
 入力:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `docs(channel-new)`: `/channel-new`（新規開設モード）の Step 7「簡易ペルソナ導出」冒頭に入口ゲートを追加し、承認済み TTP 対象（`config/channel/analytics.json::benchmark.channels`）が 0 件のままペルソナ生成へ進めないようにした。従来は 0 件検出が Step 9 の最終ゲートに集中しており、空のまま生成 → 差し戻しの手戻り（AI 生成コストの無駄）が発生し得た。判定基準は冒頭「TTP 完了条件（新規開設モード）」を単一ソースとして参照し、完了条件本体はコピーしない（#1517）
 - `feat(takt)`: lite workflow に提出前セルフ監査を組み込んだ（#1508）。過去の review-takt-default 指摘 371 件（183 レビュー）の全件分類から頻出 8 パターンを抽出した `.takt/facets/policies/pre-review-checklist.md` を新設し、`implement` step（自己監査 + 受入条件充足表の出力）と `review` step（独立照合、スコープ外の改善提案は verdict に影響させない）に注入。あわせて lite の `plan` step に `instruction: plan` を追加し、リポジトリ強化版 plan instruction（`.takt/facets/instructions/plan.md`）が lite でも注入されるようにした。運用・更新手順は `docs/takt-operations.md` の「提出前セルフ監査」節を参照
 - `docs(skills)`: takt 各 step の固定コンテキスト削減のため全スキルの frontmatter description を短縮（合計 22.4KB → 10.1KB。同義トリガー語の羅列と処理手順の重複を削り、スキル間 dispatch の境界語と機械検証キーワードは維持）。あわせて CLAUDE.md（18.9KB → 7.4KB）/ AGENTS.md（14.6KB → 2.2KB、CLAUDE.md への一元化）をスリム化し、詳細を `docs/architecture.md` / `docs/development.md` / `docs/takt-operations.md` へ移設。`.takt/config.yaml` に observability（usage_events_phase）を有効化し、小〜中規模 issue 用の軽量 3-step workflow `.takt/workflows/lite.yaml` を追加（使い分け基準は `docs/takt-operations.md`）。さらに takt 内部実装（phase 分割実行）の調査に基づき、lite の review step を全 step codex 方針に合わせて codex 化し、`structured_output`（`.takt/schemas/review-verdict.json`）+ deterministic `when:` ルールで状態判定 phase の LLM 呼び出しを排除。phase コストモデルと workflow 設計指針を `docs/takt-operations.md` に文書化
 


### PR DESCRIPTION
## Summary

`/channel-new`（新規開設モード）の Step 7「簡易ペルソナ導出」冒頭に**入口ゲート**を 1 段落追加した。従来は「承認済み TTP 対象 0 件」の検出が Step 9 の最終ゲートに集中しており、`benchmark.channels` が空のままペルソナ生成へ進める → Step 9 で差し戻し、という手戻り（AI 生成コストの無駄）が起き得た。ペルソナ生成の入口で 0 件を弾くことでこの手戻りを防ぐ。

## 変更内容

- **`.claude/skills/channel-new/SKILL.md`**: Step 7 冒頭に入口ゲートを追加
  - `config/channel/analytics.json::benchmark.channels` に承認済み TTP 対象が 1 件以上あることを確認
  - 0 件なら本 Step 以降に進まず Step 5 に戻る（または停止確認して終了）
  - 判定基準は冒頭「TTP 完了条件（新規開設モード）」を**単一ソースとして参照**し、完了条件本体はコピーしない
- **`CHANGELOG.md`**: `[Unreleased] / Changed` に追記

## 受入条件の検証

- [x] ペルソナ生成 Step（Step 7）冒頭に入口ゲートがある
- [x] `git diff` 上、既存の TTP 完了条件（48-60 行）・Step 3・Step 9 最終ゲートに差分がない（挿入は Step 7 冒頭の 1 段落のみ）
- [x] ゲート文言は完了条件本体をコピーせず冒頭セクションへの参照（単一ソース原則）
- [x] `uv run pytest tests -q --ignore=tests/integration` → 4282 passed（exit 0）
- [x] `CHANGELOG.md [Unreleased]` に追記

## スコープ外（issue 記載どおり）

- TTP 完了条件・Step 3・Step 9 の既存文言の再構成
- 既存チャンネル取り込みモード側の手順
- SKILL.md の分割・短縮などの構造改革

Closes #1517