### PR TITLE
chore(extensions): Oxlint CI 契約を固定する (#2020)

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
+      - "tests/test_actions_parallel_workflows.py"
       - "flake.nix"
       - "flake.lock"
   pull_request:
     paths:
       - "extensions/**"
       - ".github/workflows/extensions.yml"
+      - "tests/test_actions_parallel_workflows.py"
       - "flake.nix"
       - "flake.lock"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `chore(extensions)`: suno-helper と distrokid-helper の full gate / Playwright e2e を維持し、Extensions CI が各 package の既存 `pnpm lint` 入口から共通設定の Oxlint を実行する接続契約を追加した。契約テスト自体の変更でも Extensions CI が起動するよう path filter を接続した（#2020）。
+
 - `feat(masterup)`: `yt-suno-verify-playlist` に collection 相対の `--music-dir` を追加し、`NN{a|b}-<title>.<ext>` 形式のローカル音声ファイル名を name/title の英語 alias・apostrophe 除去名から canonical entry へ対応付け、entry + `a`/`b` variant 単位で unknown / missing / underfilled を fail-loud 検出できるようにした。`/masterup` の primary path は `02-Individual-music/` を直接突合するため、playlist URL や title list の確認なしで Step 5 前ゲートを実行する（#1898）。
 
 - `feat(doctor,setup)`: `yt-doctor --fix-client-secrets` を追加し、Downloads の構造妥当かつ GCP project 一致する最新 OAuth client JSON を `auth/client_secrets.json` へ移動できるようにした。既存ファイルは上書きせず、`/setup` の HUMAN STEP は secret 発行・Download JSON・done のみに簡素化した（#1903）。

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -45,10 +45,12 @@ _EXTENSIONS_JOB_CONTRACTS = {
     "check": {
         "working_directory": "extensions/suno-helper",
         "e2e_step": "E2E tests (Playwright)",
+        "lint_script": "cd .. && oxlint -c .oxlintrc.json suno-helper shared",
     },
     "distrokid-helper": {
         "working_directory": "extensions/distrokid-helper",
         "e2e_step": "E2E (Playwright)",
+        "lint_script": "cd .. && oxlint -c .oxlintrc.json distrokid-helper",
     },
 }
 _NIX_EXTENSIONS_INSTALL_COMMAND = "nix develop .#extensions --command pnpm install --frozen-lockfile"
@@ -179,7 +181,13 @@ def test_extensions_pull_request_trigger_keeps_path_filter() -> None:
     pull_request = _on_section(workflow).get("pull_request")
 
     assert isinstance(pull_request, dict), "pull_request トリガーが存在しない"
-    expected_paths = ["extensions/**", ".github/workflows/extensions.yml", "flake.nix", "flake.lock"]
+    expected_paths = [
+        "extensions/**",
+        ".github/workflows/extensions.yml",
+        "tests/test_actions_parallel_workflows.py",
+        "flake.nix",
+        "flake.lock",
+    ]
     assert pull_request.get("paths") == expected_paths
     assert _on_section(workflow).get("push", {}).get("paths") == expected_paths
 
@@ -215,6 +223,25 @@ def test_extensions_jobs_preserve_working_directory_install_and_e2e_contract(job
     steps = _job_steps(workflow, job_name)
     assert _top_level_step(steps, "Install dependencies").get("run") == _NIX_EXTENSIONS_INSTALL_COMMAND
     assert _top_level_step(steps, contract["e2e_step"]).get("run") == _NIX_EXTENSIONS_E2E_COMMAND
+
+
+@pytest.mark.parametrize("job_name", ["check", "distrokid-helper"])
+def test_extensions_jobs_run_oxlint_through_the_package_lint_entrypoint(job_name: str) -> None:
+    """Given Extensions CI, When lint runs, Then each package's pnpm lint entrypoint invokes Oxlint."""
+    workflow = _load_workflow(_EXTENSIONS_WORKFLOW_PATH)
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "jobs セクションが存在しない"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"{job_name} job が存在しない"
+    contract = _EXTENSIONS_JOB_CONTRACTS[job_name]
+
+    expected_steps = _SUNO_FAST_PARALLEL_STEPS if job_name == "check" else _DISTROKID_FAST_PARALLEL_STEPS
+    lint_group = _parallel_group_with_names(_job_steps(workflow, job_name), set(expected_steps))
+    lint_step = next(step for step in lint_group if step.get("name") == "Lint")
+    assert lint_step.get("run") == "nix develop .#extensions --command pnpm lint"
+
+    package = json.loads(_read_text(_REPO_ROOT / str(contract["working_directory"]) / "package.json"))
+    assert package["scripts"]["lint"] == contract["lint_script"]
 
 
 def test_extensions_pull_request_runs_one_fallow_audit_for_the_extensions_root() -> None:


### PR DESCRIPTION
Closes #2020

## 概要
- Extensions CI が既存 `pnpm lint` 入口から Oxlint を実行する契約を固定
- suno-helper の lint 対象に `shared` が含まれることを検証
- 契約テスト変更時にも Extensions CI / Playwright E2E が起動するよう paths を接続

## 検証
- `uv run pytest -q tests/test_actions_parallel_workflows.py`: 20 passed
- Ruff check / format / `git diff --check`: pass
- 両 helper frozen install / lint / format / compile / unit / build: pass
- DistroKid Playwright: 7 passed
- Suno Playwright: 24 passed / 1件は別repoの既存7873番サーバーによるfixture cross-talk。Linux Extensions CIを最終証拠とする
- pre-commit / CHANGELOG gate: pass

## CI
Extensions workflow の両 Playwright E2E と required checks が green になるまでマージしません。