### PR TITLE
fix(auth): client_secrets をメモリ内で渡す (#2394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `security(auth)`: 1Password fallback の client_secrets を tempfile 経由から in-memory 渡しへ変更し、異常終了時に平文 JSON がディスクへ残る経路を削除（#2394）。
+
 - `chore(actions-deps)`: CI / dashboard / extension release workflow の外部 action を最新安定版へ更新し、全 `uses:` を version コメント付き immutable commit SHA に統一する supply-chain 契約を追加（#2357）。
 
 - `chore(terraform-deps)`: 3 stack の Terraform CLI を 1.15.x、Google / Vultr / null / external / tls provider を最新安定 major の bounded constraint へ更新し、lockfile と静的検証契約を同期（#2358）。

--- a/plans/025-client-secrets-in-memory.md
+++ b/plans/025-client-secrets-in-memory.md
@@ -14,6 +14,7 @@
 
 ## Status
 
+- **Status**: DONE
 - **Priority**: P2
 - **Effort**: M
 - **Risk**: MED（OAuth 初回認証フローに触る。既存テストは厚い）

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,7 +13,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
-| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | — | TODO |
+| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | — | DONE |
 | 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | TODO |
 | 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,7 +13,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
-| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | — | DONE |
+| 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | [#2410](https://github.com/daiki-beppu/youtube-automation/pull/2410) | DONE |
 | 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | TODO |
 | 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
 

--- a/src/youtube_automation/auth/oauth_handler.py
+++ b/src/youtube_automation/auth/oauth_handler.py
@@ -109,8 +109,8 @@ def resolve_client_secrets_location(channel_dir: Path) -> tuple[str, Path]:
     return "secret-fallback", candidates[0]
 
 
-def resolve_client_secrets_path(channel_dir: Path | None = None) -> Path:
-    """実行時 OAuth が使う client_secrets.json の検索順を解決する。"""
+def resolve_client_secrets_source(channel_dir: Path | None = None) -> tuple[Path, dict[str, object] | None]:
+    """client_secrets の表示用パスと任意の in-memory config を解決する。"""
     if channel_dir is None:
         from youtube_automation.utils.config import channel_dir as _channel_dir
 
@@ -118,14 +118,30 @@ def resolve_client_secrets_path(channel_dir: Path | None = None) -> Path:
 
     kind, path = resolve_client_secrets_location(channel_dir)
     if kind in {"file", "invalid-file", "missing-file"}:
-        return path
+        return path, None
 
     try:
-        from youtube_automation.utils.secrets import get_client_secrets_path
+        from youtube_automation.utils.secrets import get_client_secrets_config
 
-        return get_client_secrets_path()
+        return path, get_client_secrets_config()
     except ConfigError:
-        return path
+        return path, None
+
+
+def resolve_client_secrets_path(channel_dir: Path | None = None) -> Path:
+    """後方互換のため client_secrets の表示用パスだけを返す。"""
+    return resolve_client_secrets_source(channel_dir)[0]
+
+
+def _validate_client_secrets_data(data: dict[str, object]) -> None:
+    """Google Desktop app 用 client_secrets の JSON 形状を検証する。"""
+    installed = data.get("installed")
+    if not isinstance(installed, dict):
+        raise ValidationError("Desktop app の client_secrets.json が必要です: installed セクションがありません")
+    required_keys = ("client_id", "client_secret", "redirect_uris")
+    missing = [key for key in required_keys if key not in installed]
+    if missing:
+        raise ValidationError(f"client_secrets.json に必須キー不足: {','.join(missing)}")
 
 
 class YouTubeOAuthHandler:
@@ -169,7 +185,7 @@ class YouTubeOAuthHandler:
         channel_dir = _channel_dir()
         self._channel_dir = channel_dir
 
-        self.client_secrets_file = resolve_client_secrets_path(channel_dir)
+        self.client_secrets_file, self._client_secrets_config = resolve_client_secrets_source(channel_dir)
 
         # scopes: 未指定時は SCOPES クラス属性（既存 callsite との後方互換）
         self._scopes = list(scopes) if scopes is not None else self.SCOPES
@@ -251,6 +267,9 @@ class YouTubeOAuthHandler:
 
     def _validate_client_secrets(self):
         """client_secrets.json の存在確認"""
+        if self._client_secrets_config is not None:
+            _validate_client_secrets_data(self._client_secrets_config)
+            return
         if self.client_secrets_file.exists() and not self.client_secrets_file.is_file():
             raise ValidationError(f"client_secrets.json は通常ファイルである必要があります: {self.client_secrets_file}")
         if not self.client_secrets_file.is_file():
@@ -276,13 +295,7 @@ class YouTubeOAuthHandler:
             raise ValidationError(f"client_secrets.json 読み込み失敗: {e}") from e
         if not isinstance(data, dict):
             raise ValidationError("client_secrets.json は JSON object である必要があります")
-        installed = data.get("installed")
-        if not isinstance(installed, dict):
-            raise ValidationError("Desktop app の client_secrets.json が必要です: installed セクションがありません")
-        required_keys = ("client_id", "client_secret", "redirect_uris")
-        missing = [key for key in required_keys if key not in installed]
-        if missing:
-            raise ValidationError(f"client_secrets.json に必須キー不足: {','.join(missing)}")
+        _validate_client_secrets_data(data)
 
     def authenticate(self, force_reauth=False):
         """
@@ -331,7 +344,10 @@ class YouTubeOAuthHandler:
             print("📝 注意: 初回認証時はブラウザが開き、Googleアカウントでのログインが必要です")
 
             try:
-                flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secrets_file), self._scopes)
+                if self._client_secrets_config is not None:
+                    flow = InstalledAppFlow.from_client_config(self._client_secrets_config, self._scopes)
+                else:
+                    flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secrets_file), self._scopes)
                 # authorization_prompt_message は run_local_server() 内で
                 # ``.format(url=...)`` される。`{url}` placeholder を壊さないよう
                 # ラベル側の brace は escape する（success_message は format されない）

--- a/src/youtube_automation/utils/secrets.py
+++ b/src/youtube_automation/utils/secrets.py
@@ -13,14 +13,11 @@
 
 from __future__ import annotations
 
-import atexit
 import json
 import os
 import shutil
 import subprocess
-import tempfile
 from functools import lru_cache
-from pathlib import Path
 
 from youtube_automation.utils.exceptions import ConfigError
 
@@ -106,42 +103,22 @@ def get_secret(name: str) -> str:
     )
 
 
-_client_secrets_tempfile: Path | None = None
+def get_client_secrets_config() -> dict[str, object]:
+    """client_secrets の JSON 内容を in-memory dict で取得する。
 
-
-def get_client_secrets_path() -> Path:
-    """client_secrets.json のパスを取得する。
-
-    `get_secret("CLIENT_SECRETS_JSON")` で JSON 内容を取得し、一時ファイルに書き出して返す。
-    `YOUTUBE_AUTOMATION_DISABLE_OP_READ=1` の場合、env が無ければ 1Password は読まない。
-    同一プロセス内では同じ一時ファイルを再利用する。
-
-    Returns:
-        一時ファイルのパス
+    tempfile を経由しないため、異常終了時にも secret がディスクに残らない。
 
     Raises:
-        ConfigError: 取得できなかった場合
+        ConfigError: 取得できない、または JSON object として解釈できない場合
     """
-    global _client_secrets_tempfile
-    if _client_secrets_tempfile and _client_secrets_tempfile.exists():
-        return _client_secrets_tempfile
-
-    json_content = get_secret("CLIENT_SECRETS_JSON")
-    # mkstemp → chmod → fdopen の順序を厳守: 書き込み前に 0o600 を確定させ
-    # OS umask に依存せず world-readable な状態を経由しないことを保証する
-    fd, path = tempfile.mkstemp(prefix="client_secrets_", suffix=".json")
-    os.chmod(path, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(json_content)
-
-    def _cleanup(p: str = path) -> None:
-        # idempotent: ファイルが既に消えていても atexit 連鎖を止めない
-        if os.path.exists(p):
-            os.unlink(p)
-
-    atexit.register(_cleanup)
-    _client_secrets_tempfile = Path(path)
-    return _client_secrets_tempfile
+    raw = get_secret("CLIENT_SECRETS_JSON")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"CLIENT_SECRETS_JSON を JSON として解釈できません: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError("CLIENT_SECRETS_JSON は JSON object である必要があります")
+    return data
 
 
 def write_op_secret(vault: str, item: str, field: str, value: str) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -454,7 +454,7 @@ class TestClientSecrets:
             ),
         )
         monkeypatch.setattr(
-            "youtube_automation.utils.secrets.get_client_secrets_path",
+            "youtube_automation.utils.secrets.get_client_secrets_config",
             lambda: pytest.fail("yt-doctor must not materialize CLIENT_SECRETS_JSON"),
         )
 

--- a/tests/test_oauth_handler_exceptions.py
+++ b/tests/test_oauth_handler_exceptions.py
@@ -279,7 +279,17 @@ class TestClientSecretsFallback:
             lambda: tmp_path,
         )
 
