### PR TITLE
chore(suno-helper): ext-v0.2.4

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

suno-helper Chrome extension release PR.

- Bump `extensions/suno-helper/package.json` from `0.2.2` to `0.2.4`
- Includes changes already documented in `CHANGELOG.md` [Unreleased]: #1586 (queue run mode), #1382 (browser-use agent flow connection), #1573 (Balanced 固定ペーシングへ簡素化)
- Local verification: `nr build` and `nr zip` in `extensions/suno-helper` (produced `suno-helper-0.2.4-chrome.zip`, manifest version confirmed `0.2.4`)

distrokid-helper has no changes since `ext-v0.2.3` and is not bumped in this PR.

## Next steps

1. Merge this PR into `main`
2. Push tag `ext-v0.2.4`
3. `.github/workflows/release-extensions.yml` attaches the helper zips to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)