### PR TITLE
fix(collection-serve): 完了済みSuno候補を除外

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `chore(extensions-ui)`: 公式 shadcn/ui skill をリポジトリ管理下へ導入し、Claude Code / Codex / wheel sync で共有する `info`・公式docs・registry diff先行のUI実装手順を追加した（#2323）。
+- `fix(collection-serve)`: `collections/planning` の Suno 一覧と個別 prompts 配信から、対応する `collections/live/<id>/workflow-state.json` が `phase: complete` の collection を除外した。不在・破損・未完了状態は従来どおり表示し、DistroKid 一覧にはフィルタを適用しない（#2331）。
 - `fix(suno-helper)`: 異常値再生成オプションを1行時は中央、説明表示時は先頭行へ揃え、曲リストのチェックボックスにコレクションカードと同じ余白基準を適用した（#2316）。
 - `fix(suno-helper)`: 投入方式の選択カードを薄い info 背景と青い枠へ調整し、light / dark の両方でモード名と説明文を読みやすくした（#2315）。
 - `docs(channel-new)`: localization 言語の生成規則を、TTP 多言語では競合セットを完全踏襲、TTP 非多言語では `en` のみ、非 TTP では単一言語・localizations 省略可の 3 分岐へ固定した。独自の高 CPM 言語追加を廃止し、生成テンプレートから `de` を除外した（#2295）。

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -384,6 +384,30 @@ def find_collection_dirs(root: Path) -> list[Path]:
     return sorted(dirs, key=lambda p: p.name)
 
 
