### PR TITLE
feat(suno): collection の genre_line を優先する (#3134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 適応型ペーシング後の Create 直前に Turnstile を再確認し、表示中の新規投入を止めて解消後に同じ entry から重複なく再開する（#2536）。
 
 - `fix(config)`: channel skill-config の未知のトップレベルキーを警告し、`thumbnail.yaml` の誤った `auto_select` 階層などが silent に無視される状態を防止（#2520）。
+- `feat(suno)`: collection の `suno-patterns.yaml` に `genre_line` がある場合は channel 設定より優先し、Style と mode 推定を collection ごとに分離（#3134）。
 
 ### Changed
 

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -447,6 +447,15 @@ def _read_vocal_patterns_track_count(data: Mapping[str, object], patterns_path: 
     return cast(int, track_count)
 
 
+def _resolve_genre_line(data: Mapping[str, object], channel_fallback: str, patterns_path: Path) -> str:
+    if "genre_line" not in data:
+        return channel_fallback
+    genre_line = data["genre_line"]
+    if not isinstance(genre_line, str):
+        raise ConfigError(f"{patterns_path}: genre_line must be a string")
+    return genre_line
+
+
 def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
     """config + patterns.yaml を解決し、md / JSON 双方の共通中間表現を返す."""
     suno = load_skill_config("suno")
@@ -456,7 +465,10 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
     advanced_json_fields = _build_advanced_json_fields(override)
     resolved_suno = resolve_suno_config(suno)
 
-    genre_line = resolved_suno.genre_line
+    with open(patterns_path) as f:
+        data = yaml.safe_load(f)
+
+    genre_line = _resolve_genre_line(data, resolved_suno.genre_line, patterns_path)
     mood_descriptors = suno.get("mood_descriptors", "")
     exclude_styles = resolved_suno.exclude_styles
     style_variants = suno.get("style_variants", {})
@@ -472,9 +484,6 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
     if mood_descriptors:
         base_parts.append(mood_descriptors)
     base_style = ", ".join(base_parts)
-
-    with open(patterns_path) as f:
-        data = yaml.safe_load(f)
 
     title = data.get("title", "Suno Prompts")
     patterns = data.get("patterns", [])

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -33,31 +33,35 @@ def channel_dir(tmp_path, monkeypatch):
     skill_config.reset()
 
 
-def _write_minimal_patterns(dir_: Path) -> Path:
+def _write_minimal_patterns(
+    dir_: Path,
+    *,
+    genre_line: object | None = None,
+    mode: str | None = "instrumental",
+) -> Path:
     """1 パターン × 1 シーンの最小 suno-patterns.yaml を作る.
 
     yaml top-level に `tracks: 2` を併設して `tracks_per_collection` の
     fail-loud 検証 (ceil(2/2) = 1 entry) と整合させる。
     """
     path = dir_ / "patterns.yaml"
-    path.write_text(
-        yaml.safe_dump(
+    payload: dict[str, object] = {
+        "title": "Test Collection",
+        "tracks": 2,
+        "patterns": [
             {
-                "title": "Test Collection",
-                "mode": "instrumental",
-                "tracks": 2,
-                "patterns": [
-                    {
-                        "name_jp": "テスト",
-                        "name_en": "Test",
-                        "tempo": "slow",
-                        "scenes": ["a quiet scene description"],
-                    }
-                ],
+                "name_jp": "テスト",
+                "name_en": "Test",
+                "tempo": "slow",
+                "scenes": ["a quiet scene description"],
             }
-        ),
-        encoding="utf-8",
-    )
+        ],
+    }
+    if genre_line is not None:
+        payload["genre_line"] = genre_line
+    if mode is not None:
+        payload["mode"] = mode
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
     return path
 
 
@@ -400,6 +404,56 @@ def test_channel_new_rules_list_suno_lyrics_override_keys():
 # ---------------------------------------------------------------------------
 # issue #360: video_analysis の suno_preset を fallback として参照する動作
 # ---------------------------------------------------------------------------
+
+
+def test_patterns_genre_line_overrides_channel_style_and_mode(channel_dir, tmp_path):
+    """patterns の genre_line は Style と mode 推定の共通 SSOT になる。"""
+    _write_suno_override(channel_dir, genre_line="channel dream pop vocals")
+    patterns_path = _write_minimal_patterns(
+        tmp_path,
+        genre_line="collection lo-fi instrumental",
+        mode=None,
+    )
+
+    markdown = generate(patterns_path)
+    entries = build_prompt_entries(patterns_path)
+
+    assert "collection lo-fi instrumental" in markdown
+    assert "collection lo-fi instrumental" in entries[0]["style"]
+    assert "channel dream pop vocals" not in entries[0]["style"]
+    assert "| Instrumental | ON（インストモード） |" in markdown
+
+
+@pytest.mark.parametrize("order", [("first", "second"), ("second", "first")])
+def test_patterns_genre_line_is_isolated_between_collections(channel_dir, tmp_path, order):
+    """同一 process で生成順を変えても collection の Style は混線しない。"""
+    _write_suno_override(channel_dir, genre_line="shared channel style")
+    paths: dict[str, Path] = {}
+    styles = {
+        "first": "first collection soul",
+        "second": "second collection jazz",
+    }
+    for name, genre_line in styles.items():
+        collection_dir = tmp_path / name
+        collection_dir.mkdir()
+        paths[name] = _write_minimal_patterns(collection_dir, genre_line=genre_line)
+
+    generated = {name: build_prompt_entries(paths[name])[0]["style"] for name in order}
+
+    for name, style in generated.items():
+        other_name = "second" if name == "first" else "first"
+        assert styles[name] in style
+        assert styles[other_name] not in style
+        assert "shared channel style" not in style
+
+
+def test_patterns_genre_line_rejects_non_string_value(channel_dir, tmp_path):
+    """patterns の genre_line は不正 shape を mode 推定前に拒否する。"""
+    _write_suno_override(channel_dir, genre_line="channel fallback")
+    patterns_path = _write_minimal_patterns(tmp_path, genre_line=["not", "a", "string"], mode=None)
+
+    with pytest.raises(ConfigError, match=r"patterns\.yaml.*genre_line.*string"):
+        build_prompt_entries(patterns_path)
 
 
 def test_fallback_uses_video_analysis_genre_line_when_config_empty(channel_dir, tmp_path):


### PR DESCRIPTION
## Summary

- suno-patterns.yaml の genre_line を channel fallback より優先
- Style と mode 推定を collection 固有値へ統一
- collection 間の混線防止と未指定 fallback を回帰テストで固定

## Verification

- focused: 122 passed
- related: 276 passed
- full pytest: 7495 passed, 1 skipped
- ruff / format / Any / diff-check: pass

Closes #3134