### PR TITLE
[#1649] issue-1649-strategy-ttp-ni-kor

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when 新コレクションの企画・テーマ選定をデー
 
 ## 完了条件
 
-企画候補をコレクションの `20-documentation/plan_proposals.md` に保存し、`workflow-state.json` の `planning.generated = true` へ更新（企画確定時は `planning.final_title` も記録）し、Next Step（`/thumbnail <theme>` → `/suno <theme>`）を案内した時点で完了。
+企画候補をコレクションの `20-documentation/plan_proposals.md` に保存し、`workflow-state.json` の `planning.generated = true` へ更新（企画確定時は `planning.final_title` も記録）し、Next Step（`/thumbnail <theme>` → `/suno <theme>`）を案内した時点で完了。画像生成を実施した場合は、採用企画の参照画像を `20-documentation/thumbnail-prompts.md` の `Reference Assignments` へ保存できるまで完了扱いにせず、保存失敗時は停止する。
 
 ## Untrusted Data 境界
 
@@ -260,23 +260,8 @@ while IFS= read -r p; do
   [ -n "$p" ] && REF_PATHS+=("$p")
 done <<< "$REFS"
 
-VALIDATED_REFS=$(printf '%s\n' "${REF_PATHS[@]}" | uv run python3 -c "
-import sys
-from pathlib import Path
-from youtube_automation.utils.config import channel_dir
-from youtube_automation.utils.thumbnail_references import plan_ttp_reference_assignments
-
-refs = [Path(line.strip()) for line in sys.stdin if line.strip()]
-candidate_count = int(sys.argv[1])
-validated = plan_ttp_reference_assignments(
-    refs,
-    candidate_count,
-    True,
-    benchmark_root=channel_dir() / 'data' / 'thumbnail_compare' / 'benchmark',
-)
-for ref in validated:
-    print(ref)
-" "$CANDIDATE_COUNT")
+VALIDATED_REFS=$(printf '%s\n' "${REF_PATHS[@]}" | uv run python3 \
+  .claude/skills/collection-ideate/references/select-ttp-references.py "$CANDIDATE_COUNT")
 mapfile -t REF_PATHS <<< "$VALIDATED_REFS"
 
 # 順次実行。candidate_count の数だけ plan-{a,b,c,...} を生成する。
@@ -380,16 +365,16 @@ parallel モードでは Next Step で `yt-stock-archive` による不採用 (`c
 
 ```bash
 # <x> は選択された企画の番号（a/b/c）
+REF_INDEX="<選択された企画の0-based index>"
+if [ "${#REF_PATHS[@]}" -le "$REF_INDEX" ]; then
+  echo "ERROR: selected preview reference is missing: index=${REF_INDEX}" >&2
+  exit 1
+fi
 PROVIDER=$(uv run python3 -c "from youtube_automation.utils.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
   # codex は image_generation.codex.default_prompt_template を必ず使う。
   # 参照画像を winning template として扱い、テキスト付き候補を先に確定する短い TTP thumbnail 先行プロンプトにする（#1611）。
   # 選択した企画と同じ index の参照画像 1 枚だけを使う（a=0, b=1, c=2）。
-  REF_INDEX="<選択された企画の0-based index>"
-  if [ "${#REF_PATHS[@]}" -le "$REF_INDEX" ]; then
-    echo "ERROR: selected preview reference is missing: index=${REF_INDEX}" >&2
-    exit 1
-  fi
   # title 引数にはサムネに焼くテキスト（見出し + 短いサブタイトル）だけを渡す。
   # 動画タイトル全文を渡さない（全文が画像に焼き込まれる事故の再発防止）。
   CODEX_PROMPT=$(uv run python3 .claude/skills/thumbnail/references/codex-prompt.py "<選択された企画タイトル>")
@@ -613,6 +598,15 @@ analytics mode / benchmark fallback mode ではベンチマークデータを分
 企画選択時にタイトルも確定する（`workflow-state.json` の `planning.final_title` に記録）。
 
 企画確定後、選択した企画のプレビュー画像は企画参照として保存し、**`main.png` にはコピーしない**。`main.png/jpg` は `/thumbnail` で承認済みのテキスト付き `thumbnail.jpg` から再生成して確定する textless 動画背景であり、文字入りサムネと同一画像にしない。`thumbnail_mode` と「画像が生成されたか」によって手順が分岐するため、ケース別に示す。
+
+画像生成を実施した場合、企画確定後かつプレビューディレクトリ削除前に、今回使用した参照割当を collection の履歴へ必ず保存する。保存に失敗した場合は処理を継続せず、エラーを解消して同じコマンドを再実行する。
+
+```bash
+REF_INDEX="<選択された企画の0-based index>"
+COLLECTION_PATH="<collection-path>"
+uv run python3 .claude/skills/collection-ideate/references/record-ttp-reference-assignments.py \
+  "$COLLECTION_PATH" "${REF_PATHS[$REF_INDEX]}"
+```
 
 ### parallel モード（デフォルト）
 

--- a/.claude/skills/collection-ideate/references/record-ttp-reference-assignments.py
+++ b/.claude/skills/collection-ideate/references/record-ttp-reference-assignments.py
@@ -1,0 +1,29 @@
+"""Persist collection-ideate TTP assignments for future rotation decisions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.thumbnail_references import record_ttp_reference_assignments
+
+
+def _resolve_from_channel(root: Path, value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else root / path
+
+
+def main() -> None:
+    root = channel_dir()
+    collection_dir = _resolve_from_channel(root, sys.argv[1])
+    selected_reference = _resolve_from_channel(root, sys.argv[2])
+    record_ttp_reference_assignments(
+        collection_dir / "20-documentation" / "thumbnail-prompts.md",
+        [selected_reference],
+        root,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/collection-ideate/references/select-ttp-references.py
+++ b/.claude/skills/collection-ideate/references/select-ttp-references.py
@@ -1,0 +1,35 @@
+"""Select collection-ideate TTP references from config and collection history."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from youtube_automation.utils.config import channel_dir
+from youtube_automation.utils.skill_config import load_skill_config
+from youtube_automation.utils.thumbnail_references import (
+    plan_ttp_reference_assignments,
+    resolve_dedup_recent_collections,
+)
+
+
+def main() -> None:
+    references = [Path(line.strip()) for line in sys.stdin if line.strip()]
+    candidate_count = int(sys.argv[1])
+    thumbnail_config = load_skill_config("thumbnail").get("image_generation", {}).get("gemini", {})
+    reference_config = thumbnail_config.get("reference_images", {}) if isinstance(thumbnail_config, dict) else {}
+    root = channel_dir()
+    selected = plan_ttp_reference_assignments(
+        references,
+        candidate_count,
+        True,
+        benchmark_root=root / "data" / "thumbnail_compare" / "benchmark",
+        channel_dir=root,
+        dedup_recent_collections=resolve_dedup_recent_collections(reference_config.get("dedup_recent_collections")),
+    )
+    for reference in selected:
+        print(reference)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -263,6 +263,8 @@ uv run yt-generate-image \
 
 `reference_images.default` は同じベンチマークチャンネル内の複数サムネ候補を list で指定する。`--max-attempts N` で N 候補を出す場合、各 attempt は別参照画像 1 枚を使う。参照画像が N 枚未満、同じ画像の重複、`--no-rotate` による先頭固定はいずれもエラーになる。
 
+`reference_images.dedup_recent_collections`（既定 `5`）は、各 collection の `20-documentation/thumbnail-prompts.md` に保存された `Reference Assignments` をローテーション履歴として使う。参照プールが候補数より大きい場合は、全参照が採用候補になる前に同じ先頭候補を再利用しない。プール自体が候補数未満なら参照画像の追加を促すエラーで停止し、履歴のない旧コレクションは無視、履歴ファイルの読取障害はエラーで停止する。`0` で履歴による除外を無効化できる。選定ロジックの正は `youtube_automation.utils.thumbnail_references.plan_ttp_reference_assignments` とする。
+
 別チャンネル由来の参照画像や stock 画像を混ぜる場合は、TTP 参照プールとは別スコープとして扱う。混在させるなら `config/skills/thumbnail.yaml` 側で明示し、生成ログの `benchmark_channel=` と `thumbnail-prompts.md` の attempt 別参照欄で追跡できるようにする。
 
 | CLI 引数 | 用途 |

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -129,6 +129,9 @@ image_generation:
     # TTP single_step は同一ベンチマークチャンネルの複数サムネを前提にするため、
     # default では OFF。別スコープとして明示的に混ぜたいチャンネルのみ override する。
     reference_images:
+      # 全 collection の thumbnail-prompts.md から未使用参照を優先し、一巡後は直近この件数を除外する。
+      # 候補数に足りない枠だけ位置順で補い、全参照が採用される前の先頭候補重複を防ぐ。0 で無効化可。
+      dedup_recent_collections: 5
       stock:
         # true で stock 合成を有効化。TTP 参照プールとは別スコープとして扱うこと。
         enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(thumbnail)`: TTP 参照画像の直近コレクション重複除外を追加（#1649）。`reference_images.dedup_recent_collections`（既定 5）が collection ごとに採用企画の参照 1 件を Reference Assignments へ保存し、全割当節から未使用参照を先頭候補として優先する。不足する候補枠だけ位置順で補うため、候補数より大きいプールは全参照が採用されるまで先頭候補を再利用しない。
+
 ### Added
 
 - `docs(skills)`: 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を `data/feedback/feedback-log.jsonl` に append-only JSONL として記録する `/feedback` スキルを追加した。entry schema は `.claude/skills/feedback/references/feedback-entry.schema.json` に単一ソース化し、`date` / `skill` / `category` / `summary` / `context` / `status` / `issue_url` の構造、`status="recorded"` の新規記録、機密情報の `***REDACTED***` マスクを SKILL.md に明記した。下流配布 CLAUDE.md テンプレにもスキル摩擦時に `/feedback` を案内する導線を追加した（#1828）。

--- a/src/youtube_automation/scripts/generate_image.py
+++ b/src/youtube_automation/scripts/generate_image.py
@@ -42,6 +42,7 @@ from youtube_automation.utils.profile import section
 from youtube_automation.utils.thumbnail_references import (
     format_reference_assignment,
     plan_ttp_reference_assignments,
+    resolve_dedup_recent_collections,
 )
 
 # Gemini 用の解像度オプション（OpenAI provider 時は無視される）
@@ -438,11 +439,18 @@ def main():
     try:
         if args.ttp_strict_references:
             benchmark_root = _channel_root() / "data" / "thumbnail_compare" / "benchmark"
+            gemini_config = skill_cfg.get("image_generation", {}).get("gemini", {})
+            reference_config = gemini_config.get("reference_images", {})
+            dedup_recent_collections = resolve_dedup_recent_collections(
+                reference_config.get("dedup_recent_collections")
+            )
             reference_assignments = plan_ttp_reference_assignments(
                 reference_images,
                 cli_max_attempts,
                 rotate,
                 benchmark_root=benchmark_root,
+                channel_dir=_channel_root(),
+                dedup_recent_collections=dedup_recent_collections,
             )
         else:
             benchmark_root = None

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -20,6 +20,7 @@ from youtube_automation.utils.placeholders import is_placeholder_value
 from youtube_automation.utils.thumbnail_references import (
     plan_ttp_reference_assignments,
     resolve_configured_benchmark_references,
+    resolve_dedup_recent_collections,
 )
 from youtube_automation.utils.youtube_tag import parse_youtube_tags, youtube_tag_chars
 
@@ -180,6 +181,10 @@ def check_thumbnail_skill_config(channel_dir: Path, thumbnail_cfg: Mapping[str, 
                     max_attempts,
                     rotate,
                     benchmark_root=benchmark_root,
+                    channel_dir=channel_dir,
+                    dedup_recent_collections=resolve_dedup_recent_collections(
+                        reference_images.get("dedup_recent_collections")
+                    ),
                 )
             except ConfigError as exc:
                 issues.append(

--- a/src/youtube_automation/utils/thumbnail_references.py
+++ b/src/youtube_automation/utils/thumbnail_references.py
@@ -10,6 +10,8 @@ from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider.composition import normalize_reference_default
 from youtube_automation.utils.placeholders import is_placeholder_value
 
+DEFAULT_DEDUP_RECENT_COLLECTIONS = 5
+
 
 @dataclass(frozen=True)
 class BenchmarkReferenceResolution:
@@ -107,14 +109,112 @@ def format_reference_assignment(reference_path: Path, benchmark_root: Path | Non
     return f"{reference_path} (benchmark_channel={infer_benchmark_channel(reference_path, benchmark_root)})"
 
 
+def record_ttp_reference_assignments(
+    prompt_log: Path,
+    reference_images: list[Path],
+    channel_dir: Path,
+) -> None:
+    """Append collection-level TTP reference assignments to a thumbnail prompt log."""
+    channel_root = channel_dir.resolve(strict=False)
+    benchmark_root = channel_dir / "data" / "thumbnail_compare" / "benchmark"
+    rows: list[str] = []
+    for index, reference in enumerate(reference_images, 1):
+        resolved_reference = reference.resolve(strict=False)
+        try:
+            documented_reference = resolved_reference.relative_to(channel_root)
+        except ValueError:
+            documented_reference = resolved_reference
+        rows.append(
+            f"| {index} | collection-ideate preview | `{documented_reference}` | "
+            f"{infer_benchmark_channel(resolved_reference, benchmark_root)} |"
+        )
+
+    rows_text = "\n".join(rows)
+    section = (
+        "## Reference Assignments\n"
+        "| attempt | output | reference_image | benchmark_channel |\n"
+        "|---:|---|---|---|\n"
+        f"{rows_text}\n"
+    )
+    try:
+        prompt_log.parent.mkdir(parents=True, exist_ok=True)
+        existing = prompt_log.read_text(encoding="utf-8") if prompt_log.exists() else ""
+        separator = "\n" if existing and not existing.endswith("\n\n") else ""
+        prompt_log.write_text(f"{existing}{separator}{section}", encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(f"参照画像履歴を保存できません: {prompt_log}: {exc}") from exc
+
+
+def resolve_dedup_recent_collections(value: object) -> int:
+    """Validate the configured number of recent collections used for deduplication."""
+    if value is None:
+        return DEFAULT_DEDUP_RECENT_COLLECTIONS
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ConfigError("reference_images.dedup_recent_collections は 0 以上の整数で指定してください")
+    return value
+
+
+def _reference_images_from_prompt_log(prompt_log: Path, channel_dir: Path) -> set[Path]:
+    """Read documented assignments, rejecting inaccessible history files."""
+    try:
+        lines = prompt_log.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ConfigError(f"参照画像履歴を読み取れません: {prompt_log}: {exc}") from exc
+
+    in_assignments = False
+    references: set[Path] = set()
+    for line in lines:
+        if line.strip() == "## Reference Assignments":
+            in_assignments = True
+            continue
+        if in_assignments and line.startswith("## "):
+            in_assignments = False
+            continue
+        if not in_assignments or not line.lstrip().startswith("|"):
+            continue
+        columns = [column.strip() for column in line.strip().split("|")]
+        if len(columns) < 5 or columns[1] in {"attempt", "---:"}:
+            continue
+        reference = columns[3].strip("` ")
+        if not reference or reference.startswith("<"):
+            continue
+        path = Path(reference)
+        references.add((path if path.is_absolute() else channel_dir / path).resolve(strict=False))
+    return references
+
+
+def _reference_image_history(channel_dir: Path, recent_limit: int) -> tuple[set[Path], set[Path]]:
+    """Return references from the recent window and from all collection prompt logs."""
+    collections_root = channel_dir / "collections"
+    if not collections_root.is_dir():
+        return set(), set()
+    collection_dirs = sorted(
+        (path for path in collections_root.glob("*/*") if path.is_dir() and not path.name.startswith("_")),
+        key=lambda path: path.name,
+        reverse=True,
+    )
+    recent_references: set[Path] = set()
+    all_references: set[Path] = set()
+    for index, collection in enumerate(collection_dirs):
+        prompt_log = collection / "20-documentation" / "thumbnail-prompts.md"
+        if prompt_log.is_file():
+            references = _reference_images_from_prompt_log(prompt_log, channel_dir)
+            all_references.update(references)
+            if index < recent_limit:
+                recent_references.update(references)
+    return recent_references, all_references
+
+
 def plan_ttp_reference_assignments(
     reference_images: list[Path],
     count: int,
     rotate: bool,
     *,
     benchmark_root: Path | None = None,
+    channel_dir: Path | None = None,
+    dedup_recent_collections: int = 0,
 ) -> list[Path | None]:
-    """Plan strict thumbnail TTP reference assignment before generation."""
+    """Plan strict TTP assignments, excluding references used by recent collections."""
     if not reference_images:
         raise ConfigError(
             "single_step TTP 生成には参照画像が必須です。"
@@ -133,7 +233,22 @@ def plan_ttp_reference_assignments(
             f"(max_attempts={count}, references={len(reference_images)})。"
             "同じベンチマークチャンネル内の別サムネイル画像を追加してください。"
         )
-    selected_references = reference_images[:count]
+    selected_references = reference_images
+    if rotate and channel_dir is not None and dedup_recent_collections:
+        recent_references, all_references = _reference_image_history(channel_dir, dedup_recent_collections)
+        unused_references = [ref for ref in reference_images if ref.resolve(strict=False) not in all_references]
+        references_outside_recent_window = [
+            ref for ref in reference_images if ref.resolve(strict=False) not in recent_references
+        ]
+        if unused_references:
+            selected_references = unused_references + [
+                ref for ref in references_outside_recent_window if ref not in unused_references
+            ]
+        elif references_outside_recent_window:
+            selected_references = references_outside_recent_window
+        selected_references += [ref for ref in reference_images if ref not in selected_references]
+
+    selected_references = selected_references[:count]
     if benchmark_root is not None:
         selected_references = [canonicalize_benchmark_reference(ref, benchmark_root) for ref in selected_references]
 

--- a/tests/test_codex_thumbnail_routing_docs.py
+++ b/tests/test_codex_thumbnail_routing_docs.py
@@ -10,6 +10,7 @@ _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
 _IDEATE_SKILL_MD = _SKILLS_DIR / "collection-ideate" / "SKILL.md"
 _IDEATE_DEFAULT_CONFIG = _SKILLS_DIR / "collection-ideate" / "config.default.yaml"
 _IDEATE_LIFECYCLE_MD = _SKILLS_DIR / "collection-ideate" / "references" / "collection-lifecycle.md"
+_IDEATE_TTP_SELECTOR = _SKILLS_DIR / "collection-ideate" / "references" / "select-ttp-references.py"
 _LYRIA_DEFAULT_CONFIG = _SKILLS_DIR / "lyria" / "config.default.yaml"
 _LYRIA_SKILL_MD = _SKILLS_DIR / "lyria" / "SKILL.md"
 _SHORT_THUMBNAIL_SKILL_MD = _SKILLS_DIR / "short-thumbnail" / "SKILL.md"
@@ -199,12 +200,14 @@ def test_collection_ideate_parallel_validates_unique_single_channel_references()
     Then duplicate / mixed channel は生成前 validation に合流する。
     """
     block = _phase_4_4_parallel_block(_read(_IDEATE_SKILL_MD))
+    selector = _read(_IDEATE_TTP_SELECTOR)
 
-    assert "plan_ttp_reference_assignments" in block
-    assert "benchmark_root=channel_dir() / 'data' / 'thumbnail_compare' / 'benchmark'" in block
+    assert ".claude/skills/collection-ideate/references/select-ttp-references.py" in block
     assert "VALIDATED_REFS" in block
     assert "CANDIDATE_COUNT" in block
-    assert "candidate_count = int(sys.argv[1])" in block
+    assert "plan_ttp_reference_assignments" in selector
+    assert 'benchmark_root=root / "data" / "thumbnail_compare" / "benchmark"' in selector
+    assert "candidate_count = int(sys.argv[1])" in selector
 
 
 def test_collection_ideate_api_parallel_uses_one_reference_per_candidate() -> None:

--- a/tests/test_generate_image_parallel.py
+++ b/tests/test_generate_image_parallel.py
@@ -13,6 +13,7 @@ API 呼び出しはフェイク provider で mock 化する。
 
 from __future__ import annotations
 
+import re
 import sys
 import threading
 from pathlib import Path
@@ -33,7 +34,11 @@ from youtube_automation.scripts.generate_image import (
 )
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.image_provider.composition import resolve_unique_path
-from youtube_automation.utils.thumbnail_references import plan_ttp_reference_assignments
+from youtube_automation.utils.thumbnail_references import (
+    plan_ttp_reference_assignments,
+    record_ttp_reference_assignments,
+    resolve_dedup_recent_collections,
+)
 
 # ---- フェイク provider ------------------------------------------------------
 
@@ -268,6 +273,235 @@ class TestPlanReferenceAssignments:
         refs = [Path("/data/thumbnail_compare/benchmark/jazzgak/a.jpg")]
         assert plan_ttp_reference_assignments(refs, 1, rotate=False) == refs
 
+    def test_no_rotate_single_attempt_pins_first_reference_despite_history(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        _write_reference_assignments(
+            tmp_path,
+            "planning/20260712-recent",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg"],
+        )
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            1,
+            rotate=False,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        ) == [refs[0]]
+
+    def test_excludes_references_used_by_recent_collections(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 4)
+        prompt_log = (
+            tmp_path / "collections" / "planning" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg` | jazzgak |\n"
+            "| 2 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg` | jazzgak |\n",
+            encoding="utf-8",
+        )
+
+        assert (
+            plan_ttp_reference_assignments(refs, 2, rotate=True, channel_dir=tmp_path, dedup_recent_collections=1)
+            == refs[2:]
+        )
+
+    def test_excludes_references_from_every_assignment_section_in_one_log(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 3)
+        prompt_log = (
+            tmp_path / "collections" / "planning" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | thumbnail | `data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg` | jazzgak |\n"
+            "\n## Prompt Details\nold content\n\n"
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | collection-ideate preview | `data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg` | jazzgak |\n",
+            encoding="utf-8",
+        )
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            1,
+            rotate=True,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        ) == [refs[2]]
+
+    def test_recent_collection_window_is_ordered_by_collection_across_states(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 3)
+        _write_reference_assignments(
+            tmp_path,
+            "planning/20260101-old",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg"],
+        )
+        _write_reference_assignments(
+            tmp_path,
+            "live/20260712-new",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg"],
+        )
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            2,
+            rotate=True,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        ) == [refs[2], refs[0]]
+
+    def test_zero_dedup_window_disables_history_exclusion(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        _write_reference_assignments(
+            tmp_path,
+            "planning/20260712-recent",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg"],
+        )
+
+        assert (
+            plan_ttp_reference_assignments(
+                refs,
+                2,
+                rotate=True,
+                channel_dir=tmp_path,
+                dedup_recent_collections=0,
+            )
+            == refs
+        )
+
+    def test_missing_dedup_window_uses_default_of_five(self) -> None:
+        assert resolve_dedup_recent_collections(None) == 5
+
+    @pytest.mark.parametrize("value", [-1, True, 1.5, "2"])
+    def test_invalid_dedup_window_is_rejected(self, value: object) -> None:
+        with pytest.raises(ConfigError, match="0 以上の整数"):
+            resolve_dedup_recent_collections(value)
+
+    def test_falls_back_to_position_order_after_entire_pool_was_used(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        prompt_log = tmp_path / "collections" / "live" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg` | jazzgak |\n"
+            "| 2 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg` | jazzgak |\n",
+            encoding="utf-8",
+        )
+
+        assert (
+            plan_ttp_reference_assignments(refs, 2, rotate=True, channel_dir=tmp_path, dedup_recent_collections=1)
+            == refs
+        )
+
+    def test_prefers_never_used_references_before_reusing_outside_recent_window(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 10)
+        for index in range(6):
+            _write_reference_assignments(
+                tmp_path,
+                f"live/202607{index + 1:02d}-collection",
+                [f"data/thumbnail_compare/benchmark/jazzgak/ref-{index}.jpg"],
+            )
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            1,
+            rotate=True,
+            channel_dir=tmp_path,
+            dedup_recent_collections=5,
+        ) == [refs[6]]
+
+    def test_fills_partial_dedup_shortage_in_position_order(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 3)
+        prompt_log = (
+            tmp_path / "collections" / "planning" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg` | jazzgak |\n"
+            "| 2 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg` | jazzgak |\n",
+            encoding="utf-8",
+        )
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            2,
+            rotate=True,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        ) == [refs[2], refs[0]]
+
+    def test_ignores_legacy_collection_without_reference_assignments(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        legacy_log = (
+            tmp_path / "collections" / "planning" / "20260712-legacy" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        legacy_log.parent.mkdir(parents=True)
+        legacy_log.write_text("# old prompt format\n", encoding="utf-8")
+
+        assert (
+            plan_ttp_reference_assignments(refs, 2, rotate=True, channel_dir=tmp_path, dedup_recent_collections=1)
+            == refs
+        )
+
+    def test_legacy_collection_counts_toward_recent_window(self, tmp_path: Path) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        _write_reference_assignments(
+            tmp_path,
+            "live/20260711-older",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg"],
+        )
+        legacy_collection = tmp_path / "collections" / "planning" / "20260712-latest-legacy"
+        legacy_collection.mkdir(parents=True)
+
+        assert plan_ttp_reference_assignments(
+            refs,
+            2,
+            rotate=True,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        ) == [refs[1], refs[0]]
+
+    def test_rejects_reference_history_that_cannot_be_read(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        refs = _benchmark_refs(tmp_path, 2)
+        prompt_log = _write_reference_assignments(
+            tmp_path,
+            "planning/20260712-unreadable",
+            ["data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg"],
+        )
+        original_read_text = Path.read_text
+
+        def fail_for_prompt_log(path: Path, *args: object, **kwargs: object) -> str:
+            if path == prompt_log:
+                raise PermissionError("history denied")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_for_prompt_log)
+
+        with pytest.raises(ConfigError, match=f"{re.escape(str(prompt_log))}.*history denied"):
+            plan_ttp_reference_assignments(
+                refs,
+                2,
+                rotate=True,
+                channel_dir=tmp_path,
+                dedup_recent_collections=1,
+            )
+
     def test_strict_rejects_mixed_known_benchmark_channels(self) -> None:
         refs = [
             Path("/data/thumbnail_compare/benchmark/jazzgak-a.jpg"),
@@ -461,6 +695,35 @@ def _benchmark_refs(tmp_path: Path, count: int) -> list[Path]:
     return refs
 
 
+def _write_reference_assignments(tmp_path: Path, collection: str, references: list[str]) -> Path:
+    prompt_log = tmp_path / "collections" / collection / "20-documentation" / "thumbnail-prompts.md"
+    prompt_log.parent.mkdir(parents=True)
+    rows = "".join(f"| {index} | output | `{reference}` | jazzgak |\n" for index, reference in enumerate(references, 1))
+    prompt_log.write_text(
+        "## Reference Assignments\n"
+        "| attempt | output | reference_image | benchmark_channel |\n"
+        "|---:|---|---|---|\n"
+        f"{rows}",
+        encoding="utf-8",
+    )
+    return prompt_log
+
+
+def test_record_ttp_reference_assignments_wraps_persistence_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompt_log = tmp_path / "collections" / "planning" / "collection" / "20-documentation" / "thumbnail-prompts.md"
+
+    def fail_write(_self: Path, *_args: object, **_kwargs: object) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+
+    with pytest.raises(ConfigError, match=rf"参照画像履歴を保存できません: {re.escape(str(prompt_log))}: disk full"):
+        record_ttp_reference_assignments(prompt_log, [tmp_path / "reference.jpg"], tmp_path)
+
+
 class TestGenerateImageCLIReferenceContract:
     def test_single_step_cli_assigns_one_unique_reference_per_attempt(
         self,
@@ -501,6 +764,54 @@ class TestGenerateImageCLIReferenceContract:
         ]
         captured = capsys.readouterr()
         assert "benchmark_channel=jazzgak" in captured.out
+
+    def test_cli_applies_configured_recent_collection_deduplication(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        refs = _benchmark_refs(tmp_path, 4)
+        prompt_log = (
+            tmp_path / "collections" / "planning" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-0.jpg` | jazzgak |\n"
+            "| 2 | output | `data/thumbnail_compare/benchmark/jazzgak/ref-1.jpg` | jazzgak |\n",
+            encoding="utf-8",
+        )
+        provider = _FakeProvider()
+        argv = [
+            "--prompt",
+            "prompt",
+            "--output",
+            str(tmp_path / "thumbnail-v1.jpg"),
+            "--max-attempts",
+            "2",
+            "--max-workers",
+            "1",
+            "--ttp-strict-references",
+            "-y",
+        ]
+        for ref in refs:
+            argv.extend(["--reference", str(ref)])
+        skill_cfg = {"image_generation": {"gemini": {"reference_images": {"dedup_recent_collections": 1}}}}
+        _patch_generate_image_cli(
+            monkeypatch,
+            argv,
+            provider=provider,
+            channel_root=tmp_path,
+            skill_cfg_override=skill_cfg,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            generate_image_main()
+
+        assert exc_info.value.code == 0
+        assert [request.references for request in provider.requests] == [[refs[2]], [refs[3]]]
 
     def test_cli_expands_typography_clause_before_provider_request(
         self,

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -267,6 +267,46 @@ class TestInitialSetupChecks:
 
         assert any("reference_images.default" in issue and "TBD" in issue for issue in issues)
 
+    def test_thumbnail_config_applies_recent_reference_deduplication(self, tmp_path: Path) -> None:
+        refs = [f"data/thumbnail_compare/benchmark/alpha/ref-{index}.jpg" for index in range(3)]
+        for reference in refs:
+            path = tmp_path / reference
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"jpg")
+        prompt_log = (
+            tmp_path / "collections" / "planning" / "20260712-recent" / "20-documentation" / "thumbnail-prompts.md"
+        )
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            "| 1 | output | `data/thumbnail_compare/benchmark/alpha/ref-0.jpg` | alpha |\n"
+            "| 2 | output | `data/thumbnail_compare/benchmark/alpha/ref-1.jpg` | alpha |\n",
+            encoding="utf-8",
+        )
+        cfg = {
+            "image_generation": {
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "single_step": {"max_attempts": 2, "rotate": True},
+                    "reference_images": {"default": refs, "dedup_recent_collections": 1},
+                    "composition_rules": {
+                        "environment": "desk",
+                        "character_size": "medium",
+                        "character_pose": "sitting",
+                        "allowed_actions": "reading",
+                        "ng_actions": "no text",
+                        "background": "warm room",
+                    },
+                }
+            }
+        }
+
+        issues = check_thumbnail_skill_config(tmp_path, cfg)
+
+        assert issues == []
+
     def test_thumbnail_config_detects_unexpanded_template_composition(self, tmp_path: Path) -> None:
         ref = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "alpha" / "alpha.jpg"
         ref.parent.mkdir(parents=True)

--- a/tests/test_skill_config.py
+++ b/tests/test_skill_config.py
@@ -71,6 +71,21 @@ def test_channel_override_merged(tmp_path, monkeypatch):
     assert "model" in gemini_block
 
 
+def test_thumbnail_dedup_window_can_be_overridden(tmp_path, monkeypatch):
+    """thumbnail の default 値と channel override が実行設定へマージされること。"""
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    (channel_dir / "config" / "skills" / "thumbnail.yaml").write_text(
+        yaml.safe_dump({"image_generation": {"gemini": {"reference_images": {"dedup_recent_collections": 2}}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("thumbnail", use_cache=False)
+
+    assert cfg["image_generation"]["gemini"]["reference_images"]["dedup_recent_collections"] == 2
+
+
 def test_load_skill_config_masterup_json_override_wins_over_yaml(tmp_path, monkeypatch):
     """masterup は JSON override が YAML override より優先されること."""
     channel_dir = tmp_path / "ch"

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -79,6 +80,96 @@ def _slice_between(text: str, start_marker: str, end_marker: str) -> str:
         raise AssertionError(f"{end_marker!r} が見つかりません")
 
     return text[start_idx:end_idx]
+
+
+def _collection_ideate_reference_validation_script() -> Path:
+    return _repo_root() / ".claude" / "skills" / "collection-ideate" / "references" / "select-ttp-references.py"
+
+
+def _collection_ideate_reference_history_script() -> Path:
+    return (
+        _repo_root() / ".claude" / "skills" / "collection-ideate" / "references" / "record-ttp-reference-assignments.py"
+    )
+
+
+def _run_collection_ideate_generation_block(
+    tmp_path: Path,
+    mode: str,
+    references: list[Path],
+    *,
+    provider: str = "gemini",
+) -> subprocess.CompletedProcess[str]:
+    ideate_skill = (_repo_root() / ".claude" / "skills" / "collection-ideate" / "SKILL.md").read_text(encoding="utf-8")
+    if mode == "parallel":
+        section = _slice_between(
+            ideate_skill,
+            "**4-4: プロンプト構築 + 一括生成（parallel デフォルト）**",
+            "### Phase 4 補足: sequential モード (opt-in)",
+        )
+        block = _slice_between(section, "# 順次実行。candidate_count", "```")
+    else:
+        section = _slice_between(
+            ideate_skill,
+            "**sequential 用 4-4 (選択 → 1 枚生成)**:",
+            "**sequential 用 4-5 (1 枚承認)**:",
+        )
+        block = _slice_between(section, "# <x> は選択された企画", "```")
+        block = re.sub(r'^REF_INDEX="<[^\n]+>"$', "REF_INDEX=0", block, count=1, flags=re.MULTILINE)
+
+    block = block.replace("<dir>", "session").replace("<slug>", "preview").replace("<x>", "a")
+    reference_values = " ".join(f'"{reference}"' for reference in references)
+    script = f"CANDIDATE_COUNT={len(references)}\nREF_PATHS=({reference_values})\n{block}"
+
+    history_dir = tmp_path / "collections" / "planning" / "_plan-previews" / "session"
+    history_dir.mkdir(parents=True)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == run && "$2" == python3 && "$3" == -c ]]; then\n'
+        f"  printf '{provider}\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [[ "$1" == run && "$2" == python3 ]]; then\n'
+        "  printf 'prompt\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [[ "$1" == run && "$2" == yt-generate-image ]]; then\n'
+        '  for argument in "$@"; do\n'
+        '    if [[ "$argument" == *.jpg ]]; then\n'
+        '      printf \'%s\\n\' "$argument" >> "$INVOCATION_LOG"\n'
+        '      [[ "$argument" == *fail* ]] && exit 23\n'
+        "    fi\n"
+        "  done\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 99\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    codex_image = tmp_path / ".claude" / "skills" / "thumbnail" / "references" / "codex-image.sh"
+    codex_image.parent.mkdir(parents=True)
+    codex_image.write_text(
+        '#!/usr/bin/env bash\nfor argument in "$@"; do\n'
+        '  if [[ "$argument" == *.jpg ]]; then\n'
+        '    printf \'%s\\n\' "$argument" >> "$INVOCATION_LOG"\n'
+        '    [[ "$argument" == *fail* ]] && exit 23\n'
+        "  fi\n"
+        "done\nexit 0\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin) + os.pathsep + env["PATH"]
+    env["INVOCATION_LOG"] = str(tmp_path / "invocations.txt")
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def _run_codex_prompt_cli(tmp_path: Path, thumbnail_yaml: str, title: str) -> subprocess.CompletedProcess[str]:
@@ -466,6 +557,359 @@ def test_thumbnail_skill_requires_reference_per_ttp_attempt_and_drops_prompt_onl
     assert "benchmark_channel" in skill
     assert "プロンプトベースモード" not in skill
     assert "参照画像なしでプロンプトのみで生成" not in skill
+
+
+def test_ttp_reference_dedup_is_documented_and_collection_ideate_passes_it() -> None:
+    skill = _read_thumbnail_skill()
+    config = _load_thumbnail_default_config()
+    ideate_skill = (_repo_root() / ".claude" / "skills" / "collection-ideate" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "reference_images.dedup_recent_collections" in skill
+    assert config["image_generation"]["gemini"]["reference_images"]["dedup_recent_collections"] == 5
+    assert ".claude/skills/collection-ideate/references/select-ttp-references.py" in ideate_skill
+    assert ".claude/skills/collection-ideate/references/record-ttp-reference-assignments.py" in ideate_skill
+
+
+def test_collection_ideate_persists_only_the_adopted_reference_after_selection() -> None:
+    ideate_skill = (_repo_root() / ".claude" / "skills" / "collection-ideate" / "SKILL.md").read_text(encoding="utf-8")
+    parallel = _slice_between(
+        ideate_skill,
+        "**4-4: プロンプト構築 + 一括生成（parallel デフォルト）**",
+        "### Phase 4 補足: sequential モード (opt-in)",
+    )
+    sequential = _slice_between(
+        ideate_skill,
+        "**sequential 用 4-4 (選択 → 1 枚生成)**:",
+        "**sequential 用 4-5 (1 枚承認)**:",
+    )
+    next_step = _slice_between(ideate_skill, "## Next Step", "### parallel モード（デフォルト）")
+
+    assert "REFERENCE_HISTORY_FILE" not in parallel
+    assert "REFERENCE_HISTORY_FILE" not in sequential
+    assert next_step.count("record-ttp-reference-assignments.py") == 1
+    assert '"$COLLECTION_PATH" "${REF_PATHS[$REF_INDEX]}"' in next_step
+
+
+def test_collection_ideate_parallel_generation_failure_continues_to_later_candidates(tmp_path: Path) -> None:
+    references = [tmp_path / "fail.jpg", tmp_path / "success.jpg"]
+
+    result = _run_collection_ideate_generation_block(tmp_path, "parallel", references)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "invocations.txt").read_text(encoding="utf-8").splitlines() == [
+        str(references[0]),
+        str(references[1]),
+    ]
+
+
+def test_collection_ideate_sequential_generation_failure_is_nonzero_and_records_nothing(tmp_path: Path) -> None:
+    references = [tmp_path / "fail.jpg"]
+
+    result = _run_collection_ideate_generation_block(tmp_path, "sequential", references)
+
+    history_file = tmp_path / "collections" / "planning" / "_plan-previews" / "session" / "reference-assignments.txt"
+    assert result.returncode != 0
+    assert not history_file.exists()
+
+
+@pytest.mark.parametrize("mode", ["parallel", "sequential"])
+def test_collection_ideate_codex_generation_success_uses_selected_reference(tmp_path: Path, mode: str) -> None:
+    references = [tmp_path / "success.jpg"]
+
+    result = _run_collection_ideate_generation_block(tmp_path, mode, references, provider="codex")
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "invocations.txt").read_text(encoding="utf-8").splitlines() == [str(references[0])]
+
+
+@pytest.mark.parametrize("mode", ["parallel", "sequential"])
+def test_collection_ideate_codex_generation_failure_is_nonzero_and_records_nothing(tmp_path: Path, mode: str) -> None:
+    references = [tmp_path / "fail.jpg"]
+
+    result = _run_collection_ideate_generation_block(tmp_path, mode, references, provider="codex")
+
+    history_file = tmp_path / "collections" / "planning" / "_plan-previews" / "session" / "reference-assignments.txt"
+    assert result.returncode != 0
+    assert not history_file.exists() or history_file.read_text(encoding="utf-8") == ""
+
+
+def test_collection_ideate_reference_validation_executes_override_and_cross_state_history(tmp_path: Path) -> None:
+    channel_dir = tmp_path / "channel"
+    refs = [
+        channel_dir / "data" / "thumbnail_compare" / "benchmark" / "jazzgak" / f"ref-{index}.jpg" for index in range(3)
+    ]
+    for ref in refs:
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_bytes(b"jpg")
+
+    config_dir = channel_dir / "config" / "skills"
+    config_dir.mkdir(parents=True)
+    (config_dir / "thumbnail.yaml").write_text(
+        yaml.safe_dump({"image_generation": {"gemini": {"reference_images": {"dedup_recent_collections": 1}}}}),
+        encoding="utf-8",
+    )
+    for collection, reference in (
+        ("planning/20260101-old", refs[1]),
+        ("live/20260712-new", refs[0]),
+    ):
+        prompt_log = channel_dir / "collections" / collection / "20-documentation" / "thumbnail-prompts.md"
+        prompt_log.parent.mkdir(parents=True)
+        prompt_log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            f"| 1 | output | `{reference.relative_to(channel_dir)}` | jazzgak |\n",
+            encoding="utf-8",
+        )
+
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(channel_dir)
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, str(_collection_ideate_reference_validation_script()), "2"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [str(refs[2]), str(refs[1])]
+
+
+def test_collection_ideate_persists_assignments_for_the_next_run(tmp_path: Path) -> None:
+    channel_dir = tmp_path / "channel"
+    refs = [
+        channel_dir / "data" / "thumbnail_compare" / "benchmark" / "jazzgak" / f"ref-{index}.jpg" for index in range(3)
+    ]
+    for ref in refs:
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_bytes(b"jpg")
+
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(channel_dir)
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    validation_script = _collection_ideate_reference_validation_script()
+    first = subprocess.run(
+        [sys.executable, str(validation_script), "1"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    assert first.stdout.splitlines() == [str(refs[0])]
+
+    collection_dir = channel_dir / "collections" / "planning" / "20260713-first"
+    prompt_log = collection_dir / "20-documentation" / "thumbnail-prompts.md"
+    prompt_log.parent.mkdir(parents=True)
+    prompt_log.write_text(
+        "## Reference Assignments\n"
+        "| attempt | output | reference_image | benchmark_channel |\n"
+        "|---:|---|---|---|\n"
+        f"| 1 | thumbnail | `{refs[2].relative_to(channel_dir)}` | jazzgak |\n"
+        "\n## Prompt Details\nexisting thumbnail prompt\n",
+        encoding="utf-8",
+    )
+    persisted = subprocess.run(
+        [
+            sys.executable,
+            str(_collection_ideate_reference_history_script()),
+            str(collection_dir),
+            first.stdout.strip(),
+        ],
+        cwd=_repo_root(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert persisted.returncode == 0, persisted.stderr
+    prompt_text = prompt_log.read_text(encoding="utf-8")
+    assert prompt_text.count("## Reference Assignments") == 2
+    assert f"`{refs[0].relative_to(channel_dir)}`" in prompt_text
+
+    second = subprocess.run(
+        [sys.executable, str(validation_script), "1"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert second.returncode == 0, second.stderr
+    assert second.stdout.splitlines() == [str(refs[1])]
+
+
+def test_collection_ideate_sequential_records_only_generated_reference_and_preserves_unused_order(
+    tmp_path: Path,
+) -> None:
+    channel_dir = tmp_path / "channel"
+    refs = [
+        channel_dir / "data" / "thumbnail_compare" / "benchmark" / "jazzgak" / f"ref-{index}.jpg" for index in range(4)
+    ]
+    for ref in refs:
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_bytes(b"jpg")
+
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(channel_dir)
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    validation_script = _collection_ideate_reference_validation_script()
+    selected = subprocess.run(
+        [sys.executable, str(validation_script), "3"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert selected.returncode == 0, selected.stderr
+    selected_refs = selected.stdout.splitlines()
+    assert selected_refs == [str(ref) for ref in refs[:3]]
+
+    ref_index = 1
+    collection_dir = channel_dir / "collections" / "planning" / "20260713-first"
+    persisted = subprocess.run(
+        [
+            sys.executable,
+            str(_collection_ideate_reference_history_script()),
+            str(collection_dir),
+            selected_refs[ref_index],
+        ],
+        cwd=_repo_root(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert persisted.returncode == 0, persisted.stderr
+    prompt_log = (collection_dir / "20-documentation" / "thumbnail-prompts.md").read_text(encoding="utf-8")
+    assert f"`{refs[1].relative_to(channel_dir)}`" in prompt_log
+    assert f"`{refs[0].relative_to(channel_dir)}`" not in prompt_log
+    assert f"`{refs[2].relative_to(channel_dir)}`" not in prompt_log
+
+    next_selection = subprocess.run(
+        [sys.executable, str(validation_script), "3"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert next_selection.returncode == 0, next_selection.stderr
+    assert next_selection.stdout.splitlines() == [str(refs[0]), str(refs[2]), str(refs[3])]
+
+
+def test_collection_ideate_cycles_entire_pool_before_reuse(tmp_path: Path) -> None:
+    channel_dir = tmp_path / "channel"
+    refs = [
+        channel_dir / "data" / "thumbnail_compare" / "benchmark" / "jazzgak" / f"ref-{index}.jpg" for index in range(5)
+    ]
+    for ref in refs:
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_bytes(b"jpg")
+
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(channel_dir)
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    validation_script = _collection_ideate_reference_validation_script()
+    history_script = _collection_ideate_reference_history_script()
+    selected: list[str] = []
+    planned: list[list[str]] = []
+
+    for index in range(len(refs)):
+        validation = subprocess.run(
+            [sys.executable, str(validation_script), "3"],
+            cwd=_repo_root(),
+            env=env,
+            input="".join(f"{ref}\n" for ref in refs),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert validation.returncode == 0, validation.stderr
+        planned_references = validation.stdout.splitlines()
+        planned.append(planned_references)
+        generated = _run_collection_ideate_generation_block(
+            tmp_path / f"preview-{index}",
+            "parallel",
+            [Path(reference) for reference in planned_references],
+        )
+        assert generated.returncode == 0, generated.stderr
+        invocation_log = tmp_path / f"preview-{index}" / "invocations.txt"
+        assert invocation_log.read_text(encoding="utf-8").splitlines() == planned_references
+
+        selected_reference = planned_references[0]
+        selected.append(selected_reference)
+        persisted = subprocess.run(
+            [
+                sys.executable,
+                str(history_script),
+                str(channel_dir / "collections" / "planning" / f"2026071{index}-collection"),
+                selected_reference,
+            ],
+            cwd=_repo_root(),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert persisted.returncode == 0, persisted.stderr
+
+    assert selected == [str(ref) for ref in refs]
+    assert planned == [
+        [str(refs[0]), str(refs[1]), str(refs[2])],
+        [str(refs[1]), str(refs[2]), str(refs[3])],
+        [str(refs[2]), str(refs[3]), str(refs[4])],
+        [str(refs[3]), str(refs[4]), str(refs[0])],
+        [str(refs[4]), str(refs[0]), str(refs[1])],
+    ]
+
+    after_cycle = subprocess.run(
+        [sys.executable, str(validation_script), "3"],
+        cwd=_repo_root(),
+        env=env,
+        input="".join(f"{ref}\n" for ref in refs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert after_cycle.returncode == 0, after_cycle.stderr
+    assert after_cycle.stdout.splitlines()[0] == str(refs[0])
+
+
+def test_collection_ideate_reference_history_failure_is_nonzero(tmp_path: Path) -> None:
+    blocked_parent = tmp_path / "channel" / "blocked"
+    blocked_parent.parent.mkdir(parents=True)
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    collection_dir = blocked_parent / "20260713-collection"
+    env = os.environ.copy()
+    env["CHANNEL_DIR"] = str(tmp_path / "channel")
+    env["PYTHONPATH"] = str(_repo_root() / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_collection_ideate_reference_history_script()),
+            str(collection_dir),
+            str(tmp_path / "reference.jpg"),
+        ],
+        cwd=_repo_root(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "参照画像履歴を保存できません" in result.stderr
 
 
 def test_thumbnail_sample_prompts_are_short_ttp_diff_not_prompt_only_style() -> None:


### PR DESCRIPTION
## Summary

## 概要
`/collection-ideate`（Phase 4-4）と `/thumbnail` single_step が使う `plan_ttp_reference_assignments()`（`thumbnail_references.py`）は `reference_images.default[:candidate_count]` の位置固定選定で、直近の使用履歴を一切考慮しない。参照画像プールが少数（5枚程度）の場合、コレクションを重ねるたびに同じ画像が数週間以内に再利用され、視覚的な「テンプレ感」を招く（#376 のRJN実例: 2026-05-13〜17の5本で2枚が2回重複）。直近N件のコレクションで使用済みの参照を除外する dedup ローテーションを追加する。

## 背景・目的
旧 #376 の後継 issue。#376 が提案した schema（`reference_images.rotation_pool`）・専用モジュール（`utils.reference_picker`）は未実装のまま残っていた一方、#376 起票の翌日に別issue #356 対応でTTP参照割当のコア機構 `plan_ttp_reference_assignments()` が新設された。この新機構を土台に、#376 の本来の動機（参照重複によるテンプレ感）を解決する形で作り直す。

## 参照資料
- .claude/skills/collection-ideate/SKILL.md（Phase 4-4, L213-317）
- .claude/skills/thumbnail/SKILL.md（「参照画像（複数 + ローテーション）」節）
- .claude/skills/thumbnail/config.default.yaml（reference_images.default / single_step.rotate）
- src/youtube_automation/utils/thumbnail_references.py（plan_ttp_reference_assignments）
- src/youtube_automation/utils/image_provider/composition.py（select_reference）

## 影響ファイル
- **変更**: src/youtube_automation/utils/thumbnail_references.py（plan_ttp_reference_assignments への dedup 対応、または新規ヘルパー関数追加）
- **変更**: .claude/skills/thumbnail/config.default.yaml（dedup window 設定キー追加）
- **変更**: .claude/skills/collection-ideate/SKILL.md（Phase 4-4 の REF_PATHS 構築コマンド）
- **新規**: tests/test_thumbnail_references.py（または既存テストファイルへの追加）にdedupシナリオのユニットテスト

**兄弟入口・貫通先**: `/thumbnail` skill の single_step も同じ `plan_ttp_reference_assignments()` を呼ぶため自動的に恩恵を受ける。config キー追加のため、default と channel 個別 config のマージ経路（load_skill_config）を通ることを確認する。

## 要件
1. `reference_images.default` に候補数を上回る参照画像が設定された状態で `/collection-ideate` を連続実行すると、直近N件（設定可能、既定値あり）のコレクションで使用済みの参照画像が選定候補から自動除外される → 同じ参照が短期間で再選定されない
2. 同一プールに対し `/collection-ideate` をプールサイズ回連続実行すると、全エントリが最低1回ずつ選ばれてから初めて重複が発生する（枯渇時は既存の位置順 fallback で継続、エラーにしない）
3. 使用履歴を追跡する情報（workflow-state.json 等）を持たない既存（レガシー）コレクションが混在していても、dedup 判定処理はエラーにならず安全側にフォールバックする
4. dedup 除外後に候補数分の参照画像が確保できない場合、`plan_ttp_reference_assignments` は現行同様「原因＋対処（参照画像を追加せよ）」を含む `ConfigError` で明確に停止する（サイレント重複選定をしない）

## スコープ外
`workflow-state.json::planning.scene_phrase_en` の新設・`yt-populate-scene-phrases` の3段優先順位化（#376 Scope 4-6）は対象外。ER値によるランキング順制御や axis タグ付けなどの高度化も対象外（まず位置順+dedup除外のみで様子見）。

## 実装方針（takt）
- workflow: improve
- 理由: 既存の参照選定挙動への dedup 追加（IF 変更なし）のため

## Execution Report

Workflow `improve` completed successfully.

Closes #1649