### PR TITLE
refactor(config): post-publish 承認設定を skip 化

### DIFF
--- a/.claude/skills/post-publish/SKILL.md
+++ b/.claude/skills/post-publish/SKILL.md
@@ -42,10 +42,10 @@ uv run python .claude/skills/post-publish/references/post-publish-chain-state.py
 ## 実行手順
 
 1. manifest を読み、`chainId == "post-publish"`、step 順が `community-post, pinned-comment, metadata-audit` であることを検証する。
-2. `load_config().workflow.post_publish.approval_gates` を読み、manifest の `configPath` と対応する 3 gate を解決する。未指定 gate は `false`。
+2. `load_config().workflow.post_publish.skip_approvals` を読み、`false` の step だけ承認対象にする。未指定は `true`（承認省略）。旧 `approval_gates` は loader が逆向きの後方互換 alias として解決し、同一 step への新旧同時指定は `ConfigError` にする。
 3. manifest 順に状態判定を実行する。exit 0 は skip、exit 20 は停止する。
-4. exit 10 かつ gate が `true` の場合、対象 video ID・collection・実行件数 1 件を表示する。外部投稿は公開後に取り消しが必要になり得ることを警告し、「この step を実行する」「チェーンを中止する」の 2 択で確認する。中止時は履歴を変更せず、再開コマンドを表示して停止する。
-5. 子 skill を対象 collection 付きで実行する。`community-post` は Studio 投稿準備、`pinned-comment` は dry-run の PASS 条件を確認して apply、`metadata-audit` は既定の local + remote 監査を実行する。チェーン gate で承認済みの step は、同じ video ID・件数の子 skill 承認を再度求めない。gate が `false` でも子 skill 自身が必須としている safety gate は省略しない。
+4. exit 10 かつ `skip_approvals` が `false` の場合、対象 video ID・collection・実行件数 1 件を表示する。外部投稿は公開後に取り消しが必要になり得ることを警告し、「この step を実行する」「チェーンを中止する」の 2 択で確認する。中止時は履歴を変更せず、再開コマンドを表示して停止する。
+5. 子 skill を対象 collection 付きで実行する。`community-post` は Studio 投稿準備、`pinned-comment` は dry-run の PASS 条件を確認して apply、`metadata-audit` は既定の local + remote 監査を実行する。チェーン gate で承認済みの step は、同じ video ID・件数の子 skill 承認を再度求めない。`skip_approvals` が `true` でも子 skill 自身が必須としている safety gate は省略しない。
 6. 子 skill の完了条件を満たした場合だけ `--mark-complete` を実行する。失敗時は mark せず停止する。
 7. 3 step 後に状態判定を再実行し、全て exit 0 であることと履歴の video ID を短く報告する。
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -514,19 +514,22 @@ remote ID がまだ取得できていない channel_id 未設定は、AI が `uv
 ### 実行条件と共通ルール
 
 1. `config/channel/` が存在せず `channel_config` の未生成経路に入った場合は、インタビューを実行しない。`channel_config` の手順どおり「運用設定は `/channel-new` 完了後に `/setup` を再実行して設定できます」と案内する。`/setup` は config を生成しない。
-2. `config/channel/` がロード可能なら、`config/channel/workflow.json` は任意であり、未存在でもインタビューを実行する。下表の workflow 3 行は、`workflow.json` またはその入れ子のキーが未設定ならいずれも `false` を現在値として扱う。回答が現在値と異なる場合は、必要な入れ子を含む `workflow.json` を作成または更新する。
+2. `config/channel/` がロード可能なら、`config/channel/workflow.json` は任意であり、未存在でもインタビューを実行する。下表の workflow 6 行は、`workflow.json` またはその入れ子のキーが未設定なら表の default を現在値として扱う。回答が現在値と異なる場合は、必要な入れ子を含む `workflow.json` を作成または更新する。
 3. 下表の各行について、質問する直前に config を読んで現在値を取得する。現在値を利用者に質問してはならない。loop-video はまず `.claude/skills/loop-video/config.default.yaml` を読み、`config/skills/loop-video.yaml` が存在する場合はそれも読んで、`youtube_automation.utils.skill_config.load_skill_config("loop-video")` と同じ deep-merge（default の上に override）で `enabled` の現在値を解決する。override に `enabled` が無い場合も default の値を現在値とする。
 4. 質問は必ず 1 問ずつ表示し、回答を待ってから次の行へ進む。各質問には現在値と、現在値を維持する推奨回答を添える。複数の質問をまとめて表示してはならない。
 5. 回答が現在値と同じならファイルを編集しない。異なる場合だけ、その行の config を Edit で更新する。既存 `config/skills/loop-video.yaml` を更新するときは `enabled` だけを変更し、ほかの override キーを保持する。
 
 | 順番 | config | キー | default | 質問と推奨回答 |
 | --- | --- | --- | --- | --- |
-| 1 | `config/channel/workflow.json` | `workflow.wf_next.approval_gates.audio` | `false` | 「音源承認ゲートを有効にしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存の音源承認フローを変えないため）」 |
-| 2 | `config/channel/workflow.json` | `workflow.wf_next.approval_gates.upload` | `false` | 「アップロード承認ゲートを有効にしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のアップロードフローを変えないため）」 |
+| 1 | `config/channel/workflow.json` | `workflow.wf_next.skip_audio_approval` | `true` | 「音源承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 2 | `config/channel/workflow.json` | `workflow.wf_next.skip_upload_approval` | `true` | 「アップロード承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
 | 3 | `config/channel/workflow.json` | `workflow.wf_next.skip_manual_mastering` | `false` | 「手動マスタリング検出をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のマスタリングフローを変えないため）」 |
-| 4 | `config/skills/loop-video.yaml` | `enabled` | `true` | 「ループ動画生成を有効にしますか？ 現在値: `<current>`。Veo API の利用には課金が発生します。推奨: 現在値を維持（既存の Veo 利用方針を変えないため）」 |
+| 4 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.community-post` | `true` | 「コミュニティ投稿前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 5 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.pinned-comment` | `true` | 「固定コメント前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 6 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.metadata-audit` | `true` | 「メタデータ監査前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 7 | `config/skills/loop-video.yaml` | `enabled` | `true` | 「ループ動画生成を有効にしますか？ 現在値: `<current>`。Veo API の利用には課金が発生します。推奨: 現在値を維持（既存の Veo 利用方針を変えないため）」 |
 
