### PR TITLE
feat(dashboard): 公開履歴 JSON API を追加する (#3405)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -37,6 +37,10 @@ uv run yt-dashboard --skip-refresh
 
 既定 URL は `http://127.0.0.1:8765/` です。別 port は `--port 9000`、別 registry は `--registry /absolute/path/channels.json` で指定できます。server は外部 interface へ bind せず、loopback だけで UI と JSON API を同一 origin 配信します。
 
+## JSON API
+
+`GET /api/publications` は、起動時に保存済み cache から構築した公開履歴 read model を読み取り専用で返します。同じ response の `days` に全チャンネルの日別合計、`channels` に登録順のチャンネル別内訳を含みます。各内訳は `status`、`fetched_at`、`timezone`、`days`、構造化された `error` を持ち、endpoint で公開日を再推測したり外部 API を呼んだりはしません。
+
 ## 表示内容
 
 - チャンネルごとの最新 snapshot、収集日時、動画数、主要指標

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -65,6 +65,9 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
         if path == "/api/channels":
             self._json(HTTPStatus.OK, self.server.api.overview())
             return True
+        if path == "/api/publications":
+            self._json(HTTPStatus.OK, cast(dict[str, object], self.server.api.model["publications"]))
+            return True
         prefix = "/api/channels/"
         if path.startswith(prefix):
             channel_id = unquote(path.removeprefix(prefix))

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -28,6 +28,22 @@ def _write_channel(root: Path) -> Path:
         ),
         encoding="utf-8",
     )
+    (channel / "data" / "dashboard_publications.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "fetched_at": "2026-07-20T13:00:00+00:00",
+                "timezone": "Asia/Tokyo",
+                "days": {"2026-07-20": 2},
+                "error": {
+                    "code": "publication_refresh_failed",
+                    "message": "quota exceeded",
+                    "attempted_at": "2026-07-20T14:00:00+00:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     return channel
 
 
@@ -67,6 +83,24 @@ def test_server_exposes_overview_and_channel_detail(dashboard_server: str):
     detail_status, detail = _json(f"{dashboard_server}/api/channels/{channel['id']}")
     assert detail_status == 200
     assert detail["videos"][0]["title"] == "Midnight"
+
+
+def test_server_exposes_saved_publication_read_model(dashboard_server: str) -> None:
+    status, payload = _json(f"{dashboard_server}/api/publications")
+
+    assert status == 200
+    assert payload["days"] == {"2026-07-20": 2}
+    assert len(payload["channels"]) == 1
+    channel = payload["channels"][0]
+    assert channel["name"] == "Night Drive"
+    assert channel["status"] == "refresh_failed"
+    assert channel["fetched_at"] == "2026-07-20T13:00:00+00:00"
+    assert channel["days"] == {"2026-07-20": 2}
+    assert channel["error"] == {
+        "code": "publication_refresh_failed",
+        "message": "quota exceeded",
+        "attempted_at": "2026-07-20T14:00:00+00:00",
+    }
 
 
 @pytest.mark.parametrize("path", ["/api/unknown", "/api/channels/not-registered"])


### PR DESCRIPTION
## Summary
- `GET /api/publications` で公開履歴 read model を読み取り専用 JSON として返す
- 日別合計・チャンネル別内訳・最終更新日時・更新エラーを同じ response に含める
- endpoint contract と unknown API path の JSON 404 維持を文書・testで固定する

## Verification
- `nix develop --command uv run pytest tests/commands/analytics/test_dashboard_server.py tests/repo/test_dashboard_packaging.py -q` (14 passed, 1 skipped: candidate wheel unavailable)
- `nix develop --command uv run ruff check src/youtube_automation/commands/analytics/dashboard.py tests/commands/analytics/test_dashboard_server.py`
- `nix develop --command uv run ruff format --check src/youtube_automation/commands/analytics/dashboard.py tests/commands/analytics/test_dashboard_server.py`
- `git diff --check HEAD^`

Closes #3405