### PR TITLE
feat(suno-helper): 複数コレクションの連続実行を追加 (#2029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(suno-helper)`: collection 選択を shadcn ベースの checkbox 一覧へ拡張し、選択順ではなく server 一覧順で生成・playlist 追加・ZIP download を直列実行する永続 queue を追加した。collection 間はページ reload で clip tracker / multi-select を分離し、部分失敗後も後続を継続して成功・失敗 summary と失敗分再実行を提供する（#2029）。
 - `feat(thumbnail)`: 単発 `codex-image.sh` を変更せず、config/CLI で同時起動数を制御し、preflight を 1 回だけ行って複数候補を並列生成する `codex-image-batch.sh` を追加した。部分失敗時も残りを完走して失敗一覧を返す（#2028）。
 - `refactor(channel-new)`: standalone `/channel-research` を `/channel-new` の第 6 モード「分析モード」へ挙動不変で統合し、既存の入力 gate、subagent 委譲、TTP 分析、成果物パスを維持したまま skill と導線を集約した（#2027）。
 - `feat(thumbnail)`: 伸びた動画の CTR と流入構成からサムネ寄与を gate し、勝因を 1 要素ずつ Studio 比較して検証済み champion を次回 `/thumbnail` の internal TTP へ還元する `/thumbnail-iterate` を追加した。複数要素が独立して勝った場合は機械的に合成せず、一貫した再生成と最終比較を要求する（#1969）。

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -686,6 +686,20 @@ export function extractPlaylistName(
   return `${channel} | ${theme}`;
 }
 
+/** collection metadata から playlist 表示名を解決する共通入口。 */
+export function playlistNameForCollection(
+  collection: CollectionSummary
+): string {
+  if (collection.channel && collection.theme) {
+    return `${collection.channel} | ${collection.theme}`;
+  }
+  const theme = (collection.theme ?? collection.name).replace(
+    /-collection$/,
+    ""
+  );
+  return extractPlaylistName(collection.id, theme);
+}
+
 /** DistroKid `/distrokid/collections` が返す 1 disc のスキーマ (#934 dir mode サーバー契約)。 */
 export interface DistrokidCollectionSummary {
   collection_id: string;

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -17,6 +17,9 @@ export const RESUME_STATE_KEY = "sunoResumeState";
 /** 定期無人実行の checkpoint / 手動介入理由を保存する chrome.storage.local key (#1893)。 */
 export const UNATTENDED_RUN_STATE_KEY = "sunoUnattendedRunState";
 
+/** 手動の複数 collection queue と成功/失敗 summary を保存する chrome.storage.local key (#2029)。 */
+export const COLLECTION_QUEUE_STATE_KEY = "sunoCollectionQueueState";
+
 /** overlay の position/minimized/hidden を保存する chrome.storage.local の単一 key (#892)。
  * Suno は 1 タブ運用前提のため global 単一 key とする。lib/overlay-state.ts が SSOT として参照する。 */
 export const OVERLAY_STATE_KEY = "sunoOverlayState";

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -37,7 +37,9 @@ browser use から overlay / popup を安定して観測できるよう、操作
 | `data-suno-selected-entry-count` | 実行対象 entry 数 |
 | `[data-suno-control="server-source-trigger"]` | ローカル配信元の動的検出を開始し、候補 listbox を開く |
 | `role="option"` | 動的検出したローカル配信元の選択 |
-| `[data-suno-control="collection-select"]` | collection 選択 |
+| `[data-suno-control="collection-checkbox"]` | shadcn ベース一覧で collection を複数選択 |
+| `[data-suno-control="collection-select"]` | 旧 agent/E2E 用の非表示単一選択 compatibility seam |
+| `[data-suno-control="collection-queue-summary"]` | collection ごとの成功 / 失敗と再実行導線 |
 | `[data-suno-control="run"]` / `[data-suno-control="stop"]` | 主要操作ボタン |
 | `[data-suno-control="resume"]` / `[data-suno-control="dismiss-resume"]` | 前回中断 resume バナーの再開 / 閉じる |
 | `[data-suno-control="adopt-selected-clips"]` | Suno 上の選択中 clip を採用 |
@@ -86,10 +88,12 @@ build 後は `.output/chrome-mv3/manifest.json`、zip 後は `.output/suno-helpe
    ```
 2. Chrome で Suno の **Advanced** タブを選択する。
 3. 拡張アイコンからポップアップを開き、**ローカル配信元** で動的検出されたチャンネル名つき候補を選ぶ。初回表示・配信元選択・collection 選択の各タイミングで一覧と prompts が自動取得される。
-4. `ready` な collection を選び、prompts の自動取得後に **異常値の曲を再生成する** を選んでから **全パターンを連続実行** を押す。既定の ON は duration guard NG の entry を最大 2 回再生成する。OFF は追加生成せず、NG を警告表示したうえで生成済み全 clip を playlist / download 候補に残す。
+4. `ready` な collection を checkbox で 1 件以上選び、prompts の自動取得後に **異常値の曲を再生成する** を選んでから実行する。1 件なら従来どおり現在の entry 選択を使い、2 件以上なら server 一覧順で各 collection の全 pattern を直列実行する。既定の ON は duration guard NG の entry を最大 2 回再生成する。OFF は追加生成せず、NG を警告表示したうえで生成済み全 clip を playlist / download 候補に残す。
 5. 各パターンで Style/Lyrics を注入 → Generate 押下 → 生成完了検知 → 次へ、を自動で繰り返す。
 6. 全件完了後、対象 clip を一括選択 → playlist 追加 → More menu の **Download all** → format 選択 → ZIP ダウンロード完了監視 → `POST /collections/<id>/downloaded` で ZIP パス通知、まで実行する。サーバーは ZIP を展開し、`02-Individual-music/` と `workflow-state.json` を更新する。
 7. captcha challenge は waiting-captcha 表示で解消（多くは自動 verify）を待って続行する。entry 単位の一時的な失敗は Balanced 固定の上限で自動リトライし、上限超過分はスキップして完走する（#948）。スキップされた entry は一覧表示され、**失敗分のみ再実行** で再投入できる。
+
+複数 collection queue は各 collection の `/downloaded` 完了または失敗結果を extension storage へ保存してから Suno タブを再読み込みする。この境界処理が clip tracker と Suno 内部 multi-select を collection 間で破棄し、次の collection は保存済み index から自動開始する。タブ再読み込みや Stop で中断した queue は同じ current collection から再開でき、全件終了後は summary の **失敗したコレクションだけ再実行** を使う。
 
 **異常値の曲を再生成する** を OFF にした run は、duration guard の閾値外 clip も歯抜けにせず playlist と ZIP に含める。popup の status / console warning で NG を確認し、完了後に対象 playlist を試聴して採否を手動判断する。popup を閉じて再表示した場合も選択は復元される。entry phase の ERROR / STOPPED は resume バナー、playlist / download phase の中断は **Playlist から再開** / **Download から再開** を使い、いずれも元 run の選択と警告を引き継ぐ。
 

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -21,6 +21,7 @@ import { PatternList } from "./PatternList";
 import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
 import { Alert } from "./ui/alert";
 import { Button, ButtonSlot } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
 import { useSunoRunner } from "./useSunoRunner";
 
 // RUN_MODES のキー集合から導出する（手書き複製だと mode 追加時に UI へ出ないまま型チェックが通る）。
@@ -43,6 +44,9 @@ export function App() {
     collections,
     selectedCollectionId,
     selectCollection,
+    collectionQueue,
+    runCollectionQueue,
+    resumeCollectionQueue,
     entries,
     itemStates,
     status,
@@ -67,6 +71,11 @@ export function App() {
     run,
     stop,
   } = useSunoRunner();
+  const queueInProgress = collectionQueue?.status === "running";
+  const controlsLocked = isRunning || queueInProgress;
+  const [selectedCollectionIds, setSelectedCollectionIds] = useState<string[]>(
+    []
+  );
   const previousEntriesRef = useRef(entries);
   const previousItemStatesRef = useRef(itemStates);
   const [refreshingServerSources, setRefreshingServerSources] = useState(false);
@@ -77,7 +86,7 @@ export function App() {
   }, [isRunning]);
 
   const openServerSourcePicker = (): void => {
-    if (refreshingServerSources || isRunning) {
+    if (refreshingServerSources || controlsLocked) {
       return;
     }
     setServerSourcePickerOpen(false);
@@ -147,6 +156,40 @@ export function App() {
     previousItemStatesRef.current = itemStates;
   }, [entries, itemStates]);
 
+  useEffect(() => {
+    setSelectedCollectionIds((selectedIds) => {
+      const visibleIds = new Set(
+        collections.map((collection) => collection.id)
+      );
+      const retained = selectedIds.filter((id) => visibleIds.has(id));
+      if (retained.length > 0) {
+        return retained;
+      }
+      return selectedCollectionId ? [selectedCollectionId] : [];
+    });
+  }, [collections, selectedCollectionId]);
+
+  const toggleCollectionSelection = (id: string, checked: boolean): void => {
+    setSelectedCollectionIds((selectedIds) => {
+      const selected = new Set(selectedIds);
+      if (checked) {
+        selected.add(id);
+      } else {
+        selected.delete(id);
+      }
+      const ordered = collections
+        .map((collection) => collection.id)
+        .filter((collectionId) => selected.has(collectionId));
+      if (checked || id === selectedCollectionId) {
+        const nextFocusedId = checked ? id : ordered[0];
+        if (nextFocusedId) {
+          selectCollection(nextFocusedId);
+        }
+      }
+      return ordered;
+    });
+  };
+
   const toggleEntrySelection = (index: number, checked: boolean): void => {
     setSelectedEntries((selection) =>
       reconcilePatternSelection({
@@ -168,19 +211,32 @@ export function App() {
     itemStates,
     entryCount: entries.length,
   });
-  const canRunSelectedEntries = canRun && selectedEntryCount > 0;
-  const runButtonLabel =
-    entries.length > 0 && selectedEntryCount === 0
+  const multipleCollectionsSelected = selectedCollectionIds.length > 1;
+  const canRunSelectedEntries =
+    canRun &&
+    !queueInProgress &&
+    selectedCollectionIds.length > 0 &&
+    (multipleCollectionsSelected || selectedEntryCount > 0);
+  const runButtonLabel = multipleCollectionsSelected
+    ? `選択した${selectedCollectionIds.length}コレクションを連続実行`
+    : entries.length > 0 && selectedEntryCount === 0
       ? "実行対象を選択"
       : entries.length > 0 && selectedEntryCount < entries.length
         ? `選択した${selectedEntryCount}件を連続実行`
         : "全パターンを連続実行";
 
   const runSelectedEntries = (): void => {
-    if (selectedEntryCount === 0) {
+    if (selectedCollectionIds.length === 0) {
       return;
     }
     setServerSourcePickerOpen(false);
+    if (multipleCollectionsSelected) {
+      void runCollectionQueue(selectedCollectionIds);
+      return;
+    }
+    if (selectedEntryCount === 0) {
+      return;
+    }
     void run(
       buildSelectedEntriesRunOverrides({
         selectedEntries: resolvedSelectedEntries,
@@ -190,7 +246,7 @@ export function App() {
     );
   };
   const serverSourcePickerVisible =
-    serverSourcePickerOpen && !isRunning && !refreshingServerSources;
+    serverSourcePickerOpen && !controlsLocked && !refreshingServerSources;
   if (reloadRequired || runnerReloadRequired) {
     return <ReloadRequiredNotice />;
   }
@@ -214,7 +270,7 @@ export function App() {
           type="button"
           aria-haspopup="listbox"
           aria-expanded={serverSourcePickerVisible}
-          disabled={isRunning || refreshingServerSources}
+          disabled={controlsLocked || refreshingServerSources}
           onClick={openServerSourcePicker}
           data-suno-control="server-source-trigger"
           className="rounded border border-gray-300 px-2 py-1 text-left"
@@ -227,7 +283,7 @@ export function App() {
         </button>
         <select
           value={url}
-          disabled={isRunning || refreshingServerSources}
+          disabled={controlsLocked || refreshingServerSources}
           onChange={(e) => setUrl(e.target.value)}
           data-suno-control="server-url"
           aria-hidden="true"
@@ -252,7 +308,7 @@ export function App() {
                 type="button"
                 role="option"
                 aria-selected={source.url === url}
-                disabled={isRunning || refreshingServerSources}
+                disabled={controlsLocked || refreshingServerSources}
                 className="block w-full rounded px-2 py-1 text-left hover:bg-gray-100"
                 onClick={() => {
                   if (isRunningRef.current || refreshingServerSources) {
@@ -269,39 +325,126 @@ export function App() {
         )}
       </label>
 
-      <label className="flex flex-col gap-1 text-sm">
-        コレクション
-        <ButtonSlot
-          variant="outline"
-          size="sm"
-          className="w-full justify-between font-normal"
+      <fieldset className="flex flex-col gap-1 rounded border border-gray-200 px-2 py-2 text-sm">
+        <legend className="px-1 text-xs text-gray-600">コレクション</legend>
+        {collections.length === 0 && (
+          <p className="text-xs text-gray-500">コレクションなし</p>
+        )}
+        {collections.map((collection) => {
+          const checked = selectedCollectionIds.includes(collection.id);
+          return (
+            <ButtonSlot
+              key={collection.id}
+              variant={checked ? "secondary" : "outline"}
+              size="sm"
+              className="h-auto w-full justify-start whitespace-normal p-2"
+            >
+              <label className="flex items-start gap-2">
+                <Checkbox
+                  className="mt-1"
+                  checked={checked}
+                  disabled={
+                    controlsLocked || collection.status === "needs_prompts"
+                  }
+                  data-suno-control="collection-checkbox"
+                  aria-label={`${collection.name} を選択`}
+                  onCheckedChange={(nextChecked) =>
+                    toggleCollectionSelection(
+                      collection.id,
+                      nextChecked === true
+                    )
+                  }
+                />
+                <span className="flex flex-col text-left">
+                  <span className="font-medium">{collection.name}</span>
+                  <span className="text-xs text-gray-500">
+                    {collection.status === "downloaded"
+                      ? `完了 ${collection.downloaded_count}/${collection.expected_file_count ?? (collection.pattern_count ?? 0) * 2}`
+                      : collection.status === "ready"
+                        ? `${collection.pattern_count} patterns`
+                        : "prompts なし"}
+                  </span>
+                </span>
+              </label>
+            </ButtonSlot>
+          );
+        })}
+      </fieldset>
+      <ButtonSlot
+        variant="outline"
+        size="sm"
+        className="sr-only"
+        aria-hidden="true"
+      >
+        <select
+          value={selectedCollectionId}
+          onChange={(event) => selectCollection(event.target.value)}
+          data-suno-control="collection-select"
+          tabIndex={-1}
         >
-          <select
-            value={selectedCollectionId}
-            onChange={(e) => selectCollection(e.target.value)}
-            data-suno-control="collection-select"
-          >
-            {collections.length === 0 && (
-              <option value="" disabled>
-                コレクションなし
-              </option>
-            )}
-            {collections.map((c) => (
-              <option
-                key={c.id}
-                value={c.id}
-                disabled={c.status === "needs_prompts"}
-              >
-                {c.status === "downloaded"
-                  ? `${c.name}（完了 ${c.downloaded_count}/${c.expected_file_count ?? (c.pattern_count ?? 0) * 2}）`
-                  : c.status === "ready"
-                    ? `${c.name} (${c.pattern_count})`
-                    : `${c.name}（prompts なし）`}
-              </option>
+          {collections.map((collection) => (
+            <option key={collection.id} value={collection.id}>
+              {collection.status === "downloaded"
+                ? `${collection.name}（完了 ${collection.downloaded_count}/${collection.expected_file_count ?? (collection.pattern_count ?? 0) * 2}）`
+                : collection.status === "ready"
+                  ? `${collection.name} (${collection.pattern_count})`
+                  : `${collection.name}（prompts なし）`}
+            </option>
+          ))}
+        </select>
+      </ButtonSlot>
+
+      {collectionQueue && (
+        <Alert
+          variant={
+            collectionQueue.items.some((item) => item.status === "failed")
+              ? "warning"
+              : "default"
+          }
+          className="flex flex-col gap-2 rounded px-2 py-2 text-xs"
+          data-suno-control="collection-queue-summary"
+        >
+          <p className="font-medium">
+            Collection queue: {collectionQueue.status}
+          </p>
+          <ul className="list-disc pl-4">
+            {collectionQueue.items.map((item) => (
+              <li key={item.collectionId}>
+                {item.collectionId}: {item.status}
+                {item.message ? ` — ${item.message}` : ""}
+              </li>
             ))}
-          </select>
-        </ButtonSlot>
-      </label>
+          </ul>
+          {collectionQueue.status === "paused" && (
+            <Button
+              type="button"
+              size="sm"
+              className="self-start"
+              onClick={() => void resumeCollectionQueue()}
+            >
+              Queue を再開
+            </Button>
+          )}
+          {collectionQueue.status === "completed" &&
+            collectionQueue.items.some((item) => item.status === "failed") && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="self-start"
+                onClick={() =>
+                  void runCollectionQueue(
+                    collectionQueue.items
+                      .filter((item) => item.status === "failed")
+                      .map((item) => item.collectionId)
+                  )
+                }
+              >
+                失敗したコレクションだけ再実行
+              </Button>
+            )}
+        </Alert>
+      )}
 
       {playlistName && (
         <p className="text-xs text-gray-600">
@@ -350,7 +493,7 @@ export function App() {
       )}
 
       {/* 失敗スキップされた entry の再実行導線 (#948)。実行中は隠す。 */}
-      {failedEntries.length > 0 && !isRunning && (
+      {failedEntries.length > 0 && !controlsLocked && (
         <Alert
           variant="destructive"
           className="flex flex-col gap-2 rounded px-2 py-2 text-xs"
@@ -392,7 +535,7 @@ export function App() {
                   checked={runModeId === id}
                   // 実行中の切替は当該 run に効かないのに保存だけ即時反映され、次回 resume の
                   // モードを無言で変えてしまうため run 中は無効化する (#1586 review)。
-                  disabled={isRunning}
+                  disabled={controlsLocked}
                   onChange={() => setRunMode(id)}
                 />
                 <span className="flex flex-col">
@@ -410,7 +553,7 @@ export function App() {
           type="checkbox"
           className="mt-1"
           checked={regenerateDurationOutliers}
-          disabled={entries.length === 0 || isRunning}
+          disabled={entries.length === 0 || controlsLocked}
           onChange={(event) =>
             setRegenerateDurationOutliers(event.target.checked)
           }
@@ -430,6 +573,8 @@ export function App() {
         DL 形式
         <select
           value={downloadFormat}
+          disabled={controlsLocked}
+          data-suno-control="download-format"
           onChange={(e) =>
             updateDownloadFormat(e.target.value as DownloadFormat)
           }
@@ -457,7 +602,7 @@ export function App() {
         <Button
           type="button"
           onClick={() => void stop()}
-          disabled={!isRunning}
+          disabled={!controlsLocked}
           data-suno-control="stop"
           variant="destructive"
           size="sm"
@@ -466,7 +611,7 @@ export function App() {
         </Button>
       </div>
 
-      {!isRunning && selectedCollectionId && (
+      {!controlsLocked && selectedCollectionId && (
         <div className="flex flex-col gap-2">
           <button
             type="button"

--- a/extensions/suno-helper/components/ui/checkbox.tsx
+++ b/extensions/suno-helper/components/ui/checkbox.tsx
@@ -1,0 +1,40 @@
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current"
+      >
+        <svg
+          aria-hidden="true"
+          className="size-3.5"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+        >
+          <path d="m3 8 3 3 7-7" />
+        </svg>
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -8,7 +8,7 @@ import { browser } from "wxt/browser";
 import {
   type CollectionSummary,
   type DurationFilter,
-  extractPlaylistName,
+  playlistNameForCollection,
   type PromptEntry,
   type PromptResponse,
   resolvePromptCollectionId,
@@ -21,13 +21,26 @@ import {
   type LocalServerSource,
   type RunModeId,
 } from "../../shared/constants";
+import {
+  createCollectionQueue,
+  currentCollectionId,
+  orderSelectedCollectionIds,
+  pauseCollectionQueue,
+  readCollectionQueue,
+  resumeCollectionQueue,
+  settleStoredCollectionQueueRun,
+  type CollectionQueueState,
+  writeCollectionQueue,
+} from "../lib/collection-queue-state";
 import { onMessage, sendMessage } from "../lib/messaging";
+import { scheduleRunCompleteReload } from "../lib/page-reload";
 import {
   DEFAULT_RUN_MODE_ID,
   readRunModeId,
   writeRunModeId,
 } from "../lib/preset-state";
 import {
+  clearResumeStateForCollection,
   readResumeState,
   resolvePlaylistExpectedClipCountForResume,
   type ResumeBanner,
@@ -61,6 +74,9 @@ interface RunnerState {
   collections: CollectionSummary[];
   selectedCollectionId: string;
   selectCollection: (id: string) => void;
+  collectionQueue: CollectionQueueState | null;
+  runCollectionQueue: (collectionIds: string[]) => Promise<void>;
+  resumeCollectionQueue: () => Promise<void>;
   entries: PromptEntry[];
   itemStates: ItemState[];
   status: string;
@@ -93,6 +109,10 @@ interface RunnerState {
   stop: () => Promise<void>;
 }
 
+type RejectedRunAcknowledgement =
+  | { ok: false; busy: true }
+  | { ok: false; error: string };
+
 function normalizePromptResponseMessage(
   response: PromptResponse | PromptEntry[]
 ): PromptResponse {
@@ -122,6 +142,47 @@ function maxDefined(
   return candidates.length > 0 ? Math.max(...candidates) : undefined;
 }
 
+function queueResumeOverrides(
+  resume: ResumeState | null,
+  collectionId: string
+): RunOverrides | undefined {
+  if (resume?.collectionId !== collectionId) {
+    return undefined;
+  }
+  return {
+    ...buildResumeRunOverrides(
+      {
+        failedIndex: resume.failedIndex,
+        total: resume.total,
+        remainingIndices: resume.remainingIndices,
+      },
+      {
+        submittedClipIds: resume.submittedClipIds ?? [],
+        submittedClipIdsAreDurationFiltered:
+          resume.submittedClipIdsAreDurationFiltered === true,
+        playlistExpectedClipCount: resume.playlistExpectedClipCount,
+      }
+    ),
+    durationOutlierWarnings: resume.durationOutlierWarnings,
+  };
+}
+
+function resolveInitialServerUrl(
+  storedUrl: string,
+  sources: LocalServerSource[],
+  queue: CollectionQueueState | null
+): string | undefined {
+  if (queue && queue.status !== "completed") {
+    return queue.baseUrl;
+  }
+  if (!storedUrl.trim()) {
+    return undefined;
+  }
+  return (
+    sources.find((source) => source.url === storedUrl)?.url ?? sources[0]?.url
+  );
+}
+
 export function useSunoRunner(): RunnerState {
   const [reloadRequired, setReloadRequired] = useState(false);
   const [url, setUrlState] = useState("");
@@ -129,6 +190,10 @@ export function useSunoRunner(): RunnerState {
   const [serverSources, setServerSources] = useState<LocalServerSource[]>([]);
   const [allCollections, setAllCollections] = useState<CollectionSummary[]>([]);
   const [selectedCollectionIdState, setSelectedCollectionId] = useState("");
+  const [collectionQueue, setCollectionQueue] =
+    useState<CollectionQueueState | null>(null);
+  const collectionQueueRef = useRef<CollectionQueueState | null>(null);
+  const [collectionQueueChecked, setCollectionQueueChecked] = useState(false);
   const [entries, setEntries] = useState<PromptEntry[]>([]);
   const [durationFilter, setDurationFilter] = useState<
     DurationFilter | undefined
@@ -190,6 +255,7 @@ export function useSunoRunner(): RunnerState {
   const [persistedResume, setPersistedResume] = useState<ResumeState | null>(
     null
   );
+  const persistedResumeRef = useRef<ResumeState | null>(null);
   // resume state を読んだ popup 起動時刻 (#872)。stale 判定の基準 now をここで一度だけ確定し、
   // render 中の Date.now()（非純粋）を避ける。
   const [resumeCheckedAt, setResumeCheckedAt] = useState<number | null>(null);
@@ -204,6 +270,16 @@ export function useSunoRunner(): RunnerState {
   const initializationRef = useRef<Promise<void> | null>(null);
 
   const resumableCollectionId = useMemo(() => {
+    const queuedCollectionId = collectionQueue
+      ? currentCollectionId(collectionQueue)
+      : null;
+    if (
+      queuedCollectionId &&
+      collectionQueue &&
+      collectionQueue.status !== "completed"
+    ) {
+      return queuedCollectionId;
+    }
     if (
       resumeCheckedAt !== null &&
       persistedResume &&
@@ -216,7 +292,7 @@ export function useSunoRunner(): RunnerState {
       return persistedResume.collectionId;
     }
     return undefined;
-  }, [persistedResume, resumeCheckedAt]);
+  }, [collectionQueue, persistedResume, resumeCheckedAt]);
 
   const resolveVisibleCollections = useCallback(
     (source: CollectionSummary[], currentSelectedId: string) => {
@@ -250,11 +326,7 @@ export function useSunoRunner(): RunnerState {
     if (!selected) {
       return undefined;
     }
-    if (selected.channel && selected.theme) {
-      return `${selected.channel} | ${selected.theme}`;
-    }
-    const theme = (selected.theme ?? selected.name).replace(/-collection$/, "");
-    return extractPlaylistName(selected.id, theme);
+    return playlistNameForCollection(selected);
   }, [selectedCollection]);
   const playlistName = derivedPlaylistName ?? restoredPlaylistName;
 
@@ -513,6 +585,16 @@ export function useSunoRunner(): RunnerState {
     setIsError(error);
   }, []);
 
+  const reportRunDispatchFailure = useCallback(
+    (error: unknown): void => {
+      setRunning(false);
+      setPhase("error");
+      const message = error instanceof Error ? error.message : String(error);
+      report(formatRunError(message), true);
+    },
+    [report, setRunning]
+  );
+
   const reportStorageFailure = useCallback((error: unknown) => {
     console.warn(
       "[suno-helper] storage 操作に失敗しました（拡張更新後はタブを再読み込みしてください）:",
@@ -527,6 +609,7 @@ export function useSunoRunner(): RunnerState {
     void readResumeState()
       .then((state) => {
         const checkedAt = Date.now();
+        persistedResumeRef.current = state;
         setPersistedResume(state);
         setResumeCheckedAt(checkedAt);
         if (
@@ -540,6 +623,16 @@ export function useSunoRunner(): RunnerState {
       .catch((err: unknown) => {
         reportStorageFailure(err);
       });
+  }, [reportStorageFailure]);
+
+  useEffect(() => {
+    void readCollectionQueue()
+      .then((state) => {
+        collectionQueueRef.current = state;
+        setCollectionQueue(state);
+      })
+      .catch(reportStorageFailure)
+      .finally(() => setCollectionQueueChecked(true));
   }, [reportStorageFailure]);
 
   useEffect(() => {
@@ -571,6 +664,206 @@ export function useSunoRunner(): RunnerState {
     setRestoredPlaylistExpectedClipCount(undefined);
     setRestoredDurationOutlierWarnings(undefined);
   }, []);
+
+  const writePausedCollectionQueue = useCallback(
+    async (queue: CollectionQueueState): Promise<void> => {
+      const paused = pauseCollectionQueue(queue, Date.now());
+      collectionQueueRef.current = paused;
+      setCollectionQueue(paused);
+      await writeCollectionQueue(paused);
+    },
+    []
+  );
+
+  const persistPausedCollectionQueue = useCallback(
+    async (
+      queue: CollectionQueueState,
+      message: string,
+      settlementError?: unknown
+    ): Promise<void> => {
+      try {
+        await writePausedCollectionQueue(queue);
+      } catch (error) {
+        reportStorageFailure(error);
+        return;
+      }
+      if (settlementError !== undefined) {
+        console.warn(
+          "[suno-helper] collection queue の失敗確定に失敗したため一時停止しました:",
+          settlementError
+        );
+      }
+      report(`${message} / queue を一時停止しました。`, true);
+    },
+    [report, reportStorageFailure, writePausedCollectionQueue]
+  );
+
+  const settleRejectedCollectionQueueStart = useCallback(
+    async (
+      queue: CollectionQueueState,
+      collectionId: string,
+      collectionName: string,
+      acknowledgement: RejectedRunAcknowledgement
+    ): Promise<void> => {
+      const message =
+        "busy" in acknowledgement
+          ? "Suno runner が別の実行で使用中です。"
+          : acknowledgement.error;
+      const transition = await settleStoredCollectionQueueRun(queue.queueId, {
+        collectionId,
+        phase: "error",
+        failedEntryCount: 0,
+        message,
+        now: Date.now(),
+      });
+      setRunning(false);
+      setPhase("error");
+      if (!transition) {
+        await persistPausedCollectionQueue(
+          queue,
+          "collection queue の保存状態が見つかりません。"
+        );
+        return;
+      }
+      collectionQueueRef.current = transition.state;
+      setCollectionQueue(transition.state);
+      report(`${collectionName}: ${message}`, true);
+      if (transition.requiresPageReload) {
+        scheduleRunCompleteReload();
+      }
+    },
+    [persistPausedCollectionQueue, report, setRunning]
+  );
+
+  const settleCollectionQueuePreflightFailure = useCallback(
+    async (
+      preferredCollectionId: string,
+      message: string
+    ): Promise<boolean> => {
+      const activeQueue = collectionQueueRef.current;
+      const activeCollectionId = activeQueue
+        ? currentCollectionId(activeQueue)
+        : null;
+      if (
+        activeQueue?.status !== "running" ||
+        !activeCollectionId ||
+        activeCollectionId !== preferredCollectionId
+      ) {
+        return false;
+      }
+      try {
+        const transition = await settleStoredCollectionQueueRun(
+          activeQueue.queueId,
+          {
+            collectionId: activeCollectionId,
+            phase: "error",
+            failedEntryCount: 0,
+            message,
+            now: Date.now(),
+          }
+        );
+        if (!transition) {
+          await persistPausedCollectionQueue(activeQueue, message);
+          return true;
+        }
+        collectionQueueRef.current = transition.state;
+        setCollectionQueue(transition.state);
+        report(message, true);
+        if (transition.requiresPageReload) {
+          scheduleRunCompleteReload();
+        }
+      } catch (error) {
+        await persistPausedCollectionQueue(activeQueue, message, error);
+      }
+      return true;
+    },
+    [persistPausedCollectionQueue, report]
+  );
+
+  const pauseCollectionQueueForReload = useCallback(
+    async (preferredCollectionId: string): Promise<void> => {
+      const activeQueue = collectionQueueRef.current;
+      if (
+        activeQueue?.status !== "running" ||
+        currentCollectionId(activeQueue) !== preferredCollectionId
+      ) {
+        return;
+      }
+      try {
+        await writePausedCollectionQueue(activeQueue);
+      } catch (error) {
+        reportStorageFailure(error);
+      }
+    },
+    [reportStorageFailure, writePausedCollectionQueue]
+  );
+
+  const startCollectionQueueItem = useCallback(
+    async (
+      queue: CollectionQueueState,
+      collection: CollectionSummary,
+      response: PromptResponse
+    ): Promise<void> => {
+      if (isRunningRef.current || queue.status !== "running") {
+        return;
+      }
+      const activeCollectionId = currentCollectionId(queue);
+      if (!activeCollectionId || activeCollectionId !== collection.id) {
+        return;
+      }
+      const overrides = queueResumeOverrides(
+        persistedResumeRef.current,
+        activeCollectionId
+      );
+      setSelectedCollectionId(activeCollectionId);
+      setEntries(response.entries);
+      setDurationFilter(response.duration_filter);
+      setItemStates(response.entries.map(() => "idle"));
+      setRunning(true);
+      setPhase("starting");
+      try {
+        const acknowledgement = await sendMessage(
+          "run",
+          buildRunPayload({
+            entries: response.entries,
+            playlistName: playlistNameForCollection(collection),
+            durationFilter: response.duration_filter,
+            range: overrides?.range,
+            collectionId: activeCollectionId,
+            collectionQueueId: queue.queueId,
+            runMode: queue.runMode,
+            regenerateDurationOutliers: queue.regenerateDurationOutliers,
+            durationOutlierWarnings: overrides?.durationOutlierWarnings,
+            overrides,
+          })
+        );
+        if (!acknowledgement.ok) {
+          await settleRejectedCollectionQueueStart(
+            queue,
+            activeCollectionId,
+            collection.name,
+            acknowledgement
+          );
+          return;
+        }
+        report(
+          `collection queue ${queue.currentIndex + 1}/${queue.items.length}: ${collection.name} を開始しました。`
+        );
+      } catch (error) {
+        await writePausedCollectionQueue(queue).catch(reportStorageFailure);
+        setRunning(false);
+        setPhase("error");
+        report(formatRunError(String(error)), true);
+      }
+    },
+    [
+      report,
+      reportStorageFailure,
+      setRunning,
+      settleRejectedCollectionQueueStart,
+      writePausedCollectionQueue,
+    ]
+  );
 
   useEffect(() => {
     const unwatch = onMessage("progress", ({ data }) => {
@@ -686,7 +979,15 @@ export function useSunoRunner(): RunnerState {
         }
       } catch (error) {
         if (isLatestRequest()) {
-          reportStorageFailure(error);
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const settledQueue = await settleCollectionQueuePreflightFailure(
+            preferredCollectionId,
+            `配信元保存失敗: ${message}`
+          );
+          if (!settledQueue) {
+            reportStorageFailure(error);
+          }
         }
         return;
       }
@@ -710,7 +1011,15 @@ export function useSunoRunner(): RunnerState {
         }
         const message = error instanceof Error ? error.message : String(error);
         if (isExtensionReloadRequiredError(message)) {
+          await pauseCollectionQueueForReload(preferredCollectionId);
           setReloadRequired(true);
+          return;
+        }
+        const settledQueue = await settleCollectionQueuePreflightFailure(
+          preferredCollectionId,
+          `互換性確認失敗: ${message}`
+        );
+        if (settledQueue) {
           return;
         }
         setPhase("error");
@@ -747,11 +1056,30 @@ export function useSunoRunner(): RunnerState {
         setItemStates(data.entries.map(() => "idle"));
         setPhase("idle");
         report(`${data.entries.length} パターンを取得しました。`);
+        const activeQueue = collectionQueueRef.current;
+        const queuedCollection = fetched.find(
+          (candidate) => candidate.id === collectionId
+        );
+        if (
+          activeQueue?.status === "running" &&
+          currentCollectionId(activeQueue) === collectionId &&
+          queuedCollection
+        ) {
+          await startCollectionQueueItem(activeQueue, queuedCollection, data);
+        }
       } catch (err) {
         if (!isLatestRequest() || restoredProgressRef.current) {
           return;
         }
         const message = err instanceof Error ? err.message : String(err);
+        if (
+          await settleCollectionQueuePreflightFailure(
+            preferredCollectionId,
+            `prompts 取得失敗: ${message}`
+          )
+        ) {
+          return;
+        }
         setPhase("error");
         report(
           `取得失敗: ${message}\nyt-collection-serve が起動しているか確認してください。`,
@@ -762,8 +1090,11 @@ export function useSunoRunner(): RunnerState {
     [
       report,
       reportStorageFailure,
+      pauseCollectionQueueForReload,
       resolveVisibleCollections,
       resumableCollectionId,
+      settleCollectionQueuePreflightFailure,
+      startCollectionQueueItem,
     ]
   );
 
@@ -825,7 +1156,11 @@ export function useSunoRunner(): RunnerState {
   }, [discoverSources, report, updateUrl]);
 
   useEffect(() => {
-    if (resumeCheckedAt === null || initialFetchStartedRef.current) {
+    if (
+      resumeCheckedAt === null ||
+      !collectionQueueChecked ||
+      initialFetchStartedRef.current
+    ) {
       return;
     }
     initialFetchStartedRef.current = true;
@@ -835,10 +1170,11 @@ export function useSunoRunner(): RunnerState {
       .then(([stored, sources]) => {
         if (revision !== serverSourcesRevisionRef.current) return;
         setServerSources(sources);
-        if (!stored.trim()) return;
-        const nextUrl = sources.some((source) => source.url === stored)
-          ? stored
-          : sources[0]?.url;
+        const nextUrl = resolveInitialServerUrl(
+          stored,
+          sources,
+          collectionQueueRef.current
+        );
         if (!nextUrl) return;
         urlRef.current = nextUrl;
         setUrlState(nextUrl);
@@ -854,10 +1190,84 @@ export function useSunoRunner(): RunnerState {
   }, [
     discoverSources,
     fetchData,
+    collectionQueueChecked,
     reportStorageFailure,
     resumableCollectionId,
     resumeCheckedAt,
   ]);
+
+  const runCollectionQueue = useCallback(
+    async (collectionIds: string[]): Promise<void> => {
+      if (isRunningRef.current) {
+        return;
+      }
+      const orderedIds = orderSelectedCollectionIds(
+        collections,
+        new Set(collectionIds)
+      );
+      if (orderedIds.length === 0) {
+        report("実行するコレクションを選択してください。", true);
+        return;
+      }
+      const queue = createCollectionQueue({
+        queueId: globalThis.crypto.randomUUID(),
+        baseUrl: url,
+        collectionIds: orderedIds,
+        runMode: runModeId,
+        regenerateDurationOutliers,
+        now: Date.now(),
+      });
+      try {
+        const staleResume = persistedResumeRef.current;
+        if (staleResume) {
+          await clearResumeStateForCollection(staleResume.collectionId);
+        }
+        persistedResumeRef.current = null;
+        setPersistedResume(null);
+        setResumeDismissed(true);
+        await writeCollectionQueue(queue);
+        collectionQueueRef.current = queue;
+        setCollectionQueue(queue);
+        restoredProgressRef.current = false;
+        clearLoadedRunState();
+        await fetchData(queue.baseUrl, orderedIds[0]);
+      } catch (error) {
+        reportStorageFailure(error);
+      }
+    },
+    [
+      clearLoadedRunState,
+      collections,
+      fetchData,
+      regenerateDurationOutliers,
+      report,
+      reportStorageFailure,
+      runModeId,
+      url,
+    ]
+  );
+
+  const resumePersistedCollectionQueue =
+    useCallback(async (): Promise<void> => {
+      const current = collectionQueueRef.current;
+      if (!current || current.status !== "paused" || isRunningRef.current) {
+        return;
+      }
+      const resumed = resumeCollectionQueue(current, Date.now());
+      try {
+        await writeCollectionQueue(resumed);
+        collectionQueueRef.current = resumed;
+        setCollectionQueue(resumed);
+        const collectionId = currentCollectionId(resumed);
+        if (collectionId) {
+          restoredProgressRef.current = false;
+          clearLoadedRunState();
+          await fetchData(resumed.baseUrl, collectionId);
+        }
+      } catch (error) {
+        reportStorageFailure(error);
+      }
+    }, [clearLoadedRunState, fetchData, reportStorageFailure]);
 
   const run = useCallback(
     async (overrides?: RunOverrides) => {
@@ -906,10 +1316,7 @@ export function useSunoRunner(): RunnerState {
         report("連続実行を開始しました。");
       } catch (err) {
         // 送信失敗時はフラグを戻して再実行可能にする（実行は始まっていない）。
-        setRunning(false);
-        setPhase("error");
-        const message = err instanceof Error ? err.message : String(err);
-        report(formatRunError(message), true);
+        reportRunDispatchFailure(err);
       }
     },
     [
@@ -921,6 +1328,7 @@ export function useSunoRunner(): RunnerState {
       runModeId,
       regenerateDurationOutliers,
       report,
+      reportRunDispatchFailure,
       setRunning,
     ]
   );
@@ -1078,10 +1486,7 @@ export function useSunoRunner(): RunnerState {
       await sendMessage("retryDownload", payload);
       report("ダウンロードを再実行しています…");
     } catch (err) {
-      setRunning(false);
-      setPhase("error");
-      const message = err instanceof Error ? err.message : String(err);
-      report(formatRunError(message), true);
+      reportRunDispatchFailure(err);
     }
   }, [
     isRunning,
@@ -1089,6 +1494,7 @@ export function useSunoRunner(): RunnerState {
     submittedClipIdsForResume,
     expectedClipCountForManualAdoption,
     report,
+    reportRunDispatchFailure,
     setRunning,
   ]);
 
@@ -1221,6 +1627,15 @@ export function useSunoRunner(): RunnerState {
   ]);
 
   const stop = useCallback(async () => {
+    const queue = collectionQueueRef.current;
+    if (queue?.status === "running") {
+      try {
+        await writePausedCollectionQueue(queue);
+      } catch (error) {
+        // Stop 自体は安全操作なので、queue checkpoint 失敗でも runner への停止通知は続行する。
+        reportStorageFailure(error);
+      }
+    }
     try {
       // tabId は指定せず background 宛に送り、同一タブの runner content へ中継させる (#892)。
       await sendMessage("stop", undefined);
@@ -1228,7 +1643,7 @@ export function useSunoRunner(): RunnerState {
       const message = err instanceof Error ? err.message : String(err);
       report(formatStopError(message), true);
     }
-  }, [report]);
+  }, [report, reportStorageFailure, writePausedCollectionQueue]);
 
   return {
     reloadRequired,
@@ -1239,6 +1654,9 @@ export function useSunoRunner(): RunnerState {
     collections,
     selectedCollectionId,
     selectCollection,
+    collectionQueue,
+    runCollectionQueue,
+    resumeCollectionQueue: resumePersistedCollectionQueue,
     entries,
     itemStates,
     status,

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1,10 +1,9 @@
 // Suno の Advanced タブへの Style / Lyrics 注入と Generate 連続実行 (content script)。
 // DOM 操作は shared/dom の純関数へ委譲し、本ファイルは連続実行のフロー制御に専念する。
 import {
-  type CollectionSummary,
   DEFAULT_DURATION_FILTER,
   type DurationFilter,
-  extractPlaylistName,
+  playlistNameForCollection,
   type PromptEntry,
   type PromptResponse,
 } from "../../shared/api";
@@ -15,6 +14,7 @@ import {
   INFLIGHT_STALL_TIMEOUT_MS,
   MAX_YIELD_RETRY,
   PHASE,
+  type Phase,
   type ProgressPayload,
   QUEUE_ERROR_WAIT_MS,
   QUEUE_SLOT_WAIT_TIMEOUT_MS,
@@ -65,6 +65,7 @@ import {
   requestSliderSet,
 } from "../lib/bridge-listener";
 import { createClipTracker } from "../lib/clip-tracker";
+import { settleStoredCollectionQueueRun } from "../lib/collection-queue-state";
 import { acquireDomRunLock, releaseDomRunLock } from "../lib/dom-run-lock";
 import { createDownloadFlow } from "../lib/download-flow";
 import type { DownloadContext } from "../lib/download-flow";
@@ -386,6 +387,13 @@ function assertRunPayload(value: unknown): RunPayload {
     durationOutlierWarnings: assertOptionalDurationOutlierWarnings(
       record.durationOutlierWarnings
     ),
+    collectionQueueId:
+      record.collectionQueueId === undefined
+        ? undefined
+        : assertNonEmptyString(
+            record.collectionQueueId,
+            "run.collectionQueueId"
+          ),
     unattended,
   };
   if (unattended) {
@@ -631,15 +639,45 @@ function detectUnattendedPreflightBlocker(): {
   return null;
 }
 
-function playlistNameForCollection(collection: CollectionSummary): string {
-  if (collection.channel && collection.theme) {
-    return `${collection.channel} | ${collection.theme}`;
+const COLLECTION_QUEUE_TERMINAL_PHASES = new Set<string>([
+  PHASE.FINISHED,
+  PHASE.ERROR,
+  PHASE.STOPPED,
+]);
+
+function isCollectionQueueTerminalPhase(
+  phase: Phase
+): phase is "finished" | "error" | "stopped" {
+  return COLLECTION_QUEUE_TERMINAL_PHASES.has(phase);
+}
+
+async function finalizeCollectionQueueBoundary(options: {
+  queueId: string;
+  collectionId: string;
+  snapshot: SnapshotPayload | null;
+}): Promise<void> {
+  if (!options.snapshot) {
+    return;
   }
-  const theme = (collection.theme ?? collection.name).replace(
-    /-collection$/,
-    ""
-  );
-  return extractPlaylistName(collection.id, theme);
+  const terminal = options.snapshot.progress;
+  if (!isCollectionQueueTerminalPhase(terminal.phase)) {
+    return;
+  }
+  const failedEntryCount = options.snapshot.failedIndices?.length ?? 0;
+  const transition = await settleStoredCollectionQueueRun(options.queueId, {
+    collectionId: options.collectionId,
+    phase: terminal.phase,
+    failedEntryCount,
+    message: terminal.message,
+    now: Date.now(),
+  });
+  if (terminal.phase === PHASE.STOPPED || !transition) {
+    return;
+  }
+  if (terminal.phase === PHASE.ERROR || failedEntryCount > 0) {
+    await clearResumeStateForCollection(options.collectionId);
+  }
+  scheduleRunCompleteReload();
 }
 
 export default defineContentScript({
@@ -1353,6 +1391,7 @@ export default defineContentScript({
       // duration filter 後に playlist 追加・download へ採用する OK clip 件数。
       playlistExpectedClipCount?: number;
       durationOutlierPolicy: DurationOutlierPolicy;
+      collectionQueueId?: string;
       unattended?: RunPayload["unattended"];
     }
 
@@ -2255,6 +2294,7 @@ export default defineContentScript({
       if (
         playlistName &&
         resumeStateCleared &&
+        !options.collectionQueueId &&
         (await persistFinishedSnapshotForReload())
       ) {
         scheduleRunCompleteReload();
@@ -2279,6 +2319,7 @@ export default defineContentScript({
         submittedClipIds,
         submittedClipIdsAreDurationFiltered,
         playlistExpectedClipCount,
+        collectionQueueId,
         unattended,
       } = assertRunPayload(data);
       // 手動 run では過去の定期実行 state を更新しない。定期実行だけが明示的に
@@ -2338,10 +2379,25 @@ export default defineContentScript({
         submittedClipIds,
         submittedClipIdsAreDurationFiltered,
         playlistExpectedClipCount,
+        collectionQueueId,
         unattended,
       }).finally(async () => {
         running = false;
+        // queue failure で resume state を消す場合、最後の checkpoint write より後に
+        // clear しないと reload 後に前 collection の state が復活する。
         await Promise.all([resumeStateWrite, unattendedStateWrite]);
+        if (collectionQueueId) {
+          await finalizeCollectionQueueBoundary({
+            queueId: collectionQueueId,
+            collectionId,
+            snapshot: currentSnapshot,
+          }).catch((error: unknown) => {
+            console.error(
+              "[suno-helper] collection queue state の更新に失敗したため次 collection へ進みません:",
+              error
+            );
+          });
+        }
         await releaseExecutionLease(unattended);
         activeUnattended = undefined;
         feedPoller.stop();

--- a/extensions/suno-helper/lib/collection-queue-state.ts
+++ b/extensions/suno-helper/lib/collection-queue-state.ts
@@ -1,0 +1,228 @@
+import { storage } from "wxt/utils/storage";
+
+import {
+  COLLECTION_QUEUE_STATE_KEY,
+  type RunModeId,
+} from "../../shared/constants";
+
+export type CollectionQueueItemStatus = "pending" | "succeeded" | "failed";
+
+export interface CollectionQueueItem {
+  collectionId: string;
+  status: CollectionQueueItemStatus;
+  message?: string;
+}
+
+export type CollectionQueueStatus = "running" | "paused" | "completed";
+
+export interface CollectionQueueState {
+  version: 1;
+  queueId: string;
+  baseUrl: string;
+  items: CollectionQueueItem[];
+  currentIndex: number;
+  status: CollectionQueueStatus;
+  runMode: RunModeId;
+  regenerateDurationOutliers: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CollectionQueueTransition {
+  state: CollectionQueueState;
+  requiresPageReload: boolean;
+}
+
+interface CreateCollectionQueueOptions {
+  queueId: string;
+  baseUrl: string;
+  collectionIds: string[];
+  runMode: RunModeId;
+  regenerateDurationOutliers: boolean;
+  now: number;
+}
+
+interface RecordCollectionResultOptions {
+  collectionId: string;
+  outcome: "succeeded" | "failed";
+  message?: string;
+  now: number;
+}
+
+interface SettleCollectionQueueRunOptions {
+  collectionId: string;
+  phase: "finished" | "error" | "stopped";
+  failedEntryCount: number;
+  message?: string;
+  now: number;
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  if (value.trim().length === 0) {
+    throw new Error(`${field} must be non-empty`);
+  }
+  return value;
+}
+
+export function orderSelectedCollectionIds(
+  collections: ReadonlyArray<{ id: string }>,
+  selectedIds: ReadonlySet<string>
+): string[] {
+  return collections
+    .map((collection) => collection.id)
+    .filter((id) => selectedIds.has(id));
+}
+
+export function createCollectionQueue(
+  options: CreateCollectionQueueOptions
+): CollectionQueueState {
+  if (options.collectionIds.length === 0) {
+    throw new Error("collection queue requires at least one collection");
+  }
+  const collectionIds = options.collectionIds.map((id, index) =>
+    requireNonEmpty(id, `collectionIds[${index}]`)
+  );
+  if (new Set(collectionIds).size !== collectionIds.length) {
+    throw new Error("collectionIds must be unique");
+  }
+  return {
+    version: 1,
+    queueId: requireNonEmpty(options.queueId, "queueId"),
+    baseUrl: requireNonEmpty(options.baseUrl, "baseUrl"),
+    items: collectionIds.map((collectionId) => ({
+      collectionId,
+      status: "pending",
+    })),
+    currentIndex: 0,
+    status: "running",
+    runMode: options.runMode,
+    regenerateDurationOutliers: options.regenerateDurationOutliers,
+    createdAt: options.now,
+    updatedAt: options.now,
+  };
+}
+
+export function currentCollectionId(
+  state: CollectionQueueState
+): string | null {
+  if (state.status === "completed") {
+    return null;
+  }
+  return state.items[state.currentIndex]?.collectionId ?? null;
+}
+
+export function recordCollectionResult(
+  state: CollectionQueueState,
+  options: RecordCollectionResultOptions
+): CollectionQueueTransition {
+  if (state.status !== "running") {
+    throw new Error("collection queue must be running");
+  }
+  const activeCollectionId = currentCollectionId(state);
+  if (activeCollectionId !== options.collectionId) {
+    throw new Error(
+      `collection queue expected ${activeCollectionId ?? "none"}, got ${options.collectionId}`
+    );
+  }
+  const items = state.items.map((item, index) =>
+    index === state.currentIndex
+      ? {
+          collectionId: item.collectionId,
+          status: options.outcome,
+          ...(options.message ? { message: options.message } : {}),
+        }
+      : item
+  );
+  const currentIndex = state.currentIndex + 1;
+  const completed = currentIndex >= items.length;
+  return {
+    state: {
+      ...state,
+      items,
+      currentIndex,
+      status: completed ? "completed" : "running",
+      updatedAt: options.now,
+    },
+    requiresPageReload: !completed,
+  };
+}
+
+export function pauseCollectionQueue(
+  state: CollectionQueueState,
+  now: number
+): CollectionQueueState {
+  if (state.status !== "running") {
+    return state;
+  }
+  return { ...state, status: "paused", updatedAt: now };
+}
+
+export function resumeCollectionQueue(
+  state: CollectionQueueState,
+  now: number
+): CollectionQueueState {
+  if (state.status !== "paused") {
+    return state;
+  }
+  return { ...state, status: "running", updatedAt: now };
+}
+
+export function settleCollectionQueueRun(
+  state: CollectionQueueState,
+  options: SettleCollectionQueueRunOptions
+): CollectionQueueTransition {
+  if (currentCollectionId(state) !== options.collectionId) {
+    throw new Error("collection queue settlement does not match current item");
+  }
+  if (options.phase === "stopped") {
+    return {
+      state: pauseCollectionQueue(state, options.now),
+      requiresPageReload: false,
+    };
+  }
+  const succeeded =
+    options.phase === "finished" && options.failedEntryCount === 0;
+  return recordCollectionResult(state, {
+    collectionId: options.collectionId,
+    outcome: succeeded ? "succeeded" : "failed",
+    ...(!succeeded && options.message ? { message: options.message } : {}),
+    now: options.now,
+  });
+}
+
+let cachedItem: ReturnType<
+  typeof storage.defineItem<CollectionQueueState | null>
+> | null = null;
+
+function collectionQueueItem() {
+  if (!cachedItem) {
+    cachedItem = storage.defineItem<CollectionQueueState | null>(
+      `local:${COLLECTION_QUEUE_STATE_KEY}`,
+      { fallback: null }
+    );
+  }
+  return cachedItem;
+}
+
+export function readCollectionQueue(): Promise<CollectionQueueState | null> {
+  return collectionQueueItem().getValue();
+}
+
+export function writeCollectionQueue(
+  state: CollectionQueueState
+): Promise<void> {
+  return collectionQueueItem().setValue(state);
+}
+
+export async function settleStoredCollectionQueueRun(
+  queueId: string,
+  options: SettleCollectionQueueRunOptions
+): Promise<CollectionQueueTransition | null> {
+  const state = await readCollectionQueue();
+  if (!state || state.queueId !== queueId) {
+    return null;
+  }
+  const transition = settleCollectionQueueRun(state, options);
+  await writeCollectionQueue(transition.state);
+  return transition;
+}

--- a/extensions/suno-helper/lib/messaging.ts
+++ b/extensions/suno-helper/lib/messaging.ts
@@ -47,6 +47,8 @@ export interface RunPayload {
   submittedClipIdsAreDurationFiltered?: boolean;
   /** duration filter 後に playlist 追加・download へ採用する OK clip 件数。 */
   playlistExpectedClipCount?: number;
+  /** 手動の複数 collection queue から起動した run の永続 queue 識別子 (#2029)。 */
+  collectionQueueId?: string;
   /** 定期実行だけが付与する上限・checkpoint 契約。未指定の手動 run は従来挙動。 */
   unattended?: {
     request: UnattendedRunRequest;

--- a/extensions/suno-helper/lib/run-overrides.ts
+++ b/extensions/suno-helper/lib/run-overrides.ts
@@ -39,6 +39,7 @@ export interface RunPayloadInput {
   durationFilter?: DurationFilter;
   range: RunRange | undefined;
   collectionId: string;
+  collectionQueueId?: string;
   runMode: RunModeId;
   regenerateDurationOutliers?: boolean;
   durationOutlierWarnings?: Record<number, string>;
@@ -52,6 +53,9 @@ export function buildRunPayload(input: RunPayloadInput): RunPayload {
     ...(input.durationFilter ? { durationFilter: input.durationFilter } : {}),
     range: input.range,
     collectionId: input.collectionId,
+    ...(input.collectionQueueId
+      ? { collectionQueueId: input.collectionQueueId }
+      : {}),
     runMode: input.overrides?.runMode ?? input.runMode,
     regenerateDurationOutliers:
       input.overrides?.regenerateDurationOutliers ??

--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -18,6 +18,7 @@
     "fix": "cd .. && ultracite fix suno-helper shared"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "1.3.7",
     "@radix-ui/react-slot": "1.2.4",
     "@webext-core/messaging": "3.0.2",
     "class-variance-authority": "0.7.1",

--- a/extensions/suno-helper/pnpm-lock.yaml
+++ b/extensions/suno-helper/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-checkbox':
+        specifier: 1.3.7
+        version: 1.3.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: 1.2.4
         version: 1.2.4(@types/react@19.0.2)(react@19.2.7)
@@ -717,6 +720,22 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
+  '@radix-ui/react-checkbox@1.3.7':
+    resolution: {integrity: sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -726,8 +745,106 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3599,15 +3716,104 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@radix-ui/primitive@1.1.5': {}
+
+  '@radix-ui/react-checkbox@1.3.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.0.2)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.0.2)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.0.2)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.0.2
+      '@types/react-dom': 19.0.2(@types/react@19.0.2)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.2)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.0.2
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.0.2
+      '@types/react-dom': 19.0.2(@types/react@19.0.2)
+
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.0.2
+      '@types/react-dom': 19.0.2(@types/react@19.0.2)
+
   '@radix-ui/react-slot@1.2.4(@types/react@19.0.2)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.0.2)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.0.2)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.0.2
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.0.2)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.0.2)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.0.2

--- a/extensions/suno-helper/tests/collection-queue-state.test.ts
+++ b/extensions/suno-helper/tests/collection-queue-state.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCollectionQueue,
+  currentCollectionId,
+  orderSelectedCollectionIds,
+  recordCollectionResult,
+  resumeCollectionQueue,
+  settleCollectionQueueRun,
+} from "../lib/collection-queue-state";
+import { buildRunPayload } from "../lib/run-overrides";
+
+const collections = [
+  { id: "first", name: "First", status: "ready" as const },
+  { id: "second", name: "Second", status: "ready" as const },
+  { id: "third", name: "Third", status: "ready" as const },
+];
+
+describe("collection queue state (#2029)", () => {
+  it("server の一覧順で選択 collection を直列進行し、境界 reload を要求する", () => {
+    const ordered = orderSelectedCollectionIds(
+      collections,
+      new Set(["third", "first"])
+    );
+    const initial = createCollectionQueue({
+      queueId: "queue-1",
+      baseUrl: "http://127.0.0.1:8765",
+      collectionIds: ordered,
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+
+    expect(ordered).toEqual(["first", "third"]);
+    expect(currentCollectionId(initial)).toBe("first");
+
+    const first = recordCollectionResult(initial, {
+      collectionId: "first",
+      outcome: "succeeded",
+      now: 200,
+    });
+
+    expect(first.requiresPageReload).toBe(true);
+    expect(currentCollectionId(first.state)).toBe("third");
+    expect(first.state.items).toEqual([
+      { collectionId: "first", status: "succeeded" },
+      { collectionId: "third", status: "pending" },
+    ]);
+
+    const final = recordCollectionResult(first.state, {
+      collectionId: "third",
+      outcome: "succeeded",
+      now: 300,
+    });
+    expect(final.requiresPageReload).toBe(false);
+    expect(final.state.status).toBe("completed");
+    expect(currentCollectionId(final.state)).toBeNull();
+  });
+
+  it("collection 失敗を記録して後続へ進み、成功/失敗 summary を保持する", () => {
+    const initial = createCollectionQueue({
+      queueId: "queue-2",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first", "second"],
+      runMode: "serial",
+      regenerateDurationOutliers: false,
+      now: 100,
+    });
+
+    const failed = recordCollectionResult(initial, {
+      collectionId: "first",
+      outcome: "failed",
+      message: "playlist timeout",
+      now: 200,
+    });
+
+    expect(failed.requiresPageReload).toBe(true);
+    expect(currentCollectionId(failed.state)).toBe("second");
+    expect(failed.state.items[0]).toEqual({
+      collectionId: "first",
+      status: "failed",
+      message: "playlist timeout",
+    });
+  });
+
+  it("中断 state は同じ collection から resume できる", () => {
+    const initial = createCollectionQueue({
+      queueId: "queue-3",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first", "second"],
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+    const paused = { ...initial, status: "paused" as const, updatedAt: 150 };
+
+    const resumed = resumeCollectionQueue(paused, 200);
+
+    expect(resumed.status).toBe("running");
+    expect(currentCollectionId(resumed)).toBe("first");
+    expect(resumed.updatedAt).toBe(200);
+  });
+
+  it("queue id を run payload に保持して content 境界へ渡す", () => {
+    const payload = buildRunPayload({
+      entries: [
+        { name: "pattern", style: "ambient", lyrics: "[Instrumental]" },
+      ],
+      playlistName: "Playlist",
+      range: undefined,
+      collectionId: "first",
+      collectionQueueId: "queue-1",
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      overrides: undefined,
+    });
+
+    expect(payload.collectionQueueId).toBe("queue-1");
+  });
+
+  it("entry failure を含む finished は collection failure として次へ進める", () => {
+    const initial = createCollectionQueue({
+      queueId: "queue-4",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first", "second"],
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+
+    const settled = settleCollectionQueueRun(initial, {
+      collectionId: "first",
+      phase: "finished",
+      failedEntryCount: 1,
+      message: "1 entry failed",
+      now: 200,
+    });
+
+    expect(settled.state.items[0]).toEqual({
+      collectionId: "first",
+      status: "failed",
+      message: "1 entry failed",
+    });
+    expect(currentCollectionId(settled.state)).toBe("second");
+    expect(settled.requiresPageReload).toBe(true);
+  });
+
+  it("明示 stop は current collection を進めず queue を pause する", () => {
+    const initial = createCollectionQueue({
+      queueId: "queue-5",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first", "second"],
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+
+    const settled = settleCollectionQueueRun(initial, {
+      collectionId: "first",
+      phase: "stopped",
+      failedEntryCount: 0,
+      now: 200,
+    });
+
+    expect(settled.state.status).toBe("paused");
+    expect(currentCollectionId(settled.state)).toBe("first");
+    expect(settled.requiresPageReload).toBe(false);
+  });
+});

--- a/extensions/suno-helper/tests/collection-queue-storage.test.ts
+++ b/extensions/suno-helper/tests/collection-queue-storage.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageMock = vi.hoisted(() => ({
+  value: null as unknown,
+  getValue: vi.fn(),
+  setValue: vi.fn(),
+  defineItem: vi.fn(),
+}));
+
+vi.mock("wxt/utils/storage", () => {
+  storageMock.getValue.mockImplementation(async () => storageMock.value);
+  storageMock.setValue.mockImplementation(async (value: unknown) => {
+    storageMock.value = value;
+  });
+  storageMock.defineItem.mockReturnValue({
+    getValue: storageMock.getValue,
+    setValue: storageMock.setValue,
+  });
+  return { storage: { defineItem: storageMock.defineItem } };
+});
+
+import {
+  createCollectionQueue,
+  currentCollectionId,
+  settleStoredCollectionQueueRun,
+  writeCollectionQueue,
+} from "../lib/collection-queue-state";
+
+describe("collection queue storage boundary (#2029)", () => {
+  beforeEach(() => {
+    storageMock.value = null;
+    vi.clearAllMocks();
+  });
+
+  it("terminal result を永続化してから次 collection を返す", async () => {
+    const state = createCollectionQueue({
+      queueId: "queue-storage",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first", "second"],
+      runMode: "queue",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+    await writeCollectionQueue(state);
+
+    const transition = await settleStoredCollectionQueueRun("queue-storage", {
+      collectionId: "first",
+      phase: "error",
+      failedEntryCount: 0,
+      message: "download failed",
+      now: 200,
+    });
+
+    expect(transition?.requiresPageReload).toBe(true);
+    expect(currentCollectionId(transition!.state)).toBe("second");
+    expect(storageMock.value).toEqual(transition?.state);
+    expect(storageMock.setValue).toHaveBeenCalledTimes(2);
+  });
+
+  it("stale queue id の terminal event は保存中 queue を変更しない", async () => {
+    const state = createCollectionQueue({
+      queueId: "active-queue",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first"],
+      runMode: "serial",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+    await writeCollectionQueue(state);
+    storageMock.setValue.mockClear();
+
+    const transition = await settleStoredCollectionQueueRun("stale-queue", {
+      collectionId: "first",
+      phase: "finished",
+      failedEntryCount: 0,
+      now: 200,
+    });
+
+    expect(transition).toBeNull();
+    expect(storageMock.setValue).not.toHaveBeenCalled();
+    expect(storageMock.value).toEqual(state);
+  });
+});

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -31,6 +31,9 @@ const runner = vi.hoisted(() => ({
   collections: [],
   selectedCollectionId: "",
   selectCollection: vi.fn(),
+  collectionQueue: null,
+  runCollectionQueue: vi.fn(),
+  resumeCollectionQueue: vi.fn(),
   entries: [],
   itemStates: [],
   status: "待機中",
@@ -100,6 +103,15 @@ describe("Overlay shell", () => {
     messagingMocks.onMessage.mockClear();
     overlayStateMocks.readOverlayState.mockClear();
     overlayStateMocks.writeOverlayState.mockClear();
+    Object.assign(runner, {
+      collections: [],
+      selectedCollectionId: "",
+      entries: [],
+      itemStates: [],
+      canRun: false,
+      collectionQueue: null,
+    });
+    runner.runCollectionQueue.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -216,5 +228,116 @@ describe("Overlay shell", () => {
       minimized: false,
       hidden: false,
     });
+  });
+
+  it("collection checkbox の複数選択を一覧順 queue として開始する", async () => {
+    Object.assign(runner, {
+      collections: [
+        {
+          id: "first",
+          name: "First",
+          status: "ready",
+          pattern_count: 1,
+          downloaded_count: 0,
+        },
+        {
+          id: "second",
+          name: "Second",
+          status: "ready",
+          pattern_count: 1,
+          downloaded_count: 0,
+        },
+      ],
+      selectedCollectionId: "first",
+      entries: [
+        { name: "pattern", style: "ambient", lyrics: "[Instrumental]" },
+      ],
+      itemStates: ["idle"],
+      canRun: true,
+    });
+    await act(async () => root.render(createElement(Overlay)));
+    const checkboxes = container.querySelectorAll<HTMLButtonElement>(
+      'button[data-suno-control="collection-checkbox"]'
+    );
+
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0].dataset.slot).toBe("checkbox");
+    expect(checkboxes[0].getAttribute("aria-checked")).toBe("true");
+    await act(async () => checkboxes[1].click());
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>('button[data-suno-control="run"]')!
+        .click()
+    );
+
+    expect(runner.runCollectionQueue).toHaveBeenCalledWith(["first", "second"]);
+  });
+
+  it("collection queue の成功/失敗 summary から失敗分だけ再実行する", async () => {
+    Object.assign(runner, {
+      collectionQueue: {
+        version: 1,
+        queueId: "queue-summary",
+        baseUrl: "http://localhost:7873",
+        items: [
+          { collectionId: "first", status: "succeeded" },
+          {
+            collectionId: "second",
+            status: "failed",
+            message: "download failed",
+          },
+        ],
+        currentIndex: 2,
+        status: "completed",
+        runMode: "queue",
+        regenerateDurationOutliers: true,
+        createdAt: 100,
+        updatedAt: 200,
+      },
+    });
+    await act(async () => root.render(createElement(Overlay)));
+    const summary = container.querySelector<HTMLElement>(
+      '[data-suno-control="collection-queue-summary"]'
+    )!;
+
+    expect(summary.textContent).toContain("first: succeeded");
+    expect(summary.textContent).toContain("second: failed — download failed");
+    await act(async () =>
+      Array.from(summary.querySelectorAll("button"))
+        .find((button) => button.textContent?.includes("失敗した"))!
+        .click()
+    );
+
+    expect(runner.runCollectionQueue).toHaveBeenCalledWith(["second"]);
+  });
+
+  it("collection 間の queue 遷移中は入力を固定し Stop だけを有効にする", async () => {
+    Object.assign(runner, {
+      collectionQueue: {
+        version: 1,
+        queueId: "queue-transition",
+        baseUrl: "http://localhost:7873",
+        items: [{ collectionId: "first", status: "pending" }],
+        currentIndex: 0,
+        status: "running",
+        runMode: "serial",
+        regenerateDurationOutliers: true,
+        createdAt: 100,
+        updatedAt: 100,
+      },
+      isRunning: false,
+    });
+    await act(async () => root.render(createElement(Overlay)));
+
+    expect(
+      container.querySelector<HTMLSelectElement>(
+        'select[data-suno-control="download-format"]'
+      )?.disabled
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        'button[data-suno-control="stop"]'
+      )?.disabled
+    ).toBe(false);
   });
 });

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -50,6 +50,13 @@ const legacySourceState = vi.hoisted(() => ({ present: true }));
 const resumeStateMocks = vi.hoisted(() => ({
   readResumeState: vi.fn(async () => null),
   writeResumeState: vi.fn(async () => undefined),
+  clearResumeStateForCollection: vi.fn(async () => undefined),
+}));
+
+const collectionQueueMocks = vi.hoisted(() => ({
+  readCollectionQueue: vi.fn(async () => null),
+  writeCollectionQueue: vi.fn(async () => undefined),
+  settleStoredCollectionQueueRun: vi.fn(async () => null),
 }));
 
 const presetStateMocks = vi.hoisted(() => ({
@@ -170,6 +177,21 @@ vi.mock("../lib/resume-state", async () => {
     ...actual,
     readResumeState: resumeStateMocks.readResumeState,
     writeResumeState: resumeStateMocks.writeResumeState,
+    clearResumeStateForCollection:
+      resumeStateMocks.clearResumeStateForCollection,
+  };
+});
+
+vi.mock("../lib/collection-queue-state", async () => {
+  const actual = await vi.importActual<
+    typeof import("../lib/collection-queue-state")
+  >("../lib/collection-queue-state");
+  return {
+    ...actual,
+    readCollectionQueue: collectionQueueMocks.readCollectionQueue,
+    writeCollectionQueue: collectionQueueMocks.writeCollectionQueue,
+    settleStoredCollectionQueueRun:
+      collectionQueueMocks.settleStoredCollectionQueueRun,
   };
 });
 
@@ -310,6 +332,8 @@ describe("Suno popup compatibility check", () => {
     downloadFormatMocks.setValue.mockResolvedValue(undefined);
     presetStateMocks.readRunModeId.mockResolvedValue("serial");
     presetStateMocks.writeRunModeId.mockResolvedValue(undefined);
+    collectionQueueMocks.readCollectionQueue.mockResolvedValue(null);
+    collectionQueueMocks.writeCollectionQueue.mockResolvedValue(undefined);
     serverSourcesMocks.migrateServerSourcesStorage.mockImplementation(
       async () => {
         legacySourceState.present = false;
@@ -367,6 +391,7 @@ describe("Suno popup compatibility check", () => {
     storageMocks.setValue.mockResolvedValue(undefined);
     resumeStateMocks.readResumeState.mockResolvedValue(null);
     resumeStateMocks.writeResumeState.mockResolvedValue(undefined);
+    resumeStateMocks.clearResumeStateForCollection.mockResolvedValue(undefined);
     presetStateMocks.readRunModeId.mockResolvedValue("serial");
     presetStateMocks.writeRunModeId.mockResolvedValue(undefined);
     serverSourcesMocks.migrateServerSourcesStorage.mockResolvedValue(undefined);
@@ -910,6 +935,171 @@ describe("Suno popup compatibility check", () => {
       playlistExpectedClipCount: undefined,
       durationOutlierWarnings: undefined,
     });
+  });
+
+  it("queue の互換性 preflight が失敗すると current collection を failed settlement する", async () => {
+    const queue = {
+      version: 1 as const,
+      queueId: "queue-preflight",
+      baseUrl: BASE_URL,
+      items: [
+        {
+          collectionId: "20260601-clm-theme-a-collection",
+          status: "pending" as const,
+        },
+      ],
+      currentIndex: 0,
+      status: "running" as const,
+      runMode: "serial" as const,
+      regenerateDurationOutliers: true,
+      createdAt: 100,
+      updatedAt: 100,
+    };
+    const completed = {
+      ...queue,
+      items: [{ ...queue.items[0], status: "failed" as const }],
+      currentIndex: 1,
+      status: "completed" as const,
+      updatedAt: 200,
+    };
+    collectionQueueMocks.readCollectionQueue.mockResolvedValue(queue as never);
+    collectionQueueMocks.settleStoredCollectionQueueRun.mockResolvedValue({
+      state: completed,
+      requiresPageReload: false,
+    } as never);
+    messagingMocks.sendMessage.mockImplementation(
+      (message: string, payload?: Record<string, string>) => {
+        if (message === "fetchCompatibilityWarning") {
+          return Promise.reject(new Error("version endpoint unavailable"));
+        }
+        return defaultSendMessage(message, payload);
+      }
+    );
+
+    await rerenderApp();
+
+    await waitFor(() => {
+      expect(
+        collectionQueueMocks.settleStoredCollectionQueueRun
+      ).toHaveBeenCalledWith("queue-preflight", {
+        collectionId: "20260601-clm-theme-a-collection",
+        phase: "error",
+        failedEntryCount: 0,
+        message: "互換性確認失敗: version endpoint unavailable",
+        now: expect.any(Number),
+      });
+    });
+    expect(container.textContent).toContain("version endpoint unavailable");
+  });
+
+  it("queue の拡張再読み込み必須 preflight は current collection を失敗確定せず pause する", async () => {
+    const queue = {
+      version: 1 as const,
+      queueId: "queue-reload-required",
+      baseUrl: BASE_URL,
+      items: [
+        {
+          collectionId: "20260601-clm-theme-a-collection",
+          status: "pending" as const,
+        },
+      ],
+      currentIndex: 0,
+      status: "running" as const,
+      runMode: "serial" as const,
+      regenerateDurationOutliers: true,
+      createdAt: 100,
+      updatedAt: 100,
+    };
+    collectionQueueMocks.readCollectionQueue.mockResolvedValue(queue as never);
+    messagingMocks.sendMessage.mockImplementation(
+      (message: string, payload?: Record<string, string>) => {
+        if (message === "fetchCompatibilityWarning") {
+          return Promise.reject(new Error("Extension context invalidated."));
+        }
+        return defaultSendMessage(message, payload);
+      }
+    );
+
+    await rerenderApp();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        EXTENSION_RELOAD_REQUIRED_MESSAGE
+      );
+    });
+    expect(
+      collectionQueueMocks.settleStoredCollectionQueueRun
+    ).not.toHaveBeenCalled();
+    expect(collectionQueueMocks.writeCollectionQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueId: "queue-reload-required",
+        currentIndex: 0,
+        status: "paused",
+        items: [
+          expect.objectContaining({
+            collectionId: "20260601-clm-theme-a-collection",
+            status: "pending",
+          }),
+        ],
+      })
+    );
+  });
+
+  it("queue run の negative ACK で保存済み queue が消えていても in-memory queue を durable pause する", async () => {
+    const collectionId = "20260601-clm-theme-a-collection";
+    const queue = {
+      version: 1 as const,
+      queueId: "queue-negative-ack-missing",
+      baseUrl: BASE_URL,
+      items: [{ collectionId, status: "pending" as const }],
+      currentIndex: 0,
+      status: "running" as const,
+      runMode: "serial" as const,
+      regenerateDurationOutliers: true,
+      createdAt: 100,
+      updatedAt: 100,
+    };
+    collectionQueueMocks.readCollectionQueue.mockResolvedValue(queue as never);
+    collectionQueueMocks.settleStoredCollectionQueueRun.mockResolvedValue(null);
+    messagingMocks.sendMessage.mockImplementation(
+      (message: string, payload?: Record<string, string>) => {
+        if (message === "fetchCompatibilityWarning") return Promise.resolve("");
+        if (message === "fetchCollections") {
+          return Promise.resolve([
+            {
+              id: collectionId,
+              name: "theme-a",
+              channel: "clm",
+              theme: "theme-a",
+              status: "ready",
+              pattern_count: 1,
+              downloaded_count: 0,
+            },
+          ]);
+        }
+        if (message === "fetchCollectionPromptResponse") {
+          return Promise.resolve({
+            entries: [{ name: "p1", style: "lofi", lyrics: "" }],
+          });
+        }
+        if (message === "run")
+          return Promise.resolve({ ok: false, busy: true });
+        return defaultSendMessage(message, payload);
+      }
+    );
+
+    await rerenderApp();
+
+    await waitFor(() => {
+      expect(collectionQueueMocks.writeCollectionQueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queueId: "queue-negative-ack-missing",
+          currentIndex: 0,
+          status: "paused",
+        })
+      );
+    });
+    expect(container.textContent).toContain("queue を一時停止しました");
   });
 
   it("ACK 済み clip ID 未観測の resume state から再開しても同じ entry を再投入しない", async () => {

--- a/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
+++ b/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
@@ -492,3 +492,19 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
     );
   });
 });
+
+describe("collection queue の fresh start / run ACK 境界 (#2029)", () => {
+  const runnerSource = read("../components/useSunoRunner.ts");
+
+  it("新規 queue は保存済み単発 resume を消去してから永続化する", () => {
+    expect(runnerSource).toMatch(
+      /const staleResume = persistedResumeRef\.current;[\s\S]*?await clearResumeStateForCollection\(staleResume\.collectionId\);[\s\S]*?persistedResumeRef\.current = null;[\s\S]*?await writeCollectionQueue\(queue\)/
+    );
+  });
+
+  it("run の negative ACK は current item を failed settlement して後続 reload へ進める", () => {
+    expect(runnerSource).toMatch(
+      /const settleRejectedCollectionQueueStart = useCallback\([\s\S]*?settleStoredCollectionQueueRun\([\s\S]*?phase: "error"[\s\S]*?scheduleRunCompleteReload\(\)[\s\S]*?const acknowledgement = await sendMessage\([\s\S]*?if \(!acknowledgement\.ok\) \{[\s\S]*?await settleRejectedCollectionQueueStart\(/
+    );
+  });
+});


### PR DESCRIPTION
## 概要
- shadcn/ui Checkbox で複数 collection を server 一覧順に選択・直列実行
- collection ごとの生成→playlist→ZIP DL→downloaded 通知を永続 queue で継続
- 失敗継続、Stop/reload resume、完了 summary、失敗分だけ再実行を追加
- collection 境界は Suno タブ再読み込みで clip tracker / multi-select を分離

## 検証
- pnpm check
- pnpm --dir .. exec oxfmt --check suno-helper shared
- pnpm compile
- pnpm test（60 files / 1240 tests）
- pnpm build
- pnpm run audit（変更差分 finding 0）
- uv run pytest -q（6362 pass、検出した既存契約2件を修正後 targeted 13 pass）
- spec / standards review clean

Closes #2029