### PR TITLE
chore(suno-helper): ext-v0.2.5

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

suno-helper 拡張のリリース PR。`extensions/suno-helper/package.json` の version を 0.2.4 → 0.2.5 に bump。distrokid-helper は ext-v0.2.4 以降変更がないため 0.2.1 のまま据え置き。

## ext-v0.2.4 以降の suno-helper 変更

- queue mode に投入完了後の一括 duration guard(欠け検知)を追加(#1762)
- Suno 新 Create UI の slider リネームに tolerant match + warn-skip で対応(#1720)
- 日本語UIの除外スタイル欄を検出(#1840)
- 日本語UIのスライダーラベル検出(ユニーク度 / スタイルの影響度)と Lexical 反映確認の空白差異吸収(#1872 → #1871 で main へ)
- Suno DOM automation の堅牢化
- 完了済みコレクションの表示・再実行対応
- 手動停止を非エラー扱いに変更

## Local verification

- [x] `nr build` / `nr zip`(`suno-helper-0.2.5-chrome.zip` 生成確認)

## Next steps

1. この PR をマージ
2. マージ後、merge commit に tag `ext-v0.2.5` を push → Release Extensions workflow が両拡張の zip をビルドして GitHub Release に添付
3. 各環境では `/ext-install` で更新