### PR TITLE
feat(wf-auto): 人間 gate 区間を timing に記録する (#3319)

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -309,6 +309,76 @@ def _ai_timing_segment(started_at: str, ended_at: str) -> TimingSegment:
     return segment
 
 
+def _timing_segment(kind: Literal["ai", "human"], started_at: str, ended_at: str) -> TimingSegment:
+    started = _timestamp(started_at, field=f"{kind}_started_at", source="record")
+    ended = _timestamp(ended_at, field=f"{kind}_ended_at", source="record")
+    try:
+        duration_seconds = (ended - started).total_seconds()
+    except TypeError as exc:
+        raise ValueError("record: timing boundary の timezone 指定が一致しません") from exc
+    segment: TimingSegment = {
+        "kind": kind,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_seconds": duration_seconds,
+    }
+    _validate_timing({"segments": [segment]}, source="record")
+    return segment
+
+
+def _human_interval(interval: list[str], index: int) -> tuple[str, str, datetime, datetime]:
+    human_started_text, human_ended_text = interval
+    human_started = _timestamp(
+        human_started_text,
+        field=f"human_intervals[{index}].started_at",
+        source="record",
+    )
+    human_ended = _timestamp(
+        human_ended_text,
+        field=f"human_intervals[{index}].ended_at",
+        source="record",
+    )
+    try:
+        if human_ended < human_started:
+            raise ValueError(f"record: human_intervals[{index}].ended_at は started_at より前にできません")
+    except TypeError as exc:
+        raise ValueError("record: timing boundary の timezone 指定が一致しません") from exc
+    return human_started_text, human_ended_text, human_started, human_ended
+
+
+def _timing_segments(
+    ai_started_at: str,
+    human_intervals: list[list[str]],
+    recorded_at: str,
+) -> list[TimingSegment]:
+    ai_started = _timestamp(ai_started_at, field="ai_started_at", source="record")
+    recorded = _timestamp(recorded_at, field="recorded_at", source="record")
+    cursor_at = ai_started
+    cursor_text = ai_started_at
+    segments: list[TimingSegment] = []
+    try:
+        if recorded < ai_started:
+            raise ValueError("record: recorded_at は ai_started_at より前にできません")
+        for index, interval in enumerate(human_intervals):
+            human_started_text, human_ended_text, human_started, human_ended = _human_interval(interval, index)
+            if human_started < ai_started:
+                raise ValueError(f"record: human_intervals[{index}] は ai_started_at より前にできません")
+            if human_started < cursor_at:
+                raise ValueError(f"record: human_intervals[{index}] は直前の区間と overlap しています")
+            if human_ended > recorded:
+                raise ValueError(f"record: human_intervals[{index}] は recorded_at より後にできません")
+            if cursor_at < human_started:
+                segments.append(_timing_segment("ai", cursor_text, human_started_text))
+            segments.append(_timing_segment("human", human_started_text, human_ended_text))
+            cursor_at = human_ended
+            cursor_text = human_ended_text
+    except TypeError as exc:
+        raise ValueError("record: timing boundary の timezone 指定が一致しません") from exc
+    if cursor_at < recorded:
+        segments.append(_timing_segment("ai", cursor_text, recorded_at))
+    return segments
+
+
 def _inside(root: Path, path: Path, field: str) -> Path:
     root = root.resolve()
     path = path.resolve()
@@ -1005,6 +1075,7 @@ def _parser() -> argparse.ArgumentParser:
     record.add_argument("--reason", required=True)
     record.add_argument("--resume-action", choices=sorted(ACTIONS))
     record.add_argument("--ai-started-at")
+    record.add_argument("--human-interval", action="append", nargs=2, metavar=("START", "END"))
     bootstrap = sub.add_parser("record-bootstrap")
     bootstrap.add_argument("--channel-dir", type=Path, default=Path.cwd())
     bootstrap.add_argument("--token", required=True)
@@ -1047,7 +1118,13 @@ def main(argv: list[str] | None = None) -> int:
         else:
             collection = select_collection(root, args.collection)
             recorded_at = datetime.now(UTC).isoformat()
-            segments = [_ai_timing_segment(args.ai_started_at, recorded_at)] if args.ai_started_at is not None else None
+            if args.human_interval and args.ai_started_at is None:
+                raise ValueError("record: human_interval には ai_started_at が必要です")
+            segments = (
+                _timing_segments(args.ai_started_at, args.human_interval or [], recorded_at)
+                if args.ai_started_at is not None
+                else None
+            )
             record_attempt(
                 root,
                 token=args.token,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
+- `feat(wf-auto)`: state CLI の `record` に repeatable な `--human-interval START END` を追加し、AI 開始から記録時刻までを連続した AI / human timing segment として保存できるようにした。不正な逆転・重複・範囲外・timezone 不一致は既存 history を変更せず拒否する（#3319）。
 - `feat(wf-auto)`: canonical action の開始時刻を state CLI の `record` へ渡し、success / failed / blocked の全 attempt に閉じた AI 実行区間を append-only で保存できる契約を追加した（#2962）。
 - `feat(wf-auto)`: workflow attempt に AI / human の型付き timing segment と種別別秒数を append-only で記録する schema v2 を追加した（#3248）。
 - `feat(wf-auto)`: schema v1 の `.automation-run/history.json` を時間未取得として読み出し、根拠のない実行時間を推測しない後方互換契約を追加した（#3247）。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -658,6 +658,178 @@ def test_cli_record_without_ai_start_keeps_timing_unavailable(tmp_path: Path, ru
     assert runner.read_history(tmp_path)["attempts"][-1]["timing"] is None
 
 
+def test_cli_record_splits_ai_timing_around_one_human_interval(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(tmp_path, "20260721-one-human-gate")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+    started = datetime.now(UTC) - timedelta(seconds=30)
+    human_started = started + timedelta(seconds=10)
+    human_ended = started + timedelta(seconds=15)
+
+    assert (
+        runner.main(
+            [
+                "record",
+                "--channel-dir",
+                str(tmp_path),
+                "--token",
+                token,
+                "--collection",
+                collection.name,
+                "--action",
+                "lyria",
+                "--status",
+                "success",
+                "--reason",
+                "approved",
+                "--ai-started-at",
+                started.isoformat(),
+                "--human-interval",
+                human_started.isoformat(),
+                human_ended.isoformat(),
+            ]
+        )
+        == 0
+    )
+
+    timing = runner.read_history(tmp_path)["attempts"][-1]["timing"]
+    assert [segment["kind"] for segment in timing["segments"]] == ["ai", "human", "ai"]
+    assert timing["segments"][0] == {
+        "kind": "ai",
+        "started_at": started.isoformat(),
+        "ended_at": human_started.isoformat(),
+        "duration_seconds": 10.0,
+    }
+    assert timing["segments"][1] == {
+        "kind": "human",
+        "started_at": human_started.isoformat(),
+        "ended_at": human_ended.isoformat(),
+        "duration_seconds": 5.0,
+    }
+    assert timing["segments"][2]["started_at"] == human_ended.isoformat()
+    assert timing["segments"][2]["ended_at"] == timing["ended_at"]
+    assert timing["human_seconds"] == 5.0
+    assert timing["ai_seconds"] == pytest.approx(
+        (datetime.fromisoformat(timing["ended_at"]) - started).total_seconds() - 5.0
+    )
+
+
+def test_human_intervals_build_continuous_typed_segments(runner: ModuleType) -> None:
+    segments = runner._timing_segments(
+        "2026-07-21T00:00:00+00:00",
+        [
+            ["2026-07-21T00:00:10+00:00", "2026-07-21T00:00:15+00:00"],
+            ["2026-07-21T00:00:20+00:00", "2026-07-21T00:00:24+00:00"],
+        ],
+        "2026-07-21T00:00:30+00:00",
+    )
+
+    assert segments == [
+        {
+            "kind": "ai",
+            "started_at": "2026-07-21T00:00:00+00:00",
+            "ended_at": "2026-07-21T00:00:10+00:00",
+            "duration_seconds": 10.0,
+        },
+        {
+            "kind": "human",
+            "started_at": "2026-07-21T00:00:10+00:00",
+            "ended_at": "2026-07-21T00:00:15+00:00",
+            "duration_seconds": 5.0,
+        },
+        {
+            "kind": "ai",
+            "started_at": "2026-07-21T00:00:15+00:00",
+            "ended_at": "2026-07-21T00:00:20+00:00",
+            "duration_seconds": 5.0,
+        },
+        {
+            "kind": "human",
+            "started_at": "2026-07-21T00:00:20+00:00",
+            "ended_at": "2026-07-21T00:00:24+00:00",
+            "duration_seconds": 4.0,
+        },
+        {
+            "kind": "ai",
+            "started_at": "2026-07-21T00:00:24+00:00",
+            "ended_at": "2026-07-21T00:00:30+00:00",
+            "duration_seconds": 6.0,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("ai_started_at", "human_intervals", "message"),
+    [
+        (None, [["2026-07-21T00:00:01+00:00", "2026-07-21T00:00:02+00:00"]], "ai_started_at"),
+        (
+            "2026-07-21T00:00:00+00:00",
+            [["2026-07-21T00:00:02+00:00", "2026-07-21T00:00:01+00:00"]],
+            "ended_at",
+        ),
+        (
+            "2026-07-21T00:00:00+00:00",
+            [
+                ["2026-07-21T00:00:01+00:00", "2026-07-21T00:00:03+00:00"],
+                ["2026-07-21T00:00:02+00:00", "2026-07-21T00:00:04+00:00"],
+            ],
+            "overlap",
+        ),
+        (
+            "2026-07-21T00:00:00+00:00",
+            [["2026-07-20T23:59:59+00:00", "2026-07-21T00:00:01+00:00"]],
+            "ai_started_at",
+        ),
+        (
+            "2026-07-21T00:00:00+00:00",
+            [["2099-07-21T00:00:01+00:00", "2099-07-21T00:00:02+00:00"]],
+            "recorded_at",
+        ),
+        (
+            "2026-07-21T00:00:00+00:00",
+            [["2026-07-21T00:00:01", "2026-07-21T00:00:02"]],
+            "timezone",
+        ),
+    ],
+)
+def test_cli_record_rejects_invalid_human_intervals_without_mutating_history(
+    tmp_path: Path,
+    runner: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    ai_started_at: str | None,
+    human_intervals: list[list[str]],
+    message: str,
+) -> None:
+    collection = _collection(tmp_path, "20260721-invalid-human-gate")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+    history_path = tmp_path / ".automation-run" / "history.json"
+    original = json.dumps({"schema_version": 2, "attempts": []})
+    history_path.write_text(original, encoding="utf-8")
+    argv = [
+        "record",
+        "--channel-dir",
+        str(tmp_path),
+        "--token",
+        token,
+        "--collection",
+        collection.name,
+        "--action",
+        "lyria",
+        "--status",
+        "failed",
+        "--reason",
+        "invalid_gate",
+    ]
+    if ai_started_at is not None:
+        argv.extend(["--ai-started-at", ai_started_at])
+    for interval in human_intervals:
+        argv.extend(["--human-interval", *interval])
+
+    assert runner.main(argv) == 2
+
+    assert message in json.loads(capsys.readouterr().out)["reason"]
+    assert history_path.read_text(encoding="utf-8") == original
+
+
 def test_completed_live_collection_finishes_after_post_publish_history(tmp_path: Path, runner: ModuleType) -> None:
     collection = _collection(
         tmp_path,


### PR DESCRIPTION
## Summary

- `record` に repeatable `--human-interval START END` を追加
- AI 開始から記録時刻までを複数の閉じた AI / human segment へ正規化
- 重複・範囲外・timezone 不一致を history 更新前に拒否

## Validation

- `nix develop --command uv run pytest -q tests/repo/test_wf_auto_state.py` (30 passed)
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3319

Stacked on #3283.
