### PR TITLE
feat(dashboard): workflow timing の公開状態を正規化する (#3334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: workflow timing の公開 status を `ready` / `unavailable` / `in_progress` に正規化し、基準未設定・旧 schema・未計測・実行中を 0 と区別できるようにした（#3334）。
 - `feat(dashboard)`: registry の各 channel から検証済み手作業基準と workflow history を読み、collection timing summary を channel detail API へ配線した（#3325）。
 - `feat(dashboard)`: workflow timing summary を channel detail read model に追加し、overview からは除外して一覧 API の軽量契約を維持した（#3324）。
 - `feat(dashboard)`: active planning と latest live collection を最大 2 件選び、`wf-auto-state.py` の正規集計から step 状態と 6 種の時間指標を構築する read adapter を追加した（#3323）。

--- a/src/youtube_automation/infrastructure/analytics/workflow_timing.py
+++ b/src/youtube_automation/infrastructure/analytics/workflow_timing.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import math
 import sys
+import time
 from functools import cache
 from importlib.resources import as_file, files
 from pathlib import Path
 from types import ModuleType
 from typing import Protocol, cast
+
+
+class _TimingUnavailableError(ValueError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 class _TimingRunner(Protocol):
@@ -125,7 +134,12 @@ def _collection_summary(
     scoped_history = _collection_history(history, channel, collection)
     summary = runner.summarize_time_savings(scoped_history, manual_baseline_minutes)
     if summary.get("available") is not True:
-        raise ValueError(f"workflow timing を集計できません: {summary.get('reason')}")
+        reason = summary.get("reason")
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("unavailable workflow timing に reason がありません")
+        raise _TimingUnavailableError(reason)
+    if not scoped_history["attempts"]:
+        raise _TimingUnavailableError("attempt_timing_unavailable")
     actions = summary.get("actions")
     totals = summary.get("totals")
     if not isinstance(actions, dict) or not isinstance(totals, dict):
@@ -144,6 +158,26 @@ def _collection_summary(
     }
 
 
+def _has_active_lease(channel: Path) -> bool:
+    lease_path = channel / ".automation-run" / "lease" / "lease.json"
+    if lease_path.is_symlink():
+        raise ValueError(f"workflow lease に symlink は使えません: {lease_path}")
+    if not lease_path.exists():
+        return False
+    if not lease_path.is_file():
+        raise ValueError(f"workflow lease が通常ファイルではありません: {lease_path}")
+    try:
+        lease = json.loads(lease_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"workflow lease を読めません: {lease_path}: {exc}") from exc
+    if not isinstance(lease, dict):
+        raise ValueError(f"workflow lease は object でなければなりません: {lease_path}")
+    expires_at = lease.get("expires_at")
+    if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)) or not math.isfinite(expires_at):
+        raise ValueError(f"workflow lease の expires_at が不正です: {lease_path}")
+    return expires_at > time.time()
+
+
 def build_workflow_timing(
     channel: Path,
     manual_baseline_minutes: dict[str, float] | None,
@@ -152,8 +186,14 @@ def build_workflow_timing(
     channel = channel.resolve()
     runner = _runner()
     history = runner.read_history(channel)
-    collections = [
-        _collection_summary(channel, collection, stage, history, manual_baseline_minutes, runner)
-        for stage, collection in _selected_collections(channel, runner)
-    ]
-    return {"collections": collections}
+    in_progress = _has_active_lease(channel)
+    try:
+        collections = [
+            _collection_summary(channel, collection, stage, history, manual_baseline_minutes, runner)
+            for stage, collection in _selected_collections(channel, runner)
+        ]
+    except _TimingUnavailableError as exc:
+        if in_progress:
+            return {"status": "in_progress", "collections": []}
+        return {"status": "unavailable", "reason": exc.reason, "collections": []}
+    return {"status": "in_progress" if in_progress else "ready", "collections": collections}

--- a/tests/infrastructure/analytics/test_workflow_timing.py
+++ b/tests/infrastructure/analytics/test_workflow_timing.py
@@ -51,6 +51,15 @@ def _write_history(channel: Path, attempts: list[dict[str, object]]) -> None:
     )
 
 
+def _write_active_lease(channel: Path) -> None:
+    lease = channel / ".automation-run" / "lease"
+    lease.mkdir(parents=True, exist_ok=True)
+    (lease / "lease.json").write_text(
+        json.dumps({"token": "active", "acquired_at": 0, "expires_at": 4_102_444_800}),
+        encoding="utf-8",
+    )
+
+
 @pytest.mark.parametrize(
     ("planning", "live", "expected"),
     [
@@ -70,10 +79,16 @@ def test_build_workflow_timing_selects_active_and_latest_collections(
         _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
     if live:
         _write_collection(tmp_path, "live", "latest", phase="complete", created_at="2026-08-01")
-    _write_history(tmp_path, [])
+    attempts = []
+    if planning:
+        attempts.append(_attempt("collections/planning/active", "wf-next", "success", 1, 1))
+    if live:
+        attempts.append(_attempt("collections/live/latest", "post-publish", "success", 1, 1))
+    _write_history(tmp_path, attempts)
 
-    result = build_workflow_timing(tmp_path, {})
+    result = build_workflow_timing(tmp_path, {"wf-next": 1.0, "post-publish": 1.0})
 
+    assert result["status"] == "ready"
     assert [(item["collection_id"], item["stage"]) for item in result["collections"]] == expected
 
 
@@ -93,6 +108,7 @@ def test_build_workflow_timing_returns_canonical_step_and_total_metrics(tmp_path
 
     result = build_workflow_timing(tmp_path, {"wf-next": 1.0, "post-publish": 2.0})
 
+    assert result["status"] == "ready"
     active, latest = result["collections"]
     assert active["steps"] == [
         {
@@ -117,3 +133,66 @@ def test_build_workflow_timing_returns_canonical_step_and_total_metrics(tmp_path
     assert latest["collection_id"] == "latest"
     assert latest["steps"][0]["action"] == "post-publish"
     assert latest["totals"]["work_seconds"] == 20.0
+
+
+@pytest.mark.parametrize(
+    ("history", "baseline", "reason"),
+    [
+        ({"schema_version": 1, "attempts": []}, {"wf-next": 1.0}, "history_schema_v1"),
+        ({"schema_version": 2, "attempts": []}, None, "manual_baseline_unconfigured"),
+        ({"schema_version": 2, "attempts": []}, {}, "attempt_timing_unavailable"),
+        (
+            {
+                "schema_version": 2,
+                "attempts": [
+                    {
+                        "collection": "collections/planning/active",
+                        "action": "wf-next",
+                        "status": "success",
+                        "timing": None,
+                    }
+                ],
+            },
+            {"wf-next": 1.0},
+            "attempt_timing_unavailable",
+        ),
+    ],
+)
+def test_build_workflow_timing_exposes_unavailable_without_zero_metrics(
+    tmp_path: Path,
+    history: dict[str, object],
+    baseline: dict[str, float] | None,
+    reason: str,
+) -> None:
+    _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
+    state = tmp_path / ".automation-run"
+    state.mkdir()
+    (state / "history.json").write_text(json.dumps(history), encoding="utf-8")
+
+    result = build_workflow_timing(tmp_path, baseline)
+
+    assert result == {"status": "unavailable", "reason": reason, "collections": []}
+
+
+def test_build_workflow_timing_exposes_active_lease_as_in_progress(tmp_path: Path) -> None:
+    _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
+    _write_history(
+        tmp_path,
+        [_attempt("collections/planning/active", "wf-next", "success", 10, 5)],
+    )
+    _write_active_lease(tmp_path)
+
+    result = build_workflow_timing(tmp_path, {"wf-next": 1.0})
+
+    assert result["status"] == "in_progress"
+    assert result["collections"][0]["totals"]["work_seconds"] == 15.0
+
+
+def test_build_workflow_timing_keeps_in_progress_distinct_before_first_measurement(tmp_path: Path) -> None:
+    _write_collection(tmp_path, "planning", "active", phase="planning", created_at="2026-08-02")
+    _write_history(tmp_path, [])
+    _write_active_lease(tmp_path)
+
+    result = build_workflow_timing(tmp_path, None)
+
+    assert result == {"status": "in_progress", "collections": []}


### PR DESCRIPTION
## Summary

- workflow timing の公開状態を `ready` / `unavailable` / `in_progress` に正規化
- 未計測・旧 schema・基準未設定を 0 と区別
- 有効 lease 中も既存の計測値を保持

## Validation

- dashboard focused tests: 36 passed
- ruff check / format check
- git diff --check

Closes #3334