### PR TITLE
fix(scripts): subprocess のパスを絶対化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `security(scripts)`: `open` / `ffmpeg` へ渡すファイルパスを絶対パス化し、先頭 `-` を option と誤解釈する余地を排除（#2396）。
+
 - `security(streaming)`: stream key / Discord webhook の Terraform file provisioner staging を素の `/tmp` から root 所有 0700 の `/run/youtube-stream-provision` へ移し、転送直後の権限露出を解消（#2395）。
 
 - `security(auth)`: 1Password fallback の client_secrets を tempfile 経由から in-memory 渡しへ変更し、異常終了時に平文 JSON がディスクへ残る経路を削除（#2394）。

--- a/plans/027-argv-absolute-path-hardening.md
+++ b/plans/027-argv-absolute-path-hardening.md
@@ -21,6 +21,7 @@
 - **Category**: security（defense-in-depth。悪用可能な欠陥ではない）
 - **Planned at**: commit `37b362ce`, 2026-07-21
 - **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/2396
+- **PR**: https://github.com/daiki-beppu/youtube-automation/pull/2412
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -15,7 +15,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 |------|-------|----------|--------|------------|-------|-----|--------|
 | 025 | 1Password フォールバックの client_secrets を tempfile 経由から in-memory 化（SIGKILL 残留解消） | P2 | M | — | [#2394](https://github.com/daiki-beppu/youtube-automation/issues/2394) | [#2410](https://github.com/daiki-beppu/youtube-automation/pull/2410) | DONE |
 | 026 | streaming VPS の stream key / webhook staging を素の /tmp から 0700 ディレクトリへ | P3 | S | — | [#2395](https://github.com/daiki-beppu/youtube-automation/issues/2395) | [#2411](https://github.com/daiki-beppu/youtube-automation/pull/2411) | DONE |
-| 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | — | TODO |
+| 027 | open / ffmpeg へ渡すパス引数の絶対パス化（defense-in-depth） | P3 | S | — | [#2396](https://github.com/daiki-beppu/youtube-automation/issues/2396) | [#2412](https://github.com/daiki-beppu/youtube-automation/pull/2412) | DONE |
 
 ### Dependency notes
 

--- a/src/youtube_automation/scripts/compare_thumbnails.py
+++ b/src/youtube_automation/scripts/compare_thumbnails.py
@@ -73,7 +73,15 @@ class ThumbnailComparer:
             return True
         try:
             subprocess.run(
-                ["ffmpeg", "-i", str(input_path), "-vf", f"scale={SMALL_WIDTH}:{SMALL_HEIGHT}", "-y", str(output_path)],
+                [
+                    "ffmpeg",
+                    "-i",
+                    str(input_path.resolve()),
+                    "-vf",
+                    f"scale={SMALL_WIDTH}:{SMALL_HEIGHT}",
+                    "-y",
+                    str(output_path.resolve()),
+                ],
                 capture_output=True,
                 check=True,
             )
@@ -146,7 +154,8 @@ class ThumbnailComparer:
         print(f"   small/      — 全 {len(small_paths)}枚（{SMALL_WIDTH}x{SMALL_HEIGHT}px モバイル表示）")
 
         if not no_open:
-            subprocess.run(["open", str(self.small_dir if small_only else self.compare_dir)])
+            target_dir = self.small_dir if small_only else self.compare_dir
+            subprocess.run(["open", str(target_dir.resolve())])
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/youtube_automation/scripts/stock_preview.py
+++ b/src/youtube_automation/scripts/stock_preview.py
@@ -45,7 +45,7 @@ def main(argv: list[str] | None = None) -> int:
         source_role=args.source_role,
         limit=args.limit,
     )
-    paths = [str(e.image_path) for e in entries]
+    paths = [str(e.image_path.resolve()) for e in entries]
 
     if not paths:
         print("(no stock entries match)", file=sys.stderr)

--- a/src/youtube_automation/utils/upload_core.py
+++ b/src/youtube_automation/utils/upload_core.py
@@ -269,7 +269,7 @@ class YouTubeUploadCore:
 
         while (quality := strategy.next_quality(failed_qualities)) is not None:
             subprocess.run(
-                ["ffmpeg", "-y", "-i", str(thumbnail_path), "-qscale:v", str(quality), str(compressed)],
+                ["ffmpeg", "-y", "-i", str(thumbnail_path.resolve()), "-qscale:v", str(quality), str(compressed)],
                 capture_output=True,
             )
             if compressed.exists() and compressed.stat().st_size <= max_bytes:

--- a/tests/test_upload_core_thumbnail.py
+++ b/tests/test_upload_core_thumbnail.py
@@ -16,6 +16,30 @@ def _make_core():
 
 
 class TestCompressThumbnailFailureCleanup:
+    def test_ffmpeg_receives_absolute_input_path(self, tmp_path, monkeypatch):
+        """相対パスが渡されても ffmpeg の入力 argv は絶対パスにする。"""
+        core = _make_core()
+        monkeypatch.chdir(tmp_path)
+        thumb = Path("thumb.jpg")
+        thumb.write_bytes(b"x" * (3 * 1024 * 1024))
+        tmp_marker = tmp_path / "compressed_tmp.jpg"
+
+        def _fake_run(cmd, capture_output=True):
+            assert Path(cmd[cmd.index("-i") + 1]).is_absolute()
+            return MagicMock()
+
+        with (
+            patch("tempfile.NamedTemporaryFile") as mock_ntf,
+            patch("subprocess.run", side_effect=_fake_run),
+        ):
+            mock_file = MagicMock()
+            mock_file.name = str(tmp_marker)
+            mock_ntf.return_value = mock_file
+
+            result = core._compress_thumbnail(thumb)
+
+        assert result == thumb
+
     def test_no_temp_file_leaked_when_ffmpeg_never_produces_output(self, tmp_path):
         """ffmpeg が一度も出力しなかった場合でも FileNotFoundError を起こさず、
         temp ファイルもリークしない（元パスをそのまま返す）。"""


### PR DESCRIPTION
Closes #2396

## Summary
- `open` / `ffmpeg` に渡す Path を argv 生成時に `Path.resolve()` で絶対化
- ffmpeg 入力 argv の絶対パス契約を相対入力の回帰テストで固定
- FFmpeg が対応しない end-of-options `--` は導入せず、絶対パスで option 誤解釈を防止

## Official docs consulted
- Python `Path.resolve()`: https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve
- FFmpeg CLI: https://ffmpeg.org/ffmpeg.html

## Verification
- `uv run pytest tests/test_upload_core_thumbnail.py -q` (4 passed)
- `uv run pytest -q -m "not slow and not repo_contract" -n auto` (5196 passed)
- `uv run ruff check src tests`
- targeted files contain no `"--"` argument