### PR TITLE
docs(thumbnail): quality 詳細を段階開示する (#3490)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -353,27 +353,12 @@ uv run yt-generate-image \
 
 これは前提ガードではない。ファイルが存在しない、またはスキーマの見出し・必須キーを満たさない場合は「thumbnail-text-profile なし」と表示し、`config.default.yaml` の現行デフォルト値（チャンネル上書きがあれば deep-merge 後の実効値)のまま標準フローを続行する。エラーで停止しない。
 
-profile が存在する場合、3 セクションを次のとおり適用する:
 
-| profile セクション | 適用先 | 変換 |
-|---|---|---|
-| `## font_tendency` | `image_generation.gemini.thumbnail_text.overlay.font.title`（必要なら `overlay.title.stroke_width` / `stroke_color` も） | 下流環境の既存ローカルフォント（日本語対応 .ttf/.otf/.ttc）から `typeface_classification` / `weight` に近い書体を選定する。`outline: present` なら縁取り（`stroke_width` > 0）を維持する |
-| `## text_content_pattern` | `--title` に渡すコピー生成の制約（config 変更なし） | タイトル行を `line_count_range` / `languages` / `character_count_range` / `copy_pattern` に従って生成する。競合のチャンネル名・コレクション名・シリーズ名・コピー原文（固有の文言）は使わない |
-| `## placement_tendency` | `overlay.layout.anchor` / `margin_x` / `margin_y` | `anchor_position` を 9 アンカー（`top|center|bottom` - `left|center|right`、中央は `center`）のいずれかへ、`margin` をピクセル値へ変換する |
-
-- 値が `unknown` のキーは適用せず、該当項目は実効デフォルト値のまま進む
-- フォント選定は**ローカルに既にあるファイルだけ**を対象にする（`fc-list :lang=ja file family style`、`/System/Library/Fonts/`・`~/Library/Fonts/`・`<channel_dir>/assets/fonts/` の列挙など）。フォントファイルの同梱・自動ダウンロードはしない。日本語対応の候補が見つからない場合は入手先（Google Fonts 等）と配置先 `<channel_dir>/assets/fonts/` を案内し、配置を待つか AI 焼き込み経路へ fallback するかをユーザーに確認する
-- profile 不在でも `overlay.font.title` が未設定の場合は、同じローカルフォント選定手順で日本語対応フォントを 1 つ選んで設定してから合成に進む（profile 由来の傾向は適用しない。これにより分析モード未実行チャンネルでもフォントの揺れだけは解消される）
-- 変換した値は `config/skills/thumbnail.yaml` の該当キーへ、設定内容と根拠（profile のどの傾向か）をユーザーへ提示し承認を得てから書き込む。「設定読み込みゲート」の「勝手に作成しない」は読み取り時の原則であり、この手順は承認を得た明示的な更新として扱う。書き込み後は deep-merge 後の実効値を再確認してから合成に進む
+変換表、ローカルフォント選定、`unknown` の扱いは [quality / operations 詳細](references/quality-and-operations.md) を読む。変換値は設定内容と根拠をユーザーに提示し、**承認を得てから** `config/skills/thumbnail.yaml` へ書き込む。書き込み後は deep-merge 後の実効値を再確認する。
 
 ### 承認済みサムネイルのアーカイブ
 
 `archive.enabled: false` が既定で、従来どおりギャラリーを作成しない。過去作サムネを TTP テンプレートとして蓄積するチャンネルだけ、`config/skills/thumbnail.yaml` で opt-in する:
-
-```yaml
-archive:
-  enabled: true
-```
 
 決定的合成（フォント固定・標準）、AI 焼き込みの手動承認、codex、Two-Phase の各経路では、それぞれの既存の検証・承認順序を変えず、最終 `10-assets/thumbnail.jpg` または `thumbnail.png` の確定直後に次の共通コマンドを 1 回実行する:
 
