### PR TITLE
fix(suno-helper): 不正な duration_sec を拒否する (#3154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
+- `fix(suno-helper)`: prompt response の optional な `duration_sec` を正の整数に限定し、bool・文字列・小数・非有限値・0 以下を拡張の取得境界で fail-loud に拒否するようにした（#3154）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -411,13 +411,36 @@ function durationFilterOrDefault(
   return durationFilter ?? { ...DEFAULT_DURATION_FILTER };
 }
 
+function validatePromptEntryDurations(entries: unknown[]): PromptEntry[] {
+  entries.forEach((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      return;
+    }
+    const durationSec = (entry as Record<string, unknown>).duration_sec;
+    if (durationSec === undefined) {
+      return;
+    }
+    if (
+      typeof durationSec !== "number" ||
+      !Number.isFinite(durationSec) ||
+      !Number.isInteger(durationSec) ||
+      durationSec <= 0
+    ) {
+      throw new Error(
+        `entries[${index}].duration_sec must be positive integer`
+      );
+    }
+  });
+  return entries as PromptEntry[];
+}
+
 function normalizePromptResponse(data: unknown): PromptResponse {
   if (Array.isArray(data)) {
     if (data.length === 0) {
       throw new Error("空、または配列ではない JSON が返りました。");
     }
     return {
-      entries: data as PromptEntry[],
+      entries: validatePromptEntryDurations(data),
       duration_filter: durationFilterOrDefault(),
     };
   }
@@ -432,7 +455,7 @@ function normalizePromptResponse(data: unknown): PromptResponse {
       ? undefined
       : assertDurationFilter(record.duration_filter, "duration_filter");
   return {
-    entries: entries as PromptEntry[],
+    entries: validatePromptEntryDurations(entries),
     duration_filter: durationFilterOrDefault(durationFilter),
   };
 }

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -174,6 +174,35 @@ describe("shared/api PromptEntry.duration_sec: optional wire 契約 (#3153)", ()
   });
 });
 
+describe("shared/api PromptEntry.duration_sec: runtime 検証 (#3154)", () => {
+  it.each([
+    ["true", true],
+    ["false", false],
+    ["文字列", "180"],
+    ["小数", 180.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["zero", 0],
+    ["negative", -1],
+  ])(
+    "Given duration_sec が不正値 %s When fetch する Then fail-loud で拒否する",
+    async (_label, durationSec) => {
+      mockFetch(() => ({
+        ok: true,
+        status: 200,
+        json: async () => [
+          { name: "p1", style: "lofi", lyrics: "", duration_sec: durationSec },
+        ],
+      }));
+
+      await expect(
+        fetchCollectionPrompts(BASE_URL, COLLECTION_ID)
+      ).rejects.toThrow(/duration_sec/);
+    }
+  );
+});
+
 describe("shared/api PromptEntry: More Options 3 フィールドの optional 契約 (#900)", () => {
   // 契約 (draft が実装する shared/api.ts PromptEntry):
   //   style_influence?: number;  // 0-100 整数 (Suno Style Influence slider)


### PR DESCRIPTION
## Summary

- duration_sec の runtime 境界検証を追加
- undefined と正の整数を受理
- bool、文字列、小数、NaN、Infinity、0以下を fail-loud
- legacy array と envelope の両形式へ適用

## Verification

- pnpm --dir extensions/suno-helper vitest run tests/api.test.ts
- pnpm --dir extensions/suno-helper vitest run
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run build
- pnpm --dir extensions/suno-helper run audit

Closes #3154
Depends on #3153