### PR TITLE
docs(suno): music_prompts の state 更新責務を是正する (#2559)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -479,7 +479,7 @@ patterns:
 uv run yt-generate-suno <collection-path>
 ```
 
-`config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `style_influence` をパターンに自動付加して `suno-prompts.md` と `suno-prompts.json` を生成する。ボーカルモードでは entry `name` を使い、同階層の `suno-lyrics.json` から同名 lyrics を Style とマージする。保存後、`workflow-state.json` の `assets.music_prompts = true` に更新する。
+`config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `style_influence` をパターンに自動付加して `suno-prompts.md` と `suno-prompts.json` を生成する。ボーカルモードでは entry `name` を使い、同階層の `suno-lyrics.json` から同名 lyrics を Style とマージする。
 
 Suno helper の Custom Duration を collection 共通で指定する場合は、チャンネル側 `config/skills/suno.yaml` に秒単位の正の整数 `duration_sec` を設定する。明示した場合だけ同じ数値を `suno-prompts.json` の全 entry へ出力し、未設定時はキー自体を省略する。`duration_sec` は生成前の目標尺であり、生成後 clip の採用範囲を表す `duration_filter` から推定・同期しない。
 
@@ -499,6 +499,8 @@ uv run yt-suno-verify <collection-path>
 ```
 
 `suno-prompts.json` / `suno-lyrics.json` の展開後 entry 数、entry name、歌詞構造、`genre_line` 文字数を検証し、exit 0 を確認する。その後、別コンテキスト reviewer が `suno-prompts.json` のみを読み、`.claude/skills/suno-lyric/references/review-rubric.md` に従って LLM semantic review を実行し、entry ごとに `PASS` / `FAIL` + 理由を出す。reviewer は `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field だけを判定材料にし、`review_context` 欠落を `/suno` entry の failure reason にしない。`FAIL` entry のみ最大 2 周まで generator subagent（Codex では別コンテキスト実行）に再生成させる。全 entry が `PASS` した後にだけ Suno UI へ投入する。上限到達時に `FAIL` が残る場合は Step 3 へ進まず、残課題をユーザーに提示する。
+
+`yt-generate-suno` 自体は `workflow-state.json` を更新しない。`/suno` を呼び出したメインエージェント（`/wf-new` / `/wf-next` からの呼び出しと、`/suno` の直接実行を含む）が、生成された成果物、`yt-suno-verify` の成功、semantic review の全 entry `PASS` を確認した後にだけ、`assets.music_prompts = true`、`planning.music`、`updated_at` を更新する。subagent は state を書き込まない。
 
 ### Step 3: `/suno-helper` で自動投入（推奨）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(doctor)`: `pip install --user` / system-wide pip で導入した `yt-doctor` を、`pyproject.toml` がないチャンネルで実行しても `uv_project` / `automation_package` を異常扱いしないようにした。実行中 distribution の配置と installer metadata から uv project / uv tool / pip user / pip system を識別し、別途存在する uv tool を実行中の導入形態と誤認せず、判別不能な global 導入も推測した installer 名を表示しない（#3074）。
 - `fix(suno-helper)`: 外部 prompt の `style_influence` / `weirdness` が `null` の場合は未指定として slider 注入を skip し、Suno UI の現在値を維持する。数値 `0` は引き続き有効値として注入する（#3032）。
 - `fix(suno-verify)`: コレクションの明示パス指定を維持しつつ、bare directory name をチャンネルの `collections/planning/`、`collections/live/` の順に解決するようにした（#3243）。
+- `docs(suno)`: `yt-generate-suno` が `workflow-state.json` を自動更新するという誤記を削除し、成果物と検証結果を確認した `/suno` 呼び出し元のメインエージェント（`/wf-new` / `/wf-next` 経由と直接実行を含む）だけが `assets.music_prompts` を更新する責務を明記（#2559）。
+
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -471,14 +471,38 @@ def test_suno_blocks_step_3_until_semantic_review_passes() -> None:
     assert step_2_match, "SKILL.md に `/suno` Step 2 節が見つからない"
     step_2 = step_2_match.group(0)
 
-    for token in (
-        "`workflow-state.json` の `assets.music_prompts = true` に更新する",
-        "全 entry が `PASS` した後にだけ Suno UI へ投入する",
-        "Step 3 へ進まず",
-    ):
+    for token in ("全 entry が `PASS` した後にだけ Suno UI へ投入する", "Step 3 へ進まず"):
         assert token in step_2, f"/suno Step 2 に semantic review gate 契約がない（`{token}` 不在）"
 
     _assert_before(step_2, "LLM semantic review", "Suno UI へ投入する")
+
+
+def test_suno_documents_workflow_state_writer_boundary() -> None:
+    """Issue #2559: CLI/subagent ではなく呼び出し元のメインが検証後に state を更新する."""
+    text = _read()
+    step_2_match = re.search(
+        r"### Step 2: スクリプトで suno-prompts\.md を生成\b.*?(?=^### Step 3:)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert step_2_match, "SKILL.md に `/suno` Step 2 節が見つからない"
+    step_2 = step_2_match.group(0)
+
+    for token in (
+        "`yt-generate-suno` 自体は `workflow-state.json` を更新しない",
+        "`/suno` を呼び出したメインエージェント",
+        "`/wf-new` / `/wf-next` からの呼び出し",
+        "`/suno` の直接実行",
+        "`yt-suno-verify` の成功",
+        "semantic review の全 entry `PASS`",
+        "`assets.music_prompts = true`",
+        "subagent は state を書き込まない",
+    ):
+        assert token in step_2, f"/suno Step 2 に state writer 境界がない（`{token}` 不在）"
+
+    assert "保存後、`workflow-state.json` の `assets.music_prompts = true` に更新する" not in step_2
+    assert "`/wf-new` または `/wf-next` のメインエージェント" not in step_2
+    _assert_before(step_2, "全 entry が `PASS`", "`assets.music_prompts = true`")
 
 
 def test_review_rubric_documents_required_semantic_viewpoints() -> None:


### PR DESCRIPTION
Closes #2559

## Summary
- state explicitly that yt-generate-suno does not write workflow-state.json
- assign verified music_prompts/planning.music/updated_at updates to the wf-new/wf-next main agent
- preserve the Hard Gate 5 prohibition on subagent state writes

## Verification
- Suno doc contracts: 27 passed
- Suno + skill-doc consistency contracts: 97 passed
- `uv run pytest -q` (7492 passed, 1 skipped)
- `uv run ruff check .` and `uv run ruff format --check .`
- Any gate and skill lint passed