### PR TITLE
feat(dashboard): 収集済み動画から公開履歴を保存する (#3357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 ### Added
 
+- `feat(dashboard)`: standard Analytics 収集に使った同一 `AnalyticsSystem` / collector の動画一覧 cache を再利用し、チャンネル設定の公開 timezone で集計した `data/dashboard_publications.json` を収集成功時だけ保存するようにした（#3357）。
 - `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
@@ -6,11 +6,27 @@ import logging
 import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Protocol
 
 from youtube_automation.core.errors import AutomationError
+from youtube_automation.infrastructure.analytics.dashboard_publications import (
+    build_dashboard_publications,
+    save_dashboard_publications,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class _AnalyticsCollector(Protocol):
+    def get_all_channel_videos(self) -> list[dict[str, object]]: ...
+
+
+class _AnalyticsSystem(Protocol):
+    collector: _AnalyticsCollector
+
+    def run_data_collection(self, *, days: int, depth: str) -> dict[str, object]: ...
 
 
 @contextmanager
@@ -36,12 +52,30 @@ def _channel_context(channel: Path) -> Iterator[None]:
         reset_config()
 
 
-def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[[], object]) -> None:
-    """既存 AnalyticsSystem を使って1チャンネルのstandard snapshotを保存する。"""
+def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[[], _AnalyticsSystem]) -> None:
+    """同じ AnalyticsSystem で standard snapshot と公開履歴を保存する。"""
+    from youtube_automation.configuration import load_config
+
     with _channel_context(channel):
-        result = analytics_system_factory().run_data_collection(days=30, depth="standard")
-    if not result.get("success"):
-        raise AutomationError(str(result.get("error", "Analytics refresh failed")))
+        system = analytics_system_factory()
+        result = system.run_data_collection(days=30, depth="standard")
+        if not result.get("success"):
+            raise AutomationError(str(result.get("error", "Analytics refresh failed")))
+
+        published_at_values: list[str] = []
+        for video in system.collector.get_all_channel_videos():
+            published_at = video.get("published_at")
+            if not isinstance(published_at, str):
+                raise ValueError("動画の published_at は ISO 8601 文字列でなければなりません")
+            published_at_values.append(published_at)
+
+        timezone = load_config().youtube.api.default_publish_timezone
+        payload = build_dashboard_publications(
+            published_at_values,
+            timezone=timezone,
+            fetched_at=datetime.now(UTC),
+        )
+        save_dashboard_publications(channel / "data" / "dashboard_publications.json", payload)
 
 
 def refresh_dashboard_channels(

--- a/tests/infrastructure/analytics/test_dashboard_refresh.py
+++ b/tests/infrastructure/analytics/test_dashboard_refresh.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import json
 import os
+from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from youtube_automation import configuration
 from youtube_automation.core.errors import AutomationError, ConfigError
+from youtube_automation.infrastructure.analytics import dashboard_refresh
 from youtube_automation.infrastructure.analytics.dashboard_refresh import (
     collect_channel_analytics,
     refresh_dashboard_channels,
@@ -68,13 +72,22 @@ def test_collect_channel_restores_environment_and_configuration_after_success(
         monkeypatch.setenv("CHANNEL", initial_slug)
     reset = Mock(wraps=configuration.reset)
     monkeypatch.setattr(configuration, "reset", reset)
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="UTC")))
+        ),
+    )
     system = Mock()
+    system.collector.get_all_channel_videos.return_value = []
 
     def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
         assert days == 30
         assert depth == "standard"
         assert os.environ["CHANNEL_DIR"] == str(channel)
         assert "CHANNEL" not in os.environ
+        (channel / "data").mkdir(parents=True)
         return {"success": True}
 
     system.run_data_collection.side_effect = run_data_collection
@@ -85,8 +98,61 @@ def test_collect_channel_restores_environment_and_configuration_after_success(
     assert reset.call_count == 2
     assert factory.call_count == 1
     system.run_data_collection.assert_called_once_with(days=30, depth="standard")
+    system.collector.get_all_channel_videos.assert_called_once_with()
+    assert (channel / "data" / "dashboard_publications.json").is_file()
     assert os.environ.get("CHANNEL_DIR") == initial_dir
     assert os.environ.get("CHANNEL") == initial_slug
+
+
+def test_collect_channel_reuses_system_collector_and_saves_publications_with_config_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    channel = tmp_path / "selected"
+    fixed_now = datetime(2026, 8, 8, 12, tzinfo=UTC)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(dashboard_refresh, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(
+                youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="America/Los_Angeles"))
+            )
+        ),
+    )
+    collector = Mock()
+    collector.get_all_channel_videos.return_value = [
+        {"published_at": "2026-08-08T01:00:00Z"},
+        {"published_at": "2026-08-08T10:00:00Z"},
+    ]
+    system = Mock(collector=collector)
+
+    def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
+        assert (days, depth) == (30, "standard")
+        collector.get_all_channel_videos()
+        (channel / "data").mkdir(parents=True)
+        return {"success": True}
+
+    system.run_data_collection.side_effect = run_data_collection
+    factory = Mock(return_value=system)
+
+    collect_channel_analytics(channel, factory)
+
+    factory.assert_called_once_with()
+    assert collector.get_all_channel_videos.call_count == 2
+    payload = json.loads((channel / "data" / "dashboard_publications.json").read_text(encoding="utf-8"))
+    assert payload == {
+        "schema_version": 1,
+        "fetched_at": "2026-08-08T12:00:00+00:00",
+        "timezone": "America/Los_Angeles",
+        "days": {"2026-08-07": 1, "2026-08-08": 1},
+    }
 
 
 def test_collect_channel_restores_environment_and_raises_automation_error(
@@ -115,5 +181,7 @@ def test_collect_channel_restores_environment_and_raises_automation_error(
         collect_channel_analytics(tmp_path / "selected", Mock(return_value=system))
 
     assert reset.call_count == 2
+    system.collector.get_all_channel_videos.assert_not_called()
+    assert not (tmp_path / "selected" / "data" / "dashboard_publications.json").exists()
     assert os.environ["CHANNEL_DIR"] == "/previous/channel"
     assert os.environ["CHANNEL"] == "previous-slug"


### PR DESCRIPTION
## Summary
- `collect_channel_analytics` で同じ `AnalyticsSystem` / collector を再利用
- cached `get_all_channel_videos()` を timezone 日別 payload へ変換
- `data/dashboard_publications.json` へ保存し、Analytics 失敗時は保存しない

## Verification
- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_refresh.py tests/infrastructure/analytics/test_dashboard_publications.py -q`
- `nix develop --command uv run pytest tests/test_changelog.py -q`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `git diff --check`

Closes #3357