### PR TITLE
docs(plans): 第 3 回監査(takt リジェクト多発の原因調査)の記録とプラン 2 本を追加

### DIFF
--- a/plans/018-issue-sibling-entrypoint-enumeration.md
+++ b/plans/018-issue-sibling-entrypoint-enumeration.md
@@ -1,0 +1,204 @@
+# Plan 018: issue テンプレの「影響ファイル」に兄弟入口・貫通先の列挙を必須化する
+
+> **Executor instructions**: このプランをステップ順に実行すること。各ステップ末尾の
+> 検証コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」に該当したら
+> 即座に停止して報告する（改変・推測で続行しない）。完了したら
+> `<automation-repo>/plans/README.md` の本プランの Status 行を更新する。
+>
+> **⚠ 作業対象リポジトリは dotfiles**: 編集対象ファイルはすべて
+> `~/01-dev/dotfiles/config/.claude/skills/` 配下にある。`~/.claude/skills/` は
+> dotfiles への symlink なので、**必ず dotfiles リポジトリ側で編集・コミットする**。
+> このプランファイル自体は automation リポジトリ（`~/02-yt/00-automation`）の
+> `plans/` にあるが、コード変更は dotfiles のみ。
+>
+> **Drift check (run first)**:
+> `cd ~/01-dev/dotfiles && git diff --stat 9a030ff..HEAD -- config/.claude/skills/issue/SKILL.md config/.claude/skills/to-issues/SKILL.md config/.claude/skills/takt-issue/SKILL.md`
+> 差分があれば「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: dx
+- **Planned at**: dotfiles `9a030ff` / automation `bf68c73d`, 2026-07-06
+
+## Why this matters
+
+takt の 7 観点レビュー（review-takt-default）の REJECT 指摘 676 件（2026-06-17〜07-06、
+review 237 run）を全数分類した結果、最大の欠陥クラスは「契約・配線の貫通漏れ」だった:
+config キーを定義したが loader→実行経路→出力まで配線されていない（75 件）、同じ責務を持つ
+別入口（別 CLI / server 側 / Chrome extension 側 / Python・TS 二重実装）に契約変更が適用
+されていない、など。issue 起票時に「変更が貫通すべき兄弟入口」を列挙しておけば、takt の
+plan step（automation リポジトリの `.takt/facets/instructions/plan.md` は「配線が必要な
+全箇所を列挙する」ことを Coder ガイドラインに要求している）がそれを読み込み、実装漏れ →
+レビュー REJECT のループを上流で削れる。現在の issue / to-issues / takt-issue の 3 テンプレは
+いずれも「影響ファイル」に新規/変更/削除の区別しか要求しておらず、兄弟入口の観点がない。
+
+## Current state
+
+対象は dotfiles リポジトリの 3 ファイル（`~/.claude/skills/` は symlink）:
+
+1. `config/.claude/skills/issue/SKILL.md`（272 行）— `/issue` スキル。Task Step 3 の
+   コアテンプレ内に以下の「影響ファイル」節がある（L82-86 付近）:
+
+   ```markdown
+   ## 影響ファイル
+   （スコープ明示。新規 / 変更 / 削除を区別）
+   - **新規**: path/to/new.ts
+   - **変更**: path/to/existing.ts
+   - **削除**: path/to/old.ts
+   ```
+
+   また L137-142 付近に「情報不足時の振る舞い」リストがあり、
+   `**`## 影響ファイル`` が会話から特定できない**: `(plan step で確定する)` と明記して残す`
+   という行がある。
+
+2. `config/.claude/skills/to-issues/SKILL.md`（146 行）— `/to-issues` スキル。
+   issue-template 内 L97-103 に同様の「影響ファイル」節:
+
+   ```markdown
+   ## 影響ファイル
+
+   （スコープ明示。新規 / 変更 / 削除を区別）
+   - **新規**: path/to/new.ts
+   - **変更**: path/to/existing.ts
+
+   特定できない場合は `(plan step で確定する)` と明記する。
+   ```
+
+3. `config/.claude/skills/takt-issue/SKILL.md`（508 行）— Step 0「issue 本文の正規化
+   （preflight）」（L61-133）が既にあり、`## 影響ファイル` を含む 4 必須セクションを検証する。
+   L107-115 の「不足セクション補完」に
+   `**`## 影響ファイル`**: 同上。`**新規**` / `**変更**` / `**削除**` を文脈から推定。不足なら `(plan step で確定する)``
+   という補完ルールがある。
+
+リポジトリ規約（dotfiles）: コミットは日本語 Conventional Commits
+（例: `fix(skills): CI 監視でコンフリクト未検知のまま待ち続ける問題を修正`）。
+dotfiles にはテストスイート・CHANGELOG ゲートはない。検証は `rg` による構造チェックのみ。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Drift check | `cd ~/01-dev/dotfiles && git diff --stat 9a030ff..HEAD -- config/.claude/skills/{issue,to-issues,takt-issue}/SKILL.md` | （差分なし、または抜粋と一致） |
+| 構造検証 | `rg -c '兄弟入口' config/.claude/skills/issue/SKILL.md` | 1 以上 |
+| symlink 確認 | `ls -la ~/.claude/skills/issue` | dotfiles 配下を指す symlink |
+
+## Scope
+
+**In scope**（変更してよいファイル — すべて `~/01-dev/dotfiles/` 配下）:
+- `config/.claude/skills/issue/SKILL.md`
+- `config/.claude/skills/to-issues/SKILL.md`
+- `config/.claude/skills/takt-issue/SKILL.md`
+
+**Out of scope**（触らない）:
+- automation リポジトリ側の一切のファイル（`.takt/` の workflow / policy / instruction を含む。
+  兄弟入口の実装時チェックは既に `.takt/facets/policies/pre-review-checklist.md` 項目 4 が
+  担っており、本プランは issue 起票側だけを扱う）
+- `config/.claude/skills/issue-direct/SKILL.md`・`issue-organize` — issue 本文テンプレを
+  持たないため対象外
+- 各テンプレの「影響ファイル」以外のセクション（要件・スコープ外・参照資料の書式）
+
+## Git workflow
+
+- リポジトリ: `~/01-dev/dotfiles`（main ブランチ運用。ブランチを切る場合は `feat/issue-sibling-entrypoints`）
+- コミット例: `feat(skills): issue テンプレの影響ファイルに兄弟入口・貫通先の列挙を追加`
+- push / PR はオペレーターの指示がない限り行わない
+
+## Steps
+
+### Step 1: `/issue` のテンプレに「兄弟入口・貫通先」小節を追加
+
+`config/.claude/skills/issue/SKILL.md` のコアテンプレ内「影響ファイル」節を次の形に拡張する
+（既存 3 行の直後に追記。セクション名 `## 影響ファイル` 自体は変更しない — takt の plan.md
+instruction と takt-issue preflight が見出し名でパースするため）:
+
+```markdown
+## 影響ファイル
+（スコープ明示。新規 / 変更 / 削除を区別）
+- **新規**: path/to/new.ts
+- **変更**: path/to/existing.ts
+- **削除**: path/to/old.ts
+
+**兄弟入口・貫通先**（契約・データ形式・config キーを変更する issue では省略不可。
+同じデータ・同じ責務を扱う別入口を列挙し、「変更する / 変更不要（理由）」を明記する）:
+- 同責務の別入口: 別 CLI サブコマンド / server 側 / extension 側 / Python・TS の対になる実装
+- config キーの変更なら定義 → loader → 実行経路 → 出力の貫通チェーン
+- 該当なしの場合は「なし（単一入口のみ）」と明記。特定できない場合は `(plan step で確定する)`
+```
+
+あわせて「情報不足時の振る舞い」リストの `## 影響ファイル` の行の直後に 1 項目追加:
+
+```markdown
+- **「兄弟入口・貫通先」が判断できない**: `(plan step で確定する)` と明記して残す（空欄・省略にしない）
+```
+
+**Verify**: `rg -n '兄弟入口' ~/01-dev/dotfiles/config/.claude/skills/issue/SKILL.md` → 2 箇所以上ヒット
+
+### Step 2: `/to-issues` のテンプレにも同じ小節を追加
+
+`config/.claude/skills/to-issues/SKILL.md` の issue-template 内「影響ファイル」節
+（L97-103 付近）に、Step 1 と同一文面の「兄弟入口・貫通先」ブロックを追記する
+（文面を 2 スキル間で一字一句揃えること — 将来の同期修正を単純化するため）。
+
+**Verify**: `diff <(rg -A7 '兄弟入口・貫通先' ~/01-dev/dotfiles/config/.claude/skills/issue/SKILL.md | head -8) <(rg -A7 '兄弟入口・貫通先' ~/01-dev/dotfiles/config/.claude/skills/to-issues/SKILL.md | head -8)` → 差分なし（exit 0）
+
+### Step 3: takt-issue preflight の補完ルールに兄弟入口を追加
+
+`config/.claude/skills/takt-issue/SKILL.md` Step 0 の「不足セクション補完」内、
+`## 影響ファイル` の補完ルール行を次のように拡張する:
+
+```markdown
+- **`## 影響ファイル`**: 同上。`**新規**` / `**変更**` / `**削除**` を文脈から推定。不足なら `(plan step で確定する)`。
+  契約・データ形式・config キーの変更を含む issue では「兄弟入口・貫通先」
+  （同責務の別 CLI / server / extension / Python・TS 対実装、config の定義→loader→実行→出力チェーン）を
+  本文から推定して小節として補完する。推定できなければ `(plan step で確定する)` と明記
+```
+
+**Verify**: `rg -n '兄弟入口' ~/01-dev/dotfiles/config/.claude/skills/takt-issue/SKILL.md` → 1 箇所以上ヒット
+
+### Step 4: symlink 経由の反映確認とコミット
+
+```bash
+rg -l '兄弟入口' ~/.claude/skills/issue/SKILL.md ~/.claude/skills/to-issues/SKILL.md ~/.claude/skills/takt-issue/SKILL.md
+```
+3 ファイルすべてヒットすること（symlink なので dotfiles 編集が即反映される）。
+その後 dotfiles でコミットする。
+
+**Verify**: `cd ~/01-dev/dotfiles && git status --short` → 上記 3 ファイルのみが変更されている
+
+## Test plan
+
+スキル（プロンプト資産）のためテストスイートはない。構造検証は各 Step の rg チェックが担う。
+動作確認（任意・推奨）: 適当な会話文脈で `/issue` を起動し、生成プレビューの「影響ファイル」に
+「兄弟入口・貫通先」小節が含まれることを目視確認する（issue は実際には作成せずプレビューで中断してよい）。
+
+## Done criteria
+
+- [ ] `rg -c '兄弟入口' config/.claude/skills/issue/SKILL.md` ≥ 2
+- [ ] `rg -c '兄弟入口' config/.claude/skills/to-issues/SKILL.md` ≥ 1
+- [ ] `rg -c '兄弟入口' config/.claude/skills/takt-issue/SKILL.md` ≥ 1
+- [ ] issue / to-issues の「兄弟入口・貫通先」ブロック文面が一致（Step 2 の diff が exit 0）
+- [ ] `git status --short` で in-scope 3 ファイル以外に変更がない
+- [ ] automation リポジトリの `plans/README.md` の 018 行を DONE に更新
+
+## STOP conditions
+
+以下の場合は停止して報告する:
+
+- Drift check で「影響ファイル」節の現行文面が Current state の抜粋と一致しない
+  （テンプレが既に改訂されている — 上書きすると他の変更を壊す）
+- `~/.claude/skills/issue` が symlink ではなく実体ディレクトリになっている
+  （dotfiles 管理から外れている — 編集先の前提が崩れている）
+- `## 影響ファイル` という見出し名自体を変更したくなった場合（takt の plan.md と
+  takt-issue preflight のパースを壊すため、見出し名の変更は本プランの範囲外）
+
+## Maintenance notes
+
+- 将来 `.takt/facets/instructions/plan.md`（automation リポジトリ）の参照資料抽出書式が
+  変わる場合、この「兄弟入口・貫通先」小節のパース互換に注意（現状は自由記述小節なので影響なし）
+- レビュー時の注視点: 2 スキル間の文面が完全一致していること（片方だけ直す将来変更が起きやすい）
+- 見送った案: `## 兄弟入口` を独立必須セクションにする案は、takt-issue preflight の
+  必須 4 セクション検証・plan.md の見出しパースへの波及が大きいため不採用（小節方式なら非破壊）

