### PR TITLE
fix(extensions): ブランド primary を指定 OKLCH に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(extensions)`: Suno・DistroKid Helper のヘッダーと primary 系 UI を指定 OKLCH 配色へ統一し、実描画色に対する WCAG AA コントラスト検証を追加（#2352）
+
 - `fix(extensions-ui)`: shared Shadow DOM theme の spacing・typography・radius・responsive token を px 基準へ固定し、ホストページの root font-size が Helper overlay の視認サイズを縮小しないように修正（#2351）
 
 - `fix(suno-helper)`: コレクション一覧と楽曲一覧を shared shadcn/ui Scroll Area へ移行し、件数が多い場合は同じ高さ上限で一覧内を縦スクロールできるようにした（#2353）。

--- a/extensions/community-helper/tests/overlay-component.test.tsx
+++ b/extensions/community-helper/tests/overlay-component.test.tsx
@@ -64,6 +64,8 @@ describe("Community Overlay", () => {
     expect(shell.style.getPropertyValue("--overlay-header-foreground")).toBe(
       "#FFFFFF"
     );
+    expect(shell.style.getPropertyValue("--primary")).toBe("");
+    expect(shell.style.getPropertyValue("--primary-foreground")).toBe("");
     expect(container.querySelector("[data-community-app]")).not.toBeNull();
 
     await act(async () =>

--- a/extensions/distrokid-helper/lib/overlay-brand.ts
+++ b/extensions/distrokid-helper/lib/overlay-brand.ts
@@ -1,7 +1,9 @@
 import type { OverlayBrandColors } from "@youtube-automation/ui";
 
-/** Official DistroKid logo page header colors, verified 2026-07-21. */
+/** User-approved DistroKid overlay identity colors. */
 export const DISTROKID_OVERLAY_BRAND = {
-  headerBackground: "#0073C7",
-  headerForeground: "#FFFFFF",
+  headerBackground: "oklch(0.8703 0.1962 116.38)",
+  headerForeground: "oklch(0.205 0 0)",
+  primary: "oklch(0.8703 0.1962 116.38)",
+  primaryForeground: "oklch(0.205 0 0)",
 } as const satisfies OverlayBrandColors;

--- a/extensions/distrokid-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/overlay-drag.spec.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expect, test, chromium, type BrowserContext } from "@playwright/test";
+import { rgbContrastRatio } from "@youtube-automation/ui";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const extensionPath = join(here, "..", "..", ".output", "chrome-mv3");
@@ -40,8 +41,59 @@ test("実ビルドした DistroKid overlay は drag・最小化・reload 復元�
     const content = page.locator("[data-overlay-content]");
     await expect(shell).toBeVisible();
     await expect(shell).toContainText("DistroKid Helper");
-    await expect(handle).toHaveCSS("background-color", "rgb(0, 115, 199)");
-    await expect(handle).toHaveCSS("color", "rgb(255, 255, 255)");
+    expect(
+      await shell.evaluate((element) => ({
+        headerBackground: element.style.getPropertyValue(
+          "--overlay-header-background"
+        ),
+        headerForeground: element.style.getPropertyValue(
+          "--overlay-header-foreground"
+        ),
+        primary: element.style.getPropertyValue("--primary"),
+        primaryForeground: element.style.getPropertyValue(
+          "--primary-foreground"
+        ),
+      }))
+    ).toEqual({
+      headerBackground: "oklch(0.8703 0.1962 116.38)",
+      headerForeground: "oklch(0.205 0 0)",
+      primary: "oklch(0.8703 0.1962 116.38)",
+      primaryForeground: "oklch(0.205 0 0)",
+    });
+    const paintedColors = await handle.evaluate((element) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext("2d", { willReadFrequently: true })!;
+      const sample = (color: string) => {
+        context.clearRect(0, 0, 1, 1);
+        context.fillStyle = "white";
+        context.fillRect(0, 0, 1, 1);
+        context.fillStyle = color;
+        context.fillRect(0, 0, 1, 1);
+        const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
+        return [red, green, blue] as const;
+      };
+      const style = getComputedStyle(element);
+      return {
+        background: sample(style.backgroundColor),
+        foreground: sample(style.color),
+      };
+    });
+    expect(
+      rgbContrastRatio(paintedColors.background, paintedColors.foreground)
+    ).toBeGreaterThanOrEqual(4.5);
+    const primaryControl = shell.locator("button.bg-primary").first();
+    await expect(primaryControl).toBeVisible();
+    expect(
+      await primaryControl.evaluate(
+        (element) => getComputedStyle(element).backgroundColor
+      )
+    ).toBe(
+      await handle.evaluate(
+        (element) => getComputedStyle(element).backgroundColor
+      )
+    );
 
     const before = await shell.evaluate((element) => ({
       left: element.style.left,

--- a/extensions/distrokid-helper/tests/overlay-brand.test.ts
+++ b/extensions/distrokid-helper/tests/overlay-brand.test.ts
@@ -1,15 +1,14 @@
-import { hexContrastRatio } from "@youtube-automation/ui";
 import { describe, expect, it } from "vitest";
 
 import { DISTROKID_OVERLAY_BRAND } from "../lib/overlay-brand";
 
 describe("DistroKid overlay brand colors", () => {
-  it("meet WCAG AA contrast for normal text", () => {
-    expect(
-      hexContrastRatio(
-        DISTROKID_OVERLAY_BRAND.headerBackground,
-        DISTROKID_OVERLAY_BRAND.headerForeground
-      )
-    ).toBeGreaterThanOrEqual(4.5);
+  it("uses the approved OKLCH color for header and primary", () => {
+    expect(DISTROKID_OVERLAY_BRAND).toEqual({
+      headerBackground: "oklch(0.8703 0.1962 116.38)",
+      headerForeground: "oklch(0.205 0 0)",
+      primary: "oklch(0.8703 0.1962 116.38)",
+      primaryForeground: "oklch(0.205 0 0)",
+    });
   });
 });

--- a/extensions/distrokid-helper/tests/overlay-component.test.tsx
+++ b/extensions/distrokid-helper/tests/overlay-component.test.tsx
@@ -61,10 +61,16 @@ describe("DistroKid Overlay", () => {
     expect(shell.style.top).toBe("50px");
     expect(shell.textContent).toContain("DistroKid Helper");
     expect(shell.style.getPropertyValue("--overlay-header-background")).toBe(
-      "#0073C7"
+      "oklch(0.8703 0.1962 116.38)"
     );
     expect(shell.style.getPropertyValue("--overlay-header-foreground")).toBe(
-      "#FFFFFF"
+      "oklch(0.205 0 0)"
+    );
+    expect(shell.style.getPropertyValue("--primary")).toBe(
+      "oklch(0.8703 0.1962 116.38)"
+    );
+    expect(shell.style.getPropertyValue("--primary-foreground")).toBe(
+      "oklch(0.205 0 0)"
     );
     expect(container.querySelector("[data-distrokid-app]")).not.toBeNull();
 

--- a/extensions/shared-ui/src/color-contrast.ts
+++ b/extensions/shared-ui/src/color-contrast.ts
@@ -1,4 +1,15 @@
-function relativeLuminance(hex: string): number {
+export type RgbColor = readonly [red: number, green: number, blue: number];
+
+function relativeLuminance([red, green, blue]: RgbColor): number {
+  const [linearRed, linearGreen, linearBlue] = [red, green, blue]
+    .map((channel) => channel / 255)
+    .map((channel) =>
+      channel <= 0.040_45 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+    );
+  return 0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue;
+}
+
+function hexToRgb(hex: string): RgbColor {
   const normalized = hex.replace(/^#/, "");
   if (!/^[0-9a-f]{6}$/i.test(normalized)) {
     throw new Error(`6-digit hex color required: ${hex}`);
@@ -6,17 +17,19 @@ function relativeLuminance(hex: string): number {
 
   const [red, green, blue] = normalized
     .match(/.{2}/g)!
-    .map((channel) => Number.parseInt(channel, 16) / 255)
-    .map((channel) =>
-      channel <= 0.040_45 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
-    );
-  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+    .map((channel) => Number.parseInt(channel, 16));
+  return [red, green, blue];
 }
 
-/** WCAG 2.x contrast ratio for two six-digit sRGB hex colors. */
-export function hexContrastRatio(first: string, second: string): number {
+/** WCAG 2.x contrast ratio for two painted sRGB colors. */
+export function rgbContrastRatio(first: RgbColor, second: RgbColor): number {
   const luminances = [relativeLuminance(first), relativeLuminance(second)].sort(
     (left, right) => right - left
   );
   return (luminances[0] + 0.05) / (luminances[1] + 0.05);
+}
+
+/** WCAG 2.x contrast ratio for two six-digit sRGB hex colors. */
+export function hexContrastRatio(first: string, second: string): number {
+  return rgbContrastRatio(hexToRgb(first), hexToRgb(second));
 }

--- a/extensions/shared-ui/src/index.ts
+++ b/extensions/shared-ui/src/index.ts
@@ -40,7 +40,11 @@ export {
   type OverlayBrandColors,
   type OverlayShellProps,
 } from "./overlay-shell";
-export { hexContrastRatio } from "./color-contrast";
+export {
+  hexContrastRatio,
+  rgbContrastRatio,
+  type RgbColor,
+} from "./color-contrast";
 export { RadioGroup, RadioGroupItem } from "./radio-group";
 export { ScrollArea, ScrollBar } from "./scroll-area";
 export {

--- a/extensions/shared-ui/src/overlay-shell.tsx
+++ b/extensions/shared-ui/src/overlay-shell.tsx
@@ -1,6 +1,6 @@
 import { overlayHiddenStyle } from "@youtube-automation/extensions-shared/overlay-state";
 import type { OverlayState } from "@youtube-automation/extensions-shared/overlay-state";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { Button } from "./button";
 import { Card, CardContent, CardHeader } from "./card";
@@ -28,6 +28,31 @@ export interface OverlayBrandColors {
   headerForeground: string;
   primary?: string;
   primaryForeground?: string;
+}
+
+interface OverlayBrandStyle extends CSSProperties {
+  "--overlay-header-background"?: string;
+  "--overlay-header-foreground"?: string;
+  "--primary"?: string;
+  "--primary-foreground"?: string;
+}
+
+function getOverlayBrandStyle(
+  brandColors: OverlayBrandColors | undefined
+): OverlayBrandStyle {
+  if (!brandColors) {
+    return {};
+  }
+  return {
+    "--overlay-header-background": brandColors.headerBackground,
+    "--overlay-header-foreground": brandColors.headerForeground,
+    ...(brandColors.primary && brandColors.primaryForeground
+      ? {
+          "--primary": brandColors.primary,
+          "--primary-foreground": brandColors.primaryForeground,
+        }
+      : {}),
+  };
 }
 
 /**
@@ -66,18 +91,7 @@ export function OverlayShell({
         className
       )}
       style={{
-        ...(brandColors
-          ? {
-              "--overlay-header-background": brandColors.headerBackground,
-              "--overlay-header-foreground": brandColors.headerForeground,
-              ...(brandColors.primary && brandColors.primaryForeground
-                ? {
-                    "--primary": brandColors.primary,
-                    "--primary-foreground": brandColors.primaryForeground,
-                  }
-                : {}),
-            }
-          : {}),
+        ...getOverlayBrandStyle(brandColors),
         left: controller.position.x,
         top: controller.position.y,
         width,

--- a/extensions/shared-ui/src/overlay-shell.tsx
+++ b/extensions/shared-ui/src/overlay-shell.tsx
@@ -26,6 +26,8 @@ export interface OverlayShellProps {
 export interface OverlayBrandColors {
   headerBackground: string;
   headerForeground: string;
+  primary?: string;
+  primaryForeground?: string;
 }
 
 /**
@@ -68,6 +70,12 @@ export function OverlayShell({
           ? {
               "--overlay-header-background": brandColors.headerBackground,
               "--overlay-header-foreground": brandColors.headerForeground,
+              ...(brandColors.primary && brandColors.primaryForeground
+                ? {
+                    "--primary": brandColors.primary,
+                    "--primary-foreground": brandColors.primaryForeground,
+                  }
+                : {}),
             }
           : {}),
         left: controller.position.x,

--- a/extensions/suno-helper/lib/overlay-brand.ts
+++ b/extensions/suno-helper/lib/overlay-brand.ts
@@ -1,7 +1,9 @@
 import type { OverlayBrandColors } from "@youtube-automation/ui";
 
-/** Official Suno site's dark UI base, verified 2026-07-21. */
+/** User-approved Suno overlay identity colors. */
 export const SUNO_OVERLAY_BRAND = {
-  headerBackground: "#101012",
-  headerForeground: "#FFFFFF",
+  headerBackground: "oklch(0.753 0.2067 57.6 / 96.4%)",
+  headerForeground: "oklch(0.205 0 0)",
+  primary: "oklch(0.753 0.2067 57.6 / 96.4%)",
+  primaryForeground: "oklch(0.205 0 0)",
 } as const satisfies OverlayBrandColors;

--- a/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expect, test, chromium, type BrowserContext } from "@playwright/test";
+import { rgbContrastRatio } from "@youtube-automation/ui";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const extensionPath = join(here, "..", "..", ".output", "chrome-mv3");
@@ -43,9 +44,48 @@ test("実ビルドした overlay は drag・最小化・automation selector 契�
     const content = card.locator('[data-slot="card-content"]');
     await expect(card).toBeVisible();
     await expect(header).toHaveClass(/flex-row/);
-    await expect(header).toHaveCSS("background-color", "rgb(16, 16, 18)");
-    await expect(header).toHaveCSS("color", "rgb(255, 255, 255)");
-
+    expect(
+      await card.evaluate((element) => ({
+        headerBackground: element.style.getPropertyValue(
+          "--overlay-header-background"
+        ),
+        headerForeground: element.style.getPropertyValue(
+          "--overlay-header-foreground"
+        ),
+        primary: element.style.getPropertyValue("--primary"),
+        primaryForeground: element.style.getPropertyValue(
+          "--primary-foreground"
+        ),
+      }))
+    ).toEqual({
+      headerBackground: "oklch(0.753 0.2067 57.6 / 96.4%)",
+      headerForeground: "oklch(0.205 0 0)",
+      primary: "oklch(0.753 0.2067 57.6 / 96.4%)",
+      primaryForeground: "oklch(0.205 0 0)",
+    });
+    const paintedColors = await header.evaluate((element) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext("2d", { willReadFrequently: true })!;
+      const sample = (color: string) => {
+        context.clearRect(0, 0, 1, 1);
+        context.fillStyle = "white";
+        context.fillRect(0, 0, 1, 1);
+        context.fillStyle = color;
+        context.fillRect(0, 0, 1, 1);
+        const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
+        return [red, green, blue] as const;
+      };
+      const style = getComputedStyle(element);
+      return {
+        background: sample(style.backgroundColor),
+        foreground: sample(style.color),
+      };
+    });
+    expect(
+      rgbContrastRatio(paintedColors.background, paintedColors.foreground)
+    ).toBeGreaterThanOrEqual(4.5);
     const before = await card.evaluate((element) => ({
       left: element.style.left,
       top: element.style.top,

--- a/extensions/suno-helper/tests/overlay-brand.test.ts
+++ b/extensions/suno-helper/tests/overlay-brand.test.ts
@@ -1,15 +1,14 @@
-import { hexContrastRatio } from "@youtube-automation/ui";
 import { describe, expect, it } from "vitest";
 
 import { SUNO_OVERLAY_BRAND } from "../lib/overlay-brand";
 
 describe("Suno overlay brand colors", () => {
-  it("meet WCAG AA contrast for normal text", () => {
-    expect(
-      hexContrastRatio(
-        SUNO_OVERLAY_BRAND.headerBackground,
-        SUNO_OVERLAY_BRAND.headerForeground
-      )
-    ).toBeGreaterThanOrEqual(4.5);
+  it("uses the approved OKLCH color for header and primary", () => {
+    expect(SUNO_OVERLAY_BRAND).toEqual({
+      headerBackground: "oklch(0.753 0.2067 57.6 / 96.4%)",
+      headerForeground: "oklch(0.205 0 0)",
+      primary: "oklch(0.753 0.2067 57.6 / 96.4%)",
+      primaryForeground: "oklch(0.205 0 0)",
+    });
   });
 });

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -144,10 +144,16 @@ describe("Overlay shell", () => {
     expect(card.style.top).toBe("50px");
     expect(header.className.split(" ")).toContain("flex-row");
     expect(card.style.getPropertyValue("--overlay-header-background")).toBe(
-      "#101012"
+      "oklch(0.753 0.2067 57.6 / 96.4%)"
     );
     expect(card.style.getPropertyValue("--overlay-header-foreground")).toBe(
-      "#FFFFFF"
+      "oklch(0.205 0 0)"
+    );
+    expect(card.style.getPropertyValue("--primary")).toBe(
+      "oklch(0.753 0.2067 57.6 / 96.4%)"
+    );
+    expect(card.style.getPropertyValue("--primary-foreground")).toBe(
+      "oklch(0.205 0 0)"
     );
     expect(header.style.pointerEvents).toBe("auto");
     expect(content.style.pointerEvents).toBe("auto");


### PR DESCRIPTION
Closes #2352

## 概要
- Suno / DistroKid のヘッダーと primary / primary-foreground を指定 OKLCH token へ統一
- OverlayShell からサービス別 semantic token を注入し、Community は従来値を維持
- Chromium の実描画RGBで alpha 合成後の WCAG AA 4.5:1 を検証

## 公式資料
- shadcn/ui Theming: https://ui.shadcn.com/docs/theming
- MDN oklch(): https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch
- W3C WCAG 1.4.3: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum

## 検証
- 3 helpers: check / compile / unit / build / Playwright E2E
- shared UI contract tests: 49 passed