### PR TITLE
fix(suno-helper): Download 再開の復元導線を明確化する (#3071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(auth)`: readonly OAuth handler に明示的な非対話 policy を追加し、`token.readonly.json` が未発行・不正・refresh 不能な場合は browser OAuth を開始せず、`uv run yt-oauth --readonly` による発行を案内して fail-fast するようにした（#2956）。
 - `fix(streaming)`: `RuntimeMaxUSec` が無制限の 24/7 配信では `activating/auto-restart` を異常として通知し、有限サイクルの計画休止だけを無音にした。`NRestarts` の増加も cron 観測ごとに一度だけ通知し、初回・破損 baseline・counter reset は無音で再同期する（#3458）。
 - `fix(suno-helper)`: Lyrics 欄が見つからない場合の診断に、Advanced → More options → Lyrics mode → Write の具体的な所在と、`[Instrumental]` を含む非空 lyrics は Lyrics 欄へ注入するため Write が必要になる理由を表示する（#3468）。
+- `fix(suno-helper)`: 完全自動生成後の FINISHED snapshot から clip ID と期待件数を復元して Download 再開へ引き継ぐ回帰テストを追加し、clip ID が無い場合は効果のないページ再読み込みではなく、Suno 上で対象曲を選択して「選択中の曲を採用」後に再試行する手順を案内するよう修正した（#3071）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -589,6 +589,24 @@ export function useSunoRunner(): RunnerState {
     );
   }, [playlistExpectedClipCountForResume, entries.length, selectedCollection]);
 
+  const expectedClipCountForDownloadResume = useMemo<number | undefined>(() => {
+    if (
+      phase === PHASE.FINISHED &&
+      restoredCollectionId === selectedCollectionId &&
+      restoredPlaylistExpectedClipCount !== undefined &&
+      restoredPlaylistExpectedClipCount > 0
+    ) {
+      return restoredPlaylistExpectedClipCount;
+    }
+    return expectedClipCountForManualAdoption;
+  }, [
+    phase,
+    restoredCollectionId,
+    selectedCollectionId,
+    restoredPlaylistExpectedClipCount,
+    expectedClipCountForManualAdoption,
+  ]);
+
   const report = useCallback((text: string, error = false) => {
     setStatus(text);
     setIsError(error);
@@ -1511,7 +1529,7 @@ export function useSunoRunner(): RunnerState {
     }
     if (submittedClipIdsForResume.length === 0) {
       report(
-        "ダウンロード再開に必要な clip ID がありません。ページを再読み込みしてから再試行してください。",
+        "ダウンロード再開に必要な clip ID がありません。Suno 上で対象曲を選択し、「選択中の曲を採用」を押してから「Download から再開」を再試行してください。",
         true
       );
       return;
@@ -1522,7 +1540,7 @@ export function useSunoRunner(): RunnerState {
       const payload = {
         collectionId: selectedCollectionId,
         submittedClipIds: submittedClipIdsForResume,
-        expectedClipCount: expectedClipCountForManualAdoption,
+        expectedClipCount: expectedClipCountForDownloadResume,
       };
       await sendMessage("retryDownload", payload);
       report("ダウンロードを再実行しています…");
@@ -1533,7 +1551,7 @@ export function useSunoRunner(): RunnerState {
     isRunning,
     selectedCollectionId,
     submittedClipIdsForResume,
-    expectedClipCountForManualAdoption,
+    expectedClipCountForDownloadResume,
     report,
     reportRunDispatchFailure,
     setRunning,

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -3507,7 +3507,7 @@ describe("Suno popup compatibility check", () => {
     });
   });
 
-  it("clip ID が無い状態で Download から再開しても retryDownload を送らずエラー表示する", async () => {
+  it("clip ID が無い状態では選択中の曲を採用してから Download を再試行するよう案内する", async () => {
     fetchMock
       .mockResolvedValueOnce(
         jsonResponse(200, {
@@ -3546,8 +3546,51 @@ describe("Suno popup compatibility check", () => {
       expect.anything()
     );
     expect(container.textContent).toContain(
-      "ダウンロード再開に必要な clip ID がありません。ページを再読み込みしてから再試行してください。"
+      "ダウンロード再開に必要な clip ID がありません。Suno 上で対象曲を選択し、「選択中の曲を採用」を押してから「Download から再開」を再試行してください。"
     );
+  });
+
+  it("完全自動生成の FINISHED snapshot をリロード後に復元して正確な期待数で Download を再開する", async () => {
+    const autoRunClipIds = ["auto-clip-a", "auto-clip-b", "auto-clip-c"];
+    messagingMocks.sendMessage.mockImplementation(
+      (message: string, payload?: Record<string, string>) => {
+        if (message === "queryProgress") {
+          return Promise.resolve({
+            collectionId: "20260601-clm-theme-a-collection",
+            entries: [
+              { name: "p1", style: "lofi", lyrics: "" },
+              { name: "p2", style: "ambient", lyrics: "" },
+            ],
+            itemStates: ["done", "done"],
+            isRunning: false,
+            progress: { phase: PHASE.FINISHED, total: 2 },
+            playlistName: "clm | theme-a",
+            submittedClipIds: autoRunClipIds,
+            submittedClipIdsAreDurationFiltered: true,
+            playlistExpectedClipCount: 3,
+          });
+        }
+        return defaultSendMessage(message, payload);
+      }
+    );
+
+    await rerenderApp();
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        "完了: 2 パターンを実行しました。"
+      );
+    });
+
+    messagingMocks.sendMessage.mockClear();
+    await act(async () => {
+      buttonByText(container, "Download から再開").click();
+    });
+
+    expect(messagingMocks.sendMessage).toHaveBeenCalledWith("retryDownload", {
+      collectionId: "20260601-clm-theme-a-collection",
+      submittedClipIds: autoRunClipIds,
+      expectedClipCount: 3,
+    });
   });
 
   it("期待 clip 数を解決できない場合は採用を送らずページ再読み込みを案内する", async () => {


### PR DESCRIPTION
## 概要

完全自動生成後の FINISHED snapshot に保存された clip ID と期待件数を、ページリロード後の popup から Download 再開 payload へ引き継ぎます。clip ID を復元できない場合は、効果のないページ再読み込みではなく、Suno 上で対象曲を選択して「選択中の曲を採用」後に再試行する手順を案内します。

Closes #3071

## 変更内容

- 下段 #3474 が production content → FINISHED storage の exact clip 契約を固定
- FINISHED snapshot 復元後の `retryDownload` が自動生成時の clip ID と期待件数を送る popup 結合テストを追加
- clip ID が 0 件の Download 再開エラーを、手動選択 → 「選択中の曲を採用」 → 「Download から再開」の実効手順へ変更
- `CHANGELOG.md::[Unreleased]` に利用者向け修正内容を追記
- 既存の snapshot / resume 永続化 runtime は変更なし

## 検証

- `pnpm --dir extensions/suno-helper test tests/popup-compatibility.test.ts` — 74 passed
- persistence / restore focused tests — 151 passed（下段含む）
- stack 全体で full Vitest / check / compile / build / Fallow / Playwright mock E2E / manifest / diff / any gate を実施

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] 下流 migration は不要（保存形式・公開 API の変更なし）

## 制約・関連

- 下段 PR: #3474（#3473）
- native dependency: #3071 is blocked by #3473
- 実 Suno の認証済み Download は #2584 / #3039 とブラウザ認証条件に依存するため、この stack では実施していません。mock E2E と production-path persistence / restore tests までを検証範囲とします。
- 外部仕様・公式資料の参照なし