### PR TITLE
feat(post-publish): resume pinned comment after scheduled publish

### DIFF
--- a/.claude/skills/pinned-comment/SKILL.md
+++ b/.claude/skills/pinned-comment/SKILL.md
@@ -125,7 +125,7 @@ uv run yt-pinned-comment --collection collections/live/<latest-dir> --apply --la
 - `pinned_comment.enabled=false です` → `config/channel/pinned-comment.json` で `enabled: true` に変更
 - `SKIP ... already_posted` ばかり → 対象動画は既に投稿済み。`pinned_comment_history.json` を確認
 - `SKIP ... video_not_found` → 削除済み / 存在しない video_id。collection の状態ファイルを確認
-- `SKIP ... video_private` → private 公開待ち。公開後に再実行
+- `SKIP ... video_private` → `/post-publish` 経由で `publishAt` が未来なら `pending_until_publish` として記録して公開後に再開する。`publishAt` 超過後も private なら予定外状態なので apply せず、Studio の公開状態・時刻・timezone を確認
 - `ERR ... status=403` → OAuth スコープが `youtube.force-ssl` を含むか確認（含まなければ `auth/token.json` を削除して再認証）
 - `ERR ... status=400`（commentsDisabled）→ 動画のコメント許可が無効になっている
 

--- a/.claude/skills/post-publish/SKILL.md
+++ b/.claude/skills/post-publish/SKILL.md
@@ -30,6 +30,10 @@ uv run python .claude/skills/post-publish/references/post-publish-chain-state.py
 
 uv run python .claude/skills/post-publish/references/post-publish-chain-state.py \
   --channel-dir . --collection <collections/live/...> --step <step-id> --mark-complete
