### PR TITLE
feat(suno-helper): partial FINISHED を成功表示する (#3168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+- `feat(suno-helper)`: 欠損内訳付き FINISHED を server summary の配置数・期待数・欠損数だけから成功文言へ整形し、既存の失敗完走表示を維持（#3168）。
+
 - `feat(suno-helper)`: FINISHED progress に downloaded API の型付き配置 summary を載せ、content snapshot へ無加工で保持できるようにした（#3167）。
 
 - `feat(suno-helper)`: downloaded API の型付き配置 summary を privileged messaging relay でも無加工のまま返すよう統一（#3166）。

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -43,6 +43,16 @@ function formatSeconds(value: number): string {
   return `${Math.round(value)}s`;
 }
 
+function formatDownloadSummary(
+  summary: NonNullable<SnapshotPayload["progress"]["downloadSummary"]>
+): string {
+  const text = `完了 (${summary.placed}/${summary.expected} clip 配置, ${summary.missing} clip 欠損`;
+  if (!summary.reasons) {
+    return `${text})`;
+  }
+  return `${text} — 内訳: Suno 未生成 ${summary.reasons.sunoUnfulfilled} / 配置 skip ${summary.reasons.applySkipped})`;
+}
+
 function formatDurationLimit(
   log: Extract<ProgressLog, { kind: "duration-check" }>
 ): string {
@@ -129,7 +139,7 @@ export function phaseToStatus(
     return logStatus;
   }
 
-  const { phase, index, total, message } = progress;
+  const { phase, index, total, message, downloadSummary } = progress;
   const n = (index ?? 0) + 1;
   switch (phase) {
     case PHASE.INJECTING:
@@ -164,9 +174,12 @@ export function phaseToStatus(
       // playlist 名は ProgressPayload.message で運ぶ（専用フィールドを足さず既存経路で表示する）。
       return { text: `Playlist '${message ?? ""}' へ追加中…` };
     case PHASE.FINISHED:
-      // 失敗スキップ付き完走 (#948) は message に失敗一覧が載る。無ければ従来文言。
-      return message
-        ? { text: `完了（一部失敗）: ${message}`, error: true }
+      // 失敗スキップ付き完走 (#948) を成功した配置 summary で覆わない。
+      if (message) {
+        return { text: `完了（一部失敗）: ${message}`, error: true };
+      }
+      return downloadSummary
+        ? { text: formatDownloadSummary(downloadSummary) }
         : { text: `完了: ${total} パターンを実行しました。` };
     case PHASE.STOPPED:
       return { text: "停止しました。再実行できます。" };

--- a/extensions/suno-helper/tests/phase-to-status.test.ts
+++ b/extensions/suno-helper/tests/phase-to-status.test.ts
@@ -73,6 +73,24 @@ describe("phaseToStatus: 終了 phase の文言と error フラグ", () => {
     expect(result.error).toBeFalsy();
   });
 
+  it("Given downloadSummary 付き FINISHED When phaseToStatus Then server count の部分完了文言・error は falsy", () => {
+    const result = statusOf({
+      phase: PHASE.FINISHED,
+      total: 28,
+      downloadSummary: {
+        expected: 56,
+        placed: 47,
+        missing: 9,
+        reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+      },
+    });
+
+    expect(result.text).toBe(
+      "完了 (47/56 clip 配置, 9 clip 欠損 — 内訳: Suno 未生成 3 / 配置 skip 6)"
+    );
+    expect(result.error).toBeFalsy();
+  });
+
   it("Given STOPPED When phaseToStatus Then 再実行可能な停止文言・error は falsy", () => {
     const result = statusOf({ phase: PHASE.STOPPED, index: 0, total: 3 });
 
@@ -144,6 +162,12 @@ describe("phaseToStatus: ENTRY_FAILED / 失敗付き FINISHED (#948)", () => {
         phase: PHASE.FINISHED,
         total: 55,
         message: "2 件の entry が失敗しました (entry 3, 7)",
+        downloadSummary: {
+          expected: 56,
+          placed: 47,
+          missing: 9,
+          reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+        },
       },
       []
     );


### PR DESCRIPTION
## Summary

- FINISHED+summary を server countだけで指定の部分完了文言へ整形
- summary付き成功は error falsy
- failure messageを優先し、summaryなし従来文言を維持

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/phase-to-status.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run build

Closes #3168
Depends on #3167