### PR TITLE
chore(extensions): ext-v0.3.0

### DIFF
--- a/extensions/community-helper/package.json
+++ b/extensions/community-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "community-helper",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "description": "YouTube コミュニティ投稿スケジュール Chrome 拡張 (WXT + React)",
   "type": "module",

--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distrokid-helper",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "description": "DistroKid 登録フォーム自動入力 Chrome 拡張 (WXT + React)",
   "type": "module",

--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "private": true,
   "description": "/suno が生成した Style/Lyrics を Suno の Advanced タブに順次注入し Generate を連続実行する補助拡張 (WXT + React + TS)。",
   "type": "module",


### PR DESCRIPTION
## Summary

`ext-v0.3.0` のリリース PR。前回 tag `ext-v0.2.5`（2026-07-10）以降、3 拡張すべてに未リリース差分が蓄積していたため、3 拡張の `package.json::version` を `0.3.0` に揃えて bump する。

| 拡張 | version | ソース差分 |
|---|---|---|
| suno-helper | 0.2.5 → 0.3.0 | 51 files, +6897/-1405 |
| distrokid-helper | 0.2.1 → 0.3.0 | 28 files, +1238/-556 |
| community-helper | 0.1.0 → 0.3.0 | 11 files, +684 |

`extensions/shared-ui`（+2104 / 23 files）は 3 拡張が共有する基盤のため、全拡張のビルド成果物に影響する。

## なぜ 3 拡張同時か

`release-extensions.yml` は tag push のたびに 3 拡張を無条件でビルドし、`.output/*.zip` を Release asset へ添付する。version を据え置くと「中身は最新・zip 名は旧版数」の asset が公開され、asset 名の version で更新要否を判断する `/ext-install` 側から更新に気付けない。変更が入った拡張は必ず bump する。

## 主な変更

**suno-helper**
- unattended run（無人実行）・server discovery・adaptive challenge pacing（#2472）
- Turnstile challenge の可視判定（#2496）、background mutation の origin 認証（#2465）
- shared overlay UI への全面移行、terminal 通知の統一（#2334）、一覧の折りたたみ（#2330）

**distrokid-helper**
- popup を shared overlay へ移設（#2319）
- background mutation の origin 認証（#2465）、configuration 層への移行（#2304）

**community-helper**
- コミュニティ投稿 runner / DOM 操作の実装（#1713, #1714）
- popup を shared overlay へ移設（#2320）
- **今回が初の Release asset 収録**（`ext-v0.2.5` は suno / distrokid の 2 件のみだった）

**3 拡張共通（shared-ui）**
- shadcn/ui primitives の共有・Base UI 移行（#2246, #2314）
- ブランド primary の OKLCH 統一（#2352）、ホスト root font-size からの寸法分離（#2351）
- 拡張別アイコン（#2341）、branded overlay header（#2327）

## Local verify

`bash .claude/skills/automation-release/references/verify-extensions.sh`（引数なし = 3 拡張）を Nix extensions shell（Node 24 / pnpm 11.15.1）で実行し、exit 0 を確認済み。

- `pnpm install --frozen-lockfile` → `pnpm build` → `pnpm zip`
- 期待名 zip が各拡張で唯一の 1 件（`suno-helper-0.3.0-chrome.zip` / `distrokid-helper-0.3.0-chrome.zip` / `community-helper-0.3.0-chrome.zip`）
- 対象 lockfile に差分なし

差分ガード: `extensions/*/package.json` の `version` 1 行 × 3 のみ。

## Next steps

1. CI green を確認 → マージ
2. マージ後、`/automation-release` を再実行して extension publish（merge commit へ `ext-v0.3.0` tag → workflow → Release asset 3 件確認）
3. 手元 Chrome の更新は `/ext-install`
