### PR TITLE
fix(thumbnail-compare): 長時間処理を可視化して有限化する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(collection-serve)`: `--allow-extension` の起動ログへ、exact origin lock に実際に選択した unpacked 拡張の path / Chrome profile / `enabled=true` を追加し、無効な重複 ID や実行中 origin との食い違いをリクエスト前に診断可能にする（#3217）。
 - `fix(collection-serve)`: `--allow-extension` が同名候補を検出しても有効 ID が 0 件、または複数 ID の場合は起動前に拒否し、検出した全候補の profile / ID / path / enabled 状態と `--allow-origin` fallback を `ConfigError` に列挙する（#3216）。
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
+- `fix(thumbnail-compare)`: ベンチマーク更新・サムネイル取得・縮小の進捗を即時表示し、画像取得を slow-drip を含む wall-clock deadline、ffmpeg を有限 timeout にした。個別対象の timeout 後も警告して成功分の比較出力を継続する（#3229）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/src/youtube_automation/commands/thumbnail/compare_thumbnails.py
+++ b/src/youtube_automation/commands/thumbnail/compare_thumbnails.py
@@ -18,7 +18,10 @@ Usage:
 import argparse
 import logging
 import os
+import shutil
 import subprocess
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -38,6 +41,15 @@ logger = logging.getLogger(__name__)
 DEFAULT_MIN_VIEWS = 10000
 SMALL_WIDTH = 320
 SMALL_HEIGHT = 180
+DOWNLOAD_TIMEOUT_SECONDS = 15
+DOWNLOAD_CHUNK_SIZE = 64 * 1024
+FFMPEG_TIMEOUT_SECONDS = 30
+
+
+def _is_timeout_error(error: OSError) -> bool:
+    if isinstance(error, TimeoutError):
+        return True
+    return isinstance(error, urllib.error.URLError) and isinstance(error.reason, TimeoutError)
 
 
 class ThumbnailComparer:
@@ -64,11 +76,31 @@ class ThumbnailComparer:
     def _download_thumbnail(self, url: str, output_path: Path) -> bool:
         if output_path.exists():
             return True
+        partial_path = output_path.with_name(f".{output_path.name}.part")
+        deadline = time.monotonic() + DOWNLOAD_TIMEOUT_SECONDS
         try:
-            urllib.request.urlretrieve(url, str(output_path))
+            with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+                with partial_path.open("wb") as output:
+                    read_chunk = getattr(response, "read1", None)
+                    if read_chunk is None:
+                        read_chunk = response.read
+                    while True:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError
+                        chunk = read_chunk(DOWNLOAD_CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError
+                        output.write(chunk)
+            partial_path.replace(output_path)
             return True
-        except Exception as e:
-            logger.warning("ダウンロード失敗 %s: %s", url, e)
+        except OSError as error:
+            partial_path.unlink(missing_ok=True)
+            if _is_timeout_error(error):
+                logger.warning("ダウンロードタイムアウト %s（%d秒）", url, DOWNLOAD_TIMEOUT_SECONDS)
+            else:
+                logger.warning("ダウンロード失敗 %s: %s", url, error)
             return False
 
     def _resize_thumbnail(self, input_path: Path, output_path: Path) -> bool:
@@ -87,17 +119,24 @@ class ThumbnailComparer:
                 ],
                 capture_output=True,
                 check=True,
+                timeout=FFMPEG_TIMEOUT_SECONDS,
             )
             return True
         except FileNotFoundError:
             logger.error("FFmpeg がインストールされていません")
             return False
+        except subprocess.TimeoutExpired:
+            output_path.unlink(missing_ok=True)
+            logger.warning("リサイズタイムアウト %s（%d秒）", input_path.name, FFMPEG_TIMEOUT_SECONDS)
+            return False
         except subprocess.CalledProcessError as e:
+            output_path.unlink(missing_ok=True)
             logger.warning("リサイズ失敗 %s: %s", input_path.name, e)
             return False
 
     def collect_and_compare(self, no_open: bool = False, small_only: bool = False):
         """サムネイルを収集・縮小・表示"""
+        print("[1/3] ベンチマーク鮮度確認を開始します...", flush=True)
         ensure_benchmark_fresh(
             self.data_dir,
             collector_factory=BenchmarkCollector,
@@ -117,6 +156,7 @@ class ThumbnailComparer:
         )
         logger.info("ベンチマーク対象: %d本（%s再生以上）", len(bench_videos), f"{self.min_views:,}")
 
+        print("[2/3] サムネイル取得を開始します...", flush=True)
         downloaded_bench = []
         for v in bench_videos:
             views_k = v["views"] // 1000
@@ -141,13 +181,12 @@ class ThumbnailComparer:
                 try:
                     os.symlink(thumb.resolve(), dest)
                 except OSError:
-                    import shutil
-
                     shutil.copy2(thumb, dest)
             channel_copies.append(dest)
 
         # 全サムネイルを 320x180 に縮小
         all_originals = downloaded_bench + channel_copies
+        print(f"[3/3] サムネイル縮小を開始します（{len(all_originals)}枚）...", flush=True)
         small_paths = []
         for orig in all_originals:
             small_path = self.small_dir / f"small_{orig.name}"

--- a/tests/commands/thumbnail/test_thumbnail_compare_cli.py
+++ b/tests/commands/thumbnail/test_thumbnail_compare_cli.py
@@ -1,5 +1,7 @@
+from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.error import URLError
 
 import pytest
 
@@ -26,15 +28,15 @@ def test_download_thumbnail_writes_requested_destination(tmp_path: Path, monkeyp
     destination = tmp_path / "download.jpg"
     calls = []
 
-    def retrieve(url, output):
-        calls.append((url, output))
-        Path(output).write_bytes(b"image")
+    def open_url(url, *, timeout):
+        calls.append((url, timeout))
+        return BytesIO(b"image")
 
-    monkeypatch.setattr(mod.urllib.request, "urlretrieve", retrieve)
+    monkeypatch.setattr(mod.urllib.request, "urlopen", open_url)
 
     assert comparer._download_thumbnail("https://example.test/thumb.jpg", destination) is True
     assert destination.read_bytes() == b"image"
-    assert calls == [("https://example.test/thumb.jpg", str(destination))]
+    assert calls == [("https://example.test/thumb.jpg", mod.DOWNLOAD_TIMEOUT_SECONDS)]
 
 
 def test_download_failure_returns_false_and_leaves_no_artifact(tmp_path: Path, monkeypatch):
@@ -42,12 +44,91 @@ def test_download_failure_returns_false_and_leaves_no_artifact(tmp_path: Path, m
     destination = tmp_path / "download.jpg"
     monkeypatch.setattr(
         mod.urllib.request,
-        "urlretrieve",
-        lambda *_args: (_ for _ in ()).throw(OSError("offline")),
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline")),
     )
 
     assert comparer._download_thumbnail("https://example.test/thumb.jpg", destination) is False
     assert not destination.exists()
+
+
+def test_download_timeout_is_bounded_and_reports_target(tmp_path: Path, monkeypatch, caplog):
+    comparer = _comparer(tmp_path)
+    destination = tmp_path / "download.jpg"
+    calls = []
+
+    class SlowResponse:
+        def __init__(self):
+            self.read_count = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _size):
+            self.read_count += 1
+            if self.read_count == 1:
+                return b"partial"
+            raise TimeoutError("timed out")
+
+    def timeout(url, *, timeout):
+        calls.append((url, timeout))
+        return SlowResponse()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", timeout)
+
+    assert comparer._download_thumbnail("https://example.test/slow.jpg", destination) is False
+    assert calls == [("https://example.test/slow.jpg", mod.DOWNLOAD_TIMEOUT_SECONDS)]
+    assert not destination.exists()
+    assert not (tmp_path / ".download.jpg.part").exists()
+    assert "https://example.test/slow.jpg" in caplog.text
+    assert "タイムアウト" in caplog.text
+
+
+def test_download_slow_drip_stops_at_wall_clock_deadline(tmp_path: Path, monkeypatch, caplog):
+    comparer = _comparer(tmp_path)
+    destination = tmp_path / "download.jpg"
+    ticks = iter((0.0, 5.0, 10.0, 16.0))
+
+    class SlowDripResponse:
+        read_count = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read1(self, _size):
+            self.read_count += 1
+            return b"still downloading"
+
+    response = SlowDripResponse()
+    monkeypatch.setattr(mod.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *_args, **_kwargs: response)
+
+    assert comparer._download_thumbnail("https://example.test/drip.jpg", destination) is False
+    assert response.read_count == 1
+    assert not destination.exists()
+    assert not (tmp_path / ".download.jpg.part").exists()
+    assert "https://example.test/drip.jpg" in caplog.text
+    assert "タイムアウト" in caplog.text
+
+
+def test_download_url_error_wrapped_timeout_uses_timeout_diagnostic(tmp_path: Path, monkeypatch, caplog):
+    comparer = _comparer(tmp_path)
+    destination = tmp_path / "download.jpg"
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError(TimeoutError("socket timed out"))),
+    )
+
+    assert comparer._download_thumbnail("https://example.test/wrapped.jpg", destination) is False
+    assert "ダウンロードタイムアウト" in caplog.text
+    assert "ダウンロード失敗" not in caplog.text
 
 
 def test_resize_invokes_ffmpeg_with_fixed_mobile_dimensions(tmp_path: Path, monkeypatch):
@@ -71,6 +152,40 @@ def test_resize_failures_return_false(tmp_path: Path, monkeypatch, error):
     monkeypatch.setattr(mod.subprocess, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(error))
 
     assert comparer._resize_thumbnail(tmp_path / "source.jpg", tmp_path / "small.jpg") is False
+
+
+def test_resize_timeout_is_bounded_and_removes_partial_output(tmp_path: Path, monkeypatch, caplog):
+    comparer = _comparer(tmp_path)
+    source = tmp_path / "source.jpg"
+    output = tmp_path / "small.jpg"
+    source.write_bytes(b"source")
+    calls = []
+
+    def timeout(command, **kwargs):
+        calls.append((command, kwargs))
+        output.write_bytes(b"partial")
+        raise mod.subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(mod.subprocess, "run", timeout)
+
+    assert comparer._resize_thumbnail(source, output) is False
+    assert calls[0][1]["timeout"] == mod.FFMPEG_TIMEOUT_SECONDS
+    assert not output.exists()
+    assert source.name in caplog.text
+    assert "タイムアウト" in caplog.text
+
+
+def test_collect_reports_refresh_progress_before_refresh_starts(tmp_path: Path, monkeypatch, capsys):
+    comparer = _comparer(tmp_path)
+
+    def refresh(*_args, **_kwargs):
+        assert "ベンチマーク鮮度確認" in capsys.readouterr().out
+
+    monkeypatch.setattr(mod, "ensure_benchmark_fresh", refresh)
+    monkeypatch.setattr(mod, "load_benchmark_videos", lambda *_args, **_kwargs: [])
+    comparer._collect_channel_thumbnails = lambda: []
+
+    comparer.collect_and_compare(no_open=True)
 
 
 def test_collect_continues_after_download_and_resize_failures_and_opens_small_dir(tmp_path: Path, monkeypatch, capsys):


### PR DESCRIPTION
## 概要

thumbnail-compare の長時間 stage を可視化し、HTTP/ffmpeg 個別処理を有限 timeout にします。

Closes #3229
Parent: #2587

## 変更内容

- benchmark refresh 前から flushed 3-stage progress を表示
- HTTP download timeout 15s と atomic .part cleanup
- ffmpeg timeout 30s と partial output cleanup
- timeout target は warning+continue、partial-success summary を維持
- CHANGELOG と regression tests を追加

## 検証

- TDD RED to GREEN
- related: 18 passed
- Ruff check/format / Any / diff-check: passed
