### PR TITLE
test(distrokid-helper): double 404 alertをE2E固定する (#2991)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(distrokid-helper)`: discovery source が DistroKid mode `disabled` を明示した場合だけ候補から除外し、legacy / `single` / `dir` source は引き続き選択できるようにした（#2988）。
 - `fix(distrokid-helper)`: ローカル配信元の構造化 metadata から `single` / `dir` と collections root を候補 label に表示し、同一 channel の配信元を port 以外でも識別できるようにした（#2989）。
 - `fix(distrokid-helper)`: discovery 候補が空でも保存済み URL を検証し、collections / release がともに 404 の場合は原因と対応する配信元の選択・server 再起動方法を明示するようにした（#2990）。
+- `test(distrokid-helper)`: 実拡張 Playwright fixture で保存済み legacy source の collections / release 二重 404 から復旧案内付き alert までを固定した（#2991）。
 
 - `fix(suno-helper)`: 無人実行中の可視 Turnstile も手動実行と同じ10分間 `waiting-captcha` で待機し、即時エラー終了しないように統一（#2978）。
 

--- a/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
@@ -59,6 +59,8 @@ function close(server: Server): Promise<void> {
   );
 }
 
+test.describe.configure({ mode: "serial" });
+
 test("最初の開操作では停止済み menu を開かず、検出完了後に更新済み候補を提示する", async () => {
   const liveServers: Server[] = [];
   let context: BrowserContext | undefined;
@@ -225,5 +227,109 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
     await Promise.all(
       liveServers.filter((server) => server.listening).map(close)
     );
+  }
+});
+
+test("保存済み legacy source の collections/release 404 を復旧案内付き alert にする", async () => {
+  let context: BrowserContext | undefined;
+  let registry: Server | undefined;
+  let legacyServer: Server | undefined;
+  const requestedPaths: string[] = [];
+  let legacyInfo: Record<string, unknown> = {};
+  try {
+    legacyServer = createServer((request, response) => {
+      requestedPaths.push(request.url ?? "");
+      response.setHeader("Content-Type", "application/json");
+      response.setHeader(
+        "Access-Control-Allow-Origin",
+        request.headers.origin ?? "*"
+      );
+      if (request.url === "/server-info") {
+        response.end(JSON.stringify(legacyInfo));
+        return;
+      }
+      response.statusCode = 404;
+      response.end("{}");
+    });
+    const legacyPort = await listen(legacyServer);
+    const legacyUrl = `http://127.0.0.1:${legacyPort}`;
+    legacyInfo = {
+      channel_name: "Legacy",
+      channel_short: "legacy",
+      hostname: "127.0.0.1",
+      port: legacyPort,
+      base_url: legacyUrl,
+      label: `Legacy (127.0.0.1:${legacyPort})`,
+    };
+    registry = createServer((request, response) => {
+      if (request.url !== "/.well-known/yt-collection-serve") {
+        response.statusCode = 404;
+        response.end("{}");
+        return;
+      }
+      response.setHeader("Content-Type", "application/json");
+      response.setHeader(
+        "Access-Control-Allow-Origin",
+        request.headers.origin ?? "*"
+      );
+      response.end(
+        JSON.stringify({
+          schema_version: 1,
+          ttl_seconds: 30,
+          servers: [
+            {
+              instance_id: "legacy",
+              expires_at: Date.now() / 1000 + 30,
+              server_info: legacyInfo,
+            },
+          ],
+        })
+      );
+    });
+    await listen(registry, 7872);
+
+    const profile = await mkdtemp(join(tmpdir(), "distrokid-helper-e2e-"));
+    context = await chromium.launchPersistentContext(profile, {
+      channel: "chromium",
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    let worker = context.serviceWorkers()[0];
+    worker ??= await context.waitForEvent("serviceworker");
+    expect(worker.url()).toContain("chrome-extension://");
+    await worker.evaluate(async (url) => {
+      const extensionGlobal = globalThis as typeof globalThis & {
+        chrome: {
+          storage: {
+            local: {
+              set(values: Record<string, string>): Promise<void>;
+            };
+          };
+        };
+      };
+      await extensionGlobal.chrome.storage.local.set({ serverUrl: url });
+    }, legacyUrl);
+    await context.route("https://distrokid.com/new", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>DistroKid fixture</title>",
+      })
+    );
+    const page = await context.newPage();
+    await page.goto("https://distrokid.com/new");
+
+    const alert = page.getByRole("alert");
+    await expect(alert).toContainText("どちらも HTTP 404");
+    await expect(alert).toContainText(/\[single\]|\[dir\//u);
+    expect(requestedPaths).toContain("/distrokid/collections");
+    expect(requestedPaths).toContain("/distrokid/release.json");
+  } finally {
+    await context?.close();
+    if (registry?.listening) await close(registry);
+    if (legacyServer?.listening) await close(legacyServer);
   }
 });


### PR DESCRIPTION
## 概要

実拡張を読み込むPlaywright fixtureで、legacy/unsupported stored serverのcollections 404→release 404→overlay alertまでを固定します。既存server-source-refresh E2Eも同じspecで維持します。

Closes #2991

## 変更内容

- real extension service workerのchrome.storage.localへstored serverUrlをseed
- loopback registry/live legacy server fixtureを構築
- /distrokid/collectionsと/distrokid/release.jsonの両404を観測
- role=alertに原因＋selector/start guidanceが表示されることを検証
- 既存refresh contractを同じowner specで維持
- CHANGELOG [Unreleased]に追加

## 物理パス（exact 2）

- CHANGELOG.md
- extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts

## TDD / 検証

- RED direct macOS headful: 1 failed（alert `Failed to fetch`、stored URL未seed）
- GREEN focused: 1 passed
- owner Playwright spec: PASS（2 tests、既存refresh含む）
- distrokid-helper check（67 files）/ compile / build: PASS
- Fallow audit / git diff --check: PASS
- canonical xvfb wrapperはmacOSに`xvfb-run`がなくexit127。同等のheadful Playwrightを直接実行してgreen、CI Linuxでcanonical gateを再確認

## Stack

- base: #3450（#2990）
- current: #3451（#2991）
- external ancestry #3118、別contract #3238をimport/cross-linkしていない
- #3293関連変更なし

## チェックリスト

- [x] real extension double404→alertをE2E固定
- [x] existing refresh E2Eを維持
- [x] check/compile/build/Fallow green