### PR TITLE
refactor(suno-helper): 生成失敗 clip ID を公開する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(skills-sync)`: legacy `feedback` skill を既知の削除対象へ追加し、`yt-skills sync --prune --yes` でのみ削除するようにした（#3189）。
 - `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
+- `refactor(suno-helper)`: clip tracker から、この run で投入し最新 status が `error` の clip ID を投入順で取得できるようにした。あわせて、reload 後の保存済み clip のように投入登録がない ID も、明示した ID 集合に対する最新 status から失敗を取得できるようにした。失敗集合は正規 status から都度導出し、既存の pending・in-flight・playlist 候補契約を変えない（#3204）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/extensions/suno-helper/lib/clip-tracker.ts
+++ b/extensions/suno-helper/lib/clip-tracker.ts
@@ -14,6 +14,7 @@ import {
 } from "../../shared/constants";
 
 const TERMINAL = new Set<string>(TERMINAL_CLIP_STATUSES);
+const FAILED_CLIP_STATUS = "error";
 
 export interface ClipTracker {
   /** generate レスポンス観測（= この run の投入受理）。submission count を進め、clip を登録する。 */
@@ -37,6 +38,10 @@ export interface ClipTracker {
   getPendingSubmittedIds(): string[];
   /** この run の generate レスポンスで観測した clip id 一覧。playlist 対象の SSOT。 */
   getSubmittedIds(): string[];
+  /** この run で投入し、最新の観測 status が error の clip id 一覧。 */
+  getFailedSubmittedIds(): string[];
+  /** 指定した id のうち、最新の観測 status が error の id 一覧。 */
+  getFailedIdsByIds(ids: string[]): string[];
   /** duration yield guard を通過した submitted clip id を記録する。 */
   markAccepted(ids: string[]): void;
   /** duration yield guard を通過した submitted clip id 一覧。 */
@@ -162,6 +167,14 @@ export function createClipTracker(now: () => number = Date.now): ClipTracker {
     },
     getSubmittedIds() {
       return Array.from(submittedById.keys());
+    },
+    getFailedSubmittedIds() {
+      return Array.from(submittedById.keys()).filter(
+        (id) => statusById.get(id) === FAILED_CLIP_STATUS
+      );
+    },
+    getFailedIdsByIds(ids) {
+      return ids.filter((id) => statusById.get(id) === FAILED_CLIP_STATUS);
     },
     markAccepted(ids) {
       for (const id of ids) {

--- a/extensions/suno-helper/tests/clip-tracker.test.ts
+++ b/extensions/suno-helper/tests/clip-tracker.test.ts
@@ -144,6 +144,77 @@ describe("createClipTracker: status ベースの in-flight 集計", () => {
 });
 
 describe("createClipTracker: playlist 対象 submitted ID 管理", () => {
+  it("Given fresh tracker が保存済み ID の requested status を観測 When 明示 ID を読む Then registerSubmitted なしでも error ID を返す", () => {
+    const tracker = createClipTracker();
+    tracker.applyRequestedStatuses([
+      { id: "saved-complete", status: "complete" },
+      { id: "saved-error", status: "error" },
+    ]);
+
+    expect(
+      tracker.getFailedIdsByIds([
+        "saved-complete",
+        "saved-error",
+        "not-observed",
+      ])
+    ).toEqual(["saved-error"]);
+    expect(tracker.getFailedSubmittedIds()).toEqual([]);
+  });
+
+  it("Given submitted clip の一部が error When 読む Then 失敗 ID だけを投入順で返す", () => {
+    const tracker = createClipTracker();
+
+    tracker.registerSubmitted([
+      { id: "failed-a", status: "submitted" },
+      { id: "complete", status: "submitted" },
+      { id: "failed-b", status: "submitted" },
+    ]);
+    tracker.applyRequestedStatuses([
+      { id: "failed-b", status: "error" },
+      { id: "complete", status: "complete" },
+      { id: "failed-a", status: "error" },
+      { id: "passive", status: "error" },
+    ]);
+
+    expect(tracker.getFailedSubmittedIds()).toEqual(["failed-a", "failed-b"]);
+    expect(tracker.getSubmittedIds()).toEqual([
+      "failed-a",
+      "complete",
+      "failed-b",
+    ]);
+    expect(tracker.getPendingSubmittedIds()).toEqual([]);
+  });
+
+  it("Given error clip の status が更新される When 読む Then 失敗 ID から外す", () => {
+    const tracker = createClipTracker();
+    tracker.registerSubmitted([{ id: "recovered", status: "submitted" }]);
+    tracker.applyRequestedStatuses([{ id: "recovered", status: "error" }]);
+    expect(tracker.getFailedSubmittedIds()).toEqual(["recovered"]);
+
+    tracker.applyRequestedStatuses([{ id: "recovered", status: "streaming" }]);
+
+    expect(tracker.getFailedSubmittedIds()).toEqual([]);
+    expect(tracker.getPendingSubmittedIds()).toEqual(["recovered"]);
+  });
+
+  it("Given error clip を drop または clear When 読む Then 失敗 ID を返さない", () => {
+    const tracker = createClipTracker();
+    tracker.registerSubmitted([
+      { id: "dropped", status: "submitted" },
+      { id: "cleared", status: "submitted" },
+    ]);
+    tracker.applyRequestedStatuses([
+      { id: "dropped", status: "error" },
+      { id: "cleared", status: "error" },
+    ]);
+
+    tracker.dropSubmittedIds(["dropped"]);
+    expect(tracker.getFailedSubmittedIds()).toEqual(["cleared"]);
+
+    tracker.clearSubmittedIds();
+    expect(tracker.getFailedSubmittedIds()).toEqual([]);
+  });
+
   it("Given generate 観測が複数回ある When 読む Then submitted ID を初回観測順で重複なく返す", () => {
     const tracker = createClipTracker();
 


### PR DESCRIPTION
## 概要

tracker の submitted clip 最新 status から生成失敗 ID を投入順で導出する SSOT API を追加します。

Closes #3204
Parent: #2543

## 変更内容

- getFailedSubmittedIds を追加
- complete、未終端、passive unknown を除外
- status update、drop、clear に追随
- regression tests と CHANGELOG を追加

## 検証

- focused: 19 passed
- suno-helper: 72 files / 1347 tests passed
- compile / ultracite / Ruff / Any / diff-check: passed
- Fallow: no issues
