### PR TITLE
feat(dashboard): timing 異常を channel 単位に隔離する (#3339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: channel ごとの workflow timing 欠損・不正 shape を専用の `status=error` へ隔離し、同じ channel の Analytics summary / videos と他 channel の timing を維持する fail-soft 境界を追加した（#3339）。
 - `feat(dashboard)`: workflow timing の公開 status を `ready` / `unavailable` / `in_progress` に正規化し、基準未設定・旧 schema・未計測・実行中を 0 と区別できるようにした（#3334）。
 - `feat(dashboard)`: registry の各 channel から検証済み手作業基準と workflow history を読み、collection timing summary を channel detail API へ配線した（#3325）。
 - `feat(dashboard)`: workflow timing summary を channel detail read model に追加し、overview からは除外して一覧 API の軽量契約を維持した（#3324）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -36,6 +37,29 @@ def _text(value: object, default: str = "") -> str:
 
 def _integer_or_none(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _workflow_timing_error(code: str, message: str) -> dict[str, object]:
+    return {
+        "status": "error",
+        "collections": [],
+        "error": {"code": code, "message": message},
+    }
+
+
+def _workflow_timing(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return _workflow_timing_error("workflow_timing_invalid", "workflow timing は object ではありません")
+    timing = cast(dict[str, object], value)
+    status = timing.get("status")
+    collections = timing.get("collections")
+    if status not in {"ready", "unavailable", "in_progress"} or not isinstance(collections, list):
+        return _workflow_timing_error("workflow_timing_invalid", "workflow timing の status/collections が不正です")
+    if any(not isinstance(collection, dict) for collection in collections):
+        return _workflow_timing_error("workflow_timing_invalid", "workflow timing collection は object ではありません")
+    if status == "unavailable" and not _text(timing.get("reason")):
+        return _workflow_timing_error("workflow_timing_invalid", "unavailable workflow timing に reason がありません")
+    return timing
 
 
 def _channel_id(channel: Path) -> str:
@@ -247,11 +271,12 @@ def build_dashboard_read_model(
     channel_paths: list[Path],
     *,
     refresh_errors: dict[Path, str] | None = None,
-    workflow_timing_by_channel: dict[Path, dict[str, object]] | None = None,
+    workflow_timing_by_channel: Mapping[Path, object] | None = None,
 ) -> dict[str, object]:
     """登録順のチャンネルから JSON serializable な read model を作る。"""
     errors = refresh_errors or {}
     workflow_timings = workflow_timing_by_channel or {}
+    timing_requested = workflow_timing_by_channel is not None
     channels: list[dict[str, object]] = []
     for channel in channel_paths:
         refresh_message = errors.get(channel)
@@ -259,8 +284,14 @@ def build_dashboard_read_model(
         item["refresh_error"] = (
             {"code": "refresh_failed", "message": refresh_message} if refresh_message is not None else None
         )
-        if channel in workflow_timings:
-            item["workflow_timing"] = workflow_timings[channel]
+        if timing_requested:
+            if channel in workflow_timings:
+                item["workflow_timing"] = _workflow_timing(workflow_timings[channel])
+            else:
+                item["workflow_timing"] = _workflow_timing_error(
+                    "workflow_timing_missing",
+                    "channel の workflow timing がありません",
+                )
         channels.append(item)
     return {
         "schema_version": SCHEMA_VERSION,

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -281,6 +281,7 @@ def test_dashboard_api_exposes_workflow_timing_only_in_channel_detail(tmp_path: 
         },
     )
     timing = {
+        "status": "ready",
         "collections": [
             {
                 "collection_id": "active",
@@ -288,7 +289,7 @@ def test_dashboard_api_exposes_workflow_timing_only_in_channel_detail(tmp_path: 
                 "steps": [],
                 "totals": {"work_seconds": 0},
             }
-        ]
+        ],
     }
 
     api = DashboardAPI(build_dashboard_read_model([channel], workflow_timing_by_channel={channel: timing}))
@@ -297,6 +298,52 @@ def test_dashboard_api_exposes_workflow_timing_only_in_channel_detail(tmp_path: 
 
     assert "workflow_timing" not in overview["channels"][0]
     assert api.channel(channel_id)["workflow_timing"] == timing
+
+
+@pytest.mark.parametrize(
+    ("broken_timing", "error_code"),
+    [
+        (None, "workflow_timing_missing"),
+        ({"status": "ready", "collections": "not-an-array"}, "workflow_timing_invalid"),
+    ],
+)
+def test_read_model_isolates_missing_or_malformed_workflow_timing_by_channel(
+    tmp_path: Path,
+    broken_timing: object,
+    error_code: str,
+) -> None:
+    healthy = tmp_path / "healthy"
+    broken = tmp_path / "broken"
+    for channel, name, views in ((healthy, "Healthy", 900), (broken, "Broken timing", 700)):
+        _write_channel(
+            channel,
+            name=name,
+            snapshots={
+                "analytics_data_20260720.json": _snapshot(
+                    collected_at="2026-07-20T00:00:00+00:00",
+                    views=views,
+                    video_views=views - 100,
+                )
+            },
+        )
+    healthy_timing = {"status": "ready", "collections": []}
+    timings: dict[Path, object] = {healthy: healthy_timing}
+    if broken_timing is not None:
+        timings[broken] = broken_timing
+
+    channels = build_dashboard_read_model(
+        [broken, healthy],
+        workflow_timing_by_channel=timings,
+    )["channels"]
+
+    broken_item, healthy_item = channels
+    assert broken_item["status"] == "ready"
+    assert broken_item["summary"]["views"] == 700
+    assert broken_item["videos"][0]["video_id"] == "video-b"
+    assert broken_item["workflow_timing"]["status"] == "error"
+    assert broken_item["workflow_timing"]["error"]["code"] == error_code
+    assert healthy_item["summary"]["views"] == 900
+    assert healthy_item["workflow_timing"] == healthy_timing
 
 
 def test_read_model_keeps_previous_snapshot_with_structured_refresh_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- workflow timing の欠落・不正 shape を channel 固有の `status=error` に正規化
- Analytics summary / videos を維持
- 他 channel の正常 timing への波及を防止

## Validation

- dashboard focused tests: 38 passed
- ruff check / format check
- git diff --check

Closes #3339