### PR TITLE
feat(doctor): check Reporting API job setup

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -28,7 +28,7 @@ description: "Use when ツール導入と GCP / OAuth の API 設定をセット
 | カテゴリ | 内容 |
 |---------|------|
 | `bootstrap` | ffmpeg / ffprobe / uv / pyproject.toml / automation パッケージ / `yt-skills sync` / 番号付き重複ファイル検知（7 check） |
-| `api` | gcloud CLI・GCP プロジェクト・Billing・APIs・ADC・IAM・.env・OAuth 認証（11 check） |
+| `api` | gcloud CLI・GCP プロジェクト・Billing・APIs・ADC・IAM・.env・OAuth 認証・Reporting API ジョブ（12 check） |
 | `channel` | config/channel/ のロード可能性・playlists.json の妥当性・playlist 作成 dry-run（3 check: `channel_config` / `playlist_config` / `playlist_create_dry_run`）。fail 時は `/channel-new`（新規開設 / 既存チャンネル取り込み / 再生成モード）を案内するだけ |
 | `data` | `/wf-new` の入力モード判定データ + 初期セットアップ事前検査（analytics_report / benchmark_data / ttp_wf_new_readiness / initial_setup_readiness）。minimal mode / benchmark fallback mode は setup のブロッカーにしない。analytics report は最新 `data/analytics_data_*.json` との相対比較に加え、`collection-ideate` の解決済み `freshness_days` を超えた絶対鮮度 stale も検出する。承認済み TTP がある場合だけ `/channel-new`（再生成モード） benchmark 反映完了を確認する |
 | `upload` | upload 必須 scope 充足・channel_id 設定済み（1 check） |
@@ -321,6 +321,16 @@ uv run yt-channel-status
 ```
 
 初回はブラウザが開いて認証が走る。完了すると `<channel_dir>/auth/token.json` が生成される。
+
+#### `reporting_job` — Reporting API ジョブ未作成
+
+`yt-doctor` の `next_action.cmd` をそのまま Bash で実行する:
+
+```bash
+uv run yt-analytics --reporting-create-job
+```
+
+コマンドは冪等で、既存ジョブがあれば再利用する。実行後に `uv run yt-doctor --json` を再実行し、`reporting_job` が `ok` になったことを確認してから次の `next_check_id` へ進む。
 
 ### channel カテゴリ
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(doctor,setup)`: `yt-doctor` の api カテゴリに `reporting_job` check を追加し、OAuth 済み環境で YouTube Reporting API ジョブ未作成を検出して `uv run yt-analytics --reporting-create-job` を案内するようにした。`/setup` wizard はコマンド実行後に doctor を再診断し、ジョブ作成済みを確認する（#1974）。
+
 - `refactor(distrokid-helper)`: popup のローカル配信元・collection/disc selector を shadcn theme token に揃え、フォーム一括入力・停止操作を Button primitive へ移行した。既存の value・handler・disabled・accessible name と runner action は維持する（#2065）。
 
 - `docs(collection-ideate)`: stale な Analytics report を検出した際、相対 stale は `/analytics-analyze`、絶対 stale は `/analytics-collect` → `/analytics-analyze` を自動実行し、再検証成功後に同じ企画フローを継続する契約へ更新した。更新失敗時は stale report を使わず、理由と再開条件を示して停止する（#2062）。

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -20,6 +20,10 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from httplib2 import HttpLib2Error
 from PIL import Image as PILImage
 from PIL import UnidentifiedImageError
 
@@ -27,7 +31,7 @@ from youtube_automation.auth.oauth_handler import resolve_client_secrets_locatio
 from youtube_automation.cli.automation_update_refs import UPSTREAM_REPO
 from youtube_automation.cli.skills_sync import bundled_skill_names
 from youtube_automation.scripts.benchmark_collector import load_benchmark_videos, select_top_vod_benchmark_videos
