### PR TITLE
docs(streaming): 再起動検知の運用手順を更新する (#3459)

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -131,9 +131,14 @@ healthcheck は systemd 状態を 4 通りに分類し、**真の異常のみ通
 | 状態 | 分類 | 通知 |
 |---|---|---|
 | `active+running` | ok | しない |
-| `activating+auto-restart+success` | idle（`stream_hours > 0` の計画休止） | しない |
+| `activating+auto-restart+success` + 有限 `RuntimeMaxUSec` | idle（11h+1h の計画休止） | しない |
+| `activating+auto-restart+success` + `RuntimeMaxUSec=infinity` / `0` | anomaly（24/7 に計画休止はない） | **送る** |
 | `inactive+dead+success` | manual（運用者の `systemctl stop`）| しない |
 | `failed` / `Result≠success` | anomaly | **送る** |
+
+さらに `NRestarts` を `/var/lib/youtube-stream/last_n_restarts` と比較する。増加を観測した cron では restart 通知を 1 通だけ送り、同じ観測の状態遷移通知とは重複させない。baseline 不在・非数値への破損・counter 減少（service 再作成など）は異常扱いせず、現在値へ無音で再基準化する。
+
+24/7 の実機 SIGKILL 確認は配信を切断する破壊的操作であり、VPS への接続と実行には利用者の明示的承認が必要。本 issue の文書更新では実行していない。承認後は healthcheck を一度実行して `NRestarts` baseline を作り、対象を限定した SIGKILL 後の次回 cron で `restart detected` が 1 通だけ届くことを確認する。11h+1h は有限 `RuntimeMaxUSec` の計画休止をまたいで通知が 0 通であることを確認する。
 
 帯域モニタリング cron 例（ローカル or CI）:
 
@@ -160,7 +165,7 @@ healthcheck は systemd 状態を 4 通りに分類し、**真の異常のみ通
 
 ```bash
 INSTANCE_IP=$(terraform -chdir=infra/terraform/streaming output -raw instance_ip)
-ssh -i ~/.ssh/yt_stream_key root@$INSTANCE_IP "systemctl show youtube-stream | grep -E 'ActiveState|SubState|Result|RuntimeMaxUSec|RestartUSec'"
+ssh -i ~/.ssh/yt_stream_key root@$INSTANCE_IP "systemctl show youtube-stream | grep -E 'ActiveState|SubState|Result|RuntimeMaxUSec|RestartUSec|NRestarts'"
 ```
 
 ## 障害時ガイダンス
@@ -186,7 +191,7 @@ VPS が消えるまで課金が続くため、**長期休止する場合は必�
 
 - **`terraform.tfvars` に secret を書く** → 必ず `TF_VAR_*` 環境変数経由。`*.tfvars` / `*.tfstate*` は gitignore 済みだが、コミット時に二重チェック
 - **配信中に動画差し替え** → 数秒の中断あり。`stream_hours > 0` の計画休止がある運用で視聴者ダウンタイム 0 を狙うなら休止時間まで待つ
-- **`activating (auto-restart)` を異常と誤認** → これは `stream_hours > 0` の正常な計画休止状態。healthcheck は idle 分類で通知しない
+- **`activating (auto-restart)` を常に計画休止とみなす** → 有限 `RuntimeMaxUSec` の 11h+1h 運用だけが idle。`infinity` / `0` の 24/7 運用では anomaly
 - **同じ動画で再 apply して心配する** → `filemd5` 不変なら no-op で安全。空打ち可能
 - **24/7 運用で `yt-stream-archive-check` を使う** → 日次アーカイブ不足判定の対象外。`stream_hours=11` / `break_hours=1` 運用で `--expected 2` を付けて使う
 - **`yt-stream-archive-check --expected 2` で 0 件** → YouTube Data API のキャッシュ遅延。`publishedAt` が UTC 基準であることに注意

--- a/docs/streaming-healthcheck.md
+++ b/docs/streaming-healthcheck.md
@@ -4,12 +4,13 @@
 
 ## 状態分類（4-way）
 
-`/opt/youtube-stream/bin/healthcheck.sh` は `systemctl show youtube-stream -p ActiveState,SubState,Result` の 3 値を以下のように分類する:
+`/opt/youtube-stream/bin/healthcheck.sh` は `systemctl show` から `ActiveState` / `SubState` / `Result` / `RuntimeMaxUSec` / `NRestarts` を取得する。状態分類は以下のとおり:
 
 | systemd 状態 | 分類 | 通知 |
 |---|---|---|
 | `active+running` | `ok` | しない |
-| `activating+auto-restart+success` | `idle` | しない |
+| `activating+auto-restart+success` + 有限 `RuntimeMaxUSec` | `idle` | しない（11h+1h の計画休止） |
+| `activating+auto-restart+success` + `RuntimeMaxUSec=infinity` / `0` | `anomaly` | **送る**（24/7 に計画休止はない） |
 | `inactive+dead+success` | `manual` | しない |
 | その他（`Result≠success` 等） | `anomaly` | **送る** |
 
@@ -28,12 +29,23 @@
 
 `unknown` は `last_status` ファイル不在時のフォールバック値（VPS 再構築直後など）。初回 `ok` は無音、初回 `anomaly` は 1 通だけ通知が来る。
 
+## 再起動カウンタ（観測間の再起動検知）
+
+cron の間に service が停止して `active+running` まで復帰すると、状態 snapshot だけでは障害を見逃す。このため `NRestarts` を `/var/lib/youtube-stream/last_n_restarts` と比較し、増加時は `[youtube-stream] restart detected: NRestarts=<current> previous=<previous> increment=<delta>` を **その cron 観測で 1 通だけ**送る。同時に anomaly / recovered 遷移を観測しても二重通知しない。同じ `NRestarts` の次回観測も無音になる。
+
+baseline ファイルが存在しない、内容が非数値に破損している、または現在値が baseline より小さい場合は、service 再作成や counter reset として現在値へ無音で再基準化する。したがって実機検証前に healthcheck を一度実行し、有効な baseline を作っておく。
+
 ## テストシナリオ
 
 ### シナリオ 1: `pkill` による異常停止
 
+> **承認ゲート:** この操作は配信中の ffmpeg を SIGKILL し、視聴中の配信を切断する破壊的な実機操作である。対象 VPS と影響を提示して利用者の明示的承認を得た場合だけ実行する。本 issue では VPS 接続・SIGKILL・実通知確認を実行していない。
+
 ```bash
 ssh -i ~/.ssh/yt_stream_key root@<instance_ip>
+# baseline を作成し、現在値を控える（初回 baseline は無通知）
+/opt/youtube-stream/bin/healthcheck.sh
+systemctl show youtube-stream -p NRestarts
 # streaming 用 ffmpeg だけを狙い撃ち（コマンドラインに current.mp4 を含むプロセスに限定）
 pkill -KILL -f 'ffmpeg .*current\.mp4'
 ```
@@ -42,10 +54,11 @@ pkill -KILL -f 'ffmpeg .*current\.mp4'
 
 期待挙動:
 
-- `systemctl show youtube-stream -p Result` が `core-dump` または `signal` を返す
+- `systemctl show youtube-stream -p NRestarts` の値が baseline より増える
 - 5 分以内に `/etc/cron.d/youtube-stream-healthcheck` が `healthcheck.sh` を呼ぶ
-- `classify_status` が `anomaly` を返し `notify.sh` が Discord に POST
-- `journalctl -t youtube-stream-healthcheck` に `[youtube-stream] anomaly detected: ...` のログが残る
+- service が cron 前に復帰していても `notify.sh` が Discord に POST する
+- `[youtube-stream] restart detected: NRestarts=... previous=... increment=...` が 1 通だけ届く
+- 24/7 の `activating+auto-restart+success` を直接観測した場合も `RuntimeMaxUSec=infinity` / `0` のため `anomaly` であり、同一観測では restart 通知と重複しない
 
 確認:
 
@@ -81,7 +94,7 @@ journalctl -t youtube-stream-healthcheck --since "10 minutes ago"
 
 - 停止直後: `ActiveState=deactivating` または `inactive`, `Result=success`
 - すぐに `Restart=always` + `RestartSec=1h` で `activating (auto-restart)` 状態へ遷移
-- `classify_status` が `idle` を返し **通知は飛ばない**
+- 有限 `RuntimeMaxUSec` を根拠に `classify_status` が `idle` を返し **通知は飛ばない**
 - 5 分間隔の cron が 12 回走るが全て idle 判定で抑止される
 
 確認:
@@ -90,6 +103,8 @@ journalctl -t youtube-stream-healthcheck --since "10 minutes ago"
 # 11h 経過の境界で:
 systemctl show youtube-stream -p ActiveState,SubState,Result
 # → ActiveState=activating SubState=auto-restart Result=success が期待値
+systemctl show youtube-stream -p RuntimeMaxUSec,NRestarts
+# → RuntimeMaxUSec は有限値。休止中の cron をまたいでも Discord 通知が 0 通であることを確認
 ```
 
 ### シナリオ 4: 1 時間後の自動再開
@@ -136,6 +151,8 @@ grep CRON /var/log/syslog | tail
 # 強制リセット（次回 cron で classify 結果が ok ならそのまま無音、anomaly なら 1 通通知）
 rm -f /var/lib/youtube-stream/last_status
 ```
+
+`last_n_restarts` は手動削除不要。ファイル不在・非数値・現在の `NRestarts` より大きい値は、次回 cron が現在値へ無音で再基準化する。
 
 ### ログが肥大化している
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -327,14 +327,17 @@ ssh -i ~/.ssh/yt_stream_key root@<instance_ip> journalctl -u youtube-stream -f
 
 ## 死活監視（issue #109）
 
-`stream_hours > 0` のとき、`youtube-stream.service` は **指定時間の配信 → 指定休止時間後に自動再開** のサイクルで自律的に回る。素朴な「サービス active か」チェックでは休止中（`activating (auto-restart)`）に誤検知が出るため、本モジュールは以下の 4-way 分類で計画停止と本物の異常を切り分ける:
+`stream_hours > 0` のとき、`youtube-stream.service` は **指定時間の配信 → 指定休止時間後に自動再開** のサイクルで自律的に回る。素朴な「サービス active か」チェックでは休止中（`activating (auto-restart)`）に誤検知が出るため、本モジュールは `RuntimeMaxUSec` も含めて計画停止と本物の異常を切り分ける。24/7 と有限サイクルで同じ systemd 状態の意味が異なる点に注意する:
 
 | systemd 状態 | 分類 | 通知 | 想定シナリオ |
 |---|---|---|---|
 | `active+running` | `ok` | しない | 配信中 |
-| `activating+auto-restart+success` | `idle` | しない | `RuntimeMaxSec` 到達による正常停止後の `RestartSec` 休止（自動再開待ち） |
+| `activating+auto-restart+success` + 有限 `RuntimeMaxUSec` | `idle` | しない | 11h+1h の `RuntimeMaxSec` 到達後の計画休止 |
+| `activating+auto-restart+success` + `RuntimeMaxUSec=infinity` / `0` | `anomaly` | **送る** | 計画休止がない 24/7 の再起動待ち |
 | `inactive+dead+success` | `manual` | しない | 運用者の `systemctl stop` |
 | その他（`failed` / `Result≠success` 等） | `anomaly` | **送る** | `kill -9` / `core-dump` / 設定不備 |
+
+状態 snapshot の間で再起動と復帰が完了しても見逃さないよう、`NRestarts` を `/var/lib/youtube-stream/last_n_restarts` と比較する。増加時は `[youtube-stream] restart detected: NRestarts=<current> previous=<previous> increment=<delta>` をその cron 観測で **1 通だけ**送り、同時に検知した anomaly / recovered 通知とは重複させない。同じ値の再観測は無音。baseline 不在、非数値への破損、または counter 減少時は現在値へ無音で再基準化する。
 
 ### 通知手段
 
@@ -352,12 +355,16 @@ Discord Webhook URL を `/etc/youtube-stream-healthcheck.env` から読み、`cu
 
 ### テストシナリオ（VPS 上で確認）
 
+`pkill -KILL` は稼働中の配信を切断する破壊的な実機操作である。対象 VPS と視聴者影響を提示し、利用者の明示的承認を得た場合だけ実施する。本 issue の文書更新では VPS 接続、SIGKILL、実 Discord 通知の確認は実行していない。
+
 | 操作 | 期待結果 |
 |---|---|
 | `pkill -KILL -f 'ffmpeg .*current\.mp4'` | 5 分以内に Discord に anomaly 通知が届く |
 | `systemctl stop youtube-stream` | 通知は飛ばない（`manual` 分類） |
 | `RuntimeMaxSec` 到達による正常停止 | 通知は飛ばない（`activating+auto-restart+success` = `idle`） |
 | `RestartSec` 経過後の自動再開（`auto-restart`） | 通知は飛ばない（休止中は `idle`、再開後は `ok`） |
+
+承認後に 24/7 の SIGKILL を確認する場合は、先に `/opt/youtube-stream/bin/healthcheck.sh` を 1 回実行して `NRestarts` baseline を作り、`systemctl show youtube-stream -p NRestarts` の値を控える。その後に対象を限定した `pkill` を実行し、次の cron までに counter が増え、`restart detected` が 1 通だけ届くことを確認する。cron 時点で service が既に `active+running` へ復帰していても検知できる。11h+1h の回帰確認では `systemctl show youtube-stream -p ActiveState,SubState,Result,RuntimeMaxUSec,NRestarts` を使い、有限 `RuntimeMaxUSec` の `activating+auto-restart+success` が `idle` となり、1 時間の計画休止を通して通知が 0 通であることを確認する。
 
 ## トラブルシューティング
 


### PR DESCRIPTION
## Summary

- 24/7 と有限の 11h+1h サイクルで auto-restart の分類が異なることを運用ガイド全体へ反映する
- `NRestarts` の 1 回通知と baseline 不在・破損・減少時の無音再基準化を説明する
- SIGKILL 実機確認は明示的承認が必要な破壊的操作として示し、本 PR では未実施と記録する

## Verification

- `uv run pytest tests/test_streaming_healthcheck.py tests/repo/streaming/test_skill_streaming.py` (140 passed)
- frontmatter / docs consistency tests (128 passed)
- `uv run yt-skills lint` (57 skills passed)
- `git diff --check HEAD^..HEAD`

## References

- [systemd.service](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html)
- [systemd.unit](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html)

Closes #3459
