### PR TITLE
fix(suno-helper): 楽曲選択の太い ring を撤去する (#2564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: Lyrics 欄が見つからない場合の診断に、Advanced → More options → Lyrics mode → Write の具体的な所在と、`[Instrumental]` を含む非空 lyrics は Lyrics 欄へ注入するため Write が必要になる理由を表示する（#3468）。
 - `fix(suno-helper)`: 完全自動生成後の FINISHED snapshot から clip ID と期待件数を復元して Download 再開へ引き継ぐ回帰テストを追加し、clip ID が無い場合は効果のないページ再読み込みではなく、Suno 上で対象曲を選択して「選択中の曲を採用」後に再試行する手順を案内するよう修正した（#3071）。
 - `fix(collection-serve)`: `--allow-extension` の unpacked 拡張検出で、path basename が `chrome-mv3` でも Chrome Preferences entry の embedded `manifest.name` が requested helper 名と一致する WXT build output を候補に含める。従来の exact basename を優先して維持し、manifest 欠落・不正 shape・別 helper は候補にしない（#3227）。
+- `fix(suno-helper)`: 楽曲リストの選択状態に重ねていた太い ring を撤去し、状態色とチェックボックスを維持したままコレクション一覧と枠線の太さを揃えた（#2564）。
 - `fix(tests)`: pnpm Worker 契約テストの実行対象を `extensions/suno-helper` から依存ゼロの一時 project へ変更し、`node_modules` が無い環境で 494 パッケージ / 318MB の実インストールが検証前に走る構造を解消した。takt worker ではこの install が `SIGKILL` されて全体 pytest のベースラインが red になり、後続 issue が着手できなくなっていた。検証している契約は `PNPM_MAX_WORKERS` が pnpm のプロセス境界を越えることだけで、対象 project の依存構成は含まれない。あわせて stdout 末尾行に依存した assertion を、検証値へラベルを付けて行集合を検査する方式へ置き換えた。pnpm は依存ゼロでも `Already up to date` を出力し、その位置が 2 つの検証値の間に入るため位置依存の判定が成立しない（#3082）。
 - `fix(extensions)`: pnpm の tarball Worker 既定値を 1 に抑制し、macOS・Node 24 で発生する libuv abort による Fallow audit の偽 red を回避した（#3078）。
 - `fix(wf-auto)`: lease token を `-` を含まない hexadecimal 形式で生成し、`argparse` が `--token` の値をオプションと誤認する確率的な CLI 失敗を解消した（#2575）。

--- a/extensions/suno-helper/components/PatternList.tsx
+++ b/extensions/suno-helper/components/PatternList.tsx
@@ -35,11 +35,6 @@ const STATE_CLASS: Record<ItemState, string> = {
     "border-destructive-border bg-destructive-background font-medium text-destructive-foreground",
 };
 
-const SELECTION_CLASS: Record<"selected" | "unselected", string> = {
-  selected: "ring-2 ring-current/20",
-  unselected: "shadow-none",
-};
-
 export function PatternList({
   entries,
   itemStates,
@@ -98,7 +93,7 @@ export function PatternList({
                       className={buttonVariants({
                         variant: "outline",
                         size: "sm",
-                        className: `h-auto w-full items-start justify-start whitespace-normal p-2 font-normal ${STATE_CLASS[itemState]} ${SELECTION_CLASS[selected ? "selected" : "unselected"]}`,
+                        className: `h-auto w-full items-start justify-start whitespace-normal p-2 font-normal ${STATE_CLASS[itemState]}`,
                       })}
                     >
                       <Checkbox

--- a/extensions/suno-helper/tests/pattern-list.test.ts
+++ b/extensions/suno-helper/tests/pattern-list.test.ts
@@ -180,9 +180,19 @@ describe("PatternList checkbox UI", () => {
       for (const token of stateTokens[states[index]!]!) {
         expect(control.className).toContain(token);
       }
-      expect(control.className).toContain(selected ? "ring-2" : "shadow-none");
+      expect(control.className).not.toContain("ring-2");
+      expect(control.className).not.toContain("ring-current");
       expect(control.className).not.toContain("text-primary-foreground");
     });
+    for (let index = 0; index < rows.length; index += 2) {
+      const unselectedControl = rows[index]!.querySelector<HTMLElement>(
+        '[data-slot="field-label"]'
+      )!;
+      const selectedControl = rows[index + 1]!.querySelector<HTMLElement>(
+        '[data-slot="field-label"]'
+      )!;
+      expect(selectedControl.className).toBe(unselectedControl.className);
+    }
   });
 
   it("各 entry の selection を shadcn variant と semantic token に反映する", () => {
@@ -281,9 +291,8 @@ describe("PatternList checkbox UI", () => {
       for (const token of stateTokens[index]!) {
         expect(control.className).toContain(token);
       }
-      expect(control.className).toContain(
-        [true, false, true, false, true][index] ? "ring-2" : "shadow-none"
-      );
+      expect(control.className).not.toContain("ring-2");
+      expect(control.className).not.toContain("ring-current");
       expect(control.className).toContain("p-2");
       expect(control.className).not.toContain("p-0");
     });


### PR DESCRIPTION
## 概要

楽曲リストの選択状態だけに付いていた太い ring を撤去し、コレクション項目と同じ1px枠線に揃えます。

Closes #2564

## 変更内容

- `SELECTION_CLASS` と `ring-2 ring-current/20` を撤去
- checkbox / `data-suno-entry-selected` と5状態のsemantic classを維持
- 選択/未選択の同一state class parityを回帰テスト化
- CHANGELOGへ利用者向け修正を記録

## 検証

- TDD RED 2 → focused 9 / full unit 1341 green
- check / compile / build / Fallow / diff-check green
- E2E 13/15。変更前段のWXT popup/overlay起動で2件失敗し、PatternListへ未到達
- auditの既存 brace-expansion advisoryは本変更非因果