### PR TITLE
fix(suno-helper): queue fatal通知前にcheckpointを保存する (#3430)

### DIFF
--- a/extensions/suno-helper/lib/queue-runner.ts
+++ b/extensions/suno-helper/lib/queue-runner.ts
@@ -507,13 +507,13 @@ export async function submitQueueEntries(
         options.isEntrySubmitted(index),
         result.error instanceof InjectNotAcknowledgedError
       );
+      options.persistInterruptState(interruptIndex, orderPosition);
       options.emitProgress({
         phase: PHASE.ERROR,
         index: interruptIndex,
         total: options.total,
         message,
       });
-      options.persistInterruptState(interruptIndex, orderPosition);
       return { completed: false, failedIndices, clipIdsByEntry };
     }
     if (result.outcome === "aborted" || options.isAborted()) {

--- a/extensions/suno-helper/tests/queue-runner.test.ts
+++ b/extensions/suno-helper/tests/queue-runner.test.ts
@@ -14,6 +14,7 @@ import {
   MAX_INFLIGHT_REQUESTS,
   PHASE,
 } from "../../shared/constants";
+import { FatalRunError } from "../../shared/dom";
 import {
   finalizeQueueEntriesYield,
   resolveStalledQueueEntries,
@@ -166,6 +167,60 @@ describe("queue-runner: production ロジック (#1586)", () => {
       [0, ["clip-z-a", "clip-z-b"]],
       [1, ["clip-a-a", "clip-a-b"]],
     ]);
+  });
+
+  it("Given queue entry が fatal When 投入を終了する Then checkpoint を ERROR より先に1回保存する", async () => {
+    const entries = makePromptEntries(1);
+    const options = makeQueueSubmissionOptions({
+      entries,
+      submittedIndexes: [],
+      submittedClipIds: [],
+    });
+    const events: string[] = [];
+    options.submitEntryToQueue = async () => {
+      throw new FatalRunError("fatal queue failure");
+    };
+    options.persistInterruptState = vi.fn((index, orderPosition) => {
+      events.push(`persist:${index}:${orderPosition}`);
+    });
+    options.emitProgress = vi.fn((payload) => {
+      if (payload.phase === PHASE.ERROR) {
+        events.push(`progress:${payload.phase}`);
+      }
+    });
+
+    const result = await submitQueueEntries(options);
+
+    expect(result.completed).toBe(false);
+    expect(options.persistInterruptState).toHaveBeenCalledOnce();
+    expect(options.persistInterruptState).toHaveBeenCalledWith(0, 0);
+    expect(events).toEqual(["persist:0:0", `progress:${PHASE.ERROR}`]);
+  });
+
+  it("Given queue 投入前に abort When 投入を終了する Then checkpoint を STOPPED より先に1回保存する", async () => {
+    const entries = makePromptEntries(1);
+    const options = makeQueueSubmissionOptions({
+      entries,
+      submittedIndexes: [],
+      submittedClipIds: [],
+    });
+    const events: string[] = [];
+    options.isAborted = () => true;
+    options.persistInterruptState = vi.fn((index, orderPosition) => {
+      events.push(`persist:${index}:${orderPosition}`);
+    });
+    options.emitProgress = vi.fn((payload) => {
+      if (payload.phase === PHASE.STOPPED) {
+        events.push(`progress:${payload.phase}`);
+      }
+    });
+
+    const result = await submitQueueEntries(options);
+
+    expect(result.completed).toBe(false);
+    expect(options.persistInterruptState).toHaveBeenCalledOnce();
+    expect(options.persistInterruptState).toHaveBeenCalledWith(0, 0);
+    expect(events).toEqual(["persist:0:0", `progress:${PHASE.STOPPED}`]);
   });
 
   it("Given 1回目の ACK 失敗後に clip ID が遅延観測される When entry retry が成功する Then retry attempt 分も同じ entry に帰属する", async () => {


### PR DESCRIPTION
## 概要

queue mode の fatal 終端で resume checkpoint を先に確定し、その後に ERROR progress を通知する順序へ統一します。

Closes #3430

## 変更内容

- fatal: `persistInterruptState` → `ERROR` emit
- abort: 既存の persist → STOPPED を維持
- happy path: checkpoint 書込みなしを維持

## 物理パス（2）

- `extensions/suno-helper/lib/queue-runner.ts`
- `extensions/suno-helper/tests/queue-runner.test.ts`

## 検証

- focused checkpoint: 2 passed / 24 skipped
- queue-runner file: 26 passed
- extension check / compile / diff-check: pass

## CHANGELOG

`skip-changelog`。外部挙動を変えない terminal ordering の内部 prerequisite で、ユーザー向け timeout/Stop 変更は上段 #3428 に記録します。

## Stack

#3423 → #3424 → #3431（本 PR）→ #3428 → #3429

- [x] #3293 関連 subtree は未変更