### PR TITLE
feat(dashboard): workflow stepの5状態表示契約を追加する (#3378)

### DIFF
--- a/dashboard/src/lib/dashboard-types.ts
+++ b/dashboard/src/lib/dashboard-types.ts
@@ -31,7 +31,7 @@ export type WorkflowTimingMetrics = {
 
 export type WorkflowTimingStep = WorkflowTimingMetrics & {
   action: string
-  status: "success" | "blocked" | "failed"
+  status: "in_progress" | "success" | "failed" | "blocked" | "not_run"
 }
 
 export type WorkflowTimingCollection = {

--- a/dashboard/src/lib/workflow-step-status.test.ts
+++ b/dashboard/src/lib/workflow-step-status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { workflowStepStatusPresentation } from "./workflow-step-status"
+
+describe("workflow step status presentation", () => {
+  it.each([
+    ["in_progress", "進行中", "default"],
+    ["success", "成功", "secondary"],
+    ["failed", "失敗", "destructive"],
+    ["blocked", "ブロック中", "warning"],
+    ["not_run", "未実行", "outline"],
+  ] as const)(
+    "maps %s to its Japanese label and badge variant",
+    (status, label, variant) => {
+      expect(workflowStepStatusPresentation(status)).toEqual({ label, variant })
+    }
+  )
+})

--- a/dashboard/src/lib/workflow-step-status.ts
+++ b/dashboard/src/lib/workflow-step-status.ts
@@ -1,0 +1,30 @@
+import type { WorkflowTimingStep } from "./dashboard-types"
+
+export type WorkflowStepStatusVariant =
+  | "default"
+  | "secondary"
+  | "destructive"
+  | "warning"
+  | "outline"
+
+export type WorkflowStepStatusPresentation = {
+  label: string
+  variant: WorkflowStepStatusVariant
+}
+
+const WORKFLOW_STEP_STATUS_PRESENTATIONS: Record<
+  WorkflowTimingStep["status"],
+  WorkflowStepStatusPresentation
+> = {
+  in_progress: { label: "進行中", variant: "default" },
+  success: { label: "成功", variant: "secondary" },
+  failed: { label: "失敗", variant: "destructive" },
+  blocked: { label: "ブロック中", variant: "warning" },
+  not_run: { label: "未実行", variant: "outline" },
+}
+
+export function workflowStepStatusPresentation(
+  status: WorkflowTimingStep["status"]
+): WorkflowStepStatusPresentation {
+  return WORKFLOW_STEP_STATUS_PRESENTATIONS[status]
+}


### PR DESCRIPTION
## Summary
- workflow step の5状態を型で固定
- 各状態を日本語ラベルと badge variant へ変換
- 5状態すべての unit test を追加

## Verification
- `nix develop .#extensions --command pnpm -C dashboard lint`
- `nix develop .#extensions --command pnpm -C dashboard typecheck`
- `nix develop .#extensions --command pnpm -C dashboard test`
- `nix develop .#extensions --command pnpm -C dashboard build`
- `git diff --exit-code -- src/youtube_automation/dashboard_dist`

Closes #3378