### PR TITLE
fix(collection-serve): 拡張選択の診断情報を起動ログへ出す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
 - `fix(suno-helper)`: prompt response の optional な `duration_sec` を正の整数に限定し、bool・文字列・小数・非有限値・0 以下を拡張の取得境界で fail-loud に拒否するようにした（#3154）。
+- `fix(collection-serve)`: `--allow-extension` の起動ログへ、exact origin lock に実際に選択した unpacked 拡張の path / Chrome profile / `enabled=true` を追加し、無効な重複 ID や実行中 origin との食い違いをリクエスト前に診断可能にする（#3217）。
 - `fix(collection-serve)`: `--allow-extension` が同名候補を検出しても有効 ID が 0 件、または複数 ID の場合は起動前に拒否し、検出した全候補の profile / ID / path / enabled 状態と `--allow-origin` fallback を `ConfigError` に列挙する（#3216）。
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -1857,7 +1857,8 @@ def main() -> None:
     if detected_extension is not None:
         print(
             f"  detected extension: {detected_extension.name} -> "
-            f"{detected_extension.extension_id} ({detected_extension.origin})"
+            f"{detected_extension.extension_id} ({detected_extension.origin}, "
+            f"path={detected_extension.path}, profile={detected_extension.profile}, enabled=true)"
         )
     if allow_origin is not None and allow_origin.startswith(_EXTENSION_ORIGIN_SCHEME):
         print(f"  serve token: GET {canonical_url}/auth/token")

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -1089,6 +1089,9 @@ def test_main_resolves_allow_extension_to_allow_origin(monkeypatch, capsys, tmp_
     stdout = capsys.readouterr().out
     assert "detected extension: suno-helper -> gdjhjiphejeeclngbljhajiffhpdepee" in stdout
     assert "chrome-extension://gdjhjiphejeeclngbljhajiffhpdepee" in stdout
+    assert f"path={detected.path}" in stdout
+    assert "profile=Default" in stdout
+    assert "enabled=true" in stdout
     assert "serve token: GET http://test-channel.localhost:7873/auth/token" in stdout
 
 


### PR DESCRIPTION
## 概要

自動選択した Chrome extension の診断情報を collection-serve 起動ログへ表示します。

Closes #3217
Parent: #2581

## 変更内容

- 確定済み origin/path/profile/enabled=true をログ出力
- 手動 --allow-origin の既存経路は不変
- regression test と CHANGELOG を追加

## 検証

- TDD RED to GREEN
- related suite: 238 passed
- Ruff check/format / Any / diff-check: passed
