### PR TITLE
fix(automation-schedule): ネイティブschedulerを既定化する

### DIFF
--- a/.claude/skills/automation-schedule/SKILL.md
+++ b/.claude/skills/automation-schedule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automation-schedule
-description: "Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Claude Code / Codex の定期実行ジョブを作成・更新・確認・停止するとき。「定期実行」「スケジュール設定」「自動で回して」「automation-schedule」で発動。automation のリリース追従は /automation-update、本体リリースは /automation-release、制作を手動で一段進めるのは /wf-next"
+description: "Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。「定期実行」「スケジュール設定」「自動で回して」「automation-schedule」で発動。automation のリリース追従は /automation-update、本体リリースは /automation-release、制作を手動で一段進めるのは /wf-next"
 ---
 
 ## 前後工程
@@ -10,105 +10,121 @@ description: "Use when チャンネルの定期制作スケジュール（workfl
 
 ## Overview
 
-チャンネルごとの定期制作設定（`config/channel/workflow.json` の `scheduled_automation`）を単一入口で管理する。前提診断 → config 生成（dry-run 差分）→ スケジューラージョブの作成・更新 → 状態確認・停止までを一度の対話で行う。スケジュール実装は実行環境別アダプタ（macOS: launchd / その他: cron）に分離し、実行環境は Claude Code（`claude -p`）または Codex（`codex exec`）を使う。
+`config/channel/workflow.json::workflow.scheduled_automation` を製品非依存の単一ソースとして、実行中製品のネイティブ scheduler に登録する。Codex は Scheduled Task、Claude は依存性に応じて `/schedule` Cloud Job または Cowork local Scheduled Task を使う。launchd / cron は明示承認された fallback に限る。
 
 ## Hard Gates
 
-1. **外部公開許可（`allow_external_publish: true`）の有効化は明示承認なしに絶対に行わない。** 有効化する前に、対象チャンネル名・頻度（run_time / cadence / timezone）・「定期実行が人手確認なしで YouTube へアップロード・公開する」影響を表示し、AskUserQuestion で「有効化する / しない（既定）」の 2 択を取る。承認が得られない・質問できない・ユーザーが言及していない、のいずれの場合も `false` のままにする。`schedule_config.py generate` へ `--allow-external-publish` を付けるのはこの承認を得た後だけ。
-2. **config 書き込みとジョブ作成は差分提示 → 承認後。** `generate --dry-run` の差分と `install` で作成・更新されるジョブ内容（label / 時刻 / 曜日 / runtime）を表示し、AskUserQuestion で「適用する / 中止」の 2 択を取ってから実行する。dry-run のみの依頼なら書き込み・ジョブ作成を一切行わない。
-3. **前提診断が fail のまま進まない。** Step 0 の `detect_runtime.sh` が exit 0 でなければ、fail 行の対処（`/setup` / `/channel-new` / CLI インストール）を案内して停止する。
-4. **重複ジョブを作らない。** ジョブは `scheduler_job.sh` 経由でのみ作成・更新する（同一 label 上書きで冪等）。launchctl / crontab を直接叩いてジョブを追加しない。
+1. **`allow_external_publish: true` は明示承認なしに有効化しない。** 対象・頻度・YouTube 書き込みの影響を表示し、「有効化する / しない（既定）」を確認する。
+2. **config と外部 scheduler は dry-run 提示・承認後だけ変更する。** config diff と `schedule_backend.py plan` の全項目を先に表示する。
+3. **ローカル依存を Cloud Job へ登録しない。** ローカルファイル、OAuth、Chrome、Suno Helper、ffmpeg、ローカル media のいずれかが必要なら `local`。対応する local Scheduled Task が利用不能なら停止する。
+4. **OS fallback は自動選択しない。** 理由・常時起動要件・製品側の履歴/停止UIを使えない制約を示し、明示承認後だけ `--confirm-os-fallback` を使う。
+5. **同一チャンネルに複数 backend を作らない。** `schedule_backend.py show/guard` で active backend を確認し、切替時は旧 backend を先に disable する。外部登録成功後だけ ID を `record` する。
+6. Step 0 の `fail` が残る場合は停止する。認証操作だけは人間に依頼し、コマンド実行・設定作成は AI が行う。
 
-## 完了条件
+## Backend selection
 
-- `setup` / `update`: `scheduler_job.sh status` で config（enabled=true）とジョブ登録の両方が確認できる
-- `status`: config とジョブの現在状態が表示されている
-- `disable`: ジョブが削除され、（ユーザーが望む場合）config も `enabled: false` になっている
+| 実行製品 / 依存 | backend | 登録・管理 |
+|---|---|---|
+| Codex（cloud / local） | `codex-automation` | ChatGPT desktop/web の Scheduled。local は desktop の local project を必須にする |
+| Claude + cloud 完結 | `claude-code-cloud` | Claude Code `/schedule` Cloud Job |
+| Claude + local 依存 | `claude-cowork-local` | Cowork Scheduled で対象 folder を選ぶ。local 実行可否を登録前に確認する |
+| ネイティブ利用不能 + 明示承認 | `os-fallback` | `scheduler_job.sh` の launchd / cron |
 
