### PR TITLE
fix(extensions): scope16の失敗境界を固定する (#2946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(extensions)`: Community / DistroKid helper の cleanup・stop・storage・asset relay・content injection 失敗を後続副作用なしで扱い、shared-ui の portal・primitive・refresh・drag・viewport 境界と entrypoint lifecycle を実 mount 回帰テストで固定した（#2926〜#2946）。
 - `fix(skills)`: スキル配布・パッケージング監査の25件を実行可能な成功／失敗契約へ置換し、market/persona の状態判定、schedule/GCP/shell reference の外部コマンド境界、thumbnail のatomic更新、動画ベンチマーク、コメント収集のpagination・途中失敗・atomic保存・CLI終了コードを回帰テストで固定した（#2831〜#2855）。
 - `test(repository)`: リポジトリ契約監査の文字列・行数・自己テストを実行時境界へ置換し、Chrome extension/worktree解決、Git ignore、dotenv非使用、pytest lane、shared-ui relay、隔離fallow cacheの回帰契約を強化した（#2888）。
 - `fix(dashboard)`: detail 選択の競合 response が現在の表示・loading/error 状態を上書きしないようにし、Analytics snapshot の bool・負値・不正 nested shape を公開 read model/API で安全な値へ正規化。dashboard・refresh・architecture・fixture/helper の失敗/境界経路を実行時回帰テストで補強し、session-expiry の定数形式テストを 404/410 の公開 upload 動作へ統合した（#2857, #2858, #2859, #2860, #2861, #2862, #2863, #2864, #2865, #2866, #2867）。

--- a/extensions/community-helper/tests/config.test.ts
+++ b/extensions/community-helper/tests/config.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { fakeBrowser } from "wxt/testing/fake-browser";
+
+import playwrightConfig from "../playwright.config";
+import vitestConfig from "../vitest.config";
+
+describe("community-helper test configuration", () => {
+  it("separates Vitest unit files from E2E and resolves shared React only once", () => {
+    expect(vitestConfig.test?.setupFiles).toEqual(["./tests/setup.ts"]);
+    expect(vitestConfig.test?.include).toEqual(["tests/**/*.test.{ts,tsx}"]);
+    expect(vitestConfig.test?.exclude).toEqual(["tests/e2e/**"]);
+    expect(vitestConfig.resolve?.alias).toMatchObject({
+      "@": expect.stringContaining("extensions/community-helper"),
+    });
+    expect(vitestConfig.resolve?.dedupe).toEqual([
+      "react",
+      "react-dom",
+      "@base-ui/react",
+    ]);
+  });
+
+  it("collects E2E from the dedicated directory in the parallel chromium project", () => {
+    expect(playwrightConfig.testDir).toBe("./tests/e2e");
+    expect(playwrightConfig.fullyParallel).toBe(true);
+    expect(playwrightConfig.projects).toHaveLength(1);
+    expect(playwrightConfig.projects?.[0]).toMatchObject({
+      name: "chromium",
+      use: expect.objectContaining({ defaultBrowserType: "chromium" }),
+    });
+  });
+
+  it("installs extension globals and the React act environment", () => {
+    expect(Reflect.get(globalThis, "chrome")).toBe(fakeBrowser);
+    expect(Reflect.get(globalThis, "browser")).toBe(fakeBrowser);
+    expect(Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT")).toBe(true);
+  });
+});

--- a/extensions/community-helper/tests/overlay-component.test.tsx
+++ b/extensions/community-helper/tests/overlay-component.test.tsx
@@ -14,6 +14,7 @@ const initialState = {
 
 const messagingMocks = vi.hoisted(() => ({
   toggle: undefined as (() => void) | undefined,
+  unsubscribe: vi.fn(),
 }));
 const storageMocks = vi.hoisted(() => ({
   read: vi.fn(async () => initialState),
@@ -26,7 +27,7 @@ vi.mock("../components/App", () => ({
 vi.mock("../lib/messaging", () => ({
   onMessage: vi.fn((_type: string, listener: () => void) => {
     messagingMocks.toggle = listener;
-    return vi.fn();
+    return messagingMocks.unsubscribe;
   }),
 }));
 vi.mock("../lib/overlay-storage", () => ({
@@ -39,21 +40,29 @@ describe("Community Overlay", () => {
   let root: Root;
 
   beforeEach(async () => {
-    storageMocks.read.mockClear();
-    storageMocks.write.mockClear();
+    storageMocks.read.mockReset().mockResolvedValue(initialState);
+    storageMocks.write.mockReset().mockResolvedValue(undefined);
     messagingMocks.toggle = undefined;
+    messagingMocks.unsubscribe.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    await act(async () => root.render(createElement(Overlay)));
   });
+
+  async function renderOverlay(): Promise<void> {
+    await act(async () => root.render(createElement(Overlay)));
+  }
 
   afterEach(() => {
     act(() => root.unmount());
+    if (messagingMocks.toggle) {
+      expect(messagingMocks.unsubscribe).toHaveBeenCalledOnce();
+    }
     container.remove();
   });
 
   it("renders the app in the shared shell and persists minimize state", async () => {
+    await renderOverlay();
     const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
     expect(shell.style.left).toBe("40px");
     expect(shell.style.top).toBe("50px");
@@ -81,10 +90,40 @@ describe("Community Overlay", () => {
   });
 
   it("keeps the action toggle listener alive while hidden", async () => {
+    await renderOverlay();
     const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
     await act(async () => messagingMocks.toggle?.());
     expect(shell.style.display).toBe("none");
     await act(async () => messagingMocks.toggle?.());
     expect(shell.style.display).toBe("block");
+  });
+
+  it("shows reload guidance when initial storage read rejects", async () => {
+    storageMocks.read.mockRejectedValueOnce(new Error("storage context lost"));
+
+    await renderOverlay();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "再読み込みが必要です"
+    );
+    expect(container.querySelector("[data-overlay-shell]")).toBeNull();
+    expect(messagingMocks.toggle).toBeUndefined();
+  });
+
+  it("shows reload guidance when state persistence rejects", async () => {
+    storageMocks.write.mockRejectedValueOnce(new Error("write failed"));
+    await renderOverlay();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="最小化"]')!
+        .click();
+      await Promise.resolve();
+    });
+
+    expect(storageMocks.write).toHaveBeenCalledOnce();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "再読み込みが必要です"
+    );
   });
 });

--- a/extensions/community-helper/tests/overlay-entrypoint.test.ts
+++ b/extensions/community-helper/tests/overlay-entrypoint.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const entrypointMocks = vi.hoisted(() => ({
+  definition: undefined as
+    | {
+        main: (context: object) => Promise<void>;
+        matches: string[];
+        cssInjectionMode: string;
+      }
+    | undefined,
+  mount: vi.fn(),
+  render: vi.fn(),
+  unmount: vi.fn(),
+  shadowOptions: undefined as
+    | {
+        onMount: (container: HTMLElement) => unknown;
+        onRemove: (root: { unmount: () => void } | undefined) => void;
+      }
+    | undefined,
+}));
+
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => ({
+    render: entrypointMocks.render,
+    unmount: entrypointMocks.unmount,
+  })),
+}));
+
+describe("community overlay content entrypoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    entrypointMocks.mount.mockClear();
+    entrypointMocks.render.mockClear();
+    entrypointMocks.unmount.mockClear();
+    entrypointMocks.definition = undefined;
+    entrypointMocks.shadowOptions = undefined;
+  });
+
+  it("mounts, renders, and unmounts the React root through the Shadow UI lifecycle", async () => {
+    vi.stubGlobal(
+      "defineContentScript",
+      (definition: typeof entrypointMocks.definition) => {
+        entrypointMocks.definition = definition;
+        return definition;
+      }
+    );
+    vi.stubGlobal(
+      "createShadowRootUi",
+      vi.fn(async (_context, options) => {
+        entrypointMocks.shadowOptions = options;
+        return { mount: entrypointMocks.mount };
+      })
+    );
+
+    await import("../entrypoints/overlay.content");
+    expect(entrypointMocks.definition).toMatchObject({
+      cssInjectionMode: "ui",
+    });
+    await entrypointMocks.definition!.main({ page: "youtube" });
+
+    expect(createShadowRootUi).toHaveBeenCalledWith(
+      { page: "youtube" },
+      expect.objectContaining({
+        name: "community-helper-overlay",
+        position: "overlay",
+      })
+    );
+    expect(entrypointMocks.mount).toHaveBeenCalledOnce();
+
+    const container = document.createElement("div");
+    const root = entrypointMocks.shadowOptions!.onMount(container);
+    expect(entrypointMocks.render).toHaveBeenCalledOnce();
+    entrypointMocks.shadowOptions!.onRemove(root as { unmount: () => void });
+    expect(entrypointMocks.unmount).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/community-helper/tests/popup.test.tsx
+++ b/extensions/community-helper/tests/popup.test.tsx
@@ -4,8 +4,14 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { COMMUNITY_PHASE } from "../../shared/constants";
 import { App } from "../components/App";
-import { sendMessage } from "../lib/messaging";
+import { onMessage, sendMessage } from "../lib/messaging";
+
+const messaging = vi.hoisted(() => ({
+  listeners: new Map<string, (message: { data: unknown }) => void>(),
+  unsubscribers: [] as Array<ReturnType<typeof vi.fn>>,
+}));
 
 vi.mock("wxt/browser", () => ({
   browser: {
@@ -14,15 +20,33 @@ vi.mock("wxt/browser", () => ({
 }));
 
 vi.mock("../lib/messaging", () => ({
-  onMessage: vi.fn(() => () => undefined),
+  onMessage: vi.fn(
+    (type: string, listener: (message: { data: unknown }) => void) => {
+      messaging.listeners.set(type, listener);
+      const unsubscribe = vi.fn();
+      messaging.unsubscribers.push(unsubscribe);
+      return unsubscribe;
+    }
+  ),
   sendMessage: vi.fn(async () => undefined),
 }));
+
+function changeInput(input: HTMLInputElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value"
+  )?.set;
+  valueSetter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
 
 describe("community-helper app", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(async () => {
+    messaging.listeners.clear();
+    messaging.unsubscribers.length = 0;
     container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
@@ -108,5 +132,134 @@ describe("community-helper app", () => {
       "互換性がありません"
     );
     expect(sendMessage).not.toHaveBeenCalledWith("run", expect.anything());
+  });
+
+  it("rejects an empty URL before compatibility or run side effects", async () => {
+    const input = container.querySelector<HTMLInputElement>(
+      'input[name="serverUrl"]'
+    )!;
+    await act(async () => {
+      changeInput(input, "   ");
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await Promise.resolve();
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "サーバー URL を入力してください"
+    );
+    expect(container.querySelector<HTMLButtonElement>("button")!.disabled).toBe(
+      false
+    );
+  });
+
+  it("rejects an unknown compatibility status without relaying run", async () => {
+    vi.mocked(sendMessage).mockResolvedValueOnce({
+      status: "future-status",
+    } as never);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "/version を確認できません"
+    );
+    expect(sendMessage).not.toHaveBeenCalledWith("run", expect.anything());
+  });
+
+  it("normalizes the run URL and releases busy with an error when stop relay rejects", async () => {
+    vi.mocked(sendMessage)
+      .mockResolvedValueOnce({
+        status: "compatible",
+        serverVersion: "0.1.0",
+        minExtensionVersion: "0.1.0",
+        extensionVersion: "0.1.0",
+      })
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("stop relay unavailable"));
+    const input = container.querySelector<HTMLInputElement>(
+      'input[name="serverUrl"]'
+    )!;
+    await act(async () => {
+      changeInput(input, "http://localhost:7873/");
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const buttons = container.querySelectorAll<HTMLButtonElement>("button");
+    expect(buttons[0].disabled).toBe(true);
+    expect(sendMessage).toHaveBeenNthCalledWith(2, "run", {
+      baseUrl: "http://localhost:7873",
+    });
+
+    await act(async () => {
+      buttons[1].click();
+      await Promise.resolve();
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("stop");
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "stop relay unavailable"
+    );
+    expect(buttons[0].disabled).toBe(false);
+    expect(buttons[1].disabled).toBe(true);
+  });
+
+  it("applies progress and error messages and unsubscribes both listeners", async () => {
+    vi.mocked(sendMessage)
+      .mockResolvedValueOnce({
+        status: "compatible",
+        serverVersion: "0.1.0",
+        minExtensionVersion: "0.1.0",
+        extensionVersion: "0.1.0",
+      })
+      .mockResolvedValueOnce(undefined);
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      messaging.listeners.get("progress")?.({
+        data: {
+          index: 2,
+          total: 3,
+          phase: COMMUNITY_PHASE.DONE,
+          message: "投稿完了",
+        },
+      });
+    });
+    expect(
+      container.querySelectorAll<HTMLElement>('[data-testid="progress-row"]')[2]
+        .textContent
+    ).toContain("投稿完了");
+    expect(container.querySelector<HTMLButtonElement>("button")!.disabled).toBe(
+      false
+    );
+
+    await act(async () => {
+      messaging.listeners.get("error")?.({
+        data: { message: "content failed" },
+      });
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "content failed"
+    );
+
+    expect(onMessage).toHaveBeenCalledTimes(2);
+    await act(async () => root.unmount());
+    expect(messaging.unsubscribers).toHaveLength(2);
+    for (const unsubscribe of messaging.unsubscribers) {
+      expect(unsubscribe).toHaveBeenCalledOnce();
+    }
+    root = createRoot(container);
   });
 });

--- a/extensions/community-helper/tests/runner.test.ts
+++ b/extensions/community-helper/tests/runner.test.ts
@@ -208,4 +208,29 @@ describe("community runner", () => {
     });
     expect(dependencies.cancelPostForm).not.toHaveBeenCalled();
   });
+
+  it("requires reconciliation and suppresses every later side effect when composer cleanup rejects", async () => {
+    const dependencies = createDependencies([]);
+    vi.mocked(dependencies.setScheduleDateTime).mockRejectedValue(
+      new Error("picker drift")
+    );
+    vi.mocked(dependencies.cancelPostForm).mockRejectedValue(
+      new Error("cleanup relay failed")
+    );
+
+    const result = runCommunityPosts("http://localhost:7873", dependencies);
+
+    await expect(result).rejects.toMatchObject({
+      completedCount: 0,
+      requiresReconciliation: true,
+      cause: expect.objectContaining({ message: "cleanup relay failed" }),
+    });
+    await expect(result).rejects.toThrow(
+      /picker drift.*cleanup relay failed.*予約投稿を照合/u
+    );
+    expect(dependencies.cancelPostForm).toHaveBeenCalledOnce();
+    expect(dependencies.clickPost).not.toHaveBeenCalled();
+    expect(dependencies.openPostForm).toHaveBeenCalledOnce();
+    expect(dependencies.setCommunityText).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/community-helper/vitest.config.ts
+++ b/extensions/community-helper/vitest.config.ts
@@ -2,15 +2,20 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
 
+const rootUrl = new URL(".", import.meta.url);
+const rootPath =
+  rootUrl.protocol === "file:" ? fileURLToPath(rootUrl) : rootUrl.pathname;
+
 export default defineConfig({
   resolve: {
     alias: {
-      "@": fileURLToPath(new URL(".", import.meta.url)),
+      "@": rootPath,
     },
     dedupe: ["react", "react-dom", "@base-ui/react"],
   },
   test: {
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["tests/e2e/**"],
   },
 });

--- a/extensions/distrokid-helper/lib/background-fetch.ts
+++ b/extensions/distrokid-helper/lib/background-fetch.ts
@@ -4,7 +4,9 @@ export async function backgroundFetch(
   input: string | URL | Request,
   init?: RequestInit
 ): Promise<Response> {
-  if (init?.method !== undefined && init.method !== "GET") {
+  const method =
+    init?.method ?? (input instanceof Request ? input.method : "GET");
+  if (method.toUpperCase() !== "GET") {
     throw new Error("background local fetch only supports GET");
   }
   const url =

--- a/extensions/distrokid-helper/lib/content-injector.ts
+++ b/extensions/distrokid-helper/lib/content-injector.ts
@@ -33,6 +33,15 @@ export function createDocumentInjector(doc: Document): Injector {
       // 以降の注入（assert / プロファイル / タイトル / credit）は行生成後に開始する（順序保証）。
       await setTrackCount(doc, release.tracks.length);
 
+      // DOM 行数の不一致は、利用者の既存入力を一切変更する前に fail-loud にする。
+      // 再読み込みが必要な不完全 DOM に profile/release/store を部分注入しない。
+      const uuids = resolveTrackUuids(doc);
+      if (uuids.length !== release.tracks.length) {
+        throw new Error(
+          `track 数が DOM と一致しません: DOM=${uuids.length}, payload=${release.tracks.length}。${RELOAD_GUIDANCE}`
+        );
+      }
+
       // 新規リリース前提を assert（過去公開対応はスコープ外）。
       assertNewRelease(doc);
       await injectProfile(doc, profile);
@@ -40,12 +49,6 @@ export function createDocumentInjector(doc: Document): Injector {
       injectReleaseDate(doc, release.release_date);
 
       // track UUID を DOM order で解決し、全 track のタイトル / songwriter を注入する。
-      const uuids = resolveTrackUuids(doc);
-      if (uuids.length !== release.tracks.length) {
-        throw new Error(
-          `track 数が DOM と一致しません: DOM=${uuids.length}, payload=${release.tracks.length}。${RELOAD_GUIDANCE}`
-        );
-      }
       release.tracks.forEach((track, i) => {
         injectTrackTitle(doc, uuids[i], track.title);
         if (profile.songwriter !== null) {

--- a/extensions/distrokid-helper/tests/alert-dialog.test.tsx
+++ b/extensions/distrokid-helper/tests/alert-dialog.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@youtube-automation/ui";
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function waitFor(assertion: () => void): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (attempt === 19) throw error;
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    }
+  }
+}
+
+describe("AlertDialog Shadow portal", () => {
+  let host: HTMLDivElement;
+  let shadow: ShadowRoot;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.append(host);
+    shadow = host.attachShadow({ mode: "open" });
+    container = document.createElement("div");
+    shadow.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it("portals inside ShadowRoot, opens/closes via cancel, and passes dialog props", async () => {
+    const onOpenChange = vi.fn();
+    await act(async () =>
+      root.render(
+        <AlertDialog onOpenChange={onOpenChange}>
+          <AlertDialogTrigger aria-label="open dialog" data-probe="trigger">
+            Open
+          </AlertDialogTrigger>
+          <AlertDialogContent
+            size="sm"
+            aria-label="confirmation"
+            data-probe="content"
+          >
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete release?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel aria-label="cancel action">
+                Cancel
+              </AlertDialogCancel>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )
+    );
+    const trigger = shadow.querySelector<HTMLButtonElement>(
+      '[aria-label="open dialog"]'
+    )!;
+    expect(trigger.dataset.probe).toBe("trigger");
+    await act(async () => trigger.click());
+    await waitFor(() =>
+      expect(
+        shadow.querySelector('[data-slot="alert-dialog-content"]')
+      ).not.toBeNull()
+    );
+
+    const content = shadow.querySelector<HTMLElement>(
+      '[data-slot="alert-dialog-content"]'
+    )!;
+    expect(content.dataset.size).toBe("sm");
+    expect(content.dataset.probe).toBe("content");
+    expect(content.getAttribute("aria-label")).toBe("confirmation");
+    expect(
+      document.body.querySelector("[data-slot='alert-dialog-content']")
+    ).toBeNull();
+    expect(
+      shadow.querySelector('[data-slot="alert-dialog-overlay"]')
+    ).not.toBeNull();
+
+    await act(async () =>
+      shadow
+        .querySelector<HTMLButtonElement>('[aria-label="cancel action"]')!
+        .click()
+    );
+    await waitFor(() =>
+      expect(
+        shadow.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull()
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: expect.anything() })
+    );
+  });
+
+  it("passes action props and lets the action close a controlled dialog", async () => {
+    const onAction = vi.fn();
+    function ControlledDialog() {
+      const [open, setOpen] = useState(false);
+      return (
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogTrigger>Open action</AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogTitle>Confirm</AlertDialogTitle>
+            <AlertDialogAction
+              aria-label="confirm action"
+              data-probe="action"
+              onClick={() => {
+                onAction();
+                setOpen(false);
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogContent>
+        </AlertDialog>
+      );
+    }
+    await act(async () => root.render(<ControlledDialog />));
+    await act(async () =>
+      shadow
+        .querySelector<HTMLButtonElement>('[data-slot="alert-dialog-trigger"]')!
+        .click()
+    );
+    await waitFor(() =>
+      expect(
+        shadow.querySelector('[aria-label="confirm action"]')
+      ).not.toBeNull()
+    );
+    const action = shadow.querySelector<HTMLButtonElement>(
+      '[aria-label="confirm action"]'
+    )!;
+    expect(action.dataset.probe).toBe("action");
+    await act(async () => action.click());
+    expect(onAction).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(
+        shadow.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull()
+    );
+  });
+});

--- a/extensions/distrokid-helper/tests/api.test.ts
+++ b/extensions/distrokid-helper/tests/api.test.ts
@@ -151,6 +151,19 @@ describe("fetchRelease", () => {
     }
   );
 
+  it.each([[null], [undefined], [["profile"]]])(
+    "profile=%j は不正 envelope として reject する",
+    async (profile) => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { ...SAMPLE_PAYLOAD, profile })
+      );
+
+      await expect(fetchRelease("http://localhost:7873")).rejects.toThrow(
+        /profile must be an object/u
+      );
+    }
+  );
+
   it.each([[null], [undefined], [["track-01"]]])(
     "release=%j は不正 payload として reject する",
     async (release) => {

--- a/extensions/distrokid-helper/tests/background-fetch.test.ts
+++ b/extensions/distrokid-helper/tests/background-fetch.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { backgroundFetch, backgroundFetchAsset } from "../lib/background-fetch";
+import { sendMessage } from "../lib/messaging";
+
+vi.mock("../lib/messaging", () => ({
+  sendMessage: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("background fetch adapter", () => {
+  it.each(["POST", "post", "HEAD"])(
+    "rejects non-GET init before relay: %s",
+    async (method) => {
+      await expect(
+        backgroundFetch("http://localhost:7873/version", { method })
+      ).rejects.toThrow("only supports GET");
+      expect(sendMessage).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a non-GET Request object before relay", async () => {
+    await expect(
+      backgroundFetch(
+        new Request("http://localhost:7873/version", { method: "POST" })
+      )
+    ).rejects.toThrow("only supports GET");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("accepts a case-insensitive GET init", async () => {
+    vi.mocked(sendMessage).mockResolvedValueOnce({
+      body: "ok",
+      contentType: "text/plain",
+      status: 200,
+      statusText: "OK",
+    });
+
+    await expect(
+      backgroundFetch("http://localhost:7873/version", { method: "get" })
+    ).resolves.toBeInstanceOf(Response);
+  });
+
+  it.each([
+    ["string", "http://localhost:7873/string"],
+    ["URL", new URL("http://localhost:7873/url")],
+    ["Request", new Request("http://localhost:7873/request")],
+  ])(
+    "normalizes a %s input and reconstructs the Response wire",
+    async (_kind, input) => {
+      vi.mocked(sendMessage).mockResolvedValueOnce({
+        body: "relay body",
+        contentType: "application/json",
+        status: 206,
+        statusText: "Partial Content",
+      });
+
+      const response = await backgroundFetch(input);
+      const expectedUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      expect(sendMessage).toHaveBeenCalledWith("fetchLocalText", {
+        url: expectedUrl,
+      });
+      expect(response.status).toBe(206);
+      expect(response.statusText).toBe("Partial Content");
+      expect(response.headers.get("content-type")).toBe("application/json");
+      await expect(response.text()).resolves.toBe("relay body");
+    }
+  );
+
+  it("relays one asset request and returns the serialized wire unchanged", async () => {
+    const wire = {
+      filename: "track.mp3",
+      mimeType: "audio/mpeg",
+      base64: "AQID",
+    };
+    vi.mocked(sendMessage).mockResolvedValueOnce(wire);
+
+    await expect(
+      backgroundFetchAsset(
+        "http://localhost:7873/distrokid/assets/track.mp3",
+        "track.mp3"
+      )
+    ).resolves.toBe(wire);
+    expect(sendMessage).toHaveBeenCalledWith("fetchLocalAsset", {
+      url: "http://localhost:7873/distrokid/assets/track.mp3",
+      filename: "track.mp3",
+    });
+  });
+});

--- a/extensions/distrokid-helper/tests/color-contrast.test.ts
+++ b/extensions/distrokid-helper/tests/color-contrast.test.ts
@@ -1,0 +1,25 @@
+import { hexContrastRatio, rgbContrastRatio } from "@youtube-automation/ui";
+import { describe, expect, it } from "vitest";
+
+describe("shared color contrast", () => {
+  it("returns the WCAG black/white and identical-color boundaries", () => {
+    expect(hexContrastRatio("#000000", "#FFFFFF")).toBe(21);
+    expect(hexContrastRatio("#336699", "#336699")).toBe(1);
+    expect(rgbContrastRatio([0, 0, 0], [255, 255, 255])).toBe(21);
+  });
+
+  it("is symmetric when argument order is swapped", () => {
+    expect(hexContrastRatio("#123456", "#FEDCBA")).toBe(
+      hexContrastRatio("#FEDCBA", "#123456")
+    );
+  });
+
+  it.each(["#fff", "ffffff00", "#gg0000", "", "#12345z"])(
+    "rejects an invalid six-digit hex color: %s",
+    (hex) => {
+      expect(() => hexContrastRatio(hex, "#000000")).toThrow(
+        "6-digit hex color required"
+      );
+    }
+  );
+});

--- a/extensions/distrokid-helper/tests/config.test.ts
+++ b/extensions/distrokid-helper/tests/config.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { fakeBrowser } from "wxt/testing/fake-browser";
+
+import playwrightConfig from "../playwright.config";
+import vitestConfig from "../vitest.config";
+import { installPointerEventFallback } from "./setup";
+
+describe("distrokid-helper test configuration", () => {
+  it("separates Vitest unit files from E2E and keeps aliases and dependency dedupe", () => {
+    expect(vitestConfig.test?.setupFiles).toEqual(["./tests/setup.ts"]);
+    expect(vitestConfig.test?.include).toEqual(["tests/**/*.test.{ts,tsx}"]);
+    expect(vitestConfig.test?.exclude).toEqual(["tests/e2e/**"]);
+    expect(vitestConfig.resolve?.alias).toMatchObject({
+      "@": expect.stringContaining("extensions/distrokid-helper"),
+    });
+    expect(vitestConfig.resolve?.dedupe).toEqual([
+      "react",
+      "react-dom",
+      "@base-ui/react",
+    ]);
+  });
+
+  it("collects E2E from the dedicated directory in the parallel chromium project", () => {
+    expect(playwrightConfig.testDir).toBe("./tests/e2e");
+    expect(playwrightConfig.fullyParallel).toBe(true);
+    expect(playwrightConfig.projects).toHaveLength(1);
+    expect(playwrightConfig.projects?.[0]).toMatchObject({
+      name: "chromium",
+      use: expect.objectContaining({ defaultBrowserType: "chromium" }),
+    });
+  });
+
+  it("installs extension globals and the PointerEvent fallback", () => {
+    expect(Reflect.get(globalThis, "chrome")).toBe(fakeBrowser);
+    expect(Reflect.get(globalThis, "browser")).toBe(fakeBrowser);
+    expect(Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT")).toBe(true);
+    const target: Parameters<typeof installPointerEventFallback>[0] = {
+      MouseEvent: window.MouseEvent,
+    };
+    installPointerEventFallback(target);
+    expect(target.PointerEvent).toBe(window.MouseEvent);
+  });
+});

--- a/extensions/distrokid-helper/tests/content-entrypoint.test.ts
+++ b/extensions/distrokid-helper/tests/content-entrypoint.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const contentMocks = vi.hoisted(() => ({
+  definition: undefined as { main: () => void } | undefined,
+  handlers: new Map<string, (message?: { data: unknown }) => unknown>(),
+  injector: { boundary: "document" },
+  reporter: undefined as
+    | ((
+        phase: "injecting" | "done" | "error" | "stopped",
+        message: string
+      ) => unknown)
+    | undefined,
+  start: vi.fn(),
+  track: vi.fn(),
+  cover: vi.fn(),
+  finish: vi.fn(),
+  stop: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("../lib/content-injector", () => ({
+  createDocumentInjector: vi.fn(() => contentMocks.injector),
+}));
+vi.mock("../lib/inject-session", () => ({
+  InjectSession: class {
+    constructor(injector: unknown, reporter: typeof contentMocks.reporter) {
+      expect(injector).toBe(contentMocks.injector);
+      contentMocks.reporter = reporter;
+    }
+    start = contentMocks.start;
+    track = contentMocks.track;
+    cover = contentMocks.cover;
+    finish = contentMocks.finish;
+    stop = contentMocks.stop;
+  },
+}));
+vi.mock("../lib/messaging", () => ({
+  onMessage: vi.fn(
+    (name: string, handler: (message: { data: unknown }) => unknown) => {
+      contentMocks.handlers.set(name, (message) => handler(message!));
+      return vi.fn();
+    }
+  ),
+  sendMessage: contentMocks.sendMessage,
+}));
+
+describe("distrokid content entrypoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.clearAllMocks();
+    contentMocks.handlers.clear();
+    contentMocks.definition = undefined;
+    contentMocks.reporter = undefined;
+  });
+
+  it("registers exact handlers, preserves payloads/order, and relays progress", async () => {
+    vi.stubGlobal(
+      "defineContentScript",
+      (definition: typeof contentMocks.definition) => {
+        contentMocks.definition = definition;
+        return definition;
+      }
+    );
+    await import("../entrypoints/content");
+    contentMocks.definition!.main();
+
+    expect([...contentMocks.handlers.keys()]).toEqual([
+      "injectStart",
+      "injectTrack",
+      "injectCover",
+      "injectFinish",
+      "stop",
+    ]);
+    const payload = { release: { tracks: [] } };
+    const trackAsset = { filename: "track.mp3", base64: "AQID" };
+    const coverAsset = { filename: "main.png", base64: "BAUG" };
+    await contentMocks.handlers.get("injectStart")!({
+      data: { payload },
+    });
+    contentMocks.handlers.get("injectTrack")!({
+      data: { trackIndex: 2, asset: trackAsset },
+    });
+    contentMocks.handlers.get("injectCover")!({
+      data: { asset: coverAsset },
+    });
+    await contentMocks.handlers.get("injectFinish")!();
+    contentMocks.handlers.get("stop")!();
+
+    expect(contentMocks.start).toHaveBeenCalledWith(payload);
+    expect(contentMocks.track).toHaveBeenCalledWith(2, trackAsset);
+    expect(contentMocks.cover).toHaveBeenCalledWith(coverAsset);
+    expect(contentMocks.finish).toHaveBeenCalledOnce();
+    expect(contentMocks.stop).toHaveBeenCalledOnce();
+    expect(contentMocks.start.mock.invocationCallOrder[0]).toBeLessThan(
+      contentMocks.track.mock.invocationCallOrder[0]
+    );
+    expect(contentMocks.track.mock.invocationCallOrder[0]).toBeLessThan(
+      contentMocks.cover.mock.invocationCallOrder[0]
+    );
+    expect(contentMocks.cover.mock.invocationCallOrder[0]).toBeLessThan(
+      contentMocks.finish.mock.invocationCallOrder[0]
+    );
+    expect(contentMocks.finish.mock.invocationCallOrder[0]).toBeLessThan(
+      contentMocks.stop.mock.invocationCallOrder[0]
+    );
+    await contentMocks.reporter!("injecting", "track 1");
+    expect(contentMocks.sendMessage).toHaveBeenCalledWith("progress", {
+      phase: "injecting",
+      message: "track 1",
+    });
+  });
+
+  it.each([
+    "injectStart",
+    "injectTrack",
+    "injectCover",
+    "injectFinish",
+    "stop",
+  ])("propagates %s handler rejection to the message caller", async (name) => {
+    vi.stubGlobal(
+      "defineContentScript",
+      (definition: typeof contentMocks.definition) => {
+        contentMocks.definition = definition;
+        return definition;
+      }
+    );
+    const method = {
+      injectStart: contentMocks.start,
+      injectTrack: contentMocks.track,
+      injectCover: contentMocks.cover,
+      injectFinish: contentMocks.finish,
+      stop: contentMocks.stop,
+    }[name]!;
+    method.mockRejectedValueOnce(new Error(`${name} rejected`));
+    await import("../entrypoints/content");
+    contentMocks.definition!.main();
+
+    const result = contentMocks.handlers.get(name)!({
+      data: {
+        payload: {},
+        trackIndex: 0,
+        asset: { filename: "asset" },
+      },
+    });
+    await expect(Promise.resolve(result)).rejects.toThrow(`${name} rejected`);
+  });
+});

--- a/extensions/distrokid-helper/tests/content-injector.test.ts
+++ b/extensions/distrokid-helper/tests/content-injector.test.ts
@@ -246,4 +246,31 @@ describe("createDocumentInjector", () => {
         .value
     ).toBe("Soulful Grooves");
   });
+
+  it("track UUID count mismatch rejects before profile, release, track, store, or credit mutation", async () => {
+    mountStaticForm(2, "Soulful Grooves");
+    wireGenreSecondaryPopulate([{ value: "Ambient", text: "Ambient" }]);
+    const bandName = document.querySelector<HTMLInputElement>(
+      'input[name="bandname"]'
+    )!;
+    const albumTitle =
+      document.querySelector<HTMLInputElement>("#albumTitleInput")!;
+    const firstTitle = document.querySelector<HTMLInputElement>(
+      'input[name="title_a"]'
+    )!;
+    const appleStore = document.querySelector<HTMLInputElement>("#chkapple")!;
+
+    await expect(
+      createDocumentInjector(document).injectStaticFields(payload(BASE_PROFILE))
+    ).rejects.toThrow(/track 数が DOM と一致しません/u);
+
+    expect(bandName.value).toBe("");
+    expect(albumTitle.value).toBe("");
+    expect(firstTitle.value).toBe("");
+    expect(appleStore.checked).toBe(false);
+    expect(
+      document.querySelector<HTMLInputElement>("#track-1-performer-1-name")!
+        .value
+    ).toBe("");
+  });
 });

--- a/extensions/distrokid-helper/tests/inject-runner.test.ts
+++ b/extensions/distrokid-helper/tests/inject-runner.test.ts
@@ -177,4 +177,77 @@ describe("runInjection", () => {
     expect(made.calls).toEqual([{ kind: "start", trackIndex: 3 }]);
     expect(made.fetched).toEqual([]);
   });
+
+  it.each([
+    ["start", ["start"]],
+    ["trackFetch", ["start", "message:track-01.mp3", "fetch:track-01.mp3"]],
+    ["track", ["start", "message:track-01.mp3", "fetch:track-01.mp3", "track"]],
+    [
+      "coverFetch",
+      [
+        "start",
+        "message:track-01.mp3",
+        "fetch:track-01.mp3",
+        "track",
+        "message:main.png",
+        "fetch:main.png",
+      ],
+    ],
+    [
+      "cover",
+      [
+        "start",
+        "message:track-01.mp3",
+        "fetch:track-01.mp3",
+        "track",
+        "message:main.png",
+        "fetch:main.png",
+        "cover",
+      ],
+    ],
+    [
+      "finish",
+      [
+        "start",
+        "message:track-01.mp3",
+        "fetch:track-01.mp3",
+        "track",
+        "message:main.png",
+        "fetch:main.png",
+        "cover",
+        "finish",
+      ],
+    ],
+  ] as const)(
+    "propagates a %s rejection and performs no later message or side effect",
+    async (failure, expectedEvents) => {
+      const events: string[] = [];
+      const rejectAt = async (name: string): Promise<void> => {
+        events.push(name);
+        if (failure === name) {
+          throw new Error(`${failure} failed`);
+        }
+      };
+      const channel: InjectChannel = {
+        start: async () => rejectAt("start"),
+        setMessage: (message) =>
+          events.push(`message:${message.split(": ").at(-1)}`),
+        fetchAsset: async (_path, filename) => {
+          const step = filename === "main.png" ? "coverFetch" : "trackFetch";
+          events.push(`fetch:${filename}`);
+          if (failure === step) throw new Error(`${failure} failed`);
+          return { filename, mimeType: "audio/mpeg", base64: "AQID" };
+        },
+        track: async () => rejectAt("track"),
+        cover: async () => rejectAt("cover"),
+        finish: async () => rejectAt("finish"),
+        isStopped: () => false,
+      };
+
+      await expect(runInjection(makePayload(1, true), channel)).rejects.toThrow(
+        `${failure} failed`
+      );
+      expect(events).toEqual(expectedEvents);
+    }
+  );
 });

--- a/extensions/distrokid-helper/tests/inject-session.test.ts
+++ b/extensions/distrokid-helper/tests/inject-session.test.ts
@@ -194,4 +194,64 @@ describe("InjectSession", () => {
       /injectStart/
     );
   });
+
+  it("static injection rejection keeps INJECTING, clears payload, and permits a clean restart", async () => {
+    const made = makeInjector();
+    let failStatic = true;
+    made.injector.injectStaticFields = async () => {
+      made.calls.push({ kind: "static" });
+      if (failStatic) throw new Error("static injection failed");
+    };
+    const localReports: { phase: Phase; message: string }[] = [];
+    const localSession = new InjectSession(made.injector, (phase, message) =>
+      localReports.push({ phase, message })
+    );
+
+    await expect(localSession.start(makePayload(1))).rejects.toThrow(
+      "static injection failed"
+    );
+    expect(localReports.at(-1)?.phase).toBe(PHASES.INJECTING);
+    expect(() => localSession.track(0, makeAsset("track-01.mp3"))).toThrow(
+      /injectStart/u
+    );
+
+    failStatic = false;
+    await expect(localSession.start(makePayload(1))).resolves.toBeUndefined();
+    expect(() =>
+      localSession.track(0, makeAsset("track-01.mp3"))
+    ).not.toThrow();
+  });
+
+  it("AI finish rejection keeps payload for retry, emits no DONE, and clears only after success", async () => {
+    const made = makeInjector();
+    let failAi = true;
+    made.injector.injectAiDisclosure = async () => {
+      made.calls.push({ kind: "ai" });
+      if (failAi) throw new Error("AI injection failed");
+    };
+    const localReports: { phase: Phase; message: string }[] = [];
+    const localSession = new InjectSession(made.injector, (phase, message) =>
+      localReports.push({ phase, message })
+    );
+    await localSession.start(makePayload(1));
+
+    await expect(localSession.finish()).rejects.toThrow("AI injection failed");
+    expect(localReports.at(-1)).toEqual({
+      phase: PHASES.INJECTING,
+      message: "AI 開示を注入中",
+    });
+    expect(localReports).not.toContainEqual(
+      expect.objectContaining({ phase: PHASES.DONE })
+    );
+    expect(() =>
+      localSession.track(0, makeAsset("track-01.mp3"))
+    ).not.toThrow();
+
+    failAi = false;
+    await expect(localSession.finish()).resolves.toBeUndefined();
+    expect(localReports.at(-1)?.phase).toBe(PHASES.DONE);
+    expect(() => localSession.track(0, makeAsset("track-01.mp3"))).toThrow(
+      /injectStart/u
+    );
+  });
 });

--- a/extensions/distrokid-helper/tests/local-fetch.test.ts
+++ b/extensions/distrokid-helper/tests/local-fetch.test.ts
@@ -11,6 +11,7 @@ describe("background local fetch boundary", () => {
     "https://localhost:7873/version",
     "http://example.com/version",
     "http://user:pass@localhost:7873/version",
+    "http://127.0.0.2:7873/version",
   ])("loopback HTTP 以外を fetch 前に拒否する: %s", async (url) => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -22,16 +23,14 @@ describe("background local fetch boundary", () => {
   });
 
   it("JSON response の status・Content-Type・body を relay wire にする", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response('{"ok":true}', {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-      )
+    const fetchMock = vi.fn(
+      async () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       fetchLocalText({ url: "http://localhost:7873/version" })
@@ -40,6 +39,27 @@ describe("background local fetch boundary", () => {
       contentType: "application/json",
       status: 200,
       statusText: "",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("http://localhost:7873/version"),
+      { method: "GET", redirect: "error" }
+    );
+  });
+
+  it.each([
+    "http://127.0.0.1:7873/version",
+    "http://music.localhost:7873/version",
+  ])("accepts the explicit loopback host boundary: %s", async (url) => {
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchLocalText({ url })).resolves.toMatchObject({
+      status: 200,
+      body: "ok",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(new URL(url), {
+      method: "GET",
+      redirect: "error",
     });
   });
 
@@ -66,4 +86,21 @@ describe("background local fetch boundary", () => {
       mimeType: "audio/mpeg",
     });
   });
+
+  it.each([404, 500])(
+    "rejects a non-OK asset response: HTTP %i",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response("failed", { status }))
+      );
+
+      await expect(
+        fetchLocalAsset({
+          url: "http://localhost:7873/distrokid/assets/track.mp3",
+          filename: "track.mp3",
+        })
+      ).rejects.toThrow(`asset fetch failed: HTTP ${status}`);
+    }
+  );
 });

--- a/extensions/distrokid-helper/tests/overlay-component.test.tsx
+++ b/extensions/distrokid-helper/tests/overlay-component.test.tsx
@@ -14,6 +14,7 @@ const initialState = {
 
 const messagingMocks = vi.hoisted(() => ({
   toggle: undefined as (() => void) | undefined,
+  unsubscribe: vi.fn(),
 }));
 const storageMocks = vi.hoisted(() => ({
   read: vi.fn(async () => initialState),
@@ -26,7 +27,7 @@ vi.mock("../components/App", () => ({
 vi.mock("../lib/messaging", () => ({
   onMessage: vi.fn((_type: string, listener: () => void) => {
     messagingMocks.toggle = listener;
-    return vi.fn();
+    return messagingMocks.unsubscribe;
   }),
 }));
 vi.mock("../lib/overlay-storage", () => ({
@@ -40,22 +41,30 @@ describe("DistroKid Overlay", () => {
 
   beforeEach(async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-    storageMocks.read.mockClear();
-    storageMocks.write.mockClear();
+    storageMocks.read.mockReset().mockResolvedValue(initialState);
+    storageMocks.write.mockReset().mockResolvedValue(undefined);
     messagingMocks.toggle = undefined;
+    messagingMocks.unsubscribe.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    await act(async () => root.render(createElement(Overlay)));
   });
+
+  async function renderOverlay(): Promise<void> {
+    await act(async () => root.render(createElement(Overlay)));
+  }
 
   afterEach(() => {
     act(() => root.unmount());
+    if (messagingMocks.toggle) {
+      expect(messagingMocks.unsubscribe).toHaveBeenCalledOnce();
+    }
     container.remove();
     vi.unstubAllGlobals();
   });
 
   it("共通 shell に既存 App を表示し、最小化 state を保存する", async () => {
+    await renderOverlay();
     const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
     expect(shell.style.left).toBe("40px");
     expect(shell.style.top).toBe("50px");
@@ -91,11 +100,41 @@ describe("DistroKid Overlay", () => {
   });
 
   it("hidden 中も action toggle listener を保って再表示する", async () => {
+    await renderOverlay();
     const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
 
     await act(async () => messagingMocks.toggle?.());
     expect(shell.style.display).toBe("none");
     await act(async () => messagingMocks.toggle?.());
     expect(shell.style.display).toBe("block");
+  });
+
+  it("initial storage read reject で再読み込み UI を表示する", async () => {
+    storageMocks.read.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await renderOverlay();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "再読み込みが必要です"
+    );
+    expect(container.querySelector("[data-overlay-shell]")).toBeNull();
+    expect(messagingMocks.toggle).toBeUndefined();
+  });
+
+  it("state write reject を onError 経由で再読み込み UI に変換する", async () => {
+    storageMocks.write.mockRejectedValueOnce(new Error("write unavailable"));
+    await renderOverlay();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="最小化"]')!
+        .click();
+      await Promise.resolve();
+    });
+
+    expect(storageMocks.write).toHaveBeenCalledOnce();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "再読み込みが必要です"
+    );
   });
 });

--- a/extensions/distrokid-helper/tests/overlay-entrypoint.test.ts
+++ b/extensions/distrokid-helper/tests/overlay-entrypoint.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const entrypointMocks = vi.hoisted(() => ({
+  definition: undefined as
+    | {
+        main: (context: object) => Promise<void>;
+        cssInjectionMode: string;
+      }
+    | undefined,
+  mount: vi.fn(),
+  render: vi.fn(),
+  unmount: vi.fn(),
+  shadowOptions: undefined as
+    | {
+        onMount: (container: HTMLElement) => unknown;
+        onRemove: (root: { unmount: () => void } | undefined) => void;
+      }
+    | undefined,
+}));
+
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => ({
+    render: entrypointMocks.render,
+    unmount: entrypointMocks.unmount,
+  })),
+}));
+
+describe("distrokid overlay content entrypoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    entrypointMocks.mount.mockClear();
+    entrypointMocks.render.mockClear();
+    entrypointMocks.unmount.mockClear();
+    entrypointMocks.definition = undefined;
+    entrypointMocks.shadowOptions = undefined;
+  });
+
+  it("mounts, renders, and unmounts the React root through the Shadow UI lifecycle", async () => {
+    vi.stubGlobal(
+      "defineContentScript",
+      (definition: typeof entrypointMocks.definition) => {
+        entrypointMocks.definition = definition;
+        return definition;
+      }
+    );
+    vi.stubGlobal(
+      "createShadowRootUi",
+      vi.fn(async (_context, options) => {
+        entrypointMocks.shadowOptions = options;
+        return { mount: entrypointMocks.mount };
+      })
+    );
+
+    await import("../entrypoints/overlay.content");
+    expect(entrypointMocks.definition?.cssInjectionMode).toBe("ui");
+    await entrypointMocks.definition!.main({ page: "distrokid" });
+    expect(createShadowRootUi).toHaveBeenCalledWith(
+      { page: "distrokid" },
+      expect.objectContaining({
+        name: "distrokid-helper-overlay",
+        position: "overlay",
+      })
+    );
+    expect(entrypointMocks.mount).toHaveBeenCalledOnce();
+
+    const root = entrypointMocks.shadowOptions!.onMount(
+      document.createElement("div")
+    );
+    expect(entrypointMocks.render).toHaveBeenCalledOnce();
+    entrypointMocks.shadowOptions!.onRemove(root as { unmount: () => void });
+    expect(entrypointMocks.unmount).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/distrokid-helper/tests/overlay-shell.test.tsx
+++ b/extensions/distrokid-helper/tests/overlay-shell.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import { OverlayShell } from "@youtube-automation/ui";
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const INITIAL_STATE = {
+  position: { x: 40, y: 50 },
+  minimized: false,
+  hidden: false,
+};
+
+function pointer(type: string, x: number, y: number): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    clientX: x,
+    clientY: y,
+  });
+}
+
+describe("OverlayShell runtime contract", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 768,
+      writable: true,
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    mounted = true;
+    unsubscribe = vi.fn();
+  });
+
+  afterEach(() => {
+    if (mounted) act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderShell({
+    title = "Overlay",
+    onStateChange = vi.fn(async () => undefined),
+    onError,
+    width,
+    brandColors,
+    initialState = INITIAL_STATE,
+  }: {
+    title?: ReactNode;
+    onStateChange?: (state: typeof INITIAL_STATE) => void | Promise<void>;
+    onError?: (error: unknown) => void;
+    width?: number;
+    brandColors?: {
+      headerBackground: string;
+      headerForeground: string;
+      primary?: string;
+      primaryForeground?: string;
+    };
+    initialState?: typeof INITIAL_STATE;
+  } = {}): Promise<void> {
+    await act(async () =>
+      root.render(
+        <OverlayShell
+          title={title}
+          initialState={initialState}
+          onStateChange={onStateChange}
+          subscribeToggle={() => unsubscribe}
+          onError={onError}
+          width={width}
+          brandColors={brandColors}
+        >
+          Body
+        </OverlayShell>
+      )
+    );
+  }
+
+  it("forwards writer rejection to onError and keeps the subscription cleanup", async () => {
+    const failure = new Error("storage write failed");
+    const onError = vi.fn();
+    const onStateChange = vi.fn(async () => {
+      throw failure;
+    });
+    await renderShell({ onStateChange, onError });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="最小化"]')!
+        .click();
+      await Promise.resolve();
+    });
+    expect(onStateChange).toHaveBeenCalledWith({
+      ...INITIAL_STATE,
+      minimized: true,
+    });
+    expect(onError).toHaveBeenCalledWith(failure);
+    act(() => root.unmount());
+    mounted = false;
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("applies custom width and each supplied partial brand CSS variable", async () => {
+    await renderShell({
+      width: 512,
+      brandColors: {
+        headerBackground: "#111111",
+        headerForeground: "#eeeeee",
+        primary: "#ff0000",
+      },
+    });
+    const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
+    expect(shell.style.width).toBe("512px");
+    expect(shell.style.getPropertyValue("--overlay-header-background")).toBe(
+      "#111111"
+    );
+    expect(shell.style.getPropertyValue("--overlay-header-foreground")).toBe(
+      "#eeeeee"
+    );
+    expect(shell.style.getPropertyValue("--primary")).toBe("#ff0000");
+    expect(shell.style.getPropertyValue("--primary-foreground")).toBe("");
+  });
+
+  it.each([
+    ["input", <input aria-label="interactive" key="input" />],
+    ["textarea", <textarea aria-label="interactive" key="textarea" />],
+    [
+      "contenteditable",
+      <span contentEditable aria-label="interactive" key="editable">
+        edit
+      </span>,
+    ],
+  ])(
+    "does not start a drag from an interactive %s target",
+    async (_name, title) => {
+      const onStateChange = vi.fn(async () => undefined);
+      await renderShell({ title, onStateChange });
+      const target = container.querySelector<HTMLElement>(
+        '[aria-label="interactive"]'
+      )!;
+
+      await act(async () => {
+        target.dispatchEvent(pointer("pointerdown", 50, 50));
+        window.dispatchEvent(pointer("pointermove", 200, 200));
+        window.dispatchEvent(pointer("pointerup", 200, 200));
+      });
+
+      expect(onStateChange).not.toHaveBeenCalled();
+      const shell = container.querySelector<HTMLElement>(
+        "[data-overlay-shell]"
+      )!;
+      expect(shell.style.left).toBe("40px");
+      expect(shell.style.top).toBe("50px");
+    }
+  );
+
+  it("clamps on viewport resize, persists the clamped position, and removes listeners on unmount", async () => {
+    const onStateChange = vi.fn(async () => undefined);
+    const addListener = vi.spyOn(window, "addEventListener");
+    const removeListener = vi.spyOn(window, "removeEventListener");
+    await renderShell({
+      onStateChange,
+      initialState: {
+        ...INITIAL_STATE,
+        position: { x: 700, y: 500 },
+      },
+    });
+    const shell = container.querySelector<HTMLElement>("[data-overlay-shell]")!;
+    shell.getBoundingClientRect = () =>
+      ({
+        x: 700,
+        y: 500,
+        top: 500,
+        left: 700,
+        right: 940,
+        bottom: 700,
+        width: 240,
+        height: 200,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 300,
+      writable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 240,
+      writable: true,
+    });
+    await act(async () => window.dispatchEvent(new Event("resize")));
+    expect(shell.style.left).toBe("60px");
+    expect(shell.style.top).toBe("40px");
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      ...INITIAL_STATE,
+      position: { x: 60, y: 40 },
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLElement>("[data-overlay-handle]")!
+        .dispatchEvent(pointer("pointerdown", 10, 10));
+    });
+    expect(addListener).toHaveBeenCalledWith(
+      "pointermove",
+      expect.any(Function)
+    );
+    expect(addListener).toHaveBeenCalledWith("pointerup", expect.any(Function));
+    act(() => root.unmount());
+    mounted = false;
+    expect(removeListener).toHaveBeenCalledWith(
+      "pointermove",
+      expect.any(Function)
+    );
+    expect(removeListener).toHaveBeenCalledWith(
+      "pointerup",
+      expect.any(Function)
+    );
+    expect(removeListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/distrokid-helper/tests/server-source-field.test.tsx
+++ b/extensions/distrokid-helper/tests/server-source-field.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+
+import {
+  SERVER_SOURCE_SELECT_EVENT,
+  ServerSourceField,
+} from "@youtube-automation/ui";
+import { act, createRef } from "react";
+import type React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useShadowPortalTriggerRef } from "../../shared-ui/src/use-shadow-portal-trigger-ref";
+
+const SOURCES = [
+  { id: "one", label: "One", url: "http://one.localhost:7873" },
+  { id: "two", label: "Two", url: "http://two.localhost:7873" },
+];
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (attempt === 19) throw error;
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 0)));
+    }
+  }
+}
+
+describe("ServerSourceField and Shadow portal ref", () => {
+  let host: HTMLDivElement;
+  let shadow: ShadowRoot;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.append(host);
+    shadow = host.attachShadow({ mode: "open" });
+    container = document.createElement("div");
+    shadow.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  async function renderField(
+    props: Partial<React.ComponentProps<typeof ServerSourceField>> = {}
+  ): Promise<void> {
+    await act(async () =>
+      root.render(
+        <ServerSourceField
+          value={SOURCES[0].url}
+          sources={SOURCES}
+          disabled={false}
+          helper="distrokid-helper"
+          onValueChange={vi.fn()}
+          onRefresh={vi.fn(async () => undefined)}
+          id="server-source"
+          {...props}
+        />
+      )
+    );
+  }
+
+  it("suppresses refresh reentry, recovers disabled state after reject, and portals into ShadowRoot", async () => {
+    const pending = deferred<void>();
+    const onRefresh = vi.fn(() => pending.promise);
+    await renderField({ onRefresh });
+    const trigger = shadow.querySelector<HTMLButtonElement>("#server-source")!;
+
+    await act(async () => {
+      trigger.click();
+      trigger.click();
+      await Promise.resolve();
+    });
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.textContent).toContain("更新中");
+
+    await act(async () => {
+      pending.reject(new Error("discovery failed"));
+      await pending.promise.catch(() => undefined);
+    });
+    await waitFor(() => expect(trigger.disabled).toBe(false));
+    await waitFor(() =>
+      expect(shadow.querySelectorAll('[role="option"]')).toHaveLength(2)
+    );
+    expect(document.body.querySelector('[role="option"]')).toBeNull();
+  });
+
+  it("suppresses equal and duplicate custom commits and honors disabled state", async () => {
+    const onValueChange = vi.fn();
+    await renderField({ onValueChange });
+    const field = shadow.querySelector<HTMLElement>('[data-slot="field"]')!;
+
+    await act(async () => {
+      field.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: SOURCES[0].url,
+        })
+      );
+      field.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: SOURCES[1].url,
+        })
+      );
+      field.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: SOURCES[1].url,
+        })
+      );
+    });
+    expect(onValueChange).toHaveBeenCalledOnce();
+    expect(onValueChange).toHaveBeenCalledWith(SOURCES[1].url);
+
+    await renderField({ onValueChange, disabled: true });
+    const disabledField = shadow.querySelector<HTMLElement>(
+      '[data-slot="field"]'
+    )!;
+    await act(async () => {
+      disabledField.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: SOURCES[0].url,
+        })
+      );
+    });
+    expect(onValueChange).toHaveBeenCalledOnce();
+    expect(
+      shadow.querySelector<HTMLButtonElement>("#server-source")!.disabled
+    ).toBe(true);
+  });
+
+  it("forwards callback/object refs, resolves the portal parent, and clears it on null", async () => {
+    const callbackRef = vi.fn();
+    const objectRef = createRef<HTMLButtonElement>();
+    const setContainer = vi.fn();
+
+    function RefProbe({
+      visible,
+      forwardedRef,
+    }: {
+      visible: boolean;
+      forwardedRef: React.Ref<HTMLButtonElement>;
+    }) {
+      const callback = useShadowPortalTriggerRef(forwardedRef, setContainer);
+      return visible ? (
+        <button ref={callback} type="button">
+          Trigger
+        </button>
+      ) : null;
+    }
+
+    await act(async () =>
+      root.render(<RefProbe visible forwardedRef={callbackRef} />)
+    );
+    const button = shadow.querySelector<HTMLButtonElement>("button")!;
+    expect(callbackRef).toHaveBeenCalledWith(button);
+    expect(setContainer).toHaveBeenCalledWith(container);
+
+    await act(async () =>
+      root.render(<RefProbe visible forwardedRef={objectRef} />)
+    );
+    expect(objectRef.current).toBe(button);
+
+    await act(async () =>
+      root.render(<RefProbe visible={false} forwardedRef={objectRef} />)
+    );
+    expect(callbackRef).toHaveBeenLastCalledWith(null);
+    expect(objectRef.current).toBeNull();
+    expect(setContainer).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/extensions/distrokid-helper/tests/setup.ts
+++ b/extensions/distrokid-helper/tests/setup.ts
@@ -10,13 +10,26 @@ import { fakeBrowser } from "wxt/testing/fake-browser";
 
 vi.stubGlobal("chrome", fakeBrowser);
 vi.stubGlobal("browser", fakeBrowser);
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+interface PointerEventWindow {
+  MouseEvent: typeof MouseEvent;
+  PointerEvent?: typeof PointerEvent;
+}
+
+export function installPointerEventFallback(target: PointerEventWindow): void {
+  if (target.PointerEvent) {
+    return;
+  }
+  Object.defineProperty(target, "PointerEvent", {
+    configurable: true,
+    value: target.MouseEvent,
+    writable: true,
+  });
+}
 
 // jsdom does not implement PointerEvent, while Base UI dispatches one through
 // hidden native form controls to preserve browser form semantics.
-if (typeof window !== "undefined" && !window.PointerEvent) {
-  Object.defineProperty(window, "PointerEvent", {
-    configurable: true,
-    value: window.MouseEvent,
-    writable: true,
-  });
+if (typeof window !== "undefined") {
+  installPointerEventFallback(window);
 }

--- a/extensions/distrokid-helper/tests/shared-primitives-runtime.test.tsx
+++ b/extensions/distrokid-helper/tests/shared-primitives-runtime.test.tsx
@@ -1,0 +1,326 @@
+// @vitest-environment jsdom
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldTitle,
+  Input,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+  ScrollArea,
+  Switch,
+} from "@youtube-automation/ui";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("shared UI runtime primitives", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("mounts Card sm/stack and every public slot with native props", async () => {
+    await act(async () =>
+      root.render(
+        <Card size="sm" id="card" aria-label="release card">
+          <CardHeader layout="stack">
+            <CardTitle>Title</CardTitle>
+            <CardDescription>Description</CardDescription>
+            <CardAction>Action</CardAction>
+          </CardHeader>
+          <CardContent>Content</CardContent>
+          <CardFooter>Footer</CardFooter>
+        </Card>
+      )
+    );
+
+    const card = container.querySelector<HTMLElement>("#card")!;
+    expect(card.dataset.size).toBe("sm");
+    expect(card.getAttribute("aria-label")).toBe("release card");
+    expect(
+      card.querySelector<HTMLElement>('[data-slot="card-header"]')!.dataset
+        .layout
+    ).toBe("stack");
+    for (const slot of [
+      "card-title",
+      "card-description",
+      "card-action",
+      "card-content",
+      "card-footer",
+    ]) {
+      expect(card.querySelector(`[data-slot="${slot}"]`)).not.toBeNull();
+    }
+  });
+
+  it("mounts Empty media/slots and Field orientation/error branches", async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <Empty data-probe="empty">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">◎</EmptyMedia>
+              <EmptyTitle>Nothing here</EmptyTitle>
+              <EmptyDescription>Description</EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>Action</EmptyContent>
+          </Empty>
+          <Field orientation="horizontal" data-invalid="true">
+            <FieldLabel htmlFor="native-input">Label</FieldLabel>
+            <FieldContent>
+              <FieldTitle>Field title</FieldTitle>
+              <FieldDescription>Field description</FieldDescription>
+              <FieldError
+                errors={[
+                  { message: "Required" },
+                  { message: "Required" },
+                  { message: "Invalid" },
+                ]}
+              />
+            </FieldContent>
+          </Field>
+        </>
+      )
+    );
+
+    const empty = container.querySelector<HTMLElement>('[data-slot="empty"]')!;
+    expect(empty.dataset.probe).toBe("empty");
+    expect(
+      empty.querySelector<HTMLElement>('[data-slot="empty-icon"]')!.dataset
+        .variant
+    ).toBe("icon");
+    for (const slot of [
+      "empty-header",
+      "empty-title",
+      "empty-description",
+      "empty-content",
+    ]) {
+      expect(empty.querySelector(`[data-slot="${slot}"]`)).not.toBeNull();
+    }
+    const field = container.querySelector<HTMLElement>('[data-slot="field"]')!;
+    expect(field.dataset.orientation).toBe("horizontal");
+    expect(field.dataset.invalid).toBe("true");
+    expect(field.querySelector('[role="alert"]')?.textContent).toBe(
+      "RequiredInvalid"
+    );
+  });
+
+  it("passes native Input and Label props and preserves label association", async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <Label htmlFor="email" title="Email label" className="custom-label">
+            Email
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            disabled
+            aria-invalid="true"
+            maxLength={32}
+            data-probe="input"
+          />
+        </>
+      )
+    );
+    const label = container.querySelector<HTMLLabelElement>("label")!;
+    const input = container.querySelector<HTMLInputElement>("input")!;
+    expect(label.htmlFor).toBe("email");
+    expect(label.title).toBe("Email label");
+    expect(label.classList).toContain("custom-label");
+    expect(input.type).toBe("email");
+    expect(input.disabled).toBe(true);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.maxLength).toBe(32);
+    expect(input.dataset.probe).toBe("input");
+  });
+
+  it("mounts Checkbox checked/indeterminate/disabled states and indicator", async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <Checkbox aria-label="normal checkbox" />
+          <Checkbox aria-label="mixed checkbox" indeterminate disabled />
+        </>
+      )
+    );
+    const normal = container.querySelector<HTMLElement>(
+      '[aria-label="normal checkbox"]'
+    )!;
+    const mixed = container.querySelector<HTMLElement>(
+      '[aria-label="mixed checkbox"]'
+    )!;
+    await act(async () => normal.click());
+    expect(normal.hasAttribute("data-checked")).toBe(true);
+    expect(
+      normal.querySelector('[data-slot="checkbox-indicator"]')
+    ).not.toBeNull();
+    expect(mixed.hasAttribute("data-indeterminate")).toBe(true);
+    expect(mixed.hasAttribute("data-disabled")).toBe(true);
+    await act(async () => mixed.click());
+    expect(mixed.hasAttribute("data-indeterminate")).toBe(true);
+  });
+
+  it("opens and closes Collapsible through its mounted trigger and panel", async () => {
+    await act(async () =>
+      root.render(
+        <Collapsible>
+          <CollapsibleTrigger>Toggle details</CollapsibleTrigger>
+          <CollapsibleContent>Panel content</CollapsibleContent>
+        </Collapsible>
+      )
+    );
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-slot="collapsible-trigger"]'
+    )!;
+    expect(
+      container.querySelector('[data-slot="collapsible-content"]')
+    ).toBeNull();
+    await act(async () => trigger.click());
+    expect(
+      container.querySelector('[data-slot="collapsible-content"]')?.textContent
+    ).toBe("Panel content");
+    await act(async () => trigger.click());
+    expect(
+      container.querySelector('[data-slot="collapsible-content"]')
+    ).toBeNull();
+  });
+
+  it("mounts RadioGroup selection/disabled/invalid/indicator states", async () => {
+    const onValueChange = vi.fn();
+    await act(async () =>
+      root.render(
+        <RadioGroup
+          defaultValue="a"
+          onValueChange={onValueChange}
+          aria-invalid="true"
+        >
+          <RadioGroupItem value="a" aria-label="A" />
+          <RadioGroupItem value="b" aria-label="B" disabled />
+          <RadioGroupItem value="c" aria-label="C" />
+        </RadioGroup>
+      )
+    );
+    const a = container.querySelector<HTMLElement>('[aria-label="A"]')!;
+    const b = container.querySelector<HTMLElement>('[aria-label="B"]')!;
+    const c = container.querySelector<HTMLElement>('[aria-label="C"]')!;
+    expect(a.hasAttribute("data-checked")).toBe(true);
+    expect(
+      a.querySelector('[data-slot="radio-group-indicator"]')
+    ).not.toBeNull();
+    expect(b.hasAttribute("data-disabled")).toBe(true);
+    await act(async () => b.click());
+    expect(a.hasAttribute("data-checked")).toBe(true);
+    await act(async () => c.click());
+    expect(c.hasAttribute("data-checked")).toBe(true);
+    expect(onValueChange).toHaveBeenLastCalledWith(
+      "c",
+      expect.objectContaining({ reason: expect.anything() })
+    );
+    expect(
+      container
+        .querySelector('[data-slot="radio-group"]')
+        ?.getAttribute("aria-invalid")
+    ).toBe("true");
+  });
+
+  it("mounts ScrollArea viewport, vertical/horizontal scrollbars, thumbs, and corner", async () => {
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(100);
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(100);
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(200);
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(200);
+    await act(async () =>
+      root.render(
+        <ScrollArea
+          scrollbars="both"
+          viewportClassName="viewport-probe"
+          aria-label="scroll area"
+        >
+          <div style={{ width: 1000, height: 1000 }}>Scrollable</div>
+        </ScrollArea>
+      )
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(
+      container.querySelector('[data-slot="scroll-area-viewport"]')?.classList
+    ).toContain("viewport-probe");
+    expect(
+      container.querySelectorAll('[data-slot="scroll-area-scrollbar"]')
+    ).toHaveLength(2);
+    expect(
+      container.querySelector(
+        '[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]'
+      )
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[data-slot="scroll-area-scrollbar"][data-orientation="horizontal"]'
+      )
+    ).not.toBeNull();
+    expect(
+      container.querySelectorAll('[data-slot="scroll-area-thumb"]')
+    ).toHaveLength(2);
+    expect(
+      container.querySelector('[data-slot="scroll-area-corner"]')
+    ).not.toBeNull();
+  });
+
+  it("mounts Switch checked/disabled/size/thumb and toggles only enabled state", async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <Switch aria-label="normal switch" size="sm" />
+          <Switch aria-label="disabled switch" checked disabled />
+        </>
+      )
+    );
+    const normal = container.querySelector<HTMLElement>(
+      '[aria-label="normal switch"]'
+    )!;
+    const disabled = container.querySelector<HTMLElement>(
+      '[aria-label="disabled switch"]'
+    )!;
+    expect(normal.dataset.size).toBe("sm");
+    expect(normal.querySelector('[data-slot="switch-thumb"]')).not.toBeNull();
+    await act(async () => normal.click());
+    expect(normal.hasAttribute("data-checked")).toBe(true);
+    expect(disabled.hasAttribute("data-checked")).toBe(true);
+    expect(disabled.hasAttribute("data-disabled")).toBe(true);
+    await act(async () => disabled.click());
+    expect(disabled.hasAttribute("data-checked")).toBe(true);
+  });
+});

