### PR TITLE
docs: 開発者bootstrapを単一入口へ統一する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 詳細ドキュメント: アーキテクチャ全容・主要モジュール表は `docs/architecture.md`、パッケージング / extensions / lefthook 詳細は `docs/development.md`、takt 運用詳細は `docs/takt-operations.md`。
 
+本リポジトリの開発者 bootstrap は `docs/development.md#開発者-bootstrap正規入口` を単一ソースとする。親 checkout / linked worktree の各 checkout で最初に `bash .lefthook/setup-worktree.sh` を実行し、非対話 shell は同 wrapper に command を渡す。
+
 ## プロジェクト概要
 
 YouTube チャンネル運営を自動化するツールキット。`youtube-channels-automation` パッケージとして配布し、各チャンネルリポジトリへ導入される（Analytics 収集、AI コンテンツ生成、動画アップロード、メタデータ生成、ベンチマーク分析）。
@@ -93,7 +95,7 @@ TS 版（tayk）の開発は専用の別リポジトリで行う（`docs/adr/002
 - 実コード（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）を変更したら `CHANGELOG.md` の `[Unreleased]` 追記が必須（lefthook pre-push + CI で機械担保）
 - tests / docs だけの変更はゲート対象外。意図的に省く場合は `SKIP_CHANGELOG=1 git push`（CI 側は PR の `skip-changelog` ラベル）
 - lefthook の有効化手順・pre-commit の詳細は `docs/development.md`
-- 親 checkout / worktree の初回は `bash .lefthook/setup-worktree.sh` を実行し、direnv（`.envrc` の `use flake`）または Nix devShell を通して `.lefthook/install.sh` まで完了させる。非対話 shell では `bash .lefthook/setup-worktree.sh uv run pytest` のように devShell 内でコマンドを実行する。診断・再インストール手順は `docs/development.md` の「Git hooks（lefthook）」を参照
+- bootstrap / 対話・非対話 shell / 依存同期の正規手順は `docs/development.md#開発者-bootstrap正規入口`、`.envrc` と `.lefthook/install.sh` を含む hook の診断・再インストールは同文書の「Git hooks（lefthook）」を参照
 
 ## 開発ワークフロー
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -280,10 +280,12 @@ uv run yt-skills sync --asset claude-md --force
 
 ### 6.1 セットアップ
 
