### PR TITLE
docs(workflow): takt routingを廃止 (#2453)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 **プロジェクト概要・アーキテクチャ・開発規約（設定アクセス / エラーハンドリング / Import / 依存ポリシー / スクリプト配置 / テスト / パッケージング / セキュリティ / CHANGELOG ゲート / 開発ワークフロー）は `CLAUDE.md` に一元化している。実装・レビューに着手する前に必ず `CLAUDE.md` を読むこと。**
 
-詳細ドキュメント: `docs/architecture.md`（モジュール構成）/ `docs/development.md`（パッケージング・extensions・lefthook）/ `docs/takt-operations.md`（takt 運用）。
+詳細ドキュメント: `docs/architecture.md`（モジュール構成）/ `docs/development.md`（パッケージング・extensions・lefthook）/ `docs/takt-operations.md`（issue / worktree 運用。takt は使用しない）。
 
 ## Codex CLI 固有の注意
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `feat(flop-analysis)`: postmortem の一般化可能な学びを、出典付きの禁止制約案として明示承認後に `creative-constraints.md` へ還流する最終工程を追加（#2451）。
 - `feat(masterup)`: 全曲の integrated LUFS 最大差を既定 2.0 LU で検証し、逸脱時は明示承認までマスター結合を停止するゲートを追加（#2450）。
+- `docs(workflow)`: takt workflow routing を廃止し、GitHub issue + `/issue-direct` + linked worktree を正規開発経路として文書化（#2453）。
 - `feat(masterup)`: Suno 個別音源 cleanup を既定 ON にし、曲ごとの `-14 LUFS` 正規化と明示 opt-out を標準化（#2445）。
 - `feat(loop-video)`: Veo / Omni の既定プロンプトへ全画面の明滅・ストロボ・急な輝度変化・顔アップを避ける注意誘引ガードを追加（#2446）。
 - `feat(suno)`: 既定 Exclude Styles に sudden drops・risers・drum fills・hard transitions・dramatic buildups を追加（#2447）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-詳細ドキュメント: アーキテクチャ全容・主要モジュール表は `docs/architecture.md`、パッケージング / extensions / lefthook 詳細は `docs/development.md`、takt 運用詳細は `docs/takt-operations.md`。
+詳細ドキュメント: アーキテクチャ全容・主要モジュール表は `docs/architecture.md`、パッケージング / extensions / lefthook 詳細は `docs/development.md`、issue / worktree 運用は `docs/takt-operations.md`。
 
 本リポジトリの開発者 bootstrap は `docs/development.md#開発者-bootstrap正規入口` を単一ソースとする。親 checkout / linked worktree の各 checkout で最初に `bash .lefthook/setup-worktree.sh` を実行し、非対話 shell は同 wrapper に command を渡す。
 
@@ -101,10 +101,10 @@ TS 版（tayk）の開発は専用の別リポジトリで行う（`docs/adr/002
 
 ## 開発ワークフロー
 
-このリポジトリの開発は **必ず worktree 上で行う**（メインの作業ツリーで直接ブランチを切らない）。標準ルートは **takt + GitHub issue**。worktree 置き場・takt 設定の継承・skill 編集と takt の関係・Codex 読み替えの詳細は `docs/takt-operations.md`。
+このリポジトリの開発は **必ず issue 専用 linked worktree 上で行う**（メインの作業ツリーで直接ブランチを切らない）。標準ルートは **GitHub issue + `/issue-direct`**。worktree の作成・検証・PR 運用は `docs/takt-operations.md`。
 
 - **issue 起票**: `gh issue create` または `/issue` スキル
-- **takt 起動**: `takt add '#<N>'` → `takt run`（base branch は **main** 固定、PR は通常 PR）
-- **workflow 使い分け**: issue の `takt:*` ラベルと同名の workflow で実行する（ラベル = workflow 名）。`takt:feature`（新規 feature・セキュリティ/認証・公開インターフェース/スキーマ変更。テスト先行の厳格 7 step）/ `takt:improve`（既存機能の意図的な挙動変更・拡張、interface 変更なし）/ `takt:diagnose-fix`（原因不明バグの診断 → 条件付き自動修正）/ `takt:fix`（原因特定済みの軽量修正）/ `takt:docs`（ドキュメント・skill のみの変更）/ `takt:lite`（refactor / chore 等の軽量タスク。迷ったらこれ）。`takt:manual` は takt を使わず `/issue-direct` や手動で直接実装する。判定基準と対応表は `docs/takt-operations.md`
+- **issue 着手**: `/issue-direct <N>`、または main から同等の issue 専用 linked worktree を作成する（base branch は **main** 固定、PR は通常 PR）
+- **takt**: 使用しない。既存の `takt:*` ラベルは履歴メタデータとしてのみ扱い、新規 issue へ付与しない
 - **commit 規約**: 日本語 Conventional Commits + タイトル末尾に `(#<N>)`
 - **リリース**: `/automation-release` スキル（post-release は `/release-notes`）

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ bash .lefthook/setup-worktree.sh
 - **非対話 shell / agent**: `bash .lefthook/setup-worktree.sh <command> [args...]` を正規入口とする。例: `bash .lefthook/setup-worktree.sh uv run pytest tests/test_doctor.py -q`。依存同期に失敗した場合は command を起動せず fail-closed で停止する
 - **直接 devShell を使う場合**: direnv の自動入室後は `uv run ...` を直接実行できる。`nix develop` は wrapper の fallback / 診断手段であり、初回 bootstrap の同格入口ではない
 
-worktree の生成・命名・issue / PR 運用は [`docs/takt-operations.md`](takt-operations.md) を参照する。
+worktree の生成・命名・issue / PR 運用は [`docs/takt-operations.md`](takt-operations.md) を参照する。ファイル名は互換性のため残しているが、takt 自体は使用しない。
 
 ## プロジェクト固有コマンド（全量）
 
@@ -103,13 +103,10 @@ component 追加前は対象 workspace で `shadcn info` と registry/公式 doc
 
 `.claude/skills/` 配下の skill を編集してから下流チャンネルリポジトリへ届くまでの一連手順（issue #2098）。
 
-### 1. 編集（経路が takt provider 設定で分岐する）
+### 1. 編集
 
 - 実体は常に `.claude/skills/<name>/` を編集する（`.agents/skills` は Codex CLI 探索パス用の symlink）。付属スクリプトは `.claude/skills/<name>/references/` に置く（ルート直下 `scripts/` は設けない）
-- `.claude/skills/**` は Claude Code の **protected paths** のため、編集経路は takt の provider 設定で分岐する:
-  - `coder` persona が **codex provider**（現行のグローバル設定から継承）→ takt から問題なく回せる
-  - `coder` を **Claude provider** に戻している環境 → takt からの Edit/Write が deny される。通常の Claude Code 対話セッションで直接編集し、commit / PR は手動で行う
-  - 詳細は `docs/takt-operations.md` の「skill 編集と takt の関係」。**設定を確認せず takt に投げると deny で初めて気づく**ので、skill を触る issue を takt に載せる前に provider 設定を確認すること
+- skill も通常コードと同じ issue 専用 linked worktree で編集する。利用中の agent が `.claude/skills/**` を protected path として扱い書き込みを拒否する場合は、権限を迂回せず Codex または許可済みの対話セッションへ同じ issue worktree を引き継ぐ
 - 書き方の規約: frontmatter `description:` は必ず double-quoted string、新規作成・改訂時は `docs/skill-design/skill-authoring-guidelines.md` の 7 ルールに従う
 
 ### 2. 検証（編集後に実行するもの）
@@ -213,9 +210,9 @@ Python 側の未使用コード検出は、追加依存なしで CI / pre-commit
 - **worktree 間の依存境界**: 共有するのは uv cache と pnpm content-addressable store だけとし、`.venv` / `node_modules` は各 worktree で生成する。親 checkout や sibling worktree の環境を symlink・コピーせず、branch ごとの lockfile、editable path、entry point を実行中 checkout と一致させる
 - **診断**: 親 checkout / worktree のそれぞれで `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'` を実行する。`git commit` / `git push` で `Can't find lefthook in PATH` が出る場合は `bash .lefthook/setup-worktree.sh` を再実行する。直接の Nix 診断・再生成には `nix develop --command sh -c 'command -v lefthook && lefthook version'` と `nix develop --command bash .lefthook/install.sh` も利用できる
 - **失敗時の扱い**: shellHook は `lefthook` 不在や hook 再生成失敗を `|| true` で握りつぶさない。devShell 入室時に明示的に失敗させ、commit / push 時の hook no-op を防ぐ
-- **TMPDIR の worktree 分離**: macOS の TMPDIR は per-user のグローバル値のため、複数 worktree の並列実行（takt の `concurrency > 1` / 手動 worktree の並行 pytest）が同一パスへ書くと一時ディレクトリが run 間で干渉しうる（issue #2088）。shellHook は `.lefthook/worktree-tmpdir.sh` の出力を `TMPDIR` へ export し、共有 TMPDIR 配下の worktree ごとの決定的なサブディレクトリ（`yt-automation-tmp-<slug>-<cksum>`）へ分離する。takt worker のように TMPDIR が既に checkout 内へ隔離済みの場合はその値を尊重し、解決に失敗した場合は共有 TMPDIR のまま fail-open で続行する
+- **TMPDIR の worktree 分離**: macOS の TMPDIR は per-user のグローバル値のため、複数 worktree の並行 pytest が同一パスへ書くと一時ディレクトリが run 間で干渉しうる（issue #2088）。shellHook は `.lefthook/worktree-tmpdir.sh` の出力を `TMPDIR` へ export し、共有 TMPDIR 配下の worktree ごとの決定的なサブディレクトリ（`yt-automation-tmp-<slug>-<cksum>`）へ分離する。TMPDIR が既に checkout 内へ隔離済みの場合はその値を尊重し、解決に失敗した場合は共有 TMPDIR のまま fail-open で続行する
 - **Nix キャッシュの worktree 分離**: 並列 worktree が同一 fingerprint の flake を同時評価すると、ユーザーグローバルの Nix キャッシュ（既定 `~/.cache/nix` の eval-cache / fetcher-cache SQLite）への同時書込みが競合し、「error (ignored): SQLite database ... is busy」を stderr へ出しつつキャッシュ書込みを破棄し続ける（issue #2089）。`.envrc` / `.lefthook/setup-worktree.sh` / shellHook は Nix 専用の `NIX_CACHE_HOME` を worktree 分離 TMPDIR 配下（`<worktree_tmpdir>/nix-cache`）へ export し、各 worktree が自分の評価結果だけを参照する。`XDG_CACHE_HOME` には触れないため uv 等の他ツールのキャッシュは共有のまま変わらない。継承値は別 worktree の値がシェル経由でリークし得るため尊重せず、解決に失敗した場合は共有キャッシュのまま fail-open で続行する
-- **sandbox / takt worker での挙動**: repo-local takt config / workflow は持たず、taktを使う場合のprovider・workflow・runtime routingはグローバル `~/.takt/` を正とする。sandbox worker向けの `.takt/runtime-prepare.sh` は、グローバル側から明示的に呼ばれた場合に `XDG_DATA_HOME=<worktree>/.takt/.runtime/data` と `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を注入する補助scriptとして残す。後者が設定された環境ではshellHook / `.lefthook/install.sh` がinstallを明示メッセージつきでskipする。また `.lefthook/setup-worktree.sh` は `direnv allow` 失敗時にhard failせず `nix develop` 経路へfallbackする
+- **sandbox worker での挙動**: 旧 `.takt/runtime-prepare.sh` は過去 runtime との互換用として残すが、現在の正規入口ではない。外部 sandbox が `YOUTUBE_AUTOMATION_SKIP_LEFTHOOK=1` を明示した場合、shellHook / `.lefthook/install.sh` は install を明示メッセージ付きで skip する。また `.lefthook/setup-worktree.sh` は `direnv allow` 失敗時に hard fail せず `nix develop` 経路へ fallback する
 - **全 hook をスキップ**: `LEFTHOOK=0 git push` / `LEFTHOOK=0 git commit`
 - **CHANGELOG ゲートのみ省く**: `SKIP_CHANGELOG=1 git push`（CI 側は PR の `skip-changelog` ラベル）
 - **テスト差分警告のみ省く**: `SKIP_TEST_DIFF=1 git push`

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -1,123 +1,50 @@
-# takt 運用詳細
+# Issue / worktree 運用（takt 廃止後）
 
-CLAUDE.md の「開発ワークフロー」節の詳細版。要点は CLAUDE.md を参照。
+> 2026-07-23 以降、このリポジトリでは takt を実装経路に使わない。このファイル名は既存リンクとの互換性のため維持する。
 
-## workflow の使い分け（ラベル = workflow 名）
+## 正規ルート
 
-issue には実行ルートを示す `takt:*` ラベルを **1 つ** 付与し、着手時はラベルと同名の workflow で実行する（`takt add '#<N>' -w <名前>`）。判定基準の単一ソースはグローバル `/issue` スキルの workflow 判断表（`~/.claude/skills/issue/SKILL.md`）で、本表はその要約。
+1. `gh issue create` または `/issue` で issue を起票する。
+2. `/issue-direct <issue番号>`、または同等の手動手順で `main` から issue 専用 linked worktree を作る。
+3. worktree 内で実装・検証・commit・push を行い、通常 PR を作成する。
+4. required CI が成功し、review 指摘と競合がないことを確認して merge する。
 
-| ラベル | workflow（step 構成） | 対象 |
-|---|---|---|
-| `takt:feature` | `feature`（plan → test_design → test_design_review → write_tests(red 実証) → implement → review → scope_review） | 新規 feature（既存挙動を触らない）。セキュリティ・認証（OAuth / secrets）系、公開インターフェース・スキーマ変更を伴う変更もこちら |
-| `takt:improve` | `improve`（plan → implement → review。挙動変更影響表で意図した変更と回帰を区別） | 既存機能の意図的な挙動変更・拡張（interface 変更なし） |
-| `takt:diagnose-fix` | `diagnose-fix`（diagnose → fix → supervise。fix 条件未達は診断レポートを残して停止） | 原因不明のバグ（再現手順・原因が issue 本文に無い） |
-| `takt:fix` | `fix`（fix → supervise の軽量 2 step。plan・テスト先行なし） | 原因特定済みの小さなバグ修正・軽微な指摘対応 |
-| `takt:docs` | `docs`（implement → review の最軽量 2 step） | ドキュメント・skill のみの変更（コード変更なし） |
-| `takt:lite` | `lite`（plan → implement → review） | refactor / chore、既存テストで挙動確認できる軽量タスク。**迷ったらこれ（トークン節約優先）** |
-| `takt:manual` | なし | takt 不要。1 行修正・誤字・設定値 1 箇所変更などの極小タスク（`/issue-direct` や手動で直接実装）、または人間の判断・対話が主となる issue |
+`takt add`、`takt run`、workflow 名による routing は実行しない。`takt:*` ラベルが既存 issue に残っていても履歴メタデータとしてのみ扱い、workflow の選択や実装方式へ使わない。新規 issue へ `takt:*` ラベルを付けない。
 
-- workflowと設定の実体はすべてグローバル `~/.takt/` を正とする。repo-local `.takt/config.yaml` / `.takt/workflows/` / facetは持たない
-- 境界の指針:
-  - 影響範囲が未確定のときは `takt:feature` に寄せる（fail-safe）
-  - アップロードの**対象選択・公開状態を変えるロジック**の変更（例: auto-detect の対象選択条件、publish / privacy 制御、live 移行）、複数スキル・複数モジュール横断、破壊的変更は厳格側（`takt:feature`）。preflight の**検証強化・メッセージ・しきい値調整**に留まる修正は `takt:fix` / `takt:lite` で可
-  - 挙動選択に設計判断が要るもの（フォールバック方針、resume ポリシー、統計手法の整合）や後方互換設計が要るものは `takt:manual` に落とさず workflow に載せる
-- 旧体系からの読み替え: `takt:default` → `takt:feature`、`takt:none` → `takt:manual`（2026-07 に世代交代。旧ラベルは削除済みで、新規付与は新ラベルのみ）
-- 導入後に新しい takt バージョンへ上げた場合は `takt workflow doctor lite` で静的検証すること（step スキーマのキー名が変わる可能性がある）
+## linked worktree
 
-## 提出前セルフ監査（pre-review-checklist）
+親 checkout は main の同期と worktree 管理に使い、実装は行わない。作業開始時は main を fast-forward してから、issue ごとの branch と worktree を作る。
 
-グローバル `~/.takt/` のpre-review checklistは、過去のreview指摘から抽出した頻出パターンを `implement` / `review` stepへ注入する。repo内にはfacetを複製せず、更新はグローバル設定側で行う。
-
-- **implement step**: 8 項目を根拠（ファイル:行）付きで照合し、受入条件充足表を出力してから完了する
-- **review step**: 実装者の自己監査を鵜呑みにせず独立照合。8 項目 pass + issue スコープ内欠陥なしのときのみ approved。スコープ外の改善提案は follow-up 候補として記録し verdict に影響させない（moving goalposts の防止）
-- **更新手順**: レビュー REJECT の傾向が変わったら `.takt/runs/*/reports/review-summary.md` の指摘を再分類し、checklist の項目・頻出度を更新する。policy のインライン注入は 2,000 字で truncate されるため、冒頭のサマリー表に要点を収める構成を維持すること
-- 機械検出可能なパターン（lint / 未使用コード / `typing.Any` grep / テスト差分ゼロ検知）は checklist ではなく lefthook / CI ゲートに委譲する方針
-
-## トークン消費の計測（observability）
-
-利用するグローバル `~/.takt/config.yaml` で必要に応じて有効化する:
-
-```yaml
-observability:
-  enabled: true
-  usage_events_phase: true
+```bash
+git switch main
+git pull --ff-only
+git worktree add .worktrees/issue-<N>-<slug> -b issue-<N>-<slug> main
+cd .worktrees/issue-<N>-<slug>
+bash .lefthook/setup-worktree.sh
 ```
 
-- 記録先: `.takt/runs/<run>/logs/<session>-usage-events.phase.jsonl`（step × phase × provider × model 粒度）
-- **worktree 実行時の注意**: takt 自動 worktree（task の `worktree: true`）では、この `.takt/runs/` は**メインリポジトリではなく worktree 側**（`<repo-parent>/takt-worktrees/<timestamp>-<slug>/.takt/runs/`）に作られる。worktree を削除するとログも消えるため、計測を残したい run はログを先に回収すること
-- 集計: takt リポジトリ同梱の `npm run analyze:usage -- <run ディレクトリ>`（`--format csv` 可）。複数 run の横断比較は同梱の `tools/token-usage.sh <takt-worktrees のパス>` が run × step 粒度で整形表示してくれる
-- codex step の input tokens は agentic ループの各ターンで会話履歴全体が再送されるため累積計上され、見かけが大きくなる。実効コストは `cached_input_tokens` を差し引いた非キャッシュ input で見ること
-- 消費が異常に見えたときは、まず phase JSONL で「どの step のどの phase が食っているか」を特定してから対策する
+base branch は `main` 固定とする。別 issue の未マージ branch を base にしない。依存 issue がある場合は依存 PR の merge 後に main を更新し、rebase してから検証する。
 
-## worktree の置き場
+## commit / push / PR
 
-このリポジトリの開発は必ず worktree 上で行う（メインの作業ツリーで直接ブランチを切らない）。
+- commit: 日本語 Conventional Commits を使い、タイトル末尾に `(#<N>)` を付ける
+- push: issue branch だけを push する
+- PR: `Closes #<N>`、変更概要、検証コマンド、参照した公式資料を本文へ記載する
+- merge: required CI 成功後に行う。チェックの削除・弱体化で green にしない
 
-- **takt 自動生成**: `<repo-parent>/takt-worktrees/<timestamp>-<N>-<slug>/`（takt が自動管理）
-- **手動 `git worktree add`**: `$REPO_ROOT/.worktrees/<slug>/`（リポジトリ内・gitignore 済み・`parallel` スキルと共通）
-- `<repo-parent>/automation-worktrees/` 等のリポジトリ外手動置き場は非推奨（過去の残骸のみ）
-- 親 checkout / worktree の初回は `bash .lefthook/setup-worktree.sh` を実行する。direnv があれば `.envrc` を allow し、なければ `nix develop` を使って、shellHook と `.lefthook/install.sh` により fail-closed hook wrapper まで再生成する。takt agent / 非対話 shell のコマンドは `bash .lefthook/setup-worktree.sh uv run pytest` のようにラッパー経由で実行する。診断は `bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'`、直接の Nix 再生成は `nix develop --command bash .lefthook/install.sh`。
-- devShell 入場時に shellHook が `.lefthook/worktree-tmpdir.sh` で `TMPDIR` を worktree ごとに分離するため、`concurrency > 1` の並列 run が共有 TMPDIR で干渉しない（issue #2088）。takt worker は takt core が注入する `<worktree>/.takt/.runtime/tmp` が優先され、そのまま尊重される。詳細は `docs/development.md` の「TMPDIR の worktree 分離」。
-- 同様に、devShell 入場（`.envrc` / `.lefthook/setup-worktree.sh`）は `NIX_CACHE_HOME` を worktree 分離 TMPDIR 配下へ export するため、並列 run のレビュー step が同一 fingerprint の flake を同時評価しても Nix の eval-cache SQLite が競合しない（issue #2089）。詳細は `docs/development.md` の「Nix キャッシュの worktree 分離」。
+## 環境と Git hooks
 
-## takt 設定の継承構造
+親 checkout と新規 worktree の両方で、最初に `bash .lefthook/setup-worktree.sh` を実行する。direnv があれば `.envrc` を allow し、なければ `nix develop` を使う。どちらも shellHook と `.lefthook/install.sh` を通して worktree ごとの hook を生成する。
 
-repo-local takt configは置かず、provider・model・language・concurrency・persona・runtime・observabilityをグローバル `~/.takt/config.yaml` から一括解決する。各workflow stepにprovider / modelの直指定がある場合はそちらが優先される。
+診断:
 
-## トークン消費の内部構造と削減指針
+```bash
+bash .lefthook/setup-worktree.sh sh -c 'command -v lefthook && lefthook version'
+nix develop --command bash .lefthook/install.sh
+```
 
-takt（v0.49 時点）の 1 step は最大 3 phase の LLM 呼び出しで構成される。workflow を書く・直すときは以下のコストモデルを前提にすること。
+commit / push で `Can't find lefthook in PATH` が出た場合は、対象 checkout で上記 setup または install を再実行する。
 
-### phase コストモデル
+## 旧 takt 状態
 
-| phase | 発生条件 | コスト特性 |
-|---|---|---|
-| Phase 1（本体実行） | 必ず 1 回 | previous_response / knowledge / policy はインライン注入 2,000 字で truncate され、全文はファイル参照に誘導される |
-| Phase 2（レポート生成） | `output_contracts` があるファイル数分 | Phase 1 のセッションを resume するため追加送信は小さい。**契約が無ければ 0 回** |
-| Phase 3（状態判定） | **自然言語 condition の rules があると起動** | **新規セッションに Phase 1 応答の全文を再送**して判定。structured → tag → ai_judge の最大 3 回。**rules が 1 個だけなら auto_select で LLM 0 回** |
-
-### rules 設計指針（判定コストの回避）
-
-1. **分岐が 1 つの step は自然言語 condition で OK**（judge は auto_select になり LLM を呼ばない）
-2. **複数分岐の step は `structured_output`（schema は `.takt/schemas/*.json`）+ deterministic `when:` 式で書く**。`when: structured.<step名>.<field> == "値"` の形式なら判定が in-code で完結し Phase 3 が丸ごとスキップされる（lite の review step が実例）。最後に `when: "true"` → ABORT の安全網を置く
-3. **`output_contracts` は本当にレポートが要る step だけに付ける**（Phase 2 の呼び出しがファイル数分増える）
-4. codex step の推論量は `provider_options.codex.reasoning_effort`（minimal / low / medium / high / xhigh）で調整できる
-
-### 制約事項（設定では変えられないもの）
-
-- Claude provider の `settingSources: ['project']` はハードコード。CLAUDE.md / `.claude/skills` の description は Claude step の全 phase で毎回注入されるため、**注入量を減らす唯一の手段はリポジトリ側ドキュメント・description を薄く保つこと**
-- 状態判定（Phase 3）だけを別モデルにする設定は無い（判定は step と同じ provider/model。唯一の例外は `loop_monitors[].judge` の provider/model 指定）
-- 厳格系 workflow（`feature` 等、レポート契約 + 自然言語 rules を持つ step が多いもの）は Phase 2 / Phase 3 のコストが構造的に乗る。大型 issue で `feature` を選ぶのは品質優先の判断として妥当
-
-### session resume と worktree
-
-takt の自動 worktree（task の `worktree: true`）では **step 間のセッション resume が無効化される**（実行 cwd がプロジェクト cwd と異なるため。ディレクトリ間汚染の防止ガード）。この場合、同一 persona の step 再訪（review⇄implement ループの implement 再訪など）でも毎回新規セッションになり、リポジトリ再探索コストがかかる。
-
-**実測結果（2026-07、#1484 の default workflow で resume OFF/ON を A/B 比較）: review⇄fix ループを持つ workflow では resume 有効化は逆効果**。非キャッシュ input が OFF ≈ 7.2M → ON ≈ 19.3M と約 2.7 倍に増えた。原因は「resume でスレッド履歴が周回ごとに肥大する」×「プロンプトキャッシュの TTL（数分）より review⇄fix の 1 周（10〜25 分）が長い」の組み合わせで、周回のたびに失効した長履歴がほぼ丸ごと非キャッシュで再課金されるため。リポジトリ再探索の節約（〜100K/回）では相殺できない。
-
-resume が効くのは**キャッシュ TTL 内に次 step が始まる隣接 step のみ**（同実験で write_tests→implement の非キャッシュ input が 187K → 102K に減少するのを確認）。したがって:
-
-- ループを持つ workflow（default 等）は **resume 無効のまま（= takt デフォルト挙動）が安い**。このガードはコスト面では防御として機能している
-- 手動 worktree 内で `takt add` → `takt run`（task の `worktree` 指定を省略 = カレント実行）にすれば `cwd === projectCwd` となり resume は有効化できるが、検討に値するのは**ループのない短い直列 workflow だけ**。この場合 auto-commit / push / auto_pr は worktree 実行時のフローなので、commit・PR 作成は手動（CLAUDE.md「開発ワークフロー」の commit 規約 + `gh pr create`）で行うこと
-
-### 計測との突き合わせ
-
-改善の効果は usage JSONL（下記）の `phase3_*` イベントの有無と step × provider 別トークンで確認する。lite の想定は「全 step codex・`phase3_*` イベントなし・Phase 2 なし」。
-
-## skill 編集と takt の関係
-
-skill の編集 → 検証 → 配布（下流反映）の一連手順は `docs/development.md` の「skill 開発ループ」を参照。本節はそのうち「takt から編集できるか」の分岐だけを詳述する。
-
-`.claude/skills/**` を含む `.claude/` 配下は Claude Code の **protected paths**（`acceptEdits` モードでも write 時に必ず prompt が出る領域）に該当する。takt は Claude Agent SDK を `settingSources: ['project']` + `permissionMode: 'acceptEdits'` で呼ぶため prompt に答える人間がおらず、**Claude provider が走る persona から** `.claude/skills/<name>/SKILL.md` 等への Edit/Write は `Claude requested permissions to write to ..., but you haven't granted it yet.` で deny される（`permissions.allow` ルールでは bypass 不可、`bypassPermissions` のみが bypass）。
-
-ただし、**実装を担う `coder` persona を codex provider にしている（グローバル設定から継承）ため**、実装ファイルへの編集は Codex CLI 経由で行われ Claude Code の protected paths 制約を回避できる（Codex は独自のサンドボックスで動作し、`$REPO_ROOT/.agents/skills` を探索パスに含む）。レビュー系 persona は opus（Claude）だが書き込みは行わないため影響しない。そのため、**skill 配下を変更する issue も takt から問題なく回せる**。実際の運用例として、`.claude/skills/videoup/references/generate_videos.sh` 等の skill 配下スクリプト修正も takt 経由で完走実績がある。
-
-逆に `coder` を Claude provider に戻している環境では、従来通り skill 配下の Edit が deny される。その場合は通常の Claude Code 対話セッション（cmux pane 等）で直接編集し、コミット・PR 作成は CLAUDE.md「開発ワークフロー」の規約に従い手動で実施する。
-
-## Codex 共用時の skill 表記読み替え
-
-`.claude/skills/**` は Claude Code / Codex CLI 共用だが、既存 SKILL.md には Claude Code 固有表現が残る。Codex で実行するときは、`AskUserQuestion` は通常のユーザー確認、`Read ツール` は画像/ファイル閲覧手段、`Bash ツール run_in_background=true` は長時間コマンドを非同期 session で起動して進捗を poll、`TodoWrite` は Codex の plan/checklist 更新として読み替える。これらの表記が残っていても実装不整合とは扱わず、同等の Codex 機能で実行する。
-
-## リリース
-
-`/automation-release` スキルで Release PR パターンを自動化（prepare → リリース PR → publish の 2 フェーズ）。post-release の運営者向けガイドと下流追従 issue は `/release-notes` が担当。
+`.takt/` 配下の runtime 補助、過去 run、task 履歴は過去実績の参照用であり、現在の正規入口ではない。古い failed / pending task や `takt-worktrees/` の残骸を新しい作業へ再利用しない。不要な runtime 状態を掃除する場合は対象を明示して確認し、通常の issue worktree や未マージ変更を巻き込まない。

--- a/tests/test_lefthook_installation_contract.py
+++ b/tests/test_lefthook_installation_contract.py
@@ -1374,3 +1374,18 @@ def test_docs_cover_parent_worktree_diagnostics_and_reinstall() -> None:
     assert "nix develop --command lefthook install --force" not in development
     assert "nix develop --command lefthook install --force" not in takt_operations
     assert "nix develop --command lefthook install --force" not in agents
+
+
+def test_development_docs_use_issue_direct_instead_of_takt_routing() -> None:
+    """Issue #2453: 解決不能な takt workflow 名を正規入口として案内しない。"""
+    takt_operations = _read(_TAKT_OPERATIONS_DOC_PATH)
+    claude = _read(_CLAUDE_PATH)
+    agents = _read(_AGENTS_PATH)
+
+    assert "GitHub issue + `/issue-direct`" in claude
+    assert "`/issue-direct <issue番号>`" in takt_operations
+    assert "takt を実装経路に使わない" in takt_operations
+    assert "新規 issue へ `takt:*` ラベルを付けない" in takt_operations
+    assert "takt は使用しない" in agents
+    assert "標準ルートは **takt + GitHub issue**" not in claude
+    assert "ラベル = workflow 名" not in takt_operations

--- a/tests/test_lifecycle_skills_no_tayk.py
+++ b/tests/test_lifecycle_skills_no_tayk.py
@@ -39,6 +39,18 @@ _LIFECYCLE_SKILL_NAMES: Final[tuple[str, ...]] = (
 # tayk cutover までは、lifecycle skill の実行手順に tayk 表記
 # （`bunx tayk <cmd>` / argv 配列の "tayk" など）を混入させない。
 _FORBIDDEN_COMMAND_FRAGMENTS: Final[tuple[str, ...]] = ("tayk",)
+_TEXT_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {
+        ".json",
+        ".md",
+        ".py",
+        ".sh",
+        ".toml",
+        ".txt",
+        ".yaml",
+        ".yml",
+    }
+)
 
 
 def _lifecycle_skill_dir(skill_name: str) -> Path:
@@ -46,7 +58,7 @@ def _lifecycle_skill_dir(skill_name: str) -> Path:
 
 
 def _text_files_under(skill_dir: Path) -> list[Path]:
-    return sorted(path for path in skill_dir.rglob("*") if path.is_file())
+    return sorted(path for path in skill_dir.rglob("*") if path.is_file() and path.suffix.lower() in _TEXT_SUFFIXES)
 
 
 def _offending_locations(skill_dir: Path, forbidden_fragment: str) -> list[str]:


### PR DESCRIPTION
## 概要

解決不能な takt workflow 名を正規開発経路から撤去し、GitHub issue + `/issue-direct` + issue 専用 linked worktree を単一の入口として文書化します。`docs/takt-operations.md` のファイル名は既存リンク互換のため維持し、旧 `.takt/` 状態は履歴参照専用と明示します。

Closes #2453

## 検証

- `uv run pytest -q tests/test_lefthook_installation_contract.py`（60 passed）
- `uv run ruff check tests/test_lefthook_installation_contract.py`
- `uv run ruff format --check tests/test_lefthook_installation_contract.py`
- `git diff --check`
- `.takt/tasks.yaml` と `takt-worktrees/` に #2442 の failed/pending 残骸がないことを確認