### PR TITLE
fix(suno-helper): 高速モードで error entry を除外する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(skill-feedback)`: 配布テンプレートと skill catalog の公開 operator route を `/skill-feedback` へ移行した（#3188）。
 - `refactor(skill-feedback)`: `/feedback` との命名衝突を避ける canonical `/skill-feedback` entrypoint を旧名と並行配置し、B6 integration receipt の owner を新 skill と issue template へ移した（#3187）。
 - `refactor(suno-helper)`: clip tracker から、この run で投入し最新 status が `error` の clip ID を投入順で取得できるようにした。あわせて、reload 後の保存済み clip のように投入登録がない ID も、明示した ID 集合に対する最新 status から失敗を取得できるようにした。失敗集合は正規 status から都度導出し、既存の pending・in-flight・playlist 候補契約を変えない（#3204）。
+- `fix(suno-helper)`: 高速モードの最終完了待ちで `status=error` の clip を検出した場合、対応する entry の sibling clip をまとめて playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした。stall と error が別 entry に混在しても両方を除外して完了済み entry の playlist 追加・ダウンロードを続行し、すべて失敗した場合は playlist を作成しない。保存済み playlist 再試行の error clip と entry に対応付けられない失敗 clip は playlist 操作前に安全に停止する（#3206）。
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -507,6 +507,27 @@ function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload {
   };
 }
 
+function assertNoFailedSavedClips(
+  failedClipIds: string[],
+  submittedClipIds: string[]
+): void {
+  if (failedClipIds.length === 0) {
+    return;
+  }
+  const submittedSet = new Set(submittedClipIds);
+  const unmappedFailedClipIds = failedClipIds.filter(
+    (clipId) => !submittedSet.has(clipId)
+  );
+  if (unmappedFailedClipIds.length > 0) {
+    throw new Error(
+      `生成失敗 clip を保存済み playlist 候補へ対応付けられません: ${unmappedFailedClipIds.join(", ")}`
+    );
+  }
+  throw new Error(
+    `保存済み clip ${failedClipIds.join(", ")} は status=error のため playlist へ追加できません。失敗分のみ再実行してください。`
+  );
+}
+
 function assertRetryDownloadPayload(value: unknown): RetryDownloadPayload {
   const record = assertRecord(value, "retryDownload payload");
   const collectionId = assertNonEmptyString(
@@ -1587,6 +1608,7 @@ export default defineContentScript({
       // 追加して resume/retry 導線へ渡すが、stall のみの失敗では完了済み clip で playlist 追加・
       // download を続行するため、finishWithFailedEntriesIfNeeded の保留判定からは除外する。
       const stalledEntryIndices: number[] = [];
+      const generationFailedEntryIndices: number[] = [];
       let queueClipIdsByEntry: Map<number, string[]> | null = null;
       let keepResumeStateForDownloadRetry = false;
       let downloadSummary: DownloadSummary | undefined;
@@ -1707,8 +1729,11 @@ export default defineContentScript({
         }
         // stall 由来の失敗だけなら playlist 追加を保留しない (#1994)。完了済み clip での
         // graceful degradation（playlist 追加 / download の続行）を優先する。
-        const stalledSet = new Set(stalledEntryIndices);
-        if (failedIndices.every((i) => stalledSet.has(i))) {
+        const degradedSet = new Set([
+          ...stalledEntryIndices,
+          ...generationFailedEntryIndices,
+        ]);
+        if (failedIndices.every((i) => degradedSet.has(i))) {
           return false;
         }
         finishDeferringPlaylistForFailedEntries();
@@ -2197,6 +2222,56 @@ export default defineContentScript({
             return;
           }
         }
+        // stall と status=error は独立した終端状態。timeout した entry を除外した後にも
+        // 残った error entry を評価し、両者が混在する run を同じ partial complete へ収束させる。
+        // 一部の埋め込み先・テスト fixture は旧 tracker shape のままでも動作できるよう、
+        // API が無い場合は従来どおり「失敗 clip なし」として扱う。
+        const failedClipIds = tracker.getFailedSubmittedIds?.() ?? [];
+        if (failedClipIds.length > 0) {
+          if (options.runMode !== "queue" || queueClipIdsByEntry === null) {
+            throw new Error(
+              `生成失敗 clip を queue entry に対応付けられません: ${failedClipIds.join(", ")}`
+            );
+          }
+          const degraded = resolveStalledQueueEntries(
+            failedClipIds,
+            queueClipIdsByEntry
+          );
+          if (degraded.unmappedStalledClipIds.length > 0) {
+            throw new Error(
+              `生成失敗 clip を queue entry に対応付けられません: ${degraded.unmappedStalledClipIds.join(", ")}`
+            );
+          }
+          for (const index of degraded.stalledEntryIndices) {
+            const entryClipIds = queueClipIdsByEntry.get(index) ?? [];
+            tracker.dropSubmittedIds(entryClipIds);
+            queueClipIdsByEntry.delete(index);
+            generationFailedEntryIndices.push(index);
+            failedIndices.push(index);
+            const message = "生成に失敗したためスキップしました (status=error)";
+            console.warn(`[suno-helper] entry ${index}: ${message}`);
+            emitProgress({
+              phase: PHASE.ENTRY_FAILED,
+              index,
+              total,
+              message,
+              yieldRetryCount: 0,
+              log: {
+                kind: "skip",
+                entryName: entryDisplayName(entries[index]),
+              },
+            });
+          }
+          playlistTargetClipCount = countQueuePlaylistClipIds(
+            previousSubmittedClipIds,
+            queueClipIdsByEntry
+          );
+          verifiedPlaylistClipCount = playlistTargetClipCount;
+          if (playlistTargetClipCount === 0) {
+            finishDeferringPlaylistForFailedEntries();
+            return;
+          }
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         persistInterruptState(total);
@@ -2205,10 +2280,13 @@ export default defineContentScript({
       }
       // stall でスキップした entry は生成物が無いため、yield finalize と playlist の title fallback
       // （order と clip ID の位置対応）から除外する (#1994)。
-      const stalledEntrySet = new Set(stalledEntryIndices);
+      const unavailableEntrySet = new Set([
+        ...stalledEntryIndices,
+        ...generationFailedEntryIndices,
+      ]);
       const completedOrder =
-        stalledEntryIndices.length > 0
-          ? order.filter((i) => !stalledEntrySet.has(i))
+        unavailableEntrySet.size > 0
+          ? order.filter((i) => !unavailableEntrySet.has(i))
           : order;
       if (aborted) {
         persistInterruptState(total);
@@ -2391,16 +2469,29 @@ export default defineContentScript({
         emitProgress({ phase: PHASE.STOPPED, total });
         return;
       }
-      // stall でスキップした entry が残る partial complete (#1994)。完了分の playlist 追加・
-      // download は実行済み。stalled entry を「失敗分のみ再実行」導線へ渡すため resume state を
-      // 保持し、消去も完了時リロードも行わない。
-      if (stalledEntryIndices.length > 0) {
+      // 生成物を得られなかった entry が残る partial complete。完了分の playlist 追加・download は
+      // 実行済み。失敗 entry を再実行導線へ渡すため resume state を保持する。
+      if (
+        stalledEntryIndices.length > 0 ||
+        generationFailedEntryIndices.length > 0
+      ) {
         persistInterruptState(total);
-        const list = stalledEntryIndices.map((i) => i + 1).join(", ");
+        const details = [
+          ...(stalledEntryIndices.length > 0
+            ? [
+                `生成停滞: entry ${stalledEntryIndices.map((i) => i + 1).join(", ")}`,
+              ]
+            : []),
+          ...(generationFailedEntryIndices.length > 0
+            ? [
+                `生成失敗 (status=error): entry ${generationFailedEntryIndices.map((i) => i + 1).join(", ")}`,
+              ]
+            : []),
+        ];
         emitProgress({
           phase: PHASE.FINISHED,
           total,
-          message: `${stalledEntryIndices.length} 件の entry が生成停滞のため失敗しました (entry ${list})。完了分の playlist 追加とダウンロードは実行済みです。「失敗分のみ再実行」で残りを生成できます。`,
+          message: `${details.join(" / ")}。完了分の playlist 追加とダウンロードは実行済みです。「失敗分のみ再実行」で残りを生成できます。`,
         });
         return;
       }
@@ -2623,6 +2714,10 @@ export default defineContentScript({
               completion.message ?? "生成完了待ちがタイムアウトしました"
             );
           }
+          assertNoFailedSavedClips(
+            tracker.getFailedIdsByIds?.(submittedClipIds) ?? [],
+            submittedClipIds
+          );
           if (aborted) {
             emitProgress({ phase: PHASE.STOPPED, total: 0 });
             return;

--- a/extensions/suno-helper/tests/content-queue-stall.test.ts
+++ b/extensions/suno-helper/tests/content-queue-stall.test.ts
@@ -32,6 +32,7 @@ async function loadContentScriptWithStalledCompletion(options: {
   initialSubmittedIds: string[];
   clipIdsByEntry: Map<number, string[]>;
   completionResult: SubmittedClipCompletionResult;
+  failedSubmittedIds?: string[];
 }) {
   vi.resetModules();
   vi.stubGlobal(
@@ -126,6 +127,14 @@ async function loadContentScriptWithStalledCompletion(options: {
         submittedIds = [...options.initialSubmittedIds];
       }),
       getSubmittedIds: vi.fn(() => [...submittedIds]),
+      getFailedSubmittedIds: vi.fn(() =>
+        (options.failedSubmittedIds ?? []).filter((id) =>
+          submittedIds.includes(id)
+        )
+      ),
+      getFailedIdsByIds: vi.fn((ids: string[]) =>
+        ids.filter((id) => (options.failedSubmittedIds ?? []).includes(id))
+      ),
       getPendingSubmittedIds: vi.fn(() => []),
       getPendingIdsByIds: vi.fn(() => []),
       getDuration: vi.fn(() => 120),
@@ -253,12 +262,17 @@ async function loadContentScriptWithStalledCompletion(options: {
   if (!runHandler) {
     throw new Error("run message handler was not registered");
   }
+  const retryPlaylistHandler = handlers.get("retryPlaylist");
+  if (!retryPlaylistHandler) {
+    throw new Error("retryPlaylist message handler was not registered");
+  }
   return {
     progressMessages,
     sentMessages,
     scrollAndMultiSelectByIdsMock,
     scheduleRunCompleteReloadMock,
     runHandler,
+    retryPlaylistHandler,
   };
 }
 
@@ -377,6 +391,207 @@ describe("content.ts queue mode stall graceful degradation (#1994)", () => {
     );
     expect(writeResumeStateMock).toHaveBeenCalledWith(
       expect.objectContaining({ failedIndices: [0, 1, 2] })
+    );
+  });
+
+  it("Given 一部 entry に error clip がある When queue run Then 当該 entry を除外して完了分をダウンロードする", async () => {
+    const {
+      progressMessages,
+      sentMessages,
+      scrollAndMultiSelectByIdsMock,
+      scheduleRunCompleteReloadMock,
+      runHandler,
+    } = await loadContentScriptWithStalledCompletion({
+      initialSubmittedIds: allClipIds,
+      clipIdsByEntry: new Map(clipIdsByEntry),
+      failedSubmittedIds: ["clip-1b"],
+      completionResult: {
+        timedOut: false,
+        submittedIds: allClipIds,
+        stalledClipIds: [],
+      },
+    });
+
+    runQueue(runHandler);
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.FINISHED })
+      )
+    );
+
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({
+        phase: PHASE.ENTRY_FAILED,
+        index: 1,
+        message: expect.stringContaining("status=error"),
+        log: { kind: "skip", entryName: "track-2" },
+      })
+    );
+    expect(scrollAndMultiSelectByIdsMock).toHaveBeenCalledWith(
+      ["clip-0a", "clip-0b", "clip-2a", "clip-2b"],
+      expect.anything()
+    );
+    expect(sentMessages).toContainEqual(
+      expect.objectContaining({ type: "startDownload" })
+    );
+    const finished = progressMessages.find(
+      (message) => message.phase === PHASE.FINISHED
+    );
+    expect(finished?.message).toContain("status=error");
+    expect(finished?.message).toContain("失敗分のみ再実行");
+    expect(writeResumeStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ failedIndices: [1] })
+    );
+    expect(clearResumeStateForCollectionMock).not.toHaveBeenCalled();
+    expect(scheduleRunCompleteReloadMock).not.toHaveBeenCalled();
+  });
+
+  it("Given 全 entry に error clip がある When queue run Then playlist を作らず失敗保留にする", async () => {
+    const { progressMessages, scrollAndMultiSelectByIdsMock, runHandler } =
+      await loadContentScriptWithStalledCompletion({
+        initialSubmittedIds: allClipIds,
+        clipIdsByEntry: new Map(clipIdsByEntry),
+        failedSubmittedIds: ["clip-0a", "clip-1a", "clip-2a"],
+        completionResult: {
+          timedOut: false,
+          submittedIds: allClipIds,
+          stalledClipIds: [],
+        },
+      });
+
+    runQueue(runHandler);
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.FINISHED })
+      )
+    );
+
+    expect(scrollAndMultiSelectByIdsMock).not.toHaveBeenCalled();
+    expect(writeResumeStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ failedIndices: [0, 1, 2] })
+    );
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({
+        phase: PHASE.FINISHED,
+        message: expect.stringContaining("失敗分のみ再実行"),
+      })
+    );
+  });
+
+  it("Given error clip が entry mapping にない When queue run Then playlist を作らず ERROR にする", async () => {
+    const { progressMessages, scrollAndMultiSelectByIdsMock, runHandler } =
+      await loadContentScriptWithStalledCompletion({
+        initialSubmittedIds: [...allClipIds, "unmapped-error"],
+        clipIdsByEntry: new Map(clipIdsByEntry),
+        failedSubmittedIds: ["unmapped-error"],
+        completionResult: {
+          timedOut: false,
+          submittedIds: allClipIds,
+          stalledClipIds: [],
+        },
+      });
+
+    runQueue(runHandler);
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.ERROR })
+      )
+    );
+
+    expect(scrollAndMultiSelectByIdsMock).not.toHaveBeenCalled();
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({
+        phase: PHASE.ERROR,
+        message: expect.stringContaining("unmapped-error"),
+      })
+    );
+  });
+
+  it("Given 保存済み clip が status=error When retryPlaylist Then playlist を作らず fail-loud にする", async () => {
+    const {
+      progressMessages,
+      scrollAndMultiSelectByIdsMock,
+      retryPlaylistHandler,
+    } = await loadContentScriptWithStalledCompletion({
+      // reload 後の retryPlaylist は fresh tracker で、保存済み ID は registerSubmitted されない。
+      initialSubmittedIds: [],
+      clipIdsByEntry: new Map(),
+      failedSubmittedIds: ["saved-error"],
+      completionResult: {
+        timedOut: false,
+        submittedIds: ["saved-ok", "saved-error"],
+        stalledClipIds: [],
+      },
+    });
+
+    retryPlaylistHandler({
+      data: {
+        playlistName: "vj | retry error regression",
+        submittedClipIds: ["saved-ok", "saved-error"],
+        expectedClipCount: 2,
+        collectionId: "collection-stall",
+      },
+    });
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.ERROR })
+      )
+    );
+
+    expect(scrollAndMultiSelectByIdsMock).not.toHaveBeenCalled();
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({
+        phase: PHASE.ERROR,
+        message: expect.stringMatching(/saved-error.*status=error/),
+      })
+    );
+  });
+
+  it("Given error entry と別の stall entry が混在 When queue run Then 両 entry を除外して完了分を処理する", async () => {
+    const {
+      progressMessages,
+      sentMessages,
+      scrollAndMultiSelectByIdsMock,
+      runHandler,
+    } = await loadContentScriptWithStalledCompletion({
+      initialSubmittedIds: allClipIds,
+      clipIdsByEntry: new Map(clipIdsByEntry),
+      failedSubmittedIds: ["clip-2a"],
+      completionResult: {
+        timedOut: true,
+        submittedIds: allClipIds,
+        stalledClipIds: ["clip-1b"],
+        message:
+          "生成完了待ちがタイムアウトしました: submitted=6/6, pending=1, 最後の進捗からの経過時間=600000ms",
+      },
+    });
+
+    runQueue(runHandler);
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.FINISHED })
+      )
+    );
+
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({ phase: PHASE.ENTRY_FAILED, index: 1 })
+    );
+    expect(progressMessages).toContainEqual(
+      expect.objectContaining({
+        phase: PHASE.ENTRY_FAILED,
+        index: 2,
+        message: expect.stringContaining("status=error"),
+      })
+    );
+    expect(scrollAndMultiSelectByIdsMock).toHaveBeenCalledWith(
+      ["clip-0a", "clip-0b"],
+      expect.anything()
+    );
+    expect(sentMessages).toContainEqual(
+      expect.objectContaining({ type: "startDownload" })
+    );
+    expect(writeResumeStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ failedIndices: [1, 2] })
     );
   });
 


### PR DESCRIPTION
## 概要

高速モードの最終 wait 後に error entry 全体を除外し、完了 entry の playlist/download は継続します。

Closes #3206
Parent: #2543

## 変更内容

- tracker error IDs を entry mapping へ対応付け
- error entry の sibling IDs を全 dropし ENTRY_FAILED/status=error と failedIndicesへ記録
- 残り完了 entry の playlist/downloadを継続
- 全失敗時は playlist を作らず保留
- unmapped error は fail-loud

## 検証

- focused: 7 passed
- related regression: 42 passed
- suno-helper: 72 files / 1351 tests passed
- check / compile / Ruff / Any / Fallow / diff-check: passed
