### PR TITLE
fix(suno-helper): CAPTCHA解消後の無人実行を再開する (#2980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。
 
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
+- `fix(suno-helper)`: 無人実行中の CAPTCHA challenge を致命的な UI blocker とせず、serial / queue 共通の解消待機後に未投入 entry を重複なく再開するようにした（#2980）。
+
 - `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -820,10 +820,17 @@ export default defineContentScript({
       });
     }
 
-    function assertUnattendedUiIsSafe(): void {
+    function assertUnattendedUiIsSafe(options?: {
+      allowCaptcha: boolean;
+    }): void {
       if (!activeUnattended) return;
       const blocker = detectUnattendedPreflightBlocker();
-      if (blocker) throw new FatalRunError(blocker.message);
+      if (
+        blocker &&
+        !(blocker.reason === "captcha-required" && options?.allowCaptcha)
+      ) {
+        throw new FatalRunError(blocker.message);
+      }
     }
 
     async function verifyUnattendedCompletion(
@@ -913,7 +920,7 @@ export default defineContentScript({
       index: number,
       total: number
     ): Promise<void> {
-      assertUnattendedUiIsSafe();
+      assertUnattendedUiIsSafe({ allowCaptcha: true });
       // captcha が出ていても即停止しない。多くは passive 検証で数秒以内に自動 verify されて閉じるため、
       // waiting-captcha phase で解消を待って自動続行する。解消されない場合のみ throw（fail-loud は維持）。
       await waitForCaptchaClear({

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -938,7 +938,7 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
   });
 
   it.each(["serial", "queue"] as const)(
-    "Given %s mode の適応型ペーシング中に challenge が出現 When 解消する Then waiting-captcha 中は Create せず同じ entry を1回だけ投入する",
+    "Given unattended-active %s mode の適応型ペーシング中に challenge が出現 When 解消する Then waiting-captcha 中は Create せず同じ entry を1回だけ投入する",
     async (runMode) => {
       vi.useFakeTimers();
       makeViewButton("Newest ▼");
@@ -946,33 +946,69 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       makeTextarea(null);
       makeTextarea("lyrics-textarea");
       const clickGenerate = vi.fn();
+      clickGenerate.mockImplementation(() => {
+        if (clickGenerate.mock.calls.length === 5) {
+          harness.handlers.get("stop")?.({ data: undefined });
+        }
+      });
       makeGenerateButtonWithClickObserver(clickGenerate);
       addCompletedRemixCard();
       await loadContentScript();
-      let challengeVisible = false;
+      harness.sendMessage.mockImplementation((type: string) =>
+        type === "releaseUnattendedLease"
+          ? Promise.resolve({ released: true })
+          : undefined
+      );
+      let challenge: HTMLIFrameElement | null = null;
 
       harness.onAbortableSleep = async (ms) => {
         if (ms === ADAPTIVE_BURST_COOLDOWN_MS) {
-          challengeVisible = true;
+          challenge = document.createElement("iframe");
+          challenge.src =
+            "https://challenges.cloudflare.com/turnstile/v0/widget";
+          markBbox(challenge, 300, 65);
+          document.body.appendChild(challenge);
         }
       };
       harness.waitForCaptchaClear.mockImplementation(async (options) => {
-        if (!challengeVisible) {
+        if (!challenge) {
           return;
         }
         options.onWaitStart?.();
         await new Promise<void>((resolve) => {
           setTimeout(() => {
-            challengeVisible = false;
+            challenge?.remove();
+            challenge = null;
             resolve();
           }, 1000);
         });
       });
 
       const entries = makePromptEntries(5);
+      const payload = makeRunPayload(entries);
+      harness.submittedClipIds = [];
       expect(
         getRunHandler()({
-          data: { ...makeRunPayload(entries), runMode },
+          data: {
+            ...payload,
+            runMode,
+            unattended: {
+              request: {
+                version: 1,
+                requestId: `scheduled-captcha-${runMode}`,
+                baseUrl: "http://localhost:8787",
+                collectionId: "20260601-clm-preflight-collection",
+                downloadFormat: "wav",
+                limits: {
+                  maxEntries: entries.length,
+                  maxConcurrentGenerations: 2,
+                  maxRetries: 1,
+                },
+              },
+              deferredIndices: [],
+              leaseToken: "lease-token",
+            },
+          },
         })
       ).toEqual({ ok: true });
 
@@ -994,6 +1030,85 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
       expect(clickGenerate).toHaveBeenCalledTimes(5);
       await vi.advanceTimersByTimeAsync(0);
       expect(clickGenerate).toHaveBeenCalledTimes(5);
+      expect(harness.writeUnattendedRunState).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: "manual-intervention" })
+      );
+      expect(progressPayloads()).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ phase: PHASE.ERROR }),
+        ])
+      );
+    }
+  );
+
+  it.each(["serial", "queue"] as const)(
+    "Given unattended-active %s mode の最後の Create 後に challenge が出現 When playlist 境界へ進む Then CAPTCHA manual state で停止し UI を変更しない",
+    async (runMode) => {
+      makeViewButton("Newest ▼");
+      makeViewButton("Grid");
+      makeTextarea(null);
+      makeTextarea("lyrics-textarea");
+      const clickGenerate = vi.fn(() => {
+        appendSubmittedClipIdsForRequest("captcha-boundary-clip");
+        const challenge = document.createElement("iframe");
+        challenge.src = "https://challenges.cloudflare.com/turnstile/v0/widget";
+        markBbox(challenge, 300, 65);
+        document.body.appendChild(challenge);
+      });
+      makeGenerateButtonWithClickObserver(clickGenerate);
+      addCompletedRemixCard();
+      await loadContentScript();
+      harness.sendMessage.mockImplementation((type: string) =>
+        type === "releaseUnattendedLease"
+          ? Promise.resolve({ released: true })
+          : undefined
+      );
+
+      const entries = makePromptEntries(1);
+      const payload = makeRunPayload(entries);
+      harness.submittedClipIds = [];
+      expect(
+        getRunHandler()({
+          data: {
+            ...payload,
+            runMode,
+            unattended: {
+              request: {
+                version: 1,
+                requestId: `scheduled-playlist-captcha-${runMode}`,
+                baseUrl: "http://localhost:8787",
+                collectionId: "20260601-clm-preflight-collection",
+                downloadFormat: "wav",
+                limits: {
+                  maxEntries: 1,
+                  maxConcurrentGenerations: 2,
+                  maxRetries: 1,
+                },
+              },
+              deferredIndices: [],
+              leaseToken: "lease-token",
+            },
+          },
+        })
+      ).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(harness.writeUnattendedRunState).toHaveBeenCalledWith(
+          expect.objectContaining({
+            checkpoint: "entries",
+            status: "manual-intervention",
+            stopReason: "captcha-required",
+          })
+        )
+      );
+      expect(clickGenerate).toHaveBeenCalledOnce();
+      expect(harness.runEntryWithRetry).toHaveBeenCalledOnce();
+      expect(fillPlaylistNameAndCreate).not.toHaveBeenCalled();
+      expect(progressPayloads()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ phase: PHASE.ERROR }),
+        ])
+      );
     }
   );
 


### PR DESCRIPTION
## 概要

無人実行中に Turnstile が現れた場合、unattended safety check で即停止せず、serial / queue 共通の既存 CAPTCHA wait 経路へ合流して未投入 entry から再開します。

Closes #2980

## 変更内容

- unattended safety check は login / cost confirmation を従来どおり fatal に維持
- `captcha-required` だけを既存 `guardCreateAgainstCaptcha` / `waitForCaptchaClear` へ通す
- active unattended の serial / queue 回帰を同一テストで固定
- 4件投入後の待機、解消後の5件目 exactly-once、manual/error 不在を検証
- 既存 resume checkpoint・queue runner・generation deadline 実装は変更しない

## 検証

- focused Vitest: 2 passed / 78 skipped
- `nix develop .#extensions --command pnpm -C extensions/suno-helper check`
- `nix develop .#extensions --command pnpm -C extensions/suno-helper compile`
- `git diff --check`

## Stack

- #3423: preflight の CAPTCHA 待機
- #3424: 解消後の unattended 再開と重複防止（本 PR）

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] #3293 関連 subtree は未変更