### PR TITLE
docs(changelog): community-draft の配布参照解消を記録する (#3532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(thumbnail)`: `/thumbnail` の長大な provider、generation、quality / operations 詳細を配布対象の references へ段階的に分離し、SKILL.md 本文には実行コマンド・承認ゲート・完了条件と明示的な導線を維持した。あわせて prompt schema 参照を wheel 内の正規パスへ統一した。実行時の振る舞いと成果物契約は変更しない（#3005）。
 - `refactor(automation-update)`: `yt-automation-update apply --help` だけで各 flag の用途と制約を確認できるようにし、追従スキルは代表フローと破壊的・直感に反する操作の承認案内へ整理した。既存の pin 更新・同期・smoke check の実行挙動は変更しない（#3513）。
 - `feat(site)`: 公開リリースノートサイトへ公式 DADS design token package を導入し、accent を blue key token の system 配色へ移行、リリース分類色を key / neutral role に分離した。あわせて muted text variable を現行 token へ修正した（#3550, #3551）。
+- `docs(community-draft)`: 下流へ配布される skill から wheel 非同梱の ADR への参照を除去し、同梱する `references/generate_batch.py` を変数解決・日時計算・path 検証・JSON schema の単一ソースとして維持した。community draft の runtime behavior は変更しない（#3532）。
 - `docs(videoup)`: 下流へ配布される skill から wheel 非同梱の encoder benchmark 文書への参照を除去し、同一入力・共通出力での比較、median wall-clock 20% 短縮の採用基準、既定 `libx264`・hardware 明示 opt-in・probe 失敗時 fallback の判断契約を inline で維持した。動画生成の実行挙動は変更しない（#3530）。
 - `docs(wf-auto)`: 下流へ配布される skill から wheel 非同梱のオーケストレーション文書への参照を除去し、長時間処理の待機主体・30 秒以下の poll・終了観測という実行契約を inline のまま維持した（#3525）。
 - `refactor(tests)`: 旧 `unit` / `streaming` テストを canonical owner と `tests/repo/streaming/` へ整理し、root allowlist・source layer・source owner の配置規約を repository contract として機械担保した（#3047）。


### PR DESCRIPTION
## Summary
- community-draft から wheel 非同梱 ADR pointer を除去したことを `[Unreleased]` に記録
- packaged `references/generate_batch.py` を実行 spec の sole source として維持
- runtime behavior は変更しない behavior-neutral release note

## TDD / Verification
- RED: `[Unreleased]` に #3532 が存在せず `rg` exit 1
- GREEN: #3532 entry exact 1
- changelog contract: 7 passed
- skill docs contract: 2 passed
- distributed references: 5 passed
- community-draft batch / schema / config: 22 passed
- combined touched-test bundle: 352 passed
- `uv run yt-skills lint community-draft`
- Ruff check / format check
- `git diff --check`

Depends on #3543
Parent: #3015
Closes #3532