### PR TITLE
feat(suno-helper): download-flow から summary を返す (#3169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
+- `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果と再試行時の全 FINISHED event で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。
+
 - `feat(suno-helper)`: 欠損内訳付き FINISHED を server summary の配置数・期待数・欠損数だけから成功文言へ整形し、既存の失敗完走表示を維持（#3168）。
 
 - `feat(suno-helper)`: FINISHED progress に downloaded API の型付き配置 summary を載せ、content snapshot へ無加工で保持できるようにした（#3167）。

--- a/extensions/suno-helper/lib/download-flow.ts
+++ b/extensions/suno-helper/lib/download-flow.ts
@@ -1,4 +1,4 @@
-import type { DownloadedPayload } from "../../shared/api";
+import type { DownloadedPayload, DownloadSummary } from "../../shared/api";
 import type { ProgressPayload } from "../../shared/constants";
 import { PHASE } from "../../shared/constants";
 import { triggerDownloadAll } from "./download";
@@ -15,7 +15,13 @@ export interface DownloadFlow {
     collectionId: string,
     progressTotal: number,
     expectedFileCount: number
-  ) => Promise<void>;
+  ) => Promise<DownloadSummary | undefined>;
+  downloadBestEffortResult: (
+    context: DownloadContext,
+    collectionId: string,
+    progressTotal: number,
+    expectedFileCount: number
+  ) => Promise<DownloadBestEffortResult>;
   downloadBestEffort: (
     context: DownloadContext,
     collectionId: string,
@@ -31,6 +37,12 @@ export interface RetryDownloadResult {
   /** FINISHED まで到達し resume state 消去も成功したか。呼び出し側の完了時リロード発火判定に使う (#1411)。
    * false は中断（STOPPED）または resume state 消去失敗（リロードすると再開バナーが誤判定するため見送る）。 */
   completedAndCleared: boolean;
+  summary?: DownloadSummary;
+}
+
+export interface DownloadBestEffortResult {
+  error: string | null;
+  summary?: DownloadSummary;
 }
 
 export interface DownloadFlowDeps {
@@ -161,7 +173,7 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     progressTotal: number,
     expectedFileCount: number,
     filename: string
-  ): Promise<void> {
+  ): Promise<DownloadSummary | undefined> {
     await deps.onDownloadComplete?.(filename);
     const postResult = await sendMessage("postDownloaded", {
       baseUrl: context.baseUrl,
@@ -183,6 +195,7 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
         message: `部分ダウンロード（不足あり）: ${postResult.warning}`,
       });
     }
+    return postResult?.summary;
   }
 
   async function performDownloadAttempt(
@@ -190,7 +203,7 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     collectionId: string,
     progressTotal: number,
     expectedFileCount: number
-  ): Promise<void> {
+  ): Promise<DownloadSummary | undefined> {
     if (deps.isAborted()) return;
 
     deps.emitProgress({
@@ -201,7 +214,7 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     await startDownloadWatcher(context.format);
     const filename = await waitForDownloadedFilename(context.format);
     if (filename === null) return;
-    await postDownloadedArchive(
+    return await postDownloadedArchive(
       context,
       collectionId,
       progressTotal,
@@ -215,9 +228,9 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     collectionId: string,
     progressTotal: number,
     expectedFileCount: number
-  ): Promise<void> {
+  ): Promise<DownloadSummary | undefined> {
     try {
-      await performDownloadAttempt(
+      return await performDownloadAttempt(
         context,
         collectionId,
         progressTotal,
@@ -228,20 +241,20 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     }
   }
 
-  async function downloadBestEffort(
+  async function downloadBestEffortResult(
     context: DownloadContext,
     collectionId: string,
     progressTotal: number,
     expectedFileCount: number
-  ): Promise<string | null> {
+  ): Promise<DownloadBestEffortResult> {
     try {
-      await performDownload(
+      const summary = await performDownload(
         context,
         collectionId,
         progressTotal,
         expectedFileCount
       );
-      return null;
+      return summary === undefined ? { error: null } : { error: null, summary };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[suno-helper] Download all failed: ${message}`);
@@ -250,8 +263,24 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
         total: progressTotal,
         message: `ダウンロード失敗（手動でダウンロードしてください）: ${message}`,
       });
