### PR TITLE
refactor(extensions-ui): resync shadcn primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(extensions-ui)`: shared Alert / Button / Card / Checkbox / Field / Label / RadioGroup / Select を現行 shadcn/ui Base UI registryへ再同期し、完全な Field composition、invalid state、現行 size・animationを追加した。独自 status variant、Radio選択色、ShadowRoot内Select portalは維持する（#2324）。
 - `fix(extensions-ui)`: shared Base UI `RadioGroupItem` の選択時 root 塗りつぶしを除去し、semantic color の円枠と中央配置した indicator dot で状態を示す公式 primitive 構成へ是正した。Suno の mouse / keyboard 選択、保存、disabled、カード配色は維持する（#2332）。
 - `feat(extensions)`: Suno / DistroKid / Community helper に用途とブランド色を区別できる透過 PNG アイコンを追加し、WXT が 16 / 32 / 48 / 128px の manifest icon を自動検出する契約を固定した（#2335）。
 - `fix(suno-helper)`: 曲リストとコレクション選択の checkbox をラベル先頭行へ揃え、異常値再生成 OFF の余白も同じ 2px 基準へ統一した。1行時のカード中央配置、完了音、選択 callback・ARIA は維持する（#2325）。

--- a/extensions/distrokid-helper/tests/ui-foundation.test.tsx
+++ b/extensions/distrokid-helper/tests/ui-foundation.test.tsx
@@ -16,18 +16,22 @@ import { describe, expect, it } from "vitest";
 
 const variantMarkers = {
   default: ["bg-primary", "text-primary-foreground"],
-  destructive: ["bg-destructive", "text-white"],
+  destructive: ["bg-destructive/10", "text-destructive"],
   outline: ["border", "bg-background"],
   secondary: ["bg-secondary", "text-secondary-foreground"],
-  ghost: ["hover:bg-accent"],
+  ghost: ["hover:bg-muted"],
   link: ["underline-offset-4", "hover:underline"],
 } as const;
 
 const sizeMarkers = {
-  default: ["h-9", "px-4"],
-  sm: ["h-8", "px-3"],
-  lg: ["h-10", "px-6"],
+  default: ["h-9", "px-2.5"],
+  xs: ["h-6", "text-xs"],
+  sm: ["h-8", "px-2.5"],
+  lg: ["h-10", "px-2.5"],
   icon: ["size-9"],
+  "icon-xs": ["size-6"],
+  "icon-sm": ["size-8"],
+  "icon-lg": ["size-10"],
 } as const;
 
 describe("shadcn/ui foundation", () => {
@@ -66,7 +70,7 @@ describe("shadcn/ui foundation", () => {
     expect(html).toContain('data-variant="default"');
     expect(html).toContain('data-size="default"');
     for (const marker of variantMarkers.default) expect(html).toContain(marker);
-    expect(html).toContain("h-9 px-4 py-2");
+    expect(html).toContain("h-9 gap-1.5 px-2.5");
     expect(html).toContain("w-full");
     expect(html).toContain("disabled");
     expect(html).toContain(">保存</button>");

--- a/extensions/shared-ui/src/alert.tsx
+++ b/extensions/shared-ui/src/alert.tsx
@@ -52,7 +52,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="alert-title"
       className={cn(
-        "font-medium group-has-[>svg]/alert:col-start-2",
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
         className
       )}
       {...props}
@@ -67,7 +67,10 @@ function AlertDescription({
   return (
     <div
       data-slot="alert-description"
-      className={cn("text-sm text-balance md:text-pretty", className)}
+      className={cn(
+        "text-sm text-balance md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
       {...props}
     />
   );

--- a/extensions/shared-ui/src/button.tsx
+++ b/extensions/shared-ui/src/button.tsx
@@ -4,32 +4,38 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "./utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         info: "border border-info-border bg-info-background text-info-foreground shadow-xs hover:bg-info-background/80 focus-visible:ring-info-border/40",
         warning:
           "border border-warning-border bg-warning-background text-warning-foreground shadow-xs hover:bg-warning-background/80 focus-visible:ring-warning-border/40",
         success:
           "border border-success-border bg-success-background text-success-foreground shadow-xs hover:bg-success-background/80 focus-visible:ring-success-border/40",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        default:
+          "h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+        lg: "h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-9",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {

--- a/extensions/shared-ui/src/card.tsx
+++ b/extensions/shared-ui/src/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] data-[size=sm]:[--card-spacing:--spacing(4)]",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}
@@ -30,9 +30,10 @@ function CardHeader({
       data-slot="card-header"
       data-layout={layout}
       className={cn(
+        "group/card-header @container/card-header items-start rounded-t-xl px-(--card-spacing) [.border-b]:pb-(--card-spacing)",
         layout === "stack"
-          ? "flex flex-col gap-1.5 px-(--card-spacing)"
-          : "grid auto-rows-min items-start gap-1 px-(--card-spacing)",
+          ? "flex flex-col gap-1.5"
+          : "grid auto-rows-min gap-1 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
         className
       )}
       {...props}
@@ -44,7 +45,10 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("text-base leading-normal font-medium", className)}
+      className={cn(
+        "text-base leading-normal font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
       {...props}
     />
   );
@@ -87,7 +91,10 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-(--card-spacing)", className)}
+      className={cn(
+        "flex items-center rounded-b-xl px-(--card-spacing) [.border-t]:pt-(--card-spacing)",
+        className
+      )}
       {...props}
     />
   );

--- a/extensions/shared-ui/src/checkbox.tsx
+++ b/extensions/shared-ui/src/checkbox.tsx
@@ -7,18 +7,17 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs outline-none transition-shadow after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground dark:data-checked:bg-primary dark:data-indeterminate:bg-primary",
         className
       )}
       {...props}
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="grid place-content-center text-current"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
         <svg
           aria-hidden="true"
-          className="size-3.5"
           viewBox="0 0 16 16"
           fill="none"
           stroke="currentColor"

--- a/extensions/shared-ui/src/field.tsx
+++ b/extensions/shared-ui/src/field.tsx
@@ -4,16 +4,65 @@ import * as React from "react";
 import { Label } from "./label";
 import { cn } from "./utils";
 
-const fieldVariants = cva("group/field flex w-full gap-3", {
-  variants: {
-    orientation: {
-      vertical: "flex-col *:w-full",
-      horizontal:
-        "flex-row items-center has-[>[data-slot=field-content]]:items-start",
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
     },
-  },
-  defaultVariants: { orientation: "vertical" },
-});
+    defaultVariants: { orientation: "vertical" },
+  }
+);
 
 function Field({
   className,
@@ -31,6 +80,19 @@ function Field({
   );
 }
 
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
 function FieldLabel({
   className,
   ...props
@@ -39,7 +101,8 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className
       )}
       {...props}
@@ -47,11 +110,14 @@ function FieldLabel({
   );
 }
 
-function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      data-slot="field-content"
-      className={cn("flex flex-1 flex-col gap-1 leading-snug", className)}
+      data-slot="field-title"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
       {...props}
     />
   );
@@ -61,10 +127,109 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
   return (
     <p
       data-slot="field-description"
-      className={cn("text-sm font-normal text-muted-foreground", className)}
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
       {...props}
     />
   );
 }
 
-export { Field, FieldContent, FieldDescription, FieldLabel, fieldVariants };
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={Boolean(children)}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <div
+        role="separator"
+        aria-label="Field separator"
+        aria-orientation="horizontal"
+        data-slot="separator"
+        className="absolute inset-x-0 top-1/2 h-px bg-border"
+      />
+      {children ? (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = React.useMemo(() => {
+    if (children) {
+      return children;
+    }
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ];
+    if (uniqueErrors.length === 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map((error) =>
+          error?.message ? <li key={error.message}>{error.message}</li> : null
+        )}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+  fieldVariants,
+};

--- a/extensions/shared-ui/src/index.ts
+++ b/extensions/shared-ui/src/index.ts
@@ -21,7 +21,13 @@ export {
   Field,
   FieldContent,
   FieldDescription,
+  FieldError,
+  FieldGroup,
   FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
   fieldVariants,
 } from "./field";
 export { Label } from "./label";

--- a/extensions/shared-ui/src/label.tsx
+++ b/extensions/shared-ui/src/label.tsx
@@ -7,7 +7,7 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
     <label
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm font-medium leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/extensions/shared-ui/src/radio-group.tsx
+++ b/extensions/shared-ui/src/radio-group.tsx
@@ -7,7 +7,7 @@ function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
   return (
     <RadioGroupPrimitive
       data-slot="radio-group"
-      className={cn("grid gap-3", className)}
+      className={cn("grid w-full gap-3", className)}
       {...props}
     />
   );
@@ -18,7 +18,7 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
     <RadioPrimitive.Root
       data-slot="radio-group-item"
       className={cn(
-        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs outline-none transition-shadow after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary dark:bg-input/30",
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input text-primary outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary",
         className
       )}
       {...props}

--- a/extensions/shared-ui/src/select.tsx
+++ b/extensions/shared-ui/src/select.tsx
@@ -44,6 +44,23 @@ function ChevronDownIcon({ className }: { className?: string }) {
   );
 }
 
+function ChevronUpIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="m4 10 4-4 4 4" />
+    </svg>
+  );
+}
+
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -111,7 +128,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 whitespace-nowrap rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 dark:bg-input/30 dark:hover:bg-input/50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex w-fit items-center justify-between gap-1.5 rounded-md border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -155,7 +172,7 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "relative isolate z-[2147483647] max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "relative isolate z-[2147483647] max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}
@@ -191,7 +208,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       label={typeof children === "string" ? children : undefined}
@@ -232,12 +249,12 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
       className={cn(
-        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1",
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <span aria-hidden="true">▲</span>
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpArrow>
   );
 }
@@ -250,12 +267,12 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"
       className={cn(
-        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1",
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <span aria-hidden="true">▼</span>
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownArrow>
   );
 }

--- a/extensions/suno-helper/tests/ui-foundation.test.tsx
+++ b/extensions/suno-helper/tests/ui-foundation.test.tsx
@@ -6,8 +6,18 @@ import {
   Card,
   CardContent,
   CardHeader,
+  Checkbox,
   cn,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
   FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
   Select,
   SelectTrigger,
   SelectValue,
@@ -18,7 +28,7 @@ import { describe, expect, it } from "vitest";
 
 const variantMarkers = {
   default: ["bg-primary", "text-primary-foreground"],
-  destructive: ["bg-destructive", "text-white"],
+  destructive: ["bg-destructive/10", "text-destructive"],
   info: ["border-info-border", "bg-info-background", "text-info-foreground"],
   outline: ["border", "bg-background"],
   secondary: ["bg-secondary", "text-secondary-foreground"],
@@ -32,15 +42,19 @@ const variantMarkers = {
     "bg-warning-background",
     "text-warning-foreground",
   ],
-  ghost: ["hover:bg-accent"],
+  ghost: ["hover:bg-muted"],
   link: ["underline-offset-4", "hover:underline"],
 } as const;
 
 const sizeMarkers = {
-  default: ["h-9", "px-4"],
-  sm: ["h-8", "px-3"],
-  lg: ["h-10", "px-6"],
+  default: ["h-9", "px-2.5"],
+  xs: ["h-6", "text-xs"],
+  sm: ["h-8", "px-2.5"],
+  lg: ["h-10", "px-2.5"],
   icon: ["size-9"],
+  "icon-xs": ["size-6"],
+  "icon-sm": ["size-8"],
+  "icon-lg": ["size-10"],
 } as const;
 
 describe("shadcn/ui foundation", () => {
@@ -79,7 +93,7 @@ describe("shadcn/ui foundation", () => {
     expect(html).toContain('data-variant="default"');
     expect(html).toContain('data-size="default"');
     for (const marker of variantMarkers.default) expect(html).toContain(marker);
-    expect(html).toContain("h-9 px-4 py-2");
+    expect(html).toContain("h-9 gap-1.5 px-2.5");
     expect(html).toContain("w-full");
     expect(html).toContain("disabled");
     expect(html).toContain(">保存</button>");
@@ -101,6 +115,22 @@ describe("shadcn/ui foundation", () => {
     expect(html).toContain(">確認</a>");
   });
 
+  it("Button render は nested interactive element を作らず非button要素へ button semantics を付与する", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        Button,
+        { render: createElement("div"), nativeButton: false },
+        "詳細"
+      )
+    );
+
+    expect(html.startsWith("<div ")).toBe(true);
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+    expect(html).not.toContain("<button");
+    expect(html).toContain(">詳細</div>");
+  });
+
   it("FieldLabel は checkbox cardをnested buttonなしで構成する", () => {
     const html = renderToStaticMarkup(
       createElement(
@@ -114,6 +144,65 @@ describe("shadcn/ui foundation", () => {
     expect(html.startsWith("<label ")).toBe(true);
     expect(html).toContain('data-slot="field-label"');
     expect(html).not.toContain("<button");
+  });
+
+  it("Field は公式の set/group/content/description/error composition を公開する", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        FieldSet,
+        null,
+        createElement(FieldLegend, null, "通知"),
+        createElement(
+          FieldGroup,
+          null,
+          createElement(
+            Field,
+            null,
+            createElement(FieldLabel, null, "メール"),
+            createElement(
+              FieldContent,
+              null,
+              createElement(FieldTitle, null, "配信先"),
+              createElement(FieldDescription, null, "受信先を選択")
+            ),
+            createElement(FieldSeparator, null, "または"),
+            createElement(FieldError, { errors: [{ message: "必須です" }] })
+          )
+        )
+      )
+    );
+
+    for (const slot of [
+      "field-set",
+      "field-legend",
+      "field-group",
+      "field",
+      "field-label",
+      "field-content",
+      "field-title",
+      "field-description",
+      "field-separator",
+      "field-error",
+    ]) {
+      expect(html).toContain(`data-slot="${slot}"`);
+    }
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("必須です");
+  });
+
+  it("Checkbox は indeterminate と invalid の Base UI state を保持する", () => {
+    const html = renderToStaticMarkup(
+      createElement(Checkbox, {
+        indeterminate: true,
+        "aria-invalid": true,
+        "aria-label": "一部選択",
+      })
+    );
+
+    expect(html).toContain('data-slot="checkbox"');
+    expect(html).toContain("data-indeterminate");
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain('aria-label="一部選択"');
   });
 
   it("Card は shell/header/content の slot と追加 props を実 DOM に反映する", () => {

--- a/tests/test_extensions_shared_ui_contract.py
+++ b/tests/test_extensions_shared_ui_contract.py
@@ -40,7 +40,9 @@ def test_shared_ui_package_owns_public_primitives_and_theme() -> None:
         "Button",
         "Card",
         "Checkbox",
+        "FieldError",
         "FieldLabel",
+        "FieldSet",
         "RadioGroup",
         "RadioGroupItem",
         "Select",
@@ -61,7 +63,9 @@ def test_shared_form_primitives_use_base_ui_state_contracts() -> None:
     assert 'data-slot="checkbox-indicator"' in checkbox
     assert "data-checked" in checkbox
     assert "disabled:opacity-50" in checkbox
-    assert "focus-visible:ring-[3px]" in checkbox
+    assert "focus-visible:ring-3" in checkbox
+    assert "data-indeterminate:bg-primary" in checkbox
+    assert "aria-invalid:ring-3" in checkbox
 
     assert 'from "@base-ui/react/radio"' in radio_group
     assert 'from "@base-ui/react/radio-group"' in radio_group
@@ -70,12 +74,41 @@ def test_shared_form_primitives_use_base_ui_state_contracts() -> None:
     assert 'data-slot="radio-group-indicator"' in radio_group
     assert "data-checked" in radio_group
     assert "disabled:opacity-50" in radio_group
-    assert "focus-visible:ring-[3px]" in radio_group
+    assert "focus-visible:ring-3" in radio_group
+    assert "aria-invalid:ring-3" in radio_group
     assert "data-checked:bg-primary" not in radio_group
     assert 'className="flex size-4 items-center justify-center"' in radio_group
     assert "left-1/2 top-1/2" in radio_group
     assert "-translate-x-1/2 -translate-y-1/2" in radio_group
     assert "rounded-full bg-current" in radio_group
+
+
+def test_shared_primitives_track_current_base_vega_composition() -> None:
+    sources = {
+        name: (EXTENSIONS / f"shared-ui/src/{name}.tsx").read_text()
+        for name in ("alert", "button", "card", "field", "select")
+    }
+
+    assert "[&_p:not(:last-child)]:mb-4" in sources["alert"]
+    assert "group/button" in sources["button"]
+    assert '"icon-xs"' in sources["button"]
+    assert "active:not-aria-[haspopup]:translate-y-px" in sources["button"]
+    assert "has-[>img:first-child]:pt-0" in sources["card"]
+    assert "has-data-[slot=card-action]:grid-cols-[1fr_auto]" in sources["card"]
+
+    for slot in (
+        "field-set",
+        "field-legend",
+        "field-group",
+        "field-title",
+        "field-separator",
+        "field-error",
+    ):
+        assert f'data-slot="{slot}"' in sources["field"]
+
+    assert "*:data-[slot=select-value]:line-clamp-1" in sources["select"]
+    assert "data-[side=bottom]:slide-in-from-top-2" in sources["select"]
+    assert "SelectPortalContext" in sources["select"]
 
 
 def test_shared_theme_exposes_light_and_dark_status_token_triplets() -> None:


### PR DESCRIPTION
## Summary

- resync all eight public `@youtube-automation/ui` component families with the current official shadcn/ui `base-vega` Base UI registry
- add the complete Field composition and current invalid/disabled, size, card media, and Select animation contracts
- preserve local status variants, the non-inverting Radio selection fixed in #2332, and the extension-local ShadowRoot Select portal
- expand shared contract and rendered behavior coverage without changing helper workflows

## Official workflow and references

Ran `shadcn info --json`, `shadcn docs`, `shadcn add --dry-run`, and `shadcn add --diff` for Alert, Button, Card, Checkbox, Field, Label, RadioGroup, and Select before merging the registry changes.

- https://ui.shadcn.com/docs/cli
- https://ui.shadcn.com/docs/components/base/field
- https://ui.shadcn.com/docs/components/base/checkbox
- https://ui.shadcn.com/docs/components/base/radio-group
- https://ui.shadcn.com/docs/components/base/select
- https://base-ui.com/react/components/checkbox

## Validation

- Suno: check, compile, 1,274 tests, build, 25 Playwright tests
- DistroKid: check, compile, 263 tests, build, 7 Playwright tests
- Community: check, compile, 44 tests, build
- shared Python UI contracts: 9 tests
- frozen-lockfile installs produced no lockfile changes

## Theme smoke

Loaded the production Suno build unpacked in Chromium and switched the emulated OS color scheme on the same Shadow DOM overlay:

- light: host has no `dark` class; card background `oklch(1 0 0)`, text `oklch(0.145 0 0)`
- dark: host has `dark`; card background `oklch(0.205 0 0)`, text `oklch(0.985 0 0)`
- Card, Select, Radio, Checkbox, disabled action, focus/status surfaces remained readable and structurally intact in both captures

Closes #2324
