### PR TITLE
test: pytestを変更種別別laneへ分類する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `test(pytest)`: repository / docs / CI / packaging の静的契約を `repo_contract`、実 tool・process・待機を伴うテストを `slow` marker へ分類し、製品 behavior 用 fast lane と変更種別別の最小コマンドを追加した。CI の無選別 full suite は維持する（#2268）。
 - `test(packaging)`: candidate wheelを隔離venvへinstallし、空の擬似下流への全asset sync、sourceとの完全一致、`.agents/skills` symlink、installed `yt-skills diff`の差分なしをCIとローカルで同じpytest targetから検証できるrelease前E2E smokeを追加した（#2266）。
 - `fix(skills)`: thumbnail の Codex 単発・batch と videoup の fill helper が fresh / partial worktree で通常の `uv run` により依存同期してから project code を実行するよう統一した。禁止語 config を読めない場合は Codex 起動前に fail-closed とし、環境不備と config 不備を復旧手順付きで区別する（#2269）。
 - `fix(doctor,setup)`: setup の全コマンド起動・実行・再診断を AI / setup 側へ統一し、認証時の人間の責務をブラウザ上のログイン・アカウント選択・OAuth 同意・秘密情報入力だけに限定した。認証 action は実行主体・人間の役割・起動コマンドを構造化して返し、`--apply` の無人認証拒否は維持する（#2262）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,9 +20,23 @@ uv run yt-skills diff --asset claude-md              # CLAUDE.md テンプレの
 ```bash
 uv run pytest -n auto                            # 全スイートを CPU コア数の worker で並列実行
 uv run pytest tests/ --ignore=tests/integration -n auto   # ユニットのみ並列実行
+uv run pytest tests/ --ignore=tests/integration -n auto -m "not repo_contract and not slow"  # behavioral fast lane
+uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract  # docs / CI / packaging 契約
+uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 tool / process / 待機を含む lane
 ```
 
 - **既定は直列**（`addopts` には入れない）。単一ファイル・単一テストのデバッグ実行で worker 起動オーバーヘッドを毎回払わないため、また `-x` / `--pdb` など直列前提のオプションと干渉しないため。フルスイートを回すときに明示的に `-n auto` を付ける
