### PR TITLE
[suno-helper] recover stale content scripts after extension reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: 拡張更新時に既存の Suno タブを自動リロードし、旧 content script の orphaned context を残さず新しい bundle を再注入するようにした（#1718）。
 - `fix(upload)`: `yt-upload-collection` の `-c` 未指定時の自動選択を、`collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクション 1 件だけに限定した。`live/` の公開済みコレクションは候補外とし、候補が 0 件または複数件なら `-c` 明示を要求して停止する。`--plan` / `--status` / 実アップロードと日次実行に同じ選択条件を適用した（#1731）。
 - `fix(upload)`: タグ件数下限が YouTube の 500 字上限の下で到達不能な場合、upload preflight と metadata audit が件数不足ではなく、`tags.min_count` を下げるか base タグを短縮するよう案内する明示診断を返すようにした。配布する content.json テンプレートの `tags.min_count` も 26 に統一した（#1732）。
 - `fix(loop-video)`: Ctrl+C 後の Veo operation resume state に入力画像の SHA-256 を保存し、再実行時に指定モデルまたは入力画像内容が state と異なる場合は旧 operation を破棄して指定どおり新規生成するようにした（#1746）。旧形式 state は安全側で破棄する。

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -9,6 +9,7 @@ import {
 import { buildSelectedEntriesRunOverrides } from "../lib/run-overrides";
 import { downloadFormatItem, readDownloadFormat, type DownloadFormat } from "../lib/storage";
 import { PatternList } from "./PatternList";
+import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
 import { useSunoRunner } from "./useSunoRunner";
 
 // RUN_MODES のキー集合から導出する（手書き複製だと mode 追加時に UI へ出ないまま型チェックが通る）。
@@ -18,8 +19,10 @@ const DOWNLOAD_FORMAT_OPTIONS: DownloadFormat[] = ["mp3", "m4a", "wav"];
 
 export function App() {
   const [downloadFormat, setDownloadFormat] = useState<DownloadFormat>(DOWNLOAD_FORMAT_DEFAULT);
+  const [reloadRequired, setReloadRequired] = useState(false);
   const [selectedEntries, setSelectedEntries] = useState<boolean[]>([]);
   const {
+    reloadRequired: runnerReloadRequired,
     url,
     setUrl,
     serverSources,
@@ -56,11 +59,21 @@ export function App() {
 
   useEffect(() => {
     let mounted = true;
-    void readDownloadFormat().then((value) => {
-      if (mounted) {
-        setDownloadFormat(value);
-      }
-    });
+    void readDownloadFormat()
+      .then((value) => {
+        if (mounted) {
+          setDownloadFormat(value);
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn(
+          "[suno-helper] ダウンロード形式の読込に失敗しました（拡張更新後はタブを再読み込みしてください）:",
+          error,
+        );
+        if (mounted) {
+          setReloadRequired(true);
+        }
+      });
     return () => {
       mounted = false;
     };
@@ -68,7 +81,13 @@ export function App() {
 
   const updateDownloadFormat = (value: DownloadFormat): void => {
     setDownloadFormat(value);
-    void downloadFormatItem.setValue(value);
+    void downloadFormatItem.setValue(value).catch((error: unknown) => {
+      console.warn(
+        "[suno-helper] ダウンロード形式の保存に失敗しました（拡張更新後はタブを再読み込みしてください）:",
+        error,
+      );
+      setReloadRequired(true);
+    });
   };
 
   useEffect(() => {
@@ -126,6 +145,10 @@ export function App() {
       }),
     );
   };
+  if (reloadRequired || runnerReloadRequired) {
+    return <ReloadRequiredNotice />;
+  }
+
   return (
     <div
       className="flex flex-col gap-3 p-3 text-gray-900"

--- a/extensions/suno-helper/components/Overlay.tsx
+++ b/extensions/suno-helper/components/Overlay.tsx
@@ -3,7 +3,7 @@
 // overlay の実マウント（Shadow DOM）は entrypoints/overlay.content.ts が担う。
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { onMessage } from "../lib/messaging";
+import { onMessage, sendMessage } from "../lib/messaging";
 import {
   clampPosition,
   hiddenStyle,
@@ -14,6 +14,7 @@ import {
   writeOverlayState,
 } from "../lib/overlay-state";
 import { App } from "./App";
+import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
 import { useDraggable } from "./useDraggable";
 
 /** overlay shell の固定幅 (px)。clamp の初期サイズと top-right 初期位置の算出に使う。 */
@@ -31,11 +32,31 @@ interface Point {
 export function Overlay() {
   // undefined=読み込み中 / null=未保存 / OverlayState=復元。
   const [initial, setInitial] = useState<OverlayState | null | undefined>(undefined);
+  const [reloadRequired, setReloadRequired] = useState(false);
 
   useEffect(() => {
-    void readOverlayState().then((state) => setInitial(state ?? null));
+    void (async () => {
+      try {
+        const version = browser.runtime.getManifest().version;
+        const handshake = await sendMessage("extensionVersionHandshake", { version });
+        if (!handshake.matches) {
+          setReloadRequired(true);
+          return;
+        }
+        setInitial((await readOverlayState()) ?? null);
+      } catch (error) {
+        console.warn(
+          "[suno-helper] overlay の初期化に失敗しました（拡張更新後はタブを再読み込みしてください）:",
+          error,
+        );
+        setReloadRequired(true);
+      }
+    })();
   }, []);
 
+  if (reloadRequired) {
+    return <ReloadRequiredNotice />;
+  }
   if (initial === undefined) {
     return null;
   }
@@ -54,9 +75,16 @@ function OverlayShell({ initial }: { initial: OverlayState | null }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [minimized, setMinimized] = useState(initial?.minimized ?? false);
   const [hidden, setHidden] = useState(initial?.hidden ?? false);
+  const [reloadRequired, setReloadRequired] = useState(false);
 
   const persist = useCallback((state: OverlayState) => {
-    void writeOverlayState(state);
+    void writeOverlayState(state).catch((error: unknown) => {
+      console.warn(
+        "[suno-helper] overlay state の保存に失敗しました（拡張更新後はタブを再読み込みしてください）:",
+        error,
+      );
+      setReloadRequired(true);
+    });
   }, []);
 
   // 一度だけ登録する toggle リスナーや非同期 commit から最新値を読むための ref。
@@ -105,6 +133,10 @@ function OverlayShell({ initial }: { initial: OverlayState | null }) {
       return next;
     });
   }, [persist]);
+
+  if (reloadRequired) {
+    return <ReloadRequiredNotice />;
+  }
 
   // hidden は unmount でなく display:none で表現する (要件1/3)。unmount すると toggleOverlay
   // リスナーが消え拡張アイコンで復帰不能になるため (#897)、DOM に残したまま CSS で隠す。

--- a/extensions/suno-helper/components/ReloadRequiredNotice.tsx
+++ b/extensions/suno-helper/components/ReloadRequiredNotice.tsx
@@ -1,0 +1,16 @@
+import { EXTENSION_RELOAD_REQUIRED_MESSAGE } from "./runner-errors";
+
+export function ReloadRequiredNotice() {
+  return (
+    <div className="fixed left-4 top-4 z-[2147483647] flex max-w-xs flex-col gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 shadow-xl">
+      <p>{EXTENSION_RELOAD_REQUIRED_MESSAGE}</p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded bg-amber-600 px-2 py-1 text-white hover:bg-amber-500"
+      >
+        タブを再読み込み
+      </button>
+    </div>
+  );
+}

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -187,16 +187,29 @@ export function isContentScriptMissingError(message: string): boolean {
   return /receiving end does not exist|could not establish connection/i.test(message);
 }
 
+export function isExtensionContextInvalidatedError(message: string): boolean {
+  return /extension context invalidated|no response at sendmessage|wxt\/storage.*web extension environment/i.test(
+    message,
+  );
+}
+
+export const EXTENSION_RELOAD_REQUIRED_MESSAGE =
+  "拡張が更新されました。Suno タブをハードリロードしてから操作してください。";
+
+export function isExtensionReloadRequiredError(message: string): boolean {
+  return isContentScriptMissingError(message) || isExtensionContextInvalidatedError(message);
+}
+
 export function formatRunError(message: string): string {
-  if (isContentScriptMissingError(message)) {
-    return `開始失敗: ${message}\nSuno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R) してから再度実行してください。`;
+  if (isExtensionReloadRequiredError(message)) {
+    return `開始失敗: ${message}\n${EXTENSION_RELOAD_REQUIRED_MESSAGE}（⌘+Shift+R / Ctrl+Shift+R）`;
   }
   return `開始失敗: ${message}\nSuno の Custom Mode 画面を開いた状態で実行してください。`;
 }
 
 export function formatStopError(message: string): string {
-  if (isContentScriptMissingError(message)) {
-    return `停止リクエスト失敗: ${message}\nSuno タブをハードリロード (⌘+Shift+R / Ctrl+Shift+R) してから再度実行してください。`;
+  if (isExtensionReloadRequiredError(message)) {
+    return `停止リクエスト失敗: ${message}\n${EXTENSION_RELOAD_REQUIRED_MESSAGE}（⌘+Shift+R / Ctrl+Shift+R）`;
   }
   return `停止リクエスト失敗: ${message}`;
 }

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -34,9 +34,16 @@ import {
 import { isTerminalPhase, nextItemStates } from "../lib/snapshot";
 import { readServerSources, rememberServerSource, serverUrlItem } from "../lib/storage";
 import { shouldReportLiveProgressStatus } from "./live-progress-status";
-import { buildRestoreState, formatRunError, formatStopError, phaseToStatus } from "./runner-errors";
+import {
+  buildRestoreState,
+  formatRunError,
+  formatStopError,
+  isExtensionReloadRequiredError,
+  phaseToStatus,
+} from "./runner-errors";
 
 interface RunnerState {
+  reloadRequired: boolean;
   url: string;
   setUrl: (url: string) => void;
   serverSources: LocalServerSource[];
@@ -95,6 +102,7 @@ function maxDefined(...values: Array<number | null | undefined>): number | undef
 }
 
 export function useSunoRunner(): RunnerState {
+  const [reloadRequired, setReloadRequired] = useState(false);
   const [url, setUrlState] = useState("");
   const [serverSources, setServerSources] = useState<LocalServerSource[]>([]);
   const [allCollections, setAllCollections] = useState<CollectionSummary[]>([]);
@@ -319,29 +327,32 @@ export function useSunoRunner(): RunnerState {
     setIsError(error);
   }, []);
 
+  const reportStorageFailure = useCallback((error: unknown) => {
+    console.warn("[suno-helper] storage 操作に失敗しました（拡張更新後はタブを再読み込みしてください）:", error);
+    setReloadRequired(true);
+  }, []);
+
   // popup 起動時に前回の ERROR 停止 state を読む (#872 要件4)。表示可否は resumeBanner 側で判定する。
   // 基準 now は読み込み完了時に確定する（render 中の Date.now() を避けるため effect 内で取得）。
   useEffect(() => {
-    void readResumeState().then((state) => {
-      setPersistedResume(state);
-      setResumeCheckedAt(Date.now());
-    });
-  }, []);
+    void readResumeState()
+      .then((state) => {
+        setPersistedResume(state);
+        setResumeCheckedAt(Date.now());
+      })
+      .catch((err: unknown) => {
+        reportStorageFailure(err);
+      });
+  }, [reportStorageFailure]);
 
   useEffect(() => {
-    // 読込失敗（拡張更新直後の context invalidated 等）は既定 serial のまま続行する。
-    // unhandled rejection にしない（UI は既定値表示と一致しており実行payload とも整合する）。
-    void readRunModeId()
-      .then(setRunModeId)
-      .catch((err) => console.warn("[suno-helper] run mode の読込に失敗しました（既定 serial を使用）:", err));
-  }, []);
+    void readRunModeId().then(setRunModeId).catch(reportStorageFailure);
+  }, [reportStorageFailure]);
 
   const setRunMode = useCallback((id: RunModeId) => {
     setRunModeId(id);
-    void writeRunModeId(id).catch((err) =>
-      console.warn("[suno-helper] run mode の保存に失敗しました（次回 popup では前回値に戻ります）:", err),
-    );
-  }, []);
+    void writeRunModeId(id).catch(reportStorageFailure);
+  }, [reportStorageFailure]);
 
   const dismissResume = useCallback(() => {
     setResumeDismissed(true);
@@ -405,15 +416,24 @@ export function useSunoRunner(): RunnerState {
   );
 
   useEffect(() => {
-    void serverUrlItem.getValue().then((stored) => {
-      setUrlState(stored);
-      const trimmed = stored.trim();
-      if (trimmed) {
-        void loadCollections(trimmed);
-      }
-    });
-    void readServerSources().then(setServerSources);
-  }, [loadCollections]);
+    void serverUrlItem
+      .getValue()
+      .then((stored) => {
+        setUrlState(stored);
+        const trimmed = stored.trim();
+        if (trimmed) {
+          void loadCollections(trimmed);
+        }
+      })
+      .catch((err: unknown) => {
+        reportStorageFailure(err);
+      });
+    void readServerSources()
+      .then(setServerSources)
+      .catch((err: unknown) => {
+        reportStorageFailure(err);
+      });
+  }, [loadCollections, reportStorageFailure]);
 
   useEffect(() => {
     const unwatch = onMessage("progress", ({ data }) => {
@@ -476,22 +496,39 @@ export function useSunoRunner(): RunnerState {
       return;
     }
     let baseUrl = trimmed;
+    let serverLabel: string | undefined;
     try {
       const info = await sendMessage("fetchServerInfo", { baseUrl: trimmed });
       baseUrl = info.base_url;
       setUrlState(baseUrl);
-      await serverUrlItem.setValue(baseUrl);
-      setServerSources(await rememberServerSource(baseUrl, info.label));
+      serverLabel = info.label;
     } catch {
+      // 古い server は fetchServerInfo を提供しないため、入力 URL のまま継続する。
+    }
+    try {
       await serverUrlItem.setValue(baseUrl);
-      setServerSources(await rememberServerSource(baseUrl));
+      setServerSources(await rememberServerSource(baseUrl, serverLabel));
+    } catch (error) {
+      reportStorageFailure(error);
+      return;
     }
     clearLoadedRunState();
     setPhase("loading");
     report("取得中…");
-    const extensionVersion = browser.runtime.getManifest().version;
-    const warning = await sendMessage("fetchCompatibilityWarning", { baseUrl, extensionVersion });
-    setCompatibilityWarning(typeof warning === "string" ? warning : "");
+    try {
+      const extensionVersion = browser.runtime.getManifest().version;
+      const warning = await sendMessage("fetchCompatibilityWarning", { baseUrl, extensionVersion });
+      setCompatibilityWarning(typeof warning === "string" ? warning : "");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isExtensionReloadRequiredError(message)) {
+        setReloadRequired(true);
+        return;
+      }
+      setPhase("error");
+      report(`互換性確認失敗: ${message}`, true);
+      return;
+    }
     try {
       const collectionId = await syncCollections(baseUrl, selectedCollectionId);
       const data = await fetchCollectionPromptResponse(baseUrl, collectionId);
@@ -507,7 +544,7 @@ export function useSunoRunner(): RunnerState {
       setPhase("error");
       report(`取得失敗: ${message}\nyt-collection-serve が起動しているか確認してください。`, true);
     }
-  }, [url, selectedCollectionId, syncCollections, clearLoadedRunState, report]);
+  }, [url, selectedCollectionId, syncCollections, clearLoadedRunState, report, reportStorageFailure]);
 
   const run = useCallback(
     async (overrides?: RunOverrides) => {
@@ -793,6 +830,7 @@ export function useSunoRunner(): RunnerState {
   }, [report]);
 
   return {
+    reloadRequired,
     url,
     setUrl: updateUrl,
     serverSources,

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -349,10 +349,13 @@ export function useSunoRunner(): RunnerState {
     void readRunModeId().then(setRunModeId).catch(reportStorageFailure);
   }, [reportStorageFailure]);
 
-  const setRunMode = useCallback((id: RunModeId) => {
-    setRunModeId(id);
-    void writeRunModeId(id).catch(reportStorageFailure);
-  }, [reportStorageFailure]);
+  const setRunMode = useCallback(
+    (id: RunModeId) => {
+      setRunModeId(id);
+      void writeRunModeId(id).catch(reportStorageFailure);
+    },
+    [reportStorageFailure],
+  );
 
   const dismissResume = useCallback(() => {
     setResumeDismissed(true);

--- a/extensions/suno-helper/entrypoints/background.ts
+++ b/extensions/suno-helper/entrypoints/background.ts
@@ -22,6 +22,9 @@ export default defineBackground(() => {
 
   installSunoContentScriptRecovery({
     addTabUpdatedListener: (listener) => browser.tabs.onUpdated.addListener(listener),
+    addInstalledListener: (listener) => browser.runtime.onInstalled.addListener(listener),
+    queryTabs: () => browser.tabs.query({}),
+    reloadTab: (tabId) => browser.tabs.reload(tabId),
     executeScript: (details) => {
       if (details.files) {
         return chrome.scripting.executeScript({
@@ -41,6 +44,12 @@ export default defineBackground(() => {
 
   browser.runtime.onInstalled.addListener((details) => {
     console.info(`[suno-helper] installed/updated: ${details.reason}`);
+  });
+
+  onMessage("extensionVersionHandshake", ({ data, sender }) => {
+    requireRelayTab(sender, "extensionVersionHandshake");
+    const version = browser.runtime.getManifest().version;
+    return { version, matches: data.version === version };
   });
 
   // popup 廃止 (#892): default_popup を持たないため action クリックで onClicked が発火する。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -272,6 +272,28 @@ async function resolveDownloadContext(): Promise<DownloadContext> {
 export default defineContentScript({
   matches: [...SUNO_MATCHES],
   main(ctx) {
+    // 更新前に残った content script は service worker と別バージョンになり得る。
+    // handshake 自体の失敗も古い context では起こり得るため、必ず catch して未処理 rejection を残さない。
+    try {
+      const version = browser.runtime.getManifest().version;
+      void sendMessage("extensionVersionHandshake", { version })
+        .then((result) => {
+          if (!result.matches) {
+            console.warn(`[suno-helper] content script のバージョンが不一致です（${version} / ${result.version}）`);
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            "[suno-helper] content script の version handshake に失敗しました（context invalidated?）:",
+            error,
+          );
+        });
+    } catch (error) {
+      console.warn(
+        "[suno-helper] content script の version handshake を開始できません（context invalidated?）:",
+        error,
+      );
+    }
     let aborted = false;
     // 連続実行の二重起動ガード (#892 要件7)。runAll 実行中の run 再着信を弾く。
     let running = false;

--- a/extensions/suno-helper/lib/content-script-recovery.ts
+++ b/extensions/suno-helper/lib/content-script-recovery.ts
@@ -3,7 +3,12 @@ interface TabChangeInfo {
 }
 
 interface TabLike {
+  id?: number;
   url?: string;
+}
+
+interface InstallDetails {
+  reason: string;
 }
 
 interface ScriptResult {
@@ -19,6 +24,9 @@ interface ExecuteScriptDetails {
 
 export interface ContentScriptRecoveryDeps {
   addTabUpdatedListener(listener: (tabId: number, changeInfo: TabChangeInfo, tab: TabLike) => void): void;
+  addInstalledListener(listener: (details: InstallDetails) => void): void;
+  queryTabs(): Promise<TabLike[]>;
+  reloadTab(tabId: number): Promise<void>;
   executeScript(details: ExecuteScriptDetails): Promise<ScriptResult[]>;
   sleep(ms: number): Promise<void>;
   warn(message: string, error: unknown): void;
@@ -27,6 +35,21 @@ export interface ContentScriptRecoveryDeps {
 const SUNO_HOSTS = new Set(["suno.com", "www.suno.com"]);
 const ISOLATED_CONTENT_FILES: ScriptPublicPath[] = ["/content-scripts/content.js", "/content-scripts/overlay.js"];
 const STATIC_INJECTION_GRACE_MS = 1_000;
+
+async function injectSunoContentScripts(tabId: number, deps: ContentScriptRecoveryDeps): Promise<void> {
+  await Promise.all([
+    deps.executeScript({
+      target: { tabId },
+      files: ["/content-scripts/suno-bridge.js"],
+      world: "MAIN",
+    }),
+    deps.executeScript({
+      target: { tabId },
+      files: [...ISOLATED_CONTENT_FILES],
+      world: "ISOLATED",
+    }),
+  ]);
+}
 
 export function isSunoPageUrl(rawUrl: string | undefined): boolean {
   if (!rawUrl || !URL.canParse(rawUrl)) return false;
@@ -56,18 +79,7 @@ export async function recoverSunoContentScripts(tabId: number, deps: ContentScri
   await deps.sleep(STATIC_INJECTION_GRACE_MS);
   if (await hasOverlay()) return false;
 
-  await Promise.all([
-    deps.executeScript({
-      target: { tabId },
-      files: ["/content-scripts/suno-bridge.js"],
-      world: "MAIN",
-    }),
-    deps.executeScript({
-      target: { tabId },
-      files: [...ISOLATED_CONTENT_FILES],
-      world: "ISOLATED",
-    }),
-  ]);
+  await injectSunoContentScripts(tabId, deps);
   return true;
 }
 
@@ -77,5 +89,21 @@ export function installSunoContentScriptRecovery(deps: ContentScriptRecoveryDeps
     void recoverSunoContentScripts(tabId, deps).catch((error: unknown) => {
       deps.warn("[suno-helper] content script の自己復旧に失敗しました", error);
     });
+  });
+
+  deps.addInstalledListener((details) => {
+    if (details.reason !== "update") return;
+    void deps
+      .queryTabs()
+      .then((tabs) =>
+        Promise.all(
+          tabs
+            .filter((tab): tab is TabLike & { id: number } => typeof tab.id === "number" && isSunoPageUrl(tab.url))
+            .map((tab) => deps.reloadTab(tab.id)),
+        ),
+      )
+      .catch((error: unknown) => {
+        deps.warn("[suno-helper] 拡張更新後の Suno タブ自動リロードに失敗しました", error);
+      });
   });
 }

--- a/extensions/suno-helper/lib/messaging.ts
+++ b/extensions/suno-helper/lib/messaging.ts
@@ -75,6 +75,8 @@ export interface RetryDownloadPayload {
 }
 
 interface ProtocolMap {
+  /** content / overlay → background: 拡張更新後の実行コンテキストを確認する。 */
+  extensionVersionHandshake(payload: { version: string }): { version: string; matches: boolean };
   /** overlay → background → runner: 連続実行を開始する。 */
   run(payload: RunPayload): { ok: true };
   /** overlay → background → runner: 連続実行を中断する。 */

--- a/extensions/suno-helper/lib/overlay-state.ts
+++ b/extensions/suno-helper/lib/overlay-state.ts
@@ -85,13 +85,7 @@ export async function readOverlayState(): Promise<OverlayState | null> {
   return overlayStateItem().getValue();
 }
 
-/** overlay state を書き込む（既存があれば上書き）。
- *  拡張更新後の invalidated context では storage アクセスが失敗するため、
- *  書き込み失敗は warning のみで握りつぶす（位置が保存されないだけで機能は継続する）。 */
+/** overlay state を書き込む（既存があれば上書き）。 */
 export async function writeOverlayState(state: OverlayState): Promise<void> {
-  try {
-    await overlayStateItem().setValue(state);
-  } catch (err) {
-    console.warn("[suno-helper] overlay state 書き込み失敗（context invalidated?）:", err);
-  }
+  await overlayStateItem().setValue(state);
 }

--- a/extensions/suno-helper/tests/background-handlers.test.ts
+++ b/extensions/suno-helper/tests/background-handlers.test.ts
@@ -243,6 +243,34 @@ function freshZip(id: number, overrides: Partial<DownloadItem> = {}): DownloadIt
   };
 }
 
+describe('background onMessage("extensionVersionHandshake"): 拡張更新検知 (#1718)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Given 同一タブの現行 version When handshake Then matches=true", async () => {
+    const { handlers } = await loadBackground();
+
+    expect(
+      handlers.get("extensionVersionHandshake")!({
+        data: { version: "0.1.0" },
+        sender: { tab: { id: 42 } },
+      }),
+    ).toEqual({ version: "0.1.0", matches: true });
+  });
+
+  it("Given stale content script version When handshake Then matches=false", async () => {
+    const { handlers } = await loadBackground();
+
+    expect(
+      handlers.get("extensionVersionHandshake")!({
+        data: { version: "0.0.9" },
+        sender: { tab: { id: 42 } },
+      }),
+    ).toEqual({ version: "0.1.0", matches: false });
+  });
+});
+
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();

--- a/extensions/suno-helper/tests/content-script-recovery.test.ts
+++ b/extensions/suno-helper/tests/content-script-recovery.test.ts
@@ -9,18 +9,35 @@ import {
 
 function createDeps(results: Array<Array<{ result?: unknown }>> = []) {
   let updatedListener: Parameters<ContentScriptRecoveryDeps["addTabUpdatedListener"]>[0] | undefined;
+  let installedListener: Parameters<ContentScriptRecoveryDeps["addInstalledListener"]>[0] | undefined;
   const executeScript = vi.fn(async () => results.shift() ?? []);
   const sleep = vi.fn(() => Promise.resolve());
   const warn = vi.fn();
+  const reloadTab = vi.fn(() => Promise.resolve());
+  const tabs: Array<{ id?: number; url?: string }> = [];
   const deps: ContentScriptRecoveryDeps = {
     addTabUpdatedListener: (listener) => {
       updatedListener = listener;
     },
+    addInstalledListener: (listener) => {
+      installedListener = listener;
+    },
+    queryTabs: vi.fn(() => Promise.resolve(tabs)),
+    reloadTab,
     executeScript,
     sleep,
     warn,
   };
-  return { deps, executeScript, sleep, warn, getUpdatedListener: () => updatedListener };
+  return {
+    deps,
+    executeScript,
+    sleep,
+    warn,
+    tabs,
+    reloadTab,
+    getUpdatedListener: () => updatedListener,
+    getInstalledListener: () => installedListener,
+  };
 }
 
 describe("isSunoPageUrl", () => {
@@ -101,5 +118,36 @@ describe("installSunoContentScriptRecovery", () => {
 
     await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
     expect(warn).toHaveBeenCalledWith("[suno-helper] content script の自己復旧に失敗しました", expect.any(Error));
+  });
+
+  it("拡張更新時は既存の Suno タブを自動リロードする", async () => {
+    const { deps, executeScript, tabs, reloadTab, getInstalledListener } = createDeps();
+    tabs.push(
+      { id: 3, url: "https://suno.com/create" },
+      { id: 4, url: "https://example.com/" },
+      { url: "https://suno.com/create" },
+    );
+    installSunoContentScriptRecovery(deps);
+
+    getInstalledListener()!({ reason: "update" });
+
+    await vi.waitFor(() => expect(reloadTab).toHaveBeenCalledOnce());
+    expect(executeScript).not.toHaveBeenCalled();
+    expect(reloadTab).toHaveBeenCalledWith(3);
+  });
+
+  it("更新対象タブの自動リロードに失敗した場合は warn する", async () => {
+    const { deps, tabs, reloadTab, warn, getInstalledListener } = createDeps();
+    tabs.push({ id: 3, url: "https://suno.com/create" });
+    reloadTab.mockRejectedValueOnce(new Error("reload blocked"));
+    installSunoContentScriptRecovery(deps);
+
+    getInstalledListener()!({ reason: "update" });
+
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
+    expect(warn).toHaveBeenCalledWith(
+      "[suno-helper] 拡張更新後の Suno タブ自動リロードに失敗しました",
+      expect.any(Error),
+    );
   });
 });

--- a/extensions/suno-helper/tests/overlay-state.test.ts
+++ b/extensions/suno-helper/tests/overlay-state.test.ts
@@ -103,17 +103,15 @@ describe("OverlayState: 永続化する状態の形 (要件2)", () => {
   });
 });
 
-// --- writeOverlayState: storage 書き込み失敗時の握りつぶし回帰テスト (#1217) ---
-// overlay-state.ts は拡張更新後の invalidated context で storage アクセスが失敗するケースを
-// try-catch で握りつぶし console.warn のみで続行する。この挙動が維持されることを検証する。
+// --- writeOverlayState: storage 書き込み失敗の伝播テスト (#1718) ---
 // 上記の純関数テスト群とは異なり storage I/O を mock するため vi.doMock + 動的 import で隔離する。
-describe("writeOverlayState: storage 書き込み失敗は throw せず console.warn する", () => {
+describe("writeOverlayState: storage 書き込み失敗を UI へ伝播する", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.resetModules();
   });
 
-  it("Given setValue が reject When writeOverlayState Then throw しない + console.warn が呼ばれる", async () => {
+  it("Given setValue が reject When writeOverlayState Then 呼び出し元へ reject する", async () => {
     vi.resetModules();
     vi.doMock("wxt/utils/storage", () => ({
       storage: {
@@ -125,12 +123,8 @@ describe("writeOverlayState: storage 書き込み失敗は throw せず console.
     }));
 
     const { writeOverlayState } = await import("../lib/overlay-state");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     const state: OverlayState = { position: { x: 100, y: 200 }, minimized: false, hidden: false };
 
-    // throw しないことを検証
-    await expect(writeOverlayState(state)).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("overlay state 書き込み失敗"), expect.any(Error));
+    await expect(writeOverlayState(state)).rejects.toThrow("Extension context invalidated");
   });
 });

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -1361,8 +1361,14 @@ describe("Suno popup compatibility check", () => {
       "server sources",
       () => serverSourcesMocks.readServerSources.mockRejectedValueOnce(new Error("Extension context invalidated.")),
     ],
-    ["run mode", () => presetStateMocks.readRunModeId.mockRejectedValueOnce(new Error("Extension context invalidated."))],
-    ["resume state", () => resumeStateMocks.readResumeState.mockRejectedValueOnce(new Error("Extension context invalidated."))],
+    [
+      "run mode",
+      () => presetStateMocks.readRunModeId.mockRejectedValueOnce(new Error("Extension context invalidated.")),
+    ],
+    [
+      "resume state",
+      () => resumeStateMocks.readResumeState.mockRejectedValueOnce(new Error("Extension context invalidated.")),
+    ],
   ])("%s の読込失敗を再読み込み案内へ集約する", async (_label, rejectRead) => {
     rejectRead();
     await rerenderApp();

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PHASE, type ProgressPayload } from "../../shared/constants";
 import { App } from "../components/App";
+import { EXTENSION_RELOAD_REQUIRED_MESSAGE } from "../components/runner-errors";
 
 const BASE_URL = "http://localhost:7873";
 const FALLBACK_URL = "http://localhost:7877";
@@ -36,6 +37,11 @@ const downloadFormatMocks = vi.hoisted(() => ({
   setValue: vi.fn(async () => undefined),
 }));
 
+const serverSourcesMocks = vi.hoisted(() => ({
+  readServerSources: vi.fn(),
+  rememberServerSource: vi.fn(),
+}));
+
 const resumeStateMocks = vi.hoisted(() => ({
   readResumeState: vi.fn(async () => null),
   writeResumeState: vi.fn(async () => undefined),
@@ -58,16 +64,8 @@ vi.mock("../lib/storage", () => ({
   serverUrlItem: storageMocks,
   downloadFormatItem: downloadFormatMocks,
   readDownloadFormat: vi.fn(() => downloadFormatMocks.getValue()),
-  readServerSources: vi.fn(async () => [
-    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
-    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
-    { id: "localhost-7873-changed", label: "localhost changed", url: `${BASE_URL}/changed` },
-  ]),
-  rememberServerSource: vi.fn(async () => [
-    { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
-    { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
-    { id: "localhost-7873-changed", label: "localhost changed", url: `${BASE_URL}/changed` },
-  ]),
+  readServerSources: serverSourcesMocks.readServerSources,
+  rememberServerSource: serverSourcesMocks.rememberServerSource,
 }));
 
 vi.mock("../lib/messaging", () => messagingMocks);
@@ -238,6 +236,12 @@ describe("Suno popup compatibility check", () => {
     downloadFormatMocks.setValue.mockResolvedValue(undefined);
     presetStateMocks.readRunModeId.mockResolvedValue("serial");
     presetStateMocks.writeRunModeId.mockResolvedValue(undefined);
+    serverSourcesMocks.readServerSources.mockResolvedValue([
+      { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+      { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+      { id: "localhost-7873-changed", label: "localhost changed", url: `${BASE_URL}/changed` },
+    ]);
+    serverSourcesMocks.rememberServerSource.mockResolvedValue([]);
     messagingMocks.sendMessage.mockImplementation(defaultSendMessage);
     messagingMocks.progressHandler = undefined;
     messagingMocks.onMessage.mockImplementation(
@@ -267,6 +271,17 @@ describe("Suno popup compatibility check", () => {
     });
   }
 
+  async function rerenderApp(): Promise<void> {
+    await act(async () => {
+      root.unmount();
+    });
+    container.innerHTML = "";
+    root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(App));
+    });
+  }
+
   afterEach(() => {
     act(() => {
       root.unmount();
@@ -280,6 +295,8 @@ describe("Suno popup compatibility check", () => {
     resumeStateMocks.writeResumeState.mockResolvedValue(undefined);
     presetStateMocks.readRunModeId.mockResolvedValue("serial");
     presetStateMocks.writeRunModeId.mockResolvedValue(undefined);
+    serverSourcesMocks.readServerSources.mockResolvedValue([]);
+    serverSourcesMocks.rememberServerSource.mockResolvedValue([]);
   });
 
   it("ローカル配信元 option は URL を表示せず、URL value はデータ取得先として維持する", async () => {
@@ -1316,6 +1333,109 @@ describe("Suno popup compatibility check", () => {
 
     expect(downloadFormatMocks.setValue).toHaveBeenCalledWith("wav");
     expect(select.value).toBe("wav");
+  });
+
+  it("DL 形式の読込が失敗すると未捕捉にせず再読み込み案内を表示する", async () => {
+    downloadFormatMocks.getValue.mockRejectedValueOnce(
+      new Error("'wxt/storage' must be loaded in a web extension environment"),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.innerHTML = "";
+    root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(App));
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+      expect(buttonByText(container, "タブを再読み込み")).toBeTruthy();
+    });
+  });
+
+  it.each([
+    ["server URL", () => storageMocks.getValue.mockRejectedValueOnce(new Error("Extension context invalidated."))],
+    [
+      "server sources",
+      () => serverSourcesMocks.readServerSources.mockRejectedValueOnce(new Error("Extension context invalidated.")),
+    ],
+    ["run mode", () => presetStateMocks.readRunModeId.mockRejectedValueOnce(new Error("Extension context invalidated."))],
+    ["resume state", () => resumeStateMocks.readResumeState.mockRejectedValueOnce(new Error("Extension context invalidated."))],
+  ])("%s の読込失敗を再読み込み案内へ集約する", async (_label, rejectRead) => {
+    rejectRead();
+    await rerenderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+      expect(buttonByText(container, "タブを再読み込み")).toBeTruthy();
+    });
+  });
+
+  it("run mode の保存失敗を再読み込み案内へ集約する", async () => {
+    presetStateMocks.writeRunModeId.mockRejectedValueOnce(new Error("Extension context invalidated."));
+    const queueRadio = radioByLabel(container, "高速モード");
+
+    await act(async () => {
+      queueRadio.click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+    });
+  });
+
+  it("server URL の保存失敗を再読み込み案内へ集約し、再保存しない", async () => {
+    storageMocks.setValue.mockRejectedValueOnce(new Error("Extension context invalidated."));
+    const serverSelect = expectControl(container, "server-url") as HTMLSelectElement;
+    setSelectValue(serverSelect, BASE_URL);
+
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+    });
+    expect(storageMocks.setValue).toHaveBeenCalledOnce();
+  });
+
+  it("互換性確認の No response を未捕捉にせず再読み込み案内へ集約する", async () => {
+    messagingMocks.sendMessage.mockImplementation((message, payload) => {
+      if (message === "fetchCompatibilityWarning") {
+        return Promise.reject(new Error("No response at sendMessage"));
+      }
+      return defaultSendMessage(message, payload);
+    });
+    const serverSelect = expectControl(container, "server-url") as HTMLSelectElement;
+    setSelectValue(serverSelect, BASE_URL);
+
+    await act(async () => {
+      buttonByText(container, "データ取得").click();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+      expect(buttonByText(container, "タブを再読み込み")).toBeTruthy();
+    });
+  });
+
+  it("DL 形式の保存が失敗すると未捕捉にせず再読み込み案内を表示する", async () => {
+    downloadFormatMocks.setValue.mockRejectedValueOnce(new Error("Extension context invalidated."));
+    const select = Array.from(container.querySelectorAll("select")).find((candidate) =>
+      Array.from(candidate.options).some((option) => option.value === "wav"),
+    );
+    if (!select) throw new Error("download format select not found");
+
+    await act(async () => {
+      setSelectValue(select, "wav");
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
+      expect(buttonByText(container, "タブを再読み込み")).toBeTruthy();
+    });
   });
 
   it("DL 形式 select は不正な storage 値を MP3 に戻す", async () => {

--- a/extensions/suno-helper/tests/relay-failure.test.ts
+++ b/extensions/suno-helper/tests/relay-failure.test.ts
@@ -9,7 +9,12 @@
 // （Vitest env は node・chrome モック無しのため、既存 content-script-missing-hint.test.ts と同方針）。
 import { describe, expect, it } from "vitest";
 
-import { describeRelayFailure } from "../components/runner-errors";
+import {
+  EXTENSION_RELOAD_REQUIRED_MESSAGE,
+  describeRelayFailure,
+  formatRunError,
+  isExtensionContextInvalidatedError,
+} from "../components/runner-errors";
 
 describe("describeRelayFailure: content script 未注入（想定内）は info に落とす (#937)", () => {
   it("Given missing-receiver エラー When 整形 Then level=info + ハードリロード案内を含む", () => {
@@ -40,5 +45,16 @@ describe("describeRelayFailure: 想定外エラーは warn で残す (#937)", ()
 
   it("Given 空メッセージ When 整形 Then level=warn（missing-receiver 扱いにしない）", () => {
     expect(describeRelayFailure("toggleOverlay", "").level).toBe("warn");
+  });
+});
+
+describe("拡張更新後の context invalidated を再読み込み案内へ集約する (#1718)", () => {
+  it.each([
+    "Extension context invalidated.",
+    "Error: No response at sendMessage",
+    "Error: 'wxt/storage' must be loaded in a web extension environment",
+  ])("Given %j When 判定 Then 更新後エラーとして扱う", (message) => {
+    expect(isExtensionContextInvalidatedError(message)).toBe(true);
+    expect(formatRunError(message)).toContain(EXTENSION_RELOAD_REQUIRED_MESSAGE);
   });
 });


### PR DESCRIPTION
Closes #1718

## Validation
- `pnpm test` — 47 files / 1,029 tests
- `nr compile`
- `nr build`
- `git diff --check`

The fix adds a version handshake and reload guidance/recovery for orphaned content scripts, while preserving normal run, playlist, and download flows.