### PR TITLE
feat(suno-helper): challenge検知文脈を記録する (#3435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: 公開履歴 payload を保存先と同じディレクトリの一時ファイルへ完全に書き終えてから原子的に置換し、置換失敗時も既存 JSON を保持して一時ファイルを片付ける保存関数を追加した（#3356）。
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
 - `feat(suno-helper)`: Turnstile challenge 検知時の安全な実行コンテキストだけを、run を跨ぐ固定長 ring buffer として `chrome.storage.local` へ best-effort で蓄積する基盤を追加した（#2982）。
+- `feat(suno-helper)`: unattended preflight・Create 直前・生成完了待ち中の challenge 検知を共通記録経路へ接続し、検知箇所と run・pacing・inflight の実行コンテキストを区別して蓄積するようにした（#3435）。
 
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -7,6 +7,7 @@ import {
   type PromptResponse,
 } from "../../shared/api";
 import {
+  ADAPTIVE_BURST_WINDOW_MS,
   BALANCED_RUN_PACING,
   CLIPS_PER_REQUEST,
   DEFAULT_REGENERATE_DURATION_OUTLIERS,
@@ -72,6 +73,10 @@ import {
   requestFeedPoll,
   requestSliderSet,
 } from "../lib/bridge-listener";
+import {
+  appendChallengeRecord,
+  type ChallengeLogSource,
+} from "../lib/challenge-log";
 import { createClipTracker } from "../lib/clip-tracker";
 import { settleStoredCollectionQueueRun } from "../lib/collection-queue-state";
 import { acquireDomRunLock, releaseDomRunLock } from "../lib/dom-run-lock";
@@ -799,6 +804,8 @@ export default defineContentScript({
     // 以降は emitProgress が sendMessage より前に同期更新する（queryProgress と race しないため）。
     let currentSnapshot: SnapshotPayload | null = null;
     let activeUnattended: RunPayload["unattended"];
+    let activeRunMode: RunModeId | null = null;
+    let runCreateCount = 0;
     // progress は高頻度で到着するため、storage 書き込みを直列化して古い phase が
     // FINISHED / manual-intervention を後から上書きする race を防ぐ。
     let unattendedStateWrite: Promise<void> = Promise.resolve();
@@ -814,6 +821,13 @@ export default defineContentScript({
     const feedPoller = createFeedPoller(tracker);
     let warnedDomFallback = false;
 
+    function observedInFlightClipCount(): number {
+      if (tracker.hasObservedAnyTraffic()) {
+        return tracker.getInFlightCount();
+      }
+      return getInFlightClipCount();
+    }
+
     /** in-flight 数の合成カウント (#948)。bridge 観測があれば status ベース、無ければ DOM プロキシへ縮退。 */
     function currentInFlightCount(): number {
       if (tracker.hasObservedAnyTraffic()) {
@@ -826,6 +840,41 @@ export default defineContentScript({
         );
       }
       return getInFlightClipCount();
+    }
+
+    function recordDetectedChallenge(input: {
+      source: ChallengeLogSource;
+      runMode: RunModeId | null;
+      unattended: boolean;
+      entryIndex: number | null;
+      total: number | null;
+    }): void {
+      const timestamp = Date.now();
+      const createTimestamps = adaptivePacingState.recentCreateTimestamps;
+      const previousCreateAt = createTimestamps.at(-2);
+      const lastCreateAt = createTimestamps.at(-1);
+      const appliedDelayMs = decideAdaptivePacing(
+        adaptivePacingState,
+        timestamp
+      ).delayMs;
+      void appendChallengeRecord({
+        timestamp,
+        ...input,
+        challengeLevel: adaptivePacingState.challengeLevel,
+        recentCreateCount: createTimestamps.filter(
+          (createdAt) => createdAt >= timestamp - ADAPTIVE_BURST_WINDOW_MS
+        ).length,
+        runCreateCount,
+        lastCreateIntervalMs:
+          previousCreateAt === undefined || lastCreateAt === undefined
+            ? null
+            : lastCreateAt - previousCreateAt,
+        appliedDelayMs,
+        inflightRequestCount: Math.ceil(
+          observedInFlightClipCount() / CLIPS_PER_REQUEST
+        ),
+      });
+      adaptivePacingState = recordChallenge(adaptivePacingState);
     }
 
     /** inject ACK のハイブリッド判定 (#948)。bridge の generate レスポンス観測 OR DOM 増分。 */
@@ -987,6 +1036,13 @@ export default defineContentScript({
           pollIntervalMs: POLL_INTERVAL_MS,
           timeoutMs: CAPTCHA_WAIT_TIMEOUT_MS,
           onWaitStart: () => {
+            recordDetectedChallenge({
+              source: "before-create",
+              runMode: activeRunMode,
+              unattended: activeUnattended !== undefined,
+              entryIndex: index,
+              total,
+            });
             adaptivePacingState = recordChallenge(adaptivePacingState);
             emitProgress({ phase: PHASE.WAITING_CAPTCHA, index, total });
           },
@@ -1123,6 +1179,7 @@ export default defineContentScript({
 
       const button = resolveGenerateButton();
       button.click();
+      runCreateCount += 1;
       adaptivePacingState = recordSuccessfulCreate(
         adaptivePacingState,
         Date.now()
@@ -1171,7 +1228,13 @@ export default defineContentScript({
         // 生成完了待ち中に captcha が出たら waiting-captcha 表示へ切り替え、解消後 generating へ戻す。
         onCaptchaWait: (waiting) => {
           if (waiting) {
-            adaptivePacingState = recordChallenge(adaptivePacingState);
+            recordDetectedChallenge({
+              source: "generation-wait",
+              runMode: activeRunMode,
+              unattended: activeUnattended !== undefined,
+              entryIndex: index,
+              total,
+            });
           }
           emitProgress({
             phase: waiting ? PHASE.WAITING_CAPTCHA : PHASE.GENERATING,
@@ -2604,6 +2667,8 @@ export default defineContentScript({
       }
       running = true;
       aborted = false;
+      activeRunMode = runMode;
+      runCreateCount = 0;
       lastSubmittedEntryIndex = -1;
       tracker.clearSubmittedIds();
       // run 中のみ active feed poll で clip status を追う (#948)。passive 観測が生きていれば
@@ -2641,6 +2706,7 @@ export default defineContentScript({
         }
         await releaseExecutionLease(unattended);
         activeUnattended = undefined;
+        activeRunMode = null;
         feedPoller.stop();
         releaseRunLock();
       });
@@ -2971,6 +3037,13 @@ export default defineContentScript({
       try {
         const blocker = detectUnattendedPreflightBlocker();
         if (blocker?.reason === "captcha-required") {
+          recordDetectedChallenge({
+            source: "preflight",
+            runMode: null,
+            unattended: true,
+            entryIndex: null,
+            total: null,
+          });
           await waitForCaptchaClear({
             isAborted: () => false,
             pollIntervalMs: POLL_INTERVAL_MS,

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -27,6 +27,10 @@ import type {
 import { type ResumeState, writeResumeState } from "../lib/resume-state";
 import { makePromptEntries, markBbox } from "./_helpers";
 
+interface GenerationWaitOptionsProbe {
+  onCaptchaWait?: (waiting: boolean) => void;
+}
+
 const harness = vi.hoisted(() => {
   const handlers = new Map<string, (message: { data: unknown }) => unknown>();
   const feedPollerStart = vi.fn();
@@ -91,6 +95,7 @@ const harness = vi.hoisted(() => {
     durationsById: {} as Record<string, number | undefined>,
     durationErrorsById: {} as Record<string, Error | undefined>,
     pendingClipIds: [] as string[],
+    trackerInFlightCount: 0,
     requestFeedPollError: undefined as Error | undefined,
     unattendedRequest: null as Record<string, unknown> | null,
     abortOnRequestFeedPoll: false,
@@ -107,10 +112,16 @@ const harness = vi.hoisted(() => {
       );
       return [];
     }),
-    waitForGeneration: vi.fn<() => Promise<void>>(async () => undefined),
+    appendChallengeRecord: vi.fn(() => Promise.resolve()),
     waitForCaptchaClear: vi.fn<
       (options: WaitForCaptchaClearOptions) => Promise<void>
     >(async () => undefined),
+    waitForGeneration: vi.fn(
+      async (
+        _button?: HTMLButtonElement,
+        _options?: GenerationWaitOptionsProbe
+      ): Promise<void> => undefined
+    ),
     waitForQueueSlot: vi.fn<
       (maxGeneratingClips: number, options?: unknown) => Promise<void>
     >(async () => undefined),
@@ -186,6 +197,10 @@ vi.mock("../lib/entry-retry", () => ({
   runEntryWithRetry: harness.runEntryWithRetry,
 }));
 
+vi.mock("../lib/challenge-log", () => ({
+  appendChallengeRecord: harness.appendChallengeRecord,
+}));
+
 vi.mock("../lib/clip-tracker", () => ({
   createClipTracker: vi.fn(() => ({
     clearSubmittedIds: vi.fn(),
@@ -223,7 +238,7 @@ vi.mock("../lib/clip-tracker", () => ({
         (id) => !dropped.has(id)
       );
     }),
-    getInFlightCount: vi.fn(() => 0),
+    getInFlightCount: vi.fn(() => harness.trackerInFlightCount),
     hasObservedAnyTraffic: vi.fn(() => true),
     lastChangeAt: vi.fn(() => Date.now()),
     submissionCount: vi.fn(() => harness.submittedClipIds.length),
@@ -596,6 +611,7 @@ beforeEach(() => {
   harness.durationsById = {};
   harness.durationErrorsById = {};
   harness.pendingClipIds = [];
+  harness.trackerInFlightCount = 0;
   harness.requestFeedPollError = undefined;
   harness.abortOnRequestFeedPoll = false;
   harness.useActualAbortableSleep = false;
@@ -618,6 +634,8 @@ beforeEach(() => {
   harness.waitForGeneration.mockResolvedValue(undefined);
   harness.waitForCaptchaClear.mockReset();
   harness.waitForCaptchaClear.mockResolvedValue(undefined);
+  harness.appendChallengeRecord.mockReset();
+  harness.appendChallengeRecord.mockResolvedValue(undefined);
   harness.waitForQueueSlot.mockReset();
   // 既定は実装呼び出し（vi.fn(actual.waitForQueueSlot) 相当）。no-op 既定にすると
   // 「Remix 0 かつ空 queue で初回 WAITING_SLOT で失敗しない」回帰テストが空虚に通る。
@@ -879,6 +897,115 @@ describe("content unattended launch", () => {
 });
 
 describe('content onMessage("run"): Run 開始前の Suno view preflight', () => {
+  it("Given unattended preflight challenge When launch を検査する Then preflight context を1回記録する", async () => {
+    harness.trackerInFlightCount = 3;
+    setUnattendedLaunchHash();
+    const iframe = document.createElement("iframe");
+    iframe.src =
+      "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv";
+    markBbox(iframe, 300, 200);
+    document.body.appendChild(iframe);
+
+    await loadContentScript();
+
+    await vi.waitFor(() =>
+      expect(harness.appendChallengeRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "preflight",
+          runMode: null,
+          unattended: true,
+          entryIndex: null,
+          total: null,
+          runCreateCount: 0,
+          lastCreateIntervalMs: null,
+          recentCreateCount: 0,
+          challengeLevel: 0,
+          appliedDelayMs: 0,
+          inflightRequestCount: 2,
+        })
+      )
+    );
+    expect(harness.appendChallengeRecord).toHaveBeenCalledOnce();
+  });
+
+  it.each(["serial", "queue"] as const)(
+    "Given %s run の Create直前 challenge When wait が始まる Then 共通 before-create context を1回記録する",
+    async (runMode) => {
+      harness.trackerInFlightCount = 3;
+      makeRunnableSunoDom("Grid");
+      harness.waitForCaptchaClear.mockImplementationOnce(async (options) => {
+        options?.onWaitStart?.();
+      });
+      await loadContentScript();
+
+      expect(
+        getRunHandler()({
+          data: { ...makeRunPayload(makePromptEntries(1)), runMode },
+        })
+      ).toEqual({ ok: true });
+
+      await vi.waitFor(() =>
+        expect(harness.appendChallengeRecord).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: "before-create",
+            runMode,
+            unattended: false,
+            entryIndex: 0,
+            total: 1,
+            runCreateCount: 0,
+            lastCreateIntervalMs: null,
+            recentCreateCount: 0,
+            challengeLevel: 0,
+            appliedDelayMs: 0,
+            inflightRequestCount: 2,
+          })
+        )
+      );
+      expect(harness.appendChallengeRecord).toHaveBeenCalledOnce();
+      await vi.waitFor(() =>
+        expect(harness.feedPollerStop).toHaveBeenCalledOnce()
+      );
+    }
+  );
+
+  it("Given generation wait challenge When true の後 false callback が来る Then true episode だけを記録する", async () => {
+    harness.trackerInFlightCount = 3;
+    makeRunnableSunoDom("Grid");
+    harness.waitForGeneration.mockImplementationOnce(
+      async (_button, options) => {
+        options?.onCaptchaWait?.(true);
+        options?.onCaptchaWait?.(false);
+      }
+    );
+    await loadContentScript();
+
+    expect(
+      getRunHandler()({ data: makeRunPayload(makePromptEntries(1)) })
+    ).toEqual({ ok: true });
+
+    await vi.waitFor(() =>
+      expect(harness.appendChallengeRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "generation-wait",
+          runMode: "serial",
+          unattended: false,
+          entryIndex: 0,
+          total: 1,
+          runCreateCount: 1,
+          lastCreateIntervalMs: null,
+          recentCreateCount: 1,
+          challengeLevel: 0,
+          appliedDelayMs: 0,
+          inflightRequestCount: 2,
+        })
+      )
+    );
+    expect(harness.appendChallengeRecord).toHaveBeenCalledOnce();
+    await vi.waitFor(() =>
+      expect(harness.feedPollerStop).toHaveBeenCalledOnce()
+    );
+  });
+
   it("Given actual run handler が実行中 When run が再着信する Then busy ACK で二重起動しない (#2909)", async () => {
     makeRunnableSunoDom("Grid");
     await loadContentScript();


### PR DESCRIPTION
## 概要

preflight・Create直前・生成待ち中の challenge 検知を、#3434 で拡張した共通 challenge context 記録経路へ接続します。各 source / episode は1回だけ記録し、保存失敗は実行を中断しません。

Closes #3435

## 変更内容

- preflight / before-create / generation-wait の3 sourceを共通 helperへ接続
- serial / queueで同じ記録経路と検知時点のrun・pacing・inflight contextを使用
- generation-waitのtrue→false callbackで重複記録しない契約をfocused testで固定
- CHANGELOG [Unreleased] に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/suno-helper/entrypoints/content.ts
- extensions/suno-helper/tests/content-run-preflight.test.ts

## 検証

- Focused TDD RED: 4 failed / 77 skipped
- Focused GREEN（新規+既存回帰）: 5 passed / 76 skipped
- Full suno-helper Vitest: PASS（73 files / 1350 tests）
- extensions/suno-helper check: PASS（182 files）
- extensions/suno-helper compile: PASS
- Fallow audit: PASS（No issues）
- git diff --check: PASS

## Review fix

- tracker test doubleの既定in-flight値を0へ戻し、3は新規contextケース内だけで設定
- 既存playlist前checkpoint失敗契約のWAITING_SLOT停滞を解消し、full suiteで回帰なしを確認

## Stack

- base: #3436（#3434）
- current: #3438（#3435）
- next: #3439（#2984）
- parent management issue: #2983

## スコープ外

- overlay / export（#3439）
- pacing値の調整
- #3293関連変更

## チェックリスト

- [x] CHANGELOG.md::[Unreleased] にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] focused / full test / check / compile / Fallowを通した