### PR TITLE
ci: frozen sync + wheel build + installed artifact smoke job を追加 (#2126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,24 @@ jobs:
       - name: Test
         run: nix develop --command uv run pytest -n auto
 
+  build-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - name: Frozen sync (lock drift check)
+        run: nix develop --command uv sync --frozen
+      - name: Build wheel and sdist
+        run: nix develop --command uv build
+      - name: Smoke test installed wheel
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            venv=$(mktemp -d)/venv
+            uv venv "$venv"
+            uv pip install --python "$venv/bin/python" dist/*.whl
+            "$venv/bin/yt-skills" list
+          '
+
   windows-cost-tracker:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` に `build-smoke` job を追加
  1. `uv sync --frozen` — `uv.lock` と `pyproject.toml` の drift を検出
  2. `uv build` — wheel / sdist の生成を検証
  3. 生成した wheel を temp venv へ install して `yt-skills list` を実行 — entry point と force-include 同梱物（`.claude/skills/` / `.claude/CLAUDE.template.md`）の smoke 確認
- 既存 job（lint / test / changelog / adr-numbering / any-gate / windows-cost-tracker）は変更なし

## ローカル検証

`nix develop --command` 経由で frozen sync → build → temp venv install → `yt-skills list` を実行し exit 0 を確認（同梱スキル一覧が wheel から正しく列挙されることを確認済み）。

Closes #2126