### PR TITLE
fix(config): 誤配置キーの候補パスを警告する (#2558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。
+
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -85,15 +85,37 @@ def _warn_deprecated_override_keys(skill: str, override: dict[str, object], over
     )
 
 
+def _find_nested_key_paths(defaults: dict[str, object], target_key: str) -> list[str]:
+    paths: list[str] = []
+
+    def visit(node: dict[str, object], prefix: tuple[str, ...]) -> None:
+        for key, value in node.items():
+            path = (*prefix, key)
+            if prefix and key == target_key:
+                paths.append(".".join(path))
+            if isinstance(value, dict):
+                visit(value, path)
+
+    visit(defaults, ())
+    return paths
+
+
 def _warn_unknown_top_level_override_keys(
     override: dict[str, object], defaults: dict[str, object], override_path: Path
 ) -> None:
     unknown_keys = sorted(override.keys() - defaults.keys())
     if not unknown_keys:
         return
+    suggestions = [
+        f"'{unknown_key}' → {', '.join(repr(path) for path in nested_paths)}"
+        for unknown_key in unknown_keys
+        if (nested_paths := _find_nested_key_paths(defaults, unknown_key))
+    ]
+    suggestion_message = f" 配置先候補: {'; '.join(suggestions)}。" if suggestions else ""
     warnings.warn(
         f"skill-config {override_path} の未知のトップレベルキーを検出しました: "
         f"{', '.join(unknown_keys)}。キー名または階層を確認してください。"
+        f"{suggestion_message}"
         "値は互換性のためマージされますが、利用側に参照されない可能性があります。",
         UserWarning,
         stacklevel=3,

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -89,6 +89,26 @@ def test_unknown_top_level_override_key_warns_but_still_merges(tmp_path, monkeyp
     assert cfg["auto_select"] == {"enabled": True}
 
 
+def test_misplaced_top_level_override_key_warns_with_nested_path(tmp_path, monkeypatch):
+    """#2558: nested schema と同名の誤配置には正しい dotted path を示す。"""
+    channel_dir = tmp_path / "ch"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    override_path = channel_dir / "config" / "skills" / "thumbnail.yaml"
+    override_path.write_text(
+        yaml.safe_dump({"auto_selection": {"enabled": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with pytest.warns(
+        UserWarning,
+        match=r"thumbnail\.yaml.*auto_selection.*image_generation\.auto_selection",
+    ):
+        cfg = skill_config.load_skill_config("thumbnail", use_cache=False)
+
+    assert cfg["auto_selection"] == {"enabled": True}
+
+
 def test_thumbnail_deprecated_override_keys_warn_but_still_merge(tmp_path, monkeypatch):
     """#1702: 縮小済みキーの override は壊さず deep-merge しつつ DeprecationWarning を出す。"""
     channel_dir = tmp_path / "ch"


### PR DESCRIPTION
## 概要

skill-config の未知のトップレベルキーが既定設定内の nested key と一致する場合、正しい dotted path の候補を警告へ表示します。

## 変更内容

- 既定設定を再帰走査し、同名 nested key の dotted path を収集
- thumbnail の auto_selection 誤配置で image_generation.auto_selection を案内する回帰テストを追加
- 一般的な未知キーの既存 warning/deep-merge 契約を維持
- CHANGELOG の Unreleased を更新

## Verification

- nix develop --command uv run pytest tests/configuration/test_skill_config.py -q （52 passed）
- nix develop --command uv run pytest -n auto （7546 passed, 1 skipped）
- nix develop --command uv run ruff check .
- nix develop --command uv run ruff format --check .
- bash .github/scripts/any-usage-gate.sh
- git diff --check

## 関連

Closes #2558

Depends on #3108