### PR TITLE
docs(plans): 第 4 回監査（Python コア本体）の実装プラン 020-024 を追加

### DIFF
--- a/plans/020-upload-path-robustness.md
+++ b/plans/020-upload-path-robustness.md
@@ -1,0 +1,286 @@
+# Plan 020: アップロード経路の堅牢化 — tracking 書き込みのアトミック化・QuotaExhaustedError の非終端化・サムネ temp リーク解消
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5394c378..HEAD -- src/youtube_automation/agents/_tracking_io.py src/youtube_automation/agents/_complete_collection_executor.py src/youtube_automation/agents/short_uploader.py src/youtube_automation/agents/_collection_uploader_constants.py src/youtube_automation/utils/upload_core.py`
+> 差分が出た in-scope ファイルは「Current state」の抜粋と実コードを突き合わせ、
+> 不一致なら STOP condition として扱う。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S-M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `5394c378`, 2026-07-09
+
+## Why this matters
+
+このリポジトリの存在理由である「無人アップロード」経路に、独立した 3 つの堅牢性欠陥がある。(1) `upload_tracking.json` が非アトミック書き込みで、アップロード中のクラッシュで truncate されると次回実行が「tracking なし」と誤認して video_id / resume session URI を喪失し再アップロード走行する。(2) `upload_core` が明示的に「リトライ可能」として raise する `QuotaExhaustedError`（retry_after_seconds 付き）が、agents 側の生 `except Exception` に吸われてコレクション恒久失敗（`status="failed"`）として記録され、オペレーターは「時間をおいて再実行すれば直る」というシグナルを失う。(3) サムネイル圧縮が全品質で失敗した場合、temp ファイルをリークした上で 2MB 超の元ファイルをそのまま API に投げて確実に失敗する。3 件とも同一サブシステム（agents + upload_core）の S 級修正なので 1 プランにまとめる。
+
+## Current state
+
+対象ファイルと役割:
+
+- `src/youtube_automation/agents/_tracking_io.py` — tracking / workflow-state JSON I/O の mixin（CollectionUploader に合成される）
+- `src/youtube_automation/agents/_complete_collection_executor.py` — Complete Collection アップロードの実行 mixin
+- `src/youtube_automation/agents/short_uploader.py` — ショート 1 本のアップロード agent（1 実行 = 1 本）
+- `src/youtube_automation/agents/_collection_uploader_constants.py` — action 文字列定数
+- `src/youtube_automation/utils/upload_core.py` — resumable upload / サムネ設定の共通エンジン
+
+### (1) 非アトミック書き込み + 破損の無言 None（_tracking_io.py:31-51）
+
+```python
+    def _load_tracking(self, collection_path: Path) -> dict | None:
+        """tracking ファイル読み込み"""
+        tracking_file = self._get_tracking_path(collection_path)
+        if not tracking_file.exists():
+            return None
+
+        try:
+            with open(tracking_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def _save_tracking(self, collection_path: Path, tracking: dict):
+        """tracking 保存"""
+        tracking_file = self._get_tracking_path(collection_path)
+        tracking_file.parent.mkdir(exist_ok=True)
+        try:
+            with open(tracking_file, "w", encoding="utf-8") as f:
+                json.dump(tracking, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.warning(f"⚠️  追跡ファイル保存エラー: {e}")
+```
+
+リポジトリ既存のアトミック書き込み規約（これに合わせる）— `src/youtube_automation/utils/comments/history.py:65-71`:
+
+```python
+    def save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        text = json.dumps(self._data, ensure_ascii=False, indent=2) + "\n"
+        # 途中断絶時の履歴破損を防ぐため tmp に書いてから rename で差し替える
+        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp_path.write_text(text, encoding="utf-8")
+        os.replace(tmp_path, self._path)
+```
+
+### (2) QuotaExhaustedError が終端 failed に潰される
+
+raise 側 — `src/youtube_automation/utils/upload_core.py:204-208`（429 リトライ枯渇時）:
+
+```python
+                elif status_code == 429:
+                    raise QuotaExhaustedError(
+                        f"YouTube API の quota 超過/レート制限。時間をおいて再実行してください: {e}",
+                        retry_after_seconds=retry_after,
+                    ) from e
+```
+
+例外クラス — `src/youtube_automation/utils/exceptions.py:45-54`。`retry_after_seconds: float | None` 属性を持ち、docstring に「時間をおいて再実行することで resume 可能であることを呼び出し側に明示する」とある。**呼び出し側がその契約を無視しているのが本バグ**。
+
+握りつぶし箇所 1 — `src/youtube_automation/agents/_complete_collection_executor.py:110-118`:
+
+```python
+        except Exception as e:
+            # 例外パスでも callback が書いた disk 状態を尊重するため再ロード
+            current = self._load_tracking(collection_path) or tracking
+            cc_current = current.setdefault("complete_collection", {})
+            cc_current["status"] = "failed"
+            cc_current["error"] = str(e)
+            self._save_tracking(collection_path, current)
+            logger.error(f"❌ Complete Collection エラー: {e}")
+            return {"action": "complete_collection_failed", "details": {"error": str(e)}}
+```
+
+握りつぶし箇所 2 — `src/youtube_automation/agents/short_uploader.py:308-319`:
+
+```python
+        try:
+            video_id = self.uploader.upload_video(
+                str(video_path),
+                metadata,
+                thumbnail_path,
+                resume_session_uri=resume_session_uri,
+                on_session_uri_changed=_on_session_uri_changed,
+                on_upload_complete=_on_upload_complete,
+            )
+        except Exception as e:
+            logger.error(f"❌ upload_video 失敗: {e}")
+            return {"action": ACTION_FAILED, "details": {"error": str(e)}}
+```
+
+action 文字列の消費側は 1 箇所のみ（確認済み）: `short_uploader.py:515` の `if result["action"] == ACTION_FAILED: sys.exit(1)`。Complete Collection 側の action 文字列を閉集合として分岐する消費側は存在しない。
+
+定数ファイル — `_collection_uploader_constants.py:8-9` に `ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED` / `ACTION_COMPLETE_COLLECTION_UPLOADED` があり、`__all__` にも列挙されている。
+
+### (3) サムネ temp リーク — `src/youtube_automation/utils/upload_core.py:256-284`
+
+```python
+        tmp_fd = tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)
+        tmp_fd.close()
+        compressed = Path(tmp_fd.name)
+        failed_qualities: set[int] = set()
+
+        while (quality := strategy.next_quality(failed_qualities)) is not None:
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", str(thumbnail_path), "-qscale:v", str(quality), str(compressed)],
+                capture_output=True,
+            )
+            if compressed.exists() and compressed.stat().st_size <= max_bytes:
+                ...
+                return compressed
+            failed_qualities.add(quality)
+
+        logger.warning(f"サムネイル圧縮後も {compressed.stat().st_size / 1024:.0f}KB — 上限超過")
+        return thumbnail_path
+```
+
+全品質失敗時（および ffmpeg が一度も出力しなかった場合）、`compressed` は unlink されない。呼び出し側 `set_thumbnail`（同ファイル :245-246）は「返り値 ≠ 入力パス」のときだけ unlink するため、元パスが返るこの経路では temp が残る。さらに `compressed.stat()` は ffmpeg が一度も書けなかった場合 `FileNotFoundError` を起こす。
+
+### 適用される規約
+
+- エラーハンドリング: `utils/exceptions.py` のドメイン例外を使う。生 `Exception` / `KeyError` を catch しない（CLAUDE.md）。既存の広い catch を**狭める方向のみ**変更し、挙動互換を保つ。
+- `src/youtube_automation/` を触るため `CHANGELOG.md` の `[Unreleased]` 追記が必須（lefthook pre-push + CI ゲート）。
+- import は fully-qualified（`from youtube_automation.xxx import ...`）。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `uv run pytest tests/test_collection_uploader.py tests/test_short_uploader.py tests/integration/test_upload_core.py -q` | all pass |
+| 全テスト | `uv run pytest -q` | all pass（約 5,000 件） |
+| Lint | `uv run ruff check src tests` | exit 0 |
+| Format | `uv run ruff format --check src tests` | exit 0 |
+
+## Scope
+
+**In scope**（変更してよいファイルはこれだけ）:
+
+- `src/youtube_automation/agents/_tracking_io.py`
+- `src/youtube_automation/agents/_complete_collection_executor.py`
+- `src/youtube_automation/agents/short_uploader.py`
+- `src/youtube_automation/agents/_collection_uploader_constants.py`
+- `src/youtube_automation/utils/upload_core.py`（`_compress_thumbnail` のみ）
+- `tests/test_collection_uploader.py`, `tests/test_short_uploader.py`, `tests/test_upload_core_thumbnail.py`（新規可）
+- `CHANGELOG.md`（`[Unreleased]` 追記）
+
+**Out of scope**（関連して見えても触らない）:
+
+- `upload_core.py` の `_resumable_upload` リトライロジック本体 — 正しく動いており、テスト済み（`tests/integration/test_upload_core.py:212-225`）
+- `_update_workflow_upload`（`_tracking_io.py:65-92`）の `write_text` — workflow-state はこのプランの対象外。tracking と違い書き込み頻度が低く、別途判断
+- `youtube_auto_uploader.py` — 同種の catch があっても本プランでは触らない（スコープ膨張防止）
+- tracking JSON のスキーマ変更（`schema_version` bump が要る変更は一切しない）
+
+## Git workflow
+
+- worktree 上で作業（`$REPO_ROOT/.worktrees/<slug>/`、リポジトリ規約）。base branch は main
+- commit 規約: 日本語 Conventional Commits。例: `fix(agents): tracking JSON をアトミック書き込み化し QuotaExhaustedError を非終端化 (#<issue>)`（issue 未起票なら `(#N)` は省略可）
+- push / PR 化はオペレーターの指示があるときのみ
+
+## Steps
+
+### Step 1: `_save_tracking` をアトミック書き込みにする
+
+`_tracking_io.py` の `_save_tracking` を `history.py:65-71` と同じ tmp + `os.replace` パターンに変更する。`import os` を追加。外側の `try/except Exception` は「保存失敗でアップロード続行を止めない」という現行挙動を守るため**残してよい**が、`logger.warning` を `logger.error` に格上げし、メッセージにファイルパスを含める。
+
+**Verify**: `uv run pytest tests/test_collection_uploader.py -q` → all pass
+
+### Step 2: `_load_tracking` で「無い」と「壊れている」を区別する
+
+`except Exception: return None` を以下に置き換える:
+
+- `json.JSONDecodeError` / `UnicodeDecodeError` を catch した場合: 破損ファイルを `tracking_file.with_suffix(".json.corrupt")` へ `os.replace` で退避し、`logger.error` で「tracking 破損を検出、<path> へ退避。再アップロード前に dedup 探索が働く」と記録して `None` を返す（現行のリカバリ挙動は維持しつつ、証拠を保全し無言でなくす）
+- `OSError` はそのまま raise させる（catch しない）
+
+**Verify**: `uv run pytest tests/test_collection_uploader.py -q` → all pass
+
+### Step 3: QuotaExhaustedError を Complete Collection 経路で非終端化する
+
+1. `_collection_uploader_constants.py` に `ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED = "complete_collection_quota_exhausted"` を追加し `__all__` にも載せる
+2. `_complete_collection_executor.py` の `except Exception` の**前**に追加:
+
+```python
+        except QuotaExhaustedError as e:
+            # リトライ可能: tracking を failed にせず、resume URI（callback が永続化済み）を
+            # 温存して次回実行に委ねる
+            logger.error(f"⏸️  quota 枯渇のため中断（再実行で resume）: {e}")
+            return {
+                "action": ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
+                "details": {"error": str(e), "retry_after_seconds": e.retry_after_seconds},
+            }
+```
+
+import は `from youtube_automation.utils.exceptions import QuotaExhaustedError`。**tracking への `status="failed"` 書き込みをしない**のがこの分岐の要点。
+
+**Verify**: `uv run pytest tests/test_collection_uploader.py -q` → all pass
+
+### Step 4: QuotaExhaustedError を short_uploader 経路で区別する
+
+`short_uploader.py:317` の `except Exception` の前に `except QuotaExhaustedError as e:` を追加し、`{"action": ACTION_FAILED, "details": {"error": str(e), "retryable": True, "retry_after_seconds": e.retry_after_seconds}}` を返す（exit code 挙動は :515 で従来どおり 1 のまま — 消費側変更なし）。ログは「quota 枯渇・時間をおいて再実行してください」と明示する。
+
+**Verify**: `uv run pytest tests/test_short_uploader.py -q` → all pass
+
+### Step 5: `_compress_thumbnail` の temp リークと oversize 続行を直す
+
+失敗経路（while ループを抜けた後）で:
+
+1. `compressed.unlink(missing_ok=True)` してから return する
+2. `compressed.stat()` を呼ぶ前に `compressed.exists()` を確認する（ffmpeg が一度も出力しなかった場合の `FileNotFoundError` 回避）。ログは「圧縮失敗、元ファイル(<size>KB)のまま試行」の形に修正
+
+返り値の意味（失敗時は元パスを返す）は変えない — `set_thumbnail` 側の挙動互換のため。
+
+**Verify**: `uv run pytest tests/integration/test_upload_core.py -q` → all pass
+
+### Step 6: CHANGELOG 追記 + 全体検証
+
+`CHANGELOG.md` の `[Unreleased]` に Fixed として 3 点を 1 行ずつ追記。
+
+**Verify**: `uv run pytest -q` → all pass / `uv run ruff check src tests` → exit 0 / `uv run ruff format --check src tests` → exit 0
+
+## Test plan
+
+既存テストの構造パターン: `tests/test_collection_uploader.py`（CollectionUploader をフェイク config で組み、mixin メソッドを直接叩く）と `tests/integration/test_upload_core.py:212-225`（`pytest.raises(QuotaExhaustedError)` の先例）。
+
+新規テスト（各 Step の中で書いてもよいが、最終的に以下が揃うこと）:
+
+1. `_save_tracking` 後に `*.tmp` が残っていない + 内容がラウンドトリップする
+2. 破損 JSON（`"{truncated"` を書いたファイル）で `_load_tracking` → `None` が返り、`.json.corrupt` 退避ファイルが存在する
+3. `upload_collection` が `QuotaExhaustedError(retry_after_seconds=42.0)` を raise するようモックした場合: 返り値 action が `complete_collection_quota_exhausted`、`details["retry_after_seconds"] == 42.0`、かつ tracking の `complete_collection.status` が `"failed"` になっ**ていない**こと
+4. short_uploader: `upload_video` が `QuotaExhaustedError` を raise → `details["retryable"] is True`
+5. `_compress_thumbnail`: `strategy.next_quality` が即 `None` を返すよう最小サイズ超ファイル + ffmpeg 不発を模擬（`subprocess.run` を monkeypatch）→ 返り値が元パスで、temp ファイルが残っていない（`tmp_path` fixture 配下を検査、または `tempfile.tempdir` を monkeypatch）
+
+**Verification**: `uv run pytest tests/test_collection_uploader.py tests/test_short_uploader.py tests/integration/test_upload_core.py -q` → all pass、新規 5 ケースを含む
+
+## Done criteria
+
+- [ ] `uv run pytest -q` exit 0
+- [ ] `uv run ruff check src tests` / `uv run ruff format --check src tests` exit 0
+- [ ] `rg -n 'except Exception' src/youtube_automation/agents/_tracking_io.py` のヒットが `_save_tracking` 内の 1 件以下
+- [ ] `rg -n 'QuotaExhaustedError' src/youtube_automation/agents/` が `_complete_collection_executor.py` と `short_uploader.py` の両方でヒットする
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] `git status` で in-scope 外の変更がない
+- [ ] `plans/README.md` の 020 行を更新
+
+## STOP conditions
+
+以下が起きたら中断して報告（改変で乗り切らない）:
+
+- Drift check で in-scope ファイルに差分があり、「Current state」の抜粋と実コードが一致しない
+- `result["action"]` を閉集合として分岐する消費側が `short_uploader.py:515` 以外に見つかった（新 action 追加が安全でなくなる）
+- tracking JSON の `schema_version` を変えないと実装できない事態になった
+- Step の Verify が修正 1 回を挟んで 2 回失敗した
+
+## Maintenance notes
+
+- 将来 `_update_workflow_upload`（workflow-state 書き込み）もアトミック化するなら、Step 1 で入れたパターンを `utils/` の共有ヘルパーに昇格させる価値が出る（今回は 2 箇所目ができるまで YAGNI で見送り）
+- レビューで見るべき点: (a) quota 分岐で tracking に `failed` が**書かれない**こと、(b) `.json.corrupt` 退避が `os.replace`（同一 FS 内 rename）であること
+- 明示的に先送り: `youtube_auto_uploader.py` の同種 catch の監査、`get_recent_videos` 系（Plan 022 が担当）

