### PR TITLE
fix(suno): instrumental の Instrument Notes を保持する (#2585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-verify)`: コレクションの明示パス指定を維持しつつ、bare directory name をチャンネルの `collections/planning/`、`collections/live/` の順に解決するようにした（#3243）。
 - `docs(suno)`: `yt-generate-suno` が `workflow-state.json` を自動更新するという誤記を削除し、成果物と検証結果を確認した `/suno` 呼び出し元のメインエージェント（`/wf-new` / `/wf-next` 経由と直接実行を含む）だけが `assets.music_prompts` を更新する責務を明記（#2559）。
 - `fix(videoup)`: 最終動画の尺検証で ffprobe / afinfo の小数精度から最大丸め誤差を算出し、1 フレーム境界の微小な丸め差を誤検知せず、境界超過と不正 probe 値は引き続き fail-loud にするよう修正（#3098）。
+- `fix(suno)`: インストモードでも `suno-patterns.yaml` の非空 `patterns[].lyrics` を保持し、Instrument Notes / Mixing Notes を Lyrics 欄へ渡せるよう修正（#2585）。
 
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -779,7 +779,7 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
             report.errors.extend(validate_banned_artists(full_style, banned_artists))
 
             # auto_lyrics_structure: 歌詞構造の自動補強 (#904)
-            lyrics = lyrics_source if resolved.is_vocal else ""
+            lyrics = lyrics_source
             if auto_lyrics:
                 lyrics = apply_auto_lyrics_structure(lyrics, is_vocal=resolved.is_vocal)
 

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -728,6 +728,25 @@ def test_build_prompt_entries_instrumental_has_empty_lyrics(channel_dir, tmp_pat
     assert entries[0]["lyrics"] == ""
 
 
+def test_build_prompt_entries_instrumental_preserves_pattern_lyrics(channel_dir, tmp_path):
+    """Instrument Notes を含む pattern lyrics を構造補強後も保持する."""
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz, soft piano",
+        auto_lyrics_structure=True,
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+    payload = yaml.safe_load(patterns_path.read_text(encoding="utf-8"))
+    payload["patterns"][0]["lyrics"] = "Instrument Notes: start directly with the main saxophone line"
+    patterns_path.write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert entries[0]["lyrics"] == (
+        "[Instrumental]\n\nInstrument Notes: start directly with the main saxophone line\n\n[Extended Outro]"
+    )
+
+
 def test_build_prompt_entries_style_contains_tempo_genre_and_scene(channel_dir, tmp_path):
     """Given tempo + genre_line + scene
     When style を読む


### PR DESCRIPTION
Closes #2585

## Summary
- preserve non-empty pattern lyrics as Instrument Notes in instrumental mode
- keep empty instrumental entries and vocal behavior unchanged

## Verification
- focused boundary tests: 3 passed
- related Suno generation/quality/verify tests: 191 passed
- `uv run pytest -q` (7492 passed, 1 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `bash .github/scripts/any-usage-gate.sh`
- `uv run yt-skills lint`