### PR TITLE
docs(roadmap): roadmap.html を ADR-0021 のイベントベース方針で再生成 (#1644)

### DIFF
--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>tayk 開発ロードマップ</title>
+<title>tayk 移行ロードマップ</title>
 <style>
   :root {
     --bg: #0d1117;
@@ -16,11 +16,6 @@
     --accent-orange: #d29922;
     --accent-purple: #bc8cff;
     --accent-red: #f85149;
-    --accent-cyan: #39d2c0;
-    --lane-a: #58a6ff;
-    --lane-b: #d29922;
-    --lane-c: #3fb950;
-    --lane-d: #bc8cff;
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -31,13 +26,23 @@
     color: var(--text);
     line-height: 1.7;
     padding: 2rem;
-    max-width: 1200px;
+    max-width: 860px;
     margin: 0 auto;
+  }
+
+  a { color: var(--accent-blue); }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.9em;
+    background: rgba(110, 118, 129, 0.2);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
   }
 
   header {
     text-align: center;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
     padding-bottom: 1.5rem;
     border-bottom: 1px solid var(--border);
   }
@@ -47,39 +52,41 @@
   header .subtitle { color: var(--text-muted); font-size: 0.95rem; }
   header .meta { color: var(--text-muted); font-size: 0.8rem; margin-top: 0.3rem; }
 
