### PR TITLE
docs(videoup): encoder 基準を配布内へ移す (#3529)

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -260,7 +260,7 @@ runtime mask helper は script 内から `uv run python -m youtube_automation.in
 - **再エンコード固定**: overlays 経路は `-c:v copy` 不可。`encoder.crf` / `maxrate` / `bufsize` で品質とサイズを制御する（DeepFocus365 で 70 分マスター = 約 1.0 GB / 2 Mbps 実績）。
 - **hardware encode は明示 opt-in**: `encoder.codec: "hardware"` で macOS は `h264_videotoolbox`、対応 NVIDIA 環境は `h264_nvenc` を選ぶ。特定 codec の明示指定も可能。利用不能または 1-frame 起動 probe 失敗時は `libx264` へ戻り、requested / selected と理由をログへ出す。既定は引き続き `libx264`。
 - **codec 固有引数**: `libx264` は preset / CRF、VideoToolbox は bitrate、NVENC は `p5` / CQ を使う。H.264 / yuv420p / profile / maxrate / bufsize / fps の出力契約は共通。
-- **性能を実測してから opt-in**: `VIDEOUP_BENCH_DURATION=60 VIDEOUP_BENCH_RUNS=3 bash .claude/skills/videoup/references/benchmark_overlay_encoders.sh` で同一入力を比較する。#2372 の基準計測は `docs/benchmarks/videoup-overlay-encoder-2026-07-21.md`。
+- **性能を実測してから opt-in**: `VIDEOUP_BENCH_DURATION=60 VIDEOUP_BENCH_RUNS=3 bash .claude/skills/videoup/references/benchmark_overlay_encoders.sh` で同一入力を比較し、H.264 / yuv420p / profile / maxrate / bufsize / fps / AAC / duration の共通出力契約と visualizer の位置・形状・opacity の一致を検証する。median wall-clock が `libx264 medium` baseline より 20% 以上短い候補だけを opt-in の採用候補とし、未達なら既定経路を維持する。
 
 ### Audio visualizer style（#1684）
 

--- a/tests/repo/test_distributed_skill_references.py
+++ b/tests/repo/test_distributed_skill_references.py
@@ -58,7 +58,6 @@ _KNOWN_UNRESOLVED: frozenset[tuple[str, str]] = frozenset(
             ".claude/skills/thumbnail/references/prompt-schema.md",
             "docs/skill-design/thumbnail-codex-imagegen-diff-report.md",
         ),
-        (".claude/skills/videoup/SKILL.md", "docs/benchmarks/videoup-overlay-encoder-2026-07-21.md"),
     }
 )
 
@@ -113,6 +112,22 @@ def test_no_claude_md_section_number_references() -> None:
     assert offenders == [], (
         "配布ファイルに CLAUDE.md の節番号参照が残っている（テンプレ再構成で腐る）:\n  " + "\n  ".join(offenders)
     )
+
+
+def test_videoup_encoder_benchmark_contract_is_self_contained() -> None:
+    """videoup の配布物だけで encoder 採用基準と安全な fallback を判断できる。"""
+    skill = (_SKILLS_DIR / "videoup" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "median wall-clock が `libx264 medium` baseline より 20% 以上短い候補だけ" in skill
+    assert "H.264 / yuv420p / profile / maxrate / bufsize / fps / AAC / duration" in skill
+    assert (
+        "VIDEOUP_BENCH_DURATION=60 VIDEOUP_BENCH_RUNS=3 "
+        "bash .claude/skills/videoup/references/benchmark_overlay_encoders.sh"
+    ) in skill
+    assert "hardware encode は明示 opt-in" in skill
+    assert "既定は引き続き `libx264`" in skill
+    assert "1-frame 起動 probe 失敗時は `libx264` へ戻り" in skill
+    assert "docs/benchmarks/videoup-overlay-encoder-2026-07-21.md" not in skill
 
 
 def test_no_new_unresolvable_docs_references() -> None:


### PR DESCRIPTION
## Summary

- remove the wheel-unshipped dated benchmark pointer from the distributed videoup skill
- keep the shipped benchmark command, 20% wall-clock adoption threshold, shared output contract, explicit hardware opt-in, and libx264 fallback inline
- remove the resolved videoup pair from the distributed-reference ratchet allowlist

## TDD evidence

- RED 1: self-contained videoup contract failed while the upstream docs pointer remained
- RED 2: distributed-reference ratchet failed on the stale allowlist entry after pointer removal
- GREEN: focused distributed-reference suite — 5 passed
- related videoup/docs bundle — 462 passed
- `uv run yt-skills lint videoup`
- ruff check / format and `git diff --check`

## Stack

- Depends on: #3527
- Parent: #3014

Closes #3529