### PR TITLE
fix(suno-helper): ZIP名の表記揺れを吸収する (#3002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(thumbnail)`: Codex prompt helper が `image_generation.gemini.single_step` の opt-in clause を silent に無視せず、非空の 1 件をテキスト付きサムネイル prompt へ伝搬するようにした。複数 clause の同時指定は fail-fast し、textless 専用の `text_strip_clause` は初回 prompt へ混入させない（#2557）。
+- `fix(suno-helper)`: Suno ZIP の clip 名に含まれる em-dash 周りの空白差・全角空白・`(1)` / `_1` 重複 suffix を prompts の同一 entry として照合し、配置 skip を防ぐようにした（#3002）。
 - `fix(suno-helper)`: localhost mutation の失敗時に、後続の serve token 再取得エラーで上書きせず、元の request の method・path・status を構造化エラーとして保持するようにした（#3000）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -81,6 +81,8 @@ _LATIN_TITLE_TAIL_RE = re.compile(r"([A-Za-z][A-Za-z0-9 &'(),.!?:/-]*)$")
 # Suno はダウンロード ZIP 内のファイル名からアポストロフィを除去する（例: Greed's Rhythm → Greeds Rhythm.m4a）。
 # typographic apostrophe（U+2019）も同一視する。それ以外の記号は Suno 仕様が未確認のため除去しない
 _APOSTROPHE_RE = re.compile(r"['’]")
+_LOOKUP_EM_DASH_RE = re.compile(r"\s*—\s*")
+_LOOKUP_SPACE_RE = re.compile(r"\s+")
 _OUTPUT_STEM_SEPARATOR_RE = re.compile(r"[\\/]+")
 _OUTPUT_STEM_SPACE_RE = re.compile(r"\s+")
 
@@ -108,22 +110,29 @@ def _suno_name_lookup_candidates(name: str) -> list[str]:
     return deduped
 
 
+def _normalize_suno_name_for_lookup(name: str) -> str:
+    with_canonical_dash = _LOOKUP_EM_DASH_RE.sub(" — ", name)
+    return _LOOKUP_SPACE_RE.sub(" ", with_canonical_dash).strip()
+
+
 def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str]]:
     member_path = PurePosixPath(filename)
     relative_stem = member_path.with_suffix("").as_posix()
     raw_stems = [relative_stem, member_path.stem]
     deduped: list[tuple[str, str]] = []
     for raw_stem in raw_stems:
-        if raw_stem.endswith("_1"):
-            stem = raw_stem[:-2]
+        dup_match = _DUP_SUFFIX_RE.fullmatch(raw_stem.strip())
+        if dup_match is not None and int(dup_match.group("paren") or dup_match.group("underscore")) == 1:
+            stem = dup_match.group("base")
             variant = "b"
         else:
             stem = raw_stem
             variant = "a"
         for candidate in _suno_name_lookup_candidates(stem):
-            item = (candidate, variant)
-            if item not in deduped:
-                deduped.append(item)
+            for lookup in (candidate, _normalize_suno_name_for_lookup(candidate)):
+                item = (lookup, variant)
+                if lookup and item not in deduped:
+                    deduped.append(item)
     return deduped
 
 
@@ -169,6 +178,9 @@ def _build_name_to_index(coll_dir: Path, prompt_entries_reader: PromptEntriesRea
         stripped = _APOSTROPHE_RE.sub("", key)
         if stripped and stripped != key:
             name_to_index.setdefault(stripped, track_index)
+        normalized = _normalize_suno_name_for_lookup(key)
+        if normalized and normalized != key:
+            name_to_index.setdefault(normalized, track_index)
     return name_to_index
 
 

--- a/tests/domains/suno/downloaded/test_archive.py
+++ b/tests/domains/suno/downloaded/test_archive.py
@@ -1,0 +1,48 @@
+"""Suno downloaded ZIP archive reconciliation tests."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from youtube_automation.domains.suno.downloaded.archive import extract_and_rename_music
+
+
+def test_extract_reconciles_suno_zip_name_variations(tmp_path: Path) -> None:
+    """Given Suno ZIP に実走で観測した4種の表記揺れがある
+    When prompts と照合して展開する
+    Then 6 clip すべてを対応する entry の a/b variant へ配置する。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [
+        {"name": "反響の花 — Echo—Bloom"},
+        {"name": "天空の道 — Full Width Sky"},
+        {"name": "静かな光 — Ordinary Light"},
+    ]
+    archive = tmp_path / "download.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("Echo — Bloom.mp3", b"em-dash-a")
+        zipped.writestr("Echo — Bloom (1).mp3", b"em-dash-b")
+        zipped.writestr("Full　Width Sky.mp3", b"fullwidth-space-a")
+        zipped.writestr("Full　Width Sky_1.mp3", b"underscore-b")
+        zipped.writestr("Ordinary Light.mp3", b"plain-a")
+        zipped.writestr("Ordinary Light (1).mp3", b"parenthesized-b")
+
+    placed_count = extract_and_rename_music(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=lambda _collection_dir: entries,
+    )
+
+    music_dir = tmp_path / "02-Individual-music"
+    assert placed_count == 6
+    assert {path.name: path.read_bytes() for path in music_dir.iterdir()} == {
+        "01a-Echo — Bloom.mp3": b"em-dash-a",
+        "01b-Echo — Bloom.mp3": b"em-dash-b",
+        "02a-Full Width Sky.mp3": b"fullwidth-space-a",
+        "02b-Full Width Sky.mp3": b"underscore-b",
+        "03a-Ordinary Light.mp3": b"plain-a",
+        "03b-Ordinary Light.mp3": b"parenthesized-b",
+    }


### PR DESCRIPTION
## Summary
- em-dash 周辺空白と全角空白を exact 優先の fallback alias へ正規化
- ZIP の `Title (1).ext` / `Title_1.ext` を同じ b variant として照合
- 実走相当 6 clip の配置回帰テストを追加

## Verification
- TDD red: 2/6 placed、4 件 skip を再現
- `uv run pytest tests/domains/suno/downloaded -q`
- 関連 archive tests: 10 passed
- playlist verification: 53 passed
- full pytest: 7492 passed, 1 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- any-usage gate / `git diff --check`

Closes #3002