### PR TITLE
chore(takt): 失敗タスクの自動再実行を無効化する (#3080)

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -20,6 +20,15 @@
 draft_pr: false
 base_branch: main
 
+# 失敗タスクの自動再実行を無効化する（グローバルの auto_requeue_max_attempts: 2 を上書き）。
+# yt-auto-* の workflow は intake / plan で「着手すべきでない」と判断したとき設計どおり ABORT
+# する。auto_requeue はこれを失敗として同じ入力のまま回し直すため、判断が覆ることはなく
+# 試行回数とトークンだけを消費する（#3043 で plan の ABORT に対し 2 回消費し、requeue された
+# run はいずれも "Task was interrupted" で終わった）。
+# 0 にすると runAllTasks 起動時の requeueExistingFailedTasks も止まり、過去の failed タスクが
+# takt run のたびに掘り起こされることもなくなる。再実行は失敗原因を解消してから明示的に積む。
+auto_requeue_max_attempts: 0
+
 provider: codex
 
 # sandbox 化された worker の direnv / lefthook セットアップ停滞対策（issue #1999）と、

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `chore(takt)`: `.takt/config.yaml` に `auto_requeue_max_attempts: 0` を追加し、失敗タスクの自動再実行を無効化した。yt-auto-* の workflow は intake / plan / diagnose で「着手すべきでない」と判断したとき設計どおり ABORT するが、auto_requeue は同じ order.md のまま回し直すため判断が覆らず試行回数とトークンだけを消費していた。あわせて `runAllTasks` 起動時の `requeueExistingFailedTasks` も止まり、過去の failed タスクが `takt run` のたびに掘り起こされることがなくなる。再実行は原因を解消してから明示的に積み直す（#3080）。
 - `refactor(tests)`: pytest lane registry の slow node 登録を module basename と test 識別子で表現し、`tests/` 以下の module 配置に依存しない lane 判定と再帰的な module 検索を可能にした（#3042）。
 - `refactor(tests)`: `tests.helpers.paths` に repository root、`tests/`、fixtures の共通 path helper を追加し、テストからの `Path(__file__)` 直接遡上を禁止する契約テストと tests 配置規約を導入した（#3041）。
 - `refactor(repository)`: 再配置後に役目を終えた旧 `youtube_automation.auth` package marker と、受領済みの plans 025〜027 を削除した。互換 façade、配布物、契約テスト、履歴受領先は維持した。


### PR DESCRIPTION
Closes #3080

## 概要

`.takt/config.yaml` に `auto_requeue_max_attempts: 0` を追加し、グローバル設定（`~/.takt/config.yaml` の `2`）を上書きして失敗タスクの自動再実行を無効化する。

## 理由

yt-auto-* の workflow は intake / plan / diagnose で「着手すべきでない」と判断したとき設計どおり ABORT する。auto_requeue はこれを失敗として**同じ order.md のまま回し直す**ため、判断が覆ることはなく試行回数とトークンだけを消費する。

2026-08-03 の実例（#3043）では plan の ABORT に対して 2 回消費され、requeue された run はいずれも `Task was interrupted before this TAKT run started` で終わった。実際の停止原因は入力ではなく実行環境側（#3078 / #3079 で解消した pnpm の並行実行障害）にあり、**同じ入力を回し直す auto_requeue は構造的に無力**だった。

order.md の出所は issue 本文であり、ABORT は「入力を直せ」というシグナルである。再実行は原因を解消してから明示的に積み直すのが正しい経路になる。

## 副次的な効果

`0` にすると `runAllTasks` 起動時の `requeueExistingFailedTasks`（takt `dist/features/tasks/execute/runAllTasks.js:56`）も止まる。**過去の failed タスクが `takt run` のたびに掘り起こされることがなくなる**ため、無関係な run を回した拍子に古い failed が再投入される事故を防げる。

## 検証

takt の config 解決がグローバルの `2` を上書きできていることを確認した。

```
{"value":0,"source":"project"}
```

判定は `runAllTasks(cwd)` が読む config、つまり `takt run` を起動した cwd（メインチェックアウト）の設定を見る。本 PR でリポジトリにコミットするため、マージ後は各自のメインチェックアウトに反映される。

`docs/` に auto_requeue の記述は無いため、ドキュメントの追従は不要だった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrWWaTayGvRkpCttyofFQ