### PR TITLE
[suno-helper] feed/v3 cursor pagination for resume polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: feed/v3 の active poll が `ids` フィルタ無効化後も cursor ページネーションを追跡し、最新ページ外の保存済み clip を完了確認できるようにした（#1929）。
 - `fix(upload)`: `yt-upload-collection` の `-c` 未指定時の自動選択を、`collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクション 1 件だけに限定した。`live/` の公開済みコレクションは候補外とし、候補が 0 件または複数件なら `-c` 明示を要求して停止する。`--plan` / `--status` / 実アップロードと日次実行に同じ選択条件を適用した（#1731）。
 - `fix(upload)`: タグ件数下限が YouTube の 500 字上限の下で到達不能な場合、upload preflight と metadata audit が件数不足ではなく、`tags.min_count` を下げるか base タグを短縮するよう案内する明示診断を返すようにした。配布する content.json テンプレートの `tags.min_count` も 26 に統一した（#1732）。
 - `fix(loop-video)`: Ctrl+C 後の Veo operation resume state に入力画像の SHA-256 を保存し、再実行時に指定モデルまたは入力画像内容が state と異なる場合は旧 operation を破棄して指定どおり新規生成するようにした（#1746）。旧形式 state は安全側で破棄する。

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -190,6 +190,12 @@ export const FEED_POLL_INTERVAL_MS = 5000;
 /** active feed poll の応答待ち上限 (ms)。bridge 不在・token 未捕捉時に listener 側が諦める時間。 */
 export const FEED_V3_POLL_RESPONSE_TIMEOUT_MS = 10000;
 
+/** active feed poll が追跡する最大ページ数。実測した対象 clip の最大到達ページに余裕を持たせる。 */
+export const FEED_V3_MAX_PAGES = 8;
+
+/** active feed poll のページ間待機 (ms)。ページ連続取得による rate limit を避ける。 */
+export const FEED_V3_PAGE_DELAY_MS = 1000;
+
 /** bridge が観測した clip の最小表現（#948）。status は Suno API の生値（submitted/queued/streaming/complete/error 等）。 */
 export interface ObservedClip {
   id: string;

--- a/extensions/suno-helper/entrypoints/suno-bridge.content.ts
+++ b/extensions/suno-helper/entrypoints/suno-bridge.content.ts
@@ -15,7 +15,9 @@
 import {
   BRIDGE_MSG,
   BRIDGE_SOURCE,
+  FEED_V3_MAX_PAGES,
   FEED_V3_METHOD,
+  FEED_V3_PAGE_DELAY_MS,
   FEED_V3_PATH,
   type ObservedClip,
   SUNO_API_ORIGIN,
@@ -50,6 +52,10 @@ export default defineContentScript({
       if (clips) {
         post(type, { clips });
       }
+    }
+
+    function sleep(delayMs: number): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, delayMs));
     }
 
     /** レスポンス clone を非同期で観測する。fetch の戻りを遅延させない・失敗を漏らさない。 */
@@ -101,22 +107,51 @@ export default defineContentScript({
         return;
       }
       try {
-        const res = await originalFetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
-          method: FEED_V3_METHOD,
-          headers: { authorization: authHeader, "content-type": "application/json" },
-          body: JSON.stringify({ ids }),
-        });
-        if (res.status === 401) {
-          // token 失効。破棄してページの次リクエストでの再捕捉に委ねる。
-          authHeader = null;
-          respond(null);
-          return;
+        const found = new Map<string, ObservedClip>();
+        let cursor: string | undefined;
+        for (let page = 0; page < FEED_V3_MAX_PAGES; page++) {
+          const res = await originalFetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+            method: FEED_V3_METHOD,
+            headers: { authorization: authHeader, "content-type": "application/json" },
+            body: JSON.stringify(cursor === undefined ? { ids } : { ids, cursor }),
+          });
+          if (res.status === 401) {
+            // token 失効。破棄してページの次リクエストでの再捕捉に委ねる。
+            authHeader = null;
+            respond(null);
+            return;
+          }
+          if (!res.ok) {
+            respond(null);
+            return;
+          }
+          const json = await res.json();
+          const clips = parseClipsFromFeedResponse(json);
+          if (clips === null) {
+            respond(null);
+            return;
+          }
+          for (const clip of clips) {
+            if (ids.includes(clip.id)) {
+              found.set(clip.id, clip);
+            }
+          }
+          if (found.size === ids.length) {
+            respond([...found.values()]);
+            return;
+          }
+          const nextCursor =
+            typeof json === "object" && json !== null && "next_cursor" in json
+              ? (json as { next_cursor?: unknown }).next_cursor
+              : undefined;
+          if (typeof nextCursor !== "string" || nextCursor.length === 0) {
+            respond([...found.values()]);
+            return;
+          }
+          cursor = nextCursor;
+          await sleep(FEED_V3_PAGE_DELAY_MS);
         }
-        if (!res.ok) {
-          respond(null);
-          return;
-        }
-        respond(parseClipsFromFeedResponse(await res.json()));
+        respond([...found.values()]);
       } catch {
         respond(null);
       }

--- a/extensions/suno-helper/tests/suno-bridge.test.ts
+++ b/extensions/suno-helper/tests/suno-bridge.test.ts
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BRIDGE_MSG,
   BRIDGE_SOURCE,
+  FEED_V3_MAX_PAGES,
   FEED_V3_METHOD,
+  FEED_V3_PAGE_DELAY_MS,
   FEED_V3_PATH,
   GENERATE_ENDPOINT_PATH,
   SUNO_API_ORIGIN,
@@ -128,5 +130,54 @@ describe("suno-bridge fetch interceptor", () => {
       },
       window.location.origin,
     );
+  });
+
+  it("Given 対象 clip が先頭ページにない When active poll request を受ける Then cursor を辿って全対象を返す", async () => {
+    vi.useFakeTimers();
+    const originalFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(jsonResponse({ clips: [{ id: "new", status: "complete" }], next_cursor: "cursor-2" }))
+      .mockResolvedValueOnce(jsonResponse({ clips: [{ id: "old", status: "complete" }] }));
+    vi.stubGlobal("fetch", originalFetch);
+    const postMessage = vi.spyOn(window, "postMessage").mockImplementation(() => undefined);
+
+    await loadBridge();
+    await window.fetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+      method: FEED_V3_METHOD,
+      headers: { authorization: "Bearer token" },
+    });
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window,
+        data: {
+          source: BRIDGE_SOURCE,
+          type: BRIDGE_MSG.FEED_V3_POLL_REQUEST,
+          requestId: 124,
+          ids: ["new", "old"],
+        },
+      }),
+    );
+    await vi.runAllTimersAsync();
+
+    expect(originalFetch).toHaveBeenLastCalledWith(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+      method: FEED_V3_METHOD,
+      headers: { authorization: "Bearer token", "content-type": "application/json" },
+      body: JSON.stringify({ ids: ["new", "old"], cursor: "cursor-2" }),
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: BRIDGE_MSG.FEED_V3_POLL_RESPONSE,
+        requestId: 124,
+        clips: [
+          { id: "new", status: "complete" },
+          { id: "old", status: "complete" },
+        ],
+      }),
+      window.location.origin,
+    );
+    expect(FEED_V3_MAX_PAGES).toBe(8);
+    expect(FEED_V3_PAGE_DELAY_MS).toBe(1000);
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
Closes #1929

## Validation
- `pnpm lint`
- `pnpm test` — 47 files / 1,014 tests
- `pnpm compile`
- `pnpm format:check`
- `git diff --check`

Takt supervisor model was updated to a supported Codex model; the final Takt controller state was not persisted after graceful shutdown, so this PR is recovered from the verified worktree.