### PR TITLE
[#1731] issue-1731-upload-yt-upload-co

### DIFF
--- a/.claude/skills/video-upload/SKILL.md
+++ b/.claude/skills/video-upload/SKILL.md
@@ -40,7 +40,7 @@ Complete Collection を YouTube にアップロードし、`planning/` → `live
 | 引数 | 説明 | 例 |
 |------|------|-----|
 | `$ARGUMENTS` | コレクションディレクトリパス（省略可） | `/video-upload collections/planning/20260304-clm-fairy-forest-collection` |
-| 未指定 | `collections/planning/` から自動検出 | `/video-upload` |
+| 未指定 | `collections/planning/` の `phase=mastered` かつ `upload.video_id=null` の未公開候補が 1 件だけなら自動検出（0 件・複数件は `-c` 明示を要求） | `/video-upload` |
 
 ## Channel Adaptation
 
@@ -75,7 +75,7 @@ Complete Collection を YouTube にアップロードし、`planning/` → `live
 $ARGUMENTS
 ```
 
-引数が指定されている場合はそのディレクトリを、未指定の場合は `collections/planning/` 配下のコレクションを自動検出します。
+引数が指定されている場合はそのディレクトリを対象にします。未指定の場合は `collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクションを自動検出します。候補が 0 件または複数件の場合は停止するため、`-c` で対象を明示します。`collections/live/` の公開済みコレクションは自動検出の対象外です。
 
 ### 前提条件チェック
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(upload)`: `yt-upload-collection` の `-c` 未指定時の自動選択を、`collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクション 1 件だけに限定した。`live/` の公開済みコレクションは候補外とし、候補が 0 件または複数件なら `-c` 明示を要求して停止する。`--plan` / `--status` / 実アップロードと日次実行に同じ選択条件を適用した（#1731）。
+
 ## [5.5.17] - 2026-07-10
 
 ### Added

--- a/src/youtube_automation/agents/collection_uploader.py
+++ b/src/youtube_automation/agents/collection_uploader.py
@@ -55,7 +55,9 @@ from youtube_automation.agents.youtube_auto_uploader import (  # noqa: E402
 )
 from youtube_automation.scripts.collection_preflight import ensure_collection_preflight  # noqa: E402
 from youtube_automation.scripts.playlist_manager import PlaylistManager  # noqa: E402
+from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.config import channel_dir, load_config  # noqa: E402
+from youtube_automation.utils.exceptions import ValidationError  # noqa: E402
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
 
 # 後方互換 / 公開 API: 定数・主要シンボルは従来どおり本モジュールから import できるよう再エクスポートする。
@@ -159,7 +161,7 @@ class CollectionUploader(
         return collections
 
     def _find_collection(self, collection_name: str | None = None) -> Path | None:
-        """名前でコレクションを検索（部分一致、planning/ と live/ を探索）"""
+        """名前指定なら全ステージ、未指定なら未公開の planning コレクションを検索する。"""
         all_collections = self.find_collections()
         if collection_name:
             for col in all_collections:
@@ -167,10 +169,36 @@ class CollectionUploader(
                     return col
             logger.error(f"❌ コレクションが見つかりません: {collection_name}")
             return None
-        if not all_collections:
-            logger.error("❌ 対象コレクションが見つかりません")
-            return None
-        return all_collections[0]
+
+        candidates = []
+        for collection in self.find_collections(("planning",)):
+            state_path = CollectionPaths(collection).workflow_state_path
+            try:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                logger.warning(f"⚠️  workflow-state.json を読み取れないため候補から除外します: {state_path}: {exc}")
+                continue
+
+            upload = state.get("upload") if isinstance(state, dict) else None
+            if (
+                isinstance(state, dict)
+                and state.get("phase") == "mastered"
+                and isinstance(upload, dict)
+                and "video_id" in upload
+                and upload["video_id"] is None
+            ):
+                candidates.append(collection)
+
+        if not candidates:
+            raise ValidationError(
+                "自動選択できる対象コレクションがありません。"
+                "planning/ 配下で phase=mastered かつ upload.video_id=null のコレクションを用意するか、"
+                "-c で対象を明示してください"
+            )
+        if len(candidates) > 1:
+            names = ", ".join(collection.name for collection in candidates)
+            raise ValidationError(f"自動選択対象が複数あります: {names}。-c で対象を明示してください")
+        return candidates[0]
 
     # ─── コアオーケストレーション ────────────────────
 
@@ -317,12 +345,12 @@ class CollectionUploader(
         """毎日の自動チェック・アップロード処理"""
         logger.info(f"📅 日次チェック実行: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
 
-        collections = self.find_collections()
-        if not collections:
-            logger.info("📋 処理対象のコレクションはありません")
+        try:
+            target_collection = self._find_collection()
+        except ValidationError as exc:
+            logger.error(f"❌ 日次アップロードを実行しません: {exc}")
             return
 
-        target_collection = collections[0]
         self.execute_next_step(target_collection)
 
     # ─── 手動実行 ────────────────────────────────────

--- a/tests/test_collection_uploader.py
+++ b/tests/test_collection_uploader.py
@@ -226,6 +226,174 @@ def _read_resume_uri(tracking_path: Path) -> str | None:
     return data.get("complete_collection", {}).get("resume_session_uri")
 
 
+def _write_workflow_state(collection: Path, *, phase: str, video_id: str | None) -> None:
+    collection.mkdir(parents=True)
+    (collection / "workflow-state.json").write_text(
+        json.dumps({"phase": phase, "upload": {"video_id": video_id}}), encoding="utf-8"
+    )
+
+
+class TestAutoDetectCollection:
+    def test_auto_detect_selects_only_unpublished_mastered_planning_collection(self, tmp_path):
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        live = tmp_path / "collections" / "live" / "20260101-published-collection"
+        target = tmp_path / "collections" / "planning" / "20260201-mastered-collection"
+        _write_workflow_state(live, phase="complete", video_id="published-video")
+        _write_workflow_state(target, phase="mastered", video_id=None)
+
+        assert uploader._find_collection() == target
+
+    def test_auto_detect_fails_when_no_unpublished_mastered_planning_collection(self, tmp_path):
+        from youtube_automation.utils.exceptions import ValidationError
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        _write_workflow_state(
+            tmp_path / "collections" / "live" / "20260101-published-collection",
+            phase="complete",
+            video_id="published-video",
+        )
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260201-uploaded-collection",
+            phase="mastered",
+            video_id="already-uploaded",
+        )
+
+        with pytest.raises(ValidationError, match="自動選択できる対象コレクションがありません"):
+            uploader._find_collection()
+
+    def test_auto_detect_fails_when_video_id_is_missing(self, tmp_path):
+        from youtube_automation.utils.exceptions import ValidationError
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        collection = tmp_path / "collections" / "planning" / "20260201-incomplete-collection"
+        collection.mkdir(parents=True)
+        (collection / "workflow-state.json").write_text(
+            json.dumps({"phase": "mastered", "upload": {}}), encoding="utf-8"
+        )
+
+        with pytest.raises(ValidationError, match="自動選択できる対象コレクションがありません"):
+            uploader._find_collection()
+
+    def test_auto_detect_fails_when_multiple_unpublished_mastered_planning_collections(self, tmp_path):
+        from youtube_automation.utils.exceptions import ValidationError
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260201-first-collection", phase="mastered", video_id=None
+        )
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260202-second-collection", phase="mastered", video_id=None
+        )
+
+        with pytest.raises(ValidationError, match="-c で対象を明示してください"):
+            uploader._find_collection()
+
+    def test_explicit_collection_name_can_still_select_live_collection(self, tmp_path):
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        live = tmp_path / "collections" / "live" / "20260101-published-collection"
+        _write_workflow_state(live, phase="complete", video_id="published-video")
+
+        assert uploader._find_collection("published") == live
+
+    @pytest.mark.parametrize(
+        ("argv", "method_name"),
+        [(["--status"], "show_status"), (["--plan"], "show_plan"), ([], "execute_next_step")],
+    )
+    def test_main_uses_safe_auto_detect_for_status_plan_and_upload(self, monkeypatch, tmp_path, argv, method_name):
+        from youtube_automation.agents import collection_uploader
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        live = tmp_path / "collections" / "live" / "20260101-published-collection"
+        target = tmp_path / "collections" / "planning" / "20260201-mastered-collection"
+        _write_workflow_state(live, phase="complete", video_id="published-video")
+        _write_workflow_state(target, phase="mastered", video_id=None)
+        method = MagicMock()
+        monkeypatch.setattr(uploader, method_name, method)
+        mock_config = MagicMock()
+        mock_config.meta.channel_short = "test"
+
+        monkeypatch.setattr(sys, "argv", ["yt-upload-collection", *argv])
+        with (
+            patch("youtube_automation.agents.collection_uploader.load_config", return_value=mock_config),
+            patch("youtube_automation.agents.collection_uploader.CollectionUploader", return_value=uploader),
+            patch("youtube_automation.agents.collection_uploader.ensure_collection_preflight") as mock_preflight,
+        ):
+            collection_uploader.main()
+
+        method.assert_called_once_with(target)
+        if argv == ["--status"]:
+            mock_preflight.assert_not_called()
+        else:
+            mock_preflight.assert_called_once_with(target)
+
+    @pytest.mark.parametrize("argv", [["--status"], ["--plan"], []])
+    def test_main_fails_loudly_when_auto_detect_has_no_candidate(self, monkeypatch, tmp_path, capsys, argv):
+        from youtube_automation.agents import collection_uploader
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        mock_config = MagicMock()
+        mock_config.meta.channel_short = "test"
+        monkeypatch.setattr(sys, "argv", ["yt-upload-collection", *argv])
+
+        with (
+            patch("youtube_automation.agents.collection_uploader.load_config", return_value=mock_config),
+            patch("youtube_automation.agents.collection_uploader.CollectionUploader", return_value=uploader),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            collection_uploader.main()
+
+        assert exc_info.value.code == 1
+        assert "-c で対象を明示してください" in capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        ("argv", "method_name"),
+        [(["--status"], "show_status"), (["--plan"], "show_plan"), ([], "execute_next_step")],
+    )
+    def test_main_fails_loudly_when_auto_detect_is_ambiguous(self, monkeypatch, tmp_path, capsys, argv, method_name):
+        from youtube_automation.agents import collection_uploader
+
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260201-first-collection", phase="mastered", video_id=None
+        )
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260202-second-collection", phase="mastered", video_id=None
+        )
+        mock_config = MagicMock()
+        mock_config.meta.channel_short = "test"
+        method = MagicMock()
+        monkeypatch.setattr(uploader, method_name, method)
+        monkeypatch.setattr(sys, "argv", ["yt-upload-collection", *argv])
+
+        with (
+            patch("youtube_automation.agents.collection_uploader.load_config", return_value=mock_config),
+            patch("youtube_automation.agents.collection_uploader.CollectionUploader", return_value=uploader),
+            patch("youtube_automation.agents.collection_uploader.ensure_collection_preflight") as mock_preflight,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            collection_uploader.main()
+
+        assert exc_info.value.code == 1
+        assert "-c で対象を明示してください" in capsys.readouterr().out
+        mock_preflight.assert_not_called()
+        method.assert_not_called()
+
+    def test_daily_check_skips_when_auto_detect_is_ambiguous(self, tmp_path, caplog):
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260201-first-collection", phase="mastered", video_id=None
+        )
+        _write_workflow_state(
+            tmp_path / "collections" / "planning" / "20260202-second-collection", phase="mastered", video_id=None
+        )
+        uploader.execute_next_step = MagicMock()
+
+        uploader._daily_check_and_upload()
+
+        uploader.execute_next_step.assert_not_called()
+        assert "-c で対象を明示してください" in caplog.text
+
+
 class TestDefaultPublishTimeFallback:
     """#1054: schedule_config 未指定時に channel youtube.default_publish_time を使う。"""
 


