### PR TITLE
feat(extensions): 配信元 selector の空状態を実装する (#3453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: stale な有効公開履歴 cache の再取得が想定内エラーで失敗した場合、前回データを維持した構造化 error payload を保存して channel 更新を継続するようにした。有効 cache が無い場合は従来の refresh error 経路へ伝播する（#3384）。
 - `feat(dashboard)`: stale を含む schema-valid な公開履歴 cache を鮮度判定と独立して読み出し、前回の `days` / `fetched_at` / `timezone` を維持したまま `code` / `message` / `attempted_at` の構造化更新エラーを付与できるようにした（#3383）。
 - `feat(dashboard)`: 公開履歴 cache が fresh な場合は通常の Analytics snapshot 更新だけを行い、公開履歴用の追加 YouTube Data API 呼び出しと cache 保存を省略するようにした。cache が missing / stale / corrupt の場合は従来どおり再取得・保存する（#3375）。
+- `feat(extensions)`: ローカル配信元が 0 件の selector に「サーバーが起動されていません」と表示して操作を無効化し、候補の再出現時は通常の選択へ戻るようにした（#3453）。
 - `fix(extensions)`: ローカル配信元 discovery は registry entry のうち稼働確認できたサーバーだけを URL 順で返し、registry が空・到達不能・不正、または全 probe 失敗の場合は未確認の既定候補を混ぜず空配列を返すようにした（#2992）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
 
+import {
+  SERVER_SOURCE_SELECT_EVENT,
+  ServerSourceField,
+} from "@youtube-automation/ui";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -269,6 +273,108 @@ describe("DistroKid popup compatibility check", () => {
     container.remove();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it("should show a disabled empty source state and reject every selection entry point", async () => {
+    const onRefresh = vi.fn(async () => undefined);
+    const onValueChange = vi.fn();
+    await act(async () => {
+      root.render(
+        createElement(ServerSourceField, {
+          id: "server-url",
+          value: "",
+          sources: [],
+          disabled: false,
+          helper: "distrokid-helper",
+          onRefresh,
+          onValueChange,
+        })
+      );
+    });
+    const trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    const field = container.querySelector<HTMLElement>('[data-slot="field"]')!;
+
+    await act(async () => {
+      trigger.click();
+      field.dispatchEvent(
+        new CustomEvent(SERVER_SOURCE_SELECT_EVENT, {
+          bubbles: true,
+          detail: BASE_URL,
+        })
+      );
+    });
+
+    expect(trigger.textContent).toBe("サーバーが起動されていません");
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("should close on an empty transition, prioritize refreshing, and re-enable when a source returns", async () => {
+    const source = { id: "live", label: "Live", url: BASE_URL };
+    const pendingRefresh = deferred<void>();
+    const onRefresh = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockReturnValueOnce(pendingRefresh.promise);
+    const onValueChange = vi.fn();
+    const renderField = async (
+      sources: Array<{ id: string; label: string; url: string }>
+    ): Promise<void> => {
+      await act(async () => {
+        root.render(
+          createElement(ServerSourceField, {
+            id: "server-url",
+            value: source.url,
+            sources,
+            disabled: false,
+            helper: "distrokid-helper",
+            onRefresh,
+            onValueChange,
+          })
+        );
+      });
+    };
+
+    await renderField([source]);
+    let trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    await act(async () => trigger.click());
+    await waitFor(() =>
+      expect(container.querySelector('[role="listbox"]')).not.toBeNull()
+    );
+
+    await renderField([]);
+    trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    await waitFor(() =>
+      expect(container.querySelector('[role="listbox"]')).toBeNull()
+    );
+
+    await renderField([source]);
+    trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.disabled).toBe(false);
+    await act(async () => trigger.click());
+    expect(trigger.textContent).toBe("稼働中の配信元を更新中…");
+
+    await renderField([]);
+    trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.textContent).toBe("稼働中の配信元を更新中…");
+    await act(async () => {
+      pendingRefresh.resolve(undefined);
+      await pendingRefresh.promise;
+    });
+    await waitFor(() =>
+      expect(trigger.textContent).toBe("サーバーが起動されていません")
+    );
+
+    await renderField([source]);
+    trigger = container.querySelector<HTMLButtonElement>("#server-url")!;
+    expect(trigger.disabled).toBe(false);
+    expect(trigger.textContent).toBe("Live | distrokid-helper");
+    expect(trigger.dataset.selectedValue).toBe(source.url);
   });
 
   it("ローカル配信元の option と選択済み trigger は channelName だけを表示する", async () => {
@@ -1033,11 +1139,14 @@ describe("DistroKid popup compatibility check", () => {
     await renderApp();
     const select = container.querySelector<HTMLButtonElement>("#server-url")!;
     await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>('button[aria-haspopup="listbox"]')!
-        .click();
       initialDiscovery.resolve([defaultSource, restoredSource]);
       await initialDiscovery.promise;
+    });
+    await waitFor(() =>
+      expect(select.dataset.selectedValue).toBe(restoredSource.url)
+    );
+    await act(async () => {
+      select.click();
     });
 
     await waitFor(() =>

--- a/extensions/shared-ui/src/server-source-field.tsx
+++ b/extensions/shared-ui/src/server-source-field.tsx
@@ -34,6 +34,18 @@ export interface ServerSourceFieldProps {
 export const SERVER_SOURCE_SELECT_EVENT =
   "youtube-automation:server-source-select";
 
+function ServerSourceValue({
+  refreshing,
+  hasSources,
+}: {
+  refreshing: boolean;
+  hasSources: boolean;
+}) {
+  if (refreshing) return <span>稼働中の配信元を更新中…</span>;
+  if (!hasSources) return <span>サーバーが起動されていません</span>;
+  return <SelectValue />;
+}
+
 export function ServerSourceField({
   value,
   sources,
@@ -51,20 +63,22 @@ export function ServerSourceField({
   const [open, setOpen] = React.useState(false);
   const [refreshing, setRefreshing] = React.useState(false);
   const refreshingRef = React.useRef(false);
-  const disabledRef = React.useRef(disabled);
+  const hasSources = sources.length > 0;
+  const interactionDisabled = disabled || !hasSources;
+  const interactionDisabledRef = React.useRef(interactionDisabled);
+  interactionDisabledRef.current = interactionDisabled;
   React.useEffect(() => {
-    disabledRef.current = disabled;
-    if (disabled) {
+    if (interactionDisabled) {
       setOpen(false);
     }
-  }, [disabled]);
+  }, [interactionDisabled]);
 
   const handleOpenChange = (nextOpen: boolean): void => {
     if (!nextOpen) {
       setOpen(false);
       return;
     }
-    if (disabledRef.current || refreshingRef.current) {
+    if (interactionDisabledRef.current || refreshingRef.current) {
       return;
     }
     setOpen(false);
@@ -75,7 +89,7 @@ export function ServerSourceField({
       .finally(() => {
         refreshingRef.current = false;
         setRefreshing(false);
-        if (!disabledRef.current) {
+        if (!interactionDisabledRef.current) {
           setOpen(true);
         }
       });
@@ -88,7 +102,7 @@ export function ServerSourceField({
   const { className: fieldClassName, ...restFieldProps } = fieldProps ?? {};
   const { className: triggerClassName, ...restTriggerProps } =
     triggerProps ?? {};
-  const selectedValue = value || sources[0]?.url || "";
+  const selectedValue = hasSources ? value || sources[0]?.url || "" : "";
   const committedValueRef = React.useRef(selectedValue);
   React.useEffect(() => {
     committedValueRef.current = selectedValue;
@@ -98,7 +112,7 @@ export function ServerSourceField({
       if (
         nextValue &&
         nextValue !== committedValueRef.current &&
-        !disabledRef.current &&
+        !interactionDisabledRef.current &&
         !refreshingRef.current
       ) {
         committedValueRef.current = nextValue;
@@ -128,7 +142,7 @@ export function ServerSourceField({
   return (
     <Field
       ref={fieldRef}
-      data-disabled={disabled || refreshing}
+      data-disabled={interactionDisabled || refreshing}
       data-selected-value={selectedValue}
       data-source-values={sources.map((source) => source.url).join(" ")}
       className={cn("gap-1", fieldClassName)}
@@ -140,7 +154,7 @@ export function ServerSourceField({
         items={items}
         value={selectedValue}
         open={open}
-        disabled={disabled || refreshing}
+        disabled={interactionDisabled || refreshing}
         onOpenChange={handleOpenChange}
         onValueChange={(nextValue) => nextValue && commitValue(nextValue)}
       >
@@ -151,17 +165,19 @@ export function ServerSourceField({
           {...restTriggerProps}
           {...triggerDataAttributes}
         >
-          {refreshing ? <span>稼働中の配信元を更新中…</span> : <SelectValue />}
+          <ServerSourceValue refreshing={refreshing} hasSources={hasSources} />
         </SelectTrigger>
-        <SelectContent alignItemWithTrigger={false}>
-          <SelectGroup>
-            {sources.map((source) => (
-              <SelectItem key={source.url} value={source.url}>
-                {formatServerSourceLabel(source, helper)}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
+        {hasSources && (
+          <SelectContent alignItemWithTrigger={false}>
+            <SelectGroup>
+              {sources.map((source) => (
+                <SelectItem key={source.url} value={source.url}>
+                  {formatServerSourceLabel(source, helper)}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        )}
       </Select>
     </Field>
   );

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -4126,7 +4126,7 @@ describe("Suno popup compatibility check", () => {
     );
   });
 
-  it("should replace a restored URL removed by discovery during an early selector refresh", async () => {
+  it("should keep a restored live URL when the empty selector rejects an early refresh", async () => {
     await act(async () => root.unmount());
     container.innerHTML = "";
     root = createRoot(container);
@@ -4151,7 +4151,7 @@ describe("Suno popup compatibility check", () => {
           discoveryCount += 1;
           return discoveryCount === 1
             ? initialDiscovery.promise
-            : Promise.resolve([defaultSource]);
+            : Promise.resolve([defaultSource, restoredSource]);
         }
         return defaultSendMessage(message, payload);
       }
@@ -4159,10 +4159,14 @@ describe("Suno popup compatibility check", () => {
 
     await act(async () => root.render(createElement(App)));
     const select = expectControl(container, "server-url");
+    const trigger = expectControl(
+      container,
+      "server-source-trigger"
+    ) as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.textContent).toBe("サーバーが起動されていません");
     await act(async () => {
-      (
-        expectControl(container, "server-source-trigger") as HTMLButtonElement
-      ).click();
+      trigger.click();
       initialDiscovery.resolve([defaultSource, restoredSource]);
       await initialDiscovery.promise;
     });
@@ -4170,11 +4174,13 @@ describe("Suno popup compatibility check", () => {
     await waitFor(() =>
       expect(messagingMocks.sendMessage).toHaveBeenCalledWith(
         "fetchCollections",
-        { baseUrl: defaultSource.url }
+        { baseUrl: restoredSource.url }
       )
     );
-    expect(select.dataset.selectedValue).toBe(defaultSource.url);
-    expect(discoveryCount).toBe(2);
+    expect(select.dataset.selectedValue).toBe(restoredSource.url);
+    expect(select.dataset.sourceValues).toContain(restoredSource.url);
+    expect(trigger.disabled).toBe(false);
+    expect(discoveryCount).toBe(1);
   });
 
   it.each([
@@ -4292,40 +4298,67 @@ describe("Suno popup compatibility check", () => {
   it("should suppress a second discovery while the first refresh is pending", async () => {
     const pending =
       deferred<Array<{ id: string; label: string; url: string }>>();
+    const liveSource = {
+      id: "live",
+      label: "Live",
+      url: "http://live.localhost:49152",
+    };
     let refreshCount = 0;
     messagingMocks.sendMessage.mockImplementation(
       (message: string, payload?: Record<string, string>) => {
         if (message === "discoverServerSources") {
           refreshCount += 1;
           if (refreshCount === 1) {
-            return Promise.resolve([]);
+            return Promise.resolve([liveSource]);
           }
-          return pending.promise;
+          if (refreshCount === 2) return pending.promise;
+          return Promise.resolve([liveSource]);
         }
         return defaultSendMessage(message, payload);
       }
     );
     await rerenderApp();
     const select = expectControl(container, "server-url");
+    const trigger = expectControl(
+      container,
+      "server-source-trigger"
+    ) as HTMLButtonElement;
+    await waitFor(() =>
+      expect(select.dataset.sourceValues).toBe(liveSource.url)
+    );
+    expect(trigger.disabled).toBe(false);
     await act(async () => {
-      const trigger = expectControl(
-        container,
-        "server-source-trigger"
-      ) as HTMLButtonElement;
       trigger.click();
       trigger.click();
       await Promise.resolve();
     });
     expect(refreshCount).toBe(2);
-    pending.resolve([
-      { id: "new", label: "New", url: "http://new.localhost:49152" },
-    ]);
+    expect(trigger.disabled).toBe(true);
+    pending.resolve([]);
     await waitFor(() =>
-      expect(select.dataset.sourceValues).toContain(
-        "http://new.localhost:49152"
+      expect(trigger.textContent).toBe("サーバーが起動されていません")
+    );
+    expect(trigger.disabled).toBe(true);
+    expect(select.dataset.sourceValues).toBe("");
+
+    await act(async () => {
+      trigger.click();
+      await Promise.resolve();
+    });
+    expect(refreshCount).toBe(2);
+
+    await rerenderApp();
+    const reenabledTrigger = expectControl(
+      container,
+      "server-source-trigger"
+    ) as HTMLButtonElement;
+    await waitFor(() =>
+      expect(expectControl(container, "server-url").dataset.sourceValues).toBe(
+        liveSource.url
       )
     );
-    expect(refreshCount).toBe(2);
+    expect(reenabledTrigger.disabled).toBe(false);
+    expect(refreshCount).toBe(3);
   });
 
   it("should discard a deferred discovery result when a run starts", async () => {


### PR DESCRIPTION
## Summary
- 候補 0 件の `ServerSourceField` を exact empty text と disabled trigger で表示する
- open / refresh / select / programmatic selection / `onValueChange` を遮断し、open menu は empty 遷移時に閉じる
- refreshing 表示を優先し、候補再出現時は selector を再有効化する
- shared field の owner contract を DistroKid / Suno 双方の Vitest で固定する

## Atomic scope rationale
shared-ui runtime は両 helper が直接利用するため、DistroKid owner test だけでは lower PR の Suno unit CI が旧 empty-click 前提で構造的に red になる。上段の E2E PR は lower PR base の unit CI を修復できないため、Suno popup compatibility を直接 owner regression として同じ runtime 段に含める。

## Validation
- focused owner Vitest: DistroKid 21 passed; Suno 対象 2 passed
- Suno `check` / `compile` / full `test` (1,342 passed) / `build`
- DistroKid `check` / `compile` / full `test` (346 passed) / `build`
- Fallow audit: changed-file issues 0
- `git diff --check`

Closes #3453