### PR TITLE
fix: video validatorの失敗境界を安定化する #2644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(video-validator)`: ffprobe の `0/0` frame rate を検証失敗として扱い、CLI をクラッシュさせず既存の metadata 読取失敗契約へ統一（#2644）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/analytics/video_validator.py
+++ b/src/youtube_automation/commands/analytics/video_validator.py
@@ -37,7 +37,7 @@ def read_video_metadata(video_path: Path) -> Optional[dict]:
             "bitrate": int(format_info["bit_rate"]) if format_info.get("bit_rate") else None,
             "fps": _parse_fps(video_stream.get("r_frame_rate", "0/1")),
         }
-    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError) as exc:
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, ValueError, ZeroDivisionError) as exc:
         print(f"ffprobe エラー {video_path.name}: {exc}", file=sys.stderr)
         return None
 

--- a/tests/test_video_validator.py
+++ b/tests/test_video_validator.py
@@ -4,8 +4,13 @@
 個別楽曲としてカウントすることを検証する。
 """
 
+import json
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from youtube_automation.commands.analytics import video_validator as vv_module
 from youtube_automation.domains.media.video_validator import VideoValidator
@@ -42,8 +47,6 @@ def test_unexpected_metadata_reader_error_is_not_converted_to_validation_result(
     video = tmp_path / "video.mp4"
     video.touch()
     validator = VideoValidator(lambda _path: (_ for _ in ()).throw(RuntimeError("bug")))
-
-    import pytest
 
     with pytest.raises(RuntimeError, match="bug"):
         validator._validate_single_video(video, "individual")
@@ -112,3 +115,110 @@ class TestGetVideoMetadataSentinel:
 
         assert captured["cmd"][-2] == "--"
         assert captured["cmd"][-1] == "-evil.mp4"
+
+
+class TestReadVideoMetadata:
+    def _stub_run(self, monkeypatch, payload):
+        monkeypatch.setattr(
+            vv_module.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(stdout=json.dumps(payload)),
+        )
+
+    def test_normalizes_ffprobe_metadata(self, monkeypatch):
+        self._stub_run(
+            monkeypatch,
+            {
+                "streams": [
+                    {"codec_type": "audio"},
+                    {
+                        "codec_type": "video",
+                        "width": 1920,
+                        "height": 1080,
+                        "codec_name": "h264",
+                        "r_frame_rate": "30000/1001",
+                    },
+                ],
+                "format": {"duration": "12.5", "bit_rate": "8000000"},
+            },
+        )
+
+        metadata = vv_module.read_video_metadata(Path("video.mp4"))
+
+        assert metadata == {
+            "duration": 12.5,
+            "resolution": "1920x1080",
+            "codec": "h264",
+            "bitrate": 8_000_000,
+            "fps": pytest.approx(29.97002997),
+        }
+
+    def test_returns_none_without_video_stream(self, monkeypatch):
+        self._stub_run(monkeypatch, {"streams": [{"codec_type": "audio"}], "format": {}})
+
+        assert vv_module.read_video_metadata(Path("audio-only.mp4")) is None
+
+    @pytest.mark.parametrize("frame_rate", ["0/0", "invalid"])
+    def test_returns_none_for_invalid_frame_rate(self, monkeypatch, frame_rate):
+        self._stub_run(
+            monkeypatch,
+            {
+                "streams": [{"codec_type": "video", "r_frame_rate": frame_rate}],
+                "format": {},
+            },
+        )
+
+        assert vv_module.read_video_metadata(Path("invalid.mp4")) is None
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            subprocess.CalledProcessError(1, ["ffprobe"]),
+            OSError("ffprobe unavailable"),
+        ],
+    )
+    def test_returns_none_when_ffprobe_fails(self, monkeypatch, failure):
+        def fail(*_args, **_kwargs):
+            raise failure
+
+        monkeypatch.setattr(vv_module.subprocess, "run", fail)
+
+        assert vv_module.read_video_metadata(Path("video.mp4")) is None
+
+    def test_returns_none_for_invalid_json(self, monkeypatch):
+        monkeypatch.setattr(
+            vv_module.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(stdout="{"),
+        )
+
+        assert vv_module.read_video_metadata(Path("video.mp4")) is None
+
+
+class TestMain:
+    def _stub_validator(self, monkeypatch, invalid):
+        class StubValidator:
+            def __init__(self, reader):
+                assert reader is vv_module.read_video_metadata
+
+            def validate_collection(self, path):
+                assert path == "/collection"
+                return {"summary": {"invalid": invalid}}
+
+            def generate_validation_report(self, results):
+                assert results["summary"]["invalid"] == invalid
+                return "report"
+
+        monkeypatch.setattr(vv_module, "VideoValidator", StubValidator)
+
+    @pytest.mark.parametrize(("invalid", "expected"), [(0, 0), (1, 1)])
+    def test_returns_status_from_validation_result(self, monkeypatch, invalid, expected):
+        self._stub_validator(monkeypatch, invalid)
+        monkeypatch.setattr(sys, "argv", ["video-validator", "/collection"])
+
+        assert vv_module.main() == expected
+
+    def test_returns_one_when_collection_argument_is_missing(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["video-validator"])
+
+        assert vv_module.main() == 1


### PR DESCRIPTION
## 対応 issue

Closes #2644

## 変更概要

- ffprobeの0/0 frame rateをmetadata読取失敗として扱う
- 正常metadata整形、video streamなし、不正FPS、ffprobe/JSON失敗を検証
- CLIの成功・検証失敗・引数不足の終了コードを検証

## 検証

- nix develop --command uv run pytest -q tests/test_video_validator.py: 17 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6881 passed, 1 skipped