### PR TITLE
feat(suno-helper): duration_sec を Duration controls へ注入する (#3160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `feat(suno-helper)`: prompt entry の `duration_sec` が明示された場合、解決済みの Custom Duration button を押してから既存の bridge-first / keydown fallback 経路で Duration slider へ秒数を注入するようにした（#3160）。
 - `feat(suno-helper)`: prompt entry の optional な `duration_sec` を wire 型で受理し、明示された数値を失わず保持するようにした（#3153）。
 - `docs(suno)`: optional な `duration_sec` の単位・値域・明示時のみ全 entry へ出力する契約と、生成後の採用範囲を担う `duration_filter` との責務分離を配布設定と Suno 手順へ記載した（#3133）。
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -524,6 +524,10 @@ export interface ResolvedAdvancedFields {
     male: HTMLButtonElement | null;
     female: HTMLButtonElement | null;
   };
+  duration: {
+    customButton: HTMLButtonElement;
+    slider: HTMLElement;
+  } | null;
 }
 
 /** injectAdvancedFields が読む entry の advanced 値（PromptEntry の部分集合）。 */
@@ -532,6 +536,7 @@ export interface AdvancedFieldValues {
   weirdness?: number;
   exclude_styles?: string;
   vocal_gender?: "male" | "female" | "neutral" | "auto";
+  duration_sec?: number;
 }
 
 /**
@@ -570,6 +575,7 @@ export function resolveAdvancedFields(): ResolvedAdvancedFields {
     weirdness,
     styleInfluence,
     vocalGender: resolveVocalGenderButtons(),
+    duration: null,
   };
 }
 
@@ -675,6 +681,14 @@ export async function injectAdvancedFields(
     if (target.getAttribute("data-selected") !== "true") {
       target.click();
     }
+  }
+  if (entry.duration_sec !== undefined && fields.duration) {
+    fields.duration.customButton.click();
+    await injectSliderValue(
+      fields.duration.slider,
+      entry.duration_sec,
+      options.bridgeSetSlider
+    );
   }
   if (entry.weirdness !== undefined) {
     // slider 未検出は throw せず warn + skip（#1720）。値は UI で手動設定でき Create を跨いで

--- a/extensions/suno-helper/tests/inject-advanced.test.ts
+++ b/extensions/suno-helper/tests/inject-advanced.test.ts
@@ -10,9 +10,9 @@
 //
 // 契約 (shared/dom.ts):
 //   injectAdvancedFields(entry, fields): Promise<void>
-//     entry:  AdvancedFieldValues { style_influence?, weirdness?, exclude_styles?, vocal_gender? }
-//     fields: ResolvedAdvancedFields { excludeStyles, weirdness, styleInfluence, vocalGender: { male, female } }
-//   注入順序: Exclude styles (text, 高速) → vocal_gender (click 1 回) → Weirdness → Style Influence
+//     entry:  AdvancedFieldValues { style_influence?, weirdness?, exclude_styles?, vocal_gender?, duration_sec? }
+//     fields: ResolvedAdvancedFields { excludeStyles, weirdness, styleInfluence, vocalGender, duration }
+//   注入順序: Exclude styles → vocal_gender → Duration Custom/slider → Weirdness → Style Influence
 //   各フィールドの非対称契約:
 //     - entry に値有 (=== undefined でない) + 対応 selector が null:
 //         - exclude_styles / vocal_gender → throw (fail-loud、UI 改装検知)
@@ -94,6 +94,7 @@ const ALL_NULL: ResolvedAdvancedFields = {
   weirdness: null,
   styleInfluence: null,
   vocalGender: { male: null, female: null },
+  duration: null,
 };
 
 beforeEach(() => {
@@ -326,6 +327,79 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
         expect.any(Error)
       );
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("duration_sec 注入 (#3160)", () => {
+    it("Given duration_sec=180 + 解決済み controls When 注入 Then Custom click 後に bridge で slider を180へ動かす", async () => {
+      const order: string[] = [];
+      const customButton = document.createElement("button");
+      customButton.addEventListener("click", () => order.push("custom"));
+      const slider = makeSlider(120, { respond: false });
+      const resolvedAriaLabel = "resolved-duration-slider";
+      slider.setAttribute("aria-label", resolvedAriaLabel);
+      const bridgeSetSlider = vi.fn(
+        async (_ariaLabel: string, target: number) => {
+          order.push("slider");
+          slider.setAttribute("aria-valuenow", String(target));
+          return true;
+        }
+      );
+      const customClick = vi.spyOn(customButton, "click");
+
+      await injectAdvancedFields(
+        { duration_sec: 180 },
+        { ...ALL_NULL, duration: { customButton, slider } },
+        { bridgeSetSlider }
+      );
+
+      expect(order).toEqual(["custom", "slider"]);
+      expect(customClick).toHaveBeenCalledTimes(1);
+      expect(bridgeSetSlider).toHaveBeenCalledWith(resolvedAriaLabel, 180);
+      expect(slider.getAttribute("aria-valuenow")).toBe("180");
+    });
+
+    it("Given duration_sec=180 + bridge false When 注入 Then Custom click 後に keydown fallback で180へ動かす", async () => {
+      const order: string[] = [];
+      const customButton = document.createElement("button");
+      customButton.addEventListener("click", () => order.push("custom"));
+      const slider = makeSlider(179);
+      slider.setAttribute("aria-label", "resolved-duration-slider");
+      slider.addEventListener("keydown", () => order.push("keydown"));
+      const bridgeSetSlider = vi.fn(async () => {
+        order.push("bridge");
+        return false;
+      });
+
+      await injectAdvancedFields(
+        { duration_sec: 180 },
+        { ...ALL_NULL, duration: { customButton, slider } },
+        { bridgeSetSlider }
+      );
+
+      expect(order).toEqual(["custom", "bridge", "keydown"]);
+      expect(slider.getAttribute("aria-valuenow")).toBe("180");
+    });
+
+    it("Given duration_sec 未指定 + 解決済み controls When 注入 Then controls に触れず slider 値を維持する", async () => {
+      const customButton = document.createElement("button");
+      const customClick = vi.spyOn(customButton, "click");
+      const slider = makeSlider(120);
+      slider.setAttribute("aria-label", "resolved-duration-slider");
+      const keydown = vi.fn();
+      slider.addEventListener("keydown", keydown);
+      const bridgeSetSlider = vi.fn().mockResolvedValue(true);
+
+      await injectAdvancedFields(
+        {},
+        { ...ALL_NULL, duration: { customButton, slider } },
+        { bridgeSetSlider }
+      );
+
+      expect(customClick).not.toHaveBeenCalled();
+      expect(bridgeSetSlider).not.toHaveBeenCalled();
+      expect(keydown).not.toHaveBeenCalled();
+      expect(slider.getAttribute("aria-valuenow")).toBe("120");
     });
   });
 


### PR DESCRIPTION
## Summary

- 解決済み Duration controls に duration_sec を注入
- Custom click → bridge-first → keydown fallback の順序を固定
- 未指定時は controls と slider を変更しない
- selector/range は推測せず #3161 に分離

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/inject-advanced.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run build
- pnpm --dir extensions/suno-helper run audit

Closes #3160
Depends on #3154