### PR TITLE
fix(scripts): bulk_update_desc の snippet 更新を read-modify-write 化し defaultAudioLanguage 消失を防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(scripts)`: `bulk_update_descriptions_from_md.py`（`yt-bulk-update-desc`）が `videos().update(part="snippet")` の body を手組みで列挙しており、`defaultAudioLanguage` を含めていなかったため、このツールを通した全動画で音声言語設定が消えていた問題を修正。`defaultLanguage` 未設定の動画に `"en"` を注入していた挙動も廃止。`bulk_update_synthetic_media.py::build_update_body` と同じ read-modify-write 方式（`build_snippet_update_body`）に統一し、mutable 6 キー（title / description / tags / categoryId / defaultLanguage / defaultAudioLanguage）だけを whitelist で保持する
 - `fix(suno-helper)`: queue mode で全 entry 投入後に duration guard を一括実行し、範囲外 clip のみだった entry を `ENTRY_FAILED` として `failedIndices` に保存するようにした（#1762）。対象 entry は「失敗分のみ再実行」導線に載せ、playlist 追加は保留する。部分的に OK clip がある entry は OK clip を accepted として `DONE` にし、duration filter 未指定時は `DEFAULT_DURATION_FILTER` で検査する。
 - `fix(suno-helper)`: queue mode の `clipIdsByEntry` を投入前後の Set 差分で捕捉し、entry retry 中に遅延観測された clip ID も同じ entry へ帰属させるようにした（#1762）。DOM-only ACK で clip ID が未観測の entry は fatal 停止せず、finalizer の warn + `DONE` 縮退へ到達する。
 - `fix(agents)`: `_tracking_io.py::_save_tracking` を tmp ファイル + `os.replace` によるアトミック書き込みに変更し、アップロード中のクラッシュで `upload_tracking.json` が truncate され resume 情報を喪失する不具合を修正した（plan 020）。`_load_tracking` は破損 JSON（`JSONDecodeError` / `UnicodeDecodeError`）を検出すると `*.json.corrupt` へ退避してから `None` を返し、無言で握りつぶさず証拠を保全するようにした

--- a/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
+++ b/src/youtube_automation/scripts/bulk_update_descriptions_from_md.py
@@ -22,6 +22,8 @@ import argparse
 import json
 import time
 
+from googleapiclient.errors import HttpError
+
 from youtube_automation.utils.config import channel_dir
 from youtube_automation.utils.descriptions_md import (
     build_descriptions_md_parse_diagnostics,
@@ -29,6 +31,34 @@ from youtube_automation.utils.descriptions_md import (
 )
 from youtube_automation.utils.youtube_service import get_youtube
 from youtube_automation.utils.youtube_tag import parse_youtube_tags
+
+# videos.update(part="snippet") で書き込み可能な mutable フィールド。
+# videos().list(part="snippet") のレスポンスにはこれ以外に publishedAt / channelId /
+# thumbnails / channelTitle / localized / liveBroadcastContent 等の read-only
+# フィールドが混ざるため、丸ごとコピーせず whitelist で保持する。
+MUTABLE_SNIPPET_KEYS = (
+    "title",
+    "description",
+    "tags",
+    "categoryId",
+    "defaultLanguage",
+    "defaultAudioLanguage",
+)
+
+
+def build_snippet_update_body(video_id: str, old_snippet: dict, title: str, description: str, tags: list) -> dict:
+    """現 snippet の mutable キーを保持したまま title/description/tags を差し替えた update body を返す.
+
+    ``videos.update(part='snippet')`` は snippet リソース全体を置換するため、
+    body に含まれない mutable フィールド（defaultAudioLanguage 等）は消える。
+    bulk_update_synthetic_media.build_update_body と同じ read-modify-write 方式。
+    """
+    new_snippet = {k: old_snippet[k] for k in MUTABLE_SNIPPET_KEYS if k in old_snippet}
+    new_snippet["title"] = title
+    new_snippet["description"] = description
+    new_snippet["tags"] = tags
+    new_snippet.setdefault("categoryId", "10")
+    return {"id": video_id, "snippet": new_snippet}
 
 
 def discover_collections() -> list[str]:
@@ -153,20 +183,11 @@ def main() -> None:
         if args.dry_run:
             continue
 
-        body = {
-            "id": p["video_id"],
-            "snippet": {
-                "title": new_title,
-                "description": new_desc,
-                "tags": new_tags,
-                "categoryId": old_snippet.get("categoryId", "10"),
-                "defaultLanguage": old_snippet.get("defaultLanguage", "en"),
-            },
-        }
+        body = build_snippet_update_body(p["video_id"], old_snippet, new_title, new_desc, new_tags)
         try:
             yt.videos().update(part="snippet", body=body).execute()
             print("   ✅ updated")
-        except Exception as e:
+        except HttpError as e:
             print(f"   ❌ update failed: {e}")
         time.sleep(0.4)
 

--- a/tests/test_bulk_update_descriptions_from_md.py
+++ b/tests/test_bulk_update_descriptions_from_md.py
@@ -670,6 +670,98 @@ class TestLoadCollection:
 # ---------------------------------------------------------------------------
 
 
+class TestBuildSnippetUpdateBody:
+    """`build_snippet_update_body` — read-modify-write で mutable キーのみ保持する."""
+
+    def test_should_preserve_default_audio_language(self):
+        """old_snippet に defaultAudioLanguage があれば body に引き継がれる (defaultAudioLanguage 消失防止)."""
+        from youtube_automation.scripts import bulk_update_descriptions_from_md as mod
+
+        # Given
+        old_snippet = {
+            "title": "old title",
+            "description": "old desc",
+            "categoryId": "10",
+            "defaultLanguage": "en",
+            "defaultAudioLanguage": "ja",
+        }
+
+        # When
+        body = mod.build_snippet_update_body("V1", old_snippet, "new title", "new desc", ["tag1"])
+
+        # Then
+        assert body["snippet"]["defaultAudioLanguage"] == "ja"
+
+    def test_should_omit_default_language_when_absent_from_old_snippet(self):
+        """old_snippet に defaultLanguage が無ければ body にも含めない（"en" 注入の再発防止）."""
+        from youtube_automation.scripts import bulk_update_descriptions_from_md as mod
+
+        # Given: defaultLanguage 未設定
+        old_snippet = {
+            "title": "old title",
+            "description": "old desc",
+            "categoryId": "10",
+        }
+
+        # When
+        body = mod.build_snippet_update_body("V1", old_snippet, "new title", "new desc", ["tag1"])
+
+        # Then
+        assert "defaultLanguage" not in body["snippet"]
+
+    def test_should_exclude_readonly_snippet_keys(self):
+        """old_snippet の read-only キー（publishedAt / thumbnails 等）は body に含めない."""
+        from youtube_automation.scripts import bulk_update_descriptions_from_md as mod
+
+        # Given: read-only フィールドが混ざった old_snippet
+        old_snippet = {
+            "title": "old title",
+            "description": "old desc",
+            "categoryId": "10",
+            "publishedAt": "2020-01-01T00:00:00Z",
+            "channelId": "UCxxxx",
+            "thumbnails": {"default": {"url": "https://example.com/x.jpg"}},
+            "channelTitle": "My Channel",
+            "localized": {"title": "old title", "description": "old desc"},
+            "liveBroadcastContent": "none",
+        }
+
+        # When
+        body = mod.build_snippet_update_body("V1", old_snippet, "new title", "new desc", ["tag1"])
+
+        # Then
+        for readonly_key in (
+            "publishedAt",
+            "channelId",
+            "thumbnails",
+            "channelTitle",
+            "localized",
+            "liveBroadcastContent",
+        ):
+            assert readonly_key not in body["snippet"]
+
+    def test_should_override_title_description_tags_with_arguments(self):
+        """title/description/tags は引数の値で上書きされる（old_snippet の値を無視する）."""
+        from youtube_automation.scripts import bulk_update_descriptions_from_md as mod
+
+        # Given
+        old_snippet = {
+            "title": "old title",
+            "description": "old desc",
+            "tags": ["old-tag"],
+            "categoryId": "10",
+        }
+
+        # When
+        body = mod.build_snippet_update_body("V1", old_snippet, "new title", "new desc", ["new-tag-1", "new-tag-2"])
+
+        # Then
+        assert body["id"] == "V1"
+        assert body["snippet"]["title"] == "new title"
+        assert body["snippet"]["description"] == "new desc"
+        assert body["snippet"]["tags"] == ["new-tag-1", "new-tag-2"]
+
+
 class TestExtractMdSection:
     """`load_collection` の Error テスト経路の前提となる補助 utility."""
 


### PR DESCRIPTION
## 概要

`yt-bulk-update-desc`（`bulk_update_descriptions_from_md.py`）は `videos().update(part="snippet")` の body を手組みで列挙しており、YouTube Data API の part 全置換セマンティクスにより **body に含まれない mutable フィールドがクリアされる**。`defaultAudioLanguage` が body に含まれていなかったため、このツールを通した全動画で音声言語設定が消えていた。さらに `defaultLanguage` 未設定の動画には `"en"` を注入していた（日本語チャンネルでは誤ラベル）。

姉妹スクリプト `bulk_update_synthetic_media.py::build_update_body` が同じ理由で採用している read-modify-write 方式に統一して修正する（実装プラン `plans/021-bulk-desc-read-modify-write.md`、別ブランチ `claude/quizzical-cerf-d84bf1` 上）。

## 変更内容

- `build_snippet_update_body()` を新設: 取得済み `old_snippet` から **mutable 6 キー（title / description / tags / categoryId / defaultLanguage / defaultAudioLanguage）だけを whitelist コピー**し、title / description / tags を差し替える。read-only キー（`publishedAt` / `thumbnails` 等）は送らない
- `defaultLanguage` は old_snippet に存在するときだけ引き継ぐ（`"en"` fallback 注入を廃止）。`categoryId` の `"10"`（音楽）fallback は現行挙動を維持
- update 呼び出しの `except Exception` を `except HttpError` に狭める（1 本失敗しても残りのバッチを続行する print-and-continue 挙動は維持）
- 回帰テスト 4 件を追加: `defaultAudioLanguage` 保持 / `defaultLanguage` 非注入 / read-only キー除外 / title・description・tags の上書き

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した（config / スキル契約の変更なしのため不要 — 挙動修正のみ）
- [x] 必要なテストを追加・更新した（対象ファイル 30 passed / 全体 4980 passed / ruff check・format pass）

## 関連

- 実装プラン: `plans/021-bulk-desc-read-modify-write.md`（第 4 回監査、branch `claude/quizzical-cerf-d84bf1` の commit 3bc174ed）
- 先例パターン: `src/youtube_automation/scripts/bulk_update_synthetic_media.py::build_update_body`

🤖 Generated with [Claude Code](https://claude.com/claude-code)