### PR TITLE
feat(dashboard): 公開活動 heatmap を追加する (#3408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(packaging)`: リポジトリを責務別 layer へ再配置し、canonical owner への production import・receipt・active documentation を同期した。`youtube_automation.utils` と `infrastructure.legacy_utils` は下流向け compatibility façade として installed wheel でも維持し、削除・統合候補は `docs/architecture/reorganization-followups.md` に記録した。
 ### Added
 
+- `feat(dashboard)`: 日別公開本数を当日終端の過去365日について週×曜日へ配置し、月・曜日ラベルと0本+4強度の semantic-token 凡例を表示する独立 heatmap component を追加した（#3408）。
 - `feat(dashboard)`: 各登録チャンネルの保存済み公開履歴 cache を canonical loader で読み、全チャンネルの日別合計、チャンネル別内訳、最終更新日時、構造化更新エラー、missing / invalid 状態を読み取り専用 dashboard read model に集約した（#3404）。
 - `feat(dashboard)`: standard Analytics 収集に使った同一 `AnalyticsSystem` / collector の動画一覧 cache を再利用し、チャンネル設定の公開 timezone で集計した `data/dashboard_publications.json` を収集成功時だけ保存するようにした（#3357）。
 - `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。

--- a/dashboard/src/features/publication-activity/publication-heatmap.test.tsx
+++ b/dashboard/src/features/publication-activity/publication-heatmap.test.tsx
@@ -1,0 +1,126 @@
+import "@testing-library/jest-dom/vitest"
+
+import { render, screen, within } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { PublicationHeatmap } from "./publication-heatmap"
+
+describe("PublicationHeatmap", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("places the 365 days ending today into week and weekday positions", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-08T12:00:00Z"))
+
+    render(<PublicationHeatmap days={{}} />)
+
+    const grid = screen.getByRole("grid", { name: "日別公開本数" })
+    const rows = within(grid).getAllByRole("row")
+    const cells = within(grid).getAllByRole("gridcell")
+    expect(rows).toHaveLength(7)
+    expect(cells).toHaveLength(365)
+    expect(
+      screen.getByRole("gridcell", { name: "2025-08-09: 0本" })
+    ).toHaveAttribute("data-week", "0")
+    expect(
+      screen.getByRole("gridcell", { name: "2025-08-09: 0本" })
+    ).toHaveAttribute("data-weekday", "6")
+    expect(
+      screen.getByRole("gridcell", { name: "2026-08-08: 0本" })
+    ).toHaveAttribute("data-week", "52")
+    expect(
+      screen.getByRole("gridcell", { name: "2026-08-08: 0本" })
+    ).toHaveAttribute("data-weekday", "6")
+
+    for (const row of rows) {
+      expect(row.parentElement).toBe(grid)
+      expect(within(row).getAllByRole("gridcell").length).toBeGreaterThan(0)
+      for (const cell of within(row).getAllByRole("gridcell")) {
+        expect(cell.parentElement).toBe(row)
+      }
+    }
+  })
+
+  it("shows four non-zero intensity levels and the five-level legend", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-08T12:00:00Z"))
+
+    render(
+      <PublicationHeatmap
+        days={{
+          "2026-08-04": 1,
+          "2026-08-05": 2,
+          "2026-08-06": 3,
+          "2026-08-07": 4,
+        }}
+      />
+    )
+
+    for (const [date, intensity] of [
+      ["2026-08-04", "1"],
+      ["2026-08-05", "2"],
+      ["2026-08-06", "3"],
+      ["2026-08-07", "4"],
+    ]) {
+      expect(
+        screen.getByRole("gridcell", { name: new RegExp(date) })
+      ).toHaveAttribute("data-intensity", intensity)
+    }
+    const legend = screen.getByRole("list", { name: "公開本数の凡例" })
+    expect(
+      within(legend)
+        .getAllByRole("listitem")
+        .map((item) => item.getAttribute("aria-label"))
+    ).toEqual(["0本", "1本", "2本", "3本", "4本以上"])
+  })
+
+  it("aligns ordered month labels to their week columns", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-08T12:00:00Z"))
+
+    render(<PublicationHeatmap days={{}} />)
+
+    const months = screen.getByRole("list", { name: "月" })
+    const labels = within(months).getAllByRole("listitem")
+    expect(labels.slice(0, 4).map((item) => item.textContent)).toEqual([
+      "8月",
+      "9月",
+      "10月",
+      "11月",
+    ])
+    expect(labels.slice(0, 4).map((item) => item.dataset.week)).toEqual([
+      "0",
+      "4",
+      "8",
+      "12",
+    ])
+    expect(labels.slice(0, 4).map((item) => item.style.gridColumn)).toEqual([
+      "1",
+      "5",
+      "9",
+      "13",
+    ])
+
+    const weekdays = screen.getByRole("list", { name: "曜日" })
+    expect(
+      within(weekdays)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent)
+    ).toEqual(["日", "月", "火", "水", "木", "金", "土"])
+  })
+
+  it("contains the fixed-width week grid in a horizontal scroll boundary", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-08T12:00:00Z"))
+
+    render(<PublicationHeatmap days={{}} />)
+
+    const boundary = screen.getByTestId("publication-heatmap-scroll")
+    expect(boundary).toHaveStyle({ maxWidth: "100%", overflowX: "auto" })
+    expect(screen.getByRole("grid", { name: "日別公開本数" })).toHaveStyle({
+      gridTemplateColumns: "repeat(53, 11px)",
+    })
+  })
+})

--- a/dashboard/src/features/publication-activity/publication-heatmap.tsx
+++ b/dashboard/src/features/publication-activity/publication-heatmap.tsx
@@ -1,0 +1,211 @@
+export type PublicationActivityError = {
+  code: string
+  message: string
+  attempted_at: string
+}
+
+export type PublicationActivityChannel = {
+  id: string
+  name: string
+  status: string
+  fetched_at: string | null
+  timezone: string | null
+  days: Record<string, number>
+  error: PublicationActivityError | null
+}
+
+export type PublicationActivityResponse = {
+  days: Record<string, number>
+  channels: PublicationActivityChannel[]
+}
+
+const DAY_COUNT = 365
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"]
+const INTENSITY_COLORS = [
+  "var(--muted)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+]
+
+function dateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function intensity(count: number): number {
+  if (count <= 0) return 0
+  if (count >= 4) return 4
+  if (count >= 3) return 3
+  if (count >= 2) return 2
+  return 1
+}
+
+function activityDays(days: Record<string, number>) {
+  const now = new Date()
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const start = new Date(end)
+  start.setDate(start.getDate() - (DAY_COUNT - 1))
+
+  return Array.from({ length: DAY_COUNT }, (_, index) => {
+    const date = new Date(start)
+    date.setDate(start.getDate() + index)
+    const key = dateKey(date)
+    return {
+      key,
+      count: days[key] ?? 0,
+      weekday: date.getDay(),
+      week: Math.floor((index + start.getDay()) / 7),
+      month: date.getMonth() + 1,
+      showMonth: index === 0 || date.getDate() === 1,
+    }
+  })
+}
+
+export function PublicationHeatmap({
+  days,
+}: {
+  days: PublicationActivityResponse["days"]
+}) {
+  const activity = activityDays(days)
+  const weekCount = activity.at(-1)!.week + 1
+  const weekColumns = `repeat(${weekCount}, 11px)`
+
+  return (
+    <section aria-label="過去365日の公開活動">
+      <div
+        data-testid="publication-heatmap-scroll"
+        style={{
+          maxWidth: "100%",
+          overflowX: "auto",
+        }}
+      >
+        <div
+          style={{
+            display: "grid",
+            columnGap: 8,
+            gridTemplateColumns: "max-content max-content",
+            width: "max-content",
+          }}
+        >
+          <span aria-hidden="true" />
+          <ol
+            aria-label="月"
+            style={{
+              display: "grid",
+              gap: 3,
+              gridTemplateColumns: weekColumns,
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+            }}
+          >
+            {activity
+              .filter((day) => day.showMonth)
+              .map((day) => (
+                <li
+                  data-week={day.week}
+                  key={day.key}
+                  style={{ gridColumn: day.week + 1, gridRow: 1 }}
+                >
+                  {day.month}月
+                </li>
+              ))}
+          </ol>
+          <ol
+            aria-label="曜日"
+            style={{
+              display: "grid",
+              gap: 3,
+              gridTemplateRows: "repeat(7, 11px)",
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+            }}
+          >
+            {WEEKDAYS.map((weekday) => (
+              <li key={weekday}>{weekday}</li>
+            ))}
+          </ol>
+          <div
+            aria-label="日別公開本数"
+            role="grid"
+            style={{
+              display: "grid",
+              gap: 3,
+              gridTemplateColumns: weekColumns,
+              gridTemplateRows: "repeat(7, 11px)",
+            }}
+          >
+            {WEEKDAYS.map((_, weekday) => (
+              <div
+                key={weekday}
+                role="row"
+                style={{
+                  display: "grid",
+                  gap: 3,
+                  gridColumn: "1 / -1",
+                  gridRow: weekday + 1,
+                  gridTemplateColumns: weekColumns,
+                }}
+              >
+                {activity
+                  .filter((day) => day.weekday === weekday)
+                  .map((day) => {
+                    const level = intensity(day.count)
+                    return (
+                      <span
+                        aria-label={`${day.key}: ${day.count}本`}
+                        data-count={day.count}
+                        data-date={day.key}
+                        data-intensity={level}
+                        data-week={day.week}
+                        data-weekday={day.weekday}
+                        key={day.key}
+                        role="gridcell"
+                        style={{
+                          backgroundColor: INTENSITY_COLORS[level],
+                          borderRadius: 2,
+                          gridColumn: day.week + 1,
+                          height: 11,
+                          width: 11,
+                        }}
+                      />
+                    )
+                  })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <ol
+        aria-label="公開本数の凡例"
+        style={{
+          display: "flex",
+          gap: 4,
+          listStyle: "none",
+          margin: 0,
+          padding: 0,
+        }}
+      >
+        {INTENSITY_COLORS.map((color, level) => (
+          <li aria-label={level === 4 ? "4本以上" : `${level}本`} key={color}>
+            <span
+              aria-hidden="true"
+              style={{
+                backgroundColor: color,
+                borderRadius: 2,
+                display: "block",
+                height: 11,
+                width: 11,
+              }}
+            />
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- 当日終端の365日を週列×曜日行へ配置する公開活動 component を追加
- 月ラベルを実week列へ配置し、排他的な0/1/2/3/4+凡例を semantic token だけで表示
- 狭幅の水平overflow境界と `grid > row > gridcell` のARIA構造を固定

## Verification
- target Vitest: 4 passed
- dashboard lint / typecheck / build: passed
- clean build後 `git diff --exit-code -- src/youtube_automation/dashboard_dist`: passed
- format / raw color scan / `git diff --check`: passed

Closes #3408