### PR TITLE
fix(suno-helper): scope 15 の監査 findings を解消する

### DIFF
--- a/extensions/suno-helper/entrypoints/overlay.content.ts
+++ b/extensions/suno-helper/entrypoints/overlay.content.ts
@@ -29,6 +29,11 @@ export default defineContentScript({
         root?.unmount();
       },
     });
-    ui.mount();
+    try {
+      ui.mount();
+    } catch (error) {
+      ui.remove();
+      throw error;
+    }
   },
 });

--- a/extensions/suno-helper/tests/download-flow.test.ts
+++ b/extensions/suno-helper/tests/download-flow.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDownloadFlow } from "../lib/download-flow";
+
+// REQ-2915-01: every watcher-side failure cancels once and clears its resolver.
+const messagingMocks = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  sendMessage: vi.fn(),
+}));
+
+const downloadMocks = vi.hoisted(() => ({
+  triggerDownloadAll: vi.fn(async () => undefined),
+}));
+
+vi.mock("../lib/messaging", () => ({
+  onMessage: vi.fn((type: string, handler: (...args: unknown[]) => unknown) => {
+    messagingMocks.handlers.set(type, handler);
+    return () => undefined;
+  }),
+  sendMessage: messagingMocks.sendMessage,
+}));
+
+vi.mock("../lib/download", () => ({
+  triggerDownloadAll: downloadMocks.triggerDownloadAll,
+}));
+
+const CONTEXT = {
+  baseUrl: "http://localhost:7873",
+  format: "mp3" as const,
+};
+
+function dispatchDownloadComplete(filename = "collection.zip"): void {
+  messagingMocks.handlers.get("downloadComplete")?.({
+    data: { filename },
+  });
+}
+
+function createSubject(isAborted: () => boolean) {
+  const flow = createDownloadFlow({
+    emitProgress: vi.fn(),
+    isAborted,
+  });
+  flow.installMessageHandlers();
+  return flow;
+}
+
+function expectOnlyStartAndCancelMessages(): void {
+  expect(
+    messagingMocks.sendMessage.mock.calls.filter(
+      ([message]) => message === "cancelDownload"
+    )
+  ).toHaveLength(1);
+  expect(
+    messagingMocks.sendMessage.mock.calls.some(
+      ([message]) => message === "postDownloaded"
+    )
+  ).toBe(false);
+}
+
+describe("download flow cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    messagingMocks.handlers.clear();
+    messagingMocks.sendMessage.mockImplementation(async (message: string) => {
+      if (message === "startDownload") {
+        return { ok: true };
+      }
+      return { ok: true };
+    });
+    downloadMocks.triggerDownloadAll.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("DOM 操作が throw すると watcher を一回 cancel し resolver を破棄する", async () => {
+    downloadMocks.triggerDownloadAll.mockRejectedValueOnce(
+      new Error("download button missing")
+    );
+    const flow = createSubject(() => false);
+
+    await expect(
+      flow.performDownload(CONTEXT, "collection", 2, 2)
+    ).rejects.toThrow("download button missing");
+
+    expectOnlyStartAndCancelMessages();
+    dispatchDownloadComplete();
+    await Promise.resolve();
+    expectOnlyStartAndCancelMessages();
+  });
+
+  it("timeout すると watcher を一回 cancel し late completion を無視する", async () => {
+    const flow = createSubject(() => false);
+    const result = flow.performDownload(CONTEXT, "collection", 2, 2);
+    const rejection = expect(result).rejects.toThrow(
+      "Download all がタイムアウトしました"
+    );
+
+    await vi.advanceTimersByTimeAsync(660_000);
+    await rejection;
+
+    expectOnlyStartAndCancelMessages();
+    dispatchDownloadComplete();
+    await Promise.resolve();
+    expectOnlyStartAndCancelMessages();
+  });
+
+  it("abort すると watcher を一回 cancel し post も resolver も残さない", async () => {
+    let aborted = false;
+    downloadMocks.triggerDownloadAll.mockImplementationOnce(async () => {
+      aborted = true;
+    });
+    const flow = createSubject(() => aborted);
+    const result = flow.performDownload(CONTEXT, "collection", 2, 2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await result;
+
+    expectOnlyStartAndCancelMessages();
+    dispatchDownloadComplete();
+    await Promise.resolve();
+    expectOnlyStartAndCancelMessages();
+  });
+});

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -91,6 +91,27 @@ describe("Overlay shell", () => {
   let container: HTMLDivElement;
   let root: Root;
 
+  async function rerenderOverlay(): Promise<void> {
+    await act(async () => root.unmount());
+    container.innerHTML = "";
+    root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(Overlay));
+    });
+  }
+
+  async function expectReloadRequired(): Promise<void> {
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="card"]')).toBeNull();
+      expect(
+        container.querySelector('[data-suno-control="reload-required"]')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-suno-control="reload-tab"]')?.textContent
+      ).toContain("タブを再読み込み");
+    });
+  }
+
   beforeEach(async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     vi.stubGlobal("browser", {
@@ -489,5 +510,51 @@ describe("Overlay shell", () => {
         'button[data-suno-control="stop"]'
       )?.disabled
     ).toBe(false);
+  });
+
+  // REQ-2918-01: initialization/persistence failures replace the shell with reload UI.
+  it("version handshake mismatch では shell を隠して再読み込みを案内する", async () => {
+    messagingMocks.sendMessage.mockResolvedValueOnce({
+      version: "0.2.4",
+      matches: false,
+    });
+
+    await rerenderOverlay();
+
+    await expectReloadRequired();
+  });
+
+  it("version handshake reject では shell を隠して再読み込みを案内する", async () => {
+    messagingMocks.sendMessage.mockRejectedValueOnce(
+      new Error("Extension context invalidated.")
+    );
+
+    await rerenderOverlay();
+
+    await expectReloadRequired();
+  });
+
+  it("overlay state read reject では shell を隠して再読み込みを案内する", async () => {
+    overlayStateMocks.readOverlayState.mockRejectedValueOnce(
+      new Error("storage unavailable")
+    );
+
+    await rerenderOverlay();
+
+    await expectReloadRequired();
+  });
+
+  it("overlay state write reject では shell を隠して再読み込みを案内する", async () => {
+    overlayStateMocks.writeOverlayState.mockRejectedValueOnce(
+      new Error("storage unavailable")
+    );
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="最小化"]')!
+        .click()
+    );
+
+    await expectReloadRequired();
   });
 });

