### PR TITLE
docs(wf-new): 直接実行をtiming契約へ接続する (#3333)

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -128,6 +128,36 @@ uv run yt-init-collection "Pilot Direction Check" "pilot-direction-check" --trac
 
 定期的なデータ収集は `/analytics-collect`（`uv run yt-analytics` のラッパー）が担当し、通常時は workflow から呼び出さない。stale report の自動更新時だけは `/collection-ideate` の freshness SSOT が指定するシーケンスに従って subagent が呼び出す。必要に応じた cron / launchd 登録はユーザー側の運用とする。テーマは企画の結果で決定されるため、最初に手入力しない。
 
+### 直接実行の canonical timing 契約
+
+`/wf-new` を直接呼んだ場合も、state 判定・lease・history/timing の正は `/wf-auto` と同じ state script とする。独自の action ID、collection ID、timing 保存処理を作らない。channel config gate を通過したら、子 skill や collection 初期化を始める前に、チャンネルルートで次の順序を守る。
+
+```bash
+STATE_SCRIPT=.claude/skills/wf-auto/references/wf-auto-state.py
+uv run python "$STATE_SCRIPT" acquire --channel-dir .
+uv run python "$STATE_SCRIPT" plan --channel-dir .
+uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
+uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())'
+```
+
+`acquire` の `busy` / exit 20 では作業を開始しない。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した `action: wf-new` と resolver が返した collection（未作成なら `null`）だけを使い、別 action や別 collection に置き換えない。`wf-new` 以外が返った場合は本 skill で工程を推測せず、返された action を報告して `/wf-auto` からの再開を案内する。
+
+collection がまだ無い段階で blocked / failed になった場合は、canonical action `wf-new` の bootstrap attempt を次の形で閉じる。同じ run ですでに閉じた human interval があれば、省略・統合せず発生順にすべて渡す。
+
+```bash
+uv run python "$STATE_SCRIPT" record-bootstrap --channel-dir . --token <token> --status blocked|failed --reason <reason> --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
+```
+
+resolver が collection を返した場合、または `yt-init-collection` の出力 path と `workflow-state.json` の実在を検証して作成済み collection の名前を固定した後は、success / blocked / failed のすべてを同じ fixed collection、canonical action `wf-new`、同じ attempt の AI 開始時刻で閉じる。成功は既存の成果物・state 検証をすべて通過した場合だけとし、手動介入は blocked、検証失敗を含むその他は failed とする。対話 gate の時間分類と `--human-interval` は `/wf-auto` の canonical timing 契約をそのまま使う。
+
+```bash
+uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collection <fixed-name> --action wf-new --status success|blocked|failed --reason <reason> --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
+```
+
+success を記録した後は同じ fixed collection を `plan --collection <fixed-name>` で再評価する。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。
+
+`/wf-auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-auto` に一度だけ行わせる。
+
 ### 呼び出しルール
 
 - **順次実行**: 子スキルは必ず上から順に呼ぶ。Agent ツールで起動する subagent も一作業ずつ呼び、並列 Agent は使わない

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
 - `feat(wf-auto)`: collection 作成前の bootstrap attempt でも複数の人間介入区間を AI 区間と分離し、同じ canonical timing history に保存できるようにした（#3342）。
+- `docs(wf-new)`: 直接実行でも `/wf-auto` の state resolver、lease、canonical action / collection ID、AI timing history を共用し、collection 作成前と作成後の全終了 status を同じ attempt として閉じる契約を追加した（#3333）。
 - `docs(wf-auto)`: blocked の停止決定時点で attempt を閉じて再開までの放置時間を計上せず、再開は新しい attempt と AI 開始時刻に分離する契約を追加した。通常の API polling と agent が保持する background wait は human interval ではなく AI 実行時間として分類する（#3321）。
 - `docs(wf-auto)`: 同一 run で回答を待つ人間介入 gate の直前・直後をメインエージェントが採時し、同じ canonical action attempt の全閉区間を発生順に `record --human-interval` へ渡す実行契約を追加した（#3320）。
 - `feat(wf-auto)`: state CLI の `record` に repeatable な `--human-interval START END` を追加し、AI 開始から記録時刻までを連続した AI / human timing segment として保存できるようにした。不正な逆転・重複・範囲外・timezone 不一致は既存 history を変更せず拒否する（#3319）。

--- a/tests/repo/test_wf_new_timing_skill_contract.py
+++ b/tests/repo/test_wf_new_timing_skill_contract.py
@@ -1,0 +1,84 @@
+"""`/wf-new` 直接実行の canonical timing 契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+WF_NEW_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
+WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^##+\s|\Z)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"`{heading}` セクションが見つかりません")
+    return match.group("body")
+
+
+def _state_script_assignment(text: str) -> str:
+    match = re.search(r"^STATE_SCRIPT=(?P<path>\S+)$", text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError("STATE_SCRIPT assignment が見つかりません")
+    return match.group("path")
+
+
+def test_direct_entry_uses_the_canonical_resolver_before_starting_work() -> None:
+    direct = _section(WF_NEW_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+    canonical = WF_AUTO_SKILL.read_text(encoding="utf-8")
+
+    assert _state_script_assignment(direct) == _state_script_assignment(canonical)
+    commands = [
+        "acquire --channel-dir .",
+        "plan --channel-dir .",
+        "heartbeat --channel-dir . --token <token>",
+        "datetime.now(UTC).isoformat()",
+    ]
+    positions = [direct.index(command) for command in commands]
+    assert positions == sorted(positions)
+    assert "`status: refreshed`" in direct
+    assert "`status: not-owner`" in direct
+    assert "exit 0 だけでは owner と判定しない" in direct
+    assert "resolver が返した `action: wf-new`" in direct
+    assert "resolver が返した collection" in direct
+
+
+def test_direct_entry_closes_bootstrap_and_fixed_collection_attempts() -> None:
+    direct = _section(WF_NEW_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+
+    bootstrap = next(line for line in direct.splitlines() if "record-bootstrap" in line)
+    assert "--status blocked|failed" in bootstrap
+    assert "--ai-started-at <current-attempt-ai-started-at>" in bootstrap
+    assert "--human-interval <human-start> <human-end>" in bootstrap
+    assert "発生順" in direct
+
+    record = next(line for line in direct.splitlines() if "record --channel-dir" in line)
+    assert "--collection <fixed-name>" in record
+    assert "--action wf-new" in record
+    assert "--status success|blocked|failed" in record
+    assert "--ai-started-at <current-attempt-ai-started-at>" in record
+    assert "出力 path" in direct
+    assert "workflow-state.json" in direct
+    assert "同じ fixed collection" in direct
+    assert "同じ attempt" in direct
+
+
+def test_direct_entry_releases_only_its_own_lease_on_every_exit() -> None:
+    direct = _section(WF_NEW_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+
+    assert "`finally` 相当" in direct
+    assert "release --channel-dir . --token <token>" in direct
+    assert "他 token" in direct
+
+
+def test_wf_auto_delegation_reuses_one_lease_and_attempt() -> None:
+    direct = _section(WF_NEW_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+
+    assert "実行文脈を再利用" in direct
+    assert "nested `acquire`" in direct
+    assert "canonical history の記録と lease 解放は `/wf-auto` に一度だけ" in direct


### PR DESCRIPTION
## Summary

- wf-new 直接実行を wf-auto state script の lease / resolver 契約へ接続
- resolver の canonical action `wf-new` と固定 collection を同じ timing 履歴へ記録
- bootstrap / collection 作成後の全終了 status と human interval、nested lease 禁止を contract test で固定

## Validation

- `uv run pytest tests/repo/test_wf_new_timing_skill_contract.py tests/repo/test_wf_auto_state.py tests/repo/test_wf_auto_ai_timing_skill_contract.py tests/repo/test_wf_auto_human_timing_skill_contract.py`
- `uv run yt-skills lint wf-auto wf-new`
- `uv run ruff check tests/repo/test_wf_new_timing_skill_contract.py`
- `uv run ruff format --check tests/repo/test_wf_new_timing_skill_contract.py`
- `git diff --check HEAD^`

Closes #3333

Stacked on #3344.