### PR TITLE
docs(plans): 第 5 回セキュリティ監査のプラン 025〜027 を追加する

### DIFF
--- a/plans/025-client-secrets-in-memory.md
+++ b/plans/025-client-secrets-in-memory.md
@@ -1,0 +1,260 @@
+# Plan 025: 1Password フォールバックの client_secrets を tempfile 経由から in-memory 渡しに変更する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 37b362ce..HEAD -- src/youtube_automation/utils/secrets.py src/youtube_automation/auth/oauth_handler.py tests/test_secrets.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED（OAuth 初回認証フローに触る。既存テストは厚い）
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `37b362ce`, 2026-07-21
+
+## Why this matters
+
+`config/channel` 側に `auth/client_secrets.json` が無いチャンネルでは、OAuth client secret を 1Password（`op read`）から取得し、**システム temp ディレクトリに平文 JSON として書き出してから** `InstalledAppFlow.from_client_secrets_file()` に渡している。ファイルは `0o600` で作成され `atexit` で削除されるが、`atexit` は SIGKILL・SIGSEGV・電源断では走らないため、異常終了時に `$TMPDIR/client_secrets_*.json` が残留する。`google-auth-oauthlib` には in-memory dict を受け取る `InstalledAppFlow.from_client_config()` が存在するので、tempfile を経由せず secret をディスクに一切書かない実装に置き換えられる。第 5 回セキュリティ監査（2026-07-21）の finding #1。
+
+## Current state
+
+関係ファイルと役割:
+
+- `src/youtube_automation/utils/secrets.py` — シークレット取得ヘルパー。`get_client_secrets_path()`（L112-144）が tempfile を書く当事者。モジュールグローバル `_client_secrets_tempfile`（L109）と `atexit` cleanup（L137-142）を持つ
+- `src/youtube_automation/auth/oauth_handler.py` — 唯一の消費者。`resolve_client_secrets_path()`（L112-128）が「実ファイル探索 → 見つからなければ `get_client_secrets_path()` フォールバック」を行い、`YouTubeOAuthHandler.__init__`（L172）が `self.client_secrets_file` に格納。`_validate_client_secrets()`（L252-285）がファイルを読んで JSON 形状検証、`authenticate()`（L334）が `from_client_secrets_file` に渡す
+- `tests/test_secrets.py` / `tests/test_oauth_handler_main.py` ほか `tests/test_oauth_*.py` — 既存テスト。構造パターンの手本
+
+`secrets.py:112-144`（現状・要旨）:
+
+```python
+def get_client_secrets_path() -> Path:
+    global _client_secrets_tempfile
+    if _client_secrets_tempfile and _client_secrets_tempfile.exists():
+        return _client_secrets_tempfile
+    json_content = get_secret("CLIENT_SECRETS_JSON")
+    fd, path = tempfile.mkstemp(prefix="client_secrets_", suffix=".json")
+    os.chmod(path, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(json_content)
+    def _cleanup(p: str = path) -> None:
+        if os.path.exists(p):
+            os.unlink(p)
+    atexit.register(_cleanup)
+    _client_secrets_tempfile = Path(path)
+    return _client_secrets_tempfile
+```
+
+`oauth_handler.py:112-128`（現状）:
+
+```python
+def resolve_client_secrets_path(channel_dir: Path | None = None) -> Path:
+    """実行時 OAuth が使う client_secrets.json の検索順を解決する。"""
+    if channel_dir is None:
+        from youtube_automation.utils.config import channel_dir as _channel_dir
+        channel_dir = _channel_dir()
+    kind, path = resolve_client_secrets_location(channel_dir)
+    if kind in {"file", "invalid-file", "missing-file"}:
+        return path
+    try:
+        from youtube_automation.utils.secrets import get_client_secrets_path
+        return get_client_secrets_path()
+    except ConfigError:
+        return path
+```
+
+`oauth_handler.py:172`（`__init__` 内）:
+
+```python
+self.client_secrets_file = resolve_client_secrets_path(channel_dir)
+```
+
+`oauth_handler.py:273-285`（`_validate_client_secrets` の JSON 形状検証部）:
+
+```python
+try:
+    data = json.loads(self.client_secrets_file.read_text(encoding="utf-8"))
+except (json.JSONDecodeError, OSError) as e:
+    raise ValidationError(f"client_secrets.json 読み込み失敗: {e}") from e
+if not isinstance(data, dict):
+    raise ValidationError("client_secrets.json は JSON object である必要があります")
+installed = data.get("installed")
+if not isinstance(installed, dict):
+    raise ValidationError("Desktop app の client_secrets.json が必要です: installed セクションがありません")
+required_keys = ("client_id", "client_secret", "redirect_uris")
+missing = [key for key in required_keys if key not in installed]
+if missing:
+    raise ValidationError(f"client_secrets.json に必須キー不足: {','.join(missing)}")
+```
+
+`oauth_handler.py:334`（`authenticate` 内）:
+
+```python
+flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secrets_file), self._scopes)
+```
+
+その他の `self.client_secrets_file` 参照（挙動を維持すべき箇所）: L354・L426 の `_redact(...)` 引数、L479 の `paths.extend([auth_handler.client_secrets_file, auth_handler.token_file])`。いずれも「パス表示/redact 用途」なので、フォールバック時も候補パス（`<channel_dir>/auth/client_secrets.json`）を指していれば足りる。
+
+リポジトリ規約: fully-qualified import（`from youtube_automation.xxx import ...`）、ドメイン例外（`ConfigError` / `ValidationError` / `AuthError`、`utils/exceptions.py`）、docstring とコメントは日本語。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `uv run pytest tests/test_secrets.py tests/test_oauth_handler_main.py tests/test_oauth_handler_exceptions.py tests/test_oauth_worktree_fallback.py -q` | all pass |
+| 全体テスト（高速レーン） | `uv run pytest -q -m "not slow and not repo_contract" -n auto` | all pass |
+| Lint | `uv run ruff check src tests` | exit 0 |
+| 残存参照確認 | `rg -n "get_client_secrets_path" src tests` | 移行後は 0 件（Step 4 完了時） |
+
+## Scope
+
+**In scope**（変更してよいファイル）:
+- `src/youtube_automation/utils/secrets.py`
+- `src/youtube_automation/auth/oauth_handler.py`
+- `tests/test_secrets.py`
+- `tests/test_oauth_handler_main.py`（必要な範囲で）
+- `CHANGELOG.md`（`[Unreleased]` 追記 — src 変更のため必須ゲート）
+- `plans/README.md`（status 更新）
+
+**Out of scope**（触らない）:
+- `src/youtube_automation/cli/doctor.py` — `_client_secrets_file_for_accounts` は実ファイル探索専用で tempfile 経路に依存しない
+- `resolve_client_secrets_location()` / `client_secrets_file_candidates()`（oauth_handler.py L68-109）の探索順序・分類 — 変更禁止（doctor / onboarding が契約として依存、`tests/test_oauth_onboarding_contract.py` が監視）
+- `write_op_secret()` / `get_secret()` 本体のシグネチャ
+
+## Git workflow
+
+- リポジトリ規約: 作業は必ず worktree（`$REPO_ROOT/.worktrees/<slug>/`）上で行う。main へ直接コミットしない
+- Branch 例: `advisor/025-client-secrets-in-memory`
+- Commit: 日本語 Conventional Commits（例: `fix(auth): client_secrets の 1Password フォールバックを in-memory 化する`）
+- push / PR はオペレーターの指示があるまで行わない
+
+## Steps
+
+### Step 1: `secrets.py` に `get_client_secrets_config()` を追加
+
+`get_secret("CLIENT_SECRETS_JSON")` の戻り値を `json.loads` して dict で返す関数を追加する:
+
+```python
+def get_client_secrets_config() -> dict:
+    """client_secrets の JSON 内容を in-memory dict で取得する。
+
+    tempfile を経由しないため、異常終了時にも secret がディスクに残らない。
+
+    Raises:
+        ConfigError: 取得できない、または JSON として解釈できない場合
+    """
+    raw = get_secret("CLIENT_SECRETS_JSON")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ConfigError(f"CLIENT_SECRETS_JSON を JSON として解釈できません: {e}") from e
+    if not isinstance(data, dict):
+        raise ConfigError("CLIENT_SECRETS_JSON は JSON object である必要があります")
+    return data
+```
+
+エラーメッセージに secret の値そのものを含めないこと（`{e}` は位置情報のみで値を含まないので可）。
+
+**Verify**: `uv run pytest tests/test_secrets.py -q` → 既存 all pass（新関数はまだ未テストでよい）
+
+### Step 2: `oauth_handler.py` をフォールバック時 in-memory 化
+
+1. `resolve_client_secrets_path()` の tempfile フォールバック分岐（L123-128）を「候補パスをそのまま返す」に変更するのではなく、**新しい解決関数を追加**する:
+
+```python
+def resolve_client_secrets_source(channel_dir: Path | None = None) -> tuple[Path, dict | None]:
+    """client_secrets の (表示用パス, in-memory config) を解決する。
+
+    実ファイルがあれば (そのパス, None)。無ければ 1Password フォールバックを試み、
+    成功時は (候補パス, dict)、失敗時は (候補パス, None) を返す。
+    """
+```
+
+実装は現行 `resolve_client_secrets_path` のロジックを流用し、`kind == "secret-fallback"` のとき `get_client_secrets_config()` を試す（`ConfigError` は握って `(path, None)`）。
+
+2. `__init__`（L172）を差し替え:
+
+```python
+self.client_secrets_file, self._client_secrets_config = resolve_client_secrets_source(channel_dir)
+```
+
+3. `_validate_client_secrets()`（L252-285）: JSON 形状検証部（L277-285 の dict / installed / required_keys チェック）をモジュールレベル関数 `_validate_client_secrets_data(data: dict) -> None` に抽出し、冒頭に分岐を追加:
+
+```python
+if self._client_secrets_config is not None:
+    _validate_client_secrets_data(self._client_secrets_config)
+    return
+```
+
+ファイル経路（既存の exists / is_file / read_text チェック）は現行どおり残し、抽出した `_validate_client_secrets_data` を呼ぶ形にする。エラーメッセージ文言は変更しない（onboarding contract テストが文言に依存する可能性がある）。
+
+4. `authenticate()`（L334）を分岐:
+
+```python
+if self._client_secrets_config is not None:
+    flow = InstalledAppFlow.from_client_config(self._client_secrets_config, self._scopes)
+else:
+    flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secrets_file), self._scopes)
+```
+
+5. 旧 `resolve_client_secrets_path()` は他 callsite が無ければ削除、あれば `resolve_client_secrets_source()[0]` を返す thin wrapper として残す（`rg -n "resolve_client_secrets_path" src tests` で確認して判断）。
+
+**Verify**: `uv run pytest tests/test_oauth_handler_main.py tests/test_oauth_handler_exceptions.py tests/test_oauth_onboarding_contract.py -q` → all pass
+
+### Step 3: `secrets.py` から tempfile 機構を削除
+
+`get_client_secrets_path()`・`_client_secrets_tempfile`・`atexit` cleanup（L109-144）と、不要になった `import atexit` / `import tempfile` を削除する。先に `rg -n "get_client_secrets_path" src tests` で参照ゼロ（tests 内の直接テストは Step 4 で書き換え）を確認すること。
+
+**Verify**: `rg -n "get_client_secrets_path|_client_secrets_tempfile" src` → 0 件。`uv run ruff check src` → exit 0
+
+### Step 4: テスト更新・追加
+
+`tests/test_secrets.py` の既存構造（`monkeypatch.setenv` + `reset_cache`）に倣い:
+
+- `get_client_secrets_config`: (a) env `CLIENT_SECRETS_JSON` に有効 JSON → dict が返る、(b) 不正 JSON → `ConfigError`、(c) JSON だが object でない（例 `"[]"`）→ `ConfigError`
+- `get_client_secrets_path` の旧テストは削除または config 版に書き換え
+- `tests/test_oauth_handler_main.py` に倣い、フォールバック経路のハンドラで: (d) `_validate_client_secrets()` が in-memory dict を検証し tempfile を作らない（`tmp_path` を `TMPDIR` に向けて `client_secrets_*` グロブが空であることを assert）、(e) `authenticate()` が `from_client_config` を呼ぶ（`InstalledAppFlow` を monkeypatch して呼び分けを assert）
+
+**Verify**: `uv run pytest tests/test_secrets.py tests/test_oauth_handler_main.py -q` → all pass（新規 5 ケース以上を含む）
+
+### Step 5: CHANGELOG 追記と最終確認
+
+`CHANGELOG.md` の `[Unreleased]` に Security 項目として追記（例: 「1Password フォールバック時の client_secrets を tempfile 経由から in-memory 渡しに変更し、異常終了時のディスク残留を解消」）。
+
+**Verify**: `uv run pytest -q -m "not slow and not repo_contract" -n auto` → all pass / `uv run ruff check src tests` → exit 0
+
+## Test plan
+
+上記 Step 4 の (a)〜(e)。構造パターンは `tests/test_secrets.py`（env + reset_cache）と `tests/test_oauth_handler_main.py`（ハンドラ初期化のフィクスチャ）に従う。`tests/conftest.py` が `CHANNEL_DIR` を `tests/fixtures/sample_channel/` に向け、`YOUTUBE_AUTOMATION_DISABLE_OP_READ=1` が既定有効な点に注意（テストは env 経由で secret を注入する）。
+
+## Done criteria
+
+- [ ] `rg -n "get_client_secrets_path|mkstemp" src/youtube_automation/utils/secrets.py` → 0 件
+- [ ] `rg -n "from_client_config" src/youtube_automation/auth/oauth_handler.py` → 1 件以上
+- [ ] `uv run pytest tests/test_secrets.py tests/test_oauth_handler_main.py tests/test_oauth_handler_exceptions.py tests/test_oauth_onboarding_contract.py tests/test_oauth_worktree_fallback.py -q` → all pass
+- [ ] `uv run pytest -q -m "not slow and not repo_contract" -n auto` → all pass
+- [ ] `uv run ruff check src tests` → exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記あり
+- [ ] in-scope 外のファイルに変更なし（`git status`）
+- [ ] `plans/README.md` の status 更新
+
+## STOP conditions
+
+- "Current state" の抜粋と実コードが一致しない（drift）
+- `resolve_client_secrets_path` の callsite が oauth_handler 以外に 3 箇所以上見つかった（設計判断が必要 — wrapper 維持で済むか advisor に確認）
+- `tests/test_oauth_onboarding_contract.py` がエラーメッセージ文言の変更で fail した（文言を戻しても解消しない場合）
+- `InstalledAppFlow.from_client_config` がインストール済み `google-auth-oauthlib` に存在しない（バージョン確認の上報告）
+
+## Maintenance notes
+
+- 今後 `client_secrets` の新しい消費者を追加する場合は、パスではなく `resolve_client_secrets_source()` を使い、tempfile 復活させないこと
+- レビュー観点: フォールバック時のエラーメッセージ UX（「client_secrets.json が見つかりません」ガイド文）が従来どおり出ること
+- 見送った follow-up: 実ファイル経路（`auth/client_secrets.json`）自体の in-memory 化は不要（ユーザー自身が置いた永続ファイルであり脅威モデルが異なる）

