### PR TITLE
docs(wf-auto): 人間 gate timing 契約を接続する (#3320)

### DIFF
--- a/.claude/skills/wf-auto/SKILL.md
+++ b/.claude/skills/wf-auto/SKILL.md
@@ -43,7 +43,8 @@ uv run python "$STATE_SCRIPT" plan --channel-dir . [--collection <fixed-name>]
 uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> \
   --collection <fixed-name> --action <action> --status success|blocked|failed \
   --reason <reason> [--resume-action <action>] \
-  --ai-started-at <current-attempt-ai-started-at>
+  --ai-started-at <current-attempt-ai-started-at> \
+  [--human-interval <human-start> <human-end>]...
 uv run python "$STATE_SCRIPT" record-bootstrap --channel-dir . --token <token> \
   --status blocked|failed --reason <reason> \
   --ai-started-at <current-attempt-ai-started-at>
@@ -82,6 +83,26 @@ uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).is
 子 skill の終了報告だけで成功とせず、期待成果物と state を検証してから終了 status を決める。検証に成功した場合だけ `success`、手動介入が必要なら `blocked`、検証失敗を含むその他の失敗は `failed` とする。すべての `record --status success|blocked|failed` と collection 作成前の `record-bootstrap --status blocked|failed` に、同じ attempt で保持した `--ai-started-at <current-attempt-ai-started-at>` を渡して AI 区間を必ず閉じる。`blocked` / `complete` の terminal action も、同じ順序で開始時刻を取得して記録する。
 
 retry・再開時は action を実行するたびに新しい開始時刻を取得し、新しい attempt として追記する。前回の開始時刻を再利用せず、前回の `failed` / `blocked` attempt と実行時間を履歴に残す。
+
+### 同一 run の人間介入 gate timing 契約
+
+canonical action の開始時に、空の `<current-attempt-human-intervals>` を同じ attempt の一時情報として用意する。対話実行で AskUserQuestion または本人操作の依頼を提示する直前に、メインエージェントが human 開始時刻を取得する。承認取得と本人操作の依頼は subagent へ委譲しない。回答または本人操作の完了を受け取った直後、成果物検証や次のコマンドへ進む前に、メインエージェントが human 終了時刻を取得し、閉じた組を `<current-attempt-human-intervals>` へ追加する。
+
+時刻の取得には AI 開始時刻と同じ UTC コマンドを使う。同一 action に複数の gate がある場合も、前の組を上書き・統合せず、各 gate の閉区間を発生順に保持する。action の status と成果物検証が確定して `record` を実行するとき、同じ attempt の AI 開始時刻に加え、保持した区間を発生順を保ったまま全件 `--human-interval START END` として渡す。gate が 0 件ならこの option は渡さない。
+
+```bash
+HUMAN_START_1="$(uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())')"
+# メインエージェントが gate を提示し、回答または必要な本人操作の完了を受け取る
+HUMAN_END_1="$(uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())')"
+
+uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> \
+  --collection <fixed-name> --action <action> --status <status> --reason <reason> \
+  --ai-started-at <current-attempt-ai-started-at> \
+  --human-interval <human-start-1> <human-end-1> \
+  --human-interval <human-start-2> <human-end-2>
+```
+
+この契約は同じ run の実行文脈へ回答または操作完了が戻る gate にだけ適用する。login / CAPTCHA は既存 Hard Gate の範囲を広げず、本人に必要な1操作だけを依頼し、認証コマンドの実行や CAPTCHA 回避を行わない。
 
 ### `suno-helper` action の自律実行契約
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
+- `docs(wf-auto)`: 同一 run で回答を待つ人間介入 gate の直前・直後をメインエージェントが採時し、同じ canonical action attempt の全閉区間を発生順に `record --human-interval` へ渡す実行契約を追加した（#3320）。
 - `feat(wf-auto)`: state CLI の `record` に repeatable な `--human-interval START END` を追加し、AI 開始から記録時刻までを連続した AI / human timing segment として保存できるようにした。不正な逆転・重複・範囲外・timezone 不一致は既存 history を変更せず拒否する（#3319）。
 - `feat(wf-auto)`: canonical action の開始時刻を state CLI の `record` へ渡し、success / failed / blocked の全 attempt に閉じた AI 実行区間を append-only で保存できる契約を追加した（#2962）。
 - `feat(wf-auto)`: workflow attempt に AI / human の型付き timing segment と種別別秒数を append-only で記録する schema v2 を追加した（#3248）。

--- a/tests/repo/test_wf_auto_human_timing_skill_contract.py
+++ b/tests/repo/test_wf_auto_human_timing_skill_contract.py
@@ -1,0 +1,65 @@
+"""`/wf-auto` の同一 run 人間介入 gate timing 契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_MD = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^###?\s|\Z)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"`{heading}` セクションが見つかりません")
+    return match.group("body")
+
+
+def test_same_run_human_gate_closes_interval_before_recording_attempt() -> None:
+    contract = _section(
+        SKILL_MD.read_text(encoding="utf-8"),
+        "### 同一 run の人間介入 gate timing 契約",
+    )
+
+    gate_start = contract.index("AskUserQuestion または本人操作の依頼を提示する直前")
+    gate_end = contract.index("回答または本人操作の完了を受け取った直後")
+    record = contract.index("`record` を実行するとき")
+
+    assert gate_start < gate_end < record
+    assert contract.count("datetime.now(UTC).isoformat()") == 2
+    assert "メインエージェント" in contract
+    assert "subagent へ委譲しない" in contract
+
+
+def test_multiple_human_gates_are_forwarded_in_order_on_the_same_attempt() -> None:
+    contract = _section(
+        SKILL_MD.read_text(encoding="utf-8"),
+        "### 同一 run の人間介入 gate timing 契約",
+    )
+
+    assert "<current-attempt-human-intervals>" in contract
+    assert "発生順を保ったまま全件" in contract
+    assert "同じ attempt" in contract
+    command = re.search(r"```bash\n(?P<body>.*?)```", contract, flags=re.DOTALL)
+    assert command is not None
+    argv = command.group("body")
+    assert "--ai-started-at <current-attempt-ai-started-at>" in argv
+    first = argv.index("--human-interval <human-start-1> <human-end-1>")
+    second = argv.index("--human-interval <human-start-2> <human-end-2>")
+    assert first < second
+
+
+def test_login_and_captcha_remain_limited_to_the_required_human_operation() -> None:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    gates = _section(text, "## Hard Gates")
+    suno = _section(text, "### `suno-helper` action の自律実行契約")
+
+    assert "login、CAPTCHA" in gates
+    assert "自動承認せず `blocked`" in gates
+    assert "本人操作が不可欠な場合だけ" in suno
+    assert "認証のコマンド実行や CAPTCHA 回避は行わない" in suno


### PR DESCRIPTION
## Summary

- 同一 run の人間 gate 直前・回答直後をメイン agent が採時する契約を追加
- 複数の閉区間を同じ attempt の repeatable `--human-interval` へ渡す契約を追加
- AskUserQuestion の責務と login / CAPTCHA の既存 Hard Gate を維持

## Validation

- focused contract tests (3 passed)
- AI timing contract included (7 passed)
- CHANGELOG / skill docs tests (77 passed)
- `nix develop --command uv run yt-skills lint wf-auto`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3320

Stacked on #3328.
