### PR TITLE
ci: lint/test job に uv キャッシュと concurrency 自動キャンセルを導入 (#2095)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,24 @@ on:
     branches: [main, feat/1143-suno-bulk-download]
   pull_request: {}
 
+# main への push は cancel-in-progress の対象外（デプロイ相当の run を途中で殺さない）
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
       - run: nix develop --command uv sync
       - parallel:
           - name: Ruff check
@@ -23,6 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
       - name: Install dependencies
         run: nix develop --command uv sync
       - name: Test

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -17,6 +17,11 @@ on:
       - "flake.nix"
       - "flake.lock"
 
+# main への push は cancel-in-progress の対象外（デプロイ相当の run を途中で殺さない）
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- lint / test job に `actions/cache@v4` で `~/.cache/uv` を永続化（key: `uv-<OS>-<uv.lock ハッシュ>` + restore-keys フォールバック）。キャッシュヒット時の run で `uv sync` が短縮される
- `ci.yml` / `extensions.yml` に workflow レベルの `concurrency` を追加。`group: ${{ github.workflow }}-${{ github.ref }}`、`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` により、同一ブランチへの連続 push で古い run が自動キャンセルされる（main への push は完走させる）

## Nix ストアキャッシュの見送り理由（要件 2）

- magic-nix-cache（DeterminateSystems）は無料サービスが 2025 年 2 月に終了しており新規導入不可
- cachix は認証トークンの発行・Secrets 管理が必要で、`nix develop` の実測コスト（devShell は cache.nixos.org のバイナリキャッシュで大半が代替済み）に対して運用コストが見合わない
- 効果の大きい `uv sync`（30 秒 ×2 job）側のキャッシュを優先した

## 検証

- `tests/test_actions_parallel_workflows.py` / `tests/test_changelog_ci_contract.py` の契約テスト 27 件 pass（fallow audit の重量テストのみ deselect）
- 受け入れ基準（キャッシュヒット時の短縮・連続 push でのキャンセル）はこの PR の CI run 以降で確認可能

## 気づき（スコープ外・記録のみ）

- `on.push.branches` に残置ブランチ `feat/1143-suno-bulk-download` が残っている（issue 記載どおり棚卸しは別途）

Closes #2095