### PR TITLE
feat: ring visualizer に conical fill を追加

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -260,7 +260,7 @@ effect:
 | `ring-line` | 細線のギザギザリング | `bars` / `ring.*` |
 | `heart` | ハート曲線上で内外へ波打つスペクトラムバー | `bars` / `size` |
 
-例: `"style": "mirror-mountain", "bars": 16, "size": "300x110"`。ring 系は `"style": "ring", "bars": 24, "ring": {"inner_r": 120, "length": 160, "arc_deg": [30, 330]}` のように指定する。heart は `"style": "heart"` の 1 行で `size: "600x480"` / `colors: "0xff69b4"`（ピンク）が既定になり、必要なら `bars` / `size` / `colors` を明示して上書きできる。`position` は全 style 共通で最終レイヤーの配置に適用される。heart は `fill`（solid / gradient / rainbow）、`rounding`、`glow` を利用でき、形状自体が左右対称のため `mirror_center` / `symmetric_vertical` は適用しない。
+例: `"style": "mirror-mountain", "bars": 16, "size": "300x110"`。ring 系は `"style": "ring", "bars": 24, "ring": {"inner_r": 120, "length": 160, "arc_deg": [30, 330]}, "fill": {"type": "conical"}` のように指定すると、角度を色相へ対応させたフルスペクトルで描画できる。旧 channel-local ring パッチからの移行は `references/ring-migration.md` を参照する。heart は `"style": "heart"` の 1 行で `size: "600x480"` / `colors: "0xff69b4"`（ピンク）が既定になり、必要なら `bars` / `size` / `colors` を明示して上書きできる。`position` は全 style 共通で最終レイヤーの配置に適用される。heart は `fill`（solid / gradient / rainbow / conical）、`rounding`、`glow` を利用でき、形状自体が左右対称のため `mirror_center` / `symmetric_vertical` は適用しない。
 
 `mirror-mountain` / ring / heart で使うバー間隔・形状マスク PNG は、`generate_videos.sh` が同梱 Python helper で一時領域へ実行時生成する。外部の `make_bars_mask.py`、`build_spectrum_video.sh`、事前生成 PNG は不要。
 

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -788,6 +788,11 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
     av_fill_color="$(ov_get '.overlays.audio_visualizer.fill.color' "$av_colors")"
     av_fill_top="$(ov_get '.overlays.audio_visualizer.fill.top' '0xA9CBF0')"
     av_fill_bottom="$(ov_get '.overlays.audio_visualizer.fill.bottom // .overlays.audio_visualizer.fill.bot' '0x3A5696')"
+    av_fill_size="$av_size"
+    if [[ "$av_style" == "ring" || "$av_style" == "ring-line" ]]; then
+        av_ring_fill_diameter=$((2 * (av_ring_inner_r + av_ring_length)))
+        av_fill_size="${av_ring_fill_diameter}x${av_ring_fill_diameter}"
+    fi
     av_mirror_center="$(ov_get '.overlays.audio_visualizer.mirror_center' 'false')"
     av_symmetric_vertical="$(ov_get '.overlays.audio_visualizer.symmetric_vertical' 'false')"
     av_rounding_blur="$(ov_get '.overlays.audio_visualizer.rounding.blur' '')"
@@ -823,7 +828,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
             echo "ERROR: yt-audio-visualizer-fill is required when audio_visualizer.fill is configured" >&2
             exit 1
         fi
-        if ! av_fill_type="$("${AV_FILL_COMMAND[@]}" --type "$av_fill_type" --size "$av_size" \
+        if ! av_fill_type="$("${AV_FILL_COMMAND[@]}" --type "$av_fill_type" --size "$av_fill_size" \
             --color "$av_fill_color" --top "$av_fill_top" --bottom "$av_fill_bottom" --output "$AV_FILL_ASSET")"; then
             echo "ERROR: invalid overlays.audio_visualizer.fill config" >&2
             exit 1
@@ -845,7 +850,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
 
     next_input_idx=2
     av_fill_input_idx=""
-    if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" ]]; then
+    if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" || "$av_fill_type" == "conical" ]]; then
         INPUTS+=(-loop 1 -framerate "$av_rate" -i "$AV_FILL_ASSET")
         av_fill_input_idx="$next_input_idx"
         next_input_idx=$((next_input_idx + 1))
