### PR TITLE
fix(suno-distrokid): 監査findingの回帰契約を追加 (#2729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-distrokid)`: DistroKid の atomic write・metadata・workflow-state 読込境界と、Suno の ffmpeg cleanup・unattended HTTP・verify CLI・artifact reader の成功／失敗契約を直接回帰テストで固定し、不正な workflow-state shape と I/O 失敗を `ConfigError` に統一した（#2719, #2720, #2721, #2722, #2723, #2724, #2725, #2726, #2727, #2728, #2729）。
 - `fix(analytics)`: 競合候補の channel ID を YouTube API 上限の 50 件単位で取得し、uploads playlist 欠損または有効な公開日を持つ動画がない候補を結果から除外する境界を公開 API テストで担保した（#2631）。
 - `fix(analytics)`: retention timeline が不正な retention 数値（変換不能・NaN・Infinity）や非有限の動画尺を `ValidationError` として利用者向けに拒否し、壊れたJSON・曖昧なanalysis参照・duration fallback・未照合・Markdown escaping の境界を直接検証した（#2612, #2636）。
 - `fix(live-chat)`: Codex の構造化出力が JSON object でない場合も `GeneratorError` として安全に拒否し、facade・filter・history保存失敗・投稿失敗・chat終了後再探索・CLI enabled/割込み/例外終了の実行時契約を直接検証した（#2648, #2651）。

--- a/src/youtube_automation/domains/distrokid/release.py
+++ b/src/youtube_automation/domains/distrokid/release.py
@@ -85,8 +85,21 @@ def _read_release_date(paths: CollectionPaths) -> str | None:
     state_path = paths.workflow_state_path
     if not state_path.is_file():
         return None
-    data = json.loads(state_path.read_text(encoding="utf-8"))
-    planning = data.get(_PLANNING_KEY) or {}
+    try:
+        raw_state = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(f"workflow-state.json を読み取れませんでした: {state_path}: {exc}") from exc
+    try:
+        data = json.loads(raw_state)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"workflow-state.json が不正な JSON です: {state_path}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError(f"workflow-state.json のトップレベルが object ではありません: {state_path}")
+    planning = data.get(_PLANNING_KEY)
+    if planning is None:
+        planning = {}
+    elif not isinstance(planning, dict):
+        raise ConfigError(f"workflow-state.json の planning が object ではありません: {state_path}")
     raw = planning.get(_PUBLISH_TARGET_KEY)
     return _normalize_release_date(raw)
 

--- a/tests/test_distrokid_metadata.py
+++ b/tests/test_distrokid_metadata.py
@@ -218,6 +218,31 @@ def test_parse_track_table_extracts_filled_isrc(tmp_path):
     assert parse_track_table(md)[0]["isrc"] == "USABC1234567"
 
 
+def test_parse_track_table_skips_numeric_row_with_too_few_columns(tmp_path):
+    """REQ-2729-03: 数値列でも title/filename の3列に満たない行は track として返さない."""
+    md = tmp_path / "metadata.md"
+    md.write_text(
+        "\n".join(
+            [
+                "| # | タイトル | ファイル |",
+                "|---|---|---|",
+                "| 1 | title |",
+                "| 2 | Complete | `02-complete.mp3` |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert parse_track_table(md) == [
+        {
+            "number": 2,
+            "title": "Complete",
+            "filename": "02-complete.mp3",
+            "isrc": None,
+        }
+    ]
+
+
 def test_parse_track_table_missing_file_raises_config_error(tmp_path):
     """Given 不在の metadata.md
     When parse_track_table

--- a/tests/test_distrokid_prepare.py
+++ b/tests/test_distrokid_prepare.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from youtube_automation.domains.distrokid import preparation as preparation_mod
 from youtube_automation.domains.distrokid.preparation import (
     COVER_ART_FILENAME,
     DISTROKID_DIRNAME,
@@ -617,6 +618,23 @@ class TestWriteReleaseDate:
 
         with pytest.raises(ConfigError, match="object ではありません"):
             write_release_date(ws_path, "2026-12-31")
+
+    def test_replace_failure_preserves_existing_state_and_removes_temp(self, tmp_path, monkeypatch):
+        """REQ-2729-02: replace 失敗時は既存 state を保持し、temp を削除して例外を伝播する."""
+        ws_path = tmp_path / "workflow-state.json"
+        original = {"planning": {"theme": "night-drive", "publish_target_at": "2026-01-01"}}
+        ws_path.write_text(json.dumps(original), encoding="utf-8")
+
+        def fail_replace(_src, _dst):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(preparation_mod.os, "replace", fail_replace)
+
+        with pytest.raises(OSError, match="replace failed"):
+            write_release_date(ws_path, "2026-12-31")
+
+        assert json.loads(ws_path.read_text(encoding="utf-8")) == original
+        assert list(tmp_path.glob(".workflow-state-*.json")) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_distrokid_release_endpoint.py
+++ b/tests/test_distrokid_release_endpoint.py
@@ -33,6 +33,7 @@ from youtube_automation.configuration.distrokid import (
     DistrokidProfile,
     SongwriterName,
 )
+from youtube_automation.domains.distrokid import release as release_mod
 from youtube_automation.domains.distrokid.release import (
     DISTROKID_ASSETS_PREFIX,
     DISTROKID_RELEASE_ROUTE,
@@ -584,3 +585,51 @@ def test_release_date_absent_yields_none(tmp_path):
     distrokid = Distrokid(enabled=True, profile=_profile())
 
     assert build_release_payload(collection, distrokid)["release"]["release_date"] is None
+
+
+def test_release_date_corrupt_json_raises_config_error(tmp_path):
+    """REQ-2729-11: 破損 workflow-state.json は ConfigError で fail-loud にする."""
+    collection = _make_collection(tmp_path)
+    (collection / "workflow-state.json").write_text("{", encoding="utf-8")
+    distrokid = Distrokid(enabled=True, profile=_profile())
+
+    with pytest.raises(ConfigError, match="workflow-state.json が不正な JSON"):
+        build_release_payload(collection, distrokid)
+
+
+def test_release_date_non_object_root_raises_config_error(tmp_path):
+    """REQ-2729-12: workflow-state.json の root は object 以外を拒否する."""
+    collection = _make_collection(tmp_path)
+    (collection / "workflow-state.json").write_text(json.dumps(["invalid"]), encoding="utf-8")
+    distrokid = Distrokid(enabled=True, profile=_profile())
+
+    with pytest.raises(ConfigError, match="トップレベルが object ではありません"):
+        build_release_payload(collection, distrokid)
+
+
+def test_release_date_non_object_planning_raises_config_error(tmp_path):
+    """REQ-2729-13: planning は object 以外を空値扱いせず拒否する."""
+    collection = _make_collection(tmp_path)
+    (collection / "workflow-state.json").write_text(json.dumps({"planning": ["invalid"]}), encoding="utf-8")
+    distrokid = Distrokid(enabled=True, profile=_profile())
+
+    with pytest.raises(ConfigError, match="planning が object ではありません"):
+        build_release_payload(collection, distrokid)
+
+
+def test_release_date_read_failure_raises_config_error(tmp_path, monkeypatch):
+    """REQ-2729-14: workflow-state.json の OSError はパス付き ConfigError に変換する."""
+    collection = _make_collection(tmp_path, publish_target_at="2026-07-01")
+    state_path = collection / "workflow-state.json"
+    distrokid = Distrokid(enabled=True, profile=_profile())
+    real_read_text = release_mod.Path.read_text
+
+    def fail_state_read(path, *args, **kwargs):
+        if path == state_path:
+            raise OSError("permission denied")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(release_mod.Path, "read_text", fail_state_read)
+
+    with pytest.raises(ConfigError, match="workflow-state.json を読み取れませんでした.*permission denied"):
+        build_release_payload(collection, distrokid)

--- a/tests/test_distrokid_spec.py
+++ b/tests/test_distrokid_spec.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from youtube_automation.domains.distrokid import specification as specification_mod
 from youtube_automation.domains.distrokid.specification import (
     SPEC_FILENAME,
     find_disc_entry,
@@ -362,6 +363,24 @@ def test_write_collection_spec_leaves_no_temp_file(tmp_path):
 
     files = sorted(p.name for p in distrokid_dir.iterdir())
     assert files == [SPEC_FILENAME]
+
+
+def test_write_collection_spec_replace_failure_preserves_existing_and_removes_temp(tmp_path, monkeypatch):
+    """REQ-2729-01: replace 失敗時は既存 spec を保持し、中間 temp を削除して例外を伝播する."""
+    distrokid_dir = tmp_path / "30-distrokid"
+    original = {"version": 1, "artist": "Original", "discs": []}
+    spec_path = _write_spec(distrokid_dir, original)
+
+    def fail_replace(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(specification_mod.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        write_collection_spec(distrokid_dir, _minimal_spec())
+
+    assert json.loads(spec_path.read_text(encoding="utf-8")) == original
+    assert list(distrokid_dir.glob(".spec-*.json")) == []
 
 
 def test_write_and_read_roundtrip(tmp_path):

--- a/tests/test_prompt_schema.py
+++ b/tests/test_prompt_schema.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
 
 import yaml
@@ -25,8 +26,8 @@ def _load_default_config() -> dict:
 
 
 def test_prompt_schema_has_imagegen_14_fields() -> None:
-    schema = PromptSchema()
-    expected = (
+    """REQ-2729-10: 実 dataclass の field 集合と順序を imagegen 契約に完全一致させる."""
+    expected_fields = (
         "use_case",
         "asset_type",
         "primary_request",
@@ -42,9 +43,7 @@ def test_prompt_schema_has_imagegen_14_fields() -> None:
         "constraints",
         "avoid",
     )
-    for name in expected:
-        assert hasattr(schema, name), f"PromptSchema lacks imagegen field: {name}"
-    assert len(expected) == 14
+    assert tuple(field.name for field in fields(PromptSchema)) == expected_fields
 
 
 def test_render_skips_unset_fields_and_uses_imagegen_labels() -> None:

--- a/tests/test_suno_audio_cleanup.py
+++ b/tests/test_suno_audio_cleanup.py
@@ -137,6 +137,30 @@ def test_process_file_apply_uses_container_matching_codec(
     assert captured_cmd[captured_cmd.index("-c:a") + 1] == expected_codec
 
 
+def test_process_file_ffmpeg_failure_preserves_original_and_removes_partial_output(tmp_path: Path, monkeypatch) -> None:
+    """REQ-2729-04: ffmpeg 非0終了では元音源を変えず、temp/backup を残さない."""
+    collection = _make_collection(tmp_path, ["01-a.mp3"])
+    source = collection / "02-Individual-music" / "01-a.mp3"
+    tmp_output = source.parent / ".01-a.cleanup-tmp.mp3"
+    backup = source.parent / "originals-pre-cleanup" / source.name
+
+    monkeypatch.setattr(mod, "probe_duration", lambda _path: 60)
+    monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+
+    def fail_run(cmd, capture_output, text):
+        Path(cmd[-1]).write_bytes(b"partial-output")
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="decode failed")
+
+    monkeypatch.setattr(mod.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError, match=r"(?s)ffmpeg cleanup failed .*rc=1.*decode failed"):
+        process_file(source, CleanupConfig(enabled=True), apply=True, force=False, quiet=True)
+
+    assert source.read_bytes() == b"audio"
+    assert not tmp_output.exists()
+    assert not backup.exists()
+
+
 def test_process_file_apply_without_backup_preserves_original_when_replace_fails(tmp_path: Path, monkeypatch) -> None:
     collection = _make_collection(tmp_path, ["01-a.mp3"])
     source = collection / "02-Individual-music" / "01-a.mp3"

--- a/tests/test_suno_lyric_duplication.py
+++ b/tests/test_suno_lyric_duplication.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import pytest
 
+from youtube_automation.domains.suno.lyrics import load_suno_lyrics_entries
+from youtube_automation.infrastructure.errors import ConfigError
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / ".claude/skills/suno-lyric/references/check_lyric_duplication.py"
 
@@ -205,6 +208,29 @@ def test_check_lyric_duplication_invalid_json_is_format_error(tmp_path: Path) ->
 
     assert result.returncode == 2
     assert "invalid JSON" in result.stderr
+
+
+def test_load_suno_lyrics_entries_invalid_json_raises_config_error(tmp_path: Path) -> None:
+    """REQ-2729-21: public lyrics reader は破損 JSON を ConfigError に変換する."""
+    path = tmp_path / "suno-lyrics.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match=f"suno-lyrics.json is invalid JSON: {path}"):
+        load_suno_lyrics_entries(path)
+
+
+def test_load_suno_lyrics_entries_propagates_read_oserror(tmp_path: Path, monkeypatch) -> None:
+    """REQ-2729-22: public lyrics reader は OSError を呼び出し側へ伝播する."""
+    path = tmp_path / "suno-lyrics.json"
+    path.write_text("[]", encoding="utf-8")
+
+    def fail_read(_path: Path, *args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    with pytest.raises(OSError, match="permission denied"):
+        load_suno_lyrics_entries(path)
 
 
 def test_check_lyric_duplication_root_must_be_list(tmp_path: Path) -> None:

--- a/tests/test_suno_unattended_request.py
+++ b/tests/test_suno_unattended_request.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
+from urllib.error import URLError
 
 import pytest
 
@@ -10,6 +12,7 @@ from youtube_automation.commands.suno.suno_unattended_request import (
     build_unattended_launch_url,
     build_unattended_request,
     main,
+    register_unattended_request,
 )
 from youtube_automation.infrastructure.errors import ConfigError
 
@@ -80,6 +83,59 @@ def test_rejects_unsafe_or_unbounded_requests(override: dict[str, object], messa
     arguments.update(override)
     with pytest.raises(ConfigError, match=message):
         build_unattended_request(**arguments)  # type: ignore[arg-type]
+
+
+def test_register_unattended_request_posts_json_and_returns_nonce(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-2729-05: localhost 登録の HTTP method/body/timeout と成功 response を固定する."""
+    captured: dict[str, object] = {}
+    expected_nonce = "abcdefghijklmnopqrstuvwxyzABCDEFGH_1234567890"
+
+    def fake_urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return io.BytesIO(json.dumps({"nonce": expected_nonce}).encode())
+
+    monkeypatch.setattr(suno_unattended_request, "urlopen", fake_urlopen)
+    request_payload = {"version": 1, "collectionId": "collection"}
+
+    nonce = register_unattended_request("http://localhost:7873/path/", request_payload)
+
+    request = captured["request"]
+    assert request.full_url == "http://localhost:7873/path/unattended/requests"
+    assert request.get_method() == "POST"
+    assert request.get_header("Content-type") == "application/json"
+    assert json.loads(request.data) == request_payload
+    assert captured["timeout"] == 10
+    assert nonce == expected_nonce
+
+
+def test_register_unattended_request_wraps_transport_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-2729-06: localhost 通信失敗は ConfigError として原因付きで公開する."""
+
+    def fail_urlopen(_request, timeout):
+        assert timeout == 10
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(suno_unattended_request, "urlopen", fail_urlopen)
+
+    with pytest.raises(ConfigError, match="登録できません.*connection refused"):
+        register_unattended_request("http://localhost:7873", {"version": 1})
+
+
+@pytest.mark.parametrize("payload", [[], {}, {"nonce": ""}, {"nonce": 123}])
+def test_register_unattended_request_rejects_invalid_nonce_response(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: object,
+) -> None:
+    """REQ-2729-07: response shape/nonce が不正なら成功扱いしない."""
+    monkeypatch.setattr(
+        suno_unattended_request,
+        "urlopen",
+        lambda _request, timeout: io.BytesIO(json.dumps(payload).encode()) if timeout == 10 else None,
+    )
+
+    with pytest.raises(ConfigError, match="有効な unattended nonce"):
+        register_unattended_request("http://localhost:7873", {"version": 1})
 
 
 def test_cli_uses_skill_config_defaults(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_suno_verify.py
+++ b/tests/test_suno_verify.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import inspect
 import json
+from pathlib import Path
 
 import pytest
 import yaml
@@ -19,6 +19,13 @@ from tests.helpers.suno_verify import (
     write_video_analysis_suno_preset,
 )
 from youtube_automation.commands.suno.generate_suno_prompts import build_prompt_entries
+from youtube_automation.domains.suno.config import ResolvedSunoConfig
+from youtube_automation.domains.suno.downloaded.validation import (
+    ArtifactEntries,
+    load_lyric_entries,
+    load_pattern_contract,
+    load_prompt_entries,
+)
 from youtube_automation.utils import skill_config
 
 
@@ -740,24 +747,102 @@ def test_invalid_prompts_json_shape_is_reported(channel_dir, tmp_path, monkeypat
     assert "entries" in output
 
 
-def test_verify_artifact_helpers_do_not_accept_mutable_issue_accumulators():
-    """検証 helper は呼び出し元 list を引数で受け取らず、issue を戻り値で返す。"""
-    from youtube_automation.domains.suno.downloaded import validation as suno_verify_artifacts
-
-    for helper_name in ("_validate_prompts", "_verify_vocal_artifacts"):
-        signature = inspect.signature(getattr(suno_verify_artifacts, helper_name))
-        assert "issues" not in signature.parameters
+def _resolved_suno_config() -> ResolvedSunoConfig:
+    return ResolvedSunoConfig(raw={}, genre_line="lo-fi jazz", exclude_styles="")
 
 
-def test_verify_reader_helpers_do_not_accept_mutable_accumulators():
-    """reader helper は呼び出し元 list/dict を引数で受け取らず、parse 結果を戻り値で返す。"""
-    from youtube_automation.domains.suno.downloaded import validation as suno_verify_readers
+def test_load_pattern_contract_reports_missing_file_directly(tmp_path):
+    """REQ-2729-15: pattern reader の欠落契約を公開 API の戻り値で固定する."""
+    path = tmp_path / "suno-patterns.yaml"
 
-    for old_helper_name in ("_append_prompt_entry", "_append_lyric_entry"):
-        assert not hasattr(suno_verify_readers, old_helper_name)
+    contract, issues = load_pattern_contract(path, _resolved_suno_config(), lambda _genre: "instrumental")
 
-    for helper_name in ("_entry_names_from_pattern", "_prompt_entry_from_mapping", "_lyric_entry_from_mapping"):
-        signature = inspect.signature(getattr(suno_verify_readers, helper_name))
-        assert "issues" not in signature.parameters
-        assert "names" not in signature.parameters
-        assert "lyrics_by_name" not in signature.parameters
+    assert contract is None
+    assert issues == [f"suno-patterns.yaml not found: {path}"]
+
+
+def test_load_pattern_contract_reports_invalid_yaml_directly(tmp_path):
+    """REQ-2729-16: pattern reader の破損 YAML 契約を公開 API で固定する."""
+    path = tmp_path / "suno-patterns.yaml"
+    path.write_text("patterns: [", encoding="utf-8")
+
+    contract, issues = load_pattern_contract(path, _resolved_suno_config(), lambda _genre: "instrumental")
+
+    assert contract is None
+    assert len(issues) == 1
+    assert issues[0].startswith(f"suno-patterns.yaml is invalid YAML: {path}:")
+
+
+def test_load_pattern_contract_reports_read_failure_directly(tmp_path, monkeypatch):
+    """REQ-2729-17: pattern reader の OSError 契約を公開 API で固定する."""
+    path = tmp_path / "suno-patterns.yaml"
+    path.write_text("patterns: []", encoding="utf-8")
+
+    def fail_read(_path: Path, *args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    contract, issues = load_pattern_contract(path, _resolved_suno_config(), lambda _genre: "instrumental")
+
+    assert contract is None
+    assert issues == [f"suno-patterns.yaml could not be read: {path}: permission denied"]
+
+
+@pytest.mark.parametrize(
+    ("loader", "filename"),
+    [
+        (load_prompt_entries, "suno-prompts.json"),
+        (load_lyric_entries, "suno-lyrics.json"),
+    ],
+)
+def test_artifact_json_readers_report_missing_file_directly(tmp_path, loader, filename):
+    """REQ-2729-18: prompt/lyric reader の欠落は空 artifact と issue を返す."""
+    path = tmp_path / filename
+
+    entries, issues = loader(path)
+
+    assert entries == ArtifactEntries(names=[], lyrics_by_name={}, lyrics_entries=[])
+    assert issues == [f"{filename} not found: {path}"]
+
+
+@pytest.mark.parametrize(
+    ("loader", "filename"),
+    [
+        (load_prompt_entries, "suno-prompts.json"),
+        (load_lyric_entries, "suno-lyrics.json"),
+    ],
+)
+def test_artifact_json_readers_report_invalid_json_directly(tmp_path, loader, filename):
+    """REQ-2729-19: prompt/lyric reader の破損 JSON は空 artifact と issue を返す."""
+    path = tmp_path / filename
+    path.write_text("{", encoding="utf-8")
+
+    entries, issues = loader(path)
+
+    assert entries == ArtifactEntries(names=[], lyrics_by_name={}, lyrics_entries=[])
+    assert len(issues) == 1
+    assert issues[0].startswith(f"{filename} is invalid JSON: {path}:")
+
+
+@pytest.mark.parametrize(
+    ("loader", "filename"),
+    [
+        (load_prompt_entries, "suno-prompts.json"),
+        (load_lyric_entries, "suno-lyrics.json"),
+    ],
+)
+def test_artifact_json_readers_report_read_failure_directly(tmp_path, monkeypatch, loader, filename):
+    """REQ-2729-20: prompt/lyric reader の OSError は空 artifact と issue を返す."""
+    path = tmp_path / filename
+    path.write_text("[]", encoding="utf-8")
+
+    def fail_read(_path: Path, *args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    entries, issues = loader(path)
+
+    assert entries == ArtifactEntries(names=[], lyrics_by_name={}, lyrics_entries=[])
+    assert issues == [f"{filename} could not be read: {path}: permission denied"]

--- a/tests/test_suno_verify_cli.py
+++ b/tests/test_suno_verify_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.suno_verify import load_suno_verify_module
+from youtube_automation.infrastructure.errors import ConfigError, ValidationError
 
 
 def test_pyproject_registers_yt_suno_verify_script():
@@ -58,3 +59,34 @@ def test_help_flag_shows_usage_and_exits_zero(monkeypatch, capsys):
 
     assert exc_info.value.code == 0
     assert "usage" in capsys.readouterr().out.lower()
+
+
+def test_collection_resolution_failure_returns_one_and_prints_error(monkeypatch, capsys):
+    """REQ-2729-08: collection 入口解決失敗は traceback ではなく exit 1 と ERROR を返す."""
+    module = load_suno_verify_module()
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", "missing"])
+    monkeypatch.setattr(
+        module,
+        "resolve_collection_dir",
+        lambda _collection: (_ for _ in ()).throw(ValidationError("collection missing")),
+    )
+
+    assert module.main() == 1
+    assert capsys.readouterr().out == "ERROR: collection missing\n"
+
+
+def test_config_loading_failure_returns_one_and_prints_error(monkeypatch, capsys, tmp_path):
+    """REQ-2729-09: 設定読込失敗も exit 1 と ERROR に正規化する."""
+    module = load_suno_verify_module()
+    collection = tmp_path / "collection"
+    collection.mkdir()
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", str(collection)])
+    monkeypatch.setattr(module, "resolve_collection_dir", lambda _collection: collection)
+    monkeypatch.setattr(
+        module,
+        "load_skill_config",
+        lambda _skill: (_ for _ in ()).throw(ConfigError("suno config invalid")),
+    )
+
+    assert module.main() == 1
+    assert capsys.readouterr().out == "ERROR: suno config invalid\n"


### PR DESCRIPTION
## Summary

- DistroKid の atomic write、列不足 metadata、workflow-state JSON/I/O 境界を実回帰テストで固定し、workflow-state の破損・契約外 shape・読込失敗を `ConfigError` に統一
- Suno の ffmpeg 失敗時副作用、unattended request の HTTP/response/nonce、verify CLI の入口失敗を直接検証
- `PromptSchema` を実 dataclass field と完全比較し、private helper 固定テストを4つの公開 reader の欠落・破損・読込失敗契約へ置換

## Leaf ledger

| Leaf | Finding | Result |
|---|---|---|
| #2719 | F-001 atomic spec replace failure | passed |
| #2720 | F-002 release date atomic replace failure | passed |
| #2721 | F-003 short numeric metadata row | passed |
| #2722 | F-008 ffmpeg failure side effects | passed |
| #2723 | F-009 unattended HTTP/response/nonce | passed |
| #2724 | F-010 verify CLI entry failures | passed |
| #2725 | F-013 PromptSchema field comparison | passed |
| #2726 | F-015 workflow-state failure boundaries | passed |
| #2727 | F-016 private helper tests removal | passed |
| #2728 | F-017 public reader failure contracts | passed |

Blocked: none.

## Validation

- `nix develop --command uv run pytest -q tests/test_distrokid_spec.py tests/test_distrokid_prepare.py tests/test_distrokid_metadata.py tests/test_suno_audio_cleanup.py tests/test_suno_unattended_request.py tests/test_suno_verify_cli.py tests/test_prompt_schema.py tests/test_distrokid_release_endpoint.py tests/test_suno_verify.py tests/test_suno_lyric_duplication.py` — 238 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 670 files already formatted
- `nix develop --command bash .github/scripts/any-usage-gate.sh` — passed
- `nix develop --command uv run pytest -n auto` — 7253 passed, 1 skipped, 48 warnings

監査レポート: `.takt/tasks/20260728-074446-06-16-suno-distrokid-python/02-unit-audit.md`

Closes #2729
Closes #2719
Closes #2720
Closes #2721
Closes #2722
Closes #2723
Closes #2724
Closes #2725
Closes #2726
Closes #2727
Closes #2728
