### PR TITLE
feat(dashboard): 公開履歴 cache の鮮度を判定する (#3374)

### DIFF
--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -7,19 +7,46 @@ import os
 import tempfile
 from collections import Counter
 from collections.abc import Iterable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from typing import cast
 from zoneinfo import ZoneInfo
 
 SCHEMA_VERSION = 1
 ROLLING_WINDOW_DAYS = 365
+CACHE_MAX_AGE = timedelta(hours=24)
 
 
-def _parse_published_at(value: str) -> datetime:
-    published_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if published_at.tzinfo is None:
-        raise ValueError("published_at は timezone-aware ISO 8601 でなければなりません")
-    return published_at.astimezone(UTC)
+def _parse_timestamp(value: str, *, field_name: str) -> datetime:
+    timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if timestamp.tzinfo is None:
+        raise ValueError(f"{field_name} は timezone-aware ISO 8601 でなければなりません")
+    return timestamp.astimezone(UTC)
+
+
+def _validate_payload(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        return None
+    schema_version = value.get("schema_version")
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+        return None
+
+    fetched_at = value.get("fetched_at")
+    timezone = value.get("timezone")
+    days = value.get("days")
+    if not isinstance(fetched_at, str) or not isinstance(timezone, str) or not isinstance(days, dict):
+        return None
+
+    try:
+        _parse_timestamp(fetched_at, field_name="fetched_at")
+        ZoneInfo(timezone)
+        for local_day, count in days.items():
+            if not isinstance(local_day, str) or type(count) is not int or count < 0:
+                return None
+            date.fromisoformat(local_day)
+    except (ValueError, KeyError):
+        return None
+    return cast(dict[str, object], value)
 
 
 def build_dashboard_publications(
@@ -38,7 +65,7 @@ def build_dashboard_publications(
     counts: Counter[str] = Counter()
 
     for value in published_at_values:
-        published_at = _parse_published_at(value)
+        published_at = _parse_timestamp(value, field_name="published_at")
         if cutoff <= published_at <= fetched_at_utc:
             local_day = published_at.astimezone(local_timezone).date().isoformat()
             counts[local_day] += 1
@@ -49,6 +76,27 @@ def build_dashboard_publications(
         "timezone": timezone,
         "days": dict(sorted(counts.items())),
     }
+
+
+def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> dict[str, object] | None:
+    """有効かつ取得から24時間以内の公開履歴 cache を返す。"""
+    if now.tzinfo is None:
+        raise ValueError("now は timezone-aware datetime でなければなりません")
+
+    try:
+        value: object = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    payload = _validate_payload(value)
+    if payload is None:
+        return None
+
+    fetched_at = _parse_timestamp(cast(str, payload["fetched_at"]), field_name="fetched_at")
+    age = now.astimezone(UTC) - fetched_at
+    if age < timedelta(0) or age > CACHE_MAX_AGE:
+        return None
+    return payload
 
 
 def save_dashboard_publications(destination: Path, payload: dict[str, object]) -> None:

--- a/tests/infrastructure/analytics/test_dashboard_publications.py
+++ b/tests/infrastructure/analytics/test_dashboard_publications.py
@@ -8,8 +8,18 @@ import pytest
 from youtube_automation.infrastructure.analytics import dashboard_publications
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
+    load_fresh_dashboard_publications,
     save_dashboard_publications,
 )
+
+
+def _publication_payload(fetched_at: str) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "fetched_at": fetched_at,
+        "timezone": "UTC",
+        "days": {"2026-08-08": 2},
+    }
 
 
 def test_build_dashboard_publications_groups_by_local_calendar_day() -> None:
@@ -109,3 +119,69 @@ def test_save_dashboard_publications_preserves_destination_and_cleans_temp_on_re
     assert destination.read_bytes() == original
     assert observed_temporary is not None
     assert not observed_temporary.exists()
+
+
+def test_load_fresh_dashboard_publications_should_return_payload_when_cache_is_24_hours_old(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    payload = _publication_payload("2026-08-07T12:00:00+00:00")
+    source.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = load_fresh_dashboard_publications(
+        source,
+        now=datetime(2026, 8, 8, 12, tzinfo=UTC),
+    )
+
+    assert result == payload
+
+
+def test_load_fresh_dashboard_publications_should_return_none_when_cache_is_older_than_24_hours(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    source.write_text(
+        json.dumps(_publication_payload("2026-08-07T11:59:59+00:00")),
+        encoding="utf-8",
+    )
+
+    result = load_fresh_dashboard_publications(
+        source,
+        now=datetime(2026, 8, 8, 12, tzinfo=UTC),
+    )
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "{not-json",
+        json.dumps({"schema_version": 2, "fetched_at": "2026-08-08T11:00:00+00:00"}),
+        json.dumps(_publication_payload("not-a-timestamp")),
+    ],
+)
+def test_load_fresh_dashboard_publications_should_return_none_when_cache_is_corrupt(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    source.write_text(content, encoding="utf-8")
+
+    result = load_fresh_dashboard_publications(
+        source,
+        now=datetime(2026, 8, 8, 12, tzinfo=UTC),
+    )
+
+    assert result is None
+
+
+def test_load_fresh_dashboard_publications_should_return_none_when_cache_is_missing(
+    tmp_path: Path,
+) -> None:
+    result = load_fresh_dashboard_publications(
+        tmp_path / "dashboard_publications.json",
+        now=datetime(2026, 8, 8, 12, tzinfo=UTC),
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

- `dashboard_publications.json` の schema と `fetched_at` を検証する cache loader を追加
- 24 時間以内だけ cache hit とし、stale・破損・欠損は miss として扱う
- hit / stale / corrupt / missing の unit test を追加

## Verification

- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_publications.py -q`

Closes #3374
