### PR TITLE
feat(thumbnail): add winning thumbnail iteration skill

### DIFF
--- a/.claude/skills/thumbnail-iterate/SKILL.md
+++ b/.claude/skills/thumbnail-iterate/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: thumbnail-iterate
+description: "Use when 伸びた動画を起点にサムネの勝因を分解し、統制した A/B 比較で次の勝ちサムネへ更新するとき。「伸びた動画のサムネ改善」「伸びた動画起点のサムネ A/B テスト」「伸びたサムネテスト」で発動。新規候補生成だけなら /thumbnail、単独の Studio Test & Compare は /thumbnail-test、失速原因分析は /flop-analysis、競合横並びは /thumbnail-compare、整合性監査は /alignment-check を使う"
+---
+
+## 前後工程
+
+- `前工程`: `/analytics-report`, `/thumbnail-test`
+- `後工程`: `/thumbnail`, `/thumbnail-test`, `/flop-analysis`
+
+## Hard Gates
+
+- 対象動画とチャンネル平均の同一期間・同一定義の impressions CTR、および対象動画の Browse features + Suggested videos 構成比が揃うまで停止する。公開後 D+2 未満など Analytics の確定待ちは推測で補わない。
+- `target CTR / channel average CTR >= 1.20` かつ `Browse + Suggested >= 50%` の両方を満たす場合だけサムネ寄与ありとして進む。満たさなければ記録して停止し、原因分析を `/flop-analysis`（旧 `/postmortem`）または `/analytics-analyze` へ委譲する。
+- 勝因仮説は `composition` / `text` / `color` / `subject` / `expression` に分解・順位付けし、上位 1〜2 個を提示してユーザー合意を得るまで候補生成しない。
+- 通常 round の control A は現在の勝ちサムネで変更 0、B/C は 1 案につき合意済み要素を厳密に 1 個だけ変える。候補は control を含め最大 3 枚。
+- Studio の Test & Compare 操作と結果記録は `/thumbnail-test` に委譲する。ブラウザ/API で代行せず、Studio の確定結果が出るまで champion を更新しない。
+- `data/thumbnail-iterate/champion.json` は helper が検証済み履歴からのみ更新する。手編集、推測勝者、hash 不一致、symlink を許可しない。
+
+## 完了条件
+
+- 因果判定、合意済み仮説、候補パス・変更要素・SHA-256 が `data/thumbnail-iterate/runs/<video-id>.json` に保存済み。
+- `/thumbnail-test` が最大 3 案の手動 Studio 比較を完了し、対象 collection の `20-documentation/thumbnail-test-history.json` に確定結果を記録済み。
+- Winner があれば helper で champion を昇格済み。`Performed Same` / `Inconclusive` は champion を変更していない。
+- 異なる要素が別 round で勝った場合は機械的に合成せず、`synthesis-required.json` を受けて一貫した 1 枚を再生成し、現 champion を control に最終比較済み。
+
+## References
+
+- `references/state-contract.md` — 保存形式、CLI、停止コード。計画保存と昇格前に読む。
+- `references/thumbnail-iterate-state.py` — パス・hash・差分数・履歴対応を検証して状態を原子的に更新する唯一の writer。
+- `../thumbnail-test/references/history-schema.md` — Studio 候補と完了履歴の正本。`/thumbnail-test` 委譲前に読む。
+
+## 想定 API call 数
+
+| API | call 数 / 実行 | 変動要因 |
+|---|---|---|
+| Vertex AI Gemini / OpenAI Images（`yt-generate-image`、`/thumbnail` 経由） | 1〜2 | 合意した上位 1〜2 仮説に対応する B/C 各 1 枚。provider retry は `/thumbnail` の設定に従う |
+
+- 上限 / 承認: 因果 gate 通過後に上位 1〜2 要素と生成費用をユーザーが承認した場合だけ `/thumbnail` へ委譲し、control を除く生成候補を最大 2 枚に制限する。
+
+## Workflow
+
+### 1. 対象と因果を確定
+
+`/analytics-report` の同一期間データから対象 CTR、チャンネル平均 CTR、Browse features と Suggested videos の流入比率を取得する。対象コレクション、`workflow-state.json::upload.video_id`、根拠ファイル/期間を表示する。
+
+閾値を満たさない、値が欠落する、期間がずれる場合は改善案を作らない。helper の `plan` で停止記録を残し、サムネ以外も含む `/flop-analysis` へ route する。
+
+### 2. 勝因を分解して合意
+
+勝ちサムネを実際に表示し、次の順で差分を表にする。
+
+1. `composition`: 主役位置、余白、視線誘導
+2. `text`: 文言、文字数、サイズ
+3. `color`: 明度、彩度、コントラスト
+4. `subject`: 人物/物体、占有率
+5. `expression`: 表情、視線、感情強度
+
+根拠の強い順に並べ、検証する上位 1〜2 要素をユーザーへ確認する。合意前に画像を生成しない。
+
+### 3. 統制候補を生成
+
+現 winner を A として無変更で保持する。B と任意 C は `/thumbnail` の既存 `yt-generate-image` / `codex-image.sh` 生成経路を使い、それぞれ別の合意済み要素を 1 個だけ変える。ファイル名、変更要素、視覚差分を提示する。
+
+計画 JSON を作り、次を実行する。入力と保存 schema は `references/state-contract.md` に従う。
+
+```bash
+python .claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py plan \
+  --repo . --input /tmp/thumbnail-iterate-plan.json
+```
+
+### 4. Studio 比較を委譲
+
+対象 collection と A/B/C の対応を渡して `/thumbnail-test` を実行する。advanced features/動画 eligibility/1280x720/hashes の gate、operator の Studio 設定、watch time share と結果の記録はすべて `/thumbnail-test` の責務とする。
+
+### 5. Winner を昇格
+
+Studio 完了履歴が保存された後だけ実行する。
+
+```bash
+python .claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py promote \
+  --repo . --video-id VIDEO_ID \
+  --history COLLECTION/20-documentation/thumbnail-test-history.json
+```
+
+- exit `0`: winner 昇格または勝者なしを安全に記録。
+- exit `3`: 別要素の独立 winner がある。一貫した構図として `/thumbnail` で再生成し、`round_type: coherent_synthesis` で現 champion と最終比較する。
+- exit `1`: 契約違反。表示された不一致を直し、手動で JSON を迂回しない。
+
+昇格した champion は次回 `/thumbnail` が external benchmark より先に internal TTP として参照する。

