### PR TITLE
docs(changelog): videoup 配布参照の解消を記録する (#3530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(thumbnail)`: `/thumbnail` の長大な provider、generation、quality / operations 詳細を配布対象の references へ段階的に分離し、SKILL.md 本文には実行コマンド・承認ゲート・完了条件と明示的な導線を維持した。あわせて prompt schema 参照を wheel 内の正規パスへ統一した。実行時の振る舞いと成果物契約は変更しない（#3005）。
 - `refactor(automation-update)`: `yt-automation-update apply --help` だけで各 flag の用途と制約を確認できるようにし、追従スキルは代表フローと破壊的・直感に反する操作の承認案内へ整理した。既存の pin 更新・同期・smoke check の実行挙動は変更しない（#3513）。
 - `feat(site)`: 公開リリースノートサイトへ公式 DADS design token package を導入し、accent を blue key token の system 配色へ移行、リリース分類色を key / neutral role に分離した。あわせて muted text variable を現行 token へ修正した（#3550, #3551）。
+- `docs(videoup)`: 下流へ配布される skill から wheel 非同梱の encoder benchmark 文書への参照を除去し、同一入力・共通出力での比較、median wall-clock 20% 短縮の採用基準、既定 `libx264`・hardware 明示 opt-in・probe 失敗時 fallback の判断契約を inline で維持した。動画生成の実行挙動は変更しない（#3530）。
 - `docs(wf-auto)`: 下流へ配布される skill から wheel 非同梱のオーケストレーション文書への参照を除去し、長時間処理の待機主体・30 秒以下の poll・終了観測という実行契約を inline のまま維持した（#3525）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。
 - `fix(tests)`: collection serve の subprocess lifecycle テストで待機処理を共通化し、デッドライン到達時に待機対象を明示して失敗させるようにした。server 起動完了は PID ファイルの存在ではなく HTTP identity endpoint の応答まで確認し、高負荷時の起動途中を準備完了と誤認しないようにした（#3091）。


### PR DESCRIPTION
## Summary

- record the videoup wheel-unshipped benchmark pointer resolution in `[Unreleased]`
- document that the shipped benchmark command, 20% adoption threshold, output contract, and runtime behavior remain unchanged

## Evidence

- RED: no `#3530` entry in `[Unreleased]`
- GREEN: changelog and related contracts — 23 passed
- videoup runtime suite — 111 passed
- `uv run yt-skills lint videoup`
- ruff check / format and `git diff --check`

## Stack

- Depends on: #3535
- Parent: #3014

Closes #3530