### PR TITLE
feat(streaming): webhook 未設定の復旧案内を出力する (#3460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(suno-helper)`: unattended preflight・Create 直前・生成完了待ち中の challenge 検知を共通記録経路へ接続し、検知箇所と run・pacing・inflight の実行コンテキストを区別して蓄積するようにした（#3435）。
 - `feat(suno-helper)`: overlay で蓄積済み challenge 履歴の総件数と直近 5 件を確認し、安全な全レコードを JSON として clipboard へコピーできるようにした（#2984）。
 
+- `feat(streaming)`: Terraform apply 完了時、healthcheck の Discord webhook が空または空白だけなら、1Password からの export コマンドと再 apply 手順を非機密 output で警告する。設定済みの場合は警告を表示せず、未設定でも明示的に空値を渡した apply は従来どおり完走する（#3460）。
 - `docs(adr)`: ADR-0024「クラウド移譲アーキテクチャの原則」を追加した。cloud/local 境界を能力ベースの規則 1 本（ブラウザ工程のみ local）で定義し、状態正本の Git 管理移行・工程所有権による分散ロック排除・二重チェック + fail-closed の冪等性・R2 の境界越え受け渡し専用化・マニフェスト = 完了マーカーの受け渡し規約・pull → run → push のサンドイッチ実行モデルを確定した。あわせて architecture の用語集へ「クラウド移譲」節（制御面 / データ面・工程所有権・サンドイッチ実行モデル・受け渡しマニフェスト・MediaStore）を追加した（#3299）。
 - `feat(thumbnail-compare)`: 公開済み live に加えて planning 中コレクションの確定済み `10-assets/thumbnail.jpg` を比較へ収集する。同一実体を重複させず、planning 出力名を stage・collection 単位で分離して既存 live 成果物との衝突を防ぐ（#3230）。
 - `feat(wf-new-batch)`: batch ledger の許可遷移・単一 active plan・current plan 整合性と atomic 保存を実行時に検証し、child が prepared + hard artifacts 完了後に ledger 更新前 crash した場合は same-provenance actual state から workflow-state を変更せず completed へ reconcile できる state helper を追加した。Done 再検証で artifact / provenance drift を検知した completed plan は、reason と resume_action を伴う guarded transition だけ blocked へ戻せる（#3279）。

--- a/infra/terraform/streaming/outputs.tf
+++ b/infra/terraform/streaming/outputs.tf
@@ -7,3 +7,13 @@ output "instance_id" {
   description = "Vultr インスタンス ID（destroy / 個別操作時の識別子）"
   value       = vultr_instance.this.id
 }
+
+output "discord_webhook_setup_warning" {
+  description = "Discord webhook が未設定の場合だけ apply 完了時に表示する復旧案内"
+  sensitive   = false
+  value = nonsensitive(trimspace(var.discord_webhook_url) == "") ? join("\n", [
+    "WARNING: healthcheck の Discord webhook が未設定です。",
+    "export TF_VAR_discord_webhook_url=\"$(op read 'op://Personal/YouTube_Stream_Discord_Webhook/url')\"",
+    "設定後に terraform apply を再実行してください。",
+  ]) : null
+}

--- a/tests/repo/streaming/test_terraform_meta.py
+++ b/tests/repo/streaming/test_terraform_meta.py
@@ -22,6 +22,7 @@ from tests.repo.streaming._helpers import (
     _ROOT_GITIGNORE,
     _TFSTATE_BACKEND_PREFIX,
     _TFVARS_EXAMPLE,
+    _VARIABLES_TF,
     _VERSIONS_TF,
 )
 
@@ -217,7 +218,13 @@ class TestVersionsTfExternalProvider:
 
 
 class TestOutputsTf:
-    """``outputs.tf`` の instance_ip / instance_id expose。"""
+    """``outputs.tf`` の apply 完了時 output。"""
+
+    _WEBHOOK_WARNING = "WARNING: healthcheck の Discord webhook が未設定です。"
+    _WEBHOOK_EXPORT = (
+        "export TF_VAR_discord_webhook_url=\\\"$(op read 'op://Personal/YouTube_Stream_Discord_Webhook/url')\\\""
+    )
+    _WEBHOOK_REAPPLY = "設定後に terraform apply を再実行してください。"
 
     def test_instance_ip_outputs_main_ip_with_description(self):
         """Given outputs.tf
@@ -244,6 +251,60 @@ class TestOutputsTf:
             "instance_id.value が vultr_instance.this.id でない"
         )
         assert re.search(r"description\s*=", block), "instance_id.description が無い"
+
+    def test_webhook_warning_outputs_actionable_recovery_steps(self):
+        """Given webhook warning output
+        When apply 完了時の案内を読む
+        Then 未設定警告・1Password export・再 apply 手順を正確に表示する。
+        """
+        text = read_file(_OUTPUTS_TF)
+        block = extract_block(text, r'output\s+"discord_webhook_setup_warning"')
+
+        assert block is not None, 'output "discord_webhook_setup_warning" が存在しない'
+        assert self._WEBHOOK_WARNING in block
+        assert self._WEBHOOK_EXPORT in block
+        assert self._WEBHOOK_REAPPLY in block
+
+    def test_webhook_warning_treats_empty_and_whitespace_as_unconfigured(self):
+        """Given sensitive webhook input
+        When warning 条件を読む
+        Then trim 後の空判定だけを非機密化し、設定済みなら null を返す。
+        """
+        text = read_file(_OUTPUTS_TF)
+        block = extract_block(text, r'output\s+"discord_webhook_setup_warning"')
+
+        assert block is not None
+        assert re.search(
+            r"nonsensitive\(\s*trimspace\(var\.discord_webhook_url\)\s*==\s*\"\"\s*\)",
+            block,
+        )
+        assert re.search(r":\s*null\s*$", block, flags=re.MULTILINE)
+
+    def test_webhook_warning_does_not_expose_or_fingerprint_secret(self):
+        """Given webhook warning output
+        When secret の参照方法を検査する
+        Then URL 値・hash・sensitive output を公開しない。
+        """
+        text = read_file(_OUTPUTS_TF)
+        block = extract_block(text, r'output\s+"discord_webhook_setup_warning"')
+
+        assert block is not None
+        assert block.count("var.discord_webhook_url") == 1
+        assert not re.search(r"\b(?:sha\d*|md5)\s*\(", block, flags=re.IGNORECASE)
+        assert not re.search(r"https?://", block, flags=re.IGNORECASE)
+        assert re.search(r"sensitive\s*=\s*false", block)
+
+    def test_webhook_remains_required_but_accepts_explicit_empty_value(self):
+        """Given discord_webhook_url variable
+        When 入力制約を読む
+        Then 欠落は fail-fast のまま、明示的な空値は validation で拒否しない。
+        """
+        text = strip_hcl_comments(read_file(_VARIABLES_TF))
+        block = extract_block(text, r'variable\s+"discord_webhook_url"')
+
+        assert block is not None
+        assert not re.search(r"\bdefault\s*=", block)
+        assert extract_block(block, r"validation") is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Discord webhook が空または空白だけの場合に限り、apply 完了時の非機密 output へ警告を表示する
- 1Password からの export コマンドと再 apply 手順を案内し、設定済みの場合は `null` を返す
- URL 値や fingerprint を公開せず、既存の required input 契約と明示的な空値 apply を維持する

## Verification

- `nix develop --command uv run pytest tests/repo/streaming/test_terraform_meta.py -q` (38 passed)
- `nix develop --command uv run pytest tests/repo/streaming -q` (252 passed)
- `nix develop --command terraform -chdir=infra/terraform/streaming fmt -check -diff`
- `nix develop --command terraform -chdir=infra/terraform/streaming validate`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check tests/repo/streaming/test_terraform_meta.py`
- `git diff --check`
- Full `pytest -n auto`: 7437 passed / 1 skipped; unrelated thumbnail font fixture could not find DejaVu Sans (56 setup errors, 2 related failures)

## References

- https://developer.hashicorp.com/terraform/language/block/output
- https://developer.hashicorp.com/terraform/language/manage-sensitive-data

Closes #3460