### PR TITLE
fix: pytest 一時ディレクトリの残骸蓄積を防ぐ (#2072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(test-infra)`: dev shell 統合テストのコピー対象と teardown を最適化し、pytest の成功時 tmp と強制終了された過去 run の fixture 残骸が蓄積しないようにした（#2072）。
+
 - `fix(suno-helper)`: 連続実行開始時に collection server の疎通を確認し、無応答時は Lyrics 欄エラーより先に明示的な server エラーで停止するようにした（#2003）。
 
 - `fix(suno-helper)`: server の一時的な取得失敗時に明示選択した配信元と collection を保持する（#2002）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,5 +154,8 @@ ignore = ["RUF001", "RUF002", "RUF003"]
 # pytest.raises(match=...) の正規表現メタ文字警告はテスト可読性を優先して抑制
 "tests/**" = ["RUF043"]
 
+[tool.pytest.ini_options]
+tmp_path_retention_policy = "failed"
+
 [dependency-groups]
 dev = ["pytest>=9,<10", "ruff>=0.15,<1"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,36 @@ if str(_SRC_DIR) not in sys.path:
 # テスト用フィクスチャディレクトリ（git 管理下のオリジナル）
 _FIXTURE_CHANNEL_DIR = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
 _OP_READ_DISABLED_ENV = "YOUTUBE_AUTOMATION_DISABLE_OP_READ"
+_TEST_TMP_PREFIX = "yt-automation-tests-"
 
 
 os.environ.setdefault(_OP_READ_DISABLED_ENV, "1")
+
+
+def _pid_is_running(pid: int) -> bool:
+    """Return whether a process exists without sending it a signal."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _cleanup_stale_isolated_channel_dirs() -> None:
+    """Remove leftovers from killed pytest runs without touching active runs."""
+    system_tmp = Path(tempfile.gettempdir())
+    for candidate in system_tmp.glob(f"{_TEST_TMP_PREFIX}*"):
+        if not candidate.is_dir() or candidate.is_symlink():
+            continue
+
+        suffix = candidate.name.removeprefix(_TEST_TMP_PREFIX)
+        pid_text, separator, _ = suffix.partition("-")
+        if separator and pid_text.isdigit() and _pid_is_running(int(pid_text)):
+            continue
+
+        shutil.rmtree(candidate, ignore_errors=True)
 
 
 def _prepare_isolated_channel_dir() -> None:
@@ -44,10 +71,12 @@ def _prepare_isolated_channel_dir() -> None:
     既存 env 上書きがあれば尊重する（setdefault 相当）。
     tmp dir は `atexit` で session 終了時に削除する。
     """
+    _cleanup_stale_isolated_channel_dirs()
+
     if os.environ.get("CHANNEL_DIR"):
         return
 
-    tmp_root = Path(tempfile.mkdtemp(prefix="yt-automation-tests-"))
+    tmp_root = Path(tempfile.mkdtemp(prefix=f"{_TEST_TMP_PREFIX}{os.getpid()}-"))
     atexit.register(shutil.rmtree, tmp_root, ignore_errors=True)
 
     isolated = tmp_root / "sample_channel"

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROJECT_COPY_ENTRIES = (
+    ".claude",
+    "LICENSE",
+    "README.md",
+    "auth/client_secrets.template.json",
+    "docs/features.md",
+    "docs/workflow-cheatsheet.md",
+    "flake.nix",
+    "flake.lock",
+    "pyproject.toml",
+    "uv.lock",
+    "src",
+)
+_PROJECT_COPY_IGNORE = shutil.ignore_patterns(".pytest_cache", "__pycache__", "*.pyc")
+_MAX_PROJECT_COPY_BYTES = 10 * 1024 * 1024
 
 
 def _nix_is_available() -> bool:
@@ -41,26 +57,45 @@ def _nix_develop(
     )
 
 
+def _remove_test_tmp(tmp_path: Path) -> None:
+    # uv creates a several-hundred-MB environment beside the project copy. Remove
+    # the whole per-test root ourselves so interrupted retention cleanup cannot
+    # accumulate successful runs. A test intentionally makes one parent read-only.
+    for directory, _, _ in os.walk(tmp_path, topdown=False):
+        directory_path = Path(directory)
+        directory_path.chmod(directory_path.stat().st_mode | stat.S_IRWXU)
+    shutil.rmtree(tmp_path)
+
+
 @pytest.fixture
-def project_copy(tmp_path: Path) -> Path:
+def project_copy(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+    request.addfinalizer(lambda: _remove_test_tmp(tmp_path))
+
     project = tmp_path / "project"
-    shutil.copytree(
-        _REPO_ROOT,
-        project,
-        ignore=shutil.ignore_patterns(".git", ".venv", ".direnv", ".pytest_cache"),
-    )
+    project.mkdir()
+    for entry_name in _PROJECT_COPY_ENTRIES:
+        source = _REPO_ROOT / entry_name
+        destination = project / entry_name
+        if source.is_dir():
+            shutil.copytree(source, destination, ignore=_PROJECT_COPY_IGNORE)
+        else:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+
     return project
 
 
 @pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
 def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(project_copy: Path, tmp_path: Path) -> None:
     environment = tmp_path / "environment"
+    project_copy_size = sum(path.stat().st_size for path in project_copy.rglob("*") if path.is_file())
+    assert project_copy_size < _MAX_PROJECT_COPY_BYTES
 
     first = _nix_develop(
         project_copy,
         environment,
         'test -x "$UV_PROJECT_ENVIRONMENT/bin/pytest"'
-        ' && "$UV_PROJECT_ENVIRONMENT/bin/pytest" --collect-only -q >/dev/null'
+        ' && "$UV_PROJECT_ENVIRONMENT/bin/pytest" --version >/dev/null'
         " && printf shell-entered",
     )
     assert first.returncode == 0, first.stderr


### PR DESCRIPTION
## Summary

- dev shell 統合テストのコピー対象を Nix / uv / editable build に必要な最小資産へ限定し、10 MiB 未満を回帰テストで担保
- fixture finalizer で read-only 権限を復元し、project copy と生成 venv をテストごとに削除
- pytest の成功時 tmp を保持せず、PID 付き CHANNEL_DIR tmp と次回起動時の stale cleanup を追加

## Verification

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest` (5241 passed)

Closes #2072