### PR TITLE
perf(videoup): overlay encoder選択と計測を追加する

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -231,6 +231,7 @@ effect:
       "position": "W-w-40:40"
     },
     "encoder": {
+      "codec": "libx264",
       "preset": "medium",
       "crf": 20,
       "maxrate": "4M",
@@ -247,6 +248,9 @@ effect:
 - **設定ファイル探索順**: `OVERLAYS_CONFIG` 環境変数 → `CHANNEL_DIR/config/channel/youtube.json` → コレクションディレクトリの祖先探索。
 - **popup 画像探索順**: 絶対パス → `10-assets/<image>` → `<collection-dir>/<image>`。見つからない場合は popup のみスキップして visualizer は実行する。
 - **再エンコード固定**: overlays 経路は `-c:v copy` 不可。`encoder.crf` / `maxrate` / `bufsize` で品質とサイズを制御する（DeepFocus365 で 70 分マスター = 約 1.0 GB / 2 Mbps 実績）。
+- **hardware encode は明示 opt-in**: `encoder.codec: "hardware"` で macOS は `h264_videotoolbox`、対応 NVIDIA 環境は `h264_nvenc` を選ぶ。特定 codec の明示指定も可能。利用不能または 1-frame 起動 probe 失敗時は `libx264` へ戻り、requested / selected と理由をログへ出す。既定は引き続き `libx264`。
+- **codec 固有引数**: `libx264` は preset / CRF、VideoToolbox は bitrate、NVENC は `p5` / CQ を使う。H.264 / yuv420p / profile / maxrate / bufsize / fps の出力契約は共通。
+- **性能を実測してから opt-in**: `VIDEOUP_BENCH_DURATION=60 VIDEOUP_BENCH_RUNS=3 bash .claude/skills/videoup/references/benchmark_overlay_encoders.sh` で同一入力を比較する。#2372 の基準計測は `docs/benchmarks/videoup-overlay-encoder-2026-07-21.md`。
 
 ### Audio visualizer style（#1684）
 

--- a/.claude/skills/videoup/references/benchmark_overlay_encoders.sh
+++ b/.claude/skills/videoup/references/benchmark_overlay_encoders.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Reproducible local benchmark for overlay encoder selection (#2372).
+set -eu
+
+DURATION="${VIDEOUP_BENCH_DURATION:-60}"
+RUNS="${VIDEOUP_BENCH_RUNS:-3}"
+OUTPUT_DIR="${VIDEOUP_BENCH_OUTPUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/videoup-overlay-bench.XXXXXX")}"
+mkdir -p "$OUTPUT_DIR"
+
+FILTER='[1:a]asplit=2[avis_in][aout];[avis_in]showfreqs=mode=bar:s=1280x180:rate=24:fscale=log:win_size=2048:win_func=hann:colors=white,format=rgba,colorchannelmixer=aa=0.85[avis];[0:v]format=yuv420p[bg];[bg][avis]overlay=(W-w)/2:H-h-40:format=auto,format=yuv420p[vout]'
+RESULTS="$OUTPUT_DIR/results.tsv"
+printf 'mode\trun\treal_seconds\tsize_bytes\tcodec\n' > "$RESULTS"
+
+ffmpeg -y -f lavfi -i "sine=frequency=220:sample_rate=48000:duration=${DURATION}" \
+    -c:a pcm_s16le -loglevel error "$OUTPUT_DIR/audio.wav"
+
+encoder_available() {
+    ffmpeg -hide_banner -encoders 2>&1 | grep -q "^ V..... $1 "
+}
+
+run_direct() {
+    local mode="$1" run="$2"
+    local output="$OUTPUT_DIR/${mode}-${run}.mp4" time_file="$OUTPUT_DIR/${mode}-${run}.time"
+    shift 2
+    /usr/bin/time -p -o "$time_file" ffmpeg -y \
+        -f lavfi -i "color=c=0x20252f:s=1920x1080:r=24:d=${DURATION}" \
+        -i "$OUTPUT_DIR/audio.wav" \
+        -filter_complex "$FILTER" -map '[vout]' -map '[aout]' \
+        "$@" -r 24 -c:a aac -b:a 192k -t "$DURATION" \
+        -movflags +faststart -loglevel error "$output"
+    local elapsed size codec
+    elapsed="$(awk '/^real /{print $2}' "$time_file")"
+    size="$(wc -c < "$output" | tr -d ' ')"
+    codec="$(ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 "$output")"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$mode" "$run" "$elapsed" "$size" "$codec" >> "$RESULTS"
+}
+
+run_twostage() {
+    local run="$1"
+    local output="$OUTPUT_DIR/twostage-${run}.mp4" time_file="$OUTPUT_DIR/twostage-${run}.time"
+    local base_elapsed=0
+    if [[ ! -f "$OUTPUT_DIR/base.mp4" ]]; then
+        /usr/bin/time -p -o "$OUTPUT_DIR/base.time" ffmpeg -y \
+            -f lavfi -i "color=c=0x20252f:s=1920x1080:r=24:d=${DURATION}" \
+            -c:v libx264 -preset ultrafast -crf 20 -pix_fmt yuv420p -r 24 -an \
+            -loglevel error "$OUTPUT_DIR/base.mp4"
+        base_elapsed="$(awk '/^real /{print $2}' "$OUTPUT_DIR/base.time")"
+    fi
+    /usr/bin/time -p -o "$time_file" ffmpeg -y -i "$OUTPUT_DIR/base.mp4" \
+        -i "$OUTPUT_DIR/audio.wav" \
+        -filter_complex "$FILTER" -map '[vout]' -map '[aout]' \
+        -c:v libx264 -preset medium -crf 20 -maxrate 4M -bufsize 8M \
+        -profile:v high -pix_fmt yuv420p -r 24 -c:a aac -b:a 192k -t "$DURATION" \
+        -movflags +faststart -loglevel error "$output"
+    local final_elapsed elapsed size codec
+    final_elapsed="$(awk '/^real /{print $2}' "$time_file")"
+    elapsed="$(awk -v base="$base_elapsed" -v final="$final_elapsed" 'BEGIN{printf "%.2f", base + final}')"
+    size="$(wc -c < "$output" | tr -d ' ')"
+    codec="$(ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 "$output")"
+    printf 'twostage\t%s\t%s\t%s\t%s\n' "$run" "$elapsed" "$size" "$codec" >> "$RESULTS"
+}
+
+run=1
+while [[ "$run" -le "$RUNS" ]]; do
+    run_direct baseline "$run" -c:v libx264 -preset medium -crf 20 -maxrate 4M -bufsize 8M -profile:v high -pix_fmt yuv420p
+    run_direct software-veryfast "$run" -c:v libx264 -preset veryfast -crf 20 -maxrate 4M -bufsize 8M -profile:v high -pix_fmt yuv420p
+    if encoder_available h264_videotoolbox; then
+        run_direct h264_videotoolbox "$run" -c:v h264_videotoolbox -b:v 4M -maxrate 4M -bufsize 8M -profile:v high -pix_fmt yuv420p
+        run_direct h264_videotoolbox-speed "$run" -c:v h264_videotoolbox -b:v 4M -maxrate 4M -bufsize 8M -profile:v high -pix_fmt yuv420p -realtime true -prio_speed 1
+    fi
+    if encoder_available h264_nvenc; then
+        run_direct h264_nvenc "$run" -c:v h264_nvenc -preset p5 -cq 20 -b:v 0 -maxrate 4M -bufsize 8M -profile:v high -pix_fmt yuv420p
+    fi
+    run_twostage "$run"
+    run=$((run + 1))
+done
+
+printf '\nresults: %s\n' "$RESULTS"
+cat "$RESULTS"
+
+printf '\nquality against baseline run 2 (SSIM):\n'
+for candidate in "$OUTPUT_DIR"/*-2.mp4; do
+    [[ "$candidate" == "$OUTPUT_DIR/baseline-2.mp4" ]] && continue
+    metric="$(ffmpeg -i "$candidate" -i "$OUTPUT_DIR/baseline-2.mp4" -lavfi ssim -f null - 2>&1 | awk -F'All:' '/SSIM/{split($2,a," "); print a[1]}' | tail -1)"
+    printf '%s\t%s\n' "$(basename "$candidate" .mp4)" "${metric:-unavailable}"
+done

--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -24,6 +24,7 @@
 # v15:   audio_visualizer style presets + runtime-generated masks (#1684)
 # v14.3: audio visualizer の runtime fill と共通 effect を追加 (#1686)
 # v15.1: effect / overlays の短尺プレビューを追加 (#1749)
+# v15.2: overlay H.264 hardware encoder の opt-in 選択と libx264 fallback (#2372)
 #
 # Usage:
 #   bash .claude/skills/videoup/references/generate_videos.sh [--preview [15-30]] <collection-path>
@@ -688,7 +689,7 @@ PROGRESS_FILE="$(mktemp)"
 AV_MASK_DIR=""
 AV_FILL_ASSET="${PROGRESS_FILE}.visualizer-fill.png"
 cleanup_runtime_files() {
-    rm -f "$PROGRESS_FILE" "$AV_FILL_ASSET"
+    rm -f "$PROGRESS_FILE" "$AV_FILL_ASSET" "${PROGRESS_FILE}.encoder-probe.mp4"
     if [[ -n "$AV_MASK_DIR" && -d "$AV_MASK_DIR" ]]; then
         rm -rf "$AV_MASK_DIR"
     fi
@@ -812,6 +813,66 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
     enc_bufsize="$(ov_get '.overlays.encoder.bufsize' '8M')"
     enc_profile="$(ov_get '.overlays.encoder.profile' 'high')"
     enc_framerate="$(ov_get '.overlays.encoder.framerate' '24')"
+
+    ffmpeg_encoder_available() {
+        ffmpeg -hide_banner -encoders 2>&1 | grep -q "^ V..... $1 "
+    }
+
+    requested_enc_codec="$enc_codec"
+    case "$requested_enc_codec" in
+        libx264)
+            ;;
+        hardware)
+            enc_codec=""
+            if [[ "$(uname -s)" == "Darwin" ]] && ffmpeg_encoder_available h264_videotoolbox; then
+                enc_codec="h264_videotoolbox"
+            elif ffmpeg_encoder_available h264_nvenc; then
+                enc_codec="h264_nvenc"
+            elif ffmpeg_encoder_available h264_videotoolbox; then
+                enc_codec="h264_videotoolbox"
+            fi
+            if [[ -z "$enc_codec" ]]; then
+                echo "  WARN: overlay hardware encoder is unavailable; falling back to libx264"
+                enc_codec="libx264"
+            fi
+            ;;
+        h264_videotoolbox|h264_nvenc)
+            if ! ffmpeg_encoder_available "$requested_enc_codec"; then
+                echo "  WARN: requested overlay encoder ${requested_enc_codec} is unavailable; falling back to libx264"
+                enc_codec="libx264"
+            fi
+            ;;
+        *)
+            echo "ERROR: overlays.encoder.codec='${requested_enc_codec}' is invalid (allowed: libx264, hardware, h264_videotoolbox, h264_nvenc)"
+            exit 1
+            ;;
+    esac
+
+    overlay_encoder_args() {
+        case "$1" in
+            h264_videotoolbox)
+                OVERLAY_VIDEO_ENCODER_ARGS=(-c:v h264_videotoolbox -b:v "$enc_maxrate" -maxrate "$enc_maxrate" -bufsize "$enc_bufsize" -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt")
+                ;;
+            h264_nvenc)
+                OVERLAY_VIDEO_ENCODER_ARGS=(-c:v h264_nvenc -preset p5 -cq "$enc_crf" -b:v 0 -maxrate "$enc_maxrate" -bufsize "$enc_bufsize" -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt")
+                ;;
+            *)
+                OVERLAY_VIDEO_ENCODER_ARGS=(-c:v libx264 -preset "$enc_preset" -crf "$enc_crf" -maxrate "$enc_maxrate" -bufsize "$enc_bufsize" -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt")
+                ;;
+        esac
+    }
+    overlay_encoder_args "$enc_codec"
+
+    if [[ "$enc_codec" != "libx264" ]]; then
+        encoder_probe="${PROGRESS_FILE}.encoder-probe.mp4"
+        if ! ffmpeg -y -f lavfi -i "color=c=black:s=1920x1080:r=${enc_framerate}:d=0.1" \
+            "${OVERLAY_VIDEO_ENCODER_ARGS[@]}" -frames:v 1 -an -loglevel error "$encoder_probe"; then
+            echo "  WARN: overlay encoder ${enc_codec} failed to start; falling back to libx264"
+            enc_codec="libx264"
+            overlay_encoder_args "$enc_codec"
+        fi
+    fi
+    echo "  Encoder  : requested=${requested_enc_codec}, selected=${enc_codec}"
 
     # fill 指定時は production CLI で色素材を検証・生成する。未指定なら v13 の
     # colors 経路をそのまま使い、既存 filtergraph を完全に維持する。
@@ -1054,9 +1115,7 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
     ffmpeg -y "${INPUTS[@]}" \
         -filter_complex "$FILTER" \
         -map "[${CURRENT_LABEL}]" -map "$AUDIO_MAP" \
-        -c:v "$enc_codec" -preset "$enc_preset" -crf "$enc_crf" \
-        -maxrate "$enc_maxrate" -bufsize "$enc_bufsize" \
-        -profile:v "$enc_profile" -pix_fmt "$enc_pix_fmt" \
+        "${OVERLAY_VIDEO_ENCODER_ARGS[@]}" \
         -r "$enc_framerate" \
         "${AUDIO_OUT_OPTS[@]}" \
         -t "$video_duration" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `videoup` の overlay H.264 encoder を同一条件で計測し、既定の `libx264` 経路を維持しつつ、VideoToolbox / NVENC の明示 opt-in、codec 固有引数、利用不能・起動失敗時の `libx264` fallback、再現可能な benchmark を追加（#2372）。
+
 - `/automation-schedule` の既定登録先を Codex / Claude のネイティブ Scheduled Task へ移し、依存性に応じた Cloud/local 分岐、backend ID による重複防止、明示承認時だけの launchd / cron fallback を追加しました（#2369）。
 
 - `feat(channel-new)`: 承認済み TTP ごとの再生数上位 5 Long VOD から Shorts / live を除外して初期動画尺の min/max を外向き丸めで導出し、根拠提示・ユーザー承認・audio.json 反映・承認済み例外・yt-doctor 完了ゲートを追加（#2368）

--- a/docs/benchmarks/videoup-overlay-encoder-2026-07-21.md
+++ b/docs/benchmarks/videoup-overlay-encoder-2026-07-21.md
@@ -1,0 +1,39 @@
+# videoup overlay encoder benchmark — 2026-07-21
+
+## Decision
+
+既定の直接 `libx264 medium` 経路を維持する。今回の Apple Silicon 実機では、二段化・software preset 調整・VideoToolbox のいずれも採用基準の wall-clock 20%短縮に達しなかった。hardware encoder は環境差を考慮して明示 opt-in として提供するが、自動有効化しない。
+
+## Environment and reproduction
+
+- Apple Silicon macOS、Homebrew FFmpeg（`libx264` / `h264_videotoolbox` 有効、`h264_nvenc` 非搭載）
+- 1920x1080、24 fps、60秒、H.264 MP4、AAC、`showfreqs` visualizer overlay
+- 各候補3回。wall-clock は `/usr/bin/time -p`、表は中央値
+
+```bash
+VIDEOUP_BENCH_DURATION=60 VIDEOUP_BENCH_RUNS=3 \
+  bash .claude/skills/videoup/references/benchmark_overlay_encoders.sh
+```
+
+比較条件と codec options は [FFmpeg Codecs Documentation](https://ffmpeg.org/ffmpeg-codecs.html) およびローカル build の `ffmpeg -h encoder=<name>` を正とした。
+
+## Results
+
+| Candidate | Median wall | Baseline比 | Size | SSIM vs baseline | Decision |
+|---|---:|---:|---:|---:|---|
+| direct libx264 medium / CRF 20 | 4.04s | baseline | 1,402,435 B | 1.000000 | 維持 |
+| direct libx264 veryfast / CRF 20 | 3.65s | 9.7% faster | 1,464,752 B | 0.999968 | 20%未達、+4.4% size |
+| two-stage cold | 5.18s | 28.2% slower | 1,402,435 B | 1.000000 | 不採用 |
+| two-stage cached median | 4.19s | 3.7% slower | 1,402,435 B | 1.000000 | 不採用。後段全尺 encode が残る |
+| h264_videotoolbox | 6.45s | 59.7% slower | 1,515,101 B | 0.999964 | 自動採用しない |
+| h264_videotoolbox `realtime` + `prio_speed` | 8.16s | 102.0% slower | 1,515,101 B | 0.999964 | 不採用 |
+| h264_nvenc | N/A | N/A | N/A | N/A | この実機の FFmpeg build に encoder なし |
+
+全出力は ffprobe で H.264、1920x1080、24/1 fps、60.000秒、AAC を確認した。10秒地点の三方式を横並びで目視し、visualizer の位置・形状・opacity に差異は認めなかった。
+
+## Production contract
+
+- `overlays.encoder.codec` の既定値は `libx264`。
+- `hardware` は VideoToolbox → NVENC の利用可能な候補を選ぶ。`h264_videotoolbox` / `h264_nvenc` の明示指定も可能。
+- encoder 一覧にない場合、または 1-frame 起動 probe が失敗した場合は実出力前に `libx264` へ fallback する。
+- overlay 無効経路、preview、batch、effect + overlays の filter graph は変更しない。

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -48,6 +48,7 @@ from youtube_automation.utils.config.workflow import (
     Workflow,
 )
 from youtube_automation.utils.config.youtube import (
+    OVERLAY_ENCODER_CODECS,
     AudioVisualizerFill,
     AudioVisualizerGlow,
     AudioVisualizerRounding,
@@ -543,8 +544,13 @@ def _build_overlays(raw: object) -> Overlays:
     enc_raw = raw.get("encoder") or {}
     if not isinstance(enc_raw, dict):
         raise ConfigError(f"overlays.encoder は object でなければなりません（got {type(enc_raw).__name__}）")
+    enc_codec = str(enc_raw.get("codec", "libx264"))
+    if enc_codec not in OVERLAY_ENCODER_CODECS:
+        raise ConfigError(
+            f"overlays.encoder.codec='{enc_codec}' は不正です（有効値: {', '.join(OVERLAY_ENCODER_CODECS)}）"
+        )
     encoder = OverlayEncoder(
-        codec=str(enc_raw.get("codec", "libx264")),
+        codec=enc_codec,
         preset=str(enc_raw.get("preset", "medium")),
         crf=int(enc_raw.get("crf", 20)),
         pix_fmt=str(enc_raw.get("pix_fmt", "yuv420p")),

--- a/src/youtube_automation/utils/config/youtube.py
+++ b/src/youtube_automation/utils/config/youtube.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+OVERLAY_ENCODER_CODECS = ("libx264", "hardware", "h264_videotoolbox", "h264_nvenc")
+
 
 @dataclass(frozen=True)
 class YoutubeApi:
@@ -131,9 +133,9 @@ class OverlaySubscribePopup:
 class OverlayEncoder:
     """`overlays.encoder` セクション（optional, #511）.
 
-    overlays を合成すると `-c:v copy` は不可能になるため x264 で再エンコードする。
-    値はすべて FFmpeg に直接渡す文字列。bitrate / bufsize は `-maxrate` / `-bufsize`
-    と同じ書式を許容する（例 `4M`, `8000k`）。
+    overlays を合成すると `-c:v copy` は不可能になるため H.264 で再エンコードする。
+    `hardware` は VideoToolbox / NVENC を opt-in 選択し、利用不能・起動失敗時は
+    `libx264` へ戻る。bitrate / bufsize は FFmpeg と同じ書式を許容する。
     """
 
     codec: str = "libx264"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -2235,6 +2235,26 @@ def test_overlays_empty_object_uses_defaults(tmp_path, monkeypatch):
     assert config.youtube.overlays.subscribe_popup.enabled is False
 
 
+@pytest.mark.parametrize("codec", ["hardware", "h264_videotoolbox", "h264_nvenc"])
+def test_overlays_hardware_encoder_codecs_are_valid(tmp_path, monkeypatch, codec):
+    sections = _minimal_sections()
+    sections["youtube.json"]["overlays"] = {"enabled": True, "encoder": {"codec": codec}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    assert load_config().youtube.overlays.encoder.codec == codec
+
+
+def test_overlays_unknown_encoder_codec_raises(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["youtube.json"]["overlays"] = {"enabled": True, "encoder": {"codec": "hevc_magic"}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match="overlays.encoder.codec='hevc_magic'"):
+        load_config()
+
+
 def test_overlays_section_non_object_raises(tmp_path, monkeypatch):
     """#511: `overlays` が object でないときは ConfigError."""
     sections = _minimal_sections()

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -91,6 +91,7 @@ exit 0
 set -eu
 if [[ "$*" == *"-encoders"* ]]; then
     printf ' A..... aac \\n'
+    if [[ -n "${FFMPEG_ENCODERS:-}" ]]; then printf '%b' "$FFMPEG_ENCODERS"; fi
     exit 0
 fi
 
@@ -200,6 +201,14 @@ with open(sys.argv[1], encoding="utf-8") as f:
 print(str(data.get("overlays", {}).get("subscribe_popup", {}).get("enabled", False)).lower())
 PY
         ;;
+    *".overlays.encoder.codec"*) printf '%s\\n' "${OVERLAY_ENCODER_CODEC:-}" ;;
+    *".overlays.encoder.preset"*) printf '%s\\n' "${OVERLAY_ENCODER_PRESET:-}" ;;
+    *".overlays.encoder.crf"*) printf '%s\\n' "${OVERLAY_ENCODER_CRF:-}" ;;
+    *".overlays.encoder.pix_fmt"*) printf '%s\\n' "${OVERLAY_ENCODER_PIX_FMT:-}" ;;
+    *".overlays.encoder.maxrate"*) printf '%s\\n' "${OVERLAY_ENCODER_MAXRATE:-}" ;;
+    *".overlays.encoder.bufsize"*) printf '%s\\n' "${OVERLAY_ENCODER_BUFSIZE:-}" ;;
+    *".overlays.encoder.profile"*) printf '%s\\n' "${OVERLAY_ENCODER_PROFILE:-}" ;;
+    *".overlays.encoder.framerate"*) printf '%s\\n' "${OVERLAY_ENCODER_FRAMERATE:-}" ;;
     *) printf '\\n' ;;
 esac
 """,
@@ -1400,6 +1409,91 @@ def _output_ffmpeg_command(ffmpeg_log: Path, output_name: str) -> str:
         if output_name in cmd:
             return cmd
     raise AssertionError(f"ffmpeg command for {output_name} not found: {commands}")
+
+
+def _overlay_encoder_env(codec: str, encoders: str = "") -> dict[str, str]:
+    return {
+        "OVERLAY_ENCODER_CODEC": codec,
+        "FFMPEG_ENCODERS": encoders,
+    }
+
+
+def test_overlay_hardware_auto_selects_videotoolbox_when_available(tmp_path: Path) -> None:
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text('{"overlays":{"enabled":true}}', encoding="utf-8")
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={
+            "OVERLAYS_CONFIG": str(overlays_config),
+            **_overlay_encoder_env("hardware", " V....D h264_videotoolbox VideoToolbox H.264 Encoder\\n"),
+        },
+    )
+
+    master_cmd = _master_ffmpeg_command(ffmpeg_log)
+    assert result.returncode == 0, result.stderr
+    assert "-c:v h264_videotoolbox" in master_cmd
+    assert " -crf " not in f" {master_cmd} "
+    assert "requested=hardware, selected=h264_videotoolbox" in result.stdout
+
+
+def test_overlay_hardware_unavailable_falls_back_to_libx264(tmp_path: Path) -> None:
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text('{"overlays":{"enabled":true}}', encoding="utf-8")
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"OVERLAYS_CONFIG": str(overlays_config), **_overlay_encoder_env("hardware")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "-c:v libx264" in _master_ffmpeg_command(ffmpeg_log)
+    assert "hardware encoder is unavailable; falling back to libx264" in result.stdout
+    assert "requested=hardware, selected=libx264" in result.stdout
+
+
+def test_overlay_hardware_start_failure_falls_back_to_libx264(tmp_path: Path) -> None:
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text('{"overlays":{"enabled":true}}', encoding="utf-8")
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={
+            "OVERLAYS_CONFIG": str(overlays_config),
+            "FFMPEG_FAIL_MATCH": "encoder-probe",
+            **_overlay_encoder_env("hardware", " V....D h264_videotoolbox VideoToolbox H.264 Encoder\\n"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "-c:v libx264" in _master_ffmpeg_command(ffmpeg_log)
+    assert "failed to start; falling back to libx264" in result.stdout
+
+
+def test_overlay_explicit_nvenc_uses_codec_specific_options(tmp_path: Path) -> None:
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text('{"overlays":{"enabled":true}}', encoding="utf-8")
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={
+            "OVERLAYS_CONFIG": str(overlays_config),
+            **_overlay_encoder_env("h264_nvenc", " V....D h264_nvenc NVIDIA NVENC H.264 encoder\\n"),
+        },
+    )
+
+    master_cmd = _master_ffmpeg_command(ffmpeg_log)
+    assert result.returncode == 0, result.stderr
+    assert "-c:v h264_nvenc -preset p5 -cq 20 -b:v 0" in master_cmd
+    assert "requested=h264_nvenc, selected=h264_nvenc" in result.stdout
+
+
+def test_overlay_benchmark_script_covers_required_candidates() -> None:
+    benchmark = (_SCRIPT_PATH.parent / "benchmark_overlay_encoders.sh").read_text(encoding="utf-8")
+    for candidate in ("baseline", "software-veryfast", "twostage", "h264_videotoolbox", "h264_nvenc"):
+        assert candidate in benchmark
+    assert "/usr/bin/time -p" in benchmark
+    assert "ssim" in benchmark
 
 
 def test_target_video_duration_unset_keeps_legacy_behavior(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- overlay encoder の同一条件 benchmark と再現スクリプトを追加
- 20%基準未達のため既定 direct libx264 medium 経路は維持
- hardware / h264_videotoolbox / h264_nvenc の明示 opt-in と codec 固有引数を追加
- encoder 利用不能・1-frame起動失敗時は実出力前に libx264 へ fallback

## Benchmark
Apple Silicon / 1080p / 24fps / 60秒 / showfreqs overlay、各3回の中央値:
- libx264 medium: 4.04s baseline
- libx264 veryfast: 3.65s（9.7%短縮、基準未達）
- two-stage: cold 5.18s / cached median 4.19s（遅延）
- h264_videotoolbox: 6.45s（遅延）
- videotoolbox realtime + prio_speed: 8.16s（遅延）
- h264_nvenc: 実機 encoder 非搭載
SSIM は 0.999964 以上。全出力は H.264 / 1920x1080 / 24fps / 60秒 / AAC を ffprobe 確認し、10秒地点を目視比較済み。

## Official documentation
- https://ffmpeg.org/ffmpeg-codecs.html
- https://ffmpeg.org/ffmpeg-filters.html
- installed FFmpeg: ffmpeg -h encoder=h264_videotoolbox

## Verification
- uv run pytest tests/test_generate_videos_script.py tests/test_generate_videos_batch.py tests/test_config_loader.py -q (331 passed)
- uv run pytest tests/test_skills_sync_installed_wheel.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run yt-skills lint videoup
- bash -n generate_videos.sh benchmark_overlay_encoders.sh
- uv run pytest -n auto (6477 passed)

Closes #2372