### PR TITLE
feat(suno): duration_sec の不正値を拒否する (#3131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -319,6 +319,16 @@ class _ResolvedPattern:
 # (_build_advanced_json_fields の skip ロジック参照)。
 _ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender")
 _VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
+_DURATION_SEC_KEY = "duration_sec"
+
+
+def _validate_duration_sec_override(override: Mapping[str, object]) -> None:
+    """明示された duration_sec が正の整数であることを検証する。"""
+    if _DURATION_SEC_KEY not in override:
+        return
+    value = override[_DURATION_SEC_KEY]
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConfigError("config/skills/suno.yaml::duration_sec must be a positive integer")
 
 
 def _duration_filter_from_config(suno: dict) -> dict:
@@ -510,6 +520,7 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
     # JSON 反映は channel override に明示されたキーのみ gating する (#900、A 案)。merged config では
     # default.yaml の既定値と区別できないため、override 単体を別途読む。
     override = load_channel_override("suno")
+    _validate_duration_sec_override(override)
     advanced_json_fields = _build_advanced_json_fields(override)
     resolved_suno = resolve_suno_config(suno)
 

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -1625,6 +1625,29 @@ def test_unique_titles_allow_same_pattern_name_when_variation_suffix_disambiguat
     assert entries[1]["name"].endswith("(Variation 2)")
 
 
+@pytest.mark.parametrize(
+    "duration_sec",
+    [True, False, "180", 180.0, float("nan"), float("inf"), float("-inf"), 0, -1],
+)
+def test_build_prompt_entries_rejects_invalid_duration_sec_override(channel_dir, tmp_path, duration_sec):
+    """明示された duration_sec が正の整数でなければ fail-loud に拒否する。"""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", duration_sec=duration_sec)
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    with pytest.raises(ConfigError, match=r"duration_sec.*positive integer"):
+        build_prompt_entries(patterns_path)
+
+
+def test_build_prompt_entries_accepts_positive_integer_duration_sec_override(channel_dir, tmp_path):
+    """正の整数の duration_sec は既存の prompt 生成を妨げない。"""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", duration_sec=180)
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert len(entries) == 1
+
+
 # ---------------------------------------------------------------------------
 # issue #900: More Options 3 フィールド (style_influence / weirdness / exclude_styles)
 # の suno-prompts.json への wire


### PR DESCRIPTION
## Summary

- duration_sec の明示値を正の整数に限定
- bool・文字列・float・非有限値・0以下を ConfigError で拒否
- 未設定と duration_filter の既存契約を維持

## Verification

- focused: 10 passed
- file: 128 passed
- related: 384 passed
- full pytest: 7501 passed, 1 skipped
- ruff / format / Any / diff-check: pass

Closes #3131