### PR TITLE
feat(thumbnail): Codex画像の並列バッチ生成を追加 (#2028)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -172,6 +172,16 @@ bash .claude/skills/thumbnail/references/codex-image.sh --require-reference \
 
 複数候補を作る場合でも、1 回の `codex-image.sh --require-reference` 呼び出しには候補に対応する参照画像 1 枚だけを渡す。TTP 生成では参照画像 0 件で停止する。DistroKid cover などの汎用 codex 生成は `--require-reference` を付けない。
 
+2 件以上の候補を同時生成する場合は、`id` / `prompt` / `output` / 任意の `reference` を持つ JSON 配列を manifest に保存し、batch launcher を使う。互換 preflight は batch 全体で 1 回だけ実行され、各 job は独立した出力先で単発 `codex-image.sh` の stale-artifact / PNG / MD5 gate を通る。一部失敗時も残りを完走し、最後に失敗一覧と非 0 exit を返す。
+
+```bash
+bash .claude/skills/thumbnail/references/codex-image-batch.sh \
+  --manifest /tmp/codex-thumbnail-jobs.json
+# 実行単位で上書きする場合だけ: --max-parallel 2
+```
+
+同時起動数は `image_generation.codex.max_parallel`（default `2`）で制御する。ChatGPT サブスクの fair-use 上限は非公開なので大量生成には使わない。通常は default `2` を維持し、rate limit / 利用制限を示す失敗時は `1` に下げる。`3` 以上はユーザーが今回の実行について明示した場合だけ使う。
+
 TTP 参照画像から上位互換サムネを作る場合は、長い個別指定ではなく
 `image_generation.codex.default_prompt_template` を使う。参照画像は mood reference
 ではなく winning template として扱い、変える要素は `{title}` と品質改善

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -317,6 +317,8 @@ image_generation:
   codex:
     # codex-image.sh 経路は API provider ではないため model / quality は持たない。
     # ChatGPT サブスクの fair-use 上限内で使い、大量生成には使わない。
+    # バッチ候補生成の同時起動上限。CLI --max-parallel で実行単位に上書きできる。
+    max_parallel: 2
     # cost_per_image_usd: null
     # 参照サムネを mood reference ではなく winning template として扱い、
     # テキスト付き thumbnail 候補を先に確定する短い TTP プロンプト（#1611 の thumbnail 先行フロー）。

--- a/.claude/skills/thumbnail/references/codex-image-batch.sh
+++ b/.claude/skills/thumbnail/references/codex-image-batch.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Usage: codex-image-batch.sh --manifest jobs.json [--max-parallel N]
+# Manifest: [{"id":"v1","prompt":"...","output":"...png","reference":"...png"}, ...]
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+manifest=""
+max_parallel=""
+runner="$script_dir/codex-image.sh"
+
+usage() {
+  echo "usage: codex-image-batch.sh --manifest jobs.json [--max-parallel N]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest)
+      manifest=${2:?--manifest requires a path}
+      shift 2
+      ;;
+    --max-parallel)
+      max_parallel=${2:?--max-parallel requires an integer}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$manifest" ] || [ ! -f "$manifest" ]; then
+  echo "ERROR: --manifest must point to an existing JSON file" >&2
+  exit 1
+fi
+if [ ! -f "$runner" ]; then
+  echo "ERROR: runner not found: $runner" >&2
+  exit 1
+fi
+for command_name in codex jq uv; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: $command_name CLI が PATH にありません" >&2
+    exit 1
+  fi
+done
+
+# Validate the complete batch before authentication or side effects. IDs and outputs
+# are unique so each single-image wrapper owns an independent stale/hash guard.
+if ! jq -e '
+  type == "array" and length >= 2 and
+  all(.[];
+    type == "object" and
+    (.id | type == "string" and length > 0) and
+    (.prompt | type == "string" and length > 0) and
+    (.output | type == "string" and length > 0) and
+    ((.reference // "") | type == "string")
+  ) and
+  ([.[].id] | length == (unique | length)) and
+  ([.[].output] | length == (unique | length))
+' "$manifest" >/dev/null; then
+  echo "ERROR: manifest requires 2+ jobs with non-empty unique id/output and string prompt/reference" >&2
+  exit 1
+fi
+
+# Lexically different paths can still point at the same file through symlinked
+# parent directories. Resolve those aliases before any preflight or generation.
+if ! uv run --no-sync python - "$manifest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+jobs = json.loads(manifest_path.read_text(encoding="utf-8"))
+outputs = []
+for job in jobs:
+    output = Path(job["output"]).expanduser()
+    if not output.is_absolute():
+        output = Path.cwd() / output
+    outputs.append(output.resolve(strict=False))
+
+if len(outputs) != len(set(outputs)):
+    raise SystemExit("canonical output paths must be unique")
+PY
+then
+  echo "ERROR: canonical output paths must be unique" >&2
+  exit 1
+fi
+
+if [ -z "$max_parallel" ]; then
+  if ! max_parallel=$(uv run --no-sync python - <<'PY'
+import os
+from pathlib import Path
+
+from youtube_automation.utils.image_provider.config import parse_image_generation_config
+from youtube_automation.utils.skill_config import load_skill_config
+
+channel_root = Path(os.environ.get("CHANNEL_DIR", "."))
+config = parse_image_generation_config(
+    load_skill_config("thumbnail", use_cache=False, channel_dir=channel_root)
+)
+if config.codex is None:
+    raise SystemExit("image_generation.provider must be codex")
+print(config.codex.max_parallel)
+PY
+  ); then
+    echo "ERROR: image_generation.codex.max_parallel を解決できません" >&2
+    exit 1
+  fi
+fi
+if ! [[ "$max_parallel" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --max-parallel / image_generation.codex.max_parallel must be an integer >= 1" >&2
+  exit 1
+fi
+
+real_codex=$(command -v codex)
+if ! login_status=$($real_codex login status 2>&1); then
+  echo "ERROR: codex login status の実行に失敗しました" >&2
+  echo "$login_status" >&2
+  exit 1
+fi
+if [[ "$login_status" != *"Logged in using ChatGPT"* ]]; then
+  echo "ERROR: codex login status で Logged in using ChatGPT を確認してから再実行してください" >&2
+  exit 1
+fi
+
+# Compatibility preflight is intentionally once per batch. Child codex-image.sh
+# processes keep their single-image implementation unchanged and see a narrow PATH
+# shim which only short-circuits checks already completed here.
+if ! $real_codex exec --json --skip-git-repo-check -- "Reply with exactly codex-model-compat-ok." \
+  </dev/null >/dev/null; then
+  echo "ERROR: codex CLI とデフォルトモデルの互換性プリフライトに失敗しました" >&2
+  exit 1
+fi
+
+tmp_root=$(mktemp -d "${TMPDIR:-/tmp}/codex-image-batch.XXXXXX")
+trap 'rm -rf "$tmp_root"' EXIT
+shim_dir="$tmp_root/bin"
+mkdir -p "$shim_dir"
+cat > "$shim_dir/codex" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+  exec "$CODEX_IMAGE_REAL_CODEX" --version
+fi
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+last=""
+for arg in "$@"; do
+  last=$arg
+done
+if [ "${1:-}" = "exec" ] && [ "$last" = "Reply with exactly codex-model-compat-ok." ]; then
+  exit 0
+fi
+exec "$CODEX_IMAGE_REAL_CODEX" "$@"
+SHIM
+chmod +x "$shim_dir/codex"
+
+job_lines="$tmp_root/jobs.jsonl"
+jq -c '.[]' "$manifest" > "$job_lines"
+failures="$tmp_root/failures.tsv"
+: > "$failures"
+
+group_pids=()
+group_ids=()
+group_prompts=()
+group_logs=()
+
+run_job() {
+  local job=$1
+  local prompt output reference
+  prompt=$(jq -r '.prompt' <<< "$job")
+  output=$(jq -r '.output' <<< "$job")
+  reference=$(jq -r '.reference // empty' <<< "$job")
+  if [ -n "$reference" ]; then
+    CODEX_IMAGE_REAL_CODEX="$real_codex" PATH="$shim_dir:$PATH" \
+      "$runner" --require-reference "$prompt" "$output" "$reference"
+  else
+    CODEX_IMAGE_REAL_CODEX="$real_codex" PATH="$shim_dir:$PATH" \
+      "$runner" "$prompt" "$output"
+  fi
+}
+
+wait_group() {
+  local index rc
+  for ((index = 0; index < ${#group_pids[@]}; index++)); do
+    rc=0
+    wait "${group_pids[$index]}" || rc=$?
+    if [ -s "${group_logs[$index]}" ]; then
+      cat "${group_logs[$index]}" >&2
+    fi
+    if [ "$rc" -ne 0 ]; then
+      jq -nc \
+        --arg id "${group_ids[$index]}" \
+        --arg prompt "${group_prompts[$index]}" \
+        --argjson exit "$rc" \
+        '{id: $id, prompt: $prompt, exit: $exit}' >> "$failures"
+    fi
+  done
+  group_pids=()
+  group_ids=()
+  group_prompts=()
+  group_logs=()
+}
+
+job_index=0
+while IFS= read -r job; do
+  job_index=$((job_index + 1))
+  id=$(jq -r '.id' <<< "$job")
+  prompt=$(jq -r '.prompt' <<< "$job")
+  log="$tmp_root/job-${job_index}.log"
+  run_job "$job" >"$log" 2>&1 &
+  group_pids+=("$!")
+  group_ids+=("$id")
+  group_prompts+=("$prompt")
+  group_logs+=("$log")
+  if [ "${#group_pids[@]}" -ge "$max_parallel" ]; then
+    wait_group
+  fi
+done < "$job_lines"
+if [ "${#group_pids[@]}" -gt 0 ]; then
+  wait_group
+fi
+
+if [ -s "$failures" ]; then
+  echo "ERROR: codex image batch failures (id, prompt, exit):" >&2
+  while IFS= read -r failed_job; do
+    failed_id=$(jq -r '.id | @json' <<< "$failed_job")
+    failed_prompt=$(jq -r '.prompt | @json' <<< "$failed_job")
+    failed_rc=$(jq -r '.exit' <<< "$failed_job")
+    printf '  - id=%s prompt=%s (exit=%s)\n' "$failed_id" "$failed_prompt" "$failed_rc" >&2
+  done < "$failures"
+  exit 1
+fi
+
+echo "completed: $(jq 'length' "$manifest") images (max_parallel=$max_parallel)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(thumbnail)`: 単発 `codex-image.sh` を変更せず、config/CLI で同時起動数を制御し、preflight を 1 回だけ行って複数候補を並列生成する `codex-image-batch.sh` を追加した。部分失敗時も残りを完走して失敗一覧を返す（#2028）。
 - `refactor(channel-new)`: standalone `/channel-research` を `/channel-new` の第 6 モード「分析モード」へ挙動不変で統合し、既存の入力 gate、subagent 委譲、TTP 分析、成果物パスを維持したまま skill と導線を集約した（#2027）。
 - `feat(thumbnail)`: 伸びた動画の CTR と流入構成からサムネ寄与を gate し、勝因を 1 要素ずつ Studio 比較して検証済み champion を次回 `/thumbnail` の internal TTP へ還元する `/thumbnail-iterate` を追加した。複数要素が独立して勝った場合は機械的に合成せず、一貫した再生成と最終比較を要求する（#1969）。
 - `feat(workspace)`: `yt-channel-import` を追加し、既存の単一 channel repository から channel 固有データだけを `channels/<slug>/` へ transaction copy できるようにした。meta 由来 slug の確認、必須 config と実 load の検証、auth 所在報告、symlink / 上書き拒否、生成 media を除外する workspace `.gitignore` scaffold、`.env` / `CHANNEL_DIR` 警告、共通 `yt-skills sync` 案内と external user 向け移行・rollback・archive ガイドを追加した（#1949）。

--- a/src/youtube_automation/utils/image_provider/config.py
+++ b/src/youtube_automation/utils/image_provider/config.py
@@ -36,6 +36,7 @@ _DEFAULT_GEMINI_CLI_TIMEOUT = 300
 # OpenAI provider の既定 quality。high は単価が数倍高いため既定にしない
 # （provider 切替時の無自覚な高単価課金を防ぐ。high は明示 opt-in のみ、#1697）
 _DEFAULT_OPENAI_QUALITY = "medium"
+_DEFAULT_CODEX_MAX_PARALLEL = 2
 
 
 @dataclass(frozen=True)
@@ -106,6 +107,7 @@ class CodexConfig:
 
     default_prompt_template: str = ""
     composition_rules: dict[str, object] | None = None
+    max_parallel: int = _DEFAULT_CODEX_MAX_PARALLEL
 
 
 @dataclass(frozen=True)
@@ -236,7 +238,14 @@ def _build_codex(d: object, *, composition_rules: dict[str, object] | None) -> C
         raise ConfigError("image_generation.codex.default_prompt_template は文字列で指定してください")
     if template:
         template = _validate_codex_prompt_template(template)
-    return CodexConfig(default_prompt_template=template, composition_rules=composition_rules)
+    max_parallel = d.get("max_parallel", _DEFAULT_CODEX_MAX_PARALLEL)
+    if isinstance(max_parallel, bool) or not isinstance(max_parallel, int) or max_parallel < 1:
+        raise ConfigError("image_generation.codex.max_parallel は 1 以上の整数で指定してください")
+    return CodexConfig(
+        default_prompt_template=template,
+        composition_rules=composition_rules,
+        max_parallel=max_parallel,
+    )
 
 
 def _composition_rules_from_gemini(section: object) -> dict[str, object] | None:

--- a/tests/test_codex_image_batch.py
+++ b/tests/test_codex_image_batch.py
@@ -1,0 +1,253 @@
+"""Contracts for the bounded codex image batch launcher (#2028)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.utils.exceptions import ConfigError
+from youtube_automation.utils.image_provider.config import parse_image_generation_config
+
+ROOT = Path(__file__).parents[1]
+BATCH = ROOT / ".claude/skills/thumbnail/references/codex-image-batch.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _mock_tools(tmp_path: Path) -> tuple[Path, Path, Path]:
+    tools = tmp_path / "bin"
+    tools.mkdir()
+    codex_log = tmp_path / "codex.log"
+    _write_executable(
+        tools / "codex",
+        """#!/usr/bin/env python3
+import json, os, pathlib, re, sys
+args = sys.argv[1:]
+if args == ["--version"]:
+    print("codex-cli 1.2.3")
+elif args[:2] == ["login", "status"]:
+    print("Logged in using ChatGPT")
+elif args and args[0] == "exec":
+    with pathlib.Path(os.environ["MOCK_CODEX_LOG"]).open("a") as handle:
+        handle.write(("preflight" if args[-1] == "Reply with exactly codex-model-compat-ok." else "generation") + "\\n")
+    if args[-1] != "Reply with exactly codex-model-compat-ok.":
+        match = re.search(r"copy the produced PNG to (.+?)\\. Then reply", args[-1])
+        if not match:
+            raise SystemExit(8)
+        output = pathlib.Path(match.group(1))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"\\x89PNG\\r\\n\\x1a\\n")
+        print(json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": str(output)}}))
+else:
+    raise SystemExit(9)
+""",
+    )
+    state = tmp_path / "runner-state.json"
+    _write_executable(
+        tools / "runner",
+        """#!/usr/bin/env python3
+import fcntl, json, os, pathlib, sys, time
+args = sys.argv[1:]
+if args and args[0] == "--require-reference":
+    args = args[1:]
+prompt, output = args[:2]
+state_path = pathlib.Path(os.environ["MOCK_RUNNER_STATE"])
+lock_path = state_path.with_suffix(".lock")
+lock_path.touch()
+def update(delta):
+    with lock_path.open("r+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = json.loads(state_path.read_text()) if state_path.exists() else {"active": 0, "max": 0, "calls": []}
+        state["active"] += delta
+        state["max"] = max(state["max"], state["active"])
+        if delta > 0:
+            state["calls"].append(prompt)
+        state_path.write_text(json.dumps(state))
+        fcntl.flock(lock, fcntl.LOCK_UN)
+update(1)
+try:
+    time.sleep(0.12)
+    if prompt.startswith("FAIL"):
+        raise SystemExit(7)
+    path = pathlib.Path(output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\\x89PNG\\r\\n\\x1a\\n")
+finally:
+    update(-1)
+""",
+    )
+    return tools, codex_log, state
+
+
+def _manifest(tmp_path: Path, prompts: list[str]) -> Path:
+    jobs = [
+        {
+            "id": f"job-{index}",
+            "prompt": prompt,
+            "output": str(tmp_path / "output" / f"{index}.png"),
+        }
+        for index, prompt in enumerate(prompts, start=1)
+    ]
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(jobs), encoding="utf-8")
+    return path
+
+
+def _run_batch(
+    tmp_path: Path,
+    manifest: Path,
+    *,
+    max_parallel: int | None = None,
+    channel_dir: Path | None = None,
+    runner_override: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    tools, codex_log, state = _mock_tools(tmp_path)
+    batch = BATCH
+    if runner_override:
+        launcher = tmp_path / "launcher"
+        launcher.mkdir()
+        batch = launcher / BATCH.name
+        shutil.copy2(BATCH, batch)
+        shutil.copy2(tools / "runner", launcher / "codex-image.sh")
+    command = ["bash", str(batch), "--manifest", str(manifest)]
+    if max_parallel is not None:
+        command.extend(["--max-parallel", str(max_parallel)])
+    env = {
+        **os.environ,
+        "PATH": f"{tools}:{os.environ['PATH']}",
+        "MOCK_CODEX_LOG": str(codex_log),
+        "MOCK_RUNNER_STATE": str(state),
+    }
+    if channel_dir is not None:
+        env["CHANNEL_DIR"] = str(channel_dir)
+    return subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
+
+
+def test_codex_config_defaults_overrides_and_rejects_invalid_parallelism() -> None:
+    default = parse_image_generation_config({"image_generation": {"provider": "codex"}})
+    overridden = parse_image_generation_config(
+        {"image_generation": {"provider": "codex", "codex": {"max_parallel": 4}}}
+    )
+
+    assert default.codex is not None and default.codex.max_parallel == 2
+    assert overridden.codex is not None and overridden.codex.max_parallel == 4
+    with pytest.raises(ConfigError, match="max_parallel"):
+        parse_image_generation_config({"image_generation": {"provider": "codex", "codex": {"max_parallel": 0}}})
+
+
+def test_batch_uses_config_limit_and_cli_override_and_runs_one_preflight(tmp_path: Path) -> None:
+    channel = tmp_path / "channel"
+    config = channel / "config/skills"
+    config.mkdir(parents=True)
+    (config / "thumbnail.yaml").write_text(
+        "image_generation:\n  provider: codex\n  codex:\n    max_parallel: 1\n",
+        encoding="utf-8",
+    )
+    manifest = _manifest(tmp_path, ["one", "two", "three"])
+
+    first = _run_batch(tmp_path, manifest, channel_dir=channel)
+
+    assert first.returncode == 0, first.stderr
+    state = json.loads((tmp_path / "runner-state.json").read_text())
+    assert state["max"] == 1
+    assert (tmp_path / "codex.log").read_text().splitlines() == ["preflight"]
+
+    second_root = tmp_path / "override"
+    second_root.mkdir()
+    manifest = _manifest(second_root, ["one", "two", "three"])
+    second = _run_batch(second_root, manifest, max_parallel=2, channel_dir=channel)
+
+    assert second.returncode == 0, second.stderr
+    state = json.loads((second_root / "runner-state.json").read_text())
+    assert state["max"] == 2
+
+
+def test_batch_finishes_remaining_jobs_and_reports_failures(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path, ["one", "FAIL two", "three"])
+
+    result = _run_batch(tmp_path, manifest, max_parallel=2)
+
+    assert result.returncode != 0
+    assert "job-2" in result.stderr and "FAIL two" in result.stderr
+    assert (tmp_path / "output/1.png").exists()
+    assert not (tmp_path / "output/2.png").exists()
+    assert (tmp_path / "output/3.png").exists()
+    state = json.loads((tmp_path / "runner-state.json").read_text())
+    assert sorted(state["calls"]) == ["FAIL two", "one", "three"]
+
+
+def test_batch_reports_multiline_failure_prompt_without_corrupting_entries(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path, ["one", "FAIL first\nsecond"])
+
+    result = _run_batch(tmp_path, manifest, max_parallel=2)
+
+    assert result.returncode != 0
+    assert 'id="job-2" prompt="FAIL first\\nsecond" (exit=7)' in result.stderr
+    assert result.stderr.count("  - id=") == 1
+
+
+def test_default_single_image_runner_skips_child_preflight_via_batch_shim(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path, ["one", "two"])
+
+    result = _run_batch(tmp_path, manifest, max_parallel=2, runner_override=False)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "codex.log").read_text().splitlines() == [
+        "preflight",
+        "generation",
+        "generation",
+    ]
+    assert (tmp_path / "output/1.png").exists()
+    assert (tmp_path / "output/2.png").exists()
+
+
+def test_batch_rejects_duplicate_outputs_before_preflight(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path, ["one", "two"])
+    jobs = json.loads(manifest.read_text())
+    jobs[1]["output"] = jobs[0]["output"]
+    manifest.write_text(json.dumps(jobs))
+
+    result = _run_batch(tmp_path, manifest, max_parallel=2)
+
+    assert result.returncode != 0
+    assert "output" in result.stderr and "unique" in result.stderr
+    assert not (tmp_path / "codex.log").exists()
+
+
+def test_batch_rejects_outputs_that_alias_through_a_symlink(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path, ["one", "two"])
+    real_output = tmp_path / "real-output"
+    real_output.mkdir()
+    alias = tmp_path / "alias-output"
+    alias.symlink_to(real_output, target_is_directory=True)
+    jobs = json.loads(manifest.read_text())
+    jobs[0]["output"] = str(real_output / "same.png")
+    jobs[1]["output"] = str(alias / "same.png")
+    manifest.write_text(json.dumps(jobs))
+
+    result = _run_batch(tmp_path, manifest, max_parallel=2)
+
+    assert result.returncode != 0
+    assert "canonical output paths must be unique" in result.stderr
+    assert not (tmp_path / "codex.log").exists()
+
+
+def test_skill_documents_batch_usage_and_fair_use_limit() -> None:
+    skill = (ROOT / ".claude/skills/thumbnail/SKILL.md").read_text()
+    for phrase in (
+        "codex-image-batch.sh",
+        "image_generation.codex.max_parallel",
+        "大量生成には使わない",
+        "default `2` を維持",
+        "失敗時は `1` に下げる",
+        "`3` 以上はユーザーが今回の実行について明示した場合だけ",
+    ):
+        assert phrase in skill


### PR DESCRIPTION
## 概要

- `codex-image.sh` を変更せず、複数候補を bounded parallel で生成する `codex-image-batch.sh` を追加
- `image_generation.codex.max_parallel`（default 2）と CLI override を追加
- 認証・互換性 preflight をバッチ全体で一度だけ実行し、子プロセスでは再利用
- 部分失敗後も残りを完走し、改行を含むプロンプトも安全な JSONL で失敗一覧に集約
- 出力先の重複・symlink alias を生成前に拒否

## 検証

- `uv run ruff check .`
- `bash -n .claude/skills/thumbnail/references/codex-image-batch.sh`
- 関連テスト: 264 passed
- フルスイート: 6364 passed, 21 warnings
- Standards / Spec の二軸レビュー: clean

Closes #2028