### PR TITLE
feat(dx): yt-skills lint サブコマンドで SKILL.md frontmatter を秒単位検証する (#2096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+- `feat(dx)`: `yt-skills lint [<skill>...]` を追加し、SKILL.md frontmatter の検証（strict YAML パース / name・description 非空 / description の double-quote）を pytest 全体実行なしで秒単位で回せるようにした。検証ロジックは CLI 側を単一ソースとし、既存の回帰テスト（tests/test_skill_frontmatter_yaml.py）は同ロジックを呼ぶ形に寄せた（#2096）。
+
 - `fix(devshell)`: 並列 run 間の共有 TMPDIR 競合（macOS の per-user TMPDIR を複数 worktree の並行 pytest が奪い合い、conftest の stale cleanup 等が run 間で干渉しうる問題）を診断し、devShell 入場時に `.lefthook/worktree-tmpdir.sh` が共有 TMPDIR 配下の worktree ごとの決定的サブディレクトリへ `TMPDIR` を分離するようにした。takt core が注入する checkout 内 TMPDIR は尊重し、解決失敗時は共有 TMPDIR のまま fail-open で続行する（#2088）。
-=======
+
 - `fix(dx)`: explicit setup 経路（`bash .lefthook/setup-worktree.sh [<command>...]`）の依存同期を fail-closed 化した。devShell 入場後に新設の `.lefthook/sync-deps.sh` が `uv sync` を明示実行し、失敗時は後続コマンドを実行せず exit 非 0 で停止する。対話 shell（direnv / `nix develop` の shellHook）は従来どおり warning 継続で入場をブロックしない（#2125）。
->>>>>>> origin/main
 
 - `feat(preflight)`: worktree / takt clone の環境不備（checkout 種別・Nix eval・lock drift・Git identity・lefthook policy）を実装着手前に read-only で検査し、`git_commit_identity` / `nix_eval` / `lock_drift` / `hook_policy` の分類キー付きで報告する CLI `yt-preflight` を追加した。identity の値は出力に含めず、lefthook は `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` の明示 skip のみ合格として曖昧な未導入を不合格にする（#2124）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ YouTube チャンネル運営を自動化するツールキット。`youtube-cha
 uv run yt-skills sync             # チャンネルリポジトリへ .claude/skills を配布（--asset claude-md で CLAUDE.md テンプレ）
 uv run yt-skills list             # 同梱スキル一覧
 uv run yt-skills diff             # 同梱版と target の差分確認
+uv run yt-skills lint [<skill>..] # SKILL.md frontmatter の軽量検証（strict YAML / double-quote。pytest 不要で秒単位）
 ```
 
 `yt-*` 系 CLI 全 30 件超は `pyproject.toml` の `[project.scripts]` に登録されている。新規 CLI を追加するときは **必ず `yt-*` プレフィックス**を踏襲し、entry point を登録すること。

--- a/src/youtube_automation/cli/skills_sync/__init__.py
+++ b/src/youtube_automation/cli/skills_sync/__init__.py
@@ -9,6 +9,7 @@ Subcommands:
     list   : 同梱アセット一覧を表示
     sync   : --target に展開 (--symlink でシンボリックリンク, --force で上書き)
     diff   : 同梱版と target の差分を表示
+    lint   : SKILL.md frontmatter を検証 (strict YAML / name・description 非空 / double-quote)
 
 Asset 種別 (`--asset`):
     all                 : デフォルト。下記すべての asset を一括処理する
@@ -190,6 +191,9 @@ from youtube_automation.cli.skills_sync._ops import _prune_orphans as _prune_orp
 from youtube_automation.cli.skills_sync._ops import _symlink_entry as _symlink_entry  # noqa: E402
 from youtube_automation.cli.skills_sync._sync import cmd_sync as cmd_sync  # noqa: E402
 from youtube_automation.cli.skills_sync._diff import cmd_diff as cmd_diff  # noqa: E402
+from youtube_automation.cli.skills_sync._lint import cmd_lint as cmd_lint  # noqa: E402
+from youtube_automation.cli.skills_sync._lint import lint_frontmatter_text as lint_frontmatter_text  # noqa: E402
+from youtube_automation.cli.skills_sync._lint import lint_skill as lint_skill  # noqa: E402
 from youtube_automation.cli.skills_sync._parser import _resolve_default_target as _resolve_default_target  # noqa: E402
 from youtube_automation.cli.skills_sync._parser import build_parser as build_parser  # noqa: E402
 

--- a/src/youtube_automation/cli/skills_sync/_lint.py
+++ b/src/youtube_automation/cli/skills_sync/_lint.py
@@ -1,0 +1,118 @@
+"""yt-skills lint — SKILL.md frontmatter の軽量検証 (Issue #2096)。
+
+skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず秒単位で回すための
+サブコマンド。検証ロジックはこのモジュールを単一ソースとし、既存の回帰テスト
+(tests/test_skill_frontmatter_yaml.py) もここを import して同じ判定基準を使う。
+
+検証内容 (Issue #652 の strict YAML 契約 + CLAUDE.md「skill frontmatter」規約):
+    1. SKILL.md が frontmatter デリミタ `---` で始まり、閉じ `---` を持つ
+    2. frontmatter が strict YAML (PyYAML safe_load) で dict として解釈できる
+    3. name / description が存在し、いずれも非空文字列
+    4. description の値が double-quoted string で書かれている
+       (値内の `: ` がマッピング区切りと誤解釈されるのを防ぐ規約)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import yaml
+
+_FRONTMATTER_DELIMITER = "---"
+
+# frontmatter 内の description 行が double-quoted string で始まることを検査する。
+# 値が複数行に折り返されていても、開始行が `description: "` であればよい。
+_DESCRIPTION_DOUBLE_QUOTED = re.compile(r'^description:\s*"', re.MULTILINE)
+
+
+def extract_frontmatter(text: str) -> str:
+    """先頭の `---` から次の `---` までの frontmatter ブロックを返す。
+
+    デリミタが欠けている場合は `ValueError` を raise する (呼び出し側で
+    violation メッセージに変換する)。
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
+        raise ValueError("SKILL.md が frontmatter デリミタ '---' で始まっていません")
+    for i in range(1, len(lines)):
+        if lines[i].strip() == _FRONTMATTER_DELIMITER:
+            return "\n".join(lines[1:i])
+    raise ValueError("frontmatter の閉じデリミタ '---' が見つかりません")
+
+
+def lint_frontmatter_text(text: str) -> list[str]:
+    """SKILL.md 全文を検証し、違反メッセージのリストを返す (空 = 合格)。
+
+    最初に構造 (デリミタ / YAML パース) を検証し、破綻していたらその時点の
+    violation だけ返す (壊れた frontmatter に対するキー検査は無意味なため)。
+    """
+    try:
+        frontmatter = extract_frontmatter(text)
+    except ValueError as exc:
+        return [str(exc)]
+
+    try:
+        parsed = yaml.safe_load(frontmatter)
+    except yaml.YAMLError as exc:
+        return [f"frontmatter が strict YAML として解釈できません: {exc}"]
+
+    if not isinstance(parsed, dict):
+        return ["frontmatter が dict として解釈できません"]
+
+    violations: list[str] = []
+    for key in ("name", "description"):
+        if key not in parsed:
+            violations.append(f"frontmatter に '{key}' がありません")
+        elif not isinstance(parsed[key], str):
+            violations.append(f"'{key}' が文字列ではありません")
+        elif not parsed[key].strip():
+            violations.append(f"'{key}' が空です")
+
+    if "description" in parsed and not _DESCRIPTION_DOUBLE_QUOTED.search(frontmatter):
+        violations.append(
+            'description が double-quoted string ではありません (CLAUDE.md 規約: description: "..." で書く)'
+        )
+
+    return violations
+
+
+def lint_skill(skill_dir: Path) -> list[str]:
+    """skill ディレクトリ 1 件を検証し、違反メッセージのリストを返す。"""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return ["SKILL.md がありません"]
+    return lint_frontmatter_text(skill_md.read_text(encoding="utf-8"))
+
+
+def cmd_lint(args: argparse.Namespace) -> int:
+    """`yt-skills lint [<skill>...]` — frontmatter を検証し違反があれば非ゼロ exit。"""
+    from youtube_automation.cli.skills_sync import _asset_root
+
+    root = _asset_root("skills")
+    available = sorted(p.name for p in root.iterdir() if p.is_dir())
+
+    requested: list[str] = getattr(args, "skills", None) or []
+    if requested:
+        unknown = sorted(set(requested) - set(available))
+        if unknown:
+            print(f"error: 存在しない skill です: {', '.join(unknown)} (source: {root})")
+            return 2
+        targets = requested
+    else:
+        targets = available
+
+    failed = 0
+    for name in targets:
+        violations = lint_skill(root / name)
+        if violations:
+            failed += 1
+            for message in violations:
+                print(f"{name}: {message}")
+
+    if failed:
+        print(f"lint 失敗: {failed}/{len(targets)} skill に違反があります (source: {root})")
+        return 1
+    print(f"lint 合格: {len(targets)} skill (source: {root})")
+    return 0

--- a/src/youtube_automation/cli/skills_sync/_parser.py
+++ b/src/youtube_automation/cli/skills_sync/_parser.py
@@ -7,6 +7,7 @@ import sys
 
 from youtube_automation.cli.skills_sync import _ASSET_SPECS, _guard_target_with_all, cmd_list
 from youtube_automation.cli.skills_sync._diff import cmd_diff
+from youtube_automation.cli.skills_sync._lint import cmd_lint
 from youtube_automation.cli.skills_sync._sync import cmd_sync
 
 
@@ -103,5 +104,19 @@ def build_parser() -> argparse.ArgumentParser:
         help=("比較先パス (default: --asset の default_target に従う、kind='file' の場合はファイルパス)"),
     )
     p_diff.set_defaults(func=cmd_diff)
+
+    p_lint = sub.add_parser(
+        "lint",
+        help="SKILL.md frontmatter を検証 (strict YAML / name・description 非空 / double-quote)",
+    )
+    p_lint.add_argument(
+        "skills",
+        nargs="*",
+        metavar="SKILL",
+        help="検証する skill 名 (省略時は全 skill)",
+    )
+    # lint は skills asset 固定 (--asset/--target は取らない)。
+    # _resolve_default_target が args.asset を参照するため default を埋めておく。
+    p_lint.set_defaults(func=cmd_lint, asset="skills")
 
     return parser

--- a/tests/test_skill_frontmatter_yaml.py
+++ b/tests/test_skill_frontmatter_yaml.py
@@ -4,8 +4,9 @@ description 値内の `: ` (コロン+スペース) は strict YAML ではマッ
 誤解釈されパースが破綻する。全 skill の frontmatter を double-quoted string に統一し、
 将来 strict YAML パーサで読む経路が追加されても壊れないことを保証する。
 
-非実行資産 (説明本文) の文言は固定しない。機械処理される契約 — frontmatter が
-safe_load で name/description を持つ dict として解釈できること — のみを検証する。
+検証ロジックの単一ソースは `yt-skills lint` 側
+(youtube_automation.cli.skills_sync._lint) にあり、本テストはそれを全 skill に
+適用する回帰テスト (Issue #2096)。判定基準を変える場合は _lint 側を修正すること。
 """
 
 from __future__ import annotations
@@ -13,45 +14,27 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+from youtube_automation.cli.skills_sync._lint import lint_skill
 
 # リポジトリルート (tests/ の親)
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
 
-_FRONTMATTER_DELIMITER = "---"
-
-_SKILL_FILES = sorted(_SKILLS_DIR.glob("*/SKILL.md"))
-
-
-def _extract_frontmatter(text: str) -> str:
-    """先頭の `---` から次の `---` までの frontmatter ブロックを返す。"""
-    lines = text.split("\n")
-    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
-        raise AssertionError("SKILL.md が frontmatter デリミタ '---' で始まっていません")
-    for i in range(1, len(lines)):
-        if lines[i].strip() == _FRONTMATTER_DELIMITER:
-            return "\n".join(lines[1:i])
-    raise AssertionError("frontmatter の閉じデリミタ '---' が見つかりません")
+_SKILL_DIRS = sorted(p.parent for p in _SKILLS_DIR.glob("*/SKILL.md"))
 
 
 def test_skill_files_discovered() -> None:
     # Given: .claude/skills 配下の SKILL.md
     # Then: 1 件以上見つかる (glob が空でないことを保証)
-    assert _SKILL_FILES, f"SKILL.md が見つかりません: {_SKILLS_DIR}"
+    assert _SKILL_DIRS, f"SKILL.md が見つかりません: {_SKILLS_DIR}"
 
 
-@pytest.mark.parametrize("skill_md", _SKILL_FILES, ids=lambda p: p.parent.name)
-def test_frontmatter_parses_with_strict_yaml(skill_md: Path) -> None:
-    # Given: SKILL.md の frontmatter
-    frontmatter = _extract_frontmatter(skill_md.read_text(encoding="utf-8"))
+@pytest.mark.parametrize("skill_dir", _SKILL_DIRS, ids=lambda p: p.name)
+def test_frontmatter_passes_lint(skill_dir: Path) -> None:
+    # Given: skill ディレクトリ
+    # When: yt-skills lint と同一の検証ロジックを適用する
+    violations = lint_skill(skill_dir)
 
-    # When: strict YAML (safe_load) で解釈する
-    parsed = yaml.safe_load(frontmatter)
-
-    # Then: name / description を持つ dict として解釈でき、いずれも非空文字列
-    assert isinstance(parsed, dict), "frontmatter が dict として解釈できません"
-    for key in ("name", "description"):
-        assert key in parsed, f"frontmatter に '{key}' がありません"
-        assert isinstance(parsed[key], str), f"'{key}' が文字列ではありません"
-        assert parsed[key].strip(), f"'{key}' が空です"
+    # Then: 違反ゼロ (strict YAML パース / name・description 非空 / double-quote)
+    assert not violations, f"{skill_dir.name}: " + "; ".join(violations)

--- a/tests/test_skills_lint.py
+++ b/tests/test_skills_lint.py
@@ -1,0 +1,131 @@
+"""yt-skills lint サブコマンドのテスト (Issue #2096)。
+
+frontmatter 検証ロジック (_lint.py) の単体検証と、CLI 経由の exit code /
+出力の検証。editable fallback を tmp_path で偽装する方式は
+tests/test_skills_sync.py と同じ。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.cli import skills_sync
+from youtube_automation.cli.skills_sync import build_parser, main
+from youtube_automation.cli.skills_sync._lint import lint_frontmatter_text, lint_skill
+
+_VALID_SKILL_MD = '---\nname: good-skill\ndescription: "Use when: 良い skill のとき"\n---\n\n# good\n'
+
+
+def _write_skill(skills_dir: Path, name: str, content: str) -> None:
+    (skills_dir / name).mkdir()
+    (skills_dir / name / "SKILL.md").write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """tmp_path にダミーの skills ツリーを仕込み editable fallback を向ける。"""
+    skills_dir = tmp_path / ".claude" / "skills"
+    skills_dir.mkdir(parents=True)
+    _write_skill(skills_dir, "good-skill", _VALID_SKILL_MD)
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+    return tmp_path
+
+
+# ---------- lint_frontmatter_text (検証ロジック単体) ----------
+
+
+def test_lint_valid_frontmatter_has_no_violations() -> None:
+    assert lint_frontmatter_text(_VALID_SKILL_MD) == []
+
+
+def test_lint_missing_opening_delimiter() -> None:
+    violations = lint_frontmatter_text("# no frontmatter\n")
+    assert len(violations) == 1
+    assert "'---' で始まっていません" in violations[0]
+
+
+def test_lint_missing_closing_delimiter() -> None:
+    violations = lint_frontmatter_text('---\nname: x\ndescription: "y"\n')
+    assert len(violations) == 1
+    assert "閉じデリミタ" in violations[0]
+
+
+def test_lint_unquoted_description_with_colon_breaks_strict_yaml() -> None:
+    # Issue #652 の本丸: 値内の `: ` が bare だとマッピング区切りと誤解釈される
+    text = "---\nname: x\ndescription: Use when: 発動条件\n---\n"
+    violations = lint_frontmatter_text(text)
+    assert violations
+    assert "strict YAML" in violations[0]
+
+
+def test_lint_unquoted_description_without_colon_violates_quote_rule() -> None:
+    # パースは通るが double-quote 規約に違反するケース
+    text = "---\nname: x\ndescription: 発動条件の説明\n---\n"
+    violations = lint_frontmatter_text(text)
+    assert any("double-quoted" in v for v in violations)
+
+
+def test_lint_missing_keys_reported_individually() -> None:
+    violations = lint_frontmatter_text("---\ntitle: x\n---\n")
+    assert any("'name' がありません" in v for v in violations)
+    assert any("'description' がありません" in v for v in violations)
+
+
+def test_lint_empty_description_violates() -> None:
+    violations = lint_frontmatter_text('---\nname: x\ndescription: "  "\n---\n')
+    assert any("'description' が空です" in v for v in violations)
+
+
+def test_lint_non_dict_frontmatter_violates() -> None:
+    violations = lint_frontmatter_text("---\n- a\n- b\n---\n")
+    assert violations == ["frontmatter が dict として解釈できません"]
+
+
+def test_lint_skill_without_skill_md(tmp_path: Path) -> None:
+    (tmp_path / "empty-skill").mkdir()
+    assert lint_skill(tmp_path / "empty-skill") == ["SKILL.md がありません"]
+
+
+# ---------- cmd_lint (CLI 経由) ----------
+
+
+def test_cli_lint_all_green_exits_zero(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["lint"]) == 0
+    out = capsys.readouterr().out
+    assert "lint 合格: 1 skill" in out
+
+
+def test_cli_lint_violation_exits_nonzero(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "bad-skill", "---\nname: bad\ndescription: Use when: 壊れる\n---\n")
+
+    assert main(["lint"]) == 1
+    out = capsys.readouterr().out
+    assert "bad-skill:" in out
+    assert "lint 失敗: 1/2 skill" in out
+
+
+def test_cli_lint_single_skill_filters_targets(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "bad-skill", "# frontmatter なし\n")
+
+    # 正常な skill だけを指定すれば bad-skill は検証されず green
+    assert main(["lint", "good-skill"]) == 0
+    out = capsys.readouterr().out
+    assert "bad-skill" not in out
+
+
+def test_cli_lint_unknown_skill_exits_two(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["lint", "no-such-skill"]) == 2
+    out = capsys.readouterr().out
+    assert "存在しない skill" in out
+    assert "no-such-skill" in out
+
+
+def test_lint_parser_registered() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["lint", "a", "b"])
+    assert args.skills == ["a", "b"]
+    assert args.asset == "skills"


### PR DESCRIPTION
## Summary

- `yt-skills lint [<skill>...]` を追加。SKILL.md frontmatter の strict YAML パース / name・description 非空 / description の double-quote を検証し、違反を skill 名つきで報告して非ゼロ exit する
- 検証ロジックは `cli/skills_sync/_lint.py` を単一ソースとし、既存の回帰テスト `tests/test_skill_frontmatter_yaml.py` は同ロジックを import する形に寄せた（二重実装なし）
- 全 48 skill の検証が約 0.5 秒で完了（従来は pytest 全体実行で約 4 分）
- exit code: 違反あり = 1 / 未知 skill 指定 = 2
- 付随修正: main にコミットされていた `CHANGELOG.md` のコンフリクトマーカー（`<<<<<<< HEAD` 等）を解消し、両エントリ（#2088 / #2125）を保持

## Test plan

- `tests/test_skills_lint.py` 新設（検証ロジック単体 + CLI exit code / 出力 / 違反フィクスチャで非ゼロ exit）
- `uv run pytest` 全体 5607 passed / ruff check・format 通過
- 実 CLI で `yt-skills lint`（48 skill, 0.5s）/ 単一 skill / 未知 skill を手動確認

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)