### PR TITLE
docs(plans): 第 2 回監査(スキル全般 Sonnet-safe 化)の記録を追加

### DIFF
--- a/plans/005-skill-authoring-standard.md
+++ b/plans/005-skill-authoring-standard.md
@@ -1,0 +1,117 @@
+# Plan 005: Sonnet-safe スキル記述規約を docs/skill-design/ に制定する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- docs/skill-design/ CLAUDE.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: dx
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+このリポジトリの `.claude/skills/` 配下 47 スキル(SKILL.md 合計約 10,300 行)は、下流チャンネルリポジトリで Claude Code / Codex CLI により実行される。実行モデルは Opus 級とは限らず Sonnet 級のことが多い。2026-07-05 の監査で 42 件の findings が出たが、その大半は少数の同型パターンの反復だった: 承認ゲートの型が曖昧、前提ファイルの存在ガードがない、判断基準なしの判断要求、同一ロジックの散文重複、兄弟スキル間の frontmatter 矛盾。個別修正(plans/006〜017)だけでは新規スキル作成時に同じ問題が再生産されるため、記述規約を 1 枚のドキュメントに定めて再発を止める。この規約は plans/006, 008, 009, 011 の修正方針の根拠にもなる。
+
+## Current state
+
+- `docs/skill-design/` — 既存ディレクトリ。`ADR-001-thumbnail-prompt-schema.md` が置かれている(`.claude/skills/thumbnail/SKILL.md:213` から参照されている)。ここに規約ドキュメントを追加する。
+- `CLAUDE.md`(リポジトリルート)— 「## 開発規約」セクション配下に「### skill frontmatter」という小節があり、`description:` の double-quote 必須規則が既に書かれている。規約ドキュメントへのポインタをここに 1 行追加する。
+- 監査で確認済みの「良い実例」(規約の each ルールの exemplar として引用する):
+  - 承認ゲートの良い例: `.claude/skills/live-clean/SKILL.md:84`「表示後、AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない。」
+  - 前提の明文化の良い例: `.claude/skills/channel-new/SKILL.md:110-140`(停止すべき 17 チェックと許容する 4 fail を理由文字列付きで分離)
+  - 単一ソースの良い例: `.claude/skills/collection-ideate/references/freshness-rules.md`(stale 判定の参照先ドキュメント)
+  - 機械検証の良い例: `.claude/skills/suno-lyric/SKILL.md:122`「機械チェックを実行して exit 0 を確認する: `python .claude/skills/suno-lyric/references/check_lyric_duplication.py ...`」
+- 悪い実例(規約の反例として引用する。修正自体は plans/006〜017 の担当なので**ここでは直さない**):
+  - frontmatter 矛盾: `.claude/skills/viewer-voice/SKILL.md:3`「任意後続スキル」 vs `.claude/skills/audience-persona-design/SKILL.md:3`「/viewer-voice を必須入力に」
+  - ゲートなし apply: `.claude/skills/comments-reply/SKILL.md:71-115`(dry-run の確認ポイント列挙の直後に apply コマンド)
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニットテスト | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+| lint | `uv run ruff check .` | exit 0 |
+
+## Scope
+
+**In scope**(変更してよいファイル):
+- `docs/skill-design/skill-authoring-guidelines.md`(新規作成)
+- `CLAUDE.md`(「### skill frontmatter」小節への 1 行追記のみ)
+
+**Out of scope**(触らない):
+- `.claude/skills/` 配下すべて — 個別スキルの修正は plans/006〜017 の担当。この plan は規約の制定のみ。
+- `CHANGELOG.md` — docs のみの変更は CHANGELOG ゲート対象外(`CLAUDE.md` の「CHANGELOG ゲート」参照)。ただし `CLAUDE.md` 自体はゲート対象パスに含まれないので追記不要。
+- `.claude/CLAUDE.template.md` — 下流向けテンプレは対象外(これを触ると CHANGELOG 必須になる)。
+
+## Git workflow
+
+- 作業は worktree 上で行う(`$REPO_ROOT/.worktrees/005-skill-authoring-standard/` に `git worktree add`)。base は main。
+- コミットメッセージは日本語 Conventional Commits。例: `docs(skill-design): Sonnet-safe スキル記述規約を制定`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 規約ドキュメントを作成する
+
+`docs/skill-design/skill-authoring-guidelines.md` を新規作成し、以下の 7 ルールを見出しごとに記述する。各ルールには (a) 規則本文、(b) 上記 Current state の「良い実例」への `file:line` 参照、(c) 反例パターンの説明(実在スキル名を挙げてよいが、修正は各 plan の担当と明記)を含める。
+
+1. **発動条件の相互排他**: 発動キーワードは兄弟スキル間で重複させない。混同しやすいペア(生成/比較、collection 型/release 型など)は双方の description に否定トリガー(「〜は /xxx」)を必ず入れる。あるスキルが別スキルの必須入力を作る場合、両者の description の依存表現(必須/任意)を一致させる。
+2. **外部反映・破壊的操作の承認ゲート標準型**: YouTube への投稿・削除・課金 API 呼び出しの前は、(a) dry-run 出力の PASS/FAIL 条件を箇条書きで定義し「全項目 PASS の場合のみ次へ」と書く、(b) AskUserQuestion で明示的選択肢(「実行する」「キャンセル」)を提示する、(c) 取り消し不可の操作はその旨を選択肢の説明に含める、の 3 点を必須とする。
+3. **前提ガードの標準型**: 前工程スキルの出力ファイルに依存する Step は、冒頭で存在確認コマンド(`ls <path>` 等)を置き、「存在しなければ /前工程スキル を案内して停止する」と書く。inline コード実行の前に依存する認証ファイル(`auth/token.json` 等)の存在確認を置く。
+4. **判断基準なしの判断要求の禁止**: 「適切に」「必要なら」「文脈に応じて」を単独で使わない。使う場合は直後に判断条件の列挙(if-then 形式または表)か、調整ルーブリックを付ける。
+5. **単一ソース原則**: 同一の判定ロジック(鮮度判定・閾値など)を複数の SKILL.md に散文で重複記述しない。`references/` 配下の 1 ファイルに定義し、他スキルからは「詳細は X を参照。要約: 〜」の 1 行参照にとどめる。
+6. **Hard Gates / 完了条件の配置**: スキルの完了条件・絶対制約は SKILL.md 冒頭 60 行以内(Overview 直後)に置く。300 行を超えるスキルでは、後半の Step から冒頭の完了条件セクションへ明示的に参照を張る。
+7. **実行者が解決できない参照の禁止**: 下流リポジトリの実行者がアクセスできない参照(オペレーター個人の別リポジトリ、未接続の試験機能)を手順文中に置かない。置く場合は「実行者向けではない」ことを明示する引用ブロック(`> 参考(オペレーター向け): ...`)に隔離する。
+
+ドキュメント冒頭に「この規約は既存スキルの一括改修を要求しない。新規作成・改訂時に適用し、既存の逸脱は plans/006〜017 で個別に解消する」と適用方針を明記する。
+
+**Verify**: `ls docs/skill-design/skill-authoring-guidelines.md` → ファイルが存在する。7 ルールの見出しがあることを `rg -c '^## ' docs/skill-design/skill-authoring-guidelines.md` で確認 → 7 以上。
+
+### Step 2: CLAUDE.md からポインタを張る
+
+`CLAUDE.md` の「### skill frontmatter」小節の末尾に 1 行追加する:
+
+```
+- スキル新規作成・改訂時は `docs/skill-design/skill-authoring-guidelines.md`（Sonnet-safe 記述規約）に従うこと
+```
+
+**Verify**: `rg -n 'skill-authoring-guidelines' CLAUDE.md` → 1 件ヒット。
+
+### Step 3: 既存テストが壊れていないことを確認する
+
+**Verify**: `uv run pytest tests -q --ignore=tests/integration` → exit 0(この plan はコードもスキルも触らないため、失敗した場合は元から失敗しているか環境問題 — STOP して報告)。
+
+## Test plan
+
+新規テストは不要(docs のみ)。既存ユニットスイートの green 維持のみ確認する。
+
+## Done criteria
+
+- [ ] `docs/skill-design/skill-authoring-guidelines.md` が存在し、7 ルールすべての見出しを含む
+- [ ] 各ルールに実在ファイルへの `file:line` 実例参照が最低 1 つある
+- [ ] `rg -n 'skill-authoring-guidelines' CLAUDE.md` が 1 件ヒット
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `git status` で In scope 外の変更ファイルがない
+- [ ] `plans/README.md` の 005 行を更新済み
+
+## STOP conditions
+
+- `docs/skill-design/` が存在しない、または `CLAUDE.md` に「### skill frontmatter」小節が見つからない(構成が drift している)。
+- 「良い実例」として引用予定の箇所(live-clean:84, channel-new:110-140, suno-lyric:122)が現物と一致しない — plans/006〜017 が先に実行されて行番号がずれた可能性がある。その場合は現物の該当箇所を確認して行番号を更新してよいが、内容自体が消えていたら STOP。
+- ユニットテストが変更前から fail している。
+
+## Maintenance notes
+
+- plans/006(承認ゲート)・008(frontmatter)・009(前提ガード)・011(live-clean)はこの規約のルール 2・1・3・2 をそれぞれ実装する。規約の文言を変える場合はそれらの plan の方針と矛盾しないか確認すること。
+- 将来的には `tests/test_skill_docs_consistency.py` の系譜で規約の一部(発動キーワード重複の検出など)を機械化できる。この plan では見送り(規約の合意が先)。
+- レビュー観点: 規約が「既存スキルの一括改修を要求しない」ことが明記されているか(さもないと 47 スキル改修という誤った着地になる)。

--- a/plans/006-dry-run-apply-approval-gates.md
+++ b/plans/006-dry-run-apply-approval-gates.md
@@ -1,0 +1,127 @@
+# Plan 006: comments-reply / pinned-comment の dry-run→apply 間に明示的承認ゲートを追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/comments-reply/ .claude/skills/pinned-comment/`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW(ドキュメント変更のみ。ただし対象は実 YouTube への公開操作の防護柵)
+- **Depends on**: plans/005-skill-authoring-standard.md(承認ゲート標準型の定義。005 未完了でも本文の指示だけで実行可能)
+- **Category**: docs(実質は安全性)
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/comments-reply` と `/pinned-comment` は YouTube に**実際にコメントを公開投稿する**スキルで、下流リポジトリで Sonnet 級モデルが実行する。現状の SKILL.md は dry-run(Phase 4 / Phase 1)の「確認ポイント」を列挙した直後に apply コマンドを提示しており、(a) 確認ポイントの PASS/FAIL 判定基準がなく、(b) apply 前のユーザー承認要求がない。弱いモデルは「確認ポイントを眺めた」ことを「確認完了」と解釈し、不適切な返信文のまま実投稿まで直行しうる。投稿されたコメントは公開されるため実害が出てからでは遅い。同リポジトリの `/live-clean` には「AskUserQuestion で確認、承認されるまで絶対に実行しない」という先例があり、それと同じ型に揃える。
+
+## Current state
+
+- `.claude/skills/comments-reply/SKILL.md` — 対象ファイル 1。
+  - 71 行目付近: `### Phase 4: dry-run で内容をプレビュー` — `uv run yt-comments-reply --dry-run --agent-replies-file /tmp/comment-replies.json --limit 5` の後に「出力の確認ポイント:」として 4 項目(`返信候補` が期待件数か / `reply` 欄が persona と言語に合うか / `skipped` に `already_replied` / `ng_word` / `reply_contains_ng_word` があるか / `agent_reply_missing` の扱い)を列挙。**PASS/FAIL の判定形式にはなっていない**。
+  - その後「## 設定スキーマ」セクションを挟んで 110 行目付近: `### Phase 5: apply で反映` — `uv run yt-comments-reply --apply --agent-replies-file /tmp/comment-replies.json --limit 5`。**Phase 4 と Phase 5 の間に承認ステップがない**。
+- `.claude/skills/pinned-comment/SKILL.md` — 対象ファイル 2。
+  - 44-60 行: `--dry-run` のコマンド例(collection 指定 / video-id 直接指定の 2 形)と「確認ポイント」3 項目(`planned` 件数 / `scene_phrase` / `scene_emoji` 展開 / `SKIP ... already_posted` 等)。
+  - 62 行目付近: `### Phase 2: apply で投稿` — 直後に `--apply` コマンド。**間に承認ステップがない**。
+- 型として揃える先例: `.claude/skills/live-clean/SKILL.md:84`「表示後、AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない。」
+- frontmatter は両スキルとも `description:` が double-quoted string(この規約を維持すること)。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニットテスト | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+| frontmatter 検証 | `uv run pytest tests/test_skill_frontmatter_yaml.py -q` | exit 0 |
+| スキル docs 整合 | `uv run pytest tests/test_skill_docs_consistency.py -q` | exit 0 |
+
+## Scope
+
+**In scope**(変更してよいファイル):
+- `.claude/skills/comments-reply/SKILL.md`
+- `.claude/skills/pinned-comment/SKILL.md`
+- `CHANGELOG.md`(`[Unreleased]` への追記 — `.claude/skills/` は CHANGELOG ゲート対象)
+
+**Out of scope**(触らない):
+- `src/youtube_automation/scripts/` の CLI 実装(`yt-comments-reply` / `yt-pinned-comment`)— CLI の挙動変更はしない。ゲートは SKILL.md の手順としてのみ追加する。
+- `.claude/skills/live-clean/SKILL.md` — 承認の選択肢形式の改善は plans/011 の担当。
+- 各スキルの `--limit` 値や設定スキーマの記述。
+
+## Git workflow
+
+- worktree 上で作業(`$REPO_ROOT/.worktrees/006-approval-gates/`)。base は main。
+- コミット例: `docs(skills): comments-reply / pinned-comment に apply 前の承認ゲートを追加`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: comments-reply の Phase 4 を PASS/FAIL ゲート化する
+
+`.claude/skills/comments-reply/SKILL.md` の Phase 4「出力の確認ポイント:」を以下の構造に書き換える(既存 4 項目の内容は保持し、判定形式に変換する):
+
+- 見出しを「出力の確認ポイント(**全項目 PASS の場合のみ Phase 5 へ進む**):」に変更。
+- 各項目を PASS 条件として書く(例: 「`skipped` の各行の理由が意図どおりである(`reply_contains_ng_word` が 1 件でもあれば該当返信文を修正して dry-run からやり直す)」)。
+- 末尾に以下を追加:
+
+```markdown
+1 項目でも FAIL の場合は `/tmp/comment-replies.json` の該当返信文を修正し、Phase 4 の dry-run を再実行する。**FAIL のまま Phase 5 に進んではならない。**
+
+全項目 PASS を確認したら、AskUserQuestion で dry-run 結果の要約(返信件数・対象コメントの抜粋)を提示し、「投稿する」「キャンセル」の明示的選択肢でユーザー承認を取る。投稿されたコメントは YouTube 上に公開される。**承認されるまで Phase 5 の apply を実行しない**(Codex など AskUserQuestion が使えない環境では、同内容をテキストで提示しユーザーの明示的な承認応答を待つ)。
+```
+
+**Verify**: `rg -n '承認されるまで Phase 5' .claude/skills/comments-reply/SKILL.md` → 1 件ヒット。`rg -n '全項目 PASS' .claude/skills/comments-reply/SKILL.md` → 1 件以上ヒット。
+
+### Step 2: pinned-comment の Phase 1→2 間に同型のゲートを追加する
+
+`.claude/skills/pinned-comment/SKILL.md` の「確認ポイント」(44-60 行付近)にも Step 1 と同じ型を適用する:
+
+- 「確認ポイント(**全項目 PASS の場合のみ Phase 2 へ進む**):」へ変更。
+- `### Phase 2: apply で投稿` の直前に、AskUserQuestion による「投稿する」「キャンセル」承認ステップ(Step 1 と同文型、対象は planned 件数と生成テキストの要約)を追加。
+
+**Verify**: `rg -n '承認されるまで' .claude/skills/pinned-comment/SKILL.md` → 1 件以上ヒット。
+
+### Step 3: CHANGELOG に追記する
+
+`CHANGELOG.md` の `[Unreleased]` に追記(セクションは既存の書式に合わせる。無ければ `### Changed`):
+
+```
+- comments-reply / pinned-comment: dry-run → apply の間に PASS/FAIL 判定と AskUserQuestion 承認ゲートを追加（Sonnet 級実行時の誤投稿防止）
+```
+
+**Verify**: `rg -n 'comments-reply / pinned-comment' CHANGELOG.md` → 1 件ヒット。
+
+### Step 4: テストで回帰がないことを確認する
+
+**Verify**: `uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テストは不要(SKILL.md の手順文変更)。`tests/test_skill_frontmatter_yaml.py` と `tests/test_skill_docs_consistency.py` を含むユニットスイートが green のままであることを確認する。もし `test_skill_docs_consistency.py` が変更箇所の文言を assert していて fail した場合、テストの期待値を新しい文言に更新してよい(その場合はコミットメッセージに明記)。
+
+## Done criteria
+
+- [ ] comments-reply: Phase 4 に「全項目 PASS の場合のみ」の判定形式と AskUserQuestion 承認ステップがあり、Phase 5 の前に位置する
+- [ ] pinned-comment: Phase 2(apply)の直前に同型の承認ステップがある
+- [ ] 両ファイルの frontmatter `description:` が double-quoted のまま
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記済み
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `git status` で In scope 外の変更がない
+- [ ] `plans/README.md` の 006 行を更新済み
+
+## STOP conditions
+
+- Phase 4 / Phase 5(comments-reply)または dry-run / Phase 2(pinned-comment)の構造が Current state の記述と一致しない(先行変更で drift)。
+- `--apply` の前に既に AskUserQuestion 承認が存在する(誰かが先に直した)— 重複追加せず STOP して報告。
+- テスト fail の原因が本変更以外にある。
+
+## Maintenance notes
+
+- `yt-comments-reply` / `yt-pinned-comment` の CLI 側に将来 `--yes` / 確認プロンプトが実装されたら、SKILL.md 側のゲートと二重にならないよう一方に寄せる。
+- レビュー観点: ゲート文言が「承認を推奨」ではなく「承認されるまで実行しない」という禁止形になっているか(Sonnet は推奨形を任意と解釈しうる)。
+- `/community-post` は Studio 手動投稿のためゲート不要(投稿自体を自動化していない)。対象を広げない。

--- a/plans/007-analytics-report-ctr-doc-fix.md
+++ b/plans/007-analytics-report-ctr-doc-fix.md
@@ -1,0 +1,128 @@
+# Plan 007: analytics-report の CTR 解釈記述をコードの実セマンティクスに合わせて書き直す
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/analytics-report/ src/youtube_automation/utils/reporting_api.py src/youtube_automation/utils/ctr_resolver.py`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs(実体は DRIFT — 記述とコードの乖離)
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`.claude/skills/analytics-report/SKILL.md` の「CTR 値の解釈」セクションは自己矛盾しており、かつコードの実装と食い違っている。「`ctr_percentage` は整数値(例: 2606)」と書かれているが、実際の `aggregated_ctr_percentage` は**百分率の float(例: 4.2 = 4.2%)**である(下記 Current state のコード根拠参照)。この記述を Sonnet 級モデルが読むと、(a) 裸の整数をそのまま HTML レポートに出力する、(b)「2606 → 26.06%」のような架空の変換式を発明する、のどちらかに振れ、レポートの CTR 表示が壊れる。正しい変換規則をコード根拠付きで 1 段落に書き直す。
+
+## Current state
+
+- `.claude/skills/analytics-report/SKILL.md:112-117` — 問題のセクション。現物:
+
+```markdown
+#### CTR 値の解釈
+
+Analytics API の `ctr_percentage` は **整数値**（例: 2606 = 実際のパーセントとして解釈が必要）。
+`impressions` と `ctr_percentage` の関係から実際の CTR% を算出:
+- `click_count ≈ impressions × (ctr_percentage / impressions)` ではなく
+- 実際には API が返す値をそのまま使用し、表示時に適切にフォーマットする
+```
+
+- コード側の真実(この plan で変更しない、根拠として読むだけ):
+  - `src/youtube_automation/utils/reporting_api.py:496` — `"aggregated_ctr_percentage": (total_weighted / total_impressions) if total_impressions else None` — impressions 加重平均の**百分率 float**。
+  - `src/youtube_automation/utils/ctr_resolver.py` — legacy 経路 `channel_ctr.average_ctr`(0-1 の割合)からの変換で `avg * 100` して `aggregated_ctr_percentage` に格納 = 単位は percent。
+  - `tests/test_ctr_resolver.py:13` — フィクスチャ値 `"aggregated_ctr_percentage": 4.2`(= 4.2% を意味する)。
+- なお `.claude/skills/postmortem/SKILL.md` も `ctr_percentage` を参照するが、そちらは比率比較(0.7 倍未満など)にしか使っておらず単位に依存しないため変更不要。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| 該当ユニットテスト | `uv run pytest tests/test_ctr_resolver.py -q` | exit 0 |
+| ユニットテスト全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/analytics-report/SKILL.md`(「#### CTR 値の解釈」セクションのみ)
+- `CHANGELOG.md`(`[Unreleased]` への追記)
+
+**Out of scope**:
+- `src/youtube_automation/utils/reporting_api.py` / `ctr_resolver.py` — コードは正しい。触らない。
+- `.claude/skills/postmortem/SKILL.md` — 比率利用のため影響なし。
+- `.claude/skills/analytics-collect/` / `analytics-analyze/` — フィールド名の言及があっても単位の誤記がなければ触らない。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(analytics-report): CTR 値の解釈をコードの実セマンティクス（百分率 float）に修正`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: コード根拠を自分で確認する
+
+`src/youtube_automation/utils/reporting_api.py:496` と `tests/test_ctr_resolver.py` の冒頭フィクスチャを開き、`aggregated_ctr_percentage` が「百分率 float」であることを確認する。
+
+**Verify**: `rg -n 'aggregated_ctr_percentage' src/youtube_automation/utils/reporting_api.py tests/test_ctr_resolver.py` → 上記行がヒットし、テスト値が `4.2` である。**もし値の形が抜粋と異なっていたら STOP**(コードが変わっている)。
+
+### Step 2: セクションを書き直す
+
+`.claude/skills/analytics-report/SKILL.md` の「#### CTR 値の解釈」ブロック全体を以下で置き換える:
+
+```markdown
+#### CTR 値の解釈
+
+`aggregated_ctr_percentage` / `ctr_percentage` は**百分率を表す float**（例: `4.2` = CTR 4.2%）。
+`reporting_api.py` が `total_weighted / total_impressions` で算出した加重平均で、単位は最初から percent。
+
+- 表示時は小数 1〜2 桁 + `%` でフォーマットする（例: `4.2%`、`f"{value:.1f}%"` 相当）
+- **やってはいけないこと**: 値を 100 で割る / 100 を掛ける / 整数とみなして再解釈する。値はそのまま percent として使う
+- 値が `None` の場合は「CTR データなし（Reporting API 未取得）」と表示する
+```
+
+**Verify**: `rg -n '2606' .claude/skills/analytics-report/SKILL.md` → 0 件。`rg -n '百分率を表す float' .claude/skills/analytics-report/SKILL.md` → 1 件。
+
+### Step 3: CHANGELOG に追記する
+
+`CHANGELOG.md` の `[Unreleased]` に追記:
+
+```
+- analytics-report: CTR 値の解釈の誤記述（「整数値 2606」）をコードの実セマンティクス（百分率 float、例 4.2 = 4.2%）に修正
+```
+
+**Verify**: `rg -n 'analytics-report: CTR' CHANGELOG.md` → 1 件。
+
+### Step 4: テスト確認
+
+**Verify**: `uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テストは不要。`tests/test_ctr_resolver.py` が単位のセマンティクスを既に担保している。SKILL.md の文言を assert するテストが fail した場合のみ、期待値を新文言へ更新する。
+
+## Done criteria
+
+- [ ] 「整数値」「2606」という記述が analytics-report/SKILL.md から消えている
+- [ ] 新しい記述が「百分率 float、そのまま percent として表示」という一義的な規則になっている
+- [ ] `CHANGELOG.md` に追記済み
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `plans/README.md` の 007 行を更新済み
+
+## STOP conditions
+
+- Step 1 の確認で `aggregated_ctr_percentage` の算出が抜粋と異なる(例: `* 100` が増減している)— 記述すべき正解が変わるため STOP して報告。
+- 「#### CTR 値の解釈」セクションが SKILL.md に存在しない。
+- リポジトリ内に「2606」を正とする別ドキュメントが見つかった場合(`rg -n '2606' --glob '!plans/**'` で確認)— 矛盾の根が深いため STOP。
+
+## Maintenance notes
+
+- 将来 Reporting API のレポートタイプを変えると `aggregated_ctr_percentage` の算出元が変わりうる。`reporting_api.py` の当該 dict を変更する PR では、この SKILL.md セクションとの整合をレビューで確認すること。
+- `/postmortem` の閾値表も同フィールドを使う(比率比較なので今回は無変更)。単位を変える改修が入る場合は両方見直すこと。

--- a/plans/008-frontmatter-contradictions.md
+++ b/plans/008-frontmatter-contradictions.md
@@ -1,0 +1,148 @@
+# Plan 008: 兄弟スキル間の frontmatter 矛盾・発動キーワード衝突を解消する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/viewer-voice/SKILL.md .claude/skills/audience-persona-design/SKILL.md .claude/skills/benchmark/SKILL.md .claude/skills/channel-research/SKILL.md .claude/skills/videoup/SKILL.md .claude/skills/video-upload/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: plans/005-skill-authoring-standard.md(ルール 1「発動条件の相互排他」。005 未完了でも実行可能)
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+スキルの frontmatter `description` は、モデルがどのスキルを発動するか決める唯一の入口情報である。監査で 3 つの実害パターンを確認した: (a) `/viewer-voice` は自分を「任意後続スキル」と名乗るが、`/audience-persona-design` は「/viewer-voice を必須入力に」と宣言しており**直接矛盾**、(b) 発動キーワード「競合分析」が `/benchmark`(データ収集)と `/channel-research`(収集済みデータの分析)の両方に登録されており、Sonnet 級モデルはどちらを呼ぶか判定できない、(c) `/videoup`(動画ファイル生成)と `/video-upload`(YouTube 投稿)は名前が酷似しているのに、互いを区別する否定トリガーがない。誤発動は前工程スキップや意図しない工程実行につながる。
+
+## Current state
+
+6 ファイルの frontmatter 3 行目(`description:`)のみが対象。現物(2026-07-05 時点、すべて実読で確認済み):
+
+- `.claude/skills/viewer-voice/SKILL.md:3`
+  `"Use when 競合コメントの収集・分析で視聴者インサイトを抽出するとき。「視聴者の声」「コメント分析」「ユーザーリサーチ」で発動。/audience-persona-design らの前提データを作る任意後続スキル"`
+- `.claude/skills/audience-persona-design/SKILL.md:3`
+  `"Use when ターゲット視聴者を第一ペルソナとして設計・見直しするとき。「ペルソナ設定」「視聴者像」「ターゲット層」で発動。/viewer-voice を必須入力に persona-definition.md を確定"`
+- `.claude/skills/benchmark/SKILL.md:3`
+  `"Use when 競合チャンネルのベンチマークデータを最新化するとき。「競合分析」「ベンチマーク更新」で発動。docs/benchmarks/*.md を更新"`
+- `.claude/skills/channel-research/SKILL.md:3`
+  `"Use when /benchmark と /viewer-voice の TTP ベンチマークデータを徹底分析するとき。「競合分析」「チャンネルリサーチ」「TTP 対象抽出」で発動"`
+- `.claude/skills/videoup/SKILL.md:3`
+  `"Use when 音声ファイルが揃い動画生成が必要なとき。「動画変換」「MP3→MP4」「generate_videos」「videoup」で発動。マスター音源・マスター動画生成を案内"`
+- `.claude/skills/video-upload/SKILL.md:3`
+  `"Use when コレクションの動画が完成し、YouTubeへのアップロード自動化が必要なとき。Complete Collection のアップロードと live 移行を実行"`
+
+規約: description は **double-quoted string 必須**(値内の `: ` が strict YAML でマッピング区切りと誤解釈されるため。`CLAUDE.md`「### skill frontmatter」)。`tests/test_skill_frontmatter_yaml.py` が YAML 妥当性を機械検証している。
+
+事実確認済みの依存関係(書き換え内容の根拠):
+- `/viewer-voice` の出力は `/audience-persona-design` の必須入力である(audience-persona-design 側が「必須入力」と宣言、Phase 1 で `docs/plans/viewer-voice-analysis.md` を要求)。「任意」なのは「/benchmark の後に必ず実行しなくてもよい」という意味で、ペルソナ設計に対しては必須。
+- `/benchmark` は YouTube API でデータ**収集**(`docs/benchmarks/*.md` 更新)、`/channel-research` は収集済みデータの**分析専用**(`channel-research/SKILL.md:11-15` に「前提: /benchmark と /viewer-voice を実行済み」と明記)。
+- `/videoup` はローカルで MP3→MP4 の動画ファイルを生成、`/video-upload` は完成した動画を YouTube へアップロードし `planning/ → live/` 移行。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| frontmatter YAML 検証 | `uv run pytest tests/test_skill_frontmatter_yaml.py -q` | exit 0 |
+| スキル docs 整合 | `uv run pytest tests/test_skill_docs_consistency.py -q` | exit 0 |
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- 上記 6 ファイルの frontmatter `description:` 行(本文は原則触らない。Step 1 の viewer-voice のみ本文中の同表現があれば合わせる)
+- `CHANGELOG.md`(`[Unreleased]` への追記)
+
+**Out of scope**:
+- 他 41 スキルの description — 発動キーワードの網羅的再設計はしない(規約 005 が新規作成時に効く)。
+- `yt-skills sync` 関連コード、スキル本文の手順。
+- `/discover-competitors` の description(「競合候補」「競合発掘」で既に区別されている)。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(skills): 兄弟スキル間の frontmatter 矛盾と発動キーワード衝突を解消`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: viewer-voice ↔ audience-persona-design の矛盾を解消する
+
+`viewer-voice/SKILL.md:3` の description 末尾「/audience-persona-design らの前提データを作る任意後続スキル」を、依存を一義化した表現に置き換える:
+
+```
+/audience-persona-design の必須入力（viewer-voice-analysis.md）を作る前工程。実行タイミングは任意
+```
+
+(「必須入力を作る」と「実行タイミングは任意」を分離することで矛盾を解く。)
+本文(`viewer-voice/SKILL.md` 内)に「任意後続スキル」という同表現があれば同様に直す: `rg -n '任意後続' .claude/skills/viewer-voice/SKILL.md` で検索。
+
+**Verify**: `rg -n '必須入力' .claude/skills/viewer-voice/SKILL.md` → frontmatter でヒット。`rg -n '任意後続スキル' .claude/skills/viewer-voice/SKILL.md` → 0 件。
+
+### Step 2: 「競合分析」キーワードの衝突を解消する
+
+- `benchmark/SKILL.md:3`: 「競合分析」を「競合データ収集」に置き換え、末尾に否定トリガーを追加:
+  `"Use when 競合チャンネルのベンチマークデータを最新化するとき。「競合データ収集」「ベンチマーク更新」で発動。docs/benchmarks/*.md を更新。収集済みデータの分析は /channel-research"`
+- `channel-research/SKILL.md:3`: 末尾に前提とデータ収集の区別を追加:
+  `"Use when /benchmark と /viewer-voice の TTP ベンチマークデータを徹底分析するとき。「競合分析」「チャンネルリサーチ」「TTP 対象抽出」で発動。データ収集・更新は /benchmark（未実行なら先に案内）"`
+
+(「競合分析」は分析側の channel-research だけに残す。)
+
+**Verify**: `rg -l '「競合分析」' .claude/skills/*/SKILL.md` → `channel-research` のみ。`rg -n '競合データ収集' .claude/skills/benchmark/SKILL.md` → 1 件。
+
+### Step 3: videoup / video-upload の相互否定トリガーを追加する
+
+- `videoup/SKILL.md:3` 末尾に追加: `。YouTube への投稿は /video-upload（本スキルはローカルで動画ファイルを生成するのみ）`
+- `video-upload/SKILL.md:3` 末尾に追加: `。「アップロード」「公開して」で発動。動画ファイルの生成（MP3→MP4）は /videoup`
+
+**Verify**: `rg -n 'video-upload' .claude/skills/videoup/SKILL.md | head -3` → frontmatter 行にヒット。`rg -n '/videoup' .claude/skills/video-upload/SKILL.md | head -3` → frontmatter 行にヒット。
+
+### Step 4: YAML 妥当性と double-quote を確認する
+
+6 ファイルすべてで description が 1 行の double-quoted string のままであること。
+
+**Verify**: `uv run pytest tests/test_skill_frontmatter_yaml.py -q` → exit 0。
+
+### Step 5: CHANGELOG に追記する
+
+```
+- skills frontmatter: viewer-voice/audience-persona-design の依存表現矛盾、benchmark/channel-research の「競合分析」衝突、videoup/video-upload の相互否定トリガー欠如を解消
+```
+
+**Verify**: `rg -n 'skills frontmatter' CHANGELOG.md` → 1 件。
+
+### Step 6: テスト全体を確認する
+
+**Verify**: `uv run pytest tests -q --ignore=tests/integration` → exit 0。`tests/test_skill_docs_consistency.py` が description 文言を assert していて fail した場合は期待値を新文言へ更新する(コミットに明記)。
+
+## Test plan
+
+既存の `test_skill_frontmatter_yaml.py`(YAML 妥当性)と `test_skill_docs_consistency.py` を検証ゲートに使う。新規テストは不要。
+
+## Done criteria
+
+- [ ] 「任意後続スキル」表現が viewer-voice から消え、「必須入力を作る前工程」に置き換わっている
+- [ ] 「競合分析」キーワードを含む description が channel-research のみ
+- [ ] videoup / video-upload が互いを名指しで区別している
+- [ ] 6 ファイルとも description は double-quoted 1 行のまま
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 008 行を更新済み
+
+## STOP conditions
+
+- 6 ファイルの description 現物が Current state の引用と一致しない(drift)。
+- `tests/test_skills_rename.py` など、description の文言に依存するテストが期待値更新だけでは直らない形で fail する。
+- description の変更が `yt-skills sync` の差分検出以外の機構(例: docs 自動生成)に影響することが判明した場合。
+
+## Maintenance notes
+
+- 下流リポジトリへは次回リリース後の `yt-skills sync` で伝播する。sync 前後で差分が出るのは意図どおり。
+- 発動キーワードの重複検出は現状人力。`test_skill_docs_consistency.py` の系譜で「同一鉤括弧キーワードが複数スキルの description に現れたら fail」という機械チェックを追加できる(follow-up、この plan では見送り)。
+- レビュー観点: description が 1 行で読み切れる長さに収まっているか(長すぎる description は skill 一覧表示で切り捨てられる)。

--- a/plans/009-prerequisite-guards.md
+++ b/plans/009-prerequisite-guards.md
@@ -1,0 +1,150 @@
+# Plan 009: 工程チェーンの前提条件ガードを 4 スキルに追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/channel-setup/SKILL.md .claude/skills/channel-research/SKILL.md .claude/skills/audience-persona-design/SKILL.md .claude/skills/channel-direction/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S-M
+- **Risk**: LOW
+- **Depends on**: plans/005-skill-authoring-standard.md(ルール 3「前提ガードの標準型」。005 未完了でも実行可能)
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+チャンネル戦略系スキルは `/channel-direction → /channel-setup`、`/benchmark → /channel-research`、`/viewing-scene → /audience-persona-design Phase 6` という工程チェーンを成すが、後工程スキルの手順に「前工程の出力が存在するか」の入口ガードがない箇所が 4 つある。Sonnet 級モデルは前提を暗黙に信じて手順を実行し、`FileNotFoundError` や空データでの続行(最悪、欠損データのまま成果物を確定)に至る。各箇所に「存在確認 → なければ前工程を案内して停止」の 1〜3 行を追加する。ガードは軽微だが、失敗が「後工程の途中」ではなく「入口」で起きるようになり、復旧手順が一義化される。
+
+## Current state
+
+対象 4 箇所(すべて実読で確認済み):
+
+1. `.claude/skills/channel-setup/SKILL.md:34-52` — 「#### Step 2.1: 競合 TTP 面のスナップショット取得（必須）」。`uv run python3 -c "... YouTubeOAuthHandler().get_youtube_service() ..."` の inline Python を提示するが、直前に `auth/token.json` / `auth/client_secrets.json` の存在確認がない。OAuth 未設定だと実行時例外で落ちる。
+2. `.claude/skills/channel-setup/SKILL.md:114-127` — 「### Step 3.5: config/skills/*.yaml への転記」。`docs/channel/channel-direction.md` の決定を転記すると書かれているが、同ファイルの存在確認ステップがない。`/channel-direction` 未実行のまま到達すると転記元がない。
+3. `.claude/skills/channel-research/SKILL.md:11-15` — Overview に「**前提**: /benchmark と /viewer-voice を実行済みで、以下のデータが存在すること」とデータ一覧(`data/benchmark_YYYYMMDD.json` 等)は**記載済み**。ただし手順(Step 1)側に存在確認コマンドと「なければ停止」の指示がない。前提は書いてあるが実行時に照合されない形。
+4. `.claude/skills/audience-persona-design/SKILL.md:119-131` — 「### Phase 5: viewing-scene 検証」は `/viewing-scene` が `docs/plans/viewing-scene-matrix.md` を生成する前提で Phase 6(最終確定)へ進む。`/viewing-scene` が実行されなかった/失敗した場合のガードがなく、Phase 6 が暫定ペルソナを最終版として確定しうる。
+
+参考(良い先例、変更しない): `.claude/skills/channel-new/SKILL.md:110`「以下の check が `ok` でない場合は、ここで `/setup` を案内して停止する。」
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| frontmatter 検証 | `uv run pytest tests/test_skill_frontmatter_yaml.py -q` | exit 0 |
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/channel-setup/SKILL.md`(Step 2.1 冒頭と Step 3.5 冒頭)
+- `.claude/skills/channel-research/SKILL.md`(最初の実行 Step の冒頭)
+- `.claude/skills/audience-persona-design/SKILL.md`(Phase 5 → Phase 6 の間)
+- `CHANGELOG.md`(`[Unreleased]` への追記)
+
+**Out of scope**:
+- `/channel-direction` 側の変更(引き継ぎ表は既に十分明示的: `channel-direction/SKILL.md:99-115`)。
+- `/wf-*` 系スキル(collection-ideate が既に存在チェックの記述を持つ)。
+- inline Python 自体の書き換え(コード内容は正しい。ガードを前置するだけ)。
+- CLI / src 側の変更。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(skills): channel-setup / channel-research / audience-persona-design に前提ガードを追加`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: channel-setup Step 2.1 に認証ガードを追加する
+
+「#### Step 2.1」見出しの直後・inline Python の前に追加:
+
+```markdown
+実行前に認証ファイルの存在を確認する。ない場合は `/setup` を案内して停止する（このまま下のコードを実行すると認証エラーで失敗する）:
+
+​```bash
+ls auth/token.json auth/client_secrets.json
+​```
+```
+
+**Verify**: `rg -n 'ls auth/token.json' .claude/skills/channel-setup/SKILL.md` → 1 件、Step 2.1 セクション内にある。
+
+### Step 2: channel-setup Step 3.5 に転記元ガードを追加する
+
+「### Step 3.5」見出しの直後に追加:
+
+```markdown
+転記元 `docs/channel/channel-direction.md` が存在することを確認する。ない場合は `/channel-direction` を先に実行するようユーザーに案内して停止する（順序: `/channel-direction` → `/channel-setup` Step 3.5 固定）。
+```
+
+**Verify**: `rg -n 'channel-direction を先に実行' .claude/skills/channel-setup/SKILL.md` → 1 件。
+
+### Step 3: channel-research の最初の Step に存在確認を追加する
+
+`.claude/skills/channel-research/SKILL.md` の最初の実行ステップ(Overview の後、最初の `## Instructions` / Step 見出しを実読して特定)の冒頭に追加:
+
+```markdown
+### Step 0: 前提データの存在確認
+
+​```bash
+ls data/benchmark_*.json data/comments_*.json docs/benchmarks/*.md
+​```
+
+1 つでも欠けている場合は分析に入らない。`data/benchmark_*.json` / `docs/benchmarks/*.md` がなければ `/benchmark` を、`data/comments_*.json` がなければ `/viewer-voice` を案内して停止する。
+```
+
+既存の Step 番号とぶつかる場合は「Step 0」とし、既存番号は変えない。
+
+**Verify**: `rg -n 'Step 0: 前提データの存在確認' .claude/skills/channel-research/SKILL.md` → 1 件。
+
+### Step 4: audience-persona-design の Phase 6 入口にガードを追加する
+
+「### Phase 6: 最終 persona-definition.md 更新」見出しの直後に追加:
+
+```markdown
+`docs/plans/viewing-scene-matrix.md` が存在しない場合、Phase 6 に進んではならない。`/viewing-scene` の実行（Phase 5）に戻るか、ユーザーが viewing-scene 検証をスキップすると明示した場合のみ、persona-definition.md に「viewing-scene 未検証」と注記した上で確定する。
+```
+
+**Verify**: `rg -n 'viewing-scene-matrix.md が存在しない場合' .claude/skills/audience-persona-design/SKILL.md` → 1 件。
+
+### Step 5: CHANGELOG に追記する
+
+```
+- channel-setup / channel-research / audience-persona-design: 前工程出力（auth token / channel-direction.md / benchmark データ / viewing-scene-matrix.md）の存在ガードを追加
+```
+
+**Verify**: `rg -n '存在ガードを追加' CHANGELOG.md` → 1 件。
+
+### Step 6: テスト確認
+
+**Verify**: `uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テスト不要(SKILL.md の手順文追加)。既存ユニットスイート green を確認。`test_skill_docs_consistency.py` が fail した場合は期待値更新で対応(コミットに明記)。
+
+## Done criteria
+
+- [ ] 4 箇所すべてに「存在確認 → なければ前工程案内で停止」のガードが入っている
+- [ ] 既存の Step 番号・見出し構造を壊していない(`rg -n '^### ' <file>` で前後比較)
+- [ ] `CHANGELOG.md` 追記済み
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `plans/README.md` の 009 行を更新済み
+
+## STOP conditions
+
+- 対象 4 箇所の現物が Current state の記述と一致しない(drift)。
+- 該当箇所に既に同等のガードが存在する(先行修正済み)— 重複追加せず該当 Step をスキップし、README にその旨を書く。
+- channel-research に `## Instructions` に相当する実行手順セクションが見つからない(構造が想定と違う)。
+
+## Maintenance notes
+
+- ガードのパス(`docs/plans/viewing-scene-matrix.md` 等)は各スキルの出力先変更と連動する。出力パスを変える PR ではガード側の追従をレビューで確認。
+- `/viewing-scene` 側に「出力完了を workflow 側へ通知する」仕組みはない(ファイル存在が唯一のシグナル)。将来状態ファイルに寄せる場合はガードも書き換える。

--- a/plans/010-channel-new-midflow-gate.md
+++ b/plans/010-channel-new-midflow-gate.md
@@ -1,0 +1,103 @@
+# Plan 010: channel-new のペルソナ生成前に TTP 対象の中間ゲートを追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/channel-new/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+**スコープ注記(監査からの縮小)**: 当初の監査 finding は「channel-new(537 行)は完了条件が埋没し、Step 3 のチェックが混在」と主張したが、plan 作成時の実読で大半は既に解決済みと判明した — TTP 完了条件は冒頭近く(48-60 行)にあり、Step 3 は「停止すべき 17 チェック」と「許容する 4 fail(理由文字列付き)」を明確に分離している(110-140 行)。残る実ギャップは 1 点のみ: **最終ゲート(Step 9、396-404 行)まで TTP 対象 0 件が検出されない**こと。途中の Step(ペルソナ生成など)は `benchmark.channels` が空でも進行でき、Sonnet 級モデルは空のまま後続成果物を作ってから Step 9 で差し戻される。無駄な生成(AI コスト)と手戻りを、ペルソナ生成直前の 2 行のゲートで防ぐ。
+
+## Current state
+
+- `.claude/skills/channel-new/SKILL.md`(537 行)— 対象ファイル。
+  - 48-60 行: 「### TTP 完了条件（新規開設モード）」— `config/channel/analytics.json::benchmark.channels` に承認済み TTP 対象 1 件以上、など 6 条件。**既に冒頭にある。変更不要。**
+  - 110-140 行: Step 3 の yt-doctor チェック分離。**変更不要。**
+  - 396-404 行: Step 9 の最終ゲート「承認済み TTP 対象が 0 件の場合は `/wf-new` 接続へ進まず、Step 1/5 に戻って候補を再確認するか、ユーザーに停止を確認して終了する。」— 唯一の 0 件検出点。
+  - ペルソナ生成の Step(Step 7 前後。実読して正確な見出しを特定すること)— `benchmark.channels` への依存があるが入口ガードなし。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/channel-new/SKILL.md`(ペルソナ生成 Step の冒頭に 2〜4 行追加のみ)
+- `CHANGELOG.md`(`[Unreleased]` への追記)
+
+**Out of scope**:
+- TTP 完了条件セクション・Step 3・Step 9 の既存文言(すでに良い状態。再構成しない)。
+- 取り込みモード(既存チャンネル取り込み)側の手順 — TTP 完了条件の適用外と明記されている(52 行)。
+- SKILL.md の分割・短縮などの構造改革。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(channel-new): ペルソナ生成前に TTP 対象 0 件の中間ゲートを追加`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: ペルソナ生成 Step を特定する
+
+`rg -n '^### ' .claude/skills/channel-new/SKILL.md` で Step 見出し一覧を出し、ペルソナ(persona)生成を行う Step を特定する(Step 7 近辺の想定)。
+
+**Verify**: 見出し一覧にペルソナ生成に該当する Step がある。なければ STOP。
+
+### Step 2: 中間ゲートを追加する
+
+特定した Step の見出し直後に追加:
+
+```markdown
+**入口ゲート**: `config/channel/analytics.json::benchmark.channels` に承認済み TTP 対象が 1 件以上あることを確認する。0 件の場合は本 Step 以降に進まず、Step 5 に戻って TTP 候補の承認を完了させる（冒頭「TTP 完了条件」参照）。0 件のままペルソナを生成すると Step 9 の最終ゲートで差し戻しになり、生成コストが無駄になる。
+```
+
+**Verify**: `rg -n '入口ゲート' .claude/skills/channel-new/SKILL.md` → 1 件、ペルソナ生成 Step 内。
+
+### Step 3: CHANGELOG 追記とテスト
+
+`CHANGELOG.md` の `[Unreleased]`:
+
+```
+- channel-new: ペルソナ生成前に TTP 対象 0 件を検出する中間ゲートを追加（最終ゲートまで気づかない手戻りを防止）
+```
+
+**Verify**: `rg -n '中間ゲート' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テスト不要。既存ユニットスイート green を確認。
+
+## Done criteria
+
+- [ ] ペルソナ生成 Step の冒頭に TTP 対象 0 件ゲートがある
+- [ ] 既存の TTP 完了条件・Step 3・Step 9 は無変更(`git diff` で該当行に差分がない)
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 010 行を更新済み
+
+## STOP conditions
+
+- ペルソナ生成 Step が特定できない、または既に同等の入口ゲートが存在する。
+- ペルソナ生成が `benchmark.channels` に依存しない構造に変わっている(ゲートの前提が崩れている)。
+
+## Maintenance notes
+
+- `/channel-new` は最近「取り込みモード統合」(#1460)で大きく改稿された。今後の改稿でもこのゲートが Step 9 の最終ゲートと二重管理にならないよう、文言は「冒頭 TTP 完了条件への参照」に留めてある(条件本体をコピーしない — 単一ソース原則)。
+- 監査 finding の残り(「537 行で長い」)は plan 化を見送り: 現構造は参照関係が明示されており、分割はリスクの割に益が薄い。

--- a/plans/011-live-clean-approval-format.md
+++ b/plans/011-live-clean-approval-format.md
@@ -1,0 +1,100 @@
+# Plan 011: live-clean の削除承認を明示的選択肢 + 取消不可警告の形式に固定する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/live-clean/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(ドキュメントのみ。対象は不可逆なファイル削除の防護柵)
+- **Depends on**: plans/005-skill-authoring-standard.md(ルール 2。005 未完了でも実行可能)
+- **Category**: docs(実質は安全性)
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/live-clean` は `collections/live/` 配下の大容量メディア(監査時の例では 1 実行あたり数 GB〜15GB)を `rm -f` で削除するスキル。承認ゲート自体は存在する(「AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない」)が、**承認の形式が未指定**のため、Sonnet 級モデルは自由文で確認を出し、ユーザーの曖昧な返答(「OK」「いいよ」が別の質問への返答である場合など)を承認と誤認する余地がある。選択肢の文言・取消不可警告・削除対象サマリーの提示内容を SKILL.md で固定し、解釈の幅を消す。
+
+## Current state
+
+- `.claude/skills/live-clean/SKILL.md`(131 行)— 対象ファイル。
+  - 84 行目(Step 3 末尾): 「表示後、AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない。」— ゲートは在るが選択肢・警告の形式指定なし。
+  - 86 行目〜: 「### Step 4: 削除実行」「ユーザーが承認した場合のみ、ファイル単位で `rm -f` を実行する。」— `rm -f "collections/live/<dir>/01-master/master.mp3"` 等の具体コマンドが続く。
+  - Step 3 では削除対象のドライラン表示(コレクション別のファイル数と GB、「削除対象: N コレクション / M ファイル / X.X GB」のサマリー)が既に定義されている(75-82 行)。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/live-clean/SKILL.md`(Step 3 末尾の承認文 1 段落の置き換えのみ)
+- `CHANGELOG.md`(`[Unreleased]` への追記)
+
+**Out of scope**:
+- Step 1-2(安全 3 条件・対象検出)と Step 4 の `rm -f` コマンド群 — 変更しない。
+- 削除対象の選定ロジック・安全条件そのもの。
+- 他スキルへの同型適用(comments-reply / pinned-comment は plans/006)。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(live-clean): 削除承認を明示的選択肢と取消不可警告の形式に固定`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 承認文を形式指定付きに置き換える
+
+`.claude/skills/live-clean/SKILL.md:84` の「表示後、AskUserQuestion でユーザーに確認を取る。承認されるまで絶対に削除を実行しない。」を以下で置き換える:
+
+```markdown
+表示後、AskUserQuestion で以下の形式の確認を取る。**承認されるまで絶対に削除を実行しない**:
+
+- 質問文: 「上記 N コレクション / M ファイル / X.X GB を削除しますか？**削除は取り消せません**（`rm -f` による物理削除）」
+- 選択肢: 「削除を実行する」/「キャンセル」の 2 択。デフォルトを実行側にしない
+- 「削除を実行する」が明示的に選ばれた場合のみ Step 4 へ進む。それ以外の応答（自由文・別話題・無回答）はすべてキャンセルとして扱う
+- AskUserQuestion が使えない環境（Codex 等）では同内容をテキスト提示し、ユーザーが「削除を実行する」と明示するまで待つ
+```
+
+**Verify**: `rg -n '削除は取り消せません' .claude/skills/live-clean/SKILL.md` → 1 件。`rg -n 'キャンセルとして扱う' .claude/skills/live-clean/SKILL.md` → 1 件。
+
+### Step 2: CHANGELOG 追記とテスト
+
+`CHANGELOG.md` の `[Unreleased]`:
+
+```
+- live-clean: 削除承認を明示的 2 択（実行/キャンセル）+ 取消不可警告の形式に固定（曖昧応答の承認誤認を防止）
+```
+
+**Verify**: `rg -n 'live-clean: 削除承認' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テスト不要。既存ユニットスイート green を確認。
+
+## Done criteria
+
+- [ ] 承認の質問文・2 択・取消不可警告・曖昧応答の扱いが SKILL.md に明文化されている
+- [ ] Step 4 の実行条件が「『削除を実行する』が明示的に選ばれた場合のみ」と一致している
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 011 行を更新済み
+
+## STOP conditions
+
+- 84 行付近の承認文が Current state の引用と一致しない(先行変更)。既に選択肢形式が指定済みなら重複追加せず STOP して報告。
+
+## Maintenance notes
+
+- plans/006 と合わせて「外部反映・破壊的操作の承認ゲート標準型」(規約 005 ルール 2)の実装例が 3 スキル分揃う。以降の新スキルはこの 3 つを exemplar にする。
+- レビュー観点: 質問文に実数(N/M/X.X)を埋める指示になっているか — 数字なしの抽象的確認は承認の質を下げる。

--- a/plans/012-freshness-single-source.md
+++ b/plans/012-freshness-single-source.md
@@ -1,0 +1,117 @@
+# Plan 012: stale/freshness 判定の記述を freshness-rules.md へ単一ソース化する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/collection-ideate/ .claude/skills/wf-new/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none(plans/005 のルール 5「単一ソース原則」の実装例)
+- **Category**: tech-debt(ドキュメント重複)
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+analytics レポートの stale 判定(相対比較 OR 絶対鮮度)が、`/collection-ideate` と `/wf-new` の 2 つの SKILL.md に**別々の散文**で書かれている。参照先として `.claude/skills/collection-ideate/references/freshness-rules.md` が既に存在するのに、両 SKILL.md が判定ロジック本体を本文に重複記述しているため、(a) 片方だけ更新されて食い違う(実際、文言は既に微妙に異なる)、(b) Sonnet 級モデルが 2 つの記述を別ルールと解釈して判定がブレる、というリスクがある。判定ロジックの正本を freshness-rules.md に置き、両 SKILL.md は「要約 1 行 + 参照」に縮約する。
+
+## Current state
+
+- `.claude/skills/collection-ideate/references/freshness-rules.md` — 既存の参照先ファイル(正本にする対象)。現在の内容を実読し、判定ロジックの完全な定義(下記 2 箇所の記述の和集合)を含むか確認すること。
+- `.claude/skills/collection-ideate/SKILL.md:58` — 判定ロジックの記述 1:
+  「`reports/analysis_*.md` が存在するが stale → fallback せず中断。stale 判定は相対比較（最新 `data/analytics_data_*.json` より古い）と絶対鮮度（収集データ自体が実行日から `freshness_days`（既定 7 日、`config/skills/collection-ideate.yaml` で上書き可）を超えて経過）の OR（#1427）。ユーザーに `/analytics-analyze` 再実行を案内（必要なら `/analytics-collect` 先行。絶対鮮度 stale では収集データ自体が古いため `/analytics-collect` → `/analytics-analyze` の順で必須）。**自動呼び出し不可**（AI 推論コスト発生のため）」
+- `.claude/skills/wf-new/SKILL.md:77` — 判定ロジックの記述 2(同ロジックの別文面):
+  「stale 判定は相対比較（最新 `data/analytics_data_*.json` より古い）と絶対鮮度（収集データ自体が実行日から `freshness_days` を超えて経過。この場合 `/analytics-collect` を先行案内）の OR。絶対鮮度では `/collection-ideate` と同じく `.claude/skills/collection-ideate/config.default.yaml` + `config/skills/collection-ideate.yaml` を deep-merge した解決済み `freshness_days`（既定 7 日）を使う — 詳細は `/collection-ideate` の `references/freshness-rules.md` を参照。」
+
+差異の例: collection-ideate 側のみ「#1427」「自動呼び出し不可」を持ち、wf-new 側のみ「deep-merge した解決済み freshness_days」の説明を持つ。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+| wf-new 契約テスト | `uv run pytest tests/test_wf_new_analytics_fallback_skill_contract.py -q` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/collection-ideate/references/freshness-rules.md`(正本化 — 必要な定義を集約)
+- `.claude/skills/collection-ideate/SKILL.md`(該当段落の縮約)
+- `.claude/skills/wf-new/SKILL.md`(該当段落の縮約)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- 判定ロジックの**内容変更**(相対 OR 絶対、既定 7 日などの規則自体は一切変えない。記述の置き場所を変えるだけ)。
+- `/analytics-analyze` / `/analytics-collect` 側の記述。
+- `config.default.yaml` の値。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(skills): stale 判定ロジックを freshness-rules.md へ単一ソース化`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: freshness-rules.md を正本化する
+
+`freshness-rules.md` を実読し、上記 2 箇所の記述の**和集合**(相対比較の定義 / 絶対鮮度の定義と `freshness_days` の解決手順(deep-merge)/ OR 判定 / stale 時の案内順序(`/analytics-collect` → `/analytics-analyze`)/ 自動呼び出し不可の理由 / #1427 参照)がすべて含まれるよう追記する。既に全部あるなら変更不要。
+
+**Verify**: `rg -n 'deep-merge|自動呼び出し不可|相対比較' .claude/skills/collection-ideate/references/freshness-rules.md` → 3 概念すべてヒット。
+
+### Step 2: collection-ideate 側を縮約する
+
+`collection-ideate/SKILL.md:58` の該当箇条書きを以下に置き換える(挙動指示は残し、ロジック定義を参照化):
+
+```markdown
+- `reports/analysis_*.md` が存在するが stale → fallback せず中断し、`/analytics-analyze` 再実行を案内（絶対鮮度 stale の場合は `/analytics-collect` → `/analytics-analyze` の順で必須）。**自動呼び出し不可**（AI 推論コスト発生のため）。stale 判定の定義（相対比較 OR 絶対鮮度、`freshness_days` の解決手順）は `references/freshness-rules.md` を正とする
+```
+
+**Verify**: `rg -n 'freshness-rules.md を正とする' .claude/skills/collection-ideate/SKILL.md` → 1 件。
+
+### Step 3: wf-new 側を縮約する
+
+`wf-new/SKILL.md:77` の stale 判定説明文を以下に置き換える:
+
+```markdown
+`reports/analysis_*.md` が存在するが stale の場合は fallback せず、`/analytics-analyze` 再実行を案内して中断する（古い分析と別入力の混在を避けるため）。stale 判定の定義は `/collection-ideate` の `references/freshness-rules.md` を正とする（相対比較 OR 絶対鮮度、既定 7 日）。
+```
+
+**Verify**: `rg -n 'freshness-rules.md を正とする' .claude/skills/wf-new/SKILL.md` → 1 件。かつ `rg -n 'deep-merge した解決済み' .claude/skills/wf-new/SKILL.md` → 0 件(重複記述が消えている)。
+
+### Step 4: CHANGELOG 追記とテスト
+
+```
+- collection-ideate / wf-new: stale 判定ロジックの重複記述を references/freshness-rules.md へ単一ソース化（判定規則の変更なし）
+```
+
+**Verify**: `rg -n '単一ソース化' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0(特に `test_wf_new_analytics_fallback_skill_contract.py`)。
+
+## Test plan
+
+`tests/test_wf_new_analytics_fallback_skill_contract.py` が wf-new の fallback 記述を契約として検証している。縮約後も pass することが必須。fail した場合、**テストが要求する文言を freshness-rules.md ではなく wf-new 本文に残す方向で調整**する(契約テストが正)。
+
+## Done criteria
+
+- [ ] freshness-rules.md に判定ロジックの完全な定義がある
+- [ ] 両 SKILL.md の本文からロジック本体の重複記述が消え、「〜を正とする」参照になっている
+- [ ] 判定規則の内容(相対 OR 絶対、7 日、案内順序)がどこにも変わっていない
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `CHANGELOG.md` 追記済み、`plans/README.md` の 012 行を更新済み
+
+## STOP conditions
+
+- freshness-rules.md の既存内容が 2 つの SKILL.md の記述と**矛盾**している(単なる欠落ではなく食い違い)— どれが正か判断できないため STOP して報告。
+- `test_wf_new_analytics_fallback_skill_contract.py` が文言調整で解決できない形で fail する。
+
+## Maintenance notes
+
+- 以降、stale 判定の規則変更(日数・順序)は freshness-rules.md の 1 箇所だけを編集すればよい。SKILL.md 側に規則本体を書き戻さないこと(レビュー観点)。
+- `/wf-next` にも鮮度関連の記述があれば同様の縮約候補(今回スコープ外、実読で確認した範囲では重複はこの 2 箇所)。

--- a/plans/013-suno-mode-decision-tree.md
+++ b/plans/013-suno-mode-decision-tree.md
@@ -1,0 +1,112 @@
+# Plan 013: suno のボーカル/インスト モード判定を decision tree 化する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/suno/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/suno` のモード判定(ボーカル/インストゥルメンタル)は後続工程すべてを分岐させる(歌詞生成の要否、Suno UI の Instrumental ON/OFF、YAML 構造)。現状の判定規則は「`genre_line` にボーカル要素(`vocals`, `vocal`, `singing`, `rap`, `male/female vocals` 等)が含まれていれば」というキーワードスキャン 1 本で、(a)「等」の範囲が不定、(b) 否定文脈(`no vocals`, `without vocals`)の扱いが未定義、(c) 判定に迷った場合の手順がない。Sonnet 級モデルが誤判定すると、インスト予定のコレクションに歌詞工程が走る(またはその逆)という高コストな手戻りになる。判定を決定木 + 迷ったら確認、の形に置き換える。
+
+## Current state
+
+- `.claude/skills/suno/SKILL.md:22-24` — 「### モード判定」セクション。現物:
+
+```markdown
+### モード判定
+
+`config/skills/suno.yaml` の `genre_line` を読み取り、**ボーカル要素**（`vocals`, `vocal`, `singing`, `rap`, `male/female vocals` 等）が含まれていれば**ボーカルモード**、なければ**インストゥルメンタルモード**として処理する。
+```
+
+- 直後(24 行目〜)にモード別の対応表(YAML 構造 / 歌詞 / Suno 設定)がある。表は変更不要。
+- `tests/test_suno_skill_doc.py` — suno SKILL.md の記述を契約検証するテストが存在する。変更後に必ず実行すること。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| suno 契約テスト | `uv run pytest tests/test_suno_skill_doc.py -q` | exit 0 |
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/suno/SKILL.md`(「### モード判定」セクションのみ)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- モード別対応表・パターン設計・後続 Step の記述。
+- `yt-generate-suno` CLI の実装(コード側の判定ロジックがあるならそれは触らない)。
+- `/suno-lyric` / `/lyria` 側の記述。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(suno): モード判定を decision tree 化し否定文脈と迷った場合の手順を明記`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: モード判定セクションを置き換える
+
+「### モード判定」の本文段落を以下で置き換える(直後の対応表は保持):
+
+```markdown
+`config/skills/suno.yaml` の `genre_line` を読み、次の順で判定する:
+
+1. **否定表現が先**: `instrumental`, `no vocals`, `without vocals`, `vocal-free` のいずれかを含む → **インストゥルメンタルモード**（他の語より優先）
+2. **ボーカル語の完全一致**: 単語として `vocals` / `vocal` / `singing` / `singer` / `rap` / `choir` / `humming` のいずれか、または `male vocals` / `female vocals` を含む → **ボーカルモード**
+3. どちらにも該当しない → **インストゥルメンタルモード**
+4. **判定に確信が持てない場合**（例: `vocal chops` のような素材系表現、上記リスト外の歌唱系の語）: 推測で進めず、genre_line の該当箇所を提示して AskUserQuestion でユーザーにモードを確認する
+
+このリストは網羅ではない。リスト外の語で歌唱を意図している可能性があるときは必ず 4 に落とす。
+```
+
+**Verify**: `rg -n '否定表現が先' .claude/skills/suno/SKILL.md` → 1 件。`rg -n '確信が持てない場合' .claude/skills/suno/SKILL.md` → 1 件。
+
+### Step 2: 契約テストと全体テスト
+
+**Verify**: `uv run pytest tests/test_suno_skill_doc.py -q` → exit 0。fail した場合はテストが旧文言を assert していないか確認し、期待値を新文言へ更新(コミットに明記)。その後 `uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+### Step 3: CHANGELOG 追記
+
+```
+- suno: モード判定をキーワードスキャン単独から decision tree（否定表現優先 → 完全一致 → 不明時はユーザー確認）に明確化
+```
+
+**Verify**: `rg -n 'decision tree' CHANGELOG.md` → 1 件。
+
+## Test plan
+
+`tests/test_suno_skill_doc.py` を主ゲートに使う。新規テストは不要(判定はモデルが実行する手順であり、コードではない)。
+
+## Done criteria
+
+- [ ] モード判定が 4 段の決定木 + 「迷ったら確認」の形になっている
+- [ ] 直後のモード別対応表が無変更
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `CHANGELOG.md` 追記済み、`plans/README.md` の 013 行を更新済み
+
+## STOP conditions
+
+- 「### モード判定」セクションが Current state の引用と一致しない。
+- `yt-generate-suno` のコード側に別のモード判定実装が見つかり、SKILL.md の決定木と矛盾する場合(`rg -n 'vocal|instrumental' src/youtube_automation/scripts/generate_suno*.py` で確認)— どちらが正か判断せず STOP して報告。
+
+## Maintenance notes
+
+- ボーカル語リストを増やす場合はこの決定木の 1・2 項だけを編集する。「等」に戻さないこと(レビュー観点)。
+- チャンネル側で判定を固定したいニーズが出たら、`config/skills/suno.yaml` に明示キー(`mode: vocal|instrumental`)を追加して決定木の 0 番目に置くのが正道(コード変更を伴うため別 plan)。

--- a/plans/014-partial-download-detection.md
+++ b/plans/014-partial-download-detection.md
@@ -1,0 +1,118 @@
+# Plan 014: suno-helper → masterup 間の部分ダウンロード検知手順を明文化する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/masterup/SKILL.md .claude/skills/suno-helper/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S(監査時は M 想定だったが、責務分離が既に明文化済みと確認できたため縮小)
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+**スコープ注記(監査からの縮小)**: 当初の finding は「DL 状態管理の責務が不明」と主張したが、実読の結果、責務分離は既に明文化されていた — `masterup/SKILL.md:10` が「DL は /suno-helper が primary path、本スキルの主責務はマスター音源生成 + workflow-state 更新」と宣言し、`suno-helper/SKILL.md:130-131` の完了確認に `workflow-state.json` の `planning.music.suno_playlist_url` と `assets.music_downloaded = true` が列挙されている。残る実ギャップは 1 点: **部分ダウンロード**(例: 10 曲中 5 曲で失敗)のとき、`assets.music_downloaded` の真偽と `02-Individual-music/` の実ファイル数が食い違う状態を masterup 側が検知する手順がないこと。Sonnet 級モデルは「フラグが true だから揃っている」と解釈し、欠けた曲数のままマスター音源を生成しうる(生成後に気づくと Suno クレジットと時間の手戻り)。期待曲数との突合チェックを masterup の入口に 1 つ追加する。
+
+## Current state
+
+- `.claude/skills/masterup/SKILL.md`(613 行)
+  - 10 行目: DL 責務分離の宣言(上記)。変更不要。
+  - Step 1(コレクション特定、148 行目付近に `collections/planning/` の `workflow-state.json` 検索)— この直後が追加位置の候補。Step 構成を実読して確定すること。
+  - 期待曲数の情報源: コレクションの `workflow-state.json` および `20-documentation/suno-prompts.json` の entry 数(インストは 1 Generate = 2 clip)。正確なキー名は `masterup/SKILL.md` 内の既存記述(`mp3_count` への言及が 114 行目にある)と `wf-new` が生成する workflow-state の構造を実読して確認する。
+- `.claude/skills/suno-helper/SKILL.md:130-131` — 完了確認リスト(`assets.music_downloaded` が true)。変更は任意(Step 3 参照)。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/masterup/SKILL.md`(入口チェックの追加 1 箇所)
+- `.claude/skills/suno-helper/SKILL.md`(完了確認への 1 項目追記のみ、任意)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- `assets.music_downloaded` フラグの仕様変更(bool のまま。曲数フィールド追加などのスキーマ変更はしない — 下流互換に関わるため別判断)。
+- masterup の Step 2-5(DL fallback・マスター生成)本体。
+- `yt-generate-master` 等の CLI 実装。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(masterup): 部分ダウンロード検知の入口チェックを追加`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 期待曲数の正確な情報源を特定する
+
+`masterup/SKILL.md` を実読し、(a) Step 構成、(b) 期待曲数が何で決まるか(`workflow-state.json` のキー / `suno-prompts.json` の entry 数×2 など)を確定する。`rg -n 'mp3_count|tracks_per_collection|曲数' .claude/skills/masterup/SKILL.md .claude/skills/suno/SKILL.md` が手がかり。
+
+**Verify**: 期待曲数の算出方法を 1 文で言える状態になっている(判断できなければ STOP)。
+
+### Step 2: masterup の入口に突合チェックを追加する
+
+コレクション特定 Step(Step 1)の完了直後に追加(文言は Step 1 の調査結果でキー名を正確にする):
+
+```markdown
+**DL 完全性チェック**: `02-Individual-music/` の mp3 実ファイル数を数え、期待曲数（<Step 1 で確定した情報源>）と突合する。
+
+- 一致 → 次の Step へ
+- 実ファイル数が少ない（部分ダウンロード）→ `assets.music_downloaded` が `true` でも揃っているとみなさない。不足曲数と該当 entry を提示し、/suno-helper の再実行（または Step 2-3 の手動 DL fallback）を案内して停止する
+- `02-Individual-music/` が空 → /suno-helper 未実行として案内して停止する
+```
+
+**Verify**: `rg -n 'DL 完全性チェック' .claude/skills/masterup/SKILL.md` → 1 件。
+
+### Step 3(任意): suno-helper の完了確認に注記を追加する
+
+`suno-helper/SKILL.md` の完了確認リスト(130-131 行付近)に 1 項目追記:
+
+```markdown
+7. `02-Individual-music/` の mp3 数が期待曲数と一致している（不足があれば `assets.music_downloaded` を true にしない）
+```
+
+既存リストの番号体系に合わせること。
+
+**Verify**: `rg -n '期待曲数と一致' .claude/skills/suno-helper/SKILL.md` → 1 件。
+
+### Step 4: CHANGELOG 追記とテスト
+
+```
+- masterup / suno-helper: 部分ダウンロード（期待曲数と実ファイル数の不一致）を masterup 入口で検知する手順を追加
+```
+
+**Verify**: `rg -n '部分ダウンロード' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テスト不要。既存ユニットスイート green を確認。
+
+## Done criteria
+
+- [ ] masterup の入口に「実ファイル数 vs 期待曲数」の突合と、不一致時の停止・案内がある
+- [ ] チェックの期待曲数の情報源が実在するキー/ファイルを指している(Step 1 で確認済みのもの)
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 014 行を更新済み
+
+## STOP conditions
+
+- Step 1 で期待曲数の情報源が特定できない(workflow-state / suno-prompts のどちらにも曲数に相当する値がない)— スキーマ追加が必要になり本 plan のスコープ外。STOP して報告。
+- masterup に既に同等の完全性チェックが存在する。
+
+## Maintenance notes
+
+- 将来 `assets.music_downloaded` を bool から `{downloaded: N, expected: M}` 型に拡張すれば、このチェックは機械化できる(スキーマ変更 + suno-helper 拡張側の対応が必要。follow-up 候補)。
+- インスト/ボーカルで期待曲数の算式が違う場合(1 Generate = 2 clip)、チェック文言に両モードの算式を明記すること。

--- a/plans/015-postmortem-threshold-rubric.md
+++ b/plans/015-postmortem-threshold-rubric.md
@@ -1,0 +1,100 @@
+# Plan 015: postmortem の閾値「文脈調整可」に調整ルーブリックを付ける
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/postmortem/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none(plans/005 ルール 4「判断基準なしの判断要求の禁止」の実装例)
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/postmortem` の症状判定表(CTR 0.7 倍未満 → サムネ訴求弱、など)の直後に「閾値は固定値ではなく**チャンネル特性に応じて文脈調整可**とする」とあるが、何をどう見て調整するかの基準がない。Sonnet 級モデルはこの一文から (a) 恣意的に閾値を動かして毎回違う結論を出す、(b) 調整を一切しない、のどちらかに振れる。postmortem は週次で繰り返し実行され結果が戦略判断に使われるため、判定の再現性が下がると分析自体への信頼が失われる。調整して良い条件と幅を 3 ケースの表で固定する。
+
+## Current state
+
+- `.claude/skills/postmortem/SKILL.md:91` — 対象の一文。現物:
+  「閾値は固定値ではなく **チャンネル特性に応じて文脈調整可** とする。判定にあたって閾値を変更した場合は postmortem.md の「症状サマリー」欄に明示する。」
+- 85-90 行: 症状判定表(4 行。`ctr_percentage` の 0.7 倍 / 0.9 倍、`impressions` の 0.5 倍、`ratio_vs_median < 0.9` などの係数)。**表自体は変更しない。**
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/postmortem/SKILL.md`(91 行目の一文を段落に拡張するのみ)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- 症状判定表の係数そのもの。
+- Phase 4(検証ステップ)以降の記述。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(postmortem): 閾値の文脈調整にルーブリック（3 ケース + 上限幅）を追加`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 調整ルーブリックを追加する
+
+91 行目の一文を以下で置き換える:
+
+```markdown
+閾値は以下のルーブリックの範囲でのみ調整可。**該当ケースがなければ表の係数をそのまま使う**（自由裁量での調整は不可）:
+
+| ケース | 判定条件 | 調整 |
+|--------|----------|------|
+| 新チャンネル | 公開動画数 < 10 本、またはチャンネル開設 30 日未満 | 母集団が小さく平均が不安定なため、平均比の閾値を ±0.1 まで緩めてよい（例: 0.7 倍 → 0.6 倍） |
+| 直近にテーマ転換 | 直近 3 本が過去の主要テーマと異なる（collection-ideate の記録で確認） | 過去平均との比較は参考値とし、`ratio_vs_median` 系の判定を優先する |
+| 外部要因の明確な痕跡 | 公開時刻ミス・サムネ差し替え等が workflow-state / 履歴から確認できる | 該当指標の判定を保留し、外部要因を先に記録する |
+
+調整した場合は、変更前後の閾値と適用したケース名を postmortem.md の「症状サマリー」欄に必ず明示する。
+```
+
+**Verify**: `rg -n '自由裁量での調整は不可' .claude/skills/postmortem/SKILL.md` → 1 件。`rg -n '±0.1' .claude/skills/postmortem/SKILL.md` → 1 件。
+
+### Step 2: CHANGELOG 追記とテスト
+
+```
+- postmortem: 閾値の「文脈調整可」に 3 ケースのルーブリックと調整上限を追加（判定の再現性向上）
+```
+
+**Verify**: `rg -n 'ルーブリック' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+新規テスト不要。既存ユニットスイート green を確認。
+
+## Done criteria
+
+- [ ] 調整可能なケース・条件・上限幅が表形式で定義され、「該当なしなら表のまま」が明記されている
+- [ ] 症状判定表(85-90 行)の係数が無変更
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 015 行を更新済み
+
+## STOP conditions
+
+- 91 行目の一文が Current state の引用と一致しない。
+- ルーブリックの 3 ケースがチャンネル運用の実態と合わないとオペレーターから指摘があった場合(ケース定義は提案値 — 変更要望があれば従う)。
+
+## Maintenance notes
+
+- ルーブリックの係数(±0.1、10 本、30 日)は初期提案値。数サイクル運用して postmortem.md の「症状サマリー」欄に調整記録が溜まったら見直す。
+- `/analytics-analyze` 側にも閾値系の記述があれば同じルーブリック参照に寄せられる(今回スコープ外)。

--- a/plans/016-setup-project-id-truncate.md
+++ b/plans/016-setup-project-id-truncate.md
@@ -1,0 +1,95 @@
+# Plan 016: setup の project ID truncate 手順を一義化する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/setup/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/setup` の GCP project ID 生成規則に「30 文字を超える場合は `yt-` を含めて 30 文字以内に truncate」とあるが、この文は「`yt-` prefix を保持して slug 側の末尾を削る」とも「全体を機械的に 30 文字で切る」とも読める。さらに機械的に切ると末尾がハイフンで終わる ID(GCP 制約違反)が生成されうる。project ID は作成後に変更できないため、規則を手順 + 具体例で一義化する。小さな修正だが、`/setup` は新チャンネルごとに必ず通る道である。
+
+## Current state
+
+- `.claude/skills/setup/SKILL.md:157-159` — 対象箇所。現物:
+  - 158 行: 「project ID: `yt-{channel-slug}`。`channel-slug` はチャンネル名を kebab-case 化し、英小文字・数字・ハイフン以外をハイフンに置換、連続ハイフンを 1 個に畳み、先頭末尾のハイフンを削る」
+  - 159 行: 「project ID は GCP 制約に合わせて 6-30 文字、英小文字開始、英小文字/数字/ハイフン終端に収める。30 文字を超える場合は `yt-` を含めて 30 文字以内に truncate し、短すぎる/空になる場合はカスタム入力を求める」
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| setup 契約テスト | `uv run pytest tests/test_setup_skill.py -q` | exit 0 |
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/setup/SKILL.md`(159 行の truncate 文のみ)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- 158 行の slug 生成規則(既に一義的)。
+- gcloud コマンド群・その他の Step。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(setup): project ID の truncate 手順を具体例付きで一義化`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: truncate 文を置き換える
+
+159 行の「30 文字を超える場合は `yt-` を含めて 30 文字以内に truncate し、短すぎる/空になる場合はカスタム入力を求める」を以下で置き換える:
+
+```markdown
+全体（`yt-` + slug）が 30 文字を超える場合は次の手順で切り詰める: (1) `yt-` prefix は必ず保持し、slug の**末尾から**文字を削って全体を 30 文字以内にする、(2) 切り詰め後の末尾がハイフンになった場合はそのハイフンも削る、(3) 結果が 6 文字未満・単語の切れ目が不自然で意味が読み取れない場合は自動生成をやめてカスタム入力を求める。例: `yt-very-long-channel-name-tokyo`（31 文字）→ `yt-very-long-channel-name-toky`（30 文字）→ 末尾はハイフンでないのでこれで確定。
+```
+
+**Verify**: `rg -n '末尾から' .claude/skills/setup/SKILL.md` → 1 件。`rg -n 'そのハイフンも削る' .claude/skills/setup/SKILL.md` → 1 件。
+
+### Step 2: 契約テストと全体テスト、CHANGELOG
+
+**Verify**: `uv run pytest tests/test_setup_skill.py -q` → exit 0(fail 時は旧文言の assert を新文言へ更新し、コミットに明記)。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+`CHANGELOG.md` の `[Unreleased]`:
+
+```
+- setup: project ID の 30 文字超過時の truncate 手順を一義化（prefix 保持・末尾削り・末尾ハイフン除去・不自然ならカスタム入力）
+```
+
+**Verify**: `rg -n 'truncate 手順を一義化' CHANGELOG.md` → 1 件。
+
+## Test plan
+
+`tests/test_setup_skill.py` を主ゲートに使う。新規テスト不要。
+
+## Done criteria
+
+- [ ] truncate 規則が手順 3 段 + 具体例で一義化されている
+- [ ] `uv run pytest tests -q --ignore=tests/integration` が exit 0
+- [ ] `CHANGELOG.md` 追記済み、`plans/README.md` の 016 行を更新済み
+
+## STOP conditions
+
+- 159 行の現物が Current state の引用と一致しない。
+- project ID の生成がコード側(`yt-doctor` / setup 系 CLI)にも実装されていて SKILL.md と食い違うことが判明した場合(`rg -n 'project.?id' src/youtube_automation/ -i | head` で確認)— 正はコード側なので STOP して報告。
+
+## Maintenance notes
+
+- GCP の project ID 制約(6-30 文字、小文字開始、末尾ハイフン不可)が変わることは考えにくいが、この段落が制約の唯一の記述箇所。gcloud 側でエラーになった場合はまずここを疑う。

--- a/plans/017-thumbnail-external-repo-ref.md
+++ b/plans/017-thumbnail-external-repo-ref.md
@@ -1,0 +1,99 @@
+# Plan 017: thumbnail の外部リポジトリ参照をオペレーター向け注記に隔離する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 8deb3f02..HEAD -- .claude/skills/thumbnail/SKILL.md`
+> 差分があれば "Current state" の抜粋と実物を突合し、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none(plans/005 ルール 7「実行者が解決できない参照の禁止」の実装例)
+- **Category**: docs
+- **Planned at**: commit `8deb3f02`, 2026-07-05
+
+## Why this matters
+
+`/thumbnail` の diff_prompt_template 解説の中に「実装事例として `daiki-beppu/rjn` の `config/skills/thumbnail.yaml` が参考になる」という文が地の文で置かれている。このスキルは `yt-skills sync` で下流チャンネルリポジトリへ配布され、そこで実行するモデル(とりわけ Sonnet 級)にとって `daiki-beppu/rjn` はアクセスできない私有リポジトリである。地の文の「参考になる」は実行手順の一部として解釈され、モデルが gh でのアクセス試行やファイル探索で時間を浪費する。オペレーター(リポジトリ所有者)向けの情報としては有用なので、削除ではなく「実行者向けではない」ことが明確な引用ブロックへ隔離する。
+
+## Current state
+
+- `.claude/skills/thumbnail/SKILL.md:340` — 対象の一文。現物(段落末尾):
+  「差分プロンプトの具体例は skill-config の `image_generation.gemini.diff_prompt_template` を参照し、チャンネル固有のオブジェクト・カラーを埋める。実装事例として `daiki-beppu/rjn` の `config/skills/thumbnail.yaml` が参考になる（jazzgak チャンネルの 5 サムネを `color_themes.<theme>.reference_image` で多軸切替）。」
+- 他に外部リポジトリを地の文で参照する箇所がないか確認する: `rg -n 'daiki-beppu/' .claude/skills/*/SKILL.md`(この plan のスコープは thumbnail のみだが、他にあれば README に followup として記録する)。
+
+## Commands you will need
+
+| 目的 | コマンド | 成功条件 |
+|------|----------|----------|
+| thumbnail 関連テスト | `uv run pytest tests/test_thumbnail_skill_assets.py tests/test_thumbnail_codex_image_skill.py -q` | exit 0 |
+| ユニット全体 | `uv run pytest tests -q --ignore=tests/integration` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `.claude/skills/thumbnail/SKILL.md`(340 行の一文の移動・書式変更のみ)
+- `CHANGELOG.md`
+
+**Out of scope**:
+- diff_prompt_template の解説本体。
+- 他スキルの外部参照(発見したら README に記録するのみ)。
+
+## Git workflow
+
+- worktree 上で作業。base は main。
+- コミット例: `docs(thumbnail): 外部リポジトリ参照をオペレーター向け注記に隔離`
+- push / PR はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 該当文を引用ブロックに隔離する
+
+340 行の「実装事例として `daiki-beppu/rjn` の…」の一文を段落から削除し、同じ段落の直後に以下の引用ブロックとして置き直す:
+
+```markdown
+> **参考（オペレーター向け・実行時は無視してよい）**: 実装事例はオペレーターの私有リポジトリ `daiki-beppu/rjn` の `config/skills/thumbnail.yaml` にある（jazzgak チャンネルの 5 サムネを `color_themes.<theme>.reference_image` で多軸切替）。下流リポジトリの実行者はアクセスできないため、取得を試みないこと。
+```
+
+**Verify**: `rg -n '実行時は無視してよい' .claude/skills/thumbnail/SKILL.md` → 1 件。`rg -n '実装事例として' .claude/skills/thumbnail/SKILL.md` → 0 件(地の文から消えている)。
+
+### Step 2: 他の外部参照を確認する(記録のみ)
+
+`rg -n 'daiki-beppu/' .claude/skills/*/SKILL.md` を実行し、thumbnail 以外にヒットがあれば `plans/README.md` の残課題欄に 1 行追記する(修正はしない)。
+
+**Verify**: コマンドを実行し、結果を README 更新(該当なしなら不要)に反映した。
+
+### Step 3: CHANGELOG 追記とテスト
+
+```
+- thumbnail: 外部リポジトリ（daiki-beppu/rjn）への参照をオペレーター向け注記に隔離（下流実行者のアクセス試行を防止）
+```
+
+**Verify**: `rg -n 'オペレーター向け注記に隔離' CHANGELOG.md` → 1 件。`uv run pytest tests -q --ignore=tests/integration` → exit 0。
+
+## Test plan
+
+`tests/test_thumbnail_skill_assets.py` / `tests/test_thumbnail_codex_image_skill.py` を含むユニットスイート green を確認。新規テスト不要。
+
+## Done criteria
+
+- [ ] `daiki-beppu/rjn` への言及が「オペレーター向け・実行時は無視」の引用ブロック内にのみ存在する
+- [ ] 「取得を試みないこと」という禁止形が含まれている
+- [ ] `CHANGELOG.md` 追記済み、ユニットテスト exit 0
+- [ ] `plans/README.md` の 017 行を更新済み
+
+## STOP conditions
+
+- 340 行付近の現物が Current state の引用と一致しない。
+- thumbnail の contract テストがこの一文の存在位置を assert している(期待値更新で直るなら更新して続行、構造的に直らないなら STOP)。
+
+## Maintenance notes
+
+- 規約(plans/005 ルール 7)の「オペレーター向け注記」書式の最初の実装例になる。以降、私有リポジトリ・未接続機能への言及はこの書式に揃える。
+- 実装事例をこのリポジトリ内に置けるなら(`examples/` に匿名化した thumbnail.yaml 例を追加)、外部参照自体を不要にできる(follow-up 候補)。

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,8 +1,74 @@
 # Implementation Plans
 
-## 第 1 回監査（distrokid-helper 本体 + yt-collection-serve、2026-06-12、基準 commit `fa296fe`）
+このリポジトリの規約: 作業は必ず worktree 上で行う（`$REPO_ROOT/.worktrees/<slug>/`）。`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml` を触るプランは `CHANGELOG.md` の `[Unreleased]` 追記が必須（lefthook pre-push + CI ゲート）。docs / tests のみの変更はゲート対象外。
 
-このリポジトリの規約: 作業は必ず worktree 上で行う（`$REPO_ROOT/.worktrees/<slug>/`）。`src/youtube_automation/` を触るプランは `CHANGELOG.md` の `[Unreleased]` 追記が必須（pre-push ゲートあり）。
+Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
+
+## 第 2 回監査（スキル全般の Sonnet-safe 化、2026-07-05、基準 commit `8deb3f02`）
+
+監査テーマ: `.claude/skills/` 全 47 スキルを「Sonnet 級のより弱いモデルが実行しても作者の期待とズレなく解釈できるか」の観点で監査（TRIGGER / AMBIG / DRIFT / ROBUST の 4 ディメンション、並列 4 subagent + 全 findings を advisor が実読 vet）。42 件の生 findings から 12 件を有効と判定し、規約 1 本 + 個別修正 12 本に plan 化した。
+
+### Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
+|------|-------|----------|--------|------------|-------|-----|--------|
+| 005 | Sonnet-safe スキル記述規約を docs/skill-design/ に制定 | P1 | M | — | [#1512](https://github.com/daiki-beppu/youtube-automation/issues/1512) | [#1529](https://github.com/daiki-beppu/youtube-automation/pull/1529) | DONE |
+| 006 | comments-reply / pinned-comment に dry-run→apply 承認ゲート追加 | P1 | S | 005 (soft) | [#1513](https://github.com/daiki-beppu/youtube-automation/issues/1513) | [#1537](https://github.com/daiki-beppu/youtube-automation/pull/1537) | DONE |
+| 007 | analytics-report の CTR 解釈記述をコード実態（百分率 float）に修正 | P1 | S | — | [#1514](https://github.com/daiki-beppu/youtube-automation/issues/1514) | [#1536](https://github.com/daiki-beppu/youtube-automation/pull/1536) | DONE |
+| 008 | 兄弟スキル間の frontmatter 矛盾・発動キーワード衝突を解消 | P1 | S | 005 (soft) | [#1515](https://github.com/daiki-beppu/youtube-automation/issues/1515) | [#1538](https://github.com/daiki-beppu/youtube-automation/pull/1538) | DONE |
+| 009 | 工程チェーンの前提条件ガードを 4 スキルに追加 | P2 | S-M | 005 (soft) | [#1516](https://github.com/daiki-beppu/youtube-automation/issues/1516) | [#1551](https://github.com/daiki-beppu/youtube-automation/pull/1551) | DONE |
+| 010 | channel-new のペルソナ生成前に TTP 中間ゲート追加 | P2 | S | — | [#1517](https://github.com/daiki-beppu/youtube-automation/issues/1517) | [#1533](https://github.com/daiki-beppu/youtube-automation/pull/1533) | DONE |
+| 011 | live-clean の削除承認を明示的 2 択 + 取消不可警告に固定 | P2 | S | 005 (soft) | [#1518](https://github.com/daiki-beppu/youtube-automation/issues/1518) | [#1541](https://github.com/daiki-beppu/youtube-automation/pull/1541) | DONE |
+| 012 | stale/freshness 判定を freshness-rules.md へ単一ソース化 | P2 | S | — | [#1519](https://github.com/daiki-beppu/youtube-automation/issues/1519) | [#1546](https://github.com/daiki-beppu/youtube-automation/pull/1546) | DONE |
+| 013 | suno のモード判定を decision tree 化 | P2 | S | — | [#1520](https://github.com/daiki-beppu/youtube-automation/issues/1520) | [#1543](https://github.com/daiki-beppu/youtube-automation/pull/1543) | DONE |
+| 014 | suno-helper → masterup の部分ダウンロード検知手順を明文化 | P2 | S | — | [#1521](https://github.com/daiki-beppu/youtube-automation/issues/1521) | [#1549](https://github.com/daiki-beppu/youtube-automation/pull/1549) | DONE |
+| 015 | postmortem の閾値調整ルーブリック追加 | P3 | S | — | [#1522](https://github.com/daiki-beppu/youtube-automation/issues/1522) | [#1542](https://github.com/daiki-beppu/youtube-automation/pull/1542) | DONE |
+| 016 | setup の project ID truncate 手順を一義化 | P3 | S | — | [#1523](https://github.com/daiki-beppu/youtube-automation/issues/1523) | [#1545](https://github.com/daiki-beppu/youtube-automation/pull/1545) | DONE |
+| 017 | thumbnail の外部リポジトリ参照をオペレーター向け注記に隔離 | P3 | S | — | [#1524](https://github.com/daiki-beppu/youtube-automation/issues/1524) | [#1544](https://github.com/daiki-beppu/youtube-automation/pull/1544) | DONE |
+
+全 13 件、2026-07-05〜07-06 に main へマージ済み（スポットチェックで #1529 / #1537 / #1551 の diff を実読し、要件との整合を確認済み）。
+
+### 既存 issue との関係
+
+- **#1489〜#1493「[skill-quality] AI 可読性改善」（親 #1487）**: 同テーマの網羅スイープ。両立方針 — 確定修正（本監査の 13 issue）を先行させ、スイープ側は適用済み修正を尊重する（各 issue にコメント済み、2026-07-05）
+- **#1499（channel-new ヒアリング TTP 特化）**: #1517 と同ファイルを触るため順序注意（#1517 の issue 本文に明記）
+
+### Dependency notes
+
+- **005 を最初に**実行することを推奨。006 / 008 / 009 / 011 は 005 の規約（承認ゲート標準型・発動条件相互排他・前提ガード標準型）の実装例になる。ただし各 plan は自己完結しており 005 未完了でも実行可能（soft dependency）。
+- 006〜017 は互いに独立（触るファイルが重複しない）。並列実行可。例外: 012 と 009 はどちらも wf 系に近いが対象ファイルは非重複。
+- `.claude/skills/` を触る plan（006〜017 すべて）は CHANGELOG 追記必須。**複数 plan を連続実行する場合、CHANGELOG の [Unreleased] で追記が conflict しやすい**ので、実行順に rebase すること。
+
+### Findings considered and rejected（再監査不要）
+
+- **「CLAUDE.md §6 が存在しない」（wf-* の参照切れ疑い）**: 誤り。`.claude/CLAUDE.template.md:171` に「## 6. Claude が判断に迷ったら参照すべきスキル一覧」が実在し、`docs/workflow-cheatsheet.md` も wheel force-include + `yt-skills sync --asset workflow-cheatsheet` で配布される正当な参照。
+- **「yt-launch-curve / yt-thumbnail-correlate / yt-theme-compare / yt-channel-trend が未登録の可能性」**: 全 4 CLI が `pyproject.toml::[project.scripts]` に実在。
+- **「channel-new の description に廃止スキル channel-import のトリガー残存」**: by design。旧名で呼ぶユーザーを統合先へルーティングする意図的な alias。
+- **「automation-release の awk が大文字小文字厳密で false positive」**: by design。`### Migration` の完全一致は `docs/changelog-contract.md` の契約仕様。
+- **「thumbnail prompt-schema 試験導入の誤用リスク」**: 本文に「実本番フローからは未接続」と明示済み。
+- **「wf-new / wf-next / wf-status のトリガー衝突」「analytics-collect / analyze / report のトリガー衝突」**: 各 description に相互の否定トリガー（「既存の進行は /wf-next」「/analytics-analyze の前段」等）が既に記述済み。
+- **「video-analyze / community-post の設定読み込みゲート文言が矛盾」**: 文言は冗長だが「存在しない override は未設定として扱い、勝手に作成しない」「fallback 元としては使わない」と一義的に書かれており誤読の余地は小さい。
+- **「suno-helper 拡張 ID の形式説明不足」「preset 定義値が SKILL.md に無い」**: Cross References で `extensions/shared/constants.ts::SPEED_PRESETS` への参照が明示済み。情報の置き場所として妥当。
+- **「community-draft の poll deprecated が frontmatter 未記載」**: 本文の型一覧表に DEPRECATED と移行ガイドが明記済み。frontmatter は現行型のみ列挙しており誤誘導なし。
+
+### Plan 作成時の再 vet による縮小（監査 finding との差分）
+
+- **010（channel-new）**: 監査は「完了条件が埋没・Step 3 が混在」と主張したが、実読では TTP 完了条件は冒頭 48-60 行に在り、Step 3 は停止 17 チェックと許容 4 fail を理由付きで分離済み。実ギャップは「ペルソナ生成前の中間ゲート欠如」のみに縮小（M → S）。
+- **014（masterup）**: 監査は「DL 状態管理の責務不明」と主張したが、責務分離は masterup:10 / suno-helper:130-131 に明文化済み。実ギャップは「部分ダウンロード検知」のみに縮小（M → S）。
+
+### 監査で plan 化を見送った残課題
+
+- **発動キーワード重複の機械検出**（`test_skill_docs_consistency.py` 系譜で「同一鉤括弧キーワードが複数 description に出たら fail」）— 規約 005 の合意後に検討
+- **`assets.music_downloaded` の曲数型への拡張**（bool → `{downloaded, expected}`。014 の機械化。スキーマ変更のため別判断）
+- **巨大 SKILL.md（collection-ideate 673 行 / automation-update 672 行）の構造分割** — 参照関係は明示されておりリスクの割に益が薄いと判断
+- **automation-update の Migration 欠落 fallback の要約手順詳細化**（M、LOW-MED）
+- **metadata-audit の issue 種別 → 対応スキル対応表**（S、LOW）
+- **streaming の ssh-agent 毎セッション再登録の前提セクション昇格**（S、LOW）
+- **修正後スキルの実測検証**: dotfiles の `empirical-prompt-tuning` スキル（バイアスを排した実行者に実行させ両面評価）で、006 / 011 / 013 など解釈が分かれやすい修正の受け入れ検証を行う選択肢がある（オペレーター判断）
+
+---
+
+## 第 1 回監査（distrokid-helper 本体 + yt-collection-serve、2026-06-12、基準 commit `fa296fe`）
 
 | Plan | Title | Priority | Effort | Depends on | Issue | Status |
 |------|-------|----------|--------|------------|-------|--------|
@@ -11,14 +77,12 @@
 | 003 | distrokid-helper に lint / format ゲート + CI パリティ | P2 | M | 002 | [#955](https://github.com/daiki-beppu/youtube-automation/issues/955) | DONE |
 | 004 | サーバー URL 既定値を shared/constants.ts に集約 | P3 | S | — | [#956](https://github.com/daiki-beppu/youtube-automation/issues/956) | DONE |
 
-Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
-
-## Dependency notes
+### Dependency notes
 
 - 003 は 002 の後に実行する（両方が package.json と pnpm-lock.yaml を編集するため conflict）→ 両方 DONE
 - 001 と 004 は完全に独立
 
-## Findings considered and rejected
+### Findings considered and rejected
 
 - **App.tsx:128 の「stale closure バグ」**: by design。コメント（App.tsx:113-114）が意図を明記済み
 - **`write_distrokid_release` の TOCTOU race**: 単一オペレーター設計で実発生確率ほぼゼロ
@@ -27,7 +91,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 - **`_send_json_error` のメッセージ切り詰め**: 信頼クライアント（自前拡張）のみ。実害なし
 - **StatusBanner の XSS**: React JSX 自動エスケープで安全
 
-## 監査で plan 化を見送った残課題
+### 監査で plan 化を見送った残課題
 
 - **popup（App.tsx 301 行）のユニットテスト新設**（テスト, M）
 - **README 運用エッジケース補強**（docs, S）


### PR DESCRIPTION
## Summary
- `.claude/skills/` 全 47 スキルの Sonnet-safe 監査（TRIGGER / AMBIG / DRIFT / ROBUST の 4 ディメンション）で作成した `plans/005〜017-*.md` を追加
- `plans/README.md` に第 2 回監査セクションを追加し、対応する issue #1512〜#1524・実装 PR・DONE ステータスを記録
- 監査の意思決定過程（vet で棄却した 9 件、実読で縮小した 2 件、既存 [skill-quality] 網羅スイープ #1489〜#1493 との棲み分け）も残す

**注記**: 記載内容が指す 13 件の実装（issue #1512〜#1524）は本 PR 作成前に既に個別 PR（#1529, #1533, #1536〜1538, #1541〜1546, #1549, #1551）でマージ済み。本 PR は監査記録（plans/ ドキュメント）を repo に残すための追記のみで、コード・スキル本文の変更は含まない。

## Test plan
- [x] docs のみの変更のため CHANGELOG ゲート対象外（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml` に該当しない）
- [x] 全 13 issue の close 状態・紐づく PR の merge 状態・merge commit が origin/main の祖先であることを `gh` で確認済み
- [x] 実装内容のスポットチェック（#1529 規約本体、#1537 承認ゲート、#1551 前提ガード）で issue の受入条件との整合を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)