### PR TITLE
feat(server-discovery): collections root表示名を返す (#2986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 無人実行中の CAPTCHA challenge を致命的な UI blocker とせず、serial / queue 共通の解消待機後に未投入 entry を重複なく再開するようにした（#2980）。
 
 - `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。
+- `feat(server-discovery)`: dir mode の `/server-info` に `planning` / `live` 相当の安全な collections root basename を追加し、absolute filesystem path を公開せず discovery registry で保持できるようにした（#2986）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -1063,6 +1063,8 @@ def create_server(
     )
     distrokid_mode = "disabled" if not distrokid_enabled else ("dir" if dir_mode else "single")
     resolved_server_info["capabilities"] = {"distrokid": {"mode": distrokid_mode}}
+    if collections_root is not None:
+        resolved_server_info["collections_root"] = collections_root.name
     resolved_community_asset_root = community_asset_root if community_asset_root is not None else collection_dir
 
     class _Handler(BaseHTTPRequestHandler):

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -475,6 +475,50 @@ def test_get_server_info_distinguishes_distrokid_capability_modes(tmp_path, dist
         thread.join(timeout=5)
 
 
+@pytest.mark.parametrize("root_name", ["planning", "live"])
+def test_dir_mode_server_info_round_trips_safe_collections_root_basename(tmp_path, root_name):
+    """Dir mode の用途ラベルを absolute path なしで registry まで保持する。"""
+    collections_root = tmp_path / "channel" / "collections" / root_name
+    collections_root.mkdir(parents=True)
+    state = RegistryState()
+    server = create_server(
+        0,
+        None,
+        prompts_path=None,
+        collection_dir=None,
+        distrokid=None,
+        collections_root=collections_root,
+        discovery_registry_state=state,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://localhost:{server.server_address[1]}"
+
+    try:
+        with urllib.request.urlopen(f"{base}{_SERVER_INFO_ROUTE}") as response:
+            server_info = json.load(response)
+
+        registration = {"instance_id": f"dir-{root_name}", "server_info": server_info}
+        request = urllib.request.Request(
+            f"{base}{DISCOVERY_PATH}",
+            data=json.dumps(registration).encode(),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request) as response:
+            assert response.status == 200
+        with urllib.request.urlopen(f"{base}{DISCOVERY_PATH}") as response:
+            registry = json.load(response)
+
+        assert server_info["collections_root"] == root_name
+        assert str(tmp_path) not in json.dumps(server_info)
+        assert registry["servers"][0]["server_info"]["collections_root"] == root_name
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 def test_post_suno_playlists_single_mode_returns_404_without_creating_legacy_json(serve, tmp_path):
     """Given single mode サーバー
     When 旧 POST /suno/playlists に送信する


### PR DESCRIPTION
## 概要

dir mode の server info に collections root の安全な basename（planning / live）を追加し、既存の loopback registry round-tripでもoptional fieldを保持します。absolute filesystem pathは返しません。

Closes #2986

## 変更内容

- dir modeだけに collections_root = Path.name を追加
- planning / liveの /server-info→registry POST/GET round-tripをcanonical testで固定
- absolute tmp pathがpayloadへ露出しないことを検証
- disabled / single modeのexact-key契約は不変
- CHANGELOG [Unreleased] に追加

## 物理パス（exact 3・canonical reorg paths）

- CHANGELOG.md
- src/youtube_automation/commands/collections/collection_serve.py
- tests/commands/collections/test_collection_serve.py

## 検証

- Focused TDD RED: 2 failed / 221 deselected（collections_root KeyError）
- Focused GREEN: 2 passed / 221 deselected
- canonical test file: PASS（223 tests）
- Ruff check: PASS
- Ruff format --check: PASS
- any-usage gate（PRE_PUSH_DIFF_BASE=#3118 head branch）: PASS
- git diff --check: PASS

## Stack / base

- external PR base: #3118（issue-2985-server-distrokid-capability）
- current: #3440（#2986）
- local gh stack trunkは#3118 head branch、stack branchは#2986のみ
- #3118をremote stackへ関連付けていない

## 安全性

- basenameのみ。absolute pathを公開しない
- discovery実装ファイル、loopback制約、既存必須fieldは変更なし
- #3293関連変更なし

## チェックリスト

- [x] CHANGELOG.md::[Unreleased] にエントリを追加した
- [x] planning / liveとregistry round-tripをcanonical testで検証した
- [x] focused / canonical / Ruff / any gateを通した