### PR TITLE
test(media): benchmark候補名固定テストを削除する

### DIFF
--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -1518,14 +1518,6 @@ def test_overlay_explicit_nvenc_uses_codec_specific_options(tmp_path: Path) -> N
     assert "requested=h264_nvenc, selected=h264_nvenc" in result.stdout
 
 
-def test_overlay_benchmark_script_covers_required_candidates() -> None:
-    benchmark = (_SCRIPT_PATH.parent / "benchmark_overlay_encoders.sh").read_text(encoding="utf-8")
-    for candidate in ("baseline", "software-veryfast", "twostage", "h264_videotoolbox", "h264_nvenc"):
-        assert candidate in benchmark
-    assert "/usr/bin/time -p" in benchmark
-    assert "ssim" in benchmark
-
-
 def test_target_video_duration_unset_keeps_legacy_behavior(tmp_path: Path) -> None:
     """env / channel override が無ければ従来動作 (音声側 -stream_loop 無し)."""
     result, ffmpeg_log = _run_generate_videos(


### PR DESCRIPTION
## 対応 issue

Closes #2664

## 変更概要

- benchmark shell本文の候補名・time・ssim文字列だけを固定するテストを削除
- encoder可用性、start failure fallback、codec固有optionの実行テストは維持
- 本番scriptと必要な挙動は変更しない

## 検証

- nix develop --command uv run pytest -q tests/test_generate_videos_script.py -k "overlay and (hardware or nvenc)": 4 passed, 104 deselected
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: 658 files already formatted
- nix develop --command uv run yt-skills lint: 57 skills passed
- nix develop --command uv run pytest -q: 6870 passed, 1 skipped
- git diff --check: passed