### PR TITLE
[#1955] issue-1955-1936-02-extensions

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
+      - "flake.nix"
+      - "flake.lock"
   pull_request:
     paths:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
+      - "flake.nix"
+      - "flake.lock"
 
 jobs:
   check:
@@ -19,33 +23,26 @@ jobs:
         working-directory: extensions/suno-helper
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.12.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: extensions/suno-helper/pnpm-lock.yaml
+      - uses: cachix/install-nix-action@v30
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: nix develop .#extensions --command pnpm install --frozen-lockfile
       - parallel:
           - name: Lint
-            run: pnpm lint
+            run: nix develop .#extensions --command pnpm lint
           - name: Format check
-            run: pnpm format:check
+            run: nix develop .#extensions --command pnpm format:check
           - name: Type check
-            run: pnpm compile
+            run: nix develop .#extensions --command pnpm compile
           - name: Unit tests (Vitest)
-            run: pnpm test
+            run: nix develop .#extensions --command pnpm test
       - parallel:
           - name: Build
-            run: pnpm build
+            run: nix develop .#extensions --command pnpm build
           - name: Install Playwright browser
-            run: pnpm exec playwright install --with-deps chromium
+            run: nix develop .#extensions --command pnpm exec playwright install --with-deps chromium
       - name: Verify generated manifest permissions (least-privilege)
         run: |
-          node --input-type=module -e '
+          nix develop .#extensions --command node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const manifest = JSON.parse(
               readFileSync(".output/chrome-mv3/manifest.json", "utf8"),
@@ -61,7 +58,7 @@ jobs:
             }
           '
       - name: E2E tests (Playwright)
-        run: pnpm test:e2e
+        run: nix develop .#extensions --command pnpm test:e2e
 
   distrokid-helper:
     runs-on: ubuntu-latest
@@ -70,33 +67,26 @@ jobs:
         working-directory: extensions/distrokid-helper
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.12.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: extensions/distrokid-helper/pnpm-lock.yaml
+      - uses: cachix/install-nix-action@v30
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: nix develop .#extensions --command pnpm install --frozen-lockfile
       - parallel:
           - name: Lint
-            run: pnpm lint
+            run: nix develop .#extensions --command pnpm lint
           - name: Format check
-            run: pnpm format:check
+            run: nix develop .#extensions --command pnpm format:check
           - name: Typecheck
-            run: pnpm compile
+            run: nix develop .#extensions --command pnpm compile
           - name: Unit tests (Vitest)
-            run: pnpm test
+            run: nix develop .#extensions --command pnpm test
       - parallel:
           - name: Build
-            run: pnpm build
+            run: nix develop .#extensions --command pnpm build
           - name: Install Playwright browser
-            run: pnpm exec playwright install --with-deps chromium
+            run: nix develop .#extensions --command pnpm exec playwright install --with-deps chromium
       - name: Verify generated manifest permissions (least-privilege)
         run: |
-          node --input-type=module -e '
+          nix develop .#extensions --command node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const manifest = JSON.parse(
               readFileSync(".output/chrome-mv3/manifest.json", "utf8"),
@@ -138,4 +128,4 @@ jobs:
             }
           '
       - name: E2E (Playwright)
-        run: pnpm test:e2e
+        run: nix develop .#extensions --command pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build/
 
 # Node / extensions (WXT)
 node_modules/
+.pnpm-store/
 coverage/
 extensions/*/dist/
 extensions/*/.wxt/

--- a/.pnpm-store/v10/projects/41fbf215a2752239847ae456a0ea751d
+++ b/.pnpm-store/v10/projects/41fbf215a2752239847ae456a0ea751d
@@ -1,1 +1,0 @@
-../../../extensions/suno-helper

