### PR TITLE
fix(suno-helper): 無人起動前のCAPTCHA解消を待つ (#2979)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。
 
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
+- `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -2788,7 +2788,13 @@ export default defineContentScript({
 
       try {
         const blocker = detectUnattendedPreflightBlocker();
-        if (blocker) {
+        if (blocker?.reason === "captcha-required") {
+          await waitForCaptchaClear({
+            isAborted: () => false,
+            pollIntervalMs: POLL_INTERVAL_MS,
+            timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
+          });
+        } else if (blocker) {
           await writeUnattendedRunState(
             createUnattendedManualState({
               request,

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -9,7 +9,11 @@ import {
   INFLIGHT_STALL_TIMEOUT_MS,
   PHASE,
 } from "../../shared/constants";
-import type { WaitForCaptchaClearOptions } from "../../shared/dom";
+import {
+  CAPTCHA_WAIT_TIMEOUT_MS,
+  POLL_INTERVAL_MS,
+  type WaitForCaptchaClearOptions,
+} from "../../shared/dom";
 import {
   findPlaylistUrlsByName,
   fillPlaylistNameAndCreate,
@@ -840,6 +844,32 @@ describe("content unattended launch", () => {
     );
     expect(harness.sendMessage).not.toHaveBeenCalledWith(
       "run",
+      expect.anything()
+    );
+  });
+
+  it("waits for a visible Turnstile before unattended preflight continues", async () => {
+    setUnattendedLaunchHash();
+    const turnstile = document.createElement("iframe");
+    turnstile.src = "https://challenges.cloudflare.com/turnstile/v0/widget";
+    markBbox(turnstile, 300, 65);
+    document.body.appendChild(turnstile);
+    harness.waitForCaptchaClear.mockImplementation(
+      () => new Promise<void>(() => undefined)
+    );
+
+    await loadContentScript();
+
+    await vi.waitFor(() =>
+      expect(harness.waitForCaptchaClear).toHaveBeenCalledWith({
+        isAborted: expect.any(Function),
+        pollIntervalMs: POLL_INTERVAL_MS,
+        timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
+      })
+    );
+    expect(harness.writeUnattendedRunState).not.toHaveBeenCalled();
+    expect(harness.sendMessage).not.toHaveBeenCalledWith(
+      "fetchCollections",
       expect.anything()
     );
   });


### PR DESCRIPTION
## 概要

無人起動の preflight で可視 Turnstile を検知した際、manual-intervention へ即停止せず、run 中と同じ `waitForCaptchaClear` 経路で解消を待つようにします。

Closes #2979

## 変更内容

- `captcha-required` だけを既存の CAPTCHA wait helper へ合流
- poll interval と timeout は run 中と同じ定数を使用
- login / cost confirmation の既存 manual-intervention 分岐を維持
- preflight の待機回帰テストと CHANGELOG を追加

## 検証

- focused Vitest: 1 passed / 79 skipped
- unattended launch regression: 5 passed / 75 skipped
- `nix develop .#extensions --command pnpm -C extensions/suno-helper check`
- `git diff --check`

## Stack

- Base dependency: #3117 (`issue-2978-unattended-captcha-timeout`)
- この stack の実装 PR は本 PR 1 件のみです。

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] #3293 関連 subtree は未変更