### PR TITLE
fix(thumbnail): Codexへopt-in clauseを伝搬する (#2557)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -203,6 +203,11 @@ Codex 経路でも `image_generation.gemini.composition_rules` は自動的に�
 レジェンド名や楽器・ポーズを手書きで重複指定しない。設定されたルールが Codex に渡らないまま
 参照被写体を踏襲することは許容しない。
 
+`image_generation.gemini.single_step` の opt-in clause は、`variation_clause` / `style_lock_clause` /
+`anatomy_clause` / `typography_clause` のうち非空の 1 つだけを Codex prompt の末尾へ追加する。
+複数を同時指定した場合はプロンプトを積み上げず `ConfigError` で停止する。`text_strip_clause` は
+承認済み thumbnail から textless main を作る後段専用で、テキスト付き候補の prompt には追加しない。
+
 codex 経路でも標準ファイル契約は同じ:
 
 1. ベンチマーク参照画像から、テキスト付き候補を `10-assets/thumbnail-codex-v1.png` に生成する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fix(thumbnail)`: Codex prompt helper が `image_generation.gemini.single_step` の opt-in clause を silent に無視せず、非空の 1 件をテキスト付きサムネイル prompt へ伝搬するようにした。複数 clause の同時指定は fail-fast し、textless 専用の `text_strip_clause` は初回 prompt へ混入させない（#2557）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/src/youtube_automation/commands/media/generate_image.py
+++ b/src/youtube_automation/commands/media/generate_image.py
@@ -43,7 +43,10 @@ from youtube_automation.infrastructure.media.image_provider.composition import (
     validate_single_step_references,
     validate_single_step_request_references,
 )
-from youtube_automation.infrastructure.media.image_provider.config import replace_model
+from youtube_automation.infrastructure.media.image_provider.config import (
+    expand_thumbnail_prompt_clauses,
+    replace_model,
+)
 from youtube_automation.infrastructure.observability.profile import section
 
 # Gemini 用の解像度オプション（OpenAI provider 時は無視される）
@@ -129,34 +132,6 @@ def apply_ab_test_pattern(prompt: str, patterns: list[dict[str, str]], pattern_n
         available = ", ".join(item["name"] for item in patterns)
         raise ConfigError(f"--ab-pattern={pattern_name!r} は未定義です（有効値: {available}）")
     return f"{prompt.rstrip()}\n{pattern['variation']}"
-
-
-def expand_thumbnail_prompt_clauses(prompt: str, skill_cfg: dict) -> str:
-    """thumbnail skill-config の prompt clause placeholder を展開する。"""
-    if "${typography_clause}" not in prompt:
-        return prompt
-
-    image_generation = _required_mapping(skill_cfg.get("image_generation"), "image_generation")
-    gemini = _required_mapping(image_generation.get("gemini"), "image_generation.gemini")
-    single_step = _required_mapping(gemini.get("single_step"), "image_generation.gemini.single_step")
-    thumbnail_text = _required_mapping(gemini.get("thumbnail_text"), "image_generation.gemini.thumbnail_text")
-    font = _required_mapping(thumbnail_text.get("font"), "image_generation.gemini.thumbnail_text.font")
-
-    typography_clause = _required_non_empty_string(
-        single_step.get("typography_clause"),
-        "image_generation.gemini.single_step.typography_clause",
-    )
-    font_description = _required_non_empty_string(
-        font.get("copy"),
-        "image_generation.gemini.thumbnail_text.font.copy",
-    )
-    if "{font_description}" not in typography_clause:
-        raise ConfigError(
-            "image_generation.gemini.single_step.typography_clause は {font_description} を含めてください"
-        )
-
-    rendered_clause = typography_clause.replace("{font_description}", font_description)
-    return prompt.replace("${typography_clause}", rendered_clause.strip())
 
 
 def _next_planned_path(output_path: Path, taken: set[Path]) -> Path:

--- a/src/youtube_automation/infrastructure/media/image_provider/config.py
+++ b/src/youtube_automation/infrastructure/media/image_provider/config.py
@@ -35,6 +35,12 @@ _DEFAULT_GEMINI_CLI_TIMEOUT = 300
 # （provider 切替時の無自覚な高単価課金を防ぐ。high は明示 opt-in のみ、#1697）
 _DEFAULT_OPENAI_QUALITY = "medium"
 _DEFAULT_CODEX_MAX_PARALLEL = 2
+_CODEX_THUMBNAIL_OPT_IN_CLAUSE_KEYS = (
+    "variation_clause",
+    "style_lock_clause",
+    "anatomy_clause",
+    "typography_clause",
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +111,7 @@ class CodexConfig:
 
     default_prompt_template: str = ""
     composition_rules: dict[str, object] | None = None
+    thumbnail_guidance: str | None = None
     max_parallel: int = _DEFAULT_CODEX_MAX_PARALLEL
 
 
@@ -166,10 +173,15 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
 
     gemini_section = section.get("gemini")
     composition_rules = _composition_rules_from_gemini(gemini_section)
+    thumbnail_guidance = _codex_thumbnail_guidance_from_gemini(gemini_section)
     codex_cfg = (
-        _build_codex(section.get("codex"), composition_rules=composition_rules)
+        _build_codex(
+            section.get("codex"),
+            composition_rules=composition_rules,
+            thumbnail_guidance=thumbnail_guidance,
+        )
         if "codex" in section
-        else CodexConfig(composition_rules=composition_rules)
+        else CodexConfig(composition_rules=composition_rules, thumbnail_guidance=thumbnail_guidance)
     )
     return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
@@ -201,7 +213,12 @@ def _build_openai(d: dict[str, Any]) -> OpenAIConfig:
     )
 
 
-def _build_codex(d: object, *, composition_rules: dict[str, object] | None) -> CodexConfig:
+def _build_codex(
+    d: object,
+    *,
+    composition_rules: dict[str, object] | None,
+    thumbnail_guidance: str | None,
+) -> CodexConfig:
     if not isinstance(d, dict):
         raise ConfigError("image_generation.codex は mapping で指定してください")
     template = d.get("default_prompt_template", "")
@@ -215,6 +232,7 @@ def _build_codex(d: object, *, composition_rules: dict[str, object] | None) -> C
     return CodexConfig(
         default_prompt_template=template,
         composition_rules=composition_rules,
+        thumbnail_guidance=thumbnail_guidance,
         max_parallel=max_parallel,
     )
 
@@ -226,6 +244,72 @@ def _composition_rules_from_gemini(section: object) -> dict[str, object] | None:
     if not isinstance(rules, dict):
         raise ConfigError("image_generation.gemini.composition_rules は mapping で指定してください")
     return rules
+
+
+def _codex_thumbnail_guidance_from_gemini(section: object) -> str | None:
+    if not isinstance(section, dict) or "single_step" not in section:
+        return None
+    single_step = section["single_step"]
+    if not isinstance(single_step, dict):
+        raise ConfigError("image_generation.gemini.single_step は mapping で指定してください")
+
+    configured: list[tuple[str, str]] = []
+    for key in _CODEX_THUMBNAIL_OPT_IN_CLAUSE_KEYS:
+        value = single_step.get(key, "")
+        if not isinstance(value, str):
+            raise ConfigError(f"image_generation.gemini.single_step.{key} は文字列で指定してください")
+        if normalized := value.strip():
+            configured.append((key, normalized))
+
+    if len(configured) > 1:
+        keys = ", ".join(key for key, _ in configured)
+        raise ConfigError(f"Codex thumbnail の opt-in clause は 1 つだけ指定してください: {keys}")
+    if not configured:
+        return None
+    key, guidance = configured[0]
+    return _render_thumbnail_typography_clause(section) if key == "typography_clause" else guidance
+
+
+def _required_mapping(value: object, key: str) -> dict:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{key} は object で指定してください")
+    return value
+
+
+def _required_non_empty_string(value: object, key: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{key} は空でない文字列で指定してください")
+    return value
+
+
+def _render_thumbnail_typography_clause(gemini: object) -> str:
+    gemini = _required_mapping(gemini, "image_generation.gemini")
+    single_step = _required_mapping(gemini.get("single_step"), "image_generation.gemini.single_step")
+    thumbnail_text = _required_mapping(gemini.get("thumbnail_text"), "image_generation.gemini.thumbnail_text")
+    font = _required_mapping(thumbnail_text.get("font"), "image_generation.gemini.thumbnail_text.font")
+    typography_clause = _required_non_empty_string(
+        single_step.get("typography_clause"),
+        "image_generation.gemini.single_step.typography_clause",
+    )
+    font_description = _required_non_empty_string(
+        font.get("copy"),
+        "image_generation.gemini.thumbnail_text.font.copy",
+    )
+    if "{font_description}" not in typography_clause:
+        raise ConfigError(
+            "image_generation.gemini.single_step.typography_clause は {font_description} を含めてください"
+        )
+    return typography_clause.replace("{font_description}", font_description).strip()
+
+
+def expand_thumbnail_prompt_clauses(prompt: str, skill_cfg: dict) -> str:
+    """thumbnail skill-config の prompt clause placeholder を展開する。"""
+    if "${typography_clause}" not in prompt:
+        return prompt
+    image_generation = _required_mapping(skill_cfg.get("image_generation"), "image_generation")
+    gemini = _required_mapping(image_generation.get("gemini"), "image_generation.gemini")
+    rendered_clause = _render_thumbnail_typography_clause(gemini)
+    return prompt.replace("${typography_clause}", rendered_clause)
 
 
 def _validate_codex_prompt_template(template: Any) -> str:
@@ -250,6 +334,12 @@ def _render_codex_composition_rules(rules: dict[str, object] | None) -> str:
     return f"\n\nComposition rules (must follow; these override the reference subject):\n{rendered}"
 
 
+def _render_codex_thumbnail_guidance(guidance: str | None) -> str:
+    if guidance is None:
+        return ""
+    return f"\n\nAdditional thumbnail guidance:\n{guidance}"
+
+
 def _validate_required_legend_motif(rules: dict[str, object] | None) -> None:
     if not rules:
         return
@@ -271,7 +361,11 @@ def build_codex_prompt(skill_cfg: dict[str, Any], title: str) -> str:
         raise ConfigError("image_generation.provider=codex の設定で実行してください")
     _validate_required_legend_motif(cfg.codex.composition_rules)
     prompt = render_codex_prompt(cfg.codex.default_prompt_template, title)
-    return prompt + _render_codex_composition_rules(cfg.codex.composition_rules)
+    return (
+        prompt
+        + _render_codex_thumbnail_guidance(cfg.codex.thumbnail_guidance)
+        + _render_codex_composition_rules(cfg.codex.composition_rules)
+    )
 
 
 def replace_model(cfg: ImageGenerationConfig, model: str) -> ImageGenerationConfig:

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -1390,6 +1390,25 @@ def test_codex_prompt_helper_cli_renders_default_template(tmp_path: Path) -> Non
     assert "{title}" not in result.stdout
 
 
+def test_codex_prompt_helper_cli_appends_style_lock_clause(tmp_path: Path) -> None:
+    """#2557: channel override の opt-in clause を Codex CLI 出力へ伝搬する。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        """image_generation:
+  provider: codex
+  gemini:
+    single_step:
+      style_lock_clause: Keep the strong caricature treatment.
+""",
+        "Night Groove",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Use the title Night Groove." in result.stdout
+    assert "Additional thumbnail guidance:" in result.stdout
+    assert "Keep the strong caricature treatment." in result.stdout
+
+
 def test_codex_prompt_helper_cli_rejects_non_codex_provider(tmp_path: Path) -> None:
     """#1300: codex 以外の provider では prompt helper を失敗させる。"""
     result = _run_codex_prompt_cli(

--- a/tests/infrastructure/media/test_image_provider_config.py
+++ b/tests/infrastructure/media/test_image_provider_config.py
@@ -242,6 +242,93 @@ class TestParseImageGenerationConfig:
 
         assert prompt == "Use the title Rain Study."
 
+    def test_build_codex_prompt_appends_single_step_opt_in_clause(self):
+        """Given Codex provider と単一の opt-in clause
+        When prompt を build する
+        Then clause 本文が title prompt の末尾へ渡る。
+        """
+        prompt = build_codex_prompt(
+            {
+                "image_generation": {
+                    "provider": "codex",
+                    "gemini": {
+                        "single_step": {
+                            "style_lock_clause": "Keep the strong caricature treatment.",
+                        }
+                    },
+                    "codex": {"default_prompt_template": "Use the title {title}."},
+                }
+            },
+            "Night Groove",
+        )
+
+        assert prompt == (
+            "Use the title Night Groove.\n\nAdditional thumbnail guidance:\nKeep the strong caricature treatment."
+        )
+
+    def test_build_codex_prompt_rejects_multiple_single_step_opt_in_clauses(self):
+        """Given Codex provider と複数の opt-in clause
+        When prompt を build する
+        Then clause の積み上げを ConfigError で拒否する。
+        """
+        skill_cfg = {
+            "image_generation": {
+                "provider": "codex",
+                "gemini": {
+                    "single_step": {
+                        "variation_clause": "Create a variation.",
+                        "style_lock_clause": "Keep the lighting.",
+                    }
+                },
+                "codex": {"default_prompt_template": "Use the title {title}."},
+            }
+        }
+
+        with pytest.raises(ConfigError, match="opt-in clause.*1 つ"):
+            build_codex_prompt(skill_cfg, "Night Groove")
+
+    def test_build_codex_prompt_expands_typography_font_description(self):
+        """Given font placeholder を持つ typography clause
+        When Codex prompt を build する
+        Then thumbnail_text.font.copy の実値へ展開する。
+        """
+        prompt = build_codex_prompt(
+            {
+                "image_generation": {
+                    "provider": "codex",
+                    "gemini": {
+                        "single_step": {
+                            "typography_clause": "Use a consistent {font_description} typeface.",
+                        },
+                        "thumbnail_text": {"font": {"copy": "classic serif"}},
+                    },
+                    "codex": {"default_prompt_template": "Use the title {title}."},
+                }
+            },
+            "Night Groove",
+        )
+
+        assert "Use a consistent classic serif typeface." in prompt
+        assert "{font_description}" not in prompt
+
+    def test_build_codex_prompt_does_not_mix_text_strip_into_thumbnail_prompt(self):
+        """Given textless main 専用 clause
+        When text-included Codex prompt を build する
+        Then text strip 指示は初回 prompt へ混入しない。
+        """
+        prompt = build_codex_prompt(
+            {
+                "image_generation": {
+                    "provider": "codex",
+                    "gemini": {"single_step": {"text_strip_clause": "Remove all text."}},
+                    "codex": {"default_prompt_template": "Use the title {title}."},
+                }
+            },
+            "Night Groove",
+        )
+
+        assert prompt == "Use the title Night Groove."
+
     def test_build_codex_prompt_injects_gemini_composition_rules_for_codex(self):
         prompt = build_codex_prompt(
             {


### PR DESCRIPTION
## Summary
- Codex prompt helperへsingle_stepの非空opt-in clauseを1件だけ伝搬
- typographyのfont_descriptionを既存生成経路と共通のvalidationで展開
- 複数clauseはfail-fastし、text_stripと後続#2586のip_safety境界を維持

## Verification
- `nix develop --command uv run pytest -n auto -q` (7496 passed, 1 skipped)
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run yt-skills lint`
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh`
- `git diff --check`
- read-only review: APPROVE

Closes #2557