### PR TITLE
test: 重複テストを実行時契約へ統合 (#2679)

### DIFF
--- a/tests/test_veo_generator.py
+++ b/tests/test_veo_generator.py
@@ -44,15 +44,6 @@ def _install_capture(monkeypatch) -> dict:
 # ---------- trim_tail ----------
 
 
-def test_trim_tail_places_sentinel_before_path(monkeypatch) -> None:
-    captured = _install_capture(monkeypatch)
-
-    veo_generator.trim_tail(Path("/fake.mp4"))
-
-    assert captured["cmd"][-2] == "--"
-    assert captured["cmd"][-1] == "/fake.mp4"
-
-
 def test_trim_tail_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
     captured = _install_capture(monkeypatch)
 
@@ -63,15 +54,6 @@ def test_trim_tail_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
 
 
 # ---------- smooth_loop ----------
-
-
-def test_smooth_loop_places_sentinel_before_path(monkeypatch) -> None:
-    captured = _install_capture(monkeypatch)
-
-    veo_generator.smooth_loop(Path("/fake.mp4"))
-
-    assert captured["cmd"][-2] == "--"
-    assert captured["cmd"][-1] == "/fake.mp4"
 
 
 def test_smooth_loop_keeps_sentinel_for_dash_prefixed_path(monkeypatch) -> None:
@@ -117,25 +99,6 @@ def test_compress_loop_uses_configured_crf_and_preset(monkeypatch) -> None:
     assert cmd[cmd.index("-preset") + 1] == "slow"
     assert cmd[cmd.index("-pix_fmt") + 1] == "yuv420p"
     assert "-an" in cmd
-
-
-def test_compress_loop_uses_custom_crf_value(monkeypatch) -> None:
-    """CRF 24（攻める設定）が argv に正しく反映される。"""
-    captured = _install_run_capture(monkeypatch)
-
-    veo_generator.compress_loop(Path("/fake.mp4"), crf=24, preset="veryslow")
-
-    cmd = captured["cmd"]
-    assert cmd[cmd.index("-crf") + 1] == "24"
-    assert cmd[cmd.index("-preset") + 1] == "veryslow"
-
-
-def test_compress_loop_returns_false_on_ffmpeg_failure(monkeypatch) -> None:
-    """ffmpeg 失敗時は False を返す。"""
-    _install_run_capture(monkeypatch)
-
-    result = veo_generator.compress_loop(Path("/nonexistent.mp4"))
-    assert result is False
 
 
 def test_smooth_loop_accepts_custom_crf_preset(monkeypatch) -> None:
@@ -693,31 +656,6 @@ class TestGenerateLoopVideoSubmitInterrupt:
         assert result is False
         out = capsys.readouterr().out
         assert "[Interrupt]" in out
-
-    def test_does_not_save_state_on_submit_keyboard_interrupt(
-        self, channel_tmp: Path, output_mp4: Path, monkeypatch
-    ) -> None:
-        """generate_videos() の Ctrl+C では operation_name 未取得のため state を保存しない。"""
-        _patch_genai_types(monkeypatch)
-        client = MagicMock()
-        client.models.generate_videos.side_effect = KeyboardInterrupt
-
-        with patch.multiple(
-            "youtube_automation.utils.veo_generator",
-            strip_audio=MagicMock(),
-            cost_tracker=MagicMock(),
-        ):
-            with patch("time.sleep"):
-                try:
-                    veo_generator.generate_loop_video(
-                        client,
-                        output_mp4.parent / "main.png",
-                        output_mp4,
-                        model="veo-3.1-fast",
-                        prompt="test prompt",
-                    )
-                except KeyboardInterrupt:
-                    pytest.fail("generate_loop_video が submit 中の KeyboardInterrupt を捕捉していない")
 
         from youtube_automation.utils import veo_operation_store as op_store
 

--- a/tests/test_veo_operation_store.py
+++ b/tests/test_veo_operation_store.py
@@ -11,6 +11,8 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 from youtube_automation.utils import veo_operation_store as store
 
 # ---------------------------------------------------------------------------
@@ -65,17 +67,6 @@ class TestStatePath:
 
         # Then
         assert key_a != key_b
-
-    def test_hash_matches_sha1_of_abs_output(self, tmp_path: Path) -> None:
-        # Given
-        output_path = tmp_path / "collections" / "loop.mp4"
-        expected_hash = hashlib.sha1(str(output_path.resolve()).encode()).hexdigest()[:16]
-
-        # When
-        result = store.state_path(output_path, channel_root=tmp_path)
-
-        # Then
-        assert result.stem == expected_hash
 
 
 # ---------------------------------------------------------------------------
@@ -149,16 +140,31 @@ class TestSave:
         # Then
         assert ops_dir.exists()
 
-    def test_atomic_write_no_tmp_remnant(self, tmp_path: Path) -> None:
-        """書き込み後に .json.tmp が残っていないこと（atomic write の確認）."""
-        # Given
+    def test_atomic_write_replaces_complete_state_and_preserves_old_state_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         output_path = tmp_path / "loop.mp4"
+        image_path = self._image_path(tmp_path)
+        store.save(output_path, image_path, "op-old", "model", channel_root=tmp_path)
 
-        # When
-        saved = store.save(output_path, self._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
-
-        # Then
+        saved = store.save(output_path, image_path, "op-new", "model", channel_root=tmp_path)
+        assert store.load(output_path, channel_root=tmp_path)["operation_name"] == "op-new"
         tmp_remnant = saved.with_suffix(saved.suffix + ".tmp")
+        assert not tmp_remnant.exists()
+
+        store.save(output_path, image_path, "op-protected", "model", channel_root=tmp_path)
+        original_write_text = Path.write_text
+
+        def fail_tmp_write(path: Path, *args, **kwargs):
+            if path == tmp_remnant:
+                raise OSError("disk full")
+            return original_write_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", fail_tmp_write)
+        with pytest.raises(OSError, match="disk full"):
+            store.save(output_path, image_path, "op-lost", "model", channel_root=tmp_path)
+
+        assert store.load(output_path, channel_root=tmp_path)["operation_name"] == "op-protected"
         assert not tmp_remnant.exists()
 
     def test_save_returns_path_to_state_file(self, tmp_path: Path) -> None:
@@ -231,20 +237,7 @@ class TestLoad:
 
         # Then: None を返して上位に例外を漏らさない
         assert result is None
-
-    def test_prints_warn_on_json_corruption(self, tmp_path: Path, capsys) -> None:
-        # Given
-        output_path = tmp_path / "loop.mp4"
-        state_file = store.state_path(output_path, channel_root=tmp_path)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text("broken", encoding="utf-8")
-
-        # When
-        store.load(output_path, channel_root=tmp_path)
-        out = capsys.readouterr().out
-
-        # Then: [Warn] が stdout に出る
-        assert "[Warn]" in out
+        assert "[Warn]" in capsys.readouterr().out
 
     def test_load_does_not_mutate_saved_data(self, tmp_path: Path) -> None:
         """load の返り値を mutate しても次回 load に影響しない（イミュータブル保証）."""
@@ -399,29 +392,6 @@ class TestLoad:
         assert "[Warn]" in out
         assert not state_file.exists()
 
-    def test_returns_none_when_output_path_is_object(self, tmp_path: Path, capsys) -> None:
-        """output_path が dict の state は None を返し、state ファイルを削除する（ai-review-006）。"""
-        # Given: output_path をオブジェクトで書き込む
-        output_path = tmp_path / "loop.mp4"
-        state_file = store.state_path(output_path, channel_root=tmp_path)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        invalid = {
-            "operation_name": "projects/veo/99",
-            "model": "veo-3.1-fast",
-            "output_path": {"path": "/some/path"},  # dict（非文字列）
-            "input_image_sha256": "test-hash",
-        }
-        state_file.write_text(json.dumps(invalid), encoding="utf-8")
-
-        # When
-        result = store.load(output_path, channel_root=tmp_path)
-        out = capsys.readouterr().out
-
-        # Then: None を返し、[Warn] を出力し、state ファイルを削除する
-        assert result is None
-        assert "[Warn]" in out
-        assert not state_file.exists()
-
     def test_returns_none_and_removes_legacy_state_without_input_image_hash(self, tmp_path: Path, capsys) -> None:
         """入力画像識別子がない旧 state は安全側で破棄する。"""
         output_path = tmp_path / "loop.mp4"
@@ -457,23 +427,6 @@ class TestLoad:
         assert "[Warn]" in out
         assert not state_file.exists()
 
-    def test_returns_none_when_state_is_json_string(self, tmp_path: Path, capsys) -> None:
-        """state が JSON 文字列の場合は None を返し、state ファイルを削除する（ai-review-005）。"""
-        # Given: state が文字列の有効 JSON
-        output_path = tmp_path / "loop.mp4"
-        state_file = store.state_path(output_path, channel_root=tmp_path)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text('"just-a-string"', encoding="utf-8")
-
-        # When
-        result = store.load(output_path, channel_root=tmp_path)
-        out = capsys.readouterr().out
-
-        # Then: None を返し、[Warn] を出力し、state ファイルを削除する
-        assert result is None
-        assert "[Warn]" in out
-        assert not state_file.exists()
-
 
 # ---------------------------------------------------------------------------
 # clear
@@ -494,6 +447,7 @@ class TestClear:
 
         # Then
         assert not store.state_path(output_path, channel_root=tmp_path).exists()
+        assert store.load(output_path, channel_root=tmp_path) is None
 
     def test_noop_when_no_state(self, tmp_path: Path) -> None:
         """state ファイルが存在しなくても例外を上げない."""
@@ -502,15 +456,3 @@ class TestClear:
 
         # When / Then: 例外なし
         store.clear(output_path, channel_root=tmp_path)
-
-    def test_load_returns_none_after_clear(self, tmp_path: Path) -> None:
-        # Given
-        output_path = tmp_path / "loop.mp4"
-        store.save(output_path, TestSave._image_path(tmp_path), "op-name", "model", channel_root=tmp_path)
-
-        # When
-        store.clear(output_path, channel_root=tmp_path)
-        result = store.load(output_path, channel_root=tmp_path)
-
-        # Then
-        assert result is None

--- a/tests/test_video_analyzer.py
+++ b/tests/test_video_analyzer.py
@@ -64,23 +64,6 @@ _VALID_PAYLOAD = {
 }
 
 
-class TestVideoTarget:
-    def test_holds_required_fields(self):
-        # Given: 必要な属性
-        target = VideoTarget(
-            video_id="vid_001",
-            slug="celtic-music",
-            url="https://www.youtube.com/watch?v=vid_001",
-            title="Celtic Forest",
-        )
-
-        # Then: 各属性にアクセスできる
-        assert target.video_id == "vid_001"
-        assert target.slug == "celtic-music"
-        assert target.url == "https://www.youtube.com/watch?v=vid_001"
-        assert target.title == "Celtic Forest"
-
-
 class TestVideoAnalyzerAnalyzeUrl:
     def test_parses_plain_json_response(self, tmp_path):
         # Given: 素の JSON を返す Gemini Client
@@ -381,17 +364,6 @@ class TestVideoAnalyzerLoadCachedJson:
         # Then
         assert cached is None
         assert "object ではない" in caplog.text
-
-    def test_returns_none_on_json_array(self, tmp_path):
-        # Given: 配列トップレベル (解析結果の形ではない)
-        analyzer = self._make_analyzer(tmp_path)
-        target = _make_target()
-        path = analyzer.json_path(target)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text('[{"hook_structure": {}}]', encoding="utf-8")
-
-        # When/Then
-        assert analyzer.load_cached_json(target) is None
 
 
 class TestVideoAnalysisReport:


### PR DESCRIPTION
## 対応 issue

Closes #2679

## 変更概要

- 監査表で指定された13 node IDを全て削除・統合・強化
- dataclass属性とSHA-1実装詳細だけを固定する2件を削除
- atomic writeを、新state読込・tmp不在・書込失敗時の旧state保持まで強化
- 同一分岐を重複実行していた10件のassertionを代表ケースへ統合

## 検証

- 13対象node IDが残存しないことを`rg`で確認
- `nix develop --command uv run pytest -q tests/test_video_analyzer.py tests/test_veo_operation_store.py tests/test_veo_generator.py` — 87 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6859 passed, 1 skipped