### PR TITLE
refactor(workflow): 手作業基準時間の設定モデルを追加する

### DIFF
--- a/src/youtube_automation/configuration/workflow.py
+++ b/src/youtube_automation/configuration/workflow.py
@@ -135,3 +135,4 @@ class Workflow:
     wf_next: WfNext = field(default_factory=WfNext)
     post_publish: PostPublish = field(default_factory=PostPublish)
     scheduled_automation: ScheduledAutomation = field(default_factory=ScheduledAutomation)
+    manual_baseline_minutes: dict[str, float] | None = None


### PR DESCRIPTION
## 概要

Workflow に optional な action 別手作業基準時間の保持先を追加する後方互換 prefactor です。

Closes #3250
Parent: #2960

## 変更内容

- manual_baseline_minutes を mapping または None として追加
- default None で既存 Workflow 構築を維持

## 検証

- configuration focused tests: passed
- Ruff check / format、diff-check: passed
