### PR TITLE
docs(channel-new): bootstrap と config 詳細を段階開示する (#3505)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -141,9 +141,11 @@ TTP に関する質問は、TTP 対象への転写要素（タイトル構造 / 
 このヒアリング結果は後続の seed fetch / TTP 対象反映に使う。
 ヒアリング後は `docs/channel/ttp-seed-confirmation.md` を作成し、TTP したいチャンネル URL / handle / channel ID、転写したい要素、関係性メモを保存する。
 
+新規開設モードで Step 2 へ進む前に、repository 初期化、setup gate の check 分類、config 入力 schema、初期ファイル生成詳細の唯一の正である **[new-channel-bootstrap.md](references/new-channel-bootstrap.md)** を必ず Read する。本体に残す Step 2〜4 の順序、承認点、実行コマンド、成功・停止条件と組み合わせて実行する。
+
 ### Step 2: 現在のディレクトリを repo 初期化
 
-`.git` がなければ現在のディレクトリで初期化する。テンプレートリポジトリは使わない。
+`.git` の有無と作成予定の private remote 名を提示し、AskUserQuestion で「repo 初期化と remote 作成を実行」/「中止」を確認する。承認された場合だけ次の副作用を実行し、中止なら `git init` より前に停止する。`.git` がすでにある場合は `git init` をスキップする。
 
 ```bash
 git init
@@ -155,61 +157,22 @@ gh repo create <repo-name> --private --source . --remote origin
 
 ### Step 3: setup 完了確認
 
-`/channel-new` は **`/setup` 完了済み** を前提に進める。`/setup` が automation パッケージ導入、`yt-skills sync`、`yt-setup-dirs` による setup 用ディレクトリ生成、GCP プロジェクト作成、API 有効化、ADC、OAuth クライアント ID 配置、OAuth token 生成までを担当する。
-
-AI は以下を実行して状態を確認する:
+`/channel-new` は **`/setup` 完了済み** を前提に、次を実行して状態を確認する。
 
 ```bash
 uv run yt-doctor --json
 ```
 
-以下の check が `ok` でない場合は、ここで `/setup` を案内して停止する。認証とツール導入が完了するまで Step 4 以降へ進まない。
+必須 check は `ffmpeg` / `ffprobe` / `uv` / `uv_project` / `automation_package` / `skills_synced` / `gcloud` / `gcloud_account` / `gcp_project` / `billing_linked` / `apis_enabled` / `adc` / `adc_quota_project` / `iam_aiplatform_user` / `env_file` / `client_secrets` / `oauth_token`。いずれかが `ok` でなければ `/setup` を案内して停止し、認証とツール導入が完了するまで Step 4 以降へ進まない。
 
-- `ffmpeg`
-- `ffprobe`
-- `uv`
-- `uv_project`
-- `automation_package`
-- `skills_synced`
-- `gcloud`
-- `gcloud_account`
-- `gcp_project`
-- `billing_linked`
-- `apis_enabled`
-- `adc`
-- `adc_quota_project`
-- `iam_aiplatform_user`
-- `env_file`
-- `client_secrets`
-- `oauth_token`
-
-Step 4 の config 生成で解消するため、以下の config 未生成由来の fail は許容する:
-
-- `channel_config`: `config/channel/ ディレクトリが存在しない (新規チャンネル、setup 用ディレクトリのみでは未生成)`
-- `playlist_config`: `config/channel/playlists.json が存在しない`
-- `playlist_create_dry_run`: config 未生成による設定ロード失敗
-- `ttp_wf_new_readiness`: `config/channel/analytics.json 未生成`
-- `initial_setup_readiness`: `config/skills/thumbnail.yaml` / `config/skills/suno.yaml` 未転記由来の warn（Step R3.5 で解消する）
-- `upload_ready`: `config/channel/meta.json が存在しない`
-- `upload_ready`: `channel.channel_id が未設定`
-
-`upload_ready` が `auth/token.json が存在しない`、`upload 必須 scope 不足`、`token.json 読み込み失敗` で fail している場合は `/setup` を案内して停止する。その他の fail / warn / unknown が残る場合は、表示された `next_action` に従って解消してから進む。
-
-seed fetch は YouTube Data API 認証に依存するため、既存チャンネルの token コピーで代替しない。
+Step 4 で解消するため、`channel_config`: `config/channel/ ディレクトリが存在しない (新規チャンネル、setup 用ディレクトリのみでは未生成)`、`upload_ready`: `config/channel/meta.json が存在しない`、`upload_ready`: `channel.channel_id が未設定` は許容する。その他の許容分類は reference に従う。`upload_ready` が `auth/token.json が存在しない`、`upload 必須 scope 不足`、`token.json 読み込み失敗` のいずれかなら許容せず `/setup` に戻る。その他の fail / warn / unknown は表示された `next_action` に従って解消してから進む。
 
 ### Step 4: フルパッケージ config / 初期運用ファイル生成
 
-`yt-channel-init` で `config/channel/*.json` と channel-new で必要な初期運用ファイルを一括生成する。`/setup` が作成済みのディレクトリはそのまま再利用する:
-Step 1 の TTP ヒアリングとは別に、config 生成に必要な初期値だけをここで確認する:
+Step 1 の TTP ヒアリングとは別に、config 生成に必要な初期値だけをここで確認する。確認項目は **仮チャンネル名と SHORT** / **初期ジャンル情報** / **音楽エンジン** / **DistroKid 配信有無** / **DistroKid 初期 profile**。値の schema と確認規則は reference に従う。
+**動画尺** はここで確認せず、Step 5 の TTP seed fetch 後に Step 5.5 で承認済み TTP の benchmark から導出する。
 
-- **仮チャンネル名と SHORT**: `meta.json::channel.name` / `channel.short` に入れる
-- **初期ジャンル情報**: `genre.primary` / `genre.style` / `genre.context`
-- **動画尺**: この Step では手入力せず、Step 5.5 で承認済み TTP の benchmark から導出する
-- **音楽エンジン**: `music_engine` に入れる `suno` / `lyria` のどちらか
-- **DistroKid 配信有無**: 配信する場合は `distrokid.enabled=true` で初期化する
-- **DistroKid 初期 profile**: 配信する場合のみ `artist` / `language` / `main_genre` / `sub_genre` / songwriter first / last
-
-ここで確認した入力は `yt-channel-init` の CLI 引数に使う。
+`yt-channel-init` で `config/channel/*.json` と channel-new に必要な初期運用ファイルを一括生成し、`/setup` が作成済みのディレクトリはそのまま再利用する。
 
 ```bash
 uv run yt-channel-init \
@@ -240,11 +203,6 @@ uv run yt-channel-init \
 ```
 
 DistroKid 配信しない場合は `--distrokid-enabled` を付けず、`config/channel/distrokid.json` は生成しない。
-未配置時は config loader が `distrokid.enabled=false` として扱う。
-配信する場合は `artist`、`language`、`main_genre` を必ずヒアリングし、推測 default では埋めない。
-
-TTP 対象がこの時点で channel ID まで分かっている場合も、Step 4 では `benchmark.channels` へ書き込まない。
-候補 URL / handle / channel ID と関係性メモだけを残し、Step 5 の実データ確認とユーザー承認後に反映する。
 
 生成対象:
 
@@ -258,7 +216,7 @@ TTP 対象がこの時点で channel ID まで分かっている場合も、Step
 
 定期制作の自動起動（`workflow.json` の `scheduled_automation`）は本スキルでは生成しない（既定は未設定 = 無効）。運用開始後に定期実行したくなったら `/automation-schedule` で有効化する。
 
-冪等性: 既存ファイルは `--force` がない限り上書きしない。差分がある場合は unified diff を確認してから `--force` を判断する。初期ディレクトリ生成は `/setup` の責務であり、`yt-channel-init` は setup が作成済みのディレクトリを削除・再生成しない。
+冪等性: 既存ファイルは `--force` がない限り上書きしない。差分がある場合は unified diff を確認してから `--force` を判断する。初期ディレクトリは `/setup` の生成物を再利用する。
 
 ### Step 5: TTP seed fetch と承認済み対象反映
 

--- a/.claude/skills/channel-new/references/new-channel-bootstrap.md
+++ b/.claude/skills/channel-new/references/new-channel-bootstrap.md
@@ -1,0 +1,54 @@
+# New channel bootstrap
+
+新規開設モードの Step 2〜4 で使う repository 初期化、setup gate、config 入力 schema、初期ファイル生成の詳細を定義する。実行順、承認点、コマンド、成功・停止条件は `../SKILL.md` を正とし、必ず本体の dispatch からこの reference を読んで実行する。
+
+## Repository initialization details
+
+- `.git` がない場合だけ、現在のディレクトリをローカル repository として初期化する。テンプレート repository は clone しない。
+- remote は private repository として現在のディレクトリを source に作り、`origin` を設定する。
+- `gh` が未認証、または remote を今は作成しない判断になった場合も、ローカル初期化後の config 生成は継続できる。remote 作成を保留した事実は作業メモへ残す。
+- repository 初期化と remote 作成は副作用なので、本体の承認より前に実行しない。
+
+## Setup gate details
+
+必須 check ID と、config 未生成でも許容する代表的な stop contract は `../SKILL.md` に残す。次の config 生成で解消する分類詳細だけをこの reference で定義する。
+
+Step 4 の config 生成で解消する次の fail / warn だけは許容する。
+
+- `playlist_config`: `config/channel/playlists.json` 未生成
+- `playlist_create_dry_run`: config 未生成による設定ロード失敗
+- `ttp_wf_new_readiness`: `config/channel/analytics.json` 未生成
+- `initial_setup_readiness`: `config/skills/thumbnail.yaml` / `config/skills/suno.yaml` 未転記由来
+
+その他の fail / warn / unknown は `next_action` を完了するまで先へ進まない。seed fetch の認証を既存チャンネルの token コピーで代替しない。
+
+## Configuration input schema
+
+Step 1 の TTP ヒアリングとは別に、次の初期値をユーザーへ確認する。
+
+- 仮チャンネル名と SHORT: `meta.json::channel.name` / `channel.short`
+- 初期ジャンル情報: `genre.primary` / `genre.style` / `genre.context`
+- 音楽エンジン: `music_engine` の `suno` / `lyria`
+- DistroKid 配信有無: 配信する場合だけ `distrokid.enabled=true`
+- DistroKid 初期 profile: 配信する場合だけ `artist` / `language` / `main_genre` / `sub_genre` / songwriter first / last
+
+動画尺は Step 5.5 で承認済み TTP の benchmark から導出し、ここでは手入力しない。DistroKid 配信時の `artist`、`language`、`main_genre` は必ず確認し、推測 default では埋めない。
+
+## Initial file generation details
+
+通常の初期化では次を生成する。
+
+- `config/channel/{meta,content,youtube,analytics,playlists,workflow,audio}.json`
+- `config/localizations.json`
+- `config/schedule_config.json`（`upload_settings` を含む）
+- `config/skills/{suno,thumbnail}.yaml`
+- `.gitignore`
+- `auth/client_secrets.template.json`
+
+DistroKid 配信時だけ `config/channel/distrokid.json` を追加生成する。配信しない場合は `--distrokid-enabled` を指定せず、ファイル未配置を config loader が `distrokid.enabled=false` として扱う。
+
+`workflow.json::scheduled_automation` は生成せず、未設定を既定の無効状態とする。定期実行は運用開始後に `/automation-schedule` で有効化する。
+
+既存ファイルは `--force` なしで上書きしない。差分がある場合は unified diff を確認してから `--force` を判断する。初期ディレクトリ生成は `/setup` の責務であり、`yt-channel-init` は setup が作成済みのディレクトリを削除・再生成しない。
+
+TTP 候補の URL / handle / channel ID と関係性メモは残すが、Step 4 では `benchmark.channels` へ書き込まない。Step 5 の実データ確認とユーザー承認後に承認済み対象だけを反映する。

--- a/tests/repo/test_channel_new_disclosure_contract.py
+++ b/tests/repo/test_channel_new_disclosure_contract.py
@@ -1,0 +1,121 @@
+"""段階開示後の channel-new bootstrap 実行契約。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "channel-new"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+BOOTSTRAP_REFERENCE_MD = SKILL_DIR / "references" / "new-channel-bootstrap.md"
+
+BOOTSTRAP_DETAIL_HEADINGS = {
+    "Repository initialization details",
+    "Setup gate details",
+    "Configuration input schema",
+    "Initial file generation details",
+}
+
+
+def _headings(markdown: str) -> set[str]:
+    return {match.group(1).strip() for match in re.finditer(r"^#{2,4}\s+(.+?)\s*$", markdown, re.MULTILINE)}
+
+
+def test_skill_dispatches_bootstrap_reference_before_step_2() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = BOOTSTRAP_REFERENCE_MD.relative_to(SKILL_DIR).as_posix()
+
+    dispatch = skill.index(f"]({relative_reference})")
+    step_2 = skill.index("### Step 2:")
+
+    assert BOOTSTRAP_REFERENCE_MD.is_file()
+    assert dispatch < step_2
+
+
+def test_bootstrap_detail_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(BOOTSTRAP_REFERENCE_MD.read_text(encoding="utf-8"))
+
+    assert BOOTSTRAP_DETAIL_HEADINGS <= reference_headings
+    assert BOOTSTRAP_DETAIL_HEADINGS.isdisjoint(skill_headings)
+
+
+def test_approval_precedes_repository_side_effects_and_steps_keep_order() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+
+    step_2 = skill.index("### Step 2:")
+    approval = skill.index("AskUserQuestion", step_2)
+    git_init = skill.index("git init", approval)
+    gh_repo_create = skill.index("gh repo create", git_init)
+    step_3 = skill.index("### Step 3:", gh_repo_create)
+    doctor = skill.index("uv run yt-doctor --json", step_3)
+    step_4 = skill.index("### Step 4:", doctor)
+    channel_init = skill.index("uv run yt-channel-init", step_4)
+
+    assert step_2 < approval < git_init < gh_repo_create < step_3 < doctor < step_4 < channel_init
+
+
+def test_reference_owns_setup_gate_check_classification() -> None:
+    reference = BOOTSTRAP_REFERENCE_MD.read_text(encoding="utf-8")
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    bootstrap = skill.split("### Step 2:", 1)[1].split("### Step 5:", 1)[0]
+
+    for detail in (
+        "playlist_create_dry_run",
+        "initial_setup_readiness",
+        "config/skills/suno.yaml` 未転記由来",
+        "既存チャンネルの token コピー",
+    ):
+        assert reference.count(detail) == 1
+        assert detail not in bootstrap
+
+
+def test_reference_owns_configuration_schema_and_initial_file_rules() -> None:
+    reference = BOOTSTRAP_REFERENCE_MD.read_text(encoding="utf-8")
+    skill = SKILL_MD.read_text(encoding="utf-8")
+
+    for detail in (
+        "動画尺は Step 5.5",
+        "推測 default では埋めない",
+        "setup が作成済みのディレクトリを削除・再生成しない",
+        "Step 5 の実データ確認とユーザー承認後",
+    ):
+        assert reference.count(detail) == 1
+        assert detail not in skill
+
+
+def test_step_4_does_not_confirm_duration_before_step_5_5_derivation() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    reference = BOOTSTRAP_REFERENCE_MD.read_text(encoding="utf-8")
+
+    step_4 = skill.index("### Step 4:")
+    step_5 = skill.index("### Step 5:", step_4)
+    step_5_5 = skill.index("### Step 5.5:", step_5)
+    step_4_confirmation = next(line for line in skill[step_4:step_5].splitlines() if "確認項目は" in line)
+
+    assert "動画尺" not in step_4_confirmation
+    assert "手入力" not in step_4_confirmation
+    assert "動画尺は Step 5.5" in reference
+    assert step_4 < step_5 < step_5_5
+
+
+def test_skill_keeps_bootstrap_commands_defaults_artifacts_and_stop_conditions() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+
+    for command in (
+        "git init",
+        "gh repo create <repo-name> --private --source . --remote origin",
+        "uv run yt-doctor --json",
+        "uv run yt-channel-init",
+        "--distrokid-enabled",
+    ):
+        assert command in skill
+    for contract in (
+        "既存ファイルは `--force` がない限り上書きしない",
+        "scheduled_automation",
+        "config/channel/{meta,content,youtube,analytics,playlists,workflow,audio}.json",
+        "Step 4 以降へ進まない",
+        "remote 作成を保留",
+    ):
+        assert contract in skill


### PR DESCRIPTION
## Summary

- new channel の repository 初期化、setup gate、config schema / initial files 詳細を専用 reference へ分離
- root skill の mode routing、承認、Step 2–4 順序、commands、停止・成功条件を維持
- Step 4 の手動確認から動画尺を除外し、Step 5 後の Step 5.5 benchmark 導出を唯一の owner として固定
- dispatch / ownership / approval-before-side-effects / duration negative-order を契約テストで固定

## Verification

- disclosure contract: 7 passed（review RED: 1 failed / 6 passed）
- channel-new: 28 passed
- docs / distributed / setup: 103 passed
- wheel sync: 1 passed
- skill lint / ruff / diff-check: green

Closes #3505