### PR TITLE
test: launch curveの判定描画境界を検証 (#2616 #2617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(analytics)`: launch-curve plotでtargetなし・benchmarkサンプル不足によりラベル対象がない場合、空legendを描画せず警告なくPNGを生成する（#2617）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/domains/analytics/analysis/launch_curve_plotter.py
+++ b/src/youtube_automation/domains/analytics/analysis/launch_curve_plotter.py
@@ -102,7 +102,9 @@ def _plot_metric_panel(ax, df, target_video_id, metric, title, ylabel):
 
     ax.set_title(title)
     ax.set_ylabel(ylabel)
-    ax.legend(loc="upper left", fontsize=9)
+    handles, labels = ax.get_legend_handles_labels()
+    if handles:
+        ax.legend(handles, labels, loc="upper left", fontsize=9)
     ax.grid(True, alpha=0.3)
 
 

--- a/tests/test_launch_curve_analyzer.py
+++ b/tests/test_launch_curve_analyzer.py
@@ -72,3 +72,91 @@ def test_compute_benchmark_flags_small_sample():
     df = _make_frame().head(2)
     bench = compute_benchmark(df, metric="cumulative_views")
     assert (bench["sample_size"] < 3).all()
+
+
+def test_judge_reports_missing_target_day():
+    judgement = judge_video_vs_benchmark(
+        _make_frame(),
+        compute_benchmark(_make_frame()),
+        video_id="missing",
+        at_day=3,
+    )
+
+    assert judgement == {"error": "video missing has no data at day 3"}
+
+
+@pytest.mark.parametrize(
+    ("benchmark", "expected_sample_size"),
+    [
+        (pd.DataFrame(columns=["days_since_publish", "sample_size"]), 0),
+        (
+            pd.DataFrame(
+                [
+                    {
+                        "days_since_publish": 3,
+                        "p25": 200,
+                        "p50": 300,
+                        "p75": 400,
+                        "sample_size": 2,
+                    }
+                ]
+            ),
+            2,
+        ),
+    ],
+)
+def test_judge_reports_missing_or_small_benchmark_sample(benchmark, expected_sample_size):
+    judgement = judge_video_vs_benchmark(_make_frame(), benchmark, video_id="vid_4", at_day=3)
+
+    assert judgement["benchmark_median"] is None
+    assert judgement["ratio_vs_median"] is None
+    assert judgement["quartile_label"] == "サンプル不足"
+    assert judgement["sample_size"] == expected_sample_size
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_label"),
+    [
+        (400, "上位25%"),
+        (300, "中央値〜上位25%"),
+        (200, "下位25%〜中央値"),
+        (199, "下位25%"),
+    ],
+)
+def test_judge_labels_exact_quartile_boundaries(value, expected_label):
+    target = pd.DataFrame([{"video_id": "target", "days_since_publish": 3, "cumulative_views": value}])
+    benchmark = pd.DataFrame(
+        [
+            {
+                "days_since_publish": 3,
+                "p25": 200,
+                "p50": 300,
+                "p75": 400,
+                "sample_size": 5,
+            }
+        ]
+    )
+
+    judgement = judge_video_vs_benchmark(target, benchmark, video_id="target", at_day=3)
+
+    assert judgement["quartile_label"] == expected_label
+
+
+def test_judge_avoids_division_when_benchmark_median_is_zero():
+    target = pd.DataFrame([{"video_id": "target", "days_since_publish": 0, "cumulative_views": 1}])
+    benchmark = pd.DataFrame(
+        [
+            {
+                "days_since_publish": 0,
+                "p25": 0,
+                "p50": 0,
+                "p75": 2,
+                "sample_size": 3,
+            }
+        ]
+    )
+
+    judgement = judge_video_vs_benchmark(target, benchmark, video_id="target", at_day=0)
+
+    assert judgement["ratio_vs_median"] is None
+    assert judgement["quartile_label"] == "中央値〜上位25%"

