### PR TITLE
perf(test-infra): テスト中の実時間 sleep を排除（retry backoff / delay_between_replies）(#2091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `perf(test-infra)`: `utils/retry.py` にモジュールスコープの sleep/jitter シーム（`_DEFAULT_SLEEP` / `_DEFAULT_JITTER`）を追加し、`execute_with_retry` にも後方互換の optional `sleep` / `jitter` 引数を貫通させた。テスト側は `no_retry_backoff` fixture と `CommentReplier` への `sleep_fn` 注入で retry backoff / `delay_between_replies_sec` の実時間 sleep（計 ~33s）を排除した（#2091）。
+
 - `feat(doctor,setup)`: `yt-doctor` の api カテゴリに `reporting_job` check を追加し、OAuth 済み環境で YouTube Reporting API ジョブ未作成を検出して `uv run yt-analytics --reporting-create-job` を案内するようにした。`/setup` wizard はコマンド実行後に doctor を再診断し、ジョブ作成済みを確認する（#1974）。
 
 - `refactor(distrokid-helper)`: popup のローカル配信元・collection/disc selector を shadcn theme token に揃え、フォーム一括入力・停止操作を Button primitive へ移行した。既存の value・handler・disabled・accessible name と runner action は維持する（#2065）。

--- a/src/youtube_automation/utils/retry.py
+++ b/src/youtube_automation/utils/retry.py
@@ -22,6 +22,11 @@ class ExecutableRequest(Protocol[T]):
 
 
 _MAX_ATTEMPTS = 3
+
+# テストから monkeypatch で差し替えられるモジュールスコープのシーム
+# （time.sleep / random.uniform をグローバルに patch せず retry 経路だけ無効化できる）
+_DEFAULT_SLEEP: Callable[[float], None] = time.sleep
+_DEFAULT_JITTER: Callable[[float, float], float] = random.uniform
 _QUOTA_REASONS = {
     "dailyLimitExceeded",
     "quotaExceeded",
@@ -47,8 +52,8 @@ def retry_youtube_api(
     jitter: Callable[[float, float], float] | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Retry transient Google API failures and expose failures as domain errors."""
-    sleep = sleep or time.sleep
-    jitter = jitter or random.uniform
+    sleep = sleep or _DEFAULT_SLEEP
+    jitter = jitter or _DEFAULT_JITTER
 
     def decorate(operation: Callable[P, T]) -> Callable[P, T]:
         @wraps(operation)
@@ -73,7 +78,13 @@ def retry_youtube_api(
     return decorate
 
 
-def execute_with_retry(request: ExecutableRequest[T], context: str) -> T:
+def execute_with_retry(
+    request: ExecutableRequest[T],
+    context: str,
+    *,
+    sleep: Callable[[float], None] | None = None,
+    jitter: Callable[[float, float], float] | None = None,
+) -> T:
     """Execute one Google API request through the shared retry boundary."""
 
-    return retry_youtube_api(context)(request.execute)()
+    return retry_youtube_api(context, sleep=sleep, jitter=jitter)(request.execute)()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,3 +95,17 @@ def _reset_config_singleton():
     reset_config()
     yield
     reset_config()
+
+
+@pytest.fixture
+def no_retry_backoff(monkeypatch):
+    """retry backoff の実 sleep を無効化する。
+
+    `execute_with_retry` / `retry_youtube_api` のリトライ経路を通るテストで
+    実 backoff（attempt 毎に数秒）を待たないために使う。`time.sleep` を
+    グローバルに patch せず、retry モジュールのシームだけを差し替える。
+    """
+    from youtube_automation.utils import retry as retry_module
+
+    monkeypatch.setattr(retry_module, "_DEFAULT_SLEEP", lambda _seconds: None)
+    monkeypatch.setattr(retry_module, "_DEFAULT_JITTER", lambda low, _high: low)

--- a/tests/test_benchmark_collector_no_fallback.py
+++ b/tests/test_benchmark_collector_no_fallback.py
@@ -134,7 +134,7 @@ class TestCollectChannelFailures:
         with pytest.raises(YouTubeAPIError, match="UC_MISS"):
             collector.collect_channel({"id": "UC_MISS", "name": "miss", "slug": "miss"}, {})
 
-    def test_wraps_http_error_from_playlist_items(self):
+    def test_wraps_http_error_from_playlist_items(self, no_retry_backoff):
         # Given: playlistItems 取得で HttpError（クォータ超過等）
         youtube = MagicMock()
         youtube.playlistItems.return_value.list.return_value.execute.side_effect = _http_error()
@@ -159,7 +159,7 @@ class TestCollectAllFailures:
         with pytest.raises(ConfigError, match="unknown"):
             collector.collect_all(channel_slug="unknown")
 
-    def test_wraps_http_error_from_channels_list(self):
+    def test_wraps_http_error_from_channels_list(self, no_retry_backoff):
         # Given: channels.list 自体が HttpError
         youtube = MagicMock()
         youtube.channels.return_value.list.return_value.execute.side_effect = _http_error(

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -262,7 +262,9 @@ def test_dry_run_does_not_call_insert(tmp_path):
             ]
         },
     )
-    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    replier = CommentReplier(
+        yt, config=_make_config(), channel_dir=tmp_path, default_language="ja", sleep_fn=lambda _: None
+    )
     plan = replier.run(dry_run=True)
 
     assert len(plan.planned) == 2
@@ -728,6 +730,7 @@ def test_unparseable_timestamp_does_not_apply_owner_replied_skip(
     )
     replier = CommentReplier(
         yt,
+        sleep_fn=lambda _: None,
         config=_make_config(),
         channel_dir=tmp_path,
         default_language="ja",
@@ -856,6 +859,7 @@ def test_unanswered_viewer_reply_remains_candidate(tmp_path):
     )
     replier = CommentReplier(
         yt,
+        sleep_fn=lambda _: None,
         config=_make_config(),
         channel_dir=tmp_path,
         default_language="ja",
@@ -1331,6 +1335,7 @@ def test_max_replies_per_run_caps_planned(tmp_path):
     )
     replier = CommentReplier(
         yt,
+        sleep_fn=lambda _: None,
         config=_make_config(max_replies_per_run=2),
         channel_dir=tmp_path,
         default_language="ja",
@@ -1420,7 +1425,7 @@ def test_comments_disabled_explicit_video_id_is_skipped(tmp_path):
     ]
 
 
-def test_comment_threads_api_error_other_than_comments_disabled_is_raised(tmp_path):
+def test_comment_threads_api_error_other_than_comments_disabled_is_raised(tmp_path, no_retry_backoff):
     err = _make_http_error(403, "Forbidden", "quotaExceeded")
     yt = _mock_youtube(video_ids=["v1"], comments_by_video={"v1": err})
     replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
@@ -1727,7 +1732,9 @@ def test_llm_retry_on_error_then_plans_reply(tmp_path):
     mock_client.models.generate_content.side_effect = [first_error, retry_response]
 
     with patch(_PATCH_GENAI_CLIENT, return_value=mock_client):
-        replier = CommentReplier(yt, config=config, channel_dir=tmp_path, default_language="ja")
+        replier = CommentReplier(
+            yt, config=config, channel_dir=tmp_path, default_language="ja", sleep_fn=lambda _: None
+        )
         plan = replier.run(dry_run=True)
 
     assert len(plan.planned) == 1
@@ -1756,7 +1763,9 @@ def test_llm_skip_on_error_when_fallback_is_skip(tmp_path):
     mock_client.models.generate_content.side_effect = RuntimeError("API 失敗")
 
     with patch(_PATCH_GENAI_CLIENT, return_value=mock_client):
-        replier = CommentReplier(yt, config=config, channel_dir=tmp_path, default_language="ja")
+        replier = CommentReplier(
+            yt, config=config, channel_dir=tmp_path, default_language="ja", sleep_fn=lambda _: None
+        )
         plan = replier.run(dry_run=True)
 
     assert plan.planned == []
@@ -1783,7 +1792,9 @@ def test_llm_retry_failure_is_skipped(tmp_path):
     mock_client.models.generate_content.side_effect = RuntimeError("API 失敗")
 
     with patch(_PATCH_GENAI_CLIENT, return_value=mock_client):
-        replier = CommentReplier(yt, config=config, channel_dir=tmp_path, default_language="ja")
+        replier = CommentReplier(
+            yt, config=config, channel_dir=tmp_path, default_language="ja", sleep_fn=lambda _: None
+        )
         plan = replier.run(dry_run=True)
 
     assert plan.planned == []
@@ -1979,7 +1990,9 @@ def test_preflight_skips_status_check_for_history_recorded_video(tmp_path):
             "fresh": [{"comment_id": "c2", "text": "こんにちは！", "author": "B"}],
         },
     )
-    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+    replier = CommentReplier(
+        yt, config=_make_config(), channel_dir=tmp_path, default_language="ja", sleep_fn=lambda _: None
+    )
     replier.run(dry_run=True)
 
     # status preflight は履歴未記録の "fresh" のみを問い合わせる
@@ -2019,7 +2032,7 @@ def test_fetch_video_status_returns_none_for_missing_video(tmp_path):
     assert result["missing"] is None
 
 
-def test_fetch_video_status_wraps_http_error(tmp_path):
+def test_fetch_video_status_wraps_http_error(tmp_path, no_retry_backoff):
     """status 取得失敗は YouTubeAPIError に変換され、握りつぶされない."""
     from youtube_automation.utils.comments.replier import fetch_video_status
 


### PR DESCRIPTION
## Summary

#2087 の計測で判明した、ユニットテスト中の実時間 sleep（計 ~33s、スイート全体の ~15%）を排除する。

### 変更内容

- **`utils/retry.py`**: モジュールスコープの `_DEFAULT_SLEEP` / `_DEFAULT_JITTER` シームを追加。`time.sleep` / `random.uniform` をグローバルに patch せず retry 経路だけ無効化できる。`execute_with_retry` にも後方互換の optional `sleep` / `jitter` 引数を貫通（全呼び出し元は実行時呼び出しのみで import 時デコレートは無いことを確認済み）
- **`tests/conftest.py`**: `no_retry_backoff` fixture を追加（opt-in。autouse にはせず、真に待つ必要のあるテストを壊さない）
- **`tests/test_comments_replier.py`** / **`tests/test_benchmark_collector_no_fallback.py`**: retry 経路を通る 4 テストに `no_retry_backoff` を適用、`CommentReplier` の `sleep_fn` 未注入テストに `sleep_fn=lambda _: None` を注入

### 計測結果

- 対象 2 ファイル: 47.97s → **4.59s**（低速テストは各 4〜5s / ~2s → いずれも 0.3s 未満）
- 全ユニットスイート: 5306 passed、`--durations=20` 上位から retry / replier 系テストが消滅（残る上位は ffmpeg subprocess / lefthook 統合系でスコープ外）

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)