### PR TITLE
fix: pinned comment CLIの履歴失敗を処理する #2652

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(pinned-comment)`: CLI で破損した履歴 JSON と atomic 履歴保存の I/O 失敗を終了コード 1 のエラー契約へ変換し、未処理例外で終了しないようにした（#2652）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/youtube/pinned_comment.py
+++ b/src/youtube_automation/commands/youtube/pinned_comment.py
@@ -368,9 +368,9 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 1
 
     history_path = _channel_dir() / cfg.history_file
-    history = load_history(history_path)
 
     try:
+        history = load_history(history_path)
         if args.collection:
             targets = resolve_targets_from_collection(Path(args.collection))
         else:
@@ -393,7 +393,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             delay=cfg.delay_between_posts_sec,
             history_path=history_path,
         )
-    except AutomationError as e:
+    except (AutomationError, OSError, json.JSONDecodeError) as e:
         print(f"[error] {e}", file=sys.stderr)
         return 1
 

--- a/tests/test_pinned_comment.py
+++ b/tests/test_pinned_comment.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from googleapiclient.errors import HttpError
@@ -480,3 +482,89 @@ def test_build_plan_insert_failure_records_quota_and_keeps_error(quota_calls):
     assert plan["posted"] == []
     assert len(plan["errors"]) == 1
     assert "status=403" in plan["errors"][0]["error"]
+
+
+def _cli_config():
+    return SimpleNamespace(
+        pinned_comment=SimpleNamespace(
+            enabled=True,
+            default_language="en",
+            templates={"en": "{video_title}"},
+            history_file="pinned-history.json",
+            delay_between_posts_sec=0,
+        )
+    )
+
+
+def _patch_cli(monkeypatch, tmp_path, youtube):
+    monkeypatch.setattr(pinned_comment, "load_config", _cli_config)
+    monkeypatch.setattr(pinned_comment, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(pinned_comment, "YouTubeOAuthHandler", lambda: object())
+    monkeypatch.setattr(
+        pinned_comment,
+        "YouTubeClients",
+        lambda **_kwargs: SimpleNamespace(youtube=youtube),
+    )
+
+
+def test_main_rejects_mutually_exclusive_targets_before_config(monkeypatch):
+    load = MagicMock()
+    monkeypatch.setattr(pinned_comment, "load_config", load)
+
+    with pytest.raises(SystemExit) as exc_info:
+        pinned_comment.main(["--video-id", "v1", "--collection", "/collection", "--dry-run"])
+
+    assert exc_info.value.code == 2
+    load.assert_not_called()
+
+
+def test_main_corrupt_history_returns_one_without_authentication(tmp_path, monkeypatch):
+    (tmp_path / "pinned-history.json").write_text("{", encoding="utf-8")
+    clients = MagicMock()
+    monkeypatch.setattr(pinned_comment, "load_config", _cli_config)
+    monkeypatch.setattr(pinned_comment, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(pinned_comment, "YouTubeClients", clients)
+
+    assert pinned_comment.main(["--video-id", "v1", "--dry-run"]) == 1
+    clients.assert_not_called()
+
+
+def test_main_save_failure_returns_one_after_post_without_replacing_history(tmp_path, monkeypatch):
+    youtube = FakeYouTube(status_items={"v1": {"privacyStatus": "public"}}, snippet_titles={"v1": "Title"})
+    _patch_cli(monkeypatch, tmp_path, youtube)
+    monkeypatch.setattr(
+        pinned_comment,
+        "save_history",
+        MagicMock(side_effect=OSError("disk full")),
+    )
+
+    assert pinned_comment.main(["--video-id", "v1", "--apply"]) == 1
+    assert youtube.inserted == [("v1", "Title")]
+    assert not (tmp_path / "pinned-history.json").exists()
+
+
+def test_main_multiple_targets_prints_complete_json_summary(tmp_path, monkeypatch, capsys):
+    youtube = FakeYouTube(
+        status_items={
+            "public": {"privacyStatus": "public"},
+            "private": {"privacyStatus": "private"},
+        },
+        snippet_titles={"public": "Public"},
+    )
+    _patch_cli(monkeypatch, tmp_path, youtube)
+
+    code = pinned_comment.main(
+        [
+            "--video-id",
+            "public",
+            "--video-id",
+            "private",
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert [row["video_id"] for row in payload["planned"]] == ["public"]
+    assert payload["skipped"] == [{"video_id": "private", "reason": "video_private"}]


### PR DESCRIPTION
## 対応 issue

Closes #2652

## 変更概要

- 破損履歴JSONと履歴I/O失敗をCLI終了コード1へ変換
- target/modeの入力排他を認証前に検証
- save失敗時の投稿/未保存状態と複数target summaryを検証

## 検証

- nix develop --command uv run pytest -q tests/test_pinned_comment.py: 30 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6875 passed, 1 skipped