### PR TITLE
feat(wf-auto): 全attemptの実行時間を集計する

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -166,6 +166,73 @@ def _attempt_timing(segments: list[TimingSegment] | None) -> dict | None:
     return timing
 
 
+def summarize_attempt_durations(history: dict) -> dict:
+    """Aggregate every measured attempt without treating unavailable timing as zero."""
+    if not isinstance(history, dict) or not isinstance(history.get("attempts"), list):
+        raise ValueError("history は attempts array を持つ object でなければなりません")
+    schema_version = history.get("schema_version")
+    if schema_version == 1:
+        return {
+            "available": False,
+            "reason": "history_schema_v1",
+            "actions": None,
+            "totals": None,
+        }
+    if schema_version != 2:
+        raise ValueError(f"未対応 history schema です: {schema_version!r}")
+
+    accumulators: dict[str, dict] = {}
+    for index, attempt in enumerate(history["attempts"]):
+        if not isinstance(attempt, dict):
+            raise ValueError(f"history.attempts[{index}] は object でなければなりません")
+        action = attempt.get("action")
+        if not isinstance(action, str) or not action:
+            raise ValueError(f"history.attempts[{index}].action は空でない string でなければなりません")
+        collection = attempt.get("collection")
+        if collection is not None and (not isinstance(collection, str) or not collection):
+            raise ValueError(f"history.attempts[{index}].collection は null または空でない string です")
+        timing = attempt.get("timing")
+        if timing is None:
+            return {
+                "available": False,
+                "reason": "attempt_timing_unavailable",
+                "actions": None,
+                "totals": None,
+            }
+        _validate_timing(timing, source=f"history.attempts[{index}]")
+
+        accumulator = accumulators.setdefault(
+            action,
+            {
+                "ai_durations": [],
+                "human_durations": [],
+                "attempt_count": 0,
+                "work_items": set(),
+            },
+        )
+        for segment in timing["segments"]:
+            accumulator[f"{segment['kind']}_durations"].append(float(segment["duration_seconds"]))
+        accumulator["attempt_count"] += 1
+        accumulator["work_items"].add(collection)
+
+    actions = {}
+    for action in sorted(accumulators):
+        accumulator = accumulators[action]
+        actions[action] = {
+            "ai_seconds": math.fsum(accumulator["ai_durations"]),
+            "human_seconds": math.fsum(accumulator["human_durations"]),
+            "attempt_count": accumulator["attempt_count"],
+            "work_item_count": len(accumulator["work_items"]),
+        }
+    totals = {
+        "ai_seconds": math.fsum(item["ai_seconds"] for item in actions.values()),
+        "human_seconds": math.fsum(item["human_seconds"] for item in actions.values()),
+        "attempt_count": sum(item["attempt_count"] for item in actions.values()),
+        "work_item_count": sum(item["work_item_count"] for item in actions.values()),
+    }
+    return {"available": True, "reason": None, "actions": actions, "totals": totals}
+
+
 def _inside(root: Path, path: Path, field: str) -> Path:
     root = root.resolve()
     path = path.resolve()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
 - `feat(wf-auto)`: workflow attempt に AI / human の型付き timing segment と種別別秒数を append-only で記録する schema v2 を追加した（#3248）。
 - `feat(wf-auto)`: schema v1 の `.automation-run/history.json` を時間未取得として読み出し、根拠のない実行時間を推測しない後方互換契約を追加した（#3247）。
 - `feat(wf-auto)`: `.automation-run/history.json` を schema v2 へ拡張し、attempt ごとの AI / human 区間と種別別秒数を append-only で保持できるようにした。schema v1 は時間を推測せず unavailable として読み、open segment・時刻逆転・負 duration は非破壊で拒否する（#2959）。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -230,6 +230,114 @@ def test_schema_v2_appends_typed_segments_and_preserves_every_attempt(tmp_path: 
     }
 
 
