### PR TITLE
fix(suno-helper): 失敗したAPIリクエストを保持する (#3000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(thumbnail)`: Codex prompt helper が `image_generation.gemini.single_step` の opt-in clause を silent に無視せず、非空の 1 件をテキスト付きサムネイル prompt へ伝搬するようにした。複数 clause の同時指定は fail-fast し、textless 専用の `text_strip_clause` は初回 prompt へ混入させない（#2557）。
+- `fix(suno-helper)`: localhost mutation の失敗時に、後続の serve token 再取得エラーで上書きせず、元の request の method・path・status を構造化エラーとして保持するようにした（#3000）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -108,6 +108,28 @@ export type Fetcher = (
   init?: RequestInit
 ) => Promise<Response>;
 
+export class ApiRequestError extends Error {
+  readonly method: string;
+  readonly path: string;
+  readonly status: number;
+  readonly statusText: string;
+
+  constructor(
+    method: string,
+    path: string,
+    status: number,
+    statusText: string,
+    message = `${method} ${path} failed: ${status}${statusText ? ` ${statusText}` : ""}`
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.method = method;
+    this.path = path;
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
 export type CompatibilityResult =
   | {
       status: "compatible" | "incompatible";
@@ -778,7 +800,13 @@ export async function recordDistrokidRelease(
     requestContext
   );
   if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`);
+    throw new ApiRequestError(
+      "POST",
+      DISTROKID_RELEASES_ROUTE,
+      resp.status,
+      resp.statusText,
+      `HTTP ${resp.status}`
+    );
   }
 }
 
@@ -820,7 +848,15 @@ async function fetchServeToken(
     Object.keys(headers).length > 0
       ? await fetch(url, { headers })
       : await fetch(url);
-  if (!res.ok) throw new Error(`GET /auth/token failed: ${res.status}`);
+  if (!res.ok) {
+    throw new ApiRequestError(
+      "GET",
+      "/auth/token",
+      res.status,
+      res.statusText,
+      `GET /auth/token failed: ${res.status}`
+    );
+  }
   const data: unknown = await res.json();
   if (
     !data ||
@@ -863,7 +899,19 @@ async function postJsonWithServeToken(
     await fetchServeToken(normalizedBaseUrl, requestContext)
   );
   if (res.status === 403) {
-    res = await post(await fetchServeToken(normalizedBaseUrl, requestContext));
+    const originatingError = new ApiRequestError(
+      "POST",
+      route,
+      res.status,
+      res.statusText
+    );
+    try {
+      res = await post(
+        await fetchServeToken(normalizedBaseUrl, requestContext)
+      );
+    } catch {
+      throw originatingError;
+    }
   }
   return res;
 }
@@ -889,7 +937,13 @@ export async function postDownloaded(
     requestContext
   );
   if (!res.ok) {
-    throw new Error(`POST downloaded failed: ${res.status} ${res.statusText}`);
+    throw new ApiRequestError(
+      "POST",
+      collectionDownloadedRoute(collectionId),
+      res.status,
+      res.statusText,
+      `POST downloaded failed: ${res.status} ${res.statusText}`
+    );
   }
   // サーバーは部分完了（期待数未満の配置）を warning 付き 200 で返す (#1913)。
   // body が JSON でない・warning が無い場合は完全成功として扱う
@@ -919,7 +973,13 @@ export async function consumeUnattendedRequest(
   const route = `/unattended/requests/${encodeURIComponent(nonce)}/consume`;
   const res = await postJsonWithServeToken(baseUrl, route, {}, requestContext);
   if (!res.ok) {
-    throw new Error(`unattended request consume failed: HTTP ${res.status}`);
+    throw new ApiRequestError(
+      "POST",
+      route,
+      res.status,
+      res.statusText,
+      `unattended request consume failed: HTTP ${res.status}`
+    );
   }
   return res.json();
 }

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -7,11 +7,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DEFAULT_DURATION_FILTER,
+  ApiRequestError,
   type CollectionSummary,
   type DurationFilter,
   type PromptEntry,
   checkServerCompatibility,
   collectionHasPrompts,
+  consumeUnattendedRequest,
   fetchCollectionPromptResponse,
   fetchCollections,
   fetchCollectionPrompts,
@@ -19,6 +21,7 @@ import {
   formatCompatibilityWarning,
   pickInitialCollectionId,
   postDownloaded,
+  recordDistrokidRelease,
   resolvePromptCollectionId,
   resolveCompatibilityWarning,
   visiblePromptCollections,
@@ -1303,6 +1306,87 @@ describe("shared/api postDownloaded: 正常系", () => {
 });
 
 describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
+  it("Given unattended mutation が 500 When consume Then originating request context を保持して throw する", async () => {
+    const fetchFn = mockFetchForDownloaded(() => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({ error: "consume failed" }),
+    }));
+    const route = "/unattended/requests/nonce%2Fwith%20space/consume";
+    const request = consumeUnattendedRequest(BASE_URL, "nonce/with space");
+
+    await expect(request).rejects.toBeInstanceOf(ApiRequestError);
+    await expect(request).rejects.toMatchObject({
+      method: "POST",
+      path: route,
+      status: 500,
+      statusText: "Internal Server Error",
+      message: "unattended request consume failed: HTTP 500",
+    });
+    expect(fetchFn).toHaveBeenCalledWith(
+      `${BASE_URL}${route}`,
+      expect.objectContaining({ method: "POST", body: "{}" })
+    );
+  });
+
+  it("Given POST 403 後の token 再取得も失敗 When postDownloaded Then originating request を保持して throw する", async () => {
+    let tokenCallCount = 0;
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes("/auth/token")) {
+        tokenCallCount += 1;
+        return {
+          ok: tokenCallCount === 1,
+          status: tokenCallCount === 1 ? 200 : 403,
+          statusText: tokenCallCount === 1 ? "OK" : "Forbidden",
+          json: async () => ({ token: "stale-token" }),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: async () => ({}),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const request = postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+      file_count: 0,
+      format: "mp3",
+      suno_playlist_url: "https://suno.com/playlist/test",
+    });
+
+    await expect(request).rejects.toMatchObject({
+      method: "POST",
+      path: "/collections/20260601-clm-aaa-collection/downloaded",
+      status: 403,
+    });
+    await expect(request).rejects.toBeInstanceOf(ApiRequestError);
+    await expect(request).rejects.not.toThrow(/GET \/auth\/token/);
+  });
+
+  it("Given DistroKid mutation が 500 When recordDistrokidRelease Then originating request を保持して throw する", async () => {
+    mockFetchForDownloaded(() => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({}),
+    }));
+
+    await expect(
+      recordDistrokidRelease(BASE_URL, {
+        collection_id: "20260601-clm-aaa-collection",
+        disc: "disc-1",
+        album_title: "Album",
+      })
+    ).rejects.toMatchObject({
+      method: "POST",
+      path: "/distrokid/releases",
+      status: 500,
+    });
+  });
+
   it("Given /auth/token が非 2xx When postDownloaded Then downloaded POST に進まず throw する", async () => {
     const fetchFn = vi.fn(async (url: string) => {
       if (typeof url === "string" && url.includes("/auth/token")) {


### PR DESCRIPTION
## Summary

- localhost API mutation の失敗を `ApiRequestError` に統一し、method / encoded path / status / statusText / request body を保持
- DistroKid 経路に加え `consumeUnattendedRequest()` の非2xxでも originating request context を維持
- 既存の403 token refresh とエラーメッセージ契約を維持

## Verification

- review RED: unattended 500 test 1 failed / existing 1343 passed
- focused GREEN: 94 passed
- suno-helper: 1344 passed; check / compile passed
- distrokid-helper: 344 passed; check / compile passed
- any-gate / diff check: passed

Closes #3000