### PR TITLE
[videoup-cli-help] batch video help を自己完結させる

### DIFF
--- a/src/youtube_automation/commands/media/generate_videos_batch.py
+++ b/src/youtube_automation/commands/media/generate_videos_batch.py
@@ -216,9 +216,27 @@ def _script_path(root: Path) -> Path:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="マスター済み・未動画化の collection を並列動画化")
-    parser.add_argument("--include-live", action="store_true", help="collections/live/ も検出対象に含める")
-    parser.add_argument("--max-workers", type=int, help="最大並列数")
+    parser = argparse.ArgumentParser(
+        description=(
+            "assets.master_audio が設定済みかつ assets.master_video: null の collection を並列動画化。"
+            "既定では collections/planning/ のみを対象にし、--include-live で collections/live/ も含める。"
+            "成功した collection のみ assets.master_video を更新し、部分失敗は non-zero で終了"
+        )
+    )
+    parser.add_argument(
+        "--include-live",
+        action="store_true",
+        help="既定の collections/planning/ に加えて collections/live/ も検出対象に含める",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        help=(
+            "最大並列数（1 以上）。未指定時は CLI > YT_VIDEOUP_MAX_WORKERS > channel skill-config > "
+            "CPU 検出 > 3 の優先順で解決。channel skill-config は "
+            "config/skills/videoup.yaml::batch.max_workers"
+        ),
+    )
     args = parser.parse_args()
 
     root = Path(channel_dir()).resolve()

--- a/tests/commands/media/test_generate_videos_batch.py
+++ b/tests/commands/media/test_generate_videos_batch.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+import sys
 import threading
 import time
 from pathlib import Path
@@ -10,6 +12,51 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.media import generate_videos_batch as batch
 from youtube_automation.core.errors import ConfigError
+
+
+def _help_text(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> str:
+    monkeypatch.setattr(sys, "argv", ["yt-generate-videos-batch", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        batch.main()
+
+    assert exc_info.value.code == 0
+    return " ".join(capsys.readouterr().out.split())
+
+
+def test_help_explains_default_stage_and_batch_target(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "既定では collections/planning/ のみ" in help_text
+    assert "--include-live で collections/live/ も含める" in help_text
+    assert "assets.master_audio が設定済み" in help_text
+    assert "assets.master_video: null" in help_text
+
+
+def test_help_explains_max_workers_resolution_without_false_choices(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "1 以上" in help_text
+    assert "CLI > YT_VIDEOUP_MAX_WORKERS > channel skill-config > CPU 検出 > 3" in help_text
+    assert "config/skills/videoup.yaml::batch.max_workers" in help_text
+    assert re.search(r"--max-workers MAX_WORKERS\b", help_text)
+    assert "--max-workers {" not in help_text
+
+
+def test_help_explains_success_state_update_and_partial_failure_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    help_text = _help_text(monkeypatch, capsys)
+
+    assert "成功した collection のみ assets.master_video を更新" in help_text
+    assert "部分失敗は non-zero" in help_text
 
 
 def _collection(root: Path, stage: str, slug: str, *, audio: object, video: object) -> Path:


### PR DESCRIPTION
## Summary

- batch video CLI help に対象 stage・state 条件と並列度解決を明記
- 成功時更新と部分失敗の契約を help 単独で確認可能にし、runtime behavior は不変

Closes #3520