### PR TITLE
fix: サムネイル分析のfail-soft契約を保つ (#2611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(benchmark)`: Gemini サムネイル分析が依存欠落・client初期化・画像取得・生成・JSON解析で失敗した場合は収集済み動画データを変更せず、解析成功時だけ `thumbnail_analysis` とgeneration記録を追加する fail-soft 契約を明確化（#2611）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/analytics/benchmark_collector.py
+++ b/src/youtube_automation/commands/analytics/benchmark_collector.py
@@ -724,7 +724,6 @@ class BenchmarkThumbnailAnalyzer:
                         )
                     except json.JSONDecodeError as e:
                         logger.warning("サムネイル分析JSONパース失敗 [%s]: %s", video["title"][:30], e)
-                        video["thumbnail_analysis"] = {"raw": response.text[:500] if "response" in dir() else str(e)}
                     except Exception as e:
                         logger.warning("サムネイル分析失敗 [%s]: %s", video["title"][:30], e)
 

--- a/tests/test_benchmark_collector_channels_batch.py
+++ b/tests/test_benchmark_collector_channels_batch.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import builtins
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -20,12 +21,14 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
+from youtube_automation.commands.analytics import benchmark_collector
 from youtube_automation.commands.analytics.benchmark_collector import (
     _CHANNELS_BATCH_SIZE,
     BenchmarkCollector,
     BenchmarkReportGenerator,
+    BenchmarkThumbnailAnalyzer,
 )
-from youtube_automation.infrastructure.errors import YouTubeAPIError
+from youtube_automation.infrastructure.errors import ConfigError, YouTubeAPIError
 
 
 def _make_collector(youtube_mock: MagicMock, *, benchmark_channels: list[dict] | None = None) -> BenchmarkCollector:
@@ -84,6 +87,124 @@ def _video_item(
         },
         "contentDetails": {"duration": duration},
     }
+
+
+def _thumbnail_analyzer(monkeypatch, tmp_path) -> BenchmarkThumbnailAnalyzer:
+    monkeypatch.setattr(
+        benchmark_collector,
+        "load_skill_config",
+        lambda _skill: {"thumbnail_analysis": {"model": "gemini-test", "delay_sec": 0, "prompt": "analyze"}},
+    )
+    return BenchmarkThumbnailAnalyzer(tmp_path)
+
+
+def _thumbnail_data() -> dict:
+    return {
+        "channels": [
+            {
+                "slug": "reference",
+                "videos": [
+                    {
+                        "video_id": "VID_REF",
+                        "title": "Reference Mix",
+                        "thumbnail_url": "https://example.com/thumbnail.jpg",
+                    }
+                ],
+            }
+        ]
+    }
+
+
+class TestBenchmarkThumbnailAnalyzer:
+    def test_missing_genai_dependency_preserves_collected_data(self, monkeypatch, tmp_path):
+        analyzer = _thumbnail_analyzer(monkeypatch, tmp_path)
+        data = _thumbnail_data()
+        real_import = builtins.__import__
+
+        def reject_genai(name, *args, **kwargs):
+            if name == "google.genai":
+                raise ImportError("google-genai unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", reject_genai)
+
+        assert analyzer.analyze_thumbnails(data) is data
+        assert "thumbnail_analysis" not in data["channels"][0]["videos"][0]
+
+    def test_client_initialization_failure_preserves_collected_data(self, monkeypatch, tmp_path):
+        analyzer = _thumbnail_analyzer(monkeypatch, tmp_path)
+        data = _thumbnail_data()
+
+        def fail_client():
+            raise ConfigError("credentials unavailable")
+
+        monkeypatch.setattr("youtube_automation.utils.genai_client.create_global_genai_client", fail_client)
+
+        assert analyzer.analyze_thumbnails(data) is data
+        assert "thumbnail_analysis" not in data["channels"][0]["videos"][0]
+
+    @pytest.mark.parametrize(
+        ("download_error", "response"),
+        [
+            (OSError("download failed"), None),
+            (None, RuntimeError("generation failed")),
+            (None, SimpleNamespace(text="not json")),
+        ],
+    )
+    def test_processing_failures_do_not_add_analysis_or_generation(
+        self,
+        monkeypatch,
+        tmp_path,
+        download_error,
+        response,
+    ):
+        analyzer = _thumbnail_analyzer(monkeypatch, tmp_path)
+        data = _thumbnail_data()
+        client = MagicMock()
+        if isinstance(response, Exception):
+            client.models.generate_content.side_effect = response
+        else:
+            client.models.generate_content.return_value = response
+        monkeypatch.setattr("youtube_automation.utils.genai_client.create_global_genai_client", lambda: client)
+
+        def download(_url, path):
+            if download_error:
+                raise download_error
+            path.write_bytes(b"jpeg")
+
+        generation = MagicMock()
+        monkeypatch.setattr(benchmark_collector.urllib.request, "urlretrieve", download)
+        monkeypatch.setattr("youtube_automation.infrastructure.cost_tracker.log_generation", generation)
+        monkeypatch.setattr(benchmark_collector.time, "sleep", lambda _seconds: None)
+
+        assert analyzer.analyze_thumbnails(data) is data
+        assert "thumbnail_analysis" not in data["channels"][0]["videos"][0]
+        generation.assert_not_called()
+
+    def test_success_adds_parsed_analysis_and_generation_record(self, monkeypatch, tmp_path):
+        analyzer = _thumbnail_analyzer(monkeypatch, tmp_path)
+        data = _thumbnail_data()
+        client = MagicMock()
+        client.models.generate_content.return_value = SimpleNamespace(text='```json\n{"composition": "centered"}\n```')
+        monkeypatch.setattr("youtube_automation.utils.genai_client.create_global_genai_client", lambda: client)
+        monkeypatch.setattr(
+            benchmark_collector.urllib.request,
+            "urlretrieve",
+            lambda _url, path: path.write_bytes(b"jpeg"),
+        )
+        generation = MagicMock()
+        monkeypatch.setattr("youtube_automation.infrastructure.cost_tracker.log_generation", generation)
+        monkeypatch.setattr(benchmark_collector.time, "sleep", lambda _seconds: None)
+
+        assert analyzer.analyze_thumbnails(data) is data
+        assert data["channels"][0]["videos"][0]["thumbnail_analysis"] == {"composition": "centered"}
+        generation.assert_called_once_with(
+            "analysis",
+            "gemini-test",
+            quantity=1,
+            unit="call",
+            metadata={"video_id": "VID_REF", "channel_slug": "reference"},
+        )
 
 
 class TestFetchChannelsMetadata:


### PR DESCRIPTION
## 対応 issue

Closes #2611

## 変更概要

- Gemini依存欠落・client初期化失敗・画像取得失敗・生成失敗・不正JSONの各経路で収集済みdataを保持
- 不正JSON時に擬似的な解析結果を追加せず、成功時だけparsed `thumbnail_analysis` とgeneration記録を追加
- download/client/response/cost trackerをstub化した直接実行テストを追加

## 検証

- `nix develop --command uv run pytest -q tests/test_benchmark_collector_channels_batch.py tests/test_benchmark_collector_no_fallback.py tests/test_benchmark_quota_wiring.py` → 51 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6877 passed, 1 skipped