### PR TITLE
docs(videoup): popup探索順とチャンネルルート契約を明記する

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -256,7 +256,7 @@ runtime mask helper は script 内から `uv run python -m youtube_automation.in
 
 - **jq 必須**: `jq` が PATH に無いときは overlays は自動 disable され既存経路で動く。
 - **設定ファイル探索順**: `OVERLAYS_CONFIG` 環境変数 → `CHANNEL_DIR/config/channel/youtube.json` → コレクションディレクトリの祖先探索。
-- **popup 画像探索順**: 絶対パス → `10-assets/<image>` → `<collection-dir>/<image>`。見つからない場合は popup のみスキップして visualizer は実行する。
+- **popup 画像探索順**: 絶対パス → `10-assets/<image>` → `<collection-dir>/<image>` → `<channel-root>/<image>`。`<channel-root>` は `CHANNEL_DIR` または canonical `config/channel/youtube.json` の配置先から確定するため、マルチチャンネル workspace で `branding/subscribe-popup.png` を指定すると選択チャンネル配下の画像を使う。見つからない場合はエラー終了し、popup を欠いた動画を生成しない。
 - **再エンコード固定**: overlays 経路は `-c:v copy` 不可。`encoder.crf` / `maxrate` / `bufsize` で品質とサイズを制御する（DeepFocus365 で 70 分マスター = 約 1.0 GB / 2 Mbps 実績）。
 - **hardware encode は明示 opt-in**: `encoder.codec: "hardware"` で macOS は `h264_videotoolbox`、対応 NVIDIA 環境は `h264_nvenc` を選ぶ。特定 codec の明示指定も可能。利用不能または 1-frame 起動 probe 失敗時は `libx264` へ戻り、requested / selected と理由をログへ出す。既定は引き続き `libx264`。
 - **codec 固有引数**: `libx264` は preset / CRF、VideoToolbox は bitrate、NVENC は `p5` / CQ を使う。H.264 / yuv420p / profile / maxrate / bufsize / fps の出力契約は共通。

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -1223,6 +1223,24 @@ def test_videoup_skill_documents_current_overlay_support() -> None:
     assert "#511 の実装を待つ" not in skill
 
 
+def test_videoup_skill_documents_subscribe_popup_path_resolution_order() -> None:
+    """#3209: popup の実行契約は runtime と同じ探索順と失敗条件を示す。"""
+    skill = _VIDEOUP_SKILL_PATH.read_text(encoding="utf-8")
+    contract = next(line for line in skill.splitlines() if line.startswith("- **popup 画像探索順**:"))
+    ordered_paths = (
+        "絶対パス",
+        "`10-assets/<image>`",
+        "`<collection-dir>/<image>`",
+        "`<channel-root>/<image>`",
+    )
+
+    indexes = [contract.index(path) for path in ordered_paths]
+    assert indexes == sorted(indexes)
+    assert "`branding/subscribe-popup.png`" in contract
+    assert "選択チャンネル" in contract
+    assert "エラー終了" in contract
+
+
 def _audio_visualizer_env(style: str, **overrides: str) -> dict[str, str]:
     env = {
         "OVERLAY_AV_ENABLED": "true",


### PR DESCRIPTION
## 概要

videoup popup の4段探索順、選択チャンネル基準、見つからない場合の fail-loud 契約を文書化します。

Closes #3209
Parent: #2580

## 変更内容

- 4段の popup 探索順を明記
- multi-channel の選択 channel root 例を追加
- 全候補欠落時の fail-loud を固定
- contract test を更新

## 検証

- TDD RED to GREEN
- videoup tests: 113 passed
- yt-skills lint: 57 passed
- Ruff / Any / diff-check: passed
