### PR TITLE
docs(suno-helper): Write mode の事前設定を明記する (#3467)

### DIFF
--- a/.claude/skills/suno-helper/SKILL.md
+++ b/.claude/skills/suno-helper/SKILL.md
@@ -40,7 +40,7 @@ overlay の phase が `finished` に到達し、Step 6 の 6 点（playlist 紐�
 
 - Chrome に unpacked の suno-helper 拡張がロード済み（拡張アイコンが popup を出す。ID 検出に失敗した場合のみ `--allow-origin` fallback で拡張 ID を手動指定する）
 - Suno (suno.com/create) にログイン済み・**Advanced タブ**が選択されている
-- Style 入力欄が出ていること。prompt entry の `lyrics` が非空なら（インストゥルメンタルを含め）Lyrics mode = Write と Style / Lyrics 入力欄を使い、空のインストゥルメンタル entry なら Lyrics mode = Instrumental と Style 入力欄を使う
+- Style 入力欄が出ていること。**Advanced → More options を開く → Lyrics mode → Write** の順に選ぶ。prompt entry の `lyrics` が非空なら、`[Instrumental]` だけのインストゥルメンタル entry でも Write が必須。suno-helper は Lyrics 欄へその値を注入して歌詞なしを指定するため、Lyrics 欄を隠す Instrumental mode では実行できない。`lyrics` が真に空の entry だけは Lyrics mode = Instrumental と Style 入力欄を使える
 - automation リポジトリで `uv` が使える・`CHANNEL_DIR` 環境変数を当該チャンネルへ向けてある
 - collection ディレクトリ名が **`*-collection` suffix** を持つ（dir mode 必須）。例: `20260201-soulful-grooves-rainy-night-soul-collection/`
 - 7873 / 7874 など特定 port を既に他の collection で使っていないか確認（並走させる場合は明示的に分ける）
@@ -95,7 +95,7 @@ collection 単体パスを直接渡す single file mode は playlist phase が�
 ### Agent primary flow: browser use で操作する
 
 1. browser use で `https://suno.com/create` を開く。
-2. ログイン済みで Advanced タブが選択されていることを確認する。prompt entry の `lyrics` が非空なら（インストゥルメンタルを含め）Lyrics mode = Write を選び、Style / Lyrics 入力欄が見えることを確認する。空のインストゥルメンタル entry なら Lyrics mode = Instrumental を選び、Style 入力欄が見えることを確認する。ログイン画面、CAPTCHA、Advanced タブ不在なら下記 handoff 条件に従い停止する。
+2. ログイン済みで **Advanced → More options を開く → Lyrics mode → Write** の順に選び、Style / Lyrics 入力欄が見えることを確認する。prompt entry の `lyrics` が非空なら、`[Instrumental]` だけでも suno-helper が Lyrics 欄へ注入するため Write が必須。`lyrics` が真に空の entry だけは Lyrics mode = Instrumental と Style 入力欄を使える。ログイン画面、CAPTCHA、Advanced タブ不在なら下記 handoff 条件に従い停止する。
 3. 拡張アイコンをクリックして suno-helper overlay を Suno タブ内に表示する。overlay が最小化されている場合はヘッダーの展開ボタンを押す。
 4. overlay ルート `[data-suno-helper="control-panel"]` を観測する。`data-suno-phase`、`data-suno-running`、`data-suno-error`、`data-suno-collection-id`、`data-suno-entry-count`、`data-suno-selected-entry-count` が browser use から読める。
 5. `[data-suno-control="server-source-trigger"]` を押し、更新後に表示される `role="option"` から Step 1 で確認した URL の配信元候補を選ぶ。
@@ -248,7 +248,7 @@ ps aux | grep '[y]t-collection-serve'
 - **entry phase の任意停止 / ERROR**（`stopped` / `error`）: 24h 以内なら次回 popup 起動時に resume バナーが出る。"再開" で保存した entry から再実行し、元 run の異常値再生成 option も引き継ぐ
 - **playlist / download phase の任意停止 / ERROR**: resume バナーは出ない。**Playlist から再開** / **Download から再開** を使い、元 run の異常値再生成 option と警告を引き継ぐ
 - ERROR 文言の代表例（いずれも fail-loud で停止する）:
-  - `Lyrics mode が Instrumental になっています。Write に切り替えてください。`
+  - `Lyrics mode が Instrumental になっています。Write に切り替えてください。` が出たら、前提条件の **Advanced → More options → Lyrics mode → Write** をやり直す。`[Instrumental]` も Lyrics 欄へ注入する値なので Write が必要
   - `Create form mode が Simple になっています。Advanced タブを選択してください。`
   - 状態を特定できない場合は Advanced タブ / Lyrics mode = Write / UI 言語（英語推奨）のチェックリストを表示する
   - `reCAPTCHA を検知しました。手動で解決してから再開してください。`
@@ -268,7 +268,7 @@ DL が止まる・形式が違う・`workflow-state.json` へ反映されない�
 
 - **`--allow-extension` / `--allow-origin` 無しで起動すると token 取得と DL 完了 POST が 403 になる**。通常は `--allow-extension suno-helper` で検出し、検出失敗時のみ `--allow-origin "chrome-extension://<EXTENSION_ID>"` を exact 指定して Step 1 の `/auth/token` 確認を通すこと。
 - **誤って single file mode で起動すると playlist phase がスキップされる**。`/collections` 404 が返り、popup 側で derivedPlaylistName が undefined になり playlist phase に分岐しない。Step 1 の `curl /collections` 確認を必ず通すこと。
-- **Advanced タブ + Lyrics mode を毎回確認**。prompt entry の `lyrics` が非空なら（インストゥルメンタルを含め）Write と Style / Lyrics 欄、空のインストゥルメンタル entry なら Instrumental と Style 欄を選ぶ。Suno が UI 状態を覚えていないことがあり、`lyrics` が非空の entry で Lyrics 欄が消えていると Step 5 開始直後に ERROR で止まる。
+- **Advanced → More options → Lyrics mode を毎回確認**。prompt entry の `lyrics` が非空なら、`[Instrumental]` を含め Write と Style / Lyrics 欄を使う。`lyrics` が真に空の entry だけは Instrumental と Style 欄を使える。Suno が UI 状態を覚えていないことがあり、`lyrics` が非空の entry で Lyrics 欄が消えていると Step 5 開始直後に ERROR で止まる。
 - **Cmd+P を手動で押す必要はない**。拡張は background script から `chrome.debugger` の `Input.dispatchKeyEvent` で trusted key event を送る。dispatchEvent では Suno listener に届かない（isTrusted=false）ため、user 側で打鍵してはいけない（衝突する）。失敗時は拡張 manifest の `debugger` 権限、対象 Suno tab への attach 失敗、DevTools/別 debugger の競合を確認する。
 - **dir 名規約は `<YYYYMMDD>-<channel>-<theme>-collection`**。拡張が dir 名の `<channel>` と collection name の `<theme>` から playlist 名（`<channel> | <theme>`）を導出する。独自規約で切ると playlist 名が壊れる。
 - **7873 / 7874 を並走させる場合は明示的に port を分ける**。両方を 7873 で立てると後者が起動失敗するので、必ず `--port` を指定して popup のローカル配信元を選び直す。

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -91,7 +91,7 @@ build 後は `.output/chrome-mv3/manifest.json`、zip 後は `.output/suno-helpe
      --allow-extension suno-helper
    # → http://<channel>.localhost:7873/collections と /auth/token を配信
    ```
-2. Chrome で Suno の **Advanced** タブを選択する。
+2. Chrome で Suno の **Advanced → More options を開く → Lyrics mode → Write** の順に選ぶ。prompt entry の `lyrics` が非空なら、`[Instrumental]` だけのインスト曲でも suno-helper が Lyrics 欄へ値を注入するため Write が必須。Lyrics 欄を隠す Instrumental mode のままでは実行できない。`lyrics` が真に空の entry だけは Instrumental mode を使える。
 3. 拡張アイコンからポップアップを開き、**ローカル配信元** で動的検出されたチャンネル名つき候補を選ぶ。初回表示・配信元選択・collection 選択の各タイミングで一覧と prompts が自動取得される。
 4. `ready` な collection を checkbox で 1 件以上選び、prompts の自動取得後に **異常値の曲を再生成する** を選んでから実行する。1 件なら従来どおり現在の entry 選択を使い、2 件以上なら server 一覧順で各 collection の全 pattern を直列実行する。既定の ON は duration guard NG の entry を最大 2 回再生成する。OFF は追加生成せず、NG を警告表示したうえで生成済み全 clip を playlist / download 候補に残す。
 5. 各パターンで Style/Lyrics を注入 → Generate 押下 → 生成完了検知 → 次へ、を自動で繰り返す。

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -23,6 +23,7 @@ from tests.helpers.paths import REPO_ROOT
 _REPO_ROOT = REPO_ROOT
 SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "suno" / "SKILL.md"
 SUNO_HELPER_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "suno-helper" / "SKILL.md"
+SUNO_HELPER_README_MD = _REPO_ROOT / "extensions" / "suno-helper" / "README.md"
 WF_NEW_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
 WF_AUTO_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
 SUNO_HELPER_PHASE_CONSTANTS_TS = _REPO_ROOT / "extensions" / "shared" / "constants.ts"
@@ -44,6 +45,10 @@ def _assert_before(text: str, earlier: str, later: str) -> None:
 
 def _read_suno_helper() -> str:
     return SUNO_HELPER_SKILL_MD.read_text(encoding="utf-8")
+
+
+def _read_suno_helper_readme() -> str:
+    return SUNO_HELPER_README_MD.read_text(encoding="utf-8")
 
 
 def _read_wf_new() -> str:
@@ -240,6 +245,19 @@ def test_suno_helper_documents_browser_use_primary_flow() -> None:
     assert '[data-suno-control="server-url"]' not in text, "非表示の互換 select が現行操作手順に残っている"
     assert '[data-suno-control="fetch-data"]' not in text, "廃止した手動取得 selector が現行手順に残っている"
     assert "サーバー URL 入力" not in text, "登録済み配信元 select を free-input と説明する旧契約が残っている"
+
+
+def test_suno_helper_documents_lyrics_mode_setup_contract() -> None:
+    """Given suno-helper の operator 向け手順
+    When 非空 lyrics を自動投入する前提を読む
+    Then Write の所在、Instrumental tag の注入理由、空 entry の例外が分かる。
+    """
+    for document in (_read_suno_helper(), _read_suno_helper_readme()):
+        assert "Advanced → More options" in document
+        assert "Lyrics mode → Write" in document
+        assert "`[Instrumental]`" in document
+        assert "Lyrics 欄へ" in document
+        assert "`lyrics` が真に空" in document
 
 
 def test_suno_helper_devtools_mcp_is_not_required_flow() -> None:


### PR DESCRIPTION
## 概要
- Advanced → More options → Lyrics mode → Write の事前設定を明記
- 非空 lyrics と [Instrumental] tag が Write を必要とする理由を説明
- 真に空の lyrics のみ Instrumental mode を許可する契約を repository test で固定

## 検証
- nix develop --command uv run pytest tests/repo/test_suno_skill_doc.py
- nix develop --command uv run yt-skills lint
- git diff --check

Closes #3467