-## When to Use
-
-- 「このチャンネルを定期的に自動で進めたい」「毎朝 /wf-next を回して」→ setup
-- 「定期実行の状態を見たい」→ `/automation-schedule status`
-- 「定期実行を止めて」→ `/automation-schedule disable`
-- 制作を今すぐ一段進めるだけなら /wf-next（本スキルは起動の定期化のみを担う）
-- 制作〜公開を継続する既定 target_workflow は automation-run。旧来の一段実行を定期化する場合だけ `--target-workflow wf-next` を明示する
+Claude Code `/loop` は最長 3 日の一時反復専用で、永続スケジュールには使わない。
 
 ## References
 
 | ファイル | 役割 |
 |---|---|
-| `references/detect_runtime.sh` | 前提診断（config / uv / claude・codex CLI / launchd・cron / 認証 / 通知） |
-| `references/schedule_config.py` | `scheduled_automation` の表示（show）・生成・差分更新（generate、loader と同一検証） |
-| `references/scheduler_job.sh` | ジョブの install / status / disable（launchd or cron、同一 label で冪等） |
-| `references/run_scheduled.sh` | ジョブから起動される実行ラッパー（enabled 確認・lock・retry・外部反映ガード・通知） |
+| `references/detect_runtime.sh` | config / uv / 実行中製品 / native 管理面 / OS fallback 可否の診断 |
+| `references/schedule_config.py` | `scheduled_automation` の show / generate / dry-run |
+| `references/schedule_backend.py` | 4 backend の plan、重複防止、外部 ID のローカル記録 |
+| `references/scheduler_job.sh` | 明示選択された OS fallback 専用の install / status / disable |
+| `references/run_scheduled.sh` | OS fallback 専用ラッパー。外部公開ゲート・lock・retry・通知を維持 |
 
-設定スキーマの正は `src/youtube_automation/utils/config/workflow.py::ScheduledAutomation`（未設定チャンネルは `enabled: false` で挙動不変）。
+設定スキーマの正は `src/youtube_automation/utils/config/workflow.py::ScheduledAutomation`。
 
-## Task
+## Task: setup / update
 
 すべてチャンネルリポジトリ直下で実行する。
 
-### Step 0. 前提診断
+### Step 0. 診断と backend 決定
 
 ```bash
 bash .claude/skills/automation-schedule/references/detect_runtime.sh
+uv run python .claude/skills/automation-schedule/references/schedule_backend.py show
 ```
 
-- exit 0 以外（fail 行あり）→ 各 fail 行の detail に書かれた対処を案内して**停止**（Hard Gate 3）
-- warn 行は続行可。ただし `runtime-claude` / `runtime-codex` の ok が付いた方を Step 3 の `--runtime` に使う（両方 ok ならユーザーに選択を聞く）
+1. `product-codex` / `product-claude` を既定候補にする。判定不能時だけユーザーに製品を確認する。
+2. 対象 workflow の依存を `cloud` / `local` に分類し、分類根拠を表示する。既定 `automation-run` は local（Chrome / OAuth / media / ffmpeg を利用）として扱う。
+3. active な別 backend があれば、旧 backend の disable が承認・成功するまで停止する。
 
-### Step 1. 現状確認と設定案の提示（dry-run）
+### Step 1. config と native task の dry-run
 
 ```bash
 uv run python .claude/skills/automation-schedule/references/schedule_config.py show
 uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --dry-run --enable \
-  --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] [--target-workflow automation-run] \
-  [--max-retries <N>] [--retry-delay-seconds <N>] [--notification terminal|none]
+  --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
+  [--target-workflow automation-run] [--max-retries <N>] \
+  [--retry-delay-seconds <N>] [--notification terminal|none]
+uv run python .claude/skills/automation-schedule/references/schedule_backend.py plan \
+  --product <codex|claude> --dependency-mode <cloud|local> \
+  --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
+  [--target-workflow automation-run] [--max-retries <N>] \
+  [--retry-delay-seconds <N>] [--notification terminal|none]
 ```
 
-- 時刻・曜日はユーザーの依頼から決める。指定がなければ聞く（勝手に決めない）
-- 差分（unified diff）をそのまま表示する
-- `--allow-external-publish` はここでは**付けない**（既定 false。付けるのは Step 2 の承認後だけ）
+時刻・曜日が未指定なら確認し、勝手に決めない。config dry-run と `plan` へ同じ候補値を渡す。`plan` は JSON を表示するだけで config / OS / 外部状態を変更しない。外部公開承認前は `--allow-external-publish` を付けない。
 
-### Step 2. 承認と config 書き込み
+### Step 2. 承認後に config を書く
 
-1. Step 1 の差分を提示し、AskUserQuestion で「適用する / 中止」を確認する（Hard Gate 2）
-2. ユーザーが外部公開（自動アップロード）も望む場合のみ: 対象チャンネル・頻度・「定期実行が人手確認なしで YouTube に書き込む（公開は取消不可）」を表示し、AskUserQuestion で有効化の明示 2 択を取る（Hard Gate 1）
-3. 承認された内容で書き込む（`--dry-run` を外し、承認された場合のみ `--allow-external-publish` を付与）
+Step 1 の config diff、backend、title、prompt、cwd、timezone、RRULE、依存分類を表示して適用確認を取る。外部公開も明示承認された場合だけ `--allow-external-publish` を付け、`schedule_config.py generate` を実行する。
 
