### PR TITLE
test: scheduler実行契約へテストを接続 (#2605 #2606)

### DIFF
--- a/tests/test_automation_schedule_backends.py
+++ b/tests/test_automation_schedule_backends.py
@@ -76,6 +76,8 @@ def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypat
     assert plan["prevent_concurrent_runs"] is True
     assert plan["target_workflow"] == "wf-auto"
     assert plan["prompt"].startswith("/wf-auto")
+    assert plan["dependency_mode"] == "local"
+    assert "local dependencies require desktop local project" in plan["management"]
 
 
 def test_plan_rejects_removed_automation_run_override(tmp_path, monkeypatch):
@@ -140,16 +142,20 @@ def test_os_scheduler_install_refuses_implicit_fallback():
     assert "--confirm-os-fallback" in result.stderr
 
 
-def test_skill_covers_native_status_disable_and_local_dependency_gate():
-    skill = (REFERENCE_DIR.parent / "SKILL.md").read_text(encoding="utf-8")
-    for backend_name in backend.BACKENDS:
-        assert backend_name in skill
-    for command in ("setup / update", "status", "disable"):
-        assert command in skill
-    for local_dependency in ("Chrome", "Suno Helper", "ffmpeg", "OAuth"):
-        assert local_dependency in skill
-    assert "/loop" in skill and "最長 3 日" in skill
-    assert "--confirm-os-fallback" in skill
+def test_scheduler_entrypoint_reports_status_and_disables_recorded_backend(tmp_path, capsys):
+    state_path = tmp_path / "state.json"
+    common = ["--channel-dir", str(tmp_path), "--state-path", str(state_path)]
+
+    assert backend.main([*common, "show"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"status": "unconfigured"}
+
+    backend.record_state(state_path, backend="codex-automation", external_id="task-1")
+    assert backend.main([*common, "disable", "--backend", "codex-automation"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["backend"] == "codex-automation"
+    assert output["external_id"] == "task-1"
+    assert output["status"] == "disabled"
+    assert backend.read_state(state_path)["status"] == "disabled"
 
 
 def test_runtime_detection_never_promotes_os_scheduler_to_required_native_backend():

--- a/tests/test_schedule_cadence.py
+++ b/tests/test_schedule_cadence.py
@@ -1,26 +1,14 @@
-"""_calculate_publish_at の cadence 曜日制約テスト
+"""PublishedDatesMixin._calculate_publish_at の cadence 曜日制約テスト。"""
 
-collection_uploader のインポート依存（schedule パッケージ等）を回避するため、
-テスト対象メソッドを直接抽出してテストする。
-"""
-
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import ClassVar
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-TZ = ZoneInfo("Asia/Tokyo")
+from youtube_automation.domains.uploads import _published_dates
+from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
 
-# collection_uploader.py から _calculate_publish_at のロジックを再現
-# 本体と同期を保つため、テスト失敗時は本体の変更を確認すること
-WEEKDAY_MAP = {
-    "mon": 1,
-    "tue": 2,
-    "wed": 3,
-    "thu": 4,
-    "fri": 5,
-    "sat": 6,
-    "sun": 7,
-}
+TZ = ZoneInfo("Asia/Tokyo")
 
 
 def calculate_publish_at(
@@ -30,29 +18,29 @@ def calculate_publish_at(
     publish_time: str = "11:00",
     auto_schedule_enabled: bool = True,
 ) -> str | None:
-    """_calculate_publish_at のスタンドアロン版（テスト用）
+    """本番 mixin を固定時刻・既存公開日で実行するテストadapter。"""
 
-    本体: application/uploads/collection_uploader.py CollectionUploader._calculate_publish_at
-    """
-    if not auto_schedule_enabled:
-        return None
+    class Scheduler(PublishedDatesMixin):
+        def __init__(self) -> None:
+            self.config = {
+                "schedule": {
+                    "auto_schedule_enabled": auto_schedule_enabled,
+                    "cadence": cadence or [],
+                    "publish_time": publish_time,
+                    "timezone": "Asia/Tokyo",
+                }
+            }
 
-    hour, minute = map(int, publish_time.split(":"))
+        def _get_published_dates(self) -> set[date]:
+            return existing_dates
 
-    allowed_weekdays = {WEEKDAY_MAP[d.lower()] for d in cadence} if cadence else set(range(1, 8))
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now
 
-    publish_dt = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-
-    if publish_dt <= now:
-        publish_dt += timedelta(days=1)
-
-    max_slide = 30
-    for _ in range(max_slide):
-        if publish_dt.isoweekday() in allowed_weekdays and publish_dt.date() not in existing_dates:
-            break
-        publish_dt += timedelta(days=1)
-
-    return publish_dt.isoformat()
+    with patch.object(_published_dates, "datetime", FixedDateTime):
+        return Scheduler()._calculate_publish_at()
 
 
 class TestCadenceScheduling:


### PR DESCRIPTION
## 対応 issue

Closes #2605
Closes #2606

## 変更概要

- scheduler backend の説明文固定テストを、show/disable の状態遷移と出力を検証する実行テストへ置換
- build plan の local dependency 契約を直接検証
- cadence の複製ロジックを削除し、本番 PublishedDatesMixin._calculate_publish_at を固定時刻で実行

## 検証

- `nix develop --command uv run pytest -q tests/test_automation_schedule_backends.py tests/test_schedule_cadence.py tests/test_collection_uploader.py` → 94 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6871 passed, 1 skipped