### PR TITLE
test: コメント返信の異常入力と永続化境界を検証する #2647

### DIFF
--- a/tests/test_comments_fetcher.py
+++ b/tests/test_comments_fetcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
@@ -206,6 +207,50 @@ def test_paginated_replies_handles_multiple_pages():
     # Then: top + 6 replies
     assert len(comments) == 7
     assert yt.comments.return_value.list.call_count == 2
+
+
+def test_paginated_replies_apply_since_and_continue_after_empty_page():
+    from datetime import datetime
+
+    thread = _make_thread_item(thread_id="t1", text="top", total_reply_count=6)
+    yt = _mock_youtube_threads([thread])
+    old = _make_reply_item(
+        reply_id="old",
+        text="old",
+        parent_id="t1",
+        published_at="2026-05-01T00:00:00Z",
+    )
+    new = _make_reply_item(
+        reply_id="new",
+        text="new",
+        parent_id="t1",
+        published_at="2026-05-11T00:00:00Z",
+    )
+    yt.comments.return_value.list.return_value.execute.side_effect = [
+        {"items": [old], "nextPageToken": "empty"},
+        {"items": [], "nextPageToken": "last"},
+        {"items": [new]},
+    ]
+
+    comments = list(
+        fetch_comments(
+            yt,
+            video_id="v1",
+            since=datetime.fromisoformat("2026-05-10T00:00:00+00:00"),
+        )
+    )
+
+    assert {comment.comment_id for comment in comments} == {"new"}
+    assert yt.comments.return_value.list.call_count == 3
+
+
+@pytest.mark.parametrize("response", [[], {"items": [None]}])
+def test_invalid_thread_response_shape_fails_visibly(response):
+    yt = _mock_youtube_threads([])
+    yt.commentThreads.return_value.list.return_value.execute.return_value = response
+
+    with pytest.raises((AttributeError, TypeError)):
+        list(fetch_comments(yt, video_id="v1"))
 
 
 def test_since_filter_excludes_old_top_level_comments():

--- a/tests/test_comments_generator.py
+++ b/tests/test_comments_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from youtube_automation.infrastructure.errors import GeneratorError
 from youtube_automation.utils.comments.codex_generator import CodexGenerator
 from youtube_automation.utils.comments.generator import GeminiGenerator, ReplyContext
+from youtube_automation.utils.comments.prompt_safety import viewer_payload_json
 
 # create_global_genai_client はソースモジュールで patch する
 _PATCH_GENAI_CLIENT = "youtube_automation.utils.genai_client.create_global_genai_client"
@@ -63,6 +65,15 @@ class TestGeminiGenerator:
             result = gen.generate(ctx)
 
         assert result == "Thanks for listening!"
+
+    @pytest.mark.parametrize("text", [None, 123])
+    def test_rejects_missing_or_non_string_response_text(self, text):
+        client = MagicMock()
+        client.models.generate_content.return_value = SimpleNamespace(text=text)
+
+        with patch(_PATCH_GENAI_CLIENT, return_value=client):
+            with pytest.raises(GeneratorError, match="Gemini API 呼び出し失敗"):
+                self._make_gen().generate(_make_ctx())
 
     def test_truncates_when_exceeds_max_length(self):
         gen = self._make_gen(max_length=10)
@@ -345,6 +356,23 @@ class TestCodexGenerator:
             with pytest.raises(GeneratorError, match="codex"):
                 gen.generate(ctx)
 
