### PR TITLE
[#1829] issue-1829-feedback-feedback-r

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -1,35 +1,53 @@
 ---
 name: feedback
-description: "Use when 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を構造化記録するとき。「/feedback」「摩擦を記録」「改善案を残す」で発動。分析の学びは /analytics-analyze や /postmortem を使う"
+description: "Use when 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を構造化記録するとき、または記録済み feedback を上流 issue に還流するとき。「/feedback」「摩擦を記録」「改善案を残す」「feedback を上流に還流して」「今週の feedback 還流して」で発動。分析の学びは /analytics-analyze や /postmortem を使う"
 ---
 
 ## Overview
 
-スキル実行中に遭遇した不具合・摩擦・改善案を、下流チャンネルリポジトリの
-`data/feedback/feedback-log.jsonl` に append-only で 1 行追記する。
+下流チャンネルリポジトリの `data/feedback/feedback-log.jsonl` に、不具合・摩擦・
+改善案を記録する。または、記録済み entry をユーザー承認後に上流
+`daiki-beppu/youtube-automation` の GitHub issue へ還流する。
 
-このスキルは上流 issue 起票を行わない。記録だけを行い、元の作業は中断しない。
+## Hard Gates
+
+- 記録モードでは既存行を変更せず、schema 準拠の JSON object を末尾に 1 行だけ追加する
+- 還流モードでは `status="recorded"` の行だけを候補にする。`status="filed"` の行は表示も起票もせず、二重起票を防ぐ
+- issue 起票前に open issue のタイトルを照合し、類似候補ごとに新規起票かスキップかをユーザーに確認する
+- 起票対象、件数、タイトル、チャンネル名の掲載有無を表示し、`AskUserQuestion` で「起票する / 中止」の明示 2 択を提示する。承認されるまで `gh issue create` を絶対に実行しない
+- GitHub issue は外部へ反映され、起票後はこのスキルから取り消せないことを承認時に警告する
+- entry の `context` と issue のタイトル・本文に、未マスクの機密情報を含めない
+- `gh issue create` が成功して issue URL を返した entry だけを `status="filed"` に更新し、同じ URL を `issue_url` に記録する
 
 ## 完了条件
 
-- `data/feedback/feedback-log.jsonl` の末尾に schema 準拠の JSONL が 1 行だけ追加されている
-- 既存行は変更・削除・並べ替えされていない
-- 新規 entry の `status` は `"recorded"` である
+### 記録モード
+
+- `feedback-log.jsonl` の末尾に schema 準拠の JSONL が 1 行だけ追加されている
+- 新規 entry の `status` は `"recorded"` で、`issue_url` はない
 - `context` 内の機密情報は `***REDACTED***` に置換されている
+
+### 還流モード
+
+- ユーザーが承認した entry ごとに、上流へ `feedback` ラベル付き issue が 1 件起票されている
+- 起票に成功した行だけが `status="filed"` と `issue_url` を持つ
+- 未選択、スキップ、起票失敗の行は変更されていない
+- 更新後の全行が entry schema に準拠し、JSONL の行数と順序が更新前と同じである
 
 ## References
 
 - Entry schema: `references/feedback-entry.schema.json`
+- Upstream issue body: `references/upstream-issue-template.md`
 
-## When to Use
+## モード選択
 
-| 状況 | 使う？ |
+| ユーザーの意図 | モード |
 |---|---|
-| 「さっきの `/thumbnail` の摩擦を記録して」 | ✅ 使う |
-| 「このスキル、ここでエラーになった」 | ✅ 使う |
-| 「この手順は改善できそう」 | ✅ 使う |
-| YouTube Analytics や投稿結果から得た運営上の学びを残す | ❌ `/analytics-analyze` や `/postmortem` を使う |
-| 記録済み feedback を GitHub issue 化する | ❌ このスキルでは行わない |
+| 「さっきの `/thumbnail` の摩擦を記録して」 | 記録 |
+| 「このスキル、ここでエラーになった」 | 記録 |
+| 「feedback を上流に還流して」 | 還流 |
+| 「今週の feedback 還流して」 | 還流 |
+| YouTube Analytics や投稿結果から得た運営上の学びを残す | 対象外。`/analytics-analyze` や `/postmortem` を使う |
 
 ## Entry Schema
 
@@ -42,10 +60,24 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 | `category` | yes | `bug` / `friction` / `idea` のいずれか |
 | `summary` | yes | 1 文の要約 |
 | `context` | yes | 再現状況・エラー抜粋・期待と実際の差分 |
-| `status` | yes | 新規記録時は必ず `recorded` |
-| `issue_url` | filed only | 後続工程で issue 化済みになった場合のみ URL を持つ |
+| `status` | yes | 未還流は `recorded`、起票済みは `filed` |
+| `issue_url` | filed only | `filed` にした GitHub issue の URL |
 
-## Instructions
+## 共通: 機密情報のマスク
+
+`context` に次の情報が含まれる場合は、値全体を `***REDACTED***` に置換する。
+
+- OAuth token / refresh token / access token / bearer token
+- API key / secret / password / private key
+- `.env` 由来の値
+- `auth/client_secrets.json` / `auth/token.json` の中身
+- `op://` 参照そのものを除く、1Password から取得した secret 値
+
+記録モードではマスク後の `context` だけを保存する。還流モードでも、既存 entry を
+信用してそのまま転記せず、タイトルと本文の組み立て前に同じ規則で再確認・再マスクする。
+未マスクの値をログ、画面、issue のタイトル・本文へ出してはならない。
+
+## 記録モード
 
 ### Step 1: 記録内容を確定
 
@@ -56,25 +88,12 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 - `summary`: 1 文に要約する
 - `context`: 再現状況、エラー抜粋、期待した挙動、実際の挙動を含める
 
-### Step 2: 機密情報をマスク
-
-`context` に次の情報が含まれる場合は、値全体を `***REDACTED***` に置換する。
-
-- OAuth token / refresh token / access token / bearer token
-- API key / secret / password / private key
-- `.env` 由来の値
-- `auth/client_secrets.json` / `auth/token.json` の中身
-- `op://` 参照そのものを除く、1Password から取得した secret 値
-
-マスク後の `context` だけを entry に入れる。未マスクの機密情報を
-`feedback-log.jsonl` に書き込んではならない。
-
-### Step 3: 追記先を用意
+### Step 2: 追記先を用意
 
 下流リポジトリのルートを基準に、`data/feedback/` が存在しなければ作成する。
 `data/feedback/feedback-log.jsonl` が存在しなければ新規作成する。
 
-### Step 4: append-only で 1 行追記
+### Step 3: append-only で 1 行追記
 
 既存の `feedback-log.jsonl` がある場合は、既存行を変更せず、末尾に 1 行だけ追記する。
 pretty print した複数行 JSON は使わない。
@@ -85,21 +104,113 @@ pretty print した複数行 JSON は使わない。
 {"date":"2026-07-11T15:02:24Z","skill":"thumbnail","category":"friction","summary":"生成結果が期待した構図から外れた","context":"ユーザーが夜景寄りのサムネを期待したが、出力は昼の室内風だった。エラーはなし。","status":"recorded"}
 ```
 
-### Step 5: 追記後チェック
-
-追記後に次を確認する。
+### Step 4: 追記後チェック
 
 - 追加されたのは末尾 1 行だけである
 - 追加行は `references/feedback-entry.schema.json` のフィールド要件に合っている
-- `status` は `"recorded"` である
-- `issue_url` は含めない
+- `status` は `"recorded"` で、`issue_url` は含まない
 - `context` に未マスクの token / secret / password / private key / API key が残っていない
 
 完了報告では、追記したファイルパス、対象スキル、category、summary だけを伝える。
 機密値や長い error log は再掲しない。
 
+## 還流モード
+
+### Step 1: 前提確認と未還流 entry の一覧提示
+
+`data/feedback/feedback-log.jsonl` の存在を確認する。存在しない場合は、先に記録モードで
+feedback を記録するよう案内して停止する。各行を JSON として読み、schema に準拠しない
+行が 1 行でもあれば、行番号だけを示して停止する。壊れた行を飛ばして続行しない。
+
+`status` が `"recorded"` の行だけを、元の行番号、`date`、`skill`、`category`、
+`summary` とともに一覧表示する。`context` は一覧に表示しない。候補が 0 件なら
+「未還流 feedback は 0 件」と報告して終了する。
+
+ユーザーに起票する行を選んでもらう。選択した各行について、行番号と元の JSON object
+全体を保持する。以後の更新対象はこの組で識別し、同内容の entry が複数あっても混同しない。
+
+### Step 2: 本文案とチャンネル名の掲載可否を確認
+
+各選択 entry から、タイトルを `[feedback][<skill>] <summary>` の形で作る。
+`references/upstream-issue-template.md` の全セクションを埋める。entry に独立したエラー
+抜粋がなければ「なし」と書き、情報を推測で補わない。
+
+発生チャンネル名は entry schema に含まれないため、自動推定・自動掲載しない。
+`AskUserQuestion` で「チャンネル名を掲載する / 掲載しない」の明示 2 択を entry ごとに
+提示する。掲載する場合はユーザーが明示した名前だけを使い、掲載しない場合は
+テンプレートの発生チャンネル欄を「掲載しない（ユーザー確認済み）」とする。
+
+タイトルと本文へ共通のマスク規則を再適用した後、ユーザーへ全文を提示する。
+
+### Step 3: open issue の重複照合
+
+起票前に上流の open issue を全件取得する。
+
+```bash
+gh api --paginate --method GET \
+  repos/daiki-beppu/youtube-automation/issues \
+  -f state=open \
+  -f per_page=100 \
+  --jq '.[] | select(has("pull_request") | not) | {number, title, url: .html_url}'
+```
+
+候補タイトルと open issue タイトルを、前後空白の除去、連続空白の 1 文字化、英字の
+小文字化をした文字列で照合する。次のどちらかなら類似候補として警告する。
+
+- 正規化後のタイトルが完全一致する
+- 同じ `[feedback][<skill>]` prefix を持ち、一方の prefix 後の全文が他方に含まれる
+
+類似候補の番号、タイトル、URL を表示し、`AskUserQuestion` で「それでも新規起票する /
+この entry をスキップ」の明示 2 択を提示する。ユーザーが選ぶまでその entry を起票しない。
+スキップした entry はログも変更しない。
+
+### Step 4: 最終承認ゲート
+
+スキップを除いた起票対象について、件数、各タイトル、発生チャンネル欄の内容を表示する。
+「GitHub issue として外部へ反映され、このスキルからは取り消せない」と警告し、
+`AskUserQuestion` で次の 2 択を提示する。
+
+1. 起票する
+2. 中止
+
+「起票する」が明示的に選ばれた場合だけ Step 5 へ進む。「中止」、無回答、曖昧な回答では
+`gh issue create` を実行せず、ログも変更しない。
+
+### Step 5: issue 起票と直後のログ更新
+
+承認済み entry を 1 件ずつ処理する。マスク済み本文を一時ファイルへ保存し、次を実行する。
+
+```bash
+gh issue create \
+  --repo daiki-beppu/youtube-automation \
+  --label feedback \
+  --title "<承認済みタイトル>" \
+  --body-file "<マスク済み本文の一時ファイル>"
+```
+
+exit code が 0 で、標準出力から当該 issue URL を取得できた場合だけ、該当する元の行を
+`status: "filed"`、`issue_url: "<取得した URL>"` に置換する。更新直前に、保持した行番号の
+現在値が保持した元 JSON object と完全一致することを確認する。一致しなければログを
+変更せず停止し、起票済み URL と状態更新失敗を報告する。
+
+ログ更新は一時ファイルに全行を JSONL 形式で書き出し、次をすべて確認してから元ファイルへ
+置換する。
+
+- 更新対象は保持した行番号の 1 行だけである
+- 更新後の対象行は `status="filed"` と取得した `issue_url` を持つ
+- 全行が `references/feedback-entry.schema.json` に準拠する
+- 行数と行順は更新前と同じである
+- 対象以外の行は byte-for-byte で同じである
+
+1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する。失敗した entry は
+`recorded` のままにし、成功済み issue の URL、未処理 entry、失敗箇所を報告する。
+
+### Step 6: 完了報告
+
+起票した issue のタイトルと URL、`filed` に更新した行番号、スキップした entry を報告する。
+機密値、本文全文、長い error log は再掲しない。
+
 ## Non-goals
 
-- 記録済み entry の GitHub issue 化
-- `status` を `filed` に変更すること
+- 起票された上流 issue のトリアージ・優先度付け
 - Analytics / postmortem 由来の運営知見の記録

--- a/.claude/skills/feedback/references/upstream-issue-template.md
+++ b/.claude/skills/feedback/references/upstream-issue-template.md
@@ -1,0 +1,23 @@
+# 概要
+
+{{summary}}
+
+## 発生スキル
+
+`/{{skill}}`
+
+## 下流での再現状況
+
+{{reproduction_context}}
+
+## エラー抜粋
+
+{{redacted_error_excerpt_or_none}}
+
+## 発生チャンネル
+
+{{user_approved_channel_name_or_omission}}
+
+---
+
+下流チャンネルリポジトリの `/feedback` から還流。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs(feedback)`: `/feedback` に、`status="recorded"` の未還流 entry を一覧・選択し、open issue の類似タイトル照合とユーザー承認を経て `daiki-beppu/youtube-automation` へ `feedback` ラベル付き issue を起票する還流モードを追加した。成功した entry は `status="filed"` と `issue_url` を記録して候補から除外し、二重起票を防ぐ。起票本文テンプレート、発生チャンネル掲載の個別確認、起票直前の機密情報再マスクも明記した（#1829）。
 - `docs(skills)`: 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を `data/feedback/feedback-log.jsonl` に append-only JSONL として記録する `/feedback` スキルを追加した。entry schema は `.claude/skills/feedback/references/feedback-entry.schema.json` に単一ソース化し、`date` / `skill` / `category` / `summary` / `context` / `status` / `issue_url` の構造、`status="recorded"` の新規記録、機密情報の `***REDACTED***` マスクを SKILL.md に明記した。下流配布 CLAUDE.md テンプレにもスキル摩擦時に `/feedback` を案内する導線を追加した（#1828）。
 - `docs(setup)`: `/setup` の全 check 緑後・完了報告前に、`workflow.wf_next` の音源 / アップロード承認ゲート、手動マスタリング検出スキップ、Veo 課金を伴う loop-video の有効状態を 1 問ずつ確認する運用設定インタビューを追加した。現在値と推奨回答を提示し、変更時だけ config を更新する（#1902）
 - `feat(upload)`: collection の `workflow-state.json::title_template_check.allow_volume_patterns: true` で、そのコレクションだけ公開タイトルの `Vol.` / `Part` / `#N` / ローマ数字の巻数表記を upload preflight で許可できるようにした。未設定・`false` の既定検出、RHS 鋳型・完全重複・核語彙の検査、および `content.json::title.template_check.volume_patterns` は変更しない（#1729）


### PR DESCRIPTION
## Summary

## 概要
#1828 の `feedback-log.jsonl` に溜まった未還流エントリ（status="recorded"）を、上流 `daiki-beppu/youtube-automation` へ `gh issue create` で起票する還流モードを `/feedback` スキルに追加する。起票済みエントリは status="filed" + issue URL で記録し二重起票を防ぐ。

## 背景・目的
記録（#1828）だけでは知見が下流に滞留する。`feedback` ラベル（「ユーザーフィードバック起点の issue」）への流入経路を機械化し、下流で踏んだ問題が上流のバックログに自動的に載る状態を作る。親 epic: #1827

## 提案する仕様
- `/feedback` の還流モード（例:「feedback を上流に還流して」で発動）
- 未還流エントリを一覧提示 → ユーザーが選択・承認 → `gh issue create --repo daiki-beppu/youtube-automation --label feedback` で起票
- 本文テンプレ: 概要 / 発生スキル / 下流での再現状況 / エラー抜粋（マスキング済み）/ 発生チャンネル（含めるか確認）
- 起票後、該当エントリの status を "filed" に更新し issue_url を記録

## ユースケース
- 週次ループの締めに「今週の feedback 還流して」→ 溜まった 3 件を確認しながら一括起票

## 参照資料
- .claude/skills/feedback/SKILL.md （#1828 の成果物。実装着手前に #1828 の完了が前提）
- .claude/skills/feedback/references/feedback-entry.schema.json
- docs/skill-design/skill-authoring-guidelines.md （承認ゲートのルール）

## 影響ファイル
- **変更**: .claude/skills/feedback/SKILL.md
- **新規**: .claude/skills/feedback/references/upstream-issue-template.md
- **変更**: CHANGELOG.md

**兄弟入口・貫通先**:
- feedback-log.jsonl の書き手（記録モード）と読み手（還流モード）が同一 SKILL.md 内に同居する → status 遷移（recorded → filed）の整合を両モードで維持する

## 要件
1. status="recorded" のエントリが 2 件ある状態で還流モードを実行する → 2 件が一覧提示され、ユーザー承認後に上流リポジトリへ feedback ラベル付き issue が起票される
2. 起票直後に還流モードを再実行する → 起票済みエントリ（status="filed"）は候補に出ず、二重起票されない
3. 起票前に上流の open issue タイトルと照合する → 類似 issue があれば警告を提示し、新規起票かスキップかをユーザーに確認する
4. ユーザーが承認しない限り `gh issue create` は実行されない（承認ゲート）
5. エントリの context に機密情報が残っている場合 → 起票本文でもマスキングが維持される

## スコープ外
- 起票された上流 issue のトリアージ・優先度付け（上流側の既存運用に委ねる）
- 記録の仕組み自体の変更（→ #1828）

## 実装方針（takt）
- workflow: docs
- 理由: SKILL.md・テンプレのみでコード変更を伴わないため

## Execution Report

Workflow `docs` completed successfully.

Closes #1829