--- a/plans/025-client-secrets-in-memory.md
+++ b/plans/025-client-secrets-in-memory.md
@@ -20,6 +20,7 @@
 - **Depends on**: none
 - **Category**: security
 - **Planned at**: commit `37b362ce`, 2026-07-21
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/2394
 
 ## Why this matters
 

--- a/plans/026-terraform-stream-env-staging.md
+++ b/plans/026-terraform-stream-env-staging.md
@@ -1,0 +1,157 @@
+# Plan 026: streaming VPS provisioning の stream key / webhook を素の /tmp 経由から 0700 ディレクトリ staging に変更する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 37b362ce..HEAD -- infra/terraform/streaming/`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW（provisioner の staging パス変更のみ。サービス定義・鍵管理は不変）
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `37b362ce`, 2026-07-21
+
+## Why this matters
+
+streaming VPS の Terraform provisioning で、YouTube stream key を含む env ファイルと Discord webhook URL を含む env ファイルを、SSH の `file` provisioner がまず `/tmp/*.tmp` に書き、その後の `remote-exec` が `install -m 0600` で本配置して削除している。`file` provisioner はデフォルト権限（通常 0644）で書くため、`install` が走るまでの数秒間、stream key / webhook URL が world-readable になる窓がある。単一テナント VPS なので悪用可能性は極めて低いが、同じ main.tf 内の live-chat-reply 経路は既に `install -d -m 0700` で作った専用ディレクトリに staging する正しいパターンを実装済みであり、揃えるだけで窓が消える。第 5 回セキュリティ監査（2026-07-21）の finding #2。
+
+## Current state
+
+関係ファイル:
+
+- `infra/terraform/streaming/main.tf` — VPS provisioning 本体。問題箇所は `youtube-stream` 側の file provisioner 2 つ（L118-131）と remote-exec（L171-177）。**手本となる live-chat-reply 側の正しいパターンは L235-286**
+- `infra/terraform/streaming/variables.tf` — `stream_key` / `discord_webhook_url` は `sensitive = true` 済み（変更不要）
+- `tests/test_terraform_bootstrap.py` / `tests/streaming/` — Terraform まわりの既存テスト（内容確認の上、staging パスをアサートしていれば追従）
+
+`main.tf:118-131`（現状・問題箇所）:
+
+```hcl
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/youtube-stream.env.tftpl", {
+      video    = "${var.install_root}/videos/current.mp4"
+      rtmp_url = "rtmp://a.rtmp.youtube.com/live2/${var.stream_key}"
+    })
+    destination = "/tmp/youtube-stream.env.tmp"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/youtube-stream-healthcheck.env.tftpl", {
+      webhook = var.discord_webhook_url
+    })
+    destination = "/tmp/youtube-stream-healthcheck.env.tmp"
+  }
+```
+
+`main.tf:171-177`（現状・本配置部）:
+
+```hcl
+  provisioner "remote-exec" {
+    inline = [
+      "umask 0077",
+      "install -m 0600 -o root -g root /tmp/youtube-stream.env.tmp /etc/youtube-stream.env",
+      "rm -f /tmp/youtube-stream.env.tmp",
+      "install -m 0600 -o root -g root /tmp/youtube-stream-healthcheck.env.tmp /etc/youtube-stream-healthcheck.env",
+      "rm -f /tmp/youtube-stream-healthcheck.env.tmp",
+```
+
+手本（live-chat-reply 側、`main.tf:235-241` 付近）: file provisioner の **前に** remote-exec で `install -d -m 0700 -o root -g root /run/live-chat-reply` を実行し、file provisioner の destination を `/run/live-chat-reply/...` にしている。provisioner はブロック記述順に直列実行されるので、「先に 0700 ディレクトリを作る remote-exec → そこへ file provisioner」で権限窓が消える。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| フォーマット検査 | `terraform -chdir=infra/terraform/streaming fmt -check` | exit 0 |
+| 構文検証（初回） | `terraform -chdir=infra/terraform/streaming init -backend=false` | 成功（provider download のみ） |
+| 構文検証 | `terraform -chdir=infra/terraform/streaming validate` | `Success! The configuration is valid.` |
+| 関連テスト | `uv run pytest tests/test_terraform_bootstrap.py tests/streaming -q` | all pass |
+
+（Terraform v1.15.8 がローカルにあることは確認済み。`init -backend=false` は state に触れない読み取り系操作）
+
+## Scope
+
+**In scope**:
+- `infra/terraform/streaming/main.tf`
+- `tests/streaming/` / `tests/test_terraform_bootstrap.py`（staging パスをアサートしているテストがあれば追従のみ）
+- `plans/README.md`（status 更新）
+- `CHANGELOG.md` — infra はゲート対象外だが、セキュリティ改善として `[Unreleased]` 追記を推奨（任意）
+
+**Out of scope**:
+- live-chat-reply 側の provisioner（L235 以降）— 既に正しいパターン。触らない
+- SSH host key の pre-seed 方式（`tls_private_key.ssh_host` / cloud-init）— 第 5 回監査で「host-key pinning のための意図的トレードオフ」として受容済み。変更しない
+- `variables.tf` / templates / systemd unit — 変更不要
+- **`terraform apply` / `plan` の実行** — 実 VPS に触れる操作は行わない（検証は fmt / validate / pytest まで）
+
+## Git workflow
+
+- 作業は worktree（`$REPO_ROOT/.worktrees/<slug>/`）上で行う
+- Branch 例: `advisor/026-terraform-stream-env-staging`
+- Commit 例: `fix(streaming): stream env の staging を 0700 ディレクトリに変更する`
+- push / PR はオペレーターの指示があるまで行わない
+
+## Steps
+
+### Step 1: staging ディレクトリ作成の remote-exec を file provisioner の前に挿入
+
+`main.tf` の `youtube-stream` 側 file provisioner 群（L113 の `var.video_path` 転送より後、L118 の env 転送より前）に挿入:
+
+```hcl
+  provisioner "remote-exec" {
+    inline = [
+      "install -d -m 0700 -o root -g root /run/youtube-stream-provision",
+    ]
+  }
+```
+
+（`/run` は tmpfs なので再起動で自動消滅する — live-chat 側と同じ選定理由）
+
+### Step 2: env 2 ファイルの destination と install 元を差し替え
+
+- L123: `destination = "/tmp/youtube-stream.env.tmp"` → `"/run/youtube-stream-provision/youtube-stream.env.tmp"`
+- L130: `destination = "/tmp/youtube-stream-healthcheck.env.tmp"` → `"/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp"`
+- remote-exec（L171-177）の `install` / `rm -f` の元パス 4 箇所を同様に差し替え、最後の `rm -f` の後に `"rm -rf /run/youtube-stream-provision"` を追加（live-chat 側の後始末パターンに合わせる）
+
+**Verify**: `rg -n '/tmp/youtube-stream' infra/terraform/streaming/` → 0 件
+
+### Step 3: fmt / validate / テスト
+
+**Verify**:
+1. `terraform -chdir=infra/terraform/streaming fmt -check` → exit 0
+2. `terraform -chdir=infra/terraform/streaming init -backend=false` → 成功（既に init 済みならスキップ可）
+3. `terraform -chdir=infra/terraform/streaming validate` → `Success!`
+4. `uv run pytest tests/test_terraform_bootstrap.py tests/streaming -q` → all pass（`/tmp/youtube-stream` をアサートしているテストがあれば新パスに更新）
+
+## Test plan
+
+既存の `tests/test_terraform_bootstrap.py` / `tests/streaming/` が main.tf の内容を静的にアサートしている場合のみ追従修正。新規テストを書くなら「`main.tf` に `/tmp/youtube-stream` という文字列が現れない」ことの回帰テスト 1 本（既存の repo_contract 系テストの書き方に倣う）で十分。
+
+## Done criteria
+
+- [ ] `rg -n '/tmp/youtube-stream' infra/terraform/streaming/` → 0 件
+- [ ] `terraform -chdir=infra/terraform/streaming fmt -check` → exit 0
+- [ ] `terraform -chdir=infra/terraform/streaming validate` → Success
+- [ ] `uv run pytest tests/test_terraform_bootstrap.py tests/streaming -q` → all pass
+- [ ] in-scope 外のファイルに変更なし（`git status`）
+- [ ] `plans/README.md` の status 更新
+
+## STOP conditions
+
+- "Current state" の抜粋と実コードが一致しない（drift）
+- `youtube-stream` 側の provisioner 実行順が想定（video → env → service → remote-exec）と異なる構造になっていた
+- validate が provisioner 順序起因で fail し、1 回の修正で解消しない
+- 修正が templates / variables / live-chat 側に波及しそうになった（out of scope）
+
+## Maintenance notes
+
+- 次回 `terraform apply` 時にこの provisioner 差分で `null_resource` / instance の再 provisioning が走る可能性がある。**apply はオペレーターが実施**し、配信停止ウィンドウを許容できるタイミングで行うこと
+- 今後 provisioner でシークレットを VPS に渡すときは必ずこの `/run/<name>-provision`（0700）パターンを使う
+- レビュー観点: remote-exec の挿入位置（file provisioner より前）と、後始末 `rm -rf` の追加

