### PR TITLE
feat(extensions): コミュニティ投稿API契約を追加する (#1711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(extensions)`: community-helper 共通層に `CommunityPost` wire 型、投稿 JSON／画像の fail-loud API client、runner フェーズ定数を追加した（#1711）。
 - `feat(collection-serve)`: community-helper 向けに `GET /community/posts.json` と投稿画像ルートを追加し、channel root 内の画像だけを Content-Type 付きで配信する。Chrome 拡張と YouTube Studio origin の CORS、および共有 route 定数を同時に追加した（#1710）。
 - `feat(community)`: `/community-draft` を `--batch` 専用の決定的 JSON generator へ移行し、旧 type 別 Markdown／clipboard フローを撤去した（#1709）。
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -4,6 +4,8 @@ import {
   collectionDownloadedRoute,
   collectionPromptsRoute,
   COLLECTIONS_ROUTE,
+  COMMUNITY_IMAGE_ROUTE,
+  COMMUNITY_POSTS_ROUTE,
   DISTROKID_COLLECTIONS_ROUTE,
   DISTROKID_RELEASES_ROUTE,
   SERVER_INFO_ROUTE,
@@ -32,6 +34,17 @@ export interface PromptEntry {
    * Suno 側の解釈とサーバー契約を揃えるため空文字は許容せず Python 側で省略する。
    */
   vocal_gender?: "male" | "female" | "neutral" | "auto";
+}
+
+/** `/community/posts.json` が返す投稿スキーマ (#1709/#1710)。 */
+export interface CommunityPost {
+  text: string;
+  scheduled_at: string;
+  /** #1709 の実 wire。channel root 相対。画像なしは null。 */
+  image_path?: string | null;
+  /** 旧 #1200 で定義された互換フィールド。 */
+  image_url?: string;
+  visibility?: "public" | "members_only";
 }
 
 /** collection 単位の Suno duration guard 閾値 (#1259)。秒単位。 */
@@ -186,9 +199,100 @@ function assertOptionalString(
   return assertString(value, field);
 }
 
+function assertOptionalNullableString(
+  value: unknown,
+  field: string
+): string | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return assertString(value, field);
+}
+
+function calendarMonthLengths(year: number): number[] {
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  return [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+}
+
+function assertIsoDateTime(value: unknown, field: string): string {
+  const text = assertString(value, field);
+  const match =
+    /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2})(?::(?<second>\d{2})(?:\.\d{1,9})?)?(?:Z|[+-](?<offsetHour>\d{2}):(?<offsetMinute>\d{2}))$/u.exec(
+      text
+    );
+  if (!match?.groups) {
+    throw new Error(`${field} must be ISO 8601 datetime with timezone`);
+  }
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
+  const hour = Number(match.groups.hour);
+  const minute = Number(match.groups.minute);
+  const second = Number(match.groups.second ?? "0");
+  const offsetHour = Number(match.groups.offsetHour ?? "0");
+  const offsetMinute = Number(match.groups.offsetMinute ?? "0");
+  const ranges = [
+    [month, 1, 12],
+    [day, 1, calendarMonthLengths(year)[month - 1]],
+    [hour, 0, 23],
+    [minute, 0, 59],
+    [second, 0, 59],
+    [offsetHour, 0, 23],
+    [offsetMinute, 0, 59],
+  ];
+  if (
+    !ranges.every(
+      ([part, minimum, maximum]) => part >= minimum && part <= maximum
+    )
+  ) {
+    throw new Error(`${field} must be valid ISO 8601 datetime`);
+  }
+  return text;
+}
+
+function normalizeCommunityPost(value: unknown, index: number): CommunityPost {
+  const field = `community posts[${index}]`;
+  const record = assertObject(value, field);
+  const post: CommunityPost = {
+    text: assertString(record.text, `${field}.text`),
+    scheduled_at: assertIsoDateTime(
+      record.scheduled_at,
+      `${field}.scheduled_at`
+    ),
+  };
+  const imagePath = assertOptionalNullableString(
+    record.image_path,
+    `${field}.image_path`
+  );
+  if (imagePath !== undefined) {
+    post.image_path = imagePath;
+  }
+  const imageUrl = assertOptionalString(record.image_url, `${field}.image_url`);
+  if (imageUrl !== undefined) {
+    post.image_url = imageUrl;
+  }
+  if (record.visibility !== undefined) {
+    if (
+      record.visibility !== "public" &&
+      record.visibility !== "members_only"
+    ) {
+      throw new Error(`${field}.visibility must be public or members_only`);
+    }
+    post.visibility = record.visibility;
+  }
+  return post;
+}
+
 function assertNonNegativeInteger(value: unknown, field: string): number {
   if (!Number.isInteger(value) || (value as number) < 0) {
     throw new Error(`${field} must be non-negative integer`);
+  }
+  return value as number;
+}
+
+function assertCommunityPostIndex(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error("community post index must be non-negative safe integer");
   }
   return value as number;
 }
