### PR TITLE
[#1935] issue-1935-worktree-de-nix-dev

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.lefthook/setup-worktree.sh
+++ b/.lefthook/setup-worktree.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! checkout_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "error: run this script from a Git checkout or worktree." >&2
+  exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+  command=(bash "$checkout_root/.lefthook/install.sh")
+else
+  command=("$@")
+fi
+
+if command -v direnv >/dev/null 2>&1; then
+  direnv allow "$checkout_root"
+  exec direnv exec "$checkout_root" "${command[@]}"
+fi
+
+if command -v nix >/dev/null 2>&1; then
+  exec nix develop "$checkout_root" --command "${command[@]}"
+fi
+
+echo "error: neither direnv nor nix is available in PATH." >&2
+exit 1

--- a/.takt/workflows/lite.yaml
+++ b/.takt/workflows/lite.yaml
@@ -16,7 +16,12 @@ steps:
     persona: planner
     provider: codex
     edit: false
-    instruction: plan
+    instruction: |
+      最初に `bash .lefthook/setup-worktree.sh` を実行し、devShell と Git hooks をセットアップすること。
+      以降の `uv` / `ruff` コマンドは `bash .lefthook/setup-worktree.sh <command> [args...]` 経由で実行すること。
+      セットアップに失敗した場合は処理を続行せず、失敗内容を報告すること。
+
+      plan
     rules:
       - condition: "実装計画が確定した"
         next: implement
@@ -27,6 +32,10 @@ steps:
     pass_previous_response: true
     policy: pre-review-checklist
     instruction: |
+      最初に `bash .lefthook/setup-worktree.sh` を実行し、devShell と Git hooks をセットアップすること。
+      以降の `uv` / `ruff` コマンドは `bash .lefthook/setup-worktree.sh <command> [args...]` 経由で実行すること。
+      セットアップに失敗した場合は処理を続行せず、失敗内容を報告すること。
+
       計画に従って実装・テスト追加・テスト実行を完了させたあと、ポリシー
       「提出前セルフ監査チェックリスト」の 8 項目を根拠（ファイル:行）付きで自己監査すること。
 
@@ -42,6 +51,10 @@ steps:
     pass_previous_response: true
     policy: pre-review-checklist
     instruction: |
+      最初に `bash .lefthook/setup-worktree.sh` を実行し、devShell と Git hooks をセットアップすること。
+      以降の `uv` / `ruff` コマンドは `bash .lefthook/setup-worktree.sh <command> [args...]` 経由で実行すること。
+      セットアップに失敗した場合は処理を続行せず、失敗内容を報告すること。
+
       実装者の自己監査を鵜呑みにせず、ポリシー「提出前セルフ監査チェックリスト」の
       8 項目を diff と実コードに対して独立に照合すること。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ TS 版（tayk）の開発は専用の別リポジトリで行う（`docs/adr/002
 - 実コード（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）を変更したら `CHANGELOG.md` の `[Unreleased]` 追記が必須（lefthook pre-push + CI で機械担保）
 - tests / docs だけの変更はゲート対象外。意図的に省く場合は `SKIP_CHANGELOG=1 git push`（CI 側は PR の `skip-changelog` ラベル）
 - lefthook の有効化手順・pre-commit の詳細は `docs/development.md`
-- worktree で commit / push する場合も、対象 worktree で `nix develop`（または direnv）に入り `.lefthook/install.sh` を通す。診断・再インストール手順は `docs/development.md` の「Git hooks（lefthook）」を参照
+- 親 checkout / worktree の初回は `bash .lefthook/setup-worktree.sh` を実行し、direnv（`.envrc` の `use flake`）または Nix devShell を通して `.lefthook/install.sh` まで完了させる。非対話 shell では `bash .lefthook/setup-worktree.sh uv run pytest` のように devShell 内でコマンドを実行する。診断・再インストール手順は `docs/development.md` の「Git hooks（lefthook）」を参照
 
 ## 開発ワークフロー
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,8 +61,9 @@ Python 側の未使用コード検出は、追加依存なしで CI / pre-commit
 
 有効化と運用:
 
-- **有効化**: 親 checkout / worktree のどちらでも `nix develop`（または direnv `use flake`）で devShell に入る。`flake.nix` の shellHook が `lefthook` を PATH に供給し、`.lefthook/install.sh` で hook を再生成する。手動再生成も `nix develop --command bash .lefthook/install.sh` を使う
-- **診断**: 親 checkout / worktree のそれぞれで `nix develop --command sh -c 'command -v lefthook && lefthook version'` を実行し、`lefthook` が PATH から解決できることを確認する。`git commit` / `git push` で `Can't find lefthook in PATH` が出る場合は、対象 checkout で `nix develop --command bash .lefthook/install.sh` を実行して stale な hook を再生成する
+- **有効化**: 親 checkout / 新規 worktree のどちらでも、最初に `bash .lefthook/setup-worktree.sh` を 1 回実行する。direnv があればルートの `.envrc`（`use flake`）を allow して devShell に入り、なければ `nix develop` を使う。どちらの経路でも shellHook と `.lefthook/install.sh` が hook wrapper を再生成する
+- **devShell 内での実行**: direnv の自動入室が有効な shell ではそのまま `uv run pytest` 等を実行できる。agent や非対話 shell では `bash .lefthook/setup-worktree.sh uv run pytest` のように引数を渡すと、同じ devShell 内でコマンドを実行できる
+- **診断**: 親 checkout / worktree のそれぞれで `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'` を実行する。`git commit` / `git push` で `Can't find lefthook in PATH` が出る場合は `bash .lefthook/setup-worktree.sh` を再実行する。直接の Nix 診断・再生成には `nix develop --command sh -c 'command -v lefthook && lefthook version'` と `nix develop --command bash .lefthook/install.sh` も利用できる
 - **失敗時の扱い**: shellHook は `lefthook` 不在や hook 再生成失敗を `|| true` で握りつぶさない。devShell 入室時に明示的に失敗させ、commit / push 時の hook no-op を防ぐ
 - **全 hook をスキップ**: `LEFTHOOK=0 git push` / `LEFTHOOK=0 git commit`
 - **CHANGELOG ゲートのみ省く**: `SKIP_CHANGELOG=1 git push`（CI 側は PR の `skip-changelog` ラベル）

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -56,7 +56,7 @@ observability:
 - **takt 自動生成**: `<repo-parent>/takt-worktrees/<timestamp>-<N>-<slug>/`（takt が自動管理）
 - **手動 `git worktree add`**: `$REPO_ROOT/.worktrees/<slug>/`（リポジトリ内・gitignore 済み・`parallel` スキルと共通）
 - `<repo-parent>/automation-worktrees/` 等のリポジトリ外手動置き場は非推奨（過去の残骸のみ）
-- worktree で commit / push する前に、対象 worktree 内で `nix develop`（direnv 利用時は `direnv allow` 後の shell）に入る。shellHook が `.lefthook/install.sh` を実行し、親 checkout と同じ `lefthook.yml` から fail-closed hook wrapper まで再生成する。診断は `nix develop --command sh -c 'command -v lefthook && lefthook version'`、再生成は `nix develop --command bash .lefthook/install.sh`。
+- 親 checkout / worktree の初回は `bash .lefthook/setup-worktree.sh` を実行する。direnv があれば `.envrc` を allow し、なければ `nix develop` を使って、shellHook と `.lefthook/install.sh` により fail-closed hook wrapper まで再生成する。takt agent / 非対話 shell のコマンドは `bash .lefthook/setup-worktree.sh uv run pytest` のようにラッパー経由で実行する。診断は `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'`、直接の Nix 再生成は `nix develop --command bash .lefthook/install.sh`。
 
 ## takt 設定の継承構造
 

--- a/tests/test_lefthook_installation_contract.py
+++ b/tests/test_lefthook_installation_contract.py
@@ -8,6 +8,9 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _FLAKE_PATH = _REPO_ROOT / "flake.nix"
 _LEFTHOOK_INSTALL_SCRIPT_PATH = _REPO_ROOT / ".lefthook" / "install.sh"
+_WORKTREE_SETUP_SCRIPT_PATH = _REPO_ROOT / ".lefthook" / "setup-worktree.sh"
+_ENVRC_PATH = _REPO_ROOT / ".envrc"
+_LITE_WORKFLOW_PATH = _REPO_ROOT / ".takt" / "workflows" / "lite.yaml"
 _LEFTHOOK_CONFIG_PATH = _REPO_ROOT / "lefthook.yml"
 _DEVELOPMENT_DOC_PATH = _REPO_ROOT / "docs" / "development.md"
 _TAKT_OPERATIONS_DOC_PATH = _REPO_ROOT / "docs" / "takt-operations.md"
@@ -50,6 +53,17 @@ def _create_fake_executable(path: Path, content: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+def _run_worktree_setup(workdir: Path, path: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_WORKTREE_SETUP_SCRIPT_PATH), *args],
+        cwd=workdir,
+        env={**os.environ, "PATH": path},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def _configure_git_identity(repo: Path) -> None:
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
@@ -79,6 +93,18 @@ def _create_linked_worktree_with_hook_files(tmp_path: Path) -> Path:
     )
     (worktree / "lefthook.yml").write_text(_read(_LEFTHOOK_CONFIG_PATH), encoding="utf-8")
     return worktree
