### PR TITLE
fix(wf-auto): lease token を CLI 安全な形式にする (#2575)

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -507,7 +507,8 @@ def _lease_mutex(root: Path):
 def acquire_lease(root: Path, *, now: float, ttl_seconds: int) -> str:
     if isinstance(ttl_seconds, bool) or ttl_seconds <= 0:
         raise ValueError("ttl_seconds は正の整数でなければなりません")
-    token = secrets.token_urlsafe(24)
+    # argparse が `-` 始まりの値を option と誤認しない文字集合に限定する。
+    token = secrets.token_hex(24)
     payload = {"token": token, "acquired_at": now, "expires_at": now + ttl_seconds}
     with _lease_mutex(root) as state_dir:
         lock_dir = state_dir / LEASE_DIR_NAME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(wf-auto)`: lease token を hexadecimal 表現で生成し、先頭が `-` になった token を `--token` の値として渡せず約 1.5% の確率で CLI が失敗する問題を解消した（#2575）。
 - `fix(automation-release)`: リリース前検証の誤検出 2 件を解消した。`verify-extensions.sh` は `pnpm zip` の直前に `.output/*.zip` を掃除し、過去 run のビルド残骸によって「期待名 zip が唯一の1件」判定が `expected exactly one zip ... found N` で誤 FAIL しないようにする（判定の意図である「今回の run が期待名の zip だけを生成した」ことの検証力は維持する。`release-extensions.yml` が `.output/*.zip` を glob で Release asset へ上げるため、期待名以外の成果物を公開前に止める必要があるという本来の目的に合わせ、回帰テストも「事前残骸は掃除されて成功する」「zip コマンドが余分な成果物を生んだら停止する」の 2 本へ分けた）。あわせて semver 判定の BREAKING 検出を大小文字非依存（`grep -qiE`）にし、本リポジトリで実際に使われる `**Breaking:**` / `breaking(scope):` 表記の取りこぼしを解消した。v5.6.0 の prepare で破壊的変更 6 件を検出できず minor と提案した事象への対策。`.output/` 残骸・パイプ越しの exit code 誤読という 2 つの落とし穴も SKILL.md の Gotchas と extension checklist へ明文化した。
 
 ## [5.6.0] - 2026-07-31

--- a/tests/test_wf_auto_state.py
+++ b/tests/test_wf_auto_state.py
@@ -201,10 +201,15 @@ def test_cli_plan_prints_bootstrap_decision(
 
 
 def test_cli_records_bootstrap_block_before_collection_exists(
-    tmp_path: Path, runner: ModuleType, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    runner: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
+    monkeypatch.setattr(runner.secrets, "token_urlsafe", lambda _size: "-unsafe-token")
     token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
 
+    assert "-" not in token
     assert (
         runner.main(
             [


### PR DESCRIPTION
## Summary

- lease token をハイフンを含まない hexadecimal 表現で生成する
- 旧生成器が `-` 始まりを返す条件でも `record-bootstrap --token` が成功する回帰テストを追加する
- CHANGELOG の Unreleased に修正内容を記録する

## Verification

- `uv run pytest tests/test_wf_auto_state.py -q`
- 対象回帰テスト 100 回反復
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run yt-skills lint`
- `uv run pytest -n auto`（初回は高並列負荷による無関係な timeout 等 8 件。失敗 8 件の単独再実行は green）

Closes #2575
Root #2575