--- a/.pnpm-store/v10/projects/5574ae06a8ea7d76778e312097ce22db
+++ b/.pnpm-store/v10/projects/5574ae06a8ea7d76778e312097ce22db
@@ -1,1 +1,0 @@
-../../../extensions/distrokid-helper

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -19,22 +19,36 @@ _CI_LINT_PARALLEL_STEPS = {
 }
 
 _SUNO_FAST_PARALLEL_STEPS = {
-    "Lint": "pnpm lint",
-    "Format check": "pnpm format:check",
-    "Type check": "pnpm compile",
-    "Unit tests (Vitest)": "pnpm test",
+    "Lint": "nix develop .#extensions --command pnpm lint",
+    "Format check": "nix develop .#extensions --command pnpm format:check",
+    "Type check": "nix develop .#extensions --command pnpm compile",
+    "Unit tests (Vitest)": "nix develop .#extensions --command pnpm test",
 }
 _SUNO_BUILD_PARALLEL_STEPS = {
-    "Build": "pnpm build",
-    "Install Playwright browser": "pnpm exec playwright install --with-deps chromium",
+    "Build": "nix develop .#extensions --command pnpm build",
+    "Install Playwright browser": (
+        "nix develop .#extensions --command pnpm exec playwright install --with-deps chromium"
+    ),
 }
 _DISTROKID_FAST_PARALLEL_STEPS = {
-    "Lint": "pnpm lint",
-    "Format check": "pnpm format:check",
-    "Typecheck": "pnpm compile",
-    "Unit tests (Vitest)": "pnpm test",
+    "Lint": "nix develop .#extensions --command pnpm lint",
+    "Format check": "nix develop .#extensions --command pnpm format:check",
+    "Typecheck": "nix develop .#extensions --command pnpm compile",
+    "Unit tests (Vitest)": "nix develop .#extensions --command pnpm test",
 }
 _DISTROKID_BUILD_PARALLEL_STEPS = _SUNO_BUILD_PARALLEL_STEPS
