### PR TITLE
test: 配信インフラ監査の回帰契約を強化 (#2830)

### DIFF
--- a/tests/streaming/test_cloud_init.py
+++ b/tests/streaming/test_cloud_init.py
@@ -440,13 +440,6 @@ class TestEnvTftpl:
     が ``${video}`` / ``${rtmp_url}`` を実値に展開し、systemd は env file をロードするだけ。
     """
 
-    def test_file_exists(self):
-        """Given infra/terraform/streaming/templates/
-        When youtube-stream.env.tftpl を探す
-        Then 存在する。
-        """
-        assert _ENV_TFTPL.exists(), "templates/youtube-stream.env.tftpl が存在しない"
-
     def test_contains_video_variable_assignment(self):
         """Given env tftpl
         When 全文を読む

--- a/tests/streaming/test_scripts.py
+++ b/tests/streaming/test_scripts.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -34,18 +37,6 @@ class TestSwapVideoScript:
     と同様）に従い、ファイルテキスト・実行ビット・主要キーワードを正規表現で検証する。
     実行時挙動（subprocess での実 terraform 呼び出し / shellcheck 適用）はスコープ外。
     """
-
-    def test_script_exists(self):
-        """Given リポジトリ
-        When ``.claude/skills/streaming/references/swap_video.sh`` を探す
-        Then 当該ファイルが存在する。
-
-        order.md「スクリプト化（任意）: ``swap_video.sh``」要件の最低条件。
-        ラッパーは README から発見可能であっても、ファイルが無ければ叩けない。
-        """
-        assert _SWAP_VIDEO_SCRIPT.exists(), (
-            f"{_SWAP_VIDEO_SCRIPT.relative_to(_REPO_ROOT)} が存在しない（1 コマンドラッパーが未実装）"
-        )
 
     def test_script_is_executable(self):
         """Given スクリプトファイル
@@ -127,54 +118,77 @@ class TestSwapVideoScript:
             "swap_video.sh に `terraform apply` 起動行が無い（差し替えを実行する本体コマンドが欠落）"
         )
 
-    def test_script_default_apply_is_interactive(self):
-        """Given スクリプト本文
-        When 全文を読む
-        Then ``-auto-approve`` の付与が条件分岐配下にある（無条件付与ではない）。
-
-        plan.md「``--auto-approve`` は off（対話確認）」要件。デフォルトで
-        ``-auto-approve`` を付けると誤 apply 事故のリスクが上がる。``--auto-approve``
-        フラグを明示した時のみ ``-auto-approve`` を Terraform に渡す分岐構造であること。
+    @pytest.mark.parametrize(
+        ("cli_args", "expected_apply"),
+        [
+            ([], "apply"),
+            (["--auto-approve"], "apply -auto-approve"),
+        ],
+    )
+    def test_script_passes_auto_approve_only_when_requested(
+        self,
+        tmp_path: Path,
+        cli_args: list[str],
+        expected_apply: str,
+    ):
+        """Given terraform・SSH 前提を隔離 stub した環境
+        When default または --auto-approve でスクリプトを実行
+        Then plan 後の apply argv に利用者指定だけが反映される。
         """
-        text = read_file(_SWAP_VIDEO_SCRIPT)
-        # `--auto-approve` のフラグハンドリング（引数パース）が存在する
-        assert re.search(r"--auto-approve\b", text), (
-            "swap_video.sh に `--auto-approve` 引数の取り扱いが無い"
-            "（plan.md 仕様: フラグ off がデフォルト / 明示時のみ非対話 apply）"
-        )
-        # `terraform ... apply -auto-approve` が無条件に書かれていない
-        # （= 直接 1 行で `terraform apply -auto-approve` を書くのは禁止。条件分岐配下が必須）
-        unconditional = re.search(
-            r"^[ \t]*terraform\s+[^\n]*\bapply\b[^\n]*-auto-approve",
-            text,
-            flags=re.MULTILINE,
-        )
-        # `if` / `case` / `$AUTO_APPROVE` などのガード語が同一スクリプト内にある場合は
-        # 上記マッチが分岐配下にある可能性がある。安全側で「``apply -auto-approve`` の
-        # 行が出現する場合は、その上方に AUTO_APPROVE 系変数のガードがあること」を要求する。
-        if unconditional is not None:
-            head = text[: unconditional.start()]
-            assert re.search(r"AUTO_APPROVE", head), (
-                "swap_video.sh が `terraform apply -auto-approve` を無条件で実行している"
-                "（AUTO_APPROVE 変数等のガードが上方に無い。誤 apply リスク）"
-            )
+        stub_dir = tmp_path / "bin"
+        stub_dir.mkdir()
+        calls_path = tmp_path / "terraform-calls.txt"
 
-    def test_script_supports_auto_approve_flag(self):
-        """Given スクリプト本文
-        When 全文を読む
-        Then ``-auto-approve`` を terraform に渡す経路と ``--auto-approve`` 受け取りが対になっている。
+        stubs = {
+            "terraform": '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$TERRAFORM_CALLS"\n',
+            "realpath": '#!/usr/bin/env bash\nprintf "%s\\n" "$1"\n',
+            "ssh-keygen": '#!/usr/bin/env bash\nprintf "256 SHA256:test operator@test (ED25519)\\n"\n',
+            "ssh-add": '#!/usr/bin/env bash\nprintf "256 SHA256:test operator@test (ED25519)\\n"\n',
+        }
+        for name, body in stubs.items():
+            path = stub_dir / name
+            path.write_text(body, encoding="utf-8")
+            path.chmod(0o755)
 
