### PR TITLE
fix: channel target解決の拒否契約を厳密化 (#2630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(config)`: channel targetの明示指定・`CHANNEL_DIR`・cwd fallbackの優先順位を検証し、fallback cwdがdirectoryでない場合も `ConfigError` で拒否する（#2630）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/utils/channel_target.py
+++ b/src/youtube_automation/utils/channel_target.py
@@ -23,4 +23,7 @@ def resolve_existing_target_dir(target: str | None) -> Path:
             raise ConfigError(f"CHANNEL_DIR で指定されたディレクトリが存在しません: {path}")
         return path
 
-    return Path.cwd().resolve()
+    path = Path.cwd().resolve()
+    if not path.is_dir():
+        raise ConfigError(f"現在の作業ディレクトリが存在しません: {path}")
+    return path

--- a/tests/test_channel_target.py
+++ b/tests/test_channel_target.py
@@ -1,0 +1,78 @@
+"""Channel target resolution precedence and rejection contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.infrastructure.errors import ConfigError
+from youtube_automation.utils.channel_target import resolve_existing_target_dir
+
+
+def test_explicit_target_precedes_channel_dir_and_cwd(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit"
+    configured = tmp_path / "configured"
+    cwd = tmp_path / "cwd"
+    explicit.mkdir()
+    configured.mkdir()
+    cwd.mkdir()
+    monkeypatch.setenv("CHANNEL_DIR", str(configured))
+    monkeypatch.setattr(Path, "cwd", lambda: cwd)
+
+    assert resolve_existing_target_dir(str(explicit)) == explicit.resolve()
+
+
+def test_channel_dir_precedes_cwd(tmp_path, monkeypatch):
+    configured = tmp_path / "configured"
+    cwd = tmp_path / "cwd"
+    configured.mkdir()
+    cwd.mkdir()
+    monkeypatch.setenv("CHANNEL_DIR", str(configured))
+    monkeypatch.setattr(Path, "cwd", lambda: cwd)
+
+    assert resolve_existing_target_dir(None) == configured.resolve()
+
+
+def test_cwd_is_fallback_when_channel_dir_is_unset(tmp_path, monkeypatch):
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.delenv("CHANNEL_DIR", raising=False)
+    monkeypatch.setattr(Path, "cwd", lambda: cwd)
+
+    assert resolve_existing_target_dir(None) == cwd.resolve()
+
+
+@pytest.mark.parametrize("source", ["explicit", "environment"])
+@pytest.mark.parametrize("target_kind", ["missing", "file"])
+def test_configured_target_rejects_missing_and_non_directory(
+    tmp_path,
+    monkeypatch,
+    source,
+    target_kind,
+):
+    target = tmp_path / "target"
+    if target_kind == "file":
+        target.write_text("not a directory", encoding="utf-8")
+    monkeypatch.delenv("CHANNEL_DIR", raising=False)
+
+    if source == "explicit":
+        explicit_target = str(target)
+        message = "--target"
+    else:
+        monkeypatch.setenv("CHANNEL_DIR", str(target))
+        explicit_target = None
+        message = "CHANNEL_DIR"
+
+    with pytest.raises(ConfigError, match=message):
+        resolve_existing_target_dir(explicit_target)
+
+
+def test_invalid_cwd_fallback_is_rejected(tmp_path, monkeypatch):
+    invalid_cwd = tmp_path / "not-a-directory"
+    invalid_cwd.write_text("file", encoding="utf-8")
+    monkeypatch.delenv("CHANNEL_DIR", raising=False)
+    monkeypatch.setattr(Path, "cwd", lambda: invalid_cwd)
+
+    with pytest.raises(ConfigError, match="作業ディレクトリ"):
+        resolve_existing_target_dir(None)


### PR DESCRIPTION
## 対応 issue

Closes #2630

## 変更概要

- 明示 `--target` → `CHANNEL_DIR` → cwdの優先順位を直接検証
- 明示値と環境値の不存在・file指定をConfigErrorで拒否する契約を検証
- cwd fallbackもdirectoryでない場合はConfigErrorで拒否

## 検証

- `nix develop --command uv run pytest -q tests/test_channel_target.py` → 8 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6879 passed, 1 skipped