### PR TITLE
fix(tests): content-run-preflight で page-reload を mock し teardown 後の timer リークを塞ぐ (#2135)

### DIFF
--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -191,6 +191,14 @@ vi.mock("../lib/finished-snapshot", () => ({
   clearFinishedSnapshot: vi.fn(() => Promise.resolve()),
 }));
 
+// 完了時リロード。実物は 1 秒の実 setTimeout を残すため、FINISHED まで進めるテストでは
+// mock 必須（teardown 後に timer が発火すると location 参照が undefined で unhandled error になる）。
+// リロード契約そのものの検証は content-finished-snapshot.test.ts が担う。
+vi.mock("../lib/page-reload", () => ({
+  scheduleRunCompleteReload: vi.fn(),
+  cancelScheduledRunCompleteReload: vi.fn(),
+}));
+
 vi.mock("../../shared/api", async () => ({
   ...(await vi.importActual<typeof import("../../shared/api")>("../../shared/api")),
   postDownloaded: vi.fn(() => Promise.resolve()),


### PR DESCRIPTION
Closes #2135

## 問題

suno-helper の `tests/content-run-preflight.test.ts` が run を `PHASE.FINISHED` まで進めると、`entrypoints/content.ts` が `scheduleRunCompleteReload()` を呼び **1 秒の実 setTimeout** が残る。このテストだけ `lib/page-reload` を vi.mock していなかったため、最後の FINISHED から 1 秒以内に vitest の環境 teardown が走ると、timer が破棄済みの `globalThis.location` を参照して `TypeError: Cannot read properties of undefined (reading 'reload')` の unhandled error になり flaky に落ちていた（CI 実例: https://github.com/daiki-beppu/youtube-automation/actions/runs/29572298925 ）。

## 修正

sibling テスト（content-finished-snapshot / content-retry-handlers / content-playlist-error）と同じ形で `lib/page-reload` を vi.mock し、実 timer の発生自体を止める。リロード契約そのものの検証は従来どおり content-finished-snapshot.test.ts が担う。

## 同型リークの横断確認

`entrypoints/content` を load する全テストを走査した結果:

- 実行系で page-reload 未 mock だったのは content-run-preflight.test.ts のみ（他 3 件は mock 済み）
- ssot-dedup.test.ts / use-suno-runner-resume.test.ts はソースを文字列として読む regex テストのため timer は発生しない

## テスト

- `pnpm test tests/content-run-preflight.test.ts`: 69 passed
- suno-helper フルスイート: 53 files / 1155 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)