### PR TITLE
fix(thumbnail): 画像生成の監査境界を固定 (#2786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: 画像保存・provider retry・参照履歴・自動選択・比較CLI・stock設定の失敗／境界契約を実回帰テストで固定し、参照画像欠落を stderr へ報告、非有限の自動選択 tolerance、非object stock metadata、不正な stock theme/max-count 設定を安全に拒否する。Codex wrapper と thumbnail skill の内部文字列だけを固定していた重複テストは、同等以上のCLI・成果物・失敗診断テストへ統合した（#2768〜#2786）。
 - `fix(analytics)`: 競合候補の channel ID を YouTube API 上限の 50 件単位で取得し、uploads playlist 欠損または有効な公開日を持つ動画がない候補を結果から除外する境界を公開 API テストで担保した（#2631）。
 - `fix(analytics)`: retention timeline が不正な retention 数値（変換不能・NaN・Infinity）や非有限の動画尺を `ValidationError` として利用者向けに拒否し、壊れたJSON・曖昧なanalysis参照・duration fallback・未照合・Markdown escaping の境界を直接検証した（#2612, #2636）。
 - `fix(live-chat)`: Codex の構造化出力が JSON object でない場合も `GeneratorError` として安全に拒否し、facade・filter・history保存失敗・投稿失敗・chat終了後再探索・CLI enabled/割込み/例外終了の実行時契約を直接検証した（#2648, #2651）。

--- a/src/youtube_automation/commands/media/generate_image.py
+++ b/src/youtube_automation/commands/media/generate_image.py
@@ -483,7 +483,7 @@ def main():
     try:
         reference_images = resolve_reference_paths(args.reference)
     except ConfigError as e:
-        print(f"[ERROR] {e}")
+        print(f"[ERROR] {e}", file=sys.stderr)
         sys.exit(1)
 
     try:

--- a/src/youtube_automation/domains/thumbnail/selection.py
+++ b/src/youtube_automation/domains/thumbnail/selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -60,7 +61,12 @@ def resolve_auto_selection_settings(cfg: dict[str, object]) -> AutoSelectionSett
         return value
 
     tolerance = raw.get("aspect_tolerance", _DEFAULT_ASPECT_TOLERANCE)
-    if isinstance(tolerance, bool) or not isinstance(tolerance, (int, float)) or tolerance < 0:
+    if (
+        isinstance(tolerance, bool)
+        or not isinstance(tolerance, (int, float))
+        or not math.isfinite(tolerance)
+        or tolerance < 0
+    ):
         raise ConfigError(f"auto_selection.aspect_tolerance は 0 以上の数値である必要があります: {tolerance!r}")
     enabled = raw.get("enabled", False)
     if not isinstance(enabled, bool):

--- a/src/youtube_automation/utils/stock.py
+++ b/src/youtube_automation/utils/stock.py
@@ -195,9 +195,10 @@ def load_stock_meta(image_path: Path) -> dict[str, Any] | None:
 
     meta_path = image_path.with_suffix(image_path.suffix + META_SUFFIX)
     try:
-        return json.loads(meta_path.read_text(encoding="utf-8"))
+        payload = json.loads(meta_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return None
+    return payload if isinstance(payload, dict) else None
 
 
 def list_stock(
@@ -284,6 +285,8 @@ def resolve_stock_refs(
         return []
 
     theme_match = stock_refs_config.get("theme_match", "exact")
+    if theme_match not in {"exact", "any"}:
+        raise ValidationError("reference_images.stock.theme_match は 'exact' または 'any' で指定してください")
     if theme_match == "exact" and not theme:
         raise ValidationError("reference_images.stock.theme_match='exact' のとき theme は必須です")
 
@@ -317,7 +320,9 @@ def resolve_stock_refs(
         shuffler = rng if rng is not None else random.Random(stock_refs_config.get("seed"))
         shuffler.shuffle(surviving)
 
-    max_count = int(stock_refs_config.get("max_count", 3))
+    max_count = stock_refs_config.get("max_count", 3)
+    if isinstance(max_count, bool) or not isinstance(max_count, int) or max_count < 0:
+        raise ValidationError("reference_images.stock.max_count は 0 以上の整数で指定してください")
     selected = surviving[:max_count] if max_count > 0 else []
 
     role_label = source_role or "any"

--- a/tests/test_image_provider_composition.py
+++ b/tests/test_image_provider_composition.py
@@ -17,12 +17,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image
 
 from youtube_automation.utils.image_provider.composition import (
+    apply_composition_rules,
     confirm_cost,
     log_image_cost,
+    persist_image,
     resolve_cost_per_image,
 )
 
@@ -251,3 +255,70 @@ class TestLogImageCost:
                 cost_usd=0.101,  # type: ignore[call-arg]
                 reference_count=0,
             )
+
+
+class TestApplyCompositionRules:
+    @pytest.mark.parametrize(
+        ("config", "prompt"),
+        [
+            ({}, "quiet library"),
+            ({"composition_prefix": "Wide shot"}, "quiet library"),
+            ({"composition_keywords": ["close-up"]}, "quiet library"),
+            (
+                {"composition_prefix": "Wide shot", "composition_keywords": ["close-up"]},
+                "A close-up portrait",
+            ),
+            (
+                {"composition_prefix": "Wide shot", "composition_keywords": ["close-up"]},
+                "Edit this image without changing the subject",
+            ),
+        ],
+    )
+    def test_returns_prompt_unchanged_when_prefix_is_not_applicable(self, config, prompt):
+        assert apply_composition_rules(prompt, config) == prompt
+
+    def test_prefixes_prompt_when_no_keyword_matches(self):
+        result = apply_composition_rules(
+            "quiet library",
+            {"composition_prefix": "Wide shot", "composition_keywords": ["close-up"]},
+        )
+        assert result == "Wide shot quiet library"
+
+
+class TestPersistImage:
+    def test_png_writes_lossless_and_jpeg_companion(self, tmp_path: Path):
+        output = tmp_path / "thumbnail.png"
+
+        saved = persist_image(Image.new("RGBA", (8, 8), (1, 2, 3, 128)), output, save_as_png=True)
+
+        assert saved == output
+        assert output.exists()
+        assert output.with_suffix(".jpg").exists()
+        with Image.open(output) as png:
+            assert png.format == "PNG"
+        with Image.open(output.with_suffix(".jpg")) as jpg:
+            assert jpg.format == "JPEG"
+
+    def test_jpeg_mode_removes_stale_non_jpeg_output_only_after_save(self, tmp_path: Path):
+        output = tmp_path / "thumbnail.png"
+        output.write_bytes(b"stale")
+
+        saved = persist_image(Image.new("RGB", (8, 8), "red"), output, save_as_png=False)
+
+        assert saved == output.with_suffix(".jpg")
+        assert saved.exists()
+        assert not output.exists()
+
+    def test_jpeg_conversion_failure_preserves_existing_source(self, tmp_path: Path):
+        output = tmp_path / "thumbnail.png"
+        output.write_bytes(b"stale")
+        image = MagicMock()
+        converted = MagicMock()
+        converted.save.side_effect = OSError("disk full")
+        image.convert.return_value = converted
+
+        with pytest.raises(OSError, match="disk full"):
+            persist_image(image, output, save_as_png=False)
+
+        assert output.read_bytes() == b"stale"
+        assert not output.with_suffix(".jpg").exists()

--- a/tests/test_image_provider_composition_cli.py
+++ b/tests/test_image_provider_composition_cli.py
@@ -13,9 +13,13 @@ CLI が同じ helper を使っていることを保証するため、import 経�
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+from youtube_automation.commands.media import generate_image
+from youtube_automation.domains.media.image import ImageGenerationResult
 from youtube_automation.infrastructure.errors import ConfigError
 from youtube_automation.utils.image_provider.composition import (
     prompt_overwrite_or_rename,
@@ -143,37 +147,84 @@ class TestResolveReferencePaths:
         assert str(missing) in str(ei.value)
 
 
-class TestCliHelperShared:
-    """``generate_image.py`` が helper 経路を import していることの構造的回帰防止。
-
-    verbatim 重複（旧 inline ブロック）の再導入を構造的に防ぐため、
-    script ソースに ``prompt_overwrite_or_rename`` / ``resolve_reference_paths``
-    が import されていることを直接検査する。
-    """
-
-    SCRIPT_NAME = "generate_image.py"
-
-    def _read_script(self) -> str:
-        commands_dir = Path(__file__).resolve().parent.parent / "src" / "youtube_automation" / "commands"
-        path = commands_dir / "media" / self.SCRIPT_NAME
-        return path.read_text(encoding="utf-8")
-
-    def test_script_imports_shared_helpers(self):
-        src = self._read_script()
-        assert "prompt_overwrite_or_rename" in src, (
-            f"{self.SCRIPT_NAME} が prompt_overwrite_or_rename を経由していない（DRY 違反の再発）"
+class TestGenerateImageCliHelperContracts:
+    @pytest.fixture
+    def cli(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        provider = MagicMock()
+        provider.supported_aspect_ratios = ()
+        provider.generate.side_effect = lambda req: ImageGenerationResult(success=True, saved_path=req.output_path)
+        cfg = SimpleNamespace(
+            provider="gemini",
+            gemini=SimpleNamespace(model="test-model"),
+            openai=None,
+            gemini_cli=None,
         )
-        assert "resolve_reference_paths" in src, (
-            f"{self.SCRIPT_NAME} が resolve_reference_paths を経由していない（DRY 違反の再発）"
+        monkeypatch.setattr(generate_image, "load_image_generation_config", lambda: cfg)
+        monkeypatch.setattr(generate_image, "get_provider", lambda _cfg: provider)
+        monkeypatch.setattr(generate_image, "_channel_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "youtube_automation.utils.skill_config.load_skill_config",
+            lambda _name: {"image_generation": {"gemini": {}}},
+        )
+        monkeypatch.setattr(generate_image, "resolve_cost_per_image", lambda *_args: 0.0)
+        monkeypatch.setattr(generate_image, "log_image_cost", lambda *_args, **_kwargs: None, raising=False)
+        return provider
+
+    def test_existing_output_with_yes_uses_versioned_path(self, cli, tmp_path: Path, monkeypatch):
+        output = tmp_path / "out.png"
+        output.write_bytes(b"existing")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["yt-generate-image", "--prompt", "scene", "--output", str(output), "--yes"],
         )
 
-    def test_script_does_not_inline_overwrite_prompt(self):
-        """インラインの 16 行ブロック特徴語が残っていないこと（再発検知）。"""
-        src = self._read_script()
-        # 元の重複ブロック特有の連続フレーズ
-        assert "上書きしますか? (y/N):" not in src, f"{self.SCRIPT_NAME} に旧 inline overwrite prompt が再発している"
+        with pytest.raises(SystemExit, match="0"):
+            generate_image.main()
 
-    def test_script_does_not_inline_reference_loop(self):
-        """インラインの参照画像存在チェック特徴語が残っていないこと（再発検知）。"""
-        src = self._read_script()
-        assert "参照画像が見つかりません" not in src, f"{self.SCRIPT_NAME} に旧 inline 参照画像チェックが再発している"
+        assert cli.generate.call_args.args[0].output_path == tmp_path / "out-v2.png"
+        assert output.read_bytes() == b"existing"
+
+    def test_reference_is_resolved_and_forwarded_to_request(self, cli, tmp_path: Path, monkeypatch):
+        reference = tmp_path / "reference.png"
+        reference.write_bytes(b"reference")
+        output = tmp_path / "out.png"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "yt-generate-image",
+                "--prompt",
+                "scene",
+                "--output",
+                str(output),
+                "--reference",
+                str(reference),
+                "--yes",
+            ],
+        )
+
+        with pytest.raises(SystemExit, match="0"):
+            generate_image.main()
+
+        assert cli.generate.call_args.args[0].references == [reference]
+
+    def test_missing_reference_exits_before_provider_creation(self, cli, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "yt-generate-image",
+                "--prompt",
+                "scene",
+                "--output",
+                str(tmp_path / "out.png"),
+                "--reference",
+                str(tmp_path / "missing.png"),
+                "--yes",
+            ],
+        )
+
+        with pytest.raises(SystemExit, match="1"):
+            generate_image.main()
+
+        captured = capsys.readouterr()
+        assert "参照画像が見つかりません" in captured.err
+        cli.generate.assert_not_called()

--- a/tests/test_image_provider_config.py
+++ b/tests/test_image_provider_config.py
@@ -359,6 +359,54 @@ class TestParseImageGenerationConfig:
         # Then
         assert replaced.gemini_cli.model == "gemini-3.0-flash-image-preview"
 
+    def test_replace_model_overrides_only_gemini_model(self):
+        cfg = ImageGenerationConfig(
+            provider="gemini",
+            gemini=GeminiConfig(model="old"),
+        )
+
+        replaced = replace_model(cfg, "new")
+
+        assert replaced.gemini.model == "new"
+        assert cfg.gemini.model == "old"
+        assert replaced.openai is None
+
+    def test_replace_model_overrides_only_openai_model(self):
+        cfg = ImageGenerationConfig(
+            provider="openai",
+            openai=OpenAIConfig(
+                model="old",
+                quality="medium",
+                aspect_ratio="16:9",
+                thinking="off",
+                batch=1,
+            ),
+        )
+
+        replaced = replace_model(cfg, "new")
+
+        assert replaced.openai.model == "new"
+        assert cfg.openai.model == "old"
+        assert replaced.gemini is None
+
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            ImageGenerationConfig(provider="gemini", gemini=None),
+            ImageGenerationConfig(provider="openai", openai=None),
+            ImageGenerationConfig(provider="gemini_cli", gemini_cli=None),
+        ],
+    )
+    def test_replace_model_rejects_missing_active_subconfig(self, cfg):
+        with pytest.raises(ConfigError, match="設定が見つかりません"):
+            replace_model(cfg, "new")
+
+    def test_replace_model_rejects_codex_api_route(self):
+        cfg = ImageGenerationConfig(provider="codex", codex=CodexConfig())
+
+        with pytest.raises(ConfigError, match="未対応.*codex"):
+            replace_model(cfg, "new")
+
     def test_unknown_provider_raises_config_error(self):
         # Given: 未対応 provider 名
         skill_cfg = {

--- a/tests/test_image_provider_gemini.py
+++ b/tests/test_image_provider_gemini.py
@@ -338,6 +338,56 @@ class TestTransientErrorRetries:
         assert result.success is False
         assert mock_client.models.generate_content.call_count == RETRY_MAX
 
+    def test_persist_failure_then_success_retries_entire_generation(self, gemini_config, request_factory):
+        provider = GeminiImageProvider(gemini_config)
+        req = request_factory()
+        response = _fake_response([_fake_image_part(_png_bytes())])
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value = response
+
+        with (
+            patch(
+                "youtube_automation.utils.image_provider.gemini.create_global_genai_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "youtube_automation.utils.image_provider.gemini.persist_image",
+                side_effect=[OSError("disk busy"), req.output_path],
+            ) as persist,
+        ):
+            result = provider.generate(req)
+
+        assert result.success is True
+        assert result.saved_path == req.output_path
+        assert mock_client.models.generate_content.call_count == 2
+        assert persist.call_count == 2
+
+    def test_persist_failure_on_every_attempt_returns_failure(self, gemini_config, request_factory):
+        from youtube_automation.utils.image_provider import RETRY_MAX
+
+        provider = GeminiImageProvider(gemini_config)
+        req = request_factory()
+        response = _fake_response([_fake_image_part(_png_bytes())])
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value = response
+
+        with (
+            patch(
+                "youtube_automation.utils.image_provider.gemini.create_global_genai_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "youtube_automation.utils.image_provider.gemini.persist_image",
+                side_effect=OSError("disk full"),
+            ) as persist,
+        ):
+            result = provider.generate(req)
+
+        assert result.success is False
+        assert result.saved_path is None
+        assert mock_client.models.generate_content.call_count == RETRY_MAX
+        assert persist.call_count == RETRY_MAX
+
 
 class TestImageWithoutInlineDataRetries:
     def test_text_only_response_triggers_retry(self, gemini_config, request_factory):

--- a/tests/test_image_provider_gemini_cli.py
+++ b/tests/test_image_provider_gemini_cli.py
@@ -215,6 +215,37 @@ class TestRetryAndFailure:
         assert result.success is False
         assert runner.call_count == RETRY_MAX
 
+    def test_oserror_then_success_retries(self, cli_config, request_factory):
+        req = request_factory()
+        attempts = 0
+
+        def _runner(cmd, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OSError("exec format error")
+            req.output_path.write_bytes(_png_bytes())
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        runner = MagicMock(side_effect=_runner)
+        provider = GeminiCliImageProvider(cli_config, runner=runner)
+
+        result = provider.generate(req)
+
+        assert result.success is True
+        assert runner.call_count == 2
+
+    def test_oserror_on_every_attempt_returns_failure(self, cli_config, request_factory):
+        req = request_factory()
+        runner = MagicMock(side_effect=OSError("permission denied"))
+        provider = GeminiCliImageProvider(cli_config, runner=runner)
+
+        result = provider.generate(req)
+
+        assert result.success is False
+        assert result.saved_path is None
+        assert runner.call_count == RETRY_MAX
+
     def test_missing_output_file_retries_then_fails(self, cli_config, request_factory):
         req = request_factory()
         # returncode=0 だが出力ファイルを書かない

--- a/tests/test_image_provider_openai.py
+++ b/tests/test_image_provider_openai.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import io
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -320,6 +321,46 @@ class TestRetryBehavior:
 
         # Then
         assert result.success is False
+        assert mock_client.images.generate.call_count == RETRY_MAX
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            SimpleNamespace(data=[]),
+            SimpleNamespace(data=[SimpleNamespace(b64_json=None)]),
+        ],
+    )
+    def test_missing_image_payload_retries_then_returns_failure(self, response, openai_config, request_factory):
+        from youtube_automation.utils.image_provider import RETRY_MAX
+
+        provider = OpenAIImageProvider(openai_config)
+        req = request_factory()
+        with patch("youtube_automation.utils.image_provider.openai.OpenAI") as mock_class:
+            mock_client = MagicMock()
+            mock_client.images.generate.return_value = response
+            mock_class.return_value = mock_client
+
+            result = provider.generate(req)
+
+        assert result.success is False
+        assert result.saved_path is None
+        assert mock_client.images.generate.call_count == RETRY_MAX
+
+    def test_invalid_base64_retries_then_returns_failure(self, openai_config, request_factory):
+        from youtube_automation.utils.image_provider import RETRY_MAX
+
+        provider = OpenAIImageProvider(openai_config)
+        req = request_factory()
+        response = SimpleNamespace(data=[SimpleNamespace(b64_json="%%%not-base64%%%")])
+        with patch("youtube_automation.utils.image_provider.openai.OpenAI") as mock_class:
+            mock_client = MagicMock()
+            mock_client.images.generate.return_value = response
+            mock_class.return_value = mock_client
+
+            result = provider.generate(req)
+
+        assert result.success is False
+        assert result.saved_path is None
         assert mock_client.images.generate.call_count == RETRY_MAX
 
 

--- a/tests/test_image_provider_single_step_rotation.py
+++ b/tests/test_image_provider_single_step_rotation.py
@@ -14,9 +14,12 @@ from pathlib import Path
 import pytest
 
 from youtube_automation.domains.thumbnail.references import (
+    canonicalize_benchmark_reference,
     format_reference_assignment,
     infer_benchmark_channel,
     normalize_reference_default,
+    plan_ttp_reference_assignments,
+    resolve_configured_benchmark_references,
 )
 from youtube_automation.infrastructure.errors import ConfigError
 from youtube_automation.utils.image_provider.composition import select_reference, validate_single_step_references
@@ -189,3 +192,125 @@ class TestNormalizeReferenceDefault:
 
     def test_empty_list_returns_empty(self) -> None:
         assert normalize_reference_default([]) == []
+
+
+class TestStrictBenchmarkReferenceBoundaries:
+    def test_configured_relative_reference_resolves_canonically(self, tmp_path: Path) -> None:
+        reference = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "channel" / "a.jpg"
+        reference.parent.mkdir(parents=True)
+        reference.write_bytes(b"image")
+
+        result = resolve_configured_benchmark_references(
+            tmp_path,
+            "data/thumbnail_compare/benchmark/channel/a.jpg",
+        )
+
+        assert result.references == [reference.resolve()]
+        assert result.placeholders == []
+        assert result.invalid_reasons == []
+
+    def test_configured_placeholder_and_escaped_paths_are_not_accepted(self, tmp_path: Path) -> None:
+        result = resolve_configured_benchmark_references(
+            tmp_path,
+            ["{{REFERENCE}}", "../outside.jpg", str(tmp_path / "absolute.jpg")],
+        )
+
+        assert result.references == []
+        assert result.placeholders == ["{{REFERENCE}}"]
+        assert any("channel_dir 外" in reason for reason in result.invalid_reasons)
+        assert any("絶対パス" in reason for reason in result.invalid_reasons)
+
+    def test_canonicalization_rejects_missing_and_outside_paths(self, tmp_path: Path) -> None:
+        benchmark = tmp_path / "benchmark"
+        benchmark.mkdir()
+        outside = tmp_path / "outside.jpg"
+        outside.write_bytes(b"outside")
+
+        with pytest.raises(ConfigError, match="見つかりません"):
+            canonicalize_benchmark_reference(benchmark / "missing.jpg", benchmark)
+        with pytest.raises(ConfigError, match="benchmark サムネイルに限定"):
+            canonicalize_benchmark_reference(outside, benchmark)
+
+    def test_recent_history_is_avoided_before_older_and_unused_references(self, tmp_path: Path) -> None:
+        benchmark = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "channel"
+        benchmark.mkdir(parents=True)
+        recent, old, unused = [benchmark / name for name in ("recent.jpg", "old.jpg", "unused.jpg")]
+        for path in (recent, old, unused):
+            path.write_bytes(path.name.encode())
+        older_log = tmp_path / "collections" / "live" / "20260101-old" / "20-documentation" / "thumbnail-prompts.md"
+        recent_log = tmp_path / "collections" / "live" / "20260102-new" / "20-documentation" / "thumbnail-prompts.md"
+        for log, ref in ((older_log, old), (recent_log, recent)):
+            log.parent.mkdir(parents=True)
+            log.write_text(
+                "## Reference Assignments\n"
+                "| attempt | output | reference_image | benchmark_channel |\n"
+                "|---:|---|---|---|\n"
+                f"| 1 | x | `{ref.relative_to(tmp_path)}` | channel |\n",
+                encoding="utf-8",
+            )
+
+        selected = plan_ttp_reference_assignments(
+            [recent, old, unused],
+            2,
+            True,
+            benchmark_root=benchmark.parent,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        )
+
+        assert selected == [unused.resolve(), old.resolve()]
+
+    def test_all_used_references_fall_back_deterministically(self, tmp_path: Path) -> None:
+        benchmark = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "channel"
+        benchmark.mkdir(parents=True)
+        refs = [benchmark / "a.jpg", benchmark / "b.jpg"]
+        for ref in refs:
+            ref.write_bytes(b"image")
+        log = tmp_path / "collections" / "live" / "20260101-one" / "20-documentation" / "thumbnail-prompts.md"
+        log.parent.mkdir(parents=True)
+        log.write_text(
+            "## Reference Assignments\n"
+            "| attempt | output | reference_image | benchmark_channel |\n"
+            "|---:|---|---|---|\n"
+            + "".join(
+                f"| {index} | x | `{ref.relative_to(tmp_path)}` | channel |\n" for index, ref in enumerate(refs, 1)
+            ),
+            encoding="utf-8",
+        )
+
+        selected = plan_ttp_reference_assignments(
+            refs,
+            2,
+            True,
+            benchmark_root=benchmark.parent,
+            channel_dir=tmp_path,
+            dedup_recent_collections=1,
+        )
+
+        assert selected == [ref.resolve() for ref in refs]
+
+    def test_unreadable_history_is_reported_as_config_error(self, tmp_path: Path, monkeypatch) -> None:
+        benchmark = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "channel"
+        benchmark.mkdir(parents=True)
+        ref = benchmark / "a.jpg"
+        ref.write_bytes(b"image")
+        log = tmp_path / "collections" / "live" / "20260101-one" / "20-documentation" / "thumbnail-prompts.md"
+        log.parent.mkdir(parents=True)
+        log.write_text("## Reference Assignments\n", encoding="utf-8")
+        original = Path.read_text
+
+        def fail_history(path: Path, *args, **kwargs):
+            if path == log:
+                raise OSError("denied")
+            return original(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_history)
+        with pytest.raises(ConfigError, match="履歴を読み取れません"):
+            plan_ttp_reference_assignments(
+                [ref],
+                1,
+                True,
+                benchmark_root=benchmark.parent,
+                channel_dir=tmp_path,
+                dedup_recent_collections=1,
+            )

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -110,6 +110,36 @@ class TestArchiveToStock:
         assert "generated_at" in meta
         assert "rejected_at" in meta
 
+    def test_metadata_write_failure_leaves_moved_image_for_recovery(
+        self, channel: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        image = _make_image(tmp_path / "main-v1.jpg")
+        original_write_text = Path.write_text
+
+        def fail_meta(path: Path, *args, **kwargs):
+            if path.name.endswith(META_SUFFIX):
+                raise OSError("disk full")
+            return original_write_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", fail_meta)
+
+        with pytest.raises(OSError, match="disk full"):
+            archive_to_stock(image, {"theme": "Tavern"}, channel_dir=channel)
+
+        moved = list((channel / "assets" / "stock" / "tavern").glob("*.jpg"))
+        assert not image.exists()
+        assert len(moved) == 1
+        assert not moved[0].with_suffix(moved[0].suffix + META_SUFFIX).exists()
+
+    def test_non_object_metadata_is_treated_as_missing(self, channel: Path) -> None:
+        image = _make_image(channel / "assets" / "stock" / "tavern" / "entry.jpg", b"x" * 2048)
+        image.with_suffix(image.suffix + META_SUFFIX).write_text('["not", "an", "object"]')
+
+        entries = list_stock(channel)
+
+        assert len(entries) == 1
+        assert entries[0].meta == {}
+
     def test_filename_includes_date_and_hash(self, channel: Path, tmp_path: Path) -> None:
         image = _make_image(tmp_path / "main-v1.jpg")
         dest = archive_to_stock(
@@ -600,3 +630,61 @@ class TestResolveStockRefs:
         )
         assert tiny_image not in result
         assert len(result) == 1
+
+
+@pytest.mark.parametrize("max_count", [True, -1, 1.5, "2"])
+def test_resolve_stock_refs_rejects_invalid_max_count(channel: Path, tmp_path: Path, max_count) -> None:
+    _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+
+    with pytest.raises(ValidationError, match="max_count"):
+        resolve_stock_refs(
+            channel,
+            stock_refs_config={
+                "enabled": True,
+                "max_count": max_count,
+                "theme_match": "exact",
+            },
+            theme="tavern",
+        )
+
+
+def test_resolve_stock_refs_zero_max_count_returns_empty(channel: Path, tmp_path: Path) -> None:
+    _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+
+    assert (
+        resolve_stock_refs(
+            channel,
+            stock_refs_config={"enabled": True, "max_count": 0, "theme_match": "exact"},
+            theme="tavern",
+        )
+        == []
+    )
+
+
+def test_resolve_stock_refs_rejects_unknown_theme_match(channel: Path) -> None:
+    with pytest.raises(ValidationError, match="theme_match"):
+        resolve_stock_refs(
+            channel,
+            stock_refs_config={"enabled": True, "theme_match": "prefix"},
+            theme="tavern",
+        )
+
+
+def test_resolve_stock_refs_surfaces_stat_failure(channel: Path, tmp_path: Path, monkeypatch) -> None:
+    archived = _seed_stock(channel, tmp_path, [("tavern", "thumbnail_candidate")])
+    target = archived[0]
+    original_stat = Path.stat
+
+    def fail_target(path: Path, *args, **kwargs):
+        if path == target:
+            raise OSError("stat denied")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_target)
+
+    with pytest.raises(OSError, match="stat denied"):
+        resolve_stock_refs(
+            channel,
+            stock_refs_config={"enabled": True, "max_count": 1, "theme_match": "exact"},
+            theme="tavern",
+        )

--- a/tests/test_thumbnail_auto_selection.py
+++ b/tests/test_thumbnail_auto_selection.py
@@ -16,7 +16,14 @@ from PIL import Image
 import youtube_automation.commands.thumbnail.auto_select_thumbnail as auto_select_thumbnail
 from youtube_automation.commands.thumbnail.auto_select_thumbnail import main, validate_audit_record
 from youtube_automation.domains.thumbnail.features import feature_centroid, feature_distance
-from youtube_automation.infrastructure.errors import ValidationError
+from youtube_automation.domains.thumbnail.selection import (
+    AutoSelectionSettings,
+    CandidateScore,
+    resolve_auto_selection_settings,
+    score_candidates,
+    select_best,
+)
+from youtube_automation.infrastructure.errors import ConfigError, ValidationError
 from youtube_automation.utils import skill_config
 
 # テスト用の最小解像度 (フル HD だと純 Python の特徴量抽出が遅いため縮小)
@@ -31,6 +38,60 @@ _REF_COLORS = ((20, 30, 80), (25, 35, 85))
 _NEAR_COLOR = (22, 32, 82)
 _FAR_COLOR = (200, 40, 40)
 _ARCHIVE_ENABLED = {"enabled": True}
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("min_width", True),
+        ("min_width", 0),
+        ("min_width", -1),
+        ("min_height", False),
+        ("min_height", 0),
+        ("aspect_tolerance", True),
+        ("aspect_tolerance", -0.1),
+        ("aspect_tolerance", float("nan")),
+        ("aspect_tolerance", float("inf")),
+    ],
+)
+def test_auto_selection_rejects_invalid_numeric_boundaries(key, value):
+    with pytest.raises(ConfigError, match=key):
+        resolve_auto_selection_settings({"image_generation": {"auto_selection": {"enabled": True, key: value}}})
+
+
+def test_auto_selection_accepts_zero_aspect_tolerance():
+    settings = resolve_auto_selection_settings({"image_generation": {"auto_selection": {"aspect_tolerance": 0}}})
+    assert settings.aspect_tolerance == 0.0
+
+
+def test_score_candidates_breaks_equal_distance_tie_by_path(tmp_path: Path):
+    settings = AutoSelectionSettings(True, "selection_only", 160, 90, 0.01)
+    a = tmp_path / "a.jpg"
+    b = tmp_path / "b.jpg"
+    Image.new("RGB", _SIZE_16_9, _NEAR_COLOR).save(a)
+    Image.new("RGB", _SIZE_16_9, _NEAR_COLOR).save(b)
+    centroid = feature_centroid([auto_select_thumbnail.extract_features_from_path(a)])
+
+    scores = score_candidates([b, a], centroid, settings)
+    selected = select_best(scores, mode=settings.mode)
+
+    assert selected.path == a
+    assert scores[0].distance == scores[1].distance
+
+
+def test_full_mode_reports_every_ineligible_candidate():
+    scores = [
+        CandidateScore(Path("small.jpg"), 100, 90, 1.0, False, ["解像度不足"]),
+        CandidateScore(Path("square.jpg"), 160, 160, 2.0, False, ["16:9 逸脱"]),
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        select_best(scores, mode="full")
+
+    message = str(exc_info.value)
+    assert "small.jpg" in message
+    assert "square.jpg" in message
+    assert "mode: full" in message
 
 
 def _archive(collection: Path, channel_dir: Path):

--- a/tests/test_thumbnail_check_cli.py
+++ b/tests/test_thumbnail_check_cli.py
@@ -25,6 +25,25 @@ def reset_skill_cache():
     skill_config.reset()
 
 
+def test_resolve_check_config_rejects_non_mapping_self_check(monkeypatch):
+    monkeypatch.setattr(thumbnail_check, "load_skill_config", lambda _name: {"self_check": ["invalid"]})
+
+    with pytest.raises(ValidationError, match="self_check は mapping"):
+        thumbnail_check._resolve_check_config(None)
+
+
+def test_resolve_check_config_normalizes_non_mapping_no_logo_guard(monkeypatch):
+    monkeypatch.setattr(
+        thumbnail_check,
+        "load_skill_config",
+        lambda _name: {"self_check": {"no_logo_guard": ["invalid"]}},
+    )
+
+    resolved = thumbnail_check._resolve_check_config(None)
+
+    assert resolved["no_logo_guard"] == {}
+
+
 # ---------------------------------------------------------------------------
 # _parse_json_response
 # ---------------------------------------------------------------------------

--- a/tests/test_thumbnail_codex_image_skill.py
+++ b/tests/test_thumbnail_codex_image_skill.py
@@ -319,55 +319,6 @@ def test_codex_image_script_is_executable() -> None:
     )
 
 
