### PR TITLE
feat(thumbnail): Gemini CLI の TTP 既定 prompt 方針を Codex へ揃える (#2071)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -321,7 +321,7 @@ config 側のデフォルトは `image_generation.gemini.single_step.{max_attemp
 
 #### プロンプト構築
 
-TTP 生成方針は provider によらず共通: 参照サムネを winning template として扱い、winning layout を維持したまま品質改善（mobile readability / face impact / no logos / no watermarks / no broken hands）だけを指示する（codex 節の「既定テンプレート」と同じ方針。#2070）。`config.default.yaml` の `image_generation.gemini.diff_prompt_template` 既定値はこの方針行を codex 既定テンプレートと同期しており、チャンネル側 `config/skills/thumbnail.yaml` の `diff_prompt_template` があればそちらが常に優先される。
+TTP 生成方針は provider によらず共通: 参照サムネを winning template として扱い、winning layout を維持したまま品質改善（mobile readability / face impact / no logos / no watermarks / no broken hands）だけを指示する（codex 節の「既定テンプレート」と同じ方針。#2070）。`config.default.yaml` の `image_generation.gemini.diff_prompt_template` 既定値はこの方針行を codex 既定テンプレートと同期しており、チャンネル側 `config/skills/thumbnail.yaml` の `diff_prompt_template` があればそちらが常に優先される。`provider: gemini_cli`（サブスク認証の gemini CLI 経由）も同じ `diff_prompt_template` とこの構築手順を共有し、CLI ラッパーはプロンプトを方針を変えずそのまま透過する（model / CLI protocol のみ異なる。#2071、`tests/test_image_provider_gemini_cli.py` の contract test で機械担保）。
 
 1. `image_generation.gemini.color_themes` からテーマのカラー設定を取得
 2. `image_generation.gemini.diff_prompt_template` のプレースホルダーを置換してプロンプト構築:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(thumbnail)`: Gemini API 経路の既定 prompt を Codex と同じ TTP 方針（winning layout 維持・最小限の品質改善のみ）へ揃えた。`config.default.yaml` の `image_generation.gemini.diff_prompt_template` 既定値を codex 既定テンプレートと方針行を同期した TTP テンプレート（`{title_line1}` / `{title_line2}` + `${ip_safety_clause}`）にし、チャンネル側 `diff_prompt_template` override の優先（deep-merge スカラ置換）と方針同期をテストで機械担保した。SKILL.md / prompting.md に provider 差のない TTP 方針を明記した（#2070）。
 
+- `feat(thumbnail)`: gemini_cli 経路が #2070 と同じ TTP 方針（codex と同期した既定 `diff_prompt_template`）を provider 切替でも損なわないことを contract test で機械担保した。CLI ラッパー `_build_prompt` はプロンプトをそのまま透過し方針文言を独自に持たないことを検証し、SKILL.md に gemini_cli が同じ `diff_prompt_template` と構築手順を共有する旨を明記した。model / timeout / CLI protocol は変更なし（#2071）。
+
 - `feat(auth)`: git worktree 上で gitignore された `auth/` が複製されず OAuth 認証が `FileNotFoundError` になる問題に対応した。`.git` pointer ファイルと `commondir` から git コマンド非依存で main 作業ツリーを検知する `utils/worktree.py::main_worktree_root()` を追加し、worktree では `client_secrets.json` の候補列末尾に main 側 `auth/` を追加、ローカル `token.json` が無い場合は token の読み書きを main 側 `auth/token.json` に集約する（refresh 結果の分岐防止）。`CLIENT_SECRETS_DIR` 最優先・非 worktree 環境の解決順序は不変で、未検出時のエラーには探索した全候補パスを表示する（#1721）。
 
 - `fix(devshell)`: 並列 worktree の Nix キャッシュ競合（同一 fingerprint の flake を複数 worktree が同時評価すると、ユーザーグローバルな `~/.cache/nix` の eval-cache SQLite への同時書込みが「error (ignored): SQLite database ... is busy」で破棄され続け、レビュー step の遅延・再試行を誘発する問題）を診断し、`.envrc` / `.lefthook/setup-worktree.sh` / shellHook が Nix 専用の `NIX_CACHE_HOME` を worktree 分離 TMPDIR 配下へ export して各 worktree が自分の評価結果だけを参照するようにした。`XDG_CACHE_HOME` は変更せず、解決失敗時は共有キャッシュのまま fail-open で続行する（#2089）。

--- a/tests/test_image_provider_gemini_cli.py
+++ b/tests/test_image_provider_gemini_cli.py
@@ -259,3 +259,49 @@ class TestRetryAndFailure:
 
         assert result.success is True
         assert runner.call_count == 2
+
+
+# ---------- TTP 方針の透過 (#2071) ----------
+
+
+def _shipped_thumbnail_default_config() -> dict:
+    import yaml
+
+    path = Path(__file__).resolve().parents[1] / ".claude" / "skills" / "thumbnail" / "config.default.yaml"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class TestTtpPolicyPassthrough:
+    """#2071: gemini_cli 経路は #2070 の TTP 方針（codex と同期した既定 prompt）を損なわず透過する。"""
+
+    def test_build_prompt_embeds_request_prompt_verbatim(self, cli_config, request_factory):
+        provider = GeminiCliImageProvider(cli_config)
+        req = request_factory(prompt="TTP policy line A.\nTTP policy line B.")
+
+        built = provider._build_prompt(req, image_size="2K")
+
+        assert "Description: TTP policy line A.\nTTP policy line B." in built
+
+    def test_provider_switch_keeps_codex_synced_ttp_policy_lines(self, cli_config, request_factory):
+        """provider を gemini_cli に切り替えても、既定 diff_prompt_template の TTP 方針行が CLI プロンプトに残る。"""
+        config = _shipped_thumbnail_default_config()
+        codex_template = config["image_generation"]["codex"]["default_prompt_template"]
+        gemini_template = config["image_generation"]["gemini"]["diff_prompt_template"]
+        rendered = gemini_template.replace("{title_line1}", "Cozy Jazz").replace("{title_line2}", "Rainy Night")
+
+        provider = GeminiCliImageProvider(cli_config)
+        built = provider._build_prompt(request_factory(prompt=rendered), image_size="2K")
+
+        policy_lines = [line for line in codex_template.strip().splitlines() if line and "{title}" not in line]
+        assert policy_lines, "codex 既定テンプレートから方針行を抽出できません"
+        for line in policy_lines:
+            assert line in built
+
+    def test_build_prompt_wrapper_adds_no_divergent_ttp_wording(self, cli_config, request_factory):
+        """CLI ラッパー自体は TTP 方針を上書き・複製する文言を持たない（方針の SSOT は skill-config 側）。"""
+        provider = GeminiCliImageProvider(cli_config)
+
+        built = provider._build_prompt(request_factory(prompt="plain description"), image_size="2K")
+
+        for phrase in ("TTP", "winning layout", "mood reference"):
+            assert phrase not in built

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -1080,6 +1080,9 @@ def test_thumbnail_docs_state_provider_agnostic_ttp_policy() -> None:
     assert "TTP 生成方針は provider によらず共通" in skill
     assert "TTP 方針は provider 共通" in prompting
     assert "チャンネル側 override" in prompting
+    # #2071: gemini_cli 経路も同じ diff_prompt_template と構築手順を共有することを明示
+    assert "`provider: gemini_cli`" in skill
+    assert "同じ `diff_prompt_template` とこの構築手順を共有" in skill
 
 
 def test_thumbnail_default_config_codex_template_matches_skill_md_block() -> None:


### PR DESCRIPTION
## Summary

- gemini_cli 経路が #2070 の TTP 方針契約（codex と方針行を同期した既定 `diff_prompt_template`）を provider 切替でも損なわないことを contract test で機械担保（`tests/test_image_provider_gemini_cli.py::TestTtpPolicyPassthrough`）
  - `_build_prompt` が `--prompt` の内容を `Description:` として逐語で透過すること
  - gemini_cli に切り替えても codex 既定テンプレートの方針行がすべて CLI プロンプトに残ること
  - CLI ラッパー自体が TTP 方針を上書き・複製する文言を持たないこと（方針の SSOT は skill-config 側、文言の独自複製なし）
- SKILL.md「プロンプト構築」に `provider: gemini_cli` が同じ `diff_prompt_template` と構築手順を共有する旨を明記し、docs テストで固定
- runtime（`gemini_cli.py`）は無変更: model / timeout / CLI protocol は従来通り

**base は #2070 の PR #2138（スタック PR）**。#2138 の merge 後に base が main へ切り替わります。

Closes #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)