### PR TITLE
fix(doctor): refresh expired OAuth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(doctor)`: `yt-doctor` の OAuth / Reporting 診断が期限切れ access token を refresh token で自動更新し、更新結果を `token.json` へ安全に保存するようにした。refresh token が失効・欠落した場合だけブラウザ再認証を案内し、2 診断の token 判定を統一した（#2293）。
 - `fix(viewer-voice)`: `yt-benchmark-comments` が `commentThreads.list` に必要な `youtube.force-ssl` を持つ full-scope token を使うよう修正し、readonly token 発行済み環境で全件 403 になる問題を解消した（#2286）。
 - `fix(collection-preflight)`: 単一言語チャンネルでは共有 `requires_scene_phrases()` 判定に従って `scene_phrases` を要求せず、多言語時だけ検証するよう修正した（#2270）。
 - `docs(auth)`: doctor の YouTube OAuth next_action と `/setup` を、AI/setup が `uv run yt-oauth` を background 起動して stdout の同意 URL を中継・exit待機・doctor再検証し、人間はブラウザ同意だけを担う契約へ統一した（#2279）。

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -24,7 +24,8 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from google.auth.exceptions import RefreshError
+from google.auth.exceptions import RefreshError, TransportError
+from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -1041,6 +1042,82 @@ def check_oauth_client_sharing(channel_dir: Path) -> CheckResult:
     )
 
 
+@dataclass(frozen=True)
+class _OAuthCredentialState:
+    credentials: Credentials | None = None
+    refreshed: bool = False
+    error: str | None = None
+    reauthentication_required: bool = False
+
+
+def _persist_refreshed_credentials(token_path: Path, credentials: Credentials) -> None:
+    """refresh 済み credentials を token.json へ 0o600 で atomic に保存する。"""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=token_path.parent,
+            prefix=f".{token_path.name}.",
+            delete=False,
+        ) as temporary:
+            temporary.write(credentials.to_json())
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.chmod(0o600)
+        os.replace(temporary_path, token_path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _load_refreshable_oauth_credentials(token_path: Path) -> _OAuthCredentialState:
+    """token を読み、期限切れなら refresh token で更新して永続化する。"""
+    try:
+        credentials = Credentials.from_authorized_user_file(str(token_path))
+    except (OSError, ValueError) as error:
+        return _OAuthCredentialState(
+            error=f"OAuth トークンが不正です: {error}",
+            reauthentication_required=True,
+        )
+
+    refreshed = False
+    if credentials.expired:
+        if not credentials.refresh_token:
+            return _OAuthCredentialState(
+                error="OAuth トークンが期限切れで、更新用トークンがありません",
+                reauthentication_required=True,
+            )
+        try:
+            credentials.refresh(Request())
+        except RefreshError:
+            return _OAuthCredentialState(
+                error="OAuth トークンの更新に失敗しました。更新用トークンが失効しています",
+                reauthentication_required=True,
+            )
+        except TransportError as error:
+            return _OAuthCredentialState(error=f"OAuth トークン更新時の通信に失敗しました: {error}")
+        try:
+            _persist_refreshed_credentials(token_path, credentials)
+        except OSError as error:
+            return _OAuthCredentialState(error=f"更新した OAuth トークンの保存に失敗しました: {error}")
+        refreshed = True
+
+    if not credentials.valid:
+        return _OAuthCredentialState(
+            error="OAuth トークンが利用できません",
+            reauthentication_required=True,
+        )
+    return _OAuthCredentialState(credentials=credentials, refreshed=refreshed)
+
+
+def _oauth_failure_action(state: _OAuthCredentialState) -> dict | None:
+    if not state.reauthentication_required:
+        return None
+    return _youtube_oauth_action("更新用トークンが利用できないため、ブラウザで OAuth 同意を完了してください。")
+
+
 def check_oauth_token(channel_dir: Path) -> CheckResult:
     path = channel_dir / "auth" / "token.json"
     if not path.exists():
@@ -1058,40 +1135,41 @@ def check_oauth_token(channel_dir: Path) -> CheckResult:
             status="fail",
             message=f"token.json 読み込み失敗: {e}",
         )
+    state = _load_refreshable_oauth_credentials(path)
+    if state.credentials is None:
+        return CheckResult(
+            id="oauth_token",
+            status="fail",
+            message=state.error or "OAuth トークンを利用できません",
+            next_action=_oauth_failure_action(state),
+        )
     scopes = data.get("scopes") or []
+    refresh_status = "・期限切れ token 更新済み" if state.refreshed else ""
     return CheckResult(
         id="oauth_token",
         status="ok",
-        message=f"token.json 存在 (scopes: {len(scopes)} 件)",
+        message=f"token.json 利用可能 (scopes: {len(scopes)} 件{refresh_status})",
     )
 
 
 def check_reporting_job(channel_dir: Path) -> CheckResult:
-    oauth_result = check_oauth_token(channel_dir)
-    if oauth_result.status != "ok":
+    token_path = channel_dir / "auth" / "token.json"
+    if not token_path.exists():
         return CheckResult(
             id="reporting_job",
             status="unknown",
             message="OAuth トークン未取得または不正のためスキップ",
         )
 
-    token_path = channel_dir / "auth" / "token.json"
-    try:
-        credentials = Credentials.from_authorized_user_file(str(token_path))
-    except (OSError, ValueError) as error:
+    state = _load_refreshable_oauth_credentials(token_path)
+    if state.credentials is None:
         return CheckResult(
             id="reporting_job",
             status="fail",
-            message=f"Reporting API ジョブ確認失敗: OAuth トークンが不正です: {error}",
+            message=f"Reporting API ジョブ確認失敗: {state.error}",
+            next_action=_oauth_failure_action(state),
         )
-
-    if not credentials.valid:
-        state = "期限切れ" if credentials.expired else "不正"
-        return CheckResult(
-            id="reporting_job",
-            status="fail",
-            message=f"Reporting API ジョブ確認失敗: OAuth トークンが{state}です。再認証してください",
-        )
+    credentials = state.credentials
 
     try:
         with _temporary_channel_dir(channel_dir), redirect_stdout(io.StringIO()):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from google.auth.exceptions import RefreshError
+from google.auth.exceptions import RefreshError, TransportError
 from googleapiclient.errors import HttpError
 from httplib2 import ServerNotFoundError
 from PIL import Image as PILImage
@@ -643,9 +643,76 @@ class TestOAuthToken:
     def test_valid(self, tmp_path):
         auth = tmp_path / "auth"
         auth.mkdir()
-        (auth / "token.json").write_text(json.dumps({"scopes": ["a", "b"]}), encoding="utf-8")
+        token = {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": ["a", "b"],
+            "expiry": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        }
+        (auth / "token.json").write_text(json.dumps(token), encoding="utf-8")
         r = doctor.check_oauth_token(tmp_path)
         assert r.status == "ok"
+
+    def test_expired_refreshable_token_is_refreshed_and_persisted(self, monkeypatch, tmp_path):
+        auth = tmp_path / "auth"
+        auth.mkdir()
+        token_path = auth / "token.json"
+        token_path.write_text('{"scopes": ["a"]}', encoding="utf-8")
+        credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=True)
+        credentials.to_json.return_value = '{"token": "refreshed", "scopes": ["a"]}'
+        monkeypatch.setattr(
+            doctor.Credentials,
+            "from_authorized_user_file",
+            lambda *_args, **_kwargs: credentials,
+        )
+
+        result = doctor.check_oauth_token(tmp_path)
+
+        assert result.status == "ok"
+        assert "更新済み" in result.message
+        credentials.refresh.assert_called_once()
+        assert token_path.read_text(encoding="utf-8") == credentials.to_json.return_value
+        assert token_path.stat().st_mode & 0o777 == 0o600
+
+    def test_refresh_failure_requests_browser_authentication(self, monkeypatch, tmp_path):
+        auth = tmp_path / "auth"
+        auth.mkdir()
+        (auth / "token.json").write_text('{"scopes": ["a"]}', encoding="utf-8")
+        credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
+        credentials.refresh.side_effect = RefreshError("invalid_grant")
+        monkeypatch.setattr(
+            doctor.Credentials,
+            "from_authorized_user_file",
+            lambda *_args, **_kwargs: credentials,
+        )
+
+        result = doctor.check_oauth_token(tmp_path)
+
+        assert result.status == "fail"
+        assert "更新に失敗" in result.message
+        assert result.next_action["reason"] == "authentication"
+        _assert_agent_driven_oauth(result.next_action)
+
+    def test_refresh_transport_failure_does_not_request_reauthentication(self, monkeypatch, tmp_path):
+        auth = tmp_path / "auth"
+        auth.mkdir()
+        (auth / "token.json").write_text('{"scopes": ["a"]}', encoding="utf-8")
+        credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
+        credentials.refresh.side_effect = TransportError("network unavailable")
+        monkeypatch.setattr(
+            doctor.Credentials,
+            "from_authorized_user_file",
+            lambda *_args, **_kwargs: credentials,
+        )
+
+        result = doctor.check_oauth_token(tmp_path)
+
+        assert result.status == "fail"
+        assert "通信" in result.message
+        assert result.next_action is None
 
 
 class TestReportingJob:
@@ -803,18 +870,36 @@ class TestReportingJob:
         assert check["status"] == "ok"
         assert os.environ["CHANNEL_DIR"] == str(original_channel_dir)
 
-    def test_expired_token_is_reported_without_refresh_or_browser_auth(self, monkeypatch, tmp_path, capsys):
+    def test_expired_token_is_refreshed_before_reporting_api_call(self, monkeypatch, tmp_path, capsys):
         self._write_token(tmp_path, expiry=datetime.now(timezone.utc) - timedelta(hours=1))
+        refresh_calls = []
 
-        def unexpected_reporting_call(*args, **kwargs):
-            raise AssertionError("expired credentials must not reach Reporting API")
+        def refresh(credentials, request):
+            refresh_calls.append(request)
+            credentials.token = "refreshed-access-token"
+            credentials.expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1)
 
-        monkeypatch.setattr(doctor, "build", unexpected_reporting_call)
+        monkeypatch.setattr(doctor.Credentials, "refresh", refresh)
+        monkeypatch.setattr(
+            doctor,
+            "build",
+            lambda *args, **kwargs: self._reporting_service(
+                jobs=[
+                    {
+                        "id": "job-1",
+                        "reportTypeId": "channel_reach_basic_a1",
+                        "name": "yt-automation",
+                    }
+                ]
+            ),
+        )
 
         check = self._json_check(monkeypatch, tmp_path, capsys)
 
-        assert check["status"] == "fail"
-        assert "期限切れ" in check["message"]
+        assert check["status"] == "ok"
+        assert len(refresh_calls) == 1
+        token = json.loads((tmp_path / "auth" / "token.json").read_text(encoding="utf-8"))
+        assert token["token"] == "refreshed-access-token"
 
     def test_invalid_token_is_reported_without_browser_auth(self, monkeypatch, tmp_path, capsys):
         auth = tmp_path / "auth"


### PR DESCRIPTION
## Summary
- refresh expired OAuth access tokens before doctor validity checks
- atomically persist refreshed credentials with mode 0600
- reserve browser reauthentication for missing or revoked refresh tokens
- align oauth_token and reporting_job token criteria

## Official docs
- https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.credentials.html
- https://google-auth.readthedocs.io/en/latest/user-guide.html

## Validation
- uv run ruff check src/youtube_automation/cli/doctor.py tests/test_doctor.py
- uv run ruff format --check src/youtube_automation/cli/doctor.py tests/test_doctor.py
- uv run pytest tests/test_doctor.py -q (298 passed)

Closes #2293