### PR TITLE
feat(wf-auto): 2種類の削減時間を算出する

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -233,6 +233,65 @@ def summarize_attempt_durations(history: dict) -> dict:
     return {"available": True, "reason": None, "actions": actions, "totals": totals}
 
 
+def summarize_time_savings(history: dict, manual_baseline_minutes: dict[str, float] | None) -> dict:
+    """Apply configured per-work-item baselines to measured attempt durations."""
+    duration_summary = summarize_attempt_durations(history)
+    if not duration_summary["available"]:
+        return duration_summary
+    if manual_baseline_minutes is None:
+        return {
+            "available": False,
+            "reason": "manual_baseline_unconfigured",
+            "actions": None,
+            "totals": None,
+        }
+    if not isinstance(manual_baseline_minutes, dict):
+        raise ValueError("manual_baseline_minutes は object または null でなければなりません")
+
+    actions = {}
+    for action, duration in duration_summary["actions"].items():
+        if action not in manual_baseline_minutes:
+            return {
+                "available": False,
+                "reason": f"manual_baseline_missing:{action}",
+                "actions": None,
+                "totals": None,
+            }
+        minutes = manual_baseline_minutes[action]
+        if isinstance(minutes, bool) or not isinstance(minutes, (int, float)):
+            raise ValueError(f"manual_baseline_minutes.{action} は 0 以上の有限 number でなければなりません")
+        try:
+            invalid_minutes = minutes < 0 or not math.isfinite(minutes)
+        except OverflowError:
+            invalid_minutes = True
+        if invalid_minutes:
+            raise ValueError(f"manual_baseline_minutes.{action} は 0 以上の有限 number でなければなりません")
+
+        baseline_seconds = float(minutes) * 60 * duration["work_item_count"]
+        actions[action] = {
+            **duration,
+            "manual_baseline_seconds": baseline_seconds,
+            "ai_inclusive_saved_seconds": max(
+                0.0,
+                baseline_seconds - duration["ai_seconds"] - duration["human_seconds"],
+            ),
+            "human_freed_seconds": max(0.0, baseline_seconds - duration["human_seconds"]),
+        }
+
+    duration_totals = duration_summary["totals"]
+    baseline_total = math.fsum(item["manual_baseline_seconds"] for item in actions.values())
+    totals = {
+        **duration_totals,
+        "manual_baseline_seconds": baseline_total,
+        "ai_inclusive_saved_seconds": max(
+            0.0,
+            baseline_total - duration_totals["ai_seconds"] - duration_totals["human_seconds"],
+        ),
+        "human_freed_seconds": max(0.0, baseline_total - duration_totals["human_seconds"]),
+    }
+    return {"available": True, "reason": None, "actions": actions, "totals": totals}
+
+
 def _inside(root: Path, path: Path, field: str) -> Path:
     root = root.resolve()
     path = path.resolve()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
 - `feat(wf-auto)`: workflow attempt に AI / human の型付き timing segment と種別別秒数を append-only で記録する schema v2 を追加した（#3248）。
 - `feat(wf-auto)`: schema v1 の `.automation-run/history.json` を時間未取得として読み出し、根拠のない実行時間を推測しない後方互換契約を追加した（#3247）。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -338,6 +338,125 @@ def test_attempt_duration_summary_distinguishes_unavailable_from_zero(
     assert zero_summary["totals"]["ai_seconds"] == 0.0
 
 
