### PR TITLE
fix(suno-helper): download 失敗理由に phase を付与する (#3126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno-helper)`: 通常・再試行の download 失敗理由へ `(phase=downloading)` を一度だけ付与し、overlay と unattended stop reason で失敗工程を特定可能にした（#3126）。
+
 - `fix(suno-helper)`: downloaded 通知 API の失敗表示に URL encode 後の実 POST endpoint を含め、token 再取得失敗でも起点 request の文脈を維持（#3125）。
 
 - `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。

--- a/extensions/suno-helper/lib/download-flow.ts
+++ b/extensions/suno-helper/lib/download-flow.ts
@@ -55,6 +55,15 @@ export interface DownloadContext {
 }
 
 const DOWNLOAD_COMPLETE_TIMEOUT_MS = 660000;
+const DOWNLOADING_PHASE_SUFFIX = "(phase=downloading)";
+
+function withDownloadingPhase(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.endsWith(DOWNLOADING_PHASE_SUFFIX)) {
+    return error instanceof Error ? error : new Error(message);
+  }
+  return new Error(`${message} ${DOWNLOADING_PHASE_SUFFIX}`);
+}
 
 export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
   let downloadCompleteResolver:
@@ -102,7 +111,81 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     });
   }
 
-  async function performDownload(
+  async function startDownloadWatcher(
+    format: DownloadContext["format"]
+  ): Promise<void> {
+    const startResult = await sendMessage("startDownload", { format });
+    if (!startResult?.ok) {
+      throw new Error(
+        startResult?.message ?? "Download all 監視を開始できませんでした"
+      );
+    }
+  }
+
+  async function cancelDownloadWatcher(): Promise<void> {
+    downloadCompleteResolver = null;
+    await sendMessage("cancelDownload", undefined).catch(
+      (cancelErr: unknown) => {
+        console.warn("[suno-helper] cancelDownload 中継失敗:", cancelErr);
+      }
+    );
+  }
+
+  async function waitForDownloadedFilename(
+    format: DownloadContext["format"]
+  ): Promise<string | null> {
+    const downloadPromise = waitForDownloadComplete();
+    let watcherActive = true;
+    try {
+      await triggerDownloadAll(format);
+      const downloadResult = await downloadPromise;
+      if (deps.isAborted()) return null;
+      if (!downloadResult) {
+        throw new Error("Download all がタイムアウトしました");
+      }
+      watcherActive = false;
+      if (!downloadResult.ok) {
+        throw new Error(downloadResult.message);
+      }
+      return downloadResult.filename;
+    } finally {
+      if (watcherActive) {
+        await cancelDownloadWatcher();
+      }
+    }
+  }
+
+  async function postDownloadedArchive(
+    context: DownloadContext,
+    collectionId: string,
+    progressTotal: number,
+    expectedFileCount: number,
+    filename: string
+  ): Promise<void> {
+    await deps.onDownloadComplete?.(filename);
+    const postResult = await sendMessage("postDownloaded", {
+      baseUrl: context.baseUrl,
+      collectionId,
+      body: {
+        file_count: expectedFileCount,
+        expected_file_count: expectedFileCount,
+        format: context.format,
+        download_path: filename,
+      },
+    });
+    // 部分完了（Suno の生成数不足）はサーバーが warning 付き 200 で受理する (#1913)。
+    // フローは止めず、不足をユーザーへ通知するだけに留める
+    if (postResult?.warning) {
+      console.warn(`[suno-helper] 部分ダウンロード: ${postResult.warning}`);
+      deps.emitProgress({
+        phase: PHASE.DOWNLOADING,
+        total: progressTotal,
+        message: `部分ダウンロード（不足あり）: ${postResult.warning}`,
+      });
+    }
+  }
+
+  async function performDownloadAttempt(
     context: DownloadContext,
     collectionId: string,
     progressTotal: number,
@@ -115,62 +198,33 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
       total: progressTotal,
       message: `${context.format.toUpperCase()} 形式`,
     });
-    const startResult = await sendMessage("startDownload", {
-      format: context.format,
-    });
-    if (!startResult?.ok) {
-      throw new Error(
-        startResult?.message ?? "Download all 監視を開始できませんでした"
-      );
-    }
-    const downloadPromise = waitForDownloadComplete();
-    let watcherActive = true;
+    await startDownloadWatcher(context.format);
+    const filename = await waitForDownloadedFilename(context.format);
+    if (filename === null) return;
+    await postDownloadedArchive(
+      context,
+      collectionId,
+      progressTotal,
+      expectedFileCount,
+      filename
+    );
+  }
+
+  async function performDownload(
+    context: DownloadContext,
+    collectionId: string,
+    progressTotal: number,
+    expectedFileCount: number
+  ): Promise<void> {
     try {
-      await triggerDownloadAll(context.format);
-
-      const downloadResult = await downloadPromise;
-
-      if (deps.isAborted()) return;
-
-      if (!downloadResult) {
-        throw new Error("Download all がタイムアウトしました");
-      }
-      watcherActive = false;
-      if (!downloadResult.ok) {
-        throw new Error(downloadResult.message);
-      }
-
-      await deps.onDownloadComplete?.(downloadResult.filename);
-
-      const postResult = await sendMessage("postDownloaded", {
-        baseUrl: context.baseUrl,
+      await performDownloadAttempt(
+        context,
         collectionId,
-        body: {
-          file_count: expectedFileCount,
-          expected_file_count: expectedFileCount,
-          format: context.format,
-          download_path: downloadResult.filename,
-        },
-      });
-      // 部分完了（Suno の生成数不足）はサーバーが warning 付き 200 で受理する (#1913)。
-      // フローは止めず、不足をユーザーへ通知するだけに留める
-      if (postResult?.warning) {
-        console.warn(`[suno-helper] 部分ダウンロード: ${postResult.warning}`);
-        deps.emitProgress({
-          phase: PHASE.DOWNLOADING,
-          total: progressTotal,
-          message: `部分ダウンロード（不足あり）: ${postResult.warning}`,
-        });
-      }
-    } finally {
-      if (watcherActive) {
-        downloadCompleteResolver = null;
-        await sendMessage("cancelDownload", undefined).catch(
-          (cancelErr: unknown) => {
-            console.warn("[suno-helper] cancelDownload 中継失敗:", cancelErr);
-          }
-        );
-      }
+        progressTotal,
+        expectedFileCount
+      );
+    } catch (error) {
+      throw withDownloadingPhase(error);
     }
   }
 

--- a/extensions/suno-helper/tests/download-flow.test.ts
+++ b/extensions/suno-helper/tests/download-flow.test.ts
@@ -57,7 +57,7 @@ function expectOnlyStartAndCancelMessages(): void {
   ).toBe(false);
 }
 
-describe("download flow cleanup", () => {
+describe("download flow", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     messagingMocks.handlers.clear();
@@ -122,5 +122,57 @@ describe("download flow cleanup", () => {
     dispatchDownloadComplete();
     await Promise.resolve();
     expectOnlyStartAndCancelMessages();
+  });
+
+  it("通常 download の API 失敗理由へ downloading phase を付与して返す", async () => {
+    const apiError =
+      "POST /collections/collection/downloaded failed: 403 Forbidden";
+    messagingMocks.sendMessage.mockImplementation(async (message: string) => {
+      if (message === "startDownload") {
+        return { ok: true };
+      }
+      if (message === "postDownloaded") {
+        throw new Error(apiError);
+      }
+      return { ok: true };
+    });
+    downloadMocks.triggerDownloadAll.mockImplementationOnce(async () => {
+      dispatchDownloadComplete();
+    });
+    const flow = createSubject(() => false);
+
+    await expect(
+      flow.downloadBestEffort(CONTEXT, "collection", 2, 2)
+    ).resolves.toBe(`${apiError} (phase=downloading)`);
+  });
+
+  it("retry download の失敗理由へ downloading phase を付与して throw する", async () => {
+    messagingMocks.sendMessage.mockResolvedValueOnce({
+      ok: false,
+      message: "watcher unavailable",
+    });
+    const flow = createSubject(() => false);
+
+    await expect(
+      flow.retryDownload({
+        context: CONTEXT,
+        collectionId: "collection",
+        submittedClipIds: ["clip-id"],
+        selectClipIds: vi.fn(async () => undefined),
+        clearResumeState: vi.fn(async () => undefined),
+      })
+    ).rejects.toThrow("watcher unavailable (phase=downloading)");
+  });
+
+  it("既に downloading phase がある失敗理由を重複して付与しない", async () => {
+    messagingMocks.sendMessage.mockResolvedValueOnce({
+      ok: false,
+      message: "watcher unavailable (phase=downloading)",
+    });
+    const flow = createSubject(() => false);
+
+    await expect(
+      flow.performDownload(CONTEXT, "collection", 2, 2)
+    ).rejects.toThrow(/^watcher unavailable \(phase=downloading\)$/);
   });
 });


### PR DESCRIPTION
## Summary

- 通常・retry download の失敗理由へ downloading phase を正確に一度付与
- API endpoint/status message を維持
- overlay と unattended stop reason の共通 message を回帰テストで固定

## Verification

- focused: 54 passed
- full Vitest: 1350 passed
- check / format / lint / compile / build / diff-check: pass

Closes #3126

Depends on #3140