### PR TITLE
feat(community): 投稿バッチ設定スキーマを定義する (#1707)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 ### 下流チャンネルリポジトリの config
 
-- `config/channel/*.json` は責務別分割。必須ファイルに加え optional として `shorts.json` / `comments.json` / `pinned-comment.json` / `distrokid.json` がある。一覧と構造は `CLAUDE.md`・`docs/architecture.md` を参照
+- `config/channel/*.json` は責務別分割。必須ファイルに加え optional として `shorts.json` / `comments.json` / `pinned-comment.json` / `distrokid.json` / `community-draft.json` がある。一覧と構造は `CLAUDE.md`・`docs/architecture.md` を参照
 
 ### lefthook と worktree
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(loop-video)`: `yt-generate-loop-video` に `--engine {veo,omni}` を追加した。既定の Veo 経路は維持し、`--engine omni` では Gemini Developer API の `gemini-omni-flash-preview` を API key 認証で呼び、画像→動画の一発生成、URI delivery の完了待ち、ループ補正まで行う。モデル名・timeout・poll 間隔は skill-config の `omni` セクションで上書きできる（#1722）。
 - 動画構成を明示する `video_type` 契約を追加し、loop/static の背景選択と将来の生成 hook 拡張ポイントを整備 (#1723)
+- `feat(community)`: optional の `config/channel/community-draft.json::community_draft` を型付き設定として追加し、投稿テンプレート、決定的な変数ソース、公開 timezone 基準の予約日時算出契約を定義した（#1707）。
+
 - `feat(videoup)`: `workflow-state.json` v2 の `assets.master_audio` / `assets.master_video` を基準に未動画化コレクションを検出し、既存 `generate_videos.sh` を collection 単位で並列実行する `yt-generate-videos-batch` CLI を追加した。成功時の `assets.master_video` 更新はファイルロック下で直列化し、`--include-live` と CLI / env / skill-config による並列度指定を提供する（#1658）。
 - `docs(loop-video)`: `loop.mp4` の生成・リトライ・継ぎ目補正後に動画プレイヤーを開き、静止画 fallback・動き・ループ継ぎ目を目視確認する必須承認ゲートを追加した。不受理時は `--smooth` または課金再承認付き Veo 再生成へ戻し、再プレビューで承認されるまで `/videoup` へ進まない（#1717）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ uv run yt-skills lint [<skill>..] # SKILL.md frontmatter の軽量検証（stric
 - `src/youtube_automation/{utils,agents,scripts,cli,templates}/` — コアライブラリ / アップロードエージェント / `yt-*` CLI 本体 / ユーザー向け CLI / 説明文テンプレート
 - `.claude/skills/` — 自動化スキル群（Claude Code / Codex 共用）。wheel に同梱され `yt-skills sync` で各チャンネルへ展開。`.agents/skills` は Codex CLI 探索パス用の symlink（実体は常に `.claude/skills/` 側を編集）
 - `auth/` — submodule 利用者向け後方互換 shim（OAuth 認証情報のみ）
-- 下流チャンネルリポジトリ（`CHANNEL_DIR`）: `config/channel/*.json`（責務別分割。meta / content / youtube / analytics / playlists / workflow / audio + optional の shorts.json / comments.json / pinned-comment.json / distrokid.json）、`config/localizations.json`、`auth/`、`.claude/skills/`、`collections/`、`assets/stock/`
+- 下流チャンネルリポジトリ（`CHANNEL_DIR`）: `config/channel/*.json`（責務別分割。meta / content / youtube / analytics / playlists / workflow / audio + optional の shorts.json / comments.json / pinned-comment.json / distrokid.json / community-draft.json）、`config/localizations.json`、`auth/`、`.claude/skills/`、`collections/`、`assets/stock/`
 
 ## 開発規約
 

--- a/docs/adr/0019-community-helper-extension.md
+++ b/docs/adr/0019-community-helper-extension.md
@@ -35,3 +35,47 @@ YouTube コミュニティ投稿のスケジュール投稿は、`/community-dra
 - `/community-draft` スキルを改修: markdown 廃止、JSON バッチ出力、テンプレート + 変数方式への移行
 - `release-extensions.yml` に community-helper の zip 化ステップを追加する (ADR-0011 の統一タグ `ext-v*` に従う)
 - YouTube Studio の DOM 構造変更に追従するコストが発生する (suno-helper の Suno DOM 追従と同種のリスク)
+
+## `community-draft.json` schema contract
+
+`config/channel/community-draft.json` is optional for channels that do not use the
+community batch workflow. When `/community-draft --batch` is explicitly requested,
+however, a missing file is an error: the command must stop before producing
+`community-posts.json` and identify the missing config path. It must not silently
+fall back to the legacy markdown templates.
+
+The canonical example is
+`examples/channel_config.example/community-draft.example.json`. Its top-level
+contract is:
+
+- `community_draft.posts`: a non-empty array. Every item has a non-empty `label` and `template`, an
+  integer `schedule_offset_days`, a zero-padded 24-hour `schedule_time` (`HH:MM`),
+  and an `image` path relative to the collection directory. Absolute paths and
+  paths containing `..` are invalid.
+- `community_draft.variables`: channel-owned literal values used by templates. The initial schema
+  defines `custom_message` here so batch generation remains deterministic.
+
+The initial template vocabulary is deliberately closed:
+
+| Variable | Single source | Rendering |
+|---|---|---|
+| `{title}` | `<collection>/workflow-state.json::planning.final_title` | string as stored |
+| `{date}` | `<collection>/workflow-state.json::planning.publish_target_at` | calendar date after conversion to `config/channel/youtube.json::youtube.default_publish_timezone` |
+| `{custom_message}` | `config/channel/community-draft.json::community_draft.variables.custom_message` | string as stored |
+
+Unknown variables or missing source values are errors. User input must be persisted
+to `community_draft.variables.custom_message` before batch generation; the batch command does not
+prompt for an ephemeral replacement.
+
+For each post, `scheduled_at` is calculated deterministically as follows:
+
+1. Parse `planning.publish_target_at` as ISO 8601. A date-only value is interpreted
+   in `config/channel/youtube.json::youtube.default_publish_timezone`; an instant with an offset
+   is first converted to that timezone.
+2. Take that local calendar date and add `schedule_offset_days` calendar days.
+3. Combine the resulting date with `schedule_time` in the same IANA timezone and
+   serialize it as an ISO 8601 datetime including its UTC offset.
+
+Missing or invalid `publish_target_at`, timezone, or schedule values stop generation
+with an error naming the invalid field. These rules are the input contract for
+#1709; JSON output and the removal of the markdown flow remain that issue's scope.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,7 @@ config/channel/         # 責務別分割設定（v2.0.0 以降）
   comments.json         # comments (optional)
   pinned-comment.json   # pinned_comment (optional)
   distrokid.json        # distrokid (optional)
+  community-draft.json  # community_draft (optional)
 config/localizations.json
 auth/{client_secrets,token}.json  # + 任意の token.readonly.json（read-only 系用。docs/oauth-scopes.md）
 .claude/skills/         # yt-skills sync で展開
@@ -45,7 +46,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | モジュール | 責務 |
 |---|---|
 | `utils.config` | `config/channel/*.json` の glob ロード／バリデーション。`load_config()` / `channel_dir()` / `reset()` / `ChannelConfig` を export |
-| `utils.config.{meta,content,youtube,analytics,playlists,workflow,shorts,audio,localizations,comments,pinned_comment,distrokid}` | 責務別 dataclass |
+| `utils.config.{meta,content,youtube,analytics,playlists,workflow,shorts,audio,localizations,comments,pinned_comment,distrokid,community_draft}` | 責務別 dataclass |
 | `utils.youtube_service` | YouTube API サービスファクトリ（ServiceRegistry） |
 | `utils.upload_core` | 再開可能アップロード・サムネイル圧縮の共通コア |
 | `utils.exceptions` | ドメイン例外（`AutomationError` 基底、`ConfigError` / `YouTubeAPIError` / `ValidationError` / `UploadError`） |

--- a/examples/channel_config.example/community-draft.example.json
+++ b/examples/channel_config.example/community-draft.example.json
@@ -1,0 +1,23 @@
+{
+  "community_draft": {
+    "variables": {
+      "custom_message": "Turn on notifications so you do not miss the premiere."
+    },
+    "posts": [
+      {
+        "label": "公開前ティーザー",
+        "template": "🎵 {title} が {date} に公開予定！\n{custom_message}",
+        "schedule_offset_days": -1,
+        "schedule_time": "18:00",
+        "image": "main.png"
+      },
+      {
+        "label": "公開当日リマインダー",
+        "template": "{title} is out {date}.\n{custom_message}",
+        "schedule_offset_days": 0,
+        "schedule_time": "09:00",
+        "image": "thumbnail.jpg"
+      }
+    ]
+  }
+}

--- a/src/youtube_automation/utils/config/__init__.py
+++ b/src/youtube_automation/utils/config/__init__.py
@@ -8,11 +8,13 @@
     select_channel()                 # CLI の明示 channel slug を初回解決へ渡す
     reset() -> None                  # シングルトン state をリセット（テスト用）
     ChannelConfig                    # 合成ルート dataclass（型ヒント用）
+    CommunityDraft                   # `community_draft` セクション（型ヒント用）
     Shorts                           # `shorts` セクション（型ヒント用）
     PinnedComment                    # `pinned_comment` セクション（型ヒント用）
     Distrokid                        # `distrokid` セクション（型ヒント用）
 """
 
+from youtube_automation.utils.config.community_draft import CommunityDraft
 from youtube_automation.utils.config.config import ChannelConfig
 from youtube_automation.utils.config.distrokid import Distrokid
 from youtube_automation.utils.config.loader import (
@@ -28,6 +30,7 @@ from youtube_automation.utils.config.shorts import Shorts
 
 __all__ = [
     "ChannelConfig",
+    "CommunityDraft",
     "Distrokid",
     "PinnedComment",
     "Shorts",

--- a/src/youtube_automation/utils/config/community_draft.py
+++ b/src/youtube_automation/utils/config/community_draft.py
@@ -1,0 +1,44 @@
+"""コミュニティ投稿バッチ設定の責務別 dataclass（optional）."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+from youtube_automation.utils.exceptions import ConfigError
+
+_SCHEDULE_TIME_PATTERN = re.compile(r"(?:[01]\d|2[0-3]):[0-5]\d")
+
+
+@dataclass(frozen=True)
+class CommunityDraftPost:
+    """`community_draft.posts[]` の投稿テンプレート."""
+
+    label: str
+    template: str
+    schedule_offset_days: int
+    schedule_time: str
+    image: str
+
+    def __post_init__(self) -> None:
+        if not self.label.strip():
+            raise ConfigError("community_draft.posts[].label は空文字にできません")
+        if not self.template.strip():
+            raise ConfigError("community_draft.posts[].template は空文字にできません")
+        if isinstance(self.schedule_offset_days, bool) or not isinstance(self.schedule_offset_days, int):
+            raise ConfigError("community_draft.posts[].schedule_offset_days は整数でなければなりません")
+        if _SCHEDULE_TIME_PATTERN.fullmatch(self.schedule_time) is None:
+            raise ConfigError("community_draft.posts[].schedule_time は HH:MM（24 時間表記）で指定してください")
+
+        image_path = PurePosixPath(self.image)
+        if not self.image or image_path.is_absolute() or ".." in image_path.parts:
+            raise ConfigError("community_draft.posts[].image は collection 内の安全な相対パスで指定してください")
+
+
+@dataclass(frozen=True)
+class CommunityDraft:
+    """`community_draft` セクション（optional）."""
+
+    variables: dict[str, str] = field(default_factory=dict)
+    posts: tuple[CommunityDraftPost, ...] = ()

--- a/src/youtube_automation/utils/config/config.py
+++ b/src/youtube_automation/utils/config/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from youtube_automation.utils.config.analytics import Analytics
 from youtube_automation.utils.config.audio import Audio
 from youtube_automation.utils.config.comments import Comments
+from youtube_automation.utils.config.community_draft import CommunityDraft
 from youtube_automation.utils.config.content import Content
 from youtube_automation.utils.config.distrokid import Distrokid
 from youtube_automation.utils.config.localizations import Localizations
@@ -32,5 +33,6 @@ class ChannelConfig:
     audio: Audio
     localizations: Localizations
     comments: Comments
+    community_draft: CommunityDraft
     pinned_comment: PinnedComment
     distrokid: Distrokid

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -21,6 +21,7 @@ from youtube_automation.utils.config.comments import (
     Comments,
     GeneratorConfig,
 )
+from youtube_automation.utils.config.community_draft import CommunityDraft, CommunityDraftPost
 from youtube_automation.utils.config.config import ChannelConfig
 from youtube_automation.utils.config.content import Content, Descriptions, Genre, Tags, Title
 from youtube_automation.utils.config.distrokid import (
@@ -289,6 +290,7 @@ def _assemble(merged: dict, channel_dir_path: Path) -> ChannelConfig:
     audio = _build_audio(merged)
     localizations = _load_localizations(channel_dir_path, youtube.api.language)
     comments = _build_comments(merged)
+    community_draft = _build_community_draft(merged)
     pinned_comment = _build_pinned_comment(merged)
     distrokid = _build_distrokid(merged)
 
@@ -305,6 +307,7 @@ def _assemble(merged: dict, channel_dir_path: Path) -> ChannelConfig:
         audio=audio,
         localizations=localizations,
         comments=comments,
+        community_draft=community_draft,
         pinned_comment=pinned_comment,
         distrokid=distrokid,
     )
@@ -819,6 +822,50 @@ def _build_generator_config(raw: dict) -> GeneratorConfig:
         fallback_on_error=fallback,
         requests_per_minute=int(raw.get("requests_per_minute", REQUESTS_PER_MINUTE_DEFAULT)),
     )
+
+
+def _build_community_draft(merged: dict) -> CommunityDraft:
+    raw = merged.get("community_draft")
+    if raw is None:
+        return CommunityDraft()
+    if not isinstance(raw, dict):
+        raise ConfigError("community_draft セクションは object でなければなりません")
+
+    variables_raw = raw.get("variables", {})
+    if not isinstance(variables_raw, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str) for key, value in variables_raw.items()
+    ):
+        raise ConfigError("community_draft.variables は string 値の object でなければなりません")
+
+    posts_raw = raw.get("posts")
+    if not isinstance(posts_raw, list) or not posts_raw:
+        raise ConfigError("community_draft.posts は空でない array でなければなりません")
+
+    required_fields = {"label", "template", "schedule_offset_days", "schedule_time", "image"}
+    posts: list[CommunityDraftPost] = []
+    for index, post_raw in enumerate(posts_raw):
+        prefix = f"community_draft.posts[{index}]"
+        if not isinstance(post_raw, dict):
+            raise ConfigError(f"{prefix} は object でなければなりません")
+        missing = required_fields - post_raw.keys()
+        unexpected = post_raw.keys() - required_fields
+        if missing:
+            raise ConfigError(f"{prefix} に必須キーがありません: {', '.join(sorted(missing))}")
+        if unexpected:
+            raise ConfigError(f"{prefix} に未知のキーがあります: {', '.join(sorted(unexpected))}")
+        if not all(isinstance(post_raw[key], str) for key in ("label", "template", "schedule_time", "image")):
+            raise ConfigError(f"{prefix} の label/template/schedule_time/image は string でなければなりません")
+        posts.append(
+            CommunityDraftPost(
+                label=post_raw["label"],
+                template=post_raw["template"],
+                schedule_offset_days=post_raw["schedule_offset_days"],
+                schedule_time=post_raw["schedule_time"],
+                image=post_raw["image"],
+            )
+        )
+
+    return CommunityDraft(variables=dict(variables_raw), posts=tuple(posts))
 
 
 def _build_comments(merged: dict) -> Comments:

--- a/tests/test_community_draft_schema_contract.py
+++ b/tests/test_community_draft_schema_contract.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from youtube_automation.utils.config.community_draft import CommunityDraftPost
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_PATH = REPO_ROOT / "examples/channel_config.example/community-draft.example.json"
+ADR_PATH = REPO_ROOT / "docs/adr/0019-community-helper-extension.md"
+
+
+def test_community_draft_example_defines_required_post_fields() -> None:
+    example = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+    posts = tuple(CommunityDraftPost(**post) for post in example["community_draft"]["posts"])
+
+    assert posts
+
+
+def test_community_draft_contract_fixes_sources_and_schedule_semantics() -> None:
+    text = ADR_PATH.read_text(encoding="utf-8")
+
+    for required in (
+        "workflow-state.json::planning.final_title",
+        "workflow-state.json::planning.publish_target_at",
+        "community-draft.json::community_draft.variables.custom_message",
+        "youtube.json::youtube.default_publish_timezone",
+        "schedule_offset_days",
+        "schedule_time",
+        "ISO 8601 datetime including its UTC offset",
+        "missing file is an error",
+    ):
+        assert required in text

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -136,11 +136,89 @@ def test_load_minimal_sections(tmp_path, monkeypatch):
     assert config.comments.rules == []
     assert config.comments.generator.provider == "codex"
     assert config.comments.max_replies_per_run == 20
+    assert config.community_draft.posts == ()
+    assert config.community_draft.variables == {}
     # pinned_comment も optional、欠如時は enabled=False のデフォルト
     assert config.pinned_comment.enabled is False
     assert config.pinned_comment.templates == {}
     assert config.pinned_comment.history_file == "pinned_comment_history.json"
     assert config.pinned_comment.default_language == "en"
+
+
+def test_community_draft_section_loads_typed_posts(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["community-draft.json"] = {
+        "community_draft": {
+            "variables": {"custom_message": "Do not miss it."},
+            "posts": [
+                {
+                    "label": "teaser",
+                    "template": "{title}: {custom_message}",
+                    "schedule_offset_days": -1,
+                    "schedule_time": "18:00",
+                    "image": "main.png",
+                }
+            ],
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+
+    assert config.community_draft.variables == {"custom_message": "Do not miss it."}
+    assert len(config.community_draft.posts) == 1
+    post = config.community_draft.posts[0]
+    assert post.label == "teaser"
+    assert post.schedule_offset_days == -1
+    assert post.schedule_time == "18:00"
+    assert post.image == "main.png"
+
+
+@pytest.mark.parametrize("schedule_time", ["9:00", "24:00", "12:60", 900])
+def test_community_draft_rejects_invalid_schedule_time(tmp_path, monkeypatch, schedule_time):
+    sections = _minimal_sections()
+    sections["community-draft.json"] = {
+        "community_draft": {
+            "posts": [
+                {
+                    "label": "teaser",
+                    "template": "{title}",
+                    "schedule_offset_days": 0,
+                    "schedule_time": schedule_time,
+                    "image": "main.png",
+                }
+            ]
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match="schedule_time"):
+        load_config()
+
+
+@pytest.mark.parametrize("image", ["/tmp/main.png", "../main.png", "assets/../../secret"])
+def test_community_draft_rejects_unsafe_image_paths(tmp_path, monkeypatch, image):
+    sections = _minimal_sections()
+    sections["community-draft.json"] = {
+        "community_draft": {
+            "posts": [
+                {
+                    "label": "teaser",
+                    "template": "{title}",
+                    "schedule_offset_days": 0,
+                    "schedule_time": "18:00",
+                    "image": image,
+                }
+            ]
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match="image"):
+        load_config()
 
 
 def test_synthetic_media_flags_default(tmp_path, monkeypatch):


### PR DESCRIPTION
## 概要

- `community_draft` optional config を `load_config()` の型付き section として追加
- 投稿テンプレート、変数ソース、timezone 付き予約日時算出契約を ADR と example に固定
- 不正時刻・危険な画像相対パス・不正 schema を fail-fast 検証

## 検証

- `uv run pytest tests/test_config_loader.py tests/test_community_draft_schema_contract.py tests/test_skill_docs_consistency.py -q` — 266 passed
- `uv run pytest -n auto -q` — 6231 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- Standards / Spec 独立レビューの blocking finding 修正済み

Closes #1707