### PR TITLE
feat(masterup): Suno個別音源cleanupを既定化 (#2445)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -65,7 +65,7 @@ TS CLI `uv run yt-generate-master` は `audio` の実行時既定値を組み込
 | `post_processing.rain_layers.volume_db` | `-19` | 各レイヤーに当てる減衰 dB（10^(-19/20) ≈ 0.112）。`uv run yt-apply-rain-layers` が ffmpeg `volume={dB}` でレイヤー毎に適用 |
 | `post_processing.rain_layers.output_name` | `master-rain.wav` | 後処理出力ファイル名（`01-master/` 配下）。成功時に `workflow-state.json::assets.raw_master` がこの名前へ書き換わる |
 | `post_processing.rain_layers.output_codec` / `.output_sample_rate` | `pcm_s16le` / `44100` | 出力 WAV の ffmpeg コーデックとサンプリングレート（ステレオ固定）。後段の外部 DAW でミキシング+マスタリングする運用想定 |
-| `post_processing.suno_audio_cleanup.enabled` | `false` | Suno ダウンロード直後の個別音源に、無音カット / EQ / dynaudnorm / limiter / LUFS 正規化 / 末尾 fade guard を適用する opt-in |
+| `post_processing.suno_audio_cleanup.enabled` | `true` | Suno ダウンロード直後の個別音源に、無音カット / EQ / dynaudnorm / limiter / LUFS 正規化 / 末尾 fade guard を適用する。従来挙動へ戻す場合はチャンネル側で `false` にする |
 | `post_processing.suno_audio_cleanup.loudnorm.I` | `-14` | YouTube 向け LUFS 正規化の目標値。チャンネル側 `config/skills/masterup.json` 優先、既存 `masterup.yaml` fallback で調整可能 |
 | `pair_selection.mode` | `auto` | `suno-prompts.json` の `lyrics` から歌詞あり/なしを判定し、歌詞ありならペアから 1 曲、歌詞なしなら 2 clip 両方を採用する。`never` で整理をスキップ |
 | `pair_selection.min_song_sec` / `.max_song_sec` | `45` / `300` | 極端に短い曲 / 長い曲を master 対象から除外する duration guard。`null` で片側だけ無効化 |
@@ -484,9 +484,9 @@ uv run yt-suno-select-tracks <collection-path> --dry-run
 
 検証失敗時は Step 4 / 4.5 のレポートを提示し、ユーザーに手動修正（再ダウンロード / Suno UI からの手動取得 / `/suno-helper` 追補生成）を促してから再実行する。
 
-#### Step 5.0: Suno 個別音源の音質補正（任意 / config opt-in）
+#### Step 5.0: Suno 個別音源の音質補正（既定 ON / config opt-out）
 
-`post_processing.suno_audio_cleanup.enabled: true` のチャンネルでは、マスター結合前に `02-Individual-music/` の各 Suno 音源へ ffmpeg 後処理を適用する:
+マスター結合前に `02-Individual-music/` の各 Suno 音源へ ffmpeg 後処理を適用する:
 
 ```bash
 uv run yt-suno-audio-cleanup plan <collection-path>   # まず対象と ffmpeg filter を確認
@@ -502,7 +502,19 @@ uv run yt-suno-audio-cleanup apply <collection-path>  # 元ファイルを origi
 - 既定 `-14 LUFS` の `loudnorm`
 - 後半崩れの被害を抑える末尾 fade-out guard
 
-`enabled: false`（既定）の場合は何もしない。ユーザーが単発で試したい場合は `--force` を付けて `plan/apply` できる。既に backup があるファイルは二重処理を避けるため skip される（再処理する場合も `--force`）。
+同梱既定は `enabled: true`。従来どおり cleanup せず結合するチャンネルは、`config/skills/masterup.json`（JSON が無ければ互換 `masterup.yaml`）で次のように明示 opt-out する:
+
+```json
+{
+  "post_processing": {
+    "suno_audio_cleanup": {
+      "enabled": false
+    }
+  }
+}
+```
+
+`enabled: false` の場合は何もしない。単発で明示実行する場合は `--force` を付けて `plan/apply` できる。既に backup があるファイルは二重処理を避けるため skip される（再処理する場合も `--force`）。
 
 #### Step 5 本体: マスター結合の実行
 

--- a/.claude/skills/masterup/config.default.yaml
+++ b/.claude/skills/masterup/config.default.yaml
@@ -119,37 +119,37 @@ stock:
 # に書き出す軽い後処理。後段で外部 DAW のミキシング+マスタリングを挟む運用向け。
 # 成功時に workflow-state.json の assets.raw_master を output_name へ切り替える。
 #
-# post_processing:
-#   suno_audio_cleanup:
-#     enabled: false              # opt-in。true なら /masterup の Suno DL 後に uv run yt-suno-audio-cleanup apply を実行
-#     backup_originals: true      # 02-Individual-music/originals-pre-cleanup/ に元ファイルを保存
-#     bitrate: "192k"             # libmp3lame 出力ビットレート (未指定なら audio.bitrate)
-#     codec: "libmp3lame"
-#     trim_silence:
-#       enabled: true             # 冒頭無音を silenceremove でカット
-#       threshold_db: -50
-#     eq:
-#       enabled: true             # 350Hz のもやつき / 8kHz 以上のシャリつきを軽く抑える
-#       muddiness_freq_hz: 350
-#       muddiness_gain_db: -2
-#       harshness_freq_hz: 8000
-#       harshness_gain_db: -1.5
-#     volume_smoothing: true      # dynaudnorm で曲中の音量ムラを緩和
-#     limiter:
-#       enabled: true             # alimiter で瞬間ピークを抑制
-#       limit: 0.95
-#     loudnorm:
-#       enabled: true             # YouTube 向け LUFS 正規化
-#       I: -14
-#       LRA: 11
-#       TP: -1.5
-#     tail_fade_guard:
-#       enabled: true             # 後半崩れ対策として末尾に短い fade-out guard を入れる
-#       fade_sec: 3
-#
-#   rain_layers:
+post_processing:
+  suno_audio_cleanup:
+    enabled: true               # 既定 ON。false で Suno DL 後の個別音源 cleanup を無効化
+    backup_originals: true      # 02-Individual-music/originals-pre-cleanup/ に元ファイルを保存
+    bitrate: "192k"             # libmp3lame 出力ビットレート (未指定なら audio.bitrate)
+    codec: "libmp3lame"
+    trim_silence:
+      enabled: true             # 冒頭無音を silenceremove でカット
+      threshold_db: -50
+    eq:
+      enabled: true             # 350Hz のもやつき / 8kHz 以上のシャリつきを軽く抑える
+      muddiness_freq_hz: 350
+      muddiness_gain_db: -2
+      harshness_freq_hz: 8000
+      harshness_gain_db: -1.5
+    volume_smoothing: true      # dynaudnorm で曲中の音量ムラを緩和
+    limiter:
+      enabled: true             # alimiter で瞬間ピークを抑制
+      limit: 0.95
+    loudnorm:
+      enabled: true             # YouTube 向け LUFS 正規化
+      I: -14
+      LRA: 11
+      TP: -1.5
+    tail_fade_guard:
+      enabled: true             # 後半崩れ対策として末尾に短い fade-out guard を入れる
+      fade_sec: 3
+
+  # rain_layers:
 #     enabled: false              # opt-in (true にしないと uv run yt-apply-rain-layers は何もしない)
 #     volume_db: -19              # 各レイヤーに当てる減衰 dB (10^(-19/20) ≈ 0.112)
 #     output_name: master-rain.wav # 出力ファイル名 (01-master/ 配下)
 #     output_codec: pcm_s16le      # 出力 ffmpeg コーデック (PCM 16-bit)
-#     output_sample_rate: 44100    # 出力サンプリングレート (Hz) / stereo 固定
+  #   output_sample_rate: 44100    # 出力サンプリングレート (Hz) / stereo 固定

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(masterup)`: Suno 個別音源 cleanup を既定 ON にし、曲ごとの `-14 LUFS` 正規化と明示 opt-out を標準化（#2445）。
 - `feat(skills)`: ペルソナと視聴シーンを、音・映像・サムネ・タイトル・測定の機械検証可能な制約へ翻訳する `/creative-constraints` を追加（#2442）。
 - `feat(skills)`: シーン定義・制約翻訳・公開前ゲート・指標還流の価値ループを読み取り専用で診断する `/value-loop-audit` を追加（#2443）。
 - `refactor(domains)`: Analytics、thumbnail、media、DistroKid、weekly vote の domain 公開面を追加し、consumer の旧 owner 参照を domain 境界へ接続（#2306）。

--- a/tests/test_skill_config.py
+++ b/tests/test_skill_config.py
@@ -287,6 +287,35 @@ def test_load_skill_config_masterup_json_override_wins_over_yaml(tmp_path, monke
     assert cfg.get("audio", {}).get("bitrate") == "256k"
 
 
+def test_load_skill_config_masterup_enables_suno_cleanup_by_default(tmp_path, monkeypatch):
+    """masterup の同梱既定で Suno 個別音源 cleanup が有効になること."""
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+
+    assert cfg["post_processing"]["suno_audio_cleanup"]["enabled"] is True
+    assert cfg["post_processing"]["suno_audio_cleanup"]["loudnorm"]["I"] == -14
+
+
+def test_load_skill_config_masterup_allows_suno_cleanup_opt_out(tmp_path, monkeypatch):
+    """channel JSON override で Suno 個別音源 cleanup を無効化できること."""
+    channel_dir = tmp_path / "ch"
+    skills_dir = channel_dir / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "masterup.json").write_text(
+        json.dumps({"post_processing": {"suno_audio_cleanup": {"enabled": False}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    cfg = skill_config.load_skill_config("masterup", use_cache=False)
+
+    assert cfg["post_processing"]["suno_audio_cleanup"]["enabled"] is False
+    assert cfg["post_processing"]["suno_audio_cleanup"]["loudnorm"]["I"] == -14
+
+
 def test_load_skill_config_non_masterup_json_is_ignored(tmp_path, monkeypatch):
     """masterup 以外は既存 YAML override 契約のままにする."""
     channel_dir = tmp_path / "ch"


### PR DESCRIPTION
## Summary

- `post_processing.suno_audio_cleanup` を同梱既定 ON に変更
- per-track の無音除去・EQ・平滑化・limiter・`-14 LUFS` loudnorm・末尾fade guardを明示設定
- channel側 `masterup.json` / 互換YAMLで `enabled: false` にできるopt-out手順と回帰テストを追加

## Official reference

- FFmpeg `loudnorm` filter: https://www.ffmpeg.org/ffmpeg-filters.html#loudnorm

## Verification

- `uv run pytest -q tests/test_skill_config.py tests/test_suno_audio_cleanup.py` — 62 passed
- `uv run yt-skills lint masterup`
- `git diff --check main...HEAD`

Closes #2445