-### Step 3. ジョブ作成・更新
+### Step 3. 選択 backend へ作成または更新
+
+まず次を実行し、別 backend が active なら登録しない。
 
 ```bash
-bash .claude/skills/automation-schedule/references/scheduler_job.sh install --runtime <claude|codex>
+uv run python .claude/skills/automation-schedule/references/schedule_backend.py guard --backend <backend>
 ```
 
-- 同一チャンネルの再実行は同一 label の上書き = 既存ジョブの更新。重複作成されない
-- timezone とシステム TZ が異なる場合は warn が出る。その場合はシステム TZ の壁時計で動くことをユーザーに伝える
+- `codex-automation`: Codex/ChatGPT の Scheduled Task 管理 capability を使う。CLI の `codex exec` や launchd / cron は使わない。local 依存では desktop local project と cwd を指定する。同じ external ID があれば更新する。
+- `claude-code-cloud`: `plan` の prompt と schedule で `/schedule` Cloud Job を作成/更新する。local 依存が判明したら中止する。
+- `claude-cowork-local`: Cowork Scheduled Task に local folder を指定して作成/更新する。製品側で local folder 実行を選べない場合は中止する。
+- `os-fallback`: ネイティブが使えない理由と制約を提示して別途承認を取り、次だけを実行する。
+
+```bash
+bash .claude/skills/automation-schedule/references/scheduler_job.sh install \
+  --backend os-fallback --confirm-os-fallback --runtime <claude|codex>
+```
+
+ネイティブ登録が成功した後だけ、返された不変 ID を記録する。
+
+```bash
+uv run python .claude/skills/automation-schedule/references/schedule_backend.py record \
+  --backend <backend> --external-id <product-task-id>
+```
 
 ### Step 4. 検証
 
-```bash
-bash .claude/skills/automation-schedule/references/scheduler_job.sh status
-```
+`schedule_backend.py show` で backend / external ID を確認し、**同じ backend の製品管理面**で status・次回実行・cadence を確認する。config が `enabled=true` で、別 backend に同名 task がないことまで確認して完了。
 
-config（enabled=true）とジョブ登録の両方が表示されることを確認して完了報告する。
+## status
 
-## サブコマンド
+1. `schedule_backend.py show` と `schedule_config.py show` を実行する。
+2. active backend と external ID を使い、その製品の Scheduled 管理面で状態・次回実行・直近結果を取得する。
+3. state が `unconfigured` なら、製品側を job key `youtube-automation:<channel-dir>` で検索する。見つけても勝手に再作成せず、record の承認を取る。
+4. `os-fallback` の場合だけ `scheduler_job.sh status --backend os-fallback` を使う。
 
-### `/automation-schedule status`
+## disable
 
-Step 0 の診断は省略してよい。`scheduler_job.sh status` の結果（effective config / ジョブ登録 / 直近ログ）を要約して報告する。
+1. status を提示して停止確認を取る。
+2. active backend の external ID を指定し、製品の Scheduled 管理面で pause/delete する。別 backend は触らない。
+3. 外部停止成功後に `schedule_backend.py disable --backend <backend>` を実行する。OS の場合だけ `scheduler_job.sh disable --backend os-fallback` が外部停止と state 更新を担う。
+4. 希望された場合のみ `schedule_config.py generate --disable` で config も無効化する。
 
-### `/automation-schedule disable`
+## Safety contract
 
-1. `scheduler_job.sh status` で現状を表示し、AskUserQuestion で「停止する / 中止」を確認する
-2. 承認後: `bash .claude/skills/automation-schedule/references/scheduler_job.sh disable`
-3. config 側も無効化するか聞き、望まれたら `schedule_config.py generate --disable` を実行する（ジョブ削除だけでも、`run_scheduled.sh` は `enabled: false` を見て何もしないため安全側に倒れる）
-
-## Gotchas
-
-- 未設定チャンネル（`scheduled_automation` なし）は定期実行も外部反映も一切有効にならない。本スキルを実行するまで挙動は変わらない
-- `run_scheduled.sh` は `prevent_concurrent_runs: true` のとき lock（`.automation-schedule/lock/`）で並行起動を抑止する。前回実行が異常終了で lock が残っても、pid 死活確認で stale lock は自動回収される
-- `allow_external_publish: false` の定期実行は、実行プロンプトに「YouTube への書き込みを実行せず直前で停止する」制約を必ず注入する。ゲートは config 値が単一ソースであり、プロンプト側だけの書き換えで外さない
-- 実行ログは `.automation-schedule/logs/` に残る。失敗調査はここから読む（全文を会話に貼らない）
-- 既定の定期 `/automation-run` は Suno 工程で `/suno-helper` の定期実行 flow と `yt-suno-unattended-request` を使う。既ログイン Chrome は前提とし、ログイン・CAPTCHA・課金確認・UI 非互換の `manual-intervention` は自動突破せず通知して停止する
+- native task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`automation-run` の lease、状態再評価、重複 upload 防止は変更しない。
+- retry は backend の再実行機能が契約を満たす場合のみ native 側へ写像する。満たさない場合は prompt 内で `max_retries` / `retry_delay_seconds` を適用する。
+- OS fallback のログは `.automation-schedule/logs/`。ネイティブの履歴は各製品の Scheduled 管理面を正とする。

