### PR TITLE
perf(tests): test_generate_videos_script の stub 実行ファイルを session-scope で共有する (#2092)

### DIFF
--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -158,6 +159,29 @@ esac
     return bin_dir
 
 
+_SHARED_STUB_BIN: Path | None = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _shared_stub_bin(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """stub 実行ファイル群を session で 1 回だけ作成して全テストで共有する。
+
+    #2092: macOS では新規作成した実行ファイルの初回 exec に Gatekeeper 検査で
+    数百 ms かかるため、テストごとに stub を作り直すと 1 テストあたり
+    0.5〜0.8s のオーバーヘッドになる。stub は環境変数と引数だけで挙動が決まり
+    bin ディレクトリ側に状態を持たないので、session 全体で安全に共有できる。
+    """
+    global _SHARED_STUB_BIN
+    _SHARED_STUB_BIN = _create_stub_bin(tmp_path_factory.mktemp("shared-stub"))
+    yield _SHARED_STUB_BIN
+    _SHARED_STUB_BIN = None
+
+
+def _shared_stub_bin_dir() -> Path:
+    assert _SHARED_STUB_BIN is not None, "_shared_stub_bin session fixture must provision the stub bin"
+    return _SHARED_STUB_BIN
+
+
 def _run_generate_videos(
     tmp_path: Path,
     stream_output: str,
@@ -172,7 +196,7 @@ def _run_generate_videos(
         collection = _create_collection(tmp_path, master_filename=master_filename)
     if not with_loop:
         (collection / "10-assets" / "loop.mp4").unlink(missing_ok=True)
-    bin_dir = _create_stub_bin(tmp_path)
+    bin_dir = _shared_stub_bin_dir()
     ffmpeg_log = tmp_path / "ffmpeg.log"
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
@@ -606,7 +630,6 @@ def test_static_bake_cache_reuses_short_clip(tmp_path: Path) -> None:
     )
     assert first_result.returncode == 0, first_result.stdout + first_result.stderr
 
-    shutil.rmtree(tmp_path / "bin")
     ffmpeg_log.unlink()
     second_result, second_log = _run_generate_videos(
         tmp_path,
@@ -1016,7 +1039,7 @@ def test_master_mix_takes_precedence_over_master(tmp_path: Path) -> None:
     # `master.mp3` も追加で配置 → `master-mix.wav` が優先されることを検証
     (collection / "01-master" / "master.mp3").write_bytes(b"fake-audio-mp3")
 
-    bin_dir = _create_stub_bin(tmp_path)
+    bin_dir = _shared_stub_bin_dir()
     ffmpeg_log = tmp_path / "ffmpeg.log"
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"


### PR DESCRIPTION
## Summary

`tests/test_generate_videos_script.py`（65 テスト）のファイル合計時間を **53.87s → 22.00s（-59%）** に短縮する。

## 計測による原因の特定

issue の仮説は「テストごとの実 ffmpeg / ffprobe subprocess 起動」だったが、計測の結果、実態は異なった:

- bash xtrace + 工程別プロファイルで切り分けたところ、スクリプト単体（scan 済み stub 使用）は **0.29s/回**（うち `sleep 0.15` の進捗ループが 0.157s）
- 一方テスト経由では 0.75〜1.2s/回。差分は **テストごとに stub 実行ファイル 4 本（ffmpeg/ffprobe/afinfo/jq）を新規作成し、その初回 exec に macOS Gatekeeper/XProtect 検査が走る**コストだった（新規 stub 初回: 1.17s → 同一 stub 再利用 2 回目以降: 0.30s）

## テスト分類（要件 1）

| 分類 | テスト | 対応 |
|---|---|---|
| 実 ffmpeg が本質（2 件） | `test_particles_geq_outputs_neutral_non_green_pixels_with_real_ffmpeg` / `test_bokeh_geq_preserves_warm_chroma_with_real_ffmpeg` | filtergraph の実出力ピクセルを検証する統合テスト。`shutil.which` ガード付きのまま維持 |
| コマンド組み立て・ログ検証で十分（63 件） | 上記以外すべて | **既に bash stub を使用しており実 ffmpeg は不使用**。stub bin を session-scope fixture で 1 回だけ作成し全テストで共有（issue の「session-scope キャッシュ共有」を stub バイナリに適用） |

## 変更内容

- `_shared_stub_bin` session-scope autouse fixture を追加し、`_run_generate_videos` と `test_master_mix_takes_precedence_over_master` を共有 stub 利用に変更
- stub は環境変数（`FFPROBE_*` / `FFMPEG_LOG`）と引数だけで挙動が決まり bin ディレクトリ側に状態を持たないため、共有は安全
- `test_missing_ffprobe_fails_before_ffmpeg` は bin から ffprobe を削除する（bin を変異させる）ため、従来どおり専用 stub を作成
- `test_static_bake_cache_reuses_short_clip` の `shutil.rmtree(tmp_path / "bin")` は「同一 tmp_path での `_create_stub_bin` 再呼び出しが mkdir 衝突する」ための機械的な回避だったため削除（検証意図の cache hit 判定は不変）

## 検証（要件 2, 3）

```
uv run pytest tests/test_generate_videos_script.py --durations=10
65 passed in 22.00s   # before: 53.87s
```

最遅テストも 2.84s → 1.00s。既存テストのアサーションは一切変更していない。

## スコープ外（issue どおり）

- `sleep 0.15`（進捗ループの実時間 sleep、~0.157s/run）の排除 → 別 issue
- pytest-xdist 導入 → 別 issue
- `generate_videos.sh` 本体の変更なし

Closes #2092

🤖 Generated with [Claude Code](https://claude.com/claude-code)