### PR TITLE
fix: 単一言語preflightでscene phrasesを要求しない

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(collection-preflight)`: 単一言語チャンネルでは共有 `requires_scene_phrases()` 判定に従って `scene_phrases` を要求せず、多言語時だけ検証するよう修正した（#2270）。
 - `docs(auth)`: doctor の YouTube OAuth next_action と `/setup` を、AI/setup が `uv run yt-oauth` を background 起動して stdout の同意 URL を中継・exit待機・doctor再検証し、人間はブラウザ同意だけを担う契約へ統一した（#2279）。
 - `feat(videoup)`: ring visualizer が `fill.type: conical` の角度→色相フルスペクトル充填を振幅・円弧 mask 内へ合成できるようにし、旧 channel-local ring patch の設定移行表を追加した（#2278）。
 - `fix(doctor/automation-update)`: OAuth token の失効時に `upload_ready` が `RefreshError` でクラッシュせず再認証用の構造化 fail を返すようにし、`channel_config=ok` なら他 doctor check の非ゼロ終了で apply を失敗扱いにしないよう修正した（#2277）。

--- a/src/youtube_automation/scripts/collection_preflight.py
+++ b/src/youtube_automation/scripts/collection_preflight.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from youtube_automation.utils.collection_paths import CollectionPaths
 from youtube_automation.utils.config import load_config
 from youtube_automation.utils.exceptions import ValidationError
+from youtube_automation.utils.preflight_checks import requires_scene_phrases
 
 
 def _planning_root() -> Path:
@@ -81,6 +82,9 @@ def _validate_scene_phrases(paths: CollectionPaths, supported_languages: list[st
         return ["workflow-state.json の JSON が不正"]
     if not isinstance(state, dict):
         return ["workflow-state.json の root は object である必要があります"]
+
+    if not requires_scene_phrases(supported_languages):
+        return []
 
     scene_phrases = state.get("scene_phrases")
     if not isinstance(scene_phrases, dict) or not scene_phrases:

--- a/tests/test_collection_preflight.py
+++ b/tests/test_collection_preflight.py
@@ -142,6 +142,24 @@ class TestCheckCollection:
         assert "ja" in line
         assert "ko" in line
 
+    def test_single_language_does_not_require_scene_phrases(self, tmp_path):
+        collection = _make_collection(tmp_path, "20260702-tc-single-language-collection")
+        (collection / "workflow-state.json").write_text(json.dumps({"theme": "focus"}), encoding="utf-8")
+
+        ok, line = check_collection(collection, fix=False, supported_languages=["en"])
+
+        assert ok
+        assert line.startswith("[OK]")
+
+    def test_single_language_still_rejects_malformed_workflow_state(self, tmp_path):
+        collection = _make_collection(tmp_path, "20260702-tc-malformed-state-collection")
+        (collection / "workflow-state.json").write_text("{broken", encoding="utf-8")
+
+        ok, line = check_collection(collection, fix=False, supported_languages=["en"])
+
+        assert not ok
+        assert "JSON が不正" in line
+
 
 # ---------------------------------------------------------------------------
 # main の exit code 契約


### PR DESCRIPTION
## Summary
- collection preflight を共有 `requires_scene_phrases` 判定へ統一
- 単一言語は scene_phrases 無しで通過、多言語は従来どおり全言語を検証
- workflow-state JSON 自体の破損は単一言語でも引き続き拒否

## Test
- `uv run pytest tests/test_collection_preflight.py tests/test_preflight_checks.py tests/test_preflight.py tests/test_metadata_audit.py -q` (144 passed)
- Ruff check/format

Closes #2270