### PR TITLE
docs(skills): discover-competitors に障害時ガイダンス節を追加 (#1652)

### DIFF
--- a/.claude/skills/discover-competitors/SKILL.md
+++ b/.claude/skills/discover-competitors/SKILL.md
@@ -120,6 +120,15 @@ uv run yt-discover-competitors \
 
 並行検証で連発するときは quota 残量に注意。
 
+## 障害時ガイダンス
+
+| 状況 | 兆候 | 対処 |
+|---|---|---|
+| OAuth 未認証/失効 | `auth.oauth_handler` の `FileNotFoundError`（`client_secrets.json` 不在）/ `AuthError` / HTTP 403 | 初回認証フローを再実行。403 が続く場合は `auth/token.json` を削除しスコープを確認のうえ再認証 |
+| YouTube quota / rate | HTTP 429 / 403 `quotaExceeded` | 日次 quota（既定 10,000 units・太平洋時間 0 時リセット）を待つか呼び出しを抑える。本スキルは 1 回あたり約 660 units を消費するため、並行検証の連発を控え、キーワード数や `--per-keyword` を減らして次回リセット後に再実行する |
+| API 障害 / サービス停止 | HTTP 503 / タイムアウト | Google Cloud / YouTube のステータスを確認し、時間を置いて再実行 |
+| 同一 `--output` での再実行 | 前回の `.md` / `.csv` の内容が消える | 仕様どおりの動作。出力ペア（`.md` + 同名 `.csv`）は再実行時に全体が上書きされ、部分結果のマージ・保持はされない（API 呼び出しが途中で失敗した場合はファイルは書き込まれず、前回の出力がそのまま残る）。結果を比較したい場合は実行ごとに `--output` を別ファイル名にする |
+
 ## スコープ外（他スキルへバトン）
 
 - 競合の動画詳細分析 → `/benchmark`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs(skills)`: `/discover-competitors` の SKILL.md に他 skill と同一フォーマット（状況 / 兆候 / 対処）の「障害時ガイダンス」節を追加（#1652）。OAuth 未認証・失効時の再認証手順、YouTube quota 超過（HTTP 429 / `quotaExceeded`。本スキルは約 660 units/回消費）時のリセット待ち・呼び出し抑制、同一 `--output` での再実行時に出力ペア（`.md` + 同名 `.csv`）が全体上書きされ部分結果は保持されないこと（途中失敗時はファイル未書き込みで前回出力が残ること）を文書化した
 - `feat(suno-helper)`: 連続実行に投入方式セレクタ（Serial / Queue）を追加（#1586）。Queue は投入 ACK と clip ID 観測を確認したら生成完了を待たずに次 entry を先行投入し、最大 10 request（20 clip）まで Suno queue を使って全体の実行時間を短縮する。全 entry 投入後に生成完了をまとめて待ってから playlist 追加へ進む。進捗 UI には投入済み・生成未完了を表す `submitted` 状態（琥珀色）を追加。選択は chrome.storage.local（`sunoRunMode`）に永続化し、既定は従来挙動の Serial。中断時は投入方式を resume state に保存し、再開は popup の現在選択ではなく元 run のモードで行う。制約: Queue は per-entry duration guard の自動再生成を行わず（範囲外 clip は playlist 追加時に除外のみ）、bridge の clip ID 観測が必須（未観測は fail-loud で run 停止）
 - `feat(suno-helper)`: `/suno-helper` を browser use 主経路で操作・監視できるように、SKILL.md に agent primary flow、DOM signal、無限待機回避、handoff 条件を追加。Chrome DevTools MCP は診断・補助・フォールバック扱いに固定し、拡張 overlay / popup には `data-suno-*` と `role="status"` の観測 signal を追加した。`/wf-new` の Suno 後続案内も `/suno-helper` の browser use 主導フローへ接続する表現に更新（#1382）
 - `feat(doctor)`: `yt-doctor` に playlist スキル向けの `playlist_config` / `playlist_create_dry_run` チェックを追加（#1504）。`config/channel/playlists.json` の欠落・JSON 破損・`playlist_id` 未設定を channel カテゴリで診断し、`PlaylistManager.create_all_playlists(dry_run=True)` 経路で作成計画を検証する。dry-run は YouTube API への書き込みを行わず、失敗時は human next_action で設定修正手順を示す。


### PR DESCRIPTION
## Summary
- `.claude/skills/discover-competitors/SKILL.md` に「## 障害時ガイダンス」節（状況/兆候/対処表）を新設
- OAuth 未認証/失効・quota 超過（429 / quotaExceeded、660 units/run 前提の抑制策）・API 障害・同一 `--output` 再実行時の全体上書き挙動を文書化
- 見出し・表フォーマットは analytics-collect 等の既存 26 skill と統一
- CHANGELOG.md の `[Unreleased]` に追記（CHANGELOG ゲート対応）

上書き挙動は `src/youtube_automation/scripts/discover_competitors.py` の実装（write_text による全体上書き、API 完了後に書き込み）で裏取り済み。ドキュメント追記のみでコード変更なし。

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)