### PR TITLE
test(extensions): 配信元の空状態を実拡張で検証する (#3454)

### DIFF
--- a/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/distrokid-helper/tests/e2e/server-source-refresh.spec.ts
@@ -8,6 +8,7 @@ import { expect, test, chromium, type BrowserContext } from "@playwright/test";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const extensionPath = join(here, "..", "..", ".output", "chrome-mv3");
+test.describe.configure({ mode: "serial" });
 const releasePayload = {
   profile: {
     artist: "Midnight Echoes",
@@ -58,8 +59,6 @@ function close(server: Server): Promise<void> {
     server.close((error) => (error ? reject(error) : resolve()))
   );
 }
-
-test.describe.configure({ mode: "serial" });
 
 test("最初の開操作では停止済み menu を開かず、検出完了後に更新済み候補を提示する", async () => {
   const liveServers: Server[] = [];
@@ -230,6 +229,11 @@ test("最初の開操作では停止済み menu を開かず、検出完了後�
       })
       .click();
     await expect(trigger).toHaveText("New (Channel) | distrokid-helper");
+    await expect(sourceField).toHaveAttribute(
+      "data-source-values",
+      new RegExp(newServer.url)
+    );
+    await expect(trigger).toHaveAttribute("data-selected-value", newServer.url);
     await expect(page.getByRole("alert")).toHaveText(/HTTP 500/);
   } finally {
     await context?.close();
@@ -341,5 +345,74 @@ test("保存済み legacy source の collections/release 404 を復旧案内付�
     await context?.close();
     if (registry?.listening) await close(registry);
     if (legacyServer?.listening) await close(legacyServer);
+  }
+});
+
+test("配信元候補が空なら操作不能な専用表示を保つ", async () => {
+  let registryRequestCount = 0;
+  let context: BrowserContext | undefined;
+  let registry: Server | undefined;
+  try {
+    registry = createServer((request, response) => {
+      if (request.url !== "/.well-known/yt-collection-serve") {
+        response.statusCode = 404;
+        response.end("{}");
+        return;
+      }
+      registryRequestCount += 1;
+      response.setHeader("Content-Type", "application/json");
+      response.setHeader(
+        "Access-Control-Allow-Origin",
+        request.headers.origin ?? "*"
+      );
+      response.end(
+        JSON.stringify({ schema_version: 1, ttl_seconds: 30, servers: [] })
+      );
+    });
+    await listen(registry, 7872);
+
+    const profile = await mkdtemp(
+      join(tmpdir(), "distrokid-helper-e2e-empty-")
+    );
+    context = await chromium.launchPersistentContext(profile, {
+      channel: "chromium",
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    let worker = context.serviceWorkers()[0];
+    worker ??= await context.waitForEvent("serviceworker");
+    expect(worker.url()).toContain("chrome-extension://");
+    await context.route("https://distrokid.com/new", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>DistroKid fixture</title>",
+      })
+    );
+    const page = await context.newPage();
+    await page.goto("https://distrokid.com/new");
+
+    const trigger = page.locator("#server-url");
+    const sourceField = page.locator("[data-source-values]");
+    await expect(trigger).toHaveText("サーバーが起動されていません");
+    await expect(trigger).toBeDisabled();
+    await expect(sourceField).toHaveAttribute("data-source-values", "");
+    await expect(sourceField).toHaveAttribute("data-selected-value", "");
+
+    const settledRequestCount = registryRequestCount;
+    await trigger.click({ force: true });
+    await sourceField.dispatchEvent("youtube-automation:server-source-select", {
+      bubbles: true,
+      detail: "http://127.0.0.1:65534",
+    });
+    await expect(page.getByRole("listbox")).toHaveCount(0);
+    await expect(sourceField).toHaveAttribute("data-selected-value", "");
+    await expect.poll(() => registryRequestCount).toBe(settledRequestCount);
+  } finally {
+    await context?.close();
+    if (registry?.listening) await close(registry);
   }
 });

--- a/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
@@ -117,7 +117,14 @@ test("実ビルドした overlay は drag・最小化・automation selector 契�
     const panel = content.locator(
       ':scope > [data-suno-helper="control-panel"]'
     );
-    // 配信元 0 件の専用表示は #2993 が担う。この段では未確認候補を選ばず idle を保つ。
+    const sourceTrigger = panel.locator(
+      '[data-suno-control="server-source-trigger"]'
+    );
+    const sourceField = panel.locator('[data-suno-control="server-url"]');
+    await expect(sourceTrigger).toHaveText("サーバーが起動されていません");
+    await expect(sourceTrigger).toBeDisabled();
+    await expect(sourceField).toHaveAttribute("data-source-values", "");
+    await expect(sourceField).toHaveAttribute("data-selected-value", "");
     await expect(panel).toHaveAttribute("data-suno-phase", "idle");
     await expect(panel).toHaveAttribute("data-suno-running", "false");
     await expect(panel).toHaveAttribute("data-suno-error", "false");

--- a/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
@@ -8,6 +8,7 @@ import { expect, test, chromium, type BrowserContext } from "@playwright/test";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const extensionPath = join(here, "..", "..", ".output", "chrome-mv3");
+test.describe.configure({ mode: "serial" });
 
 function listen(server: Server, port = 0): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -148,6 +149,10 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
       .click();
     await expect(trigger).toHaveText("New (Channel) | suno-helper");
     await expect(sourceField).toHaveAttribute(
+      "data-source-values",
+      new RegExp(String(newServer.info.base_url))
+    );
+    await expect(trigger).toHaveAttribute(
       "data-selected-value",
       String(newServer.info.base_url)
     );
@@ -157,5 +162,68 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
     await Promise.all(
       liveServers.filter((server) => server.listening).map(close)
     );
+  }
+});
+
+test("配信元候補が空なら操作不能な専用表示を保つ", async () => {
+  let registryRequestCount = 0;
+  let context: BrowserContext | undefined;
+  let registry: Server | undefined;
+  try {
+    registry = createServer((request, response) => {
+      if (request.url !== "/.well-known/yt-collection-serve") {
+        response.statusCode = 404;
+        response.end("{}");
+        return;
+      }
+      registryRequestCount += 1;
+      response.setHeader("Content-Type", "application/json");
+      response.end(
+        JSON.stringify({ schema_version: 1, ttl_seconds: 30, servers: [] })
+      );
+    });
+    await listen(registry, 7872);
+
+    const profile = await mkdtemp(join(tmpdir(), "suno-helper-e2e-empty-"));
+    context = await chromium.launchPersistentContext(profile, {
+      channel: "chromium",
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    let worker = context.serviceWorkers()[0];
+    worker ??= await context.waitForEvent("serviceworker");
+    expect(worker.url()).toContain("chrome-extension://");
+    await context.route("https://suno.com/create", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>Suno fixture</title>",
+      })
+    );
+    const page = await context.newPage();
+    await page.goto("https://suno.com/create");
+
+    const trigger = page.locator('[data-suno-control="server-source-trigger"]');
+    const sourceField = page.locator('[data-suno-control="server-url"]');
+    await expect(trigger).toHaveText("サーバーが起動されていません");
+    await expect(trigger).toBeDisabled();
+    await expect(sourceField).toHaveAttribute("data-source-values", "");
+    await expect(sourceField).toHaveAttribute("data-selected-value", "");
+
+    const settledRequestCount = registryRequestCount;
+    await trigger.click({ force: true });
+    await sourceField.dispatchEvent("youtube-automation:server-source-select", {
+      bubbles: true,
+      detail: "http://127.0.0.1:65534",
+    });
+    await expect(page.getByRole("listbox")).toHaveCount(0);
+    await expect(sourceField).toHaveAttribute("data-selected-value", "");
+    await expect.poll(() => registryRequestCount).toBe(settledRequestCount);
+  } finally {
+    await context?.close();
+    if (registry?.listening) await close(registry);
   }
 });


### PR DESCRIPTION
## Summary
- Suno / DistroKid の live candidate refresh と URL value 契約を維持する
- 候補 0 件では exact text `サーバーが起動されていません` と disabled trigger を実拡張で観測する
- empty 状態で click / programmatic selection / storage 更新が起きないことを E2E で固定する

## Validation
- Suno focused Playwright: 3 passed
- DistroKid focused Playwright: 2 passed
- Suno full Playwright: 16 passed
- DistroKid full Playwright: 9 passed
- Suno `check` / `compile` / `test` (1,342 passed) / `build`
- DistroKid `check` / `compile` / `test` (346 passed) / `build`
- Fallow audit: changed-file issues 0
- `git diff --check`

Closes #3454