### PR TITLE
docs(community-draft): 配布参照を generator に集約する (#3531)

### DIFF
--- a/.claude/skills/community-draft/SKILL.md
+++ b/.claude/skills/community-draft/SKILL.md
@@ -10,7 +10,7 @@ description: "Use when コレクションの YouTube コミュニティ投稿を
 
 ## Hard Gates
 
-- `CLAUDE.md` と `docs/adr/0019-community-helper-extension.md` を読む。
+- `CLAUDE.md` を読む。
 - `config/channel/community-draft.json` が存在し、`load_config().community_draft.posts`
   が空でないこと。欠落時は
   `examples/channel_config.example/community-draft.example.json` をコピーしてチャンネル値へ
@@ -33,8 +33,7 @@ generator が exit 0 で終了し、`<collection>/30-promo/community-posts.json`
 `config/channel/community-draft.json::community_draft` の投稿テンプレートから
 `<collection>/30-promo/community-posts.json` を決定的に生成する。実行モードは
 `--batch` のみ。変数解決・日時計算・path 検証・JSON schema の単一ソースは
-`references/generate_batch.py` と `docs/adr/0019-community-helper-extension.md` とし、
-SKILL.md 側で再実装しない。
+`references/generate_batch.py` とし、SKILL.md 側で再実装しない。
 
 ## 実行
 

--- a/tests/repo/test_distributed_skill_references.py
+++ b/tests/repo/test_distributed_skill_references.py
@@ -49,7 +49,6 @@ _KNOWN_UNRESOLVED: frozenset[tuple[str, str]] = frozenset(
             ".claude/skills/automation-update/references/post-apply-checks.md",
             "docs/migration/numbered-duplicate-files-cleanup.md",
         ),
-        (".claude/skills/community-draft/SKILL.md", "docs/adr/0019-community-helper-extension.md"),
         (
             ".claude/skills/thumbnail/references/prompt-schema.md",
             "docs/skill-design/ADR-001-thumbnail-prompt-schema.md",

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1146,10 +1146,20 @@ def test_community_draft_documents_typed_batch_generator_contract() -> None:
     text = _read(".claude/skills/community-draft/SKILL.md")
 
     assert "load_config().community_draft.posts" in text
-    assert "references/generate_batch.py" in text
+    assert re.search(r"単一ソースは\s+`references/generate_batch\.py`\s+とし", text)
+    assert "planning.final_title" in text
     assert "planning.publish_target_at" in text
-    assert "docs/adr/0019-community-helper-extension.md" in text
+    assert "`CHANNEL_DIR` 配下" in text
     assert "community-posts.json" in text
+    assert "timezone 付き `scheduled_at`" in text
+    assert "channel root 相対 `image_path`" in text
+    assert "`visibility: public`" in text
+
+
+def test_community_draft_does_not_require_upstream_adr() -> None:
+    text = _read(".claude/skills/community-draft/SKILL.md")
+
+    assert "docs/adr/0019-community-helper-extension.md" not in text
 
 
 def test_skill_config_defaults_have_read_gate_in_skill_docs() -> None:


### PR DESCRIPTION
## Summary
- wheel に同梱されない ADR pointer を Hard Gate / Overview から除去
- 同梱済み `references/generate_batch.py` を変数解決・日時計算・path 検証・JSON schema の sole source として契約化
- 既存 Hard Gates と `community-posts.json` 完了条件を維持し、runtime behavior は変更しない
- 解消済み pair を `_KNOWN_UNRESOLVED` から削除

## TDD / Verification
- RED1: docs contract 2 failures（ADR absence / generator sole-source）
- RED2: pointer 除去後、stale allowlist 1 failure
- GREEN: skill docs contract 2 passed + distributed reference 5 passed
- community-draft batch / schema / config focused: 22 passed
- `uv run yt-skills lint community-draft`
- Ruff check / format check
- `git diff --check`

Depends on #3539
Parent: #3015
Closes #3531