### PR TITLE
feat(suno-helper): challenge履歴をoverlay表示する (#2984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: uploads playlist 由来の公開日時を UTC の取得時刻から rolling 365 日で絞り、チャンネル設定の timezone に変換したローカル暦日別件数 payload を構築する純粋関数を追加した（#3355）。
 - `feat(suno-helper)`: Turnstile challenge 検知時の安全な実行コンテキストだけを、run を跨ぐ固定長 ring buffer として `chrome.storage.local` へ best-effort で蓄積する基盤を追加した（#2982）。
 - `feat(suno-helper)`: unattended preflight・Create 直前・生成完了待ち中の challenge 検知を共通記録経路へ接続し、検知箇所と run・pacing・inflight の実行コンテキストを区別して蓄積するようにした（#3435）。
+- `feat(suno-helper)`: overlay で蓄積済み challenge 履歴の総件数と直近 5 件を確認し、安全な全レコードを JSON として clipboard へコピーできるようにした（#2984）。
 
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。

--- a/extensions/suno-helper/components/Overlay.tsx
+++ b/extensions/suno-helper/components/Overlay.tsx
@@ -2,11 +2,169 @@ import type { OverlayState } from "@youtube-automation/extensions-shared/overlay
 import { OverlayShell } from "@youtube-automation/ui";
 import { useCallback, useEffect, useState } from "react";
 
+import {
+  type ChallengeLogRecord,
+  readChallengeLog,
+} from "../lib/challenge-log";
 import { onMessage, sendMessage } from "../lib/messaging";
 import { SUNO_OVERLAY_BRAND } from "../lib/overlay-brand";
 import { readOverlayState, writeOverlayState } from "../lib/overlay-storage";
 import { App } from "./App";
 import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
+
+const RECENT_CHALLENGE_RECORD_COUNT = 5;
+type ChallengeLogCopyResult = "idle" | "success" | "failure";
+
+function allowlistedChallengeRecord(
+  record: ChallengeLogRecord
+): ChallengeLogRecord {
+  return {
+    timestamp: record.timestamp,
+    source: record.source,
+    runMode: record.runMode,
+    unattended: record.unattended,
+    entryIndex: record.entryIndex,
+    total: record.total,
+    challengeLevel: record.challengeLevel,
+    recentCreateCount: record.recentCreateCount,
+    runCreateCount: record.runCreateCount,
+    lastCreateIntervalMs: record.lastCreateIntervalMs,
+    appliedDelayMs: record.appliedDelayMs,
+    inflightRequestCount: record.inflightRequestCount,
+  };
+}
+
+function useChallengeLogRecords(refreshToken: number) {
+  const [records, setRecords] = useState<ChallengeLogRecord[] | null>(null);
+  const [copyResult, setCopyResult] = useState<ChallengeLogCopyResult>("idle");
+
+  useEffect(() => {
+    let active = true;
+    setCopyResult("idle");
+    void readChallengeLog().then((storedRecords) => {
+      if (active) {
+        setRecords(storedRecords.map(allowlistedChallengeRecord));
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [refreshToken]);
+
+  const copyAllRecords = useCallback(async () => {
+    if (!records || records.length === 0) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
+      setCopyResult("success");
+    } catch (error) {
+      console.warn(
+        "[suno-helper] challenge 履歴を clipboard へコピーできませんでした:",
+        error
+      );
+      setCopyResult("failure");
+    }
+  }, [records]);
+
+  return { copyAllRecords, copyResult, records };
+}
+
+function ChallengeLogFeedback({
+  copyResult,
+  records,
+}: {
+  copyResult: ChallengeLogCopyResult;
+  records: ChallengeLogRecord[] | null;
+}) {
+  if (records === null) {
+    return (
+      <p data-suno-control="challenge-log-status" role="status">
+        Challenge 履歴を読み込み中です。
+      </p>
+    );
+  }
+  if (records.length === 0) {
+    return (
+      <p data-suno-control="challenge-log-status" role="status">
+        Challenge の記録はありません。
+      </p>
+    );
+  }
+  if (copyResult === "success") {
+    return (
+      <p data-suno-control="challenge-log-status" role="status">
+        Challenge 履歴をコピーしました。
+      </p>
+    );
+  }
+  if (copyResult === "failure") {
+    return (
+      <p data-suno-control="challenge-log-error" role="alert">
+        Challenge 履歴をコピーできませんでした。
+      </p>
+    );
+  }
+  return null;
+}
+
+function ChallengeRecordList({
+  records,
+}: {
+  records: ChallengeLogRecord[] | null;
+}) {
+  const recentRecords =
+    records?.slice(-RECENT_CHALLENGE_RECORD_COUNT).toReversed() ?? [];
+  if (recentRecords.length === 0) return null;
+  return (
+    <ol className="mt-2 space-y-1">
+      {recentRecords.map((record, index) => (
+        <li
+          data-suno-control="challenge-log-record"
+          key={`${record.timestamp}-${record.source}-${index}`}
+        >
+          <time dateTime={new Date(record.timestamp).toISOString()}>
+            {record.source} · {record.runMode ?? "run前"} · entry{" "}
+            {record.entryIndex ?? "-"}/{record.total ?? "-"}
+          </time>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function ChallengeLogPanel({ refreshToken }: { refreshToken: number }) {
+  const { copyAllRecords, copyResult, records } =
+    useChallengeLogRecords(refreshToken);
+
+  return (
+    <section
+      aria-labelledby="suno-challenge-log-title"
+      className="mt-3 rounded-md border p-3 text-xs"
+      data-suno-control="challenge-log"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="font-semibold" id="suno-challenge-log-title">
+          Challenge 履歴
+        </h2>
+        <span data-suno-control="challenge-log-count">
+          {records?.length ?? 0}件
+        </span>
+      </div>
+
+      <ChallengeLogFeedback copyResult={copyResult} records={records} />
+      <ChallengeRecordList records={records} />
+
+      <button
+        className="mt-2 rounded-md border px-2 py-1 disabled:cursor-not-allowed disabled:opacity-50"
+        data-suno-control="copy-challenge-log"
+        disabled={records === null || records.length === 0}
+        onClick={() => void copyAllRecords()}
+        type="button"
+      >
+        全件を JSON でコピー
+      </button>
+    </section>
+  );
+}
 
 /**
  * Suno adapter for the shared overlay foundation. Messaging, copy and the
@@ -17,6 +175,7 @@ export function Overlay() {
     undefined
   );
   const [reloadRequired, setReloadRequired] = useState(false);
+  const [challengeLogRefreshToken, setChallengeLogRefreshToken] = useState(0);
 
   useEffect(() => {
     void (async () => {
@@ -41,7 +200,11 @@ export function Overlay() {
   }, []);
 
   const subscribeToggle = useCallback(
-    (toggle: () => void) => onMessage("toggleOverlay", toggle),
+    (toggle: () => void) =>
+      onMessage("toggleOverlay", () => {
+        toggle();
+        setChallengeLogRefreshToken((current) => current + 1);
+      }),
     []
   );
 
@@ -70,6 +233,7 @@ export function Overlay() {
       brandColors={SUNO_OVERLAY_BRAND}
     >
       <App />
+      <ChallengeLogPanel refreshToken={challengeLogRefreshToken} />
     </OverlayShell>
   );
 }

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Overlay } from "../components/Overlay";
+import type { ChallengeLogRecord } from "../lib/challenge-log";
 
 const INITIAL_STATE = {
   position: { x: 40, y: 50 },
@@ -13,13 +14,38 @@ const INITIAL_STATE = {
 };
 
 const messagingMocks = vi.hoisted(() => ({
-  onMessage: vi.fn(() => () => undefined),
+  onMessage: vi.fn((_name: string, _handler: () => void) => () => undefined),
   sendMessage: vi.fn(async () => ({ version: "0.2.5", matches: true })),
 }));
 
 const overlayStateMocks = vi.hoisted(() => ({
   readOverlayState: vi.fn(async () => INITIAL_STATE),
   writeOverlayState: vi.fn(async () => undefined),
+}));
+
+const challengeLogMocks = vi.hoisted(() => ({
+  readChallengeLog: vi.fn<() => Promise<ChallengeLogRecord[]>>(),
+  writeClipboard: vi.fn<(text: string) => Promise<void>>(),
+}));
+
+const CHALLENGE_RECORDS: ChallengeLogRecord[] = [
+  "preflight",
+  "before-create",
+  "generation-wait",
+  "before-create",
+].map((source, index) => ({
+  timestamp: 1_800_000_000_000 + index,
+  source: source as ChallengeLogRecord["source"],
+  runMode: index === 0 ? null : "serial",
+  unattended: index === 0,
+  entryIndex: index === 0 ? null : index,
+  total: index === 0 ? null : 4,
+  challengeLevel: index,
+  recentCreateCount: index,
+  runCreateCount: index,
+  lastCreateIntervalMs: index === 0 ? null : 6000,
+  appliedDelayMs: index * 15_000,
+  inflightRequestCount: index,
 }));
 
 const runner = vi.hoisted(() => ({
@@ -66,6 +92,9 @@ vi.mock("../lib/messaging", () => messagingMocks);
 vi.mock("../lib/overlay-storage", () => ({
   readOverlayState: overlayStateMocks.readOverlayState,
   writeOverlayState: overlayStateMocks.writeOverlayState,
+}));
+vi.mock("../lib/challenge-log", () => ({
+  readChallengeLog: challengeLogMocks.readChallengeLog,
 }));
 vi.mock("../lib/storage", () => ({
   downloadFormatItem: { setValue: vi.fn(async () => undefined) },
@@ -121,6 +150,14 @@ describe("Overlay shell", () => {
     messagingMocks.onMessage.mockClear();
     overlayStateMocks.readOverlayState.mockClear();
     overlayStateMocks.writeOverlayState.mockClear();
+    challengeLogMocks.readChallengeLog.mockReset();
+    challengeLogMocks.readChallengeLog.mockResolvedValue(CHALLENGE_RECORDS);
+    challengeLogMocks.writeClipboard.mockReset();
+    challengeLogMocks.writeClipboard.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: challengeLogMocks.writeClipboard },
+    });
     Object.assign(runner, {
       collections: [],
       selectedCollectionId: "",
@@ -220,6 +257,175 @@ describe("Overlay shell", () => {
       minimized: false,
       hidden: false,
     });
+  });
+
+  it("challenge履歴を総件数と直近5件で表示する", async () => {
+    const sixRecords = [
+      ...CHALLENGE_RECORDS,
+      { ...CHALLENGE_RECORDS[0], timestamp: 1_800_000_000_004 },
+      { ...CHALLENGE_RECORDS[1], timestamp: 1_800_000_000_005 },
+    ];
+    challengeLogMocks.readChallengeLog.mockResolvedValueOnce(sixRecords);
+    await rerenderOverlay();
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-suno-control="challenge-log-count"]')
+          ?.textContent
+      ).toContain("6件");
+    });
+    const records = container.querySelectorAll(
+      '[data-suno-control="challenge-log-record"]'
+    );
+
+    expect(records).toHaveLength(5);
+    expect(records[0].textContent).toContain("before-create");
+    expect(records[4].textContent).toContain("before-create");
+    expect(records[4].textContent).not.toContain("preflight");
+  });
+
+  it("toggleで開くたびにchallenge履歴を再読込し、表示とexportを更新する", async () => {
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-suno-control="challenge-log-count"]')
+          ?.textContent
+      ).toContain("4件")
+    );
+    const toggle = messagingMocks.onMessage.mock.calls.find(
+      ([name]) => name === "toggleOverlay"
+    )?.[1];
+    expect(toggle).toBeTypeOf("function");
+
+    await act(async () => toggle?.());
+
+    const tamperedRecord = {
+      ...CHALLENGE_RECORDS[0],
+      timestamp: 1_800_000_000_004,
+      source: "generation-wait" as const,
+      secret: "must-not-leak",
+    } as ChallengeLogRecord;
+    challengeLogMocks.readChallengeLog.mockResolvedValue([
+      ...CHALLENGE_RECORDS,
+      tamperedRecord,
+    ]);
+    await act(async () => toggle?.());
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-suno-control="challenge-log-count"]')
+          ?.textContent
+      ).toContain("5件")
+    );
+    expect(
+      container.querySelector('[data-suno-control="challenge-log-record"]')
+        ?.textContent
+    ).toContain("generation-wait");
+    expect(container.textContent).not.toContain("must-not-leak");
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-suno-control="copy-challenge-log"]'
+        )!
+        .click()
+    );
+    const exported = JSON.parse(
+      challengeLogMocks.writeClipboard.mock.calls[0][0]
+    ) as Array<Record<string, unknown>>;
+    expect(exported).toHaveLength(5);
+    expect(Object.keys(exported[4]).sort()).toEqual(
+      [
+        "appliedDelayMs",
+        "challengeLevel",
+        "entryIndex",
+        "inflightRequestCount",
+        "lastCreateIntervalMs",
+        "recentCreateCount",
+        "runCreateCount",
+        "runMode",
+        "source",
+        "timestamp",
+        "total",
+        "unattended",
+      ].sort()
+    );
+    expect(exported[4]).not.toHaveProperty("secret");
+  });
+
+  it("challenge履歴の全件を安全なJSONとしてclipboardへコピーする", async () => {
+    await waitFor(() =>
+      expect(
+        container.querySelector<HTMLButtonElement>(
+          '[data-suno-control="copy-challenge-log"]'
+        )?.disabled
+      ).toBe(false)
+    );
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-suno-control="copy-challenge-log"]'
+        )!
+        .click()
+    );
+
+    expect(challengeLogMocks.writeClipboard).toHaveBeenCalledOnce();
+    expect(
+      JSON.parse(challengeLogMocks.writeClipboard.mock.calls[0][0])
+    ).toEqual(CHALLENGE_RECORDS);
+    expect(
+      container.querySelector('[data-suno-control="challenge-log-status"]')
+        ?.textContent
+    ).toContain("コピーしました");
+  });
+
+  it("challenge履歴が空なら空状態を表示してcopyを無効化する", async () => {
+    challengeLogMocks.readChallengeLog.mockResolvedValueOnce([]);
+
+    await rerenderOverlay();
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-suno-control="challenge-log-status"]')
+          ?.textContent
+      ).toContain("記録はありません")
+    );
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '[data-suno-control="copy-challenge-log"]'
+      )?.disabled
+    ).toBe(true);
+    expect(container.querySelector('[data-slot="card"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-suno-helper="control-panel"]')
+    ).not.toBeNull();
+  });
+
+  it("challenge履歴のcopy失敗を通知して既存overlayを維持する", async () => {
+    challengeLogMocks.writeClipboard.mockRejectedValueOnce(
+      new Error("clipboard unavailable")
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelector<HTMLButtonElement>(
+          '[data-suno-control="copy-challenge-log"]'
+        )?.disabled
+      ).toBe(false)
+    );
+
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-suno-control="copy-challenge-log"]'
+        )!
+        .click()
+    );
+
+    expect(
+      container.querySelector('[data-suno-control="challenge-log-error"]')
+        ?.textContent
+    ).toContain("コピーできませんでした");
+    expect(container.querySelector('[data-slot="card"]')).not.toBeNull();
   });
 
   it("drag handle の pointer 操作で位置を更新し pointerup 時に永続化する", async () => {


### PR DESCRIPTION
## 概要

蓄積したchallengeレコードの件数と直近レコードをoverlayで確認し、安全な全レコードをJSONとしてクリップボードへコピーできるようにします。既存の固定長challenge-logを読み取り、manifest権限は追加しません。

Closes #2984

## 変更内容

- overlay open/toggleごとにstorageを再読込し、蓄積件数と最新5件を表示
- 全件を整形済みJSONとしてクリップボードへコピー
- storage値を12-field exact allowlist objectへ再構築し、tampered extra keyを表示/exportしない
- resolved-emptyはoverlayを壊さず0件表示、copy failureは既存alertを維持
- CHANGELOG [Unreleased] に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/suno-helper/components/Overlay.tsx
- extensions/suno-helper/tests/overlay-component.test.tsx

## 検証

- Review TDD RED: 2 failed（latest3 / toggle後stale count）
- Focused GREEN: 5 passed / 12 skipped
- overlay component full: PASS（17 tests）
- extensions/suno-helper check: PASS（182 files）
- extensions/suno-helper compile: PASS
- Fallow audit: PASS（No issues）
- git diff --check: PASS

## Stack

- base: #3438（#3435）
- current: #3439（#2984）
- parent management issue: #2563

## 権限・安全性

- manifest permission追加なし
- display/export対象は12-field exact allowlistへ再構築
- #3293関連変更なし

## チェックリスト

- [x] CHANGELOG.md::[Unreleased] にエントリを追加した
- [x] toggle reread・latest5・exact export・empty/copy failureをunit testで固定した
- [x] focused / overlay full / check / compile / Fallowを通した