+_EXTENSIONS_JOB_CONTRACTS = {
+    "check": {
+        "working_directory": "extensions/suno-helper",
+        "e2e_step": "E2E tests (Playwright)",
+    },
+    "distrokid-helper": {
+        "working_directory": "extensions/distrokid-helper",
+        "e2e_step": "E2E (Playwright)",
+    },
+}
+_NIX_EXTENSIONS_INSTALL_COMMAND = "nix develop .#extensions --command pnpm install --frozen-lockfile"
+_NIX_EXTENSIONS_E2E_COMMAND = "nix develop .#extensions --command pnpm test:e2e"
 
 _RELEASE_BUILD_PARALLEL_STEPS = {
     "Build and zip suno-helper": ("extensions/suno-helper", "pnpm zip"),
@@ -159,7 +173,42 @@ def test_extensions_pull_request_trigger_keeps_path_filter() -> None:
     pull_request = _on_section(workflow).get("pull_request")
 
     assert isinstance(pull_request, dict), "pull_request トリガーが存在しない"
-    assert pull_request.get("paths") == ["extensions/**", ".github/workflows/extensions.yml"]
+    expected_paths = ["extensions/**", ".github/workflows/extensions.yml", "flake.nix", "flake.lock"]
+    assert pull_request.get("paths") == expected_paths
+    assert _on_section(workflow).get("push", {}).get("paths") == expected_paths
+
+
+@pytest.mark.parametrize("job_name", ["check", "distrokid-helper"])
+def test_extensions_jobs_use_only_the_nix_extensions_toolchain(job_name: str) -> None:
+    """Given Extensions CI, When commands run, Then both jobs use the Nix extensions shell."""
+    steps = _job_steps(_load_workflow(_EXTENSIONS_WORKFLOW_PATH), job_name)
+
+    assert _top_level_step_index_with_uses(steps, "actions/checkout@v4") < _top_level_step_index_with_uses(
+        steps, "cachix/install-nix-action@v30"
+    )
+    uses = {step.get("uses") for step in steps}
+    assert "pnpm/action-setup@v4" not in uses
+    assert "actions/setup-node@v4" not in uses
+    run_steps = [step for step in steps if "run" in step]
+    run_steps.extend(child for group in _parallel_groups(steps) for child in group)
+    assert run_steps
+    assert all(str(step.get("run", "")).startswith("nix develop .#extensions --command ") for step in run_steps)
+
+
+@pytest.mark.parametrize("job_name", ["check", "distrokid-helper"])
+def test_extensions_jobs_preserve_working_directory_install_and_e2e_contract(job_name: str) -> None:
+    """Given Extensions CI, When Nix supplies its tools, Then each job keeps its check contract."""
+    workflow = _load_workflow(_EXTENSIONS_WORKFLOW_PATH)
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"{job_name} job が存在しない"
+    contract = _EXTENSIONS_JOB_CONTRACTS[job_name]
+
+    assert job.get("defaults") == {"run": {"working-directory": contract["working_directory"]}}
+    steps = _job_steps(workflow, job_name)
+    assert _top_level_step(steps, "Install dependencies").get("run") == _NIX_EXTENSIONS_INSTALL_COMMAND
+    assert _top_level_step(steps, contract["e2e_step"]).get("run") == _NIX_EXTENSIONS_E2E_COMMAND
 
 
 def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:

--- a/tests/test_extension_package_manager_contract.py
+++ b/tests/test_extension_package_manager_contract.py
@@ -84,12 +84,15 @@ def test_both_extensions_preserve_build_approval() -> None:
         assert _workspace_settings(name)["allowBuilds"] == {"esbuild": True, "spawn-sync": False}
 
 
-def test_ci_and_release_workflows_use_the_pinned_pnpm() -> None:
-    for path in (".github/workflows/extensions.yml", ".github/workflows/release-extensions.yml"):
-        versions = _pnpm_setup_versions(path)
+def test_extensions_ci_uses_the_nix_pnpm_instead_of_a_setup_action() -> None:
+    assert _pnpm_setup_versions(".github/workflows/extensions.yml") == []
 
-        assert versions
-        assert versions == [_WORKFLOW_PNPM] * len(versions)
+
+def test_release_workflow_uses_the_pinned_pnpm_setup_action() -> None:
+    versions = _pnpm_setup_versions(".github/workflows/release-extensions.yml")
+
+    assert versions
+    assert versions == [_WORKFLOW_PNPM] * len(versions)
 
 
 def test_shared_docs_precede_commands_with_the_pinned_contract() -> None:

--- a/tests/test_extension_package_manager_contract.py
+++ b/tests/test_extension_package_manager_contract.py
@@ -88,6 +88,11 @@ def test_extensions_ci_uses_the_nix_pnpm_instead_of_a_setup_action() -> None:
     assert _pnpm_setup_versions(".github/workflows/extensions.yml") == []
 
 
+def test_local_pnpm_store_is_ignored_and_has_no_tracked_project_metadata() -> None:
+    assert ".pnpm-store/" in _read(".gitignore").splitlines()
+    assert not list((_REPO_ROOT / ".pnpm-store" / "v10" / "projects").glob("*"))
+
+
 def test_release_workflow_uses_the_pinned_pnpm_setup_action() -> None:
     versions = _pnpm_setup_versions(".github/workflows/release-extensions.yml")
 


### PR DESCRIPTION
## Summary

## 親 issue

#1936

## 概要

Extensions PR check の既存検査内容を維持したまま、Node.js / pnpm の供給と実行を Nix extensions shell に統一する。

## 参照資料

- `.github/workflows/extensions.yml`
- `.github/workflows/ci.yml`
- `tests/test_actions_parallel_workflows.py`

## 影響ファイル

- **変更**: `.github/workflows/extensions.yml`
- **変更**: `tests/test_actions_parallel_workflows.py`
- **変更**: `.gitignore`
- **削除**: `.pnpm-store/v10/projects/*`（#1958 で誤って追跡されたローカル store metadata）

**兄弟入口・貫通先**:
- Extensions PR check の各並列 group を同じ `devShells.extensions` 入口へ変更する。
- Release Extensions は変更しない（別 sibling issue）。

## 要件

1. workflow を実行する → `pnpm/action-setup` と `actions/setup-node` を使わず `cachix/install-nix-action@v30` で Nix が導入される。
2. Node / pnpm コマンドを確認する → すべて `nix develop .#extensions --command` 経由で実行される。
3. push / pull_request paths を確認する → `flake.nix` と `flake.lock` の変更で workflow が起動する。
4. PR check を実行する → lint、format、compile、unit、build、manifest 最小権限検証が既存の並列構造と working-directory を維持して green になる。
5. E2E check を実行する → Playwright の `--with-deps chromium` が runner 側で維持され green になる。
6. ローカル pnpm store を利用する → `.pnpm-store/` が Git 管理対象にならず、#1958 で混入した project symlink が main から削除される。

## スコープ外

- Release Extensions、flake/packageManager、文書は変更しない。
- 並列構造の再設計と CI キャッシュ最適化は対象外。

## 依存

- #1953

## 実装方針（takt）

- workflow: improve
- 理由: 既存 check の検査契約を維持し、ツールチェーン供給経路だけを改善するため。

## Execution Report

Workflow `improve` completed successfully.

Closes #1955