### PR TITLE
test: package versionのfallbackを検証 (#2590)

### DIFF
--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,0 +1,29 @@
+"""Package metadata から解決する公開 version 契約のテスト。"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import runpy
+from pathlib import Path
+from unittest.mock import patch
+
+PACKAGE_INIT = Path(__file__).parents[1] / "src" / "youtube_automation" / "__init__.py"
+
+
+def test_version_uses_installed_package_metadata() -> None:
+    with patch.object(importlib.metadata, "version", return_value="9.8.7") as version:
+        namespace = runpy.run_path(str(PACKAGE_INIT))
+
+    assert namespace["__version__"] == "9.8.7"
+    version.assert_called_once_with("youtube-channels-automation")
+
+
+def test_version_falls_back_when_package_metadata_is_unavailable() -> None:
+    with patch.object(
+        importlib.metadata,
+        "version",
+        side_effect=importlib.metadata.PackageNotFoundError("youtube-channels-automation"),
+    ):
+        namespace = runpy.run_path(str(PACKAGE_INIT))
+
+    assert namespace["__version__"] == "0.0.0+unknown"


### PR DESCRIPTION
## 対応 issue

Closes #2590

## 変更概要

- installed package metadata取得成功時の公開`__version__`を直接検証
- `PackageNotFoundError`時の`0.0.0+unknown` fallbackを直接検証

## 検証

- `nix develop --command uv run pytest -q tests/test_package_version.py` — 2 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6873 passed, 1 skipped