### PR TITLE
docs(wf-auto): blocked 待機の時間分類を固定する (#3321)

### DIFF
--- a/.claude/skills/wf-auto/SKILL.md
+++ b/.claude/skills/wf-auto/SKILL.md
@@ -104,6 +104,14 @@ uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> \
 
 この契約は同じ run の実行文脈へ回答または操作完了が戻る gate にだけ適用する。login / CAPTCHA は既存 Hard Gate の範囲を広げず、本人に必要な1操作だけを依頼し、認証コマンドの実行や CAPTCHA 回避を行わない。
 
+### blocked 停止と agent wait の timing 分類
+
+人間の回答や操作完了を同じ run で待たず `blocked` として停止すると決めた場合は、その停止決定時点で、すでに閉じている同一 run の human interval だけを渡して `record --status blocked` を実行する。未完了の human interval を開始・保存せず、その場で現在の attempt を閉じて lease を release し、run を停止する。停止後から次回起動までの放置時間を timing segment に含めない。
+
+次回の再開では新しい lease を取得し、resolver で action を再評価する。owner 確認後に新しい attempt と新しい AI 開始時刻を作り、前回の AI 開始時刻を再利用しない。前回の `blocked` attempt は閉じた履歴として保持し、再開後の timing を追記する。login / CAPTCHA も本人に必要な1操作だけを依頼してこの blocked 停止契約に従い、自動突破しない。
+
+通常の API polling、実行中 tool call の待機、agent が保持する background session の30 秒以下の間隔での poll は、agent が処理の完了・失敗を観測する canonical action 内の作業である。これらは AI 実行時間として扱い、human interval を開始しない。human interval に切り替えるのは、前節どおり同じ run へ回答が戻る明示的な AskUserQuestion または本人操作 gate だけとする。
+
 ### `suno-helper` action の自律実行契約
 
 resolver が `action: suno-helper` を返したら、agent 自身が `/suno-helper` の **Agent primary flow: browser use** を実行する。Codex は browser use、Claude Code は browser use または Claude in Chrome を使い、固定 collection について次を完走する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
+- `docs(wf-auto)`: blocked の停止決定時点で attempt を閉じて再開までの放置時間を計上せず、再開は新しい attempt と AI 開始時刻に分離する契約を追加した。通常の API polling と agent が保持する background wait は human interval ではなく AI 実行時間として分類する（#3321）。
 - `docs(wf-auto)`: 同一 run で回答を待つ人間介入 gate の直前・直後をメインエージェントが採時し、同じ canonical action attempt の全閉区間を発生順に `record --human-interval` へ渡す実行契約を追加した（#3320）。
 - `feat(wf-auto)`: state CLI の `record` に repeatable な `--human-interval START END` を追加し、AI 開始から記録時刻までを連続した AI / human timing segment として保存できるようにした。不正な逆転・重複・範囲外・timezone 不一致は既存 history を変更せず拒否する（#3319）。
 - `feat(wf-auto)`: canonical action の開始時刻を state CLI の `record` へ渡し、success / failed / blocked の全 attempt に閉じた AI 実行区間を append-only で保存できる契約を追加した（#2962）。

--- a/tests/repo/test_wf_auto_human_timing_skill_contract.py
+++ b/tests/repo/test_wf_auto_human_timing_skill_contract.py
@@ -63,3 +63,34 @@ def test_login_and_captcha_remain_limited_to_the_required_human_operation() -> N
     assert "自動承認せず `blocked`" in gates
     assert "本人操作が不可欠な場合だけ" in suno
     assert "認証のコマンド実行や CAPTCHA 回避は行わない" in suno
+
+
+def test_blocked_stop_closes_attempt_and_restart_uses_a_new_ai_start() -> None:
+    contract = _section(
+        SKILL_MD.read_text(encoding="utf-8"),
+        "### blocked 停止と agent wait の timing 分類",
+    )
+
+    blocked_record = contract.index("`record --status blocked`")
+    release = contract.index("lease を release")
+    restart = contract.index("次回の再開")
+    assert blocked_record < release < restart
+    assert "停止決定時点" in contract
+    assert "放置時間を timing segment に含めない" in contract
+    assert "新しい attempt" in contract
+    assert "新しい AI 開始時刻" in contract
+    assert "前回の AI 開始時刻を再利用しない" in contract
+
+
+def test_agent_polling_remains_ai_time_without_opening_a_human_interval() -> None:
+    contract = _section(
+        SKILL_MD.read_text(encoding="utf-8"),
+        "### blocked 停止と agent wait の timing 分類",
+    )
+
+    assert "通常の API polling" in contract
+    assert "agent が保持する background session" in contract
+    assert "AI 実行時間" in contract
+    assert "human interval を開始しない" in contract
+    assert "実行中 tool call" in contract
+    assert "30 秒以下の間隔" in contract


### PR DESCRIPTION
## Summary

- blocked 停止時点で current attempt を閉じ、再開までの放置を human interval に含めない契約を追加
- 再開を新しい attempt / AI 開始時刻として記録する契約を固定
- API polling と agent 主体の background wait を AI time として分類

## Validation

- human timing focused contract tests (5 passed)
- related AI/human timing, CHANGELOG and skill docs tests (passed)
- `nix develop --command uv run yt-skills lint wf-auto`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3321

Stacked on #3330.
