### PR TITLE
fix(suno-helper): retry download menu auto-close race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: Download all メニューの短時間 auto-close レースに対し、More クリック直後から探索を開始し、検出失敗時は最大 3 回再クリックしてダウンロードを継続できるようにした（#1926）。
 - `fix(upload)`: `yt-upload-collection` の `-c` 未指定時の自動選択を、`collections/planning/` 配下で `phase=mastered` かつ `upload.video_id=null` の未公開コレクション 1 件だけに限定した。`live/` の公開済みコレクションは候補外とし、候補が 0 件または複数件なら `-c` 明示を要求して停止する。`--plan` / `--status` / 実アップロードと日次実行に同じ選択条件を適用した（#1731）。
 - `fix(upload)`: タグ件数下限が YouTube の 500 字上限の下で到達不能な場合、upload preflight と metadata audit が件数不足ではなく、`tags.min_count` を下げるか base タグを短縮するよう案内する明示診断を返すようにした。配布する content.json テンプレートの `tags.min_count` も 26 に統一した（#1732）。
 - `fix(loop-video)`: Ctrl+C 後の Veo operation resume state に入力画像の SHA-256 を保存し、再実行時に指定モデルまたは入力画像内容が state と異なる場合は旧 operation を破棄して指定どおり新規生成するようにした（#1746）。旧形式 state は安全側で破棄する。

--- a/extensions/suno-helper/lib/download.ts
+++ b/extensions/suno-helper/lib/download.ts
@@ -10,8 +10,9 @@ const DOWNLOAD_MENU_ITEM_TEXT = /download\s*all/i;
 const FORMAT_MODAL_SELECTOR = "div.modal-class.modal-overlay";
 const FORMAT_OPTION_SELECTOR = "button.flex.w-full";
 const DOWNLOAD_CONFIRM_SELECTOR = "button.hxc-btn-variant-primary";
-const MENU_APPEAR_POLL_MS = 100;
-const MENU_APPEAR_TIMEOUT_MS = 5000;
+const MENU_APPEAR_POLL_MS = 10;
+const MENU_APPEAR_TIMEOUT_MS = 1500;
+const MAX_DOWNLOAD_MENU_ATTEMPTS = 3;
 const MODAL_APPEAR_POLL_MS = 200;
 const MODAL_APPEAR_TIMEOUT_MS = 10000;
 const MODAL_CLOSE_POLL_MS = 200;
@@ -184,17 +185,28 @@ export async function triggerDownloadAll(
   format: string,
   deps: TriggerDownloadAllDeps = defaultDownloadDeps(),
 ): Promise<void> {
-  const moreBtn = deps.findMoreButton();
-  if (!moreBtn) {
-    throw new Error(
-      `More メニューボタン (${MORE_BUTTON_SELECTOR}) が見つかりませんでした。` +
-        "clip が multi-select されているか確認してください。",
-    );
+  let downloadItem: HTMLElement | undefined;
+  for (let attempt = 0; attempt < MAX_DOWNLOAD_MENU_ATTEMPTS; attempt += 1) {
+    const moreBtn = deps.findMoreButton();
+    if (!moreBtn) {
+      throw new Error(
+        `More メニューボタン (${MORE_BUTTON_SELECTOR}) が見つかりませんでした。` +
+          "clip が multi-select されているか確認してください。",
+      );
+    }
+    deps.clickElement(moreBtn);
+    try {
+      downloadItem = await deps.waitForDownloadMenuItem(MENU_APPEAR_TIMEOUT_MS, MENU_APPEAR_POLL_MS);
+      break;
+    } catch (error) {
+      if (attempt === MAX_DOWNLOAD_MENU_ATTEMPTS - 1) {
+        throw error;
+      }
+    }
   }
-  deps.clickElement(moreBtn);
-  await deps.sleep(SETTLE_AFTER_CLICK_MS);
-
-  const downloadItem = await deps.waitForDownloadMenuItem(MENU_APPEAR_TIMEOUT_MS, MENU_APPEAR_POLL_MS);
+  if (!downloadItem) {
+    throw new Error('"Download all" menu item が見つかりませんでした');
+  }
   deps.clickElement(downloadItem);
   await deps.sleep(SETTLE_AFTER_CLICK_MS);
 

--- a/extensions/suno-helper/tests/download.test.ts
+++ b/extensions/suno-helper/tests/download.test.ts
@@ -104,7 +104,25 @@ describe("triggerDownloadAll", () => {
     expect(deps.selectFormat).toHaveBeenCalledWith(expect.anything(), "m4a");
   });
 
-  it("waitForDownloadMenuItem が throw した場合はそのまま伝播する", async () => {
+  it("Download all の待機に失敗しても More の再クリックで成功できる", async () => {
+    const formatModal = stubElement();
+    const deps = createMockDeps({
+      waitForDownloadMenuItem: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Download all menu item が見つかりませんでした"))
+        .mockResolvedValueOnce(stubElement()),
+      waitForFormatModal: vi.fn(async () => formatModal),
+    });
+
+    await triggerDownloadAll("mp3", deps);
+
+    expect(deps.findMoreButton).toHaveBeenCalledTimes(2);
+    expect(deps.waitForDownloadMenuItem).toHaveBeenCalledTimes(2);
+    expect(deps.clickElement).toHaveBeenCalledTimes(3);
+    expect(deps.selectFormat).toHaveBeenCalledWith(formatModal, "mp3");
+  });
+
+  it("Download all の待機に 3 回失敗した場合は最後のエラーを伝播する", async () => {
     const deps = createMockDeps({
       waitForDownloadMenuItem: vi.fn(async () => {
         throw new Error("Download all menu item が見つかりませんでした");
@@ -112,6 +130,8 @@ describe("triggerDownloadAll", () => {
     });
 
     await expect(triggerDownloadAll("mp3", deps)).rejects.toThrow(/Download all menu item/);
+    expect(deps.findMoreButton).toHaveBeenCalledTimes(3);
+    expect(deps.waitForDownloadMenuItem).toHaveBeenCalledTimes(3);
     // selectFormat / clickConfirm は呼ばれない
     expect(deps.selectFormat).not.toHaveBeenCalled();
     expect(deps.clickConfirm).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Start Download all menu discovery immediately after the More click.
- Retry the More click up to three times when the short menu window closes.
- Add regression coverage and update CHANGELOG.

Closes #1926