### PR TITLE
feat(suno-helper): discard settled collection queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `refactor(extensions-ui)`: shared Alert / Button / Card / Checkbox / Field / Label / RadioGroup / Select を現行 shadcn/ui Base UI registryへ再同期し、完全な Field composition、invalid state、現行 size・animationを追加した。独自 status variant、Radio選択色、ShadowRoot内Select portalは維持する（#2324）。
+- `feat(suno-helper)`: paused / completed の collection queue summary にアクセシブルな Close を追加し、paused はインライン確認後、completed は即時に永続 queue state を削除できるようにした。running queue と単発 Resume state は破棄対象外とする（#2328）。
 - `fix(extensions-ui)`: shared Base UI `RadioGroupItem` の選択時 root 塗りつぶしを除去し、semantic color の円枠と中央配置した indicator dot で状態を示す公式 primitive 構成へ是正した。Suno の mouse / keyboard 選択、保存、disabled、カード配色は維持する（#2332）。
 - `feat(extensions)`: Suno / DistroKid / Community helper に用途とブランド色を区別できる透過 PNG アイコンを追加し、WXT が 16 / 32 / 48 / 128px の manifest icon を自動検出する契約を固定した（#2335）。
 - `fix(suno-helper)`: 曲リストとコレクション選択の checkbox をラベル先頭行へ揃え、異常値再生成 OFF の余白も同じ 2px 基準へ統一した。1行時のカード中央配置、完了音、選択 callback・ARIA は維持する（#2325）。

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -42,6 +42,8 @@ browser use から overlay / popup を安定して観測できるよう、操作
 | `[data-suno-control="collection-checkbox"]`                                                        | shadcn ベース一覧で collection を複数選択                                                                 |
 | `[data-suno-control="collection-select"]`                                                          | 旧 agent/E2E 用の非表示単一選択 compatibility seam                                                        |
 | `[data-suno-control="collection-queue-summary"]`                                                   | collection ごとの成功 / 失敗と再実行導線                                                                  |
