### PR TITLE
fix(suno-helper): Lyrics mode 診断を自己完結させる (#3468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(thumbnail-compare)`: ベンチマーク更新・サムネイル取得・縮小の進捗を即時表示し、画像取得を slow-drip を含む wall-clock deadline、ffmpeg を有限 timeout にした。個別対象の timeout 後も警告して成功分の比較出力を継続する（#3229）。
 - `fix(auth)`: readonly OAuth handler に明示的な非対話 policy を追加し、`token.readonly.json` が未発行・不正・refresh 不能な場合は browser OAuth を開始せず、`uv run yt-oauth --readonly` による発行を案内して fail-fast するようにした（#2956）。
 - `fix(streaming)`: `RuntimeMaxUSec` が無制限の 24/7 配信では `activating/auto-restart` を異常として通知し、有限サイクルの計画休止だけを無音にした。`NRestarts` の増加も cron 観測ごとに一度だけ通知し、初回・破損 baseline・counter reset は無音で再同期する（#3458）。
+- `fix(suno-helper)`: Lyrics 欄が見つからない場合の診断に、Advanced → More options → Lyrics mode → Write の具体的な所在と、`[Instrumental]` を含む非空 lyrics は Lyrics 欄へ注入するため Write が必要になる理由を表示する（#3468）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -136,6 +136,10 @@ export interface ResolvedFields {
 
 const LYRICS_MODE_NAMES = ["Write", "Prompt", "Instrumental"] as const;
 const CREATE_FORM_MODE_NAMES = ["Simple", "Advanced", "Sounds"] as const;
+const LYRICS_WRITE_LOCATION =
+  "Advanced → More options → Lyrics mode → Write の順に切り替えてください。";
+const LYRICS_WRITE_REASON =
+  "suno-helper は非空の lyrics（[Instrumental] を含む）を Lyrics 欄へ注入するため、Write が必要です。";
 
 function controlName(el: Element): string {
   return (el.getAttribute("aria-label") ?? el.textContent ?? "").trim();
@@ -187,7 +191,11 @@ export function diagnoseLyricsInputState(): string {
     LYRICS_MODE_NAMES
   );
   if (lyricsMode === "Prompt" || lyricsMode === "Instrumental") {
-    return `Lyrics mode が ${lyricsMode} になっています。Write に切り替えてください。`;
+    return [
+      `Lyrics mode が ${lyricsMode} になっています。Write に切り替えてください。`,
+      LYRICS_WRITE_LOCATION,
+      LYRICS_WRITE_REASON,
+    ].join("\n");
   }
 
   const createFormMode = selectedModeName(
@@ -197,13 +205,18 @@ export function diagnoseLyricsInputState(): string {
     CREATE_FORM_MODE_NAMES
   );
   if (createFormMode === "Simple" || createFormMode === "Sounds") {
-    return `Create form mode が ${createFormMode} になっています。Advanced タブを選択してください。`;
+    return [
+      `Create form mode が ${createFormMode} になっています。Advanced タブを選択してください。`,
+      LYRICS_WRITE_LOCATION,
+      LYRICS_WRITE_REASON,
+    ].join("\n");
   }
 
   return [
     "Lyrics 欄を表示できる状態か確認してください:",
     "- Advanced タブが選択されているか",
-    "- Lyrics mode が Write になっているか",
+    "- More options を開き、Lyrics mode が Write になっているか",
+    `- ${LYRICS_WRITE_REASON}`,
     "- Suno の UI 言語が日本語になっていないか（英語推奨）",
   ].join("\n");
 }

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -178,8 +178,14 @@ describe("diagnoseLyricsInputState: 現行 Suno UI の ARIA 状態診断 (#1899)
       addLyricsMode(selectedName);
       addCreateFormMode("Advanced");
 
-      expect(diagnoseLyricsInputState()).toBe(
-        `Lyrics mode が ${selectedName} になっています。Write に切り替えてください。`
+      expect(diagnoseLyricsInputState()).toContain(
+        `Lyrics mode が ${selectedName} になっています。`
+      );
+      expect(diagnoseLyricsInputState()).toContain(
+        "Advanced → More options → Lyrics mode → Write"
+      );
+      expect(diagnoseLyricsInputState()).toContain(
+        "非空の lyrics（[Instrumental] を含む）を Lyrics 欄へ注入"
       );
     }
   );
@@ -190,8 +196,14 @@ describe("diagnoseLyricsInputState: 現行 Suno UI の ARIA 状態診断 (#1899)
       addLyricsMode("Write");
       addCreateFormMode(selectedName);
 
-      expect(diagnoseLyricsInputState()).toBe(
-        `Create form mode が ${selectedName} になっています。Advanced タブを選択してください。`
+      expect(diagnoseLyricsInputState()).toContain(
+        `Create form mode が ${selectedName} になっています。`
+      );
+      expect(diagnoseLyricsInputState()).toContain(
+        "Advanced → More options → Lyrics mode → Write"
+      );
+      expect(diagnoseLyricsInputState()).toContain(
+        "非空の lyrics（[Instrumental] を含む）を Lyrics 欄へ注入"
       );
     }
   );
@@ -238,7 +250,11 @@ describe("diagnoseLyricsInputState: 現行 Suno UI の ARIA 状態診断 (#1899)
 
       const message = diagnoseLyricsInputState();
       expect(message).toContain("Advanced タブが選択されているか");
+      expect(message).toContain("More options");
       expect(message).toContain("Lyrics mode が Write になっているか");
+      expect(message).toContain(
+        "非空の lyrics（[Instrumental] を含む）を Lyrics 欄へ注入"
+      );
       expect(message).toContain("UI 言語が日本語になっていないか（英語推奨）");
     }
   );


### PR DESCRIPTION
## 概要
- Lyrics mode / Create form mode の現在状態を維持して診断
- Advanced → More options → Lyrics mode → Write の具体的な所在を案内
- 非空 lyrics（[Instrumental] を含む）を Lyrics 欄へ注入するため Write が必要な理由を説明
- DOM を変更しない既存契約を維持

## 検証
- nix develop .#extensions --command pnpm -C extensions/suno-helper exec vitest run tests/dom.test.ts tests/content-run-preflight.test.ts
- nix develop .#extensions --command pnpm -C extensions/suno-helper compile
- nix develop .#extensions --command pnpm -C extensions/suno-helper check
- git diff --check

Closes #3468