### PR TITLE
docs(skill): 既存skillへのmode追加を優先検討する (#3486)

### DIFF
--- a/docs/skill-design/skill-authoring-guidelines.md
+++ b/docs/skill-design/skill-authoring-guidelines.md
@@ -82,6 +82,8 @@
 
 skill に新しい mode・variant を設ける場合は、呼び出しを `--<mode>` 形式の引数で表す。`mode=<name>` 形式や自然言語の mode 名を新規に導入しない。値を伴う variant も、名前付き引数として表現する。
 
+既存 skill と責務・完了条件を共有する新しい利用形態は、skill を新設する前に、既存 skill へ `--<mode>` 引数を追加できないかを先に検討する。新しい責務または独立した完了条件を持つ場合の skill 新設は禁止しない。また、この原則を既存の skill family へ遡及適用して統合することは要求しない。
+
 - mode の実例: [community-draft の `--batch`](../../.claude/skills/community-draft/SKILL.md)
 - 値を伴う variant の実例: [flop-analysis の `--since <N>`](../../.claude/skills/flop-analysis/SKILL.md)
 


### PR DESCRIPTION
## Summary

- 新しい mode は新規 skill より既存 skill への `--` 引数追加を先に検討
- 既存 skill family への遡及適用は強制しない
- 独立した責務・完了条件を持つ場合の skill 新設は維持

## Verification

- docs consistency / distributed references: 74 passed
- `yt-skills lint`: 57 skill passed
- `git diff --check`

Closes #3486