### PR TITLE
fix(streaming): 再起動を実態ベースで検知する (#3458)

### DIFF
--- a/.claude/skills/streaming/references/healthcheck.sh
+++ b/.claude/skills/streaming/references/healthcheck.sh
@@ -3,7 +3,7 @@
 #
 # 4-way 分類:
 #   ok      : active+running           （配信中、Result は問わない）
-#   idle    : activating+auto-restart+success （stream_hours > 0 の RuntimeMaxSec 到達後の計画休止）
+#   idle    : activating+auto-restart+success かつ有限 RuntimeMaxUSec（計画休止）
 #   manual  : inactive+dead+success    （systemctl stop）
 #   anomaly : 上記以外                 （kill -9 / failed / Result≠success など）
 #
@@ -20,12 +20,13 @@ set -euo pipefail
 # にあるため、cron セーフなパスを末尾に append しておく（既存 PATH が空でも動く）。
 export PATH="${PATH:+${PATH}:}/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# systemctl show の 3 値を ok / idle / manual / anomaly のいずれかに分類する純関数。
+# systemctl show の状態と RuntimeMaxUSec を ok / idle / manual / anomaly に分類する純関数。
 # stdout に分類名を 1 行 echo するだけ。
 classify_status() {
   local active="$1"
   local sub="$2"
   local result="$3"
+  local runtime_max_usec="${4:-}"
 
   if [[ "$active" == "active" && "$sub" == "running" ]]; then
     echo "ok"
@@ -33,7 +34,12 @@ classify_status() {
   fi
 
   if [[ "$active" == "activating" && "$sub" == "auto-restart" && "$result" == "success" ]]; then
-    echo "idle"
+    if [[ -n "$runtime_max_usec" && "$runtime_max_usec" != "infinity" && "$runtime_max_usec" != "0" ]]; then
+      echo "idle"
+    else
+      # 24/7 配信には計画休止がないため、auto-restart 待ちは異常。
+      echo "anomaly"
+    fi
     return
   fi
 
@@ -47,19 +53,23 @@ classify_status() {
 }
 
 # stdin の `KEY=VALUE` 行（systemctl show -p ... 出力）を読み、
-# ActiveState/SubState/Result を呼び出し元 scope の active/sub/result 変数にセットする。
+# 監視対象 property を呼び出し元 scope の変数にセットする。
 # `systemctl show ... --value` は property 引数順序を保証しないため `KEY=VALUE` 形式で
 # パースする（順序非依存）。process substitution `< <(...)` で呼ぶ前提。
 parse_systemctl_kv() {
   active=""
   sub=""
   result=""
+  runtime_max_usec=""
+  n_restarts=""
   local line
   while IFS= read -r line; do
     case "$line" in
       ActiveState=*) active="${line#*=}" ;;
       SubState=*)    sub="${line#*=}" ;;
       Result=*)      result="${line#*=}" ;;
+      RuntimeMaxUSec=*) runtime_max_usec="${line#*=}" ;;
+      NRestarts=*)      n_restarts="${line#*=}" ;;
     esac
   done
 }
@@ -107,17 +117,45 @@ readonly UNIT="youtube-stream"
 # STATE_DIR は本番では /var/lib/youtube-stream 固定。テスト時のみ YT_STREAM_STATE_DIR で override。
 readonly STATE_DIR="${YT_STREAM_STATE_DIR:-/var/lib/youtube-stream}"
 readonly LAST_STATUS_FILE="${STATE_DIR}/last_status"
+readonly LAST_N_RESTARTS_FILE="${STATE_DIR}/last_n_restarts"
 
 mkdir -p "$STATE_DIR"
 
 # 順序非依存パース（KEY=VALUE 形式）。process substitution で親 scope に変数を反映させる。
-parse_systemctl_kv < <(systemctl show "$UNIT" -p ActiveState -p SubState -p Result)
+parse_systemctl_kv < <(
+  systemctl show "$UNIT" \
+    -p ActiveState \
+    -p SubState \
+    -p Result \
+    -p RuntimeMaxUSec \
+    -p NRestarts
+)
 
