### PR TITLE
fix(thumbnail): CodexプロンプトへIP保護句を付与する (#2586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: Codex のテキスト付きサムネイルプロンプトへ、deep-merge 後の `single_step.ip_safety_clause` を自動で一度だけ付与する（#2586）。
+
 - `fix(videoup)`: 有効化した登録ポップアップ画像を解決できない場合、ポップアップを黙って省略せず動画生成前にエラー終了する（#2579）。
 
 - `fix(doctor)`: duration TTP 証跡の同義ラベル・空白・区切り記号と、見出し配下の複数行箇条書きを解釈しつつ、根拠・対象 channel・上位5本・min/max・承認の必須条件を維持（#2545）。

--- a/src/youtube_automation/infrastructure/media/image_provider/config.py
+++ b/src/youtube_automation/infrastructure/media/image_provider/config.py
@@ -110,6 +110,7 @@ class CodexConfig:
     """Codex shell 経路で使う prompt 設定。"""
 
     default_prompt_template: str = ""
+    ip_safety_clause: str = ""
     composition_rules: dict[str, object] | None = None
     thumbnail_guidance: str | None = None
     max_parallel: int = _DEFAULT_CODEX_MAX_PARALLEL
@@ -174,14 +175,20 @@ def _build_from_new_namespace(section: dict[str, Any]) -> ImageGenerationConfig:
     gemini_section = section.get("gemini")
     composition_rules = _composition_rules_from_gemini(gemini_section)
     thumbnail_guidance = _codex_thumbnail_guidance_from_gemini(gemini_section)
+    ip_safety_clause = _ip_safety_clause_from_gemini(gemini_section)
     codex_cfg = (
         _build_codex(
             section.get("codex"),
             composition_rules=composition_rules,
             thumbnail_guidance=thumbnail_guidance,
+            ip_safety_clause=ip_safety_clause,
         )
         if "codex" in section
-        else CodexConfig(composition_rules=composition_rules, thumbnail_guidance=thumbnail_guidance)
+        else CodexConfig(
+            composition_rules=composition_rules,
+            thumbnail_guidance=thumbnail_guidance,
+            ip_safety_clause=ip_safety_clause,
+        )
     )
     return ImageGenerationConfig(provider="codex", gemini=None, openai=None, codex=codex_cfg)
 
@@ -218,6 +225,7 @@ def _build_codex(
     *,
     composition_rules: dict[str, object] | None,
     thumbnail_guidance: str | None,
+    ip_safety_clause: str,
 ) -> CodexConfig:
     if not isinstance(d, dict):
         raise ConfigError("image_generation.codex は mapping で指定してください")
@@ -231,10 +239,23 @@ def _build_codex(
         raise ConfigError("image_generation.codex.max_parallel は 1 以上の整数で指定してください")
     return CodexConfig(
         default_prompt_template=template,
+        ip_safety_clause=ip_safety_clause,
         composition_rules=composition_rules,
         thumbnail_guidance=thumbnail_guidance,
         max_parallel=max_parallel,
     )
+
+
+def _ip_safety_clause_from_gemini(section: object) -> str:
+    if not isinstance(section, dict):
+        return ""
+    single_step = section.get("single_step")
+    if not isinstance(single_step, dict) or "ip_safety_clause" not in single_step:
+        return ""
+    clause = single_step["ip_safety_clause"]
+    if not isinstance(clause, str):
+        raise ConfigError("image_generation.gemini.single_step.ip_safety_clause は文字列で指定してください")
+    return clause.strip()
 
 
 def _composition_rules_from_gemini(section: object) -> dict[str, object] | None:
@@ -340,6 +361,12 @@ def _render_codex_thumbnail_guidance(guidance: str | None) -> str:
     return f"\n\nAdditional thumbnail guidance:\n{guidance}"
 
 
+def _append_codex_ip_safety_clause(prompt: str, clause: str) -> str:
+    if not clause or clause in prompt:
+        return prompt
+    return f"{prompt.rstrip()}\n\n{clause}"
+
+
 def _validate_required_legend_motif(rules: dict[str, object] | None) -> None:
     if not rules:
         return
@@ -361,6 +388,7 @@ def build_codex_prompt(skill_cfg: dict[str, Any], title: str) -> str:
         raise ConfigError("image_generation.provider=codex の設定で実行してください")
     _validate_required_legend_motif(cfg.codex.composition_rules)
     prompt = render_codex_prompt(cfg.codex.default_prompt_template, title)
+    prompt = _append_codex_ip_safety_clause(prompt, cfg.codex.ip_safety_clause)
     return (
         prompt
         + _render_codex_thumbnail_guidance(cfg.codex.thumbnail_guidance)

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -1377,16 +1377,21 @@ def test_channel_new_thumbnail_template_includes_channel_branding_contract() -> 
 
 
 def test_codex_prompt_helper_cli_renders_default_template(tmp_path: Path) -> None:
-    """#1300: provider=codex の最小 override で default template を title 差し替えして出力する。"""
+    """#1300 / #2586: default template と IP safety clause を title 付きで出力する。"""
     result = _run_codex_prompt_cli(
         tmp_path,
         "image_generation:\n  provider: codex\n",
         "Rain Study",
     )
 
+    default_clause = _load_thumbnail_default_config()["image_generation"]["gemini"]["single_step"][
+        "ip_safety_clause"
+    ].strip()
     assert result.returncode == 0, result.stderr
     assert "TTP this reference thumbnail, then improve it into a stronger original thumbnail." in result.stdout
     assert "Use the title Rain Study." in result.stdout
+    assert result.stdout.count(default_clause) == 1
+    assert "Remove all text" not in result.stdout
     assert "{title}" not in result.stdout
 
 
@@ -1407,6 +1412,30 @@ def test_codex_prompt_helper_cli_appends_style_lock_clause(tmp_path: Path) -> No
     assert "Use the title Night Groove." in result.stdout
     assert "Additional thumbnail guidance:" in result.stdout
     assert "Keep the strong caricature treatment." in result.stdout
+
+
+def test_codex_prompt_helper_cli_uses_channel_ip_safety_override_without_text_strip(tmp_path: Path) -> None:
+    """#2586: channel の IP clause だけを初回の文字入り prompt へ一度展開する。"""
+    result = _run_codex_prompt_cli(
+        tmp_path,
+        """image_generation:
+  provider: codex
+  gemini:
+    single_step:
+      ip_safety_clause: Channel-specific IP safety clause.
+      text_strip_clause: Remove all text from the image.
+""",
+        "Rain Study",
+    )
+
+    default_clause = _load_thumbnail_default_config()["image_generation"]["gemini"]["single_step"][
+        "ip_safety_clause"
+    ].strip()
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("Use the title Rain Study.") == 1
+    assert result.stdout.count("Channel-specific IP safety clause.") == 1
+    assert default_clause not in result.stdout
+    assert "Remove all text from the image." not in result.stdout
 
 
 def test_codex_prompt_helper_cli_rejects_non_codex_provider(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- resolved default / channel override の `single_step.ip_safety_clause` を Codex text-included prompt へ自動付与
- clean spacing で exactly once を保証
- title semantics を維持し、初回 prompt へ `text_strip_clause` は含めない

## Verification
- TDD red: default/override とも clause count 0
- thumbnail assets: 61 passed
- config: 48 passed
- routing: 21 passed
- full pytest: 7504 passed, 1 skipped
- ruff / format / any-usage / thumbnail skill lint / diff check

Closes #2586