### PR TITLE
fix: shadcn公式のテーマクラス契約へ統一

### DIFF
--- a/extensions/shared-ui/src/color-scheme.ts
+++ b/extensions/shared-ui/src/color-scheme.ts
@@ -1,5 +1,5 @@
 export interface ColorSchemeTarget {
-  classList: Pick<DOMTokenList, "toggle">;
+  classList: Pick<DOMTokenList, "add" | "remove">;
 }
 
 const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
@@ -7,7 +7,8 @@ const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
 export function watchColorScheme(target: ColorSchemeTarget): () => void {
   const mediaQuery = window.matchMedia(DARK_MODE_QUERY);
   const update = ({ matches }: MediaQueryList | MediaQueryListEvent): void => {
-    target.classList.toggle("dark", matches);
+    target.classList.remove("light", "dark");
+    target.classList.add(matches ? "dark" : "light");
   };
 
   update(mediaQuery);

--- a/extensions/suno-helper/tests/color-scheme.test.ts
+++ b/extensions/suno-helper/tests/color-scheme.test.ts
@@ -47,23 +47,24 @@ afterEach(() => {
 });
 
 describe("watchColorScheme", () => {
-  it("adds dark for an initially dark OS theme", () => {
+  it("keeps only dark for an initially dark OS theme", () => {
     mockMatchMedia(true);
     const target = document.createElement("div");
+    target.classList.add("light");
 
     watchColorScheme(target);
 
-    expect(target.classList.contains("dark")).toBe(true);
+    expect([...target.classList]).toEqual(["dark"]);
   });
 
-  it("removes dark for an initially light OS theme", () => {
+  it("keeps only light for an initially light OS theme", () => {
     mockMatchMedia(false);
     const target = document.createElement("div");
     target.classList.add("dark");
 
     watchColorScheme(target);
 
-    expect(target.classList.contains("dark")).toBe(false);
+    expect([...target.classList]).toEqual(["light"]);
   });
 
   it("follows OS theme changes without reloading", () => {
@@ -72,10 +73,10 @@ describe("watchColorScheme", () => {
     watchColorScheme(target);
 
     matchMedia.emit(true);
-    expect(target.classList.contains("dark")).toBe(true);
+    expect([...target.classList]).toEqual(["dark"]);
 
     matchMedia.emit(false);
-    expect(target.classList.contains("dark")).toBe(false);
+    expect([...target.classList]).toEqual(["light"]);
   });
 
   it("removes the change listener during cleanup", () => {


### PR DESCRIPTION
## Summary
- shadcn/ui の公式 Vite dark mode 手順に合わせ、`light` / `dark` を一度除去して解決済みテーマだけを付与
- Chrome 拡張固有のOSテーマchange購読、Suno Shadow DOM host、cleanupは維持
- 初期dark/lightとリアルタイム切替でクラスが排他的になる回帰テストへ更新

## Official reference
- https://ui.shadcn.com/docs/dark-mode/vite

## Validation
- shared-ui: check / compile
- suno-helper: check / compile / 1257 tests / build
- distrokid-helper: check / compile / 258 tests / build
- community-helper: check / compile / 44 tests / build
- Standards review: 0 findings
- Spec review: 0 findings

Closes #2291