### PR TITLE
fix(metadata): 監査スコープ08の境界契約を固定 (#2806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(metadata)`: metadata remote audit の不正 `snippet` 応答を動画単位の診断へ変換し、連続 channel 実行時の skill-config 混入を防止。collection 必須 directory の壊れた symlink と作成 I/O 失敗も文脈付き `ValidationError` へ統一し、metadata・collection・localization の監査 findings 19件を実回帰テストで固定した（#2787〜#2806）。
 - `fix(analytics)`: 競合候補の channel ID を YouTube API 上限の 50 件単位で取得し、uploads playlist 欠損または有効な公開日を持つ動画がない候補を結果から除外する境界を公開 API テストで担保した（#2631）。
 - `fix(analytics)`: retention timeline が不正な retention 数値（変換不能・NaN・Infinity）や非有限の動画尺を `ValidationError` として利用者向けに拒否し、壊れたJSON・曖昧なanalysis参照・duration fallback・未照合・Markdown escaping の境界を直接検証した（#2612, #2636）。
 - `fix(live-chat)`: Codex の構造化出力が JSON object でない場合も `GeneratorError` として安全に拒否し、facade・filter・history保存失敗・投稿失敗・chat終了後再探索・CLI enabled/割込み/例外終了の実行時契約を直接検証した（#2648, #2651）。

--- a/src/youtube_automation/commands/metadata/metadata_audit.py
+++ b/src/youtube_automation/commands/metadata/metadata_audit.py
@@ -201,7 +201,10 @@ def audit_remote(video_ids: dict[str, str]) -> dict[str, list[str]]:
         if not item:
             issues[vid].append("not found on YouTube")
             continue
-        snippet = item["snippet"]
+        snippet = item.get("snippet")
+        if not isinstance(snippet, dict):
+            issues[vid].append("YT snippet missing or not an object")
+            continue
         title = snippet.get("title", "")
         desc = snippet.get("description", "")
         locs = item.get("localizations", {}) or {}

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -19,7 +19,7 @@ from typing import Dict, List
 
 import yaml
 
-from youtube_automation.configuration import load_config
+from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
 from youtube_automation.domains.metadata.descriptions import (
     build_complete_collection_description,
@@ -63,9 +63,13 @@ class BAHMetadataGenerator:
             collection_path (str): コレクションディレクトリのパス
         """
         self.config = load_config()
-        self._masterup_config = load_skill_config("masterup")
+        current_channel_dir = channel_dir()
+        self._masterup_config = load_skill_config("masterup", channel_dir=current_channel_dir)
         self._crossfade_sec = float(self._masterup_config.get("audio", {}).get("crossfade_duration", 1.0))
-        self._video_description_config = load_skill_config("video-description")
+        self._video_description_config = load_skill_config(
+            "video-description",
+            channel_dir=current_channel_dir,
+        )
         self.collection_path = Path(collection_path)
         self.collection_name = self._extract_collection_name()
         self.bit_depth = self.config.content.genre.style

--- a/src/youtube_automation/utils/collection_paths.py
+++ b/src/youtube_automation/utils/collection_paths.py
@@ -122,6 +122,15 @@ class CollectionPaths:
 
         既存のディレクトリ・ファイルには一切触れない（非破壊）。
         """
+        broken_symlinks = [
+            sub for sub in REQUIRED_SUBDIRS if (self.root / sub).is_symlink() and not (self.root / sub).exists()
+        ]
+        if broken_symlinks:
+            raise ValidationError(
+                "必須サブディレクトリ名と同名の壊れた symlink があります: "
+                + ", ".join(broken_symlinks)
+                + "。symlink を修復または退避してから再実行してください。"
+            )
         invalid = self.invalid_required_dirs()
         if invalid:
             raise ValidationError(
@@ -131,7 +140,10 @@ class CollectionPaths:
             )
         missing = self.missing_required_dirs()
         for sub in missing:
-            (self.root / sub).mkdir(parents=True, exist_ok=True)
+            try:
+                (self.root / sub).mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                raise ValidationError(f"必須サブディレクトリ {sub} を作成できません: {exc}") from exc
         return missing
 
     def find_master_video(self) -> Path | None:

--- a/tests/test_bulk_update_descriptions_from_md.py
+++ b/tests/test_bulk_update_descriptions_from_md.py
@@ -610,6 +610,39 @@ class TestMainExecution:
                 "Keeping old title; updating description only.",
             ) in [(record.levelname, record.message) for record in caplog.records]
 
+    def test_should_accept_new_title_at_exactly_100_utf16_units(self, tmp_path, monkeypatch):
+        """REQ-2805-01: UTF-16 ちょうど 100 units は新 title を保持する."""
+        from youtube_automation.commands.metadata import bulk_update_descriptions as mod
+
+        boundary_title = "x" * 98 + "🎵"
+        assert mod.utf16_units(boundary_title) == 100
+        ch = _setup_channel(tmp_path)
+        _make_collection_with_descriptions(
+            ch,
+            "alpha",
+            video_id="V_ALPHA",
+            title=boundary_title,
+            description="new desc",
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+        reset()
+        monkeypatch.setattr(sys, "argv", ["yt-bulk-update-desc"])
+        yt_mock = _build_youtube_mock([_snippet("V_ALPHA", title="old title", description="old desc")])
+
+        with (
+            patch.object(
+                mod,
+                "create_authenticated_youtube_clients",
+                return_value=SimpleNamespace(youtube=yt_mock),
+            ),
+            patch.object(mod.time, "sleep"),
+        ):
+            mod.main()
+
+        body = yt_mock.videos.return_value.update.call_args_list[0].kwargs["body"]
+        assert body["snippet"]["title"] == boundary_title
+        assert body["snippet"]["description"] == "new desc"
+
     def test_should_log_collection_load_failure(self, tmp_path, monkeypatch, caplog):
         """collection 読み込み失敗は collection 名と例外詳細を ERROR に残す."""
         from youtube_automation.commands.metadata import bulk_update_descriptions as mod

--- a/tests/test_bulk_update_short_localizations.py
+++ b/tests/test_bulk_update_short_localizations.py
@@ -14,6 +14,7 @@ plan 要件 #10 / 14-d / アンチパターン #8 を検証する:
 
 from __future__ import annotations
 
+import builtins
 import json
 import shutil
 import sys
@@ -169,6 +170,48 @@ class TestCollectShortVideos:
         assert "V_OK" in ids
         assert None not in ids
         assert len(videos) == 1
+
+    def test_corrupt_workflow_state_is_logged_and_skipped(self, tmp_path, monkeypatch, caplog):
+        """REQ-2797-01: Shorts の破損 JSON を診断して skip する."""
+        from youtube_automation.commands.metadata import bulk_update_short_localizations as mod
+
+        ch = _setup_channel(tmp_path)
+        col = _make_collection_with_shorts(
+            ch,
+            "20250101-live-broken",
+            shorts=[{"short_num": 1, "video_id": "V_BROKEN"}],
+        )
+        (col / "workflow-state.json").write_text("{broken", encoding="utf-8")
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+        reset()
+
+        assert mod.collect_short_videos() == []
+        assert "20250101-live-broken 読み込み失敗" in caplog.text
+
+    def test_tracking_read_oserror_is_logged_and_skipped(self, tmp_path, monkeypatch, caplog):
+        """REQ-2797-02: Shorts tracking の I/O 失敗を診断して skip する."""
+        from youtube_automation.commands.metadata import bulk_update_short_localizations as mod
+
+        ch = _setup_channel(tmp_path)
+        col = _make_collection_with_shorts(
+            ch,
+            "20250101-live-unreadable",
+            shorts=[{"short_num": 1, "video_id": "V_UNREADABLE"}],
+        )
+        target = col / "20-documentation" / "upload_tracking.json"
+        original_open = builtins.open
+
+        def selective_open(file, *args, **kwargs):
+            if Path(file) == target:
+                raise OSError("permission denied")
+            return original_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", selective_open)
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+        reset()
+
+        assert mod.collect_short_videos() == []
+        assert "permission denied" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bulk_update_synthetic_media.py
+++ b/tests/test_bulk_update_synthetic_media.py
@@ -12,6 +12,45 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from youtube_automation.commands.metadata import bulk_update_synthetic_media as mod
+from youtube_automation.infrastructure.errors import YouTubeAPIError
+
+
+def _http_error(status: int = 503):
+    from googleapiclient.errors import HttpError
+
+    response = MagicMock()
+    response.status = status
+    return HttpError(response, b'{"error": {"message": "backend unavailable"}}')
+
+
+class TestReadFailures:
+    def test_empty_authenticated_channel_is_a_domain_error(self):
+        """REQ-2797-03: channel items 空を domain error とする."""
+        youtube = MagicMock()
+        youtube.channels.return_value.list.return_value.execute.return_value = {"items": []}
+
+        with pytest.raises(YouTubeAPIError, match="items 空"):
+            mod.list_uploads_video_ids(youtube)
+
+    def test_uploads_playlist_read_http_error_is_a_domain_error(self):
+        """REQ-2797-04: uploads 読み取り HttpError を domain error に変換する."""
+        youtube = MagicMock()
+        youtube.channels.return_value.list.return_value.execute.return_value = {
+            "items": [{"contentDetails": {"relatedPlaylists": {"uploads": "UPLOADS"}}}]
+        }
+        youtube.playlistItems.return_value.list.return_value.execute.side_effect = _http_error()
+
+        with pytest.raises(YouTubeAPIError, match="uploads playlist"):
+            mod.list_uploads_video_ids(youtube)
+
+    def test_status_read_http_error_is_a_domain_error(self):
+        """REQ-2797-05: status 読み取り HttpError を domain error に変換する."""
+        youtube = MagicMock()
+        youtube.videos.return_value.list.return_value.execute.side_effect = _http_error()
+
+        with pytest.raises(YouTubeAPIError, match="動画 status"):
+            mod.fetch_status_batch(youtube, ["VID"])
+
 
 # ---------------------------------------------------------------------------
 # select_targets

--- a/tests/test_collection_paths.py
+++ b/tests/test_collection_paths.py
@@ -667,3 +667,37 @@ class TestRequiredSkeleton:
 
         assert collision.is_file()
         assert collision.read_text(encoding="utf-8") == "keep me"
+
+    def test_ensure_required_dirs_rejects_broken_symlink_without_replacing_it(self, tmp_path):
+        """REQ-2800-01: 壊れた symlink を破壊せず domain error にする."""
+        collision = tmp_path / "01-master"
+        collision.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+        paths = CollectionPaths(tmp_path)
+
+        with pytest.raises(ValidationError, match="壊れた symlink"):
+            paths.ensure_required_dirs()
+
+        assert collision.is_symlink()
+        assert not collision.exists()
+
+    def test_ensure_required_dirs_wraps_directory_creation_oserror(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """REQ-2800-02: directory 作成 I/O 失敗を文脈付き domain error にする."""
+        target = tmp_path / "01-master"
+        original_mkdir = Path.mkdir
+
+        def selective_mkdir(path: Path, *args, **kwargs):
+            if path == target:
+                raise PermissionError("permission denied")
+            return original_mkdir(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", selective_mkdir)
+        paths = CollectionPaths(tmp_path)
+
+        with pytest.raises(ValidationError, match="01-master.*permission denied"):
+            paths.ensure_required_dirs()
+
+        assert not target.exists()

--- a/tests/test_collection_serve.py
+++ b/tests/test_collection_serve.py
@@ -3757,16 +3757,19 @@ def test_post_downloaded_default_rejects_extension_origin_without_exact_lock(ser
     assert exc_info.value.code == 403
 
 
-def test_post_downloaded_default_rejects_missing_origin_without_exact_lock(serve_dir, tmp_path):
-    """Given allow_origin 未指定の通常起動
-    When Origin なしで /auth/token を取得しようとする
-    Then 403 を返す。
-    """
+def test_post_downloaded_rejects_missing_runtime_origin_even_with_valid_token(serve_dir, tmp_path):
+    """REQ-2801-01: downloaded POST は token が正しくても runtime origin 未申告なら拒否する."""
     planning = tmp_path / "planning"
     _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
-    base = serve_dir(planning)
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
+    token = _fetch_token(base)
+
     with pytest.raises(urllib.error.HTTPError) as exc_info:
-        urllib.request.urlopen(f"{base}/auth/token")
+        _post(
+            f"{base}{_COLLECTIONS_ROUTE}/20260601-clm-aaa-collection/downloaded",
+            {"file_count": 0, "format": "mp3"},
+            headers={"X-Serve-Token": token},
+        )
 
     assert exc_info.value.code == 403
 

--- a/tests/test_collection_serve_discovery.py
+++ b/tests/test_collection_serve_discovery.py
@@ -387,6 +387,18 @@ class InitiallyUnavailableTransport(RecordingTransport):
         super().register(payload)
 
 
+class HeartbeatTemporarilyUnavailableTransport(RecordingTransport):
+    def __init__(self, state: RegistryState) -> None:
+        super().__init__(state)
+        self.attempts = 0
+
+    def register(self, payload: dict[str, object]) -> None:
+        self.attempts += 1
+        if self.attempts == 2:
+            raise urllib.error.URLError("temporary heartbeat failure")
+        super().register(payload)
+
+
 class HeartbeatRejectedTransport(RecordingTransport):
     def register(self, payload: dict[str, object]) -> None:
         if self.registered:
@@ -468,6 +480,39 @@ def test_lifecycle_recovers_when_initial_follower_registration_races_registry_st
         assert len(state.snapshot()["servers"]) == 1
     finally:
         lifecycle.stop()
+
+
+def test_lifecycle_reregisters_after_temporary_heartbeat_failure():
+    """REQ-2793-01: 初回成功後の一時 heartbeat 障害から再登録する."""
+    clock = FakeClock(100.0)
+    state = RegistryState(ttl_seconds=30, clock=clock)
+    wait = ControlledWait(clock)
+    transport = HeartbeatTemporarilyUnavailableTransport(state)
+    lifecycle = DiscoveryLifecycle(
+        server_info=server_info("http://alpha.localhost:9001", "Alpha"),
+        instance_id="instance-a",
+        heartbeat_seconds=10,
+        wait=wait,
+        transport=transport,
+    )
+
+    try:
+        lifecycle.start()
+        assert len(transport.registered) == 1
+
+        wait.release()
+        wait_until(lambda: assert_transport_attempts(transport, 2))
+        wait.release()
+        wait_until(lambda: assert_registration_count(transport, 2))
+
+        assert transport.attempts == 3
+        assert len(state.snapshot()["servers"]) == 1
+    finally:
+        lifecycle.stop()
+
+
+def assert_transport_attempts(transport: HeartbeatTemporarilyUnavailableTransport, expected: int) -> None:
+    assert transport.attempts >= expected
 
 
 def test_lifecycle_heartbeat_reports_permanent_http_rejection(monkeypatch):

--- a/tests/test_collection_uploader.py
+++ b/tests/test_collection_uploader.py
@@ -905,26 +905,36 @@ class TestExecuteCompleteCollectionResume:
         assert cc.get("concurrent_marker") == "x"
 
     def test_should_not_reuse_stale_uri_after_successful_previous_upload(self, tmp_path):
-        """plan 要件 #6 回帰: 前回成功で URI クリア済みの tracking で再実行しても URI は None."""
-        # Given: 前回成功で URI クリア済みの tracking（=URI 無し、status pending に戻したとする）
-        col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
+        """REQ-2802-01: 成功時の URI 消去を disk で観測し、次回へ stale URI を渡さない."""
+        col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=_SESS_PREV)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
         mock_inner.upload_collection.return_value = {
             "complete_video": {
-                "video_id": "V_FRESH",
+                "video_id": "V_FIRST",
                 "video_url": "u",
                 "title": "t",
                 "file_path": "p",
             }
         }
 
-        # When
-        tracking = uploader._load_tracking(col)
-        uploader._execute_complete_collection(col, tracking, publish_at=None)
+        first_tracking = uploader._load_tracking(col)
+        uploader._execute_complete_collection(col, first_tracking, publish_at=None)
 
-        # Then
-        call_kwargs = mock_inner.upload_collection.call_args.kwargs
-        assert call_kwargs.get("resume_session_uri") is None
+        assert mock_inner.upload_collection.call_args_list[0].kwargs["resume_session_uri"] == _SESS_PREV
+        assert _read_resume_uri(tracking_path) is None
+
+        mock_inner.upload_collection.return_value = {
+            "complete_video": {
+                "video_id": "V_SECOND",
+                "video_url": "u2",
+                "title": "t2",
+                "file_path": "p2",
+            }
+        }
+        second_tracking = uploader._load_tracking(col)
+        uploader._execute_complete_collection(col, second_tracking, publish_at=None)
+
+        assert mock_inner.upload_collection.call_args_list[1].kwargs["resume_session_uri"] is None
 
     def test_should_resume_same_session_uri_on_retry_after_mid_upload_failure(self, tmp_path):
         """**issue #381 中核回帰**: 1 回目失敗 → 2 回目で同一 URI で resume."""

--- a/tests/test_distrokid_collections_endpoint.py
+++ b/tests/test_distrokid_collections_endpoint.py
@@ -22,6 +22,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -218,6 +219,41 @@ def test_write_and_read_distrokid_release_round_trip(tmp_path):
     released = read_released_discs(root)
 
     assert "20260526-abc-collection/disc1-alpha" in released
+
+
+def test_write_distrokid_release_recovers_from_corrupt_existing_json(tmp_path):
+    """REQ-2794-01: 破損 release 記録を fail-soft で上書き回復する."""
+    root = tmp_path / "channel"
+    target = distrokid_releases_output_path(root)
+    target.parent.mkdir(parents=True)
+    target.write_text("{broken", encoding="utf-8")
+
+    write_distrokid_release(root, "20260526-abc-collection", "disc1-alpha", "Recovered")
+
+    assert read_released_discs(root) == {"20260526-abc-collection/disc1-alpha"}
+    assert (
+        json.loads(target.read_text(encoding="utf-8"))["20260526-abc-collection/disc1-alpha"]["album_title"]
+        == "Recovered"
+    )
+
+
+def test_write_distrokid_release_recovers_after_existing_json_read_oserror(tmp_path):
+    """REQ-2794-02: 読み取り I/O 失敗後も新規 release 記録を書ける."""
+    root = tmp_path / "channel"
+    target = distrokid_releases_output_path(root)
+    target.parent.mkdir(parents=True)
+    target.write_text('{"old/disc": {"album_title": "old"}}', encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def fail_target_read(path: Path, *args, **kwargs):
+        if path == target:
+            raise OSError("temporary read failure")
+        return original_read_text(path, *args, **kwargs)
+
+    with patch.object(Path, "read_text", fail_target_read):
+        write_distrokid_release(root, "20260526-abc-collection", "disc1-alpha", "Recovered")
+
+    assert read_released_discs(root) == {"20260526-abc-collection/disc1-alpha"}
 
 
 def test_write_distrokid_release_stores_album_title_and_recorded_at(tmp_path):

--- a/tests/test_example_localizations.py
+++ b/tests/test_example_localizations.py
@@ -39,14 +39,7 @@ def _assert_non_empty_string(value: object, *, field_name: str) -> None:
     assert value.strip(), f"{field_name} must not be empty"
 
 
-def test_example_localizations_file_exists() -> None:
-    assert _EXAMPLE_LOCALIZATIONS.is_file()
-
-
-def test_channel_new_localizations_template_exists() -> None:
-    assert _CHANNEL_SETUP_TEMPLATE.is_file()
-
-
+# REQ-2798-01: JSON 読込を伴う構造検証が file existence も一意に担保する。
 def test_example_localizations_supported_languages_are_high_cpm_tier_only() -> None:
     data = _read_json(_EXAMPLE_LOCALIZATIONS)
 

--- a/tests/test_init_collection.py
+++ b/tests/test_init_collection.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 from youtube_automation.commands.collections.init_collection import main
-from youtube_automation.configuration import channel_dir
+from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.utils.collection_paths import REQUIRED_SUBDIRS
 
 
@@ -75,6 +75,49 @@ class TestScaffold:
             assert "uv run yt-collection-preflight" in err
             assert "bunx tayk collection-preflight" not in err
             assert "quote scaffold-collection'" in err
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_cli_options_are_persisted_in_workflow_state(self, monkeypatch):
+        """REQ-2795-01: CLI option を workflow-state の実値として保存する."""
+        _run(
+            monkeypatch,
+            [
+                "Configured Scaffold",
+                "init-scaffold",
+                "--track-count",
+                "7",
+                "--selected-plan",
+                "D",
+                "--music-engine",
+                "lyria",
+            ],
+        )
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["collection_name"] == "Configured Scaffold"
+            assert state["theme"] == "init-scaffold"
+            assert state["track_count"] == 7
+            assert state["selected_plan"] == "D"
+            assert state["music_engine"] == "lyria"
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_music_engine_falls_back_to_channel_config(self, monkeypatch):
+        """REQ-2795-02: 未指定値は channel config/default から補完する."""
+        expected_engine = load_config().youtube.music_engine
+        _run(monkeypatch, ["Fallback Scaffold", "init-scaffold"])
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["music_engine"] == expected_engine
+            assert state["track_count"] == 12
+            assert state["selected_plan"] == "A"
         finally:
             import shutil
 

--- a/tests/test_metadata_audit.py
+++ b/tests/test_metadata_audit.py
@@ -298,3 +298,63 @@ class TestRemoteChapterMaxSkillConfig:
         ):
             result = audit_remote({video_id: "test-collection"})
         assert any("chapters (>12)" in issue for issue in result[video_id])
+
+    def test_audit_remote_continues_when_quota_recording_fails(self) -> None:
+        """REQ-2791-01: quota 台帳失敗は remote audit を停止させない."""
+        video_id = "VID"
+        response = _yt_response(video_id, {})
+        with (
+            patch(
+                "youtube_automation.infrastructure.google.youtube.YouTubeClients",
+                return_value=SimpleNamespace(youtube_readonly=_patched_yt(response)),
+            ),
+            patch(
+                "youtube_automation.commands.metadata.metadata_audit.cost_tracker.log_quota",
+                side_effect=OSError("quota ledger unavailable"),
+            ),
+        ):
+            result = audit_remote({video_id: "test-collection"})
+
+        assert result == {video_id: []}
+
+    @pytest.mark.parametrize("snippet", [None, [], "invalid"])
+    def test_audit_remote_reports_non_object_snippet_without_stopping(self, snippet: object) -> None:
+        """REQ-2791-02: snippet 非 object を診断して次動画へ継続する."""
+        response = {
+            "items": [
+                {"id": "BROKEN", "snippet": snippet, "localizations": {}},
+                {
+                    "id": "VALID",
+                    "snippet": {"title": "valid", "description": ""},
+                    "localizations": {},
+                },
+            ]
+        }
+        with patch(
+            "youtube_automation.infrastructure.google.youtube.YouTubeClients",
+            return_value=SimpleNamespace(youtube_readonly=_patched_yt(response)),
+        ):
+            result = audit_remote({"BROKEN": "broken", "VALID": "valid"})
+
+        assert result["BROKEN"] == ["YT snippet missing or not an object"]
+        assert result["VALID"] == []
+
+    def test_audit_remote_reports_missing_snippet_without_stopping(self) -> None:
+        response = {
+            "items": [
+                {"id": "BROKEN", "localizations": {}},
+                {
+                    "id": "VALID",
+                    "snippet": {"title": "valid", "description": ""},
+                    "localizations": {},
+                },
+            ]
+        }
+        with patch(
+            "youtube_automation.infrastructure.google.youtube.YouTubeClients",
+            return_value=SimpleNamespace(youtube_readonly=_patched_yt(response)),
+        ):
+            result = audit_remote({"BROKEN": "broken", "VALID": "valid"})
+
+        assert result["BROKEN"] == ["YT snippet missing or not an object"]
+        assert result["VALID"] == []

--- a/tests/test_metadata_generator.py
+++ b/tests/test_metadata_generator.py
@@ -5,6 +5,7 @@ BAHMetadataGenerator のユニットテスト
 副作用のない純粋ロジック（タイムスタンプ計算、ファイル名サニタイズ、メタデータ生成）を検証する。
 """
 
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 import yaml
 
+import youtube_automation.domains.metadata as metadata_api
 from youtube_automation.configuration import load_config
 from youtube_automation.domains.metadata import (
     LOCALIZED_TITLE_PLACEHOLDERS,
@@ -25,7 +27,12 @@ from youtube_automation.domains.metadata import (
     validate_scene_phrases,
 )
 from youtube_automation.domains.metadata import service as metadata_generator_module
-from youtube_automation.domains.metadata.localizations import _localized_title_values
+from youtube_automation.domains.metadata.descriptions import build_short_description
+from youtube_automation.domains.metadata.localizations import (
+    _localized_title_values,
+    build_short_localizations,
+)
+from youtube_automation.domains.metadata.placeholders import is_placeholder_value
 from youtube_automation.domains.metadata.titles import _extract_pattern_key
 from youtube_automation.infrastructure.errors import ValidationError
 from youtube_automation.utils.time_utils import format_duration_display
@@ -52,6 +59,96 @@ def _make_generator(dir_name: str = "20250907-live-8bit-adventure-music") -> BAH
     gen.bit_depth = gen.config.content.genre.style
     gen.tracks = []
     return gen
+
+
+# REQ-2787-01: placeholder policy の全入力分岐を直接観測する。
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, True),
+        (123, False),
+        (" \t", True),
+        ("TBD", True),
+        ("{{ scene_phrase }}", True),
+        ("finished", False),
+        ("prefix {{ scene_phrase }}", False),
+    ],
+)
+def test_placeholder_value_policy_covers_every_input_branch(value: object, expected: bool) -> None:
+    assert is_placeholder_value(value) is expected
+
+
+# REQ-2788-01: localization template の非正規 shape を専用入力で観測する。
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"languages": []},
+        {"languages": {"ja": {"title_template": ["not", "a", "string"]}}},
+    ],
+)
+def test_localization_template_validator_ignores_noncanonical_shapes(payload: dict) -> None:
+    assert validate_localizations_title_templates(payload) == []
+
+
+# REQ-2790-01: metadata package の遅延 export 表と解決挙動を固定する。
+def test_metadata_public_api_resolves_exact_lazy_export_contract() -> None:
+    expected = {
+        "BAHMetadataGenerator",
+        "LOCALIZED_TITLE_PLACEHOLDERS",
+        "SceneTitleViolation",
+        "build_short_description",
+        "build_short_localizations",
+        "format_scene_title_violations",
+        "format_title_template",
+        "validate_localizations_title_templates",
+        "validate_scene_phrases",
+    }
+
+    assert set(metadata_api.__all__) == expected
+    resolved = {name: getattr(metadata_api, name) for name in metadata_api.__all__}
+    assert resolved == {
+        "BAHMetadataGenerator": BAHMetadataGenerator,
+        "LOCALIZED_TITLE_PLACEHOLDERS": LOCALIZED_TITLE_PLACEHOLDERS,
+        "SceneTitleViolation": SceneTitleViolation,
+        "build_short_description": build_short_description,
+        "build_short_localizations": build_short_localizations,
+        "format_scene_title_violations": format_scene_title_violations,
+        "format_title_template": format_title_template,
+        "validate_localizations_title_templates": validate_localizations_title_templates,
+        "validate_scene_phrases": validate_scene_phrases,
+    }
+
+
+def test_metadata_public_api_rejects_unknown_lazy_export() -> None:
+    with pytest.raises(AttributeError, match="definitely_not_public"):
+        metadata_api.__getattr__("definitely_not_public")
+
+
+# REQ-2789-01: syntactically valid な workflow-state 不正 shape を拒否する。
+@pytest.mark.parametrize(
+    ("payload", "loader", "message"),
+    [
+        ([], "_load_workflow_state", "root は object"),
+        ({"planning": []}, "_load_scene_emoji", "planning は object"),
+        ({"planning": {"scene_emoji": 123}}, "_load_scene_emoji", "scene_emoji は string"),
+        ({"scene_phrases": []}, "_load_scene_phrases", "scene_phrases は object"),
+    ],
+)
+def test_workflow_state_rejects_syntactically_valid_invalid_shapes(
+    tmp_path: Path,
+    payload: object,
+    loader: str,
+    message: str,
+) -> None:
+    (tmp_path / "workflow-state.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+    gen = _make_generator()
+    gen.collection_path = tmp_path
+
+    with pytest.raises(ValidationError, match=message):
+        getattr(gen, loader)()
 
 
 # ===========================================================================
@@ -665,6 +762,49 @@ class TestCrossfade:
         try:
             gen = BAHMetadataGenerator(str(channel / "collections" / "demo"))
             assert gen._crossfade_sec == 2.5
+        finally:
+            reset_config()
+            reset_skill_config()
+
+    def test_sequential_channels_do_not_inherit_config_or_skill_overrides(self, tmp_path, monkeypatch):
+        """REQ-2799-01: A→B 連続生成でも B の channel/skill 設定だけを使う."""
+        from youtube_automation.configuration import reset as reset_config
+        from youtube_automation.utils.skill_config import reset as reset_skill_config
+
+        fixture = Path(__file__).resolve().parent / "fixtures" / "sample_channel"
+        channels: list[Path] = []
+        for name, channel_name, crossfade in [
+            ("channel-a", "Channel A", 2.0),
+            ("channel-b", "Channel B", 7.0),
+        ]:
+            channel = tmp_path / name
+            shutil.copytree(fixture, channel)
+            meta_path = channel / "config" / "channel" / "meta.json"
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta["channel"]["name"] = channel_name
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
+            skills_dir = channel / "config" / "skills"
+            skills_dir.mkdir(parents=True)
+            (skills_dir / "masterup.yaml").write_text(
+                yaml.safe_dump({"audio": {"crossfade_duration": crossfade}}),
+                encoding="utf-8",
+            )
+            channels.append(channel)
+
+        reset_config()
+        reset_skill_config()
+        try:
+            monkeypatch.setenv("CHANNEL_DIR", str(channels[0]))
+            first = BAHMetadataGenerator(str(channels[0] / "collections" / "demo"))
+            assert first.config.meta.channel_name == "Channel A"
+            assert first._crossfade_sec == 2.0
+
+            monkeypatch.setenv("CHANNEL_DIR", str(channels[1]))
+            reset_config()
+            second = BAHMetadataGenerator(str(channels[1] / "collections" / "demo"))
+
+            assert second.config.meta.channel_name == "Channel B"
+            assert second._crossfade_sec == 7.0
         finally:
             reset_config()
             reset_skill_config()

--- a/tests/test_numbered_duplicates.py
+++ b/tests/test_numbered_duplicates.py
@@ -106,6 +106,33 @@ class TestScanNumberedDuplicates:
         assert result.errors[0].path == tmp_path
         assert "permission denied" in result.errors[0].reason
 
+    def test_recursive_scan_keeps_found_duplicates_when_a_child_scan_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """REQ-2796-01: 部分走査失敗でも既発見 duplicate と error を両方返す."""
+        (tmp_path / "mix.mp3").write_bytes(b"base")
+        duplicate = tmp_path / "mix 2.mp3"
+        duplicate.write_bytes(b"duplicate")
+        failing_child = tmp_path / "unreadable"
+        failing_child.mkdir()
+        original_iterdir = Path.iterdir
+
+        def selective_iterdir(path: Path):
+            if path == failing_child:
+                raise PermissionError("permission denied")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", selective_iterdir)
+
+        result = scan_numbered_duplicates(tmp_path, recursive=True)
+
+        assert result.duplicates == (duplicate,)
+        assert len(result.errors) == 1
+        assert result.errors[0].path == failing_child
+        assert "permission denied" in result.errors[0].reason
+
     def test_scan_rejects_symlink_root(self, tmp_path: Path):
         outside = tmp_path / "outside"
         outside.mkdir()

--- a/tests/test_title_duplicate_check.py
+++ b/tests/test_title_duplicate_check.py
@@ -102,6 +102,7 @@ def test_main_rejects_title_over_100_codepoints(tmp_path: Path, capsys: pytest.C
     captured = capsys.readouterr()
     assert rc == 1
     assert "YouTube 制限 100 を超過" in captured.out
+    assert "title duplicate warning" not in captured.out
 
 
 def test_main_rejects_descriptions_title_over_100_codepoints(
@@ -140,6 +141,60 @@ def test_main_rejects_long_title_before_duplicate_warning(tmp_path: Path, capsys
     captured = capsys.readouterr()
     assert rc == 1
     assert "YouTube 制限 100 を超過" in captured.out
+    assert "title duplicate warning" not in captured.out
+
+
+@pytest.mark.parametrize(("strict_args", "expected_rc"), [([], 0), (["--strict"], 1)])
+def test_main_duplicate_warning_respects_strict_mode(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    strict_args: list[str],
+    expected_rc: int,
+) -> None:
+    """REQ-2792-01: duplicate warning の strict/non-strict 終了コードを固定する."""
+    from youtube_automation.commands.metadata.title_duplicate_check import main
+
+    title = "Rainy Night Focus Mix"
+    existing = tmp_path / "collections" / "live" / "published"
+    _write_descriptions_md(existing, _valid_descriptions_md(title))
+
+    rc = main(
+        [
+            "--title",
+            title,
+            "--collections-root",
+            str(tmp_path / "collections"),
+            *strict_args,
+        ]
+    )
+
+    assert rc == expected_rc
+    assert "title duplicate warning" in capsys.readouterr().out
+
+
+def test_main_excludes_the_current_live_collection_from_duplicate_check(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """REQ-2792-02: 現在の live collection は自己重複から除外する."""
+    from youtube_automation.commands.metadata.title_duplicate_check import main
+
+    current = tmp_path / "collections" / "live" / "current"
+    title = "Rainy Night Focus Mix"
+    _write_descriptions_md(current, _valid_descriptions_md(title))
+
+    rc = main(
+        [
+            str(current),
+            "--collections-root",
+            str(tmp_path / "collections"),
+            "--strict",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "title duplicate check OK" in captured.out
     assert "title duplicate warning" not in captured.out
 
 

--- a/tests/test_vote_log_cli.py
+++ b/tests/test_vote_log_cli.py
@@ -44,6 +44,22 @@ def test_parse_axis_arg_rejects_negative_votes():
         cli._parse_axis_arg("a:A:-1")
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (":Rain Window:1", "key が空"),
+        ("rain_window::1", "label が空"),
+        ("rain_window:Rain Window:not-an-int", "votes が整数ではありません"),
+    ],
+)
+def test_parse_axis_arg_rejects_empty_fields_and_non_integer_votes(value: str, message: str):
+    """REQ-2804-01: axis の空 key/label と非整数 votes を個別拒否する."""
+    import argparse
+
+    with pytest.raises(argparse.ArgumentTypeError, match=message):
+        cli._parse_axis_arg(value)
+
+
 def test_cli_append_then_show(channel_dir_env: Path, capsys: pytest.CaptureFixture[str]):
     rc = cli.main(
         [

--- a/tests/test_weekly_vote_log.py
+++ b/tests/test_weekly_vote_log.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -17,6 +17,8 @@ from youtube_automation.domains.collections.weekly_vote_log import (
     compute_vote_log_weights,
     load_weekly_vote_log,
     load_weekly_vote_log_schema,
+    parse_iso_date,
+    parse_isoformat_datetime,
     poll_deprecation_message,
     save_weekly_vote_log,
     validate_weekly_vote_log,
@@ -75,6 +77,58 @@ def test_validate_minimal_payload():
 def test_validate_rejects_unknown_schema_version():
     with pytest.raises(ValidationError, match="schema_version"):
         validate_weekly_vote_log({"schema_version": 999, "entries": []})
+
+
+# REQ-2803-01: weekly vote log の root/entry/axis 非 object を個別拒否する。
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "トップは dict"),
+        ({"schema_version": 1, "entries": ["invalid"]}, r"entries\[0\]: dict"),
+        (
+            {
+                "schema_version": 1,
+                "entries": [
+                    {
+                        "week_start": "2026-05-04",
+                        "axes": ["invalid"],
+                        "top_axis": "rain",
+                    }
+                ],
+            },
+            r"axes\[0\]: dict",
+        ),
+    ],
+)
+def test_validate_rejects_non_object_root_entry_and_axis_shapes(payload: object, message: str):
+    with pytest.raises(ValidationError, match=message):
+        validate_weekly_vote_log(payload)
+
+
+def test_public_date_helpers_parse_valid_values():
+    """REQ-2803-02: 公開日付 helper の正常変換を固定する."""
+    assert parse_iso_date("2026-05-04") == date(2026, 5, 4)
+    assert parse_isoformat_datetime("2026-05-04T12:34:56+00:00") == datetime(
+        2026,
+        5,
+        4,
+        12,
+        34,
+        56,
+        tzinfo=timezone.utc,
+    )
+
+
+@pytest.mark.parametrize(
+    ("parser", "value", "error"),
+    [
+        (parse_iso_date, "2026/05/04", ValidationError),
+        (parse_isoformat_datetime, "not-a-datetime", ValueError),
+    ],
+)
+def test_public_date_helpers_reject_invalid_values(parser, value: str, error: type[Exception]):
+    with pytest.raises(error):
+        parser(value)
 
 
 def test_validate_rejects_total_votes_mismatch():


### PR DESCRIPTION
## 変更概要

- metadata remote audit が quota 記録失敗後も継続し、欠落・非objectの `snippet` を動画単位の診断として扱う
- metadata generator が channel directory を明示して skill-config を読み、同一processで A→B と連続実行しても設定を混入させない
- collection必須directoryの壊れたsymlinkと作成I/O失敗を非破壊の `ValidationError` に統一する
- 監査スコープ08の全19 leafについて、失敗・境界・状態遷移を実行する回帰テストを追加または強化し、重複していたexistence/tokenテストは同等以上の実挙動検証へ整理する

## Leaf findings

Closes #2806
Closes #2787
Closes #2788
Closes #2789
Closes #2790
Closes #2791
Closes #2792
Closes #2793
Closes #2794
Closes #2795
Closes #2796
Closes #2797
Closes #2798
Closes #2799
Closes #2800
Closes #2801
Closes #2802
Closes #2803
Closes #2804
Closes #2805

## 検証

- `nix develop --command uv run pytest -q tests/test_metadata_generator.py tests/test_metadata_audit.py tests/test_title_duplicate_check.py tests/test_collection_serve_discovery.py tests/test_distrokid_collections_endpoint.py tests/test_init_collection.py tests/test_numbered_duplicates.py tests/test_bulk_update_short_localizations.py tests/test_bulk_update_synthetic_media.py tests/test_collection_paths.py tests/test_collection_serve.py tests/test_collection_uploader.py tests/test_weekly_vote_log.py tests/test_vote_log_cli.py tests/test_bulk_update_descriptions_from_md.py tests/test_example_localizations.py` — 826 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 670 files already formatted
- `nix develop --command bash .github/scripts/any-usage-gate.sh` — passed
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto` — 7247 passed, 1 skipped