-status="$(classify_status "$active" "$sub" "$result")"
+status="$(classify_status "$active" "$sub" "$result" "$runtime_max_usec")"
+
+# NRestarts は配信が次の観測までに active へ復帰しても再起動を検知できる。
+# 初回・破損 baseline・counter reset は通知せず、現在値へ rebaseline する。
+prev_n_restarts="$(cat "$LAST_N_RESTARTS_FILE" 2>/dev/null || true)"
+restart_notified=false
+if [[ "$n_restarts" =~ ^[0-9]+$ ]]; then
+  if [[ "$status" != "idle" && "$prev_n_restarts" =~ ^[0-9]+$ ]] && ((n_restarts > prev_n_restarts)); then
+    restart_delta=$((n_restarts - prev_n_restarts))
+    restart_msg="[youtube-stream] restart detected: NRestarts=${n_restarts} previous=${prev_n_restarts} increment=${restart_delta}"
+    logger -t youtube-stream-healthcheck -- "$restart_msg" || true
+    "$(dirname "$0")/notify.sh" "$restart_msg"
+    restart_notified=true
+  fi
+  printf '%s\n' "$n_restarts" > "$LAST_N_RESTARTS_FILE"
+fi
 
 # 初回・破損時は unknown フォールバック（decide_notification の遷移表に従う）
 prev="$(cat "$LAST_STATUS_FILE" 2>/dev/null || echo unknown)"
 action="$(decide_notification "$prev" "$status")"
+
+# 同じ cron 観測で再起動増加も検知した場合、状態遷移との二重通知を避ける。
+if [[ "$restart_notified" == true ]]; then
+  action=""
+fi
 
 case "$action" in
   anomaly)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。
 - `fix(thumbnail-compare)`: ベンチマーク更新・サムネイル取得・縮小の進捗を即時表示し、画像取得を slow-drip を含む wall-clock deadline、ffmpeg を有限 timeout にした。個別対象の timeout 後も警告して成功分の比較出力を継続する（#3229）。
 - `fix(auth)`: readonly OAuth handler に明示的な非対話 policy を追加し、`token.readonly.json` が未発行・不正・refresh 不能な場合は browser OAuth を開始せず、`uv run yt-oauth --readonly` による発行を案内して fail-fast するようにした（#2956）。
+- `fix(streaming)`: `RuntimeMaxUSec` が無制限の 24/7 配信では `activating/auto-restart` を異常として通知し、有限サイクルの計画休止だけを無音にした。`NRestarts` の増加も cron 観測ごとに一度だけ通知し、初回・破損 baseline・counter reset は無音で再同期する（#3458）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/tests/test_streaming_healthcheck.py
+++ b/tests/test_streaming_healthcheck.py
@@ -124,14 +124,19 @@ def _run_bash(
     )
 
 
-def _classify(active: str, sub: str, result: str) -> tuple[int, str, str]:
+def _classify(
+    active: str,
+    sub: str,
+    result: str,
+    runtime_max_usec: str = "infinity",
+) -> tuple[int, str, str]:
     """healthcheck.sh を source して ``classify_status`` を呼び、(returncode, stdout, stderr) を返す。
 
     bash 関数の単体テスト用 fixture。stdout のトリム済み文字列を分類結果として比較する。
     """
     if not _HEALTHCHECK_SH.exists():
         pytest.fail(f"healthcheck.sh が存在しない: {_HEALTHCHECK_SH}")
-    snippet = f'source "{_HEALTHCHECK_SH}" && classify_status "{active}" "{sub}" "{result}"'
+    snippet = f'source "{_HEALTHCHECK_SH}" && classify_status "{active}" "{sub}" "{result}" "{runtime_max_usec}"'
     proc = _run_bash(snippet)
     return proc.returncode, proc.stdout.strip(), proc.stderr
 
@@ -214,9 +219,19 @@ class TestHealthcheckShClassifyStatus:
 
         order.md「5 分間隔 × 1 時間の休止 = 12 回ぶん抑止」要件。
         """
-        rc, out, _ = _classify("activating", "auto-restart", "success")
+        rc, out, _ = _classify("activating", "auto-restart", "success", "39600000000")
         assert rc == 0
         assert out == "idle", f"activating+auto-restart+success の分類が idle でない: {out!r}"
+
+    @pytest.mark.parametrize("runtime_max_usec", ["infinity", "0"])
+    def test_24_7_auto_restart_classifies_as_anomaly(self, runtime_max_usec: str):
+        """Given RuntimeMaxUSec が無制限の 24/7 配信
+        When activating+auto-restart+success を観測する
+        Then 計画休止ではないため anomaly を出力する。
+        """
+        rc, out, _ = _classify("activating", "auto-restart", "success", runtime_max_usec)
+        assert rc == 0
+        assert out == "anomaly"
 
     def test_activating_auto_restart_with_signal_classifies_as_anomaly(self):
         """Given kill -9 直後の自動再起動待ち (activating+auto-restart+signal)
