### PR TITLE
[suno-helper] 投入方式の選択中カードを黒文字にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 投入方式の選択中カードでタイトルと説明文を黒い foreground 色へ戻し、青いラジオボタン・枠・淡い背景による選択表示は維持（#2364）
+
 - `refactor(extensions-ui)`: 3 helper の手組みフォーム・空状態・警告・確認 UI を公式 shadcn/ui Base UI の Field / Input / Select / Alert / AlertDialog / Empty / ScrollArea へ移行し、ShadowRoot portal・最前面表示・選択前の配信元更新・既存 data / ARIA 契約を維持（#2360）
 
 - `fix(extensions)`: Suno・DistroKid Helper のヘッダーと primary 系 UI を指定 OKLCH 配色へ統一し、実描画色に対する WCAG AA コントラスト検証を追加（#2352）

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -599,7 +599,7 @@ export function App() {
                     }),
                     "h-auto w-full justify-start whitespace-normal p-2",
                     selected &&
-                      "bg-info-background/40 hover:bg-info-background/60"
+                      "bg-info-background/40 text-foreground hover:bg-info-background/60"
                   )}
                 >
                   <RadioGroupItem
@@ -614,9 +614,7 @@ export function App() {
                       data-suno-slot="run-mode-description"
                       className={cn(
                         "text-xs",
-                        selected
-                          ? "text-info-foreground"
-                          : "text-muted-foreground"
+                        selected ? "text-foreground" : "text-muted-foreground"
                       )}
                     >
                       {mode.riskNote}

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -591,12 +591,16 @@ describe("Suno popup compatibility check", () => {
       '[data-slot="field-label"]'
     )!;
     expect(Array.from(selectedModeCard.classList)).toEqual(
-      expect.arrayContaining(["border-info-border", "bg-info-background/40"])
+      expect.arrayContaining([
+        "border-info-border",
+        "bg-info-background/40",
+        "text-foreground",
+      ])
     );
     expect(
       selectedModeCard.querySelector('[data-suno-slot="run-mode-description"]')
         ?.classList
-    ).toContain("text-info-foreground");
+    ).toContain("text-foreground");
     expectShadcnControl(
       queueMode.closest<HTMLElement>('[data-slot="field-label"]')!,
       "outline",
@@ -606,6 +610,7 @@ describe("Suno popup compatibility check", () => {
       '[data-slot="field-label"]'
     )!;
     expect(unselectedModeCard.classList).not.toContain("bg-info-background/40");
+    expect(unselectedModeCard.classList).not.toContain("text-foreground");
     expect(
       unselectedModeCard.querySelector(
         '[data-suno-slot="run-mode-description"]'
@@ -1304,15 +1309,34 @@ describe("Suno popup compatibility check", () => {
       "field-label"
     );
     expect(
-      radioByLabel(container, "高速モード").closest<HTMLElement>(
-        '[data-slot="field-label"]'
-      )?.classList
-    ).toContain("bg-info-background/40");
+      Array.from(
+        radioByLabel(container, "高速モード").closest<HTMLElement>(
+          '[data-slot="field-label"]'
+        )?.classList ?? []
+      )
+    ).toEqual(
+      expect.arrayContaining(["bg-info-background/40", "text-foreground"])
+    );
     expect(
       radioByLabel(container, "安全モード").closest<HTMLElement>(
         '[data-slot="field-label"]'
       )?.classList
     ).not.toContain("bg-info-background/40");
+    expect(
+      radioByLabel(container, "安全モード").closest<HTMLElement>(
+        '[data-slot="field-label"]'
+      )?.classList
+    ).not.toContain("text-foreground");
+    expect(
+      radioByLabel(container, "高速モード")
+        .closest<HTMLElement>('[data-slot="field-label"]')
+        ?.querySelector('[data-suno-slot="run-mode-description"]')?.classList
+    ).toContain("text-foreground");
+    expect(
+      radioByLabel(container, "安全モード")
+        .closest<HTMLElement>('[data-slot="field-label"]')
+        ?.querySelector('[data-suno-slot="run-mode-description"]')?.classList
+    ).toContain("text-muted-foreground");
 
     messagingMocks.sendMessage.mockClear();
     await act(async () => {


### PR DESCRIPTION
## Summary
- 選択中の投入方式カードに semantic `text-foreground` を適用し、タイトルを黒系の文字色へ変更
- 選択中の説明文も `text-foreground`、未選択時は従来の `text-muted-foreground` を維持
- 青い radio・枠・淡い背景と、keyboard / pointer 切替時の追従を popup compatibility test で固定

## Official docs
- shadcn/ui Field choice card composition
- shadcn/ui / Base UI Radio Group behavior

## Verification
- `nix develop .#extensions --command pnpm -C extensions/suno-helper check`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper compile`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper test` (66 files / 1290 tests)
- `nix develop .#extensions --command pnpm -C extensions/suno-helper build`

Closes #2364
