### PR TITLE
fix: ffprobeの非有限値を取得失敗として扱う

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ffprobe の `nan` / `inf` / `-inf` を duration・bitrate の取得失敗として正規化（#2668）
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/utils/probe.py
+++ b/src/youtube_automation/utils/probe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from math import isfinite
 from pathlib import Path
 
 DEFAULT_FFPROBE_TIMEOUT_SECONDS = 30
@@ -28,7 +29,8 @@ def probe_duration(path: Path) -> float | None:
             check=True,
             timeout=DEFAULT_FFPROBE_TIMEOUT_SECONDS,
         )
-        return float(result.stdout.strip())
+        value = float(result.stdout.strip())
+        return value if isfinite(value) else None
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, FileNotFoundError):
         return None
 
@@ -57,6 +59,7 @@ def probe_bitrate(path: Path) -> float | None:
             check=True,
             timeout=DEFAULT_FFPROBE_TIMEOUT_SECONDS,
         )
-        return float(result.stdout.strip())
+        value = float(result.stdout.strip())
+        return value if isfinite(value) else None
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, FileNotFoundError):
         return None

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -6,6 +6,10 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from youtube_automation.commands.media import generate_master
+from youtube_automation.infrastructure.errors import ValidationError
 from youtube_automation.utils import probe
 
 
@@ -50,6 +54,13 @@ def test_returns_none_on_unparseable_stdout(monkeypatch) -> None:
         return SimpleNamespace(stdout="not a number\n")
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
+    assert probe.probe_duration(Path("/fake.mp3")) is None
+
+
+@pytest.mark.parametrize("stdout", ["nan\n", "inf\n", "-inf\n"])
+def test_probe_duration_returns_none_on_non_finite_stdout(monkeypatch, stdout) -> None:
+    monkeypatch.setattr(probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(stdout=stdout))
+
     assert probe.probe_duration(Path("/fake.mp3")) is None
 
 
@@ -121,6 +132,21 @@ def test_probe_bitrate_returns_none_on_unparseable(monkeypatch) -> None:
 
     monkeypatch.setattr(probe.subprocess, "run", fake_run)
     assert probe.probe_bitrate(Path("/fake.mp4")) is None
+
+
+@pytest.mark.parametrize("stdout", ["nan\n", "inf\n", "-inf\n"])
+def test_probe_bitrate_returns_none_on_non_finite_stdout(monkeypatch, stdout) -> None:
+    monkeypatch.setattr(probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(stdout=stdout))
+
+    assert probe.probe_bitrate(Path("/fake.mp4")) is None
+
+
+def test_generate_master_rejects_non_finite_track_duration(monkeypatch) -> None:
+    monkeypatch.setattr(probe.subprocess, "run", lambda *_args, **_kwargs: SimpleNamespace(stdout="nan\n"))
+    monkeypatch.setattr(generate_master, "probe_duration", probe.probe_duration)
+
+    with pytest.raises(ValidationError, match="probe に失敗"):
+        generate_master._sum_track_duration([Path("/fake.mp3")])
 
 
 # ---------- argv-injection defense (Issue #167): "--" sentinel ----------


### PR DESCRIPTION
## 対応issue

Closes #2668

## 変更概要

- durationとbitrateのnan/inf/-infをNoneへ正規化
- 両公開関数とmaster生成呼出元の失敗契約を検証
- CHANGELOGを更新

## 検証

- `nix develop --command uv run pytest -q tests/test_probe.py tests/test_generate_master.py` — 106 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6878 passed, 1 skipped