### PR TITLE
[suno-ui] run controlsをshadcnへ移行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `refactor(suno-helper)`: collection・投入方式・開始/停止・resume/retry controls を、既存 handler・disabled 条件・`data-suno-control` / aria 契約を維持したまま shadcn primitive へ移行した（#2067）。
+
 - `feat(distrokid-helper)`: 初回表示、コレクション選択、ローカル配信元選択の各タイミングで collection 一覧と release.json を自動取得し、手動の「データ取得」ボタンを廃止した（#1992）。
 
 - `feat(suno-helper)`: 初回表示、コレクション選択、ローカル配信元選択の各タイミングで collection prompts を自動取得し、手動の「データ取得」ボタンを廃止した（#1991）。

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -10,6 +10,7 @@ import { buildSelectedEntriesRunOverrides } from "../lib/run-overrides";
 import { downloadFormatItem, readDownloadFormat, type DownloadFormat } from "../lib/storage";
 import { PatternList } from "./PatternList";
 import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
+import { Button, ButtonSlot } from "./ui/button";
 import { useSunoRunner } from "./useSunoRunner";
 
 // RUN_MODES のキー集合から導出する（手書き複製だと mode 追加時に UI へ出ないまま型チェックが通る）。
@@ -181,27 +182,28 @@ export function App() {
 
       <label className="flex flex-col gap-1 text-sm">
         コレクション
-        <select
-          value={selectedCollectionId}
-          onChange={(e) => selectCollection(e.target.value)}
-          data-suno-control="collection-select"
-          className="rounded border border-gray-300 px-2 py-1"
-        >
-          {collections.length === 0 && (
-            <option value="" disabled>
-              コレクションなし
-            </option>
-          )}
-          {collections.map((c) => (
-            <option key={c.id} value={c.id} disabled={c.status === "needs_prompts"}>
-              {c.status === "downloaded"
-                ? `${c.name}（完了 ${c.downloaded_count}/${c.expected_file_count ?? (c.pattern_count ?? 0) * 2}）`
-                : c.status === "ready"
-                  ? `${c.name} (${c.pattern_count})`
-                  : `${c.name}（prompts なし）`}
-            </option>
-          ))}
-        </select>
+        <ButtonSlot variant="outline" size="sm" className="w-full justify-between font-normal">
+          <select
+            value={selectedCollectionId}
+            onChange={(e) => selectCollection(e.target.value)}
+            data-suno-control="collection-select"
+          >
+            {collections.length === 0 && (
+              <option value="" disabled>
+                コレクションなし
+              </option>
+            )}
+            {collections.map((c) => (
+              <option key={c.id} value={c.id} disabled={c.status === "needs_prompts"}>
+                {c.status === "downloaded"
+                  ? `${c.name}（完了 ${c.downloaded_count}/${c.expected_file_count ?? (c.pattern_count ?? 0) * 2}）`
+                  : c.status === "ready"
+                    ? `${c.name} (${c.pattern_count})`
+                    : `${c.name}（prompts なし）`}
+              </option>
+            ))}
+          </select>
+        </ButtonSlot>
       </label>
 
       {playlistName && (
@@ -217,22 +219,18 @@ export function App() {
             <span className="font-semibold">{visibleResumeBanner.failedIndex + 1}</span> から再開しますか？
           </p>
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={acceptResume}
-              data-suno-control="resume"
-              className="rounded bg-amber-600 px-2 py-1 text-white hover:bg-amber-500"
-            >
+            <Button type="button" onClick={acceptResume} data-suno-control="resume" size="sm">
               再開
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={dismissResume}
               data-suno-control="dismiss-resume"
-              className="rounded border border-amber-400 px-2 py-1 hover:bg-amber-100"
+              variant="outline"
+              size="sm"
             >
               閉じる
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -250,13 +248,9 @@ export function App() {
             失敗してスキップされた entry:{" "}
             <span className="font-semibold">{failedEntries.map((i) => i + 1).join(", ")}</span>
           </p>
-          <button
-            type="button"
-            onClick={rerunFailed}
-            className="self-start rounded bg-red-600 px-2 py-1 text-white hover:bg-red-500"
-          >
+          <Button type="button" onClick={rerunFailed} variant="destructive" size="sm" className="self-start">
             失敗分のみ再実行
-          </button>
+          </Button>
         </div>
       )}
 
@@ -265,22 +259,29 @@ export function App() {
         {RUN_MODE_ORDER.map((id) => {
           const mode = RUN_MODES[id];
           return (
-            <label key={id} className="flex items-start gap-2">
-              <input
-                type="radio"
-                name="run-mode"
-                className="mt-1"
-                checked={runModeId === id}
-                // 実行中の切替は当該 run に効かないのに保存だけ即時反映され、次回 resume の
-                // モードを無言で変えてしまうため run 中は無効化する (#1586 review)。
-                disabled={isRunning}
-                onChange={() => setRunMode(id)}
-              />
-              <span className="flex flex-col">
-                <span className="font-medium">{mode.label}</span>
-                <span className="text-xs text-gray-500">{mode.riskNote}</span>
-              </span>
-            </label>
+            <ButtonSlot
+              key={id}
+              variant={runModeId === id ? "default" : "outline"}
+              size="sm"
+              className="h-auto w-full justify-start whitespace-normal p-2"
+            >
+              <label className="flex items-start gap-2">
+                <input
+                  type="radio"
+                  name="run-mode"
+                  className="mt-1"
+                  checked={runModeId === id}
+                  // 実行中の切替は当該 run に効かないのに保存だけ即時反映され、次回 resume の
+                  // モードを無言で変えてしまうため run 中は無効化する (#1586 review)。
+                  disabled={isRunning}
+                  onChange={() => setRunMode(id)}
+                />
+                <span className="flex flex-col">
+                  <span className="font-medium">{mode.label}</span>
+                  <span className="text-xs text-gray-500">{mode.riskNote}</span>
+                </span>
+              </label>
+            </ButtonSlot>
           );
         })}
       </fieldset>
@@ -319,24 +320,26 @@ export function App() {
       </label>
 
       <div className="flex gap-2">
-        <button
+        <Button
           type="button"
           onClick={runSelectedEntries}
           disabled={!canRunSelectedEntries}
           data-suno-control="run"
-          className="flex-1 rounded bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-500 disabled:opacity-40"
+          size="sm"
+          className="flex-1"
         >
           {runButtonLabel}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
           onClick={() => void stop()}
           disabled={!isRunning}
           data-suno-control="stop"
-          className="rounded bg-red-600 px-2 py-1 text-sm text-white hover:bg-red-500 disabled:opacity-40"
+          variant="destructive"
+          size="sm"
         >
           停止
-        </button>
+        </Button>
       </div>
 
       {!isRunning && selectedCollectionId && (
@@ -351,24 +354,28 @@ export function App() {
           </button>
           <div className="flex gap-2">
             {playlistName && (
-              <button
+              <Button
                 type="button"
                 onClick={() => void retryPlaylist()}
                 data-suno-control="retry-playlist"
-                className="flex-1 rounded border border-amber-500 px-2 py-1 text-xs text-amber-700 hover:bg-amber-50"
+                variant="outline"
+                size="sm"
+                className="flex-1"
               >
                 Playlist から再開
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="button"
               onClick={() => void retryDownload()}
               disabled={!selectedCollectionId}
               data-suno-control="retry-download"
-              className="flex-1 rounded border border-green-500 px-2 py-1 text-xs text-green-700 hover:bg-green-50 disabled:opacity-40"
+              variant="outline"
+              size="sm"
+              className="flex-1"
             >
               Download から再開
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -215,6 +215,12 @@ function expectControl(container: HTMLElement, control: string): HTMLElement {
   return element!;
 }
 
+function expectShadcnControl(element: HTMLElement, variant: "default" | "destructive" | "outline"): void {
+  expect(element.dataset.slot).toBe("button");
+  expect(element.dataset.variant).toBe(variant);
+  expect(element.dataset.size).toBe("sm");
+}
+
 async function waitFor(assertion: () => void): Promise<void> {
   for (let i = 0; i < 20; i += 1) {
     try {
@@ -332,6 +338,24 @@ describe("Suno popup compatibility check", () => {
     expect(container.textContent).not.toContain("Balanced");
     expect(container.textContent).not.toContain("Safe");
     expect(container.querySelector('input[name="speed-preset"]')).toBeNull();
+  });
+
+  it("collection・投入方式・開始/停止 control を shadcn primitive で描画し、実操作要素の契約を維持する", () => {
+    const collectionSelect = expectControl(container, "collection-select");
+    expect(collectionSelect).toBeInstanceOf(HTMLSelectElement);
+    expectShadcnControl(collectionSelect, "outline");
+
+    const serialMode = radioByLabel(container, "安全モード");
+    const queueMode = radioByLabel(container, "高速モード");
+    expect(serialMode.name).toBe("run-mode");
+    expect(serialMode.checked).toBe(true);
+    expect(queueMode.name).toBe("run-mode");
+    expect(queueMode.checked).toBe(false);
+    expectShadcnControl(serialMode.closest<HTMLElement>('[data-slot="button"]')!, "default");
+    expectShadcnControl(queueMode.closest<HTMLElement>('[data-slot="button"]')!, "outline");
+
+    expectShadcnControl(expectControl(container, "run"), "default");
+    expectShadcnControl(expectControl(container, "stop"), "destructive");
   });
 
   it("progress handler が DONE + duration-check log を受けると live status を更新する", async () => {
@@ -666,6 +690,8 @@ describe("Suno popup compatibility check", () => {
       radioByLabel(container, "高速モード").click();
     });
     expect(presetStateMocks.writeRunModeId).toHaveBeenCalledWith("queue");
+    expectShadcnControl(radioByLabel(container, "安全モード").closest<HTMLElement>('[data-slot="button"]')!, "outline");
+    expectShadcnControl(radioByLabel(container, "高速モード").closest<HTMLElement>('[data-slot="button"]')!, "default");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {
@@ -816,6 +842,7 @@ describe("Suno popup compatibility check", () => {
     await waitFor(() => {
       expect(buttonByText(container, "失敗分のみ再実行")).toBeTruthy();
     });
+    expectShadcnControl(buttonByText(container, "失敗分のみ再実行"), "destructive");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {
@@ -1496,6 +1523,8 @@ describe("Suno popup compatibility check", () => {
     await waitFor(() => {
       expect(container.textContent).toContain("選択中の曲 2 件を採用しました。");
     });
+    expectShadcnControl(expectControl(container, "retry-playlist"), "outline");
+    expectShadcnControl(expectControl(container, "retry-download"), "outline");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {
@@ -2026,8 +2055,8 @@ describe("Suno popup compatibility check", () => {
       expect(container.textContent).toContain("前回の実行が中断されました。");
       expect(container.textContent).toContain("取得失敗:");
     });
-    expectControl(container, "resume");
-    expectControl(container, "dismiss-resume");
+    expectShadcnControl(expectControl(container, "resume"), "default");
+    expectShadcnControl(expectControl(container, "dismiss-resume"), "outline");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {


### PR DESCRIPTION
## Summary
- collection/mode 選択と start/stop/resume/retry controls を shadcn primitive へ移行
- 既存の handler、disabled、data-suno、aria 契約を維持

## Validation
- unit / compile / lint / format / build: pass
- local E2E: macOS sandbox の Chromium 起動制限で未実行（GitHub CI で確認）

Closes #2067