### PR TITLE
docs(collection-ideate): preview 生成詳細を段階開示する (#3502)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -274,9 +274,11 @@ mkdir -p collections/planning/_plan-previews/${PREVIEW_DIR}
 
 `_` プレフィックスで通常コレクションと区別。セッション ID 付きディレクトリで並列実行時の競合を回避する。
 
+4-4以降へ進む前に [preview generation](references/preview-generation.md) を読み、確定済みmodeへprovider / prompt / 生成物 / retry / failure handlingの詳細を適用する。SKILL本体のcommandと順序を変更せず実行する。
+
 **4-4: プロンプト構築 + 一括生成（parallel デフォルト）**
 
-preview contract の候補 schema で確定した prompt を使う。`REF_PATHS` を構築してから provider に応じた経路で `candidate_count` 枚を順次生成する:
+`parallel` の場合だけ実行する。`REF_PATHS` を構築してからproviderに応じた経路で `candidate_count` 枚を順次生成する。候補数ぶんの参照が無い場合は参照不足なら生成せず停止する。
 
 ```bash
 # <dir> は 4-3 で作成したセッション固有ディレクトリ名（例: 20260306-a3f1）
@@ -317,11 +319,6 @@ mapfile -t REF_PATHS <<< "$VALIDATED_REFS"
 LABELS=(a b c d e f g h)
 PROVIDER=$(uv run python3 -c "from youtube_automation.infrastructure.media.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
-  # codex は image_generation.codex.default_prompt_template を必ず使う。
-  # image_generation.gemini.composition_rules（legend_motif / allowed_actions を含む）は
-  # codex-prompt.py が自動注入するため、title にレジェンドや楽器を重複して書かない。
-  # 参照画像を winning template として扱い、テキスト付き候補を先に確定する短い TTP thumbnail 先行プロンプトにする（#1611）。
-  # 候補ごとに別参照画像 1 枚だけを渡す。参照不足なら生成せず設定を直す。
   if [ "${#REF_PATHS[@]}" -lt "$CANDIDATE_COUNT" ]; then
     echo "ERROR: codex single_step preview requires at least ${CANDIDATE_COUNT} unique reference images" >&2
     exit 1
@@ -331,8 +328,6 @@ if [ "$PROVIDER" = "codex" ]; then
   }
   for idx in $(seq 0 $((CANDIDATE_COUNT - 1))); do
     label="${LABELS[$idx]}"
-    # title にはサムネに焼くテキスト（見出し + 短いサブタイトル）だけを渡す。
-    # 動画タイトル全文を渡さない（全文が画像に焼き込まれる事故の再発防止）。
     title="<企画${label}タイトル>"
     bash .claude/skills/thumbnail/references/codex-image.sh --require-reference \
       "$(build_codex_prompt "$title")" \
@@ -352,10 +347,7 @@ else
 fi
 ```
 
-- 全企画とも `REF_PATHS[$idx]` の別々の benchmark 参照を 1 枚ずつ使う。TTP strict preview では stock を混ぜない
-- 出力先: `collections/planning/_plan-previews/<dir>/plan-<x>-<slug>.png`（`<x>` は a/b/c/... のラベル、`candidate_count` 枚ぶん）
-- `-y` 指定時、同名ファイルが既存なら自動で `-v2`, `-v3` ... と採番（追加の安全策）
-- stock は TTP strict preview には混ぜない。stock 参照を使う場合は `/thumbnail` の汎用参照生成で別途扱う
+個別生成が失敗しても後続候補のcommandは実行する。生成成功が 0 枚なら画像比較へ進まず、失敗を明記したテキスト候補だけで4-5へ進む。
 
 **4-4-check: 生成後セルフチェック (#489, 任意)**
 
@@ -367,7 +359,7 @@ uv run yt-thumbnail-check \
   --json
 ```
 
-判定と再生成条件は preview contract のセルフチェック契約を適用する。
+exit 0だけを合格とする。exit 1ではpreview contractの上限内で不合格候補だけを再生成し、checkを再実行する。check実行不能は停止し、上限到達時は結果を提示して明示承認を待つ。
 
 **4-5: 全枚を比較提示 → ユーザー選択**
 
@@ -377,15 +369,12 @@ uv run yt-thumbnail-check \
    open collections/planning/_plan-previews/<dir>/plan-{a,b,c}-*.png
    ```
 
-2. Read（Codex では同等の画像閲覧機能）でも各プレビュー画像を表示しながら企画を提示する
-3. 各企画にはサムネイル情報に加え、`objects` で定義されたオブジェクトの名前・ストーリーを併記する（`objects` 未定義時は省略）
-4. 生成に失敗した分はテキストのみで提示（「プレビュー生成失敗」と明記）
+2. Read（Codex では同等の画像閲覧機能）でも各成功画像を表示し、生成失敗候補は「プレビュー生成失敗」と明記する
 
 ユーザーから採用企画を番号（A, B, C, ... のラベル）または企画タイトルで受け取る。NG だった場合の戻り経路:
 
-- 同じペルソナで再生成したい → Phase 3 から再実行
-- 別の利用文脈を試したい → `ttp_mode: false` では第一ペルソナの別シーン・別感情・別活動軸、`true` では別の高再生パターンを使って Phase 3 から再実行
-- 個別画像だけ気に入らない → 該当企画を 4-4 のコマンドで単発再生成
+- 企画を変える → Phase 3から再実行
+- 個別画像だけ再生成する → 該当候補の4-4 commandを再実行
 
 parallel モードでは Next Step で `yt-stock-archive` による不採用 (`candidate_count` - 1) 枚の stock 退避が走る（「Next Step」参照）。
 
@@ -401,7 +390,7 @@ mode 判定が `sequential` の場合のみ実行する。
 
 **sequential 用 4-4 (選択 → 1 枚生成)**:
 
-先にユーザーから採用企画を番号（A, B, C, ... のラベル）または企画タイトルで受け取り（不採用 (`candidate_count` - 1) 案は破棄、画像は未生成なので副作用なし）、選択 1 案のみ provider に応じた生成経路を 1 回呼ぶ:
+先にユーザーから採用企画を番号（A, B, C, ... のラベル）または企画タイトルで受け取り、選択1案だけproviderに応じた生成経路を1回呼ぶ。参照indexが無ければ停止する。
 
 ```bash
 # <x> は選択された企画の番号（a/b/c）
@@ -412,12 +401,6 @@ if [ "${#REF_PATHS[@]}" -le "$REF_INDEX" ]; then
 fi
 PROVIDER=$(uv run python3 -c "from youtube_automation.infrastructure.media.image_provider import load_image_generation_config; cfg = load_image_generation_config(); print(cfg.provider)")
 if [ "$PROVIDER" = "codex" ]; then
-  # codex は image_generation.codex.default_prompt_template を必ず使う。
-  # image_generation.gemini.composition_rules は codex-prompt.py が自動注入する。
-  # 参照画像を winning template として扱い、テキスト付き候補を先に確定する短い TTP thumbnail 先行プロンプトにする（#1611）。
-  # 選択した企画と同じ index の参照画像 1 枚だけを使う（a=0, b=1, c=2）。
-  # title 引数にはサムネに焼くテキスト（見出し + 短いサブタイトル）だけを渡す。
-  # 動画タイトル全文を渡さない（全文が画像に焼き込まれる事故の再発防止）。
   CODEX_PROMPT=$(uv run python3 .claude/skills/thumbnail/references/codex-prompt.py "<選択された企画タイトル>")
   bash .claude/skills/thumbnail/references/codex-image.sh --require-reference \
     "$CODEX_PROMPT" \
@@ -430,12 +413,13 @@ else
 fi
 ```
 
+生成commandがnon-zeroなら4-5へ進まず停止し、同じ4-4から再開する。
+
 **sequential 用 4-5 (1 枚承認)**:
 
 1. `open` で生成 1 枚をプレビューアプリで開く
-2. Read（Codex では同等の画像閲覧機能）でもプレビュー画像を表示する
-3. オブジェクトの名前・ストーリーを併記する
-4. 承認 NG / 生成失敗の場合は次のいずれかの経路で復帰:
+2. Read（Codex では同等の画像閲覧機能）でもプレビュー画像を表示して明示承認を待つ
+3. 承認 NG の場合は次のいずれかの経路で復帰:
    - 同じ企画で再生成 → 4-4 を再実行
    - 別の企画に切り替え → 4-4 の選択からやり直し
 

--- a/.claude/skills/collection-ideate/references/preview-generation.md
+++ b/.claude/skills/collection-ideate/references/preview-generation.md
@@ -1,0 +1,35 @@
+# Preview generation
+
+Phase 4 の parallel / sequential preview について、prompt 構築、provider 呼び出し、生成物、検証、retry、failure handling の詳細を定義する。mode 判定、コスト承認、セッション作成、実行コマンド、停止条件の順序は `../SKILL.md` を正とする。候補内容とセルフチェック設定は `preview-contract.md` に従う。
+
+## Parallel 生成詳細
+
+preview contract の候補 schema で確定した prompt を使い、`candidate_count` 件を a / b / c ... の順に生成する。候補ごとに `select-ttp-references.py` が返した別々の benchmark 参照画像を1枚だけ割り当てる。TTP strict preview に stock を混ぜない。
+
+- Codex provider は `image_generation.codex.default_prompt_template` と `thumbnail/references/codex-prompt.py` を使う。title 引数には画像へ焼く見出しと短いサブタイトルだけを渡し、動画タイトル全文、composition rule、legend、楽器を重複注入しない。候補数ぶんの一意な参照画像が無ければ生成前に停止する。
+- Gemini / OpenAI provider は候補の確定済み prompt を `yt-generate-image --ttp-strict-references --reference ... --max-attempts 1` へ渡す。provider 内部の追加 retry は行わない。
+- 1候補の生成が non-zero でも、残り候補は順番どおり試行する。成功候補は比較対象へ残し、失敗候補は画像無しのテキスト候補として扱う。
+- 出力は `collections/planning/_plan-previews/<dir>/plan-<label>-<slug>.png` とする。`-y` 経路で同名が存在する場合は上書きせず `-v2`, `-v3` ... を使う。
+
+成功画像は一度に開き、同じ候補順で画像、タイトル、prompt、オブジェクトの名前とストーリーを提示する。個別画像の再生成は同じ候補と参照割当でその候補の4-4 commandだけを再実行する。企画自体を変える場合は Phase 3 へ戻る。
+
+## Sequential 生成詳細
+
+画像生成前にテキスト候補から1案を選び、選択ラベルの0-based indexと同じ `REF_PATHS` の1枚だけを使う。不採用案は画像を生成しない。indexに対応する参照が無ければproviderを呼ばず停止する。
+
+provider別のprompt構築、TTP strict reference、ファイル名、no-overwrite契約はparallelと同じで、呼び出し回数だけを1回にする。生成commandがnon-zeroなら画像承認や参照履歴保存へ進まない。
+
+成功した1枚を開き、画像、タイトル、prompt、オブジェクトの名前とストーリーを提示して承認を待つ。承認NGの場合は同じ企画を再生成するか、別のテキスト候補を選び直して同じ4-4 commandへ戻る。sequentialは不採用画像を生成しないためstock退避しない。
+
+## 出力検証と再生成
+
+`self_check.enabled: true` の場合は生成後かつユーザー提示前に、SKILL本体の `yt-thumbnail-check --json` commandで成功画像を検証する。exit 0 は全対象合格、exit 1 は1件以上不合格として扱う。
+
+不合格時は `self_check.max_regeneration_attempts` が1以上なら不合格候補だけを再生成し、同じcheckを再実行する。上限到達または値が0なら警告と検査結果を提示し、明示承認なしに採用しない。check自体を実行できない場合は合格扱いにせず停止する。`self_check.enabled: false` の場合だけcheckを省略する。
+
+## Failure handling
+
+- parallelで一部失敗した場合は後続候補を続行し、成功画像だけを比較表示する。失敗候補は「プレビュー生成失敗」と明記してテキストのみ提示する。
+- parallelの生成成功が0枚なら画像比較をスキップし、テキスト候補の選択へ進む。存在するセッション残骸はNext Stepのcleanup契約で削除する。
+- sequentialの参照不足、provider non-zero、check実行不能はその段階で停止し、画像承認・参照履歴保存・cleanupへ先行しない。原因を解消後、同じ4-4または4-4-checkから再開する。
+- 採用企画の参照割当は企画確定後にSKILL本体のNext Stepで1回だけ保存する。生成途中や不採用候補を履歴へ記録しない。

--- a/tests/repo/test_collection_ideate_disclosure_contract.py
+++ b/tests/repo/test_collection_ideate_disclosure_contract.py
@@ -10,6 +10,7 @@ SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "collection-ideate"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 PLANNING_RULES_MD = SKILL_DIR / "references" / "planning-rules.md"
 PREVIEW_CONTRACT_MD = SKILL_DIR / "references" / "preview-contract.md"
+PREVIEW_GENERATION_MD = SKILL_DIR / "references" / "preview-generation.md"
 
 PLANNING_RULE_HEADINGS = {
     "ペルソナベース企画フレームワーク",
@@ -25,6 +26,12 @@ PREVIEW_CONTRACT_HEADINGS = {
     "候補 schema",
     "コスト計算契約",
     "セルフチェック契約",
+}
+PREVIEW_GENERATION_HEADINGS = {
+    "Parallel 生成詳細",
+    "Sequential 生成詳細",
+    "出力検証と再生成",
+    "Failure handling",
 }
 
 
@@ -112,3 +119,51 @@ def test_cost_approval_precedes_preview_side_effects() -> None:
     image_generation = skill.index("yt-generate-image", phase_4)
 
     assert approval < session_creation < image_generation
+
+
+def test_skill_dispatches_preview_generation_before_generation_steps() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = PREVIEW_GENERATION_MD.relative_to(SKILL_DIR).as_posix()
+
+    dispatch = skill.index(f"]({relative_reference})")
+    parallel_generation = skill.index("**4-4: プロンプト構築 + 一括生成（parallel デフォルト）**")
+
+    assert PREVIEW_GENERATION_MD.is_file()
+    assert dispatch < parallel_generation
+
+
+def test_preview_generation_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(PREVIEW_GENERATION_MD.read_text(encoding="utf-8"))
+
+    assert PREVIEW_GENERATION_HEADINGS <= reference_headings
+    assert PREVIEW_GENERATION_HEADINGS.isdisjoint(skill_headings)
+
+
+def test_skill_keeps_generation_routing_commands_and_hard_gates() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    phase_4 = skill.index("### Phase 4:")
+
+    mode_decision = skill.index("`preview.thumbnail_mode`", phase_4)
+    approval = skill.index("confirm_cost", phase_4)
+    session_creation = skill.index("mkdir -p", phase_4)
+    dispatch = skill.index("](references/preview-generation.md)", phase_4)
+    parallel_generation = skill.index("**4-4: プロンプト構築 + 一括生成（parallel デフォルト）**")
+    validation = skill.index("yt-thumbnail-check", parallel_generation)
+    user_selection = skill.index("**4-5: 全枚を比較提示 → ユーザー選択**", validation)
+
+    assert mode_decision < approval < session_creation < dispatch < parallel_generation < validation < user_selection
+    for command in (
+        "select-ttp-references.py",
+        "codex-image.sh --require-reference",
+        "yt-generate-image --ttp-strict-references",
+        "yt-thumbnail-check",
+    ):
+        assert command in skill
+    for hard_gate in (
+        "参照不足なら生成せず停止",
+        "生成成功が 0 枚",
+        "不合格候補だけを再生成",
+        "生成失敗",
+    ):
+        assert hard_gate in skill


### PR DESCRIPTION
## Summary

- collection-ideate の preview 生成詳細を配布内 reference へ段階開示
- SKILL の判断導線を保ちつつ、生成手順・契約を必要時だけ読める構成へ整理
- dispatch・reference・command/runtime 契約を repository contract で固定

## Test

- disclosure contract RED → GREEN
- related focused / full pytest / `yt-skills lint collection-ideate` / ruff / diff-check

Closes #3502