+| `[data-suno-control="collection-queue-dismiss"]`                                                   | 停止・完了した collection queue の破棄操作                                                                |
+| `[data-suno-control="collection-queue-discard-confirmation"]`                                      | 停止中 queue のインライン破棄確認                                                                          |
 | `[data-suno-control="run"]` / `[data-suno-control="stop"]`                                         | 主要操作ボタン                                                                                            |
 | `[data-suno-control="completion-sound-enabled"]`                                                   | 完了音 ON/OFF の shadcn Checkbox                                                                          |
 | `[data-suno-control="completion-sound-preset"]` / `[data-suno-control="completion-sound-preview"]` | 合成音 preset の選択 / 試聴                                                                               |

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -61,6 +61,7 @@ export function App() {
     collectionQueue,
     runCollectionQueue,
     resumeCollectionQueue,
+    discardCollectionQueue,
     entries,
     itemStates,
     status,
@@ -99,10 +100,14 @@ export function App() {
   const previousItemStatesRef = useRef(itemStates);
   const [refreshingServerSources, setRefreshingServerSources] = useState(false);
   const [serverSourcePickerOpen, setServerSourcePickerOpen] = useState(false);
+  const [queueDiscardConfirming, setQueueDiscardConfirming] = useState(false);
   const isRunningRef = useRef(isRunning);
   useEffect(() => {
     isRunningRef.current = isRunning;
   }, [isRunning]);
+  useEffect(() => {
+    setQueueDiscardConfirming(false);
+  }, [collectionQueue?.queueId, collectionQueue?.status]);
 
   const openServerSourcePicker = (): void => {
     if (refreshingServerSources || controlsLocked) {
@@ -432,10 +437,42 @@ export function App() {
                   ? "warning"
                   : "info"
           }
-          className="flex flex-col gap-2 rounded px-2 py-2 text-xs"
+          className="relative flex flex-col gap-2 rounded px-2 py-2 text-xs"
           data-suno-control="collection-queue-summary"
         >
-          <p className="font-medium">
+          {collectionQueue.status !== "running" && (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="absolute top-1 right-1 size-6"
+              aria-label={
+                collectionQueue.status === "paused"
+                  ? "停止中の collection queue を破棄"
+                  : "完了した collection queue を閉じる"
+              }
+              data-suno-control="collection-queue-dismiss"
+              onClick={() => {
+                if (collectionQueue.status === "paused") {
+                  setQueueDiscardConfirming(true);
+                  return;
+                }
+                void discardCollectionQueue();
+              }}
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth="2"
+              >
+                <path d="m4 4 8 8m0-8-8 8" />
+              </svg>
+            </Button>
+          )}
+          <p className="pr-7 font-medium">
             Collection queue: {collectionQueue.status}
           </p>
           <ul className="list-disc pl-4">
@@ -446,7 +483,33 @@ export function App() {
               </li>
             ))}
           </ul>
-          {collectionQueue.status === "paused" && (
+          {collectionQueue.status === "paused" && queueDiscardConfirming && (
+            <div
+              role="group"
+              aria-label="未完了の collection queue の破棄確認"
+              className="flex flex-wrap items-center gap-2"
+              data-suno-control="collection-queue-discard-confirmation"
+            >
+              <p className="w-full">未完了の queue を破棄しますか？</p>
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                onClick={() => void discardCollectionQueue()}
+              >
+                破棄
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setQueueDiscardConfirming(false)}
+              >
+                戻る
+              </Button>
+            </div>
+          )}
+          {collectionQueue.status === "paused" && !queueDiscardConfirming && (
             <Button
               type="button"
               size="sm"

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -27,6 +27,7 @@ import {
   orderSelectedCollectionIds,
   pauseCollectionQueue,
   readCollectionQueue,
+  removeCollectionQueue,
   resumeCollectionQueue,
   settleStoredCollectionQueueRun,
   type CollectionQueueState,
@@ -83,6 +84,7 @@ interface RunnerState {
   collectionQueue: CollectionQueueState | null;
   runCollectionQueue: (collectionIds: string[]) => Promise<void>;
   resumeCollectionQueue: () => Promise<void>;
+  discardCollectionQueue: () => Promise<void>;
   entries: PromptEntry[];
   itemStates: ItemState[];
   status: string;
@@ -1301,6 +1303,21 @@ export function useSunoRunner(): RunnerState {
       }
     }, [clearLoadedRunState, fetchData, reportStorageFailure]);
 
+  const discardPersistedCollectionQueue =
+    useCallback(async (): Promise<void> => {
+      const current = collectionQueueRef.current;
+      if (!current || current.status === "running") {
+        return;
+      }
+      try {
+        await removeCollectionQueue();
+        collectionQueueRef.current = null;
+        setCollectionQueue(null);
+      } catch (error) {
+        reportStorageFailure(error);
+      }
+    }, [reportStorageFailure]);
+
   const run = useCallback(
     async (overrides?: RunOverrides) => {
       // 二重実行ガード (#892 要件7)。実行中の再入（「再開」連打等）を no-op で弾く。
@@ -1689,6 +1706,7 @@ export function useSunoRunner(): RunnerState {
     collectionQueue,
     runCollectionQueue,
     resumeCollectionQueue: resumePersistedCollectionQueue,
+    discardCollectionQueue: discardPersistedCollectionQueue,
     entries,
     itemStates,
     status,

--- a/extensions/suno-helper/lib/collection-queue-state.ts
+++ b/extensions/suno-helper/lib/collection-queue-state.ts
@@ -214,6 +214,10 @@ export function writeCollectionQueue(
   return collectionQueueItem().setValue(state);
 }
 
+export function removeCollectionQueue(): Promise<void> {
+  return collectionQueueItem().removeValue();
+}
+
 export async function settleStoredCollectionQueueRun(
   queueId: string,
   options: SettleCollectionQueueRunOptions

--- a/extensions/suno-helper/tests/collection-queue-storage.test.ts
+++ b/extensions/suno-helper/tests/collection-queue-storage.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const storageMock = vi.hoisted(() => ({
   value: null as unknown,
   getValue: vi.fn(),
+  removeValue: vi.fn(),
   setValue: vi.fn(),
   defineItem: vi.fn(),
 }));
@@ -12,8 +13,12 @@ vi.mock("wxt/utils/storage", () => {
   storageMock.setValue.mockImplementation(async (value: unknown) => {
     storageMock.value = value;
   });
+  storageMock.removeValue.mockImplementation(async () => {
+    storageMock.value = null;
+  });
   storageMock.defineItem.mockReturnValue({
     getValue: storageMock.getValue,
+    removeValue: storageMock.removeValue,
     setValue: storageMock.setValue,
   });
   return { storage: { defineItem: storageMock.defineItem } };
@@ -22,6 +27,8 @@ vi.mock("wxt/utils/storage", () => {
 import {
   createCollectionQueue,
   currentCollectionId,
+  readCollectionQueue,
+  removeCollectionQueue,
   settleStoredCollectionQueueRun,
   writeCollectionQueue,
 } from "../lib/collection-queue-state";
@@ -79,5 +86,22 @@ describe("collection queue storage boundary (#2029)", () => {
     expect(transition).toBeNull();
     expect(storageMock.setValue).not.toHaveBeenCalled();
     expect(storageMock.value).toEqual(state);
+  });
+
+  it("queue state を storage key ごと削除し、再読込時に復活させない", async () => {
+    const state = createCollectionQueue({
+      queueId: "discarded-queue",
+      baseUrl: "http://localhost:8765",
+      collectionIds: ["first"],
+      runMode: "serial",
+      regenerateDurationOutliers: true,
+      now: 100,
+    });
+    await writeCollectionQueue(state);
+
+    await removeCollectionQueue();
+
+    expect(storageMock.removeValue).toHaveBeenCalledOnce();
+    await expect(readCollectionQueue()).resolves.toBeNull();
   });
 });

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -34,6 +34,7 @@ const runner = vi.hoisted(() => ({
   collectionQueue: null,
   runCollectionQueue: vi.fn(),
   resumeCollectionQueue: vi.fn(),
+  discardCollectionQueue: vi.fn(async () => undefined),
   entries: [],
   itemStates: [],
   status: "待機中",
@@ -116,6 +117,8 @@ describe("Overlay shell", () => {
       collectionQueue: null,
     });
     runner.runCollectionQueue.mockClear();
+    runner.resumeCollectionQueue.mockClear();
+    runner.discardCollectionQueue.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -340,6 +343,94 @@ describe("Overlay shell", () => {
     ).toBe("success");
   });
 
+  it("paused queue は確認後だけ破棄し、戻ると再開操作を維持する", async () => {
+    Object.assign(runner, {
+      collectionQueue: {
+        version: 1,
+        queueId: "queue-paused",
+        baseUrl: "http://localhost:7873",
+        items: [{ collectionId: "first", status: "pending" }],
+        currentIndex: 0,
+        status: "paused",
+        runMode: "serial",
+        regenerateDurationOutliers: true,
+        createdAt: 100,
+        updatedAt: 200,
+      },
+    });
+    await act(async () => root.render(createElement(Overlay)));
+
+    const close = container.querySelector<HTMLButtonElement>(
+      'button[data-suno-control="collection-queue-dismiss"]'
+    )!;
+    expect(close.getAttribute("aria-label")).toContain("停止中");
+    await act(async () => close.click());
+
+    const confirmation = container.querySelector<HTMLElement>(
+      '[data-suno-control="collection-queue-discard-confirmation"]'
+    )!;
+    expect(confirmation.textContent).toContain(
+      "未完了の queue を破棄しますか？"
+    );
+    expect(runner.discardCollectionQueue).not.toHaveBeenCalled();
+    expect(
+      Array.from(confirmation.querySelectorAll("button")).map(
+        (button) => button.textContent
+      )
+    ).toEqual(["破棄", "戻る"]);
+
+    await act(async () =>
+      Array.from(confirmation.querySelectorAll("button"))
+        .find((button) => button.textContent === "戻る")!
+        .click()
+    );
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (button) => button.textContent === "Queue を再開"
+      )
+    ).toBe(true);
+
+    await act(async () => close.click());
+    await act(async () =>
+      Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent === "破棄")!
+        .click()
+    );
+    expect(runner.discardCollectionQueue).toHaveBeenCalledOnce();
+    expect(runner.resumeCollectionQueue).not.toHaveBeenCalled();
+  });
+
+  it("completed queue の Close は確認なしで即時破棄する", async () => {
+    Object.assign(runner, {
+      collectionQueue: {
+        version: 1,
+        queueId: "queue-completed",
+        baseUrl: "http://localhost:7873",
+        items: [{ collectionId: "first", status: "succeeded" }],
+        currentIndex: 1,
+        status: "completed",
+        runMode: "serial",
+        regenerateDurationOutliers: true,
+        createdAt: 100,
+        updatedAt: 200,
+      },
+    });
+    await act(async () => root.render(createElement(Overlay)));
+
+    const close = container.querySelector<HTMLButtonElement>(
+      'button[data-suno-control="collection-queue-dismiss"]'
+    )!;
+    expect(close.getAttribute("aria-label")).toContain("完了した");
+    await act(async () => close.click());
+
+    expect(runner.discardCollectionQueue).toHaveBeenCalledOnce();
+    expect(
+      container.querySelector(
+        '[data-suno-control="collection-queue-discard-confirmation"]'
+      )
+    ).toBeNull();
+  });
+
   it("collection 間の queue 遷移中は入力を固定し Stop だけを有効にする", async () => {
     Object.assign(runner, {
       collectionQueue: {
@@ -363,6 +454,11 @@ describe("Overlay shell", () => {
         '[data-suno-control="collection-queue-summary"]'
       )?.dataset.variant
     ).toBe("info");
+    expect(
+      container.querySelector(
+        'button[data-suno-control="collection-queue-dismiss"]'
+      )
+    ).toBeNull();
 
     expect(
       container.querySelector<HTMLButtonElement>(


### PR DESCRIPTION
## Summary

- add an accessible shadcn/Base UI icon Button to paused and completed collection queue summaries
- require inline confirmation before discarding unfinished paused queues; completed summaries discard immediately
- remove the WXT storage item with `removeValue()` and clear the runner ref/state so discarded summaries do not return
- keep running queues non-dismissible and leave the separate single-run Resume state untouched

## Official references

- https://ui.shadcn.com/docs/components/base/button
- https://base-ui.com/react/overview/accessibility
- https://wxt.dev/storage

## Validation

- Suno check and compile
- 1,274 Vitest tests, including paused confirm/back/discard, completed immediate discard, running guard, and storage removal
- production build
- 25 Playwright tests

Closes #2328