--- a/.claude/skills/thumbnail-iterate/agents/openai.yaml
+++ b/.claude/skills/thumbnail-iterate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Thumbnail Iterate"
+  short_description: "伸びた動画の勝因を検証し次のサムネ比較と生成へつなぐ"
+  default_prompt: "Use $thumbnail-iterate to validate a winning thumbnail hypothesis and plan the next controlled comparison."

--- a/.claude/skills/thumbnail-iterate/references/state-contract.md
+++ b/.claude/skills/thumbnail-iterate/references/state-contract.md
@@ -1,0 +1,40 @@
+# Thumbnail iterate state contract
+
+すべて repository root 相対。writer は `thumbnail-iterate-state.py` だけとし、JSON は atomic replace する。
+
+## Plan input
+
+```json
+{
+  "video_id": "YouTube video ID",
+  "collection": "collections/planning/example",
+  "target_ctr": 6.0,
+  "channel_average_ctr": 4.0,
+  "browse_share": 35.0,
+  "suggested_share": 25.0,
+  "hypotheses": ["color", "composition"],
+  "round_type": "controlled",
+  "candidates": [
+    {"id": "A", "file": "collections/planning/example/10-assets/thumbnail.jpg", "changed_elements": []},
+    {"id": "B", "file": "collections/planning/example/10-assets/thumbnail-v2.jpg", "changed_elements": ["color"]},
+    {"id": "C", "file": "collections/planning/example/10-assets/thumbnail-v3.jpg", "changed_elements": ["composition"]}
+  ]
+}
+```
+
+`hypotheses` は `composition` / `text` / `color` / `subject` / `expression` の 1〜2 個。通常比較は B/C ごとに 1 要素だけ変える。複数の独立 winner を統合する final round だけ `round_type: coherent_synthesis` とし、B/C は pending 要素を一貫した 1 枚として 2 個以上変えてよい。
+
+## Outputs
+
+- `data/thumbnail-iterate/runs/<video-id>.json`: 因果判定、候補 hash、状態。因果閾値未達も `stopped` として残す。
+- `data/thumbnail-iterate/champion.json`: Studio 履歴と plan の file/hash が一致した winner のみ。winner は content hash 名で `champions/` に snapshot し、次回生成の immutable internal TTP にする。
+- `data/thumbnail-iterate/synthesis-required.json`: 異なる要素が別 round で勝ったときの pending contract。現 champion は final round が勝つまで維持する。
+
+## Exit codes
+
+| code | meaning |
+|---|---|
+| 0 | plan 保存、winner/勝者なしの安全な反映 |
+| 1 | JSON、パス、symlink、要素差分、hash、履歴対応の契約違反 |
+| 2 | CTR または流入構成比が因果閾値未達。`/flop-analysis` へ route |
+| 3 | 複数 winner 要素を coherent regeneration + final comparison すべき状態 |

