### PR TITLE
fix(collection-serve): SIGTERM停止時に証跡を残す (#2001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(collection-serve)`: SIGTERM による予期せぬ停止を専用例外へ変換し、終了理由と traceback が stderr に残るようにした（#2001）。
 - `chore(suno-helper)`: React 19 と Tailwind CSS 4 の Vite plugin 構成へ移行し、`@/*` alias、Shadow DOM 対応 CSS variable theme、`cn` utility、Button primitive を含む shadcn/ui 最小基盤を追加した（#2011）。
 - `chore(distrokid-helper)`: Tailwind CSS 4 の Vite plugin 構成へ移行し、`@/*` alias、CSS variable theme、`cn` utility、Button primitive を含む shadcn/ui 最小基盤を追加した（#2012）。
 - `refactor(scripts)`: `yt-bulk-update-desc` の YouTube API `HttpError` を `YouTubeAPIError` へ変換し、metadata の意味的エラーだけを collection 単位で継続するよう例外境界を限定した。更新 API 失敗時は後続動画を処理後にドメイン例外を伝播し、破損 JSON / I/O error も fail-loud とした。tags / categoryId / defaultLanguage 欠落時の既存フォールバックは公開 `main()` 経路の回帰テストで固定した（#2032）。

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -20,6 +20,7 @@ import json
 import mimetypes
 import os
 import re
+import signal
 import tempfile
 import urllib.parse
 import uuid
@@ -95,6 +96,14 @@ _DISTROKID_RELEASES_ROUTE = "/distrokid/releases"
 # small JSON objects/lists; larger bodies are rejected before reading from rfile.
 _MAX_POST_BODY_BYTES = 1024 * 1024
 _MAX_DOWNLOADED_POST_BODY_BYTES = 10 * 1024
+
+
+class _ServerTerminationSignal(RuntimeError):
+    """SIGTERM を未捕捉例外として記録可能にする。"""
+
+    def __init__(self, signum: int) -> None:
+        signal_name = signal.Signals(signum).name
+        super().__init__(f"{signal_name} (signal {signum}) requested server termination")
 
 
 def _hostname_slug(text: str) -> str:
@@ -1094,11 +1103,20 @@ def main() -> None:
             f"/downloaded and {_DISTROKID_RELEASES_ROUTE}"
         )
     print("Press Ctrl-C to stop.")
+
+    def handle_sigterm(signum: int, _frame: object) -> None:
+        raise _ServerTerminationSignal(signum)
+
+    previous_sigterm_handler = signal.signal(
+        signal.SIGTERM,
+        handle_sigterm,
+    )
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\nStopped.")
     finally:
+        signal.signal(signal.SIGTERM, previous_sigterm_handler)
         server.server_close()
 
 

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -27,6 +27,7 @@ import json
 import logging
 import re
 import shutil
+import signal
 import socket
 import sys
 import threading
@@ -789,6 +790,49 @@ def test_main_resolves_allow_extension_to_allow_origin(monkeypatch, capsys, tmp_
     assert "detected extension: suno-helper -> gdjhjiphejeeclngbljhajiffhpdepee" in stdout
     assert "chrome-extension://gdjhjiphejeeclngbljhajiffhpdepee" in stdout
     assert "serve token: GET http://test-channel.localhost:7873/auth/token" in stdout
+
+
+def test_main_turns_sigterm_into_traceable_exception_and_restores_handler(monkeypatch, tmp_path):
+    """SIGTERM は理由を持つ例外として伝播し、終了後に handler を復元する。"""
+
+    class FakeServer:
+        server_address = ("localhost", 7873)
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        def serve_forever(self) -> None:
+            installed_handler(signal.SIGTERM, None)
+
+        def server_close(self) -> None:
+            self.closed = True
+
+    planning = tmp_path / "planning"
+    _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
+    fake_server = FakeServer()
+    installed_handler = None
+    signal_calls = []
+    previous_handler = object()
+
+    def fake_signal(signum, handler):
+        nonlocal installed_handler
+        signal_calls.append((signum, handler))
+        if handler is not previous_handler:
+            installed_handler = handler
+            return previous_handler
+        return previous_handler
+
+    monkeypatch.setattr(collection_serve_module, "signal", signal)
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    monkeypatch.setattr(collection_serve_module, "create_server", lambda *args, **kwargs: fake_server)
+    monkeypatch.setattr(sys, "argv", ["yt-collection-serve", str(planning)])
+
+    with pytest.raises(RuntimeError, match=r"SIGTERM \(signal 15\)"):
+        main()
+
+    assert fake_server.closed is True
+    assert signal_calls[0][0] == signal.SIGTERM
+    assert signal_calls[-1] == (signal.SIGTERM, previous_handler)
 
 
 def test_main_resolves_allow_extension_from_chrome_preferences(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary

- `yt-collection-serve` の SIGTERM を専用例外へ変換し、終了理由と traceback を stderr に残す
- server lifecycle の終了時に以前の SIGTERM handler を復元する
- 異常停止の証跡と handler 復元を回帰テストで固定する

## Validation

- `bash .lefthook/setup-worktree.sh uv run pytest tests/test_collection_serve.py` (187 passed)
- `bash .lefthook/setup-worktree.sh uv run ruff check .`
- `bash .lefthook/setup-worktree.sh uv run ruff format --check .`
- `bash .lefthook/setup-worktree.sh lefthook run pre-commit`
- pre-push CHANGELOG / test-diff / Any gates
- actual CLI SIGTERM repro: exit 1, stderr traceback with `_ServerTerminationSignal: SIGTERM (signal 15) requested server termination`

Closes #2001