--- a/tests/test_launch_curve_data.py
+++ b/tests/test_launch_curve_data.py
@@ -178,3 +178,52 @@ def test_build_launch_curve_frame_without_reporting_snapshot_keeps_columns():
     df = build_launch_curve_frame(daily_data=daily, video_meta=meta)
     assert df["reporting_ctr_snapshot"].isna().all()
     assert df["reporting_impressions_snapshot"].isna().all()
+
+
+def test_build_launch_curve_frame_empty_rows_returns_stable_schema():
+    df = build_launch_curve_frame(daily_data={"rows": []}, video_meta={})
+
+    assert df.empty
+    assert list(df.columns) == [
+        "video_id",
+        "date",
+        "published_at",
+        "days_since_publish",
+        "daily_views",
+        "cumulative_views",
+        "daily_impressions",
+        "ctr",
+        "reporting_ctr_snapshot",
+        "reporting_impressions_snapshot",
+    ]
+
+
+def test_build_launch_curve_frame_excludes_video_without_metadata():
+    daily = {
+        "rows": [
+            {"video_id": "known", "date": "2026-04-01", "views": 10},
+            {"video_id": "unknown", "date": "2026-04-01", "views": 999},
+        ]
+    }
+    meta = {"known": {"title": "Known", "published_at": "2026-04-01T00:00:00Z"}}
+
+    df = build_launch_curve_frame(daily_data=daily, video_meta=meta)
+
+    assert list(df["video_id"]) == ["known"]
+    assert list(df["daily_views"]) == [10]
+
+
+def test_build_launch_curve_frame_excludes_rows_before_publish_date():
+    daily = {
+        "rows": [
+            {"video_id": "v1", "date": "2026-03-31", "views": 999},
+            {"video_id": "v1", "date": "2026-04-01", "views": 10},
+            {"video_id": "v1", "date": "2026-04-02", "views": 20},
+        ]
+    }
+    meta = {"v1": {"title": "Video", "published_at": "2026-04-01T12:00:00Z"}}
+
+    df = build_launch_curve_frame(daily_data=daily, video_meta=meta)
+
+    assert list(df["days_since_publish"]) == [0, 1]
+    assert list(df["cumulative_views"]) == [10, 30]

--- a/tests/test_launch_curve_plotter.py
+++ b/tests/test_launch_curve_plotter.py
@@ -31,3 +31,24 @@ def test_plot_launch_curve_writes_png(tmp_path):
     )
     assert out.exists()
     assert out.stat().st_size > 1000
+
+
+def test_plot_launch_curve_without_target_uses_two_video_sample(tmp_path):
+    df = _make_frame()
+    df = df[df["video_id"].isin(["vid_0", "vid_1"])]
+    out = tmp_path / "two-videos.png"
+
+    plot_launch_curve(df=df, target_video_id=None, output_path=out, window=30)
+
+    assert out.exists()
+    assert out.stat().st_size > 1000
+
+
+def test_plot_launch_curve_ignores_rows_outside_window(tmp_path):
+    df = _make_frame()
+    out = tmp_path / "window.png"
+
+    plot_launch_curve(df=df, target_video_id="vid_4", output_path=out, window=2)
+
+    assert out.exists()
+    assert out.stat().st_size > 1000


### PR DESCRIPTION
## 対応 issue

Closes #2616
Closes #2617
Closes #2633

## 変更概要

- analyzerの対象/日数不在、benchmark不在・少数、中央値0、p25/p50/p75同値境界を直接検証
- plotterのtargetなし・2動画・window除外をGUI非依存PNG生成で検証し、空legend警告を解消
- frameの空rows安定schema、metadataなしvideo、公開日前row除外を直接検証

## 検証

- `nix develop --command uv run pytest -q tests/test_launch_curve_data.py tests/test_launch_curve_analyzer.py tests/test_launch_curve_plotter.py tests/test_japanize_font_regression.py` → 28 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6884 passed, 1 skipped