### PR TITLE
feat(streaming): live chat reply daemon を VPS に統合

### DIFF
--- a/.claude/skills/streaming/references/deploy_live_chat.sh
+++ b/.claude/skills/streaming/references/deploy_live_chat.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# deploy_live_chat.sh — 1Password から ephemeral secret を注入して live-chat-reply を配備する
+#
+# Usage:
+#   OP_LIVE_CHAT_TOKEN_REF='op://<vault>/<item>/<field>' \
+#   OP_LIVE_CHAT_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>' \
+#   OP_CODEX_AUTH_REF='op://<vault>/<item>/<field>' \
+#   deploy_live_chat.sh [--tf-dir DIR] [--auto-approve] <channel-dir>
+
+set -euo pipefail
+
+TF_DIR="infra/terraform/streaming"
+AUTO_APPROVE=false
+CHANNEL_DIR=""
+
+log()   { printf '\033[0;36m[live-chat-deploy]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+
+usage() { sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tf-dir) TF_DIR="$2"; shift 2 ;;
+        --tf-dir=*) TF_DIR="${1#*=}"; shift ;;
+        --auto-approve) AUTO_APPROVE=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) error "未知のオプション: $1"; usage; exit 2 ;;
+        *)
+            [[ -z "$CHANNEL_DIR" ]] || { error "channel-dir は 1 つだけ指定してください"; exit 2; }
+            CHANNEL_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$CHANNEL_DIR" ]] || { error "channel-dir が未指定です"; usage; exit 2; }
+for command_name in terraform op realpath; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        error "$command_name が見つかりません"
+        exit 1
+    }
+done
+
+for ref_name in OP_LIVE_CHAT_TOKEN_REF OP_LIVE_CHAT_CLIENT_SECRETS_REF OP_CODEX_AUTH_REF; do
+    [[ -n "${!ref_name:-}" ]] || {
+        error "$ref_name に 1Password secret reference を設定してください"
+        exit 1
+    }
+done
+
+[[ -d "$TF_DIR" && -f "$TF_DIR/main.tf" ]] || { error "Terraform module が見つかりません: $TF_DIR"; exit 1; }
+[[ -d "$CHANNEL_DIR" ]] || { error "channel directory が見つかりません: $CHANNEL_DIR"; exit 1; }
+CHANNEL_DIR_ABS="$(realpath "$CHANNEL_DIR")"
+[[ -f "$CHANNEL_DIR_ABS/config/channel/comments.json" ]] || {
+    error "comments.json が見つかりません: $CHANNEL_DIR_ABS/config/channel/comments.json"
+    exit 1
+}
+
+export TF_VAR_live_chat_youtube_token_json="$(op read "$OP_LIVE_CHAT_TOKEN_REF")"
+export TF_VAR_live_chat_client_secrets_json="$(op read "$OP_LIVE_CHAT_CLIENT_SECRETS_REF")"
+export TF_VAR_live_chat_codex_auth_json="$(op read "$OP_CODEX_AUTH_REF")"
+cleanup() {
+    unset TF_VAR_live_chat_youtube_token_json
+    unset TF_VAR_live_chat_client_secrets_json
+    unset TF_VAR_live_chat_codex_auth_json
+}
+trap cleanup EXIT HUP INT TERM
+
+for json_value in \
+    "$TF_VAR_live_chat_youtube_token_json" \
+    "$TF_VAR_live_chat_client_secrets_json" \
+    "$TF_VAR_live_chat_codex_auth_json"; do
+    printf '%s' "$json_value" | python3 -m json.tool >/dev/null || {
+        error "1Password から取得した値が JSON ではありません"
+        exit 1
+    }
+done
+
+if command -v shasum >/dev/null 2>&1; then
+    CREDENTIALS_REVISION="$(printf '%s\0%s\0%s' \
+        "$TF_VAR_live_chat_youtube_token_json" \
+        "$TF_VAR_live_chat_client_secrets_json" \
+        "$TF_VAR_live_chat_codex_auth_json" | shasum -a 256 | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+    CREDENTIALS_REVISION="$(printf '%s\0%s\0%s' \
+        "$TF_VAR_live_chat_youtube_token_json" \
+        "$TF_VAR_live_chat_client_secrets_json" \
+        "$TF_VAR_live_chat_codex_auth_json" | sha256sum | awk '{print $1}')"
+else
+    error "shasum または sha256sum が見つかりません"
+    exit 1
+fi
+
+export TF_VAR_enable_live_chat_reply=true
+export TF_VAR_live_chat_channel_dir="$CHANNEL_DIR_ABS"
+export TF_VAR_live_chat_credentials_revision="$CREDENTIALS_REVISION"
+
+log "channel: $CHANNEL_DIR_ABS"
+log "terraform plan（secret 値は ephemeral のため plan/state に保存されません）"
+terraform -chdir="$TF_DIR" plan
+
+log "terraform apply"
+if $AUTO_APPROVE; then
+    terraform -chdir="$TF_DIR" apply -auto-approve
+else
+    terraform -chdir="$TF_DIR" apply
+fi
+
+ok "live-chat-reply の配備が完了しました"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `videoup` の overlay H.264 encoder を同一条件で計測し、既定の `libx264` 経路を維持しつつ、VideoToolbox / NVENC の明示 opt-in、codec 固有引数、利用不能・起動失敗時の `libx264` fallback、再現可能な benchmark を追加（#2372）。
 - `feat(live-chat)`: アクティブ配信を検出し、YouTube の指定間隔で新着チャットを取得、Codex の構造化判定と機械フィルタ・返信上限・履歴による重複防止を通して投稿する `yt-live-chat-reply` を追加（#2374）。