--- a/.claude/skills/automation-schedule/references/detect_runtime.sh
+++ b/.claude/skills/automation-schedule/references/detect_runtime.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 定期実行の前提診断（/automation-schedule Step 0）（#1892）。
+# ネイティブ定期実行の前提診断（/automation-schedule Step 0）（#1892, #2369）。
 # チャンネルリポジトリ直下で実行し、`ok|fail|warn <check> <detail>` を 1 行ずつ出力する。
 # fail が 1 件でもあれば exit 1（SKILL.md 側はこれを hard gate に使う）。
 set -u
@@ -24,38 +24,30 @@ else
   report fail uv "uv が無い（/setup を実行する）"
 fi
 
-# --- 実行環境（少なくとも一方が必要） ---
-have_runtime=0
-if command -v claude >/dev/null 2>&1; then
-  report ok runtime-claude "claude CLI あり（非対話実行: claude -p）"
-  have_runtime=1
+# --- 実行中製品とネイティブ経路 ---
+if [ -n "${CODEX_THREAD_ID:-}" ]; then
+  report ok product-codex "Codex task を検出。既定 backend: Codex Automation"
+elif [ -n "${CLAUDECODE:-}" ]; then
+  report ok product-claude "Claude Code を検出。依存性に応じて /schedule Cloud Job または Cowork local を選ぶ"
 else
-  report warn runtime-claude "claude CLI が無い"
+  report warn product "実行中製品を自動判定できないため、Codex / Claude をユーザーに確認する"
 fi
-if command -v codex >/dev/null 2>&1; then
-  report ok runtime-codex "codex CLI あり（非対話実行: codex exec）"
-  have_runtime=1
-else
-  report warn runtime-codex "codex CLI が無い"
-fi
-if [ "$have_runtime" -eq 0 ]; then
-  report fail runtime "claude / codex のどちらの CLI も見つからない（いずれかをインストールする）"
-fi
+report warn native-management "ネイティブ scheduler の作成・status・disable は製品の Scheduled 管理機能で行う（CLI で代替しない）"
 
-# --- スケジューラー経路 ---
+# --- OS fallback（利用可能性のみ。自動選択しない） ---
 case "$(uname -s)" in
   Darwin)
     if command -v launchctl >/dev/null 2>&1; then
-      report ok scheduler "launchd（launchctl）利用可"
+      report warn os-fallback "launchd 利用可。明示選択 + --confirm-os-fallback の場合だけ使用"
     else
-      report fail scheduler "launchctl が見つからない"
+      report warn os-fallback "launchctl が見つからない（ネイティブ backend には影響なし）"
     fi
     ;;
   *)
     if command -v crontab >/dev/null 2>&1; then
-      report ok scheduler "cron（crontab）利用可"
+      report warn os-fallback "cron 利用可。明示選択 + --confirm-os-fallback の場合だけ使用"
     else
-      report fail scheduler "crontab が見つからない"
+      report warn os-fallback "crontab が見つからない（ネイティブ backend には影響なし）"
     fi
     ;;
 esac

--- a/.claude/skills/automation-schedule/references/run_scheduled.sh
+++ b/.claude/skills/automation-schedule/references/run_scheduled.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 定期実行の実体ラッパー（scheduler_job.sh が登録するジョブから起動される）（#1892）。
+# OS fallback の実体ラッパー（scheduler_job.sh からだけ起動される）（#1892, #2369）。
 #
 # usage: run_scheduled.sh --channel-dir <path> --runtime claude|codex
 #