+def test_attempt_duration_summary_includes_every_status_and_work_item(runner: ModuleType) -> None:
+    def attempt(collection: str, action: str, status: str, ai_seconds: float, human_seconds: float) -> dict:
+        return {
+            "collection": collection,
+            "action": action,
+            "status": status,
+            "timing": {
+                "segments": [
+                    {
+                        "kind": "ai",
+                        "started_at": "2026-07-21T00:00:00+00:00",
+                        "ended_at": "2026-07-21T00:00:01+00:00",
+                        "duration_seconds": ai_seconds,
+                    },
+                    {
+                        "kind": "human",
+                        "started_at": "2026-07-21T00:00:01+00:00",
+                        "ended_at": "2026-07-21T00:00:02+00:00",
+                        "duration_seconds": human_seconds,
+                    },
+                ]
+            },
+        }
+
+    history = {
+        "schema_version": 2,
+        "attempts": [
+            attempt("collections/planning/a", "wf-next", "failed", 10.0, 2.0),
+            attempt("collections/planning/a", "wf-next", "blocked", 5.0, 3.0),
+            attempt("collections/planning/a", "wf-next", "success", 20.0, 1.0),
+            attempt("collections/planning/b", "wf-next", "success", 30.0, 4.0),
+            attempt("collections/planning/a", "masterup", "success", 7.0, 6.0),
+        ],
+    }
+
+    summary = runner.summarize_attempt_durations(history)
+
+    assert summary == {
+        "available": True,
+        "reason": None,
+        "actions": {
+            "masterup": {
+                "ai_seconds": 7.0,
+                "human_seconds": 6.0,
+                "attempt_count": 1,
+                "work_item_count": 1,
+            },
+            "wf-next": {
+                "ai_seconds": 65.0,
+                "human_seconds": 10.0,
+                "attempt_count": 4,
+                "work_item_count": 2,
+            },
+        },
+        "totals": {
+            "ai_seconds": 72.0,
+            "human_seconds": 16.0,
+            "attempt_count": 5,
+            "work_item_count": 3,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("history", "reason"),
+    [
+        ({"schema_version": 1, "attempts": []}, "history_schema_v1"),
+        (
+            {"schema_version": 2, "attempts": [{"collection": None, "action": "wf-new", "timing": None}]},
+            "attempt_timing_unavailable",
+        ),
+    ],
+)
+def test_attempt_duration_summary_distinguishes_unavailable_from_zero(
+    runner: ModuleType, history: dict, reason: str
+) -> None:
+    assert runner.summarize_attempt_durations(history) == {
+        "available": False,
+        "reason": reason,
+        "actions": None,
+        "totals": None,
+    }
+
+    zero_summary = runner.summarize_attempt_durations(
+        {
+            "schema_version": 2,
+            "attempts": [
+                {
+                    "collection": None,
+                    "action": "wf-new",
+                    "timing": {
+                        "segments": [
+                            {
+                                "kind": "ai",
+                                "started_at": "2026-07-21T00:00:00+00:00",
+                                "ended_at": "2026-07-21T00:00:00+00:00",
+                                "duration_seconds": 0.0,
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+    )
+    assert zero_summary["available"] is True
+    assert zero_summary["totals"]["ai_seconds"] == 0.0
+
+
 @pytest.mark.parametrize(
     ("segment", "message"),
     [


### PR DESCRIPTION
## 概要

schema v2 history の全 attempt を status に関係なく再集計し、action 別・全体の AI 秒、人間秒、attempt 数、work item 数を返します。legacy / timing 欠落は 0 とせず unavailable にします。

Closes #3272
Parent: #2961
Depends on: #3257
Stack: #3256

## 変更内容

- validated segment から duration を再合算
- 同じ collection / action を 1 work item として集約
- failed / blocked / retry / success をすべて保持
- schema v1 / timing 欠落と実測 0 秒を区別

## 検証

- `uv run pytest -q tests/repo/test_wf_auto_state.py`（19 passed）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` 更新
- [x] focused unit tests 更新
- [x] 3 files / 1 branch / 1 commit