### PR TITLE
fix: Lyria回収保存失敗でも中断を保持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Lyria の中断時回収ファイル保存に失敗しても元の `KeyboardInterrupt` を保ち、誤った回収成功表示を出さないよう修正（#2667）
+
 - `chore(takt)`: ユニットテスト監査で稼働中の `audit-unit-split` workflow 資産（workflow 1 本 + facets 4 本、v3 の上書きセマンティクス対策済み）を無改変で git 管理下に置いた。#2686 で `.takt/workflows/` / `.takt/facets/` の git 管理が前提となったため、worktree・他 checkout でも定義を解決できるようにする（#2690）。
 
 - `feat(takt)`: リポジトリ専用 workflow 群を整備し、takt を開発の標準実装経路へ戻した（#2453 の廃止根拠だった「workflow 実体の不在」を、`.takt/workflows/` の git 管理 + `takt workflow doctor` 検証で解消）。レーンは yt-auto-feature（設計ゲート + テスト先行）/ yt-auto-fix（診断ゲート + 再現テスト red 検証）/ yt-auto-docs（文書・スキル限定の軽量レーン）/ yt-auto-maintenance（維持契約の列挙 + safety net 付きリファクタリング）/ yt-auto-audit（台帳ベース汎用監査）の 5 本と、共通 callable の yt-auto-intake / yt-auto-impl-review。全実装レーンに CI 同等ゲート（`ci_verify`: ruff / any-gate / pytest / CHANGELOG のローカル実行。ローカル git hook 廃止後の push 前関門）を置き、facets（personas / knowledge / policies / instructions / output-contracts）約 50 本と persona routing を追加した。CLAUDE.md / AGENTS.md / `docs/development.md` / `docs/takt-operations.md` の「takt は使用しない」を反転し、`/issue-direct` は対話用の代替経路として残した（#2686）。

--- a/src/youtube_automation/utils/lyria_client.py
+++ b/src/youtube_automation/utils/lyria_client.py
@@ -204,7 +204,11 @@ def _recover_audio_on_interrupt(response: requests.Response) -> None:
     if audio is None:
         print("\n[Interrupt] Ctrl+C 検出。退避可能なオーディオデータがありませんでした。")
         return
-    path = persist_recovered_audio(audio)
+    try:
+        path = persist_recovered_audio(audio)
+    except OSError as e:
+        print(f"\n[Interrupt] 支払い済みオーディオの退避に失敗しました: {e}")
+        return
     print(
         f"\n[Recovered] 支払い済みオーディオを退避しました → {path}\n"
         "            手動で WAV 化して 02-Individual-music/ に置けば再課金なしで再利用できます。"

--- a/tests/test_lyria_client.py
+++ b/tests/test_lyria_client.py
@@ -306,6 +306,41 @@ class TestInterruptRecovery:
         assert len(recovered) == 1
         assert recovered[0].read_bytes() == audio
 
+    def test_recovery_write_failure_preserves_existing_files_and_reraises_interrupt(
+        self, mock_token, tmp_path, monkeypatch, capsys
+    ):
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "my-project"
+        audio = b"\xff\xfb\x90\x00new-paid-audio"
+        from youtube_automation.utils import lyria_client
+
+        recovery_dir = tmp_path / "tmp" / "lyria-recovered"
+        recovery_dir.mkdir(parents=True)
+        existing = recovery_dir / "existing.mp3"
+        existing.write_bytes(b"existing-paid-audio")
+        monkeypatch.setattr(lyria_client, "channel_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            lyria_client,
+            "persist_recovered_audio",
+            MagicMock(side_effect=OSError("disk full")),
+        )
+
+        resp = MagicMock()
+        resp.ok = True
+        good_body = {
+            "outputs": [{"type": "audio", "mime_type": "audio/mpeg", "data": base64.b64encode(audio).decode()}]
+        }
+        resp.json.side_effect = [KeyboardInterrupt(), good_body]
+
+        with patch.object(lyria_client.requests, "post", return_value=resp):
+            with pytest.raises(KeyboardInterrupt):
+                lyria_client.generate_music("p", "lyria-3-pro-preview")
+
+        assert existing.read_bytes() == b"existing-paid-audio"
+        assert list(recovery_dir.iterdir()) == [existing]
+        output = capsys.readouterr().out
+        assert "退避に失敗しました: disk full" in output
+        assert "[Recovered]" not in output
+
     def test_persist_recovered_audio_writes_sha1_path_idempotently(self, tmp_path, monkeypatch):
         import hashlib
 


### PR DESCRIPTION
## 対応issue

Closes #2667

## 変更概要

- 中断時の課金済みaudio退避がOSErrorになっても元のKeyboardInterruptを保持
- 既存回収物を不変に保ち、誤ったRecovered表示を抑止
- CHANGELOGを更新

## 検証

- `nix develop --command uv run pytest -q tests/test_lyria_client.py` — 56 passed
- `nix develop --command uv run pytest -q tests/test_collection_serve_lifecycle.py::test_console_script_unexpected_sigterm_remains_traceable_failure` — 1 passed（初回全回帰の無関係な時刻依存失敗を隔離確認）
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `nix develop --command uv run yt-skills lint` — passed (57 skills)
- `nix develop --command uv run pytest -q` — rerun 6872 passed, 1 skipped