### PR TITLE
fix(suno-helper): CAPTCHA待機時間を表示する (#3427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(distrokid-helper)`: `/server-info` に DistroKid の `disabled` / `single` / `dir` 実行モードを判別できる optional capability を追加し、既存必須フィールドと discovery schema v1 の互換性を維持（#2985）。
 - `fix(suno-helper)`: 無人実行の CAPTCHA 解消待機が timeout した場合、未投入 entry をすべて checkpoint に保持して `manual-intervention / captcha-required` で停止するようにした。待機中の Stop はエラー化せず、同じ checkpoint から再開できる（#3426）。
+- `fix(suno-helper)`: CAPTCHA 待機中の popup に自動解消を最大10分待つことを明示し、手動・無人実行で共通の待機契約と表示を一致させた（#3427）。
 
 - `fix(suno-helper)`: 無人実行中の CAPTCHA challenge を致命的な UI blocker とせず、serial / queue 共通の解消待機後に未投入 entry を重複なく再開するようにした（#2980）。
 

--- a/extensions/suno-helper/components/runner-errors.ts
+++ b/extensions/suno-helper/components/runner-errors.ts
@@ -153,7 +153,7 @@ export function phaseToStatus(
       };
     case PHASE.WAITING_CAPTCHA:
       return {
-        text: `[${n}/${total}] captcha 解消待ち…（多くは自動で解消します）`,
+        text: `[${n}/${total}] CAPTCHA 解消待ち…（自動解消を待機中・最大10分）`,
       };
     case PHASE.GENERATING:
       return {

--- a/extensions/suno-helper/tests/phase-to-status.test.ts
+++ b/extensions/suno-helper/tests/phase-to-status.test.ts
@@ -41,7 +41,7 @@ describe("phaseToStatus: 非終了 phase の進捗文言（live と同一）", (
     [
       "WAITING_CAPTCHA",
       { phase: PHASE.WAITING_CAPTCHA, index: 1, total: 3 },
-      "[2/3] captcha 解消待ち…（多くは自動で解消します）",
+      "[2/3] CAPTCHA 解消待ち…（自動解消を待機中・最大10分）",
     ],
     [
       "GENERATING",


### PR DESCRIPTION
## 概要

CAPTCHA 待機中の popup 文言を手動・無人実行で共通の実挙動に合わせ、自動解消を最大10分待つことを明示します。

Closes #3427

## 変更内容

- `CAPTCHA 解消待ち…（自動解消を待機中・最大10分）` と表示
- phase status test と CHANGELOG を更新

## 物理パス（3）

- `CHANGELOG.md`
- `extensions/suno-helper/components/runner-errors.ts`
- `extensions/suno-helper/tests/phase-to-status.test.ts`

## 検証

- focused phase test: 1 passed / 21 skipped
- extension check / compile / diff-check: pass

## Stack

#3423 → #3424 → #3431 → #3428 → #3429（本 PR）

- [x] #3293 関連 subtree は未変更