### PR TITLE
chore(extensions): Fallow audit を CI 品質ゲートへ統合

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -23,9 +23,16 @@ jobs:
         working-directory: extensions/suno-helper
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: cachix/install-nix-action@v30
       - name: Install dependencies
         run: nix develop .#extensions --command pnpm install --frozen-lockfile
+      - name: Fallow audit
+        if: github.event_name == 'pull_request'
+        env:
+          FALLOW_AUDIT_BASE: ${{ github.event.pull_request.base.sha }}
+        run: nix develop .#extensions --command pnpm run audit
       - parallel:
           - name: Lint
             run: nix develop .#extensions --command pnpm lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `chore(extensions)`: Fallow audit を PR の base commit との差分に対する extensions 全体の品質ゲートとして CI へ統合した（#2076）。
+
 - `chore(test-infra)`: pytest-xdist を dev dependency に追加し、`uv run pytest -n auto` での並列実行に対応した。`tests/conftest.py` は `CHANNEL_DIR` の tmp コピーを xdist worker ごとに独立して作り直し、CI の test ジョブは `-n auto` を有効化した。ローカル既定は直列のまま（opt-in、詳細は `docs/development.md`）（#2093）。
 
 - `feat(skills)`: `/postmortem` skill command / directory を `/flop-analysis` へ改称し、feedback・workflow・機能一覧・現役戦略文書の利用者導線を新名称へ統一した。下流の `config/skills/postmortem.yaml` は `config/skills/flop-analysis.yaml` へリネームすること。旧 override は移行 fallback として警告付きで読み込むが、旧 command alias と旧 skill directory は残さない（#2023）。

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -49,9 +49,23 @@ bash .claude/skills/automation-release/references/verify-extensions.sh [<name>]
 | Playwright browser（初回） | `nix develop .#extensions --command pnpm -C extensions/suno-helper exec playwright install --with-deps chromium` |
 | e2e テスト（Playwright） | `nix develop .#extensions --command pnpm -C extensions/suno-helper test:e2e` |
 | lint / format | `nix develop .#extensions --command pnpm -C extensions/suno-helper lint` / `nix develop .#extensions --command pnpm -C extensions/suno-helper format:check` |
+| Fallow audit | `nix develop .#extensions --command pnpm -C extensions/suno-helper run audit` |
 | 配布 zip | `nix develop .#extensions --command pnpm -C extensions/suno-helper zip` |
 
 build 後は `extensions/suno-helper/.output/chrome-mv3/manifest.json`、zip 後は `extensions/suno-helper/.output/suno-helper-<package.json の version>-chrome.zip` が生成される。build / zip と期待名 zip が唯一の 1 件であることまで一括検証する場合は、前節の `verify-extensions.sh suno-helper` を使う。
+
+## 品質ゲートの責務
+
+| ゲート | 責務 |
+|---|---|
+| Oxlint（`pnpm lint`） | 共通の `extensions/.oxlintrc.json` に基づき TypeScript / React コードを検査する |
+| Prettier（`pnpm format:check`） | ソースのフォーマットが統一されていることを検査する |
+| TypeScript（`pnpm compile`） | 型エラーがなく、WXT の型生成を含む compile が成功することを検査する |
+| Fallow（`pnpm run audit`） | `extensions/` 全体を静的解析し、既存 baseline との差分 finding を検査する |
+
+Fallow のローカル実行は上表のコマンドを使う。Extensions CI では pull request の base commit SHA を比較元として `pnpm run audit` を1回だけ実行する。共通設定の `audit.gate: new-only` により、base にない新規 error-severity finding がある場合だけ品質ゲートが失敗し、既存 finding や warn-severity finding だけなら成功する。
+
+Oxlint はコード単体の lint rule 違反を検出し、Fallow は未使用ファイルなどリポジトリ差分に増えた finding を検出する。Extensions CI では両者を独立した品質ゲートとして実行する。
 
 ## unpacked ロード手順
 

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -49,6 +53,7 @@ _EXTENSIONS_JOB_CONTRACTS = {
 }
 _NIX_EXTENSIONS_INSTALL_COMMAND = "nix develop .#extensions --command pnpm install --frozen-lockfile"
 _NIX_EXTENSIONS_E2E_COMMAND = "nix develop .#extensions --command xvfb-run -a pnpm test:e2e"
