### PR TITLE
fix(ci): issue-lint.sh の takt 実行対象判定を現行ラベル体系に更新 (#1832)

### DIFF
--- a/.github/scripts/issue-lint.sh
+++ b/.github/scripts/issue-lint.sh
@@ -22,10 +22,7 @@ case ",${labels}," in
   *,takt:default,*) is_takt_target=1 ;;
 esac
 case ",${labels}," in
-  *,takt:default-mini,*) is_takt_target=1 ;;
-esac
-case ",${labels}," in
-  *,takt:mini,*) is_takt_target=1 ;;
+  *,takt:lite,*) is_takt_target=1 ;;
 esac
 
 if [ "$is_takt_target" -ne 1 ]; then


### PR DESCRIPTION
## 概要

Closes #1832

`.github/scripts/issue-lint.sh` の `is_takt_target` 判定が旧世代ラベル名（`takt:default-mini` / `takt:mini`）を参照したままで、現行体系の主力 `takt:lite` 付き issue が粒度 lint の対象にならず silent skip されていた。判定を現行ラベル体系（takt 自動実行対象 = `takt:default` / `takt:lite`）に更新した。

## 変更内容

- `.github/scripts/issue-lint.sh`: 旧ラベル 2 分岐を削除し `takt:lite` 分岐を追加（+1/-4 の最小差分）。`.github/` 内に旧ラベル名への参照が残らないことを rg で確認済み

## 検証（監査済み）

fixture payload（`## 要件` / `## スコープ外` 欠落の本文）を 7 ラベルパターンで直接実行:

| ラベル | 結果 |
|---|---|
| `takt:lite` | lint 実行・警告出力（修正の本命） |
| `takt:default` | lint 実行・警告出力（回帰なし） |
| `takt:manual` / `takt:none` / ラベルなし | skip・出力なし |
| `takt:default-mini` / `takt:mini`（旧） | skip（対象外化） |

`docs/takt-operations.md` の「issue ラベルとの対応」節の定義（takt 自動実行 = default / lite）と判定が一致することを確認。`.github/` のみの変更のため CHANGELOG ゲート対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)