### PR TITLE
fix(video-upload): 2026 quota bucket を plan と preflight に反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(workflow)`: `thumbnail::textless.enabled: false` の共有 `main.jpg` を wf-new・loop-video・videoup・wf-next が正規の文字入り動画背景として貫通させる契約を追加（#2458）。
 - `fix(metadata-audit)`: channel audio の target duration（分）を秒へ正規化してからローカル動画尺と比較し、60〜90分を1分扱いする誤検知を解消（#2468）。
 - `fix(masterup)`: libmp3lame の bitrate (`-b:a`) と VBR quality (`-q:a`) の同時指定を解消し、FFmpeg 8.1.2 の末尾 frame flush error を防止（#2466）。
+- `fix(video-upload)`: 2026-06-01以降の YouTube Data API quota を `videos.insert` / `search.list` の独立100-call bucket とその他 endpoint の10,000-unit pool に分離し、plan と preflight を更新（#2467）。
 - `feat(thumbnail)`: `textless.enabled: false` の opt-in で追加の textless 生成・承認を省略し、確定済み `thumbnail.jpg` を同一内容の `main.jpg` として検証付きで共用（#2457）。
 - `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `fix(wf-auto)`: Suno の生成・playlist 追加・ZIP download・strict 検証を browser use で agent が完走し、人間への handoff を login / CAPTCHA の該当操作だけに限定（#2454）。

--- a/src/youtube_automation/agents/_complete_collection_executor.py
+++ b/src/youtube_automation/agents/_complete_collection_executor.py
@@ -20,7 +20,9 @@ from youtube_automation.agents._collection_uploader_constants import (
     TRACKING_STATUS_COMPLETED,
 )
 from youtube_automation.agents.youtube_auto_uploader import UPLOAD_SOURCE_EXISTING
+from youtube_automation.utils import cost_tracker
 from youtube_automation.utils.exceptions import QuotaExhaustedError
+from youtube_automation.utils.youtube_quota import complete_collection_quota_plan, quota_shortages
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,18 @@ class CompleteCollectionExecutorMixin:
         # tracking から resumable upload session URI を取り出す（無ければ None でフレッシュ実行）
         cc = tracking.get("complete_collection", {})
         resume_session_uri = cc.get("resume_session_uri")
