### PR TITLE
[#1902] issue-1902-setup-ni-intabyuuwo

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -47,7 +47,7 @@ description: "Use when ツール導入と GCP / OAuth の API 設定をセット
 4. `uv run yt-skills sync --asset skills --force` / `uv run yt-skills sync --asset claude-md` / `uv run yt-skills sync --asset auth-template` を Bash で実行する
 5. `uv run yt-setup-dirs` を Bash で実行し、OAuth クライアント JSON の配置先 `auth/` など setup に必要な最小ディレクトリを作成する
 6. `uv run yt-doctor --json` を Bash で実行し、結果を読む
-7. `summary.next_check_id` が `null` なら「全 check 緑です。`/setup` は完了済みです」と報告して終了
+7. `summary.next_check_id` が `null` なら「運用設定インタビュー」を実行してから「完了時」の報告を行う
 8. `null` でないなら、その check に対応する手順 (§Steps) に進む
 9. 1 ステップ完了したら、必ず `uv run yt-doctor --json` を再実行して進捗確認してから次の `next_check_id` に移る
 
@@ -309,7 +309,7 @@ uv run yt-channel-status
 
 `yt-doctor` の `next_action.instructions` を確認:
 
-- **`/channel-new` 案内** (config/channel/ ディレクトリ未存在): 新規チャンネルの場合は `/channel-new` を実行して設定を作成する
+- **`/channel-new` 案内** (config/channel/ ディレクトリ未存在): 新規チャンネルの場合は `/channel-new` を実行して設定を作成する。この経路では対象 config が未生成のため「運用設定インタビュー」はスキップし、「運用設定は `/channel-new` 完了後に `/setup` を再実行して設定できます」と案内する
 - **`/channel-new` 取り込みモード案内** (ディレクトリ存在・ロード失敗): 既存チャンネルの config を持ち込む場合は `/channel-new`（既存チャンネル取り込みモード）を実行して設定を修復する
 
 AI は config をここで生成しない。`yt-setup-dirs` で setup 用ディレクトリが作成済みでも `config/channel/*.json` は未生成で正常な中間状態として扱う。`yt-doctor` の `message` に含まれるエラー詳細をそのまま利用者に示し、どちらのルートかを確認してから案内する。
@@ -381,9 +381,32 @@ channel_id 未設定の場合は AI が以下を確認・案内:
 1. `uv run yt-channel-status` を Bash で実行してチャンネル ID を取得
 2. 取得した ID を `config/channel/meta.json` の `channel.channel_id` に書き込む
 
+## 運用設定インタビュー
+
+`uv run yt-doctor --json` で `summary.next_check_id` が `null` になった後、完了報告の**直前**に実行する。`/setup` の再診断時も同じ手順で現在の運用設定を確認する。
+
+### 実行条件と共通ルール
+
+1. `config/channel/` が存在せず `channel_config` の未生成経路に入った場合は、インタビューを実行しない。`channel_config` の手順どおり「運用設定は `/channel-new` 完了後に `/setup` を再実行して設定できます」と案内する。`/setup` は config を生成しない。
+2. `config/channel/` がロード可能なら、`config/channel/workflow.json` は任意であり、未存在でもインタビューを実行する。下表の workflow 3 行は、`workflow.json` またはその入れ子のキーが未設定ならいずれも `false` を現在値として扱う。回答が現在値と異なる場合は、必要な入れ子を含む `workflow.json` を作成または更新する。
+3. 下表の各行について、質問する直前に config を読んで現在値を取得する。現在値を利用者に質問してはならない。loop-video はまず `.claude/skills/loop-video/config.default.yaml` を読み、`config/skills/loop-video.yaml` が存在する場合はそれも読んで、`youtube_automation.utils.skill_config.load_skill_config("loop-video")` と同じ deep-merge（default の上に override）で `enabled` の現在値を解決する。override に `enabled` が無い場合も default の値を現在値とする。
+4. 質問は必ず 1 問ずつ表示し、回答を待ってから次の行へ進む。各質問には現在値と、現在値を維持する推奨回答を添える。複数の質問をまとめて表示してはならない。
+5. 回答が現在値と同じならファイルを編集しない。異なる場合だけ、その行の config を Edit で更新する。既存 `config/skills/loop-video.yaml` を更新するときは `enabled` だけを変更し、ほかの override キーを保持する。
+
+| 順番 | config | キー | default | 質問と推奨回答 |
+| --- | --- | --- | --- | --- |
+| 1 | `config/channel/workflow.json` | `workflow.wf_next.approval_gates.audio` | `false` | 「音源承認ゲートを有効にしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存の音源承認フローを変えないため）」 |
+| 2 | `config/channel/workflow.json` | `workflow.wf_next.approval_gates.upload` | `false` | 「アップロード承認ゲートを有効にしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のアップロードフローを変えないため）」 |
+| 3 | `config/channel/workflow.json` | `workflow.wf_next.skip_manual_mastering` | `false` | 「手動マスタリング検出をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のマスタリングフローを変えないため）」 |
+| 4 | `config/skills/loop-video.yaml` | `enabled` | `true` | 「ループ動画生成を有効にしますか？ 現在値: `<current>`。Veo API の利用には課金が発生します。推奨: 現在値を維持（既存の Veo 利用方針を変えないため）」 |
+
+`workflow.wf_next.approval_gates.audio` は最終マスター候補の採用前、`workflow.wf_next.approval_gates.upload` は YouTube アップロード前に承認を取る設定である。`workflow.wf_next.skip_manual_mastering` を `true` にすると、最終マスター候補がなくても raw master を最終音源として採用する。
+
+`config/skills/loop-video.yaml` が存在しない場合は、解決した現在値と異なる回答のときだけ、回答値を `enabled` に持つ override ファイルを新規作成する。現在値のままなら override ファイルを作成してはならない。
+
 ## 完了時
 
-`uv run yt-doctor --json` で `summary.next_check_id` が `null` (全 check 緑) になったら:
+`uv run yt-doctor --json` で `summary.next_check_id` が `null` (全 check 緑) になり、「運用設定インタビュー」を終えたら:
 
 ```
 ✓ setup 完了。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs(setup)`: `/setup` の全 check 緑後・完了報告前に、`workflow.wf_next` の音源 / アップロード承認ゲート、手動マスタリング検出スキップ、Veo 課金を伴う loop-video の有効状態を 1 問ずつ確認する運用設定インタビューを追加した。現在値と推奨回答を提示し、変更時だけ config を更新する（#1902）
 - `feat(upload)`: collection の `workflow-state.json::title_template_check.allow_volume_patterns: true` で、そのコレクションだけ公開タイトルの `Vol.` / `Part` / `#N` / ローマ数字の巻数表記を upload preflight で許可できるようにした。未設定・`false` の既定検出、RHS 鋳型・完全重複・核語彙の検査、および `content.json::title.template_check.volume_patterns` は変更しない（#1729）
 
 ### Fixed


### PR DESCRIPTION
## Summary

## 概要

/setup は現状「全 check 緑」で完了するが、`workflow.json` の承認ゲートや loop-video の有効/無効など、運用挙動を左右する設定項目がデフォルト値のまま暗黙に決まり、ユーザーが存在を知らないまま運用に入る。setup 完了報告の直前に grilling スタイル（1 問ずつ・推奨回答つき）の「運用設定インタビュー」を追加し、これらを明示的に確認して config に反映する。

## 背景・目的

- `approval_gates.audio` / `approval_gates.upload` / `skip_manual_mastering`（`config/channel/workflow.json`）と `enabled`（`config/skills/loop-video.yaml`、Veo 課金に直結）は、ユーザーが自分で config を開かない限り存在に気づけない
- grilling skill の 3 原則（1 問ずつ聞く / 各質問に推奨回答を添える / 事実は聞かず調べる）を質問部分の設計として踏襲する

## 提案する仕様

- setup/SKILL.md の記述のみで実現する（yt-doctor の Python コード変更なし）
- `summary.next_check_id` が `null`（全 check 緑）になった後、「完了時」報告の直前に「運用設定インタビュー」セクションを実行する
- 対象項目はテーブル管理とし、行を足せば拡張できる構造にする。初期セットは以下の 4 項目:

| config | キー | default | 質問の観点 |
| --- | --- | --- | --- |
| config/channel/workflow.json | wf_next.approval_gates.audio | false | 音源承認ゲートを有効にするか |
| config/channel/workflow.json | wf_next.approval_gates.upload | false | アップロード承認ゲートを有効にするか |
| config/channel/workflow.json | wf_next.skip_manual_mastering | false | 手動マスタリング検出をスキップするか |
| config/skills/loop-video.yaml | enabled | true | ループ動画生成（Veo 課金）を使うか |

- 質問は 1 問ずつ・推奨回答つき。AI が config を読んだ現在値を必ず添える（事実は聞かず調べる）
- loop-video `enabled` の質問文には Veo 課金への影響を明記する
- 回答が現在値と異なる場合のみ Edit で反映する。`config/skills/loop-video.yaml` が未存在の場合、デフォルトと異なる値を選んだときのみ override ファイルを新規作成する（デフォルトのままなら作らない。loop-video skill の「存在しない override は勝手に作成しない」規定と整合）
- 対象 config が未生成（/channel-new 前）の場合はインタビューをスキップし、/channel-new 完了後に設定できる旨を案内する

## ユースケース

- 新規チャンネルの初回セットアップで、承認ゲートの存在と Veo 課金の opt-out を知ったうえで運用を開始できる
- `/setup` を再診断として再実行した際、現在の運用設定を確認・変更する入口になる

## 参照資料

- .claude/skills/setup/SKILL.md
- .claude/skills/loop-video/SKILL.md（`enabled` / override 作成規定）
- examples/channel_config.example/workflow.json
- src/youtube_automation/utils/config/workflow.py（approval_gates / skip_manual_mastering の定義）
- ~/.claude/skills/grilling/SKILL.md（質問部分の 3 原則。リポジトリ外のため文面を issue 本文・実装時に転記して参照）

## 影響ファイル

- **変更**: .claude/skills/setup/SKILL.md
- **変更**: CHANGELOG.md（[Unreleased] 追記）

**兄弟入口・貫通先**: なし（SKILL.md 単一入口。skill は Claude Code / Codex 共用だが実体は `.claude/skills/` 側のみ。config キー自体の変更は行わないため貫通チェーン不要）

## 要件

1. /setup で全 check 緑になる → 完了報告の前に「運用設定インタビュー」が実行される
2. 対象 4 項目が 1 問ずつ・推奨回答つきで質問される（複数同時に投げない。grilling の 3 原則を踏襲し、loop-video enabled の質問文には Veo 課金への影響が明記される）
3. 各質問に AI が config を読んだ現在値が添えられる（現在値をユーザーに聞かない）
4. 回答が現在値と異なる場合のみ Edit で config に反映される。同じ値なら書き込まない（loop-video.yaml 未存在時はデフォルトと異なる回答のときのみ新規作成）
5. 対象 config 未生成（/channel-new 前）の場合 → インタビューをスキップし、/channel-new 後に設定できる旨が案内される

## スコープ外

- yt-doctor への「運用設定確認済み」check 追加（Python コード変更）は扱わない（必要になったら別 issue）
- /channel-new 側の config 生成フロー改善は扱わない
- 4 項目以外の設定項目追加は扱わない（テーブル拡張で将来対応）

## 受け入れ基準

- [ ] lint / test / typecheck は該当なし（SKILL.md のみの変更で対象コードが無いため）
- [ ] `CHANGELOG.md` の `[Unreleased]` に追記されている（`.claude/skills/` は CHANGELOG ゲート対象）
- [ ] SKILL.md frontmatter の `description:` が double-quoted string のまま維持されている

## 実装方針（takt）

- workflow: docs
- 理由: setup SKILL.md への記述追加のみのため

## Execution Report

Workflow `docs` completed successfully.

Closes #1902