-        ユーザーが ``--auto-approve`` を渡した時に Terraform 側へ ``-auto-approve``
-        が伝播する経路があること。フラグだけ受け取って何もしない実装になっていないか担保する。
-        """
-        text = read_file(_SWAP_VIDEO_SCRIPT)
-        # ユーザー向けフラグ `--auto-approve` の取り回し
-        assert re.search(r"--auto-approve\b", text), "swap_video.sh が `--auto-approve` 引数を受け取っていない"
-        # terraform へ渡す `-auto-approve`（シングルダッシュ）
-        assert re.search(r"-auto-approve\b", text), (
-            "swap_video.sh が terraform へ `-auto-approve` を渡していない"
-            "（ユーザーフラグだけ受け取って Terraform 側に伝播していない）"
+        home_dir = tmp_path / "home"
+        ssh_dir = home_dir / ".ssh"
+        ssh_dir.mkdir(parents=True)
+        (ssh_dir / "yt_stream_key.pub").write_text("stub public key\n", encoding="utf-8")
+
+        terraform_dir = tmp_path / "terraform"
+        terraform_dir.mkdir()
+        (terraform_dir / "main.tf").write_text("# stub\n", encoding="utf-8")
+        video_path = tmp_path / "video.mp4"
+        video_path.write_bytes(b"video")
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(home_dir),
+                "PATH": f"{stub_dir}:/usr/bin:/bin",
+                "TERRAFORM_CALLS": str(calls_path),
+            }
         )
+        proc = subprocess.run(
+            [
+                "bash",
+                str(_SWAP_VIDEO_SCRIPT),
+                *cli_args,
+                "--tf-dir",
+                str(terraform_dir),
+                str(video_path),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        assert calls_path.read_text(encoding="utf-8").splitlines() == [
+            f"-chdir={terraform_dir} plan",
+            f"-chdir={terraform_dir} {expected_apply}",
+        ]
 
 
 # ============================================================================
@@ -194,18 +208,6 @@ class TestRunFfmpegScript:
     本テストは terraform バイナリ非依存方針に従い、ファイルテキスト・主要キーワードの
     包含のみ正規表現で検証する（既存 ``TestSwapVideoScript`` と同じスタイル）。
     """
-
-    def test_script_exists(self):
-        """Given リポジトリ
-        When ``scripts/streaming/run-ffmpeg.sh`` を探す
-        Then 当該ファイルが存在する。
-
-        ExecStart の差し替え先が物理的に欠落すると ``systemctl start`` が
-        ``status=203/EXEC`` で fail する。最低限の存在保証。
-        """
-        assert _RUN_FFMPEG_SCRIPT.exists(), (
-            f"{_RUN_FFMPEG_SCRIPT.relative_to(_REPO_ROOT)} が存在しない（#160 ラッパーが未実装）"
-        )
 
     def test_script_has_bash_shebang(self):
         """Given ラッパー本文

--- a/tests/streaming/test_skill_streaming.py
+++ b/tests/streaming/test_skill_streaming.py
@@ -28,13 +28,6 @@ class TestStreamingSkillFirewall:
     本テストは raw text のキーワード包含のみ検証する（章立て自由度を残す）。
     """
 
-    def test_skill_file_exists(self):
-        """Given .claude/skills/streaming/
-        When SKILL.md を探す
-        Then 存在する。
-        """
-        assert _STREAMING_SKILL.exists(), ".claude/skills/streaming/SKILL.md が存在しない"
-
     def test_mentions_allowed_ssh_cidr(self):
         """Given SKILL.md
         When 全文を読む
@@ -131,13 +124,6 @@ class TestStreamingReadme:
     包含のみ検証する（執筆の自由度を残す）。
     """
 
-    def test_file_exists(self):
-        """Given infra/terraform/streaming/
-        When README.md を探す
-        Then 存在する（gcp モジュールと並列の慣例）。
-        """
-        assert _STREAMING_README.exists(), "infra/terraform/streaming/README.md が存在しない"
-
     def test_mentions_tf_var_stream_key(self):
         """Given README
         When 全文を読む
@@ -224,14 +210,31 @@ class TestStreamingReadme:
         assert "低エントロピー値" in text, "README に低エントロピー値の hash 化が secret 保護でない説明が無い"
 
     def test_mentions_systemctl_status_for_verification(self):
-        """Given README
-        When 全文を読む
-        Then ``systemctl status`` 等の動作確認コマンドが書かれている。
-
-        order.md「動作確認」セクションの最低限の引用。
+        """Given README の動作確認節
+        When サービス・サイクル・ログの確認手順を読む
+        Then 各確認目的と実行コマンドが同じ節で対応付く。
         """
         text = read_file(_STREAMING_README)