-def test_codex_image_script_has_bash_shebang_and_strict_mode() -> None:
-    """Given codex-image.sh
-    When 先頭付近を読む
-    Then bash shebang と `set -euo pipefail` を含む。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    first_line = text.splitlines()[0]
-    assert first_line == "#!/usr/bin/env bash"
-    assert re.search(r"^set\s+-euo\s+pipefail\s*$", text, flags=re.MULTILINE), (
-        "codex-image.sh に `set -euo pipefail` が無い"
-    )
-
-
-def test_codex_image_script_usage_comment_points_to_canonical_path() -> None:
-    """Given codex-image.sh
-    When Usage コメントを読む
-    Then 実行パスとして `.claude/skills/thumbnail/references/codex-image.sh` を案内する。
-    """
-    head = "\n".join(_read(_CODEX_IMAGE_SH).splitlines()[:12])
-    assert ".claude/skills/thumbnail/references/codex-image.sh" in head, (
-        "Usage コメントが canonical path を案内していない"
-    )
-
-
-def test_codex_image_script_invokes_codex_exec_json_and_parses_agent_message() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then `codex exec --json` 系の新フラグセットと `jq` 経由の `agent_message` 解析がある。
-
-    旧プロトコル (`--enable image_generation` / `awk '/^generated image /` /
-    `base64 -d`) の残骸が無いこともここで確定する。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-
-    # 新プロトコルのフラグ・パイプライン
-    assert "--json" in text, "`codex exec --json` が無い"
-    assert "--sandbox workspace-write" in text, "`--sandbox workspace-write` が無い"
-    assert "--add-dir" in text, "`--add-dir <out_dir>` が無い"
-    assert "--skip-git-repo-check" in text, "`--skip-git-repo-check` が無い"
-    assert re.search(r"\bjq\b", text), "`jq` パイプラインが無い"
-    assert "agent_message" in text, "`agent_message` イベントを対象にした jq フィルタが無い"
-
-    # 旧プロトコル残骸が無いこと
-    assert "--enable image_generation" not in text, "旧 `--enable image_generation` フラグが残っている（要件 #4 違反）"
-    assert "generated image" not in text, "旧プロトコル文字列 `generated image` が残っている（要件 #4 違反）"
-    assert not re.search(r"awk\s+'/\^generated image /", text), "旧 awk 抽出パターンが残っている（要件 #4 違反）"
-    assert not re.search(r"\bbase64\s+-d\b", text), "旧 `base64 -d` 復号が残っている（要件 #4 違反）"
-
-
 def test_codex_image_script_appends_cp_instructions_to_prompt(tmp_path: Path) -> None:
     """Given codex-image.sh
     When 偽 codex で `codex exec` の `--` 後 prompt を観測する
