### PR TITLE
feat(dashboard): 公開履歴 cache に更新失敗状態を付与する (#3383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `feat(server-source)`: ローカル配信元 selector の候補名を構造化されたチャンネル名と helper 名から組み立て、接続先 URL や `(default)`、hostname、port を表示しないようにした（#3232〜#3235）。
+- `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。
 - `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -36,9 +36,19 @@ def _validate_payload(value: object) -> dict[str, object] | None:
     days = value.get("days")
     if not isinstance(fetched_at, str) or not isinstance(timezone, str) or not isinstance(days, dict):
         return None
+    error = value.get("error")
+    if "error" in value:
+        if not isinstance(error, dict):
+            return None
+        if not isinstance(error.get("code"), str) or not isinstance(error.get("message"), str):
+            return None
+        if not isinstance(error.get("attempted_at"), str):
+            return None
 
     try:
         _parse_timestamp(fetched_at, field_name="fetched_at")
+        if "error" in value:
+            _parse_timestamp(cast(str, error["attempted_at"]), field_name="error.attempted_at")
         ZoneInfo(timezone)
         for local_day, count in days.items():
             if not isinstance(local_day, str) or type(count) is not int or count < 0:
@@ -78,17 +88,21 @@ def build_dashboard_publications(
     }
 
 
+def load_dashboard_publications(source: Path) -> dict[str, object] | None:
+    """鮮度に関係なく有効な公開履歴 cache を返す。"""
+    try:
+        value: object = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return _validate_payload(value)
+
+
 def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> dict[str, object] | None:
     """有効かつ取得から24時間以内の公開履歴 cache を返す。"""
     if now.tzinfo is None:
         raise ValueError("now は timezone-aware datetime でなければなりません")
 
-    try:
-        value: object = json.loads(source.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    payload = _validate_payload(value)
+    payload = load_dashboard_publications(source)
     if payload is None:
         return None
 
@@ -97,6 +111,29 @@ def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> dict[st
     if age < timedelta(0) or age > CACHE_MAX_AGE:
         return None
     return payload
+
+
+def with_dashboard_publication_error(
+    payload: dict[str, object],
+    *,
+    code: str,
+    message: str,
+    attempted_at: datetime,
+) -> dict[str, object]:
+    """公開履歴の前回値を維持して構造化された更新失敗を付与する。"""
+    if _validate_payload(payload) is None:
+        raise ValueError("有効な公開履歴 payload が必要です")
+    if attempted_at.tzinfo is None:
+        raise ValueError("attempted_at は timezone-aware datetime でなければなりません")
+
+    return {
+        **payload,
+        "error": {
+            "code": code,
+            "message": message,
+            "attempted_at": attempted_at.astimezone(UTC).isoformat(),
+        },
+    }
 
 
 def save_dashboard_publications(destination: Path, payload: dict[str, object]) -> None:

--- a/tests/infrastructure/analytics/test_dashboard_publications.py
+++ b/tests/infrastructure/analytics/test_dashboard_publications.py
@@ -8,8 +8,10 @@ import pytest
 from youtube_automation.infrastructure.analytics import dashboard_publications
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
+    load_dashboard_publications,
     load_fresh_dashboard_publications,
     save_dashboard_publications,
+    with_dashboard_publication_error,
 )
 
 
@@ -185,3 +187,70 @@ def test_load_fresh_dashboard_publications_should_return_none_when_cache_is_miss
     )
 
     assert result is None
+
+
+def test_load_dashboard_publications_should_return_valid_payload_when_cache_is_stale(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    payload = _publication_payload("2025-08-08T12:00:00+00:00")
+    source.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = load_dashboard_publications(source)
+
+    assert result == payload
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        None,
+        {},
+        {
+            "code": "youtube_api_error",
+            "message": "uploads playlist request failed",
+            "attempted_at": "not-a-timestamp",
+        },
+    ],
+)
+def test_load_dashboard_publications_should_return_none_when_error_is_malformed(
+    tmp_path: Path,
+    error: object,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    source.write_text(
+        json.dumps({**_publication_payload("2026-08-08T12:00:00+00:00"), "error": error}),
+        encoding="utf-8",
+    )
+
+    result = load_dashboard_publications(source)
+
+    assert result is None
+
+
+def test_with_dashboard_publication_error_should_preserve_cached_data_when_refresh_fails(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "dashboard_publications.json"
+    payload = _publication_payload("2025-08-08T12:00:00+00:00")
+
+    failed_payload = with_dashboard_publication_error(
+        payload,
+        code="youtube_api_error",
+        message="uploads playlist request failed",
+        attempted_at=datetime.fromisoformat("2026-08-08T21:00:00+09:00"),
+    )
+    source.write_text(json.dumps(failed_payload), encoding="utf-8")
+
+    assert load_dashboard_publications(source) == {
+        "schema_version": 1,
+        "fetched_at": "2025-08-08T12:00:00+00:00",
+        "timezone": "UTC",
+        "days": {"2026-08-08": 2},
+        "error": {
+            "code": "youtube_api_error",
+            "message": "uploads playlist request failed",
+            "attempted_at": "2026-08-08T12:00:00+00:00",
+        },
+    }
+    assert payload == _publication_payload("2025-08-08T12:00:00+00:00")


### PR DESCRIPTION
## Summary

- freshness と独立して schema-valid な公開履歴 cache を読み出す
- 前回のデータと取得日時を維持した構造化更新失敗状態を生成する

## Verification

- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_publications.py -q`
- ruff check / format / any usage gate / git diff --check

Closes #3383