-        assert "systemctl" in text, "README に systemctl 系の動作確認コマンドが書かれていない"
+        match = re.search(
+            r"^## 動作確認\s*$\n(.*?)(?=^##\s|\Z)",
+            text,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        assert match is not None, "README に動作確認節が無い"
+        section = match.group(1)
+        assert (
+            "# サービス状態（active / inactive / failed）\n"
+            "ssh -i ~/.ssh/yt_stream_key root@<instance_ip> systemctl status youtube-stream"
+        ) in section
+        assert (
+            "# 配信サイクル設定が効いているか確認\n"
+            "ssh -i ~/.ssh/yt_stream_key root@<instance_ip> systemctl show youtube-stream "
+            "| grep -E 'RuntimeMaxUSec|RestartUSec'"
+        ) in section
+        assert (
+            "# リアルタイムログ（ffmpeg の出力）\n"
+            "ssh -i ~/.ssh/yt_stream_key root@<instance_ip> journalctl -u youtube-stream -f"
+        ) in section
 
     def test_mentions_default_24_7_and_optional_11h_1h_streaming_cycle(self):
         """Given README

--- a/tests/streaming/test_systemd_unit.py
+++ b/tests/streaming/test_systemd_unit.py
@@ -70,13 +70,6 @@ class TestSystemdUnitTemplate:
         )
         return text
 
-    def test_file_exists(self):
-        """Given infra/terraform/streaming/templates/
-        When youtube-stream.service.tftpl を探す
-        Then 存在する。
-        """
-        assert _SYSTEMD_TFTPL.exists(), "templates/youtube-stream.service.tftpl が存在しない"
-
     def test_unit_section_has_description(self):
         """Given .tftpl
         When [Unit] セクションを読む

--- a/tests/streaming/test_terraform_meta.py
+++ b/tests/streaming/test_terraform_meta.py
@@ -254,13 +254,6 @@ class TestOutputsTf:
 class TestTfvarsExample:
     """``terraform.tfvars.example`` の secret 漏洩防止。"""
 
-    def test_example_file_exists(self):
-        """Given infra/terraform/streaming/
-        When terraform.tfvars.example を探す
-        Then 存在する（cp して使うサンプル）。
-        """
-        assert _TFVARS_EXAMPLE.exists(), "terraform.tfvars.example が存在しない"
-
     def test_does_not_contain_vultr_api_key_assignment(self):
         """Given terraform.tfvars.example
         When ファイル内容を読む

--- a/tests/test_stream_bandwidth_cli.py
+++ b/tests/test_stream_bandwidth_cli.py
@@ -363,24 +363,6 @@ def test_probe_bitrate_returns_nonzero_when_probe_fails(tmp_path: Path):
     assert rc != 0
 
 
-# ---------- argparse 妥当性 ----------
-
-
-def test_main_returns_int_for_systemd_exit():
-    """Given 引数なし
-    When main を呼ぶ
-    Then int を返す (sys.exit(main()) で使われる)。
-    """
-    bw = {"2026-04-01": {"incoming_bytes": 0, "outgoing_bytes": 0}}
-    mocks = _patch_all(bandwidth=bw)
-    _enter(mocks)
-    try:
-        rc = stream_bandwidth.main(["--instance-id", "VULTR_X"])
-    finally:
-        _exit(mocks)
-    assert isinstance(rc, int)
-
-
 # ---------- R13: --help が落ちない (% リテラルのエスケープ回帰防止) ----------
 
 

--- a/tests/test_stream_cycle_uptime.py
+++ b/tests/test_stream_cycle_uptime.py
@@ -43,9 +43,6 @@ def test_actual_uptime_ratio_validates_days_when_archives_are_not_expected():
         (60, 30, 1.0),
         (30, 30, 0.5),
         (0, 30, 0.0),
-        (62, 31, 1.0),
-        (56, 28, 1.0),
-        (45, 30, 0.75),
     ],
 )
 def test_actual_uptime_ratio_uses_archive_count_when_archives_are_expected(
@@ -83,6 +80,16 @@ def test_theoretical_archive_count_returns_none_by_default():
     Then 理論アーカイブ本数は None になる。
     """
     assert cycle_uptime.theoretical_archive_count(days_in_month=30) is None
+
+
+@pytest.mark.parametrize("days_in_month", [0, -1])
+def test_theoretical_archive_count_rejects_non_positive_days(days_in_month: int):
+    """Given days_in_month が 0 以下
+    When theoretical_archive_count を直接呼ぶ
+    Then archive mode に関係なく ValueError を送出する。
+    """
+    with pytest.raises(ValueError, match="days_in_month must be positive"):
+        cycle_uptime.theoretical_archive_count(days_in_month=days_in_month)
 
 
 def test_theoretical_archive_count_uses_days_when_archives_are_expected(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_stream_instance_resolver.py
+++ b/tests/test_stream_instance_resolver.py
@@ -96,6 +96,28 @@ def test_resolve_raises_config_error_when_terraform_fails(tmp_path: Path):
             instance_resolver.resolve_instance_id(override=None, terraform_dir=tmp_path)
 
 
+def test_resolve_wraps_terraform_timeout_and_preserves_cause(tmp_path: Path):
+    """Given terraform output が timeout
+    When resolve_instance_id を呼ぶ
+    Then ConfigError へ正規化し TimeoutExpired を原因として保持する。
+    """
+    timeout = subprocess.TimeoutExpired(
+        cmd=["terraform", "output", "-raw", "instance_id"],
+        timeout=30,
+    )
+    with patch(
+        "youtube_automation.utils.streaming.instance_resolver.subprocess.run",
+        side_effect=timeout,
+    ):
+        with pytest.raises(ConfigError, match="timed out") as exc_info:
+            instance_resolver.resolve_instance_id(
+                override=None,
+                terraform_dir=tmp_path,
+            )
+
+    assert exc_info.value.__cause__ is timeout
+
+
 def test_resolve_raises_config_error_when_output_empty(tmp_path: Path):
     """Given terraform output が空文字
     When resolve_instance_id を呼ぶ

--- a/tests/test_stream_monthly_report.py
+++ b/tests/test_stream_monthly_report.py
@@ -44,8 +44,7 @@ def test_format_monthly_report_includes_usage_gb_with_unit():
         archives=60,
         days_in_month=30,
     )
-    assert "1188" in text
-    assert "GB" in text
+    assert "帯域消費量: 1188.0 GB / 2048 GB (58.0%)" in text
 
 
 def test_format_monthly_report_includes_previous_month_diff_with_sign():
@@ -61,9 +60,7 @@ def test_format_monthly_report_includes_previous_month_diff_with_sign():
         archives=60,
         days_in_month=30,
     )
-    assert "+" in text
-    # 前月比文言（"前月比" もしくは "前月" / "diff"）
-    assert ("前月" in text) or ("diff" in text.lower())
+    assert "  - 前月比: +200.0 GB (+20.0%)" in text
 
 
 def test_format_monthly_report_includes_negative_previous_month_diff():
@@ -79,7 +76,25 @@ def test_format_monthly_report_includes_negative_previous_month_diff():
         archives=60,
         days_in_month=30,
     )
-    assert "-" in text
+    assert "  - 前月比: -100.0 GB (-10.0%)" in text
+
+
+def test_format_monthly_report_omits_percentage_when_previous_usage_is_zero():
+    """Given previous_usage_gb=0
+    When format_monthly_report を呼ぶ
+    Then ゼロ除算せず、GB 差分だけを前月比行へ表示する。
+    """
+    text = monthly_report.format_monthly_report(
+        year=2026,
+        month=4,
+        usage_gb=1200.0,
+        previous_usage_gb=0.0,
+        archives=60,
+        days_in_month=30,
+    )
+    diff_line = next(line for line in text.splitlines() if "前月比:" in line)
+    assert diff_line == "  - 前月比: +1200.0 GB"
+    assert "%" not in diff_line
 
 
 def test_format_monthly_report_handles_no_previous_month():
@@ -145,25 +160,7 @@ def test_format_monthly_report_includes_quota_percentage():
         archives=60,
         days_in_month=30,
     )
-    assert "80" in text
-    assert "%" in text
-
-
-def test_format_monthly_report_returns_str():
-    """Given 通常入力
-    When format_monthly_report を呼ぶ
-    Then str を返す (Discord webhook の content に流せる)。
-    """
-    text = monthly_report.format_monthly_report(
-        year=2026,
-        month=4,
-        usage_gb=1188.0,
-        previous_usage_gb=1100.0,
-        archives=60,
-        days_in_month=30,
-    )
-    assert isinstance(text, str)
-    assert len(text) > 0
+    assert "帯域消費量: 1638.4 GB / 2048 GB (80.0%)" in text
 
 
 def test_format_monthly_report_archives_expected_true_includes_uptime_and_count(
@@ -187,11 +184,7 @@ def test_format_monthly_report_archives_expected_true_includes_uptime_and_count(
         archives=45,
         days_in_month=30,
     )
-    # 実測稼働率が N/A ではなく数値 (%) で表示される
-    assert "実測 N/A" not in text
-    assert "実測" in text
-    assert "理論 100.0%" in text
-    # アーカイブ件数行が含まれる
+    assert "稼働率 (24/7 連続配信): 実測 75.0% / 理論 100.0%" in text
     assert "アーカイブ件数: 実測 45 本 / 理論 60 本" in text
 
 

--- a/tests/test_stream_vultr_bandwidth.py
+++ b/tests/test_stream_vultr_bandwidth.py
@@ -45,6 +45,22 @@ def _fake_urlopen(payload: dict, status: int = 200):
     return _Resp(json.dumps(payload).encode("utf-8"))
 
 
+def _fake_urlopen_bytes(body: bytes):
+    """JSON でない HTTP body も返せる urlopen response mock."""
+
+    class _Resp:
+        def read(self):
+            return body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    return _Resp()
+
+
 def test_fetch_bandwidth_calls_vultr_api_with_bearer_token():
     """Given instance_id=ABC, api_key=KEY
     When fetch_bandwidth を呼ぶ
@@ -103,6 +119,45 @@ def test_fetch_bandwidth_raises_when_response_missing_bandwidth_key():
     with patch("youtube_automation.utils.streaming.vultr_bandwidth.urllib.request.urlopen") as mock_open:
         mock_open.return_value = _fake_urlopen({"unexpected": "shape"})
         with pytest.raises(YouTubeAPIError):
+            vultr_bandwidth.fetch_bandwidth(instance_id="ABC", api_key="KEY")
+
+
+def test_fetch_bandwidth_wraps_invalid_json():
+    """Given Vultr が不正 JSON を返す
+    When fetch_bandwidth を呼ぶ
+    Then YouTubeAPIError へ正規化し JSONDecodeError を原因として保持する。
+    """
+    with patch("youtube_automation.utils.streaming.vultr_bandwidth.urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _fake_urlopen_bytes(b"{not-json")
+        with pytest.raises(YouTubeAPIError) as exc_info:
+            vultr_bandwidth.fetch_bandwidth(instance_id="ABC", api_key="KEY")
+
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
+def test_fetch_bandwidth_wraps_timeout_error():
+    """Given HTTP 読み出しが timeout
+    When fetch_bandwidth を呼ぶ
+    Then YouTubeAPIError へ正規化し TimeoutError を原因として保持する。
+    """
+    timeout = TimeoutError("timed out")
+    with patch("youtube_automation.utils.streaming.vultr_bandwidth.urllib.request.urlopen") as mock_open:
+        mock_open.side_effect = timeout
+        with pytest.raises(YouTubeAPIError) as exc_info:
+            vultr_bandwidth.fetch_bandwidth(instance_id="ABC", api_key="KEY")
+
+    assert exc_info.value.__cause__ is timeout
+
+
+@pytest.mark.parametrize("payload", [[], "bandwidth", 42])
+def test_fetch_bandwidth_rejects_non_dict_payload(payload):
+    """Given Vultr が object 以外の JSON payload を返す
+    When fetch_bandwidth を呼ぶ
+    Then envelope を推測せず YouTubeAPIError で拒否する。
+    """
+    with patch("youtube_automation.utils.streaming.vultr_bandwidth.urllib.request.urlopen") as mock_open:
+        mock_open.return_value = _fake_urlopen_bytes(json.dumps(payload).encode("utf-8"))
+        with pytest.raises(YouTubeAPIError, match="unexpected shape"):
             vultr_bandwidth.fetch_bandwidth(instance_id="ABC", api_key="KEY")
 
 
@@ -179,26 +234,3 @@ def test_monthly_total_gb_returns_zero_when_month_absent():
         "2026-03-15": {"incoming_bytes": _BYTES_PER_GB, "outgoing_bytes": 0},
     }
     assert vultr_bandwidth.monthly_total_gb(bandwidth, year=2026, month=4) == 0.0
-
-
-def test_monthly_total_gb_handles_february_with_31day_query():
-    """Given 2026-02 のデータ
-    When monthly_total_gb(2026, 2) を呼ぶ
-    Then 2 月分のみ集計 (うるう年判定不要、文字列前方一致で十分)。
-    """
-    bandwidth = {
-        "2026-02-28": {"incoming_bytes": _BYTES_PER_GB * 5, "outgoing_bytes": 0},
-        "2026-03-01": {"incoming_bytes": _BYTES_PER_GB * 5, "outgoing_bytes": 0},
-    }
-    assert vultr_bandwidth.monthly_total_gb(bandwidth, year=2026, month=2) == pytest.approx(5.0)
-
-
-def test_monthly_total_gb_zero_padded_month_match():
-    """Given month=4 (int)
-    When キーが "2026-04-..." のとき
-    Then ゼロパディングを考慮してヒットさせる (month=4 → "04")。
-    """
-    bandwidth = {
-        "2026-04-01": {"incoming_bytes": _BYTES_PER_GB, "outgoing_bytes": 0},
-    }
-    assert vultr_bandwidth.monthly_total_gb(bandwidth, year=2026, month=4) == pytest.approx(1.0)

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -78,6 +78,28 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _HEALTHCHECK_DOC = _REPO_ROOT / "docs" / "streaming-healthcheck.md"
 
 
+def _markdown_section(path: Path, heading: str) -> str:
+    """指定 Markdown 見出しから次の同階層以上の見出し直前までを返す。"""
+    lines = read_file(path).splitlines()
+    level = len(heading) - len(heading.lstrip("#"))
+    try:
+        start = lines.index(heading)
+    except ValueError:
+        pytest.fail(f"Markdown 見出しが見つからない: {heading}")
+
+    section: list[str] = []
+    in_fence = False
+    for line in lines[start + 1 :]:
+        if line.startswith("```"):
+            in_fence = not in_fence
+        if not in_fence:
+            next_heading = re.match(r"^(#{1,6})\s", line)
+            if next_heading and len(next_heading.group(1)) <= level:
+                break
+        section.append(line)
+    return "\n".join(section)
+
+
 # ---------- bash ヘルパー ----------
 
 
@@ -121,13 +143,6 @@ def _classify(active: str, sub: str, result: str) -> tuple[int, str, str]:
 class TestHealthcheckShStructure:
     """``.claude/skills/streaming/references/healthcheck.sh`` の静的構造
     （shebang / set -euo / PATH）。"""
-
-    def test_file_exists(self):
-        """Given .claude/skills/streaming/references/
-        When healthcheck.sh を探す
-        Then 存在する。
-        """
-        assert _HEALTHCHECK_SH.exists(), ".claude/skills/streaming/references/healthcheck.sh が存在しない"
 
     def test_has_bash_shebang(self):
         """Given healthcheck.sh
@@ -545,13 +560,6 @@ class TestHealthcheckShStateChange:
 class TestNotifyShStructure:
     """``.claude/skills/streaming/references/notify.sh`` の静的構造。"""
 
-    def test_file_exists(self):
-        """Given .claude/skills/streaming/references/
-        When notify.sh を探す
-        Then 存在する。
-        """
-        assert _NOTIFY_SH.exists(), ".claude/skills/streaming/references/notify.sh が存在しない"
-
     def test_has_bash_shebang(self):
         """Given notify.sh
         When 1 行目を読む
@@ -802,13 +810,6 @@ class TestHealthcheckEnvTftpl:
     systemd ``EnvironmentFile`` 慣例: ``KEY=VALUE``、引用符なし。terraform
     ``templatefile()`` で ``${webhook}`` を実値に展開する。
     """
-
-    def test_file_exists(self):
-        """Given infra/terraform/streaming/templates/
-        When youtube-stream-healthcheck.env.tftpl を探す
-        Then 存在する。
-        """
-        assert _HEALTHCHECK_ENV_TFTPL.exists(), "templates/youtube-stream-healthcheck.env.tftpl が存在しない"
 
     def test_contains_webhook_variable_assignment(self):
         """Given env tftpl
@@ -1127,14 +1128,6 @@ class TestTfvarsExampleDiscordWebhook:
 class TestStreamingReadmeHealthcheck:
     """README.md の死活監視セクション（plan §3）。"""
 
-    def test_mentions_discord(self):
-        """Given README
-        When 全文を読む
-        Then Discord 言及がある（通知手段の説明）。
-        """
-        text = read_file(_STREAMING_README)
-        assert "Discord" in text, "README に Discord 言及が無い（死活監視の通知手段が説明されない）"
-
     def test_mentions_tf_var_discord_webhook_url(self):
         """Given README
         When 全文を読む
@@ -1154,31 +1147,36 @@ class TestStreamingReadmeHealthcheck:
         assert "healthcheck.sh" in text, "README に healthcheck.sh の言及が無い"
 
     @pytest.mark.parametrize(
-        "scenario_keyword",
+        ("operation", "expected"),
         [
-            "kill",  # kill -9 シナリオ
-            "systemctl stop",  # 手動停止シナリオ
-            "RuntimeMaxSec",  # 計画停止シナリオ
-            "再開",  # 自動再開シナリオ（漢字でも英語の "restart" でも可）
+            (
+                r"`pkill -KILL -f 'ffmpeg .*current\.mp4'`",
+                "5 分以内に Discord に anomaly 通知が届く",
+            ),
+            (
+                "`systemctl stop youtube-stream`",
+                "通知は飛ばない（`manual` 分類）",
+            ),
+            (
+                "`RuntimeMaxSec` 到達による正常停止",
+                "通知は飛ばない（`activating+auto-restart+success` = `idle`）",
+            ),
+            (
+                "`RestartSec` 経過後の自動再開（`auto-restart`）",
+                "通知は飛ばない（休止中は `idle`、再開後は `ok`）",
+            ),
         ],
     )
-    def test_mentions_each_test_scenario(self, scenario_keyword: str):
-        """Given README
-        When 全文を読む
-        Then order.md の 4 テストシナリオが運用手順に含まれている。
-
-        ``再開`` は systemd の自動再起動文脈。"restart" 単独は他箇所と被るため、
-        日本語キーワードまたは "RestartSec" / "auto-restart" を緩く受け入れる。
+    def test_documents_each_healthcheck_scenario_outcome(self, operation: str, expected: str):
+        """Given README のテストシナリオ表
+        When 操作と期待結果を読む
+        Then 各操作が固有の分類・通知結果と同じ行で対応付く。
         """
-        text = read_file(_STREAMING_README)
-        if scenario_keyword == "再開":
-            assert "再開" in text or "auto-restart" in text or "RestartSec" in text, (
-                "README に自動再開シナリオの言及が無い"
-            )
-        else:
-            assert scenario_keyword in text, (
-                f"README に '{scenario_keyword}' シナリオの言及が無い（4 シナリオ運用手順未網羅）"
-            )
+        section = _markdown_section(
+            _STREAMING_README,
+            "### テストシナリオ（VPS 上で確認）",
+        )
+        assert f"| {operation} | {expected} |" in section
 
 
 # ============================================================================
@@ -1214,6 +1212,26 @@ class TestStreamingArchiveCount:
         count = count_archives_for_date(service, date(2026, 5, 1))
         assert count == 0, f"動画ゼロのとき 0 を返すべき: {count}"
 
+    def test_searches_fixed_utc_window_and_completed_video_contract(self):
+        """Given target_date=2026-05-01
+        When count_archives_for_date を呼ぶ
+        Then UTC 前日から翌々日までを固定引数で検索する。
+        """
+        from youtube_automation.utils.streaming.daily_archive import count_archives_for_date
+
+        service = self._make_service(search_items=[], video_items=[])
+        count_archives_for_date(service, date(2026, 5, 1))
+
+        service.search.return_value.list.assert_called_once_with(
+            forMine=True,
+            type="video",
+            eventType="completed",
+            publishedAfter="2026-04-30T00:00:00Z",
+            publishedBefore="2026-05-03T00:00:00Z",
+            part="id",
+            maxResults=50,
+        )
+
     def test_counts_videos_with_actual_end_time_in_target_date(self):
         """Given target_date に actualEndTime を持つ動画 2 本
         When count_archives_for_date を呼ぶ
@@ -1243,6 +1261,28 @@ class TestStreamingArchiveCount:
         service = self._make_service(search_items, video_items)
         count = count_archives_for_date(service, target)
         assert count == 2, f"target_date のアーカイブ 2 本を数えていない: {count}"
+
+    def test_counts_offset_end_time_by_utc_date(self):
+        """Given 2026-05-02 00:30 +09:00 に終了した配信
+        When UTC の target_date=2026-05-01 を数える
+        Then ローカル日付でなく UTC 日付へ変換して 1 本に数える。
+        """
+        from youtube_automation.utils.streaming.daily_archive import count_archives_for_date
+
+        service = self._make_service(
+            search_items=[{"id": {"videoId": "offset"}}],
+            video_items=[
+                {
+                    "id": "offset",
+                    "snippet": {"liveBroadcastContent": "none"},
+                    "liveStreamingDetails": {
+                        "actualEndTime": "2026-05-02T00:30:00+09:00",
+                    },
+                }
+            ],
+        )
+
+        assert count_archives_for_date(service, date(2026, 5, 1)) == 1
 
     def test_excludes_videos_outside_target_date(self):
         """Given actualEndTime が target_date より前または後の動画
@@ -1640,40 +1680,63 @@ class TestPyprojectEntryPoint:
 class TestHealthcheckDoc:
     """``docs/streaming-healthcheck.md`` の運用手順書（4 シナリオ網羅）。"""
 
-    def test_file_exists(self):
-        """Given docs/
-        When streaming-healthcheck.md を探す
-        Then 存在する。
-        """
-        assert _HEALTHCHECK_DOC.exists(), "docs/streaming-healthcheck.md が存在しない"
-
     @pytest.mark.parametrize(
-        "scenario_keyword",
+        ("heading", "required_contracts"),
         [
-            "kill",
-            "systemctl stop",
-            "RuntimeMaxSec",
+            (
+                "### シナリオ 1: `pkill` による異常停止",
+                (
+                    "pkill -KILL -f 'ffmpeg .*current\\.mp4'",
+                    "`anomaly`",
+                    "Discord に POST",
+                    'journalctl -t youtube-stream-healthcheck --since "5 minutes ago"',
+                ),
+            ),
+            (
+                "### シナリオ 2: 運用者による `systemctl stop`",
+                (
+                    "systemctl stop youtube-stream",
+                    "`ActiveState=inactive`, `SubState=dead`, `Result=success`",
+                    "`manual`",
+                    "通知は飛ばない",
+                    "systemctl start youtube-stream",
+                    'journalctl -t youtube-stream-healthcheck --since "10 minutes ago"',
+                ),
+            ),
+            (
+                "### シナリオ 3: `RuntimeMaxSec=11h` 到達による正常停止",
+                (
+                    "`Restart=always` + `RestartSec=1h`",
+                    "`activating (auto-restart)`",
+                    "`idle`",
+                    "通知は飛ばない",
+                    "systemctl show youtube-stream -p ActiveState,SubState,Result",
+                ),
+            ),
+            (
+                "### シナリオ 4: 1 時間後の自動再開",
+                (
+                    "`RestartSec=1h`",
+                    "`ActiveState=active`, `SubState=running`",
+                    "`ok`",
+                    "通知は飛ばない",
+                    "journalctl -u youtube-stream -f",
+                ),
+            ),
         ],
     )
-    def test_documents_each_test_scenario(self, scenario_keyword: str):
-        """Given streaming-healthcheck.md
-        When 全文を読む
-        Then order.md の 3 シナリオ（4 つ目「自動再開」は文脈で吸収）が手順書に含まれている。
-
-        order.md「各シナリオが運用手順書に記載済み」要件。
+    def test_documents_scenario_operation_outcome_and_verification(
+        self,
+        heading: str,
+        required_contracts: tuple[str, ...],
+    ):
+        """Given 各シナリオ節
+        When 操作・期待状態・通知・確認方法を読む
+        Then 4 要素が同じ節に揃っている。
         """
-        text = read_file(_HEALTHCHECK_DOC)
-        assert scenario_keyword in text, f"運用手順書に '{scenario_keyword}' シナリオの記載が無い"
-
-    def test_documents_auto_restart_scenario(self):
-        """Given streaming-healthcheck.md
-        When 全文を読む
-        Then 1 時間後の自動再開（RestartSec / auto-restart / 再開 のいずれか）の言及がある。
-        """
-        text = read_file(_HEALTHCHECK_DOC)
-        assert "再開" in text or "RestartSec" in text or "auto-restart" in text, (
-            "運用手順書に自動再開シナリオの記載が無い"
-        )
+        section = _markdown_section(_HEALTHCHECK_DOC, heading)
+        for contract in required_contracts:
+            assert contract in section
 
     def test_documents_archive_check_as_archive_mode_only(self):
         """Given streaming-healthcheck.md


### PR DESCRIPTION
## 変更概要

- streaming・配信インフラ監査の未検証境界を、実際の API 呼出・例外連鎖・shell argv・完全な出力行・同一 Markdown 節の操作/期待結果/確認手順で固定
- 固有の回帰契約を持たない型/存在確認と同値 parameter を、監査台帳どおり限定的に統合・削除
- 本番コードや運用文書は変更せず、最新 `origin/main` に既存の挙動を実回帰テストで保護

監査根拠: `.takt/tasks/20260728-074448-10-16-ta/02-unit-audit.md`（SHA-256 `07d17dddffb96f52b1113b2c74ffd393dcbcbe9e8387a43d7b0038a0c0ddf0b4`）

## leaf 台帳

| leaf | status | 差分 / 実回帰テスト |
|---|---|---|
| #2817 F-001 | passed | UTC検索窓の固定引数と +09:00 終了時刻のUTC日付判定 |
| #2818 F-002 | passed | `TimeoutExpired` → `ConfigError` と `__cause__` |
| #2819 F-003 | passed | 前月0 GB時の百分率なし差分行 |
| #2820 F-004 | passed | 不正JSON・timeout・非dict payloadの例外正規化 |
| #2821 F-005 | passed | 使用量・増減・使用率・実測稼働率の完全な出力行 |
| #2822 F-006 | passed | 1.0/0.0/分数比率の代表parameterへ統合 |
| #2823 F-007 | passed | README/運用文書の操作・期待結果・通知・確認コマンド契約 |
| #2824 F-008 | passed | 型だけのCLI戻り値テストを削除、具体的default契約を維持 |
| #2825 F-009 | passed | stub terraformでdefault/auto-approveの実argvを検証 |
| #2826 F-010 | passed | 重複する文書存在確認2件のみ削除、具体契約を維持 |
| #2827 F-011 | passed | `theoretical_archive_count` の0/負日数を直接検証 |
| #2828 F-012 | passed | 固有契約のない型/存在確認9件のみ削除 |
| #2829 F-013 | passed | 月別prefix選別を代表ケースへ統合 |

failed: 0 / blocked: 0

## 検証

- `nix develop --command uv run pytest -q tests/test_streaming_healthcheck.py tests/test_stream_instance_resolver.py tests/test_stream_monthly_report.py tests/test_stream_vultr_bandwidth.py tests/test_stream_cycle_uptime.py tests/test_stream_bandwidth_cli.py tests/streaming/test_scripts.py tests/streaming/test_skill_streaming.py tests/streaming/test_cloud_init.py tests/streaming/test_terraform_meta.py tests/streaming/test_systemd_unit.py tests/test_terraform_bootstrap.py` — 310 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 670 files formatted
- `nix develop --command bash .github/scripts/any-usage-gate.sh` — passed
- `nix develop --command uv run yt-skills lint` — 57 skills passed
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto -q` — 7194 passed, 1 skipped

外部仕様の変更はなく、参照資料は上記監査レポート、各 issue 本文、既存実装・運用文書です。

Closes #2830
Closes #2817
Closes #2818
Closes #2819
Closes #2820
Closes #2821
Closes #2822
Closes #2823
Closes #2824
Closes #2825
Closes #2826
Closes #2827
Closes #2828
Closes #2829
