### PR TITLE
feat(dashboard): collection別の時間指標を集計する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: active planning と latest live collection を最大 2 件選び、`wf-auto-state.py` の正規集計から step 状態と 6 種の時間指標を構築する read adapter を追加した（#3323）。
 - `feat(config)`: channel registry の任意 path から検証済み設定を読み込み、既存 singleton の channel 選択へ影響させない API を追加した（#3322）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。

--- a/src/youtube_automation/infrastructure/analytics/workflow_timing.py
+++ b/src/youtube_automation/infrastructure/analytics/workflow_timing.py
@@ -1,0 +1,159 @@
+"""Dashboard 向け workflow timing read adapter。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from functools import cache
+from importlib.resources import as_file, files
+from pathlib import Path
+from types import ModuleType
+from typing import Protocol, cast
+
+
+class _TimingRunner(Protocol):
+    NoActiveCollectionError: type[ValueError]
+
+    def read_history(self, root: Path) -> dict[str, object]: ...
+
+    def select_collection(self, root: Path, requested: str | None = None) -> Path: ...
+
+    def _collection_sort_key(self, collection: Path) -> tuple[str, str]: ...
+
+    def summarize_time_savings(
+        self,
+        history: dict[str, object],
+        manual_baseline_minutes: dict[str, float] | None,
+    ) -> dict[str, object]: ...
+
+
+def _load_module(path: Path) -> _TimingRunner:
+    module_name = "youtube_automation._wf_auto_state_dashboard"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"wf-auto timing module をロードできません: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return cast(_TimingRunner, cast(ModuleType, module))
+
+
+@cache
+def _runner() -> _TimingRunner:
+    resource = files("youtube_automation").joinpath("_skills", "wf-auto", "references", "wf-auto-state.py")
+    with as_file(resource) as resource_path:
+        if resource_path.is_file():
+            return _load_module(resource_path)
+    source_path = (
+        Path(__file__).resolve().parents[4] / ".claude" / "skills" / "wf-auto" / "references" / "wf-auto-state.py"
+    )
+    if not source_path.is_file():
+        raise RuntimeError("wf-auto-state.py が package resource と source checkout のどちらにもありません")
+    return _load_module(source_path)
+
+
+def _selected_collections(channel: Path, runner: _TimingRunner) -> list[tuple[str, Path]]:
+    selected: list[tuple[str, Path]] = []
+    try:
+        active = runner.select_collection(channel)
+    except runner.NoActiveCollectionError:
+        active = None
+    if active is not None:
+        selected.append(("planning", active))
+
+    live_states = list((channel / "collections" / "live").glob("*/workflow-state.json"))
+    if live_states:
+        latest_path = max((state.parent for state in live_states), key=runner._collection_sort_key)
+        latest = runner.select_collection(channel, str(latest_path.resolve()))
+        if active is None or latest != active:
+            selected.append(("live", latest))
+    return selected
+
+
+def _collection_history(history: dict[str, object], channel: Path, collection: Path) -> dict[str, object]:
+    attempts = history.get("attempts")
+    if not isinstance(attempts, list):
+        raise ValueError("workflow history は attempts array を持つ必要があります")
+    relative = collection.relative_to(channel).as_posix()
+    filtered = [attempt for attempt in attempts if isinstance(attempt, dict) and attempt.get("collection") == relative]
+    return {**history, "attempts": filtered}
+
+
+def _latest_statuses(history: dict[str, object]) -> dict[str, str]:
+    attempts = history.get("attempts")
+    if not isinstance(attempts, list):
+        raise ValueError("workflow history は attempts array を持つ必要があります")
+    statuses: dict[str, str] = {}
+    for attempt in attempts:
+        if not isinstance(attempt, dict):
+            raise ValueError("workflow history attempt は object でなければなりません")
+        action = attempt.get("action")
+        status = attempt.get("status")
+        if not isinstance(action, str) or status not in {"success", "blocked", "failed"}:
+            raise ValueError("workflow history attempt の action/status が不正です")
+        statuses[action] = cast(str, status)
+    return statuses
+
+
+def _six_metrics(values: dict[str, object]) -> dict[str, object]:
+    ai_seconds = values["ai_seconds"]
+    human_seconds = values["human_seconds"]
+    if not isinstance(ai_seconds, (int, float)) or not isinstance(human_seconds, (int, float)):
+        raise ValueError("workflow timing の AI / human 秒が number ではありません")
+    return {
+        "manual_baseline_seconds": values["manual_baseline_seconds"],
+        "ai_seconds": ai_seconds,
+        "human_seconds": human_seconds,
+        "work_seconds": ai_seconds + human_seconds,
+        "ai_inclusive_saved_seconds": values["ai_inclusive_saved_seconds"],
+        "human_freed_seconds": values["human_freed_seconds"],
+    }
+
+
+def _collection_summary(
+    channel: Path,
+    collection: Path,
+    stage: str,
+    history: dict[str, object],
+    manual_baseline_minutes: dict[str, float] | None,
+    runner: _TimingRunner,
+) -> dict[str, object]:
+    scoped_history = _collection_history(history, channel, collection)
+    summary = runner.summarize_time_savings(scoped_history, manual_baseline_minutes)
+    if summary.get("available") is not True:
+        raise ValueError(f"workflow timing を集計できません: {summary.get('reason')}")
+    actions = summary.get("actions")
+    totals = summary.get("totals")
+    if not isinstance(actions, dict) or not isinstance(totals, dict):
+        raise ValueError("available workflow timing に actions/totals がありません")
+    statuses = _latest_statuses(scoped_history)
+    steps = []
+    for action, raw_metrics in actions.items():
+        if not isinstance(action, str) or not isinstance(raw_metrics, dict):
+            raise ValueError("workflow timing action summary が不正です")
+        steps.append({"action": action, "status": statuses[action], **_six_metrics(raw_metrics)})
+    return {
+        "collection_id": collection.name,
+        "stage": stage,
+        "steps": steps,
+        "totals": _six_metrics(totals),
+    }
+
+
+def build_workflow_timing(
+    channel: Path,
+    manual_baseline_minutes: dict[str, float] | None,
+) -> dict[str, object]:
+    """active planning と latest live の timing summary を返す。"""
+    channel = channel.resolve()
+    runner = _runner()
+    history = runner.read_history(channel)
+    collections = [
+        _collection_summary(channel, collection, stage, history, manual_baseline_minutes, runner)
+        for stage, collection in _selected_collections(channel, runner)
+    ]
+    return {"collections": collections}

--- a/tests/infrastructure/analytics/test_workflow_timing.py
+++ b/tests/infrastructure/analytics/test_workflow_timing.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.infrastructure.analytics.workflow_timing import build_workflow_timing
+
+
+def _write_collection(channel: Path, stage: str, name: str, *, phase: str, created_at: str) -> Path:
+    collection = channel / "collections" / stage / name
+    collection.mkdir(parents=True)
+    (collection / "workflow-state.json").write_text(
+        json.dumps({"phase": phase, "created_at": created_at}),
+        encoding="utf-8",
+    )
+    return collection
+
+
+def _attempt(collection: str, action: str, status: str, ai: float, human: float) -> dict[str, object]:
+    return {
+        "collection": collection,
+        "action": action,
+        "status": status,
+        "timing": {
+            "segments": [
+                {
+                    "kind": "ai",
+                    "started_at": "2026-08-01T00:00:00+00:00",
+                    "ended_at": "2026-08-01T00:00:10+00:00",
+                    "duration_seconds": ai,
+                },
+                {
+                    "kind": "human",
+                    "started_at": "2026-08-01T00:00:10+00:00",
+                    "ended_at": "2026-08-01T00:00:20+00:00",
+                    "duration_seconds": human,
+                },
+            ]
+        },
+    }
+
+
+def _write_history(channel: Path, attempts: list[dict[str, object]]) -> None:
+    state = channel / ".automation-run"
+    state.mkdir()
+    (state / "history.json").write_text(
+        json.dumps({"schema_version": 2, "attempts": attempts}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("planning", "live", "expected"),
+    [
+        (True, False, [("active", "planning")]),
+        (False, True, [("latest", "live")]),
+        (True, True, [("active", "planning"), ("latest", "live")]),
+        (False, False, []),
+    ],
+)
+def test_build_workflow_timing_selects_active_and_latest_collections(
+    tmp_path: Path,
+    planning: bool,
+    live: bool,
+    expected: list[tuple[str, str]],
+) -> None:
+    if planning:
+        _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
+    if live:
+        _write_collection(tmp_path, "live", "latest", phase="complete", created_at="2026-08-01")
+    _write_history(tmp_path, [])
+
+    result = build_workflow_timing(tmp_path, {})
+
+    assert [(item["collection_id"], item["stage"]) for item in result["collections"]] == expected
+
+
+def test_build_workflow_timing_returns_canonical_step_and_total_metrics(tmp_path: Path) -> None:
+    _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
+    _write_collection(tmp_path, "live", "older", phase="complete", created_at="2026-07-01")
+    _write_collection(tmp_path, "live", "latest", phase="complete", created_at="2026-08-01")
+    _write_history(
+        tmp_path,
+        [
+            _attempt("collections/planning/active", "wf-next", "failed", 10, 5),
+            _attempt("collections/planning/active", "wf-next", "success", 20, 10),
+            _attempt("collections/live/latest", "post-publish", "success", 15, 5),
+            _attempt("collections/live/older", "post-publish", "success", 99, 99),
+        ],
+    )
+
+    result = build_workflow_timing(tmp_path, {"wf-next": 1.0, "post-publish": 2.0})
+
+    active, latest = result["collections"]
+    assert active["steps"] == [
+        {
+            "action": "wf-next",
+            "status": "success",
+            "manual_baseline_seconds": 60.0,
+            "ai_seconds": 30.0,
+            "human_seconds": 15.0,
+            "work_seconds": 45.0,
+            "ai_inclusive_saved_seconds": 15.0,
+            "human_freed_seconds": 45.0,
+        }
+    ]
+    assert active["totals"] == {
+        "manual_baseline_seconds": 60.0,
+        "ai_seconds": 30.0,
+        "human_seconds": 15.0,
+        "work_seconds": 45.0,
+        "ai_inclusive_saved_seconds": 15.0,
+        "human_freed_seconds": 45.0,
+    }
+    assert latest["collection_id"] == "latest"
+    assert latest["steps"][0]["action"] == "post-publish"
+    assert latest["totals"]["work_seconds"] == 20.0


### PR DESCRIPTION
## 概要

- active planning と latest live を最大2件選択
- collection ごとの attempt だけを canonical wf-auto 集計へ入力
- step status と baseline / AI / human / work / 2種類の削減秒を返却

## 検証

- `uv run pytest -q tests/infrastructure/analytics/test_workflow_timing.py tests/repo/test_wf_auto_state.py`（29 passed）
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `git diff --check`

Closes #3323
Parent: #2965
Depends on: #3326
Stack: #3256