### PR TITLE
feat(collection-serve): downloaded 応答へ配置 summary を返す (#3164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+
 - `feat(collection-serve)`: Suno downloaded の部分成功応答へ生成不足・配置 skip の内訳を追加し、warning と workflow state の欠損理由を一致（#3130）。
 
 - `feat(downloaded)`: Suno apply の詳細結果で期待数・archive 内音声数・配置数と生成不足・配置 skip を返し、同じ欠損内訳を workflow state に保存（#3129）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -1179,16 +1179,22 @@ def create_server(
                 self._send_json_error(500, str(exc))
                 return
             resp: dict = {"ok": True, "collection_id": cid, "placed_count": apply_result.placed_count}
-            # 部分完了（Suno が期待数未満しか生成しないケース）は 500 にせず warning で返す（#1913）
-            if downloaded.download_path and 0 < apply_result.placed_count < apply_result.expected_count:
-                missing = apply_result.expected_count - apply_result.placed_count
-                missing_reasons = apply_result.missing_reasons
-                resp["missing_reasons"] = missing_reasons
-                resp["warning"] = (
-                    f"placed {apply_result.placed_count} files, expected {apply_result.expected_count} "
-                    f"({missing} missing; Suno 未生成 {missing_reasons['suno_unfulfilled']} / "
-                    f"配置 skip {missing_reasons['apply_skipped']})"
+            # playlist URL だけを記録する先行 POST は legacy 応答を維持し、実 ZIP 適用後だけ summary を返す。
+            if downloaded.download_path:
+                missing_file_count = max(apply_result.expected_count - apply_result.placed_count, 0)
+                resp.update(
+                    expected_file_count=apply_result.expected_count,
+                    missing_file_count=missing_file_count,
                 )
+                # 部分完了（Suno が期待数未満しか生成しないケース）は 500 にせず warning で返す（#1913）
+                if 0 < apply_result.placed_count < apply_result.expected_count:
+                    missing_reasons = apply_result.missing_reasons
+                    resp["missing_reasons"] = missing_reasons
+                    resp["warning"] = (
+                        f"placed {apply_result.placed_count} files, expected {apply_result.expected_count} "
+                        f"({missing_file_count} missing; Suno 未生成 {missing_reasons['suno_unfulfilled']} / "
+                        f"配置 skip {missing_reasons['apply_skipped']})"
+                    )
             resp_body = json.dumps(resp).encode("utf-8")
             self._send_bytes(resp_body, "application/json; charset=utf-8")
 

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -2560,6 +2560,41 @@ def test_post_downloaded_zero_file_count_does_not_set_music_downloaded(serve_dir
     assert "assets" not in ws or "music_downloaded" not in ws.get("assets", {})
 
 
+def test_post_downloaded_metadata_only_omits_structured_placement_summary(serve_dir, tmp_path):
+    """Given playlist 記録用の metadata-only POST
+    When file_count=0、expected_file_count>0、download_path なしで通知する
+    Then 後続の実 download 前に部分配置 summary を返さない。
+    """
+    planning = tmp_path / "planning"
+    _make_collection(
+        planning,
+        "20260601-clm-aaa-collection",
+        entries=[{"name": "A", "style": "s", "lyrics": ""}],
+    )
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
+    token = _fetch_token(base)
+    payload = {
+        "file_count": 0,
+        "expected_file_count": 2,
+        "format": "mp3",
+        "suno_playlist_url": "https://suno.com/playlist/abc",
+    }
+
+    with _post(
+        f"{base}{_COLLECTIONS_ROUTE}/20260601-clm-aaa-collection/downloaded",
+        payload,
+        headers={"Origin": _EXTENSION_ORIGIN, "X-Serve-Token": token},
+    ) as resp:
+        assert resp.status == 200
+        result = json.loads(resp.read().decode("utf-8"))
+
+    assert result == {
+        "ok": True,
+        "collection_id": "20260601-clm-aaa-collection",
+        "placed_count": 0,
+    }
+
+
 def test_post_downloaded_zero_file_count_preserves_existing_music_downloaded(serve_dir, tmp_path):
     """Given 既に downloaded の workflow-state
     When playlist URL 記録用に file_count=0 で POST する
@@ -3993,7 +4028,9 @@ def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
         result = json.loads(resp.read().decode("utf-8"))
 
     assert result["ok"] is True
+    assert result["expected_file_count"] == 4
     assert result["placed_count"] == 2
+    assert result["missing_file_count"] == 2
     assert result["missing_reasons"] == {"suno_unfulfilled": 1, "apply_skipped": 1}
     assert result["warning"] == "placed 2 files, expected 4 (2 missing; Suno 未生成 1 / 配置 skip 1)"
     music_dir = planning / "20260601-clm-aaa-collection" / "02-Individual-music"
@@ -4001,9 +4038,9 @@ def test_post_downloaded_partial_zip_succeeds_with_warning(serve_dir, tmp_path):
     ws_path = planning / "20260601-clm-aaa-collection" / "workflow-state.json"
     workflow_state = json.loads(ws_path.read_text(encoding="utf-8"))
     music = workflow_state["planning"]["music"]
-    assert music["expected_file_count"] == 4
-    assert music["actual_file_count"] == 2
-    assert music["missing_file_count"] == 2
+    assert music["expected_file_count"] == result["expected_file_count"]
+    assert music["actual_file_count"] == result["placed_count"]
+    assert music["missing_file_count"] == result["missing_file_count"]
     assert music["missing_reasons"] == result["missing_reasons"]
     assert workflow_state["assets"]["music_downloaded"] is True
 
@@ -4095,7 +4132,9 @@ def test_post_downloaded_full_redownload_resets_missing_file_count(serve_dir, tm
     ) as resp:
         result = json.loads(resp.read().decode("utf-8"))
 
+    assert result["expected_file_count"] == 4
     assert result["placed_count"] == 4
+    assert result["missing_file_count"] == 0
     assert "warning" not in result
     assert "missing_reasons" not in result
     ws_path = planning / "20260601-clm-aaa-collection" / "workflow-state.json"


### PR DESCRIPTION
## Summary

- successful downloaded 応答へ expected/placed/missing count を構造化して返す
- partial reasons/warning と同じ apply result を SSOT に使用
- 4/2/2+1/1 と workflow state 一致、full 4/4/0、zero/origin契約を維持

## Verification

- uv run pytest -q tests/commands/collections/test_collection_serve.py
- uv run pytest -q tests/domains/suno/downloaded
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3164
Depends on #3126
Depends on #3130