@@ -282,6 +386,50 @@ async function fetchPromptArray(url: string): Promise<PromptEntry[]> {
   return (await fetchPromptResponseBody(url)).entries;
 }
 
+async function fetchJsonArray(url: string): Promise<unknown[]> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const data: unknown = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error("配列ではない JSON が返りました。");
+  }
+  return data;
+}
+
+/** community 投稿を取得する。非 2xx / 空配列 / 非配列 / 不正要素は fail-loud。 */
+export async function fetchCommunityPosts(
+  baseUrl: string
+): Promise<CommunityPost[]> {
+  const data = await fetchJsonArray(
+    `${normalizeBaseUrl(baseUrl)}${COMMUNITY_POSTS_ROUTE}`
+  );
+  if (data.length === 0) {
+    throw new Error("community posts response must be non-empty array");
+  }
+  return data.map(normalizeCommunityPost);
+}
+
+/** 指定投稿の画像 binary を取得する。 */
+export async function fetchCommunityImage(
+  baseUrl: string,
+  index: number
+): Promise<Blob> {
+  const resolvedIndex = assertCommunityPostIndex(index);
+  const response = await fetch(
+    `${normalizeBaseUrl(baseUrl)}${COMMUNITY_IMAGE_ROUTE}/${resolvedIndex}/image`
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const image = await response.blob();
+  if (!image.type.startsWith("image/")) {
+    throw new Error("community image response must have image Content-Type");
+  }
+  return image;
+}
+
 /** サーバー version envelope を取得する（#1023）。404 は caller が旧サーバー判定に使う。 */
 export async function fetchServerVersion(
   baseUrl: string
@@ -362,14 +510,7 @@ export async function checkServerCompatibility(
 export async function fetchCollections(
   baseUrl: string
 ): Promise<CollectionSummary[]> {
-  const resp = await fetch(`${baseUrl}${COLLECTIONS_ROUTE}`);
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`);
-  }
-  const data: unknown = await resp.json();
-  if (!Array.isArray(data)) {
-    throw new Error("配列ではない JSON が返りました。");
-  }
+  const data = await fetchJsonArray(`${baseUrl}${COLLECTIONS_ROUTE}`);
   return data.map((item, index) => normalizeCollectionSummary(item, index));
 }
 
@@ -562,14 +703,7 @@ export interface DistrokidReleaseRecord {
 export async function fetchDistrokidCollections(
   baseUrl: string
 ): Promise<DistrokidCollectionSummary[]> {
-  const resp = await fetch(`${baseUrl}${DISTROKID_COLLECTIONS_ROUTE}`);
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`);
-  }
-  const data: unknown = await resp.json();
-  if (!Array.isArray(data)) {
-    throw new Error("配列ではない JSON が返りました。");
-  }
+  const data = await fetchJsonArray(`${baseUrl}${DISTROKID_COLLECTIONS_ROUTE}`);
   return data as DistrokidCollectionSummary[];
 }
 

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -39,13 +39,23 @@ export const PROMPTS_ROUTE = "/suno/prompts.json";
 
 /** community-helper が投稿 JSON を取得するサブパス (#1710)。
  * SSOT 対応: collection_serve.py COMMUNITY_POSTS_ROUTE。 */
-// fallow-ignore-next-line unused-export -- community-helper API client (#1711) が後続で参照する公開契約。
 export const COMMUNITY_POSTS_ROUTE = "/community/posts.json";
 
 /** community-helper が投稿画像を取得するサブパスの prefix (#1710)。
  * `${COMMUNITY_IMAGE_ROUTE}/${index}/image` として使う。 */
-// fallow-ignore-next-line unused-export -- community-helper API client (#1711) が後続で参照する公開契約。
 export const COMMUNITY_IMAGE_ROUTE = "/community/posts";
+
+/** community-helper runner の進捗フェーズ (#1711)。 */
+export const COMMUNITY_PHASE = {
+  INJECTING: "injecting",
+  SCHEDULING: "scheduling",
+  UPLOADING_IMAGE: "uploading-image",
+  DONE: "done",
+  ERROR: "error",
+} as const;
+
+export type CommunityPhase =
+  (typeof COMMUNITY_PHASE)[keyof typeof COMMUNITY_PHASE];
 
 /** yt-collection-serve dir mode の collection 列挙サブパス (#816)。
  * SSOT: src/youtube_automation/scripts/suno_artifacts.py COLLECTIONS_ROUTE。 */

--- a/extensions/suno-helper/tests/community-api.test.ts
+++ b/extensions/suno-helper/tests/community-api.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type CommunityPost,
+  fetchCommunityImage,
+  fetchCommunityPosts,
+} from "../../shared/api";
+import { COMMUNITY_PHASE, type CommunityPhase } from "../../shared/constants";
+
+const BASE_URL = "http://localhost:7873";
+
+function mockFetch(impl: () => Partial<Response>) {
+  const fn = vi.fn(async () => impl() as Response);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("shared community API", () => {
+  it("投稿配列をルート定数の URL から取得する", async () => {
+    const posts: CommunityPost[] = [
+      {
+        text: "公開のお知らせ",
+        scheduled_at: "2026-07-19T18:00:00+09:00",
+        image_path: "collections/planning/demo-collection/main.png",
+        visibility: "public",
+      },
+    ];
+    const fetchFn = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => posts,
+    }));
+
+    await expect(fetchCommunityPosts(`${BASE_URL}/`)).resolves.toEqual(posts);
+    expect(fetchFn).toHaveBeenCalledWith(`${BASE_URL}/community/posts.json`);
+  });
+
+  it.each([
+    ["404", { ok: false, status: 404, json: async () => [] }],
+    ["空配列", { ok: true, status: 200, json: async () => [] }],
+    ["非配列", { ok: true, status: 200, json: async () => ({ posts: [] }) }],
+  ])("%s response は fail-loud で reject する", async (_label, response) => {
+    mockFetch(() => response);
+
+    await expect(fetchCommunityPosts(BASE_URL)).rejects.toThrow();
+  });
+
+  it("投稿 index の画像を Blob で返す", async () => {
+    const image = new Blob(["image"], { type: "image/png" });
+    const fetchFn = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      blob: async () => image,
+    }));
+
+    await expect(fetchCommunityImage(`${BASE_URL}/`, 2)).resolves.toBe(image);
+    expect(fetchFn).toHaveBeenCalledWith(`${BASE_URL}/community/posts/2/image`);
+  });
+
+  it("画像 endpoint の非 2xx を fail-loud で reject する", async () => {
+    mockFetch(() => ({ ok: false, status: 404 }));
+
+    await expect(fetchCommunityImage(BASE_URL, 0)).rejects.toThrow("HTTP 404");
+  });
+
+  it("200 でも非画像 Content-Type の Blob は reject する", async () => {
+    mockFetch(() => ({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(["{}"], { type: "application/json" }),
+    }));
+
+    await expect(fetchCommunityImage(BASE_URL, 0)).rejects.toThrow(
+      "image Content-Type"
+    );
+  });
+
+  it.each([-1, 0.5, Number.NaN, Number.MAX_SAFE_INTEGER + 1, 1e21])(
+    "不正 index %s は fetch 前に reject する",
+    async (index) => {
+      const fetchFn = mockFetch(() => ({ ok: true, status: 200 }));
+
+      await expect(fetchCommunityImage(BASE_URL, index)).rejects.toThrow(
+        "safe integer"
+      );
+      expect(fetchFn).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    "2026-02-30T00:00:00+09:00",
+    "2025-02-29T00:00:00+09:00",
+    "2026-13-01T00:00:00+09:00",
+    "2026-01-01T24:00:00+09:00",
+  ])("不正な予約日時 %s は reject する", async (scheduledAt) => {
+    mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: async () => [{ text: "post", scheduled_at: scheduledAt }],
+    }));
+
+    await expect(fetchCommunityPosts(BASE_URL)).rejects.toThrow("ISO 8601");
+  });
+});
+
+describe("COMMUNITY_PHASE", () => {
+  it("community runner の全フェーズを import 可能な定数として公開する", () => {
+    expect(COMMUNITY_PHASE).toEqual({
+      INJECTING: "injecting",
+      SCHEDULING: "scheduling",
+      UPLOADING_IMAGE: "uploading-image",
+      DONE: "done",
+      ERROR: "error",
+    });
+    const phases: CommunityPhase[] = Object.values(COMMUNITY_PHASE);
+    expect(phases).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- shared に CommunityPost wire 型と community runner phase 定数を追加
- 投稿配列と画像 Blob の fail-loud API client を追加し #1710 route constants を消費
- strict ISO calendar validation、image Content-Type、safe index を境界で検証
- shared JSON-array fetch の重複を共通化

## Validation
- Suno Vitest: 55 files / 1189 tests passed (`--maxWorkers=4`)
- community + shared API targeted: 108 passed
- `pnpm compile` / Ultracite check / fallow changed-files audit green
- `uv run pytest -n auto -q` (6282 passed)
- independent standards/spec reviews: clean

Closes #1711