+開発者 bootstrap の正規入口は [`docs/development.md`](docs/development.md#開発者-bootstrap正規入口)。親 checkout は初期化だけに使い、変更は issue 用 linked worktree 上で行う。
+
 ```bash
-git clone git@github.com:daiki-beppu/youtube-channels-automation.git
-cd youtube-channels-automation
-nix develop  # shellHook が uv sync を自動実行する
+git clone git@github.com:daiki-beppu/youtube-automation.git
+cd youtube-automation
+bash .lefthook/setup-worktree.sh
 ```
 
 ### 6.2 開発フロー
@@ -293,7 +295,7 @@ nix develop  # shellHook が uv sync を自動実行する
 - **設定アクセス**: チャンネル固有値は `from youtube_automation.utils.config import load_config` 経由で取得する。ハードコーディング禁止。詳細は [`CLAUDE.md`](CLAUDE.md) の「開発規約」節
 - **新規 CLI**: `yt-*` プレフィックスを必ず付け、`pyproject.toml` の `[project.scripts]` に entry point を登録する
 - **テストフィクスチャ**: `tests/conftest.py` が `CHANNEL_DIR` を `tests/fixtures/sample_channel/` に向ける。新スキーマ（`config/channel/*.json`）で配置する
-- **takt + GitHub issue 経由の開発フロー**: ブランチ手作業ではなく、`takt-issue` スキルで issue → worktree → PR を統一手順化する（`CLAUDE.md` の「開発ワークフロー」節）
+- **issue / worktree 開発フロー**: worktree の生成・命名・PR 運用は [`docs/takt-operations.md`](docs/takt-operations.md) を参照する
 
 ### 6.3 配布アセット（`yt-skills sync`）
 

--- a/README.md
+++ b/README.md
@@ -209,12 +209,14 @@ nix develop
 
 ## Development
 
-### Editable install
+### Developer bootstrap
+
+開発環境の正規入口と worktree / 対話・非対話 shell の区別は [`docs/development.md`](docs/development.md#開発者-bootstrap正規入口) を単一ソースとします。親 checkout は初期化だけに使い、変更は linked worktree 上で行ってください。
 
 ```bash
 git clone git@github.com:daiki-beppu/youtube-automation.git
 cd youtube-automation
-uv sync
+bash .lefthook/setup-worktree.sh
 ```
 
 ### テスト実行
@@ -223,7 +225,7 @@ uv sync
 uv run pytest
 ```
 
-`uv sync` 単独で `uv run pytest tests/` が collection error 0 件で走るために必要な依存がすべて揃います。
+正規 bootstrap wrapper 内の `uv sync` で、`uv run pytest tests/` が collection error 0 件で走るために必要な依存がすべて揃います。非対話 shell は `bash .lefthook/setup-worktree.sh uv run pytest` のように command を渡します。
 
 - テスト用ツール (`pytest` / `ruff`) は `[dependency-groups].dev` 経由で導入されます。
 - テストが間接的に require する `Pillow` / `pandas` / `pyyaml` / `matplotlib` / `japanize-matplotlib` / `google-api-python-client` / `google-auth-oauthlib` などは `[project] dependencies`（main deps）に同梱されています。

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,26 @@
 
 CLAUDE.md の「パッケージング」「extensions」「Git hooks」節の詳細版。要点（規約として常に守るもの）は CLAUDE.md を参照。
 
+## 開発者 bootstrap（正規入口）
+
+この節を、本リポジトリを変更する人間・agent向け bootstrap の単一ソースとする。README / ONBOARDING / CLAUDE は読者別の短い入口だけを持ち、詳細手順はこの節を参照する。
+
+初回 clone 後の親 checkout は、環境と hook を初期化する場所であり、実装場所にはしない。
+
+```bash
+git clone git@github.com:daiki-beppu/youtube-automation.git
+cd youtube-automation
+bash .lefthook/setup-worktree.sh
+```
+
+変更は必ず issue 用の linked worktree 上で行う。worktree を作成・移動した後も、その checkout で最初に `bash .lefthook/setup-worktree.sh` を実行する。親 checkout の `.venv` / `node_modules` は共有しない。
+
+- **対話 shell**: setup wrapper は direnv があれば `.envrc` を allow して Nix devShell へ入り、なければ `nix develop` へ fallback する。どちらも toolchain、worktree-local依存、lefthook を同じ状態へ収束させる
+- **非対話 shell / agent**: `bash .lefthook/setup-worktree.sh <command> [args...]` を正規入口とする。例: `bash .lefthook/setup-worktree.sh uv run pytest tests/test_doctor.py -q`。依存同期に失敗した場合は command を起動せず fail-closed で停止する
+- **直接 devShell を使う場合**: direnv の自動入室後は `uv run ...` を直接実行できる。`nix develop` は wrapper の fallback / 診断手段であり、初回 bootstrap の同格入口ではない
+
+worktree の生成・命名・issue / PR 運用は [`docs/takt-operations.md`](takt-operations.md) を参照する。
+
 ## プロジェクト固有コマンド（全量）
 
 ```bash
@@ -64,7 +84,13 @@ uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 
 
 ### 2. 検証（編集後に実行するもの）
 
-skill 単体の軽量 lint コマンドはまだ無い（`yt-skills lint` は #2096 で計画中。実装されたらここに組み込む）。現状は pytest の skill 検証テスト群を直接叩くのが最短:
+SKILL.md frontmatter だけを検証する最短入口は `yt-skills lint`。全 skill は引数なし、変更対象だけなら skill 名を列挙する。
+
+```bash
+uv run yt-skills lint [<skill>...]
+```
+
+これは strict YAML / `description:` double-quote の軽量検証であり、skill 本文・docs・features catalog・配布経路の契約は対象外。広い契約は目的を分けて pytest で確認する:
 
 ```bash
 # 全 skill 横断の契約（frontmatter strict YAML / docs 整合 / features カタログ整合）

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ REPO_CONTRACT_MODULES = frozenset(
         "test_cli_stdio.py",
         "test_codex_thumbnail_routing_docs.py",
         "test_comments_reply_skill_doc.py",
+        "test_developer_bootstrap_documentation.py",
         "test_extension_package_manager_contract.py",
         "test_extension_readme_allow_extension_contract.py",
         "test_features_catalog_documentation.py",

--- a/tests/test_developer_bootstrap_documentation.py
+++ b/tests/test_developer_bootstrap_documentation.py
@@ -1,0 +1,71 @@
+"""Developer bootstrap の単一正規入口と skill lint docs の drift 契約。"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+CANONICAL_COMMAND = "bash .lefthook/setup-worktree.sh"
+CANONICAL_LINK = "docs/development.md#開発者-bootstrap正規入口"
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def _section(path: str, heading: str) -> str:
+    text = _read(path)
+    match = re.search(rf"^{re.escape(heading)}\n.*?(?=^## |\Z)", text, flags=re.DOTALL | re.MULTILINE)
+    assert match is not None, f"{path}: missing section {heading}"
+    return match.group(0)
+
+
+def test_development_owns_complete_bootstrap_contract() -> None:
+    development = _read("docs/development.md")
+    section = _section("docs/development.md", "## 開発者 bootstrap（正規入口）")
+
+    assert development.count("## 開発者 bootstrap（正規入口）") == 1
+    for phrase in (
+        CANONICAL_COMMAND,
+        "linked worktree",
+        "対話 shell",
+        "非対話 shell / agent",
+        "fail-closed",
+        ".envrc",
+        "nix develop",
+    ):
+        assert phrase in section
+
+
+def test_reader_specific_docs_point_to_canonical_bootstrap() -> None:
+    sections = {
+        "README.md": _section("README.md", "## Development"),
+        "ONBOARDING.md": _section("ONBOARDING.md", "## 6. 付録: 開発者向け（本リポジトリ側を編集する人）"),
+        "CLAUDE.md": _read("CLAUDE.md"),
+    }
+    for path, text in sections.items():
+        assert CANONICAL_LINK in text, f"{path}: canonical bootstrap link is missing"
+        assert CANONICAL_COMMAND in text, f"{path}: canonical bootstrap command is missing"
+        assert "worktree" in text, f"{path}: worktree-only development is missing"
+
+    readme_bootstrap = re.search(r"### Developer bootstrap.*?```bash\n(.*?)```", sections["README.md"], re.DOTALL)
+    onboarding_setup = re.search(r"### 6\.1 セットアップ.*?```bash\n(.*?)```", sections["ONBOARDING.md"], re.DOTALL)
+    assert readme_bootstrap is not None and onboarding_setup is not None
+    for block in (readme_bootstrap.group(1), onboarding_setup.group(1)):
+        assert "git clone git@github.com:daiki-beppu/youtube-automation.git" in block
+        assert "cd youtube-automation" in block
+        assert CANONICAL_COMMAND in block
+        assert "uv sync" not in block
+        assert "nix develop" not in block
+
+
+def test_skill_lint_docs_reject_stale_unimplemented_guidance() -> None:
+    development = _read("docs/development.md")
+    stale_patterns = ("skill 単体の軽量 lint コマンドはまだ無い", "yt-skills lint` は #2096 で計画中")
+
+    assert "uv run yt-skills lint [<skill>...]" in development
+    assert "strict YAML" in development
+    assert "features catalog" in development
+    for stale in stale_patterns:
+        assert stale not in development

--- a/tests/test_readme_dev_install_documentation.py
+++ b/tests/test_readme_dev_install_documentation.py
@@ -5,8 +5,8 @@ Issue #329: pytest 全実行で optional dependency 未インストール時の 
 完了条件 3 が「どの optional dep が必要かを README/CONTRIBUTING に明文化」のため、
 本リポジトリでは README.md の Development 節に以下を含めることで満たす:
 
-1. Editable install のコマンド例から空 extra (`--extra veo`) を取り除き、
-   `uv sync` 単独で揃うことを示す。
+1. Developer bootstrap のコマンド例から空 extra (`--extra veo`) を取り除き、
+   正規 setup wrapper で依存が揃うことを示す。
    - 理由: `pyproject.toml:33-35` で `veo = []` (空 extra) になっており、
      `--extra veo` を案内し続けるのは「optional dep を明文化」の主旨と矛盾する。
    - Plan 024 (dev 依存一本化) で `pytest` / `ruff` は `[dependency-groups].dev`
@@ -53,15 +53,15 @@ def _development_section(text: str) -> str:
     return match.group(0)
 
 
-def _editable_install_block(dev_section: str) -> str:
-    """Development 節内の Editable install 配下の最初の bash コードブロックを抽出する。"""
+def _developer_bootstrap_block(dev_section: str) -> str:
+    """Development 節内の Developer bootstrap 配下の bash code block を抽出する。"""
     match = re.search(
-        r"### Editable install\b.*?```bash\n(.*?)```",
+        r"### Developer bootstrap\b.*?```bash\n(.*?)```",
         dev_section,
         flags=re.DOTALL,
     )
     if not match:
-        raise AssertionError("README.md に Editable install の bash コードブロックが見つかりません")
+        raise AssertionError("README.md に Developer bootstrap の bash code block が見つかりません")
     return match.group(1)
 
 
@@ -97,29 +97,31 @@ def test_readme_has_development_section() -> None:
     assert "## Development" in text, "README.md に `## Development` 節がない"
 
 
-# ---------- Editable install: `--extra veo` の撤去 ----------
+# ---------- Developer bootstrap: `--extra veo` の撤去 ----------
 
 
-def test_editable_install_drops_empty_veo_extra() -> None:
-    """Given README.md Editable install ブロック
+def test_developer_bootstrap_drops_empty_veo_extra() -> None:
+    """Given README.md Developer bootstrap block
     When `uv sync` コマンドを読む
     Then 空 extra `--extra veo` が削除されている (pyproject.toml で `veo = []`)。
     """
-    block = _editable_install_block(_development_section(_read(README)))
+    block = _developer_bootstrap_block(_development_section(_read(README)))
     assert "--extra veo" not in block, (
-        f"Editable install に空 extra `--extra veo` が残存 (pyproject.toml で `veo = []` なので no-op):\n{block}"
+        f"Developer bootstrap に空 extra `--extra veo` が残存 (pyproject.toml で `veo = []` なので no-op):\n{block}"
     )
 
 
-def test_editable_install_uses_plain_uv_sync() -> None:
-    """Given README.md Editable install ブロック
+def test_developer_bootstrap_uses_canonical_setup_wrapper() -> None:
+    """Given README.md Developer bootstrap block
     When 推奨コマンドを読む
-    Then `uv sync` が案内されている（dev 依存は default group のため extra 指定不要）。
+    Then canonical setup wrapper だけが環境準備入口として案内されている。
     """
-    block = _editable_install_block(_development_section(_read(README)))
-    assert "uv sync" in block, f"Editable install で `uv sync` が案内されていない:\n{block}"
+    block = _developer_bootstrap_block(_development_section(_read(README)))
+    assert "bash .lefthook/setup-worktree.sh" in block
+    assert "uv sync" not in block
+    assert "nix develop" not in block
     assert "--extra dev" not in block, (
-        f"Editable install に不要な `--extra dev` が残存 (dev は default group):\n{block}"
+        f"Developer bootstrap に不要な `--extra dev` が残存 (dev は default group):\n{block}"
     )
 
 
@@ -203,7 +205,7 @@ def test_readme_does_not_advertise_empty_extras() -> None:
     When `--extra veo` の登場箇所を探す
     Then 一切登場しない (pyproject.toml で `veo = []` の空 extra のため)。
 
-    Editable install ブロック以外の場所にも残っていないかの横断確認。
+    Developer bootstrap block 以外の場所にも残っていないかの横断確認。
     """
     text = _read(README)
     assert "--extra veo" not in text, "README.md のどこかに `--extra veo` (空 extra) の案内が残存"


### PR DESCRIPTION
Closes #2267

## Summary
- `docs/development.md` に開発者 bootstrap の単一正規入口を定義
- README / ONBOARDING / CLAUDE は setup wrapper と canonical section への短い導線へ統一
- 親 checkout は初期化のみ、変更は linked worktree、非対話 command は fail-closed wrapper 経由と明文化
- 実装済み `yt-skills lint` を frontmatter 最短検証として案内し、広い pytest 契約と分離
- 矛盾する `uv sync` / `nix develop` bootstrap と stale 未実装説明を拒否する docs contract を追加

## Validation
- related docs / hook / skill tests: 146 passed
- `uv run yt-skills lint`: 53 skills passed
- `uv run ruff check .`
- `uv run ruff format --check .`