### PR TITLE
fix(video-upload): ghost 検索結果を候補単位で除外する (#2574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(suno)`: `yt-generate-suno` が `workflow-state.json` を自動更新するという誤記を削除し、成果物と検証結果を確認した `/suno` 呼び出し元のメインエージェント（`/wf-new` / `/wf-next` 経由と直接実行を含む）だけが `assets.music_prompts` を更新する責務を明記（#2559）。
 - `fix(videoup)`: 最終動画の尺検証で ffprobe / afinfo の小数精度から最大丸め誤差を算出し、1 フレーム境界の微小な丸め差を誤検知せず、境界超過と不正 probe 値は引き続き fail-loud にするよう修正（#3098）。
 - `fix(suno)`: インストモードでも `suno-patterns.yaml` の非空 `patterns[].lyrics` を保持し、Instrument Notes / Mixing Notes を Lyrics 欄へ渡せるよう修正（#2585）。
+- `fix(video-upload)`: dedup 検索で `snippet.title` 等を欠く ghost item を候補単位で除外し、同じレスポンス内の正常な完全一致候補を引き続き検証できるよう修正（#2574）。
 
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/src/youtube_automation/domains/uploads/_dedup_search.py
+++ b/src/youtube_automation/domains/uploads/_dedup_search.py
@@ -75,17 +75,17 @@ class DedupSearchMixin:
             return None
 
     @staticmethod
-    def _exact_title_video_ids(items: list[dict], title: str) -> list[str]:
+    def _exact_title_video_ids(items: list[object], title: str) -> list[str]:
         video_ids = []
         for item in items:
             if not isinstance(item, dict):
-                raise ValidationError("search.list response item must be an object")
+                continue
             snippet = item.get("snippet")
             identity = item.get("id")
             if not isinstance(snippet, dict) or not isinstance(snippet.get("title"), str):
-                raise ValidationError("search.list response item is missing snippet.title")
+                continue
             if not isinstance(identity, dict) or not isinstance(identity.get("videoId"), str):
-                raise ValidationError("search.list response item is missing id.videoId")
+                continue
             if snippet["title"] == title:
                 video_ids.append(identity["videoId"])
         return video_ids

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -779,6 +779,45 @@ class TestFindExistingVideoByTitle:
         # Then
         assert result is None
 
+    def test_should_skip_ghost_search_items_and_keep_valid_exact_match(self, tmp_path):
+        uploader, mock_youtube = self._make_uploader_with_mock_youtube(tmp_path)
+        mock_youtube.search.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {"id": {"videoId": "ghost-no-snippet"}},
+                None,
+                {"id": {"videoId": "ghost-bad-snippet"}, "snippet": []},
+                {"id": {"videoId": "ghost-no-title"}, "snippet": {}},
+                {"id": {"videoId": "v9"}, "snippet": {"title": "Rainy Jazz"}},
+            ]
+        }
+        mock_youtube.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {"id": "v9", "snippet": {"title": "Rainy Jazz"}, "status": {"uploadStatus": "processed"}},
+            ]
+        }
+
+        result = uploader._find_existing_video_by_title("Rainy Jazz")
+
+        assert result == {
+            "video_id": "v9",
+            "video_url": "https://www.youtube.com/watch?v=v9",
+        }
+        mock_youtube.videos.return_value.list.assert_called_once_with(id="v9", part="status,snippet")
+
+    def test_should_return_none_when_all_search_items_are_ghosts(self, tmp_path):
+        uploader, mock_youtube = self._make_uploader_with_mock_youtube(tmp_path)
+        mock_youtube.search.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {"id": {"videoId": "ghost-no-snippet"}},
+                {"id": {"videoId": "ghost-no-title"}, "snippet": {}},
+            ]
+        }
+
+        result = uploader._find_existing_video_by_title("Rainy Jazz")
+
+        assert result is None
+        mock_youtube.videos.return_value.list.assert_not_called()
+
     def test_should_return_none_when_search_returns_empty_items(self, tmp_path):
         """検索結果が空なら None を返す."""
         # Given


### PR DESCRIPTION
Closes #2574

## Summary
- skip malformed ghost items in YouTube search results
- continue evaluating valid exact-title candidates in the same response
- preserve existing API and outer-response fail-open behavior

## Verification
- `uv run pytest tests/domains/uploads/test_youtube_auto_uploader.py -q` (70 passed)
- `uv run pytest -q` (7493 passed, 1 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `bash .github/scripts/any-usage-gate.sh`
- `uv run yt-skills lint`