### PR TITLE
fix(upload): support multi-part title templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(upload)`: upload preflight が複数セパレータの `title.template` と準拠タイトルを正しく照合し、3パート以上のタイトルを誤って拒否しないようにした（#2037）。
+
 - `feat(doctor,setup)`: `yt-doctor` の api カテゴリに `reporting_job` check を追加し、OAuth 済み環境で YouTube Reporting API ジョブ未作成を検出して `uv run yt-analytics --reporting-create-job` を案内するようにした。`/setup` wizard はコマンド実行後に doctor を再診断し、ジョブ作成済みを確認する（#1974）。
 
 - `refactor(distrokid-helper)`: popup のローカル配信元・collection/disc selector を shadcn theme token に揃え、フォーム一括入力・停止操作を Button primitive へ移行した。既存の value・handler・disabled・accessible name と runner action は維持する（#2065）。

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -225,7 +225,8 @@ def check_title_template_compliance(
     検出した逸脱を `; ` で連結した理由文字列を返し、問題なければ None を返す:
 
     - **鋳型形式**: セパレータ（既定 ` | `）で LHS/RHS に分割でき、RHS が
-      チャンネル鋳型（既定 `N Hours of ...`）に一致するか
+      チャンネル鋳型（既定 `N Hours of ...`）に一致するか。複数セパレータを持つ
+      鋳型は、template 全体の固定部分と変数部分に一致するか検証する
     - **巻数表記**: LHS に `Vol.` / `Vol N` / `Part N` / ローマ数字巻数 / `#N` を
       含まないか（コレクション名＝内部管理ラベルの公開タイトル流用事故を検出）
     - **RHS 重複**: 既存 live タイトル群と RHS（セパレータ以降）が完全一致しないか
@@ -255,14 +256,21 @@ def check_title_template_compliance(
         return None
 
     normalized = title.strip()
-    parts = normalized.split(separator)
-    if len(parts) != 2:
-        return f"鋳型形式逸脱: '{separator.strip()}' で LHS/RHS に分割できません: {normalized!r}"
+    template_parts = template.split(separator) if template else []
+    is_multi_part_template = len(template_parts) > 2
+    if is_multi_part_template:
+        if not _matches_title_template(normalized, template):
+            return f"鋳型形式逸脱: 鋳型に一致しません: {normalized!r}"
+        parts = normalized.split(separator, maxsplit=1)
+    else:
+        parts = normalized.split(separator)
+        if len(parts) != 2:
+            return f"鋳型形式逸脱: '{separator.strip()}' で LHS/RHS に分割できません: {normalized!r}"
     lhs, rhs = parts[0].strip(), parts[1].strip()
 
     issues: list[str] = []
 
-    if not re.match(rhs_pattern, rhs):
+    if not is_multi_part_template and not re.match(rhs_pattern, rhs):
         issues.append(f"RHS が鋳型に一致しません（要 /{rhs_pattern}/）: {rhs!r}")
 
     vol_hit = _first_pattern_hit(lhs, volume_patterns)
@@ -276,6 +284,15 @@ def check_title_template_compliance(
         issues.append(f"LHS に鋳型語彙 {list(core_vocabulary)} が含まれません: {lhs!r}")
 
     return "; ".join(issues) if issues else None
+
+
+def _matches_title_template(title: str, template: str) -> bool:
+    """複数セパレータを持つ title.template と公開タイトルを照合する."""
+    pattern_parts = re.split(r"(\{[^{}]+\})", template)
+    pattern = "".join(
+        ".+?" if part.startswith("{") and part.endswith("}") else re.escape(part) for part in pattern_parts
+    )
+    return re.fullmatch(pattern, title) is not None
 
 
 def check_title_duplicate_warnings(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -192,6 +192,30 @@ def test_en_only_channel_without_timestamps_passes(tmp_path: Path, monkeypatch: 
     _run_preflight(channel_dir, collection_dir, monkeypatch)
 
 
+def test_three_part_title_template_passes_collection_preflight(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en"])
+    content_path = channel_dir / "config" / "channel" / "content.json"
+    content = json.loads(content_path.read_text(encoding="utf-8"))
+    content["title"]["template"] = "{tagline} | Inspirational Pinoy Reggae Music {year} | {subtitle}"
+    content_path.write_text(json.dumps(content), encoding="utf-8")
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "continuous focus mix"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+    descriptions_path = collection_dir / "20-documentation" / "descriptions.md"
+    descriptions = descriptions_path.read_text(encoding="utf-8")
+    descriptions_path.write_text(
+        descriptions.replace(
+            "Continuous Focus Mix",
+            "YAKAP NG PAMILYA 💛 | Inspirational Pinoy Reggae Music 2026 | Awit ng Pagmamahal",
+        ),
+        encoding="utf-8",
+    )
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
 def test_scene_phrases_require_only_supported_languages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     channel_dir = _write_minimal_channel(tmp_path, youtube_language="ja", supported_languages=["ja"])
     collection_dir = _write_collection(

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -762,6 +762,25 @@ class TestCheckTitleTemplateCompliance:
         title = "Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves"
         assert check_title_template_compliance(title, self.EXISTING, self.CFG) is None
 
+    def test_three_part_template_passes(self) -> None:
+        cfg = {
+            "template": "{tagline} | Inspirational Pinoy Reggae Music {year} | {subtitle}",
+        }
+        title = "YAKAP NG PAMILYA 💛 | Inspirational Pinoy Reggae Music 2026 | Awit ng Pagmamahal"
+
+        assert check_title_template_compliance(title, [], cfg) is None
+
+    def test_three_part_template_still_rejects_volume_notation(self) -> None:
+        cfg = {
+            "template": "{tagline} | Inspirational Pinoy Reggae Music {year} | {subtitle}",
+        }
+        title = "YAKAP NG PAMILYA Vol.2 | Inspirational Pinoy Reggae Music 2026 | Awit ng Pagmamahal"
+
+        msg = check_title_template_compliance(title, [], cfg)
+
+        assert msg is not None
+        assert "巻数表記" in msg
+
     def test_volume_notation_rejected(self) -> None:
         title = "Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves"
         msg = check_title_template_compliance(title, [], self.CFG)


### PR DESCRIPTION
## Summary

- validate title templates with three or more separator-delimited parts against the full configured template
- preserve existing two-part RHS checks and volume-notation rejection
- add unit and collection-preflight regression coverage

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q` (5,335 passed on latest main)

Closes #2037