+
+        shortages = quota_shortages(
+            complete_collection_quota_plan(),
+            cost_tracker.read_quota_log(),
+        )
+        if shortages:
+            error = QuotaExhaustedError("YouTube API quota preflight failed: " + "; ".join(shortages))
+            logger.error(f"⏸️  quota 枯渇のため中断（再実行で resume）: {error}")
+            return {
+                "action": ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
+                "details": {"error": str(error), "retry_after_seconds": None},
+            }
 
         def _on_session_uri_changed(uri: str | None) -> None:
             """upload 中の URI 変化を tracking に永続化する。

--- a/src/youtube_automation/agents/_dedup_search.py
+++ b/src/youtube_automation/agents/_dedup_search.py
@@ -21,8 +21,8 @@ from youtube_automation.utils import cost_tracker
 logger = logging.getLogger(__name__)
 
 _QUOTA_SERVICE = "youtube-data-api"
-# YouTube Data API v3 の公式 quota cost（search.list=100 / videos.list=1）
-_SEARCH_LIST_UNITS = 100
+# YouTube Data API v3 の公式 quota cost（2026-06-01以降は search.list 独立 bucket で 1/call）
+_SEARCH_LIST_UNITS = 1
 _VIDEOS_LIST_UNITS = 1
 _QUOTA_CONTEXT = "upload_dedup_search"
 

--- a/src/youtube_automation/agents/_published_dates.py
+++ b/src/youtube_automation/agents/_published_dates.py
@@ -19,8 +19,8 @@ from youtube_automation.utils.schedule import get_schedule_timezone
 logger = logging.getLogger(__name__)
 
 _QUOTA_SERVICE = "youtube-data-api"
-# YouTube Data API v3 の公式 quota cost（search.list=100 / videos.list=1）
-_SEARCH_LIST_UNITS = 100
+# YouTube Data API v3 の公式 quota cost（2026-06-01以降は search.list 独立 bucket で 1/call）
+_SEARCH_LIST_UNITS = 1
 _VIDEOS_LIST_UNITS = 1
 _QUOTA_CONTEXT = "published_dates_lookup"
 

--- a/src/youtube_automation/agents/collection_uploader.py
+++ b/src/youtube_automation/agents/collection_uploader.py
@@ -58,6 +58,12 @@ from youtube_automation.scripts.collection_preflight import ensure_collection_pr
 from youtube_automation.scripts.playlist_manager import PlaylistManager  # noqa: E402
 from youtube_automation.utils.collection_paths import CollectionPaths  # noqa: E402
 from youtube_automation.utils.exceptions import ValidationError  # noqa: E402
+from youtube_automation.utils.youtube_quota import (  # noqa: E402
+    DAILY_BUCKET_LIMITS,
+    UNIT_COSTS,
+    UNIT_POOL_LIMIT,
+    complete_collection_quota_plan,
+)
 from youtube_automation.utils.youtube_service import get_youtube  # noqa: E402
 
 # 後方互換 / 公開 API: 定数・主要シンボルは従来どおり本モジュールから import できるよう再エクスポートする。
@@ -301,10 +307,13 @@ class CollectionUploader(
                     "予約投稿したい場合は true に変更してください"
                 )
         print()
-        # 実測クォータ: 約84ユニット/アップロード
-        # CC アップロード (84) + 公開日一覧 search (100) + dedup 直前 search (100)
-        estimated_quota = 84 + 100 + 100
-        print(f"  推定クォータ消費: 約 {estimated_quota:,}/10,000 ユニット")
+        quota_plan = complete_collection_quota_plan()
+        print("  推定 YouTube API quota:")
+        for method, calls in quota_plan.bucket_calls.items():
+            print(f"    独立日次 bucket: {method} {calls}/{DAILY_BUCKET_LIMITS[method]} calls")
+        for method, calls in quota_plan.unit_pool_calls.items():
+            print(f"    unit pool: {method} {calls} × {UNIT_COSTS[method]} units")
+        print(f"    unit pool 合計: {quota_plan.unit_pool_units:,}/{UNIT_POOL_LIMIT:,} units")
 
     # ─── コレクション管理 ────────────────────────────
 

--- a/src/youtube_automation/utils/youtube_quota.py
+++ b/src/youtube_automation/utils/youtube_quota.py
@@ -1,0 +1,90 @@
+"""YouTube Data API の現行日次 bucket / unit pool 契約。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+DAILY_BUCKET_LIMITS = {
+    "videos.insert": 100,
+    "search.list": 100,
+}
+UNIT_POOL_LIMIT = 10_000
+UNIT_COSTS = {
+    "videos.insert": 1,
+    "search.list": 1,
+    "videos.list": 1,
+    "thumbnails.set": 50,
+    "playlistItems.insert": 50,
+}
+_RESET_TIMEZONE = ZoneInfo("America/Los_Angeles")
+
+
+@dataclass(frozen=True)
+class UploadQuotaPlan:
+    """Complete Collection 1件の保守的な API call 見積もり。"""
+
+    bucket_calls: dict[str, int]
+    unit_pool_calls: dict[str, int]
+
+    @property
+    def unit_pool_units(self) -> int:
+        return sum(UNIT_COSTS[method] * count for method, count in self.unit_pool_calls.items())
+
+
+def complete_collection_quota_plan(*, playlist_inserts: int = 1) -> UploadQuotaPlan:
+    """upload + schedule lookup + dedup + thumbnail + playlist の見積もりを返す。"""
+    if playlist_inserts < 0:
+        raise ValueError("playlist_inserts must be >= 0")
+    unit_pool_calls = {
+        "videos.list": 2,
+        "thumbnails.set": 1,
+    }
+    if playlist_inserts:
+        unit_pool_calls["playlistItems.insert"] = playlist_inserts
+    return UploadQuotaPlan(
+        bucket_calls={"videos.insert": 1, "search.list": 2},
+        unit_pool_calls=unit_pool_calls,
+    )
+
+
+def quota_shortages(
+    plan: UploadQuotaPlan,
+    entries: list[dict],
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """ローカル記録済みの当日使用量に plan を加え、既知の不足を返す。"""
+    current = now or datetime.now(timezone.utc)
+    current_reset_date = current.astimezone(_RESET_TIMEZONE).date()
+    today = [
+        entry
+        for entry in entries
+        if _entry_reset_date(entry.get("timestamp")) == current_reset_date
+        and entry.get("service") == "youtube-data-api"
+    ]
+
+    shortages: list[str] = []
+    for bucket, planned in plan.bucket_calls.items():
+        used = sum(1 for entry in today if entry.get("bucket") == bucket)
+        limit = DAILY_BUCKET_LIMITS[bucket]
+        if used + planned > limit:
+            shortages.append(f"{bucket}: used {used} + planned {planned} > daily {limit} calls")
+
+    unit_used = sum(float(entry.get("units", 0)) for entry in today if entry.get("bucket") not in DAILY_BUCKET_LIMITS)
+    if unit_used + plan.unit_pool_units > UNIT_POOL_LIMIT:
+        shortages.append(f"unit pool: used {int(unit_used)} + planned {plan.unit_pool_units} > daily {UNIT_POOL_LIMIT}")
+    return shortages
+
+
+def _entry_reset_date(value: object):
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(_RESET_TIMEZONE).date()

--- a/tests/test_collection_uploader.py
+++ b/tests/test_collection_uploader.py
@@ -555,7 +555,7 @@ class TestPublishedDatesQuotaRecording:
 
         assert len(dates) == 1
         assert self._quota_calls(mock_log_quota) == [
-            ("youtube-data-api", "search.list", 100),
+            ("youtube-data-api", "search.list", 1),
             ("youtube-data-api", "videos.list", 1),
         ]
 
@@ -568,7 +568,7 @@ class TestPublishedDatesQuotaRecording:
             dates = uploader._get_published_dates()
 
         assert dates == set()
-        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 100)]
+        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
         mock_service.videos.return_value.list.assert_not_called()
 
     def test_should_record_quota_and_keep_fail_safe_on_api_error(self, tmp_path, caplog):