+
+uv run python .claude/skills/post-publish/references/post-publish-chain-state.py \
+  --channel-dir . --collection <collections/live/...> --step pinned-comment \
+  --mark-pending-until-publish
 ```
 
 | exit | decision | 処理 |
@@ -37,17 +41,20 @@ uv run python .claude/skills/post-publish/references/post-publish-chain-state.py
 | 0 | `skip` | 完了済み。子 skill を実行せず次段へ進む |
 | 10 | `run` | gate を解決後、子 skill を実行する |
 | 20 | `blocked` | 前段未完了または video ID 不明。理由を表示して停止する |
+| 30 | `pending_until_publish` | 予約公開前。`--mark-pending-until-publish` で履歴へ実行可能時刻を記録し、子 skill/API を呼ばず停止する |
 | その他 | `error` | manifest / history / 引数エラーとして停止する |
 
 ## 実行手順
 
 1. manifest を読み、`chainId == "post-publish"`、step 順が `community-post, pinned-comment, metadata-audit` であること、各 `approvalGate` は `skip` または legacy `enabled` のどちらか一方だけを持つことを検証する。
 2. manifest の gate を解決する。`skip` はそのまま、旧 `enabled` は `skip = not enabled` とする。正規 `configPath` の `load_config().workflow.post_publish.skip_approvals` を読み、`false` の step だけ承認対象にする。未指定は `true`（承認省略）。channel config の旧 `approval_gates` は loader が逆向きの後方互換 alias として解決し、同一 step への新旧同時指定は `ConfigError` にする。
-3. manifest 順に状態判定を実行する。exit 0 は skip、exit 20 は停止する。
+3. manifest 順に状態判定を実行する。exit 0 は skip、exit 20 は停止する。`pinned-comment` が exit 30 の場合は `--mark-pending-until-publish` を実行し、返された `pending_until` と同じ collection/video ID の再開コマンドを表示する。この時点では `pinned-comment` を dry-run/apply とも呼ばない。
 4. exit 10 かつ `skip_approvals` が `false` の場合、対象 video ID・collection・実行件数 1 件を表示する。外部投稿は公開後に取り消しが必要になり得ることを警告し、「この step を実行する」「チェーンを中止する」の 2 択で確認する。中止時は履歴を変更せず、再開コマンドを表示して停止する。
 5. 子 skill を対象 collection 付きで実行する。`community-post` は Studio 投稿準備、`pinned-comment` は dry-run の PASS 条件を確認して apply、`metadata-audit` は既定の local + remote 監査を実行する。チェーン gate で承認済みの step は、同じ video ID・件数の子 skill 承認を再度求めない。`skip_approvals` が `true` でも子 skill 自身が必須としている safety gate は省略しない。
 6. 子 skill の完了条件を満たした場合だけ `--mark-complete` を実行する。失敗時は mark せず停止する。
 7. 3 step 後に状態判定を再実行し、全て exit 0 であることと履歴の video ID を短く報告する。
+
+予約時刻後の再開では、同じコマンドを実行すると state が exit 10 に戻る。同じ video ID の `pinned_comment_history.json` を子 skill が確認するため、投稿済みなら `already_posted` で二重投稿しない。時刻を過ぎても `video_private` の場合は予定超過として actionable error にし、履歴を complete にせず、YouTube Studio の公開状態・`publishAt`・timezone を確認するまで apply しない。
 
 ## References
 

--- a/.claude/skills/post-publish/references/post-publish-chain-state.py
+++ b/.claude/skills/post-publish/references/post-publish-chain-state.py
@@ -14,6 +14,7 @@ from typing import TypedDict
 EXIT_SKIP = 0
 EXIT_RUN = 10
 EXIT_BLOCKED = 20
+EXIT_PENDING = 30
 EXIT_ERROR = 2
 SCHEMA_VERSION = 1
 STEPS = ("community-post", "pinned-comment", "metadata-audit")
@@ -27,6 +28,7 @@ class StateResult(TypedDict):
     video_id: str | None
     history_file: str
     completed_steps: list[str]
+    pending_until: str | None
 
 
 def _read_object(path: Path) -> dict:
@@ -55,6 +57,30 @@ def resolve_video_id(collection: Path) -> str | None:
     return None
 
 
+def resolve_publish_at(collection: Path) -> datetime | None:
+    """Resolve the scheduled publish time from upload tracking, then workflow state."""
+    candidates: list[object] = []
+    tracking_path = collection / "20-documentation" / "upload_tracking.json"
+    if tracking_path.is_file():
+        tracking = _read_object(tracking_path)
+        candidates.append((tracking.get("complete_collection") or {}).get("publish_at"))
+    state_path = collection / "workflow-state.json"
+    if state_path.is_file():
+        state = _read_object(state_path)
+        candidates.append((state.get("upload") or {}).get("publish_at"))
+    for value in candidates:
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"publish_at が ISO 8601 ではありません: {value}") from exc
+        if parsed.tzinfo is None:
+            raise ValueError(f"publish_at に timezone がありません: {value}")
+        return parsed.astimezone(UTC)
+    return None
+
+
 def _load_history(path: Path) -> dict:
     if not path.exists():
         return {"schema_version": SCHEMA_VERSION, "videos": {}}
@@ -70,10 +96,22 @@ def _load_history(path: Path) -> dict:
         unknown_steps = set(completed) - set(STEPS)
         if unknown_steps or any(not isinstance(value, str) or not value for value in completed.values()):
             raise ValueError(f"不正な completed entry です: video_id={video_id}")
+        pending = video.get("pending", {})
+        if not isinstance(pending, dict):
+            raise ValueError(f"pending は object でなければなりません: video_id={video_id}")
+        unknown_pending = set(pending) - {"pinned-comment"}
+        if unknown_pending or any(not isinstance(value, str) or not value for value in pending.values()):
+            raise ValueError(f"不正な pending entry です: video_id={video_id}")
     return history
 
 
-def evaluate(root: Path, collection: Path, step: str) -> tuple[int, StateResult]:
+def evaluate(
+    root: Path,
+    collection: Path,
+    step: str,
+    *,
+    now: datetime | None = None,
+) -> tuple[int, StateResult]:
     if step not in STEPS:
         raise ValueError(f"未知の step です: {step}")
     root = root.resolve()
@@ -92,6 +130,7 @@ def evaluate(root: Path, collection: Path, step: str) -> tuple[int, StateResult]
             "video_id": None,
             "history_file": HISTORY_NAME,
             "completed_steps": [],
+            "pending_until": None,
         }
     history = _load_history(history_path)
     video = history["videos"].get(video_id, {"completed": {}})
@@ -105,6 +144,7 @@ def evaluate(root: Path, collection: Path, step: str) -> tuple[int, StateResult]
             "video_id": video_id,
             "history_file": HISTORY_NAME,
             "completed_steps": completed_steps,
+            "pending_until": None,
         }
     predecessor_index = STEPS.index(step)
     missing = [candidate for candidate in STEPS[:predecessor_index] if candidate not in completed]
@@ -116,6 +156,19 @@ def evaluate(root: Path, collection: Path, step: str) -> tuple[int, StateResult]
             "video_id": video_id,
             "history_file": HISTORY_NAME,
             "completed_steps": completed_steps,
+            "pending_until": None,
+        }
+    publish_at = resolve_publish_at(collection) if step == "pinned-comment" else None
+    current = datetime.now(UTC) if now is None else now.astimezone(UTC)
+    if publish_at is not None and publish_at > current:
+        return EXIT_PENDING, {
+            "step": step,
+            "decision": "pending_until_publish",
+            "reason": "scheduled_publish_in_future",
+            "video_id": video_id,
+            "history_file": HISTORY_NAME,
+            "completed_steps": completed_steps,
+            "pending_until": publish_at.isoformat(),
         }
     return EXIT_RUN, {
         "step": step,
@@ -124,11 +177,18 @@ def evaluate(root: Path, collection: Path, step: str) -> tuple[int, StateResult]
         "video_id": video_id,
         "history_file": HISTORY_NAME,
         "completed_steps": completed_steps,
+        "pending_until": None,
     }
 
 
-def mark_complete(root: Path, collection: Path, step: str) -> StateResult:
-    code, result = evaluate(root, collection, step)
+def mark_complete(
+    root: Path,
+    collection: Path,
+    step: str,
+    *,
+    now: datetime | None = None,
+) -> StateResult:
+    code, result = evaluate(root, collection, step, now=now)
     if code == EXIT_SKIP:
         return result
     if code != EXIT_RUN or result["video_id"] is None:
@@ -137,9 +197,10 @@ def mark_complete(root: Path, collection: Path, step: str) -> StateResult:
     history_path = root / HISTORY_NAME
     history = _load_history(history_path)
     video_id = result["video_id"]
-    video = history["videos"].setdefault(video_id, {"completed": {}})
+    video = history["videos"].setdefault(video_id, {"completed": {}, "pending": {}})
     completed = video.setdefault("completed", {})
     completed[step] = datetime.now(UTC).isoformat()
+    video.setdefault("pending", {}).pop(step, None)
     temp_path = history_path.with_name(f".{history_path.name}.{os.getpid()}.tmp")
     try:
         temp_path.write_text(json.dumps(history, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -150,19 +211,48 @@ def mark_complete(root: Path, collection: Path, step: str) -> StateResult:
     return updated
 
 
+def mark_pending_until_publish(
+    root: Path,
+    collection: Path,
+    step: str,
+    *,
+    now: datetime | None = None,
+) -> StateResult:
+    code, result = evaluate(root, collection, step, now=now)
+    if code != EXIT_PENDING or result["video_id"] is None or result["pending_until"] is None:
+        raise ValueError(result["reason"])
+    history_path = root.resolve() / HISTORY_NAME
+    history = _load_history(history_path)
+    video = history["videos"].setdefault(result["video_id"], {"completed": {}, "pending": {}})
+    video.setdefault("pending", {})[step] = result["pending_until"]
+    temp_path = history_path.with_name(f".{history_path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(json.dumps(history, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        os.replace(temp_path, history_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return result
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--channel-dir", type=Path, required=True)
     parser.add_argument("--collection", type=Path, required=True)
     parser.add_argument("--step", choices=STEPS, required=True)
     parser.add_argument("--mark-complete", action="store_true")
+    parser.add_argument("--mark-pending-until-publish", action="store_true")
     args = parser.parse_args()
     root = args.channel_dir.resolve()
     collection = args.collection if args.collection.is_absolute() else root / args.collection
     try:
+        if args.mark_complete and args.mark_pending_until_publish:
+            raise ValueError("mark action は同時指定できません")
         if args.mark_complete:
             result = mark_complete(root, collection, args.step)
             code = EXIT_SKIP
+        elif args.mark_pending_until_publish:
+            result = mark_pending_until_publish(root, collection, args.step)
+            code = EXIT_PENDING
         else:
             code, result = evaluate(root, collection, args.step)
     except ValueError as exc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(skills)`: `/suno`・`/thumbnail`・`/loop-video`・`/alignment-check` が `docs/channel/creative-constraints.md` の担当セクションを毎回参照し、不在時は既存チャンネルを止めず `/creative-constraints` を案内（#2449）。
 - `fix(masterup)`: `config/channel/audio.json` の目標尺を master loop 解決と upload preflight の SSOT にし、整数ループでは min–max を満たせない構成と目標尺外動画を明示 override なしで停止（#2469）。
