### PR TITLE
feat(dashboard): fresh な公開履歴 cache の再取得を省略する (#3375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `feat(server-source)`: ローカル配信元 selector の候補名を構造化されたチャンネル名と helper 名から組み立て、接続先 URL や `(default)`、hostname、port を表示しないようにした（#3232〜#3235）。
+- `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
@@ -13,6 +13,7 @@ from typing import Protocol
 from youtube_automation.core.errors import AutomationError
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
+    load_fresh_dashboard_publications,
     save_dashboard_publications,
 )
 
@@ -62,6 +63,11 @@ def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[
         if not result.get("success"):
             raise AutomationError(str(result.get("error", "Analytics refresh failed")))
 
+        publication_path = channel / "data" / "dashboard_publications.json"
+        fetched_at = datetime.now(UTC)
+        if load_fresh_dashboard_publications(publication_path, now=fetched_at) is not None:
+            return
+
         published_at_values: list[str] = []
         for video in system.collector.get_all_channel_videos():
             published_at = video.get("published_at")
@@ -73,9 +79,9 @@ def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[
         payload = build_dashboard_publications(
             published_at_values,
             timezone=timezone,
-            fetched_at=datetime.now(UTC),
+            fetched_at=fetched_at,
         )
-        save_dashboard_publications(channel / "data" / "dashboard_publications.json", payload)
+        save_dashboard_publications(publication_path, payload)
 
 
 def refresh_dashboard_channels(

--- a/tests/infrastructure/analytics/test_dashboard_refresh.py
+++ b/tests/infrastructure/analytics/test_dashboard_refresh.py
@@ -104,12 +104,32 @@ def test_collect_channel_restores_environment_and_configuration_after_success(
     assert os.environ.get("CHANNEL") == initial_slug
 
 
-def test_collect_channel_reuses_system_collector_and_saves_publications_with_config_timezone(
+@pytest.mark.parametrize(
+    "cache_contents",
+    [
+        None,
+        json.dumps(
+            {
+                "schema_version": 1,
+                "fetched_at": "2026-08-07T11:59:59+00:00",
+                "timezone": "UTC",
+                "days": {},
+            }
+        ),
+        "{not-json",
+    ],
+    ids=["missing", "stale", "corrupt"],
+)
+def test_collect_channel_should_refresh_publication_cache_when_cache_is_unusable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    cache_contents: str | None,
 ) -> None:
     channel = tmp_path / "selected"
     fixed_now = datetime(2026, 8, 8, 12, tzinfo=UTC)
+    if cache_contents is not None:
+        (channel / "data").mkdir(parents=True, exist_ok=True)
+        (channel / "data" / "dashboard_publications.json").write_text(cache_contents, encoding="utf-8")
 
     class FixedDateTime(datetime):
         @classmethod
@@ -136,7 +156,7 @@ def test_collect_channel_reuses_system_collector_and_saves_publications_with_con
     def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
         assert (days, depth) == (30, "standard")
         collector.get_all_channel_videos()
-        (channel / "data").mkdir(parents=True)
+        (channel / "data").mkdir(parents=True, exist_ok=True)
         return {"success": True}
 
     system.run_data_collection.side_effect = run_data_collection
@@ -153,6 +173,53 @@ def test_collect_channel_reuses_system_collector_and_saves_publications_with_con
         "timezone": "America/Los_Angeles",
         "days": {"2026-08-07": 1, "2026-08-08": 1},
     }
+
+
+def test_collect_channel_should_reuse_publication_cache_when_cache_is_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    channel = tmp_path / "selected"
+    fixed_now = datetime(2026, 8, 8, 12, tzinfo=UTC)
+    publication_path = channel / "data" / "dashboard_publications.json"
+    cached_payload = {
+        "schema_version": 1,
+        "fetched_at": "2026-08-08T12:00:00+00:00",
+        "timezone": "Asia/Tokyo",
+        "days": {"2026-08-08": 2},
+    }
+    publication_path.parent.mkdir(parents=True)
+    publication_path.write_text(json.dumps(cached_payload), encoding="utf-8")
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(dashboard_refresh, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="UTC")))
+        ),
+    )
+    collector = Mock()
+    collector.get_all_channel_videos.return_value = []
+    system = Mock(collector=collector)
+
+    def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
+        assert (days, depth) == (30, "standard")
+        collector.get_all_channel_videos()
+        return {"success": True}
+
+    system.run_data_collection.side_effect = run_data_collection
+
+    collect_channel_analytics(channel, Mock(return_value=system))
+
+    system.run_data_collection.assert_called_once_with(days=30, depth="standard")
+    collector.get_all_channel_videos.assert_called_once_with()
+    assert json.loads(publication_path.read_text(encoding="utf-8")) == cached_payload
 
 
 def test_collect_channel_restores_environment_and_raises_automation_error(


### PR DESCRIPTION
## Summary

- dashboard 更新入口で公開履歴 cache の鮮度を独立に確認
- fresh cache では公開履歴用 API 再取得と保存を省略
- missing / stale / corrupt では従来どおり再取得し、関連経路を unit test で固定

## Verification

- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_publications.py tests/infrastructure/analytics/test_dashboard_refresh.py -q`（20 passed）
- `nix develop --command uv run ruff check`
- `nix develop --command uv run ruff format --check`
- any-usage gate

Closes #3375
