### PR TITLE
fix(skills-sync): legacy feedback skill を既知の prune 対象にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `docs(streaming)`: `/streaming` の Quick Reference にチャンネル別 Terraform workspace の確認・作成・切替入口を追加し、切替後のチャンネル固有 `TF_VAR_*` 再注入と README 正本への導線を明示した（#3184）。
+- `fix(skills-sync)`: legacy `feedback` skill を既知の削除対象へ追加し、`yt-skills sync --prune --yes` でのみ削除するようにした（#3189）。
 - `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。

--- a/src/youtube_automation/commands/system/skills_sync/_ops.py
+++ b/src/youtube_automation/commands/system/skills_sync/_ops.py
@@ -38,6 +38,7 @@ _KNOWN_REMOVED_SKILL_NAMES = frozenset(
         "channel-direction",
         "automation-release",
         "shadcn",
+        "feedback",
     }
 )
 

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -844,6 +844,35 @@ def test_cmd_sync_prune_removes_orphan_dir_when_yes(fake_repo: Path, tmp_path: P
 
 
 @pytest.mark.parametrize(
+    ("prune_flags", "feedback_exists"),
+    [
+        pytest.param([], True, id="normal-sync-keeps"),
+        pytest.param(["--prune"], True, id="unapproved-prune-keeps"),
+        pytest.param(["--prune", "--yes"], False, id="approved-prune-removes"),
+    ],
+)
+def test_cmd_sync_legacy_feedback_prune_requires_explicit_yes(
+    fake_repo: Path,
+    tmp_path: Path,
+    prune_flags: list[str],
+    feedback_exists: bool,
+) -> None:
+    """legacy feedback は明示承認した prune でだけ削除する。"""
+    target = tmp_path / "out" / ".claude" / "skills"
+    _seed_bundled_target(target)
+    legacy_feedback = target / "feedback"
+    legacy_feedback.mkdir()
+    (legacy_feedback / "SKILL.md").write_text("# legacy feedback\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force", *prune_flags])
+    rc = args.func(args)
+
+    assert rc == 0
+    assert legacy_feedback.exists() is feedback_exists
+
+
+@pytest.mark.parametrize(
     "skill_name",
     ["onboard", "distrokid-prep", "channel-import", "channel-setup", "channel-direction"],
 )


### PR DESCRIPTION
## 概要

承認済み prune のときだけ旧 feedback skill を削除対象として扱います。

Closes #3189
Parent: #2528

## 変更内容

- feedback を既知の削除済み skill 名へ追加
- normal sync と未承認 prune では保持する regression test を追加
- unknown custom skill の保護を維持
- CHANGELOG を更新

## 検証

- skills-sync / wheel tests: 82 passed
- yt-skills lint: 58 passed
- Ruff check / format: passed
- Any gate / diff-check: passed

## チェックリスト

- [x] CHANGELOG.md の Unreleased を更新
- [x] 必要なテストを追加
- [x] 1 branch 1 commit