### PR TITLE
fix(suno-verify): patterns の Style へ文字数上限を適用する (#3152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 適応型ペーシング後の Create 直前に Turnstile を再確認し、表示中の新規投入を止めて解消後に同じ entry から重複なく再開する（#2536）。
 
 - `fix(config)`: channel skill-config の未知のトップレベルキーを警告し、`thumbnail.yaml` の誤った `auto_select` 階層などが silent に無視される状態を防止（#2520）。
+- `fix(suno-verify)`: `suno-patterns.yaml` の root `genre_line` と使用中 `style_variants` に channel の設定済み Style 文字数上限を適用し、未使用 variant は検査対象から除外（#3152）。
+
 - `feat(suno)`: collection の `suno-patterns.yaml` にある `vocal_gender` を全 JSON entry で channel 設定より優先し、空文字による省略と型契約検証に対応（#3137）。
 
 - `feat(suno)`: collection の `suno-patterns.yaml` にある `exclude_styles` を Markdown と全 JSON entry で channel 設定より優先し、空文字を明示値として扱う（#3136）。

--- a/src/youtube_automation/domains/suno/downloaded/validation.py
+++ b/src/youtube_automation/domains/suno/downloaded/validation.py
@@ -270,6 +270,7 @@ def load_pattern_contract(
     issues.extend(mode_issues)
     issues.extend(pattern_issues)
     issues.extend(tracks_issues)
+    issues.extend(_effective_style_char_limit_issues(raw, suno_cfg, style_keys))
     if mode is None:
         return None, issues
     contract = PatternContract(
@@ -549,12 +550,10 @@ def verify_suno_collection(
     prompts_path = docs_dir / SUNO_PROMPTS_JSON_FILENAME
     lyrics_path = docs_dir / SUNO_LYRICS_JSON_FILENAME
 
-    issues = _preflight_issues(suno_cfg)
     contract, pattern_issues = load_pattern_contract(patterns_path, suno_cfg, infer_mode)
-    issues = [*issues, *pattern_issues]
+    issues = pattern_issues
     if contract is None:
         return issues, "mode=unknown prompt_entries=0"
-    issues = [*issues, *_style_variant_genre_line_issues(suno_cfg, contract)]
 
     expected_name_issue = unique_entry_names_issue(
         source_name=SUNO_PATTERNS_FILENAME,
@@ -572,33 +571,49 @@ def verify_suno_collection(
     return issues, _instrumental_summary(contract, prompts)
 
 
-def _preflight_issues(suno_cfg: SunoConfig) -> list[str]:
-    genre_line_issue = check_suno_genre_line_char_limit({**suno_cfg.raw, "genre_line": suno_cfg.genre_line})
-    return [] if genre_line_issue is None else [genre_line_issue]
+def _effective_style_char_limit_issues(
+    raw: Mapping[str, object], suno_cfg: SunoConfig, style_keys: frozenset[str]
+) -> list[str]:
+    if isinstance(raw.get("genre_line"), str):
+        genre_line = cast(str, raw["genre_line"])
+        genre_line_source = f"{SUNO_PATTERNS_FILENAME}::genre_line"
+    else:
+        genre_line = suno_cfg.genre_line
+        genre_line_source = "config/skills/suno.yaml::genre_line"
 
+    issues = _style_char_limit_issues(suno_cfg, genre_line, genre_line_source)
 
-def _style_variant_genre_line_issues(suno_cfg: SunoConfig, contract: PatternContract) -> list[str]:
-    variants = suno_cfg.raw.get("style_variants")
+    if "style_variants" in raw:
+        variants = raw.get("style_variants")
+        variants_source = f"{SUNO_PATTERNS_FILENAME}::style_variants"
+    else:
+        variants = suno_cfg.raw.get("style_variants")
+        variants_source = "config/skills/suno.yaml::style_variants"
     if not isinstance(variants, Mapping):
-        return []
+        return issues
 
-    issues: list[str] = []
-    for style_key in sorted(contract.style_keys):
+    for style_key in sorted(style_keys):
         variant = variants.get(style_key)
         if not isinstance(variant, Mapping):
             continue
         genre_line = variant.get("genre_line")
         if not isinstance(genre_line, str):
             continue
-        issue = check_suno_genre_line_char_limit({**suno_cfg.raw, "genre_line": genre_line})
-        if issue is not None:
-            issues.append(
-                issue.replace(
-                    "config/skills/suno.yaml::genre_line",
-                    f"config/skills/suno.yaml::style_variants.{style_key}.genre_line",
-                )
+        issues.extend(
+            _style_char_limit_issues(
+                suno_cfg,
+                genre_line,
+                f"{variants_source}.{style_key}.genre_line",
             )
+        )
     return issues
+
+
+def _style_char_limit_issues(suno_cfg: SunoConfig, genre_line: str, source: str) -> list[str]:
+    issue = check_suno_genre_line_char_limit({**suno_cfg.raw, "genre_line": genre_line})
+    if issue is None:
+        return []
+    return [issue.replace("config/skills/suno.yaml::genre_line", source)]
 
 
 def _validate_prompts(prompts_path: Path, contract: PatternContract) -> tuple[ArtifactEntries, list[str]]:

--- a/tests/commands/suno/test_suno_verify.py
+++ b/tests/commands/suno/test_suno_verify.py
@@ -643,6 +643,90 @@ def test_video_analysis_genre_line_uses_configured_char_limit(channel_dir, tmp_p
     assert "OK" in output
 
 
+def _update_patterns_style_config(docs: Path, **updates: object) -> None:
+    patterns_path = docs / "suno-patterns.yaml"
+    payload = yaml.safe_load(patterns_path.read_text(encoding="utf-8"))
+    payload.update(updates)
+    patterns_path.write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
+
+
+def test_patterns_genre_line_char_limit_is_reported(channel_dir, tmp_path, monkeypatch, capsys):
+    """patterns root genre_line が上限超過なら effective Style 違反として報告する."""
+    write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    _update_patterns_style_config(docs, genre_line="x" * 121)
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "suno-patterns.yaml::genre_line" in output
+    assert "121 / 120" in output
+
+
+def test_patterns_genre_line_uses_configured_char_limit(channel_dir, tmp_path, monkeypatch, capsys):
+    """patterns root genre_line にも channel の configured limit を維持する."""
+    write_suno_override(channel_dir, genre_line="lo-fi jazz", style_char_limit=373)
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    _update_patterns_style_config(docs, genre_line="x" * 373)
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK" in output
+
+
+def test_used_patterns_style_variant_char_limit_is_reported(channel_dir, tmp_path, monkeypatch, capsys):
+    """使用中の patterns style variant は channel variant より優先して検査する."""
+    write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        style_variants={"long": {"name": "Channel", "genre_line": "short"}},
+    )
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2, style="long")
+    _update_patterns_style_config(
+        docs,
+        style_variants={"long": {"name": "Patterns", "genre_line": "x" * 121}},
+    )
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "suno-patterns.yaml::style_variants.long.genre_line" in output
+    assert "121 / 120" in output
+
+
+def test_unused_patterns_style_variant_char_limit_is_not_reported(channel_dir, tmp_path, monkeypatch, capsys):
+    """未使用の patterns style variant は文字数上限の対象にしない."""
+    write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    collection = tmp_path / "collection"
+    docs = docs_dir(collection)
+    write_patterns(docs, mode="instrumental", scenes=["scene one"], tracks=2)
+    _update_patterns_style_config(
+        docs,
+        style_variants={"unused": {"name": "Unused", "genre_line": "x" * 121}},
+    )
+    write_prompts(docs, prompt_names(mode="instrumental", scenes_count=1))
+
+    code = run_verify(monkeypatch, collection)
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "OK" in output
+    assert "style_variants.unused.genre_line" not in output
+
+
 def test_used_style_variant_genre_line_char_limit_is_reported(channel_dir, tmp_path, monkeypatch, capsys):
     """Given pattern が 121 文字 genre_line の style variant を使用する
     When yt-suno-verify を実行する


### PR DESCRIPTION
## Summary

- patterns root genre_line に configured style_char_limit を適用
- 実際に使用される collection style variant を検査
- 未使用 variant は誤検知しない

## Verification

- uv run pytest -q tests/commands/suno/test_suno_verify.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3152
Depends on #3137