### PR TITLE
feat(downloaded): workflow state に missing_reasons を保存する (#3128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(downloaded)`: Suno の欠損数を生成不足と配置 skip の内訳として workflow state に保存し、完全完了時は過去の内訳を消去（#3128）。
+
 - `refactor(downloaded)`: Suno ZIP の archive 内音声総数と実配置数を単一走査の詳細結果として返し、現行の配置数 API 契約を維持（#3127）。
 
 - `fix(suno-helper)`: 通常・再試行の download 失敗理由へ `(phase=downloading)` を一度だけ付与し、overlay と unattended stop reason で失敗工程を特定可能にした（#3126）。

--- a/src/youtube_automation/domains/suno/downloaded/workflow.py
+++ b/src/youtube_automation/domains/suno/downloaded/workflow.py
@@ -14,6 +14,7 @@ from youtube_automation.domains.suno.downloaded.models import (
 )
 
 _SUNO_CLIPS_PER_PROMPT = 2
+_MISSING_REASON_KEYS = frozenset({"suno_unfulfilled", "apply_skipped"})
 
 
 class AtomicJsonWriter(Protocol):
@@ -56,15 +57,30 @@ def _read_existing_workflow_state(ws_path: Path) -> dict:
     return data
 
 
+def _validate_missing_reasons(missing_reasons: dict[str, object] | None) -> dict[str, int] | None:
+    if missing_reasons is None:
+        return None
+    if set(missing_reasons) != _MISSING_REASON_KEYS:
+        raise ValueError("missing_reasons must contain suno_unfulfilled and apply_skipped")
+    if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in missing_reasons.values()):
+        raise ValueError("missing_reasons values must be non-negative integers")
+    return {
+        "suno_unfulfilled": missing_reasons["suno_unfulfilled"],
+        "apply_skipped": missing_reasons["apply_skipped"],
+    }
+
+
 def update_workflow_state_downloaded(
     coll_dir: Path,
     *,
     file_count: int,
     suno_playlist_url: str | None = None,
     expected_file_count: int | None = None,
+    missing_reasons: dict[str, object] | None = None,
     prompt_entries_reader: PromptEntriesReader,
     atomic_json_write: AtomicJsonWriter,
 ) -> None:
+    validated_missing_reasons = _validate_missing_reasons(missing_reasons)
     ws_path = CollectionPaths(coll_dir).workflow_state_path
     data = _read_existing_workflow_state(ws_path)
 
@@ -92,7 +108,13 @@ def update_workflow_state_downloaded(
         # 不足は actual/missing_file_count で機械可読に残し、後続工程が観測する
         music["actual_file_count"] = file_count
         if effective_expected_count is not None:
-            music["missing_file_count"] = max(0, effective_expected_count - file_count)
+            missing_file_count = max(0, effective_expected_count - file_count)
+            music["missing_file_count"] = missing_file_count
+        download_complete = effective_expected_count is not None and file_count >= effective_expected_count
+        if download_complete:
+            music.pop("missing_reasons", None)
+        elif validated_missing_reasons is not None:
+            music["missing_reasons"] = validated_missing_reasons
         assets["music_downloaded"] = True
 
     ws_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/domains/suno/downloaded/test_workflow_missing_reasons.py
+++ b/tests/domains/suno/downloaded/test_workflow_missing_reasons.py
@@ -1,0 +1,122 @@
+"""Suno downloaded workflow missing-reason contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.domains.suno.downloaded.workflow import update_workflow_state_downloaded
+
+
+def _write_json(target: Path, data: dict, *, prefix: str) -> None:
+    target.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _read_music(collection_dir: Path) -> dict:
+    state = json.loads((collection_dir / "workflow-state.json").read_text(encoding="utf-8"))
+    return state["planning"]["music"]
+
+
+def test_should_store_missing_reasons_as_non_negative_integers(tmp_path: Path) -> None:
+    update_workflow_state_downloaded(
+        tmp_path,
+        file_count=2,
+        missing_reasons={"suno_unfulfilled": 1, "apply_skipped": 1},
+        prompt_entries_reader=lambda _collection_dir: [],
+        atomic_json_write=_write_json,
+    )
+
+    assert _read_music(tmp_path)["missing_reasons"] == {
+        "suno_unfulfilled": 1,
+        "apply_skipped": 1,
+    }
+
+
+@pytest.mark.parametrize("key", ["suno_unfulfilled", "apply_skipped"])
+@pytest.mark.parametrize("invalid_value", [-1, True, 1.5, "1"])
+def test_should_reject_invalid_missing_reason_counts(tmp_path: Path, key: str, invalid_value: object) -> None:
+    missing_reasons: dict[str, object] = {
+        "suno_unfulfilled": 1,
+        "apply_skipped": 1,
+    }
+    missing_reasons[key] = invalid_value
+
+    with pytest.raises(ValueError, match="missing_reasons values must be non-negative integers"):
+        update_workflow_state_downloaded(
+            tmp_path,
+            file_count=2,
+            expected_file_count=4,
+            missing_reasons=missing_reasons,
+            prompt_entries_reader=lambda _collection_dir: [],
+            atomic_json_write=_write_json,
+        )
+
+    assert not (tmp_path / "workflow-state.json").exists()
+
+
+@pytest.mark.parametrize(
+    "missing_reasons",
+    [
+        {"suno_unfulfilled": 1},
+        {"suno_unfulfilled": 1, "apply_skipped": 0, "other": 0},
+    ],
+)
+def test_should_reject_invalid_missing_reason_shape(tmp_path: Path, missing_reasons: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="missing_reasons must contain suno_unfulfilled and apply_skipped"):
+        update_workflow_state_downloaded(
+            tmp_path,
+            file_count=2,
+            expected_file_count=4,
+            missing_reasons=missing_reasons,
+            prompt_entries_reader=lambda _collection_dir: [],
+            atomic_json_write=_write_json,
+        )
+
+    assert not (tmp_path / "workflow-state.json").exists()
+
+
+def test_should_remove_previous_missing_reasons_when_download_is_complete(tmp_path: Path) -> None:
+    (tmp_path / "workflow-state.json").write_text(
+        json.dumps(
+            {
+                "planning": {
+                    "music": {
+                        "missing_reasons": {
+                            "suno_unfulfilled": 2,
+                            "apply_skipped": 0,
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    update_workflow_state_downloaded(
+        tmp_path,
+        file_count=4,
+        expected_file_count=4,
+        prompt_entries_reader=lambda _collection_dir: [],
+        atomic_json_write=_write_json,
+    )
+
+    music = _read_music(tmp_path)
+    assert music["missing_file_count"] == 0
+    assert "missing_reasons" not in music
+
+
+def test_should_preserve_existing_caller_path_without_missing_reasons(tmp_path: Path) -> None:
+    update_workflow_state_downloaded(
+        tmp_path,
+        file_count=2,
+        expected_file_count=4,
+        prompt_entries_reader=lambda _collection_dir: [],
+        atomic_json_write=_write_json,
+    )
+
+    music = _read_music(tmp_path)
+    assert music["actual_file_count"] == 2
+    assert music["missing_file_count"] == 2
+    assert "missing_reasons" not in music


### PR DESCRIPTION
## Summary

- missing_reasons の2キーと非負整数を検証して workflow state に保存
- 完全完了時は旧内訳を削除
- 引数未指定の既存 caller 契約を維持

## Verification

- uv run pytest -q tests/domains/suno/downloaded/test_workflow_missing_reasons.py
- uv run pytest -q tests/domains/suno/downloaded tests/commands/test_collection_serve.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3128