--- a/plans/026-terraform-stream-env-staging.md
+++ b/plans/026-terraform-stream-env-staging.md
@@ -20,6 +20,7 @@
 - **Depends on**: none
 - **Category**: security
 - **Planned at**: commit `37b362ce`, 2026-07-21
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/2395
 
 ## Why this matters
 

--- a/plans/027-argv-absolute-path-hardening.md
+++ b/plans/027-argv-absolute-path-hardening.md
@@ -1,0 +1,146 @@
+# Plan 027: open / ffmpeg に渡すパス引数を絶対パス化してフラグ誤解釈の余地を消す
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 37b362ce..HEAD -- src/youtube_automation/scripts/stock_preview.py src/youtube_automation/scripts/compare_thumbnails.py src/youtube_automation/utils/upload_core.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW（`.resolve()` の付加のみ。挙動は同一）
+- **Depends on**: none
+- **Category**: security（defense-in-depth。悪用可能な欠陥ではない）
+- **Planned at**: commit `37b362ce`, 2026-07-21
+
+## Why this matters
+
+`open` / `ffmpeg` の argv にファイルシステム由来のパスを渡す箇所が数箇所あり、仮に先頭が `-` のパスが混入するとフラグとして解釈される余地がある（shell は経由しないので RCE 経路は無く、実害は「想定外フラグで失敗する」程度）。第 5 回セキュリティ監査（2026-07-21）の vet では、**現状の全呼び出し箇所の入力はディレクトリ結合済み Path であり先頭 `-` になり得ない（= 現時点で悪用不能）** ことを確認済み。本プランは、将来のリファクタで相対パスが混入しても安全なままにする純粋な defense-in-depth であり、優先度は最低。手が空いたときに実施すればよい。
+
+**重要**: サブエージェント監査が提案した「`--` セパレータの挿入」は採用しない。**ffmpeg は `--` による end-of-options をサポートしない**ため壊れる。正しい対策は「argv に渡す時点で絶対パスであることを保証する（`.resolve()`）」こと。絶対パスは `/` 始まりなのでフラグ解釈され得ない。
+
+## Current state
+
+対象 3 ファイル・4 箇所:
+
+`src/youtube_automation/scripts/stock_preview.py:48,59` — stock 画像の一括プレビュー:
+
+```python
+    paths = [str(e.image_path) for e in entries]
+    ...
+    subprocess.run(["open", *paths], check=False)
+```
+
+`src/youtube_automation/scripts/compare_thumbnails.py:75-79` — サムネの 320px 縮小:
+
+```python
+            subprocess.run(
+                ["ffmpeg", "-i", str(input_path), "-vf", f"scale={SMALL_WIDTH}:{SMALL_HEIGHT}", "-y", str(output_path)],
+                capture_output=True,
+                check=True,
+            )
+```
+
+`src/youtube_automation/scripts/compare_thumbnails.py:149` — 比較ディレクトリを Finder で開く:
+
+```python
+            subprocess.run(["open", str(self.small_dir if small_only else self.compare_dir)])
+```
+
+`src/youtube_automation/utils/upload_core.py:271-274` — サムネの JPEG 圧縮:
+
+```python
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", str(thumbnail_path), "-qscale:v", str(quality), str(compressed)],
+                capture_output=True,
+            )
+```
+
+リポジトリ規約: コメントは「コードで表せない制約」のみ日本語で書く。既存テスト `tests/test_upload_core_thumbnail.py` が `_compress_thumbnail` をカバー。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `uv run pytest tests/test_upload_core_thumbnail.py -q` | all pass |
+| 全体テスト（高速レーン） | `uv run pytest -q -m "not slow and not repo_contract" -n auto` | all pass |
+| Lint | `uv run ruff check src tests` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `src/youtube_automation/scripts/stock_preview.py`
+- `src/youtube_automation/scripts/compare_thumbnails.py`
+- `src/youtube_automation/utils/upload_core.py`
+- `tests/test_upload_core_thumbnail.py`（アサート追加のみ）
+- `CHANGELOG.md`（`[Unreleased]` 追記 — src 変更のため必須ゲート）
+- `plans/README.md`（status 更新）
+
+**Out of scope**:
+- リポジトリ内の他の subprocess 呼び出し（監査で argv リスト形式・安全と確認済み。網羅的な書き換えはノイズ）
+- `--` セパレータの導入（ffmpeg 非対応のため禁止）
+- ffprobe 側（`utils/veo_generator.py:433` は既に `--` 付きで対応済み — ffprobe は `--` をサポートする）
+
+## Git workflow
+
+- 作業は worktree（`$REPO_ROOT/.worktrees/<slug>/`）上で行う
+- Branch 例: `advisor/027-argv-absolute-path-hardening`
+- Commit 例: `fix(scripts): subprocess へ渡すパス引数を絶対パス化する`
+- push / PR はオペレーターの指示があるまで行わない
+
+## Steps
+
+### Step 1: 4 箇所のパス引数に `.resolve()` を付加
+
+- `stock_preview.py:48`: `paths = [str(e.image_path.resolve()) for e in entries]`（`--print-only` の出力も絶対パスになるが、絶対パス表示はプレビュー用途としてむしろ望ましい）
+- `compare_thumbnails.py:76`: `str(input_path.resolve())` / `str(output_path.resolve())`（`output_path` は `-y` の後ろの出力先。resolve は親が存在すれば非存在ファイルでも動く — `small_dir` は L92-93 で `mkdir` 済み）
+- `compare_thumbnails.py:149`: `str((self.small_dir if small_only else self.compare_dir).resolve())`
+- `upload_core.py:272`: `str(thumbnail_path.resolve())`（`compressed` は `NamedTemporaryFile` 由来で常に絶対パスなのでそのままでよいが、揃えて `.resolve()` しても害はない）
+
+**Verify**: `uv run ruff check src` → exit 0
+
+### Step 2: 回帰アサートの追加
+
+`tests/test_upload_core_thumbnail.py` の既存テスト構造に倣い、`subprocess.run` を monkeypatch して受け取った argv の入力パス（`-i` の次要素）が `os.path.isabs()` で True であることを assert する 1 ケースを追加（相対パスの `thumbnail_path` を渡して確認）。
+
+**Verify**: `uv run pytest tests/test_upload_core_thumbnail.py -q` → all pass（新規 1 ケース含む）
+
+### Step 3: CHANGELOG 追記と最終確認
+
+`CHANGELOG.md` の `[Unreleased]` に追記（例: 「open / ffmpeg へ渡すパス引数を絶対パス化（defense-in-depth）」）。
+
+**Verify**: `uv run pytest -q -m "not slow and not repo_contract" -n auto` → all pass
+
+## Test plan
+
+Step 2 の 1 ケースのみ（`_compress_thumbnail` 経由で argv 絶対パスを assert）。`stock_preview` / `compare_thumbnails` は表示系スクリプトで既存テストが薄ければ新設不要（変更が `.resolve()` 付加のみで、失敗モードは既存と同一のため）。
+
+## Done criteria
+
+- [ ] 上記 4 箇所すべてに `.resolve()` が入っている
+- [ ] `rg -n '"--"' src/youtube_automation/scripts/stock_preview.py src/youtube_automation/scripts/compare_thumbnails.py src/youtube_automation/utils/upload_core.py` → 0 件（誤って `--` 方式を採らなかったことの確認）
+- [ ] `uv run pytest tests/test_upload_core_thumbnail.py -q` → all pass
+- [ ] `uv run pytest -q -m "not slow and not repo_contract" -n auto` → all pass
+- [ ] `uv run ruff check src tests` → exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記あり
+- [ ] in-scope 外のファイルに変更なし（`git status`）
+- [ ] `plans/README.md` の status 更新
+
+## STOP conditions
+
+- "Current state" の抜粋と実コードが一致しない（drift）
+- `.resolve()` 付加でテストが fail し、原因が symlink 解決による期待パスのズレだった場合（`compare_thumbnails` は symlink を作る — L126。resolve が symlink 実体を指して既存挙動と変わるようなら、そのファイルだけ `Path.absolute()` に切り替えて報告）
+
+## Maintenance notes
+
+- 今後 subprocess にパスを渡すときの規約: argv に入れる時点で絶対パス（`.resolve()`）にする。`--` は ffmpeg では使えない
+- レビュー観点: `compare_thumbnails.py` の symlink（L126）と resolve の相互作用のみ
+- 見送った follow-up: 全 subprocess 呼び出し（~30 箇所）への一括適用 — 監査で安全確認済みのためノイズと判断

