### PR TITLE
fix(automation-release): リリース前検証の誤検出 2 件を解消する

### DIFF
--- a/.claude/skills/automation-release/SKILL.md
+++ b/.claude/skills/automation-release/SKILL.md
@@ -95,7 +95,7 @@ open_release_branch=$(git ls-remote --heads origin "release/v*" | head -1)
 
 `CHANGELOG.md::[Unreleased]` の内容を読み、semver bump 種別を提案する:
 
-- `### Removed` 有り、または本文中に `BREAKING` / `破壊的変更` 記述 → **major**
+- `### Removed` 有り、または本文中に `BREAKING` / `破壊的変更` 記述 → **major**（検索は **大小文字を問わない**。`**Breaking:**` / `breaking(scope):` 表記を取りこぼさないこと）
 - `### Added` 有り → **minor**
 - `### Fixed` のみ（または `### Changed` のみで挙動変更が patch レベル）→ **patch**
 
@@ -449,6 +449,8 @@ Asset: <name>-<VER>-chrome.zip
 - **`pnpm install --frozen-lockfile` の失敗**: version bump 自体では lockfile は乖離しない。失敗＝依存差分の混入なので、リリースとは切り離して lockfile 同期の修正 PR を先に main へ入れる
 - **ext-v tag 系列と package.json 版数の乖離**: `ext-v*` は3拡張共通の単一系列のため、bump 対象の拡張によっては tag 版数と package.json 版数がずれる（前例: `ext-v0.2.3` で distrokid-helper 0.2.1）。Release asset 名は package.json 版数に従う（E0 の「tag 版数の決定」参照）
 - **Chrome 拡張の pnpm 版数乖離**: ambient pnpm の版は各環境で異なり得る。prepare Phase 1-6 の Nix extensions shell（Node 24 / pnpm 11.15.1）で3拡張を検証し、期待 zip と lockfile 無差分を確認する
+- **`.output/` のビルド残骸で verify が誤 FAIL**: `verify-extensions.sh` は zip が「期待名の唯一 1 件」であることを検証するため、過去 run の zip（`<name>-<旧版数>-chrome.zip`）が `.output/` に残っていると `expected exactly one zip ... found N` で停止する。原因はリポジトリ側ではなくローカルのビルド成果物（gitignore 済み）。スクリプトが zip 生成前に `.output/*.zip` を掃除するので通常は起きないが、手動で `pnpm zip` を先に走らせた場合は掃除してから再実行する
+- **verify を `| tail` 等へパイプすると exit code を見失う**: `bash verify-extensions.sh | tail -60` の `$?` はパイプ末尾（`tail`）の値になり、スクリプトが `exit 1` していても 0 に見える。Hard Gate の「exit 0 を必須」を満たすには、パイプせずに実行するか `${PIPESTATUS[0]}` を評価する
 
 ## Rules
 

--- a/.claude/skills/automation-release/references/extension-release-checklist.md
+++ b/.claude/skills/automation-release/references/extension-release-checklist.md
@@ -33,6 +33,10 @@ bash .claude/skills/automation-release/references/verify-extensions.sh <name>
 
 検証ロジックとPASS/FAIL条件は `verify-extensions.sh` が単一ソース。`pnpm install --frozen-lockfile` → `pnpm build` → `pnpm zip`、対象拡張の期待名 zip が唯一の1件であること、対象 lockfile に差分がないことを検証する。non-zeroなら出力された原因を解消するまでabort。
 
