### PR TITLE
[site-release-notes] Python publish から post-release PR を作成する

### DIFF
--- a/.claude/skills/automation-release/SKILL.md
+++ b/.claude/skills/automation-release/SKILL.md
@@ -14,7 +14,7 @@ description: "Use when 本リポジトリの新規リリースを作成すると
 - 「前提」のいずれかが不成立なら、記載した復旧手順を案内して停止する。前提が満たされるまで後続Phaseへ進まない。
 - extension verify は repository root で `bash .claude/skills/automation-release/references/verify-extensions.sh [<name>]` を実行し、exit 0を必須とする。non-zeroならreleaseを停止する。
 - tag push前に tag名・対象commit SHA・対象版数を表示し、取消不能な外部反映操作であることを警告して `AskUserQuestion` の「実行 / 中止」2択で承認を得る。承認前にpushしない。
-- Python prepare完了 = version / CHANGELOG / uv.lockが同期したPRを作成済み。Python publish完了 = tagとGitHub Releaseを作成済み。
+- Python prepare完了 = version / CHANGELOG / uv.lockが同期したPRを作成済み。Python publish完了 = tagとGitHub Releaseを作成済み。post-release note の PR は別の完了状態として扱い、skip や PR pending を release publish の失敗へ巻き戻さない。
 - extension prepare完了 = package.jsonのversion差分だけを含むPRを作成し、verifyと差分ガードがPASS。extension publish完了 = merge commitへのtag、workflow成功、Releaseのzip asset 3件を確認済み。
 
 ## Overview
