### PR TITLE
chore(site): DADS design token 依存を固定する (#3550)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
+    "@digital-go-jp/design-tokens": "2.0.1",
     "blume": "1.2.1",
     "zod": "4.1.12"
   },

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@digital-go-jp/design-tokens':
+        specifier: 2.0.1
+        version: 2.0.1
       blume:
         specifier: 1.2.1
         version: 1.2.1(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@shikijs/themes@4.3.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@vercel/functions@3.7.6)(csstype@3.2.3)(esbuild@0.28.1)(prettier@3.9.6)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
@@ -324,6 +327,9 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@digital-go-jp/design-tokens@2.0.1':
+    resolution: {integrity: sha512-F0SWlZDghgWuD6AzD4IawL9PlO+GD2Ns8s72g9FvBSKcgDX3hxzB8fjW64PqqonHocEpLj7Lj+LGbkh6eSgZ0g==}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -4587,6 +4593,8 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@digital-go-jp/design-tokens@2.0.1': {}
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -9,6 +9,34 @@ const readRelease = (version) =>
   readFile(new URL(`../dist/${version}/index.html`, import.meta.url), "utf8");
 const execFileAsync = promisify(execFile);
 
+test("公式 DADS design tokens の exact dependency と CSS token surface を提供する", async () => {
+  const sitePackage = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8")
+  );
+  const designTokensPackage = JSON.parse(
+    await readFile(
+      new URL(
+        "../node_modules/@digital-go-jp/design-tokens/package.json",
+        import.meta.url
+      ),
+      "utf8"
+    )
+  );
+  const tokens = await readFile(
+    new URL(
+      "../node_modules/@digital-go-jp/design-tokens/dist/tokens-simple.css",
+      import.meta.url
+    ),
+    "utf8"
+  );
+
+  assert.equal(sitePackage.dependencies["@digital-go-jp/design-tokens"], "2.0.1");
+  assert.equal(designTokensPackage.version, "2.0.1");
+  assert.match(tokens, /--color-key-/);
+  assert.match(tokens, /--color-neutral-/);
+  assert.match(tokens, /--color-semantic-/);
+});
+
 test("一覧は本体とChrome拡張に分かれ、それぞれ公開日の新しい順で表示する", async () => {
   const html = await readIndex();
   const section = (kind) =>


### PR DESCRIPTION
## Summary

- 公式 `@digital-go-jp/design-tokens` を exact `2.0.1` で site の直接依存へ追加
- pnpm lockfile に同一 version と integrity を固定
- installed package と `dist/tokens-simple.css` の key / neutral / semantic token surface を site test で契約化
- Blume / zod / TypeScript の既存 pin、config、CSS の色割当は変更しない

## TDD / Verification

- RED: package 未導入のため installed manifest / `tokens-simple.css` が ENOENT
- GREEN: focused dependency / CSS surface contract 1 passed
- frozen lockfile install
- site check / build / test: 6 passed
- repository site distribution contract: 6 passed
- TypeScript Any gate / `git diff --check`

Parent: #3065
Closes #3550
