### PR TITLE
test: browser取得の失敗境界を網羅 (#2598)

### DIFF
--- a/tests/test_infrastructure_browser.py
+++ b/tests/test_infrastructure_browser.py
@@ -1,0 +1,61 @@
+"""Browser HTTP boundary の redirect / network failure 契約テスト。"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock
+from urllib import error
+
+import pytest
+
+from youtube_automation.infrastructure import browser
+
+
+def test_fetch_html_validates_url_and_returns_response_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.read.return_value = b"<html>ok</html>"
+    opener = MagicMock()
+    opener.open.return_value = nullcontext(response)
+    build_opener = MagicMock(return_value=opener)
+    validator = MagicMock()
+    monkeypatch.setattr(browser.request, "build_opener", build_opener)
+
+    result = browser.fetch_html("https://allowed.example/page", timeout=2.5, validator=validator)
+
+    assert result == b"<html>ok</html>"
+    validator.assert_called_once_with("https://allowed.example/page")
+    request_arg = opener.open.call_args.args[0]
+    assert request_arg.full_url == "https://allowed.example/page"
+    assert request_arg.get_method() == "GET"
+    assert opener.open.call_args.kwargs == {"timeout": 2.5}
+    assert isinstance(build_opener.call_args.args[0], browser.request.HTTPRedirectHandler)
+
+
+def test_fetch_html_rejects_redirect_without_opening_second_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    def build_opener(handler):
+        opener = MagicMock()
+        opener.open.side_effect = lambda *_args, **_kwargs: handler.redirect_request(
+            None, None, 302, "Found", {}, "https://rejected.example"
+        )
+        return opener
+
+    monkeypatch.setattr(browser.request, "build_opener", build_opener)
+
+    with pytest.raises(browser.RedirectRejectedError):
+        browser.fetch_html("https://allowed.example", timeout=1)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        error.URLError("network unavailable"),
+        TimeoutError("request timed out"),
+    ],
+)
+def test_fetch_html_propagates_network_failures(monkeypatch: pytest.MonkeyPatch, failure: Exception) -> None:
+    opener = MagicMock()
+    opener.open.side_effect = failure
+    monkeypatch.setattr(browser.request, "build_opener", lambda *_handlers: opener)
+
+    with pytest.raises(type(failure), match=str(failure)):
+        browser.fetch_html("https://allowed.example", timeout=1)


### PR DESCRIPTION
## 対応 issue

Closes #2598

## 変更概要

- validator成功時のGET URL・timeout・response bytesを検証
- redirect handlerが遷移先を拒否する契約を検証
- URLErrorとTimeoutErrorの伝播を検証

## 検証

- `nix develop --command uv run pytest -q tests/test_infrastructure_browser.py tests/test_channel_seed.py` — 29 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6875 passed, 1 skipped