### PR TITLE
[collection-ideate-cli-help] post-disclosure の CLI help ownership を一元化する

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -278,7 +278,7 @@ mkdir -p collections/planning/_plan-previews/${PREVIEW_DIR}
 
 **4-4: プロンプト構築 + 一括生成（parallel デフォルト）**
 
-`parallel` の場合だけ実行する。`REF_PATHS` を構築してからproviderに応じた経路で `candidate_count` 枚を順次生成する。候補数ぶんの参照が無い場合は参照不足なら生成せず停止する。
+`parallel` の場合だけ実行する。`REF_PATHS` を構築してからproviderに応じた経路で `candidate_count` 枚を順次生成する。候補数ぶんの参照が無い場合は参照不足なら生成せず停止する。通常 flag の意味・既定値は `uv run yt-generate-image --help` を正とする。
 
 ```bash
 # <dir> は 4-3 で作成したセッション固有ディレクトリ名（例: 20260306-a3f1）

--- a/.claude/skills/collection-ideate/references/preview-generation.md
+++ b/.claude/skills/collection-ideate/references/preview-generation.md
@@ -1,15 +1,15 @@
 # Preview generation
 
-Phase 4 の parallel / sequential preview について、prompt 構築、provider 呼び出し、生成物、検証、retry、failure handling の詳細を定義する。mode 判定、コスト承認、セッション作成、実行コマンド、停止条件の順序は `../SKILL.md` を正とする。候補内容とセルフチェック設定は `preview-contract.md` に従う。
+Phase 4 の parallel / sequential preview について、prompt 構築、provider 呼び出し、生成物、検証、retry、failure handling の詳細を定義する。mode 判定、コスト承認、セッション作成、代表的な実行コマンド、停止条件の順序は `../SKILL.md` を正とする。`yt-generate-image` の通常 flag は CLI help を正とし、ここでは再定義しない。候補内容とセルフチェック設定は `preview-contract.md` に従う。
 
 ## Parallel 生成詳細
 
-preview contract の候補 schema で確定した prompt を使い、`candidate_count` 件を a / b / c ... の順に生成する。候補ごとに `select-ttp-references.py` が返した別々の benchmark 参照画像を1枚だけ割り当てる。TTP strict preview に stock を混ぜない。
+preview contract の候補 schema で確定した prompt を使い、`candidate_count` 件を a / b / c ... の順に生成する。候補ごとに `select-ttp-references.py` が返した別々の benchmark 参照画像を1枚だけ割り当てる。TTP strict preview は一意な benchmark 参照だけを使い、stock を混ぜない。
 
 - Codex provider は `image_generation.codex.default_prompt_template` と `thumbnail/references/codex-prompt.py` を使う。title 引数には画像へ焼く見出しと短いサブタイトルだけを渡し、動画タイトル全文、composition rule、legend、楽器を重複注入しない。候補数ぶんの一意な参照画像が無ければ生成前に停止する。
-- Gemini / OpenAI provider は候補の確定済み prompt を `yt-generate-image --ttp-strict-references --reference ... --max-attempts 1` へ渡す。provider 内部の追加 retry は行わない。
+- Gemini / OpenAI provider は候補の確定済み prompt と一意な参照割当をSKILL本体の代表コマンドへ渡す。provider 内部の追加 retry は行わない。
 - 1候補の生成が non-zero でも、残り候補は順番どおり試行する。成功候補は比較対象へ残し、失敗候補は画像無しのテキスト候補として扱う。
-- 出力は `collections/planning/_plan-previews/<dir>/plan-<label>-<slug>.png` とする。`-y` 経路で同名が存在する場合は上書きせず `-v2`, `-v3` ... を使う。
+- 出力は `collections/planning/_plan-previews/<dir>/plan-<label>-<slug>.png` とする。
 
 成功画像は一度に開き、同じ候補順で画像、タイトル、prompt、オブジェクトの名前とストーリーを提示する。個別画像の再生成は同じ候補と参照割当でその候補の4-4 commandだけを再実行する。企画自体を変える場合は Phase 3 へ戻る。
 

--- a/tests/repo/test_collection_ideate_cli_help_ownership_contract.py
+++ b/tests/repo/test_collection_ideate_cli_help_ownership_contract.py
@@ -1,0 +1,70 @@
+"""collection-ideate skill と yt-generate-image help の ownership 境界。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "collection-ideate"
+SKILL_TEXT = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+GENERATION_TEXT = (SKILL_DIR / "references" / "preview-generation.md").read_text(encoding="utf-8")
+
+
+def _generate_image_invocations(markdown: str) -> list[str]:
+    return re.findall(r"^\s*uv run yt-generate-image(?:\s|$)", markdown, flags=re.MULTILINE)
+
+
+def test_skill_keeps_mode_commands_and_delegates_flag_help() -> None:
+    skill_invocations = _generate_image_invocations(SKILL_TEXT)
+    reference_invocations = _generate_image_invocations(GENERATION_TEXT)
+
+    assert len(skill_invocations) == 2
+    assert reference_invocations == []
+    assert "`uv run yt-generate-image --help`" in SKILL_TEXT
+
+
+def test_skill_prose_does_not_redefine_normal_generate_image_flags() -> None:
+    distributed_text = f"{SKILL_TEXT}\n{GENERATION_TEXT}"
+    prose = re.sub(r"```.*?```", "", distributed_text, flags=re.DOTALL)
+
+    for option in ("prompt", "output", "model", "reference-index", "max-attempts", "yes"):
+        assert re.search(rf"--{option}\b", prose) is None
+
+
+def test_skill_keeps_mode_dispatch_and_generation_order() -> None:
+    phase_4 = SKILL_TEXT.index("### Phase 4:")
+    mode_dispatch = SKILL_TEXT.index("`preview.thumbnail_mode`", phase_4)
+    cost_approval = SKILL_TEXT.index("confirm_cost", mode_dispatch)
+    session_creation = SKILL_TEXT.index("mkdir -p", cost_approval)
+    generation_dispatch = SKILL_TEXT.index("](references/preview-generation.md)", session_creation)
+    parallel_command = SKILL_TEXT.index("uv run yt-generate-image", generation_dispatch)
+    validation = SKILL_TEXT.index("yt-thumbnail-check", parallel_command)
+    sequential = SKILL_TEXT.index("### Phase 4 補足: sequential", validation)
+    sequential_command = SKILL_TEXT.index("uv run yt-generate-image", sequential)
+
+    assert mode_dispatch < cost_approval < session_creation < generation_dispatch
+    assert generation_dispatch < parallel_command < validation < sequential < sequential_command
+
+
+def test_generation_reference_keeps_strict_references_and_failure_contracts() -> None:
+    strict_reference_paragraph = next(
+        paragraph for paragraph in GENERATION_TEXT.split("\n\n") if "TTP strict" in paragraph and "一意" in paragraph
+    )
+
+    assert "stock" in strict_reference_paragraph
+    assert "生成前に停止" in GENERATION_TEXT
+    assert "exit 0" in GENERATION_TEXT
+    assert "exit 1" in GENERATION_TEXT
+    assert "不合格候補だけを再生成" in GENERATION_TEXT
+    assert "同じ4-4" in GENERATION_TEXT
+
+
+def test_skill_keeps_output_and_cleanup_order() -> None:
+    next_step = SKILL_TEXT.index("## Next Step")
+    assignment = SKILL_TEXT.index("record-ttp-reference-assignments.py", next_step)
+    adopted_copy = SKILL_TEXT.index("cp collections/planning/_plan-previews", assignment)
+    stock_archive = SKILL_TEXT.index("uv run yt-stock-archive", adopted_copy)
+    cleanup = SKILL_TEXT.index("rm -rf collections/planning/_plan-previews", stock_archive)
+
+    assert assignment < adopted_copy < stock_archive < cleanup


### PR DESCRIPTION
## Summary

- collection-ideate の反復 CLI flag 説明を command help の所有へ一元化
- skill 固有の実行順・安全契約を保持し、ownership regression を追加

Closes #3517