--- a/extensions/suno-helper/tests/overlay-entrypoint.test.tsx
+++ b/extensions/suno-helper/tests/overlay-entrypoint.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const reactRootMocks = vi.hoisted(() => ({
+  createRoot: vi.fn(),
+  render: vi.fn(),
+  unmount: vi.fn(),
+}));
+
+vi.mock("react-dom/client", () => ({
+  createRoot: reactRootMocks.createRoot,
+}));
+
+vi.mock("../components/Overlay", () => ({
+  Overlay: () => null,
+}));
+
+interface ShadowUiOptions {
+  onMount: (container: HTMLElement) => { unmount: () => void };
+  onRemove: (root: { unmount: () => void } | undefined) => void;
+}
+
+// REQ-2920-01: overlay lifecycle unmounts and cleans up failed mounts.
+describe("overlay content entrypoint", () => {
+  let options: ShadowUiOptions;
+  const mount = vi.fn();
+  const remove = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    reactRootMocks.createRoot.mockReturnValue({
+      render: reactRootMocks.render,
+      unmount: reactRootMocks.unmount,
+    });
+    mount.mockImplementation(() => undefined);
+    remove.mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "defineContentScript",
+      (definition: { main: (context: unknown) => Promise<void> }) => definition
+    );
+    vi.stubGlobal(
+      "createShadowRootUi",
+      vi.fn(async (_context: unknown, receivedOptions: ShadowUiOptions) => {
+        options = receivedOptions;
+        return { mount, remove };
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("onRemove は mount 済み React root を一回 unmount する", async () => {
+    const entrypoint = (await import("../entrypoints/overlay.content")).default;
+
+    await entrypoint.main({} as never);
+    const root = options.onMount(document.createElement("div"));
+    options.onRemove(root);
+
+    expect(mount).toHaveBeenCalledOnce();
+    expect(reactRootMocks.render).toHaveBeenCalledOnce();
+    expect(reactRootMocks.unmount).toHaveBeenCalledOnce();
+  });
+
+  it("mount 失敗時は UI を cleanup して元の失敗を reject する", async () => {
+    const error = new Error("shadow mount failed");
+    mount.mockImplementationOnce(() => {
+      throw error;
+    });
+    const entrypoint = (await import("../entrypoints/overlay.content")).default;
+
+    await expect(entrypoint.main({} as never)).rejects.toBe(error);
+
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/suno-helper/tests/oxlint-react-hooks-contract.test.ts
+++ b/extensions/suno-helper/tests/oxlint-react-hooks-contract.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, test } from "vitest";
 
 // ".bin" を含む specifier 風文字列は fallow が依存 import と誤認するため join で組み立てる。
 const oxlint = join(
-  fileURLToPath(new URL("../node_modules", import.meta.url)),
+  fileURLToPath(new URL("../../node_modules", import.meta.url)),
   ".bin",
   "oxlint"
 );
@@ -43,11 +43,13 @@ afterEach(() => {
   }
 });
 
+// REQ-2922-01: the shared config resolves from its own workspace and preserves severities.
 describe("React Hooks lint contract", () => {
   test("conditional Hook calls fail with rules-of-hooks", () => {
     const result = lintFixture("conditional-hook");
 
     expect(result.status).not.toBe(0);
+    expect(result.output).not.toContain("Cannot find package");
     expect(result.output).toContain("react-hooks(rules-of-hooks)");
     expect(result.output).toMatch(/\berror\b/);
   });
@@ -56,6 +58,7 @@ describe("React Hooks lint contract", () => {
     const result = lintFixture("missing-effect-dependency");
 
     expect(result.status).toBe(0);
+    expect(result.output).not.toContain("Cannot find package");
     expect(result.output).toContain("react-hooks(exhaustive-deps)");
     expect(result.output).toMatch(/\bwarning\b/);
   });
@@ -64,6 +67,7 @@ describe("React Hooks lint contract", () => {
     const result = lintFixture("ref-read-during-render");
 
     expect(result.status).toBe(0);
+    expect(result.output).not.toContain("Cannot find package");
     expect(result.output).not.toContain("react(react-compiler)");
   });
 });

--- a/extensions/suno-helper/tests/page-reload.test.ts
+++ b/extensions/suno-helper/tests/page-reload.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  cancelScheduledRunCompleteReload,
+  scheduleRunCompleteReload,
+} from "../lib/page-reload";
+
+// REQ-2916-01: reload scheduling is delayed, replaceable, and cancellable.
+describe("run complete reload scheduler", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("location", { reload });
+    cancelScheduledRunCompleteReload();
+  });
+
+  afterEach(() => {
+    cancelScheduledRunCompleteReload();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("1 秒未満では発火せず、1 秒後に一回だけ reload する", () => {
+    scheduleRunCompleteReload();
+
+    vi.advanceTimersByTime(999);
+    expect(reload).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(reload).toHaveBeenCalledOnce();
+    vi.runAllTimers();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("二重予約では旧 timer を取り消して最後の予約だけを発火する", () => {
+    scheduleRunCompleteReload();
+    vi.advanceTimersByTime(500);
+    scheduleRunCompleteReload();
+
+    vi.advanceTimersByTime(500);
+    expect(reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("cancel 後は予約時刻を過ぎても発火しない", () => {
+    scheduleRunCompleteReload();
+    cancelScheduledRunCompleteReload();
+
+    vi.runAllTimers();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -2904,6 +2904,7 @@ describe("Suno popup compatibility check", () => {
     );
   });
 
+  // REQ-2921-01: the reload-required action reloads the tab exactly once.
   it("DL 形式の読込が失敗すると未捕捉にせず再読み込み案内を表示する", async () => {
     downloadFormatMocks.getValue.mockRejectedValueOnce(
       new Error("'wxt/storage' must be loaded in a web extension environment")
@@ -2927,6 +2928,20 @@ describe("Suno popup compatibility check", () => {
       expect(alert.dataset.variant).toBe("warning");
       expectShadcnControl(expectControl(container, "reload-tab"), "outline");
     });
+
+    const reload = vi.fn();
+    const reloadWindow = Object.create(window) as Window & typeof globalThis;
+    Object.defineProperty(reloadWindow, "location", {
+      configurable: true,
+      value: { reload },
+    });
+    vi.stubGlobal("window", reloadWindow);
+
+    await act(async () => {
+      expectControl(container, "reload-tab").click();
+    });
+
+    expect(reload).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/extensions/suno-helper/tests/popup-entrypoint.test.tsx
+++ b/extensions/suno-helper/tests/popup-entrypoint.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../components/App", async () => {
+  const { createElement } = await import("react");
+  return {
+    App: () =>
+      createElement("div", { "data-suno-popup-app": "mounted" }, "Suno App"),
+  };
+});
+
+// REQ-2919-01: popup boot fails loud without #root and mounts App with it.
+describe("popup entrypoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("root が欠落していると既定エラーで fail loud する", async () => {
+    await expect(import("../entrypoints/popup/main")).rejects.toThrow(
+      "popup root 要素が見つかりません。"
+    );
+  });
+
+  it("root があると App を描画する", async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+
+    await act(async () => {
+      await import("../entrypoints/popup/main");
+    });
+
+    expect(
+      document.querySelector('[data-suno-popup-app="mounted"]')?.textContent
+    ).toBe("Suno App");
+  });
+});

--- a/extensions/suno-helper/tests/trusted-shortcut.test.ts
+++ b/extensions/suno-helper/tests/trusted-shortcut.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendTrustedCmdP } from "../lib/trusted-shortcut";
+
+// REQ-2917-01: debugger detach is attempted once and its failures stay visible.
+describe("trusted shortcut debugger cleanup", () => {
+  const attach = vi.fn(async () => undefined);
+  const sendCommand = vi.fn(async () => undefined);
+  const detach = vi.fn(async () => undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("chrome", {
+      debugger: { attach, sendCommand, detach },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("detach reject を warn して呼び出し側へ伝播する", async () => {
+    const error = new Error("detach failed");
+    detach.mockRejectedValueOnce(error);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(sendTrustedCmdP(42, true)).rejects.toBe(error);
+
+    expect(detach).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("sendTrustedCmdP failed"),
+      error
+    );
+  });
+
+  it("send と detach が両方 reject しても detach を一回試行して reject する", async () => {
+    sendCommand.mockRejectedValueOnce(new Error("send failed"));
+    const detachError = new Error("detach failed");
+    detach.mockRejectedValueOnce(detachError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(sendTrustedCmdP(42, false)).rejects.toBe(detachError);
+
+    expect(detach).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("sendTrustedCmdP failed"),
+      detachError
+    );
+  });
+
+  it("send reject 時も detach を一回試行し、元の失敗を warn して伝播する", async () => {
+    const error = new Error("send failed");
+    sendCommand.mockRejectedValueOnce(error);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(sendTrustedCmdP(42, true)).rejects.toBe(error);
+
+    expect(detach).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("sendTrustedCmdP failed"),
+      error
+    );
+  });
+});

--- a/extensions/suno-helper/tests/ui-foundation.test.tsx
+++ b/extensions/suno-helper/tests/ui-foundation.test.tsx
@@ -305,7 +305,8 @@ describe("shadcn/ui foundation", () => {
     }
   );
 
-  it("Alert は role を暗黙追加せず、指定された semantic role と props を透過する", () => {
+  // REQ-2923-01: the test name states the explicit-role override contract.
+  it("Alert は明示 role で既定 alert role を上書きし、aria-live 等の props を透過する", () => {
     const html = renderToStaticMarkup(
       createElement(
         Alert,


### PR DESCRIPTION
## Summary

- scope 15 の全9 findingsを1 PRに統合し、各 leaf を `REQ-<issue>-01` から直接追跡できるテストで固定
- download watcher cleanup、reload timer、debugger detach、Overlay/popup entrypoint、reload notice の失敗・境界契約を追加
- overlay mount失敗時に `ui.remove()` を実行してから元の例外を再送出する cleanup を追加
- Hooks contractを共有configと同じ `extensions` workspaceのOxlintで実行し、Alertテスト名を実契約へ修正

## Leaf ledger

| Leaf | Status | Implementation / direct evidence |
| --- | --- | --- |
| #2915 | passed | `tests/download-flow.test.ts`: DOM throw / timeout / abortでcancel一回、postなし、late completion無視 |
| #2916 | passed | `tests/page-reload.test.ts`: 999ms非発火、二重予約の旧timer取消、一回発火、cancel後非発火 |
| #2917 | passed | `tests/trusted-shortcut.test.ts`: detach reject、send+detach reject、send rejectでwarn/reject/detach一回 |
| #2918 | passed | `tests/overlay-component.test.tsx`: handshake mismatch/reject、read/write rejectでshell非表示・reload UI |
| #2919 | passed | `tests/popup-entrypoint.test.tsx`: root欠落の既定error、rootありApp mount |
| #2920 | passed | `tests/overlay-entrypoint.test.tsx` + production cleanup: onRemove unmount一回、mount失敗remove/reject |
| #2921 | passed | `tests/popup-compatibility.test.ts`: reload button一回clickでreload一回 |
| #2922 | passed | Hooks contractをconfigと同じworkspaceのbinaryへ揃え、rules-of-hooks error / exhaustive-deps warning+exit0 / compiler diagnosticなし+exit0 |
| #2923 | passed | Alertテスト名を「明示roleが既定alertを上書きしaria-live等props透過」へ変更、assertion維持 |

## TDD evidence

- Red: overlay mount failure test reproduced missing cleanup (`remove` 0 calls)
- Green: production entrypoint cleanup後、9 direct files / 134 tests passed
- Coverage-only findingsは既存production契約を弱めず直接assertionとして追加

## Validation

- `nix develop .#extensions --command pnpm -C extensions/suno-helper check`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper compile`
- direct Vitest: 9 files / 134 tests passed
- full Vitest: 72 files / 1341 tests passed
- Playwright: 15 passed
- WXT production build passed; generated manifest permissions matched expected 6 permissions
- shared-ui compile/check passed
- Fallow changed-file audit passed (no new issues)
- extension repository contract pytest: 55 passed
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- unit-only full pytest: 7357 passed, 1 skipped
- Any usage gate passed
- `git diff --check` passed

Closes #2924
Closes #2915
Closes #2916
Closes #2917
Closes #2918
Closes #2919
Closes #2920
Closes #2921
Closes #2922
Closes #2923
