### PR TITLE
fix: 動画metadata欠落をvalidation errorへ分類

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- 動画 metadata の codec 欠落・非文字列を例外にせず validation error として分類（#2671）
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/domains/media/video_validator.py
+++ b/src/youtube_automation/domains/media/video_validator.py
@@ -205,7 +205,7 @@ class VideoValidator:
 
         # 解像度チェック
         resolution = video_info.get("resolution", "0x0")
-        if resolution == "0x0":
+        if not resolution or resolution == "0x0":
             errors.append("解像度が取得できません")
         else:
             try:
@@ -216,8 +216,8 @@ class VideoValidator:
                 errors.append("解像度の形式が不正です")
 
         # コーデックチェック
-        codec = video_info.get("codec", "")
-        if codec.lower() not in SUPPORTED_CODECS:
+        codec = video_info.get("codec") or ""
+        if not isinstance(codec, str) or codec.lower() not in SUPPORTED_CODECS:
             errors.append(f"サポートされていないコーデックです: {codec}")
 
         return errors

--- a/tests/test_video_validator.py
+++ b/tests/test_video_validator.py
@@ -7,6 +7,8 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from youtube_automation.commands.analytics import video_validator as vv_module
 from youtube_automation.domains.media.video_validator import VideoValidator
 
@@ -43,10 +45,62 @@ def test_unexpected_metadata_reader_error_is_not_converted_to_validation_result(
     video.touch()
     validator = VideoValidator(lambda _path: (_ for _ in ()).throw(RuntimeError("bug")))
 
-    import pytest
-
     with pytest.raises(RuntimeError, match="bug"):
         validator._validate_single_video(video, "individual")
+
+
+def test_none_metadata_is_classified_as_invalid_error(tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+
+    result = VideoValidator(lambda _path: None)._validate_single_video(video, "individual")
+
+    assert result["valid"] is False
+    assert result["errors"] == ["動画メタデータの取得に失敗しました"]
+    assert result["warnings"] == []
+
+
+def test_partial_metadata_is_invalid_without_exception(tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+
+    result = VideoValidator(lambda _path: {"duration": 120})._validate_single_video(video, "individual")
+
+    assert result["valid"] is False
+    assert "解像度が取得できません" in result["errors"]
+    assert any("サポートされていないコーデックです" in error for error in result["errors"])
+    assert result["warnings"] == []
+
+
+def test_valid_metadata_keeps_quality_problem_as_warning(tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    metadata = {
+        "duration": 120,
+        "resolution": "1920x1080",
+        "codec": "h264",
+        "bitrate": 1_000_000,
+        "fps": 30,
+    }
+
+    result = VideoValidator(lambda _path: metadata)._validate_single_video(video, "individual")
+
+    assert result["valid"] is True
+    assert result["errors"] == []
+    assert result["warnings"] == ["1080p動画のビットレートが推奨範囲外です（8-12 Mbps）"]
+
+
+@pytest.mark.parametrize("error", [OSError("io"), ValueError("bad"), TypeError("shape")])
+def test_expected_metadata_reader_errors_are_classified_without_propagation(tmp_path, error):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"video")
+    validator = VideoValidator(lambda _path: (_ for _ in ()).throw(error))
+
+    result = validator._validate_single_video(video, "individual")
+
+    assert result["valid"] is False
+    assert result["errors"] == [f"検証エラー: {error}"]
+    assert result["warnings"] == []
 
 
 def test_mixed_extensions_are_counted(tmp_path):


### PR DESCRIPTION
## 対応issue

Closes #2671

## 変更概要

- codecとresolutionの欠落を例外にせずvalidation errorへ分類
- metadata None、部分値、OSError/ValueError/TypeError、warningのみの入力を検証
- CHANGELOGを更新

## 検証

- `nix develop --command uv run pytest -q tests/test_video_validator.py` — 13 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — 6877 passed, 1 skipped