### PR TITLE
test: profiler初期化の冪等性を検証 (#2634)

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import nullcontext
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -85,3 +86,19 @@ def test_flag_truthy_variants(monkeypatch):
 
 def test_noop_is_nullcontext():
     assert isinstance(profile._NOOP, type(nullcontext()))
+
+
+def test_summary_registration_and_initialization_are_idempotent(monkeypatch):
+    register = MagicMock()
+    monkeypatch.setattr(profile.atexit, "register", register)
+    monkeypatch.setenv("YT_PROFILE", "1")
+    monkeypatch.setenv("YT_PROFILE_SUMMARY", "1")
+
+    with profile.section("first"):
+        pass
+    with profile.section("second"):
+        pass
+
+    register.assert_called_once_with(profile._dump_summary)
+    assert profile._initialized is True
+    assert set(profile._records) == {"first", "second"}


### PR DESCRIPTION
## 対応 issue

Closes #2634

## 変更概要

- `YT_PROFILE_SUMMARY=1` 時のatexit summary登録を直接検証
- 複数 `section()` でも初期化・登録が一度だけで、両recordが保持されることを検証

## 検証

- `nix develop --command uv run pytest -q tests/test_profile.py` → 8 passed
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → passed
- `nix develop --command uv run yt-skills lint` → passed
- `nix develop --command uv run pytest -q` → 6872 passed, 1 skipped