-`workflow.wf_next.approval_gates.audio` は最終マスター候補の採用前、`workflow.wf_next.approval_gates.upload` は YouTube アップロード前に承認を取る設定である。`workflow.wf_next.skip_manual_mastering` を `true` にすると、最終マスター候補がなくても raw master を最終音源として採用する。
+`workflow.wf_next.skip_*_approval` と `workflow.post-publish.skip_approvals.*` はすべて `true = 承認省略`。`workflow.wf_next.skip_manual_mastering` を `true` にすると、最終マスター候補がなくても raw master を最終音源として採用する。
 
 `config/skills/loop-video.yaml` が存在しない場合は、解決した現在値と異なる回答のときだけ、回答値を `enabled` に持つ override ファイルを新規作成する。現在値のままなら override ファイルを作成してはならない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(config)`: `workflow.post-publish.skip_approvals` を正規キーとして追加し、`true = 承認省略` に統一。旧 `approval_gates` は逆向きの後方互換 alias として維持し、同一 step の新旧同時指定は拒否（#2403）。
+
 - `refactor(workflow)`: `/automation-run` 互換 skill を削除し、一気通貫 workflow の公開入口を `/wf-auto` に一本化。旧 `target_workflow: automation-run` は黙って変換せず移行案内付きで拒否し、`.automation-run/` の lease・履歴パスは維持（#2400）。
 
 - `security(scripts)`: `open` / `ffmpeg` へ渡すファイルパスを絶対パス化し、先頭 `-` を option と誤解釈する余地を排除（#2396）。

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ nix develop
 | `pinned-comment.json` | `pinned_comment` (optional) |
 | `distrokid.json` | `distrokid` (optional) |
 
-`workflow.json` は `/wf-next` と `/post-publish` 向けの任意設定です。`workflow.wf_next` は制作フェーズの承認・mastering 運用を宣言します。`workflow.post-publish.approval_gates.{community-post,pinned-comment,metadata-audit}` は公開後 step 直前の承認を boolean で宣言し、section 自体が未設定なら従来どおり community-post のみを案内します。
+`workflow.json` は `/wf-next` と `/post-publish` 向けの任意設定です。`workflow.wf_next` は制作フェーズの承認・mastering 運用を宣言します。`workflow.post-publish.skip_approvals.{community-post,pinned-comment,metadata-audit}` は `true` で公開後 step 直前の承認を省略します。旧 `approval_gates` は逆向きの後方互換 alias で、同一 step の新旧同時指定はエラーです。section 自体が未設定なら従来どおり community-post のみを案内します。
 
 詳細なフィールド説明は [`examples/channel_config.example/`](examples/channel_config.example/) を参照してください。多言語テンプレートは `config/localizations.json` に集約します（単一ソース）。`community.example.json` は `/community-post` が直接読む skill-local raw JSON の雛形で、共通 config loader の必須/optional section ではありません。
 

--- a/examples/channel_config.example/workflow.json
+++ b/examples/channel_config.example/workflow.json
@@ -6,7 +6,7 @@
       "skip_manual_mastering": false
     },
     "post-publish": {
-      "approval_gates": {
+      "skip_approvals": {
         "community-post": true,
         "pinned-comment": true,
         "metadata-audit": true

--- a/src/youtube_automation/utils/config/loader.py
+++ b/src/youtube_automation/utils/config/loader.py
@@ -44,6 +44,7 @@ from youtube_automation.utils.config.workflow import (
     ApprovalGates,
     PostPublish,
     PostPublishApprovalGates,
+    PostPublishSkipApprovals,
     ScheduledAutomation,
     WfNext,
     Workflow,
@@ -636,10 +637,16 @@ def _build_workflow(merged: dict) -> Workflow:
         raise ConfigError(
             f"workflow.post-publish は object でなければなりません（got {type(post_publish_raw).__name__}）"
         )
-    unexpected = set(post_publish_raw) - {"approval_gates"}
+    unexpected = set(post_publish_raw) - {"skip_approvals", "approval_gates"}
     if unexpected:
         names = ", ".join(sorted(unexpected))
         raise ConfigError(f"workflow.post-publish に未知のキーがあります: {names}")
+    post_publish_skip_raw = post_publish_raw.get("skip_approvals", {})
+    if not isinstance(post_publish_skip_raw, dict):
+        raise ConfigError(
+            "workflow.post-publish.skip_approvals は object でなければなりません"
+            f"（got {type(post_publish_skip_raw).__name__}）"
+        )
     post_publish_gates_raw = post_publish_raw.get("approval_gates", {})
     if not isinstance(post_publish_gates_raw, dict):
         raise ConfigError(
@@ -647,10 +654,19 @@ def _build_workflow(merged: dict) -> Workflow:
             f"（got {type(post_publish_gates_raw).__name__}）"
         )
     post_publish_steps = {"community-post", "pinned-comment", "metadata-audit"}
-    unknown_steps = set(post_publish_gates_raw) - post_publish_steps
-    if unknown_steps:
-        names = ", ".join(sorted(unknown_steps))
-        raise ConfigError(f"workflow.post-publish.approval_gates に未知の step があります: {names}")
+    for key, values in (
+        ("skip_approvals", post_publish_skip_raw),
+        ("approval_gates", post_publish_gates_raw),
+    ):
+        unknown_steps = set(values) - post_publish_steps
+        if unknown_steps:
+            names = ", ".join(sorted(unknown_steps))
+            raise ConfigError(f"workflow.post-publish.{key} に未知の step があります: {names}")
+
+    post_publish_skips = {
+        step: _resolve_post_publish_skip_approval(post_publish_skip_raw, post_publish_gates_raw, step)
+        for step in post_publish_steps
+    }
 
     return Workflow(
         wf_next=WfNext(
@@ -665,22 +681,15 @@ def _build_workflow(merged: dict) -> Workflow:
         ),
         post_publish=PostPublish(
             configured=post_publish_configured,
+            skip_approvals=PostPublishSkipApprovals(
+                community_post=post_publish_skips["community-post"],
+                pinned_comment=post_publish_skips["pinned-comment"],
+                metadata_audit=post_publish_skips["metadata-audit"],
+            ),
             approval_gates=PostPublishApprovalGates(
-                community_post=_workflow_bool(
-                    post_publish_gates_raw,
-                    "community-post",
-                    "workflow.post-publish.approval_gates.community-post",
-                ),
-                pinned_comment=_workflow_bool(
-                    post_publish_gates_raw,
-                    "pinned-comment",
-                    "workflow.post-publish.approval_gates.pinned-comment",
-                ),
-                metadata_audit=_workflow_bool(
-                    post_publish_gates_raw,
-                    "metadata-audit",
-                    "workflow.post-publish.approval_gates.metadata-audit",
-                ),
+                community_post=not post_publish_skips["community-post"],
+                pinned_comment=not post_publish_skips["pinned-comment"],
+                metadata_audit=not post_publish_skips["metadata-audit"],
             ),
         ),
         scheduled_automation=_build_scheduled_automation(wf),
@@ -810,6 +819,20 @@ def _resolve_skip_approval(wf_next_raw: dict, gates_raw: dict, new_key: str, leg
         return _workflow_bool(wf_next_raw, new_key, f"workflow.wf_next.{new_key}")
     if legacy_specified:
         return not _workflow_bool(gates_raw, legacy_key, f"workflow.wf_next.approval_gates.{legacy_key}")
+    return True
+
+
+def _resolve_post_publish_skip_approval(skip_raw: dict, gates_raw: dict, step: str) -> bool:
+    """`skip_approvals` を正とし、逆向きの旧 `approval_gates` を解決する."""
+    if step in skip_raw and step in gates_raw:
+        raise ConfigError(
+            f"workflow.post-publish.skip_approvals.{step} と "
+            f"workflow.post-publish.approval_gates.{step} は同時指定できません"
+        )
+    if step in skip_raw:
+        return _workflow_bool(skip_raw, step, f"workflow.post-publish.skip_approvals.{step}")
+    if step in gates_raw:
+        return not _workflow_bool(gates_raw, step, f"workflow.post-publish.approval_gates.{step}")
     return True
 
 

--- a/src/youtube_automation/utils/config/workflow.py
+++ b/src/youtube_automation/utils/config/workflow.py
@@ -103,11 +103,20 @@ class ScheduledAutomation:
 
 @dataclass(frozen=True)
 class PostPublishApprovalGates:
-    """`/post-publish` の各 step 直前に置く承認ゲート."""
+    """`/post-publish` の旧 `approval_gates` consumer 向け derived view."""
 
     community_post: bool = False
     pinned_comment: bool = False
     metadata_audit: bool = False
+
+
+@dataclass(frozen=True)
+class PostPublishSkipApprovals:
+    """`/post-publish` の承認省略設定（`True` = 承認なし）."""
+
+    community_post: bool = True
+    pinned_comment: bool = True
+    metadata_audit: bool = True
 
 
 @dataclass(frozen=True)
@@ -119,6 +128,7 @@ class PostPublish:
     """
 
     configured: bool = False
+    skip_approvals: PostPublishSkipApprovals = field(default_factory=PostPublishSkipApprovals)
     approval_gates: PostPublishApprovalGates = field(default_factory=PostPublishApprovalGates)
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -841,13 +841,62 @@ def test_workflow_post_publish_unset_preserves_legacy_mode(tmp_path, monkeypatch
     config = load_config()
 
     assert config.workflow.post_publish.configured is False
+    assert config.workflow.post_publish.skip_approvals.community_post is True
+    assert config.workflow.post_publish.skip_approvals.pinned_comment is True
+    assert config.workflow.post_publish.skip_approvals.metadata_audit is True
     assert config.workflow.post_publish.approval_gates.community_post is False
     assert config.workflow.post_publish.approval_gates.pinned_comment is False
     assert config.workflow.post_publish.approval_gates.metadata_audit is False
 
 
-def test_workflow_post_publish_gate_overrides_are_observable(tmp_path, monkeypatch):
-    """#1824: section の存在で chain を opt-in し、step ごとの boolean を貫通する."""
+def test_workflow_post_publish_empty_section_skips_all_approvals(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    post_publish = load_config().workflow.post_publish
+
+    assert post_publish.configured is True
+    assert post_publish.skip_approvals.community_post is True
+    assert post_publish.skip_approvals.pinned_comment is True
+    assert post_publish.skip_approvals.metadata_audit is True
+
+
+@pytest.mark.parametrize(
+    ("step", "attribute"),
+    [
+        ("community-post", "community_post"),
+        ("pinned-comment", "pinned_comment"),
+        ("metadata-audit", "metadata_audit"),
+    ],
+)
+def test_workflow_post_publish_skip_approval_true_is_observable(tmp_path, monkeypatch, step, attribute):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {"skip_approvals": {step: True}}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    post_publish = load_config().workflow.post_publish
+
+    assert getattr(post_publish.skip_approvals, attribute) is True
+    assert getattr(post_publish.approval_gates, attribute) is False
+
+
+def test_workflow_post_publish_skip_approval_false_requires_approval(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {"skip_approvals": {"pinned-comment": False}}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    post_publish = load_config().workflow.post_publish
+
+    assert post_publish.skip_approvals.pinned_comment is False
+    assert post_publish.approval_gates.pinned_comment is True
+
+
+def test_workflow_post_publish_legacy_gate_alias_preserves_behavior(tmp_path, monkeypatch):
+    """旧 `approval_gates` は値を反転して従来の承認有無を維持する."""
     sections = _minimal_sections()
     sections["workflow.json"] = {
         "workflow": {
@@ -866,6 +915,9 @@ def test_workflow_post_publish_gate_overrides_are_observable(tmp_path, monkeypat
     config = load_config()
 
     assert config.workflow.post_publish.configured is True
+    assert config.workflow.post_publish.skip_approvals.community_post is False
+    assert config.workflow.post_publish.skip_approvals.pinned_comment is True
+    assert config.workflow.post_publish.skip_approvals.metadata_audit is False
     assert config.workflow.post_publish.approval_gates.community_post is True
     assert config.workflow.post_publish.approval_gates.pinned_comment is False
     assert config.workflow.post_publish.approval_gates.metadata_audit is True
@@ -879,6 +931,57 @@ def test_workflow_post_publish_gate_must_be_boolean(tmp_path, monkeypatch, inval
     monkeypatch.setenv("CHANNEL_DIR", str(ch))
 
     with pytest.raises(ConfigError, match="workflow.post-publish.approval_gates.pinned-comment は boolean"):
+        load_config()
+
+
+@pytest.mark.parametrize("invalid", ["true", 1, None, {}, []])
+def test_workflow_post_publish_skip_approval_must_be_boolean(tmp_path, monkeypatch, invalid):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {"skip_approvals": {"pinned-comment": invalid}}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match="workflow.post-publish.skip_approvals.pinned-comment は boolean"):
+        load_config()
+
+
+def test_workflow_post_publish_rejects_new_and_legacy_gate_for_same_step(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {
+        "workflow": {
+            "post-publish": {
+                "skip_approvals": {"community-post": True},
+                "approval_gates": {"community-post": False},
+            }
+        }
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match=r"skip_approvals\.community-post.*approval_gates\.community-post"):
+        load_config()
+
+
+@pytest.mark.parametrize("key", ["skip_approvals", "approval_gates"])
+def test_workflow_post_publish_rejects_unknown_step_in_both_forms(tmp_path, monkeypatch, key):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {key: {"unknown-step": True}}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match=rf"workflow.post-publish\.{key}.*unknown-step"):
+        load_config()
+
+
+@pytest.mark.parametrize("key", ["skip_approvals", "approval_gates"])
+@pytest.mark.parametrize("invalid", [None, False, [], "bad"])
+def test_workflow_post_publish_gate_containers_must_be_objects(tmp_path, monkeypatch, key, invalid):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"post-publish": {key: invalid}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match=rf"workflow.post-publish\.{key} は object"):
         load_config()
 
 

--- a/tests/test_skill_docs_consistency.py
+++ b/tests/test_skill_docs_consistency.py
@@ -1039,6 +1039,26 @@ def test_wf_next_skip_approval_keys_are_documented_consistently() -> None:
     assert "skip_audio_approval" in schema
 
 
+def test_post_publish_skip_approvals_are_documented_consistently() -> None:
+    post_publish = _read(".claude/skills/post-publish/SKILL.md")
+    setup = _read(".claude/skills/setup/SKILL.md")
+    readme = _read("README.md")
+    example = json.loads(_read("examples/channel_config.example/workflow.json"))
+    config = example["workflow"]["post-publish"]
+
+    assert "approval_gates" not in config
+    assert config["skip_approvals"] == {
+        "community-post": True,
+        "pinned-comment": True,
+        "metadata-audit": True,
+    }
+    for text in (post_publish, setup, readme):
+        assert "skip_approvals" in text
+    assert "`false` の step だけ承認対象" in post_publish
+    assert "後方互換 alias" in post_publish
+    assert "同一 step" in post_publish and "ConfigError" in post_publish
+
+
 def test_common_docs_list_optional_channel_config_files() -> None:
     required = ("shorts.json", "comments.json", "pinned-comment.json", "distrokid.json")
 


### PR DESCRIPTION
Closes #2403
Part of #2402

## Summary
- `workflow.post-publish.skip_approvals` を正規キーとして追加（`true = 承認省略`）
- 旧 `approval_gates` は値を反転する derived compatibility view として挙動維持
- 同一 step の新旧同時指定、未知 step、非 boolean / 非 object を `ConfigError` で拒否
- example / README / post-publish / setup skill を新しい向きへ同期

## Official docs consulted
- Python dataclasses: https://docs.python.org/3/library/dataclasses.html
- Python JSON: https://docs.python.org/3/library/json.html

## Verification
- `uv run pytest tests/test_config_loader.py tests/test_skill_docs_consistency.py -q`
- `uv run yt-skills lint post-publish setup`
- `uv run pytest -q -n auto` (6557 passed, 1 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`