### PR TITLE
fix(tests): lefthook 契約テストの subprocess env から SKIP_LEFTHOOK のリークを遮断する (#2101)

### DIFF
--- a/tests/test_lefthook_installation_contract.py
+++ b/tests/test_lefthook_installation_contract.py
@@ -22,11 +22,21 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _subprocess_env(**overrides: str) -> dict[str, str]:
+    # 契約テストの前提となる環境変数はテスト自身が固定する。takt runtime が全 worker へ
+    # 注入する YOUTUBE_AUTOMATION_SKIP_LEFTHOOK が subprocess へリークすると install 実行を
+    # 期待するテストが skip 分岐に入って失敗するため、必ず除去する（issue #2101）。
+    # skip 挙動を検証するテストは overrides で明示的に設定する
+    env = {key: value for key, value in os.environ.items() if key != "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK"}
+    env.update(overrides)
+    return env
+
+
 def _run_install_script(workdir: Path, path: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(_LEFTHOOK_INSTALL_SCRIPT_PATH)],
         cwd=workdir,
-        env={**os.environ, "PATH": path},
+        env=_subprocess_env(PATH=path),
         text=True,
         capture_output=True,
         check=False,
@@ -41,7 +51,7 @@ def _run_shell_hook_install_entrypoint(workdir: Path, path: str) -> subprocess.C
             f'git rev-parse --git-dir >/dev/null 2>&1 && bash "{_LEFTHOOK_INSTALL_SCRIPT_PATH}"',
         ],
         cwd=workdir,
-        env={**os.environ, "PATH": path},
+        env=_subprocess_env(PATH=path),
         text=True,
         capture_output=True,
         check=False,
@@ -57,7 +67,7 @@ def _run_worktree_setup(workdir: Path, path: str, *args: str) -> subprocess.Comp
     return subprocess.run(
         ["bash", str(_WORKTREE_SETUP_SCRIPT_PATH), *args],
         cwd=workdir,
-        env={**os.environ, "PATH": path},
+        env=_subprocess_env(PATH=path),
         text=True,
         capture_output=True,
         check=False,
@@ -134,7 +144,7 @@ def _push_head(repo: Path, path: str, *, extra_env: dict[str, str] | None = None
     return subprocess.run(
         ["git", "push", "origin", "HEAD:main"],
         cwd=repo,
-        env={**os.environ, "PATH": path, **(extra_env or {})},
+        env=_subprocess_env(PATH=path, **(extra_env or {})),
         text=True,
         capture_output=True,
         check=False,
@@ -166,7 +176,7 @@ def test_lefthook_install_script_skips_when_skip_env_is_set(tmp_path: Path) -> N
     result = subprocess.run(
         ["bash", str(_LEFTHOOK_INSTALL_SCRIPT_PATH)],
         cwd=tmp_path,
-        env={**os.environ, "PATH": "/usr/bin:/bin", "YOUTUBE_AUTOMATION_SKIP_LEFTHOOK": "1"},
+        env=_subprocess_env(PATH="/usr/bin:/bin", YOUTUBE_AUTOMATION_SKIP_LEFTHOOK="1"),
         text=True,
         capture_output=True,
         check=False,
@@ -188,7 +198,7 @@ def test_takt_runtime_prepare_injects_sandbox_safe_environment(tmp_path: Path) -
     runtime_root = tmp_path / "runtime"
     result = subprocess.run(
         ["bash", str(_REPO_ROOT / ".takt" / "runtime-prepare.sh")],
-        env={**os.environ, "TAKT_RUNTIME_ROOT": str(runtime_root)},
+        env=_subprocess_env(TAKT_RUNTIME_ROOT=str(runtime_root)),
         text=True,
         capture_output=True,
         check=False,
@@ -311,7 +321,7 @@ def test_generated_pre_commit_hook_fails_closed_when_lefthook_path_is_stale(tmp_
     commit_result = subprocess.run(
         ["git", "commit", "-m", "test commit"],
         cwd=tmp_path,
-        env={**os.environ, "PATH": "/usr/bin:/bin"},
+        env=_subprocess_env(PATH="/usr/bin:/bin"),
         text=True,
         capture_output=True,
         check=False,
@@ -360,7 +370,7 @@ def test_generated_pre_commit_hook_uses_path_fallback_when_installed_path_is_sta
     commit_result = subprocess.run(
         ["git", "commit", "--allow-empty", "-m", "fallback commit"],
         cwd=tmp_path,
-        env={**os.environ, "PATH": f"{fallback_bin_dir}:/usr/bin:/bin"},
+        env=_subprocess_env(PATH=f"{fallback_bin_dir}:/usr/bin:/bin"),
         text=True,
         capture_output=True,
         check=False,
@@ -389,7 +399,7 @@ def test_generated_pre_commit_hook_honors_lefthook_zero_when_lefthook_path_is_st
     commit_result = subprocess.run(
         ["git", "commit", "-m", "skip hooks"],
         cwd=tmp_path,
-        env={**os.environ, "PATH": "/usr/bin:/bin", "LEFTHOOK": "0"},
+        env=_subprocess_env(PATH="/usr/bin:/bin", LEFTHOOK="0"),
         text=True,
         capture_output=True,
         check=False,
@@ -417,7 +427,7 @@ def test_generated_pre_commit_hook_fails_closed_in_linked_worktree_when_lefthook
     commit_result = subprocess.run(
         ["git", "commit", "-m", "test commit"],
         cwd=worktree,
-        env={**os.environ, "PATH": "/usr/bin:/bin"},
+        env=_subprocess_env(PATH="/usr/bin:/bin"),
         text=True,
         capture_output=True,
         check=False,


### PR DESCRIPTION
## Summary

takt runtime（`.takt/runtime-prepare.sh`）が全 worker へ注入する `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` が、lefthook 契約テストの subprocess 起動環境（`env={**os.environ, ...}`）へリークし、install 実行を期待するテストが skip 分岐を観測して決定的に失敗していた。

- `_subprocess_env()` ヘルパーを導入し、外側環境から `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK` を必ず除去したうえで overrides を適用する
- 同ファイル内の subprocess 起動 10 箇所すべてをヘルパー経由に統一。skip 挙動を検証するテスト（`test_lefthook_install_script_skips_when_skip_env_is_set`）のみ overrides で明示設定
- 注入設計（`.takt/runtime-prepare.sh` / `flake.nix` / docs）は変更なし（意図された設計のため）

診断結果（失敗テスト一覧・リーク経路）は https://github.com/daiki-beppu/youtube-automation/issues/2101#issuecomment-5000415342 に記録済み。

## 検証

- `uv run ruff check` / `uv run ruff format --check` … pass
- `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1 uv run pytest tests/test_lefthook_installation_contract.py` … 修正前 18 failed → 修正後 **36 passed**
- 通常環境フルスイート … 5576 passed（残る 2 errors は `tests/integration/test_dev_shell_sync.py` がローカルディスク枯渇 `No space left on device` で copytree に失敗したもので、本変更と無関係）

Closes #2101

🤖 Generated with [Claude Code](https://claude.com/claude-code)