-      return message;
+      return { error: message };
     }
+  }
+
+  async function downloadBestEffort(
+    context: DownloadContext,
+    collectionId: string,
+    progressTotal: number,
+    expectedFileCount: number
+  ): Promise<string | null> {
+    return (
+      await downloadBestEffortResult(
+        context,
+        collectionId,
+        progressTotal,
+        expectedFileCount
+      )
+    ).error;
   }
 
   async function retryDownload(
@@ -271,7 +300,7 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
       deps.emitProgress({ phase: PHASE.STOPPED, total: 0 });
       return { completedAndCleared: false };
     }
-    await performDownload(
+    const summary = await performDownload(
       options.context,
       options.collectionId,
       total,
@@ -279,7 +308,9 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
     );
     if (deps.isAborted()) {
       deps.emitProgress({ phase: PHASE.STOPPED, total: 0 });
-      return { completedAndCleared: false };
+      return summary === undefined
+        ? { completedAndCleared: false }
+        : { completedAndCleared: false, summary };
     }
     // 消去失敗でも FINISHED は維持する（download 自体は成功しているため）。
     // その場合はリロードを見送る合図として completedAndCleared=false を返す (#1411)。
@@ -293,13 +324,20 @@ export function createDownloadFlow(deps: DownloadFlowDeps): DownloadFlow {
         err
       );
     }
-    deps.emitProgress({ phase: PHASE.FINISHED, total: 0 });
-    return { completedAndCleared: resumeStateCleared };
+    deps.emitProgress({
+      phase: PHASE.FINISHED,
+      total: 0,
+      ...(summary === undefined ? {} : { downloadSummary: summary }),
+    });
+    return summary === undefined
+      ? { completedAndCleared: resumeStateCleared }
+      : { completedAndCleared: resumeStateCleared, summary };
   }
 
   return {
     installMessageHandlers,
     performDownload,
+    downloadBestEffortResult,
     downloadBestEffort,
     retryDownload,
   };

--- a/extensions/suno-helper/tests/download-flow.test.ts
+++ b/extensions/suno-helper/tests/download-flow.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { PHASE } from "../../shared/constants";
 import { createDownloadFlow } from "../lib/download-flow";
 
 // REQ-2915-01: every watcher-side failure cancels once and clears its resolver.
@@ -29,15 +30,22 @@ const CONTEXT = {
   format: "mp3" as const,
 };
 
+const PARTIAL_SUMMARY = {
+  expected: 56,
+  placed: 47,
+  missing: 9,
+  reasons: { sunoUnfulfilled: 3, applySkipped: 6 },
+};
+
 function dispatchDownloadComplete(filename = "collection.zip"): void {
   messagingMocks.handlers.get("downloadComplete")?.({
     data: { filename },
   });
 }
 
