### PR TITLE
test: visualizer maskの数値境界を検証

### DIFF
--- a/tests/test_audio_visualizer_mask.py
+++ b/tests/test_audio_visualizer_mask.py
@@ -52,3 +52,43 @@ def test_heart_mask_places_discrete_bars_on_cardioid(tmp_path: Path) -> None:
 def test_parse_size_rejects_invalid_values(value: str) -> None:
     with pytest.raises(ValueError, match="WIDTHxHEIGHT"):
         parse_size(value)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"bars": 0},
+        {"inner_r": -1},
+        {"length": 0},
+        {"arc_deg": (0, 0)},
+        {"arc_deg": (-1, 360)},
+        {"arc_deg": (0, 361)},
+        {"arc_deg": (300, 200)},
+    ],
+)
+def test_generate_mask_rejects_invalid_geometry_without_creating_output(tmp_path: Path, override: dict) -> None:
+    output = tmp_path / "invalid.png"
+    kwargs = {
+        "style": "ring",
+        "size": "300x110",
+        "bars": 12,
+        "inner_r": 30,
+        "length": 20,
+        "arc_deg": (0, 360),
+        **override,
+    }
+
+    with pytest.raises(ValueError):
+        generate_mask(output, **kwargs)
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("size", ["301x110", "300x111"])
+def test_generate_mirror_mask_rejects_odd_dimensions_without_output(tmp_path: Path, size: str) -> None:
+    output = tmp_path / "invalid-mirror.png"
+
+    with pytest.raises(ValueError, match="both be even"):
+        generate_mask(output, style="mirror-mountain", size=size, bars=16)
+
+    assert not output.exists()


### PR DESCRIPTION
## 対応issue

Closes #2666

## 変更概要

- bars、内半径、長さ、arc範囲の不正境界を検証
- mirror時の奇数幅・奇数高さを拒否し、出力を作らない契約を検証

## 検証

- `nix develop --command uv run pytest -q tests/test_audio_visualizer_mask.py` — 17 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6880 passed, 1 skipped