--- a/.claude/skills/automation-schedule/references/schedule_backend.py
+++ b/.claude/skills/automation-schedule/references/schedule_backend.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Native scheduler plan and backend identity state for /automation-schedule (#2369)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from youtube_automation.utils.config import channel_dir, load_config
+
+BACKENDS = (
+    "codex-automation",
+    "claude-code-cloud",
+    "claude-cowork-local",
+    "os-fallback",
+)
+PRODUCTS = ("codex", "claude")
+DEPENDENCY_MODES = ("cloud", "local")
+
+
+class BackendError(ValueError):
+    """Backend selection or state transition is unsafe."""
+
+
+def select_backend(*, product: str, dependency_mode: str, os_fallback: bool = False) -> str:
+    """Select the native backend; OS fallback is never selected implicitly."""
+    if os_fallback:
+        return "os-fallback"
+    if product == "codex":
+        return "codex-automation"
+    if product == "claude" and dependency_mode == "cloud":
+        return "claude-code-cloud"
+    if product == "claude" and dependency_mode == "local":
+        return "claude-cowork-local"
+    raise BackendError(f"unsupported product/dependency mode: {product}/{dependency_mode}")
+
+
+def _rrule(run_time: str, cadence: list[str]) -> str:
+    day_map = {
+        "mon": "MO",
+        "tue": "TU",
+        "wed": "WE",
+        "thu": "TH",
+        "fri": "FR",
+        "sat": "SA",
+        "sun": "SU",
+    }
+    hour, minute = (int(part) for part in run_time.split(":", maxsplit=1))
+    days = ",".join(day_map[day] for day in cadence)
+    return f"RRULE:FREQ=WEEKLY;BYDAY={days};BYHOUR={hour};BYMINUTE={minute}"
+
+
+def build_plan(
+    *,
+    product: str,
+    dependency_mode: str,
+    os_fallback: bool = False,
+    overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a product-neutral dry-run payload from effective workflow config."""
+    config = load_config()
+    scheduled = config.workflow.scheduled_automation
+    overrides = overrides or {}
+    run_time = str(overrides.get("run_time") or scheduled.run_time)
+    raw_cadence = overrides.get("cadence") or list(scheduled.cadence)
+    cadence = list(raw_cadence) if not isinstance(raw_cadence, str) else raw_cadence.split(",")
+    target_workflow = str(overrides.get("target_workflow") or scheduled.target_workflow)
+    max_retries = int(overrides.get("max_retries", scheduled.max_retries))
+    retry_delay_seconds = int(overrides.get("retry_delay_seconds", scheduled.retry_delay_seconds))
+    allow_external_publish = bool(overrides.get("allow_external_publish", scheduled.allow_external_publish))
+    backend = select_backend(product=product, dependency_mode=dependency_mode, os_fallback=os_fallback)
+    cwd = channel_dir().resolve()
+    prompt = f"/{target_workflow}"
+    if not allow_external_publish:
+        prompt += "\n\n制約: YouTube への書き込みは実行せず、外部反映を伴うステップの直前で停止して報告する。"
+    if max_retries:
+        prompt += (
+            f"\n\n一時的な失敗では {retry_delay_seconds} 秒待って最大 {max_retries} 回再試行する。"
+            "認証・権限・手動介入が必要な失敗は再試行せず停止して報告する。"
+        )
+    plan: dict[str, object] = {
+        "dry_run": True,
+        "backend": backend,
+        "job_key": f"youtube-automation:{cwd.name}",
+        "title": f"youtube-automation / {cwd.name}",
+        "prompt": prompt,
+        "cwd": str(cwd),
+        "timezone": str(overrides.get("timezone") or scheduled.timezone),
+        "recurrence": _rrule(run_time, cadence),
+        "dependency_mode": dependency_mode,
+        "target_workflow": target_workflow,
+        "max_retries": max_retries,
+        "retry_delay_seconds": retry_delay_seconds,
+        "prevent_concurrent_runs": scheduled.prevent_concurrent_runs,
+        "notification": overrides.get("notification", scheduled.notification),
+        "allow_external_publish": allow_external_publish,
+    }
+    if backend == "codex-automation":
+        plan["management"] = "ChatGPT desktop/web Scheduled; local dependencies require desktop local project"
+    elif backend == "claude-code-cloud":
+        plan["management"] = "Claude Code /schedule Cloud Job"
+    elif backend == "claude-cowork-local":
+        plan["management"] = "Claude Cowork Scheduled task with the local folder selected"
+    else:
+        plan["management"] = "scheduler_job.sh explicit launchd/cron fallback"
+        plan["warning"] = "OS fallback requires explicit user selection and --confirm-os-fallback"
+    return plan
+
+
+def default_state_path(channel_root: Path) -> Path:
+    """Keep machine-specific backend identity in git metadata, never tracked files."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", "youtube-automation-schedule.json"],
+        cwd=channel_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        path = Path(result.stdout.strip())
+        return path if path.is_absolute() else channel_root / path
+    digest = hashlib.sha256(str(channel_root.resolve()).encode()).hexdigest()[:16]
+    return Path.home() / ".local" / "state" / "youtube-automation" / f"schedule-{digest}.json"
+
+
+def read_state(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise BackendError(f"backend state must be an object: {path}")
+    return payload
+
+
+def ensure_backend_available(path: Path, *, backend: str) -> dict[str, object]:
+    """Reject a second active backend before any external scheduler mutation."""
+    current = read_state(path)
+    if current and current.get("status") == "active" and current.get("backend") != backend:
+        raise BackendError(f"active backend {current.get('backend')} exists; disable it before using {backend}")
+    return current or {"status": "available", "backend": backend}
+
+
+def record_state(path: Path, *, backend: str, external_id: str, replace_backend: bool = False) -> dict[str, object]:
+    if not replace_backend:
+        ensure_backend_available(path, backend=backend)
+    payload: dict[str, object] = {
+        "backend": backend,
+        "external_id": external_id,
+        "status": "active",
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def disable_state(path: Path, *, backend: str) -> dict[str, object]:
+    current = read_state(path)
+    if current is None:
+        raise BackendError("backend state is not recorded")
+    if current.get("backend") != backend:
+        raise BackendError(f"recorded backend is {current.get('backend')}, not {backend}")
+    current["status"] = "disabled"
+    current["updated_at"] = datetime.now(UTC).isoformat()
+    path.write_text(json.dumps(current, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return current
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--state-path", type=Path, help=argparse.SUPPRESS)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan")
+    plan.add_argument("--product", choices=PRODUCTS, required=True)
+    plan.add_argument("--dependency-mode", choices=DEPENDENCY_MODES, required=True)
+    plan.add_argument("--os-fallback", action="store_true")
+    plan.add_argument("--timezone")
+    plan.add_argument("--run-time")
+    plan.add_argument("--cadence")
+    plan.add_argument("--target-workflow")
+    plan.add_argument("--max-retries", type=int)
+    plan.add_argument("--retry-delay-seconds", type=int)
+    plan.add_argument("--notification")
+    plan.add_argument("--allow-external-publish", action="store_true")
+
+    sub.add_parser("show")
+    guard = sub.add_parser("guard")
+    guard.add_argument("--backend", choices=BACKENDS, required=True)
+    record = sub.add_parser("record")
+    record.add_argument("--backend", choices=BACKENDS, required=True)
+    record.add_argument("--external-id", required=True)
+    record.add_argument("--replace-backend", action="store_true")
+    disable = sub.add_parser("disable")
+    disable.add_argument("--backend", choices=BACKENDS, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = args.channel_dir.resolve()
+    state_path = args.state_path or default_state_path(root)
+    try:
+        if args.command == "plan":
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                payload = build_plan(
+                    product=args.product,
+                    dependency_mode=args.dependency_mode,
+                    os_fallback=args.os_fallback,
+                    overrides={
+                        key: value
+                        for key in (
+                            "timezone",
+                            "run_time",
+                            "cadence",
+                            "target_workflow",
+                            "max_retries",
+                            "retry_delay_seconds",
+                            "notification",
+                            "allow_external_publish",
+                        )
+                        if (value := getattr(args, key)) is not None
+                    },
+                )
+            finally:
+                os.chdir(previous_cwd)
+        elif args.command == "show":
+            payload = read_state(state_path) or {"status": "unconfigured"}
+        elif args.command == "guard":
+            payload = ensure_backend_available(state_path, backend=args.backend)
+        elif args.command == "record":
+            payload = record_state(
+                state_path,
+                backend=args.backend,
+                external_id=args.external_id,
+                replace_backend=args.replace_backend,
+            )
+        else:
+            payload = disable_state(state_path, backend=args.backend)
+    except (BackendError, json.JSONDecodeError, OSError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False, indent=2))
+        return 1
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/automation-schedule/references/scheduler_job.sh
+++ b/.claude/skills/automation-schedule/references/scheduler_job.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# 定期実行ジョブの作成・更新・確認・停止（/automation-schedule Step 3 以降）（#1892）。
+# 明示選択された OS fallback の作成・更新・確認・停止（#1892, #2369）。
 #
-# usage: scheduler_job.sh install|status|disable [--runtime claude|codex]
+# usage: scheduler_job.sh install|status|disable --backend os-fallback [--confirm-os-fallback] [--runtime claude|codex]
 #
 # - macOS: launchd（~/Library/LaunchAgents/<label>.plist）。同一 label を上書きするため
 #   再実行は常に「更新」になり、重複ジョブを作らない。
@@ -12,17 +12,29 @@ set -eu
 COMMAND="${1:-}"
 shift || true
 RUNTIME="claude"
+BACKEND=""
+CONFIRM_OS_FALLBACK=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --runtime) RUNTIME="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
+    --confirm-os-fallback) CONFIRM_OS_FALLBACK=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 case "$COMMAND" in install|status|disable) ;; *)
-  echo "usage: scheduler_job.sh install|status|disable [--runtime claude|codex]" >&2
+  echo "usage: scheduler_job.sh install|status|disable --backend os-fallback [--confirm-os-fallback] [--runtime claude|codex]" >&2
   exit 2
   ;;
 esac