+def test_time_savings_uses_every_attempt_and_baseline_per_work_item(runner: ModuleType) -> None:
+    def attempt(collection: str, action: str, kind: str, duration: float) -> dict:
+        return {
+            "collection": collection,
+            "action": action,
+            "timing": {
+                "segments": [
+                    {
+                        "kind": kind,
+                        "started_at": "2026-07-21T00:00:00+00:00",
+                        "ended_at": "2026-07-21T00:00:01+00:00",
+                        "duration_seconds": duration,
+                    }
+                ]
+            },
+        }
+
+    history = {
+        "schema_version": 2,
+        "attempts": [
+            attempt("collections/planning/a", "wf-next", "ai", 50.0),
+            attempt("collections/planning/a", "wf-next", "human", 30.0),
+            attempt("collections/planning/b", "wf-next", "ai", 30.0),
+            attempt("collections/planning/b", "wf-next", "human", 20.0),
+            attempt("collections/planning/a", "masterup", "ai", 10.0),
+            attempt("collections/planning/a", "masterup", "human", 20.0),
+        ],
+    }
+
+    summary = runner.summarize_time_savings(history, {"wf-next": 1.0, "masterup": 1.0})
+
+    assert summary["available"] is True
+    assert summary["actions"]["wf-next"] == {
+        "ai_seconds": 80.0,
+        "human_seconds": 50.0,
+        "attempt_count": 4,
+        "work_item_count": 2,
+        "manual_baseline_seconds": 120.0,
+        "ai_inclusive_saved_seconds": 0.0,
+        "human_freed_seconds": 70.0,
+    }
+    assert summary["actions"]["masterup"]["ai_inclusive_saved_seconds"] == 30.0
+    assert summary["totals"] == {
+        "ai_seconds": 90.0,
+        "human_seconds": 70.0,
+        "attempt_count": 6,
+        "work_item_count": 3,
+        "manual_baseline_seconds": 180.0,
+        "ai_inclusive_saved_seconds": 20.0,
+        "human_freed_seconds": 110.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("history", "baselines", "reason"),
+    [
+        ({"schema_version": 2, "attempts": []}, None, "manual_baseline_unconfigured"),
+        (
+            {
+                "schema_version": 2,
+                "attempts": [
+                    {
+                        "collection": None,
+                        "action": "wf-new",
+                        "timing": {"segments": []},
+                    }
+                ],
+            },
+            {},
+            "manual_baseline_missing:wf-new",
+        ),
+        ({"schema_version": 1, "attempts": []}, {"wf-new": 30.0}, "history_schema_v1"),
+    ],
+)
+def test_time_savings_keeps_unavailable_distinct_from_zero(
+    runner: ModuleType, history: dict, baselines: dict | None, reason: str
+) -> None:
+    assert runner.summarize_time_savings(history, baselines) == {
+        "available": False,
+        "reason": reason,
+        "actions": None,
+        "totals": None,
+    }
+
+
+def test_time_savings_clamps_negative_values_to_available_zero(runner: ModuleType) -> None:
+    history = {
+        "schema_version": 2,
+        "attempts": [
+            {
+                "collection": "collections/planning/a",
+                "action": "wf-next",
+                "timing": {
+                    "segments": [
+                        {
+                            "kind": "ai",
+                            "started_at": "2026-07-21T00:00:00+00:00",
+                            "ended_at": "2026-07-21T00:00:01+00:00",
+                            "duration_seconds": 120.0,
+                        },
+                        {
+                            "kind": "human",
+                            "started_at": "2026-07-21T00:00:01+00:00",
+                            "ended_at": "2026-07-21T00:00:02+00:00",
+                            "duration_seconds": 60.0,
+                        },
+                    ]
+                },
+            }
+        ],
+    }
+
+    summary = runner.summarize_time_savings(history, {"wf-next": 1.0})
+
+    assert summary["available"] is True
+    assert summary["totals"]["ai_inclusive_saved_seconds"] == 0.0
+    assert summary["totals"]["human_freed_seconds"] == 0.0
+
+
 @pytest.mark.parametrize(
     ("segment", "message"),
     [


### PR DESCRIPTION
## 概要

全 attempt の duration 集計へ action 別手作業基準を適用し、「AI込み削減時間」と「人間が浮いた時間」を action 別・全体で算出します。

Closes #3273
Parent: #2961
Depends on: #3276
Stack: #3256

## 変更内容

- baseline 分を work item 件数に応じて秒へ変換
- 全 retry の AI / human 秒を 2 つの式へ反映
- 負値を available な 0 に clamp
- baseline 未設定・action 欠落・legacy timing を理由付き unavailable として維持

## 検証

- `uv run pytest -q tests/repo/test_wf_auto_state.py`（24 passed）
- `uv run ruff check .`
- `uv run ruff format --check .`（737 files）
- `uv run yt-skills lint wf-auto`
- `git diff --check`

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` 更新
- [x] focused unit tests 更新
- [x] 3 files / 1 branch / 1 commit