### PR TITLE
fix(extensions): 稼働確認済み配信元だけ返す (#2992)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: stale な有効公開履歴 cache の再取得が想定内エラーで失敗した場合、前回データを維持した構造化 error payload を保存して channel 更新を継続するようにした。有効 cache が無い場合は従来の refresh error 経路へ伝播する（#3384）。
 - `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。
 - `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。
+- `fix(extensions)`: ローカル配信元 discovery は registry entry のうち稼働確認できたサーバーだけを URL 順で返し、registry が空・到達不能・不正、または全 probe 失敗の場合は未確認の既定候補を混ぜず空配列を返すようにした（#2992）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。
 - `refactor(tests)`: domains / application / configuration 層と同名衝突分のテストを production module の鏡像配置へ移し、repository contract は `tests/repo/`、infrastructure の裁定分は各鏡像へ配置した。active consumer の参照を canonical path に追従させ、複数テストが同一 production module に対応する場合の共存規則と root 残置理由を配置規約へ記録した（#3046）。

--- a/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
@@ -204,6 +204,7 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
 
     active = newServer;
     delayNextResponse = true;
+    releaseFails = true;
     await trigger.click();
     await expect(trigger).toBeDisabled();
     await expect(sourceField).toHaveAttribute(
@@ -214,17 +215,13 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
 
     await expect(trigger).toBeEnabled();
     const options = page.getByRole("option");
-    await expect(options).toHaveText([
-      "YouTube Automation | distrokid-helper",
-      "New (Channel) | distrokid-helper",
-    ]);
+    await expect(options).toHaveText(["New (Channel) | distrokid-helper"]);
     await expect(options.filter({ hasText: "Old" })).toHaveCount(0);
     expect(
       await options
         .first()
         .evaluate((option) => option.getRootNode() instanceof ShadowRoot)
     ).toBe(true);
-
     releaseFails = true;
     await page
       .getByRole("option", {

--- a/extensions/shared/server-discovery.ts
+++ b/extensions/shared/server-discovery.ts
@@ -1,6 +1,5 @@
 import { parseServerInfo, type ServerInfo } from "./api";
 import {
-  DEFAULT_SERVER_SOURCES,
   DISCOVERY_REGISTRY_URL,
   DISCOVERY_REQUEST_TIMEOUT_MS,
   DISCOVERY_SCHEMA_VERSION,
@@ -183,28 +182,21 @@ export async function discoverServerSources(
       fetcher,
       DISCOVERY_REGISTRY_URL
     );
-    if (!response.ok) return [...DEFAULT_SERVER_SOURCES];
+    if (!response.ok) return [];
     const registry = parseDiscoveryResponse(body);
     const probed = await Promise.all(
       registry.servers.map((entry) => validatedSource(fetcher, entry))
     );
-    const byUrl = new Map(
-      DEFAULT_SERVER_SOURCES.map((source) => [
-        normalizeServerUrl(source.url),
-        source,
-      ])
-    );
+    const byUrl = new Map<string, LocalServerSource>();
     for (const source of probed.filter(
       (source): source is LocalServerSource => source !== undefined
     )) {
       byUrl.set(source.url, source);
     }
-    const [defaultSource, ...dynamic] = [...byUrl.values()];
-    return [
-      defaultSource,
-      ...dynamic.sort((left, right) => left.url.localeCompare(right.url)),
-    ];
+    return [...byUrl.values()].sort((left, right) =>
+      left.url.localeCompare(right.url)
+    );
   } catch {
-    return [...DEFAULT_SERVER_SOURCES];
+    return [];
   }
 }

--- a/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
@@ -117,13 +117,11 @@ test("実ビルドした overlay は drag・最小化・automation selector 契�
     const panel = content.locator(
       ':scope > [data-suno-helper="control-panel"]'
     );
-    // 実拡張はローカル配信元が無い fixture では fail-loud に error 状態へ遷移する。
-    await expect(panel).toHaveAttribute("data-suno-phase", "error");
+    // 配信元 0 件の専用表示は #2993 が担う。この段では未確認候補を選ばず idle を保つ。
+    await expect(panel).toHaveAttribute("data-suno-phase", "idle");
     await expect(panel).toHaveAttribute("data-suno-running", "false");
-    await expect(panel).toHaveAttribute("data-suno-error", "true");
-    const status = panel.getByRole("status");
-    await expect(status).toHaveAttribute("aria-live", "polite");
-    await expect(status).toHaveAttribute("data-suno-status", "error");
+    await expect(panel).toHaveAttribute("data-suno-error", "false");
+    await expect(panel.getByRole("status")).toHaveCount(0);
 
     const collectionsTrigger = panel.locator(
       '[data-suno-control="collections-collapsible-trigger"]'

--- a/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
@@ -116,7 +116,7 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
     await page.goto("https://suno.com/create");
     const trigger = page.locator('[data-suno-control="server-source-trigger"]');
     const sourceField = page.locator('[data-suno-control="server-url"]');
-    await expect(trigger).toHaveText("YouTube Automation | suno-helper");
+    await expect(trigger).toHaveText("Old (Archive) | suno-helper");
     await expect(sourceField).toHaveAttribute(
       "data-source-values",
       new RegExp(String(oldServer.info.base_url))
@@ -133,10 +133,7 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
 
     await expect(trigger).toBeEnabled();
     const options = page.getByRole("option");
-    await expect(options).toHaveText([
-      "YouTube Automation | suno-helper",
-      "New (Channel) | suno-helper",
-    ]);
+    await expect(options).toHaveText(["New (Channel) | suno-helper"]);
     await expect(options.filter({ hasText: "Old" })).toHaveCount(0);
     expect(
       await options

--- a/extensions/suno-helper/tests/server-discovery.test.ts
+++ b/extensions/suno-helper/tests/server-discovery.test.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  DEFAULT_SERVER_SOURCES,
   DISCOVERY_REGISTRY_URL,
   DISCOVERY_REQUEST_TIMEOUT_MS,
 } from "../../shared/constants";
@@ -173,15 +172,6 @@ describe("shared live server discovery", () => {
     vi.useRealTimers();
   });
 
-  it("should expose a structured channel name on the permanent default source", () => {
-    expect(DEFAULT_SERVER_SOURCES[0]).toEqual({
-      id: "youtube-automation-localhost-7873",
-      channelName: "YouTube Automation",
-      label: "YouTube Automation (default)",
-      url: DEFAULT_URL,
-    });
-  });
-
   it("should preserve the probed channel name independently from the legacy label", async () => {
     const fetchMock = vi.fn((input: string | URL | Request) => {
       const url = String(input);
@@ -207,7 +197,7 @@ describe("shared live server discovery", () => {
 
     const sources = await discoverServerSources({ fetch: fetchMock });
 
-    expect(sources[1]).toEqual({
+    expect(sources[0]).toEqual({
       id: "live-localhost-49152",
       channelName: "Ambient (Night)",
       label: "Ambient (Night) (live.localhost:49152)",
@@ -252,8 +242,8 @@ describe("shared live server discovery", () => {
     const sources = await discoverServerSources({ fetch: fetchMock });
 
     expect(sources.map(({ url }: { url: string }) => url)).toEqual([
-      DEFAULT_URL,
       LIVE_URL,
+      DEFAULT_URL,
     ]);
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
       DISCOVERY_REGISTRY_URL,
@@ -293,7 +283,6 @@ describe("shared live server discovery", () => {
     });
 
     await expect(discoverServerSources({ fetch: fetchMock })).resolves.toEqual([
-      DEFAULT_SERVER_SOURCES[0],
       {
         id: "live-localhost-49152",
         channelName: "Probe",
@@ -319,20 +308,14 @@ describe("shared live server discovery", () => {
 
     const sources = await discoverServerSources({ fetch: fetchMock });
 
-    expect(DEFAULT_SERVER_SOURCES[0]).toEqual({
-      id: "youtube-automation-localhost-7873",
-      channelName: "YouTube Automation",
-      label: "YouTube Automation (default)",
-      url: DEFAULT_URL,
-    });
-    expect(sources[1]).toEqual({
+    expect(sources[0]).toEqual({
       id: "live-localhost-49152",
       channelName: "Legacy",
       label: "Legacy",
       url: LIVE_URL,
     });
-    expect(sources[1]).not.toHaveProperty("capabilities");
-    expect(sources[1]).not.toHaveProperty("collectionsRoot");
+    expect(sources[0]).not.toHaveProperty("capabilities");
+    expect(sources[0]).not.toHaveProperty("collectionsRoot");
   });
 
   it.each([
@@ -346,18 +329,27 @@ describe("shared live server discovery", () => {
       () => Promise.resolve(response(200, { schema_version: 1, servers: {} })),
     ],
   ])(
-    "should return only the permanent default after a registry %s",
+    "should return no sources after a registry %s",
     async (_label, registryFetch) => {
       const fetchMock = vi.fn(registryFetch);
 
       await expect(
         discoverServerSources({ fetch: fetchMock })
-      ).resolves.toEqual(DEFAULT_SERVER_SOURCES);
+      ).resolves.toEqual([]);
       expect(fetchMock).toHaveBeenCalledOnce();
     }
   );
 
-  it("should fall back without probing when the registry exceeds its entry limit", async () => {
+  it("should return no sources without probing when the registry is empty", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(response(200, registry([]))));
+
+    await expect(discoverServerSources({ fetch: fetchMock })).resolves.toEqual(
+      []
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("should return no sources without probing when the registry exceeds its entry limit", async () => {
     const fetchMock = vi.fn(() =>
       Promise.resolve(
         response(
@@ -372,7 +364,7 @@ describe("shared live server discovery", () => {
     );
 
     await expect(discoverServerSources({ fetch: fetchMock })).resolves.toEqual(
-      DEFAULT_SERVER_SOURCES
+      []
     );
     expect(fetchMock).toHaveBeenCalledOnce();
   });
@@ -412,7 +404,6 @@ describe("shared live server discovery", () => {
     resolveFirst(response(200, serverInfo(firstUrl, "Alpha")));
 
     await expect(pending).resolves.toEqual([
-      DEFAULT_SERVER_SOURCES[0],
       expect.objectContaining({ url: firstUrl }),
       expect.objectContaining({ url: secondUrl }),
     ]);
@@ -455,7 +446,7 @@ describe("shared live server discovery", () => {
     const pending = discoverServerSources({ fetch: fetchMock });
     await vi.advanceTimersByTimeAsync(DISCOVERY_REQUEST_TIMEOUT_MS);
 
-    await expect(pending).resolves.toEqual(DEFAULT_SERVER_SOURCES);
+    await expect(pending).resolves.toEqual([]);
     expect(signals).toHaveLength(1);
     expect(signals[0].aborted).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
@@ -480,7 +471,7 @@ describe("shared live server discovery", () => {
 
     const pending = discoverServerSources({ fetch: fetchMock });
     await vi.advanceTimersByTimeAsync(DISCOVERY_REQUEST_TIMEOUT_MS);
-    await expect(pending).resolves.toEqual(DEFAULT_SERVER_SOURCES);
+    await expect(pending).resolves.toEqual([]);
 
     expect(registrySignal?.aborted).toBe(true);
     resolveRegistry(response(200, registry([registryEntry(LIVE_URL, "late")])));
@@ -506,7 +497,7 @@ describe("shared live server discovery", () => {
     const pending = discoverServerSources({ fetch: fetchMock });
     await vi.advanceTimersByTimeAsync(DISCOVERY_REQUEST_TIMEOUT_MS);
 
-    await expect(pending).resolves.toEqual(DEFAULT_SERVER_SOURCES);
+    await expect(pending).resolves.toEqual([]);
     expect(signal?.aborted).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
   });


### PR DESCRIPTION
## Summary
- discovery registry の未確認 default 候補を戻り値へ混ぜない
- probe 成功した配信元だけを重複排除し、URL 順で返す
- 空・到達不能・不正 registry と全 probe 失敗を空配列として回帰テストする
- Suno / DistroKid の実ブラウザ契約を、確認済み live 候補だけを表示する挙動へ同期する

## Atomic scope rationale
共有 discovery の戻り値変更だけでは、lower PR 自身の Suno / DistroKid E2E が未確認 default を期待して構造的に red になる。上段の #2993 は各 PR base ごとの CI を修復できないため、直接影響する E2E 3ファイルを同じ変更に含める。候補 0 件の disabled 空状態 UI は実装せず、#2993 の責務として残す。

## Validation
- focused Vitest: `server-discovery.test.ts` (23 passed)
- Suno: `check`, `compile`, `test` (1,342 passed), `build`
- Suno focused Playwright (2 passed), full Playwright (15 passed)
- DistroKid: `check`, `compile`, `test` (344 passed), `build`
- DistroKid focused Playwright (1 passed), full Playwright (8 passed)
- Community: `check`, `compile`, `test` (63 passed)
- Fallow audit: 0 changed-file issues (1 inherited complexity finding excluded by baseline)
- `git diff --check`

Closes #2992