### PR TITLE
fix(auth): readonly consumer を非対話認証へ接続する (#3270)

### DIFF
--- a/src/youtube_automation/infrastructure/google/youtube.py
+++ b/src/youtube_automation/infrastructure/google/youtube.py
@@ -19,7 +19,7 @@ def create_authenticated_youtube_clients() -> "YouTubeClients":
 def create_readonly_youtube_clients() -> "YouTubeClients":
     from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
 
-    return YouTubeClients(readonly_handler=YouTubeOAuthHandler.create_readonly())
+    return YouTubeClients(readonly_handler=YouTubeOAuthHandler.create_readonly(interactive=False))
 
 
 def execute_youtube_request(request, context: str, *, on_attempt: Callable[[], None] | None = None):

--- a/tests/infrastructure/google/test_youtube_service.py
+++ b/tests/infrastructure/google/test_youtube_service.py
@@ -1,12 +1,16 @@
 """Instance-scoped YouTube client cache tests."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from youtube_automation.core.errors import ValidationError
-from youtube_automation.infrastructure.google.youtube import YouTubeClients, validate_youtube_response_items
+from youtube_automation.infrastructure.google.youtube import (
+    YouTubeClients,
+    create_readonly_youtube_clients,
+    validate_youtube_response_items,
+)
 
 
 def _handler(*, youtube=None):
@@ -36,6 +40,17 @@ def test_full_and_readonly_services_are_cached_independently():
     assert clients.youtube_readonly == "readonly"
     full_handler.get_youtube_service.assert_called_once_with()
     readonly_handler.get_youtube_service.assert_called_once_with()
+
+
+def test_readonly_factory_disables_interactive_browser_auth():
+    readonly_handler = MagicMock()
+    with patch("youtube_automation.infrastructure.auth.youtube.YouTubeOAuthHandler") as handler_class:
+        handler_class.create_readonly.return_value = readonly_handler
+
+        clients = create_readonly_youtube_clients()
+
+    assert clients._read_handler is readonly_handler
+    handler_class.create_readonly.assert_called_once_with(interactive=False)
 
 
 def test_reset_clears_only_this_instance_cache():


### PR DESCRIPTION
## 概要

read-only consumer 共通 factory を非対話 OAuth policy に接続し、channel-status / metadata-audit が token 不備時に browser 待ちへ入らないようにします。

Closes #3270
Parent: #2956

## 変更内容

- `create_readonly_youtube_clients()` が `create_readonly(interactive=False)` を選択
- factory の policy 伝播を unit test で固定
- channel-status / metadata-audit を含む consumer focused tests で既存経路を検証

## 検証

- [x] `nix develop --command uv run pytest tests/infrastructure/google/test_youtube_service.py tests/commands/channel/test_channel_status.py tests/commands/metadata/test_metadata_audit.py tests/infrastructure/auth/test_oauth_readonly_token.py -q` (54 passed)
- [x] 対象 Python の ruff check / format
- [x] `git diff --check`