+
+
+def _create_parent_checkout_with_hook_files(tmp_path: Path) -> Path:
+    parent = tmp_path / "parent-checkout"
+    subprocess.run(["git", "init", str(parent)], check=True, capture_output=True, text=True)
+    (parent / ".lefthook").mkdir()
+    (parent / ".lefthook" / "install.sh").write_text(
+        _read(_LEFTHOOK_INSTALL_SCRIPT_PATH),
+        encoding="utf-8",
+    )
+    (parent / "lefthook.yml").write_text(_read(_LEFTHOOK_CONFIG_PATH), encoding="utf-8")
+    return parent
 
 
 def _commit_file(repo: Path, name: str = "tracked.txt", *, verify: bool = True) -> subprocess.CompletedProcess[str]:
@@ -527,6 +553,191 @@ def test_lefthook_install_script_fails_when_force_install_fails(tmp_path: Path) 
     assert (
         "error: lefthook install failed; run 'nix develop --command bash .lefthook/install.sh' after fixing the error."
     ) in result.stderr
+
+
+def test_worktree_setup_uses_direnv_allow_and_exec_with_forwarded_arguments(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "direnv-calls.txt"
+    _create_fake_executable(
+        bin_dir / "direnv",
+        f"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{call_log}"
+if [ "$1" = "allow" ]; then
+  exit 0
+fi
+shift 2
+exec "$@"
+""",
+    )
+
+    result = _run_worktree_setup(
+        tmp_path,
+        f"{bin_dir}:/usr/bin:/bin",
+        "sh",
+        "-c",
+        "printf forwarded",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "forwarded"
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        f"allow {tmp_path}",
+        f"exec {tmp_path} sh -c printf forwarded",
+    ]
+
+
+def test_worktree_setup_resolves_checkout_root_from_subdirectory(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    nested = tmp_path / "nested" / "directory"
+    nested.mkdir(parents=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "direnv-calls.txt"
+    _create_fake_executable(
+        bin_dir / "direnv",
+        f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "{call_log}"\nexit 0\n',
+    )
+
+    result = _run_worktree_setup(nested, f"{bin_dir}:/usr/bin:/bin")
+
+    assert result.returncode == 0
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        f"allow {tmp_path}",
+        f"exec {tmp_path} bash {tmp_path}/.lefthook/install.sh",
+    ]
+
+
+def test_worktree_setup_falls_back_to_nix_and_runs_default_install(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / ".lefthook").mkdir()
+    install_log = tmp_path / "install-ran.txt"
+    _create_fake_executable(
+        tmp_path / ".lefthook" / "install.sh",
+        f'#!/usr/bin/env bash\nprintf installed > "{install_log}"\n',
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    nix_log = tmp_path / "nix-call.txt"
+    _create_fake_executable(
+        bin_dir / "nix",
+        f"""#!/usr/bin/env bash
+printf '%s\n' "$*" > "{nix_log}"
+shift 3
+exec "$@"
+""",
+    )
+
+    result = _run_worktree_setup(tmp_path, f"{bin_dir}:/usr/bin:/bin")
+
+    assert result.returncode == 0
+    assert nix_log.read_text(encoding="utf-8") == (
+        f"develop {tmp_path} --command bash {tmp_path}/.lefthook/install.sh\n"
+    )
+    assert install_log.read_text(encoding="utf-8") == "installed"
+
+
+def _assert_setup_supplies_dev_shell_tools_and_commit_hook(checkout: Path, tmp_path: Path) -> None:
+    _configure_git_identity(checkout)
+    hook_log = tmp_path / f"{checkout.name}-hook-ran.txt"
+    (checkout / "flake.nix").write_text(_read(_FLAKE_PATH), encoding="utf-8")
+    (checkout / "flake.lock").write_text(_read(_REPO_ROOT / "flake.lock"), encoding="utf-8")
+    (checkout / "lefthook.yml").write_text(
+        f"pre-commit:\n  commands:\n    prove-hook-runs:\n      run: printf ran > {hook_log}\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=checkout, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "prepare dev shell fixture"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    setup_result = _run_worktree_setup(
+        checkout,
+        "/nix/var/nix/profiles/default/bin:/usr/bin:/bin",
+        "sh",
+        "-c",
+        "command -v lefthook && command -v uv",
+    )
+    commit_result = _commit_file(checkout)
+
+    assert setup_result.returncode == 0
+    tool_paths = setup_result.stdout.splitlines()[-2:]
+    assert all(path.startswith("/nix/store/") for path in tool_paths)
+    assert tool_paths[0].endswith("/bin/lefthook")
+    assert tool_paths[1].endswith("/bin/uv")
+    assert commit_result.returncode == 0
+    assert hook_log.read_text(encoding="utf-8") == "ran"
+
+
+def test_parent_checkout_setup_supplies_dev_shell_tools_and_commit_hook(tmp_path: Path) -> None:
+    parent = _create_parent_checkout_with_hook_files(tmp_path)
+
+    _assert_setup_supplies_dev_shell_tools_and_commit_hook(parent, tmp_path)
+
+
+def test_linked_worktree_setup_supplies_dev_shell_tools_and_commit_hook(tmp_path: Path) -> None:
+    worktree = _create_linked_worktree_with_hook_files(tmp_path)
+
+    _assert_setup_supplies_dev_shell_tools_and_commit_hook(worktree, tmp_path)
+
+
+def test_worktree_setup_propagates_direnv_allow_failure(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_fake_executable(bin_dir / "direnv", "#!/usr/bin/env bash\nexit 23\n")
+
+    result = _run_worktree_setup(tmp_path, f"{bin_dir}:/usr/bin:/bin", "sh", "-c", "exit 0")
+
+    assert result.returncode == 23
+
+
+def test_worktree_setup_fails_outside_git_checkout(tmp_path: Path) -> None:
+    result = _run_worktree_setup(tmp_path, "/usr/bin:/bin")
+
+    assert result.returncode == 1
+    assert result.stderr == "error: run this script from a Git checkout or worktree.\n"
+
+
+def test_worktree_setup_fails_when_no_environment_loader_is_available(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    result = _run_worktree_setup(tmp_path, "/usr/bin:/bin")
+
+    assert result.returncode == 1
+    assert result.stderr == "error: neither direnv nor nix is available in PATH.\n"
+
+
+def test_worktree_environment_contract_is_wired_into_lite_steps_and_docs() -> None:
+    assert _read(_ENVRC_PATH) == "use flake\n"
+    workflow = _read(_LITE_WORKFLOW_PATH)
+    setup_instruction = "最初に `bash .lefthook/setup-worktree.sh` を実行"
+    wrapped_command_instruction = "`bash .lefthook/setup-worktree.sh <command> [args...]` 経由"
+    assert workflow.count(setup_instruction) == 3
+    assert workflow.count(wrapped_command_instruction) == 3
+
+    for document in (_DEVELOPMENT_DOC_PATH, _TAKT_OPERATIONS_DOC_PATH, _CLAUDE_PATH):
+        content = _read(document)
+        assert "bash .lefthook/setup-worktree.sh" in content
+        assert ".envrc" in content
+
+
+def test_direnv_cache_is_gitignored() -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", ".direnv/cache"],
+        cwd=_REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ".direnv/cache\n"
 
 
 def test_lefthook_config_documents_install_script_entrypoint() -> None:


### PR DESCRIPTION
## Summary

## 概要

worktree（takt 自動生成 / 手動 `git worktree add`）で開発する際、`nix develop` を実行しない限り devShell が提供するツール（lefthook / uv / node 等）が揃わず、lefthook hooks の再生成も行われない。現状は docs の手順（「worktree でも nix develop に入れ」）だけが頼りで、人間・agent が忘れると素通りできてしまう。`.envrc`（direnv）の導入とセットアップ自動化で、worktree でも環境が確実に揃う状態にする。

## 背景・目的

- `flake.nix` の shellHook が `lefthook` を PATH に供給し `.lefthook/install.sh` で hook を再生成する設計のため、`nix develop`（または direnv）入室が環境セットアップの唯一の入口になっている
- しかしルートに `.envrc` が存在せず direnv 自動入室は未整備。takt の `.takt/config.yaml` にも worktree 作成後に環境を通すフックは無い
- 結果として、worktree では lefthook ゲート（CHANGELOG / テスト差分 / 型注釈）が効かないまま commit / push できたり、takt agent がテスト・lint コマンドを実行できず失敗したりする

## 参照資料

- flake.nix
- .lefthook/install.sh
- docs/development.md
- docs/takt-operations.md
- CLAUDE.md
- .takt/config.yaml
- .takt/workflows/

## 影響ファイル

- **新規**: .envrc（`use flake`）
- **新規**: worktree セットアップスクリプト（配置は plan step で確定。ルート直下 `scripts/` は設けない規約に留意）
- **変更**: .gitignore（`.direnv/` 追加）
- **変更**: .takt/ 配下の workflow instructions（セットアップ実行の組み込み。具体的な組み込み点は plan step で確定）
- **変更**: docs/development.md
- **変更**: docs/takt-operations.md
- **変更**: CLAUDE.md（worktree 手順の更新）

**兄弟入口・貫通先**:
- 親 checkout と worktree の両方が入口（`.envrc` は checkout されるため両方に効く。両経路で検証する）
- CI（`.github/workflows/ci.yml`）は `nix develop --command` を明示実行しており変更不要（direnv 非依存のまま）
- グローバル skill（takt-issue / issue-direct）と takt CLI 本体は変更不要（本 issue はリポジトリ内で閉じる。スコープ外参照）

## 要件

1. ルートに `.envrc`（`use flake`）を追加する → 親 checkout / 新規 worktree で `direnv allow` すると `command -v lefthook && command -v uv` が devShell 由来で解決し、shellHook により lefthook hook wrapper が再生成される
2. worktree セットアップスクリプトを追加する → 新規 worktree で 1 コマンド実行すると（direnv 利用時は allow 含め）`.lefthook/install.sh` の hook 再生成まで完了し、その worktree での `git commit` / `git push` で lefthook ゲートが発火する
3. `.gitignore` に `.direnv/` を追加する → direnv キャッシュディレクトリが `git status` に untracked として現れない
4. `.takt/` の workflow instructions にセットアップ実行の指示を組み込む → takt 生成 worktree で agent が step 開始時に環境を通し、`uv run pytest` / `uv run ruff check .` を実行できる
5. docs/development.md・docs/takt-operations.md・CLAUDE.md の worktree 手順を新フロー（.envrc / セットアップスクリプト前提）に更新する → 記載手順どおりに操作した新規 worktree で環境が揃うことがドキュメントと一致する

## スコープ外

- takt CLI 本体への worktree 作成後フック機能の追加（別リポジトリの作業。必要なら別 issue）
- グローバル skill（takt-issue / issue-direct 等、dotfiles 管理）の手順更新（dotfiles リポジトリで対応）
- 下流チャンネルリポジトリへの展開（本リポジトリの開発環境のみが対象）

## 受け入れ基準

- [ ] `uv run ruff check .` が exit 0 になる
- [ ] `uv run ruff format --check .` が exit 0 になる
- [ ] `uv run pytest` が成功する
- [ ] 新規 worktree でセットアップ実行後、`command -v lefthook` が解決し `git commit` で lefthook hook が発火する

## 実装方針（takt）

- workflow: lite
- 理由: src/ のコード変更を伴わない開発環境整備（設定ファイル追加・docs 更新・takt instructions 調整）で、既存 CI と手動検証で挙動確認できるため

## Execution Report

Workflow `lite` completed successfully.

Closes #1935