### PR TITLE
test: GCP project明示値の優先契約を検証 (#2604)

### DIFF
--- a/tests/test_google_cloud_project.py
+++ b/tests/test_google_cloud_project.py
@@ -1,0 +1,20 @@
+"""GCP project ID の明示 override 優先順位テスト。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from youtube_automation.utils import google_cloud_project
+
+
+def test_explicit_project_override_precedes_environment_and_adc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "environment-project")
+    adc = MagicMock(return_value=(object(), "adc-project"))
+    monkeypatch.setattr(google_cloud_project, "google_auth_default", adc)
+
+    assert google_cloud_project.resolve_project_id("explicit-project") == "explicit-project"
+    adc.assert_not_called()


### PR DESCRIPTION
## 対応 issue

Closes #2604

## 変更概要

- `resolve_project_id()` の明示project overrideが環境変数とADCより優先されることを直接検証
- 明示値がある場合にADC解決を呼ばない境界を確認

## 検証

- `nix develop --command uv run pytest -q tests/test_google_cloud_project.py tests/test_genai_client.py` → 7 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6872 passed, 1 skipped