+def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
+    """planning の対応する live collection が完了済みなら True を返す（#2331）。
+
+    Suno の dir mode を ``collections/planning`` で配信する場合だけ sibling の
+    ``collections/live/<collection_id>/workflow-state.json`` を参照する。状態ファイルが
+    不在・破損・非 object の場合は fail-open とし、planning 側を従来どおり表示する。
+    """
+    if root.name != "planning" or root.parent.name != "collections":
+        return False
+    workflow_state = root.parent / "live" / collection_id / "workflow-state.json"
+    if not workflow_state.is_file():
+        return False
+    try:
+        data = json.loads(workflow_state.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    return isinstance(data, dict) and data.get("phase") == "complete"
+
+
+def _find_suno_collection_dirs(root: Path) -> list[Path]:
+    """Suno に提示可能な planning collection だけを返す（#2331）。"""
+    return [coll for coll in find_collection_dirs(root) if not _is_live_complete_collection(root, coll.name)]
+
+
 def _determine_status(
     has_prompts: bool,
     pattern_count: int | None,
@@ -525,7 +549,7 @@ def build_collections_index(root: Path) -> list[dict]:
     #1216 BREAKING: mapped_slugs を廃止。mapped / has_prompts / playlist_name を廃止。
     """
     index: list[dict] = []
-    for coll in find_collection_dirs(root):
+    for coll in _find_suno_collection_dirs(root):
         prompts_path = coll / DOCUMENTATION_DIRNAME / SUNO_PROMPTS_JSON_FILENAME
         has_prompts = prompts_path.is_file()
         pattern_count = read_pattern_count(coll)
@@ -569,7 +593,7 @@ def resolve_collection_prompts_path(root: Path, cid: str) -> Path | None:
     一致せず None を返す（fail-loud でなく 404 化できる形）。json の実在判定は
     呼び出し側に委ねる（has_prompts=False の collection も dir 自体は既知）。
     """
-    known = {coll.name for coll in find_collection_dirs(root)}
+    known = {coll.name for coll in _find_suno_collection_dirs(root)}
     if cid not in known:
         return None
     return root / cid / DOCUMENTATION_DIRNAME / SUNO_PROMPTS_JSON_FILENAME

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -1516,6 +1516,75 @@ def test_build_collections_index_reports_status_and_pattern_count(tmp_path):
     assert no_prompts["downloaded_count"] == 0
 
 
+def test_build_collections_index_excludes_live_complete_collection(tmp_path):
+    """Given planning と同じ id の live collection が phase=complete
+    When Suno の collection index を構築する
+    Then 完了済み collection を候補から除外する（#2331）。
+    """
+    planning = tmp_path / "collections" / "planning"
+    collection_id = "20260601-clm-complete-collection"
+    _make_collection(planning, collection_id, entries=[])
+    live = tmp_path / "collections" / "live" / collection_id
+    live.mkdir(parents=True)
+    (live / "workflow-state.json").write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+
+    assert build_collections_index(planning) == []
+    assert resolve_collection_prompts_path(planning, collection_id) is None
+
+
+@pytest.mark.parametrize(
+    "workflow_state",
+    [
+        None,
+        "{",
+        json.dumps([]),
+        json.dumps({"phase": "active"}),
+        json.dumps({"phase": "Complete"}),
+    ],
+)
+def test_build_collections_index_keeps_collection_when_live_state_is_not_valid_complete(tmp_path, workflow_state):
+    """live state が欠落・破損・非 object・未完了なら planning 候補を fail-open で維持する。"""
+    planning = tmp_path / "collections" / "planning"
+    collection_id = "20260601-clm-pending-collection"
+    _make_collection(planning, collection_id, entries=[])
+    if workflow_state is not None:
+        live = tmp_path / "collections" / "live" / collection_id
+        live.mkdir(parents=True)
+        (live / "workflow-state.json").write_text(workflow_state, encoding="utf-8")
+
+    assert [row["id"] for row in build_collections_index(planning)] == [collection_id]
+    assert resolve_collection_prompts_path(planning, collection_id) is not None
+
+
+def test_build_collections_index_does_not_filter_arbitrary_planning_root(tmp_path):
+    """collections/planning 以外の同名 root には live 完了フィルタを適用しない。"""
+    planning = tmp_path / "planning"
+    collection_id = "20260601-clm-complete-collection"
+    _make_collection(planning, collection_id, entries=[])
+    live = tmp_path / "live" / collection_id
+    live.mkdir(parents=True)
+    (live / "workflow-state.json").write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+
+    assert [row["id"] for row in build_collections_index(planning)] == [collection_id]
+
+
+def test_live_complete_filter_does_not_affect_distrokid_index(tmp_path):
+    """Suno で除外された collection も DistroKid 一覧には残す。"""
+    planning = tmp_path / "collections" / "planning"
+    collection_id = "20260601-clm-complete-collection"
+    coll = _make_collection(planning, collection_id, entries=[])
+    disc = coll / "30-distrokid" / "disc-1"
+    disc.mkdir(parents=True)
+    (disc / "track.mp3").write_bytes(b"fake")
+    live = tmp_path / "collections" / "live" / collection_id
+    live.mkdir(parents=True)
+    (live / "workflow-state.json").write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+
+    rows = collection_serve_module.build_distrokid_collections_index(planning)
+
+    assert [(row["collection_id"], row["disc"]) for row in rows] == [(collection_id, "disc-1")]
+
+
 def test_build_collections_index_counts_prompt_response_entries(tmp_path):
     """Given duration_filter 付き envelope prompts
     When build_collections_index を呼ぶ
@@ -1872,6 +1941,29 @@ def test_get_collections_lists_planning_collections(serve_dir, tmp_path):
     }
     assert by_id["20260602-clm-bbb-collection"]["status"] == "needs_prompts"
     assert by_id["20260602-clm-bbb-collection"]["pattern_count"] is None
+
+
+def test_dir_mode_hides_live_complete_collection_from_index_and_prompts(serve_dir, tmp_path):
+    """phase=complete の live collection は一覧に出ず、個別 prompts も 404 にする。"""
+    planning = tmp_path / "collections" / "planning"
+    collection_id = "20260601-clm-complete-collection"
+    _make_collection(planning, collection_id, entries=[{"name": "A", "style": "s", "lyrics": ""}])
+    live = tmp_path / "collections" / "live" / collection_id
+    live.mkdir(parents=True)
+    (live / "workflow-state.json").write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+    base = serve_dir(planning)
+
+    with urllib.request.urlopen(f"{base}{_COLLECTIONS_ROUTE}") as resp:
+        assert json.loads(resp.read().decode("utf-8")) == []
+
+    req = urllib.request.Request(
+        f"{base}{_collection_prompts_route(collection_id)}",
+        headers={"Origin": _SUNO_ORIGIN},
+    )
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+
+    _assert_json_404_with_cors(exc_info.value, _SUNO_ORIGIN)
 
 
 def test_get_collections_does_not_include_playlist_name_when_capture_enabled(serve_dir, tmp_path):


### PR DESCRIPTION
## Summary
- `collections/planning` の Suno 一覧から、対応する live state が `phase: complete` の collection を除外
- 完了済み ID の個別 prompts 配信を 404 に統一
- state 欠落・破損・非 object・未完了は fail-open、任意 root と DistroKid 一覧は従来挙動を維持

## Official references
- [Python `pathlib`](https://docs.python.org/3/library/pathlib.html)
- [Python `json`](https://docs.python.org/3/library/json.html)

## Validation
- `uv run pytest -q tests/test_collection_serve.py` (216 passed)
- `uv run ruff check src/youtube_automation/scripts/collection_serve.py tests/test_collection_serve.py`
- `uv run ruff format --check src/youtube_automation/scripts/collection_serve.py tests/test_collection_serve.py`

Closes #2331