### PR TITLE
[videoup-cli-help] generate_videos.sh help を自己完結させる

### DIFF
--- a/.claude/skills/videoup/references/generate_videos.sh
+++ b/.claude/skills/videoup/references/generate_videos.sh
@@ -80,7 +80,21 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --help|-h)
-            echo "Usage: $0 [--preview [15-30]] [--overlays|--no-overlays] [collection-path]"
+            cat <<EOF
+Usage: $0 [--preview [15-30]] [--overlays|--no-overlays] [collection-path]
+
+collection-path:
+  対象 collection のパス。collection-path 省略時は現在の作業ディレクトリ (CWD) を使う。
+  CWD には 01-master/ と 10-assets/ が必要。
+
+Options:
+  --preview [15-30]  15〜30 秒の preview を生成。秒数省略時 20 秒。
+                     preview は full output を作成・置換しない。また workflow-state.json を更新しない。
+  --overlays         overlay を有効化。config の値をこの実行だけ上書きし、config 自体は変更しない。
+  --no-overlays      overlay を無効化。config の値をこの実行だけ上書きし、config 自体は変更しない。
+                     VIDEOUP_OVERLAYS が設定されている場合は環境変数を優先。
+  -h, --help         この help を表示して終了。
+EOF
             exit 0
             ;;
         --*)

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -18,6 +18,38 @@ _SCRIPT_PATH = _REPO_ROOT / ".claude" / "skills" / "videoup" / "references" / "g
 _VIDEOUP_SKILL_PATH = _REPO_ROOT / ".claude" / "skills" / "videoup" / "SKILL.md"
 
 
+def _help_text() -> str:
+    result = subprocess.run(
+        ["/bin/bash", str(_SCRIPT_PATH), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    return " ".join(result.stdout.split())
+
+
+def test_help_explains_collection_and_preview_contract() -> None:
+    help_text = _help_text()
+
+    assert "collection-path 省略時は現在の作業ディレクトリ (CWD)" in help_text
+    assert "--preview [15-30]" in help_text
+    assert "省略時 20 秒" in help_text
+    assert "full output を作成・置換しない" in help_text
+    assert "workflow-state.json を更新しない" in help_text
+
+
+def test_help_explains_overlay_overrides_are_invocation_scoped() -> None:
+    help_text = _help_text()
+
+    assert "--overlays" in help_text
+    assert "overlay を有効化" in help_text
+    assert "--no-overlays" in help_text
+    assert "overlay を無効化" in help_text
+    assert "config の値をこの実行だけ上書き" in help_text
+
+
 def _write_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(0o755)


### PR DESCRIPTION
## Summary

- generate_videos.sh help に CWD、preview 範囲・既定・安全性を明記
- overlay override の契約を自己完結させ、生成・fail-fast behavior は不変

Closes #3521