### PR TITLE
feat(suno-helper): challenge履歴を固定長で保存する (#2982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: standard Analytics 収集に使った同一 `AnalyticsSystem` / collector の動画一覧 cache を再利用し、チャンネル設定の公開 timezone で集計した `data/dashboard_publications.json` を収集成功時だけ保存するようにした（#3357）。
 - `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
+- `feat(suno-helper)`: Turnstile challenge 検知時の安全な実行コンテキストだけを、run を跨ぐ固定長 ring buffer として `chrome.storage.local` へ best-effort で蓄積する基盤を追加した（#2982）。
+
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。
 - `feat(wf-new-batch)`: batch ledger の許可遷移・単一 active plan・current plan 整合性と atomic 保存を実行時に検証し、child が prepared + hard artifacts 完了後に ledger 更新前 crash した場合は same-provenance actual state から workflow-state を変更せず completed へ reconcile できる state helper を追加した。Done 再検証で artifact / provenance drift を検知した completed plan は、reason と resume_action を伴う guarded transition だけ blocked へ戻せる（#3279）。

--- a/extensions/suno-helper/lib/challenge-log.ts
+++ b/extensions/suno-helper/lib/challenge-log.ts
@@ -1,0 +1,77 @@
+import { storage } from "wxt/utils/storage";
+
+export const CHALLENGE_LOG_MAX_RECORDS = 100;
+
+export type ChallengeLogSource =
+  | "preflight"
+  | "before-create"
+  | "generation-wait";
+
+export interface ChallengeLogRecord {
+  timestamp: number;
+  source: ChallengeLogSource;
+  runMode: "serial" | "queue" | null;
+  unattended: boolean;
+  entryIndex: number | null;
+  total: number | null;
+  challengeLevel: number;
+  recentCreateCount: number;
+}
+
+const CHALLENGE_LOG_STORAGE_KEY = "sunoChallengeLog";
+
+let cachedItem: ReturnType<
+  typeof storage.defineItem<ChallengeLogRecord[]>
+> | null = null;
+let appendQueue: Promise<void> = Promise.resolve();
+
+function challengeLogItem() {
+  if (!cachedItem) {
+    cachedItem = storage.defineItem<ChallengeLogRecord[]>(
+      `local:${CHALLENGE_LOG_STORAGE_KEY}`,
+      { fallback: [] }
+    );
+  }
+  return cachedItem;
+}
+
+function allowlistedRecord(input: ChallengeLogRecord): ChallengeLogRecord {
+  return {
+    timestamp: input.timestamp,
+    source: input.source,
+    runMode: input.runMode,
+    unattended: input.unattended,
+    entryIndex: input.entryIndex,
+    total: input.total,
+    challengeLevel: input.challengeLevel,
+    recentCreateCount: input.recentCreateCount,
+  };
+}
+
+async function appendRecord(record: ChallengeLogRecord): Promise<void> {
+  try {
+    const current = (await challengeLogItem().getValue()) ?? [];
+    const next = [...current, record].slice(-CHALLENGE_LOG_MAX_RECORDS);
+    await challengeLogItem().setValue(next);
+  } catch (error) {
+    console.warn("[suno-helper] challenge log の保存に失敗しました:", error);
+  }
+}
+
+export function appendChallengeRecord(
+  input: ChallengeLogRecord
+): Promise<void> {
+  const record = allowlistedRecord(input);
+  const pending = appendQueue.then(() => appendRecord(record));
+  appendQueue = pending;
+  return pending;
+}
+
+export async function readChallengeLog(): Promise<ChallengeLogRecord[]> {
+  try {
+    return (await challengeLogItem().getValue()) ?? [];
+  } catch (error) {
+    console.warn("[suno-helper] challenge log の読込に失敗しました:", error);
+    return [];
+  }
+}

--- a/extensions/suno-helper/tests/challenge-log.test.ts
+++ b/extensions/suno-helper/tests/challenge-log.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const challengeStorage = vi.hoisted(() => {
+  let value: unknown[] = [];
+  const getValue = vi.fn(async () => [...value]);
+  const setValue = vi.fn(async (next: unknown[]) => {
+    value = [...next];
+  });
+  const defineItem = vi.fn(() => ({ getValue, setValue }));
+  return {
+    defineItem,
+    getValue,
+    setValue,
+    read: () => [...value],
+    reset: () => {
+      value = [];
+      defineItem.mockClear();
+      getValue.mockReset().mockImplementation(async () => [...value]);
+      setValue.mockReset().mockImplementation(async (next: unknown[]) => {
+        value = [...next];
+      });
+    },
+  };
+});
+
+vi.mock("wxt/utils/storage", () => ({
+  storage: { defineItem: challengeStorage.defineItem },
+}));
+
+function record(timestamp: number) {
+  return {
+    timestamp,
+    source: "before-create" as const,
+    runMode: "queue" as const,
+    unattended: true,
+    entryIndex: 2,
+    total: 10,
+    challengeLevel: 1,
+    recentCreateCount: 4,
+  };
+}
+
+describe("challenge log storage boundary (#2982)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    challengeStorage.reset();
+  });
+
+  it("storage item を local key と空配列 fallback で遅延定義する", async () => {
+    const { readChallengeLog } = await import("../lib/challenge-log");
+
+    expect(challengeStorage.defineItem).not.toHaveBeenCalled();
+    await expect(readChallengeLog()).resolves.toEqual([]);
+
+    expect(challengeStorage.defineItem).toHaveBeenCalledOnce();
+    expect(challengeStorage.defineItem).toHaveBeenCalledWith(
+      "local:sunoChallengeLog",
+      { fallback: [] }
+    );
+  });
+
+  it("上限超過時に最古から破棄し、run を跨ぐ逐次 append の順序を保持する", async () => {
+    const { appendChallengeRecord, CHALLENGE_LOG_MAX_RECORDS } =
+      await import("../lib/challenge-log");
+
+    for (
+      let timestamp = 0;
+      timestamp < CHALLENGE_LOG_MAX_RECORDS + 2;
+      timestamp += 1
+    ) {
+      await appendChallengeRecord(record(timestamp));
+    }
+
+    const stored = challengeStorage.read() as Array<{ timestamp: number }>;
+    expect(stored).toHaveLength(CHALLENGE_LOG_MAX_RECORDS);
+    expect(stored.map(({ timestamp }) => timestamp)).toEqual(
+      Array.from({ length: CHALLENGE_LOG_MAX_RECORDS }, (_, index) => index + 2)
+    );
+  });
+
+  it("allowlist field だけを再構築し、生成内容や認証情報を保存しない", async () => {
+    const { appendChallengeRecord } = await import("../lib/challenge-log");
+    const input = {
+      ...record(100),
+      style: "secret style",
+      lyrics: "secret lyrics",
+      token: "secret token",
+      authorization: "Bearer secret",
+    };
+
+    await appendChallengeRecord(input);
+
+    expect(challengeStorage.read()).toEqual([record(100)]);
+  });
+
+  it("storage の read / write failure を呼び出し元へ伝播しない", async () => {
+    const { appendChallengeRecord, readChallengeLog } =
+      await import("../lib/challenge-log");
+    challengeStorage.getValue.mockRejectedValueOnce(new Error("read failed"));
+
+    await expect(appendChallengeRecord(record(1))).resolves.toBeUndefined();
+
+    challengeStorage.getValue.mockRejectedValueOnce(new Error("read failed"));
+    await expect(readChallengeLog()).resolves.toEqual([]);
+    challengeStorage.setValue.mockRejectedValueOnce(new Error("write failed"));
+    await expect(appendChallengeRecord(record(2))).resolves.toBeUndefined();
+  });
+
+  it("同時 append を直列化して lost update を防ぐ", async () => {
+    const { appendChallengeRecord } = await import("../lib/challenge-log");
+
+    await Promise.all([
+      appendChallengeRecord(record(1)),
+      appendChallengeRecord(record(2)),
+      appendChallengeRecord(record(3)),
+    ]);
+
+    expect(challengeStorage.read()).toEqual([record(1), record(2), record(3)]);
+  });
+});


### PR DESCRIPTION
## 概要

Turnstile challenge の安全な実行コンテキストを、run を跨ぐ固定長 ring buffer として `chrome.storage.local` に best-effort 保存する基盤を追加します。検知点への接続・overlay 表示は後続 issue の責務です。

Closes #2982

## 変更内容

- `CHALLENGE_LOG_MAX_RECORDS = 100` の固定長 ring buffer
- `local:sunoChallengeLog` を空配列 fallback で遅延定義
- 最古からの eviction と append 順序を維持
- Promise chain で同時 append の lost update を防止
- read / write failure を内部で吸収する best-effort 境界
- timestamp/source/runMode/unattended/entryIndex/total/challengeLevel/recentCreateCount の8フィールドだけを再構築し、Style・Lyrics・token・authorization を保存しない

## 物理パス（3）

1. `extensions/suno-helper/lib/challenge-log.ts`
2. `extensions/suno-helper/tests/challenge-log.test.ts`
3. `CHANGELOG.md`

## 検証

- focused Vitest: 5 passed
- Fallow: 3 changed files、issue なし
- extension check: 182 files pass
- extension compile: pass
- `git diff --check`: pass

## スコープ外

- challenge 検知点からの呼び出し接続
- overlay 表示・export
- pacing 定数の調整

- [x] CHANGELOG `[Unreleased] / Added` 更新
- [x] #3293 関連 subtree は未変更