### PR TITLE
docs(streaming): workspace 操作を Quick Reference に追加する (#3184)

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -32,6 +32,11 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 | 操作 | コマンド |
 |------|----------|
 | 初回構築 | §1 |
+| workspace 一覧 | `terraform -chdir=infra/terraform/streaming workspace list` |
+| 現在の workspace | `terraform -chdir=infra/terraform/streaming workspace show` |
+| workspace 作成 | `terraform -chdir=infra/terraform/streaming workspace new <workspace>` |
+| workspace 切替 | `terraform -chdir=infra/terraform/streaming workspace select <workspace>` |
+| 選択 workspace の GCS state | `workspace=$(terraform -chdir=infra/terraform/streaming workspace show); bucket=$(jq -r '.backend.config.bucket' infra/terraform/streaming/.terraform/terraform.tfstate); gcloud storage ls "gs://${bucket}/streaming/${workspace}.tfstate"` |
 | ライブチャット自動返信 | `/live-chat-reply` |
 | 動画差し替え | `$(git rev-parse --show-toplevel)/.claude/skills/streaming/references/swap_video.sh ./new_video.mp4` |
 | 帯域チェック | `uv run yt-stream-bandwidth --check-threshold --terraform-dir infra/terraform/streaming` |
@@ -40,6 +45,8 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 | サービス状態 | `ssh -i ~/.ssh/yt_stream_key root@$(terraform -chdir=infra/terraform/streaming output -raw instance_ip) systemctl status youtube-stream` |
 | ログ追跡 | 同上 + `journalctl -u youtube-stream -f` |
 | 破棄 | §5 |
+
+workspace は state だけを切り替える。作成・切替後は対象チャンネルの `TF_VAR_video_path` / `TF_VAR_stream_key` / `TF_VAR_discord_webhook_url` を必ず再注入し、apply 前の照合まで含む詳細手順は [README の「チャンネル別 Terraform workspace 運用」](../../../infra/terraform/streaming/README.md#チャンネル別-terraform-workspace-運用) を正本とする。
 
 | CLI / スクリプト | 用途 |
 |---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(suno)`: optional な `duration_sec` の単位・値域・明示時のみ全 entry へ出力する契約と、生成後の採用範囲を担う `duration_filter` との責務分離を配布設定と Suno 手順へ記載した（#3133）。
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
+- `docs(streaming)`: `/streaming` の Quick Reference にチャンネル別 Terraform workspace の確認・作成・切替入口を追加し、切替後のチャンネル固有 `TF_VAR_*` 再注入と README 正本への導線を明示した（#3184）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/tests/repo/streaming/test_skill_streaming.py
+++ b/tests/repo/streaming/test_skill_streaming.py
@@ -109,6 +109,36 @@ class TestStreamingSkillSshAgent:
         assert "preflight 合否は `terraform plan` / `apply` の stream-level 検証" in text
 
 
+class TestStreamingSkillWorkspaces:
+    """Quick Reference から README 正本の workspace 手順へ到達できる契約。"""
+
+    def test_quick_reference_indexes_workspace_operations_and_variable_warning(self):
+        """workspace 操作、変数再注入警告、詳細正本への link を固定する。"""
+        text = read_file(_STREAMING_SKILL)
+        match = re.search(
+            r"^## Quick Reference\s*$\n(.*?)(?=^##\s|\Z)",
+            text,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        assert match is not None, "streaming SKILL.md に Quick Reference 節が無い"
+        section = match.group(1)
+
+        for required in (
+            "workspace list",
+            "workspace show",
+            "workspace new <workspace>",
+            "workspace select <workspace>",
+            "jq -r '.backend.config.bucket'",
+            'gcloud storage ls "gs://${bucket}/streaming/${workspace}.tfstate"',
+            "TF_VAR_video_path",
+            "TF_VAR_stream_key",
+            "TF_VAR_discord_webhook_url",
+            "再注入",
+            "../../../infra/terraform/streaming/README.md#チャンネル別-terraform-workspace-運用",
+        ):
+            assert required in section, f"Quick Reference に {required!r} が無い"
+
+
 # ============================================================================
 # infra/terraform/streaming/README.md — #125 新規ドキュメント
 # ============================================================================


### PR DESCRIPTION
## Summary

- Quick Referenceにworkspace list/show/new/select入口を追加
- channel固有TF_VAR再注入警告をoperator索引へ追加
- 詳細はREADME正本へlinkし重複を避ける

## Verification

- uv run pytest -q tests/repo/streaming/test_skill_streaming.py
- uv run pytest -q tests/repo/streaming
- uv run yt-skills lint streaming
- uv run pytest -n auto -q

Closes #3184
Depends on #3183