### PR TITLE
docs(collection-ideate): selection handoff を段階開示する (#3501)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -429,6 +429,8 @@ sequential モードでは Next Step で stock 退避は走らない（不採用
 
 コレクション作成の詳細ライフサイクル（ディレクトリ構造、段階別手順、チェックリスト）は `references/collection-lifecycle.md` を参照。入力モード・鮮度判定の正本は `references/freshness-rules.md` とする。
 
+ユーザーが企画を選択したら、保存・参照割当・stock・cleanup・後工程の判断詳細を [selection / handoff](references/selection-handoff.md) から読み、以下の分岐とコマンドへ適用する。
+
 ## 企画レポート保存
 
 企画候補は必ずコレクションの `20-documentation/plan_proposals.md` に保存すること。`preview.skip_cost_confirm: true` で画像生成した場合は、Phase 4-2 の生成条件と想定 call 数も同じ文書へ保存する。
@@ -439,7 +441,7 @@ sequential モードでは Next Step で stock 退避は走らない（不採用
 
 企画選択時にタイトルも確定する（`workflow-state.json` の `planning.final_title` に記録）。
 
-企画確定後、選択した企画のプレビュー画像は企画参照として保存し、**`main.png` にはコピーしない**。`main.png/jpg` は `/thumbnail` で承認済みのテキスト付き `thumbnail.jpg` から再生成して確定する textless 動画背景であり、文字入りサムネと同一画像にしない。`thumbnail_mode` と「画像が生成されたか」によって手順が分岐するため、ケース別に示す。
+企画確定後は `thumbnail_mode` と画像の有無で分岐する。採用画像は企画参照へ保存し、**`main.png` にはコピーしない**。不可逆操作は、参照割当の保存 → 採用画像のコピー → 不採用画像の stock 退避 → セッション cleanup の順で実行する。
 
 画像生成を実施した場合、企画確定後かつプレビューディレクトリ削除前に、今回使用した参照割当を collection の履歴へ必ず保存する。保存に失敗した場合は処理を継続せず、エラーを解消して同じコマンドを再実行する。
 
@@ -481,8 +483,6 @@ JSON
 rm -rf collections/planning/_plan-previews/<session-dir>/
 ```
 
-parallel モードでは `config/skills/collection-ideate.yaml` の `preview.stock_archive: false` か `config/skills/thumbnail.yaml` の `image_generation.stock.enabled: false` のいずれかで stock 退避を無効化できる（無効化時は CLI 経由で単純削除に戻る）。
-
 ### sequential モード時の Next Step
 
 不採用 (`candidate_count` - 1) 案は画像が未生成なので stock 退避は不要。`cp` 1 回 + `rm -rf` だけで済む:
@@ -505,12 +505,7 @@ rm -rf collections/planning/_plan-previews/<session-dir>/
 [ -d collections/planning/_plan-previews/<session-dir> ] && rm -rf collections/planning/_plan-previews/<session-dir>/
 ```
 
-このケースでも下流の `/thumbnail <theme>` がベンチマーク参照からテキスト付き `thumbnail.jpg` を先に生成・承認し、承認済み `thumbnail.jpg` から textless `main.png/jpg` を再生成する流れに合流する（下記「企画選択後」参照）。
-
-> **定期クリーンアップ**: 放棄されたセッションのディレクトリが残る場合、7 日以上前のものは手動削除可:
-> `find collections/planning/_plan-previews/ -maxdepth 1 -type d -mtime +7 -exec rm -rf {} +`
->
-> stock 側の保守は `uv run yt-stock-prune --dry-run` で候補確認 →（必要なら）本実行。
+このケースも下記「企画選択後」へ合流する。
 
 企画選択後:
 - `/thumbnail <theme>` で、テキスト付き `thumbnail.jpg` を先に確定し、承認済み `thumbnail.jpg` から textless `main.png/jpg` を別成果物として再生成・確定する。企画プレビューは参照素材であり、`main.png` として動画背景に流用しない

--- a/.claude/skills/collection-ideate/references/selection-handoff.md
+++ b/.claude/skills/collection-ideate/references/selection-handoff.md
@@ -1,0 +1,38 @@
+# Selection and handoff
+
+ユーザーが企画を選択した後の保存、reference assignment、stock archive、cleanup、後工程 handoff の判断詳細を定義する。選択分岐、停止条件、不可逆操作の順序、実行コマンド、Next Step、完了条件は `../SKILL.md` を正とする。
+
+## 採用候補の保存
+
+採用企画は `20-documentation/plan_proposals.md` に保存し、`workflow-state.json` の `planning.generated = true` と `planning.final_title` を更新する。`preview.skip_cost_confirm: true` で画像を生成した場合は、Phase 4-2 で確定した生成条件と想定 API call 数も同じレポートへ残す。
+
+採用画像がある場合だけ `10-assets/planning-preview.png` として保存する。この画像は企画参照素材であり、textless 動画背景の `main.png/jpg` へコピーしない。採用画像が無い経路では空ファイルや代替画像を作らない。
+
+## Reference assignment
+
+画像を生成した場合は、企画確定後かつセッション cleanup 前に、採用企画へ実際に割り当てた `REF_PATHS[$REF_INDEX]` だけを `record-ttp-reference-assignments.py` で履歴へ保存する。生成途中の候補、不採用候補、未生成候補は記録しない。
+
+履歴保存が non-zero の場合は後続のコピー、stock archive、cleanupへ進まない。原因を解消して同じコマンドを再実行する。コスト拒否または全画像生成失敗の経路では割当履歴を追加しない。
+
+## Stock archive
+
+parallel は採用画像をコピーした後、不採用の成功画像だけを `yt-stock-archive` で `assets/stock/<theme>/` へ退避する。`--exclude` は採用ファイル1枚を除外し、metadataには実際の provider、model、generation mode、prompt、reference images、personaを渡す。
+
+`preview.stock_archive: false` または thumbnail側の `image_generation.stock.enabled: false` でstock退避を無効化した場合は、採用画像を残したままCLIの削除経路へ切り替える。sequentialは不採用画像を生成しないためstock archiveを実行しない。
+
+## Cleanup と失敗時処理
+
+cleanupは必要な保存とarchiveがすべて成功した後にだけ実行する。
+
+- parallel: reference assignment → 採用画像コピー → 不採用画像archive → セッション削除。
+- sequential: reference assignment → 採用画像コピー → セッション削除。stock archiveは行わない。
+- コスト拒否または成功画像0枚: reference assignmentとコピーを行わず、存在するセッション残骸だけを削除する。
+- 一部生成失敗: 採用可能な成功画像の経路を使い、失敗画像をコピーやarchive対象にしない。
+
+放棄された `_plan-previews` セッションは7日以上経過したものだけを手動cleanup対象にする。stock側は先に `uv run yt-stock-prune --dry-run` で候補を確認し、確認なしに削除しない。
+
+## Handoff semantics
+
+完了条件は、企画レポート保存、`planning.generated` と `planning.final_title` の更新、画像がある場合の採用画像とreference assignmentの保存、mode別cleanupの完了である。失敗した必須操作があればhandoffせず、同じ段階から再開する。
+
+完了後は `/thumbnail <theme>` へ渡し、ベンチマーク参照からテキスト付き `thumbnail.jpg` を生成・承認してから、その承認済み画像を入力にtextless `main.png/jpg`を別成果物として確定する。企画プレビューを動画背景に流用しない。サムネイル確定後にだけ `/suno <theme>` へ進む。

--- a/tests/repo/test_collection_ideate_disclosure_contract.py
+++ b/tests/repo/test_collection_ideate_disclosure_contract.py
@@ -11,6 +11,7 @@ SKILL_MD = SKILL_DIR / "SKILL.md"
 PLANNING_RULES_MD = SKILL_DIR / "references" / "planning-rules.md"
 PREVIEW_CONTRACT_MD = SKILL_DIR / "references" / "preview-contract.md"
 PREVIEW_GENERATION_MD = SKILL_DIR / "references" / "preview-generation.md"
+SELECTION_HANDOFF_MD = SKILL_DIR / "references" / "selection-handoff.md"
 
 PLANNING_RULE_HEADINGS = {
     "ペルソナベース企画フレームワーク",
@@ -32,6 +33,13 @@ PREVIEW_GENERATION_HEADINGS = {
     "Sequential 生成詳細",
     "出力検証と再生成",
     "Failure handling",
+}
+SELECTION_HANDOFF_HEADINGS = {
+    "採用候補の保存",
+    "Reference assignment",
+    "Stock archive",
+    "Cleanup と失敗時処理",
+    "Handoff semantics",
 }
 
 
@@ -167,3 +175,85 @@ def test_skill_keeps_generation_routing_commands_and_hard_gates() -> None:
         "生成失敗",
     ):
         assert hard_gate in skill
+
+
+def test_skill_dispatches_selection_handoff_after_user_selection() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = SELECTION_HANDOFF_MD.relative_to(SKILL_DIR).as_posix()
+
+    user_selection = skill.index("**4-5: 全枚を比較提示 → ユーザー選択**")
+    dispatch = skill.index(f"]({relative_reference})")
+    report_save = skill.index("## 企画レポート保存", dispatch)
+
+    assert SELECTION_HANDOFF_MD.is_file()
+    assert user_selection < dispatch < report_save
+
+
+def test_selection_handoff_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(SELECTION_HANDOFF_MD.read_text(encoding="utf-8"))
+
+    assert SELECTION_HANDOFF_HEADINGS <= reference_headings
+    assert SELECTION_HANDOFF_HEADINGS.isdisjoint(skill_headings)
+
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    reference = SELECTION_HANDOFF_MD.read_text(encoding="utf-8")
+    for detail in (
+        "空ファイルや代替画像を作らない",
+        "生成途中の候補、不採用候補、未生成候補",
+        "7日以上経過したもの",
+        "同じ段階から再開する",
+    ):
+        assert detail not in skill
+        assert reference.count(detail) == 1
+
+
+def test_skill_keeps_selection_commands_hard_gates_and_handoff_order() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    next_step = skill.index("## Next Step")
+
+    report_save = skill.index("plan_proposals.md")
+    planning_generated = skill.index("planning.generated = true", report_save)
+    final_title = skill.index("planning.final_title", next_step)
+    assignment = skill.index("record-ttp-reference-assignments.py", next_step)
+    parallel = skill.index("### parallel モード（デフォルト）", assignment)
+    adopted_copy = skill.index("cp collections/planning/_plan-previews", parallel)
+    stock_archive = skill.index("uv run yt-stock-archive", adopted_copy)
+    parallel_cleanup = skill.index("rm -rf collections/planning/_plan-previews", stock_archive)
+    downstream_thumbnail = skill.index("`/thumbnail <theme>`", parallel_cleanup)
+    downstream_suno = skill.index("`/suno <theme>`", downstream_thumbnail)
+
+    assert report_save < planning_generated < final_title < assignment
+    assert assignment < adopted_copy < stock_archive < parallel_cleanup
+    assert parallel_cleanup < downstream_thumbnail < downstream_suno
+    for command in (
+        "record-ttp-reference-assignments.py",
+        "uv run yt-stock-archive",
+        "cp collections/planning/_plan-previews",
+        "rm -rf collections/planning/_plan-previews",
+    ):
+        assert command in skill
+    for hard_gate in (
+        "保存に失敗した場合は処理を継続せず",
+        "`main.png` にはコピーしない",
+        "`planning-preview.png` が未生成",
+    ):
+        assert hard_gate in skill
+
+
+def test_skill_keeps_mode_specific_cleanup_order() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    sequential = skill.index("### sequential モード時の Next Step")
+    no_image = skill.index("### コスト拒否 / 生成失敗で企画参照画像が無い場合", sequential)
+    handoff = skill.index("企画選択後:", no_image)
+
+    sequential_block = skill[sequential:no_image]
+    assert sequential_block.index("cp collections/planning/_plan-previews") < sequential_block.index(
+        "rm -rf collections/planning/_plan-previews"
+    )
+    assert "yt-stock-archive" not in sequential_block
+
+    no_image_block = skill[no_image:handoff]
+    assert "planning-preview.png コピーはスキップ" in no_image_block
+    assert "rm -rf collections/planning/_plan-previews" in no_image_block
+    assert "record-ttp-reference-assignments.py" not in no_image_block


### PR DESCRIPTION
## Summary

- collection-ideate の selection / handoff 詳細を配布内 reference へ段階開示
- 分岐・Hard Gates・不可逆操作順・既存 command 契約を維持
- dispatch・reference・実行順を repository contract で固定

## Test

- disclosure contract: 13 passed
- distributed/wheel: 18 passed; related: 153 passed
- `yt-skills lint collection-ideate` / ruff / diff-check

Closes #3501