### PR TITLE
fix(playlist): CLI終了契約を明示する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(playlist)`: playlist manager/status CLI が成功・中断・外部失敗を明示的な終了コードで返し、status/help/引数不備では不要な書き込み認証を開始せず、init/status/clean/assign の引数伝播と表示を command-level test で担保した（#2653）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/youtube/playlist_manager.py
+++ b/src/youtube_automation/commands/youtube/playlist_manager.py
@@ -2,13 +2,15 @@
 
 import argparse
 import logging
+import sys
 
 from youtube_automation.domains.uploads.playlists import PlaylistManager
 from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
+from youtube_automation.infrastructure.errors import AutomationError
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(description="YouTube プレイリストの作成・割り当て・整理を行う")
     parser.add_argument("--init", action="store_true", help="プレイリスト作成 + 全動画割り当て")
@@ -19,24 +21,31 @@ def main() -> None:
         "--clean-deleted", action="store_true", help="全プレイリストから削除済み/非公開動画のエントリを除去"
     )
     parser.add_argument("--dry-run", action="store_true", help="ドライラン（実行せず計画のみ表示）")
-    args = parser.parse_args()
-    manager = PlaylistManager(clients=YouTubeClients(full_handler=YouTubeOAuthHandler()))
+    args = parser.parse_args(argv)
+    try:
+        if args.status:
+            from youtube_automation.commands.youtube.playlist_status import PlaylistStatusViewer
 
-    if args.init:
-        manager.init(dry_run=args.dry_run)
-    elif args.status:
-        from youtube_automation.commands.youtube.playlist_status import PlaylistStatusViewer
-
-        PlaylistStatusViewer().show_status()
-    elif args.clean_deleted:
-        results = manager.clean_deleted_entries(dry_run=args.dry_run)
-        print(f"完了: {sum(results.values())} 件除去")
-    elif args.assign:
-        if not args.theme:
+            PlaylistStatusViewer().show_status()
+            return 0
+        if args.assign and not args.theme:
             parser.error("--assign には --theme が必要です")
-        print(f"割り当て: {manager.assign_video(args.assign, args.theme, dry_run=args.dry_run)}")
-    else:
-        parser.print_help()
+        if not (args.init or args.clean_deleted or args.assign):
+            parser.print_help()
+            return 0
+
+        manager = PlaylistManager(clients=YouTubeClients(full_handler=YouTubeOAuthHandler()))
+        if args.init:
+            manager.init(dry_run=args.dry_run)
+        elif args.clean_deleted:
+            results = manager.clean_deleted_entries(dry_run=args.dry_run)
+            print(f"完了: {sum(results.values())} 件除去")
+        else:
+            print(f"割り当て: {manager.assign_video(args.assign, args.theme, dry_run=args.dry_run)}")
+        return 0
+    except AutomationError as error:
+        print(f"エラー: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/youtube/playlist_status.py
+++ b/src/youtube_automation/commands/youtube/playlist_status.py
@@ -112,18 +112,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
 
-def main(argv: list[str] | None = None):
+def main(argv: list[str] | None = None) -> int:
     # 引数解析を先に済ませることで、CHANNEL_DIR 未設定でも --help は exit 0 で返る（#2308）
     build_parser().parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     try:
         viewer = PlaylistStatusViewer()
         viewer.show_status()
+        return 0
     except KeyboardInterrupt:
         print("\n中断されました")
+        return 0
     except Exception as e:
         print(f"エラー: {e}")
-        sys.exit(1)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_playlist_cli.py
+++ b/tests/test_playlist_cli.py
@@ -1,0 +1,112 @@
+"""Playlist command adapter の実行時契約。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from youtube_automation.commands.youtube import playlist_manager, playlist_status
+from youtube_automation.infrastructure.errors import YouTubeAPIError
+
+
+def _manager_cli(monkeypatch):
+    manager = MagicMock()
+    manager.clean_deleted_entries.return_value = {"first": 2, "second": 1}
+    manager.assign_video.return_value = ["all", "focus"]
+    manager_class = MagicMock(return_value=manager)
+    clients = MagicMock(return_value=object())
+    handler = MagicMock(return_value=object())
+    monkeypatch.setattr(playlist_manager, "PlaylistManager", manager_class)
+    monkeypatch.setattr(playlist_manager, "YouTubeClients", clients)
+    monkeypatch.setattr(playlist_manager, "YouTubeOAuthHandler", handler)
+    return manager, manager_class, clients, handler
+
+
+def test_manager_cli_init_forwards_dry_run(monkeypatch):
+    manager, manager_class, clients, handler = _manager_cli(monkeypatch)
+
+    assert playlist_manager.main(["--init", "--dry-run"]) == 0
+
+    handler.assert_called_once_with()
+    clients.assert_called_once_with(full_handler=handler.return_value)
+    manager_class.assert_called_once_with(clients=clients.return_value)
+    manager.init.assert_called_once_with(dry_run=True)
+
+
+def test_manager_cli_status_uses_viewer_without_full_auth(monkeypatch):
+    _, manager_class, clients, handler = _manager_cli(monkeypatch)
+    viewer = MagicMock()
+    monkeypatch.setattr(playlist_status, "PlaylistStatusViewer", MagicMock(return_value=viewer))
+
+    assert playlist_manager.main(["--status"]) == 0
+
+    viewer.show_status.assert_called_once_with()
+    manager_class.assert_not_called()
+    clients.assert_not_called()
+    handler.assert_not_called()
+
+
+def test_manager_cli_clean_deleted_prints_total(monkeypatch, capsys):
+    manager, _, _, _ = _manager_cli(monkeypatch)
+
+    assert playlist_manager.main(["--clean-deleted", "--dry-run"]) == 0
+
+    manager.clean_deleted_entries.assert_called_once_with(dry_run=True)
+    assert capsys.readouterr().out == "完了: 3 件除去\n"
+
+
+def test_manager_cli_assign_forwards_video_theme_and_dry_run(monkeypatch, capsys):
+    manager, _, _, _ = _manager_cli(monkeypatch)
+
+    assert playlist_manager.main(["--assign", "VIDEO123", "--theme", "night cafe", "--dry-run"]) == 0
+
+    manager.assign_video.assert_called_once_with("VIDEO123", "night cafe", dry_run=True)
+    assert capsys.readouterr().out == "割り当て: ['all', 'focus']\n"
+
+
+def test_manager_cli_rejects_assign_without_theme_before_auth(monkeypatch, capsys):
+    _, manager_class, clients, handler = _manager_cli(monkeypatch)
+
+    with pytest.raises(SystemExit) as error:
+        playlist_manager.main(["--assign", "VIDEO123"])
+
+    assert error.value.code == 2
+    assert "--assign には --theme が必要です" in capsys.readouterr().err
+    manager_class.assert_not_called()
+    clients.assert_not_called()
+    handler.assert_not_called()
+
+
+def test_manager_cli_returns_one_for_domain_error(monkeypatch, capsys):
+    manager, _, _, _ = _manager_cli(monkeypatch)
+    manager.init.side_effect = YouTubeAPIError("quota exceeded")
+
+    assert playlist_manager.main(["--init"]) == 1
+    assert capsys.readouterr().err == "エラー: quota exceeded\n"
+
+
+def test_status_cli_runs_viewer(monkeypatch):
+    viewer = MagicMock()
+    monkeypatch.setattr(playlist_status, "PlaylistStatusViewer", MagicMock(return_value=viewer))
+
+    assert playlist_status.main([]) == 0
+    viewer.show_status.assert_called_once_with()
+
+
+def test_status_cli_keyboard_interrupt_is_clean_exit(monkeypatch, capsys):
+    viewer = MagicMock()
+    viewer.show_status.side_effect = KeyboardInterrupt
+    monkeypatch.setattr(playlist_status, "PlaylistStatusViewer", MagicMock(return_value=viewer))
+
+    assert playlist_status.main([]) == 0
+    assert "中断されました" in capsys.readouterr().out
+
+
+def test_status_cli_external_failure_returns_one(monkeypatch, capsys):
+    monkeypatch.setattr(
+        playlist_status,
+        "PlaylistStatusViewer",
+        MagicMock(side_effect=RuntimeError("API unavailable")),
+    )
+
+    assert playlist_status.main([]) == 1
+    assert capsys.readouterr().out == "エラー: API unavailable\n"


### PR DESCRIPTION
## 対応 issue

Closes #2653

## 変更概要

- playlist manager/status CLIが成功・中断・外部失敗を0/1で返す契約を追加
- status/help/assign引数不備では不要な書き込み認証を開始しない
- init/status/clean/assignのdoubleへの引数、表示、終了をcommand-level testで検証
- 既存pagination/API失敗回帰を関連テストと合わせて確認

## 検証

- nix develop --command uv run pytest -q tests/test_playlist_manager.py tests/test_playlist_status.py tests/test_playlist_cli.py tests/test_quota_read_wiring.py: 86 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: 659 files already formatted
- nix develop --command uv run yt-skills lint: 57 skills passed
- nix develop --command uv run pytest -q: 6880 passed, 1 skipped
- git diff --check: passed