### PR TITLE
docs(skill-feedback): public routes を新コマンドへ移行する (#3188)

### DIFF
--- a/.claude/CLAUDE.template.md
+++ b/.claude/CLAUDE.template.md
@@ -58,7 +58,7 @@ Claude はこのリポジトリ上で **「BGM チャンネルを運営して収
 スキル選択は各 `.claude/skills/<name>/SKILL.md` の `description` を正とする。全カタログは [`docs/features.md`](../docs/features.md)。
 
 - workflow 起点の質問（`/wf-new` `/wf-next` `/wf-status` `/collection-ideate`、「次なに作る？」「制作どこまで進んだ？」「`workflow-state.json` 触っていい？」）をセッション内で初めて受けたら、skill 実行に進む前に [`docs/workflow-cheatsheet.md`](../docs/workflow-cheatsheet.md) の判定フローと `workflow-state.json` の扱いを **1 回だけ**提示する（同一セッション内で繰り返さない）
-- スキル実行中に不具合・摩擦・改善案に遭遇したら `/feedback` を案内する
+- スキル実行中に不具合・摩擦・改善案に遭遇したら `/skill-feedback` を案内する
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `docs(streaming)`: `/streaming` の Quick Reference にチャンネル別 Terraform workspace の確認・作成・切替入口を追加し、切替後のチャンネル固有 `TF_VAR_*` 再注入と README 正本への導線を明示した（#3184）。
+- `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/docs/features.md
+++ b/docs/features.md
@@ -121,7 +121,7 @@ YouTube Analytics と動画本体の解析。
 | /automation-release | 本リポジトリの新規リリースを作成（prepare → publish の 2 フェーズ） |
 | /automation-update | 下流チャンネルを upstream 最新版に追従（pin bump + `yt-skills sync` + 動作確認） |
 | /ext-install | Chrome 拡張（suno-helper / distrokid-helper / community-helper）の初回インストールまたは更新ガイド |
-| /feedback | スキル実行中の不具合・摩擦・改善案を append-only JSONL に構造化記録 |
+| /skill-feedback | スキル実行中の不具合・摩擦・改善案を append-only JSONL に構造化記録 |
 | /shadcn | `components.json` を読み、公式docs・registry差分を基準にshadcn/ui componentを追加・更新・監査 |
 
 ---


### PR DESCRIPTION
## Summary

- distributed templateとfeatures catalogを /skill-feedback へ移行
- data path/schema reference/feedback labelを維持
- old /feedback operator routeを除去

## Verification

- uv run pytest -q tests/repo/test_skills_rename.py
- uv run yt-skills lint
- uv run ruff check .
- uv run ruff format --check .

Closes #3188
Depends on #3187