@@ -583,7 +583,7 @@ class TestPublishedDatesQuotaRecording:
             dates = uploader._get_published_dates()
 
         assert dates == set()
-        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 100)]
+        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
         assert any(rec.levelno == logging.WARNING for rec in caplog.records)
 
 
@@ -974,6 +974,16 @@ class TestShowPlanPrivacyDisplay:
         """skill docs（test_skill_docs_consistency）が例示する文字列を維持する。"""
         out = self._plan_output(tmp_path, capsys, "public")
         assert "📅 公開設定: 即時公開 (public)" in out
+
+    def test_plan_separates_daily_buckets_from_unit_pool(self, tmp_path, capsys):
+        out = self._plan_output(tmp_path, capsys, "private")
+
+        assert "独立日次 bucket: videos.insert 1/100 calls" in out
+        assert "独立日次 bucket: search.list 2/100 calls" in out
+        assert "unit pool: thumbnails.set 1 × 50 units" in out
+        assert "unit pool: playlistItems.insert 1 × 50 units" in out
+        assert "unit pool 合計: 102/10,000 units" in out
+        assert "284/10,000" not in out
 
 
 def test_execute_collection_suppresses_lower_default_publish_fallback_when_schedule_disabled(tmp_path):

--- a/tests/test_youtube_auto_uploader.py
+++ b/tests/test_youtube_auto_uploader.py
@@ -798,7 +798,7 @@ class TestDedupSearchQuotaRecording:
 
         assert result is not None
         assert self._quota_calls(mock_log_quota) == [
-            ("youtube-data-api", "search.list", 100),
+            ("youtube-data-api", "search.list", 1),
             ("youtube-data-api", "videos.list", 1),
         ]
 
@@ -811,7 +811,7 @@ class TestDedupSearchQuotaRecording:
             result = uploader._find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
-        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 100)]
+        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
         mock_youtube.videos.return_value.list.assert_not_called()
 
     def test_should_record_search_quota_and_fail_open_on_search_http_error(self, tmp_path, caplog):
@@ -826,7 +826,7 @@ class TestDedupSearchQuotaRecording:
             result = uploader._find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