--- a/plans/021-bulk-desc-read-modify-write.md
+++ b/plans/021-bulk-desc-read-modify-write.md
@@ -1,0 +1,177 @@
+# Plan 021: bulk_update_descriptions_from_md の snippet 更新を read-modify-write 化し defaultAudioLanguage 消失を止める
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5394c378..HEAD -- src/youtube_automation/scripts/bulk_update_descriptions_from_md.py tests/test_bulk_update_descriptions_from_md.py`
+> 差分が出たら「Current state」の抜粋と実コードを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: MED（公開済み動画のメタデータを一括で書き換えるツールの挙動変更）
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `5394c378`, 2026-07-09
+
+## Why this matters
+
+`yt-bulk-update-desc` は `collections/live/*` の descriptions.md を YouTube へ一括反映するツールで、`videos().update(part="snippet")` を使う。**YouTube Data API の仕様では `part=snippet` の update は snippet リソース全体を置換し、リクエスト body に含まれない mutable フィールドはクリアされる**。現在の実装は body を手組みで列挙しており、`defaultAudioLanguage` が入っていないため、このツールを通した全動画で音声言語設定が消える。さらに `defaultLanguage` 未設定の動画には `"en"` を注入してしまう（日本語チャンネルでは誤ラベル）。音楽アップロードでは `defaultAudioLanguage` が設定されていることが多く、back catalog 全体が blast radius。姉妹スクリプト `bulk_update_synthetic_media.py` は全く同じ理由で read-modify-write を既に実装しており、本プランはそのパターンに揃えるだけである。
+
+## Current state
+
+- `src/youtube_automation/scripts/bulk_update_descriptions_from_md.py` — 対象スクリプト（181 行）。`:116` で `videos().list(id=..., part="snippet")` により現 snippet を取得済み（`old_snippet`、`:124`）なのに、body 構築で使っていない
+- `tests/test_bulk_update_descriptions_from_md.py` — 既存テスト。`videos().update().execute` の呼び出し回数・dry-run・UTF-16 境界を検証している（構造パターンとして流用する）
+
+問題の body 構築 — `bulk_update_descriptions_from_md.py:156-165`:
+
+```python
+        body = {
+            "id": p["video_id"],
+            "snippet": {
+                "title": new_title,
+                "description": new_desc,
+                "tags": new_tags,
+                "categoryId": old_snippet.get("categoryId", "10"),
+                "defaultLanguage": old_snippet.get("defaultLanguage", "en"),
+            },
+        }
+        try:
+            yt.videos().update(part="snippet", body=body).execute()
+            print("   ✅ updated")
+        except Exception as e:
+            print(f"   ❌ update failed: {e}")
+```
+
+リポジトリ内の正しい先例 — `src/youtube_automation/scripts/bulk_update_synthetic_media.py:143-151`:
+
+```python
+def build_update_body(video_id: str, status: dict) -> dict:
+    """現 status を保持したまま ``containsSyntheticMedia=True`` を立てた update body を返す.
+
+    ``videos.update(part='status')`` は status リソース全体を置換するため、現値を
+    コピーして read-only キーを除去し、``containsSyntheticMedia`` だけ差し替える。
+    """
+    new_status = {k: v for k, v in status.items() if k not in READONLY_STATUS_KEYS}
+    new_status["containsSyntheticMedia"] = True
+    return {"id": video_id, "status": new_status}
+```
+
+### API 知識（executor が知っている必要がある事実）
+
+`videos.update` で書き換え可能な snippet のフィールドは次の 6 つだけ:
+`title`, `description`, `tags`, `categoryId`, `defaultLanguage`, `defaultAudioLanguage`。
+`videos().list(part="snippet")` のレスポンスにはこれ以外に `publishedAt` / `channelId` / `thumbnails` / `channelTitle` / `localized` / `liveBroadcastContent` などの read-only フィールドが混ざるため、**old_snippet の丸ごとコピーではなく mutable 6 キーの whitelist コピー**にする（synthetic_media の `READONLY_STATUS_KEYS` 方式の snippet 版）。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `uv run pytest tests/test_bulk_update_descriptions_from_md.py -q` | all pass |
+| 全テスト | `uv run pytest -q` | all pass |
+| Lint / Format | `uv run ruff check src tests && uv run ruff format --check src tests` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `src/youtube_automation/scripts/bulk_update_descriptions_from_md.py`
+- `tests/test_bulk_update_descriptions_from_md.py`
+- `CHANGELOG.md`（`[Unreleased]` 追記 — src/ を触るため必須）
+
+**Out of scope**:
+
+- `bulk_update_synthetic_media.py` — 参照する先例であり、変更しない
+- `bulk_update_short_localizations.py` — 別 part（localizations）を扱う別ツール。触らない
+- descriptions.md のパース部（`:110` より前）— 本プランの欠陥と無関係
+- title の UTF-16 100 units ガード（`:132-139`）— 正しく動いている
+
+## Git workflow
+
+- worktree 上で作業。base branch は main
+- commit 例: `fix(scripts): bulk_update_desc の snippet 更新を read-modify-write 化 (#<issue>)`
+- push / PR 化はオペレーター指示時のみ
+
+## Steps
+
+### Step 1: mutable キー whitelist で body を構築する関数を切り出す
+
+モジュールレベルに定数と純粋関数を追加する（テスト容易性のため main 内へ inline しない）:
+
+```python
+MUTABLE_SNIPPET_KEYS = ("title", "description", "tags", "categoryId", "defaultLanguage", "defaultAudioLanguage")
+
+
+def build_snippet_update_body(video_id: str, old_snippet: dict, title: str, description: str, tags: list) -> dict:
+    """現 snippet の mutable キーを保持したまま title/description/tags を差し替えた update body を返す.
+
+    ``videos.update(part='snippet')`` は snippet リソース全体を置換するため、
+    body に含まれない mutable フィールド（defaultAudioLanguage 等）は消える。
+    bulk_update_synthetic_media.build_update_body と同じ read-modify-write 方式。
+    """
+    new_snippet = {k: old_snippet[k] for k in MUTABLE_SNIPPET_KEYS if k in old_snippet}
+    new_snippet["title"] = title
+    new_snippet["description"] = description
+    new_snippet["tags"] = tags
+    new_snippet.setdefault("categoryId", "10")
+    return {"id": video_id, "snippet": new_snippet}
+```
+
+要点: `defaultLanguage` は**存在するときだけ**引き継ぐ（無い動画に `"en"` を注入する現行挙動を廃止）。`categoryId` の `"10"`（音楽）fallback は現行挙動を維持。
+
+**Verify**: `uv run ruff check src/youtube_automation/scripts/bulk_update_descriptions_from_md.py` → exit 0
+
+### Step 2: main ループから新関数を使う
+
+`:156-165` の手組み body を `body = build_snippet_update_body(p["video_id"], old_snippet, new_title, new_desc, new_tags)` に置き換える。あわせて `:169` の `except Exception` を `except HttpError` に狭める（`from googleapiclient.errors import HttpError` を追加。1 本の失敗で残りのバッチを止めない print-and-continue 挙動は維持）。
+
+**Verify**: `uv run pytest tests/test_bulk_update_descriptions_from_md.py -q` → all pass（既存テストが body 形状を握っていれば期待値を新形状に更新してよい — それがこの修正の本体）
+
+### Step 3: 回帰テストを追加
+
+`tests/test_bulk_update_descriptions_from_md.py` に既存テストと同じフェイク構造で追加:
+
+1. old_snippet に `defaultAudioLanguage: "ja"` がある → update body の snippet に `defaultAudioLanguage == "ja"` が含まれる
+2. old_snippet に `defaultLanguage` が**ない** → body の snippet に `defaultLanguage` キーが**存在しない**（`"en"` 注入の再発防止）
+3. old_snippet の read-only キー（例 `publishedAt`, `thumbnails`）が body に**含まれない**
+4. `build_snippet_update_body` 単体: title/description/tags が引数の値で上書きされる
+
+**Verify**: `uv run pytest tests/test_bulk_update_descriptions_from_md.py -q` → all pass（新規 4 ケース含む）
+
+### Step 4: CHANGELOG 追記 + 全体検証
+
+`CHANGELOG.md` `[Unreleased]` の Fixed に「bulk_update_desc が snippet 全置換で defaultAudioLanguage を消していた問題を read-modify-write 化で修正」を追記。
+
+**Verify**: `uv run pytest -q` → all pass / `uv run ruff check src tests && uv run ruff format --check src tests` → exit 0
+
+## Test plan
+
+（Step 3 に統合。構造パターンは同ファイルの既存テスト — `videos().update` をモックし body を捕捉して assert する方式 — に従う）
+
+## Done criteria
+
+- [ ] `uv run pytest -q` exit 0（新規 4 テスト含む）
+- [ ] `rg -n 'defaultAudioLanguage' src/youtube_automation/scripts/bulk_update_descriptions_from_md.py` が MUTABLE_SNIPPET_KEYS 定義でヒットする
+- [ ] `rg -n '"defaultLanguage": old_snippet.get' src/youtube_automation/scripts/` が 0 件（"en" fallback の消滅）
+- [ ] `uv run ruff check src tests` / `uv run ruff format --check src tests` exit 0
+- [ ] `CHANGELOG.md` `[Unreleased]` に追記
+- [ ] `git status` で in-scope 外の変更なし
+- [ ] `plans/README.md` の 021 行を更新
+
+## STOP conditions
+
+- Drift check 不一致（特に body 構築部 `:156-165` が既に変更されている場合）
+- 既存テストが body の旧形状（`defaultLanguage: "en"` fallback 等）を**仕様として**固定しており、その変更が他のテスト・スキル記述（`.claude/skills/video-description/` 等）と連動している形跡を見つけた場合 — 影響範囲の判断はオペレーターに戻す
+- `videos().list` の取得 part が snippet 以外に変わっていた場合
+
+## Maintenance notes
+
+- レビューで見るべき点: whitelist が mutable 6 キー**ちょうど**であること（read-only キーを送ると API はエラーにはしないが、意図しないフィールドを「保持しているつもり」になる事故のもと）
+- 将来 `part` を増やす（status 等を同時更新する）変更が入る場合、synthetic_media 側の `READONLY_STATUS_KEYS` との共通化を検討する
+- 明示的に先送り: 実 YouTube への統合テスト（このツールは operator が dry-run → 実行の 2 段で使う運用ガードが既にある）

--- a/plans/022-analytics-collect-quota-reduction.md
+++ b/plans/022-analytics-collect-quota-reduction.md
@@ -1,0 +1,201 @@
+# Plan 022: analytics collect の uploads playlist 二重取得を解消し、video_listing の例外握りつぶしと TZ 境界ズレを直す
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5394c378..HEAD -- src/youtube_automation/utils/video_listing.py src/youtube_automation/utils/strategic_analytics.py src/youtube_automation/scripts/analytics_system.py`
+> 差分が出たら「Current state」の抜粋と実コードを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: perf + bug
+- **Planned at**: commit `5394c378`, 2026-07-09
+
+## Why this matters
+
+YouTube Data API は日次ハードクォータ（デフォルト 10,000 units）の共有資源で、この自動化基盤の全機能が奪い合う。`analytics-collect` の標準実行は uploads playlist の全ページネーション（50 本/ページ、1 ページ = 1 unit）を**最低 2 回**走らせている — 動画リストは 1 プロセス内で変わらないのに。数百本のチャンネルでは毎 collect で数〜十数 units を無駄にし、チャンネルが増えるほど効く。あわせて同ファイルに 2 つの正確性問題が同居している: (1) `get_all_channel_videos` / `get_recent_videos` が生 `Exception` を握りつぶして `[]` を返すため、認証切れやクォータ枯渇が「動画 0 本のチャンネル」として無言で分析結果に化ける。(2) naive `datetime.now()`（ローカル JST）と UTC の `publishedAt` を比較しており、「直近 N 日」フィルタの境界が 9 時間ズレる（真の境界直後 9 時間に公開された動画が漏れる）。同一ファイル中心の S 級修正なので 1 プランにまとめる。
+
+## Current state
+
+- `src/youtube_automation/utils/video_listing.py` — `VideoListingMixin`。`YouTubeAnalyticsCollector`（`utils/analytics_collector.py:43-`）に合成される mixin の 1 つ。**mixin には `__init__` が無い**（キャッシュ属性は遅延初期化にする必要がある）
+- `src/youtube_automation/utils/strategic_analytics.py` — `get_combined_analytics`（efficient 経路）が `:50` で全動画取得し、`:56-63` に直近フィルタの**重複実装**（同じ naive TZ 比較）を持つ
+- `src/youtube_automation/scripts/analytics_system.py` — collect の司令塔。`:50` で `YouTubeAnalyticsCollector()` を生成し、`:102` の `collect_basic_analytics(...)` の後、`:133` で**再度** `self.collector.get_all_channel_videos()` を呼ぶ
+
+二重取得の実体 — `video_listing.py:46-57`（memoize なしの全ページネーション）:
+
+```python
+            while True:
+                # プレイリストのアイテムを取得
+                playlist_response = (
+                    self.youtube_service.playlistItems()
+                    .list(
+                        part="snippet,contentDetails",
+                        playlistId=uploads_playlist_id,
+                        maxResults=50,
+                        pageToken=next_page_token,
+                    )
+                    .execute()
+                )
+```
+
+握りつぶし — `video_listing.py:81-86`（`get_recent_videos` にも `:124-126` に同型）:
+
+```python
+        except HttpError as e:
+            logger.error(f"YouTube API エラー（動画リスト取得）: {e}")
+            return []
+        except Exception as e:
+            logger.error(f"動画リスト取得エラー: {e}")
+            return []
+```
+
+TZ 境界ズレ — `video_listing.py:104-116`:
+
+```python
+            cutoff_date = datetime.now() - timedelta(days=days)
+            ...
+                published_date = datetime.fromisoformat(video["published_at"].replace("Z", "+00:00"))
+
+                if published_date.replace(tzinfo=None) >= cutoff_date:
+```
+
+`cutoff_date` はローカル（JST）の naive 時刻、`published_date.replace(tzinfo=None)` は UTC の壁時計。JST は UTC+9 なので cutoff が実質 9 時間厳しくなる。同じパターンが `strategic_analytics.py:56-63` にもある。
+
+再取得箇所 — `analytics_system.py:131-138`:
+
+```python
+                # 動画×日次データ（launch curve 分析用）
+                try:
+                    video_list = self.collector.get_all_channel_videos()
+                    video_ids = [v["video_id"] for v in video_list]
+```
+
+`get_all_channel_videos` の全呼び出し箇所（確認済み・これで全部）: `video_listing.py:107`（get_recent_videos 内）、`strategic_analytics.py:50` / `:251`、`analytics_system.py:133`。Protocol 宣言が `analytics_base.py:32` にある。
+
+### 適用される規約
+
+- 生 `Exception` catch はリポジトリ規約違反。ドメイン例外は `utils/exceptions.py`（`YouTubeAPIError.from_http_error(error, context)` が使える）
+- `src/` を触るため `CHANGELOG.md` `[Unreleased]` 追記必須
+- テストの autouse fixture が config singleton をリセットする（`tests/conftest.py`）。collector はプロセス毎に生成されるためキャッシュはインスタンス属性で安全
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `uv run pytest tests/test_analytics_system.py tests/test_strategic_analytics_parallel.py -q` | all pass |
+| 新規テスト | `uv run pytest tests/test_video_listing.py -q` | all pass |
+| 全テスト | `uv run pytest -q` | all pass |
+| Lint / Format | `uv run ruff check src tests && uv run ruff format --check src tests` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `src/youtube_automation/utils/video_listing.py`
+- `src/youtube_automation/utils/strategic_analytics.py`（`:56-63` の TZ 比較の統一と `:50`/`:251` のキャッシュ経由化のみ）
+- `tests/test_video_listing.py`（新規）
+- `CHANGELOG.md`
+
+**Out of scope**:
+
+- `analytics_system.py:133` の呼び出し自体 — インスタンスキャッシュ導入で自動的に 2 回目が無料になるため、**呼び出し構造は変えない**
+- PERF-02 系（`_get_video_details` / `dimensions=video` クエリのサブ分析間共有）— M 級の別課題。今回は着手しない
+- `analytics_base.py` の Protocol シグネチャ変更
+- retention の per-video クエリ（API 仕様上バッチ不可、by design）
+
+## Git workflow
+
+- worktree 上で作業。base branch は main
+- commit 例: `fix(analytics): 全動画リストの instance cache 導入と TZ 境界・例外握りつぶし修正 (#<issue>)`
+- push / PR 化はオペレーター指示時のみ
+
+## Steps
+
+### Step 1: `get_all_channel_videos` にインスタンスキャッシュを入れる
+
+`video_listing.py` の `get_all_channel_videos` 冒頭（`initialize()` 呼び出しの後）に:
+
+```python
+        cached = getattr(self, "_all_videos_cache", None)
+        if cached is not None:
+            return cached
+```
+
+成功 return の直前で `self._all_videos_cache = videos` を代入。**空リスト `[]` はキャッシュしない**（エラー時 `[]` の再試行余地を残す — Step 2 で例外化した後も、途中 break の空結果を恒久化しないため）。あわせて `refresh: bool = False` 引数を追加し、`True` でキャッシュを無視して再取得できるようにする（Protocol `analytics_base.py:32` はデフォルト引数の追加なので互換）。
+
+**Verify**: `uv run pytest tests/test_analytics_system.py tests/test_strategic_analytics_parallel.py -q` → all pass
+
+### Step 2: 例外の握りつぶしをやめる
+
+`video_listing.py` の 2 メソッドで:
+
+- `except Exception` 節（`:84-86`, `:124-126`）を**削除**する
+- `except HttpError` 節は `raise YouTubeAPIError.from_http_error(e, "チャンネル動画リスト取得")` に変更する（`from youtube_automation.utils.exceptions import YouTubeAPIError` を追加）
+
+呼び出し側の空リスト分岐（`strategic_analytics.py:51-52` の `if not all_videos: return ...`）は「動画 0 本の正当なチャンネル」用として残す。`analytics_system.py:132` の daily セクションは既に `try` で囲まれているため collect 全体は落ちない（確認済み — `:132` の `try:`）。
+
+**Verify**: `uv run pytest -q` → all pass（analytics 系テストが `[]` フォールバックに依存していたら、そのテストは「エラーを無言で握りつぶす」仕様を固定していたということ — `pytest.raises(YouTubeAPIError)` へ書き換えてよい）
+
+### Step 3: TZ 比較を aware に統一する
+
+両ファイルの直近フィルタを次の形に:
+
+```python
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
+        ...
+            published_date = datetime.fromisoformat(video["published_at"].replace("Z", "+00:00"))
+            if published_date >= cutoff_date:
+```
+
+対象: `video_listing.py:104` + `:115`、`strategic_analytics.py:56` + `:63`。`from datetime import timezone` を追加。`.replace(tzinfo=None)` を撤去。
+
+**Verify**: `uv run pytest -q` → all pass
+
+### Step 4: 新規テスト + CHANGELOG
+
+`tests/test_video_listing.py` を新規作成（構造パターン: `tests/test_strategic_analytics_parallel.py` — collector を作らずフェイク `youtube_service` を属性注入して mixin メソッドを直接叩く方式に従う）。
+
+**Verify**: `uv run pytest tests/test_video_listing.py -q` → all pass / `uv run pytest -q` → all pass / ruff 2 コマンド exit 0
+
+## Test plan
+
+`tests/test_video_listing.py` に最低 5 ケース:
+
+1. **キャッシュ**: フェイク `playlistItems().list().execute` に呼び出しカウンタを仕込み、`get_all_channel_videos()` 2 回呼びで playlist ページ取得が 1 巡分しか走らない
+2. **refresh**: `get_all_channel_videos(refresh=True)` で再取得が走る
+3. **空リスト非キャッシュ**: 1 回目が 0 件 → 2 回目も API を叩く
+4. **例外**: `execute` が `HttpError` を raise（`googleapiclient.errors.HttpError` はフェイク resp で組める — `tests/integration/test_upload_core.py` に組み方の先例）→ `pytest.raises(YouTubeAPIError)`
+5. **TZ 境界**: `published_at` が「cutoff の 4 時間後（UTC）」の動画を用意し、`get_recent_videos(days=N)` に**含まれる**こと（修正前は JST ズレで漏れるケース）。時刻固定には monkeypatch で `datetime` を差し替えず、`published_at` を `datetime.now(timezone.utc)` 相対で組み立てる（実時刻依存を避ける）
+
+## Done criteria
+
+- [ ] `uv run pytest -q` exit 0（新規 5 テスト含む）
+- [ ] `rg -n 'except Exception' src/youtube_automation/utils/video_listing.py` → 0 件
+- [ ] `rg -n 'replace\(tzinfo=None\)' src/youtube_automation/utils/video_listing.py src/youtube_automation/utils/strategic_analytics.py` → 0 件
+- [ ] `rg -n '_all_videos_cache' src/youtube_automation/utils/video_listing.py` → ヒットあり
+- [ ] ruff check / format --check exit 0
+- [ ] `CHANGELOG.md` `[Unreleased]` に追記
+- [ ] `git status` で in-scope 外の変更なし
+- [ ] `plans/README.md` の 022 行を更新
+
+## STOP conditions
+
+- Drift check 不一致
+- `get_all_channel_videos` の呼び出し箇所が「Current state」に列挙した 4 箇所以外に増えていた場合（キャッシュの生存期間の再検討が要る）
+- Step 2 で `[]` フォールバックに依存するテストが 5 件を超えて壊れた場合（無言劣化が広範に仕様化されている — 影響範囲の判断をオペレーターへ）
+- `YouTubeAnalyticsCollector` がプロセスをまたいで再利用される（daemon 化等の）形跡を見つけた場合
+
+## Maintenance notes
+
+- このキャッシュは「1 プロセス = 1 collect 実行」前提。collector を長寿命化する変更（常駐 daemon 等）が入るなら TTL か明示 invalidation が要る — その時は `refresh=True` が既にある
+- レビューで見るべき点: 空リストをキャッシュしていないこと、`strategic_analytics.py` 側の直近フィルタが video_listing 側と同じ aware 比較になっていること
+- 明示的に先送り: PERF-02（サブ分析間の `_get_video_details` 共有、M 級）、`get_recent_videos` と `strategic_analytics.py:54-67` の直近フィルタ重複実装の共通化（今回は挙動統一まで）

--- a/plans/023-delete-dead-analytics-cluster.md
+++ b/plans/023-delete-dead-analytics-cluster.md
@@ -1,0 +1,125 @@
+# Plan 023: dead analytics/report クラスタ 3 ファイル（1,016 行）を削除する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5394c378..HEAD -- src/youtube_automation/utils/report_generator.py src/youtube_automation/utils/report_renderer.py src/youtube_automation/utils/analytics_analyzer.py src/youtube_automation/utils/ctr_analytics.py`
+> 差分が出たら Step 1 の到達可能性検査を必ずやり直す。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: tech-debt
+- **Planned at**: commit `5394c378`, 2026-07-09
+
+## Why this matters
+
+`utils/report_generator.py`（426 行）+ `utils/report_renderer.py`（127 行）+ `utils/analytics_analyzer.py`（463 行）は、analytics が現行の mixin 構成（`analytics_base.py` Protocol + `strategic_analytics.py` / `ctr_analytics.py` 等）へ移行する前の旧モノリスの残骸で、**どこからも import されていない**。実装らしい見た目（`AnalyticsAnalyzer` クラス、HTML レポート生成）のせいで「どちらの analytics 経路が正か」を読者に誤認させ、dead 側を拡張してしまう事故の温床になっている。テストもゼロなので削除はランタイムもスイートも壊し得ない。1,016 行のメンテナンス表面積が純減する。
+
+## Current state
+
+到達可能性は監査時に検証済み（executor は Step 1 で再検証すること）:
+
+- `report_generator.py` — importer ゼロ。`:23-24` で `analytics_analyzer` と `report_renderer` を import している（このクラスタ内部の参照のみ）
+- `report_renderer.py` — importer は `report_generator.py:24` だけ
+- `analytics_analyzer.py` — importer は `report_generator.py:23` だけ。`AnalyticsAnalyzer` はどのテストにも登場しない
+- 動的 import の確認済み: `importlib` / `__import__` を使うのは `cli_entrypoints.py`, `cli/skills_sync/__init__.py`, `utils/weekly_vote_log.py`, `utils/skill_config.py`, `utils/schemas/__init__.py`, `__init__.py` のみで、いずれもこの 3 モジュール名を文字列で参照しない
+- `pyproject.toml` の `[project.scripts]` にこの 3 モジュールを指す entry point は無い
+- 残る参照はコメント 1 行 — `src/youtube_automation/utils/ctr_analytics.py:16`:
+
+  ```
+  コレクション別ランキングは `analytics_analyzer._analyze_collection_ctrs` 側で
+  ```
+
+  これは stale なドキュメント参照であり、削除と同時に修正する
+
+- `docs/superpowers/specs/2026-04-14-launch-curve-analysis-design.md` と `docs/superpowers/plans/2026-04-14-launch-curve-analysis.md` にも名前が出るが、これらは**過去の設計記録**（歴史文書）なので触らない
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 到達可能性 | `rg -l 'report_generator\|report_renderer\|analytics_analyzer\|AnalyticsAnalyzer' src tests --glob '!__pycache__'` | 3 ファイル自身 + `ctr_analytics.py` のみ |
+| 全テスト | `uv run pytest -q` | all pass |
+| Lint / Format | `uv run ruff check src tests && uv run ruff format --check src tests` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `src/youtube_automation/utils/report_generator.py`（削除）
+- `src/youtube_automation/utils/report_renderer.py`（削除）
+- `src/youtube_automation/utils/analytics_analyzer.py`（削除）
+- `src/youtube_automation/utils/ctr_analytics.py`（`:16` 周辺のコメント 1 箇所の修正のみ）
+- `CHANGELOG.md`（`[Unreleased]` 追記 — src/ を触るため必須）
+
+**Out of scope**:
+
+- `docs/superpowers/` 配下 — 歴史文書。参照が残っていても直さない
+- CHANGELOG の**過去エントリ** — 履歴の書き換えはしない（追記のみ）
+- live な analytics mixin 群（`analytics_base.py`, `strategic_analytics.py`, `ctr_analytics.py` の実コード部分, `traffic_source_analytics.py`, `audience_analytics.py`, `retention_analytics.py`）— 削除対象と名前が似ているが**現役**。1 行も変えない
+- `strategic_analytics.py` の未使用 `comprehensive` モード — 監査で latent と判定されたが、削除判断は別（README の残課題参照）
+
+## Git workflow
+
+- worktree 上で作業。base branch は main
+- commit 例: `refactor(utils): 旧 analytics モノリス残骸 3 ファイル(1,016行)を削除 (#<issue>)`
+- push / PR 化はオペレーター指示時のみ
+
+## Steps
+
+### Step 1: 到達可能性を再検証する
+
+```
+rg -l 'report_generator|report_renderer|analytics_analyzer|AnalyticsAnalyzer' src tests --glob '!__pycache__'
+```
+
+期待: `src/youtube_automation/utils/report_generator.py`, `src/youtube_automation/utils/analytics_analyzer.py`, `src/youtube_automation/utils/ctr_analytics.py` の 3 件のみ（report_renderer は generator 経由でのみ参照されるため単体では出ないことがある）。**これ以外の src/tests ファイルが出たら STOP**。
+
+**Verify**: 上記コマンド → 期待どおりの 3 件以下
+
+### Step 2: 3 ファイルを削除し、コメントを修正する
+
+`git rm` で 3 ファイルを削除。`ctr_analytics.py:14-17` 付近の docstring/コメントから `analytics_analyzer._analyze_collection_ctrs` への言及を、実際の現行実装位置（そのコメントが説明している対象。前後の文脈から `ctr_analytics.py` 自身のメソッドを指すよう書き直すか、文ごと削除）に改める。コメント以外のコード変更はしない。
+
+**Verify**: `rg -n 'analytics_analyzer' src --glob '!__pycache__'` → 0 件
+
+### Step 3: CHANGELOG 追記 + 全体検証
+
+`CHANGELOG.md` `[Unreleased]` の Removed に「旧 analytics モノリスの unreachable な残骸（report_generator / report_renderer / analytics_analyzer、計 1,016 行）を削除」を追記。
+
+**Verify**: `uv run pytest -q` → all pass / `uv run ruff check src tests && uv run ruff format --check src tests` → exit 0
+
+## Test plan
+
+新規テストなし（削除のみ）。全スイート green が回帰検証そのもの。削除対象にテストが存在しないことは監査で確認済み（Step 1 の rg が tests/ でヒットしないことで再確認される）。
+
+## Done criteria
+
+- [ ] 3 ファイルがリポジトリから消えている（`ls src/youtube_automation/utils/report_generator.py` → No such file）
+- [ ] `rg -n 'report_generator|report_renderer|analytics_analyzer|AnalyticsAnalyzer' src tests --glob '!__pycache__'` → 0 件
+- [ ] `uv run pytest -q` exit 0
+- [ ] ruff check / format --check exit 0
+- [ ] `CHANGELOG.md` `[Unreleased]` に追記
+- [ ] `git status` で in-scope 外の変更なし
+- [ ] `plans/README.md` の 023 行を更新
+
+## STOP conditions
+
+- Step 1 の rg で src/tests 内に第 4 の参照元が出た（プラン作成後に誰かが使い始めた — 削除不可）
+- `uv run pytest -q` が削除後に fail し、失敗テストのトレースにこの 3 モジュールが関与している
+- wheel build / force-include（`pyproject.toml`）にこれらのファイルへの明示参照が見つかった場合（監査時点では無い）
+
+## Maintenance notes
+
+- レビューで見るべき点: diff が「3 ファイル削除 + コメント 1 箇所 + CHANGELOG」**だけ**であること
+- この削除で `utils/` の flat 化解消（監査 finding DEBT-03、未プラン化）の対象母数が 83 → 80 になる。将来 `utils/analytics/` パッケージ化をやる場合、dead code が消えている分だけ移行が単純になる
+- `strategic_analytics.py` の `comprehensive` モード（呼び出し元ゼロの N+1 経路、`:208-210` / `:237-261`）は本プランで消していない。次に analytics を触る誰かが「使うか消すか」を判断すること（plans/README の残課題に記録済み）

--- a/plans/024-toolchain-hygiene.md
+++ b/plans/024-toolchain-hygiene.md
@@ -1,0 +1,264 @@
+# Plan 024: ツールチェーン整備 — dev 依存の一本化・ruff B/RUF 導入・seaborn 削除・Any-gate の CI バックストップ・CJK フォント回帰テスト
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 5394c378..HEAD -- pyproject.toml .github/workflows/ci.yml flake.nix ONBOARDING.md README.md uv.lock`
+> 差分が出たら「Current state」の抜粋と実コードを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW（すべて挙動非依存のツールチェーン変更 + lint 指摘の機械的解消）
+- **Depends on**: none。ただし **020〜023 と CHANGELOG.md / pyproject.toml が衝突しやすい**ので、連続実行時は最後に回して rebase すること
+- **Category**: dx
+- **Planned at**: commit `5394c378`, 2026-07-09
+
+## Why this matters
+
+4 つの独立した小さなほつれを一括で直す。(1) dev 依存が `[project.optional-dependencies].dev` と `[dependency-groups].dev` に**二重宣言されドリフト済み** — 素の `uv sync` では ruff が入らず、新規貢献者のローカル `ruff check` が動かない（CI は `--extra dev` で偶然救われている）。(2) ruff が `E,F,I,W` のみで、バグ検出系の `B`（bugbear）/`RUF` が無効 — メンテナンスモードのリポジトリでこそ、レビューだけが頼りの欠陥クラス（except 内 raise の from 欠落、mutable class default 等）を機械捕捉に載せる価値が高い。(3) `seaborn` は宣言だけで import ゼロの死んだ直接依存。(4) 「新規 Any 禁止」ゲートが client-side lefthook のみで、`origin/main` 不在時は self-skip する — CI バックストップが無く実質 advisory。加えて、2020 年から未更新の `japanize-matplotlib`（CJK フォントの単一障害点）に glyph 回帰テストを張り、壊れたら即検知できるようにする（移行そのものは別判断）。
+
+## Current state
+
+### (1) dev 依存の二重宣言 — `pyproject.toml:33-34` と `:155-158`
+
+```toml
+[project.optional-dependencies]
+dev = ["pytest>=9,<10", "ruff>=0.15,<1"]
+veo = []  # google-genai, Pillow moved to main dependencies
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
+```
+
+`uv sync` はデフォルトで `dependency-groups` の dev を入れる（→ ruff が入らない）。CI は `uv sync --extra dev` を使用。`--extra dev` の参照箇所（更新対象）: `.github/workflows/ci.yml:14`（lint job）/ `:27`（test job）/ `:40`（windows job）、`flake.nix`、`ONBOARDING.md`、`README.md`。`docs/migration/`・`docs/investigations/`・`docs/upgrades/` にも文字列があるが**歴史文書なので触らない**。
+
+### (2) ruff ルール — `pyproject.toml:152-153`
+
+```toml
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+```
+
+監査時の実測（`uv run ruff check --select B,RUF --statistics src tests`、2026-07-09）: 総数 6,362 件だが、うち **6,147 件は RUF001/RUF002/RUF003（ambiguous-unicode）** — 日本語 docstring/コメント/文字列への誤検知であり ignore が正しい。それを除く実バックログは約 215 件: RUF100×93（unused-noqa、ただし select 集合依存で実数は変わる）、RUF043×35（テストの `pytest.raises(match=...)` の正規表現メタ文字）、B904×22（`raise ... from` 欠落）、RUF013×15（implicit Optional）、RUF012×10（mutable class default）、RUF005×9、B905×7（zip strict 未指定）、B007×5、ほか少数。約半数は `--fix` で自動修正可能。
+
+### (3) seaborn — `pyproject.toml:22`
+
+```toml
+    "seaborn>=0.13,<1",
+```
+
+`rg -n 'seaborn|sns\.' src tests` → 0 件（監査時確認済み。transitive に必要な pandas/matplotlib は独立に直接依存として宣言済み）。
+
+### (4) Any-gate — `.lefthook/pre-push/any-usage-gate.sh:16-21`
+
+```bash
+  BASE_REF="origin/main"
+  if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+    echo "any-usage-gate: ${BASE_REF} が無いためスキップします（CI / review で確認してください）。" >&2
+    exit 0
+  fi
+```
+
+スクリプトは `PRE_PUSH_DIFF_BASE` 環境変数があればそれを diff 基準に使う（`:13-15`）。bash + python3 のみに依存（`:45-48` で python3 を検出、ubuntu-latest に標準装備）。CI（`.github/workflows/ci.yml`）には対応 job が無い。**注意**: lefthook.yml の pre-push は「changelog-gate.sh が唯一のエントリポイントで他ゲートへ連鎖する」構成をコメントで固定している — **lefthook.yml は触らない**。CI 側に独立 job を足すだけ。
+
+### (5) japanize-matplotlib — 単一消費者 `src/youtube_automation/utils/launch_curve_plotter.py:11`
+
+```python
+import japanize_matplotlib  # noqa: E402, F401 — registers Japanese fonts
+```
+
+`uv.lock` 上 `japanize-matplotlib==1.1.3`（最終リリース 2020-10）。matplotlib は 3.10.8。壊れたときの症状は「日本語ラベルが豆腐化」だが、matplotlib は描画時に `Glyph NNNN (...) missing from font(s)` の `UserWarning` を出すため機械検知できる。
+
+### 適用される規約
+
+- `pyproject.toml` を触るため `CHANGELOG.md` `[Unreleased]` 追記必須
+- CI は nix devShell 経由（`nix develop --command ...`）。ローカル検証も同じコマンドが使えるが、`uv run` 直でも可
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 依存同期 | `uv sync` | exit 0、ruff がインストールされる（Step 1 後） |
+| Lint 全量 | `uv run ruff check .` | exit 0（Step 2 完了後） |
+| Format | `uv run ruff format --check .` | exit 0 |
+| 全テスト | `uv run pytest -q` | all pass |
+| lock 再生成 | `uv lock` | exit 0、uv.lock 更新 |
+| any-gate 単体 | `PRE_PUSH_DIFF_BASE=$(git merge-base origin/main HEAD) bash .lefthook/pre-push/any-usage-gate.sh` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `pyproject.toml`
+- `uv.lock`（`uv lock` / `uv sync` による再生成のみ。手編集禁止）
+- `.github/workflows/ci.yml`
+- `flake.nix` / `ONBOARDING.md` / `README.md`（`--extra dev` 記述の更新のみ）
+- `src/**/*.py` / `tests/**/*.py`（**Step 2 の ruff 指摘解消に必要な機械的修正のみ**）
+- `tests/test_japanize_font_regression.py`（新規）
+- `CHANGELOG.md`
+
+**Out of scope**:
+
+- `lefthook.yml` — pre-push の 1 コマンド構成はコメントで意図固定されている。触らない
+- `docs/migration/` / `docs/investigations/` / `docs/upgrades/` の `--extra dev` 記述 — 歴史文書
+- japanize-matplotlib の**置換**（フォント直接登録への移行）— 本プランは回帰テストの設置まで。移行は壊れてから/matplotlib メジャー更新時に判断
+- ruff `UP` / `SIM` の導入 — メンテナンスモードでは churn に見合わない（監査で棄却済み）
+- `[project.optional-dependencies].veo`（空 extra）— 後方互換のため残す
+- extensions/（TS 側）の lint — 別ツールチェーン
+
+## Git workflow
+
+- worktree 上で作業。base branch は main
+- 論理単位でコミットを分ける（最低: Step 1+3 / Step 2 / Step 4 / Step 5 の 4 コミット推奨）。例: `chore(dev): dev 依存を dependency-groups へ一本化 (#<issue>)`
+- push / PR 化はオペレーター指示時のみ
+
+## Steps
+
+### Step 1: dev 依存を `[dependency-groups]` へ一本化する
+
+1. `pyproject.toml` の `[dependency-groups]` を `dev = ["pytest>=9,<10", "ruff>=0.15,<1"]` にする（pin は optional-dependencies 側の広い指定を採用）
+2. `[project.optional-dependencies]` から `dev` 行を削除（`veo = []` は残す）
+3. `uv lock` を実行
+4. `--extra dev` 参照を更新: `.github/workflows/ci.yml` の 3 箇所を `uv sync` に、`flake.nix` / `ONBOARDING.md` / `README.md` 内の該当記述を同様に（`rg -n 'extra dev' .github flake.nix ONBOARDING.md README.md` で漏れなく拾う）
+
+**Verify**: `uv sync && uv run ruff --version && uv run pytest -q` → すべて exit 0 / `rg -n 'extra dev' .github flake.nix ONBOARDING.md README.md` → 0 件
+
+### Step 2: ruff に B / RUF を導入し、バックログを解消する
+
+1. `pyproject.toml` を:
+
+```toml
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "B", "RUF"]
+# RUF001/002/003: 日本語コードベースのため全角文字の ambiguous-unicode 検知は誤検知のみ
+ignore = ["RUF001", "RUF002", "RUF003"]
+
+[tool.ruff.lint.per-file-ignores]
+# pytest.raises(match=...) の正規表現メタ文字警告はテスト可読性を優先して抑制
+"tests/**" = ["RUF043"]
+```
+
+2. `uv run ruff check . --fix` で自動修正可能分を消化（安全 fix のみ。`--unsafe-fixes` は使わない）
+3. 残りを手動解消。ルール別の方針:
+   - **B904**（~22 件）: except 節内の raise に `from e`（原因連鎖が有用な場合）または `from None`（意図的に隠す場合）を付ける。迷ったら `from e`
+   - **RUF013**: 暗黙 Optional 引数に `| None` を明記（挙動変更なし）
+   - **RUF012**: クラス変数の mutable default に `typing.ClassVar[...]` 注釈を付ける（**Any は使わない** — any-gate に引っかかる）
+   - **B905**: `zip(..., strict=False)` を明示（zip のデフォルトと同じ = 挙動保存）。両 iterable が同一長であることがコード上自明な場合のみ `strict=True`
+   - **B007**: 未使用ループ変数を `_` に
+   - **RUF100**: select 集合が変わったので実数は再計測される。残った unused-noqa は削除
+   - その他の単発（B017, RUF005, RUF010, RUF015, RUF017, RUF019, RUF022, RUF023, RUF046, RUF059）: メッセージの指示どおり機械的に。**修正がコードの意味を変えると思ったら該当行のみ `# noqa: <rule>` + 1 語の理由コメントで逃がしてよい**（10 件を超えて noqa 逃げが必要なら STOP）
+4. `uv run ruff format .` で format 差分がないことを確認（fix が format を崩した場合のみ再 format）
+
+**Verify**: `uv run ruff check .` → exit 0 / `uv run pytest -q` → all pass（lint fix による挙動変化がないことの確認）
+
+### Step 3: seaborn を削除する
+
+`pyproject.toml:22` の seaborn 行を削除し `uv lock`。事前に `rg -n 'seaborn' src tests --glob '!__pycache__'` が 0 件であることを再確認。
+
+**Verify**: `uv sync && uv run pytest -q` → all pass / `rg -n '"seaborn' pyproject.toml` → 0 件
+
+### Step 4: Any-gate の CI バックストップ job を追加する
+
+`.github/workflows/ci.yml` に job を追加（PR のみ。push 時は base が定義できないため対象外とする）:
+
+```yaml
+  any-gate:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check new Any usage
+        env:
+          PRE_PUSH_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+        run: bash .lefthook/pre-push/any-usage-gate.sh
+```
+
+既存の `changelog` job（`:44-`）と同じ構造（`fetch-depth: 0` + base sha を env で渡す）を踏襲している。
+
+**Verify**: ローカルで `PRE_PUSH_DIFF_BASE=$(git merge-base origin/main HEAD) bash .lefthook/pre-push/any-usage-gate.sh` → exit 0（自分の作業ブランチに新規 Any が無いこと。Step 2 の RUF012 対応で `Any` を書いていたらここで捕まる — ClassVar の具体型に直すこと）
+
+### Step 5: CJK フォント glyph 回帰テストを追加する
+
+`tests/test_japanize_font_regression.py` を新規作成:
+
+```python
+"""japanize-matplotlib（2020 年から未更新）の font 登録が壊れたら検知する回帰テスト。
+
+壊れた場合の症状は日本語ラベルの豆腐化で、matplotlib は描画時に
+"Glyph NNNN ... missing from font(s)" の UserWarning を出す。それを検知する。
+"""
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def test_japanese_glyphs_render_without_missing_font_warnings():
+    import japanize_matplotlib  # noqa: F401 — フォント登録の副作用が本テストの対象
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.set_title("日本語ラベル描画テスト（再生回数・視聴維持率）")
+    ax.plot([0, 1], [0, 1], label="テスト系列")
+    ax.legend()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fig.canvas.draw()
+    plt.close(fig)
+
+    missing = [w for w in caught if "missing from font" in str(w.message)]
+    assert not missing, f"日本語 glyph が描画できていない: {[str(w.message) for w in missing]}"
+```
+
+**Verify**: `uv run pytest tests/test_japanize_font_regression.py -q` → 1 passed
+
+### Step 6: CHANGELOG 追記 + 全体検証
+
+`CHANGELOG.md` `[Unreleased]` に Changed（dev 依存一本化 / ruff B・RUF 導入）と Removed（seaborn）を追記。
+
+**Verify**: `uv run pytest -q` → all pass / `uv run ruff check . && uv run ruff format --check .` → exit 0
+
+## Test plan
+
+- 新規: `tests/test_japanize_font_regression.py`（Step 5、1 ケース）
+- 既存スイート全 green が Step 2 の「lint fix は挙動を変えていない」ことの検証
+- CI job（Step 4）は PR を開いたときに初めて実走する — ローカルでは Step 4 の Verify コマンドが等価検証
+
+## Done criteria
+
+- [ ] `rg -n 'optional-dependencies' pyproject.toml` の dev 行が消え、`[dependency-groups].dev` に pytest + ruff がある
+- [ ] `uv run ruff check .` exit 0（select に B, RUF を含む状態で）
+- [ ] `rg -n 'seaborn' pyproject.toml uv.lock` → pyproject 0 件（uv.lock は transitive で残らないこと — 残ったら何かが依存している。STOP 条件参照）
+- [ ] `.github/workflows/ci.yml` に `any-gate` job が存在し、`rg -n 'extra dev' .github` → 0 件
+- [ ] `uv run pytest -q` exit 0（glyph 回帰テスト含む）
+- [ ] `CHANGELOG.md` `[Unreleased]` に追記
+- [ ] `git status` で in-scope 外の変更なし
+- [ ] `plans/README.md` の 024 行を更新
+
+## STOP conditions
+
+- Drift check 不一致（特に pyproject.toml の依存節が既に変わっている場合）
+- Step 2 で `# noqa` 逃げが 10 件を超える（ルール選定の再検討が要る — 報告して指示を待つ）
+- Step 2 の fix 後に pytest が fail し、原因が lint fix にある（当該 fix を revert して noqa + 報告）
+- Step 3 で `uv lock` 後も uv.lock に seaborn が残る（何かが transitive に要求している — 削除中止して報告）
+- Step 5 のテストが**現状のコードで**すでに fail する（japanize-matplotlib が既に壊れている — それ自体が重要 finding なので即報告。テスト追加は保留）
+
+## Maintenance notes
+
+- ruff / pytest のバージョン更新時、`[dependency-groups].dev` だけを見ればよくなった（二重管理の終了）
+- matplotlib をメジャー更新（4.x）する際は japanize-matplotlib 互換が最大の懸念 — Step 5 のテストが早期警報になる。fail したら `matplotlib.font_manager.fontManager.addfont()` による直接登録への移行（監査 finding DEPS-02 の fix sketch）を実施
+- レビューで見るべき点: Step 2 の diff に「機械的でない」変更（ロジック変更・リネーム）が紛れていないこと
+- 明示的に先送り: japanize-matplotlib の置換移行、ruff `UP`/`SIM`、mypy/pyright 導入（監査で「導入しない」判断 — plans/README 参照）

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,6 +4,46 @@
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
+## 第 4 回監査（Python コア本体の一般監査、2026-07-09、基準 commit `5394c378`）
+
+初の `src/youtube_automation/`（~46K 行）本体監査。並列 4 subagent（正確性+セキュリティ / パフォ+依存 / テスト+負債 / DX+docs+方向性）→ 全 findings を advisor が実読 vet。
+総評: subprocess・パス traversal・OAuth・シークレット・コメント冪等性は防御済み、クリティカルパスは 4,976 テストで実挙動検証済みと**健全**。実弾はアップロード経路のエラー処理・dead code・ツールチェーンのほつれに集中。
+
+### Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
+|------|-------|----------|--------|------------|-------|-----|--------|
+| 020 | アップロード経路の堅牢化（tracking アトミック化 / QuotaExhaustedError 非終端化 / サムネ temp リーク） | P1 | S-M | — | — | — | TODO |
+| 021 | bulk_update_desc の snippet 更新を read-modify-write 化（defaultAudioLanguage 消失防止） | P1 | S | — | — | — | TODO |
+| 022 | analytics collect の uploads playlist 二重取得解消 + video_listing の例外/TZ 修正 | P2 | S | — | — | — | TODO |
+| 023 | dead analytics/report クラスタ 3 ファイル（1,016 行）削除 | P2 | S | — | — | — | TODO |
+| 024 | ツールチェーン整備（dev 依存一本化 / ruff B・RUF / seaborn 削除 / Any-gate CI / CJK フォント回帰テスト） | P2 | M | — | — | — | TODO |
+
+### Dependency notes
+
+- 020〜023 は互いにファイル非重複で並列実行可。**024 は全プランと CHANGELOG.md が、020 と `upload_core.py` の近傍が競合しうる**ため、連続実行時は 024 を最後に回して rebase する
+- 020〜024 すべて CHANGELOG `[Unreleased]` 追記必須（docs/tests のみの変更なし）
+
+### Findings considered and rejected（再監査不要）
+
+- **`ci.yml` の `parallel:` ステップが不正構文疑い**: 誤り。現行 GitHub Actions の正規のステップグループ構文で、run 29001443387 で Ruff 両ステップの実行成功を確認済み
+- **`collection_serve` の同時 POST `/downloaded` race**: 単一オペレーター + 単一拡張の運用モデルでは実発生確率ほぼゼロ（第 1 回監査の `write_distrokid_release` TOCTOU 棄却と同判断）。多重化するなら per-cid lock を検討
+- **mypy/pyright 導入**: tayk（TS 後継、ADR-0021）移行済みのメンテナンスモードでは L+ 工数の回収期間が無い。「導入しない」を本行で明文化とする。型規律は any-usage-gate（024 で CI 化）が代替
+- **`QuotaExceededError` が dormant という subagent 報告**: 二重に誤り。実名は `QuotaExhaustedError`（exceptions.py:45）で、upload_core.py:205 から raise されテスト済み。問題は「呼び出し側が握りつぶす」ことで、020 が修正する
+- **`schedule.py` vs `publish_schedule.py` の重複疑い / `profile.py` 等の dead 疑い / comments の generator 3 実装**: いずれも誤検知（責務が別 / 現役 importer あり / 意図した strategy パターン）
+- **CLI 起動時の pandas/matplotlib 重量 import**: 誤検知。`cli_entrypoints.py` は `import_module` の遅延 dispatcher で、重量 import は plotting 系コマンドに閉じている
+- **retention の per-video Analytics クエリ**: audience retention curve にバッチ endpoint が無い API 制約。by design
+- **GitHub Actions の Node 20 deprecation 注記**: 現状は自動 fallback で実害なし。actions メジャー bump は任意のついで作業
+
+### 監査で plan 化を見送った残課題
+
+- **doctor.py（2,650 行・61 コミット churn）の god module 分割**（L、テストは厚く安全）— TTP/branding 業務ロジックの `utils/` 移設 + GCP チェックのサブモジュール化。ユーザー未選択
+- **中粒の構造整理**（M）— utils 83 モジュールの flat 化解消（suno_downloaded_* 8 分片の統合、`utils/comments/`・`utils/config/` パッケージ方式に倣う）/ metadata_generator.py（1,271 行）の 4 責務分割 / doc-contract 系テスト ~25 本への pytest marker 付与と behavioral-only fast lane。ユーザー未選択
+- **PERF-02: サブ分析間の `_get_video_details` / `dimensions=video` クエリ共有**（M、collect 1 回のクォータをさらに削減）— 022 の続編として設計余地
+- **`strategic_analytics.py` の `comprehensive` モード**（呼び出し元ゼロ、per-video N+1 内蔵）— 使うか消すかの判断待ち。023 のスコープ外として温存
+- **japanize-matplotlib の置換移行**（S-M、MED リスク）— 024 は glyph 回帰テストの設置まで。テストが fail したら `font_manager.addfont()` 直接登録へ移行
+- **Direction 3 件（ユーザー未選択、spike/design プラン候補）**: (1) Data API クォータ可観測性 — cost_tracker 相当の units 台帳 + pre-flight 見積（無人運転を止める最有力因子に事前可視性）。(2) `yt-unpublish` — 公開 3 entrypoint に対する逆操作の不在。`videos().update` の既存配管で `privacyStatus=private` 一括復帰、dry-run→confirm 必須。(3) cost_tracker の `estimated_cost_usd` null 固定（Issue #132 の意図的決定）の再訪 — 単価表 1 枚でドル換算が完成する
+
 ## 第 3 回監査（takt リジェクト多発の原因調査、2026-07-06、基準 commit `bf68c73d` / dotfiles `9a030ff`）
 
 調査テーマ: review-takt-default の REJECT 多発（`.takt/runs/` 239 run・指摘 676 件の全数解析）。


### PR DESCRIPTION
## 概要

`/improve` による第 4 回監査の成果物。過去 3 回（Chrome 拡張 / スキル記述 / takt プロセス）で未踏だった **`src/youtube_automation/` 本体（~46K 行）の初の一般監査**を実施し（並列 4 subagent + advisor による全 findings の実読 vet、基準 commit `5394c378`）、選択された上位 5 findings を zero-context executor 向けの自己完結プランとして書き出した。**プランのみの追加で実コードの変更は含まない。**

## 変更内容

- `plans/020-upload-path-robustness.md` — P1/S-M: tracking JSON のアトミック化 + 破損検知、`QuotaExhaustedError` の非終端化（CC・shorts 両経路）、サムネ圧縮の temp リーク解消
- `plans/021-bulk-desc-read-modify-write.md` — P1/S: `videos.update(part=snippet)` の全置換仕様で `defaultAudioLanguage` が消える問題を read-modify-write 化で修正（`bulk_update_synthetic_media` の既存パターン準拠）
- `plans/022-analytics-collect-quota-reduction.md` — P2/S: uploads playlist の collect 毎 2 回全ページネーションを instance cache 化、生 `Exception` 握りつぶし廃止、JST/UTC の 9 時間境界ズレ修正
- `plans/023-delete-dead-analytics-cluster.md` — P2/S: importer ゼロの旧 analytics モノリス 3 ファイル（1,016 行）を削除
- `plans/024-toolchain-hygiene.md` — P2/M: dev 依存の二重宣言解消、ruff `B`/`RUF` 導入（RUF001-003 ignore で実バックログ ~215 件と実測済み）、seaborn 削除、Any-gate の CI job 化、japanize-matplotlib の glyph 回帰テスト
- `plans/README.md` — 第 4 回監査セクション追記（実行順・依存関係・棄却 findings 8 件・見送り残課題の記録）

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` — 対象外（`plans/` のみの docs 変更のため `skip-changelog` ラベルを付与）
- [x] 下流チャンネルへの影響なし（Migration 不要）
- [x] テスト追加不要（各プラン内に executor 向けの Test plan を記載済み）

## 関連

- 監査の総評: subprocess / パス traversal / OAuth / シークレット / コメント冪等性は防御済み、クリティカルパスは 4,976 テストでカバー済みと健全。実弾はアップロード経路のエラー処理・dead code・ツールチェーンに集中
- レビュー時の注目点: 各プランの「Current state」抜粋はすべて advisor が実読した基準 commit `5394c378` 時点のコード。棄却 findings（`plans/README.md` 第 4 回セクション）には subagent の誤検知 vet 結果も記録している
- 実行順序: 020〜023 は並列可、024 は CHANGELOG / pyproject 競合を避けるため最後に rebase 推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)