### PR TITLE
test: upload副作用とretry境界を検証する #2655

### DIFF
--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -730,6 +730,44 @@ def test_list_playlist_video_ids_returns_partial_result_for_invalid_item(manager
     assert manager._list_playlist_video_ids("PL_ALL") == {"v1"}
 
 
+def test_list_playlist_video_ids_keeps_first_page_when_next_page_fails(manager):
+    items = manager._youtube.playlistItems.return_value
+    first_request = items.list.return_value
+    first_response = {"items": [{"contentDetails": {"videoId": "v1"}}]}
+    first_request.execute.return_value = first_response
+    second_request = MagicMock()
+    second_request.execute.side_effect = OSError("page unavailable")
+    items.list_next.side_effect = [second_request]
+
+    assert manager._list_playlist_video_ids("PL_ALL") == {"v1"}
+
+
+def test_write_back_playlist_ids_preserves_unrelated_config(manager, monkeypatch):
+    raw = {
+        "playlists": {
+            "main": {"title": "Main", "playlist_id": None},
+            "existing": {"title": "Existing", "playlist_id": "PL_OLD"},
+        },
+        "unrelated": {"keep": True},
+    }
+    write = MagicMock()
+    monkeypatch.setattr("youtube_automation.domains.uploads.playlists.read_json", lambda _path: raw)
+    monkeypatch.setattr("youtube_automation.domains.uploads.playlists.write_json", write)
+
+    manager._write_back_playlist_ids({"main": "PL_NEW", "missing": "PL_IGNORED"})
+
+    write.assert_called_once_with(
+        manager._config_path,
+        {
+            "playlists": {
+                "main": {"title": "Main", "playlist_id": "PL_NEW"},
+                "existing": {"title": "Existing", "playlist_id": "PL_OLD"},
+            },
+            "unrelated": {"keep": True},
+        },
+    )
+
+
 @pytest.mark.parametrize("response", [None, {"items": {"videoId": "v1"}}])
 def test_list_playlist_video_ids_returns_empty_for_invalid_response_shape(manager, response):
     manager._youtube.playlistItems.return_value.list.return_value.execute.return_value = response

--- a/tests/test_upload_core_thumbnail.py
+++ b/tests/test_upload_core_thumbnail.py
@@ -7,6 +7,9 @@ plan 020 Step 5: 全品質失敗時の temp ファイルリークと、ffmpeg �
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from googleapiclient.errors import HttpError
+from httplib2 import Response
+
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 
@@ -105,3 +108,37 @@ class TestCompressThumbnailFailureCleanup:
         result = core._compress_thumbnail(thumb)
 
         assert result == thumb
+
+    def test_returns_first_successful_compressed_path_and_stops_quality_fallback(self, tmp_path):
+        core = _make_core()
+        thumb = tmp_path / "thumb.jpg"
+        thumb.write_bytes(b"x" * (3 * 1024 * 1024))
+        compressed = tmp_path / "compressed.jpg"
+
+        with patch(
+            "youtube_automation.domains.uploads.youtube.compress_image",
+            return_value=compressed,
+        ) as compress:
+            result = core._compress_thumbnail(thumb)
+
+        assert result == compressed
+        compress.assert_called_once_with(thumb, [2], 2_097_152)
+
+
+def test_resumable_upload_expired_session_clears_persisted_uri():
+    core = _make_core()
+    request = MagicMock(resumable_uri="https://upload/session")
+    request.next_chunk.side_effect = HttpError(
+        Response({"status": "410"}),
+        b'{"error": {"message": "gone"}}',
+    )
+    callback = MagicMock()
+
+    result = core._resumable_upload(
+        request,
+        "video.mp4",
+        on_session_uri_changed=callback,
+    )
+
+    assert result is None
+    callback.assert_called_once_with(None)


### PR DESCRIPTION
## 対応 issue

Closes #2655

## 変更概要

- thumbnail圧縮成功時に最初のqualityで停止し圧縮Pathを返す契約を検証
- resumable session 410時のURI clear callbackを検証
- playlist pagination途中失敗時の部分結果とconfig書戻しの保持契約を検証

## 検証

- nix develop --command uv run pytest -q tests/test_playlist_manager.py tests/test_upload_core_thumbnail.py tests/test_youtube_auto_uploader.py: 129 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6875 passed, 1 skipped