### PR TITLE
feat(dashboard): 符号付き秒数を時間表記へ整形する (#3352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: workflow timing を含む dashboard API schema を v2 とし、overview は timing を除いた channel 集約、detail は `ready` / `unavailable` / `in_progress` / `error` の timing を返す境界を HTTP 200 契約として固定した（#3338）。
 - `feat(dashboard)`: channel ごとの workflow timing 欠損・不正 shape を専用の `status=error` へ隔離し、同じ channel の Analytics summary / videos と他 channel の timing を維持する fail-soft 境界を追加した（#3339）。
 - `feat(dashboard)`: workflow timing の公開 status を `ready` / `unavailable` / `in_progress` に正規化し、基準未設定・旧 schema・未計測・実行中を 0 と区別できるようにした（#3334）。
+- `feat(dashboard)`: API の符号付き秒数を、正負を保った比較しやすい `HH:MM:SS` 表記へ整形する formatter を追加した（#3352）。
 - `feat(dashboard)`: registry の各 channel から検証済み手作業基準と workflow history を読み、collection timing summary を channel detail API へ配線した（#3325）。
 - `feat(dashboard)`: workflow timing summary を channel detail read model に追加し、overview からは除外して一覧 API の軽量契約を維持した（#3324）。
 - `feat(dashboard)`: active planning と latest live collection を最大 2 件選び、`wf-auto-state.py` の正規集計から step 状態と 6 種の時間指標を構築する read adapter を追加した（#3323）。

--- a/dashboard/src/lib/dashboard-formatters.test.ts
+++ b/dashboard/src/lib/dashboard-formatters.test.ts
@@ -4,6 +4,7 @@ import {
   formatCollectedAt,
   formatDateRange,
   formatInteger,
+  formatSignedDuration,
   formatSignedInteger,
 } from "./dashboard-formatters"
 
@@ -14,6 +15,24 @@ describe("dashboard formatters", () => {
     expect(formatSignedInteger(12)).toBe("+12")
     expect(formatSignedInteger(-4)).toBe("-4")
   })
+
+  it("formats signed seconds as a comparable hours timestamp", () => {
+    expect(formatSignedDuration(3661)).toBe("+01:01:01")
+    expect(formatSignedDuration(0)).toBe("00:00:00")
+    expect(formatSignedDuration(-61)).toBe("-00:01:01")
+  })
+
+  it("rounds fractional durations to the nearest second", () => {
+    expect(formatSignedDuration(59.5)).toBe("+00:01:00")
+    expect(formatSignedDuration(-0.4)).toBe("00:00:00")
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects a non-finite duration: %s",
+    (value) => {
+      expect(() => formatSignedDuration(value)).toThrow(RangeError)
+    }
+  )
 
   it("shows collection fallbacks without hiding an invalid timestamp", () => {
     expect(formatCollectedAt(null)).toBe("未収集")

--- a/dashboard/src/lib/dashboard-formatters.ts
+++ b/dashboard/src/lib/dashboard-formatters.ts
@@ -12,6 +12,22 @@ export function formatSignedInteger(value: number): string {
   return value > 0 ? `+${formatInteger(value)}` : formatInteger(value)
 }
 
+export function formatSignedDuration(value: number): string {
+  if (!Number.isFinite(value)) {
+    throw new RangeError("duration must be finite")
+  }
+
+  const totalSeconds = Math.round(Math.abs(value))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  const sign = totalSeconds === 0 ? "" : value > 0 ? "+" : "-"
+
+  return `${sign}${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`
+}
+
 export function formatCollectedAt(value: string | null): string {
   if (!value) return "未収集"
   const date = new Date(value)


### PR DESCRIPTION
## Summary

- 符号付き秒数を比較可能な HH:MM:SS 表記へ整形
- 正数・ゼロ・負数・丸め・非有限値の境界を単体テストで固定
- CHANGELOG の Unreleased に利用者向け変更を記録

## Verification

- pnpm -C dashboard lint
- pnpm -C dashboard typecheck
- pnpm -C dashboard test
- pnpm -C dashboard exec prettier --check src/lib/dashboard-formatters.ts src/lib/dashboard-formatters.test.ts
- git diff --check

Closes #3352
Parent: #2967
Depends on: #2965
