### PR TITLE
fix: benchmark commentsでfull scopeを使う

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(viewer-voice)`: `yt-benchmark-comments` が `commentThreads.list` に必要な `youtube.force-ssl` を持つ full-scope token を使うよう修正し、readonly token 発行済み環境で全件 403 になる問題を解消した（#2286）。
 - `fix(collection-preflight)`: 単一言語チャンネルでは共有 `requires_scene_phrases()` 判定に従って `scene_phrases` を要求せず、多言語時だけ検証するよう修正した（#2270）。
 - `docs(auth)`: doctor の YouTube OAuth next_action と `/setup` を、AI/setup が `uv run yt-oauth` を background 起動して stdout の同意 URL を中継・exit待機・doctor再検証し、人間はブラウザ同意だけを担う契約へ統一した（#2279）。
 - `feat(videoup)`: ring visualizer が `fill.type: conical` の角度→色相フルスペクトル充填を振幅・円弧 mask 内へ合成できるようにし、旧 channel-local ring patch の設定移行表を追加した（#2278）。

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -33,7 +33,8 @@ scope 定義の単一ソースは `src/youtube_automation/auth/oauth_handler.py`
 |---|---|---|---|
 | /analytics-collect, /analytics-analyze | `yt-analytics`（analytics_system / analytics_collector / reporting_analytics） | read-only | readonly 優先 |
 | /channel-status | `yt-channel-status` | read-only | readonly 優先 |
-| /benchmark | `yt-benchmark-collect` / `yt-benchmark-comments` | read-only | readonly 優先 |
+| /benchmark（動画収集） | `yt-benchmark-collect` | read-only | readonly 優先 |
+| /viewer-voice（コメント収集） | `yt-benchmark-comments` | `youtube.force-ssl`（`commentThreads.list` の API 要件） | `token.json` |
 | /discover-competitors | `yt-discover-competitors` | read-only | readonly 優先 |
 | /metadata-audit | `yt-metadata-audit`（監査のみ） | read-only | readonly 優先 |
 | /playlist（状態確認） | `yt-playlist-status` | read-only | readonly 優先 |

--- a/src/youtube_automation/scripts/fetch_benchmark_comments.py
+++ b/src/youtube_automation/scripts/fetch_benchmark_comments.py
@@ -31,7 +31,7 @@ from youtube_automation.scripts.benchmark_collector import (
 from youtube_automation.utils.cli_arguments import CompetitorArgumentParser
 from youtube_automation.utils.config import channel_dir as _channel_dir
 from youtube_automation.utils.cost_tracker import log_quota
-from youtube_automation.utils.youtube_service import get_youtube_readonly
+from youtube_automation.utils.youtube_service import get_youtube
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +115,9 @@ class BenchmarkCommentCollector:
         logger.info("対象動画: %d本（%s再生以上）", len(targets), f"{self.min_views:,}")
 
         logger.info("YouTube API 認証中...")
-        self.youtube = get_youtube_readonly()
+        # commentThreads.list は read API だが youtube.force-ssl scope が必要なため、
+        # youtube.readonly token ではなく full-scope token を使う。
+        self.youtube = get_youtube()
         logger.info("認証完了")
 
         result = {

--- a/tests/test_fetch_benchmark_comments_cli.py
+++ b/tests/test_fetch_benchmark_comments_cli.py
@@ -224,7 +224,7 @@ def test_collect_checks_benchmark_freshness(monkeypatch, tmp_path):
         return [target]
 
     def fake_get_youtube():
-        calls.append(("youtube",))
+        calls.append(("youtube-full-scope",))
         return object()
 
     def fake_fetch_comments(video_id: str):
@@ -233,7 +233,7 @@ def test_collect_checks_benchmark_freshness(monkeypatch, tmp_path):
 
     monkeypatch.setattr(mod, "ensure_benchmark_fresh", fake_ensure_benchmark_fresh)
     monkeypatch.setattr(mod, "load_benchmark_videos", fake_load_benchmark_videos)
-    monkeypatch.setattr(mod, "get_youtube_readonly", fake_get_youtube)
+    monkeypatch.setattr(mod, "get_youtube", fake_get_youtube)
     monkeypatch.setattr(collector, "_fetch_comments", fake_fetch_comments)
 
     result = collector.collect()
@@ -241,7 +241,7 @@ def test_collect_checks_benchmark_freshness(monkeypatch, tmp_path):
     assert calls == [
         ("fresh", collector.data_dir),
         ("load", collector.data_dir, 10000, None),
-        ("youtube",),
+        ("youtube-full-scope",),
         ("fetch", "video-1"),
     ]
     assert result["summary"] == {


### PR DESCRIPTION
## Summary
- `commentThreads.list` を `get_youtube()` 経由の `youtube.force-ssl` token で実行
- readonly token の scope は広げず、他の read-only API の最小権限を維持
- OAuth scope 対応表と client 選択の回帰テストを更新

## Validation
- `uv run pytest tests/test_fetch_benchmark_comments_cli.py tests/test_benchmark_quota_wiring.py tests/test_youtube_service.py -q` (29 passed)
- `uv run ruff check ...`
- `uv run ruff format --check ...`

Closes #2286