### PR TITLE
feat(suno-helper): 配信元ラベルを構造化チャンネル名へ切り替える

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -314,10 +314,7 @@ export function formatServerSourceLabel(
   source: LocalServerSource,
   helper: HelperProcessName
 ): string {
-  const channelName =
-    helper === "distrokid-helper"
-      ? (source.channelName ?? source.label)
-      : source.label;
+  const channelName = source.channelName ?? source.label;
   return `${channelName} | ${helper}`;
 }
 

--- a/extensions/suno-helper/tests/constants.test.ts
+++ b/extensions/suno-helper/tests/constants.test.ts
@@ -91,20 +91,34 @@ describe("shared/constants: サーバー互換の契約値", () => {
     expect(DEFAULT_SERVER_SOURCES).toHaveLength(1);
   });
 
-  it("Given server selector When helper ごとの option 表示名を組み立てる Then URL を含めずプロセスを識別できる", () => {
+  it("Given structured channelName When helper ごとの表示名を組み立てる Then legacy label と URL を表示しない", () => {
     expect(
       formatServerSourceLabel(
         {
           id: "abyss-mi",
-          label: "ABYSS MI",
+          channelName: "Ambient (Night)",
+          label: "Ambient (Night) (abyss-mi.localhost:7873)",
           url: "http://abyss-mi.localhost:7873",
         },
         "distrokid-helper"
       )
-    ).toBe("ABYSS MI | distrokid-helper");
+    ).toBe("Ambient (Night) | distrokid-helper");
     expect(
       formatServerSourceLabel(DEFAULT_SERVER_SOURCES[0], "suno-helper")
-    ).toBe("YouTube Automation (default) | suno-helper");
+    ).toBe("YouTube Automation | suno-helper");
+  });
+
+  it("Given expand 前の source When 表示名を組み立てる Then legacy label を互換表示する", () => {
+    expect(
+      formatServerSourceLabel(
+        {
+          id: "legacy",
+          label: "Legacy Channel",
+          url: "http://legacy.localhost:7873",
+        },
+        "suno-helper"
+      )
+    ).toBe("Legacy Channel | suno-helper");
   });
 
   it("Given server selector When host permissions を読む Then *.localhost を許可する", () => {

--- a/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
@@ -34,7 +34,7 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
   let registry: Server | undefined;
   try {
     const makeLiveServer = async (
-      label: string
+      channelName: string
     ): Promise<{ info: Record<string, unknown> }> => {
       const server = createServer((request, response) => {
         response.setHeader("Content-Type", "application/json");
@@ -47,9 +47,10 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
       });
       const port = await listen(server);
       liveServers.push(server);
+      const label = `${channelName} (127.0.0.1:${port})`;
       const info = {
-        channel_name: label,
-        channel_short: label.toLowerCase(),
+        channel_name: channelName,
+        channel_short: channelName.toLowerCase(),
         hostname: "127.0.0.1",
         port,
         base_url: `http://127.0.0.1:${port}`,
@@ -57,8 +58,8 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
       };
       return { info };
     };
-    const oldServer = await makeLiveServer("Old");
-    const newServer = await makeLiveServer("New");
+    const oldServer = await makeLiveServer("Old (Archive)");
+    const newServer = await makeLiveServer("New (Channel)");
     let active = oldServer;
     let delayNextResponse = false;
     registry = createServer((request, response) => {
@@ -115,7 +116,7 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
     await page.goto("https://suno.com/create");
     const trigger = page.locator('[data-suno-control="server-source-trigger"]');
     const sourceField = page.locator('[data-suno-control="server-url"]');
-    await expect(trigger).toContainText("YouTube Automation (default)");
+    await expect(trigger).toHaveText("YouTube Automation | suno-helper");
     await expect(sourceField).toHaveAttribute(
       "data-source-values",
       new RegExp(String(oldServer.info.base_url))
@@ -132,9 +133,9 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
 
     await expect(trigger).toBeEnabled();
     const options = page.getByRole("option");
-    await expect(options).toContainText([
-      "YouTube Automation (default)",
-      "New",
+    await expect(options).toHaveText([
+      "YouTube Automation | suno-helper",
+      "New (Channel) | suno-helper",
     ]);
     await expect(options.filter({ hasText: "Old" })).toHaveCount(0);
     expect(
@@ -142,6 +143,17 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
         .first()
         .evaluate((option) => option.getRootNode() instanceof ShadowRoot)
     ).toBe(true);
+    await page
+      .getByRole("option", {
+        name: "New (Channel) | suno-helper",
+        exact: true,
+      })
+      .click();
+    await expect(trigger).toHaveText("New (Channel) | suno-helper");
+    await expect(sourceField).toHaveAttribute(
+      "data-selected-value",
+      String(newServer.info.base_url)
+    );
   } finally {
     await context?.close();
     if (registry?.listening) await close(registry);


### PR DESCRIPTION
## 概要

Suno helper の配信元表示も構造化 `channelName` へ切り替え、共有 formatter の両 helper 契約と Suno 実拡張 E2E をこの段で成立させます。

Closes #3234
Parent: #2531

## 変更内容

- shared formatter が両 helper で構造化 `channelName` を優先
- `channelName` がない source は legacy label に fallback
- default は `YouTube Automation | suno-helper` と表示
- channel 名の括弧を保持し、legacy hostname・port・URL を表示から除外
- Suno の refresh・選択 URL value を維持

## 検証

- Suno constants + popup unit: 109 passed
- Suno Chromium E2E: 1 passed
- DistroKid popup unit: 19 passed
- DistroKid Chromium E2E: 1 passed
- 両 helper の check / compile / build、Any / diff-check: passed
