### PR TITLE
[#1796] issue-1796-thumbnail-benchimaa

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark
-description: "Use when 競合チャンネルのベンチマークデータを最新化するとき。「競合データ収集」「ベンチマーク更新」で発動。docs/benchmarks/*.md を更新。収集済みデータの分析は /channel-research"
+description: "Use when 競合チャンネルのベンチマークデータを最新化するとき。「競合データ収集」「ベンチマーク更新」で発動。docs/benchmarks/*.md を更新。収集済みデータの分析は /channel-research、サムネイルだけの深掘りは /thumbnail-research"
 ---
 
 ## Overview

--- a/.claude/skills/channel-research/SKILL.md
+++ b/.claude/skills/channel-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: channel-research
-description: "Use when /benchmark と /viewer-voice の TTP ベンチマークデータを徹底分析するとき。「競合分析」「チャンネルリサーチ」「TTP 対象抽出」で発動。データ収集・更新は /benchmark（未実行なら先に案内）"
+description: "Use when /benchmark と /viewer-voice のデータからタイトル・動画尺・投稿・コメントを含むチャンネル全体を徹底分析するとき。「競合分析」「チャンネルリサーチ」「TTP 対象抽出」で発動。サムネイルだけの深掘りは /thumbnail-research。データ収集・更新は /benchmark（未実行なら先に案内）"
 ---
 
 ## Overview

--- a/.claude/skills/thumbnail-compare/SKILL.md
+++ b/.claude/skills/thumbnail-compare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: thumbnail-compare
-description: "Use when サムネイルを競合と並べて視認性を比較検証するとき。「サムネ比較」「目立ってるか確認」「モバイル表示テスト」「320px」で発動。方向性見直し時に必須"
+description: "Use when 自チャンネルの生成済みサムネイルを競合と並べて 320px 視認性を比較検証するとき。「サムネ比較」「目立ってるか確認」「モバイル表示テスト」「320px」で発動。競合だけの勝ちパターン分析は /thumbnail-research、生成は /thumbnail"
 ---
 
 ## Overview

--- a/.claude/skills/thumbnail-research/SKILL.md
+++ b/.claude/skills/thumbnail-research/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: thumbnail-research
+description: "Use when 収集済み競合サムネイルだけを再生数上位群 vs 下位群で深掘りし、勝ちパターンを抽出するとき。「サムネイル徹底分析」「競合サムネ分析」「サムネ勝ちパターン」で発動。データ収集は /benchmark、チャンネル全体の TTP 分析は /channel-research、生成は /thumbnail、320px 視認性比較は /thumbnail-compare"
+---
+
+## Hard Gates
+
+- `data/benchmark_*.json` と、次のいずれかの視覚情報が必要:
+  - `docs/benchmarks/thumbnails/` または `data/thumbnail_compare/benchmark/` の JPEG / PNG / WebP 画像
+  - 最新 benchmark JSON の `channels[].videos[].thumbnail_analysis` にある既存分析
+- `data/benchmark_*.json` が無い場合は、サムネイル画像の有無にかかわらず、再生数による上位群 / 下位群を決められないため、先に `/benchmark` を案内して停止する。
+- benchmark JSON があっても視覚情報が 1 件も無い場合は、`/benchmark` をサムネイル取得あり（`--no-thumbnails` を付けない）で再実行するよう案内して停止する。JSON の `thumbnail_url` だけを画像分析の代わりにしない。
+- 視覚情報と JSON を `video_id` で対応付けられる動画が 2 件未満なら、上位群 vs 下位群を比較できないためレポートを生成せず、`/benchmark` で対象データを増やすよう案内して停止する。
+- データ収集・画像生成・自チャンネル画像との 320px 比較は行わない。外部 API を呼ばず、既存のローカル成果物だけを分析する。
+
+## 完了条件
+
+- 最新 benchmark JSON と対応する視覚情報を使い、再生数上位群 / 下位群を同じ規則で抽出している
+- 構図・配色・テキスト配置・視線誘導・キャラ / 被写体の比較を、件数と割合を添えて記録している
+- 上位群と下位群の差から、勝ちパターン・負けパターン・判定保留を分離している
+- `/thumbnail` が参照画像選定と差分プロンプト作成に使える推奨事項を含む `docs/benchmarks/thumbnail-analysis.md` を生成している
+- 使用した入力パス、対象件数、生成先、主要な勝ちパターンをユーザーへ報告している
+
+## Overview
+
+`/benchmark` が収集した競合動画の再生数とサムネイル視覚情報を対応付け、上位群と下位群の差からサムネイル固有の勝ちパターンを抽出する。出力は `/thumbnail` の TTP 入力であり、サムネイルの生成や自チャンネルとの視認性比較はこのスキルでは行わない。
+
+## 実行フロー
+
+### Step 0: 入力存在確認
+
+リポジトリルート（チャンネルの独立リポジトリ）で、以下を実行する:
+
+```bash
+latest_benchmark="$(ls -t data/benchmark_*.json 2>/dev/null | head -1)"
+printf '%s\n' "$latest_benchmark"
+find docs/benchmarks/thumbnails data/thumbnail_compare/benchmark \
+  -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.webp' \) \
+  2>/dev/null | sort
+```
+
+`latest_benchmark` が空なら `/benchmark` を案内して停止する。画像一覧が空の場合は、最新 JSON の `channels[].videos[].thumbnail_analysis` に非 null の分析があるか確認する。画像も既存分析も無ければ、`/benchmark` を `--no-thumbnails` なしで再実行するよう案内して停止する。
+
+### Step 1: 分析対象の対応付け
+
+最新 benchmark JSON の `channels[].videos[]` から、各動画の `video_id`、`title`、`views`、`thumbnail_analysis` と、親 channel の `slug`、`name` を取得する。
+
+視覚情報は次の優先順で `video_id` に対応付ける:
+
+1. `docs/benchmarks/thumbnails/{slug}_{video_id}.jpg`
+2. `data/thumbnail_compare/benchmark/*_{video_id}.jpg`
+3. JSON の `thumbnail_analysis`（ローカル画像が無い動画だけ）
+
+ローカル画像は Read（Codex では同等の画像閲覧機能）で開く。画像も `thumbnail_analysis` も対応付かない動画は対象外とし、除外件数を記録する。`thumbnail_url` は対応確認に使えるメタデータだが、このスキルでは URL からダウンロードしない。
+
+### Step 2: 上位群 / 下位群の確定
+
+対応付け済み動画を `views` の降順で並べる。同数の場合は `video_id` の昇順を tie-break とする。
+
+- 対象件数を `N` とする
+- 群サイズを `K = ceil(N / 4)` とする
+- 先頭 `K` 件を上位群、末尾 `K` 件を下位群とする
+- 上位群と下位群の間にある動画は中間群として、パターン判定の分母に含めない
+
+`N < 2` なら Hard Gate に従って停止する。レポートには `N`、`K`、各群の最小 / 最大再生数、動画 ID を記録する。
+
+### Step 3: 同一ルーブリックで画像を分析
+
+上位群と下位群の全動画を、次のカテゴリで同じ粒度に分類する。観察できない項目を推測せず `判定不能` とする。
+
+| カテゴリ | 記録する項目 |
+|---|---|
+| 構図 | 主役位置（左 / 中央 / 右）、主役の画面占有率（小: 33% 未満 / 中: 33〜66% / 大: 66% 超）、奥行き、余白位置 |
+| 配色 | 支配色、アクセント色、暖色 / 寒色 / 混合、明 / 中 / 暗、高彩度 / 中彩度 / 低彩度、主役と背景のコントラスト |
+| テキスト配置 | 文字なし / 1〜10 文字 / 11 文字以上、言語、書体の印象、上 / 中央 / 下、左 / 中央 / 右、縁取りや影の有無 |
+| 視線誘導 | 最初に見る要素、2 番目に見る要素、その移動方向、視線を作る明暗・人物の目線・指差し・パース線 |
+| キャラ / 被写体 | 種別、人数 / 個数、顔の向き、カメラ目線の有無、表情、動作、背景との分離度 |
+
+各分類値について、上位群と下位群それぞれの `該当件数 / 判定可能件数` と割合を集計する。`判定不能` は割合の分母から除き、件数だけを別記する。
+
+### Step 4: 勝ちパターン判定
+
+分類値ごとに、上位群割合と下位群割合の差を percentage point（pp）で計算する。
+
+- **勝ちパターン**: 上位群で 60% 以上、かつ `上位群割合 - 下位群割合 >= 20pp`
+- **負けパターン**: 下位群で 60% 以上、かつ `下位群割合 - 上位群割合 >= 20pp`
+- **判定保留**: 上記のどちらにも該当しない、またはいずれかの群で判定可能件数が 0
+
+各勝ち / 負けパターンには、両群の件数・割合・差分、代表動画の `video_id` と画像パス（画像が無い場合は `thumbnail_analysis`）を根拠として添える。再生数との因果関係とは断定せず、この benchmark 母集団で観測した相関として記述する。
+
+### Step 5: レポート生成
+
+`docs/benchmarks/thumbnail-analysis.md` を次の構造で生成する:
+
+```markdown
+# ベンチマークサムネイル分析
+生成日: YYYY-MM-DD
+
+## 入力とサンプル定義
+- benchmark JSON: ...
+- 画像ディレクトリ: ...
+- 対応付け済み / 除外: N 件 / N 件
+- 上位群 / 下位群: K 件 / K 件
+
+## 上位群 vs 下位群
+### 構図
+### 配色
+### テキスト配置
+### 視線誘導
+### キャラ / 被写体
+
+## 勝ちパターン
+[件数・割合・差分・代表例]
+
+## 負けパターンと判定保留
+[件数・割合・差分・代表例]
+
+## /thumbnail への TTP 推奨事項
+### 維持する構造
+### テーマに合わせて差し替える要素
+### 避ける要素
+### 参照候補
+[video_id / views / 画像パス / 採用理由]
+
+## データ上の制約
+[サンプル数、欠損、相関であり因果ではない旨]
+```
+
+`/thumbnail` への推奨事項は、勝ちパターン判定で根拠が出た項目だけを書く。競合のロゴ・透かし・署名・チャンネル固有キャラクターは TTP 対象にせず、構図・配色・文字量・視線誘導などの構造へ抽象化する。
+
+### Step 6: 完了報告
+
+次をユーザーへ報告する:
+
+- 使用した benchmark JSON と画像ディレクトリ
+- 対応付け済み件数、上位群 / 下位群件数、除外件数
+- `docs/benchmarks/thumbnail-analysis.md` の生成
+- 主要な勝ちパターンと、`/thumbnail` で参照する次アクション
+
+## 障害時ガイダンス
+
+| 状況 | 対処 |
+|---|---|
+| benchmark JSON が無い | `/benchmark` を実行してから再実行する |
+| JSON はあるが画像も `thumbnail_analysis` も無い | `/benchmark` を `--no-thumbnails` なしで再実行する |
+| JSON と画像の `video_id` が対応しない | 最新 JSON と同じ収集結果の画像か確認し、`/benchmark` で揃え直す |
+| 対応付けが 2 件未満 | `/benchmark` の対象チャンネル / 収集結果を確認し、比較可能な件数を用意する |
+
+## Cross References
+
+- `/benchmark` → 前工程: 競合動画データとサムネイル画像の収集・更新
+- `/thumbnail` → 後工程: `docs/benchmarks/thumbnail-analysis.md` の勝ちパターンと参照候補を TTP 入力として生成
+- `/thumbnail-compare` → 生成候補と競合を並べた 320px 視認性比較
+- `/channel-research` → タイトル・動画尺・投稿・コメントを含むチャンネル全体の TTP 分析

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: thumbnail
-description: "Use when コレクションの YouTube サムネイル（thumbnail.jpg）を CTR 最適化し、textless main.png/jpg を後続生成するとき。「サムネイル」「画像生成」「アイキャッチ」で発動。SVG・汎用画像生成には使わない"
+description: "Use when コレクションの YouTube サムネイル（thumbnail.jpg）を CTR 最適化し、textless main.png/jpg を後続生成するとき。「サムネイル生成」「画像生成」「アイキャッチ」で発動。競合の勝ちパターン分析は /thumbnail-research、320px 視認性比較は /thumbnail-compare、SVG・汎用画像生成には使わない"
 ---
 
 ## Overview
@@ -234,7 +234,9 @@ uv run yt-generate-image \
 
 `/thumbnail` の標準手順は、**テキスト付き YouTube サムネ → 承認済みサムネから textless 動画背景**の順に進める。
 
-1. ベンチマーク先サムネを参照画像にして、構図・色温度・主役スケール・背景テクスチャを踏襲したテキスト付き YouTube サムネ候補を生成する。
+`docs/benchmarks/thumbnail-analysis.md` が存在する場合は、生成前に Read（Codex では同等のファイル閲覧）で開き、`## /thumbnail への TTP 推奨事項` の「維持する構造」「テーマに合わせて差し替える要素」「避ける要素」「参照候補」を、参照画像選定と差分プロンプトの入力にする。存在せず競合サムネイルの勝ちパターンを先に深掘りする場合は `/thumbnail-research` を実行する。
+
+1. ベンチマーク先サムネを参照画像にして、`thumbnail-analysis.md` がある場合はその勝ちパターンも使い、構図・色温度・主役スケール・背景テクスチャを踏襲したテキスト付き YouTube サムネ候補を生成する。
 2. `/thumbnail-compare` で 320px 視認性検証後にユーザー承認し、テキスト付き最終サムネを `10-assets/thumbnail.jpg` として確定する。
 3. 承認済み `thumbnail.jpg` を参照画像にして、タイトル文字・字幕・ロゴ・透かしを除去した textless 動画背景候補を生成する。
 4. 背景候補を `open` と `uv run yt-thumbnail-check` で確認し、ユーザー承認後に `10-assets/main.png` または `10-assets/main.jpg` として確定する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs(thumbnail-research)`: `/benchmark` の収集済み JSON と競合サムネイル画像を再生数上位群 / 下位群で比較し、構図・配色・テキスト配置・視線誘導・被写体の勝ちパターンを `docs/benchmarks/thumbnail-analysis.md` に出力する `/thumbnail-research` スキルを追加した。レポートの推奨事項と参照候補を `/thumbnail` の TTP 入力として相互参照し、データ収集・チャンネル全体分析・320px 視認性比較との発動条件を分離した（#1796）。
 - `docs(skills)`: 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を `data/feedback/feedback-log.jsonl` に append-only JSONL として記録する `/feedback` スキルを追加した。entry schema は `.claude/skills/feedback/references/feedback-entry.schema.json` に単一ソース化し、`date` / `skill` / `category` / `summary` / `context` / `status` / `issue_url` の構造、`status="recorded"` の新規記録、機密情報の `***REDACTED***` マスクを SKILL.md に明記した。下流配布 CLAUDE.md テンプレにもスキル摩擦時に `/feedback` を案内する導線を追加した（#1828）。
 - `docs(setup)`: `/setup` の全 check 緑後・完了報告前に、`workflow.wf_next` の音源 / アップロード承認ゲート、手動マスタリング検出スキップ、Veo 課金を伴う loop-video の有効状態を 1 問ずつ確認する運用設定インタビューを追加した。現在値と推奨回答を提示し、変更時だけ config を更新する（#1902）
 - `feat(upload)`: collection の `workflow-state.json::title_template_check.allow_volume_patterns: true` で、そのコレクションだけ公開タイトルの `Vol.` / `Part` / `#N` / ローマ数字の巻数表記を upload preflight で許可できるようにした。未設定・`false` の既定検出、RHS 鋳型・完全重複・核語彙の検査、および `content.json::title.template_check.volume_patterns` は変更しない（#1729）

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **46 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **47 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -93,6 +93,7 @@ YouTube Analytics と動画本体の解析。
 | Skill | なにができるか |
 |---|---|
 | /benchmark | 競合チャンネルの最新動画データを取得し `docs/benchmarks/*.md` を更新 |
+| /thumbnail-research | 収集済み競合サムネイルの再生数上位群 / 下位群を比較し、勝ちパターンと `/thumbnail` 向け TTP 推奨事項を生成 |
 
 ## 配信インフラ
 


### PR DESCRIPTION
## Summary

## 概要

`/benchmark` で収集済みのベンチマークデータ・サムネイル画像を入力に、競合サムネイルを徹底的に分析して勝ちパターンをレポート化する新スキル `/thumbnail-research` を追加する。分析結果は `/thumbnail`（生成）の TTP 入力として参照できる形で出力する。

## 背景・目的

サムネイル関連スキルは収集（/benchmark の軽量分析セクション）・視認性比較（/thumbnail-compare）・生成（/thumbnail）が存在するが、**サムネイル単独の深掘り分析**は /channel-research の 1 ステップに埋もれており、構図・配色・テキスト配置・勝ち動画/負け動画の比較といった観点を徹底的に掘る専用工程が無い。分析を独立スキル化し、生成工程へのフィードバックループを強化する。

## 提案する仕様

- 新スキル `.claude/skills/thumbnail-research/SKILL.md` を追加
- 入力: `data/benchmark_*.json`（thumbnail_analysis / サムネイル URL）、`docs/benchmarks/thumbnails/` または `data/thumbnail_compare/benchmark/` の画像
- 分析観点: 構図・配色・テキスト配置（量 / フォント / 位置）・視線誘導・キャラ/被写体の使い方を、再生数上位群 vs 下位群で比較し共通パターンを抽出
- 出力: `docs/benchmarks/thumbnail-analysis.md`（勝ちパターンの構造化レポート + /thumbnail への推奨事項）

## ユースケース

- 新コレクションのサムネイル制作前に競合の勝ちパターンを把握したい
- CTR が伸びない際、方向性見直しの材料として競合サムネイルの傾向を深掘りしたい
- /channel-research を全部回すほどではなく、サムネイルだけ集中的に分析したい

## 参照資料

- .claude/skills/benchmark/SKILL.md
- .claude/skills/channel-research/SKILL.md
- .claude/skills/thumbnail-compare/SKILL.md（references/compare_thumbnails.py 含む）
- .claude/skills/thumbnail/SKILL.md
- docs/skill-design/skill-authoring-guidelines.md

## 影響ファイル

- **新規**: .claude/skills/thumbnail-research/SKILL.md
- **新規**: .claude/skills/thumbnail-research/references/（画像取得スクリプト等が必要な場合。plan step で確定する）
- **変更**: CHANGELOG.md（[Unreleased] 追記）

**兄弟入口・貫通先**: なし（新規スキル追加のみ。`.claude/skills/` は wheel force-include により `yt-skills sync` へ自動反映され、`.agents/skills` symlink 経由で Codex からも参照される — 追加配線は不要）

## 要件

1. `/thumbnail-research` を発動する → ベンチマークサムネイルの分析が実行され `docs/benchmarks/thumbnail-analysis.md` が生成される
2. `data/benchmark_*.json` もサムネイル画像も無い状態で発動する → `/benchmark` を先に実行するよう案内して停止する（前提存在ガード）
3. レポートには再生数上位群 vs 下位群の比較に基づく勝ちパターン（構図・配色・テキスト配置・視線誘導）が構造化されて含まれる
4. `/thumbnail` 実行時に thumbnail-analysis.md を TTP 入力として参照できる旨が両スキルの導線（SKILL.md の相互参照）に明記される
5. SKILL.md の description が既存スキル（/benchmark, /channel-research, /thumbnail, /thumbnail-compare）と相互排他な発動キーワードを持ち、frontmatter description は double-quoted string で書かれている
6. skill-authoring-guidelines の 7 ルールに準拠している（Hard Gates 冒頭配置・references 単一ソース化 等）
7. CHANGELOG.md の [Unreleased] に追記されている

## スコープ外

- サムネイルの生成・改善そのもの（/thumbnail の責務）
- 視認性のモバイル表示比較（/thumbnail-compare の責務）
- ベンチマークデータの収集・更新（/benchmark の責務）
- /channel-research 既存 Step の改修・分析ロジックの移設（必要なら別 issue）
- 自チャンネルのサムネイル分析（/postmortem・/alignment-check の領域）

## 実装方針（takt）

- workflow: docs
- 理由: 新規 SKILL.md + references のみの skill 追加のため

## Execution Report

Workflow `docs` completed successfully.

Closes #1796