### PR TITLE
feat: 拡張UIをOSダークモードへ追随

### DIFF
--- a/extensions/community-helper/entrypoints/popup/main.tsx
+++ b/extensions/community-helper/entrypoints/popup/main.tsx
@@ -1,9 +1,12 @@
+import { watchColorScheme } from "@youtube-automation/ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
 
 import "./style.css";
+
+watchColorScheme(document.documentElement);
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/extensions/distrokid-helper/entrypoints/popup/main.tsx
+++ b/extensions/distrokid-helper/entrypoints/popup/main.tsx
@@ -1,9 +1,12 @@
+import { watchColorScheme } from "@youtube-automation/ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
 
 import "./style.css";
+
+watchColorScheme(document.documentElement);
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/extensions/shared-ui/src/color-scheme.ts
+++ b/extensions/shared-ui/src/color-scheme.ts
@@ -1,0 +1,17 @@
+export interface ColorSchemeTarget {
+  classList: Pick<DOMTokenList, "toggle">;
+}
+
+const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
+
+export function watchColorScheme(target: ColorSchemeTarget): () => void {
+  const mediaQuery = window.matchMedia(DARK_MODE_QUERY);
+  const update = ({ matches }: MediaQueryList | MediaQueryListEvent): void => {
+    target.classList.toggle("dark", matches);
+  };
+
+  update(mediaQuery);
+  mediaQuery.addEventListener("change", update);
+
+  return () => mediaQuery.removeEventListener("change", update);
+}

--- a/extensions/shared-ui/src/index.ts
+++ b/extensions/shared-ui/src/index.ts
@@ -1,5 +1,6 @@
 export { Alert, AlertDescription, alertVariants } from "./alert";
 export { Button, ButtonSlot, buttonVariants } from "./button";
 export { Card, CardContent, CardHeader, CardTitle } from "./card";
+export { type ColorSchemeTarget, watchColorScheme } from "./color-scheme";
 export { Select } from "./select";
 export { cn } from "./utils";

--- a/extensions/suno-helper/entrypoints/overlay.content.ts
+++ b/extensions/suno-helper/entrypoints/overlay.content.ts
@@ -2,6 +2,7 @@
 // runner 本体 (entrypoints/content.ts) とは責務分離し、本 script は Shadow DOM 上へ
 // React tree (<Overlay />) をマウントするだけに専念する。messaging 経由で runner と話すため
 // マウント先は問わない。Shadow DOM 隔離で Suno 側 CSS と Tailwind が競合しない (要件8)。
+import { watchColorScheme } from "@youtube-automation/ui";
 import { createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -15,6 +16,7 @@ export default defineContentScript({
   // 生成した CSS を Shadow DOM 内へ注入する（webpage 側へは漏らさない）。
   cssInjectionMode: "ui",
   async main(ctx) {
+    let stopWatchingColorScheme: (() => void) | undefined;
     const ui = await createShadowRootUi<Root>(ctx, {
       name: "suno-helper-overlay",
       position: "overlay",
@@ -25,8 +27,13 @@ export default defineContentScript({
         root.render(createElement(Overlay));
         return root;
       },
-      onRemove: (root) => root?.unmount(),
+      onRemove: (root) => {
+        stopWatchingColorScheme?.();
+        stopWatchingColorScheme = undefined;
+        root?.unmount();
+      },
     });
+    stopWatchingColorScheme = watchColorScheme(ui.shadowHost);
     ui.mount();
   },
 });

--- a/extensions/suno-helper/tests/color-scheme.test.ts
+++ b/extensions/suno-helper/tests/color-scheme.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { watchColorScheme } from "@youtube-automation/ui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface MatchMediaMock {
+  emit(matches: boolean): void;
+  mediaQuery: MediaQueryList;
+}
+
+function mockMatchMedia(initialMatches: boolean): MatchMediaMock {
+  let listener: ((event: MediaQueryListEvent) => void) | undefined;
+  const mediaQuery = {
+    matches: initialMatches,
+    addEventListener: vi.fn(
+      (_type: "change", nextListener: (event: MediaQueryListEvent) => void) => {
+        listener = nextListener;
+      }
+    ),
+    removeEventListener: vi.fn(
+      (
+        _type: "change",
+        removedListener: (event: MediaQueryListEvent) => void
+      ) => {
+        if (listener === removedListener) {
+          listener = undefined;
+        }
+      }
+    ),
+  } as unknown as MediaQueryList;
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mediaQuery)
+  );
+
+  return {
+    mediaQuery,
+    emit(matches) {
+      listener?.({ matches } as MediaQueryListEvent);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("watchColorScheme", () => {
+  it("adds dark for an initially dark OS theme", () => {
+    mockMatchMedia(true);
+    const target = document.createElement("div");
+
+    watchColorScheme(target);
+
+    expect(target.classList.contains("dark")).toBe(true);
+  });
+
+  it("removes dark for an initially light OS theme", () => {
+    mockMatchMedia(false);
+    const target = document.createElement("div");
+    target.classList.add("dark");
+
+    watchColorScheme(target);
+
+    expect(target.classList.contains("dark")).toBe(false);
+  });
+
+  it("follows OS theme changes without reloading", () => {
+    const matchMedia = mockMatchMedia(false);
+    const target = document.createElement("div");
+    watchColorScheme(target);
+
+    matchMedia.emit(true);
+    expect(target.classList.contains("dark")).toBe(true);
+
+    matchMedia.emit(false);
+    expect(target.classList.contains("dark")).toBe(false);
+  });
+
+  it("removes the change listener during cleanup", () => {
+    const { mediaQuery } = mockMatchMedia(false);
+    const cleanup = watchColorScheme(document.createElement("div"));
+
+    cleanup();
+
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledOnce();
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- shared-ui に `matchMedia` ベースの `watchColorScheme` を追加
- Suno Shadow DOM host と DistroKid/Community popup root に `.dark` を自動付与
- OS theme change の即時追随と Suno unmount 時の listener cleanup を実装
- dark/light 初期値、双方向 change、cleanup の unit test を追加

## Validation
- shared-ui: check / compile
- suno-helper: check / compile / test (1257 passed) / build
- distrokid-helper: check / compile / test (258 passed) / build
- community-helper: check / compile / test (44 passed) / build

Closes #2285