### PR TITLE
fix(suno-helper): downloaded API エラーに実 endpoint を保持する (#3125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: downloaded 通知 API の失敗表示に URL encode 後の実 POST endpoint を含め、token 再取得失敗でも起点 request の文脈を維持（#3125）。
+
 - `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。
 
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -941,8 +941,7 @@ export async function postDownloaded(
       "POST",
       collectionDownloadedRoute(collectionId),
       res.status,
-      res.statusText,
-      `POST downloaded failed: ${res.status} ${res.statusText}`
+      res.statusText
     );
   }
   // サーバーは部分完了（期待数未満の配置）を warning 付き 200 で返す (#1913)。

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -1351,7 +1351,7 @@ describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
     });
     vi.stubGlobal("fetch", fetchFn);
 
-    const request = postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+    const request = postDownloaded(BASE_URL, "retry collection/slash", {
       file_count: 0,
       format: "mp3",
       suno_playlist_url: "https://suno.com/playlist/test",
@@ -1359,8 +1359,11 @@ describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
 
     await expect(request).rejects.toMatchObject({
       method: "POST",
-      path: "/collections/20260601-clm-aaa-collection/downloaded",
+      path: "/collections/retry%20collection%2Fslash/downloaded",
       status: 403,
+      statusText: "Forbidden",
+      message:
+        "POST /collections/retry%20collection%2Fslash/downloaded failed: 403 Forbidden",
     });
     await expect(request).rejects.toBeInstanceOf(ApiRequestError);
     await expect(request).rejects.not.toThrow(/GET \/auth\/token/);
@@ -1436,7 +1439,7 @@ describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
-  it("Given HTTP 500 When postDownloaded Then ステータスを含めて throw する", async () => {
+  it("Given HTTP 500 When postDownloaded Then encode 済み endpoint とステータスを含めて throw する", async () => {
     mockFetchForDownloaded(() => ({
       ok: false,
       status: 500,
@@ -1444,13 +1447,20 @@ describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
       json: async () => ({}),
     }));
 
-    await expect(
-      postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
-        file_count: 0,
-        format: "mp3",
-        suno_playlist_url: "https://suno.com/playlist/test",
-      })
-    ).rejects.toThrow(/POST downloaded failed: 500/);
+    const request = postDownloaded(BASE_URL, "collection with spaces/slash", {
+      file_count: 0,
+      format: "mp3",
+      suno_playlist_url: "https://suno.com/playlist/test",
+    });
+
+    await expect(request).rejects.toMatchObject({
+      method: "POST",
+      path: "/collections/collection%20with%20spaces%2Fslash/downloaded",
+      status: 500,
+      statusText: "Internal Server Error",
+      message:
+        "POST /collections/collection%20with%20spaces%2Fslash/downloaded failed: 500 Internal Server Error",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- downloaded POST の canonical ApiRequestError message を保持
- URL encode 済み endpoint と status を利用者向け error へ残す
- token retry 失敗でも起点 POST context を維持

## Verification

- focused: 94 passed
- full Vitest: 1347 passed
- check / format / lint / compile / build / diff-check: pass

Closes #3125

Depends on #3104