--- a/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
+++ b/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
@@ -388,6 +388,23 @@ describe("useDistrokidRunner", () => {
     expect(sendMessage).toHaveBeenCalledWith("stop");
   });
 
+  it("stop relay reject: error phase/message を表示して busy を解除する", async () => {
+    stubDirModeServer();
+    await fetchDirModeRelease();
+    vi.mocked(sendMessage).mockRejectedValueOnce(
+      new Error("stop relay unavailable")
+    );
+
+    await act(async () => {
+      await current.stop();
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("stop");
+    expect(current.phase).toBe("error");
+    expect(current.message).toBe("stop relay unavailable");
+    expect(current.busy).toBe(false);
+  });
+
   it("inject: 完了後に配信済み記録を POST し、一覧を再取得して配信済み disc を除外する", async () => {
     stubDirModeServer();
     await fetchDirModeRelease();

--- a/extensions/distrokid-helper/vitest.config.ts
+++ b/extensions/distrokid-helper/vitest.config.ts
@@ -2,6 +2,10 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
 
+const rootUrl = new URL(".", import.meta.url);
+const rootPath =
+  rootUrl.protocol === "file:" ? fileURLToPath(rootUrl) : rootUrl.pathname;
+
 // unit テスト（tests/**/*.test.{ts,tsx}）専用。E2E（tests/e2e）は Playwright が担う。
 //
 // setupFiles で fakeBrowser を chrome/browser グローバルへ注入し、
@@ -12,7 +16,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
-      "@": fileURLToPath(new URL(".", import.meta.url)),
+      "@": rootPath,
     },
     dedupe: ["react", "react-dom", "@base-ui/react"],
   },

--- a/extensions/shared-ui/src/overlay-shell.tsx
+++ b/extensions/shared-ui/src/overlay-shell.tsx
@@ -46,11 +46,9 @@ function getOverlayBrandStyle(
   return {
     "--overlay-header-background": brandColors.headerBackground,
     "--overlay-header-foreground": brandColors.headerForeground,
-    ...(brandColors.primary && brandColors.primaryForeground
-      ? {
-          "--primary": brandColors.primary,
-          "--primary-foreground": brandColors.primaryForeground,
-        }
+    ...(brandColors.primary ? { "--primary": brandColors.primary } : {}),
+    ...(brandColors.primaryForeground
+      ? { "--primary-foreground": brandColors.primaryForeground }
       : {}),
   };
 }

--- a/extensions/shared-ui/src/scroll-area.tsx
+++ b/extensions/shared-ui/src/scroll-area.tsx
@@ -5,12 +5,14 @@ import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 import { cn } from "./utils";
 
 type ScrollAreaProps = ScrollAreaPrimitive.Root.Props & {
+  scrollbars?: "vertical" | "horizontal" | "both";
   viewportClassName?: string;
 };
 
 function ScrollArea({
   className,
   children,
+  scrollbars = "vertical",
   viewportClassName,
   ...props
 }: ScrollAreaProps) {
@@ -29,14 +31,20 @@ function ScrollArea({
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
-      <ScrollAreaPrimitive.Corner />
+      {scrollbars === "vertical" || scrollbars === "both" ? (
+        <ScrollBar />
+      ) : null}
+      {scrollbars === "horizontal" || scrollbars === "both" ? (
+        <ScrollBar orientation="horizontal" />
+      ) : null}
+      <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
     </ScrollAreaPrimitive.Root>
   );
 }
 
 function ScrollBar({
   className,
+  keepMounted = true,
   orientation = "vertical",
   ...props
 }: ScrollAreaPrimitive.Scrollbar.Props) {
@@ -44,6 +52,7 @@ function ScrollBar({
     <ScrollAreaPrimitive.Scrollbar
       data-slot="scroll-area-scrollbar"
       data-orientation={orientation}
+      keepMounted={keepMounted}
       orientation={orientation}
       className={cn(
         "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",

--- a/extensions/shared-ui/src/server-source-field.tsx
+++ b/extensions/shared-ui/src/server-source-field.tsx
@@ -50,6 +50,7 @@ export function ServerSourceField({
   const fieldRef = React.useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = React.useState(false);
   const [refreshing, setRefreshing] = React.useState(false);
+  const refreshingRef = React.useRef(false);
   const disabledRef = React.useRef(disabled);
   React.useEffect(() => {
     disabledRef.current = disabled;
@@ -63,17 +64,21 @@ export function ServerSourceField({
       setOpen(false);
       return;
     }
-    if (disabledRef.current || refreshing) {
+    if (disabledRef.current || refreshingRef.current) {
       return;
     }
     setOpen(false);
+    refreshingRef.current = true;
     setRefreshing(true);
-    void onRefresh().finally(() => {
-      setRefreshing(false);
-      if (!disabledRef.current) {
-        setOpen(true);
-      }
-    });
+    void onRefresh()
+      .catch(() => undefined)
+      .finally(() => {
+        refreshingRef.current = false;
+        setRefreshing(false);
+        if (!disabledRef.current) {
+          setOpen(true);
+        }
+      });
   };
 
   const items = sources.map((source) => ({
@@ -94,13 +99,13 @@ export function ServerSourceField({
         nextValue &&
         nextValue !== committedValueRef.current &&
         !disabledRef.current &&
-        !refreshing
+        !refreshingRef.current
       ) {
         committedValueRef.current = nextValue;
         onValueChange(nextValue);
       }
     },
-    [onValueChange, refreshing]
+    [onValueChange]
   );
   React.useEffect(() => {
     const field = fieldRef.current;

--- a/extensions/shared-ui/src/use-draggable.ts
+++ b/extensions/shared-ui/src/use-draggable.ts
@@ -16,13 +16,13 @@ export interface UseDraggableResult {
 }
 
 function isInteractive(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!(target instanceof Element)) {
     return false;
   }
   return (
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.isContentEditable
+    target.closest(
+      'a[href],button,input,select,textarea,[contenteditable]:not([contenteditable="false"]),[role="button"],[role="link"]'
+    ) !== null
   );
 }
 

--- a/extensions/shared-ui/src/use-shadow-portal-trigger-ref.ts
+++ b/extensions/shared-ui/src/use-shadow-portal-trigger-ref.ts
@@ -13,9 +13,7 @@ export function useShadowPortalTriggerRef<T extends HTMLElement>(
       } else if (forwardedRef) {
         forwardedRef.current = node;
       }
-      if (node) {
-        setContainer?.(node.parentElement);
-      }
+      setContainer?.(node?.parentElement ?? null);
     },
     [forwardedRef, setContainer]
   );

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -4275,9 +4275,9 @@ describe("Suno popup compatibility check", () => {
     );
   });
 
-  it("should ignore an older discovery completion", async () => {
-    const older = deferred<Array<{ id: string; label: string; url: string }>>();
-    const newer = deferred<Array<{ id: string; label: string; url: string }>>();
+  it("should suppress a second discovery while the first refresh is pending", async () => {
+    const pending =
+      deferred<Array<{ id: string; label: string; url: string }>>();
     let refreshCount = 0;
     messagingMocks.sendMessage.mockImplementation(
       (message: string, payload?: Record<string, string>) => {
@@ -4286,7 +4286,7 @@ describe("Suno popup compatibility check", () => {
           if (refreshCount === 1) {
             return Promise.resolve([]);
           }
-          return refreshCount === 2 ? older.promise : newer.promise;
+          return pending.promise;
         }
         return defaultSendMessage(message, payload);
       }
@@ -4300,8 +4300,10 @@ describe("Suno popup compatibility check", () => {
       ) as HTMLButtonElement;
       trigger.click();
       trigger.click();
+      await Promise.resolve();
     });
-    newer.resolve([
+    expect(refreshCount).toBe(2);
+    pending.resolve([
       { id: "new", label: "New", url: "http://new.localhost:49152" },
     ]);
     await waitFor(() =>
@@ -4309,14 +4311,7 @@ describe("Suno popup compatibility check", () => {
         "http://new.localhost:49152"
       )
     );
-    older.resolve([
-      { id: "old", label: "Old", url: "http://old.localhost:9001" },
-    ]);
-    await act(async () => Promise.resolve());
-    expect(select.dataset.sourceValues).toContain("http://new.localhost:49152");
-    expect(select.dataset.sourceValues).not.toContain(
-      "http://old.localhost:9001"
-    );
+    expect(refreshCount).toBe(2);
   });
 
   it("should discard a deferred discovery result when a run starts", async () => {


### PR DESCRIPTION
## 概要

GitHub audit scope16 の Community Helper / DistroKid Helper / shared-ui 20 findings を、共有挙動を分割せず1 PRへ統合しました。

- cleanup / stop / storage / fetch relay / injection の失敗を後続副作用なしで扱う境界を直接検証
- ShadowRoot entrypoint・portal・公開 UI primitive を jsdom への実 mount で検証
- track UUID 不一致、background non-GET、refresh 同一tick再入、partial brand、interactive drag、viewport clamp などの不足実装を修正
- Vitest / Playwright 設定・setup副作用・生成manifest最小権限を実行経路で検証

## 20 leaf 対応表

| Finding | Issue | 実装・直接回帰 | 状態 |
|---|---:|---|---|
| F-001 | #2926 | Community cleanup rejectをreconciliation必須・後続副作用なしで固定 | passed |
| F-002 | #2927 | 空URL、未知status、stop reject、message購読解除、UI/payloadを実mount | passed |
| F-003 | #2928 | Community storage read/write rejectとShadow mount/render/unmount | passed |
| F-004 | #2929 | profile null/欠落/配列envelopeをAPI境界で拒否 | passed |
| F-005 | #2930 | stop relay reject後のerror/message/busy解除 | passed |
| F-006 | #2931 | DistroKid storage read/write reject、購読解除、Shadow lifecycle | passed |
| F-007 | #2932 | exact handler/payload/progress順序と全reject伝播 | passed |
| F-008 | #2933 | UUID数検証をfield注入前へ移動し部分変更を抑止 | passed |
| F-009 | #2934 | redirect:`error`、asset 404/500、loopback allowlist境界 | passed |
| F-010 | #2935 | non-GET拒否、string/URL/Request正規化、Response wire、asset relay | passed |
| F-011 | #2936 | 各inject/fetch/send reject後の後続message/副作用なし | passed |
| F-012 | #2937 | start/static/AI/finish失敗後のphase/payload/再実行状態 | passed |
| F-013 | #2938 | 両Vitest setup/include/exclude/alias/dedupe、Playwright chromium/list | passed |
| F-014 | #2939 | AlertDialogをShadowRootへ実portalしopen/close/action/cancel/props検証 | passed |
| F-015 | #2940 | Card/Checkbox/Collapsible/Empty/Field/Input/Labelを実mount | passed |
| F-016 | #2941 | contrast 21/1、対称性、不正hex拒否 | passed |
| F-017 | #2942 | OverlayShell writer reject/onError、width、partial brand CSS vars | passed |
| F-018 | #2943 | RadioGroup/ScrollArea/Switchの状態・indicator・縦横/cornerを実mount | passed |
| F-019 | #2944 | refresh reject/再入/disabled/重複抑止、ref/null、Shadow portal | passed |
| F-020 | #2945 | interactive除外、resize clamp、listener cleanup、保存reject/onError | passed |

failed: 0 / blocked: 0

## 赤 → 緑

- F-008: UUID不一致でもprofile field（band name）が変更される赤を再現し、UUID整合検証を全field注入前へ移動して緑化
- F-018: 横scrollbar/cornerが実mountされない赤を再現し、orientation選択とmounted scrollbar契約を追加して緑化
- F-019: 同一tickのrefresh二重clickで`onRefresh`が2回走る赤を再現し、同期ref lockで緑化
- その他17 findings: 監査時点で直接実行可能な回帰が存在しないcoverage-redを、reject/DOM/lifecycle/config seamの実テストとして追加

## 検証

固定経路: `nix develop .#extensions`（Node 24.18.0 / pnpm 11.15.1）

- Community direct: 25 passed
- DistroKid/shared-ui direct: 127 passed
- Community full Vitest: 63 passed
- DistroKid full Vitest: 344 passed
- Community Playwright: `--list --project=chromium` 1件、E2E 1 passed
- DistroKid Playwright: `--list --project=chromium` 8件、E2E 8 passed
- Community / DistroKid: frozen install、check、compile、build passed
- shared-ui: frozen install、check、compile passed
- generated manifest permissions / host_permissions / content matches: 両helper passed
- Fallow changed-file audit: new error 0（既存由来を除外、warnのみ）
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: 674 files formatted
- unit-only全pytest: 7,357 passed / 1 skipped
- Any usage gate: passed
- `git diff --check`: passed

資格情報不要のreject・不正shape・404/500・DOM不一致・storage失敗・listener cleanup経路をローカルで実証済みです。

Closes #2946
Closes #2926
Closes #2927
Closes #2928
Closes #2929
Closes #2930
Closes #2931
Closes #2932
Closes #2933
Closes #2934
Closes #2935
Closes #2936
Closes #2937
Closes #2938
Closes #2939
Closes #2940
Closes #2941
Closes #2942
Closes #2943
Closes #2944
Closes #2945

## CI fix rounds

1. Extensions集約checkで、F-019のrefresh再入抑止とSuno既存consumerテストの同一tick二重refresh期待が競合。consumer契約を再入抑止へ更新し、Suno focused 73 / full 1,341 tests、全consumer compile/checkをgreen化（production追加変更なし）。