### PR TITLE
fix(thumbnail): Codex batchのチャンネル解決を統一する (#2949)

### DIFF
--- a/.claude/skills/thumbnail/references/codex-image-batch.sh
+++ b/.claude/skills/thumbnail/references/codex-image-batch.sh
@@ -104,16 +104,18 @@ PY
     exit 1
   fi
   if ! max_parallel=$(uv run python - <<'PY'
-import os
-from pathlib import Path
-
+from youtube_automation.configuration import channel_dir
 from youtube_automation.infrastructure.media.image_provider.config import parse_image_generation_config
 from youtube_automation.configuration.skills import load_skill_config
+from youtube_automation.core.errors import ConfigError
 
-channel_root = Path(os.environ.get("CHANNEL_DIR", "."))
-config = parse_image_generation_config(
-    load_skill_config("thumbnail", use_cache=False, channel_dir=channel_root)
-)
+try:
+    channel_root = channel_dir()
+    config = parse_image_generation_config(
+        load_skill_config("thumbnail", use_cache=False, channel_dir=channel_root)
+    )
+except ConfigError as exc:
+    raise SystemExit(f"ERROR: {exc}") from None
 if config.codex is None:
     raise SystemExit("image_generation.provider must be codex")
 print(config.codex.max_parallel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: Codex batch の channel 解決を共通 resolver へ統一し、multi-channel workspace の `CHANNEL=<slug>` を受理するとともに、未指定・不正 slug を jobs 起動前に候補付きで診断する（#2949）。
+
 - `fix(thumbnail)`: Codex batch manifest を実行ごとの `mktemp` で作成し、その実行が所有する path だけを終了時に削除する運用契約へ変更して、並列 collection 間の上書きを防止する（#2948）。
 
 - `fix(thumbnail)`: Codex のテキスト付きサムネイルプロンプトへ、deep-merge 後の `single_step.ip_safety_clause` を自動で一度だけ付与する（#2586）。

--- a/tests/test_codex_image_batch.py
+++ b/tests/test_codex_image_batch.py
@@ -110,6 +110,8 @@ def _run_batch(
     channel_dir: Path | None = None,
     project_environment: Path | None = None,
     runner_override: bool = True,
+    cwd: Path = ROOT,
+    channel_slug: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     tools, codex_log, state = _mock_tools(tmp_path)
     batch = BATCH
@@ -127,12 +129,29 @@ def _run_batch(
         "PATH": f"{tools}:{os.environ['PATH']}",
         "MOCK_CODEX_LOG": str(codex_log),
         "MOCK_RUNNER_STATE": str(state),
+        "UV_PROJECT": str(ROOT),
     }
+    env.pop("CHANNEL", None)
+    env.pop("CHANNEL_DIR", None)
     if channel_dir is not None:
         env["CHANNEL_DIR"] = str(channel_dir)
+    if channel_slug is not None:
+        env["CHANNEL"] = channel_slug
     if project_environment is not None:
         env["UV_PROJECT_ENVIRONMENT"] = str(project_environment)
-    return subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
+    return subprocess.run(command, cwd=cwd, env=env, text=True, capture_output=True, check=False)
+
+
+def _workspace_channel(workspace: Path, slug: str) -> Path:
+    channel = workspace / "channels" / slug
+    (channel / "config" / "channel").mkdir(parents=True)
+    skills = channel / "config" / "skills"
+    skills.mkdir()
+    (skills / "thumbnail.yaml").write_text(
+        "image_generation:\n  provider: codex\n  codex:\n    max_parallel: 1\n",
+        encoding="utf-8",
+    )
+    return channel
 
 
 def test_codex_config_defaults_overrides_and_rejects_invalid_parallelism() -> None:
@@ -228,6 +247,43 @@ def test_batch_reports_config_failure_after_environment_is_ready(tmp_path: Path)
     assert not (tmp_path / "codex.log").exists()
 
 
+@pytest.mark.parametrize(
+    ("channel_slug", "diagnostic"),
+    [
+        (None, "workspace ルートでは --channel <slug> または CHANNEL=<slug> を指定してください"),
+        ("missing", "CHANNEL='missing' に対応するチャンネルが見つかりません"),
+    ],
+)
+def test_batch_rejects_missing_or_wrong_workspace_channel_before_jobs(
+    tmp_path: Path,
+    channel_slug: str | None,
+    diagnostic: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    _workspace_channel(workspace, "alpha")
+    manifest = _manifest(tmp_path, ["one", "two"])
+
+    result = _run_batch(tmp_path, manifest, cwd=workspace, channel_slug=channel_slug)
+
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+    assert "候補: alpha" in result.stderr
+    assert not (tmp_path / "codex.log").exists()
+    assert not (tmp_path / "runner-state.json").exists()
+
+
+def test_batch_resolves_channel_slug_from_workspace_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _workspace_channel(workspace, "alpha")
+    manifest = _manifest(tmp_path, ["one", "two"])
+
+    result = _run_batch(tmp_path, manifest, cwd=workspace, channel_slug="alpha")
+
+    assert result.returncode == 0, result.stderr
+    state = json.loads((tmp_path / "runner-state.json").read_text())
+    assert sorted(state["calls"]) == ["one", "two"]
+
+
 def test_batch_finishes_remaining_jobs_and_reports_failures(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path, ["one", "FAIL two", "three"])
 
@@ -254,8 +310,9 @@ def test_batch_reports_multiline_failure_prompt_without_corrupting_entries(tmp_p
 
 def test_default_single_image_runner_skips_child_preflight_via_batch_shim(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path, ["one", "two"])
+    channel = _workspace_channel(tmp_path / "workspace", "alpha")
 
-    result = _run_batch(tmp_path, manifest, max_parallel=2, runner_override=False)
+    result = _run_batch(tmp_path, manifest, max_parallel=2, runner_override=False, channel_dir=channel)
 
     assert result.returncode == 0, result.stderr
     assert (tmp_path / "codex.log").read_text().splitlines() == [


### PR DESCRIPTION
## Summary
- Codex batch も共通 `channel_dir()` resolver を使用
- workspace root から `CHANNEL=<slug>` で正しい channel config を解決
- missing/invalid context は preflight/jobs 前に candidate-aware 診断で fail-loudし、明示 `CHANNEL_DIR` は維持

## Verification
- TDD red: missing/wrong context は generic provider error、valid CHANNEL は無視
- focused batch tests: 15 passed
- full pytest: 7508 passed, 1 skipped
- ruff / format / any-usage / thumbnail skill lint / diff check

Closes #2949