+- `feat(post-publish)`: 予約公開前の pinned-comment を `pending_until_publish` と実行可能時刻で履歴化し、公開後は同じ video ID で安全に再開。予定時刻超過後も private の場合は apply せず actionable error とする（#2470）。
 - `docs(workflow)`: `thumbnail::textless.enabled: false` の共有 `main.jpg` を wf-new・loop-video・videoup・wf-next が正規の文字入り動画背景として貫通させる契約を追加（#2458）。
 - `fix(metadata-audit)`: channel audio の target duration（分）を秒へ正規化してからローカル動画尺と比較し、60〜90分を1分扱いする誤検知を解消（#2468）。
 - `fix(masterup)`: libmp3lame の bitrate (`-b:a`) と VBR quality (`-q:a`) の同時指定を解消し、FFmpeg 8.1.2 の末尾 frame flush error を防止（#2466）。

--- a/tests/test_post_publish_chain.py
+++ b/tests/test_post_publish_chain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
 
@@ -41,10 +42,18 @@ def state() -> ModuleType:
     return _load_module()
 
 
-def _collection(root: Path, name: str = "20260718-test", video_id: str = "video-123") -> Path:
+def _collection(
+    root: Path,
+    name: str = "20260718-test",
+    video_id: str = "video-123",
+    publish_at: str | None = None,
+) -> Path:
     collection = root / "collections" / "live" / name
     collection.mkdir(parents=True)
