### PR TITLE
test: comments reply CLIの終了契約を検証する #2650

### DIFF
--- a/tests/test_comments_replier.py
+++ b/tests/test_comments_replier.py
@@ -921,6 +921,91 @@ def test_cli_export_candidates_requires_json(monkeypatch, tmp_path, capsys):
     clients.assert_not_called()
 
 
+def test_cli_rejects_mutually_exclusive_modes_before_loading_config(monkeypatch):
+    load = MagicMock()
+    monkeypatch.setattr(comment_reply, "load_config", load)
+
+    with pytest.raises(SystemExit) as exc_info:
+        comment_reply.main(["--dry-run", "--apply"])
+
+    assert exc_info.value.code == 2
+    load.assert_not_called()
+
+
+def test_cli_rejects_invalid_since_before_authentication(monkeypatch):
+    config = SimpleNamespace(
+        comments=_make_config(),
+        youtube=SimpleNamespace(api=SimpleNamespace(language="ja")),
+    )
+    clients = MagicMock()
+    monkeypatch.setattr(comment_reply, "load_config", lambda: config)
+    monkeypatch.setattr(comment_reply, "YouTubeClients", clients)
+
+    with pytest.raises(SystemExit) as exc_info:
+        comment_reply.main(["--dry-run", "--since", "not-a-date"])
+
+    assert "--since は ISO8601" in str(exc_info.value)
+    clients.assert_not_called()
+
+
+def test_cli_disabled_config_returns_one_without_authentication(monkeypatch, capsys):
+    config = SimpleNamespace(
+        comments=SimpleNamespace(enabled=False),
+        youtube=SimpleNamespace(api=SimpleNamespace(language="ja")),
+    )
+    clients = MagicMock()
+    monkeypatch.setattr(comment_reply, "load_config", lambda: config)
+    monkeypatch.setattr(comment_reply, "YouTubeClients", clients)
+
+    assert comment_reply.main(["--dry-run"]) == 1
+
+    assert "comments.enabled=false" in capsys.readouterr().err
+    clients.assert_not_called()
+
+
+def test_cli_api_error_returns_one(monkeypatch, tmp_path, capsys):
+    config = SimpleNamespace(
+        comments=_make_config(),
+        youtube=SimpleNamespace(api=SimpleNamespace(language="ja")),
+    )
+
+    class FailingReplier:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, **_kwargs):
+            raise YouTubeAPIError("quota exceeded")
+
+    monkeypatch.setattr(comment_reply, "load_config", lambda: config)
+    monkeypatch.setattr(comment_reply, "YouTubeClients", lambda **_: SimpleNamespace(youtube=object()))
+    monkeypatch.setattr(comment_reply, "CommentReplier", FailingReplier)
+    monkeypatch.setattr(comment_reply, "_channel_dir", lambda: tmp_path)
+
+    assert comment_reply.main(["--dry-run"]) == 1
+    assert "quota exceeded" in capsys.readouterr().err
+
+
+def test_cli_plan_errors_return_two(monkeypatch, tmp_path):
+    config = SimpleNamespace(
+        comments=_make_config(),
+        youtube=SimpleNamespace(api=SimpleNamespace(language="ja")),
+    )
+    plan = SimpleNamespace(
+        planned=[],
+        replied=[],
+        skipped=[],
+        errors=[{"video_id": "v1", "comment_id": "c1", "error": "insert failed"}],
+    )
+    replier = MagicMock()
+    replier.run.return_value = plan
+    monkeypatch.setattr(comment_reply, "load_config", lambda: config)
+    monkeypatch.setattr(comment_reply, "YouTubeClients", lambda **_: SimpleNamespace(youtube=object()))
+    monkeypatch.setattr(comment_reply, "CommentReplier", MagicMock(return_value=replier))
+    monkeypatch.setattr(comment_reply, "_channel_dir", lambda: tmp_path)
+
+    assert comment_reply.main(["--dry-run", "--json"]) == 2
+
+
 def test_cli_export_candidates_json_excludes_comment_with_later_owner_reply(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
## 対応 issue

Closes #2650

## 変更概要

- dry-run/apply排他と不正sinceを認証前に拒否する契約を検証
- disabled設定とAPI例外の終了コード1を検証
- plan.errorsが終了コード2へ反映される契約を検証

## 検証

- nix develop --command uv run pytest -q tests/test_comments_replier.py: 102 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6876 passed, 1 skipped