### PR TITLE
fix(suno-helper): 一時取得失敗でも選択状態を保持する (#2002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: server の一時的な取得失敗時に明示選択した配信元と collection を保持する（#2002）
+
 - `fix(collection-serve)`: SIGTERM による予期せぬ停止を専用例外へ変換し、終了理由と traceback が stderr に残るようにした（#2001）。
 - `chore(suno-helper)`: React 19 と Tailwind CSS 4 の Vite plugin 構成へ移行し、`@/*` alias、Shadow DOM 対応 CSS variable theme、`cn` utility、Button primitive を含む shadcn/ui 最小基盤を追加した（#2011）。
 - `chore(distrokid-helper)`: Tailwind CSS 4 の Vite plugin 構成へ移行し、`@/*` alias、CSS variable theme、`cn` utility、Button primitive を含む shadcn/ui 最小基盤を追加した（#2012）。

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -423,9 +423,7 @@ export function useSunoRunner(): RunnerState {
   }, []);
 
   const clearLoadedRunState = useCallback(() => {
-    setEntries([]);
     setDurationFilter(undefined);
-    setItemStates([]);
     setPhase("idle");
     setRestoredCollectionId(undefined);
     setRestoredPlaylistName(undefined);
@@ -505,6 +503,7 @@ export function useSunoRunner(): RunnerState {
     async (targetUrl: string, preferredCollectionId: string) => {
       const requestId = ++fetchRequestIdRef.current;
       const isLatestRequest = (): boolean => requestId === fetchRequestIdRef.current;
+      const isRestoreFetch = (): boolean => restoredProgressRef.current || resumableCollectionId !== undefined;
       const trimmed = targetUrl.trim();
       if (!trimmed) {
         if (isLatestRequest()) {
@@ -520,7 +519,6 @@ export function useSunoRunner(): RunnerState {
           return;
         }
         baseUrl = info.base_url;
-        setUrlState(baseUrl);
         serverLabel = info.label;
       } catch {
         // 古い server は fetchServerInfo を提供しないため、入力 URL のまま継続する。
@@ -532,11 +530,11 @@ export function useSunoRunner(): RunnerState {
         if (!isLatestRequest()) {
           return;
         }
-        await serverUrlItem.setValue(baseUrl);
+        await serverUrlItem.setValue(trimmed);
         if (!isLatestRequest()) {
           return;
         }
-        const rememberedSources = await rememberServerSource(baseUrl, serverLabel);
+        const rememberedSources = await rememberServerSource(trimmed, serverLabel);
         if (!isLatestRequest()) {
           return;
         }
@@ -584,18 +582,23 @@ export function useSunoRunner(): RunnerState {
         if (!isLatestRequest()) {
           return;
         }
-        setAllCollections(fetched);
         const { nextSelectedId: collectionId } = resolveVisibleCollections(fetched, preferredCollectionId);
         if (collectionId === null) {
           throw new Error("prompts を取得できる collection がありません。");
         }
-        if (!restoredProgressRef.current) {
+        if (isRestoreFetch()) {
+          setAllCollections(fetched);
           setSelectedCollectionId(collectionId);
         }
         const data = await fetchCollectionPromptResponse(baseUrl, collectionId);
-        if (!isLatestRequest() || restoredProgressRef.current) {
+        if (!isLatestRequest()) {
           return;
         }
+        setAllCollections(fetched);
+        if (restoredProgressRef.current) {
+          return;
+        }
+        setSelectedCollectionId(collectionId);
         setEntries(data.entries);
         setDurationFilter(data.duration_filter);
         setItemStates(data.entries.map(() => "idle"));
@@ -606,13 +609,11 @@ export function useSunoRunner(): RunnerState {
           return;
         }
         const message = err instanceof Error ? err.message : String(err);
-        setEntries([]);
-        setItemStates([]);
         setPhase("error");
         report(`取得失敗: ${message}\nyt-collection-serve が起動しているか確認してください。`, true);
       }
     },
-    [report, reportStorageFailure, resolveVisibleCollections],
+    [report, reportStorageFailure, resolveVisibleCollections, resumableCollectionId],
   );
 
   const updateUrl = useCallback(
@@ -621,14 +622,13 @@ export function useSunoRunner(): RunnerState {
       setUrlState(nextUrl);
       restoredProgressRef.current = false;
       clearLoadedRunState();
-      void fetchData(nextUrl, "");
+      void fetchData(nextUrl, selectedCollectionId);
     },
-    [clearLoadedRunState, fetchData],
+    [clearLoadedRunState, fetchData, selectedCollectionId],
   );
 
   const selectCollection = useCallback(
     (id: string) => {
-      setSelectedCollectionId(id);
       restoredProgressRef.current = false;
       clearLoadedRunState();
       void fetchData(url, id);

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -2267,6 +2267,54 @@ describe("Suno popup compatibility check", () => {
     });
   });
 
+  it("配信元の一時失敗では明示した配信元と collection の表示を保持する", async () => {
+    const collections = [
+      {
+        id: "20260601-clm-theme-a-collection",
+        name: "theme-a-collection",
+        status: "ready",
+        pattern_count: 1,
+        downloaded_count: 0,
+      },
+    ];
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockResolvedValueOnce(jsonResponse(200, collections))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "initial", style: "lofi", lyrics: "" }]))
+      .mockResolvedValueOnce(jsonResponse(200, { version: "5.5.7", min_extension_version: MANIFEST_VERSION }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    serverSourcesMocks.rememberServerSource.mockResolvedValue([
+      { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+      { id: "localhost-7877", label: "localhost fallback 7877", url: FALLBACK_URL },
+    ]);
+    messagingMocks.sendMessage.mockImplementation((message: string, payload?: Record<string, string>) => {
+      if (message === "fetchServerInfo" && payload?.baseUrl === FALLBACK_URL) {
+        return Promise.resolve({ base_url: "http://127.0.0.1:7877", label: "fallback" });
+      }
+      return defaultSendMessage(message, payload);
+    });
+
+    await act(async () => {
+      setSelectValue(expectControl(container, "server-url") as HTMLSelectElement, BASE_URL);
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 パターンを取得しました。");
+    });
+
+    await act(async () => {
+      setSelectValue(expectControl(container, "server-url") as HTMLSelectElement, FALLBACK_URL);
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("取得失敗: Failed to fetch");
+    });
+    expect((expectControl(container, "server-url") as HTMLSelectElement).value).toBe(FALLBACK_URL);
+    expect(container.querySelector<HTMLElement>('[data-suno-helper="control-panel"]')?.dataset.sunoCollectionId).toBe(
+      "20260601-clm-theme-a-collection",
+    );
+    expect(container.textContent).toContain("initial");
+  });
+
   it("連続する配信元変更では遅い旧保存が最新 URL・配信元一覧・entries を上書きしない", async () => {
     const firstSave = deferred<undefined>();
     let saveCount = 0;
@@ -2332,7 +2380,7 @@ describe("Suno popup compatibility check", () => {
     storageMocks.getValue.mockResolvedValue(BASE_URL);
     serverSourcesMocks.readServerSources.mockReturnValueOnce(initialSources.promise);
     serverSourcesMocks.rememberServerSource.mockResolvedValue([
-      { id: "canonical", label: "Canonical source", url: "http://canonical.localhost:7873" },
+      { id: "selected", label: "Selected source", url: BASE_URL },
     ]);
     messagingMocks.sendMessage.mockImplementation((message: string, payload?: Record<string, string>) => {
       if (message === "fetchServerInfo") {
@@ -2371,7 +2419,7 @@ describe("Suno popup compatibility check", () => {
     await waitFor(() => {
       expect(
         Array.from((expectControl(container, "server-url") as HTMLSelectElement).options, (option) => option.value),
-      ).toEqual(["http://canonical.localhost:7873"]);
+      ).toEqual([BASE_URL]);
     });
   });
 


### PR DESCRIPTION
## 概要

- server-info の接続先とユーザーが明示選択した配信元 URL を分離
- collections/prompts の取得が完了するまで collection state の更新を遅延
- transient failure 時は既存 collection・entries を保持し、明示変更の成功経路は従来どおり更新
- 回帰テストと CHANGELOG を追加

Closes #2002

## 検証

- `node .takt/.runtime/tmp/issue-2002-repro.mjs` — GREEN: explicit selections were retained
- `CI=true nix develop .#extensions --command pnpm -C extensions/suno-helper install --frozen-lockfile`
- `pnpm -C extensions/suno-helper lint`（Nix extensions shell）
- `pnpm -C extensions/suno-helper format:check`（Nix extensions shell）
- `pnpm -C extensions/suno-helper compile`（Nix extensions shell）
- `pnpm -C extensions/suno-helper test`（49 files / 1104 tests passed）
- `pnpm -C extensions/suno-helper build`（Nix extensions shell）
- `uv run pytest tests/test_chrome_extensions.py tests/test_extension_package_manager_contract.py tests/test_extension_readme_allow_extension_contract.py tests/test_release_extensions_workflow.py tests/test_verify_extensions_script.py`（47 passed）
- `uv run ruff check .`
- `uv run ruff format --check .`（461 files）
- `lefthook run pre-commit`
- `lefthook run pre-push`
- CHANGELOG / test-diff / Any usage gates green
