### PR TITLE
[site-release-notes] authoring と tag 契約を配布内で自己完結させる

### DIFF
--- a/.claude/skills/automation-release/references/release-notes-authoring.md
+++ b/.claude/skills/automation-release/references/release-notes-authoring.md
@@ -1,0 +1,63 @@
+# 公開リリースノート authoring 契約
+
+この reference は、release 完了後に `docs/release-notes/<tag>.md` を作るときの入力、公開内容、検証、pull request の契約を定める。この段では `/automation-release` の publish flow は接続しない。既存の version bump、tag push、GitHub Release 作成、extension asset 公開の動作は変更しない。
+
+## 入力の単一ソース
+
+最初に対象 tag を確定し、`git fetch origin --tags --prune` で tag history を取得する。対象 tag が `git rev-parse --verify "refs/tags/${TAG}"` で実在しなければ authoring を停止する。
+
+- Python 本体（`vX.Y.Z`）は、対象 version の `CHANGELOG.md` section を入力とする。`[Unreleased]` や別 version の section を混ぜない。
+- Chrome 拡張（`ext-vX.Y.Z`）は、同一 tag の GitHub Release body を入力とする。`gh release view "${TAG}" --json body --jq .body` で取得し、別 tag の release やローカル CHANGELOG で補完しない。
+
+入力から、設定変更、移行、導入・更新手順、利用可能になった機能、挙動変更、修正された不具合など、運営者への影響がある項目を全件保持する。近い項目の統合や利用者向け表現への翻訳はよいが、短文化を理由に項目を落とさない。
+
+## 出力 identity と frontmatter
+
+出力先は `docs/release-notes/<tag>.md` とし、filename / frontmatter `version` / GitHub Release link を同一 tag に揃える。GitHub Release link は `https://github.com/daiki-beppu/youtube-automation/releases/tag/<tag>` とする。
+
+frontmatter は `title` / `version` / `released_at` / `kind` / `summary` / `sidebar` の exact keys だけを持つ。`sidebar` の子は `order` だけとする。
+
+- `title`: 詳細ページと sidebar に表示するタイトル
+- `version`: filename と同じ tag
+- `released_at`: `YYYY-MM-DD` の公開日
+- `kind`: Python 本体は `main`、Chrome 拡張は `extension`
+- `summary`: 改行を含まない一覧用の要約
+- `sidebar.order`: 新しい公開日ほど先になる負数。同日では本体を拡張より先にする
+
+## 本文契約
+
+本文に level 1 heading は置かない。次の見出しをこの順序で置く。
+
+## 30 秒サマリー
+
+運営者が更新の規模、必要な作業、主要な影響を短時間で判断できるようにまとめる。
+
+## アップデート方法
+
+Python 本体は `/automation-update`、Chrome 拡張は `/ext-install` を単独の `text` code block で示す。必要な移行作業があれば省略しない。
+
+## 新機能
+
+入力に該当項目がない場合も見出しを残し、追加がないことを利用者向けに記す。
+
+## 改善
+
+運用、安全性、性能、使い勝手への影響が分かる表現にする。
+
+## 直った不具合
+
+症状と修正後の状態を運営者の視点で説明する。
+
+## 詳しい変更内容
+
+同一 tag の GitHub Release link を置く。必要なら「移行作業」や「今後のアップデート予定」を追加できるが、必須見出しの順序は変えない。
+
+内部実装・issue・PR 番号、内部関数・内部 package 名、特定 community 向けの記号や link は本文から除外する。実装の羅列を消すときも、その変更が運営者へ与える影響は消さない。
+
+## branch・preview・merge gate
+
+post-release の authoring は最新 `origin/main` から専用 branch を作り、変更を commit して pull request にする。main へ直接 push しない。
+
+pull request では site の check / build / test を実行し、Cloudflare Pages の preview で一覧、詳細ページ、link、見出し、mobile 表示を確認する。active main ruleset が要求する pull request、preview、required checks の `lint` / `test` をすべて通し、未通過のまま merge しない。
+
+この手順は公開ノートの authoring と review だけを扱う。GitHub Release や Cloudflare production への再 publish は行わない。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         run: echo "Extension-only change; Python tests are not applicable."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.changes.outputs.python == 'true'
+        with:
+          fetch-depth: 0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         if: needs.changes.outputs.python == 'true'
       - name: Cache uv

