### PR TITLE
fix(videoup): aac_at は実行時プローブに成功したときだけ採用する (#3034)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -457,10 +457,21 @@ EFFECT_FILTER_LOOP="$(build_effect_filter "0:v" "vout")"
 EFFECT_FILTER_STATIC="scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2[scaled];$(build_effect_filter "scaled" "vout")"
 
 # ─── Audio encoder 自動選択 (macOS は AudioToolbox 優先) ─
+# 一覧に載っていても初期化できるとは限らない。aac_at は AudioToolbox 経由で
+# coreaudiod への Mach lookup を必要とするため、サンドボックス下では
+# `AudioToolbox init error: 1718449215` (kAudioFormatUnsupportedDataFormatError) で
+# 失敗する。overlay encoder と同じく、実際に短いエンコードを試して通ったときだけ採用する。
+AUDIO_ENCODER="aac"
 if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
-    AUDIO_ENCODER="aac_at"
-else
-    AUDIO_ENCODER="aac"
+    audio_encoder_probe="$(mktemp "${TMPDIR:-/tmp}/yt-audio-encoder-probe.XXXXXX")"
+    if ffmpeg -y -f lavfi -i anullsrc -t 0.1 -c:a aac_at -f mp4 \
+        -loglevel error "$audio_encoder_probe" &>/dev/null; then
+        AUDIO_ENCODER="aac_at"
+    else
+        echo "  WARN: audio encoder aac_at failed to start; falling back to aac"
+    fi
+    rm -f "$audio_encoder_probe"
+    unset audio_encoder_probe
 fi
 
 # ─── 音声出力オプション (m4a/aac はストリームコピー、それ以外は再エンコード) ─

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(videoup)`: `generate_videos.sh` の音声エンコーダ選択を、`ffmpeg -encoders` の列挙だけでなく実行時プローブの成功を条件にした。`aac_at` は AudioToolbox 経由で coreaudiod への Mach lookup を必要とするため、サンドボックス下では列挙されていても初期化に失敗し ffmpeg が exit 171 で落ちていた。プローブに失敗した場合は警告を出して `aac` へフォールバックする（#3034）。
+
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 
 - `chore(takt)`: takt 0.54.1 追随 — 0.53 で既定 off になった Codex Skill 継承（`.agents/skills` の repo スコープ）を yt-auto-* 全 workflow で復元し、builtin 準拠の fix-report 契約（`instruction: fix` の 2 step）・`session: compact`（yt-auto-audit の台帳拡張 step）・final-gate タグルーティング（最終関門のみ Sol へ）・`use-relevant-skills` partial（実装系 4 instruction）を導入した（#2686）。

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -1512,6 +1512,47 @@ def _output_ffmpeg_command(ffmpeg_log: Path, output_name: str) -> str:
     raise AssertionError(f"ffmpeg command for {output_name} not found: {commands}")
 
 
+# ─── Audio encoder 実行時プローブ (#3034) ─────────────────
+
+_AAC_AT_ENCODER_LINE = " A..... aac_at aac (AudioToolbox) (codec aac)\\n"
+
+
+def test_audio_encoder_uses_aac_at_when_probe_succeeds(tmp_path: Path) -> None:
+    """#3034: aac_at が列挙され、実際に初期化できるなら aac_at を使う."""
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"FFMPEG_ENCODERS": _AAC_AT_ENCODER_LINE},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "-c:a aac_at" in _master_ffmpeg_command(ffmpeg_log)
+    assert "falling back to aac" not in result.stdout
+
+
+def test_audio_encoder_falls_back_to_aac_when_probe_fails(tmp_path: Path) -> None:
+    """#3034: 列挙されていても初期化できないなら aac へフォールバックする.
+
+    aac_at は AudioToolbox 経由で coreaudiod への Mach lookup を必要とするため、
+    サンドボックス下では `-encoders` に載っていても初期化に失敗する。列挙の有無だけで
+    採用すると ffmpeg が exit 171 で落ちるので、実行時プローブの結果で決める。
+    """
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={
+            "FFMPEG_ENCODERS": _AAC_AT_ENCODER_LINE,
+            "FFMPEG_FAIL_MATCH": "yt-audio-encoder-probe",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    master_cmd = _master_ffmpeg_command(ffmpeg_log)
+    assert "-c:a aac " in f"{master_cmd} "
+    assert "-c:a aac_at" not in master_cmd
+    assert "audio encoder aac_at failed to start; falling back to aac" in result.stdout
+
+
 def _overlay_encoder_env(codec: str, encoders: str = "") -> dict[str, str]:
     return {
         "OVERLAY_ENCODER_CODEC": codec,


### PR DESCRIPTION
Closes #3034

## 問題

`generate_videos.sh` は `ffmpeg -encoders` の一覧に `aac_at` が載っているかどうかだけで音声エンコーダを選んでいた。

```bash
if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
    AUDIO_ENCODER="aac_at"
else
    AUDIO_ENCODER="aac"
fi
```

しかし **「一覧に載っている」と「初期化できる」は同値ではない**。`aac_at` は AudioToolbox 経由で `coreaudiod` への Mach lookup を必要とするため、これが遮断された環境では初期化に失敗し、ffmpeg が exit 171 で落ちる。フォールバックが無いため生成がそのまま失敗していた。

```
[aac_at @ ...] AudioToolbox init error: 1718449215   # 'fmt?' = kAudioFormatUnsupportedDataFormatError
[enc:aac_at @ ...] Could not open encoder before EOF
ERROR: FFmpeg failed with exit code 171
```

## 影響

takt の run は codex を `--sandbox workspace-write` で起動するため常にこの条件に該当し、`tests/test_generate_videos_script.py` の実 FFmpeg ケース 4 件が決定論的に失敗していた。

```
test_audio_visualizer_new_styles_render_minimal_video_with_real_ffmpeg[mirror-mountain|ring|ring-line|heart]
```

このため本リポジトリの takt run は `safety_net`（変更前ベースラインが green であることを要求する関門）を通過できず、#3024 が 3 回連続で ABORT していた。サンドボックス外（通常のシェル、CI）では再現しないため CI は green のままで、ローカルの takt run でだけ踏む状態だった。

## 変更

overlay video encoder が既に採っている実行時プローブ（`${PROGRESS_FILE}.encoder-probe.mp4` へ 1 フレーム書いて起動可否を見る）と同じ流儀を音声側にも適用した。実際に短いエンコードが通ったときだけ `aac_at` を採用し、失敗したら警告を出して `aac` へ落とす。

```bash
AUDIO_ENCODER="aac"
if ffmpeg -hide_banner -encoders 2>&1 | grep -q '^ A..... aac_at '; then
    audio_encoder_probe="$(mktemp "${TMPDIR:-/tmp}/yt-audio-encoder-probe.XXXXXX")"
    if ffmpeg -y -f lavfi -i anullsrc -t 0.1 -c:a aac_at -f mp4 \
        -loglevel error "$audio_encoder_probe" &>/dev/null; then
        AUDIO_ENCODER="aac_at"
    else
        echo "  WARN: audio encoder aac_at failed to start; falling back to aac"
    fi
    rm -f "$audio_encoder_probe"
    unset audio_encoder_probe
fi
```

## テスト

スタブ ffmpeg を使い、実環境のサンドボックス有無に依存しない決定論的なテストを 2 件追加した。

| テスト | 内容 |
|---|---|
| `test_audio_encoder_uses_aac_at_when_probe_succeeds` | `-encoders` に `aac_at` が載りプローブが通れば `-c:a aac_at` |
| `test_audio_encoder_falls_back_to_aac_when_probe_fails` | 列挙されていてもプローブが失敗すれば `-c:a aac` + 警告 |

fallback テストは修正を外すと落ちることを確認済み（テストが実際に契約を守っていることの確認）。

## 検証結果

`tests/test_generate_videos_script.py`:

| 環境 | 修正前 | 修正後 |
|---|---|---|
| `deny mach-lookup` サンドボックス（takt 相当） | 4 failed, 105 passed | **111 passed** |
| 通常環境 | 109 passed | **111 passed** |

takt 環境の再現方法:

```console
$ nix develop --command sandbox-exec -p '(version 1)(allow default)(deny mach-lookup)' \
    ./.venv/bin/python -m pytest tests/test_generate_videos_script.py -q
```

品質ゲート: `ruff check` / `ruff format --check` / `uv sync --frozen` / `uv build` / `yt-skills lint` すべて green。

全体 `pytest -n auto` は `3 failed, 7414 passed, 1 skipped`。失敗 3 件は本変更と無関係な並列負荷 flake で、単独再実行では 3 件とも pass する。

```
tests/test_cli_help_contract.py::test_cli_help_needs_no_config_credentials_or_api_client[yt-playlist-manager]
tests/test_collection_serve_lifecycle.py::test_parallel_console_starts_publish_one_owner_and_reuse_it
tests/test_actions_parallel_workflows.py::test_fallow_audit_fails_for_a_new_error_finding_in_a_git_diff
```

## stack

PR #3022 の上に積む stacked PR。#3024（再配置後の不要ファイル削除）は本 PR がマージされるまで `safety_net` を通過できないため、`blocked_by` で紐付け済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXQo69CBYZ72DLME2cGAgd
