### PR TITLE
fix(extensions-ui): RadioGroup選択表示を是正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(extensions-ui)`: shared Base UI `RadioGroupItem` の選択時 root 塗りつぶしを除去し、semantic color の円枠と中央配置した indicator dot で状態を示す公式 primitive 構成へ是正した。Suno の mouse / keyboard 選択、保存、disabled、カード配色は維持する（#2332）。
 - `fix(suno-helper)`: 曲リストとコレクション選択の checkbox をラベル先頭行へ揃え、異常値再生成 OFF の余白も同じ 2px 基準へ統一した。1行時のカード中央配置、完了音、選択 callback・ARIA は維持する（#2325）。
 - `perf(ci)`: issue イベントごとの lint workflow を廃止し、PR / main push の changed path を共通 classifier で判定するようにした。required `lint` / `test` は常時結果を返しつつ、extension-only 変更では Python full suite・wheel smoke・Windows・ADR を起動せず、Extensions も影響 helper だけを検証する（#2333）。
 - `chore(extensions-ui)`: 公式 shadcn/ui skill をリポジトリ管理下へ導入し、Claude Code / Codex / wheel sync で共有する `info`・公式docs・registry diff先行のUI実装手順を追加した（#2323）。

--- a/extensions/shared-ui/src/radio-group.tsx
+++ b/extensions/shared-ui/src/radio-group.tsx
@@ -18,16 +18,16 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
     <RadioPrimitive.Root
       data-slot="radio-group-item"
       className={cn(
-        "peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs outline-none transition-shadow after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:data-checked:bg-primary",
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs outline-none transition-shadow after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary dark:bg-input/30",
         className
       )}
       {...props}
     >
       <RadioPrimitive.Indicator
         data-slot="radio-group-indicator"
-        className="flex items-center justify-center"
+        className="flex size-4 items-center justify-center"
       >
-        <span className="size-2 rounded-full bg-current" />
+        <span className="absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current" />
       </RadioPrimitive.Indicator>
     </RadioPrimitive.Root>
   );

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -534,7 +534,25 @@ describe("Suno popup compatibility check", () => {
           "data-checked:text-info-foreground",
         ])
       );
+      expect(radio.classList).not.toContain("data-checked:bg-primary");
     }
+    const selectedIndicator = serialMode.querySelector<HTMLElement>(
+      '[data-slot="radio-group-indicator"]'
+    );
+    expect(Array.from(selectedIndicator?.classList ?? [])).toEqual(
+      expect.arrayContaining(["size-4", "items-center", "justify-center"])
+    );
+    expect(
+      Array.from(selectedIndicator?.firstElementChild?.classList ?? [])
+    ).toEqual(
+      expect.arrayContaining([
+        "left-1/2",
+        "top-1/2",
+        "-translate-x-1/2",
+        "-translate-y-1/2",
+        "bg-current",
+      ])
+    );
     expectShadcnControl(
       serialMode.closest<HTMLElement>('[data-slot="field-label"]')!,
       "info",
@@ -1182,6 +1200,16 @@ describe("Suno popup compatibility check", () => {
     expect(
       radioByLabel(container, "高速モード").hasAttribute("data-checked")
     ).toBe(true);
+    expect(
+      radioByLabel(container, "高速モード").querySelector(
+        '[data-slot="radio-group-indicator"]'
+      )
+    ).not.toBeNull();
+    expect(
+      radioByLabel(container, "安全モード").querySelector(
+        '[data-slot="radio-group-indicator"]'
+      )
+    ).toBeNull();
     await act(async () => {
       radioByLabel(container, "安全モード").click();
       radioByLabel(container, "高速モード").click();

--- a/tests/test_extensions_shared_ui_contract.py
+++ b/tests/test_extensions_shared_ui_contract.py
@@ -71,6 +71,11 @@ def test_shared_form_primitives_use_base_ui_state_contracts() -> None:
     assert "data-checked" in radio_group
     assert "disabled:opacity-50" in radio_group
     assert "focus-visible:ring-[3px]" in radio_group
+    assert "data-checked:bg-primary" not in radio_group
+    assert 'className="flex size-4 items-center justify-center"' in radio_group
+    assert "left-1/2 top-1/2" in radio_group
+    assert "-translate-x-1/2 -translate-y-1/2" in radio_group
+    assert "rounded-full bg-current" in radio_group
 
 
 def test_shared_theme_exposes_light_and_dark_status_token_triplets() -> None:


### PR DESCRIPTION
## Summary
- shared Base UI `RadioGroupItem` から selected root の全面塗りを除去
- 公式 Base UI の Root/Indicator 構成を維持し、Indicator を 16px box + absolute 50% translate で中央配置
- consumer の semantic info 色を円枠と `bg-current` dot に反映
- keyboard/pointer/value/storage/disabled と #2315 の card 配色を維持し、primitive/consumer contract test を追加

## Official references
- [shadcn Base UI Radio Group](https://ui.shadcn.com/docs/components/base/radio-group)
- [Base UI Radio Group API](https://base-ui.com/react/components/radio-group)

## Validation
- shadcn `info`, `docs radio-group`, `add --dry-run`, `add --diff`
- `nix develop .#extensions --command pnpm -C extensions/shared-ui check`
- `nix develop .#extensions --command pnpm -C extensions/shared-ui compile`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper compile`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper test` (1267 passed)
- `nix develop .#extensions --command pnpm -C extensions/suno-helper build`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper test:e2e` (25 passed)
- `uv run pytest tests/test_extensions_shared_ui_contract.py -q` (8 passed)

## CI optimization evidence (#2333)
This extension-only PR should report required `lint` / `test` through lightweight success steps and skip Python wheel/Windows/ADR jobs. Because shared-ui changed, all three extension consumers remain in scope.

Closes #2332