### PR TITLE
fix(tests): repo 内 worktree を契約テストの走査対象から除外する (#3097)

### DIFF
--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -3,3 +3,18 @@ from pathlib import Path
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent.parent
 TESTS_DIR: Path = REPO_ROOT / "tests"
 FIXTURES_DIR: Path = TESTS_DIR / "fixtures"
+
+# worktree の置き場は規約上リポジトリの内側にある(`docs/takt-operations.md`)。
+# 1 つ 1 つが完全なチェックアウトなので、リポジトリを全走査する契約テストから見ると
+# 本体のファイルと区別が付かない。走査対象から外すための正本。
+# `.worktrees/` は旧い置き場で、移行期間中のローカル環境にのみ残る。
+WORKTREE_STORE_PREFIXES: tuple[tuple[str, ...], ...] = ((".claude", "worktrees"), (".worktrees",))
+
+
+def is_inside_worktree_store(path: Path, root: Path = REPO_ROOT) -> bool:
+    """`path` が worktree 置き場の配下にあるか判定する。"""
+    try:
+        parts = path.resolve().relative_to(root.resolve()).parts
+    except ValueError:
+        return False
+    return any(parts[: len(prefix)] == prefix for prefix in WORKTREE_STORE_PREFIXES)

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.helpers.paths import REPO_ROOT
+from tests.helpers.paths import REPO_ROOT, is_inside_worktree_store
 
 _REPO_ROOT = REPO_ROOT
 _PROJECT_COPY_ENTRIES = (
@@ -25,8 +25,20 @@ _PROJECT_COPY_ENTRIES = (
     "uv.lock",
     "src",
 )
-_PROJECT_COPY_IGNORE = shutil.ignore_patterns(".pytest_cache", "__pycache__", "*.pyc")
+_BUILD_ARTIFACT_IGNORE = shutil.ignore_patterns(".pytest_cache", "__pycache__", "*.pyc")
 _MAX_PROJECT_COPY_BYTES = 10 * 1024 * 1024
+
+
+def _project_copy_ignore(directory: str, names: list[str]) -> set[str]:
+    """ビルド生成物と worktree 置き場をコピー対象から外す。
+
+    `.claude` を丸ごとコピーするため、規約どおり `.claude/worktrees/` に切られた
+    worktree をそのまま含めるとコピーが GB 級に膨らむ。サイズ上限は `.claude` 自体の
+    肥大を検出するためのものなので、上限を緩めずに worktree だけを除外する。
+    """
+    ignored = set(_BUILD_ARTIFACT_IGNORE(directory, names))
+    ignored.update(name for name in names if is_inside_worktree_store(Path(directory) / name, _REPO_ROOT))
+    return ignored
 
 
 def _nix_is_available() -> bool:
@@ -78,7 +90,7 @@ def project_copy(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
         source = _REPO_ROOT / entry_name
         destination = project / entry_name
         if source.is_dir():
-            shutil.copytree(source, destination, ignore=_PROJECT_COPY_IGNORE)
+            shutil.copytree(source, destination, ignore=_project_copy_ignore)
         else:
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)

--- a/tests/test_b4_auth_resource_contract.py
+++ b/tests/test_b4_auth_resource_contract.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.helpers.paths import REPO_ROOT
+from tests.helpers.paths import REPO_ROOT, is_inside_worktree_store
 
 ROOT = REPO_ROOT
 CANONICAL_RELATIVE = Path("src/youtube_automation/infrastructure/resources/auth/client_secrets.template.json")
@@ -74,7 +74,10 @@ def test_canonical_template_is_the_only_source_and_has_no_root_copy() -> None:
     templates = sorted(
         path.relative_to(ROOT)
         for path in ROOT.rglob(TEMPLATE_NAME)
-        if ".git" not in path.parts and ".takt" not in path.parts and ".venv" not in path.parts
+        if ".git" not in path.parts
+        and ".takt" not in path.parts
+        and ".venv" not in path.parts
+        and not is_inside_worktree_store(path, ROOT)
     )
 
     assert canonical.is_file()


### PR DESCRIPTION
## 概要

Closes #3097

リポジトリ内に worktree があるとローカルの全体 pytest が red になる。契約テスト 2 件が gitignore を見ないファイルシステム走査でリポジトリを検査しており、worktree（それ自体が完全なチェックアウト）を本体の一部として数えるため。

規約上 worktree はリポジトリの内側に置かれる（#3096）ので、テスト側がそれを前提にする。

## 変更内容

- `tests/helpers/paths.py` に置き場の定義 `WORKTREE_STORE_PREFIXES` と判定 `is_inside_worktree_store()` を置き、両テストの正本にした
- `tests/test_b4_auth_resource_contract.py` — `ROOT.rglob` の既存除外（`.git` / `.takt` / `.venv`）に worktree 置き場を加えた
- `tests/integration/test_dev_shell_sync.py` — `.claude` の copytree から worktree だけを外した

**10 MB のサイズ上限は緩めていない。** あの判定は `.claude` 自体の肥大を検出するためのもので、上限を上げると本来の検出力を失う。

## 検証

`.claude/worktrees/probe` に実際に worktree（20 MB）を切った状態で実測した。

| 条件 | 結果 |
|---|---|
| 修正なし・probe あり | **2 件とも fail**（`assert [PosixPath('.claude/worktrees/...'), ...] == [...]` / `assert 27... < 10485760`） |
| 修正あり・probe あり | 2 件とも pass |
| 修正あり・probe あり・全体 | **7491 passed, 1 skipped** |

`ruff check .` / `ruff format --check .` ともに pass。

## 関連

- 下段 PR #3100（#3096）— worktree の置き場をグローバル規約へ揃える
