### PR TITLE
chore(docs): worktree の置き場を .claude/worktrees/ へ揃える (#3096)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dist/
 build/
 *.egg-info/
 .coverage
+.claude/worktrees/
 .worktrees/
 
 # Node / extensions (WXT)

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -78,14 +78,16 @@
 ```bash
 git switch main
 git pull --ff-only
-git worktree add .worktrees/issue-<N>-<slug> -b issue-<N>-<slug> main
-cd .worktrees/issue-<N>-<slug>
+git worktree add .claude/worktrees/issue-<N>-<slug> -b issue-<N>-<slug> main
+cd .claude/worktrees/issue-<N>-<slug>
 nix develop
 ```
 
 stack を組まない単独 PR の base branch は `main` 固定とする。stack の上段 branch は直下の branch を base に取るが、その chain は `gh stack` が管理するものであり、手で別 issue の未マージ branch を base に指定しない。stack に載せない依存 issue は、依存 PR の merge 後に main を更新し、rebase してから検証する。takt が生成する worktree(`<repo-parent>/takt-worktrees/`)は takt CLI が管理し、この規約の対象外。
 
-1 worktree = 1 stack とする。`.worktrees/` には `codex/*` の worktree が多数あり、同じ branch が 2 箇所にチェックアウトされていると stack の branch 移動が exit 6 で失敗するため、stack 用の branch 名はそれらと衝突させない。
+worktree の置き場は `$REPO_ROOT/.claude/worktrees/<slug>/` に統一する(グローバル規約と同じ)。takt が生成する `<repo-parent>/takt-worktrees/` だけが例外で、takt CLI が管理する。
+
+1 worktree = 1 stack とする。旧い置き場 `.worktrees/` にはローカル環境によって `codex/*` の worktree が残っていることがあり、同じ branch が 2 箇所にチェックアウトされていると stack の branch 移動が exit 6 で失敗するため、stack 用の branch 名はそれらと衝突させない。`.gitignore` は移行期間中どちらの置き場も無視する。
 
 ## commit / push / PR(gh stack 前提)
 


### PR DESCRIPTION
## 概要

Closes #3096

worktree の置き場をグローバル規約（`$REPO_ROOT/.claude/worktrees/<slug>/`）へ揃える。リポジトリ側は `.worktrees/` を指示しており、置き場が 2 系統に分かれていた。

## 変更内容

- `.gitignore` に `.claude/worktrees/` を追加した。従来は `.git/info/exclude`（コミットされないローカル設定）でしか無視されておらず、**別のクローンで規約どおりに worktree を切ると作業ツリーが untracked ファイルで汚れる**状態だった
- `docs/takt-operations.md` の worktree 作成手順を `.claude/worktrees/` へ変更し、置き場の規約と takt 管理分（`<repo-parent>/takt-worktrees/`）の例外を明記した
- 移行期間中はローカルに残る `.worktrees/` も無視したままにする

## 検証

`.claude/worktrees/probe` に worktree を作り、**追跡される `.gitignore` が ignore の出所になっている**ことを確認した（`.git/info/exclude` ではない）。

```
$ git check-ignore -v .claude/worktrees/probe
.gitignore:39:.claude/worktrees/	.claude/worktrees/probe
```

変更が波及しうる `tests/repo/test_takt_workflow_contract.py` / `test_skill_docs_consistency.py` / `test_b6_integration_contract.py` は 102 passed。

## 関連

- 上段 PR #3101（#3097）— 契約テストが repo 内 worktree を拾う問題。本 PR で置き場が確定してから対処する
