### PR TITLE
fix: VideoAnalyzerの応答境界を厳格化 (#2678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(video-analyze)`: Gemini が JSON object 以外を返した場合を明示的な `ValidationError` として扱い、解析失敗時に sleep や結果保存へ進まない境界を固定（#2678）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/utils/video_analyzer.py
+++ b/src/youtube_automation/utils/video_analyzer.py
@@ -162,10 +162,15 @@ def _parse_json_response(text: str) -> dict[str, Any]:
     stripped = _CODE_FENCE_HEAD.sub("", stripped)
     stripped = _CODE_FENCE_TAIL.sub("", stripped)
     try:
-        return json.loads(stripped)
+        payload = json.loads(stripped)
     except json.JSONDecodeError as err:
         # 握りつぶさず ValidationError へ昇格 (Fail Fast)
         raise ValidationError(f"Gemini レスポンスの JSON パースに失敗: {err}") from err
+    if not isinstance(payload, dict):
+        raise ValidationError(
+            f"Gemini レスポンスは JSON object である必要があります (received: {type(payload).__name__})"
+        )
+    return payload
 
 
 def _attach_metadata(

--- a/tests/test_video_analyze_cli.py
+++ b/tests/test_video_analyze_cli.py
@@ -22,6 +22,7 @@ from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.genai.errors import APIError
 
 from youtube_automation.commands.analytics.video_analyze import (
     _analysis_window_sec_from_config,
@@ -669,6 +670,26 @@ class TestRunAnalysisCache:
         assert analyzer.client.models.generate_content.call_count == 1
         assert failures == []
         assert analyzer.json_path(target).exists()
+
+    def test_sdk_failure_records_failure_without_saving(self):
+        target = VideoTarget(
+            video_id="FAILED",
+            slug="test",
+            url="https://www.youtube.com/watch?v=FAILED",
+            title="Failed video",
+        )
+        analyzer = MagicMock(spec=VideoAnalyzer)
+        analyzer.load_cached_json.return_value = None
+        analyzer.analyze_url.side_effect = APIError(503, {"message": "unavailable"})
+
+        results, failures = _run_analysis(analyzer=analyzer, targets=[target])
+
+        assert results == []
+        assert len(failures) == 1
+        assert failures[0]["video_id"] == "FAILED"
+        assert failures[0]["url"] == target.url
+        assert "unavailable" in failures[0]["error"]
+        analyzer.save_json.assert_not_called()
 
 
 class TestBuildParser:

--- a/tests/test_video_analyzer.py
+++ b/tests/test_video_analyzer.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.genai.errors import APIError
 
 from youtube_automation.infrastructure.errors import ValidationError
 from youtube_automation.utils.video_analyzer import (
@@ -174,6 +176,72 @@ class TestVideoAnalyzerAnalyzeUrl:
         # When/Then: 握りつぶさず ValidationError を投げる
         with pytest.raises(ValidationError):
             analyzer.analyze_url(_make_target())
+
+    @pytest.mark.parametrize("response_text", ["[]", "null"])
+    def test_raises_validation_error_on_non_object_json(self, tmp_path, response_text):
+        analyzer = VideoAnalyzer(
+            client=_make_client(response_text),
+            model="gemini-3.5-flash",
+            prompt="analyze",
+            delay_sec=7,
+            data_dir=tmp_path,
+            analysis_window_sec=900,
+        )
+
+        with patch("youtube_automation.utils.video_analyzer.time.sleep") as sleep:
+            with pytest.raises(ValidationError, match="JSON object"):
+                analyzer.analyze_url(_make_target())
+
+        sleep.assert_not_called()
+
+    def test_sdk_error_does_not_sleep(self, tmp_path):
+        client = MagicMock()
+        client.models.generate_content.side_effect = APIError(503, {"message": "unavailable"})
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-3.5-flash",
+            prompt="analyze",
+            delay_sec=7,
+            data_dir=tmp_path,
+            analysis_window_sec=900,
+        )
+
+        with patch("youtube_automation.utils.video_analyzer.time.sleep") as sleep:
+            with pytest.raises(APIError):
+                analyzer.analyze_url(_make_target())
+
+        sleep.assert_not_called()
+
+    def test_target_metadata_overwrites_conflicting_response_values(self, tmp_path):
+        target = _make_target()
+        payload = {
+            **_VALID_PAYLOAD,
+            "video_id": "wrong",
+            "slug": "wrong",
+            "url": "https://wrong.invalid",
+            "title": "wrong",
+            "model": "wrong",
+            "analysis_window_sec": -1,
+        }
+        analyzer = VideoAnalyzer(
+            client=_make_client(json.dumps(payload)),
+            model="gemini-3.5-flash",
+            prompt="analyze",
+            delay_sec=0,
+            data_dir=tmp_path,
+            analysis_window_sec=900,
+        )
+
+        result = analyzer.analyze_url(target)
+
+        assert {key: result[key] for key in ("video_id", "slug", "url", "title", "model", "analysis_window_sec")} == {
+            "video_id": target.video_id,
+            "slug": target.slug,
+            "url": target.url,
+            "title": target.title,
+            "model": "gemini-3.5-flash",
+            "analysis_window_sec": 900,
+        }
 
     def test_uses_target_url_in_request(self, tmp_path):
         # Given: 解析対象 URL
@@ -366,6 +434,22 @@ class TestVideoAnalyzerLoadCachedJson:
         assert cached is None
         assert "破損" in caplog.text
 
+    def test_returns_none_on_cache_read_os_error(self, tmp_path, caplog):
+        analyzer = self._make_analyzer(tmp_path)
+        target = _make_target()
+        path = analyzer.json_path(target)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+
+        with (
+            patch.object(Path, "read_text", side_effect=PermissionError("denied")),
+            caplog.at_level(logging.WARNING),
+        ):
+            cached = analyzer.load_cached_json(target)
+
+        assert cached is None
+        assert "denied" in caplog.text
+
     def test_returns_none_on_json_null(self, tmp_path, caplog):
         # Given: JSON としては valid だが object ではない null
         analyzer = self._make_analyzer(tmp_path)
@@ -484,6 +568,22 @@ class TestVideoAnalysisReport:
         assert "BAD1" in md
         # 失敗件数を示す手がかりがある
         assert ("失敗" in md) or ("failed" in md.lower())
+
+    def test_failure_rows_preserve_order_and_escape_pipes(self):
+        md = VideoAnalysisReport.render(
+            slug="test",
+            results=[],
+            failures=[
+                {"video_id": "FIRST", "url": "https://first", "error": "rate | limited"},
+                {"video_id": "SECOND", "url": "https://second", "error": "private"},
+            ],
+        )
+
+        first_row = "| FIRST | https://first | rate \\| limited |"
+        second_row = "| SECOND | https://second | private |"
+        assert first_row in md
+        assert second_row in md
+        assert md.index(first_row) < md.index(second_row)
 
     def test_render_handles_empty_results(self):
         # Given: 結果なし、失敗のみ


### PR DESCRIPTION
## 対応 issue

Closes #2678

## 変更概要

- Geminiの非object JSONをValidationErrorとしてfail-fast化
- SDK/parse失敗時のsleep抑止とtarget metadata上書きを検証
- cache読込OSError、failure表のpipe escape/順序を検証
- CLI上位フローでSDK失敗をfailuresへ積み、JSONを保存しない契約を検証

## 検証

- `nix develop --command uv run pytest -q tests/test_video_analyzer.py tests/test_video_analyze_cli.py` — 85 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6878 passed, 1 skipped