### PR TITLE
fix(thumbnail): Codex manifestを実行ごとに分離する (#2948)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -182,11 +182,14 @@ bash .claude/skills/thumbnail/references/codex-image.sh --require-reference \
 
 複数候補を作る場合でも、1 回の `codex-image.sh --require-reference` 呼び出しには候補に対応する参照画像 1 枚だけを渡す。TTP 生成では参照画像 0 件で停止する。DistroKid cover などの汎用 codex 生成は `--require-reference` を付けない。
 
-2 件以上の候補を同時生成する場合は、`id` / `prompt` / `output` / 任意の `reference` を持つ JSON 配列を manifest に保存し、batch launcher を使う。互換 preflight は batch 全体で 1 回だけ実行され、各 job は独立した出力先で単発 `codex-image.sh` の stale-artifact / PNG / MD5 gate を通る。一部失敗時も残りを完走し、最後に失敗一覧と非 0 exit を返す。
+2 件以上の候補を同時生成する場合は、`id` / `prompt` / `output` / 任意の `reference` を持つ JSON 配列を manifest に保存し、batch launcher を使う。manifest は共有 scratchpad の固定名に置かず、実行ごとに `mktemp` で作成する。cleanup はその実行が取得した path だけを `trap` で削除し、glob や固定名で他の並列実行の manifest を削除しない。互換 preflight は batch 全体で 1 回だけ実行され、各 job は独立した出力先で単発 `codex-image.sh` の stale-artifact / PNG / MD5 gate を通る。一部失敗時も残りを完走し、最後に失敗一覧と非 0 exit を返す。
 
 ```bash
+manifest=$(mktemp "${TMPDIR:-/tmp}/codex-thumbnail-jobs.XXXXXX")
+trap 'rm -f "$manifest"' EXIT
+# id / prompt / output / 任意の reference を持つ JSON 配列を "$manifest" へ保存してから実行する
 bash .claude/skills/thumbnail/references/codex-image-batch.sh \
-  --manifest /tmp/codex-thumbnail-jobs.json
+  --manifest "$manifest"
 # 実行単位で上書きする場合だけ: --max-parallel 2
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: Codex batch manifest を実行ごとの `mktemp` で作成し、その実行が所有する path だけを終了時に削除する運用契約へ変更して、並列 collection 間の上書きを防止する（#2948）。
+
 - `fix(thumbnail)`: Codex のテキスト付きサムネイルプロンプトへ、deep-merge 後の `single_step.ip_safety_clause` を自動で一度だけ付与する（#2586）。
 
 - `fix(videoup)`: 有効化した登録ポップアップ画像を解決できない場合、ポップアップを黙って省略せず動画生成前にエラー終了する（#2579）。

--- a/tests/test_codex_image_batch.py
+++ b/tests/test_codex_image_batch.py
@@ -309,3 +309,15 @@ def test_skill_documents_batch_usage_and_fair_use_limit() -> None:
         "`3` 以上はユーザーが今回の実行について明示した場合だけ",
     ):
         assert phrase in skill
+
+
+def test_skill_uses_per_run_manifest_with_caller_owned_cleanup() -> None:
+    """#2948: 並列 collection は固定 manifest を共有せず、自身の一時ファイルだけを消す。"""
+    skill = (ROOT / ".claude/skills/thumbnail/SKILL.md").read_text()
+    batch_contract = skill.split("2 件以上の候補を同時生成する場合", maxsplit=1)[1].split("同時起動数は", maxsplit=1)[0]
+
+    assert "/tmp/codex-thumbnail-jobs.json" not in batch_contract
+    assert 'manifest=$(mktemp "${TMPDIR:-/tmp}/codex-thumbnail-jobs.XXXXXX")' in batch_contract
+    assert "trap 'rm -f \"$manifest\"' EXIT" in batch_contract
+    assert '--manifest "$manifest"' in batch_contract
+    assert 'rm -f "${TMPDIR:-/tmp}/codex-thumbnail-jobs.' not in batch_contract


### PR DESCRIPTION
## Summary
- batch guidance の manifest を per-run `mktemp` で一意化
- launcher へ現在 run の `$manifest` だけを渡し、trap で自分の path だけ cleanup
- 固定共有 path と broad/glob cleanup を禁止し、launcher/schema は維持

## Verification
- TDD red: fixed `/tmp/codex-thumbnail-jobs.json` を検出
- focused batch tests: 12 passed
- full pytest: 7505 passed, 1 skipped
- ruff / format / any-usage / thumbnail skill lint / diff check

Closes #2948