### PR TITLE
fix(videoup): 未解決の登録ポップアップ画像で停止する (#2579)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -968,8 +968,8 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
             sp_path="${COLLECTION_DIR}/${sp_image}"
         fi
         if [[ -z "$sp_path" || ! -f "$sp_path" ]]; then
-            echo "  WARN: subscribe popup image not found: ${sp_image} (overlay 経路だが popup はスキップ)"
-            sp_enabled="false"
+            echo "ERROR: subscribe popup image not found: ${sp_image}"
+            exit 1
         else
             INPUTS+=(-loop 1 -i "$sp_path")
             sp_input_idx="$next_input_idx"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(videoup)`: 有効化した登録ポップアップ画像を解決できない場合、ポップアップを黙って省略せず動画生成前にエラー終了する（#2579）。
+
 - `fix(doctor)`: duration TTP 証跡の同義ラベル・空白・区切り記号と、見出し配下の複数行箇条書きを解釈しつつ、根拠・対象 channel・上位5本・min/max・承認の必須条件を維持（#2545）。
 
 - `fix(suno-helper)`: 適応型ペーシング後の Create 直前に Turnstile を再確認し、表示中の新規投入を止めて解消後に同じ entry から重複なく再開する（#2536）。

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -203,6 +203,16 @@ with open(sys.argv[1], encoding="utf-8") as f:
 print(str(data.get("overlays", {}).get("subscribe_popup", {}).get("enabled", False)).lower())
 PY
         ;;
+    *".overlays.subscribe_popup.image"*)
+        python3 - "$file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+print(data.get("overlays", {}).get("subscribe_popup", {}).get("image", ""))
+PY
+        ;;
     *".overlays.encoder.codec"*) printf '%s\\n' "${OVERLAY_ENCODER_CODEC:-}" ;;
     *".overlays.encoder.preset"*) printf '%s\\n' "${OVERLAY_ENCODER_PRESET:-}" ;;
     *".overlays.encoder.crf"*) printf '%s\\n' "${OVERLAY_ENCODER_CRF:-}" ;;
@@ -2113,6 +2123,39 @@ def test_preview_overlay_filter_includes_effect_visualizer_and_popup(tmp_path: P
     assert preview_cmd.index("showfreqs=mode=bar") < preview_cmd.index("fade=t=in")
     assert " -t 25 " in f" {preview_cmd} "
     assert "Route   : overlays + particles effect/full encode" in result.stdout
+
+
+def test_enabled_subscribe_popup_with_missing_image_fails_before_ffmpeg(tmp_path: Path) -> None:
+    """#2579: 有効な popup 画像を解決できなければ動画生成を成功扱いにしない。"""
+    collection = _create_collection(tmp_path)
+    overlays_config = tmp_path / "youtube.json"
+    overlays_config.write_text(
+        json.dumps(
+            {
+                "overlays": {
+                    "enabled": True,
+                    "audio_visualizer": {"enabled": False},
+                    "subscribe_popup": {
+                        "enabled": True,
+                        "image": "missing-popup.png",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"OVERLAYS_CONFIG": str(overlays_config)},
+        collection=collection,
+    )
+
+    assert result.returncode != 0
+    assert "ERROR: subscribe popup image not found: missing-popup.png" in result.stdout + result.stderr
+    assert not ffmpeg_log.exists()
+    assert not (collection / "01-master" / "Ambient-Master.mp4").exists()
 
 
 def test_no_preview_keeps_master_output_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- subscribe popup が enabled で設定画像を解決できない場合、ffmpeg 前に fail-loud
- missing image のまま Master 動画を成功扱いする経路を廃止
- valid popup と disabled/default の既存挙動を維持

## Verification
- TDD red: missing image でも exit 0 / Master生成を再現
- focused preservation tests: 3 passed
- videoup module: 112 passed
- full pytest: 7503 passed, 1 skipped
- ruff / format / any-usage / videoup skill lint / diff check

Closes #2579