### PR TITLE
docs(claude-md): 実在しない commit-convention/pr スキル参照を CLAUDE.md 規約記述へ統一 (#1780)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,5 +102,5 @@ TS 版（tayk）の開発は専用の別リポジトリで行う（`docs/adr/002
 - **issue 起票**: `gh issue create` または `/issue` スキル
 - **takt 起動**: `takt add '#<N>'` → `takt run`（base branch は **main** 固定、PR は通常 PR）
 - **workflow 使い分け**: 小〜中規模 issue はリポジトリ同梱の軽量 workflow **`lite`**（plan → implement → review の 3 step、トークン消費が少ない）。セキュリティ・認証・アップロード系、スキル横断・破壊的変更、テスト戦略設計が要る issue は組み込み **default**（9 step）を使う。基準は `docs/takt-operations.md`
-- **commit 規約**: 日本語 Conventional Commits + タイトル末尾に `(#<N>)`。`commit-convention` スキル参照
+- **commit 規約**: 日本語 Conventional Commits + タイトル末尾に `(#<N>)`
 - **リリース**: `/automation-release` スキル（post-release は `/release-notes`）

--- a/docs/release-skill-update-253.md
+++ b/docs/release-skill-update-253.md
@@ -134,7 +134,7 @@ git log <last-tag>..HEAD --oneline           # 前回以降のコミット一覧
 1. `git pull origin main`（ローカル main を最新に同期）
 2. `git switch -c release/v<version>`
 3. `package.json` の `version` フィールドを更新
-4. `/skills commit-convention` に従いコミット（例: `release: v0.5.0`）
+4. Conventional Commits 規約に従いコミット（例: `release: v0.5.0`）
 5. `git push -u origin release/v<version>`
 
 #### Step 4: sub-PR の Closes 集約と PR 本文生成
@@ -281,7 +281,7 @@ git push origin --delete release/v<version> 2>/dev/null  # リモート（自動
 - リリースノートは `--generate-notes` で GitHub に任せる
 - 対応リポジトリは Node.js / npm（`package.json`）に限定。Cargo.toml / pyproject.toml / go.mod 等は対象外
 - バージョン更新は `package.json` の `version` フィールドのみ
-- コミットメッセージは commit-convention に従う（タイプ: `release`）
+- コミットメッセージは Conventional Commits 規約に従う（タイプ: `release`）
 - バージョン判定はユーザーが上書き可能
 - リリースブランチの命名: `release/v<version>`
 - リリース PR 本文は sub-PR から `Closes #N` を集約し、main マージ時の自動クローズ発火を保証する（対象キーワード: `Closes` / `Fixes` / `Resolves`、case-insensitive）

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -83,7 +83,7 @@ takt の自動 worktree（task の `worktree: true`）では **step 間のセッ
 resume が効くのは**キャッシュ TTL 内に次 step が始まる隣接 step のみ**（同実験で write_tests→implement の非キャッシュ input が 187K → 102K に減少するのを確認）。したがって:
 
 - ループを持つ workflow（default 等）は **resume 無効のまま（= takt デフォルト挙動）が安い**。このガードはコスト面では防御として機能している
-- 手動 worktree 内で `takt add` → `takt run`（task の `worktree` 指定を省略 = カレント実行）にすれば `cwd === projectCwd` となり resume は有効化できるが、検討に値するのは**ループのない短い直列 workflow だけ**。この場合 auto-commit / push / auto_pr は worktree 実行時のフローなので、commit・PR 作成は手動（`commit-convention` / `pr` スキル）で行うこと
+- 手動 worktree 内で `takt add` → `takt run`（task の `worktree` 指定を省略 = カレント実行）にすれば `cwd === projectCwd` となり resume は有効化できるが、検討に値するのは**ループのない短い直列 workflow だけ**。この場合 auto-commit / push / auto_pr は worktree 実行時のフローなので、commit・PR 作成は手動（CLAUDE.md「開発ワークフロー」の commit 規約 + `gh pr create`）で行うこと
 
 ### 計測との突き合わせ
 
@@ -95,7 +95,7 @@ resume が効くのは**キャッシュ TTL 内に次 step が始まる隣接 st
 
 ただし、**実装を担う `coder` persona を codex provider にしている（グローバル設定から継承）ため**、実装ファイルへの編集は Codex CLI 経由で行われ Claude Code の protected paths 制約を回避できる（Codex は独自のサンドボックスで動作し、`$REPO_ROOT/.agents/skills` を探索パスに含む）。レビュー系 persona は opus（Claude）だが書き込みは行わないため影響しない。そのため、**skill 配下を変更する issue も takt から問題なく回せる**。実際の運用例として、`.claude/skills/videoup/references/generate_videos.sh` 等の skill 配下スクリプト修正も takt 経由で完走実績がある。
 
-逆に `coder` を Claude provider に戻している環境では、従来通り skill 配下の Edit が deny される。その場合は通常の Claude Code 対話セッション（cmux pane 等）で直接編集し、コミット・PR 作成は `commit-convention` / `pr` スキル経由で実施する。
+逆に `coder` を Claude provider に戻している環境では、従来通り skill 配下の Edit が deny される。その場合は通常の Claude Code 対話セッション（cmux pane 等）で直接編集し、コミット・PR 作成は CLAUDE.md「開発ワークフロー」の規約に従い手動で実施する。
 
 ## Codex 共用時の skill 表記読み替え
 


### PR DESCRIPTION
## Summary

CLAUDE.md と docs/ が、`.claude/skills/` にも `~/.claude/skills/`（グローバル）にも実在しない `commit-convention` / `pr` スキルを参照していた問題を解消した。

## 方針決定

PR #1776（#1688 の一環）で automation-release / automation-update の SKILL.md に既に適用済みの方針を踏襲し、**スキル実体を新規に用意せず、参照を廃止してインライン規約記述を単一ソースにする**。

- **CLAUDE.md / docs/takt-operations.md**: 本リポジトリ（YTCA）固有のドキュメントのため、CLAUDE.md「開発ワークフロー」節（日本語 Conventional Commits + タイトル末尾 `(#<N>)`）への参照に統一
- **docs/release-skill-update-253.md**: このファイルは dotfiles 側配布の汎用 `/release` スキル（Node.js プロジェクト向け、YTCA 非依存、ファイル冒頭の位置付け説明を参照）の完成版 SKILL.md 全文コピーであり、YTCA の CLAUDE.md に依存させるのは意味的に不整合。そのため、この2箇所のみ YTCA CLAUDE.md 参照ではなく一般的な「Conventional Commits 規約」という表現に差し替えた

## 変更内容

- `CLAUDE.md:105` — 「`commit-convention` スキル参照」の文言を削除（CLAUDE.md 自身が単一ソースのため）
- `docs/takt-operations.md:86,98` — 「`commit-convention` / `pr` スキル」への言及を CLAUDE.md「開発ワークフロー」参照 + `gh pr create` に差し替え
- `docs/release-skill-update-253.md:137,284` — `/skills commit-convention` / `commit-convention に従う` を「Conventional Commits 規約」表現に差し替え

## スコープ外

- `.claude/skills/automation-release/SKILL.md` / `.claude/skills/automation-update/SKILL.md` 内の同種参照（PR #1776 で対応中、本 PR 作成時点では #1776 は未マージのため一部残存しているが、issue #1780 の「スコープ外」指定に従いこの PR では触れていない）
- commit 規約自体の変更

## 検証

```
$ rg -n 'commit-convention' CLAUDE.md docs/takt-operations.md docs/release-skill-update-253.md
# 0 件
```

Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)