### PR TITLE
chore(takt): concurrency 5 を恒久設定化

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -4,6 +4,9 @@
 draft_pr: false
 base_branch: main
 
+# 並列実行数（グローバル既定 3 の override）。open issue 一括消化ミッションで実績あり
+concurrency: 5
+
 provider: codex
 persona_providers:
   coder:


### PR DESCRIPTION
## Summary

- `.takt/config.yaml` に `concurrency: 5`（グローバル既定 3 の override）を正式追加

## 背景

7/14 の open issue 一括消化ミッション（Codex セッション）が設定した並列度 5 が未コミット差分のまま main の作業ツリーに残っており、takt worktree 作成のたびに無関係差分として混入 → reviewer のスコープ違反判定（#2075 初回 run の REJECT 理由の 1 つ）や auto-commit 失敗の原因になっていた。実績のある値なので恒久設定として確定する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)