### PR TITLE
[thumbnail-distributed-ref] prompt-schema の配布外 pointer を解消する

### DIFF
--- a/.claude/skills/thumbnail/references/prompt-schema.md
+++ b/.claude/skills/thumbnail/references/prompt-schema.md
@@ -1,10 +1,8 @@
 # imagegen Shared prompt schema bridge（試験導入）
 
 > 試験導入レイヤ。実本番のプロンプト構築フロー（`composition.py` / `scripts/generate_image.py`）
-> からは **未接続**。issue #654 で導入。本ファイルは差分レポート
-> （`docs/skill-design/thumbnail-codex-imagegen-diff-report.md`）の「提案 5: Shared
-> prompt schema の導入（差分 E）」に対応する。設計判断は
-> `docs/skill-design/ADR-001-thumbnail-prompt-schema.md` を参照。
+> からは **未接続**。issue #654 で導入した Shared prompt schema の bridge と、
+> 実本番接続を再評価する gate を本書だけで確認できるようにする。
 
 ## 14 項目スキーマと skill-config キーの対応マッピング
 
@@ -100,8 +98,8 @@ text = prompt_schema.render(schema)
 4. **legacy 撤去**: skill-config 全体の管理方法見直し epic と同期して
    `diff_prompt_template` を撤去。
 
-ステップ 2 以降は **skill-config 全体の責務分割・配布経路の見直し**
-（issue #654 §制約「トリガ条件」）が発火するまで着手しない。
+ステップ 2 以降は issue #654 の再評価 gate である
+**skill-config 全体の責務分割・配布経路の見直し**が発火するまで着手しない。
 
 ## 既存独自機能との関係
 

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -38,6 +38,11 @@ def _read_thumbnail_quality_and_operations() -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_thumbnail_prompt_schema() -> str:
+    path = _repo_root() / ".claude" / "skills" / "thumbnail" / "references" / "prompt-schema.md"
+    return path.read_text(encoding="utf-8")
+
+
 def _read_loop_video_skill() -> str:
     path = _repo_root() / ".claude" / "skills" / "loop-video" / "SKILL.md"
     return path.read_text(encoding="utf-8")
@@ -912,6 +917,30 @@ def test_thumbnail_design_report_uses_current_two_phase_contract() -> None:
     assert "承認済み `thumbnail.jpg` から textless `main.png/jpg` を再生成" in two_phase_section
     assert "背景 → テキストオーバーレイ" not in two_phase_section
     assert "Phase 1 で背景（`main.png`）を生成" not in two_phase_section
+
+
+def test_thumbnail_prompt_schema_is_self_contained_experimental_contract() -> None:
+    prompt_schema = _read_thumbnail_prompt_schema()
+
+    for required in (
+        "試験導入",
+        "実本番のプロンプト構築フロー",
+        "**未接続**",
+        "issue #654",
+        "再評価",
+        "14 項目スキーマと skill-config キーの対応マッピング",
+        "`PromptSchema` dataclass（frozen）",
+        "`from_skill_config(skill_config: dict) -> PromptSchema`",
+        "`render(schema: PromptSchema) -> str`",
+        "段階移行パスと並存設計",
+        "opt-in フェーズ",
+        "default 切替",
+        "legacy 撤去",
+    ):
+        assert required in prompt_schema
+
+    assert "docs/skill-design/ADR-001-thumbnail-prompt-schema.md" not in prompt_schema
+    assert "docs/skill-design/thumbnail-codex-imagegen-diff-report.md" not in prompt_schema
 
 
 def test_thumbnail_default_config_keeps_font_stabilization_contract() -> None:

--- a/tests/repo/test_distributed_skill_references.py
+++ b/tests/repo/test_distributed_skill_references.py
@@ -49,14 +49,6 @@ _KNOWN_UNRESOLVED: frozenset[tuple[str, str]] = frozenset(
             ".claude/skills/automation-update/references/post-apply-checks.md",
             "docs/migration/numbered-duplicate-files-cleanup.md",
         ),
-        (
-            ".claude/skills/thumbnail/references/prompt-schema.md",
-            "docs/skill-design/ADR-001-thumbnail-prompt-schema.md",
-        ),
-        (
-            ".claude/skills/thumbnail/references/prompt-schema.md",
-            "docs/skill-design/thumbnail-codex-imagegen-diff-report.md",
-        ),
     }
 )
 


### PR DESCRIPTION
## Summary

- prompt-schema から wheel 非同梱 docs への2参照を除去
- 試験導入・本番未接続・#654 gate・14項目 mapping/API/段階移行を配布内で自己完結
- distributed/asset contract tests で境界を固定

Closes #3533