### PR TITLE
feat(dashboard): channel registry と read model を追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(dashboard)`: `~/.config/tayk/channels.json` の絶対 path registry loader と、各チャンネルの最新 Analytics snapshot を概要・動画指標・CTRへ正規化する読み取り専用 read model/APIを追加。snapshot 欠損・破損・meta 不正はチャンネル単位の状態として隔離する（#2387）。
+
 - `refactor(workflow)`: `/wf-auto` を一気通貫 workflow の正規入口にし、scheduler の新規既定を `wf-auto` へ変更。`/automation-run` は既存の明示設定を保つ薄い互換 alias とし、`.automation-run/` の lease・履歴パスは維持する（#2383）。
 
 - `feat(workflow)`: `/wf-auto` を追加し、active collection が無い場合は state を捏造せず `/wf-new` から開始し、作成された collection を同じ run で固定して制作・公開・post-publish まで再評価する一気通貫入口を実装。既存 collection の再開、無人実行の手動介入履歴、公開禁止、upload reconciliation、完了済み公開後処理の契約を共有 resolver で維持する（#2382）。

--- a/src/youtube_automation/utils/channel_registry.py
+++ b/src/youtube_automation/utils/channel_registry.py
@@ -1,0 +1,44 @@
+"""所有チャンネル registry の読み取り専用 loader。"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from youtube_automation.utils.exceptions import ChannelRegistryError
+
+DEFAULT_CHANNEL_REGISTRY = Path.home() / ".config" / "tayk" / "channels.json"
+
+
+def load_channel_registry(path: Path | None = None) -> list[Path]:
+    """JSON 配列のチャンネル path を宣言順で返す。"""
+    registry_path = path or DEFAULT_CHANNEL_REGISTRY
+    try:
+        values = json.loads(registry_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ChannelRegistryError(
+            f"channel registry がありません: {registry_path}。絶対 path の JSON 配列を作成してください"
+        ) from exc
+    except OSError as exc:
+        raise ChannelRegistryError(f"channel registry を読めません: {registry_path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ChannelRegistryError(f"channel registry が不正な JSON です: {registry_path}: {exc}") from exc
+
+    if not isinstance(values, list):
+        raise ChannelRegistryError(f"channel registry は絶対 path の JSON 配列でなければなりません: {registry_path}")
+
+    channels: list[Path] = []
+    seen: set[str] = set()
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value:
+            raise ChannelRegistryError(f"channel registry index {index} は空でない文字列でなければなりません")
+        channel = Path(value)
+        if not channel.is_absolute():
+            raise ChannelRegistryError(f"channel registry index {index} は絶対 path でなければなりません: {value}")
+        normalized = os.path.normcase(os.path.normpath(value))
+        if normalized in seen:
+            raise ChannelRegistryError(f"channel registry index {index} の path が重複しています: {value}")
+        seen.add(normalized)
+        channels.append(channel)
+    return channels

--- a/src/youtube_automation/utils/dashboard_read_model.py
+++ b/src/youtube_automation/utils/dashboard_read_model.py
@@ -1,0 +1,219 @@
+"""収集済み Analytics JSON の dashboard 向け読み取り専用 read model。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from youtube_automation.utils.exceptions import DashboardChannelNotFoundError
+
+SCHEMA_VERSION = 1
+
+
+def _object(value: object) -> dict[str, object]:
+    return cast(dict[str, object], value) if isinstance(value, dict) else {}
+
+
+def _number(value: object, default: int | float = 0) -> int | float:
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else default
+
+
+def _text(value: object, default: str = "") -> str:
+    return value if isinstance(value, str) else default
+
+
+def _channel_id(channel: Path) -> str:
+    digest = hashlib.sha256(str(channel).encode("utf-8")).hexdigest()[:16]
+    return f"channel-{digest}"
+
+
+def _reporting_by_video(snapshot: dict[str, object]) -> dict[str, dict[str, object]]:
+    summary = _object(_object(snapshot.get("reporting_api")).get("impressions_summary"))
+    rows = summary.get("per_video")
+    if not isinstance(rows, list):
+        return {}
+    result: dict[str, dict[str, object]] = {}
+    for row in rows:
+        item = _object(row)
+        video_id = _text(item.get("video_id"))
+        if video_id:
+            result[video_id] = item
+    return result
+
+
+def _videos(snapshot: dict[str, object]) -> list[dict[str, object]]:
+    analytics = _object(snapshot.get("video_analytics"))
+    reporting = _reporting_by_video(snapshot)
+    videos: list[dict[str, object]] = []
+    for key, raw in analytics.items():
+        source = _object(raw)
+        video_id = _text(source.get("video_id"), key)
+        reach = reporting.get(video_id, {})
+        likes = _number(source.get("likes"))
+        comments = _number(source.get("comments"))
+        shares = _number(source.get("shares"))
+        videos.append(
+            {
+                "video_id": video_id,
+                "title": _text(source.get("title"), "Unknown"),
+                "views": _number(source.get("views")),
+                "impressions": _number(reach.get("impressions")),
+                "ctr_percentage": _number(reach.get("ctr_percentage")),
+                "likes": likes,
+                "comments": comments,
+                "shares": shares,
+                "subscribers_gained": _number(source.get("subscribers_gained")),
+                "average_view_duration_seconds": _number(source.get("average_view_duration")),
+                "engagements": likes + comments + shares,
+            }
+        )
+    return sorted(videos, key=lambda item: (-cast(int | float, item["views"]), cast(str, item["video_id"])))
+
+
+def _error_channel(
+    channel: Path,
+    *,
+    name: str,
+    status: str,
+    code: str,
+    message: str,
+) -> dict[str, object]:
+    return {
+        "id": _channel_id(channel),
+        "name": name,
+        "status": status,
+        "snapshot": None,
+        "collected_at": None,
+        "period": {"start_date": None, "end_date": None},
+        "summary": None,
+        "videos": [],
+        "error": {"code": code, "message": message},
+    }
+
+
+def _load_name(channel: Path) -> str:
+    meta_path = channel / "config" / "channel" / "meta.json"
+    meta_value = json.loads(meta_path.read_text(encoding="utf-8"))
+    if not isinstance(meta_value, dict):
+        raise ValueError("meta.json root は object でなければなりません")
+    name = _text(_object(meta_value.get("channel")).get("name"))
+    if not name:
+        raise ValueError("meta.json の channel.name がありません")
+    return name
+
+
+def _load_snapshot(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Analytics snapshot root は object でなければなりません")
+    return cast(dict[str, object], value)
+
+
+def _ready_channel(
+    channel: Path,
+    *,
+    name: str,
+    snapshot_path: Path,
+    snapshot: dict[str, object],
+) -> dict[str, object]:
+    period = _object(snapshot.get("collection_period"))
+    summary = _object(_object(snapshot.get("channel_analytics")).get("summary"))
+    return {
+        "id": _channel_id(channel),
+        "name": name,
+        "status": "ready",
+        "snapshot": snapshot_path.name,
+        "collected_at": _text(period.get("collected_at")) or None,
+        "period": {
+            "start_date": _text(period.get("start_date")) or None,
+            "end_date": _text(period.get("end_date")) or None,
+        },
+        "summary": {
+            "views": _number(summary.get("total_views")),
+            "watch_time_minutes": _number(summary.get("total_watch_time")),
+            "subscribers_net": _number(summary.get("net_subscribers")),
+            "engagements": _number(summary.get("total_engagement")),
+            "average_view_percentage": _number(summary.get("avg_view_percentage")),
+        },
+        "videos": _videos(snapshot),
+        "error": None,
+    }
+
+
+def _build_channel(channel: Path) -> dict[str, object]:
+    try:
+        name = _load_name(channel)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        return _error_channel(
+            channel,
+            name=channel.name,
+            status="invalid_channel",
+            code="meta_invalid",
+            message=str(exc),
+        )
+
+    snapshots = sorted((channel / "data").glob("analytics_data_*.json"))
+    if not snapshots:
+        return _error_channel(
+            channel,
+            name=name,
+            status="missing_snapshot",
+            code="snapshot_missing",
+            message=f"Analytics snapshot がありません: {channel / 'data'}",
+        )
+    snapshot_path = snapshots[-1]
+    try:
+        snapshot = _load_snapshot(snapshot_path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        return _error_channel(
+            channel,
+            name=name,
+            status="invalid_snapshot",
+            code="snapshot_invalid",
+            message=str(exc),
+        )
+    return _ready_channel(channel, name=name, snapshot_path=snapshot_path, snapshot=snapshot)
+
+
+def build_dashboard_read_model(channel_paths: list[Path]) -> dict[str, object]:
+    """登録順のチャンネルから JSON serializable な read model を作る。"""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "channels": [_build_channel(channel) for channel in channel_paths],
+    }
+
+
+@dataclass(frozen=True)
+class DashboardAPI:
+    """HTTP layer が利用する読み取り専用 JSON API service。"""
+
+    model: dict[str, object]
+
+    def _channels(self) -> list[dict[str, object]]:
+        channels = self.model.get("channels")
+        if not isinstance(channels, list):
+            return []
+        return [cast(dict[str, object], item) for item in channels if isinstance(item, dict)]
+
+    def overview(self) -> dict[str, object]:
+        """動画行を除いた全チャンネル概要を返す。"""
+        overview_channels: list[dict[str, object]] = []
+        for item in self._channels():
+            videos = item.get("videos")
+            overview = {key: value for key, value in item.items() if key != "videos"}
+            overview["video_count"] = len(videos) if isinstance(videos, list) else 0
+            overview_channels.append(overview)
+        return {
+            "schema_version": self.model.get("schema_version", SCHEMA_VERSION),
+            "channels": overview_channels,
+        }
+
+    def channel(self, channel_id: str) -> dict[str, object]:
+        """選択チャンネルの動画を含む詳細を返す。"""
+        for item in self._channels():
+            if item.get("id") == channel_id:
+                return item
+        raise DashboardChannelNotFoundError(f"dashboard channel が見つかりません: {channel_id}")

--- a/src/youtube_automation/utils/exceptions.py
+++ b/src/youtube_automation/utils/exceptions.py
@@ -19,6 +19,14 @@ class ConfigError(AutomationError):
     """
 
 
+class ChannelRegistryError(ConfigError):
+    """所有チャンネル registry の読み込み・バリデーションエラー。"""
+
+
+class DashboardChannelNotFoundError(AutomationError):
+    """Dashboard read model に要求されたチャンネルが存在しない。"""
+
+
 class YouTubeAPIError(AutomationError):
     """YouTube Data API / Analytics API の呼び出しエラー
 

--- a/tests/test_channel_registry.py
+++ b/tests/test_channel_registry.py
@@ -1,0 +1,52 @@
+"""所有チャンネル registry の public contract。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.utils.channel_registry import load_channel_registry
+from youtube_automation.utils.exceptions import ChannelRegistryError
+
+
+def test_registry_returns_absolute_paths_in_declared_order(tmp_path: Path) -> None:
+    first = tmp_path / "first-channel"
+    second = tmp_path / "second-channel"
+    registry = tmp_path / "channels.json"
+    registry.write_text(json.dumps([str(second), str(first)]), encoding="utf-8")
+
+    assert load_channel_registry(registry) == [second, first]
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        ("not-json", "JSON"),
+        (json.dumps({"channels": []}), "JSON 配列"),
+        (json.dumps(["relative/channel"]), "index 0"),
+    ],
+)
+def test_registry_rejects_invalid_documents(tmp_path: Path, contents: str, message: str) -> None:
+    registry = tmp_path / "channels.json"
+    registry.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ChannelRegistryError, match=message):
+        load_channel_registry(registry)
+
+
+def test_registry_reports_missing_location(tmp_path: Path) -> None:
+    registry = tmp_path / "missing.json"
+
+    with pytest.raises(ChannelRegistryError, match=str(registry)):
+        load_channel_registry(registry)
+
+
+def test_registry_rejects_duplicate_paths(tmp_path: Path) -> None:
+    channel = tmp_path / "channel"
+    registry = tmp_path / "channels.json"
+    registry.write_text(json.dumps([str(channel), str(channel)]), encoding="utf-8")
+
+    with pytest.raises(ChannelRegistryError, match="index 1.*重複"):
+        load_channel_registry(registry)

--- a/tests/test_dashboard_read_model.py
+++ b/tests/test_dashboard_read_model.py
@@ -1,0 +1,193 @@
+"""Dashboard read model/API の public contract。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.utils.dashboard_read_model import DashboardAPI, build_dashboard_read_model
+from youtube_automation.utils.exceptions import DashboardChannelNotFoundError
+
+
+def _write_channel(channel: Path, *, name: str, snapshots: dict[str, dict]) -> None:
+    meta = channel / "config" / "channel" / "meta.json"
+    meta.parent.mkdir(parents=True)
+    meta.write_text(json.dumps({"channel": {"name": name}}), encoding="utf-8")
+    data = channel / "data"
+    data.mkdir()
+    for filename, payload in snapshots.items():
+        (data / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _snapshot(*, collected_at: str, views: int, video_views: int) -> dict:
+    return {
+        "collection_period": {
+            "start_date": "2026-07-01",
+            "end_date": "2026-07-20",
+            "collected_at": collected_at,
+        },
+        "channel_analytics": {
+            "summary": {
+                "total_views": views,
+                "total_watch_time": 420,
+                "net_subscribers": 8,
+                "total_engagement": 31,
+                "avg_view_percentage": 62.5,
+            }
+        },
+        "video_analytics": {
+            "video-b": {
+                "video_id": "video-b",
+                "title": "Later video",
+                "views": video_views,
+                "likes": 20,
+                "comments": 4,
+                "shares": 3,
+                "subscribers_gained": 2,
+                "average_view_duration": 180,
+            }
+        },
+        "reporting_api": {
+            "impressions_summary": {"per_video": [{"video_id": "video-b", "impressions": 1000, "ctr_percentage": 4.5}]}
+        },
+    }
+
+
+def test_read_model_uses_latest_snapshot_and_normalizes_metrics(tmp_path: Path) -> None:
+    channel = tmp_path / "channel-one"
+    _write_channel(
+        channel,
+        name="Channel One",
+        snapshots={
+            "analytics_data_20260701.json": _snapshot(
+                collected_at="2026-07-01T00:00:00+00:00", views=100, video_views=40
+            ),
+            "analytics_data_20260720.json": _snapshot(
+                collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+            ),
+        },
+    )
+
+    model = build_dashboard_read_model([channel])
+
+    assert model["schema_version"] == 1
+    item = model["channels"][0]
+    assert item["name"] == "Channel One"
+    assert item["status"] == "ready"
+    assert item["snapshot"] == "analytics_data_20260720.json"
+    assert item["collected_at"] == "2026-07-20T00:00:00+00:00"
+    assert item["summary"] == {
+        "views": 900,
+        "watch_time_minutes": 420,
+        "subscribers_net": 8,
+        "engagements": 31,
+        "average_view_percentage": 62.5,
+    }
+    assert item["videos"] == [
+        {
+            "video_id": "video-b",
+            "title": "Later video",
+            "views": 700,
+            "impressions": 1000,
+            "ctr_percentage": 4.5,
+            "likes": 20,
+            "comments": 4,
+            "shares": 3,
+            "subscribers_gained": 2,
+            "average_view_duration_seconds": 180,
+            "engagements": 27,
+        }
+    ]
+
+
+def test_read_model_keeps_other_channels_when_snapshot_is_missing_or_broken(tmp_path: Path) -> None:
+    ready = tmp_path / "ready"
+    _write_channel(
+        ready,
+        name="Ready",
+        snapshots={
+            "analytics_data_20260720.json": _snapshot(
+                collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+            )
+        },
+    )
+    missing = tmp_path / "missing"
+    _write_channel(missing, name="Missing", snapshots={})
+    broken = tmp_path / "broken"
+    _write_channel(broken, name="Broken", snapshots={})
+    (broken / "data" / "analytics_data_20260720.json").write_text("not-json", encoding="utf-8")
+
+    model = build_dashboard_read_model([missing, ready, broken])
+
+    channels = model["channels"]
+    assert [item["name"] for item in channels] == ["Missing", "Ready", "Broken"]
+    assert channels[0]["status"] == "missing_snapshot"
+    assert channels[0]["error"]["code"] == "snapshot_missing"
+    assert channels[0]["videos"] == []
+    assert channels[1]["status"] == "ready"
+    assert channels[2]["status"] == "invalid_snapshot"
+    assert channels[2]["error"]["code"] == "snapshot_invalid"
+
+
+def test_read_model_marks_invalid_meta_without_stopping_other_channels(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid-meta"
+    (invalid / "config" / "channel").mkdir(parents=True)
+    (invalid / "config" / "channel" / "meta.json").write_text("{}", encoding="utf-8")
+
+    item = build_dashboard_read_model([invalid])["channels"][0]
+
+    assert item["status"] == "invalid_channel"
+    assert item["error"]["code"] == "meta_invalid"
+    assert item["name"] == "invalid-meta"
+
+
+def test_dashboard_api_exposes_overview_and_selected_channel(tmp_path: Path) -> None:
+    channel = tmp_path / "channel"
+    _write_channel(
+        channel,
+        name="Selected",
+        snapshots={
+            "analytics_data_20260720.json": _snapshot(
+                collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+            )
+        },
+    )
+    api = DashboardAPI(build_dashboard_read_model([channel]))
+
+    overview = api.overview()
+    channel_id = overview["channels"][0]["id"]
+
+    assert "videos" not in overview["channels"][0]
+    assert overview["channels"][0]["video_count"] == 1
+    assert api.channel(channel_id)["videos"][0]["video_id"] == "video-b"
+    with pytest.raises(DashboardChannelNotFoundError, match="unknown"):
+        api.channel("unknown")
+
+
+def test_read_model_does_not_modify_channel_files(tmp_path: Path) -> None:
+    channel = tmp_path / "read-only"
+    _write_channel(
+        channel,
+        name="Read Only",
+        snapshots={
+            "analytics_data_20260720.json": _snapshot(
+                collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+            )
+        },
+    )
+    before = {
+        path.relative_to(channel): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in channel.rglob("*")
+        if path.is_file()
+    }
+
+    build_dashboard_read_model([channel])
+
+    after = {
+        path.relative_to(channel): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in channel.rglob("*")
+        if path.is_file()
+    }
+    assert after == before


### PR DESCRIPTION
## Summary

- `~/.config/tayk/channels.json` の絶対path registry loaderを追加
- 最新Analytics snapshotを概要・動画指標・Reporting CTRへ正規化
- snapshot欠損/破損・meta不正をチャンネル単位の状態として隔離
- overview/detailを提供する読み取り専用 `DashboardAPI` を追加

## Tests

- `uv run pytest tests/test_channel_registry.py tests/test_dashboard_read_model.py -q` (11 passed)
- behavioral fast lane (5154 passed)
- unit-only full suite (6516 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`

Closes #2387