### PR TITLE
feat(dashboard): serverに時間指標を配線する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: registry の各 channel から検証済み手作業基準と workflow history を読み、collection timing summary を channel detail API へ配線した（#3325）。
 - `feat(dashboard)`: workflow timing summary を channel detail read model に追加し、overview からは除外して一覧 API の軽量契約を維持した（#3324）。
 - `feat(dashboard)`: active planning と latest live collection を最大 2 件選び、`wf-auto-state.py` の正規集計から step 状態と 6 種の時間指標を構築する read adapter を追加した（#3323）。
 - `feat(config)`: channel registry の任意 path から検証済み設定を読み込み、既存 singleton の channel 選択へ影響させない API を追加した（#3322）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -17,6 +17,7 @@ from typing import cast
 from urllib.parse import unquote, urlsplit
 
 from youtube_automation.commands.analytics.analytics_system import AnalyticsSystem
+from youtube_automation.configuration.loader import load_config_from_path
 from youtube_automation.core.errors import DashboardChannelNotFoundError
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,
@@ -27,9 +28,22 @@ from youtube_automation.infrastructure.analytics.dashboard_refresh import (
     collect_channel_analytics,
     refresh_dashboard_channels,
 )
+from youtube_automation.infrastructure.analytics.workflow_timing import build_workflow_timing
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+
+
+def _build_channel_workflow_timing(channel: Path) -> dict[str, object]:
+    collection_states = (
+        state_path
+        for stage in ("planning", "live")
+        for state_path in (channel / "collections" / stage).glob("*/workflow-state.json")
+    )
+    if next(collection_states, None) is None:
+        return {"collections": []}
+    config = load_config_from_path(channel)
+    return build_workflow_timing(channel, config.workflow.manual_baseline_minutes)
 
 
 class DashboardServer(ThreadingHTTPServer):
@@ -128,7 +142,14 @@ def create_server(
 ) -> DashboardServer:
     """registry を一度読み、loopback にだけ bind する server を作る。"""
     channels = channel_paths if channel_paths is not None else load_channel_registry(registry_path)
