### PR TITLE
fix(workspace): 内部 symlink を安全に実体化して import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(thumbnail)`: `textless.enabled: false` の opt-in で追加の textless 生成・承認を省略し、確定済み `thumbnail.jpg` を同一内容の `main.jpg` として検証付きで共用（#2457）。
+- `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `feat(flop-analysis)`: postmortem の一般化可能な学びを、出典付きの禁止制約案として明示承認後に `creative-constraints.md` へ還流する最終工程を追加（#2451）。
 - `feat(masterup)`: 全曲の integrated LUFS 最大差を既定 2.0 LU で検証し、逸脱時は明示承認までマスター結合を停止するゲートを追加（#2450）。
 - `feat(masterup)`: Suno 個別音源 cleanup を既定 ON にし、曲ごとの `-14 LUFS` 正規化と明示 opt-out を標準化（#2445）。

--- a/docs/channel-workspace-migration.md
+++ b/docs/channel-workspace-migration.md
@@ -30,7 +30,13 @@ CLI は次の channel 固有 path だけをコピーします。
 - `config/`, `auth/`, `data/`, `collections/`, `assets/`, `branding/`, `research/`
 - `docs/channel/`, `docs/benchmarks/`
 
-`.claude/` や共通 docs はコピーしません。symlink、既存の同名 target、必須 config 欠落、`config/channel/*.json` の load 失敗を検出すると target を残さず停止します。
+`.claude/` や共通 docs はコピーしません。既存の同名 target、必須 config 欠落、`config/channel/*.json` の load 失敗を検出すると target を残さず停止します。
+
+### symlink の扱い
+
+移行元 repository 内かつ上記コピー対象 path 内の通常ファイルを指す symlink だけを許可し、リンクではなく解決先の内容を通常ファイルとしてコピーします。`data/thumbnail_compare/<slug>/*.jpg` が同じ repository の `collections/live/.../10-assets/thumbnail.jpg` を指す構成はこの経路で移行でき、移行先に絶対 path の symlink は残りません。
+
+repository 外、コピー対象外、存在しない解決先、directory、循環 link を指す symlink は validation error として import 全体を rollback します。移行前に安全な内部 link を手動で実体化する必要はありません。
 
 成功時は config load の結果と `auth/client_secrets.json` / `auth/token*.json` のコピー先を表示します。auth が `missing` の場合は、旧 repository の正しい channel 用ファイルを確認してから配置してください。OAuth client の統合や再認証はこの移行では行いません。
 

--- a/src/youtube_automation/cli/channel_import.py
+++ b/src/youtube_automation/cli/channel_import.py
@@ -114,18 +114,48 @@ def _warn_source_residue(source: Path) -> None:
             )
 
 
-def _reject_symlinks(path: Path) -> None:
+def _validated_symlink_target(path: Path, *, source: Path, selected_roots: tuple[Path, ...]) -> Path:
+    """Return a safe regular-file target contained by the selected source tree."""
+    try:
+        target = path.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise ValueError(f"壊れた、または循環する symlink はコピーできません: {path}") from error
+    if not target.is_relative_to(source):
+        raise ValueError(f"移行元 repository 外を指す symlink はコピーできません: {path} -> {target}")
+    if not any(target.is_relative_to(root) for root in selected_roots):
+        raise ValueError(f"コピー対象外を指す symlink はコピーできません: {path} -> {target}")
+    if not target.is_file():
+        raise ValueError(f"通常ファイル以外を指す symlink はコピーできません: {path} -> {target}")
+    return target
+
+
+def _validate_symlinks(path: Path, *, source: Path, selected_roots: tuple[Path, ...]) -> None:
     if path.is_symlink():
-        raise ValueError(f"symlink はコピーできません: {path}")
+        _validated_symlink_target(path, source=source, selected_roots=selected_roots)
+        return
     if not path.is_dir():
         return
     for candidate in path.rglob("*"):
         if candidate.is_symlink():
-            raise ValueError(f"symlink はコピーできません: {candidate}")
+            _validated_symlink_target(candidate, source=source, selected_roots=selected_roots)
+
+
+def _copy_validated_file(source: Path, destination: Path, *, repository: Path, selected_roots: tuple[Path, ...]) -> str:
+    copy_source = (
+        _validated_symlink_target(source, source=repository, selected_roots=selected_roots)
+        if source.is_symlink()
+        else source
+    )
+    return shutil.copy2(copy_source, destination)
 
 
 def _copy_per_channel_paths(source: Path, temporary: Path) -> list[str]:
     copied: list[str] = []
+    selected_roots = tuple(
+        origin.resolve(strict=True)
+        for relative in PER_CHANNEL_PATHS
+        if (origin := source / relative).exists() and not origin.is_symlink()
+    )
     for relative in PER_CHANNEL_PATHS:
         origin = source / relative
         if not origin.exists():
