### PR TITLE
[#1746] issue-1746-video-gen-loop-vide

### DIFF
--- a/.claude/skills/loop-video/SKILL.md
+++ b/.claude/skills/loop-video/SKILL.md
@@ -281,7 +281,7 @@ veo:
 | フェーズ | Ctrl+C の効き | API 側 operation | クレジット消費 | 再開可否 |
 |---|---|---|---|---|
 | `client.models.generate_videos(...)` 送信中（submit 中） | ローカルプロセスは即停止 | submit が成立していれば API 側で開始済み | submit 後ならフル課金 | **不可**（operation_name を持たない） |
-| polling 中（submit 済み、生成待ち） | ローカルプロセスは即停止 | **継続実行される**（cancel されない） | フル課金（中断しても止まらない） | **可**（`<CHANNEL_DIR>/tmp/veo-operations/` に保存された operation_name を次回実行で resume） |
+| polling 中（submit 済み、生成待ち） | ローカルプロセスは即停止 | **継続実行される**（cancel されない） | フル課金（中断しても止まらない） | **可**（同じ model・同じ入力画像なら、`<CHANNEL_DIR>/tmp/veo-operations/` に保存された operation_name を次回実行で resume） |
 | polling 中の `operations.get` 一時障害 | 例外捕捉、state を保持 | API 側継続 | フル課金 | 可 |
 | polling 中の `operations.get` で失効（404） | state を削除 | （失効済み） | 課金済み bytes は取りこぼし | 不可 |
 
@@ -289,8 +289,8 @@ veo:
 
 - **Veo API には `operations.cancel` 相当が現状未実装** (`client.operations.cancel` は未提供)。本スキルの実装 (`utils/veo_generator.py`) も `KeyboardInterrupt` を捕捉してメッセージ表示と state 保存だけを行い、cancel API を呼んでいない。**Ctrl+C はあくまでローカルプロセスを止めるだけで、API 側のジョブとクレジット消費は止められない**。
 - submit が成功した時点で課金は確定する想定で運用する。中断は「節約」にはならず、せいぜい「次回の二重課金を resume で防ぐ」効果しかない。
-- 中断 → 即再実行すれば、保存済み operation_name から resume して既課金分を回収できる（loop.mp4 を取り出せる）。**再課金は発生しない**。
-- 完全に捨てる場合でも、state ファイル (`<CHANNEL_DIR>/tmp/veo-operations/<output-hash>.json`) を手動削除しない限り、次回 `yt-generate-loop-video` 実行時に resume を試みる点に注意（不要なら削除）。
+- 中断 → 同じ model・同じ入力画像で即再実行すれば、保存済み operation_name から resume して既課金分を回収できる（loop.mp4 を取り出せる）。**再課金は発生しない**。
+- model または入力画像を変えて完全に作り直す場合は、state を手動削除する必要はない。次回 `yt-generate-loop-video` 実行時に自動で state を破棄して新規 submit する。
 
 ### 運用ガイドライン
 
@@ -302,7 +302,8 @@ veo:
 ### state ファイルの場所
 
 - パス: `<CHANNEL_DIR>/tmp/veo-operations/<output-hash>.json`
-- 中身: `{ "operation_name": "operations/...", "model": "veo-3.1-fast-generate-001", "output_path": "..." }`
+- 中身: `{ "operation_name": "operations/...", "model": "veo-3.1-fast-generate-001", "output_path": "...", "input_image_sha256": "..." }`
+- 再実行時は model と入力画像内容の SHA-256 が両方一致した state だけを resume する。不一致または旧形式の state は破棄して新規 submit する
 - 再開不要なら手動削除可（次回実行は新規 submit になる）
 
 ## 長時間処理の取り扱い

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(loop-video)`: Ctrl+C 後の Veo operation resume state に入力画像の SHA-256 を保存し、再実行時に指定モデルまたは入力画像内容が state と異なる場合は旧 operation を破棄して指定どおり新規生成するようにした（#1746）。旧形式 state は安全側で破棄する。
+
 ## [5.5.17] - 2026-07-10
 
 ### Added

--- a/src/youtube_automation/utils/veo_generator.py
+++ b/src/youtube_automation/utils/veo_generator.py
@@ -71,15 +71,10 @@ def _handle_operations_get_error(exc: Exception, output_path: Path) -> None:
         print(f"\n  [ERROR]  operation.get 失敗（一時障害、state を保持）: {exc}")
 
 
-def _resume_operation(client, gen_types, output_path: Path, requested_model: str, state: dict):
+def _resume_operation(client, gen_types, output_path: Path, state: dict):
     """保存済み operation を復元し、resume 用の operation と実効モデルを返す。"""
     saved_model = state["model"]
     operation_name = state["operation_name"]
-    if saved_model != requested_model:
-        print(
-            f"  [Warn]   保存済みモデル ({saved_model}) と引数モデル ({requested_model}) が異なります。"
-            f"保存済みモデルで続行します"
-        )
     print(f"  [Resume] 前回の operation を引き継ぎます: {operation_name}")
     operation = gen_types.GenerateVideosOperation(name=operation_name)
     try:
@@ -173,7 +168,7 @@ def _submit_operation(
         return None
 
     if operation.name:
-        op_store.save(output_path, operation.name, model)
+        op_store.save(output_path, image_path, operation.name, model)
     else:
         print("  [Warn]   operation.name が空のため state を保存できません")
     return operation
@@ -326,17 +321,36 @@ def generate_loop_video(
 ) -> bool:
     """Veo 3.1 API でループ動画を生成する。
 
-    前回 Ctrl+C で中断した state が残っている場合は generate_videos を呼ばずに
-    保存済み operation_name から polling を再開する（二重課金防止）。
+    前回 Ctrl+C で中断した state があり、model と入力画像 SHA-256 が一致する場合は
+    generate_videos を呼ばずに保存済み operation_name から polling を再開する（二重課金防止）。
     """
     from google.genai import types as gen_types
 
     state = op_store.load(output_path)
 
     if state is not None:
-        operation, effective_model = _resume_operation(client, gen_types, output_path, model, state)
-        if operation is None:
-            return False
+        image_matches = state["input_image_sha256"] == op_store.image_sha256(image_path)
+        model_matches = state["model"] == model
+        if image_matches and model_matches:
+            operation, effective_model = _resume_operation(client, gen_types, output_path, state)
+            if operation is None:
+                return False
+        else:
+            print("  [Resume] 保存済み state のモデルまたは入力画像が現在の指定と一致しないため破棄し、新規生成します")
+            op_store.clear(output_path)
+            effective_model = model
+            operation = _submit_operation(
+                client,
+                gen_types,
+                image_path,
+                output_path,
+                model,
+                prompt,
+                aspect_ratio,
+                duration_seconds,
+            )
+            if operation is None:
+                return False
     else:
         effective_model = model
         operation = _submit_operation(

--- a/src/youtube_automation/utils/veo_operation_store.py
+++ b/src/youtube_automation/utils/veo_operation_store.py
@@ -1,7 +1,7 @@
 """Veo operation 永続化ストア。
 
-Ctrl+C 中断時に operation_name を <CHANNEL_DIR>/tmp/veo-operations/ に保存し、
-再実行時に resume できるようにする pure I/O モジュール。google.genai 非依存。
+Ctrl+C 中断時に operation_name と入力画像 SHA-256 を <CHANNEL_DIR>/tmp/veo-operations/ に保存し、
+同一入力の再実行時に resume できるようにする pure I/O モジュール。google.genai 非依存。
 """
 
 from __future__ import annotations
@@ -12,7 +12,16 @@ import os
 from pathlib import Path
 
 _HASH_LEN = 16
-_REQUIRED_KEYS = {"operation_name", "model", "output_path"}
+_REQUIRED_KEYS = {"operation_name", "model", "output_path", "input_image_sha256"}
+
+
+def image_sha256(image_path: Path) -> str:
+    """入力画像の内容を識別する SHA-256 ハッシュを返す。"""
+    digest = hashlib.sha256()
+    with image_path.open("rb") as image_file:
+        for chunk in iter(lambda: image_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _resolve_channel_root(channel_root: Path | None) -> Path:
@@ -32,18 +41,20 @@ def state_path(output_path: Path, *, channel_root: Path | None = None) -> Path:
 
 def save(
     output_path: Path,
+    image_path: Path,
     operation_name: str,
     model: str,
     *,
     channel_root: Path | None = None,
 ) -> Path:
-    """state を JSON で永続化する（atomic write）。保存先パスを返す。"""
+    """入力画像識別子を含む state を JSON で永続化する（atomic write）。"""
     path = state_path(output_path, channel_root=channel_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "operation_name": operation_name,
         "output_path": str(output_path.resolve()),
         "model": model,
+        "input_image_sha256": image_sha256(image_path),
     }
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
@@ -75,13 +86,17 @@ def load(output_path: Path, *, channel_root: Path | None = None) -> dict | None:
         path.unlink(missing_ok=True)
         return None
 
-    # 型検証: operation_name, model, output_path は文字列である必要
+    # 型検証: operation_name, model, output_path, input_image_sha256 は文字列である必要
     if (
         not isinstance(data["operation_name"], str)
         or not isinstance(data["model"], str)
         or not isinstance(data["output_path"], str)
+        or not isinstance(data["input_image_sha256"], str)
     ):
-        print(f"  [Warn]   state の operation_name/model/output_path が文字列ではありません（削除します）: {path}")
+        print(
+            "  [Warn]   state の operation_name/model/output_path/input_image_sha256 が文字列ではありません"
+            f"（削除します）: {path}"
+        )
         path.unlink(missing_ok=True)
         return None
 

--- a/tests/test_veo_generator.py
+++ b/tests/test_veo_generator.py
@@ -311,7 +311,10 @@ def channel_tmp(tmp_path: Path, monkeypatch):
 @pytest.fixture
 def output_mp4(channel_tmp: Path):
     """テスト用の出力パスを返す（ファイルは未作成）。"""
-    return channel_tmp / "collections" / "foo" / "10-assets" / "loop.mp4"
+    assets_dir = channel_tmp / "collections" / "foo" / "10-assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "main.png").write_bytes(b"test-image")
+    return assets_dir / "loop.mp4"
 
 
 def _make_done_operation(name: str = "projects/veo/12345") -> MagicMock:
@@ -416,7 +419,13 @@ class TestGenerateLoopVideoResume:
     def _write_state(self, channel_tmp: Path, output_mp4: Path, operation_name: str, model: str) -> None:
         from youtube_automation.utils import veo_operation_store as op_store
 
-        op_store.save(output_mp4, operation_name, model, channel_root=channel_tmp)
+        op_store.save(
+            output_mp4,
+            output_mp4.parent / "main.png",
+            operation_name,
+            model,
+            channel_root=channel_tmp,
+        )
 
     def test_skips_generate_videos_when_state_exists(self, channel_tmp: Path, output_mp4: Path, monkeypatch) -> None:
         """Given: state あり / When: generate_loop_video / Then: client.models.generate_videos 未呼び出し。"""
@@ -447,14 +456,13 @@ class TestGenerateLoopVideoResume:
         # Then: 保存済み operation_name で GenerateVideosOperation を再構築した
         mock_types.GenerateVideosOperation.assert_called_once_with(name="projects/veo/resumed-op")
 
-    def test_warns_on_model_mismatch(self, channel_tmp: Path, output_mp4: Path, monkeypatch, capsys) -> None:
-        """保存モデルと引数モデルが違う場合 [Warn] を出す。"""
-        mock_types = _patch_genai_types(monkeypatch)
+    def test_discards_state_and_submits_when_model_mismatches(
+        self, channel_tmp: Path, output_mp4: Path, monkeypatch, capsys
+    ) -> None:
+        """保存モデルと引数モデルが違う場合は resume せず新規 submit する。"""
+        _patch_genai_types(monkeypatch)
         client = MagicMock()
-        done_op = _make_done_operation("projects/veo/op-x")
-        mock_types.GenerateVideosOperation.return_value = MagicMock(name="projects/veo/op-x", done=True)
-        client.operations.get.return_value = done_op
-        # state に保存したモデルと引数モデルを意図的に変える
+        client.models.generate_videos.return_value = _make_done_operation("projects/veo/new-model")
         self._write_state(channel_tmp, output_mp4, "projects/veo/op-x", "veo-3.1-fast")
 
         with patch.multiple(
@@ -472,7 +480,68 @@ class TestGenerateLoopVideoResume:
                 )
 
         out = capsys.readouterr().out
-        assert "[Warn]" in out
+        assert "state のモデルまたは入力画像が現在の指定と一致しないため破棄し、新規生成します" in out
+        client.operations.get.assert_not_called()
+        client.models.generate_videos.assert_called_once()
+
+    def test_discards_old_state_when_new_submit_fails_after_model_mismatch(
+        self, channel_tmp: Path, output_mp4: Path, monkeypatch
+    ) -> None:
+        """モデル不一致後の submit 失敗でも、旧 state は残さない。"""
+        _patch_genai_types(monkeypatch)
+        client = MagicMock()
+        client.models.generate_videos.side_effect = RuntimeError("submit failed")
+        self._write_state(channel_tmp, output_mp4, "projects/veo/old-model", "veo-3.1-fast")
+
+        with patch.multiple(
+            "youtube_automation.utils.veo_generator",
+            strip_audio=MagicMock(),
+            cost_tracker=MagicMock(),
+        ):
+            result = veo_generator.generate_loop_video(
+                client,
+                output_mp4.parent / "main.png",
+                output_mp4,
+                model="veo-3.1-DIFFERENT-model",
+                prompt="test prompt",
+            )
+
+        assert result is False
+        client.operations.get.assert_not_called()
+        client.models.generate_videos.assert_called_once()
+        from youtube_automation.utils import veo_operation_store as op_store
+
+        assert op_store.load(output_mp4, channel_root=channel_tmp) is None
+
+    def test_discards_state_and_submits_when_input_image_changes(
+        self, channel_tmp: Path, output_mp4: Path, monkeypatch, capsys
+    ) -> None:
+        """入力画像の内容が変わった場合は旧 operation を resume しない。"""
+        _patch_genai_types(monkeypatch)
+        client = MagicMock()
+        client.models.generate_videos.return_value = _make_done_operation("projects/veo/new-image")
+        self._write_state(channel_tmp, output_mp4, "projects/veo/old-image", "veo-3.1-fast")
+        (output_mp4.parent / "main.png").write_bytes(b"replacement-image")
+
+        with patch.multiple(
+            "youtube_automation.utils.veo_generator",
+            strip_audio=MagicMock(),
+            cost_tracker=MagicMock(),
+        ):
+            with patch("time.sleep"):
+                result = veo_generator.generate_loop_video(
+                    client,
+                    output_mp4.parent / "main.png",
+                    output_mp4,
+                    model="veo-3.1-fast",
+                    prompt="test prompt",
+                )
+
+        assert result is True
+        output = capsys.readouterr().out
+        assert "state のモデルまたは入力画像が現在の指定と一致しないため破棄し、新規生成します" in output
+        client.operations.get.assert_not_called()
+        client.models.generate_videos.assert_called_once()
 
     def test_clears_state_on_success(self, channel_tmp: Path, output_mp4: Path, monkeypatch) -> None:
         """resume 成功後に state が削除される。"""
@@ -562,15 +631,15 @@ class TestGenerateLoopVideoResume:
 
         assert op_store.load(output_mp4, channel_root=channel_tmp) is None
 
-    def test_cost_log_uses_saved_model_on_mismatch(self, channel_tmp: Path, output_mp4: Path, monkeypatch) -> None:
-        """resume 時のモデル不一致でも cost_tracker には保存済みモデルを記録する（ai-review-002）。"""
-        mock_types = _patch_genai_types(monkeypatch)
+    def test_cost_log_uses_requested_model_after_model_mismatch(
+        self, channel_tmp: Path, output_mp4: Path, monkeypatch
+    ) -> None:
+        """モデル不一致で新規 submit した場合は指定モデルを課金ログへ記録する。"""
+        _patch_genai_types(monkeypatch)
         client = MagicMock()
-        done_op = _make_done_operation("projects/veo/op-mismatch")
-        mock_types.GenerateVideosOperation.return_value = MagicMock(name="projects/veo/op-mismatch", done=True)
-        client.operations.get.return_value = done_op
-        # state に保存したモデルと引数モデルを意図的に変える
+        client.models.generate_videos.return_value = _make_done_operation("projects/veo/new-model")
         saved_model = "veo-3.1-fast"
+        requested_model = "veo-3.1-DIFFERENT-model"
         self._write_state(channel_tmp, output_mp4, "projects/veo/op-mismatch", saved_model)
 
         mock_cost = MagicMock()
@@ -584,15 +653,13 @@ class TestGenerateLoopVideoResume:
                     client,
                     output_mp4.parent / "main.png",
                     output_mp4,
-                    model="veo-3.1-DIFFERENT-model",
+                    model=requested_model,
                     prompt="test prompt",
                 )
 
-        # Then: cost_tracker.log_generation は保存済みモデルで呼ばれる
         mock_cost.log_generation.assert_called_once()
         call_args = mock_cost.log_generation.call_args
-        # log_generation("video", model=...) なので keyword で渡される
-        assert call_args.kwargs.get("model") == saved_model
+        assert call_args.kwargs.get("model") == requested_model
 
 
 class TestGenerateLoopVideoSubmitInterrupt:

--- a/tests/test_veo_operation_store.py
+++ b/tests/test_veo_operation_store.py
@@ -86,12 +86,24 @@ class TestStatePath:
 class TestSave:
     """save() の書き込み・構造テスト."""
 
+    @staticmethod
+    def _image_path(tmp_path: Path) -> Path:
+        image_path = tmp_path / "main.png"
+        image_path.write_bytes(b"test-image")
+        return image_path
+
     def test_creates_state_file(self, tmp_path: Path) -> None:
         # Given
         output_path = tmp_path / "loop.mp4"
 
         # When
-        saved = store.save(output_path, "projects/veo/12345", "veo-3.1-fast", channel_root=tmp_path)
+        saved = store.save(
+            output_path,
+            self._image_path(tmp_path),
+            "projects/veo/12345",
+            "veo-3.1-fast",
+            channel_root=tmp_path,
+        )
 
         # Then
         assert saved.exists()
@@ -103,13 +115,15 @@ class TestSave:
         model = "veo-3.1-fast"
 
         # When
-        saved = store.save(output_path, operation_name, model, channel_root=tmp_path)
+        image_path = self._image_path(tmp_path)
+        saved = store.save(output_path, image_path, operation_name, model, channel_root=tmp_path)
         data = json.loads(saved.read_text(encoding="utf-8"))
 
         # Then
         assert data["operation_name"] == operation_name
         assert data["output_path"] == str(output_path.resolve())
         assert data["model"] == model
+        assert data["input_image_sha256"] == hashlib.sha256(image_path.read_bytes()).hexdigest()
 
     def test_submitted_at_is_not_in_saved_state(self, tmp_path: Path) -> None:
         """submitted_at は state schema に含まれない（未使用フィールドによる契約膨張の防止）。"""
@@ -117,7 +131,7 @@ class TestSave:
         output_path = tmp_path / "loop.mp4"
 
         # When
-        saved = store.save(output_path, "op-name", "veo-3.1-fast", channel_root=tmp_path)
+        saved = store.save(output_path, self._image_path(tmp_path), "op-name", "veo-3.1-fast", channel_root=tmp_path)
         data = json.loads(saved.read_text(encoding="utf-8"))
 
         # Then: 使われていないフィールドは state に含まれない
@@ -130,7 +144,7 @@ class TestSave:
         assert not ops_dir.exists()
 
         # When
-        store.save(output_path, "op-name", "model", channel_root=tmp_path)
+        store.save(output_path, self._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
 
         # Then
         assert ops_dir.exists()
@@ -141,7 +155,7 @@ class TestSave:
         output_path = tmp_path / "loop.mp4"
 
         # When
-        saved = store.save(output_path, "op-name", "model", channel_root=tmp_path)
+        saved = store.save(output_path, self._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
 
         # Then
         tmp_remnant = saved.with_suffix(saved.suffix + ".tmp")
@@ -153,7 +167,7 @@ class TestSave:
         expected = store.state_path(output_path, channel_root=tmp_path)
 
         # When
-        result = store.save(output_path, "op-name", "model", channel_root=tmp_path)
+        result = store.save(output_path, self._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
 
         # Then
         assert result == expected
@@ -162,10 +176,11 @@ class TestSave:
         """2 回 save しても壊れず最新データが残る."""
         # Given
         output_path = tmp_path / "loop.mp4"
-        store.save(output_path, "op-old", "model", channel_root=tmp_path)
+        image_path = self._image_path(tmp_path)
+        store.save(output_path, image_path, "op-old", "model", channel_root=tmp_path)
 
         # When
-        saved = store.save(output_path, "op-new", "model", channel_root=tmp_path)
+        saved = store.save(output_path, image_path, "op-new", "model", channel_root=tmp_path)
         data = json.loads(saved.read_text(encoding="utf-8"))
 
         # Then
@@ -193,7 +208,9 @@ class TestLoad:
     def test_returns_dict_after_save(self, tmp_path: Path) -> None:
         # Given
         output_path = tmp_path / "loop.mp4"
-        store.save(output_path, "projects/veo/99", "veo-3.1-fast", channel_root=tmp_path)
+        image_path = tmp_path / "main.png"
+        image_path.write_bytes(b"test-image")
+        store.save(output_path, image_path, "projects/veo/99", "veo-3.1-fast", channel_root=tmp_path)
 
         # When
         result = store.load(output_path, channel_root=tmp_path)
@@ -233,7 +250,9 @@ class TestLoad:
         """load の返り値を mutate しても次回 load に影響しない（イミュータブル保証）."""
         # Given
         output_path = tmp_path / "loop.mp4"
-        store.save(output_path, "op-original", "model", channel_root=tmp_path)
+        image_path = tmp_path / "main.png"
+        image_path.write_bytes(b"test-image")
+        store.save(output_path, image_path, "op-original", "model", channel_root=tmp_path)
 
         # When: 返り値を mutate
         data = store.load(output_path, channel_root=tmp_path)
@@ -251,7 +270,11 @@ class TestLoad:
         output_path = tmp_path / "loop.mp4"
         state_file = store.state_path(output_path, channel_root=tmp_path)
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        incomplete = {"model": "veo-3.1-fast", "output_path": str(output_path.resolve())}
+        incomplete = {
+            "model": "veo-3.1-fast",
+            "output_path": str(output_path.resolve()),
+            "input_image_sha256": "test-hash",
+        }
         state_file.write_text(json.dumps(incomplete), encoding="utf-8")
 
         # When
@@ -275,6 +298,7 @@ class TestLoad:
             "operation_name": "projects/veo/mismatch",
             "model": "veo-3.1-fast",
             "output_path": str(other_path.resolve()),
+            "input_image_sha256": "test-hash",
         }
         state_file.write_text(json.dumps(mismatched), encoding="utf-8")
 
@@ -297,6 +321,7 @@ class TestLoad:
             "operation_name": 12345,  # 非文字列
             "model": "veo-3.1-fast",
             "output_path": str(output_path.resolve()),
+            "input_image_sha256": "test-hash",
         }
         state_file.write_text(json.dumps(invalid), encoding="utf-8")
 
@@ -319,6 +344,7 @@ class TestLoad:
             "operation_name": "projects/veo/99",
             "model": None,  # 非文字列
             "output_path": str(output_path.resolve()),
+            "input_image_sha256": "test-hash",
         }
         state_file.write_text(json.dumps(invalid), encoding="utf-8")
 
@@ -331,6 +357,25 @@ class TestLoad:
         assert "[Warn]" in out
         assert not state_file.exists()
 
+    def test_returns_none_when_input_image_hash_is_not_str(self, tmp_path: Path, capsys) -> None:
+        """input_image_sha256 が非文字列の state は削除する。"""
+        output_path = tmp_path / "loop.mp4"
+        state_file = store.state_path(output_path, channel_root=tmp_path)
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        invalid = {
+            "operation_name": "projects/veo/99",
+            "model": "veo-3.1-fast",
+            "output_path": str(output_path.resolve()),
+            "input_image_sha256": 123,
+        }
+        state_file.write_text(json.dumps(invalid), encoding="utf-8")
+
+        result = store.load(output_path, channel_root=tmp_path)
+
+        assert result is None
+        assert "input_image_sha256" in capsys.readouterr().out
+        assert not state_file.exists()
+
     def test_returns_none_when_output_path_is_not_str(self, tmp_path: Path, capsys) -> None:
         """output_path が非文字列の state は None を返し、state ファイルを削除する（ai-review-006）。"""
         # Given: output_path を整数で書き込む（壊れた state）
@@ -341,6 +386,7 @@ class TestLoad:
             "operation_name": "projects/veo/99",
             "model": "veo-3.1-fast",
             "output_path": 123,  # 非文字列
+            "input_image_sha256": "test-hash",
         }
         state_file.write_text(json.dumps(invalid), encoding="utf-8")
 
@@ -363,6 +409,7 @@ class TestLoad:
             "operation_name": "projects/veo/99",
             "model": "veo-3.1-fast",
             "output_path": {"path": "/some/path"},  # dict（非文字列）
+            "input_image_sha256": "test-hash",
         }
         state_file.write_text(json.dumps(invalid), encoding="utf-8")
 
@@ -373,6 +420,24 @@ class TestLoad:
         # Then: None を返し、[Warn] を出力し、state ファイルを削除する
         assert result is None
         assert "[Warn]" in out
+        assert not state_file.exists()
+
+    def test_returns_none_and_removes_legacy_state_without_input_image_hash(self, tmp_path: Path, capsys) -> None:
+        """入力画像識別子がない旧 state は安全側で破棄する。"""
+        output_path = tmp_path / "loop.mp4"
+        state_file = store.state_path(output_path, channel_root=tmp_path)
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        legacy_state = {
+            "operation_name": "projects/veo/legacy",
+            "model": "veo-3.1-fast",
+            "output_path": str(output_path.resolve()),
+        }
+        state_file.write_text(json.dumps(legacy_state), encoding="utf-8")
+
+        result = store.load(output_path, channel_root=tmp_path)
+
+        assert result is None
+        assert "input_image_sha256" in capsys.readouterr().out
         assert not state_file.exists()
 
     def test_returns_none_when_state_is_json_array(self, tmp_path: Path, capsys) -> None:
@@ -421,7 +486,7 @@ class TestClear:
     def test_removes_existing_state(self, tmp_path: Path) -> None:
         # Given
         output_path = tmp_path / "loop.mp4"
-        store.save(output_path, "op-name", "model", channel_root=tmp_path)
+        store.save(output_path, TestSave._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
         assert store.state_path(output_path, channel_root=tmp_path).exists()
 
         # When
@@ -441,7 +506,7 @@ class TestClear:
     def test_load_returns_none_after_clear(self, tmp_path: Path) -> None:
         # Given
         output_path = tmp_path / "loop.mp4"
-        store.save(output_path, "op-name", "model", channel_root=tmp_path)
+        store.save(output_path, TestSave._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
 
         # When
         store.clear(output_path, channel_root=tmp_path)


### PR DESCRIPTION
## Summary

## 概要

Ctrl+C resume 用の Veo operation キャッシュ（`<CHANNEL_DIR>/tmp/veo-operations/*.json`）が、再実行時に引数モデルとの相違を Warn のみで無視して保存済みモデルで続行し、入力画像（`main.png` / `main.jpg`）の差し替えも検知しない。そのため lite モデル指定や textless 画像への差し替えが反映されず、旧設定のまま生成・課金される。

## 背景・目的

旧 #1636 の後継。

フィードバック: `veo-3.1-lite` を指定したのに fast の保存済み operation に上書きされ、テキスト入りの旧画像で再生成された。復旧にはキャッシュ JSON の手動削除が必要だった。

## 再現手順

1. `uv run yt-generate-loop-video` を Ctrl+C で中断し、operation state を残す
2. `main.png` を差し替える、または `--model veo-3.1-lite-generate-preview` を指定して再実行する

## 期待される動作

保存済み operation と現在のパラメータ（モデル・入力画像）が一致しない場合は resume せず、キャッシュを破棄して新しいパラメータで生成する（`-y` なしの場合は明示確認）。

## 実際の動作

モデル相違は Warn ログのみで保存済みモデルのまま resume され、入力画像の差し替えは一切検知されない。新パラメータが無視されたまま生成・課金される。

## 影響範囲

`yt-generate-loop-video` の中断→再開を伴う全運用。モデル切り替えや画像差し替えのやり直しが静かに無効化され、意図しない課金が発生する。

## 参照資料

- `src/youtube_automation/utils/veo_generator.py`（`_resume_operation` L74-81 / `generate` L334-337）
- `src/youtube_automation/utils/veo_operation_store.py`（`save` / `load` / `clear`, `_REQUIRED_KEYS`）
- `src/youtube_automation/scripts/generate_loop_video.py`
- `.claude/skills/loop-video/SKILL.md`
- `tests/test_veo_operation_store.py`
- `tests/test_veo_generator.py`

## 影響ファイル

- 変更: `src/youtube_automation/utils/veo_operation_store.py`（state に入力画像識別子 = mtime or hash を追加）
- 変更: `src/youtube_automation/utils/veo_generator.py`（モデル不一致・画像変更時は resume せず clear → 新規生成。`-y` なしは明示確認）
- 変更: `.claude/skills/loop-video/SKILL.md`
- 変更: `tests/test_veo_operation_store.py`
- 変更: `tests/test_veo_generator.py`
- 変更: `CHANGELOG.md`（[Unreleased] 追記）

**兄弟入口・貫通先**:
- `veo_generator` は `generate_short_loop.py`（`/short-loop`）からも呼ばれるため、resume ポリシー変更が同一に効くこと

## 要件

1. 保存済みモデルと引数モデルが異なる状態で実行する → resume せず新規生成（または確認。`-y` 時は新規生成）となることがログで観測できる
2. 入力画像を差し替えて再実行する → 旧 operation が破棄され、新画像で生成される
3. モデル・画像とも同一のまま中断→再実行する → 従来どおり resume される（後方互換）
4. 旧フォーマット（画像識別子なし）の state を load する → クラッシュせず安全側に倒れることがテストで担保されている

## スコープ外

- 生成前の確認 UI 全般
- `loop_raw.mp4` の FileExistsError（別 issue）
- バックアップ保持数上限（#1654）
- エンジン追加（#1722）・video_type 基盤（#1723）

## 実装方針（takt）

`takt:lite`。utils 2 ファイル中心で、既存テストパターンの延長で担保できるため lite workflow で足りる。

## Execution Report

Workflow `lite` completed successfully.

Closes #1746