### PR TITLE
fix(distrokid-helper): コレクション表示を簡略化する (#2515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `fix(thumbnail)`: Codex prompt helper が `image_generation.gemini.single_step` の opt-in clause を silent に無視せず、非空の 1 件をテキスト付きサムネイル prompt へ伝搬するようにした。複数 clause の同時指定は fail-fast し、textless 専用の `text_strip_clause` は初回 prompt へ混入させない（#2557）。
+- `fix(distrokid-helper)`: dir mode のコレクション選択表示を `アルバム名（曲数）` へ簡略化し、選択中ラベルの省略表示と候補一覧の横 overflow 防止を追加。表示と独立した `collection_id / disc` の選択 identity は維持した（#2515）。
 - `fix(suno-helper)`: Suno ZIP の clip 名に含まれる em-dash 周りの空白差・全角空白・`(1)` / `_1` 重複 suffix を prompts の同一 entry として照合し、配置 skip を防ぐようにした（#3002）。
 - `fix(suno-helper)`: localhost mutation の失敗時に、後続の serve token 再取得エラーで上書きせず、元の request の method・path・status を構造化エラーとして保持するようにした（#3000）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。

--- a/extensions/distrokid-helper/components/App.tsx
+++ b/extensions/distrokid-helper/components/App.tsx
@@ -64,18 +64,18 @@ export function App() {
             value={String(selectedIndex)}
             items={collections.map((item, index) => ({
               value: String(index),
-              label: `${item.name} / ${item.disc}（${item.album_title}・${item.track_count} 曲）`,
+              label: `${item.album_title}（${item.track_count} 曲）`,
             }))}
             disabled={isInjecting}
             onValueChange={(value) => selectCollection(Number(value))}
           >
             <SelectTrigger
               data-selected-value={String(selectedIndex)}
-              className="w-full"
+              className="w-full min-w-0 overflow-hidden"
               aria-labelledby="collection-select-label"
               data-distrokid-control="collection-select"
             >
-              <SelectValue />
+              <SelectValue className="min-w-0 truncate" />
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
@@ -84,7 +84,7 @@ export function App() {
                     key={`${item.collection_id}/${item.disc}`}
                     value={String(idx)}
                   >
-                    {`${item.name} / ${item.disc}（${item.album_title}・${item.track_count} 曲）`}
+                    {`${item.album_title}（${item.track_count} 曲）`}
                   </SelectItem>
                 ))}
               </SelectGroup>

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -357,6 +357,54 @@ describe("DistroKid popup compatibility check", () => {
     expect(stopButton?.dataset.variant).toBe("outline");
   });
 
+  it("コレクション selector は選択中と候補をアルバム名（曲数）で表示し、横 overflow を防ぐ", async () => {
+    vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
+    stubDirModeServer();
+
+    await renderApp();
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-distrokid-control="collection-select"]'
+    )!;
+    await waitFor(() => {
+      expect(trigger.textContent).toBe(
+        `${DISC1.album_title}（${DISC1.track_count} 曲）`
+      );
+    });
+    expect(Array.from(trigger.classList)).toEqual(
+      expect.arrayContaining(["w-full", "min-w-0", "overflow-hidden"])
+    );
+    expect(
+      Array.from(
+        trigger.querySelector<HTMLElement>('[data-slot="select-value"]')!
+          .classList
+      )
+    ).toEqual(expect.arrayContaining(["min-w-0", "truncate"]));
+
+    await act(async () => trigger.click());
+    const collectionOptions = (): HTMLElement[] =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>('[role="option"]')
+      ).filter(
+        (option) => option.dataset.value === "0" || option.dataset.value === "1"
+      );
+    await waitFor(() => expect(collectionOptions()).toHaveLength(2));
+    expect(
+      collectionOptions().map((option) => ({
+        text: option.textContent,
+        value: option.dataset.value,
+      }))
+    ).toEqual([
+      { text: `${DISC1.album_title}（${DISC1.track_count} 曲）`, value: "0" },
+      { text: `${DISC2.album_title}（${DISC2.track_count} 曲）`, value: "1" },
+    ]);
+    expect(
+      collectionOptions()[0].closest<HTMLElement>(
+        '[data-slot="select-content"]'
+      )?.classList
+    ).toContain("overflow-x-hidden");
+  });
+
   it("全 disc が配信済みなら選択肢を表示せず all-released 状態を案内する", async () => {
     vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
     fetchMock.mockImplementation(async (url: string) => {
@@ -467,7 +515,26 @@ describe("DistroKid popup compatibility check", () => {
 
   it("collection 選択時に一覧を最新化し、選択 disc の release へ自動更新する", async () => {
     vi.mocked(serverUrlItem.getValue).mockResolvedValue(BASE_URL);
-    stubDirModeServer();
+    const sameLabelDisc2 = {
+      ...DISC2,
+      album_title: DISC1.album_title,
+      track_count: DISC1.track_count,
+    };
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/server-info` || url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(200, [DISC1, sameLabelDisc2]);
+      }
+      if (url.includes(`/${DISC1.disc}/release.json`)) {
+        return jsonResponse(200, RELEASE_PAYLOAD);
+      }
+      if (url.includes(`/${DISC2.disc}/release.json`)) {
+        return jsonResponse(200, SECOND_RELEASE_PAYLOAD);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
     await renderApp();
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- 選択中表示と候補ラベルを `アルバム名（曲数）` に統一
- trigger/value を縮小し clip/truncate で overflow を防止
- 同一表示ラベルの複数 disc でも内部 identity から正しい release を取得

## Verification
- TDD red: 旧ラベルを返す失敗を再現
- focused Vitest: 20 passed
- full DistroKid Vitest: 345 passed
- Chromium E2E: 8 passed
- check / compile / build
- ruff check / format, any-gate, `git diff --check`

Closes #2515