### PR TITLE
chore(suno-helper): ext-v0.2.2

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

suno-helper Chrome extension release PR.

- Bump `extensions/suno-helper/package.json` from `0.2.1` to `0.2.2`
- Local verification: `pnpm@9.15.9 -C extensions/suno-helper build` and `pnpm@9.15.9 -C extensions/suno-helper zip`

## Next steps

1. Merge this PR into `main`
2. Push tag `ext-v0.2.2`
3. `.github/workflows/release-extensions.yml` attaches the helper zips to the GitHub Release