+- `feat(streaming)`: ライブチャット返信 daemon を opt-in で既存 Vultr VPS に同居させ、ephemeral Terraform 変数による 1Password 認証注入、専用 systemd service、Codex CLI / Python package の pin 配備と無効化時の安全な削除を追加（#2375）。
 
 - `/automation-schedule` の既定登録先を Codex / Claude のネイティブ Scheduled Task へ移し、依存性に応じた Cloud/local 分岐、backend ID による重複防止、明示承認時だけの launchd / cron fallback を追加しました（#2369）。
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -12,10 +12,11 @@ Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に
 - `vultr_firewall_rule` × N（`var.allowed_ssh_cidr` の CIDR ごとに 22/tcp の inbound rule。IPv4 のみ）
 - `vultr_instance` × 1（Ubuntu 24.04 LTS / vc2-1c-2gb / 東京リージョン）
 - `null_resource.deploy` × 1（動画アップロード + `EnvironmentFile` 配置 + systemd 起動 + 死活監視配置）
+- `null_resource.live_chat_reply` × 0..1（opt-in のライブチャット返信 daemon。認証・config 配布 + Codex / Python package + systemd 起動）
 
 ## 前提
 
-- `terraform` >= 1.5 インストール済み
+- `terraform` >= 1.10 インストール済み（ライブチャット認証を state から除外する ephemeral input を使用）
 - `python3` が PATH 上にある（配信元 MP4 のプリフライト検証を Terraform `external` data source から実行するため）
 - Vultr API キーを 1Password に保管済み（または環境変数で渡せる状態）
 - `yt-fetch-stream-key --vault=Personal --item=YouTube` でストリームキーを 1Password に保管済み（初回のみ）
