### PR TITLE
docs(thumbnail-compare): planning 候補の比較フローを案内する

### DIFF
--- a/.claude/skills/thumbnail-compare/SKILL.md
+++ b/.claude/skills/thumbnail-compare/SKILL.md
@@ -25,7 +25,7 @@ description: "Use when 自チャンネルの生成済みサムネイルを競合
 - `config/channel/` が存在すること（`load_config()` でロード可能）。存在しない場合は `/channel-new`（既存チャンネルは取り込みモード）を案内して停止する
 - `config/channel/analytics.json::benchmark.channels` に承認済みベンチマークチャンネルが設定済みであること。未設定なら `/channel-new` / `/discover-competitors` を案内して停止する
 - `data/benchmark_*.json` が存在すること（鮮度が古い場合はスクリプトが自動更新する）。一度も収集していなければ先に `/benchmark` を案内する
-- 自チャンネルのサムネイル `collections/live/*/10-assets/thumbnail.jpg` が 1 件以上存在すること。無ければ比較対象なしとして `/thumbnail` → `/video-upload` の前工程を案内する
+- 自チャンネルの確定済みサムネイル `collections/live/*/10-assets/thumbnail.jpg` または `collections/planning/*/10-assets/thumbnail.jpg` が 1 件以上存在すること。どちらにも無ければ比較対象なしとして `/thumbnail` を案内する
 - ベンチマーク更新は YouTube Data API を使うため `auth/token.json` の OAuth 認証が必要。未認証なら `/setup` を案内する
 
 ## 想定 API call 数
@@ -48,7 +48,11 @@ uv run yt-thumbnail-compare --no-open
 スクリプトが自動で以下を実行:
 1. ベンチマークデータの鮮度チェック → 古ければ全チャンネル一括更新
 2. 1万再生以上の動画サムネイルをダウンロード → `data/thumbnail_compare/benchmark/`
-3. 自チャンネルの全サムネイルをコピー → `data/thumbnail_compare/自チャンネルスラッグ/`
+3. 自チャンネルの確定済みサムネイルを収集 → `data/thumbnail_compare/自チャンネルスラッグ/`
+   - 公開済み: `collections/live/*/10-assets/thumbnail.jpg` → `<channel_slug>_<theme>.jpg`
+   - 企画中: `collections/planning/*/10-assets/thumbnail.jpg` → `<channel_slug>_planning_<collection>.jpg`
+   - `thumbnail-v*.jpg`、`planning-preview.png`、textless の `main.png/jpg` は入力にしない
+   - 同一実体は 1 件にまとめ、同名の既存出力は上書きしない
 4. 全サムネイルを 320x180px に縮小 → `data/thumbnail_compare/small/`
 
 ### Phase 2: 比較分析（サブエージェント並列）
@@ -100,13 +104,15 @@ open data/thumbnail_compare/
 |---|---|---|
 | 入力データ不在 | `data/` のベンチマーク/Analytics スナップショットが無い | 先に `/benchmark`・`/analytics-collect` 等を実行して入力を用意 |
 | サムネ取得失敗 | `yt-thumbnail-compare` の画像 DL が HTTP エラー | YouTube / CDN のステータスを確認し時間を置いて再実行 |
+| 個別 timeout | 画像取得または縮小対象を示す timeout warning | 失敗対象だけを確認する。処理は残りを継続し、成功分の出力と最終件数を提示する |
 
 ## 関連ファイル
 
 - `yt-thumbnail-compare` (`youtube_automation.commands.thumbnail.compare_thumbnails`) — サムネイル収集・縮小スクリプト
 - `data/thumbnail_compare/` — 出力ディレクトリ
 - `data/benchmark_YYYYMMDD.json` — ベンチマーク動画データ（サムネURL）
-- `collections/live/*/10-assets/thumbnail.jpg` — 自チャンネルサムネイル
+- `collections/live/*/10-assets/thumbnail.jpg` — 公開済み自チャンネルサムネイル
+- `collections/planning/*/10-assets/thumbnail.jpg` — 企画中の確定済み自チャンネルサムネイル
 - `docs/benchmarks/common-patterns.md` — サムネイルチェックリスト v4
 - `data/video_analysis/<slug>/<video_id>.json` — `/video-analyze` の `signature_elements` / `hook_structure` 出力（競合のサムネ実装パターン抽出を補強）
   - 冒頭クリップ窓（既定 900 秒、JSON の `analysis_window_sec`）内の実装パターン。動画全尺で出る signature 要素を網羅したものとは扱わない。

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1334,6 +1334,27 @@ def test_channel_new_regeneration_documents_ttp_wf_new_readiness_gate() -> None:
         assert "config/skills/thumbnail.yaml::image_generation.gemini.reference_images.channel_branding" in text
 
 
+def test_thumbnail_compare_documents_planning_thumbnail_runtime_contract() -> None:
+    skill = _read(".claude/skills/thumbnail-compare/SKILL.md")
+    prerequisites = skill.split("## 前提", 1)[1].split("## 想定 API call 数", 1)[0]
+    phase_one = skill.split("### Phase 1: サムネイル収集", 1)[1].split("### Phase 2:", 1)[0]
+    troubleshooting = skill.split("## 障害時ガイダンス", 1)[1].split("## 関連ファイル", 1)[0]
+    related_files = skill.split("## 関連ファイル", 1)[1]
+
+    for section in (prerequisites, phase_one, related_files):
+        assert "collections/live/*/10-assets/thumbnail.jpg" in section
+        assert "collections/planning/*/10-assets/thumbnail.jpg" in section
+
+    for excluded in ("thumbnail-v*.jpg", "planning-preview.png", "main.png/jpg"):
+        assert excluded in phase_one
+
+    assert "<channel_slug>_planning_<collection>.jpg" in phase_one
+    assert "既存出力" in phase_one
+    assert "上書きしない" in phase_one
+    assert "個別 timeout" in troubleshooting
+    assert "成功分" in troubleshooting
+
+
 def test_channel_new_setting_push_mode_contract_is_documented() -> None:
     channel_new = _read(".claude/skills/channel-new/SKILL.md")
     description = _frontmatter(".claude/skills/channel-new/SKILL.md")["description"]


### PR DESCRIPTION
## 概要

thumbnail-compare の live/planning discovery、除外、出力、timeout partial-success 契約を文書化します。

Closes #3231
Parent: #2587

## 変更内容

- live または planning の exact 10-assets/thumbnail.jpg を案内
- thumbnail-v* / planning-preview / main を除外
- live legacy / planning 固有 output patterns
- realpath dedupe と no-overwrite
- 個別 timeout warning と successful partial output

## 検証

- TDD RED to GREEN
- docs consistency: 71 passed
- yt-skills lint: 57 passed
- Ruff / Any / diff-check: passed
