### PR TITLE
fix(collection-serve): 無効な Chrome 拡張候補を除外する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
 - `fix(suno-helper)`: prompt response の optional な `duration_sec` を正の整数に限定し、bool・文字列・小数・非有限値・0 以下を拡張の取得境界で fail-loud に拒否するようにした（#3154）。
+- `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/src/youtube_automation/infrastructure/collections/chrome_extensions.py
+++ b/src/youtube_automation/infrastructure/collections/chrome_extensions.py
@@ -140,6 +140,8 @@ def _candidates_from_preferences(
         extension_path = Path(raw_path)
         if not extension_path.is_absolute() or extension_path.name != extension_name:
             continue
+        if _is_disabled_extension_entry(raw_entry):
+            continue
         candidates.append(
             _ExtensionCandidate(
                 extension_id=extension_id,
@@ -149,6 +151,10 @@ def _candidates_from_preferences(
             )
         )
     return candidates
+
+
+def _is_disabled_extension_entry(raw_entry: dict[object, object]) -> bool:
+    return bool(raw_entry.get("disable_reasons")) or raw_entry.get("state") == 0
 
 
 def _format_candidates(candidates: list[_ExtensionCandidate]) -> str:

--- a/tests/infrastructure/collections/test_chrome_extensions.py
+++ b/tests/infrastructure/collections/test_chrome_extensions.py
@@ -72,6 +72,32 @@ def test_resolve_unpacked_extension_origin_matches_secure_preferences(tmp_path):
     assert resolved.path == Path(_extension_path(tmp_path, "suno-helper"))
 
 
+@pytest.mark.parametrize(
+    "disabled_fields",
+    (
+        {"disable_reasons": [1]},
+        {"state": 0},
+    ),
+)
+def test_resolve_unpacked_extension_origin_selects_enabled_duplicate(tmp_path, disabled_fields):
+    disabled_id = "gdjhjiphejeeclngbljhajiffhpdepee"
+    enabled_id = "abcdefghijklmnopabcdefghijklmnop"
+    extension_path = _extension_path(tmp_path, "suno-helper")
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {
+            disabled_id: {"path": extension_path, **disabled_fields},
+            enabled_id: {"path": extension_path},
+        },
+    )
+
+    resolved = resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+    assert resolved.extension_id == enabled_id
+    assert resolved.origin == f"chrome-extension://{enabled_id}"
+
+
 def test_resolve_unpacked_extension_origin_uses_preferences_fallback(tmp_path):
     _write_preferences(
         tmp_path / "Profile 1",


### PR DESCRIPTION
## 概要

collection-serve の Chrome extension resolver から無効な候補を除外します。

Closes #3215
Parent: #2581

## 変更内容

- disable_reasons が非空の候補を除外
- state=0 の候補を除外
- 有効な重複候補だけが選択される regression tests を追加
- CHANGELOG を更新

## 検証

- TDD RED to GREEN
- focused: 19 passed
- Ruff check/format / Any / diff-check: passed
