### PR TITLE
[#1915] issue-1915-thumbnail-codex-ima

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -107,6 +107,7 @@ Gemini / OpenAI の CLI 経路で全 attempt が失敗した場合、`uv run yt-
 - codex CLI 0.131 系以降（旧 stdout プロトコル `generated image <id> <base64>` は 0.131 で削除済み）
 - `codex login status` が `Logged in using ChatGPT` を返す
 - `jq` が PATH 上にある（`--json` の JSONL 解析に使う）
+- wrapper は生成前に最小 `codex exec --json` プローブで codex CLI とサーバー側デフォルトモデルの互換性を確認する。非互換時は生成を試みず、CLI version・検出モデル・アップグレード手順を stderr に出して停止する
 - TTP 生成のため、3 引数目以降に参照画像を 1 件以上渡す
 - ChatGPT サブスクの fair-use 上限は明文化されていないため、大量生成には使わない
 
@@ -149,6 +150,7 @@ Use the title {title}.
 
 内部実装の要約:
 
+- wrapper は `codex --version` で CLI version を控え、ログイン確認後に `codex exec --json --skip-git-repo-check -- "Reply with exactly codex-model-compat-ok."` の最小プローブを実行する。互換性エラーなら本番生成を呼ばず、`npm install -g @openai/codex@latest` / `brew upgrade codex` / `bun add -g @openai/codex@latest` を案内して非0終了する
 - wrapper は `codex exec --json --sandbox workspace-write --add-dir <out_dir> --skip-git-repo-check` で起動する
 - 受け取った prompt 末尾に `Generate a new image with the image_generation tool. Do not copy any provided reference image; produce a freshly generated PNG. After generation, copy the produced PNG to <out>. Then reply with exactly <out>.` を自動付与する（後述の reference cp failure mode を抑止するため、tool 呼び出しと「reference を copy するな」を明示）
 - agent 自身が `~/.codex/generated_images/<thread_id>/ig_*.png` から `<out>` へ `cp` し、最終 `agent_message.text` で `<out>` を返す
@@ -161,7 +163,7 @@ Use the title {title}.
 
 - **prompt は短く保つ**: 長すぎる prompt は agent が `image_generation` tool 呼び出しを skip して path だけ echo する failure mode に陥る。TTP 参照画像つきでは `image_generation.codex.default_prompt_template` を使い、`{title}` だけを差し替える。失敗したら短縮を最優先で試す
 - **reference 画像つきは prompt で「変更点」を明示する**: 「reference を参考に」程度の弱い指示だと agent が `image_generation` tool を skip して reference を `<out>` に cp するだけで終わる failure mode がある。wrapper の自動付与文 + MD5 一致検証で抑止しているが、prompt 側でも reference からの差分（色味の参考 / 構図だけ流用 / 主役を差し替え 等）を明示しておくと安定する
-- 失敗時 wrapper は `agent_message (最終)` と codex stderr の末尾 30 行を診断 dump するので、これを見て prompt 短縮 or 参照画像見直しに切り替える
+- 失敗時 wrapper は codex CLI version・デフォルトモデル推定値・`agent_message (最終)`・codex stderr の末尾 30 行を診断 dump するので、これを見て CLI upgrade / prompt 短縮 / 参照画像見直しに切り替える
 
 この経路のスコープ:
 - `uv run yt-generate-image` の API 呼び出しは使わない

--- a/.claude/skills/thumbnail/references/codex-image.sh
+++ b/.claude/skills/thumbnail/references/codex-image.sh
@@ -33,6 +33,54 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+codex_cli_version="unknown"
+codex_default_model="unknown"
+
+detect_codex_cli_version() {
+  local raw_version
+  if raw_version=$(codex --version 2>/dev/null | head -n 1); then
+    if [[ "$raw_version" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+      printf 'v%s\n' "${BASH_REMATCH[1]}"
+    elif [ -n "$raw_version" ]; then
+      printf '%s\n' "$raw_version"
+    else
+      printf 'unknown\n'
+    fi
+  else
+    printf 'unknown\n'
+  fi
+}
+
+extract_codex_model_from_text() {
+  local text=$1
+  local model
+  model=$(printf '%s\n' "$text" | grep -Eo 'gpt-[A-Za-z0-9._-]+' | head -n 1 || true)
+  if [ -n "$model" ]; then
+    printf '%s\n' "$model"
+  else
+    printf 'unknown\n'
+  fi
+}
+
+is_codex_model_incompatibility_error() {
+  local text=$1
+  printf '%s\n' "$text" | grep -Eiq '(incompat|unsupported|not supported|unknown model|requires[[:space:]].*newer|upgrade[[:space:]].*codex|model[[:space:]].*not[[:space:]].*supported)'
+}
+
+print_codex_environment() {
+  echo "codex CLI: ${codex_cli_version}" >&2
+  echo "codex default model: ${codex_default_model}" >&2
+}
+
+print_codex_upgrade_instructions() {
+  echo "アップグレード手順:" >&2
+  echo "  npm: npm install -g @openai/codex@latest" >&2
+  echo "  Homebrew: brew upgrade codex" >&2
+  echo "  Bun: bun add -g @openai/codex@latest" >&2
+}
+
+codex_cli_version=$(detect_codex_cli_version)
+
 if login_status=$(codex login status 2>&1); then
   :
 else
@@ -77,14 +125,42 @@ rm -f "$out"
 err_log=$(mktemp -t codex-image.XXXXXX)
 trap 'rm -f "$err_log"' EXIT
 
-# 3 つの error 分岐に同一 4 行ブロックがコピペされていた DRY 違反を解消するための helper。
+# error 分岐に同一診断ブロックがコピペされていた DRY 違反を解消するための helper。
 # `$err_log` はスクリプト全体で 1 つしか存在しないため引数化せずクロージャ的に参照する。
 dump_codex_stderr() {
+  if [ -s "$err_log" ]; then
+    local detected_model
+    detected_model=$(extract_codex_model_from_text "$(cat "$err_log")")
+    if [ "$detected_model" != "unknown" ]; then
+      codex_default_model=$detected_model
+    fi
+  fi
+  print_codex_environment
   if [ -s "$err_log" ]; then
     echo "--- codex stderr (tail) ---" >&2
     tail -n 30 "$err_log" >&2
   fi
 }
+
+if codex exec --json --skip-git-repo-check -- "Reply with exactly codex-model-compat-ok." \
+  </dev/null >/dev/null 2>"$err_log"; then
+  :
+else
+  rc=$?
+  preflight_stderr=$(cat "$err_log")
+  codex_default_model=$(extract_codex_model_from_text "$preflight_stderr")
+  if is_codex_model_incompatibility_error "$preflight_stderr"; then
+    echo "ERROR: codex CLI ${codex_cli_version} がモデル \`${codex_default_model}\` と非互換です" >&2
+    print_codex_upgrade_instructions
+    dump_codex_stderr
+    exit 1
+  fi
+  echo "ERROR: codex CLI とデフォルトモデルの互換性プリフライトに失敗しました (rc=${rc})" >&2
+  echo "ヒント: codex CLI / 認証 / ネットワーク状態を確認してください" >&2
+  dump_codex_stderr
+  exit 1
+fi
+: > "$err_log"
 
 if ! final_msg=$(codex exec --json --sandbox workspace-write --add-dir "$out_dir" --skip-git-repo-check \
   "${image_args[@]+"${image_args[@]}"}" -- "$full_prompt" </dev/null 2>"$err_log" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(thumbnail)`: `codex-image.sh` に codex CLI とサーバー側デフォルトモデルの互換性プリフライトを追加し、非互換時は画像生成を試みず CLI version・検出モデル・アップグレード手順を stderr に出して停止するようにした。生成失敗時の診断 dump にも codex CLI version と default model 推定値を含める（#1915）。
 - `fix(upload)`: `yt-upload-collection` の `-c` 未指定時の自動選択を、`collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクション 1 件だけに限定した。`live/` の公開済みコレクションは候補外とし、候補が 0 件または複数件なら `-c` 明示を要求して停止する。`--plan` / `--status` / 実アップロードと日次実行に同じ選択条件を適用した（#1731）。
 - `fix(upload)`: タグ件数下限が YouTube の 500 字上限の下で到達不能な場合、upload preflight と metadata audit が件数不足ではなく、`tags.min_count` を下げるか base タグを短縮するよう案内する明示診断を返すようにした。配布する content.json テンプレートの `tags.min_count` も 26 に統一した（#1732）。
 - `fix(loop-video)`: Ctrl+C 後の Veo operation resume state に入力画像の SHA-256 を保存し、再実行時に指定モデルまたは入力画像内容が state と異なる場合は旧 operation を破棄して指定どおり新規生成するようにした（#1746）。旧形式 state は安全側で破棄する。

--- a/tests/test_thumbnail_codex_image_skill.py
+++ b/tests/test_thumbnail_codex_image_skill.py
@@ -65,12 +65,18 @@ def _write_fake_codex(bin_dir: Path) -> Path:
     """Fake codex CLI を tmp PATH に配置する。
 
     挙動:
+    - `--version` は `$FAKE_CODEX_VERSION`（未指定時 `codex-cli 0.142.5`）を返す
     - `login status` サブコマンドは `$FAKE_CODEX_LOGIN_STATUS` を stdout に返す
     - `$FAKE_CODEX_LOGIN_STATUS_RC` が非空のときは `login status` をその値で
       非 0 終了させる（`$FAKE_CODEX_LOGIN_STATUS` が指定されていれば stderr に
       流す）。wrapper の `codex login status` 自体が非 0 終了する failure mode
       の回帰テスト用
-    - `exec` サブコマンドは prompt 末尾の
+    - `exec` サブコマンドは、互換性プリフライト prompt
+      `Reply with exactly codex-model-compat-ok.` なら画像生成なしで JSONL を返す。
+      `$FAKE_CODEX_PREFLIGHT_INCOMPATIBLE` が非空のときは stderr に
+      codex CLI / model 非互換エラーを、`$FAKE_CODEX_PREFLIGHT_FAIL` が非空のときは
+      汎用エラーを出して非 0 終了する
+    - それ以外の `exec` サブコマンドは prompt 末尾の
       `copy the produced PNG to <path>` から `<path>` を抽出し、PNG マジックバイト
       を書き出した上で、最小 JSONL（`thread.started` / `turn.started` /
       `item.completed` × 2 (`agent_message`) / `turn.completed`）を stdout に流す
@@ -117,16 +123,12 @@ if [[ "${1:-}" == "login" && "${2:-}" == "status" ]]; then
   exit 0
 fi
 
-if [[ "${1:-}" == "exec" ]]; then
-  if [[ -n "${FAKE_CODEX_EXEC_FAIL:-}" ]]; then
-    # codex exec が非0で終了する failure mode を再現する。
-    # wrapper の `if ! final_msg=$(...); then ... fi` 経路が踏まれ、
-    # stderr ログの tail dump が呼び出し元 stderr に流れることを確認する。
-    printf 'fake codex exec: simulated failure line 1\n' >&2
-    printf 'fake codex exec: simulated failure line 2\n' >&2
-    exit "${FAKE_CODEX_EXEC_FAIL}"
-  fi
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' "${FAKE_CODEX_VERSION:-codex-cli 0.142.5}"
+  exit 0
+fi
 
+if [[ "${1:-}" == "exec" ]]; then
   # `--` 区切り以降に来る prompt を取り出す
   prompt=""
   found_sep=0
@@ -139,6 +141,31 @@ if [[ "${1:-}" == "exec" ]]; then
       found_sep=1
     fi
   done
+
+  if [[ "$prompt" == "Reply with exactly codex-model-compat-ok." ]]; then
+    if [[ -n "${FAKE_CODEX_PREFLIGHT_INCOMPATIBLE:-}" ]]; then
+      printf 'fake codex exec: codex CLI v0.142.5 is incompatible with model gpt-5.6-terra\n' >&2
+      printf 'fake codex exec: upgrade codex CLI to use model gpt-5.6-terra\n' >&2
+      exit "${FAKE_CODEX_PREFLIGHT_INCOMPATIBLE}"
+    fi
+    if [[ -n "${FAKE_CODEX_PREFLIGHT_FAIL:-}" ]]; then
+      printf 'fake codex exec: network request timed out\n' >&2
+      exit "${FAKE_CODEX_PREFLIGHT_FAIL}"
+    fi
+    msg_preflight='{"type":"item.completed","item":{"id":"item_preflight",'
+    msg_preflight+='"type":"agent_message","text":"codex-model-compat-ok"}}'
+    printf '%s\n' "$msg_preflight"
+    exit 0
+  fi
+
+  if [[ -n "${FAKE_CODEX_EXEC_FAIL:-}" ]]; then
+    # codex exec が非0で終了する failure mode を再現する。
+    # wrapper の `if ! final_msg=$(...); then ... fi` 経路が踏まれ、
+    # stderr ログの tail dump が呼び出し元 stderr に流れることを確認する。
+    printf 'fake codex exec: simulated failure line 1 for model gpt-5.6-terra\n' >&2
+    printf 'fake codex exec: simulated failure line 2\n' >&2
+    exit "${FAKE_CODEX_EXEC_FAIL}"
+  fi
 
   out_path=""
   if [[ "$prompt" =~ copy\ the\ produced\ PNG\ to\ ([^[:space:]]+\.png) ]]; then
@@ -187,6 +214,8 @@ def _prepare_fake_codex_env(
     *,
     login_status: str | None = None,
     exec_fail_rc: int | None = None,
+    preflight_incompatible_rc: int | None = None,
+    preflight_fail_rc: int | None = None,
     login_status_rc: int | None = None,
     skip_cp: bool = False,
     agent_message_override: str | None = None,
@@ -204,6 +233,10 @@ def _prepare_fake_codex_env(
         env["FAKE_CODEX_LOGIN_STATUS"] = login_status
     if exec_fail_rc is not None:
         env["FAKE_CODEX_EXEC_FAIL"] = str(exec_fail_rc)
+    if preflight_incompatible_rc is not None:
+        env["FAKE_CODEX_PREFLIGHT_INCOMPATIBLE"] = str(preflight_incompatible_rc)
+    if preflight_fail_rc is not None:
+        env["FAKE_CODEX_PREFLIGHT_FAIL"] = str(preflight_fail_rc)
     if login_status_rc is not None:
         env["FAKE_CODEX_LOGIN_STATUS_RC"] = str(login_status_rc)
     if skip_cp:
@@ -531,6 +564,20 @@ def test_codex_image_script_checks_login_output_and_png_validity() -> None:
     assert "89504e470d0a1a0a" in text, "PNG ヘッダ検証のマジック値が無い"
 
 
+def test_codex_image_script_contains_model_compatibility_preflight_and_diagnostics() -> None:
+    """Given codex-image.sh
+    When 本文を読む
+    Then codex CLI version / default model 診断と互換性プリフライトが含まれる。
+    """
+    text = _read(_CODEX_IMAGE_SH)
+    assert "codex --version" in text, "codex CLI version 取得が無い"
+    assert "Reply with exactly codex-model-compat-ok." in text, "互換性プリフライト prompt が無い"
+    assert "codex default model:" in text, "default model 診断行が無い"
+    assert "npm install -g @openai/codex@latest" in text, "npm のアップグレード手順が無い"
+    assert "brew upgrade codex" in text, "Homebrew のアップグレード手順が無い"
+    assert "bun add -g @openai/codex@latest" in text, "Bun のアップグレード手順が無い"
+
+
 def test_codex_image_script_stops_when_codex_is_not_logged_in(tmp_path: Path) -> None:
     """Given 未ログイン状態の codex CLI
     When codex-image.sh を実行する
@@ -550,7 +597,9 @@ def test_codex_image_script_stops_when_codex_is_not_logged_in(tmp_path: Path) ->
         f"未ログイン時の案内が stderr に無い: {result.stderr!r}"
     )
     invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
-    assert invocations == [["login", "status"]], f"未ログイン時に `codex exec` を呼んではいけない: {invocations!r}"
+    assert invocations == [["--version"], ["login", "status"]], (
+        f"未ログイン時に `codex exec` を呼んではいけない: {invocations!r}"
+    )
     assert not output_path.exists(), "未ログイン時は出力ファイルを作らない"
 
 
@@ -574,7 +623,7 @@ def test_codex_image_script_rejects_not_logged_in_substring_false_positive(tmp_p
 
     assert result.returncode != 0, "`Not Logged in` でも `Logged in` の部分一致が通って未ログインで進んでしまっている"
     invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
-    assert invocations == [["login", "status"]], (
+    assert invocations == [["--version"], ["login", "status"]], (
         f"`Not Logged in` 時に `codex exec` を呼んではいけない: {invocations!r}"
     )
     assert not output_path.exists(), "`Not Logged in` 時は出力ファイルを作らない"
@@ -631,10 +680,92 @@ def test_codex_image_script_surfaces_codex_login_status_nonzero_exit(tmp_path: P
         f"経路で実 exit code を捕捉すること: {result.stderr!r}"
     )
     invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
-    assert invocations == [["login", "status"]], (
+    assert invocations == [["--version"], ["login", "status"]], (
         f"`codex login status` 非 0 終了時に `codex exec` を呼んではいけない: {invocations!r}"
     )
     assert not output_path.exists(), "`codex login status` 非 0 終了時は出力ファイルを作らない"
+
+
+def test_codex_image_script_stops_on_model_incompatibility_before_generation(tmp_path: Path) -> None:
+    """Given codex CLI とデフォルトモデルが非互換な環境
+    When codex-image.sh を実行する
+    Then 本番生成を試みる前に非 0 で停止し、CLI version / model / upgrade 手順を stderr に出す。
+    """
+    if not _CODEX_IMAGE_SH.exists():
+        pytest.fail(f"{_CODEX_IMAGE_SH.relative_to(_REPO_ROOT)} が存在しない")
+
+    env, log_file = _prepare_fake_codex_env(tmp_path, preflight_incompatible_rc=42)
+    output_path = tmp_path / "output.png"
+    ref_path = _write_reference_file(tmp_path)
+
+    result = _run_script(_CODEX_IMAGE_SH, "tiny prompt", str(output_path), str(ref_path), env=env)
+
+    assert result.returncode != 0, "モデル非互換時は wrapper も非 0 終了する必要がある"
+    assert "codex CLI v0.142.5" in result.stderr
+    assert "モデル `gpt-5.6-terra` と非互換" in result.stderr
+    assert "npm install -g @openai/codex@latest" in result.stderr
+    assert "brew upgrade codex" in result.stderr
+    assert "bun add -g @openai/codex@latest" in result.stderr
+    assert not output_path.exists(), "モデル非互換時は出力ファイルを作らない"
+
+    invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
+    exec_invocations = [args for args in invocations if args and args[0] == "exec"]
+    assert len(exec_invocations) == 1, (
+        f"モデル非互換時は互換性プリフライトだけで止まり、本番生成 exec を呼ばない: {invocations!r}"
+    )
+    assert "codex-model-compat-ok" in exec_invocations[0][-1]
+
+
+def test_codex_image_script_stops_on_other_preflight_failures_before_generation(tmp_path: Path) -> None:
+    """Given 互換性以外で codex のプリフライトが失敗する環境
+    When codex-image.sh を実行する
+    Then 本番生成を試みず、実 exit code と診断を stderr に出して非 0 で停止する。
+    """
+    if not _CODEX_IMAGE_SH.exists():
+        pytest.fail(f"{_CODEX_IMAGE_SH.relative_to(_REPO_ROOT)} が存在しない")
+
+    env, log_file = _prepare_fake_codex_env(tmp_path, preflight_fail_rc=43)
+    output_path = tmp_path / "output.png"
+    ref_path = _write_reference_file(tmp_path)
+
+    result = _run_script(_CODEX_IMAGE_SH, "tiny prompt", str(output_path), str(ref_path), env=env)
+
+    assert result.returncode != 0, "プリフライト失敗時は wrapper も非 0 終了する必要がある"
+    assert "互換性プリフライトに失敗しました (rc=43)" in result.stderr
+    assert "codex CLI / 認証 / ネットワーク状態を確認してください" in result.stderr
+    assert "fake codex exec: network request timed out" in result.stderr
+    assert not output_path.exists(), "プリフライト失敗時は出力ファイルを作らない"
+
+    invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
+    exec_invocations = [args for args in invocations if args and args[0] == "exec"]
+    assert len(exec_invocations) == 1, (
+        f"プリフライト失敗時は本番生成 exec を呼ばない: {invocations!r}"
+    )
+    assert "codex-model-compat-ok" in exec_invocations[0][-1]
+
+
+def test_codex_image_script_runs_model_compatibility_preflight_before_generation(tmp_path: Path) -> None:
+    """Given 互換な codex CLI 環境
+    When codex-image.sh を実行する
+    Then 本番生成 exec の前に最小 `codex exec --json` プリフライトを実行し、従来通り成功する。
+    """
+    if not _CODEX_IMAGE_SH.exists():
+        pytest.fail(f"{_CODEX_IMAGE_SH.relative_to(_REPO_ROOT)} が存在しない")
+
+    env, log_file = _prepare_fake_codex_env(tmp_path)
+    output_path = tmp_path / "output.png"
+    ref_path = _write_reference_file(tmp_path)
+
+    result = _run_script(_CODEX_IMAGE_SH, "tiny prompt", str(output_path), str(ref_path), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+
+    invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
+    exec_invocations = [args for args in invocations if args and args[0] == "exec"]
+    assert len(exec_invocations) == 2, f"プリフライト exec と本番生成 exec の 2 回だけを期待: {invocations!r}"
+    assert "codex-model-compat-ok" in exec_invocations[0][-1]
+    assert f"copy the produced PNG to {output_path}" in exec_invocations[1][-1]
 
 
 def test_codex_image_script_surfaces_codex_exec_failure_diagnostics(tmp_path: Path) -> None:
@@ -658,6 +789,10 @@ def test_codex_image_script_surfaces_codex_exec_failure_diagnostics(tmp_path: Pa
 
     assert result.returncode != 0, "codex exec 非0終了時は wrapper も非0終了する必要がある"
     assert "ERROR" in result.stderr, f"診断ブロックの ERROR 行が stderr に届いていない: {result.stderr!r}"
+    assert "codex CLI: v0.142.5" in result.stderr, f"生成失敗診断に codex CLI version が出ていない: {result.stderr!r}"
+    assert "codex default model: gpt-5.6-terra" in result.stderr, (
+        f"生成失敗診断に default model が出ていない: {result.stderr!r}"
+    )
     assert "fake codex exec: simulated failure" in result.stderr, (
         f"codex stderr の tail dump が呼び出し元 stderr に出ていない (silent failure 再発): {result.stderr!r}"
     )
@@ -841,11 +976,11 @@ def test_codex_image_script_passes_bash_syntax_check() -> None:
 def test_codex_image_script_centralizes_stderr_tail_dump_in_helper() -> None:
     """Given codex-image.sh
     When 本文を読む
-    Then `dump_codex_stderr` ヘルパが 1 度だけ定義され、3 つの error 分岐から呼ばれている。
+    Then `dump_codex_stderr` ヘルパが 1 度だけ定義され、5 つの error 分岐から呼ばれている。
 
     回帰防止 (AI-547-006-N2 / family_tag: dry-violation-error-diagnostics):
     `--- codex stderr (tail) ---` を echo して `tail -n 30 "$err_log"` する 4 行ブロックが
-    3 つの error 分岐に直接コピペで散在していた DRY 違反を、共通ヘルパに集約した状態を維持する。
+    error 分岐に直接コピペで散在していた DRY 違反を、共通ヘルパに集約した状態を維持する。
     """
     text = _read(_CODEX_IMAGE_SH)
 
@@ -853,11 +988,12 @@ def test_codex_image_script_centralizes_stderr_tail_dump_in_helper() -> None:
     assert len(re.findall(r"^dump_codex_stderr\(\)\s*\{", text, flags=re.MULTILINE)) == 1, (
         "`dump_codex_stderr` ヘルパが 1 度だけ定義されている必要がある"
     )
-    # 呼び出しは error 3 分岐ぶん（行頭でない位置にあるかも知れないので空白許可）
+    # 呼び出しは error 5 分岐ぶん（行頭でない位置にあるかも知れないので空白許可）
     call_sites = re.findall(r"^\s*dump_codex_stderr\s*$", text, flags=re.MULTILINE)
-    assert len(call_sites) == 3, (
-        f"`dump_codex_stderr` 呼び出しが 3 箇所揃っていない (現在 {len(call_sites)} 件): "
-        "codex exec 失敗 / final_msg 不一致 / 画像未生成 の 3 つの error 分岐から呼ばれること"
+    assert len(call_sites) == 5, (
+        f"`dump_codex_stderr` 呼び出しが 5 箇所揃っていない (現在 {len(call_sites)} 件): "
+        "互換性プリフライト非互換 / 互換性プリフライト汎用失敗 / codex exec 失敗 / "
+        "final_msg 不一致 / 画像未生成 の 5 つの error 分岐から呼ばれること"
     )
     # コピペブロックが再び発生していないことを確認
     duplicated_pattern = re.findall(r'echo "--- codex stderr \(tail\) ---" >&2', text)

--- a/tests/test_thumbnail_codex_image_skill.py
+++ b/tests/test_thumbnail_codex_image_skill.py
@@ -738,9 +738,7 @@ def test_codex_image_script_stops_on_other_preflight_failures_before_generation(
 
     invocations = _parse_invocations(log_file.read_text(encoding="utf-8"))
     exec_invocations = [args for args in invocations if args and args[0] == "exec"]
-    assert len(exec_invocations) == 1, (
-        f"プリフライト失敗時は本番生成 exec を呼ばない: {invocations!r}"
-    )
+    assert len(exec_invocations) == 1, f"プリフライト失敗時は本番生成 exec を呼ばない: {invocations!r}"
     assert "codex-model-compat-ok" in exec_invocations[0][-1]
 
 


### PR DESCRIPTION
## Summary

## 概要

`codex-image.sh` は codex CLI とサーバー側デフォルトモデルの互換性を確認せずに `codex exec` を起動するため、モデル側の更新（例: gpt-5.6-terra）に CLI が追従できていない環境では、原因の分かりにくい生成失敗として現れる。生成開始前に互換性プリフライトを行い、非互換時は明確なエラーとアップグレード手順を案内する。

## 背景・目的

下流チャンネルリポ（deepfocus365）の `/collection-ideate` プレビュー画像生成（`provider: codex` 経由）で「codex CLI v0.142.5 が最新モデル gpt-5.6-terra と非互換のため、プレビュー画像生成が失敗しました」という失敗が発生した。`codex-image.sh` は codex の存在・jq・ログイン状態はプリフライトしているが、CLI とモデルの互換性は確認しておらず、環境ドリフト（サーバー側モデル更新 × ローカル CLI 据え置き）を検知・案内できない。

## 提案する仕様

- `codex exec` 起動前に codex CLI とデフォルトモデルの互換性を確認するプリフライトを追加する
- 非互換の場合は生成を試みずに「codex CLI vX.Y.Z がモデル `<model>` と非互換」という明確なエラーと CLI アップグレード手順を stderr に出力して非 0 で終了する
- 非互換の検知方法（バージョン比較 / プローブ実行 / エラーパターン判定）は plan step で確定する
- 生成失敗時の既存診断 dump（stderr tail 30 行）に codex CLI バージョンとデフォルトモデル名を含める

## ユースケース

- チャンネル運用者が `/collection-ideate` や `/thumbnail` を実行した際、codex CLI が古くてモデルと非互換な場合に、生成失敗の diagnostics を読み解かなくても「CLI をアップグレードすればよい」と即座に分かる

## 参照資料

- .claude/skills/thumbnail/references/codex-image.sh
- .claude/skills/thumbnail/SKILL.md
- tests/test_thumbnail_codex_image_skill.py

## 影響ファイル

- **変更**: .claude/skills/thumbnail/references/codex-image.sh
- **変更**: tests/test_thumbnail_codex_image_skill.py
- **変更**: .claude/skills/thumbnail/SKILL.md（前提条件・トラブルシュート記述の追記が必要な場合）

**兄弟入口・貫通先**:
- `uv run yt-generate-image`（gemini / openai 経路）: 変更不要（codex CLI を使わず API 直呼びのため本問題の影響を受けない。誤配線時は既存ガードで codex-image.sh へ誘導済み）
- `/collection-ideate` / `/thumbnail` / DistroKid cover 生成: いずれも codex-image.sh を共通入口として呼ぶため、wrapper 側の修正で貫通する（skill 本文の変更は不要）

## 要件

1. codex CLI とモデルが非互換な環境で `codex-image.sh` を実行する → 生成を試みる前に「codex CLI vX.Y.Z がモデル `<model>` と非互換」という明確なエラーと CLI アップグレード手順（インストール経路別の update コマンド例）が stderr に出力され、非 0 で終了する
2. 互換な環境で実行する → 従来どおり画像生成が成功する（既存フローへの回帰なし）
3. 生成失敗時の診断 dump（既存の stderr tail 30 行）に codex CLI バージョンとデフォルトモデル名が含まれる → 失敗報告から環境情報が一目で特定できる

## スコープ外

- `--model` の明示ピン留め・config 化は本 issue では扱わない（→ 必要なら別 issue で検討）
- codex CLI の自動アップグレード機構は扱わない（アップグレード手順の案内のみ）
- gemini / openai 経路（`yt-generate-image`）の改修は扱わない

## 受け入れ基準

- [ ] `uv run ruff check` が exit 0 になる
- [ ] `uv run pytest tests/test_thumbnail_codex_image_skill.py` が成功する

## 実装方針（takt）

- workflow: improve
- 理由: 既存 wrapper（codex-image.sh）への挙動拡張で interface 変更なし。既存テストファイル（test_thumbnail_codex_image_skill.py）に回帰保護を追加できるため

## Execution Report

Workflow `improve` completed successfully.

Closes #1915