-from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.exceptions import AutomationError, ConfigError, YouTubeAPIError
 from youtube_automation.utils.numbered_duplicates import (
     CLEANUP_GUIDE_URL,
     format_duplicate_name,
@@ -39,6 +43,7 @@ from youtube_automation.utils.preflight_checks import (
     check_suno_genre_line_char_limit,
     check_thumbnail_skill_config,
 )
+from youtube_automation.utils.reporting_api import ReportingAPIClient
 from youtube_automation.utils.skill_config import load_skill_config
 from youtube_automation.utils.thumbnail_references import resolve_configured_benchmark_references
 
@@ -920,6 +925,71 @@ def check_oauth_token(channel_dir: Path) -> CheckResult:
         id="oauth_token",
         status="ok",
         message=f"token.json 存在 (scopes: {len(scopes)} 件)",
+    )
+
+
+def check_reporting_job(channel_dir: Path) -> CheckResult:
+    oauth_result = check_oauth_token(channel_dir)
+    if oauth_result.status != "ok":
+        return CheckResult(
+            id="reporting_job",
+            status="unknown",
+            message="OAuth トークン未取得または不正のためスキップ",
+        )
+
+    token_path = channel_dir / "auth" / "token.json"
+    try:
+        credentials = Credentials.from_authorized_user_file(str(token_path))
+    except (OSError, ValueError) as error:
+        return CheckResult(
+            id="reporting_job",
+            status="fail",
+            message=f"Reporting API ジョブ確認失敗: OAuth トークンが不正です: {error}",
+        )
+
+    if not credentials.valid:
+        state = "期限切れ" if credentials.expired else "不正"
+        return CheckResult(
+            id="reporting_job",
+            status="fail",
+            message=f"Reporting API ジョブ確認失敗: OAuth トークンが{state}です。再認証してください",
+        )
+
+    try:
+        with _temporary_channel_dir(channel_dir), redirect_stdout(io.StringIO()):
+            service = build("youtubereporting", "v1", credentials=credentials)
+            client = ReportingAPIClient(service)
+            report_type_id = client.select_report_type()
+            existing_job = client.find_existing_job(report_type_id)
+    except HttpError as error:
+        api_error = YouTubeAPIError.from_http_error(error, "reporting:jobs.list")
+        return CheckResult(
+            id="reporting_job",
+            status="fail",
+            message=f"Reporting API ジョブ確認失敗: {api_error}",
+        )
+    except (AutomationError, FileNotFoundError, HttpLib2Error, OSError) as error:
+        return CheckResult(
+            id="reporting_job",
+            status="fail",
+            message=f"Reporting API ジョブ確認失敗: {error}",
+        )
+
+    if existing_job is None:
+        return CheckResult(
+            id="reporting_job",
+            status="fail",
+            message="Reporting API ジョブが未作成",
+            next_action={
+                "kind": "ai-exec",
+                "cmd": "uv run yt-analytics --reporting-create-job",
+            },
+        )
+
+    return CheckResult(
+        id="reporting_job",
+        status="ok",
+        message=f"Reporting API ジョブ作成済み (jobId: {existing_job['id']})",
     )
 
 
@@ -2519,6 +2589,7 @@ def run_all_checks(channel_dir: Path) -> list[CheckResult]:
         check_env_file(channel_dir),
         check_client_secrets(channel_dir),
         check_oauth_token(channel_dir),
+        check_reporting_job(channel_dir),
         check_channel_config(channel_dir),
         check_playlist_config(channel_dir),
         check_playlist_create_dry_run(channel_dir),

--- a/src/youtube_automation/utils/reporting_api.py
+++ b/src/youtube_automation/utils/reporting_api.py
@@ -164,6 +164,22 @@ class ReportingAPIClient:
     # ------------------------------------------------------------------
     # ジョブ管理（冪等化）
     # ------------------------------------------------------------------
+    def find_existing_job(self, report_type_id: str) -> dict[str, object] | None:
+        """`reportTypeId + name` が作成対象と一致する既存ジョブを返す。"""
+        try:
+            existing = self._service.jobs().list().execute()
+        except HttpError as e:
+            raise YouTubeAPIError.from_http_error(e, "reporting:jobs.list") from e
+
+        return next(
+            (
+                job
+                for job in existing.get("jobs", [])
+                if job.get("reportTypeId") == report_type_id and job.get("name") == self.JOB_NAME
+            ),
+            None,
+        )
+
     def ensure_job(self, report_type_id: str) -> str:
         """`reportTypeId + name` 一致のジョブを再利用、無ければ create。
 
@@ -176,15 +192,10 @@ class ReportingAPIClient:
         Raises:
             YouTubeAPIError: API 呼び出し失敗
         """
