### PR TITLE
docs(workflow): 手作業基準を example と fixture に同期する

### DIFF
--- a/examples/channel_config.example/workflow.json
+++ b/examples/channel_config.example/workflow.json
@@ -8,6 +8,13 @@
       "skip_upload_approval": true,
       "skip_manual_mastering": false
     },
+    "manual_baseline_minutes": {
+      "wf-new": 30,
+      "suno-helper": 45,
+      "masterup": 20,
+      "wf-next": 15,
+      "post-publish": 10
+    },
     "post-publish": {
       "skip_approvals": {
         "community-post": true,

--- a/tests/fixtures/sample_channel/config/channel/workflow.json
+++ b/tests/fixtures/sample_channel/config/channel/workflow.json
@@ -1,3 +1,8 @@
 {
-  "workflow": {}
+  "workflow": {
+    "manual_baseline_minutes": {
+      "wf-new": 30,
+      "wf-next": 15
+    }
+  }
 }


### PR DESCRIPTION
## 概要

manual_baseline_minutes の公開設定例と sample channel fixture を runtime schema に同期します。

Closes #3251
Parent: #2960

## 変更内容

- example に canonical wf-auto action の分単位 baseline 例を追加
- sample fixture に設定済み baseline を追加

## 検証

- 両 JSON: python -m json.tool passed
- sample fixture load_config smoke: passed
- tests/configuration/test_config_loader.py: 276 passed
- diff-check: passed
