### PR TITLE
feat(dashboard): 公開履歴の強制更新 option を追加する (#3397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `feat(server-source)`: ローカル配信元 selector の候補名を構造化されたチャンネル名と helper 名から組み立て、接続先 URL や `(default)`、hostname、port を表示しないようにした（#3232〜#3235）。
+- `feat(dashboard)`: 公開履歴 refresh に明示的な強制更新 option を追加し、指定時は fresh cache があっても同じ `AnalyticsSystem` の collector から再取得して保存できるようにした。既定の fresh cache 再利用と更新失敗時の前回 cache 維持は変更しない（#3397）。
 - `feat(dashboard)`: stale な有効公開履歴 cache の再取得が想定内エラーで失敗した場合、前回データを維持した構造化 error payload を保存して channel 更新を継続するようにした。有効 cache が無い場合は従来の refresh error 経路へ伝播する（#3384）。
 - `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。
 - `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
@@ -56,7 +56,12 @@ def _channel_context(channel: Path) -> Iterator[None]:
         reset_config()
 
 
-def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[[], _AnalyticsSystem]) -> None:
+def collect_channel_analytics(
+    channel: Path,
+    analytics_system_factory: Callable[[], _AnalyticsSystem],
+    *,
+    force_publication_refresh: bool = False,
+) -> None:
     """同じ AnalyticsSystem で standard snapshot と公開履歴を保存する。"""
     from youtube_automation.configuration import load_config
 
@@ -68,7 +73,10 @@ def collect_channel_analytics(channel: Path, analytics_system_factory: Callable[
 
         publication_path = channel / "data" / "dashboard_publications.json"
         fetched_at = datetime.now(UTC)
-        if load_fresh_dashboard_publications(publication_path, now=fetched_at) is not None:
+        if (
+            not force_publication_refresh
+            and load_fresh_dashboard_publications(publication_path, now=fetched_at) is not None
+        ):
             return
 
         timezone = load_config().youtube.api.default_publish_timezone

--- a/tests/infrastructure/analytics/test_dashboard_refresh.py
+++ b/tests/infrastructure/analytics/test_dashboard_refresh.py
@@ -222,6 +222,64 @@ def test_collect_channel_should_reuse_publication_cache_when_cache_is_fresh(
     assert json.loads(publication_path.read_text(encoding="utf-8")) == cached_payload
 
 
+def test_collect_channel_should_refresh_fresh_publication_cache_when_forced(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    channel = tmp_path / "selected"
+    fixed_now = datetime(2026, 8, 8, 12, tzinfo=UTC)
+    publication_path = channel / "data" / "dashboard_publications.json"
+    publication_path.parent.mkdir(parents=True)
+    publication_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "fetched_at": "2026-08-08T11:00:00+00:00",
+                "timezone": "UTC",
+                "days": {"2026-08-07": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(dashboard_refresh, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        configuration,
+        "load_config",
+        Mock(
+            return_value=SimpleNamespace(youtube=SimpleNamespace(api=SimpleNamespace(default_publish_timezone="UTC")))
+        ),
+    )
+    collector = Mock()
+    collector.get_all_channel_videos.side_effect = [
+        [],
+        [{"published_at": "2026-08-08T01:00:00Z"}],
+    ]
+    system = Mock(collector=collector)
+
+    def run_data_collection(*, days: int, depth: str) -> dict[str, bool]:
+        assert (days, depth) == (30, "standard")
+        collector.get_all_channel_videos()
+        return {"success": True}
+
+    system.run_data_collection.side_effect = run_data_collection
+
+    collect_channel_analytics(channel, Mock(return_value=system), force_publication_refresh=True)
+
+    assert collector.get_all_channel_videos.call_count == 2
+    assert json.loads(publication_path.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "fetched_at": "2026-08-08T12:00:00+00:00",
+        "timezone": "UTC",
+        "days": {"2026-08-08": 1},
+    }
+
+
 def test_refresh_channels_should_keep_stale_cache_and_continue_when_publication_refresh_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- 公開履歴収集へ既定無効の強制更新 option を追加
- fresh cache の既定再利用と、強制時の再取得・保存を固定
- 既存の fail-soft fallback を同じ経路で維持

## Verification

- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_refresh.py -q` (12 passed)
- `nix develop --command uv run ruff check src/youtube_automation/infrastructure/analytics/dashboard_refresh.py tests/infrastructure/analytics/test_dashboard_refresh.py`
- `nix develop --command uv run ruff format --check src/youtube_automation/infrastructure/analytics/dashboard_refresh.py tests/infrastructure/analytics/test_dashboard_refresh.py`
- `git diff --check HEAD^ HEAD`

Closes #3397