### PR TITLE
feat(dashboard): detailに時間指標を追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: workflow timing summary を channel detail read model に追加し、overview からは除外して一覧 API の軽量契約を維持した（#3324）。
 - `feat(dashboard)`: active planning と latest live collection を最大 2 件選び、`wf-auto-state.py` の正規集計から step 状態と 6 種の時間指標を構築する read adapter を追加した（#3323）。
 - `feat(config)`: channel registry の任意 path から検証済み設定を読み込み、既存 singleton の channel 選択へ影響させない API を追加した（#3322）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -247,9 +247,11 @@ def build_dashboard_read_model(
     channel_paths: list[Path],
     *,
     refresh_errors: dict[Path, str] | None = None,
+    workflow_timing_by_channel: dict[Path, dict[str, object]] | None = None,
 ) -> dict[str, object]:
     """登録順のチャンネルから JSON serializable な read model を作る。"""
     errors = refresh_errors or {}
+    workflow_timings = workflow_timing_by_channel or {}
     channels: list[dict[str, object]] = []
     for channel in channel_paths:
         refresh_message = errors.get(channel)
@@ -257,6 +259,8 @@ def build_dashboard_read_model(
         item["refresh_error"] = (
             {"code": "refresh_failed", "message": refresh_message} if refresh_message is not None else None
         )
+        if channel in workflow_timings:
+            item["workflow_timing"] = workflow_timings[channel]
         channels.append(item)
     return {
         "schema_version": SCHEMA_VERSION,
@@ -282,7 +286,7 @@ class DashboardAPI:
         overview_channels: list[dict[str, object]] = []
         for item in self._channels():
             videos = item.get("videos")
-            overview = {key: value for key, value in item.items() if key != "videos"}
+            overview = {key: value for key, value in item.items() if key not in {"videos", "workflow_timing"}}
             overview["video_count"] = len(videos) if isinstance(videos, list) else 0
             overview_channels.append(overview)
         return {

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -263,9 +263,40 @@ def test_dashboard_api_exposes_overview_and_selected_channel(tmp_path: Path) -> 
 
     assert "videos" not in overview["channels"][0]
     assert overview["channels"][0]["video_count"] == 1
+    assert "workflow_timing" not in api.channel(channel_id)
     assert api.channel(channel_id)["videos"][0]["video_id"] == "video-b"
     with pytest.raises(DashboardChannelNotFoundError, match="unknown"):
         api.channel("unknown")
+
+
+def test_dashboard_api_exposes_workflow_timing_only_in_channel_detail(tmp_path: Path) -> None:
+    channel = tmp_path / "channel"
+    _write_channel(
+        channel,
+        name="Selected",
+        snapshots={
+            "analytics_data_20260720.json": _snapshot(
+                collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+            )
+        },
+    )
+    timing = {
+        "collections": [
+            {
+                "collection_id": "active",
+                "stage": "planning",
+                "steps": [],
+                "totals": {"work_seconds": 0},
+            }
+        ]
+    }
+
+    api = DashboardAPI(build_dashboard_read_model([channel], workflow_timing_by_channel={channel: timing}))
+    overview = api.overview()
+    channel_id = overview["channels"][0]["id"]
+
+    assert "workflow_timing" not in overview["channels"][0]
+    assert api.channel(channel_id)["workflow_timing"] == timing
 
 
 def test_read_model_keeps_previous_snapshot_with_structured_refresh_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要

- channel path ごとの workflow timing を read model へ注入
- channel detail で timing を返却
- overview から timing を除外して軽量契約を維持

## 検証

- `uv run pytest -q tests/infrastructure/analytics/test_dashboard_read_model.py`（13 passed）
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `git diff --check`

Closes #3324
Parent: #2965
Depends on: #3327
Stack: #3256