### PR TITLE
feat(takt): runtime-prepare で .venv を事前同期し worker の uv cache 依存を解消 (#2539)

### DIFF
--- a/.takt/runtime-prepare.sh
+++ b/.takt/runtime-prepare.sh
@@ -29,6 +29,19 @@ uv_cache_dir="${cache_dir}/uv"
 
 mkdir -p "$tmp_dir" "$cache_dir" "$config_dir" "$data_dir" "$state_dir" "$uv_cache_dir"
 
+# worker sandbox は既定の ~/.cache/uv を開けず、隔離 UV_CACHE_DIR も run ごとに
+# 空で始まるため、worker 側の初回 uv sync が全依存を再取得していた（issue #2539）。
+# 本スクリプトは takt 本体が sandbox 外で実行するため、ここで共有キャッシュ
+# （プロセス既定の UV_CACHE_DIR）を使って .venv を事前同期する。worker の
+# uv run は同期済み .venv の検証だけになる。stdout は KEY=VALUE 契約のため
+# uv の出力は stderr へ流し、失敗しても run は止めない（worker 側の同期に
+# フォールバックする fail-open）
+if [ -f pyproject.toml ] && command -v uv >/dev/null 2>&1; then
+  if ! uv sync --quiet 1>&2; then
+    echo "warning: runtime-prepare の uv sync に失敗しました。worker 側の同期にフォールバックします。" >&2
+  fi
+fi
+
 echo "TMPDIR=${tmp_dir}"
 echo "XDG_CACHE_HOME=${cache_dir}"
 echo "XDG_CONFIG_HOME=${config_dir}"


### PR DESCRIPTION
Closes #2539

## 概要

takt worker の隔離 `UV_CACHE_DIR` は run ごとに空で始まり、初回 `uv sync` が全依存を再取得していた。`.takt/runtime-prepare.sh` は takt 本体が **sandbox 外で** 実行する（`runtime-environment.js` の `spawnSync`、cwd = clone/worktree）ことを利用し、共有キャッシュ（プロセス既定の UV_CACHE_DIR）で `.venv` をここで事前同期する。

- worker の `uv run` は同期済み `.venv` の検証だけになり、隔離 cache が冷えていてもダウンロード・共有 cache アクセスが発生しない
- stdout の KEY=VALUE 契約を守るため uv の出力は stderr へ流す
- 失敗は warning に留め、worker 側の同期へフォールバック（fail-open）
- 検討済み代替案: `~/.cache/uv`（3.2GB / 25万ファイル）の APFS CoW 複製は実測 42 秒/run のため不採用

## 検証

- cold `.venv` を削除して `TAKT_RUNTIME_ROOT` 付きで実行 → stdout は KEY=VALUE のみ、`.venv` 同期済み、exit 0
- worker 相当環境（隔離空 UV_CACHE_DIR + runtime env）で `uv run python -c "import youtube_automation"` → 0.1 秒、cache 書込み 12KB（ダウンロードなし）

## 備考

- #2533（runtime.prepare 設定の復旧）がマージされて初めて本スクリプトが実行される
- #2538（lefthook 廃止）が同ファイルの別 hunk（SKIP_LEFTHOOK 行の削除）を変更するが、hunk が独立しているため両立する

🤖 Generated with [Claude Code](https://claude.com/claude-code)