### PR TITLE
feat(suno-helper): downloaded partial response を検証する (#3165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+- `feat(suno-helper)`: downloaded 成功応答の期待数・配置数・欠損数・欠損理由を型検証して保持し、不正な count や不整合な内訳を fail-loud で拒否（#3165）。
+
+- `feat(collection-serve)`: Suno downloaded 成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一（#3164）。
 
 - `feat(collection-serve)`: Suno downloaded の部分成功応答へ生成不足・配置 skip の内訳を追加し、warning と workflow state の欠損理由を一致（#3130）。
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -916,9 +916,81 @@ async function postJsonWithServeToken(
   return res;
 }
 
-/** POST /collections/:id/downloaded の応答 (#1913)。部分完了時のみ warning が入る。 */
+export interface DownloadMissingReasons {
+  sunoUnfulfilled: number;
+  applySkipped: number;
+}
+
+export interface DownloadSummary {
+  expected: number;
+  placed: number;
+  missing: number;
+  reasons: DownloadMissingReasons | null;
+}
+
+/** POST /collections/:id/downloaded の応答 (#1913/#3165)。 */
 export interface PostDownloadedResult {
+  summary?: DownloadSummary;
   warning: string | null;
+}
+
+function assertNonnegativeSafeInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be nonnegative safe integer`);
+  }
+  return value;
+}
+
+function parseDownloadedResult(data: unknown): PostDownloadedResult {
+  const record = assertObject(data, "downloaded response");
+  const warning = typeof record.warning === "string" ? record.warning : null;
+  const hasStructuredSummary =
+    "expected_file_count" in record ||
+    "missing_file_count" in record ||
+    "missing_reasons" in record;
+  if (!hasStructuredSummary) {
+    return { warning };
+  }
+
+  const expected = assertNonnegativeSafeInteger(
+    record.expected_file_count,
+    "downloaded response expected_file_count"
+  );
+  const placed = assertNonnegativeSafeInteger(
+    record.placed_count,
+    "downloaded response placed_count"
+  );
+  const missing = assertNonnegativeSafeInteger(
+    record.missing_file_count,
+    "downloaded response missing_file_count"
+  );
+  if (expected !== placed + missing) {
+    throw new Error("downloaded response counts are inconsistent");
+  }
+
+  let reasons: DownloadMissingReasons | null = null;
+  if (record.missing_reasons !== undefined) {
+    const reasonRecord = assertObject(
+      record.missing_reasons,
+      "downloaded response missing_reasons"
+    );
+    const sunoUnfulfilled = assertNonnegativeSafeInteger(
+      reasonRecord.suno_unfulfilled,
+      "downloaded response missing_reasons.suno_unfulfilled"
+    );
+    const applySkipped = assertNonnegativeSafeInteger(
+      reasonRecord.apply_skipped,
+      "downloaded response missing_reasons.apply_skipped"
+    );
+    if (sunoUnfulfilled + applySkipped !== missing) {
+      throw new Error("downloaded response reason total is inconsistent");
+    }
+    reasons = { sunoUnfulfilled, applySkipped };
+  } else if (missing > 0) {
+    throw new Error("downloaded response missing_reasons is required");
+  }
+
+  return { summary: { expected, placed, missing, reasons }, warning };
 }
 
 export async function postDownloaded(
@@ -944,23 +1016,14 @@ export async function postDownloaded(
       res.statusText
     );
   }
-  // サーバーは部分完了（期待数未満の配置）を warning 付き 200 で返す (#1913)。
-  // body が JSON でない・warning が無い場合は完全成功として扱う
-  let warning: string | null = null;
+  // 旧サーバーの body なし応答は warning/summary なしの成功として扱う (#1913)。
+  let data: unknown;
   try {
-    const data: unknown = await res.json();
-    if (
-      data &&
-      typeof data === "object" &&
-      "warning" in data &&
-      typeof (data as Record<string, unknown>).warning === "string"
-    ) {
-      warning = (data as Record<string, string>).warning;
-    }
+    data = await res.json();
   } catch {
-    warning = null;
+    return { warning: null };
   }
-  return { warning };
+  return parseDownloadedResult(data);
 }
 
 /** Atomically consume a server-issued unattended request nonce. */

--- a/extensions/suno-helper/tests/api.test.ts
+++ b/extensions/suno-helper/tests/api.test.ts
@@ -1182,6 +1182,63 @@ describe("shared/api postDownloaded: 正常系", () => {
     ).resolves.toEqual({ warning: "placed 10 files, expected 12 (2 missing)" });
   });
 
+  it("Given structured 部分完了応答 When postDownloaded Then warning を解析せず summary を保持する", async () => {
+    mockFetchForDownloaded(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        expected_file_count: 56,
+        placed_count: 47,
+        missing_file_count: 9,
+        missing_reasons: { suno_unfulfilled: 3, apply_skipped: 6 },
+        warning: "localized warning text",
+      }),
+    }));
+
+    await expect(
+      postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+        file_count: 56,
+        expected_file_count: 56,
+        format: "mp3",
+        download_path: "/Users/test/Downloads/test.zip",
+      })
+    ).resolves.toEqual({
+      summary: {
+        expected: 56,
+        placed: 47,
+        missing: 9,
+        reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+      },
+      warning: "localized warning text",
+    });
+  });
+
+  it("Given structured 完全完了応答 When postDownloaded Then reasons=null と warning=null を返す", async () => {
+    mockFetchForDownloaded(() => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        expected_file_count: 4,
+        placed_count: 4,
+        missing_file_count: 0,
+      }),
+    }));
+
+    await expect(
+      postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+        file_count: 4,
+        expected_file_count: 4,
+        format: "mp3",
+        download_path: "/Users/test/Downloads/test.zip",
+      })
+    ).resolves.toEqual({
+      summary: { expected: 4, placed: 4, missing: 0, reasons: null },
+      warning: null,
+    });
+  });
+
   it("Given JSON でない 200 応答 When postDownloaded Then warning なしとして resolve する (#1913)", async () => {
     mockFetchForDownloaded(() => ({
       ok: true,
@@ -1306,6 +1363,80 @@ describe("shared/api postDownloaded: 正常系", () => {
 });
 
 describe("shared/api postDownloaded: 異常系 (fail-loud)", () => {
+  it.each([
+    ["negative", -1],
+    ["fraction", 1.5],
+    ["unsafe", Number.MAX_SAFE_INTEGER + 1],
+  ])(
+    "Given structured count が %s When postDownloaded Then fail-loud に拒否する",
+    async (_label, invalidCount) => {
+      mockFetchForDownloaded(() => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          expected_file_count: 4,
+          placed_count: invalidCount,
+          missing_file_count: 2,
+          missing_reasons: { suno_unfulfilled: 1, apply_skipped: 1 },
+        }),
+      }));
+
+      await expect(
+        postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+          file_count: 4,
+          format: "mp3",
+          download_path: "/Users/test/Downloads/test.zip",
+        })
+      ).rejects.toThrow(/placed_count.*nonnegative safe integer/);
+    }
+  );
+
+  it.each([
+    [
+      "count fields are incomplete",
+      { expected_file_count: 4, placed_count: 2 },
+    ],
+    [
+      "missing count disagrees",
+      {
+        expected_file_count: 4,
+        placed_count: 3,
+        missing_file_count: 2,
+        missing_reasons: { suno_unfulfilled: 1, apply_skipped: 1 },
+      },
+    ],
+    [
+      "partial reasons are absent",
+      { expected_file_count: 4, placed_count: 2, missing_file_count: 2 },
+    ],
+    [
+      "reason total disagrees",
+      {
+        expected_file_count: 4,
+        placed_count: 2,
+        missing_file_count: 2,
+        missing_reasons: { suno_unfulfilled: 1, apply_skipped: 0 },
+      },
+    ],
+  ])(
+    "Given structured response whose %s When postDownloaded Then fail-loud に拒否する",
+    async (_label, responseBody) => {
+      mockFetchForDownloaded(() => ({
+        ok: true,
+        status: 200,
+        json: async () => responseBody,
+      }));
+
+      await expect(
+        postDownloaded(BASE_URL, "20260601-clm-aaa-collection", {
+          file_count: 4,
+          format: "mp3",
+          download_path: "/Users/test/Downloads/test.zip",
+        })
+      ).rejects.toThrow(/downloaded response/);
+    }
+  );
+
   it("Given unattended mutation が 500 When consume Then originating request context を保持して throw する", async () => {
     const fetchFn = mockFetchForDownloaded(() => ({
       ok: false,


### PR DESCRIPTION
## Summary

- structured download summary を camelCase typed resultへ正規化
- nonnegative safe integer、expected=placed+missing、reason合計、partial reasons必須を fail-loud
- legacy warning/JSONなし、full warning-null、#3125 error contextを維持

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/api.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run build

Closes #3165
Depends on #3164