### PR TITLE
[#1694] issue-1694-audit-discover-comp

### DIFF
--- a/.claude/skills/discover-competitors/SKILL.md
+++ b/.claude/skills/discover-competitors/SKILL.md
@@ -11,7 +11,7 @@ description: "Use when 追加競合候補の自動発掘やニッチ仮説の並
 
 - 入力: ニッチキーワード（カンマ区切り）+ フィルタ条件
 - 出力: ランキング付き Markdown + 同名 CSV（スコア内訳列付き）
-- 想定時間: 5 分以内（API quota 約 660 units / 実行）
+- 想定時間: 5 分以内（初回または強制更新時の API quota 約 660 units。24 時間以内の同一検索条件はキャッシュを利用）
 
 `/channel-new` の標準フローでは実行しない。TTP 対象確認後に追加の競合候補を広げたい場合や、複数のニッチ仮説を
 並行検証したい場合に、このスキルを任意で走らせる。
@@ -122,6 +122,7 @@ config からの抽出例（rjn）:
 | `--posted-within-days` | `search.posted_within_days`（既定 30） | 「動いている競合」のみ。1 年単位で見たいなら 365 |
 | `--top` | `search.top`（既定 20） | レポートに出す件数 |
 | `--per-keyword` | `search.per_keyword`（既定 20） | search.list の maxResults（合計クエリ数 = keywords × per-keyword） |
+| `--refresh` | — | 24 時間の TTL 内でも検索キャッシュを無視して search.list を再実行 |
 
 ### Step 3: 実行
 
@@ -134,6 +135,11 @@ uv run yt-discover-competitors \
   --posted-within-days 30 --top 20 \
   --output research/lo-fi-discovery.md
 ```
+
+同じ keyword と `--per-keyword` の組み合わせによる `search.list` 結果は、チャンネル配下の
+`.cache/youtube-automation/discover-competitors-search.json` に 24 時間保存される。最新結果が必要な場合だけ
+上記コマンドへ `--refresh` を追加する。`config/channel/analytics.json::benchmark.channels` に登録済みの
+channel ID は候補から除外される。
 
 出力ペア:
 - `research/lo-fi-discovery.md` — Markdown ランキングテーブル
@@ -156,7 +162,7 @@ subagent へは次を具体値で渡す:
 
 ## API コスト
 
-1 回実行あたり概ね 660 units（10,000/日 quota の 6.6%）:
+初回または `--refresh` 実行あたり概ね 660 units（10,000/日 quota の 6.6%）。同一条件の search.list は 24 時間キャッシュされる:
 - search.list × keywords: 100 units × N
 - channels.list: 1 unit × 候補数（バッチ）
 - videos.list: 1 unit × 候補数（直近 5 本まとめて 1 リクエスト）
@@ -168,7 +174,7 @@ subagent へは次を具体値で渡す:
 | 状況 | 兆候 | 対処 |
 |---|---|---|
 | OAuth 未認証/失効 | `auth.oauth_handler` の `FileNotFoundError`（`client_secrets.json` 不在）/ `AuthError` / HTTP 403 | 初回認証フローを再実行。403 が続く場合は `auth/token.json` を削除しスコープを確認のうえ再認証 |
-| YouTube quota / rate | HTTP 429 / 403 `quotaExceeded` | 日次 quota（既定 10,000 units・太平洋時間 0 時リセット）を待つか呼び出しを抑える。本スキルは 1 回あたり約 660 units を消費するため、並行検証の連発を控え、キーワード数や `--per-keyword` を減らして次回リセット後に再実行する |
+| YouTube quota / rate | HTTP 429 / 403 `quotaExceeded` | 日次 quota（既定 10,000 units・太平洋時間 0 時リセット）を待つか呼び出しを抑える。初回または `--refresh` は約 660 units を消費するため、並行検証の連発を控え、キーワード数や `--per-keyword` を減らして次回リセット後に再実行する |
 | API 障害 / サービス停止 | HTTP 503 / タイムアウト | Google Cloud / YouTube のステータスを確認し、時間を置いて再実行 |
 | 同一 `--output` での再実行 | 前回の `.md` / `.csv` の内容が消える | 仕様どおりの動作。出力ペア（`.md` + 同名 `.csv`）は再実行時に全体が上書きされ、部分結果のマージ・保持はされない（API 呼び出しが途中で失敗した場合はファイルは書き込まれず、前回の出力がそのまま残る）。結果を比較したい場合は実行ごとに `--output` を別ファイル名にする |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `perf(discover-competitors)`: `search.list` 結果を 24 時間キャッシュし、`--refresh` による強制更新と benchmark 登録済みチャンネルの除外を追加した（#1694）
+
 - `feat(suno-helper)`: duration guard NG の同一 prompt 再生成を popup の「異常値の曲を再生成する」で切り替え可能にした。既定 ON は安全・高速モードとも最大 2 回再生成し、OFF は NG を警告表示しつつ生成済み全 clip を playlist / download 候補に維持する。選択は popup 再表示、resume、失敗分再実行、playlist 再実行へ引き継ぐ（#1733）
 - `docs(skills)`: リサーチ・戦略チェーンの 6 スキル（benchmark / discover-competitors / viewer-voice / audience-persona-design / viewing-scene / channel-research）の冒頭 60 行以内に、停止する fail と許容する fail を分離した前提成果物ガードを統一書式で整備した。必須入力が無い場合は生成元の前工程スキルを案内して停止し、後続 Step で生成・自動更新・代替できる入力欠如は停止条件から除外する（#1825）
 

--- a/src/youtube_automation/scripts/discover_competitors.py
+++ b/src/youtube_automation/scripts/discover_competitors.py
@@ -25,7 +25,7 @@ import csv
 import logging
 from pathlib import Path
 
-from youtube_automation.utils.competitor_discovery import discover_competitors
+from youtube_automation.utils.competitor_discovery import SearchCacheMode, discover_competitors
 from youtube_automation.utils.competitor_scoring import (
     CandidateChannel,
     DiscoveryParams,
@@ -125,6 +125,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "既定: ON（topic 不明チャンネルは fail-open で通す）。"
             "従来挙動に戻すには --no-require-music-topic"
         ),
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="TTL 内の検索キャッシュも無視して search.list を再実行する",
     )
     parser.add_argument("--output", required=True, help="Markdown 出力先（同名 .csv も書き出す）")
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -272,7 +277,8 @@ def main() -> None:
     params = _build_params(args)
 
     youtube = get_youtube()
-    scored = discover_competitors(youtube, params)
+    cache_mode = SearchCacheMode.REFRESH if args.refresh else SearchCacheMode.USE
+    scored = discover_competitors(youtube, params, cache_mode)
 
     output_md = Path(args.output)
     output_csv = output_md.with_suffix(".csv")

--- a/src/youtube_automation/utils/competitor_discovery.py
+++ b/src/youtube_automation/utils/competitor_discovery.py
@@ -11,9 +11,15 @@ YouTube Data API I/O と公開関数 `discover_competitors` を提供する。
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import time
 from collections import defaultdict
 from dataclasses import replace
 from datetime import datetime
+from enum import Enum
+from pathlib import Path
 
 from youtube_automation.utils.competitor_scoring import (
     _RECENT_VIDEOS_PER_CHANNEL,
@@ -24,11 +30,92 @@ from youtube_automation.utils.competitor_scoring import (
     _apply_filters,
     _score_candidate,
 )
+from youtube_automation.utils.config import channel_dir, load_config
 from youtube_automation.utils.exceptions import YouTubeAPIError
 from youtube_automation.utils.retry import execute_with_retry
 
 # channels.list バッチ単位（YouTube Data API 上限）
 _CHANNELS_BATCH_SIZE = 50
+_SEARCH_CACHE_TTL_SECONDS = 24 * 60 * 60
+_SEARCH_CACHE_VERSION = 1
+logger = logging.getLogger(__name__)
+
+
+class SearchCacheMode(Enum):
+    """search.list キャッシュの利用方針。"""
+
+    USE = "use"
+    REFRESH = "refresh"
+
+
+def _search_cache_path() -> Path:
+    return channel_dir() / ".cache" / "youtube-automation" / "discover-competitors-search.json"
+
+
+def _cache_key(keyword: str, max_results: int) -> str:
+    return json.dumps([keyword, max_results], ensure_ascii=False, separators=(",", ":"))
+
+
+def _read_search_cache(path: Path) -> dict[str, dict]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        logger.warning("検索キャッシュを読み込めないため再検索します: %s", error)
+        return {}
+    if (
+        not isinstance(payload, dict)
+        or payload.get("version") != _SEARCH_CACHE_VERSION
+        or not isinstance(payload.get("entries"), dict)
+    ):
+        logger.warning("検索キャッシュの形式が不正なため再検索します: %s", path)
+        return {}
+    return payload["entries"]
+
+
+def _write_search_cache(path: Path, entries: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": _SEARCH_CACHE_VERSION, "entries": entries}
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _cached_search_channels(
+    youtube,
+    keyword: str,
+    max_results: int,
+    cache_mode: SearchCacheMode,
+) -> dict[str, set[str]]:
+    path = _search_cache_path()
+    entries = _read_search_cache(path)
+    key = _cache_key(keyword, max_results)
+    entry = entries.get(key)
+    now = time.time()
+    if cache_mode is SearchCacheMode.USE and isinstance(entry, dict):
+        saved_at = entry.get("saved_at")
+        channel_ids = entry.get("channel_ids")
+        if (
+            isinstance(saved_at, (int, float))
+            and 0 <= now - saved_at < _SEARCH_CACHE_TTL_SECONDS
+            and isinstance(channel_ids, list)
+            and all(isinstance(channel_id, str) for channel_id in channel_ids)
+        ):
+            return {channel_id: {keyword} for channel_id in channel_ids}
+
+    hits = _search_channels(youtube, keyword, max_results)
+    entries[key] = {"saved_at": now, "channel_ids": list(hits)}
+    _write_search_cache(path, entries)
+    return hits
+
+
+def _discovered_channel_ids() -> set[str]:
+    return {
+        channel_id
+        for channel in load_config().analytics.benchmark.channels
+        if isinstance(channel, dict) and isinstance((channel_id := channel.get("id")), str) and channel_id
+    }
 
 
 # ----------------------------------------------------------------------------
@@ -153,21 +240,29 @@ def _fetch_recent_videos(youtube, uploads_playlist_id: str) -> list[VideoMetric]
 # ----------------------------------------------------------------------------
 
 
-def discover_competitors(youtube, params: DiscoveryParams) -> list[ScoredCandidate]:
+def discover_competitors(
+    youtube,
+    params: DiscoveryParams,
+    cache_mode: SearchCacheMode = SearchCacheMode.USE,
+) -> list[ScoredCandidate]:
     """競合チャンネル候補を発掘し、複合スコア降順で返す。
 
     パイプライン:
-      1. search.list × keywords → channel_id → matched_keywords map（直接 union）
-      2. channels.list → メタデータ + uploads playlist
-      3. _apply_filters（subs / total_videos）
-      4. _fetch_recent_videos → recent_videos + last_posted_at
-      5. _apply_filters（posted_within_days）
-      6. _score_candidate + sort + top N
+      1. TTL キャッシュまたは search.list × keywords → channel_id → matched_keywords map（直接 union）
+      2. benchmark.channels の検出済み channel ID を除外
+      3. channels.list → メタデータ + uploads playlist
+      4. _apply_filters（subs / total_videos）
+      5. _fetch_recent_videos → recent_videos + last_posted_at
+      6. _apply_filters（posted_within_days）
+      7. _score_candidate + sort + top N
     """
     keyword_map: dict[str, set[str]] = defaultdict(set)
     for keyword in params.keywords:
-        for ch_id, kws in _search_channels(youtube, keyword, params.per_keyword_results).items():
+        for ch_id, kws in _cached_search_channels(youtube, keyword, params.per_keyword_results, cache_mode).items():
             keyword_map[ch_id] |= kws
+
+    for channel_id in _discovered_channel_ids():
+        keyword_map.pop(channel_id, None)
 
     if not keyword_map:
         return []

--- a/tests/test_competitor_discovery.py
+++ b/tests/test_competitor_discovery.py
@@ -15,14 +15,16 @@ Issue #114 で追加する `yt-discover-competitors` のコアロジックを検
 from __future__ import annotations
 
 import dataclasses
+import json
 from datetime import date, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from youtube_automation.utils.competitor_discovery import discover_competitors
+from youtube_automation.utils.competitor_discovery import SearchCacheMode, discover_competitors
 from youtube_automation.utils.competitor_scoring import (
     _MUSIC_TOPIC_URLS,
     CandidateChannel,
@@ -40,6 +42,16 @@ from youtube_automation.utils.competitor_scoring import (
     _is_music_topic_match,
 )
 from youtube_automation.utils.exceptions import YouTubeAPIError
+
+
+@pytest.fixture(autouse=True)
+def _isolated_discovery_cache(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "discover-competitors-search.json"
+    monkeypatch.setattr(
+        "youtube_automation.utils.competitor_discovery._search_cache_path",
+        lambda: cache_path,
+    )
+
 
 # ----------------------------------------------------------------------------
 # テストデータ生成ヘルパー
@@ -844,6 +856,138 @@ class TestDiscoverCompetitors:
         }
 
         return youtube
+
+    def _make_single_candidate_youtube(self, channel_id: str = "UC_NEW") -> MagicMock:
+        today_iso = date.today().isoformat()
+        return self._make_youtube_mock(
+            search_items=[{"snippet": {"channelId": channel_id}}],
+            channel_items=[
+                {
+                    "id": channel_id,
+                    "snippet": {"title": "New Channel", "customUrl": "@new"},
+                    "statistics": {"subscriberCount": "100000", "videoCount": "10"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_NEW"}},
+                }
+            ],
+            playlist_items={"UU_NEW": [{"contentDetails": {"videoId": "V_NEW"}}]},
+            video_items=[
+                {
+                    "id": "V_NEW",
+                    "snippet": {"publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+
+    def test_second_identical_run_uses_cached_search_results(self):
+        youtube = self._make_single_candidate_youtube()
+        params = _make_params(keywords=("lo-fi study",))
+
+        first = discover_competitors(youtube, params)
+        youtube.search.return_value.list.reset_mock()
+        second = discover_competitors(youtube, params)
+
+        assert [item.channel.channel_id for item in first] == ["UC_NEW"]
+        assert [item.channel.channel_id for item in second] == ["UC_NEW"]
+        assert youtube.search.return_value.list.call_count == 0
+
+    def test_expired_cache_repeats_search_and_updates_timestamp(self, tmp_path: Path):
+        youtube = self._make_single_candidate_youtube()
+        params = _make_params(keywords=("lo-fi study",))
+        discover_competitors(youtube, params)
+        cache_path = tmp_path / "discover-competitors-search.json"
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        next(iter(payload["entries"].values()))["saved_at"] = 0
+        cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        discover_competitors(youtube, params)
+
+        updated = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert youtube.search.return_value.list.call_count == 2
+        assert next(iter(updated["entries"].values()))["saved_at"] > 0
+
+    def test_refresh_repeats_search_with_fresh_cache(self):
+        youtube = self._make_single_candidate_youtube()
+        params = _make_params(keywords=("lo-fi study",))
+        discover_competitors(youtube, params)
+
+        discover_competitors(youtube, params, SearchCacheMode.REFRESH)
+
+        assert youtube.search.return_value.list.call_count == 2
+
+    def test_cache_write_failure_propagates_from_discovery_entrypoint(self, monkeypatch):
+        youtube = self._make_single_candidate_youtube()
+        params = _make_params(keywords=("lo-fi study",))
+
+        def fail_write_text(self, data, *, encoding=None, errors=None, newline=None):
+            raise PermissionError("cache is not writable")
+
+        monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+        with pytest.raises(PermissionError, match="cache is not writable"):
+            discover_competitors(youtube, params)
+
+        assert youtube.search.return_value.list.call_count == 1
+
+    def test_skips_channel_already_registered_for_benchmark(self):
+        today_iso = date.today().isoformat()
+        youtube = self._make_youtube_mock(
+            search_items=[
+                {"snippet": {"channelId": "UC123"}},
+                {"snippet": {"channelId": "UC_NEW"}},
+            ],
+            channel_items=[
+                {
+                    "id": "UC_NEW",
+                    "snippet": {"title": "New Channel", "customUrl": "@new"},
+                    "statistics": {"subscriberCount": "100000", "videoCount": "10"},
+                    "contentDetails": {"relatedPlaylists": {"uploads": "UU_NEW"}},
+                }
+            ],
+            playlist_items={"UU_NEW": [{"contentDetails": {"videoId": "V_NEW"}}]},
+            video_items=[
+                {
+                    "id": "V_NEW",
+                    "snippet": {"publishedAt": f"{today_iso}T00:00:00Z"},
+                    "statistics": {"viewCount": "10000", "likeCount": "100", "commentCount": "10"},
+                }
+            ],
+        )
+        params = _make_params(keywords=("lo-fi study",))
+
+        result = discover_competitors(youtube, params)
+
+        assert [candidate.channel.channel_id for candidate in result] == ["UC_NEW"]
+        youtube.channels.return_value.list.assert_called_once()
+        assert youtube.channels.return_value.list.call_args.kwargs["id"] == "UC_NEW"
+
+    @pytest.mark.parametrize(
+        ("cache_contents", "warning"),
+        [
+            ("{not valid JSON", "検索キャッシュを読み込めないため再検索します"),
+            (json.dumps({"version": 0, "entries": []}), "検索キャッシュの形式が不正なため再検索します"),
+        ],
+    )
+    def test_invalid_cache_warns_researches_and_replaces_cache(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        cache_contents: str,
+        warning: str,
+    ):
+        cache_path = tmp_path / "discover-competitors-search.json"
+        cache_path.write_text(cache_contents, encoding="utf-8")
+        youtube = self._make_single_candidate_youtube()
+
+        with caplog.at_level("WARNING"):
+            result = discover_competitors(youtube, _make_params(keywords=("lo-fi study",)))
+
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert [candidate.channel.channel_id for candidate in result] == ["UC_NEW"]
+        assert any(warning in message for message in caplog.messages)
+        assert youtube.search.return_value.list.call_count == 1
+        assert payload["version"] == 1
+        assert len(payload["entries"]) == 1
 
     def test_retries_transient_api_failure_through_discovery_entrypoint(self, monkeypatch):
         monkeypatch.setattr("youtube_automation.utils.retry.time.sleep", lambda _: None)

--- a/tests/test_discover_competitors_cli.py
+++ b/tests/test_discover_competitors_cli.py
@@ -29,6 +29,7 @@ from youtube_automation.scripts.discover_competitors import (
     _write_markdown,
     main,
 )
+from youtube_automation.utils.competitor_discovery import SearchCacheMode
 from youtube_automation.utils.competitor_scoring import (
     CandidateChannel,
     DiscoveryParams,
@@ -128,6 +129,14 @@ class TestBuildParser:
         assert args.posted_within_days == 30
         assert args.top == 20
         assert args.per_keyword == 20
+        assert args.refresh is False
+
+    def test_refresh_flag_parses(self):
+        parser = _build_parser()
+
+        args = parser.parse_args(["--keywords", "lo-fi", "--refresh", "--output", "out.md"])
+
+        assert args.refresh is True
 
     def test_explicit_filter_values_override_defaults(self):
         # Given: 全フラグ指定
@@ -473,6 +482,56 @@ class TestWriteCsv:
 
 
 class TestMain:
+    def test_main_passes_default_cache_mode_to_discovery(self, tmp_path: Path, monkeypatch):
+        out_md = tmp_path / "cached.md"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["yt-discover-competitors", "--keywords", "lo-fi", "--output", str(out_md)],
+        )
+
+        with (
+            patch(
+                "youtube_automation.scripts.discover_competitors.discover_competitors",
+                return_value=[],
+            ) as discover,
+            patch(
+                "youtube_automation.scripts.discover_competitors.get_youtube",
+                return_value=MagicMock(),
+            ) as get_youtube_mock,
+        ):
+            main()
+
+        discover.assert_called_once()
+        youtube, params, cache_mode = discover.call_args.args
+        assert youtube is get_youtube_mock.return_value
+        assert params.keywords == ("lo-fi",)
+        assert cache_mode is SearchCacheMode.USE
+
+    def test_main_passes_refresh_mode_to_discovery(self, tmp_path: Path, monkeypatch):
+        out_md = tmp_path / "refresh.md"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["yt-discover-competitors", "--keywords", "lo-fi", "--refresh", "--output", str(out_md)],
+        )
+
+        with (
+            patch(
+                "youtube_automation.scripts.discover_competitors.discover_competitors",
+                return_value=[],
+            ) as discover,
+            patch(
+                "youtube_automation.scripts.discover_competitors.get_youtube",
+                return_value=MagicMock(),
+            ) as get_youtube_mock,
+        ):
+            main()
+
+        discover.assert_called_once()
+        youtube, params, cache_mode = discover.call_args.args
+        assert youtube is get_youtube_mock.return_value
+        assert params.keywords == ("lo-fi",)
+        assert cache_mode is SearchCacheMode.REFRESH
+
     def test_main_writes_markdown_and_csv(self, tmp_path: Path, monkeypatch):
         # Given: discover_competitors を 2 件返すように mock
         scored = [


### PR DESCRIPTION
## Summary

## 概要

`competitor_discovery.py:46-67` にキャッシュがなく、`/discover-competitors` の実行ごとに同じ `search.list` 検索（1 実行あたり約 660 unit）を打ち、YouTube Data API quota を線形に消費する。

## 背景・目的

旧 #395 の後継（skill-audit-2026-05 / PR #375 P1-3 由来）。本日の実装乖離監査で、`src/youtube_automation/utils/competitor_discovery.py:46-67` に結果キャッシュが依然として無いことを確認済み。

## 再現手順

1. `/discover-competitors` を実行する（search.list 消費）
2. 同一条件で直後にもう一度実行する

## 期待される動作

- 直近の検索結果が TTL 付きキャッシュから返り、search.list を再消費しない
- `--refresh` 指定時のみキャッシュを無効化して再検索する
- 既に検出済みのチャンネルは skip される

## 実際の動作

- 実行のたびに同一検索を API へ発行し、毎回約 660 unit を消費する（日次 quota 10,000 unit に対して大きい）

## 影響範囲

- discover-competitors を反復実行する運用全般。quota 枯渇により同日中の他 skill（benchmark / analytics-collect 等）の API 実行を巻き込む

## 参照資料

- src/youtube_automation/utils/competitor_discovery.py（L46-67 が対象）
- .claude/skills/discover-competitors/SKILL.md

## 影響ファイル

- **変更**: src/youtube_automation/utils/competitor_discovery.py（TTL キャッシュ / `--refresh` / 検出済み skip）
- **変更**: .claude/skills/discover-competitors/SKILL.md（キャッシュ挙動・`--refresh` の記述）
- **新規**: キャッシュ保存先の設計（保存場所・フォーマット・TTL は plan step で確定）
- **新規/変更**: tests/（キャッシュ hit/miss・TTL 失効・refresh・skip の各ケース）

**兄弟入口・貫通先**: .claude/skills/benchmark（同じく YouTube Data API を消費する兄弟。今回の対象は competitor_discovery.py のみで benchmark 側は変更しない）

## 要件

1. 初回実行後、同一条件で再実行する → search.list が呼ばれず（mock 呼び出し回数 0）キャッシュ結果が返る
2. TTL を失効させて再実行する → 再検索が発行され、キャッシュが更新される
3. `--refresh` を付けて実行する → TTL 内でもキャッシュを無視して再検索する
4. 検出済みチャンネルを含む結果で再実行する → 検出済みチャンネルが skip され、新規のみが追加される
5. `uv run pytest tests/` を実行する → 追加テスト含め全件 pass する

## スコープ外

- video-analyze の Gemini キャッシュ（旧 #394 の後継 issue）は扱わない
- YouTube Data API 系の共通 retry 導入（旧 #396 の後継 issue）は扱わない
- 競合発掘のスコアリングロジック自体の変更は行わない

## 実装方針（takt）

- workflow: improve
- 理由: 再実行時の挙動を変えるコスト最適化拡張のため

## Execution Report

Workflow `improve` completed successfully.

Closes #1694