### PR TITLE
[#1960] issue-1960-devshell-shellhook

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -263,7 +263,7 @@ uv run yt-skills sync --asset claude-md --force
 ```bash
 git clone git@github.com:daiki-beppu/youtube-channels-automation.git
 cd youtube-channels-automation
-uv sync --extra veo
+nix develop  # shellHook が uv sync を自動実行する
 ```
 
 ### 6.2 開発フロー

--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,7 @@
           # op read で都度取得する。`op` (1Password CLI) は unfree のため
           # nixpkgs から外し、システム（Homebrew 等）の op を利用する想定。
           #
-          # 初回セットアップ:
-          #   uv sync --extra veo
+          # devShell 入室時に uv sync が自動実行される。
           # その後の利用:
           #   uv run yt-skills list
           #   uv run pytest
@@ -71,6 +70,7 @@
             if git rev-parse --git-dir >/dev/null 2>&1; then
               bash "${./.}/.lefthook/install.sh" || exit 1
             fi
+            uv sync --quiet || echo "warning: uv sync failed; dependencies may be out of date." >&2
           '';
         };
       }

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -1,0 +1,93 @@
+"""devShell 入室時の依存同期を公開入口から検証する。"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _nix_is_available() -> bool:
+    if shutil.which("nix") is None:
+        return False
+    probe = subprocess.run(
+        ["nix", "store", "ping"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return probe.returncode == 0
+
+
+def _nix_develop(
+    project: Path, environment: Path, command: str = "printf shell-entered"
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["UV_PROJECT_ENVIRONMENT"] = str(environment)
+    return subprocess.run(
+        ["nix", "develop", "--command", "sh", "-c", command],
+        cwd=project,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.fixture
+def project_copy(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    shutil.copytree(
+        _REPO_ROOT,
+        project,
+        ignore=shutil.ignore_patterns(".git", ".venv", ".direnv", ".pytest_cache"),
+    )
+    return project
+
+
+@pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
+def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(
+    project_copy: Path, tmp_path: Path
+) -> None:
+    environment = tmp_path / "environment"
+
+    first = _nix_develop(
+        project_copy,
+        environment,
+        'test -x "$UV_PROJECT_ENVIRONMENT/bin/pytest"'
+        ' && "$UV_PROJECT_ENVIRONMENT/bin/pytest" --collect-only -q >/dev/null'
+        " && printf shell-entered",
+    )
+    assert first.returncode == 0, first.stderr
+    assert first.stdout == "shell-entered"
+    assert (environment / "bin" / "pytest").exists()
+    assert "warning: uv sync failed; dependencies may be out of date." not in first.stderr
+
+    second = _nix_develop(project_copy, environment)
+    assert second.returncode == 0, second.stderr
+    assert second.stdout == "shell-entered"
+    assert "Resolved " not in second.stderr
+    assert "Audited " not in second.stderr
+
+
+@pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
+def test_nix_develop_warns_when_sync_fails_but_enters_shell(
+    project_copy: Path, tmp_path: Path
+) -> None:
+    environment = tmp_path / "missing-parent" / "environment"
+    environment.parent.mkdir()
+    environment.parent.chmod(0o500)
+
+    result = _nix_develop(project_copy, environment)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "shell-entered"
+    assert "warning: uv sync failed; dependencies may be out of date." in result.stderr
+    assert not environment.exists()

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -53,9 +53,7 @@ def project_copy(tmp_path: Path) -> Path:
 
 
 @pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
-def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(
-    project_copy: Path, tmp_path: Path
-) -> None:
+def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(project_copy: Path, tmp_path: Path) -> None:
     environment = tmp_path / "environment"
 
     first = _nix_develop(
@@ -78,9 +76,7 @@ def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(
 
 
 @pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
-def test_nix_develop_warns_when_sync_fails_but_enters_shell(
-    project_copy: Path, tmp_path: Path
-) -> None:
+def test_nix_develop_warns_when_sync_fails_but_enters_shell(project_copy: Path, tmp_path: Path) -> None:
     environment = tmp_path / "missing-parent" / "environment"
     environment.parent.mkdir()
     environment.parent.chmod(0o500)


### PR DESCRIPTION
## Summary

## 概要

flake.nix の devShell shellHook に `uv sync` を追加し、worktree を切った直後に `nix develop`（または direnv 入室）するだけで `.venv` が揃うようにする。現在は lefthook の初期化のみ自動で、`uv sync` は手動実行が必要。

## 背景・目的

- shellHook は既に lefthook install を入室ごとに自動実行しており、「devShell 入室 = 冪等な初期化完了」の設計。uv sync だけが手動で残っている
- uv は lock と `.venv` が一致していれば no-op（数十 ms）のため、2 回目以降の入室コストは実質ゼロ
- `veo` extra は現在空（`pyproject.toml` で `veo = []`、依存は main に移動済み）のため `--extra veo` は指定しない。README は既に `uv sync` 単独へ修正済みで、`tests/test_readme_dev_install_documentation.py` が回帰を担保している

## 参照資料

- flake.nix
- .lefthook/install.sh
- ONBOARDING.md
- tests/test_readme_dev_install_documentation.py
- docs/development.md

## 影響ファイル

- **変更**: flake.nix（shellHook に uv sync 追加 + コメントの「初回セットアップ: uv sync --extra veo」記載を更新）
- **変更**: ONBOARDING.md（L266 の `uv sync --extra veo` → `uv sync`）

**兄弟入口・貫通先**: なし（devShell 入室経路は flake.nix の shellHook のみ。CI は `.github/workflows/ci.yml` が独自に uv を呼ぶが本 issue では変更しない）

## 要件

1. `.venv` が無い状態の worktree で `nix develop` に入室する → shellHook が `uv sync` を実行し、入室直後に `uv run pytest --collect-only` が依存不足エラーなしで動く
2. `uv sync` が失敗する状況（オフライン等）で `nix develop` に入室する → stderr に警告が出るが shell 入室自体は継続する（lefthook の `|| exit 1` とは異なり非致命扱い）
3. `.venv` が最新の状態で再入室する → uv sync は no-op で完了し、入室が体感遅くならない（`--quiet` 等で通常時のノイズ出力を抑える）
4. flake.nix のコメントおよび ONBOARDING.md から `uv sync --extra veo` の記載が消え、自動実行を前提とした説明に更新されている → `rg -- '--extra veo'` のヒットが tests/（回帰テスト自身）のみになる

## スコープ外

- 空の `veo` extra を pyproject.toml から削除すること（別 issue で対応）
- uv2nix 等による venv の Nix derivation 化
- CI（.github/workflows/ci.yml）の uv セットアップ手順の変更
- `direnv allow` の自動化（セキュリティゲートのため対象外）

## 受け入れ基準

- [ ] `uv run ruff check` が exit 0 になる
- [ ] `uv run pytest` が成功する（特に tests/test_readme_dev_install_documentation.py）
- [ ] typecheck: 該当コマンドなし（mypy / pyright 未導入）

## 実装方針（takt）

- workflow: lite
- 理由: shellHook 1 箇所 + ドキュメント 2 箇所の軽量変更で interface 変更なし。既存の回帰テストと手動の nix develop 確認で挙動担保できるため

## Execution Report

Workflow `lite` completed successfully.

Closes #1960