### PR TITLE
docs(thumbnail): prompt schema 参照を配布内に正規化する (#3487)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -343,7 +343,7 @@ from the reference image. Keep all corners clean and free of such marks.
 - **textless main 再生成**: 承認済み `thumbnail.jpg` を参照し、除去指示（`text_strip_clause` を設定していれば展開、未設定なら `Remove all text` 相当を明記）だけを足す
 - **two_phase（テキストオーバーレイ）**: `thumbnail_text.text_overlay_prompt` が単一の入口。旧個別フィールド（`channel_name_style` / `title_format` / `title_prefix` / `copy_position` / `color` / `decoration`）は deprecated で、位置・色・装飾の意図は `text_overlay_prompt` の本文に直接書く（段階的廃止 #1702。override は当面 deep-merge され続けるが、config ロード時に DeprecationWarning が出る）
 
-> 将来検討（issue #654）: imagegen の 14 項目 Shared prompt schema 形式と既存 skill-config の bridge ヘルパが `references/prompt-schema.md` および `youtube_automation.infrastructure.media.image_provider.prompt_schema` に試験導入されている。実本番フローからは未接続。設計判断は `docs/skill-design/ADR-001-thumbnail-prompt-schema.md`。
+> 将来検討（issue #654）: imagegen の 14 項目 Shared prompt schema 形式と既存 skill-config の bridge ヘルパが `references/prompt-schema.md` および `youtube_automation.infrastructure.media.image_provider.prompt_schema` に試験導入されている。実本番フローからは未接続。設計判断は `references/prompt-schema.md`。
 
 ## ワークフロー
 

--- a/tests/repo/test_distributed_skill_references.py
+++ b/tests/repo/test_distributed_skill_references.py
@@ -50,7 +50,6 @@ _KNOWN_UNRESOLVED: frozenset[tuple[str, str]] = frozenset(
             "docs/migration/numbered-duplicate-files-cleanup.md",
         ),
         (".claude/skills/community-draft/SKILL.md", "docs/adr/0019-community-helper-extension.md"),
-        (".claude/skills/thumbnail/SKILL.md", "docs/skill-design/ADR-001-thumbnail-prompt-schema.md"),
         (
             ".claude/skills/thumbnail/references/prompt-schema.md",
             "docs/skill-design/ADR-001-thumbnail-prompt-schema.md",


### PR DESCRIPTION
## Summary

- thumbnail skill の wheel 非同梱 ADR 参照を、既存の配布対象 `references/prompt-schema.md` へ正規化
- distributed reference test の stale allowlist を削除
- 実行手順・コマンド・承認順は変更なし

## Verification

- RED: stale allowlist を検出して 1 failed
- GREEN: docs/distributed 74 passed
- thumbnail asset baseline 88 passed
- `yt-skills lint thumbnail`
- ruff check / ruff format --check
- `git diff --check`

Closes #3487