@@ -924,7 +929,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
                         FILTER+=",gblur=sigma=${av_rounding_blur},eq=contrast=${av_rounding_contrast}"
                     fi
                     FILTER+="[avis_alpha];"
-                    if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" ]]; then
+                    if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" || "$av_fill_type" == "conical" ]]; then
                         FILTER+="[${av_fill_input_idx}:v]format=rgb24[avis_fill];"
                     else
                         av_effective_color="$av_colors"
@@ -955,9 +960,21 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
                 fi
                 av_ring_x="mod(atan2(Y-H/2,X-W/2)*W/(2*PI)+W,W-1)"
                 av_ring_y="clip(H-(hypot(X-W/2,Y-H/2)-${av_ring_inner_r})*H/${av_ring_length},0,H-1)"
-                FILTER+="[avis_in]showfreqs=mode=${av_ring_mode}:s=${av_width}x${av_height}:rate=${av_rate}:fscale=${av_fscale}:win_size=${av_win_size}:win_func=${av_win_func}:colors=${av_colors},scale=${av_bars}:${av_height}:flags=neighbor,scale=${av_ring_diameter}:${av_ring_diameter}:flags=neighbor,format=rgba[avis_rect];"
-                FILTER+="[avis_rect]geq=r='r(${av_ring_x},${av_ring_y})':g='g(${av_ring_x},${av_ring_y})':b='b(${av_ring_x},${av_ring_y})':a=255[avis_shape];"
-                FILTER+="[${av_mask_input_idx}:v]format=gray[avis_mask];[avis_shape][avis_mask]alphamerge,colorkey=black:0.1:0,colorchannelmixer=aa=${av_opacity}[avis];"
+                if [[ -z "$av_fill_type" ]]; then
+                    FILTER+="[avis_in]showfreqs=mode=${av_ring_mode}:s=${av_width}x${av_height}:rate=${av_rate}:fscale=${av_fscale}:win_size=${av_win_size}:win_func=${av_win_func}:colors=${av_colors},scale=${av_bars}:${av_height}:flags=neighbor,scale=${av_ring_diameter}:${av_ring_diameter}:flags=neighbor,format=rgba[avis_rect];"
+                    FILTER+="[avis_rect]geq=r='r(${av_ring_x},${av_ring_y})':g='g(${av_ring_x},${av_ring_y})':b='b(${av_ring_x},${av_ring_y})':a=255[avis_shape];"
+                    FILTER+="[${av_mask_input_idx}:v]format=gray[avis_mask];[avis_shape][avis_mask]alphamerge,colorkey=black:0.1:0,colorchannelmixer=aa=${av_opacity}[avis];"
+                else
+                    FILTER+="[avis_in]showfreqs=mode=${av_ring_mode}:s=${av_width}x${av_height}:rate=${av_rate}:fscale=${av_fscale}:win_size=${av_win_size}:win_func=${av_win_func}:colors=white,scale=${av_bars}:${av_height}:flags=neighbor,scale=${av_ring_diameter}:${av_ring_diameter}:flags=neighbor,format=gray[avis_rect];"
+                    FILTER+="[avis_rect]geq=lum='lum(${av_ring_x},${av_ring_y})'[avis_shape];"
+                    FILTER+="[${av_mask_input_idx}:v]format=gray[avis_mask];[avis_shape][avis_mask]blend=all_mode=multiply,lut=y='val*${av_opacity}'[avis_alpha];"
+                    if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" || "$av_fill_type" == "conical" ]]; then
+                        FILTER+="[${av_fill_input_idx}:v]format=rgb24[avis_fill];"
+                    else
+                        FILTER+="color=c=${av_fill_color}:s=${av_fill_size}:r=${av_rate},format=rgb24[avis_fill];"
+                    fi
+                    FILTER+="[avis_fill][avis_alpha]alphamerge[avis];"
+                fi
                 ;;
             heart)
                 av_width="${av_size%x*}"
@@ -973,7 +990,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
                     FILTER+=",gblur=sigma=${av_rounding_blur},eq=contrast=${av_rounding_contrast}"
                 fi
                 FILTER+=",lut=y='val*${av_opacity}'[avis_alpha];"
-                if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" ]]; then
+                if [[ "$av_fill_type" == "gradient" || "$av_fill_type" == "rainbow" || "$av_fill_type" == "conical" ]]; then
                     FILTER+="[${av_fill_input_idx}:v]format=rgb24[avis_fill];"
                 else
                     av_effective_color="$av_colors"

