### PR TITLE
feat(dashboard): 公開履歴 read model を集約する (#3404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 ### Added
 
+- `feat(dashboard)`: 各登録チャンネルの保存済み公開履歴 cache を canonical loader で読み、全チャンネルの日別合計、チャンネル別内訳、最終更新日時、構造化更新エラー、missing / invalid 状態を読み取り専用 dashboard read model に集約した（#3404）。
 - `feat(dashboard)`: standard Analytics 収集に使った同一 `AnalyticsSystem` / collector の動画一覧 cache を再利用し、チャンネル設定の公開 timezone で集計した `data/dashboard_publications.json` を収集成功時だけ保存するようにした（#3357）。
 - `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import cast
 
 from youtube_automation.core.errors import DashboardChannelNotFoundError
+from youtube_automation.infrastructure.analytics.dashboard_publications import load_dashboard_publications
 
 SCHEMA_VERSION = 1
 
@@ -198,6 +199,50 @@ def _build_channel(channel: Path, *, allow_snapshot_fallback: bool = False) -> d
     )
 
 
+def _publication_channel(channel: Path, item: dict[str, object]) -> dict[str, object]:
+    publication_path = channel / "data" / "dashboard_publications.json"
+    payload = load_dashboard_publications(publication_path)
+    if payload is None:
+        return {
+            "id": item["id"],
+            "name": item["name"],
+            "status": "invalid" if publication_path.exists() else "missing",
+            "fetched_at": None,
+            "timezone": None,
+            "days": {},
+            "error": None,
+        }
+
+    error = payload.get("error")
+    return {
+        "id": item["id"],
+        "name": item["name"],
+        "status": "refresh_failed" if error is not None else "ready",
+        "fetched_at": payload["fetched_at"],
+        "timezone": payload["timezone"],
+        "days": payload["days"],
+        "error": error,
+    }
+
+
+def _publication_read_model(
+    channel_paths: list[Path],
+    channels: list[dict[str, object]],
+) -> dict[str, object]:
+    totals: dict[str, int] = {}
+    publication_channels: list[dict[str, object]] = []
+    for channel, item in zip(channel_paths, channels, strict=True):
+        publication = _publication_channel(channel, item)
+        publication_channels.append(publication)
+        days = cast(dict[str, int], publication["days"])
+        for local_day, count in days.items():
+            totals[local_day] = totals.get(local_day, 0) + count
+    return {
+        "days": dict(sorted(totals.items())),
+        "channels": publication_channels,
+    }
+
+
 def build_dashboard_read_model(
     channel_paths: list[Path],
     *,
@@ -216,6 +261,7 @@ def build_dashboard_read_model(
     return {
         "schema_version": SCHEMA_VERSION,
         "channels": channels,
+        "publications": _publication_read_model(channel_paths, channels),
     }
 
 

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -56,6 +56,106 @@ def _snapshot(*, collected_at: str, views: int, video_views: int) -> dict:
     }
 
 
+def _write_publications(
+    channel: Path,
+    *,
+    fetched_at: str,
+    timezone: str,
+    days: dict[str, int],
+    error: dict[str, str] | None = None,
+) -> None:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "fetched_at": fetched_at,
+        "timezone": timezone,
+        "days": days,
+    }
+    if error is not None:
+        payload["error"] = error
+    (channel / "data" / "dashboard_publications.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_read_model_aggregates_publication_days_and_channel_cache_state(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    for channel, name in ((first, "First"), (second, "Second")):
+        _write_channel(
+            channel,
+            name=name,
+            snapshots={
+                "analytics_data_20260720.json": _snapshot(
+                    collected_at="2026-07-20T00:00:00+00:00", views=900, video_views=700
+                )
+            },
+        )
+    _write_publications(
+        first,
+        fetched_at="2026-08-08T12:00:00+00:00",
+        timezone="Asia/Tokyo",
+        days={"2026-08-07": 2, "2026-08-08": 3},
+    )
+    publication_error = {
+        "code": "publication_refresh_failed",
+        "message": "quota exceeded",
+        "attempted_at": "2026-08-08T13:00:00+00:00",
+    }
+    _write_publications(
+        second,
+        fetched_at="2026-08-07T12:00:00+00:00",
+        timezone="UTC",
+        days={"2026-08-08": 4},
+        error=publication_error,
+    )
+
+    model = build_dashboard_read_model([first, second])
+
+    assert model["publications"] == {
+        "days": {"2026-08-07": 2, "2026-08-08": 7},
+        "channels": [
+            {
+                "id": model["channels"][0]["id"],
+                "name": "First",
+                "status": "ready",
+                "fetched_at": "2026-08-08T12:00:00+00:00",
+                "timezone": "Asia/Tokyo",
+                "days": {"2026-08-07": 2, "2026-08-08": 3},
+                "error": None,
+            },
+            {
+                "id": model["channels"][1]["id"],
+                "name": "Second",
+                "status": "refresh_failed",
+                "fetched_at": "2026-08-07T12:00:00+00:00",
+                "timezone": "UTC",
+                "days": {"2026-08-08": 4},
+                "error": publication_error,
+            },
+        ],
+    }
+
+
+def test_read_model_isolates_missing_and_invalid_publication_caches(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    invalid = tmp_path / "invalid"
+    ready = tmp_path / "ready"
+    for channel, name in ((missing, "Missing"), (invalid, "Invalid"), (ready, "Ready")):
+        _write_channel(channel, name=name, snapshots={})
+    (invalid / "data" / "dashboard_publications.json").write_text("not-json", encoding="utf-8")
+    _write_publications(
+        ready,
+        fetched_at="2026-08-08T12:00:00+00:00",
+        timezone="UTC",
+        days={"2026-08-08": 5},
+    )
+
+    publications = build_dashboard_read_model([missing, invalid, ready])["publications"]
+
+    assert publications["days"] == {"2026-08-08": 5}
+    assert [channel["status"] for channel in publications["channels"]] == ["missing", "invalid", "ready"]
+    assert publications["channels"][0]["fetched_at"] is None
+    assert publications["channels"][1]["days"] == {}
+
+
 def test_read_model_uses_latest_snapshot_and_normalizes_metrics(tmp_path: Path) -> None:
     channel = tmp_path / "channel-one"
     _write_channel(


### PR DESCRIPTION
## Summary
- 保存済み公開履歴 cache を canonical loader で読み取る
- 全チャンネルの日別合計とチャンネル別内訳を集約する
- 最終更新日時・構造化更新エラー・欠損/破損 cache を read model contract に含める

## Verification
- `nix develop --command uv run pytest tests/infrastructure/analytics/test_dashboard_read_model.py -q` (14 passed)
- `nix develop --command uv run ruff check src/youtube_automation/infrastructure/analytics/dashboard_read_model.py tests/infrastructure/analytics/test_dashboard_read_model.py`
- `nix develop --command uv run ruff format --check src/youtube_automation/infrastructure/analytics/dashboard_read_model.py tests/infrastructure/analytics/test_dashboard_read_model.py`
- `git diff --check HEAD^`

Closes #3404