### PR TITLE
fix(auth): readonly OAuth を非対話で fail-fast にする (#3269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(collection-serve)`: `--allow-extension` が同名候補を検出しても有効 ID が 0 件、または複数 ID の場合は起動前に拒否し、検出した全候補の profile / ID / path / enabled 状態と `--allow-origin` fallback を `ConfigError` に列挙する（#3216）。
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
 - `fix(thumbnail-compare)`: ベンチマーク更新・サムネイル取得・縮小の進捗を即時表示し、画像取得を slow-drip を含む wall-clock deadline、ffmpeg を有限 timeout にした。個別対象の timeout 後も警告して成功分の比較出力を継続する（#3229）。
+- `fix(auth)`: readonly OAuth handler に明示的な非対話 policy を追加し、`token.readonly.json` が未発行・不正・refresh 不能な場合は browser OAuth を開始せず、`uv run yt-oauth --readonly` による発行を案内して fail-fast するようにした（#2956）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/src/youtube_automation/infrastructure/auth/youtube.py
+++ b/src/youtube_automation/infrastructure/auth/youtube.py
@@ -128,7 +128,7 @@ class YouTubeOAuthHandler:
     # token_streaming.json（#135）と並ぶ第 3 の用途別 token（#1699）
     READONLY_TOKEN_FILENAME: ClassVar[str] = "token.readonly.json"
 
-    def __init__(self, auth_dir=None, scopes=None, token_path=None):
+    def __init__(self, auth_dir=None, scopes=None, token_path=None, *, interactive: bool = True):
         """
         初期化
 
@@ -137,6 +137,7 @@ class YouTubeOAuthHandler:
             scopes (list[str] | None): OAuth scopes。未指定時はクラス属性 ``SCOPES``（既存挙動）
             token_path (str | Path | None): token ファイルパス。未指定時は ``<auth_dir>/token.json``。
                 stream key 取得用に ``token_streaming.json`` を分離する用途で使用する（issue #135）
+            interactive (bool): token を利用できない場合に browser OAuth を開始してよいか。
         """
         from youtube_automation.configuration import channel_dir as _channel_dir
 
@@ -168,6 +169,7 @@ class YouTubeOAuthHandler:
         else:
             self.token_file = resolve_token_path(self.auth_dir)
         self.credentials = None
+        self._interactive = interactive
 
     @classmethod
     def readonly_token_path(cls) -> Path | None:
@@ -192,7 +194,7 @@ class YouTubeOAuthHandler:
         return None
 
     @classmethod
-    def create_readonly(cls) -> "YouTubeOAuthHandler":
+    def create_readonly(cls, *, interactive: bool = True) -> "YouTubeOAuthHandler":
         """read-only スコープ + ``token.readonly.json`` のハンドラーを生成する。
 
         未発行時の保存先は ``token.json`` と同じ規則で解決する
@@ -208,7 +210,16 @@ class YouTubeOAuthHandler:
             if main_root is not None:
                 auth_dir = main_root / "auth"
             resolved_token_path = resolve_token_path(auth_dir, cls.READONLY_TOKEN_FILENAME)
-        return cls(scopes=cls.READONLY_SCOPES, token_path=resolved_token_path)
+        return cls(scopes=cls.READONLY_SCOPES, token_path=resolved_token_path, interactive=interactive)
+
+    def _require_interactive_reauthentication(self) -> None:
+        if self._interactive:
+            return
+        command = "uv run yt-oauth --readonly" if self._scopes == self.READONLY_SCOPES else "uv run yt-oauth"
+        raise AuthError(
+            "非対話実行では OAuth token を新規発行できません。"
+            f"対話可能なターミナルで `{command}` を実行して token を発行してください。"
+        )
 
     def _channel_label(self) -> str:
         """認証メッセージに埋め込むチャンネル識別ラベルを返す。
@@ -267,9 +278,6 @@ class YouTubeOAuthHandler:
         """
         print("🔐 YouTube Data API OAuth 2.0 認証開始...")
 
-        # client_secrets.json の確認
-        self._validate_client_secrets()
-
         # 既存トークンの読み込み
         if not force_reauth and self.token_file.exists():
             try:
@@ -289,7 +297,7 @@ class YouTubeOAuthHandler:
                     self.credentials.refresh(Request())
                     print("✅ トークン更新成功")
                     self._save_credentials()
-                except google.auth.exceptions.RefreshError as e:
+                except google.auth.exceptions.GoogleAuthError as e:
                     # AuthError を raise すると新規認証へのフォールスルー recovery が壊れる。
                     # credentials=None に落として下の新規認証ブロックで recovery する。
                     logger.warning("token refresh 失敗: %s", redact_sensitive_data(str(e)))
@@ -297,6 +305,8 @@ class YouTubeOAuthHandler:
 
         # 新規認証が必要な場合
         if not self.credentials or not self.credentials.valid:
+            self._require_interactive_reauthentication()
+            self._validate_client_secrets()
             channel_label = self._channel_label()
             print(f"🌐 [{channel_label}] ブラウザで認証を実行します...")
             print("📝 注意: 初回認証時はブラウザが開き、Googleアカウントでのログインが必要です")

--- a/tests/infrastructure/auth/test_oauth_readonly_token.py
+++ b/tests/infrastructure/auth/test_oauth_readonly_token.py
@@ -10,6 +10,10 @@ read-only skill が write scope を共用しないための 3 点を検証する
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import google.auth.exceptions
+import pytest
+
+from youtube_automation.core.errors import AuthError
 from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
@@ -31,6 +35,16 @@ def _make_worktree_pair(tmp_path: Path) -> tuple[Path, Path]:
     worktree.mkdir()
     (worktree / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
     return main_root, worktree
+
+
+def _create_readonly_handler(tmp_path: Path, monkeypatch, *, interactive: bool):
+    channel = tmp_path / "channel"
+    (channel / "auth").mkdir(parents=True)
+    monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
+    monkeypatch.setenv("CHANNEL_DIR", str(channel))
+    handler = YouTubeOAuthHandler.create_readonly(interactive=interactive)
+    handler._validate_client_secrets = MagicMock()
+    return handler
 
 
 class TestReadonlyScopes:
@@ -111,6 +125,127 @@ class TestCreateReadonly:
 
         handler = YouTubeOAuthHandler.create_readonly()
         assert handler.token_file == main_root.resolve() / "auth" / "token.readonly.json"
+
+
+class TestReadonlyInteractivePolicy:
+    def test_noninteractive_missing_token_fails_with_issue_command_before_browser(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        browser_flow = MagicMock()
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.InstalledAppFlow.from_client_secrets_file",
+            browser_flow,
+        )
+
+        with pytest.raises(AuthError, match=r"uv run yt-oauth --readonly"):
+            handler.authenticate()
+
+        browser_flow.assert_not_called()
+
+    def test_noninteractive_invalid_token_fails_before_browser(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        handler.token_file.write_text("{}", encoding="utf-8")
+        browser_flow = MagicMock()
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(side_effect=ValueError("invalid token")),
+        )
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.InstalledAppFlow.from_client_secrets_file",
+            browser_flow,
+        )
+
+        with pytest.raises(AuthError, match=r"uv run yt-oauth --readonly"):
+            handler.authenticate()
+
+        browser_flow.assert_not_called()
+
+    def test_noninteractive_refresh_failure_fails_before_browser(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        handler.token_file.write_text("{}", encoding="utf-8")
+        credentials = MagicMock(expired=True, valid=False, refresh_token="refresh-token")
+        credentials.refresh.side_effect = google.auth.exceptions.RefreshError("revoked")
+        browser_flow = MagicMock()
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(return_value=credentials),
+        )
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.InstalledAppFlow.from_client_secrets_file",
+            browser_flow,
+        )
+
+        with pytest.raises(AuthError, match=r"uv run yt-oauth --readonly"):
+            handler.authenticate()
+
+        browser_flow.assert_not_called()
+
+    def test_noninteractive_refresh_transport_failure_fails_before_browser(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        handler.token_file.write_text("{}", encoding="utf-8")
+        credentials = MagicMock(expired=True, valid=False, refresh_token="refresh-token")
+        credentials.refresh.side_effect = google.auth.exceptions.TransportError("network unavailable")
+        browser_flow = MagicMock()
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(return_value=credentials),
+        )
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.InstalledAppFlow.from_client_secrets_file",
+            browser_flow,
+        )
+
+        with pytest.raises(AuthError, match=r"uv run yt-oauth --readonly"):
+            handler.authenticate()
+
+        browser_flow.assert_not_called()
+
+    def test_noninteractive_valid_token_is_reused(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        handler.token_file.write_text("{}", encoding="utf-8")
+        credentials = MagicMock(expired=False, valid=True)
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(return_value=credentials),
+        )
+
+        assert handler.authenticate() is credentials
+        handler._validate_client_secrets.assert_not_called()
+
+    def test_noninteractive_refreshable_token_is_refreshed(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=False)
+        handler.token_file.write_text("{}", encoding="utf-8")
+        credentials = MagicMock(expired=True, valid=False, refresh_token="refresh-token")
+
+        def mark_valid(_request):
+            credentials.expired = False
+            credentials.valid = True
+
+        credentials.refresh.side_effect = mark_valid
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(return_value=credentials),
+        )
+        handler._save_credentials = MagicMock()
+
+        assert handler.authenticate() is credentials
+        credentials.refresh.assert_called_once()
+        handler._save_credentials.assert_called_once_with()
+
+    def test_default_policy_keeps_interactive_browser_flow(self, tmp_path, monkeypatch):
+        handler = _create_readonly_handler(tmp_path, monkeypatch, interactive=True)
+        credentials = MagicMock(expired=False, valid=True)
+        flow = MagicMock()
+        flow.run_local_server.return_value = credentials
+        browser_flow = MagicMock(return_value=flow)
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.InstalledAppFlow.from_client_secrets_file",
+            browser_flow,
+        )
+        handler._save_credentials = MagicMock()
+
+        assert handler.authenticate() is credentials
+        browser_flow.assert_called_once()
+        flow.run_local_server.assert_called_once()
 
 
 class TestYouTubeClientsReadonly:


### PR DESCRIPTION
## 概要

readonly OAuth handler に明示的な interactive policy を追加し、非対話実行では browser OAuth に入らず fail-fast します。

Closes #3269
Parent: #2956

## 変更内容

- `create_readonly(interactive=...)` と handler policy を追加（既定は interactive）
- missing / invalid / refresh不能 token を `AuthError` にして `yt-oauth --readonly` を案内
- valid / refreshable token と既定 browser flow の回帰テストを追加

## 検証

- [x] `nix develop --command uv run pytest tests/infrastructure/auth/test_oauth_readonly_token.py tests/infrastructure/auth/test_oauth_handler_exceptions.py -q` (78 passed)
- [x] 対象 Python の ruff check / format
- [x] `git diff --check`