@@ -135,11 +165,20 @@ def _copy_per_channel_paths(source: Path, temporary: Path) -> list[str]:
             current /= part
             if current.is_symlink():
                 raise ValueError(f"symlink はコピーできません: {current}")
-        _reject_symlinks(origin)
+        _validate_symlinks(origin, source=source, selected_roots=selected_roots)
         destination = temporary / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         if origin.is_dir():
-            shutil.copytree(origin, destination)
+            shutil.copytree(
+                origin,
+                destination,
+                copy_function=lambda source_path, destination_path: _copy_validated_file(
+                    Path(source_path),
+                    Path(destination_path),
+                    repository=source,
+                    selected_roots=selected_roots,
+                ),
+            )
         elif origin.is_file():
             shutil.copy2(origin, destination)
         else:

--- a/tests/test_channel_import.py
+++ b/tests/test_channel_import.py
@@ -222,6 +222,71 @@ def test_symlink_in_copy_tree_is_rejected_and_rolled_back(tmp_path, monkeypatch,
     assert "symlink" in capsys.readouterr().err
 
 
+def test_internal_selected_file_symlink_is_materialized(tmp_path, monkeypatch):
+    source = _write_source(tmp_path)
+    thumbnail = source / "collections" / "live" / "demo" / "10-assets" / "thumbnail.jpg"
+    thumbnail.parent.mkdir(parents=True)
+    thumbnail.write_bytes(b"approved-thumbnail")
+    comparison = source / "data" / "thumbnail_compare" / "ambient-island" / "demo.jpg"
+    comparison.parent.mkdir(parents=True)
+    comparison.symlink_to(thumbnail)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert channel_import.main([str(source), "--slug", "ambient-island"]) == channel_import.EXIT_OK
+
+    copied = workspace / "channels" / "ambient-island" / "data" / "thumbnail_compare" / "ambient-island" / "demo.jpg"
+    assert copied.is_file()
+    assert not copied.is_symlink()
+    assert copied.read_bytes() == b"approved-thumbnail"
+
+
+def test_internal_symlink_to_unselected_path_is_rejected(tmp_path, monkeypatch, capsys):
+    source = _write_source(tmp_path)
+    unselected = source / "README-private.md"
+    unselected.write_text("not selected", encoding="utf-8")
+    (source / "data" / "linked.md").symlink_to(unselected)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert channel_import.main([str(source), "--slug", "ambient-island"]) == channel_import.EXIT_VALIDATION
+    assert "コピー対象外" in capsys.readouterr().err
+    assert not (workspace / "channels" / "ambient-island").exists()
+
+
+def test_broken_and_directory_symlinks_are_rejected(tmp_path, monkeypatch, capsys):
+    source = _write_source(tmp_path)
+    (source / "data" / "broken.jpg").symlink_to(source / "collections" / "missing.jpg")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert channel_import.main([str(source), "--slug", "ambient-island"]) == channel_import.EXIT_VALIDATION
+    assert "壊れた、または循環する symlink" in capsys.readouterr().err
+
+    (source / "data" / "broken.jpg").unlink()
+    (source / "data" / "linked-dir").symlink_to(source / "collections", target_is_directory=True)
+    assert channel_import.main([str(source), "--slug", "ambient-island"]) == channel_import.EXIT_VALIDATION
+    assert "通常ファイル以外" in capsys.readouterr().err
+
+
+def test_cyclic_symlink_is_rejected(tmp_path, monkeypatch, capsys):
+    source = _write_source(tmp_path)
+    first = source / "data" / "first.json"
+    second = source / "data" / "second.json"
+    first.symlink_to(second)
+    second.symlink_to(first)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert channel_import.main([str(source), "--slug", "ambient-island"]) == channel_import.EXIT_VALIDATION
+    assert "壊れた、または循環する symlink" in capsys.readouterr().err
+    assert not (workspace / "channels" / "ambient-island").exists()
+
+
 def test_symlinked_parent_of_selected_path_is_rejected(tmp_path, monkeypatch, capsys):
     source = _write_source(tmp_path)
     shutil_docs = source / "docs"


### PR DESCRIPTION
Closes #2462

## 変更
- 移行元 repository 内かつ選択されたコピー対象内の通常ファイル symlink のみ許可
- 許可した link は移行先で通常ファイルとして実体化
- 外部・対象外・壊れた・directory・循環 link は import 全体を rollback
- migration guide と回帰テストを更新

## 公式ドキュメント
- Python `Path.resolve(strict=True)` / `Path.is_relative_to`: https://docs.python.org/3/library/pathlib.html
- Python `shutil.copytree` / `copy2`: https://docs.python.org/3/library/shutil.html

## 検証
- `uv run pytest -q tests/test_channel_import.py` (23 passed)
- `uv run ruff check src/youtube_automation/cli/channel_import.py tests/test_channel_import.py`
- `uv run ruff format --check src/youtube_automation/cli/channel_import.py tests/test_channel_import.py`
- `git diff --check`