### PR TITLE
fix(suno-helper): 日本語UIの曲名欄を検出する

### DIFF
--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -20,8 +20,8 @@ const SELECTORS = {
   // 「Lyrics 以外の可視 textarea」述語だけでは Style の特定根拠が弱くなったため一次識別にする。
   stylesWrapper: '[data-testid="create-form-styles-wrapper"]',
   // Song Title 欄は testid/aria/label を持たず placeholder のみ安定 (#844 実 DOM 検証)。
-  // 表記変更 ((Optional) の有無等) に耐えるよう "Song Title" の弱い case-insensitive substring match。
-  title: 'input[placeholder*="Song Title" i]',
+  // 英語 UI は "Song Title (Optional)"、日本語 UI は "曲名(任意)"（2026-07 実 DOM）で出る。
+  title: 'input[placeholder*="Song Title" i], input[placeholder*="曲名"]',
   // Custom Mode > More Options の 3 フィールド (#900、chrome-devtools-mcp で実機確定済み)。
   //   - Exclude styles: native text input/textarea (placeholder / aria-label の表記ゆれを許容)
   //   - Weirdness / Style Influence: radix slider ([role="slider"] + aria-label で区別)

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -529,7 +529,7 @@ describe("resolveFields: Song Title 欄の解決 (#844, fail-soft)", () => {
     expect(fields.title).toBe(title);
   });
 
-  it.each(["Song Title (Optional)", "song title", "SONG TITLE", "Enter Song Title here"])(
+  it.each(["Song Title (Optional)", "song title", "SONG TITLE", "Enter Song Title here", "曲名(任意)"])(
     "Given placeholder '%s' When 解決する Then 弱い case-insensitive substring match で title に解決する",
     (placeholder) => {
       // (Optional) を含めない弱マッチ + i フラグ（order.md: Suno の表記変更耐性）。


### PR DESCRIPTION
## Summary
- Suno 日本語 UI の Song Title 欄 `placeholder="曲名(任意)"` を検出対象に追加
- 英語 UI の `Song Title` 検出は維持
- 実 Suno DOM で日本語 UI の生成ボタンと曲名欄を確認

## Root Cause
日本語 UI では生成ボタンは `作成`、曲名欄は `曲名(任意)` として表示される。前 PR で生成ボタンは対応したが、曲名欄 selector は `Song Title` のみだったため、title 注入が fail-soft でスキップされる状態だった。

## Actual DOM
- `htmlLang`: `ja`
- Generate button: text `作成`, aria-label `曲を作成`
- Title input: placeholder `曲名(任意)`
- Lyrics textarea: `data-testid="lyrics-textarea"`
- Style textarea wrapper: `data-testid="create-form-styles-wrapper"`

## Validation
- `pnpm --filter suno-helper exec vitest run tests/dom.test.ts`
- `pnpm --filter suno-helper exec playwright test tests/e2e/suno-inject.spec.ts`
- `SUNO_HELPER_TEST_BUILD=1 pnpm --filter suno-helper zip`