### PR TITLE
docs(suno): duration_sec の設定契約を公開する (#3133)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -481,6 +481,8 @@ uv run yt-generate-suno <collection-path>
 
 `config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `style_influence` をパターンに自動付加して `suno-prompts.md` と `suno-prompts.json` を生成する。ボーカルモードでは entry `name` を使い、同階層の `suno-lyrics.json` から同名 lyrics を Style とマージする。保存後、`workflow-state.json` の `assets.music_prompts = true` に更新する。
 
+Suno helper の Custom Duration を collection 共通で指定する場合は、チャンネル側 `config/skills/suno.yaml` に秒単位の正の整数 `duration_sec` を設定する。明示した場合だけ同じ数値を `suno-prompts.json` の全 entry へ出力し、未設定時はキー自体を省略する。`duration_sec` は生成前の目標尺であり、生成後 clip の採用範囲を表す `duration_filter` から推定・同期しない。
+
 `suno-prompts.json` には suno-helper 拡張が playlist 採用判定に使う `duration_filter`（既定 `min_sec: 60` / `max_sec: 300`）も書き出される。1 曲 5 分超が常態の長尺 BGM チャンネルでは既定 `max_sec: 300` で大半の clip が duration guard NG になり Queue モード + 一括 DL が完走しないため、チャンネル側 `config/skills/suno.yaml` で override する（部分指定可。未指定キーは既定値と deep-merge）:
 
 ```yaml

--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -120,6 +120,11 @@ style_variation:
 # - pattern 概念は廃止: 各 entry は独立した情景フレーズで設計する (旧 4 パターン × 3 回生成は使わない)。
 tracks_per_collection: 20
 
+# Suno helper の Custom Duration へ渡す collection 共通の目標尺（秒）。
+# channel override に正の整数を明示した場合だけ全 prompt entry へ出力し、未設定時はキーを省略する。
+# 生成後 clip の採用範囲を決める duration_filter とは独立し、自動推定・同期しない。
+# duration_sec: 180
+
 # Suno helper の playlist 採用判定に使う collection 単位 duration guard（秒）。
 # 生成された clip がこの範囲外なら playlist 追加対象から除外される。
 duration_filter:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `docs(suno)`: optional な `duration_sec` の単位・値域・明示時のみ全 entry へ出力する契約と、生成後の採用範囲を担う `duration_filter` との責務分離を配布設定と Suno 手順へ記載した（#3133）。
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。


### PR DESCRIPTION
## Summary

- duration_sec の秒単位・正整数・collection 共通契約を公開
- 未設定時の省略と duration_filter との責務分離を明記
- active default は追加せずコメント例だけを配布

## Verification

- uv run yt-skills lint
- uv run pytest -q tests/commands/suno tests/skills/test_suno_skill_contract.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3133
Depends on #3132