### PR TITLE
docs(suno-helper): partial FINISHED 契約を公開する (#3172)

### DIFF
--- a/.claude/skills/suno-helper/SKILL.md
+++ b/.claude/skills/suno-helper/SKILL.md
@@ -17,7 +17,7 @@ suno-helper は生成 → playlist 追加 → 一括ダウンロードまでを 
 
 ## 完了条件
 
-overlay の phase が `finished` に到達し、Step 6 の 6 点（playlist 紐付け / clip 数 = entry 数 × 2 / `02-Individual-music/` への音声配置 / `status = downloaded` / `suno_playlist_url` 記録 / `assets.music_downloaded = true`）を確認後、collection server を停止してプロセスが残っていないとき完了とする（詳細は Step 6 が正）。異常値再生成を OFF にした run は、さらに duration guard NG の clip を試聴し、NG clip が ZIP に含まれることを確認してから完了とする。`entry-failed`、clip 数不足、server プロセス残留のいずれかがある場合は完了扱いにしない。
+overlay の phase が `finished` に到達し、Step 6 の 6 点（playlist 紐付け / clip 数 = entry 数 × 2 / `02-Individual-music/` への音声配置 / `status = downloaded` / `suno_playlist_url` 記録 / `assets.music_downloaded = true`）を確認後、collection server を停止してプロセスが残っていないとき strict 完了とする（詳細は Step 6 が正）。`finished` は download 通知の終端成功を示し、1 件以上配置できた部分成功も含むため、それだけで strict 完了とは判定しない。異常値再生成を OFF にした run は、さらに duration guard NG の clip を試聴し、NG clip が ZIP に含まれることを確認してから完了とする。`entry-failed`、clip 数不足、server プロセス残留のいずれかがある場合は完了扱いにしない。
 
 ## 設定読み込みゲート
 
@@ -188,11 +188,11 @@ overlay / popup 上部の live region と root の `data-suno-phase` に進捗�
 | `entry-failed` | 当該 entry は失敗としてスキップし、run 全体は次 entry へ継続 |
 | `adding-to-playlist` | 全 entry 完了、clip を一括 playlist 化中 |
 | `downloading` | playlist 追加完了後、全 clip を ZIP 一括ダウンロード中 |
-| `finished` | 完了（DL 含む） |
+| `finished` | DL 通知成功。`placed > 0` なら部分配置も終端成功とし、status に配置数 / 期待数 / 欠損数と `missing_reasons` の内訳を表示 |
 | `stopped` | user が停止ボタンで中断 |
-| `error` | 失敗（赤色で停止）|
+| `error` | server reject を含む失敗（赤色で停止）。`placed = 0` は成功へ縮退せずこの phase |
 
-**phase 遷移の詳細**: `done`（最終 entry）→ `adding-to-playlist` → `downloading` → `finished`。playlist 追加完了直後に `postDownloaded(file_count: 0)` を呼んで playlist URL のみをサーバーに記録し、ZIP ダウンロード完了後に `postDownloaded(file_count: N)` で実ファイル数を報告する。
+**phase 遷移の詳細**: `done`（最終 entry）→ `adding-to-playlist` → `downloading` → `finished`。playlist 追加完了直後に `postDownloaded(file_count: 0)` を呼んで playlist URL のみをサーバーに記録し、ZIP ダウンロード完了後に `postDownloaded(file_count: N)` で実ファイル数を報告する。後者の server 応答で `placed > 0` なら期待数未満でも `finished` へ進み、status は `完了 (placed/expected clip 配置, missing clip 欠損 — 内訳: Suno 未生成 N / 配置 skip N)` を表示する。ZIP からの `placed = 0` は server が reject し、拡張は `error` のまま resume state を保持する。
 
 無限待機を避ける監視ルール:
 
@@ -219,12 +219,16 @@ handoff 条件（agent は自動突破しない）:
 
 `finished` 表示後、以下を確認:
 
+最初に、overlay の `role="status"` に保持された server 応答 summary、`workflow-state.json`、`02-Individual-music/` の実ファイルを照合する。server 応答の `placed_count` / `expected_file_count` / `missing_file_count` は、それぞれ実ファイル数 / `planning.music.actual_file_count`、`planning.music.expected_file_count`、`planning.music.missing_file_count` と一致すること。部分配置では `planning.music.missing_reasons` の `suno_unfulfilled` / `apply_skipped` が status の「Suno 未生成」/「配置 skip」と一致し、`suno_unfulfilled + apply_skipped = missing_file_count` であること。不一致なら成功表示のまま進めず、server log と配置 skip を調査する。
+
 1. Suno 側で対象 playlist に collection の全 clip が紐付いている
 2. clip 数 = collection の entry 数 × 2（数が合わなければ resume で残りを回す）
 3. `02-Individual-music/` に mp3/m4a/wav が配置されている
 4. `GET /collections` で対象 collection の `status` が `downloaded`、`downloaded_count` が期待 clip 数以上になっている
 5. `workflow-state.json` の `planning.music.suno_playlist_url` に playlist URL が記録されている
 6. `workflow-state.json` の `assets.music_downloaded` が `true` になっている（DL 完了時）
+
+`placed_count > 0` かつ `missing_file_count > 0` の partial FINISHED は download 通知としては成功だが、strict 完了ではない。`status = downloaded` や `assets.music_downloaded = true` だけを根拠に `/masterup` へ進めない。不足分の再実行または手動解決を行い、上記 6 点と `missing_file_count = 0` が揃ってから後工程へ進む。
 
 **異常値の曲を再生成する** を OFF にした場合は、上記に加えて status / console warning で記録された duration guard NG の clip を playlist 上で試聴し、手動採否を確認する。NG clip も意図どおり ZIP に含まれていることを確認してから完了とする。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
 - `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果と再試行時の全 FINISHED event で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。
+- `docs(suno-helper)`: 配置数が 1 件以上の部分 download は欠損内訳付き FINISHED、配置ゼロは ERROR とする operator 契約を公開し、server 応答・workflow state・実ファイルの照合後だけ strict 完了として後工程へ進む手順を明記（#3172）。
+
 - `feat(suno-helper)`: retry download の部分成功 summary を FINISHED progress と完了 snapshot に保持し、既存の resume 消去・リロード順序と reject 時の ERROR 契約を維持（#3171）。
 
 - `feat(suno-helper)`: normal collection run の部分 download 成功 summary を FINISHED progress と完了 snapshot に保持し、既存の resume 消去・リロード順序と失敗時の再開契約を維持（#3170）。

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -282,6 +282,34 @@ def test_suno_helper_phase_table_matches_shared_phase_constants() -> None:
     assert _suno_helper_phase_table_values() == _shared_phase_values()
 
 
+def test_suno_helper_documents_partial_finished_operator_contract() -> None:
+    """Issue #3172: 部分配置の終端 phase と strict 完了判定を operator 向けに固定する。"""
+    text = _read_suno_helper()
+    phase_section = text.split("### Step 5. 進捗 phase を読む", 1)[1].split("### Step 6. 完了確認", 1)[0]
+    completion_section = text.split("### Step 6. 完了確認", 1)[1].split("\n### ", 1)[0]
+
+    for token in (
+        "`placed > 0`",
+        "`finished`",
+        "配置数 / 期待数 / 欠損数",
+        "`missing_reasons`",
+        "`placed = 0`",
+        "`error`",
+    ):
+        assert token in phase_section, f"Step 5 に部分 FINISHED 契約がない（`{token}` 不在）"
+
+    for token in (
+        "server 応答",
+        "`planning.music.actual_file_count`",
+        "`planning.music.missing_file_count`",
+        "`planning.music.missing_reasons`",
+        "`suno_unfulfilled + apply_skipped = missing_file_count`",
+        "strict 完了ではない",
+        "`/masterup` へ進めない",
+    ):
+        assert token in completion_section, f"Step 6 に部分配置の照合契約がない（`{token}` 不在）"
+
+
 def test_wf_new_hands_off_to_suno_helper_browser_use_flow() -> None:
     """Given wf-new SKILL.md
     When Suno 後続案内を読む


### PR DESCRIPTION
## Summary

- placed>0 partialを欠損内訳付きFINISHED、配置0をERRORと明記
- server/workflow/filesの理由一致確認をoperator contract化
- partial FINISHEDをstrict completenessと誤認せず /masterupへ進めない

## Verification

- uv run pytest -q tests/repo/test_suno_skill_doc.py
- uv run yt-skills lint suno-helper
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .

Closes #3172
Depends on #3171