### PR TITLE
fix(videoup): correct audio label when audio_visualizer overlay is disabled

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -687,7 +687,11 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
         CURRENT_LABEL="bg_av"
         AUDIO_LABEL="a_out"
     else
-        AUDIO_LABEL="1:a"
+        # av_enabled=false でも後段は常に -map "[${AUDIO_LABEL}]" とブラケットで
+        # 参照するため、生の入力ストリーム指定 "1:a" ではなく filter_complex の
+        # named label を経由させる。
+        FILTER+="[1:a]anull[a_pass];"
+        AUDIO_LABEL="a_pass"
     fi
 
     if [[ "$sp_enabled" == "true" ]]; then

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -687,11 +687,9 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
         CURRENT_LABEL="bg_av"
         AUDIO_LABEL="a_out"
     else
-        # av_enabled=false でも後段は常に -map "[${AUDIO_LABEL}]" とブラケットで
-        # 参照するため、生の入力ストリーム指定 "1:a" ではなく filter_complex の
-        # named label を経由させる。
-        FILTER+="[1:a]anull[a_pass];"
-        AUDIO_LABEL="a_pass"
+        # 音声をフィルタしない場合は生の入力ストリーム指定のまま保持する
+        # (後段で -map のブラケット有無を出し分け、-c:a copy を温存できる)。
+        AUDIO_LABEL="1:a"
     fi
 
     if [[ "$sp_enabled" == "true" ]]; then
@@ -708,10 +706,21 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
         AUDIO_LABEL="a_norm"
     fi
 
+    # 音声 map の出し分け:
+    #   - 生ストリーム指定 (1:a) → ブラケットなしで map し、-c:a copy を温存
+    #   - filter_complex のラベル → ブラケット付きで map。filtergraph 出力は
+    #     stream copy 不可 (ffmpeg が fatal error) のため再エンコードを強制
+    if [[ "$AUDIO_LABEL" == "1:a" ]]; then
+        AUDIO_MAP="1:a"
+    else
+        AUDIO_MAP="[${AUDIO_LABEL}]"
+        AUDIO_OUT_OPTS=(-c:a "$AUDIO_ENCODER" -b:a 384k -ar 48000)
+    fi
+
     # 末尾ラベル統一: 最終 video ラベルが CURRENT_LABEL
     ffmpeg -y "${INPUTS[@]}" \
         -filter_complex "$FILTER" \
-        -map "[${CURRENT_LABEL}]" -map "[${AUDIO_LABEL}]" \
+        -map "[${CURRENT_LABEL}]" -map "$AUDIO_MAP" \
         -c:v "$enc_codec" -preset "$enc_preset" -crf "$enc_crf" \
         -maxrate "$enc_maxrate" -bufsize "$enc_bufsize" \
         -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(distrokid-helper)`: `ext-v0.2.3` リリース前に DistroKid Helper の manifest / popup 表示名へ残っていた `(TEST)` 接尾辞を外し、配布 zip が本番名 `DistroKid Helper` として表示されるようにした。
-- `fix(videoup)`: `generate_videos.sh` の overlays 経路で `overlays.audio_visualizer.enabled` が false/未設定（`subscribe_popup` のみ有効等）のとき、`AUDIO_LABEL="1:a"`（生の入力ストリーム指定）がセットされるが最終 ffmpeg コマンドは常に `-map "[${AUDIO_LABEL}]"` とブラケットで囲むため `-map "[1:a]"` という無効な構文になり `Output with label '1:a' does not exist in any defined filter graph` で失敗するバグを修正。else 分岐でも `[1:a]anull[a_pass]` を filter_complex に追加し `AUDIO_LABEL="a_pass"` とすることで、`av_enabled` の真偽に関わらず常に有効な named label を経由するようにした。下流チャンネルリポジトリで実際に再現（`overlays.enabled=true` + `subscribe_popup.enabled=true` + `audio_visualizer` 未設定の組み合わせ）。
+- `fix(videoup)`: `generate_videos.sh` の overlays 経路で `overlays.audio_visualizer.enabled` が false/未設定（`subscribe_popup` のみ有効等）のとき、`AUDIO_LABEL="1:a"`（生の入力ストリーム指定）を最終 ffmpeg コマンドが常に `-map "[${AUDIO_LABEL}]"` とブラケットで囲むため `-map "[1:a]"` という無効な filtergraph ラベル参照になり `Output with label '1:a' does not exist in any defined filter graph` で失敗するバグを修正。音声 map を出し分ける方式とし、(1) 音声をフィルタしない場合は生ストリーム指定のままブラケットなしで `-map 1:a` する（m4a/aac マスターの `-c:a copy` を温存）、(2) 音声が filter_complex を通る場合（`audio_visualizer` 有効 or loudnorm 統合時）はブラケット付き map + 音声再エンコードを強制する。後者により、filtergraph 出力へ `-c:a copy` を要求して `Streamcopy requested for output stream fed from a complex filtergraph` で失敗する潜在バグ（`audio_visualizer` 有効 + m4a/aac マスターの組み合わせ）も解消。下流チャンネルリポジトリで実際に再現（`overlays.enabled=true` + `subscribe_popup.enabled=true` + `audio_visualizer` 未設定の組み合わせ）。
 
 ## [5.5.16] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(distrokid-helper)`: `ext-v0.2.3` リリース前に DistroKid Helper の manifest / popup 表示名へ残っていた `(TEST)` 接尾辞を外し、配布 zip が本番名 `DistroKid Helper` として表示されるようにした。
