### PR TITLE
fix(distrokid-helper): disabled sourceを除外する (#2988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 無人実行の起動前確認で可視 CAPTCHA challenge を検出した場合、即時に手動介入状態へ停止せず既存の CAPTCHA 解消待機経路へ入るようにした（#2979）。
 - `feat(server-discovery)`: dir mode の `/server-info` に `planning` / `live` 相当の安全な collections root basename を追加し、absolute filesystem path を公開せず discovery registry で保持できるようにした（#2986）。
 - `fix(server-discovery)`: shared `ServerInfo` parser が optional な DistroKid 実行 mode と安全な collections root basename を strict に検証・保持し、存在する malformed metadata を fail-loud に拒否するようにした（#3441）。
+- `fix(distrokid-helper)`: discovery source が DistroKid mode `disabled` を明示した場合だけ候補から除外し、legacy / `single` / `dir` source は引き続き選択できるようにした（#2988）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/distrokid-helper/components/useDistrokidRunner.ts
+++ b/extensions/distrokid-helper/components/useDistrokidRunner.ts
@@ -62,6 +62,10 @@ interface CollectionLoadResult {
   isDirMode: boolean;
 }
 
+function supportsDistrokid(source: LocalServerSource): boolean {
+  return source.capabilities?.distrokid.mode !== "disabled";
+}
+
 export function useDistrokidRunner(): DistrokidRunnerState {
   const [serverUrl, setServerUrl] = useState("");
   const serverUrlRef = useRef(serverUrl);
@@ -322,12 +326,15 @@ export function useDistrokidRunner(): DistrokidRunnerState {
     if (injectionActiveRef.current) return;
     const revision = ++serverSourcesRevisionRef.current;
     try {
-      const sources = await discoverServerSources({ fetch: backgroundFetch });
+      const discovered = await discoverServerSources({
+        fetch: backgroundFetch,
+      });
       if (
         injectionActiveRef.current ||
         revision !== serverSourcesRevisionRef.current
       )
         return;
+      const sources = discovered.filter(supportsDistrokid);
       setServerSources(sources);
       const currentServerUrl = serverUrlRef.current;
       if (
@@ -357,13 +364,14 @@ export function useDistrokidRunner(): DistrokidRunnerState {
           discoverServerSources({ fetch: backgroundFetch }),
         ])
       )
-      .then(([stored, sources]) => {
+      .then(([stored, discovered]) => {
         if (
           initialFetchStartedRef.current ||
           revision !== serverSourcesRevisionRef.current
         )
           return;
         initialFetchStartedRef.current = true;
+        const sources = discovered.filter(supportsDistrokid);
         setServerSources(sources);
         if (!stored.trim()) return;
         const nextUrl = sources.some((source) => source.url === stored)

--- a/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
+++ b/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
@@ -13,6 +13,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { LocalServerSource } from "../../shared/constants";
 import {
   useDistrokidRunner,
   type DistrokidRunnerState,
@@ -556,6 +557,86 @@ describe("useDistrokidRunner", () => {
 
     expect(current.serverSources.map(({ url }) => url)).toContain(live.url);
     expect(serverUrlItem.setValue).toHaveBeenCalledWith(live.url);
+  });
+
+  it("should filter only explicitly disabled sources during initialization and fall back from the stored URL", async () => {
+    const disabledUrl = "http://disabled.localhost:49152";
+    const legacyUrl = "http://legacy.localhost:49153";
+    await act(async () => root.unmount());
+    vi.mocked(serverUrlItem.getValue).mockResolvedValueOnce(disabledUrl);
+    discoveryMocks.discoverServerSources.mockResolvedValueOnce([
+      {
+        id: "disabled",
+        label: "Disabled",
+        url: disabledUrl,
+        capabilities: { distrokid: { mode: "disabled" } },
+      },
+      { id: "legacy", label: "Legacy", url: legacyUrl },
+    ] as LocalServerSource[]);
+    fetchMock.mockRejectedValue(new TypeError("offline"));
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          onState: (state) => {
+            current = state;
+          },
+        })
+      );
+    });
+    await waitFor(() => expect(current.serverUrl).toBe(legacyUrl));
+
+    expect(current.serverSources).toEqual([
+      { id: "legacy", label: "Legacy", url: legacyUrl },
+    ]);
+    expect(serverUrlItem.setValue).toHaveBeenCalledWith(legacyUrl);
+  });
+
+  it("should filter disabled sources on refresh while retaining legacy, single, and dir modes", async () => {
+    const disabledUrl = "http://disabled.localhost:49152";
+    const legacy = {
+      id: "legacy",
+      label: "Legacy",
+      url: "http://legacy.localhost:49153",
+    };
+    const single = {
+      id: "single",
+      label: "Single",
+      url: "http://single.localhost:49154",
+      capabilities: { distrokid: { mode: "single" as const } },
+    };
+    const dir = {
+      id: "dir",
+      label: "Dir",
+      url: "http://dir.localhost:49155",
+      capabilities: { distrokid: { mode: "dir" as const } },
+    };
+    fetchMock.mockRejectedValue(new TypeError("offline"));
+    await act(async () => {
+      current.setServerUrl(disabledUrl);
+    });
+    await waitFor(() => expect(current.busy).toBe(false));
+    vi.mocked(serverUrlItem.setValue).mockClear();
+    discoveryMocks.discoverServerSources.mockResolvedValueOnce([
+      {
+        id: "disabled",
+        label: "Disabled",
+        url: disabledUrl,
+        capabilities: { distrokid: { mode: "disabled" } },
+      },
+      legacy,
+      single,
+      dir,
+    ] as LocalServerSource[]);
+
+    await act(async () => {
+      await current.refreshServerSources();
+    });
+    await waitFor(() => expect(current.serverUrl).toBe(legacy.url));
+
+    expect(current.serverSources).toEqual([legacy, single, dir]);
+    expect(serverUrlItem.setValue).toHaveBeenCalledWith(legacy.url);
   });
 
   it("should ignore stale discovery completions", async () => {


### PR DESCRIPTION
## 概要

DistroKid capabilityがexplicit disabledのdiscovery sourceだけをselector候補から除外します。legacy capability omission、single、dir sourceは候補に残します。

Closes #2988

## 変更内容

- init/refreshの両経路で、state更新とfallback選定の前にexplicit disabledをfilter
- filtered selected/stored URLはfirst eligible sourceへdeterministic fallback
- legacy / single / dir sourceは維持
- shared selector UIやdisabled optionは変更なし
- CHANGELOG [Unreleased]に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/distrokid-helper/components/useDistrokidRunner.ts
- extensions/distrokid-helper/tests/use-distrokid-runner.test.ts

## 検証

- TDD RED init: 1 failed / 16 skipped（disabled stored URLが残る）
- GREEN init: 1 passed / 16 skipped
- GREEN refresh: 1 passed / 16 skipped
- owner test file: PASS（17 tests）
- distrokid-helper check: PASS（67 files）
- distrokid-helper compile: PASS
- Fallow audit / git diff --check: PASS
- package test 1回: 346 tests PASS、変更外overlay-entrypointの1 testのみ5秒timeout（再試行なし、CIで再確認）

## Stack

- external ancestry: #3118
- #3440 → #3443 → #3445 → #3446
- base: #3445（#3442）
- current: #3446（#2988）
- #2531/#3236をimport・cross-linkしていない
- #3293関連変更なし

## チェックリスト

- [x] explicit disabledだけをinit/refreshで除外
- [x] legacy compatibilityとfiltered selection fallbackをtestで固定
- [x] owner tests / check / compile / Fallow green