### PR TITLE
[#1695] issue-1695-audit-utils-youtube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(api)`: playlist / benchmark / analytics / comments-reply / discover-competitors の YouTube API 呼び出しで、429・5xx・quota 系 403・network error を jitter 付き指数 backoff で最大 3 回試行し、恒久 4xx は即座にドメイン例外へ変換する共通 retry 境界を追加した（#1695）。
+
 - `fix(suno-helper)`: Download all メニューの短時間 auto-close レースに対し、More クリック直後から探索を開始し、検出失敗時は最大 3 回再クリックしてダウンロードを継続できるようにした（#1926）。
 - `fix(suno-helper)`: 拡張更新時に既存の Suno タブを自動リロードし、旧 content script の orphaned context を残さず新しい bundle を再注入するようにした（#1718）。
 - `fix(suno-helper)`: feed/v3 の active poll が `ids` フィルタ無効化後も cursor ページネーションを追跡し、最新ページ外の保存済み clip を完了確認できるようにした（#1929）。

--- a/src/youtube_automation/scripts/benchmark_collector.py
+++ b/src/youtube_automation/scripts/benchmark_collector.py
@@ -28,8 +28,6 @@ from collections import Counter
 from datetime import date, datetime
 from pathlib import Path
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.benchmark_analyzer import (
     compute_daily_views,
     compute_engagement_rate,
@@ -41,6 +39,7 @@ from youtube_automation.utils.config import channel_dir as _channel_dir
 from youtube_automation.utils.config import load_config
 from youtube_automation.utils.exceptions import ConfigError, YouTubeAPIError
 from youtube_automation.utils.profile import section
+from youtube_automation.utils.retry import execute_with_retry
 from youtube_automation.utils.skill_config import load_skill_config
 from youtube_automation.utils.youtube_service import get_youtube
 
@@ -133,16 +132,13 @@ class BenchmarkCollector:
             batch = channel_ids[i : i + _CHANNELS_BATCH_SIZE]
             with section("benchmark.channels_list", batch_size=len(batch)):
                 try:
-                    resp = (
-                        self.youtube.channels()
-                        .list(
-                            part="snippet,statistics,contentDetails",
-                            id=",".join(batch),
-                        )
-                        .execute()
+                    request = self.youtube.channels().list(
+                        part="snippet,statistics,contentDetails",
+                        id=",".join(batch),
                     )
-                except HttpError as e:
-                    raise YouTubeAPIError.from_http_error(e, f"benchmark.channels_list (id={','.join(batch)})") from e
+                    resp = execute_with_retry(request, f"benchmark.channels_list (id={','.join(batch)})")
+                except YouTubeAPIError:
+                    raise
             for item in resp.get("items", []):
                 items_by_id[item["id"]] = item
         return items_by_id
@@ -193,20 +189,15 @@ class BenchmarkCollector:
         while remaining > 0:
             with section("benchmark.playlist_items", page_size=min(50, remaining)):
                 try:
-                    playlist_resp = (
-                        self.youtube.playlistItems()
-                        .list(
-                            part="contentDetails",
-                            playlistId=uploads_playlist_id,
-                            maxResults=min(50, remaining),
-                            pageToken=page_token,
-                        )
-                        .execute()
+                    request = self.youtube.playlistItems().list(
+                        part="contentDetails",
+                        playlistId=uploads_playlist_id,
+                        maxResults=min(50, remaining),
+                        pageToken=page_token,
                     )
-                except HttpError as e:
-                    raise YouTubeAPIError.from_http_error(
-                        e, f"benchmark.playlist_items ({channel_info.get('name', channel_id)})"
-                    ) from e
+                    playlist_resp = execute_with_retry(request, "benchmark.playlist_items")
+                except YouTubeAPIError:
+                    raise
             batch_ids = [item["contentDetails"]["videoId"] for item in playlist_resp.get("items", [])]
             video_ids.extend(batch_ids)
             page_token = playlist_resp.get("nextPageToken")
@@ -232,18 +223,13 @@ class BenchmarkCollector:
             batch = video_ids[i : i + 50]
             with section("benchmark.videos_list", batch_size=len(batch)):
                 try:
-                    videos_resp = (
-                        self.youtube.videos()
-                        .list(
-                            part="snippet,statistics,contentDetails",
-                            id=",".join(batch),
-                        )
-                        .execute()
+                    request = self.youtube.videos().list(
+                        part="snippet,statistics,contentDetails",
+                        id=",".join(batch),
                     )
-                except HttpError as e:
-                    raise YouTubeAPIError.from_http_error(
-                        e, f"benchmark.videos_list ({channel_info.get('name', channel_id)})"
-                    ) from e
+                    videos_resp = execute_with_retry(request, "benchmark.videos_list")
+                except YouTubeAPIError:
+                    raise
 
             for video in videos_resp.get("items", []):
                 snippet = video["snippet"]
@@ -390,16 +376,13 @@ class BenchmarkCollector:
         playlists_raw = []
         page_token = None
         while True:
-            resp = (
-                self.youtube.playlists()
-                .list(
-                    part="snippet,contentDetails",
-                    channelId=channel_id,
-                    maxResults=50,
-                    pageToken=page_token,
-                )
-                .execute()
+            request = self.youtube.playlists().list(
+                part="snippet,contentDetails",
+                channelId=channel_id,
+                maxResults=50,
+                pageToken=page_token,
             )
+            resp = execute_with_retry(request, "benchmark.playlists_list")
             playlists_raw.extend(resp.get("items", []))
             page_token = resp.get("nextPageToken")
             if not page_token:
@@ -418,16 +401,13 @@ class BenchmarkCollector:
             items = []
             item_page_token = None
             while True:
-                items_resp = (
-                    self.youtube.playlistItems()
-                    .list(
-                        part="snippet,contentDetails",
-                        playlistId=playlist_id,
-                        maxResults=50,
-                        pageToken=item_page_token,
-                    )
-                    .execute()
+                request = self.youtube.playlistItems().list(
+                    part="snippet,contentDetails",
+                    playlistId=playlist_id,
+                    maxResults=50,
+                    pageToken=item_page_token,
                 )
+                items_resp = execute_with_retry(request, "benchmark.playlist_items")
                 for item in items_resp.get("items", []):
                     item_snip = item["snippet"]
                     video_id = item["contentDetails"]["videoId"]
@@ -459,14 +439,11 @@ class BenchmarkCollector:
         video_id_list = list(all_video_ids)
         for i in range(0, len(video_id_list), 50):
             batch = video_id_list[i : i + 50]
-            videos_resp = (
-                self.youtube.videos()
-                .list(
-                    part="statistics,contentDetails",
-                    id=",".join(batch),
-                )
-                .execute()
+            request = self.youtube.videos().list(
+                part="statistics,contentDetails",
+                id=",".join(batch),
             )
+            videos_resp = execute_with_retry(request, "benchmark.videos_list")
             for v in videos_resp.get("items", []):
                 stats = v.get("statistics", {})
                 content = v.get("contentDetails", {})

--- a/src/youtube_automation/scripts/playlist_manager.py
+++ b/src/youtube_automation/scripts/playlist_manager.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import channel_dir, load_config, reset
+from youtube_automation.utils.retry import execute_with_retry
 from youtube_automation.utils.youtube_service import get_youtube
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,8 @@ class PlaylistManager:
                 "snippet": {"title": title, "description": description},
                 "status": {"privacyStatus": privacy_status},
             }
-            response = youtube.playlists().insert(part="snippet,status", body=body).execute()
+            request = youtube.playlists().insert(part="snippet,status", body=body)
+            response = execute_with_retry(request, "playlists.insert failed")
             playlist_id = response["id"]
             playlist_url = f"https://www.youtube.com/playlist?list={playlist_id}"
             logger.info(f"✅ Playlist created: {playlist_id} ({playlist_url})")
@@ -89,7 +91,8 @@ class PlaylistManager:
             }
             if position is not None:
                 snippet["position"] = position
-            youtube.playlistItems().insert(part="snippet", body={"snippet": snippet}).execute()
+            request = youtube.playlistItems().insert(part="snippet", body={"snippet": snippet})
+            execute_with_retry(request, "playlistItems.insert failed")
             logger.info(f"✅ Video added to playlist ({where})")
             return True
         except Exception as e:
@@ -209,7 +212,7 @@ class PlaylistManager:
         try:
             request = youtube.playlistItems().list(playlistId=playlist_id, part="contentDetails", maxResults=50)
             while request:
-                response = request.execute()
+                response = execute_with_retry(request, "playlistItems.list failed")
                 for item in response.get("items", []):
                     video_ids.add(item["contentDetails"]["videoId"])
                 request = youtube.playlistItems().list_next(request, response)
@@ -366,16 +369,13 @@ class PlaylistManager:
             removed = 0
             page_token = None
             while True:
-                resp = (
-                    youtube.playlistItems()
-                    .list(
-                        part="snippet",
-                        playlistId=playlist_id,
-                        maxResults=50,
-                        pageToken=page_token,
-                    )
-                    .execute()
+                request = youtube.playlistItems().list(
+                    part="snippet",
+                    playlistId=playlist_id,
+                    maxResults=50,
+                    pageToken=page_token,
                 )
+                resp = execute_with_retry(request, "playlistItems.list failed")
 
                 for item in resp.get("items", []):
                     title = item["snippet"].get("title", "")
@@ -385,7 +385,8 @@ class PlaylistManager:
                         if dry_run:
                             print(f"  [DRY-RUN] {key}: 除去予定 {video_id} ({title})")
                         else:
-                            youtube.playlistItems().delete(id=item_id).execute()
+                            request = youtube.playlistItems().delete(id=item_id)
+                            execute_with_retry(request, "playlistItems.delete failed")
                             logger.info(f"  {key}: 除去 {video_id} ({title})")
                         removed += 1
 

--- a/src/youtube_automation/utils/analytics_collector.py
+++ b/src/youtube_automation/utils/analytics_collector.py
@@ -30,6 +30,7 @@ from youtube_automation.utils.ctr_analytics import CTRAnalyticsMixin
 from youtube_automation.utils.exceptions import YouTubeAPIError
 from youtube_automation.utils.reporting_analytics import ReportingAPIMixin
 from youtube_automation.utils.retention_analytics import RetentionAnalyticsMixin
+from youtube_automation.utils.retry import execute_with_retry
 from youtube_automation.utils.strategic_analytics import StrategicAnalyticsMixin
 from youtube_automation.utils.traffic_source_analytics import TrafficSourceMixin
 from youtube_automation.utils.video_analytics import VideoAnalyticsMixin
@@ -75,7 +76,8 @@ class YouTubeAnalyticsCollector(
     def _get_channel_id(self) -> str:
         """チャンネルID取得"""
         try:
-            response = self.youtube_service.channels().list(part="id,snippet", mine=True).execute()
+            request = self.youtube_service.channels().list(part="id,snippet", mine=True)
+            response = execute_with_retry(request, "analytics channels.list failed")
 
             if response["items"]:
                 channel = response["items"][0]

--- a/src/youtube_automation/utils/audience_analytics.py
+++ b/src/youtube_automation/utils/audience_analytics.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict
 
-from googleapiclient.errors import HttpError
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -37,18 +38,15 @@ class AudienceAnalyticsMixin:
         logger.info("デバイス別分析実行中...")
 
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration",
-                    dimensions="deviceType",
-                    sort="-views",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration",
+                dimensions="deviceType",
+                sort="-views",
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             devices = {}
             if "rows" in response:
@@ -71,7 +69,7 @@ class AudienceAnalyticsMixin:
                 "total_views": total_views,
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（デバイス分析）: {e}")
             return {"devices": {}, "total_views": 0, "error": str(e)}
         except Exception as e:
@@ -96,19 +94,16 @@ class AudienceAnalyticsMixin:
         logger.info("地域別分析実行中...")
 
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained",
-                    dimensions="country",
-                    sort="-views",
-                    maxResults=max_countries,
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained",
+                dimensions="country",
+                sort="-views",
+                maxResults=max_countries,
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             countries = {}
             if "rows" in response:
@@ -132,7 +127,7 @@ class AudienceAnalyticsMixin:
                 "total_views": total_views,
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（地域分析）: {e}")
             return {"countries": {}, "total_views": 0, "error": str(e)}
         except Exception as e:

--- a/src/youtube_automation/utils/channel_analytics.py
+++ b/src/youtube_automation/utils/channel_analytics.py
@@ -10,9 +10,9 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -64,17 +64,14 @@ class ChannelAnalyticsMixin:
 
         try:
             # 基本メトリクス
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,likes,dislikes,comments,shares,averageViewPercentage,cardImpressions,cardClicks,cardClickRate",
-                    dimensions="day",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,likes,dislikes,comments,shares,averageViewPercentage,cardImpressions,cardClicks,cardClickRate",
+                dimensions="day",
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             # Note: サムネイル CTR (impressions/impressionClickThroughRate) は
             # チャンネルレベル (dimensions=day) では取得不可。
@@ -91,7 +88,7 @@ class ChannelAnalyticsMixin:
                 "summary": self._calculate_summary_stats(response),
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（チャンネル分析）: {e}")
             return {"error": str(e)}
         except Exception as e:

--- a/src/youtube_automation/utils/comments/fetcher.py
+++ b/src/youtube_automation/utils/comments/fetcher.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterator
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 # YouTube API が commentThreads.list の replies.comments に含める最大件数
 _INLINE_REPLY_LIMIT = 5
@@ -85,19 +84,16 @@ def _fetch_replies_paginated(
     page_token: str | None = None
     while True:
         try:
-            response = (
-                youtube.comments()
-                .list(
-                    part="snippet",
-                    parentId=top_comment_id,
-                    maxResults=100,
-                    pageToken=page_token,
-                    textFormat="plainText",
-                )
-                .execute()
+            request = youtube.comments().list(
+                part="snippet",
+                parentId=top_comment_id,
+                maxResults=100,
+                pageToken=page_token,
+                textFormat="plainText",
             )
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, f"comments.list 失敗 (parentId={top_comment_id})") from e
+            response = execute_with_retry(request, f"comments.list failed (parentId={top_comment_id})")
+        except YouTubeAPIError:
+            raise
 
         for item in response.get("items", []):
             if _after_since(item["snippet"].get("publishedAt", ""), since):
@@ -205,19 +201,16 @@ def fetch_comments(
     yielded = 0
     while yielded < max_results:
         try:
-            response = (
-                youtube.commentThreads()
-                .list(
-                    part="snippet,replies",
-                    videoId=video_id,
-                    maxResults=min(page_size, max_results - yielded),
-                    pageToken=next_page_token,
-                    textFormat="plainText",
-                )
-                .execute()
+            request = youtube.commentThreads().list(
+                part="snippet,replies",
+                videoId=video_id,
+                maxResults=min(page_size, max_results - yielded),
+                pageToken=next_page_token,
+                textFormat="plainText",
             )
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, f"commentThreads.list 失敗 (video_id={video_id})") from e
+            response = execute_with_retry(request, f"commentThreads.list failed (video_id={video_id})")
+        except YouTubeAPIError:
+            raise
 
         for item in response.get("items", []):
             for comment in _iter_thread(youtube, item, video_id=video_id, since=since):

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -9,8 +9,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.comments.fetcher import FetchedComment, fetch_comments
 from youtube_automation.utils.comments.generator import (
     ReplyContext,
@@ -24,6 +22,7 @@ from youtube_automation.utils.config.comments import (
     Comments,
 )
 from youtube_automation.utils.exceptions import ConfigError, GeneratorError, YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +58,10 @@ def fetch_video_status(youtube, video_ids: list[str]) -> dict[str, dict | None]:
     for start in range(0, len(video_ids), _VIDEOS_LIST_CHUNK):
         chunk = video_ids[start : start + _VIDEOS_LIST_CHUNK]
         try:
-            resp = youtube.videos().list(part="status", id=",".join(chunk)).execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, f"videos.list (status) 失敗 (count={len(chunk)})") from e
+            request = youtube.videos().list(part="status", id=",".join(chunk))
+            resp = execute_with_retry(request, "videos.list (status) failed")
+        except YouTubeAPIError:
+            raise
         for item in resp.get("items", []):
             result[item["id"]] = item.get("status", {})
     return result
@@ -111,9 +111,10 @@ class CommentReplier:
         if self._owner_channel_id is not None:
             return
         try:
-            resp = self._youtube.channels().list(part="id", mine=True).execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "channels.list (owner channel ID) 失敗") from e
+            request = self._youtube.channels().list(part="id", mine=True)
+            resp = execute_with_retry(request, "channels.list (owner channel ID) failed")
+        except YouTubeAPIError:
+            raise
         items = resp.get("items") or []
         if not items:
             raise YouTubeAPIError("channels.list が空を返しました — チャンネルが見つかりません")
@@ -122,9 +123,10 @@ class CommentReplier:
     def _fetch_channel_info(self) -> tuple[str, str]:
         """channels().list(part="contentDetails") から (owner_id, uploads_playlist_id) を返す."""
         try:
-            resp = self._youtube.channels().list(part="contentDetails", mine=True).execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "channels.list (mine=True) 失敗") from e
+            request = self._youtube.channels().list(part="contentDetails", mine=True)
+            resp = execute_with_retry(request, "channels.list (mine=True) failed")
+        except YouTubeAPIError:
+            raise
         items = resp.get("items") or []
         if not items:
             raise YouTubeAPIError("channels.list が空を返しました — チャンネルが見つかりません")
@@ -135,18 +137,15 @@ class CommentReplier:
         page_token: str | None = None
         while True:
             try:
-                resp = (
-                    self._youtube.playlistItems()
-                    .list(
-                        part="contentDetails",
-                        playlistId=uploads_playlist_id,
-                        maxResults=50,
-                        pageToken=page_token,
-                    )
-                    .execute()
+                request = self._youtube.playlistItems().list(
+                    part="contentDetails",
+                    playlistId=uploads_playlist_id,
+                    maxResults=50,
+                    pageToken=page_token,
                 )
-            except HttpError as e:
-                raise YouTubeAPIError.from_http_error(e, "playlistItems.list 失敗") from e
+                resp = execute_with_retry(request, "playlistItems.list failed")
+            except YouTubeAPIError:
+                raise
             for item in resp.get("items", []):
                 yield item["contentDetails"]["videoId"]
             page_token = resp.get("nextPageToken")
@@ -258,9 +257,10 @@ class CommentReplier:
         if video_id in self._title_cache:
             return self._title_cache[video_id]
         try:
-            resp = self._youtube.videos().list(part="snippet", id=video_id).execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, f"videos.list 失敗 (video_id={video_id})") from e
+            request = self._youtube.videos().list(part="snippet", id=video_id)
+            resp = execute_with_retry(request, f"videos.list failed (video_id={video_id})")
+        except YouTubeAPIError:
+            raise
         title = ""
         for item in resp.get("items", []):
             title = item["snippet"].get("title", "")
@@ -453,7 +453,7 @@ class CommentReplier:
             False: insert 自体が失敗した。
         """
         try:
-            self._youtube.comments().insert(
+            request = self._youtube.comments().insert(
                 part="snippet",
                 body={
                     "snippet": {
@@ -461,9 +461,10 @@ class CommentReplier:
                         "textOriginal": reply_text,
                     }
                 },
-            ).execute()
-        except HttpError as e:
-            status = getattr(getattr(e, "resp", None), "status", None)
+            )
+            execute_with_retry(request, "comments.insert failed")
+        except YouTubeAPIError as e:
+            status = e.status_code
             plan.errors.append(
                 self._error_record(
                     comment,

--- a/src/youtube_automation/utils/competitor_discovery.py
+++ b/src/youtube_automation/utils/competitor_discovery.py
@@ -15,8 +15,6 @@ from collections import defaultdict
 from dataclasses import replace
 from datetime import datetime
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.competitor_scoring import (
     _RECENT_VIDEOS_PER_CHANNEL,
     CandidateChannel,
@@ -27,6 +25,7 @@ from youtube_automation.utils.competitor_scoring import (
     _score_candidate,
 )
 from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 # channels.list バッチ単位（YouTube Data API 上限）
 _CHANNELS_BATCH_SIZE = 50
@@ -44,18 +43,15 @@ def _search_channels(youtube, keyword: str, max_results: int) -> dict[str, set[s
     重複 channel_id は呼び出し側で union する。
     """
     try:
-        resp = (
-            youtube.search()
-            .list(
-                part="snippet",
-                q=keyword,
-                type="channel",
-                maxResults=max_results,
-            )
-            .execute()
+        request = youtube.search().list(
+            part="snippet",
+            q=keyword,
+            type="channel",
+            maxResults=max_results,
         )
-    except HttpError as e:
-        raise YouTubeAPIError.from_http_error(e, f"search.list failed (q={keyword!r})") from e
+        resp = execute_with_retry(request, f"search.list failed (q={keyword!r})")
+    except YouTubeAPIError:
+        raise
 
     hits: dict[str, set[str]] = {}
     for item in resp.get("items", []):
@@ -78,13 +74,10 @@ def _fetch_channel_details(
     for i in range(0, len(channel_ids), _CHANNELS_BATCH_SIZE):
         batch = channel_ids[i : i + _CHANNELS_BATCH_SIZE]
         try:
-            resp = (
-                youtube.channels()
-                .list(part="snippet,statistics,contentDetails,topicDetails", id=",".join(batch))
-                .execute()
-            )
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "channels.list failed") from e
+            request = youtube.channels().list(part="snippet,statistics,contentDetails,topicDetails", id=",".join(batch))
+            resp = execute_with_retry(request, "channels.list failed")
+        except YouTubeAPIError:
+            raise
 
         for item in resp.get("items", []):
             ch_id = item["id"]
@@ -114,26 +107,24 @@ def _fetch_channel_details(
 def _fetch_recent_videos(youtube, uploads_playlist_id: str) -> list[VideoMetric]:
     """uploads playlist から直近動画を `_RECENT_VIDEOS_PER_CHANNEL` 本取得する。"""
     try:
-        playlist_resp = (
-            youtube.playlistItems()
-            .list(
-                part="contentDetails",
-                playlistId=uploads_playlist_id,
-                maxResults=_RECENT_VIDEOS_PER_CHANNEL,
-            )
-            .execute()
+        request = youtube.playlistItems().list(
+            part="contentDetails",
+            playlistId=uploads_playlist_id,
+            maxResults=_RECENT_VIDEOS_PER_CHANNEL,
         )
-    except HttpError as e:
-        raise YouTubeAPIError.from_http_error(e, f"playlistItems.list failed (playlist={uploads_playlist_id})") from e
+        playlist_resp = execute_with_retry(request, f"playlistItems.list failed (playlist={uploads_playlist_id})")
+    except YouTubeAPIError:
+        raise
 
     video_ids = [item["contentDetails"]["videoId"] for item in playlist_resp.get("items", [])]
     if not video_ids:
         return []
 
     try:
-        videos_resp = youtube.videos().list(part="snippet,statistics", id=",".join(video_ids)).execute()
-    except HttpError as e:
-        raise YouTubeAPIError.from_http_error(e, "videos.list failed") from e
+        request = youtube.videos().list(part="snippet,statistics", id=",".join(video_ids))
+        videos_resp = execute_with_retry(request, "videos.list failed")
+    except YouTubeAPIError:
+        raise
 
     metrics: list[VideoMetric] = []
     for item in videos_resp.get("items", []):

--- a/src/youtube_automation/utils/ctr_analytics.py
+++ b/src/youtube_automation/utils/ctr_analytics.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -50,32 +51,26 @@ class CTRAnalyticsMixin:
 
         try:
             # 基本メトリクス
-            overall_response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,likes,comments,shares,subscribersGained",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,likes,comments,shares,subscribersGained",
             )
+            overall_response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             # 動画別データ（トップ30）
             video_ctr_response = self._fetch_video_ctr(start_date, end_date)
 
             # エンゲージメントデータ
-            traffic_response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched",
-                    dimensions="day",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched",
+                dimensions="day",
             )
+            traffic_response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             overall_data = self._process_overall_ctr(overall_response)
             video_data = self._process_video_ctr(video_ctr_response)
@@ -95,7 +90,7 @@ class CTRAnalyticsMixin:
                 "ctr_analysis": perf_analysis,
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（CTR分析）: {e}")
             return {"error": str(e)}
         except Exception as e:
@@ -104,19 +99,16 @@ class CTRAnalyticsMixin:
 
     def _fetch_video_ctr(self, start_date: str, end_date: str) -> Dict:
         """動画別パフォーマンスデータを取得する（トップ30本、views 降順）"""
-        return (
-            self.analytics_service.reports()
-            .query(
-                ids=f"channel=={self.channel_id}",
-                startDate=start_date,
-                endDate=end_date,
-                metrics="views,likes,comments,estimatedMinutesWatched",
-                dimensions="video",
-                sort="-views",
-                maxResults=30,
-            )
-            .execute()
+        request = self.analytics_service.reports().query(
+            ids=f"channel=={self.channel_id}",
+            startDate=start_date,
+            endDate=end_date,
+            metrics="views,likes,comments,estimatedMinutesWatched",
+            dimensions="video",
+            sort="-views",
+            maxResults=30,
         )
+        return execute_with_retry(request, "YouTube Analytics API request failed")
 
     def get_collection_performance(self, start_date: str, end_date: str) -> Dict:
         """

--- a/src/youtube_automation/utils/retention_analytics.py
+++ b/src/youtube_automation/utils/retention_analytics.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -36,19 +37,16 @@ class RetentionAnalyticsMixin:
             self.initialize()
 
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="audienceWatchRatio,relativeRetentionPerformance",
-                    dimensions="elapsedVideoTimeRatio",
-                    filters=f"video=={video_id}",
-                    sort="elapsedVideoTimeRatio",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="audienceWatchRatio,relativeRetentionPerformance",
+                dimensions="elapsedVideoTimeRatio",
+                filters=f"video=={video_id}",
+                sort="elapsedVideoTimeRatio",
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             retention_curve = []
             if "rows" in response:
@@ -80,7 +78,7 @@ class RetentionAnalyticsMixin:
                 "data_points": len(retention_curve),
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.warning(f"視聴維持率取得不可 (video={video_id}): {e}")
             return {
                 "video_id": video_id,
@@ -122,20 +120,17 @@ class RetentionAnalyticsMixin:
 
         # 上位動画の video_id を取得
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views",
-                    dimensions="video",
-                    sort="-views",
-                    maxResults=top_n,
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views",
+                dimensions="video",
+                sort="-views",
+                maxResults=top_n,
             )
-        except HttpError as e:
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
+        except YouTubeAPIError as e:
             logger.error(f"上位動画リスト取得エラー: {e}")
             return []
 

--- a/src/youtube_automation/utils/retry.py
+++ b/src/youtube_automation/utils/retry.py
@@ -1,0 +1,79 @@
+"""Retry boundary for Google API requests."""
+
+from __future__ import annotations
+
+import random
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, Protocol, TypeVar
+
+from googleapiclient.errors import HttpError
+from httplib2 import HttpLib2Error
+
+from youtube_automation.utils.exceptions import YouTubeAPIError
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class ExecutableRequest(Protocol[T]):
+    def execute(self) -> T: ...
+
+
+_MAX_ATTEMPTS = 3
+_QUOTA_REASONS = {
+    "dailyLimitExceeded",
+    "quotaExceeded",
+    "rateLimitExceeded",
+    "userRateLimitExceeded",
+}
+
+
+def _is_retryable(error: HttpError) -> bool:
+    converted = YouTubeAPIError.from_http_error(error, "YouTube API request failed")
+    status = converted.status_code
+    return (
+        status == 429
+        or (status is not None and 500 <= status < 600)
+        or (status == 403 and converted.reason in _QUOTA_REASONS)
+    )
+
+
+def retry_youtube_api(
+    context: str,
+    *,
+    sleep: Callable[[float], None] | None = None,
+    jitter: Callable[[float, float], float] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Retry transient Google API failures and expose failures as domain errors."""
+    sleep = sleep or time.sleep
+    jitter = jitter or random.uniform
+
+    def decorate(operation: Callable[P, T]) -> Callable[P, T]:
+        @wraps(operation)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+            for attempt in range(_MAX_ATTEMPTS):
+                try:
+                    return operation(*args, **kwargs)
+                except HttpError as error:
+                    if not _is_retryable(error) or attempt == _MAX_ATTEMPTS - 1:
+                        raise YouTubeAPIError.from_http_error(error, context) from error
+                except (HttpLib2Error, OSError) as error:
+                    if attempt == _MAX_ATTEMPTS - 1:
+                        raise YouTubeAPIError(f"{context}: {error}") from error
+
+                delay = 2**attempt
+                sleep(jitter(delay, delay * 2))
+
+            raise AssertionError("retry loop exited unexpectedly")
+
+        return wrapped
+
+    return decorate
+
+
+def execute_with_retry(request: ExecutableRequest[T], context: str) -> T:
+    """Execute one Google API request through the shared retry boundary."""
+
+    return retry_youtube_api(context)(request.execute)()

--- a/src/youtube_automation/utils/strategic_analytics.py
+++ b/src/youtube_automation/utils/strategic_analytics.py
@@ -10,9 +10,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
-
+from youtube_automation.utils.exceptions import YouTubeAPIError
 from youtube_automation.utils.profile import section
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -75,20 +75,17 @@ class StrategicAnalyticsMixin:
             batch_size = min(10, remaining_count)
 
             try:
-                response = (
-                    self.analytics_service.reports()
-                    .query(
-                        ids=f"channel=={self.channel_id}",
-                        startDate=start_date,
-                        endDate=end_date,
-                        metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
-                        dimensions="video",
-                        sort="-views",
-                        maxResults=batch_size,
-                        startIndex=len(top_videos_data) + 1,
-                    )
-                    .execute()
+                request = self.analytics_service.reports().query(
+                    ids=f"channel=={self.channel_id}",
+                    startDate=start_date,
+                    endDate=end_date,
+                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                    dimensions="video",
+                    sort="-views",
+                    maxResults=batch_size,
+                    startIndex=len(top_videos_data) + 1,
                 )
+                response = execute_with_retry(request, "YouTube Analytics API request failed")
 
                 if "rows" not in response:
                     break
@@ -130,7 +127,7 @@ class StrategicAnalyticsMixin:
                 if len(response["rows"]) < batch_size:
                     break
 
-            except HttpError as e:
+            except YouTubeAPIError as e:
                 logger.error(f"YouTube API エラー（上位動画取得）: {e}")
                 break
             except Exception as e:
@@ -287,20 +284,17 @@ class StrategicAnalyticsMixin:
             batch_size = min(10, remaining_count)
 
             try:
-                response = (
-                    self.analytics_service.reports()
-                    .query(
-                        ids=f"channel=={self.channel_id}",
-                        startDate=start_date,
-                        endDate=end_date,
-                        metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
-                        dimensions="video",
-                        sort="-views",
-                        maxResults=batch_size,
-                        startIndex=len(videos_data) + 1,
-                    )
-                    .execute()
+                request = self.analytics_service.reports().query(
+                    ids=f"channel=={self.channel_id}",
+                    startDate=start_date,
+                    endDate=end_date,
+                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                    dimensions="video",
+                    sort="-views",
+                    maxResults=batch_size,
+                    startIndex=len(videos_data) + 1,
                 )
+                response = execute_with_retry(request, "YouTube Analytics API request failed")
 
                 if "rows" not in response:
                     break
@@ -343,7 +337,7 @@ class StrategicAnalyticsMixin:
                 if len(response["rows"]) < batch_size:
                     break
 
-            except HttpError as e:
+            except YouTubeAPIError as e:
                 logger.error(f"YouTube API エラー（バッチ取得）: {e}")
                 break
             except Exception as e:

--- a/src/youtube_automation/utils/traffic_source_analytics.py
+++ b/src/youtube_automation/utils/traffic_source_analytics.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -37,18 +38,15 @@ class TrafficSourceMixin:
         logger.info("トラフィックソース分析実行中...")
 
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration",
-                    dimensions="insightTrafficSourceType",
-                    sort="-views",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration",
+                dimensions="insightTrafficSourceType",
+                sort="-views",
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             sources = {}
             if "rows" in response:
@@ -72,7 +70,7 @@ class TrafficSourceMixin:
                 "total_views": total_views,
             }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（トラフィックソース）: {e}")
             return {"sources": {}, "total_views": 0, "error": str(e)}
         except Exception as e:
@@ -97,20 +95,17 @@ class TrafficSourceMixin:
         logger.info(f"トラフィックソース詳細取得: {source_type}")
 
         try:
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched",
-                    dimensions="insightTrafficSourceDetail",
-                    filters=f"insightTrafficSourceType=={source_type}",
-                    sort="-views",
-                    maxResults=25,
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched",
+                dimensions="insightTrafficSourceDetail",
+                filters=f"insightTrafficSourceType=={source_type}",
+                sort="-views",
+                maxResults=25,
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             details = []
             if "rows" in response:
@@ -126,7 +121,7 @@ class TrafficSourceMixin:
             logger.info(f"{source_type} 詳細: {len(details)} 件")
             return details
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（トラフィック詳細 {source_type}）: {e}")
             return []
         except Exception as e:

--- a/src/youtube_automation/utils/video_analytics.py
+++ b/src/youtube_automation/utils/video_analytics.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -38,19 +39,16 @@ class VideoAnalyticsMixin:
 
         try:
             # 動画別メトリクス取得
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
-                    dimensions="video",
-                    sort="-views",
-                    maxResults=10,
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                dimensions="video",
+                sort="-views",
+                maxResults=10,
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             videos_data = []
 
@@ -84,7 +82,7 @@ class VideoAnalyticsMixin:
 
             return videos_data
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（動画別分析）: {e}")
             return []
         except Exception as e:
@@ -108,17 +106,14 @@ class VideoAnalyticsMixin:
 
         try:
             # 動画別メトリクス取得
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    ids=f"channel=={self.channel_id}",
-                    startDate=start_date,
-                    endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
-                    filters=f"video=={video_id}",
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                ids=f"channel=={self.channel_id}",
+                startDate=start_date,
+                endDate=end_date,
+                metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                filters=f"video=={video_id}",
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
 
             if response.get("rows"):
                 row = response["rows"][0]
@@ -146,7 +141,7 @@ class VideoAnalyticsMixin:
                     "subscribers_gained": 0,
                 }
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（動画ID {video_id}）: {e}")
             return {
                 "video_id": video_id,
@@ -187,11 +182,10 @@ class VideoAnalyticsMixin:
             for i in range(0, len(video_ids), 50):
                 batch_ids = video_ids[i : i + 50]
 
-                response = (
-                    self.youtube_service.videos()
-                    .list(part="snippet,statistics,contentDetails,topicDetails", id=",".join(batch_ids))
-                    .execute()
+                request = self.youtube_service.videos().list(
+                    part="snippet,statistics,contentDetails,topicDetails", id=",".join(batch_ids)
                 )
+                response = execute_with_retry(request, "YouTube Analytics API request failed")
 
                 for item in response.get("items", []):
                     video_id = item["id"]
@@ -213,7 +207,7 @@ class VideoAnalyticsMixin:
 
             return all_details
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.warning(f"YouTube API エラー（動画詳細取得）: {e}")
             return {}
         except Exception as e:

--- a/src/youtube_automation/utils/video_daily_analytics.py
+++ b/src/youtube_automation/utils/video_daily_analytics.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, List, Optional
 
 from youtube_automation.utils.profile import section
+from youtube_automation.utils.retry import execute_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +54,11 @@ class VideoDailyAnalyticsMixin:
             days=(start_date, end_date),
             filtered=bool(video_ids),
         ):
-            response = (
-                self.analytics_service.reports()
-                .query(
-                    metrics="views",
-                    **query_kwargs,
-                )
-                .execute()
+            request = self.analytics_service.reports().query(
+                metrics="views",
+                **query_kwargs,
             )
+            response = execute_with_retry(request, "YouTube Analytics API request failed")
         rows = self._parse_video_daily_rows(response)
         logger.debug("video_daily rows=%d", len(rows))
         return rows

--- a/src/youtube_automation/utils/video_listing.py
+++ b/src/youtube_automation/utils/video_listing.py
@@ -9,9 +9,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List
 
-from googleapiclient.errors import HttpError
-
 from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import execute_with_retry
 
 if TYPE_CHECKING:
     from .analytics_base import AnalyticsBase  # noqa: F401
@@ -47,7 +46,8 @@ class VideoListingMixin:
 
         try:
             # チャンネルのアップロード済みプレイリストIDを取得
-            channel_response = self.youtube_service.channels().list(part="contentDetails", id=self.channel_id).execute()
+            request = self.youtube_service.channels().list(part="contentDetails", id=self.channel_id)
+            channel_response = execute_with_retry(request, "YouTube Data API request failed")
 
             uploads_playlist_id = channel_response["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
 
@@ -57,16 +57,13 @@ class VideoListingMixin:
 
             while True:
                 # プレイリストのアイテムを取得
-                playlist_response = (
-                    self.youtube_service.playlistItems()
-                    .list(
-                        part="snippet,contentDetails",
-                        playlistId=uploads_playlist_id,
-                        maxResults=50,
-                        pageToken=next_page_token,
-                    )
-                    .execute()
+                request = self.youtube_service.playlistItems().list(
+                    part="snippet,contentDetails",
+                    playlistId=uploads_playlist_id,
+                    maxResults=50,
+                    pageToken=next_page_token,
                 )
+                playlist_response = execute_with_retry(request, "YouTube Analytics API request failed")
 
                 for item in playlist_response["items"]:
                     video_info = {
@@ -92,9 +89,9 @@ class VideoListingMixin:
                 self._all_videos_cache = videos
             return videos
 
-        except HttpError as e:
+        except YouTubeAPIError as e:
             logger.error(f"YouTube API エラー（動画リスト取得）: {e}")
-            raise YouTubeAPIError.from_http_error(e, "チャンネル動画リスト取得") from e
+            raise YouTubeAPIError(str(e), status_code=e.status_code, reason=e.reason) from e
 
     def get_recent_videos(self, days: int = 30) -> List[Dict]:
         """

--- a/tests/test_audience_analytics.py
+++ b/tests/test_audience_analytics.py
@@ -4,9 +4,12 @@ AudienceAnalyticsMixin のユニットテスト
 テスト対象: utils/audience_analytics.py
 """
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
 
 from youtube_automation.utils.audience_analytics import AudienceAnalyticsMixin
 
@@ -26,6 +29,27 @@ def collector():
 
 
 class TestGetDeviceAnalytics:
+    def test_retries_transient_api_failure_through_analytics_entrypoint(self, collector, monkeypatch):
+        monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)
+        transient = HttpError(Response({"status": "503"}), b'{"error": {"errors": [{"reason": "backendError"}]}}')
+        request = collector.analytics_service.reports().query()
+        request.execute.side_effect = [transient, {"rows": [["MOBILE", 1, 2, 3]]}]
+
+        result = collector.get_device_analytics("2026-01-01", "2026-04-01")
+
+        assert result["devices"]["MOBILE"]["views"] == 1
+        assert request.execute.call_count == 2
+
+    def test_permanent_api_failure_keeps_api_specific_fail_soft_result(self, collector, caplog):
+        permanent = HttpError(Response({"status": "403"}), b'{"error": {"errors": [{"reason": "forbidden"}]}}')
+        collector.analytics_service.reports().query().execute.side_effect = permanent
+
+        with caplog.at_level(logging.ERROR):
+            result = collector.get_device_analytics("2026-01-01", "2026-04-01")
+
+        assert result["devices"] == {}
+        assert "YouTube API エラー（デバイス分析）" in caplog.text
+
     def test_returns_devices_with_share(self, collector):
         """デバイス別データとシェアが正しく返る"""
         mock_response = {

--- a/tests/test_benchmark_collector_channels_batch.py
+++ b/tests/test_benchmark_collector_channels_batch.py
@@ -17,6 +17,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
 
 from youtube_automation.scripts.benchmark_collector import (
     _CHANNELS_BATCH_SIZE,
@@ -84,6 +86,19 @@ def _video_item(
 
 
 class TestFetchChannelsMetadata:
+    def test_retries_transient_api_failure_through_benchmark_collector(self, monkeypatch):
+        monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)
+        youtube = MagicMock()
+        transient = HttpError(Response({"status": "503"}), b'{"error": {"errors": [{"reason": "backendError"}]}}')
+        request = youtube.channels.return_value.list.return_value
+        request.execute.side_effect = [transient, {"items": [_ch_item("UC_OK")]}]
+        collector = _make_collector(youtube)
+
+        result = collector._fetch_channels_metadata([{"id": "UC_OK"}])
+
+        assert result == {"UC_OK": _ch_item("UC_OK")}
+        assert request.execute.call_count == 2
+
     def test_single_batch_uses_comma_separated_ids(self):
         # Given: 3 チャンネル分の channel_info
         channel_infos = [{"id": f"UC_{i}", "name": f"ch{i}", "slug": f"s{i}"} for i in range(3)]

--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from googleapiclient.errors import HttpError
+from httplib2 import Response
+
 from youtube_automation.utils.comments.fetcher import fetch_comments
 
 
@@ -82,6 +85,19 @@ def test_top_level_comment_has_parent_id_none():
     assert comments[0].comment_id == "t1"
     assert comments[0].parent_id is None
     assert comments[0].video_id == "v1"
+
+
+def test_retries_transient_api_failure_through_comments_entrypoint(monkeypatch):
+    monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)
+    transient = HttpError(Response({"status": "503"}), b'{"error": {"errors": [{"reason": "backendError"}]}}')
+    yt = _mock_youtube_threads([_make_thread_item(thread_id="t1", text="hello")])
+    request = yt.commentThreads.return_value.list.return_value
+    request.execute.side_effect = [transient, {"items": [_make_thread_item(thread_id="t1", text="hello")]}]
+
+    comments = list(fetch_comments(yt, video_id="v1"))
+
+    assert [comment.comment_id for comment in comments] == ["t1"]
+    assert request.execute.call_count == 2
 
 
 def test_top_level_comment_includes_author_channel_id():

--- a/tests/test_competitor_discovery.py
+++ b/tests/test_competitor_discovery.py
@@ -19,6 +19,8 @@ from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
 
 from youtube_automation.utils.competitor_discovery import discover_competitors
 from youtube_automation.utils.competitor_scoring import (
@@ -842,6 +844,18 @@ class TestDiscoverCompetitors:
         }
 
         return youtube
+
+    def test_retries_transient_api_failure_through_discovery_entrypoint(self, monkeypatch):
+        monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)
+        youtube = MagicMock()
+        transient = HttpError(Response({"status": "503"}), b'{"error": {"errors": [{"reason": "backendError"}]}}')
+        request = youtube.search.return_value.list.return_value
+        request.execute.side_effect = [transient, {"items": []}]
+
+        result = discover_competitors(youtube, _make_params(keywords=("lo-fi study",)))
+
+        assert result == []
+        assert request.execute.call_count == 2
 
     def test_returns_scored_candidates_sorted_by_total_desc(self):
         # Given: 2 つのチャンネルが search で hit、両方ともフィルタ通過

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
 
 # ---------------------------------------------------------------------------
 # フィクスチャ
@@ -334,6 +336,17 @@ class TestCreatePlaylist:
         body = call_kwargs[1]["body"]
         assert body["status"]["privacyStatus"] == "unlisted"
         assert body["snippet"]["title"] == "T"
+
+    def test_retries_transient_api_failure_through_playlist_manager(self, manager, mock_youtube, monkeypatch):
+        monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)
+        transient = HttpError(Response({"status": "503"}), b'{"error": {"errors": [{"reason": "backendError"}]}}')
+        request = mock_youtube.playlists.return_value.insert.return_value
+        request.execute.side_effect = [transient, {"id": "PL_NEW"}]
+
+        result = manager._create_playlist("My Playlist", "Desc")
+
+        assert result["playlist_id"] == "PL_NEW"
+        assert request.execute.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,69 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response, ServerNotFoundError
+
+from youtube_automation.utils.exceptions import YouTubeAPIError
+from youtube_automation.utils.retry import retry_youtube_api
+
+
+def _http_error(status: int, reason: str) -> HttpError:
+    content = json.dumps({"error": {"errors": [{"reason": reason}]}}).encode()
+    return HttpError(Response({"status": str(status)}), content)
+
+
+def test_retries_503_twice_then_returns_success() -> None:
+    operation = Mock(side_effect=[_http_error(503, "backendError"), _http_error(503, "backendError"), "ok"])
+    sleep = Mock()
+    jitter = Mock(side_effect=[1.5, 3.0])
+
+    result = retry_youtube_api("fetch", sleep=sleep, jitter=jitter)(operation)()
+
+    assert result == "ok"
+    assert operation.call_count == 3
+    assert [call.args for call in jitter.call_args_list] == [(1, 2), (2, 4)]
+    assert [call.args for call in sleep.call_args_list] == [(1.5,), (3.0,)]
+
+
+def test_429_exhaustion_raises_domain_error() -> None:
+    operation = Mock(side_effect=_http_error(429, "rateLimitExceeded"))
+
+    with pytest.raises(YouTubeAPIError) as raised:
+        retry_youtube_api("fetch", sleep=Mock(), jitter=lambda low, high: low)(operation)()
+
+    assert operation.call_count == 3
+    assert raised.value.status_code == 429
+    assert raised.value.reason == "rateLimitExceeded"
+    assert isinstance(raised.value.__cause__, HttpError)
+
+
+def test_non_quota_403_fails_without_retry() -> None:
+    operation = Mock(side_effect=_http_error(403, "commentsDisabled"))
+    sleep = Mock()
+
+    with pytest.raises(YouTubeAPIError) as raised:
+        retry_youtube_api("fetch", sleep=sleep)(operation)()
+
+    assert operation.call_count == 1
+    assert sleep.call_count == 0
+    assert raised.value.status_code == 403
+    assert raised.value.reason == "commentsDisabled"
+
+
+def test_quota_403_is_retried() -> None:
+    operation = Mock(side_effect=[_http_error(403, "quotaExceeded"), "ok"])
+
+    assert retry_youtube_api("fetch", sleep=Mock(), jitter=lambda low, high: low)(operation)() == "ok"
+    assert operation.call_count == 2
+
+
+def test_network_error_is_retried_and_exhaustion_is_domain_error() -> None:
+    operation = Mock(side_effect=ServerNotFoundError("youtube.googleapis.com"))
+
+    with pytest.raises(YouTubeAPIError) as raised:
+        retry_youtube_api("fetch", sleep=Mock(), jitter=lambda low, high: low)(operation)()
+
+    assert operation.call_count == 3
+    assert isinstance(raised.value.__cause__, ServerNotFoundError)

--- a/tests/test_video_daily_analytics.py
+++ b/tests/test_video_daily_analytics.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from googleapiclient.errors import HttpError
 
+from youtube_automation.utils.exceptions import YouTubeAPIError
 from youtube_automation.utils.video_daily_analytics import VideoDailyAnalyticsMixin
 
 
@@ -50,9 +51,11 @@ def test_get_video_daily_analytics_query_uses_views_metric_only():
     assert "videoThumbnailImpressions" not in last_call_kwargs["metrics"]
 
 
-def test_get_video_daily_analytics_propagates_http_error():
+def test_get_video_daily_analytics_converts_permanent_http_error():
     mock_service = MagicMock()
     mock_service.reports().query().execute.side_effect = HttpError(MagicMock(status=400), b"metric not found")
     collector = DummyCollector(mock_service)
-    with pytest.raises(HttpError):
+    with pytest.raises(YouTubeAPIError) as raised:
         collector.get_video_daily_analytics("2026-04-01", "2026-04-01", video_ids=["vid_A"])
+    assert raised.value.status_code == 400
+    assert isinstance(raised.value.__cause__, HttpError)


### PR DESCRIPTION
## Summary

## 概要

YouTube Data API を叩く 5 モジュール（playlist / benchmark / analytics / comments-reply / discover-competitors 系）に retry が一切なく、transient エラー（5xx / 429 / network error）で即落ちする。共通 retry decorator を `utils/retry.py` に新設して適用する。

## 背景・目的

旧 #396 の後継（skill-audit-2026-05 / PR #375 P1-4、出典 `data-failure-recovery.md §4.1`）。本日の実装乖離監査で、YouTube Data API 系 5 モジュールに retry が依然として無いことを確認済み。

## 提案する仕様

1. `src/youtube_automation/utils/retry.py` を新設し、共通 retry decorator を提供する
2. 5xx / 429 / network error に対して指数 backoff（jitter 付き、最大試行回数上限あり）で再試行する
3. 4xx（quota 超過を除く恒久エラー）は再試行せず即座にドメイン例外（`YouTubeAPIError`）へ変換する
4. 関連 5 モジュールの API 呼び出し箇所へ decorator を適用する

## ユースケース

- 深夜バッチ的に回る analytics 収集・benchmark 更新が、一過性の 503 / ネットワーク断で全体失敗せず自動復帰する
- 429（rate limit）時に backoff で自然回復し、手動再実行が不要になる

## 参照資料

- src/youtube_automation/utils/exceptions.py（`YouTubeAPIError.from_http_error` との整合）
- YouTube Data API を呼び出す 5 モジュール（playlist / benchmark / analytics / comments-reply / discover-competitors 系。正確なファイル一覧は plan step で `googleapiclient` 呼び出し箇所を洗い出して確定）

## 影響ファイル

- **新規**: src/youtube_automation/utils/retry.py
- **変更**: playlist / benchmark / analytics / comments-reply / discover-competitors 系の API 呼び出しモジュール（decorator 適用のみの薄い変更）
- **新規**: tests/test_retry.py（backoff・回数上限・非対象エラーの即時失敗）

**兄弟入口・貫通先**: YouTube Data API を呼ぶ全モジュールが貫通先。上記 5 系統以外（video-upload 等）で同 API を呼ぶ箇所を plan step で洗い出し、適用可否を判断して plan に記録する

## 要件

1. mock で 503 → 503 → 200 を返すテストを実行する → 指数 backoff で 2 回再試行し最終的に成功する
2. mock で 429 を返すテストを実行する → backoff 再試行され、上限超過時は `YouTubeAPIError` が送出される
3. mock で 403（quota 以外の恒久エラー）を返すテストを実行する → 再試行せず即座にドメイン例外となる
4. 対象 5 モジュールのコードを確認する → API 呼び出しが共通 decorator 経由になっており、モジュール個別の ad-hoc retry が存在しない
5. `uv run pytest tests/` を実行する → 追加テスト含め全件 pass する

## スコープ外

- discover-competitors のキャッシュ導入（旧 #395 の後継 issue）は扱わない（retry と cache は独立に導入可能）
- Gemini / Vertex AI 系（video-analyze, lyria）への retry 適用は扱わない
- quota 使用量の削減そのもの（呼び出し回数最適化）は扱わない

## 実装方針（takt）

- workflow: improve
- 理由: 既存 API 呼び出しの transient エラー時挙動を変える拡張のため

## Execution Report

Workflow `improve` completed successfully.

Closes #1695