### PR TITLE
fix(suno-helper): チェックボックスカードの配置を統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 異常値再生成オプションを1行時は中央、説明表示時は先頭行へ揃え、曲リストのチェックボックスにコレクションカードと同じ余白基準を適用した（#2316）。
 - `fix(suno-helper)`: 投入方式の選択カードを薄い info 背景と青い枠へ調整し、light / dark の両方でモード名と説明文を読みやすくした（#2315）。
 - `docs(channel-new)`: localization 言語の生成規則を、TTP 多言語では競合セットを完全踏襲、TTP 非多言語では `en` のみ、非 TTP では単一言語・localizations 省略可の 3 分岐へ固定した。独自の高 CPM 言語追加を廃止し、生成テンプレートから `de` を除外した（#2295）。
 - `fix(doctor)`: `yt-doctor` の OAuth / Reporting 診断が期限切れ access token を refresh token で自動更新し、更新結果を `token.json` へ安全に保存するようにした。refresh token が失効・欠落した場合だけブラウザ再認証を案内し、2 診断の token 判定を統一した（#2293）。

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -602,9 +602,14 @@ export function App() {
         </RadioGroup>
       </fieldset>
 
-      <label className="flex items-start gap-2 rounded border border-border px-2 py-2 text-sm">
+      <FieldLabel
+        className={cn(
+          "w-full gap-2 rounded border border-border px-2 py-2 text-sm",
+          regenerateDurationOutliers ? "items-center" : "items-start"
+        )}
+      >
         <Checkbox
-          className="mt-1"
+          className={regenerateDurationOutliers ? undefined : "mt-1"}
           checked={regenerateDurationOutliers}
           disabled={entries.length === 0 || controlsLocked}
           data-suno-control="regenerate-duration-outliers"
@@ -622,7 +627,7 @@ export function App() {
             </span>
           )}
         </span>
-      </label>
+      </FieldLabel>
 
       <CompletionSoundControls
         settings={completionSoundSettings}

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -59,17 +59,21 @@ export function PatternList({
               className={buttonVariants({
                 variant: "outline",
                 size: "sm",
-                className: `h-auto w-full justify-start whitespace-normal p-0 font-normal ${STATE_CLASS[itemState]} ${SELECTION_CLASS[selected ? "selected" : "unselected"]}`,
+                className: `h-auto w-full justify-start whitespace-normal p-2 font-normal ${STATE_CLASS[itemState]} ${SELECTION_CLASS[selected ? "selected" : "unselected"]}`,
               })}
             >
               <Checkbox
+                className="mt-1"
                 checked={selected}
                 onCheckedChange={(checked) =>
                   onToggleEntry(index, checked === true)
                 }
                 aria-label={`entry ${index + 1}: ${entry.name}`}
               />
-              <span className="min-w-0 flex-1 px-2 py-1 text-left">
+              <span
+                className="min-w-0 flex-1 text-left"
+                data-suno-slot="entry-name"
+              >
                 {entry.name}
               </span>
             </FieldLabel>

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -233,7 +233,23 @@ describe("PatternList checkbox UI", () => {
       expect(control.className).toContain(
         [true, false, true, false, true][index] ? "ring-2" : "shadow-none"
       );
+      expect(control.className).toContain("p-2");
+      expect(control.className).not.toContain("p-0");
     });
+    expect(
+      checkboxes.every((checkbox) => checkbox.classList.contains("mt-1"))
+    ).toBe(true);
+    expect(
+      rows.every((row) => {
+        const text = row.querySelector('[data-suno-slot="entry-name"]');
+        return (
+          text?.classList.contains("min-w-0") &&
+          text.classList.contains("flex-1") &&
+          !text.classList.contains("px-2") &&
+          !text.classList.contains("py-1")
+        );
+      })
+    ).toBe(true);
     expect(rows[3].className).toContain("line-through");
   });
 

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -1062,10 +1062,18 @@ describe("Suno popup compatibility check", () => {
       expect(container.textContent).toContain("1 パターンを取得しました。");
     });
     expect(outlierOption.hasAttribute("data-disabled")).toBe(false);
+    expect(
+      outlierOption.closest<HTMLElement>('[data-slot="field-label"]')?.classList
+    ).toContain("items-center");
+    expect(outlierOption.classList).not.toContain("mt-1");
     await act(async () => {
       outlierOption.click();
     });
     expect(outlierOption.hasAttribute("data-checked")).toBe(false);
+    expect(
+      outlierOption.closest<HTMLElement>('[data-slot="field-label"]')?.classList
+    ).toContain("items-start");
+    expect(outlierOption.classList).toContain("mt-1");
     expect(container.textContent).toContain(
       "duration guard NG も Playlist / Download 候補に残ります"
     );


### PR DESCRIPTION
## Summary
- 異常値再生成オプションを、ONの1行表示では中央揃え、OFFの説明表示では先頭行揃えへ切り替える
- PatternListの余白をテキストだけでなくカード全体へ適用し、Checkboxをコレクションカードと同じ先頭行基準へ揃える
- checked / disabled / ARIA / callback / state color contractを維持したままlayout class testを追加

## Official references
- https://ui.shadcn.com/docs/components/base/field
- https://ui.shadcn.com/docs/components/base/checkbox
- https://ui.shadcn.com/docs/dark-mode/vite

## Validation
- unit: 63 files / 1267 tests passed
- targeted: 2 files / 76 tests passed
- E2E: 25 tests passed
- changed-file Oxfmt / Oxlint passed
- compile / production build passed
- full local `check` reached only a pre-existing macOS format mismatch in unchanged `extensions/suno-helper/README.md`; Linux CI is used for the authoritative full check

Closes #2316
