### PR TITLE
fix(dashboard): timing 障害を channel 単位に隔離する (#3348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new-batch)`: 相互差別化済み manifest を canonical `/wf-new` へ 1 件ずつ渡し、atomic ledger と実成果物照合により completed を飛ばして最初の未完了 plan から再開する batch orchestrator を追加した。child 完了後・ledger 更新前 crash は same-provenance の prepared state と hard artifacts を再検証し、workflow state を変更せず ledger だけを completed へ reconcile する。失敗・承認待ちでは後続を開始しない（#3264）。
 - `feat(wf-new)`: 検証済み batch manifest の 1 plan を指定して開始する opt-in 入口を追加し、企画生成だけを省略して初期化以降の承認・state・failure gate を通常入口と共有する契約を固定した。不正・曖昧な入力は state mutation 前に拒否する（#3263）。
 - `feat(collection-ideate)`: 明示的な batch plan mode で N 件の企画を既存 collection と batch 内の全組合せに対して相互差別化し、全件承認・件数・slug 一意性・provenance を検証した manifest だけを atomic に保存する契約を追加した。通常の single collection 企画契約は維持する（#3262）。
+- `feat(dashboard)`: production dashboard の workflow timing 構築を channel 単位で fail-soft 化し、history / lease / state / config の破損を他 channel や Analytics payload へ波及させず、collection 作成前の active lease も `in_progress` として返すようにした（#3348）。
 - `feat(dashboard)`: workflow timing を含む dashboard API schema を v2 とし、overview は timing を除いた channel 集約、detail は `ready` / `unavailable` / `in_progress` / `error` の timing を返す境界を HTTP 200 契約として固定した（#3338）。
 - `feat(dashboard)`: channel ごとの workflow timing 欠損・不正 shape を専用の `status=error` へ隔離し、同じ channel の Analytics summary / videos と他 channel の timing を維持する fail-soft 境界を追加した（#3339）。
 - `feat(dashboard)`: workflow timing の公開 status を `ready` / `unavailable` / `in_progress` に正規化し、基準未設定・旧 schema・未計測・実行中を 0 と区別できるようにした（#3334）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -18,7 +18,7 @@ from urllib.parse import unquote, urlsplit
 
 from youtube_automation.commands.analytics.analytics_system import AnalyticsSystem
 from youtube_automation.configuration.loader import load_config_from_path
-from youtube_automation.core.errors import DashboardChannelNotFoundError
+from youtube_automation.core.errors import ConfigError, DashboardChannelNotFoundError
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,
     load_channel_registry,
@@ -34,16 +34,22 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 
 
-def _build_channel_workflow_timing(channel: Path) -> dict[str, object]:
-    collection_states = (
-        state_path
-        for stage in ("planning", "live")
-        for state_path in (channel / "collections" / stage).glob("*/workflow-state.json")
-    )
-    if next(collection_states, None) is None:
-        return {"collections": []}
-    config = load_config_from_path(channel)
-    return build_workflow_timing(channel, config.workflow.manual_baseline_minutes)
+def _build_channel_workflow_timing(channel: Path) -> dict[str, object] | None:
+    try:
+        collection_states = (
+            state_path
+            for stage in ("planning", "live")
+            for state_path in (channel / "collections" / stage).glob("*/workflow-state.json")
+        )
+        if next(collection_states, None) is None:
+            timing = build_workflow_timing(channel, None)
+            if timing.get("status") == "in_progress":
+                return timing
+            return {"status": "unavailable", "reason": "collection_missing", "collections": []}
+        config = load_config_from_path(channel)
+        return build_workflow_timing(channel, config.workflow.manual_baseline_minutes)
+    except (ConfigError, OSError, ValueError):
+        return None
 
 
 class DashboardServer(ThreadingHTTPServer):

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -229,8 +229,7 @@ def test_server_keeps_analytics_payload_when_workflow_timing_is_unavailable_or_e
         history_path = channel / ".automation-run" / "history.json"
         history_path.write_text(json.dumps({"schema_version": 1, "attempts": []}), encoding="utf-8")
     else:
-        for state_path in channel.glob("collections/*/*/workflow-state.json"):
-            state_path.unlink()
+        (channel / ".automation-run" / "history.json").write_text("not-json", encoding="utf-8")
     server = create_server(port=0, channel_paths=[channel])
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -249,6 +248,63 @@ def test_server_keeps_analytics_payload_when_workflow_timing_is_unavailable_or_e
         assert detail["workflow_timing"]["status"] == expected_status
         if expected_code is not None:
             assert detail["workflow_timing"]["error"]["code"] == expected_code
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_server_isolates_corrupt_history_from_healthy_channel(tmp_path: Path) -> None:
+    corrupt = _write_channel(tmp_path / "corrupt-root")
+    healthy = _write_channel(tmp_path / "healthy-root")
+    (corrupt / ".automation-run" / "history.json").write_text("not-json", encoding="utf-8")
+
+    server = create_server(port=0, channel_paths=[corrupt, healthy])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        overview_status, overview = _json(f"{base_url}/api/channels")
+        corrupt_overview, healthy_overview = overview["channels"]
+        corrupt_status, corrupt_detail = _json(f"{base_url}/api/channels/{corrupt_overview['id']}")
+        healthy_status, healthy_detail = _json(f"{base_url}/api/channels/{healthy_overview['id']}")
+
+        assert overview_status == corrupt_status == healthy_status == 200
+        assert corrupt_overview["summary"]["views"] == 123
+        assert corrupt_detail["videos"][0]["title"] == "Midnight"
+        assert corrupt_detail["workflow_timing"]["status"] == "error"
+        assert healthy_overview["summary"]["views"] == 123
+        assert healthy_detail["videos"][0]["title"] == "Midnight"
+        assert healthy_detail["workflow_timing"]["status"] == "ready"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_server_exposes_active_lease_without_collection_as_in_progress(tmp_path: Path) -> None:
+    channel = _write_channel(tmp_path)
+    for state_path in channel.glob("collections/*/*/workflow-state.json"):
+        state_path.unlink()
+    lease = channel / ".automation-run" / "lease"
+    lease.mkdir()
+    (lease / "lease.json").write_text(
+        json.dumps({"token": "active", "acquired_at": 0, "expires_at": 4_102_444_800}),
+        encoding="utf-8",
+    )
+
+    server = create_server(port=0, channel_paths=[channel])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        _, overview = _json(f"{base_url}/api/channels")
+        status, detail = _json(f"{base_url}/api/channels/{overview['channels'][0]['id']}")
+
+        assert status == 200
+        assert detail["summary"]["views"] == 123
+        assert detail["videos"][0]["title"] == "Midnight"
+        assert detail["workflow_timing"] == {"status": "in_progress", "collections": []}
     finally:
         server.shutdown()
         thread.join(timeout=5)


### PR DESCRIPTION
## Summary

- history / lease / state / config の timing 障害を channel 単位に隔離
- 破損 channel があっても HTTP 200、Analytics、healthy channel timing を維持
- collection 作成前の active lease を `in_progress` として公開
- catch 対象を `ConfigError` / `OSError` / `ValueError` に限定

## Validation

- timing/read-model/server focused tests: 42 passed
- ruff check / format check
- git diff --check

Closes #3348