### PR TITLE
[#1732] issue-1732-upload-yt-upload-co

### DIFF
--- a/.claude/skills/channel-new/references/config-template/content.json
+++ b/.claude/skills/channel-new/references/config-template/content.json
@@ -5,6 +5,7 @@
     "context": "{{CONTEXT}}"
   },
   "tags": {
+    "min_count": 26,
     "base": [],
     "themes": {}
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(upload)`: タグ件数下限が YouTube の 500 字上限の下で到達不能な場合、upload preflight と metadata audit が件数不足ではなく、`tags.min_count` を下げるか base タグを短縮するよう案内する明示診断を返すようにした。配布する content.json テンプレートの `tags.min_count` も 26 に統一した（#1732）。
+
 ## [5.5.17] - 2026-07-10
 
 ### Added

--- a/examples/channel_config.example/content.json
+++ b/examples/channel_config.example/content.json
@@ -5,7 +5,7 @@
     "context": "RPG"
   },
   "tags": {
-    "min_count": 30,
+    "min_count": 26,
     "base": ["chiptune music", "8-bit music", "RPG music", "game music"],
     "themes": {
       "adventure": ["adventure music", "journey music"],

--- a/src/youtube_automation/cli/channel_init_templates.py
+++ b/src/youtube_automation/cli/channel_init_templates.py
@@ -68,7 +68,7 @@ def _render_meta(ctx: ChannelInitContext) -> dict:
 def _render_content(ctx: ChannelInitContext) -> dict:
     return {
         "genre": {"primary": ctx.genre, "style": ctx.style, "context": ctx.context},
-        "tags": {"base": [], "themes": {}},
+        "tags": {"min_count": 26, "base": [], "themes": {}},
         "descriptions": {
             "opening": f"{ctx.style} {ctx.genre} music inspired by {ctx.context}.",
             "sub_opening": f"Perfect for studying, relaxing, or immersing yourself in {ctx.context}.",

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -419,10 +419,21 @@ def extract_descriptions_md_tags(desc_md: Path) -> list[str] | None:
 
 
 def check_tags_count(tags: list[str], min_count: int | None) -> str | None:
-    """件数下限を満たさない場合 issue 文字列、満たせば None."""
+    """タグ件数下限を検証し、500 字制約下で不可能なら原因を明示する."""
     if min_count is None:
         return None
     if len(tags) < min_count:
+        missing_count = min_count - len(tags)
+        current_chars = youtube_tag_chars(tags)
+        # 1 文字タグを追加する場合でも、既存タグがあれば各タグに `,` が必要になる。
+        minimum_chars = current_chars + (2 * missing_count) - (0 if tags else 1)
+        if minimum_chars > YT_TAG_CHAR_LIMIT:
+            return (
+                f"tags.min_count={min_count} is unreachable under YouTube's {YT_TAG_CHAR_LIMIT}-character "
+                f"tag limit: {len(tags)} current tags use {current_chars} characters, and adding "
+                f"{missing_count} one-character tags requires at least {minimum_chars}. "
+                "Reduce tags.min_count or shorten base tags."
+            )
         return f"tags count: {len(tags)} (min {min_count})"
     return None
 

--- a/tests/test_channel_init.py
+++ b/tests/test_channel_init.py
@@ -163,6 +163,16 @@ def test_content_json_reflects_genre_style_context_args(tmp_path):
     assert content["genre"]["context"] == "RPG"
 
 
+def test_content_json_uses_base_only_tags_min_count(tmp_path):
+    # Given/When: yt-channel-init の通常実行で content.json を生成
+    rc = main(_required_args(tmp_path))
+
+    # Then: 生成器が base-only 設計と整合する件数下限を明示する
+    assert rc == 0
+    content = _read_json(_channel_dir(tmp_path) / "content.json")
+    assert content["tags"]["min_count"] == 26
+
+
 # ===================== Case 5: genre/style/context のデフォルト "TBD" =====================
 
 

--- a/tests/test_content_templates.py
+++ b/tests/test_content_templates.py
@@ -1,0 +1,21 @@
+"""配布する content.json テンプレートのタグ件数下限を検証する。"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "examples/channel_config.example/content.json",
+        ".claude/skills/channel-new/references/config-template/content.json",
+    ],
+)
+def test_content_templates_use_base_only_tags_min_count(path: str) -> None:
+    content = json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+    assert content["tags"]["min_count"] == 26

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 
 from youtube_automation.agents._preflight import PreflightMixin
+from youtube_automation.agents.youtube_auto_uploader import YouTubeAutoUploader
+from youtube_automation.utils.config import load_config
 
 
 class _PreflightHarness(PreflightMixin):
@@ -81,10 +83,25 @@ def _write_minimal_channel(
     return channel_dir
 
 
-def _write_collection(channel_dir: Path, *, scene_phrases: dict[str, str], description: str) -> Path:
+def _write_collection(
+    channel_dir: Path,
+    *,
+    scene_phrases: dict[str, str],
+    description: str,
+    tags: list[str] | None = None,
+) -> Path:
     collection_dir = channel_dir / "collections" / "planning" / "20260622-tc-continuous"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True, exist_ok=True)
+    tags_section = (
+        ""
+        if tags is None
+        else f"""\n## タグ（YouTube タグ欄）
+```
+{", ".join(tags)}
+```
+"""
+    )
     (docs_dir / "descriptions.md").write_text(
         f"""## タイトル案
 ```
@@ -95,6 +112,7 @@ Continuous Focus Mix
 ```
 {description}
 ```
+{tags_section}
 """,
         encoding="utf-8",
     )
@@ -276,3 +294,57 @@ def test_target_duration_config_does_not_block_upload_preflight(
     (master_dir / "master.mp4").write_bytes(b"not a valid mp4")
 
     _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_unreachable_tags_min_count_reports_character_limit_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en"])
+    content_path = channel_dir / "config" / "channel" / "content.json"
+    content = json.loads(content_path.read_text(encoding="utf-8"))
+    content["tags"]["min_count"] = 30
+    _write_json(content_path, content)
+
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={},
+        description="A continuous BGM mix without chapter markers.",
+        tags=["a" * 17] * 26 + ["b" * 27],
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+    message = str(excinfo.value)
+    assert "tags.min_count=30 is unreachable under YouTube's 500-character tag limit" in message
+    assert "Reduce tags.min_count or shorten base tags." in message
+
+
+def test_upload_collection_reports_unreachable_tags_min_count_from_channel_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """公開 upload agent は content.json を loader 経由で読み、到達不能設定を停止する。"""
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en"])
+    content_path = channel_dir / "config" / "channel" / "content.json"
+    content = json.loads(content_path.read_text(encoding="utf-8"))
+    content["tags"]["min_count"] = 30
+    _write_json(content_path, content)
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={},
+        description="A continuous BGM mix without chapter markers.",
+        tags=["a" * 17] * 26 + ["b" * 27],
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    assert load_config().content.tags.min_count == 30
+    uploader = YouTubeAutoUploader(str(channel_dir / "collections"))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        uploader.upload_collection(str(collection_dir), apply_default_publish_at=False)
+
+    message = str(excinfo.value)
+    assert "tags.min_count=30 is unreachable under YouTube's 500-character tag limit" in message
+    assert "Reduce tags.min_count or shorten base tags." in message

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -52,6 +52,22 @@ class TestCheckTagsCount:
         msg = check_tags_count(["a", "b"], 5)
         assert msg == "tags count: 2 (min 5)"
 
+    def test_under_min_at_character_limit_returns_existing_message(self) -> None:
+        tags = ["a" * 17] * 26 + ["b" * 26]
+
+        assert check_tags_count(tags, 30) == "tags count: 27 (min 30)"
+
+    def test_under_min_unreachable_under_character_limit_explains_resolution(self) -> None:
+        tags = ["a" * 17] * 26 + ["b" * 27]
+
+        msg = check_tags_count(tags, 30)
+
+        assert msg == (
+            "tags.min_count=30 is unreachable under YouTube's 500-character tag limit: "
+            "27 current tags use 495 characters, and adding 3 one-character tags requires at least 501. "
+            "Reduce tags.min_count or shorten base tags."
+        )
+
     def test_at_min_passes(self) -> None:
         assert check_tags_count(["a", "b", "c"], 3) is None
 


### PR DESCRIPTION
## Summary

## 概要
CC アップロードの preflight が `content.json::tags.min_count` を強制するが、この値が YouTube のタグ 500 字上限の下で到達不能になっているケースを検出できない。#1240 で tags.base を 26 個（493/500 chars で char budget をほぼ使い切り）へ統一し themes を空にしたのに `min_count: 30` が残ると、base 26 + channel tag = 27 < 30 で preflight が失敗し、CC アップロードがブロックされる。到達不能な min_count の検出とテンプレ整合を upstream 側で対応する。

## 背景・目的
旧 #1567 の後継（実装乖離監査の全件再起票方針による新基準テンプレートでの作り直し）。急性症状（該当下流チャンネルの publish 不能）は downstream の `content.json` で `min_count` を 30→26 に暫定修正して回避済みだが、upstream 側の 3 要件（到達不能検出 / テンプレ整合 / 事前診断）は監査時点で未対応（`check_tags_count` は単純な count 比較のみで到達不能検出なし）。

経緯: #1240（2026-06-25）で `tags.base` を Flow365 TTP の union 上位 26 個に転写し `tags.themes` を空に統一したが、`tags.min_count: 30` が残った。base は 500 字上限をほぼ使い切っているため、追加タグで 30 に届かせると今度は 500 字超で YouTube API 側が弾く = 30 は物理的に到達不能。

### 再現手順
1. #1240 適用後相当の `content.json`（base 26 tags / themes 空 / min_count 30）を持つチャンネルで
2. `/video-description` で概要欄を生成する（tags = base 26 + channel tag = 27）
3. `uv run yt-upload-collection -c <collection>` を実行する

### 期待される動作
- (a) preflight が「min_count が 500 字上限の下で到達不能」を検出し、count 不足エラーではなく原因の分かる明示メッセージ（例:「min_count=30 は base タグの 500 字上限に反する。min_count を下げるか base を短縮せよ」）を出す
- (b) upstream が配布/推奨する `content.json` テンプレの `tags.min_count` が base-only 設計（26/27）に整合している

### 実際の動作
preflight が `tags count: 27 (min 30)` で停止しアップロードされない。「count 27 < min 30」しか出ず、500 字上限との矛盾（そもそも 30 は達成不能）が読み取れない。エラーメッセージが「タグを増やせ」と誤誘導し、増やすと 500 字超で別の失敗を招く。

### 影響範囲
- min_count が到達不能な設定のチャンネルは全 CC のアップロードが preflight で失敗する（暫定修正前の下流チャンネルで実際に発生）
- 新規チャンネルでもテンプレの min_count が base 設計と不整合なら同事象が再発する

## 参照資料
- src/youtube_automation/utils/preflight_checks.py（`check_tags_count`: 現状は count 比較のみ）
- config/channel/content.json（下流。`tags.min_count` / `tags.base` / `tags._base_note` / `tags.themes`）
- #1240（tags TTP 転写 / themes 廃止の経緯）

## 影響ファイル
- **変更**: src/youtube_automation/utils/preflight_checks.py（min_count と 500 字上限の整合チェック + 明示メッセージ）
- **変更**: channel-new 等が配布する content.json テンプレの `tags.min_count` デフォルト（配布箇所は plan step で確定）
- **新規/変更**: 対応するユニットテスト
- **変更（任意）**: yt-doctor の診断項目（要件 3）

**兄弟入口・貫通先**:
- config キーの貫通: content.json 定義 → metadata_generator（タグ生成）→ preflight（検証）→ YouTube API（500 字制約）
- `tags.min_count` を参照する他経路（`--plan` / `--status` / 実アップロード）で同じ検証を共有する

## 要件
1. base タグの合計文字数が 500 字に近く `min_count` が達成不能な設定で preflight を実行する → count 不足だけでなく「min_count が 500 字制約下で到達不能」を示す明示メッセージが出て、オペレーターが原因（min_count を下げる / base を短縮）を即判断できる
2. upstream 配布/推奨の content.json テンプレを確認する → `tags.min_count` が base-only 設計（26 または 27）に整合しており、新規チャンネルで同事象が再発しない
3. （任意）`yt-doctor` 等を実行する → min_count と base タグ数・文字数の不整合を事前検出できる
4. min_count が到達可能な既存チャンネルで preflight を実行する → 挙動が変わらない（回帰なし）

## スコープ外
- タグ内容そのものの TTP 見直し（base 26 個の選定）
- 500 字上限内で 30 個に収める短縮タグ設計の是非（本 issue は「到達不能な min_count の検出/整合」に限定）
- 下流チャンネルの暫定修正（min_count 30→26）の巻き戻し・追従作業

## 実装方針（takt）
- workflow: lite
- 理由: `check_tags_count` への整合チェック 1 本の追加 + テンプレ値の整合 + テストに収まる局所的な変更のため。priority: high だが急性症状は下流暫定修正で回避済みで、変更範囲は狭い

## Execution Report

Workflow `lite` completed successfully.

Closes #1732