--- a/plans/027-argv-absolute-path-hardening.md
+++ b/plans/027-argv-absolute-path-hardening.md
@@ -20,6 +20,7 @@
 - **Depends on**: none
 - **Category**: security（defense-in-depth。悪用可能な欠陥ではない）
 - **Planned at**: commit `37b362ce`, 2026-07-21
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/2396
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,6 +4,39 @@
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
+## 第 5 回監査（セキュリティ専門監査、2026-07-21、基準 commit `37b362ce`）
+
+セキュリティ集中監査（フォーカス指定 /improve）。並列 4 subagent（シークレット/認証 / インジェクション・パス / ネットワーク・サーバー / Chrome 拡張・配布）→ 全 findings を advisor が実読 vet。
+総評: **HIGH / MEDIUM 脆弱性ゼロ**。shell=True / eval / unsafe yaml / curl|bash ゼロ、全 subprocess が argv 形式、zip-slip・path traversal・CORS・CSRF・token 0o600・redact・webhook 許可リストいずれも防御済み。第 4 回以降の新サーフェス（live-chat 自動返信 daemon / streaming VPS）も、プロンプトインジェクション対策（`<viewer_input>` ラップ + stdin 渡し + `--sandbox read-only` + 出力監査 + 3 段レート制限）と systemd hardening を実装済みで健全。残ったのは LOW の hardening 3 件のみ。
+
+### Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
+|------|-------|----------|--------|------------|-------|-----|--------|
+| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | — | — | TODO |
+| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | — | — | TODO |
+| 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | — | — | TODO |
+
+### Dependency notes
+
+- 025〜027 は完全に独立（触るファイル非重複）。並列実行可
+- 026 の `terraform apply` は実 VPS の再 provisioning を伴うためオペレーターが別途実施（プランは fmt / validate / pytest まで）
+
+### Findings considered and rejected（再監査不要）
+
+- **CORS 既定で任意の Chrome 拡張が collection-serve の read ルートを読める**（collection_serve.py:666-668）: by design（#896 コメントに意図明記）。第 1 回監査で同系 finding を裁定済み — `--allow-origin` lock が存在し、mutating 側は extension lock + token 必須（Plan 001）。露出は未公開プロンプト・下書きのみで受容
+- **suno.com ページから拡張 bridge メッセージ（MAIN→ISOLATED postMessage）を偽装可能**: MAIN world の構造的制約で完全防御は不可能。悪用には suno.com 自体の侵害が前提、影響も自動化進捗状態の撹乱のみ。受容
+- **SSH ホスト秘密鍵の cloud-init user-data 埋め込み**（infra/terraform/streaming/main.tf:66-72）: host-key pinning（provisioner の `host_key` 検証）のための意図的トレードオフ。鍵は当該サーバー自身の identity 鍵で、state / tfvars は gitignore 済み。受容
+- **skill 配布（wheel → yt-skills sync）に内容署名なし**: 脆弱性ではなく trust model（wheel が trust root）。sync 自体は traversal 安全を確認済み。メンテナンスモードのリポジトリに L 工数の署名基盤は見合わない
+- **`--` セパレータによる argv hardening 提案**（subagent 報告）: 手法が誤り。**ffmpeg は `--` end-of-options 非対応**。正しい対策（絶対パス化）に修正して Plan 027 とした
+
+### クリーン確認済み領域（次回セキュリティ監査の短縮用）
+
+- secrets.py（env → op read → ConfigError、値は stdin/ヘッダーのみ、argv 露出なし）/ oauth_handler（0o600 + `_redact`、READONLY_SCOPES 分離 #1699）/ fetch_stream_key（TTY 検知 + `::add-mask::`）/ notification（HTTPS + Discord ホスト許可リスト）
+- suno ZIP 展開（zip-slip + entry 数 + サイズ上限）/ CollectionPaths・thumbnail_archive の `relative_to` 境界 / channel slug regex 検証
+- collection_serve（localhost bind、mutating は extension lock + X-Serve-Token、body 上限、path traversal 防御）/ live_chat（上記総評参照）
+- 拡張 manifest 最小権限（`<all_urls>` なし、CSP 緩和なし、innerHTML/eval ゼロ、background は sender 由来 tab のみ操作）/ pnpm-lock 全て registry.npmjs.org + integrity / lefthook・flake に remote fetch なし / コミット済みシークレットなし
+
 ## 第 4 回監査（Python コア本体の一般監査、2026-07-09、基準 commit `5394c378`）
 
 初の `src/youtube_automation/`（~46K 行）本体監査。並列 4 subagent（正確性+セキュリティ / パフォ+依存 / テスト+負債 / DX+docs+方向性）→ 全 findings を advisor が実読 vet。

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,9 +13,9 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
-| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | — | — | TODO |
-| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | — | — | TODO |
-| 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | — | — | TODO |
+| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | — | TODO |
+| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | TODO |
+| 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
 
 ### Dependency notes
 