--- a/tests/repo/test_release_notes_contract.py
+++ b/tests/repo/test_release_notes_contract.py
@@ -1,0 +1,126 @@
+"""公開リリースノートの authoring・tag・CI 契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+ROOT = REPO_ROOT
+NOTES_DIR = ROOT / "docs" / "release-notes"
+AUTHORING_REFERENCE = ROOT / ".claude" / "skills" / "automation-release" / "references" / "release-notes-authoring.md"
+REQUIRED_FRONTMATTER_KEYS = {"title", "version", "released_at", "kind", "summary", "sidebar"}
+REQUIRED_HEADINGS = (
+    "## 30 秒サマリー",
+    "## アップデート方法",
+    "## 新機能",
+    "## 改善",
+    "## 直った不具合",
+    "## 詳しい変更内容",
+)
+RELEASE_URL_PREFIX = "https://github.com/daiki-beppu/youtube-automation/releases/tag/"
+
+
+def _read_note(path: Path) -> tuple[dict[str, object], str]:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path}: YAML frontmatter がありません"
+    _, frontmatter, body = text.split("---\n", 2)
+    metadata = yaml.safe_load(frontmatter)
+    assert isinstance(metadata, dict), f"{path}: frontmatter は mapping が必要です"
+    return metadata, body
+
+
+def _repository_tags() -> frozenset[str]:
+    result = subprocess.run(
+        ["git", "tag", "--list"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return frozenset(result.stdout.splitlines())
+
+
+def _validate_release_note(path: Path, repository_tags: frozenset[str]) -> None:
+    metadata, body = _read_note(path)
+    version = metadata.get("version")
+
+    assert set(metadata) == REQUIRED_FRONTMATTER_KEYS
+    assert isinstance(version, str) and version
+    assert isinstance(metadata["sidebar"], dict) and set(metadata["sidebar"]) == {"order"}
+    assert path.stem == version, f"{path}: filename と frontmatter version が一致しません"
+    assert version in repository_tags, f"{path}: version は実在する git tag が必要です: {version}"
+    release_tags = re.findall(rf"{re.escape(RELEASE_URL_PREFIX)}([^\s)]+)", body)
+    assert release_tags == [version], f"{path}: GitHub Release link は同一 tag を1件だけ指す必要があります"
+    assert not body.lstrip().startswith("# ")
+
+    heading_positions = [body.index(heading) for heading in REQUIRED_HEADINGS]
+    assert heading_positions == sorted(heading_positions), f"{path}: 必須見出しの順序が不正です"
+    assert all(body.count(heading) == 1 for heading in REQUIRED_HEADINGS)
+    assert not re.search(r"(?<!\w)#\d+", body), f"{path}: issue・PR 番号を本文へ出してはいけません"
+    assert "/pull/" not in body
+
+
+def test_release_notes_authoring_reference_is_self_contained() -> None:
+    reference = AUTHORING_REFERENCE.read_text(encoding="utf-8")
+
+    for required in (
+        "対象 version の `CHANGELOG.md` section",
+        "同一 tag の GitHub Release body",
+        "filename / frontmatter `version` / GitHub Release link",
+        "`title` / `version` / `released_at` / `kind` / `summary` / `sidebar`",
+        "運営者への影響がある項目を全件保持",
+        "内部実装・issue・PR 番号",
+        "専用 branch",
+        "pull request",
+        "preview",
+        "`lint` / `test`",
+        "main へ直接 push しない",
+        "publish flow は接続しない",
+    ):
+        assert required in reference
+
+    heading_positions = [reference.index(heading) for heading in REQUIRED_HEADINGS]
+    assert heading_positions == sorted(heading_positions)
+
+
+def test_existing_release_notes_match_real_tags_and_public_contract() -> None:
+    tags = _repository_tags()
+    notes = sorted(NOTES_DIR.glob("*.md"))
+
+    assert len(notes) == 4
+    for note in notes:
+        _validate_release_note(note, tags)
+
+
+def test_release_note_rejects_nonexistent_tag(tmp_path: Path) -> None:
+    version = "v999.999.999"
+    note = tmp_path / f"{version}.md"
+    note.write_text(
+        "---\n"
+        'title: "nonexistent release"\n'
+        f"version: {version}\n"
+        "released_at: 2099-01-01\n"
+        "kind: main\n"
+        'summary: "tag validation fixture"\n'
+        "sidebar:\n"
+        "  order: -2099010102\n"
+        "---\n\n" + "\n\n".join(REQUIRED_HEADINGS) + f"\n\n[GitHub Release]({RELEASE_URL_PREFIX}{version})\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError, match="実在する git tag"):
+        _validate_release_note(note, _repository_tags())
+
+
+def test_ci_python_test_checkout_fetches_full_tag_history() -> None:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
+    test_job = workflow["jobs"]["test"]
+    checkout = next(step for step in test_job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+
+    assert checkout["with"]["fetch-depth"] == 0


### PR DESCRIPTION
## Summary

- 公開 release note の入力・tag・frontmatter・本文・PR gate 契約を自己完結
- CI test job が全 tag 履歴を取得し、tag整合と不実在tag拒否を検証

Closes #3583