### PR TITLE
fix(streaming): secret staging を 0700 にする (#2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `security(streaming)`: stream key / Discord webhook の Terraform file provisioner staging を素の `/tmp` から root 所有 0700 の `/run/youtube-stream-provision` へ移し、転送直後の権限露出を解消（#2395）。
+
 - `security(auth)`: 1Password fallback の client_secrets を tempfile 経由から in-memory 渡しへ変更し、異常終了時に平文 JSON がディスクへ残る経路を削除（#2394）。
 
 - `chore(actions-deps)`: CI / dashboard / extension release workflow の外部 action を最新安定版へ更新し、全 `uses:` を version コメント付き immutable commit SHA に統一する supply-chain 契約を追加（#2357）。

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -115,19 +115,25 @@ resource "null_resource" "deploy" {
     destination = "${var.install_root}/videos/current.mp4"
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "install -d -m 0700 -o root -g root /run/youtube-stream-provision",
+    ]
+  }
+
   provisioner "file" {
     content = templatefile("${path.module}/templates/youtube-stream.env.tftpl", {
       video    = "${var.install_root}/videos/current.mp4"
       rtmp_url = "rtmp://a.rtmp.youtube.com/live2/${var.stream_key}"
     })
-    destination = "/tmp/youtube-stream.env.tmp"
+    destination = "/run/youtube-stream-provision/youtube-stream.env.tmp"
   }
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/youtube-stream-healthcheck.env.tftpl", {
       webhook = var.discord_webhook_url
     })
