### PR TITLE
feat(distrokid-helper): データ取得を自動化する (#1992)

### DIFF
--- a/.claude/skills/distrokid-helper/SKILL.md
+++ b/.claude/skills/distrokid-helper/SKILL.md
@@ -261,7 +261,7 @@ curl -s http://localhost:7874/distrokid/collections | python3 -m json.tool | hea
 
 `--distrokid-capture-root` は distrokid-helper の配信済み記録 `POST /distrokid/releases` に必要。DistroKid dir mode では必ずチャンネルルートを指定する。`--allow-extension distrokid-helper` は Chrome の profile preferences から unpacked 拡張 ID を検出し、DistroKid page origin からの write POST を許可しない exact origin lock として使う。検出 0 件・複数 ID 競合・Preferences 読み取り不可・Preferences JSON parse failure で失敗する場合のみ、エラーに表示された候補を確認して `--allow-origin chrome-extension://<EXTENSION_ID>` を手動指定する。
 
-ユーザーには `http://localhost:7874` を distrokid-helper popup のサーバー URL として案内する。Chrome 拡張 **distrokid-helper** を使った DistroKid Web フォームへの転記・アップロード操作そのものは本スキルの範囲外。
+ユーザーには distrokid-helper popup の登録済み **ローカル配信元** selector から `http://localhost:7874` の配信元を選ぶよう案内する。選択した配信元は自動保存され、コレクション一覧と選択 disc の release.json が自動取得される。最新データの再取得は popup を閉じて再表示する。Chrome 拡張 **distrokid-helper** を使った DistroKid Web フォームへの転記・アップロード操作そのものは本スキルの範囲外。
 
 ---
 
@@ -285,7 +285,7 @@ curl -s http://localhost:7874/distrokid/collections | python3 -m json.tool | hea
 
 サーバー起動と疎通確認が完了したら:
 
-1. distrokid-helper popup のサーバー URL に `http://localhost:7874` を設定
+1. distrokid-helper popup の登録済み **ローカル配信元** selector から `http://localhost:7874` を選択する（選択内容は自動保存され、データも自動取得される。再取得は popup を閉じて再表示する）
 2. Chrome 拡張 **distrokid-helper** を使って `30-distrokid/README.md` の手順に従い DistroKid Web フォームへ転記・アップロードを行う
 
 DistroKid 申請後の DSP リンク（Spotify / Apple Music）到着は通常 1〜2 週間かかる。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(distrokid-helper)`: 初回表示、コレクション選択、ローカル配信元選択の各タイミングで collection 一覧と release.json を自動取得し、手動の「データ取得」ボタンを廃止した（#1992）。
+
 - `feat(suno-helper)`: 初回表示、コレクション選択、ローカル配信元選択の各タイミングで collection prompts を自動取得し、手動の「データ取得」ボタンを廃止した（#1991）。
 
 - `feat(suno-helper)`: Queue mode の duration guard 全滅 entry を、全 entry の ACK 先行投入後に既存 pacing で同一 prompt から最大 2 回自動再生成する挙動を明示し、Queue mode の説明文にも自動再生成を追記した（#1775）。

--- a/extensions/distrokid-helper/README.md
+++ b/extensions/distrokid-helper/README.md
@@ -84,9 +84,9 @@ nix develop .#extensions --command pnpm -C extensions/distrokid-helper compile
    `--allow-extension distrokid-helper` は配信済み記録の書き込み（`POST /distrokid/releases`）に**必須**。
    未指定だと `GET /auth/token` が無効になり、フィル完了後の配信済み記録が 403 で失敗する（フィル自体は成功する）。
 2. Chrome で `distrokid.com/new` を開く。
-3. 拡張ポップアップで **ローカル配信元** を選び **データ取得**。
-4. popup に **コレクション選択** のドロップダウンが表示される。未配信の disc のみ列挙される。
-5. disc を選んで **データ取得** → レビューを確認して **フォーム一括入力**。
+3. 拡張ポップアップの登録済み **ローカル配信元** selector から対象を選ぶ。選択した配信元は自動保存され、コレクション一覧と先頭の未配信 disc の release.json が自動取得される。
+4. popup の **コレクション選択** には未配信の disc だけが表示される。別 disc を選ぶと一覧と選択 disc の release.json が自動取得される。
+5. レビューを確認して **フォーム一括入力**。最新データを再取得する場合は popup を閉じて再表示する。
 6. 目視確認 → **「続ける」を手動押下** → マスタリング選択 → 完了。
 7. フィル完了後、拡張が自動的に `POST /distrokid/releases` で配信済み記録を送信し、ドロップダウンから当該 disc が消える。
 
@@ -106,8 +106,8 @@ nix develop .#extensions --command pnpm -C extensions/distrokid-helper compile
    対象チャンネルは `config/channel/distrokid.json` を `enabled: true` + profile 付きにしておく
    （`enabled: false` / 未配置だと `/distrokid/*` が 404 になり、popup がガイダンスを表示する）。
 2. Chrome で `distrokid.com/new` を開く。
-3. 拡張ポップアップで **ローカル配信元**（既定 `http://youtube-automation.localhost:7873`）を選び **データ取得**。
-   コレクション選択 UI は表示されない（単一 mode のため）。
+3. 拡張ポップアップの登録済み **ローカル配信元** selector から対象（既定 `http://youtube-automation.localhost:7873`）を選ぶ。選択した配信元は自動保存され、release.json が自動取得される。
+   コレクション選択 UI は表示されない（単一 mode のため）。最新データを再取得する場合は popup を閉じて再表示する。
 4. レビュー表示を確認して **フォーム一括入力**。プロファイル + 動的データがフォームに注入される。
 5. 目視確認 → **「続ける」を手動押下** → マスタリング選択 → 完了。
 

--- a/extensions/distrokid-helper/components/ServerUrlField.tsx
+++ b/extensions/distrokid-helper/components/ServerUrlField.tsx
@@ -5,11 +5,10 @@ export interface ServerUrlFieldProps {
   sources: LocalServerSource[];
   disabled: boolean;
   onChange: (value: string) => void;
-  onFetch: () => void;
 }
 
-// ローカル配信元 selector + データ取得ボタン。
-export function ServerUrlField({ value, sources, disabled, onChange, onFetch }: ServerUrlFieldProps) {
+// 登録済みローカル配信元 selector。選択変更は runner の自動取得へ接続する。
+export function ServerUrlField({ value, sources, disabled, onChange }: ServerUrlFieldProps) {
   return (
     <div className="flex flex-col gap-2">
       <label className="text-xs font-medium text-gray-600" htmlFor="server-url">
@@ -19,8 +18,8 @@ export function ServerUrlField({ value, sources, disabled, onChange, onFetch }: 
         id="server-url"
         className="rounded border border-gray-300 px-2 py-1 text-sm"
         value={value}
-        onChange={(event) => onChange(event.target.value)}
         disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
       >
         {sources.map((source) => (
           <option key={source.url} value={source.url}>
@@ -28,14 +27,6 @@ export function ServerUrlField({ value, sources, disabled, onChange, onFetch }: 
           </option>
         ))}
       </select>
-      <button
-        type="button"
-        className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-        disabled={disabled}
-        onClick={onFetch}
-      >
-        データ取得
-      </button>
     </div>
   );
 }

--- a/extensions/distrokid-helper/components/useDistrokidRunner.ts
+++ b/extensions/distrokid-helper/components/useDistrokidRunner.ts
@@ -31,6 +31,7 @@ export interface DistrokidRunnerState {
   serverSources: LocalServerSource[];
   payload: ReleasePayload | null;
   busy: boolean;
+  isInjecting: boolean;
   phase: Phase | null;
   message: string;
   compatibilityWarning: string;
@@ -41,9 +42,15 @@ export interface DistrokidRunnerState {
   // 選択中 disc の index（collections 配列の index）。-1 = 未選択（単一 mode）。
   selectedIndex: number;
   selectCollection: (index: number) => void;
-  fetchData: () => Promise<void>;
   inject: () => Promise<void>;
   stop: () => Promise<void>;
+}
+
+type DiscIdentity = Pick<DistrokidCollectionSummary, "collection_id" | "disc">;
+
+interface CollectionLoadResult {
+  list: DistrokidCollectionSummary[];
+  isDirMode: boolean;
 }
 
 async function activeTabId(): Promise<number> {
@@ -62,6 +69,7 @@ export function useDistrokidRunner(): DistrokidRunnerState {
   const [serverSources, setServerSources] = useState<LocalServerSource[]>([]);
   const [payload, setPayload] = useState<ReleasePayload | null>(null);
   const [busy, setBusy] = useState(false);
+  const [isInjecting, setIsInjecting] = useState(false);
   const [phase, setPhase] = useState<Phase | null>(null);
   const [message, setMessage] = useState("");
   const [compatibilityWarning, setCompatibilityWarning] = useState("");
@@ -72,49 +80,61 @@ export function useDistrokidRunner(): DistrokidRunnerState {
 
   // 停止要求フラグ。injection ループの境界で参照し、押下後は以降の送信を打ち切る。
   const stoppedRef = useRef(false);
+  // 注入中は取得操作を受け付けない。busy は fetch と注入で共有されるため、selector と
+  // 停止ボタンの制御には使わない。
+  const injectionActiveRef = useRef(false);
   // dir mode 判定フラグ（fetchDistrokidCollections 成功時に true）。
   const isDirModeRef = useRef(false);
   // 現在の payload を取得した disc（#934）。配信済み記録はフィルした payload の
   // 取得元に束縛する — fetch 後に select を変えても誤った disc を記録しないため。
   const payloadSourceRef = useRef<DistrokidReleaseRecord | null>(null);
+  // 自動取得は選択操作が連続しても最後の要求だけを state へ反映する。
+  const fetchRequestIdRef = useRef(0);
+  // URL 永続化を直列化し、遅い旧 write の後に必ず最新 write が完了するようにする。
+  const serverSourcePersistenceRef = useRef<Promise<void>>(Promise.resolve());
+  // 初期 readServerSources の遅延応答が自動保存後の候補一覧を上書きしないための revision。
+  const serverSourcesRevisionRef = useRef(0);
+  // ユーザー選択後に遅い初期 URL 読込が開始されないようにする。
+  const initialFetchStartedRef = useRef(false);
 
   // サーバー URL が確定したときに DistroKid collection 一覧を試行する (#934)。
   // 成功（dir mode）: released 除外済み一覧を state にセットし、その一覧を返す。
-  // 失敗（404 等 = 単一 mode）: collections を空のままにして従来動作へ fallback。
+  // 404（単一 mode）: collections を空のままにして従来動作へ fallback。
+  // 通信障害・不正応答: 既存の一覧と選択を保持したまま caller へ失敗を伝える。
   // setState は次レンダーまで反映されないため、同一ハンドラ内で一覧を使う caller は
   // 戻り値を直接参照する（stale closure 回避、#934）。
-  const loadCollections = useCallback(async (baseUrl: string): Promise<DistrokidCollectionSummary[]> => {
-    try {
-      const fetched = await fetchDistrokidCollections(baseUrl);
-      const list = excludeReleasedDiscs(fetched);
-      setCollections(list);
-      setAllReleased(fetched.length > 0 && list.length === 0);
-      // 未配信 disc があれば先頭を初期選択する。
-      setSelectedIndex(list.length > 0 ? 0 : -1);
-      isDirModeRef.current = true;
-      return list;
-    } catch {
-      // 単一ファイル mode サーバーは /distrokid/collections が 404。
-      // ドロップダウンを出さず従来の単一 mode へ fallback する（後方互換）。
-      setCollections([]);
-      setAllReleased(false);
-      setSelectedIndex(-1);
-      isDirModeRef.current = false;
-      return [];
-    }
-  }, []);
-
-  useEffect(() => {
-    // 永続化済みサーバー URL を復元し、URL があれば collection 一覧も試行する。
-    serverUrlItem.getValue().then((stored) => {
-      setServerUrl(stored);
-      const trimmed = stored.trim();
-      if (trimmed) {
-        void loadCollections(trimmed);
+  const loadCollections = useCallback(
+    async (baseUrl: string, shouldApply: () => boolean = () => true): Promise<CollectionLoadResult | null> => {
+      try {
+        const fetched = await fetchDistrokidCollections(baseUrl);
+        if (!shouldApply()) {
+          return null;
+        }
+        const list = excludeReleasedDiscs(fetched);
+        setCollections(list);
+        setAllReleased(fetched.length > 0 && list.length === 0);
+        // 未配信 disc があれば先頭を初期選択する。
+        setSelectedIndex(list.length > 0 ? 0 : -1);
+        isDirModeRef.current = true;
+        return { list, isDirMode: true };
+      } catch (error) {
+        if (!shouldApply()) {
+          return null;
+        }
+        if (!(error instanceof Error && error.message === "HTTP 404")) {
+          throw error;
+        }
+        // 単一ファイル mode サーバーは /distrokid/collections が 404。
+        // ドロップダウンを出さず従来の単一 mode へ fallback する（後方互換）。
+        setCollections([]);
+        setAllReleased(false);
+        setSelectedIndex(-1);
+        isDirModeRef.current = false;
+        return { list: [], isDirMode: false };
       }
-    });
-    void readServerSources().then(setServerSources);
-  }, [loadCollections]);
+    },
+    [],
+  );
 
   useEffect(() => {
     const unwatch = onMessage("progress", ({ data }) => {
@@ -127,82 +147,194 @@ export function useDistrokidRunner(): DistrokidRunnerState {
     return () => unwatch();
   }, []);
 
-  // データ取得。dir mode では選択中 disc の collection-scoped release.json を fetch し、
-  // 単一 mode では従来の /distrokid/release.json を fetch する (#934)。
-  const fetchData = useCallback(async () => {
-    setBusy(true);
-    setPhase(null);
-    setMessage("");
-    let baseUrl = serverUrl.trim();
-    try {
-      const info = await fetchServerInfo(baseUrl);
-      baseUrl = info.base_url;
-      setServerUrl(baseUrl);
-      await serverUrlItem.setValue(baseUrl);
-      setServerSources(await rememberServerSource(baseUrl, info.label));
-    } catch {
-      await serverUrlItem.setValue(baseUrl);
-      setServerSources(await rememberServerSource(baseUrl));
-    }
-    const extensionVersion = browser.runtime.getManifest().version;
-    setCompatibilityWarning(await resolveCompatibilityWarning(baseUrl, extensionVersion));
+  // 対象 URL と優先 disc をイベント時点の値で受け取り、一覧最新化から release 取得まで行う。
+  // 各 await 後に request ID を検査し、古い応答が最新の state を上書きするのを防ぐ。
+  const fetchData = useCallback(
+    async (targetUrl: string, preferredDisc: DiscIdentity | null) => {
+      const requestId = ++fetchRequestIdRef.current;
+      const isLatestRequest = (): boolean => requestId === fetchRequestIdRef.current;
+      let baseUrl = targetUrl.trim();
+      if (!baseUrl) {
+        return;
+      }
 
-    // URL 変更時に collection 一覧を再取得する（blur 後の最初のデータ取得で最新化）。
-    // state の collections/selectedIndex はこのレンダーの closure では古いままなので、
-    // 戻り値の最新一覧を直接使う（stale closure 回避、#934）。
-    const list = await loadCollections(baseUrl);
+      setBusy(true);
+      setPhase(null);
+      setMessage("");
+      setPayload(null);
+      payloadSourceRef.current = null;
 
-    try {
-      let result: ReleasePayload;
-      if (isDirModeRef.current) {
-        if (list.length === 0) {
-          // dir mode で未配信 disc が無い場合は単一 mode へ fallback しない
-          // （dir mode サーバーに /distrokid/release.json は無く、誤った 404 ガイダンスになるため）。
-          setPayload(null);
-          setMessage("未配信の disc はありません。");
+      let serverLabel: string | undefined;
+      try {
+        const info = await fetchServerInfo(baseUrl);
+        if (!isLatestRequest()) {
           return;
         }
-        // 再取得後も同じ disc が残っていれば選択を維持し、消えていれば先頭にする。
-        const prev = collections[selectedIndex];
-        const keptIndex = prev
-          ? list.findIndex((item) => item.collection_id === prev.collection_id && item.disc === prev.disc)
-          : -1;
-        const effectiveIndex = keptIndex >= 0 ? keptIndex : 0;
-        setSelectedIndex(effectiveIndex);
-        const selected = list[effectiveIndex];
-        // 配信済み記録はこの payload の取得元 disc に束縛する（#934）。
-        payloadSourceRef.current = {
-          collection_id: selected.collection_id,
-          disc: selected.disc,
-          album_title: selected.album_title,
-        };
-        result = await fetchCollectionRelease(baseUrl, selected.collection_id, selected.disc);
-      } else {
-        // 単一 mode（後方互換）: 従来の /distrokid/release.json を取得する。
-        payloadSourceRef.current = null;
-        result = await fetchRelease(baseUrl);
+        baseUrl = info.base_url;
+        setServerUrl(baseUrl);
+        serverLabel = info.label;
+      } catch {
+        // /server-info 非対応の旧サーバーは選択 URL のまま継続する。
+        if (!isLatestRequest()) {
+          return;
+        }
       }
-      setPayload(result);
-    } catch (error) {
-      setPayload(null);
-      setPhase(PHASES.ERROR);
-      setMessage(
-        error instanceof ReleaseUnavailableError
-          ? UNAVAILABLE_GUIDANCE
-          : error instanceof Error
-            ? error.message
-            : String(error),
-      );
-    } finally {
-      setBusy(false);
-    }
-  }, [serverUrl, collections, selectedIndex, loadCollections]);
+
+      const persistServerSource = serverSourcePersistenceRef.current.then(async () => {
+        if (!isLatestRequest()) {
+          return;
+        }
+        await serverUrlItem.setValue(baseUrl);
+        if (!isLatestRequest()) {
+          return;
+        }
+        const rememberedSources = await rememberServerSource(baseUrl, serverLabel);
+        if (!isLatestRequest()) {
+          return;
+        }
+        serverSourcesRevisionRef.current += 1;
+        setServerSources(rememberedSources);
+      });
+      serverSourcePersistenceRef.current = persistServerSource.catch(() => undefined);
+
+      try {
+        await persistServerSource;
+        if (!isLatestRequest()) {
+          return;
+        }
+
+        const extensionVersion = browser.runtime.getManifest().version;
+        const warning = await resolveCompatibilityWarning(baseUrl, extensionVersion);
+        if (!isLatestRequest()) {
+          return;
+        }
+        setCompatibilityWarning(warning);
+
+        const loadedCollections = await loadCollections(baseUrl, isLatestRequest);
+        if (loadedCollections === null) {
+          return;
+        }
+        const { list, isDirMode } = loadedCollections;
+
+        let result: ReleasePayload;
+        if (isDirMode) {
+          if (list.length === 0) {
+            // dir mode で未配信 disc が無い場合は単一 mode へ fallback しない
+            // （dir mode サーバーに /distrokid/release.json は無く、誤った 404 ガイダンスになるため）。
+            setPayload(null);
+            setMessage("未配信の disc はありません。");
+            return;
+          }
+          // 識別子で選択を維持し、一覧から消えていれば先頭へフォールバックする。
+          const keptIndex = preferredDisc
+            ? list.findIndex(
+                (item) => item.collection_id === preferredDisc.collection_id && item.disc === preferredDisc.disc,
+              )
+            : -1;
+          const effectiveIndex = keptIndex >= 0 ? keptIndex : 0;
+          setSelectedIndex(effectiveIndex);
+          const selected = list[effectiveIndex];
+          // 配信済み記録はこの payload の取得元 disc に束縛する（#934）。
+          payloadSourceRef.current = {
+            collection_id: selected.collection_id,
+            disc: selected.disc,
+            album_title: selected.album_title,
+          };
+          result = await fetchCollectionRelease(baseUrl, selected.collection_id, selected.disc);
+        } else {
+          // 単一 mode（後方互換）: 従来の /distrokid/release.json を取得する。
+          payloadSourceRef.current = null;
+          result = await fetchRelease(baseUrl);
+        }
+        if (!isLatestRequest()) {
+          return;
+        }
+        setPayload(result);
+      } catch (error) {
+        if (!isLatestRequest()) {
+          return;
+        }
+        setPayload(null);
+        setPhase(PHASES.ERROR);
+        setMessage(
+          error instanceof ReleaseUnavailableError
+            ? UNAVAILABLE_GUIDANCE
+            : error instanceof Error
+              ? error.message
+              : String(error),
+        );
+      } finally {
+        if (isLatestRequest()) {
+          setBusy(false);
+        }
+      }
+    },
+    [loadCollections],
+  );
+
+  const updateServerUrl = useCallback(
+    (nextUrl: string) => {
+      if (injectionActiveRef.current) {
+        return;
+      }
+      initialFetchStartedRef.current = true;
+      setServerUrl(nextUrl);
+      void fetchData(nextUrl, null);
+    },
+    [fetchData],
+  );
+
+  const selectCollection = useCallback(
+    (index: number) => {
+      if (injectionActiveRef.current) {
+        return;
+      }
+      const selected = collections[index];
+      if (!selected) {
+        return;
+      }
+      setSelectedIndex(index);
+      void fetchData(serverUrl, {
+        collection_id: selected.collection_id,
+        disc: selected.disc,
+      });
+    },
+    [collections, fetchData, serverUrl],
+  );
+
+  useEffect(() => {
+    void serverUrlItem.getValue().then((stored) => {
+      if (initialFetchStartedRef.current) {
+        return;
+      }
+      initialFetchStartedRef.current = true;
+      setServerUrl(stored);
+      if (stored.trim()) {
+        void fetchData(stored, null);
+      }
+    });
+
+    const revisionAtStart = serverSourcesRevisionRef.current;
+    void readServerSources().then((sources) => {
+      if (revisionAtStart === serverSourcesRevisionRef.current) {
+        setServerSources(sources);
+      }
+    });
+  }, [fetchData]);
 
   const inject = useCallback(async () => {
-    if (payload === null) {
+    if (payload === null || injectionActiveRef.current) {
       return;
     }
+    // 注入と配信済み記録は、開始時に表示されていた payload と取得元へ束縛する。
+    // await 中に UI 外から state 更新が試みられても、別 disc/URL を記録しない。
+    const injectionPayload = payload;
+    const injectionBaseUrl = serverUrl.trim();
+    const injectionSource = payloadSourceRef.current;
+    const injectionIsDirMode = isDirModeRef.current;
     stoppedRef.current = false;
+    injectionActiveRef.current = true;
+    setIsInjecting(true);
     setBusy(true);
     setPhase(PHASES.INJECTING);
     setMessage("注入を開始します");
@@ -211,8 +343,8 @@ export function useDistrokidRunner(): DistrokidRunnerState {
       // ページ origin で CORS 評価され遮断されるため（asset-transfer.ts 参照）。逐次実行・
       // 停止境界の制御フローは runInjection に抽出し、ここでは transport を束ねて渡す（#871）。
       const tabId = await activeTabId();
-      await runInjection(payload, {
-        fetchAsset: (assetPath, filename) => fetchAsset(serverUrl, assetPath, filename),
+      await runInjection(injectionPayload, {
+        fetchAsset: (assetPath, filename) => fetchAsset(injectionBaseUrl, assetPath, filename),
         start: (p) => sendMessage("injectStart", { payload: p }, tabId),
         track: (trackIndex, asset) => sendMessage("injectTrack", { trackIndex, asset }, tabId),
         cover: (asset) => sendMessage("injectCover", { asset }, tabId),
@@ -227,12 +359,11 @@ export function useDistrokidRunner(): DistrokidRunnerState {
       // POST は popup から直接 fetch せず background に委譲する — serve token 必須の
       // 書き込み境界は extension origin の background で越える（#1360、ADR-0016）。
       // POST 失敗はフィル成功を覆さない（warning を添えるだけ）。
-      const source = payloadSourceRef.current;
-      if (isDirModeRef.current && source !== null) {
+      if (injectionIsDirMode && injectionSource !== null) {
         try {
-          await sendMessage("recordRelease", { baseUrl: serverUrl.trim(), record: source });
+          await sendMessage("recordRelease", { baseUrl: injectionBaseUrl, record: injectionSource });
           // 配信済み記録成功後、一覧を再取得して select から消す (#934)。
-          await loadCollections(serverUrl.trim());
+          await loadCollections(injectionBaseUrl);
         } catch (recordError) {
           // 配信記録失敗はフィル結果に影響しない補助機能のため warn 表示のみ (#934)。
           setMessage(
@@ -244,6 +375,9 @@ export function useDistrokidRunner(): DistrokidRunnerState {
       setPhase(PHASES.ERROR);
       setMessage(error instanceof Error ? error.message : String(error));
       setBusy(false);
+    } finally {
+      injectionActiveRef.current = false;
+      setIsInjecting(false);
     }
   }, [payload, serverUrl, loadCollections]);
 
@@ -261,18 +395,18 @@ export function useDistrokidRunner(): DistrokidRunnerState {
 
   return {
     serverUrl,
-    setServerUrl,
+    setServerUrl: updateServerUrl,
     serverSources,
     payload,
     busy,
+    isInjecting,
     phase,
     message,
     compatibilityWarning,
     collections,
     allReleased,
     selectedIndex,
-    selectCollection: setSelectedIndex,
-    fetchData,
+    selectCollection,
     inject,
     stop,
   };

--- a/extensions/distrokid-helper/entrypoints/popup/App.tsx
+++ b/extensions/distrokid-helper/entrypoints/popup/App.tsx
@@ -12,6 +12,7 @@ export function App() {
     serverSources,
     payload,
     busy,
+    isInjecting,
     phase,
     message,
     compatibilityWarning,
@@ -19,7 +20,6 @@ export function App() {
     allReleased,
     selectedIndex,
     selectCollection,
-    fetchData,
     inject,
     stop,
   } = useDistrokidRunner();
@@ -28,13 +28,7 @@ export function App() {
     <main className="flex flex-col gap-3 p-4">
       <h1 className="text-base font-bold text-gray-900">DistroKid Helper</h1>
 
-      <ServerUrlField
-        value={serverUrl}
-        sources={serverSources}
-        disabled={busy}
-        onChange={setServerUrl}
-        onFetch={() => void fetchData()}
-      />
+      <ServerUrlField value={serverUrl} sources={serverSources} disabled={isInjecting} onChange={setServerUrl} />
 
       {compatibilityWarning && (
         <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
@@ -48,6 +42,7 @@ export function App() {
           コレクション
           <select
             value={selectedIndex}
+            disabled={isInjecting}
             onChange={(e) => selectCollection(Number(e.target.value))}
             className="rounded border border-gray-300 px-2 py-1"
           >
@@ -77,7 +72,7 @@ export function App() {
         <button
           type="button"
           className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 disabled:opacity-50"
-          disabled={!busy}
+          disabled={!isInjecting}
           onClick={() => void stop()}
         >
           停止

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -5,6 +5,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "../entrypoints/popup/App";
+import { sendMessage } from "../lib/messaging";
+import { readServerSources, rememberServerSource, serverUrlItem } from "../lib/storage";
 import type { ReleasePayload } from "../lib/types";
 
 const BASE_URL = "http://localhost:7873";
@@ -38,6 +40,29 @@ const RELEASE_PAYLOAD: ReleasePayload = {
     cover: { filename: "main.png", asset_path: "/distrokid/assets/main.png" },
     release_date: "2026-07-01",
   },
+};
+
+const SECOND_RELEASE_PAYLOAD: ReleasePayload = {
+  ...RELEASE_PAYLOAD,
+  release: {
+    ...RELEASE_PAYLOAD.release,
+    album_title: "Winter Focus",
+  },
+};
+
+const DISC1 = {
+  collection_id: "20260526-coding-focus-collection",
+  name: "coding focus",
+  disc: "disc1",
+  album_title: RELEASE_PAYLOAD.release.album_title,
+  track_count: 1,
+  released: false,
+};
+
+const DISC2 = {
+  ...DISC1,
+  disc: "disc2",
+  album_title: SECOND_RELEASE_PAYLOAD.release.album_title,
 };
 
 vi.mock("wxt/browser", () => ({
@@ -83,6 +108,17 @@ function jsonResponse(status: number, body: unknown): Response {
   } as Response;
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 function setSelectValue(select: HTMLSelectElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
   if (!setter) {
@@ -119,11 +155,44 @@ describe("DistroKid popup compatibility check", () => {
     root = createRoot(container);
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue("");
+    vi.mocked(serverUrlItem.setValue).mockResolvedValue(undefined);
+    vi.mocked(readServerSources).mockResolvedValue([
+      { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+      { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+    ]);
+    vi.mocked(rememberServerSource).mockResolvedValue([
+      { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+      { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+    ]);
+  });
 
+  async function renderApp(): Promise<void> {
     await act(async () => {
       root.render(createElement(App));
     });
-  });
+  }
+
+  function stubDirModeServer(): void {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(200, [DISC1, DISC2]);
+      }
+      if (url.includes(`/${DISC1.disc}/release.json`)) {
+        return jsonResponse(200, RELEASE_PAYLOAD);
+      }
+      if (url.includes(`/${DISC2.disc}/release.json`)) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+  }
 
   afterEach(() => {
     act(() => {
@@ -135,6 +204,7 @@ describe("DistroKid popup compatibility check", () => {
   });
 
   it("ローカル配信元 option は URL を表示せず、URL value はデータ取得先として維持する", async () => {
+    await renderApp();
     const select = container.querySelector<HTMLSelectElement>("#server-url")!;
 
     await waitFor(() => {
@@ -148,7 +218,35 @@ describe("DistroKid popup compatibility check", () => {
     expect(select.textContent).not.toContain("http://");
   });
 
-  it("データ取得時に manifest version で /version を先に呼び、非互換警告を表示して release 取得を継続する", async () => {
+  it("popup 初回表示時に保存 URL から一覧と選択 disc の release を自動取得し、取得ボタンを表示しない", async () => {
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(200, [DISC1, DISC2]))
+      .mockResolvedValueOnce(jsonResponse(200, RELEASE_PAYLOAD));
+
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(RELEASE_PAYLOAD.release.album_title);
+      expect(container.textContent).toContain(RELEASE_PAYLOAD.release.cover?.filename);
+    });
+    expect(container.textContent).not.toContain("データ取得");
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/distrokid/collections`);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      `${BASE_URL}/collections/${DISC1.collection_id}/distrokid/${DISC1.disc}/release.json`,
+      { method: "GET" },
+    );
+    expect(container.querySelector<HTMLSelectElement>("select:not(#server-url)")?.value).toBe("0");
+    const injectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "フォーム一括入力",
+    );
+    expect(injectButton?.disabled).toBe(false);
+  });
+
+  it("配信元選択時に manifest version で /version を先に呼び、非互換警告を表示して release 取得を継続する", async () => {
     fetchMock
       .mockResolvedValueOnce(
         jsonResponse(200, {
@@ -164,11 +262,10 @@ describe("DistroKid popup compatibility check", () => {
       .mockResolvedValueOnce(jsonResponse(404, {}))
       .mockResolvedValueOnce(jsonResponse(200, RELEASE_PAYLOAD));
 
+    await renderApp();
+
     await act(async () => {
       setSelectValue(container.querySelector<HTMLSelectElement>("#server-url")!, BASE_URL);
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>("button")!.click();
     });
 
     await waitFor(() => {
@@ -179,6 +276,8 @@ describe("DistroKid popup compatibility check", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/version`);
     expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/distrokid/collections`);
     expect(fetchMock).toHaveBeenNthCalledWith(4, `${BASE_URL}/distrokid/release.json`, { method: "GET" });
+    expect(serverUrlItem.setValue).toHaveBeenCalledWith(BASE_URL);
+    expect(rememberServerSource).toHaveBeenCalledWith(BASE_URL, "localhost");
   });
 
   it("旧サーバーの /version 404 は警告なしで release 取得を継続する", async () => {
@@ -188,11 +287,10 @@ describe("DistroKid popup compatibility check", () => {
       .mockResolvedValueOnce(jsonResponse(404, {}))
       .mockResolvedValueOnce(jsonResponse(200, RELEASE_PAYLOAD));
 
+    await renderApp();
+
     await act(async () => {
       setSelectValue(container.querySelector<HTMLSelectElement>("#server-url")!, BASE_URL);
-    });
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>("button")!.click();
     });
 
     await waitFor(() => {
@@ -203,5 +301,344 @@ describe("DistroKid popup compatibility check", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/version`);
     expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/distrokid/collections`);
     expect(fetchMock).toHaveBeenNthCalledWith(4, `${BASE_URL}/distrokid/release.json`, { method: "GET" });
+  });
+
+  it("collection 選択時に一覧を最新化し、選択 disc の release へ自動更新する", async () => {
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    stubDirModeServer();
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(RELEASE_PAYLOAD.release.album_title);
+    });
+    const collectionSelect = container.querySelector<HTMLSelectElement>("select:not(#server-url)")!;
+    await act(async () => {
+      setSelectValue(collectionSelect, "1");
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+    expect(fetchMock.mock.calls.filter(([url]) => url === `${BASE_URL}/distrokid/collections`)).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/collections/${DISC2.collection_id}/distrokid/${DISC2.disc}/release.json`,
+      { method: "GET" },
+    );
+    expect(collectionSelect.value).toBe("1");
+  });
+
+  it("注入中は両 selector をロックし、停止ボタンは有効なまま選択変更による取得を開始しない", async () => {
+    const injectionStart = deferred<void>();
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    stubDirModeServer();
+    vi.mocked(sendMessage).mockImplementation(async (type) => {
+      if (type === "injectStart") {
+        await injectionStart.promise;
+      }
+      return undefined;
+    });
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(RELEASE_PAYLOAD.release.album_title);
+    });
+    const sourceSelect = container.querySelector<HTMLSelectElement>("#server-url")!;
+    const collectionSelect = container.querySelector<HTMLSelectElement>("select:not(#server-url)")!;
+    const injectButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "フォーム一括入力",
+    )!;
+    const stopButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "停止",
+    )!;
+    const requestCountBeforeChange = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      injectButton.click();
+    });
+    await waitFor(() => {
+      expect(sourceSelect.disabled).toBe(true);
+      expect(collectionSelect.disabled).toBe(true);
+      expect(stopButton.disabled).toBe(false);
+    });
+
+    await act(async () => {
+      setSelectValue(sourceSelect, FALLBACK_URL);
+      setSelectValue(collectionSelect, "1");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(requestCountBeforeChange);
+
+    await act(async () => {
+      stopButton.click();
+    });
+    expect(sendMessage).toHaveBeenCalledWith("stop", undefined, 1);
+
+    await act(async () => {
+      injectionStart.resolve();
+      await injectionStart.promise;
+    });
+  });
+
+  it("取得失敗後も配信元 selector は操作可能で、変更すると再取得できる", async () => {
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith(BASE_URL)) {
+        throw new Error("server stopped");
+      }
+      if (
+        url === `${FALLBACK_URL}/server-info` ||
+        url === `${FALLBACK_URL}/version` ||
+        url === `${FALLBACK_URL}/distrokid/collections`
+      ) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${FALLBACK_URL}/distrokid/release.json`) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("server stopped");
+    });
+    const sourceSelect = container.querySelector<HTMLSelectElement>("#server-url")!;
+    expect(sourceSelect.disabled).toBe(false);
+
+    await act(async () => {
+      setSelectValue(sourceSelect, FALLBACK_URL);
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`${FALLBACK_URL}/distrokid/release.json`, { method: "GET" });
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+    expect(sourceSelect.disabled).toBe(false);
+  });
+
+  it("選択 disc の取得失敗後も collection selector は操作可能で、別 disc へ切り替えられる", async () => {
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info` || url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(200, [DISC1, DISC2]);
+      }
+      if (url.includes(`/${DISC1.disc}/release.json`)) {
+        throw new Error("disc1 server stopped");
+      }
+      if (url.includes(`/${DISC2.disc}/release.json`)) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("disc1 server stopped");
+    });
+    const collectionSelect = container.querySelector<HTMLSelectElement>("select:not(#server-url)")!;
+    expect(collectionSelect.disabled).toBe(false);
+
+    await act(async () => {
+      setSelectValue(collectionSelect, "1");
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+    expect(collectionSelect.disabled).toBe(false);
+  });
+
+  it("collection 再選択時に一覧取得が失敗してもエラーを表示し、一覧と選択を維持する", async () => {
+    let collectionsRequestCount = 0;
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info` || url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        collectionsRequestCount += 1;
+        if (collectionsRequestCount === 2) {
+          throw new Error("collections server stopped");
+        }
+        return jsonResponse(200, [DISC1, DISC2]);
+      }
+      if (url.includes(`/${DISC1.disc}/release.json`)) {
+        return jsonResponse(200, RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(RELEASE_PAYLOAD.release.album_title);
+    });
+    const sourceSelect = container.querySelector<HTMLSelectElement>("#server-url")!;
+    const collectionSelect = container.querySelector<HTMLSelectElement>("select:not(#server-url)")!;
+
+    await act(async () => {
+      setSelectValue(collectionSelect, "1");
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("collections server stopped");
+    });
+
+    expect(container.querySelector<HTMLSelectElement>("select:not(#server-url)")).toBe(collectionSelect);
+    expect(collectionSelect.options).toHaveLength(2);
+    expect(collectionSelect.value).toBe("1");
+    expect(collectionSelect.disabled).toBe(false);
+    expect(sourceSelect.disabled).toBe(false);
+  });
+
+  it("遅い旧 release 応答が後から完了しても最新 disc の payload と DOM を維持する", async () => {
+    const firstRelease = deferred<Response>();
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info` || url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(200, [DISC1, DISC2]);
+      }
+      if (url.includes(`/${DISC1.disc}/release.json`)) {
+        return firstRelease.promise;
+      }
+      if (url.includes(`/${DISC2.disc}/release.json`)) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+
+    await waitFor(() => {
+      expect(container.querySelector("select:not(#server-url)")).not.toBeNull();
+    });
+    await act(async () => {
+      setSelectValue(container.querySelector<HTMLSelectElement>("select:not(#server-url)")!, "1");
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+
+    await act(async () => {
+      firstRelease.resolve(jsonResponse(200, RELEASE_PAYLOAD));
+      await firstRelease.promise;
+    });
+    expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    expect(container.textContent).not.toContain(`アルバム名${RELEASE_PAYLOAD.release.album_title}`);
+    expect(container.querySelector<HTMLSelectElement>("select:not(#server-url)")!.value).toBe("1");
+  });
+
+  it("遅い初期一覧が後から完了しても最新配信元の URL・payload・DOM を維持する", async () => {
+    const initialCollections = deferred<Response>();
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info` || url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return initialCollections.promise;
+      }
+      if (url === `${FALLBACK_URL}/server-info` || url === `${FALLBACK_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${FALLBACK_URL}/distrokid/collections`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${FALLBACK_URL}/distrokid/release.json`) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/distrokid/collections`);
+    });
+
+    const sourceSelect = container.querySelector<HTMLSelectElement>("#server-url")!;
+    await act(async () => {
+      setSelectValue(sourceSelect, FALLBACK_URL);
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+
+    await act(async () => {
+      initialCollections.resolve(jsonResponse(200, [DISC1, DISC2]));
+      await initialCollections.promise;
+    });
+    expect(sourceSelect.value).toBe(FALLBACK_URL);
+    expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    expect(container.querySelector("select:not(#server-url)")).toBeNull();
+  });
+
+  it("遅い旧 URL 保存後に最新 URL を保存し、永続化値を latest-wins にする", async () => {
+    const firstWrite = deferred<void>();
+    let persistedUrl = "";
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    vi.mocked(serverUrlItem.setValue).mockImplementation(async (url) => {
+      if (url === BASE_URL) {
+        await firstWrite.promise;
+      }
+      persistedUrl = url;
+    });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/server-info") || url.endsWith("/version") || url.endsWith("/distrokid/collections")) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${FALLBACK_URL}/distrokid/release.json`) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      if (url === `${BASE_URL}/distrokid/release.json`) {
+        return jsonResponse(200, RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+    await waitFor(() => {
+      expect(serverUrlItem.setValue).toHaveBeenCalledWith(BASE_URL);
+    });
+
+    await act(async () => {
+      setSelectValue(container.querySelector<HTMLSelectElement>("#server-url")!, FALLBACK_URL);
+    });
+    await act(async () => {
+      firstWrite.resolve();
+      await firstWrite.promise;
+    });
+    await waitFor(() => {
+      expect(persistedUrl).toBe(FALLBACK_URL);
+      expect(container.textContent).toContain(SECOND_RELEASE_PAYLOAD.release.album_title);
+    });
+  });
+
+  it("遅い初期配信元一覧が自動保存後に完了しても最新候補一覧を維持する", async () => {
+    const initialSources = deferred<Awaited<ReturnType<typeof readServerSources>>>();
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    vi.mocked(readServerSources).mockReturnValue(initialSources.promise);
+    vi.mocked(rememberServerSource).mockResolvedValue([
+      { id: "latest", label: "Latest", url: BASE_URL },
+      { id: "latest-fallback", label: "Latest fallback", url: FALLBACK_URL },
+    ]);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/server-info") || url.endsWith("/version") || url.endsWith("/distrokid/collections")) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/release.json`) {
+        return jsonResponse(200, RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    await renderApp();
+    await waitFor(() => {
+      expect(container.querySelector<HTMLSelectElement>("#server-url")?.options).toHaveLength(2);
+      expect(container.textContent).toContain("Latest fallback");
+    });
+
+    await act(async () => {
+      initialSources.resolve([{ id: "stale", label: "Stale", url: "http://localhost:7999" }]);
+      await initialSources.promise;
+    });
+    expect(container.textContent).toContain("Latest fallback");
+    expect(container.textContent).not.toContain("Stale");
   });
 });

--- a/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
+++ b/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
@@ -119,6 +119,22 @@ function blobResponse(): Response {
   } as unknown as Response;
 }
 
+async function waitFor(assertion: () => void): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (i === 19) {
+        throw error;
+      }
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+}
+
 // hook を直接マウントする probe。render のたびに最新の runner state を onState 経由で捕捉する
 // （component 内からモジュール変数へ直接代入すると react-hooks/globals に抵触するため）。
 function Probe({ onState }: { onState: (state: DistrokidRunnerState) => void }): null {
@@ -174,6 +190,12 @@ describe("useDistrokidRunner", () => {
       if (url === `${BASE_URL}/collections/${DISC1.collection_id}/distrokid/${DISC1.disc}/release.json`) {
         return jsonResponse(200, RELEASE_PAYLOAD);
       }
+      if (url === `${BASE_URL}/collections/${DISC2.collection_id}/distrokid/${DISC2.disc}/release.json`) {
+        return jsonResponse(200, {
+          ...RELEASE_PAYLOAD,
+          release: { ...RELEASE_PAYLOAD.release, album_title: DISC2.album_title },
+        });
+      }
       if (url === `${BASE_URL}/distrokid/assets/track-01.mp3`) {
         return blobResponse();
       }
@@ -200,8 +222,9 @@ describe("useDistrokidRunner", () => {
     await act(async () => {
       current.setServerUrl(BASE_URL);
     });
-    await act(async () => {
-      await current.fetchData();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(current.busy).toBe(false);
     });
   }
 
@@ -240,6 +263,54 @@ describe("useDistrokidRunner", () => {
     expect(current.busy).toBe(false);
   });
 
+  it("単一 mode: release が利用不可なら既存ガイダンスを表示して payload を返さない", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/version` || url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/release.json`) {
+        return jsonResponse(404, {});
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await fetchDirModeRelease();
+
+    expect(current.payload).toBeNull();
+    expect(current.phase).toBe("error");
+    expect(current.message).toContain("distrokid 連携が無効です");
+    expect(current.busy).toBe(false);
+  });
+
+  it("単一 mode: 一般取得エラーなら詳細を表示して古い payload を無効化する", async () => {
+    stubDirModeServer();
+    await fetchDirModeRelease();
+    expect(current.payload).not.toBeNull();
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/version` || url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/release.json`) {
+        return jsonResponse(500, {});
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await act(async () => {
+      current.setServerUrl(BASE_URL);
+    });
+    await waitFor(() => {
+      expect(current.message).toContain("HTTP 500");
+      expect(current.busy).toBe(false);
+    });
+
+    expect(current.payload).toBeNull();
+    expect(current.phase).toBe("error");
+    expect(current.message).toContain("HTTP 500");
+    expect(current.busy).toBe(false);
+  });
+
   it("stop: content へ stop message を送る", async () => {
     await act(async () => {
       await current.stop();
@@ -270,6 +341,78 @@ describe("useDistrokidRunner", () => {
       },
     });
     expect(current.collections.map((c) => c.disc)).toEqual([DISC2.disc]);
+  });
+
+  it("inject: collection 自動切替後は取得した最新 disc に配信済み記録を束縛する", async () => {
+    stubDirModeServer();
+    await fetchDirModeRelease();
+
+    await act(async () => {
+      current.selectCollection(1);
+    });
+    await waitFor(() => {
+      expect(current.payload?.release.album_title).toBe(DISC2.album_title);
+      expect(current.busy).toBe(false);
+    });
+    await act(async () => {
+      await current.inject();
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("recordRelease", {
+      baseUrl: BASE_URL,
+      record: {
+        collection_id: DISC2.collection_id,
+        disc: DISC2.disc,
+        album_title: DISC2.album_title,
+      },
+    });
+  });
+
+  it("inject: 開始後の強制選択変更を受け付けず、開始時 URL・payload・disc で完了する", async () => {
+    let resolveInjectionStart!: () => void;
+    const injectionStart = new Promise<void>((resolve) => {
+      resolveInjectionStart = resolve;
+    });
+    stubDirModeServer();
+    await fetchDirModeRelease();
+    vi.mocked(sendMessage).mockImplementation(async (type) => {
+      if (type === "injectStart") {
+        await injectionStart;
+      }
+      return undefined;
+    });
+
+    let injectionPromise!: Promise<void>;
+    await act(async () => {
+      injectionPromise = current.inject();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("injectStart", { payload: RELEASE_PAYLOAD }, 1);
+      expect(current.isInjecting).toBe(true);
+    });
+
+    await act(async () => {
+      current.setServerUrl("http://localhost:7999");
+      current.selectCollection(1);
+    });
+    await act(async () => {
+      resolveInjectionStart();
+      await injectionPromise;
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/distrokid/assets/track-01.mp3`, { method: "GET" });
+    expect(sendMessage).toHaveBeenCalledWith("recordRelease", {
+      baseUrl: BASE_URL,
+      record: {
+        collection_id: DISC1.collection_id,
+        disc: DISC1.disc,
+        album_title: DISC1.album_title,
+      },
+    });
+    expect(current.serverUrl).toBe(BASE_URL);
+    expect(current.selectedIndex).toBe(0);
+    expect(current.isInjecting).toBe(false);
   });
 
   it("inject: 配信済み記録の POST 失敗はフィル結果を覆さず warning を表示する", async () => {

--- a/tests/test_skill_docs_consistency.py
+++ b/tests/test_skill_docs_consistency.py
@@ -766,6 +766,22 @@ def test_distrokid_skill_and_example_document_single_and_multi_disc_naming() -> 
     assert example["multi_disc"]["discs"][1]["slug"] == "disc2-coding-focus-vol2"
 
 
+def test_distrokid_helper_docs_describe_automatic_selector_fetch_contract() -> None:
+    skill = _read(".claude/skills/distrokid-helper/SKILL.md")
+    readme = _read("extensions/distrokid-helper/README.md")
+
+    for text in (skill, readme):
+        assert "ローカル配信元" in text
+        assert "selector" in text
+        assert "自動保存" in text
+        assert "自動取得" in text
+        assert "popup を閉じて再表示" in text
+        assert "データ取得" not in text
+
+    assert "popup のサーバー URL" not in skill
+    assert "サーバー URL に `http://localhost:7874` を設定" not in skill
+
+
 def test_community_post_declares_raw_json_loader_exception() -> None:
     text = _read(".claude/skills/community-post/SKILL.md")
 


### PR DESCRIPTION
## Summary

- popup 初回表示・collection 選択・登録済みローカル配信元選択で release データを自動取得
- 手動の「データ取得」ボタンを廃止し、連続選択は latest-wins で保護
- 注入中は selector を固定し、開始時の URL・payload・disc snapshot で完了
- README・配布 skill・文書契約テスト・CHANGELOG を同期

## Validation

- `pnpm lint`
- `pnpm compile`
- `pnpm test` (14 files / 221 tests)
- `pnpm format:check`
- `uv run pytest tests/test_skill_docs_consistency.py -q` (46 passed)
- Ruff / `git diff --check` / lefthook pre-commit・pre-push

Closes #1992

<!-- takt:managed -->