### PR TITLE
fix(collection-serve): 有効候補の曖昧性を状態付きで拒否する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
 - `fix(suno-helper)`: prompt response の optional な `duration_sec` を正の整数に限定し、bool・文字列・小数・非有限値・0 以下を拡張の取得境界で fail-loud に拒否するようにした（#3154）。
+- `fix(collection-serve)`: `--allow-extension` が同名候補を検出しても有効 ID が 0 件、または複数 ID の場合は起動前に拒否し、検出した全候補の profile / ID / path / enabled 状態と `--allow-origin` fallback を `ConfigError` に列挙する（#3216）。
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。

--- a/src/youtube_automation/infrastructure/collections/chrome_extensions.py
+++ b/src/youtube_automation/infrastructure/collections/chrome_extensions.py
@@ -28,6 +28,7 @@ class _ExtensionCandidate:
     extension_id: str
     profile: str
     path: Path
+    enabled: bool
     preferences_path: Path
 
 
@@ -49,7 +50,15 @@ def resolve_unpacked_extension_origin(
             "Load the unpacked extension in Chrome, or pass --allow-origin chrome-extension://<EXTENSION_ID> manually."
         )
 
-    ids = {candidate.extension_id for candidate in candidates}
+    enabled_candidates = [candidate for candidate in candidates if candidate.enabled]
+    if not enabled_candidates:
+        raise ConfigError(
+            f"Chrome unpacked extension named {extension_name!r} matched no enabled extension IDs. "
+            f"Candidates: {_format_candidates(candidates)}. "
+            "Pass --allow-origin chrome-extension://<EXTENSION_ID> manually."
+        )
+
+    ids = {candidate.extension_id for candidate in enabled_candidates}
     if len(ids) > 1:
         raise ConfigError(
             f"Chrome unpacked extension named {extension_name!r} matched multiple extension IDs. "
@@ -57,7 +66,7 @@ def resolve_unpacked_extension_origin(
             "Pass --allow-origin chrome-extension://<EXTENSION_ID> manually."
         )
 
-    selected = candidates[0]
+    selected = enabled_candidates[0]
     return ChromeExtensionOrigin(
         name=extension_name,
         extension_id=selected.extension_id,
@@ -140,13 +149,12 @@ def _candidates_from_preferences(
         extension_path = Path(raw_path)
         if not extension_path.is_absolute() or extension_path.name != extension_name:
             continue
-        if _is_disabled_extension_entry(raw_entry):
-            continue
         candidates.append(
             _ExtensionCandidate(
                 extension_id=extension_id,
                 profile=profile_dir.name,
                 path=extension_path,
+                enabled=not _is_disabled_extension_entry(raw_entry),
                 preferences_path=preferences_path,
             )
         )
@@ -159,6 +167,7 @@ def _is_disabled_extension_entry(raw_entry: dict[object, object]) -> bool:
 
 def _format_candidates(candidates: list[_ExtensionCandidate]) -> str:
     return "; ".join(
-        f"{candidate.profile}: {candidate.extension_id} ({candidate.path}) via {candidate.preferences_path}"
+        f"profile={candidate.profile}, id={candidate.extension_id}, path={candidate.path}, "
+        f"enabled={str(candidate.enabled).lower()}, preferences={candidate.preferences_path}"
         for candidate in candidates
     )

--- a/tests/infrastructure/collections/test_chrome_extensions.py
+++ b/tests/infrastructure/collections/test_chrome_extensions.py
@@ -98,6 +98,32 @@ def test_resolve_unpacked_extension_origin_selects_enabled_duplicate(tmp_path, d
     assert resolved.origin == f"chrome-extension://{enabled_id}"
 
 
+def test_resolve_unpacked_extension_origin_lists_all_disabled_candidates(tmp_path):
+    first_id = "gdjhjiphejeeclngbljhajiffhpdepee"
+    second_id = "abcdefghijklmnopabcdefghijklmnop"
+    first_path = tmp_path / "first" / "suno-helper"
+    second_path = tmp_path / "second" / "suno-helper"
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {first_id: {"path": str(first_path), "disable_reasons": [1]}},
+    )
+    _write_preferences(
+        tmp_path / "Profile 1",
+        "Secure Preferences",
+        {second_id: {"path": str(second_path), "state": 0}},
+    )
+
+    with pytest.raises(ConfigError) as exc_info:
+        resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+    message = str(exc_info.value)
+    assert "matched no enabled extension IDs" in message
+    assert f"profile=Default, id={first_id}, path={first_path}, enabled=false" in message
+    assert f"profile=Profile 1, id={second_id}, path={second_path}, enabled=false" in message
+    assert "--allow-origin chrome-extension://<EXTENSION_ID>" in message
+
+
 def test_resolve_unpacked_extension_origin_uses_preferences_fallback(tmp_path):
     _write_preferences(
         tmp_path / "Profile 1",
@@ -220,8 +246,9 @@ def test_resolve_unpacked_extension_origin_conflicting_ids_lists_candidates(tmp_
 
     message = str(exc_info.value)
     assert "matched multiple extension IDs" in message
-    assert "Default: gdjhjiphejeeclngbljhajiffhpdepee" in message
-    assert "Profile 1: abcdefghijklmnopabcdefghijklmnop" in message
+    assert "profile=Default, id=gdjhjiphejeeclngbljhajiffhpdepee" in message
+    assert "profile=Profile 1, id=abcdefghijklmnopabcdefghijklmnop" in message
+    assert message.count("enabled=true") == 2
     assert "--allow-origin chrome-extension://<EXTENSION_ID>" in message
 
 


### PR DESCRIPTION
## 概要

Chrome extension の有効候補が0件または複数件なら、候補状態と手動fallbackを示して拒否します。

Closes #3216
Parent: #2581

## 変更内容

- candidate inventory に enabled 状態を保持
- 選択対象を enabled 候補だけに限定
- 0件/複数件で全候補の profile/id/path/enabled/preferences を ConfigError に列挙
- 手動 fallback を案内

## 検証

- TDD RED to GREEN: all-disabled / multiple-enabled / mixed duplicate
- focused: 20 passed
- Ruff check/format / Any / diff-check: passed