-        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 100)]
+        assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
         assert any(rec.levelno == logging.WARNING for rec in caplog.records)
 
     def test_should_record_both_quotas_and_fail_open_on_videos_list_http_error(self, tmp_path, caplog):
@@ -845,7 +845,7 @@ class TestDedupSearchQuotaRecording:
 
         assert result is None
         assert self._quota_calls(mock_log_quota) == [
-            ("youtube-data-api", "search.list", 100),
+            ("youtube-data-api", "search.list", 1),
             ("youtube-data-api", "videos.list", 1),
         ]
         assert any(rec.levelno == logging.WARNING for rec in caplog.records)

--- a/tests/test_youtube_quota.py
+++ b/tests/test_youtube_quota.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+
+from youtube_automation.utils.youtube_quota import (
+    DAILY_BUCKET_LIMITS,
+    UNIT_COSTS,
+    UNIT_POOL_LIMIT,
+    complete_collection_quota_plan,
+    quota_shortages,
+)
+
+
+def test_official_2026_quota_values_and_complete_collection_plan() -> None:
+    plan = complete_collection_quota_plan()
+
+    assert DAILY_BUCKET_LIMITS == {"videos.insert": 100, "search.list": 100}
+    assert UNIT_POOL_LIMIT == 10_000
+    assert UNIT_COSTS["videos.insert"] == 1
+    assert UNIT_COSTS["search.list"] == 1
+    assert UNIT_COSTS["thumbnails.set"] == 50
+    assert UNIT_COSTS["playlistItems.insert"] == 50
+    assert plan.bucket_calls == {"videos.insert": 1, "search.list": 2}
+    assert plan.unit_pool_units == 102
+
+
+def test_quota_preflight_reports_each_exhausted_pool() -> None:
+    today = "2026-07-23T12:00:00+00:00"
+    entries = [
+        *[
+            {"timestamp": today, "service": "youtube-data-api", "bucket": "videos.insert", "units": 1}
+            for _ in range(100)
+        ],
+        *[{"timestamp": today, "service": "youtube-data-api", "bucket": "search.list", "units": 1} for _ in range(99)],
+        {
+            "timestamp": today,
+            "service": "youtube-data-api",
+            "bucket": "videos.update",
+            "units": 9_950,
+        },
+    ]
+
+    shortages = quota_shortages(
+        complete_collection_quota_plan(),
+        entries,
+        now=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
+    )
+
+    assert any(message.startswith("videos.insert:") for message in shortages)
+    assert any(message.startswith("search.list:") for message in shortages)
+    assert any(message.startswith("unit pool:") for message in shortages)
+
+
+def test_quota_preflight_ignores_previous_pacific_day() -> None:
+    entries = [
+        {
+            "timestamp": "2026-07-23T06:59:59+00:00",
+            "service": "youtube-data-api",
+            "bucket": "videos.insert",
+            "units": 1,
+        }
+        for _ in range(100)
+    ]
+
+    assert (
+        quota_shortages(
+            complete_collection_quota_plan(),
+            entries,
+            now=datetime(2026, 7, 23, 8, tzinfo=timezone.utc),
+        )
+        == []
+    )


### PR DESCRIPTION
Closes #2467

## 変更
- `videos.insert` / `search.list` を各100 call/dayの独立 bucket としてモデル化
- thumbnail / playlist / videos.list を10,000-unit poolへ分離
- Complete Collection plan に bucket calls と unit cost を別表示
- Pacific Time 日次境界のローカル使用履歴を加味し、既知の不足は外部 upload 前に fail-loud
- search.list の記録値を旧100 unitsから現行1 call/unitへ更新

## 公式ドキュメント
- Quota Calculator（2026-06-01更新）: https://developers.google.com/youtube/v3/determine_quota_cost
- videos.insert: https://developers.google.com/youtube/v3/docs/videos/insert
- search.list: https://developers.google.com/youtube/v3/docs/search/list

## 検証
- `uv run pytest -q tests/test_youtube_quota.py tests/test_collection_uploader.py tests/test_youtube_auto_uploader.py` (108 passed)
- 関連 ruff check / format check
- `git diff --check`