### PR TITLE
docs(channel-new): save・settings push・troubleshooting を段階開示する (#3508)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -346,16 +346,13 @@ uv run yt-doctor --json
 
 ### Step 10: 初回保存と automation-update 前の整理
 
-`/channel-new` 完了直後は、`/setup` と本スキルで生成したファイルが未コミットのまま残りやすい。後続の `/automation-update` は dirty worktree で停止するため、最後に必ず git 状態を確認する。
+初回保存・cleanup・設定 push・障害対応の詳細は **[save-push-troubleshooting.md](references/save-push-troubleshooting.md)** を Read してから実行する。後続の `/automation-update` は dirty worktree で停止するため、最後に必ず git 状態を確認する。
 
 ```bash
 git status --porcelain
 ```
 
-出力が空なら、作業ツリーが整理済みで `/automation-update` に進める状態だと案内する。
-
-出力が非空の場合は、差分をユーザーに見せたうえで初回 commit を作成する。シークレットを混入させないため、staged files 全体を commit 前 guard で確認してから commit する。
-ignore 済み `.env` は exclude pathspec 付き `git add` でも Git が exit 1 になり得るため、`git add -A` 後の guard を唯一の安全境界にする。guard が失敗した場合は staged secret を自動で外して停止し、`git commit` へ進まない。
+出力が空なら、作業ツリーが整理済みで `/automation-update` に進める状態だと案内する。非空なら差分をユーザーに見せ、`git add -A` 後の guard を唯一の安全境界にする。次を順に実行し、guard が失敗した場合は staged secret を自動で外して停止して `git commit` へ進まない。
 
 ```bash
 git status --short
@@ -366,16 +363,7 @@ git commit -m "chore: 初回チャンネル設定を保存"
 git status --porcelain
 ```
 
-guard が `secret-like file staged; unstaged before commit` を出した場合は commit しない。該当ファイルは staged から外れているため、`.gitignore` を確認してからやり直す。
-
-`gh repo create` や remote 作成を保留している、git user identity 未設定で commit できない、またはユーザーが今 commit しない判断をした場合は、保存未完了として次の手順を明確に案内して終了する:
-
-```text
-未コミット変更が残っています。/automation-update の前に以下を完了してください:
-  1. git status --short で差分を確認
-  2. .env / auth/client_secrets.json / auth/token*.json が staged されていないことを確認
-  3. git commit -m "chore: 初回チャンネル設定を保存"
-```
+guard が `secret-like file staged; unstaged before commit` を出した場合は commit しない。remote 作成保留、git user identity 未設定、またはユーザーが今 commit しない場合は、reference の「未コミット変更が残っています。/automation-update の前に以下を完了してください」案内を提示して保存未完了として終了する。
 
 保存未完了として終了した場合は、以下の成功案内は出さない。作業ツリーが最初から clean、または初回 commit が成功した場合だけ最後に案内する:
 
@@ -416,15 +404,22 @@ guard が `secret-like file staged; unstaged before commit` を出した場合�
 
 ## 設定 push モード（運用中チャンネルの設定同期）
 
-ローカル `config/channel/meta.json` の `youtube_channel` セクション（description / keywords / country / default_language / unsubscribed_trailer / made_for_kids）と `config/localizations.json` を YouTube チャンネルに反映、もしくは YouTube 側から取り込む。新規セットアップ後はもちろん、運用中に設定を変更したときの **設定反映フェーズ** としても本セクションが入口。
+実行前に **[save-push-troubleshooting.md](references/save-push-troubleshooting.md)** を Read する。ローカル `config/channel/meta.json` の `youtube_channel` と `config/localizations.json` を YouTube チャンネルに反映、もしくは YouTube 側から取り込む。
 
 **前提**: OAuth 認証完了済み (`auth/token.json` が存在) かつ `config/channel/meta.json` の `channel.channel_id` が設定済みであること。
 
-**運用フロー（push 方向: local → YouTube）**:
+push 方向は次の読み取り専用確認を順に実行する。
 
-1. `uv run yt-channel-settings diff` で意図しないずれがないか確認（読み取り専用）
-2. `uv run yt-channel-settings push` の dry-run 出力をレビュー（`channels().update()` 呼び出しなし）
-3. 問題なければ `uv run yt-channel-settings push --apply` で実反映
+```bash
+uv run yt-channel-settings diff
+uv run yt-channel-settings push
+```
+
+dry-run の差分、対象 part、`meta.json::channel.channel_id` を提示し、ユーザー承認後だけ実反映する。
+
+```bash
+uv run yt-channel-settings push --apply
+```
 
 **逆方向（pull: YouTube → local）が必要な場合**:
 
@@ -433,24 +428,11 @@ uv run yt-channel-settings pull               # dry-run: 取り込み内容の�
 uv run yt-channel-settings pull --apply       # 実反映: meta.json と localizations.json を書き換え
 ```
 
-YouTube 側で手動編集した設定をローカルに取り込みたいときに使う。`--apply` 後は git diff で変更内容を必ず確認すること。
-
-**API 制約と運用上の注意**:
-
-- `--apply` 実行時は `brandingSettings` / `localizations` / `status` を **別々の `channels().update()` 呼び出し** として個別に発火する。YouTube Data API は `brandingSettings` を他の part と同時送信すると `branding_settings cannot be used with other parts` で 400 エラーを返すため (#230)。この分割は CLI 側で自動対応済みで、運用者が意識する必要はない。
-- `localizations` セクションを **完全に空** にして送信すると `Required` 400 エラーになる。`config/localizations.json` の `supported_languages` を全削除して全ローカライゼーションを消したい場合は、少なくとも `default_language` の 1 件はエントリを残して push すること（送信しなかったロケールは YouTube 側で自動削除される）。
-- `--no-localizations` を付けると localizations 関連の比較・送信をスキップする（branding と status だけを反映したいときに使う）。
-- 認可スコープは `youtube.force-ssl` が必要。`auth/token.json` が古い OAuth scope のままだと 403 になるので、その場合は `auth/token.json` を削除して再認証する。
+pull は YouTube 側の手動編集を取り込む場合だけ使い、`--apply` 後は `git diff` で確認する。API 契約として、`brandingSettings` / `localizations` / `status` は別々の `channels().update()` で送り、`branding_settings cannot be used with other parts` を避ける。空の `localizations` は `Required` 400 になる。`--no-localizations` は localization を対象外にする。認可には `youtube.force-ssl` が必要で、古い `auth/token.json` の scope 不足時は再認証する。
 
 ## 障害時ガイダンス
 
-| 状況 | 兆候 | 対処 |
-|---|---|---|
-| `/setup` 未完了 | `auth/token.json` 不在、ADC 未設定、API 403 | `/setup` を先に完了する |
-| `gh` CLI 不在/未認証 | `command not found: gh` / `gh auth` エラー | `gh` を install し `gh auth login` を実行。remote 作成だけ保留して config 生成は継続可 |
-| YouTube quota / rate | HTTP 429 / 403 `quotaExceeded` | 日次 quota リセットを待つか、対象チャンネル数を絞る |
-| seed が誤チャンネル | `yt-channel-seed --no-write-benchmark --json` の表示が想定と違う | ユーザー確認で不採用にし、承認後の書き込みコマンドを実行しない |
-| branding push 失敗 | `yt-channel-settings push --apply` が 400/403 | dry-run 差分、OAuth scope、`meta.json::channel.channel_id` を確認する |
+詳細な兆候・対処は **[save-push-troubleshooting.md](references/save-push-troubleshooting.md)** を Read する。`/setup` 未完了は setup 完了まで停止し、`gh` 未認証は remote 作成だけ保留できる。quota / rate はリセット待ちまたは対象削減、誤チャンネルは不採用、branding push 失敗は dry-run 差分・OAuth scope・`meta.json::channel.channel_id` を確認し、原因解消まで書き込みを再実行しない。
 
 ## Cross References
 

--- a/.claude/skills/channel-new/references/save-push-troubleshooting.md
+++ b/.claude/skills/channel-new/references/save-push-troubleshooting.md
@@ -1,0 +1,51 @@
+# Save, settings push, and troubleshooting details
+
+新規開設モード Step 10 の初回保存、設定 push モード、障害対応の実施詳細を定義する。mode routing、不可逆操作前の承認、実行コマンドと順序、完了・停止条件、成果物は `../SKILL.md` を正とする。
+
+## Initial save and cleanup details
+
+`/channel-new` 完了直後は `/setup` と本スキルの生成物が未コミットで残りやすい。後続 `/automation-update` は dirty worktree で停止するため、最初と最後の `git status --porcelain` で cleanup 状態を判定する。
+
+- 最初の出力が空なら、初回保存済みとして成功案内へ進む。
+- 非空なら差分をユーザーへ提示し、root の順序どおり全変更を stage、一覧確認、secret guard、commit、最終確認する。
+- ignore 済み `.env` は exclude pathspec 付き `git add` でも exit 1 になり得るため、`git add -A` 後の `initial_save_guard.sh` を唯一の安全境界とする。
+- guard が失敗したら secret-like file は staged から自動で外れる。commit せず、`.gitignore` を確認してから再実行する。
+
+remote 作成保留、git user identity 未設定、またはユーザーが今 commit しない判断をした場合は、次の案内を提示して保存未完了として停止する。
+
+```text
+未コミット変更が残っています。/automation-update の前に以下を完了してください:
+  1. git status --short で差分を確認
+  2. .env / auth/client_secrets.json / auth/token*.json が staged されていないことを確認
+  3. git commit -m "chore: 初回チャンネル設定を保存"
+```
+
+作業ツリーが最初から clean、または初回 commit 後の `git status --porcelain` が空の場合だけ、root の成功案内を提示する。
+
+## Settings push details
+
+設定 push はローカルの次の値を認証済み YouTube チャンネルへ同期する。
+
+- `config/channel/meta.json::youtube_channel`: description / keywords / country / default language / unsubscribed trailer / made for kids
+- `config/localizations.json`: 対応言語ごとの title / description
+
+push 方向では root の順序どおり、読み取り専用 diff、push dry-run、ユーザー承認、`--apply` を実行する。dry-run は `channels().update()` を呼ばない。認証済みチャンネル ID と `meta.json::channel.channel_id` の一致を確認し、差分と対象 part をユーザーが承認するまで apply しない。
+
+YouTube 側の手動編集を local へ取り込む場合だけ pull を使う。pull dry-run で変更を確認し、承認後に `pull --apply` で `meta.json` と `config/localizations.json` を更新する。apply 後は `git diff` で保存内容を確認する。
+
+## Settings API constraints
+
+- apply は `brandingSettings` / `localizations` / `status` を別々の `channels().update()` として送る。`brandingSettings` と他 part の同時送信は `branding_settings cannot be used with other parts` の 400 になる。
+- localizations を完全に空で送ると `Required` 400 になる。全ローカライゼーションを削除する場合も default language の 1 件を残し、送信しなかったロケールを YouTube 側で削除させる。
+- `--no-localizations` は localizations の比較と送信をスキップし、branding と status だけを対象にする。
+- apply には `youtube.force-ssl` scope が必要。古い `auth/token.json` で scope が不足する場合は token を削除して再認証する。
+
+## Troubleshooting details
+
+| 状況 | 兆候 | 対処 |
+|---|---|---|
+| `/setup` 未完了 | `auth/token.json` 不在、ADC 未設定、API 403 | `/setup` を完了するまで停止する。 |
+| `gh` CLI 不在 / 未認証 | `command not found: gh`、`gh auth` エラー | `gh` を install して `gh auth login` を実行する。remote 作成だけ保留し、config 生成は継続できる。 |
+| YouTube quota / rate | HTTP 429、403 `quotaExceeded` | 日次 quota リセットを待つか対象チャンネル数を絞る。書き込みへ進まない。 |
+| seed が誤チャンネル | seed preview が想定と異なる | ユーザー確認で不採用にし、承認後コマンドを実行しない。 |
+| branding push 失敗 | push apply が 400 / 403 | dry-run 差分、OAuth scope、`meta.json::channel.channel_id` を確認し、原因解消まで再 apply しない。 |

--- a/tests/repo/test_channel_new_disclosure_contract.py
+++ b/tests/repo/test_channel_new_disclosure_contract.py
@@ -11,6 +11,7 @@ SKILL_MD = SKILL_DIR / "SKILL.md"
 BOOTSTRAP_REFERENCE_MD = SKILL_DIR / "references" / "new-channel-bootstrap.md"
 TTP_SEED_DURATION_REFERENCE_MD = SKILL_DIR / "references" / "ttp-seed-and-duration.md"
 PERSONA_BRANDING_READINESS_REFERENCE_MD = SKILL_DIR / "references" / "persona-branding-readiness.md"
+SAVE_PUSH_TROUBLESHOOTING_REFERENCE_MD = SKILL_DIR / "references" / "save-push-troubleshooting.md"
 
 BOOTSTRAP_DETAIL_HEADINGS = {
     "Repository initialization details",
@@ -30,6 +31,12 @@ PERSONA_BRANDING_READINESS_DETAIL_HEADINGS = {
     "Prelaunch persona chain details",
     "Branding generation and review details",
     "Readiness matrix details",
+}
+SAVE_PUSH_TROUBLESHOOTING_DETAIL_HEADINGS = {
+    "Initial save and cleanup details",
+    "Settings push details",
+    "Settings API constraints",
+    "Troubleshooting details",
 }
 
 
@@ -256,5 +263,71 @@ def test_skill_keeps_persona_branding_readiness_artifacts_and_stop_contracts() -
         "ttp_wf_new_readiness",
         "成功案内を出さない",
         "Step 1/5 に戻って候補を再確認",
+    ):
+        assert contract in skill
+
+
+def test_skill_dispatches_save_push_troubleshooting_reference_in_both_paths() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = SAVE_PUSH_TROUBLESHOOTING_REFERENCE_MD.relative_to(SKILL_DIR).as_posix()
+
+    step_10 = skill.index("### Step 10:")
+    new_channel_dispatch = skill.index(f"]({relative_reference})", step_10)
+    first_save_check = skill.index("git status --porcelain", new_channel_dispatch)
+    settings_mode = skill.index("## 設定 push モード")
+    settings_dispatch = skill.index(f"]({relative_reference})", settings_mode)
+    settings_diff = skill.index("uv run yt-channel-settings diff", settings_dispatch)
+
+    assert SAVE_PUSH_TROUBLESHOOTING_REFERENCE_MD.is_file()
+    assert step_10 < new_channel_dispatch < first_save_check
+    assert settings_mode < settings_dispatch < settings_diff
+
+
+def test_save_push_troubleshooting_detail_sections_have_one_reference_owner() -> None:
+    skill_headings = _headings(SKILL_MD.read_text(encoding="utf-8"))
+    reference_headings = _headings(SAVE_PUSH_TROUBLESHOOTING_REFERENCE_MD.read_text(encoding="utf-8"))
+
+    assert SAVE_PUSH_TROUBLESHOOTING_DETAIL_HEADINGS <= reference_headings
+    assert SAVE_PUSH_TROUBLESHOOTING_DETAIL_HEADINGS.isdisjoint(skill_headings)
+
+
+def test_initial_save_cleanup_keeps_guarded_mutation_order() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    step_10 = skill.index("### Step 10:")
+
+    porcelain_before = skill.index("git status --porcelain", step_10)
+    git_add = skill.index("git add -A", porcelain_before)
+    staged_review = skill.index("git diff --cached --name-only", git_add)
+    secret_guard = skill.index("initial_save_guard.sh || exit 1", staged_review)
+    commit = skill.index('git commit -m "chore: 初回チャンネル設定を保存"', secret_guard)
+    porcelain_after = skill.index("git status --porcelain", commit)
+
+    assert porcelain_before < git_add < staged_review < secret_guard < commit < porcelain_after
+
+
+def test_settings_push_requires_review_and_approval_before_apply() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    settings_mode = skill.index("## 設定 push モード")
+
+    diff = skill.index("uv run yt-channel-settings diff", settings_mode)
+    dry_run = skill.index("uv run yt-channel-settings push", diff)
+    approval = skill.index("ユーザー承認", dry_run)
+    apply = skill.index("uv run yt-channel-settings push --apply", approval)
+
+    assert settings_mode < diff < dry_run < approval < apply
+
+
+def test_skill_keeps_save_push_artifacts_and_failure_stop_contracts() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+
+    for contract in (
+        "config/channel/meta.json",
+        "config/localizations.json",
+        "auth/token.json",
+        "secret-like file staged; unstaged before commit",
+        "保存未完了として",
+        "成功案内は出さない",
+        "branding_settings cannot be used with other parts",
+        "youtube.force-ssl",
     ):
         assert contract in skill


### PR DESCRIPTION
## Summary

- initial save、settings push、troubleshooting の詳細を専用 reference へ分離
- root skill の両 route、guard、review→approval→apply、failure-stop 契約を維持
- dispatch / ownership / order / failure contract をテストで固定

## Verification

- disclosure contract: 20 passed（RED: 3 failed / 17 passed）
- related suites: 125 + 119 + 21 passed
- wheel sync: 1 passed
- skill lint / ruff / diff-check: green

Closes #3508