### PR TITLE
fix(extensions): authenticate MV3 background mutations by exact origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(masterup)`: libmp3lame の bitrate (`-b:a`) と VBR quality (`-q:a`) の同時指定を解消し、FFmpeg 8.1.2 の末尾 frame flush error を防止（#2466）。
 - `fix(video-upload)`: 2026-06-01以降の YouTube Data API quota を `videos.insert` / `search.list` の独立100-call bucket とその他 endpoint の10,000-unit pool に分離し、plan と preflight を更新（#2467）。
 - `fix(suno-helper)`: 可視で対話が必要な Cloudflare Turnstile challenge を CAPTCHA 待機へ接続し、非表示の background verification は誤検知せず、解消後に重複 Create なしで再開（#2471）。
+- `fix(extensions)`: MV3 background の認証付き localhost mutation で runtime extension origin を明示送信し、サーバー側の exact extension lock と一致する場合だけ `Origin: null` / 省略を許可。Suno downloaded/unattended と DistroKid release の token 取得・stale token 1回再試行を同じ境界へ統一（#2465）。
 - `feat(thumbnail)`: `textless.enabled: false` の opt-in で追加の textless 生成・承認を省略し、確定済み `thumbnail.jpg` を同一内容の `main.jpg` として検証付きで共用（#2457）。
 - `fix(workspace)`: `yt-channel-import` が移行元・コピー対象内の通常ファイル symlink を安全検証後に実体化し、外部・対象外・壊れた・directory link は従来どおり rollback（#2462）。
 - `fix(wf-auto)`: Suno の生成・playlist 追加・ZIP download・strict 検証を browser use で agent が完走し、人間への handoff を login / CAPTCHA の該当操作だけに限定（#2454）。

--- a/extensions/distrokid-helper/entrypoints/background.ts
+++ b/extensions/distrokid-helper/entrypoints/background.ts
@@ -9,6 +9,7 @@ import { onMessage, sendMessage } from "../lib/messaging";
 import { migrateServerSourcesStorage } from "../lib/storage";
 
 export default defineBackground(() => {
+  const extensionOrigin = browser.runtime.getURL("").replace(/\/+$/, "");
   console.info("[distrokid-helper] background service worker started");
 
   browser.runtime.onInstalled.addListener(() => {
@@ -60,6 +61,8 @@ export default defineBackground(() => {
   // overlay → background: 配信済み記録。token 取得と 403 retry は shared/api に委譲する。
   // 失敗（reject）は overlay 側が warning 表示に変換し、フィル成功は覆さない（#934 の契約を維持）。
   onMessage("recordRelease", async ({ data }) => {
-    await recordDistrokidRelease(data.baseUrl, data.record);
+    await recordDistrokidRelease(data.baseUrl, data.record, {
+      extensionOrigin,
+    });
   });
 });

--- a/extensions/distrokid-helper/tests/background-handlers.test.ts
+++ b/extensions/distrokid-helper/tests/background-handlers.test.ts
@@ -42,6 +42,8 @@ async function loadBackground(opts?: {
       },
     },
     runtime: {
+      getURL: (path: string) =>
+        `chrome-extension://distrokid-helper-id/${path}`,
       onInstalled: {
         addListener: vi.fn((listener: () => void) =>
           installedListeners.push(listener)
@@ -156,7 +158,8 @@ describe('background onMessage("recordRelease"): serve token 書き込み境界 
 
     expect(recordDistrokidReleaseMock).toHaveBeenCalledWith(
       "http://localhost:7873",
-      RECORD
+      RECORD,
+      { extensionOrigin: "chrome-extension://distrokid-helper-id" }
     );
   });
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -768,12 +768,14 @@ export function excludeReleasedDiscs(
  */
 export async function recordDistrokidRelease(
   baseUrl: string,
-  record: DistrokidReleaseRecord
+  record: DistrokidReleaseRecord,
+  requestContext?: ServeTokenRequestContext
 ): Promise<void> {
   const resp = await postJsonWithServeToken(
     baseUrl,
     DISTROKID_RELEASES_ROUTE,
-    record
+    record,
+    requestContext
   );
   if (!resp.ok) {
     throw new Error(`HTTP ${resp.status}`);
@@ -793,8 +795,31 @@ export interface DownloadedPayload {
  * ダウンロード完了をサーバーに通知する (#1215)。POST /collections/:id/downloaded。
  * 非 2xx は fail-loud で throw する。
  */
-async function fetchServeToken(baseUrl: string): Promise<string> {
-  const res = await fetch(`${normalizeBaseUrl(baseUrl)}/auth/token`);
+export interface ServeTokenRequestContext {
+  extensionOrigin?: string;
+}
+
+function extensionOriginHeaders(
+  requestContext?: ServeTokenRequestContext
+): Record<string, string> {
+  const extensionOrigin = requestContext?.extensionOrigin?.replace(/\/+$/, "");
+  if (!extensionOrigin) return {};
+  if (!extensionOrigin.startsWith("chrome-extension://")) {
+    throw new Error("extensionOrigin must use chrome-extension://");
+  }
+  return { "X-Extension-Origin": extensionOrigin };
+}
+
+async function fetchServeToken(
+  baseUrl: string,
+  requestContext?: ServeTokenRequestContext
+): Promise<string> {
+  const headers = extensionOriginHeaders(requestContext);
+  const url = `${normalizeBaseUrl(baseUrl)}/auth/token`;
+  const res =
+    Object.keys(headers).length > 0
+      ? await fetch(url, { headers })
+      : await fetch(url);
   if (!res.ok) throw new Error(`GET /auth/token failed: ${res.status}`);
   const data: unknown = await res.json();
   if (
@@ -819,19 +844,26 @@ async function fetchServeToken(baseUrl: string): Promise<string> {
 async function postJsonWithServeToken(
   baseUrl: string,
   route: string,
-  body: unknown
+  body: unknown,
+  requestContext?: ServeTokenRequestContext
 ): Promise<Response> {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   const url = `${normalizedBaseUrl}${route}`;
   const post = (token: string) =>
     fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Serve-Token": token },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Serve-Token": token,
+        ...extensionOriginHeaders(requestContext),
+      },
       body: JSON.stringify(body),
     });
-  let res = await post(await fetchServeToken(normalizedBaseUrl));
+  let res = await post(
+    await fetchServeToken(normalizedBaseUrl, requestContext)
+  );
   if (res.status === 403) {
-    res = await post(await fetchServeToken(normalizedBaseUrl));
+    res = await post(await fetchServeToken(normalizedBaseUrl, requestContext));
   }
   return res;
 }
@@ -844,7 +876,8 @@ export interface PostDownloadedResult {
 export async function postDownloaded(
   baseUrl: string,
   collectionId: string,
-  payload: DownloadedPayload
+  payload: DownloadedPayload,
+  requestContext?: ServeTokenRequestContext
 ): Promise<PostDownloadedResult> {
   if (payload.file_count > 0 && !payload.download_path) {
     throw new Error("file_count が正数の場合は download_path が必要です");
@@ -852,7 +885,8 @@ export async function postDownloaded(
   const res = await postJsonWithServeToken(
     baseUrl,
     collectionDownloadedRoute(collectionId),
-    payload
+    payload,
+    requestContext
   );
   if (!res.ok) {
     throw new Error(`POST downloaded failed: ${res.status} ${res.statusText}`);
@@ -879,10 +913,11 @@ export async function postDownloaded(
 /** Atomically consume a server-issued unattended request nonce. */
 export async function consumeUnattendedRequest(
   baseUrl: string,
-  nonce: string
+  nonce: string,
+  requestContext?: ServeTokenRequestContext
 ): Promise<unknown> {
   const route = `/unattended/requests/${encodeURIComponent(nonce)}/consume`;
-  const res = await postJsonWithServeToken(baseUrl, route, {});
+  const res = await postJsonWithServeToken(baseUrl, route, {}, requestContext);
   if (!res.ok) {
     throw new Error(`unattended request consume failed: HTTP ${res.status}`);
   }

--- a/extensions/suno-helper/entrypoints/background.ts
+++ b/extensions/suno-helper/entrypoints/background.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/unattended-lease";
 
 export default defineBackground(() => {
+  const extensionOrigin = browser.runtime.getURL("").replace(/\/+$/, "");
   const leaseStorageKey = "sunoUnattendedLeases";
   let leaseMutation: Promise<unknown> = Promise.resolve();
   const mutateLeases = <T>(
@@ -227,12 +228,16 @@ export default defineBackground(() => {
   // token fetch と POST /downloaded は background の extension origin から実行する。
   onMessage("postDownloaded", async ({ data, sender }) => {
     requireRelayTab(sender, "postDownloaded");
-    return await postDownloaded(data.baseUrl, data.collectionId, data.body);
+    return await postDownloaded(data.baseUrl, data.collectionId, data.body, {
+      extensionOrigin,
+    });
   });
 
   onMessage("consumeUnattendedRequest", async ({ data, sender }) => {
     requireRelayTab(sender, "consumeUnattendedRequest");
-    return await consumeUnattendedRequest(data.baseUrl, data.nonce);
+    return await consumeUnattendedRequest(data.baseUrl, data.nonce, {
+      extensionOrigin,
+    });
   });
 
   onMessage("acquireUnattendedLease", ({ data, sender }) => {

--- a/extensions/suno-helper/tests/background-handlers.test.ts
+++ b/extensions/suno-helper/tests/background-handlers.test.ts
@@ -95,6 +95,7 @@ async function loadBackground(opts?: {
         ),
       },
       getManifest: () => ({ version: "0.1.0" }),
+      getURL: (path: string) => `chrome-extension://suno-helper-id/${path}`,
     },
     notifications: { create: notificationCreate },
     action: { onClicked: { addListener: vi.fn() } },
@@ -492,7 +493,12 @@ describe('background onMessage("postDownloaded"): shared/api 実配線', () => {
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      "http://localhost:7873/auth/token"
+      "http://localhost:7873/auth/token",
+      {
+        headers: {
+          "X-Extension-Origin": "chrome-extension://suno-helper-id",
+        },
+      }
     );
     expect(fetchImpl).toHaveBeenNthCalledWith(
       2,
@@ -501,6 +507,7 @@ describe('background onMessage("postDownloaded"): shared/api 実配線', () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Extension-Origin": "chrome-extension://suno-helper-id",
           "X-Serve-Token": "stale-token",
         },
         body: JSON.stringify({
@@ -512,7 +519,12 @@ describe('background onMessage("postDownloaded"): shared/api 実配線', () => {
     );
     expect(fetchImpl).toHaveBeenNthCalledWith(
       3,
-      "http://localhost:7873/auth/token"
+      "http://localhost:7873/auth/token",
+      {
+        headers: {
+          "X-Extension-Origin": "chrome-extension://suno-helper-id",
+        },
+      }
     );
     expect(fetchImpl).toHaveBeenNthCalledWith(
       4,
@@ -520,6 +532,7 @@ describe('background onMessage("postDownloaded"): shared/api 実配線', () => {
       expect.objectContaining({
         headers: {
           "Content-Type": "application/json",
+          "X-Extension-Origin": "chrome-extension://suno-helper-id",
           "X-Serve-Token": "fresh-token",
         },
       })
@@ -1654,7 +1667,8 @@ describe('background onMessage("postDownloaded"): privileged POST boundary', () 
     expect(postDownloadedMock).toHaveBeenCalledWith(
       "http://localhost:8787",
       "coll-1",
-      body
+      body,
+      { extensionOrigin: "chrome-extension://suno-helper-id" }
     );
   });
 

--- a/src/youtube_automation/scripts/collection_serve.py
+++ b/src/youtube_automation/scripts/collection_serve.py
@@ -679,15 +679,22 @@ def _is_read_origin_allowed(origin: str | None, allow_origin: str | None, _path:
     return is_origin_allowed(origin, allow_origin)
 
 
-def _is_locked_extension_request(raw_origin: str | None, allow_origin: str | None) -> bool:
+def _is_locked_extension_request(
+    raw_origin: str | None,
+    declared_extension_origin: str | None,
+    allow_origin: str | None,
+) -> bool:
     """Token/mutating endpoints require an explicit extension lock.
 
-    Chrome MV3 background fetches can omit the Origin header. Web-page CORS
-    fetches include an Origin, so keep rejecting non-matching explicit origins.
+    Chrome MV3 background fetches can omit or serialize Origin as ``null``.
+    In that case the service worker must declare its runtime origin explicitly;
+    it is accepted only when it exactly matches the configured extension lock.
     """
     if allow_origin is None or not allow_origin.startswith(_EXTENSION_ORIGIN_SCHEME):
         return False
-    return raw_origin is None or raw_origin == allow_origin
+    if raw_origin == allow_origin:
+        return True
+    return raw_origin in {None, "null"} and declared_extension_origin == allow_origin
 
 
 def build_version_payload() -> dict[str, str]:
@@ -1125,14 +1132,18 @@ def create_server(
             self.send_response(204)
             self._send_cors(origin)
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Serve-Token")
+            self.send_header(
+                "Access-Control-Allow-Headers",
+                "Content-Type, X-Serve-Token, X-Extension-Origin",
+            )
             self.end_headers()
 
         def _handle_downloaded_post(self, cid: str) -> None:
             """POST /collections/<id>/downloaded を処理する（dir mode only、#1216/#1217）。"""
             assert collections_root is not None
             raw_origin = self.headers.get("Origin")
-            if not _is_locked_extension_request(raw_origin, allow_origin):
+            declared_origin = self.headers.get("X-Extension-Origin")
+            if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
                 self.send_error(403, "Forbidden")
                 return
             req_token = self.headers.get("X-Serve-Token")
@@ -1283,7 +1294,8 @@ def create_server(
             consume_prefix = f"{_UNATTENDED_REQUESTS_ROUTE}/"
             if dir_mode and self.path.startswith(consume_prefix) and self.path.endswith("/consume"):
                 raw_origin = self.headers.get("Origin")
-                if not _is_locked_extension_request(raw_origin, allow_origin):
+                declared_origin = self.headers.get("X-Extension-Origin")
+                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
                     self.send_error(403, "Forbidden")
                     return
                 if self.headers.get("X-Serve-Token") != serve_token:
@@ -1312,10 +1324,11 @@ def create_server(
                     self.send_error(404, "Not Found")
                     return
                 # 書き込み境界（#1360）: /downloaded と同じく extension lock + serve token 必須。
-                # MV3 background fetch は Origin を省略しうるため _is_locked_extension_request で
-                # 「Origin 無し or 完全一致」を許可し、本人性は X-Serve-Token で担保する。
+                # MV3 background fetch は Origin を省略しうるため、runtime origin の明示宣言を
+                # configured extension lock と完全一致させる。本人性は serve token も併用する。
                 raw_origin = self.headers.get("Origin")
-                if not _is_locked_extension_request(raw_origin, allow_origin):
+                declared_origin = self.headers.get("X-Extension-Origin")
+                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
                     self.send_error(403, "Forbidden")
                     return
                 req_token = self.headers.get("X-Serve-Token")
@@ -1396,7 +1409,8 @@ def create_server(
                 return
             if self.path == "/auth/token":
                 raw_origin = self.headers.get("Origin")
-                if not _is_locked_extension_request(raw_origin, allow_origin):
+                declared_origin = self.headers.get("X-Extension-Origin")
+                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
                     self.send_error(403, "Forbidden")
                     return
                 body = json.dumps({"token": serve_token}).encode("utf-8")

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -337,14 +337,22 @@ def test_unattended_request_is_single_use_and_extension_locked(tmp_path):
         with urllib.request.urlopen(register) as response:
             nonce = json.load(response)["nonce"]
 
-        token_request = urllib.request.Request(f"{base}/auth/token")
+        extension_headers = {"X-Extension-Origin": extension_origin}
+        token_request = urllib.request.Request(
+            f"{base}/auth/token",
+            headers=extension_headers,
+        )
         with urllib.request.urlopen(token_request) as response:
             token = json.load(response)["token"]
         consume = urllib.request.Request(
             f"{base}/unattended/requests/{nonce}/consume",
             data=b"{}",
             method="POST",
-            headers={"Content-Type": "application/json", "X-Serve-Token": token},
+            headers={
+                "Content-Type": "application/json",
+                "X-Serve-Token": token,
+                **extension_headers,
+            },
         )
         with urllib.request.urlopen(consume) as response:
             assert json.load(response) == payload
@@ -3523,9 +3531,10 @@ def test_get_auth_token_web_origin_returns_403(serve_dir, tmp_path):
     assert exc_info.value.code == 403
 
 
-def test_get_auth_token_no_origin_with_extension_lock_returns_uuid(serve_dir, tmp_path):
+def test_get_auth_token_no_origin_requires_declared_extension_origin(serve_dir, tmp_path):
     """Given extension origin に lock した dir mode サーバー
     And Chrome MV3 background fetch 相当の Origin ヘッダ無しリクエスト
+    And runtime が configured lock と同じ extension origin を明示する
     When リクエストする
     Then UUID 形式の token を含む JSON を返す。
     """
@@ -3533,7 +3542,11 @@ def test_get_auth_token_no_origin_with_extension_lock_returns_uuid(serve_dir, tm
     _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
     base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
 
-    with urllib.request.urlopen(f"{base}/auth/token") as resp:
+    req = urllib.request.Request(
+        f"{base}/auth/token",
+        headers={"X-Extension-Origin": _EXTENSION_ORIGIN},
+    )
+    with urllib.request.urlopen(req) as resp:
         assert resp.status == 200
         body = json.loads(resp.read().decode("utf-8"))
 
@@ -3615,24 +3628,54 @@ def test_post_downloaded_valid_token_succeeds(serve_dir, tmp_path):
         assert resp.status == 200
 
 
-def test_post_downloaded_no_origin_with_valid_token_succeeds(serve_dir, tmp_path):
-    """Given extension origin lock + Origin なしで取得した正しい X-Serve-Token
+def test_post_downloaded_null_origin_with_declared_origin_and_valid_token_succeeds(serve_dir, tmp_path):
+    """Given extension origin lock + runtime が明示した extension origin + 正しい token
     When Origin なしで POST /collections/<id>/downloaded を送る
     Then 200 を返す（Chrome MV3 background fetch の実挙動）。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
     base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
-    with urllib.request.urlopen(f"{base}/auth/token") as resp:
+    auth_headers = {"Origin": "null", "X-Extension-Origin": _EXTENSION_ORIGIN}
+    token_req = urllib.request.Request(f"{base}/auth/token", headers=auth_headers)
+    with urllib.request.urlopen(token_req) as resp:
         token = json.loads(resp.read().decode("utf-8"))["token"]
     payload = {"file_count": 0, "format": "mp3", "suno_playlist_url": "https://suno.com/playlist/abc"}
 
     with _post(
         f"{base}{_COLLECTIONS_ROUTE}/20260601-clm-aaa-collection/downloaded",
         payload,
-        headers={"X-Serve-Token": token},
+        headers={**auth_headers, "X-Serve-Token": token},
     ) as resp:
         assert resp.status == 200
+
+
+def test_get_auth_token_no_origin_without_declared_origin_returns_403(serve_dir, tmp_path):
+    """Origin と runtime extension origin の両方が無い caller は token を取得できない。"""
+    planning = tmp_path / "planning"
+    _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(f"{base}/auth/token")
+
+    assert exc_info.value.code == 403
+
+
+def test_get_auth_token_rejects_wrong_declared_extension_origin(serve_dir, tmp_path):
+    """MV3 fallback header は configured extension lock との完全一致を要求する。"""
+    planning = tmp_path / "planning"
+    _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
+    req = urllib.request.Request(
+        f"{base}/auth/token",
+        headers={"Origin": "null", "X-Extension-Origin": "chrome-extension://other"},
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+
+    assert exc_info.value.code == 403
 
 
 def test_apply_downloaded_artifacts_propagates_unknown_atomic_write_error(tmp_path):

--- a/tests/test_distrokid_collections_endpoint.py
+++ b/tests/test_distrokid_collections_endpoint.py
@@ -1167,7 +1167,7 @@ def test_post_distrokid_releases_single_mode_with_capture_root_preserves_legacy_
 def test_post_distrokid_releases_without_origin_and_token_returns_403(tmp_path, serve_dir_dk):
     """Given Origin ヘッダも X-Serve-Token も無い POST
     When POST する
-    Then 403 を返す（Origin 省略は MV3 background として許容されるが token は必須、#1360）。
+    Then exact extension lock を満たさず 403 を返す（#1360、#2465）。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260526-abc-collection", discs=["disc1-alpha"])
@@ -1234,9 +1234,9 @@ def test_post_distrokid_releases_with_invalid_token_returns_403(tmp_path, serve_
 
 
 def test_post_distrokid_releases_background_fetch_without_origin_succeeds(tmp_path, serve_dir_dk):
-    """Given Origin 無し + 正しい X-Serve-Token の POST（MV3 background fetch 相当、#1360）
+    """Given Origin 無し + runtime extension origin + 正しい token（MV3 background、#2465）
     When POST /distrokid/releases する
-    Then 200 で記録される（Origin 省略は background として許容し、本人性は token で担保）。
+    Then configured extension lock との完全一致を確認して 200 で記録される。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260526-abc-collection", discs=["disc1-alpha"])
@@ -1251,7 +1251,10 @@ def test_post_distrokid_releases_background_fetch_without_origin_succeeds(tmp_pa
     with _post(
         f"{base}{_DISTROKID_RELEASES_ROUTE}",
         payload,
-        headers={"X-Serve-Token": _fetch_serve_token(base)},
+        headers={
+            "X-Extension-Origin": _EXTENSION_ORIGIN,
+            "X-Serve-Token": _fetch_serve_token(base),
+        },
     ) as resp:
         assert resp.status == 200
 


### PR DESCRIPTION
Closes #2465

## Summary
- derive the installed extension origin in each MV3 background worker via `browser.runtime.getURL("")`
- send that origin on token acquisition and authenticated mutations; preserve the single stale-token retry
- accept omitted/`null` Origin only when the declared runtime origin exactly matches the server configured extension lock
- cover Suno downloaded/unattended and DistroKid release mutations with the shared boundary

## Official references
- Chrome runtime.getURL: https://developer.chrome.com/docs/extensions/reference/api/runtime/#method-getURL
- Chrome cross-origin network requests: https://developer.chrome.com/docs/extensions/develop/concepts/network-requests

## Verification
- `uv run pytest -q tests/test_collection_serve.py tests/test_distrokid_collections_endpoint.py` (287 passed after the boundary update; focused rerun 6 passed)
- Suno Helper Vitest: 66 files / 1291 tests passed
- DistroKid Helper Vitest: 21 files / 279 tests passed
- both extension `compile` checks passed
- Ultracite and Ruff passed