### PR TITLE
[#1895] issue-1895-komento-oonaa-miwos

### DIFF
--- a/.claude/skills/comments-reply/SKILL.md
+++ b/.claude/skills/comments-reply/SKILL.md
@@ -10,7 +10,7 @@ YouTube Data API v3 の `commentThreads.list` / `comments.insert` を使い、
 
 - **dry-run**: 対象コメントと生成返信テキストのプレビューのみ（API 書き込みなし）
 - **apply**: 実際に YouTube 側へ返信を反映、同時に履歴 JSON を更新
-- **対象条件**: `ng_words` / 既返信 / held for review / 自チャンネル自身のコメント等の基本フィルタを通過した全コメント
+- **対象条件**: `ng_words` / 既返信 / held for review / 自チャンネル自身のコメント / 対象より後のオーナー返信等の基本フィルタを通過した全コメント
 
 ## 前提
 
@@ -128,7 +128,7 @@ uv run yt-comments-reply --dry-run --agent-replies-file /tmp/comment-replies.jso
 出力の確認ポイント(**全項目 PASS の場合のみ** Phase 6 へ進む):
 - [ ] `返信候補` が期待件数になっている
 - [ ] `reply` 欄の Agent 生成文がチャンネル persona とコメント言語に合っている
-- [ ] `skipped` の内訳が想定どおりである(`already_replied` / `ng_word` / `reply_contains_ng_word` 以外の予期しない skip がない)
+- [ ] `skipped` の内訳が想定どおりである(`already_replied` / `owner_replied` / `ng_word` / `reply_contains_ng_word` 以外の予期しない skip がない。`owner_replied` は同一スレッドに対象コメントより後のオーナー返信がある場合)
 - [ ] `agent_reply_missing` は Reviewer 起因の除外一覧と `comment_id` が一致するものだけである（一致しない場合は `/tmp/comment-replies.json` に該当返信を追加して再実行）
 
 1 項目でも FAIL なら返信文を修正して dry-run（Phase 5）を再実行する。FAIL のまま Phase 6 に進んではならない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(comments-reply)`: 同一スレッド内で対象コメントより後に投稿されたオーナー返信を検出し、Studio 等で手動返信済みのコメントへの重複返信を防止した。オーナー返信後の視聴者フォローアップは引き続き候補に含める（#1895）
 - `fix(suno-helper)`: Lexical Lyrics 欄で paste 反映検証が失敗した場合に inject retry 後 beforeinput fallback を試し、全方式が失敗したときは entry 名・歌詞長・差分付き診断を出して停止するようにした（#1676）。
 - `fix(suno-helper)`: ユーザー操作による `stopped` を赤いエラー扱いにせず、「停止しました。再実行できます。」と通常状態で表示するようにした。
 - `fix(suno-helper)`: ダウンロード完了済み collection を popup の一覧から消さず、「完了 N/N」として再表示するように戻した。完了済み collection も選択でき、同じテストを再実行できる。

--- a/src/youtube_automation/utils/comments/replier.py
+++ b/src/youtube_automation/utils/comments/replier.py
@@ -241,18 +241,50 @@ class CommentReplier:
         limit: int,
         export_candidates: bool,
     ) -> None:
-        comments = fetch_comments(self._youtube, video_id=video_id, max_results=per_video_limit, since=since)
-        while len(plan.planned) < limit:
-            try:
-                comment = next(comments)
-            except StopIteration:
-                return
-            except YouTubeAPIError as e:
-                if not _is_comments_disabled_error(e):
-                    raise
-                plan.skipped.append(self._video_skip_record(video_id, _COMMENTS_DISABLED_SKIP_REASON))
-                return
-            self._process_comment(comment, plan, dry_run, export_candidates)
+        comments = iter(fetch_comments(self._youtube, video_id=video_id, max_results=per_video_limit, since=since))
+        next_comment: FetchedComment | None = None
+        try:
+            while len(plan.planned) < limit:
+                if next_comment is None:
+                    try:
+                        first_comment = next(comments)
+                    except StopIteration:
+                        return
+                else:
+                    first_comment = next_comment
+                    next_comment = None
+                if len(plan.planned) + 1 == limit and self._skip_reason(first_comment, ()) is None:
+                    self._process_comment(first_comment, plan, dry_run, export_candidates, ())
+                    if len(plan.planned) >= limit:
+                        return
+                    thread_comments = []
+                else:
+                    thread_comments = [first_comment]
+                thread_id = first_comment.parent_id or first_comment.comment_id
+                while True:
+                    try:
+                        comment = next(comments)
+                    except StopIteration:
+                        break
+                    if (comment.parent_id or comment.comment_id) != thread_id:
+                        next_comment = comment
+                        break
+                    thread_comments.append(comment)
+                owner_reply_times = tuple(
+                    published_at
+                    for comment in thread_comments
+                    if comment.parent_id is not None
+                    and comment.author_channel_id == self._owner_channel_id
+                    and (published_at := _parse_published_at(comment.published_at)) is not None
+                )
+                for comment in thread_comments:
+                    if len(plan.planned) >= limit:
+                        return
+                    self._process_comment(comment, plan, dry_run, export_candidates, owner_reply_times)
+        except YouTubeAPIError as e:
+            if not _is_comments_disabled_error(e):
+                raise
+            plan.skipped.append(self._video_skip_record(video_id, _COMMENTS_DISABLED_SKIP_REASON))
 
     def _get_title(self, video_id: str) -> str:
         if video_id in self._title_cache:
@@ -274,8 +306,9 @@ class CommentReplier:
         plan: ReplyPlan,
         dry_run: bool,
         export_candidates: bool,
+        owner_reply_times: tuple[datetime, ...],
     ) -> None:
-        skip_reason = self._skip_reason(comment)
+        skip_reason = self._skip_reason(comment, owner_reply_times)
         if skip_reason is not None:
             plan.skipped.append(self._skip_record(comment, skip_reason))
             return
@@ -390,7 +423,7 @@ class CommentReplier:
         plan.skipped.append(self._skip_record(comment, "llm_error_skip"))
         return None
 
-    def _skip_reason(self, comment: FetchedComment) -> str | None:
+    def _skip_reason(self, comment: FetchedComment, owner_reply_times: tuple[datetime, ...]) -> str | None:
         if not comment.can_reply:
             return "canReply=False"
         if self._config.skip_held_for_review and comment.moderation_status == _HELD_FOR_REVIEW:
@@ -403,6 +436,11 @@ class CommentReplier:
         # reply 走査時に履歴外の自分のコメントを拾わないよう authorChannelId で除外する
         if self._owner_channel_id and comment.author_channel_id == self._owner_channel_id:
             return "own_comment"
+        published_at = _parse_published_at(comment.published_at)
+        if published_at is not None and any(
+            owner_published_at > published_at for owner_published_at in owner_reply_times
+        ):
+            return "owner_replied"
         return None
 
     def _audit_reply_text(
@@ -553,6 +591,16 @@ class CommentReplier:
 
 def _is_comments_disabled_error(error: YouTubeAPIError) -> bool:
     return error.status_code == 403 and error.reason == _COMMENTS_DISABLED_API_REASON
+
+
+def _parse_published_at(value: str) -> datetime | None:
+    try:
+        published_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if published_at.tzinfo is None:
+        return None
+    return published_at
 
 
 def _author_mention(author: str | None) -> str | None:

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -88,6 +88,7 @@ def _mock_youtube(
             raise raw
         items = []
         for c in raw:
+            replies = c.get("replies", [])
             top_snippet: dict = {
                 "authorDisplayName": c.get("author", "Unknown"),
                 "textOriginal": c["text"],
@@ -96,18 +97,35 @@ def _mock_youtube(
             }
             if c.get("author_channel_id"):
                 top_snippet["authorChannelId"] = {"value": c["author_channel_id"]}
-            items.append(
-                {
-                    "snippet": {
-                        "canReply": c.get("can_reply", True),
-                        "totalReplyCount": c.get("total_reply_count", 0),
-                        "topLevelComment": {
-                            "id": c["comment_id"],
-                            "snippet": top_snippet,
-                        },
-                    }
+            item = {
+                "snippet": {
+                    "canReply": c.get("can_reply", True),
+                    "totalReplyCount": c.get("total_reply_count", len(replies)),
+                    "topLevelComment": {
+                        "id": c["comment_id"],
+                        "snippet": top_snippet,
+                    },
                 }
-            )
+            }
+            if replies:
+                item["replies"] = {
+                    "comments": [
+                        {
+                            "id": reply["comment_id"],
+                            "snippet": {
+                                "authorDisplayName": reply.get("author", "Unknown"),
+                                "authorChannelId": {"value": reply["author_channel_id"]}
+                                if reply.get("author_channel_id")
+                                else {},
+                                "textOriginal": reply["text"],
+                                "publishedAt": reply.get("published_at", "2026-04-01T00:00:00Z"),
+                                "moderationStatus": reply.get("moderation_status"),
+                            },
+                        }
+                        for reply in replies
+                    ]
+                }
+            items.append(item)
         return {"items": items}
 
     _list_execute.current_video_id = None
@@ -129,6 +147,59 @@ def _mock_youtube(
         insert_mock.execute.return_value = {"id": "insert-ok"}
     yt.comments.return_value.insert.return_value = insert_mock
     yt._insert_mock = insert_mock
+    return yt
+
+
+def _mock_youtube_with_paginated_owner_reply(owner_id: str) -> MagicMock:
+    inline_replies = [
+        {
+            "comment_id": f"viewer-{index}",
+            "text": f"Viewer reply {index}",
+            "author": "Viewer",
+            "author_channel_id": "UCviewer",
+            "published_at": f"2026-04-01T0{index}:00:00Z",
+        }
+        for index in range(1, 6)
+    ]
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "total_reply_count": 6,
+                    "replies": inline_replies,
+                }
+            ]
+        },
+    )
+    yt.comments.return_value.list.return_value.execute.return_value = {
+        "items": [
+            *[
+                {
+                    "id": reply["comment_id"],
+                    "snippet": {
+                        "authorDisplayName": reply["author"],
+                        "authorChannelId": {"value": reply["author_channel_id"]},
+                        "textOriginal": reply["text"],
+                        "publishedAt": reply["published_at"],
+                    },
+                }
+                for reply in inline_replies
+            ],
+            {
+                "id": "owner-page-2",
+                "snippet": {
+                    "authorDisplayName": "Owner",
+                    "authorChannelId": {"value": owner_id},
+                    "textOriginal": "Owner answer",
+                    "publishedAt": "2026-04-01T06:00:00Z",
+                },
+            },
+        ]
+    }
     return yt
 
 
@@ -314,6 +385,451 @@ def test_export_candidates_does_not_call_generator(tmp_path, _mock_default_genai
     _mock_default_genai_client.models.generate_content.assert_not_called()
 
 
+def test_dry_run_skips_viewer_reply_when_owner_replied_later_in_thread(tmp_path):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "viewer-reply",
+                            "text": "Follow-up question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": "2026-04-01T01:00:00Z",
+                        },
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T02:00:00Z",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    yt.comments.return_value.list.return_value.execute.return_value = {"items": []}
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert "viewer-reply" not in {row["comment_id"] for row in plan.planned}
+    assert any(row["comment_id"] == "viewer-reply" and row["reason"] == "owner_replied" for row in plan.skipped)
+    yt.commentThreads.return_value.list.assert_called_once()
+    yt.comments.return_value.list.assert_not_called()
+
+
+def test_export_candidates_excludes_comment_with_later_owner_reply(tmp_path, _mock_default_genai_client):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T01:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True, export_candidates=True)
+
+    assert "top" not in {row["comment_id"] for row in plan.planned}
+    assert any(row["comment_id"] == "top" and row["reason"] == "owner_replied" for row in plan.skipped)
+    _mock_default_genai_client.models.generate_content.assert_not_called()
+
+
+def test_dry_run_skips_comments_when_paginated_owner_reply_is_later(tmp_path):
+    owner_id = "UCowner"
+    yt = _mock_youtube_with_paginated_owner_reply(owner_id)
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    skipped = {(row["comment_id"], row["reason"]) for row in plan.skipped}
+    assert ("top", "owner_replied") in skipped
+    assert ("viewer-1", "owner_replied") in skipped
+    assert "top" not in {row["comment_id"] for row in plan.planned}
+    assert "viewer-1" not in {row["comment_id"] for row in plan.planned}
+    yt.comments.return_value.list.assert_called_once()
+
+
+def test_export_candidates_excludes_comment_with_paginated_owner_reply(
+    tmp_path,
+    _mock_default_genai_client,
+):
+    owner_id = "UCowner"
+    yt = _mock_youtube_with_paginated_owner_reply(owner_id)
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True, export_candidates=True)
+
+    assert "top" not in {row["comment_id"] for row in plan.planned}
+    assert any(row["comment_id"] == "top" and row["reason"] == "owner_replied" for row in plan.skipped)
+    yt.comments.return_value.list.assert_called_once()
+    _mock_default_genai_client.models.generate_content.assert_not_called()
+
+
+def test_apply_does_not_post_to_comment_with_later_owner_reply(tmp_path, _mock_default_genai_client):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T01:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=False)
+
+    assert plan.planned == []
+    assert plan.replied == []
+    assert any(row["comment_id"] == "top" and row["reason"] == "owner_replied" for row in plan.skipped)
+    yt._insert_mock.execute.assert_not_called()
+    _mock_default_genai_client.models.generate_content.assert_not_called()
+
+
+def test_viewer_follow_up_after_owner_reply_remains_candidate(tmp_path):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T01:00:00Z",
+                        },
+                        {
+                            "comment_id": "viewer-follow-up",
+                            "text": "One more question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": "2026-04-01T02:00:00Z",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert any(row["comment_id"] == "top" and row["reason"] == "owner_replied" for row in plan.skipped)
+    assert "viewer-follow-up" in {row["comment_id"] for row in plan.planned}
+
+
+def test_owner_reply_at_same_published_at_does_not_skip_comment(tmp_path):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "viewer-reply",
+                            "text": "Follow-up question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": "2026-04-01T01:00:00Z",
+                        },
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T01:00:00Z",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert "viewer-reply" in {row["comment_id"] for row in plan.planned}
+
+
+def test_owner_reply_timestamp_is_compared_as_rfc3339_instant(tmp_path):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "viewer-reply",
+                            "text": "Follow-up question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": "2026-04-01T01:30:00+01:00",
+                        },
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": "2026-04-01T00:45:00Z",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert any(row["comment_id"] == "viewer-reply" and row["reason"] == "owner_replied" for row in plan.skipped)
+
+
+@pytest.mark.parametrize(
+    ("viewer_published_at", "owner_published_at"),
+    [
+        ("2026-04-01T01:00:00Z", "invalid"),
+        ("invalid", "2026-04-01T02:00:00Z"),
+        ("2026-04-01T01:00:00Z", ""),
+        ("", "2026-04-01T02:00:00Z"),
+    ],
+)
+def test_unparseable_timestamp_does_not_apply_owner_replied_skip(
+    tmp_path,
+    viewer_published_at,
+    owner_published_at,
+):
+    owner_id = "UCowner"
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "viewer-reply",
+                            "text": "Follow-up question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": viewer_published_at,
+                        },
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": owner_id,
+                            "published_at": owner_published_at,
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id=owner_id,
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert "viewer-reply" in {row["comment_id"] for row in plan.planned}
+
+
+def test_candidate_limit_does_not_fetch_paginated_replies_from_later_thread(tmp_path):
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {"comment_id": "first", "text": "First candidate"},
+                {
+                    "comment_id": "later",
+                    "text": "Later candidate",
+                    "total_reply_count": 6,
+                },
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(max_replies_per_run=1),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id="UCowner",
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert [row["comment_id"] for row in plan.planned] == ["first"]
+    yt.comments.return_value.list.assert_not_called()
+
+
+def test_candidate_limit_does_not_fetch_paginated_replies_from_current_thread(tmp_path):
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "first",
+                    "text": "First candidate",
+                    "total_reply_count": 6,
+                }
+            ]
+        },
+    )
+    yt.comments.return_value.list.return_value.execute.return_value = {"items": []}
+    replier = CommentReplier(
+        yt,
+        config=_make_config(max_replies_per_run=1),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id="UCowner",
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert [row["comment_id"] for row in plan.planned] == ["first"]
+    yt.comments.return_value.list.assert_not_called()
+
+
+def test_unanswered_viewer_reply_remains_candidate(tmp_path):
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "viewer-reply",
+                            "text": "Follow-up question",
+                            "author": "Viewer",
+                            "author_channel_id": "UCviewer",
+                            "published_at": "2026-04-01T01:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    replier = CommentReplier(
+        yt,
+        config=_make_config(),
+        channel_dir=tmp_path,
+        default_language="ja",
+        owner_channel_id="UCowner",
+    )
+
+    plan = replier.run(dry_run=True)
+
+    assert "viewer-reply" in {row["comment_id"] for row in plan.planned}
+
+
 def test_export_candidates_rejects_apply_mode_before_generating(tmp_path, _mock_default_genai_client):
     yt = _mock_youtube(
         video_ids=["v1"],
@@ -363,6 +879,50 @@ def test_cli_export_candidates_requires_json(monkeypatch, tmp_path, capsys):
     assert rc == 1
     assert "--json" in capsys.readouterr().err
     get_youtube.assert_not_called()
+
+
+def test_cli_export_candidates_json_excludes_comment_with_later_owner_reply(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    _mock_default_genai_client,
+):
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [
+                {
+                    "comment_id": "top",
+                    "text": "Initial question",
+                    "published_at": "2026-04-01T00:00:00Z",
+                    "replies": [
+                        {
+                            "comment_id": "owner-reply",
+                            "text": "Owner answer",
+                            "author": "Owner",
+                            "author_channel_id": "UCtest",
+                            "published_at": "2026-04-01T01:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    config = SimpleNamespace(
+        comments=_make_config(),
+        youtube=SimpleNamespace(api=SimpleNamespace(language="ja")),
+    )
+    monkeypatch.setattr(comment_reply, "load_config", lambda: config)
+    monkeypatch.setattr(comment_reply, "get_youtube", lambda: yt)
+    monkeypatch.setattr(comment_reply, "_channel_dir", lambda: tmp_path)
+
+    rc = comment_reply.main(["--dry-run", "--export-candidates", "--json", "--video-id", "v1"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["planned"] == []
+    assert any(row["comment_id"] == "top" and row["reason"] == "owner_replied" for row in payload["skipped"])
+    _mock_default_genai_client.models.generate_content.assert_not_called()
 
 
 def test_cli_export_candidates_rejects_apply_before_youtube(monkeypatch, tmp_path, capsys):
@@ -708,6 +1268,21 @@ def test_held_for_review_is_skipped(tmp_path):
     plan = replier.run(dry_run=True)
     assert any(row["reason"].startswith("moderationStatus") for row in plan.skipped)
     assert plan.planned == []
+
+
+def test_can_reply_false_is_skipped_with_existing_reason(tmp_path):
+    yt = _mock_youtube(
+        video_ids=["v1"],
+        comments_by_video={
+            "v1": [{"comment_id": "c1", "text": "こんにちは！", "can_reply": False}],
+        },
+    )
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    plan = replier.run(dry_run=True)
+
+    assert plan.planned == []
+    assert any(row["comment_id"] == "c1" and row["reason"] == "canReply=False" for row in plan.skipped)
 
 
 def test_max_replies_per_run_caps_planned(tmp_path):


### PR DESCRIPTION
## Summary

## 概要

`yt-comments-reply` の返信候補判定を改善する。履歴 JSON はツール経由の返信しか記録しないため、Studio 等で**手動返信済み**のコメントに自動返信が重複しうる。同一スレッド内のオーナー返信（手動・ツール経由を問わず）を検出して候補から除外しつつ、オーナー返信の**後**に視聴者が返したフォローアップ返信（返信の返信）は引き続き候補として正常に扱えるようにする。

## 提案する仕様

- コメント（top-level / reply とも）は、同一スレッド内に**対象コメントの publishedAt より後**のオーナー返信が存在する場合、返信候補から除外する（skip 理由: `owner_replied`。名称は実装時に調整可）
- スキップは設定キーなしで常時有効とする（opt-out はスコープ外）
- オーナー返信より後に付いた視聴者のフォローアップ返信は候補に残す（会話の続きに返信できる）
- スレッド判定は fetch 済みデータ（`FetchedComment.parent_id` / `published_at`）で行い、追加の API 呼び出しは増やさない

## ユースケース

- 運用者が Studio で一部コメントに手動返信している → 自動返信 run がそれらに重複返信しない
- オーナーの返信に視聴者がさらに質問を返した → その返信の返信が候補として取得され、自動返信フローに乗る

## 参照資料

- src/youtube_automation/utils/comments/replier.py
- src/youtube_automation/utils/comments/fetcher.py
- src/youtube_automation/utils/comments/history.py
- .claude/skills/comments-reply/SKILL.md
- tests/test_comments_replier.py

## 影響ファイル

- **変更**: src/youtube_automation/utils/comments/replier.py（`_skip_reason` へのスレッド内オーナー返信判定の追加、スレッド索引の構築）
- **変更**: tests/test_comments_replier.py（新 skip 理由・フォローアップ候補化のテスト追加）
- **変更**: .claude/skills/comments-reply/SKILL.md（skip 理由一覧への `owner_replied` 追記）
- **変更**: CHANGELOG.md（[Unreleased] 追記）
- **変更（必要なら）**: src/youtube_automation/utils/comments/fetcher.py（判定に必要な情報が揃っているため原則変更不要の想定。plan step で確定する）

**兄弟入口・貫通先**:
- `yt-pinned-comment`（固定コメント投稿）: 責務が異なるため変更不要
- `yt-benchmark-comments`（競合コメント収集）: 自チャンネル返信と無関係のため変更不要
- comments-reply skill の agent フロー（export-candidates JSON）: 候補抽出結果を消費するため、skip が export にも反映されることを要件 2 で担保する

## 要件

1. 対象コメントより後の publishedAt を持つオーナー返信が同一スレッドに存在する状態で `yt-comments-reply --dry-run` を実行する → 当該コメントは候補から除外され、plan に skip 理由 `owner_replied` が記録される
2. 同条件で `yt-comments-reply --dry-run --export-candidates --json` を実行する → export された候補 JSON に当該コメントが含まれない
3. top-level にオーナー返信済み・その後に視聴者のフォローアップ返信がある状態で dry-run を実行する → top-level はスキップされ、フォローアップ返信は候補に含まれる
4. スレッド内の視聴者返信（返信の返信）でオーナーがまだ答えていないものがある状態で dry-run を実行する → その返信は従来どおり候補に含まれる
5. 既存の skip 理由（`already_replied` / `ng_word` / `own_comment` / `heldForReview` / `canReply=False`）の挙動が変わらない → 既存テストが green のまま
6. 上記 1〜4 のユニットテストを tests/test_comments_replier.py に追加する → `uv run pytest` が成功する

## スコープ外

- スキップの opt-out 設定キー（comments.json）追加は扱わない（要望が出たら別 issue）
- 手動返信フロー自体の支援・人手キューへのエスカレーション機能は扱わない
- 1 件ずつ対話承認するモード（SKILL.md 記載の既存の別 issue 予定事項）は扱わない
- `yt-pinned-comment` / `yt-benchmark-comments` の改修は扱わない

## 受け入れ基準

- [ ] `uv run ruff check .` が exit 0 になる
- [ ] `uv run ruff format --check .` が exit 0 になる
- [ ] `uv run pytest` が成功する
- [ ] 型チェッカーは本リポジトリに存在しないため対象外（新規 `Any` 注釈は lefthook の any-usage-gate で担保）

## 実装方針（takt）

- workflow: improve
- 理由: 既存 replier の候補判定への挙動追加のため

## Execution Report

Workflow `improve` completed successfully.

Closes #1895