### PR TITLE
fix(suno-helper): 無人実行でもcaptcha解消を待つ (#2978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
+
 - `fix(doctor)`: read-only OAuth token の発行状況を独立診断し、未発行時は対象チャンネルの context 付きで `uv run yt-oauth --readonly` を案内する warning を追加（#2957）。
 
 - `fix(suno)`: `genre_line` のモード推定で否定表現をボーカル語より優先し、完全な語境界だけを照合して部分文字列による誤判定を防止（#2954）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1092,7 +1092,7 @@ export default defineContentScript({
         timeoutMs: GENERATE_TIMEOUT_MS,
         pollIntervalMs: POLL_INTERVAL_MS,
         settleMs: SETTLE_MS,
-        captchaWaitTimeoutMs: activeUnattended ? 0 : CAPTCHA_WAIT_TIMEOUT_MS,
+        captchaWaitTimeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
         // 生成完了待ち中に captcha が出たら waiting-captcha 表示へ切り替え、解消後 generating へ戻す。
         onCaptchaWait: (waiting) => {
           if (waiting) {

--- a/extensions/suno-helper/tests/wait-for-generation.test.ts
+++ b/extensions/suno-helper/tests/wait-for-generation.test.ts
@@ -10,6 +10,9 @@
 //
 // 純関数化に伴い、中断フラグと各タイミングは引数 (options) で注入する。
 // 旧実装のモジュール変数 `aborted` / 定数 (GENERATE_TIMEOUT_MS 等) を直接参照しない。
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -27,6 +30,11 @@ const FAST_OPTIONS = {
   pollIntervalMs: 10,
   settleMs: 10,
 } as const;
+
+const CONTENT_SOURCE = readFileSync(
+  resolve(process.cwd(), "entrypoints/content.ts"),
+  "utf8"
+);
 
 function disabledButton(): HTMLButtonElement {
   const btn = document.createElement("button");
@@ -293,5 +301,16 @@ describe("shared/dom: タイミング定数", () => {
     expect(POLL_INTERVAL_MS).toBe(500);
     expect(SETTLE_MS).toBe(1500);
     expect(CAPTCHA_WAIT_TIMEOUT_MS).toBe(600000);
+  });
+});
+
+describe("content runner: captcha 待機上限", () => {
+  it("Given manual / unattended run When 生成完了を待つ Then 両方で共有の10分上限を使う", () => {
+    expect(CONTENT_SOURCE).toContain(
+      "captchaWaitTimeoutMs: CAPTCHA_WAIT_TIMEOUT_MS"
+    );
+    expect(CONTENT_SOURCE).not.toMatch(
+      /captchaWaitTimeoutMs:\s*activeUnattended/
+    );
   });
 });


### PR DESCRIPTION
## Summary

- unattended 実行だけ CAPTCHA timeout を 0 にする分岐を削除
- manual / unattended とも共有の `CAPTCHA_WAIT_TIMEOUT_MS`（600000ms）を使用
- Turnstile 自動突破、preflight、解消後 resume の挙動は変更しない

## Verification

- RED: focused 15 tests 中 1 failed
- focused GREEN: 15 passed
- suno-helper: 72 files / 1346 passed
- `pnpm check`, `pnpm compile`, `yt-skills lint suno-helper`, any-usage, diff check: passed

Closes #2978