### PR TITLE
fix: rain layerのstate保存失敗を処理する #2660

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(apply-rain-layers)`: ffmpeg 出力後の workflow-state 保存失敗を終了コード 1 として報告し、生成済み出力と更新前 state を保ったまま安全に再実行できるようにした（#2660）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/media/apply_rain_layers.py
+++ b/src/youtube_automation/commands/media/apply_rain_layers.py
@@ -267,7 +267,11 @@ def apply_rain_layers(
         )
         return 1
 
-    _update_workflow_state_raw_master(paths.workflow_state_path, rain_cfg["output_name"])
+    try:
+        _update_workflow_state_raw_master(paths.workflow_state_path, rain_cfg["output_name"])
+    except OSError as e:
+        print(f"ERROR: workflow-state.json の更新に失敗: {e}", file=sys.stderr)
+        return 1
 
     if not quiet:
         print(f"  Rain layer applied: {output.name} (assets.raw_master を更新)")

--- a/tests/test_apply_rain_layers.py
+++ b/tests/test_apply_rain_layers.py
@@ -506,6 +506,38 @@ class TestApplyRainLayersRun:
 
 
 class TestApplyRainLayersFailure:
+    def test_state_write_failure_preserves_output_and_allows_retry(self, tmp_path, monkeypatch):
+        collection = _setup_collection(tmp_path, n_rain=1)
+        workflow_state = collection / "workflow-state.json"
+        original_state = {"assets": {"raw_master": "master.mp3", "master_audio": None}}
+        workflow_state.write_text(json.dumps(original_state), encoding="utf-8")
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        _patch_skill_config(monkeypatch, {"post_processing": {"rain_layers": {"enabled": True}}})
+        captured: dict = {}
+        original_update = mod._update_workflow_state_raw_master
+        attempts = 0
+
+        def fail_once(path, new_name):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OSError("disk full")
+            return original_update(path, new_name)
+
+        monkeypatch.setattr(mod, "_update_workflow_state_raw_master", fail_once)
+        with patch.object(mod.subprocess, "run", side_effect=_fake_run_writes_output(captured)):
+            first_rc = apply_rain_layers(collection, collection, quiet=True)
+
+            assert first_rc == 1
+            assert json.loads(workflow_state.read_text(encoding="utf-8")) == original_state
+            assert (collection / "01-master" / "master-rain.wav").read_bytes() == _NEW_OUTPUT_BYTES
+
+            second_rc = apply_rain_layers(collection, collection, quiet=True)
+
+        assert second_rc == 0
+        assert json.loads(workflow_state.read_text(encoding="utf-8"))["assets"]["raw_master"] == "master-rain.wav"
+        assert len(captured["cmds"]) == 2
+
     def test_returns_rc1_when_ffmpeg_not_on_path(self, tmp_path, monkeypatch):
         # Given: enabled + rain wav 在り、ffmpeg 未インストール
         collection = _setup_collection(tmp_path, n_rain=1)


### PR DESCRIPTION
## 対応 issue

Closes #2660

## 変更概要

- ffmpeg出力後のworkflow-state保存OSErrorを終了コード1へ変換
- 保存失敗時に生成済みWAVと更新前stateが保持されることを検証
- 同一collectionの再実行でstate更新まで完了できることを検証

## 検証

- nix develop --command uv run pytest -q tests/test_apply_rain_layers.py: 33 passed
- nix develop --command uv run ruff check .: passed
- nix develop --command uv run ruff format --check .: passed
- nix develop --command uv run yt-skills lint: passed
- nix develop --command uv run pytest -q: 6872 passed, 1 skipped