### PR TITLE
feat(collection-serve): コミュニティ投稿ルートを追加する (#1710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(collection-serve)`: community-helper 向けに `GET /community/posts.json` と投稿画像ルートを追加し、channel root 内の画像だけを Content-Type 付きで配信する。Chrome 拡張と YouTube Studio origin の CORS、および共有 route 定数を同時に追加した（#1710）。
 - `feat(community)`: `/community-draft` を `--batch` 専用の決定的 JSON generator へ移行し、旧 type 別 Markdown／clipboard フローを撤去した（#1709）。
 
 ### Added

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -37,6 +37,16 @@ export const DOWNLOAD_FORMAT_DEFAULT = "mp3" as const;
 /** yt-collection-serve が prompts を配信するサブパス (#698 で `/prompts.json` から分離)。 */
 export const PROMPTS_ROUTE = "/suno/prompts.json";
 
+/** community-helper が投稿 JSON を取得するサブパス (#1710)。
+ * SSOT 対応: collection_serve.py COMMUNITY_POSTS_ROUTE。 */
+// fallow-ignore-next-line unused-export -- community-helper API client (#1711) が後続で参照する公開契約。
+export const COMMUNITY_POSTS_ROUTE = "/community/posts.json";
+
+/** community-helper が投稿画像を取得するサブパスの prefix (#1710)。
+ * `${COMMUNITY_IMAGE_ROUTE}/${index}/image` として使う。 */
+// fallow-ignore-next-line unused-export -- community-helper API client (#1711) が後続で参照する公開契約。
+export const COMMUNITY_IMAGE_ROUTE = "/community/posts";
+
 /** yt-collection-serve dir mode の collection 列挙サブパス (#816)。
  * SSOT: src/youtube_automation/scripts/suno_artifacts.py COLLECTIONS_ROUTE。 */
 export const COLLECTIONS_ROUTE = "/collections";

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -6,6 +6,8 @@ issue #698: #692 の `yt-suno-serve` を一般化し、エンドポイントを�
 - `GET /suno/prompts.json` … suno-prompts.json 配列 JSON（#692 契約不変）
 - `GET /distrokid/release.json` … profile + collection 動的データのマージ JSON
 - `GET /distrokid/assets/<path>` … 曲・ジャケットファイルの binary 配信
+- `GET /community/posts.json` … community-posts.json の投稿配列
+- `GET /community/posts/<index>/image` … 投稿画像の binary 配信
 
 起動中は port 別 PID ファイルを記録し、`--stop --port <PORT>` または HTTP request の
 idle timeout（既定 60 分）で終了する。同一 port かつ同一構成の生存 server は再利用する。
@@ -88,7 +90,7 @@ _LIFECYCLE_ROUTE_PREFIX = "/.well-known/yt-collection-serve-lifecycle/"
 MIN_EXTENSION_VERSION = "0.2.0"
 _EXTENSION_ORIGIN_SCHEME = "chrome-extension://"
 # overlay 化（#892/#895）で content script の fetch が page origin になったため、
-# helper 拡張がホストされる web origin をデフォルト許可する（#896）。完全一致のみ。
+# helper 拡張がホストされる web origin をデフォルト許可する（#896/#1710）。完全一致のみ。
 _DEFAULT_ALLOWED_WEB_ORIGINS = frozenset(
     {
         "https://suno.com",
@@ -112,6 +114,13 @@ _DISTROKID_METADATA_FILENAME = "metadata.md"
 # distrokid-helper 拡張と対の契約（extensions/shared/constants.ts に追加予定）。
 _DISTROKID_COLLECTIONS_ROUTE = "/distrokid/collections"
 _DISTROKID_RELEASES_ROUTE = "/distrokid/releases"
+
+# community-helper と対の公開 HTTP 契約。extensions/shared/constants.ts に同値を置く。
+COMMUNITY_POSTS_ROUTE = "/community/posts.json"
+COMMUNITY_IMAGE_ROUTE = "/community/posts"
+_COMMUNITY_POSTS_RELPATH = Path("30-promo") / "community-posts.json"
+_COMMUNITY_IMAGE_ROUTE_PATTERN = re.compile(r"^/community/posts/(?P<index>\d+)/image$")
+_YOUTUBE_STUDIO_ORIGIN = "https://studio.youtube.com"
 
 # POST body upper bound for helper write endpoints. The expected payloads are
 # small JSON objects/lists; larger bodies are rejected before reading from rfile.
@@ -559,6 +568,59 @@ def resolve_collection_prompts_path(root: Path, cid: str) -> Path | None:
     return root / cid / DOCUMENTATION_DIRNAME / SUNO_PROMPTS_JSON_FILENAME
 
 
+def _resolve_single_mode_prompts_path(path: Path) -> Path | None:
+    """Suno または community の成果物を持つ single collection を受理する。"""
+    try:
+        return resolve_prompts_path(path)
+    except ConfigError:
+        if path.is_dir() and (path / _COMMUNITY_POSTS_RELPATH).is_file():
+            return None
+        raise
+
+
+def _read_community_posts(collection_dir: Path) -> list[dict] | None:
+    """community-draft の envelope を外部 API の CommunityPost[] に正規化する。"""
+    posts_path = collection_dir / _COMMUNITY_POSTS_RELPATH
+    if not posts_path.is_file():
+        return None
+    try:
+        payload = json.loads(posts_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ConfigError(f"community-posts.json を読み込めません: {posts_path}: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("posts"), list):
+        raise ConfigError(f"community-posts.json::posts は配列でなければなりません: {posts_path}")
+    posts = payload["posts"]
+    if not all(isinstance(post, dict) for post in posts):
+        raise ConfigError(f"community-posts.json::posts[] は object でなければなりません: {posts_path}")
+    return posts
+
+
+def _resolve_community_image(
+    collection_dir: Path,
+    community_asset_root: Path,
+    index: int,
+) -> Path | None:
+    """投稿 index の画像を channel root 内だけに解決する。画像なし・不在は None。"""
+    posts = _read_community_posts(collection_dir)
+    if posts is None or index >= len(posts):
+        return None
+    image_path = posts[index].get("image_path")
+    if image_path is None:
+        return None
+    if not isinstance(image_path, str) or not image_path:
+        raise ConfigError("community-posts.json::posts[].image_path は string または null でなければなりません")
+    root = community_asset_root.resolve()
+    collection_root = collection_dir.resolve()
+    resolved = (root / image_path).resolve()
+    try:
+        resolved.relative_to(root)
+        resolved.relative_to(collection_root)
+    except ValueError:
+        return None
+    content_type = mimetypes.guess_type(resolved.name)[0]
+    return resolved if resolved.is_file() and content_type is not None and content_type.startswith("image/") else None
+
+
 def is_origin_allowed(origin: str | None, allow_origin: str | None) -> bool:
     """CORS 判定.
 
@@ -575,12 +637,19 @@ def is_origin_allowed(origin: str | None, allow_origin: str | None) -> bool:
     return origin in _DEFAULT_ALLOWED_WEB_ORIGINS
 
 
-def _is_read_origin_allowed(origin: str | None, allow_origin: str | None) -> bool:
+def _is_community_route(path: str) -> bool:
+    return path == COMMUNITY_POSTS_ROUTE or _COMMUNITY_IMAGE_ROUTE_PATTERN.fullmatch(path) is not None
+
+
+def _is_read_origin_allowed(origin: str | None, allow_origin: str | None, path: str) -> bool:
     """Read-only GET/OPTIONS CORS 判定.
 
     `--allow-origin` 指定時は read-only も exact lock に従う。Suno overlay から
-    必要な read API は background script が extension origin で取得する。
+    必要な read API は background script が extension origin で取得する。既定の
+    YouTube Studio page origin は community route だけに許可し、他成果物へ波及させない。
     """
+    if allow_origin is None and origin == _YOUTUBE_STUDIO_ORIGIN:
+        return _is_community_route(path)
     return is_origin_allowed(origin, allow_origin)
 
 
@@ -943,6 +1012,7 @@ def create_server(
     prompts_path: Path | None,
     collection_dir: Path | None,
     distrokid: Distrokid | None,
+    community_asset_root: Path | None = None,
     collections_root: Path | None = None,
     distrokid_source: str | None = None,
     capture_root: Path | None = None,
@@ -968,6 +1038,7 @@ def create_server(
     resolved_server_info = (
         server_info if server_info is not None else build_server_info("YouTube Automation", "YA", port)
     )
+    resolved_community_asset_root = community_asset_root if community_asset_root is not None else collection_dir
 
     class _Handler(BaseHTTPRequestHandler):
         def _allowed_origin(self) -> str | None:
@@ -976,7 +1047,7 @@ def create_server(
                 return None
             origin = headers.get("Origin")
             if self.command in {"GET", "HEAD", "OPTIONS"}:
-                return origin if _is_read_origin_allowed(origin, allow_origin) else None
+                return origin if _is_read_origin_allowed(origin, allow_origin, self.path) else None
             return origin if is_origin_allowed(origin, allow_origin) else None
 
         def _send_cors(self, origin: str | None) -> None:
@@ -1244,7 +1315,42 @@ def create_server(
             if dir_mode:
                 self._serve_dir_mode()
                 return
+            if self.path == COMMUNITY_POSTS_ROUTE:
+                assert collection_dir is not None
+                try:
+                    posts = _read_community_posts(collection_dir)
+                except ConfigError as exc:
+                    self._send_json_error(500, str(exc))
+                    return
+                if posts is None:
+                    self.send_error(404, "Not Found")
+                    return
+                body = json.dumps(posts, ensure_ascii=False).encode("utf-8")
+                self._send_bytes(body, "application/json; charset=utf-8")
+                return
+            community_image_match = _COMMUNITY_IMAGE_ROUTE_PATTERN.fullmatch(self.path)
+            if community_image_match is not None:
+                assert collection_dir is not None
+                assert resolved_community_asset_root is not None
+                try:
+                    image = _resolve_community_image(
+                        collection_dir,
+                        resolved_community_asset_root,
+                        int(community_image_match.group("index")),
+                    )
+                except ConfigError as exc:
+                    self._send_json_error(500, str(exc))
+                    return
+                if image is None:
+                    self.send_error(404, "Not Found")
+                    return
+                content_type = mimetypes.guess_type(image.name)[0] or "application/octet-stream"
+                self._send_bytes(image.read_bytes(), content_type)
+                return
             if self.path == SUNO_PROMPTS_ROUTE:
+                if prompts_path is None:
+                    self.send_error(404, "Not Found")
+                    return
                 self._send_bytes(prompts_path.read_bytes(), "application/json; charset=utf-8")
                 return
             if self.path == DISTROKID_RELEASE_ROUTE:
@@ -1431,8 +1537,8 @@ def _resolve_allow_origin(
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Serve collection artifacts over localhost HTTP for the suno-helper / "
-            "distrokid-helper Chrome extensions (subpaths: /suno/*, /distrokid/*)."
+            "Serve collection artifacts over localhost HTTP for the suno-helper / distrokid-helper / "
+            "community-helper Chrome extensions (subpaths: /suno/*, /distrokid/*, /community/*)."
         ),
     )
     parser.add_argument(
@@ -1541,7 +1647,8 @@ def main() -> None:
             channel_short = "YA"
         distrokid_capture_active = distrokid_cfg is not None and distrokid_cfg.enabled
     else:
-        prompts_path = resolve_prompts_path(args.path)
+        # community-draft だけを使う collection は suno-prompts.json を持たなくても起動可能。
+        prompts_path = _resolve_single_mode_prompts_path(args.path)
         # collection dir: dir 引数はそのまま、json ファイル引数なら <collection>/20-documentation/x.json から 2 階層上。
         collection_dir = args.path if args.path.is_dir() else args.path.parent.parent
         config = load_config()
@@ -1581,6 +1688,7 @@ def main() -> None:
                 server_info=server_info,
                 prompts_path=prompts_path,
                 collection_dir=collection_dir,
+                community_asset_root=channel_dir(),
                 distrokid=distrokid,
                 distrokid_source=args.distrokid_source,
                 capture_root=capture_root,
@@ -1632,7 +1740,10 @@ def main() -> None:
                 f"{COLLECTIONS_ROUTE}/<id>/distrokid/<disc>/release.json"
             )
     else:
-        print(f"Serving {collection_dir} at {canonical_url}{SUNO_PROMPTS_ROUTE}")
+        print(f"Serving {collection_dir} at {canonical_url}")
+        if prompts_path is not None:
+            print(f"  suno endpoint: {SUNO_PROMPTS_ROUTE}")
+        print(f"  community endpoints: {COMMUNITY_POSTS_ROUTE}, {COMMUNITY_IMAGE_ROUTE}/<index>/image")
         print(f"  legacy URL: http://localhost:{port}{SUNO_PROMPTS_ROUTE}")
         print(f"  selector label: {server_info['label']}")
         if distrokid.enabled:

--- a/tests/test_community_endpoint.py
+++ b/tests/test_community_endpoint.py
@@ -1,0 +1,251 @@
+"""community-helper 向け collection-serve HTTP 契約（#1710）。"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from youtube_automation.scripts import collection_serve as collection_serve_module
+from youtube_automation.scripts.collection_serve import create_server, main
+
+_COMMUNITY_POSTS_ROUTE = "/community/posts.json"
+_COMMUNITY_IMAGE_ROUTE = "/community/posts"
+_EXTENSION_ORIGIN = "chrome-extension://abcdefghijklmnopabcdefghijklmnop"
+_STUDIO_ORIGIN = "https://studio.youtube.com"
+
+
+@pytest.fixture
+def serve_community(tmp_path):
+    started = []
+
+    def _start(posts: list[dict], *, image: tuple[str, bytes] | None = None) -> str:
+        collection = tmp_path / "collections" / "planning" / "20260718-community-collection"
+        promo = collection / "30-promo"
+        promo.mkdir(parents=True)
+        (promo / "community-posts.json").write_text(
+            json.dumps({"posts": posts}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        if image is not None:
+            image_path = tmp_path / image[0]
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            image_path.write_bytes(image[1])
+
+        server = create_server(
+            0,
+            None,
+            prompts_path=None,
+            collection_dir=collection,
+            community_asset_root=tmp_path,
+            distrokid=None,
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        started.append((server, thread))
+        return f"http://localhost:{server.server_address[1]}"
+
+    yield _start
+
+    for server, thread in started:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_get_community_posts_returns_post_array(serve_community):
+    posts = [
+        {
+            "text": "公開のお知らせ",
+            "scheduled_at": "2026-07-19T18:00:00+09:00",
+            "image_path": None,
+            "visibility": "public",
+        }
+    ]
+    base = serve_community(posts)
+
+    with urllib.request.urlopen(f"{base}{_COMMUNITY_POSTS_ROUTE}") as response:
+        assert response.status == 200
+        assert response.headers.get_content_type() == "application/json"
+        assert json.loads(response.read().decode("utf-8")) == posts
+
+
+def test_community_only_server_returns_404_for_suno_route(serve_community):
+    base = serve_community([])
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}/suno/prompts.json")
+
+    assert exc_info.value.code == 404
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "content_type"),
+    [
+        ("collections/planning/20260718-community-collection/main.png", "image/png"),
+        ("collections/planning/20260718-community-collection/main.jpg", "image/jpeg"),
+    ],
+)
+def test_get_community_image_returns_binary_with_detected_content_type(
+    serve_community, relative_path: str, content_type: str
+):
+    image = b"image-binary"
+    base = serve_community(
+        [{"text": "post", "scheduled_at": "2026-07-19T18:00:00+09:00", "image_path": relative_path}],
+        image=(relative_path, image),
+    )
+
+    with urllib.request.urlopen(f"{base}{_COMMUNITY_IMAGE_ROUTE}/0/image") as response:
+        assert response.status == 200
+        assert response.headers.get_content_type() == content_type
+        assert response.read() == image
+
+
+def test_get_community_image_returns_404_when_image_path_is_null(serve_community):
+    base = serve_community([{"text": "post", "scheduled_at": "2026-07-19T18:00:00+09:00", "image_path": None}])
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}{_COMMUNITY_IMAGE_ROUTE}/0/image")
+
+    assert exc_info.value.code == 404
+
+
+def test_get_community_image_rejects_path_outside_channel_root(serve_community, tmp_path):
+    outside = tmp_path.parent / "outside.png"
+    outside.write_bytes(b"secret")
+    base = serve_community(
+        [{"text": "post", "scheduled_at": "2026-07-19T18:00:00+09:00", "image_path": "../outside.png"}]
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}{_COMMUNITY_IMAGE_ROUTE}/0/image")
+
+    assert exc_info.value.code == 404
+
+
+def test_get_community_image_rejects_channel_file_outside_collection(serve_community, tmp_path):
+    secret = tmp_path / "auth" / "token.png"
+    secret.parent.mkdir()
+    secret.write_bytes(b"secret")
+    base = serve_community(
+        [{"text": "post", "scheduled_at": "2026-07-19T18:00:00+09:00", "image_path": "auth/token.png"}]
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}{_COMMUNITY_IMAGE_ROUTE}/0/image")
+
+    assert exc_info.value.code == 404
+
+
+def test_get_community_image_rejects_non_image_file(serve_community):
+    relative_path = "collections/planning/20260718-community-collection/secret.json"
+    base = serve_community(
+        [{"text": "post", "scheduled_at": "2026-07-19T18:00:00+09:00", "image_path": relative_path}],
+        image=(relative_path, b'{"token": "secret"}'),
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}{_COMMUNITY_IMAGE_ROUTE}/0/image")
+
+    assert exc_info.value.code == 404
+
+
+@pytest.mark.parametrize("origin", [_EXTENSION_ORIGIN, _STUDIO_ORIGIN])
+def test_community_routes_allow_required_cors_origins(serve_community, origin: str):
+    base = serve_community([])
+    request = urllib.request.Request(f"{base}{_COMMUNITY_POSTS_ROUTE}", headers={"Origin": origin})
+
+    with urllib.request.urlopen(request) as response:
+        assert response.headers.get("Access-Control-Allow-Origin") == origin
+
+
+def test_studio_origin_is_not_allowed_to_read_non_community_routes(serve_community):
+    base = serve_community([])
+    request = urllib.request.Request(f"{base}/version", headers={"Origin": _STUDIO_ORIGIN})
+
+    with urllib.request.urlopen(request) as response:
+        assert response.headers.get("Access-Control-Allow-Origin") is None
+
+
+def test_shared_route_constants_match_server_contract():
+    constants = (Path(__file__).parents[1] / "extensions/shared/constants.ts").read_text(encoding="utf-8")
+
+    assert 'export const COMMUNITY_POSTS_ROUTE = "/community/posts.json"' in constants
+    assert 'export const COMMUNITY_IMAGE_ROUTE = "/community/posts"' in constants
+
+
+def test_dir_mode_does_not_expose_initial_scope_community_routes(tmp_path):
+    collection = tmp_path / "20260718-community-collection"
+    (collection / "30-promo").mkdir(parents=True)
+    (collection / "30-promo/community-posts.json").write_text('{"posts": []}', encoding="utf-8")
+    server = create_server(
+        0,
+        None,
+        prompts_path=None,
+        collection_dir=None,
+        collections_root=tmp_path,
+        distrokid=None,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://localhost:{server.server_address[1]}"
+    try:
+        for route in (_COMMUNITY_POSTS_ROUTE, f"{_COMMUNITY_IMAGE_ROUTE}/0/image"):
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                urllib.request.urlopen(f"{base}{route}")
+            assert exc_info.value.code == 404
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_main_accepts_community_only_collection(tmp_path, monkeypatch):
+    collection = tmp_path / "collections" / "planning" / "20260718-community-collection"
+    (collection / "30-promo").mkdir(parents=True)
+    (collection / "30-promo/community-posts.json").write_text('{"posts": []}', encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    class FakeServer:
+        server_address = ("localhost", 0)
+
+        def serve_forever(self) -> None:
+            raise KeyboardInterrupt
+
+        def server_close(self) -> None:
+            pass
+
+    class FakeDiscoveryLifecycle:
+        def start(self) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    def fake_create_server(port: int, allow_origin: str | None, **kwargs: object) -> FakeServer:
+        captured.update(kwargs)
+        return FakeServer()
+
+    config = SimpleNamespace(
+        distrokid=SimpleNamespace(enabled=False),
+        meta=SimpleNamespace(channel_name="Test", channel_short="T"),
+    )
+    monkeypatch.setattr(collection_serve_module, "load_config", lambda: config)
+    monkeypatch.setattr(collection_serve_module, "channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(collection_serve_module, "create_server", fake_create_server)
+    monkeypatch.setattr(
+        collection_serve_module,
+        "create_discovery_lifecycle",
+        lambda _server_info: FakeDiscoveryLifecycle(),
+    )
+    monkeypatch.setattr(sys, "argv", ["yt-collection-serve", str(collection), "--port", "0"])
+
+    main()
+
+    assert captured["prompts_path"] is None
+    assert captured["collection_dir"] == collection
+    assert captured["community_asset_root"] == tmp_path


### PR DESCRIPTION
## Summary
- community-draft の envelope を `CommunityPost[]` として返す read-only endpoint を追加
- 投稿画像を対象 collection 内の `image/*` に限定して Content-Type 付きで配信
- YouTube Studio CORS を community route のみに限定し、shared route constants を追加
- Suno prompts のない community-only collection でも single mode 起動を可能化

## Validation
- `uv run pytest -n auto -q` (6282 passed)
- collection-serve related suites (351 passed)
- `tests/test_community_endpoint.py` (14 passed)
- Ruff check / format / diff check
- shared TypeScript formatter + suno-helper compile
- independent standards/spec reviews: clean

Closes #1710