### PR TITLE
feat(suno-helper): FINISHED progress に summary を保持する (#3167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+- `feat(suno-helper)`: FINISHED progress に downloaded API の型付き配置 summary を載せ、content snapshot へ無加工で保持できるようにした（#3167）。
+
 - `feat(suno-helper)`: downloaded API の型付き配置 summary を privileged messaging relay でも無加工のまま返すよう統一（#3166）。
 
 - `feat(suno-helper)`: downloaded 成功応答の期待数・配置数・欠損数・欠損理由を型検証して保持し、不正な count や不整合な内訳を fail-loud で拒否（#3165）。

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -2,7 +2,7 @@
 // これらは yt-collection-serve (#692/#698) との互換契約であり、変更すると
 // サーバー側 (`/suno/prompts.json`) と整合しなくなる。
 // SSOT: src/youtube_automation/domains/suno/downloaded/models.py SUNO_PROMPTS_ROUTE
-import type { DurationFilter, PromptEntry } from "./api";
+import type { DownloadSummary, DurationFilter, PromptEntry } from "./api";
 
 /** chrome.storage.local に保存するサーバー URL の key。 */
 export const STORAGE_KEY = "sunoServerUrl";
@@ -399,6 +399,8 @@ type ProgressPayloadBase = {
   /** duration yield guard を通過した clip ID (#1268)。 */
   acceptedClipIds?: string[];
   durationOutlierWarning?: string;
+  /** downloaded API が検証した配置結果。warning 文言から再構築しない。 */
+  downloadSummary?: DownloadSummary;
 };
 
 type ProgressPayloadWithoutLog = ProgressPayloadBase & {

--- a/extensions/suno-helper/tests/query-progress.test.ts
+++ b/extensions/suno-helper/tests/query-progress.test.ts
@@ -227,6 +227,27 @@ describe("applyProgress: progress 受信でスナップショットを更新す�
     expect(finished.entries).toEqual(entries);
     expect(finished.itemStates).toEqual(["done", "idle"]);
     expect(finished.isRunning).toBe(false);
+    expect(finished.progress).toEqual({ phase: PHASE.FINISHED, total: 2 });
+  });
+
+  it("Given downloadSummary 付き FINISHED When applyProgress Then summary を無加工で snapshot に保持する", () => {
+    const snap = initSnapshot(makePromptEntries(2), snapshotOptions());
+    const downloadSummary = {
+      expected: 56,
+      placed: 47,
+      missing: 9,
+      reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+    };
+    const progress = {
+      phase: PHASE.FINISHED,
+      total: 2,
+      downloadSummary,
+    } as const;
+
+    const next = applyProgress(snap, progress);
+
+    expect(next.progress).toBe(progress);
+    expect(next.progress.downloadSummary).toBe(downloadSummary);
   });
 
   it("Given snap When ERROR を message 付きで適用 Then progress.message を保持する", () => {


### PR DESCRIPTION
## Summary

- ProgressPayload に typed downloadSummary を追加
- FINISHED payload から snapshot へ identity のまま保持
- summaryなし既存shapeを維持し warning text はparseしない

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/query-progress.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run build

Closes #3167
Depends on #3166