### PR TITLE
[suno-helper] 投入方式の選択ラジオを primary 色へ統一する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `fix(suno-helper)`: 投入方式の選択中カードでタイトルと説明文を黒い foreground 色へ戻し、青いラジオボタン・枠・淡い背景による選択表示は維持（#2364）
+- `fix(suno-helper)`: 投入方式の選択 radio に残っていた青い info 色の override を撤去し、枠と中央ドットが overlay の primary ブランド色へ追従するように統一（#2366）
+
+- `fix(suno-helper)`: 投入方式の選択中カードでタイトルと説明文を黒い foreground 色へ戻し、枠・淡い背景による選択表示は維持（#2364）
 
 - `refactor(extensions-ui)`: 3 helper の手組みフォーム・空状態・警告・確認 UI を公式 shadcn/ui Base UI の Field / Input / Select / Alert / AlertDialog / Empty / ScrollArea へ移行し、ShadowRoot portal・最前面表示・選択前の配信元更新・既存 data / ARIA 契約を維持（#2360）
 

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -604,7 +604,7 @@ export function App() {
                 >
                   <RadioGroupItem
                     value={id}
-                    className="mt-1 data-checked:border-info-foreground data-checked:text-info-foreground"
+                    className="mt-1"
                     aria-label={mode.label}
                     data-suno-control="run-mode"
                   />

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -558,10 +558,13 @@ describe("Suno popup compatibility check", () => {
     expect(queueMode.hasAttribute("data-checked")).toBe(false);
     for (const radio of [serialMode, queueMode]) {
       expect(Array.from(radio.classList)).toEqual(
-        expect.arrayContaining([
-          "data-checked:border-info-foreground",
-          "data-checked:text-info-foreground",
-        ])
+        expect.arrayContaining(["data-checked:border-primary", "text-primary"])
+      );
+      expect(radio.classList).not.toContain(
+        "data-checked:border-info-foreground"
+      );
+      expect(radio.classList).not.toContain(
+        "data-checked:text-info-foreground"
       );
       expect(radio.classList).not.toContain("data-checked:bg-primary");
     }


### PR DESCRIPTION
## Summary
- 投入方式の RadioGroupItem に残っていた checked 時の info 色 override を撤去
- shared shadcn RadioGroup の `text-primary` / `data-checked:border-primary` を利用し、Suno overlay のブランド primary 色へ追従
- カードの info 枠・淡い背景・黒文字と、radio の非塗りつぶし表示を維持

## Official docs
- shadcn/ui Base UI Radio Group の composition / choice card / fieldset 契約を確認

## Verification
- `nix develop .#extensions --command pnpm -C extensions/suno-helper check`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper compile`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper test` (66 files / 1290 tests)
- `nix develop .#extensions --command pnpm -C extensions/suno-helper build`

Closes #2366
