### PR TITLE
test: archive不足時の終了コードを厳密化する #2654

### DIFF
--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -1464,7 +1464,7 @@ class TestStreamingArchiveCheckCli:
                 rc = streaming_archive_check.main()
             except SystemExit as e:
                 rc = e.code
-        assert rc not in (0, None), f"件数不足で exit 非 0 にならない: {rc}"
+        assert rc == 1, f"件数不足の終了コードが通知失敗の 2 と区別されない: {rc}"
 
     def test_expected_is_required(self):
         """Given --expected なし


### PR DESCRIPTION
## 対応 issue

Closes #2654

## 変更概要

- archive件数不足かつ通知失敗なしの終了コードを厳密に1と検証
- 通知失敗を示す終了コード2との区別を固定

## 検証

- nix develop --command uv run pytest -q tests/test_streaming_healthcheck.py: 103 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6871 passed, 1 skipped