### PR DESCRIPTION
## Summary

## 概要
`yt-upload-collection`（`--plan` / 実アップロード）を `-c` 省略で実行すると、auto-detect が `collections/live/` 配下の公開済みコレクションを対象に選ぶことがある。planning/ の未公開コレクションが存在しても live/ 側が選ばれるため、`-c` 無し運用では公開済み動画の二重アップロード事故につながる。

## 背景・目的
旧 #1566 の後継（実装乖離監査の全件再起票方針による新基準テンプレートでの作り直し。監査時点で `collection_uploader.py` の `_find_collection` が候補リストの先頭要素を無条件返却する実装のままであることを確認済み）。

### 再現手順
1. `collections/live/` に公開済みコレクション（例: `20260511-df365-mental-stamina-mode-collection`）が存在する
2. `collections/planning/` に未公開コレクション（phase=mastered / video_id=null）が 1 件存在する
3. `-c` を付けずに `uv run yt-upload-collection --plan` を実行する

### 期待される動作
- auto-detect は `collections/planning/` 配下かつ未公開（`phase=mastered` / `upload.video_id=null`）のコレクションのみを対象にする
- `collections/live/` の公開済みコレクションは対象にしない
- 対象が 0 件 / 複数で曖昧なときは fail-loud（`-c` 明示を要求）

