### PR TITLE
feat(suno-helper): adapt pacing to bursts and Turnstile challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(skills)`: `/suno`・`/thumbnail`・`/loop-video`・`/alignment-check` が `docs/channel/creative-constraints.md` の担当セクションを毎回参照し、不在時は既存チャンネルを止めず `/creative-constraints` を案内（#2449）。
 - `fix(masterup)`: `config/channel/audio.json` の目標尺を master loop 解決と upload preflight の SSOT にし、整数ループでは min–max を満たせない構成と目標尺外動画を明示 override なしで停止（#2469）。
 - `feat(post-publish)`: 予約公開前の pinned-comment を `pending_until_publish` と実行可能時刻で履歴化し、公開後は同じ video ID で安全に再開。予定時刻超過後も private の場合は apply せず actionable error とする（#2470）。
+- `feat(suno-helper)`: 通常時の Create 3–9秒・最大10 request を維持し、30秒内 burst と同一 run の Turnstile 検知時だけ中断可能な追加 cooldown/backoff を適用。正常投入で段階回復する共有 policy を serial/queue/retry に接続（#2472）。
 - `docs(workflow)`: `thumbnail::textless.enabled: false` の共有 `main.jpg` を wf-new・loop-video・videoup・wf-next が正規の文字入り動画背景として貫通させる契約を追加（#2458）。
 - `fix(metadata-audit)`: channel audio の target duration（分）を秒へ正規化してからローカル動画尺と比較し、60〜90分を1分扱いする誤検知を解消（#2468）。
 - `fix(masterup)`: libmp3lame の bitrate (`-b:a`) と VBR quality (`-q:a`) の同時指定を解消し、FFmpeg 8.1.2 の末尾 frame flush error を防止（#2466）。

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -168,6 +168,14 @@ export const BALANCED_RUN_PACING: RunPacing = {
   maxEntryRetry: 2,
 };
 
+/** Adaptive pacing policy. The baseline 3–9s jitter and max 10 requests stay unchanged. */
+export const ADAPTIVE_BURST_WINDOW_MS = 30_000;
+export const ADAPTIVE_BURST_CREATE_THRESHOLD = 4;
+export const ADAPTIVE_BURST_COOLDOWN_MS = 15_000;
+export const ADAPTIVE_CHALLENGE_BACKOFF_STEP_MS = 15_000;
+export const ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS = 60_000;
+export const ADAPTIVE_HEALTHY_CREATES_PER_RECOVERY = 3;
+
 export interface RunMode {
   label: string;
   riskNote: string;

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1,5 +1,3 @@
-// Suno の Advanced タブへの Style / Lyrics 注入と Generate 連続実行 (content script)。
-// DOM 操作は shared/dom の純関数へ委譲し、本ファイルは連続実行のフロー制御に専念する。
 import {
   DEFAULT_DURATION_FILTER,
   type DurationFilter,
@@ -58,6 +56,15 @@ import {
   waitForNewPlaylistUrlByName,
 } from "../../shared/playlist-dom";
 import { createAckWaiter, markAck } from "../lib/ack-probe";
+// Suno の Advanced タブへの Style / Lyrics 注入と Generate 連続実行 (content script)。
+// DOM 操作は shared/dom の純関数へ委譲し、本ファイルは連続実行のフロー制御に専念する。
+import {
+  createAdaptivePacingState,
+  decideAdaptivePacing,
+  recordChallenge,
+  recordSuccessfulCreate,
+  waitForAdaptivePacing,
+} from "../lib/adaptive-pacing";
 import {
   attachBridgeListener,
   createFeedPoller,
@@ -708,6 +715,7 @@ export default defineContentScript({
       );
     }
     let aborted = false;
+    let adaptivePacingState = createAdaptivePacingState();
     // 連続実行の二重起動ガード (#892 要件7)。runAll 実行中の run 再着信を弾く。
     let running = false;
     const runLockOwner = `${Date.now()}-${Math.random()}`;
@@ -900,6 +908,7 @@ export default defineContentScript({
     });
     downloadFlow.installMessageHandlers();
 
+    // fallow-ignore-next-line complexity
     async function injectEntryAndClickGenerate(
       entry: PromptEntry,
       index: number,
@@ -994,15 +1003,43 @@ export default defineContentScript({
         isAborted: () => aborted,
         pollIntervalMs: POLL_INTERVAL_MS,
         timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
-        onWaitStart: () =>
-          emitProgress({ phase: PHASE.WAITING_CAPTCHA, index, total }),
+        onWaitStart: () => {
+          adaptivePacingState = recordChallenge(adaptivePacingState);
+          emitProgress({ phase: PHASE.WAITING_CAPTCHA, index, total });
+        },
       });
       if (aborted) {
         return null; // captcha 解消待ち中の停止。Generate を押さない（未投入のまま STOPPED 経路へ）
       }
 
+      const adaptiveDecision = decideAdaptivePacing(
+        adaptivePacingState,
+        Date.now()
+      );
+      if (adaptiveDecision.delayMs > 0) {
+        emitProgress({
+          phase: PHASE.WAITING_SLOT,
+          index,
+          total,
+          message: `適応型ペーシング: ${adaptiveDecision.reasons.join("+")} (${Math.ceil(adaptiveDecision.delayMs / 1000)}秒)`,
+          yieldRetryCount: 0,
+        });
+        await waitForAdaptivePacing(
+          adaptiveDecision,
+          abortableSleep,
+          () => aborted
+        );
+      }
+      if (aborted) {
+        return null;
+      }
+
       const button = resolveGenerateButton();
       button.click();
+      adaptivePacingState = recordSuccessfulCreate(
+        adaptivePacingState,
+        Date.now()
+      );
       // Generate click 直後に lastSubmittedEntryIndex を更新する。中断時の interruptIndex 計算で
       // 「この entry は click 済み（submitted）」と判定できるようにする (#924)。
       lastSubmittedEntryIndex = index;
@@ -1045,12 +1082,16 @@ export default defineContentScript({
         settleMs: SETTLE_MS,
         captchaWaitTimeoutMs: activeUnattended ? 0 : CAPTCHA_WAIT_TIMEOUT_MS,
         // 生成完了待ち中に captcha が出たら waiting-captcha 表示へ切り替え、解消後 generating へ戻す。
-        onCaptchaWait: (waiting) =>
+        onCaptchaWait: (waiting) => {
+          if (waiting) {
+            adaptivePacingState = recordChallenge(adaptivePacingState);
+          }
           emitProgress({
             phase: waiting ? PHASE.WAITING_CAPTCHA : PHASE.GENERATING,
             index,
             total,
-          }),
+          });
+        },
       });
     }
 
@@ -1396,6 +1437,7 @@ export default defineContentScript({
       unattended?: RunPayload["unattended"];
     }
 
+    // fallow-ignore-next-line complexity
     async function runAll(
       entries: PromptEntry[],
       options: RunOptions
@@ -1410,6 +1452,7 @@ export default defineContentScript({
       } = options;
       const previousSubmittedClipIds = submittedClipIds ?? [];
       const pacing = BALANCED_RUN_PACING;
+      adaptivePacingState = createAdaptivePacingState();
       try {
         const baseUrl = await serverUrlItem.getValue();
         await sendMessage("fetchCollectionPromptResponse", {

--- a/extensions/suno-helper/lib/adaptive-pacing.ts
+++ b/extensions/suno-helper/lib/adaptive-pacing.ts
@@ -1,0 +1,96 @@
+import {
+  ADAPTIVE_BURST_COOLDOWN_MS,
+  ADAPTIVE_BURST_CREATE_THRESHOLD,
+  ADAPTIVE_BURST_WINDOW_MS,
+  ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS,
+  ADAPTIVE_CHALLENGE_BACKOFF_STEP_MS,
+  ADAPTIVE_HEALTHY_CREATES_PER_RECOVERY,
+} from "../../shared/constants";
+
+export interface AdaptivePacingState {
+  recentCreateTimestamps: number[];
+  challengeLevel: number;
+  healthyCreatesSinceChallenge: number;
+}
+
+export interface AdaptivePacingDecision {
+  delayMs: number;
+  reasons: Array<"burst" | "challenge">;
+}
+
+export function createAdaptivePacingState(): AdaptivePacingState {
+  return {
+    recentCreateTimestamps: [],
+    challengeLevel: 0,
+    healthyCreatesSinceChallenge: 0,
+  };
+}
+
+function recentCreates(state: AdaptivePacingState, now: number): number[] {
+  const cutoff = now - ADAPTIVE_BURST_WINDOW_MS;
+  return state.recentCreateTimestamps.filter(
+    (timestamp) => timestamp >= cutoff
+  );
+}
+
+export function decideAdaptivePacing(
+  state: AdaptivePacingState,
+  now: number
+): AdaptivePacingDecision {
+  const reasons: AdaptivePacingDecision["reasons"] = [];
+  const burstDelay =
+    recentCreates(state, now).length >= ADAPTIVE_BURST_CREATE_THRESHOLD
+      ? ADAPTIVE_BURST_COOLDOWN_MS
+      : 0;
+  if (burstDelay > 0) reasons.push("burst");
+  const challengeDelay = Math.min(
+    state.challengeLevel * ADAPTIVE_CHALLENGE_BACKOFF_STEP_MS,
+    ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS
+  );
+  if (challengeDelay > 0) reasons.push("challenge");
+  return { delayMs: Math.max(burstDelay, challengeDelay), reasons };
+}
+
+export async function waitForAdaptivePacing(
+  decision: AdaptivePacingDecision,
+  abortableSleep: (ms: number, isAborted: () => boolean) => Promise<void>,
+  isAborted: () => boolean
+): Promise<AdaptivePacingDecision> {
+  if (decision.delayMs > 0 && !isAborted()) {
+    await abortableSleep(decision.delayMs, isAborted);
+  }
+  return decision;
+}
+
+export function recordChallenge(
+  state: AdaptivePacingState
+): AdaptivePacingState {
+  return {
+    ...state,
+    challengeLevel: Math.min(
+      state.challengeLevel + 1,
+      Math.ceil(
+        ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS / ADAPTIVE_CHALLENGE_BACKOFF_STEP_MS
+      )
+    ),
+    healthyCreatesSinceChallenge: 0,
+  };
+}
+
+export function recordSuccessfulCreate(
+  state: AdaptivePacingState,
+  now: number
+): AdaptivePacingState {
+  const healthyCreatesSinceChallenge =
+    state.challengeLevel > 0 ? state.healthyCreatesSinceChallenge + 1 : 0;
+  const recovered =
+    state.challengeLevel > 0 &&
+    healthyCreatesSinceChallenge >= ADAPTIVE_HEALTHY_CREATES_PER_RECOVERY;
+  return {
+    recentCreateTimestamps: [...recentCreates(state, now), now],
+    challengeLevel: recovered
+      ? Math.max(0, state.challengeLevel - 1)
+      : state.challengeLevel,
+    healthyCreatesSinceChallenge: recovered ? 0 : healthyCreatesSinceChallenge,
+  };
+}

--- a/extensions/suno-helper/tests/adaptive-pacing.test.ts
+++ b/extensions/suno-helper/tests/adaptive-pacing.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ADAPTIVE_BURST_COOLDOWN_MS,
+  ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS,
+  BALANCED_RUN_PACING,
+  MAX_INFLIGHT_REQUESTS,
+} from "../../shared/constants";
+import {
+  createAdaptivePacingState,
+  decideAdaptivePacing,
+  recordChallenge,
+  recordSuccessfulCreate,
+  waitForAdaptivePacing,
+} from "../lib/adaptive-pacing";
+
+describe("adaptive pacing policy", () => {
+  it("keeps the existing 3–9 second baseline and max 10 requests", () => {
+    expect(BALANCED_RUN_PACING.interCreateDelayMs).toBe(6000);
+    expect(BALANCED_RUN_PACING.jitterMs).toBe(3000);
+    expect(BALANCED_RUN_PACING.maxInflightRequests).toBe(MAX_INFLIGHT_REQUESTS);
+    expect(MAX_INFLIGHT_REQUESTS).toBe(10);
+    expect(decideAdaptivePacing(createAdaptivePacingState(), 0)).toEqual({
+      delayMs: 0,
+      reasons: [],
+    });
+  });
+
+  it("adds a finite cooldown only after four creates inside 30 seconds", () => {
+    let state = createAdaptivePacingState();
+    for (const now of [0, 6000, 12_000, 18_000]) {
+      state = recordSuccessfulCreate(state, now);
+    }
+
+    expect(decideAdaptivePacing(state, 20_000)).toEqual({
+      delayMs: ADAPTIVE_BURST_COOLDOWN_MS,
+      reasons: ["burst"],
+    });
+    expect(decideAdaptivePacing(state, 48_001)).toEqual({
+      delayMs: 0,
+      reasons: [],
+    });
+  });
+
+  it("steps challenge backoff to a cap and recovers after healthy creates", () => {
+    let state = createAdaptivePacingState();
+    for (let index = 0; index < 10; index += 1) {
+      state = recordChallenge(state);
+    }
+    expect(decideAdaptivePacing(state, 0).delayMs).toBe(
+      ADAPTIVE_CHALLENGE_BACKOFF_MAX_MS
+    );
+
+    state = recordSuccessfulCreate(state, 0);
+    state = recordSuccessfulCreate(state, 40_000);
+    expect(state.challengeLevel).toBe(4);
+    state = recordSuccessfulCreate(state, 80_000);
+    expect(state.challengeLevel).toBe(3);
+    expect(decideAdaptivePacing(state, 80_001).delayMs).toBe(45_000);
+  });
+
+  it("uses the larger delay when burst and challenge overlap", () => {
+    let state = recordChallenge(createAdaptivePacingState());
+    for (const now of [0, 1000, 2000, 3000]) {
+      state = recordSuccessfulCreate(state, now);
+    }
+    state = recordChallenge(state);
+    state = recordChallenge(state);
+
+    expect(decideAdaptivePacing(state, 4000)).toEqual({
+      delayMs: 30_000,
+      reasons: ["burst", "challenge"],
+    });
+  });
+
+  it("uses abortable sleep so Stop interrupts a cooldown before Create", async () => {
+    const state = recordChallenge(createAdaptivePacingState());
+    let aborted = false;
+    const sleep = vi.fn(async (_ms: number, _isAborted: () => boolean) => {
+      aborted = true;
+    });
+
+    const decision = await waitForAdaptivePacing(
+      decideAdaptivePacing(state, 0),
+      sleep,
+      () => aborted
+    );
+
+    expect(decision.delayMs).toBe(15_000);
+    expect(sleep).toHaveBeenCalledWith(15_000, expect.any(Function));
+    expect(aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the existing 3–9 second baseline jitter and maximum 10 in-flight requests unchanged
- add one shared adaptive pacing policy for serial, queue, and duration-retry Create paths
- insert abortable burst cooldowns and capped challenge backoff, then recover stepwise after healthy creates
- record only visible Turnstile/CAPTCHA waits from the #2471 detection path; no challenge bypass is attempted

## Official documentation
- Cloudflare Turnstile client-side rendering and widget visibility/lifecycle: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/

## Verification
- `pnpm --dir extensions/suno-helper test` (1300 passed)
- `pnpm --dir extensions/suno-helper compile`
- `pnpm --dir extensions/suno-helper check`
- `git diff --check`

Closes #2472
