### PR TITLE
docs(masterup): ラウドネス検証をworkspace rootから起動する

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -353,8 +353,10 @@ uv run yt-suno-audio-cleanup apply <collection-path>  # 元ファイルを origi
 cleanup の有効・無効にかかわらず、マスター結合前に次の単一スクリプトを実行する。計測・閾値判定・逸脱曲の特定はスクリプトを正とし、本文で再計算しない。
 
 ```bash
-uv run python3 .claude/skills/masterup/references/check_loudness_deviation.py <collection-path>
+uv run python3 "$(git rev-parse --show-toplevel)/.claude/skills/masterup/references/check_loudness_deviation.py" <collection-path>
 ```
+
+`git rev-parse` は同期済み skill が置かれた workspace root だけを解決し、実行 CWD は変更しない。したがって `channels/<channel>` を CWD にするマルチチャンネル workspace でも、そのチャンネルの `config/channel/` を読みながら同梱スクリプトを起動できる。
 
 - exit 0: PASS と全曲の実測 LUFS を表示し、Step 5 本体へ進む
 - exit 1: 計測または設定エラー。表示された原因を解消して再実行し、Step 5 本体へ進まない

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(distrokid-helper)`: dir mode のコレクション選択表示を `アルバム名（曲数）` へ簡略化し、選択中ラベルの省略表示と候補一覧の横 overflow 防止を追加。表示と独立した `collection_id / disc` の選択 identity は維持した（#2515）。
 - `fix(suno-helper)`: Suno ZIP の clip 名に含まれる em-dash 周りの空白差・全角空白・`(1)` / `_1` 重複 suffix を prompts の同一 entry として照合し、配置 skip を防ぐようにした（#3002）。
 - `fix(suno-helper)`: localhost mutation の失敗時に、後続の serve token 再取得エラーで上書きせず、元の request の method・path・status を構造化エラーとして保持するようにした（#3000）。
+- `docs(masterup)`: マルチチャンネル workspace のチャンネルディレクトリを CWD に保ったまま、workspace root に同期された曲間ラウドネス検証スクリプトを起動できる portable command へ更新した（#3210）。
+
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。

--- a/tests/repo/test_masterup_loudness_deviation.py
+++ b/tests/repo/test_masterup_loudness_deviation.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -12,6 +15,7 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 
 SCRIPT = REPO_ROOT / ".claude" / "skills" / "masterup" / "references" / "check_loudness_deviation.py"
+SKILL = REPO_ROOT / ".claude" / "skills" / "masterup" / "SKILL.md"
 
 
 def _load_module():
@@ -35,6 +39,58 @@ def _collection(tmp_path: Path) -> Path:
     for name in ("01-a.mp3", "02-b.mp3", "03-c.wav"):
         (music / name).write_bytes(b"fixture")
     return collection
+
+
+@pytest.mark.parametrize("nested_channel", (False, True), ids=("single-channel", "nested-channel"))
+def test_documented_invocation_resolves_script_from_channel_cwd(tmp_path: Path, nested_channel: bool) -> None:
+    """#3210: 配布コマンドは channel CWD を保って workspace 側 script を起動する。"""
+    workspace = tmp_path / "workspace with spaces"
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+    channel = workspace / "channels" / "focus" if nested_channel else workspace
+    collection = channel / "collections" / "planning" / "demo"
+    collection.mkdir(parents=True)
+    distributed_script = workspace / ".claude" / "skills" / "masterup" / "references" / SCRIPT.name
+    distributed_script.parent.mkdir(parents=True)
+    distributed_script.write_text(
+        """from pathlib import Path
+import json
+import sys
+
+print(json.dumps({"cwd": str(Path.cwd()), "script": str(Path(__file__).resolve()), "collection": sys.argv[1]}))
+""",
+        encoding="utf-8",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text('#!/bin/sh\nset -eu\ntest "$1" = run\nshift\nexec "$@"\n', encoding="utf-8")
+    uv.chmod(0o755)
+    documented = next(
+        line
+        for line in SKILL.read_text(encoding="utf-8").splitlines()
+        if line.startswith("uv run python3 ") and SCRIPT.name in line
+    )
+    command = documented.replace("<collection-path>", shlex.quote(str(collection)))
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    completed = subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/bash",
+        cwd=channel,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload == {
+        "cwd": str(channel),
+        "script": str(distributed_script),
+        "collection": str(collection),
+    }
 
 
 def test_parse_loudnorm_input_i_uses_ffmpeg_json(module):


### PR DESCRIPTION
## 概要

masterup のラウドネス検証スクリプトを nested channel cwd でも workspace root から安定して起動する手順へ変更します。

Closes #3210
Parent: #2580

## 変更内容

- workspace root を解決する portable command を記載
- single-channel と nested-channel の runtime contract を追加
- CHANGELOG を更新

## 検証

- TDD: nested workspace の旧相対パス RED to GREEN
- runtime contract: 2 passed
- masterup focused: 10 passed
- yt-skills lint: 57 passed
- Ruff / Any / diff-check: passed
