### PR TITLE
test: TTP health CLIの出力契約を検証 (#2614)

### DIFF
--- a/tests/test_ttp_health.py
+++ b/tests/test_ttp_health.py
@@ -191,6 +191,20 @@ def test_cli_returns_unavailable_when_benchmark_json_is_missing(tmp_path, monkey
     assert report["reason"] == "no_benchmark_json"
 
 
+def test_cli_returns_unavailable_when_benchmark_channels_are_not_configured(tmp_path, monkeypatch) -> None:
+    config = SimpleNamespace(analytics=SimpleNamespace(benchmark=SimpleNamespace(channels=[])))
+    monkeypatch.setattr(ttp_health_cli, "load_config", lambda: config)
+
+    report = ttp_health_cli.build_report(data_dir=tmp_path)
+
+    assert report == {
+        "status": "unavailable",
+        "reason": "no_benchmark_channels",
+        "detail": "config/channel/analytics.json の benchmark.channels に対象がありません。",
+        "channels": [],
+    }
+
+
 def test_cli_loads_latest_json_and_preserves_source_name(tmp_path, monkeypatch) -> None:
     config = SimpleNamespace(analytics=SimpleNamespace(benchmark=SimpleNamespace(channels=[CONFIG_CHANNEL])))
     monkeypatch.setattr(ttp_health_cli, "load_config", lambda: config)
@@ -205,3 +219,40 @@ def test_cli_loads_latest_json_and_preserves_source_name(tmp_path, monkeypatch) 
     assert report["status"] == "ok"
     assert report["source"] == benchmark_path.name
     assert report["channels"][0]["status"] == "healthy"
+
+
+def test_main_emits_compact_json_and_forwards_thresholds(tmp_path, monkeypatch, capsys) -> None:
+    calls = []
+    monkeypatch.setattr(ttp_health_cli, "channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        ttp_health_cli,
+        "build_report",
+        lambda **kwargs: calls.append(kwargs) or {"status": "ok", "channels": []},
+    )
+
+    assert ttp_health_cli.main(["--stale-days", "14", "--decline-ratio", "0.75", "--window-days", "30"]) == 0
+
+    assert capsys.readouterr().out == '{"status":"ok","channels":[]}\n'
+    assert calls == [
+        {
+            "data_dir": tmp_path / "data",
+            "stale_days": 14,
+            "decline_ratio": 0.75,
+            "window_days": 30,
+        }
+    ]
+
+
+def test_main_emits_pretty_json(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(ttp_health_cli, "channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        ttp_health_cli,
+        "build_report",
+        lambda **_kwargs: {"status": "unavailable", "reason": "no_benchmark_json"},
+    )
+
+    assert ttp_health_cli.main(["--pretty"]) == 0
+
+    output = capsys.readouterr().out
+    assert json.loads(output) == {"status": "unavailable", "reason": "no_benchmark_json"}
+    assert output.startswith('{\n  "status"')


### PR DESCRIPTION
## 対応 issue

Closes #2614

## 変更概要

- benchmark channel未設定時のunavailable理由/detailを検証
- compact/pretty JSON出力を直接検証
- stale/decline/windowのCLI閾値がbuild_reportへ伝播することを検証

## 検証

- `nix develop --command uv run pytest -q tests/test_ttp_health.py` → 17 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6874 passed, 1 skipped