### PR TITLE
fix(distrokid-helper): double 404を案内する (#2990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(server-discovery)`: shared `ServerInfo` parser が optional な DistroKid 実行 mode と安全な collections root basename を strict に検証・保持し、存在する malformed metadata を fail-loud に拒否するようにした（#3441）。
 - `fix(distrokid-helper)`: discovery source が DistroKid mode `disabled` を明示した場合だけ候補から除外し、legacy / `single` / `dir` source は引き続き選択できるようにした（#2988）。
 - `fix(distrokid-helper)`: ローカル配信元の構造化 metadata から `single` / `dir` と collections root を候補 label に表示し、同一 channel の配信元を port 以外でも識別できるようにした（#2989）。
+- `fix(distrokid-helper)`: discovery 候補が空でも保存済み URL を検証し、collections / release がともに 404 の場合は原因と対応する配信元の選択・server 再起動方法を明示するようにした（#2990）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/distrokid-helper/components/useDistrokidRunner.ts
+++ b/extensions/distrokid-helper/components/useDistrokidRunner.ts
@@ -30,7 +30,7 @@ import { discoverServerSources } from "../../shared/server-discovery";
 
 // 無効チャンネル（distrokid.enabled=false / 未配置）時のガイダンス（要件 #16）。
 const UNAVAILABLE_GUIDANCE =
-  "このチャンネルでは distrokid 連携が無効です。config/channel/distrokid.json を enabled:true にして yt-collection-serve を再起動してください。";
+  "選択したローカル配信元では /distrokid/collections と /distrokid/release.json がどちらも HTTP 404 です。このチャンネルでは distrokid 連携が無効です、または非対応のサーバーです。ローカル配信元 selector から [single] または [dir/<collectionsRoot>] の候補を選ぶか、config/channel/distrokid.json を enabled:true にして yt-collection-serve を再起動してください。";
 
 // overlay 表示 component へ渡す runner state と実行制御。
 export interface DistrokidRunnerState {
@@ -176,6 +176,7 @@ export function useDistrokidRunner(): DistrokidRunnerState {
       setMessage("");
       setPayload(null);
       payloadSourceRef.current = null;
+      let attemptedTopLevelRelease = false;
 
       try {
         const info = await fetchServerInfo(baseUrl, backgroundFetch);
@@ -261,6 +262,7 @@ export function useDistrokidRunner(): DistrokidRunnerState {
         } else {
           // 単一 mode（後方互換）: 従来の /distrokid/release.json を取得する。
           payloadSourceRef.current = null;
+          attemptedTopLevelRelease = true;
           result = await fetchRelease(baseUrl, backgroundFetch);
         }
         if (!isLatestRequest()) {
@@ -274,7 +276,7 @@ export function useDistrokidRunner(): DistrokidRunnerState {
         setPayload(null);
         setPhase(PHASES.ERROR);
         setMessage(
-          error instanceof ReleaseUnavailableError
+          error instanceof ReleaseUnavailableError && attemptedTopLevelRelease
             ? UNAVAILABLE_GUIDANCE
             : error instanceof Error
               ? error.message
@@ -376,7 +378,7 @@ export function useDistrokidRunner(): DistrokidRunnerState {
         if (!stored.trim()) return;
         const nextUrl = sources.some((source) => source.url === stored)
           ? stored
-          : sources[0]?.url;
+          : (sources[0]?.url ?? stored);
         if (!nextUrl) return;
         serverUrlRef.current = nextUrl;
         setServerUrl(nextUrl);

--- a/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
+++ b/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
@@ -327,6 +327,33 @@ describe("useDistrokidRunner", () => {
     expect(current.busy).toBe(false);
   });
 
+  it("dir mode: scoped release 404 を top-level release との二重 404 と誤案内しない", async () => {
+    const scopedReleaseUrl = `${BASE_URL}/collections/${DISC1.collection_id}/distrokid/${DISC1.disc}/release.json`;
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === `${BASE_URL}/version`) {
+        return jsonResponse(404, {});
+      }
+      if (url === `${BASE_URL}/distrokid/collections`) {
+        return jsonResponse(200, [DISC1]);
+      }
+      if (url === scopedReleaseUrl) {
+        return jsonResponse(404, {});
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await fetchDirModeRelease();
+
+    expect(current.payload).toBeNull();
+    expect(current.phase).toBe("error");
+    expect(current.message).toBe("distrokid release is unavailable (404)");
+    expect(current.message).not.toContain("どちらも HTTP 404");
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      `${BASE_URL}/distrokid/release.json`,
+      expect.anything()
+    );
+  });
+
   it("単一 mode: release が利用不可なら既存ガイダンスを表示して payload を返さない", async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (
@@ -591,6 +618,50 @@ describe("useDistrokidRunner", () => {
       { id: "legacy", label: "Legacy", url: legacyUrl },
     ]);
     expect(serverUrlItem.setValue).toHaveBeenCalledWith(legacyUrl);
+  });
+
+  it("should probe a stored URL with no eligible discovery candidates and explain a double 404", async () => {
+    const storedUrl = "http://legacy.localhost:49152";
+    await act(async () => root.unmount());
+    vi.mocked(serverUrlItem.getValue).mockResolvedValueOnce(storedUrl);
+    discoveryMocks.discoverServerSources.mockResolvedValueOnce([]);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (
+        url === `${storedUrl}/server-info` ||
+        url === `${storedUrl}/version` ||
+        url === `${storedUrl}/distrokid/collections` ||
+        url === `${storedUrl}/distrokid/release.json`
+      ) {
+        return jsonResponse(404, {});
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          onState: (state) => {
+            current = state;
+          },
+        })
+      );
+    });
+    await waitFor(() => expect(current.busy).toBe(false));
+
+    expect(current.serverSources).toEqual([]);
+    expect(current.serverUrl).toBe(storedUrl);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${storedUrl}/distrokid/collections`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${storedUrl}/distrokid/release.json`,
+      { method: "GET" }
+    );
+    expect(current.phase).toBe("error");
+    expect(current.message).toContain("どちらも HTTP 404");
+    expect(current.message).toContain("[single]");
+    expect(current.message).toContain("[dir/");
   });
 
   it("should filter disabled sources on refresh while retaining legacy, single, and dir modes", async () => {


### PR DESCRIPTION
## 概要

capability未提供の旧serverや保存済み非対応URLでcollections / top-level releaseがともに404のときだけ、原因と正しいserver起動・selector選択方法をrunner errorへ明示します。eligible candidateが空でもstored URLをprobeします。

Closes #2990

## 変更内容

- init fallbackを matched stored ? stored : sources[0]?.url ?? stored の意味に強化
- empty eligible candidatesでもstored URLをprobe
- 実際にcollections404→top-level release404を試したnon-dir fallbackだけdouble404 guidanceを表示
- supported dirのcollections200→scoped release404は実際のscoped endpoint errorを維持し、top-level releaseを呼ばない
- 既存 `distrokid 連携が無効です` wording compatibilityを維持
- CHANGELOG [Unreleased]に追加

## 物理パス（exact 3）

- CHANGELOG.md
- extensions/distrokid-helper/components/useDistrokidRunner.ts
- extensions/distrokid-helper/tests/use-distrokid-runner.test.ts

## 検証

- Review TDD RED: scoped-release 1 failed / 18 skipped（false double404 claim）
- Review GREEN: focused 1 passed / 18 skipped
- owner test file: PASS（19 tests）
- package test: PASS（30 files / 350 tests）
- distrokid-helper check（67 files）/ compile: PASS
- Fallow audit / git diff --check: PASS

## Stack

- base: #3449（#3447 docs）
- current: #3450（#2990）
- next: #3451（#2991）
- external ancestry #3118、#2531/#3236 cross-linkなし
- #3293関連変更なし

## チェックリスト

- [x] actual non-dir double404だけにguidanceを限定
- [x] dir scoped-releaseのtruthful error/no top-level callを回帰test固定
- [x] owner/package/check/compile/Fallow green