@@ -59,6 +60,43 @@ terraform apply
 ```
 
 `terraform.tfvars` には secret 値を書かない（`stream_key` / `vultr_api_key` は `TF_VAR_*` のみ）。
+
+## ライブチャット自動返信（opt-in）
+
+既定の `enable_live_chat_reply=false` では関連 resource を一切作らず、既存の `youtube-stream` 配備だけが従来どおり動く。有効化時も返信 daemon は独立した `live-chat-reply.service` として動き、失敗時は `Restart=on-failure` で自動復帰する。unit は `youtube-stream.service` を `Requires=` しないため、返信 daemon の停止や再起動が配信本体を止めることはない。
+
+初回は人間が Google / OpenAI の認証画面で認証を済ませ、生成済みの `token.json`、`client_secrets.json`、Codex の `auth.json` をそれぞれ 1Password の secure field に保存する。以後の secret 取得・Terraform 実行はラッパーが担う。
+
+```bash
+# 通常の streaming secret（Vultr / stream key / Discord）を先に用意する
+export TF_VAR_vultr_api_key="$(op read 'op://Personal/Vultr/api_key')"
+export TF_VAR_stream_key="$(op read 'op://Personal/YouTube/stream_key')"
+export TF_VAR_discord_webhook_url="$(op read 'op://Personal/YouTube_Stream_Discord_Webhook/url')"
+
+# 認証 JSON を保存した 1Password field の参照だけを渡す（JSON 値自体は argv に載せない）
+export OP_LIVE_CHAT_TOKEN_REF='op://<vault>/<item>/<field>'
+export OP_LIVE_CHAT_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>'
+export OP_CODEX_AUTH_REF='op://<vault>/<item>/<field>'
+
+.claude/skills/streaming/references/deploy_live_chat.sh /absolute/path/to/channel
+```
+
+実行前に channel の `config/channel/comments.json` で `comments.live_chat.enabled: true` にする。リリース運用では再現性のため `live_chat_automation_git_ref` を release tag または commit SHA に固定する。Codex CLI は OpenAI 公式 installer を使い、`live_chat_codex_version`（既定は開発時に検証した `0.144.1`）へ固定する。
+
+Terraform 1.10 以降の `ephemeral = true` と `sensitive = true` を併用した 3 変数を provisioner へ直接渡すため、OAuth / Codex の JSON 本文は plan ファイルや state に保存されない。`sensitive` 単独は表示を隠すだけで state 除外にはならない。VPS 上では専用 user `live-chat-reply` が所有する `/var/lib/live-chat-reply/{channel,codex}` のみに mode `0600` で配置する。ラッパーは値を表示せず、終了時に shell 変数を unset する。
+
+```bash
+# 状態・ログ
+ssh root@<instance_ip> systemctl status live-chat-reply
+ssh root@<instance_ip> journalctl -u live-chat-reply -n 100 -f
+
+# opt-out（plan で live_chat_reply だけが destroy されることを確認）
+terraform -chdir=infra/terraform/streaming apply -var='enable_live_chat_reply=false'
+```
+
+opt-out は unit、`/var/lib/live-chat-reply` の OAuth / Codex 認証、専用 venv を削除する。既存 `youtube-stream` の unit、動画、stream key には触れない。token 失効時は人間がブラウザ認証を行って 1Password の値を更新し、同じラッパーを再実行する。
+
+設計根拠: [Terraform ephemeral values](https://developer.hashicorp.com/terraform/language/manage-sensitive-data#ephemeral-values)、[Terraform file provisioner](https://developer.hashicorp.com/terraform/language/block/resource#file)、[OpenAI Codex](https://github.com/openai/codex)、[1Password secret references](https://developer.1password.com/docs/cli/secret-references/)。
 
 ## 配信元動画のプリフライト
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -6,6 +6,13 @@ locals {
   source_video_preflight  = data.external.source_video_preflight.result
   source_video_ok         = local.source_video_preflight.ok == "true"
   source_video_profile_ok = local.source_video_preflight.profile_ok == "true"
+  live_chat_config_dir    = "${var.live_chat_channel_dir}/config/channel"
+  live_chat_config_files  = var.enable_live_chat_reply ? fileset(local.live_chat_config_dir, "*.json") : toset([])
+  live_chat_config_hash = var.enable_live_chat_reply ? sha256(join("", [
+    for name in sort(tolist(local.live_chat_config_files)) : filesha256("${local.live_chat_config_dir}/${name}")
+  ])) : "disabled"
+  live_chat_install_root = "${var.install_root}/live-chat-reply"
+  live_chat_state_root   = "/var/lib/live-chat-reply"
 }
 
 data "external" "source_video_preflight" {
@@ -179,6 +186,126 @@ resource "null_resource" "deploy" {
       "systemctl enable --now youtube-stream",
       "systemctl restart youtube-stream",
       "systemctl restart cron",
+    ]
+  }
+}
+
+resource "null_resource" "live_chat_reply" {
+  count      = var.enable_live_chat_reply ? 1 : 0
+  depends_on = [null_resource.deploy]
+
+  triggers = {
+    instance_id         = vultr_instance.this.id
+    instance_ip         = vultr_instance.this.main_ip
+    ssh_host_key        = local.ssh_host_public_key
+    channel_config_hash = local.live_chat_config_hash
+    credentials         = var.live_chat_credentials_revision
+    automation_git_ref  = var.live_chat_automation_git_ref
+    codex_version       = var.live_chat_codex_version
+    install_root        = local.live_chat_install_root
+    systemd_unit        = filemd5("${path.module}/templates/live-chat-reply.service.tftpl")
+  }
+
+  lifecycle {
+    precondition {
+      condition     = try(fileexists("${local.live_chat_config_dir}/comments.json"), false)
+      error_message = "enable_live_chat_reply=true では live_chat_channel_dir/config/channel/comments.json が必要です。"
+    }
+    precondition {
+      condition = try(
+        jsondecode(file("${local.live_chat_config_dir}/comments.json")).comments.live_chat.enabled == true,
+        false,
+      )
+      error_message = "comments.json の comments.live_chat.enabled を true にしてください。"
+    }
+    precondition {
+      condition     = length(var.live_chat_credentials_revision) == 64
+      error_message = "live_chat_credentials_revision に deploy script が生成する SHA-256 を指定してください。"
+    }
+  }
+
+  connection {
+    type     = "ssh"
+    host     = self.triggers.instance_ip
+    user     = "root"
+    agent    = true
+    host_key = self.triggers.ssh_host_key
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "install -d -m 0700 -o root -g root /run/live-chat-reply",
+    ]
+  }
+
+  provisioner "file" {
+    source      = local.live_chat_config_dir
+    destination = "/run/live-chat-reply/"
+  }
+
+  provisioner "file" {
+    content     = var.live_chat_youtube_token_json
+    destination = "/run/live-chat-reply/token.json"
+  }
+
+  provisioner "file" {
+    content     = var.live_chat_client_secrets_json
+    destination = "/run/live-chat-reply/client_secrets.json"
+  }
+
+  provisioner "file" {
+    content     = var.live_chat_codex_auth_json
+    destination = "/run/live-chat-reply/codex-auth.json"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/live-chat-reply.service.tftpl", {
+      install_root = local.live_chat_install_root
+      state_root   = local.live_chat_state_root
+    })
+    destination = "/run/live-chat-reply/live-chat-reply.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -eu",
+      "export DEBIAN_FRONTEND=noninteractive",
+      "apt-get update -qq",
+      "apt-get install -y -qq ca-certificates curl git python3-venv",
+      "python3 -m json.tool /run/live-chat-reply/token.json >/dev/null",
+      "python3 -m json.tool /run/live-chat-reply/client_secrets.json >/dev/null",
+      "python3 -m json.tool /run/live-chat-reply/codex-auth.json >/dev/null",
+      "id -u live-chat-reply >/dev/null 2>&1 || useradd --system --home-dir ${local.live_chat_state_root} --create-home --shell /usr/sbin/nologin live-chat-reply",
+      "install -d -m 0755 -o root -g root ${local.live_chat_install_root}",
+      "install -d -m 0700 -o live-chat-reply -g live-chat-reply ${local.live_chat_state_root}/channel/auth ${local.live_chat_state_root}/channel/config/channel ${local.live_chat_state_root}/codex",
+      "cp -a /run/live-chat-reply/channel/. ${local.live_chat_state_root}/channel/config/channel/",
+      "chown -R live-chat-reply:live-chat-reply ${local.live_chat_state_root}/channel/config",
+      "find ${local.live_chat_state_root}/channel/config -type f -exec chmod 0600 {} +",
+      "install -m 0600 -o live-chat-reply -g live-chat-reply /run/live-chat-reply/token.json ${local.live_chat_state_root}/channel/auth/token.json",
+      "install -m 0600 -o live-chat-reply -g live-chat-reply /run/live-chat-reply/client_secrets.json ${local.live_chat_state_root}/channel/auth/client_secrets.json",
+      "install -m 0600 -o live-chat-reply -g live-chat-reply /run/live-chat-reply/codex-auth.json ${local.live_chat_state_root}/codex/auth.json",
+      "curl -fsSL https://chatgpt.com/codex/install.sh -o /run/live-chat-reply/codex-install.sh",
+      "CODEX_RELEASE=${var.live_chat_codex_version} CODEX_NON_INTERACTIVE=1 CODEX_INSTALL_DIR=/usr/local/bin CODEX_HOME=${local.live_chat_state_root}/codex sh /run/live-chat-reply/codex-install.sh",
+      "python3 -m venv ${local.live_chat_install_root}/venv",
+      "${local.live_chat_install_root}/venv/bin/pip install --quiet --upgrade pip",
+      "${local.live_chat_install_root}/venv/bin/pip install --quiet --upgrade git+https://github.com/daiki-beppu/youtube-automation.git@${var.live_chat_automation_git_ref}",
+      "install -m 0644 -o root -g root /run/live-chat-reply/live-chat-reply.service /etc/systemd/system/live-chat-reply.service",
+      "rm -rf /run/live-chat-reply",
+      "systemctl daemon-reload",
+      "systemctl enable --now live-chat-reply",
+      "systemctl restart live-chat-reply",
+      "systemctl is-active --quiet live-chat-reply",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when       = destroy
+    on_failure = continue
+    inline = [
+      "systemctl disable --now live-chat-reply 2>/dev/null || true",
+      "rm -f /etc/systemd/system/live-chat-reply.service",
+      "rm -rf /var/lib/live-chat-reply ${self.triggers.install_root}",
+      "systemctl daemon-reload",
     ]
   }
 }

--- a/infra/terraform/streaming/templates/live-chat-reply.service.tftpl
+++ b/infra/terraform/streaming/templates/live-chat-reply.service.tftpl
@@ -1,0 +1,44 @@
+[Unit]
+Description=YouTube Live Chat Reply (Codex)
+Wants=network-online.target
+After=network-online.target youtube-stream.service
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=live-chat-reply
+Group=live-chat-reply
+WorkingDirectory=${state_root}/channel
+Environment=CHANNEL_DIR=${state_root}/channel
+Environment=CODEX_HOME=${state_root}/codex
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PYTHONUNBUFFERED=1
+UMask=0077
+ExecStart=${install_root}/venv/bin/yt-live-chat-reply
+Restart=on-failure
+RestartSec=10s
+TimeoutStopSec=30s
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=${state_root}
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RemoveIPC=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/terraform/streaming/terraform.tfvars.example
+++ b/infra/terraform/streaming/terraform.tfvars.example
@@ -33,3 +33,15 @@ allowed_ssh_cidr = ["203.0.113.5/32"]
 #   従来の 11 時間配信 + 1 時間休止に戻す場合は 11 / 1 を指定する。
 # stream_hours = 0
 # break_hours  = 0
+
+# ライブチャット返信 daemon（既定 false / opt-in）:
+# secret 3 種は tfvars に書かず、1Password 参照を渡して専用ラッパーを実行する。
+# enable_live_chat_reply       = true
+# live_chat_channel_dir        = "/absolute/path/to/channel"
+# live_chat_automation_git_ref = "<release-tag-or-commit-sha>"
+# live_chat_codex_version      = "0.144.1"
+#
+# OP_LIVE_CHAT_TOKEN_REF='op://<vault>/<item>/<field>' \
+# OP_LIVE_CHAT_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>' \
+# OP_CODEX_AUTH_REF='op://<vault>/<item>/<field>' \
+# .claude/skills/streaming/references/deploy_live_chat.sh /absolute/path/to/channel

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -83,3 +83,67 @@ variable "allowed_ssh_cidr" {
     error_message = "allowed_ssh_cidr を 1 件以上指定してください（例: 自分の IP を `curl -s ifconfig.me` で取得し \"203.0.113.5/32\" 形式で渡す）。"
   }
 }
+
+variable "enable_live_chat_reply" {
+  type        = bool
+  description = "Codex によるライブチャット返信 daemon を同居させる opt-in"
+  default     = false
+}
+
+variable "live_chat_channel_dir" {
+  type        = string
+  description = "config/channel/comments.json を含むローカル channel root。enable 時のみ必須"
+  default     = ""
+}
+
+variable "live_chat_automation_git_ref" {
+  type        = string
+  description = "VPS に install する youtube-automation の Git ref。本番では commit SHA pin を推奨"
+  default     = "main"
+
+  validation {
+    condition     = can(regex("^[0-9A-Za-z._/-]+$", var.live_chat_automation_git_ref))
+    error_message = "live_chat_automation_git_ref は Git ref に使える英数字と ._/- のみ指定できます。"
+  }
+}
+
+variable "live_chat_codex_version" {
+  type        = string
+  description = "OpenAI 公式 install.sh で導入する Codex CLI version"
+  default     = "0.144.1"
+
+  validation {
+    condition     = can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+([-.][0-9A-Za-z.]+)?$", var.live_chat_codex_version))
+    error_message = "live_chat_codex_version は x.y.z 形式で指定してください。"
+  }
+}
+
+variable "live_chat_credentials_revision" {
+  type        = string
+  description = "ephemeral 認証の差し替えを検知する非秘密 revision（deploy script が SHA-256 を設定）"
+  default     = ""
+}
+
+variable "live_chat_youtube_token_json" {
+  type        = string
+  description = "YouTube OAuth token.json の内容。state / plan に保存しない ephemeral secret"
+  sensitive   = true
+  ephemeral   = true
+  default     = ""
+}
+
+variable "live_chat_client_secrets_json" {
+  type        = string
+  description = "YouTube OAuth client_secrets.json の内容。state / plan に保存しない ephemeral secret"
+  sensitive   = true
+  ephemeral   = true
+  default     = ""
+}
+
+variable "live_chat_codex_auth_json" {
+  type        = string
+  description = "Codex auth.json の内容。state / plan に保存しない ephemeral secret"
+  sensitive   = true
+  ephemeral   = true
+  default     = ""
+}

--- a/infra/terraform/streaming/versions.tf
+++ b/infra/terraform/streaming/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.10"
 
   backend "gcs" {
     prefix = "streaming"

--- a/tests/streaming/test_live_chat_reply_integration.py
+++ b/tests/streaming/test_live_chat_reply_integration.py
@@ -1,0 +1,80 @@
+"""ライブチャット返信 daemon の streaming VPS 統合契約（#2375）。"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.helpers.hcl import extract_block, read_file, strip_hcl_comments
+from tests.streaming._helpers import _MAIN_TF, _STREAMING_DIR, _VARIABLES_TF, _VERSIONS_TF
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_UNIT = _STREAMING_DIR / "templates" / "live-chat-reply.service.tftpl"
+_DEPLOY_SCRIPT = _REPO_ROOT / ".claude/skills/streaming/references/deploy_live_chat.sh"
+
+
+def test_terraform_requires_ephemeral_input_capable_version() -> None:
+    assert 'required_version = ">= 1.10"' in read_file(_VERSIONS_TF)
+
+
+def test_live_chat_is_opt_in_and_secrets_are_ephemeral() -> None:
+    text = strip_hcl_comments(read_file(_VARIABLES_TF))
+    enabled = extract_block(text, r'variable\s+"enable_live_chat_reply"')
+    assert enabled is not None
+    assert re.search(r"default\s*=\s*false", enabled)
+
+    for name in (
+        "live_chat_youtube_token_json",
+        "live_chat_client_secrets_json",
+        "live_chat_codex_auth_json",
+    ):
+        block = extract_block(text, rf'variable\s+"{name}"')
+        assert block is not None
+        assert re.search(r"sensitive\s*=\s*true", block)
+        assert re.search(r"ephemeral\s*=\s*true", block)
+
+
+def test_live_chat_resource_is_separate_and_does_not_persist_secrets() -> None:
+    text = strip_hcl_comments(read_file(_MAIN_TF))
+    block = extract_block(text, r'resource\s+"null_resource"\s+"live_chat_reply"')
+    assert block is not None
+    assert re.search(r"count\s*=\s*var\.enable_live_chat_reply\s*\?\s*1\s*:\s*0", block)
+    assert "depends_on = [null_resource.deploy]" in block
+
+    triggers = extract_block(block, r"triggers")
+    assert triggers is not None
+    assert "live_chat_youtube_token_json" not in triggers
+    assert "live_chat_client_secrets_json" not in triggers
+    assert "live_chat_codex_auth_json" not in triggers
+    assert "credentials         = var.live_chat_credentials_revision" in triggers
+
+    assert "install -m 0600 -o live-chat-reply -g live-chat-reply" in block
+    assert "systemctl is-active --quiet live-chat-reply" in block
+    assert "systemctl disable --now live-chat-reply" in block
+    assert "rm -rf /var/lib/live-chat-reply ${self.triggers.install_root}" in block
+
+
+def test_systemd_unit_restarts_without_coupling_stream_lifecycle() -> None:
+    unit = read_file(_UNIT)
+    assert "User=live-chat-reply" in unit
+    assert "Restart=on-failure" in unit
+    assert "NoNewPrivileges=true" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "ReadWritePaths=${state_root}" in unit
+    assert "Requires=youtube-stream.service" not in unit
+    assert "PartOf=youtube-stream.service" not in unit
+
+
+def test_deploy_script_reads_1password_and_cleans_ephemeral_env() -> None:
+    script = read_file(_DEPLOY_SCRIPT)
+    assert _DEPLOY_SCRIPT.stat().st_mode & 0o111
+    assert "set -euo pipefail" in script
+    assert 'op read "$OP_LIVE_CHAT_TOKEN_REF"' in script
+    assert 'op read "$OP_LIVE_CHAT_CLIENT_SECRETS_REF"' in script
+    assert 'op read "$OP_CODEX_AUTH_REF"' in script
+    assert "export TF_VAR_live_chat_youtube_token_json" in script
+    assert "export TF_VAR_live_chat_credentials_revision" in script
+    assert "trap cleanup EXIT HUP INT TERM" in script
+    assert 'terraform -chdir="$TF_DIR" plan' in script
+    assert 'terraform -chdir="$TF_DIR" apply' in script
+    assert "set -x" not in script

--- a/tests/streaming/test_terraform_meta.py
+++ b/tests/streaming/test_terraform_meta.py
@@ -33,16 +33,16 @@ from tests.streaming._helpers import (
 class TestVersionsTf:
     """``versions.tf`` の terraform / required_providers / provider 宣言。"""
 
-    def test_required_version_is_at_least_1_5(self):
+    def test_required_version_supports_ephemeral_inputs(self):
         """Given versions.tf
         When terraform ブロックを読む
-        Then required_version は ">= 1.5" を含む（既存 gcp/versions.tf と同じ最低保証）。
+        Then required_version は ephemeral variables を導入した Terraform 1.10 以上。
         """
         text = strip_hcl_comments(read_file(_VERSIONS_TF))
         terraform_block = extract_block(text, r"terraform")
         assert terraform_block is not None, "terraform { ... } ブロックが存在しない"
-        assert re.search(r'required_version\s*=\s*"[^"]*>=\s*1\.5', terraform_block), (
-            "required_version が >= 1.5 を含んでいない"
+        assert re.search(r'required_version\s*=\s*"[^"]*>=\s*1\.10', terraform_block), (
+            "required_version が >= 1.10 を含んでいない"
         )
 
     def test_backend_uses_gcs_remote_state(self):


### PR DESCRIPTION
## Summary
- `enable_live_chat_reply` opt-in で既存 streaming VPS に独立した `live-chat-reply.service` を配備
- YouTube OAuth / Codex auth を Terraform 1.10+ の `ephemeral` + `sensitive` 変数で注入し、plan/state へ保存しない
- 1Password から JSON を取得する配備ラッパー、mode 0600 配置、再起動・無効化時 cleanup、運用ドキュメントを追加

## Design
- `sensitive` 単独では state に値が残るため、HashiCorp 公式仕様に従い `ephemeral = true` を併用
- 既存 cloud-init を変更せず opt-in の `null_resource.live_chat_reply` に分離し、無効時や返信 daemon 障害時に `youtube-stream` を変更・停止しない
- Codex は OpenAI 公式 installer を version pin して導入

## Official references
- https://developer.hashicorp.com/terraform/language/manage-sensitive-data#ephemeral-values
- https://developer.hashicorp.com/terraform/language/block/resource#file
- https://github.com/openai/codex
- https://developer.1password.com/docs/cli/secret-references/
- https://github.com/systemd/systemd/blob/main/man/systemd.service.xml

## Validation
- `terraform -chdir=infra/terraform/streaming validate`
- `terraform -chdir=infra/terraform/streaming fmt -check`
- `bash -n .claude/skills/streaming/references/deploy_live_chat.sh`
- `uv run pytest tests/streaming tests/test_skills_sync_installed_wheel.py::test_candidate_wheel_syncs_all_assets_into_clean_downstream -q` (257 passed)
- full suite: 6507 passed; the only initial failure was the new untracked wheel asset, then the staged wheel sync test passed

Closes #2375