-        try:
-            existing = self._service.jobs().list().execute()
-        except HttpError as e:
-            raise YouTubeAPIError.from_http_error(e, "reporting:jobs.list") from e
-
-        for job in existing.get("jobs", []):
-            if job.get("reportTypeId") == report_type_id and job.get("name") == self.JOB_NAME:
-                logger.info(f"Reporting API: 既存ジョブを再利用 jobId={job['id']}")
-                return job["id"]
+        existing_job = self.find_existing_job(report_type_id)
+        if existing_job is not None:
+            logger.info(f"Reporting API: 既存ジョブを再利用 jobId={existing_job['id']}")
+            return existing_job["id"]
 
         try:
             created = (

--- a/tests/test_analytics_system.py
+++ b/tests/test_analytics_system.py
@@ -199,6 +199,18 @@ class TestCollectAnalyticsData:
         result = system.collect_analytics_data(days=14, save_data=False)
         assert result == expected_data
 
+    def test_include_reporting_keeps_csv_summary_in_analytics_data(self, system):
+        """--include-reporting 相当の経路は Reporting API 集計結果を保持する."""
+        system.authenticated = True
+        system.collector.collect_basic_analytics.return_value = {"views": 500}
+        summary = {"aggregated_impressions": 1200, "aggregated_ctr_percentage": 4.2}
+        system.collector.get_reporting_impressions_summary.return_value = summary
+
+        result = system.collect_analytics_data(days=14, save_data=False, include_reporting=True)
+
+        assert result["reporting_api"] == {"impressions_summary": summary}
+        system.collector.get_reporting_impressions_summary.assert_called_once_with(days=14)
+
     def test_collector_domain_exception(self, system):
         """ドメイン例外（YouTubeAPIError）発生時に None を返す"""
         system.authenticated = True
@@ -316,3 +328,40 @@ class TestRunDataCollection:
             ):
                 with pytest.raises(RuntimeError, match="Network error"):
                     system.run_data_collection(days=30)
+
+
+class TestReportingSubmodes:
+    def test_dry_run_only_observes_reporting_state(self, monkeypatch, capsys):
+        from youtube_automation.scripts import analytics_system
+
+        client = MagicMock()
+        client.dry_run_inspection.return_value = {
+            "selected_report_type": "channel_reach_basic_a1",
+            "existing_job": {"id": "job-1"},
+            "recent_reports_count": 2,
+        }
+        monkeypatch.setattr(analytics_system, "_make_reporting_client", lambda: client)
+
+        code = analytics_system._run_reporting_dry_run()
+
+        assert code == 0
+        client.dry_run_inspection.assert_called_once_with()
+        client.select_report_type.assert_not_called()
+        client.ensure_job.assert_not_called()
+        assert "job-1" in capsys.readouterr().out
+
+    def test_create_job_remains_idempotent_and_reports_backfill_contract(self, monkeypatch, capsys):
+        from youtube_automation.scripts import analytics_system
+
+        client = MagicMock()
+        client.select_report_type.return_value = "channel_reach_basic_a1"
+        client.ensure_job.return_value = "job-1"
+        monkeypatch.setattr(analytics_system, "_make_reporting_client", lambda: client)
+
+        code = analytics_system._run_reporting_create_job()
+
+        assert code == 0
+        client.ensure_job.assert_called_once_with("channel_reach_basic_a1")
+        output = capsys.readouterr().out
+        assert "過去 30 日分が backfill" in output
+        assert "日次（D+2）" in output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -6,9 +6,13 @@ import json
 import os
 import re
 import shutil
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import ServerNotFoundError
 from PIL import Image as PILImage
 
 from youtube_automation.cli import doctor
@@ -587,6 +591,190 @@ class TestOAuthToken:
         assert r.status == "ok"
 
 
