### PR TITLE
fix(suno-helper): 実行前にcollection取得を確認する (#2003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 連続実行開始時に collection server の疎通を確認し、無応答時は Lyrics 欄エラーより先に明示的な server エラーで停止するようにした（#2003）。
+
 - `fix(suno-helper)`: server の一時的な取得失敗時に明示選択した配信元と collection を保持する（#2002）
 
 - `fix(collection-serve)`: SIGTERM による予期せぬ停止を専用例外へ変換し、終了理由と traceback が stderr に残るようにした（#2001）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -815,6 +815,19 @@ export default defineContentScript({
       const { range, collectionId, playlistName, submittedClipIds, playlistExpectedClipCount } = options;
       const previousSubmittedClipIds = submittedClipIds ?? [];
       const pacing = BALANCED_RUN_PACING;
+      try {
+        const baseUrl = await serverUrlItem.getValue();
+        await sendMessage("fetchCollectionPromptResponse", { baseUrl, collectionId });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        emitProgress({
+          phase: PHASE.ERROR,
+          index: 0,
+          total: entries.length,
+          message: `collection server から実行対象を取得できません。server が起動し、collection が利用可能か確認してください: ${message}`,
+        });
+        return;
+      }
       // Suno 同時生成キューに積める clip 数の上限（Balanced の並列リクエスト数 × 2 clip）。
       const maxGeneratingClips = pacing.maxInflightRequests * CLIPS_PER_REQUEST;
       const total = entries.length;

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -426,6 +426,8 @@ function makeRunPayload(entries = makePromptEntries(0)): {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  harness.sendMessage.mockReset();
+  harness.sendMessage.mockImplementation(() => undefined);
   vi.stubGlobal("DataTransfer", DataTransferStub);
   vi.stubGlobal("ClipboardEvent", ClipboardEventStub);
   (document as unknown as { execCommand: ReturnType<typeof vi.fn> }).execCommand = vi.fn(() => true);
@@ -843,6 +845,87 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       expect(errorMessage).toContain("UI 言語が日本語になっていないか（英語推奨）");
     });
     expect(harness.feedPollerStop).toHaveBeenCalledOnce();
+  });
+
+  it("Given collection server と Lyrics 欄が同時に利用不能 When run を受ける Then server ERROR を先に出す", async () => {
+    makeViewButton("Grid");
+    makeTextarea(null);
+    harness.sendMessage.mockImplementation((type: string) => {
+      if (type === "fetchCollectionPromptResponse") {
+        return Promise.reject(new Error("fetch failed"));
+      }
+      return undefined;
+    });
+    await loadContentScript();
+
+    expect(
+      getRunHandler()({ data: makeRunPayload([{ name: "missing-lyrics", style: "ambient", lyrics: "lyrics" }]) }),
+    ).toEqual({
+      ok: true,
+    });
+    await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce());
+
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: PHASE.ERROR,
+          message: expect.stringContaining("collection server から実行対象を取得できません"),
+        }),
+      ]),
+    );
+    expect(progressPayloads()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("Lyrics 欄が見つかりません") }),
+      ]),
+    );
+    expect(harness.sendMessage).toHaveBeenCalledWith("fetchCollectionPromptResponse", {
+      baseUrl: "http://localhost:8787",
+      collectionId: "20260601-clm-preflight-collection",
+    });
+  });
+
+  it("Given fetchServerInfo 非対応の旧 server は正常で Lyrics 欄だけがない When run を受ける Then 従来の Lyrics ERROR を出す", async () => {
+    makeViewButton("Grid");
+    makeTextarea(null);
+    harness.sendMessage.mockImplementation((type: string) => {
+      if (type === "fetchServerInfo") {
+        return Promise.reject(new Error("HTTP 404"));
+      }
+      if (type === "fetchCollectionPromptResponse") {
+        return Promise.resolve({ entries: [], duration_filter: { min_sec: 60, max_sec: 300 } });
+      }
+      return undefined;
+    });
+    harness.runEntryWithRetry.mockImplementationOnce(async (options: RunEntryWithRetryOptions) => {
+      try {
+        await options.attempt();
+        return { outcome: "ok" };
+      } catch (error) {
+        return options.isFatal(error) ? { outcome: "fatal", error } : { outcome: "failed", error };
+      }
+    });
+    await loadContentScript();
+
+    expect(
+      getRunHandler()({ data: makeRunPayload([{ name: "missing-lyrics", style: "ambient", lyrics: "lyrics" }]) }),
+    ).toEqual({
+      ok: true,
+    });
+    await vi.waitFor(() => expect(harness.feedPollerStop).toHaveBeenCalledOnce());
+
+    expect(harness.sendMessage).not.toHaveBeenCalledWith("fetchServerInfo", expect.anything());
+    expect(harness.sendMessage).toHaveBeenCalledWith("fetchCollectionPromptResponse", {
+      baseUrl: "http://localhost:8787",
+      collectionId: "20260601-clm-preflight-collection",
+    });
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: PHASE.ERROR,
+          message: expect.stringContaining("Lyrics 欄が見つかりません"),
+        }),
+      ]),
+    );
   });
 
   it("Given Lyrics 欄がなく entry.lyrics が空 When run を受ける Then従来どおり停止せず Generate する", async () => {


### PR DESCRIPTION
## 概要

- 連続実行の開始時に、現在の collection の prompt を server から再取得して疎通を確認
- server / collection fetch 失敗時は Lyrics DOM 探索より先に server エラーで停止
- `fetchServerInfo` 非対応の旧 server でも既存 collection endpoint により互換性を維持
- 両故障、Lyrics 単独故障、旧 server 互換の回帰テストを追加

## 検証

- `pnpm install --frozen-lockfile`
- Prettier / ESLint / TypeScript compile / WXT build
- Vitest: 49 files, 1106 tests
- Playwright: 27 tests
- production bundle deterministic repro
- root pytest: 47 tests
- Ruff check / format: 461 files
- lefthook pre-commit / pre-push

Closes #2003