### PR TITLE
test(media): audio unit属性固定テストを削除する

### DIFF
--- a/tests/test_generate_music_unit_resolver.py
+++ b/tests/test_generate_music_unit_resolver.py
@@ -38,14 +38,3 @@ def test_unit_for_audio_unknown_model_raises_value_error():
     """
     with pytest.raises(ValueError, match="no-such-model"):
         unit_for_audio("no-such-model")
-
-
-def test_unit_for_audio_is_publicly_exported():
-    """Given the audio domain module
-    When `unit_for_audio` を import する
-    Then underscore-private でなく、scripts 跨ぎ import に耐える公開 API として参照できる。
-    """
-    from youtube_automation.domains.media import audio_units
-
-    assert hasattr(audio_units, "unit_for_audio")
-    assert audio_units.unit_for_audio.__name__ == "unit_for_audio"


### PR DESCRIPTION
## 対応 issue

Closes #2665

## 変更概要

- moduleのhasattrと関数名だけを固定するテストを削除
- model→unit変換と未知modelのfail-fastを検証する3ケースを維持
- 本番moduleと公開挙動は変更しない

## 検証

- nix develop --command uv run pytest -q tests/test_generate_music_unit_resolver.py: 3 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: 658 files already formatted
- nix develop --command uv run yt-skills lint: 57 skills passed
- nix develop --command uv run pytest -q: 6870 passed, 1 skipped
- git diff --check: passed