@@ -381,7 +366,7 @@ archive:
 uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>
 ```
 
-自動選択では、既存どおりユーザー承認を省略し、`yt-thumbnail-auto-select --apply` が確定直後にこの処理を内部で実行してから workflow-state を更新する。有効時は `assets/thumbnail-gallery/<collection-dir-name>.<ext>` へ元の拡張子と内容のままコピーする。同じコレクションを再承認した場合は最新の確定サムネで置き換える。無効時は副作用なしで正常終了する。設定不正、確定サムネ欠落、シンボリックリンク、コピー失敗は明示エラーで停止し、アーカイブ成功として扱わない。アーカイブまたは workflow-state 更新の失敗時、自動選択は確定サムネイル、ギャラリー、workflow-state を元に戻す。自動確定後の `/thumbnail-compare` と後工程の順序は従来どおり変更しない。
+自動選択では、既存どおりユーザー承認を省略し、`yt-thumbnail-auto-select --apply` が確定直後にこの処理を内部で実行してから workflow-state を更新する。設定不正、確定サムネ欠落、コピーまたは state 更新失敗は明示エラーで停止し、成功として扱わない。保存先・置換・ロールバックの詳細は [quality / operations 詳細](references/quality-and-operations.md) を読む。自動確定後の `/thumbnail-compare` と後工程の順序は変更しない。
 
 ### Single-Step / TTP モード（`generation_mode: "single_step"`、デフォルト・推奨）
 
@@ -548,41 +533,9 @@ Two-Phase は旧チャンネル向けのフォールバック。使う場合も�
 | **決定的合成経路**（`yt-thumbnail-text`・**既定**） | textless 背景に実フォントファイル（.ttf/.otf/.ttc）を Pillow で描画 | **完全に安定**。同一の背景・テキスト・設定なら常に同一出力 |
 | **AI プロンプト経路**（fallback・非既定） | テキスト付きサムネ生成プロンプトで書体の雰囲気を指示（`thumbnail_text.font` / `single_step.typography_clause`） | **保証されない**。AI 画像生成はフォント名を厳密に再現できず、同じ指示でも生成ごとに書体が揺れる |
 
-### AI プロンプト経路でのフォント指示（fallback）
+標準は「標準生成順序とファイル契約」の `yt-thumbnail-text` 経路とし、textless 背景の承認後に合成する。文字入り画像を `--background` に流用しない。AI プロンプト経路は fallback であり、フォントの厳密な再現を保証しない。
 
-- **single_step（TTP）**: 初回 `diff_prompt_template` はテキスト付き `thumbnail-v*.jpg/png` 候補生成用。書体の一貫性を高めたい場合は、override に本文を設定（既定空文字の opt-in）した上で `single_step.typography_clause` を展開し、`{font_description}` を `thumbnail_text.font.copy` の値で置換する。承認済み `thumbnail.jpg` から作る textless 再生成プロンプトには、`${typography_clause}` やタイトル文字の描画指示を入れない
-- **two_phase**: Phase 2 のオーバーレイプロンプトで `thumbnail_text.font.copy` / `font.genre_tag` の記述が使われる
-
-いずれも改善であって保証ではない。「同一チャンネルで常に同じフォント」が必要なら決定的合成経路を使う。
-
-### 決定的合成経路（yt-thumbnail-text・標準）
-
-標準 `/thumbnail` フローの既定テキスト描画経路（#1907）。textless 背景 `main.png/jpg` の生成・承認から、`yt-thumbnail-text` 合成 → `/thumbnail-compare` → `thumbnail.jpg` 確定までの手順は「標準生成順序とファイル契約」に従う。フォント選定・コピー生成制約・配置へのプロファイル反映は「thumbnail-text-profile 適用」節に従う。
-
-`config/skills/thumbnail.yaml` にフォントファイルを設定する:
-
-```yaml
-image_generation:
-  gemini:
-    thumbnail_text:
-      overlay:
-        font:
-          title: "assets/fonts/NotoSansJP-Bold.ttf"   # channel_dir 相対 or 絶対パス
-```
-
-フォントファイルは Google Fonts 等から入手し `<channel_dir>/assets/fonts/` に置く運用を推奨（フォントのライセンス条項を確認すること）。サイズ・色・縁取り・配置は `overlay.title` / `overlay.channel_name` / `overlay.layout` で調整する（デフォルト値は `config.default.yaml` 参照）。
-
-決定的合成はテキスト描画だけを担う。`--background` に渡す textless 背景は AI 焼き込みテキストを含まない状態で先に確定しておく。AI 焼き込み経路で確定した過去コレクションのサムネを実フォントで作り直す場合も、承認済み `thumbnail.jpg` から textless `main-v*.png/jpg` を AI 再生成・承認してから合成する（文字入り画像を `--background` に流用しない）。
-
-### フォント指定に失敗した場合
-
-`yt-thumbnail-text` は失敗理由と代替手順を明示して終了コード 1 で停止する:
-
-- **`image_generation.gemini.thumbnail_text.overlay.font.title` 未設定** → `config/skills/thumbnail.yaml` に .ttf/.otf/.ttc のパスを設定する
-- **フォントファイルが存在しない** → パスを確認（相対パスは channel_dir 起点）。フォントを `<channel_dir>/assets/fonts/` に配置し直す
-- **ファイルが壊れている・フォントとして読めない** → 別のフォントファイルを用意する
-
-決定的合成を使わない判断をした場合は、AI プロンプト経路（上記 `typography_clause` / two_phase の `thumbnail_text.font`）へフォールバックする。その場合フォントの厳密な再現は保証されないことをユーザーに伝えること。
+font config、`typography_clause`、ライセンス、失敗時の切り替えは [quality / operations 詳細](references/quality-and-operations.md) を読む。`yt-thumbnail-text` が失敗したら理由を表示して終了コード 1 で停止し、無断で fallback しない。
 
 ## 自動選択（auto-selection・opt-in）
 
@@ -596,17 +549,7 @@ TTP 参照画像が固定されているチャンネルでは、候補生成後�
 
 `selection_only` の既存手順は変更しない。`auto_selection.enabled` が false / 未設定のチャンネルも従来の手動承認フローを使う。
 
-有効化（チャンネル側 `config/skills/thumbnail.yaml`）:
-
-```yaml
-image_generation:
-  auto_selection:
-    enabled: true          # opt-in。false / 未設定なら従来の手動承認フロー
-    mode: selection_only   # selection_only（既定）| full（4 ゲートを省略）
-    min_width: 1280        # 候補の最小解像度
-    min_height: 720
-    aspect_tolerance: 0.01 # 16:9 判定の許容誤差
-```
+有効化キーと採点パラメータは [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
 ### `mode: full` のテーマ自動決定
 
@@ -634,11 +577,7 @@ uv run yt-thumbnail-auto-select <collection-path> --dry-run
 uv run yt-thumbnail-auto-select <collection-path> --apply
 ```
 
