### PR TITLE
feat(dashboard): 公開履歴の日別 payload を構築する (#3355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 ### Added
 
+- `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。
 - `feat(wf-new-batch)`: batch ledger の許可遷移・単一 active plan・current plan 整合性と atomic 保存を実行時に検証し、child が prepared + hard artifacts 完了後に ledger 更新前 crash した場合は same-provenance actual state から workflow-state を変更せず completed へ reconcile できる state helper を追加した。Done 再検証で artifact / provenance drift を検知した completed plan は、reason と resume_action を伴う guarded transition だけ blocked へ戻せる（#3279）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -1,0 +1,47 @@
+"""dashboard の公開動画日時をローカル暦日別に集計する。"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+SCHEMA_VERSION = 1
+ROLLING_WINDOW_DAYS = 365
+
+
+def _parse_published_at(value: str) -> datetime:
+    published_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if published_at.tzinfo is None:
+        raise ValueError("published_at は timezone-aware ISO 8601 でなければなりません")
+    return published_at.astimezone(UTC)
+
+
+def build_dashboard_publications(
+    published_at_values: Iterable[str],
+    *,
+    timezone: str,
+    fetched_at: datetime,
+) -> dict[str, object]:
+    """公開日時を rolling 365 日のローカル暦日別件数へ変換する。"""
+    if fetched_at.tzinfo is None:
+        raise ValueError("fetched_at は timezone-aware datetime でなければなりません")
+
+    fetched_at_utc = fetched_at.astimezone(UTC)
+    cutoff = fetched_at_utc - timedelta(days=ROLLING_WINDOW_DAYS)
+    local_timezone = ZoneInfo(timezone)
+    counts: Counter[str] = Counter()
+
+    for value in published_at_values:
+        published_at = _parse_published_at(value)
+        if cutoff <= published_at <= fetched_at_utc:
+            local_day = published_at.astimezone(local_timezone).date().isoformat()
+            counts[local_day] += 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "fetched_at": fetched_at_utc.isoformat(),
+        "timezone": timezone,
+        "days": dict(sorted(counts.items())),
+    }

--- a/tests/infrastructure/analytics/test_dashboard_publications.py
+++ b/tests/infrastructure/analytics/test_dashboard_publications.py
@@ -1,0 +1,57 @@
+from datetime import UTC, datetime, timedelta
+
+from youtube_automation.infrastructure.analytics.dashboard_publications import (
+    build_dashboard_publications,
+)
+
+
+def test_build_dashboard_publications_groups_by_local_calendar_day() -> None:
+    fetched_at = datetime(2026, 8, 9, 12, tzinfo=UTC)
+
+    payload = build_dashboard_publications(
+        [
+            "2026-08-07T15:30:00Z",
+            "2026-08-08T14:59:00Z",
+            "2026-08-08T15:00:00Z",
+        ],
+        timezone="Asia/Tokyo",
+        fetched_at=fetched_at,
+    )
+
+    assert payload == {
+        "schema_version": 1,
+        "fetched_at": "2026-08-09T12:00:00+00:00",
+        "timezone": "Asia/Tokyo",
+        "days": {
+            "2026-08-08": 2,
+            "2026-08-09": 1,
+        },
+    }
+
+
+def test_build_dashboard_publications_includes_cutoff_and_excludes_older_timestamp() -> None:
+    fetched_at = datetime(2026, 8, 8, 12, tzinfo=UTC)
+    cutoff = fetched_at - timedelta(days=365)
+
+    payload = build_dashboard_publications(
+        [
+            (cutoff - timedelta(microseconds=1)).isoformat(),
+            cutoff.isoformat(),
+            fetched_at.isoformat(),
+        ],
+        timezone="UTC",
+        fetched_at=fetched_at,
+    )
+
+    assert payload["days"] == {
+        "2025-08-08": 1,
+        "2026-08-08": 1,
+    }
+
+
+def test_build_dashboard_publications_normalizes_fetched_at_to_utc() -> None:
+    fetched_at = datetime.fromisoformat("2026-08-08T21:00:00+09:00")
+
+    payload = build_dashboard_publications([], timezone="UTC", fetched_at=fetched_at)
+
+    assert payload["fetched_at"] == "2026-08-08T12:00:00+00:00"


### PR DESCRIPTION
## Summary
- rolling 365 日の公開動画をチャンネル timezone の暦日別に集計
- schema v1 と UTC fetched_at、inclusive cutoff を固定
- timezone 日付境界と cutoff 境界を unit test で検証

## Verification
- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_publications.py -q`
- `nix develop --command uv run pytest tests/test_changelog.py -q`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3355