### PR TITLE
feat(suno): collection の除外スタイルを優先する (#3136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 適応型ペーシング後の Create 直前に Turnstile を再確認し、表示中の新規投入を止めて解消後に同じ entry から重複なく再開する（#2536）。
 
 - `fix(config)`: channel skill-config の未知のトップレベルキーを警告し、`thumbnail.yaml` の誤った `auto_select` 階層などが silent に無視される状態を防止（#2520）。
+- `feat(suno)`: collection の `suno-patterns.yaml` にある `exclude_styles` を Markdown と全 JSON entry で channel 設定より優先し、空文字を明示値として扱う（#3136）。
+
 - `feat(suno)`: collection の `suno-patterns.yaml` にある `style_variants` を channel 設定より優先し、不正な collection variant を生成前に拒否（#3135）。
 
 - `feat(suno)`: collection の `suno-patterns.yaml` に `genre_line` がある場合は channel 設定より優先し、Style と mode 推定を collection ごとに分離（#3134）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -456,6 +456,20 @@ def _resolve_genre_line(data: Mapping[str, object], channel_fallback: str, patte
     return genre_line
 
 
+def _resolve_exclude_styles(
+    data: Mapping[str, object],
+    channel_fallback: str,
+    channel_json_fields: dict,
+    patterns_path: Path,
+) -> tuple[str, dict]:
+    if "exclude_styles" not in data:
+        return channel_fallback, channel_json_fields
+    exclude_styles = data["exclude_styles"]
+    if not isinstance(exclude_styles, str):
+        raise ConfigError(f"{patterns_path}: exclude_styles must be a string")
+    return exclude_styles, {**channel_json_fields, "exclude_styles": exclude_styles}
+
+
 def _resolve_style_variants(
     data: Mapping[str, object], channel_fallback: object, patterns_path: Path
 ) -> Mapping[str, Mapping[str, str]]:
@@ -489,7 +503,12 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
 
     genre_line = _resolve_genre_line(data, resolved_suno.genre_line, patterns_path)
     mood_descriptors = suno.get("mood_descriptors", "")
-    exclude_styles = resolved_suno.exclude_styles
+    exclude_styles, advanced_json_fields = _resolve_exclude_styles(
+        data,
+        resolved_suno.exclude_styles,
+        advanced_json_fields,
+        patterns_path,
+    )
     style_variants = _resolve_style_variants(data, suno.get("style_variants", {}), patterns_path)
     style_influence = suno.get("style_influence", 50)
     weirdness = suno.get("weirdness", 50)

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -21,6 +21,7 @@ _SUNO_LYRIC_DEFAULT_YAML = REPO_ROOT / ".claude" / "skills" / "suno-lyric" / "co
 _SKILL_MD = REPO_ROOT / ".claude" / "skills" / "suno" / "SKILL.md"
 _CONFIG_RULES_MD = REPO_ROOT / ".claude" / "skills" / "channel-new" / "references" / "config-generation-rules.md"
 _STYLE_VARIANTS_UNSET = object()
+_EXCLUDE_STYLES_UNSET = object()
 
 
 @pytest.fixture
@@ -1495,6 +1496,7 @@ def _write_patterns_with_explicit_entries(
     tracks_top: int,
     *,
     style_variants: object = _STYLE_VARIANTS_UNSET,
+    exclude_styles: object = _EXCLUDE_STYLES_UNSET,
 ) -> Path:
     """name_jp / name_en を明示した複数 entry の yaml を書き出す.
 
@@ -1508,6 +1510,8 @@ def _write_patterns_with_explicit_entries(
     }
     if style_variants is not _STYLE_VARIANTS_UNSET:
         payload["style_variants"] = style_variants
+    if exclude_styles is not _EXCLUDE_STYLES_UNSET:
+        payload["exclude_styles"] = exclude_styles
     path = dir_ / "patterns.yaml"
     path.write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
     return path
@@ -1629,6 +1633,62 @@ def test_unique_titles_allow_same_pattern_name_when_variation_suffix_disambiguat
 # 【要レビュー】product owner が B 案 (同梱既定の暗黙 auto-flow) を意図する場合、本セクションの
 # テストは設計やり直しが必要 (特に backward-compat の exact-3-keys テスト)。
 # ---------------------------------------------------------------------------
+
+
+def test_collection_exclude_styles_overrides_channel_in_md_and_every_json_entry(channel_dir, tmp_path):
+    """collection の exclude_styles は表示と全 JSON entry で channel より優先する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", exclude_styles="channel metal")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[
+            {"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]},
+            {"name_jp": "書斎", "name_en": "Study", "tempo": "gentle", "scenes": ["warm study"]},
+        ],
+        tracks_top=4,
+        exclude_styles="collection edm",
+    )
+
+    md = generate(patterns_path)
+    entries = build_prompt_entries(patterns_path)
+
+    assert "collection edm" in md
+    assert "channel metal" not in md
+    assert all(entry["exclude_styles"] == "collection edm" for entry in entries)
+
+
+def test_collection_empty_exclude_styles_is_explicit_for_md_and_json(channel_dir, tmp_path):
+    """collection の空文字は channel 値へ fallback せず、JSON にも明示値として載せる."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", exclude_styles="channel metal")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[
+            {"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]},
+            {"name_jp": "書斎", "name_en": "Study", "tempo": "gentle", "scenes": ["warm study"]},
+        ],
+        tracks_top=4,
+        exclude_styles="",
+    )
+
+    md = generate(patterns_path)
+    entries = build_prompt_entries(patterns_path)
+
+    assert "**Exclude Styles:**" not in md
+    assert all("exclude_styles" in entry and entry["exclude_styles"] == "" for entry in entries)
+
+
+@pytest.mark.parametrize("exclude_styles", [None, [], {}])
+def test_collection_exclude_styles_rejects_non_string(channel_dir, tmp_path, exclude_styles):
+    """collection の exclude_styles が文字列でなければ生成前に拒否する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[{"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]}],
+        tracks_top=2,
+        exclude_styles=exclude_styles,
+    )
+
+    with pytest.raises(ConfigError, match=r"patterns\.yaml.*exclude_styles.*string"):
+        build_prompt_entries(patterns_path)
 
 
 def test_build_prompt_entries_includes_style_influence_from_channel_override(channel_dir, tmp_path):


### PR DESCRIPTION
## Summary

- collection exclude_styles を Markdown と全 JSON entry で優先
- 空文字を明示値として扱う
- 未指定時の channel 表示・wire 契約を維持

## Verification

- focused: 134 passed
- related: 288 passed
- full pytest: 7507 passed, 1 skipped
- ruff / format / Any / diff-check: pass

Closes #3136

Depends on #3144