### PR TITLE
[#1736] issue-1736-suno-helper-no-nipu

### DIFF
--- a/extensions/distrokid-helper/components/ServerUrlField.tsx
+++ b/extensions/distrokid-helper/components/ServerUrlField.tsx
@@ -1,4 +1,4 @@
-import type { LocalServerSource } from "../../shared/constants";
+import { formatServerSourceLabel, type LocalServerSource } from "../../shared/constants";
 
 export interface ServerUrlFieldProps {
   value: string;
@@ -24,7 +24,7 @@ export function ServerUrlField({ value, sources, disabled, onChange, onFetch }: 
       >
         {sources.map((source) => (
           <option key={source.url} value={source.url}>
-            {source.label} - {source.url}
+            {formatServerSourceLabel(source, "distrokid-helper")}
           </option>
         ))}
       </select>

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -8,6 +8,7 @@ import { App } from "../entrypoints/popup/App";
 import type { ReleasePayload } from "../lib/types";
 
 const BASE_URL = "http://localhost:7873";
+const FALLBACK_URL = "http://localhost:7877";
 const MANIFEST_VERSION = "0.1.9";
 
 const RELEASE_PAYLOAD: ReleasePayload = {
@@ -55,8 +56,14 @@ vi.mock("../lib/storage", () => ({
     getValue: vi.fn(async () => ""),
     setValue: vi.fn(async () => undefined),
   },
-  readServerSources: vi.fn(async () => [{ id: "localhost-7873", label: "localhost", url: BASE_URL }]),
-  rememberServerSource: vi.fn(async () => [{ id: "localhost-7873", label: "localhost", url: BASE_URL }]),
+  readServerSources: vi.fn(async () => [
+    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+  ]),
+  rememberServerSource: vi.fn(async () => [
+    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+  ]),
 }));
 
 vi.mock("../lib/messaging", () => ({
@@ -125,6 +132,20 @@ describe("DistroKid popup compatibility check", () => {
     container.remove();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it("ローカル配信元 option は URL を表示せず、URL value はデータ取得先として維持する", async () => {
+    const select = container.querySelector<HTMLSelectElement>("#server-url")!;
+
+    await waitFor(() => {
+      expect(select.options).toHaveLength(2);
+    });
+
+    expect(Array.from(select.options, (option) => ({ text: option.text, value: option.value }))).toEqual([
+      { text: "ABYSS MI | distrokid-helper", value: BASE_URL },
+      { text: "localhost fallback 7877 | distrokid-helper", value: FALLBACK_URL },
+    ]);
+    expect(select.textContent).not.toContain("http://");
   });
 
   it("データ取得時に manifest version で /version を先に呼び、非互換警告を表示して release 取得を継続する", async () => {

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -247,6 +247,15 @@ export interface LocalServerSource {
   url: string;
 }
 
+export type HelperProcessName = "distrokid-helper" | "suno-helper";
+
+export function formatServerSourceLabel(
+  source: LocalServerSource,
+  helper: HelperProcessName,
+): string {
+  return `${source.label} | ${helper}`;
+}
+
 /** 拡張初回起動時のローカル配信元候補。 */
 export const DEFAULT_SERVER_SOURCES: LocalServerSource[] = [
   {

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { DOWNLOAD_FORMAT_DEFAULT, RUN_MODES, type RunModeId } from "../../shared/constants";
+import { DOWNLOAD_FORMAT_DEFAULT, formatServerSourceLabel, RUN_MODES, type RunModeId } from "../../shared/constants";
 import {
   buildInitialPatternSelection,
   reconcilePatternSelection,
@@ -149,7 +149,7 @@ export function App() {
         >
           {serverSources.map((source) => (
             <option key={source.url} value={source.url}>
-              {source.label} - {source.url}
+              {formatServerSourceLabel(source, "suno-helper")}
             </option>
           ))}
         </select>

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_URL,
   FEED_V3_METHOD,
   FEED_V3_PATH,
+  formatServerSourceLabel,
   INJECT_ACK_TIMEOUT_MS,
   INTER_CREATE_DELAY_MS,
   MAX_INJECT_RETRY,
@@ -55,6 +56,18 @@ describe("shared/constants: サーバー互換の契約値", () => {
       "http://localhost:7876",
       "http://localhost:7877",
     ]);
+  });
+
+  it("Given server selector When helper ごとの option 表示名を組み立てる Then URL を含めずプロセスを識別できる", () => {
+    expect(
+      formatServerSourceLabel(
+        { id: "abyss-mi", label: "ABYSS MI", url: "http://abyss-mi.localhost:7873" },
+        "distrokid-helper",
+      ),
+    ).toBe("ABYSS MI | distrokid-helper");
+    expect(formatServerSourceLabel(DEFAULT_SERVER_SOURCES.at(-1)!, "suno-helper")).toBe(
+      "localhost fallback 7877 | suno-helper",
+    );
   });
 
   it("Given server selector When host permissions を読む Then *.localhost を許可する", () => {

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -9,6 +9,7 @@ import { PHASE, type ProgressPayload } from "../../shared/constants";
 import { App } from "../components/App";
 
 const BASE_URL = "http://localhost:7873";
+const FALLBACK_URL = "http://localhost:7877";
 const MANIFEST_VERSION = "0.1.9";
 
 const messagingMocks = vi.hoisted(() => {
@@ -58,11 +59,13 @@ vi.mock("../lib/storage", () => ({
   downloadFormatItem: downloadFormatMocks,
   readDownloadFormat: vi.fn(() => downloadFormatMocks.getValue()),
   readServerSources: vi.fn(async () => [
-    { id: "localhost-7873", label: "localhost", url: BASE_URL },
+    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
     { id: "localhost-7873-changed", label: "localhost changed", url: `${BASE_URL}/changed` },
   ]),
   rememberServerSource: vi.fn(async () => [
-    { id: "localhost-7873", label: "localhost", url: BASE_URL },
+    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
     { id: "localhost-7873-changed", label: "localhost changed", url: `${BASE_URL}/changed` },
   ]),
 }));
@@ -277,6 +280,21 @@ describe("Suno popup compatibility check", () => {
     resumeStateMocks.writeResumeState.mockResolvedValue(undefined);
     presetStateMocks.readRunModeId.mockResolvedValue("serial");
     presetStateMocks.writeRunModeId.mockResolvedValue(undefined);
+  });
+
+  it("ローカル配信元 option は URL を表示せず、URL value はデータ取得先として維持する", async () => {
+    const select = expectControl(container, "server-url") as HTMLSelectElement;
+
+    await waitFor(() => {
+      expect(select.options).toHaveLength(3);
+    });
+
+    expect(Array.from(select.options, (option) => ({ text: option.text, value: option.value }))).toEqual([
+      { text: "ABYSS MI | suno-helper", value: BASE_URL },
+      { text: "localhost fallback 7877 | suno-helper", value: FALLBACK_URL },
+      { text: "localhost changed | suno-helper", value: `${BASE_URL}/changed` },
+    ]);
+    expect(select.textContent).not.toContain("http://");
   });
 
   it("popup に投入方式 selector を表示し、Fast / Balanced / Safe の速度プリセットは表示しない", () => {

--- a/extensions/suno-helper/tests/storage.test.ts
+++ b/extensions/suno-helper/tests/storage.test.ts
@@ -1,4 +1,4 @@
-// `lib/storage.ts` の契約テスト。
+// `lib/storage.ts` の候補復元契約テスト。
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,23 +7,18 @@ const storageMocks = vi.hoisted(() => ({
   setValue: vi.fn(),
 }));
 
-vi.mock("@wxt-dev/storage", () => ({
+vi.mock("wxt/utils/storage", () => ({
   storage: {
     defineItem: vi.fn(() => storageMocks),
   },
 }));
 
-import { DEFAULT_URL } from "../../shared/constants";
 import { readServerSources } from "../lib/storage";
 
-describe("DEFAULT_URL (shared constants)", () => {
+describe("local server source storage", () => {
   beforeEach(() => {
     storageMocks.getValue.mockReset();
     storageMocks.setValue.mockReset();
-  });
-
-  it("yt-collection-serve の既定ポート 7873 を指す", () => {
-    expect(DEFAULT_URL).toBe("http://youtube-automation.localhost:7873");
   });
 
   it("保存済み候補の label と id が欠損しても、既存の URL を接続先として復元する", async () => {


### PR DESCRIPTION
## Summary

## 概要
helper 拡張（distrokid-helper / suno-helper）のローカル配信元セレクトで、`localhost fallback 7877 - http://localhost:7877` のように URL を前面表示するのをやめ、表示ラベルを `チャンネル名 | distrokid-helper` のようなプロセス識別名にする。ユーザーが選択時に判別したいのは URL ではなく、どのチャンネル / どの helper プロセスなのか。

## 背景・目的
旧 #1604 の後継（実装乖離監査の全件再起票方針による新基準テンプレートでの作り直し。監査時点で `ServerUrlField.tsx` / suno-helper `App.tsx` が `{source.label} - {source.url}` 表示のままであることを確認済み）。

現在の配信元候補は URL を値として保持するだけでなく `<option>` の表示にも URL を併記しており、複数プロセス起動時に人間が選ぶべき対象を判別しにくい。なお配信元候補の供給方式自体は #1616（ローカル配信元の自動蓄積を廃止し稼働中サーバーの動的検出に変更）で見直しが進行中のため、#1616 の先行が望ましい。本 issue は「候補をどう表示するか」のみを扱い、候補の検出・蓄積方式は扱わない。

### 提案する仕様
- セレクトの表示名は URL ではなく、チャンネル名と helper 種別がわかる形式にする（例: `ABYSS MI | distrokid-helper`）
- fallback 候補も URL 併記を避け、`localhost fallback 7877 | distrokid-helper` のようにプロセス種別を表示する
- `value` として保持する URL は従来どおり維持し、fetch 先の挙動は変えない

### ユースケース
DistroKid Helper の popup で複数の `yt-collection-serve` 起動候補がある場合、ユーザーが localhost の URL ではなく「どのチャンネル / どの helper 用プロセスか」を見て選択できる。

## 参照資料
- extensions/shared/constants.ts（`LocalServerSource` / `DEFAULT_SERVER_SOURCES`）
- extensions/distrokid-helper/components/ServerUrlField.tsx
- extensions/distrokid-helper/components/useDistrokidRunner.ts
- extensions/suno-helper/components/App.tsx
- extensions/suno-helper/lib/storage.ts / extensions/distrokid-helper/lib/storage.ts
- #1616（配信元候補の動的検出。先行が望ましい）

## 影響ファイル
- **変更**: extensions/shared/constants.ts
- **変更**: extensions/distrokid-helper/components/ServerUrlField.tsx
- **変更**: extensions/suno-helper/components/App.tsx
- **変更**: extensions/distrokid-helper/tests/ / extensions/suno-helper/tests/

**兄弟入口・貫通先**:
- distrokid-helper popup と suno-helper popup が同じ `LocalServerSource` / `DEFAULT_SERVER_SOURCES` を使う兄弟入口。表示仕様を両方に揃える
- server 側 `/server-info`: 既存レスポンスにチャンネル名 / helper 種別を含められるか plan step で確認する。URL 契約は変更しない
- chrome.storage.local `ytCollectionServeSources`: 保存済み候補との互換を維持する。既存 `url` は fetch 先として引き続き使う

## 要件
1. DistroKid Helper のローカル配信元セレクトを開く → option 表示に `http://localhost:7877` のような URL 併記が出ず、`チャンネル名 | distrokid-helper` 形式でプロセスを識別できる
2. 候補を選択してデータ取得する → `value` として保持される URL は従来どおり使われ、既存の `fetchData()` / `/server-info` / payload 取得の挙動が変わらない
3. fallback localhost 候補を表示する → `localhost fallback 7877 | distrokid-helper` のように、URL ではなく fallback 名と helper 種別で判別できる
4. Suno Helper 側で同じ配信元候補を表示する → `チャンネル名 | suno-helper` 相当の形式になり、DistroKid Helper と表示方針が揃う
5. 既存の storage に保存済みの `LocalServerSource` を読む → 欠損フィールドがあっても既存候補が壊れず、従来の URL で接続できる

## スコープ外
- #1616（ローカル配信元の自動蓄積廃止・稼働中サーバー動的検出）の責務: 候補の検出・蓄積方式そのものは本 issue では扱わない。本 issue は候補の「表示形式」のみ。#1616 実装後に候補メタデータ（チャンネル名等）の取得元が変わる場合は本 issue 側が追従する
- `yt-collection-serve` のポート割り当てロジック変更
- Chrome 拡張の ID や manifest permission の変更
- DistroKid フォーム注入ロジックの変更

## 実装方針（takt）
- workflow: lite
- 理由: helper popup の表示改善が中心で、影響範囲は少数の TS/TSX ファイルと既存テストに収まるため

## Execution Report

Workflow `lite` completed successfully.

Closes #1736