@@ -552,32 +503,6 @@ def test_codex_image_script_require_reference_rejects_multiple_reference_images(
     assert not output_path.exists()
 
 
-def test_codex_image_script_checks_login_output_and_png_validity() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then `codex login status` 前提確認、`$out` の非ゼロサイズ検証、PNG ヘッダ検証が含まれる。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert "codex login status" in text, "未ログイン時の事前確認が無い"
-    assert "Logged in" in text, "`codex login status` の期待出力が本文に無い"
-    assert re.search(r'-s\s+"\$out"', text), '`-s "$out"` による非ゼロサイズ検証が無い'
-    assert "89504e470d0a1a0a" in text, "PNG ヘッダ検証のマジック値が無い"
-
-
-def test_codex_image_script_contains_model_compatibility_preflight_and_diagnostics() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then codex CLI version / default model 診断と互換性プリフライトが含まれる。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert "codex --version" in text, "codex CLI version 取得が無い"
-    assert "Reply with exactly codex-model-compat-ok." in text, "互換性プリフライト prompt が無い"
-    assert "codex default model:" in text, "default model 診断行が無い"
-    assert "npm install -g @openai/codex@latest" in text, "npm のアップグレード手順が無い"
-    assert "brew upgrade codex" in text, "Homebrew のアップグレード手順が無い"
-    assert "bun add -g @openai/codex@latest" in text, "Bun のアップグレード手順が無い"
-
-
 def test_codex_image_script_stops_when_codex_is_not_logged_in(tmp_path: Path) -> None:
     """Given 未ログイン状態の codex CLI
     When codex-image.sh を実行する
@@ -627,21 +552,6 @@ def test_codex_image_script_rejects_not_logged_in_substring_false_positive(tmp_p
         f"`Not Logged in` 時に `codex exec` を呼んではいけない: {invocations!r}"
     )
     assert not output_path.exists(), "`Not Logged in` 時は出力ファイルを作らない"
-
-
-def test_codex_image_script_requires_chatgpt_login_phrase() -> None:
-    """Given codex-image.sh
-    When ログイン判定の条件式を読む
-    Then `Logged in using ChatGPT` の厳密一致を要求している。
-
-    回帰防止 (AI-547-002): `*"Logged in"*` の部分一致だと `Not Logged in` が
-    通過する。実装側でも文字列を `Logged in using ChatGPT` に固定する契約を担保。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert '!= *"Logged in using ChatGPT"*' in text, (
-        "ログイン判定が `Logged in using ChatGPT` の厳密一致になっていない（"
-        '`*"Logged in"*` だと `Not Logged in` を通してしまう）'
-    )
 
 
 def test_codex_image_script_surfaces_codex_login_status_nonzero_exit(tmp_path: Path) -> None:
@@ -899,60 +809,6 @@ def test_codex_image_script_rejects_output_matching_reference(tmp_path: Path) ->
     assert "reference" in result.stderr, f"reference 一致を示す診断文が stderr に出ていない: {result.stderr!r}"
 
 
-def test_codex_image_script_removes_stale_out_before_invoking_codex() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then codex exec 呼び出し前に `rm -f "$out"` で stale artifact を消すコードがある。
-
-    回帰防止 (ARCH-547-002): 既存 PNG が残っていると agent が cp スキップしても
-    `-s "$out"` / PNG ヘッダ検証が通って偽陽性 success になる。実行前削除を契約化する。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    # rm -f "$out" が codex exec 行より前に出現することを確認する
-    rm_match = re.search(r'^\s*rm\s+-f\s+"\$out"\s*$', text, flags=re.MULTILINE)
-    assert rm_match is not None, '`rm -f "$out"` で stale artifact を消す処理が無い'
-
-    codex_exec_match = re.search(r"codex\s+exec\b", text)
-    assert codex_exec_match is not None, "codex exec の呼び出しが見つからない"
-    assert rm_match.start() < codex_exec_match.start(), (
-        '`rm -f "$out"` が codex exec の前に出現していない（stale artifact 削除が後置だと意味がない）'
-    )
-
-
-def test_codex_image_script_validates_final_msg_matches_out() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then `final_msg` と `$out` の一致を検証する条件分岐がある。
-
-    回帰防止 (ARCH-547-002): agent_message の path を取り出しているのに成功判定に
-    使わない配線漏れを禁止する。`final_msg != $out` を非 0 終了で扱う経路を担保する。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert re.search(r'\[\s*"\$final_msg"\s+!=\s+"\$out"\s*\]', text), (
-        '`final_msg == "$out"` の契約検証が無い（agent_message の path と出力先の境界が緩く ARCH-547-002 が再発する）'
-    )
-
-
-def test_codex_image_script_reports_saved_message() -> None:
-    """Given codex-image.sh
-    When 成功時メッセージの形式を確認する
-    Then `saved: <path> (<size> bytes)` を出力する。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert re.search(r"saved:\s+\$out\s+\(\$\([^)]*\)\s*bytes\)", text, flags=re.DOTALL), (
-        "成功時の `saved: <path> (<size> bytes)` 出力が見つからない"
-    )
-
-
-def test_codex_image_script_uses_cross_platform_stat_fallback() -> None:
-    """Given codex-image.sh
-    When ファイルサイズ取得処理を確認する
-    Then `stat -f%z ... || stat -c%s ...` のフォールバックを持つ。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-    assert re.search(r"stat\s+-f%z[^|]*\|\|\s*stat\s+-c%s", text), "macOS/Linux 両対応の stat フォールバックが無い"
-
-
 def test_codex_image_script_passes_bash_syntax_check() -> None:
     """Given codex-image.sh
     When `bash -n` で構文チェックする
@@ -969,85 +825,6 @@ def test_codex_image_script_passes_bash_syntax_check() -> None:
     assert result.returncode == 0, (
         f"{_CODEX_IMAGE_SH.relative_to(_REPO_ROOT)} の bash 構文チェックに失敗:\n{result.stderr}"
     )
-
-
-def test_codex_image_script_centralizes_stderr_tail_dump_in_helper() -> None:
-    """Given codex-image.sh
-    When 本文を読む
-    Then `dump_codex_stderr` ヘルパが 1 度だけ定義され、5 つの error 分岐から呼ばれている。
-
-    回帰防止 (AI-547-006-N2 / family_tag: dry-violation-error-diagnostics):
-    `--- codex stderr (tail) ---` を echo して `tail -n 30 "$err_log"` する 4 行ブロックが
-    error 分岐に直接コピペで散在していた DRY 違反を、共通ヘルパに集約した状態を維持する。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-
-    # ヘルパ定義は 1 つだけ
-    assert len(re.findall(r"^dump_codex_stderr\(\)\s*\{", text, flags=re.MULTILINE)) == 1, (
-        "`dump_codex_stderr` ヘルパが 1 度だけ定義されている必要がある"
-    )
-    # 呼び出しは error 5 分岐ぶん（行頭でない位置にあるかも知れないので空白許可）
-    call_sites = re.findall(r"^\s*dump_codex_stderr\s*$", text, flags=re.MULTILINE)
-    assert len(call_sites) == 5, (
-        f"`dump_codex_stderr` 呼び出しが 5 箇所揃っていない (現在 {len(call_sites)} 件): "
-        "互換性プリフライト非互換 / 互換性プリフライト汎用失敗 / codex exec 失敗 / "
-        "final_msg 不一致 / 画像未生成 の 5 つの error 分岐から呼ばれること"
-    )
-    # コピペブロックが再び発生していないことを確認
-    duplicated_pattern = re.findall(r'echo "--- codex stderr \(tail\) ---" >&2', text)
-    assert len(duplicated_pattern) == 1, (
-        f'`echo "--- codex stderr (tail) ---"` がヘルパ以外で再びコピペされている (現在 {len(duplicated_pattern)} 件)'
-    )
-
-
-def test_codex_image_script_drops_unreachable_defense_around_final_msg_after_contract() -> None:
-    """Given codex-image.sh の `[ ! -s "$out" ]` 分岐
-    When 本文を読む
-    Then `if [ -n "$final_msg" ]; then echo "agent_message (最終)` の論理到達不能な防御 if が無く、
-        `final_msg` を直接 echo している。
-
-    回帰防止 (AI-547-006-N1 / family_tag: logically-unreachable-defense):
-    `[ ! -s "$out" ]` 分岐に到達した時点で直前の `[ "$final_msg" != "$out" ]` 契約検証を通過済みであり、
-    `out` は `out=${2:?...}` で空文字でない契約。したがって `final_msg == "$out"` も非空が保証され、
-    `[ -n "$final_msg" ]` チェックは常に真。「念のため」の防御 if を AI 由来で再追加させない。
-    """
-    text = _read(_CODEX_IMAGE_SH)
-
-    # `[ ! -s "$out" ]` 分岐の本文を抽出
-    match = re.search(
-        r'if \[ ! -s "\$out" \]; then(?P<body>.*?)\n  exit 1\nfi',
-        text,
-        flags=re.DOTALL,
-    )
-    assert match is not None, '`[ ! -s "$out" ]` 分岐が見つからない'
-    body = match.group("body")
-    assert re.search(r'if \[ -n "\$final_msg" \]; then', body) is None, (
-        '`[ ! -s "$out" ]` 分岐内の `if [ -n "$final_msg" ]` 防御 if は論理到達不能なので削除されている必要がある '
-        "(AI 由来の防御コピペ再発: AI-547-006-N1)"
-    )
-    assert 'echo "agent_message (最終): $final_msg" >&2' in body, (
-        "`final_msg` の echo（防御 if 削除後）は維持されている必要がある"
-    )
-
-
-def test_thumbnail_skill_lists_codex_in_provider_switch_table() -> None:
-    """Given thumbnail/SKILL.md の provider 表
-    When `## プロバイダー切り替え` セクションだけを読む
-    Then `codex` は正規 provider 行として追加されている。
-    """
-    section = _provider_section(_read(_THUMBNAIL_SKILL_MD))
-    assert "| `codex` |" in section, "`codex` が provider 表に正規 provider として載っていない"
-    assert "ChatGPT" in section
-    assert "GCP" in section
-
-
-def test_thumbnail_skill_has_codex_generation_section() -> None:
-    """Given thumbnail/SKILL.md
-    When 該当セクションを抽出する
-    Then codex 経路のセクションが存在する。
-    """
-    section = _codex_section(_read(_THUMBNAIL_SKILL_MD))
-    assert "codex 経由" in section
 
 
 def test_thumbnail_skill_codex_section_documents_login_and_direct_command() -> None:
@@ -1068,60 +845,6 @@ def test_thumbnail_skill_provider_fallback_codex_example_starts_with_thumbnail()
     assert "<thumbnail prompt>" in section
     assert "<collection-path>/10-assets/thumbnail-codex-v1.png" in section
     assert "<textless background prompt>" not in section
-
-
-def test_thumbnail_skill_codex_section_follows_thumbnail_then_textless_main_contract() -> None:
-    """#1611: codex 経路も文字入り thumbnail 先行で textless main を別成果物にする。"""
-    section = _codex_section(_read(_THUMBNAIL_SKILL_MD))
-
-    for required in (
-        "codex 経路でも標準ファイル契約は同じ",
-        "10-assets/thumbnail-codex-v1.png",
-        "10-assets/thumbnail.jpg",
-        "確定した `thumbnail.jpg`",
-        "10-assets/main-v1.png",
-        "10-assets/main.png",
-        "動画背景には使わない",
-    ):
-        assert required in section
-
-
-def test_thumbnail_skill_codex_section_documents_api_route_boundary() -> None:
-    """Given codex 経路セクション
-    When 本文を読む
-    Then 正規 provider だが uv run yt-generate-image / ImageProvider の API 経路ではないことを説明する。
-    """
-    section = _codex_section(_read(_THUMBNAIL_SKILL_MD))
-    assert "正規" in section
-    assert "uv run yt-generate-image" in section
-    assert "ImageProvider" in section
-    assert "codex-image.sh" in section
-
-
-def test_thumbnail_skill_codex_section_documents_cost_and_retry_policy() -> None:
-    """Given codex 経路セクション
-    When 本文を読む
-    Then GCP 課金・cost_tracker・fair-use と自動リトライなしの扱いが明文化されている。
-    """
-    section = _codex_section(_read(_THUMBNAIL_SKILL_MD))
-    assert "GCP" in section
-    assert "cost_tracker" in section
-    assert "fair-use" in section
-    assert "リトライ" in section
-    assert "自動" in section
-
-
-def test_thumbnail_skill_codex_section_documents_prompt_length_caveat() -> None:
-    """Given codex 経路セクション
-    When 本文を読む
-    Then 「prompt は短く保つ（長いと agent が image_generation tool を skip する
-        failure mode あり）」「画像は agent が cp してくるので wrapper 側 path
-        指定がそのまま使える」が明文化されている。
-    """
-    section = _codex_section(_read(_THUMBNAIL_SKILL_MD))
-    assert "短く" in section, "prompt を短く保つ運用ルールが明文化されていない（要件 #5）"
-    assert "skip" in section, "長い prompt で agent が tool を skip する failure mode の言及が無い（要件 #5）"
-    assert "cp" in section, "agent が cp する設計の言及が無い（要件 #5）"
 
 
 def test_codex_image_script_blocks_forbidden_keyword_before_codex_exec(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_compare_cli.py
+++ b/tests/test_thumbnail_compare_cli.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from youtube_automation.commands.thumbnail import compare_thumbnails as mod
+
+
+def _comparer(tmp_path: Path) -> mod.ThumbnailComparer:
+    comparer = object.__new__(mod.ThumbnailComparer)
+    comparer.config = SimpleNamespace(meta=SimpleNamespace(channel_short="mine"))
+    comparer.channel_dir = tmp_path
+    comparer.data_dir = tmp_path / "data"
+    comparer.min_views = 100
+    comparer.competitor_slug = None
+    comparer.channel_slug = "mine"
+    comparer.compare_dir = comparer.data_dir / "thumbnail_compare"
+    comparer.benchmark_dir = comparer.compare_dir / "benchmark"
+    comparer.channel_thumb_dir = comparer.compare_dir / "mine"
+    comparer.small_dir = comparer.compare_dir / "small"
+    return comparer
+
+
+def test_download_thumbnail_writes_requested_destination(tmp_path: Path, monkeypatch):
+    comparer = _comparer(tmp_path)
+    destination = tmp_path / "download.jpg"
+    calls = []
+
+    def retrieve(url, output):
+        calls.append((url, output))
+        Path(output).write_bytes(b"image")
+
+    monkeypatch.setattr(mod.urllib.request, "urlretrieve", retrieve)
+
+    assert comparer._download_thumbnail("https://example.test/thumb.jpg", destination) is True
+    assert destination.read_bytes() == b"image"
+    assert calls == [("https://example.test/thumb.jpg", str(destination))]
+
+
+def test_download_failure_returns_false_and_leaves_no_artifact(tmp_path: Path, monkeypatch):
+    comparer = _comparer(tmp_path)
+    destination = tmp_path / "download.jpg"
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlretrieve",
+        lambda *_args: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+    assert comparer._download_thumbnail("https://example.test/thumb.jpg", destination) is False
+    assert not destination.exists()
+
+
+def test_resize_invokes_ffmpeg_with_fixed_mobile_dimensions(tmp_path: Path, monkeypatch):
+    comparer = _comparer(tmp_path)
+    source = tmp_path / "source.jpg"
+    output = tmp_path / "small.jpg"
+    source.write_bytes(b"source")
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda command, **kwargs: calls.append((command, kwargs)))
+
+    assert comparer._resize_thumbnail(source, output) is True
+    command, kwargs = calls[0]
+    assert f"scale={mod.SMALL_WIDTH}:{mod.SMALL_HEIGHT}" in command
+    assert command[-1] == str(output.resolve())
+    assert kwargs["check"] is True
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError("ffmpeg"), mod.subprocess.CalledProcessError(1, ["ffmpeg"])])
+def test_resize_failures_return_false(tmp_path: Path, monkeypatch, error):
+    comparer = _comparer(tmp_path)
+    monkeypatch.setattr(mod.subprocess, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(error))
+
+    assert comparer._resize_thumbnail(tmp_path / "source.jpg", tmp_path / "small.jpg") is False
+
+
+def test_collect_continues_after_download_and_resize_failures_and_opens_small_dir(tmp_path: Path, monkeypatch, capsys):
+    comparer = _comparer(tmp_path)
+    thumb = tmp_path / "collections" / "live" / "20260101-x-rain-collection" / "10-assets" / "thumbnail.jpg"
+    thumb.parent.mkdir(parents=True)
+    thumb.write_bytes(b"mine")
+    monkeypatch.setattr(mod, "ensure_benchmark_fresh", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        mod,
+        "load_benchmark_videos",
+        lambda *_args, **_kwargs: [
+            {
+                "views": 10_000,
+                "channel_slug": "other",
+                "video_id": "bad",
+                "thumbnail_url": "https://bad",
+                "title": "bad",
+            },
+            {
+                "views": 20_000,
+                "channel_slug": "other",
+                "video_id": "good",
+                "thumbnail_url": "https://good",
+                "title": "good",
+            },
+        ],
+    )
+    comparer._collect_channel_thumbnails = lambda: [thumb]
+    comparer._download_thumbnail = lambda url, output: url.endswith("good")
+    comparer._resize_thumbnail = lambda source, output: "mine_" in source.name
+    opened = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda command, **_kwargs: opened.append(command))
+
+    comparer.collect_and_compare(small_only=True)
+
+    assert len(opened) == 1
+    assert opened[0] == ["open", str(comparer.small_dir.resolve())]
+    assert "ベンチマーク 1枚" in capsys.readouterr().out
+    assert (comparer.channel_thumb_dir / "mine_rain.jpg").exists()
+
+
+def test_collect_no_open_never_launches_platform_opener(tmp_path: Path, monkeypatch):
+    comparer = _comparer(tmp_path)
+    monkeypatch.setattr(mod, "ensure_benchmark_fresh", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "load_benchmark_videos", lambda *_args, **_kwargs: [])
+    comparer._collect_channel_thumbnails = lambda: []
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda command, **_kwargs: calls.append(command))
+
+    comparer.collect_and_compare(no_open=True)
+
+    assert calls == []