-  /* ── View toggle ── */
-  .view-toggle {
-    display: flex;
-    justify-content: center;
-    gap: 0;
-    margin-bottom: 2.5rem;
-  }
-
-  .view-btn {
-    padding: 0.5rem 1.5rem;
-    border: 1px solid var(--border);
-    background: var(--surface);
-    color: var(--text-muted);
-    cursor: pointer;
+  /* ── 正本への案内 ── */
+  .source-note {
+    background: rgba(88, 166, 255, 0.08);
+    border: 1px solid rgba(88, 166, 255, 0.25);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
     font-size: 0.9rem;
-    font-family: inherit;
-    transition: all 0.15s ease;
+    color: var(--text-muted);
   }
 
-  .view-btn:first-child { border-radius: 8px 0 0 8px; }
-  .view-btn:last-child { border-radius: 0 8px 8px 0; }
+  .source-note strong { color: var(--accent-blue); }
 
-  .view-btn.active {
-    background: var(--accent-blue);
-    color: var(--bg);
-    border-color: var(--accent-blue);
-    font-weight: 600;
+  /* ── TL;DR ── */
+  .tldr {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 2.5rem;
+    font-size: 0.95rem;
   }
 
-  .view-btn:not(.active):hover {
-    background: rgba(88, 166, 255, 0.1);
-    color: var(--text);
+  .tldr h2 {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 0.6rem;
   }
+
+  .tldr ul { list-style: none; }
+  .tldr li { margin-bottom: 0.4rem; padding-left: 1.2rem; position: relative; }
+  .tldr li::before { content: '›'; position: absolute; left: 0.2rem; color: var(--accent-blue); }
 
   /* ── Legend ── */
   .legend {
@@ -104,348 +111,128 @@
     border-radius: 50%;
   }
 
-  /* ════════════════════════════════════════
-     Timeline View
-     ════════════════════════════════════════ */
-  .timeline-view { display: block; }
-  .timeline-view.hidden { display: none; }
+  .legend-dot.done { background: var(--accent-green); }
+  .legend-dot.doing { background: var(--accent-blue); box-shadow: 0 0 8px rgba(88, 166, 255, 0.5); }
+  .legend-dot.todo { background: var(--border); }
 
-  .timeline { position: relative; }
+  /* ── Milestone timeline ── */
+  .timeline {
+    position: relative;
+    padding-left: 3rem;
+  }
 
   .timeline::before {
     content: '';
     position: absolute;
-    left: 140px;
-    top: 0;
-    bottom: 0;
+    left: 15px;
+    top: 8px;
+    bottom: 8px;
     width: 2px;
     background: var(--border);
   }
 
-  .phase { position: relative; margin-bottom: 3rem; }
+  .milestone {
+    position: relative;
+    margin-bottom: 2rem;
+  }
 
-  .phase-header {
+  .milestone:last-child { margin-bottom: 0; }
+
+  .milestone-marker {
+    position: absolute;
+    left: -3rem;
+    top: 0.2rem;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .phase-month {
-    width: 120px;
-    text-align: right;
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    font-weight: 500;
-    flex-shrink: 0;
-  }
-
-  .phase-dot {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    border: 3px solid var(--accent-blue);
-    background: var(--bg);
-    flex-shrink: 0;
+    justify-content: center;
+    font-size: 0.9rem;
+    font-weight: 700;
     z-index: 1;
-    position: relative;
+    background: var(--bg);
   }
 
-  .phase-dot.milestone {
-    background: var(--accent-blue);
-    box-shadow: 0 0 12px rgba(88, 166, 255, 0.4);
+  .milestone.done .milestone-marker {
+    background: var(--accent-green);
+    color: var(--bg);
   }
 
-  .phase-title { font-size: 1.2rem; font-weight: 600; }
-
-  .phase-tag {
-    font-size: 0.7rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 10px;
-    font-weight: 600;
+  .milestone.doing .milestone-marker {
+    background: var(--bg);
+    border: 3px solid var(--accent-blue);
+    color: var(--accent-blue);
+    box-shadow: 0 0 14px rgba(88, 166, 255, 0.45);
   }
 
-  .tag-prep { background: rgba(210, 153, 34, 0.2); color: var(--accent-orange); }
-  .tag-ship { background: rgba(88, 166, 255, 0.2); color: var(--accent-blue); }
-  .tag-grow { background: rgba(63, 185, 80, 0.2); color: var(--accent-green); }
-  .tag-stable { background: rgba(188, 140, 255, 0.2); color: var(--accent-purple); }
-
-  .lanes {
-    margin-left: 160px;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+  .milestone.todo .milestone-marker {
+    background: var(--bg);
+    border: 2px solid var(--border);
+    color: var(--text-muted);
   }
 
-  .lane {
+  .milestone-card {
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1rem 1.25rem;
-    border-left: 3px solid;
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    border-left: 3px solid var(--border);
   }
 
-  .lane:hover {
-    transform: translateX(4px);
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  .milestone.done .milestone-card { border-left-color: var(--accent-green); }
+
+  .milestone.doing .milestone-card {
+    border-left-color: var(--accent-blue);
+    border-color: rgba(88, 166, 255, 0.45);
+    box-shadow: 0 0 18px rgba(88, 166, 255, 0.12);
   }
 
-  .lane-a { border-left-color: var(--lane-a); }
-  .lane-b { border-left-color: var(--lane-b); }
-  .lane-c { border-left-color: var(--lane-c); }
-  .lane-d { border-left-color: var(--lane-d); }
+  .milestone.todo .milestone-card { opacity: 0.75; }
 
-  .lane-header {
+  .milestone-header {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.6rem;
+    flex-wrap: wrap;
     margin-bottom: 0.4rem;
   }
 
-  .lane-label {
+  .milestone-title { font-weight: 600; font-size: 1rem; }
+
+  .milestone.todo .milestone-title { color: var(--text-muted); }
+
+  .status-tag {
     font-size: 0.7rem;
     font-weight: 700;
-    padding: 0.1rem 0.45rem;
-    border-radius: 4px;
-    color: var(--bg);
-  }
-
-  .label-a { background: var(--lane-a); }
-  .label-b { background: var(--lane-b); }
-  .label-c { background: var(--lane-c); }
-  .label-d { background: var(--lane-d); }
-
-  .lane-name { font-weight: 600; font-size: 0.95rem; }
-
-  .lane-detail {
-    color: var(--text-muted);
-    font-size: 0.85rem;
-    margin-left: calc(0.7rem * 2 + 0.45rem * 2 + 0.6rem);
-  }
-
-  .lane-detail ul { list-style: none; padding: 0; }
-  .lane-detail li { margin-bottom: 0.3rem; }
-  .lane-detail li::before { content: '›'; margin-right: 0.4rem; color: var(--text-muted); }
-
-  .benefit {
-    display: block;
-    margin-top: 0.15rem;
-    margin-left: 1rem;
-    color: var(--accent-green);
-    font-size: 0.8rem;
-  }
-
-  .benefit::before {
-    content: '→ ';
-  }
-
-  .cutover-banner {
-    margin-left: 160px;
-    background: linear-gradient(135deg, rgba(88, 166, 255, 0.1), rgba(188, 140, 255, 0.1));
-    border: 1px solid rgba(88, 166, 255, 0.3);
+    padding: 0.1rem 0.55rem;
     border-radius: 10px;
-    padding: 1.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    white-space: nowrap;
   }
 
-  .cutover-banner h3 { color: var(--accent-blue); font-size: 1rem; margin-bottom: 0.75rem; }
+  .status-tag.done { background: rgba(63, 185, 80, 0.2); color: var(--accent-green); }
+  .status-tag.doing { background: rgba(88, 166, 255, 0.2); color: var(--accent-blue); }
+  .status-tag.todo { background: rgba(139, 148, 158, 0.15); color: var(--text-muted); }
 
-  .cutover-items {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.4rem 2rem;
-    font-size: 0.85rem;
+  .milestone-effect {
+    font-size: 0.88rem;
     color: var(--text-muted);
   }
 
-  .cutover-items li { list-style: none; }
-  .cutover-items li::before { content: '✓'; margin-right: 0.4rem; color: var(--accent-green); font-weight: 700; }
+  .milestone-effect strong { color: var(--text); }
 
-  .callout {
-    margin-left: 160px;
+  /* ── 注意書き ── */
+  .note {
+    margin-top: 2.5rem;
+    background: rgba(210, 153, 34, 0.08);
+    border: 1px solid rgba(210, 153, 34, 0.3);
     border-radius: 8px;
     padding: 1rem 1.25rem;
-    margin-bottom: 1rem;
     font-size: 0.85rem;
     color: var(--text-muted);
   }
 
-  .callout-warn {
-    background: rgba(248, 81, 73, 0.08);
-    border: 1px solid rgba(248, 81, 73, 0.25);
-  }
-
-  .callout-info {
-    background: rgba(88, 166, 255, 0.08);
-    border: 1px solid rgba(88, 166, 255, 0.25);
-  }
-
-  .callout strong.red { color: var(--accent-red); }
-  .callout strong.blue { color: var(--accent-blue); }
-
-  .divider {
-    margin-left: 140px;
-    border: none;
-    border-top: 2px dashed var(--accent-blue);
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    opacity: 0.4;
-  }
-
-  /* ════════════════════════════════════════
-     Gantt Chart View
-     ════════════════════════════════════════ */
-  .gantt-view { display: none; }
-  .gantt-view.visible { display: block; }
-
-  .gantt-container {
-    overflow-x: auto;
-    margin-top: 1rem;
-  }
-
-  .gantt {
-    min-width: 800px;
-    border-collapse: collapse;
-    width: 100%;
-  }
-
-  .gantt th {
-    padding: 0.75rem 0.5rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    border-bottom: 2px solid var(--border);
-    text-align: center;
-    color: var(--text-muted);
-    position: sticky;
-    top: 0;
-    background: var(--bg);
-  }
-
-  .gantt th:first-child {
-    text-align: left;
-    width: 260px;
-    min-width: 260px;
-  }
-
-  .gantt th.month-header {
-    border-left: 1px solid var(--border);
-  }
-
-  .gantt th.current-month {
-    color: var(--accent-blue);
-    border-bottom-color: var(--accent-blue);
-  }
-
-  .gantt td {
-    padding: 0.5rem;
-    border-bottom: 1px solid rgba(48, 54, 61, 0.5);
-    vertical-align: middle;
-    position: relative;
-  }
-
-  .gantt td:first-child {
-    font-size: 0.85rem;
-    padding-right: 1rem;
-  }
-
-  .gantt td:not(:first-child) {
-    border-left: 1px solid rgba(48, 54, 61, 0.3);
-  }
-
-  .gantt-row-group td {
-    padding-top: 1.2rem;
-    padding-bottom: 0.4rem;
-    border-bottom: none;
-  }
-
-  .gantt-group-label {
-    font-weight: 700;
-    font-size: 0.9rem;
-    color: var(--text);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .gantt-group-tag {
-    font-size: 0.65rem;
-    padding: 0.1rem 0.4rem;
-    border-radius: 8px;
-    font-weight: 600;
-  }
-
-  .gantt-task-name {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding-left: 1rem;
-  }
-
-  .gantt-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .gantt-label {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-  }
-
-  .gantt-bar-cell {
-    padding: 0.5rem 0.25rem;
-  }
-
-  .gantt-bar {
-    height: 24px;
-    border-radius: 4px;
-    opacity: 0.85;
-    position: relative;
-    transition: opacity 0.15s ease;
-  }
-
-  .gantt-bar:hover {
-    opacity: 1;
-  }
-
-  .gantt-bar-full { width: 100%; }
-  .gantt-bar-left { width: 100%; border-radius: 4px 0 0 4px; }
-  .gantt-bar-right { width: 100%; border-radius: 0 4px 4px 0; }
-  .gantt-bar-mid { width: 100%; border-radius: 0; }
-
-  .bar-a { background: var(--lane-a); }
-  .bar-b { background: var(--lane-b); }
-  .bar-c { background: var(--lane-c); }
-  .bar-d { background: var(--lane-d); }
-  .bar-cyan { background: var(--accent-cyan); }
-
-  .gantt-milestone {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%) rotate(45deg);
-    width: 12px;
-    height: 12px;
-    background: var(--accent-blue);
-    box-shadow: 0 0 8px rgba(88, 166, 255, 0.5);
-  }
-
-  .gantt-milestone-label {
-    font-size: 0.75rem;
-    color: var(--accent-blue);
-    text-align: center;
-    font-weight: 600;
-  }
-
-  .half-left, .half-right {
-    display: inline-block;
-    width: 50%;
-    height: 24px;
-    vertical-align: top;
-  }
+  .note strong { color: var(--accent-orange); }
 
   /* ── Footer ── */
   footer {
@@ -458,464 +245,119 @@
   }
 
   /* ── Responsive ── */
-  @media (max-width: 768px) {
+  @media (max-width: 600px) {
     body { padding: 1rem; }
-    .timeline::before { left: 20px; }
-    .phase-month { width: 0; font-size: 0; }
-    .lanes, .cutover-banner, .callout { margin-left: 40px; }
-    .phase-header { gap: 0.5rem; }
-    .cutover-items { grid-template-columns: 1fr; }
+    .timeline { padding-left: 2.6rem; }
+    .timeline::before { left: 13px; }
+    .milestone-marker { left: -2.6rem; width: 28px; height: 28px; font-size: 0.8rem; }
   }
 </style>
 </head>
 <body>
 
-<div style="max-width:960px;margin:1rem auto;padding:1rem 1.25rem;border:2px solid #d97706;border-radius:8px;background:rgba(217,119,6,.08);font-weight:600;">
-  ⚠️ この開発ロードマップは失効しました（2026-07-08 / ADR-0021）。ここに記載の月別スケジュール（8月・9月等）は撤回済みです。現在の進行はイベントベースのマイルストーンで管理しています — 最新情報は <a href="migration/python-to-tayk.md">docs/migration/python-to-tayk.md</a> を参照してください。
-</div>
-
 <header>
-  <h1><span>tayk</span> 開発ロードマップ</h1>
-  <p class="subtitle">YouTube 自動化ツールの次世代版への移行計画</p>
-  <p class="meta">最終更新: 2026-06-25 &middot; ADR-0015（ADR-0021 により失効）</p>
+  <h1><span>tayk</span> 移行ロードマップ</h1>
+  <p class="subtitle">Python 版から後継 <code>tayk</code> へのイベントベース移行計画</p>
+  <p class="meta">ADR-0021: 別リポジトリでの再出発（イベントベース進行）</p>
 </header>
 
-<!-- View Toggle -->
-<div class="view-toggle">
-  <button class="view-btn active" onclick="showView('timeline')">タイムライン</button>
-  <button class="view-btn" onclick="showView('gantt')">ガントチャート</button>
+<div class="source-note">
+  <strong>ℹ️ 本ページについて</strong> — このロードマップは ADR-0021 のイベントベース方針に準拠しています。日付・期限は提示せず、マイルストーンの到達をもって次の段階へ進みます。正本は移行ガイド <a href="migration/python-to-tayk.md">docs/migration/python-to-tayk.md</a> です。本ページと差異がある場合は正本が優先されます。
+</div>
+
+<div class="tldr">
+  <h2>TL;DR</h2>
+  <ul>
+    <li>Python 版（<code>youtube-channels-automation</code>）は<strong>メンテナンスモード</strong> — 以後バグ修正のみで、新機能は追加しない</li>
+    <li>後継の <code>tayk</code> は<strong>専用の別リポジトリ</strong>で 0 ベース開発中（新リポは未公開。公開時に移行ガイドで案内）</li>
+    <li><strong>期日は約束しない</strong> — 各マイルストーンの到達をもって次の段階へ進み、その都度移行ガイドと GitHub Release で告知する</li>
+  </ul>
 </div>
 
 <div class="legend">
-  <div class="legend-item"><div class="legend-dot" style="background:var(--lane-a)"></div>次世代版の開発</div>
-  <div class="legend-item"><div class="legend-dot" style="background:var(--lane-b)"></div>現行版の品質改善</div>
-  <div class="legend-item"><div class="legend-dot" style="background:var(--lane-c)"></div>ブラウザ拡張</div>
-  <div class="legend-item"><div class="legend-dot" style="background:var(--lane-d)"></div>ダッシュボード</div>
+  <div class="legend-item"><div class="legend-dot done"></div>済</div>
+  <div class="legend-item"><div class="legend-dot doing"></div>進行中</div>
+  <div class="legend-item"><div class="legend-dot todo"></div>未</div>
 </div>
 
-<!-- ════════════════════════════════════════
-     Timeline View
-     ════════════════════════════════════════ -->
-<div class="timeline-view" id="timeline-view">
 <div class="timeline">
 
-  <!-- ===== 6月（進行中） ===== -->
-  <div class="phase">
-    <div class="phase-header">
-      <div class="phase-month">2026年 6月</div>
-      <div class="phase-dot"></div>
-      <div class="phase-title">先行着手</div>
-      <span class="phase-tag tag-prep">進行中</span>
-    </div>
-
-    <div class="lanes">
-      <div class="lane lane-b">
-        <div class="lane-header">
-          <span class="lane-label label-b">B</span>
-          <span class="lane-name">現行版の品質改善（17件）</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>既知の不具合を全件修正 — 切替後は修正できなくなるため
-              <span class="benefit">制作中に起きていた細かいエラーや中断がなくなり、安定した運用に</span></li>
-            <li>ライブ配信関連の残作業も並行して消化
-              <span class="benefit">24/7 配信がより安定し、配信停止リスクが低減</span></li>
-          </ul>
-        </div>
+  <div class="milestone done">
+    <div class="milestone-marker">✓</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag done">済</span>
+        <span class="milestone-title">本告知の公開・Python 版のメンテナンスモード移行</span>
       </div>
-
-      <div class="lane lane-c">
-        <div class="lane-header">
-          <span class="lane-label label-c">C</span>
-          <span class="lane-name">ブラウザ拡張の修正</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>Suno 連携: グリッド表示の不具合修正（〜7月前半まで）
-              <span class="benefit">Suno の新 UI でもプレイリスト追加が正常に動作するように</span></li>
-            <li>Suno 連携: 楽曲の一括ダウンロード機能を追加（〜7月前半まで）
-              <span class="benefit">Suno で生成した楽曲を手動でダウンロードする手間がゼロに</span></li>
-            <li>DistroKid 連携の安定化
-              <span class="benefit">音楽配信サービスへの登録作業がより確実に完了</span></li>
-          </ul>
-        </div>
-      </div>
+      <p class="milestone-effect">Python 版は以後バグ修正のみ（新機能は追加しない）</p>
     </div>
   </div>
 
-  <!-- ===== 7月 ===== -->
-  <div class="phase">
-    <div class="phase-header">
-      <div class="phase-month">2026年 7月</div>
-      <div class="phase-dot"></div>
-      <div class="phase-title">告知 + 開発加速</div>
-      <span class="phase-tag tag-prep">準備</span>
-    </div>
-
-    <div class="callout callout-info">
-      <strong class="blue">📢 移行告知を公開</strong> — 現在お使いのユーザーの皆さまへ「8月中に現行版は提供終了します」とご案内。移行ガイドを同時公開
-    </div>
-
-    <div class="lanes">
-      <div class="lane lane-a">
-        <div class="lane-header">
-          <span class="lane-label label-a">A</span>
-          <span class="lane-name">次世代版（tayk）の開発追い込み</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>自動化の中核エンジンを刷新
-              <span class="benefit">処理速度が向上し、エラー発生率が大幅に低下</span></li>
-            <li>コマンドラインツール <code>tayk</code> の完成
-              <span class="benefit">1 コマンドで導入・更新が完結（<code>bunx tayk</code>）</span></li>
-            <li>AI エージェントが直接操作できる仕組み（MCP）の構築
-              <span class="benefit">Claude が自動化ツールを直接呼び出せるように。より賢い自動判断が可能に</span></li>
-            <li>60 以上あるスキルを 5 つに整理統合
-              <span class="benefit">「どのスキルを使えばいいか分からない」問題が解消。迷わず制作に集中できる</span></li>
-            <li>動画の自動生成エンジンを Remotion に切替
-              <span class="benefit">テキストアニメーションやトランジションなど、表現力のある動画を自動生成</span></li>
-            <li>分析データの保存基盤を構築
-              <span class="benefit">過去の分析結果が蓄積され、トレンド比較や長期的な改善判断が可能に</span></li>
-          </ul>
-        </div>
+  <div class="milestone doing">
+    <div class="milestone-marker">●</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag doing">進行中</span>
+        <span class="milestone-title"><code>tayk</code> 開発リポジトリの始動（別リポ・0 ベース）</span>
       </div>
+      <p class="milestone-effect">本リポの TS レイヤー（<code>packages/</code>）は削除され、開発は新リポへ移る</p>
     </div>
   </div>
 
-  <!-- ===== 8月 ===== -->
-  <div class="phase">
-    <div class="phase-header">
-      <div class="phase-month">2026年 8月</div>
-      <div class="phase-dot milestone"></div>
-      <div class="phase-title">検証 + 切替</div>
-      <span class="phase-tag tag-ship">出荷</span>
-    </div>
-
-    <div class="lanes">
-      <div class="lane lane-a">
-        <div class="lane-header">
-          <span class="lane-label label-a">A</span>
-          <span class="lane-name">実環境での検証 → 正式リリース</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>自社チャンネル 2 つで実際にコレクションを制作して検証
-              <span class="benefit">実際の制作フローで問題がないことを確認してからリリース</span></li>
-            <li>重大な問題がないことを確認
-              <span class="benefit">誤公開・データ破壊・認証エラーの 3 種のみをブロック基準に</span></li>
-            <li>現行版から次世代版への切替を実行
-              <span class="benefit">全ユーザーが同じタイミングで新しい体験に移行</span></li>
-          </ul>
-        </div>
+  <div class="milestone todo">
+    <div class="milestone-marker">3</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag todo">未</span>
+        <span class="milestone-title"><code>tayk</code> v0.1.0: collection フルライフサイクル 1 周の dogfood 完走</span>
       </div>
-
-    </div>
-
-    <hr class="divider">
-
-    <div class="cutover-banner">
-      <h3>🚀 tayk v0.1.0 — 次世代版リリース</h3>
-      <ul class="cutover-items">
-        <li>自動化の中核エンジン</li>
-        <li>コマンドラインツール（<code>tayk</code>）</li>
-        <li>AI 連携インターフェース（MCP）</li>
-        <li>統合スキル 5 本</li>
-        <li>Remotion 動画生成</li>
-        <li>分析データ保存基盤</li>
-        <li>移行ガイド</li>
-        <li>既存の制作フロー（/wf-new）を維持</li>
-      </ul>
-    </div>
-
-    <div class="callout callout-warn">
-      <strong class="red">⚠ 重要な変更</strong> — 現行版（Python）は完全に削除されます。旧コマンド（<code>yt-*</code>）は使用不可に。バックアップ版の提供はありません
+      <p class="milestone-effect"><strong>次回告知</strong>。移行手順の具体化・新リポの案内を移行ガイド（python-to-tayk.md）に追記</p>
     </div>
   </div>
 
-  <!-- ===== 9月 ===== -->
-  <div class="phase">
-    <div class="phase-header">
-      <div class="phase-month">2026年 9月</div>
-      <div class="phase-dot"></div>
-      <div class="phase-title">新機能の追加</div>
-      <span class="phase-tag tag-grow">拡張</span>
-    </div>
-
-    <div class="lanes">
-      <div class="lane lane-c">
-        <div class="lane-header">
-          <span class="lane-label label-c">C'</span>
-          <span class="lane-name">コミュニティ投稿の自動化</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>YouTube Studio でのコミュニティ投稿を自動入力する拡張
-              <span class="benefit">動画公開のたびに手作業で投稿していた作業が自動化。投稿忘れも防止</span></li>
-            <li>テキスト・画像・スケジュール設定を一括操作
-              <span class="benefit">複数チャンネルの投稿も一度に準備でき、運用時間を大幅に短縮</span></li>
-          </ul>
-        </div>
+  <div class="milestone todo">
+    <div class="milestone-marker">4</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag todo">未</span>
+        <span class="milestone-title">first-party チャンネルの日常運用が <code>tayk</code> のみで回る（実運用カバレッジ到達）</span>
       </div>
-
-      <div class="lane lane-d">
-        <div class="lane-header">
-          <span class="lane-label label-d">D</span>
-          <span class="lane-name">分析ダッシュボード</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>全チャンネルの再生数・登録者数を一画面で確認
-              <span class="benefit">YouTube Studio を複数タブで開き回る必要がなくなる</span></li>
-            <li>動画ごとのパフォーマンス詳細表示
-              <span class="benefit">どの動画が伸びているか一目で把握。次の企画判断がデータで裏付けられる</span></li>
-          </ul>
-        </div>
-      </div>
+      <p class="milestone-effect"><strong>cutover 判断</strong>。判断が固まり次第、実施前に移行ガイドと GitHub Release で告知</p>
     </div>
   </div>
 
-  <!-- ===== 10月〜 ===== -->
-  <div class="phase">
-    <div class="phase-header">
-      <div class="phase-month">2026年 10月〜</div>
-      <div class="phase-dot"></div>
-      <div class="phase-title">運用改善</div>
-      <span class="phase-tag tag-stable">安定化</span>
-    </div>
-
-    <div class="lanes">
-      <div class="lane lane-a" style="border-left-color: var(--accent-cyan);">
-        <div class="lane-header">
-          <span class="lane-label" style="background: var(--accent-cyan);">→</span>
-          <span class="lane-name">安定化 + 次の計画</span>
-        </div>
-        <div class="lane-detail">
-          <ul>
-            <li>ユーザーからのフィードバックを反映
-              <span class="benefit">実際に使ってみて困ったことを優先的に改善</span></li>
-            <li>自動化機能の追加・改善
-              <span class="benefit">日々の運用で感じる「ここも自動化したい」に応える</span></li>
-            <li>次期ロードマップを検討
-              <span class="benefit">ユーザーの声をもとに、次に作るべきものを一緒に決める</span></li>
-          </ul>
-        </div>
+  <div class="milestone todo">
+    <div class="milestone-marker">5</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag todo">未</span>
+        <span class="milestone-title">cutover 実施</span>
       </div>
+      <p class="milestone-effect">main ブランチから Python コードを削除。以後の修正は <code>tayk</code> のみ</p>
+    </div>
+  </div>
+
+  <div class="milestone todo">
+    <div class="milestone-marker">6</div>
+    <div class="milestone-card">
+      <div class="milestone-header">
+        <span class="status-tag todo">未</span>
+        <span class="milestone-title">外部ユーザー移行サポート期間</span>
+      </div>
+      <p class="milestone-effect">移行で問題があれば issue で報告</p>
     </div>
   </div>
 
 </div>
-</div>
 
-<!-- ════════════════════════════════════════
-     Gantt Chart View
-     ════════════════════════════════════════ -->
-<div class="gantt-view" id="gantt-view">
-<div class="gantt-container">
-<table class="gantt">
-  <thead>
-    <tr>
-      <th></th>
-      <th class="month-header current-month" colspan="2">6月</th>
-      <th class="month-header" colspan="2">7月</th>
-      <th class="month-header" colspan="2">8月</th>
-      <th class="month-header" colspan="2">9月</th>
-      <th class="month-header" colspan="2">10月〜</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th>前半</th><th>後半</th>
-      <th>前半</th><th>後半</th>
-      <th>前半</th><th>後半</th>
-      <th>前半</th><th>後半</th>
-      <th>前半</th><th>後半</th>
-    </tr>
-  </thead>
-  <tbody>
-    <!-- Group: 先行着手 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          先行着手
-          <span class="gantt-group-tag tag-prep">進行中</span>
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--accent-blue)"></div><span class="gantt-label">移行告知の公開</span></div></td>
-      <td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-full" title="7月前半: 移行告知公開"></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <!-- Group: 現行版の品質改善 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          <div class="gantt-dot" style="background:var(--lane-b)"></div>
-          現行版の品質改善
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-b)"></div><span class="gantt-label">不具合 17 件の修正</span></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-b gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-b gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <!-- Group: ブラウザ拡張 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          <div class="gantt-dot" style="background:var(--lane-c)"></div>
-          ブラウザ拡張
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-c)"></div><span class="gantt-label">Suno 連携の修正 + DL 機能</span></div></td>
-      <td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-c gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-c gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <!-- Group: 次世代版の開発 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          <div class="gantt-dot" style="background:var(--lane-a)"></div>
-          次世代版の開発（tayk）
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-a)"></div><span class="gantt-label">中核エンジン + AI 連携</span></div></td>
-      <td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-mid"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-a)"></div><span class="gantt-label">スキル統合（60+ → 5本）</span></div></td>
-      <td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-mid"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-a)"></div><span class="gantt-label">動画生成エンジン切替</span></div></td>
-      <td></td><td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td><td></td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-a)"></div><span class="gantt-label">実環境での検証</span></div></td>
-      <td></td><td></td><td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-a gantt-bar-right"></div></td>
-      <td></td><td></td><td></td><td></td>
-    </tr>
-
-    <!-- Milestone -->
-    <tr>
-      <td><div class="gantt-task-name"><span class="gantt-milestone-label">🚀 tayk v0.1.0 リリース</span></div></td>
-      <td></td><td></td><td></td><td></td><td></td>
-      <td class="gantt-bar-cell" style="text-align:center; position:relative;"><div class="gantt-milestone"></div></td>
-      <td></td><td></td><td></td><td></td>
-    </tr>
-
-    <!-- Group: 新機能 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          <div class="gantt-dot" style="background:var(--lane-c)"></div>
-          新機能
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-c)"></div><span class="gantt-label">コミュニティ投稿の自動化</span></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-c gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-c gantt-bar-right"></div></td>
-      <td></td><td></td>
-    </tr>
-
-    <!-- Group: ダッシュボード -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          <div class="gantt-dot" style="background:var(--lane-d)"></div>
-          分析ダッシュボード
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--lane-d)"></div><span class="gantt-label">全チャンネル一覧 + 詳細画面</span></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-d gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-d gantt-bar-right"></div></td>
-      <td></td><td></td>
-    </tr>
-
-    <!-- Group: 安定化 -->
-    <tr class="gantt-row-group">
-      <td colspan="11">
-        <div class="gantt-group-label">
-          運用改善
-          <span class="gantt-group-tag tag-stable">安定化</span>
-        </div>
-      </td>
-    </tr>
-
-    <tr>
-      <td><div class="gantt-task-name"><div class="gantt-dot" style="background:var(--accent-cyan)"></div><span class="gantt-label">フィードバック反映 + 次期計画</span></div></td>
-      <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-cyan gantt-bar-left"></div></td>
-      <td class="gantt-bar-cell"><div class="gantt-bar bar-cyan gantt-bar-right"></div></td>
-    </tr>
-  </tbody>
-</table>
-</div>
+<div class="note">
+  <strong>⚠ 日付は提示しません</strong> — 各マイルストーンの到達をもって次の段階へ進み、その都度移行ガイド（<a href="migration/python-to-tayk.md">python-to-tayk.md</a>）と GitHub Release で告知します。
 </div>
 
 <footer>
   <p>tayk — YouTube チャンネル運営自動化ツールキット</p>
-  <p>ADR-0015: 開発ロードマップ &middot; 決定日: 2026-06-25</p>
+  <p>ADR-0021: 別リポジトリでの再出発 &middot; 正本: <a href="migration/python-to-tayk.md">docs/migration/python-to-tayk.md</a></p>
 </footer>
-
-<script>
-function showView(view) {
-  const tl = document.getElementById('timeline-view');
-  const gt = document.getElementById('gantt-view');
-  const btns = document.querySelectorAll('.view-btn');
-
-  if (view === 'gantt') {
-    tl.classList.add('hidden');
-    gt.classList.add('visible');
-    btns[0].classList.remove('active');
-    btns[1].classList.add('active');
-  } else {
-    tl.classList.remove('hidden');
-    gt.classList.remove('visible');
-    btns[1].classList.remove('active');
-    btns[0].classList.add('active');
-  }
-}
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

- 失効した ADR-0015 の月別（2026年6〜10月）タイムライン + ガントチャートを全面廃止し、ADR-0021 準拠のイベントベース（日付なし）マイルストーン・タイムラインとして `docs/roadmap.html` を再生成
- マイルストーン 6 項目の文言・順序・進行状態（済 / 進行中 / 未）は正本 `docs/migration/python-to-tayk.md` §1 の表と完全一致
- #1630 で暫定追加した失効バナーを除去し、ADR-0021 準拠である旨と正本へのリンク（header 直下の案内 + footer）に差し替え
- view 切替ボタン・ガントチャート表・JS を削除し、静的な単一 HTML に簡素化（-737 行 / +179 行）
- 検証: `rg` で月名・年・ガント・ADR-0015・日付パターン（YYYY-MM）のヒットが 0 件であること、HTML タグ整合を確認済み

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)