### PR TITLE
feat(distrokid-helper): 配信元ラベルを構造化チャンネル名へ切り替える

### DIFF
--- a/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
@@ -68,7 +68,7 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
   let releaseFails = false;
   try {
     const makeLiveServer = async (
-      label: string
+      channelName: string
     ): Promise<{ url: string; info: Record<string, unknown> }> => {
       const server = createServer((request, response) => {
         response.setHeader("Content-Type", "application/json");
@@ -103,9 +103,10 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
       const port = await listen(server);
       liveServers.push(server);
       const url = `http://127.0.0.1:${port}`;
+      const label = `${channelName} (127.0.0.1:${port})`;
       const info = {
-        channel_name: label,
-        channel_short: label.toLowerCase(),
+        channel_name: channelName,
+        channel_short: channelName.toLowerCase(),
         hostname: "127.0.0.1",
         port,
         base_url: url,
@@ -113,8 +114,8 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
       };
       return { url, info };
     };
-    const oldServer = await makeLiveServer("Old");
-    const newServer = await makeLiveServer("New");
+    const oldServer = await makeLiveServer("Old (Archive)");
+    const newServer = await makeLiveServer("New (Channel)");
     let active = oldServer;
     let delayNextResponse = false;
     registry = createServer((request, response) => {
@@ -180,7 +181,13 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
       new RegExp(oldServer.url)
     );
     await trigger.click();
-    await page.getByRole("option", { name: /Old/ }).click();
+    await page
+      .getByRole("option", {
+        name: "Old (Archive) | distrokid-helper",
+        exact: true,
+      })
+      .click();
+    await expect(trigger).toHaveText("Old (Archive) | distrokid-helper");
     await expect(page.locator('[data-slot="card-title"]')).toHaveText(
       releasePayload.release.album_title
     );
@@ -207,9 +214,9 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
 
     await expect(trigger).toBeEnabled();
     const options = page.getByRole("option");
-    await expect(options).toContainText([
-      "YouTube Automation (default)",
-      "New",
+    await expect(options).toHaveText([
+      "YouTube Automation | distrokid-helper",
+      "New (Channel) | distrokid-helper",
     ]);
     await expect(options.filter({ hasText: "Old" })).toHaveCount(0);
     expect(
@@ -219,7 +226,13 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
     ).toBe(true);
 
     releaseFails = true;
-    await page.getByRole("option", { name: /New/ }).click();
+    await page
+      .getByRole("option", {
+        name: "New (Channel) | distrokid-helper",
+        exact: true,
+      })
+      .click();
+    await expect(trigger).toHaveText("New (Channel) | distrokid-helper");
     await expect(page.getByRole("alert")).toHaveText(/HTTP 500/);
   } finally {
     await context?.close();

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -98,12 +98,19 @@ const discoveryMocks = vi.hoisted(() => ({
   discoverServerSources: vi.fn(async () => [
     {
       id: "youtube-automation-localhost-7873",
+      channelName: "YouTube Automation",
       label: "YouTube Automation (default)",
       url: "http://youtube-automation.localhost:7873",
     },
-    { id: "abyss-mi", label: "ABYSS MI", url: "http://localhost:7873" },
+    {
+      id: "abyss-mi",
+      channelName: "ABYSS (MI)",
+      label: "ABYSS (MI) (localhost:7873)",
+      url: "http://localhost:7873",
+    },
     {
       id: "localhost-7877",
+      channelName: "Fallback Channel",
       label: "localhost fallback 7877",
       url: "http://localhost:7877",
     },
@@ -205,12 +212,19 @@ describe("DistroKid popup compatibility check", () => {
     discoveryMocks.discoverServerSources.mockReset().mockResolvedValue([
       {
         id: "youtube-automation-localhost-7873",
+        channelName: "YouTube Automation",
         label: "YouTube Automation (default)",
         url: "http://youtube-automation.localhost:7873",
       },
-      { id: "abyss-mi", label: "ABYSS MI", url: BASE_URL },
+      {
+        id: "abyss-mi",
+        channelName: "ABYSS (MI)",
+        label: "ABYSS (MI) (localhost:7873)",
+        url: BASE_URL,
+      },
       {
         id: "localhost-7877",
+        channelName: "Fallback Channel",
         label: "localhost fallback 7877",
         url: FALLBACK_URL,
       },
@@ -257,9 +271,10 @@ describe("DistroKid popup compatibility check", () => {
     vi.clearAllMocks();
   });
 
-  it("ローカル配信元 option は URL を表示せず、URL value はデータ取得先として維持する", async () => {
+  it("ローカル配信元の option と選択済み trigger は channelName だけを表示する", async () => {
     await renderApp();
     const trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.textContent).toBe("YouTube Automation | distrokid-helper");
     await act(async () => trigger.click());
     await waitFor(() =>
       expect(document.querySelectorAll('[role="option"]')).toHaveLength(3)
@@ -275,12 +290,12 @@ describe("DistroKid popup compatibility check", () => {
       )
     ).toEqual([
       {
-        text: "YouTube Automation (default) | distrokid-helper",
+        text: "YouTube Automation | distrokid-helper",
         value: "http://youtube-automation.localhost:7873",
       },
-      { text: "ABYSS MI | distrokid-helper", value: BASE_URL },
+      { text: "ABYSS (MI) | distrokid-helper", value: BASE_URL },
       {
-        text: "localhost fallback 7877 | distrokid-helper",
+        text: "Fallback Channel | distrokid-helper",
         value: FALLBACK_URL,
       },
     ]);
@@ -913,21 +928,37 @@ describe("DistroKid popup compatibility check", () => {
   it("should rerun shared discovery before the selector opens and replace a stopped port", async () => {
     const defaultSource = {
       id: "youtube-automation-localhost-7873",
+      channelName: "YouTube Automation",
       label: "YouTube Automation (default)",
       url: "http://youtube-automation.localhost:7873",
     };
     discoveryMocks.discoverServerSources
       .mockResolvedValueOnce([
         defaultSource,
-        { id: "old", label: "Old", url: "http://old.localhost:9001" },
+        {
+          id: "old",
+          channelName: "Old",
+          label: "Old",
+          url: "http://old.localhost:9001",
+        },
       ])
       .mockResolvedValueOnce([
         defaultSource,
-        { id: "new", label: "New", url: "http://new.localhost:49152" },
+        {
+          id: "new",
+          channelName: "New",
+          label: "New",
+          url: "http://new.localhost:49152",
+        },
       ])
       .mockResolvedValueOnce([
         defaultSource,
-        { id: "new", label: "New", url: "http://new.localhost:49152" },
+        {
+          id: "new",
+          channelName: "New",
+          label: "New",
+          url: "http://new.localhost:49152",
+        },
       ]);
 
     await renderApp();
@@ -974,15 +1005,23 @@ describe("DistroKid popup compatibility check", () => {
   });
 
   it("should replace a restored URL removed by discovery during an early selector refresh", async () => {
-    const initialDiscovery =
-      deferred<Array<{ id: string; label: string; url: string }>>();
+    const initialDiscovery = deferred<
+      Array<{
+        id: string;
+        channelName: string;
+        label: string;
+        url: string;
+      }>
+    >();
     const defaultSource = {
       id: "youtube-automation-localhost-7873",
+      channelName: "YouTube Automation",
       label: "YouTube Automation (default)",
       url: "http://youtube-automation.localhost:7873",
     };
     const restoredSource = {
       id: "restored",
+      channelName: "Restored",
       label: "Restored",
       url: "http://restored.localhost:49152",
     };
@@ -1028,11 +1067,13 @@ describe("DistroKid popup compatibility check", () => {
     async (_label, savedUrl, expectedUrl) => {
       const defaultSource = {
         id: "youtube-automation-localhost-7873",
+        channelName: "YouTube Automation",
         label: "YouTube Automation (default)",
         url: "http://youtube-automation.localhost:7873",
       };
       const liveSource = {
         id: "live",
+        channelName: "Live",
         label: "Live",
         url: "http://live.localhost:49152",
       };
@@ -1067,12 +1108,14 @@ describe("DistroKid popup compatibility check", () => {
   it("should select a discovered non-default URL without recreating candidate history", async () => {
     const live = {
       id: "channel-b",
-      label: "Channel B",
+      channelName: "Channel (B)",
+      label: "Channel (B) (channel-b.localhost:49152)",
       url: "http://channel-b.localhost:49152",
     };
     const liveSources = [
       {
         id: "youtube-automation-localhost-7873",
+        channelName: "YouTube Automation",
         label: "YouTube Automation (default)",
         url: "http://youtube-automation.localhost:7873",
       },
@@ -1086,6 +1129,7 @@ describe("DistroKid popup compatibility check", () => {
     await waitFor(() =>
       expect(serverUrlItem.setValue).toHaveBeenCalledWith(live.url)
     );
+    expect(select.textContent).toBe("Channel (B) | distrokid-helper");
     expect(select.getAttribute("aria-expanded")).toBe("false");
     expect(migrateServerSourcesStorage).toHaveBeenCalled();
     expect(legacySourceState.present).toBe(false);

--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -314,7 +314,11 @@ export function formatServerSourceLabel(
   source: LocalServerSource,
   helper: HelperProcessName
 ): string {
-  return `${source.label} | ${helper}`;
+  const channelName =
+    helper === "distrokid-helper"
+      ? (source.channelName ?? source.label)
+      : source.label;
+  return `${channelName} | ${helper}`;
 }
 
 /** 拡張初回起動時のローカル配信元候補。 */


### PR DESCRIPTION
## 概要

DistroKid helper の配信元表示を先行 #3232 の構造化 `channelName` へ切り替え、Suno helper はこの段では従来表示のまま維持します。

Closes #3233
Parent: #2531

## 変更内容

- DistroKid の option / selected trigger を `チャンネル名 | distrokid-helper` 形式へ変更
- legacy label の hostname・port・URL・`(default)` を表示から除外
- channel 名自体の括弧と URL value による選択・取得・保存を維持
- `channelName` がない source は legacy label に fallback
- この段では Suno helper の表示を変更しない

## 検証

- DistroKid popup unit: 19 passed
- DistroKid Chromium E2E: 1 passed
- legacy Suno constants + popup: 108 passed
- Suno Chromium E2E: 1 passed
- 両 helper の check / compile / build、Any / diff-check: passed
