### PR TITLE
feat(suno-helper): downloaded summary を relay で保持する (#3166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+- `feat(suno-helper)`: downloaded API の型付き配置 summary を privileged messaging relay でも無加工のまま返すよう統一（#3166）。
+
 - `feat(suno-helper)`: downloaded 成功応答の期待数・配置数・欠損数・欠損理由を型検証して保持し、不正な count や不整合な内訳を fail-loud で拒否（#3165）。
 
 - `feat(collection-serve)`: Suno downloaded 成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一（#3164）。

--- a/extensions/suno-helper/lib/messaging.ts
+++ b/extensions/suno-helper/lib/messaging.ts
@@ -7,6 +7,7 @@ import type {
   CollectionSummary,
   DownloadedPayload,
   DurationFilter,
+  PostDownloadedResult,
   PromptEntry,
   PromptResponse,
   ServerInfo,
@@ -198,9 +199,7 @@ interface ProtocolMap {
     baseUrl: string;
     collectionId: string;
     body: DownloadedPayload;
-  }): {
-    warning: string | null;
-  };
+  }): PostDownloadedResult;
   /** overlay → background → runner: ダウンロードのみ再実行する (#1251)。 */
   retryDownload(
     payload: RetryDownloadPayload

--- a/extensions/suno-helper/tests/background-handlers.test.ts
+++ b/extensions/suno-helper/tests/background-handlers.test.ts
@@ -4,6 +4,8 @@
 // background 版の defineBackground + chrome API stub を構築する。
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PostDownloadedResult } from "../../shared/api";
+
 type Handler = (msg: {
   data: Record<string, unknown>;
   sender: Record<string, unknown>;
@@ -67,6 +69,7 @@ async function loadBackground(opts?: {
   debuggerAttachError?: Error;
   debuggerSendCommandError?: Error;
   postDownloadedError?: Error;
+  postDownloadedResult?: PostDownloadedResult;
   sessionState?: StoredDownloadWatcher;
   sessionGetDelayMs?: number;
   useRealPostDownloaded?: boolean;
@@ -248,7 +251,7 @@ async function loadBackground(opts?: {
 
   const postDownloadedMock = opts?.postDownloadedError
     ? vi.fn(() => Promise.reject(opts.postDownloadedError))
-    : vi.fn(() => Promise.resolve());
+    : vi.fn(() => Promise.resolve(opts?.postDownloadedResult));
   if (opts?.useRealPostDownloaded) {
     vi.doUnmock("../../shared/api");
     vi.stubGlobal("fetch", opts.fetchImpl ?? vi.fn());
@@ -1796,6 +1799,35 @@ describe('background onMessage("postDownloaded"): privileged POST boundary', () 
       body,
       { extensionOrigin: "chrome-extension://suno-helper-id" }
     );
+  });
+
+  it("Given shared api が summary を返す When handler runs Then summary を無加工で返す", async () => {
+    const postDownloadedResult = {
+      summary: {
+        expected: 56,
+        placed: 47,
+        missing: 9,
+        reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+      },
+      warning: "localized warning text",
+    };
+    const { handlers } = await loadBackground({ postDownloadedResult });
+
+    const result = await handlers.get("postDownloaded")!({
+      data: {
+        baseUrl: "http://localhost:8787",
+        collectionId: "coll-1",
+        body: {
+          file_count: 56,
+          expected_file_count: 56,
+          format: "mp3",
+          download_path: "/Users/test/Downloads/test.zip",
+        },
+      },
+      sender: { tab: { id: 42 } },
+    });
+
+    expect(result).toBe(postDownloadedResult);
   });
 
   it("Given shared api rejects When handler runs Then rejection を呼び出し側へ伝播する", async () => {


### PR DESCRIPTION
## Summary

- ProtocolMap postDownloaded return を exported PostDownloadedResult へ統一
- background handler が structured summary を identity のまま返却
- origin/relay guard と rejection propagation を維持

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/background-handlers.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run build

Closes #3166
Depends on #3165