### PR TITLE
fix(videoup): popup相対パスをチャンネルルートから解決する

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -492,6 +492,7 @@ fi
 # どれか 1 つでも欠ければ既存 stream copy 経路へフォールバックする。
 OVERLAYS_ENABLED=0
 OVERLAYS_CONFIG_PATH=""
+OVERLAYS_CHANNEL_ROOT=""
 
 resolve_overlays_config() {
     if [[ -n "${OVERLAYS_CONFIG:-}" && -f "$OVERLAYS_CONFIG" ]]; then
@@ -516,6 +517,23 @@ resolve_overlays_config() {
     done
 }
 
+resolve_overlays_channel_root() {
+    local config_path="$1"
+    case "$config_path" in
+        */config/channel/youtube.json)
+            local channel_root="${config_path%/config/channel/youtube.json}"
+            [[ -n "$channel_root" ]] || channel_root="/"
+            if [[ -d "$channel_root" ]]; then
+                (cd "$channel_root" && pwd)
+                return
+            fi
+            ;;
+    esac
+    if [[ -n "${CHANNEL_DIR:-}" && -d "$CHANNEL_DIR" ]]; then
+        (cd "$CHANNEL_DIR" && pwd)
+    fi
+}
+
 if [[ -n "${VIDEOUP_OVERLAYS:-}" && "${VIDEOUP_OVERLAYS}" != "0" && "${VIDEOUP_OVERLAYS}" != "1" ]]; then
     echo "ERROR: VIDEOUP_OVERLAYS must be 0 or 1 (got: ${VIDEOUP_OVERLAYS})"
     exit 1
@@ -528,6 +546,7 @@ elif [[ -n "$OVERLAYS_CLI_OVERRIDE" ]]; then
 elif command -v jq &>/dev/null; then
     OVERLAYS_CONFIG_PATH="$(resolve_overlays_config)"
     if [[ -n "$OVERLAYS_CONFIG_PATH" ]]; then
+        OVERLAYS_CHANNEL_ROOT="$(resolve_overlays_channel_root "$OVERLAYS_CONFIG_PATH")"
         ov_enabled="$(jq -r '(.overlays.enabled // false) | tostring' "$OVERLAYS_CONFIG_PATH" 2>/dev/null)"
         if [[ "$ov_enabled" == "true" ]]; then
             OVERLAYS_ENABLED=1
@@ -966,6 +985,8 @@ if [[ "$OVERLAYS_ENABLED" -eq 1 ]]; then
             sp_path="${ASSETS_DIR}/${sp_image}"
         elif [[ -f "${COLLECTION_DIR}/${sp_image}" ]]; then
             sp_path="${COLLECTION_DIR}/${sp_image}"
+        elif [[ -n "$OVERLAYS_CHANNEL_ROOT" && -f "${OVERLAYS_CHANNEL_ROOT}/${sp_image}" ]]; then
+            sp_path="${OVERLAYS_CHANNEL_ROOT}/${sp_image}"
         fi
         if [[ -z "$sp_path" || ! -f "$sp_path" ]]; then
             echo "ERROR: subscribe popup image not found: ${sp_image}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(distrokid-helper)`: dir mode のコレクション選択表示を `アルバム名（曲数）` へ簡略化し、選択中ラベルの省略表示と候補一覧の横 overflow 防止を追加。表示と独立した `collection_id / disc` の選択 identity は維持した（#2515）。
 - `fix(suno-helper)`: Suno ZIP の clip 名に含まれる em-dash 周りの空白差・全角空白・`(1)` / `_1` 重複 suffix を prompts の同一 entry として照合し、配置 skip を防ぐようにした（#3002）。
 - `fix(suno-helper)`: localhost mutation の失敗時に、後続の serve token 再取得エラーで上書きせず、元の request の method・path・status を構造化エラーとして保持するようにした（#3000）。
+- `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
+
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -2158,6 +2158,42 @@ def test_enabled_subscribe_popup_with_missing_image_fails_before_ffmpeg(tmp_path
     assert not (collection / "01-master" / "Ambient-Master.mp4").exists()
 
 
+def test_subscribe_popup_resolves_relative_to_canonical_channel_root(tmp_path: Path) -> None:
+    """#3208: nested workspace の popup は選択チャンネルの branding から解決する。"""
+    channel_root = tmp_path / "workspace with spaces" / "channels" / "focus"
+    collection = _create_collection(channel_root / "collections" / "planning")
+    popup = channel_root / "branding" / "subscribe-popup.png"
+    popup.parent.mkdir(parents=True)
+    popup.write_bytes(b"fake-popup")
+    config = channel_root / "config" / "channel" / "youtube.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "overlays": {
+                    "enabled": True,
+                    "audio_visualizer": {"enabled": False},
+                    "subscribe_popup": {
+                        "enabled": True,
+                        "image": "branding/subscribe-popup.png",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result, ffmpeg_log = _run_generate_videos(
+        tmp_path,
+        "1920,1080,yuv420p,24/1",
+        extra_env={"CHANNEL_DIR": ""},
+        collection=collection,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert str(popup) in _filter_complex_command(ffmpeg_log)
+
+
 def test_no_preview_keeps_master_output_contract(tmp_path: Path) -> None:
     """#1749: --preview 無しの既存 CLI は Master 出力を維持する。"""
     collection = _create_collection(tmp_path)


### PR DESCRIPTION
## 概要

videoup の popup 相対パスを実行 cwd ではなくチャンネルルートから解決します。

Closes #3208
Parent: #2580
Blocked by #2579; predecessor ready PR #3111

## 変更内容

- popup 相対パスの基準を channel root へ変更
- multi-channel workspace からの実行を regression test で固定
- CHANGELOG を更新

## 検証

- TDD RED to GREEN
- videoup tests: 112 passed
- yt-skills lint: 57 passed
- bash -n / Ruff / Any / diff-check: passed