--- a/.claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py
+++ b/.claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Validate thumbnail iteration plans and promote Studio-proven champions."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ALLOWED_ELEMENTS = {"composition", "text", "color", "subject", "expression"}
+
+
+class ContractError(ValueError):
+    """Raised when operator input violates the iteration contract."""
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ContractError(f"JSON root must be an object: {path}")
+    return value
+
+
+def _write_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+    os.close(fd)
+    try:
+        shutil.copyfile(source, temporary)
+        os.replace(temporary, destination)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def _number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ContractError(f"{field} must be a number")
+    return float(value)
+
+
+def _safe_file(repo: Path, relative: object, collection: str) -> tuple[str, str]:
+    if not isinstance(relative, str) or not relative:
+        raise ContractError("candidate file must be a non-empty relative path")
+    path = Path(relative)
+    if path.is_absolute() or ".." in path.parts:
+        raise ContractError(f"candidate escapes repository: {relative}")
+    if not relative.startswith(f"{collection}/10-assets/"):
+        raise ContractError(f"candidate must be inside {collection}/10-assets/: {relative}")
+    absolute = repo / path
+    current = repo
+    for part in path.parts:
+        current /= part
+        if current.is_symlink():
+            raise ContractError(f"candidate path contains symlink: {relative}")
+    try:
+        absolute.resolve(strict=True).relative_to(repo.resolve(strict=True))
+    except (FileNotFoundError, ValueError) as exc:
+        raise ContractError(f"candidate is missing or outside repository: {relative}") from exc
+    if not absolute.is_file():
+        raise ContractError(f"candidate is not a file: {relative}")
+    digest = hashlib.sha256(absolute.read_bytes()).hexdigest()
+    return relative, digest
+
+
+def _plan(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve(strict=True)
+    payload = _read_json(Path(args.input))
+    video_id = payload.get("video_id")
+    collection = payload.get("collection")
+    if not isinstance(video_id, str) or not video_id or "/" in video_id or video_id in {".", ".."}:
+        raise ContractError("video_id must be a non-empty filename-safe string")
+    if (
+        not isinstance(collection, str)
+        or not collection
+        or Path(collection).is_absolute()
+        or ".." in Path(collection).parts
+    ):
+        raise ContractError("collection must be a repository-relative path")
+
+    target_ctr = _number(payload.get("target_ctr"), "target_ctr")
+    average_ctr = _number(payload.get("channel_average_ctr"), "channel_average_ctr")
+    browse_share = _number(payload.get("browse_share"), "browse_share")
+    suggested_share = _number(payload.get("suggested_share"), "suggested_share")
+    if average_ctr <= 0 or min(target_ctr, browse_share, suggested_share) < 0:
+        raise ContractError("CTR and traffic shares must be non-negative; channel average must be positive")
+    ctr_ratio = round(target_ctr / average_ctr, 4)
+    source_share = round(browse_share + suggested_share, 4)
+    supported = ctr_ratio >= 1.20 and source_share >= 50.0
+    attribution = {
+        "target_ctr": target_ctr,
+        "channel_average_ctr": average_ctr,
+        "ctr_ratio": ctr_ratio,
+        "browse_suggested_share": source_share,
+        "verdict": "thumbnail_supported" if supported else "thumbnail_not_supported",
+    }
+    run_path = repo / "data/thumbnail-iterate/runs" / f"{video_id}.json"
+    if not supported:
+        _write_json(
+            run_path,
+            {
+                "schema_version": 1,
+                "video_id": video_id,
+                "collection": collection,
+                "status": "stopped",
+                "stop_reason": "thumbnail causality threshold not met",
+                "attribution": attribution,
+            },
+        )
+        print("thumbnail causality is not supported; route to /flop-analysis", file=sys.stderr)
+        return 2
+
+    hypotheses = payload.get("hypotheses")
+    if (
+        not isinstance(hypotheses, list)
+        or not 1 <= len(hypotheses) <= 2
+        or len(set(hypotheses)) != len(hypotheses)
+        or not set(hypotheses) <= ALLOWED_ELEMENTS
+    ):
+        raise ContractError("hypotheses must contain 1-2 unique allowed elements")
+    round_type = payload.get("round_type", "controlled")
+    if round_type not in {"controlled", "coherent_synthesis"}:
+        raise ContractError("round_type must be controlled or coherent_synthesis")
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not 2 <= len(candidates) <= 3:
+        raise ContractError("candidates must contain 2-3 items")
+    if [candidate.get("id") for candidate in candidates if isinstance(candidate, dict)] != ["A", "B", "C"][
+        : len(candidates)
+    ]:
+        raise ContractError("candidate IDs must be A, B, then optional C")
+
+    normalized: list[dict[str, object]] = []
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise ContractError("each candidate must be an object")
+        changes = candidate.get("changed_elements")
+        if not isinstance(changes, list) or len(set(changes)) != len(changes) or not set(changes) <= ALLOWED_ELEMENTS:
+            raise ContractError("changed_elements must contain unique allowed elements")
+        if index == 0 and changes:
+            raise ContractError("control A must change zero elements")
+        if index > 0 and round_type == "controlled" and len(changes) != 1:
+            raise ContractError("each controlled variant must change exactly one element")
+        if index > 0 and round_type == "coherent_synthesis" and len(changes) < 2:
+            raise ContractError("a coherent synthesis variant must change at least two elements")
+        if not set(changes) <= set(hypotheses):
+            raise ContractError("candidate changes must be selected from ranked hypotheses")
+        relative, digest = _safe_file(repo, candidate.get("file"), collection)
+        normalized.append({"id": candidate["id"], "file": relative, "changed_elements": changes, "sha256": digest})
+    if len({item["file"] for item in normalized}) != len(normalized) or len(
+        {item["sha256"] for item in normalized}
+    ) != len(normalized):
+        raise ContractError("candidate files and contents must be unique")
+
+    pending_path = repo / "data/thumbnail-iterate/synthesis-required.json"
+    if round_type == "coherent_synthesis":
+        if not pending_path.exists():
+            raise ContractError("coherent synthesis requires synthesis-required.json")
+        pending = _read_json(pending_path)
+        if pending.get("status") != "coherent_synthesis_required" or hypotheses != pending.get("elements"):
+            raise ContractError("coherent synthesis hypotheses must match pending elements in order")
+        control = pending.get("control")
+        if not isinstance(control, dict) or normalized[0]["sha256"] != control.get("sha256"):
+            raise ContractError("coherent synthesis control A must match the current champion content hash")
+        if any(set(candidate["changed_elements"]) != set(hypotheses) for candidate in normalized[1:]):
+            raise ContractError("each coherent synthesis variant must implement all pending elements")
+    elif pending_path.exists():
+        raise ContractError("coherent synthesis is pending; another controlled round cannot start")
+
+    run = {
+        "schema_version": 1,
+        "video_id": video_id,
+        "collection": collection,
+        "status": "planned",
+        "attribution": attribution,
+        "hypotheses": hypotheses,
+        "round_type": round_type,
+        "candidates": normalized,
+    }
+    _write_json(run_path, run)
+    print(run_path)
+    return 0
+
+
+def _promote(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve(strict=True)
+    video_id = args.video_id
+    run_path = repo / "data/thumbnail-iterate/runs" / f"{video_id}.json"
+    run = _read_json(run_path)
+    if run.get("status") != "planned" or run.get("video_id") != video_id:
+        raise ContractError("matching planned run is required")
+    history_path = Path(args.history).resolve(strict=True)
+    expected_history = (repo / run["collection"] / "20-documentation/thumbnail-test-history.json").resolve()
+    if history_path != expected_history:
+        raise ContractError(f"history must be the collection history: {expected_history}")
+    history = _read_json(history_path)
+    entries = [
+        entry for entry in history.get("entries", []) if isinstance(entry, dict) and entry.get("video_id") == video_id
+    ]
+    if not entries:
+        raise ContractError("history has no matching video_id")
+    entry = entries[-1]
+    result = entry.get("result")
+    if not isinstance(result, dict) or result.get("status") not in {"winner", "performed_same", "inconclusive"}:
+        raise ContractError("history result status is invalid")
+    recorded = entry.get("candidates")
+    if not isinstance(recorded, list) or len(recorded) != len(run["candidates"]):
+        raise ContractError("history candidates do not match planned candidates")
+    for expected, actual in zip(run["candidates"], recorded, strict=True):
+        if not isinstance(actual, dict) or any(actual.get(key) != expected[key] for key in ("id", "file", "sha256")):
+            raise ContractError("history candidate mapping or hash differs from plan")
+        _, current_hash = _safe_file(repo, expected["file"], run["collection"])
+        if current_hash != expected["sha256"]:
+            raise ContractError(f"candidate current content hash differs from plan: {expected['file']}")
+
+    if result["status"] != "winner":
+        run["status"] = "completed_without_winner"
+        run["completed_at"] = entry.get("completed_at")
+        _write_json(run_path, run)
+        print("no champion update")
+        return 0
+    winner_id = result.get("result_candidate_id")
+    winner = next((candidate for candidate in run["candidates"] if candidate["id"] == winner_id), None)
+    if winner is None:
+        raise ContractError("winner candidate ID does not exist")
+
+    champion_path = repo / "data/thumbnail-iterate/champion.json"
+    existing = _read_json(champion_path) if champion_path.exists() else None
+    if existing:
+        existing_file = existing.get("file")
+        if not isinstance(existing_file, str) or Path(existing_file).is_absolute() or ".." in Path(existing_file).parts:
+            raise ContractError("existing champion file path is invalid")
+        existing_path = repo / existing_file
+        if existing_path.is_symlink() or not existing_path.is_file():
+            raise ContractError("existing champion file is missing or a symlink")
+        if hashlib.sha256(existing_path.read_bytes()).hexdigest() != existing.get("sha256"):
+            raise ContractError("existing champion current content hash differs")
+    new_elements = winner["changed_elements"]
+    existing_elements = existing.get("validated_elements", []) if existing else []
+    combined = list(dict.fromkeys([*existing_elements, *new_elements]))
+    if existing and run["round_type"] == "controlled" and set(new_elements) - set(existing_elements):
+        pending = {
+            "schema_version": 1,
+            "status": "coherent_synthesis_required",
+            "elements": combined,
+            "control": {"file": existing["file"], "sha256": existing["sha256"]},
+            "evidence_video_ids": [existing["video_id"], video_id],
+        }
+        _write_json(repo / "data/thumbnail-iterate/synthesis-required.json", pending)
+        run["status"] = "winner_requires_synthesis"
+        _write_json(run_path, run)
+        print("independent winners require coherent regeneration and a final comparison", file=sys.stderr)
+        return 3
+
+    winner_source = repo / winner["file"]
+    suffix = winner_source.suffix.lower()
+    snapshot_relative = f"data/thumbnail-iterate/champions/{winner['sha256']}{suffix}"
+    _copy_file(winner_source, repo / snapshot_relative)
+    champion = {
+        "schema_version": 1,
+        "video_id": video_id,
+        "collection": run["collection"],
+        "file": snapshot_relative,
+        "sha256": winner["sha256"],
+        "validated_elements": combined,
+        "promoted_at": entry.get("completed_at"),
+        "history": str(history_path.relative_to(repo)),
+    }
+    _write_json(champion_path, champion)
+    if run["round_type"] == "coherent_synthesis":
+        (repo / "data/thumbnail-iterate/synthesis-required.json").unlink(missing_ok=True)
+    run["status"] = "champion_promoted"
+    _write_json(run_path, run)
+    print(champion_path)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan = subparsers.add_parser("plan")
+    plan.add_argument("--repo", required=True)
+    plan.add_argument("--input", required=True)
+    plan.set_defaults(handler=_plan)
+    promote = subparsers.add_parser("promote")
+    promote.add_argument("--repo", required=True)
+    promote.add_argument("--video-id", required=True)
+    promote.add_argument("--history", required=True)
+    promote.set_defaults(handler=_promote)
+    args = parser.parse_args()
+    try:
+        return args.handler(args)
+    except (ContractError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/thumbnail-test/SKILL.md
+++ b/.claude/skills/thumbnail-test/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: thumbnail-test
-description: "Use when 長尺動画で YouTube Studio のサムネイル A/B テストを設計し、結果を記録するとき。「サムネ A/B テスト」「Test & Compare」「サムネテスト結果」で発動。公開前の競合・320px 視認性比較は /thumbnail-compare、候補生成は /thumbnail を使う"
+description: "Use when 長尺動画で YouTube Studio のサムネイル A/B テストを単独で設計し、結果を記録するとき。「サムネ A/B テスト」「Test & Compare」「サムネテスト結果」で発動。伸びた動画起点の勝因検証ループは /thumbnail-iterate、公開前の競合・320px 視認性比較は /thumbnail-compare、候補生成は /thumbnail を使う"
 ---
 
 ## 前後工程
 
-- `前工程`: `/thumbnail`, `/video-upload`
-- `後工程`: `/thumbnail`, `/flop-analysis`
+- `前工程`: `/thumbnail`, `/video-upload`, `/thumbnail-iterate`
+- `後工程`: `/thumbnail`, `/thumbnail-iterate`, `/flop-analysis`
 
 ## Overview
 

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: thumbnail
-description: "Use when コレクションの YouTube サムネイル（thumbnail.jpg）を CTR 最適化し、textless main.png/jpg を先行生成して実フォント合成するとき。「サムネイル生成」「画像生成」「アイキャッチ」で発動。競合の勝ちパターン分析は /thumbnail-research、320px 視認性比較は /thumbnail-compare、Studio の A/B テスト設計・結果記録は /thumbnail-test、SVG・汎用画像生成には使わない"
+description: "Use when コレクションの YouTube サムネイル（thumbnail.jpg）を CTR 最適化し、textless main.png/jpg を先行生成して実フォント合成するとき。「サムネイル生成」「画像生成」「アイキャッチ」で発動。伸びた動画起点の改善ループは /thumbnail-iterate、競合の勝ちパターン分析は /thumbnail-research、320px 視認性比較は /thumbnail-compare、単独の Studio A/B 設計・結果記録は /thumbnail-test、SVG・汎用画像生成には使わない"
 ---
 
 ## 前後工程
 
-- `前工程`: `/collection-ideate`, `/wf-new`
+- `前工程`: `/collection-ideate`, `/wf-new`, `/thumbnail-iterate`
 - `後工程`: `/loop-video`, `/thumbnail-compare`, `/alignment-check`, `/thumbnail-test`
 
 ## Overview
@@ -52,6 +52,8 @@ description: "Use when コレクションの YouTube サムネイル（thumbnail
 subagent として呼ぶ場合、メインエージェントは対象コレクションと生成対象（`thumbnail` / `main`）をリポジトリルート相対パスまたは値で入力に含める。候補画像生成前の承認が必要なら、メインが承認を得るまで subagent を起動しない。subagent は `workflow-state.json` を読み書きせず、`AskUserQuestion` を実行しない。候補画像の完了報告には `status: success | failure`、生成した `10-assets/thumbnail-vN.jpg/png` または `10-assets/main-vN.png/jpg` と `20-documentation/thumbnail-prompts.md` の絶対パス一覧、エラーを含める。メインは報告されたファイルの存在と生成対象を検証し、候補承認後の確定コピーと state 更新を行う。直接実行時は既存の承認・state 更新手順を変更しない。
 
 ## 勝ちパターン参照ゲート
+
+最初に `data/thumbnail-iterate/champion.json` の有無を確認する。存在する場合は `.claude/skills/thumbnail-iterate/references/state-contract.md` を読み、`file` が repository 内の実ファイル（symlink 不可）で、現在の SHA-256 が `sha256` と一致することを検証する。失敗時は黙って external TTP へ fallback せず対象と不一致を表示して停止する。検証済み champion は **internal TTP** として external benchmark より先に参照画像と `validated_elements` をプロンプトへ反映する。このスキルから champion JSON を作成・更新しない。
 
 プロンプト構築前に `collections/planning/*/20-documentation/thumbnail-test-history.json` と `collections/live/*/20-documentation/thumbnail-test-history.json` を列挙する。存在する各ファイルは `.claude/skills/thumbnail-test/references/history-schema.md` の `### Completed history` にある履歴構造検証コマンドだけで確認し、検証に失敗した履歴は黙って無視せず、対象パスとエラーを表示して修正を案内する。そのファイルを集計から除外してよいが、未検証値をプロンプトへ入れない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(thumbnail)`: 伸びた動画の CTR と流入構成からサムネ寄与を gate し、勝因を 1 要素ずつ Studio 比較して検証済み champion を次回 `/thumbnail` の internal TTP へ還元する `/thumbnail-iterate` を追加した。複数要素が独立して勝った場合は機械的に合成せず、一貫した再生成と最終比較を要求する（#1969）。
 - `feat(workspace)`: `yt-channel-import` を追加し、既存の単一 channel repository から channel 固有データだけを `channels/<slug>/` へ transaction copy できるようにした。meta 由来 slug の確認、必須 config と実 load の検証、auth 所在報告、symlink / 上書き拒否、生成 media を除外する workspace `.gitignore` scaffold、`.env` / `CHANNEL_DIR` 警告、共通 `yt-skills sync` 案内と external user 向け移行・rollback・archive ガイドを追加した（#1949）。
 - `feat(workflow)`: `/automation-run` を追加し、active collection 1 件を durable lease 下で選択して、Lyria / Suno の音源生成、masterup、動画・metadata 生成、公開許可付き YouTube upload、post-publish まで既存 skill へ状態駆動で委譲できるようにした。工程ごとに成果物を再評価し、失敗・手動介入・公開未許可では停止理由と再開地点を履歴へ記録する。定期実行の既定 target は `automation-run` とし、未設定チャンネルの `enabled: false` / `allow_external_publish: false` は維持する（#1894）。
 - `feat(suno-helper)`: 定期実行用の loopback 限定 launch URL 契約と CLI を追加し、collection / entry / DL 形式 / entry・concurrency・retry 上限を指定可能にした。既存 resume state から entry / playlist / download を重複なしで再開し、上限超過は checkpoint、ログイン・CAPTCHA・課金確認・UI 非互換は手動介入理由として保存する。手動 overlay flow は従来挙動を維持する（#1893）。

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **53 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **54 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -42,6 +42,7 @@
 | /alignment-check | 音楽ムード × サムネ × タイトル訴求の整合性を監査 |
 | /thumbnail-compare | サムネをベンチマーク競合と並べてモバイル視認性（320px）を検証 |
 | /thumbnail-test | Studio のサムネ A/B テストを設計し、watch time share・勝敗・勝ちパターンをコレクション履歴へ記録 |
+| /thumbnail-iterate | 伸びた動画のサムネ寄与を判定し、1 要素ずつ比較して検証済み champion を次回生成へ還元 |
 
 ## 企画・コンテンツ生成
 

--- a/tests/test_skill_api_call_estimate_contract.py
+++ b/tests/test_skill_api_call_estimate_contract.py
@@ -175,6 +175,7 @@ TARGET_SKILLS: frozenset[str] = frozenset(
         "streaming",
         "thumbnail",
         "thumbnail-compare",
+        "thumbnail-iterate",
         "video-analyze",
         "video-upload",
         "viewer-voice",

--- a/tests/test_thumbnail_iterate.py
+++ b/tests/test_thumbnail_iterate.py
@@ -1,0 +1,263 @@
+"""Contract tests for the /thumbnail-iterate state helper (issue #1969)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / ".claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py"
+
+
+def _run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _candidate(repo: Path, name: str, body: bytes) -> tuple[str, str]:
+    relative = f"collections/planning/demo/10-assets/{name}"
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+    return relative, hashlib.sha256(body).hexdigest()
+
+
+def _plan(repo: Path, *, video_id: str = "video-1", element: str = "color") -> Path:
+    control, _ = _candidate(repo, "thumbnail.jpg", b"control")
+    variant, _ = _candidate(repo, "thumbnail-v2.jpg", b"variant")
+    payload = {
+        "video_id": video_id,
+        "collection": "collections/planning/demo",
+        "target_ctr": 6.0,
+        "channel_average_ctr": 4.0,
+        "browse_share": 35.0,
+        "suggested_share": 25.0,
+        "hypotheses": [element],
+        "round_type": "controlled",
+        "candidates": [
+            {"id": "A", "file": control, "changed_elements": []},
+            {"id": "B", "file": variant, "changed_elements": [element]},
+        ],
+    }
+    path = repo / "plan.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _history(repo: Path, plan: dict, winner: str | None) -> Path:
+    candidates = []
+    for candidate in plan["candidates"]:
+        candidates.append(
+            {
+                "id": candidate["id"],
+                "file": candidate["file"],
+                "sha256": candidate["sha256"],
+                "watch_time_share": 60 if candidate["id"] == winner else 40,
+            }
+        )
+    status = "winner" if winner else "performed_same"
+    history = {
+        "schema_version": 1,
+        "entries": [
+            {
+                "video_id": plan["video_id"],
+                "completed_at": "2026-07-18T00:00:00Z",
+                "result": {
+                    "studio_label": "Winner" if winner else "Performed Same",
+                    "status": status,
+                    "result_candidate_id": winner,
+                },
+                "candidates": candidates,
+            }
+        ],
+    }
+    path = repo / plan["collection"] / "20-documentation/thumbnail-test-history.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(history), encoding="utf-8")
+    return path
+
+
+def test_plan_records_supported_attribution_and_content_hashes(tmp_path: Path) -> None:
+    source = _plan(tmp_path)
+
+    result = _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    run = json.loads((tmp_path / "data/thumbnail-iterate/runs/video-1.json").read_text())
+    assert run["attribution"] == {
+        "target_ctr": 6.0,
+        "channel_average_ctr": 4.0,
+        "ctr_ratio": 1.5,
+        "browse_suggested_share": 60.0,
+        "verdict": "thumbnail_supported",
+    }
+    assert all(len(candidate["sha256"]) == 64 for candidate in run["candidates"])
+
+
+def test_plan_stops_when_thumbnail_causality_is_not_supported(tmp_path: Path) -> None:
+    source = _plan(tmp_path)
+    payload = json.loads(source.read_text())
+    payload["target_ctr"] = 4.1
+    source.write_text(json.dumps(payload))
+
+    result = _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path)
+
+    assert result.returncode == 2
+    run = json.loads((tmp_path / "data/thumbnail-iterate/runs/video-1.json").read_text())
+    assert run["status"] == "stopped"
+    assert run["attribution"]["verdict"] == "thumbnail_not_supported"
+
+
+def test_plan_rejects_multi_element_variant_and_symlink(tmp_path: Path) -> None:
+    source = _plan(tmp_path)
+    payload = json.loads(source.read_text())
+    payload["candidates"][1]["changed_elements"] = ["color", "text"]
+    source.write_text(json.dumps(payload))
+    result = _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path)
+    assert result.returncode == 1
+    assert "exactly one" in result.stderr
+
+    source = _plan(tmp_path)
+    payload = json.loads(source.read_text())
+    target = tmp_path / payload["candidates"][1]["file"]
+    target.unlink()
+    target.symlink_to(tmp_path / payload["candidates"][0]["file"])
+    result = _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path)
+    assert result.returncode == 1
+    assert "symlink" in result.stderr
+
+
+def test_promote_winner_then_requires_coherent_synthesis_for_second_element(
+    tmp_path: Path,
+) -> None:
+    source = _plan(tmp_path, video_id="video-1", element="color")
+    assert _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path).returncode == 0
+    run = json.loads((tmp_path / "data/thumbnail-iterate/runs/video-1.json").read_text())
+    history = _history(tmp_path, run, "B")
+    first = _run("promote", "--repo", str(tmp_path), "--video-id", "video-1", "--history", str(history), cwd=tmp_path)
+    assert first.returncode == 0, first.stderr
+    champion_path = tmp_path / "data/thumbnail-iterate/champion.json"
+    champion = json.loads(champion_path.read_text())
+    assert champion["file"].startswith("data/thumbnail-iterate/champions/")
+    assert champion["file"].endswith(".jpg")
+    assert champion["validated_elements"] == ["color"]
+
+    source = _plan(tmp_path, video_id="video-2", element="composition")
+    assert _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path).returncode == 0
+    run = json.loads((tmp_path / "data/thumbnail-iterate/runs/video-2.json").read_text())
+    history = _history(tmp_path, run, "B")
+    second = _run("promote", "--repo", str(tmp_path), "--video-id", "video-2", "--history", str(history), cwd=tmp_path)
+    assert second.returncode == 3
+    unchanged = json.loads(champion_path.read_text())
+    assert unchanged["video_id"] == "video-1"
+    pending = json.loads((tmp_path / "data/thumbnail-iterate/synthesis-required.json").read_text())
+    assert pending["elements"] == ["color", "composition"]
+
+
+def test_promote_rejects_candidate_changed_after_studio_history(tmp_path: Path) -> None:
+    source = _plan(tmp_path)
+    assert _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path).returncode == 0
+    run = json.loads((tmp_path / "data/thumbnail-iterate/runs/video-1.json").read_text())
+    history = _history(tmp_path, run, "B")
+    (tmp_path / run["candidates"][1]["file"]).write_bytes(b"changed-after-result")
+
+    result = _run(
+        "promote",
+        "--repo",
+        str(tmp_path),
+        "--video-id",
+        "video-1",
+        "--history",
+        str(history),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 1
+    assert "current content hash" in result.stderr
+    assert not (tmp_path / "data/thumbnail-iterate/champion.json").exists()
+
+
+def test_coherent_synthesis_requires_current_champion_as_control(tmp_path: Path) -> None:
+    champion_body = b"current-champion"
+    champion_hash = hashlib.sha256(champion_body).hexdigest()
+    snapshot = tmp_path / f"data/thumbnail-iterate/champions/{champion_hash}.jpg"
+    snapshot.parent.mkdir(parents=True)
+    snapshot.write_bytes(champion_body)
+    (tmp_path / "data/thumbnail-iterate/champion.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "video_id": "older-video",
+                "file": str(snapshot.relative_to(tmp_path)),
+                "sha256": champion_hash,
+                "validated_elements": ["color"],
+            }
+        )
+    )
+    (tmp_path / "data/thumbnail-iterate/synthesis-required.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "coherent_synthesis_required",
+                "elements": ["color", "composition"],
+                "control": {"file": str(snapshot.relative_to(tmp_path)), "sha256": champion_hash},
+                "evidence_video_ids": ["older-video", "newer-video"],
+            }
+        )
+    )
+    control, _ = _candidate(tmp_path, "thumbnail.jpg", b"wrong-control")
+    variant, _ = _candidate(tmp_path, "thumbnail-v2.jpg", b"coherent-result")
+    payload = {
+        "video_id": "final-video",
+        "collection": "collections/planning/demo",
+        "target_ctr": 6.0,
+        "channel_average_ctr": 4.0,
+        "browse_share": 35.0,
+        "suggested_share": 25.0,
+        "hypotheses": ["color", "composition"],
+        "round_type": "coherent_synthesis",
+        "candidates": [
+            {"id": "A", "file": control, "changed_elements": []},
+            {
+                "id": "B",
+                "file": variant,
+                "changed_elements": ["color", "composition"],
+            },
+        ],
+    }
+    source = tmp_path / "synthesis-plan.json"
+    source.write_text(json.dumps(payload))
+
+    result = _run("plan", "--repo", str(tmp_path), "--input", str(source), cwd=tmp_path)
+
+    assert result.returncode == 1
+    assert "current champion" in result.stderr
+
+
+def test_skill_docs_define_routing_thresholds_and_champion_contract() -> None:
+    iterate = (ROOT / ".claude/skills/thumbnail-iterate/SKILL.md").read_text()
+    thumbnail = (ROOT / ".claude/skills/thumbnail/SKILL.md").read_text()
+    thumbnail_test = (ROOT / ".claude/skills/thumbnail-test/SKILL.md").read_text()
+
+    for phrase in (
+        "1.20",
+        "50%",
+        "/thumbnail-test",
+        "最大 3",
+        "champion.json",
+        "機械的に合成",
+        "yt-generate-image",
+        "codex-image.sh",
+    ):
+        assert phrase in iterate
+    assert "/thumbnail-iterate" in thumbnail
+    assert "champion.json" in thumbnail
+    assert "/thumbnail-iterate" in thumbnail_test


### PR DESCRIPTION
## Summary
- add `/thumbnail-iterate` with attribution, ranked hypothesis, controlled variant, Studio handoff, and champion promotion gates
- persist validated run/champion state through a path- and hash-safe helper; require coherent regeneration when independent elements win
- route `/thumbnail`, `/thumbnail-test`, docs, API-call estimates, and regression tests through the new contract

## Validation
- `uv run pytest -q` (6352 passed)
- `uv run ruff check tests/test_thumbnail_iterate.py .claude/skills/thumbnail-iterate/references/thumbnail-iterate-state.py`
- `quick_validate.py .claude/skills/thumbnail-iterate`

Closes #1969