### PR TITLE
refactor(skill): automation-update help の責務を分離する (#3512)

### DIFF
--- a/.claude/skills/automation-update/SKILL.md
+++ b/.claude/skills/automation-update/SKILL.md
@@ -357,15 +357,13 @@ uv run yt-skills diff
 
 ### Step 3-2. 追従の一括実行（CLI）
 
-Step 3-1 の判断結果に応じて 1 コマンドで実行:
+Step 3-1 の判断結果に応じて 1 コマンドで実行する。以下は Step 2-4 で合意した tag pin の代表例:
 
 ```bash
-uv run yt-automation-update apply --tag <target_tag>                    # tag pin。Step 2-4 で同意済みの v 付き tag を必ず固定
-uv run yt-automation-update apply --tag <target_tag> --force-sync       # tag pin + (a) 上書き
-uv run yt-automation-update apply --tag <target_tag> --sync-only <skill1> <skill2> ...  # tag pin + (b) local fix 解消後に指定 skill だけ同期（claude-md も同期）
-uv run yt-automation-update apply                                    # main 追従。pin 書き換えなしで lock/sync する
-uv run yt-automation-update apply --rev <sha>                        # sha pin（bump 先は Step 1-1 の [HUMAN STEP] で確定）
+uv run yt-automation-update apply --tag <target_tag>
 ```
+
+pin 形式ごとの指定方法と通常のオプションは `uv run yt-automation-update apply --help` を正とする。
 
 `apply` の内部ステップ（順に実行、失敗時は **失敗ステップ名を明示して非 0 終了**）:
 

--- a/tests/repo/test_automation_update_help_ownership_contract.py
+++ b/tests/repo/test_automation_update_help_ownership_contract.py
@@ -1,0 +1,36 @@
+"""automation-update skill と CLI help の ownership 境界を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_TEXT = (REPO_ROOT / ".claude/skills/automation-update/SKILL.md").read_text(encoding="utf-8")
+
+
+def _apply_commands() -> list[str]:
+    return re.findall(r"^uv run yt-automation-update apply(?:\s.*)?$", SKILL_TEXT, flags=re.MULTILINE)
+
+
+def test_skill_keeps_one_representative_apply_command_between_decision_and_smoke_check() -> None:
+    commands = _apply_commands()
+
+    assert commands == ["uv run yt-automation-update apply --tag <target_tag>"]
+    assert SKILL_TEXT.index("uv run yt-automation-update check") < SKILL_TEXT.index("### Step 2-4.")
+    assert SKILL_TEXT.index("### Step 2-4.") < SKILL_TEXT.index(commands[0])
+    assert SKILL_TEXT.index(commands[0]) < SKILL_TEXT.index("uv run yt-doctor")
+
+
+def test_skill_keeps_nonintuitive_safety_contracts_owned_by_the_wizard() -> None:
+    required_clauses = {
+        "--force-sync": ("local fix", "bypass"),
+        "--sync-only": ("claude-md", "bypass しない"),
+        "--accept-hooks": ("新規 hook", "承認"),
+        "--allow-dirty": ("途中失敗", "再実行"),
+        "--prune": ("明示同意", "別途実行"),
+    }
+
+    for option, clauses in required_clauses.items():
+        matching_paragraphs = [paragraph for paragraph in SKILL_TEXT.split("\n\n") if option in paragraph]
+        assert any(all(clause in paragraph for clause in clauses) for paragraph in matching_paragraphs), option


### PR DESCRIPTION
## Summary

- `automation-update` の apply 例を代表フローへ集約し、CLI help と重複する 5 variants を除去
- pin/default/force-sync/sync-only/allow-dirty/accept-hooks の危険・非直感的な契約と実行順を維持
- SKILL と CLI help の ownership 境界を repository contract で固定

## Test

- ownership contract: 2 passed
- related docs/API/distributed: 107 passed
- full pytest / `yt-skills lint automation-update` / ruff / diff-check

Closes #3512