### PR TITLE
feat(suno-helper): normal run の FINISHED に summary を載せる (#3170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
 - `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果と再試行時の全 FINISHED event で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。
+- `feat(suno-helper)`: normal collection run の部分 download 成功 summary を FINISHED progress と完了 snapshot に保持し、既存の resume 消去・リロード順序と失敗時の再開契約を維持（#3170）。
+
+- `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。
 
 - `feat(suno-helper)`: 欠損内訳付き FINISHED を server summary の配置数・期待数・欠損数だけから成功文言へ整形し、既存の失敗完走表示を維持（#3168）。
 

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_DURATION_FILTER,
+  type DownloadSummary,
   type DurationFilter,
   playlistNameForCollection,
   type PromptEntry,
@@ -1525,6 +1526,7 @@ export default defineContentScript({
       const stalledEntryIndices: number[] = [];
       let queueClipIdsByEntry: Map<number, string[]> | null = null;
       let keepResumeStateForDownloadRetry = false;
+      let downloadSummary: DownloadSummary | undefined;
       let playlistPersistInfo: PlaylistClipPersistInfo | null = null;
       // 中断 entry を永続化し、reload 後の ResumeBanner で続きから再開できるようにする。
       // ERROR phase (#872 要件3) と STOPPED phase (#898 要件1/2/3) の共通処理。failedIndex 名は
@@ -2273,19 +2275,20 @@ export default defineContentScript({
             unattended?.request.downloadFormat
           );
           assertUnattendedUiIsSafe();
-          const downloadError = await downloadFlow.downloadBestEffort(
+          const downloadResult = await downloadFlow.downloadBestEffortResult(
             downloadContext,
             collectionId,
             total,
             verifiedPlaylistClipCount
           );
-          keepResumeStateForDownloadRetry = downloadError !== null;
-          if (downloadError !== null) {
+          downloadSummary = downloadResult.summary;
+          keepResumeStateForDownloadRetry = downloadResult.error !== null;
+          if (downloadResult.error !== null) {
             emitProgress({
               phase: PHASE.ERROR,
               index: total,
               total,
-              message: downloadError,
+              message: downloadResult.error,
             });
             return;
           }
@@ -2342,7 +2345,11 @@ export default defineContentScript({
           );
         }
       }
-      emitProgress({ phase: PHASE.FINISHED, total });
+      emitProgress({
+        phase: PHASE.FINISHED,
+        total,
+        ...(downloadSummary === undefined ? {} : { downloadSummary }),
+      });
       // run 一式完了時リロード (#1411 要件2)。playlist 追加で作った multi-select 状態は
       // Suno 内部 state に残り、同一タブの次 run の Cmd+P に混入するためページごと破棄する。
       // collection mode の run は playlist phase を実行するため対象。

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { DownloadSummary } from "../../shared/api";
 import {
   ADAPTIVE_BURST_COOLDOWN_MS,
   BALANCED_RUN_PACING,
@@ -14,6 +15,7 @@ import {
   fillPlaylistNameAndCreate,
   scrollAndMultiSelectByIds,
 } from "../../shared/playlist-dom";
+import type { DownloadBestEffortResult } from "../lib/download-flow";
 import type {
   EntryRunResult,
   RunEntryWithRetryOptions,
@@ -40,6 +42,12 @@ const harness = vi.hoisted(() => {
     injectAckTimeoutMs: 12345,
     maxEntryRetry: 9,
   }));
+  const clearResumeStateForCollection = vi.fn(() => Promise.resolve());
+  const downloadBestEffortResult = vi.fn<
+    () => Promise<DownloadBestEffortResult>
+  >(() => Promise.resolve({ error: null }));
+  const writeFinishedSnapshot = vi.fn(() => Promise.resolve());
+  const scheduleRunCompleteReload = vi.fn();
 
   return {
     handlers,
@@ -60,6 +68,10 @@ const harness = vi.hoisted(() => {
     runEntryWithRetry,
     legacyReadSpeedPresetId,
     legacyResolveSpeedPreset,
+    clearResumeStateForCollection,
+    downloadBestEffortResult,
+    writeFinishedSnapshot,
+    scheduleRunCompleteReload,
     serverUrlSet: vi.fn(() => Promise.resolve()),
     downloadFormatSet: vi.fn(() => Promise.resolve()),
     readResumeState: vi.fn<() => Promise<ResumeState | null>>(() =>
@@ -230,7 +242,7 @@ vi.mock("../lib/resume-state", async () => {
   );
   return {
     ...actual,
-    clearResumeStateForCollection: vi.fn(() => Promise.resolve()),
+    clearResumeStateForCollection: harness.clearResumeStateForCollection,
     readResumeState: harness.readResumeState,
     writeResumeState: vi.fn(() => Promise.resolve()),
   };
@@ -248,7 +260,7 @@ vi.mock("../lib/download", () => ({
 vi.mock("../lib/download-flow", () => ({
   createDownloadFlow: vi.fn(() => ({
     installMessageHandlers: vi.fn(),
-    downloadBestEffort: vi.fn(() => Promise.resolve(null)),
+    downloadBestEffortResult: harness.downloadBestEffortResult,
     performDownload: vi.fn(() => Promise.resolve()),
     retryDownload: vi.fn(() => Promise.resolve({ completedAndCleared: true })),
   })),
@@ -257,7 +269,7 @@ vi.mock("../lib/download-flow", () => ({
 // 完了時リロード前の snapshot 退避。実物は chrome.storage へアクセスするため node/jsdom 環境では mock 必須。
 // 退避契約そのものの検証は content-finished-snapshot.test.ts が担う。
 vi.mock("../lib/finished-snapshot", () => ({
-  writeFinishedSnapshot: vi.fn(() => Promise.resolve()),
+  writeFinishedSnapshot: harness.writeFinishedSnapshot,
   readFreshFinishedSnapshot: vi.fn(() => Promise.resolve(null)),
   clearFinishedSnapshot: vi.fn(() => Promise.resolve()),
 }));
@@ -266,7 +278,7 @@ vi.mock("../lib/finished-snapshot", () => ({
 // mock 必須（teardown 後に timer が発火すると location 参照が undefined で unhandled error になる）。
 // リロード契約そのものの検証は content-finished-snapshot.test.ts が担う。
 vi.mock("../lib/page-reload", () => ({
-  scheduleRunCompleteReload: vi.fn(),
+  scheduleRunCompleteReload: harness.scheduleRunCompleteReload,
   cancelScheduledRunCompleteReload: vi.fn(),
 }));
 
@@ -569,6 +581,8 @@ beforeEach(() => {
       return { outcome: "ok" };
     }
   );
+  harness.downloadBestEffortResult.mockReset();
+  harness.downloadBestEffortResult.mockResolvedValue({ error: null });
   harness.submittedClipIds = [];
   harness.acceptedClipIds = [];
   harness.droppedClipIds = [];
@@ -1105,6 +1119,109 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       ])
     );
   });
+
+  it("Given download が部分成功 When normal run completes Then summary 付き FINISHED を保存して順序どおりリロードする", async () => {
+    const summary = {
+      expected: 2,
+      placed: 1,
+      missing: 1,
+      reasons: { sunoUnfulfilled: 0, applySkipped: 1 },
+    } satisfies DownloadSummary;
+    harness.downloadBestEffortResult.mockResolvedValueOnce({
+      error: null,
+      summary,
+    });
+    makeRunnableSunoDom("Grid");
+    await loadContentScript();
+
+    expect(
+      getRunHandler()({ data: makeRunPayload(makePromptEntries(1)) })
+    ).toEqual({ ok: true });
+
+    await vi.waitFor(() =>
+      expect(harness.scheduleRunCompleteReload).toHaveBeenCalledOnce()
+    );
+    const progress = progressPayloads() as Array<{
+      phase: string;
+      downloadSummary?: DownloadSummary;
+    }>;
+    const finished = progress.find(
+      (payload) => payload.phase === PHASE.FINISHED
+    );
+    expect(finished?.downloadSummary).toBe(summary);
+    expect(progress.some((payload) => payload.phase === PHASE.ERROR)).toBe(
+      false
+    );
+    expect(harness.writeFinishedSnapshot).toHaveBeenCalledWith({
+      snapshot: expect.objectContaining({
+        progress: expect.objectContaining({
+          phase: PHASE.FINISHED,
+          downloadSummary: summary,
+        }),
+      }),
+      timestamp: expect.any(Number),
+    });
+
+    const finishedCallIndex = harness.sendMessage.mock.calls.findIndex(
+      ([type, payload]) =>
+        type === "progress" &&
+        (payload as { phase?: string }).phase === PHASE.FINISHED
+    );
+    expect(finishedCallIndex).toBeGreaterThanOrEqual(0);
+    const finishedCallOrder =
+      harness.sendMessage.mock.invocationCallOrder[finishedCallIndex];
+    expect(
+      harness.clearResumeStateForCollection.mock.invocationCallOrder[0]
+    ).toBeLessThan(finishedCallOrder);
+    expect(finishedCallOrder).toBeLessThan(
+      harness.writeFinishedSnapshot.mock.invocationCallOrder[0]
+    );
+    expect(
+      harness.writeFinishedSnapshot.mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      harness.scheduleRunCompleteReload.mock.invocationCallOrder[0]
+    );
+  });
+
+  it.each([
+    "POST downloaded failed: 500 Internal Server Error (phase=downloading)",
+    "placed_count must be positive (phase=downloading)",
+  ])(
+    "Given download result が %s When normal run completes Then ERROR で resume state を保持する",
+    async (downloadError) => {
+      harness.downloadBestEffortResult.mockResolvedValueOnce({
+        error: downloadError,
+      });
+      makeRunnableSunoDom("Grid");
+      await loadContentScript();
+
+      expect(
+        getRunHandler()({ data: makeRunPayload(makePromptEntries(1)) })
+      ).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(progressPayloads()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              phase: PHASE.ERROR,
+              message: downloadError,
+            }),
+          ])
+        )
+      );
+      expect(writeResumeState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectionId: "20260601-clm-preflight-collection",
+        })
+      );
+      expect(harness.clearResumeStateForCollection).not.toHaveBeenCalled();
+      expect(progressPayloads()).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ phase: PHASE.FINISHED }),
+        ])
+      );
+    }
+  );
 
   it("Given durationFilter が小数秒 When run を受ける Then payload を受理して実行を開始する", async () => {
     makeViewButton("Grid");


### PR DESCRIPTION
## Summary

- normal runをtyped downloadBestEffortResultへ移行
- partial success summaryをFINISHEDとfinished snapshotへ保持
- ERRORなし、resume clear→emit→snapshot→reload順を維持
- reject/zeroはERRORでresume保持

## Verification

- pnpm --dir extensions/suno-helper exec vitest run tests/content-run-preflight.test.ts
- pnpm --dir extensions/suno-helper exec vitest run
- pnpm --dir extensions/suno-helper run compile
- pnpm --dir extensions/suno-helper run check
- pnpm --dir extensions/suno-helper run build
- nix develop .#extensions --command pnpm --dir extensions/suno-helper run audit

Closes #3170
Depends on #3169