-    def test_should_fallback_to_default_candidate_when_get_client_secrets_path_raises_config_error(
+    @staticmethod
+    def _valid_config() -> dict[str, object]:
+        return {
+            "installed": {
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "redirect_uris": ["http://localhost"],
+            }
+        }
+
+    def test_should_fallback_to_default_candidate_when_get_client_secrets_config_raises_config_error(
         self, tmp_path: Path, monkeypatch
     ):
         """Given 1Password 取得が ``ConfigError`` を raise
@@ -288,13 +298,55 @@ class TestClientSecretsFallback:
         """
         self._force_fallback_path(monkeypatch, tmp_path)
         monkeypatch.setattr(
-            "youtube_automation.utils.secrets.get_client_secrets_path",
+            "youtube_automation.utils.secrets.get_client_secrets_config",
             MagicMock(side_effect=ConfigError("op read failed")),
         )
 
         handler = YouTubeOAuthHandler()
 
         assert handler.client_secrets_file == tmp_path / "auth" / "client_secrets.json"
+
+    def test_should_validate_fallback_config_without_materializing_tempfile(self, tmp_path: Path, monkeypatch):
+        self._force_fallback_path(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "youtube_automation.utils.secrets.get_client_secrets_config",
+            MagicMock(return_value=self._valid_config()),
+        )
+
+        handler = YouTubeOAuthHandler()
+        handler._validate_client_secrets()
+
+        assert handler.client_secrets_file == tmp_path / "auth" / "client_secrets.json"
+        assert list(tmp_path.glob("client_secrets_*.json")) == []
+
+    def test_should_authenticate_fallback_with_in_memory_config(self, tmp_path: Path, monkeypatch):
+        self._force_fallback_path(monkeypatch, tmp_path)
+        config = self._valid_config()
+        monkeypatch.setattr(
+            "youtube_automation.utils.secrets.get_client_secrets_config",
+            MagicMock(return_value=config),
+        )
+        handler = YouTubeOAuthHandler(token_path=tmp_path / "token.json")
+        monkeypatch.setattr(handler, "_channel_label", MagicMock(return_value="test-channel"))
+        monkeypatch.setattr(handler, "_save_credentials", MagicMock())
+
+        credentials = _make_credentials()
+        flow = MagicMock()
+        flow.run_local_server.return_value = credentials
+        from_config = MagicMock(return_value=flow)
+        from_file = MagicMock(side_effect=AssertionError("file flow must not be used"))
+        monkeypatch.setattr(
+            "youtube_automation.auth.oauth_handler.InstalledAppFlow.from_client_config",
+            from_config,
+        )
+        monkeypatch.setattr(
+            "youtube_automation.auth.oauth_handler.InstalledAppFlow.from_client_secrets_file",
+            from_file,
+        )
+
+        assert handler.authenticate(force_reauth=True) is credentials
+        from_config.assert_called_once_with(config, handler._scopes)
+        from_file.assert_not_called()
 
     def test_should_use_submodule_candidate_before_one_password_fallback(self, tmp_path: Path, monkeypatch):
         """Given submodule 互換 path に client_secrets.json がある
@@ -305,16 +357,16 @@ class TestClientSecretsFallback:
         submodule_path = tmp_path / "automation" / "auth" / "client_secrets.json"
         submodule_path.parent.mkdir(parents=True)
         submodule_path.write_text('{"installed": {}}\n', encoding="utf-8")
-        get_client_secrets_path = MagicMock(side_effect=ConfigError("should not be called"))
+        get_client_secrets_config = MagicMock(side_effect=ConfigError("should not be called"))
         monkeypatch.setattr(
-            "youtube_automation.utils.secrets.get_client_secrets_path",
-            get_client_secrets_path,
+            "youtube_automation.utils.secrets.get_client_secrets_config",
+            get_client_secrets_config,
         )
 
         handler = YouTubeOAuthHandler()
 
         assert handler.client_secrets_file == submodule_path
-        get_client_secrets_path.assert_not_called()
+        get_client_secrets_config.assert_not_called()
 
     def test_should_report_invalid_location_for_client_secrets_directory(self, tmp_path: Path, monkeypatch):
         """Given client_secrets.json がディレクトリ
@@ -383,7 +435,7 @@ class TestClientSecretsFallback:
         """Missing secrets must point every direct OAuth entrypoint at the new Console UI."""
         self._force_fallback_path(monkeypatch, tmp_path)
         monkeypatch.setattr(
-            "youtube_automation.utils.secrets.get_client_secrets_path",
+            "youtube_automation.utils.secrets.get_client_secrets_config",
             MagicMock(side_effect=ConfigError("op read failed")),
         )
         handler = YouTubeOAuthHandler()
@@ -419,7 +471,7 @@ class TestClientSecretsFallback:
         """
         self._force_fallback_path(monkeypatch, tmp_path)
         monkeypatch.setattr(
-            "youtube_automation.utils.secrets.get_client_secrets_path",
+            "youtube_automation.utils.secrets.get_client_secrets_config",
             MagicMock(side_effect=RuntimeError("unexpected")),
         )
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -24,7 +23,7 @@ from youtube_automation.utils import secrets as secrets_module
 from youtube_automation.utils.exceptions import ConfigError
 from youtube_automation.utils.secrets import (
     _SECRET_REFS,
-    get_client_secrets_path,
+    get_client_secrets_config,
     get_secret,
     reset_cache,
 )
@@ -283,210 +282,23 @@ class TestStreamingSecretsRegistered:
                 get_secret(name)
 
 
-# ---------- Issue #150: client_secrets tempfile の atexit クリーンアップ ----------
+class TestGetClientSecretsConfig:
+    """client_secrets JSON をディスクへ書かずに解決する契約。"""
 
+    def test_returns_parsed_json_object(self):
+        with patch("youtube_automation.utils.secrets.get_secret", return_value='{"installed": {}}'):
+            assert get_client_secrets_config() == {"installed": {}}
 
-_TEST_JSON_PAYLOAD = '{"installed":{"client_id":"x"}}'
-_EXPECTED_PREFIX = "client_secrets_"
-_EXPECTED_SUFFIX = ".json"
-_EXPECTED_MODE = 0o600
+    def test_rejects_invalid_json_without_exposing_secret(self):
+        raw = "not-json-secret-value"
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=raw):
+            with pytest.raises(ConfigError) as exc_info:
+                get_client_secrets_config()
+        assert "JSON として解釈できません" in str(exc_info.value)
+        assert raw not in str(exc_info.value)
 
-
-class TestGetClientSecretsPath:
-    """`get_client_secrets_path` の振る舞いを検証する。
-
-    plan.md / test-design.md に基づく 12 ケース:
-      1. 初回呼び出しで実在する tempfile への Path を返す
-      2. 同一プロセス内 2 回呼ぶと同じ Path / get_secret 1 回のみ
-      3. キャッシュミス時に atexit.register がちょうど 1 回呼ばれる
-      4. 作成された tempfile のパーミッションは 0o600
-      5. ファイル名が `client_secrets_` prefix / `.json` suffix
-      6. キャッシュヒット時に atexit.register が再度呼ばれない
-      7. tempfile の中身が get_secret の戻り値と一致する
-      8. 登録された atexit ハンドラを実行すると tempfile が削除される
-      9. atexit ハンドラ実行時にファイルが既に消えていても例外を投げない
-     10. キャッシュされたファイルが消失していたら新規作成する
-     11. get_secret が ConfigError を raise したら伝播し、tempfile を作らない
-     12. get_secret が raise したとき atexit.register が呼ばれない
-    """
-
-    @pytest.fixture(autouse=True)
-    def clean_client_secrets_tempfile(self):
-        """テスト前後でモジュール変数 `_client_secrets_tempfile` を必ず None に戻し、
-        実 tempfile が残っていれば削除する。テスト独立性確保のため。
-        """
-        prev = secrets_module._client_secrets_tempfile
-        secrets_module._client_secrets_tempfile = None
-        yield
-        leftover = secrets_module._client_secrets_tempfile
-        secrets_module._client_secrets_tempfile = prev
-        if leftover is not None and leftover.exists():
-            try:
-                os.unlink(leftover)
-            except OSError:
-                pass
-
-    # ---- Case 1 ----
-    def test_returns_path_to_existing_tempfile_on_first_call(self):
-        """Given get_secret がモック JSON を返す
-        When get_client_secrets_path() を初めて呼ぶ
-        Then 実在する tempfile への Path を返す
-        """
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
-            path = get_client_secrets_path()
-        assert isinstance(path, Path)
-        assert path.exists()
-
-    # ---- Case 2 ----
-    def test_returns_same_path_and_calls_get_secret_once_on_repeat_calls(self):
-        """Given 同一プロセス内で 2 回呼び出す
-        When 2 回目の get_client_secrets_path()
-        Then 同じ Path が返り、get_secret は 1 回しか呼ばれない
-        """
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD) as mock_get_secret:
-            first = get_client_secrets_path()
-            second = get_client_secrets_path()
-        assert first == second
-        assert mock_get_secret.call_count == 1
-
-    # ---- Case 3 ----
-    def test_registers_exactly_one_atexit_handler_on_cache_miss(self):
-        """Given キャッシュミス（初回呼び出し）
-        When get_client_secrets_path() を呼ぶ
-        Then atexit.register がちょうど 1 回呼ばれる
-        """
-        with (
-            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
-            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
-        ):
-            get_client_secrets_path()
-        assert mock_register.call_count == 1
-
-    # ---- Case 4 ----
-    def test_creates_tempfile_with_owner_only_permissions(self):
-        """Given get_secret がモック JSON を返す
-        When get_client_secrets_path() を呼ぶ
-        Then 作成された tempfile のパーミッションは 0o600
-        """
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
-            path = get_client_secrets_path()
-        mode = os.stat(path).st_mode & 0o777
-        assert mode == _EXPECTED_MODE
-
-    # ---- Case 5 ----
-    def test_tempfile_name_uses_expected_prefix_and_suffix(self):
-        """Given get_secret がモック JSON を返す
-        When get_client_secrets_path() を呼ぶ
-        Then ファイル名は "client_secrets_" prefix / ".json" suffix
-        """
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
-            path = get_client_secrets_path()
-        assert path.name.startswith(_EXPECTED_PREFIX)
-        assert path.name.endswith(_EXPECTED_SUFFIX)
-
-    # ---- Case 6 ----
-    def test_does_not_register_atexit_on_cache_hit(self):
-        """Given 1 回目で tempfile を作成済み
-        When 2 回目の get_client_secrets_path() を呼ぶ
-        Then atexit.register は再度呼ばれない（合計 1 回のまま）
-        """
-        with (
-            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
-            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
-        ):
-            get_client_secrets_path()
-            get_client_secrets_path()
-        assert mock_register.call_count == 1
-
-    # ---- Case 7 ----
-    def test_tempfile_content_matches_get_secret_return_value(self):
-        """Given get_secret がモック JSON を返す
-        When get_client_secrets_path() を呼ぶ
-        Then 書き出された tempfile の中身は get_secret の戻り値と一致する
-        """
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
-            path = get_client_secrets_path()
-        assert path.read_text() == _TEST_JSON_PAYLOAD
-
-    # ---- Case 8 ----
-    def test_registered_cleanup_handler_removes_tempfile(self):
-        """Given get_client_secrets_path() で atexit に登録された cleanup
-        When 登録された callback を手動実行する
-        Then tempfile が削除される
-        """
-        with (
-            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
-            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
-        ):
-            path = get_client_secrets_path()
-            cleanup = mock_register.call_args[0][0]
-        assert path.exists()
-        cleanup()
-        assert not path.exists()
-
-    # ---- Case 9 ----
-    def test_cleanup_handler_is_idempotent_when_file_already_gone(self):
-        """Given 登録された cleanup callback
-        When ファイルを先に削除した状態で cleanup() を呼ぶ
-        Then 例外は投げない（atexit 連鎖を止めない）
-        """
-        with (
-            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
-            patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD),
-        ):
-            path = get_client_secrets_path()
-            cleanup = mock_register.call_args[0][0]
-        # 先に手動で消す
-        path.unlink()
-        assert not path.exists()
-        # ここで例外が出れば pytest がテストを失敗にする
-        cleanup()
-
-    # ---- Case 10 ----
-    def test_recreates_tempfile_when_cached_path_no_longer_exists(self):
-        """Given キャッシュ変数に Path はあるが実ファイルが既に消えている状態
-        When get_client_secrets_path() を呼ぶ
-        Then 新しい tempfile が作成される
-        """
-        # キャッシュをセットしつつファイルは存在させない
-        secrets_module._client_secrets_tempfile = Path("/tmp/__nonexistent_client_secrets__.json")
-        with patch("youtube_automation.utils.secrets.get_secret", return_value=_TEST_JSON_PAYLOAD):
-            path = get_client_secrets_path()
-        assert path.exists()
-        assert path != Path("/tmp/__nonexistent_client_secrets__.json")
-
-    # ---- Case 11 ----
-    def test_propagates_config_error_and_does_not_create_tempfile(self):
-        """Given get_secret が ConfigError を raise する
-        When get_client_secrets_path() を呼ぶ
-        Then ConfigError が伝播し、tempfile は作成されない（mkstemp 未呼出）
-        """
-        with (
-            patch(
-                "youtube_automation.utils.secrets.get_secret",
-                side_effect=ConfigError("test failure"),
-            ),
-            patch("youtube_automation.utils.secrets.tempfile.mkstemp") as mock_mkstemp,
-        ):
-            with pytest.raises(ConfigError, match="test failure"):
-                get_client_secrets_path()
-            mock_mkstemp.assert_not_called()
-        # キャッシュも汚染されていない
-        assert secrets_module._client_secrets_tempfile is None
-
-    # ---- Case 12 ----
-    def test_does_not_register_atexit_when_get_secret_raises(self):
-        """Given get_secret が ConfigError を raise する
-        When get_client_secrets_path() を呼ぶ
-        Then atexit.register は呼ばれない（エラー時の atexit 汚染防止）
-        """
-        with (
-            patch(
-                "youtube_automation.utils.secrets.get_secret",
-                side_effect=ConfigError("test failure"),
-            ),
-            patch("youtube_automation.utils.secrets.atexit.register") as mock_register,
-        ):
-            with pytest.raises(ConfigError):
-                get_client_secrets_path()
-        mock_register.assert_not_called()
+    @pytest.mark.parametrize("raw", ["[]", '"text"', "null"])
+    def test_rejects_non_object_json(self, raw: str):
+        with patch("youtube_automation.utils.secrets.get_secret", return_value=raw):
+            with pytest.raises(ConfigError, match="JSON object"):
+                get_client_secrets_config()


### PR DESCRIPTION
## 概要

- `CLIENT_SECRETS_JSON` / 1Password fallback を JSON object としてメモリ内で解決
- Google 公式の `InstalledAppFlow.from_client_config()` へ直接渡し、平文 tempfile と atexit cleanup を削除
- 永続 `auth/client_secrets.json` の探索順・ファイル検証・表示用 path・人間によるブラウザ認証は維持
- invalid JSON / non-object / Desktop app 必須キー / file-flow と config-flow の回帰テストを更新

## 公式資料

- [google-auth-oauthlib: `InstalledAppFlow.from_client_config`](https://googleapis.dev/python/google-auth-oauthlib/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.Flow.from_client_config)
- [google-auth-oauthlib implementation](https://googleapis.dev/python/google-auth-oauthlib/latest/_modules/google_auth_oauthlib/flow.html)

## 検証

- OAuth / secrets / doctor 対象: 432 passed
- 高速レーン全体: 5194 passed
- `uv run ruff check src tests`
- `get_client_secrets_path` / `_client_secrets_tempfile` / secrets.py の `mkstemp`: 残存 0
- fallback 時に `client_secrets_*.json` を作らないことをテスト

認証操作自体は従来どおり人間がブラウザで行います。

Closes #2394
