### PR TITLE
feat(suno): Style文字数上限を設定可能にする (#1938)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -84,7 +84,7 @@ generator は pattern draft、設定、benchmark analysis、必要な References
 - **明示 override 優先**: pattern に `style: <variant-key>` がある entry は `style_variants` の genre_line をそのまま使い、自動バリエーションは付与しない（通し番号は消費する）
 - **プール定義**: `config.default.yaml::style_variation.pools` に axis 名（`texture` / `rhythm` 等）→ descriptor 配列で定義する。axis 名の辞書順で round-robin に interleave した列を循環割り当てる。チャンネル側 `config/skills/suno.yaml` では axis 単位で丸ごと置換（deep-merge のリスト置換）・axis 追加・空リスト上書きによる axis 無効化ができる
 - **設定契約**: `style_variation` は mapping、`enabled` は bool、`pools` は mapping、各 axis は `list[str]`。descriptor は非空文字列のみ有効で、契約外 shape は `uv run yt-generate-suno` が `ConfigError` で停止する
-- **語彙の制約**: descriptor に禁止形容詞（`references/suno-examples.md`）・雨音／環境音 NG ワード・楽器名の裸置き・アーティスト名を入れない。120 文字上限は descriptor 込みの Style 文で検証される
+- **語彙の制約**: descriptor に禁止形容詞（`references/suno-examples.md`）・雨音／環境音 NG ワード・楽器名の裸置き・アーティスト名を入れない。`style_char_limit`（既定 120）の上限は descriptor 込みの Style 文で検証される
 - **重複検証**: 生成時に全 entry の Style 文（第 1 行 + 情景行）が完全一致する組があれば `uv run yt-generate-suno` が警告する
 - **無効化**: チャンネル側で `style_variation.enabled: false` を設定すると従来動作（全 entry 同一の Style 第 1 行）に戻る
 
@@ -157,9 +157,9 @@ Style テキストは以下の順序で構成する。順序を守ることで S
 4. **リズム/ベース** (e.g. laid-back boom-bap drums, deep fretless bass)
 5. **テンポ** (e.g. slow, moderate)
 
-### 120 Character Limit
+### Configurable Character Limit
 
-Style フィールドは **120 文字以下** でなければならない。`uv run yt-generate-suno` がビルド時に超過を警告する。5-Element Order に従って要素を絞り込み、収まらない修飾語は削る。
+Style フィールドの文字数上限は `config/skills/suno.yaml::style_char_limit` で設定する（既定 **120 文字**）。`uv run yt-generate-suno` はビルド時に超過を警告し、`uv run yt-suno-verify` は設定上限を超えた `genre_line` と使用中の `style_variants.*.genre_line` をエラーにする。5-Element Order に従って要素を絞り込むか、意図的な長文 Style 運用では実際の上限を設定する。
 
 ### Artist Name Prohibition
 

--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -21,7 +21,7 @@ weirdness: 50
 # 歌詞構造の自動タグ付け ([Verse], [Chorus] 等を AI が自動挿入)
 auto_lyrics_structure: true
 
-# Style 欄の文字数上限 (Suno UI の制約に合わせる)
+# Style 欄の文字数上限 (チャンネル側 config/skills/suno.yaml で上書き可能)
 style_char_limit: 120
 
 # Style テキストに含めてはならないアーティスト名 (Suno ポリシー / ベストプラクティス)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno)`: `yt-suno-verify` と共通 initial-setup preflight が `config/skills/suno.yaml::style_char_limit` の上書きを尊重し、長文の base `genre_line`・video analysis 由来 Style・使用中 style variant を設定上限で検証するようにした。未設定時は従来どおり 120 文字超過をエラーにする（#1938）。
+
 - `perf(dx)`: `.envrc` に nix-direnv 3.1.1 のブートストラップを追加し、devShell 入場コストを削減した。dev 環境を `.direnv/` にキャッシュし `flake.nix` / `flake.lock` / `.envrc` 変更時のみ再評価するため、dirty worktree でも 2 回目以降の `direnv exec` が 1 秒未満で安定する（従来は入場のたびに flake 評価が走り 7〜80 秒まで変動）。shellHook（lefthook install / uv sync）は従来どおり毎入場で実行される（#2097）。
 
 - `docs(wf-new)`: analytics mode の stale report を `/collection-ideate` の freshness SSOT に従って自動更新し、再検証後に入力モード判定と企画フローを継続する契約へ更新した。更新失敗時は古い report を使わず、理由と再開条件を示して停止する（#2063）。

--- a/src/youtube_automation/utils/preflight_checks.py
+++ b/src/youtube_automation/utils/preflight_checks.py
@@ -117,7 +117,10 @@ def check_suno_genre_line_char_limit(suno_cfg: Mapping[str, object]) -> str | No
     genre_line = str(suno_cfg.get("genre_line") or "").strip()
     if not genre_line:
         return None
-    limit = SUNO_DEFAULT_STYLE_CHAR_LIMIT
+    limit = _positive_int(
+        suno_cfg.get("style_char_limit"),
+        default=SUNO_DEFAULT_STYLE_CHAR_LIMIT,
+    )
     if len(genre_line) <= limit:
         return None
     return (

--- a/src/youtube_automation/utils/suno_verify_artifacts.py
+++ b/src/youtube_automation/utils/suno_verify_artifacts.py
@@ -63,7 +63,7 @@ def verify_suno_collection(collection_dir: Path) -> tuple[list[str], str]:
 
 
 def _preflight_issues(suno_cfg: ResolvedSunoConfig) -> list[str]:
-    genre_line_issue = check_suno_genre_line_char_limit({"genre_line": suno_cfg.genre_line})
+    genre_line_issue = check_suno_genre_line_char_limit({**suno_cfg.raw, "genre_line": suno_cfg.genre_line})
     return [] if genre_line_issue is None else [genre_line_issue]
 
 
@@ -80,7 +80,7 @@ def _style_variant_genre_line_issues(suno_cfg: ResolvedSunoConfig, contract: Pat
         genre_line = variant.get("genre_line")
         if not isinstance(genre_line, str):
             continue
-        issue = check_suno_genre_line_char_limit({"genre_line": genre_line})
+        issue = check_suno_genre_line_char_limit({**suno_cfg.raw, "genre_line": genre_line})
         if issue is not None:
             issues.append(
                 issue.replace(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1428,7 +1428,10 @@ class TestCheckInitialSetupReadiness:
             ),
             encoding="utf-8",
         )
-        (skills_dir / "suno.yaml").write_text('genre_line: "lo-fi jazz, soft piano"\n', encoding="utf-8")
+        (skills_dir / "suno.yaml").write_text(
+            f'genre_line: "{"x" * 373}"\nstyle_char_limit: 373\n',
+            encoding="utf-8",
+        )
         desc = tmp_path / "collections" / "planning" / "alpha" / "20-documentation" / "descriptions.md"
         _write_valid_descriptions_md(desc)
 

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -212,15 +212,21 @@ class TestCheckChapterVariationSuffix:
 
 
 class TestInitialSetupChecks:
-    def test_suno_genre_line_over_fixed_style_limit_warns_even_if_config_raises_limit(self) -> None:
-        msg = check_suno_genre_line_char_limit({"genre_line": "x" * 121, "style_char_limit": 999})
+    def test_suno_genre_line_uses_default_style_limit_when_not_configured(self) -> None:
+        msg = check_suno_genre_line_char_limit({"genre_line": "x" * 121})
 
         assert msg is not None
         assert "121 / 120" in msg
         assert "config/skills/suno.yaml::genre_line" in msg
 
-    def test_suno_genre_line_at_style_limit_passes(self) -> None:
-        assert check_suno_genre_line_char_limit({"genre_line": "x" * 120, "style_char_limit": 1}) is None
+    def test_suno_genre_line_at_configured_style_limit_passes(self) -> None:
+        assert check_suno_genre_line_char_limit({"genre_line": "x" * 373, "style_char_limit": 373}) is None
+
+    def test_suno_genre_line_over_configured_style_limit_reports_configured_limit(self) -> None:
+        msg = check_suno_genre_line_char_limit({"genre_line": "x" * 374, "style_char_limit": 373})
+
+        assert msg is not None
+        assert "374 / 373" in msg
 
     def test_thumbnail_config_detects_empty_refs_and_tbd_composition(self, tmp_path: Path) -> None:
         cfg = {

--- a/tests/test_suno_prompt_quality_rules.py
+++ b/tests/test_suno_prompt_quality_rules.py
@@ -348,9 +348,10 @@ def test_skill_md_has_5_element_order():
 
 
 def test_skill_md_has_120_char_limit():
-    """SKILL.md に 120 文字制限の記述があること."""
+    """SKILL.md に既定 120 文字と設定による上書きの記述があること."""
     text = _SKILL_MD.read_text(encoding="utf-8")
     assert "120" in text
+    assert "style_char_limit" in text
 
 
 def test_skill_md_has_banned_artists():

--- a/tests/test_suno_verify.py
+++ b/tests/test_suno_verify.py
@@ -580,6 +580,62 @@ def test_genre_line_char_limit_uses_preflight_check(channel_dir, tmp_path, monke
     assert "121 / 120" in output
 
 
+def test_configured_genre_line_char_limit_allows_long_style(channel_dir, tmp_path, monkeypatch, capsys):
+    """Given genre_line が設定した 373 文字上限ちょうど
+    When yt-suno-verify を実行する
+    Then Style 上限検証を通過して exit 0 にする。
+    """
+    write_suno_override(channel_dir, genre_line="x" * 373, style_char_limit=373)
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK" in output
+
+
+def test_configured_genre_line_char_limit_rejects_over_limit(channel_dir, tmp_path, monkeypatch, capsys):
+    """Given genre_line が設定した 373 文字上限を 1 文字超過
+    When yt-suno-verify を実行する
+    Then 実際の上限を診断して exit 1 にする。
+    """
+    write_suno_override(channel_dir, genre_line="x" * 374, style_char_limit=373)
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "genre_line" in output
+    assert "374 / 373" in output
+
+
+def test_video_analysis_genre_line_uses_configured_char_limit(channel_dir, tmp_path, monkeypatch, capsys):
+    """Given video analysis 由来 genre_line が設定した上限ちょうど
+    When yt-suno-verify が effective config を解決する
+    Then override の上限を保持して exit 0 にする。
+    """
+    write_suno_override(channel_dir, genre_line="", style_char_limit=373)
+    write_video_analysis_suno_preset(channel_dir, genre_line="x" * 373)
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK" in output
+
+
 def test_used_style_variant_genre_line_char_limit_is_reported(channel_dir, tmp_path, monkeypatch, capsys):
     """Given pattern が 121 文字 genre_line の style variant を使用する
     When yt-suno-verify を実行する
@@ -606,6 +662,34 @@ def test_used_style_variant_genre_line_char_limit_is_reported(channel_dir, tmp_p
     assert code == 1
     assert "style_variants.long.genre_line" in output
     assert "121 / 120" in output
+
+
+def test_used_style_variant_uses_configured_genre_line_char_limit(channel_dir, tmp_path, monkeypatch, capsys):
+    """Given pattern が設定上限内の長い style variant を使用する
+    When yt-suno-verify を実行する
+    Then variant にもグローバル上限を適用して exit 0 にする。
+    """
+    write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        style_char_limit=373,
+        style_variants={
+            "long": {
+                "name": "Long",
+                "genre_line": "x" * 373,
+            }
+        },
+    )
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2, style="long")
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK" in output
 
 
 def test_unused_style_variant_genre_line_char_limit_is_not_reported(channel_dir, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Closes #1938

## 概要
- Suno の genre_line / Style 文字数上限を skill config で上書き可能にする
- preflight・artifact verification・doctor が同じ実効値を参照する
- default / override / variant の契約テストを追加する

## 検証
- `uv run pytest -n auto`: 5,347 passed
- 関連テスト: 429 passed
- `uv run ruff check`: passed
- `uv run ruff format --check`: 465 files formatted
- takt architecture review: approved