### PR TITLE
docs(wf-next): 直接実行をtiming契約へ接続する (#3335)

### DIFF
--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -88,6 +88,41 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ## Instructions
 
+### 直接実行の canonical timing 契約
+
+`/wf-next` を直接呼んだ場合も、state 判定・lease・history/timing の正は `/wf-auto` と同じ state script とする。下記「1. アクティブなコレクションの特定」の既存手順で対象名を `<fixed-name>` として固定した後、フェーズ処理や子 skill を開始する前に、チャンネルルートで次の順序を守る。
+
+```bash
+STATE_SCRIPT=.claude/skills/wf-auto/references/wf-auto-state.py
+uv run python "$STATE_SCRIPT" acquire --channel-dir .
+uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name>
+uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
+uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())'
+```
+
+`acquire` の `busy` / exit 20 では作業を開始しない。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した固定 collection と action を `<resolver-action>` としてそのまま使い、公開許可や実成果物から action を独自再判定せず、別 action へ読み替えない。別 collection ID や timing 保存処理も作らない。
+
+resolver action と直接入口の既存責務は次の対応を正とする。
+
+| resolver action | 直接 `/wf-next` の処理 |
+|---|---|
+| `wf-new` | planning が未完了であることを報告し、`/wf-new` を再開 action として blocked で閉じる |
+| `lyria` / `suno-helper` / `masterup` | prepared の既存のフェーズ別処理をそのまま実行し、同じ action ID で記録する |
+| `wf-next-local` / `wf-next` | mastered / publishing の既存のフェーズ別処理を実行する。`wf-next-local` は resolver が許可したローカル成果物までに限定し、YouTube write を行わない |
+| `post-publish` | production 完了を検証して `/post-publish` を再開 action として blocked で閉じ、公開後処理を本 skill へ複製しない |
+| `blocked` | resolver の reason / resume action を変更せず blocked で閉じる |
+| `complete` | 下記 complete の既存検証を通過した場合だけ success で閉じる |
+
+既存の成果物検証、承認 gate、state 更新責務を変更せず、子 skill の終了報告だけで成功にしない。期待成果物と state を検証した後、成功だけを success、手動介入または責務外 action への handoff を blocked、検証失敗を含むその他を failed とし、すべて同じ固定 collection、resolver action、同じ attempt の AI 開始時刻で閉じる。対話 gate の時間分類と `--human-interval` は `/wf-auto` の canonical timing 契約をそのまま使う。
+
+```bash
+uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collection <fixed-name> --action <resolver-action> --status success|blocked|failed --reason <reason> [--resume-action <resolver-resume-action>] --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
+```
+
+status を記録した後は、成功時だけでなく blocked / failed の停止報告前にも同じ固定 collection を `plan --channel-dir . --collection <fixed-name>` で再評価し、次回の再開 action を推測しない。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。
+
+`/wf-auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-auto` に一度だけ行わせる。
+
 ### 1. アクティブなコレクションの特定
 
 - `collections/planning/` の `workflow-state.json` を探索

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
 - `feat(wf-auto)`: collection 作成前の bootstrap attempt でも複数の人間介入区間を AI 区間と分離し、同じ canonical timing history に保存できるようにした（#3342）。
+- `docs(wf-next)`: 直接実行でも `/wf-auto` の resolver が返す `wf-next-local` / `wf-next` と固定 collection、lease、AI timing history を共用し、全終了 status を同じ canonical attempt として記録する契約を追加した（#3335）。
 - `docs(wf-new)`: 直接実行でも `/wf-auto` の state resolver、lease、canonical action / collection ID、AI timing history を共用し、collection 作成前と作成後の全終了 status を同じ attempt として閉じる契約を追加した（#3333）。
 - `docs(wf-auto)`: blocked の停止決定時点で attempt を閉じて再開までの放置時間を計上せず、再開は新しい attempt と AI 開始時刻に分離する契約を追加した。通常の API polling と agent が保持する background wait は human interval ではなく AI 実行時間として分類する（#3321）。
 - `docs(wf-auto)`: 同一 run で回答を待つ人間介入 gate の直前・直後をメインエージェントが採時し、同じ canonical action attempt の全閉区間を発生順に `record --human-interval` へ渡す実行契約を追加した（#3320）。

--- a/tests/repo/test_wf_next_timing_skill_contract.py
+++ b/tests/repo/test_wf_next_timing_skill_contract.py
@@ -1,0 +1,104 @@
+"""`/wf-next` 直接実行の canonical timing 契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+WF_NEXT_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-next" / "SKILL.md"
+WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^##+\s|\Z)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"`{heading}` セクションが見つかりません")
+    return match.group("body")
+
+
+def _state_script_assignment(text: str) -> str:
+    match = re.search(r"^STATE_SCRIPT=(?P<path>\S+)$", text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError("STATE_SCRIPT assignment が見つかりません")
+    return match.group("path")
+
+
+def test_direct_entry_plans_the_fixed_collection_before_starting_work() -> None:
+    direct = _section(WF_NEXT_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+    canonical = WF_AUTO_SKILL.read_text(encoding="utf-8")
+
+    assert _state_script_assignment(direct) == _state_script_assignment(canonical)
+    commands = [
+        "acquire --channel-dir .",
+        "plan --channel-dir . --collection <fixed-name>",
+        "heartbeat --channel-dir . --token <token>",
+        "datetime.now(UTC).isoformat()",
+    ]
+    positions = [direct.index(command) for command in commands]
+    assert positions == sorted(positions)
+    assert "`status: refreshed`" in direct
+    assert "`status: not-owner`" in direct
+    assert "exit 0 だけでは owner と判定しない" in direct
+    for action in (
+        "wf-new",
+        "lyria",
+        "suno-helper",
+        "masterup",
+        "wf-next-local",
+        "wf-next",
+        "post-publish",
+        "blocked",
+        "complete",
+    ):
+        assert f"`{action}`" in direct
+    assert "resolver が返した固定 collection" in direct
+
+
+def test_direct_entry_records_every_status_with_the_resolver_decision() -> None:
+    direct = _section(WF_NEXT_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+
+    record = next(line for line in direct.splitlines() if "record --channel-dir" in line)
+    assert "--collection <fixed-name>" in record
+    assert "--action <resolver-action>" in record
+    assert "--status success|blocked|failed" in record
+    assert "--ai-started-at <current-attempt-ai-started-at>" in record
+    assert "同じ attempt" in direct
+    assert "成果物と state を検証" in direct
+    assert "plan --channel-dir . --collection <fixed-name>" in direct
+
+
+def test_action_selection_and_existing_gates_keep_their_canonical_owners() -> None:
+    text = WF_NEXT_SKILL.read_text(encoding="utf-8")
+    direct = _section(text, "### 直接実行の canonical timing 契約")
+
+    assert "公開許可や実成果物から action を独自再判定せず" in direct
+    assert "既存の成果物検証、承認 gate、state 更新責務" in direct
+    assert "## Hard Gates: subagent 委譲境界" in text
+    assert "## 承認ゲート（config 駆動）" in text
+
+
+def test_prepared_phase_actions_keep_their_existing_direct_handlers() -> None:
+    text = WF_NEXT_SKILL.read_text(encoding="utf-8")
+    direct = _section(text, "### 直接実行の canonical timing 契約")
+
+    for action in ("lyria", "suno-helper", "masterup", "wf-next-local", "wf-next"):
+        assert f"`{action}`" in direct
+    assert "prepared" in direct
+    assert "既存のフェーズ別処理" in direct
+    assert "別 action へ読み替えない" in direct
+    assert "#### `prepared` → 段階的サポート" in text
+
+
+def test_delegation_reuses_one_lease_attempt_and_history_record() -> None:
+    direct = _section(WF_NEXT_SKILL.read_text(encoding="utf-8"), "### 直接実行の canonical timing 契約")
+
+    assert "実行文脈を再利用" in direct
+    assert "nested `acquire`" in direct
+    assert "canonical history の記録と lease 解放は `/wf-auto` に一度だけ" in direct
+    assert "release --channel-dir . --token <token>" in direct
+    assert "他 token" in direct


### PR DESCRIPTION
## Summary

- wf-next 直接実行を wf-auto state script の lease / resolver 契約へ接続
- resolver の canonical action `wf-next-local` / `wf-next` と固定 collection を同じ timing 履歴へ記録
- 全終了 status、同一 collection の再 plan、nested lease 禁止を contract test で固定

## Validation

- `uv run pytest tests/repo/test_wf_next_timing_skill_contract.py tests/repo/test_wf_new_timing_skill_contract.py tests/repo/test_wf_auto_ai_timing_skill_contract.py tests/repo/test_wf_auto_human_timing_skill_contract.py`
- `uv run yt-skills lint wf-auto wf-next`
- `uv run ruff check tests/repo/test_wf_next_timing_skill_contract.py`
- `uv run ruff format --check tests/repo/test_wf_next_timing_skill_contract.py`
- `git diff --check HEAD^`

Closes #3335

Stacked on #3340.