### PR TITLE
fix: sandbox 化された takt worker の direnv/lefthook セットアップ反復停滞を解消 (#1999)

### DIFF
--- a/.lefthook/install.sh
+++ b/.lefthook/install.sh
@@ -5,6 +5,13 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi
 
+# sandbox 化された takt worker 等、hooks を書き込めない環境向けの安全なスキップ
+# （ゲートは CI 側で担保される。issue #1999）
+if [ "${YOUTUBE_AUTOMATION_SKIP_LEFTHOOK:-0}" = "1" ]; then
+  echo "info: YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1 のため lefthook install をスキップします。" >&2
+  exit 0
+fi
+
 if ! lefthook_bin="$(command -v lefthook 2>/dev/null)"; then
   echo "error: lefthook is not available in PATH; enter via nix develop or direnv." >&2
   exit 1

--- a/.lefthook/setup-worktree.sh
+++ b/.lefthook/setup-worktree.sh
@@ -12,9 +12,14 @@ else
   command=("$@")
 fi
 
+# direnv allow は allow ストア（$XDG_DATA_HOME/direnv/allow、既定 ~/.local/share）への
+# 書込みを要する。sandbox 化された環境ではホーム配下へ書込みできず失敗するため、
+# 失敗時は hard fail せず nix develop 経路へフォールバックする（issue #1999）
 if command -v direnv >/dev/null 2>&1; then
-  direnv allow "$checkout_root"
-  exec direnv exec "$checkout_root" "${command[@]}"
+  if direnv allow "$checkout_root" 2>/dev/null; then
+    exec direnv exec "$checkout_root" "${command[@]}"
+  fi
+  echo "warning: direnv allow に失敗しました（allow ストアが書込み不可の可能性）。nix develop にフォールバックします。" >&2
 fi
 
 if command -v nix >/dev/null 2>&1; then

--- a/.takt/.gitignore
+++ b/.takt/.gitignore
@@ -7,6 +7,10 @@
 # Project configuration
 !config.yaml
 
+# Runtime prepare script (tracked): sandbox 化された worker への
+# 環境変数注入（issue #1999）。worktree でも解決できるよう必ずコミットする
+!runtime-prepare.sh
+
 # Custom workflows (tracked)
 !workflows/
 !workflows/*.yaml

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -11,6 +11,14 @@ persona_providers:
   planner:
     provider: codex
 
+# sandbox 化された worker の direnv / lefthook セットアップ停滞対策（issue #1999）。
+# runtime-prepare.sh の stdout（KEY=VALUE）が全 worker の環境へ注入され、
+# XDG_DATA_HOME を worktree ローカルへ向けて direnv allow を通し、
+# lefthook install はスキップさせる（ゲートは CI 側で担保）。
+runtime:
+  prepare:
+    - .takt/runtime-prepare.sh
+
 # トークン消費の計測。記録先: .takt/runs/<run>/logs/<session>-usage-events.phase.jsonl
 observability:
   enabled: true

--- a/.takt/runtime-prepare.sh
+++ b/.takt/runtime-prepare.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# takt runtime.prepare スクリプト（issue #1999）。
+# sandbox 化された worker はホームディレクトリ配下（~/.local/share 等）へ
+# 書込みできず、direnv の allow ストア（$XDG_DATA_HOME/direnv/allow）への
+# 書込みと lefthook install が反復失敗して run が停滞する。
+# ここで stdout に出力した KEY=VALUE 行は takt が worker 環境へ注入する:
+# - XDG_DATA_HOME: worktree ローカルの runtime ディレクトリへ向け、
+#   direnv allow の書込み先を sandbox 内で完結させる
+# - YOUTUBE_AUTOMATION_SKIP_LEFTHOOK: flake.nix shellHook / .lefthook/install.sh
+#   に lefthook install を安全にスキップさせる（ゲートは CI 側で担保）
+set -euo pipefail
+
+echo "XDG_DATA_HOME=${TAKT_RUNTIME_ROOT}/data"
+echo "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(dx)`: sandbox 化された takt worker がホーム配下（direnv allow ストア・共有 hooks）へ書込みできず direnv / lefthook セットアップが反復停滞する障害を解消した。`.takt/config.yaml` の `runtime.prepare`（`.takt/runtime-prepare.sh`）が全 worker へ `XDG_DATA_HOME=<worktree>/.takt/.runtime/data` と `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を注入し、flake.nix shellHook / `.lefthook/install.sh` は同変数で lefthook install を安全にスキップ（ゲートは CI 側で担保）、`.lefthook/setup-worktree.sh` は `direnv allow` 失敗時に `nix develop` へフォールバックする（#1999）。
 - `docs(workflow)`: `/wf-new` と `/wf-next` の制作フェーズ実行を subagent 委譲契約へ統一し、親エージェントが前提確認・承認・状態更新を保持しつつ、各フェーズの成果物を絶対パス付きで受け取って検証する責務境界を明確化した。運用チートシートも同じ委譲モデルへ同期した（#1661）。
 - `docs(collection-ideate)`: stale な Analytics report 検出時に推論コスト見積もり付きの 3 択を提示し、承認時または上限内の `freshness.stale_action: auto` 時だけ `/analytics-analyze` を同一セッションで実行する導線を追加した。`/wf-new` は判定を委譲し二重ダイアログを防ぐ（#1716）。
 - `docs(skills)`: wf-* から委譲される制作系 10 skill に subagent 入出力契約を追加し、リポジトリ相対の入力、成果物絶対パスの完了報告、state 非更新、承認・選択確定後のみの委譲を明記した。state を扱う `/masterup` の over-max 例外採用と `/suno` vocal の標準 collection 生成はメインエージェントが実行する（#1662）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,7 @@ Python 側の未使用コード検出は、追加依存なしで CI / pre-commit
 - **devShell 内での実行**: direnv の自動入室が有効な shell ではそのまま `uv run pytest` 等を実行できる。agent や非対話 shell では `bash .lefthook/setup-worktree.sh uv run pytest` のように引数を渡すと、同じ devShell 内でコマンドを実行できる
 - **診断**: 親 checkout / worktree のそれぞれで `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'` を実行する。`git commit` / `git push` で `Can't find lefthook in PATH` が出る場合は `bash .lefthook/setup-worktree.sh` を再実行する。直接の Nix 診断・再生成には `nix develop --command sh -c 'command -v lefthook && lefthook version'` と `nix develop --command bash .lefthook/install.sh` も利用できる
 - **失敗時の扱い**: shellHook は `lefthook` 不在や hook 再生成失敗を `|| true` で握りつぶさない。devShell 入室時に明示的に失敗させ、commit / push 時の hook no-op を防ぐ
+- **sandbox / takt worker での挙動**: sandbox 化された takt worker はホーム配下（direnv の allow ストア `~/.local/share/direnv/allow` や共有 hooks ディレクトリ）へ書込みできないため、`.takt/config.yaml` の `runtime.prepare`（`.takt/runtime-prepare.sh`）が全 worker へ `XDG_DATA_HOME=<worktree>/.takt/.runtime/data`（direnv allow の書込み先を worktree 内に完結）と `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を注入する。後者が設定された環境では shellHook / `.lefthook/install.sh` が lefthook install を明示メッセージつきでスキップする（CHANGELOG 等のゲートは CI 側で担保）。また `.lefthook/setup-worktree.sh` は `direnv allow` 失敗時に hard fail せず `nix develop` 経路へフォールバックする
 - **全 hook をスキップ**: `LEFTHOOK=0 git push` / `LEFTHOOK=0 git commit`
 - **CHANGELOG ゲートのみ省く**: `SKIP_CHANGELOG=1 git push`（CI 側は PR の `skip-changelog` ラベル）
 - **テスト差分警告のみ省く**: `SKIP_TEST_DIFF=1 git push`

--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,15 @@
 
             # Git hooks (lefthook) を有効化。stale な Nix store 固定パスを残さないよう
             # devShell 入室ごとに再生成し、失敗は commit / push 前に明示的に止める。
+            # ただし sandbox 化された takt worker 等、hooks ディレクトリへ書込みできない
+            # 環境では YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1 で安全にスキップする
+            # （CHANGELOG 等のゲートは CI 側で担保される。issue #1999）。
             if git rev-parse --git-dir >/dev/null 2>&1; then
-              bash "${./.}/.lefthook/install.sh" || exit 1
+              if [ "''${YOUTUBE_AUTOMATION_SKIP_LEFTHOOK:-0}" = "1" ]; then
+                echo "info: YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1 のため lefthook install をスキップします。" >&2
+              else
+                bash "${./.}/.lefthook/install.sh" || exit 1
+              fi
             fi
             uv sync --quiet || echo "warning: uv sync failed; dependencies may be out of date." >&2
           '';

--- a/tests/test_lefthook_installation_contract.py
+++ b/tests/test_lefthook_installation_contract.py
@@ -151,6 +151,55 @@ def test_dev_shell_reinstalls_lefthook_without_hiding_failures() -> None:
     assert "exit 1" in flake
 
 
+def test_dev_shell_skips_lefthook_install_when_skip_env_is_set() -> None:
+    # sandbox 化された takt worker（hooks を書き込めない）向けの安全なスキップ分岐
+    # （issue #1999）。既定では従来どおり fail-closed（|| exit 1）のまま
+    flake = _read(_FLAKE_PATH)
+
+    assert "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK" in flake
+
+
+def test_lefthook_install_script_skips_when_skip_env_is_set(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    # lefthook が PATH に無くても skip が優先され成功終了する
+    result = subprocess.run(
+        ["bash", str(_LEFTHOOK_INSTALL_SCRIPT_PATH)],
+        cwd=tmp_path,
+        env={**os.environ, "PATH": "/usr/bin:/bin", "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK": "1"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1" in result.stderr
+    hooks_dir = tmp_path / ".git" / "hooks"
+    assert not (hooks_dir / "pre-commit").exists()
+    assert not (hooks_dir / "pre-push").exists()
+
+
+def test_takt_runtime_prepare_injects_sandbox_safe_environment(tmp_path: Path) -> None:
+    # takt の runtime.prepare が全 worker へ worktree ローカルの XDG_DATA_HOME と
+    # lefthook skip を注入する配線契約（issue #1999）
+    takt_config = _read(_REPO_ROOT / ".takt" / "config.yaml")
+    assert ".takt/runtime-prepare.sh" in takt_config
+
+    runtime_root = tmp_path / "runtime"
+    result = subprocess.run(
+        ["bash", str(_REPO_ROOT / ".takt" / "runtime-prepare.sh")],
+        env={**os.environ, "TAKT_RUNTIME_ROOT": str(runtime_root)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    lines = result.stdout.splitlines()
+    assert f"XDG_DATA_HOME={runtime_root}/data" in lines
+    assert "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1" in lines
+
+
 def test_lefthook_install_script_noops_outside_git_repo(tmp_path: Path) -> None:
     result = _run_install_script(tmp_path, "/usr/bin:/bin")
 
@@ -686,7 +735,33 @@ def test_linked_worktree_setup_supplies_dev_shell_tools_and_commit_hook(tmp_path
     _assert_setup_supplies_dev_shell_tools_and_commit_hook(worktree, tmp_path)
 
 
-def test_worktree_setup_propagates_direnv_allow_failure(tmp_path: Path) -> None:
+def test_worktree_setup_falls_back_to_nix_when_direnv_allow_fails(tmp_path: Path) -> None:
+    # sandbox 化された環境では direnv の allow ストア（$XDG_DATA_HOME/direnv/allow）へ
+    # 書込みできず direnv allow が失敗する。hard fail で反復停滞せず nix develop へ
+    # フォールバックする契約（issue #1999）
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_fake_executable(bin_dir / "direnv", "#!/usr/bin/env bash\nexit 23\n")
+    nix_log = tmp_path / "nix-call.txt"
+    _create_fake_executable(
+        bin_dir / "nix",
+        f"""#!/usr/bin/env bash
+printf '%s\n' "$*" > "{nix_log}"
+shift 3
+exec "$@"
+""",
+    )
+
+    result = _run_worktree_setup(tmp_path, f"{bin_dir}:/usr/bin:/bin", "sh", "-c", "printf ran")
+
+    assert result.returncode == 0
+    assert result.stdout == "ran"
+    assert "direnv allow に失敗しました" in result.stderr
+    assert nix_log.read_text(encoding="utf-8") == (f"develop {tmp_path} --command sh -c printf ran\n")
+
+
+def test_worktree_setup_fails_when_direnv_allow_fails_without_nix(tmp_path: Path) -> None:
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -694,7 +769,9 @@ def test_worktree_setup_propagates_direnv_allow_failure(tmp_path: Path) -> None:
 
     result = _run_worktree_setup(tmp_path, f"{bin_dir}:/usr/bin:/bin", "sh", "-c", "exit 0")
 
-    assert result.returncode == 23
+    assert result.returncode == 1
+    assert "direnv allow に失敗しました" in result.stderr
+    assert "error: neither direnv nor nix is available in PATH." in result.stderr
 
 
 def test_worktree_setup_fails_outside_git_checkout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

sandbox 化された takt worker（Codex）がホームディレクトリ配下（direnv の allow ストア `~/.local/share/direnv/allow` や共有 hooks ディレクトリ）へ書込みできず、devShell セットアップ（direnv / lefthook）が反復失敗して run が停滞する障害を解消する。

### 変更内容

- **`.takt/runtime-prepare.sh`（新規）+ `.takt/config.yaml`**: takt の `runtime.prepare` で全 worker へ `XDG_DATA_HOME=<worktree>/.takt/.runtime/data`（direnv allow の書込み先を worktree 内に完結）と `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を注入
- **`flake.nix` shellHook / `.lefthook/install.sh`**: `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` の環境では lefthook install を明示メッセージつきで安全にスキップ（既定は従来どおり fail-closed。CHANGELOG 等のゲートは CI 側で担保）
- **`.lefthook/setup-worktree.sh`**: `direnv allow` 失敗時に hard fail せず `nix develop` 経路へフォールバック（反復停滞の直接原因を除去）
- **契約テスト**: 旧「direnv allow 失敗を伝播」を新契約（nix フォールバック / nix 不在時のみ失敗）へ更新し、skip 分岐と runtime.prepare 配線のテストを追加
- docs/development.md に sandbox / takt worker での挙動を追記

### 検証

- `uv run ruff check .` ✅
- `uv run pytest`（5210 passed）✅
- `nix develop -c true` ✅（skip 分岐は `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1 nix develop -c true` でスキップメッセージを確認）
- `XDG_DATA_HOME` リダイレクト下で `direnv allow` がホーム外に書込み成功することを確認
- `takt list` で `runtime.prepare` 追加後の config が正常に読めることを確認

※ 受け入れ基準の「takt run を 1 本実行して末尾ログを確認」はホスト側での手動検証が必要なため、merge 後の次回 takt run で確認する。

Closes #1999