### PR TITLE
[videoup-cli-help] SKILL の CLI help ownership を一元化する

### DIFF
--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -62,11 +62,10 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 |---------|------|
 | `yt-generate-master` | CWD のコレクションでマスター音源生成 |
 | `yt-generate-master <path>` | 指定コレクションでマスター音源生成 |
-| `yt-generate-videos-batch` | `collections/planning/` の `assets.master_audio` 設定済みかつ `assets.master_video: null` のコレクションを並列動画化 |
-| `yt-generate-videos-batch --include-live` | 上記に `collections/live/` も含めて並列動画化 |
-| `uv run bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh"` | CWD のコレクションで全動画生成（コレクションディレクトリ内で実行） |
-| `uv run bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" <path>` | 指定コレクションで全動画生成 |
-| `uv run bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" --preview 20 <path>` | effect / overlay を反映した 15〜30 秒の確認用サンプルを生成（既定 20 秒） |
+| `yt-generate-videos-batch` | マスター音源確定済み・未動画化のコレクションを並列動画化 |
+| `uv run bash "$(git rev-parse --show-toplevel)/.claude/skills/videoup/references/generate_videos.sh" <collection-path>` | 1 コレクションの動画を生成 |
+
+対象 stage・並列度・通常 option は `yt-generate-videos-batch --help`、collection path・preview・overlay option は `generate_videos.sh --help` を正とする。
 
 ## Instructions
 
@@ -78,7 +77,7 @@ $ARGUMENTS
 
 引数が指定されている場合、そのコレクションを対象とします。
 未指定の場合、`collections/planning/` から `assets.master_audio` が設定済み（`null` 以外）かつ `assets.master_video` が `null` のコレクションを自動検出します。
-複数件を一括処理する場合は `yt-generate-videos-batch` を使います。並列度は `--max-workers` > `YT_VIDEOUP_MAX_WORKERS` > `config/skills/videoup.yaml::batch.max_workers` > CPU 自動検出 > 既定値 3 の順で解決されます。
+複数件を一括処理する場合は `yt-generate-videos-batch` を使います。通常 option と解決契約は同 CLI の `--help` に従います。
 
 ### ステップ
 
@@ -202,7 +201,7 @@ effect:
 
 `config/channel/youtube.json::overlays` で audio visualizer + subscribe popup の合成を有効化できる。`overlays.enabled: true` のときだけ `generate_videos.sh` は **x264 再エンコード経路** に分岐し、`filter_complex` で背景の上に visualizer / popup を重ねる。`overlays.enabled: false`（既定）または `overlays` キー欠落時は、ループ動画または静止画の短尺ベイクを使う **stream copy 経路**を維持する。
 
-一回だけ切り替える場合は `VIDEOUP_OVERLAYS=0|1` または `--no-overlays|--overlays` を使う。解決順は env > CLI > `config/channel/youtube.json` > default。例: `VIDEOUP_OVERLAYS=0 uv run bash .../generate_videos.sh <path>`。設定ファイルを一時編集しない。
+overlay 合成は動画生成工程だけが担当し、Suno / Lyria / masterup では適用しない。一回限りの切替入口と config に対する override 契約は `generate_videos.sh --help` を正とし、設定ファイルを一時編集しない。
 
 runtime mask helper は script 内から `uv run python -m youtube_automation.infrastructure.media.audio_visualizer_mask` で起動する。script 自体も `uv run bash` で実行し、system Python に package が無い環境でも venv の依存を使う。
 

--- a/tests/repo/test_videoup_cli_help_ownership_contract.py
+++ b/tests/repo/test_videoup_cli_help_ownership_contract.py
@@ -1,0 +1,63 @@
+"""videoup skill と CLI / script help の ownership 境界。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_TEXT = (REPO_ROOT / ".claude" / "skills" / "videoup" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _section(start: str, end: str) -> str:
+    start_index = SKILL_TEXT.index(start)
+    end_index = SKILL_TEXT.index(end, start_index)
+    return SKILL_TEXT[start_index:end_index]
+
+
+def _quick_reference_commands() -> list[str]:
+    quick_reference = _section("## Quick Reference", "## Instructions")
+    return re.findall(r"^\| `([^`]+)` \|", quick_reference, flags=re.MULTILINE)
+
+
+def test_skill_keeps_one_representative_command_per_video_entrypoint() -> None:
+    commands = _quick_reference_commands()
+
+    assert sum(command.startswith("yt-generate-videos-batch") for command in commands) == 1
+    assert sum("generate_videos.sh" in command for command in commands) == 1
+    assert "`yt-generate-videos-batch --help`" in SKILL_TEXT
+    assert "`generate_videos.sh --help`" in SKILL_TEXT
+
+
+def test_skill_keeps_master_preview_approval_full_generation_and_state_order() -> None:
+    steps = _section("### ステップ", "### 自動検出される要素")
+
+    master = steps.index("2. **マスター音源**")
+    preview = steps.index("4. **プレビュー確認ゲート**", master)
+    approval = steps.index("5. **承認分岐**", preview)
+    full_generation = steps.index("6. **動画生成**", approval)
+    state_update = steps.index("7. **workflow-state.json 更新**", full_generation)
+
+    assert master < preview < approval < full_generation < state_update
+
+
+def test_skill_keeps_preview_and_state_safety_contracts() -> None:
+    steps = _section("### ステップ", "### 自動検出される要素")
+
+    assert "skip_preview_approval: false" in steps
+    assert "ユーザーが受理した場合のみ全尺生成" in steps
+    assert "プレビューファイルの存在を確認して承認だけを省略" in steps
+    assert "全尺生成の成功後だけ" in steps
+    assert "プレビューのみでは更新しない" in steps
+
+
+def test_skill_keeps_input_overlay_and_long_running_safety_contracts() -> None:
+    steps = _section("### ステップ", "### 自動検出される要素")
+    overlays = _section("## Overlays", "## 所要時間と完了報告")
+    completion = _section("## 所要時間と完了報告", "## オーディオビジュアライザー")
+
+    assert "固定名探索へ fallback せずエラー停止" in steps
+    assert "config/channel/youtube.json::overlays" in overlays
+    assert "generate_videos.sh" in overlays
+    assert "ログ末尾" in completion
+    assert "生成された `.mp4` のパス" in completion


### PR DESCRIPTION
## Summary

- videoup の command variants を代表入口へ整理
- 通常 option を CLI/script help の所有へ移し、orchestration と safety contract を保持

Closes #3522