--- a/.claude/skills/videoup/references/ring-migration.md
+++ b/.claude/skills/videoup/references/ring-migration.md
@@ -1,0 +1,36 @@
+# Ring visualizer の upstream 移行
+
+旧 channel-local patch の ring は upstream の `overlays.audio_visualizer.style: ring` へ統合済みです。`yt-skills sync` 後に patch を再適用せず、`config/channel/youtube.json` のキーを次のように移行します。
+
+| 旧 channel-local patch | upstream native |
+|---|---|
+| `ring.inner_radius` | `ring.inner_r` |
+| `ring.thickness` | `ring.length` |
+| `ring.diameter` | `2 * (inner_r + length)` から自動算出するため削除 |
+| `ring.fill_image: conical-rainbow.png` | `fill.type: conical` |
+| `ring.arc_deg` | `ring.arc_deg`（変更なし） |
+
+移行例:
+
+```json
+{
+  "overlays": {
+    "enabled": true,
+    "audio_visualizer": {
+      "enabled": true,
+      "style": "ring",
+      "bars": 36,
+      "ring": {
+        "inner_r": 125,
+        "length": 105,
+        "arc_deg": [30, 330]
+      },
+      "fill": {
+        "type": "conical"
+      }
+    }
+  }
+}
+```
+
+`conical` は実行時に ring の直径へ合わせた画像を生成し、色相を中心からの角度へ対応させます。外部 PNG と固定 `diameter` は不要です。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(videoup)`: ring visualizer が `fill.type: conical` の角度→色相フルスペクトル充填を振幅・円弧 mask 内へ合成できるようにし、旧 channel-local ring patch の設定移行表を追加した（#2278）。
 - `fix(doctor/automation-update)`: OAuth token の失効時に `upload_ready` が `RefreshError` でクラッシュせず再認証用の構造化 fail を返すようにし、`channel_config=ok` なら他 doctor check の非ゼロ終了で apply を失敗扱いにしないよう修正した（#2277）。
 - `fix(automation-update)`: tag pin の check/apply が GitHub release 一覧から本体の stable `vX.Y.Z` だけを publish 日時順で選ぶようにし、より新しい `ext-vX.Y.Z` 拡張 release を追従先と誤認して exit 2 になる問題を修正した（#2276）。
 - `test(pytest)`: repository / docs / CI / packaging の静的契約を `repo_contract`、実 tool・process・待機を伴うテストを `slow` marker へ分類し、製品 behavior 用 fast lane と変更種別別の最小コマンドを追加した。CI の無選別 full suite は維持する（#2268）。

--- a/src/youtube_automation/utils/audio_visualizer_fill.py
+++ b/src/youtube_automation/utils/audio_visualizer_fill.py
@@ -1,4 +1,4 @@
-"""Audio visualizer の gradient / rainbow fill を実行時生成する。"""
+"""Audio visualizer の gradient / conical fill を実行時生成する。"""
 
 from __future__ import annotations
 
@@ -54,8 +54,8 @@ def create_fill_asset(
 ) -> str:
     """fill asset を生成し、縮退後の type を返す。"""
     width, height = parse_size(size)
-    if fill_type not in {"solid", "gradient", "rainbow"}:
-        raise ValueError(f"invalid fill type: {fill_type!r} (expected solid, gradient, or rainbow)")
+    if fill_type not in {"solid", "gradient", "rainbow", "conical"}:
+        raise ValueError(f"invalid fill type: {fill_type!r} (expected solid, gradient, rainbow, or conical)")
     if fill_type == "solid":
         normalize_ffmpeg_color(color)
         return "solid"
@@ -92,7 +92,7 @@ def create_fill_asset(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--type", required=True, choices=("solid", "gradient", "rainbow"))
+    parser.add_argument("--type", required=True, choices=("solid", "gradient", "rainbow", "conical"))
     parser.add_argument("--size", required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--color", default="white")

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -453,8 +453,10 @@ def _build_overlays(raw: object) -> Overlays:
     fill = None
     if fill_raw is not None:
         fill_type = str(fill_raw.get("type", "solid"))
-        if fill_type not in {"solid", "gradient", "rainbow"}:
-            raise ConfigError("overlays.audio_visualizer.fill.type は solid / gradient / rainbow のいずれかです")
+        if fill_type not in {"solid", "gradient", "rainbow", "conical"}:
+            raise ConfigError(
+                "overlays.audio_visualizer.fill.type は solid / gradient / rainbow / conical のいずれかです"
+            )
         fill_color = str(fill_raw.get("color", av_raw.get("colors", "white")))
         fill_top = str(fill_raw.get("top", "0xA9CBF0"))
         fill_bottom = str(fill_raw.get("bottom", fill_raw.get("bot", "0x3A5696")))

--- a/tests/test_audio_visualizer_fill.py
+++ b/tests/test_audio_visualizer_fill.py
@@ -39,6 +39,16 @@ def test_rainbow_asset_contains_multiple_hues(tmp_path: Path) -> None:
     assert len({image.getpixel((0, 4)), image.getpixel((8, 4)), image.getpixel((4, 0))}) == 3
 
 
+def test_conical_asset_maps_angle_to_hue(tmp_path: Path) -> None:
+    output = tmp_path / "conical.png"
+
+    effective = create_fill_asset("conical", "9x9", output)
+
+    image = Image.open(output)
+    assert effective == "conical"
+    assert len({image.getpixel((0, 4)), image.getpixel((8, 4)), image.getpixel((4, 0))}) == 3
+
+
 @pytest.mark.parametrize(("fill_type", "color"), [("plasma", "white"), ("solid", "oops")])
 def test_invalid_fill_fails_loudly(tmp_path: Path, fill_type: str, color: str) -> None:
     with pytest.raises(ValueError, match="invalid fill"):

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -2316,6 +2316,18 @@ def test_audio_visualizer_invalid_fill_raises(tmp_path, monkeypatch, fill, messa
         load_config()
 
 
+def test_audio_visualizer_accepts_conical_fill(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["youtube.json"]["overlays"] = {"audio_visualizer": {"style": "ring", "fill": {"type": "conical"}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+
+    assert config.youtube.overlays.audio_visualizer.fill is not None
+    assert config.youtube.overlays.audio_visualizer.fill.type == "conical"
+
+
 # ----- workflow.scheduled_automation (#1892) --------------------------------
 
 

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -995,6 +995,35 @@ def test_audio_visualizer_solid_fill_uses_color_source(tmp_path: Path) -> None:
     assert "alphamerge[avis]" in command
 
 
+def test_ring_visualizer_uses_conical_fill_asset(tmp_path: Path) -> None:
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text('{"overlays": {"enabled": true}}', encoding="utf-8")
+
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        stream_bitrate_output="5000000",
+        extra_env={
+            **_audio_visualizer_env(
+                "ring",
+                OVERLAY_AV_SIZE="300x110",
+                OVERLAY_AV_RING_INNER_R="30",
+                OVERLAY_AV_RING_LENGTH="20",
+            ),
+            "OVERLAYS_CONFIG": str(overlays_config),
+            "JQ_AV_FILL_TYPE": "conical",
+            "FILL_EFFECTIVE_TYPE": "conical",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    command = _filter_complex_command(ffmpeg_log)
+    assert "format=gray[avis_rect]" in command
+    assert "blend=all_mode=multiply" in command
+    assert "format=rgb24[avis_fill]" in command
+    assert "[avis_fill][avis_alpha]alphamerge[avis]" in command
+
+
 @pytest.mark.parametrize(
     ("env_key", "enabled", "fragment"),
     [
@@ -1282,6 +1311,8 @@ def test_audio_visualizer_new_styles_render_minimal_video_with_real_ffmpeg(tmp_p
     }
     if style != "heart":
         visualizer_config["size"] = "300x110"
+    if style == "ring":
+        visualizer_config["fill"] = {"type": "conical"}
 
     overlays_config = tmp_path / "youtube.json"
     overlays_config.write_text(


### PR DESCRIPTION
## Summary
- `fill.type: conical` で角度を色相へ対応させた runtime fill asset を生成
- ring/ring-line の振幅と円弧 mask を alpha にして conical/gradient/solid fill を合成
- 旧 channel-local ring patch から native config への移行表を追加

## Test
- `uv run pytest tests/test_audio_visualizer_fill.py tests/test_config_loader.py tests/test_generate_videos_script.py -q` (313 passed; real ffmpeg ring render included)
- `uv run yt-skills lint videoup`
- `bash -n .claude/skills/videoup/references/generate_videos.sh`
- Ruff check/format

Closes #2278