### PR TITLE
feat(suno-helper): duration_sec を wire entry に保持する (#3153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(suno-helper)`: prompt entry の optional な `duration_sec` を wire 型で受理し、明示された数値を失わず保持するようにした（#3153）。
 - `docs(suno)`: optional な `duration_sec` の単位・値域・明示時のみ全 entry へ出力する契約と、生成後の採用範囲を担う `duration_filter` との責務分離を配布設定と Suno 手順へ記載した（#3133）。
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -28,6 +28,8 @@ export interface PromptEntry {
   weirdness?: number;
   /** Exclude styles free text。Suno の Exclude styles 欄へ注入。 */
   exclude_styles?: string;
+  /** Custom Duration の秒数。channel override に明示された entry だけが持つ。 */
+  duration_sec?: number;
   /**
    * Voice section の Male / Female ボタン (Suno UI)。"male" / "female" のみ対応ボタンを click する。
    * "neutral" / "auto" / undefined は何もしない（既選択を解除しない、"Auto = Suno に任せる"解釈）。

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -147,6 +147,33 @@ describe("shared/api PromptEntry.title: optional 契約 (#844, 後方互換)", (
   });
 });
 
+describe("shared/api PromptEntry.duration_sec: optional wire 契約 (#3153)", () => {
+  it("Given duration_sec 付き entry When fetch する Then 数値を保持して返す", async () => {
+    const entries: PromptEntry[] = [
+      {
+        name: "p1",
+        style: "lofi",
+        lyrics: "",
+        duration_sec: 180,
+      },
+    ];
+    mockFetch(() => ({ ok: true, status: 200, json: async () => entries }));
+
+    const result = await fetchCollectionPrompts(BASE_URL, COLLECTION_ID);
+
+    expect(result[0].duration_sec).toBe(180);
+  });
+
+  it("Given duration_sec 無し entry When fetch する Then undefined のまま返す", async () => {
+    const entries: PromptEntry[] = [{ name: "p1", style: "lofi", lyrics: "" }];
+    mockFetch(() => ({ ok: true, status: 200, json: async () => entries }));
+
+    const result = await fetchCollectionPrompts(BASE_URL, COLLECTION_ID);
+
+    expect(result[0].duration_sec).toBeUndefined();
+  });
+});
+
 describe("shared/api PromptEntry: More Options 3 フィールドの optional 契約 (#900)", () => {
   // 契約 (draft が実装する shared/api.ts PromptEntry):
   //   style_influence?: number;  // 0-100 整数 (Suno Style Influence slider)


### PR DESCRIPTION
## Summary

- PromptEntry に optional duration_sec を追加
- 明示値を wire entry に保持
- 未指定互換を維持し、この段では runtime validation を追加しない

## Verification

- pnpm --dir extensions/suno-helper vitest run tests/api.test.ts
- pnpm --dir extensions/suno-helper vitest run
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run build
- pnpm --dir extensions/suno-helper run audit

Closes #3153
Depends on #3133