### PR TITLE
feat(suno-helper): challenge記録にpacing文脈を追加する (#3434)

### DIFF
--- a/extensions/suno-helper/lib/challenge-log.ts
+++ b/extensions/suno-helper/lib/challenge-log.ts
@@ -16,6 +16,10 @@ export interface ChallengeLogRecord {
   total: number | null;
   challengeLevel: number;
   recentCreateCount: number;
+  runCreateCount: number;
+  lastCreateIntervalMs: number | null;
+  appliedDelayMs: number;
+  inflightRequestCount: number;
 }
 
 const CHALLENGE_LOG_STORAGE_KEY = "sunoChallengeLog";
@@ -45,6 +49,10 @@ function allowlistedRecord(input: ChallengeLogRecord): ChallengeLogRecord {
     total: input.total,
     challengeLevel: input.challengeLevel,
     recentCreateCount: input.recentCreateCount,
+    runCreateCount: input.runCreateCount,
+    lastCreateIntervalMs: input.lastCreateIntervalMs,
+    appliedDelayMs: input.appliedDelayMs,
+    inflightRequestCount: input.inflightRequestCount,
   };
 }
 

--- a/extensions/suno-helper/tests/challenge-log.test.ts
+++ b/extensions/suno-helper/tests/challenge-log.test.ts
@@ -37,6 +37,10 @@ function record(timestamp: number) {
     total: 10,
     challengeLevel: 1,
     recentCreateCount: 4,
+    runCreateCount: 7,
+    lastCreateIntervalMs: 3200,
+    appliedDelayMs: 5000,
+    inflightRequestCount: 3,
   };
 }
 
@@ -80,8 +84,15 @@ describe("challenge log storage boundary (#2982)", () => {
 
   it("allowlist field だけを再構築し、生成内容や認証情報を保存しない", async () => {
     const { appendChallengeRecord } = await import("../lib/challenge-log");
-    const input = {
+    const expected = {
       ...record(100),
+      runCreateCount: 0,
+      lastCreateIntervalMs: null,
+      appliedDelayMs: 0,
+      inflightRequestCount: 0,
+    };
+    const input = {
+      ...expected,
       style: "secret style",
       lyrics: "secret lyrics",
       token: "secret token",
@@ -90,7 +101,7 @@ describe("challenge log storage boundary (#2982)", () => {
 
     await appendChallengeRecord(input);
 
-    expect(challengeStorage.read()).toEqual([record(100)]);
+    expect(challengeStorage.read()).toEqual([expected]);
   });
 
   it("storage の read / write failure を呼び出し元へ伝播しない", async () => {


### PR DESCRIPTION
## 概要

challenge record に、3検知点接続で必要な pacing 実行コンテキストを安全な allowlist field として追加します。

Closes #3434

## 変更内容

- `runCreateCount`
- `lastCreateIntervalMs`（null 許容）
- `appliedDelayMs`
- `inflightRequestCount`
- 既存 `recentCreateCount` は burst-window 件数として維持
- Style / Lyrics / token / authorization は引き続き破棄

## 物理パス（2）

- `extensions/suno-helper/lib/challenge-log.ts`
- `extensions/suno-helper/tests/challenge-log.test.ts`

## 検証

- focused Vitest: 5 passed
- extension check: 182 files pass
- compile / Fallow / diff-check: pass

## CHANGELOG

`skip-changelog`。後続 #3435 の検知点接続に必要な内部 schema prerequisite で、ユーザー向け変更は #3435 に記録します。

## Stack

#3433 → #3436（本 PR）→ #3435（予定）

- [x] #3293 関連 subtree は未変更