### PR TITLE
fix(takt): runtime.prepare 設定を復旧し sandbox 権限エラーを解消 (#2532)

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,3 +1,24 @@
+# automation リポジトリの takt 設定
+# provider / model / language / concurrency はグローバル設定 (~/.takt/config.yaml) を継承する。
+
+# sandbox 化された worker の direnv / lefthook セットアップ停滞対策（issue #1999）と、
+# sibling worktree 由来 path の持ち込み遮断（issue #2163）。
+# bb9d9dd9 での config 削除時に消失し、~/.cache/uv・.git/hooks への sandbox
+# 権限エラーが再発したため復旧する（issue #2532）。
+# runtime-prepare.sh の stdout（KEY=VALUE）が全 worker の環境へ注入され、
+# TMPDIR / XDG_CACHE_HOME / XDG_CONFIG_HOME / XDG_DATA_HOME / XDG_STATE_HOME /
+# UV_CACHE_DIR を current TAKT_RUNTIME_ROOT 配下へ再構成して direnv allow を通し、
+# lefthook install はスキップさせる（ゲートは CI 側で担保）。
+runtime:
+  prepare:
+    - .takt/runtime-prepare.sh
+
+# トークン消費の計測。記録先: .takt/runs/<run>/logs/<session>-usage-events.phase.jsonl
+observability:
+  enabled: true
+  usage_events_phase: true
+
+# レビュワーペルソナは Claude provider（issue #2518）
 persona_providers:
   ai-antipattern-reviewer:
     provider: claude


### PR DESCRIPTION
Closes #2532

## 概要

takt run のログで多発していた sandbox 権限エラー（`~/.cache/uv` を開けない / `.git/hooks` へ書き込めない）を、`.takt/config.yaml` の `runtime.prepare` 復旧で解消する。

## 原因

- 7/23〜7/24 の run 10 件中 6 件で、worker が `sandbox が /Users/mba/.cache/uv を開けず起動前に失敗` → 一時 `UV_CACHE_DIR` への切替を毎回自力で発見してリトライ、という停滞が発生
- bootstrap（lefthook install）も worktree の `.git/hooks` 書き込み拒否で反復失敗
- 原因は bb9d9dd9（7/19）で `.takt/config.yaml` ごと削除された際に、issue #1999 / #2163 で導入済みだった `runtime.prepare`（`.takt/runtime-prepare.sh` による TMPDIR / XDG_* / UV_CACHE_DIR / YOUTUBE_AUTOMATION_SKIP_LEFTHOOK 注入）も消失したこと。#2518 の config 再作成では `persona_providers` のみ復元されていた

## 変更

- `runtime.prepare: [.takt/runtime-prepare.sh]` を復旧（コメントで消失経緯を明記）
- `observability`（usage_events_phase）を復旧
- 既存の `persona_providers`（#2518）は維持

## 検証

- `TAKT_RUNTIME_ROOT` を与えて `.takt/runtime-prepare.sh` を実行し、UV_CACHE_DIR / YOUTUBE_AUTOMATION_SKIP_LEFTHOOK を含む KEY=VALUE 出力を確認
- takt v0.52.0 の実装で、`runtime` / `observability` / `persona_providers` が project config の有効キーであること、および解決順が project → global（project 優先）であることを確認（`resolveConfigValue.js` の `DEFAULT_RULE: layers ['local','global']`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)