### PR TITLE
[site-colors] DADS key / neutral token を site 配色へ割り当てる

### DIFF
--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -1,5 +1,9 @@
+import dadsTokens from "@digital-go-jp/design-tokens";
 import { defineConfig } from "blume";
 import { releaseFrontmatter } from "./release-schema";
+
+const lightAccent = dadsTokens.Color.Key["800"].$value;
+const darkAccent = dadsTokens.Color.Key["400"].$value;
 
 export default defineConfig({
   title: "youtube-automation ドキュメント",
@@ -24,7 +28,10 @@ export default defineConfig({
     tabs: [{ label: "リリースノート", path: "/", href: "/" }],
   },
   theme: {
-    accent: "violet",
+    accent: {
+      light: lightAccent,
+      dark: darkAccent,
+    },
     mode: "system",
     radius: "lg",
   },

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -1,8 +1,25 @@
+@import "@digital-go-jp/design-tokens/dist/tokens-simple.css";
+
 :root {
-  --release-main: #7c3aed;
-  --release-main-bg: color-mix(in srgb, #7c3aed 12%, transparent);
-  --release-extension: #0f766e;
-  --release-extension-bg: color-mix(in srgb, #0f766e 12%, transparent);
+  --release-main: var(--color-key-800);
+  --release-main-bg: color-mix(in srgb, var(--color-key-800) 12%, transparent);
+  --release-extension: var(--color-neutral-solid-gray-700);
+  --release-extension-bg: color-mix(
+    in srgb,
+    var(--color-neutral-solid-gray-700) 12%,
+    transparent
+  );
+}
+
+:root[data-theme="dark"] {
+  --release-main: var(--color-key-400);
+  --release-main-bg: color-mix(in srgb, var(--color-key-400) 12%, transparent);
+  --release-extension: var(--color-neutral-solid-gray-300);
+  --release-extension-bg: color-mix(
+    in srgb,
+    var(--color-neutral-solid-gray-300) 12%,
+    transparent
+  );
 }
 
 .release-shell {
@@ -31,7 +48,7 @@
 }
 
 .release-hero > p:last-child {
-  color: var(--color-text-muted, #6b7280);
+  color: var(--color-muted-foreground);
   font-size: clamp(1rem, 2vw, 1.2rem);
   line-height: 1.8;
   margin: 1.5rem 0 0;
@@ -58,7 +75,7 @@
 }
 
 .release-card {
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: 1rem;
   color: inherit;
   display: block;
@@ -69,7 +86,7 @@
 
 .release-card:hover {
   border-color: color-mix(in srgb, var(--release-main) 45%, transparent);
-  box-shadow: 0 18px 50px rgb(30 20 60 / 10%);
+  box-shadow: 0 18px 50px color-mix(in srgb, var(--release-main) 10%, transparent);
   transform: translateY(-2px);
 }
 
@@ -81,7 +98,7 @@
 }
 
 .release-meta time {
-  color: var(--color-text-muted, #6b7280);
+  color: var(--color-muted-foreground);
   font-size: 0.875rem;
 }
 
@@ -109,7 +126,7 @@
 }
 
 .release-card > p {
-  color: var(--color-text-muted, #6b7280);
+  color: var(--color-muted-foreground);
   line-height: 1.75;
   margin: 0;
   max-width: 52rem;

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import test from "node:test";
 import { promisify } from "node:util";
 
@@ -8,6 +8,18 @@ const readIndex = () => readFile(new URL("../dist/index.html", import.meta.url),
 const readRelease = (version) =>
   readFile(new URL(`../dist/${version}/index.html`, import.meta.url), "utf8");
 const execFileAsync = promisify(execFile);
+
+const readStylesheetClosure = async (html) => {
+  const inlineStyles = [...html.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/g)].map(
+    (match) => match[1]
+  );
+  const linkedStyles = await Promise.all(
+    [...html.matchAll(/<link[^>]+href=["']([^"']+\.css)["'][^>]*>/g)].map((match) =>
+      readFile(new URL(`../dist${match[1]}`, import.meta.url), "utf8")
+    )
+  );
+  return [...inlineStyles, ...linkedStyles].join("\n");
+};
 
 test("公式 DADS design tokens の exact dependency と CSS token surface を提供する", async () => {
   const sitePackage = JSON.parse(
@@ -35,6 +47,90 @@ test("公式 DADS design tokens の exact dependency と CSS token surface を�
   assert.match(tokens, /--color-key-/);
   assert.match(tokens, /--color-neutral-/);
   assert.match(tokens, /--color-semantic-/);
+});
+
+test("DADS key と neutral token を system mode の site 配色へ割り当てる", async () => {
+  const config = await readFile(new URL("../blume.config.ts", import.meta.url), "utf8");
+  const sourceCss = await readFile(
+    new URL("../styles/release-notes.css", import.meta.url),
+    "utf8"
+  );
+  const assetDirectory = new URL("../dist/_astro/", import.meta.url);
+  const generatedCss = (
+    await Promise.all(
+      (await readdir(assetDirectory))
+        .filter((name) => name.endsWith(".css"))
+        .map((name) => readFile(new URL(name, assetDirectory), "utf8"))
+    )
+  ).join("\n");
+
+  assert.match(
+    sourceCss,
+    /@import ["']@digital-go-jp\/design-tokens\/dist\/tokens-simple\.css["'];/
+  );
+  assert.match(
+    config,
+    /import dadsTokens from ["']@digital-go-jp\/design-tokens["']/
+  );
+  assert.match(
+    config,
+    /const lightAccent = dadsTokens\.Color\.Key\["800"\]\.\$value/
+  );
+  assert.match(
+    config,
+    /const darkAccent = dadsTokens\.Color\.Key\["400"\]\.\$value/
+  );
+  assert.match(
+    config,
+    /accent:\s*\{\s*light:\s*lightAccent,\s*dark:\s*darkAccent,?\s*\}/
+  );
+  assert.doesNotMatch(config, /#[0-9a-f]{3,8}\b/i);
+  assert.match(config, /mode:\s*["']system["']/);
+  assert.match(sourceCss, /--release-main:\s*var\(--color-key-800\)/);
+  assert.match(
+    sourceCss,
+    /--release-extension:\s*var\(--color-neutral-solid-gray-700\)/
+  );
+  assert.match(
+    sourceCss,
+    /:root\[data-theme=["']dark["']\][\s\S]*--release-main:\s*var\(--color-key-400\)[\s\S]*--release-extension:\s*var\(--color-neutral-solid-gray-300\)/
+  );
+  assert.match(sourceCss, /color:\s*var\(--color-muted-foreground\)/);
+  assert.match(sourceCss, /border:\s*1px solid var\(--color-border\)/);
+  assert.doesNotMatch(sourceCss, /#[0-9a-f]{3,8}\b/i);
+  assert.doesNotMatch(sourceCss, /#7c3aed|#0f766e|--color-text-muted/i);
+  assert.doesNotMatch(
+    sourceCss,
+    /--release-(?:main|extension):[^;]*--color-semantic-(?:success|error|warning)/
+  );
+  assert.match(generatedCss, /--color-key-800/);
+  assert.match(generatedCss, /--color-key-400/);
+  assert.match(generatedCss, /--color-neutral-solid-gray-700/);
+  assert.match(generatedCss, /--color-neutral-solid-gray-300/);
+  assert.doesNotMatch(generatedCss, /#7c3aed|#0f766e/i);
+});
+
+test("全 Blume page の stylesheet closure で DADS accent を解決する", async () => {
+  const designTokens = (await import("@digital-go-jp/design-tokens")).default;
+  const lightAccent = designTokens.Color.Key["800"].$value;
+  const darkAccent = designTokens.Color.Key["400"].$value;
+  const distDirectory = new URL("../dist/", import.meta.url);
+  const htmlPaths = (await readdir(distDirectory, { recursive: true })).filter((path) =>
+    path.endsWith(".html")
+  );
+
+  assert.ok(htmlPaths.length > 1);
+  for (const htmlPath of htmlPaths) {
+    const html = await readFile(new URL(htmlPath, distDirectory), "utf8");
+    const styles = await readStylesheetClosure(html);
+    const accentReferences = [...styles.matchAll(/--blume-accent:\s*var\((--[^)]+)\)/g)];
+
+    for (const [, variable] of accentReferences) {
+      assert.match(styles, new RegExp(`${variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:`));
+    }
+    assert.match(styles, new RegExp(`--blume-accent:\\s*${lightAccent}`));
+    assert.match(styles, new RegExp(`--blume-accent:\\s*${darkAccent}`));
+  }
 });
 
 test("一覧は本体とChrome拡張に分かれ、それぞれ公開日の新しい順で表示する", async () => {


### PR DESCRIPTION
## Summary
- DADS tokens-simple.css を site CSS へ読み込む
- DADS package の key-800 / key-400 実値を system mode の global accent へ割り当て、全 Blume page の stylesheet closure で解決する
- main / extension 分類を key / neutral token へ割り当て、muted / border token と旧色を是正する

Closes #3551