### PR TITLE
feat(wf-auto): record CLI で AI 区間を保存する (#3280)

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -292,6 +292,23 @@ def summarize_time_savings(history: dict, manual_baseline_minutes: dict[str, flo
     return {"available": True, "reason": None, "actions": actions, "totals": totals}
 
 
+def _ai_timing_segment(started_at: str, ended_at: str) -> TimingSegment:
+    started = _timestamp(started_at, field="ai_started_at", source="record")
+    ended = _timestamp(ended_at, field="recorded_at", source="record")
+    try:
+        duration_seconds = (ended - started).total_seconds()
+    except TypeError as exc:
+        raise ValueError("record: ai_started_at と recorded_at の timezone 指定が一致しません") from exc
+    segment: TimingSegment = {
+        "kind": "ai",
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_seconds": duration_seconds,
+    }
+    _validate_timing({"segments": [segment]}, source="record")
+    return segment
+
+
 def _inside(root: Path, path: Path, field: str) -> Path:
     root = root.resolve()
     path = path.resolve()
@@ -947,6 +964,7 @@ def record_bootstrap_attempt(
     status: Literal["blocked", "failed"],
     reason: str,
     now: str,
+    ai_started_at: str | None = None,
 ) -> None:
     """Record an unattended `/wf-new` stop before a collection exists."""
     record_attempt(
@@ -958,6 +976,7 @@ def record_bootstrap_attempt(
         reason=reason,
         resume_action="wf-new",
         now=now,
+        segments=[_ai_timing_segment(ai_started_at, now)] if ai_started_at is not None else None,
     )
 
 
@@ -985,11 +1004,13 @@ def _parser() -> argparse.ArgumentParser:
     record.add_argument("--status", choices=("success", "blocked", "failed"), required=True)
     record.add_argument("--reason", required=True)
     record.add_argument("--resume-action", choices=sorted(ACTIONS))
+    record.add_argument("--ai-started-at")
     bootstrap = sub.add_parser("record-bootstrap")
     bootstrap.add_argument("--channel-dir", type=Path, default=Path.cwd())
     bootstrap.add_argument("--token", required=True)
     bootstrap.add_argument("--status", choices=("blocked", "failed"), required=True)
     bootstrap.add_argument("--reason", required=True)
+    bootstrap.add_argument("--ai-started-at")
     return parser
 
 
@@ -1013,16 +1034,20 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "plan":
             result = resolve_action(root, args.collection)
         elif args.command == "record-bootstrap":
+            recorded_at = datetime.now(UTC).isoformat()
             record_bootstrap_attempt(
                 root,
                 token=args.token,
                 status=args.status,
                 reason=args.reason,
-                now=datetime.now(UTC).isoformat(),
+                now=recorded_at,
+                ai_started_at=args.ai_started_at,
             )
             result = {"status": "recorded"}
         else:
             collection = select_collection(root, args.collection)
+            recorded_at = datetime.now(UTC).isoformat()
+            segments = [_ai_timing_segment(args.ai_started_at, recorded_at)] if args.ai_started_at is not None else None
             record_attempt(
                 root,
                 token=args.token,
@@ -1031,7 +1056,8 @@ def main(argv: list[str] | None = None) -> int:
                 status=args.status,
                 reason=args.reason,
                 resume_action=args.resume_action,
-                now=datetime.now(UTC).isoformat(),
+                now=recorded_at,
+                segments=segments,
             )
             result = {"status": "recorded"}
     except LeaseBusyError as exc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
+- `feat(wf-auto)`: canonical action の開始時刻を state CLI の `record` へ渡し、success / failed / blocked の全 attempt に閉じた AI 実行区間を append-only で保存できる契約を追加した（#2962）。
 - `feat(wf-auto)`: workflow attempt に AI / human の型付き timing segment と種別別秒数を append-only で記録する schema v2 を追加した（#3248）。
 - `feat(wf-auto)`: schema v1 の `.automation-run/history.json` を時間未取得として読み出し、根拠のない実行時間を推測しない後方互換契約を追加した（#3247）。
 - `feat(wf-auto)`: `.automation-run/history.json` を schema v2 へ拡張し、attempt ごとの AI / human 区間と種別別秒数を append-only で保持できるようにした。schema v1 は時間を推測せず unavailable として読み、open segment・時刻逆転・負 duration は非破壊で拒否する（#2959）。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import sys
 import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import ModuleType
 
@@ -156,6 +157,7 @@ def test_unattended_manual_intervention_is_recorded_with_resume_action(tmp_path:
     assert history["attempts"][-1]["collection"] is None
     assert history["attempts"][-1]["action"] == "wf-new"
     assert history["attempts"][-1]["resume_action"] == "wf-new"
+    assert history["attempts"][-1]["timing"] is None
 
 
 def test_schema_v1_history_reads_timing_as_unavailable_without_mutation(tmp_path: Path, runner: ModuleType) -> None:
@@ -545,6 +547,117 @@ def test_invalid_timing_fails_loud_on_read_and_append_without_mutating_history(
     assert history_path.read_text(encoding="utf-8") == original
 
 
+@pytest.mark.parametrize("status", ["success", "failed", "blocked"])
+def test_cli_record_closes_ai_segment_for_every_outcome(
+    tmp_path: Path,
+    runner: ModuleType,
+    status: str,
+) -> None:
+    collection = _collection(tmp_path, "20260721-timed")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+    started_at = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+
+    assert (
+        runner.main(
+            [
+                "record",
+                "--channel-dir",
+                str(tmp_path),
+                "--token",
+                token,
+                "--collection",
+                collection.name,
+                "--action",
+                "lyria",
+                "--status",
+                status,
+                "--reason",
+                f"timed_{status}",
+                "--ai-started-at",
+                started_at,
+            ]
+        )
+        == 0
+    )
+
+    attempt = runner.read_history(tmp_path)["attempts"][-1]
+    assert attempt["status"] == status
+    assert attempt["timing"]["human_seconds"] == 0
+    assert attempt["timing"]["ai_seconds"] >= 1
+    assert attempt["timing"]["segments"] == [
+        {
+            "kind": "ai",
+            "started_at": started_at,
+            "ended_at": attempt["timing"]["ended_at"],
+            "duration_seconds": attempt["timing"]["ai_seconds"],
+        }
+    ]
+
+
+def test_cli_record_retry_appends_new_timed_attempt_without_overwriting_failure(
+    tmp_path: Path, runner: ModuleType
+) -> None:
+    collection = _collection(tmp_path, "20260721-retry")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+
+    for index, status in enumerate(("failed", "success"), start=1):
+        started_at = (datetime.now(UTC) - timedelta(seconds=index)).isoformat()
+        assert (
+            runner.main(
+                [
+                    "record",
+                    "--channel-dir",
+                    str(tmp_path),
+                    "--token",
+                    token,
+                    "--collection",
+                    collection.name,
+                    "--action",
+                    "lyria",
+                    "--status",
+                    status,
+                    "--reason",
+                    f"attempt_{status}",
+                    "--ai-started-at",
+                    started_at,
+                ]
+            )
+            == 0
+        )
+
+    attempts = runner.read_history(tmp_path)["attempts"]
+    assert [attempt["status"] for attempt in attempts] == ["failed", "success"]
+    assert all(attempt["timing"]["segments"][0]["kind"] == "ai" for attempt in attempts)
+
+
+def test_cli_record_without_ai_start_keeps_timing_unavailable(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(tmp_path, "20260721-legacy-record")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+
+    assert (
+        runner.main(
+            [
+                "record",
+                "--channel-dir",
+                str(tmp_path),
+                "--token",
+                token,
+                "--collection",
+                collection.name,
+                "--action",
+                "lyria",
+                "--status",
+                "success",
+                "--reason",
+                "legacy_caller",
+            ]
+        )
+        == 0
+    )
+
+    assert runner.read_history(tmp_path)["attempts"][-1]["timing"] is None
+
+
 def test_completed_live_collection_finishes_after_post_publish_history(tmp_path: Path, runner: ModuleType) -> None:
     collection = _collection(
         tmp_path,
@@ -589,17 +702,20 @@ def test_cli_plan_prints_bootstrap_decision(
     assert json.loads(capsys.readouterr().out)["reason"] == "no_active_collection"
 
 
-def test_cli_records_bootstrap_block_before_collection_exists(
+@pytest.mark.parametrize("status", ["blocked", "failed"])
+def test_cli_records_timed_bootstrap_stop_before_collection_exists(
     tmp_path: Path,
     runner: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    status: str,
 ) -> None:
     safe_token = "a1" * 24
     monkeypatch.setattr(runner.secrets, "token_urlsafe", lambda _: "-unsafe-token")
     monkeypatch.setattr(runner.secrets, "token_hex", lambda _: safe_token)
 
     token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+    started_at = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
 
     assert token == safe_token
     assert (
@@ -611,11 +727,25 @@ def test_cli_records_bootstrap_block_before_collection_exists(
                 "--token",
                 token,
                 "--status",
-                "blocked",
+                status,
                 "--reason",
                 "user_input_required",
+                "--ai-started-at",
+                started_at,
             ]
         )
         == 0
     )
     assert json.loads(capsys.readouterr().out) == {"status": "recorded"}
+    attempt = runner.read_history(tmp_path)["attempts"][-1]
+    assert attempt["collection"] is None
+    assert attempt["action"] == "wf-new"
+    assert attempt["status"] == status
+    assert attempt["timing"]["segments"] == [
+        {
+            "kind": "ai",
+            "started_at": started_at,
+            "ended_at": attempt["timing"]["ended_at"],
+            "duration_seconds": attempt["timing"]["ai_seconds"],
+        }
+    ]


### PR DESCRIPTION
## 概要

`wf-auto-state.py record` と collection 作成前の `record-bootstrap` が canonical action の AI 実行開始時刻を受け取り、既存 timing 契約に準拠した閉区間として履歴へ保存できるようにします。

## 変更内容

- `record --ai-started-at` と `record-bootstrap --ai-started-at` を追加し、同一の `recorded_at` で AI 区間を閉じる
- success / failed / blocked と retry の append-only 履歴を検証
- collection 作成前の wf-new blocked / failed も閉区間として検証
- オプション未指定の既存呼び出しは `timing: null` を維持
- CHANGELOG を更新

## 検証

- `uv run pytest tests/repo/test_wf_auto_state.py -q` (22 passed)
- Ruff check / format check

Closes #3280

Stacked on #3255 (issue #3249).