### PR TITLE
test: captions upload CLIのapply契約を検証する #2649

### DIFF
--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -162,6 +162,25 @@ def test_upload_caption_ask_can_choose_skip(tmp_path, monkeypatch):
     youtube.captions.return_value.update.assert_not_called()
 
 
+def test_upload_caption_ask_can_choose_update(tmp_path, monkeypatch):
+    existing = {"id": "existing-caption", "snippet": {"language": "en", "name": "Old"}}
+    youtube = _youtube_with_captions([existing])
+    monkeypatch.setattr("youtube_automation.infrastructure.captions_adapter.log_quota", MagicMock())
+
+    result = upload_caption(
+        youtube,
+        video_id="video-1",
+        language="en",
+        name="English lyrics",
+        srt_path=_srt(tmp_path),
+        existing_policy="ask",
+        confirm_update=lambda item: item is existing,
+    )
+
+    assert result.action == "updated"
+    youtube.captions.return_value.update.assert_called_once()
+
+
 def test_upload_caption_rejects_ambiguous_existing_tracks(tmp_path, monkeypatch):
     youtube = _youtube_with_captions(
         [

--- a/tests/test_captions_upload_cli.py
+++ b/tests/test_captions_upload_cli.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
+
+from youtube_automation.commands.youtube import captions_upload
 from youtube_automation.commands.youtube.captions_upload import main
+from youtube_automation.infrastructure.errors import YouTubeAPIError
 
 
 def test_dry_run_generates_srt_without_youtube_api(tmp_path, monkeypatch):
@@ -43,3 +49,133 @@ def test_dry_run_generates_srt_without_youtube_api(tmp_path, monkeypatch):
 
     assert code == 0
     assert output.read_text(encoding="utf-8").count(" --> ") == 2
+
+
+def _cli_files(tmp_path, *, include_duration=True):
+    lyrics = tmp_path / "lyrics.txt"
+    lyrics.write_text("Hello", encoding="utf-8")
+    duration = ", 01:00" if include_duration else ""
+    descriptions = tmp_path / "descriptions.md"
+    descriptions.write_text(f"🎵 One track{duration}\n00:00 First\n", encoding="utf-8")
+    return lyrics, descriptions
+
+
+def test_end_time_allows_apply_when_description_has_no_duration(tmp_path, monkeypatch):
+    lyrics, descriptions = _cli_files(tmp_path, include_duration=False)
+    clients = SimpleNamespace(youtube=object())
+    upload = MagicMock(return_value=SimpleNamespace(action="inserted", caption_id="cap-1"))
+    monkeypatch.setattr(captions_upload, "create_authenticated_youtube_clients", lambda: clients)
+    monkeypatch.setattr(captions_upload, "upload_caption", upload)
+
+    code = main(
+        [
+            "--video-id",
+            "video-1",
+            "--lyrics",
+            str(lyrics),
+            "--descriptions",
+            str(descriptions),
+            "--language",
+            "ja",
+            "--name",
+            "Japanese lyrics",
+            "--end-time",
+            "01:00",
+            "--existing",
+            "update",
+            "--apply",
+        ]
+    )
+
+    assert code == 0
+    upload.assert_called_once_with(
+        clients.youtube,
+        video_id="video-1",
+        language="ja",
+        name="Japanese lyrics",
+        srt_path=tmp_path / "captions.ja.srt",
+        existing_policy="update",
+        confirm_update=captions_upload._confirm_update,
+    )
+
+
+def test_missing_duration_without_end_time_exits_one_without_api(tmp_path, monkeypatch):
+    lyrics, descriptions = _cli_files(tmp_path, include_duration=False)
+    auth = MagicMock()
+    monkeypatch.setattr(captions_upload, "create_authenticated_youtube_clients", auth)
+
+    code = main(
+        [
+            "--video-id",
+            "video-1",
+            "--lyrics",
+            str(lyrics),
+            "--descriptions",
+            str(descriptions),
+            "--language",
+            "en",
+            "--apply",
+        ]
+    )
+
+    assert code == 1
+    auth.assert_not_called()
+
+
+@pytest.mark.parametrize("policy", ["ask", "update", "skip"])
+def test_apply_forwards_each_existing_policy(tmp_path, monkeypatch, policy):
+    lyrics, descriptions = _cli_files(tmp_path)
+    upload = MagicMock(return_value=SimpleNamespace(action="skipped", caption_id="cap-1"))
+    monkeypatch.setattr(
+        captions_upload,
+        "create_authenticated_youtube_clients",
+        lambda: SimpleNamespace(youtube="youtube"),
+    )
+    monkeypatch.setattr(captions_upload, "upload_caption", upload)
+
+    code = main(
+        [
+            "--video-id",
+            "video-1",
+            "--lyrics",
+            str(lyrics),
+            "--descriptions",
+            str(descriptions),
+            "--language",
+            "en",
+            "--existing",
+            policy,
+            "--apply",
+        ]
+    )
+
+    assert code == 0
+    assert upload.call_args.kwargs["existing_policy"] == policy
+
+
+@pytest.mark.parametrize("error", [YouTubeAPIError("API failed"), OSError("disk full")])
+def test_apply_failure_returns_one(tmp_path, monkeypatch, error):
+    lyrics, descriptions = _cli_files(tmp_path)
+    monkeypatch.setattr(
+        captions_upload,
+        "create_authenticated_youtube_clients",
+        lambda: SimpleNamespace(youtube="youtube"),
+    )
+    monkeypatch.setattr(captions_upload, "upload_caption", MagicMock(side_effect=error))
+
+    assert (
+        main(
+            [
+                "--video-id",
+                "video-1",
+                "--lyrics",
+                str(lyrics),
+                "--descriptions",
+                str(descriptions),
+                "--language",
+                "en",
+                "--apply",
+            ]
+        )
+        == 1
+    )


### PR DESCRIPTION
## 対応 issue

Closes #2649

## 変更概要

- JSON lyricsを含むdry-run契約に加え、end-timeによるduration補完を検証
- apply時のvideo/language/name/output/existing policy伝播を検証
- ask/update/skipとadapter/API/I/O失敗の終了コードを検証

## 検証

- nix develop --command uv run pytest -q tests/test_captions.py tests/test_captions_upload_cli.py: 24 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6879 passed, 1 skipped