### PR TITLE
test: mtime 失敗テストの teardown FileNotFoundError を修正する (#2540)

### DIFF
--- a/tests/test_doctor_fix_client_secrets.py
+++ b/tests/test_doctor_fix_client_secrets.py
@@ -179,10 +179,14 @@ def test_fix_reports_mtime_failure_and_preserves_source(tmp_path, monkeypatch, c
     _write_client_secret(source, project_id="target-project")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     original_fstat = doctor.os.fstat
+    # inode は patch 前に取得する。patch 後に source.stat() を呼ぶと、
+    # tmp_path の retention cleanup (rmtree) が monkeypatch の復元より先に
+    # source を削除した場合、teardown 中の fstat 経由で FileNotFoundError になる
+    source_ino = source.stat().st_ino
 
     def fail_candidate_stat(descriptor: int):
         metadata = original_fstat(descriptor)
-        if metadata.st_ino == source.stat().st_ino:
+        if metadata.st_ino == source_ino:
             raise OSError("candidate disappeared")
         return metadata
 


### PR DESCRIPTION
Closes #2540

## 原因

`tmp_path_retention_policy = "failed"`（pyproject.toml）により、テスト成功時に tmp_path fixture の teardown が `shutil.rmtree` で一時ディレクトリを削除する。この rmtree（fd ベース走査）が `os.fstat` を呼ぶ時点で monkeypatch による `doctor.os.fstat` の差し替えがまだ復元されておらず、`fail_candidate_stat` 内の `source.stat()` が rmtree に削除済みのファイルを stat して FileNotFoundError になっていた。

`-o tmp_path_retention_policy=all` では 18 passed になることで rmtree 起因を確認済み。

## 修正

比較用の inode を monkeypatch **前に一度だけ**取得してクロージャに閉じ込め、パッチ後の経路（teardown 中の rmtree を含む）から `source.stat()` を呼ばないようにした。

## 検証

- `uv run pytest tests/test_doctor_fix_client_secrets.py -q` → 18 passed（teardown ERROR なし）

tests のみの変更のため CHANGELOG ゲート対象外（`skip-changelog`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)