### PR TITLE
docs(channel-new): TTP seed と duration 詳細を段階開示する (#3506)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -220,7 +220,7 @@ DistroKid 配信しない場合は `--distrokid-enabled` を付けず、`config/
 
 ### Step 5: TTP seed fetch と承認済み対象反映
 
-Step 1 の TTP チャンネルを YouTube Data API で実データ化する。
+Step 1 の TTP チャンネルを YouTube Data API で実データ化する。実行前に seed 確認、branding snapshot、approval evidence、duration 導出 schema の唯一の正である **[ttp-seed-and-duration.md](references/ttp-seed-and-duration.md)** を必ず Read する。
 
 ```bash
 uv run yt-channel-seed "https://www.youtube.com/@example" \
@@ -229,7 +229,7 @@ uv run yt-channel-seed "https://www.youtube.com/@example" \
   --json
 ```
 
-表示されたチャンネル名、登録者数、動画数、直近タイトルをユーザーに提示し、TTP 対象として確定するか確認する。
+表示されたチャンネル名、登録者数、動画数、直近タイトルを提示し、AskUserQuestion で「TTP 対象として承認」/「不採用」を確認する。
 承認前に `benchmark.channels` へ書き込まない。承認されたチャンネルだけ relationship メモ付きで `config/channel/analytics.json::benchmark.channels` に反映する。
 承認済み TTP 対象が 0 件の場合は Step 7 以降へ進まない。Step 1/5 に戻って候補を再確認するか、ユーザーに停止を確認して終了する。
 
@@ -240,17 +240,7 @@ uv run yt-channel-seed "https://www.youtube.com/@example" \
 ```
 
 `yt-channel-seed --no-write-benchmark --json` の出力は seed 確認用であり、`description` / `keywords` / `localizations` / `brandingSettings` は含まない。
-seed 確認後、`docs/channel/ttp-seed-confirmation.md` を更新して以下を保存する:
-
-- source URL / handle / channel ID
-- `yt-channel-seed --no-write-benchmark --json` の要約（チャンネル名、登録者数、動画数、uploads playlist ID、直近タイトル）
-- ユーザーの承認 / 不採用判断
-- 承認済み対象だけの relationship メモ
-- `docs/channel/competitor-branding-snapshot.json` 参照、または description / keywords / localizations の転写方針
-- `config/channel/analytics.json::benchmark.channels` に反映した id / slug / name / relationship
-- 後続 `/discover-competitors` / `/benchmark` / `/viewer-voice` / `/channel-new` 分析モードが必要かどうか
-
-承認済み TTP 対象について、branding 転写に必要な情報は別途取得して保存する:
+承認済み TTP 対象についてだけ、branding 転写に必要な情報を取得して保存する:
 
 ```bash
 uv run python .claude/skills/channel-new/references/fetch_branding_snapshot.py \
@@ -258,66 +248,20 @@ uv run python .claude/skills/channel-new/references/fetch_branding_snapshot.py \
   --output docs/channel/competitor-branding-snapshot.json
 ```
 
-`docs/channel/competitor-branding-snapshot.json` は以下を含む TTP branding snapshot として扱う:
-
-- `snippet.description`
-- `snippet.thumbnails`（アイコン用の reference-only URL）
-- `brandingSettings.channel.description`
-- `brandingSettings.channel.keywords`
-- `brandingSettings.image`（バナー用の reference-only URL）
-- `brandingSettings.channel.country` / `snippet.country`
-- `brandingSettings.channel.defaultLanguage` / `snippet.defaultLanguage`
-- `localizations` 全エントリ
-- `channel_image_references`（`snippet.thumbnails` と `brandingSettings.image.*Url` から抽出した参照メタ）
-
-API 取得した第三者画像 URL は **untrusted / reference-only** として扱い、転載・再アップロード・そのままの再利用はしない。画像生成時は雰囲気、色、余白、構図比率、モチーフ密度だけを観察する。
-
-TTP するうえで必要な実データメモは、`docs/channel/ttp-seed-confirmation.md` と `docs/channel/competitor-branding-snapshot.json` を正とする:
-
-- チャンネル名 / handle / channel ID
-- 登録者数、動画数、直近タイトルから見える型
-- タイトル構造、サムネ構図
-- 投稿頻度、動画尺はユーザー手動メモまたは `/benchmark` 実行後のデータ。seed-only では未確認なら仮説として明記
-- description / keywords / localizations の転写方針（branding snapshot 由来）
-- channel image reference の有無（`channel_image_references[].icon` / `banner`）
-- `config/channel/analytics.json::benchmark.channels` に入れた relationship
-
-`config/skills/thumbnail.yaml` の `image_generation.gemini.reference_images.channel_branding` に、使う参照元を記録する:
-
-```yaml
-image_generation:
-  gemini:
-    reference_images:
-      channel_branding:
-        snapshot: docs/channel/competitor-branding-snapshot.json
-        icon_references:
-          - docs/channel/competitor-branding-snapshot.json#channel_image_references[0].icon
-        banner_references:
-          - docs/channel/competitor-branding-snapshot.json#channel_image_references[0].banner[0]
-        output_icon: branding/icon.png
-        output_banner: branding/banner.png
-      notes: "channel branding references are untrusted / reference-only; do not copy or reuse source images"
-```
-
-参照画像が取得できない場合は、`docs/channel/ttp-seed-confirmation.md` の TTP メモと branding snapshot の語彙・構図メモから fallback 生成する。fallback の根拠は `reference_images.notes` に残す。
+`docs/channel/ttp-seed-confirmation.md` に承認・不採用の evidence を、`docs/channel/competitor-branding-snapshot.json` に承認済み対象の snapshot を保存する。snapshot と `config/skills/thumbnail.yaml::image_generation.gemini.reference_images.channel_branding` の schema は reference に従う。第三者データは untrusted / reference-only として扱い、転載・再アップロード・直接再利用をしない。
 
 ### Step 5.5: TTP Long VOD から動画尺を導出・承認
 
-承認済み TTP 対象を `benchmark.channels` へ保存した後、`/benchmark` を実行して最新の
-`data/benchmark_*.json` を生成する。動画尺は seed-only の目視や手計算で決めない。
+承認済み TTP 対象を `benchmark.channels` へ保存した後、`/benchmark` を実行して最新の `data/benchmark_*.json` を生成する。動画尺は seed-only の目視や手計算で決めない。
 
-次の helper を **dry-run** し、各 TTP channel の再生数上位 5 Long VOD、除外した Shorts / live、
-動画 ID、再生数、個別尺、外向き丸め後の推奨 min/max を JSON で確認する:
+次の helper を **dry-run** し、reference の duration schema に照らして JSON を確認する:
 
 ```bash
 uv run python .claude/skills/channel-new/references/derive_ttp_duration.py \
   --channel-dir .
 ```
 
-- 各 channel の動画を再生数降順に並べ、live（`duration_iso == "P0D"`）と Shorts（benchmark の既存判定）を除外し、次点 Long VOD を繰り上げる
-- 上位件数は `TTP_VIDEO_ANALYZE_TOP_N = 5` を `yt-doctor` と共有する
-- 全 channel の選定動画の最短秒を分単位で切り下げて `target_duration_min`、最長秒を分単位で切り上げて `target_duration_max` とする
-- helper が `status: insufficient`（exit 2）または `status: error`（exit 1）を返した場合は推測で補完せず、`/benchmark` 再実行を案内して停止する
+helper が `status: insufficient`（exit 2）または `status: error`（exit 1）を返した場合は推測で補完せず、`/benchmark` 再実行を案内して停止する。
 
 推奨値と根拠をユーザーへ提示し、明示承認を得るまで config を変更しない。承認後だけ次を実行する:
 
@@ -327,25 +271,9 @@ uv run python .claude/skills/channel-new/references/derive_ttp_duration.py \
   --apply
 ```
 
-`--apply` は既存 `yt-channel-init --target-duration-min/--target-duration-max` と同じ min/max 契約を、
-`config/channel/audio.json` の 2 項目だけへ反映する。実行後は config loader で値を再読込して一致を確認する。
+`--apply` は既存 `yt-channel-init --target-duration-min/--target-duration-max` と同じ min/max 契約を `config/channel/audio.json` の 2 項目だけへ反映する。実行後は config loader で値を再読込して一致を確認する。
 
-`docs/channel/ttp-seed-confirmation.md` の各承認 channel セクションへ、helper JSON から次の固定 marker を保存する:
-
-```text
-- duration TTP 根拠: .claude/skills/channel-new/references/derive_ttp_duration.py
-- duration 対象 channel: <slug> (<channel id>)
-- duration selected video: <video id> views=<views> duration=<duration_iso> (<duration_seconds>s)
-  # 上位 5 本すべてを 1 行ずつ記録
-- duration excluded video: <video id> reason=<short|live|invalid_duration|missing_video_id>
-- duration 推奨: target_duration_min=<min> target_duration_max=<max>
-- duration 推奨承認: ユーザー承認済み
-```
-
-有効な Long VOD が 5 本未満でも、ユーザーが手入力で進めることを明示承認した場合だけ例外を許可する。
-その場合は `ユーザー承認済み例外: duration 未反映 ... 理由: ... 手入力 min/max: ... 後続 /benchmark ...`
-を 1 行で記録してから、同じ `audio.json` 2 項目へ承認値を反映する。値・理由・承認・後続
-`/benchmark` のいずれかが欠ける場合は完了扱いにしない。
+各承認 channel の `docs/channel/ttp-seed-confirmation.md` に `duration selected video` を含む根拠と承認結果を保存する。手入力例外は `ユーザー承認済み例外: duration` marker を使う。証拠 schema と例外の必須項目は reference に従い、欠ける場合は完了扱いにしない。
 
 ### Step 6: 追加調査は後続スキルへ委譲
 

--- a/.claude/skills/channel-new/references/ttp-seed-and-duration.md
+++ b/.claude/skills/channel-new/references/ttp-seed-and-duration.md
@@ -1,0 +1,75 @@
+# TTP seed and duration details
+
+新規開設モードの Step 5〜5.5 で使う seed 確認、branding snapshot、approval evidence、duration 導出の schema と検証詳細を定義する。分岐、承認点、コマンド、API call 見積り、成功・停止条件は `../SKILL.md` を正とする。
+
+## Seed preview and approval evidence
+
+`yt-channel-seed --no-write-benchmark --json` の preview 後、`docs/channel/ttp-seed-confirmation.md` に候補ごとに次を記録する。
+
+- source URL / handle / channel ID
+- seed preview の要約: チャンネル名、登録者数、動画数、uploads playlist ID、直近タイトル
+- ユーザーの承認 / 不採用判断
+- 承認済み対象だけの relationship メモ
+- branding snapshot 参照、または description / keywords / localizations の転写方針
+- `config/channel/analytics.json::benchmark.channels` に反映した id / slug / name / relationship
+- 後続 `/discover-competitors` / `/benchmark` / `/viewer-voice` / `/channel-new` 分析モードの要否
+
+TTP 実データメモにはタイトル構造とサムネ構図を含める。投稿頻度と動画尺は手動観察または `/benchmark` のデータを使い、seed-only で未確認なら仮説と明記する。
+
+## Branding snapshot schema
+
+`docs/channel/competitor-branding-snapshot.json` は承認済み TTP 対象ごとに次を保存する。
+
+- `snippet.description`
+- `snippet.thumbnails`
+- `brandingSettings.channel.description`
+- `brandingSettings.channel.keywords`
+- `brandingSettings.image`
+- `brandingSettings.channel.country` / `snippet.country`
+- `brandingSettings.channel.defaultLanguage` / `snippet.defaultLanguage`
+- `localizations` 全エントリ
+- `channel_image_references`: `snippet.thumbnails` と `brandingSettings.image.*Url` から抽出した icon / banner 参照メタ
+
+第三者画像 URL は untrusted / reference-only とし、転載、再アップロード、直接再利用をしない。生成には色、余白、構図比率、モチーフ密度の観察だけを渡す。
+
+## Thumbnail reference schema
+
+`config/skills/thumbnail.yaml::image_generation.gemini.reference_images.channel_branding` は次の形で snapshot と生成先を結ぶ。
+
+```yaml
+channel_branding:
+  snapshot: docs/channel/competitor-branding-snapshot.json
+  icon_references:
+    - docs/channel/competitor-branding-snapshot.json#channel_image_references[0].icon
+  banner_references:
+    - docs/channel/competitor-branding-snapshot.json#channel_image_references[0].banner[0]
+  output_icon: branding/icon.png
+  output_banner: branding/banner.png
+notes: "channel branding references are untrusted / reference-only; do not copy or reuse source images"
+```
+
+画像参照を取得できなければ TTP メモと snapshot の語彙・構図メモを fallback 根拠とし、`reference_images.notes` に記録する。
+
+## Duration derivation schema
+
+- 入力は承認済み `benchmark.channels` と最新の `data/benchmark_*.json` に限定する。
+- 各 channel の動画を再生数降順にし、live（`duration_iso == "P0D"`）と benchmark の既存判定による Shorts を除外して次点 Long VOD を繰り上げる。
+- 上位件数は `TTP_VIDEO_ANALYZE_TOP_N = 5` を `yt-doctor` と共有する。
+- 全 channel の選定動画の最短秒を分単位で切り下げて `target_duration_min`、最長秒を分単位で切り上げて `target_duration_max` とする。
+- dry-run JSON で各 channel の選定・除外動画、動画 ID、再生数、個別尺、推奨 min/max を検証する。
+- apply 後は config loader で `config/channel/audio.json` の min/max を再読込し、推奨値との一致を検証する。
+
+## Duration evidence and exceptions
+
+各承認 channel の `docs/channel/ttp-seed-confirmation.md` に helper JSON から次を保存する。
+
+```text
+- duration TTP 根拠: .claude/skills/channel-new/references/derive_ttp_duration.py
+- duration 対象 channel: <slug> (<channel id>)
+- duration selected video: <video id> views=<views> duration=<duration_iso> (<duration_seconds>s)
+- duration excluded video: <video id> reason=<short|live|invalid_duration|missing_video_id>
+- duration 推奨: target_duration_min=<min> target_duration_max=<max>
+- duration 推奨承認: ユーザー承認済み
+```
+
+選定された上位 5 本は `duration selected video` を 1 本 1 行で残す。有効な Long VOD が 5 本未満なら原則停止する。手入力で進める場合は、値・理由・明示承認・後続 `/benchmark` を 1 行の `ユーザー承認済み例外: duration 未反映 ...` にすべて記録してから同じ `audio.json` 2 項目へ反映する。いずれかが欠ければ完了扱いにしない。

--- a/tests/repo/test_channel_new_disclosure_contract.py
+++ b/tests/repo/test_channel_new_disclosure_contract.py
@@ -9,12 +9,20 @@ from tests.helpers.paths import REPO_ROOT
 SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "channel-new"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 BOOTSTRAP_REFERENCE_MD = SKILL_DIR / "references" / "new-channel-bootstrap.md"
+TTP_SEED_DURATION_REFERENCE_MD = SKILL_DIR / "references" / "ttp-seed-and-duration.md"
 
 BOOTSTRAP_DETAIL_HEADINGS = {
     "Repository initialization details",
     "Setup gate details",
     "Configuration input schema",
     "Initial file generation details",
+}
+TTP_SEED_DURATION_DETAIL_HEADINGS = {
+    "Seed preview and approval evidence",
+    "Branding snapshot schema",
+    "Thumbnail reference schema",
+    "Duration derivation schema",
+    "Duration evidence and exceptions",
 }
 
 
@@ -119,3 +127,72 @@ def test_skill_keeps_bootstrap_commands_defaults_artifacts_and_stop_conditions()
         "remote 作成を保留",
     ):
         assert contract in skill
