### PR TITLE
fix(suno-helper): コレクション一覧をスクロール可能にする (#2353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: コレクション件数が多い場合、楽曲一覧と同じ高さ上限で一覧内を縦スクロールできるようにした（#2353）。
+
 - `feat(extensions)`: Suno・DistroKid・Community Helper の共通 overlay ヘッダーへ、公式一次資料に基づく識別可能なサービス別配色と WCAG AA コントラスト検証を追加（#2327）
 
 - `refactor(community-helper)`: native popup を YouTube チャンネル投稿ページ上の shared shadcn/ui Shadow DOM overlay へ移し、drag・viewport clamp・最小化・action toggle・reload 復元を追加した。run / stop / progress / error は background が送信元と同一タブへ relay し、既存の server fetch 境界と投稿 runner を維持する（#2320）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `fix(suno-helper)`: コレクション件数が多い場合、楽曲一覧と同じ高さ上限で一覧内を縦スクロールできるようにした（#2353）。
+- `fix(suno-helper)`: コレクション一覧と楽曲一覧を shared shadcn/ui Scroll Area へ移行し、件数が多い場合は同じ高さ上限で一覧内を縦スクロールできるようにした（#2353）。
 
 - `feat(extensions)`: Suno・DistroKid・Community Helper の共通 overlay ヘッダーへ、公式一次資料に基づく識別可能なサービス別配色と WCAG AA コントラスト検証を追加（#2327）
 

--- a/extensions/shared-ui/src/index.ts
+++ b/extensions/shared-ui/src/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./overlay-shell";
 export { hexContrastRatio } from "./color-contrast";
 export { RadioGroup, RadioGroupItem } from "./radio-group";
+export { ScrollArea, ScrollBar } from "./scroll-area";
 export {
   Select,
   SelectContent,

--- a/extensions/shared-ui/src/scroll-area.tsx
+++ b/extensions/shared-ui/src/scroll-area.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+
+import { cn } from "./utils";
+
+type ScrollAreaProps = ScrollAreaPrimitive.Root.Props & {
+  viewportClassName?: string;
+};
+
+function ScrollArea({
+  className,
+  children,
+  viewportClassName,
+  ...props
+}: ScrollAreaProps) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className={cn(
+          "size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1",
+          viewportClassName
+        )}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -374,7 +374,11 @@ export function App() {
             <path d="M6 12V4l4.5 4z" />
           </svg>
         </CollapsibleTrigger>
-        <CollapsibleContent keepMounted className="mt-1 flex flex-col gap-1">
+        <CollapsibleContent
+          keepMounted
+          className="mt-1 flex max-h-48 flex-col gap-1 overflow-y-auto"
+          data-suno-collection-list="true"
+        >
           {collections.length === 0 && (
             <p className="text-xs text-muted-foreground">コレクションなし</p>
           )}

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -10,6 +10,7 @@ import {
   FieldLabel,
   RadioGroup,
   RadioGroupItem,
+  ScrollArea,
   Select,
   SelectContent,
   SelectItem,
@@ -374,59 +375,65 @@ export function App() {
             <path d="M6 12V4l4.5 4z" />
           </svg>
         </CollapsibleTrigger>
-        <CollapsibleContent
-          keepMounted
-          className="mt-1 flex max-h-48 flex-col gap-1 overflow-y-auto"
-          data-suno-collection-list="true"
-        >
-          {collections.length === 0 && (
-            <p className="text-xs text-muted-foreground">コレクションなし</p>
-          )}
-          {collections.map((collection) => {
-            const checked = selectedCollectionIds.includes(collection.id);
-            return (
-              <FieldLabel
-                key={collection.id}
-                data-variant={checked ? "secondary" : "outline"}
-                data-size="sm"
-                data-disabled={
-                  controlsLocked || collection.status === "needs_prompts"
-                }
-                className={buttonVariants({
-                  variant: checked ? "secondary" : "outline",
-                  size: "sm",
-                  className:
-                    "h-auto w-full items-start justify-start whitespace-normal p-2",
-                })}
-              >
-                <Checkbox
-                  className="mt-0.5"
-                  checked={checked}
-                  disabled={
-                    controlsLocked || collection.status === "needs_prompts"
-                  }
-                  data-suno-control="collection-checkbox"
-                  aria-label={`${collection.name} を選択`}
-                  onCheckedChange={(nextChecked) =>
-                    toggleCollectionSelection(
-                      collection.id,
-                      nextChecked === true
-                    )
-                  }
-                />
-                <span className="flex flex-col text-left">
-                  <span className="font-medium">{collection.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {collection.status === "downloaded"
-                      ? `完了 ${collection.downloaded_count}/${collection.expected_file_count ?? (collection.pattern_count ?? 0) * 2}`
-                      : collection.status === "ready"
-                        ? `${collection.pattern_count} patterns`
-                        : "prompts なし"}
-                  </span>
-                </span>
-              </FieldLabel>
-            );
-          })}
+        <CollapsibleContent keepMounted>
+          <ScrollArea
+            className="mt-1"
+            viewportClassName="max-h-48"
+            data-suno-collection-list="true"
+          >
+            <div className="flex flex-col gap-1 pr-3">
+              {collections.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  コレクションなし
+                </p>
+              )}
+              {collections.map((collection) => {
+                const checked = selectedCollectionIds.includes(collection.id);
+                return (
+                  <FieldLabel
+                    key={collection.id}
+                    data-variant={checked ? "secondary" : "outline"}
+                    data-size="sm"
+                    data-disabled={
+                      controlsLocked || collection.status === "needs_prompts"
+                    }
+                    className={buttonVariants({
+                      variant: checked ? "secondary" : "outline",
+                      size: "sm",
+                      className:
+                        "h-auto w-full items-start justify-start whitespace-normal p-2",
+                    })}
+                  >
+                    <Checkbox
+                      className="mt-0.5"
+                      checked={checked}
+                      disabled={
+                        controlsLocked || collection.status === "needs_prompts"
+                      }
+                      data-suno-control="collection-checkbox"
+                      aria-label={`${collection.name} を選択`}
+                      onCheckedChange={(nextChecked) =>
+                        toggleCollectionSelection(
+                          collection.id,
+                          nextChecked === true
+                        )
+                      }
+                    />
+                    <span className="flex flex-col text-left">
+                      <span className="font-medium">{collection.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {collection.status === "downloaded"
+                          ? `完了 ${collection.downloaded_count}/${collection.expected_file_count ?? (collection.pattern_count ?? 0) * 2}`
+                          : collection.status === "ready"
+                            ? `${collection.pattern_count} patterns`
+                            : "prompts なし"}
+                      </span>
+                    </span>
+                  </FieldLabel>
+                );
+              })}
+            </div>
+          </ScrollArea>
         </CollapsibleContent>
       </Collapsible>
       <select

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -6,6 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
   FieldLabel,
+  ScrollArea,
 } from "@youtube-automation/ui";
 
 import type { PromptEntry } from "../../shared/api";
@@ -60,53 +61,56 @@ export function PatternList({
         </svg>
       </CollapsibleTrigger>
       <CollapsibleContent keepMounted>
-        <ul
-          className="max-h-48 overflow-y-auto rounded border border-border"
-          data-suno-entry-list="true"
+        <ScrollArea
+          className="rounded border border-border"
+          viewportClassName="max-h-48"
+          data-suno-entry-scroll-area="true"
         >
-          {entries.map((entry, index) => {
-            const itemState = itemStates[index] ?? "idle";
-            const selected = isEntrySelected(
-              selectedEntries,
-              itemStates,
-              index
-            );
-            return (
-              <li
-                key={`${entry.name}-${index}`}
-                className={`p-1 text-sm ${itemState === "done" ? "line-through" : ""}`}
-                data-suno-entry-index={index}
-                data-suno-entry-state={itemState}
-                data-suno-entry-selected={selected ? "true" : "false"}
-              >
-                <FieldLabel
-                  data-variant="outline"
-                  data-size="sm"
-                  className={buttonVariants({
-                    variant: "outline",
-                    size: "sm",
-                    className: `h-auto w-full items-start justify-start whitespace-normal p-2 font-normal ${STATE_CLASS[itemState]} ${SELECTION_CLASS[selected ? "selected" : "unselected"]}`,
-                  })}
+          <ul className="pr-3" data-suno-entry-list="true">
+            {entries.map((entry, index) => {
+              const itemState = itemStates[index] ?? "idle";
+              const selected = isEntrySelected(
+                selectedEntries,
+                itemStates,
+                index
+              );
+              return (
+                <li
+                  key={`${entry.name}-${index}`}
+                  className={`p-1 text-sm ${itemState === "done" ? "line-through" : ""}`}
+                  data-suno-entry-index={index}
+                  data-suno-entry-state={itemState}
+                  data-suno-entry-selected={selected ? "true" : "false"}
                 >
-                  <Checkbox
-                    className="mt-0.5"
-                    checked={selected}
-                    onCheckedChange={(checked) =>
-                      onToggleEntry(index, checked === true)
-                    }
-                    aria-label={`entry ${index + 1}: ${entry.name}`}
-                  />
-                  <span
-                    className="min-w-0 flex-1 text-left"
-                    data-suno-slot="entry-name"
+                  <FieldLabel
+                    data-variant="outline"
+                    data-size="sm"
+                    className={buttonVariants({
+                      variant: "outline",
+                      size: "sm",
+                      className: `h-auto w-full items-start justify-start whitespace-normal p-2 font-normal ${STATE_CLASS[itemState]} ${SELECTION_CLASS[selected ? "selected" : "unselected"]}`,
+                    })}
                   >
-                    {entry.name}
-                  </span>
-                </FieldLabel>
-              </li>
-            );
-          })}
-        </ul>
+                    <Checkbox
+                      className="mt-0.5"
+                      checked={selected}
+                      onCheckedChange={(checked) =>
+                        onToggleEntry(index, checked === true)
+                      }
+                      aria-label={`entry ${index + 1}: ${entry.name}`}
+                    />
+                    <span
+                      className="min-w-0 flex-1 text-left"
+                      data-suno-slot="entry-name"
+                    >
+                      {entry.name}
+                    </span>
+                  </FieldLabel>
+                </li>
+              );
+            })}
+          </ul>
+        </ScrollArea>
       </CollapsibleContent>
     </Collapsible>
   );

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -220,7 +220,9 @@ describe("PatternList checkbox UI", () => {
     );
     expect(list?.tagName).toBe("UL");
     expect(list?.dataset.sunoEntryList).toBe("true");
-    expect(list?.className).toContain("border-border");
+    const scrollArea = list?.closest<HTMLElement>('[data-slot="scroll-area"]');
+    expect(scrollArea?.dataset.sunoEntryScrollArea).toBe("true");
+    expect(scrollArea?.className).toContain("border-border");
     const rows = Array.from(
       container.querySelectorAll<HTMLLIElement>("[data-suno-entry-index]")
     );

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -872,6 +872,16 @@ describe("Suno popup compatibility check", () => {
     );
     expect(collectionsTrigger.textContent).toContain("コレクション (1)");
     expect(entriesTrigger.textContent).toContain("楽曲 (2)");
+    const collectionList = container.querySelector<HTMLElement>(
+      "[data-suno-collection-list]"
+    );
+    const entryList = container.querySelector<HTMLElement>(
+      "[data-suno-entry-list]"
+    );
+    expect(collectionList?.classList).toContain("max-h-48");
+    expect(collectionList?.classList).toContain("overflow-y-auto");
+    expect(entryList?.classList).toContain("max-h-48");
+    expect(entryList?.classList).toContain("overflow-y-auto");
     expect(collectionsTrigger.getAttribute("aria-expanded")).toBe("false");
     expect(entriesTrigger.getAttribute("aria-expanded")).toBe("false");
     await act(async () => {

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -878,10 +878,20 @@ describe("Suno popup compatibility check", () => {
     const entryList = container.querySelector<HTMLElement>(
       "[data-suno-entry-list]"
     );
-    expect(collectionList?.classList).toContain("max-h-48");
-    expect(collectionList?.classList).toContain("overflow-y-auto");
-    expect(entryList?.classList).toContain("max-h-48");
-    expect(entryList?.classList).toContain("overflow-y-auto");
+    const entryScrollArea = container.querySelector<HTMLElement>(
+      "[data-suno-entry-scroll-area]"
+    );
+    expect(collectionList?.dataset.slot).toBe("scroll-area");
+    expect(entryScrollArea?.dataset.slot).toBe("scroll-area");
+    expect(
+      collectionList?.querySelector('[data-slot="scroll-area-viewport"]')
+        ?.classList
+    ).toContain("max-h-48");
+    expect(
+      entryScrollArea?.querySelector('[data-slot="scroll-area-viewport"]')
+        ?.classList
+    ).toContain("max-h-48");
+    expect(entryList?.classList).not.toContain("overflow-y-auto");
     expect(collectionsTrigger.getAttribute("aria-expanded")).toBe("false");
     expect(entriesTrigger.getAttribute("aria-expanded")).toBe("false");
     await act(async () => {

--- a/extensions/suno-helper/tests/ui-foundation.test.tsx
+++ b/extensions/suno-helper/tests/ui-foundation.test.tsx
@@ -21,6 +21,7 @@ import {
   Select,
   SelectTrigger,
   SelectValue,
+  ScrollArea,
 } from "@youtube-automation/ui";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -58,6 +59,20 @@ const sizeMarkers = {
 } as const;
 
 describe("shadcn/ui foundation", () => {
+  it("ScrollArea は Base UI viewport を公開し、viewport class を反映する", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        ScrollArea,
+        { viewportClassName: "max-h-48" },
+        createElement("div", null, "content")
+      )
+    );
+
+    expect(html).toContain('data-slot="scroll-area"');
+    expect(html).toContain('data-slot="scroll-area-viewport"');
+    expect(html).toContain("max-h-48");
+  });
+
   it("cn は条件付き class を連結し、競合する Tailwind class は後勝ちで統合する", () => {
     expect(
       cn("px-2", { hidden: false }, ["font-medium", { block: true }], "px-4")

--- a/tests/test_extensions_shared_ui_contract.py
+++ b/tests/test_extensions_shared_ui_contract.py
@@ -13,6 +13,7 @@ PRIMITIVES = (
     "field.tsx",
     "label.tsx",
     "radio-group.tsx",
+    "scroll-area.tsx",
     "select.tsx",
     "switch.tsx",
 )
@@ -52,6 +53,8 @@ def test_shared_ui_package_owns_public_primitives_and_theme() -> None:
         "OverlayShell",
         "RadioGroup",
         "RadioGroupItem",
+        "ScrollArea",
+        "ScrollBar",
         "Select",
         "Switch",
         "useDraggable",
@@ -138,6 +141,22 @@ def test_shared_collapsible_tracks_current_base_vega_composition() -> None:
     assert "CollapsiblePrimitive.Root.Props" in collapsible
     assert "CollapsiblePrimitive.Trigger.Props" in collapsible
     assert "CollapsiblePrimitive.Panel.Props" in collapsible
+
+
+def test_shared_scroll_area_tracks_current_base_vega_composition() -> None:
+    scroll_area = (EXTENSIONS / "shared-ui/src/scroll-area.tsx").read_text()
+
+    assert 'from "@base-ui/react/scroll-area"' in scroll_area
+    for slot in (
+        "scroll-area",
+        "scroll-area-viewport",
+        "scroll-area-scrollbar",
+        "scroll-area-thumb",
+    ):
+        assert f'data-slot="{slot}"' in scroll_area
+    assert "ScrollAreaPrimitive.Root.Props" in scroll_area
+    assert "ScrollAreaPrimitive.Scrollbar.Props" in scroll_area
+    assert "viewportClassName" in scroll_area
 
 
 def test_shared_switch_tracks_current_light_only_base_vega_composition() -> None:


### PR DESCRIPTION
## 概要

suno-helper overlay のコレクション一覧と楽曲一覧を shared shadcn/ui Scroll Area へ移行します。少件数では自然な高さを保ち、内容が上限を超えた場合は両一覧とも同じ高さで縦スクロールできます。

Closes #2353

## 変更内容

- 公式 Base UI版に沿った `ScrollArea` / `ScrollBar` を shared-ui に追加
- 自然高を保ったまま上限を指定できる `viewportClassName` を共有APIに追加
- コレクション一覧と楽曲一覧の生 `overflow-y-auto` を shared `ScrollArea` に置換
- Root / Viewport / Scrollbar / Thumb と両一覧のDOM契約を回帰テストで固定

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 下流チャンネル向け Migration は不要（拡張 overlay の表示変更のみ）
- [x] 必要なテストを追加・更新した

## 検証

- Vitest: 66 files / 1290 tests passed
- shared-ui contract pytest: 14 passed
- TypeScript compile
- Ultracite check
- WXT production build

## 関連

- #2353
