### PR TITLE
feat(suno): collection のボーカル性別を優先する (#3137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 適応型ペーシング後の Create 直前に Turnstile を再確認し、表示中の新規投入を止めて解消後に同じ entry から重複なく再開する（#2536）。
 
 - `fix(config)`: channel skill-config の未知のトップレベルキーを警告し、`thumbnail.yaml` の誤った `auto_select` 階層などが silent に無視される状態を防止（#2520）。
+- `feat(suno)`: collection の `suno-patterns.yaml` にある `vocal_gender` を全 JSON entry で channel 設定より優先し、空文字による省略と型契約検証に対応（#3137）。
+
 - `feat(suno)`: collection の `suno-patterns.yaml` にある `exclude_styles` を Markdown と全 JSON entry で channel 設定より優先し、空文字を明示値として扱う（#3136）。
 
 - `feat(suno)`: collection の `suno-patterns.yaml` にある `style_variants` を channel 設定より優先し、不正な collection variant を生成前に拒否（#3135）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -318,6 +318,7 @@ class _ResolvedPattern:
 # (拡張型契約: "male" | "female" | "neutral" | "auto")。空文字は「未指定」として JSON 出力から省く
 # (_build_advanced_json_fields の skip ロジック参照)。
 _ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender")
+_VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
 
 
 def _duration_filter_from_config(suno: dict) -> dict:
@@ -470,6 +471,20 @@ def _resolve_exclude_styles(
     return exclude_styles, {**channel_json_fields, "exclude_styles": exclude_styles}
 
 
+def _resolve_vocal_gender(data: Mapping[str, object], channel_json_fields: dict, patterns_path: Path) -> dict:
+    if "vocal_gender" not in data:
+        return channel_json_fields
+    vocal_gender = data["vocal_gender"]
+    if not isinstance(vocal_gender, str) or (vocal_gender and vocal_gender not in _VOCAL_GENDERS):
+        raise ConfigError(f"{patterns_path}: vocal_gender must be empty or one of: male, female, neutral, auto")
+    resolved_fields = channel_json_fields.copy()
+    if vocal_gender:
+        resolved_fields["vocal_gender"] = vocal_gender
+    else:
+        resolved_fields.pop("vocal_gender", None)
+    return resolved_fields
+
+
 def _resolve_style_variants(
     data: Mapping[str, object], channel_fallback: object, patterns_path: Path
 ) -> Mapping[str, Mapping[str, str]]:
@@ -509,6 +524,7 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
         advanced_json_fields,
         patterns_path,
     )
+    advanced_json_fields = _resolve_vocal_gender(data, advanced_json_fields, patterns_path)
     style_variants = _resolve_style_variants(data, suno.get("style_variants", {}), patterns_path)
     style_influence = suno.get("style_influence", 50)
     weirdness = suno.get("weirdness", 50)

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -22,6 +22,7 @@ _SKILL_MD = REPO_ROOT / ".claude" / "skills" / "suno" / "SKILL.md"
 _CONFIG_RULES_MD = REPO_ROOT / ".claude" / "skills" / "channel-new" / "references" / "config-generation-rules.md"
 _STYLE_VARIANTS_UNSET = object()
 _EXCLUDE_STYLES_UNSET = object()
+_VOCAL_GENDER_UNSET = object()
 
 
 @pytest.fixture
@@ -1497,6 +1498,7 @@ def _write_patterns_with_explicit_entries(
     *,
     style_variants: object = _STYLE_VARIANTS_UNSET,
     exclude_styles: object = _EXCLUDE_STYLES_UNSET,
+    vocal_gender: object = _VOCAL_GENDER_UNSET,
 ) -> Path:
     """name_jp / name_en を明示した複数 entry の yaml を書き出す.
 
@@ -1512,6 +1514,8 @@ def _write_patterns_with_explicit_entries(
         payload["style_variants"] = style_variants
     if exclude_styles is not _EXCLUDE_STYLES_UNSET:
         payload["exclude_styles"] = exclude_styles
+    if vocal_gender is not _VOCAL_GENDER_UNSET:
+        payload["vocal_gender"] = vocal_gender
     path = dir_ / "patterns.yaml"
     path.write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
     return path
@@ -1802,6 +1806,57 @@ def test_build_prompt_entries_omits_empty_vocal_gender(channel_dir, tmp_path):
     entries = build_prompt_entries(patterns_path)
 
     assert "vocal_gender" not in entries[0]
+
+
+def test_collection_vocal_gender_overrides_channel_for_every_json_entry(channel_dir, tmp_path):
+    """collection の vocal_gender は全 JSON entry で channel より優先する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", vocal_gender="male")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[
+            {"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]},
+            {"name_jp": "書斎", "name_en": "Study", "tempo": "gentle", "scenes": ["warm study"]},
+        ],
+        tracks_top=4,
+        vocal_gender="female",
+    )
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert all(entry["vocal_gender"] == "female" for entry in entries)
+
+
+def test_collection_empty_vocal_gender_omits_channel_value_from_every_json_entry(channel_dir, tmp_path):
+    """collection の空文字は channel 値へ fallback せず JSON から省略する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", vocal_gender="male")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[
+            {"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]},
+            {"name_jp": "書斎", "name_en": "Study", "tempo": "gentle", "scenes": ["warm study"]},
+        ],
+        tracks_top=4,
+        vocal_gender="",
+    )
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert all("vocal_gender" not in entry for entry in entries)
+
+
+@pytest.mark.parametrize("vocal_gender", [None, "other"])
+def test_collection_vocal_gender_rejects_values_outside_json_contract(channel_dir, tmp_path, vocal_gender):
+    """collection の vocal_gender が拡張の型契約外なら生成前に拒否する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=[{"name_jp": "屋上", "name_en": "Rooftop", "tempo": "slow", "scenes": ["quiet rooftop"]}],
+        tracks_top=2,
+        vocal_gender=vocal_gender,
+    )
+
+    with pytest.raises(ConfigError, match=r"patterns\.yaml.*vocal_gender.*male.*female.*neutral.*auto"):
+        build_prompt_entries(patterns_path)
 
 
 def test_build_prompt_entries_omits_advanced_fields_without_channel_override(channel_dir, tmp_path):


### PR DESCRIPTION
## Summary

- collection vocal_gender を全 JSON entry で優先
- 空文字は既存契約どおり省略
- 列挙外値を生成前に fail-loud で拒否

## Verification

- focused: 138 passed
- related: 292 passed
- full pytest: 7511 passed, 1 skipped
- ruff / format / Any / diff-check: pass

Closes #3137

Depends on #3146