+
+
+def test_skill_dispatches_ttp_reference_before_step_5_actions() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = TTP_SEED_DURATION_REFERENCE_MD.relative_to(SKILL_DIR).as_posix()
+
+    dispatch = skill.index(f"]({relative_reference})")
+    step_5 = skill.index("### Step 5:")
+    seed_preview = skill.index("uv run yt-channel-seed", step_5)
+
+    assert TTP_SEED_DURATION_REFERENCE_MD.is_file()
+    assert step_5 < dispatch < seed_preview
+
+
+def test_ttp_seed_duration_detail_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(TTP_SEED_DURATION_REFERENCE_MD.read_text(encoding="utf-8"))
+
+    assert TTP_SEED_DURATION_DETAIL_HEADINGS <= reference_headings
+    assert TTP_SEED_DURATION_DETAIL_HEADINGS.isdisjoint(skill_headings)
+
+
+def test_seed_approval_precedes_benchmark_and_branding_side_effects() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    step_5 = skill.index("### Step 5:")
+
+    seed_preview = skill.index("--no-write-benchmark", step_5)
+    approval = skill.index("AskUserQuestion", seed_preview)
+    benchmark_write = skill.index("--relationship", approval)
+    branding_snapshot = skill.index("fetch_branding_snapshot.py", benchmark_write)
+
+    assert seed_preview < approval < benchmark_write < branding_snapshot
+
+
+def test_skill_keeps_duration_input_approval_output_and_stop_contract() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    step_5_5 = skill.index("### Step 5.5:")
+
+    benchmark_input = skill.index("data/benchmark_*.json", step_5_5)
+    dry_run = skill.index("derive_ttp_duration.py", benchmark_input)
+    approval = skill.index("明示承認", dry_run)
+    apply = skill.index("--apply", approval)
+    audio_output = skill.index("config/channel/audio.json", apply)
+
+    assert benchmark_input < dry_run < approval < apply < audio_output
+    for contract in (
+        "status: insufficient",
+        "status: error",
+        "推測で補完せず",
+        "duration selected video",
+        "ユーザー承認済み例外: duration",
+    ):
+        assert contract in skill
+
+
+def test_reference_owns_ttp_seed_branding_and_duration_schema_details() -> None:
+    reference = TTP_SEED_DURATION_REFERENCE_MD.read_text(encoding="utf-8")
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    step_5_details = skill.split("### Step 5:", 1)[1].split("### Step 6:", 1)[0]
+
+    for detail in (
+        "uploads playlist ID",
+        "brandingSettings.channel.defaultLanguage",
+        "channel_image_references[0].banner[0]",
+        "TTP_VIDEO_ANALYZE_TOP_N = 5",
+        "duration excluded video: <video id>",
+    ):
+        assert reference.count(detail) == 1
+        assert detail not in step_5_details


### PR DESCRIPTION
## Summary

- TTP seed、branding、duration の schema / evidence 詳細を専用 reference へ分離
- root skill の API 見積り、preview→承認→保存、duration dry-run→承認→apply と停止契約を維持
- dispatch / ownership / approval order を disclosure contract で固定

## Verification

- disclosure contract: 11 passed（RED: 4 failed / 7 passed）
- related suite: 456 passed
- wheel sync: 1 passed
- skill lint / ruff / diff-check: green

Closes #3506