+- **marker の境界**: `repo_contract` は production behavior を起動せず repository 内の docs / CI / workflow / packaging を読むテスト、`slow` は実 Nix・ffmpeg・socket TTL・外部 tool/process・意図的待機を含むテストに付ける。分類の単一 registry は `tests/conftest.py`、存在・CI無選別の回帰契約は `tests/test_pytest_lane_contract.py` が担う。両方に該当するテストは両 marker を持つ
+- **fast lane の位置づけ**: behavioral fast lane は Python product code の短い red/green loop 用で、repository-only / slow test と `tests/integration/` を除く。変更した対象の直接テストは marker にかかわらず別途実行し、PR 前または CI では無選別の全スイートを必ず通す
+
+変更種別ごとの最小入口:
+
+| 変更 | 最初に実行 | PR 前の追加確認 |
+|---|---|---|
+| Python product code | behavioral fast lane + 変更 module の直接 test | unit-only full suite |
+| skill / skill reference script | 対応する `tests/test_*skill*.py` / script test | repository contract lane + unit-only full suite |
+| docs / CI / packaging / hook | repository contract lane + 対応 file の直接 test | slow lane（tool 契約を含む場合）+ unit-only full suite |
+| extensions | 対象 workspace の既存 pnpm lint / type / Vitest / Playwright | Extensions CI（pytest marker 対象外） |
 - **CI では `-n auto` を有効化済み**（`.github/workflows/ci.yml` の test ジョブ）
 - worker ごとの分離: `tests/conftest.py` が `CHANNEL_DIR` の tmp コピーを **worker プロセスごとに独立して** 作り直す（controller が自動設定した値を環境変数継承でそのまま共有しない）。ユーザーが明示的に `CHANNEL_DIR` を指定した場合は全 worker がその指定を尊重する
 - 注意: `tests/test_lefthook_installation_contract.py` の nix devShell 契約テストなど実 subprocess を叩くテストはホスト負荷に敏感で、混雑したマシンでは並列時に所要時間が大きく伸びることがある

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,10 @@ ignore = ["RUF001", "RUF002", "RUF003"]
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "failed"
+markers = [
+    "repo_contract: static repository, documentation, CI, workflow, or packaging contract",
+    "slow: intentional wait or external tool/process integration unsuitable for the behavioral fast lane",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,74 @@ _TEST_TMP_PREFIX = "yt-automation-tests-"
 # 区別し、後者なら worker 専用のコピーを作り直す（共有 tmp への並行書き込みを防ぐ）。
 _ISOLATED_MARKER_ENV = "YOUTUBE_AUTOMATION_TEST_ISOLATED_CHANNEL_DIR"
 
+# Fast lane から分離する分類の単一 registry。repo_contract は production
+# behavior を起動せず repository 内の docs / workflow / packaging を読む module、
+# slow は実 tool/process・socket TTL・意図的待機を含む module / node に限定する。
+REPO_CONTRACT_MODULES = frozenset(
+    {
+        "test_actions_parallel_workflows.py",
+        "test_analytics_analyze_skill_contract.py",
+        "test_analytics_revenue_skill_contract.py",
+        "test_changelog_ci_contract.py",
+        "test_channel_new_analysis_mode.py",
+        "test_cli_stdio.py",
+        "test_codex_thumbnail_routing_docs.py",
+        "test_comments_reply_skill_doc.py",
+        "test_extension_package_manager_contract.py",
+        "test_extension_readme_allow_extension_contract.py",
+        "test_features_catalog_documentation.py",
+        "test_flop_analysis_skill_contract.py",
+        "test_lifecycle_skills_no_tayk.py",
+        "test_loop_video_preview_skill_contract.py",
+        "test_market_research_skill_contract.py",
+        "test_no_google_auth_httplib2_direct_import.py",
+        "test_pytest_lane_contract.py",
+        "test_readme_dev_install_documentation.py",
+        "test_scripts_layout.py",
+        "test_server_discovery_docs.py",
+        "test_skill_api_call_estimate_contract.py",
+        "test_skill_cost_documentation.py",
+        "test_skill_frontmatter_yaml.py",
+        "test_suno_skill_doc.py",
+        "test_upgrade_guide_command_guard.py",
+        "test_video_description_skill_contract.py",
+        "test_wf_new_analytics_fallback_skill_contract.py",
+    }
+)
+
+SLOW_MODULES = frozenset(
+    {
+        "test_actions_parallel_workflows.py",
+        "test_codex_image_batch.py",
+        "test_collection_serve.py",
+        "test_collection_serve_discovery.py",
+        "test_collection_serve_lifecycle.py",
+        "test_community_endpoint.py",
+        "test_distrokid_collections_endpoint.py",
+        "test_distrokid_prepare.py",
+        "test_distrokid_release_endpoint.py",
+        "test_generate_videos_script.py",
+        "test_lefthook_installation_contract.py",
+        "test_preflight_cli.py",
+        "test_skills_sync_installed_wheel.py",
+        "test_streaming_healthcheck.py",
+        "test_thumbnail_codex_image_skill.py",
+        "test_thumbnail_skill_assets.py",
+        "test_verify_extensions_script.py",
+    }
+)
+
+SLOW_NODE_IDS = (
+    "tests/test_analytics_cli_integration.py::test_yt_analytics_returns_failure_when_subscribed_status_collection_fails",
+    "tests/test_audience_analytics.py::TestGetDeviceAnalytics::test_retries_transient_api_failure_through_analytics_entrypoint",
+    "tests/test_audience_analytics.py::TestGetSubscribedStatusAnalytics::test_retries_transient_api_failure",
+    "tests/test_audience_analytics.py::TestGetSubscribedStatusAnalytics::test_returns_error_shape_for_http_error",
+    "tests/test_benchmark_collector_channels_batch.py::TestFetchChannelsMetadata::test_retries_transient_api_failure_through_benchmark_collector",
+    "tests/test_comments_fetcher.py::test_retries_transient_api_failure_through_comments_entrypoint",
+    "tests/test_competitor_discovery.py::TestDiscoverCompetitors::test_retries_transient_api_failure_through_discovery_entrypoint",
+    "tests/test_playlist_manager.py::TestCreatePlaylist::test_retries_transient_api_failure_through_playlist_manager",
+)
+
 
 os.environ.setdefault(_OP_READ_DISABLED_ENV, "1")
 
@@ -95,6 +163,17 @@ def _prepare_isolated_channel_dir() -> None:
 
 
 _prepare_isolated_channel_dir()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply registered lane markers before pytest evaluates ``-m`` selection."""
+    for item in items:
+        module_name = Path(str(item.path)).name
+        if module_name in REPO_CONTRACT_MODULES:
+            item.add_marker(pytest.mark.repo_contract)
+        if module_name in SLOW_MODULES or any(item.nodeid.startswith(prefix) for prefix in SLOW_NODE_IDS):
+            item.add_marker(pytest.mark.slow)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pytest_lane_contract.py
+++ b/tests/test_pytest_lane_contract.py
@@ -1,0 +1,59 @@
+"""pytest fast / repository-contract / slow lane classification contracts."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+TESTS = ROOT / "tests"
+CONFTEST = TESTS / "conftest.py"
+
+
+def _registry_value(name: str) -> frozenset[str] | tuple[str, ...]:
+    tree = ast.parse(CONFTEST.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "frozenset":
+            assert len(value.args) == 1
+            return frozenset(ast.literal_eval(value.args[0]))
+        parsed = ast.literal_eval(value)
+        assert isinstance(parsed, tuple)
+        return parsed
+    raise AssertionError(f"pytest lane registry is missing {name}")
+
+
+REPO_CONTRACT_MODULES = _registry_value("REPO_CONTRACT_MODULES")
+SLOW_MODULES = _registry_value("SLOW_MODULES")
+SLOW_NODE_IDS = _registry_value("SLOW_NODE_IDS")
+
+
+def test_registered_lane_modules_exist() -> None:
+    registered = REPO_CONTRACT_MODULES | SLOW_MODULES
+    missing = sorted(name for name in registered if not (TESTS / name).is_file())
+    assert not missing, f"pytest lane registry points to missing modules: {missing}"
+
+
+def test_slow_node_ids_reference_existing_modules_and_tests() -> None:
+    for node_id in SLOW_NODE_IDS:
+        module_path, separator, test_name = node_id.partition("::")
+        assert separator and test_name, f"slow node id must select a test: {node_id}"
+        source = ROOT / module_path
+        assert source.is_file(), f"slow node module does not exist: {module_path}"
+        assert test_name.split("::")[-1] in source.read_text(encoding="utf-8"), (
+            f"slow node test name is absent from {module_path}: {test_name}"
+        )
+
+
+def test_lane_commands_keep_ci_full_suite_unfiltered() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    development = (ROOT / "docs/development.md").read_text(encoding="utf-8")
+
+    assert "nix develop --command uv run pytest -n auto" in workflow
+    assert '-m "not repo_contract and not slow"' not in workflow
+    for expression in ('-m "not repo_contract and not slow"', "-m repo_contract", "-m slow"):
+        assert expression in development


### PR DESCRIPTION
Closes #2268

## Summary
- `repo_contract` / `slow` marker を登録し、明示 registry と回帰契約を追加
- behavioral fast / repository contract / slow の3 laneと変更種別別の最小入口を文書化
- CI の無選別 full suiteと既存 6,357 testsは維持（新規 contract 3件で計6,360）

## Warm benchmark (same host/cache, 3 runs)
- full: 63.61 / 64.01 / 64.08s; median 64.01s; 6,360 passed
- fast: 12.80 / 12.89 / 13.08s; median 12.89s; 5,036 passed
- fast/full: 20.1% (requirement: <= 50%)
- repo contract: 446 passed in 8.77s
- slow: 902 passed in 42.69s

## Validation
- full suite 3/3 green
- all three documented lanes green
- `uv run ruff check .`
- `uv run ruff format --check .`