### PR TITLE
refactor(cli): automation-update help を自己完結させる (#3511)

### DIFF
--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -45,6 +45,7 @@ EXIT_UP_TO_DATE = 0
 EXIT_DIFF = 1
 EXIT_ERROR = 2
 _STABLE_RELEASE_TAG_RE = re.compile(r"v\d+\.\d+\.\d+")
+_TARGET_HELP = "下流チャンネルリポジトリのルート。省略時は CWD から親方向へ自動解決"
 
 
 class _StepFailed(Exception):
@@ -432,35 +433,58 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_check = sub.add_parser("check", help="実行場所・pin 形式・upstream 最新との差分を判定 (read-only)")
-    p_check.add_argument("--target", default=None, help="対象チャンネルリポジトリ (default: CWD から自動解決)")
-    p_check.add_argument("--tag", default=None, help="比較先 tag を明示 (default: upstream 最新リリース)")
+    p_check.add_argument("--target", default=None, help=_TARGET_HELP)
+    p_check.add_argument(
+        "--tag",
+        default=None,
+        help="tag pin 専用の比較先。vX.Y.Z 形式で指定し、省略時は upstream の最新 stable release",
+    )
     p_check.set_defaults(func=cmd_check)
 
     p_apply = sub.add_parser("apply", help="pin 書き換え → uv lock → yt-skills sync → smoke check を一括実行")
-    p_apply.add_argument("--target", default=None, help="対象チャンネルリポジトリ (default: CWD から自動解決)")
-    p_apply.add_argument("--tag", default=None, help="追従先 tag を明示 (default: upstream 最新リリース)")
-    p_apply.add_argument("--rev", default=None, help="sha pin の bump 先 sha（sha pin では必須）")
+    p_apply.add_argument("--target", default=None, help=_TARGET_HELP)
+    p_apply.add_argument(
+        "--tag",
+        default=None,
+        help="tag pin 専用の追従先。vX.Y.Z 形式で指定し、省略時は upstream の最新 stable release",
+    )
+    p_apply.add_argument(
+        "--rev",
+        default=None,
+        help="sha pin 専用の追従先。40 桁の hex SHA を指定し、sha pin では必須",
+    )
     p_apply.add_argument(
         "--force-sync",
         action="store_true",
-        help="互換用。apply は human step 後の機械実行として常に yt-skills sync --force を使う",
+        help=(
+            "local fix の破棄を承認済みの場合に、yt-skills diff の local fix guard だけを bypass し、"
+            "upstream 版で上書きする"
+        ),
     )
     p_apply.add_argument(
         "--accept-hooks",
         action="store_true",
-        help="settings asset が提示する新規 hook の追加を承認する（省略時は hook だけスキップ）",
+        help=(
+            "--sync-only では使用しない。全 asset 同期時に settings asset の新規 hook 追加を承認する。"
+            "省略時は新規 hook だけ追加しない"
+        ),
     )
     p_apply.add_argument(
         "--sync-only",
         nargs="+",
         default=None,
         metavar="SKILL",
-        help="skills asset を指定スキルのみ同期する（claude-md asset も同期するため local fix guard は実行）",
+        help=(
+            "配布済み skill 名を 1 件以上指定し、skills asset の指定スキルと claude-md asset だけを同期する。"
+            "local fix guard は既定で維持し、--force-sync 併用時のみ bypass"
+        ),
     )
     p_apply.add_argument(
         "--allow-dirty",
         action="store_true",
-        help="作業ツリーが clean でなくても実行する（途中失敗からの再実行用）",
+        help=(
+            "途中失敗からの再実行時に作業ツリーの clean guard だけを bypass する。それ単独では local fix guard は維持"
+        ),
     )
     p_apply.set_defaults(func=cmd_apply)
 

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -150,6 +150,56 @@ def recorded_commands(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     return commands
 
 
+def _subcommand_help(command: str, capsys: pytest.CaptureFixture) -> str:
+    with pytest.raises(SystemExit) as exc_info:
+        main([command, "--help"])
+
+    assert exc_info.value.code == 0
+    return " ".join(capsys.readouterr().out.split())
+
+
+@pytest.mark.parametrize("command", ["check", "apply"])
+def test_subcommand_help_explains_target_resolution(command: str, capsys: pytest.CaptureFixture) -> None:
+    help_text = _subcommand_help(command, capsys)
+
+    assert "下流チャンネルリポジトリのルート" in help_text
+    assert "省略時は CWD から親方向へ自動解決" in help_text
+
+
+def test_check_help_explains_tag_pin_comparison(capsys: pytest.CaptureFixture) -> None:
+    help_text = _subcommand_help("check", capsys)
+
+    assert "tag pin 専用" in help_text
+    assert "vX.Y.Z 形式" in help_text
+    assert "省略時は upstream の最新 stable release" in help_text
+
+
+def test_apply_help_explains_pin_specific_revision_inputs(capsys: pytest.CaptureFixture) -> None:
+    help_text = _subcommand_help("apply", capsys)
+
+    assert "tag pin 専用" in help_text
+    assert "vX.Y.Z 形式" in help_text
+    assert "省略時は upstream の最新 stable release" in help_text
+    assert "sha pin 専用" in help_text
+    assert "40 桁の hex SHA" in help_text
+    assert "sha pin では必須" in help_text
+
+
+def test_apply_help_explains_safety_flag_scope(capsys: pytest.CaptureFixture) -> None:
+    help_text = _subcommand_help("apply", capsys)
+
+    assert "local fix の破棄を承認済み" in help_text
+    assert "local fix guard だけを bypass" in help_text
+    assert "配布済み skill 名を 1 件以上指定" in help_text
+    assert "skills asset の指定スキルと claude-md asset" in help_text
+    assert "local fix guard は既定で維持" in help_text
+    assert "全 asset 同期時" in help_text
+    assert "--sync-only では使用しない" in help_text
+    assert "省略時は新規 hook だけ追加しない" in help_text
+    assert "作業ツリーの clean guard だけを bypass" in help_text
+    assert "それ単独では local fix guard は維持" in help_text
+
+
 # ---------------------------------------------------------------------------
 # 実行場所判定 (要件 3)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `check` / `apply --help` に tag pin、40桁SHA、動的な既定動作を明記
- `--force-sync`、`--sync-only`、`--accept-hooks`、`--allow-dirty` の安全境界を実装どおりに説明
- parser の default・validation・実行挙動は変更せず、公開 help 契約をテストで固定

## Test

- `uv run pytest tests/commands/system/test_automation_update.py tests/test_cli_help_contract.py -q`（163 passed）
- `uv run ruff check ...` / `uv run ruff format --check ...`
- `git diff --check`

Closes #3511