### PR TITLE
fix(suno-helper): 日本語UIの作成ボタンを検出する

### DIFF
--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -35,7 +35,7 @@ const SELECTORS = {
   // 付けた属性) で候補を全 query → textContent 完全一致で Male/Female を絞り込む方式を採用。
   // Emotion class hash や親 div の role/class には依存しない。
   vocalGenderButtons: 'button[data-selected][type="button"]',
-  generateLabel: /^(create|generate|生成)$/i,
+  generateLabel: /^(create|generate|生成|作成(?:する)?)$/i,
   recaptcha:
     'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]',
 } as const;
@@ -629,7 +629,7 @@ export function resolveGenerateButton(): HTMLButtonElement {
   );
   if (!btn) {
     throw new FatalRunError(
-      "Generate ボタンが見つかりません。Suno の UI 変更の可能性があります。",
+      "生成ボタン（Create / Generate / 作成）が見つかりません。Suno の UI 変更または UI 言語ラベル変更の可能性があります。",
     );
   }
   return btn;

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -605,7 +605,7 @@ describe("resolveFields: Song Title 欄の解決 (#844, fail-soft)", () => {
 });
 
 describe("resolveGenerateButton: Generate ボタンの解決", () => {
-  it.each(["Create", "Generate", "生成", "  generate  "])(
+  it.each(["Create", "Generate", "生成", "作成", "作成する", "  generate  "])(
     "Given ラベル '%s' When 解決する Then 一致するボタンを返す",
     (label) => {
       const btn = addButton(label);

--- a/extensions/suno-helper/wxt.config.ts
+++ b/extensions/suno-helper/wxt.config.ts
@@ -3,6 +3,15 @@ import { defineConfig } from "wxt";
 import { SERVER_HOST_PERMISSIONS, SUNO_MATCHES } from "../shared/constants";
 import { MANIFEST_PERMISSIONS } from "./lib/manifest";
 
+const isTestBuild = process.env.SUNO_HELPER_TEST_BUILD === "1";
+const extensionName = isTestBuild
+  ? "[TEST] Suno Helper (youtube-channels-automation)"
+  : "Suno Helper (youtube-channels-automation)";
+const extensionDescription = isTestBuild
+  ? "[TEST BUILD] /suno が生成した Style/Lyrics を Suno Custom Mode に順次注入し Generate を連続実行する補助拡張。"
+  : "/suno が生成した Style/Lyrics を Suno Custom Mode に順次注入し Generate を連続実行する補助拡張。";
+const actionTitle = isTestBuild ? "[TEST] Suno Helper" : "Suno Helper";
+
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
@@ -12,13 +21,13 @@ export default defineConfig({
   // suno-bridge は MAIN world の fetch 観測 bridge (#948)。
   filterEntrypoints: ["background", "content", "overlay", "suno-bridge"],
   manifest: {
-    name: "Suno Helper (youtube-channels-automation)",
-    description: "/suno が生成した Style/Lyrics を Suno Custom Mode に順次注入し Generate を連続実行する補助拡張。",
+    name: extensionName,
+    description: extensionDescription,
     // 最小権限。SSOT は lib/manifest.ts (tests/manifest.test.ts で機械担保)。
     permissions: [...MANIFEST_PERMISSIONS],
     host_permissions: [...SERVER_HOST_PERMISSIONS, ...SUNO_MATCHES],
     action: {
-      default_title: "Suno Helper",
+      default_title: actionTitle,
     },
   },
 });


### PR DESCRIPTION
## Summary
- suno-helper の Generate ボタン検出で日本語 UI の `作成` / `作成する` を許可
- ボタン未検出時のエラーメッセージを日本語 UI ラベル変更も分かる文言に更新
- テスト用ビルド時に manifest 名・説明・action title へ `[TEST]` を付ける

## Root Cause
日本語 UI で Suno の生成ボタンが `作成` 系ラベルになった場合、既存の検出正規表現が `Create` / `Generate` / `生成` しか許可しておらず、ボタン未検出として停止する可能性があった。

## Validation
- `pnpm --filter suno-helper exec vitest run tests/dom.test.ts tests/inject-advanced.test.ts tests/download.test.ts tests/dom-playlist.test.ts`
- `pnpm --filter suno-helper exec playwright test tests/e2e/suno-inject.spec.ts tests/e2e/playlist-add.spec.ts`
- `SUNO_HELPER_TEST_BUILD=1 pnpm --filter suno-helper zip`