### PR TITLE
fix(skill-config): flop-analysis override の移行 fallback を追加 (#2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(skill-config)`: `load_skill_config("postmortem")` と `load_channel_override("postmortem")` は `config/skills/flop-analysis.yaml` を優先し、旧 `config/skills/postmortem.yaml` だけがある場合は互換読み込みして `UserWarning` で移行を案内する。利用者は `postmortem.yaml` を `flop-analysis.yaml` へリネームすることで警告を解消できる（#2022）。
 - `fix(dx)`: sandbox 化された takt worker がホーム配下（direnv allow ストア・共有 hooks）へ書込みできず direnv / lefthook セットアップが反復停滞する障害を解消した。`.takt/config.yaml` の `runtime.prepare`（`.takt/runtime-prepare.sh`）が全 worker へ `XDG_DATA_HOME=<worktree>/.takt/.runtime/data` と `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を注入し、flake.nix shellHook / `.lefthook/install.sh` は同変数で lefthook install を安全にスキップ（ゲートは CI 側で担保）、`.lefthook/setup-worktree.sh` は `direnv allow` 失敗時に `nix develop` へフォールバックする（#1999）。
 - `docs(workflow)`: `/wf-new` と `/wf-next` の制作フェーズ実行を subagent 委譲契約へ統一し、親エージェントが前提確認・承認・状態更新を保持しつつ、各フェーズの成果物を絶対パス付きで受け取って検証する責務境界を明確化した。運用チートシートも同じ委譲モデルへ同期した（#1661）。
 - `docs(collection-ideate)`: stale な Analytics report 検出時に推論コスト見積もり付きの 3 択を提示し、承認時または上限内の `freshness.stale_action: auto` 時だけ `/analytics-analyze` を同一セッションで実行する導線を追加した。`/wf-new` は判定を委譲し二重ダイアログを防ぐ（#1716）。

--- a/src/youtube_automation/utils/skill_config.py
+++ b/src/youtube_automation/utils/skill_config.py
@@ -2,6 +2,8 @@
 
 各スキル (.claude/skills/<skill>/config.default.yaml) のデフォルト値と、
 チャンネルリポジトリ側 (config/skills/<skill>.yaml) の上書きをマージして返す。
+postmortem は `flop-analysis.yaml` を優先し、旧 `postmortem.yaml` だけが
+存在する場合は UserWarning を出して互換読み込みする。
 
 使い方:
 
@@ -20,6 +22,7 @@ from __future__ import annotations
 
 import json
 import stat
+import warnings
 from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any
@@ -74,6 +77,11 @@ def _channel_override_candidates(skill: str, target_channel_dir: Path | None = N
             _channel_override_path(skill, target_channel_dir, "json"),
             _channel_override_path(skill, target_channel_dir, "yaml"),
         ]
+    if skill == "postmortem":
+        return [
+            _channel_override_path("flop-analysis", target_channel_dir, "yaml"),
+            _channel_override_path(skill, target_channel_dir, "yaml"),
+        ]
     return [_channel_override_path(skill, target_channel_dir, "yaml")]
 
 
@@ -89,6 +97,21 @@ def _override_candidate_exists(path: Path, *, strict_regular_file: bool) -> bool
     if not stat.S_ISREG(mode):
         raise ConfigError(f"skill-config は regular file である必要があります: {path}")
     return True
+
+
+def _resolve_channel_override(skill: str, target_channel_dir: Path | None = None) -> Path | None:
+    candidates = _channel_override_candidates(skill, target_channel_dir)
+    selected = next(
+        (path for path in candidates if _override_candidate_exists(path, strict_regular_file=skill == "masterup")),
+        None,
+    )
+    if skill == "postmortem" and selected == candidates[1]:
+        warnings.warn(
+            f"旧 skill-config {selected} を読み込みます。{candidates[0]} へリネームしてください。",
+            UserWarning,
+            stacklevel=3,
+        )
+    return selected
 
 
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -161,14 +184,7 @@ def load_skill_config(
 
     defaults = _load_yaml(_default_path(skill))
 
-    override_path = next(
-        (
-            path
-            for path in _channel_override_candidates(skill, channel_dir)
-            if _override_candidate_exists(path, strict_regular_file=skill == "masterup")
-        ),
-        None,
-    )
+    override_path = _resolve_channel_override(skill, channel_dir)
     if override_path is not None:
         override = _load_override(override_path)
         merged = _deep_merge(defaults, override)
@@ -186,14 +202,7 @@ def load_channel_override(skill: str) -> dict[str, Any]:
     skill-config の旧 namespace 移行など、ユーザーが明示的に設定したキーだけを
     検出したいケースで使う。override ファイルが無ければ空 dict。
     """
-    path = next(
-        (
-            candidate
-            for candidate in _channel_override_candidates(skill)
-            if _override_candidate_exists(candidate, strict_regular_file=skill == "masterup")
-        ),
-        None,
-    )
+    path = _resolve_channel_override(skill)
     if path is None:
         return {}
     return _load_override(path)

--- a/tests/test_skill_config.py
+++ b/tests/test_skill_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import pytest
@@ -69,6 +70,116 @@ def test_channel_override_merged(tmp_path, monkeypatch):
     assert gemini_block.get("brand_background") == "custom-color"
     # default.yaml の他のキーが残っていること (モデル名など)
     assert "model" in gemini_block
+
+
+def test_load_skill_config_postmortem_prefers_flop_analysis_override(tmp_path, monkeypatch):
+    """postmortem は新名 flop-analysis override を default にマージする。"""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "flop-analysis.yaml").write_text(
+        yaml.safe_dump({"thresholds": {"min_impressions": 321}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        cfg = skill_config.load_skill_config("postmortem", use_cache=False)
+
+    assert cfg["thresholds"]["min_impressions"] == 321
+    assert "ctr_low" in cfg["hypothesis_ratios"]
+    assert not warning_records
+
+
+def test_load_skill_config_postmortem_warns_for_legacy_override(tmp_path, monkeypatch):
+    """旧名だけなら読み込み、旧名と移行先を含む UserWarning を出す。"""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    legacy_path = skills_dir / "postmortem.yaml"
+    replacement_path = skills_dir / "flop-analysis.yaml"
+    legacy_path.write_text(
+        yaml.safe_dump({"thresholds": {"min_impressions": 654}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with pytest.warns(UserWarning) as warning_records:
+        cfg = skill_config.load_skill_config("postmortem", use_cache=False)
+
+    assert cfg["thresholds"]["min_impressions"] == 654
+    assert str(legacy_path) in str(warning_records[0].message)
+    assert str(replacement_path) in str(warning_records[0].message)
+    assert warning_records[0].filename == __file__
+
+
+def test_load_skill_config_postmortem_does_not_read_legacy_when_both_exist(tmp_path, monkeypatch):
+    """新旧併存時は新名を採用し、不正な旧名も読まず警告しない。"""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "flop-analysis.yaml").write_text(
+        yaml.safe_dump({"thresholds": {"min_impressions": 777}}),
+        encoding="utf-8",
+    )
+    (skills_dir / "postmortem.yaml").write_text("[broken", encoding="utf-8")
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        cfg = skill_config.load_skill_config("postmortem", use_cache=False)
+
+    assert cfg["thresholds"]["min_impressions"] == 777
+    assert not warning_records
+
+
+def test_load_channel_override_postmortem_uses_same_legacy_fallback(tmp_path, monkeypatch):
+    """override 単体 API も新名優先と旧名 fallback 警告を適用する。"""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    legacy_path = skills_dir / "postmortem.yaml"
+    replacement_path = skills_dir / "flop-analysis.yaml"
+    legacy_path.write_text(yaml.safe_dump({"legacy_only": True}), encoding="utf-8")
+    replacement_path.write_text(yaml.safe_dump({"new_only": True}), encoding="utf-8")
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        cfg = skill_config.load_channel_override("postmortem")
+
+    assert cfg == {"new_only": True}
+    assert not warning_records
+
+    replacement_path.unlink()
+    with pytest.warns(UserWarning) as warning_records:
+        cfg = skill_config.load_channel_override("postmortem")
+
+    assert cfg == {"legacy_only": True}
+    assert str(legacy_path) in str(warning_records[0].message)
+    assert str(replacement_path) in str(warning_records[0].message)
+
+
+def test_load_skill_config_postmortem_invalid_new_override_does_not_fallback(tmp_path, monkeypatch):
+    """不正な新名が選ばれたら有効な旧名へ逃げず ConfigError にする。"""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    replacement_path = skills_dir / "flop-analysis.yaml"
+    replacement_path.write_text("[broken", encoding="utf-8")
+    (skills_dir / "postmortem.yaml").write_text(
+        yaml.safe_dump({"thresholds": {"min_impressions": 999}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as warning_records:
+        warnings.simplefilter("always")
+        with pytest.raises(ConfigError, match=str(replacement_path)):
+            skill_config.load_skill_config("postmortem", use_cache=False)
+
+    assert not warning_records
 
 
 def test_thumbnail_dedup_window_can_be_overridden(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- postmortem skill config の override 候補を flop-analysis.yaml → postmortem.yaml の順に解決
- 旧 postmortem.yaml のみ存在する場合は、旧・新パスを含む UserWarning で移行を案内
- load_skill_config と load_channel_override を共通 resolver に統一し、選択済み不正ファイルは ConfigError で fail loud

## Validation

- tests/test_skill_config.py: 40 passed
- full pytest: 5218 passed
- Ruff check: green
- Ruff format check: 461 files green
- lefthook pre-commit / pre-push: green
- git diff --check: green

## Execution Report

takt improve workflow は sandbox 内の localhost bind / Nix 制約により review 反復上限へ到達しました。専用 worktree の差分を supervisor が受入条件と全 diff に照合し、通常環境・repository 外 basetemp で全 gate を再実行して green を確認しています。

Closes #2022

<!-- takt:managed -->
