### PR TITLE
fix(suno-helper): 投入方式カードを淡いアクセント配色に調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 投入方式の選択カードを薄い info 背景と青い枠へ調整し、light / dark の両方でモード名と説明文を読みやすくした（#2315）。
 - `docs(channel-new)`: localization 言語の生成規則を、TTP 多言語では競合セットを完全踏襲、TTP 非多言語では `en` のみ、非 TTP では単一言語・localizations 省略可の 3 分岐へ固定した。独自の高 CPM 言語追加を廃止し、生成テンプレートから `de` を除外した（#2295）。
 - `fix(doctor)`: `yt-doctor` の OAuth / Reporting 診断が期限切れ access token を refresh token で自動更新し、更新結果を `token.json` へ安全に保存するようにした。refresh token が失効・欠落した場合だけブラウザ再認証を案内し、2 診断の token 判定を統一した（#2293）。
 - `fix(viewer-voice)`: `yt-benchmark-comments` が `commentThreads.list` に必要な `youtube.force-ssl` を持つ full-scope token を使うよう修正し、readonly token 発行済み環境で全件 403 になる問題を解消した（#2286）。

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   buttonVariants,
   Checkbox,
+  cn,
   FieldLabel,
   RadioGroup,
   RadioGroupItem,
@@ -558,18 +559,22 @@ export function App() {
         >
           {RUN_MODE_ORDER.map((id) => {
             const mode = RUN_MODES[id];
+            const selected = runModeId === id;
             return (
               <FieldLabel
                 key={id}
-                data-variant={runModeId === id ? "info" : "outline"}
+                data-variant={selected ? "info" : "outline"}
                 data-size="sm"
                 data-disabled={controlsLocked}
-                className={buttonVariants({
-                  variant: runModeId === id ? "info" : "outline",
-                  size: "sm",
-                  className:
-                    "h-auto w-full justify-start whitespace-normal p-2",
-                })}
+                className={cn(
+                  buttonVariants({
+                    variant: selected ? "info" : "outline",
+                    size: "sm",
+                  }),
+                  "h-auto w-full justify-start whitespace-normal p-2",
+                  selected &&
+                    "bg-info-background/40 hover:bg-info-background/60 dark:bg-info-background/25 dark:hover:bg-info-background/40"
+                )}
               >
                 <RadioGroupItem
                   value={id}
@@ -579,7 +584,15 @@ export function App() {
                 />
                 <span className="flex flex-col">
                   <span className="font-medium">{mode.label}</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span
+                    data-suno-slot="run-mode-description"
+                    className={cn(
+                      "text-xs",
+                      selected
+                        ? "text-info-foreground"
+                        : "text-muted-foreground"
+                    )}
+                  >
                     {mode.riskNote}
                   </span>
                 </span>

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -540,11 +540,34 @@ describe("Suno popup compatibility check", () => {
       "info",
       "field-label"
     );
+    const selectedModeCard = serialMode.closest<HTMLElement>(
+      '[data-slot="field-label"]'
+    )!;
+    expect(Array.from(selectedModeCard.classList)).toEqual(
+      expect.arrayContaining([
+        "border-info-border",
+        "bg-info-background/40",
+        "dark:bg-info-background/25",
+      ])
+    );
+    expect(
+      selectedModeCard.querySelector('[data-suno-slot="run-mode-description"]')
+        ?.classList
+    ).toContain("text-info-foreground");
     expectShadcnControl(
       queueMode.closest<HTMLElement>('[data-slot="field-label"]')!,
       "outline",
       "field-label"
     );
+    const unselectedModeCard = queueMode.closest<HTMLElement>(
+      '[data-slot="field-label"]'
+    )!;
+    expect(unselectedModeCard.classList).not.toContain("bg-info-background/40");
+    expect(
+      unselectedModeCard.querySelector(
+        '[data-suno-slot="run-mode-description"]'
+      )?.classList
+    ).toContain("text-muted-foreground");
 
     expectShadcnControl(expectControl(container, "run"), "info");
     expectShadcnControl(expectControl(container, "stop"), "destructive");
@@ -1170,6 +1193,16 @@ describe("Suno popup compatibility check", () => {
       "info",
       "field-label"
     );
+    expect(
+      radioByLabel(container, "高速モード").closest<HTMLElement>(
+        '[data-slot="field-label"]'
+      )?.classList
+    ).toContain("bg-info-background/40");
+    expect(
+      radioByLabel(container, "安全モード").closest<HTMLElement>(
+        '[data-slot="field-label"]'
+      )?.classList
+    ).not.toContain("bg-info-background/40");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {


### PR DESCRIPTION
## Summary
- 投入方式の選択カードだけに薄い info 背景を適用し、shared `info` variant は変更しない
- 選択中の説明文を `text-info-foreground` に切り替え、light / dark 双方の可読性を維持
- 安全／高速モード切替時の選択・未選択 class contract を追加

## Official references
- https://ui.shadcn.com/docs/components/base/field
- https://ui.shadcn.com/docs/components/base/checkbox
- https://ui.shadcn.com/docs/theming
- https://ui.shadcn.com/docs/dark-mode/vite

## Validation
- `vitest run`: 63 files / 1267 tests passed
- changed-file Oxfmt / Oxlint passed
- `compile` passed
- production `build` passed
- full local `check` reached only a pre-existing macOS format mismatch in unchanged `extensions/suno-helper/README.md`; Linux CI is used for the authoritative full check

Closes #2315