@@ -304,10 +319,12 @@ class TestHealthcheckShBehavior:
         fake_systemctl = bin_dir / "systemctl"
         fake_systemctl.write_text(
             "#!/usr/bin/env bash\n"
-            "# 偽 systemctl: -p ActiveState -p SubState -p Result のとき KEY=VALUE で 3 行出力\n"
+            "# 偽 systemctl: 監視対象 property を KEY=VALUE で出力\n"
             'echo "ActiveState=${FAKE_ACTIVE:-active}"\n'
             'echo "SubState=${FAKE_SUB:-running}"\n'
             'echo "Result=${FAKE_RESULT:-success}"\n'
+            'echo "RuntimeMaxUSec=${FAKE_RUNTIME_MAX_USEC:-infinity}"\n'
+            'echo "NRestarts=${FAKE_N_RESTARTS:-0}"\n'
         )
         fake_systemctl.chmod(0o755)
 
@@ -335,6 +352,8 @@ class TestHealthcheckShBehavior:
         active: str,
         sub: str,
         result: str,
+        runtime_max_usec: str = "infinity",
+        n_restarts: str = "0",
     ) -> subprocess.CompletedProcess:
         """偽 systemd 状態を環境変数で渡して healthcheck.sh を実行する。"""
         env = os.environ.copy()
@@ -343,6 +362,8 @@ class TestHealthcheckShBehavior:
         env["FAKE_ACTIVE"] = active
         env["FAKE_SUB"] = sub
         env["FAKE_RESULT"] = result
