### PR TITLE
fix: OAuth失効でautomation-updateを誤失敗させない

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(doctor/automation-update)`: OAuth token の失効時に `upload_ready` が `RefreshError` でクラッシュせず再認証用の構造化 fail を返すようにし、`channel_config=ok` なら他 doctor check の非ゼロ終了で apply を失敗扱いにしないよう修正した（#2277）。
 - `fix(automation-update)`: tag pin の check/apply が GitHub release 一覧から本体の stable `vX.Y.Z` だけを publish 日時順で選ぶようにし、より新しい `ext-vX.Y.Z` 拡張 release を追従先と誤認して exit 2 になる問題を修正した（#2276）。
 - `test(pytest)`: repository / docs / CI / packaging の静的契約を `repo_contract`、実 tool・process・待機を伴うテストを `slow` marker へ分類し、製品 behavior 用 fast lane と変更種別別の最小コマンドを追加した。CI の無選別 full suite は維持する（#2268）。
 - `test(packaging)`: candidate wheelを隔離venvへinstallし、空の擬似下流への全asset sync、sourceとの完全一致、`.agents/skills` symlink、installed `yt-skills diff`の差分なしをCIとローカルで同じpytest targetから検証できるrelease前E2E smokeを追加した（#2266）。

--- a/src/youtube_automation/cli/automation_update.py
+++ b/src/youtube_automation/cli/automation_update.py
@@ -191,12 +191,12 @@ def _check_channel_config(root: Path) -> str:
         )
     except OSError as e:
         raise _StepFailed(f"{' '.join(cmd)} を起動できません: {e}") from e
-    if proc.returncode != 0:
-        details = proc.stderr.strip() or proc.stdout.strip()
-        raise _StepFailed(f"exit code {proc.returncode}: {' '.join(cmd)}\n{details}")
     try:
         payload = json.loads(proc.stdout)
     except json.JSONDecodeError as e:
+        if proc.returncode != 0:
+            details = proc.stderr.strip() or proc.stdout.strip()
+            raise _StepFailed(f"exit code {proc.returncode}: {' '.join(cmd)}\n{details}") from e
         raise _StepFailed(f"yt-doctor --json の出力を解析できません: {e}") from e
     if not isinstance(payload, dict) or not isinstance(payload.get("checks"), list):
         raise _StepFailed("yt-doctor --json の出力に checks 配列がありません")
@@ -209,7 +209,10 @@ def _check_channel_config(root: Path) -> str:
     message = result.get("message")
     if result.get("status") != "ok":
         raise _StepFailed(message if isinstance(message, str) else "channel_config check が失敗しました")
-    return message if isinstance(message, str) else "channel_config check 成功"
+    success_message = message if isinstance(message, str) else "channel_config check 成功"
+    if proc.returncode != 0:
+        return f"{success_message}（warning: yt-doctor の他 check が失敗し exit code {proc.returncode}）"
+    return success_message
 
 
 def _skills_diff_has_changes(root: Path) -> bool:

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -2744,6 +2745,19 @@ def check_upload_ready(channel_dir: Path) -> CheckResult:
     try:
         service = build("youtube", "v3", credentials=credentials)
         response = service.channels().list(part="id,snippet", mine=True).execute()
+    except RefreshError:
+        return CheckResult(
+            id="upload_ready",
+            status="fail",
+            category=UPLOAD_CATEGORY,
+            message="OAuth token の更新に失敗しました。token が期限切れまたは失効しています",
+            next_action=_human_auth_action(
+                ["uv", "run", "yt-channel-status"],
+                "承認後に AI が auth/token.json を削除して `uv run yt-channel-status` を起動し、"
+                "利用者はブラウザで OAuth 認証をやり直してください。",
+            ),
+            data={"reason": "oauth_refresh_failed"},
+        )
     except HttpError as error:
         return _upload_ready_api_error_result(YouTubeAPIError.from_http_error(error, "doctor:channels.list"))
     except (AutomationError, HttpLib2Error, OSError) as error:

--- a/tests/test_automation_update.py
+++ b/tests/test_automation_update.py
@@ -1003,6 +1003,27 @@ def test_apply_returns_nonzero_when_target_channel_config_is_invalid(
     assert commands[-1] == ["uv", "run", "yt-skills", "list"]
 
 
+def test_channel_config_check_ignores_nonzero_exit_when_channel_config_is_ok(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    payload = {
+        "checks": [
+            {"id": "channel_config", "status": "ok", "message": "config/channel/ ロード成功"},
+            {"id": "upload_ready", "status": "fail", "message": "OAuth token が失効しています"},
+        ]
+    }
+    completed = automation_update.subprocess.CompletedProcess([], 1, json.dumps(payload), "")
+    monkeypatch.setattr(automation_update.subprocess, "run", lambda *args, **kwargs: completed)
+
+    result = automation_update._check_channel_config(repo)
+
+    assert result.startswith("config/channel/ ロード成功")
+    assert "warning" in result
+    assert "exit code 1" in result
+
+
 @pytest.mark.parametrize(
     ("completed", "expected"),
     [

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from google.auth.exceptions import RefreshError
 from googleapiclient.errors import HttpError
 from httplib2 import ServerNotFoundError
 from PIL import Image as PILImage
@@ -4056,6 +4057,20 @@ class TestCheckUploadReady:
         assert r.data["reason"] == "api_error"
         assert r.next_action is not None
         assert "uv run yt-channel-status" in r.next_action["instructions"]
+
+    def test_refresh_error_is_fail_with_reauthentication(self, tmp_path, monkeypatch):
+        _write_token(tmp_path, _FULL_SCOPES)
+        _write_meta_channel_id(tmp_path, _CHANNEL_ID)
+        _mock_upload_channel_api(monkeypatch, error=RefreshError("invalid_grant: token expired"))
+
+        r = doctor.check_upload_ready(tmp_path)
+
+        assert r.status == "fail"
+        assert r.data == {"reason": "oauth_refresh_failed"}
+        assert r.next_action is not None
+        assert r.next_action["kind"] == "human"
+        assert "uv run yt-channel-status" in r.next_action["instructions"]
+        assert "invalid_grant" not in r.message
 
     def test_network_error_is_warn_not_channel_not_found(self, tmp_path, monkeypatch):
         _write_token(tmp_path, _FULL_SCOPES)


### PR DESCRIPTION
## Summary
- upload readiness の credential refresh で `RefreshError` を構造化された再認証 fail に変換
- automation-update の smoke check は doctor JSON を先に解析し、`channel_config` の状態だけを判定
- unrelated check による非ゼロ終了は warning として表示

## Test
- `uv run pytest tests/test_doctor.py::TestCheckUploadReady tests/test_automation_update.py -q`
- `uv run ruff check ...`
- `uv run ruff format --check ...`

Closes #2277