### PR TITLE
test: 公開時刻とquota計画の境界を検証する #2646

### DIFF
--- a/tests/test_publish_schedule.py
+++ b/tests/test_publish_schedule.py
@@ -1,0 +1,36 @@
+from datetime import datetime, time, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from youtube_automation.utils.publish_schedule import (
+    parse_default_publish_time,
+    resolve_default_publish_at,
+)
+
+
+def _config(default_time: str, timezone_name: str = "Asia/Tokyo") -> SimpleNamespace:
+    api = SimpleNamespace(
+        default_publish_time=default_time,
+        default_publish_timezone=timezone_name,
+    )
+    return SimpleNamespace(youtube=SimpleNamespace(api=api))
+
+
+def test_parse_default_publish_time_preserves_seconds() -> None:
+    assert parse_default_publish_time("23:59:58") == time(23, 59, 58)
+
+
+@pytest.mark.parametrize("value", ["24:00", "23:60", "23:59:60", "12", "12:00:00:00"])
+def test_parse_default_publish_time_rejects_invalid_values(value: str) -> None:
+    with pytest.raises((ValueError, OverflowError)):
+        parse_default_publish_time(value)
+
+
+def test_resolve_default_publish_at_uses_seconds_at_day_boundary() -> None:
+    result = resolve_default_publish_at(
+        _config("00:00:01", "UTC"),
+        now=datetime(2026, 7, 23, 0, 0, 1, tzinfo=timezone.utc),
+    )
+
+    assert result == "2026-07-24T00:00:01+00:00"

--- a/tests/test_youtube_quota.py
+++ b/tests/test_youtube_quota.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from youtube_automation.utils.youtube_quota import (
     DAILY_BUCKET_LIMITS,
     UNIT_COSTS,
@@ -20,6 +22,18 @@ def test_official_2026_quota_values_and_complete_collection_plan() -> None:
     assert UNIT_COSTS["playlistItems.insert"] == 50
     assert plan.bucket_calls == {"videos.insert": 1, "search.list": 2}
     assert plan.unit_pool_units == 102
+
+
+def test_complete_collection_quota_plan_accepts_zero_playlist_inserts() -> None:
+    plan = complete_collection_quota_plan(playlist_inserts=0)
+
+    assert "playlistItems.insert" not in plan.unit_pool_calls
+    assert plan.unit_pool_units == 52
+
+
+def test_complete_collection_quota_plan_rejects_negative_playlist_inserts() -> None:
+    with pytest.raises(ValueError, match="playlist_inserts must be >= 0"):
+        complete_collection_quota_plan(playlist_inserts=-1)
 
 
 def test_quota_preflight_reports_each_exhausted_pool() -> None:
@@ -65,6 +79,35 @@ def test_quota_preflight_ignores_previous_pacific_day() -> None:
             complete_collection_quota_plan(),
             entries,
             now=datetime(2026, 7, 23, 8, tzinfo=timezone.utc),
+        )
+        == []
+    )
+
+
+def test_quota_preflight_ignores_invalid_timestamps_and_other_services() -> None:
+    entries = [
+        {
+            "timestamp": "not-a-timestamp",
+            "service": "youtube-data-api",
+            "bucket": "videos.insert",
+            "units": 1,
+        },
+        *[
+            {
+                "timestamp": "2026-07-23T12:00:00+00:00",
+                "service": "youtube-analytics-api",
+                "bucket": "videos.insert",
+                "units": 1,
+            }
+            for _ in range(100)
+        ],
+    ]
+
+    assert (
+        quota_shortages(
+            complete_collection_quota_plan(),
+            entries,
+            now=datetime(2026, 7, 23, 13, tzinfo=timezone.utc),
         )
         == []
     )


### PR DESCRIPTION
## 対応 issue

Closes #2646

## 変更概要

- 秒付き公開時刻と無効な時刻値を検証
- playlist insert 0件と負値のquota plan契約を検証
- 不正timestampと異serviceの履歴を当日使用量から除外する契約を検証

## 検証

- nix develop --command uv run pytest -q tests/test_publish_schedule.py tests/test_youtube_quota.py: 13 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6881 passed, 1 skipped