### PR TITLE
feat(loop-video): 注意誘引要素の既定ガードを追加 (#2446)

### DIFF
--- a/.claude/skills/loop-video/config.default.yaml
+++ b/.claude/skills/loop-video/config.default.yaml
@@ -36,6 +36,9 @@ veo:
     Static scene with only natural subtle movements: gentle flickering of candle flames,
     slight sway of character breathing, soft light shifts on surfaces.
     No smoke, no magical effects, no particles, no falling objects.
+    Lighting and contrast remain steady and gradual across the full frame.
+    The composition stays free of full-frame flashes, strobing, sudden brightness changes,
+    and close-up human faces; local candle-flame movement stays confined to each flame.
     Keep the scene calm and grounded, like a living painting.
 
   # 構造化プロンプト (issue #358)。
@@ -66,6 +69,9 @@ veo:
   base_rules: |
     Preserve the original lighting, color palette, depth, and framing.
     No new objects, no new creatures, no smoke or magical particles appear; the world is closed and stable.
+    Lighting and contrast remain steady and gradual across the full frame.
+    The composition stays free of full-frame flashes, strobing, sudden brightness changes,
+    and close-up human faces; local candle-flame movement stays confined to each flame.
 
   # 生成尺（Veo API 制約で現状 8 秒固定）
   duration_seconds: 8
@@ -86,6 +92,9 @@ omni:
     Static scene with only natural subtle movements: gentle flickering of candle flames,
     slight sway of character breathing, soft light shifts on surfaces.
     No smoke, no magical effects, no particles, no falling objects.
+    Lighting and contrast remain steady and gradual across the full frame.
+    The composition stays free of full-frame flashes, strobing, sudden brightness changes,
+    and close-up human faces; local candle-flame movement stays confined to each flame.
     Keep the scene calm and grounded, like a living painting.
 
 # Veo 出力直後に libx264 で再エンコードして容量削減（Issue #175）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(masterup)`: Suno 個別音源 cleanup を既定 ON にし、曲ごとの `-14 LUFS` 正規化と明示 opt-out を標準化（#2445）。
+- `feat(loop-video)`: Veo / Omni の既定プロンプトへ全画面の明滅・ストロボ・急な輝度変化・顔アップを避ける注意誘引ガードを追加（#2446）。
 - `feat(skills)`: ペルソナと視聴シーンを、音・映像・サムネ・タイトル・測定の機械検証可能な制約へ翻訳する `/creative-constraints` を追加（#2442）。
 - `feat(skills)`: シーン定義・制約翻訳・公開前ゲート・指標還流の価値ループを読み取り専用で診断する `/value-loop-audit` を追加（#2443）。
 - `refactor(domains)`: Analytics、thumbnail、media、DistroKid、weekly vote の domain 公開面を追加し、consumer の旧 owner 参照を domain 境界へ接続（#2306）。

--- a/tests/test_generate_loop_video_cli.py
+++ b/tests/test_generate_loop_video_cli.py
@@ -463,6 +463,38 @@ class TestMotionIntensityControlledByTargets:
 
         assert "subtle steam rising from coffee" in result
 
+
+class TestAttentionGuardDefaults:
+    """Veo / Omni の既定 prompt が注意誘引要素を避けること."""
+
+    @pytest.mark.parametrize("field", ("default_prompt", "base_rules"))
+    def test_veo_prompt_guards_attention_grabbing_elements(self, field):
+        value = _default_veo_config()[field]
+
+        for forbidden_visual in (
+            "full-frame flashes",
+            "strobing",
+            "sudden brightness changes",
+            "close-up human faces",
+        ):
+            assert forbidden_visual in value
+        assert "local candle-flame movement stays confined to each flame" in value
+
+    def test_omni_prompt_has_same_attention_guards(self):
+        import yaml
+
+        with _LOOP_VIDEO_DEFAULT_CONFIG.open(encoding="utf-8") as file:
+            prompt = yaml.safe_load(file)["omni"]["default_prompt"]
+
+        for forbidden_visual in (
+            "full-frame flashes",
+            "strobing",
+            "sudden brightness changes",
+            "close-up human faces",
+        ):
+            assert forbidden_visual in prompt
+        assert "local candle-flame movement stays confined to each flame" in prompt
+
     def test_channel_prompt_template_override_still_applied(self):
         # 要件 3: チャンネル側 prompt_template 上書きは引き続き有効
         # （チャンネル判断で強度文言を template に戻すことも可能）


### PR DESCRIPTION
## Summary

- Veo structured / fallback と Omni の既定promptに全画面flash・strobe・急な輝度変化・顔アップのガードを追加
- ローカルなろうそくの揺らぎは許容し、強いmotion targetを弱めない表現へ分離
- Veo / Omni両方の既定configを回帰テストで固定

## Official reference

- Google Cloud Veo prompt guide: https://cloud.google.com/vertex-ai/generative-ai/docs/video/video-gen-prompt-guide
- 公式推奨に従い、negative項目は `no` / `don’t` の命令形ではなく除外対象の記述で追加

## Verification

- `uv run pytest -q tests/test_generate_loop_video_cli.py` — 65 passed
- `uv run yt-skills lint loop-video`
- `git diff --check main...HEAD`

Closes #2446