@@ -280,7 +280,68 @@ gh release edit "v${VER}" --notes "${section}
 ${auto}"
 ```
 
-#### 2-4. リリースブランチのクリーンアップ
+#### 2-4. 公開リリースノート案の生成と内容確認
+
+`gh release create` の成功を確認してから、canonical contract の `references/release-notes-authoring.md` を読み、対象 version の CHANGELOG section を公開向けに変換する。
+
+```bash
+TAG="v${VER}"
+NOTE_PATH="docs/release-notes/v${VER}.md"
+POST_RELEASE_BRANCH="docs/release-notes-v${VER}"
+
+section=$(awk -v ver="${VER}" '
+  $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+  /^## \\[/                  { flag = 0 }
+  flag
+' CHANGELOG.md)
+test -n "${section}" || { echo "ERROR: CHANGELOG.md に ${TAG} section がありません"; exit 1; }
+```
+
+`section` の運営者影響を全件保持し、`docs/release-notes/v${VER}.md` を作る。canonical reference の frontmatter、見出し順、同一 tag link、内部実装・issue・PR 番号の除外を満たすこと。既存ファイルがある場合は上書きせず停止し、差分を確認して再開方法をユーザーへ提示する。
+
+生成後、ファイル全文と `git diff -- "${NOTE_PATH}"` を確認し、生成内容・対象 tag・post-release branch・変更 path をユーザーへ提示する。期待する変更 path は `${NOTE_PATH}` だけとし、別 path の差分があれば承認へ進まず原因を解消する。
+
+#### 2-5. post-release PR の承認
+
+`AskUserQuestion` で「PR 作成 / 非承認 / skip」の選択を得る。承認前に commit / push / pull request 作成を行わない。main へ直接 push しない。
+
+- 内容修正を求められたら生成内容を修正して再提示し、同じ承認 gate に戻る。
+- 非承認 / skip ではノートを commit せず、GitHub Release publish は完了扱いとする。`references/release-notes-authoring.md` と `${NOTE_PATH}` を使う手動作成手順を報告し、Phase 2-7 の release branch cleanup へ進む。
+- 承認された場合だけ Phase 2-6 へ進む。
+
+#### 2-6. post-release 専用 branch と pull request
+
+既存 branch / PR を破壊・重複作成しないため、最初に local・remote・GitHub の状態を確認する。
+
+```bash
+if git show-ref --verify --quiet "refs/heads/${POST_RELEASE_BRANCH}" \
+  || git ls-remote --exit-code --heads origin "${POST_RELEASE_BRANCH}" >/dev/null 2>&1; then
+  echo "ERROR: 既存 post-release branch: ${POST_RELEASE_BRANCH}"
+  gh pr list --state all --head "${POST_RELEASE_BRANCH}" --json number,state,url
+  echo "既存 branch / pull request を削除・上書きせず、内容を照合して retry してください"
+else
+  git checkout -b "${POST_RELEASE_BRANCH}" origin/main
+fi
+```
+
+既存 post-release branch を検出した場合は自動処理を停止し、既存 pull request の URL または branch の照合・retry 手順を報告する。GitHub Release publish は完了したまま、Phase 2-7 の release branch cleanup は必ず続行する。
+
+新規 branch を作れた場合は `references/publish-checklist.md` の「post-release note の local gates」を記載順にそのまま実行する。non-zero なら commit / push せず、失敗した gate と retry 手順を報告する。
+
+全 gate が green の場合だけ commit、push、main 向け PR 作成へ進む。
+
+```bash
+git add "${NOTE_PATH}"
+git commit -m "docs(release-notes): ${TAG} の公開ノートを追加する"
+git push -u origin "${POST_RELEASE_BRANCH}"
+PR_URL=$(gh pr create --base main --head "${POST_RELEASE_BRANCH}" \
+  --title "docs(release-notes): ${TAG}" \
+  --body "${TAG} の公開リリースノート。Cloudflare Pages preview と required checks を確認後に merge する。")
+```
+
+pull request では Cloudflare Pages preview と branch protection の required checks の `lint` / `test` を通す。production site は PR merge 後に更新されるため、この時点では site は PR pending として報告する。
+
+#### 2-7. リリースブランチのクリーンアップ
 
 ```bash
 # リモート
@@ -292,14 +353,22 @@ git branch -D "release/v${VER}" 2>/dev/null || true
 
 PR マージ時に GitHub 側で自動削除されているケースもあるため、エラーは無視。
 
-#### 2-5. 次工程の案内
+#### 2-8. 完了報告
 
 ```
 ✅ v${VER} のリリースが完了しました。
 
+GitHub Release: https://github.com/daiki-beppu/youtube-automation/releases/tag/v${VER}
+生成 path: docs/release-notes/v${VER}.md
+post-release PR: ${PR_URL または skip / retry 状態}
+site は PR pending: Cloudflare Pages preview と required checks の確認待ち
+merge 後の公開 URL: https://youtube-automation-release-notes.pages.dev/v${VER}/
+
 次の選択肢:
 - 各チャンネルリポジトリで `/automation-update` を実行すれば CHANGELOG.md / Release 本文から累積影響を要約して追従可能
 ```
+
+非承認 / skip、生成失敗、local gate 失敗、既存 branch 検出でも GitHub Release publish 自体は完了として同じ URL を報告する。PR が無い場合は理由と手動作成手順を、PR 作成途中の失敗では重複作成しない retry 手順を併記する。
 
 ### Phase E0: 状態判定（extension）
 

--- a/.claude/skills/automation-release/references/publish-checklist.md
+++ b/.claude/skills/automation-release/references/publish-checklist.md
@@ -66,6 +66,22 @@ fi
 
 ---
 
+## post-release note の local gates
+
+承認済みの公開ノート案を post-release branch に載せた後、commit / push 前に次を記載順で実行する。
+
+```bash
+nix develop .#extensions --command pnpm -C site install --frozen-lockfile
+nix develop .#extensions --command pnpm -C site check
+nix develop .#extensions --command pnpm -C site build
+nix develop .#extensions --command pnpm -C site test
+git diff --check
+```
+
+すべて exit 0 の場合だけ commit / push / PR 作成へ進む。失敗時の扱いはケース E に従う。
+
+---
+
 ## エッジケース
 
 ### ケース A: tag は打ったが gh release create で失敗
@@ -86,6 +102,26 @@ GitHub の PR 設定で「マージ後に自動削除」が有効だと、リモ
 
 **対応**: `git push origin --delete "release/v${VER}"` のエラーは無視（`|| true`）。ローカルブランチだけ削除して終了。
 
+### ケース D: 公開ノート案が非承認または修正依頼
+
+生成内容を修正して再提示し、対象 tag・post-release branch・変更 path とともに再度承認を得る。承認されるまで git 副作用を起こさない。
+
+非承認 / skip の場合はノートを commit / push せず、GitHub Release publish は完了扱いにする。canonical authoring reference、生成 path、手動作成手順を報告して release branch cleanup は必ず続行する。
+
+### ケース E: local gates が失敗
+
+失敗した check / build / test と診断を表示し、push せず retry 手順を報告する。post-release branch を作成済みでも、失敗を隠して commit・push・PR 作成へ進まない。GitHub Release publish と tag は取り消さず、release branch cleanup は必ず続行する。
+
+### ケース F: 既存 post-release branch / PR がある
+
+local または remote に既存 post-release branch がある場合は削除・上書きしない。`gh pr list --state all --head "${POST_RELEASE_BRANCH}"` で既存 pull request を確認し、存在すれば URL と state を報告して重複作成しない。
+
+PR が無ければ branch の対象 tag、生成 path、commit、diff を照合する。一致が確認できた場合だけ local gates から retry し、不一致なら自動処理を停止して手動 reconciliation を依頼する。どちらの場合も release branch cleanup は必ず続行する。
+
+### ケース G: push または PR 作成が失敗
+
+push 済みかを remote branch で、PR 作成済みかを `gh pr list` で再確認する。既存 pull request があればその URL を再利用して重複作成しない。未作成なら同じ branch の local gates と diff を再確認してから失敗した操作だけ retry する。
+
 ---
 
 ## チェックリスト（最終確認用）
@@ -98,6 +134,10 @@ publish 完了直後にユーザーへ提示するサマリ:
 Tag: v${VER}（push 済み）
 GitHub Release: https://github.com/daiki-beppu/youtube-automation/releases/tag/v${VER}
 リリースブランチ: release/v${VER}（削除済み）
+生成 path: docs/release-notes/v${VER}.md
+post-release PR: <URL または skip / retry 状態>
+site は PR pending: Cloudflare Pages preview と required checks の確認待ち
+merge 後の公開 URL: https://youtube-automation-release-notes.pages.dev/v${VER}/
 
 次のステップ:
 - 各チャンネルリポジトリで `/automation-update` を実行すれば CHANGELOG.md / Release 本文から累積影響を要約して追従可能

--- a/tests/repo/test_release_notes_contract.py
+++ b/tests/repo/test_release_notes_contract.py
@@ -14,6 +14,8 @@ from tests.helpers.paths import REPO_ROOT
 ROOT = REPO_ROOT
 NOTES_DIR = ROOT / "docs" / "release-notes"
 AUTHORING_REFERENCE = ROOT / ".claude" / "skills" / "automation-release" / "references" / "release-notes-authoring.md"
+RELEASE_SKILL = ROOT / ".claude" / "skills" / "automation-release" / "SKILL.md"
+PUBLISH_CHECKLIST = ROOT / ".claude" / "skills" / "automation-release" / "references" / "publish-checklist.md"
 REQUIRED_FRONTMATTER_KEYS = {"title", "version", "released_at", "kind", "summary", "sidebar"}
 REQUIRED_HEADINGS = (
     "## 30 秒サマリー",
@@ -124,3 +126,54 @@ def test_ci_python_test_checkout_fetches_full_tag_history() -> None:
     checkout = next(step for step in test_job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
 
     assert checkout["with"]["fetch-depth"] == 0
+
+
+def test_python_publish_orders_release_authoring_review_approval_and_pull_request() -> None:
+    skill = RELEASE_SKILL.read_text(encoding="utf-8")
+    phase_two = skill[skill.index("### Phase 2: publish") : skill.index("### Phase E0: 状態判定（extension）")]
+    ordered_contract = (
+        'gh release create "v${VER}" --generate-notes --title "v${VER}"',
+        "references/release-notes-authoring.md",
+        "docs/release-notes/v${VER}.md",
+        "生成内容・対象 tag・post-release branch・変更 path",
+        "AskUserQuestion",
+        'git push -u origin "${POST_RELEASE_BRANCH}"',
+        'gh pr create --base main --head "${POST_RELEASE_BRANCH}"',
+    )
+
+    positions = [phase_two.index(fragment) for fragment in ordered_contract]
+    assert positions == sorted(positions)
+
+
+def test_python_publish_requires_approval_and_reports_pending_site_on_skip() -> None:
+    skill = RELEASE_SKILL.read_text(encoding="utf-8")
+
+    for required in (
+        "承認前に commit / push / pull request 作成を行わない",
+        "main へ直接 push しない",
+        "非承認 / skip",
+        "GitHub Release publish は完了扱い",
+        "手動作成手順",
+        "Cloudflare Pages preview",
+        "required checks の `lint` / `test`",
+        "site は PR pending",
+        "merge 後の公開 URL",
+    ):
+        assert required in skill
+
+
+def test_python_post_release_failures_are_retryable_without_weakening_release_cleanup() -> None:
+    checklist = PUBLISH_CHECKLIST.read_text(encoding="utf-8")
+
+    for required in (
+        "生成内容を修正して再提示",
+        "承認されるまで git 副作用を起こさない",
+        "local gates が失敗",
+        "push せず retry 手順を報告",
+        "既存 post-release branch",
+        "削除・上書きしない",
+        "既存 pull request",
+        "重複作成しない",
+        "release branch cleanup は必ず続行",
+    ):
+        assert required in checklist


### PR DESCRIPTION
## Summary

- Python Release 後の公開ノート生成・承認・専用 branch/PR flow を接続
- skip/retry/既存 branch・PR を failure-safe に処理

Closes #3584