### PR TITLE
fix: distrokid-helper の実DOM注入を修正

### DIFF
--- a/extensions/distrokid-helper/components/ServerUrlField.tsx
+++ b/extensions/distrokid-helper/components/ServerUrlField.tsx
@@ -20,6 +20,7 @@ export function ServerUrlField({ value, sources, disabled, onChange, onFetch }: 
         className="rounded border border-gray-300 px-2 py-1 text-sm"
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
       >
         {sources.map((source) => (
           <option key={source.url} value={source.url}>

--- a/extensions/distrokid-helper/entrypoints/popup/App.tsx
+++ b/extensions/distrokid-helper/entrypoints/popup/App.tsx
@@ -26,7 +26,7 @@ export function App() {
 
   return (
     <main className="flex flex-col gap-3 p-4">
-      <h1 className="text-base font-bold text-gray-900">DistroKid Helper</h1>
+      <h1 className="text-base font-bold text-gray-900">DistroKid Helper (TEST)</h1>
 
       <ServerUrlField
         value={serverUrl}

--- a/extensions/distrokid-helper/entrypoints/popup/index.html
+++ b/extensions/distrokid-helper/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DistroKid Helper</title>
+    <title>DistroKid Helper (TEST)</title>
   </head>
   <body>
     <div id="root"></div>

--- a/extensions/distrokid-helper/lib/distrokid-injector.ts
+++ b/extensions/distrokid-helper/lib/distrokid-injector.ts
@@ -37,11 +37,12 @@ export const PROFILE_SELECTORS = {
   artist: 'input[name="bandname"]',
   language: "#language",
   main_genre: "#genrePrimary",
-  sub_genre: "#genreSecondary",
+  sub_genre: "#subGenrePrimary",
 } as const;
 
-// main genre 変更後、DistroKid が secondary genre の option を再生成するまでの待ち上限（ms）（#1407）。
+// main genre 変更後、DistroKid が primary subgenre の option を再生成するまでの待ち上限（ms）（#1407）。
 const GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS = 10_000;
+const GENRE_SECONDARY_EXISTING_OPTION_FALLBACK_MS = 50;
 
 // アルバム名（アルバム時のみ存在。シングルモードでは要素不在 → skip）。
 export const ALBUM_SELECTORS = {
@@ -307,6 +308,14 @@ function findExactSelectOptionIndex(el: HTMLSelectElement, payloadValue: string)
   return idx;
 }
 
+function selectSelectedOptionMatches(el: HTMLSelectElement, payloadValue: string): boolean {
+  const selected = el.options[el.selectedIndex];
+  if (selected === undefined) {
+    return false;
+  }
+  return selected.value === payloadValue || normalizeOptionText(selected.text) === normalizeOptionText(payloadValue);
+}
+
 // <select> に対して payload 値で option を選ぶ。
 function setSelectValue(el: HTMLSelectElement, payloadValue: string): void {
   const idx = findSelectOptionIndex(el, payloadValue);
@@ -365,19 +374,19 @@ function mutationTouchesSelector(mutation: MutationRecord, selector: string, cur
 }
 
 // 依存 dropdown の option 再生成を待つ（#1407）。
-// #genrePrimary の change 後、#genreSecondary は非同期に populate されるため、
+// #genrePrimary の change 後、#subGenrePrimary は非同期に populate されるため、
 // payload と一致する option が現れてから setNativeValue する。
 function waitForSelectOption(
   root: ParentNode,
   selector: string,
   payloadValue: string,
   timeoutMs: number,
-  options: { requireSelectorMutation?: boolean } = {},
+  options: { allowExistingAfterQuietMs?: number; requireSelectorMutation?: boolean } = {},
 ): Promise<HTMLSelectElement> {
-  const initial = requireVisibleField(root, selector);
-  if (!(initial instanceof HTMLSelectElement)) {
-    throw new FieldNotFoundError(selector);
-  }
+  const currentSelect = (): HTMLSelectElement | null => {
+    const current = findVisibleField(root, selector);
+    return current instanceof HTMLSelectElement ? current : null;
+  };
   if (options.requireSelectorMutation !== true) {
     const existing = findVisibleSelectWithOption(root, selector, payloadValue);
     if (existing !== null) {
@@ -386,27 +395,48 @@ function waitForSelectOption(
   }
   const observeRoot = ownerDocumentOf(root).body ?? ownerDocumentOf(root);
   return new Promise((resolve, reject) => {
+    let quietTimer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (select: HTMLSelectElement) => {
+      clearTimeout(timer);
+      if (quietTimer !== undefined) {
+        clearTimeout(quietTimer);
+      }
+      observer.disconnect();
+      resolve(select);
+    };
     const timer = setTimeout(() => {
       observer.disconnect();
-      const current = findVisibleField(root, selector);
-      const options = current instanceof HTMLSelectElement ? selectOptionLabels(current) : [];
-      reject(new OptionNotFoundError(selector, payloadValue, options));
+      if (quietTimer !== undefined) {
+        clearTimeout(quietTimer);
+      }
+      const current = currentSelect();
+      if (current === null) {
+        reject(new FieldNotFoundError(selector));
+        return;
+      }
+      reject(new OptionNotFoundError(selector, payloadValue, selectOptionLabels(current)));
     }, timeoutMs);
     const observer = new MutationObserver((mutations) => {
       if (
         options.requireSelectorMutation === true &&
-        !mutations.some((mutation) => mutationTouchesSelector(mutation, selector, findVisibleField(root, selector)))
+        !mutations.some((mutation) => mutationTouchesSelector(mutation, selector, currentSelect()))
       ) {
         return;
       }
       const found = findVisibleSelectWithOption(root, selector, payloadValue);
       if (found !== null) {
-        clearTimeout(timer);
-        observer.disconnect();
-        resolve(found);
+        finish(found);
       }
     });
     observer.observe(observeRoot, { childList: true, subtree: true, characterData: true, attributes: true });
+    if (options.allowExistingAfterQuietMs !== undefined) {
+      quietTimer = setTimeout(() => {
+        const existing = findVisibleSelectWithOption(root, selector, payloadValue);
+        if (existing !== null) {
+          finish(existing);
+        }
+      }, options.allowExistingAfterQuietMs);
+    }
   });
 }
 
@@ -416,14 +446,20 @@ export async function injectProfile(root: ParentNode, profile: DistrokidProfile)
     setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.artist), profile.artist.trim());
   }
   setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.language), profile.language);
-  setNativeValue(requireVisibleField(root, PROFILE_SELECTORS.main_genre), profile.main_genre);
+  const mainGenre = requireVisibleField(root, PROFILE_SELECTORS.main_genre);
+  const mainGenreAlreadySelected =
+    mainGenre instanceof HTMLSelectElement && selectSelectedOptionMatches(mainGenre, profile.main_genre);
+  setNativeValue(mainGenre, profile.main_genre);
   if (profile.sub_genre !== null) {
     const subGenre = await waitForSelectOption(
       root,
       PROFILE_SELECTORS.sub_genre,
       profile.sub_genre,
       GENRE_SECONDARY_OPTION_WAIT_TIMEOUT_MS,
-      { requireSelectorMutation: true },
+      {
+        allowExistingAfterQuietMs: mainGenreAlreadySelected ? GENRE_SECONDARY_EXISTING_OPTION_FALLBACK_MS : undefined,
+        requireSelectorMutation: true,
+      },
     );
     setNativeValue(subGenre, profile.sub_genre);
   }
@@ -472,6 +508,11 @@ const IMPORTANT_TERMS_REQUIRED_IDS = [
   "#areyousuretandc",
 ] as const;
 
+const IMPORTANT_TERMS_OPTIONAL_DIRECT_IDS = [
+  // Non-standard capitalization warning appears asynchronously after DistroKid validates title fields.
+  "#areyousurenonstandardscaps",
+] as const;
+
 // 条件付き重要事項 checkbox のセレクタ（ストア選択に連動して可視化）（#923）。
 const IMPORTANT_TERMS_CONDITIONAL_SELECTOR = 'input[type="checkbox"].areyousure';
 
@@ -484,8 +525,16 @@ export function acceptImportantTerms(root: ParentNode): void {
   for (const id of IMPORTANT_TERMS_REQUIRED_IDS) {
     setChecked(requireInput(root, id), true);
   }
+  for (const id of IMPORTANT_TERMS_OPTIONAL_DIRECT_IDS) {
+    const cb = root.querySelector<HTMLInputElement>(id);
+    if (cb !== null) {
+      setChecked(cb, true);
+    }
+  }
   // conditional: .areyousure を列挙し、required id を除外した上で可視のもののみ check
-  const requiredIds = new Set(IMPORTANT_TERMS_REQUIRED_IDS.map((id) => id.slice(1)));
+  const requiredIds = new Set(
+    [...IMPORTANT_TERMS_REQUIRED_IDS, ...IMPORTANT_TERMS_OPTIONAL_DIRECT_IDS].map((id) => id.slice(1)),
+  );
   const conditionals = Array.from(root.querySelectorAll<HTMLInputElement>(IMPORTANT_TERMS_CONDITIONAL_SELECTOR)).filter(
     (cb) => !requiredIds.has(cb.id) && isVisible(cb),
   );

--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -2,7 +2,7 @@
   "name": "distrokid-helper",
   "description": "DistroKid 登録フォーム自動入力 Chrome 拡張 (WXT + React)",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/extensions/distrokid-helper/tests/content-injector.test.ts
+++ b/extensions/distrokid-helper/tests/content-injector.test.ts
@@ -89,7 +89,7 @@ function mountStaticForm(trackCount: number, fallbackArtist: string): void {
   mountInput({ name: "bandname" });
   mountSelect("language", ["English", "Japanese"]);
   mountSelect("genrePrimary", ["Electronic", "Jazz"]);
-  mountSelect("genreSecondary", ["Ambient", "House"]);
+  mountSelect("subGenrePrimary", ["Ambient", "House"]);
   mountInput({ id: "albumTitleInput" });
   mountInput({ id: "release-date-dp", type: "date" });
   mountInput({ id: "artistName", type: "hidden", value: fallbackArtist });
@@ -116,7 +116,7 @@ function mountStaticForm(trackCount: number, fallbackArtist: string): void {
 
 function wireGenreSecondaryPopulate(options: ReadonlyArray<{ value: string; text: string }>): void {
   const genre = document.querySelector<HTMLSelectElement>("#genrePrimary")!;
-  const subGenre = document.querySelector<HTMLSelectElement>("#genreSecondary")!;
+  const subGenre = document.querySelector<HTMLSelectElement>("#subGenrePrimary")!;
   genre.addEventListener("change", () => {
     setTimeout(() => {
       subGenre.innerHTML = "";
@@ -170,7 +170,7 @@ describe("createDocumentInjector", () => {
   it("injectStaticFields が main_genre change 後の非同期 sub_genre populate を待ってから後続注入する", async () => {
     // Given
     mountStaticForm(1, "Soulful Grooves");
-    const subGenre = document.querySelector<HTMLSelectElement>("#genreSecondary")!;
+    const subGenre = document.querySelector<HTMLSelectElement>("#subGenrePrimary")!;
     subGenre.innerHTML = "";
     const staleOption = document.createElement("option");
     staleOption.value = "old-ambient";

--- a/extensions/distrokid-helper/tests/distrokid-injector.test.ts
+++ b/extensions/distrokid-helper/tests/distrokid-injector.test.ts
@@ -357,7 +357,7 @@ describe("PROFILE_SELECTORS（id ベース・実 DOM 検証）", () => {
     expect(PROFILE_SELECTORS.artist).toBe('input[name="bandname"]');
     expect(PROFILE_SELECTORS.language).toBe("#language");
     expect(PROFILE_SELECTORS.main_genre).toBe("#genrePrimary");
-    expect(PROFILE_SELECTORS.sub_genre).toBe("#genreSecondary");
+    expect(PROFILE_SELECTORS.sub_genre).toBe("#subGenrePrimary");
   });
 });
 
@@ -460,7 +460,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     const artist = mountInput({ name: "bandname" });
     const language = mountSelect("language", ["ja", "en"]);
     const genre = mountSelect("genrePrimary", ["Electronic", "Pop"]);
-    const sub = mountSelect("genreSecondary", ["House", "Techno"]);
+    const sub = mountSelect("subGenrePrimary", ["House", "Techno"]);
     genre.addEventListener("change", () => {
       setTimeout(() => {
         sub.innerHTML = "";
@@ -483,12 +483,12 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     expect(sub.value).toBe("House");
   });
 
-  it("sub_genre が null なら genreSecondary を触らない（skip）", async () => {
+  it("sub_genre が null なら subGenrePrimary を触らない（skip）", async () => {
     // Given
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
     mountSelect("genrePrimary", ["Electronic"]);
-    const sub = mountSelect("genreSecondary", ["House", "Techno"]);
+    const sub = mountSelect("subGenrePrimary", ["House", "Techno"]);
     let subChanges = 0;
     sub.addEventListener("change", () => {
       subChanges += 1;
@@ -548,7 +548,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
     const genre = mountSelect("genrePrimary", ["エレクトロニック", "ポップ"]);
-    const sub = mountSelectWithOptions("genreSecondary", [{ value: "", text: "サブジャンルを選択" }]);
+    const sub = mountSelectWithOptions("subGenrePrimary", [{ value: "", text: "サブジャンルを選択" }]);
     genre.addEventListener("change", () => {
       setTimeout(() => {
         for (const text of ["ハウス", "テクノ", "トランス"]) {
@@ -572,12 +572,63 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     expect(sub.value).toBe("テクノ");
   });
 
+  it("main_genre の change 後に sub_genre select 自体が mount される場合も待って選択する", async () => {
+    // Given: DistroKid 実機ではサブジャンル select が main genre 選択後に遅れて mount される場合がある。
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    const genre = mountSelect("genrePrimary", ["エレクトロニック", "ポップ"]);
+    genre.addEventListener("change", () => {
+      setTimeout(() => {
+        mountSelectWithOptions("subGenrePrimary", [
+          { value: "", text: "サブジャンルを選択" },
+          { value: "53", text: "テクノ" },
+        ]);
+      }, 0);
+    });
+
+    // When
+    await injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+
+    // Then
+    expect(document.querySelector<HTMLSelectElement>("#subGenrePrimary")!.value).toBe("53");
+  });
+
+  it("main_genre が既に一致している場合は populate 済み sub_genre option をそのまま選択する", async () => {
+    // Given: 実機で再実行した状態。main genre と subgenre options は既に選択可能。
+    mountInput({ name: "bandname" });
+    mountSelect("language", ["ja"]);
+    mountSelectWithOptions("genrePrimary", [
+      { value: "", text: "ジャンルを選択" },
+      { value: "9", text: "エレクトロニック" },
+    ]).value = "9";
+    const sub = mountSelectWithOptions("subGenrePrimary", [
+      { value: "", text: "サブジャンルを選択" },
+      { value: "53", text: "テクノ" },
+    ]);
+
+    // When
+    await injectProfile(document, {
+      ...SAMPLE_PROFILE,
+      language: "ja",
+      main_genre: "エレクトロニック",
+      sub_genre: "テクノ",
+    });
+
+    // Then
+    expect(sub.value).toBe("53");
+  });
+
   it("sub_genre option 待機は部分一致では resolve せず完全一致の option を待つ（#1407）", async () => {
     // Given
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
     const genre = mountSelect("genrePrimary", ["エレクトロニック"]);
-    const sub = mountSelectWithOptions("genreSecondary", [
+    const sub = mountSelectWithOptions("subGenrePrimary", [
       { value: "", text: "サブジャンルを選択" },
       { value: "hardcore-techno", text: "ハードコア／ハードテクノ" },
     ]);
@@ -607,7 +658,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
     const genre = mountSelect("genrePrimary", ["エレクトロニック"]);
-    const sub = mountSelectWithOptions("genreSecondary", [
+    const sub = mountSelectWithOptions("subGenrePrimary", [
       { value: "", text: "サブジャンルを選択" },
       { value: "old-techno", text: "テクノ" },
     ]);
@@ -644,7 +695,7 @@ describe("injectProfile（language/main_genre 必須・sub_genre 任意・isVisi
     mountInput({ name: "bandname" });
     mountSelect("language", ["ja"]);
     mountSelect("genrePrimary", ["エレクトロニック"]);
-    const sub = mountSelectWithOptions("genreSecondary", [
+    const sub = mountSelectWithOptions("subGenrePrimary", [
       { value: "", text: "サブジャンルを選択" },
       { value: "house", text: "ハウス" },
     ]);
@@ -1518,6 +1569,22 @@ describe("acceptImportantTerms（#923 重要事項 4 個 + 条件付き）", () 
     // Then: visible は check、hidden は skip
     expect(visibleCond.checked).toBe(true);
     expect(hiddenCond.checked).toBe(false);
+  });
+
+  it("non-standard caps warning は表示タイミングに依存せず存在すれば check する", () => {
+    // Given: DistroKid が title 検証後に追加する capitalization warning。
+    mountRequiredTerms();
+    const caps = document.createElement("input");
+    caps.type = "checkbox";
+    caps.id = "areyousurenonstandardscaps";
+    caps.className = "areyousure";
+    document.body.appendChild(caps);
+
+    // When
+    acceptImportantTerms(document);
+
+    // Then
+    expect(caps.checked).toBe(true);
   });
 
   it("required id のいずれかが不在なら FieldNotFoundError", () => {

--- a/extensions/distrokid-helper/wxt.config.ts
+++ b/extensions/distrokid-helper/wxt.config.ts
@@ -7,8 +7,11 @@ import { MANIFEST_HOST_PERMISSIONS, MANIFEST_PERMISSIONS } from "./lib/manifest"
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   manifest: {
-    name: "DistroKid Helper",
+    name: "DistroKid Helper (TEST)",
     description: "DistroKid 登録フォームに静的プロファイル + 動的データを自動入力する",
+    action: {
+      default_title: "DistroKid Helper (TEST)",
+    },
     // 最小権限。SSOT は lib/manifest.ts (tests/manifest.test.ts で機械担保)。
     permissions: [...MANIFEST_PERMISSIONS],
     host_permissions: [...MANIFEST_HOST_PERMISSIONS, ...SERVER_HOST_PERMISSIONS],

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -249,6 +249,8 @@ export const DEFAULT_SERVER_HOSTNAME = "youtube-automation.localhost" as const;
 export const LEGACY_DEFAULT_URL =
   `http://localhost:${DEFAULT_SERVER_PORT}` as const;
 
+const FALLBACK_LOCALHOST_PORTS = [7874, 7875, 7876, 7877] as const;
+
 /** ローカル配信元の既定 URL。 */
 export const DEFAULT_URL =
   `http://${DEFAULT_SERVER_HOSTNAME}:${DEFAULT_SERVER_PORT}` as const;
@@ -274,6 +276,11 @@ export const DEFAULT_SERVER_SOURCES: LocalServerSource[] = [
     label: "localhost fallback",
     url: LEGACY_DEFAULT_URL,
   },
+  ...FALLBACK_LOCALHOST_PORTS.map((port) => ({
+    id: `localhost-${port}`,
+    label: `localhost fallback ${port}`,
+    url: `http://localhost:${port}`,
+  })),
 ] as const satisfies LocalServerSource[];
 
 export function normalizeServerUrl(url: string): string {

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -44,10 +44,14 @@ describe("shared/constants: サーバー互換の契約値", () => {
     expect(DEFAULT_URL).toBe("http://youtube-automation.localhost:7873");
   });
 
-  it("Given server selector When 既定候補を読む Then チャンネル別 hostname と legacy localhost を持つ", () => {
+  it("Given server selector When 既定候補を読む Then チャンネル別 hostname と localhost fallback を持つ", () => {
     expect(DEFAULT_SERVER_SOURCES.map((source) => source.url)).toEqual([
       "http://youtube-automation.localhost:7873",
       "http://localhost:7873",
+      "http://localhost:7874",
+      "http://localhost:7875",
+      "http://localhost:7876",
+      "http://localhost:7877",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Fix DistroKid helper genre injection to use the real primary subgenre select (`#subGenrePrimary`) instead of the secondary genre select.
- Make subgenre injection wait for delayed select mounting/options and handle reruns when the genre is already selected.
- Add the non-standard capitalization confirmation checkbox to the required fill path.
- Mark the unpacked test build as `DistroKid Helper (TEST)` and bump extension version to `0.2.0`.
- Add localhost fallback server choices through port 7877 for local testing.

## Validation
- `pnpm test -- --runInBand` in `extensions/distrokid-helper`
- `pnpm compile` in `extensions/distrokid-helper`
- `pnpm build` in `extensions/distrokid-helper`
- Verified the live DistroKid DOM selectors via Chrome DevTools (`#subGenrePrimary`, `#areyousurenonstandardscaps`).
