### PR TITLE
fix(analytics): retention照合の不正入力を拒否する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(analytics)`: retention timeline が不正な retention 数値（変換不能・NaN・Infinity）や非有限の動画尺を `ValidationError` として利用者向けに拒否し、壊れたJSON・曖昧なanalysis参照・duration fallback・未照合・Markdown escaping の境界を直接検証した（#2612, #2636）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/utils/retention_timeline.py
+++ b/src/youtube_automation/utils/retention_timeline.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from dataclasses import asdict, dataclass
 from itertools import pairwise
@@ -91,16 +92,23 @@ def detect_retention_drops(
         try:
             elapsed = float(raw["elapsed_ratio"])
             watch = float(raw["watch_ratio"])
+            relative_raw = raw.get("relative_performance")
+            relative = float(relative_raw) if relative_raw is not None else None
         except (KeyError, TypeError, ValueError) as error:
-            raise ValidationError("retention_curve の elapsed_ratio / watch_ratio が不正です") from error
+            raise ValidationError("retention_curve の数値が不正です") from error
+        if (
+            not math.isfinite(elapsed)
+            or not math.isfinite(watch)
+            or (relative is not None and not math.isfinite(relative))
+        ):
+            raise ValidationError("retention_curve の数値が不正です")
         if not 0 <= elapsed <= 1 or watch < 0:
             raise ValidationError("retention_curve の値が範囲外です")
-        relative = raw.get("relative_performance")
         points.append(
             {
                 "elapsed_ratio": elapsed,
                 "watch_ratio": watch,
-                "relative_performance": float(relative) if relative is not None else None,
+                "relative_performance": relative,
             }
         )
 
@@ -129,7 +137,7 @@ def correlate_retention_timeline(
     threshold: float = DEFAULT_DROP_THRESHOLD,
 ) -> dict[str, object]:
     """drop 地点を scene / BGM タイムラインへ割り当てる。"""
-    if duration_seconds <= 0:
+    if not math.isfinite(duration_seconds) or duration_seconds <= 0:
         raise ValidationError("duration_seconds は正の値である必要があります")
     if not isinstance(video_analysis, dict):
         raise ValidationError("video_analysis JSON は object である必要があります")

--- a/tests/test_retention_timeline.py
+++ b/tests/test_retention_timeline.py
@@ -14,6 +14,7 @@ from youtube_automation.utils.retention_timeline import (
     detect_retention_drops,
     parse_iso8601_duration,
     parse_timestamp,
+    render_retention_report,
 )
 
 
@@ -96,6 +97,11 @@ def test_parses_seconds_range_from_its_start() -> None:
     assert parse_timestamp("12.5-30s") == 12.5
 
 
+@pytest.mark.parametrize("timestamp", [True, -1, "1:60", "1:00:60", "not-a-time", None])
+def test_invalid_timestamps_are_ignored(timestamp: object) -> None:
+    assert parse_timestamp(timestamp) is None
+
+
 def test_threshold_is_configurable_and_validated() -> None:
     curve = [
         {"elapsed_ratio": 0.0, "watch_ratio": 1.0},
@@ -113,6 +119,88 @@ def test_threshold_is_configurable_and_validated() -> None:
 )
 def test_parses_youtube_duration(duration: str, expected: float) -> None:
     assert parse_iso8601_duration(duration) == expected
+
+
+@pytest.mark.parametrize("duration", ["not-a-duration", "PT0S", "P1D"])
+def test_rejects_invalid_or_non_positive_youtube_duration(duration: str) -> None:
+    with pytest.raises(ValidationError, match="動画尺"):
+        parse_iso8601_duration(duration)
+
+
+@pytest.mark.parametrize(
+    "invalid_point",
+    [
+        {},
+        {"elapsed_ratio": "invalid", "watch_ratio": 0.8},
+        {"elapsed_ratio": -0.1, "watch_ratio": 0.8},
+        {"elapsed_ratio": 0.1, "watch_ratio": -0.1},
+        {"elapsed_ratio": 0.1, "watch_ratio": 0.8, "relative_performance": "invalid"},
+        {"elapsed_ratio": 0.1, "watch_ratio": float("nan")},
+    ],
+)
+def test_rejects_invalid_retention_curve_points(invalid_point: dict[str, object]) -> None:
+    with pytest.raises(ValidationError, match="retention_curve"):
+        detect_retention_drops(
+            [
+                {"elapsed_ratio": 0.0, "watch_ratio": 1.0},
+                invalid_point,
+            ]
+        )
+
+
+@pytest.mark.parametrize("duration_seconds", [0, -1, float("nan"), float("inf")])
+def test_rejects_invalid_duration_seconds(duration_seconds: float) -> None:
+    with pytest.raises(ValidationError, match="duration_seconds"):
+        correlate_retention_timeline(
+            video_id="VID123",
+            duration_seconds=duration_seconds,
+            retention_curve=[],
+            video_analysis={},
+        )
+
+
+def test_marks_drop_unmatched_when_scene_and_bgm_do_not_match() -> None:
+    result = correlate_retention_timeline(
+        video_id="VID123",
+        duration_seconds=600,
+        retention_curve=[
+            {"elapsed_ratio": 0.0, "watch_ratio": 1.0},
+            {"elapsed_ratio": 0.1, "watch_ratio": 0.9},
+        ],
+        video_analysis={
+            "scene_timeline": [{"start": "invalid", "summary": "scene"}],
+            "bgm_arc": {"segments": [{"start": "2:00", "track": "later track"}]},
+        },
+    )
+
+    assert result["drops"][0]["scene"] is None
+    assert result["drops"][0]["bgm"] is None
+    assert result["drops"][0]["mapping_status"] == "unmatched"
+
+
+def test_markdown_report_escapes_table_pipes_and_newlines() -> None:
+    result = correlate_retention_timeline(
+        video_id="VID123",
+        duration_seconds=600,
+        retention_curve=[
+            {"elapsed_ratio": 0.0, "watch_ratio": 1.0},
+            {"elapsed_ratio": 0.1, "watch_ratio": 0.9},
+        ],
+        video_analysis={
+            "scene_timeline": [{"start": "0:00", "summary": "scene | one\nsecond line"}],
+            "bgm_arc": {"segments": [{"start": "0:00", "track": "track | one\nsecond line"}]},
+        },
+    )
+
+    markdown = render_retention_report(
+        result,
+        analytics_path=Path("data/analytics.json"),
+        analysis_path=Path("data/analysis.json"),
+    )
+
+    assert "scene \\| one second line" in markdown
+    assert "track \\| one second line" in markdown
+    assert "scene | one" not in markdown
 
 
 def test_cli_writes_json_and_markdown_reports(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -176,6 +264,47 @@ def test_cli_rejects_slug_traversal(tmp_path: Path, monkeypatch, caplog) -> None
     assert cli.main(["--video", "VID123", "--slug", "../../outside"]) == 2
 
     assert "--slug が不正" in caplog.text
+
+
+def test_cli_returns_two_for_broken_analytics_json(tmp_path: Path, monkeypatch, caplog) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "analytics_data_20260718.json").write_text("{broken", encoding="utf-8")
+    monkeypatch.setattr(cli, "channel_dir", lambda: tmp_path)
+
+    assert cli.main(["--video", "VID123"]) == 2
+    assert "analytics_data JSON を読み込めません" in caplog.text
+
+
+def test_cli_rejects_ambiguous_video_analysis(tmp_path: Path, monkeypatch, caplog) -> None:
+    _write_analytics(tmp_path)
+    for slug in ("first", "second"):
+        analysis_dir = tmp_path / "data" / "video_analysis" / slug
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "VID123.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "channel_dir", lambda: tmp_path)
+
+    assert cli.main(["--video", "VID123"]) == 2
+    assert "video_analysis が複数あります" in caplog.text
+    assert "--slug で指定してください" in caplog.text
+
+
+def test_cli_uses_analysis_duration_when_analytics_duration_is_missing(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_analytics(tmp_path)
+    analytics_path = tmp_path / "data" / "analytics_data_20260718.json"
+    analytics = json.loads(analytics_path.read_text(encoding="utf-8"))
+    analytics["video_analytics"] = {}
+    analytics_path.write_text(json.dumps(analytics), encoding="utf-8")
+    analysis_dir = tmp_path / "data" / "video_analysis" / "own"
+    analysis_dir.mkdir(parents=True)
+    (analysis_dir / "VID123.json").write_text(
+        json.dumps({"duration_seconds": 321}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli, "channel_dir", lambda: tmp_path)
+
+    assert cli.main(["--video", "VID123"]) == 0
+    assert json.loads(capsys.readouterr().out)["duration_seconds"] == 321
 
 
 def _write_analytics(root: Path) -> None:


### PR DESCRIPTION
## 対応 issue

Closes #2612
Closes #2636

## 変更概要

- 壊れたanalytics JSON、同一video IDの曖昧なanalysis、analysis側duration fallbackをCLI main()で検証
- retention数値の変換不能・NaN・Infinityと非有限durationをValidationErrorへ統一
- 不正timestamp、scene/BGM未照合、Markdown tableのpipe/newline escapingを検証

## 検証

- nix develop --command uv run pytest -q tests/test_retention_timeline.py: 36 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: 658 files already formatted
- nix develop --command uv run yt-skills lint: 57 skills passed
- nix develop --command uv run pytest -q: 6895 passed, 1 skipped
- git diff --check: passed