### PR TITLE
test: entrypointのchannel境界を網羅 (#2592)

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,61 @@
+"""Console entrypoint の共通 channel 引数境界テスト。"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from youtube_automation import entrypoints
+from youtube_automation.infrastructure.errors import ConfigError
+
+
+def test_consume_channel_rejects_missing_value_without_mutating_argv() -> None:
+    argv = ["yt-command", "--dry-run", "--channel"]
+
+    with pytest.raises(ConfigError, match="channel slug が必要"):
+        entrypoints._consume_channel_option(argv)
+
+    assert argv == ["yt-command", "--dry-run", "--channel"]
+
+
+def test_consume_channel_rejects_empty_equals_value() -> None:
+    argv = ["yt-command", "--channel="]
+
+    with pytest.raises(ConfigError, match="空でない channel slug"):
+        entrypoints._consume_channel_option(argv)
+
+    assert argv == ["yt-command"]
+
+
+def test_consume_channel_rejects_duplicates_after_consuming_options() -> None:
+    argv = ["yt-command", "--channel", "alpha", "--channel=beta", "--dry-run"]
+
+    with pytest.raises(ConfigError, match="複数回指定"):
+        entrypoints._consume_channel_option(argv)
+
+    assert argv == ["yt-command", "--dry-run"]
+
+
+def test_consume_channel_accepts_equals_form_and_removes_only_that_option() -> None:
+    argv = ["yt-command", "--channel=alpha", "--dry-run"]
+
+    assert entrypoints._consume_channel_option(argv) == "alpha"
+    assert argv == ["yt-command", "--dry-run"]
+
+
+def test_consume_channel_stops_at_double_dash_and_preserves_tail() -> None:
+    argv = ["yt-command", "--dry-run", "--", "--channel", "target-value"]
+
+    assert entrypoints._consume_channel_option(argv) is None
+    assert argv == ["yt-command", "--dry-run", "--", "--channel", "target-value"]
+
+
+def test_run_rejects_non_callable_module_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["yt-command"])
+    monkeypatch.setattr(entrypoints, "configure_utf8_stdio", lambda: None)
+    monkeypatch.setattr(entrypoints, "import_module", lambda _path: SimpleNamespace(main=42))
+
+    with pytest.raises(TypeError, match="dummy.module:main is not callable"):
+        entrypoints._run("dummy.module")


### PR DESCRIPTION
## 対応 issue

Closes #2592

## 変更概要

- `--channel`の欠落値・空値・重複拒否とargv副作用を直接検証
- equals形式と`--`以後の停止・保持を直接検証
- `_run`が非callable module attributeを拒否する契約を検証

## 検証

- `nix develop --command uv run pytest -q tests/test_entrypoints.py tests/test_cli_stdio.py` — 95 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6877 passed, 1 skipped