+_NIX_EXTENSIONS_AUDIT_COMMAND = "nix develop .#extensions --command pnpm run audit"
 
 _RELEASE_BUILD_PARALLEL_STEPS = {
     "Build and zip suno-helper": ("extensions/suno-helper", "verify-extensions.sh suno-helper"),
@@ -210,6 +215,137 @@ def test_extensions_jobs_preserve_working_directory_install_and_e2e_contract(job
     steps = _job_steps(workflow, job_name)
     assert _top_level_step(steps, "Install dependencies").get("run") == _NIX_EXTENSIONS_INSTALL_COMMAND
     assert _top_level_step(steps, contract["e2e_step"]).get("run") == _NIX_EXTENSIONS_E2E_COMMAND
+
+
+def test_extensions_pull_request_runs_one_fallow_audit_for_the_extensions_root() -> None:
+    """Given an extension PR, When CI runs, Then one audit checks the entire extensions tree."""
+    workflow = _load_workflow(_EXTENSIONS_WORKFLOW_PATH)
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+
+    audit_steps: list[tuple[str, dict[str, object]]] = []
+    for job_name in jobs:
+        for step in _job_steps(workflow, str(job_name)):
+            if step.get("run") == _NIX_EXTENSIONS_AUDIT_COMMAND:
+                audit_steps.append((str(job_name), step))
+            parallel_steps = step.get("parallel")
+            if isinstance(parallel_steps, list):
+                audit_steps.extend(
+                    (str(job_name), child)
+                    for child in parallel_steps
+                    if child.get("run") == _NIX_EXTENSIONS_AUDIT_COMMAND
+                )
+
+    assert audit_steps == [
+        (
+            "check",
+            {
+                "name": "Fallow audit",
+                "if": "github.event_name == 'pull_request'",
+                "env": {"FALLOW_AUDIT_BASE": "${{ github.event.pull_request.base.sha }}"},
+                "run": _NIX_EXTENSIONS_AUDIT_COMMAND,
+            },
+        )
+    ]
+
+    steps = _job_steps(workflow, "check")
+    checkout = steps[_top_level_step_index_with_uses(steps, "actions/checkout@v4")]
+    assert checkout.get("with") == {"fetch-depth": 0}
+
+    jobs_check = jobs.get("check")
+    assert isinstance(jobs_check, dict)
+    working_directory = jobs_check.get("defaults", {}).get("run", {}).get("working-directory")
+    assert working_directory == "extensions/suno-helper"
+    package_json = json.loads(_read_text(_REPO_ROOT / working_directory / "package.json"))
+    assert package_json["scripts"]["audit"] == "fallow audit --root .."
+    assert (_REPO_ROOT / working_directory / "..").resolve() == (_REPO_ROOT / "extensions").resolve()
+
+    assert (
+        _top_level_step_index(steps, "Install dependencies")
+        < _top_level_step_index(steps, "Fallow audit")
+        < _parallel_group_index_containing(steps, "Lint")
+    )
+
+
+def test_fallow_audit_fails_for_a_new_error_finding_in_a_git_diff(tmp_path: Path) -> None:
+    """Given a new error finding, When the audit package script runs, Then it exits non-zero."""
+    extensions_root = tmp_path / "extensions"
+    helper_root = extensions_root / "suno-helper"
+    helper_root.mkdir(parents=True)
+    package_json = json.loads(_read_text(_REPO_ROOT / "extensions" / "suno-helper" / "package.json"))
+    audit_package_json = {
+        "name": "fallow-audit-fixture",
+        "private": True,
+        "scripts": {"audit": package_json["scripts"]["audit"]},
+    }
+    (helper_root / "package.json").write_text(json.dumps(audit_package_json), encoding="utf-8")
+    shutil.copy2(_REPO_ROOT / "extensions" / ".fallowrc.json", extensions_root / ".fallowrc.json")
+    (extensions_root / "src").mkdir()
+    (extensions_root / "src" / "existing.ts").write_text("export const existing = 1;\n", encoding="utf-8")
+
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "add", "extensions/.fallowrc.json", "extensions/suno-helper/package.json", "extensions/src"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Fallow test",
+            "-c",
+            "user.email=fallow-test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "baseline",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    audit_command = [
+        "nix",
+        "develop",
+        f"{_REPO_ROOT}#extensions",
+        "--command",
+        "pnpm",
+        "run",
+        "audit",
+    ]
+    audit_env = {
+        **os.environ,
+        "FALLOW_AUDIT_BASE": base_sha,
+        "PATH": f"{_REPO_ROOT / 'extensions' / 'suno-helper' / 'node_modules' / '.bin'}:{os.environ['PATH']}",
+    }
+    clean_audit = subprocess.run(
+        audit_command,
+        cwd=helper_root,
+        env=audit_env,
+        capture_output=True,
+        text=True,
+    )
+    assert clean_audit.returncode == 0, clean_audit.stdout + clean_audit.stderr
+
+    (extensions_root / "src" / "unused.ts").write_text(
+        "export function unusedFunction() {\n  return 1;\n}\n", encoding="utf-8"
+    )
+    audit = subprocess.run(
+        audit_command,
+        cwd=helper_root,
+        env=audit_env,
+        capture_output=True,
+        text=True,
+    )
+
+    audit_output = audit.stdout + audit.stderr
+    print(audit_output)
+    assert audit.returncode != 0, audit_output
+    assert "Unused files (1)" in audit_output, audit_output
+    assert "src/unused.ts" in audit_output, audit_output
 
 
 def test_ci_lint_runs_ruff_checks_in_a_single_parallel_group() -> None:

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -273,6 +273,7 @@ def test_fallow_audit_fails_for_a_new_error_finding_in_a_git_diff(tmp_path: Path
     helper_root = extensions_root / "suno-helper"
     helper_root.mkdir(parents=True)
     package_json = json.loads(_read_text(_REPO_ROOT / "extensions" / "suno-helper" / "package.json"))
+    fallow_version = package_json["devDependencies"]["fallow"]
     audit_package_json = {
         "name": "fallow-audit-fixture",
         "private": True,
@@ -313,13 +314,15 @@ def test_fallow_audit_fails_for_a_new_error_finding_in_a_git_diff(tmp_path: Path
         f"{_REPO_ROOT}#extensions",
         "--command",
         "pnpm",
+        f"--package=fallow@{fallow_version}",
+        "dlx",
+        "pnpm",
         "run",
         "audit",
     ]
     audit_env = {
         **os.environ,
         "FALLOW_AUDIT_BASE": base_sha,
-        "PATH": f"{_REPO_ROOT / 'extensions' / 'suno-helper' / 'node_modules' / '.bin'}:{os.environ['PATH']}",
     }
     clean_audit = subprocess.run(
         audit_command,


### PR DESCRIPTION
## Summary
- PR の base SHA を使う Fallow audit を Extensions CI に1回だけ追加
- clean diff / 新規 unused finding の実経路契約テストを追加
- Oxlint・Prettier・TypeScript・Fallow の品質ゲート責務を文書化

## Validation
- `uv run pytest -q tests/test_actions_parallel_workflows.py` (18 passed)
- Ruff check / format
- suno-helper: Oxlint, Prettier, compile, 1145 unit tests, build
- distrokid-helper: Oxlint, Prettier, compile, 249 unit tests, build
- `FALLOW_AUDIT_BASE=$(git rev-parse origin/main) nix develop .#extensions --command pnpm run audit`
- pre-commit / pre-push hooks
- Playwright e2e はローカル macOS sandbox の MachPort 制約のため GitHub Actions で検証

Closes #2076