+「唯一の1件」判定は今回の run が生成した zip だけを対象にする必要があるため、スクリプトは `pnpm zip` の直前に `.output/*.zip` を削除する（`.output/` は gitignore 済みのビルド成果物で `pnpm zip` が再生成する）。過去 run の zip を残したまま判定すると `expected exactly one zip ... found N` で誤 abort する。
+
+なお exit code をパイプ越しに読まないこと。`bash verify-extensions.sh | tail -60` の `$?` は `tail` の値になり、スクリプトの `exit 1` が 0 に見える。
+
 ### 4. 開いている release/ext-v* ブランチが無い
 
 ```bash

--- a/.claude/skills/automation-release/references/verify-extensions.sh
+++ b/.claude/skills/automation-release/references/verify-extensions.sh
@@ -40,6 +40,10 @@ for name in "${extension_names[@]}"; do
   extension_dir="extensions/${name}"
   nix develop .#extensions --command pnpm -C "${extension_dir}" install --frozen-lockfile
   nix develop .#extensions --command pnpm -C "${extension_dir}" build
+  # 過去 run の zip が残っていると下の「唯一の1件」判定が誤 FAIL する。
+  # .output/ は gitignore 済みのビルド成果物で pnpm zip が再生成するため、
+  # 判定対象を今回の run が生成した zip だけに揃えてから zip する。
+  rm -f "${extension_dir}/.output"/*.zip
   nix develop .#extensions --command pnpm -C "${extension_dir}" zip
 
   version=$(nix develop .#extensions --command node -p "require('./${extension_dir}/package.json').version")

--- a/.claude/skills/automation-release/references/version-rules.md
+++ b/.claude/skills/automation-release/references/version-rules.md
@@ -13,6 +13,8 @@
   ├─ ### Removed セクション あり
   │    → major bump
   ├─ 本文中に "BREAKING" / "破壊的変更" / "後方互換性無し" / "API 削除" 記述
+  │    （大小文字を問わない。本リポジトリでは "**Breaking:**" と
+  │      "breaking(scope):" の 2 表記が実際に使われている）
   │    → major bump
   ├─ ### Added セクション あり
   │    → minor bump
@@ -108,8 +110,8 @@ prepare Phase 1-1 で Unreleased 内容を判定するときの実装ヒント:
 # Unreleased セクション本文を抽出
 unreleased=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
 
-# major 判定
-if echo "$unreleased" | grep -qE "^### Removed|BREAKING|破壊的変更|後方互換性無し"; then
+# major 判定（-i 必須: "**Breaking:**" / "breaking(scope):" 表記を取りこぼさない）
+if echo "$unreleased" | grep -qiE "^### Removed|BREAKING|破壊的変更|後方互換性無し"; then
   bump="major"
 # minor 判定
 elif echo "$unreleased" | grep -qE "^### Added|^### Deprecated"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fix(automation-release)`: リリース前検証の誤検出 2 件を解消した。`verify-extensions.sh` は `pnpm zip` の直前に `.output/*.zip` を掃除し、過去 run のビルド残骸によって「期待名 zip が唯一の1件」判定が `expected exactly one zip ... found N` で誤 FAIL しないようにする（判定の意図である「今回の run が期待名の zip だけを生成した」ことの検証力は維持する。`release-extensions.yml` が `.output/*.zip` を glob で Release asset へ上げるため、期待名以外の成果物を公開前に止める必要があるという本来の目的に合わせ、回帰テストも「事前残骸は掃除されて成功する」「zip コマンドが余分な成果物を生んだら停止する」の 2 本へ分けた）。あわせて semver 判定の BREAKING 検出を大小文字非依存（`grep -qiE`）にし、本リポジトリで実際に使われる `**Breaking:**` / `breaking(scope):` 表記の取りこぼしを解消した。v5.6.0 の prepare で破壊的変更 6 件を検出できず minor と提案した事象への対策。`.output/` 残骸・パイプ越しの exit code 誤読という 2 つの落とし穴も SKILL.md の Gotchas と extension checklist へ明文化した。
+
 ## [5.6.0] - 2026-07-31
 
 - `chore(takt)`: takt 0.54.1 追随 — 0.53 で既定 off になった Codex Skill 継承（`.agents/skills` の repo スコープ）を yt-auto-* 全 workflow で復元し、builtin 準拠の fix-report 契約（`instruction: fix` の 2 step）・`session: compact`（yt-auto-audit の台帳拡張 step）・final-gate タグルーティング（最終関門のみ Sol へ）・`use-relevant-skills` partial（実装系 4 instruction）を導入した（#2686）。

--- a/tests/test_verify_extensions_script.py
+++ b/tests/test_verify_extensions_script.py
@@ -53,6 +53,9 @@ if [[ ${4:-} == pnpm ]]; then
   if [[ ${command} == zip && ${FAKE_SKIP_ZIP:-} != "${name}" ]]; then
     mkdir -p "${extension_dir}/.output"
     : > "${extension_dir}/.output/${name}-1.2.3-chrome.zip"
+    if [[ ${FAKE_EXTRA_ZIP:-} == "${name}" ]]; then
+      : > "${extension_dir}/.output/${name}-sources.zip"
+    fi
   fi
   exit 0
 fi