-    api = DashboardAPI(build_dashboard_read_model(channels, refresh_errors=refresh_errors))
+    workflow_timings = {channel: _build_channel_workflow_timing(channel) for channel in channels}
+    api = DashboardAPI(
+        build_dashboard_read_model(
+            channels,
+            refresh_errors=refresh_errors,
+            workflow_timing_by_channel=workflow_timings,
+        )
+    )
     resolved_assets = asset_root or files("youtube_automation").joinpath("dashboard_dist")
     return DashboardServer((DEFAULT_HOST, port), api, resolved_assets)
 

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -16,7 +16,37 @@ def _write_channel(root: Path) -> Path:
     (channel / "config" / "channel").mkdir(parents=True)
     (channel / "data").mkdir()
     (channel / "config" / "channel" / "meta.json").write_text(
-        json.dumps({"channel": {"name": "Night Drive"}}), encoding="utf-8"
+        json.dumps(
+            {
+                "channel": {
+                    "name": "Night Drive",
+                    "short": "ND",
+                    "youtube_handle": "@nightdrive",
+                    "url": "https://youtube.com/@nightdrive",
+                    "tagline": "Drive at night",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (channel / "config" / "channel" / "content.json").write_text(
+        json.dumps(
+            {
+                "genre": {"primary": "synthwave", "style": "retro", "context": "driving"},
+                "tags": {"base": ["synthwave"], "themes": {}},
+                "descriptions": {"opening": "Night music", "perfect_for": ["Driving"], "hashtags": ["#Night"]},
+                "title": {"template": "{theme}"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (channel / "config" / "channel" / "youtube.json").write_text(
+        json.dumps({"youtube": {"category_id": "10", "privacy_status": "public", "language": "ja"}}),
+        encoding="utf-8",
+    )
+    (channel / "config" / "channel" / "workflow.json").write_text(
+        json.dumps({"workflow": {"manual_baseline_minutes": {"wf-next": 1, "post-publish": 2}}}),
+        encoding="utf-8",
     )
     (channel / "data" / "analytics_data_2026-07-20.json").write_text(
         json.dumps(
@@ -40,6 +70,70 @@ def _write_channel(root: Path) -> Path:
                     "message": "quota exceeded",
                     "attempted_at": "2026-07-20T14:00:00+00:00",
                 },
+            }
+        ),
+        encoding="utf-8",
+    )
+    active = channel / "collections" / "planning" / "active"
+    active.mkdir(parents=True)
+    (active / "workflow-state.json").write_text(
+        json.dumps({"phase": "planning", "created_at": "2026-07-21"}), encoding="utf-8"
+    )
+    latest = channel / "collections" / "live" / "latest"
+    latest.mkdir(parents=True)
+    (latest / "workflow-state.json").write_text(
+        json.dumps({"phase": "complete", "created_at": "2026-07-20"}), encoding="utf-8"
+    )
+    history_dir = channel / ".automation-run"
+    history_dir.mkdir()
+    (history_dir / "history.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "attempts": [
+                    {
+                        "collection": "collections/planning/active",
+                        "action": "wf-next",
+                        "status": "success",
+                        "timing": {
+                            "segments": [
+                                {
+                                    "kind": "ai",
+                                    "started_at": "2026-07-21T00:00:00+00:00",
+                                    "ended_at": "2026-07-21T00:00:10+00:00",
+                                    "duration_seconds": 10,
+                                },
+                                {
+                                    "kind": "human",
+                                    "started_at": "2026-07-21T00:00:10+00:00",
+                                    "ended_at": "2026-07-21T00:00:20+00:00",
+                                    "duration_seconds": 5,
+                                },
+                            ]
+                        },
+                    },
+                    {
+                        "collection": "collections/live/latest",
+                        "action": "post-publish",
+                        "status": "success",
+                        "timing": {
+                            "segments": [
+                                {
+                                    "kind": "ai",
+                                    "started_at": "2026-07-20T00:00:00+00:00",
+                                    "ended_at": "2026-07-20T00:00:10+00:00",
+                                    "duration_seconds": 20,
+                                },
+                                {
+                                    "kind": "human",
+                                    "started_at": "2026-07-20T00:00:10+00:00",
+                                    "ended_at": "2026-07-20T00:00:20+00:00",
+                                    "duration_seconds": 10,
+                                },
+                            ]
+                        },
+                    },
+                ],
             }
         ),
         encoding="utf-8",
@@ -83,6 +177,17 @@ def test_server_exposes_overview_and_channel_detail(dashboard_server: str):
     detail_status, detail = _json(f"{dashboard_server}/api/channels/{channel['id']}")
     assert detail_status == 200
     assert detail["videos"][0]["title"] == "Midnight"
+    active, latest = detail["workflow_timing"]["collections"]
+    assert (active["collection_id"], active["stage"], active["totals"]["work_seconds"]) == (
+        "active",
+        "planning",
+        15,
+    )
+    assert (latest["collection_id"], latest["stage"], latest["totals"]["work_seconds"]) == (
+        "latest",
+        "live",
+        30,
+    )
 
 
 def test_server_exposes_saved_publication_read_model(dashboard_server: str) -> None:


### PR DESCRIPTION
## 概要

- registry channel ごとに検証済み workflow config を読込
- canonical timing adapter の結果を read model へ配線
- collection が無い channel は設定全体を要求せず空 summary を返す
- HTTP detail endpoint で active planning + latest live の timing JSON を統合検証

## 検証

- `uv run pytest -q tests/commands/analytics/test_dashboard_server.py tests/infrastructure/analytics/test_dashboard_read_model.py tests/infrastructure/analytics/test_workflow_timing.py tests/configuration/test_config_loader.py`（307 passed）
- `pnpm -C dashboard test:e2e`（6 passed）
- `uv run ruff check .`
- `uv run ruff format --check .`（739 files）
- Any usage gate
- `git diff --check`

Closes #3325
Parent: #2965
Depends on: #3329
Stack: #3256