-    (collection / "workflow-state.json").write_text(json.dumps({"upload": {"video_id": video_id}}), encoding="utf-8")
+    upload = {"video_id": video_id}
+    if publish_at is not None:
+        upload["publish_at"] = publish_at
+    (collection / "workflow-state.json").write_text(json.dumps({"upload": upload}), encoding="utf-8")
     return collection
 
 
@@ -122,6 +131,65 @@ def test_corrupt_history_fails_closed(tmp_path: Path, state: ModuleType) -> None
 
     with pytest.raises(ValueError, match="completed は object"):
         state.evaluate(tmp_path, collection, "community-post")
+
+
+def test_future_publish_records_pending_without_completing_pinned_step(tmp_path: Path, state: ModuleType) -> None:
+    collection = _collection(tmp_path, publish_at="2026-07-24T11:00:00Z")
+    state.mark_complete(tmp_path, collection, "community-post")
+
+    code, pending = state.evaluate(
+        tmp_path,
+        collection,
+        "pinned-comment",
+        now=datetime(2026, 7, 24, 10, 0, tzinfo=UTC),
+    )
+    recorded = state.mark_pending_until_publish(
+        tmp_path,
+        collection,
+        "pinned-comment",
+        now=datetime(2026, 7, 24, 10, 0, tzinfo=UTC),
+    )
+
+    assert code == state.EXIT_PENDING
+    assert pending["decision"] == "pending_until_publish"
+    assert pending["pending_until"] == "2026-07-24T11:00:00+00:00"
+    assert recorded["decision"] == "pending_until_publish"
+    history = json.loads((tmp_path / "post_publish_history.json").read_text(encoding="utf-8"))
+    video = history["videos"]["video-123"]
+    assert video["pending"]["pinned-comment"] == "2026-07-24T11:00:00+00:00"
+    assert "pinned-comment" not in video["completed"]
+
+
+def test_publish_time_reached_resumes_same_video_and_clears_pending_on_complete(
+    tmp_path: Path,
+    state: ModuleType,
+) -> None:
+    collection = _collection(tmp_path, publish_at="2026-07-24T11:00:00Z")
+    state.mark_complete(tmp_path, collection, "community-post")
+    state.mark_pending_until_publish(
+        tmp_path,
+        collection,
+        "pinned-comment",
+        now=datetime(2026, 7, 24, 10, 0, tzinfo=UTC),
+    )
+
+    code, runnable = state.evaluate(
+        tmp_path,
+        collection,
+        "pinned-comment",
+        now=datetime(2026, 7, 24, 11, 1, tzinfo=UTC),
+    )
+    assert code == state.EXIT_RUN
+    assert runnable["video_id"] == "video-123"
+
+    state.mark_complete(
+        tmp_path,
+        collection,
+        "pinned-comment",
+        now=datetime(2026, 7, 24, 11, 1, tzinfo=UTC),
+    )
+    history = json.loads((tmp_path / "post_publish_history.json").read_text(encoding="utf-8"))
+    assert "pinned-comment" not in history["videos"]["video-123"]["pending"]
 
 
 def test_child_skills_support_chain_and_standalone_invocation() -> None:


### PR DESCRIPTION
Closes #2470

## Summary
- add a `pending_until_publish` chain decision and persist the executable time by video ID
- do not invoke pinned-comment dry-run/apply before a future `publishAt`
- return to `run` after publish time and clear pending only after successful completion
- keep pinned-comment history as the duplicate-post barrier; treat still-private-after-publish as actionable error

## Official references
- Videos status/publishAt: https://developers.google.com/youtube/v3/docs/videos
- CommentThreads insert: https://developers.google.com/youtube/v3/docs/commentThreads/insert

## Verification
- 19 post-publish/wf-auto state tests passed
- Ruff check passed