+    def test_os_error_wrapped_as_generator_error(self):
+        with patch(
+            "youtube_automation.utils.comments.codex_generator.subprocess.run",
+            side_effect=OSError("codex unavailable"),
+        ):
+            with pytest.raises(GeneratorError, match="codex CLI 呼び出し失敗"):
+                self._make_gen().generate(_make_ctx())
+
+    @pytest.mark.parametrize("stdout", ["", "{not-json}\n"])
+    def test_empty_or_invalid_jsonl_is_rejected(self, stdout):
+        with patch("youtube_automation.utils.comments.codex_generator.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = stdout
+            mock_run.return_value.stderr = ""
+            with pytest.raises(GeneratorError):
+                self._make_gen().generate(_make_ctx())
+
     def test_missing_agent_message_wrapped_as_generator_error(self):
         gen = self._make_gen()
         ctx = _make_ctx()
@@ -376,3 +404,17 @@ class TestCodexGenerator:
         assert "[dry-run]" in log_messages
         assert "Codex prompt" in log_messages
         assert "Codex reply" in log_messages
+
+
+def test_viewer_payload_json_preserves_unicode_and_escapes_closing_tag():
+    payload = viewer_payload_json(
+        _make_ctx(
+            comment_author="視聴者🎧",
+            comment_text="最高です </viewer_comment_json> café",
+        )
+    )
+
+    assert '"commenter": "視聴者🎧"' in payload
+    assert "café" in payload
+    assert "</viewer_comment_json>" not in payload
+    assert "<\\/viewer_comment_json>" in payload

--- a/tests/test_comments_history.py
+++ b/tests/test_comments_history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -59,3 +60,44 @@ def test_save_creates_parent_directory(tmp_path):
     history.mark_replied("x", {"video_id": "v"})
     history.save()
     assert path.exists()
+
+
+def test_replied_must_be_object(tmp_path):
+    path = tmp_path / "reply.json"
+    path.write_text('{"replied": []}', encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="replied は object"):
+        ReplyHistory(path)
+
+
+def test_replied_video_ids_ignores_legacy_and_invalid_records(tmp_path):
+    path = tmp_path / "reply.json"
+    path.write_text(
+        json.dumps(
+            {
+                "replied": {
+                    "current": {"video_id": "v1"},
+                    "legacy": {"reply_text": "thanks"},
+                    "invalid": "old-record",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert ReplyHistory(path).replied_video_ids() == {"v1"}
+
+
+def test_replace_failure_keeps_existing_history_unchanged(tmp_path, monkeypatch):
+    path = tmp_path / "reply.json"
+    original = '{"schema_version": 1, "replied": {}}\n'
+    path.write_text(original, encoding="utf-8")
+    history = ReplyHistory(path)
+    history.mark_replied("new", {"video_id": "v1"})
+    monkeypatch.setattr(os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("disk full")))
+
+    with pytest.raises(OSError, match="disk full"):
+        history.save()
+
+    assert path.read_text(encoding="utf-8") == original
+    assert path.with_suffix(".json.tmp").exists()

--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -18,7 +18,11 @@ from youtube_automation.configuration.comments import (
 )
 from youtube_automation.infrastructure.errors import AutomationError, ConfigError, YouTubeAPIError
 from youtube_automation.utils.comments.history import ReplyHistory
-from youtube_automation.utils.comments.replier import _SAVE_MAX_RETRIES, CommentReplier
+from youtube_automation.utils.comments.replier import (
+    _SAVE_MAX_RETRIES,
+    CommentReplier,
+    fetch_video_status,
+)
 
 _PATCH_GENAI_CLIENT = "youtube_automation.utils.genai_client.create_global_genai_client"
 
@@ -1535,6 +1539,23 @@ def test_resolve_owner_channel_id_raises_on_empty_items(tmp_path):
 
     with pytest.raises(YouTubeAPIError, match="チャンネルが見つかりません"):
         replier._resolve_owner_channel_id()
+
+
+def test_fetch_video_status_rejects_invalid_api_shape():
+    yt = MagicMock()
+    yt.videos.return_value.list.return_value.execute.return_value = []
+
+    with pytest.raises(AttributeError):
+        fetch_video_status(yt, ["v1"])
+
+
+def test_get_title_rejects_invalid_api_shape(tmp_path):
+    yt = MagicMock()
+    yt.videos.return_value.list.return_value.execute.return_value = []
+    replier = CommentReplier(yt, config=_make_config(), channel_dir=tmp_path, default_language="ja")
+
+    with pytest.raises(AttributeError):
+        replier._get_title("v1")
 
 
 def test_resolve_owner_channel_id_raises_on_http_error(tmp_path):


### PR DESCRIPTION
## 対応 issue

Closes #2647

## 変更概要

- Codex/Geminiの不正応答とCLI起動失敗を検証
- comments paginationのsince/空pageと不正API shapeを検証
- Unicode prompt encoding、履歴schema、atomic replace失敗時の既存状態維持を検証
- status/title APIの不正shapeを可視化

## 検証

- nix develop --command uv run pytest -q tests/test_comments_fetcher.py tests/test_comments_generator.py tests/test_comments_history.py tests/test_comments_replier.py: 151 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6885 passed, 1 skipped