### PR TITLE
test: Omni生成の失敗境界を網羅 (#2675)

### DIFF
--- a/tests/test_omni_generator.py
+++ b/tests/test_omni_generator.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import httpx
+import pytest
 
 from youtube_automation.utils import omni_generator
 
@@ -133,3 +134,137 @@ def test_interactions_timeout_returns_false(tmp_path: Path) -> None:
 
     assert result is False
     assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "output_video",
+    [
+        None,
+        SimpleNamespace(data=None, uri=None),
+        SimpleNamespace(data="not valid base64!", uri=None),
+    ],
+    ids=["missing-video", "missing-data-and-uri", "invalid-base64"],
+)
+def test_invalid_inline_responses_fail_without_output_or_smoothing(tmp_path: Path, output_video: object) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    client.interactions.create.return_value = SimpleNamespace(output_video=output_video)
+
+    with patch.object(omni_generator, "smooth_loop") as smooth:
+        result = omni_generator.generate_loop_video(client, image, output, omni_generator.DEFAULT_MODEL, "prompt")
+
+    assert result is False
+    assert not output.exists()
+    client.files.get.assert_not_called()
+    client.files.download.assert_not_called()
+    smooth.assert_not_called()
+
+
+def test_malformed_uri_fails_without_files_api_or_output(tmp_path: Path) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    client.interactions.create.return_value = SimpleNamespace(
+        output_video=SimpleNamespace(data=None, uri="https://example.test/not-a-file")
+    )
+
+    with patch.object(omni_generator, "smooth_loop") as smooth:
+        result = omni_generator.generate_loop_video(client, image, output, omni_generator.DEFAULT_MODEL, "prompt")
+
+    assert result is False
+    assert not output.exists()
+    client.files.get.assert_not_called()
+    client.files.download.assert_not_called()
+    smooth.assert_not_called()
+
+
+def test_files_get_error_fails_without_download_or_output(tmp_path: Path) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    client.interactions.create.return_value = SimpleNamespace(
+        output_video=SimpleNamespace(data=None, uri="https://example.test/v1beta/files/get-error")
+    )
+    client.files.get.side_effect = httpx.ReadError("state request failed")
+
+    with patch.object(omni_generator, "smooth_loop") as smooth:
+        result = omni_generator.generate_loop_video(client, image, output, omni_generator.DEFAULT_MODEL, "prompt")
+
+    assert result is False
+    assert not output.exists()
+    client.files.download.assert_not_called()
+    smooth.assert_not_called()
+
+
+def test_files_download_error_fails_without_output_or_smoothing(tmp_path: Path) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    uri = "https://example.test/v1beta/files/download-error"
+    client.interactions.create.return_value = SimpleNamespace(output_video=SimpleNamespace(data=None, uri=uri))
+    client.files.get.return_value = SimpleNamespace(state="ACTIVE")
+    client.files.download.side_effect = httpx.ReadError("download failed")
+
+    with patch.object(omni_generator, "smooth_loop") as smooth:
+        result = omni_generator.generate_loop_video(client, image, output, omni_generator.DEFAULT_MODEL, "prompt")
+
+    assert result is False
+    assert not output.exists()
+    client.files.download.assert_called_once_with(file=uri)
+    smooth.assert_not_called()
+
+
+def test_uri_video_cancelled_state_returns_false_without_download_or_output(tmp_path: Path) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    client.interactions.create.return_value = SimpleNamespace(
+        output_video=SimpleNamespace(data=None, uri="https://example.test/v1beta/files/cancelled-id")
+    )
+    client.files.get.return_value = SimpleNamespace(state="CANCELLED")
+
+    with patch.object(omni_generator, "smooth_loop") as smooth:
+        result = omni_generator.generate_loop_video(client, image, output, omni_generator.DEFAULT_MODEL, "prompt")
+
+    assert result is False
+    assert not output.exists()
+    client.files.download.assert_not_called()
+    smooth.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("compression", "expected_crf", "expected_preset"),
+    [
+        ({"enabled": True, "crf": 27, "preset": "fast"}, 27, "fast"),
+        ({"enabled": False, "crf": 27, "preset": "fast"}, 18, "slow"),
+    ],
+    ids=["configured", "disabled"],
+)
+def test_smooth_failure_keeps_generated_video_and_resolves_compression(
+    tmp_path: Path,
+    compression: dict[str, object],
+    expected_crf: int,
+    expected_preset: str,
+) -> None:
+    image, output = _paths(tmp_path)
+    client = MagicMock()
+    client.interactions.create.return_value = SimpleNamespace(
+        output_video=SimpleNamespace(data=base64.b64encode(b"generated").decode(), uri=None)
+    )
+
+    with patch.object(omni_generator, "smooth_loop", return_value=False) as smooth:
+        result = omni_generator.generate_loop_video(
+            client,
+            image,
+            output,
+            omni_generator.DEFAULT_MODEL,
+            "prompt",
+            compression=compression,
+        )
+
+    assert result is True
+    assert output.read_bytes() == b"generated"
+    client.files.download.assert_not_called()
+    smooth.assert_called_once_with(
+        output,
+        crossfade_sec=0.5,
+        trim_tail_sec=1.0,
+        crf=expected_crf,
+        preset=expected_preset,
+    )


### PR DESCRIPTION
## 対応 issue

Closes #2675

## 変更概要

- 動画欠落、不正Base64、data/URI欠落、URI不正を戻り値・ファイル・呼出有無で検証
- Files API get/download例外とCANCELLED経路を検証
- smooth失敗後も生成済み動画を保持し、compression設定を解決する契約を検証

## 検証

- `nix develop --command uv run pytest -q tests/test_omni_generator.py` — 15 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6880 passed, 1 skipped