### PR TITLE
[#1775] issue-1775-suno-helper-queue-m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(suno-helper)`: Queue mode の duration guard 全滅 entry を、全 entry の ACK 先行投入後に既存 pacing で同一 prompt から最大 2 回自動再生成する挙動を明示し、Queue mode の説明文にも自動再生成を追記した（#1775）。
+
 - `perf(discover-competitors)`: `search.list` 結果を 24 時間キャッシュし、`--refresh` による強制更新と benchmark 登録済みチャンネルの除外を追加した（#1694）
 
 - `feat(suno-helper)`: duration guard NG の同一 prompt 再生成を popup の「異常値の曲を再生成する」で切り替え可能にした。既定 ON は安全・高速モードとも最大 2 回再生成し、OFF は NG を警告表示しつつ生成済み全 clip を playlist / download 候補に維持する。選択は popup 再表示、resume、失敗分再実行、playlist 再実行へ引き継ぐ（#1733）

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -140,7 +140,8 @@ export const RUN_MODES: Record<RunModeId, RunMode> = {
   },
   queue: {
     label: "高速モード",
-    riskNote: "最大10件を先行投入する、速度重視のモードです。",
+    riskNote:
+      "最大10件を先行投入し、duration guard NG 時は自動再生成する速度重視のモードです。",
   },
 };
 

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1234,23 +1234,16 @@ export default defineContentScript({
                     pollIntervalMs: POLL_INTERVAL_MS,
                     describeEntry: () => `entry ${index} (${entryDisplayName(entries[index])})`,
                   });
