### PR TITLE
feat(takt): ci_verify の環境差を CI へ委譲する

### DIFF
--- a/.takt/facets/instructions/yt-auto-ci-verify.md
+++ b/.takt/facets/instructions/yt-auto-ci-verify.md
@@ -10,4 +10,6 @@ git diff --check
 
 Also run applicable packaging, frontend/extension, ADR, skill, and CHANGELOG checks selected by the CI path contract. Never edit files, skip tests, narrow scope, or reinterpret a failed command as success.
 
-Set structured verdict to `pass` only when all applicable commands exited zero and name every command/result. Set `fail` for a product/test/docs defect, or `abort` when an unavailable tool or environment prevents an honest verdict.
+The structured verdict has exactly two outcomes: `pass` or `fail`. Set `pass` only when every locally runnable applicable command exited zero, and name every command/result. Set `fail` when a locally runnable gate exposes a product/test/docs defect so the workflow routes to `fix`. Never return `abort` from `ci_verify`.
+
+When an applicable gate cannot run locally because the measured environment lacks its command or cannot resolve a required resource, classify that gate as **CI-only** and exclude it from the local verdict. In `findings`, list every excluded gate by name together with the observed reason it was unavailable. Do not silently skip it or treat attempted execution as success. CI-only is permitted only after observing the unavailable command or resource; never use it to avoid a runnable test. The authoritative CI remains responsible for every CI-only gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(takt)`: `ci_verify` の verdict を `pass` / `fail` の 2 値に限定し、ローカル環境で実測上実行できないゲートは項目名と理由を findings に残す CI-only 項目として正本の CI へ委ねるようにした。環境差による ABORT で完成済み実装が破棄されることを防ぎつつ、ローカルで実行できるゲートの失敗は従来どおり fix へ送る（#3087）。
 - `refactor(tests)`: infrastructure / core 層のテストを production module の鏡像配置へ移し、active consumer の参照を更新した（#3044）。
 - `refactor(takt)`: takt 0.55.1 の builtin workflow / step fragment を基準に `.takt/` の feature・fix・docs・maintenance・audit 系 workflow を再設計した。公開 lane の目的を維持しつつ、structured fail-closed gate、有限 loop monitor、CI 同等ゲート、外部副作用を起こさない spillover へ統一し、旧 callable・facet・schema と内部構造固定テストを利用者向け契約テストへ置換した。
 - `refactor(tests)`: repository-only contract testsを `tests/repo/` へ移し、CI・active documentation・workflow facet の参照を canonical path に追従させた（#3043）。

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -63,7 +63,7 @@
 公開定義は `.takt/workflows/`、takt 0.55.1 builtin から eject した共有 step とリポジトリ固有 step は `.takt/steps/`、固有 instruction / report contract だけを `.takt/facets/` に置く。一般的な plan / test-first / implementation review / fix / final gate は builtin 由来 fragment を正とし、旧内部構造への互換 adapter は持たない。
 
 - **検証は実行時 takt を正とする。** 変更前に `takt --version` と `takt catalog` / `takt eject` の内容を確認し、全公開 workflow へ `takt workflow doctor`、各 workflow へ `takt prompt <workflow>` を実行する
-- **CI 同等ゲート(`ci_verify`)を final gate より前に置く。** 最低でも ruff check / format、全 pytest、any-usage gate、`git diff --check` を実行し、変更 path に応じた CI job も追加する。失敗時は修正または再計画へ戻し、環境障害は ABORT する
+- **CI 同等ゲート(`ci_verify`)を final gate より前に置く。** 最低でも ruff check / format、全 pytest、any-usage gate、`git diff --check` を実行し、変更 path に応じた CI job も追加する。ローカルで実行できるゲートの失敗は `fail` として修正へ戻す。実測した環境でコマンドまたは前提リソースを利用できない項目は、項目名と理由を findings に列挙して CI-only とし、ローカル判定から除外して正本の CI へ委ねる。`ci_verify` の verdict は `pass` / `fail` の 2 値とし、環境差を理由に ABORT しない
 - **レビューと final gate は fail-closed。** 専門レビューは未解決 finding / conflict / 判定不能を修正・再計画・ABORT へ送り、既知 verdict に一致しない出力も ABORT する。final gate も COMPLETE 以外をレビュー・修正・再計画・ABORT へ戻す
 - **分岐は 1 個の strict structured schema と `when(structured.*)` で決定する。** 並列 reviewer は各 report を生成するだけにし、直後の gate が全 report を読み structured verdict を返す。これにより判定不能を fallback ABORT へ送り、`takt prompt` でも全 step を reportContent なしで合成できる
 - **有限停止は root `max_steps` と loop monitor で担保する。** monitor は `ignore_steps` でゲートを挟む実際の cycle を追跡し、継続・再計画・ABORT を明示する。公開 lane から無制限 self-loop を作らない


### PR DESCRIPTION
## Summary

- ci_verify の verdict を pass / fail の 2 値に限定する
- ローカルで実測上利用できないゲートを、項目名と理由を findings に残す CI-only 項目として正本の CI へ委ねる
- ローカルで実行可能なゲートの失敗は従来どおり fix へ routing する

Closes #3087