### PR TITLE
fix(benchmark): 個別収集で既存チャンネルを保持する (#2508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: 最終動画の尺検証で ffprobe / afinfo の小数精度から最大丸め誤差を算出し、1 フレーム境界の微小な丸め差を誤検知せず、境界超過と不正 probe 値は引き続き fail-loud にするよう修正（#3098）。
 - `fix(suno)`: インストモードでも `suno-patterns.yaml` の非空 `patterns[].lyrics` を保持し、Instrument Notes / Mixing Notes を Lyrics 欄へ渡せるよう修正（#2585）。
 - `fix(video-upload)`: dedup 検索で `snippet.title` 等を欠く ghost item を候補単位で除外し、同じレスポンス内の正常な完全一致候補を引き続き検証できるよう修正（#2574）。
+- `fix(benchmark)`: `--competitor` による同日個別収集で対象 slug だけを更新し、既存の他チャンネル・playlist データ・top-level metadata を保持するよう修正（#2508）。
 
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/src/youtube_automation/commands/analytics/benchmark_collector.py
+++ b/src/youtube_automation/commands/analytics/benchmark_collector.py
@@ -531,8 +531,11 @@ class BenchmarkCollector:
             "playlists": playlists_data,
         }
 
-    def save_json(self, data: dict) -> Path:
+    def save_json(self, data: dict, *, competitor_slug: str | None = None) -> Path:
         """中間 JSON を data/ に保存する。
+
+        ``competitor_slug`` 指定時は同日ファイルの同一 slug だけを更新し、
+        他チャンネルと playlist 収集済みフィールドを保持する。
 
         Returns:
             保存先パス
@@ -540,6 +543,22 @@ class BenchmarkCollector:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         filename = f"benchmark_{self.today.strftime('%Y%m%d')}.json"
         path = self.data_dir / filename
+        if competitor_slug is not None and path.exists():
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    existing_data = json.load(f)
+            except json.JSONDecodeError:
+                existing_data = None
+            if existing_data is not None:
+                incoming_by_slug = {channel.get("slug"): channel for channel in data.get("channels", [])}
+                merged_channels = []
+                for existing_channel in existing_data.get("channels", []):
+                    incoming = incoming_by_slug.pop(existing_channel.get("slug"), None)
+                    merged_channels.append(
+                        {**existing_channel, **incoming} if incoming is not None else existing_channel
+                    )
+                merged_channels.extend(incoming_by_slug.values())
+                data = {**existing_data, **data, "channels": merged_channels}
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
@@ -1328,7 +1347,10 @@ def main():
         data = analyzer.analyze_thumbnails(data, keep=True)
 
     # JSON 保存
-    json_path = collector.save_json(data)
+    if args.competitor:
+        json_path = collector.save_json(data, competitor_slug=args.competitor)
+    else:
+        json_path = collector.save_json(data)
     print(f"JSON 保存: {json_path}")
 
     # Markdown 生成

--- a/tests/commands/analytics/test_benchmark_collector_channels_batch.py
+++ b/tests/commands/analytics/test_benchmark_collector_channels_batch.py
@@ -13,6 +13,8 @@
 from __future__ import annotations
 
 import builtins
+import json
+import sys
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -560,6 +562,126 @@ class TestCollectAllPrefetchesChannels:
         # When / Then: 欠落を黙ってスキップせず収集失敗として停止（issue #619）
         with pytest.raises(YouTubeAPIError, match="UC_DEL"):
             collector.collect_all(force=True)
+
+
+class TestSaveJson:
+    def _collector(self, tmp_path) -> BenchmarkCollector:
+        collector = _make_collector(MagicMock())
+        collector.data_dir = tmp_path
+        collector.today = date(2026, 8, 6)
+        return collector
+
+    def test_competitor_saves_preserve_other_channels(self, tmp_path):
+        collector = self._collector(tmp_path)
+        collector.save_json(
+            {"channels": [{"slug": "channel-a", "views": 100}], "collected_at": "first", "source": "api"},
+            competitor_slug="channel-a",
+        )
+
+        path = collector.save_json(
+            {"channels": [{"slug": "channel-b", "views": 200}], "collected_at": "second"},
+            competitor_slug="channel-b",
+        )
+
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        assert saved == {
+            "channels": [
+                {"slug": "channel-a", "views": 100},
+                {"slug": "channel-b", "views": 200},
+            ],
+            "collected_at": "second",
+            "source": "api",
+        }
+
+    def test_competitor_save_updates_same_slug_and_preserves_playlists(self, tmp_path):
+        collector = self._collector(tmp_path)
+        collector.save_json(
+            {
+                "channels": [
+                    {"slug": "channel-a", "views": 100, "playlists": [{"playlist_id": "PL_A"}]},
+                    {"slug": "channel-b", "views": 200},
+                ],
+                "collected_at": "first",
+            }
+        )
+
+        path = collector.save_json(
+            {"channels": [{"slug": "channel-a", "views": 300}], "collected_at": "second"},
+            competitor_slug="channel-a",
+        )
+
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        assert saved["channels"] == [
+            {"slug": "channel-a", "views": 300, "playlists": [{"playlist_id": "PL_A"}]},
+            {"slug": "channel-b", "views": 200},
+        ]
+
+    def test_full_collection_replaces_existing_channels_and_top_level_fields(self, tmp_path):
+        collector = self._collector(tmp_path)
+        collector.save_json(
+            {"channels": [{"slug": "channel-a"}], "collected_at": "first", "source": "legacy"},
+            competitor_slug="channel-a",
+        )
+
+        replacement = {"channels": [{"slug": "channel-b"}], "collected_at": "second"}
+        path = collector.save_json(replacement)
+
+        assert json.loads(path.read_text(encoding="utf-8")) == replacement
+
+    def test_competitor_save_recovers_from_malformed_existing_json(self, tmp_path):
+        collector = self._collector(tmp_path)
+        path = tmp_path / "benchmark_20260806.json"
+        path.write_text("{broken", encoding="utf-8")
+        incoming = {"channels": [{"slug": "channel-a", "views": 100}], "collected_at": "recovered"}
+
+        saved_path = collector.save_json(incoming, competitor_slug="channel-a")
+
+        assert saved_path == path
+        assert json.loads(path.read_text(encoding="utf-8")) == incoming
+
+    def test_main_passes_competitor_slug_to_save(self, monkeypatch, tmp_path):
+        calls = []
+
+        class FakeCollector:
+            config = SimpleNamespace(
+                analytics=SimpleNamespace(
+                    benchmark=SimpleNamespace(channels=[{"id": "UC_A", "name": "Channel A", "slug": "channel-a"}])
+                )
+            )
+
+            def __init__(self):
+                self.benchmark_config = {"gemini_thumbnail_analysis": False, "scan_recent": 1, "freshness_days": 3}
+
+            def initialize(self):
+                pass
+
+            def collect_all(self, *, force, competitor_slug):
+                assert force is True
+                assert competitor_slug == "channel-a"
+                return {"channels": [{"slug": "channel-a", "name": "Channel A", "videos": []}]}
+
+            def save_json(self, data, *, competitor_slug):
+                calls.append((data, competitor_slug))
+                return tmp_path / "benchmark_20260806.json"
+
+        monkeypatch.setattr(benchmark_collector, "BenchmarkCollector", FakeCollector)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "yt-benchmark-collect",
+                "--competitor",
+                "channel-a",
+                "--force",
+                "--yes",
+                "--json-only",
+                "--no-thumbnails",
+            ],
+        )
+
+        benchmark_collector.main()
+
+        assert calls == [({"channels": [{"slug": "channel-a", "name": "Channel A", "videos": []}]}, "channel-a")]
 
 
 class TestBenchmarkReportGeneratorDescriptionSamples:


### PR DESCRIPTION
## Summary

- `--competitor` 個別収集時は同日のJSONをslug単位でマージし、他チャンネルを保持
- 同slugの既存playlistと未知top-level metadataを維持し、新しい収集値を更新
- 全件収集の完全置換を維持し、破損JSONは従来どおりincoming snapshotで回復（IO/permission例外は非捕捉）

## Verification

- review RED: malformed daily JSONで1 failed
- focused save contracts: 5 passed
- related benchmark regressions: 59 passed
- full pytest: 7496 passed, 1 skipped
- ruff check / format, any-gate, benchmark skill lint, diff check: passed

Closes #2508