### PR TITLE
fix(metadata-audit): target duration の分を秒へ正規化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `docs(workflow)`: `thumbnail::textless.enabled: false` の共有 `main.jpg` を wf-new・loop-video・videoup・wf-next が正規の文字入り動画背景として貫通させる契約を追加（#2458）。
+- `fix(metadata-audit)`: channel audio の target duration（分）を秒へ正規化してからローカル動画尺と比較し、60〜90分を1分扱いする誤検知を解消（#2468）。
 - `feat(thumbnail)`: `textless.enabled: false` の opt-in で追加の textless 生成・承認を省略し、確定済み `thumbnail.jpg` を同一内容の `main.jpg` として検証付きで共用（#2457）。
 - `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `fix(wf-auto)`: Suno の生成・playlist 追加・ZIP download・strict 検証を browser use で agent が完走し、人間への handoff を login / CAPTCHA の該当操作だけに限定（#2454）。

--- a/src/youtube_automation/scripts/metadata_audit.py
+++ b/src/youtube_automation/scripts/metadata_audit.py
@@ -163,8 +163,8 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
             else:
                 msg = check_duration(
                     dur,
-                    config.audio.target_duration_min,
-                    config.audio.target_duration_max,
+                    (config.audio.target_duration_min * 60 if config.audio.target_duration_min is not None else None),
+                    (config.audio.target_duration_max * 60 if config.audio.target_duration_max is not None else None),
                 )
                 if msg:
                     issues.append(msg)

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -44,12 +44,17 @@ def _patched_yt(response: dict) -> MagicMock:
     return yt
 
 
-def _audit_config(supported_languages: list[str]) -> SimpleNamespace:
+def _audit_config(
+    supported_languages: list[str],
+    *,
+    target_duration_min: float | None = None,
+    target_duration_max: float | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         audio=SimpleNamespace(
             chapter_max=12,
-            target_duration_min=None,
-            target_duration_max=None,
+            target_duration_min=target_duration_min,
+            target_duration_max=target_duration_max,
         ),
         content=SimpleNamespace(
             tags=SimpleNamespace(
@@ -94,6 +99,43 @@ Continuous Focus Mix
 
 
 class TestAuditLocalPreflightContract:
+    def test_duration_targets_are_converted_from_minutes_to_seconds(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={"en": "continuous focus mix"},
+            description="A continuous BGM mix without chapter markers.",
+        )
+        master = collection_dir / "01-master" / "Complete-Collection-Master.mp4"
+        master.parent.mkdir()
+        master.touch()
+
+        with patch("youtube_automation.scripts.metadata_audit.probe_duration", return_value=50 * 60):
+            issues = audit_local(
+                collection_dir,
+                _audit_config(
+                    ["en"],
+                    target_duration_min=60,
+                    target_duration_max=90,
+                ),
+            )
+
+        assert issues == ["duration: 50m (target 1h00m〜1h30m)"]
+
+    def test_duration_check_remains_disabled_without_targets(self, tmp_path: Path) -> None:
+        collection_dir = _write_local_collection(
+            tmp_path,
+            scene_phrases={"en": "continuous focus mix"},
+            description="A continuous BGM mix without chapter markers.",
+        )
+        master = collection_dir / "01-master" / "Complete-Collection-Master.mp4"
+        master.parent.mkdir()
+        master.touch()
+
+        with patch("youtube_automation.scripts.metadata_audit.probe_duration") as probe:
+            assert audit_local(collection_dir, _audit_config(["en"])) == []
+
+        probe.assert_not_called()
+
     def test_en_only_channel_without_timestamps_passes(self, tmp_path: Path) -> None:
         collection_dir = _write_local_collection(
             tmp_path,


### PR DESCRIPTION
Closes #2468

## 変更
- channel audio の `target_duration_min/max`（分）を metadata audit 境界で秒へ変換
- `check_duration()` の秒単位契約は変更しない
- 60〜90分設定と50分動画、target 未設定時の skip を回帰テスト化

## 検証
- `uv run pytest -q tests/test_metadata_audit.py tests/test_preflight_checks.py` (114 passed)
- `uv run ruff check src/youtube_automation/scripts/metadata_audit.py tests/test_metadata_audit.py`
- `uv run ruff format --check ...`
- `git diff --check`