### PR TITLE
fix: automation-update が本体 release tag だけを追従する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(automation-update)`: tag pin の check/apply が GitHub release 一覧から本体の stable `vX.Y.Z` だけを publish 日時順で選ぶようにし、より新しい `ext-vX.Y.Z` 拡張 release を追従先と誤認して exit 2 になる問題を修正した（#2276）。
 - `test(pytest)`: repository / docs / CI / packaging の静的契約を `repo_contract`、実 tool・process・待機を伴うテストを `slow` marker へ分類し、製品 behavior 用 fast lane と変更種別別の最小コマンドを追加した。CI の無選別 full suite は維持する（#2268）。
 - `test(packaging)`: candidate wheelを隔離venvへinstallし、空の擬似下流への全asset sync、sourceとの完全一致、`.agents/skills` symlink、installed `yt-skills diff`の差分なしをCIとローカルで同じpytest targetから検証できるrelease前E2E smokeを追加した（#2266）。
 - `fix(skills)`: thumbnail の Codex 単発・batch と videoup の fill helper が fresh / partial worktree で通常の `uv run` により依存同期してから project code を実行するよう統一した。禁止語 config を読めない場合は Codex 起動前に fail-closed とし、環境不備と config 不備を復旧手順付きで区別する（#2269）。

--- a/src/youtube_automation/cli/automation_update.py
+++ b/src/youtube_automation/cli/automation_update.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -43,6 +44,7 @@ from youtube_automation.utils.exceptions import ConfigError
 EXIT_UP_TO_DATE = 0
 EXIT_DIFF = 1
 EXIT_ERROR = 2
+_STABLE_RELEASE_TAG_RE = re.compile(r"v\d+\.\d+\.\d+")
 
 
 class _StepFailed(Exception):
@@ -115,20 +117,32 @@ def _validate_sync_only(sync_only: list[str] | None) -> None:
         raise ConfigError(f"--sync-only に同梱版に存在しない skill が指定されています: {', '.join(unknown)}")
 
 
-def _github_api_get(path: str) -> dict:
+def _github_api_get(path: str) -> object:
     return _remote_github_api_get(path)
 
 
 def _fetch_latest_release_tag() -> str:
-    release = _github_api_get(f"repos/{UPSTREAM_REPO}/releases/latest")
-    tag = release.get("tag_name")
-    if not isinstance(tag, str) or not tag:
-        raise ConfigError("upstream 最新リリースの tag_name を取得できません")
-    return tag
+    releases = _github_api_get(f"repos/{UPSTREAM_REPO}/releases?per_page=100&page=1")
+    if not isinstance(releases, list):
+        raise ConfigError("upstream release 一覧を取得できません")
+
+    candidates: list[tuple[str, str]] = []
+    for release in releases:
+        if not isinstance(release, dict) or release.get("draft") is True or release.get("prerelease") is True:
+            continue
+        tag = release.get("tag_name")
+        published_at = release.get("published_at")
+        if isinstance(tag, str) and _STABLE_RELEASE_TAG_RE.fullmatch(tag) and isinstance(published_at, str):
+            candidates.append((published_at, tag))
+    if not candidates:
+        raise ConfigError("upstream release 一覧に本体の stable release tag (vX.Y.Z) がありません")
+    return max(candidates)[1]
 
 
 def _fetch_branch_head_sha(branch: str) -> str:
     commit = _github_api_get(f"repos/{UPSTREAM_REPO}/commits/{branch}")
+    if not isinstance(commit, dict):
+        raise ConfigError(f"upstream {branch} の commit 情報を取得できません")
     sha = commit.get("sha")
     if not isinstance(sha, str) or not sha:
         raise ConfigError(f"upstream {branch} の HEAD sha を取得できません")

--- a/src/youtube_automation/cli/automation_update_remote.py
+++ b/src/youtube_automation/cli/automation_update_remote.py
@@ -13,7 +13,7 @@ from youtube_automation.cli.automation_update_refs import PACKAGE_NAME, _canonic
 from youtube_automation.utils.exceptions import ConfigError
 
 
-def _github_api_get(path: str) -> dict:
+def _github_api_get(path: str) -> object:
     url = f"https://api.github.com/{path}"
     request = urllib.request.Request(
         url,

--- a/tests/test_automation_update.py
+++ b/tests/test_automation_update.py
@@ -369,6 +369,49 @@ def test_detect_pin_rejects_unofficial_direct_git_url() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_fetch_latest_release_tag_ignores_newer_extension_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def _releases(path: str) -> object:
+        calls.append(path)
+        return [
+            {"tag_name": "ext-v0.2.5", "published_at": "2026-07-10T11:05:00Z"},
+            {"tag_name": "v5.5.17", "published_at": "2026-07-10T10:50:00Z"},
+            {"tag_name": "v5.5.16", "published_at": "2026-07-09T10:50:00Z"},
+        ]
+
+    monkeypatch.setattr(automation_update, "_github_api_get", _releases)
+
+    assert automation_update._fetch_latest_release_tag() == "v5.5.17"
+    assert calls == ["repos/daiki-beppu/youtube-automation/releases?per_page=100&page=1"]
+
+
+def test_fetch_latest_release_tag_uses_publish_time_not_response_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        automation_update,
+        "_github_api_get",
+        lambda path: [
+            {"tag_name": "v5.5.16", "published_at": "2026-07-09T10:50:00Z"},
+            {"tag_name": "v5.5.17", "published_at": "2026-07-10T10:50:00Z"},
+        ],
+    )
+
+    assert automation_update._fetch_latest_release_tag() == "v5.5.17"
+
+
+def test_fetch_latest_release_tag_fails_when_only_extension_releases_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        automation_update,
+        "_github_api_get",
+        lambda path: [{"tag_name": "ext-v0.2.5", "published_at": "2026-07-10T11:05:00Z"}],
+    )
+
+    with pytest.raises(automation_update.ConfigError, match="本体の stable release tag"):
+        automation_update._fetch_latest_release_tag()
+
+
 def test_check_inline_tag_pin_up_to_date(tmp_path: Path, no_network, capsys: pytest.CaptureFixture) -> None:
     repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
 


### PR DESCRIPTION
## Summary
- GitHub release 一覧から stable な本体タグ `vX.Y.Z` だけを抽出
- extension release と draft/prerelease を除外し、公開日時が最新の本体 release を選択
- extension release の方が新しい回帰ケースをテストで固定

## Test
- `uv run pytest tests/test_automation_update.py -q`
- `uv run ruff check src/youtube_automation/cli/automation_update.py src/youtube_automation/cli/automation_update_remote.py tests/test_automation_update.py`
- `uv run ruff format --check src/youtube_automation/cli/automation_update.py src/youtube_automation/cli/automation_update_remote.py tests/test_automation_update.py`

Closes #2276