### PR TITLE
feat(distrokid-helper): サーバー情報に実行モードを追加する (#2985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
+
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 
 - `fix(doctor)`: read-only OAuth token の発行状況を独立診断し、未発行時は対象チャンネルの context 付きで `uv run yt-oauth --readonly` を案内する warning を追加（#2957）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -190,7 +190,7 @@ def channel_hostname(channel_name: str) -> str:
     return f"{_hostname_slug(channel_name)}.localhost"
 
 
-def build_server_info(channel_name: str, channel_short: str, port: int) -> dict[str, str | int]:
+def build_server_info(channel_name: str, channel_short: str, port: int) -> dict[str, object]:
     """helper 拡張の接続先 selector に出す配信元情報（#1352）。"""
     hostname_source = (
         channel_short if channel_short and not re.search(r"[a-z0-9]", channel_name.lower()) else channel_name
@@ -1029,7 +1029,7 @@ def create_server(
     port: int,
     allow_origin: str | None,
     *,
-    server_info: dict[str, str | int] | None = None,
+    server_info: dict[str, object] | None = None,
     prompts_path: Path | None,
     collection_dir: Path | None,
     distrokid: Distrokid | None,
@@ -1061,6 +1061,8 @@ def create_server(
     resolved_server_info = (
         server_info if server_info is not None else build_server_info("YouTube Automation", "YA", port)
     )
+    distrokid_mode = "disabled" if not distrokid_enabled else ("dir" if dir_mode else "single")
+    resolved_server_info["capabilities"] = {"distrokid": {"mode": distrokid_mode}}
     resolved_community_asset_root = community_asset_root if community_asset_root is not None else collection_dir
 
     class _Handler(BaseHTTPRequestHandler):

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -424,7 +424,55 @@ def test_get_server_info_returns_json_body(serve):
     assert body["hostname"] == "youtube-automation.localhost"
     assert body["port"] == urllib.parse.urlparse(base).port
     assert body["base_url"] == f"http://youtube-automation.localhost:{body['port']}"
-    assert set(body) == {"channel_name", "channel_short", "hostname", "port", "base_url", "label"}
+    assert body["capabilities"] == {"distrokid": {"mode": "disabled"}}
+    assert set(body) == {
+        "channel_name",
+        "channel_short",
+        "hostname",
+        "port",
+        "base_url",
+        "label",
+        "capabilities",
+    }
+
+
+@pytest.mark.parametrize(
+    ("distrokid", "collections_root", "expected_mode"),
+    [
+        (None, None, "disabled"),
+        (collection_serve_module.Distrokid(enabled=True), None, "single"),
+        (collection_serve_module.Distrokid(enabled=True), "planning", "dir"),
+    ],
+)
+def test_get_server_info_distinguishes_distrokid_capability_modes(tmp_path, distrokid, collections_root, expected_mode):
+    """旧 server-info payload を入力しても DistroKid の実行 capability を判別できる。"""
+    json_path = tmp_path / "suno-prompts.json"
+    json_path.write_text("[]", encoding="utf-8")
+    old_server_info = build_server_info("Test Channel", "TC", 7873)
+    old_required_fields = old_server_info.copy()
+    server = create_server(
+        0,
+        None,
+        server_info=old_server_info,
+        prompts_path=json_path if collections_root is None else None,
+        collection_dir=tmp_path if collections_root is None else None,
+        distrokid=distrokid,
+        collections_root=tmp_path / collections_root if collections_root is not None else None,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        base = f"http://localhost:{server.server_address[1]}"
+        with urllib.request.urlopen(f"{base}{_SERVER_INFO_ROUTE}") as response:
+            body = json.load(response)
+
+        assert {key: body[key] for key in old_required_fields} == old_required_fields
+        assert body["capabilities"] == {"distrokid": {"mode": expected_mode}}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def test_post_suno_playlists_single_mode_returns_404_without_creating_legacy_json(serve, tmp_path):


### PR DESCRIPTION
## Summary

- `/server-info.capabilities.distrokid.mode` に `disabled` / `single` / `dir` を追加
- 既存の必須6フィールドと `schema_version: 1` を維持
- capability 未提供の旧 payload 互換と discovery round-trip を固定

## Verification

- RED: focused 4 failed / 2 passed
- focused GREEN: 7 passed
- collection server module: 221 passed
- full pytest: 7538 passed, 1 skipped
- ruff check / format, any-gate, skill lint, diff check: passed

Closes #2985