### PR TITLE
fix(suno): 否定表現を優先してモード判定する (#2954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno)`: `genre_line` のモード推定で否定表現をボーカル語より優先し、完全な語境界だけを照合して部分文字列による誤判定を防止（#2954）。
+
 - `fix(thumbnail)`: Codex batch の channel 解決を共通 resolver へ統一し、multi-channel workspace の `CHANNEL=<slug>` を受理するとともに、未指定・不正 slug を jobs 起動前に候補付きで診断する（#2949）。
 
 - `fix(thumbnail)`: Codex batch manifest を実行ごとの `mktemp` で作成し、その実行が所有する path だけを終了時に削除する運用契約へ変更して、並列 collection 間の上書きを防止する（#2948）。

--- a/src/youtube_automation/domains/suno/config.py
+++ b/src/youtube_automation/domains/suno/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -12,7 +13,33 @@ from youtube_automation.core.adapters.errors import ConfigError
 from youtube_automation.core.adapters.media import VIDEO_ANALYSIS_DIRNAME
 
 _TOP_GENRE_PHRASES = 8
-_VOCAL_KEYWORDS = ("vocals", "vocal", "singing", "rap", "sings", "sung")
+_VOCAL_TERMS = (
+    "male vocals",
+    "female vocals",
+    "vocals",
+    "vocal",
+    "singing",
+    "singer",
+    "rap",
+    "choir",
+    "humming",
+)
+_TERM_LEFT_BOUNDARY = r"(?<![\w-])"
+_TERM_RIGHT_BOUNDARY = r"(?![\w-])"
+_INSTRUMENTAL_PATTERNS = tuple(
+    re.compile(f"{_TERM_LEFT_BOUNDARY}{expression}{_TERM_RIGHT_BOUNDARY}", re.IGNORECASE)
+    for expression in (
+        r"instrumental",
+        r"no(?:\s+(?:male|female))?\s+vocals?",
+        r"without(?:\s+(?:male|female))?\s+vocals?",
+        r"vocals?(?:-|\s+)free",
+        r"non(?:-|\s+)vocals?",
+    )
+)
+_VOCAL_PATTERN = re.compile(
+    f"{_TERM_LEFT_BOUNDARY}(?:{'|'.join(re.escape(term) for term in _VOCAL_TERMS)}){_TERM_RIGHT_BOUNDARY}",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -32,7 +59,9 @@ def resolve_suno_config(suno_cfg: Mapping[str, object]) -> ResolvedSunoConfig:
 
 
 def infer_suno_mode(genre_line: str) -> str:
-    return "vocal" if any(keyword in genre_line.lower() for keyword in _VOCAL_KEYWORDS) else "instrumental"
+    if any(pattern.search(genre_line) for pattern in _INSTRUMENTAL_PATTERNS):
+        return "instrumental"
+    return "vocal" if _VOCAL_PATTERN.search(genre_line) else "instrumental"
 
 
 def collect_video_analysis_suno_presets() -> tuple[str, str]:

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -13,6 +13,7 @@ from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.suno.generate_suno_prompts import build_prompt_entries, generate, main
 from youtube_automation.configuration import skills as skill_config
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.suno.config import infer_suno_mode
 
 # `_skills/<skill>/config.default.yaml` の解決元になる editable install のソースツリー
 _DEFAULT_YAML = REPO_ROOT / ".claude" / "skills" / "suno" / "config.default.yaml"
@@ -107,6 +108,73 @@ def test_help_flag_shows_usage_and_exits_zero(monkeypatch, capsys):
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "usage" in captured.out.lower()
+
+
+@pytest.mark.parametrize(
+    "genre_line",
+    [
+        "instrumental",
+        "no vocals",
+        "without vocals",
+        "vocal-free",
+        "non-vocal",
+    ],
+)
+def test_infer_suno_mode_treats_negative_vocal_expressions_as_instrumental(genre_line):
+    assert infer_suno_mode(genre_line) == "instrumental"
+
+
+@pytest.mark.parametrize(
+    "genre_line",
+    [
+        "vocals",
+        "vocal",
+        "singing",
+        "singer",
+        "rap",
+        "choir",
+        "humming",
+        "male vocals",
+        "female vocals",
+    ],
+)
+def test_infer_suno_mode_recognizes_complete_vocal_terms(genre_line):
+    assert infer_suno_mode(genre_line) == "vocal"
+
+
+@pytest.mark.parametrize(
+    "genre_line",
+    [
+        "female vocals, instrumental arrangement",
+        "rap without vocals",
+        "choir, vocal-free mix",
+    ],
+)
+def test_infer_suno_mode_prioritizes_negative_expressions(genre_line):
+    assert infer_suno_mode(genre_line) == "instrumental"
+
+
+@pytest.mark.parametrize(
+    ("genre_line", "expected"),
+    [
+        ("vocalist", "instrumental"),
+        ("vocality", "instrumental"),
+        ("crap", "instrumental"),
+        ("instrumentalist with choir", "vocal"),
+        ("non-vocalist with rap", "vocal"),
+    ],
+)
+def test_infer_suno_mode_matches_terms_at_token_boundaries(genre_line, expected):
+    assert infer_suno_mode(genre_line) == expected
+
+
+def test_explicit_instrumental_mode_overrides_vocal_genre_line(channel_dir, tmp_path):
+    _write_suno_override(channel_dir, genre_line="dream pop vocals")
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    output = generate(patterns_path)
+
+    assert "dream pop vocals" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `instrumental` / `no vocals` / `without vocals` / `vocal-free` / `non-vocal` を positive vocal 語より先に判定
- 語境界付き regex で unrelated substring を除外
- スキル記載の positive 語リストと YAML 明示 mode override を維持

## Verification
- TDD red: negatives/boundaries/mixed precedence 15 failed
- focused tests: 23 passed
- Suno generate+verify regression: 179 passed
- full pytest: 7531 passed, 1 skipped
- ruff / format / suno skill lint / any-usage / diff check

Closes #2954