### PR TITLE
fix(suno-helper): 投入方式の選択色を明瞭化

### DIFF
--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -570,7 +570,7 @@ export function App() {
                 <label className="flex items-start gap-2">
                   <RadioGroupItem
                     value={id}
-                    className="mt-1"
+                    className="mt-1 data-[state=checked]:border-info-foreground data-[state=checked]:text-info-foreground"
                     aria-label={mode.label}
                     data-suno-control="run-mode"
                   />

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -525,6 +525,14 @@ describe("Suno popup compatibility check", () => {
     expect(serialMode.dataset.state).toBe("checked");
     expect(queueMode.value).toBe("queue");
     expect(queueMode.dataset.state).toBe("unchecked");
+    for (const radio of [serialMode, queueMode]) {
+      expect(Array.from(radio.classList)).toEqual(
+        expect.arrayContaining([
+          "data-[state=checked]:border-info-foreground",
+          "data-[state=checked]:text-info-foreground",
+        ])
+      );
+    }
     expectShadcnControl(
       serialMode.closest<HTMLElement>('[data-slot="button"]')!,
       "info"
@@ -1127,6 +1135,10 @@ describe("Suno popup compatibility check", () => {
       radioByLabel(container, "高速モード").click();
     });
     expect(presetStateMocks.writeRunModeId).toHaveBeenCalledWith("queue");
+    expect(radioByLabel(container, "安全モード").dataset.state).toBe(
+      "unchecked"
+    );
+    expect(radioByLabel(container, "高速モード").dataset.state).toBe("checked");
     expectShadcnControl(
       radioByLabel(container, "安全モード").closest<HTMLElement>(
         '[data-slot="button"]'


### PR DESCRIPTION
## 概要

- 選択中の投入方式ラジオの円枠と中央点に `info-foreground` を適用
- Radix の `data-state=checked` に限定し、未選択状態と共通 RadioGroup primitive は変更しない
- 安全/高速モード切替後の checked state とクラス契約を回帰テストで固定

Closes #2312

## 公式ドキュメント

- https://ui.shadcn.com/docs/components/radix/radio-group
- https://www.radix-ui.com/primitives/docs/components/radio-group
- https://ui.shadcn.com/docs/dark-mode/vite

## 検証

- `nr test -- tests/popup-compatibility.test.ts`（63 files / 1265 tests）
- `nr compile`
- `nr build`
- 変更ファイルの `oxfmt --check` / `oxlint`
- `verify-extensions.sh suno-helper`（build / zip）