### 実際の動作
`--plan`（引数なし）が live/ 側の公開済みコレクションを対象に選び、Complete Collection アップロード + live/ 移動を計画した（下流チャンネルで実測）。`-c` で planning/ のコレクションを明示すると正しい対象を選ぶことは確認済み。

### 影響範囲
- `-c` 無しで `/video-upload` を自動実行する運用（`/wf-next` の全自動経路など）で、公開済み動画の二重アップロードが起こりうる
- SKILL.md は `-c` 省略を許容しているため、オペレーターが省略した場合に顕在化する

## 参照資料
- src/youtube_automation/agents/collection_uploader.py（`_find_collection` の先頭要素無条件返却）
- .claude/skills/video-upload/SKILL.md（`## Quick Reference` の「未指定: 自動検出」記述、`### 対象コレクション` 節）

## 影響ファイル
- **変更**: src/youtube_automation/agents/collection_uploader.py（`_find_collection` の対象選択ロジック: planning/ 限定 + 未公開条件 + 0 件/複数件の fail-loud）
- **変更**: .claude/skills/video-upload/SKILL.md（auto-detect の対象条件の明文化）
- **新規/変更**: 対応するユニットテスト（live/ 除外・0 件・複数件の各ケース）

**兄弟入口・貫通先**:
- `yt-upload-collection --status` / `--plan` / 実アップロードが同じ auto-detect を共有しているかを確認し、全経路へ一貫適用する
- `/wf-next` の `mastered` フェーズ step（`/video-upload` を呼ぶ経路）が `-c` を渡しているか確認する（渡していなくても本修正で安全になることがゴール）

## 要件
1. `-c` 省略で `yt-upload-collection --plan` を実行する → live/ 配下は候補から除外され、planning/ かつ `upload.video_id=null` のコレクションのみが選ばれる
2. planning/ 候補が 0 件の状態で実行する → fail-loud（「対象なし」の明示エラー）で live/ を代替選択しない
3. planning/ 候補が 2 件以上の状態で実行する → fail-loud で `-c` 明示を要求する
4. `--plan` / `--status` / 実アップロードの全経路で上記の選択挙動が一貫する
5. `-c` 明示時の挙動は現状維持で、既存テストが green のまま

## スコープ外
- スケジュール公開日の算出ロジック（公開日スライド）の変更
- `/wf-next` 側で常に `-c` を渡すよう固定する改修（本 issue は uploader 単体の安全化）

## 実装方針（takt）
- workflow: lite
- 理由: `_find_collection` 単一関数のフィルタ条件と fail-loud 追加 + テストに収まる局所的な bug fix のため。priority: high だが変更範囲は狭く、lite の 3 step で十分

## Execution Report

Workflow `lite` completed successfully.

Closes #1731