### PR TITLE
fix: 拡張UIを共有テーマトークンへ統一

### DIFF
--- a/extensions/distrokid-helper/components/ReleaseReview.tsx
+++ b/extensions/distrokid-helper/components/ReleaseReview.tsx
@@ -20,17 +20,19 @@ export function ReleaseReview({ payload }: ReleaseReviewProps) {
         <CardTitle>{release.album_title}</CardTitle>
       </CardHeader>
       <CardContent className="px-3">
-        <dl className="grid grid-cols-2 gap-x-2 gap-y-1 text-xs text-gray-600">
+        <dl className="grid grid-cols-2 gap-x-2 gap-y-1 text-xs text-muted-foreground">
           <dt>言語</dt>
-          <dd className="text-gray-900">{profile.language}</dd>
+          <dd className="text-foreground">{profile.language}</dd>
           <dt>ジャンル</dt>
-          <dd className="text-gray-900">{profile.main_genre}</dd>
+          <dd className="text-foreground">{profile.main_genre}</dd>
           <dt>リリース日</dt>
-          <dd className="text-gray-900">{release.release_date ?? "未定"}</dd>
+          <dd className="text-foreground">{release.release_date ?? "未定"}</dd>
           <dt>曲数</dt>
-          <dd className="text-gray-900">{release.tracks.length}</dd>
+          <dd className="text-foreground">{release.tracks.length}</dd>
           <dt>ジャケット</dt>
-          <dd className="text-gray-900">{release.cover?.filename ?? "なし"}</dd>
+          <dd className="text-foreground">
+            {release.cover?.filename ?? "なし"}
+          </dd>
         </dl>
       </CardContent>
     </Card>

--- a/extensions/distrokid-helper/components/ServerUrlField.tsx
+++ b/extensions/distrokid-helper/components/ServerUrlField.tsx
@@ -48,7 +48,10 @@ export function ServerUrlField({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-xs font-medium text-gray-600" htmlFor="server-url">
+      <label
+        className="text-xs font-medium text-muted-foreground"
+        htmlFor="server-url"
+      >
         ローカル配信元
       </label>
       <Button
@@ -85,7 +88,7 @@ export function ServerUrlField({
         <div
           role="listbox"
           aria-label="ローカル配信元"
-          className="rounded border border-gray-300 bg-white p-1"
+          className="rounded border border-border bg-popover p-1 text-popover-foreground"
         >
           {sources.map((source) => (
             <Button

--- a/extensions/distrokid-helper/entrypoints/popup/App.tsx
+++ b/extensions/distrokid-helper/entrypoints/popup/App.tsx
@@ -28,8 +28,8 @@ export function App() {
   } = useDistrokidRunner();
 
   return (
-    <main className="flex flex-col gap-3 p-4">
-      <h1 className="text-base font-bold text-gray-900">DistroKid Helper</h1>
+    <main className="flex flex-col gap-3 bg-background p-4 text-foreground">
+      <h1 className="text-base font-bold">DistroKid Helper</h1>
 
       <ServerUrlField
         value={serverUrl}
@@ -40,7 +40,7 @@ export function App() {
       />
 
       {compatibilityWarning && (
-        <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+        <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
           {compatibilityWarning}
         </div>
       )}
@@ -65,7 +65,9 @@ export function App() {
 
       {/* dir mode で全 disc が配信済みの場合（#934）。suno-helper の allMapped パターンを踏襲。 */}
       {allReleased && (
-        <p className="text-xs text-gray-600">未配信の disc はありません。</p>
+        <p className="text-xs text-muted-foreground">
+          未配信の disc はありません。
+        </p>
       )}
 
       {payload !== null && <ReleaseReview payload={payload} />}

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -258,7 +258,7 @@ export function App() {
 
   return (
     <div
-      className="flex flex-col gap-3 p-3 text-gray-900"
+      className="flex flex-col gap-3 bg-background p-3 text-foreground"
       data-suno-helper="control-panel"
       data-suno-phase={phase}
       data-suno-running={isRunning ? "true" : "false"}
@@ -278,7 +278,7 @@ export function App() {
           disabled={controlsLocked || refreshingServerSources}
           onClick={openServerSourcePicker}
           data-suno-control="server-source-trigger"
-          className="rounded border border-gray-300 px-2 py-1 text-left"
+          className="rounded border border-input bg-background px-2 py-1 text-left"
         >
           {refreshingServerSources
             ? "稼働中の配信元を更新中…"
@@ -305,7 +305,7 @@ export function App() {
           <div
             role="listbox"
             aria-label="ローカル配信元"
-            className="rounded border border-gray-300 bg-white p-1"
+            className="rounded border border-border bg-popover p-1 text-popover-foreground"
           >
             {serverSources.map((source) => (
               <button
@@ -314,7 +314,7 @@ export function App() {
                 role="option"
                 aria-selected={source.url === url}
                 disabled={controlsLocked || refreshingServerSources}
-                className="block w-full rounded px-2 py-1 text-left hover:bg-gray-100"
+                className="block w-full rounded px-2 py-1 text-left hover:bg-accent hover:text-accent-foreground"
                 onClick={() => {
                   if (isRunningRef.current || refreshingServerSources) {
                     return;
@@ -330,10 +330,12 @@ export function App() {
         )}
       </label>
 
-      <fieldset className="flex flex-col gap-1 rounded border border-gray-200 px-2 py-2 text-sm">
-        <legend className="px-1 text-xs text-gray-600">コレクション</legend>
+      <fieldset className="flex flex-col gap-1 rounded border border-border px-2 py-2 text-sm">
+        <legend className="px-1 text-xs text-muted-foreground">
+          コレクション
+        </legend>
         {collections.length === 0 && (
-          <p className="text-xs text-gray-500">コレクションなし</p>
+          <p className="text-xs text-muted-foreground">コレクションなし</p>
         )}
         {collections.map((collection) => {
           const checked = selectedCollectionIds.includes(collection.id);
@@ -362,7 +364,7 @@ export function App() {
                 />
                 <span className="flex flex-col text-left">
                   <span className="font-medium">{collection.name}</span>
-                  <span className="text-xs text-gray-500">
+                  <span className="text-xs text-muted-foreground">
                     {collection.status === "downloaded"
                       ? `完了 ${collection.downloaded_count}/${collection.expected_file_count ?? (collection.pattern_count ?? 0) * 2}`
                       : collection.status === "ready"
@@ -452,7 +454,7 @@ export function App() {
       )}
 
       {playlistName && (
-        <p className="text-xs text-gray-600">
+        <p className="text-xs text-muted-foreground">
           Playlist: <span className="font-medium">{playlistName}</span>
         </p>
       )}
@@ -522,8 +524,8 @@ export function App() {
         </Alert>
       )}
 
-      <fieldset className="flex flex-col gap-2 rounded border border-gray-200 px-2 py-2 text-sm">
-        <legend className="px-1 text-xs text-gray-600">投入方式</legend>
+      <fieldset className="flex flex-col gap-2 rounded border border-border px-2 py-2 text-sm">
+        <legend className="px-1 text-xs text-muted-foreground">投入方式</legend>
         {RUN_MODE_ORDER.map((id) => {
           const mode = RUN_MODES[id];
           return (
@@ -546,7 +548,9 @@ export function App() {
                 />
                 <span className="flex flex-col">
                   <span className="font-medium">{mode.label}</span>
-                  <span className="text-xs text-gray-500">{mode.riskNote}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {mode.riskNote}
+                  </span>
                 </span>
               </label>
             </ButtonSlot>
@@ -554,7 +558,7 @@ export function App() {
         })}
       </fieldset>
 
-      <label className="flex items-start gap-2 rounded border border-gray-200 px-2 py-2 text-sm">
+      <label className="flex items-start gap-2 rounded border border-border px-2 py-2 text-sm">
         <input
           type="checkbox"
           className="mt-1"
@@ -567,7 +571,7 @@ export function App() {
         <span className="flex flex-col">
           <span className="font-medium">異常値の曲を再生成する</span>
           {!regenerateDurationOutliers && (
-            <span className="text-xs text-amber-700">
+            <span className="text-xs text-amber-700 dark:text-amber-300">
               OFF の場合、duration guard NG も Playlist / Download
               候補に残ります。完了後に手動確認してください。
             </span>
@@ -592,7 +596,7 @@ export function App() {
           onChange={(e) =>
             updateDownloadFormat(e.target.value as DownloadFormat)
           }
-          className="rounded border border-gray-300 px-2 py-1"
+          className="rounded border border-input bg-background px-2 py-1 text-foreground"
         >
           {DOWNLOAD_FORMAT_OPTIONS.map((format) => (
             <option key={format} value={format}>
@@ -631,7 +635,7 @@ export function App() {
             type="button"
             onClick={() => void adoptSelectedClips()}
             data-suno-control="adopt-selected-clips"
-            className="rounded border border-gray-400 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            className="rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-accent hover:text-accent-foreground"
           >
             選択中の曲を採用
           </button>
@@ -677,7 +681,7 @@ export function App() {
           role="status"
           aria-live="polite"
           data-suno-status={isError ? "error" : "ok"}
-          className={`rounded-none border-0 bg-transparent p-0 whitespace-pre-wrap text-xs ${isError ? "text-red-600" : "text-gray-600"}`}
+          className={`rounded-none border-0 bg-transparent p-0 whitespace-pre-wrap text-xs ${isError ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}`}
         >
           {status}
         </Alert>

--- a/extensions/suno-helper/components/ReloadRequiredNotice.tsx
+++ b/extensions/suno-helper/components/ReloadRequiredNotice.tsx
@@ -2,12 +2,12 @@ import { EXTENSION_RELOAD_REQUIRED_MESSAGE } from "./runner-errors";
 
 export function ReloadRequiredNotice() {
   return (
-    <div className="fixed left-4 top-4 z-[2147483647] flex max-w-xs flex-col gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 shadow-xl">
+    <div className="fixed left-4 top-4 z-[2147483647] flex max-w-xs flex-col gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 shadow-xl dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
       <p>{EXTENSION_RELOAD_REQUIRED_MESSAGE}</p>
       <button
         type="button"
         onClick={() => window.location.reload()}
-        className="rounded bg-amber-600 px-2 py-1 text-white hover:bg-amber-500"
+        className="rounded bg-amber-600 px-2 py-1 text-amber-50 hover:bg-amber-500 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400"
       >
         タブを再読み込み
       </button>


### PR DESCRIPTION
## Summary
- suno-helper と distrokid-helper のハードコードされた中性色を共有 shadcn theme token に置換
- popup、popover、input の背景・前景・border を semantic token に統一
- amber/red の状態色に dark variant を追加

## Validation
- `pnpm -C extensions/suno-helper check`
- `pnpm -C extensions/suno-helper compile`
- `pnpm -C extensions/suno-helper test` (1253 passed)
- `pnpm -C extensions/suno-helper build`
- `pnpm -C extensions/distrokid-helper check`
- `pnpm -C extensions/distrokid-helper compile`
- `pnpm -C extensions/distrokid-helper test` (258 passed)
- `pnpm -C extensions/distrokid-helper build`
- issue 指定の `rg` 検索 0 件

Closes #2284