### PR TITLE
refactor(suno-ui): PatternList を shadcn へ移行する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `refactor(suno-helper)`: PatternList の entry 選択表示を、selection semantics・accessible name・`data-suno-entry-*` 契約を維持したまま shadcn variant と Tailwind semantic token へ移行した（#2068）。
+
 - `refactor(suno-helper)`: collection・投入方式・開始/停止・resume/retry controls を、既存 handler・disabled 条件・`data-suno-control` / aria 契約を維持したまま shadcn primitive へ移行した（#2067）。
 
 - `feat(distrokid-helper)`: 初回表示、コレクション選択、ローカル配信元選択の各タイミングで collection 一覧と release.json を自動取得し、手動の「データ取得」ボタンを廃止した（#1992）。

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -1,6 +1,7 @@
 import type { PromptEntry } from "../../shared/api";
 import type { ItemState } from "../../shared/constants";
 import { isEntrySelected } from "../lib/pattern-selection";
+import { ButtonSlot } from "./ui/button";
 
 interface PatternListProps {
   entries: PromptEntry[];
@@ -10,12 +11,12 @@ interface PatternListProps {
 }
 
 const STATE_CLASS: Record<ItemState, string> = {
-  idle: "text-gray-700",
-  active: "bg-blue-100 font-medium text-blue-800",
-  submitted: "bg-amber-50 font-medium text-amber-800",
-  done: "text-green-700 line-through",
+  idle: "text-foreground",
+  active: "bg-primary/10 font-medium text-primary",
+  submitted: "bg-secondary font-medium text-secondary-foreground",
+  done: "text-muted-foreground line-through",
   // リトライ上限まで失敗しスキップされた entry (#948)。「失敗分のみ再実行」の対象。
-  failed: "bg-red-50 font-medium text-red-700",
+  failed: "bg-destructive/10 font-medium text-destructive",
 };
 
 export function PatternList({ entries, itemStates, selectedEntries, onToggleEntry }: PatternListProps) {
@@ -23,28 +24,34 @@ export function PatternList({ entries, itemStates, selectedEntries, onToggleEntr
     return null;
   }
   return (
-    <ul className="max-h-48 overflow-y-auto rounded border border-gray-200" data-suno-entry-list="true">
+    <ul className="max-h-48 overflow-y-auto rounded border border-border" data-suno-entry-list="true">
       {entries.map((entry, index) => {
         const itemState = itemStates[index] ?? "idle";
         const selected = isEntrySelected(selectedEntries, itemStates, index);
         return (
           <li
             key={`${entry.name}-${index}`}
-            className={`px-2 py-1 text-sm ${STATE_CLASS[itemState]}`}
+            className={`p-1 text-sm ${itemState === "done" ? "line-through" : ""}`}
             data-suno-entry-index={index}
             data-suno-entry-state={itemState}
             data-suno-entry-selected={selected ? "true" : "false"}
           >
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={selected}
-                onChange={(event) => onToggleEntry(index, event.currentTarget.checked)}
-                aria-label={`entry ${index + 1}: ${entry.name}`}
-                className="h-4 w-4 shrink-0"
-              />
-              <span className="min-w-0 flex-1">{entry.name}</span>
-            </label>
+            <ButtonSlot
+              variant={selected ? "default" : "outline"}
+              size="sm"
+              className="h-auto w-full justify-start whitespace-normal p-0 font-normal"
+            >
+              <label className="flex items-center gap-2 px-2 py-1">
+                <input
+                  type="checkbox"
+                  checked={selected}
+                  onChange={(event) => onToggleEntry(index, event.currentTarget.checked)}
+                  aria-label={`entry ${index + 1}: ${entry.name}`}
+                  className="size-4 shrink-0 accent-primary"
+                />
+                <span className={`min-w-0 flex-1 text-left ${STATE_CLASS[itemState]}`}>{entry.name}</span>
+              </label>
+            </ButtonSlot>
           </li>
         );
       })}

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -65,41 +65,68 @@ describe("PatternList checkbox UI", () => {
     container.remove();
   });
 
-  it("各 entry の checkbox に selection を反映し、done entry は打ち消し線のまま手動で再チェックできる", () => {
+  it("各 entry の selection を shadcn variant と semantic token に反映する", () => {
     const onToggleEntry = vi.fn();
 
     act(() => {
       root.render(
         createElement(PatternList, {
-          entries: makePromptEntries(3),
-          itemStates: ["idle", "done", "failed"],
-          selectedEntries: [true, false, true],
+          entries: makePromptEntries(5),
+          itemStates: ["idle", "active", "submitted", "done", "failed"],
+          selectedEntries: [true, false, true, false, true],
           onToggleEntry,
         }),
       );
     });
 
     const checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
-    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, false, true]);
-    expect(checkboxes[1].closest("li")?.className).toContain("line-through");
-    expect(container.querySelector("[data-suno-entry-list]")).not.toBeNull();
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, false, true, false, true]);
+    expect(checkboxes.map((checkbox) => checkbox.getAttribute("aria-label"))).toEqual([
+      "entry 1: pattern-1",
+      "entry 2: pattern-2",
+      "entry 3: pattern-3",
+      "entry 4: pattern-4",
+      "entry 5: pattern-5",
+    ]);
+
+    const list = container.querySelector<HTMLUListElement>("[data-suno-entry-list]");
+    expect(list?.tagName).toBe("UL");
+    expect(list?.dataset.sunoEntryList).toBe("true");
+    expect(list?.className).toContain("border-border");
+    const rows = Array.from(container.querySelectorAll<HTMLLIElement>("[data-suno-entry-index]"));
+    expect(rows.map((row) => row.tagName)).toEqual(["LI", "LI", "LI", "LI", "LI"]);
     expect(
-      Array.from(container.querySelectorAll<HTMLLIElement>("[data-suno-entry-index]")).map((row) => ({
+      rows.map((row) => ({
         index: row.dataset.sunoEntryIndex,
         selected: row.dataset.sunoEntrySelected,
         state: row.dataset.sunoEntryState,
       })),
     ).toEqual([
       { index: "0", selected: "true", state: "idle" },
-      { index: "1", selected: "false", state: "done" },
-      { index: "2", selected: "true", state: "failed" },
+      { index: "1", selected: "false", state: "active" },
+      { index: "2", selected: "true", state: "submitted" },
+      { index: "3", selected: "false", state: "done" },
+      { index: "4", selected: "true", state: "failed" },
     ]);
-
-    act(() => {
-      checkboxes[1].click();
-    });
-
-    expect(onToggleEntry).toHaveBeenCalledWith(1, true);
+    expect(rows.map((row) => row.querySelector("label")?.dataset.variant)).toEqual([
+      "default",
+      "outline",
+      "default",
+      "outline",
+      "default",
+    ]);
+    expect(rows.map((row) => row.querySelector("label")?.dataset.size)).toEqual(["sm", "sm", "sm", "sm", "sm"]);
+    expect(checkboxes.every((checkbox) => checkbox.className.includes("accent-primary"))).toBe(true);
+    const names = rows.map((row) => row.querySelector("span")!);
+    expect(names[0].className).toContain("text-foreground");
+    expect(names[1].className).toContain("bg-primary/10");
+    expect(names[1].className).toContain("text-primary");
+    expect(names[2].className).toContain("bg-secondary");
+    expect(names[2].className).toContain("text-secondary-foreground");
+    expect(names[3].className).toContain("text-muted-foreground");
+    expect(names[3].className).toContain("line-through");
+    expect(names[4].className).toContain("bg-destructive/10");
+    expect(names[4].className).toContain("text-destructive");
   });
 
   it("controlled state 更新後に done entry の手動再チェックを DOM に反映する", () => {
@@ -124,13 +151,18 @@ describe("PatternList checkbox UI", () => {
 
     let checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
     expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, false, true]);
+    expect(checkboxes.map((checkbox) => checkbox.disabled)).toEqual([false, false, false]);
 
     act(() => {
+      checkboxes[0]!.click();
       checkboxes[1]!.click();
     });
 
     checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
-    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([true, true, true]);
-    expect(checkboxes[1]!.closest("li")?.className).toContain("line-through");
+    expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([false, true, true]);
+    const rows = Array.from(container.querySelectorAll<HTMLLIElement>("[data-suno-entry-index]"));
+    expect(rows.map((row) => row.dataset.sunoEntrySelected)).toEqual(["false", "true", "true"]);
+    expect(rows.map((row) => row.querySelector("label")?.dataset.variant)).toEqual(["outline", "default", "default"]);
+    expect(rows[1].querySelector("span")?.className).toContain("line-through");
   });
 });


### PR DESCRIPTION
## Summary

Issue #2068 の takt 実装・レビュー成果を反映します。

## Verification

- format/lint/compile/Vitest 1,145/build pass
- local Playwright blocked before assertions by macOS sandbox; CI validates E2E

Closes #2068