### PR TITLE
fix(suno-helper): 安全モードで error entry を除外する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
 - `refactor(suno-helper)`: clip tracker から、この run で投入し最新 status が `error` の clip ID を投入順で取得できるようにした。あわせて、reload 後の保存済み clip のように投入登録がない ID も、明示した ID 集合に対する最新 status から失敗を取得できるようにした。失敗集合は正規 status から都度導出し、既存の pending・in-flight・playlist 候補契約を変えない（#3204）。
+- `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -1473,10 +1473,20 @@ export default defineContentScript({
         isAborted,
         now: Date.now,
       });
-      return evaluateClips(
-        clipIds.map((id) => ({ id, duration: tracker.getDuration(id) })),
-        durationFilter
-      );
+      const failedSubmittedIds = new Set(tracker.getFailedSubmittedIds());
+      const failedClipIds = clipIds.filter((id) => failedSubmittedIds.has(id));
+      return failedClipIds.length > 0
+        ? { kind: "generation-failed" as const, failedClipIds }
+        : {
+            kind: "evaluated" as const,
+            evaluation: evaluateClips(
+              clipIds.map((id) => ({
+                id,
+                duration: tracker.getDuration(id),
+              })),
+              durationFilter
+            ),
+          };
     }
 
     interface RunOptions {
@@ -1932,7 +1942,7 @@ export default defineContentScript({
               options.durationFilter ?? DEFAULT_DURATION_FILTER;
             let attemptResult;
             try {
-              const evaluation = await evaluateAttemptYield(
+              const yieldResult = await evaluateAttemptYield(
                 attemptClipIds,
                 durationFilter,
                 () => aborted
@@ -1951,7 +1961,25 @@ export default defineContentScript({
                 });
                 return;
               }
-              attemptResult = { kind: "evaluated" as const, evaluation };
+              if (yieldResult.kind === "generation-failed") {
+                const message = `生成に失敗した clip を検出しました (status=error): ${yieldResult.failedClipIds.join(", ")}`;
+                tracker.dropSubmittedIds(attemptClipIds);
+                failedIndices.push(i);
+                console.warn(`[suno-helper] entry ${i}: ${message}`);
+                emitProgress({
+                  phase: PHASE.ENTRY_FAILED,
+                  index: i,
+                  total,
+                  message,
+                  yieldRetryCount,
+                  log: {
+                    kind: "skip",
+                    entryName: entryDisplayName(entries[i]),
+                  },
+                });
+                break;
+              }
+              attemptResult = yieldResult;
             } catch (err) {
               attemptResult = {
                 kind: "evaluation-failed" as const,

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -85,6 +85,7 @@ const harness = vi.hoisted(() => {
     readUnattendedRunState: vi.fn(() => Promise.resolve(null)),
     requestSliderSet: vi.fn(),
     submittedClipIds: [] as string[],
+    failedClipIds: [] as string[],
     acceptedClipIds: [] as string[],
     droppedClipIds: [] as string[],
     durationsById: {} as Record<string, number | undefined>,
@@ -189,6 +190,7 @@ vi.mock("../lib/clip-tracker", () => ({
   createClipTracker: vi.fn(() => ({
     clearSubmittedIds: vi.fn(),
     getSubmittedIds: vi.fn(() => harness.submittedClipIds),
+    getFailedSubmittedIds: vi.fn(() => harness.failedClipIds),
     getPendingSubmittedIds: vi.fn(() => []),
     getPendingIdsByIds: vi.fn((ids: string[]) =>
       ids.filter((id) => harness.pendingClipIds.includes(id))
@@ -588,6 +590,7 @@ beforeEach(() => {
   harness.downloadBestEffortResult.mockReset();
   harness.downloadBestEffortResult.mockResolvedValue({ error: null });
   harness.submittedClipIds = [];
+  harness.failedClipIds = [];
   harness.acceptedClipIds = [];
   harness.droppedClipIds = [];
   harness.durationsById = {};
@@ -2655,6 +2658,68 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
           acceptedClipIds: ["serial-on-3-a", "serial-on-3-b"],
           yieldRetryCount: 2,
         }),
+      ])
+    );
+  });
+
+  it("Given serial mode で error clip を観測 When 実行する Then 再生成せず失敗 entry として後続へ進む", async () => {
+    makeViewButton("Grid");
+    makeTextarea(null);
+    makeTextarea("lyrics-textarea");
+    let generationCount = 0;
+    makeGenerateButtonWithClickObserver(() => {
+      generationCount += 1;
+      appendSubmittedClipIdsForRequest(
+        generationCount === 1 ? "serial-error" : "serial-complete"
+      );
+    });
+    addCompletedRemixCard();
+    await loadContentScript();
+    const entries = makePromptEntries(2);
+    const payload = makeRunPayload(entries);
+    harness.submittedClipIds = [];
+    harness.failedClipIds = ["serial-error-1"];
+    harness.durationErrorsById = {
+      "serial-error-1": new Error("error clip の duration は評価しない"),
+    };
+
+    expect(getRunHandler()({ data: payload })).toEqual({ ok: true });
+
+    await vi.waitFor(
+      () => expect(harness.feedPollerStop).toHaveBeenCalledOnce(),
+      { timeout: 3000 }
+    );
+    expect(generationCount).toBe(2);
+    expect(harness.droppedClipIds).toEqual([
+      "serial-error-1",
+      "serial-error-2",
+    ]);
+    expect(harness.acceptedClipIds).toEqual([
+      "serial-complete-1",
+      "serial-complete-2",
+    ]);
+    expect(progressPayloads()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: PHASE.ENTRY_FAILED,
+          index: 0,
+          message: expect.stringContaining("status=error"),
+          log: { kind: "skip", entryName: "pattern-1" },
+        }),
+        expect.objectContaining({
+          phase: PHASE.DONE,
+          index: 1,
+          acceptedClipIds: ["serial-complete-1", "serial-complete-2"],
+        }),
+        expect.objectContaining({
+          phase: PHASE.FINISHED,
+          message: expect.stringContaining("失敗分のみ再実行"),
+        }),
+      ])
+    );
+    expect(progressPayloads()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: PHASE.ADDING_TO_PLAYLIST }),
       ])
     );
   });


### PR DESCRIPTION
## 概要

安全モードで error clip を含む attempt を再生成せず ENTRY_FAILED として除外し、後続 entry を継続します。

Closes #3205
Parent: #2543

## 変更内容

- attempt IDs と tracker failed IDs の交差を duration 判定前に検出
- error があれば attempt 全 clip を drop
- ENTRY_FAILED と failedIndices に記録し再実行導線を維持
- 後続 entry は継続

## 検証

- TDD RED to GREEN
- focused: 78 passed
- suno-helper: 72 files / 1348 tests passed
- compile / ultracite / Ruff / Any / diff-check: passed
- Fallow: no issues
