### PR TITLE
fix: バッチ状態保存の部分失敗を終了コードへ反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(generate-videos-batch)`: 複数 collection の workflow-state 永続化が途中で失敗した場合を終了コード 1 に変換し、更新済み collection を再実行対象から除外したまま未更新分だけ再開できる契約を固定（#2662）。
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/commands/media/generate_videos_batch.py
+++ b/src/youtube_automation/commands/media/generate_videos_batch.py
@@ -231,7 +231,7 @@ def main() -> int:
         print(f"対象: {len(targets)} collection / 最大並列数: {min(max_workers, len(targets))}")
         results = run_batch_parallel(targets, max_workers=max_workers, script_path=_script_path(root))
         updated = update_workflow_states(results)
-    except (ConfigError, ValidationError) as exc:
+    except (ConfigError, ValidationError, OSError) as exc:
         print(f"ERROR: {exc}")
         return 1
 

--- a/tests/test_generate_videos_batch.py
+++ b/tests/test_generate_videos_batch.py
@@ -119,6 +119,42 @@ def test_update_workflow_states_accepts_successful_collection_paths(tmp_path: Pa
     assert batch.update_workflow_states([collection]) == {collection: "Success-Master.mp4"}
 
 
+def test_main_state_write_partial_failure_leaves_only_failed_target_for_retry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    first = _collection(tmp_path, "planning", "first", audio="master.mp3", video=None)
+    second = _collection(tmp_path, "planning", "second", audio="master.mp3", video=None)
+    (first / "01-master" / "First-Master.mp4").touch()
+    (second / "01-master" / "Second-Master.mp4").touch()
+    script = tmp_path / ".claude" / "skills" / "videoup" / "references" / "generate_videos.sh"
+    script.parent.mkdir(parents=True)
+    script.touch()
+    results = [batch.BatchResult(first, 0), batch.BatchResult(second, 0)]
+    monkeypatch.setattr("sys.argv", ["yt-generate-videos-batch"])
+    monkeypatch.setattr(batch, "channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(batch, "run_batch_parallel", lambda *_args, **_kwargs: results)
+    original_write = batch._write_state_atomic
+    writes = 0
+
+    def fail_second(path, state):
+        nonlocal writes
+        writes += 1
+        if writes == 2:
+            raise OSError("disk full")
+        original_write(path, state)
+
+    monkeypatch.setattr(batch, "_write_state_atomic", fail_second)
+
+    assert batch.main() == 1
+
+    first_state = json.loads((first / "workflow-state.json").read_text(encoding="utf-8"))
+    second_state = json.loads((second / "workflow-state.json").read_text(encoding="utf-8"))
+    assert first_state["assets"]["master_video"] == "First-Master.mp4"
+    assert second_state["assets"]["master_video"] is None
+    assert batch.find_batch_targets(tmp_path) == [second.resolve()]
+
+
 @pytest.mark.parametrize(
     ("cli", "env", "config", "cpu", "expected"),
     [


### PR DESCRIPTION
## 対応issue

Closes #2662

## 変更概要

- 動画バッチのstate保存失敗を捕捉して終了コード1へ反映
- 先行成功分を保持し、失敗対象のみ次回探索で再選択されることを検証
- CHANGELOGを更新

## 検証

- `nix develop --command uv run pytest -q tests/test_generate_videos_batch.py` — 16 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6872 passed, 1 skipped