### PR TITLE
docs(thumbnail): generation 詳細を段階開示する (#3489)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -244,6 +244,8 @@ Use the title {title}.
 | `diff_from_reference` | 既存キャラ画像を参照に差分指示 |
 | `two_phase` | 従来方式フォールバック。既存参照を選択 → テキスト付き `thumbnail.jpg` 確定 → 承認済み `thumbnail.jpg` から textless `main.png/jpg` 再生成 |
 
+モードを選んだ後の参照ローテーション、プロンプト展開、Single-Step / TTP と Two-Phase の詳細は [generation workflow 詳細](references/generation-workflows.md) を読む。実行順序・コマンド・承認ゲートは後続の本文を正とする。
+
 ### 参照画像モード（必須）
 
 参照画像を渡して TTP の勝ちパターンを踏襲する方式。`single_step` では参照画像なしの生成は行わない。
@@ -260,41 +262,15 @@ uv run yt-generate-image \
 - `reference_images.default` には同じベンチマークチャンネル内の別サムネイル画像を並べる
 - `--max-attempts N` のときは N 枚以上のユニーク参照画像が必要。不足・重複・同一参照の再利用はエラー
 - `--reference-index N` を指定した場合のみ単一参照固定になり、attempt 数は 1 に固定される
-- `path_base: "channel_dir"` の場合、パスはプロジェクトルートからの相対パス
 - `--reference` 使用時は `composition_prefix` が自動スキップされる（generate_image.py 修正済み）
+
+パス解決と collection 間ローテーションの詳細は [generation workflow 詳細](references/generation-workflows.md) に従う。
 
 ## プロンプト構築
 
-プロンプト指示の解説はこのセクションを単一ソースとし、各モードの節（Single-Step / Two-Phase）には差分だけを書く。補足の原則は `references/prompting.md`、短い差分プロンプト例は `references/sample-prompts.md` を参照する。
+生成時は `image_generation.gemini.diff_prompt_template` のプレースホルダを置換し、TTP では `${ip_safety_clause}` を必ず展開する。textless 再生成では承認済み `thumbnail.jpg` を参照し、テキスト除去指示だけを足す。Two-Phase のテキスト付き候補は `thumbnail_text.text_overlay_prompt` を入口とする。
 
-**原則: 参照画像主導 + 最小限のキーワード。** TTP では勝ちパターンは参照画像が運ぶ。プロンプトに指示を積むほど参照画像の支配力が薄れるため、プロンプトにはテーマ・主題・スタイルなど最小限のキーワードと、サムネに焼くタイトルだけを書く。
-
-**既定の組み立て（provider 共通）:**
-
-1. `image_generation.gemini.diff_prompt_template`（TTP 方針行 + `{title_line1}` / `{title_line2}`）のプレースホルダを置換する
-2. 既定で展開する clause は `${ip_safety_clause}` の 1 つだけ（#569、TTP で常時挿入必須）
-
-opt-in clause（`variation_clause` / `style_lock_clause` / `text_strip_clause` / `anatomy_clause` / `typography_clause`）は既定空文字。必要なチャンネルだけ `config/skills/thumbnail.yaml` に本文を設定し、自前の `diff_prompt_template` で展開する（推奨文面は `config.default.yaml` のコメント参照）。複数の clause を同時に積み上げない — バリエーション vs スタイル固定 vs テキスト除去の指示は相互に打ち消し合い、参照画像の支配力を薄める。
-
-**最終プロンプト例（TTP / 既定 config でプロバイダーへ渡る全文）:**
-
-```text
-TTP this reference thumbnail, then improve it into a stronger original thumbnail.
-Keep the winning layout, typography feel, character scale, color mood, texture, and energy.
-Make it cleaner, more readable on mobile, stronger face impact, no logos, no watermarks, no broken hands.
-Use the title Midnight Jazz Rainy Tokyo Mood.
-Do not reproduce any signature, autograph, handwritten name, watermark,
-logo, brand mark, channel badge, copyright notice, or identifying mark
-from the reference image. Keep all corners clean and free of such marks.
-```
-
-参照画像 + この最小プロンプトだけで TTP は機能する。テーマ固有の差分（色・オブジェクト）を足す場合も 1〜2 文にとどめる。
-
-**モード別差分:**
-
-- **single_step（テキスト付き thumbnail 候補）**: 既定の組み立てをそのまま使う。手順の詳細は「Single-Step / TTP モード > プロンプト構築」
-- **textless main 再生成**: 承認済み `thumbnail.jpg` を参照し、除去指示（`text_strip_clause` を設定していれば展開、未設定なら `Remove all text` 相当を明記）だけを足す
-- **two_phase（テキストオーバーレイ）**: `thumbnail_text.text_overlay_prompt` が単一の入口。旧個別フィールド（`channel_name_style` / `title_format` / `title_prefix` / `copy_position` / `color` / `decoration`）は deprecated で、位置・色・装飾の意図は `text_overlay_prompt` の本文に直接書く（段階的廃止 #1702。override は当面 deep-merge され続けるが、config ロード時に DeprecationWarning が出る）
+参照画像主導の原則、opt-in clause の選び方、完成プロンプト例、モード別差分は [generation workflow 詳細](references/generation-workflows.md) を読む。
 
 > 将来検討（issue #654）: imagegen の 14 項目 Shared prompt schema 形式と既存 skill-config の bridge ヘルパが `references/prompt-schema.md` および `youtube_automation.infrastructure.media.image_provider.prompt_schema` に試験導入されている。実本番フローからは未接続。設計判断は `references/prompt-schema.md`。
 
@@ -443,7 +419,7 @@ config 側のデフォルトは `image_generation.gemini.single_step.{max_attemp
 
 #### プロンプト構築
 
-TTP 生成方針は provider によらず共通: 参照サムネを winning template として扱い、winning layout を維持したまま品質改善（mobile readability / face impact / no logos / no watermarks / no broken hands）だけを指示する（codex 節の「既定テンプレート」と同じ方針。#2070）。`config.default.yaml` の `image_generation.gemini.diff_prompt_template` 既定値はこの方針行を codex 既定テンプレートと同期しており、チャンネル側 `config/skills/thumbnail.yaml` の `diff_prompt_template` があればそちらが常に優先される。`provider: gemini_cli`（サブスク認証の gemini CLI 経由）も同じ `diff_prompt_template` とこの構築手順を共有し、CLI ラッパーはプロンプトを方針を変えずそのまま透過する（model / CLI protocol のみ異なる。#2071、`tests/infrastructure/media/test_image_provider_gemini_cli.py` の contract test で機械担保）。
+テンプレート展開と provider 間の共通方針は [generation workflow 詳細](references/generation-workflows.md) を読む。実行時は以下の入力と安全ゲートを必ず適用する。
 
 1. `image_generation.gemini.color_themes` からテーマのカラー設定を取得
 2. `image_generation.gemini.diff_prompt_template` のプレースホルダーを置換してプロンプト構築:
@@ -551,7 +527,7 @@ Two-Phase は旧チャンネル向けのフォールバック。使う場合も�
 **`thumbnail_text.text_overlay_prompt` が定義されている場合（推奨）:**
 テンプレート内の `{title_line1}`, `{title_line2}`, `{channel_name}` をコレクションのタイトルとチャンネル名で置換して使用。
 
-**未定義の場合（フォールバック）:** `references/sample-prompts.md` の「Two-Phase モードのテキストオーバーレイ・フォールバックプロンプト」を使用する。
+**未定義の場合（フォールバック）:** [generation workflow 詳細](references/generation-workflows.md) から正規の sample prompt へルーティングする。
 
 `text_overlay_prompt` が実質単一の入口。旧個別フィールド（`channel_name_style` / `title_format` / `title_prefix` / `copy_position` / `color` / `decoration`）は deprecated で、位置・色・装飾の意図は `text_overlay_prompt` の本文に直接書く（段階的廃止 #1702）。
 

--- a/.claude/skills/thumbnail/references/generation-workflows.md
+++ b/.claude/skills/thumbnail/references/generation-workflows.md
@@ -1,0 +1,52 @@
+# generation workflow 詳細
+
+`SKILL.md` の生成モード判定後に読む補足。実行コマンド、生成順序、コスト確認、承認・完了ゲートは `SKILL.md` を正とする。
+
+## 参照画像の選択とローテーション
+
+`reference_images.default` には同じベンチマークチャンネル内の別サムネイルを並べる。`--max-attempts N` では N 枚以上のユニーク参照を用意し、attempt ごとに別の 1 枚を使う。`--reference-index N` を明示したときだけ単一参照に固定し、attempt 数も 1 にする。
+
+`path_base: "channel_dir"` の場合、設定値はチャンネルディレクトリを基準に解決する。`reference_images.dedup_recent_collections` は過去 collection の `thumbnail-prompts.md` にある `Reference Assignments` を履歴とし、参照プールが候補数より大きいときに先頭候補の早期再利用を避ける。別チャンネルや stock 画像は TTP 参照プールと別スコープにし、採用元を記録する。
+
+## プロンプト構築
+
+**原則: 参照画像主導 + 最小限のキーワード。** TTP では勝ちパターンを参照画像が運ぶ。プロンプトにはテーマ・主題・スタイルなど最小限のキーワードと、必要なタイトルだけを書く。
+
+**既定の組み立て（provider 共通）:**
+
+1. `image_generation.gemini.diff_prompt_template`（TTP 方針行 + `{title_line1}` / `{title_line2}`）のプレースホルダを置換する
+2. 既定で展開する clause は `${ip_safety_clause}` の 1 つだけ（TTP で常時挿入必須）
+
+opt-in clause（`variation_clause` / `style_lock_clause` / `text_strip_clause` / `anatomy_clause` / `typography_clause`）は既定空文字。必要なチャンネルだけ override に本文を設定し、自前の `diff_prompt_template` で展開する。複数の clause を同時に積み上げない。バリエーション、スタイル固定、テキスト除去を同時に強く指示すると、参照画像の支配力が薄れる。
+
+**最終プロンプト例（TTP / 既定 config でプロバイダーへ渡る全文）:**
+
+```text
+TTP this reference thumbnail, then improve it into a stronger original thumbnail.
+Keep the winning layout, typography feel, character scale, color mood, texture, and energy.
+Make it cleaner, more readable on mobile, stronger face impact, no logos, no watermarks, no broken hands.
+Use the title Midnight Jazz Rainy Tokyo Mood.
+Do not reproduce any signature, autograph, handwritten name, watermark,
+logo, brand mark, channel badge, copyright notice, or identifying mark
+from the reference image. Keep all corners clean and free of such marks.
+```
+
+**モード別差分:**
+
+- single_step は既定の組み立てを使う。
+- textless main 再生成は承認済み `thumbnail.jpg` を参照し、`text_strip_clause` または同等の除去指示だけを足す。
+- two_phase は `thumbnail_text.text_overlay_prompt` を単一の入口とする。
+
+## Single-Step / TTP 詳細
+
+TTP 生成方針は provider によらず共通。参照サムネを winning template とし、winning layout を維持したまま mobile readability / face impact / no logos / no watermarks / no broken hands の品質改善だけを指示する。`config.default.yaml` の既定 template と codex 既定 template はこの方針行を共有し、チャンネル側 override があればそちらを優先する。
+
+`provider: gemini_cli` も同じ `diff_prompt_template` とこの構築手順を共有し、ラッパーは prompt の方針を変えない。カラーテーマ、オブジェクト、タイトルの placeholder を入力から展開し、IP safety を必須にする。手や指が壊れる構図だけ `anatomy_clause` を opt-in clause として追加する。
+
+collection 間のローテーションでは最近の `Reference Assignments` を見て参照の偏りを抑える。同じ attempt 内の重複と、候補数より少ない参照プールはエラーとする。
+
+## Two-Phase 詳細
+
+Phase 1 では既存画像を Phase 2 の参照素材としてだけ選び、この時点で `main.png/jpg` として確定しない。Phase 2 でテキスト付き候補を作り、Phase 3 で承認済み `thumbnail.jpg` から textless main を作る。
+
+`thumbnail_text.text_overlay_prompt` があれば `{title_line1}` / `{title_line2}` / `{channel_name}` を置換する。未定義なら `references/sample-prompts.md` の「Two-Phase モードのテキストオーバーレイ・フォールバックプロンプト」を使う。旧個別フィールドは deprecated であり、位置・色・装飾は `text_overlay_prompt` 本文に直接書く。

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -28,6 +28,11 @@ def _read_thumbnail_provider_guidance() -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_thumbnail_generation_workflows() -> str:
+    path = _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "generation-workflows.md"
+    return path.read_text(encoding="utf-8")
+
+
 def _read_loop_video_skill() -> str:
     path = _repo_root() / ".claude" / "skills" / "loop-video" / "SKILL.md"
     return path.read_text(encoding="utf-8")
@@ -1367,17 +1372,18 @@ def test_thumbnail_gemini_diff_template_channel_override_takes_priority(tmp_path
 
 def test_thumbnail_docs_state_provider_agnostic_ttp_policy() -> None:
     """#2070: SKILL.md / prompting.md が provider 差なく同じ TTP 方針を明示する。"""
-    skill = _read_thumbnail_skill()
     prompting = (_repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "prompting.md").read_text(
         encoding="utf-8"
     )
 
-    assert "TTP 生成方針は provider によらず共通" in skill
+    generation_workflows = _read_thumbnail_generation_workflows()
+
+    assert "TTP 生成方針は provider によらず共通" in generation_workflows
     assert "TTP 方針は provider 共通" in prompting
     assert "チャンネル側 override" in prompting
     # #2071: gemini_cli 経路も同じ diff_prompt_template と構築手順を共有することを明示
-    assert "`provider: gemini_cli`" in skill
-    assert "同じ `diff_prompt_template` とこの構築手順を共有" in skill
+    assert "`provider: gemini_cli`" in generation_workflows
+    assert "同じ `diff_prompt_template` とこの構築手順を共有" in generation_workflows
 
 
 def test_thumbnail_default_config_codex_template_matches_skill_md_block() -> None:
@@ -1562,8 +1568,7 @@ def test_thumbnail_default_config_slims_composition_rules_and_thumbnail_text() -
 
 def test_thumbnail_skill_prompt_section_is_single_source_with_final_prompt_example() -> None:
     """#1702: プロンプト指示解説は 1 セクション + モード別差分に集約し、最終プロンプト例を 1 例掲載する。"""
-    skill = _read_thumbnail_skill()
-    prompt_section = _slice_between(skill, "## プロンプト構築", "## ワークフロー")
+    prompt_section = _read_thumbnail_generation_workflows()
 
     assert "最小限のキーワード" in prompt_section
     assert "参照画像主導" in prompt_section
@@ -1574,9 +1579,43 @@ def test_thumbnail_skill_prompt_section_is_single_source_with_final_prompt_examp
     assert "Do not reproduce any signature" in prompt_section
     # 既定 clause は ip_safety のみ。多重 clause の同時展開指示は解消済み
     assert "${ip_safety_clause}` の 1 つだけ" in prompt_section
-    single_step_prompt_block = _slice_between(skill, "#### プロンプト構築", "#### 生成コマンド")
+    single_step_prompt_block = _slice_between(prompt_section, "## Single-Step / TTP 詳細", "## Two-Phase 詳細")
     assert "共通ガイダンス clause（`single_step.variation_clause` / `style_lock_clause`" not in single_step_prompt_block
     assert "opt-in clause" in single_step_prompt_block
+
+
+def test_thumbnail_skill_routes_generation_details_without_moving_runtime_contract() -> None:
+    skill = _read_thumbnail_skill()
+    route = "[generation workflow 詳細](references/generation-workflows.md)"
+
+    assert skill.index("## 生成モード判定") < skill.index(route) < skill.index("## ワークフロー")
+    for mode in ("`single_step`", "`diff_from_reference`", "`two_phase`"):
+        assert mode in _slice_between(skill, "## 生成モード判定", "## ワークフロー")
+    assert skill.count("uv run yt-generate-image") == 11
+    assert skill.count("uv run yt-thumbnail-text") == 1
+    assert skill.count("archive-approved-thumbnail.py") == 5
+    assert '### Single-Step / TTP モード（`generation_mode: "single_step"`、デフォルト・推奨）' in skill
+    assert "### Two-Phase モード（従来方式・フォールバック）" in skill
+    assert "/thumbnail-compare" in skill
+    assert "ユーザー承認" in skill
+    assert "## 完了条件" in skill
+
+
+def test_thumbnail_generation_workflows_owns_generation_details_once() -> None:
+    skill = _read_thumbnail_skill()
+    details = _read_thumbnail_generation_workflows()
+    combined = skill + details
+    moved_details = (
+        '`path_base: "channel_dir"',
+        "複数の clause を同時に積み上げない",
+        "**最終プロンプト例（TTP / 既定 config でプロバイダーへ渡る全文）:**",
+        "TTP 生成方針は provider によらず共通",
+        "Two-Phase モードのテキストオーバーレイ・フォールバックプロンプト",
+    )
+    for detail in moved_details:
+        assert detail not in skill
+        assert details.count(detail) == 1
+        assert combined.count(detail) == 1
 
 
 def test_thumbnail_skill_quality_check_covers_hand_anatomy() -> None:


### PR DESCRIPTION
## Summary

- rotation・prompt expansion・Single-Step/TTP/Two-Phase の詳細を `references/generation-workflows.md` へ移設
- SKILL 本文には mode decision、標準呼び出し順、実行コマンド、承認・完了 gates を維持
- routing・配置・内容保存を強い契約テストで固定し、実行挙動は変更なし

## Verification

- RED: reference/routing 欠落で 4 failed
- GREEN: thumbnail assets 64 passed
- docs/distributed references 74 passed
- installed-wheel asset sync 1 passed
- `yt-skills lint thumbnail`
- ruff check / ruff format --check
- `git diff --check`

Closes #3489