+class TestReportingJob:
+    @staticmethod
+    def _write_token(channel_dir: Path, *, expiry: datetime | None = None) -> None:
+        auth = channel_dir / "auth"
+        auth.mkdir()
+        token = {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": ["youtube.readonly"],
+            "expiry": (expiry or datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        }
+        (auth / "token.json").write_text(json.dumps(token), encoding="utf-8")
+
+    @staticmethod
+    def _reporting_service(*, jobs: list[dict] | None = None) -> MagicMock:
+        service = MagicMock()
+        service.reportTypes.return_value.list.return_value.execute.return_value = {
+            "reportTypes": [{"id": "channel_reach_basic_a1"}]
+        }
+        service.jobs.return_value.list.return_value.execute.return_value = {"jobs": jobs or []}
+        return service
+
+    @staticmethod
+    def _json_check(monkeypatch, tmp_path: Path, capsys) -> dict:
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        code = doctor.main(["--json", "--target", str(tmp_path)])
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        return next(check for check in payload["checks"] if check["id"] == "reporting_job")
+
+    def test_json_reports_missing_job_with_creation_command(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        service = self._reporting_service()
+        monkeypatch.setattr(doctor, "build", lambda *args, **kwargs: service)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert check["category"] == "api"
+        assert check["next_action"] == {
+            "kind": "ai-exec",
+            "cmd": "uv run yt-analytics --reporting-create-job",
+        }
+
+    def test_json_reports_existing_job_as_ok(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        service = self._reporting_service(
+            jobs=[
+                {
+                    "id": "job-1",
+                    "reportTypeId": "channel_reach_basic_a1",
+                    "name": "yt-automation",
+                }
+            ]
+        )
+        monkeypatch.setattr(doctor, "build", lambda *args, **kwargs: service)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "ok"
+        assert "1" in check["message"]
+
+    def test_json_reports_unrelated_job_as_missing(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        service = self._reporting_service(
+            jobs=[
+                {
+                    "id": "job-unrelated",
+                    "reportTypeId": "channel_demographics_a1",
+                    "name": "other",
+                }
+            ]
+        )
+        monkeypatch.setattr(doctor, "build", lambda *args, **kwargs: service)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert check["next_action"]["cmd"] == "uv run yt-analytics --reporting-create-job"
+
+    def test_missing_oauth_token_skips_reporting_api_after_oauth_check(self, monkeypatch, tmp_path, capsys):
+        def unexpected_reporting_call(*args, **kwargs):
+            raise AssertionError("Reporting API must not be called without an OAuth token")
+
+        monkeypatch.setattr(doctor, "build", unexpected_reporting_call)
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+
+        code = doctor.main(["--json", "--target", str(tmp_path)])
+
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        checks = payload["checks"]
+        oauth_index = next(i for i, check in enumerate(checks) if check["id"] == "oauth_token")
+        reporting_index = next(i for i, check in enumerate(checks) if check["id"] == "reporting_job")
+        assert oauth_index < reporting_index
+        assert checks[oauth_index]["status"] == "fail"
+        assert checks[reporting_index]["status"] == "unknown"
+        assert "OAuth" in checks[reporting_index]["message"]
+
+    def test_json_reports_reporting_api_error_without_crashing(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        service = self._reporting_service()
+        response = MagicMock(status=403, reason="Forbidden")
+        service.reportTypes.return_value.list.return_value.execute.side_effect = HttpError(
+            response,
+            b'{"error":{"message":"permission denied"}}',
+        )
+        monkeypatch.setattr(doctor, "build", lambda *args, **kwargs: service)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert "permission denied" in check["message"]
+
+    def test_json_reports_reporting_network_error_without_crashing(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        service = self._reporting_service()
+        service.reportTypes.return_value.list.return_value.execute.side_effect = ServerNotFoundError(
+            "network unavailable"
+        )
+        monkeypatch.setattr(doctor, "build", lambda *args, **kwargs: service)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert "network unavailable" in check["message"]
+
+    def test_target_channel_dir_is_used_for_reporting_auth_and_restored(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path)
+        original_channel_dir = tmp_path / "original"
+        monkeypatch.setenv("CHANNEL_DIR", str(original_channel_dir))
+        service = self._reporting_service(
+            jobs=[
+                {
+                    "id": "job-1",
+                    "reportTypeId": "channel_reach_basic_a1",
+                    "name": "yt-automation",
+                }
+            ]
+        )
+
+        def reporting_for_target(*args, **kwargs):
+            assert os.environ["CHANNEL_DIR"] == str(tmp_path)
+            return service
+
+        monkeypatch.setattr(doctor, "build", reporting_for_target)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "ok"
+        assert os.environ["CHANNEL_DIR"] == str(original_channel_dir)
+
+    def test_expired_token_is_reported_without_refresh_or_browser_auth(self, monkeypatch, tmp_path, capsys):
+        self._write_token(tmp_path, expiry=datetime.now(timezone.utc) - timedelta(hours=1))
+
+        def unexpected_reporting_call(*args, **kwargs):
+            raise AssertionError("expired credentials must not reach Reporting API")
+
+        monkeypatch.setattr(doctor, "build", unexpected_reporting_call)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert "期限切れ" in check["message"]
+
+    def test_invalid_token_is_reported_without_browser_auth(self, monkeypatch, tmp_path, capsys):
+        auth = tmp_path / "auth"
+        auth.mkdir()
+        (auth / "token.json").write_text(json.dumps({"scopes": ["youtube.readonly"]}), encoding="utf-8")
+
+        def unexpected_reporting_call(*args, **kwargs):
+            raise AssertionError("invalid credentials must not reach Reporting API")
+
+        monkeypatch.setattr(doctor, "build", unexpected_reporting_call)
+
+        check = self._json_check(monkeypatch, tmp_path, capsys)
+
+        assert check["status"] == "fail"
+        assert "不正" in check["message"]
+
+
 class TestSummarize:
     def test_next_check_id(self):
         results = [
@@ -650,8 +838,8 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 7 bootstrap + 11 api + 3 channel + 4 data + 1 upload = 26
-        assert len(payload["checks"]) == 26
+        # 7 bootstrap + 12 api + 3 channel + 4 data + 1 upload = 27
+        assert len(payload["checks"]) == 27
         for c in payload["checks"]:
             assert c["status"] in ("ok", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
@@ -3840,18 +4028,19 @@ class TestCheckNumberedDuplicates:
 
 
 class TestRunAllChecksExtended:
-    def test_returns_26_checks(self, monkeypatch, tmp_path):
-        """7 bootstrap + 11 api + 3 channel + 4 data + 1 upload = 計 26 件."""
+    def test_returns_27_checks(self, monkeypatch, tmp_path):
+        """7 bootstrap + 12 api + 3 channel + 4 data + 1 upload = 計 27 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 26
+        assert len(results) == 27
 
-    def test_existing_11_api_checks_present(self, monkeypatch, tmp_path):
-        """既存 11 check が全て api カテゴリで含まれている."""
+    def test_12_api_checks_present(self, monkeypatch, tmp_path):
+        """reporting_job を含む 12 check が api カテゴリで含まれている."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         api_results = [r for r in results if r.category == "api"]
-        assert len(api_results) == 11
+        assert len(api_results) == 12
+        assert api_results[-1].id == "reporting_job"
 
     def test_new_check_ids_present(self, monkeypatch, tmp_path):
         """bootstrap / channel / data / upload の check が含まれる."""
@@ -3870,6 +4059,7 @@ class TestRunAllChecksExtended:
         assert "ttp_wf_new_readiness" in ids
         assert "initial_setup_readiness" in ids
         assert "upload_ready" in ids
+        assert "reporting_job" in ids
 
     def test_category_order_bootstrap_then_api_then_channel_then_data_then_upload(self, monkeypatch, tmp_path):
         """runway 順序: bootstrap → api → channel → data → upload."""

--- a/tests/test_doctor_system_checks.py
+++ b/tests/test_doctor_system_checks.py
@@ -127,11 +127,11 @@ class TestRunAllChecksWithBootstrap:
         bootstrap_results = [r for r in results if r.category == "bootstrap"]
         assert len(bootstrap_results) == 7
 
-    def test_total_checks_is_26(self, monkeypatch, tmp_path):
-        """7 bootstrap + 11 api + 3 channel + 4 data + 1 upload = 計 26 件."""
+    def test_total_checks_is_27(self, monkeypatch, tmp_path):
+        """7 bootstrap + 12 api + 3 channel + 4 data + 1 upload = 計 27 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 26
+        assert len(results) == 27
 
     def test_bootstrap_before_api(self, monkeypatch, tmp_path):
         """bootstrap カテゴリは api カテゴリより前に配置される."""

--- a/tests/test_setup_skill.py
+++ b/tests/test_setup_skill.py
@@ -75,6 +75,18 @@ def test_setup_skill_follows_skills_synced_next_action_contract() -> None:
     assert "`.agents/skills` が `.claude/skills` を指す symlink" in text
 
 
+def test_setup_skill_handles_reporting_job_next_action_and_rechecks() -> None:
+    text = _SETUP_SKILL.read_text(encoding="utf-8")
+    assert "#### `reporting_job`" in text
+    assert "next_action.cmd" in text
+    assert "uv run yt-analytics --reporting-create-job" in text
+    reporting_step = text.index("#### `reporting_job`")
+    next_step = text.find("\n#### `", reporting_step + 1)
+    section = text[reporting_step : next_step if next_step != -1 else None]
+    assert "uv run yt-doctor --json" in section
+    assert "`reporting_job` が `ok`" in section
+
+
 def test_setup_skill_delegates_minimum_directory_generation_to_setup() -> None:
     text = _SETUP_SKILL.read_text(encoding="utf-8")
     assert "`/setup` は `uv run yt-setup-dirs`" in text


### PR DESCRIPTION
## Summary

- add a read-only `reporting_job` check to `yt-doctor`
- reuse the Reporting API job identity contract used by job creation
- document the setup wizard remediation flow and add regression coverage

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q` (5,332 passed)

Closes #1974