@@ -174,15 +177,33 @@ def test_verification_rejects_missing_zip(
 def test_verification_rejects_extra_zip(
     verify_environment: tuple[Path, dict[str, str], Path],
 ) -> None:
+    # release-extensions.yml は .output/*.zip を glob で Release asset へ上げるため、
+    # zip コマンドが期待名以外の成果物を生んだ場合は公開前に停止する必要がある。
+    result = _run_verify(
+        verify_environment,
+        "suno-helper",
+        environment_overrides={"FAKE_EXTRA_ZIP": "suno-helper"},
+    )
+
+    assert result.returncode != 0
+    assert "found 2" in result.stderr
+
+
+def test_verification_cleans_stale_zip_before_zipping(
+    verify_environment: tuple[Path, dict[str, str], Path],
+) -> None:
+    # 過去 run のビルド残骸（gitignore 済みで pnpm zip が再生成する）は
+    # 唯一性判定の対象外。掃除した上で今回の生成物だけを検証する。
     repository = verify_environment[0]
     output_dir = repository / "extensions/suno-helper/.output"
     output_dir.mkdir(parents=True)
     (output_dir / "stale.zip").touch()
+    (output_dir / "suno-helper-0.0.1-chrome.zip").touch()
 
     result = _run_verify(verify_environment, "suno-helper")
 
-    assert result.returncode != 0
-    assert "found 2" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert sorted(path.name for path in output_dir.glob("*.zip")) == ["suno-helper-1.2.3-chrome.zip"]
 
 
 def test_verification_rejects_lockfile_diff(


### PR DESCRIPTION
## Summary

v5.6.0 の prepare（#3023）で実際に踏んだ `/automation-release` の検出バグ 2 件を解消する。

### 1. `verify-extensions.sh` がローカルのビルド残骸で誤 FAIL する

`.output/*.zip` が「期待名の唯一 1 件」であることを検証するが、過去 run の zip が残っていると `expected exactly one zip ... found N` で停止していた。今回は `suno-helper-0.1.0` / `0.2.1` / `test-pr-1348-0.2.0` の 3 件が残っており、リリースが実際にブロックされた。

`pnpm zip` の直前に `.output/*.zip` を掃除する方式で解消した。**判定自体は緩めていない** — 「唯一の 1 件」チェックは「今回の run が期待名の zip *だけ* を生成した」ことの検証であり、WXT が予期しない追加成果物を吐いた場合の検出力を保つ必要があるため、判定を緩めるのではなく判定の前提（対象が今回の生成物だけであること）を成立させた。

### 2. semver 判定の BREAKING 検出が小文字表記を取りこぼす

`grep -qE "...|BREAKING|..."` が大文字のみを見ており、本リポジトリの CHANGELOG で実際に使われる 2 表記を拾えていなかった:

- `**Breaking:**`（Keep a Changelog 慣習）
- `breaking(scope):`（Conventional Commits 慣習）

このため v5.6.0 の prepare で破壊的変更 6 件（#1948 / #2305 / #2304 / #2400 / #2477-2478 / #2023）を検出できず、minor を提案していた。`grep -qiE` へ変更し、フローチャートと SKILL.md 側の記述にも「大小文字を問わない」旨を明記した。

### あわせて明文化した落とし穴

- `.output/` 残骸による誤 FAIL とその復旧（SKILL.md Gotchas / extension checklist）
- `bash verify-extensions.sh | tail -60` の `$?` は `tail` の値になり、スクリプトの `exit 1` が 0 に見える。Hard Gate の「exit 0 必須」を満たすにはパイプせず実行するか `${PIPESTATUS[0]}` を評価する

## 検証

**1. grep 修正の回帰**（main の `[Unreleased]` 427 行 = v5.6.0 へ昇格した内容と同一を対象）

| | 結果 |
|---|---|
| 旧 `grep -qE` | major と判定されず（← 今回の取りこぼし） |
| 新 `grep -qiE` | major と判定（← 修正で検出） |

拾えるようになった行: `breaking(refactor/domains): Suno 14旧 utils.suno_* ...`（#2305）、`**Breaking:** benchmark 系 CLI の競合 slug 指定を --channel から --competitor へ ...`（#1948）

**2. zip 残骸下での verify**（community-helper で実行）

`community-helper-0.0.1-chrome.zip` と期待名と異なる `stale-sources.zip` を仕込んだ状態で実行:

- `VERIFY_EXIT=0`（修正前なら `found 3` で FAIL）
- 実行後の `.output/` は正しい `community-helper-0.1.0-chrome.zip` の 1 件のみ

**3. その他**

- `bash -n` 構文チェック: pass
- `uv run yt-skills lint automation-release`: 合格
- `pytest tests/test_changelog_ci_contract.py tests/test_skill_docs_consistency.py`: 77 passed

## Stack

`chore(release): v5.6.0`（#3023）の上に積んでいる。両者とも `CHANGELOG.md` の `## [Unreleased]` 直後を触るため、main ベースだと確実にコンフリクトするのが理由。本 PR の CHANGELOG エントリは v5.6.0 昇格後の `[Unreleased]` に入るため、この修正は次回リリースに乗る。