### PR DESCRIPTION
## 概要

/improve スキルによる第 5 回監査（セキュリティ集中、基準 commit `37b362ce`）の成果物。並列 4 subagent（シークレット/認証・インジェクション/パス・ネットワーク/サーバー・Chrome 拡張/配布）で監査し、全 findings を advisor が実読 vet した。

**総評: HIGH / MEDIUM 脆弱性ゼロ。** 残った LOW の hardening 3 件を自己完結プランとして追加する。

## 変更内容

- `plans/025-client-secrets-in-memory.md` — 1Password フォールバックの client_secrets を tempfile 経由から `InstalledAppFlow.from_client_config()` の in-memory 渡しへ（SIGKILL 時の $TMPDIR 残留解消、P2/M）
- `plans/026-terraform-stream-env-staging.md` — streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ（live-chat 経路の既存パターンに統一、P3/S）
- `plans/027-argv-absolute-path-hardening.md` — open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth、P3/S）
- `plans/README.md` — 第 5 回監査セクション追記（総評 / 棄却記録 5 件 / 次回監査短縮用のクリーン確認済み領域一覧）

## レビュー観点

- 棄却記録 5 件（CORS 既定・bridge 偽装・SSH ホスト鍵・skill 署名なし・`--` セパレータ案の技術的誤り）の判断妥当性
- 027 は subagent 提案の `--` 方式を「ffmpeg 非対応」で棄却し絶対パス化に修正済み

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` — 免除（plans/ のみの docs 変更、`skip-changelog` ラベル付与）
- [x] 下流チャンネルへの影響なし（配布物に plans/ は含まれない）
- [x] テスト追加不要（ドキュメントのみ）

## 関連

- 第 4 回監査: plans/README.md 参照（020〜024、全 DONE）
- 各プランの issue 化は別途承認待ち（gh issue create が権限ブロックされたため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)