### PR TITLE
fix(doctor): 承認済みサムネ例外を初期検査へ反映 (#2509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(doctor)`: `initial_setup_readiness` でも `ttp-seed-confirmation.md` の有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
+
 - `fix(automation-release)`: リリース前検証の誤検出 2 件を解消した。`verify-extensions.sh` は `pnpm zip` の直前に `.output/*.zip` を掃除し、過去 run のビルド残骸によって「期待名 zip が唯一の1件」判定が `expected exactly one zip ... found N` で誤 FAIL しないようにする（判定の意図である「今回の run が期待名の zip だけを生成した」ことの検証力は維持する。`release-extensions.yml` が `.output/*.zip` を glob で Release asset へ上げるため、期待名以外の成果物を公開前に止める必要があるという本来の目的に合わせ、回帰テストも「事前残骸は掃除されて成功する」「zip コマンドが余分な成果物を生んだら停止する」の 2 本へ分けた）。あわせて semver 判定の BREAKING 検出を大小文字非依存（`grep -qiE`）にし、本リポジトリで実際に使われる `**Breaking:**` / `breaking(scope):` 表記の取りこぼしを解消した。v5.6.0 の prepare で破壊的変更 6 件を検出できず minor と提案した事象への対策。`.output/` 残骸・パイプ越しの exit code 誤読という 2 つの落とし穴も SKILL.md の Gotchas と extension checklist へ明文化した。
 
 ## [5.6.0] - 2026-07-31

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -2622,11 +2622,27 @@ def _suno_music_readiness(channel_dir: Path, channels: list[dict[str, object]]) 
 def check_initial_setup_readiness(channel_dir: Path) -> CheckResult:
     issues: list[str] = []
 
+    seed_confirmation = channel_dir / "docs" / "channel" / "ttp-seed-confirmation.md"
+    approved_exceptions: set[str] = set()
+    if seed_confirmation.is_file():
+        try:
+            seed_text = seed_confirmation.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            pass
+        else:
+            approved_exceptions, _ = _approved_ttp_exceptions(seed_text)
+
     thumbnail_cfg, thumbnail_error = _load_skill_config_for_channel("thumbnail", channel_dir)
     if thumbnail_error:
         issues.append(thumbnail_error)
     else:
-        issues.extend(check_thumbnail_skill_config(channel_dir, thumbnail_cfg))
+        issues.extend(
+            check_thumbnail_skill_config(
+                channel_dir,
+                thumbnail_cfg,
+                skip_reference_images="thumbnail" in approved_exceptions,
+            )
+        )
 
     suno_cfg, suno_error = _load_skill_config_for_channel("suno", channel_dir)
     if suno_error:

--- a/src/youtube_automation/domains/uploads/preflight.py
+++ b/src/youtube_automation/domains/uploads/preflight.py
@@ -132,14 +132,19 @@ def check_suno_genre_line_char_limit(suno_cfg: Mapping[str, object]) -> str | No
     )
 
 
-def check_thumbnail_skill_config(channel_dir: Path, thumbnail_cfg: Mapping[str, object]) -> list[str]:
+def check_thumbnail_skill_config(
+    channel_dir: Path,
+    thumbnail_cfg: Mapping[str, object],
+    *,
+    skip_reference_images: bool = False,
+) -> list[str]:
     """thumbnail skill-config の初期セットアップ漏れを検出する."""
     image_generation = _as_mapping(thumbnail_cfg.get("image_generation"))
     gemini = _as_mapping(image_generation.get("gemini"))
     generation_mode = str(gemini.get("generation_mode") or "single_step").strip()
 
     issues: list[str] = []
-    if generation_mode == "single_step":
+    if generation_mode == "single_step" and not skip_reference_images:
         single_step = _as_mapping(gemini.get("single_step"))
         max_attempts = _positive_int(single_step.get("max_attempts"), default=1)
         rotate = _bool(single_step.get("rotate"), default=True)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1800,6 +1800,41 @@ class TestCheckInitialSetupReadiness:
 
         assert r.status == "ok"
 
+    def test_approved_thumbnail_exception_allows_non_benchmark_reference(self, tmp_path):
+        ref = tmp_path / "branding" / "proven-thumbnail.jpg"
+        ref.parent.mkdir(parents=True)
+        ref.write_bytes(b"jpg")
+        skills_dir = tmp_path / "config" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "thumbnail.yaml").write_text(
+            "\n".join(
+                [
+                    "image_generation:",
+                    "  gemini:",
+                    "    generation_mode: single_step",
+                    "    reference_images:",
+                    "      default:",
+                    "        - branding/proven-thumbnail.jpg",
+                    "      path_base: channel_dir",
+                    "    composition_rules:",
+                    '      text_lines: "2 lines"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (skills_dir / "suno.yaml").write_text('genre_line: "lo-fi jazz"\n', encoding="utf-8")
+        seed_confirmation = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_confirmation.parent.mkdir(parents=True)
+        seed_confirmation.write_text(
+            "- 未反映項目: ユーザー承認済み例外: thumbnail reference は実績画像を使うため"
+            "後続 /thumbnail で確認し、benchmark path への転写はスキップ\n",
+            encoding="utf-8",
+        )
+
+        r = doctor.check_initial_setup_readiness(tmp_path)
+
+        assert r.status == "ok"
+
     def test_descriptions_md_symlink_escape_warns_without_reading_external_heading(self, tmp_path):
         outside = tmp_path.parent / f"{tmp_path.name}-outside"
         outside_desc = outside / "descriptions.md"


### PR DESCRIPTION
## Summary

- `initial_setup_readiness` が `ttp-seed-confirmation.md` の有効な thumbnail ユーザー承認済み例外を尊重するようにする
- 例外適用時も composition rules など参照画像以外の thumbnail 検査は維持する
- 規約外の実績画像を使う承認済みケースの回帰テストを追加する

## Validation

- `nix develop --command uv run pytest tests/test_doctor.py::TestCheckInitialSetupReadiness tests/test_preflight_checks.py -q` (110 passed)
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `bash .github/scripts/any-usage-gate.sh`
- full pytest: 7,377 passed / 1 skipped; resource contention failures 8件は対象を直列再実行して全件 pass

Closes #2509
Root #2509
