### PR TITLE
fix(collection-serve): バージョン付き拡張を検出する (#3033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(videoup)`: マルチチャンネル workspace で `overlays.subscribe_popup.image` の相対パスを、canonical `config/channel/youtube.json` が属するチャンネルルートから解決できるようにした（#3208）。
 
 - `fix(suno-helper)`: prompt response の optional な `duration_sec` を正の整数に限定し、bool・文字列・小数・非有限値・0 以下を拡張の取得境界で fail-loud に拒否するようにした（#3154）。
+- `fix(collection-serve)`: `--allow-extension` が exact basename を優先しつつ、`<name>-X.Y.Z`・`<name>-X.Y.Z-chrome`・`<name>-chrome` の release folder を狭い完全一致で検出するようにした。正規候補が 0 件の場合は、requested name を literal に含む近似候補を profile / ID / path / enabled 状態と候補ごとの `yt-collection-serve --allow-origin chrome-extension://<ID>` コマンド付きで列挙する（#3033）。
 - `fix(collection-serve)`: `--allow-extension` の起動ログへ、exact origin lock に実際に選択した unpacked 拡張の path / Chrome profile / `enabled=true` を追加し、無効な重複 ID や実行中 origin との食い違いをリクエスト前に診断可能にする（#3217）。
 - `fix(collection-serve)`: `--allow-extension` が同名候補を検出しても有効 ID が 0 件、または複数 ID の場合は起動前に拒否し、検出した全候補の profile / ID / path / enabled 状態と `--allow-origin` fallback を `ConfigError` に列挙する（#3216）。
 - `fix(collection-serve)`: Chrome Preferences の同名 unpacked 拡張候補に無効化済み ID が混在しても、非空の `disable_reasons` または `state=0` を持つ entry を除外し、唯一の有効候補へ `--allow-extension` の exact origin lock を設定する（#3215）。

--- a/src/youtube_automation/infrastructure/collections/chrome_extensions.py
+++ b/src/youtube_automation/infrastructure/collections/chrome_extensions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -30,6 +31,7 @@ class _ExtensionCandidate:
     path: Path
     enabled: bool
     preferences_path: Path
+    match_priority: int | None
 
 
 def resolve_unpacked_extension_origin(
@@ -43,11 +45,15 @@ def resolve_unpacked_extension_origin(
         raise ConfigError("Chrome extension name must not be empty. Use --allow-origin for manual fallback.")
 
     root = chrome_user_data_dir if chrome_user_data_dir is not None else Path.home() / _CHROME_USER_DATA_RELPATH
-    candidates = _find_unpacked_extension_candidates(extension_name, root)
+    candidates, near_candidates = _find_unpacked_extension_candidates(extension_name, root)
     if not candidates:
+        near_candidate_guidance = (
+            f" Nearby unpacked extensions: {_format_near_candidates(near_candidates)}." if near_candidates else ""
+        )
         raise ConfigError(
             f"Chrome unpacked extension named {extension_name!r} was not found in {root}. "
-            "Load the unpacked extension in Chrome, or pass --allow-origin chrome-extension://<EXTENSION_ID> manually."
+            f"Load the unpacked extension in Chrome.{near_candidate_guidance} "
+            "Otherwise pass --allow-origin chrome-extension://<EXTENSION_ID> manually."
         )
 
     enabled_candidates = [candidate for candidate in candidates if candidate.enabled]
@@ -76,15 +82,26 @@ def resolve_unpacked_extension_origin(
     )
 
 
-def _find_unpacked_extension_candidates(extension_name: str, root: Path) -> list[_ExtensionCandidate]:
-    candidates: list[_ExtensionCandidate] = []
+def _find_unpacked_extension_candidates(
+    extension_name: str,
+    root: Path,
+) -> tuple[list[_ExtensionCandidate], list[_ExtensionCandidate]]:
+    discovered: list[_ExtensionCandidate] = []
     for profile_dir in _iter_profile_dirs(root):
         preferences_path = _preferences_path(profile_dir)
         if preferences_path is None:
             continue
         payload = _read_preferences(preferences_path)
-        candidates.extend(_candidates_from_preferences(extension_name, profile_dir, preferences_path, payload))
-    return candidates
+        discovered.extend(_candidates_from_preferences(extension_name, profile_dir, preferences_path, payload))
+
+    priorities = [candidate.match_priority for candidate in discovered if candidate.match_priority is not None]
+    if priorities:
+        selected_priority = min(priorities)
+        return (
+            [candidate for candidate in discovered if candidate.match_priority == selected_priority],
+            [],
+        )
+    return [], [candidate for candidate in discovered if extension_name in candidate.path.name]
 
 
 def _iter_profile_dirs(root: Path) -> list[Path]:
@@ -147,7 +164,10 @@ def _candidates_from_preferences(
         if not isinstance(raw_path, str):
             continue
         extension_path = Path(raw_path)
-        if not extension_path.is_absolute() or not _matches_extension_name(extension_name, extension_path, raw_entry):
+        if not extension_path.is_absolute():
+            continue
+        match_priority = _extension_name_match_priority(extension_name, extension_path, raw_entry)
+        if match_priority is None and extension_name not in extension_path.name:
             continue
         candidates.append(
             _ExtensionCandidate(
@@ -156,6 +176,7 @@ def _candidates_from_preferences(
                 path=extension_path,
                 enabled=not _is_disabled_extension_entry(raw_entry),
                 preferences_path=preferences_path,
+                match_priority=match_priority,
             )
         )
     return candidates
@@ -165,23 +186,41 @@ def _is_disabled_extension_entry(raw_entry: dict[object, object]) -> bool:
     return bool(raw_entry.get("disable_reasons")) or raw_entry.get("state") == 0
 
 
-def _matches_extension_name(extension_name: str, extension_path: Path, raw_entry: dict[object, object]) -> bool:
+def _extension_name_match_priority(
+    extension_name: str,
+    extension_path: Path,
+    raw_entry: dict[object, object],
+) -> int | None:
     if extension_path.name == extension_name:
-        return True
+        return 0
+    release_folder_pattern = rf"{re.escape(extension_name)}(?:-\d+(?:\.\d+)*)?(?:-chrome)?"
+    if re.fullmatch(release_folder_pattern, extension_path.name):
+        return 1
     manifest = raw_entry.get("manifest")
     if not isinstance(manifest, dict):
-        return False
+        return None
     manifest_name = manifest.get("name")
     if not isinstance(manifest_name, str):
-        return False
+        return None
     requested_name = " ".join(extension_name.replace("-", " ").split()).casefold()
     display_name = " ".join(manifest_name.split()).casefold()
-    return display_name in {requested_name, f"{requested_name} (youtube-channels-automation)"}
+    if display_name in {requested_name, f"{requested_name} (youtube-channels-automation)"}:
+        return 2
+    return None
 
 
 def _format_candidates(candidates: list[_ExtensionCandidate]) -> str:
     return "; ".join(
         f"profile={candidate.profile}, id={candidate.extension_id}, path={candidate.path}, "
         f"enabled={str(candidate.enabled).lower()}, preferences={candidate.preferences_path}"
+        for candidate in candidates
+    )
+
+
+def _format_near_candidates(candidates: list[_ExtensionCandidate]) -> str:
+    return "; ".join(
+        f"profile={candidate.profile}, id={candidate.extension_id}, path={candidate.path}, "
+        f"enabled={str(candidate.enabled).lower()}, "
+        f"command=yt-collection-serve --allow-origin {_EXTENSION_ORIGIN_PREFIX}{candidate.extension_id}"
         for candidate in candidates
     )

--- a/tests/infrastructure/collections/test_chrome_extensions.py
+++ b/tests/infrastructure/collections/test_chrome_extensions.py
@@ -73,6 +73,66 @@ def test_resolve_unpacked_extension_origin_matches_secure_preferences(tmp_path):
 
 
 @pytest.mark.parametrize(
+    "folder_name",
+    (
+        "suno-helper-0.2.5",
+        "suno-helper-0.2.5-chrome",
+        "suno-helper-chrome",
+    ),
+)
+def test_resolve_unpacked_extension_origin_matches_versioned_release_folder(tmp_path, folder_name):
+    extension_id = "gdjhjiphejeeclngbljhajiffhpdepee"
+    extension_path = tmp_path / "Downloads" / folder_name
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {extension_id: {"path": str(extension_path)}},
+    )
+
+    resolved = resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+    assert resolved.extension_id == extension_id
+    assert resolved.path == extension_path
+
+
+@pytest.mark.parametrize(
+    "folder_name",
+    (
+        "other-suno-helper-0.2.5",
+        "suno-helper-0.2.5-preview",
+        "suno-helper-0..2-chrome",
+        "suno-helper-v0.2.5-chrome",
+    ),
+)
+def test_resolve_unpacked_extension_origin_rejects_broad_release_folder_matches(tmp_path, folder_name):
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {"gdjhjiphejeeclngbljhajiffhpdepee": {"path": _extension_path(tmp_path, folder_name)}},
+    )
+
+    with pytest.raises(ConfigError, match="was not found"):
+        resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+
+def test_resolve_unpacked_extension_origin_prefers_exact_folder_over_release_folder(tmp_path):
+    exact_id = "gdjhjiphejeeclngbljhajiffhpdepee"
+    release_id = "abcdefghijklmnopabcdefghijklmnop"
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {
+            exact_id: {"path": _extension_path(tmp_path, "suno-helper")},
+            release_id: {"path": _extension_path(tmp_path, "suno-helper-0.2.5-chrome")},
+        },
+    )
+
+    resolved = resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+    assert resolved.extension_id == exact_id
+
+
+@pytest.mark.parametrize(
     "disabled_fields",
     (
         {"disable_reasons": [1]},
@@ -217,6 +277,30 @@ def test_resolve_unpacked_extension_origin_missing_extension_guides_allow_origin
     message = str(exc_info.value)
     assert "suno-helper" in message
     assert "--allow-origin chrome-extension://<EXTENSION_ID>" in message
+
+
+def test_resolve_unpacked_extension_origin_lists_literal_near_candidates_with_commands(tmp_path):
+    enabled_id = "gdjhjiphejeeclngbljhajiffhpdepee"
+    disabled_id = "abcdefghijklmnopabcdefghijklmnop"
+    enabled_path = tmp_path / "Downloads" / "suno-helper-preview"
+    disabled_path = tmp_path / "Downloads" / "my-suno-helper-build"
+    _write_preferences(
+        tmp_path / "Default",
+        "Secure Preferences",
+        {
+            enabled_id: {"path": str(enabled_path)},
+            disabled_id: {"path": str(disabled_path), "state": 0},
+        },
+    )
+
+    with pytest.raises(ConfigError) as exc_info:
+        resolve_unpacked_extension_origin("suno-helper", chrome_user_data_dir=tmp_path)
+
+    message = str(exc_info.value)
+    assert f"profile=Default, id={enabled_id}, path={enabled_path}, enabled=true" in message
+    assert f"--allow-origin chrome-extension://{enabled_id}" in message
+    assert f"profile=Default, id={disabled_id}, path={disabled_path}, enabled=false" in message
+    assert f"--allow-origin chrome-extension://{disabled_id}" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- exact basename を優先し、バージョン付き release folder と `-chrome` suffix を狭い完全一致で検出する
- canonical candidate がない場合だけ literal な近似候補と候補ごとの `--allow-origin` コマンドを表示する
- embedded manifest.name fallback と曖昧候補の拒否を維持する

## Verification
- `uv run pytest tests/infrastructure/collections/test_chrome_extensions.py tests/commands/collections/test_collection_serve.py -q` (256 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- CHANGELOG gate equivalent
- full pytest: 7454 passed / 1 skipped; unrelated thumbnail font fixture failed because local Matplotlib cannot find DejaVu Sans (same 56 setup errors + 2 dependent failures, changed paths do not intersect)
- live Chrome / Load unpacked / server smoke: authorization-blocked and intentionally not run

Closes #3033