+        env["FAKE_RUNTIME_MAX_USEC"] = runtime_max_usec
+        env["FAKE_N_RESTARTS"] = n_restarts
         # last_status を tmp に閉じ込める（本番では /var/lib/youtube-stream/last_status）
         env["YT_STREAM_STATE_DIR"] = str(fake_env["state_dir"])
         return subprocess.run(
@@ -369,11 +390,94 @@ class TestHealthcheckShBehavior:
 
         order.md「5 分 × 12 回抑止」要件の core test。
         """
-        proc = self._run_with_state(fake_env, active="activating", sub="auto-restart", result="success")
+        proc = self._run_with_state(
+            fake_env,
+            active="activating",
+            sub="auto-restart",
+            result="success",
+            runtime_max_usec="39600000000",
+        )
         assert proc.returncode == 0, f"healthcheck.sh が non-zero: {proc.stderr}"
         assert not fake_env["called_marker"].exists(), (
             "1h 休止中（idle）で notify.sh が呼ばれた（5 分間隔で誤検知が 12 回飛ぶ）"
         )
+
+    @pytest.mark.parametrize("runtime_max_usec", ["infinity", "0"])
+    def test_24_7_auto_restart_calls_notify(self, fake_env, runtime_max_usec: str):
+        """24/7 配信の auto-restart 待ちは計画休止ではなく異常として通知する。"""
+        proc = self._run_with_state(
+            fake_env,
+            active="activating",
+            sub="auto-restart",
+            result="success",
+            runtime_max_usec=runtime_max_usec,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert fake_env["called_marker"].exists()
+
+    def test_restart_counter_increment_notifies_only_once(self, fake_env):
+        """NRestarts の増加は初回観測時だけ通知し、同じ値の再観測では連打しない。"""
+        first = self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="4")
+        assert first.returncode == 0, first.stderr
+        assert not fake_env["called_marker"].exists()
+
+        second = self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="5")
+        assert second.returncode == 0, second.stderr
+        calls_after_increment = fake_env["called_marker"].read_text().splitlines()
+        assert len(calls_after_increment) == 1
+        assert "NRestarts=5" in calls_after_increment[0]
+
+        third = self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="5")
+        assert third.returncode == 0, third.stderr
+        assert fake_env["called_marker"].read_text().splitlines() == calls_after_increment
+
+    def test_restart_increment_and_anomaly_share_one_notification(self, fake_env):
+        """再起動増加と anomaly 遷移を同時観測しても notify は一度だけ呼ぶ。"""
+        self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="0")
+        proc = self._run_with_state(
+            fake_env,
+            active="activating",
+            sub="auto-restart",
+            result="success",
+            runtime_max_usec="infinity",
+            n_restarts="1",
+        )
+        assert proc.returncode == 0, proc.stderr
+        calls = fake_env["called_marker"].read_text().splitlines()
+        assert len(calls) == 1
+        assert "NRestarts=1" in calls[0]
+
+    def test_planned_finite_idle_restart_rebaselines_without_notification(self, fake_env):
+        """11h+1h の計画 restart は counter を進めるが通知しない。"""
+        self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="0")
+
+        planned_idle = {
+            "active": "activating",
+            "sub": "auto-restart",
+            "result": "success",
+            "runtime_max_usec": "39600000000",
+            "n_restarts": "1",
+        }
+        first = self._run_with_state(fake_env, **planned_idle)
+        second = self._run_with_state(fake_env, **planned_idle)
+
+        assert first.returncode == 0, first.stderr
+        assert second.returncode == 0, second.stderr
+        assert not fake_env["called_marker"].exists()
+        assert (fake_env["state_dir"] / "last_n_restarts").read_text() == "1\n"
+
+    @pytest.mark.parametrize("baseline", [None, "broken\n", "8\n"])
+    def test_restart_counter_invalid_baseline_or_decrease_rebaselines_silently(self, fake_env, baseline):
+        """baseline 不在・破損・counter 減少は通知せず現在値へ rebaseline する。"""
+        baseline_file = fake_env["state_dir"] / "last_n_restarts"
+        if baseline is not None:
+            fake_env["state_dir"].mkdir(parents=True)
+            baseline_file.write_text(baseline)
+
+        proc = self._run_with_state(fake_env, active="active", sub="running", result="success", n_restarts="3")
+        assert proc.returncode == 0, proc.stderr
+        assert not fake_env["called_marker"].exists()
+        assert baseline_file.read_text() == "3\n"
 
     def test_manual_state_does_not_call_notify(self, fake_env):
         """Given inactive+dead+success（systemctl stop）
@@ -500,6 +604,19 @@ class TestHealthcheckShOrderIndependentParse:
         assert "active=active" in out, f"active が正しく束ねられていない: {out!r}"
         assert "sub=running" in out, f"sub が正しく束ねられていない: {out!r}"
         assert "result=success" in out, f"result が正しく束ねられていない: {out!r}"
+
+    def test_parses_runtime_and_restart_properties(self):
+        """RuntimeMaxUSec と NRestarts も行順に依存せず取得する。"""
+        snippet = (
+            f'source "{_HEALTHCHECK_SH}"\n'
+            "parse_systemctl_kv <<EOF\n"
+            "NRestarts=7\nResult=success\nRuntimeMaxUSec=39600000000\n"
+            "SubState=running\nActiveState=active\nEOF\n"
+            'echo "$runtime_max_usec:$n_restarts"\n'
+        )
+        proc = _run_bash(snippet)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip() == "39600000000:7"
 
 
 class TestHealthcheckShStateChange:


### PR DESCRIPTION
## Summary

- `RuntimeMaxUSec` で 24/7 と有限サイクルを判別し、24/7 の auto-restart を anomaly として扱う
- `NRestarts` の増分を永続化した baseline と比較し、短時間のクラッシュ復帰も 1 回だけ通知する
- baseline 不在・破損・カウンタ減少は無音で再基準化し、11h+1h の計画休止を維持する

## Verification

- `uv run pytest tests/test_streaming_healthcheck.py` (110 passed)
- `bash -n .claude/skills/streaming/references/healthcheck.sh`
- `uv run ruff check tests/test_streaming_healthcheck.py`
- `uv run ruff format --check tests/test_streaming_healthcheck.py`
- `git diff --check main...HEAD`

## References

- [systemd.service](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html)
- [systemd.unit](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html)

Closes #3458