-選択ロジック（deterministic・学習なし）:
-
-- `image_generation.gemini.reference_images.default` の各参照画像から特徴量（brightness / contrast / saturation / dominant_hue / colorfulness）を抽出して centroid を作る
-- `10-assets/` の候補（`thumbnail-v*.jpg` / `thumbnail-v*.png` / `thumbnail-codex-v*.png`）を採点し、16:9・最小解像度を満たす候補のうち centroid に最も近いもの（distance 最小）を選ぶ
-- apply 時は選択候補を `thumbnail.jpg` にコピー（PNG 候補は JPEG 変換）し、`workflow-state.json` があれば `thumbnail_auto_selection` キーに選択候補・distance・ランキング・実行時刻を記録する
+採点は deterministic・学習なしで、16:9 と最小解像度を満たす候補から参照群に最も近い候補を選ぶ。特徴量、centroid、distance、監査ログの詳細は [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
 失敗時は silent fallback しない（終了コード 1 / 2 の明示エラー）:
 
@@ -671,25 +610,9 @@ uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json
 JSON で返す（終了コード 0=合格 / 1=不合格）。手作業チェックの前段スクリーニングとして、
 TTP 構図逸脱（wet_runway 不在・矩形ロゴ混入・テキスト burned-in 等）を機械的に検出する。
 
-テキスト付き thumbnail 候補生成後（`thumbnail-v1.jpg` / `thumbnail-codex-v1.png`）:
-- [ ] ベンチマーク参照の構図・主役スケール・光・色温度・背景テクスチャが維持されているか
-- [ ] `/thumbnail-compare` で 320px 縮小時のタイトル可読性・コントラスト・主役認識を確認したか
-- [ ] タイトルテキストが `composition_rules.text_lines` の制約内か
-- [ ] `thumbnail_text.channel_name` が表示されているか
-- [ ] 参照元の署名・サイン・透かし・ロゴ・ブランドマークが焼き込まれていないか
-- [ ] `image_generation.gemini.style` に記載されたスタイルが維持されているか
-- [ ] `fixed_character` の外見が維持されているか（ある場合）
-- [ ] キャラの顔が見えているか（`fixed_character.face` の指示通り）
-- [ ] **解剖学チェック（手・指）**: キャラが写っている場合、手・指が解剖学的に正しいか（各手 5 本指・指の分離が明瞭・指の融合や本数異常・溶融が無い・プロポーションが破綻していない）。**特に楽器持ちキャラ・指を伸ばす/握るポーズでは Gemini が破綻しやすい**ため必ず Read ツールで等倍プレビューを開いて目視確認する。NG なら `anatomy_clause` を強調 / 再生成 / プロバイダー切り替え（codex は人体破綻に強い傾向）で対応する（#570）
+テキスト付き thumbnail 候補は、承認前に `/thumbnail-compare` で 320px 可読性・コントラスト・主役認識を確認し、署名・透かし・ロゴと手指の破綻がないことを目視確認する。textless main 候補は承認済み `thumbnail.jpg` の構図を維持し、タイトル文字・字幕・ロゴ・透かし・タイポグラフィ・チャンネル名が残っていないことを確認する。
 
-textless main 候補生成後（`main-v1.png` / `main-v1.jpg`）:
-- [ ] 承認済み `thumbnail.jpg` の構図・主役スケール・光・色温度・背景テクスチャが textless 背景として維持されているか
-- [ ] タイトル文字、字幕、ロゴ、透かし、タイポグラフィ、チャンネル名が残っていないか
-- [ ] 新しい文字や記号が追加されていないか
-- [ ] `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json` を通したか（JPEG 候補なら `main-v1.jpg` を指定）
-- [ ] `/loop-video` 入力や `/videoup` 静止背景として使える textless 背景になっているか
-
-> **Note (#570)**: キャラ + 手が写る構図で指の破綻が出るチャンネルは、`image_generation.gemini.single_step.anatomy_clause` に本文を設定（既定空文字の opt-in、推奨文面は `config.default.yaml` のコメント）してプロンプト末尾に `${anatomy_clause}` として展開すると、Gemini の手・指破綻（指の融合・本数異常・溶融）の発生率を下げられる。`/collection-ideate` の single_step プレビューは企画参照素材であり最終 thumbnail には流用しないが、参照素材として採用する前にも最低限の QA（手・指 / 署名 / ロゴ）を通すこと。
+完整な thumbnail / textless main の QA チェックリストと `anatomy_clause` の対処は [quality / operations 詳細](references/quality-and-operations.md) を読む。JPEG 候補は `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.jpg --json` のように実ファイルを指定する。セルフチェック、上記の目視 QA、`/thumbnail-compare` が揃うまで承認・確定しない。
 
 ## 視認性検証と整合性監査の役割分担
 
@@ -706,54 +629,7 @@ textless main 候補生成後（`main-v1.png` / `main-v1.jpg`）:
 
 ## プロンプト保存
 
-プロンプトは `20-documentation/thumbnail-prompts.md` に保存:
-
-```markdown
-# Thumbnail Prompts - <コレクション名>
-
-*プロバイダー: {image_generation.provider}*
-*スタイル: {image_generation.gemini.style}*
-*モデル: {image_generation.gemini.model}*
-
-## Reference Assignments
-
-| attempt | output | reference_image | benchmark_channel |
-|---:|---|---|---|
-| 1 | `10-assets/thumbnail-v1.jpg` | `<参照画像 1>` | `<benchmark_channel>` |
-| 2 | `10-assets/thumbnail-v2.jpg` | `<参照画像 2>` | `<benchmark_channel>` |
-| 3 | `10-assets/thumbnail-v3.jpg` | `<参照画像 3>` | `<benchmark_channel>` |
-
-## Text-Included Thumbnail Prompt (thumbnail.jpg)
-
-\```
-<ベンチマーク参照画像からテキスト付きサムネを生成したプロンプト>
-\```
-
-## Textless Background Prompt (main.png/main.jpg)
-
-\```
-<承認済み thumbnail.jpg からテキストなし背景を生成したプロンプト>
-\```
-
-## A/B Test Pattern Prompts
-
-| pattern | final output | variation |
-|---|---|---|
-| `a` | `10-assets/thumbnail-a.jpg` | `<pattern a variation>` |
-| `b` | `10-assets/thumbnail-b.jpg` | `<pattern b variation>` |
-
-### Pattern a Final Prompt
-
-\```
-<diff_prompt_template 展開結果 + pattern a variation>
-\```
-
-### Pattern b Final Prompt
-
-\```
-<diff_prompt_template 展開結果 + pattern b variation>
-\```
-```
+プロンプトは `20-documentation/thumbnail-prompts.md` に保存する。provider / model / style、attempt ごとの output / reference / benchmark channel、テキスト付き生成プロンプト、textless 背景生成プロンプト、A/B pattern ごとの最終プロンプトを欠落なく記録する。正規テンプレートは [quality / operations 詳細](references/quality-and-operations.md) を使う。
 
 ## ファイル命名ルール（上書き禁止）
 
@@ -800,7 +676,7 @@ JSON
 
 ## stock 退避と再利用
 
-不採用画像は `<channel_dir>/assets/stock/<theme-slug>/` に画像本体 + 隣接 `<image>.meta.json` で退避される（schema_version=1）。メタには prompt / provider / model / generation_mode / source_collection / reference_images / generated_at / rejected_at を保存し、将来別コレクションの参照画像として再利用できる。
+不採用画像は `<channel_dir>/assets/stock/<theme-slug>/` に画像と隣接メタデータを退避する。メタデータの schema、retention、参照プールへの合成条件は [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
 stock の操作 CLI:
 
@@ -810,38 +686,9 @@ stock の操作 CLI:
 | `uv run yt-stock-preview [--theme T] [--limit N]` | macOS `open` でプレビュー起動 |
 | `uv run yt-stock-prune [--retention-days N] [--max-per-theme N] [--dry-run]` | 古い画像 / 上限超過分を削除（config 既定値あり） |
 
-`config/skills/thumbnail.yaml` の `image_generation.stock`:
-
-```yaml
-image_generation:
-  stock:
-    enabled: true          # false で退避を無効化（unlink のみ）
-    retention_days: 90     # uv run yt-stock-prune の保持日数
-    max_per_theme: 50      # uv run yt-stock-prune の上限
-```
-
 ### stock 再利用（参照画像プールへの自動合成）
 
-PR-B (#364): stock 画像は `reference_images.default` とは別スコープの参照プールとして扱う。TTP single_step の標準フローでは同じベンチマークチャンネル内の別サムネだけを使い、`--ttp-strict-references` では stock 混在を拒否するため、stock 合成は default OFF。必要なチャンネルだけ `enabled: true` を明示し、TTP strict ではない汎用参照生成に限って `resolve_stock_refs()` の結果を `--reference` に追加する。
-
-- **デフォルト動作**: `enabled: false` で stock は混ぜない。
-- **有効化**: `config/skills/thumbnail.yaml` で `image_generation.gemini.reference_images.stock.enabled: true` を明示する。TTP strict 候補生成では使わない。
-- **採用ログ**: 1 枚採用ごとに stderr へ `[INFO] stock 採用: <path> (theme=<t>, role=thumbnail_candidate)` を出力。監査時は stderr を grep。
-- **チューニング**: `max_count` / `shuffle` / `theme_match: "any"` / `source_role: null` (role フィルタなし) などをチャンネル側で調整。
-
-```yaml
-image_generation:
-  gemini:
-    reference_images:
-      stock:
-        enabled: false
-        max_count: 3
-        theme_match: "exact"     # "any" で全テーマ横断
-        source_role: "thumbnail_candidate"
-        shuffle: true
-        seed: null
-        fallback_when_empty: true
-```
+stock 合成は default OFF。TTP strict 候補生成では stock を混ぜない。必要なチャンネルだけ `image_generation.gemini.reference_images.stock.enabled: true` を明示し、TTP strict ではない汎用参照生成に限る。設定例と採用ログの読み方は [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
 ## 所要時間と完了報告
 
@@ -851,12 +698,7 @@ image_generation:
 
 ## 障害時ガイダンス
 
-| 状況 | 兆候 | 対処 |
-|---|---|---|
-| GCP ADC 未取得/失効 | `ConfigError` / ADC 認証エラー | `gcloud auth application-default login`（必要なら `set-quota-project`）を再実行 |
-| Vertex AI rate | HTTP 429 | 時間を置いて再実行。並列実行を避け順次処理する |
-| API 障害 / サービス停止 | HTTP 503 / タイムアウト | Google Cloud（Vertex AI）のステータスを確認し、時間を置いて再実行 |
-| 画像 provider 障害 | 片方の provider のエラー | `image_generation.provider` を `gemini` ↔ `openai` で切り替える |
+障害は silent fallback せず停止し、エラーと provider を報告する。ADC、rate limit、service outage、provider 切り替えの詳細は [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
 ## Next Step
 

--- a/.claude/skills/thumbnail/references/quality-and-operations.md
+++ b/.claude/skills/thumbnail/references/quality-and-operations.md
@@ -1,0 +1,111 @@
+# quality / operations 詳細
+
+`SKILL.md` の必須コマンド、承認順序、hard gate、完了条件を変更せず、設定例・採点・チェックリスト・運用時の詳細だけを補足する。
+
+## thumbnail-text-profile 変換
+
+profile が存在する場合は 3 セクションを次のとおり適用する。
+
+| profile セクション | 適用先 | 変換 |
+|---|---|---|
+| `## font_tendency` | `image_generation.gemini.thumbnail_text.overlay.font.title`（必要なら `overlay.title.stroke_width` / `stroke_color` も） | 日本語対応 .ttf/.otf/.ttc から `typeface_classification` / `weight` に近い書体を選び、`outline: present` なら縁取りを維持 |
+| `## text_content_pattern` | `--title` に渡すコピー生成の制約 | `line_count_range` / `languages` / `character_count_range` / `copy_pattern` に従う。競合のチャンネル名・コレクション名・シリーズ名・コピー原文は使わない |
+| `## placement_tendency` | `overlay.layout.anchor` / `margin_x` / `margin_y` | `anchor_position` を 9 アンカーのいずれかへ、`margin` をピクセル値へ変換 |
+
+`unknown` のキーは適用せず実効デフォルト値のまま進む。フォント選定はローカルに既にあるファイルだけを対象とし、同梱・自動ダウンロードはしない。profile 不在でも `overlay.font.title` が未設定なら日本語対応フォントを 1 つ選ぶ。候補がない場合は `<channel_dir>/assets/fonts/` への配置を待つか、AI 焼き込み経路へ fallback するかをユーザーに確認する。
+
+## 承認済みサムネイルのアーカイブ
+
+`archive.enabled: true` のときだけ `assets/thumbnail-gallery/<collection-dir-name>.<ext>` へ元の拡張子と内容のままコピーする。同じ collection の再承認は最新の確定サムネで置き換え、無効時は副作用なしで終了する。シンボリックリンクやコピー失敗は成功として扱わない。アーカイブまたは workflow-state 更新に失敗した自動選択は、確定サムネ・ギャラリー・workflow-state を元に戻す。
+
+## フォント運用
+
+single_step の初回 `diff_prompt_template` はテキスト付き `thumbnail-v*.jpg/png` 候補生成用。AI 焼き込み経路では `single_step.typography_clause` を opt-in で展開し、`{font_description}` を `thumbnail_text.font.copy` で置換する。textless 再生成プロンプトには `${typography_clause}` やタイトル描画指示を入れない。two_phase は Phase 2 で `thumbnail_text.font.copy` / `font.genre_tag` を使う。
+
+決定的合成では `image_generation.gemini.thumbnail_text.overlay.font.title` に channel_dir 相対または絶対パスのフォントを設定する。フォントは `<channel_dir>/assets/fonts/` に配置し、ライセンス条項を確認する。未設定、ファイル不在、壊れたフォントはそれぞれ設定・配置・代替ファイルを見直す。AI 経路へ切り替える場合は厳密なフォント再現が保証されないことを伝える。
+
+## auto-selection 設定と採点
+
+`image_generation.auto_selection` で `enabled`、`mode`、`min_width`、`min_height`、`aspect_tolerance` を設定する。`selection_only` は候補承認だけを省略し、`full` は `SKILL.md` の表に示す 4 ゲートを省略する。
+
+`image_generation.gemini.reference_images.default` の各参照画像から brightness / contrast / saturation / dominant_hue / colorfulness を抽出して centroid を作る。16:9 と最小解像度を満たす候補を採点し、centroid への distance が最小の候補を選ぶ。apply 時は PNG 候補を必要に応じて JPEG へ変換し、`thumbnail_auto_selection` に選択候補・distance・ランキング・実行時刻を記録する。
+
+候補なし、参照なし、解像度や 16:9 条件を満たす候補なし、確定済みファイル存在、無効設定は silent fallback せず停止する。
+
+## QA チェックリスト
+
+テキスト付き thumbnail 候補生成後:
+
+- [ ] ベンチマーク参照の構図・主役スケール・光・色温度・背景テクスチャが維持されている
+- [ ] `/thumbnail-compare` で 320px 縮小時のタイトル可読性・コントラスト・主役認識を確認した
+- [ ] タイトルテキストが `composition_rules.text_lines` の制約内である
+- [ ] `thumbnail_text.channel_name` が表示され、署名・ロゴ・透かしが焼き込まれていない
+- [ ] `image_generation.gemini.style` に記載されたスタイルが維持されている
+- [ ] `fixed_character` の外見が維持されている（設定されている場合）
+- [ ] キャラの顔が `fixed_character.face` の指示どおり見えている
+- [ ] **解剖学チェック（手・指）**: 各手 5 本指、指の分離、本数異常・融合・溶融・プロポーション破綻がないことを等倍で目視確認した
+
+textless main 候補生成後:
+
+- [ ] 承認済み `thumbnail.jpg` の構図・主役スケール・光・色温度・背景テクスチャが維持されている
+- [ ] タイトル文字、字幕、ロゴ、透かし、タイポグラフィ、チャンネル名が残っていない
+- [ ] 新しい文字や記号が追加されていない
+- [ ] `/loop-video` 入力や `/videoup` 静止背景として使える
+
+手指の破綻が出るチャンネルは `image_generation.gemini.single_step.anatomy_clause` を opt-in で展開する。`/collection-ideate` の single_step プレビューは企画参照素材であり、最終 thumbnail に流用しない。
+
+## プロンプト保存テンプレート
+
+```markdown
+# Thumbnail Prompts - <コレクション名>
+
+*プロバイダー: {image_generation.provider}*
+*スタイル: {image_generation.gemini.style}*
+*モデル: {image_generation.gemini.model}*
+
+## Reference Assignments
+
+| attempt | output | reference_image | benchmark_channel |
+|---:|---|---|---|
+| 1 | `10-assets/thumbnail-v1.jpg` | `<参照画像 1>` | `<benchmark_channel>` |
+| 2 | `10-assets/thumbnail-v2.jpg` | `<参照画像 2>` | `<benchmark_channel>` |
+| 3 | `10-assets/thumbnail-v3.jpg` | `<参照画像 3>` | `<benchmark_channel>` |
+
+## Text-Included Thumbnail Prompt (thumbnail.jpg)
+
+<テキスト付きサムネを生成したプロンプト>
+
+## Textless Background Prompt (main.png/main.jpg)
+
+<テキストなし背景を生成したプロンプト>
+
+## A/B Test Pattern Prompts
+
+| pattern | final output | variation |
+|---|---|---|
+| `a` | `10-assets/thumbnail-a.jpg` | `<pattern a variation>` |
+| `b` | `10-assets/thumbnail-b.jpg` | `<pattern b variation>` |
+
+### Pattern a Final Prompt
+
+<diff_prompt_template 展開結果 + pattern a variation>
+
+### Pattern b Final Prompt
+
+<diff_prompt_template 展開結果 + pattern b variation>
+```
+
+## stock 退避と再利用
+
+隣接 `<image>.meta.json` は schema_version=1 とし、prompt / provider / model / generation_mode / source_collection / reference_images / generated_at / rejected_at を保存する。`image_generation.stock` の `enabled`、`retention_days`、`max_per_theme` で退避と保持上限を調整する。
+
+stock 参照は `reference_images.default` と別スコープにし、`--ttp-strict-references` では混在させない。汎用参照生成でだけ `enabled: true` を明示し、`max_count` / `shuffle` / `theme_match` / `source_role` を調整する。採用時は stderr の `[INFO] stock 採用` ログで path / theme / role を監査する。
+
+## 障害時ガイダンス
+
+| 状況 | 兆候 | 対処 |
+|---|---|---|
+| GCP ADC 未取得/失効 | `ConfigError` / ADC 認証エラー | `gcloud auth application-default login`（必要なら `set-quota-project`）を再実行 |
+| Vertex AI rate | HTTP 429 | 時間を置いて再実行し、並列実行を避ける |
+| API 障害 / サービス停止 | HTTP 503 / タイムアウト | Vertex AI のステータスを確認し、時間を置く |
+| 画像 provider 障害 | 片方の provider のエラー | `image_generation.provider` を `gemini` ↔ `openai` で切り替える |

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -33,6 +33,11 @@ def _read_thumbnail_generation_workflows() -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_thumbnail_quality_and_operations() -> str:
+    path = _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "quality-and-operations.md"
+    return path.read_text(encoding="utf-8")
+
+
 def _read_loop_video_skill() -> str:
     path = _repo_root() / ".claude" / "skills" / "loop-video" / "SKILL.md"
     return path.read_text(encoding="utf-8")
@@ -503,11 +508,20 @@ def test_thumbnail_skill_applies_thumbnail_text_profile_with_default_fallback() 
         "### thumbnail-text-profile 適用（#1907）",
         "### 承認済みサムネイルのアーカイブ",
     )
+    profile_details = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## thumbnail-text-profile 変換",
+        "## 承認済みサムネイルのアーカイブ",
+    )
 
     for required in (
         "docs/benchmarks/thumbnail-text-profile.md",
         "`schema_version: 1`",
         ".claude/skills/channel-new/references/analysis-mode.md",
+    ):
+        assert required in profile_block
+
+    for required in (
         "## font_tendency",
         "## text_content_pattern",
         "## placement_tendency",
@@ -522,18 +536,18 @@ def test_thumbnail_skill_applies_thumbnail_text_profile_with_default_fallback() 
         "日本語対応 .ttf/.otf/.ttc",
         "競合のチャンネル名・コレクション名・シリーズ名・コピー原文",
     ):
-        assert required in profile_block
+        assert required in profile_details
 
     # profile 不在は前提ガードにしない（現行デフォルト値で続行）
     assert "前提ガードではない" in profile_block
     assert "エラーで停止しない" in profile_block
-    assert "unknown" in profile_block
+    assert "unknown" in profile_details
     # フォントはローカル既存ファイルのみ（同梱・自動ダウンロードはスコープ外）
-    assert "同梱・自動ダウンロードはしない" in profile_block
+    assert "同梱・自動ダウンロードはしない" in profile_details
     # profile 不在かつフォント未設定でもローカル選定でフォント揺れを解消する
-    assert "profile 不在でも `overlay.font.title` が未設定の場合" in profile_block
+    assert "profile 不在でも `overlay.font.title` が未設定なら" in profile_details
     # config への書き込みはユーザー承認つきの明示更新
-    assert "承認を得てから書き込む" in profile_block
+    assert "承認を得てから" in profile_block
 
 
 def test_thumbnail_archive_is_opt_in_and_wired_after_every_approval_path() -> None:
@@ -635,20 +649,25 @@ def test_thumbnail_skill_applies_typography_to_thumbnail_prompt_only() -> None:
     """#1901: single_step の書体指定は thumbnail 生成だけに使う。"""
     skill = _read_thumbnail_skill()
     prompt_construction_block = _slice_between(skill, "#### プロンプト構築", "#### 生成コマンド")
-    font_block = _slice_between(skill, "## フォント安定化", "## 品質チェック")
+    font_block = _slice_between(skill, "## フォント安定化", "## 自動選択")
+    font_details = _slice_between(_read_thumbnail_quality_and_operations(), "## フォント運用", "## auto-selection")
 
     assert "typography_clause" in prompt_construction_block
     assert "text_strip_clause" in prompt_construction_block
-    assert "テキスト付き `thumbnail-v*.jpg/png` 候補生成用" in font_block
-    assert "`single_step.typography_clause` を展開" in font_block
-    assert "textless 再生成プロンプトには、`${typography_clause}`" in font_block
-    assert "初回 `diff_prompt_template` は textless" not in font_block
+    assert "テキスト付き `thumbnail-v*.jpg/png` 候補生成用" in font_details
+    assert "`single_step.typography_clause` を opt-in で展開" in font_details
+    assert "textless 再生成プロンプトには `${typography_clause}`" in font_details
+    assert "初回 `diff_prompt_template` は textless" not in font_block + font_details
 
 
 def test_thumbnail_skill_prompt_log_and_file_contract_cover_issue_1310_outputs() -> None:
     """#1310: prompt 保存とファイル命名が thumbnail/main/loop の役割を明示する。"""
     skill = _read_thumbnail_skill()
-    prompt_block = _slice_between(skill, "## プロンプト保存", "## ファイル命名ルール（上書き禁止）")
+    prompt_block = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## プロンプト保存テンプレート",
+        "## stock 退避と再利用",
+    )
     naming_block = _slice_between(skill, "## ファイル命名ルール（上書き禁止）", "### クリーンアップ")
 
     for required in (
@@ -658,6 +677,13 @@ def test_thumbnail_skill_prompt_log_and_file_contract_cover_issue_1310_outputs()
         "テキスト付きサムネを生成したプロンプト",
         "`10-assets/thumbnail-v1.jpg`",
         "`10-assets/thumbnail-v2.jpg`",
+        "`10-assets/thumbnail-v3.jpg`",
+        "`<参照画像 3>`",
+        "| pattern | final output | variation |",
+        "`10-assets/thumbnail-a.jpg`",
+        "`<pattern a variation>`",
+        "`10-assets/thumbnail-b.jpg`",
+        "`<pattern b variation>`",
     ):
         assert required in prompt_block
 
@@ -676,29 +702,38 @@ def test_thumbnail_skill_quality_check_separates_thumbnail_and_textless_main_qa(
     """#1310: 品質チェックは文字入り thumbnail と textless main を逆に扱わない。"""
     skill = _read_thumbnail_skill()
     qa_block = _slice_between(skill, "## 品質チェック", "## 視認性検証")
+    qa_details = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## QA チェックリスト",
+        "## プロンプト保存テンプレート",
+    )
 
     for required in (
         "テキスト付き thumbnail 候補生成後",
-        "`thumbnail-v1.jpg` / `thumbnail-codex-v1.png`",
         "ベンチマーク参照の構図",
         "/thumbnail-compare",
         "タイトル可読性",
-        "`thumbnail_text.channel_name` が表示されているか",
+        "`composition_rules.text_lines`",
+        "`thumbnail_text.channel_name` が表示され",
+        "`image_generation.gemini.style`",
+        "`fixed_character` の外見",
+        "`fixed_character.face`",
         "textless main 候補生成後",
-        "`main-v1.png` / `main-v1.jpg`",
         "承認済み `thumbnail.jpg` の構図",
-        "タイトル文字、字幕、ロゴ、透かし、タイポグラフィ、チャンネル名が残っていないか",
-        "uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json",
+        "タイトル文字、字幕、ロゴ、透かし、タイポグラフィ、チャンネル名が残っていない",
     ):
-        assert required in qa_block
+        assert required in qa_details
 
-    assert qa_block.find("テキスト付き thumbnail 候補生成後") < qa_block.find("textless main 候補生成後")
-    assert "承認済み `main.png/jpg` の構図" not in qa_block
+    assert "uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json" in qa_block
+    assert "承認・確定しない" in qa_block
+    assert qa_details.find("テキスト付き thumbnail 候補生成後") < qa_details.find("textless main 候補生成後")
+    assert "承認済み `main.png/jpg` の構図" not in qa_block + qa_details
 
-    assert "Phase 1 生成後" not in qa_block
-    assert "Phase 2 生成後" not in qa_block
-    assert "テキストが入っていないか" not in qa_block
-    assert "single_step プレビューを最終 thumbnail に流用" not in qa_block
+    combined = qa_block + qa_details
+    assert "Phase 1 生成後" not in combined
+    assert "Phase 2 生成後" not in combined
+    assert "テキストが入っていないか" not in combined
+    assert "single_step プレビューを最終 thumbnail に流用" not in combined
 
 
 def test_thumbnail_skill_cleanup_archives_png_candidates() -> None:
@@ -755,10 +790,10 @@ def test_thumbnail_skill_deterministic_text_path_is_standard_default() -> None:
     """#1907: 決定的合成経路が標準の既定で、textless 背景を先に確定してから合成する。"""
     skill = _read_thumbnail_skill()
     font_block = _slice_between(skill, "## フォント安定化", "## 自動選択")
-    deterministic_block = _slice_between(
-        skill,
-        "### 決定的合成経路（yt-thumbnail-text・標準）",
-        "### フォント指定に失敗した場合",
+    font_details = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## フォント運用",
+        "## auto-selection",
     )
 
     # 経路表の既定は決定的合成、AI プロンプト経路は fallback
@@ -766,19 +801,14 @@ def test_thumbnail_skill_deterministic_text_path_is_standard_default() -> None:
     assert "**AI プロンプト経路**（fallback・非既定）" in font_block
     assert "**AI プロンプト経路**（既定）" not in font_block
 
-    assert "既定テキスト描画経路（#1907）" in deterministic_block
-    assert "「標準生成順序とファイル契約」に従う" in deterministic_block
-    assert "「thumbnail-text-profile 適用」節に従う" in deterministic_block
-    assert "決定的合成はテキスト描画だけを担う" in deterministic_block
-    # 文字入り画像を背景に流用しない（過去コレクションの作り直しでも textless を先に用意する）
-    assert (
-        "承認済み `thumbnail.jpg` から textless `main-v*.png/jpg` を AI 再生成・承認してから合成する"
-        in deterministic_block
-    )
-    assert "文字入り画像を `--background` に流用しない" in deterministic_block
+    assert "標準生成順序とファイル契約" in font_block
+    assert "textless 背景の承認後に合成" in font_block
+    assert "image_generation.gemini.thumbnail_text.overlay.font.title" in font_details
+    assert "文字入り画像を `--background` に流用しない" in font_block
     # 旧契約（テキスト付き先行）の手順は標準から撤去済み
-    assert "最初にテキスト付き `thumbnail-v*.jpg` を生成・承認して" not in deterministic_block
-    assert "標準 `/thumbnail` フローから自動分岐しない" not in deterministic_block
+    combined = font_block + font_details
+    assert "最初にテキスト付き `thumbnail-v*.jpg` を生成・承認して" not in combined
+    assert "標準 `/thumbnail` フローから自動分岐しない" not in combined
 
 
 def test_loop_video_skill_uses_textless_main_image_and_respects_disabled_channels() -> None:
@@ -859,7 +889,11 @@ def test_thumbnail_skill_documents_ab_test_outputs_prompts_and_approval_contract
     ):
         assert required in block
 
-    prompt_block = _slice_between(skill, "## プロンプト保存", "## ファイル命名ルール（上書き禁止）")
+    prompt_block = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## プロンプト保存テンプレート",
+        "## stock 退避と再利用",
+    )
     assert "## A/B Test Pattern Prompts" in prompt_block
     assert "Pattern a Final Prompt" in prompt_block
     assert "Pattern b Final Prompt" in prompt_block
@@ -1618,12 +1652,50 @@ def test_thumbnail_generation_workflows_owns_generation_details_once() -> None:
         assert combined.count(detail) == 1
 
 
+def test_thumbnail_skill_routes_quality_details_without_moving_hard_gates() -> None:
+    skill = _read_thumbnail_skill()
+    route = "[quality / operations 詳細](references/quality-and-operations.md)"
+
+    assert skill.index("## ワークフロー") < skill.index(route) < skill.index("## フォント安定化")
+    assert skill.count("uv run yt-thumbnail-check") == 5
+    assert skill.count("uv run yt-thumbnail-auto-select") == 3
+    assert skill.count("archive-approved-thumbnail.py") == 5
+    assert skill.count("uv run yt-stock-archive") == 1
+    assert "## 完了条件" in skill
+    assert "**Hard Gate**" in "\n".join(skill.splitlines()[:60])
+    assert "/thumbnail-compare" in skill
+    assert "ユーザー承認" in skill
+    assert "thumbnail.approved = true" in skill
+
+
+def test_thumbnail_quality_and_operations_owns_details_once() -> None:
+    skill = _read_thumbnail_skill()
+    details = _read_thumbnail_quality_and_operations()
+    combined = skill + details
+    moved_details = (
+        "| `## font_tendency` |",
+        "シンボリックリンクやコピー失敗は成功として扱わない",
+        "brightness / contrast / saturation / dominant_hue / colorfulness",
+        "**解剖学チェック（手・指）**",
+        "# Thumbnail Prompts - <コレクション名>",
+        "schema_version=1",
+        "| Vertex AI rate | HTTP 429 |",
+    )
+    for detail in moved_details:
+        assert detail not in skill
+        assert details.count(detail) == 1
+        assert combined.count(detail) == 1
+
+
 def test_thumbnail_skill_quality_check_covers_hand_anatomy() -> None:
     """#570: 品質チェックに手・指の解剖学項目が含まれている。"""
-    skill = _read_thumbnail_skill()
-    quality_block = _slice_between(skill, "## 品質チェック", "## 視認性検証と整合性監査の役割分担")
+    quality_block = _slice_between(
+        _read_thumbnail_quality_and_operations(),
+        "## QA チェックリスト",
+        "## プロンプト保存テンプレート",
+    )
 
     # issue #570 の修正要件 1: 手・指の解剖学チェック項目
     assert "解剖学" in quality_block
     assert "5 本指" in quality_block or "五本指" in quality_block
-    assert "楽器" in quality_block
+    assert "指の分離" in quality_block


### PR DESCRIPTION
## Summary

- profile/archive/font/auto-selection scoring/QA checklist/prompt-save/stock/troubleshooting の詳細を `references/quality-and-operations.md` へ移設
- SKILL 本文には completion/hard gates、承認順、全 quality 実行コマンド、必須判断と routing を維持
- review 修正で `composition_rules.text_lines`、configured style、`fixed_character` appearance/face の必須 QA 4 gate を復元
- prompt-log の attempt 3 と A/B `final output` / `variation` summary を復元
- root-only と combined corpus の契約を意図別に分離し、負・count・順序 assertion を維持

## Verification

- Initial RED: routing/reference 欠落で 2 failed
- Review-fix RED: QA/prompt-log contract 2 failed
- Review-fix GREEN: focused 2 passed
- thumbnail assets 66 passed
- docs/distributed references + installed-wheel sync 75 passed
- `yt-skills lint thumbnail`
- ruff check / ruff format --check
- `git diff --check`

Closes #3490