### PR TITLE
feat(wf-auto): bootstrapの人間区間を記録する (#3342)

### DIFF
--- a/.claude/skills/wf-auto/references/wf-auto-state.py
+++ b/.claude/skills/wf-auto/references/wf-auto-state.py
@@ -1035,8 +1035,12 @@ def record_bootstrap_attempt(
     reason: str,
     now: str,
     ai_started_at: str | None = None,
+    human_intervals: list[list[str]] | None = None,
 ) -> None:
     """Record an unattended `/wf-new` stop before a collection exists."""
+    if human_intervals and ai_started_at is None:
+        raise ValueError("record-bootstrap: human_interval には ai_started_at が必要です")
+    segments = _timing_segments(ai_started_at, human_intervals or [], now) if ai_started_at is not None else None
     record_attempt(
         root,
         token=token,
@@ -1046,7 +1050,7 @@ def record_bootstrap_attempt(
         reason=reason,
         resume_action="wf-new",
         now=now,
-        segments=[_ai_timing_segment(ai_started_at, now)] if ai_started_at is not None else None,
+        segments=segments,
     )
 
 
@@ -1082,6 +1086,7 @@ def _parser() -> argparse.ArgumentParser:
     bootstrap.add_argument("--status", choices=("blocked", "failed"), required=True)
     bootstrap.add_argument("--reason", required=True)
     bootstrap.add_argument("--ai-started-at")
+    bootstrap.add_argument("--human-interval", action="append", nargs=2, metavar=("START", "END"))
     return parser
 
 
@@ -1113,6 +1118,7 @@ def main(argv: list[str] | None = None) -> int:
                 reason=args.reason,
                 now=recorded_at,
                 ai_started_at=args.ai_started_at,
+                human_intervals=args.human_interval,
             )
             result = {"status": "recorded"}
         else:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
 - `feat(wf-auto)`: action 別手作業基準を同じ collection / action の work item 数へ適用し、全 retry の AI・人間時間を差し引いた「AI 込み削減時間」と「人間が浮いた時間」を action 別・全体で返す集計を追加した。負値は available な 0 に丸め、基準欠落と legacy timing は unavailable を維持する（#3273）。
 - `feat(wf-auto)`: schema v2 history の全 attempt を status に関係なく同じ collection / action の work item と action 別に集約し、AI 秒・人間秒・attempt 数・work item 数を決定的に返す純粋関数を追加した。schema v1 または timing 欠落は 0 とせず unavailable を返す（#3272）。
+- `feat(wf-auto)`: collection 作成前の bootstrap attempt でも複数の人間介入区間を AI 区間と分離し、同じ canonical timing history に保存できるようにした（#3342）。
 - `docs(wf-auto)`: blocked の停止決定時点で attempt を閉じて再開までの放置時間を計上せず、再開は新しい attempt と AI 開始時刻に分離する契約を追加した。通常の API polling と agent が保持する background wait は human interval ではなく AI 実行時間として分類する（#3321）。
 - `docs(wf-auto)`: 同一 run で回答を待つ人間介入 gate の直前・直後をメインエージェントが採時し、同じ canonical action attempt の全閉区間を発生順に `record --human-interval` へ渡す実行契約を追加した（#3320）。
 - `feat(wf-auto)`: state CLI の `record` に repeatable な `--human-interval START END` を追加し、AI 開始から記録時刻までを連続した AI / human timing segment として保存できるようにした。不正な逆転・重複・範囲外・timezone 不一致は既存 history を変更せず拒否する（#3319）。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -887,7 +887,11 @@ def test_cli_records_timed_bootstrap_stop_before_collection_exists(
     monkeypatch.setattr(runner.secrets, "token_hex", lambda _: safe_token)
 
     token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
-    started_at = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    started_at = datetime.now(UTC) - timedelta(seconds=30)
+    first_human_start = started_at + timedelta(seconds=5)
+    first_human_end = started_at + timedelta(seconds=10)
+    second_human_start = started_at + timedelta(seconds=15)
+    second_human_end = started_at + timedelta(seconds=20)
 
     assert token == safe_token
     assert (
@@ -903,7 +907,13 @@ def test_cli_records_timed_bootstrap_stop_before_collection_exists(
                 "--reason",
                 "user_input_required",
                 "--ai-started-at",
-                started_at,
+                started_at.isoformat(),
+                "--human-interval",
+                first_human_start.isoformat(),
+                first_human_end.isoformat(),
+                "--human-interval",
+                second_human_start.isoformat(),
+                second_human_end.isoformat(),
             ]
         )
         == 0
@@ -913,11 +923,71 @@ def test_cli_records_timed_bootstrap_stop_before_collection_exists(
     assert attempt["collection"] is None
     assert attempt["action"] == "wf-new"
     assert attempt["status"] == status
-    assert attempt["timing"]["segments"] == [
-        {
-            "kind": "ai",
-            "started_at": started_at,
-            "ended_at": attempt["timing"]["ended_at"],
-            "duration_seconds": attempt["timing"]["ai_seconds"],
-        }
+    assert [segment["kind"] for segment in attempt["timing"]["segments"]] == [
+        "ai",
+        "human",
+        "ai",
+        "human",
+        "ai",
     ]
+    assert attempt["timing"]["segments"][1] == {
+        "kind": "human",
+        "started_at": first_human_start.isoformat(),
+        "ended_at": first_human_end.isoformat(),
+        "duration_seconds": 5.0,
+    }
+    assert attempt["timing"]["segments"][3] == {
+        "kind": "human",
+        "started_at": second_human_start.isoformat(),
+        "ended_at": second_human_end.isoformat(),
+        "duration_seconds": 5.0,
+    }
+    assert attempt["timing"]["human_seconds"] == 10.0
+
+
+@pytest.mark.parametrize(
+    ("ai_started_at", "human_intervals", "message"),
+    [
+        (None, [["2026-08-08T00:00:01+00:00", "2026-08-08T00:00:02+00:00"]], "ai_started_at"),
+        (
+            "2026-08-08T00:00:00+00:00",
+            [
+                ["2026-08-08T00:00:01+00:00", "2026-08-08T00:00:03+00:00"],
+                ["2026-08-08T00:00:02+00:00", "2026-08-08T00:00:04+00:00"],
+            ],
+            "overlap",
+        ),
+    ],
+)
+def test_cli_rejects_invalid_bootstrap_human_intervals_without_mutating_history(
+    tmp_path: Path,
+    runner: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    ai_started_at: str | None,
+    human_intervals: list[list[str]],
+    message: str,
+) -> None:
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+    history_path = tmp_path / ".automation-run" / "history.json"
+    original = json.dumps({"schema_version": 2, "attempts": []})
+    history_path.write_text(original, encoding="utf-8")
+
+    argv = [
+        "record-bootstrap",
+        "--channel-dir",
+        str(tmp_path),
+        "--token",
+        token,
+        "--status",
+        "blocked",
+        "--reason",
+        "user_input_required",
+    ]
+    if ai_started_at is not None:
+        argv.extend(["--ai-started-at", ai_started_at])
+    for interval in human_intervals:
+        argv.extend(["--human-interval", *interval])
+
+    assert runner.main(argv) == 2
+    assert message in json.loads(capsys.readouterr().out)["reason"]
+    assert history_path.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary

- `record-bootstrap` に repeatable な `--human-interval` を追加
- collection 作成前も AI / human 区間を発生順の連続 segment として保存
- AI 開始時刻欠落・interval overlap を history 非変更で拒否

## Validation

- `uv run pytest tests/repo/test_wf_auto_state.py -q`
- `uv run ruff check .claude/skills/wf-auto/references/wf-auto-state.py tests/repo/test_wf_auto_state.py`
- `uv run ruff format --check .claude/skills/wf-auto/references/wf-auto-state.py tests/repo/test_wf_auto_state.py`
- `git diff --check HEAD^`

Closes #3342

Stacked on #3332.