### PR TITLE
fix(server-discovery): optional capabilityを検証する (#3441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。
 - `feat(server-discovery)`: dir mode の `/server-info` に `planning` / `live` 相当の安全な collections root basename を追加し、absolute filesystem path を公開せず discovery registry で保持できるようにした（#2986）。
+- `fix(server-discovery)`: shared `ServerInfo` parser が optional な DistroKid 実行 mode と安全な collections root basename を strict に検証・保持し、存在する malformed metadata を fail-loud に拒否するようにした（#3441）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/shared/api.ts
+++ b/extensions/shared/api.ts
@@ -101,6 +101,12 @@ export interface ServerInfo {
   port: number;
   base_url: string;
   label: string;
+  capabilities?: {
+    distrokid: {
+      mode: "disabled" | "single" | "dir";
+    };
+  };
+  collections_root?: string;
 }
 
 export type Fetcher = (
@@ -238,6 +244,35 @@ function assertOptionalNullableString(
     return value;
   }
   return assertString(value, field);
+}
+
+function assertOptionalServerCapabilities(
+  record: Record<string, unknown>
+): ServerInfo["capabilities"] {
+  if (!Object.hasOwn(record, "capabilities")) return undefined;
+  const capabilities = assertObject(record.capabilities, "capabilities");
+  const distrokid = assertObject(
+    capabilities.distrokid,
+    "capabilities.distrokid"
+  );
+  const mode = distrokid.mode;
+  if (mode !== "disabled" && mode !== "single" && mode !== "dir") {
+    throw new Error(
+      "capabilities.distrokid.mode must be disabled, single, or dir"
+    );
+  }
+  return { distrokid: { mode } };
+}
+
+function assertOptionalCollectionsRoot(
+  record: Record<string, unknown>
+): string | undefined {
+  if (!Object.hasOwn(record, "collections_root")) return undefined;
+  const value = assertString(record.collections_root, "collections_root");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value)) {
+    throw new Error("collections_root must be a safe basename");
+  }
+  return value;
 }
 
 function calendarMonthLengths(year: number): number[] {
@@ -494,6 +529,8 @@ export function parseServerInfo(data: unknown): ServerInfo {
   if (port === 0) {
     throw new Error("port must be positive integer");
   }
+  const capabilities = assertOptionalServerCapabilities(record);
+  const collectionsRoot = assertOptionalCollectionsRoot(record);
   return {
     channel_name: assertString(record.channel_name, "channel_name"),
     channel_short: assertString(record.channel_short, "channel_short"),
@@ -501,6 +538,10 @@ export function parseServerInfo(data: unknown): ServerInfo {
     port,
     base_url: assertString(record.base_url, "base_url"),
     label: assertString(record.label, "label"),
+    ...(capabilities === undefined ? {} : { capabilities }),
+    ...(collectionsRoot === undefined
+      ? {}
+      : { collections_root: collectionsRoot }),
   };
 }
 

--- a/extensions/suno-helper/tests/server-discovery.test.ts
+++ b/extensions/suno-helper/tests/server-discovery.test.ts
@@ -66,6 +66,73 @@ describe("discovery schema v1", () => {
     expect(input).toEqual(before);
   });
 
+  it("should preserve strict optional server capabilities and a safe collections root", () => {
+    const legacy = serverInfo(LIVE_URL, "live");
+    const input = registry([
+      {
+        ...registryEntry(LIVE_URL, "live"),
+        server_info: {
+          ...legacy,
+          capabilities: { distrokid: { mode: "dir" } },
+          collections_root: "planning",
+          unrelated_future_field: "ignored",
+        },
+      },
+    ]);
+
+    const parsed = parseDiscoveryResponse(input);
+
+    expect(parsed.servers[0].server_info).toEqual({
+      ...legacy,
+      capabilities: { distrokid: { mode: "dir" } },
+      collections_root: "planning",
+    });
+  });
+
+  it("should preserve exact legacy omission of optional server capabilities", () => {
+    const parsed = parseDiscoveryResponse(
+      registry([registryEntry(LIVE_URL, "legacy")])
+    );
+
+    expect(parsed.servers[0].server_info).toEqual(
+      serverInfo(LIVE_URL, "legacy")
+    );
+    expect(parsed.servers[0].server_info).not.toHaveProperty("capabilities");
+    expect(parsed.servers[0].server_info).not.toHaveProperty(
+      "collections_root"
+    );
+  });
+
+  it.each([
+    { capabilities: undefined },
+    { capabilities: null },
+    { capabilities: {} },
+    { capabilities: { distrokid: null } },
+    { capabilities: { distrokid: {} } },
+    { capabilities: { distrokid: { mode: "parallel" } } },
+    { collections_root: undefined },
+    { collections_root: null },
+    { collections_root: "" },
+    { collections_root: "." },
+    { collections_root: ".." },
+    { collections_root: "/planning" },
+    { collections_root: "collections/planning" },
+    { collections_root: "collections\\planning" },
+    { collections_root: "C:planning" },
+  ])("should reject malformed present optional server metadata", (optional) => {
+    const input = registry([
+      {
+        ...registryEntry(LIVE_URL, "invalid-optional"),
+        server_info: {
+          ...serverInfo(LIVE_URL, "invalid-optional"),
+          ...optional,
+        },
+      },
+    ]);
+
+    expect(() => parseDiscoveryResponse(input)).toThrow();
+  });
+
   it.each([
     { schema_version: 2, ttl_seconds: 30, servers: [] },
     { schema_version: 1, ttl_seconds: "30", servers: [] },


### PR DESCRIPTION
## 概要

server-infoのoptional capabilityをshared ServerInfo parserでstrictに検証・保持します。capability未提供のlegacy payloadはexact shapeのまま受理します。

Closes #3441

## 変更内容

- capabilities.distrokid.modeをdisabled / single / dirのstrict enumとしてparse
- collections_rootをsafe non-empty basenameとしてparse
- optional fieldがpresentでmalformedならfail-loud（explicit undefinedを含む）
- legacy omissionとunknown unrelated field discardを維持
- CHANGELOG [Unreleased]に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/shared/api.ts
- extensions/suno-helper/tests/server-discovery.test.ts

## 検証

- Focused TDD RED: 16 failed / 1 passed
- Focused GREEN: 17 passed / 22 skipped
- suno-helper check / compile: PASS
- distrokid-helper compile: PASS
- Fallow audit: PASS
- git diff --check: PASS

## Stack

- external ancestry: #3118
- base: #3440（#2986）
- current: #3443（#3441）
- parent management issue: #2987
- #2531/#3236をimport・cross-linkしていない

## チェックリスト

- [x] CHANGELOG [Unreleased]更新
- [x] strict malformed-present / legacy omission test追加
- [x] focused / check / compile / Fallow green