+if [ "$BACKEND" != "os-fallback" ]; then
+  echo "scheduler_job.sh は明示選択された OS fallback 専用です。--backend os-fallback が必要です" >&2
+  exit 2
+fi
+if [ "$COMMAND" = "install" ] && [ "$CONFIRM_OS_FALLBACK" -ne 1 ]; then
+  echo "OS fallback は自動登録しません。制約を提示してユーザー承認後に --confirm-os-fallback を付けてください" >&2
+  exit 2
+fi
 case "$RUNTIME" in claude|codex) ;; *)
   echo "--runtime は claude または codex を指定する（got: $RUNTIME）" >&2
   exit 2
@@ -32,6 +44,7 @@ esac
 CHANNEL_DIR="$(pwd)"
 LABEL="com.youtube-automation.$(basename "$CHANNEL_DIR").schedule"
 RUN_SCRIPT="$CHANNEL_DIR/.claude/skills/automation-schedule/references/run_scheduled.sh"
+BACKEND_SCRIPT="$CHANNEL_DIR/.claude/skills/automation-schedule/references/schedule_backend.py"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 IS_DARWIN=0
 [ "$(uname -s)" = "Darwin" ] && IS_DARWIN=1
@@ -49,6 +62,7 @@ weekday_num() { # launchd/cron 共通: 0=sun .. 6=sat
 }
 
 install_job() {
+  uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" guard --backend os-fallback >/dev/null
   CONFIG_JSON="$(read_config)"
   py() { printf '%s' "$CONFIG_JSON" | uv run python -c "$1"; }
 
@@ -96,16 +110,21 @@ install_job() {
     # 既存ジョブがあれば一度外してから読み直す（同一 label の更新。重複作成しない）
     launchctl bootout "gui/$(id -u)" "$PLIST" 2>/dev/null || true
     launchctl bootstrap "gui/$(id -u)" "$PLIST"
+    uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" record --backend os-fallback --external-id "$LABEL" >/dev/null
     echo "launchd job を作成・更新しました: $LABEL ($RUN_TIME [$CADENCE] runtime=$RUNTIME)"
   else
     CRON_DAYS="$(for day in $CADENCE; do weekday_num "$day"; done | paste -sd, -)"
     CRON_LINE="$((10#$MINUTE)) $((10#$HOUR)) * * $CRON_DAYS /bin/bash $RUN_SCRIPT --channel-dir $CHANNEL_DIR --runtime $RUNTIME # $LABEL"
     (crontab -l 2>/dev/null | grep -vF "# $LABEL"; echo "$CRON_LINE") | crontab -
+    uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" record --backend os-fallback --external-id "$LABEL" >/dev/null
     echo "crontab entry を作成・更新しました: $LABEL"
   fi
 }
 
 status_job() {
+  uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" guard --backend os-fallback >/dev/null
+  echo "--- backend identity ---"
+  uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" show
   echo "--- config (effective) ---"
   read_config
   echo "--- scheduler ---"
@@ -124,6 +143,7 @@ status_job() {
 }
 
 disable_job() {
+  uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" guard --backend os-fallback >/dev/null
   if [ "$IS_DARWIN" -eq 1 ]; then
     launchctl bootout "gui/$(id -u)" "$PLIST" 2>/dev/null || true
     rm -f "$PLIST"
@@ -132,6 +152,7 @@ disable_job() {
     (crontab -l 2>/dev/null | grep -vF "# $LABEL") | crontab -
     echo "crontab entry を削除しました: $LABEL"
   fi
+  uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" disable --backend os-fallback >/dev/null || true
   echo "config 側も無効化する場合: uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --disable"
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `/automation-schedule` の既定登録先を Codex / Claude のネイティブ Scheduled Task へ移し、依存性に応じた Cloud/local 分岐、backend ID による重複防止、明示承認時だけの launchd / cron fallback を追加しました（#2369）。
+
 - `feat(channel-new)`: 承認済み TTP ごとの再生数上位 5 Long VOD から Shorts / live を除外して初期動画尺の min/max を外向き丸めで導出し、根拠提示・ユーザー承認・audio.json 反映・承認済み例外・yt-doctor 完了ゲートを追加（#2368）
 
 - `fix(suno-helper)`: 投入方式の選択 radio に残っていた青い info 色の override を撤去し、枠と中央ドットが overlay の primary ブランド色へ追従するように統一（#2366）

--- a/tests/test_automation_schedule_backends.py
+++ b/tests/test_automation_schedule_backends.py
@@ -1,0 +1,131 @@
+"""Native scheduler backend contract tests (#2369)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_DIR = ROOT / ".claude" / "skills" / "automation-schedule" / "references"
+
+
+def _load_backend_module():
+    path = REFERENCE_DIR / "schedule_backend.py"
+    spec = importlib.util.spec_from_file_location("schedule_backend", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backend = _load_backend_module()
+
+
+@pytest.mark.parametrize(
+    ("product", "dependency_mode", "os_fallback", "expected"),
+    [
+        ("codex", "cloud", False, "codex-automation"),
+        ("codex", "local", False, "codex-automation"),
+        ("claude", "cloud", False, "claude-code-cloud"),
+        ("claude", "local", False, "claude-cowork-local"),
+        ("codex", "local", True, "os-fallback"),
+    ],
+)
+def test_native_backend_selection(product, dependency_mode, os_fallback, expected):
+    assert backend.select_backend(product=product, dependency_mode=dependency_mode, os_fallback=os_fallback) == expected
+
+
+def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypatch):
+    scheduled = SimpleNamespace(
+        target_workflow="automation-run",
+        allow_external_publish=False,
+        timezone="Asia/Tokyo",
+        run_time="09:05",
+        cadence=("mon", "wed", "fri"),
+        max_retries=2,
+        retry_delay_seconds=300,
+        prevent_concurrent_runs=True,
+        notification="terminal",
+    )
+    monkeypatch.setattr(
+        backend,
+        "load_config",
+        lambda: SimpleNamespace(workflow=SimpleNamespace(scheduled_automation=scheduled)),
+    )
+    monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
+
+    plan = backend.build_plan(
+        product="codex",
+        dependency_mode="local",
+        overrides={"run_time": "10:15", "cadence": "tue,thu", "max_retries": 4},
+    )
+
+    assert plan["dry_run"] is True
+    assert plan["backend"] == "codex-automation"
+    assert plan["recurrence"] == "RRULE:FREQ=WEEKLY;BYDAY=TU,TH;BYHOUR=10;BYMINUTE=15"
+    assert "YouTube への書き込みは実行せず" in plan["prompt"]
+    assert plan["cwd"] == str(tmp_path)
+    assert plan["max_retries"] == 4
+    assert plan["retry_delay_seconds"] == 300
+    assert "最大 4 回再試行" in plan["prompt"]
+    assert plan["prevent_concurrent_runs"] is True
+
+
+def test_backend_identity_is_idempotent_and_blocks_duplicates(tmp_path):
+    state_path = tmp_path / "state.json"
+    first = backend.record_state(state_path, backend="codex-automation", external_id="task-1")
+    updated = backend.record_state(state_path, backend="codex-automation", external_id="task-1")
+    assert first["backend"] == updated["backend"] == "codex-automation"
+    assert json.loads(state_path.read_text(encoding="utf-8"))["external_id"] == "task-1"
+
+    with pytest.raises(backend.BackendError, match="disable it before"):
+        backend.ensure_backend_available(state_path, backend="os-fallback")
+    with pytest.raises(backend.BackendError, match="disable it before"):
+        backend.record_state(state_path, backend="claude-code-cloud", external_id="job-2")
+
+
+def test_disable_must_target_recorded_backend(tmp_path):
+    state_path = tmp_path / "state.json"
+    backend.record_state(state_path, backend="claude-cowork-local", external_id="local-1")
+    with pytest.raises(backend.BackendError, match="not os-fallback"):
+        backend.disable_state(state_path, backend="os-fallback")
+    state = backend.disable_state(state_path, backend="claude-cowork-local")
+    assert state["status"] == "disabled"
+
+
+def test_os_scheduler_install_refuses_implicit_fallback():
+    script = REFERENCE_DIR / "scheduler_job.sh"
+    result = subprocess.run(
+        ["bash", str(script), "install", "--backend", "os-fallback", "--runtime", "codex"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "--confirm-os-fallback" in result.stderr
+
+
+def test_skill_covers_native_status_disable_and_local_dependency_gate():
+    skill = (REFERENCE_DIR.parent / "SKILL.md").read_text(encoding="utf-8")
+    for backend_name in backend.BACKENDS:
+        assert backend_name in skill
+    for command in ("setup / update", "status", "disable"):
+        assert command in skill
+    for local_dependency in ("Chrome", "Suno Helper", "ffmpeg", "OAuth"):
+        assert local_dependency in skill
+    assert "/loop" in skill and "最長 3 日" in skill
+    assert "--confirm-os-fallback" in skill
+
+
+def test_runtime_detection_never_promotes_os_scheduler_to_required_native_backend():
+    script = (REFERENCE_DIR / "detect_runtime.sh").read_text(encoding="utf-8")
+    assert "product-codex" in script
+    assert "product-claude" in script
+    assert "report warn os-fallback" in script
+    assert "report fail scheduler" not in script

--- a/tests/test_skill_docs_consistency.py
+++ b/tests/test_skill_docs_consistency.py
@@ -1542,7 +1542,13 @@ def test_automation_schedule_skill_contract() -> None:
     skill = _read(skill_path)
 
     # references 単一ソース化: 本文で参照するスクリプトが実在する
-    for ref in ("detect_runtime.sh", "schedule_config.py", "scheduler_job.sh", "run_scheduled.sh"):
+    for ref in (
+        "detect_runtime.sh",
+        "schedule_config.py",
+        "schedule_backend.py",
+        "scheduler_job.sh",
+        "run_scheduled.sh",
+    ):
         assert ref in skill
         assert (ROOT / ".claude/skills/automation-schedule/references" / ref).exists()
 
@@ -1558,6 +1564,8 @@ def test_automation_schedule_skill_contract() -> None:
 
     # 設定スキーマの正へのポインタ
     assert "ScheduledAutomation" in skill
+    assert "Codex" in skill and "claude-code-cloud" in skill and "claude-cowork-local" in skill
+    assert "--confirm-os-fallback" in skill
 
 
 def test_channel_new_points_scheduled_automation_to_automation_schedule() -> None:


### PR DESCRIPTION
## Summary
- Codex / Claude の実行製品と cloud/local 依存からネイティブ scheduler backend を選ぶ dry-run plan を追加
- backend と external ID を git metadata に保持し、setup/update/status/disable で別 backend の重複を拒否
- launchd / cron を明示承認と --confirm-os-fallback が必須の fallback 専用経路へ変更
- 外部公開ゲート、retry、automation-run の lease / 重複 upload 防止契約を維持

## Official documentation
- OpenAI Scheduled tasks: https://learn.chatgpt.com/docs/automations
- Claude Code scheduled and recurring tasks: https://support.claude.com/en/articles/14554000-claude-code-power-user-tips
- Claude Cowork scheduled tasks: https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork

## Verification
- uv run yt-skills lint automation-schedule automation-run
- uv run ruff check .
- uv run ruff format --check .
- bash -n automation-schedule references
- uv run pytest -n auto (6468 passed)

Closes #2369