-                  const regeneratedClipIds = tracker.getSubmittedIds().filter((id) => !submittedBefore.has(id));
-                  try {
-                    await waitForAttemptClipsComplete(regeneratedClipIds, {
-                      getPendingIdsByIds: (ids) => tracker.getPendingIdsByIds(ids),
-                      requestFeedPoll,
-                      abortableSleep,
-                      isAborted: () => aborted,
-                      now: Date.now,
-                    });
-                  } catch (error) {
-                    tracker.dropSubmittedIds(regeneratedClipIds);
-                    throw error;
-                  }
-                  if (aborted) {
-                    tracker.dropSubmittedIds(regeneratedClipIds);
-                  }
-                  return regeneratedClipIds;
+                  return tracker.getSubmittedIds().filter((id) => !submittedBefore.has(id));
+                },
+                waitForRegeneratedClips: async (regeneratedClipIds: string[]) => {
+                  await waitForAttemptClipsComplete(regeneratedClipIds, {
+                    getPendingIdsByIds: (ids) => tracker.getPendingIdsByIds(ids),
+                    requestFeedPoll,
+                    abortableSleep,
+                    isAborted: () => aborted,
+                    now: Date.now,
+                  });
                 },
               };
         const yieldResult = await finalizeQueueEntriesYield({

--- a/extensions/suno-helper/lib/queue-runner.ts
+++ b/extensions/suno-helper/lib/queue-runner.ts
@@ -92,7 +92,11 @@ export interface QueueEntriesYieldOptions {
   emitProgress: (payload: ProgressPayload) => void;
   durationOutlierStrategy:
     | { kind: "retain" }
-    | { kind: "regenerate"; regenerateEntry: (index: number, attempt: number) => Promise<string[]> };
+    | {
+        kind: "regenerate";
+        regenerateEntry: (index: number, attempt: number) => Promise<string[]>;
+        waitForRegeneratedClips: (clipIds: string[]) => Promise<void>;
+      };
   isAborted?: () => boolean;
 }
 
@@ -159,8 +163,10 @@ async function submitQueueEntry(options: QueueSubmissionOptions, index: number):
 export async function finalizeQueueEntriesYield(options: QueueEntriesYieldOptions): Promise<QueueEntriesYieldResult> {
   const failedIndices: number[] = [];
   const durationFilter = options.durationFilter ?? DEFAULT_DURATION_FILTER;
+  const pendingEntries = new Map<number, { clipIds: string[]; yieldRetryCount: number }>();
+
   for (const index of options.order) {
-    let entryClipIds = options.clipIdsByEntry.get(index) ?? [];
+    const entryClipIds = options.clipIdsByEntry.get(index) ?? [];
     if (entryClipIds.length === 0) {
       console.warn(
         `[suno-helper] entry ${index} の clip ID を bridge で観測できなかったため duration guard を skip します。`,
@@ -168,8 +174,17 @@ export async function finalizeQueueEntriesYield(options: QueueEntriesYieldOption
       options.emitProgress({ phase: PHASE.DONE, index, total: options.total, yieldRetryCount: 0 });
       continue;
     }
-    let yieldRetryCount = 0;
-    for (;;) {
+    pendingEntries.set(index, { clipIds: entryClipIds, yieldRetryCount: 0 });
+  }
+
+  while (pendingEntries.size > 0) {
+    const retries: Array<{ index: number; previousClipIds: string[]; yieldRetryCount: number }> = [];
+    for (const index of options.order) {
+      const pendingEntry = pendingEntries.get(index);
+      if (pendingEntry === undefined) {
+        continue;
+      }
+      const { clipIds: entryClipIds, yieldRetryCount } = pendingEntry;
       let attemptResult;
       try {
         attemptResult = {
@@ -207,52 +222,31 @@ export async function finalizeQueueEntriesYield(options: QueueEntriesYieldOption
           yieldRetryCount,
           acceptedClipIds: decision.acceptedClipIds,
         });
-        break;
+        pendingEntries.delete(index);
+        continue;
       }
       if (decision.kind === "retry") {
         if (options.durationOutlierStrategy.kind !== "regenerate") {
           throw new Error("duration retain policy returned an invalid retry decision");
         }
-        yieldRetryCount += 1;
+        const nextYieldRetryCount = yieldRetryCount + 1;
         console.warn(
-          `[suno-helper] entry ${index} duration guard NG、同一 prompt で再生成します (${yieldRetryCount}/${MAX_YIELD_RETRY}): ${decision.message}`,
+          `[suno-helper] entry ${index} duration guard NG、同一 prompt で再生成します (${nextYieldRetryCount}/${MAX_YIELD_RETRY}): ${decision.message}`,
         );
         options.emitProgress({
           phase: PHASE.WAITING_SLOT,
           index,
           total: options.total,
-          message: `${decision.message}; retry ${yieldRetryCount}/${MAX_YIELD_RETRY}`,
-          yieldRetryCount,
+          message: `${decision.message}; retry ${nextYieldRetryCount}/${MAX_YIELD_RETRY}`,
+          yieldRetryCount: nextYieldRetryCount,
           log: {
             kind: "retry",
             entryName: entryDisplayName(options.entries[index]),
-            attempt: yieldRetryCount,
+            attempt: nextYieldRetryCount,
             max: MAX_YIELD_RETRY,
           },
         });
-        try {
-          const regeneratedClipIds = await options.durationOutlierStrategy.regenerateEntry(index, yieldRetryCount);
-          if (options.isAborted?.()) {
-            return { failedIndices, abortedIndex: index };
-          }
-          options.dropSubmittedIds(entryClipIds);
-          entryClipIds = regeneratedClipIds;
-        } catch (error) {
-          const regenerationMessage = error instanceof Error ? error.message : String(error);
-          options.dropSubmittedIds(entryClipIds);
-          failedIndices.push(index);
-          console.warn(`[suno-helper] entry ${index} の duration 再生成に失敗しました: ${regenerationMessage}`);
-          options.emitProgress({
-            phase: PHASE.ENTRY_FAILED,
-            index,
-            total: options.total,
-            message: regenerationMessage,
-            yieldRetryCount,
-            log: { kind: "skip", entryName: entryDisplayName(options.entries[index]) },
-          });
-          break;
-        }
-        options.clipIdsByEntry.set(index, entryClipIds);
+        retries.push({ index, previousClipIds: entryClipIds, yieldRetryCount: nextYieldRetryCount });
         continue;
       }
       options.dropSubmittedIds(entryClipIds);
@@ -268,7 +262,90 @@ export async function finalizeQueueEntriesYield(options: QueueEntriesYieldOption
         yieldRetryCount,
         log: { kind: "skip", entryName: entryDisplayName(options.entries[index]) },
       });
-      break;
+      pendingEntries.delete(index);
+    }
+
+    if (retries.length === 0) {
+      continue;
+    }
+    const { durationOutlierStrategy } = options;
+    if (durationOutlierStrategy.kind !== "regenerate") {
+      throw new Error("duration retain policy returned retry entries");
+    }
+
+    const submittedRetries: Array<{
+      index: number;
+      previousClipIds: string[];
+      regeneratedClipIds: string[];
+      yieldRetryCount: number;
+    }> = [];
+    for (const retry of retries) {
+      try {
+        const regeneratedClipIds = await durationOutlierStrategy.regenerateEntry(retry.index, retry.yieldRetryCount);
+        if (options.isAborted?.()) {
+          options.dropSubmittedIds(regeneratedClipIds);
+          for (const submittedRetry of submittedRetries) {
+            options.dropSubmittedIds(submittedRetry.regeneratedClipIds);
+          }
+          return { failedIndices, abortedIndex: retries[0].index };
+        }
+        submittedRetries.push({ ...retry, regeneratedClipIds });
+      } catch (error) {
+        const regenerationMessage = error instanceof Error ? error.message : String(error);
+        options.dropSubmittedIds(retry.previousClipIds);
+        failedIndices.push(retry.index);
+        pendingEntries.delete(retry.index);
+        console.warn(`[suno-helper] entry ${retry.index} の duration 再生成に失敗しました: ${regenerationMessage}`);
+        options.emitProgress({
+          phase: PHASE.ENTRY_FAILED,
+          index: retry.index,
+          total: options.total,
+          message: regenerationMessage,
+          yieldRetryCount: retry.yieldRetryCount,
+          log: { kind: "skip", entryName: entryDisplayName(options.entries[retry.index]) },
+        });
+      }
+    }
+
+    const completionResults = await Promise.all(
+      submittedRetries.map(async (retry) => {
+        try {
+          await durationOutlierStrategy.waitForRegeneratedClips(retry.regeneratedClipIds);
+          return { ...retry, error: undefined };
+        } catch (error) {
+          return { ...retry, error: error instanceof Error ? error.message : String(error) };
+        }
+      }),
+    );
+    if (options.isAborted?.()) {
+      for (const completion of completionResults) {
+        options.dropSubmittedIds(completion.regeneratedClipIds);
+      }
+      return { failedIndices, abortedIndex: completionResults[0]?.index };
+    }
+    for (const completion of completionResults) {
+      if (completion.error !== undefined) {
+        options.dropSubmittedIds(completion.regeneratedClipIds);
+        options.dropSubmittedIds(completion.previousClipIds);
+        failedIndices.push(completion.index);
+        pendingEntries.delete(completion.index);
+        console.warn(`[suno-helper] entry ${completion.index} の duration 再生成に失敗しました: ${completion.error}`);
+        options.emitProgress({
+          phase: PHASE.ENTRY_FAILED,
+          index: completion.index,
+          total: options.total,
+          message: completion.error,
+          yieldRetryCount: completion.yieldRetryCount,
+          log: { kind: "skip", entryName: entryDisplayName(options.entries[completion.index]) },
+        });
+        continue;
+      }
+      options.dropSubmittedIds(completion.previousClipIds);
+      options.clipIdsByEntry.set(completion.index, completion.regeneratedClipIds);
+      pendingEntries.set(completion.index, {
+        clipIds: completion.regeneratedClipIds,
+        yieldRetryCount: completion.yieldRetryCount,
+      });
     }
   }
   return { failedIndices };

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -259,8 +259,10 @@ describe("shared/constants: 投入方式 run mode (#1586)", () => {
     expect(RUN_MODES.serial.riskNote).toBe("1件ずつ完了を待つ、安定性重視のモードです。");
   });
 
-  it("Given queue mode When label / riskNote を読む Then 高速モードとして速度重視の説明を表示する (#1862)", () => {
+  it("Given queue mode When label / riskNote を読む Then 先行投入と duration NG 時の自動再生成を表示する (#1775)", () => {
     expect(RUN_MODES.queue.label).toBe("高速モード");
-    expect(RUN_MODES.queue.riskNote).toBe("最大10件を先行投入する、速度重視のモードです。");
+    expect(RUN_MODES.queue.riskNote).toBe(
+      "最大10件を先行投入し、duration guard NG 時は自動再生成する速度重視のモードです。",
+    );
   });
 });

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -441,6 +441,18 @@ beforeEach(() => {
   harness.pendingClipIds = [];
   harness.requestFeedPollError = undefined;
   harness.abortOnRequestFeedPoll = false;
+  harness.requestFeedPoll.mockReset();
+  harness.requestFeedPoll.mockImplementation(async (ids: string[]) => {
+    if (harness.abortOnRequestFeedPoll) {
+      harness.handlers.get("stop")?.({ data: undefined });
+    }
+    if (harness.requestFeedPollError) {
+      throw harness.requestFeedPollError;
+    }
+    const requested = new Set(ids);
+    harness.pendingClipIds = harness.pendingClipIds.filter((id) => !requested.has(id));
+    return [];
+  });
   harness.waitForGeneration.mockReset();
   harness.waitForGeneration.mockResolvedValue(undefined);
   harness.waitForQueueSlot.mockReset();
@@ -1371,6 +1383,33 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       { timeout: 3000 },
     );
     await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce());
+    expect(generateCount).toBe(4);
+    expect(harness.waitForQueueSlot).toHaveBeenCalledTimes(4);
+    const progress = progressPayloads();
+    const secondOriginalSubmittedAt = progress.findIndex(
+      (payload) =>
+        typeof payload === "object" &&
+        payload !== null &&
+        "phase" in payload &&
+        payload.phase === PHASE.SUBMITTED &&
+        "index" in payload &&
+        payload.index === 1 &&
+        "yieldRetryCount" in payload &&
+        payload.yieldRetryCount === 0,
+    );
+    const firstDurationRetryAt = progress.findIndex(
+      (payload) =>
+        typeof payload === "object" &&
+        payload !== null &&
+        "phase" in payload &&
+        payload.phase === PHASE.WAITING_SLOT &&
+        "index" in payload &&
+        payload.index === 1 &&
+        "yieldRetryCount" in payload &&
+        payload.yieldRetryCount === 1,
+    );
+    expect(secondOriginalSubmittedAt).toBeGreaterThanOrEqual(0);
+    expect(firstDurationRetryAt).toBeGreaterThan(secondOriginalSubmittedAt);
     expect(harness.acceptedClipIds).toEqual(["queue-duration-clip-1", "queue-duration-clip-2"]);
     expect(harness.requestFeedPoll).toHaveBeenCalledWith(["queue-duration-clip-5", "queue-duration-clip-6"]);
     expect(harness.droppedClipIds).toEqual([
@@ -1423,6 +1462,64 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
     );
     expect(progressPayloads()).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ phase: PHASE.ADDING_TO_PLAYLIST })]),
+    );
+  });
+
+  it("Given queue mode で複数 entry の clip が全て duration filter 外 When 再生成する Then 最初の retry 完了待ち前に全 retry を ACK 済みにする", async () => {
+    makeViewButton("Newest ▼");
+    makeViewButton("Grid");
+    makeTextarea(null);
+    makeTextarea("lyrics-textarea");
+    const events: string[] = [];
+    let generateCount = 0;
+    makeGenerateButtonWithClickObserver(() => {
+      generateCount += 1;
+      const firstClipNumber = generateCount * 2 - 1;
+      const generatedIds = [`queue-parallel-retry-${firstClipNumber}`, `queue-parallel-retry-${firstClipNumber + 1}`];
+      events.push(`generate-${generateCount}`);
+      harness.submittedClipIds.push(...generatedIds);
+      if (generateCount > 2) {
+        harness.pendingClipIds.push(...generatedIds);
+      }
+    });
+    addCompletedRemixCard();
+    await loadContentScript();
+    const entries = makePromptEntries(2);
+    const payload = {
+      ...makeRunPayload(entries),
+      runMode: "queue" as const,
+      durationFilter: { min_sec: 75, max_sec: 240 },
+    };
+    harness.submittedClipIds = [];
+    harness.durationsById = {
+      "queue-parallel-retry-1": 45,
+      "queue-parallel-retry-2": 46,
+      "queue-parallel-retry-3": 45,
+      "queue-parallel-retry-4": 46,
+      "queue-parallel-retry-5": 120,
+      "queue-parallel-retry-6": 180,
+      "queue-parallel-retry-7": 120,
+      "queue-parallel-retry-8": 180,
+    };
+    harness.requestFeedPoll.mockImplementation(async (ids: string[]) => {
+      events.push(`poll-${ids[0]}`);
+      const requested = new Set(ids);
+      harness.pendingClipIds = harness.pendingClipIds.filter((id) => !requested.has(id));
+      return [];
+    });
+
+    expect(getRunHandler()({ data: payload })).toEqual({ ok: true });
+
+    await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce(), { timeout: 3000 });
+    expect(generateCount).toBe(4);
+    expect(harness.waitForQueueSlot).toHaveBeenCalledTimes(4);
+    expect(events.indexOf("generate-4")).toBeGreaterThan(events.indexOf("generate-3"));
+    expect(events.indexOf("generate-4")).toBeLessThan(events.findIndex((event) => event.startsWith("poll-")));
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: PHASE.DONE, index: 0, yieldRetryCount: 1 }),
+        expect.objectContaining({ phase: PHASE.DONE, index: 1, yieldRetryCount: 1 }),
+      ]),
     );
   });
 
