### PR TITLE
fix(suno-verify): コレクション名を planning / live から解決する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 楽曲リストの選択状態に重ねていた太い ring を撤去し、状態色とチェックボックスを維持したままコレクション一覧と枠線の太さを揃えた（#2564）。
 - `fix(doctor)`: `pip install --user` / system-wide pip で導入した `yt-doctor` を、`pyproject.toml` がないチャンネルで実行しても `uv_project` / `automation_package` を異常扱いしないようにした。実行中 distribution の配置と installer metadata から uv project / uv tool / pip user / pip system を識別し、別途存在する uv tool を実行中の導入形態と誤認せず、判別不能な global 導入も推測した installer 名を表示しない（#3074）。
 - `fix(suno-helper)`: 外部 prompt の `style_influence` / `weirdness` が `null` の場合は未指定として slider 注入を skip し、Suno UI の現在値を維持する。数値 `0` は引き続き有効値として注入する（#3032）。
+- `fix(suno-verify)`: コレクションの明示パス指定を維持しつつ、bare directory name をチャンネルの `collections/planning/`、`collections/live/` の順に解決するようにした（#3243）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/src/youtube_automation/commands/suno/suno_verify.py
+++ b/src/youtube_automation/commands/suno/suno_verify.py
@@ -5,12 +5,34 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
+from youtube_automation.configuration import channel_dir
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.suno.config import infer_suno_mode, resolve_suno_config
 from youtube_automation.domains.suno.downloaded.validation import verify_suno_collection
 from youtube_automation.infrastructure.media.collection_paths import resolve_collection_dir
+
+
+def _resolve_collection_argument(collection: str | None) -> Path:
+    """明示パスを維持し、bare name だけを channel collections から解決する."""
+    if collection is None:
+        return resolve_collection_dir(None)
+
+    explicit = Path(collection)
+    if explicit.is_absolute() or explicit.exists() or "/" in collection or "\\" in collection:
+        return resolve_collection_dir(collection)
+
+    collections_root = channel_dir() / "collections"
+    for stage in ("planning", "live"):
+        candidate = collections_root / stage / collection
+        if candidate.is_dir():
+            return candidate.resolve()
+
+    raise ValidationError(
+        f"コレクション '{collection}' が collections/planning/ にも collections/live/ にも見つかりません"
+    )
 
 
 def main() -> int:
@@ -19,7 +41,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        collection_dir = resolve_collection_dir(args.collection)
+        collection_dir = _resolve_collection_argument(args.collection)
         suno_cfg = resolve_suno_config(load_skill_config("suno"))
         issues, summary = verify_suno_collection(collection_dir, suno_cfg, infer_suno_mode)
     except (ConfigError, ValidationError, OSError) as exc:

--- a/tests/commands/suno/test_suno_verify_cli.py
+++ b/tests/commands/suno/test_suno_verify_cli.py
@@ -67,7 +67,7 @@ def test_collection_resolution_failure_returns_one_and_prints_error(monkeypatch,
     monkeypatch.setattr(sys, "argv", ["yt-suno-verify", "missing"])
     monkeypatch.setattr(
         module,
-        "resolve_collection_dir",
+        "_resolve_collection_argument",
         lambda _collection: (_ for _ in ()).throw(ValidationError("collection missing")),
     )
 
@@ -90,3 +90,87 @@ def test_config_loading_failure_returns_one_and_prints_error(monkeypatch, capsys
 
     assert module.main() == 1
     assert capsys.readouterr().out == "ERROR: suno config invalid\n"
+
+
+def test_bare_collection_name_prefers_planning_over_live(monkeypatch, tmp_path):
+    """bare name が planning / live の両方にある場合は planning を検証する."""
+    module = load_suno_verify_module()
+    channel = tmp_path / "channel"
+    planning = channel / "collections" / "planning" / "same-name"
+    live = channel / "collections" / "live" / "same-name"
+    planning.mkdir(parents=True)
+    live.mkdir(parents=True)
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", "same-name"])
+    monkeypatch.setattr(module, "channel_dir", lambda: channel)
+    monkeypatch.setattr(module, "load_skill_config", lambda _skill: {})
+    monkeypatch.setattr(module, "resolve_suno_config", lambda _config: object())
+
+    def fake_verify(collection, config, infer_mode):
+        seen.update(collection=collection, config=config, infer_mode=infer_mode)
+        return [], "verified"
+
+    monkeypatch.setattr(module, "verify_suno_collection", fake_verify)
+
+    assert module.main() == 0
+    assert seen["collection"] == planning.resolve()
+
+
+def test_bare_collection_name_falls_back_to_live(monkeypatch, tmp_path):
+    """bare name が planning に無く live にある場合は live を検証する."""
+    module = load_suno_verify_module()
+    channel = tmp_path / "channel"
+    live = channel / "collections" / "live" / "live-only"
+    live.mkdir(parents=True)
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", "live-only"])
+    monkeypatch.setattr(module, "channel_dir", lambda: channel)
+    monkeypatch.setattr(module, "load_skill_config", lambda _skill: {})
+    monkeypatch.setattr(module, "resolve_suno_config", lambda _config: object())
+    monkeypatch.setattr(
+        module,
+        "verify_suno_collection",
+        lambda collection, _config, _infer_mode: (seen.update(collection=collection) or [], "verified"),
+    )
+
+    assert module.main() == 0
+    assert seen["collection"] == live.resolve()
+
+
+@pytest.mark.parametrize("path_kind", ["relative", "absolute"])
+def test_explicit_collection_path_is_preserved(monkeypatch, tmp_path, path_kind):
+    """既存の相対パス・絶対パス指定は collection-name 探索へ置換しない."""
+    module = load_suno_verify_module()
+    collection = tmp_path / "explicit"
+    collection.mkdir()
+    monkeypatch.chdir(tmp_path)
+    argument = "explicit" if path_kind == "relative" else str(collection)
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", argument])
+    monkeypatch.setattr(module, "channel_dir", lambda: tmp_path / "channel")
+    monkeypatch.setattr(module, "load_skill_config", lambda _skill: {})
+    monkeypatch.setattr(module, "resolve_suno_config", lambda _config: object())
+    monkeypatch.setattr(
+        module,
+        "verify_suno_collection",
+        lambda resolved, _config, _infer_mode: (seen.update(collection=resolved) or [], "verified"),
+    )
+
+    assert module.main() == 0
+    assert seen["collection"] == collection.resolve()
+
+
+def test_missing_bare_collection_name_returns_one_and_prints_error(monkeypatch, capsys, tmp_path):
+    """planning / live に無い bare name は ERROR と exit 1 に正規化する."""
+    module = load_suno_verify_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-suno-verify", "missing"])
+    monkeypatch.setattr(module, "channel_dir", lambda: tmp_path / "channel")
+
+    assert module.main() == 1
+    assert capsys.readouterr().out == (
+        "ERROR: コレクション 'missing' が collections/planning/ にも collections/live/ にも見つかりません\n"
+    )


### PR DESCRIPTION
## 概要

suno-verify が bare collection name を CHANNEL_DIR の planning/live から解決できるようにします。

Closes #3243
Parent: #2588
Blocked by closed #2724

## 変更内容

- explicit relative/absolute path を優先維持
- bare name は planning then live の順で検索
- duplicate name は planning が優先
- missing bare name は既存 ERROR/exit 1
- CHANGELOG と CLI regression tests を追加

## 検証

- TDD RED to GREEN: 5 cases
- focused: 48 passed
- Ruff check/format / Any / diff-check: passed
