### PR TITLE
feat(collection-serve): downloaded 応答に欠損理由を返す (#3130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(collection-serve)`: Suno downloaded の部分成功応答へ生成不足・配置 skip の内訳を追加し、warning と workflow state の欠損理由を一致（#3130）。
+
 - `feat(downloaded)`: Suno apply の詳細結果で期待数・archive 内音声数・配置数と生成不足・配置 skip を返し、同じ欠損内訳を workflow state に保存（#3129）。
 
 - `feat(downloaded)`: Suno の欠損数を生成不足と配置 skip の内訳として workflow state に保存し、完全完了時は過去の内訳を消去（#3128）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -68,12 +68,12 @@ from youtube_automation.domains.distrokid.specification import find_disc_entry, 
 from youtube_automation.domains.suno.downloaded import (
     DownloadedArtifactError,
     DownloadedPayloadError,
-    apply_downloaded_artifacts,
     count_audio_files,
     expected_download_count,
     parse_downloaded_payload,
     read_pattern_count,
 )
+from youtube_automation.domains.suno.downloaded.apply import apply_downloaded_artifacts_detailed
 from youtube_automation.domains.suno.downloaded.models import (
     COLLECTIONS_ROUTE,
     DOCUMENTATION_DIRNAME,
@@ -1166,7 +1166,7 @@ def create_server(
 
             coll_dir = collections_root / cid
             try:
-                placed_count_for_response = apply_downloaded_artifacts(
+                apply_result = apply_downloaded_artifacts_detailed(
                     coll_dir,
                     downloaded,
                     prompt_entries_reader=read_suno_prompt_entries,
@@ -1178,24 +1178,16 @@ def create_server(
             except DownloadedArtifactError as exc:
                 self._send_json_error(500, str(exc))
                 return
-            resp: dict = {"ok": True, "collection_id": cid, "placed_count": placed_count_for_response}
+            resp: dict = {"ok": True, "collection_id": cid, "placed_count": apply_result.placed_count}
             # 部分完了（Suno が期待数未満しか生成しないケース）は 500 にせず warning で返す（#1913）
-            expected_count = expected_download_count(
-                read_pattern_count(
-                    coll_dir,
-                    prompt_entries_reader=read_suno_prompt_entries,
-                    default=0,
-                ),
-                downloaded.expected_file_count,
-            )
-            if (
-                downloaded.download_path
-                and expected_count is not None
-                and 0 < placed_count_for_response < expected_count
-            ):
-                missing = expected_count - placed_count_for_response
+            if downloaded.download_path and 0 < apply_result.placed_count < apply_result.expected_count:
+                missing = apply_result.expected_count - apply_result.placed_count
+                missing_reasons = apply_result.missing_reasons
+                resp["missing_reasons"] = missing_reasons
                 resp["warning"] = (
-                    f"placed {placed_count_for_response} files, expected {expected_count} ({missing} missing)"
+                    f"placed {apply_result.placed_count} files, expected {apply_result.expected_count} "
+                    f"({missing} missing; Suno 未生成 {missing_reasons['suno_unfulfilled']} / "
+                    f"配置 skip {missing_reasons['apply_skipped']})"
                 )
             resp_body = json.dumps(resp).encode("utf-8")
             self._send_bytes(resp_body, "application/json; charset=utf-8")

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -3958,9 +3958,9 @@ def test_post_downloaded_empty_zip_returns_500(serve_dir, tmp_path):
 
 
 def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
-    """Given prompts 2 件（期待 4 clips）に対して ZIP 内の音声が 2 件
+    """Given prompts 2 件（期待 4 clips）に対して ZIP 内の音声が 3 件、配置可能が 2 件
     When POST /collections/<id>/downloaded を送る
-    Then 200 で受理してファイルを配置し、warning と expected/actual/missing を記録する（#1913）。
+    Then 200 で受理して生成不足・配置 skip の内訳を応答と workflow state に記録する。
     """
     planning = tmp_path / "planning"
     _make_collection(
@@ -3971,7 +3971,10 @@ def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
             {"name": "曲B — Song B", "style": "s", "lyrics": ""},
         ],
     )
-    zip_path = _make_zip(tmp_path / "partial.zip", {"Song A.mp3": b"audio1", "Song A_1.mp3": b"audio2"})
+    zip_path = _make_zip(
+        tmp_path / "partial.zip",
+        {"Song A.mp3": b"audio1", "Song A_1.mp3": b"audio2", "Unknown.mp3": b"unmatched"},
+    )
     base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
     token = _fetch_token(base)
     payload = {
@@ -3991,7 +3994,8 @@ def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
 
     assert result["ok"] is True
     assert result["placed_count"] == 2
-    assert result["warning"] == "placed 2 files, expected 4 (2 missing)"
+    assert result["missing_reasons"] == {"suno_unfulfilled": 1, "apply_skipped": 1}
+    assert result["warning"] == "placed 2 files, expected 4 (2 missing; Suno 未生成 1 / 配置 skip 1)"
     music_dir = planning / "20260601-clm-aaa-collection" / "02-Individual-music"
     assert len(list(music_dir.glob("*.mp3"))) == 2
     ws_path = planning / "20260601-clm-aaa-collection" / "workflow-state.json"
@@ -4000,6 +4004,7 @@ def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
     assert music["expected_file_count"] == 4
     assert music["actual_file_count"] == 2
     assert music["missing_file_count"] == 2
+    assert music["missing_reasons"] == result["missing_reasons"]
     assert workflow_state["assets"]["music_downloaded"] is True
 
 
@@ -4092,10 +4097,12 @@ def test_post_downloaded_full_redownload_resets_missing_file_count(serve_dir, tm
 
     assert result["placed_count"] == 4
     assert "warning" not in result
+    assert "missing_reasons" not in result
     ws_path = planning / "20260601-clm-aaa-collection" / "workflow-state.json"
     music = json.loads(ws_path.read_text(encoding="utf-8"))["planning"]["music"]
     assert music["actual_file_count"] == 4
     assert music["missing_file_count"] == 0
+    assert "missing_reasons" not in music
 
 
 def test_post_downloaded_unmatched_zip_returns_500_and_does_not_set_music_downloaded(serve_dir, tmp_path):
@@ -4321,7 +4328,7 @@ def test_post_downloaded_partial_zip_cleans_up_download_archive(serve_dir, tmp_p
         assert resp.status == 200
         result = json.loads(resp.read().decode("utf-8"))
 
-    assert result["warning"] == "placed 1 files, expected 4 (3 missing)"
+    assert result["warning"] == "placed 1 files, expected 4 (3 missing; Suno 未生成 3 / 配置 skip 0)"
     assert not zip_path.exists()
 
 


### PR DESCRIPTION
## Summary

- partial downloaded 200 応答へ missing_reasons と内訳 warning を返す
- #3129 の detailed result を server/workflow state の共通算出源として使用
- 完全成功では内訳を省略し、配置0件/unmatched fail-loud を維持

## Verification

- uv run pytest -q tests/commands/collections/test_collection_serve.py
- uv run pytest -q tests/domains/suno/downloaded
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3130
Depends on #3129