### PR TITLE
test(suno-helper): FINISHED snapshot の再開契約を固定する (#3473)

### DIFF
--- a/extensions/suno-helper/tests/content-finished-snapshot.test.ts
+++ b/extensions/suno-helper/tests/content-finished-snapshot.test.ts
@@ -28,6 +28,7 @@ async function loadContentScript(
   overrides?: {
     writeFinishedSnapshotError?: Error;
     persistedFinishedSnapshot?: SnapshotPayload | null;
+    downloadFilename?: string;
   }
 ) {
   vi.resetModules();
@@ -57,6 +58,9 @@ async function loadContentScript(
     sendMessage: vi.fn((type: string, payload?: unknown) => {
       if (type === "progress") {
         progressMessages.push(payload as ProgressMessage);
+      }
+      if (type === "startDownload" && overrides?.downloadFilename) {
+        return Promise.resolve({ ok: true });
       }
       return Promise.resolve();
     }),
@@ -173,7 +177,13 @@ async function loadContentScript(
   }));
 
   vi.doMock("../lib/download", () => ({
-    triggerDownloadAll: vi.fn(() => Promise.resolve()),
+    triggerDownloadAll: vi.fn(async () => {
+      if (overrides?.downloadFilename) {
+        handlers.get("downloadComplete")?.({
+          data: { filename: overrides.downloadFilename },
+        });
+      }
+    }),
   }));
 
   vi.doMock("../../shared/api", async () => ({
@@ -254,6 +264,35 @@ describe("content.ts 完了時リロード前の FINISHED snapshot 退避", () =
     expect(writeFinishedSnapshotMock.mock.invocationCallOrder[0]).toBeLessThan(
       scheduleRunCompleteReloadMock.mock.invocationCallOrder[0]
     );
+  });
+
+  it("Given 完全自動生成が完走 When FINISHED snapshot を永続化 Then Download 再開用 clip 契約を保持する", async () => {
+    const autoRunClipIds = ["clip-1", "clip-2", "clip-3", "clip-4"];
+    const { runHandler, progressMessages, writeFinishedSnapshotMock } =
+      await loadContentScript(autoRunClipIds, {
+        downloadFilename: "/downloads/collection.zip",
+      });
+
+    runHandler({
+      data: {
+        ...partialRunPayload(),
+        range: undefined,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.FINISHED })
+      )
+    );
+    expect(writeFinishedSnapshotMock).toHaveBeenCalledWith({
+      snapshot: expect.objectContaining({
+        submittedClipIds: autoRunClipIds,
+        submittedClipIdsAreDurationFiltered: true,
+        playlistExpectedClipCount: autoRunClipIds.length,
+      }),
+      timestamp: expect.any(Number),
+    });
   });
 
   it("Given snapshot 退避が失敗 When FINISHED Then リロードを見送る（in-memory snapshot を生かして復元性を守る）", async () => {


### PR DESCRIPTION
## 概要

完全自動生成の完走時に content producer が永続化する FINISHED snapshot へ、Download 再開に必要な clip ID、duration filter 適用済み flag、期待件数が正確に含まれることを production-path 回帰テストで固定します。

Closes #3473

## 変更内容

- 実際の content `run` handler を完走させ、Download 完了イベントまで通す production-path テストを追加
- `writeFinishedSnapshot` に渡る `submittedClipIds`、`submittedClipIdsAreDurationFiltered`、`playlistExpectedClipCount` を exact 値で検証
- browser download 境界の mock は `startDownload` 成功と `downloadComplete` イベントを本番契約どおり再現
- production runtime は既に契約を満たしたため変更なし

## 検証

- `pnpm --dir extensions/suno-helper test tests/content-finished-snapshot.test.ts` — 10 passed
- stack 全体の check / compile / full Vitest / build / Fallow / Playwright mock E2E は上段と合わせて実施

## チェックリスト

- [x] 必要な production-path 回帰テストを追加した
- [x] production runtime の不要な変更を追加していない
- [x] test-only PR のため `skip-changelog` ラベルを付与した

## 関連

- 上段 UX: #3472
- native dependency: #3071 is blocked by #3473
- 外部仕様・公式資料の参照なし