### PR TITLE
docs(collection-ideate): preview 契約を段階開示する (#3503)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -213,29 +213,19 @@ benchmark fallback mode または `ttp_mode: false` の minimal mode でペル�
 
 ### Phase 4: プレビューサムネイル生成
 
-既定では `preview.thumbnail_mode: parallel` ── テキストで `preview.candidate_count` 案（デフォルト 3）を先に提示して合意を取り、その後 `candidate_count` 枚を一括生成して比較選択する。コストを抑えたい場合は `sequential` に切り替えると「テキスト `candidate_count` 案 → 選択 → 選択 1 案だけ生成」フローになる（コスト 1/`candidate_count`、節末「Phase 4 補足: sequential モード (opt-in)」参照）。
+設定、候補 schema、コスト計算、セルフチェックは [preview contract](references/preview-contract.md) を先に読み、その解決結果を Phase 4 全体で共有する。
 
-以下、本文中の Bash 例・テーブル・採番（A/B/C / plan-a/b/c）はすべて `candidate_count = 3` のときのサンプル。`candidate_count` を変更した場合は連打回数・採番をその値に合わせて調整すること。
+`preview.thumbnail_mode` が `parallel` ならテキスト候補への合意後に全候補を一括生成して比較し、`sequential` ならテキスト候補から選んだ1案だけを生成する。
 
 両モード共通の前半（4-1〜4-2）でテキスト案提示とコスト条件を確定してから、後半（4-3〜4-5）で生成・比較・選択に進む。
 
 **4-1: 企画 `candidate_count` 案（プロンプト本文込み）をテキストで提示**
 
-`preview.candidate_count`（デフォルト 3）個の企画について、`/thumbnail` スキルの Phase 1 と同等の本番品質プロンプトを **テキストで** 生成・提示する。この段階では画像は生成しない。
-
-- `config/skills/thumbnail.yaml` の `image_generation.gemini.prompt_prefix` + `composition_rules` を完全適用
-- 英語 1 段落、誇張表現禁止、16:9 構図、テキスト除外
-- **キャラ + 手が写る構図では `image_generation.gemini.single_step.anatomy_clause` の内容（hands anatomically correct, five fingers each, no fused/extra/melted fingers）をプロンプトに含める**（#570、Gemini の指破綻を抑止）
-- **IP / 版権セーフティ (#569)**: 参照画像が TTP のベンチマーク（競合サムネ）である以上、原作者のサイン・署名・透かし・ロゴが転写される事故を抑止するため、各企画プロンプトの末尾に標準除外 clause を必ず含める: `no signature, no autograph, no watermark, no logo, no brand mark, clean corners`（`image_generation.gemini.single_step.ip_safety_clause` を参照）。プロンプト本文の比較材料に含まれるため、テキスト案提示の段階で抜けに気付けるようにしておく
-- **本番品質で生成する**（選択された企画のプロンプトをそのまま `yt-generate-image` に渡すため、再生成によるばらつきを避ける）
-
-各企画について、テーマ・タイトル・オブジェクト定義・サムネプロンプト全文をユーザーに提示する。プロンプト本文も比較材料に含めることで、視覚出力を見る前にユーザーが意図を把握できる。
+解決済み `candidate_count` 件を preview contract の候補 schema でテキスト提示する。この段階では画像を生成しない。
 
 **4-2: コスト一括確認**
 
-事前見積もりは `config/skills/thumbnail.yaml` の `image_generation.<provider>.cost_per_image_usd` を
-指定したときのみ提示する（Issue #132 以降、ハードコード単価表は撤廃済み）。実コストは GCP Cloud
-Console > Billing で確認する。`thumbnail_mode` によって生成枚数が異なるため、ワンライナーで自動分岐させる:
+preview contract の計算契約に従い、mode 別の生成枚数、provider、model / quality、画像サイズ、単価、API call 数を次のコマンドで確定する:
 
 ```bash
 uv run python3 -c "
@@ -267,14 +257,7 @@ else:
 "
 ```
 
-例（`cost_per_image_usd` が設定済み・parallel・`candidate_count=3` の場合）: `3 枚 × $0.101 = $0.303 (parallel / gemini-3.1-flash-image-preview / 2K)`
-
-deep-merge 後の `preview.skip_cost_confirm` で分岐する:
-
-- `false`（既定）: 上記見積もりを提示し、confirm_cost の y/N で明示承認を待つ。承認までは画像生成を実行しない
-- `true`: y/N を省略し、上記ワンライナーが確定した生成枚数、provider、model / quality、画像サイズ、単価または単価未設定、想定 call 数を terminal / agent run の実行ログへ表示して画像生成へ進む。同じ内容を `20-documentation/plan_proposals.md` の `Preview generation` 節へ追記する。記録に失敗した場合は画像生成せず停止する
-
-**`skip_cost_confirm: false` でユーザーが拒否した場合** → プレビュー画像生成を完全スキップしテキストのみで提示（企画参照画像生成はブロッキングにしない）。`planning-preview.png` は未生成のまま Next Step に進み、後段の `/thumbnail <theme>` がベンチマーク参照からテキスト付き `thumbnail.jpg` を先に生成・承認し、承認済み `thumbnail.jpg` から textless `main.png/jpg` を再生成する（Next Step の「コスト拒否 / 生成失敗で企画参照画像が無い場合」参照）。
+見積もりを提示し、preview contract が確認を要求する場合は `confirm_cost` の y/N で明示承認を待つ。承認または承認省略時の必須記録が完了するまで、4-3 以降の副作用へ進まない。記録に失敗した場合は画像生成せず停止する。ユーザーが拒否した場合は画像生成をスキップし、テキストのみで Next Step へ進む。
 
 **4-3: セッションディレクトリ作成**
 
@@ -293,18 +276,7 @@ mkdir -p collections/planning/_plan-previews/${PREVIEW_DIR}
 
 **4-4: プロンプト構築 + 一括生成（parallel デフォルト）**
 
-`config/skills/thumbnail.yaml` の `image_generation.gemini.generation_mode` を確認:
-
-- **`single_step` の場合**: `image_generation.gemini.diff_prompt_template` をベースに、オブジェクトデザインルール（`objects` が定義されている場合）に従って企画ごとのオリジナルオブジェクトを指定。
-  - **背景色**: `image_generation.gemini.brand_background` を使用（定義がある場合）。全コレクション統一
-  - **オブジェクトの扱い**: `ttp_mode: false` では `objects.swappable` で定義されたスロットを企画ごとに変えて差別化する。`ttp_mode: true` では差別化軸からスロット値を作らず、転写元の高再生コレクションまたは勝ちパターンに基づく値だけを使う
-  - **キャラ + 手が写る構図では `${anatomy_clause}` を全企画プロンプトに展開する**（#570）。`single_step` プレビューは企画参照素材として保存され、最終 `thumbnail.jpg` には流用しない。ただし参照素材の手・指破綻（指の融合・本数異常・溶融）が後段 `/thumbnail` の方向性に影響するため、ここで anatomy 強調 clause を当てておく
-  - **IP / 版権セーフティ clause を常時付与 (#569)**: ベンチマーク TTP 由来の署名・サイン・透かし・ロゴが焼き込まれないよう、`single_step.ip_safety_clause`（`no signature, no autograph, no watermark, no logo, no brand mark, clean corners`）を全企画プロンプトに含める。`diff_prompt_template` 自体に組み込んでおけば 4-1 で生成するテキスト案にも自動で含まれる
-  - 具体的な差分プロンプトの書き方は `references/object-design-examples.md` を参照
-
-- **それ以外の場合**: 4-1 で生成済みの本番品質プロンプトをそのまま流用
-
-`REF_PATHS` を構築してから provider に応じた経路で `preview.candidate_count` 枚を順次生成する:
+preview contract の候補 schema で確定した prompt を使う。`REF_PATHS` を構築してから provider に応じた経路で `candidate_count` 枚を順次生成する:
 
 ```bash
 # <dir> は 4-3 で作成したセッション固有ディレクトリ名（例: 20260306-a3f1）
@@ -387,11 +359,7 @@ fi
 
 **4-4-check: 生成後セルフチェック (#489, 任意)**
 
-`config/skills/collection-ideate.yaml` の `self_check.enabled: true`（デフォルト）の場合、
-4-5 のユーザー提示の **前** に `yt-thumbnail-check` を実行する。これは Gemini Vision で
-`objects.fixed`（wet_runway / matte_black_car / aircraft_mid_distance 等）と
-`no_logo_guard`（テキスト・ロゴ・透かし混入）を JSON 形式の YES/NO チェックリストで
-検査するセルフチェック CLI。
+preview contract がセルフチェックを要求する場合、4-5 のユーザー提示前に実行する:
 
 ```bash
 uv run yt-thumbnail-check \
@@ -399,14 +367,7 @@ uv run yt-thumbnail-check \
   --json
 ```
 
-- 終了コード 0 で全画像合格、1 で 1 件以上が不合格。
-- 不合格時は `self_check.max_regeneration_attempts` が 1 以上なら 4-4 の生成を該当
-  企画だけ再実行、0 なら警告表示のみで 4-5 に進む（ユーザー承認時に保存）。
-- `--print-prompt` で実際に Gemini に渡すチェック prompt を確認できる（呼び出しなし）。
-- 検査対象を絞りたい場合は `--check 'Does the aircraft sit off-center?'` のように追加可能。
-
-`self_check.enabled: false` または `objects.fixed` 未定義のチャンネルでは
-チェックリストが no_logo_guard のみになる（または完全 skip）。
+判定と再生成条件は preview contract のセルフチェック契約を適用する。
 
 **4-5: 全枚を比較提示 → ユーザー選択**
 
@@ -432,9 +393,9 @@ parallel モードでは Next Step で `yt-stock-archive` による不採用 (`c
 
 ### Phase 4 補足: sequential モード (opt-in)
 
-`config/skills/collection-ideate.yaml` で `preview.thumbnail_mode: sequential` に切り替えた場合のみ実行する。コストは parallel の 1/`candidate_count`（`candidate_count=3` で例えば `1 枚 × $0.101 = $0.101`）。テキスト案のプロンプト本文だけで企画を絞り込めるときに有効。
+mode 判定が `sequential` の場合のみ実行する。
 
-**sequential 用 4-1 / 4-2**: 共通。4-2 のコストワンライナーは `mode == sequential` のとき `count = 1` を返すため自動的に `1 枚 × $X` 表示になる。コスト拒否時の挙動も共通。
+**sequential 用 4-1 / 4-2**: 共通。4-2 のコストコマンドは生成1枚として見積もり、承認境界も共通。
 
 **sequential 用 4-3 (セッションディレクトリ作成)**: 共通。
 

--- a/.claude/skills/collection-ideate/references/preview-contract.md
+++ b/.claude/skills/collection-ideate/references/preview-contract.md
@@ -1,0 +1,49 @@
+# Preview contract
+
+Phase 4 の設定解決、候補の内容、コスト見積もり、生成後チェックはこのファイルを正とする。実行順、承認境界、実行コマンドは `../SKILL.md` に従う。
+
+## Preview 設定
+
+`config.default.yaml` と `config/skills/collection-ideate.yaml` を deep-merge し、`preview` を一度だけ解決する。
+
+| key | 既定値 | 契約 |
+|---|---:|---|
+| `thumbnail_mode` | `parallel` | `parallel` は合意した候補を全枚生成、`sequential` はテキスト候補から選んだ1枚だけを生成する |
+| `candidate_count` | `3` | テキスト候補数。`parallel` の生成枚数にも使い、`sequential` の生成枚数は常に1 |
+| `skip_cost_confirm` | `false` | `false` は課金 call 前に `confirm_cost`、`true` は確認だけを省略して見積条件を記録する |
+| `session_id_bytes` | `2` | preview session ID のランダム byte 数 |
+| `stock_archive` | `true` | `parallel` で不採用画像を stock へ退避するかを決める |
+
+`config/skills/thumbnail.yaml` も同じ deep-merge 規則で解決する。`candidate_count` を変えた場合は候補ラベル、生成回数、比較対象を同じ数にそろえる。既定値や生成枚数を暗黙に補正しない。
+
+## 候補 schema
+
+各候補は次をひとまとまりとして提示し、画像生成にも同じ prompt を使う。
+
+- テーマ
+- タイトル
+- オブジェクト定義（名前とストーリーを含む）
+- 本番用 thumbnail prompt 全文
+- `ttp_mode: true` の場合は転写元、転写する構造・パターン・型、参照元が満たす欲求、企画の欲求整合根拠
+
+Phase 4-1 の prompt は英語 1 段落、誇張表現禁止、16:9 構図、テキスト除外を共通の出力契約とし、`config/skills/thumbnail.yaml` の provider 設定を正とする。Gemini では `prompt_prefix`、`composition_rules`、`single_step.anatomy_clause`（キャラクターの手が写る場合）、`single_step.ip_safety_clause` を適用する。IP safety clause は署名、透かし、ロゴ、brand mark を除外し、clean corners を要求する。
+
+Gemini の `generation_mode: single_step` は `diff_prompt_template` を prompt source とし、`object-design-examples.md` を参照する。`ttp_mode: false` のみ swappable slot で差別化し、`ttp_mode: true` は転写元から得た値だけを使う。それ以外の generation mode は Phase 4-1 のプロンプト全文をそのまま再利用し、生成時に再構築しない。
+
+Codex provider では `image_generation.codex.default_prompt_template` と `thumbnail/references/codex-prompt.py` を正とし、タイトル引数には画像へ焼く見出しと短いサブタイトルだけを渡す。動画タイトル全文、composition rule、legend、楽器を重複注入しない。候補ごとに別の benchmark 参照画像を1枚割り当て、必要枚数に満たなければ生成せず停止する。TTP strict preview に stock 参照を混ぜない。
+
+## コスト計算契約
+
+生成前に mode から課金 call 数を確定する。`parallel` は `candidate_count` 枚、`sequential` は1枚で、各画像につき生成1 call。セルフチェックを実施する場合は各画像につき Vision check 1 call を別に数える。生成しない場合は画像系 call は0。
+
+見積もりは解決済み provider、model / quality、画像サイズと `config/skills/thumbnail.yaml` の `cost_per_image_usd` を使う。Codex provider は GCP 課金なしとして表示する。単価未設定時は金額を推測せず「不明」と表示し、実コストは GCP Cloud Console の Billing を正とする。
+
+`skip_cost_confirm: false` は見積もりを表示して `confirm_cost` の y/N を待つ。拒否時は画像生成を完全にスキップし、テキスト候補だけで続行する。`true` は確認を省略できるが、生成枚数、provider、model / quality、画像サイズ、単価または単価未設定、想定 call 数を実行ログと `20-documentation/plan_proposals.md` の `Preview generation` 節へ保存する。保存失敗時は生成せず停止する。
+
+例: 単価 `$0.101`、`parallel`、候補3件なら生成見積もりは `3 枚 × $0.101 = $0.303`。同じ候補数の `sequential` は `1 枚 × $0.101 = $0.101`。
+
+## セルフチェック契約
+
+`self_check.enabled` の既定値は `true`。生成後、ユーザー提示前に `yt-thumbnail-check --json` を実行する。`objects.fixed` と `no_logo_guard` を JSON の YES/NO checklist で検査し、終了コード0を全画像合格、1を1件以上不合格として扱う。
+
+不合格時は `self_check.max_regeneration_attempts` が1以上なら該当候補だけを再生成し、0なら警告を表示してユーザー承認へ進む。`objects.fixed` が未定義なら `no_logo_guard` だけを検査する。`self_check.enabled: false` は check を省略する。調査時は `--print-prompt` で課金 call なしに prompt を確認でき、追加の `--check` で検査対象を絞れる。

--- a/tests/repo/test_collection_ideate_disclosure_contract.py
+++ b/tests/repo/test_collection_ideate_disclosure_contract.py
@@ -9,6 +9,7 @@ from tests.helpers.paths import REPO_ROOT
 SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "collection-ideate"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 PLANNING_RULES_MD = SKILL_DIR / "references" / "planning-rules.md"
+PREVIEW_CONTRACT_MD = SKILL_DIR / "references" / "preview-contract.md"
 
 PLANNING_RULE_HEADINGS = {
     "ペルソナベース企画フレームワーク",
@@ -18,6 +19,12 @@ PLANNING_RULE_HEADINGS = {
     "オブジェクトデザインルール",
     "オリジナリティ保証ルール",
     "第一ペルソナの企画バリエーション",
+}
+PREVIEW_CONTRACT_HEADINGS = {
+    "Preview 設定",
+    "候補 schema",
+    "コスト計算契約",
+    "セルフチェック契約",
 }
 
 
@@ -55,3 +62,53 @@ def test_skill_keeps_phase_order_and_approval_boundary() -> None:
     approval = skill.index("confirm_cost", phase_4)
 
     assert dispatch < phase_2 < phase_3 < phase_4 < approval
+
+
+def test_skill_dispatches_preview_contract_before_preview_steps() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = PREVIEW_CONTRACT_MD.relative_to(SKILL_DIR).as_posix()
+
+    dispatch = skill.index(f"]({relative_reference})")
+    first_preview_step = skill.index("**4-1:")
+
+    assert PREVIEW_CONTRACT_MD.is_file()
+    assert dispatch < first_preview_step
+
+
+def test_preview_contract_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(PREVIEW_CONTRACT_MD.read_text(encoding="utf-8"))
+
+    assert PREVIEW_CONTRACT_HEADINGS <= reference_headings
+    assert PREVIEW_CONTRACT_HEADINGS.isdisjoint(skill_headings)
+
+
+def test_preview_contract_preserves_phase_4_1_prompt_semantics() -> None:
+    contract = PREVIEW_CONTRACT_MD.read_text(encoding="utf-8")
+
+    assert "英語 1 段落" in contract
+    assert "誇張表現禁止" in contract
+    assert "16:9 構図" in contract
+    assert "テキスト除外" in contract
+
+
+def test_preview_contract_dispatches_generation_mode_prompt_source() -> None:
+    contract = PREVIEW_CONTRACT_MD.read_text(encoding="utf-8")
+
+    single_step = contract.index("`generation_mode: single_step`")
+    diff_template = contract.index("`diff_prompt_template`", single_step)
+    other_modes = contract.index("それ以外の generation mode", diff_template)
+    phase_4_1_prompt = contract.index("Phase 4-1 のプロンプト全文", other_modes)
+
+    assert single_step < diff_template < other_modes < phase_4_1_prompt
+
+
+def test_cost_approval_precedes_preview_side_effects() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    phase_4 = skill.index("### Phase 4:")
+
+    approval = skill.index("confirm_cost", phase_4)
+    session_creation = skill.index("mkdir -p", phase_4)
+    image_generation = skill.index("yt-generate-image", phase_4)
+
+    assert approval < session_creation < image_generation


### PR DESCRIPTION
## Summary

- collection-ideate の preview 契約を配布内 reference へ段階開示
- Phase 4 の実行 command blocks と Hard Gate の停止契約を保持
- dispatch・reference・ownership 境界を repository contract で固定

## Test

- disclosure contract: 6 passed
- related focused: 166 passed
- `yt-skills lint collection-ideate` / ruff / diff-check

Closes #3503