### PR TITLE
docs(skill): mode 引数を description に自己記述する (#3485)

### DIFF
--- a/docs/skill-design/skill-authoring-guidelines.md
+++ b/docs/skill-design/skill-authoring-guidelines.md
@@ -89,6 +89,7 @@ skill に新しい mode・variant を設ける場合は、呼び出しを `--<mo
 
 実行者はまず `description` だけを見てスキルを選ぶ。ここが唯一の選択インターフェースなので、**発動条件と否定条件の両方**を書く。
 
+- skill が mode・variant を持つ場合は、対応する引数（`--batch`、`--since <N>` など）を `description` に列挙する。本文だけに記載してもスキル選択時には見えないため、本文を `description` の代わりにしない。
 - 標準型: 用途 + 発動キーワード + `〜の場合は /<sibling> を使う`。棲み分けは双方向に書く（A→B と B→A の両方）。
 - frontmatter の記法規約（`description:` の double-quote 等）は `CLAUDE.md`「### skill frontmatter」を正とし、ここでは再掲しない。検証は `uv run yt-skills lint`。
 - **良い実例**: [.claude/skills/short/SKILL.md](../../.claude/skills/short/SKILL.md) と [.claude/skills/short-release/SKILL.md](../../.claude/skills/short-release/SKILL.md) — collection 型 / release 型を互いに否定トリガーで排他している。


### PR DESCRIPTION
## Summary

- 対応する mode 引数を frontmatter `description:` に列挙する契約を追加
- 既存の「description はスキル選択の唯一の API」原則へ接続
- 既存 skill frontmatter の一括変更と lint rule追加は対象外

## Verification

- docs consistency / distributed references: 74 passed
- `yt-skills lint`: 57 skill passed
- `git diff --check`

Closes #3485