### PR TITLE
test: Analytics初期化の応答契約を検証する #2641

### DIFF
--- a/tests/test_analytics_system.py
+++ b/tests/test_analytics_system.py
@@ -219,6 +219,37 @@ class TestInit:
         assert system.authenticated is False
 
 
+class TestCollectorInitialize:
+    def _collector(self, response):
+        youtube = MagicMock()
+        youtube.resolve_channel.return_value = response
+        collector = YouTubeAnalyticsCollector(
+            youtube_client=youtube,
+            analytics_client=MagicMock(),
+            reporting_client=MagicMock(),
+            channel_root=Path("/tmp/channel"),
+        )
+        return collector, youtube
+
+    def test_success_sets_resolved_channel_id(self):
+        collector, youtube = self._collector({"id": "UC_RESOLVED", "snippet": {"title": "Channel"}})
+
+        collector.initialize()
+
+        assert collector.channel_id == "UC_RESOLVED"
+        youtube.resolve_channel.assert_called_once_with()
+
+    @pytest.mark.parametrize("response", [None, {}])
+    def test_empty_response_raises_without_setting_channel_id(self, response):
+        collector, youtube = self._collector(response)
+
+        with pytest.raises(YouTubeAPIError, match="channel was not found"):
+            collector.initialize()
+
+        assert collector.channel_id is None
+        youtube.resolve_channel.assert_called_once_with()
+
+
 # ---------------------------------------------------------------------------
 # authenticate
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 対応 issue

Closes #2641

## 変更概要

- initialize 成功時に resolve_channel の channel ID が保存される契約を検証
- None / 空レスポンス時に YouTubeAPIError を送出し、channel_id を未設定のまま保つことを検証

## 検証

- nix develop --command uv run pytest -q tests/test_analytics_system.py tests/test_analytics_collector_additional.py: 37 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6874 passed, 1 skipped