### PR TITLE
docs(changelog): import path 対応表の契約を定義する (#3476)

### DIFF
--- a/docs/changelog-contract.md
+++ b/docs/changelog-contract.md
@@ -94,6 +94,30 @@ local fix 衝突注意:
 
 `/automation-update` が Top 3 を AI 抽出する際の参考情報として使う。
 
+## Migration の import path 対応表
+
+リリースで import 可能な Python module を移動し、旧 import path に互換 facade を設けない場合、`### Migration` に以下の対応表を置く。該当する移動を全件記載し、下流コードの置換元と置換先を一意にする。
+
+```markdown
+Python module 移動: あり
+互換 facade: なし
+
+| 旧 import path | 新 import path |
+|---|---|
+| `youtube_automation.cli.doctor` | `youtube_automation.commands.system.doctor` |
+```
+
+- 旧 / 新 path は、いずれも `youtube_automation.*` から始まる fully-qualified module path とする
+- class・関数・変数名は表へ含めず、import 文で module として指定する path だけを書く
+- 1 module の移動を 1 行とし、旧 path と新 path に同じ値を書かない
+- 旧 path に互換 facade を残す移動はこの表の対象外とし、通常の Migration サマリで互換範囲を説明する
+
+facade 無しの Python module 移動がないリリースでは、対応表を空のまま置かず、次の 1 行だけを記載する。この状態は「module を移動したが facade が無い」状態と区別される。
+
+```markdown
+Python module 移動: なし
+```
+
 ## 推奨される追加要素（任意）
 
 - バグ修正への issue / PR 参照（`(#NNN)` 形式）

--- a/tests/repo/test_import_migration_contract.py
+++ b/tests/repo/test_import_migration_contract.py
@@ -1,0 +1,59 @@
+"""Migration の import path 対応表フォーマットを検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+_CONTRACT_PATH = REPO_ROOT / "docs" / "changelog-contract.md"
+_SECTION_HEADING = "## Migration の import path 対応表"
+_MOVE_MARKER = "Python module 移動: あり"
+_NO_MOVE_MARKER = "Python module 移動: なし"
+_FACADE_MARKER = "互換 facade: なし"
+_TABLE_HEADER = "| 旧 import path | 新 import path |"
+_MODULE_PATH_PATTERN = re.compile(r"youtube_automation(?:\.[A-Za-z_][A-Za-z0-9_]*)+\Z")
+_ROW_PATTERN = re.compile(r"\| `([^`]+)` \| `([^`]+)` \|")
+
+
+def _contract_section() -> str:
+    text = _CONTRACT_PATH.read_text(encoding="utf-8")
+    start = text.index(_SECTION_HEADING)
+    next_section = text.find("\n## ", start + len(_SECTION_HEADING))
+    return text[start:] if next_section == -1 else text[start:next_section]
+
+
+def _markdown_examples() -> list[str]:
+    return re.findall(r"```markdown\n(.*?)\n```", _contract_section(), flags=re.DOTALL)
+
+
+def test_facade_less_move_example_uses_exact_markers_and_columns() -> None:
+    examples = _markdown_examples()
+    move_example = next(example for example in examples if example.startswith(_MOVE_MARKER))
+    lines = move_example.splitlines()
+
+    assert lines[:2] == [_MOVE_MARKER, _FACADE_MARKER]
+    assert _TABLE_HEADER in lines
+    assert "|---|---|" in lines
+
+
+def test_facade_less_move_example_uses_fully_qualified_module_paths() -> None:
+    examples = _markdown_examples()
+    move_example = next(example for example in examples if example.startswith(_MOVE_MARKER))
+    rows = [_ROW_PATTERN.fullmatch(line) for line in move_example.splitlines()]
+    mappings = [match.groups() for match in rows if match is not None]
+
+    assert mappings
+    for old_path, new_path in mappings:
+        assert _MODULE_PATH_PATTERN.fullmatch(old_path)
+        assert _MODULE_PATH_PATTERN.fullmatch(new_path)
+        assert old_path != new_path
+
+
+def test_no_move_example_is_a_distinct_table_free_state() -> None:
+    examples = _markdown_examples()
+    no_move_example = next(example for example in examples if example.startswith(_NO_MOVE_MARKER))
+
+    assert no_move_example == _NO_MOVE_MARKER
+    assert _TABLE_HEADER not in no_move_example
+    assert _FACADE_MARKER not in no_move_example


### PR DESCRIPTION
## Summary

- facade 無しの Python module 移動を fully-qualified な旧→新 import table で記録する契約を定義
- exact marker・列・旧新 path の非同一性と「移動なし」の表記を contract test で固定

## Verification

- RED: 3 failed（normative section absent）
- GREEN: focused 3 passed / related contracts 14 passed
- ruff check / format / git diff --check

Closes #3476