@@ -1504,6 +1601,61 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       { timeout: 3000 },
     );
     expect(harness.droppedClipIds).toEqual(["queue-stop-2-a", "queue-stop-2-b", "queue-stop-1-a", "queue-stop-1-b"]);
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ phase: PHASE.STOPPED, index: 0 })]),
+    );
+  });
+
+  it("Given 複数queue retryの1件目ACK後 When 2件目の投入中にstop Then 全entryを再開候補にしてoriginalとretry IDsを除去する", async () => {
+    makeViewButton("Newest ▼");
+    makeViewButton("Grid");
+    makeTextarea(null);
+    makeTextarea("lyrics-textarea");
+    let generateCount = 0;
+    makeGenerateButtonWithClickObserver(() => {
+      generateCount += 1;
+      harness.submittedClipIds.push(`queue-submit-stop-${generateCount}-a`, `queue-submit-stop-${generateCount}-b`);
+    });
+    addCompletedRemixCard();
+    await loadContentScript();
+    const entries = makePromptEntries(2);
+    const payload = { ...makeRunPayload(entries), runMode: "queue" as const };
+    harness.submittedClipIds = [];
+    harness.durationsById = {
+      "queue-submit-stop-1-a": 45,
+      "queue-submit-stop-1-b": 46,
+      "queue-submit-stop-2-a": 45,
+      "queue-submit-stop-2-b": 46,
+    };
+    harness.waitForQueueSlot.mockImplementation(async () => {
+      if (harness.waitForQueueSlot.mock.calls.length === 4) {
+        harness.handlers.get("stop")?.({ data: undefined });
+      }
+    });
+
+    expect(getRunHandler()({ data: payload })).toEqual({ ok: true });
+
+    await vi.waitFor(
+      () =>
+        expect(writeResumeState).toHaveBeenCalledWith(
+          expect.objectContaining({
+            failedIndex: 0,
+            remainingIndices: [0, 1],
+            submittedClipIds: [],
+          }),
+        ),
+      { timeout: 3000 },
+    );
+    await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce());
+    expect(generateCount).toBe(3);
+    expect(harness.droppedClipIds).toEqual([
+      "queue-submit-stop-3-a",
+      "queue-submit-stop-3-b",
+      "queue-submit-stop-1-a",
+      "queue-submit-stop-1-b",
+      "queue-submit-stop-2-a",
+      "queue-submit-stop-2-b",
+    ]);
     expect(progressPayloads()).toEqual(
       expect.arrayContaining([expect.objectContaining({ phase: PHASE.STOPPED, index: 0 })]),
     );

--- a/extensions/suno-helper/tests/queue-runner.test.ts
+++ b/extensions/suno-helper/tests/queue-runner.test.ts
@@ -219,7 +219,11 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: entries.length,
       clipIdsByEntry: new Map([[0, ["clip-ok-a", "clip-ok-b"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry: vi.fn(async () => []) },
+      durationOutlierStrategy: {
+        kind: "regenerate",
+        regenerateEntry: vi.fn(async () => []),
+        waitForRegeneratedClips: vi.fn(async () => {}),
+      },
       getDuration: (clipId: string) => {
         const durations: Record<string, number> = { "clip-ok-a": 120, "clip-ok-b": 180 };
         return durations[clipId];
@@ -256,7 +260,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: entries.length,
       clipIdsByEntry: new Map([[1, ["clip-ng-a", "clip-ng-b"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry },
+      durationOutlierStrategy: { kind: "regenerate", regenerateEntry, waitForRegeneratedClips: vi.fn(async () => {}) },
       getDuration: (clipId: string) => {
         const durations: Record<string, number> = { "clip-ng-a": 45, "clip-ng-b": 360 };
         return durations[clipId];
@@ -298,7 +302,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: 1,
       clipIdsByEntry: new Map([[0, ["clip-ng-a", "clip-ng-b"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry },
+      durationOutlierStrategy: { kind: "regenerate", regenerateEntry, waitForRegeneratedClips: vi.fn(async () => {}) },
       getDuration: (id) => durations[id],
       markAccepted,
       dropSubmittedIds,
@@ -329,7 +333,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: 1,
       clipIdsByEntry: new Map([[0, ["clip-ng-0-a", "clip-ng-0-b"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry },
+      durationOutlierStrategy: { kind: "regenerate", regenerateEntry, waitForRegeneratedClips: vi.fn(async () => {}) },
       getDuration: () => 45,
       markAccepted: vi.fn(),
       dropSubmittedIds: vi.fn(),
@@ -358,6 +362,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
         regenerateEntry: vi.fn(async () => {
           throw new Error("inject failed");
         }),
+        waitForRegeneratedClips: vi.fn(async () => {}),
       },
       getDuration: () => 45,
       markAccepted: vi.fn(),
@@ -405,7 +410,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
     );
   });
 
-  it("Given queue 再生成の完了待ち中にstop When finalizerを確定する Then 元clipを保持して中断indexを返す", async () => {
+  it("Given queue 再生成の投入直後にstop When finalizerを確定する Then retry clipを除去して中断indexを返す", async () => {
     const isAborted = vi.fn(() => true);
     const dropSubmittedIds = vi.fn();
 
@@ -418,6 +423,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       durationOutlierStrategy: {
         kind: "regenerate",
         regenerateEntry: vi.fn(async () => ["clip-retry-a", "clip-retry-b"]),
+        waitForRegeneratedClips: vi.fn(async () => {}),
       },
       isAborted,
       getDuration: () => 45,
@@ -427,7 +433,8 @@ describe("queue-runner: production ロジック (#1586)", () => {
     });
 
     expect(result).toEqual({ failedIndices: [], abortedIndex: 0 });
-    expect(dropSubmittedIds).not.toHaveBeenCalled();
+    expect(dropSubmittedIds).toHaveBeenCalledOnce();
+    expect(dropSubmittedIds).toHaveBeenCalledWith(["clip-retry-a", "clip-retry-b"]);
   });
 
   it("Given option OFF とOK/NG混在 When entryを確定する Then NGをdropせず全clipを採用候補に残す", async () => {
@@ -462,7 +469,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: 1,
       clipIdsByEntry: new Map([[0, ["clip-original"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry },
+      durationOutlierStrategy: { kind: "regenerate", regenerateEntry, waitForRegeneratedClips: vi.fn(async () => {}) },
       getDuration: () => {
         throw new Error("feed unavailable");
       },
@@ -490,7 +497,11 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: entries.length,
       clipIdsByEntry: new Map([[0, ["clip-partial-ok", "clip-partial-ng"]]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry: vi.fn(async () => []) },
+      durationOutlierStrategy: {
+        kind: "regenerate",
+        regenerateEntry: vi.fn(async () => []),
+        waitForRegeneratedClips: vi.fn(async () => {}),
+      },
       getDuration: (clipId: string) => {
         const durations: Record<string, number> = { "clip-partial-ok": 180, "clip-partial-ng": 45 };
         return durations[clipId];
@@ -525,7 +536,11 @@ describe("queue-runner: production ロジック (#1586)", () => {
       total: entries.length,
       clipIdsByEntry: new Map([[0, []]]),
       durationFilter: { min_sec: 75, max_sec: 240 },
-      durationOutlierStrategy: { kind: "regenerate", regenerateEntry: vi.fn(async () => []) },
+      durationOutlierStrategy: {
+        kind: "regenerate",
+        regenerateEntry: vi.fn(async () => []),
+        waitForRegeneratedClips: vi.fn(async () => {}),
+      },
       getDuration: () => {
         throw new Error("duration should not be read without clip IDs");
       },
@@ -560,6 +575,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       durationOutlierStrategy: {
         kind: "regenerate",
         regenerateEntry: vi.fn(async () => ["clip-short"]),
+        waitForRegeneratedClips: vi.fn(async () => {}),
       },
       getDuration: () => 45,
       markAccepted: vi.fn(),


### PR DESCRIPTION
## Summary

## 概要

Queue mode（ACK後に次entryを先行投入する投入方式）に、duration filter 範囲外の clip しか生成されなかった entry を検知し、Serial mode と同様に同一プロンプトで自動再生成する機構を追加する。

## 背景・目的

Serial mode は entry ごとに生成完了を待つため、その場で duration を検査し、全滅なら同一プロンプトで最大 `MAX_YIELD_RETRY` 回再生成 → それでも失敗なら `ENTRY_FAILED` にする（content.ts の serial 分岐）。Queue mode は投入を先行させる高速性のため導入されたが、現状は duration 不足を検知する仕組み自体がなく（#1762 で検知・可視化のみ追加予定）、自動再生成は明示的にスコープ外とされている。Queue mode の速度（ACK後すぐ次entryを先行投入する連続投入）を維持したまま、Serial mode と同等の生成品質（duration filter を満たす確率）を担保したい。

## 提案する仕様

- 前提: #1762 で追加される「投入完了後の一括 duration 検査」「entry index → clip ID mapping」「`ENTRY_FAILED` 可視化」の上に構築する
- 全 entry 投入完了後の一括検査で duration 全滅と判定された entry について、即座に `ENTRY_FAILED` として止めるのではなく、Serial 同様に同一プロンプトで再投入する（`MAX_YIELD_RETRY` 回まで）
- 再投入も Queue の ACK 先行投入方式（既存 pacing）に乗せ、再投入のためだけに Serial 相当の逐次待機に倒さない
- `MAX_YIELD_RETRY` 回を尽くしてなお duration filter を満たす clip が得られない entry のみ、#1762 の `ENTRY_FAILED` 経路（赤表示 + 「失敗分のみ再実行」導線）に落とす

## ユースケース

20 entry（40 clip 期待）を Queue mode で実行し、3 entry 分の 6 clip が duration filter 範囲外だった場合: 現状案（#1762 適用後）では 3 entry が `ENTRY_FAILED` になり手動再実行が必要。本 issue 適用後は、その場で自動的に同一プロンプトで再生成が走り、`MAX_YIELD_RETRY` 以内で成功すれば手動操作なしで完走する。

## 参照資料

- extensions/suno-helper/lib/queue-runner.ts
- extensions/suno-helper/entrypoints/content.ts （serial 分岐の自動再生成実装 = 挙動の参照元）
- extensions/shared/constants.ts （MAX_YIELD_RETRY, RUN_MODES.queue.riskNote）

## 影響ファイル

- **変更**: extensions/suno-helper/lib/queue-runner.ts
- **変更**: extensions/suno-helper/entrypoints/content.ts
- **変更**: extensions/shared/constants.ts （RUN_MODES.queue.riskNote 文言更新）

**兄弟入口・貫通先**: (plan step で確定する) — #1762 の実装内容（entry 単位 clip ID mapping・finalize 関数のシグネチャ等）に依存するため、#1762 の着手/完了状況を踏まえて plan 時に確定させる。

## 要件

1. #1762 で追加される entry 単位 duration 検査で全滅と判定された entry を、即座に `ENTRY_FAILED` にせず、Serial mode と同じ `MAX_YIELD_RETRY` 回まで同一プロンプトで自動再生成する
2. 再生成の投入は Queue mode の ACK 先行投入方式（`waitForQueueSlot` 等の既存 pacing）に乗せる → Serial 相当の逐次待機（次entryを止めて待つ）にはならないことをログ/挙動で確認できる
3. `MAX_YIELD_RETRY` 回再生成しても duration filter を満たす clip が得られない entry のみ、#1762 の `ENTRY_FAILED`（赤表示 + 「失敗分のみ再実行」導線）に落ちる
4. `RUN_MODES.queue.riskNote` の文言が、自動再生成が Queue mode でも行われる旨に更新されている

## スコープ外

- #1762（duration 不足の検知・可視化そのもの）は本 issue では扱わない（前提として先に実装される想定）
- Serial mode 側の再生成ロジック自体の変更は本 issue では扱わない

## 実装方針（takt）
- workflow: improve
- 理由: 既存 Queue mode の挙動を Serial 同等に拡張するため

## Execution Report

Workflow `improve` completed successfully.

Closes #1775