### PR TITLE
docs(extensions): ESLint と Oxlint の lint 性能を再現可能な条件で比較し記録する

### DIFF
--- a/docs/investigations/2026-07-17-2021-eslint-vs-oxlint-lint-benchmark.md
+++ b/docs/investigations/2026-07-17-2021-eslint-vs-oxlint-lint-benchmark.md
@@ -1,0 +1,98 @@
+# ESLint と Oxlint の lint 性能比較（issue #2021）
+
+#1882 の第 4 slice。#2102（Oxlint 移行）の性能主張「Oxlint は ESLint より高速」を、
+同一環境・warm cache・複数回計測で検証した記録。
+
+## 結論
+
+**高速化主張は成立する。** 両 Chrome 拡張とも、中央値ベースで Oxlint は ESLint の
+**約 30〜90 倍高速**（最も保守的なセット同士の比較でも 30 倍以上）。
+
+## 計測条件
+
+| 項目 | 値 |
+|---|---|
+| マシン | Apple M4 / 16 GB RAM / macOS 26.5.2 |
+| 実行環境 | Nix extensions shell（`nix develop .#extensions`）: Node 24.14.0 / pnpm 11.12.0 |
+| Oxlint | 1.73.0（main の現行構成: `extensions/.oxlintrc.json`） |
+| ESLint | 9.39.4 + typescript-eslint 8.60.1 + eslint-plugin-react-hooks 7.1.1（移行前コミット `554e9808^` の構成を復元） |
+| lint 対象 | suno-helper: `suno-helper` + `shared` / distrokid-helper: `distrokid-helper`（package.json の `lint` script と同一） |
+| 計測方法 | `extensions/lint-bench.sh` — linter バイナリを直接実行（pnpm 起動オーバーヘッド除外）、warmup 1 回を捨てて 10 回計測、`/usr/bin/time -p` の real の中央値 |
+| cache | warm（warmup 実行後。依存 install・`wxt prepare` 済み） |
+| セット数 | 各 linter × 各 helper で 2 セット（計 20 run ずつ） |
+
+## 測定値
+
+各 run の wall-clock（秒）と中央値。
+
+### suno-helper（対象: suno-helper + shared）
+
+| linter | set | runs | 中央値 |
+|---|---|---|---|
+| ESLint | 1 | 3.46, 4.53, 36.00, 6.56, 4.37, 20.49, 7.62, 7.56, 24.38, 19.54 | **7.590** |
+| ESLint | 2 | 6.15, 4.67, 14.33, 5.12, 4.22, 4.91, 4.04, 3.72, 4.47, 4.61 | **4.640** |
+| Oxlint | 1 | 0.06, 0.08, 0.07, 0.07, 0.06, 0.05, 0.04, 0.04, 0.04, 0.04 | **0.055** |
+| Oxlint | 2 | 0.16, 0.11, 0.11, 0.10, 0.09, 0.08, 0.08, 0.08, 0.08, 0.08 | **0.085** |
+
+→ セット中央値の比: 4.640 / 0.085 ≈ **55 倍** 〜 7.590 / 0.055 ≈ **138 倍**
+
+### distrokid-helper（対象: distrokid-helper）
+
+| linter | set | runs | 中央値 |
+|---|---|---|---|
+| ESLint | 1 | 10.54, 3.65, 3.78, 5.91, 3.74, 4.05, 3.40, 1.80, 2.49, 2.44 | **3.695** |
+| ESLint | 2 | 1.52, 1.54, 1.77, 3.13, 2.20, 3.21, 4.46, 2.85, 1.95, 2.37 | **2.285** |
+| Oxlint | 1 | 0.09, 0.08, 0.07, 0.06, 0.07, 0.06, 0.07, 0.07, 0.06, 0.08 | **0.070** |
+| Oxlint | 2 | 0.07, 0.07, 0.08, 0.08, 0.08, 0.08, 0.07, 0.07, 0.07, 0.07 | **0.070** |
+
+→ セット中央値の比: 2.285 / 0.070 ≈ **33 倍** 〜 3.695 / 0.070 ≈ **53 倍**
+
+### 参考: ambient 環境（Node 25.4.0、nix shell 外）
+
+| helper | ESLint 中央値 | Oxlint 中央値 | 比 |
+|---|---|---|---|
+| suno-helper | 2.895 | 0.165 | ≈ 18 倍 |
+| distrokid-helper | 1.470 | 0.160 | ≈ 9 倍 |
+
+環境が変わっても方向は同じ（Oxlint が 1 桁倍以上高速）。
+
+## 計測ノート（結果の解釈に必要な注意）
+
+- **ESLint 側の外れ値**: ESLint の run には背景負荷起因とみられる外れ値（最大 36s）が
+  混入した。中央値は外れ値に頑健なため記録として採用し、全 run の生値も上表に残した。
+  外れ値をすべて除外した最小値同士（ESLint 3.40s vs Oxlint 0.04s）で比較しても
+  結論は変わらない。
+- **ESLint 側の 1 error**: 移行コミット #2102 で disable コメントが oxlint 形式へ
+  変更済みのため、現行ソースを旧 ESLint 構成で lint すると
+  `content-playlist-error.test.ts` に `no-unused-vars` が 1 件報告される。
+  全ファイルの lint 作業自体は完走しており、計測値としては有効。
+- **Oxlint は Rust バイナリ**のため Node バージョンの影響を受けない。ESLint は
+  Node 上で動くため、再現時は Nix extensions shell（Node 24）を使うこと。
+
+## 再現手順
+
+```bash
+# 1. 現行（Oxlint）を計測
+nix develop .#extensions --command bash -c 'cd extensions/suno-helper && ni --frozen'
+nix develop .#extensions --command bash -c 'cd extensions/distrokid-helper && ni --frozen'
+nix develop .#extensions --command ./extensions/lint-bench.sh suno-helper 10
+nix develop .#extensions --command ./extensions/lint-bench.sh distrokid-helper 10
+
+# 2. 移行前（ESLint）構成を復元して計測
+for h in suno-helper distrokid-helper; do
+  git show 554e9808^:extensions/$h/package.json     > extensions/$h/package.json
+  git show 554e9808^:extensions/$h/pnpm-lock.yaml   > extensions/$h/pnpm-lock.yaml
+  git show 554e9808^:extensions/$h/eslint.config.js > extensions/$h/eslint.config.js
+done
+nix develop .#extensions --command bash -c 'cd extensions/suno-helper && ni --frozen'
+nix develop .#extensions --command bash -c 'cd extensions/distrokid-helper && ni --frozen'
+nix develop .#extensions --command ./extensions/lint-bench.sh suno-helper 10
+nix develop .#extensions --command ./extensions/lint-bench.sh distrokid-helper 10
+
+# 3. 現行構成へ戻す
+git checkout -- extensions/*/package.json extensions/*/pnpm-lock.yaml
+rm extensions/*/eslint.config.js
+```
+
+`extensions/lint-bench.sh` は node_modules/.bin の oxlint（優先）または eslint を
+自動検出するため、構成の切り替えだけで両者を同一手順で計測できる。

