### PR TITLE
chore(actions): 依存 action を更新して SHA 固定 (#2357)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       windows: ${{ steps.classify.outputs.windows }}
       adr: ${{ steps.classify.outputs.adr }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Classify changed paths
@@ -57,13 +57,13 @@ jobs:
       - name: No Python lint required
         if: needs.changes.outputs.python != 'true'
         run: echo "Extension-only change; Python lint is not applicable."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.changes.outputs.python == 'true'
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         if: needs.changes.outputs.python == 'true'
       - name: Cache uv
         if: needs.changes.outputs.python == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -86,13 +86,13 @@ jobs:
       - name: No Python tests required
         if: needs.changes.outputs.python != 'true'
         run: echo "Extension-only change; Python tests are not applicable."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.changes.outputs.python == 'true'
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         if: needs.changes.outputs.python == 'true'
       - name: Cache uv
         if: needs.changes.outputs.python == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -110,8 +110,8 @@ jobs:
     if: needs.changes.outputs.packaging == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Frozen sync (lock drift check)
         run: nix develop --command uv sync --frozen
       - name: Build wheel and sdist
@@ -134,11 +134,11 @@ jobs:
     if: needs.changes.outputs.windows == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
         run: uv sync
       - name: Test cost tracker on Windows
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Check CHANGELOG update
@@ -180,7 +180,7 @@ jobs:
     if: needs.changes.outputs.adr == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check ADR number uniqueness
         run: |
           set -eu
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && needs.changes.outputs.python == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Check new Any usage

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -31,9 +31,9 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install Python dependencies
         run: nix develop --command uv sync --frozen
       - name: Install dependencies

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -32,7 +32,7 @@ jobs:
       distrokid: ${{ steps.classify.outputs.distrokid }}
       community: ${{ steps.classify.outputs.community }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Classify changed paths
@@ -71,10 +71,10 @@ jobs:
       run:
         working-directory: extensions/suno-helper
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Install dependencies
         run: nix develop .#extensions --command pnpm install --frozen-lockfile
       - name: Install DistroKid helper dependencies for cross-extension audit
@@ -131,8 +131,8 @@ jobs:
       run:
         working-directory: extensions/distrokid-helper
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Install dependencies
         run: nix develop .#extensions --command pnpm install --frozen-lockfile
       - name: Install shared lint toolchain
@@ -204,8 +204,8 @@ jobs:
       run:
         working-directory: extensions/community-helper
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Install dependencies
         run: nix develop .#extensions --command pnpm install --frozen-lockfile
       - name: Install shared lint toolchain

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -14,8 +14,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - parallel:
           - name: Build and zip suno-helper
             working-directory: extensions/suno-helper
@@ -27,7 +27,7 @@ jobs:
             working-directory: extensions/community-helper
             run: cd ../.. && bash .claude/skills/automation-release/references/verify-extensions.sh community-helper
       - name: Attach zips to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             extensions/suno-helper/.output/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `chore(actions-deps)`: CI / dashboard / extension release workflow の外部 action を最新安定版へ更新し、全 `uses:` を version コメント付き immutable commit SHA に統一する supply-chain 契約を追加（#2357）。
+
 - `chore(terraform-deps)`: 3 stack の Terraform CLI を 1.15.x、Google / Vultr / null / external / tls provider を最新安定 major の bounded constraint へ更新し、lockfile と静的検証契約を同期（#2358）。
 
 - `chore(extensions-deps)`: 3 helper と shared UI の npm 依存、security overrides、pnpm toolchain を最新安定版へ統一し、4 workspace の lockfile・Nix・release 検証契約を同期（#2356）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,7 @@ uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 
 | extensions | 対象 workspace の既存 pnpm lint / type / Vitest / Playwright | Extensions CI（pytest marker 対象外） |
 | dashboard | `dashboard/` の lint / typecheck / test | test:e2e / build + Python server・wheel smoke |
 - **CI では `-n auto` を有効化済み**（`.github/workflows/ci.yml` の test ジョブ）
+- **外部 GitHub Actions は full commit SHA で固定**し、追跡する stable version を同じ `uses:` 行のコメントに残す。複数 workflow で同じ action を使う場合も SHA/version を統一し、`tests/test_github_actions_pinning.py` で mutable ref・drift・未棚卸し action を拒否する
 - **CI の changed-path 分岐**: `.github/scripts/classify-ci-paths.sh` が PR と `main` push の差分を Python / packaging / Windows / ADR / 3 helper に分類する。branch protection の required check である `lint` / `test` job は path filter や job-level `if` で消さず、extension-only 変更では成功する軽量 step を返して Nix・uv・pytest を起動しない。空 diff は全 gate を有効化する fail-safe とし、分類変更時は `tests/test_actions_parallel_workflows.py` の対応表も更新する
 - worker ごとの分離: `tests/conftest.py` が `CHANNEL_DIR` の tmp コピーを **worker プロセスごとに独立して** 作り直す（controller が自動設定した値を環境変数継承でそのまま共有しない）。ユーザーが明示的に `CHANNEL_DIR` を指定した場合は全 worker がその指定を尊重する
 - 注意: `tests/test_lefthook_installation_contract.py` の nix devShell 契約テストなど実 subprocess を叩くテストはホスト負荷に敏感で、混雑したマシンでは並列時に所要時間が大きく伸びることがある

--- a/tests/test_actions_parallel_workflows.py
+++ b/tests/test_actions_parallel_workflows.py
@@ -71,7 +71,7 @@ _RELEASE_BUILD_PARALLEL_STEPS = {
     "Build and zip distrokid-helper": ("extensions/distrokid-helper", "verify-extensions.sh distrokid-helper"),
     "Build and zip community-helper": ("extensions/community-helper", "verify-extensions.sh community-helper"),
 }
-_RELEASE_NIX_INSTALL_ACTION = "DeterminateSystems/nix-installer-action@main"
+_RELEASE_NIX_INSTALL_ACTION = "DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25"
 _SHELL_BACKGROUND_OPERATOR = re.compile(r"(?<!&)&(?!&)")
 
 
@@ -291,9 +291,9 @@ def test_extensions_jobs_use_only_the_nix_extensions_toolchain(job_name: str) ->
     """Given Extensions CI, When commands run, Then all jobs use the Nix extensions shell."""
     steps = _job_steps(_load_workflow(_EXTENSIONS_WORKFLOW_PATH), job_name)
 
-    assert _top_level_step_index_with_uses(steps, "actions/checkout@v4") < _top_level_step_index_with_uses(
-        steps, "cachix/install-nix-action@v30"
-    )
+    assert _top_level_step_index_with_uses(
+        steps, "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) < _top_level_step_index_with_uses(steps, "cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342")
     uses = {step.get("uses") for step in steps}
     assert "pnpm/action-setup@v4" not in uses
     assert "actions/setup-node@v4" not in uses
@@ -379,7 +379,9 @@ def test_extensions_pull_request_runs_one_fallow_audit_for_the_extensions_root()
     ]
 
     steps = _job_steps(workflow, "check")
-    checkout = steps[_top_level_step_index_with_uses(steps, "actions/checkout@v4")]
+    checkout = steps[
+        _top_level_step_index_with_uses(steps, "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")
+    ]
     assert checkout.get("with") == {"fetch-depth": 0}
 
     jobs_check = jobs.get("check")
@@ -656,7 +658,10 @@ def test_release_extensions_builds_all_zips_before_release_attachment() -> None:
         assert step.get("working-directory") == working_directory
         assert required_command in str(step.get("run", ""))
         assert str(step.get("run", "")).startswith("cd ../.. && bash ")
-    assert _top_level_step_index_with_uses(steps, "actions/checkout@v4") < build_parallel_index
+    assert (
+        _top_level_step_index_with_uses(steps, "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")
+        < build_parallel_index
+    )
     assert _top_level_step_index_with_uses(steps, _RELEASE_NIX_INSTALL_ACTION) < build_parallel_index
     assert build_parallel_index < _top_level_step_index(steps, "Attach zips to Release")
     _assert_parallel_runs_do_not_use_shell_backgrounding(steps)

--- a/tests/test_changelog_ci_contract.py
+++ b/tests/test_changelog_ci_contract.py
@@ -120,7 +120,10 @@ def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
     steps = workflow["jobs"]["changelog"]["steps"]
 
     checkout_step = steps[0]
-    assert checkout_step == {"uses": "actions/checkout@v4", "with": {"fetch-depth": 0}}
+    assert checkout_step == {
+        "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "with": {"fetch-depth": 0},
+    }
 
     changelog_step = steps[1]
     assert changelog_step.get("name") == "Check CHANGELOG update"

--- a/tests/test_github_actions_pinning.py
+++ b/tests/test_github_actions_pinning.py
@@ -1,0 +1,47 @@
+"""GitHub Actions の supply-chain pinning 契約。"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+_USES_LINE = re.compile(
+    r"^\s*-?\s*uses:\s+([^\s@]+/[^\s@]+)@([0-9a-f]{40})\s+#\s+(\S+)\s*$",
+    re.MULTILINE,
+)
+
+_EXPECTED_ACTIONS = {
+    "actions/cache": ("55cc8345863c7cc4c66a329aec7e433d2d1c52a9", "v6.1.0"),
+    "actions/checkout": ("3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
+    "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
+    "astral-sh/setup-uv": ("c771a70e6277c0a99b617c7a806ffedaca235ff9", "v9.0.0"),
+    "cachix/install-nix-action": ("630ae543ea3a38a9a4166f03376c02c50f408342", "v31.11.0"),
+    "DeterminateSystems/nix-installer-action": ("ef8a148080ab6020fd15196c2084a2eea5ff2d25", "v22"),
+    "softprops/action-gh-release": ("3d0d9888cb7fd7b750713d6e236d1fcb99157228", "v3.0.2"),
+}
+
+
+@pytest.mark.parametrize("workflow", sorted(_WORKFLOWS_DIR.glob("*.yml")), ids=lambda path: path.name)
+def test_third_party_actions_are_pinned_to_documented_commit_sha(workflow: Path) -> None:
+    text = workflow.read_text(encoding="utf-8")
+    uses_lines = [line for line in text.splitlines() if re.match(r"^\s*-?\s*uses:\s+", line)]
+    matches = list(_USES_LINE.finditer(text))
+
+    assert len(matches) == len(uses_lines), f"{workflow.name}: mutable または version comment のない uses がある"
+    for match in matches:
+        action, sha, version = match.groups()
+        assert action in _EXPECTED_ACTIONS, f"{workflow.name}: 未棚卸し action: {action}"
+        assert (sha, version) == _EXPECTED_ACTIONS[action], f"{workflow.name}: {action} の pin が不一致"
+
+
+def test_every_catalogued_action_is_used() -> None:
+    used = {
+        match.group(1)
+        for workflow in _WORKFLOWS_DIR.glob("*.yml")
+        for match in _USES_LINE.finditer(workflow.read_text(encoding="utf-8"))
+    }
+    assert used == set(_EXPECTED_ACTIONS)

--- a/tests/test_release_extensions_workflow.py
+++ b/tests/test_release_extensions_workflow.py
@@ -15,8 +15,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "release-extensions.yml"
 
 _RELEASE_TAG_GLOB = "ext-v*"
-_GH_RELEASE_ACTION = "softprops/action-gh-release@v2"
-_NIX_INSTALL_ACTION = "DeterminateSystems/nix-installer-action@main"
+_GH_RELEASE_ACTION = "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
+_NIX_INSTALL_ACTION = "DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25"
 _VERIFY_SCRIPT = ".claude/skills/automation-release/references/verify-extensions.sh"
 _EXTENSIONS = ("suno-helper", "distrokid-helper", "community-helper")
 _ZIP_GLOBS = tuple(f"extensions/{name}/.output/*.zip" for name in _EXTENSIONS)
@@ -102,7 +102,11 @@ def test_builds_and_zips_each_extension(name: str) -> None:
 def test_installs_nix_before_parallel_extension_builds() -> None:
     """release job が checkout 後、build 前に Nix を導入する。"""
     steps = _release_top_level_steps()
-    checkout_index = next(index for index, step in enumerate(steps) if step.get("uses") == "actions/checkout@v4")
+    checkout_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("uses") == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    )
     nix_index = next(index for index, step in enumerate(steps) if step.get("uses") == _NIX_INSTALL_ACTION)
     parallel_index = next(index for index, step in enumerate(steps) if "parallel" in step)
     uses = {step.get("uses") for step in steps if "uses" in step}


### PR DESCRIPTION
## 概要

全 workflow の third-party action を 2026-07-22 時点の最新安定版へ更新し、version tag ではなく full commit SHA へ固定しました。追跡 version は Renovate/人間が確認できるよう `uses:` 行のコメントに保持しています。

| Action | Version |
|---|---:|
| actions/checkout | v7.0.1 |
| actions/cache | v6.1.0 |
| actions/setup-python | v7.0.0 |
| cachix/install-nix-action | v31.11.0 |
| astral-sh/setup-uv | v9.0.0 |
| DeterminateSystems/nix-installer-action | v22 |
| softprops/action-gh-release | v3.0.2 |

- setup-python v7 で削除された `pip-install` input は本 workflow では未使用
- setup-uv v9 の `prune-cache` 既定変更は cache input 自体を利用していないため追加設定不要
- release workflow の mutable `@main` を解消
- mutable ref、version drift、version comment 欠落、未棚卸し action を拒否する repository contract を追加

## 公式リリース

- [actions/checkout v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)
- [actions/cache v6.1.0](https://github.com/actions/cache/releases/tag/v6.1.0)
- [actions/setup-python v7.0.0](https://github.com/actions/setup-python/releases/tag/v7.0.0)
- [cachix/install-nix-action v31.11.0](https://github.com/cachix/install-nix-action/releases/tag/v31.11.0)
- [astral-sh/setup-uv v9.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0)
- [DeterminateSystems/nix-installer-action v22](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v22)
- [softprops/action-gh-release v3.0.2](https://github.com/softprops/action-gh-release/releases/tag/v3.0.2)

## 検証

- 指定 workflow contract + pinning/changelog contract: 65 passed
- `.github/workflows` に mutable `@main` / version ref なし
- Python CI / Extensions CI / Dashboard CI はこの PR 自身で更新後 action を実行して確認

更新を見送った action はありません。実 extension release は作成していません。

Closes #2357
