### PR TITLE
refactor(skill-feedback): canonical receipt owner を移行する (#3187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `docs(streaming)`: `/streaming` の Quick Reference にチャンネル別 Terraform workspace の確認・作成・切替入口を追加し、切替後のチャンネル固有 `TF_VAR_*` 再注入と README 正本への導線を明示した（#3184）。
+- `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/docs/architecture/b6-integration-receipt.json
+++ b/docs/architecture/b6-integration-receipt.json
@@ -626,14 +626,14 @@
     },
     {
       "old_owner": "legacy..claude.skills.feedback.SKILL.md",
-      "exact_new_owner": ".claude/skills/feedback/SKILL.md",
+      "exact_new_owner": ".claude/skills/skill-feedback/SKILL.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"
     },
     {
       "old_owner": "legacy..claude.skills.feedback.references.upstream-issue-template.md",
-      "exact_new_owner": ".claude/skills/feedback/references/upstream-issue-template.md",
+      "exact_new_owner": ".claude/skills/skill-feedback/references/upstream-issue-template.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"

--- a/tests/repo/test_b6_integration_contract.py
+++ b/tests/repo/test_b6_integration_contract.py
@@ -19,6 +19,13 @@ EXPECTED_B3_MAPPINGS = {
     for mapping in json.loads(B3_RECEIPT_PATH.read_text(encoding="utf-8"))["mappings"]
 }
 
+EXPECTED_SKILL_FEEDBACK_OWNER_MAPPINGS = {
+    "legacy..claude.skills.feedback.SKILL.md": ".claude/skills/skill-feedback/SKILL.md",
+    "legacy..claude.skills.feedback.references.upstream-issue-template.md": (
+        ".claude/skills/skill-feedback/references/upstream-issue-template.md"
+    ),
+}
+
 EXPECTED_GROUP_EVIDENCE = {
     "C-01": "unreferenced after consumer search",
     "C-02": "unreferenced after consumer search",
@@ -137,6 +144,19 @@ def test_b6_receipt_accounts_for_every_old_owner_without_duplicates() -> None:
 
     mapping_pairs = {(mapping["old_owner"], mapping["exact_new_owner"]) for mapping in mappings}
     assert EXPECTED_B3_MAPPINGS <= mapping_pairs
+
+
+def test_b6_receipt_maps_historical_feedback_owners_to_skill_feedback() -> None:
+    mappings = _read_receipt().get("mappings")
+    assert isinstance(mappings, list)
+
+    actual = {
+        mapping["old_owner"]: mapping["exact_new_owner"]
+        for mapping in mappings
+        if isinstance(mapping, dict) and mapping.get("old_owner") in EXPECTED_SKILL_FEEDBACK_OWNER_MAPPINGS
+    }
+
+    assert actual == EXPECTED_SKILL_FEEDBACK_OWNER_MAPPINGS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- B6 receiptのexact_new_owner 2件をnew SKILL/templateへ移行
- historical old_ownerを維持
- canonical owner contractを回帰テストで固定

## Verification

- uv run pytest -q tests/repo/test_b6_integration_contract.py
- uv run yt-skills lint
- uv run ruff check .
- uv run ruff format --check .

Closes #3187
Depends on #3186