### PR TITLE
feat(dashboard): 公開履歴を原子的に保存する (#3356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 ### Added
 
+- `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import os
+import tempfile
 from collections import Counter
 from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 SCHEMA_VERSION = 1
@@ -45,3 +49,21 @@ def build_dashboard_publications(
         "timezone": timezone,
         "days": dict(sorted(counts.items())),
     }
+
+
+def save_dashboard_publications(destination: Path, payload: dict[str, object]) -> None:
+    """同一ディレクトリの一時ファイルを置換して payload を原子的に保存する。"""
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(payload, file, ensure_ascii=False, indent=2)
+            file.write("\n")
+            file.flush()
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/tests/infrastructure/analytics/test_dashboard_publications.py
+++ b/tests/infrastructure/analytics/test_dashboard_publications.py
@@ -1,7 +1,14 @@
+import json
+import os
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
+import pytest
+
+from youtube_automation.infrastructure.analytics import dashboard_publications
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
+    save_dashboard_publications,
 )
 
 
@@ -55,3 +62,50 @@ def test_build_dashboard_publications_normalizes_fetched_at_to_utc() -> None:
     payload = build_dashboard_publications([], timezone="UTC", fetched_at=fetched_at)
 
     assert payload["fetched_at"] == "2026-08-08T12:00:00+00:00"
+
+
+def test_save_dashboard_publications_replaces_with_complete_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "dashboard_publications.json"
+    payload = {"schema_version": 1, "days": {"2026-08-08": 2}}
+    real_replace = os.replace
+    observed_temporary: Path | None = None
+
+    def inspect_then_replace(source: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:
+        nonlocal observed_temporary
+        observed_temporary = Path(source)
+        assert observed_temporary.parent == destination.parent
+        assert json.loads(observed_temporary.read_text(encoding="utf-8")) == payload
+        real_replace(source, target)
+
+    monkeypatch.setattr(dashboard_publications.os, "replace", inspect_then_replace)
+
+    save_dashboard_publications(destination, payload)
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == payload
+    assert observed_temporary is not None
+    assert not observed_temporary.exists()
+
+
+def test_save_dashboard_publications_preserves_destination_and_cleans_temp_on_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "dashboard_publications.json"
+    original = b'{"existing": true}\n'
+    destination.write_bytes(original)
+    observed_temporary: Path | None = None
+
+    def fail_replace(source: str | os.PathLike[str], _target: str | os.PathLike[str]) -> None:
+        nonlocal observed_temporary
+        observed_temporary = Path(source)
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(dashboard_publications.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="injected replace failure"):
+        save_dashboard_publications(destination, {"replacement": True})
+
+    assert destination.read_bytes() == original
+    assert observed_temporary is not None
+    assert not observed_temporary.exists()


### PR DESCRIPTION
## Summary
- 保存先と同じディレクトリの一時ファイルへ JSON を完全書き込み
- `os.replace` により完全な payload だけを公開
- 置換失敗時の既存 JSON 保持と一時ファイル清掃を検証

## Verification
- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_publications.py -q`
- `nix develop --command uv run pytest tests/test_changelog.py -q`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3356