--- a/tests/test_thumbnail_correlate_cli.py
+++ b/tests/test_thumbnail_correlate_cli.py
@@ -48,3 +48,55 @@ def test_ctr_present_does_not_fall_back(monkeypatch, capsys, _patched_env):
     result = _run_main(monkeypatch, capsys, [])
     assert result["metric"] == "ctr"
     assert result["metric_fallback"] is None
+
+
+def test_engagement_metric_uses_rate_and_rejects_zero_views():
+    assert (
+        mod._resolve_metric(
+            {"views": 20, "likes": 2, "comments": 1, "shares": 1},
+            {},
+            "video",
+            "engagement",
+        )
+        == 20.0
+    )
+    assert mod._resolve_metric({"views": 0, "likes": 2}, {}, "video", "engagement") is None
+
+
+def test_unknown_metric_is_rejected_by_cli(monkeypatch, capsys, _patched_env):
+    monkeypatch.setattr("sys.argv", ["yt-thumbnail-correlate", "--metric", "unknown"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main()
+
+    assert exc_info.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_missing_metric_skips_thumbnail_fetch(monkeypatch):
+    analytics = {"video_analytics": {"v1": {"title": "missing all metrics"}}}
+    fetch_calls = []
+    monkeypatch.setattr(mod, "_fetch_thumbnail", lambda *args: fetch_calls.append(args))
+
+    videos = mod._collect_video_features(analytics, mod.Path("/tmp/cache"), "views")
+
+    assert videos == []
+    assert fetch_calls == []
+
+
+def test_all_thumbnail_fetch_failures_produce_empty_json_result(monkeypatch, capsys, tmp_path):
+    analytics = {
+        "video_analytics": {
+            "v1": {"title": "one", "views": 10},
+            "v2": {"title": "two", "views": 20},
+        }
+    }
+    monkeypatch.setattr(mod, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(mod, "_load_analytics", lambda _channel: analytics)
+    monkeypatch.setattr(mod, "_fetch_thumbnail", lambda *_args: (_ for _ in ()).throw(RuntimeError("offline")))
+
+    result = _run_main(monkeypatch, capsys, ["--metric", "views"])
+
+    assert result["metric"] == "views"
+    assert result["video_count"] == 0
+    assert result["videos"] == []

--- a/tests/test_thumbnail_correlation.py
+++ b/tests/test_thumbnail_correlation.py
@@ -5,6 +5,7 @@ from youtube_automation.domains.thumbnail.correlation import (
     MIN_SAMPLES_DEFAULT,
     _benjamini_hochberg,
     _pearson_p_value,
+    _regularized_incomplete_beta,
     compute_correlations,
 )
 
@@ -85,6 +86,15 @@ def test_pearson_p_value_matches_scipy_reference():
     assert _pearson_p_value(0.5, 12) == pytest.approx(0.09765, abs=0.001)
     assert _pearson_p_value(1.0, 10) == 0.0
     assert _pearson_p_value(0.0, 10) == pytest.approx(1.0, abs=0.001)
+
+
+def test_pearson_p_value_returns_one_for_fewer_than_three_samples():
+    assert _pearson_p_value(0.9, 2) == 1.0
+
+
+@pytest.mark.parametrize(("x", "expected"), [(-0.1, 0.0), (0.0, 0.0), (1.0, 1.0), (1.1, 1.0)])
+def test_regularized_incomplete_beta_clamps_x_endpoints(x, expected):
+    assert _regularized_incomplete_beta(2.0, 3.0, x) == expected
 
 
 def test_benjamini_hochberg_adjustment():

--- a/tests/test_thumbnail_features.py
+++ b/tests/test_thumbnail_features.py
@@ -1,6 +1,12 @@
+import pytest
 from PIL import Image
 
-from youtube_automation.domains.thumbnail.features import extract_features
+from youtube_automation.domains.thumbnail.features import (
+    extract_features,
+    extract_features_from_path,
+    feature_centroid,
+    feature_distance,
+)
 
 
 def _solid_image(color, size=(100, 100)):
@@ -47,3 +53,31 @@ def test_extract_features_contains_all_keys():
     f = extract_features(img)
     expected = {"brightness", "contrast", "saturation", "dominant_hue", "colorfulness"}
     assert expected.issubset(f.keys())
+
+
+def test_feature_centroid_rejects_empty_input():
+    with pytest.raises(ValueError, match="特徴量リストが空"):
+        feature_centroid([])
+
+
+def test_feature_distance_rejects_missing_feature_key():
+    complete = {
+        "brightness": 1.0,
+        "contrast": 1.0,
+        "saturation": 1.0,
+        "dominant_hue": 1.0,
+        "colorfulness": 1.0,
+    }
+    incomplete = dict(complete)
+    incomplete.pop("contrast")
+
+    with pytest.raises(KeyError, match="contrast"):
+        feature_distance(incomplete, complete)
+
+
+def test_extract_features_from_path_rejects_corrupt_image(tmp_path):
+    corrupt = tmp_path / "corrupt.jpg"
+    corrupt.write_bytes(b"not an image")
+
+    with pytest.raises(OSError):
+        extract_features_from_path(corrupt)

--- a/tests/test_thumbnail_skill_assets.py
+++ b/tests/test_thumbnail_skill_assets.py
@@ -1343,15 +1343,6 @@ def test_channel_new_thumbnail_template_includes_channel_branding_contract() -> 
     }
 
 
-def test_thumbnail_skill_includes_codex_prompt_helper_script() -> None:
-    """#1300: collection-ideate から共有する Codex prompt helper を同梱する。"""
-    script = _read_codex_prompt_script()
-
-    assert "from youtube_automation.utils.image_provider.config import build_codex_prompt" in script
-    assert 'load_skill_config("thumbnail")' in script
-    assert 'parser.add_argument("title"' in script
-
-
 def test_codex_prompt_helper_cli_renders_default_template(tmp_path: Path) -> None:
     """#1300: provider=codex の最小 override で default template を title 差し替えして出力する。"""
     result = _run_codex_prompt_cli(


### PR DESCRIPTION
## 変更概要

- 画像保存、composition rule、Gemini / Gemini CLI / OpenAI retry、benchmark参照履歴、自動選択、thumbnail check / correlate / compare、stock の失敗・境界経路を実行する回帰テストを追加
- 非有限の `aspect_tolerance`、非object stock metadata、不正な stock `theme_match` / `max_count` を安全に扱い、`yt-generate-image` の参照欠落を stderr に統一
- Codex wrapper / thumbnail skill / prompt helper の内部文字列だけを固定していた重複テストを、CLI・終了コード・診断・成果物を観測する既存／新規テストへ統合

## Leaf findings

Closes #2786
Closes #2768
Closes #2769
Closes #2770
Closes #2771
Closes #2772
Closes #2773
Closes #2774
Closes #2775
Closes #2776
Closes #2777
Closes #2778
Closes #2779
Closes #2780
Closes #2781
Closes #2782
Closes #2783
Closes #2784
Closes #2785

## 検証

- `nix develop --command uv run pytest -q <監査対象16ファイル>` — 407 passed
- `nix develop --command uv run pytest -q tests/test_image_provider_composition_cli.py tests/test_image_provider_composition.py tests/test_image_provider_single_step_rotation.py tests/test_thumbnail_codex_image_skill.py tests/test_thumbnail_skill_assets.py` — 151 passed
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract` — 446 passed
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto` — 7253 passed, 1 skipped
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 671 files already formatted
- `nix develop --command bash .github/scripts/any-usage-gate.sh` — passed
- `nix develop --command uv run yt-skills lint` — 57 skill passed
- extension workspace — 対象差分なし（Python production / tests / CHANGELOG のみ）
