### PR TITLE
[site-operator-docs] allowlist source と相対リンク解決を実装する

### DIFF
--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -1,19 +1,43 @@
 import dadsTokens from "@digital-go-jp/design-tokens";
 import { defineConfig } from "blume";
 import { releaseScaleLabels } from "./release-scale";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+import {
+  createOperatorDocSource,
+  operatorDocMap,
+  operatorDocReleaseField,
+} from "./operator-doc-source";
 import { releaseFrontmatter } from "./release-schema";
 
 const lightAccent = dadsTokens.Color.Key["800"].$value;
 const darkAccent = dadsTokens.Color.Key["400"].$value;
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const operatorDocReleaseFieldSchema = z
+  .custom((value) => value === operatorDocReleaseField)
+  .transform(() => undefined);
+const mixedContentFrontmatter = Object.fromEntries(
+  Object.entries(releaseFrontmatter).map(([key, schema]) => [
+    key,
+    schema.or(operatorDocReleaseFieldSchema),
+  ])
+);
 
 export default defineConfig({
   title: "youtube-automation ドキュメント",
   description: "youtube-automation の公式ドキュメント",
   content: {
     root: "../docs/release-notes",
+    sources: [
+      { root: "../docs/release-notes", type: "filesystem" },
+      {
+        source: createOperatorDocSource({ map: operatorDocMap, repositoryRoot }),
+        type: "custom",
+      },
+    ],
   },
   frontmatter: {
-    extend: releaseFrontmatter,
+    extend: mixedContentFrontmatter,
   },
   navigation: {
     sidebar: [

--- a/site/operator-doc-source.ts
+++ b/site/operator-doc-source.ts
@@ -1,0 +1,196 @@
+import { existsSync, realpathSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { isAbsolute, posix, resolve, sep } from "node:path";
+import type { ContentSource, SourceEntry } from "blume/sources/types";
+
+const GITHUB_BLOB_BASE =
+  "https://github.com/daiki-beppu/youtube-automation/blob/main/";
+
+export interface OperatorDocMapping {
+  readonly source: string;
+  readonly route: string;
+}
+
+export const operatorDocMap = [
+  { source: "ONBOARDING.md", route: "/onboarding" },
+  { source: "docs/oauth-setup.md", route: "/oauth-setup" },
+  { source: "docs/features.md", route: "/features" },
+  { source: "docs/workflow-cheatsheet.md", route: "/workflow-cheatsheet" },
+  {
+    source: "docs/chrome-extension-install-guide.md",
+    route: "/chrome-extension-install-guide",
+  },
+  { source: "docs/dashboard.md", route: "/dashboard" },
+  {
+    source: "docs/channel-workspace-migration.md",
+    route: "/channel-workspace-migration",
+  },
+] as const satisfies readonly OperatorDocMapping[];
+
+/** Internal marker allowing staged operator entries through release-only fields. */
+export const operatorDocReleaseField = Symbol("operator-doc-release-field");
+
+const normalizedRepositoryPath = (path: string): string => {
+  const normalized = posix.normalize(path.replaceAll("\\", "/"));
+  if (
+    path.length === 0 ||
+    isAbsolute(path) ||
+    normalized === ".." ||
+    normalized.startsWith("../")
+  ) {
+    throw new Error(`Operator document path escapes repository: ${path}`);
+  }
+  return normalized.replace(/^\.\//u, "");
+};
+
+const normalizedRoute = (route: string): string => {
+  const normalized = posix.normalize(`/${route}`);
+  if (route.length === 0 || normalized === "/" || normalized.includes("..")) {
+    throw new Error(`Invalid operator document route: ${route}`);
+  }
+  return normalized;
+};
+
+const validateMap = (
+  map: readonly OperatorDocMapping[]
+): readonly OperatorDocMapping[] => {
+  const sources = new Set<string>();
+  const routes = new Set<string>();
+  return map.map((entry) => {
+    const source = normalizedRepositoryPath(entry.source);
+    const route = normalizedRoute(entry.route);
+    if (sources.has(source)) {
+      throw new Error(`Duplicate source in operator document map: ${source}`);
+    }
+    if (routes.has(route)) {
+      throw new Error(`Duplicate route in operator document map: ${route}`);
+    }
+    sources.add(source);
+    routes.add(route);
+    return { route, source };
+  });
+};
+
+const targetParts = (target: string): { fragment: string; path: string } => {
+  const fragmentIndex = target.indexOf("#");
+  return fragmentIndex === -1
+    ? { fragment: "", path: target }
+    : {
+        fragment: target.slice(fragmentIndex),
+        path: target.slice(0, fragmentIndex),
+      };
+};
+
+const isAbsoluteUrl = (target: string): boolean =>
+  target.startsWith("//") || /^[a-z][a-z\d+.-]*:/iu.test(target);
+
+const resolveLinkTarget = (
+  target: string,
+  source: string,
+  routeBySource: ReadonlyMap<string, string>
+): string => {
+  if (target.startsWith("#") || isAbsoluteUrl(target)) {
+    return target;
+  }
+  const wrapped = target.startsWith("<") && target.endsWith(">");
+  const unwrapped = wrapped ? target.slice(1, -1) : target;
+  const { fragment, path } = targetParts(unwrapped);
+  if (!/\.mdx?$/iu.test(path)) {
+    return target;
+  }
+
+  const sourceDirectory = posix.dirname(normalizedRepositoryPath(source));
+  const repositoryPath = normalizedRepositoryPath(
+    path.startsWith("/")
+      ? path.slice(1)
+      : posix.join(sourceDirectory === "." ? "" : sourceDirectory, path)
+  );
+  const resolved = `${routeBySource.get(repositoryPath) ?? `${GITHUB_BLOB_BASE}${repositoryPath}`}${fragment}`;
+  return wrapped ? `<${resolved}>` : resolved;
+};
+
+export const rewriteMarkdownLinks = (
+  markdown: string,
+  source: string,
+  map: readonly OperatorDocMapping[]
+): string => {
+  const validatedMap = validateMap(map);
+  const routeBySource = new Map(
+    validatedMap.map((entry) => [entry.source, entry.route])
+  );
+  return markdown.replace(
+    /(!?\[[^\]\n]*\]\()(<[^>\n]+>|[^\s)]+)([^)\n]*\))/gu,
+    (_match, opening: string, target: string, closing: string) =>
+      `${opening}${resolveLinkTarget(target, source, routeBySource)}${closing}`
+  );
+};
+
+const assertReadableSource = (repositoryRoot: string, source: string): string => {
+  const path = resolve(repositoryRoot, source);
+  if (!existsSync(path)) {
+    throw new Error(`Operator document source not found: ${source}`);
+  }
+  const realRepositoryRoot = realpathSync(repositoryRoot);
+  const realSource = realpathSync(path);
+  if (
+    realSource !== realRepositoryRoot &&
+    !realSource.startsWith(`${realRepositoryRoot}${sep}`)
+  ) {
+    throw new Error(`Operator document source escapes repository: ${source}`);
+  }
+  return realSource;
+};
+
+export const createOperatorDocSource = (options: {
+  readonly map: readonly OperatorDocMapping[];
+  readonly repositoryRoot: string;
+}): ContentSource => {
+  const map = validateMap(options.map);
+  const repositoryRoot = resolve(options.repositoryRoot);
+
+  const validate = (): void => {
+    for (const entry of map) {
+      assertReadableSource(repositoryRoot, entry.source);
+    }
+  };
+
+  const readEntry = async (mapping: OperatorDocMapping): Promise<SourceEntry> => {
+    const path = assertReadableSource(repositoryRoot, mapping.source);
+    const original = await readFile(path, "utf8");
+    const text = rewriteMarkdownLinks(original, mapping.source, map);
+    return {
+      body: { format: "md", text },
+      data: {
+        kind: operatorDocReleaseField,
+        released_at: operatorDocReleaseField,
+        summary: operatorDocReleaseField,
+        type: "doc",
+        version: operatorDocReleaseField,
+      },
+      editUrl: `${GITHUB_BLOB_BASE}${mapping.source}`,
+      raw: `---\ntype: doc\n---\n\n${text}`,
+      ref: mapping.source,
+      slug: mapping.route,
+    };
+  };
+
+  return {
+    load: async () => {
+      validate();
+      return {
+        diagnostics: [],
+        entries: await Promise.all(map.map(readEntry)),
+      };
+    },
+    name: "operator-docs",
+    read: async (ref) => {
+      const mapping = map.find((entry) => entry.source === ref);
+      if (!mapping) {
+        throw new Error(`Unknown operator document source: ${ref}`);
+      }
+      return (await readEntry(mapping)).body.text;
+    },
+    staged: true,
+    validate,
+  };
+};

--- a/site/tests/operator-doc-source.test.mjs
+++ b/site/tests/operator-doc-source.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createOperatorDocSource,
+  operatorDocMap,
+  rewriteMarkdownLinks,
+} from "../operator-doc-source.ts";
+
+const expectedSources = [
+  "ONBOARDING.md",
+  "docs/oauth-setup.md",
+  "docs/features.md",
+  "docs/workflow-cheatsheet.md",
+  "docs/chrome-extension-install-guide.md",
+  "docs/dashboard.md",
+  "docs/channel-workspace-migration.md",
+];
+
+const createRepository = async (map = operatorDocMap) => {
+  const repositoryRoot = await mkdtemp(join(tmpdir(), "operator-doc-source-"));
+  await Promise.all(
+    map.map(async ({ source }) => {
+      const path = join(repositoryRoot, source);
+      await mkdir(join(path, ".."), { recursive: true });
+      await writeFile(path, `# ${source}\n`, "utf8");
+    })
+  );
+  return repositoryRoot;
+};
+
+test("operator document map は公開対象7件だけを明示列挙する", () => {
+  assert.deepEqual(
+    operatorDocMap.map(({ source }) => source),
+    expectedSources
+  );
+  assert.equal(new Set(operatorDocMap.map(({ route }) => route)).size, 7);
+});
+
+test("source は build ごとに原本を読み、安定 route と doc type を返す", async () => {
+  const repositoryRoot = await createRepository();
+  const source = createOperatorDocSource({ map: operatorDocMap, repositoryRoot });
+  const onboarding = join(repositoryRoot, "ONBOARDING.md");
+
+  await writeFile(onboarding, "# First\n", "utf8");
+  const first = await source.load();
+  await writeFile(onboarding, "# Second\n", "utf8");
+  const second = await source.load();
+
+  assert.equal(first.entries.length, 7);
+  assert.equal(first.entries[0].body.text, "# First\n");
+  assert.equal(second.entries[0].body.text, "# Second\n");
+  assert.equal(first.entries[0].slug, operatorDocMap[0].route);
+  assert.equal(first.entries[0].data.type, "doc");
+  assert.match(first.entries[0].raw, /^---\ntype: doc\n---/);
+});
+
+test("存在しない原本は解決対象を示して fail closed する", async () => {
+  const repositoryRoot = await createRepository(operatorDocMap.slice(1));
+  const source = createOperatorDocSource({ map: operatorDocMap, repositoryRoot });
+
+  await assert.rejects(source.load(), /ONBOARDING\.md/);
+});
+
+test("重複 route は衝突した route を示して拒否する", () => {
+  const map = [
+    { source: "ONBOARDING.md", route: "/setup" },
+    { source: "docs/oauth-setup.md", route: "/setup" },
+  ];
+
+  assert.throws(
+    () => createOperatorDocSource({ map, repositoryRoot: "/tmp/repository" }),
+    /duplicate route.*\/setup/i
+  );
+});
+
+test("重複 source は衝突した source を示して拒否する", () => {
+  const map = [
+    { source: "ONBOARDING.md", route: "/setup" },
+    { source: "ONBOARDING.md", route: "/another" },
+  ];
+
+  assert.throws(
+    () => createOperatorDocSource({ map, repositoryRoot: "/tmp/repository" }),
+    /duplicate source.*ONBOARDING\.md/i
+  );
+});
+
+test("repository 外 path は解決対象を示して拒否する", () => {
+  const map = [{ source: "../private.md", route: "/private" }];
+
+  assert.throws(
+    () => createOperatorDocSource({ map, repositoryRoot: "/tmp/repository" }),
+    /repository.*\.\.\/private\.md/i
+  );
+});
+
+test("repository 外を指す symlink は解決対象を示して拒否する", async () => {
+  const repositoryRoot = await mkdtemp(join(tmpdir(), "operator-doc-source-"));
+  const externalRoot = await mkdtemp(join(tmpdir(), "operator-doc-external-"));
+  const external = join(externalRoot, "private.md");
+  await writeFile(external, "# Private\n", "utf8");
+  await symlink(external, join(repositoryRoot, "linked.md"));
+  const source = createOperatorDocSource({
+    map: [{ source: "linked.md", route: "/linked" }],
+    repositoryRoot,
+  });
+
+  await assert.rejects(source.load(), /escapes repository.*linked\.md/i);
+});
+
+test("mapped Markdown link は site route と fragment へ書き換える", () => {
+  const markdown =
+    "[workflow](workflow-cheatsheet.md#再開) [setup](../ONBOARDING.md#install)";
+
+  assert.equal(
+    rewriteMarkdownLinks(markdown, "docs/features.md", operatorDocMap),
+    "[workflow](/workflow-cheatsheet#再開) [setup](/onboarding#install)"
+  );
+});
+
+test("map 外の repository-relative Markdown link は GitHub 原本へ書き換える", () => {
+  const markdown = "[scope](oauth-scopes.md#read-only)";
+
+  assert.equal(
+    rewriteMarkdownLinks(markdown, "docs/oauth-setup.md", operatorDocMap),
+    "[scope](https://github.com/daiki-beppu/youtube-automation/blob/main/docs/oauth-scopes.md#read-only)"
+  );
+});
+
+test("anchor、絶対 URL、非 Markdown link は変更しない", () => {
+  const markdown = [
+    "[anchor](#local)",
+    "[web](https://example.com/guide.md)",
+    "[mail](mailto:operator@example.com)",
+    "[config](../config/channel/meta.json)",
+  ].join(" ");
+
+  assert.equal(
+    rewriteMarkdownLinks(markdown, "docs/features.md", operatorDocMap),
+    markdown
+  );
+});


### PR DESCRIPTION
## Summary

- exact 7 allowlist と Blume custom operator-doc source を追加
- stable route/doc type、mapped/GitHub link 解決、欠損・重複・repository escape の fail-closed を実装

Closes #3579