--- a/plans/019-takt-review-fix-self-audit.md
+++ b/plans/019-takt-review-fix-self-audit.md
@@ -1,0 +1,274 @@
+# Plan 019: takt-review の fix 工程を「レビュアーと同じ視点の自己監査つき」に再設計する
+
+> **Executor instructions**: このプランをステップ順に実行すること。各ステップ末尾の
+> 検証コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」に該当したら
+> 即座に停止して報告する。完了したら `<automation-repo>/plans/README.md` の本プランの
+> Status 行を更新する。
+>
+> **⚠ 作業対象リポジトリは dotfiles**: 編集対象は
+> `~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` の 1 ファイルのみ。
+> `~/.claude/skills/takt-review` は dotfiles への symlink。
+>
+> **Drift check (run first)**:
+> `cd ~/01-dev/dotfiles && git diff --stat 9a030ff..HEAD -- config/.claude/skills/takt-review/SKILL.md`
+> 差分があれば「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: LOW（プロンプト資産のみの変更。コードには触れない）
+- **Depends on**: none（018 と独立）
+- **Category**: dx
+- **Planned at**: dotfiles `9a030ff` / automation `bf68c73d`, 2026-07-06
+
+## Why this matters
+
+automation リポジトリの `.takt/runs/`（review-takt-default 237 run、2026-06-17〜07-06）の
+全数解析で、fix → 再レビューの成績が定量化された:
+
+- **REJECT → 再レビューのペア 126 件中 91% が再 REJECT**
+- 再 REJECT のうち **前回指摘が未解消（persists）だったのは 14% のみ** — つまり fix は
+  指摘そのものはほぼ解消できている
+- 再 REJECT の **77% は「前回指摘と同じファイルへの新規指摘」** — fix が指摘行だけを
+  なぞって直し、同じファイル・同じ契約の周辺をレビュアーと同じ視点で監査していない
+
+構造的な非対称が原因: レビュアーは毎回「マージベースからの累積差分全体 + 関係箇所」を
+再走査するのに対し、現行の fix 工程は `review-summary.md` の指摘のみを入力に、指摘箇所だけを
+修正する。fix が生む新しい差分・summary に載らなかった個別レポートの WARNING / 改善提案が、
+次ラウンドの「新規指摘」として同じファイルから湧き続ける。fix 工程の入力と自己検査の範囲を
+レビュアーの走査範囲に揃えることで、1 回だけ許される再レビューの通過率を上げる。
+
+## Current state
+
+対象: `~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md`（229 行）。
+関連する現行記述:
+
+- **Step 4「fix（REJECT 時）」冒頭（L155-164）** — fix の入力が summary のみ:
+
+  ```markdown
+  ### 4. fix（REJECT 時）
+
+  `review-summary.md` の指摘事項に基づき、**worktree 内で直接コードを修正** する。
+
+  1. `review-summary.md` の全文を読む:
+
+  ```bash
+  RUN_SLUG=$(ls -t .takt/runs/ | head -1)
+  cat .takt/runs/${RUN_SLUG}/reports/*review-summary.md
+  ```
+  ```
+
+  実際の run の `reports/` には summary の他に 7 個別レポート
+  （`architecture-review.md` / `security-review.md` / `qa-review.md` / `testing-review.md` /
+  `ai-antipattern-review.md` / `pure-review.md` / `coding-review.md`）が存在するが、
+  現行手順はこれらを読まない。summary は 7 レポートを表 1 行ずつに圧縮したもので、
+  ブロッキングに至らなかった警告・改善提案の多くが落ちる。
+
+- **L172-188** — 根本原因分解の指針（「レビュー文面をなぞった表面的な修正で終わらせない」
+  「同型箇所を探す」等）は既にある。**足りないのは修正後の自己監査ゲート**で、現行手順は
+  修正 → commit → push → PR コメント → 即再レビューと進む。
+
+- **L198-218** — PR コメントのテンプレは「修正内容 / 根本原因・横展開 / 検証」の 3 見出しで、
+  **finding_id 単位の解消根拠表がない**。レビュアー側（takt builtin の review policy）は
+  persists / resolved の判定に「前回根拠 / 今回根拠（ファイル:行）」を要求するため、
+  fix 側が finding_id ごとの解消根拠を提示しないと resolved 判定を取りこぼしやすい。
+
+- **L222-229 Gotchas** — 「fix は 1 回のみ」「review ログは全文読まない（`tail -80`）。
+  `review-summary.md` だけ全文読んでよい」という制約がある。7 個別レポートは各数 KB の
+  Markdown であり、この token guard の趣旨（巨大 jsonl ログの抑制）とは別物。
+
+- **レビュアー側の走査範囲**（参考・変更対象外）: takt builtin の review policy は
+  「タスク開始時点（ベース）からの累積差分全体をレビューする。直前イテレーションの修正分だけを
+  対象にしない」と定めている。また automation リポジトリには
+  `.takt/facets/policies/pre-review-checklist.md`（提出前セルフ監査 8 項目 — 受入条件充足表 /
+  挙動⇔テスト 1:1 / 実経路テスト / 兄弟入口貫通 / ドキュメント突き合わせ / 失敗を成功に
+  見せない / 既存契約の退行禁止 / スコープ検査）が存在し、lite workflow の implement /
+  review step が使っている。fix 工程はこれを参照していない。
+
+dotfiles の規約: 日本語 Conventional Commits（例: `fix(skills): Codex 実行時の完了検知をブロッキング待機に統一`）。テストスイート・CI ゲートなし。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Drift check | `cd ~/01-dev/dotfiles && git diff --stat 9a030ff..HEAD -- config/.claude/skills/takt-review/SKILL.md` | 差分なし、または抜粋と一致 |
+| 構造検証 | `rg -c '解消根拠' config/.claude/skills/takt-review/SKILL.md` | 1 以上 |
+| YAML frontmatter 検証 | `python3 -c "import yaml,pathlib; t=pathlib.Path('config/.claude/skills/takt-review/SKILL.md').read_text(); yaml.safe_load(t.split('---')[1])"` | エラーなし |
+
+## Scope
+
+**In scope**:
+- `~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` のみ
+
+**Out of scope**（触らない）:
+- takt 本体・builtin workflow / policy（`~/.bun/install/cache/takt@*` 配下）— 読み取り参照のみ
+- automation リポジトリの `.takt/` 配下（`pre-review-checklist.md` を含む）— fix 工程から
+  「存在すれば読む」参照先であり、本プランでは変更しない
+- 「fix は 1 回のみ」のループ上限 — 変更しない（上限緩和はトークンコストと停止性の
+  トレードオフでユーザー判断事項。本プランは 1 回の fix の質を上げる）
+- takt-issue / issue / to-issues スキル（Plan 018 の担当）
+
+## Git workflow
+
+- リポジトリ: `~/01-dev/dotfiles`（ブランチを切る場合は `feat/takt-review-fix-self-audit`）
+- コミット例: `feat(skills): takt-review の fix に累積差分の自己監査と解消根拠表を追加`
+- push / PR はオペレーターの指示がない限り行わない
+
+## Steps
+
+### Step 1: fix の入力を 7 個別レポートまで拡張する
+
+Step 4 の手順 1（L159-164 付近）を次の形に置き換える:
+
+```markdown
+1. `review-summary.md` の全文と、7 個別レポートの指摘部分を読む:
+
+```bash
+RUN_SLUG=$(ls -t .takt/runs/ | head -1)
+cat .takt/runs/${RUN_SLUG}/reports/review-summary.md
+# 個別レポート（各数 KB の Markdown。jsonl ログとは別物なので全文読んでよい）
+cat .takt/runs/${RUN_SLUG}/reports/{architecture,security,qa,testing,ai-antipattern,pure,coding}-review.md
+```
+
+summary の指摘（new / persists）に加えて、個別レポートから次の 2 種を拾い、fix 対象リストに含める:
+
+- **今回修正するファイルと同じファイルへの警告・非ブロッキング指摘** — 次ラウンドで
+  新規指摘に昇格しやすい（実測: 再 REJECT の 77% が前回と同じファイルへの新規指摘）
+- **改善提案のうち PR スコープ内で数分で対応できるもの** — スコープ外のものは対応せず、
+  PR コメントで「対応しない理由」を 1 行ずつ明記する
+```
+
+ファイル名 glob は実際の reports/ の命名（`architecture-review.md` 等）に合わせること。
+存在しないレポートがあっても続行してよい（`cat` の個別失敗は無視）。
+
+**Verify**: `rg -n 'ai-antipattern,pure,coding' ~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` → 1 箇所ヒット
+
+### Step 2: 修正後・再レビュー前の自己監査ゲートを追加する
+
+Step 4 の手順 2（修正の実行）と手順 3（コミット・push）の間に、新しい手順を挿入する:
+
+```markdown
+3. **自己監査（再レビュー前ゲート）**: レビュアーは「マージベースからの累積差分全体 +
+   関係箇所」を毎回再走査する。fix した行だけでなく、自分の fix を含めた累積差分全体を
+   レビュアーと同じ視点で監査してから再レビューに出す:
+
+   ```bash
+   # レビュアーが見るのと同じ差分を取る
+   git diff $(git merge-base origin/main HEAD)..HEAD
+   ```
+
+   - リポジトリに `.takt/facets/policies/pre-review-checklist.md` が存在する場合は、
+     その監査 8 項目（挙動⇔テスト 1:1、兄弟入口の貫通、ドキュメント突き合わせ等）を
+     累積差分全体に対して照合する。存在しないリポジトリでは次の最低限 4 点を照合する:
+     1. 変更した観測可能な挙動それぞれに対応するテストがあるか
+     2. 変更した契約（データ形式・config キー・API）が同責務の全入口に貫通しているか
+     3. 変更内容と矛盾するドキュメント・コメント・CHANGELOG の旧記述が残っていないか
+     4. fix で追加した catch / fallback が失敗を握りつぶしていないか
+   - fix によって未使用になったコード（import・引数・変数）が残っていないか累積差分を確認する
+   - リポジトリのテスト・lint を全実行して green を確認する（コマンドはリポジトリの
+     CLAUDE.md / package.json / pyproject.toml から特定する）
+   - 自己監査で見つけた問題は、この時点で fix に含める（再レビュー後に直す機会はない）
+```
+
+以降の手順番号（コミット・push が 4、PR コメントが 5）を振り直す。
+
+**Verify**: `rg -n '自己監査（再レビュー前ゲート）' ~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` → 1 箇所ヒット
+
+### Step 3: PR コメントに finding_id 単位の解消根拠表を追加する
+
+PR コメントのテンプレ（現行 L201-217 の heredoc）を次の形に置き換える:
+
+```markdown
+```bash
+gh pr comment "${PR_NUM}" --body "$(cat <<COMMENT
+## 🔧 fix
+
+### 指摘ごとの解消根拠
+| finding_id | 原因 | 修正（ファイル:行 / commit） | 検証 |
+|---|---|---|---|
+| SUM-NEW-... | (根本原因 1 文) | \`path/to/file.ts:42\` | (追加・更新したテスト名 or 実行した確認) |
+
+### 個別レポートの警告・改善提案への対応
+- 対応済み: (同一ファイルの警告で fix に含めたもの)
+- 対応しない: (改善提案のうちスコープ外としたもの — 理由を 1 行ずつ)
+
+### 自己監査
+- 累積差分（merge-base 起点）に対するチェックリスト照合: (結果)
+- test / lint: (実行コマンドと結果)
+
+再レビューを 1 回だけ実行します。
+COMMENT
+)"
+```
+```
+
+狙い: レビュアー側の resolved / persists 判定は finding_id と「今回根拠（ファイル:行）」の
+突き合わせで行われるため、fix 側が同じ形式で解消根拠を提示すると resolved 判定を
+取りこぼしにくくなる。**表の finding_id は review-summary.md の表記をそのまま使うこと**
+（`SUM-NEW-*` / `ARCH-*` / `PURE-*` などレビューごとに形式が異なるが、変換しない）。
+
+**Verify**: `rg -n '指摘ごとの解消根拠' ~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` → 1 箇所ヒット
+
+### Step 4: Gotchas の token guard を実態に合わせて修正する
+
+Gotchas の「**review ログは全文読まない**: `tail -80` で末尾のみ。`review-summary.md` だけ
+全文読んでよい」の行を次に置き換える:
+
+```markdown
+- **review ログ（jsonl / trace.md）は全文読まない**: `tail -80` で末尾のみ。
+  `reports/` 配下の Markdown（summary + 7 個別レポート）は各数 KB なので全文読んでよい
+```
+
+**Verify**: `rg -n 'summary \+ 7 個別レポート' ~/01-dev/dotfiles/config/.claude/skills/takt-review/SKILL.md` → 1 箇所ヒット
+
+### Step 5: 整合確認とコミット
+
+SKILL.md 全体を読み直し、手順番号の連番（Step 4 内の 1〜5）と、Step 3「判定 → fix」の
+フロー図・Gotchas の記述が新手順と矛盾していないことを確認する。frontmatter の
+`description:` は変更していないこと（発動条件を変えない）。
+
+**Verify**:
+- `python3 -c "import yaml,pathlib; t=pathlib.Path('config/.claude/skills/takt-review/SKILL.md').read_text(); yaml.safe_load(t.split('---')[1])"` → エラーなし
+- `cd ~/01-dev/dotfiles && git status --short` → `config/.claude/skills/takt-review/SKILL.md` のみ変更
+
+## Test plan
+
+プロンプト資産のためテストスイートはない。各 Step の rg / python 検証が構造チェックを担う。
+実地検証（推奨・本プランの完了条件には含めない）: 次に REJECT が出た PR で本スキルを起動し、
+(1) fix 前に 7 個別レポートが読まれる、(2) 再レビュー前に累積差分の自己監査が走る、
+(3) PR コメントに解消根拠表が載る、の 3 点を観測する。効果測定は
+`.takt/runs/` の再レビュー verdict（本プラン適用後の fix → 再レビュー通過率が実測 9% から
+改善するか）で行う。
+
+## Done criteria
+
+- [ ] `rg -c 'ai-antipattern,pure,coding' config/.claude/skills/takt-review/SKILL.md` = 1
+- [ ] `rg -c '自己監査（再レビュー前ゲート）' config/.claude/skills/takt-review/SKILL.md` = 1
+- [ ] `rg -c '指摘ごとの解消根拠' config/.claude/skills/takt-review/SKILL.md` = 1
+- [ ] `rg -c 'summary \+ 7 個別レポート' config/.claude/skills/takt-review/SKILL.md` = 1
+- [ ] frontmatter が有効な YAML のまま（Step 5 の python 検証が exit 0）
+- [ ] 「fix は 1 回のみ」の記述が Step 3 / Gotchas に残っている（ループ上限は不変）:
+      `rg -c 'fix は 1 回のみ' config/.claude/skills/takt-review/SKILL.md` ≥ 2
+- [ ] `git status --short` で対象 1 ファイル以外に変更がない
+- [ ] automation リポジトリの `plans/README.md` の 019 行を DONE に更新
+
+## STOP conditions
+
+以下の場合は停止して報告する:
+
+- Drift check で Step 4（fix）節の現行文面が Current state の抜粋と一致しない
+  （スキルが既に改訂されている）
+- `~/.claude/skills/takt-review` が symlink ではなく実体ディレクトリになっている
+- 変更の過程で「fix ループを複数回にする」「takt の builtin workflow を変える」必要が
+  あると判断した場合（どちらも本プランのスコープ外 — ユーザー判断事項として報告する)
+
+## Maintenance notes
+
+- 本プランは「1 回の fix の質」を上げる施策。適用後 10〜20 件の fix → 再レビューで
+  通過率（実測ベースライン 9%）が改善しなければ、次の一手は fix 側ではなく
+  レビューの verdict 設計（重大度閾値）かループ上限の見直しで、それはユーザー判断事項
+- automation リポジトリの `.takt/facets/policies/pre-review-checklist.md` の 8 項目が
+  改訂されたら、Step 2 で挿入した fallback 4 点との乖離を確認すること
+- レビュー時の注視点: Step 4 内の手順番号の振り直し漏れ、heredoc 内のバッククォート
+  エスケープ（`\``）の崩れ

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,6 +4,39 @@
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
+## 第 3 回監査（takt リジェクト多発の原因調査、2026-07-06、基準 commit `bf68c73d` / dotfiles `9a030ff`）
+
+調査テーマ: review-takt-default の REJECT 多発（`.takt/runs/` 239 run・指摘 676 件の全数解析）。
+主要結果 — (1) REJECT 率 91%（171/187）は 7 観点ゼロトレランス全員一致ゲートの数理的帰結
+（各観点の個別 REJECT 率 27〜41% → 通過率 ≈9%）で品質シグナルではない。(2) fix → 再レビュー
+126 ペアの 91% が再 REJECT だが、前回指摘未解消（persists）は 14% のみで、77% は「同じファイル
+への新規指摘」＝ fix がレビュアーの走査範囲（累積差分全体）を自己監査していない。(3) issue 品質が
+効く指摘は全体の ~11%、CI ツーリング不足は ~3% のみ。(4) 上流対策（#1508 チェックリスト・
+強化 plan 指示）は 2026-07-03〜05 投入でクリーンな効果測定サンプル 0 件。
+
+**注意: 018 / 019 の変更対象は dotfiles リポジトリ（`~/01-dev/dotfiles/config/.claude/skills/`）**。
+プランファイルだけが本リポジトリにある。
+
+### Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
+|------|-------|----------|--------|------------|-------|-----|--------|
+| 019 | takt-review の fix を累積差分の自己監査 + finding_id 解消根拠表つきに再設計 | P1 | M | — | — | — | DONE（executor worktree `scratchpad/wt-019`・branch `feat/takt-review-fix-self-audit`・commit `874d28b`。レビュー済み・未マージ） |
+| 018 | issue / to-issues / takt-issue テンプレに「兄弟入口・貫通先」列挙を必須化 | P2 | S | — | — | — | DONE（executor worktree `scratchpad/wt-018`・branch `feat/issue-sibling-entrypoints`・commit `cf6a598`。レビュー済み・未マージ） |
+
+### Findings considered and rejected（再監査不要）
+
+- **「issue の内容が悪いから REJECT される」説**: 主因ではない。要求解釈系の指摘は 676 件中 75 件（11%）。issue 本文の長さ・テンプレ準拠と REJECT 回数に相関なし（2,105 字・影響ファイル記載ありの #1141 でも 14 REJECT）。
+- **「CI / lint ツーリング不足」説**: 機械捕捉可能クラス（未使用コード・依存脆弱性・型）は指摘の ~3%。knip / oxlint / tests は機能している。
+- **「/issue・/to-issues に受入条件・スコープ外が無い」**: 2026-07-05 のスキル改訂で導入済み（takt-issue の preflight 正規化も同日導入済み）。残ギャップは「兄弟入口・貫通先」の観点のみ → Plan 018。
+- **takt 本体（builtin review policy のゼロトレランス設計・7 観点一致）の変更**: ユーザー前提により対象外（takt は据え置き）。
+
+### 監査で plan 化を見送った残課題
+
+- **効果測定基盤**（`.takt/runs` から verdict / persists / High 件数 / 欠陥クラス別の自動集計を常設し、#1508 チェックリストと本監査 018/019 の効果を 20〜30 run で判定）— 提案済み・ユーザー未選択
+- **自己申告ゲートの機械化**（変更行カバレッジゲート、config キーの定義⇔loader⇔使用の貫通チェック CLI）— 指摘最頻 2 クラスの CI 昇格。効果測定の結果を見てから判断
+- **運用指標の変更**（REJECT 数ではなく persists 数 + High 件数を見る）— ドキュメント化のみの小変更だが docs/takt-operations.md の改訂はユーザー確認待ち
+
 ## 第 2 回監査（スキル全般の Sonnet-safe 化、2026-07-05、基準 commit `8deb3f02`）
 
 監査テーマ: `.claude/skills/` 全 47 スキルを「Sonnet 級のより弱いモデルが実行しても作者の期待とズレなく解釈できるか」の観点で監査（TRIGGER / AMBIG / DRIFT / ROBUST の 4 ディメンション、並列 4 subagent + 全 findings を advisor が実読 vet）。42 件の生 findings から 12 件を有効と判定し、規約 1 本 + 個別修正 12 本に plan 化した。


### PR DESCRIPTION
## What

takt の REJECT 多発について `.takt/runs/` 239 run・レビュー指摘 676 件を全数解析した第 3 回監査の記録を `plans/` に追加する。

- `plans/README.md` — 第 3 回監査セクション(調査サマリー、実行順・ステータス表、棄却した仮説、見送り課題)
- `plans/018-issue-sibling-entrypoint-enumeration.md` — issue / to-issues / takt-issue テンプレに「兄弟入口・貫通先」列挙を必須化するプラン
- `plans/019-takt-review-fix-self-audit.md` — takt-review の fix を「累積差分の自己監査 + finding_id 解消根拠表」つきに再設計するプラン

## Why

調査の主要結果:

- REJECT 率 91%(171/187)は 7 観点ゼロトレランス全員一致ゲートの数理的帰結(各観点の個別 REJECT 率 27〜41% → 通過率 ≈9%)で、品質シグナルではない
- fix → 再レビュー 126 ペアの 91% が再 REJECT。ただし前回指摘未解消(persists)は 14% のみで、77% は「同一ファイルへの新規指摘」= fix の走査範囲(指摘行のみ)とレビュアーの走査範囲(累積差分全体)の非対称が原因
- issue 品質が効く指摘は全体の ~11%、CI ツーリング不足は ~3%

## Reviewer notes

- 両プランの変更対象は dotfiles リポジトリ(`~/01-dev/dotfiles/config/.claude/skills/`)で、**実行・レビュー・マージ済み**(dotfiles `71d453f` / `3dbd88e`)。本 PR はその調査記録とプラン文書のみで、このリポジトリの実コードには触れない
- plans/ のみの変更のため CHANGELOG ゲート対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)