### PR TITLE
feat(dashboard): 公開履歴の強制更新 flag を追加する (#3398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 安全モードの entry 完了待ちで `status=error` の clip を観測した場合、duration outlier として自動再生成せず attempt 全体を playlist 候補から除外し、生成失敗の `ENTRY_FAILED` と失敗分再実行導線へ渡すようにした（#3205）。
 - `fix(suno-helper)`: active feed poll で要求 clip が欠落した場合、認証済みの単体 clip API を順次照会して `status=error` を含む終端状態を観測できるようにした。feed で確認済みの ID は重複照会せず、個別失敗は残りの照会を妨げず、401 後は token の再捕捉まで自前通信を停止する（#3203）。
 - `feat(server-source)`: ローカル配信元 selector の候補名を構造化されたチャンネル名と helper 名から組み立て、接続先 URL や `(default)`、hostname、port を表示しないようにした（#3232〜#3235）。
+- `feat(dashboard)`: `yt-dashboard --refresh-publications` を追加し、通常の Analytics 更新とともに全登録チャンネルの公開履歴 cache を強制更新できるようにした。`--skip-refresh` との同時指定では offline 契約を優先し、公開履歴を含む API 更新を行わない（#3398）。
 - `feat(dashboard)`: 公開履歴 refresh に明示的な強制更新 option を追加し、指定時は fresh cache があっても同じ `AnalyticsSystem` の collector から再取得して保存できるようにした。既定の fresh cache 再利用と更新失敗時の前回 cache 維持は変更しない（#3397）。
 - `feat(dashboard)`: stale な有効公開履歴 cache の再取得が想定内エラーで失敗した場合、前回データを維持した構造化 error payload を保存して channel 更新を継続するようにした。有効 cache が無い場合は従来の refresh error 経路へ伝播する（#3384）。
 - `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -140,6 +140,11 @@ def _parser() -> argparse.ArgumentParser:
         help="API更新を行わず既存snapshotを表示します（offline test用）",
     )
     parser.add_argument(
+        "--refresh-publications",
+        action="store_true",
+        help="fresh cache があっても公開履歴を再取得します",
+    )
+    parser.add_argument(
         "--registry",
         type=Path,
         default=DEFAULT_CHANNEL_REGISTRY,
@@ -160,7 +165,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.skip_refresh
         else refresh_dashboard_channels(
             channels,
-            collect_channel=lambda channel: collect_channel_analytics(channel, AnalyticsSystem),
+            collect_channel=lambda channel: collect_channel_analytics(
+                channel,
+                AnalyticsSystem,
+                force_publication_refresh=args.refresh_publications,
+            ),
         )
     )
     server = create_server(

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -149,6 +149,54 @@ def test_cli_opens_loopback_url_after_server_starts(monkeypatch: pytest.MonkeyPa
     assert opened == ["http://127.0.0.1:4321/"]
 
 
+def test_cli_refresh_publications_forces_every_channel(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    channels = [tmp_path / "one", tmp_path / "two"]
+    collected: list[tuple[Path, bool]] = []
+
+    class FakeServer:
+        server_port = 4321
+
+        def serve_forever(self) -> None:
+            raise KeyboardInterrupt
+
+        def server_close(self) -> None:
+            return None
+
+    monkeypatch.setattr("youtube_automation.commands.analytics.dashboard.load_channel_registry", lambda _path: channels)
+
+    def refresh_channels(paths: list[Path], *, collect_channel) -> dict[Path, str]:
+        for path in paths:
+            collect_channel(path)
+        return {}
+
+    def collect_analytics(
+        channel: Path,
+        _factory,
+        *,
+        force_publication_refresh: bool,
+    ) -> None:
+        collected.append((channel, force_publication_refresh))
+
+    monkeypatch.setattr(
+        "youtube_automation.commands.analytics.dashboard.refresh_dashboard_channels",
+        refresh_channels,
+    )
+    monkeypatch.setattr(
+        "youtube_automation.commands.analytics.dashboard.collect_channel_analytics",
+        collect_analytics,
+    )
+    monkeypatch.setattr(
+        "youtube_automation.commands.analytics.dashboard.create_server",
+        lambda **_kwargs: FakeServer(),
+    )
+
+    assert main(["--refresh-publications", "--registry", str(tmp_path / "channels.json")]) == 0
+    assert collected == [(channels[0], True), (channels[1], True)]
+
+
 def test_cli_skip_refresh_starts_from_existing_snapshots_without_api_calls(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
@@ -177,7 +225,9 @@ def test_cli_skip_refresh_starts_from_existing_snapshots_without_api_calls(
     )
     monkeypatch.setattr(
         "youtube_automation.commands.analytics.dashboard.collect_channel_analytics",
-        lambda _channel, _factory: api_calls.append("publication collector"),
+        lambda _channel, _factory, *, force_publication_refresh: api_calls.append(
+            f"publication collector force={force_publication_refresh}"
+        ),
     )
     monkeypatch.setattr(
         "youtube_automation.commands.analytics.dashboard.create_server",
@@ -188,7 +238,17 @@ def test_cli_skip_refresh_starts_from_existing_snapshots_without_api_calls(
         ),
     )
 
-    assert main(["--skip-refresh", "--registry", str(tmp_path / "channels.json")]) == 0
+    assert (
+        main(
+            [
+                "--skip-refresh",
+                "--refresh-publications",
+                "--registry",
+                str(tmp_path / "channels.json"),
+            ]
+        )
+        == 0
+    )
     assert api_calls == []
 
 


### PR DESCRIPTION
## Summary

- `yt-dashboard` に `--refresh-publications` を追加
- 全 channel の公開履歴収集へ強制更新 option を貫通
- `--skip-refresh` 同時指定時は offline 契約を優先

## Verification

- `nix develop --command uv run pytest tests/commands/analytics/test_dashboard_server.py -q` (13 passed)
- `nix develop --command uv run ruff check src/youtube_automation/commands/analytics/dashboard.py tests/commands/analytics/test_dashboard_server.py`
- `nix develop --command uv run ruff format --check src/youtube_automation/commands/analytics/dashboard.py tests/commands/analytics/test_dashboard_server.py`
- `git diff --check HEAD^ HEAD`

Closes #3398