### PR TITLE
fix(lyria): segment 数に hard cap (60) を導入し超過時は clamp + warning (#1698)

### DIFF
--- a/.claude/skills/lyria/SKILL.md
+++ b/.claude/skills/lyria/SKILL.md
@@ -74,7 +74,7 @@ $ARGUMENTS → コレクションのテーマ指定
 | `prompt_prefix` | プロンプト先頭の共通ジャンル句 |
 | `style_hints` | 補足スタイル句（optional） |
 | `ng_words` | プロンプトに使用禁止の語（Claude がプロンプト設計時にチェック） |
-| `duration_padding_min` | `audio.target_duration_min` に上乗せする余裕分（分）。`yt-generate-lyria-master` が `ceil((target + padding) * 60 / 184)` でセグメント数を算出する |
+| `duration_padding_min` | `audio.target_duration_min` に上乗せする余裕分（分）。`yt-generate-lyria-master` が `ceil((target + padding) * 60 / 184)` でセグメント数を算出する（上限 60 セグメント、超過時は clamp + warning） |
 | `default_bpm` | チャンネル共通 BPM（generate_music() の `bpm` 引数に流用、個別上書き可） |
 | `default_intensity` | チャンネル共通 intensity（generate_music() の `intensity` に流用、個別上書き可） |
 | `default_mode` | チャンネル共通 mode（generate_music() の `mode` に流用、個別上書き可） |
@@ -178,7 +178,7 @@ celtic folk only, clean dry recording, no pads, gentle melodic phrases rising an
 
 ユーザー承認後、`yt-generate-lyria-master` CLI を呼ぶ。CLI が以下を一気通貫で実行する:
 
-1. `audio.target_duration_min` + skill-config `duration_padding_min` から必要セグメント数 N を自動算出（`ceil((target + padding) * 60 / 184)`）
+1. `audio.target_duration_min` + skill-config `duration_padding_min` から必要セグメント数 N を自動算出（`ceil((target + padding) * 60 / 184)`）。上限は 60 セグメント（= Lyria API リクエスト数の hard cap）で、超過時は 60 に clamp して warning を stderr に出力する
 2. `lyria_client.generate_music()` を N 回呼び、レスポンスを `02-Individual-music/{NN}_{name}.wav` に PCM s16le 48 kHz stereo で保存（既存ファイルは skip = resume 可能）
 3. 失敗時は `--max-retries` 回までリトライ
 4. 全セグメント揃ったら `generate_master.generate_master()` 経由でクロスフェード結合し `01-master/master.mp3` を出力（`masterup.audio.crossfade_duration` を参照）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(lyria)`: `yt-generate-lyria-master` のセグメント数算出（`_resolve_segment_count`）に hard cap（`_MAX_SEGMENT_COUNT = 60`）を導入した（#1698）。従来は `target_duration_min` の桁ミスで Lyria API リクエスト（= Vertex AI 課金）が無制限に発行され得たが、上限超過時は 60 に clamp して warning を stderr に出力する。上限以内の算出結果は従来どおり
 - `fix(scripts)`: `bulk_update_descriptions_from_md.py`（`yt-bulk-update-desc`）が `videos().update(part="snippet")` の body を手組みで列挙しており、`defaultAudioLanguage` を含めていなかったため、このツールを通した全動画で音声言語設定が消えていた問題を修正。`defaultLanguage` 未設定の動画に `"en"` を注入していた挙動も廃止。`bulk_update_synthetic_media.py::build_update_body` と同じ read-modify-write 方式（`build_snippet_update_body`）に統一し、mutable 6 キー（title / description / tags / categoryId / defaultLanguage / defaultAudioLanguage）だけを whitelist で保持する
 - `fix(suno-helper)`: queue mode で全 entry 投入後に duration guard を一括実行し、範囲外 clip のみだった entry を `ENTRY_FAILED` として `failedIndices` に保存するようにした（#1762）。対象 entry は「失敗分のみ再実行」導線に載せ、playlist 追加は保留する。部分的に OK clip がある entry は OK clip を accepted として `DONE` にし、duration filter 未指定時は `DEFAULT_DURATION_FILTER` で検査する。
 - `fix(suno-helper)`: queue mode の `clipIdsByEntry` を投入前後の Set 差分で捕捉し、entry retry 中に遅延観測された clip ID も同じ entry へ帰属させるようにした（#1762）。DOM-only ACK で clip ID が未観測の entry は fatal 停止せず、finalizer の warn + `DONE` 縮退へ到達する。

--- a/src/youtube_automation/scripts/generate_lyria_master.py
+++ b/src/youtube_automation/scripts/generate_lyria_master.py
@@ -52,6 +52,10 @@ from youtube_automation.utils.skill_config import load_skill_config
 # 必要呼び出し回数を割り出す基準として使う。short 化や引き伸ばしのトリミングは行わない。
 _LYRIA_SEGMENT_SEC = 184
 
+# セグメント数 (= Lyria API リクエスト数 = Vertex AI 課金回数) の hard cap。
+# `target_duration_min` の桁ミスで数百リクエスト規模の課金が走るのを防ぐ。
+_MAX_SEGMENT_COUNT = 60
+
 # `generate_music_dj._save_audio_as_wav` と揃える (ffmpeg 経由で PCM s16le に正規化する設定)。
 _WAV_SAMPLE_RATE = 48000
 _WAV_CHANNELS = 2
@@ -70,13 +74,24 @@ def _resolve_segment_count(target_min: float, padding_min: float) -> int:
 
     `(target_min + padding_min) * 60 / 184` を切り上げ。
     `target_min > 0` を validate するため戻り値は必ず 1 以上になる。
+    `_MAX_SEGMENT_COUNT` を超える場合は上限に clamp して warning を出す。
     """
     if target_min <= 0:
         raise ValidationError(f"--target-duration は 1 以上を指定してください (got {target_min})")
     if padding_min < 0:
         raise ValidationError(f"--padding-min は 0 以上を指定してください (got {padding_min})")
     total_sec = (target_min + padding_min) * 60
-    return math.ceil(total_sec / _LYRIA_SEGMENT_SEC)
+    count = math.ceil(total_sec / _LYRIA_SEGMENT_SEC)
+    if count > _MAX_SEGMENT_COUNT:
+        print(
+            f"WARNING: 算出セグメント数 {count} が上限 {_MAX_SEGMENT_COUNT} を超えたため "
+            f"{_MAX_SEGMENT_COUNT} に切り詰めます "
+            f"(target {target_min:g}min + padding {padding_min:g}min)。"
+            "--target-duration の指定を確認してください",
+            file=sys.stderr,
+        )
+        return _MAX_SEGMENT_COUNT
+    return count
 
 
 def _save_audio_as_wav(data: bytes, path: Path) -> None:

--- a/tests/test_generate_lyria_master.py
+++ b/tests/test_generate_lyria_master.py
@@ -14,6 +14,7 @@ import pytest
 from youtube_automation.scripts import generate_lyria_master
 from youtube_automation.scripts.generate_lyria_master import (
     _LYRIA_SEGMENT_SEC,
+    _MAX_SEGMENT_COUNT,
     _generate_one_segment,
     _resolve_segment_count,
 )
@@ -65,6 +66,19 @@ class TestResolveSegmentCount:
     def test_negative_padding_raises(self):
         with pytest.raises(ValidationError, match="padding-min"):
             _resolve_segment_count(60, -1)
+
+    def test_over_cap_clamped_with_warning(self, capsys):
+        # (600 + 3) * 60 / 184 = 196.6... → 197 > 60 なので 60 に clamp + warning
+        assert _resolve_segment_count(600, 3) == _MAX_SEGMENT_COUNT
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert f"上限 {_MAX_SEGMENT_COUNT}" in err
+
+    def test_exactly_at_cap_no_warning(self, capsys):
+        # ちょうど 60 セグメント (60 * 184 秒 = 184 分) は clamp も warning もなし
+        target_min = _MAX_SEGMENT_COUNT * _LYRIA_SEGMENT_SEC / 60
+        assert _resolve_segment_count(target_min, 0) == _MAX_SEGMENT_COUNT
+        assert capsys.readouterr().err == ""
 
 
 def _patch_lyria_generate(monkeypatch, *, payload: bytes | None = b"FAKE_MP3", call_log: list | None = None):


### PR DESCRIPTION
## 概要

Closes #1698

`yt-generate-lyria-master` の `_resolve_segment_count` に hard cap が無く、`target_duration_min` の桁ミスで Lyria API リクエスト（= Vertex AI 課金）が数百規模で発行され得た。上限 `_MAX_SEGMENT_COUNT = 60` を導入し、超過時は 60 に clamp して stderr に warning を出す。

## 設計判断

- 超過時挙動は issue が許容する 2 案（対話確認 / clamp + 明示ログ）のうち **clamp + warning** を採用。CLI 自動実行と相性が良く、テストで決定的に検証できるため
- warning は logging ではなく `print(..., file=sys.stderr)`。このスクリプトは全出力が print 系（エラーも同形式）のため現行スタイルに統一

## 変更内容

- `src/youtube_automation/scripts/generate_lyria_master.py`: モジュール定数 `_MAX_SEGMENT_COUNT = 60` + clamp ロジック
- `tests/test_generate_lyria_master.py`: 上限超過（197→60 に clamp + warning）/ 境界値（ちょうど 60 で warning なし）の 2 テスト追加。既存の上限内テストは無変更で pass（回帰なし）
- `.claude/skills/lyria/SKILL.md`: セグメント数算出の記述 2 箇所に上限と超過時挙動を追記
- `CHANGELOG.md`: `[Unreleased]` > `### Fixed` に追記

## 検証（監査済み）

- clamp は算出時の 1 箇所（呼び出し元は `main` の 1 経路のみ）で、下流は n セグメントの生成・連結のみ。target 未達を assert する箇所は無く、warning 通知と整合
- `uv run pytest tests/` 4995 passed / 対象テストファイル 19 passed（監査側でも再実行して確認）
- ruff check / format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)