### PR TITLE
feat(server-discovery): capabilityをsourceへ伝播する (#3442)

### DIFF
--- a/extensions/shared/constants.ts
+++ b/extensions/shared/constants.ts
@@ -299,6 +299,12 @@ export interface LocalServerSource {
   id: string;
   label: string;
   url: string;
+  capabilities?: {
+    distrokid: {
+      mode: "disabled" | "single" | "dir";
+    };
+  };
+  collectionsRoot?: string;
 }
 
 export type HelperProcessName = "distrokid-helper" | "suno-helper";

--- a/extensions/shared/server-discovery.ts
+++ b/extensions/shared/server-discovery.ts
@@ -161,6 +161,12 @@ async function validatedSource(
       id: serverSourceIdFromUrl(registeredUrl),
       label: info.label,
       url: registeredUrl,
+      ...(info.capabilities === undefined
+        ? {}
+        : { capabilities: info.capabilities }),
+      ...(info.collections_root === undefined
+        ? {}
+        : { collectionsRoot: info.collections_root }),
     };
   } catch {
     return undefined;

--- a/extensions/suno-helper/tests/server-discovery.test.ts
+++ b/extensions/suno-helper/tests/server-discovery.test.ts
@@ -222,6 +222,74 @@ describe("shared live server discovery", () => {
     ]);
   });
 
+  it("should propagate optional metadata from the validated probe instead of the registry", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === DISCOVERY_REGISTRY_URL) {
+        return response(
+          200,
+          registry([
+            {
+              ...registryEntry(LIVE_URL, "live"),
+              server_info: {
+                ...serverInfo(LIVE_URL, "Registry"),
+                capabilities: { distrokid: { mode: "disabled" } },
+                collections_root: "registry-root",
+              },
+            },
+          ])
+        );
+      }
+      if (url === `${LIVE_URL}/server-info`) {
+        return response(200, {
+          ...serverInfo(LIVE_URL, "Probe"),
+          capabilities: { distrokid: { mode: "dir" } },
+          collections_root: "planning",
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await expect(discoverServerSources({ fetch: fetchMock })).resolves.toEqual([
+      DEFAULT_SERVER_SOURCES[0],
+      {
+        id: "live-localhost-49152",
+        label: "Probe",
+        url: LIVE_URL,
+        capabilities: { distrokid: { mode: "dir" } },
+        collectionsRoot: "planning",
+      },
+    ]);
+  });
+
+  it("should preserve exact source shapes when optional metadata is omitted", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === DISCOVERY_REGISTRY_URL) {
+        return response(200, registry([registryEntry(LIVE_URL, "legacy")]));
+      }
+      if (url === `${LIVE_URL}/server-info`) {
+        return response(200, serverInfo(LIVE_URL, "Legacy"));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const sources = await discoverServerSources({ fetch: fetchMock });
+
+    expect(DEFAULT_SERVER_SOURCES[0]).toEqual({
+      id: "youtube-automation-localhost-7873",
+      label: "YouTube Automation (default)",
+      url: DEFAULT_URL,
+    });
+    expect(sources[1]).toEqual({
+      id: "live-localhost-49152",
+      label: "Legacy",
+      url: LIVE_URL,
+    });
+    expect(sources[1]).not.toHaveProperty("capabilities");
+    expect(sources[1]).not.toHaveProperty("collectionsRoot");
+  });
+
   it.each([
     ["HTTP failure", () => Promise.resolve(response(503, {}))],
     [


### PR DESCRIPTION
## 概要

#3441でstrict validation済みのoptional server capabilityをLocalServerSourceへ構造化伝播します。legacy probeとdefault sourceはoptional keyを追加せずexact shapeを維持します。

Closes #3442

## 変更内容

- LocalServerSourceにoptional structured capability fieldとcollectionsRootを追加
- probe済み /server-infoのvalidated値をsourceへ伝播
- registry payloadではなくprobe responseを正とする
- legacy/default sourceのid/label/url exact shapeを維持
- malformed probeは既存fail-soft境界でsourceを除外

## 物理パス（exact 3）

- extensions/shared/constants.ts
- extensions/shared/server-discovery.ts
- extensions/suno-helper/tests/server-discovery.test.ts

## CHANGELOG

- skip-changelog: user-visible contract説明は直下#3443 / #3441のUnreleased entryに集約

## 検証

- Focused TDD RED: 1 failed / 1 passed
- Focused GREEN: 2 passed / 39 skipped
- Suno: check / compile / 72 files・1366 tests PASS
- DistroKid: check / compile / 30 files・345 tests PASS
- Community: check / compile / 13 files・63 tests PASS
- Fallow audit: PASS
- git diff --check: PASS

## Stack

- external ancestry: #3118
- #3440（#2986）→ #3443（#3441）→ #3445（#3442）
- parent management issue: #2987
- #2531/#3236をimport・cross-linkしていない
- #3293関連変更なし

## チェックリスト

- [x] legacy/default exact omissionをtestで固定
- [x] validated probe metadata propagationをtestで固定
- [x] 3 extension full gates / Fallow green