### PR TITLE
feat(dashboard): 公開履歴更新失敗を channel 単位で隔離する (#3384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `feat(server-source)`: ローカル配信元 selector の候補名を構造化されたチャンネル名と helper 名から組み立て、接続先 URL や `(default)`、hostname、port を表示しないようにした（#3232〜#3235）。
+- `feat(dashboard)`: stale な有効公開履歴 cache の再取得が想定内エラーで失敗した場合、前回データを維持した構造化 error payload を保存して channel 更新を継続するようにした。有効 cache が無い場合は従来の refresh error 経路へ伝播する（#3384）。
 - `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。
 - `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
@@ -13,11 +13,14 @@ from typing import Protocol
 from youtube_automation.core.errors import AutomationError
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
+    load_dashboard_publications,
     load_fresh_dashboard_publications,
     save_dashboard_publications,
+    with_dashboard_publication_error,
 )
 
 logger = logging.getLogger(__name__)
+_PUBLICATION_REFRESH_ERROR_CODE = "publication_refresh_failed"
 
 
 class _AnalyticsCollector(Protocol):
@@ -68,19 +71,30 @@ def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[
         if load_fresh_dashboard_publications(publication_path, now=fetched_at) is not None:
             return
 
-        published_at_values: list[str] = []
-        for video in system.collector.get_all_channel_videos():
-            published_at = video.get("published_at")
-            if not isinstance(published_at, str):
-                raise ValueError("動画の published_at は ISO 8601 文字列でなければなりません")
-            published_at_values.append(published_at)
-
         timezone = load_config().youtube.api.default_publish_timezone
-        payload = build_dashboard_publications(
-            published_at_values,
-            timezone=timezone,
-            fetched_at=fetched_at,
-        )
+        try:
+            published_at_values: list[str] = []
+            for video in system.collector.get_all_channel_videos():
+                published_at = video.get("published_at")
+                if not isinstance(published_at, str):
+                    raise ValueError("動画の published_at は ISO 8601 文字列でなければなりません")
+                published_at_values.append(published_at)
+
+            payload = build_dashboard_publications(
+                published_at_values,
+                timezone=timezone,
+                fetched_at=fetched_at,
+            )
+        except (AutomationError, OSError, RuntimeError, ValueError) as exc:
+            cached_payload = load_dashboard_publications(publication_path)
+            if cached_payload is None:
+                raise
+            payload = with_dashboard_publication_error(
+                cached_payload,
+                code=_PUBLICATION_REFRESH_ERROR_CODE,
+                message=str(exc),
+                attempted_at=fetched_at,
+            )
         save_dashboard_publications(publication_path, payload)
 
 

--- a/tests/infrastructure/analytics/test_dashboard_refresh.py
+++ b/tests/infrastructure/analytics/test_dashboard_refresh.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 from youtube_automation import configuration
-from youtube_automation.core.errors import AutomationError, ConfigError
+from youtube_automation.core.errors import AutomationError, ConfigError, YouTubeAPIError
 from youtube_automation.infrastructure.analytics import dashboard_refresh
 from youtube_automation.infrastructure.analytics.dashboard_refresh import (
     collect_channel_analytics,
@@ -220,6 +220,96 @@ def test_collect_channel_should_reuse_publication_cache_when_cache_is_fresh(
     system.run_data_collection.assert_called_once_with(days=30, depth="standard")
     collector.get_all_channel_videos.assert_called_once_with()
     assert json.loads(publication_path.read_text(encoding="utf-8")) == cached_payload
+
+
+def test_refresh_channels_should_keep_stale_cache_and_continue_when_publication_refresh_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    broken = tmp_path / "broken"
+    last = tmp_path / "last"
+    fixed_now = datetime(2026, 8, 8, 12, tzinfo=UTC)
+    publication_path = broken / "data" / "dashboard_publications.json"
+    cached_payload = {
+        "schema_version": 1,
+        "fetched_at": "2026-08-07T11:59:59+00:00",
+        "timezone": "Asia/Tokyo",
+        "days": {"2026-08-07": 2},
+    }
+    publication_path.parent.mkdir(parents=True)
+    publication_path.write_text(json.dumps(cached_payload), encoding="utf-8")
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(dashboard_refresh, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="UTC")))
+        ),
+    )
+    collector = Mock()
+    collector.get_all_channel_videos.side_effect = [[], YouTubeAPIError("uploads playlist request failed")]
+    system = Mock(collector=collector)
+
+    def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
+        assert (days, depth) == (30, "standard")
+        collector.get_all_channel_videos()
+        return {"success": True}
+
+    system.run_data_collection.side_effect = run_data_collection
+    attempted: list[Path] = []
+
+    def collect(channel: Path) -> None:
+        attempted.append(channel)
+        if channel == broken:
+            collect_channel_analytics(channel, Mock(return_value=system))
+
+    errors = refresh_dashboard_channels([broken, last], collect_channel=collect)
+
+    assert attempted == [broken, last]
+    assert errors == {}
+    assert json.loads(publication_path.read_text(encoding="utf-8")) == {
+        **cached_payload,
+        "error": {
+            "code": "publication_refresh_failed",
+            "message": "uploads playlist request failed",
+            "attempted_at": "2026-08-08T12:00:00+00:00",
+        },
+    }
+
+
+def test_collect_channel_should_raise_publication_error_when_valid_cache_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    channel = tmp_path / "selected"
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="UTC")))
+        ),
+    )
+    collector = Mock()
+    collector.get_all_channel_videos.side_effect = [[], YouTubeAPIError("uploads playlist request failed")]
+    system = Mock(collector=collector)
+
+    def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
+        assert (days, depth) == (30, "standard")
+        collector.get_all_channel_videos()
+        return {"success": True}
+
+    system.run_data_collection.side_effect = run_data_collection
+
+    with pytest.raises(YouTubeAPIError, match="uploads playlist request failed"):
+        collect_channel_analytics(channel, Mock(return_value=system))
+
+    assert not (channel / "data" / "dashboard_publications.json").exists()
 
 
 def test_collect_channel_restores_environment_and_raises_automation_error(


### PR DESCRIPTION
## Summary

- stale な公開履歴 cache の再取得失敗時に前回 payload と取得日時を維持する
- 構造化された更新失敗状態を保存し、後続 channel の更新を継続する
- 有効な前回 cache がない失敗は既存の channel refresh error 経路へ伝播する

## Verification

- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_refresh.py tests/infrastructure/analytics/test_dashboard_publications.py -q`
- ruff check / format / any usage gate / git diff --check

Closes #3384