### PR TITLE
[#1899] issue-1899-suno-helper-lyrics

### DIFF
--- a/.claude/skills/suno-helper/SKILL.md
+++ b/.claude/skills/suno-helper/SKILL.md
@@ -198,7 +198,9 @@ handoff 条件（agent は自動突破しない）:
 - **任意停止**（`stopped`）: 次回 popup 起動時に resume バナーは出ない
 - **ERROR**（`error`）: 24h 以内なら resume バナーが出る。"再開" で失敗 entry から再実行
 - ERROR 文言の代表例（いずれも fail-loud で停止する）:
-  - `Lyrics 欄が見つかりません。Instrumental OFF（Custom Mode）になっているか確認してください。`
+  - `Lyrics mode が Instrumental になっています。Write に切り替えてください。`
+  - `Create form mode が Simple になっています。Advanced タブを選択してください。`
+  - 状態を特定できない場合は Advanced タブ / Lyrics mode = Write / UI 言語（英語推奨）のチェックリストを表示する
   - `reCAPTCHA を検知しました。手動で解決してから再開してください。`
   - `Clip multi-select verification failed: expected N selected, got M`
   - `中断: Add to Playlist dialog を検出できませんでした。clip が selected 状態であることを確認してください。Suno の UI 変更の可能性があります。`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(suno-helper)`: Lyrics 欄の不在・注入失敗時に、現行 Suno UI の ARIA 選択状態を read-only で診断し、Prompt / Instrumental なら Write、Simple / Sounds なら Advanced への切り替えを案内するよう改善した。状態を特定できない場合は Advanced / Write / 英語 UI 推奨のチェックリストを表示する（#1899）。
 - `fix(suno-helper)`: Lexical Lyrics 欄で paste 反映検証が失敗した場合に inject retry 後 beforeinput fallback を試し、全方式が失敗したときは entry 名・歌詞長・差分付き診断を出して停止するようにした（#1676）。
 - `fix(suno-helper)`: ユーザー操作による `stopped` を赤いエラー扱いにせず、「停止しました。再実行できます。」と通常状態で表示するようにした。
 - `fix(suno-helper)`: ダウンロード完了済み collection を popup の一覧から消さず、「完了 N/N」として再表示するように戻した。完了済み collection も選択でき、同じテストを再実行できる。

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -134,6 +134,80 @@ export interface ResolvedFields {
   title?: HTMLInputElement;
 }
 
+const LYRICS_MODE_NAMES = ["Write", "Prompt", "Instrumental"] as const;
+const CREATE_FORM_MODE_NAMES = ["Simple", "Advanced", "Sounds"] as const;
+
+function controlName(el: Element): string {
+  return (el.getAttribute("aria-label") ?? el.textContent ?? "").trim();
+}
+
+function selectedModeName(
+  groupRole: "radiogroup" | "tablist",
+  controlRole: "radio" | "tab",
+  selectedAttribute: "aria-checked" | "aria-selected",
+  modeNames: readonly string[],
+): string | null {
+  const expectedNames = new Map(
+    modeNames.map((name) => [name.toLowerCase(), name]),
+  );
+  const candidates = Array.from(
+    document.querySelectorAll(`[role="${groupRole}"]`),
+  ).flatMap((group) => {
+    const controls = Array.from(
+      group.querySelectorAll(`[role="${controlRole}"]`),
+    );
+    const names = controls.map(controlName);
+    if (
+      !modeNames.every((modeName) =>
+        names.some((name) => name.toLowerCase() === modeName.toLowerCase()),
+      )
+    ) {
+      return [];
+    }
+    const selected = controls.filter(
+      (control) => control.getAttribute(selectedAttribute) === "true",
+    );
+    if (selected.length !== 1) {
+      return [];
+    }
+    const canonicalName = expectedNames.get(
+      controlName(selected[0]).toLowerCase(),
+    );
+    return canonicalName ? [canonicalName] : [];
+  });
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+/** Lyrics 欄を表示するためにユーザーが確認すべき、現在の Suno UI 状態を返す。DOM は変更しない。 */
+export function diagnoseLyricsInputState(): string {
+  const lyricsMode = selectedModeName(
+    "radiogroup",
+    "radio",
+    "aria-checked",
+    LYRICS_MODE_NAMES,
+  );
+  if (lyricsMode === "Prompt" || lyricsMode === "Instrumental") {
+    return `Lyrics mode が ${lyricsMode} になっています。Write に切り替えてください。`;
+  }
+
+  const createFormMode = selectedModeName(
+    "tablist",
+    "tab",
+    "aria-selected",
+    CREATE_FORM_MODE_NAMES,
+  );
+  if (createFormMode === "Simple" || createFormMode === "Sounds") {
+    return `Create form mode が ${createFormMode} になっています。Advanced タブを選択してください。`;
+  }
+
+  return [
+    "Lyrics 欄を表示できる状態か確認してください:",
+    "- Advanced タブが選択されているか",
+    "- Lyrics mode が Write になっているか",
+    "- Suno の UI 言語が日本語になっていないか（英語推奨）",
+  ].join("\n");
+}
+
 export interface WaitForGenerationOptions {
   /** 中断フラグ。true を返した時点で待機を打ち切り resolve する。 */
   isAborted: () => boolean;
@@ -746,7 +820,7 @@ export function resolveFields(): ResolvedFields {
   ).filter(isVisible);
   if (areas.length === 0) {
     throw new FatalRunError(
-      "textarea が見つかりません。Suno の Custom Mode 画面を開いてください。",
+      `textarea が見つかりません。${diagnoseLyricsInputState()}`,
     );
   }
 

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -204,7 +204,7 @@ export function formatRunError(message: string): string {
   if (isExtensionReloadRequiredError(message)) {
     return `開始失敗: ${message}\n${EXTENSION_RELOAD_REQUIRED_MESSAGE}（⌘+Shift+R / Ctrl+Shift+R）`;
   }
-  return `開始失敗: ${message}\nSuno の Custom Mode 画面を開いた状態で実行してください。`;
+  return `開始失敗: ${message}\nSuno の Advanced タブを開き、Lyrics mode を確認してから実行してください。`;
 }
 
 export function formatStopError(message: string): string {

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -35,6 +35,7 @@ import { acquireDomRunLock, releaseDomRunLock } from "../lib/dom-run-lock";
 import {
   abortableSleep,
   CAPTCHA_WAIT_TIMEOUT_MS,
+  diagnoseLyricsInputState,
   FatalRunError,
   GENERATE_TIMEOUT_MS,
   LyricsPasteReflectionError,
@@ -461,7 +462,7 @@ export default defineContentScript({
                 fallbackError,
               });
               throw new FatalRunError(
-                `entry ${index} (${entryDisplayName(entry)}) の Lyrics 注入に失敗しました: ${message}`,
+                `entry ${index} (${entryDisplayName(entry)}) の Lyrics 注入に失敗しました: ${message}\n${diagnoseLyricsInputState()}`,
               );
             }
           },
@@ -472,9 +473,7 @@ export default defineContentScript({
       } else if (entry.lyrics) {
         // 歌詞があるのに Lyrics 欄が見つからないのは設定不整合。silent に飛ばさず停止する。
         // 設定不整合は全 entry で再発するため fatal（entry retry の対象外）。
-        throw new FatalRunError(
-          "Lyrics 欄が見つかりません。Instrumental OFF（Custom Mode）になっているか確認してください。",
-        );
+        throw new FatalRunError(`Lyrics 欄が見つかりません。${diagnoseLyricsInputState()}`);
       }
       if (title) {
         // Song Title は entry.title 優先、無ければ entry.name で代替する (#844)。

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -224,6 +224,34 @@ function makeTextarea(testId: string | null): HTMLTextAreaElement {
   return textarea;
 }
 
+function makeSelectedMode(
+  groupRole: "radiogroup" | "tablist",
+  controlRole: "radio" | "tab",
+  selectedAttribute: "aria-checked" | "aria-selected",
+  names: readonly string[],
+  selectedName: string,
+): void {
+  const group = document.createElement("div");
+  group.setAttribute("role", groupRole);
+  group.setAttribute("aria-label", "翻訳されたグループ名");
+  for (const name of names) {
+    const control = document.createElement("button");
+    control.setAttribute("role", controlRole);
+    control.setAttribute(selectedAttribute, String(name === selectedName));
+    control.textContent = name;
+    group.appendChild(control);
+  }
+  document.body.appendChild(group);
+}
+
+function makeLyricsMode(selectedName: "Write" | "Prompt" | "Instrumental"): void {
+  makeSelectedMode("radiogroup", "radio", "aria-checked", ["Write", "Prompt", "Instrumental"], selectedName);
+}
+
+function makeCreateFormMode(selectedName: "Simple" | "Advanced" | "Sounds"): void {
+  makeSelectedMode("tablist", "tab", "aria-selected", ["Simple", "Advanced", "Sounds"], selectedName);
+}
+
 function makeGenerateButton(): HTMLButtonElement {
   const button = document.createElement("button");
   button.textContent = "Create";
@@ -680,6 +708,108 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
     },
   );
 
+  it.each([
+    [
+      "Lyrics mode = Prompt",
+      () => {
+        makeTextarea(null);
+        makeLyricsMode("Prompt");
+        makeCreateFormMode("Advanced");
+      },
+      "Lyrics mode が Prompt になっています。Write に切り替えてください。",
+    ],
+    [
+      "Create form mode = Simple",
+      () => {
+        makeLyricsMode("Write");
+        makeCreateFormMode("Simple");
+      },
+      "Advanced タブを選択してください。",
+    ],
+  ] as const)(
+    "Given %s で非空 lyrics When run を受ける Then 状態診断つき ERROR で停止する",
+    async (_label, arrange, expected) => {
+      makeViewButton("Newest ▼");
+      makeViewButton("Grid");
+      arrange();
+      await loadContentScript();
+      const runHandler = getRunHandler();
+      const entries = [{ name: "vocal", style: "neo soul", lyrics: "sing this" }];
+      harness.runEntryWithRetry.mockImplementationOnce(async (options: RunEntryWithRetryOptions) => {
+        try {
+          await options.attempt();
+          return { outcome: "ok" };
+        } catch (error) {
+          return options.isFatal(error) ? { outcome: "fatal", error } : { outcome: "failed", error };
+        }
+      });
+
+      expect(runHandler({ data: makeRunPayload(entries) })).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(progressPayloads()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              phase: PHASE.ERROR,
+              message: expect.stringContaining(expected),
+            }),
+          ]),
+        ),
+      );
+      expect(harness.feedPollerStop).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("Given ARIA 状態を特定できず Lyrics 欄がない When run を受ける Then 3 項目 checklist つき ERROR で停止する", async () => {
+    makeViewButton("Newest ▼");
+    makeViewButton("Grid");
+    makeTextarea(null);
+    await loadContentScript();
+    const runHandler = getRunHandler();
+    const entries = [{ name: "vocal", style: "neo soul", lyrics: "sing this" }];
+    harness.runEntryWithRetry.mockImplementationOnce(async (options: RunEntryWithRetryOptions) => {
+      try {
+        await options.attempt();
+        return { outcome: "ok" };
+      } catch (error) {
+        return options.isFatal(error) ? { outcome: "fatal", error } : { outcome: "failed", error };
+      }
+    });
+
+    expect(runHandler({ data: makeRunPayload(entries) })).toEqual({ ok: true });
+
+    await vi.waitFor(() => {
+      const errorMessage = progressPayloads().find(
+        (payload): payload is { phase: string; message: string } =>
+          typeof payload === "object" && payload !== null && "phase" in payload && payload.phase === PHASE.ERROR,
+      )?.message;
+      expect(errorMessage).toContain("Advanced タブが選択されているか");
+      expect(errorMessage).toContain("Lyrics mode が Write になっているか");
+      expect(errorMessage).toContain("UI 言語が日本語になっていないか（英語推奨）");
+    });
+    expect(harness.feedPollerStop).toHaveBeenCalledOnce();
+  });
+
+  it("Given Lyrics 欄がなく entry.lyrics が空 When run を受ける Then従来どおり停止せず Generate する", async () => {
+    makeViewButton("Newest ▼");
+    makeViewButton("Grid");
+    makeTextarea(null);
+    const onGenerate = vi.fn();
+    makeGenerateButtonWithClickObserver(onGenerate);
+    addCompletedRemixCard();
+    await loadContentScript();
+    const runHandler = getRunHandler();
+    const entries = [{ name: "instrumental", style: "cinematic", lyrics: "" }];
+
+    expect(runHandler({ data: makeRunPayload(entries) })).toEqual({ ok: true });
+
+    await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce());
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ phase: PHASE.FINISHED, total: 1 })]),
+    );
+    expect(onGenerate).toHaveBeenCalledOnce();
+  });
+
   it("Given Lexical lyrics editor When run を受ける Then actual run handler が paste 完了後に Generate する", async () => {
     makeViewButton("Newest ▼");
     makeViewButton("Grid");
@@ -736,6 +866,8 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
     makeViewButton("Grid");
     makeTextarea(null);
     const lyrics = makeUnresponsiveLexicalLyrics("old lyrics");
+    makeLyricsMode("Write");
+    makeCreateFormMode("Advanced");
     const onGenerate = vi.fn();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     makeGenerateButtonWithClickObserver(onGenerate);
@@ -769,6 +901,15 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
     );
     expect(onGenerate).not.toHaveBeenCalled();
     expect(lyrics.textContent).toBe("old lyrics");
+    const errorMessage = (
+      progressPayloads().find(
+        (payload): payload is { phase: string; message: string } =>
+          typeof payload === "object" && payload !== null && "phase" in payload && payload.phase === PHASE.ERROR,
+      ) as { message: string }
+    ).message;
+    expect(errorMessage).toContain("Advanced タブが選択されているか");
+    expect(errorMessage).toContain("Lyrics mode が Write になっているか");
+    expect(errorMessage).toContain("UI 言語が日本語になっていないか（英語推奨）");
     expect(consoleError).toHaveBeenCalledWith(
       "[suno-helper] Lyrics 欄への全注入方式が失敗しました",
       expect.objectContaining({

--- a/extensions/suno-helper/tests/content-script-missing-hint.test.ts
+++ b/extensions/suno-helper/tests/content-script-missing-hint.test.ts
@@ -27,9 +27,10 @@ describe("formatRunError", () => {
     expect(text).toMatch(/⌘\+Shift\+R/);
   });
 
-  it("Given 他のエラー When formatRunError Then Custom Mode 起動案内を返す（従来挙動）", () => {
+  it("Given 他のエラー When formatRunError Then Advanced と Lyrics mode の案内を返す", () => {
     const text = formatRunError("アクティブなタブが見つかりません。");
-    expect(text).toMatch(/Custom Mode 画面を開いた状態/);
+    expect(text).toMatch(/Advanced タブ/);
+    expect(text).toMatch(/Lyrics mode/);
     expect(text).not.toMatch(/ハードリロード/);
   });
 });

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   abortableSleep,
   detectRecaptcha,
+  diagnoseLyricsInputState,
   isQueueLimitErrorVisible,
   QUEUE_LIMIT_ERROR_SELECTOR,
   resolveAdvancedFields,
@@ -105,8 +106,117 @@ function addLexicalLyrics(
   return div;
 }
 
+function addModeGroup(
+  groupRole: "radiogroup" | "tablist",
+  controlRole: "radio" | "tab",
+  selectedAttribute: "aria-checked" | "aria-selected",
+  names: readonly string[],
+  selectedName: string,
+  groupLabel: string,
+): void {
+  const group = document.createElement("div");
+  group.setAttribute("role", groupRole);
+  group.setAttribute("aria-label", groupLabel);
+  for (const name of names) {
+    const control = document.createElement("button");
+    control.setAttribute("role", controlRole);
+    control.setAttribute(selectedAttribute, String(name === selectedName));
+    control.textContent = name;
+    group.appendChild(control);
+  }
+  document.body.appendChild(group);
+}
+
+function addLyricsMode(selectedName: "Write" | "Prompt" | "Instrumental", groupLabel = "歌詞モード"): void {
+  addModeGroup("radiogroup", "radio", "aria-checked", ["Write", "Prompt", "Instrumental"], selectedName, groupLabel);
+}
+
+function addCreateFormMode(selectedName: "Simple" | "Advanced" | "Sounds", groupLabel = "作成フォームモード"): void {
+  addModeGroup("tablist", "tab", "aria-selected", ["Simple", "Advanced", "Sounds"], selectedName, groupLabel);
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
+});
+
+describe("diagnoseLyricsInputState: 現行 Suno UI の ARIA 状態診断 (#1899)", () => {
+  it.each(["Prompt", "Instrumental"] as const)(
+    "Given Lyrics mode が %s When 診断する Then 選択中モードと Write への切り替えを案内する",
+    (selectedName) => {
+      addLyricsMode(selectedName);
+      addCreateFormMode("Advanced");
+
+      expect(diagnoseLyricsInputState()).toBe(
+        `Lyrics mode が ${selectedName} になっています。Write に切り替えてください。`,
+      );
+    },
+  );
+
+  it.each(["Simple", "Sounds"] as const)(
+    "Given Create form mode が %s When 診断する Then Advanced タブを案内する",
+    (selectedName) => {
+      addLyricsMode("Write");
+      addCreateFormMode(selectedName);
+
+      expect(diagnoseLyricsInputState()).toBe(
+        `Create form mode が ${selectedName} になっています。Advanced タブを選択してください。`,
+      );
+    },
+  );
+
+  it("Given Lyrics mode と Create form mode の両方が不正 When 診断する Then Lyrics mode を優先する", () => {
+    addLyricsMode("Instrumental");
+    addCreateFormMode("Simple");
+
+    expect(diagnoseLyricsInputState()).toMatch(/^Lyrics mode が Instrumental/);
+  });
+
+  it("Given group の aria-label が英語名でない When 診断する Then role 構造と選択属性で状態を特定する", () => {
+    addLyricsMode("Prompt", "翻訳されたラベル");
+    addCreateFormMode("Advanced", "別の翻訳されたラベル");
+
+    expect(diagnoseLyricsInputState()).toContain("Lyrics mode が Prompt");
+  });
+
+  it.each([
+    ["group 不在", (): void => undefined],
+    [
+      "選択状態不明",
+      (): void =>
+        addModeGroup("radiogroup", "radio", "aria-checked", ["Write", "Prompt", "Instrumental"], "", "歌詞モード"),
+    ],
+    [
+      "Advanced + Write",
+      (): void => {
+        addLyricsMode("Write");
+        addCreateFormMode("Advanced");
+      },
+    ],
+  ] as const)("Given %s When 診断する Then 3 項目の fallback チェックリストを返す", (_label, arrange) => {
+    arrange();
+
+    const message = diagnoseLyricsInputState();
+    expect(message).toContain("Advanced タブが選択されているか");
+    expect(message).toContain("Lyrics mode が Write になっているか");
+    expect(message).toContain("UI 言語が日本語になっていないか（英語推奨）");
+  });
+
+  it("Given ARIA 状態を持つ DOM When 診断する Then DOM を変更しない", () => {
+    addLyricsMode("Prompt");
+    addCreateFormMode("Simple");
+    const before = document.body.innerHTML;
+
+    diagnoseLyricsInputState();
+
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  it("Given textarea 不在かつ Sounds 選択 When resolveFields Then Advanced 案内つきで fail-loud する", () => {
+    addLyricsMode("Write");
+    addCreateFormMode("Sounds");
+
+    expect(() => resolveFields()).toThrow("Advanced タブを選択してください");
+  });
 });
 
 describe("setNativeValue: React 互換の値注入", () => {


### PR DESCRIPTION
## Summary

## 概要

suno-helper で歌詞（Lyrics）の注入に失敗したときのエラーメッセージが旧 Suno UI（Custom Mode トグル + Instrumental チェックボックス）前提のままで、現行 UI ではユーザーを正しい復旧操作に誘導できない。現行 UI の実 DOM 構造（2026-07 に chrome-devtools-mcp で実機確認済み）に合わせ、状態検出つきの診断メッセージへ改善する。

## 背景・目的

現行の Suno create 画面（suno.com/create）は旧 UI から以下のように変わっている（実 DOM 確認済み）:

| 旧 UI（現エラーメッセージの前提） | 現行 UI（実 DOM） |
| --- | --- |
| Custom Mode トグル | タブ `role="tablist"` aria-label="Create form mode": **Simple / Advanced / Sounds** |
| Instrumental チェックボックス | ラジオ `role="radiogroup"` aria-label="Lyrics mode": **Write / Prompt / Instrumental**（`aria-checked` で状態取得可） |
| `[data-testid="lyrics-textarea"]` | 存在しない。Lexical editor `div.lyrics-editor-content[data-lexical-editor][contenteditable]` のみ |

歌詞欄が表示される条件は「**Advanced タブ選択 + Lyrics mode = Write**」。現行のエラーメッセージ「Instrumental OFF（Custom Mode）になっているか確認してください」は存在しない UI を案内しており、また「UI 言語が日本語になっていないか」「Lyrics mode が Write か」という主要な失敗原因への言及がない。

ARIA 属性（`role="radiogroup"` / `role="tab"` / `aria-checked` / `aria-selected`）はロケール非依存のため、日本語 UI でも壊れない状態検出の基盤に使える。一方 `aria-label="Lyrics mode"` 等のラベル文字列は翻訳される可能性があるため、ラベル文字列単独に依存した検出は避ける。

## 提案する仕様

1. **状態検出つき診断メッセージ**: Lyrics 欄が見つからない / 注入に失敗したとき、read-only で DOM 状態を読み取り原因を特定したメッセージを出す:
   - Lyrics mode ラジオが Prompt / Instrumental → 「Lyrics mode が {選択中モード} になっています。Write に切り替えてください」
   - Simple / Sounds タブ選択中 → 「Advanced タブを選択してください」
2. **fallback チェックリスト**: 状態検出に失敗した場合（radiogroup / tablist が見つからない等）は、汎用チェックリストを列挙するメッセージに fallback する:
   - Advanced タブが選択されているか
   - Lyrics mode が Write になっているか
   - Suno の UI 言語が日本語になっていないか（英語推奨）
3. **旧 UI 用語の一掃（エラーメッセージのみ）**: `dom.ts` / `runner-errors.ts` の「Custom Mode」「Instrumental OFF」文言を現行 UI 用語へ置き換える
4. 既存の read-only 設計を維持する（タブ・ラジオの自動クリックはしない）

## ユースケース

- Suno 側が Lyrics mode を記憶しておらず Instrumental に戻っていた場合、operator（または AFK 実行中の agent）がエラーメッセージだけで正しい復旧操作（Write へ切り替え）に到達できる
- 日本語 UI で実行して失敗した場合、チェックリストから UI 言語を疑える

## 参照資料

- extensions/shared/dom.ts（セレクタ SSOT・`resolveFields()`:743・`setLyricsValue()`:316・エラーメッセージ:749）
- extensions/suno-helper/entrypoints/content.ts（オーケストレーション・エラーメッセージ:411）
- extensions/suno-helper/components/runner-errors.ts（エラー整形:194）
- extensions/suno-helper/tests/content-script-missing-hint.test.ts（既存文言のテスト）
- extensions/suno-helper/tests/dom.test.ts（歌詞注入テスト）
- .claude/skills/suno-helper/SKILL.md（トラブルシュート節:201）

### 実機確認済みの現行 DOM（2026-07-11、UI 言語 en）

- Create form モードタブ: `[role="tablist"][aria-label="Create form mode"]` > `[role="tab"]`（Simple / Advanced / Sounds、`aria-selected`）
- Lyrics mode: `[role="radiogroup"][aria-label="Lyrics mode"]` > `button[role="radio"]`（Write / Prompt / Instrumental、`aria-checked`）
- 歌詞欄: `div.lyrics-editor-content[data-lexical-editor][contenteditable]`（`[data-testid="lyrics-textarea"]` は不在）
- 注意: `aria-label` の文字列は UI 言語で翻訳される可能性があるため、検出は role 構造 + 状態属性ベースを優先する

## 影響ファイル

- **変更**: extensions/shared/dom.ts
- **変更**: extensions/suno-helper/entrypoints/content.ts
- **変更**: extensions/suno-helper/components/runner-errors.ts
- **変更**: extensions/suno-helper/tests/content-script-missing-hint.test.ts
- **変更**: extensions/suno-helper/tests/dom.test.ts（検出ロジックのテスト追加先は plan step で確定）
- **変更**: .claude/skills/suno-helper/SKILL.md

**兄弟入口・貫通先**: なし（Lyrics 注入経路は suno-helper 拡張の content script のみ。distrokid-helper は Suno UI を扱わない。関連する #1866 / #1840 は別セレクタの検出問題で本 issue のスコープ外）

## 要件

1. Lyrics mode ラジオが Prompt または Instrumental の状態で歌詞注入を試みる → 選択中モード名を含む「Write に切り替えてください」系のエラーで停止する
2. Simple / Sounds タブ選択中に実行する → 「Advanced タブを選択してください」を含むエラーで停止する
3. 状態検出に失敗した場合（radiogroup / tablist 不在）→ 汎用チェックリスト（Advanced タブ / Lyrics mode = Write / UI 言語が日本語なら英語推奨）を列挙する fallback メッセージが出る
4. `extensions/shared/dom.ts` / `extensions/suno-helper/components/runner-errors.ts` から「Custom Mode」「Instrumental OFF」文言が消え、現行 UI 用語に置き換わった状態で既存テストが pass する
5. .claude/skills/suno-helper/SKILL.md のトラブルシュート節（エラーメッセージ引用箇所）が新メッセージに追従している

## スコープ外

- suno / suno-helper の SKILL.md・README・package.json / wxt.config.ts description 等に残る「Custom Mode」用語の一斉置換（挙動に影響しないドキュメント文言 → 別 issue）
- #1866（vocal_gender ボタン検出）・#1840（Exclude Styles 欄検出）が扱う日本語 UI セレクタ問題そのもの
- タブ・ラジオを自動クリックする自動修復（read-only 設計を維持）
- `[data-testid="lyrics-textarea"]` セレクタの削除・整理（fallback として無害なため現状維持）

## 受け入れ基準

- [ ] `extensions/suno-helper/` で `pnpm lint` が exit 0 になる
- [ ] `extensions/suno-helper/` で `pnpm test` が成功する
- [ ] `extensions/suno-helper/` で `pnpm compile` が exit 0 になる
- [ ] `extensions/suno-helper/` で `pnpm format:check` が exit 0 になる
- [ ] CHANGELOG.md の [Unreleased] に追記されている（.claude/skills 変更を含むため CHANGELOG ゲート対象）

## 実装方針（takt）

- workflow: improve
- 理由: 既存エラーメッセージ経路の挙動改善（公開 IF 変更なし）のため

## Execution Report

Workflow `improve` completed successfully.

Closes #1899