-function createSubject(isAborted: () => boolean) {
+function createSubject(isAborted: () => boolean, emitProgress = vi.fn()) {
   const flow = createDownloadFlow({
-    emitProgress: vi.fn(),
+    emitProgress,
     isAborted,
   });
   flow.installMessageHandlers();
@@ -55,6 +63,24 @@ function expectOnlyStartAndCancelMessages(): void {
       ([message]) => message === "postDownloaded"
     )
   ).toBe(false);
+}
+
+function arrangePartialDownloadSuccess(): void {
+  messagingMocks.sendMessage.mockImplementation(async (message: string) => {
+    if (message === "startDownload") {
+      return { ok: true };
+    }
+    if (message === "postDownloaded") {
+      return {
+        summary: PARTIAL_SUMMARY,
+        warning: "placed 47 files, expected 56 (9 missing)",
+      };
+    }
+    return { ok: true };
+  });
+  downloadMocks.triggerDownloadAll.mockImplementationOnce(async () => {
+    dispatchDownloadComplete();
+  });
 }
 
 describe("download flow", () => {
@@ -124,6 +150,61 @@ describe("download flow", () => {
     expectOnlyStartAndCancelMessages();
   });
 
+  it("通常 download の部分成功は server summary を同一objectで返す", async () => {
+    arrangePartialDownloadSuccess();
+    const flow = createSubject(() => false);
+
+    const summary = await flow.performDownload(CONTEXT, "collection", 28, 56);
+
+    expect(summary).toBe(PARTIAL_SUMMARY);
+  });
+
+  it("best-effort download の部分成功は error なしで同じ server summary を返す", async () => {
+    arrangePartialDownloadSuccess();
+    const flow = createSubject(() => false);
+
+    const result = await flow.downloadBestEffortResult(
+      CONTEXT,
+      "collection",
+      28,
+      56
+    );
+
+    expect(result).toEqual({ error: null, summary: PARTIAL_SUMMARY });
+    expect(result.summary).toBe(PARTIAL_SUMMARY);
+  });
+
+  it("retry download の部分成功は同じ server summary を返す", async () => {
+    arrangePartialDownloadSuccess();
+    const emitProgress = vi.fn();
+    const flow = createSubject(() => false, emitProgress);
+
+    const result = await flow.retryDownload({
+      context: CONTEXT,
+      collectionId: "collection",
+      submittedClipIds: ["clip-id"],
+      expectedClipCount: 56,
+      selectClipIds: vi.fn(async () => undefined),
+      clearResumeState: vi.fn(async () => undefined),
+    });
+
+    expect(result).toEqual({
+      completedAndCleared: true,
+      summary: PARTIAL_SUMMARY,
+    });
+    expect(result.summary).toBe(PARTIAL_SUMMARY);
+    const finishedProgress = emitProgress.mock.calls
+      .map(([payload]) => payload)
+      .filter((payload) => payload.phase === PHASE.FINISHED);
+    expect(finishedProgress).toEqual([
+      {
+        phase: PHASE.FINISHED,
+        total: 0,
+        downloadSummary: PARTIAL_SUMMARY,
+      },
+    ]);
+  });
+
   it("通常 download の API 失敗理由へ downloading phase を付与して返す", async () => {
     const apiError =
       "POST /collections/collection/downloaded failed: 403 Forbidden";
@@ -162,6 +243,27 @@ describe("download flow", () => {
         clearResumeState: vi.fn(async () => undefined),
       })
     ).rejects.toThrow("watcher unavailable (phase=downloading)");
+  });
+
+  it("配置数 0 の server error を通常 download で握りつぶさない", async () => {
+    const serverError = "placed_count must be positive";
+    messagingMocks.sendMessage.mockImplementation(async (message: string) => {
+      if (message === "startDownload") {
+        return { ok: true };
+      }
+      if (message === "postDownloaded") {
+        throw new Error(serverError);
+      }
+      return { ok: true };
+    });
+    downloadMocks.triggerDownloadAll.mockImplementationOnce(async () => {
+      dispatchDownloadComplete();
+    });
+    const flow = createSubject(() => false);
+
+    await expect(
+      flow.performDownload(CONTEXT, "collection", 2, 2)
+    ).rejects.toThrow(`${serverError} (phase=downloading)`);
   });
 
   it("既に downloading phase がある失敗理由を重複して付与しない", async () => {


### PR DESCRIPTION
## Summary

- performDownload/retryDownload がserver summaryをidentityのまま返す
- legacy downloadBestEffort(string|null)を維持し typed downloadBestEffortResultを追加
- partial 200成功、API phase=downloading、zero-placed fail-loudを維持

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/download-flow.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run build
- nix develop .#extensions --command pnpm --dir extensions/suno-helper run audit

Closes #3169
Depends on #3168