--- a/extensions/lint-bench.sh
+++ b/extensions/lint-bench.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# lint 実行時間ベンチマーク（ESLint / Oxlint 共用）
+#
+# 使い方:
+#   ./lint-bench.sh <suno-helper|distrokid-helper> [runs]
+#
+# helper の node_modules/.bin にある linter（oxlint 優先、無ければ eslint）を
+# package.json の lint script と同一の対象・設定で直接実行して計測する。
+# pnpm 起動オーバーヘッドを除外するため linter バイナリを直接叩く。
+# warm cache 前提: 計測前に 1 回 warmup 実行を捨てる。
+# 出力: 各 run の wall-clock（/usr/bin/time -p の real）と中央値。
+#
+# ESLint 側を計測する場合は、移行前コミットの構成を復元してから実行する:
+#   git show 554e9808^:extensions/<helper>/package.json    > <helper>/package.json
+#   git show 554e9808^:extensions/<helper>/pnpm-lock.yaml  > <helper>/pnpm-lock.yaml
+#   git show 554e9808^:extensions/<helper>/eslint.config.js > <helper>/eslint.config.js
+#   (cd <helper> && ni --frozen)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+helper="${1:?usage: lint-bench.sh <suno-helper|distrokid-helper> [runs]}"
+runs="${2:-10}"
+bin_dir="${helper}/node_modules/.bin"
+
+targets=("$helper")
+[[ "$helper" == "suno-helper" ]] && targets+=("shared")
+
+if [[ -x "${bin_dir}/oxlint" ]]; then
+  linter="oxlint"
+  cmd=("${bin_dir}/oxlint" -c .oxlintrc.json "${targets[@]}")
+elif [[ -x "${bin_dir}/eslint" ]]; then
+  linter="eslint"
+  cmd=("${bin_dir}/eslint" -c "${helper}/eslint.config.js" "${targets[@]}")
+else
+  echo "error: ${bin_dir} に oxlint も eslint も見つからない（ni --frozen 済みか確認）" >&2
+  exit 1
+fi
+
+echo "linter: ${linter} ($("${bin_dir}/${linter}" --version 2>/dev/null | head -1))"
+echo "targets: ${targets[*]}"
+echo "runs: ${runs} (+1 warmup)"
+
+# warmup（lint エラーがあっても計測は続行する）
+"${cmd[@]}" > /dev/null 2>&1 || true
+
+times=()
+for i in $(seq "$runs"); do
+  # lint の診断出力(stdout)は捨て、time の出力(stderr)だけを拾う
+  t=$({ /usr/bin/time -p "${cmd[@]}" > /dev/null || true; } 2>&1 | awk '/^real/{print $2}')
+  times+=("$t")
+  echo "run ${i}: ${t}s"
+done
+
+median=$(printf '%s\n' "${times[@]}" | sort -n | awk '{a[NR]=$1} END {if (NR%2) print a[(NR+1)/2]; else printf "%.3f", (a[NR/2]+a[NR/2+1])/2}')
+echo "median (${linter}, ${helper}): ${median}s"


### PR DESCRIPTION
## Summary

#1882 の第 4 slice。両 Chrome 拡張で ESLint（移行前構成 `554e9808^` を復元）と Oxlint（現行構成）を同一環境・warm cache・各 10 run × 2 セットで計測し、条件・全測定値・中央値を `docs/investigations/2026-07-17-2021-eslint-vs-oxlint-lint-benchmark.md` に記録した。

- **結論: #2102 の高速化主張は成立**。中央値ベースで suno-helper は約 55〜138 倍、distrokid-helper は約 33〜53 倍 Oxlint が高速（Nix extensions shell / Apple M4）
- 再現用の計測スクリプト `extensions/lint-bench.sh` を追加（node_modules/.bin の oxlint / eslint を自動検出、warmup 1 回 + N 回計測で中央値を出力）
- ESLint 側 run の外れ値と、旧構成 lint で出る 1 件の `no-unused-vars`（#2102 で disable コメントを oxlint 形式へ移行済みのため）は計測ノートに明記

## 検証

- `uv run pytest tests/test_extension_oxlint_contract.py` → 1 passed
- 計測後、両拡張の構成・lockfile は現行（Oxlint）へ復元済みで差分なし

Closes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)