### PR TITLE
fix(doctor): readonly token の発行状況を診断する (#2957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(doctor)`: read-only OAuth token の発行状況を独立診断し、未発行時は対象チャンネルの context 付きで `uv run yt-oauth --readonly` を案内する warning を追加（#2957）。
+
 - `fix(suno)`: `genre_line` のモード推定で否定表現をボーカル語より優先し、完全な語境界だけを照合して部分文字列による誤判定を防止（#2954）。
 
 - `fix(thumbnail)`: Codex batch の channel 解決を共通 resolver へ統一し、multi-channel workspace の `CHANNEL=<slug>` を受理するとともに、未指定・不正 slug を jobs 起動前に候補付きで診断する（#2949）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -54,7 +54,7 @@ from youtube_automation.domains.uploads.preflight import (
     check_suno_genre_line_char_limit,
     check_thumbnail_skill_config,
 )
-from youtube_automation.infrastructure.auth.youtube import resolve_client_secrets_location
+from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler, resolve_client_secrets_location
 from youtube_automation.infrastructure.collections.numbered_duplicates import (
     CLEANUP_GUIDE_URL,
     format_duplicate_name,
@@ -158,6 +158,26 @@ def _youtube_oauth_action(instructions: str) -> dict:
     )
     action.update(
         {
+            "execution_mode": "background",
+            "url_source": "stdout",
+            "completion_signal": "process-exit",
+            "post_check_cmd": "uv run yt-doctor --json",
+        }
+    )
+    return action
+
+
+def _youtube_readonly_oauth_action(channel_dir: Path) -> dict:
+    """Return the agent-driven read-only OAuth hand-off in the target channel context."""
+    action = _human_auth_action(
+        ["uv", "run", "yt-oauth", "--readonly"],
+        "AI または setup が対象チャンネルのディレクトリで `uv run yt-oauth --readonly` を background session "
+        "として起動し、stdout の同意 URL を利用者へ中継します。利用者はブラウザで OAuth 同意だけを"
+        "完了してください。AI は同じ process の exit 0 を待ち、`uv run yt-doctor --json` で再検証します。",
+    )
+    action.update(
+        {
+            "cwd": str(channel_dir),
             "execution_mode": "background",
             "url_source": "stdout",
             "completion_signal": "process-exit",
@@ -1085,6 +1105,24 @@ def check_oauth_token(channel_dir: Path) -> CheckResult:
         id="oauth_token",
         status="ok",
         message=f"token.json 利用可能 (scopes: {len(scopes)} 件{refresh_status})",
+    )
+
+
+def check_oauth_token_readonly(channel_dir: Path) -> CheckResult:
+    """Check whether the independently issued read-only token is available."""
+    with _temporary_channel_dir(channel_dir):
+        path = YouTubeOAuthHandler.readonly_token_path()
+    if path is None or not path.is_file():
+        return CheckResult(
+            id="oauth_token_readonly",
+            status="warn",
+            message="token.readonly.json が未発行",
+            next_action=_youtube_readonly_oauth_action(channel_dir),
+        )
+    return CheckResult(
+        id="oauth_token_readonly",
+        status="ok",
+        message="token.readonly.json 発行済み",
     )
 
 
@@ -3006,6 +3044,7 @@ def run_all_checks(channel_dir: Path) -> list[CheckResult]:
         check_client_secrets(channel_dir),
         check_oauth_client_sharing(channel_dir),
         check_oauth_token(channel_dir),
+        check_oauth_token_readonly(channel_dir),
         check_reporting_job(channel_dir),
         check_channel_config(channel_dir),
         check_playlist_config(channel_dir),

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -823,6 +823,80 @@ class TestOAuthToken:
         assert result.next_action is None
 
 
+class TestOAuthTokenReadonly:
+    def test_missing_is_warning_with_channel_scoped_oauth_action(self, tmp_path):
+        result = doctor.check_oauth_token_readonly(tmp_path)
+
+        assert result.id == "oauth_token_readonly"
+        assert result.category == doctor.API_CATEGORY
+        assert result.status == "warn"
+        assert result.next_action["kind"] == "human"
+        assert result.next_action["reason"] == "authentication"
+        assert result.next_action["cmd"] == "uv run yt-oauth --readonly"
+        assert result.next_action["cwd"] == str(tmp_path)
+        assert result.next_action["execution_owner"] == "ai-or-setup"
+
+    def test_present_at_resolved_location_is_ok_without_reading_contents(self, tmp_path):
+        auth = tmp_path / "auth"
+        auth.mkdir()
+        token_path = auth / "token.readonly.json"
+        token_path.write_text("not-json-and-must-not-be-read", encoding="utf-8")
+
+        result = doctor.check_oauth_token_readonly(tmp_path)
+
+        assert result.status == "ok"
+        assert result.next_action is None
+        assert "発行済み" in result.message
+
+    def test_directory_at_resolved_location_is_warning_with_canonical_action(self, tmp_path):
+        token_path = tmp_path / "auth" / "token.readonly.json"
+        token_path.mkdir(parents=True)
+
+        result = doctor.check_oauth_token_readonly(tmp_path)
+
+        assert result.status == "warn"
+        assert result.next_action["cmd"] == "uv run yt-oauth --readonly"
+        assert result.next_action["cwd"] == str(tmp_path)
+
+    def test_json_exposes_readonly_warning_and_canonical_next_action(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            doctor,
+            "run_all_checks",
+            lambda channel_dir: [doctor.check_oauth_token_readonly(channel_dir)],
+        )
+
+        code = doctor.main(["--json", "--target", str(tmp_path)])
+
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["warn"] == 1
+        assert payload["summary"]["next_check_id"] == "oauth_token_readonly"
+        check = payload["checks"][0]
+        assert check["status"] == "warn"
+        assert check["next_action"]["cmd"] == "uv run yt-oauth --readonly"
+        assert check["next_action"]["cwd"] == str(tmp_path)
+
+    def test_apply_treats_readonly_warning_as_human_authentication_step(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            doctor,
+            "run_all_checks",
+            lambda channel_dir: [doctor.check_oauth_token_readonly(channel_dir)],
+        )
+        monkeypatch.setattr(
+            doctor,
+            "_run_apply_command",
+            lambda _argv, _cwd: (_ for _ in ()).throw(AssertionError("OAuth browser flow must not run")),
+        )
+
+        code = doctor.main(["--apply", "--json", "--target", str(tmp_path)])
+
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["apply"]["stop_reason"] == "human_required"
+        assert payload["apply"]["check_id"] == "oauth_token_readonly"
+        assert payload["apply"]["next_action"]["cmd"] == "uv run yt-oauth --readonly"
+
+
 class TestReportingJob:
     @staticmethod
     def _write_token(channel_dir: Path, *, expiry: datetime | None = None) -> None:
@@ -1200,8 +1274,8 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 7 bootstrap + 12 api + 3 channel + 4 data + 1 upload = 27
-        assert len(payload["checks"]) == 27
+        # 7 bootstrap + 13 api + 3 channel + 4 data + 1 upload = 28
+        assert len(payload["checks"]) == 28
         for c in payload["checks"]:
             assert c["status"] in ("ok", "info", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
@@ -4880,20 +4954,21 @@ class TestCheckNumberedDuplicates:
 
 
 class TestRunAllChecksExtended:
-    def test_returns_27_checks(self, monkeypatch, tmp_path):
-        """7 bootstrap + 12 api + 3 channel + 4 data + 1 upload = 計 27 件."""
+    def test_returns_28_checks(self, monkeypatch, tmp_path):
+        """7 bootstrap + 13 api + 3 channel + 4 data + 1 upload = 計 28 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 27
+        assert len(results) == 28
 
-    def test_12_api_checks_present(self, monkeypatch, tmp_path):
-        """dotenv を含まず oauth_client_sharing を含む 12 check が api カテゴリにある."""
+    def test_13_api_checks_present(self, monkeypatch, tmp_path):
+        """readonly token と oauth_client_sharing を含む 13 check が api カテゴリにある."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         api_results = [r for r in results if r.category == "api"]
-        assert len(api_results) == 12
+        assert len(api_results) == 13
         assert api_results[-1].id == "reporting_job"
         assert any(r.id == "oauth_client_sharing" for r in api_results)
+        assert any(r.id == "oauth_token_readonly" for r in api_results)
 
     def test_new_check_ids_present(self, monkeypatch, tmp_path):
         """bootstrap / channel / data / upload の check が含まれる."""


### PR DESCRIPTION
## Summary

- doctor に readonly OAuth token の独立診断を追加
- 通常ファイルだけを発行済みとし、欠落・directory等はwarnとcanonical `uv run yt-oauth --readonly` action/cwdを返す
- token 内容は読まず、既存 `oauth_token` 診断と #2956 runtime は維持

## Verification

- review RED: directory tokenを誤ってok（1 failed）
- readonly: 5 passed; resolver/runtime: 14 passed; doctor: 336 passed
- full pytest: 7542 passed, 1 skipped
- ruff / any-gate / all skill lint / diff check: passed

Closes #2957