### PR TITLE
fix(suno-helper): feed 欠落 clip を単体 API で補完する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(skills-sync)`: legacy `feedback` skill を既知の削除対象へ追加し、`yt-skills sync --prune --yes` でのみ削除するようにした（#3189）。
 - `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
+- `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/extensions/suno-helper/entrypoints/suno-bridge.content.ts
+++ b/extensions/suno-helper/entrypoints/suno-bridge.content.ts
@@ -38,6 +38,8 @@ import {
   setSliderValueViaReact,
 } from "../lib/slider-bridge";
 
+const CLIP_PATH_PREFIX = "/api/clip/";
+
 export default defineContentScript({
   matches: [...SUNO_MATCHES],
   // ページの最初の fetch（認証付き）から token を捕捉できるよう document_start で注入する。
@@ -117,6 +119,53 @@ export default defineContentScript({
     Object.assign(observedFetch, originalFetch);
     window.fetch = observedFetch as typeof fetch;
 
+    function isEmptyFeedResponse(json: unknown): boolean {
+      if (Array.isArray(json)) {
+        return json.length === 0;
+      }
+      if (typeof json !== "object" || json === null) {
+        return false;
+      }
+      const clips = (json as { clips?: unknown }).clips;
+      return Array.isArray(clips) && clips.length === 0;
+    }
+
+    async function lookupMissingClips(
+      ids: string[],
+      found: Map<string, ObservedClip>
+    ): Promise<ObservedClip[] | null> {
+      for (const id of ids) {
+        if (found.has(id)) {
+          continue;
+        }
+        const authorization = authHeader;
+        if (!authorization) {
+          return null;
+        }
+        try {
+          const response = await originalFetch(
+            `${SUNO_API_ORIGIN}${CLIP_PATH_PREFIX}${encodeURIComponent(id)}`,
+            { headers: { authorization } }
+          );
+          if (response.status === 401) {
+            authHeader = null;
+            return null;
+          }
+          if (!response.ok) {
+            continue;
+          }
+          const clips = parseClipsFromFeedResponse([await response.json()]);
+          const clip = clips?.find((candidate) => candidate.id === id);
+          if (clip) {
+            found.set(id, clip);
+          }
+        } catch {
+          // Suno の個別 clip 観測失敗は、他 ID の終端観測を妨げない。
+        }
+      }
+      return [...found.values()];
+    }
+
     /** content script からの active feed poll 要求に応える。token 未捕捉・失敗は clips: null。 */
     async function handleFeedPoll(
       requestId: number,
@@ -153,7 +202,9 @@ export default defineContentScript({
             return;
           }
           const json = await res.json();
-          const clips = parseClipsFromFeedResponse(json);
+          const clips =
+            parseClipsFromFeedResponse(json) ??
+            (isEmptyFeedResponse(json) ? [] : null);
           if (clips === null) {
             respond(null);
             return;
@@ -172,13 +223,13 @@ export default defineContentScript({
               ? (json as { next_cursor?: unknown }).next_cursor
               : undefined;
           if (typeof nextCursor !== "string" || nextCursor.length === 0) {
-            respond([...found.values()]);
+            respond(await lookupMissingClips(ids, found));
             return;
           }
           cursor = nextCursor;
           await sleep(FEED_V3_PAGE_DELAY_MS);
         }
-        respond([...found.values()]);
+        respond(await lookupMissingClips(ids, found));
       } catch {
         respond(null);
       }

--- a/extensions/suno-helper/tests/suno-bridge.test.ts
+++ b/extensions/suno-helper/tests/suno-bridge.test.ts
@@ -357,4 +357,153 @@ describe("suno-bridge fetch interceptor", () => {
     expect(FEED_V3_PAGE_DELAY_MS).toBe(1000);
     vi.useRealTimers();
   });
+
+  it("Given feed に error clip が現れない When active poll request を受ける Then 欠落 ID だけを単体照会して返す", async () => {
+    const originalFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ clips: [{ id: "complete", status: "complete" }] })
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: "failed", status: "error" }));
+    vi.stubGlobal("fetch", originalFetch);
+    const postMessage = vi
+      .spyOn(window, "postMessage")
+      .mockImplementation(() => undefined);
+
+    await loadBridge();
+    await window.fetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+      method: FEED_V3_METHOD,
+      headers: { authorization: "Bearer token" },
+    });
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window,
+        data: {
+          source: BRIDGE_SOURCE,
+          type: BRIDGE_MSG.FEED_V3_POLL_REQUEST,
+          requestId: 125,
+          ids: ["complete", "failed"],
+        },
+      })
+    );
+
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: BRIDGE_MSG.FEED_V3_POLL_RESPONSE,
+          requestId: 125,
+          clips: [
+            { id: "complete", status: "complete" },
+            { id: "failed", status: "error" },
+          ],
+        }),
+        window.location.origin
+      )
+    );
+    expect(originalFetch).toHaveBeenNthCalledWith(
+      3,
+      `${SUNO_API_ORIGIN}/api/clip/failed`,
+      { headers: { authorization: "Bearer token" } }
+    );
+    expect(
+      originalFetch.mock.calls.filter(([url]) =>
+        String(url).includes("/api/clip/complete")
+      )
+    ).toHaveLength(0);
+  });
+
+  it("Given 一部の単体照会が失敗する When 複数 ID を補完する Then 残りの ID は順次観測する", async () => {
+    const originalFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ id: "failed-b", status: "error" }));
+    vi.stubGlobal("fetch", originalFetch);
+    const postMessage = vi
+      .spyOn(window, "postMessage")
+      .mockImplementation(() => undefined);
+
+    await loadBridge();
+    await window.fetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+      method: FEED_V3_METHOD,
+      headers: { authorization: "Bearer token" },
+    });
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window,
+        data: {
+          source: BRIDGE_SOURCE,
+          type: BRIDGE_MSG.FEED_V3_POLL_REQUEST,
+          requestId: 126,
+          ids: ["failed-a", "failed-b"],
+        },
+      })
+    );
+
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: BRIDGE_MSG.FEED_V3_POLL_RESPONSE,
+          requestId: 126,
+          clips: [{ id: "failed-b", status: "error" }],
+        }),
+        window.location.origin
+      )
+    );
+    expect(originalFetch).toHaveBeenNthCalledWith(
+      3,
+      `${SUNO_API_ORIGIN}/api/clip/failed-a`,
+      { headers: { authorization: "Bearer token" } }
+    );
+    expect(originalFetch).toHaveBeenNthCalledWith(
+      4,
+      `${SUNO_API_ORIGIN}/api/clip/failed-b`,
+      { headers: { authorization: "Bearer token" } }
+    );
+  });
+
+  it("Given 単体照会が 401 When 次の active poll を受ける Then token 再捕捉まで fetch しない", async () => {
+    const originalFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(jsonResponse({ clips: [] }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", originalFetch);
+    const postMessage = vi
+      .spyOn(window, "postMessage")
+      .mockImplementation(() => undefined);
+
+    await loadBridge();
+    await window.fetch(`${SUNO_API_ORIGIN}${FEED_V3_PATH}`, {
+      method: FEED_V3_METHOD,
+      headers: { authorization: "Bearer token" },
+    });
+    for (const requestId of [127, 128]) {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: window,
+          data: {
+            source: BRIDGE_SOURCE,
+            type: BRIDGE_MSG.FEED_V3_POLL_REQUEST,
+            requestId,
+            ids: ["failed"],
+          },
+        })
+      );
+      await vi.waitFor(() =>
+        expect(postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: BRIDGE_MSG.FEED_V3_POLL_RESPONSE,
+            requestId,
+            clips: null,
+          }),
+          window.location.origin
+        )
+      );
+    }
+
+    expect(originalFetch).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## 概要

feed/v3 に欠落した clip ID を single-clip API で補完し、status=error を tracker が観測できるようにします。

Closes #3203
Parent: #2543

## 変更内容

- feed に欠落した ID のみ /api/clip/<encoded-id> へ逐次照会
- empty feed を正常な欠落として処理
- 401 は auth を破棄し、個別 500/不正応答は残りの照会を継続
- regression tests と CHANGELOG を追加

## 検証

- focused: 11 passed
- suno-helper: 72 files / 1344 tests passed
- compile / ultracite / Ruff / Any / diff-check: passed
- Fallow: no issues in 3 changed files
