### PR TITLE
fix(suno-helper): CAPTCHA待機の終了契約を固定する (#3426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(config)`: skill-config の未知のトップレベルキーと同名のキーが既定設定内にある場合、正しい nested path の候補を警告へ表示（#2558）。
 
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
+- `fix(suno-helper)`: 無人実行の CAPTCHA 解消待機が timeout した場合、未投入 entry をすべて checkpoint に保持して `manual-intervention / captcha-required` で停止するようにした。待機中の Stop はエラー化せず、同じ checkpoint から再開できる（#3426）。
+
 - `fix(suno-helper)`: 無人実行中の CAPTCHA challenge を致命的な UI blocker とせず、serial / queue 共通の解消待機後に未投入 entry を重複なく再開するようにした（#2980）。
 
 - `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -586,6 +586,43 @@ interface PlaylistClipPersistInfo {
   playlistUrlsBeforeCreate?: string[];
 }
 
+type ActiveUnattendedRun = NonNullable<RunPayload["unattended"]>;
+
+function remainingRunIndices(
+  order: number[],
+  interruptedIndex: number,
+  orderPosition: number
+): number[] {
+  const remainingStart =
+    interruptedIndex === order[orderPosition]
+      ? orderPosition
+      : orderPosition + 1;
+  return order.slice(remainingStart);
+}
+
+function resolveInterruptRemainingIndices(
+  explicitRemainingIndices: number[] | undefined,
+  hasExplicitIndices: boolean,
+  remainingIndicesInRun: number[] | undefined
+): number[] | undefined {
+  if (explicitRemainingIndices !== undefined) {
+    return explicitRemainingIndices;
+  }
+  return hasExplicitIndices ? remainingIndicesInRun : undefined;
+}
+
+function appendDeferredIndices(
+  unattended: ActiveUnattendedRun,
+  remainingIndicesInRun: number[]
+): ActiveUnattendedRun {
+  return {
+    ...unattended,
+    deferredIndices: [
+      ...new Set([...remainingIndicesInRun, ...unattended.deferredIndices]),
+    ],
+  };
+}
+
 async function resolveDownloadContext(
   formatOverride?: DownloadContext["format"]
 ): Promise<DownloadContext> {
@@ -923,15 +960,24 @@ export default defineContentScript({
       assertUnattendedUiIsSafe({ allowCaptcha: true });
       // captcha が出ていても即停止しない。多くは passive 検証で数秒以内に自動 verify されて閉じるため、
       // waiting-captcha phase で解消を待って自動続行する。解消されない場合のみ throw（fail-loud は維持）。
-      await waitForCaptchaClear({
-        isAborted: () => aborted,
-        pollIntervalMs: POLL_INTERVAL_MS,
-        timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
-        onWaitStart: () => {
-          adaptivePacingState = recordChallenge(adaptivePacingState);
-          emitProgress({ phase: PHASE.WAITING_CAPTCHA, index, total });
-        },
-      });
+      try {
+        await waitForCaptchaClear({
+          isAborted: () => aborted,
+          pollIntervalMs: POLL_INTERVAL_MS,
+          timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
+          onWaitStart: () => {
+            adaptivePacingState = recordChallenge(adaptivePacingState);
+            emitProgress({ phase: PHASE.WAITING_CAPTCHA, index, total });
+          },
+        });
+      } catch (error) {
+        if (activeUnattended) {
+          throw new FatalRunError(
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+        throw error;
+      }
     }
 
     // fallow-ignore-next-line complexity
@@ -1545,15 +1591,21 @@ export default defineContentScript({
         explicitRemainingIndices?: number[],
         propagateWriteError = false
       ): void {
-        const remainingIndices =
-          explicitRemainingIndices ??
-          (hasExplicitIndices && orderPosition !== undefined
-            ? order.slice(
-                interruptedIndex === order[orderPosition]
-                  ? orderPosition
-                  : orderPosition + 1
-              )
-            : undefined);
+        const remainingIndicesInRun =
+          orderPosition === undefined
+            ? undefined
+            : remainingRunIndices(order, interruptedIndex, orderPosition);
+        const remainingIndices = resolveInterruptRemainingIndices(
+          explicitRemainingIndices,
+          hasExplicitIndices,
+          remainingIndicesInRun
+        );
+        if (activeUnattended && remainingIndicesInRun) {
+          activeUnattended = appendDeferredIndices(
+            activeUnattended,
+            remainingIndicesInRun
+          );
+        }
         const currentSubmittedIds = tracker.getSubmittedIds();
         const regenerateDurationOutliers =
           options.durationOutlierPolicy.kind === "regenerate";

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -1112,6 +1112,205 @@ describe('content onMessage("run"): Run 開始前の Suno view preflight', () =>
     }
   );
 
+  it.each(["serial", "queue"] as const)(
+    "Given unattended-active %s mode の CAPTCHA が timeout まで残る When Create 前に待つ Then fatal CAPTCHA state で未投入 entry を保持する",
+    async (runMode) => {
+      makeViewButton("Newest ▼");
+      makeViewButton("Grid");
+      makeTextarea(null);
+      makeTextarea("lyrics-textarea");
+      const clickGenerate = vi.fn();
+      makeGenerateButtonWithClickObserver(clickGenerate);
+      addCompletedRemixCard();
+      const captcha = document.createElement("iframe");
+      captcha.src = "https://challenges.cloudflare.com/turnstile/v0/widget";
+      markBbox(captcha, 300, 65);
+      document.body.appendChild(captcha);
+      await loadContentScript();
+      harness.waitForCaptchaClear.mockImplementation(async (options) => {
+        options.onWaitStart?.();
+        throw new Error("captcha challenge が timeout しました");
+      });
+      harness.runEntryWithRetry.mockImplementation(async (options) => {
+        try {
+          await options.attempt();
+        } catch (error) {
+          expect(options.isFatal(error)).toBe(true);
+          return { outcome: "fatal", error };
+        }
+        return { outcome: "ok" };
+      });
+      harness.sendMessage.mockImplementation((type: string) =>
+        type === "releaseUnattendedLease"
+          ? Promise.resolve({ released: true })
+          : undefined
+      );
+      const entries = makePromptEntries(2);
+
+      expect(
+        getRunHandler()({
+          data: {
+            ...makeRunPayload(entries),
+            runMode,
+            unattended: {
+              request: {
+                version: 1,
+                requestId: `scheduled-timeout-${runMode}`,
+                baseUrl: "http://localhost:8787",
+                collectionId: "20260601-clm-preflight-collection",
+                downloadFormat: "wav",
+                limits: {
+                  maxEntries: 2,
+                  maxConcurrentGenerations: 1,
+                  maxRetries: 1,
+                },
+              },
+              deferredIndices: [],
+              leaseToken: "lease-token",
+            },
+          },
+        })
+      ).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(harness.writeUnattendedRunState).toHaveBeenCalledWith(
+          expect.objectContaining({
+            checkpoint: "entries",
+            pendingEntryIndices: [0, 1],
+            status: "manual-intervention",
+            stopReason: "captcha-required",
+          })
+        )
+      );
+      expect(harness.runEntryWithRetry).toHaveBeenCalledOnce();
+      expect(clickGenerate).not.toHaveBeenCalled();
+      expect(progressPayloads()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ phase: PHASE.ERROR }),
+        ])
+      );
+    }
+  );
+
+  it("Given manual mode の CAPTCHA 待機が失敗 When Create 前 guard が終了する Then generic error のまま retry 契約へ返す", async () => {
+    makeViewButton("Newest ▼");
+    makeViewButton("Grid");
+    makeTextarea(null);
+    makeTextarea("lyrics-textarea");
+    const clickGenerate = vi.fn();
+    makeGenerateButtonWithClickObserver(clickGenerate);
+    addCompletedRemixCard();
+    const captcha = document.createElement("iframe");
+    captcha.src = "https://challenges.cloudflare.com/turnstile/v0/widget";
+    markBbox(captcha, 300, 65);
+    document.body.appendChild(captcha);
+    await loadContentScript();
+    const waitError = new Error("manual captcha wait failed");
+    harness.waitForCaptchaClear.mockRejectedValue(waitError);
+    harness.runEntryWithRetry.mockImplementation(async (options) => {
+      try {
+        await options.attempt();
+      } catch (error) {
+        expect(error).toBe(waitError);
+        expect(options.isFatal(error)).toBe(false);
+        return { outcome: "failed", error };
+      }
+      return { outcome: "ok" };
+    });
+
+    expect(
+      getRunHandler()({ data: makeRunPayload(makePromptEntries(1)) })
+    ).toEqual({ ok: true });
+
+    await vi.waitFor(() =>
+      expect(harness.runEntryWithRetry).toHaveBeenCalledOnce()
+    );
+    expect(clickGenerate).not.toHaveBeenCalled();
+    expect(harness.writeUnattendedRunState).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "manual-intervention" })
+    );
+  });
+
+  it.each(["serial", "queue"] as const)(
+    "Given unattended-active %s mode の CAPTCHA 待機中 When Stop する Then pending entry を保持して STOPPED にする",
+    async (runMode) => {
+      makeViewButton("Newest ▼");
+      makeViewButton("Grid");
+      makeTextarea(null);
+      makeTextarea("lyrics-textarea");
+      const clickGenerate = vi.fn();
+      makeGenerateButtonWithClickObserver(clickGenerate);
+      addCompletedRemixCard();
+      const captcha = document.createElement("iframe");
+      captcha.src = "https://challenges.cloudflare.com/turnstile/v0/widget";
+      markBbox(captcha, 300, 65);
+      document.body.appendChild(captcha);
+      await loadContentScript();
+      harness.waitForCaptchaClear.mockImplementation(async (options) => {
+        options.onWaitStart?.();
+        harness.handlers.get("stop")?.({ data: undefined });
+      });
+      harness.sendMessage.mockImplementation((type: string) =>
+        type === "releaseUnattendedLease"
+          ? Promise.resolve({ released: true })
+          : undefined
+      );
+      const entries = makePromptEntries(2);
+
+      expect(
+        getRunHandler()({
+          data: {
+            ...makeRunPayload(entries),
+            runMode,
+            unattended: {
+              request: {
+                version: 1,
+                requestId: `scheduled-stop-${runMode}`,
+                baseUrl: "http://localhost:8787",
+                collectionId: "20260601-clm-preflight-collection",
+                downloadFormat: "wav",
+                limits: {
+                  maxEntries: 2,
+                  maxConcurrentGenerations: 1,
+                  maxRetries: 1,
+                },
+              },
+              deferredIndices: [],
+              leaseToken: "lease-token",
+            },
+          },
+        })
+      ).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(progressPayloads()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ phase: PHASE.STOPPED }),
+          ])
+        )
+      );
+      expect(writeResumeState).toHaveBeenCalledWith(
+        expect.objectContaining({ failedIndex: 0, total: 2 })
+      );
+      expect(harness.writeUnattendedRunState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkpoint: "entries",
+          pendingEntryIndices: [0, 1],
+          status: "checkpoint",
+        })
+      );
+      expect(harness.writeUnattendedRunState).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: "manual-intervention" })
+      );
+      expect(clickGenerate).not.toHaveBeenCalled();
+      expect(progressPayloads()).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ phase: PHASE.ERROR }),
+        ])
+      );
+    }
+  );
+
   it("duration guard の pending 減少後は新しい stall deadline まで待機し、停滞時だけ timeout する", async () => {
     await loadContentScript();
     const { waitForAttemptClipsComplete } =


### PR DESCRIPTION
## 概要

active unattended の CAPTCHA 待機で、timeout は manual-intervention、Stop は非エラー checkpoint とし、未投入 entry を完全に保持します。

Closes #3426

## 変更内容

- unattended の wait timeout を `FatalRunError` として分類
- current run の残りと deferred indices を重複なく terminal state へ反映
- Stop は STOPPED / resumable checkpoint を維持
- manual run の generic rejection は非 fatal のまま維持
- `persistInterruptState` を純 helper へ分解し Fallow 閾値内へ縮小

## 物理パス（3）

1. `CHANGELOG.md`
2. `extensions/suno-helper/entrypoints/content.ts`
3. `extensions/suno-helper/tests/content-run-preflight.test.ts`

## 検証

- focused timeout/Stop/manual: 5 passed / 82 skipped
- Fallow: pass、`persistInterruptState` 14 cyclomatic / 11 cognitive / 93 LOC
- extension check / compile / diff-check: pass

## Stack

#3423 → #3424 → #3431 → #3428（本 PR）→ #3429

- [x] CHANGELOG `[Unreleased]` 更新
- [x] #3293 関連 subtree は未変更