### PR TITLE
fix(suno-helper): 可視 Turnstile challenge を安全に待機・再開

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(metadata-audit)`: channel audio の target duration（分）を秒へ正規化してからローカル動画尺と比較し、60〜90分を1分扱いする誤検知を解消（#2468）。
 - `fix(masterup)`: libmp3lame の bitrate (`-b:a`) と VBR quality (`-q:a`) の同時指定を解消し、FFmpeg 8.1.2 の末尾 frame flush error を防止（#2466）。
 - `fix(video-upload)`: 2026-06-01以降の YouTube Data API quota を `videos.insert` / `search.list` の独立100-call bucket とその他 endpoint の10,000-unit pool に分離し、plan と preflight を更新（#2467）。
+- `fix(suno-helper)`: 可視で対話が必要な Cloudflare Turnstile challenge を CAPTCHA 待機へ接続し、非表示の background verification は誤検知せず、解消後に重複 Create なしで再開（#2471）。
 - `feat(thumbnail)`: `textless.enabled: false` の opt-in で追加の textless 生成・承認を省略し、確定済み `thumbnail.jpg` を同一内容の `main.jpg` として検証付きで共用（#2457）。
 - `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `fix(wf-auto)`: Suno の生成・playlist 追加・ZIP download・strict 検証を browser use で agent が完走し、人間への handoff を login / CAPTCHA の該当操作だけに限定（#2454）。

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -41,7 +41,7 @@ const SELECTORS = {
   vocalGenderButtons: 'button[data-selected][type="button"]',
   generateLabel: /^(create|generate|生成|作成(?:する)?)$/i,
   recaptcha:
-    'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"]',
+    'iframe[src*="recaptcha"], iframe[title*="recaptcha" i], iframe[src*="hcaptcha"], iframe[src*="challenges.cloudflare.com"], iframe[title*="turnstile" i]',
 } as const;
 
 /** radix slider 注入の step ごとの読み戻し検証の poll 間隔 (ms)。 */
@@ -728,7 +728,8 @@ function isChallengeFrame(src: string): boolean {
 }
 
 /**
- * active な recaptcha / hcaptcha challenge iframe を検知する（#810, #875, #924）。
+ * active な reCAPTCHA / hCaptcha / Cloudflare Turnstile challenge iframe を検知する
+ *（#810, #875, #924, #2471）。
  * Suno は hCaptcha challenge を非表示プリロード iframe として常駐させるため、
  * querySelector の hit だけでは常に true になってしまう。
  *
@@ -742,7 +743,9 @@ function isChallengeFrame(src: string): boolean {
  * anchor / checkbox / badge 系の常駐 widget iframe（reCAPTCHA anchor は title="reCAPTCHA"、
  * hCaptcha checkbox widget も常時 title あり）まで誤検知してしまう。
  * title 非空ヒューリスティックは challenge 系 iframe（`frame=challenge` / `/bframe`）に限定し、
- * それ以外の iframe は従来通り strict isVisible() のみで判定する。
+ * それ以外の iframe（Turnstile を含む）は strict isVisible() のみで判定する。Cloudflare 公式の
+ * implicit / explicit rendering はいずれも `challenges.cloudflare.com` の widget を挿入するが、
+ * 非表示の background verification は停止要因にしない。
  */
 export function detectRecaptcha(): boolean {
   const iframes = document.querySelectorAll<HTMLIFrameElement>(

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -932,6 +932,14 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
       });
       expect(detectRecaptcha()).toBe(true);
     });
+
+    it("Given 可視 Cloudflare Turnstile iframe When 検知する Then true", () => {
+      addCaptchaIframe({
+        src: "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv",
+        title: "Widget containing a Cloudflare security challenge",
+      });
+      expect(detectRecaptcha()).toBe(true);
+    });
   });
 
   describe("非表示のプリロード hCaptcha iframe は false (誤検知防止)", () => {
@@ -972,6 +980,29 @@ describe("detectRecaptcha: 可視なチャレンジのみ検知 (#810)", () => {
         src: "https://hcaptcha-assets-prod.suno.com/captcha/v1/x",
         width: 0,
         height: 150,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
+  });
+
+  describe("非対話 Turnstile widget は false (誤検知防止)", () => {
+    it("Given display:none の Turnstile iframe When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv",
+        display: "none",
+        width: 0,
+        height: 0,
+      });
+      expect(detectRecaptcha()).toBe(false);
+    });
+
+    it("Given background verification 用 opacity:0 Turnstile iframe When 検知する Then false", () => {
+      addCaptchaIframe({
+        src: "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv",
+        title: "Widget containing a Cloudflare security challenge",
+        opacity: "0",
+        width: 300,
+        height: 65,
       });
       expect(detectRecaptcha()).toBe(false);
     });

--- a/extensions/suno-helper/tests/wait-for-generation.test.ts
+++ b/extensions/suno-helper/tests/wait-for-generation.test.ts
@@ -77,6 +77,32 @@ describe("waitForGeneration: 完了検知", () => {
 });
 
 describe("waitForGeneration: captcha 検知で待機し解消後に続行する", () => {
+  it("Given 可視 Turnstile が解消する When poll する Then waiting-captcha を経て同じ生成待機へ戻る", async () => {
+    const btn = disabledButton();
+    const captcha = addCaptchaIframe({
+      src: "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv",
+      title: "Widget containing a Cloudflare security challenge",
+    });
+    const phases: boolean[] = [];
+
+    const pending = waitForGeneration(btn, {
+      isAborted: () => false,
+      ...FAST_OPTIONS,
+      captchaWaitTimeoutMs: 500,
+      onCaptchaWait: (waiting) => phases.push(waiting),
+    });
+    await vi.advanceTimersByTimeAsync(
+      FAST_OPTIONS.settleMs + FAST_OPTIONS.pollIntervalMs
+    );
+    captcha.remove();
+    await vi.advanceTimersByTimeAsync(FAST_OPTIONS.pollIntervalMs * 2);
+    btn.disabled = false;
+    await vi.advanceTimersByTimeAsync(FAST_OPTIONS.pollIntervalMs * 2);
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(phases).toEqual([true, false]);
+  });
+
   it("Given 待機中に可視 captcha 出現 → 自動 verify で消滅 When poll する Then throw せず生成完了まで待って resolve する", async () => {
     const btn = disabledButton();
     const captcha = addCaptchaIframe({


### PR DESCRIPTION
Closes #2471

## 変更
- `challenges.cloudflare.com` の Turnstile iframe を CAPTCHA detector に追加
- strict visibility（bbox / display / visibility / opacity / 親要素）を維持し、非表示 background verification は除外
- Create 前 preflight と生成完了待ちの既存共通経路へ接続
- challenge 解消後に waiting-captcha から同じ生成待機へ戻る回帰テストを追加
- 自動突破処理は追加していない

## 公式ドキュメント
- Cloudflare Turnstile client-side rendering: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/

## 検証
- `nix develop .#extensions --command pnpm --dir extensions/suno-helper test` (66 files, 1295 tests)
- `nix develop .#extensions --command pnpm --dir extensions/suno-helper compile`
- `nix develop .#extensions --command pnpm --dir extensions/suno-helper check`
- `git diff --check`