### PR TITLE
chore(distrokid-helper): ext-v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(collection-serve)`: `yt-collection-serve` に unpacked Chrome 拡張名から exact origin lock を自動解決する `--allow-extension <name>` を追加（#1486）。macOS Chrome profile の `Secure Preferences`（無ければ `Preferences`）を走査し、`extensions.settings[*].path` が絶対パスかつ basename が指定名に一致する拡張 IDから `chrome-extension://<id>` を組み立て、既存の `/auth/token` / write endpoint lock にそのまま適用する。`--allow-origin` とは排他で、検出 0 件・複数 ID 競合・profile root 走査不可・Preferences 読み取り不可・Preferences JSON parse failure は `--allow-origin` fallback 案内付きの `ConfigError` で fail-loud する。`/suno-helper` / `/distrokid-helper` / `/wf-new` のサーバー起動手順と拡張 README も `--allow-extension` 基準へ更新した
 
+### Fixed
+
+- `fix(distrokid-helper)`: `ext-v0.2.3` リリース前に DistroKid Helper の manifest / popup 表示名へ残っていた `(TEST)` 接尾辞を外し、配布 zip が本番名 `DistroKid Helper` として表示されるようにした。
+
 ## [5.5.16] - 2026-07-06
 
 ### Added

--- a/extensions/distrokid-helper/entrypoints/popup/App.tsx
+++ b/extensions/distrokid-helper/entrypoints/popup/App.tsx
@@ -26,7 +26,7 @@ export function App() {
 
   return (
     <main className="flex flex-col gap-3 p-4">
-      <h1 className="text-base font-bold text-gray-900">DistroKid Helper (TEST)</h1>
+      <h1 className="text-base font-bold text-gray-900">DistroKid Helper</h1>
 
       <ServerUrlField
         value={serverUrl}

--- a/extensions/distrokid-helper/entrypoints/popup/index.html
+++ b/extensions/distrokid-helper/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DistroKid Helper (TEST)</title>
+    <title>DistroKid Helper</title>
   </head>
   <body>
     <div id="root"></div>

--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -2,7 +2,7 @@
   "name": "distrokid-helper",
   "description": "DistroKid 登録フォーム自動入力 Chrome 拡張 (WXT + React)",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/extensions/distrokid-helper/wxt.config.ts
+++ b/extensions/distrokid-helper/wxt.config.ts
@@ -7,10 +7,10 @@ import { MANIFEST_HOST_PERMISSIONS, MANIFEST_PERMISSIONS } from "./lib/manifest"
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   manifest: {
-    name: "DistroKid Helper (TEST)",
+    name: "DistroKid Helper",
     description: "DistroKid 登録フォームに静的プロファイル + 動的データを自動入力する",
     action: {
-      default_title: "DistroKid Helper (TEST)",
+      default_title: "DistroKid Helper",
     },
     // 最小権限。SSOT は lib/manifest.ts (tests/manifest.test.ts で機械担保)。
     permissions: [...MANIFEST_PERMISSIONS],


### PR DESCRIPTION
## Summary

DistroKid Helper Chrome extension release PR.

- Bump `extensions/distrokid-helper/package.json` from `0.2.0` to `0.2.1`
- Remove the `(TEST)` suffix from the DistroKid Helper manifest and popup display name before release
- Local verification:
  - `pnpm@9.15.9 -C extensions/distrokid-helper test`
  - `pnpm@9.15.9 -C extensions/distrokid-helper build`
  - `pnpm@9.15.9 -C extensions/distrokid-helper zip`

## Release notes preview

The release workflow will publish tag `ext-v0.2.3` after merge and attach both helper zips. Expected DistroKid asset: `distrokid-helper-0.2.1-chrome.zip`.

## Next steps

1. Merge this PR into `main`
2. Push tag `ext-v0.2.3`
3. `.github/workflows/release-extensions.yml` attaches the helper zips to the GitHub Release