### PR TITLE
fix: benchmark動画policyの境界を厳密化 (#2618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(benchmark)`: Short判定のISO 8601 durationを完全一致で検証し、空の `PT` や末尾に不正文字を含む値をShortとして扱わないよう修正（#2618）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/domains/analytics/benchmark.py
+++ b/src/youtube_automation/domains/analytics/benchmark.py
@@ -10,8 +10,8 @@ TTP_VIDEO_ANALYZE_TOP_N = 5
 
 def is_short_benchmark_duration(duration_iso: str) -> bool:
     """Return whether an ISO duration is shorter than five minutes."""
-    match = re.match(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?", duration_iso)
-    if not match:
+    match = re.fullmatch(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?", duration_iso)
+    if not match or all(group is None for group in match.groups()):
         return False
     hours = int(match.group(1) or 0)
     minutes = int(match.group(2) or 0)

--- a/tests/test_benchmark_policy.py
+++ b/tests/test_benchmark_policy.py
@@ -1,0 +1,64 @@
+"""Provider-neutral benchmark video policy boundaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from youtube_automation.domains.analytics.benchmark import (
+    is_live_benchmark_video,
+    is_short_benchmark_duration,
+    is_short_benchmark_video,
+    select_top_vod_benchmark_videos,
+)
+
+
+@pytest.mark.parametrize(
+    ("duration_iso", "expected"),
+    [
+        ("PT4M59S", True),
+        ("PT5M", False),
+        ("PT1H", False),
+        ("PT0S", True),
+        ("P0D", False),
+        ("PT", False),
+        ("PT4M59S-invalid", False),
+        ("not-a-duration", False),
+        ("", False),
+    ],
+)
+def test_short_duration_boundary_and_invalid_values(duration_iso: str, expected: bool) -> None:
+    assert is_short_benchmark_duration(duration_iso) is expected
+
+
+def test_video_classification_handles_missing_duration_and_live_marker() -> None:
+    assert is_short_benchmark_video({}) is False
+    assert is_live_benchmark_video({}) is False
+    assert is_live_benchmark_video({"duration_iso": "P0D"}) is True
+
+
+@pytest.mark.parametrize(
+    ("top", "expected_ids", "expected_live_ids"),
+    [
+        (0, [], []),
+        (1, ["short"], ["live-first"]),
+        (3, ["short", "vod", "vod-next"], ["live-first", "live-middle"]),
+        (10, ["short", "vod", "vod-next"], ["live-first", "live-middle"]),
+    ],
+)
+def test_top_vod_selection_skips_live_and_honors_limit(
+    top: int,
+    expected_ids: list[str],
+    expected_live_ids: list[str],
+) -> None:
+    videos = [
+        {"video_id": "live-first", "duration_iso": "P0D"},
+        {"video_id": "short", "duration_iso": "PT4M59S"},
+        {"video_id": "vod", "duration_iso": "PT1H"},
+        {"video_id": "live-middle", "duration_iso": "P0D"},
+        {"video_id": "vod-next", "duration_iso": "PT30M"},
+    ]
+
+    selected, skipped_live = select_top_vod_benchmark_videos(videos, top)
+
+    assert [video["video_id"] for video in selected] == expected_ids
+    assert [video["video_id"] for video in skipped_live] == expected_live_ids


### PR DESCRIPTION
## 対応 issue

Closes #2618

## 変更概要

- Short duration判定を完全一致にし、空 `PT` と不正suffixを拒否
- 5分境界、live marker、欠損durationを直接検証
- live混在時の繰上げとtop=0/1/N上限を直接検証

## 検証

- `nix develop --command uv run pytest -q tests/test_benchmark_policy.py` → 14 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6885 passed, 1 skipped