### PR TITLE
fix(tests): pnpm Worker 契約テストから依存ツリーの実インストールを外す (#3082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。
 - `fix(takt)`: `.takt/runtime-prepare.sh` が `NIX_CACHE_HOME` を current runtime root 配下へ再構成するようにした。Nix は `XDG_CACHE_HOME` より `NIX_CACHE_HOME` を優先するため、`XDG_CACHE_HOME` だけを差し替えても sibling worktree 由来の継承値が残り、別 worktree の fetcher-cache SQLite を readonly で開いて `nix develop` が `attempt to write a readonly database` で test 開始前に停止していた。注入値は devShell 入場時に `flake.nix` shellHook / `.envrc` が導出する `$TMPDIR/nix-cache` と一致させ、入場前後で cache path が動かないようにする。あわせて `yt-preflight` の `check_runtime_path` の検査対象へ `NIX_CACHE_HOME` を追加し、スクリプトの注入対象と preflight の検査対象が一致することを回帰テストで機械担保した（#3040）。

--- a/tests/test_extension_package_manager_runtime.py
+++ b/tests/test_extension_package_manager_runtime.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shlex
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
 
 _NIX_TIMEOUT_SECONDS = 180
+
+# pnpm の子プロセスが受け取った Worker 値をラベル付きで出力する。pnpm 自身が
+# `Already up to date` / `Done in ...` を stdout へ混ぜ、その位置は検証値の前後どちらにも
+# なりうるため、行の位置ではなく行の集合として検査できるようラベルを付ける。
+_CHILD_PROBE = """node -p '"CHILD=" + process.env.PNPM_MAX_WORKERS'"""
 
 
 def _run_extensions(command: str, *, worker_value: str | None) -> subprocess.CompletedProcess[str]:
@@ -44,15 +52,19 @@ def _assert_success(result: subprocess.CompletedProcess[str]) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def _trailing_lines(result: subprocess.CompletedProcess[str], count: int) -> list[str]:
-    """stdout の末尾 count 行を返す。
+def _dependency_free_project(tmp_path: Path) -> str:
+    """依存を持たない pnpm project を作り、shell へ渡せる形のパスを返す。
 
-    `node_modules` が無い環境では `pnpm exec` が依存インストールを先に走らせ、その進捗
-    出力が stdout の先頭へ混ざる（CI のクリーンチェックアウトが該当）。検証対象は
-    Worker 値だけなので末尾から取り、テストの実行順やインストール済みかどうかに
-    依存しないようにする。
+    検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、どの
+    project 上で実行するかは含まれない。`extensions/suno-helper` を対象にすると `pnpm exec` が
+    依存ツリー（494 パッケージ）の実インストールを先に走らせ、その失敗がそのままテストの失敗に
+    なる。依存ゼロなら外部ダウンロードが発生せず、`node_modules` の有無にも左右されない。
     """
-    return result.stdout.strip().splitlines()[-count:]
+    project = tmp_path / "pnpm-worker-probe"
+    project.mkdir()
+    manifest = {"name": "pnpm-worker-probe", "version": "0.0.0", "private": True}
+    (project / "package.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+    return shlex.quote(str(project))
 
 
 def test_extensions_shell_initializes_an_unset_worker_limit() -> None:
@@ -71,23 +83,23 @@ def test_extensions_shell_treats_an_empty_worker_limit_as_unset() -> None:
     assert result.stdout == "1"
 
 
-def test_pnpm_wrapper_initializes_a_worker_limit_after_shell_unset() -> None:
+def test_pnpm_wrapper_initializes_a_worker_limit_after_shell_unset(tmp_path: Path) -> None:
     """REQ-3078-01 / TC-01E: pnpm supplies one at its process boundary."""
-    command = "unset PNPM_MAX_WORKERS; pnpm -C extensions/suno-helper exec node -p 'process.env.PNPM_MAX_WORKERS'"
+    project = _dependency_free_project(tmp_path)
+    command = f"unset PNPM_MAX_WORKERS; pnpm -C {project} exec {_CHILD_PROBE}"
     result = _run_extensions(command, worker_value=None)
 
     _assert_success(result)
-    assert _trailing_lines(result, 1) == ["1"]
+    assert "CHILD=1" in result.stdout.splitlines()
 
 
-def test_worker_override_reaches_the_pnpm_child_node_process() -> None:
+def test_worker_override_reaches_the_pnpm_child_node_process(tmp_path: Path) -> None:
     """REQ-3078-01 / TC-01F: an explicit seven survives both boundaries."""
-    command = (
-        "printf '%s\\n' \"$PNPM_MAX_WORKERS\"; "
-        "pnpm -C extensions/suno-helper exec node -p "
-        "'process.env.PNPM_MAX_WORKERS'"
-    )
+    project = _dependency_free_project(tmp_path)
+    command = f"printf 'SHELL=%s\\n' \"$PNPM_MAX_WORKERS\"; pnpm -C {project} exec {_CHILD_PROBE}"
     result = _run_extensions(command, worker_value="7")
 
     _assert_success(result)
-    assert _trailing_lines(result, 2) == ["7", "7"]
+    lines = result.stdout.splitlines()
+    assert "SHELL=7" in lines
+    assert "CHILD=7" in lines


### PR DESCRIPTION
Closes #3082

## 概要

`tests/test_extension_package_manager_runtime.py` の 2 件が `pnpm -C extensions/suno-helper exec` を使うため、`node_modules` が無い環境では検証の前に **494 パッケージ / 318MB の実インストール**が走っていた。takt worker ではこの install が `SIGKILL` され、全体 pytest のベースラインが red になって #3043 が plan で ABORT した。

検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。依存ゼロの一時 project へ切り替えて外部ダウンロードを検証経路から除去する。

## 変更

```python
def _dependency_free_project(tmp_path: Path) -> str:
    project = tmp_path / "pnpm-worker-probe"
    project.mkdir()
    manifest = {"name": "pnpm-worker-probe", "version": "0.0.0", "private": True}
    (project / "package.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
    return shlex.quote(str(project))
```

あわせて `_trailing_lines()` を削除し、**検証値へラベルを付けて行集合を検査する**方式へ置き換えた。

## なぜ位置依存の assertion では成立しないか

pnpm は依存ゼロでも `Already up to date` / `Done in ...` を stdout へ出す。TC-01F は shell 境界と child 境界の 2 値を見るが、実測ではノイズが**その 2 値の間**に入る。

```text
SHELL=7
Already up to date

Done in 255ms using pnpm v11.15.1
CHILD=7
```

末尾 2 行は `["Done in ...", "CHILD=7"]` になり `["7", "7"]` にはならない。`_trailing_lines()` は「ノイズは先頭にしか出ない」という暗黙の前提に乗っており、install 済みの環境で 2 件とも通っていたため #3079 の時点では見えていなかった。

```python
assert "CHILD=1" in result.stdout.splitlines()
```

行の位置ではなく内容で照合するため、ノイズの有無・位置・行数のいずれからも独立する。

## 検証

要件 1（実インストールが検証経路から消えたこと）は、`node_modules` が存在しない新規 worktree で決定的に確認した。

| 条件 | 結果 |
|---|---|
| 変更前・クリーンチェックアウト | 494 パッケージの install 後に検証 |
| **変更後・クリーンチェックアウト** | **4 passed / 4.97s、`extensions/suno-helper/node_modules` は生成されない** |
| 空の `XDG_DATA_HOME`（cold store）5 回 | 5/5 green、ダウンロード 0 |

| ゲート | 結果 |
|---|---|
| pytest `-n auto` | **7469 passed, 1 skipped**（158.84s） |
| ruff check / format --check | green |
| yt-skills lint | green（57 skill） |

## 未確認事項

`SIGKILL` の直接原因は特定していない。install を検証経路から外すことで、原因によらず失敗経路ごと除去している。「クリーンチェックアウトで install が走る」ことは #3079 の CI 失敗出力で確定済みのため、318MB の再ダウンロードによる再現は行っていない。

## 影響

この修正により #3043（tests/repo 移設）の blocker が解消する。#3043 の open な blocker は本 issue のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NrWWaTayGvRkpCttyofFQ
