### PR TITLE
fix(suno-helper): reset stall timeout only on progress

### DIFF
--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -133,6 +133,49 @@ function assertOptionalBoolean(value: unknown, field: string): boolean | undefin
   return value;
 }
 
+export interface AttemptClipCompletionOptions {
+  getPendingIdsByIds: (clipIds: string[]) => string[];
+  requestFeedPoll: (clipIds: string[]) => Promise<unknown>;
+  abortableSleep: (milliseconds: number, isAborted: () => boolean) => Promise<void>;
+  isAborted: () => boolean;
+  now: () => number;
+}
+
+export async function waitForAttemptClipsComplete(
+  clipIds: string[],
+  options: AttemptClipCompletionOptions,
+): Promise<void> {
+  if (clipIds.length === 0) {
+    throw new Error("duration guard 用の clip ID を観測できませんでした。bridge の generate 観測を確認してください。");
+  }
+  let lastProgressAt = options.now();
+  let deadline = lastProgressAt + INFLIGHT_STALL_TIMEOUT_MS;
+  let lastPendingCount: number | undefined;
+  while (!options.isAborted()) {
+    const pendingIds = options.getPendingIdsByIds(clipIds);
+    if (pendingIds.length === 0) {
+      return;
+    }
+    const currentNow = options.now();
+    const pendingCountDecreased = lastPendingCount !== undefined && pendingIds.length < lastPendingCount;
+    if (pendingCountDecreased) {
+      lastProgressAt = currentNow;
+      deadline = lastProgressAt + INFLIGHT_STALL_TIMEOUT_MS;
+    }
+    if (pendingIds.length !== lastPendingCount) {
+      console.info(`[suno-helper] yield guard wait: pending=${pendingIds.length}/${clipIds.length}`);
+    }
+    lastPendingCount = pendingIds.length;
+    if (currentNow >= deadline) {
+      throw new Error(
+        `duration guard の clip 完了待ちがタイムアウトしました: pending=${pendingIds.length}, 最後の進捗からの経過時間=${currentNow - lastProgressAt}ms`,
+      );
+    }
+    await options.requestFeedPoll(pendingIds);
+    await options.abortableSleep(POLL_INTERVAL_MS, options.isAborted);
+  }
+}
+
 function assertOptionalDurationFilter(value: unknown, field: string): DurationFilter | undefined {
   if (value === undefined) {
     return undefined;
@@ -676,33 +719,14 @@ export default defineContentScript({
       return new Set([...previousSubmittedClipIds, ...Array.from(clipIdsByEntry.values()).flat()]).size;
     }
 
-    async function waitForAttemptClipsComplete(clipIds: string[], isAborted: () => boolean): Promise<void> {
-      if (clipIds.length === 0) {
-        throw new Error(
-          "duration guard 用の clip ID を観測できませんでした。bridge の generate 観測を確認してください。",
-        );
-      }
-      const deadline = Date.now() + INFLIGHT_STALL_TIMEOUT_MS;
-      let lastPendingCount = Number.POSITIVE_INFINITY;
-      while (!isAborted()) {
-        const pendingIds = tracker.getPendingIdsByIds(clipIds);
-        if (pendingIds.length === 0) {
-          return;
-        }
-        if (pendingIds.length !== lastPendingCount) {
-          lastPendingCount = pendingIds.length;
-          console.info(`[suno-helper] yield guard wait: pending=${pendingIds.length}/${clipIds.length}`);
-        }
-        if (Date.now() >= deadline) {
-          throw new Error(`duration guard の clip 完了待ちがタイムアウトしました: pending=${pendingIds.length}`);
-        }
-        await requestFeedPoll(pendingIds);
-        await abortableSleep(POLL_INTERVAL_MS, isAborted);
-      }
-    }
-
     async function evaluateAttemptYield(clipIds: string[], durationFilter: DurationFilter, isAborted: () => boolean) {
-      await waitForAttemptClipsComplete(clipIds, isAborted);
+      await waitForAttemptClipsComplete(clipIds, {
+        getPendingIdsByIds: (ids) => tracker.getPendingIdsByIds(ids),
+        requestFeedPoll,
+        abortableSleep,
+        isAborted,
+        now: Date.now,
+      });
       return evaluateClips(
         clipIds.map((id) => ({ id, duration: tracker.getDuration(id) })),
         durationFilter,

--- a/extensions/suno-helper/lib/queue-runner.ts
+++ b/extensions/suno-helper/lib/queue-runner.ts
@@ -271,8 +271,9 @@ export async function submitQueueEntries(options: QueueSubmissionOptions): Promi
 
 export async function waitForSubmittedClipsComplete(options: SubmittedClipCompletionOptions): Promise<string[]> {
   const now = options.now ?? Date.now;
-  const deadline = now() + INFLIGHT_STALL_TIMEOUT_MS;
-  let lastPendingCount = Number.POSITIVE_INFINITY;
+  let lastProgressAt = now();
+  let deadline = lastProgressAt + INFLIGHT_STALL_TIMEOUT_MS;
+  let lastPendingCount: number | undefined;
   while (!options.isAborted()) {
     const submittedIds = options.getSubmittedIds();
     const observedSubmittedCount = new Set([...options.previousSubmittedClipIds, ...submittedIds]).size;
@@ -287,15 +288,21 @@ export async function waitForSubmittedClipsComplete(options: SubmittedClipComple
         `playlist 対象の clip ID 数が不足しています: expected ${options.expectedClipCount}, got ${observedSubmittedCount}`,
       );
     }
+    const currentNow = now();
+    const pendingCountDecreased = lastPendingCount !== undefined && pendingSubmittedIds.length < lastPendingCount;
+    if (pendingCountDecreased) {
+      lastProgressAt = currentNow;
+      deadline = lastProgressAt + INFLIGHT_STALL_TIMEOUT_MS;
+    }
     if (pendingSubmittedIds.length !== lastPendingCount) {
-      lastPendingCount = pendingSubmittedIds.length;
       console.info(
         `[suno-helper] final clip completion wait: submitted=${observedSubmittedCount}/${options.expectedClipCount}, pending=${pendingSubmittedIds.length}`,
       );
     }
-    if (now() >= deadline) {
+    lastPendingCount = pendingSubmittedIds.length;
+    if (currentNow >= deadline) {
       throw new Error(
-        `生成完了待ちがタイムアウトしました: submitted=${observedSubmittedCount}/${options.expectedClipCount}, pending=${pendingSubmittedIds.length}`,
+        `生成完了待ちがタイムアウトしました: submitted=${observedSubmittedCount}/${options.expectedClipCount}, pending=${pendingSubmittedIds.length}, 最後の進捗からの経過時間=${currentNow - lastProgressAt}ms`,
       );
     }
     await options.requestFeedPoll(pendingSubmittedIds);

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { BALANCED_RUN_PACING, CLIPS_PER_REQUEST, PHASE } from "../../shared/constants";
+import { BALANCED_RUN_PACING, CLIPS_PER_REQUEST, INFLIGHT_STALL_TIMEOUT_MS, PHASE } from "../../shared/constants";
 import type { EntryRunResult, RunEntryWithRetryOptions } from "../lib/entry-retry";
 import { writeResumeState } from "../lib/resume-state";
 import { makePromptEntries, markBbox } from "./_helpers";
@@ -404,6 +404,56 @@ afterEach(() => {
 });
 
 describe('content onMessage("run"): Run 開始前の Suno view preflight', () => {
+  it("duration guard の pending 減少後は新しい stall deadline まで待機し、停滞時だけ timeout する", async () => {
+    await loadContentScript();
+    const { waitForAttemptClipsComplete } = await import("../entrypoints/content");
+    let currentTime = 0;
+    let pollCount = 0;
+    const pendingClipIds = new Set(["clip-a", "clip-b"]);
+
+    await expect(
+      waitForAttemptClipsComplete(["clip-a", "clip-b"], {
+        getPendingIdsByIds: (ids) => ids.filter((id) => pendingClipIds.has(id)),
+        requestFeedPoll: async () => {
+          pollCount += 1;
+          if (pollCount === 1) {
+            pendingClipIds.delete("clip-a");
+          }
+        },
+        abortableSleep: async () => {
+          currentTime += INFLIGHT_STALL_TIMEOUT_MS;
+        },
+        isAborted: () => false,
+        now: () => currentTime,
+      }),
+    ).rejects.toThrow(`最後の進捗からの経過時間=${INFLIGHT_STALL_TIMEOUT_MS}ms`);
+    expect(pollCount).toBe(2);
+  });
+
+  it("duration guard の pending 増加は stall deadline をリセットしない", async () => {
+    await loadContentScript();
+    const { waitForAttemptClipsComplete } = await import("../entrypoints/content");
+    let currentTime = 0;
+    let pollCount = 0;
+    const pendingClipIds = new Set(["clip-a", "clip-b"]);
+
+    await expect(
+      waitForAttemptClipsComplete(["clip-a", "clip-b", "clip-c"], {
+        getPendingIdsByIds: (ids) => ids.filter((id) => pendingClipIds.has(id)),
+        requestFeedPoll: async () => {
+          pollCount += 1;
+          pendingClipIds.add("clip-c");
+        },
+        abortableSleep: async () => {
+          currentTime += INFLIGHT_STALL_TIMEOUT_MS;
+        },
+        isAborted: () => false,
+        now: () => currentTime,
+      }),
+    ).rejects.toThrow(`最後の進捗からの経過時間=${INFLIGHT_STALL_TIMEOUT_MS}ms`);
+    expect(pollCount).toBe(1);
+  });
+
   it("Given 旧 array payload When run を受ける Then fail-loud し副作用を起こさない", async () => {
     await loadContentScript();
     const runHandler = getRunHandler();

--- a/extensions/suno-helper/tests/queue-runner.test.ts
+++ b/extensions/suno-helper/tests/queue-runner.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { PromptEntry } from "../../shared/api";
-import { CLIPS_PER_REQUEST, MAX_INFLIGHT_REQUESTS, PHASE } from "../../shared/constants";
+import { CLIPS_PER_REQUEST, INFLIGHT_STALL_TIMEOUT_MS, MAX_INFLIGHT_REQUESTS, PHASE } from "../../shared/constants";
 import { finalizeQueueEntriesYield, submitQueueEntries, waitForSubmittedClipsComplete } from "../lib/queue-runner";
 import type { QueueSubmissionOptions, SubmittedClipCompletionOptions } from "../lib/queue-runner";
 import { buildRunPayload } from "../lib/run-overrides";
@@ -401,5 +401,61 @@ describe("queue-runner: production ロジック (#1586)", () => {
     feedPollMayFinish.resolve();
     await pendingCompletion;
     expect(playlistReached).toBe(true);
+  });
+
+  it("production completion gate は pending 減少時に stall deadline をリセットする", async () => {
+    let currentTime = 0;
+    const pendingClipIds = new Set(["clip-a", "clip-b"]);
+    let pollCount = 0;
+    const options: SubmittedClipCompletionOptions = {
+      expectedClipCount: 2,
+      previousSubmittedClipIds: [],
+      isAborted: () => false,
+      getSubmittedIds: () => ["clip-a", "clip-b"],
+      getPendingIdsByIds: (ids) => ids.filter((id) => pendingClipIds.has(id)),
+      getPendingSubmittedIds: () => Array.from(pendingClipIds),
+      requestFeedPoll: async () => {
+        pollCount += 1;
+        if (pollCount === 1) {
+          pendingClipIds.delete("clip-a");
+        }
+      },
+      abortableSleep: async () => {
+        currentTime += INFLIGHT_STALL_TIMEOUT_MS;
+      },
+      now: () => currentTime,
+    };
+
+    await expect(waitForSubmittedClipsComplete(options)).rejects.toThrow(
+      `最後の進捗からの経過時間=${INFLIGHT_STALL_TIMEOUT_MS}ms`,
+    );
+    expect(pollCount).toBe(2);
+  });
+
+  it("production completion gate は pending 増加時に stall deadline をリセットしない", async () => {
+    let currentTime = 0;
+    const pendingClipIds = new Set(["clip-a", "clip-b"]);
+    let pollCount = 0;
+    const options: SubmittedClipCompletionOptions = {
+      expectedClipCount: 3,
+      previousSubmittedClipIds: [],
+      isAborted: () => false,
+      getSubmittedIds: () => ["clip-a", "clip-b", "clip-c"],
+      getPendingIdsByIds: (ids) => ids.filter((id) => pendingClipIds.has(id)),
+      getPendingSubmittedIds: () => Array.from(pendingClipIds),
+      requestFeedPoll: async () => {
+        pollCount += 1;
+        pendingClipIds.add("clip-c");
+      },
+      abortableSleep: async () => {
+        currentTime += INFLIGHT_STALL_TIMEOUT_MS;
+      },
+      now: () => currentTime,
+    };
+
+    await expect(waitForSubmittedClipsComplete(options)).rejects.toThrow(
+      `最後の進捗からの経過時間=${INFLIGHT_STALL_TIMEOUT_MS}ms`,
+    );
+    expect(pollCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Reset Queue mode stall timers only when pending work decreases.
- Apply the same rule to duration guard waiting.
- Add regression coverage for progress and non-progress cases.

Closes #1925