### PR TITLE
fix(videoup): 尺検証で小数丸め誤差を許容する (#3098)

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -1491,6 +1491,12 @@ output_frame_rate="$(ffprobe -v error -select_streams v:0 \
     -show_entries stream=r_frame_rate -of default=noprint_wrappers=1:nokey=1 "$MASTER_OUTPUT" 2>/dev/null | head -1)"
 output_duration="$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$MASTER_OUTPUT" 2>/dev/null)"
 duration_check="$(awk -v actual="$output_duration" -v expected="$video_duration" -v rate="$output_frame_rate" '
+    function decimal_rounding_error(value, parts, digits) {
+        if (index(value, ".") == 0) return 0
+        split(value, parts, ".")
+        digits = length(parts[2])
+        return 0.5 / (10 ^ digits)
+    }
     BEGIN {
         split(rate, fps, "/")
         if (actual !~ /^[0-9]+([.][0-9]+)?$/ || expected !~ /^[0-9]+([.][0-9]+)?$/ ||
@@ -1498,10 +1504,12 @@ duration_check="$(awk -v actual="$output_duration" -v expected="$video_duration"
             print "invalid"
             exit
         }
-        tolerance = fps[2] / fps[1]
+        # ffprobe and afinfo serialize durations at different decimal precision.
+        # Add only the maximum half-ULP rounding error of each value to the one-frame budget.
+        tolerance = fps[2] / fps[1] + decimal_rounding_error(actual) + decimal_rounding_error(expected)
         delta = actual - expected
         if (delta < 0) delta = -delta
-        printf "%s|%.6f|%.6f", (delta <= tolerance + 0.000001 ? "ok" : "mismatch"), delta, tolerance
+        printf "%s|%.6f|%.6f", (delta <= tolerance ? "ok" : "mismatch"), delta, tolerance
     }
 ')"
 IFS='|' read -r duration_status duration_delta duration_tolerance <<< "$duration_check"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 外部 prompt の `style_influence` / `weirdness` が `null` の場合は未指定として slider 注入を skip し、Suno UI の現在値を維持する。数値 `0` は引き続き有効値として注入する（#3032）。
 - `fix(suno-verify)`: コレクションの明示パス指定を維持しつつ、bare directory name をチャンネルの `collections/planning/`、`collections/live/` の順に解決するようにした（#3243）。
 - `docs(suno)`: `yt-generate-suno` が `workflow-state.json` を自動更新するという誤記を削除し、成果物と検証結果を確認した `/suno` 呼び出し元のメインエージェント（`/wf-new` / `/wf-next` 経由と直接実行を含む）だけが `assets.music_prompts` を更新する責務を明記（#2559）。
+- `fix(videoup)`: 最終動画の尺検証で ffprobe / afinfo の小数精度から最大丸め誤差を算出し、1 フレーム境界の微小な丸め差を誤検知せず、境界超過と不正 probe 値は引き続き fail-loud にするよう修正（#3098）。
 
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -844,6 +844,41 @@ def test_final_output_duration_exactly_one_frame_succeeds(tmp_path: Path) -> Non
     assert "final output duration mismatch" not in result.stdout
 
 
+def test_final_output_duration_allows_reported_decimal_rounding_error(tmp_path: Path) -> None:
+    """#3098: 1 frame と計測値の小数丸め誤差の合計までは許容する."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        with_loop=False,
+        extra_env={
+            "FFPROBE_DURATION": "10981.44",
+            "FFPROBE_OUTPUT_DURATION": "10981.398000",
+            "FFPROBE_OUTPUT_FRAME_RATE": "24/1",
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "final output duration mismatch" not in result.stdout
+
+
+def test_final_output_duration_beyond_decimal_rounding_error_fails_loud(tmp_path: Path) -> None:
+    """#3098: 小数精度から導く丸め余裕を超えた 1 frame 超過は許容しない."""
+    result, _ = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        with_loop=False,
+        extra_env={
+            "FFPROBE_DURATION": "10981.44",
+            "FFPROBE_OUTPUT_DURATION": "10981.393332",
+            "FFPROBE_OUTPUT_FRAME_RATE": "24/1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "final output duration mismatch" in result.stdout
+    assert "delta=0.046668s" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("output_duration", "output_frame_rate"),
     [


### PR DESCRIPTION
Closes #3098

## Summary
- add the maximum half-ULP rounding bound of each serialized duration to the one-frame tolerance
- preserve fail-loud behavior beyond that derived bound and for invalid probe data

## Verification
- focused duration/invalid/ffprobe tests: 9 passed
- `uv run pytest tests/test_generate_videos_script.py -q` (113 passed)
- `uv run pytest -q` (7493 passed, 1 skipped)
- `bash -n .claude/skills/videoup/references/generate_videos.sh`
- `uv run ruff check .` and `uv run ruff format --check .`
- Any gate and skill lint passed