+- `fix(videoup)`: `generate_videos.sh` の overlays 経路で `overlays.audio_visualizer.enabled` が false/未設定（`subscribe_popup` のみ有効等）のとき、`AUDIO_LABEL="1:a"`（生の入力ストリーム指定）がセットされるが最終 ffmpeg コマンドは常に `-map "[${AUDIO_LABEL}]"` とブラケットで囲むため `-map "[1:a]"` という無効な構文になり `Output with label '1:a' does not exist in any defined filter graph` で失敗するバグを修正。else 分岐でも `[1:a]anull[a_pass]` を filter_complex に追加し `AUDIO_LABEL="a_pass"` とすることで、`av_enabled` の真偽に関わらず常に有効な named label を経由するようにした。下流チャンネルリポジトリで実際に再現（`overlays.enabled=true` + `subscribe_popup.enabled=true` + `audio_visualizer` 未設定の組み合わせ）。
 
 ## [5.5.16] - 2026-07-06
 


### PR DESCRIPTION
## 概要

`/videoup` の `generate_videos.sh` で、overlays 経路 (`overlays.enabled=true`) かつ `overlays.audio_visualizer.enabled` が false / 未設定（例: `subscribe_popup` のみ有効）のとき、音声マッピングが壊れて ffmpeg が失敗するバグを修正します。

下流チャンネルリポジトリで実際に踏んで判明しました（`overlays.enabled=true` + `audio_visualizer.enabled` 未設定 + `subscribe_popup.enabled=true` の組み合わせで実行 → ffmpeg が `Output with label '1:a' does not exist in any defined filter graph` で失敗）。

## 原因

`.claude/skills/videoup/references/generate_videos.sh` の `av_enabled` 分岐:

```bash
if [[ "$av_enabled" == "true" ]]; then
    ...
    AUDIO_LABEL="a_out"
else
    AUDIO_LABEL="1:a"   # ← 生の入力ストリーム指定
fi
```

しかし最終的な ffmpeg 呼び出しは `av_enabled` の値に関わらず常に

```bash
-map "[${CURRENT_LABEL}]" -map "[${AUDIO_LABEL}]"
```

とブラケットで囲むため、`av_enabled=false` のときは `-map "[1:a]"` という無効な構文になり、filter_complex 内に該当ラベルが存在せず失敗します。

## 変更内容

- else 分岐でも `[1:a]anull[a_pass];` を `FILTER` に追加し、`AUDIO_LABEL="a_pass"` とすることで、`av_enabled` の真偽に関わらず `AUDIO_LABEL` が常に filter_complex 上の有効な named label になるようにしました
- `CHANGELOG.md::[Unreleased] > Fixed` にエントリを追加

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [ ] Migration セクション: 下流チャンネルリポジトリで `generate_videos.sh` にこのバグへの local fix（同等の `a_pass` パッチ）を当てている場合があるため、`yt-skills sync --force` 適用前に確認を推奨します（詳細は本 PR の変更差分と同一のロジックです）
- [x] 追加のテストは無し（bash スクリプトの分岐修正のみ、既存の overlays 系テストがあれば併せて確認をお願いします）

## 関連

再現条件: `config/channel/youtube.json` で `overlays.enabled=true`、`overlays.audio_visualizer.enabled` は未設定/false のまま `overlays.subscribe_popup.enabled=true` のみ有効にした状態で `generate_videos.sh` を実行。