### PR TITLE
feat(suno): duration_sec を全 entry へ出力する (#3132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -309,7 +309,7 @@ class _ResolvedPattern:
     lyrics_by_scene: list[str]  # scenes と同じ長さ。各値は rstrip 済み。歌詞が無ければ ""
 
 
-# suno-prompts.json へ wire する More Options の key 一覧 (#900, vocal_gender 追加)。
+# suno-prompts.json へ wire する More Options の key 一覧 (#900, vocal_gender / duration_sec 追加)。
 # JSON への反映は **channel override (config/skills/suno.yaml) に明示設定されたキーのみ**。
 # config.default.yaml 同梱の既定値 (style_influence: 50 等) は JSON には載せない
 # (= 「何も足さない既存 collection は name/style/lyrics の 3 キーちょうど」の後方互換を守るため)。
@@ -317,9 +317,9 @@ class _ResolvedPattern:
 # vocal_gender は suno-helper 拡張が Suno UI Voice section の Male / Female ボタン押下に使う
 # (拡張型契約: "male" | "female" | "neutral" | "auto")。空文字は「未指定」として JSON 出力から省く
 # (_build_advanced_json_fields の skip ロジック参照)。
-_ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender")
-_VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
 _DURATION_SEC_KEY = "duration_sec"
+_ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender", _DURATION_SEC_KEY)
+_VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
 
 
 def _validate_duration_sec_override(override: Mapping[str, object]) -> None:

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -1638,14 +1638,44 @@ def test_build_prompt_entries_rejects_invalid_duration_sec_override(channel_dir,
         build_prompt_entries(patterns_path)
 
 
-def test_build_prompt_entries_accepts_positive_integer_duration_sec_override(channel_dir, tmp_path):
-    """正の整数の duration_sec は既存の prompt 生成を妨げない。"""
+def test_build_prompt_entries_includes_positive_integer_duration_sec_override(channel_dir, tmp_path):
+    """正の整数の duration_sec を数値のまま prompt entry へ出力する。"""
     _write_suno_override(channel_dir, genre_line="lo-fi jazz", duration_sec=180)
     patterns_path = _write_minimal_patterns(tmp_path)
 
     entries = build_prompt_entries(patterns_path)
 
-    assert len(entries) == 1
+    assert entries[0]["duration_sec"] == 180
+    assert isinstance(entries[0]["duration_sec"], int)
+
+
+def test_build_prompt_entries_applies_duration_sec_to_every_scene(channel_dir, tmp_path):
+    """collection 共通の duration_sec を multi-scene の全 entry へ伝搬する。"""
+    _write_suno_override(channel_dir, genre_line="dream pop vocals", duration_sec=180)
+    patterns_path = _write_vocal_patterns(tmp_path, ["scene one", "scene two"])
+    _write_suno_lyrics_json(
+        tmp_path,
+        ["歌もの — Vocal (Variation 1)", "歌もの — Vocal (Variation 2)"],
+    )
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert len(entries) == 2
+    assert [entry["duration_sec"] for entry in entries] == [180, 180]
+
+
+def test_build_prompt_entries_does_not_derive_duration_sec_from_duration_filter(channel_dir, tmp_path):
+    """duration_filter だけの設定から duration_sec を推定・同期しない。"""
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        duration_filter={"min_sec": 120, "max_sec": 240},
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert "duration_sec" not in entries[0]
 
 
 # ---------------------------------------------------------------------------
@@ -1900,6 +1930,7 @@ def test_build_prompt_entries_omits_advanced_fields_without_channel_override(cha
     assert "style_influence" not in entries[0]
     assert "weirdness" not in entries[0]
     assert "exclude_styles" not in entries[0]
+    assert "duration_sec" not in entries[0]
 
 
 def test_build_prompt_entries_omits_advanced_fields_when_no_override_file(channel_dir, tmp_path):


### PR DESCRIPTION
## Summary

- 明示した duration_sec を全 prompt entry へ数値で出力
- 未設定時はキーを省略
- multi-scene 伝搬と duration_filter 非同期を固定

## Verification

- focused: 22 passed
- file: 130 passed
- related: 386 passed
- full pytest: 7503 passed, 1 skipped
- ruff / format / Any / diff-check: pass

Closes #3132

Depends on #3143