### PR TITLE
refactor(downloaded): ZIP の音声数と配置数を分離する (#3127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(downloaded)`: Suno ZIP の archive 内音声総数と実配置数を単一走査の詳細結果として返し、現行の配置数 API 契約を維持（#3127）。
+
 - `fix(suno-helper)`: 通常・再試行の download 失敗理由へ `(phase=downloading)` を一度だけ付与し、overlay と unattended stop reason で失敗工程を特定可能にした（#3126）。
 
 - `fix(suno-helper)`: downloaded 通知 API の失敗表示に URL encode 後の実 POST endpoint を含め、token 再取得失敗でも起点 request の文脈を維持（#3125）。

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from youtube_automation.core.adapters.media import CollectionPaths
@@ -20,6 +21,12 @@ _AUDIO_EXTENSIONS = frozenset({".mp3", ".m4a", ".wav"})
 _ZIP_MAX_TOTAL_SIZE = 2 * 1024 * 1024 * 1024
 _ZIP_MAX_SINGLE_FILE = 500 * 1024 * 1024
 _ZIP_MAX_ENTRIES = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadedArchiveResult:
+    audio_count: int
+    placed_count: int
 
 
 def count_audio_files(music_dir: Path) -> int:
@@ -54,23 +61,36 @@ def commit_staged_music_files(coll_dir: Path, staging_dir: Path) -> None:
             shutil.rmtree(backup_dir, ignore_errors=True)
 
 
-def extract_downloaded_archive(
+def extract_downloaded_archive_detailed(
     coll_dir: Path, download_path: str, *, prompt_entries_reader: PromptEntriesReader
-) -> int:
+) -> DownloadedArchiveResult:
     # 期待数未満の部分 ZIP も受け入れて配置する（#1913）。不足の記録と警告は
     # workflow-state（actual/missing_file_count）と downloaded API response が担う
     resolved_dp = Path(download_path).resolve()
     staging_dir = Path(tempfile.mkdtemp(dir=str(coll_dir), prefix=".suno-music-"))
     try:
-        placed_count = extract_and_rename_music(
-            coll_dir, str(resolved_dp), prompt_entries_reader=prompt_entries_reader, target_dir=staging_dir
+        result = _extract_and_rename_music_to_dir(
+            coll_dir,
+            str(resolved_dp),
+            staging_dir,
+            prompt_entries_reader,
         )
-        if placed_count == 0:
+        if result.placed_count == 0:
             raise DownloadedArtifactError("ZIP extraction failed: 0 audio files placed")
         commit_staged_music_files(coll_dir, staging_dir)
     finally:
         shutil.rmtree(staging_dir, ignore_errors=True)
-    return placed_count
+    return result
+
+
+def extract_downloaded_archive(
+    coll_dir: Path, download_path: str, *, prompt_entries_reader: PromptEntriesReader
+) -> int:
+    return extract_downloaded_archive_detailed(
+        coll_dir,
+        download_path,
+        prompt_entries_reader=prompt_entries_reader,
+    ).placed_count
 
 
 _CANONICAL_MUSIC_FILENAME_RE = re.compile(r"^(?P<index>\d{2,})(?P<variant>[ab])-(?P<title>.+)$")
@@ -265,11 +285,11 @@ def _extract_and_rename_music_to_dir(
     download_path: str,
     target_dir: Path,
     prompt_entries_reader: PromptEntriesReader,
-) -> int:
+) -> DownloadedArchiveResult:
     zip_path = Path(download_path)
     if not zip_path.is_file() or not zipfile.is_zipfile(zip_path):
         print(f"[yt-collection-serve] ZIP が無効です（skip）: {download_path}")
-        return 0
+        return DownloadedArchiveResult(audio_count=0, placed_count=0)
 
     name_to_index = _build_name_to_index(coll_dir, prompt_entries_reader)
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -279,7 +299,7 @@ def _extract_and_rename_music_to_dir(
             infos = zf.infolist()
             if len(infos) > _ZIP_MAX_ENTRIES:
                 print(f"[yt-collection-serve] ZIP entry 数が上限超過 ({len(infos)} > {_ZIP_MAX_ENTRIES}): skip")
-                return 0
+                return DownloadedArchiveResult(audio_count=0, placed_count=0)
             total_size = 0
             for info in infos:
                 if info.file_size > _ZIP_MAX_SINGLE_FILE:
@@ -287,11 +307,11 @@ def _extract_and_rename_music_to_dir(
                         f"[yt-collection-serve] ZIP 内ファイルがサイズ上限超過"
                         f" ({info.filename}: {info.file_size} bytes): skip"
                     )
-                    return 0
+                    return DownloadedArchiveResult(audio_count=0, placed_count=0)
                 total_size += info.file_size
             if total_size > _ZIP_MAX_TOTAL_SIZE:
                 print(f"[yt-collection-serve] ZIP 総展開サイズが上限超過 ({total_size} bytes): skip")
-                return 0
+                return DownloadedArchiveResult(audio_count=0, placed_count=0)
             audio_infos = [
                 info for info in infos if not info.is_dir() and Path(info.filename).suffix.lower() in _AUDIO_EXTENSIONS
             ]
@@ -331,10 +351,10 @@ def _extract_and_rename_music_to_dir(
             moved_count += 1
 
         print(f"[yt-collection-serve] 展開完了: {moved_count} files → {target_dir}")
-        return moved_count
+        return DownloadedArchiveResult(audio_count=len(audio_infos), placed_count=moved_count)
     except zipfile.BadZipFile as exc:
         print(f"[yt-collection-serve] ZIP 展開エラー（skip）: {exc}")
-        return 0
+        return DownloadedArchiveResult(audio_count=0, placed_count=0)
     except (OSError, ValueError, shutil.Error) as exc:
         print(f"[yt-collection-serve] ZIP 展開エラー: {exc}")
         raise DownloadedArtifactError(f"ZIP extraction failed: {exc}") from exc
@@ -350,11 +370,13 @@ def extract_and_rename_music(
     target_dir: Path | None = None,
 ) -> int:
     if target_dir is not None:
-        return _extract_and_rename_music_to_dir(coll_dir, download_path, target_dir, prompt_entries_reader)
+        return _extract_and_rename_music_to_dir(coll_dir, download_path, target_dir, prompt_entries_reader).placed_count
 
     staging_dir = Path(tempfile.mkdtemp(dir=str(coll_dir), prefix=".suno-music-"))
     try:
-        placed_count = _extract_and_rename_music_to_dir(coll_dir, download_path, staging_dir, prompt_entries_reader)
+        placed_count = _extract_and_rename_music_to_dir(
+            coll_dir, download_path, staging_dir, prompt_entries_reader
+        ).placed_count
         if placed_count > 0:
             try:
                 commit_staged_music_files(coll_dir, staging_dir)

--- a/tests/domains/suno/downloaded/test_archive_result.py
+++ b/tests/domains/suno/downloaded/test_archive_result.py
@@ -1,0 +1,112 @@
+"""Suno downloaded ZIP archive result contract tests."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.domains.suno.downloaded.archive import (
+    DownloadedArchiveResult,
+    extract_downloaded_archive,
+    extract_downloaded_archive_detailed,
+)
+from youtube_automation.domains.suno.downloaded.models import (
+    DownloadedArtifactError,
+    PromptEntriesReader,
+)
+
+
+def _prepare_collection(collection_dir: Path, entries: list[dict[str, str]]) -> PromptEntriesReader:
+    documentation_dir = collection_dir / "20-documentation"
+    documentation_dir.mkdir()
+    (documentation_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    return lambda _collection_dir: entries
+
+
+def _write_archive(path: Path, files: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return path
+
+
+def test_detailed_extraction_reports_archive_audio_and_placed_counts(tmp_path: Path) -> None:
+    """Given matched/unmatched 音声を含む ZIP
+    When detailed API で展開する
+    Then archive 内音声総数と実配置数を別々に返す。
+    """
+    read_entries = _prepare_collection(tmp_path, [{"name": "既知 — Known"}])
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {"Known.mp3": b"matched", "Unknown.mp3": b"unmatched"},
+    )
+
+    result = extract_downloaded_archive_detailed(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=read_entries,
+    )
+
+    assert result == DownloadedArchiveResult(audio_count=2, placed_count=1)
+    assert [path.name for path in (tmp_path / "02-Individual-music").iterdir()] == ["01a-Known.mp3"]
+
+
+def test_legacy_extraction_returns_placed_count(tmp_path: Path) -> None:
+    """Given matched/unmatched 音声を含む ZIP
+    When 現行 API で展開する
+    Then 従来どおり実配置数だけを返す。
+    """
+    read_entries = _prepare_collection(tmp_path, [{"name": "既知 — Known"}])
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {"Known.mp3": b"matched", "Unknown.mp3": b"unmatched"},
+    )
+
+    placed_count = extract_downloaded_archive(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=read_entries,
+    )
+
+    assert placed_count == 1
+
+
+def test_detailed_extraction_keeps_zip_slip_validation(tmp_path: Path) -> None:
+    """Given safe/unsafe 音声 entry を含む ZIP
+    When detailed API で展開する
+    Then unsafe entry を配置せず archive 内音声総数には含める。
+    """
+    read_entries = _prepare_collection(tmp_path, [{"name": "既知 — Known"}])
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {"Known.mp3": b"safe", "../Known_1.mp3": b"unsafe"},
+    )
+
+    result = extract_downloaded_archive_detailed(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=read_entries,
+    )
+
+    assert result == DownloadedArchiveResult(audio_count=2, placed_count=1)
+    assert not (tmp_path.parent / "Known_1.mp3").exists()
+
+
+def test_detailed_extraction_fails_when_no_audio_is_placed(tmp_path: Path) -> None:
+    """Given prompts に一致しない音声だけの ZIP
+    When detailed API で展開する
+    Then 配置0件を fail-loud にする。
+    """
+    read_entries = _prepare_collection(tmp_path, [{"name": "既知 — Known"}])
+    archive = _write_archive(tmp_path / "download.zip", {"Unknown.mp3": b"unmatched"})
+
+    with pytest.raises(DownloadedArtifactError, match="0 audio files placed"):
+        extract_downloaded_archive_detailed(
+            tmp_path,
+            str(archive),
+            prompt_entries_reader=read_entries,
+        )
+
+    assert not (tmp_path / "02-Individual-music").exists()


### PR DESCRIPTION
## Summary

- ZIP 内の音声総数と実際の配置数を immutable な詳細結果として分離
- 既存の配置数 API、ZIP safety、配置0件 fail-loud を維持

## Verification

- uv run pytest -q tests/domains/suno/downloaded/test_archive_result.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3127
Depends on #3002