### PR TITLE
fix(doctor): workspace共有assetsを正しく診断する (#2463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(doctor)`: workspace root の `--channel` 選択を診断対象へ反映し、channel 配下からの診断でも root の `pyproject.toml`・共有 skills・`.agents/skills`・重複ファイル検査を利用するよう修正（#2463）。
 - `breaking(refactor/domains)`: Suno 14旧 `utils.suno_*` module と `utils.metadata_generator` を削除し、`domains.suno` / `domains.suno.downloaded` / `domains.metadata` へ移行。旧 import path は恒久 facade として提供しない（#2305）。
 - `feat(skills-sync)`: Claude Code settings の allow / deny / hook を既存値保持・hook 明示承認付きで downstream へ JSON merge 配布し、開発専用 skill を同期対象外として既存配置は prune 可能にした（#2425, #2426, #2428）。
 - `fix(upload)`: `assets.master_video` を動画選択の正本にして Preview 誤選択を防ぎ、plan で全 locale の100文字制限を検証。タイトル短縮の再承認と公開時刻 conflict の停止契約も追加（#2429, #2434, #2437, #2438）。

--- a/docs/channel-workspace-migration.md
+++ b/docs/channel-workspace-migration.md
@@ -50,6 +50,7 @@ uv run yt-doctor --channel ambient-island
 ```
 
 channel directory 内で実行する CLI は従来どおり cwd から channel を解決します。workspace root から実行するときは `--channel ambient-island` または `CHANNEL=ambient-island` を指定します。
+`yt-doctor` の bootstrap 診断は channel 固有の config / auth と、workspace root に1セットだけ置いた `pyproject.toml` / `.claude/skills` / `.agents/skills` を組み合わせて検査します。
 
 ## 4. `.env` と git 管理対象を確認する
 

--- a/src/youtube_automation/cli/doctor.py
+++ b/src/youtube_automation/cli/doctor.py
@@ -36,7 +36,12 @@ from PIL import UnidentifiedImageError
 from youtube_automation.auth.oauth_handler import resolve_client_secrets_location
 from youtube_automation.cli.automation_update_refs import UPSTREAM_REPO
 from youtube_automation.cli.skills_sync import bundled_skill_names
-from youtube_automation.configuration import find_workspace_root, workspace_channels
+from youtube_automation.configuration import (
+    channel_dir,
+    find_workspace_root,
+    workspace_channels,
+)
+from youtube_automation.configuration.loader import _explicit_channel_selection
 from youtube_automation.scripts.benchmark_collector import (
     TTP_VIDEO_ANALYZE_TOP_N,
     load_benchmark_videos,
@@ -360,6 +365,21 @@ def _agents_skills_link_is_valid(channel_dir: Path, skills_dir: Path) -> bool:
         return False
 
 
+def _workspace_root_for_channel(channel_dir: Path) -> Path | None:
+    """登録済み workspace channel の共有 root だけを返す."""
+    resolved_channel = channel_dir.resolve()
+    workspace_root = find_workspace_root(resolved_channel)
+    if workspace_root is None:
+        return None
+    registered_channels = {path.resolve() for path in workspace_channels(workspace_root).values()}
+    return workspace_root if resolved_channel in registered_channels else None
+
+
+def _bootstrap_root(channel_dir: Path) -> Path:
+    """共有 tool / skill を検査・更新する repository root を返す."""
+    return _workspace_root_for_channel(channel_dir) or channel_dir
+
+
 # --- checks ---
 
 
@@ -423,7 +443,7 @@ def check_uv() -> CheckResult:
 
 
 def check_uv_project(channel_dir: Path) -> CheckResult:
-    pyproject_path = channel_dir / PYPROJECT_FILENAME
+    pyproject_path = _bootstrap_root(channel_dir) / PYPROJECT_FILENAME
     if not pyproject_path.exists():
         if _has_automation_tool():
             return CheckResult(
@@ -450,7 +470,7 @@ def check_uv_project(channel_dir: Path) -> CheckResult:
 
 
 def check_automation_package(channel_dir: Path) -> CheckResult:
-    pyproject_path = channel_dir / PYPROJECT_FILENAME
+    pyproject_path = _bootstrap_root(channel_dir) / PYPROJECT_FILENAME
     if not pyproject_path.exists():
         if _has_automation_tool():
             return CheckResult(
@@ -518,7 +538,8 @@ def check_automation_package(channel_dir: Path) -> CheckResult:
 
 
 def check_skills_synced(channel_dir: Path) -> CheckResult:
-    skills_dir = channel_dir / CLAUDE_SKILLS_DIR
+    bootstrap_root = _bootstrap_root(channel_dir)
+    skills_dir = bootstrap_root / CLAUDE_SKILLS_DIR
     bundled_skills = bundled_skill_names()
     for legacy_skill in LEGACY_BUNDLED_SKILLS:
         if (skills_dir / legacy_skill / SKILL_FILENAME).exists():
@@ -533,7 +554,7 @@ def check_skills_synced(channel_dir: Path) -> CheckResult:
     if missing_skill_files:
         sample = ", ".join(str(CLAUDE_SKILLS_DIR / path) for path in missing_skill_files[:5])
         return _skills_sync_failure(f"同梱 skill が未展開: {sample}")
-    if not _agents_skills_link_is_valid(channel_dir, skills_dir):
+    if not _agents_skills_link_is_valid(bootstrap_root, skills_dir):
         return _skills_sync_warning(f"{AGENTS_SKILLS_LINK} が {CLAUDE_SKILLS_DIR} を指す symlink になっていない")
     return CheckResult(
         id="skills_synced",
@@ -550,13 +571,14 @@ def check_numbered_duplicates(channel_dir: Path) -> CheckResult:
     yt-skills sync が同名上書きで管理する領域のため、`<名前> <数字>` 形式が
     現れたら外部要因 (同期サービス) による汚染とみなす (#1409 / #1410)。
     """
+    bootstrap_root = _bootstrap_root(channel_dir)
     findings: list[str] = []
     scan_targets = (
-        (".venv/bin", channel_dir / ".venv" / "bin", False),
-        (str(CLAUDE_SKILLS_DIR), channel_dir / CLAUDE_SKILLS_DIR, True),
+        (".venv/bin", bootstrap_root / ".venv" / "bin", False),
+        (str(CLAUDE_SKILLS_DIR), bootstrap_root / CLAUDE_SKILLS_DIR, True),
     )
     for label, directory, recursive in scan_targets:
-        result = scan_numbered_duplicates(directory, recursive=recursive, root_boundary=channel_dir)
+        result = scan_numbered_duplicates(directory, recursive=recursive, root_boundary=bootstrap_root)
         if result.duplicates:
             sample = ", ".join(format_duplicate_name(path) for path in result.duplicates[:3])
             findings.append(f"{label} に {len(result.duplicates)} 件 (例: {sample})")
@@ -3206,7 +3228,8 @@ def _run_apply_loop(
                 exit_code=1,
             )
         attempted_steps.add(step_key)
-        returncode, _stdout, stderr = _run_apply_command(argv, channel_dir)
+        command_cwd = _bootstrap_root(channel_dir) if unresolved.category == BOOTSTRAP_CATEGORY else channel_dir
+        returncode, _stdout, stderr = _run_apply_command(argv, command_cwd)
         executed.append(ExecutedStep(unresolved.id, command, returncode))
         if returncode != 0:
             return _apply_outcome(
@@ -3246,10 +3269,19 @@ def run_apply(
 def resolve_channel_dir(target: Optional[str]) -> Path:
     if target:
         return Path(target).resolve()
-    env_dir = os.environ.get("CHANNEL_DIR")
-    if env_dir:
-        return Path(env_dir).resolve()
-    return Path.cwd().resolve()
+    cwd = Path.cwd().resolve()
+    try:
+        return channel_dir().resolve()
+    except ConfigError:
+        selection_requested = (
+            _explicit_channel_selection() is not None
+            or bool(os.environ.get("CHANNEL"))
+            or bool(os.environ.get("CHANNEL_DIR"))
+            or find_workspace_root(cwd) is not None
+        )
+        if selection_requested:
+            raise
+        return cwd
 
 
 @dataclass(frozen=True)

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -129,6 +129,11 @@ def select_channel(slug: str | None) -> None:
     _explicit_channel = slug
 
 
+def _explicit_channel_selection() -> str | None:
+    """共通 CLI wrapper が受け取った明示 channel slug を返す."""
+    return _explicit_channel
+
+
 def _find_channel_ancestor(start: Path) -> Path | None:
     current = start.expanduser().resolve()
     for parent in [current, *current.parents]:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1000,6 +1000,18 @@ class TestOAuthClientSharingRecommendation:
 
 
 class TestResolveChannelDir:
+    @staticmethod
+    def _workspace(tmp_path: Path) -> tuple[Path, Path]:
+        workspace = tmp_path / "workspace"
+        channel = workspace / "channels" / "alpha"
+        (channel / "config" / "channel").mkdir(parents=True)
+        return workspace, channel
+
+    @staticmethod
+    def _clear_channel_env(monkeypatch) -> None:
+        monkeypatch.delenv("CHANNEL", raising=False)
+        monkeypatch.delenv("CHANNEL_DIR", raising=False)
+
     def test_target_explicit(self, tmp_path):
         r = doctor.resolve_channel_dir(str(tmp_path))
         assert r == tmp_path.resolve()
@@ -1014,6 +1026,42 @@ class TestResolveChannelDir:
         monkeypatch.chdir(tmp_path)
         r = doctor.resolve_channel_dir(None)
         assert r == tmp_path.resolve()
+
+    def test_common_channel_selection_resolves_workspace_channel(self, tmp_path, monkeypatch):
+        from youtube_automation.configuration import select_channel
+
+        self._clear_channel_env(monkeypatch)
+        workspace, channel = self._workspace(tmp_path)
+        monkeypatch.chdir(workspace)
+        select_channel("alpha")
+
+        assert doctor.resolve_channel_dir(None) == channel.resolve()
+
+    def test_workspace_root_without_selection_is_rejected(self, tmp_path, monkeypatch):
+        self._clear_channel_env(monkeypatch)
+        workspace, _channel = self._workspace(tmp_path)
+        monkeypatch.chdir(workspace)
+
+        with pytest.raises(ConfigError, match=r"workspace ルート.*--channel"):
+            doctor.resolve_channel_dir(None)
+
+    def test_target_remains_higher_priority_than_common_selection(self, tmp_path, monkeypatch):
+        from youtube_automation.configuration import select_channel
+
+        self._clear_channel_env(monkeypatch)
+        workspace, _channel = self._workspace(tmp_path)
+        target = tmp_path / "explicit-target"
+        target.mkdir()
+        monkeypatch.chdir(workspace)
+        select_channel("alpha")
+
+        assert doctor.resolve_channel_dir(str(target)) == target.resolve()
+
+    def test_unconfigured_setup_directory_still_uses_cwd(self, tmp_path, monkeypatch):
+        self._clear_channel_env(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+
+        assert doctor.resolve_channel_dir(None) == tmp_path.resolve()
 
 
 class TestMain:
@@ -1680,6 +1728,13 @@ class TestCheckInitialSetupReadiness:
 
 
 class TestBootstrapChecks:
+    @staticmethod
+    def _workspace_channel(tmp_path: Path) -> tuple[Path, Path]:
+        workspace = tmp_path / "workspace"
+        channel = workspace / "channels" / "alpha"
+        (channel / "config" / "channel").mkdir(parents=True)
+        return workspace, channel
+
     def test_check_uv_ok(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None)
         r = doctor.check_uv()
@@ -1731,6 +1786,16 @@ class TestBootstrapChecks:
         assert r.status == "ok"
         assert r.category == "bootstrap"
 
+    def test_workspace_channel_uses_root_uv_project(self, monkeypatch, tmp_path):
+        workspace, channel = self._workspace_channel(tmp_path)
+        (workspace / "pyproject.toml").write_text('[project]\nname = "workspace"\n', encoding="utf-8")
+        monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: pytest.fail("uv tool list should not run"))
+
+        r = doctor.check_uv_project(channel)
+
+        assert r.status == "ok"
+        assert r.message == "uv project 初期化済み"
+
     def test_automation_package_missing_pyproject_is_fail_with_uv_init(self, monkeypatch, tmp_path):
         monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: (0, "", ""))
         r = doctor.check_automation_package(tmp_path)
@@ -1775,6 +1840,19 @@ class TestBootstrapChecks:
         r = doctor.check_automation_package(tmp_path)
         assert r.status == "ok"
         assert r.category == "bootstrap"
+
+    def test_workspace_channel_uses_root_automation_dependency(self, monkeypatch, tmp_path):
+        workspace, channel = self._workspace_channel(tmp_path)
+        (workspace / "pyproject.toml").write_text(
+            '[project]\nname = "workspace"\ndependencies = ["youtube-channels-automation"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: pytest.fail("uv tool list should not run"))
+
+        r = doctor.check_automation_package(channel)
+
+        assert r.status == "ok"
+        assert r.message == "automation パッケージ導入済み"
 
     def test_automation_package_similar_name_is_fail(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
@@ -1863,6 +1941,43 @@ class TestBootstrapChecks:
         r = doctor.check_skills_synced(tmp_path)
         assert r.status == "ok"
         assert r.category == "bootstrap"
+
+    def test_workspace_channel_uses_root_shared_skills(self, tmp_path, monkeypatch):
+        workspace, channel = self._workspace_channel(tmp_path)
+        monkeypatch.setattr(doctor, "bundled_skill_names", lambda: ["channel-new", "setup"])
+        for skill_name in ["channel-new", "setup"]:
+            skill_dir = workspace / ".claude" / "skills" / skill_name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"# {skill_name}", encoding="utf-8")
+        agents_dir = workspace / ".agents"
+        agents_dir.mkdir()
+        (agents_dir / "skills").symlink_to(Path("..") / ".claude" / "skills")
+
+        r = doctor.check_skills_synced(channel)
+
+        assert r.status == "ok"
+        assert r.category == "bootstrap"
+
+    def test_workspace_channel_scans_root_managed_directories(self, tmp_path):
+        workspace, channel = self._workspace_channel(tmp_path)
+        (workspace / ".claude" / "skills").mkdir(parents=True)
+
+        r = doctor.check_numbered_duplicates(channel)
+
+        assert r.status == "ok"
+        assert "走査できません" not in r.message
+
+    def test_nested_standalone_channel_does_not_use_outer_workspace_bootstrap(self, tmp_path, monkeypatch):
+        workspace, _channel = self._workspace_channel(tmp_path)
+        standalone = workspace / "standalone"
+        (standalone / "config" / "channel").mkdir(parents=True)
+        (workspace / "pyproject.toml").write_text('[project]\nname = "workspace"\n', encoding="utf-8")
+        monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: (0, "", ""))
+
+        r = doctor.check_uv_project(standalone)
+
+        assert r.status == "fail"
+        assert r.next_action["cmd"] == "uv init"
 
     def test_skills_synced_legacy_onboard_orphan_is_fail_with_prune(self, tmp_path, monkeypatch):
         monkeypatch.setattr(doctor, "bundled_skill_names", lambda: ["setup"])

--- a/tests/test_doctor_apply.py
+++ b/tests/test_doctor_apply.py
@@ -92,6 +92,39 @@ def test_apply_executes_ai_step_and_rediagnoses(monkeypatch, tmp_path: Path, cap
     }
 
 
+def test_apply_executes_workspace_bootstrap_step_from_root(monkeypatch, tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "workspace"
+    channel = workspace / "channels" / "alpha"
+    (channel / "config" / "channel").mkdir(parents=True)
+    diagnoses = iter(
+        [
+            [
+                doctor.CheckResult(
+                    id="skills_synced",
+                    status="fail",
+                    message="missing",
+                    category=doctor.BOOTSTRAP_CATEGORY,
+                    next_action=_ai_action("uv", "run", "yt-skills", "sync"),
+                )
+            ],
+            [],
+        ]
+    )
+    commands: list[tuple[list[str], Path]] = []
+    monkeypatch.setattr(doctor, "run_all_checks", lambda _channel_dir: next(diagnoses))
+    monkeypatch.setattr(
+        doctor,
+        "_run_apply_command",
+        lambda argv, cwd: commands.append((argv, cwd)) or (0, "synced", ""),
+    )
+
+    code = doctor.main(["--apply", "--json", "--target", str(channel)])
+
+    assert code == 0
+    assert commands == [(["uv", "run", "yt-skills", "sync"], workspace)]
+    assert json.loads(capsys.readouterr().out)["apply"]["stop_reason"] == "completed"
+
+
 def test_apply_never_executes_interactive_auth_even_if_mislabeled(monkeypatch, tmp_path: Path, capsys) -> None:
     action = _ai_action("gcloud", "auth", "application-default", "login")
     monkeypatch.setattr(doctor, "run_all_checks", lambda _channel_dir: [_result("adc", "fail", action)])


### PR DESCRIPTION
## Summary

- 共通 `--channel` で選んだ workspace channel を `yt-doctor` の診断対象へ反映
- channel 固有 config/auth と workspace root の pyproject・共有 skills・`.agents/skills` を組み合わせて診断
- bootstrap の `--apply` を workspace root で実行し、nested standalone repository は誤検出しない
- migration guide と CHANGELOG を更新

## Verification

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pytest -q` — 6648 passed, 1 skipped
- 実 workspace で `yt-doctor --channel harana-island-sounds --json` が対象 channel と root 共有 assets を解決

Blocks #2459
Closes #2463
