### PR TITLE
docs(release): import 移動監査を prepare に追加する (#3478)

### DIFF
--- a/.claude/skills/automation-release/SKILL.md
+++ b/.claude/skills/automation-release/SKILL.md
@@ -127,6 +127,23 @@ git checkout -b "release/v${VER}"
 `Edit` ツールで `pyproject.toml` の `version = "X.Y.Z"` 行のみ差し替える。
 他のフィールドや CLI 一覧には触らない。
 
+#### 1-3a. Python module 移動監査
+
+<!-- import-migration-audit-contract:start -->
+1. previous tag から HEAD までの production module 差分を rename 検出付きで取得する。
+
+   ```bash
+   previous_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+   test -n "${previous_tag}" || { echo "ERROR: previous Python tag が見つかりません"; exit 1; }
+   git diff --find-renames --name-status "${previous_tag}..HEAD" -- src/youtube_automation
+   ```
+
+2. rename として検出されなかった deleted / added module は、内容・責務・git history を確認して **手動 D/A pairing** する。package marker を含む各候補について、旧 module が HEAD に残る互換 facade か、facade 無し移動かを分類する。
+3. facade 無し移動のうち、旧 path が **documented / exported / known-downstream-use** のいずれかなら下流影響対象とする。判断根拠と old/new path を監査結果に残す。
+4. 対象 move ごとに `[Unreleased]` の `### Migration` を照合する。`Python module 移動: あり`、`互換 facade: なし`、旧→新の **fully-qualified** `youtube_automation.*` row が全件揃わなければならない。1件でも未記載なら release prepare を停止し、CHANGELOG を補完してから再監査する。
+5. 対象となる facade 無し移動が 0 件なら、監査結果と `### Migration` に `Python module 移動: なし` を明示する。
+<!-- import-migration-audit-contract:end -->
+
 #### 1-4. CHANGELOG.md の昇格
 
 `references/changelog-promotion.md` の 3 段階手順をそのまま実行する。

--- a/.claude/skills/automation-release/references/prepare-checklist.md
+++ b/.claude/skills/automation-release/references/prepare-checklist.md
@@ -44,6 +44,23 @@ awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
 
 無くても abort はしない。`AskUserQuestion` で「Migration セクション無しで続行するか」を確認する。Migration セクションは下流の `/automation-update` が `所要時間の目安` / `local fix 衝突注意` を抽出する契約上の入力源（詳細: `docs/changelog-contract.md`）。
 
+### 4a. Python module 移動監査（必須）
+
+<!-- import-migration-audit-contract:start -->
+1. previous tag から HEAD までの production module 差分を rename 検出付きで取得する。
+
+   ```bash
+   previous_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+   test -n "${previous_tag}" || { echo "ERROR: previous Python tag が見つかりません"; exit 1; }
+   git diff --find-renames --name-status "${previous_tag}..HEAD" -- src/youtube_automation
+   ```
+
+2. rename として検出されなかった deleted / added module は、内容・責務・git history を確認して **手動 D/A pairing** する。package marker を含む各候補について、旧 module が HEAD に残る互換 facade か、facade 無し移動かを分類する。
+3. facade 無し移動のうち、旧 path が **documented / exported / known-downstream-use** のいずれかなら下流影響対象とする。判断根拠と old/new path を監査結果に残す。
+4. 対象 move ごとに `[Unreleased]` の `### Migration` を照合する。`Python module 移動: あり`、`互換 facade: なし`、旧→新の **fully-qualified** `youtube_automation.*` row が全件揃わなければならない。1件でも未記載なら release prepare を停止し、CHANGELOG を補完してから再監査する。
+5. 対象となる facade 無し移動が 0 件なら、監査結果と `### Migration` に `Python module 移動: なし` を明示する。
+<!-- import-migration-audit-contract:end -->
+
 ### 5. 開いている release/* ブランチが無い
 
 ```bash

--- a/tests/repo/test_import_migration_contract.py
+++ b/tests/repo/test_import_migration_contract.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
 
 _CONTRACT_PATH = REPO_ROOT / "docs" / "changelog-contract.md"
 _CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+_RELEASE_SKILL_PATH = REPO_ROOT / ".claude" / "skills" / "automation-release" / "SKILL.md"
+_PREPARE_CHECKLIST_PATH = (
+    REPO_ROOT / ".claude" / "skills" / "automation-release" / "references" / "prepare-checklist.md"
+)
+_AUDIT_CONTRACT_START = "<!-- import-migration-audit-contract:start -->"
+_AUDIT_CONTRACT_END = "<!-- import-migration-audit-contract:end -->"
 _SECTION_HEADING = "## Migration の import path 対応表"
 _MOVE_MARKER = "Python module 移動: あり"
 _NO_MOVE_MARKER = "Python module 移動: なし"
@@ -53,6 +60,13 @@ def _v560_migration_section() -> str:
     release = text[release_start:release_end]
     migration_start = release.index("### Migration")
     return release[migration_start:]
+
+
+def _import_audit_contract(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    start = text.index(_AUDIT_CONTRACT_START)
+    end = text.index(_AUDIT_CONTRACT_END, start)
+    return text[start + len(_AUDIT_CONTRACT_START) : end].strip()
 
 
 def test_facade_less_move_example_uses_exact_markers_and_columns() -> None:
@@ -110,3 +124,30 @@ def test_v560_canonical_import_paths_are_importable_in_subprocess() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_release_prepare_distributes_the_import_migration_audit_contract() -> None:
+    skill_contract = _import_audit_contract(_RELEASE_SKILL_PATH)
+    checklist_contract = _import_audit_contract(_PREPARE_CHECKLIST_PATH)
+
+    assert skill_contract == checklist_contract
+    for required_contract in (
+        'git diff --find-renames --name-status "${previous_tag}..HEAD" -- src/youtube_automation',
+        "手動 D/A pairing",
+        "documented / exported / known-downstream-use",
+        "fully-qualified",
+        _MOVE_MARKER,
+        _FACADE_MARKER,
+        _NO_MOVE_MARKER,
+        "未記載なら release prepare を停止",
+    ):
+        assert required_contract in skill_contract
+
+
+def test_release_prepare_audits_unreleased_before_changelog_promotion() -> None:
+    skill = _RELEASE_SKILL_PATH.read_text(encoding="utf-8")
+    audit_position = skill.index(_AUDIT_CONTRACT_START)
+    promotion_position = skill.index("#### 1-4. CHANGELOG.md の昇格")
+
+    assert "`[Unreleased]` の `### Migration`" in _import_audit_contract(_RELEASE_SKILL_PATH)
+    assert audit_position < promotion_position


### PR DESCRIPTION
## Summary

- release prepare に previous tag→HEAD の Python module move/delete/add 監査を追加
- rename 検出と手動 D/A pairing、downstream 影響分類、facade 有無、Migration row 全件照合を SKILL/checklist で統一
- import audit を CHANGELOG promotion 前の 1-3a に配置し、実対象 `[Unreleased]::Migration` と実行順を contract test で固定
- 未記載時は停止し、移動なしの場合も明示

## Verification

- Initial RED: 1 failed / 5 passed（共有 import audit contract 欠落）
- Initial GREEN: focused 6 passed / distributed references 10 passed
- Review fix RED: 1 failed / 6 passed（audit marker が promotion 後）
- Review fix GREEN: focused + distributed references 11 passed
- `uv run yt-skills lint`: 57 skills
- ruff check / ruff format / git diff --check

Closes #3478