### PR TITLE
feat(dashboard): timing状態の表示契約を一元化する (#3389)

### DIFF
--- a/dashboard/src/lib/dashboard-types.ts
+++ b/dashboard/src/lib/dashboard-types.ts
@@ -41,6 +41,27 @@ export type WorkflowTimingCollection = {
   totals: WorkflowTimingMetrics
 }
 
-export type WorkflowTiming = {
-  collections: WorkflowTimingCollection[]
+export type WorkflowTimingError = {
+  code: string
+  message: string
 }
+
+export type WorkflowTiming =
+  | {
+      status: "ready"
+      collections: WorkflowTimingCollection[]
+    }
+  | {
+      status: "unavailable"
+      reason: string
+      collections: []
+    }
+  | {
+      status: "in_progress"
+      collections: WorkflowTimingCollection[]
+    }
+  | {
+      status: "error"
+      collections: []
+      error: WorkflowTimingError
+    }

--- a/dashboard/src/lib/workflow-timing-presentation.test.ts
+++ b/dashboard/src/lib/workflow-timing-presentation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import type { WorkflowTiming } from "./dashboard-types"
+import { workflowTimingPresentation } from "./workflow-timing-presentation"
+
+describe("workflow timing presentation", () => {
+  it.each([
+    ["manual_baseline_unconfigured", "unconfigured", "未設定"],
+    ["attempt_timing_unavailable", "unmeasured", "—"],
+    ["history_schema_v1", "unavailable", "利用不可"],
+  ] as const)(
+    "maps unavailable reason %s without collapsing distinct states",
+    (reason, kind, label) => {
+      const workflowTiming: WorkflowTiming = {
+        status: "unavailable",
+        reason,
+        collections: [],
+      }
+
+      const presentation = workflowTimingPresentation(workflowTiming)
+
+      expect(presentation).toEqual({ kind, label, reason })
+    }
+  )
+
+  it("keeps ready zero metrics as numbers for duration formatting", () => {
+    const workflowTiming: WorkflowTiming = {
+      status: "ready",
+      collections: [
+        {
+          collection_id: "active",
+          stage: "planning",
+          steps: [],
+          totals: {
+            manual_baseline_seconds: 0,
+            ai_seconds: 0,
+            human_seconds: 0,
+            work_seconds: 0,
+            ai_inclusive_saved_seconds: 0,
+            human_freed_seconds: 0,
+          },
+        },
+      ],
+    }
+
+    const presentation = workflowTimingPresentation(workflowTiming)
+
+    expect(presentation.kind).toBe("ready")
+    if (presentation.kind !== "ready") {
+      throw new Error("ready presentation expected")
+    }
+    expect(presentation.label).toBe("計測済み")
+    expect(presentation.collections[0]?.totals.work_seconds).toBe(0)
+    expect(typeof presentation.collections[0]?.totals.work_seconds).toBe(
+      "number"
+    )
+  })
+
+  it("keeps in-progress distinct while preserving measured collections", () => {
+    const collections = [
+      {
+        collection_id: "active",
+        stage: "planning" as const,
+        steps: [],
+        totals: {
+          manual_baseline_seconds: 60,
+          ai_seconds: 10,
+          human_seconds: 20,
+          work_seconds: 30,
+          ai_inclusive_saved_seconds: 30,
+          human_freed_seconds: 40,
+        },
+      },
+    ]
+
+    const workflowTiming: WorkflowTiming = {
+      status: "in_progress",
+      collections,
+    }
+
+    const presentation = workflowTimingPresentation(workflowTiming)
+
+    expect(presentation).toEqual({
+      kind: "in_progress",
+      label: "進行中",
+      collections,
+    })
+  })
+
+  it("keeps the structured error for a local error presentation", () => {
+    const error = {
+      code: "workflow_timing_invalid",
+      message: "workflow timing の status が不正です",
+    }
+
+    const workflowTiming: WorkflowTiming = {
+      status: "error",
+      collections: [],
+      error,
+    }
+
+    const presentation = workflowTimingPresentation(workflowTiming)
+
+    expect(presentation).toEqual({ kind: "error", label: "エラー", error })
+  })
+})

--- a/dashboard/src/lib/workflow-timing-presentation.ts
+++ b/dashboard/src/lib/workflow-timing-presentation.ts
@@ -1,0 +1,84 @@
+import type {
+  WorkflowTiming,
+  WorkflowTimingCollection,
+  WorkflowTimingError,
+} from "./dashboard-types"
+
+type ReadyPresentation = {
+  kind: "ready"
+  label: "計測済み"
+  collections: WorkflowTimingCollection[]
+}
+
+type InProgressPresentation = {
+  kind: "in_progress"
+  label: "進行中"
+  collections: WorkflowTimingCollection[]
+}
+
+type UnavailablePresentation =
+  | {
+      kind: "unconfigured"
+      label: "未設定"
+      reason: string
+    }
+  | {
+      kind: "unmeasured"
+      label: "—"
+      reason: string
+    }
+  | {
+      kind: "unavailable"
+      label: "利用不可"
+      reason: string
+    }
+
+type ErrorPresentation = {
+  kind: "error"
+  label: "エラー"
+  error: WorkflowTimingError
+}
+
+export type WorkflowTimingPresentation =
+  | ReadyPresentation
+  | InProgressPresentation
+  | UnavailablePresentation
+  | ErrorPresentation
+
+function unavailablePresentation(reason: string): UnavailablePresentation {
+  switch (reason) {
+    case "manual_baseline_unconfigured":
+      return { kind: "unconfigured", label: "未設定", reason }
+    case "attempt_timing_unavailable":
+      return { kind: "unmeasured", label: "—", reason }
+    default:
+      return { kind: "unavailable", label: "利用不可", reason }
+  }
+}
+
+export function workflowTimingPresentation(
+  workflowTiming: WorkflowTiming
+): WorkflowTimingPresentation {
+  switch (workflowTiming.status) {
+    case "ready":
+      return {
+        kind: "ready",
+        label: "計測済み",
+        collections: workflowTiming.collections,
+      }
+    case "unavailable":
+      return unavailablePresentation(workflowTiming.reason)
+    case "in_progress":
+      return {
+        kind: "in_progress",
+        label: "進行中",
+        collections: workflowTiming.collections,
+      }
+    case "error":
+      return {
+        kind: "error",
+        label: "エラー",
+        error: workflowTiming.error,
+      }
+  }
+}


### PR DESCRIPTION
## Summary

- workflow timing の API status/reason/error を discriminated union で表現
- 未設定・未計測・未知 unavailable・進行中・error の日本語表示契約を一元化
- ready/in-progress の collections と 0 秒の number 値を保持

## Verification

- focused unit tests (6)
- dashboard typecheck / lint / prettier
- git diff --check

Closes #3389