### PR TITLE
docs(generate-image): make CLI help self-contained (#3516)

### DIFF
--- a/src/youtube_automation/commands/media/generate_image.py
+++ b/src/youtube_automation/commands/media/generate_image.py
@@ -281,18 +281,46 @@ def main():
     parser = argparse.ArgumentParser(
         description="画像生成プロバイダー（Gemini / OpenAI）で画像を生成（ダイレクトモード）"
     )
-    parser.add_argument("--prompt", type=str, default=None, help="プロンプトテキスト")
-    parser.add_argument("--output", type=str, default=None, help="出力パス")
-    parser.add_argument("-y", "--yes", action="store_true", help="コスト確認をスキップ")
-    parser.add_argument("--model", type=str, default=None, help="使用するモデル（skill-config の値を上書き）")
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="プロンプトテキスト。通常生成では必須（--costs 単独実行時は不要）",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="出力パス。通常生成では必須（--costs 単独実行時は不要）",
+    )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="コスト承認のみを省略。既存出力は上書きせず -vN で自動採番",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="使用するモデル。未指定時は skill-config の provider 別 model を使い、指定時はその値を上書き",
+    )
     parser.add_argument(
         "--reference",
         type=str,
         action="append",
         default=None,
-        help="参照画像パス（複数指定可。複数指定時はスタイルブレンド/合成）",
+        help=("参照画像パス。画像ごとに繰り返し指定可能。複数指定時はスタイルブレンドまたは合成に使う"),
     )
-    parser.add_argument("--aspect-ratio", type=str, default="16:9", help="アスペクト比（例: 16:9, 9:16, 1:1）")
+    parser.add_argument(
+        "--aspect-ratio",
+        type=str,
+        default="16:9",
+        help=(
+            "アスペクト比 (デフォルト: %(default)s)。OpenAI は 16:9 または 9:16 のみ。"
+            "Gemini / gemini_cli は provider/config の対応範囲に従う"
+        ),
+    )
     parser.add_argument(
         "--size",
         type=str,
@@ -300,7 +328,7 @@ def main():
         default=_GEMINI_DEFAULT_IMAGE_SIZE,
         help=(
             f"画像解像度 {_GEMINI_VALID_IMAGE_SIZES}（Gemini provider 用、デフォルト: "
-            f"{_GEMINI_DEFAULT_IMAGE_SIZE}）。OpenAI provider では aspect_ratio から自動決定"
+            "%(default)s）。OpenAI provider では aspect_ratio から自動決定"
         ),
     )
     parser.add_argument("--no-composition", action="store_true", help="composition_prefix の自動付加をスキップ")
@@ -337,7 +365,7 @@ def main():
         "--reference-index",
         type=int,
         default=None,
-        help="複数参照画像のうち特定のインデックスのみ使用（attempt ループ無効）",
+        help=("複数参照画像から 0-based index で1枚を選ぶ（--reference 必須）。指定時は attempt ループを無効化"),
     )
     parser.add_argument(
         "--max-workers",

--- a/tests/commands/media/test_generate_image_help.py
+++ b/tests/commands/media/test_generate_image_help.py
@@ -1,0 +1,68 @@
+"""``yt-generate-image --help`` の自己完結した入力契約。"""
+
+import re
+import sys
+
+import pytest
+
+from youtube_automation.commands.media import generate_image
+
+
+def _help_text(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> str:
+    monkeypatch.setattr(sys, "argv", ["yt-generate-image", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_image.main()
+
+    assert exc_info.value.code == 0
+    return " ".join(capsys.readouterr().out.split())
+
+
+def test_help_explains_required_generation_inputs_and_costs_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "--prompt" in help_text
+    assert "--output" in help_text
+    assert "通常生成では必須" in help_text
+    assert "--costs 単独実行時は不要" in help_text
+
+
+def test_help_explains_reference_and_approval_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "画像ごとに繰り返し指定可能" in help_text
+    assert "コスト承認のみを省略" in help_text
+    assert "既存出力は上書きせず -vN で自動採番" in help_text
+
+
+def test_help_explains_reference_index_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "0-based index" in help_text
+    assert "--reference 必須" in help_text
+    assert "attempt ループを無効化" in help_text
+
+
+def test_help_exposes_static_and_dynamic_defaults_without_false_choices(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "アスペクト比 (デフォルト: 16:9)" in help_text
+    assert "OpenAI は 16:9 または 9:16 のみ" in help_text
+    assert "Gemini / gemini_cli は provider/config の対応範囲に従う" in help_text
+    assert "未指定時は skill-config の provider 別 model" in help_text
+    assert "未指定時は skill-config の image_generation.gemini.single_step.max_attempts" in help_text
+    assert re.search(r"--aspect-ratio ASPECT_RATIO\b", help_text)
+    assert re.search(r"--model MODEL\b", help_text)
+    assert re.search(r"--reference-index REFERENCE_INDEX\b", help_text)


### PR DESCRIPTION
## 概要

`yt-generate-image --help` だけで必須入力・reference・cost 承認・動的既定値を判断できるようにします。

Closes #3516

## 変更内容

- prompt/output、reference、aspect ratio、`-y`、reference-index の意味を help に明記
- config 由来の model/max-attempts を実効値として表示
- parser/runtime 挙動を変えず semantic help contract を追加

## 検証

- TDD: RED 4 → GREEN 4
- 関連 304 tests pass
- Ruff check/format、diff-check pass
- 変更外の DejaVu Sans 欠如による Codex rendering 2 tests のみローカル環境で失敗

## 関連

- Depends on #3563
- #3517/#3518 は #3265 との ancestry 解消まで未着手