### PR TITLE
perf(dx): .envrc に nix-direnv を導入し devShell 入場コストを安定化 (#2097)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,8 @@
+# nix-direnv: dev 環境を .direnv/ にキャッシュし、flake.nix / flake.lock / .envrc が
+# 変わらない限り入場時に nix を起動しない。direnv stdlib の use_flake は入場のたびに
+# `nix print-dev-env`（flake 評価）を実行するため、dirty worktree では評価コストが
+# 毎回壁時計に乗り 7〜80 秒まで変動し得る（issue #2097）
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.1/direnvrc" "sha256-p+fzQdrms/hDa7g+soShAybJNo4bN4SIAeSfqNKgD5I="
+fi
 use flake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `perf(dx)`: `.envrc` に nix-direnv 3.1.1 のブートストラップを追加し、devShell 入場コストを削減した。dev 環境を `.direnv/` にキャッシュし `flake.nix` / `flake.lock` / `.envrc` 変更時のみ再評価するため、dirty worktree でも 2 回目以降の `direnv exec` が 1 秒未満で安定する（従来は入場のたびに flake 評価が走り 7〜80 秒まで変動）。shellHook（lefthook install / uv sync）は従来どおり毎入場で実行される（#2097）。
+
 - `chore(test-infra)`: pytest-xdist を dev dependency に追加し、`uv run pytest -n auto` での並列実行に対応した。`tests/conftest.py` は `CHANNEL_DIR` の tmp コピーを xdist worker ごとに独立して作り直し、CI の test ジョブは `-n auto` を有効化した。ローカル既定は直列のまま（opt-in、詳細は `docs/development.md`）（#2093）。
 
 - `feat(skills)`: `/postmortem` skill command / directory を `/flop-analysis` へ改称し、feedback・workflow・機能一覧・現役戦略文書の利用者導線を新名称へ統一した。下流の `config/skills/postmortem.yaml` は `config/skills/flop-analysis.yaml` へリネームすること。旧 override は移行 fallback として警告付きで読み込むが、旧 command alias と旧 skill directory は残さない（#2023）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,7 +72,8 @@ Python 側の未使用コード検出は、追加依存なしで CI / pre-commit
 
 有効化と運用:
 
-- **有効化**: 親 checkout / 新規 worktree のどちらでも、最初に `bash .lefthook/setup-worktree.sh` を 1 回実行する。direnv があればルートの `.envrc`（`use flake`）を allow して devShell に入り、なければ `nix develop` を使う。どちらの経路でも shellHook と `.lefthook/install.sh` が hook wrapper を再生成する
+- **有効化**: 親 checkout / 新規 worktree のどちらでも、最初に `bash .lefthook/setup-worktree.sh` を 1 回実行する。direnv があればルートの `.envrc`（nix-direnv 経由の `use flake`）を allow して devShell に入り、なければ `nix develop` を使う。どちらの経路でも shellHook と `.lefthook/install.sh` が hook wrapper を再生成する
+- **devShell 入場コスト**: `.envrc` は [nix-direnv](https://github.com/nix-community/nix-direnv) をブートストラップし、評価済み dev 環境を `.direnv/` にキャッシュする。`flake.nix` / `flake.lock` / `.envrc` が変わらない限り入場時に nix を起動しないため、dirty worktree でも 2 回目以降の `direnv exec` は 1 秒未満で安定する（direnv stdlib の `use_flake` は入場のたびに `nix print-dev-env` を実行するため、flake 評価コストが毎回壁時計に乗り 7〜80 秒まで変動していた。issue #2097）。shellHook（lefthook install / `uv sync`）はキャッシュヒット時も毎入場で実行される。worktree ごとの初回入場のみキャッシュ生成（20 秒前後）が走る。nix-direnv の direnvrc 本体は初回のみ GitHub から取得しハッシュ検証のうえ `~/.cache/direnv/cas/` に永続キャッシュされる（オフライン初回のみ失敗し得る。その場合は `nix develop` 経路を使う）
 - **devShell 内での実行**: direnv の自動入室が有効な shell ではそのまま `uv run pytest` 等を実行できる。agent や非対話 shell では `bash .lefthook/setup-worktree.sh uv run pytest` のように引数を渡すと、同じ devShell 内でコマンドを実行できる
 - **診断**: 親 checkout / worktree のそれぞれで `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'` を実行する。`git commit` / `git push` で `Can't find lefthook in PATH` が出る場合は `bash .lefthook/setup-worktree.sh` を再実行する。直接の Nix 診断・再生成には `nix develop --command sh -c 'command -v lefthook && lefthook version'` と `nix develop --command bash .lefthook/install.sh` も利用できる
 - **失敗時の扱い**: shellHook は `lefthook` 不在や hook 再生成失敗を `|| true` で握りつぶさない。devShell 入室時に明示的に失敗させ、commit / push 時の hook no-op を防ぐ

--- a/tests/test_lefthook_installation_contract.py
+++ b/tests/test_lefthook_installation_contract.py
@@ -791,7 +791,13 @@ def test_worktree_setup_fails_when_no_environment_loader_is_available(tmp_path: 
 
 
 def test_worktree_environment_contract_is_wired_into_lite_steps_and_docs() -> None:
-    assert _read(_ENVRC_PATH) == "use flake\n"
+    envrc = _read(_ENVRC_PATH)
+    # nix-direnv を version + SRI hash 固定でブートストラップし（issue #2097）、
+    # 最終ディレクティブは従来どおり use flake であること
+    assert 'source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/' in envrc
+    assert '" "sha256-' in envrc
+    assert "nix_direnv_version" in envrc
+    assert envrc.rstrip().splitlines()[-1] == "use flake"
     workflow = _read(_LITE_WORKFLOW_PATH)
     setup_instruction = "最初に `bash .lefthook/setup-worktree.sh` を実行"
     wrapped_command_instruction = "`bash .lefthook/setup-worktree.sh <command> [args...]` 経由"


### PR DESCRIPTION
## Summary

devShell 入場コスト（dirty worktree で `direnv exec` が 7〜80 秒に変動）の原因を切り分け、`.envrc` に nix-direnv 3.1.1 のブートストラップを導入して安定化する。

### 原因の切り分け（実測は issue コメント参照）

- dirty tree の Nix store コピー（当初の推測）は **現環境では発生しない**（Determinate Nix の `lazy-trees = true` が有効）
- flake eval キャッシュの有無も律速要因ではなかった（退避実験で差なし）
- 構造要因は direnv stdlib の `use_flake` が **入場のたびに `nix print-dev-env`（flake 評価）を実行する**こと。評価が遅くなる条件（nixpkgs bump 直後・GC 後・並列負荷）でそのまま毎回の壁時計に乗る

### 変更内容

- `.envrc`: nix-direnv 3.1.1 を SRI hash 固定で `source_url` ブートストラップ。dev 環境を `.direnv/` にキャッシュし、`flake.nix` / `flake.lock` / `.envrc` 変更時のみ再評価
- `docs/development.md`: devShell 入場コストの節を追加（オフライン初回の注意含む）
- `tests/test_lefthook_installation_contract.py`: `.envrc` 厳密一致の契約を「nix-direnv ブートストラップ + 最終 `use flake`」の契約へ更新
- `CHANGELOG.md`: `[Unreleased]` に追記

### 実測（dirty tree・2 回目以降）

| 構成 | 入場コスト |
|---|---|
| stdlib `use_flake`（従来） | 1.2〜3.3 秒（eval 状況次第で 7〜80 秒に変動） |
| nix-direnv（本 PR） | **0.3 秒**（nix 起動ゼロ） |

shellHook（lefthook install / `uv sync`）はキャッシュヒット時も毎入場で実行され、fail-closed な hook 再生成の設計は維持される。

### 検証

- `uv run pytest -n auto`: 5339 passed
- `ruff check` / `ruff format --check`: パス
- worktree で cold（キャッシュ生成 21 秒）→ warm 0.3 秒を実測

Closes #2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)