### PR TITLE
feat(downloaded): apply 結果から欠損理由を算出する (#3129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(downloaded)`: Suno apply の詳細結果で期待数・archive 内音声数・配置数と生成不足・配置 skip を返し、同じ欠損内訳を workflow state に保存（#3129）。
+
 - `feat(downloaded)`: Suno の欠損数を生成不足と配置 skip の内訳として workflow state に保存し、完全完了時は過去の内訳を消去（#3128）。
 
 - `refactor(downloaded)`: Suno ZIP の archive 内音声総数と実配置数を単一走査の詳細結果として返し、現行の配置数 API 契約を維持（#3127）。

--- a/src/youtube_automation/domains/suno/downloaded/apply.py
+++ b/src/youtube_automation/domains/suno/downloaded/apply.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.domains.suno.downloaded.archive import extract_downloaded_archive
+from youtube_automation.domains.suno.downloaded.archive import extract_downloaded_archive_detailed
 from youtube_automation.domains.suno.downloaded.models import (
     DownloadedArtifactError,
     DownloadedPayload,
@@ -22,6 +24,32 @@ from youtube_automation.domains.suno.downloaded.workflow import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadedApplyResult:
+    expected_count: int
+    audio_count: int
+    placed_count: int
+    suno_unfulfilled: int
+    apply_skipped: int
+
+    @classmethod
+    def from_counts(cls, *, expected_count: int, audio_count: int, placed_count: int) -> DownloadedApplyResult:
+        return cls(
+            expected_count=expected_count,
+            audio_count=audio_count,
+            placed_count=placed_count,
+            suno_unfulfilled=max(expected_count - audio_count, 0),
+            apply_skipped=max(audio_count - placed_count, 0),
+        )
+
+    @property
+    def missing_reasons(self) -> dict[str, int]:
+        return {
+            "suno_unfulfilled": self.suno_unfulfilled,
+            "apply_skipped": self.apply_skipped,
+        }
 
 
 def _restore_downloaded_transaction(
@@ -46,17 +74,17 @@ def _restore_downloaded_transaction(
         workflow_state_path.unlink(missing_ok=True)
 
 
-def apply_downloaded_artifacts(
+def apply_downloaded_artifacts_detailed(
     coll_dir: Path,
     payload: DownloadedPayload,
     *,
     prompt_entries_reader: PromptEntriesReader,
     atomic_json_write: AtomicJsonWriter,
-) -> int:
+) -> DownloadedApplyResult:
     pattern_count = read_pattern_count(coll_dir, prompt_entries_reader=prompt_entries_reader, default=0)
-    expected_count = expected_download_count(pattern_count, payload.expected_file_count)
-    placed_count_for_response = payload.file_count
-    file_count = payload.file_count
+    expected_count = cast(int, expected_download_count(pattern_count, payload.expected_file_count))
+    audio_count = payload.file_count
+    placed_count = payload.file_count
     paths = CollectionPaths(coll_dir)
     music_dir = paths.music_dir
     workflow_state_path = paths.workflow_state_path
@@ -71,17 +99,24 @@ def apply_downloaded_artifacts(
                 music_backup_dir = Path(tempfile.mkdtemp(dir=str(coll_dir), prefix=".suno-music-apply-backup-"))
                 shutil.copytree(music_dir, music_backup_dir / "02-Individual-music")
             restore_music_on_error = True
-            placed_count = extract_downloaded_archive(
+            archive_result = extract_downloaded_archive_detailed(
                 coll_dir, payload.download_path, prompt_entries_reader=prompt_entries_reader
             )
-            placed_count_for_response = placed_count
-            file_count = placed_count
+            audio_count = archive_result.audio_count
+            placed_count = archive_result.placed_count
+
+        result = DownloadedApplyResult.from_counts(
+            expected_count=expected_count,
+            audio_count=audio_count,
+            placed_count=placed_count,
+        )
 
         update_workflow_state_downloaded(
             coll_dir,
-            file_count=file_count,
+            file_count=result.placed_count,
             suno_playlist_url=payload.suno_playlist_url,
-            expected_file_count=expected_count,
+            expected_file_count=result.expected_count,
+            missing_reasons=result.missing_reasons,
             prompt_entries_reader=prompt_entries_reader,
             atomic_json_write=atomic_json_write,
         )
@@ -113,4 +148,19 @@ def apply_downloaded_artifacts(
             Path(payload.download_path).unlink()
         except OSError as exc:
             logger.warning("Suno download ZIP cleanup failed for %s: %s", payload.download_path, exc)
-    return placed_count_for_response
+    return result
+
+
+def apply_downloaded_artifacts(
+    coll_dir: Path,
+    payload: DownloadedPayload,
+    *,
+    prompt_entries_reader: PromptEntriesReader,
+    atomic_json_write: AtomicJsonWriter,
+) -> int:
+    return apply_downloaded_artifacts_detailed(
+        coll_dir,
+        payload,
+        prompt_entries_reader=prompt_entries_reader,
+        atomic_json_write=atomic_json_write,
+    ).placed_count

--- a/tests/domains/suno/downloaded/test_apply_missing_reasons.py
+++ b/tests/domains/suno/downloaded/test_apply_missing_reasons.py
@@ -1,0 +1,128 @@
+"""Suno downloaded apply missing-reason contract tests."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.domains.suno.downloaded.apply import (
+    DownloadedApplyResult,
+    apply_downloaded_artifacts,
+    apply_downloaded_artifacts_detailed,
+)
+from youtube_automation.domains.suno.downloaded.models import (
+    DownloadedArtifactError,
+    DownloadedPayload,
+    PromptEntriesReader,
+)
+
+
+def _prepare_collection(collection_dir: Path) -> PromptEntriesReader:
+    documentation_dir = collection_dir / "20-documentation"
+    documentation_dir.mkdir()
+    (documentation_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    return lambda _collection_dir: [{"name": "既知 — Known"}]
+
+
+def _write_archive(path: Path, files: dict[str, bytes]) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return path
+
+
+def _write_json(target: Path, data: dict, *, prefix: str) -> None:
+    target.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _payload(archive: Path, *, expected_count: int) -> DownloadedPayload:
+    return DownloadedPayload(
+        file_count=0,
+        format="mp3",
+        expected_file_count=expected_count,
+        download_path=str(archive),
+    )
+
+
+def test_detailed_apply_calculates_and_persists_missing_reasons(tmp_path: Path) -> None:
+    read_entries = _prepare_collection(tmp_path)
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {
+            "Known.mp3": b"matched-a",
+            "Known_1.mp3": b"matched-b",
+            "Unknown.mp3": b"unmatched",
+        },
+    )
+
+    result = apply_downloaded_artifacts_detailed(
+        tmp_path,
+        _payload(archive, expected_count=4),
+        prompt_entries_reader=read_entries,
+        atomic_json_write=_write_json,
+    )
+
+    assert result == DownloadedApplyResult(
+        expected_count=4,
+        audio_count=3,
+        placed_count=2,
+        suno_unfulfilled=1,
+        apply_skipped=1,
+    )
+    state = json.loads((tmp_path / "workflow-state.json").read_text(encoding="utf-8"))
+    assert state["planning"]["music"]["missing_reasons"] == result.missing_reasons
+
+
+def test_detailed_apply_clamps_unfulfilled_when_archive_exceeds_expected(tmp_path: Path) -> None:
+    read_entries = _prepare_collection(tmp_path)
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {"Known.mp3": b"matched-a", "Known_1.mp3": b"matched-b"},
+    )
+
+    result = apply_downloaded_artifacts_detailed(
+        tmp_path,
+        _payload(archive, expected_count=1),
+        prompt_entries_reader=read_entries,
+        atomic_json_write=_write_json,
+    )
+
+    assert result.suno_unfulfilled == 0
+    assert result.apply_skipped == 0
+
+
+def test_legacy_apply_still_returns_placed_count(tmp_path: Path) -> None:
+    read_entries = _prepare_collection(tmp_path)
+    archive = _write_archive(
+        tmp_path / "download.zip",
+        {"Known.mp3": b"matched", "Unknown.mp3": b"unmatched"},
+    )
+
+    placed_count = apply_downloaded_artifacts(
+        tmp_path,
+        _payload(archive, expected_count=2),
+        prompt_entries_reader=read_entries,
+        atomic_json_write=_write_json,
+    )
+
+    assert placed_count == 1
+
+
+def test_detailed_apply_keeps_zero_placed_fail_loud(tmp_path: Path) -> None:
+    read_entries = _prepare_collection(tmp_path)
+    archive = _write_archive(tmp_path / "download.zip", {"Unknown.mp3": b"unmatched"})
+
+    with pytest.raises(DownloadedArtifactError, match="0 audio files placed"):
+        apply_downloaded_artifacts_detailed(
+            tmp_path,
+            _payload(archive, expected_count=2),
+            prompt_entries_reader=read_entries,
+            atomic_json_write=_write_json,
+        )
+
+    assert archive.exists()
+    assert not (tmp_path / "02-Individual-music").exists()
+    assert not (tmp_path / "workflow-state.json").exists()


### PR DESCRIPTION
## Summary

- archive detail と apply 結果から欠損理由を算出
- 算出結果を workflow state へ連携
- 既存の配置/照合契約を維持

## Verification

- uv run pytest -q tests/domains/suno/downloaded/test_apply_missing_reasons.py
- uv run pytest -q tests/domains/suno/downloaded tests/commands/test_collection_serve.py
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3129
Depends on #3127
Depends on #3128