### PR TITLE
feat(dashboard): timing API schema 境界を明示する (#3338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: workflow timing を含む dashboard API schema を v2 とし、overview は timing を除いた channel 集約、detail は `ready` / `unavailable` / `in_progress` / `error` の timing を返す境界を HTTP 200 契約として固定した（#3338）。
 - `feat(dashboard)`: channel ごとの workflow timing 欠損・不正 shape を専用の `status=error` へ隔離し、同じ channel の Analytics summary / videos と他 channel の timing を維持する fail-soft 境界を追加した（#3339）。
 - `feat(dashboard)`: workflow timing の公開 status を `ready` / `unavailable` / `in_progress` に正規化し、基準未設定・旧 schema・未計測・実行中を 0 と区別できるようにした（#3334）。
 - `feat(dashboard)`: registry の各 channel から検証済み手作業基準と workflow history を読み、collection timing summary を channel detail API へ配線した（#3325）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -13,7 +13,8 @@ from typing import cast
 from youtube_automation.core.errors import DashboardChannelNotFoundError
 from youtube_automation.infrastructure.analytics.dashboard_publications import load_dashboard_publications
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+LEGACY_SCHEMA_VERSION = 1
 
 
 def _object(value: object) -> dict[str, object]:
@@ -294,7 +295,7 @@ def build_dashboard_read_model(
                 )
         channels.append(item)
     return {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": SCHEMA_VERSION if timing_requested else LEGACY_SCHEMA_VERSION,
         "channels": channels,
         "publications": _publication_read_model(channel_paths, channels),
     }

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -172,11 +172,14 @@ def test_server_exposes_overview_and_channel_detail(dashboard_server: str):
     channel = overview["channels"][0]
 
     assert status == 200
+    assert overview["schema_version"] == 2
     assert channel["name"] == "Night Drive"
     assert channel["video_count"] == 1
+    assert "workflow_timing" not in channel
     detail_status, detail = _json(f"{dashboard_server}/api/channels/{channel['id']}")
     assert detail_status == 200
     assert detail["videos"][0]["title"] == "Midnight"
+    assert detail["workflow_timing"]["status"] == "ready"
     active, latest = detail["workflow_timing"]["collections"]
     assert (active["collection_id"], active["stage"], active["totals"]["work_seconds"]) == (
         "active",
@@ -206,6 +209,50 @@ def test_server_exposes_saved_publication_read_model(dashboard_server: str) -> N
         "message": "quota exceeded",
         "attempted_at": "2026-07-20T14:00:00+00:00",
     }
+
+
+@pytest.mark.parametrize(
+    ("timing_state", "expected_status", "expected_code"),
+    [
+        ("unavailable", "unavailable", None),
+        ("error", "error", "workflow_timing_invalid"),
+    ],
+)
+def test_server_keeps_analytics_payload_when_workflow_timing_is_unavailable_or_error(
+    tmp_path: Path,
+    timing_state: str,
+    expected_status: str,
+    expected_code: str | None,
+) -> None:
+    channel = _write_channel(tmp_path)
+    if timing_state == "unavailable":
+        history_path = channel / ".automation-run" / "history.json"
+        history_path.write_text(json.dumps({"schema_version": 1, "attempts": []}), encoding="utf-8")
+    else:
+        for state_path in channel.glob("collections/*/*/workflow-state.json"):
+            state_path.unlink()
+    server = create_server(port=0, channel_paths=[channel])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        overview_status, overview = _json(f"{base_url}/api/channels")
+        overview_channel = overview["channels"][0]
+        detail_status, detail = _json(f"{base_url}/api/channels/{overview_channel['id']}")
+
+        assert overview_status == detail_status == 200
+        assert overview["schema_version"] == 2
+        assert overview_channel["summary"]["views"] == 123
+        assert "workflow_timing" not in overview_channel
+        assert detail["summary"]["views"] == 123
+        assert detail["videos"][0]["title"] == "Midnight"
+        assert detail["workflow_timing"]["status"] == expected_status
+        if expected_code is not None:
+            assert detail["workflow_timing"]["error"]["code"] == expected_code
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
 
 
 @pytest.mark.parametrize("path", ["/api/unknown", "/api/channels/not-registered"])


### PR DESCRIPTION
## Summary

- timing 対応 API を schema v2 として明示
- overview / detail の workflow timing 責務境界を固定
- unavailable / error でも HTTP 200 と Analytics payload を維持
- timing 未指定の legacy model は schema v1 を維持

## Validation

- dashboard/read-model/workflow-timing focused tests: 40 passed
- ruff check / format check
- git diff --check

Closes #3338