-    destination = "/tmp/youtube-stream-healthcheck.env.tmp"
+    destination = "/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp"
   }
 
   provisioner "file" {
@@ -171,10 +177,11 @@ resource "null_resource" "deploy" {
   provisioner "remote-exec" {
     inline = [
       "umask 0077",
-      "install -m 0600 -o root -g root /tmp/youtube-stream.env.tmp /etc/youtube-stream.env",
-      "rm -f /tmp/youtube-stream.env.tmp",
-      "install -m 0600 -o root -g root /tmp/youtube-stream-healthcheck.env.tmp /etc/youtube-stream-healthcheck.env",
-      "rm -f /tmp/youtube-stream-healthcheck.env.tmp",
+      "install -m 0600 -o root -g root /run/youtube-stream-provision/youtube-stream.env.tmp /etc/youtube-stream.env",
+      "rm -f /run/youtube-stream-provision/youtube-stream.env.tmp",
+      "install -m 0600 -o root -g root /run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp /etc/youtube-stream-healthcheck.env",
+      "rm -f /run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp",
+      "rm -rf /run/youtube-stream-provision",
       "mkdir -p ${var.install_root}/bin",
       "chmod 755 ${var.install_root}/bin/healthcheck.sh ${var.install_root}/bin/notify.sh ${var.install_root}/bin/run-ffmpeg.sh",
       "chmod 0600 /etc/youtube-stream-healthcheck.env",

--- a/plans/026-terraform-stream-env-staging.md
+++ b/plans/026-terraform-stream-env-staging.md
@@ -14,6 +14,7 @@
 
 ## Status
 
+- **Status**: DONE
 - **Priority**: P3
 - **Effort**: S
 - **Risk**: LOW（provisioner の staging パス変更のみ。サービス定義・鍵管理は不変）

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
 | 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | [#2410](https://github.com/daiki-beppu/youtube-automation/pull/2410) | DONE |
-| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | DONE |
+| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | [#2411](https://github.com/daiki-beppu/youtube-automation/pull/2411) | DONE |
 | 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
 
 ### Dependency notes

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
 | 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | [#2410](https://github.com/daiki-beppu/youtube-automation/pull/2410) | DONE |
-| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | TODO |
+| 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | — | DONE |
 | 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
 
 ### Dependency notes

--- a/tests/streaming/test_main_tf.py
+++ b/tests/streaming/test_main_tf.py
@@ -652,7 +652,7 @@ class TestMainTfNullResource:
     def test_provisioner_file_places_env_via_templatefile(self):
         """Given main.tf
         When 2 つ目の ``provisioner "file"`` を読む
-        Then content=templatefile(...), destination=/tmp/youtube-stream.env.tmp。
+        Then content=templatefile(...), destination は root 専用 staging 配下。
 
         templatefile は ``${path.module}/templates/youtube-stream.env.tftpl`` を読む。
         secret を tfstate に残さず provisioner 経由で配信する経路。
@@ -662,11 +662,11 @@ class TestMainTfNullResource:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        # templatefile を引数に取る provisioner "file" を抽出（destination=/tmp/youtube-stream.env.tmp）
+        # templatefile を引数に取る provisioner "file" は 0700 staging 配下へ配置する。
         assert re.search(
-            r'destination\s*=\s*"/tmp/youtube-stream\.env\.tmp"',
+            r'destination\s*=\s*"/run/youtube-stream-provision/youtube-stream\.env\.tmp"',
             block,
-        ), 'provisioner "file" の destination が "/tmp/youtube-stream.env.tmp" でない'
+        ), "stream env の destination が 0700 staging 配下でない"
         assert re.search(
             r'templatefile\(\s*"\$\{path\.module\}/templates/youtube-stream\.env\.tftpl"',
             block,
@@ -700,7 +700,7 @@ class TestMainTfNullResource:
         When ``provisioner "remote-exec"`` の inline を読む
         Then 仕様通りのコマンドがすべて含まれている。
 
-        - install -m 0600 -o root -g root /tmp/youtube-stream.env.tmp /etc/youtube-stream.env
+        - install -m 0600 -o root -g root /run/youtube-stream-provision/youtube-stream.env.tmp /etc/youtube-stream.env
           （0600 / root 所有を原子移送で確定。race window 閉鎖）
         - systemctl daemon-reload  （新 unit / .env 反映）
         - systemctl enable --now youtube-stream  （初回起動）
@@ -711,28 +711,40 @@ class TestMainTfNullResource:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None, 'provisioner "remote-exec" ブロックが見つからない'
-        inline = remote_exec.group(1)
+        inline = next((item for item in remote_exec_blocks if "umask 0077" in item), None)
+        assert inline is not None, '本配置用 provisioner "remote-exec" ブロックが見つからない'
         for command, hint in [
             (r"umask\s+0077", "umask 0077 (defense-in-depth)"),
             (
-                r"install\s+-m\s+0600\s+-o\s+root\s+-g\s+root\s+/tmp/youtube-stream\.env\.tmp\s+/etc/youtube-stream\.env",
+                r"install\s+-m\s+0600\s+-o\s+root\s+-g\s+root\s+/run/youtube-stream-provision/youtube-stream\.env\.tmp\s+/etc/youtube-stream\.env",
                 "install -m 0600 -o root -g root .../etc/youtube-stream.env",
             ),
             (
-                r"rm\s+-f\s+/tmp/youtube-stream\.env\.tmp",
-                "rm -f /tmp/youtube-stream.env.tmp (tmp secret cleanup)",
+                r"rm\s+-rf\s+/run/youtube-stream-provision",
+                "rm -rf /run/youtube-stream-provision (secret staging cleanup)",
             ),
             (r"systemctl\s+daemon-reload", "daemon-reload"),
             (r"systemctl\s+enable\s+--now\s+youtube-stream", "enable --now youtube-stream"),
             (r"systemctl\s+restart\s+youtube-stream", "restart youtube-stream"),
         ]:
             assert re.search(command, inline), f"remote-exec の inline に '{hint}' コマンドが無い"
+
+    def test_secret_staging_directory_is_created_before_env_uploads(self):
+        """0700 staging の作成後にだけ secret env を転送する。"""
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
+        assert block is not None
+
+        create = '"install -d -m 0700 -o root -g root /run/youtube-stream-provision"'
+        env_destination = 'destination = "/run/youtube-stream-provision/youtube-stream.env.tmp"'
+        health_destination = 'destination = "/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp"'
+        assert block.index(create) < block.index(env_destination) < block.index(health_destination)
+        assert "/tmp/youtube-stream" not in block
 
     def test_no_explicit_depends_on_for_null_resource(self):
         """Given main.tf
@@ -1377,13 +1389,13 @@ class TestMainTfRunFfmpegProvisioner:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None, 'provisioner "remote-exec" ブロックが見つからない'
-        inline = remote_exec.group(1)
+        inline = next((item for item in remote_exec_blocks if "run-ffmpeg.sh" in item), None)
+        assert inline is not None, '本配置用 provisioner "remote-exec" ブロックが見つからない'
         assert re.search(
             rf"chmod\s+755\b[^\n]*{_INSTALL_ROOT_VAR}/bin/run-ffmpeg\.sh\b",
             inline,
@@ -1403,13 +1415,13 @@ class TestMainTfRunFfmpegProvisioner:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None
-        inline = remote_exec.group(1)
+        inline = next((item for item in remote_exec_blocks if "run-ffmpeg.sh" in item), None)
+        assert inline is not None
 
         chmod_match = re.search(
             r"chmod\s+755\b[^\n]*run-ffmpeg\.sh\b",

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -925,7 +925,7 @@ class TestMainTfHealthcheckDeploy:
     def test_provisioner_file_uploads_healthcheck_env_via_templatefile(self):
         """Given main.tf
         When null_resource.deploy 内の provisioner "file" を走査する
-        Then ``/tmp/youtube-stream-healthcheck.env.tmp`` への配信があり、
+        Then ``/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp`` への配信があり、
              ``templatefile("${path.module}/templates/youtube-stream-healthcheck.env.tftpl", ...)``
              で生成されている。
 
@@ -936,9 +936,9 @@ class TestMainTfHealthcheckDeploy:
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
         assert re.search(
-            r'destination\s*=\s*"/tmp/youtube-stream-healthcheck\.env\.tmp"',
+            r'destination\s*=\s*"/run/youtube-stream-provision/youtube-stream-healthcheck\.env\.tmp"',
             block,
-        ), '/tmp/youtube-stream-healthcheck.env.tmp への provisioner "file" destination が無い'
+        ), '/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp への provisioner "file" destination が無い'
         assert re.search(
             r'templatefile\(\s*"\$\{path\.module\}/templates/youtube-stream-healthcheck\.env\.tftpl"',
             block,
@@ -966,33 +966,37 @@ class TestMainTfHealthcheckDeploy:
         Then ``/etc/youtube-stream-healthcheck.env`` を
              ``install -m 0600 -o root -g root`` で原子移送している。
 
-        SCP 経由の ``/tmp/*.tmp`` 着地 → install で /etc/ へ rename(2) 相当の
+        SCP 経由の ``/run/youtube-stream-provision/*.tmp`` 着地 → install で /etc/ へ rename(2) 相当の
         atomic move を行うことで、0600 root:root が確定するまでの race window を閉じる。
         webhook を読める範囲を root に限定する（secret 隔離）。
         """
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None
-        inline = remote_exec.group(1)
+        inline = next(
+            (item for item in remote_exec_blocks if "youtube-stream-healthcheck.env" in item),
+            None,
+        )
+        assert inline is not None
         assert re.search(
-            r"install\s+-m\s+0600\s+-o\s+root\s+-g\s+root\s+/tmp/youtube-stream-healthcheck\.env\.tmp\s+/etc/youtube-stream-healthcheck\.env",
+            r"install\s+-m\s+0600\s+-o\s+root\s+-g\s+root\s+/run/youtube-stream-provision/youtube-stream-healthcheck\.env\.tmp\s+/etc/youtube-stream-healthcheck\.env",
             inline,
         ), (
-            "install -m 0600 -o root -g root /tmp/youtube-stream-healthcheck.env.tmp "
+            "install -m 0600 -o root -g root "
+            "/run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp "
             "/etc/youtube-stream-healthcheck.env が無い（race window が閉じられていない）"
         )
         assert re.search(
-            r"rm\s+-f\s+/tmp/youtube-stream-healthcheck\.env\.tmp",
+            r"rm\s+-f\s+/run/youtube-stream-provision/youtube-stream-healthcheck\.env\.tmp",
             inline,
         ), (
-            "rm -f /tmp/youtube-stream-healthcheck.env.tmp が無い"
-            "（install 後の /tmp 上の 0644 secret が残置し race window が /tmp/ に横移しになる）"
+            "rm -f /run/youtube-stream-provision/youtube-stream-healthcheck.env.tmp が無い"
+            "（install 後の staging 上に secret が残置する）"
         )
 
     def test_remote_exec_makes_bin_dir_and_executable(self):
@@ -1005,13 +1009,16 @@ class TestMainTfHealthcheckDeploy:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None
-        inline = remote_exec.group(1)
+        inline = next(
+            (item for item in remote_exec_blocks if "run-ffmpeg.sh" in item),
+            None,
+        )
+        assert inline is not None
         # ディレクトリ作成（mkdir -p または install -d）
         assert re.search(
             rf"(mkdir\s+-p|install\s+-d)[^\n]*{_INSTALL_ROOT_VAR}/bin\b",
@@ -1034,13 +1041,16 @@ class TestMainTfHealthcheckDeploy:
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"null_resource"\s+"deploy"')
         assert block is not None
-        remote_exec = re.search(
+        remote_exec_blocks = re.findall(
             r'provisioner\s+"remote-exec"\s*\{(.*?)\n\s*\}',
             block,
             flags=re.DOTALL,
         )
-        assert remote_exec is not None
-        inline = remote_exec.group(1)
+        inline = next(
+            (item for item in remote_exec_blocks if "systemctl restart cron" in item),
+            None,
+        )
+        assert inline is not None
         has_systemctl = re.search(r"systemctl\s+(?:restart|reload)\s+cron\b", inline)
         has_service = re.search(r"service\s+cron\s+(?:restart|reload)\b", inline)
         assert has_systemctl or has_service, (


### PR DESCRIPTION
## 概要

- stream key と Discord webhook env の staging を素の `/tmp` から `/run/youtube-stream-provision` へ変更
- secret upload より前に root:root / 0700 で staging directory を作成
- `/etc` へ 0600 で配置後、個別一時ファイルと staging directory を削除
- 既存 live-chat-reply 側と同じ安全な順序・配置パターンに統一

## 公式資料

- [Terraform file/remote-exec provisioners](https://developer.hashicorp.com/terraform/language/resources/provisioners/file)
- [Terraform resource/provisioner reference](https://developer.hashicorp.com/terraform/language/block/resource#provisioner)

HashiCorp 公式仕様どおり、同一 resource 内の provisioner は定義順に実行されるため、0700 directory 作成 → file upload → 0600 本配置の順序を静的テストで固定しています。

## 検証

- `terraform -chdir=infra/terraform/streaming init -backend=false -input=false`
- `terraform -chdir=infra/terraform/streaming fmt -check`
- `terraform -chdir=infra/terraform/streaming validate`
- Terraform / streaming tests: 264 passed
- `/tmp/youtube-stream` 残存 0

`terraform plan` / `apply` は実行していません。次回 apply は実 VPS の再 provisioning を伴う可能性があるため、配信停止を許容できるタイミングで人間が判断します。

Closes #2395
