### PR TITLE
fix(distrokid-helper): source modeをlabel表示する (#2989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(server-discovery)`: dir mode の `/server-info` に `planning` / `live` 相当の安全な collections root basename を追加し、absolute filesystem path を公開せず discovery registry で保持できるようにした（#2986）。
 - `fix(server-discovery)`: shared `ServerInfo` parser が optional な DistroKid 実行 mode と安全な collections root basename を strict に検証・保持し、存在する malformed metadata を fail-loud に拒否するようにした（#3441）。
 - `fix(distrokid-helper)`: discovery source が DistroKid mode `disabled` を明示した場合だけ候補から除外し、legacy / `single` / `dir` source は引き続き選択できるようにした（#2988）。
+- `fix(distrokid-helper)`: ローカル配信元の構造化 metadata から `single` / `dir` と collections root を候補 label に表示し、同一 channel の配信元を port 以外でも識別できるようにした（#2989）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/distrokid-helper/components/ServerUrlField.tsx
+++ b/extensions/distrokid-helper/components/ServerUrlField.tsx
@@ -11,6 +11,18 @@ export type ServerUrlFieldProps = Pick<
   onOpen: () => Promise<void>;
 };
 
+function withDistrokidSourceLabel(
+  source: ServerSourceFieldProps["sources"][number]
+): ServerSourceFieldProps["sources"][number] {
+  const mode = source.capabilities?.distrokid.mode;
+  if (mode === undefined) return source;
+  const detail =
+    mode === "dir" && source.collectionsRoot
+      ? `${mode}/${source.collectionsRoot}`
+      : mode;
+  return { ...source, label: `${source.label} [${detail}]` };
+}
+
 export function ServerUrlField({
   value,
   sources,
@@ -18,11 +30,12 @@ export function ServerUrlField({
   onChange,
   onOpen,
 }: ServerUrlFieldProps) {
+  const labeledSources = sources.map(withDistrokidSourceLabel);
   return (
     <ServerSourceField
       id="server-url"
       value={value}
-      sources={sources}
+      sources={labeledSources}
       disabled={disabled}
       helper="distrokid-helper"
       onValueChange={onChange}

--- a/extensions/distrokid-helper/tests/server-source-field.test.tsx
+++ b/extensions/distrokid-helper/tests/server-source-field.test.tsx
@@ -10,6 +10,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useShadowPortalTriggerRef } from "../../shared-ui/src/use-shadow-portal-trigger-ref";
+import { ServerUrlField } from "../components/ServerUrlField";
 
 const SOURCES = [
   { id: "one", label: "One", url: "http://one.localhost:7873" },
@@ -191,5 +192,82 @@ describe("ServerSourceField and Shadow portal ref", () => {
     expect(callbackRef).toHaveBeenLastCalledWith(null);
     expect(objectRef.current).toBeNull();
     expect(setContainer).toHaveBeenLastCalledWith(null);
+  });
+
+  it("renders DistroKid mode and root from structured metadata while preserving legacy labels and URLs", async () => {
+    const onChange = vi.fn();
+    const sources = [
+      {
+        id: "single",
+        label: "Same Channel (same.localhost:49152)",
+        url: "http://same.localhost:49152",
+        capabilities: { distrokid: { mode: "single" as const } },
+      },
+      {
+        id: "planning",
+        label: "Same Channel (same.localhost:49153)",
+        url: "http://same.localhost:49153",
+        capabilities: { distrokid: { mode: "dir" as const } },
+        collectionsRoot: "planning",
+      },
+      {
+        id: "live",
+        label: "Same Channel (same.localhost:49154)",
+        url: "http://same.localhost:49154",
+        capabilities: { distrokid: { mode: "dir" as const } },
+        collectionsRoot: "live",
+      },
+      {
+        id: "legacy",
+        label: "Legacy Channel (legacy.localhost:49155)",
+        url: "http://legacy.localhost:49155",
+      },
+    ];
+    await act(async () =>
+      root.render(
+        <ServerUrlField
+          value={sources[0].url}
+          sources={sources}
+          disabled={false}
+          onChange={onChange}
+          onOpen={vi.fn(async () => undefined)}
+        />
+      )
+    );
+
+    const trigger = shadow.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.textContent).toContain(
+      "Same Channel (same.localhost:49152) [single] | distrokid-helper"
+    );
+    expect(
+      trigger
+        .closest('[data-slot="field"]')
+        ?.getAttribute("data-selected-value")
+    ).toBe(sources[0].url);
+    await act(async () => trigger.click());
+    await waitFor(() =>
+      expect(shadow.querySelectorAll('[role="option"]')).toHaveLength(4)
+    );
+    expect(
+      [...shadow.querySelectorAll('[role="option"]')].map((option) =>
+        option.textContent?.trim()
+      )
+    ).toEqual([
+      "Same Channel (same.localhost:49152) [single] | distrokid-helper",
+      "Same Channel (same.localhost:49153) [dir/planning] | distrokid-helper",
+      "Same Channel (same.localhost:49154) [dir/live] | distrokid-helper",
+      "Legacy Channel (legacy.localhost:49155) | distrokid-helper",
+    ]);
+
+    const field = shadow.querySelector<HTMLElement>('[data-slot="field"]')!;
+    await act(async () => {
+      field.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: sources[2].url,
+        })
+      );
+    });
+    expect(onChange).toHaveBeenCalledWith(sources[2].url);
   });
 });


### PR DESCRIPTION
## 概要

DistroKid対応sourceのlabelへ、structured capabilityからmodeとcollections rootを付加し、同一channel/hostname候補をport以外でも識別できるようにします。legacy labelとURL選択は維持します。

Closes #2989

## 変更内容

- structured metadataだけから [single] / [dir/planning] / [dir/live] を表示
- label文字列のparseに依存しない
- legacy capability omissionは既存label exact維持
- selectorのURL value/selectionとport troubleshooting表示を維持
- CHANGELOG [Unreleased]に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/distrokid-helper/components/ServerUrlField.tsx
- extensions/distrokid-helper/tests/server-source-field.test.tsx

## 検証

- TDD RED: 1 failed / 3 skipped
- Focused GREEN: 1 passed / 3 skipped
- owner test file: PASS（4 tests）
- distrokid-helper check（67 files）/ compile: PASS
- Fallow audit / git diff --check: PASS

## Stack

- base: #3446（#2988）
- current: #3448（#2989 runtime）
- next: #3447 docs child（PR未作成）
- external ancestry #3118、#2531/#3236 cross-linkなし
- #3293関連変更なし

## チェックリスト

- [x] single / dir planning / dir live / legacyをtest固定
- [x] URL selection/valueとlegacy labelを維持
- [x] owner/check/compile/Fallow green