### PR TITLE
feat(config): 任意channelの設定を副作用なく読む

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(config)`: channel registry の任意 path から検証済み設定を読み込み、既存 singleton の channel 選択へ影響させない API を追加した（#3322）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
 - `feat(wf-auto)`: collection 作成前の bootstrap attempt でも複数の人間介入区間を AI 区間と分離し、同じ canonical timing history に保存できるようにした（#3342）。

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -232,6 +232,11 @@ def load_config() -> ChannelConfig:
     return _instance
 
 
+def load_config_from_path(channel_dir_path: Path) -> ChannelConfig:
+    """明示した channel root の設定を singleton state へ影響させず読み込む。"""
+    return _build(channel_dir_path.resolve())
+
+
 def _build(channel_dir_path: Path) -> ChannelConfig:
     channel_subdir = channel_dir_path / "config" / "channel"
     legacy_path = channel_dir_path / "config" / "channel_config.json"

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -21,6 +21,7 @@ from youtube_automation.configuration import (
     select_channel,
     workspace_channels,
 )
+from youtube_automation.configuration.loader import load_config_from_path
 from youtube_automation.core.errors import ConfigError
 
 # ----- helpers -------------------------------------------------------------
@@ -143,6 +144,24 @@ def test_load_minimal_sections(tmp_path, monkeypatch):
     assert config.pinned_comment.templates == {}
     assert config.pinned_comment.history_file == "pinned_comment_history.json"
     assert config.pinned_comment.default_language == "en"
+
+
+def test_load_config_from_path_does_not_change_singleton_selection(tmp_path, monkeypatch):
+    selected_sections = _minimal_sections()
+    selected_sections["meta.json"]["channel"]["name"] = "Selected Channel"
+    selected = _setup_channel(tmp_path / "selected", selected_sections)
+    requested_sections = _minimal_sections()
+    requested_sections["meta.json"]["channel"]["name"] = "Requested Channel"
+    requested = _setup_channel(tmp_path / "requested", requested_sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(selected))
+
+    selected_config = load_config()
+    requested_config = load_config_from_path(requested)
+
+    assert selected_config.meta.channel_name == "Selected Channel"
+    assert requested_config.meta.channel_name == "Requested Channel"
+    assert load_config() is selected_config
+    assert channel_dir() == selected
 
 
 def test_community_draft_section_loads_typed_posts(tmp_path, monkeypatch):


### PR DESCRIPTION
## 概要

- channel path を明示して正規設定を読み込む API を追加
- process-global singleton の channel 選択を変更しない契約を固定

## 検証

- `uv run pytest -q tests/configuration/test_config_loader.py`（277 passed）
- `uv run ruff check src/youtube_automation/configuration/loader.py tests/configuration/test_config_loader.py`
- `uv run ruff format --check src/youtube_automation/configuration/loader.py tests/configuration/test_config_loader.py`
- `git diff --check`

Closes #3322
Parent: #2965
Depends on: #3277
Stack: #3256