### PR TITLE
fix(extensions): pnpm の tarball Worker 並列を 1 に固定する (#3078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。
 - `fix(takt)`: `.takt/runtime-prepare.sh` が `NIX_CACHE_HOME` を current runtime root 配下へ再構成するようにした。Nix は `XDG_CACHE_HOME` より `NIX_CACHE_HOME` を優先するため、`XDG_CACHE_HOME` だけを差し替えても sibling worktree 由来の継承値が残り、別 worktree の fetcher-cache SQLite を readonly で開いて `nix develop` が `attempt to write a readonly database` で test 開始前に停止していた。注入値は devShell 入場時に `flake.nix` shellHook / `.envrc` が導出する `$TMPDIR/nix-cache` と一致させ、入場前後で cache path が動かないようにする。あわせて `yt-preflight` の `check_runtime_path` の検査対象へ `NIX_CACHE_HOME` を追加し、スクリプトの注入対象と preflight の検査対象が一致することを回帰テストで機械担保した（#3040）。
 - `fix(videoup)`: `generate_videos.sh` の音声エンコーダ選択を、`ffmpeg -encoders` の列挙だけでなく実行時プローブの成功を条件にした。`aac_at` は AudioToolbox 経由で coreaudiod への Mach lookup を必要とするため、サンドボックス下では列挙されていても初期化に失敗し ffmpeg が exit 171 で落ちていた。プローブに失敗した場合は警告を出して `aac` へフォールバックする（#3034）。

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             mkdir -p "$out/lib/pnpm" "$out/bin"
             cp -R . "$out/lib/pnpm/"
             makeWrapper "${pkgs.nodejs_24}/bin/node" "$out/bin/pnpm" \
+              --set-default PNPM_MAX_WORKERS 1 \
               --add-flags "$out/lib/pnpm/bin/pnpm.cjs"
             runHook postInstall
           '';
@@ -36,6 +37,12 @@
       in
       {
         devShells.extensions = pkgs.mkShell {
+          shellHook = ''
+            if [ -z "''${PNPM_MAX_WORKERS:-}" ]; then
+              export PNPM_MAX_WORKERS=1
+            fi
+          '';
+
           packages = with pkgs; [
             nodejs_24
             pnpmLatest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ SLOW_MODULES = frozenset(
         "test_distrokid_release_endpoint.py",
         "test_generate_videos_script.py",
         "test_preflight_cli.py",
+        "test_extension_package_manager_runtime.py",
         "test_skills_sync_installed_wheel.py",
         "test_site_repository_contract.py",
         "test_streaming_healthcheck.py",

--- a/tests/test_extension_package_manager_contract.py
+++ b/tests/test_extension_package_manager_contract.py
@@ -62,10 +62,12 @@ def _pnpm_setup_versions(path: str) -> list[object]:
 
 
 def test_extensions_shell_contains_only_the_node_toolchain() -> None:
+    """REQ-3078-01 / TC-01B: worker default is wired only into extensions shell."""
     flake = _read("flake.nix")
     extensions_shell = re.search(
         r"(?ms)^(?P<indent>[ \t]*)devShells\.extensions\s*="
         r"\s*pkgs\.mkShell\s*\{"
+        r".*?"
         r"\s*packages\s*=\s*with pkgs;\s*\[(?P<packages>.*?)\];"
         r"\s*\};",
         flake,
@@ -80,8 +82,29 @@ def test_extensions_shell_contains_only_the_node_toolchain() -> None:
     assert extensions_shell.group("indent") == default_shell.group("indent")
 
     block = extensions_shell.group(0)
-    for excluded in ("python311", "uv", "ffmpeg", "shellHook"):
+    for excluded in ("python314", "uv", "ffmpeg"):
         assert excluded not in block
+    assert "shellHook" in block
+    assert "if [ -z \"''${PNPM_MAX_WORKERS:-}\" ]; then" in block
+    assert "export PNPM_MAX_WORKERS=1" in block
+
+    default_shell_start = default_shell.start()
+    assert "PNPM_MAX_WORKERS" not in flake[default_shell_start:]
+
+
+def test_pnpm_wrapper_sets_a_default_worker_limit() -> None:
+    """REQ-3078-01 / TC-01A: pnpm wrapper preserves overrides and Node entrypoint."""
+    flake = _read("flake.nix")
+    wrapper = re.search(
+        r'(?ms)makeWrapper .*?"\$out/bin/pnpm" \\\n+(?P<args>.*?)\n\s*runHook postInstall',
+        flake,
+    )
+
+    assert wrapper is not None
+    args = wrapper.group("args")
+    assert "--set-default PNPM_MAX_WORKERS 1" in args
+    assert "--set PNPM_MAX_WORKERS" not in args
+    assert '--add-flags "$out/lib/pnpm/bin/pnpm.cjs"' in args
 
 
 def test_all_extensions_pin_the_nix_pnpm() -> None:

--- a/tests/test_extension_package_manager_runtime.py
+++ b/tests/test_extension_package_manager_runtime.py
@@ -1,0 +1,93 @@
+"""Nix extensions shell と pnpm wrapper の Worker 環境契約を検証する。"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+
+_NIX_TIMEOUT_SECONDS = 180
+
+
+def _run_extensions(command: str, *, worker_value: str | None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if worker_value is None:
+        env.pop("PNPM_MAX_WORKERS", None)
+    else:
+        env["PNPM_MAX_WORKERS"] = worker_value
+    try:
+        return subprocess.run(
+            [
+                "nix",
+                "develop",
+                f"{REPO_ROOT}#extensions",
+                "--command",
+                "sh",
+                "-c",
+                command,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_NIX_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        pytest.skip("nix executable is unavailable")
+
+
+def _assert_success(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _trailing_lines(result: subprocess.CompletedProcess[str], count: int) -> list[str]:
+    """stdout の末尾 count 行を返す。
+
+    `node_modules` が無い環境では `pnpm exec` が依存インストールを先に走らせ、その進捗
+    出力が stdout の先頭へ混ざる（CI のクリーンチェックアウトが該当）。検証対象は
+    Worker 値だけなので末尾から取り、テストの実行順やインストール済みかどうかに
+    依存しないようにする。
+    """
+    return result.stdout.strip().splitlines()[-count:]
+
+
+def test_extensions_shell_initializes_an_unset_worker_limit() -> None:
+    """REQ-3078-01 / TC-01C: an unset parent value becomes one in the shell."""
+    result = _run_extensions('printf "%s" "$PNPM_MAX_WORKERS"', worker_value=None)
+
+    _assert_success(result)
+    assert result.stdout == "1"
+
+
+def test_extensions_shell_treats_an_empty_worker_limit_as_unset() -> None:
+    """REQ-3078-01 / TC-01D: an empty parent value becomes one in the shell."""
+    result = _run_extensions('printf "%s" "$PNPM_MAX_WORKERS"', worker_value="")
+
+    _assert_success(result)
+    assert result.stdout == "1"
+
+
+def test_pnpm_wrapper_initializes_a_worker_limit_after_shell_unset() -> None:
+    """REQ-3078-01 / TC-01E: pnpm supplies one at its process boundary."""
+    command = "unset PNPM_MAX_WORKERS; pnpm -C extensions/suno-helper exec node -p 'process.env.PNPM_MAX_WORKERS'"
+    result = _run_extensions(command, worker_value=None)
+
+    _assert_success(result)
+    assert _trailing_lines(result, 1) == ["1"]
+
+
+def test_worker_override_reaches_the_pnpm_child_node_process() -> None:
+    """REQ-3078-01 / TC-01F: an explicit seven survives both boundaries."""
+    command = (
+        "printf '%s\\n' \"$PNPM_MAX_WORKERS\"; "
+        "pnpm -C extensions/suno-helper exec node -p "
+        "'process.env.PNPM_MAX_WORKERS'"
+    )
+    result = _run_extensions(command, worker_value="7")
+
+    _assert_success(result)
+    assert _trailing_lines(result, 2) == ["7", "7"]

--- a/tests/test_takt_runtime_prepare.py
+++ b/tests/test_takt_runtime_prepare.py
@@ -20,7 +20,9 @@ ROOT = REPO_ROOT
 PREPARE_SCRIPT = ROOT / ".takt" / "runtime-prepare.sh"
 
 
-def _run_prepare(tmp_path: Path, *, inherited: dict[str, str] | None = None) -> dict[str, str]:
+def _run_prepare_process(
+    tmp_path: Path, *, inherited: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     """runtime root を tmp へ向けてスクリプトを実行し、注入される環境を返す。
 
     cwd は `pyproject.toml` を持たない tmp にする。スクリプトは pyproject.toml が
@@ -42,6 +44,11 @@ def _run_prepare(tmp_path: Path, *, inherited: dict[str, str] | None = None) -> 
         check=False,
     )
 
+    return result
+
+
+def _run_prepare(tmp_path: Path, *, inherited: dict[str, str] | None = None) -> dict[str, str]:
+    result = _run_prepare_process(tmp_path, inherited=inherited)
     assert result.returncode == 0, result.stderr
     injected = {}
     for line in result.stdout.splitlines():
@@ -49,6 +56,22 @@ def _run_prepare(tmp_path: Path, *, inherited: dict[str, str] | None = None) -> 
         assert separator, f"KEY=VALUE 契約に反する出力: {line!r}"
         injected[key] = value
     return injected
+
+
+def test_runtime_prepare_emits_the_ordered_seven_line_contract(tmp_path: Path) -> None:
+    """REQ-3078-04 / TC-04: raw stdout has exactly the seven ordered path lines."""
+    result = _run_prepare_process(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "TMPDIR=" + str(tmp_path / "current" / ".takt" / ".runtime" / "tmp"),
+        "XDG_CACHE_HOME=" + str(tmp_path / "current" / ".takt" / ".runtime" / "cache"),
+        "XDG_CONFIG_HOME=" + str(tmp_path / "current" / ".takt" / ".runtime" / "config"),
+        "XDG_DATA_HOME=" + str(tmp_path / "current" / ".takt" / ".runtime" / "data"),
+        "XDG_STATE_HOME=" + str(tmp_path / "current" / ".takt" / ".runtime" / "state"),
+        "UV_CACHE_DIR=" + str(tmp_path / "current" / ".takt" / ".runtime" / "cache" / "uv"),
+        "NIX_CACHE_HOME=" + str(tmp_path / "current" / ".takt" / ".runtime" / "tmp" / "nix-cache"),
+    ]
 
 
 def test_injected_variables_match_the_preflight_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #3078

## 概要

macOS・Node 24 上で pnpm が複数の tarball Worker を使って package を処理すると、libuv が `uv__io_poll` の kqueue assertion で SIGABRT し、**処理が完走しているのに終了コードだけが `-6` になる**。`tests/test_actions_parallel_workflows.py::test_fallow_audit_*` が確率的に red になり、全体 pytest をゲートに持つ takt run のベースライン判定を壊していた。

上流（Node / pnpm / libuv）の並行実行障害で本リポジトリでは根治できないため、Worker 数を 1 に固定して回避する。

**本 PR は回避策であって原因の除去ではない。**

## 変更

```nix
makeWrapper "${pkgs.nodejs_24}/bin/node" "$out/bin/pnpm" \
  --set-default PNPM_MAX_WORKERS 1 \
  --add-flags "$out/lib/pnpm/bin/pnpm.cjs"
```

`devShells.extensions` の shellHook でも未設定時に `1` を入れる。wrapper の `--set-default` だけでは pnpm プロセス内にしか効かず、shell 環境から観測できないため二境界で担保する。

**`--set` ではなく `--set-default`** を使っている。回避策である以上、原因究明のために並列を戻して再現させる余地を残す必要がある。この選択は `test_pnpm_wrapper_sets_a_default_worker_limit` が機械担保している（`--set-default` を要求し `--set` を禁止する）。

変更は `devShells.extensions` に閉じる。`devShells.default` は pnpm を持たないため対象外。

## 性能影響（実測）

`PNPM_MAX_WORKERS` は tarball Worker 数なので、差は展開処理を伴う install に出る。各条件 2 回ずつ計測。

| 対象 | workers=8 | workers=1 | 差 |
|---|---|---|---|
| `suno-helper` install | 4816 / 4444 ms | 6139 / 4955 ms | **+20%** |
| `suno-helper` build | 1659 / 1575 ms | 1609 / 1595 ms | 差なし |
| `dashboard` install | 4755 / 3460 ms | 6240 / 5716 ms | **+45%** |

install は毎回 `node_modules` を削除して計測。build に差が出ないのは tarball 展開を伴わないため。

**絶対値は 1〜2 秒**で、CI 全体から見れば誤差の範囲と判断した。並列度低下は回避策の既知の代償であり、合否判定には使っていない。

## 検証

| ゲート | 結果 |
|---|---|
| pytest | **7469 passed, 1 skipped**（3 回実施） |
| ruff check / format | green |
| uv sync --frozen / uv build | green |
| yt-skills lint | green |

新規テスト `tests/test_extension_package_manager_runtime.py` は 4 ケースで両境界を検証する。

- 親で未設定 / 空文字 → shell で `1`
- shell で `unset` した後 → pnpm wrapper が `1` を供給
- 明示的に `7` を渡す → 両境界を通過（**上書き可能性の担保**）

`.takt/runtime-prepare.sh` の stdout 7 行契約も回帰テストを追加した（本 PR では同スクリプトを変更していないが、隣接領域のため保全を明示）。

## 未解決事項

直接原因は次の 2 仮説に絞られたが、識別できていない。

1. Worker 間の fd lifecycle 競合が fd 警告と kqueue failure の両方を起こす
2. 複数 Worker の終了・event-loop teardown 競合が両者を別々に発生させる

`PNPM_MAX_WORKERS=1` で両症状が消える観測は**どちらの仮説でも同じ結果になる**ため識別に使えない。決着には `kevent()` の実 errno・kqueue fd・Worker/thread ID の採取が要る（本 PR のスコープ外）。

なお #3078 の初版は「空の `XDG_DATA_HOME` が原因で決定論的に red」としていたが、これは実測で全面的に否定されている（独立 cold store でも 10 件中 6 件のみ red、warm store でも red が発生）。棄却済み仮説は issue 本文に記録済み。

## 影響

この修正により #3043（tests/repo 移設）の blocker が解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrWWaTayGvRkpCttyofFQ
