### PR TITLE
[site-operator-docs] 目的別 navigation と7ページ描画を実装する

### DIFF
--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -42,6 +42,23 @@ export default defineConfig({
   navigation: {
     sidebar: [
       {
+        label: "はじめる",
+        items: [
+          "/onboarding",
+          "/oauth-setup",
+          "/chrome-extension-install-guide",
+        ],
+      },
+      {
+        label: "使う",
+        items: [
+          "/features",
+          "/workflow-cheatsheet",
+          "/dashboard",
+          "/channel-workspace-migration",
+        ],
+      },
+      {
         label: `本体｜${releaseScaleLabels.major}`,
         items: ["/v5.6.0"],
       },
@@ -58,7 +75,25 @@ export default defineConfig({
         items: ["/ext-v0.2.5"],
       },
     ],
-    tabs: [{ label: "リリースノート", path: "/", href: "/" }],
+    // Operator routes are intentionally flat; root-scoped tabs keep the same
+    // three-section sidebar visible instead of treating one route as a prefix.
+    tabs: [
+      {
+        href: "/#getting-started",
+        label: "はじめる",
+        path: "/",
+      },
+      {
+        href: "/#use",
+        label: "使う",
+        path: "/",
+      },
+      {
+        href: "/#release-notes",
+        label: "リリースノート",
+        path: "/",
+      },
+    ],
   },
   theme: {
     accent: {

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -14,6 +14,56 @@ interface ReleaseData {
   version: string;
 }
 
+const operatorSections = [
+  {
+    id: "getting-started",
+    label: "はじめる",
+    pages: [
+      {
+        description: "導入から最初のコレクション制作までの標準手順",
+        href: "/onboarding",
+        label: "セットアップ",
+      },
+      {
+        description: "Google Cloud と YouTube API の設定・トラブルシューティング",
+        href: "/oauth-setup",
+        label: "OAuth",
+      },
+      {
+        description: "Suno・DistroKid・Community Helper の導入手順",
+        href: "/chrome-extension-install-guide",
+        label: "Chrome 拡張の導入",
+      },
+    ],
+  },
+  {
+    id: "use",
+    label: "使う",
+    pages: [
+      {
+        description: "チャンネル運営で利用できる skill の一覧",
+        href: "/features",
+        label: "skill カタログ",
+      },
+      {
+        description: "制作 workflow の選び方と再開方法",
+        href: "/workflow-cheatsheet",
+        label: "ワークフローの使い分け",
+      },
+      {
+        description: "複数チャンネルの数字を確認する dashboard の使い方",
+        href: "/dashboard",
+        label: "dashboard",
+      },
+      {
+        description: "単一チャンネル構成から workspace へ移行する手順",
+        href: "/channel-workspace-migration",
+        label: "workspace 移行",
+      },
+    ],
+  },
+] as const;
+
 const routeByEntryId = new Map(data.routes.map((route) => [route.entryId, route.path]));
 const releases = (await getCollection("docs"))
   .map((entry) => {
@@ -60,49 +110,72 @@ const formatDate = (date: Date) =>
   siteUrl={data.config.site}
   ogEnabled={data.config.og.enabled}
   page={{
-    title: "リリースノート | youtube-automation",
+    title: "運用ガイド | youtube-automation",
     description: data.config.description,
   }}
 >
   <main class="release-shell">
     <header class="release-hero">
-      <p class="release-eyebrow">RELEASE NOTES</p>
-      <h1>最新のアップデート</h1>
-      <p>日々の YouTube 運営を、もっと速く、安全に。新機能と改善内容をお知らせします。</p>
+      <p class="release-eyebrow">OPERATOR GUIDE</p>
+      <h1>YouTube 運用ガイド</h1>
+      <p>導入、日々の制作、アップデート確認に必要な公式ドキュメントを目的別に案内します。</p>
     </header>
 
-    <div class="release-sections">
-      {releaseGroupsByKind.map(({ groups, kind, label }) => (
-        <section class="release-section" data-release-kind={kind}>
-          <h2>{label}</h2>
-          {groups.map((group) => (
-            <section class="release-scale" data-release-scale={group.scale}>
-              <h3>{group.label}</h3>
-              <ol class="release-list" aria-label={`${label}の${group.label}一覧`}>
-                {group.releases.map((release) => (
-                  <li>
-                    <a class="release-card" href={release.href}>
-                      <div class="release-meta">
-                        <span class:list={["release-kind", `release-kind--${release.kind}`]}>
-                          {kindLabel[release.kind]}
-                        </span>
-                        <time datetime={release.released_at.toISOString()}>
-                          {formatDate(release.released_at)}
-                        </time>
-                      </div>
-                      <h4>{release.version}</h4>
-                      <p>{release.summary}</p>
-                      <span class="release-link" aria-hidden="true">
-                        詳しく見る <span>→</span>
-                      </span>
-                    </a>
-                  </li>
-                ))}
-              </ol>
-            </section>
-          ))}
+    <div class="doc-sections">
+      {operatorSections.map((section) => (
+        <section class="doc-section" data-doc-section={section.id} id={section.id}>
+          <h2>{section.label}</h2>
+          <ul class="doc-list">
+            {section.pages.map((page) => (
+              <li>
+                <a class="doc-card" href={page.href}>
+                  <h3>{page.label}</h3>
+                  <p>{page.description}</p>
+                  <span aria-hidden="true">読む →</span>
+                </a>
+              </li>
+            ))}
+          </ul>
         </section>
       ))}
+
+      <section class="doc-section" data-doc-section="release-notes" id="release-notes">
+        <h2>リリースノート</h2>
+        <p class="doc-section-lead">本体と Chrome 拡張の新機能・改善内容を確認できます。</p>
+        <div class="release-sections">
+          {releaseGroupsByKind.map(({ groups, kind, label }) => (
+            <section class="release-section" data-release-kind={kind}>
+              <h3>{label}</h3>
+              {groups.map((group) => (
+                <section class="release-scale" data-release-scale={group.scale}>
+                  <h4>{group.label}</h4>
+                  <ol class="release-list" aria-label={`${label}の${group.label}一覧`}>
+                    {group.releases.map((release) => (
+                      <li>
+                        <a class="release-card" href={release.href}>
+                          <div class="release-meta">
+                            <span class:list={["release-kind", `release-kind--${release.kind}`]}>
+                              {kindLabel[release.kind]}
+                            </span>
+                            <time datetime={release.released_at.toISOString()}>
+                              {formatDate(release.released_at)}
+                            </time>
+                          </div>
+                          <h5>{release.version}</h5>
+                          <p>{release.summary}</p>
+                          <span class="release-link" aria-hidden="true">
+                            詳しく見る <span>→</span>
+                          </span>
+                        </a>
+                      </li>
+                    ))}
+                  </ol>
+                </section>
+              ))}
+            </section>
+          ))}
+        </div>
+      </section>
     </div>
   </main>
 </PageLayout>

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -56,15 +56,77 @@
   margin: 1.5rem 0 0;
 }
 
-.release-sections {
+.doc-sections {
   display: grid;
   gap: clamp(3rem, 7vw, 5rem);
   margin-top: clamp(3rem, 7vw, 5rem);
 }
 
-.release-section > h2 {
+.doc-section > h2 {
   font-size: clamp(1.6rem, 3vw, 2.25rem);
   letter-spacing: -0.035em;
+  margin: 0 0 1.5rem;
+}
+
+.doc-section-lead {
+  color: var(--color-muted-foreground);
+  line-height: 1.75;
+  margin: -0.75rem 0 2rem;
+}
+
+.doc-list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.doc-card {
+  border: 1px solid var(--release-border);
+  border-radius: 1rem;
+  color: inherit;
+  display: block;
+  height: 100%;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  text-decoration: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.doc-card:hover {
+  border-color: color-mix(in srgb, var(--release-main) 60%, transparent);
+  box-shadow: 0 18px 50px color-mix(in srgb, var(--release-main) 10%, transparent);
+  transform: translateY(-2px);
+}
+
+.doc-card h3 {
+  font-size: clamp(1.2rem, 2.5vw, 1.5rem);
+  letter-spacing: -0.025em;
+  margin: 0;
+}
+
+.doc-card p {
+  color: var(--color-muted-foreground);
+  line-height: 1.7;
+  margin: 0.75rem 0 0;
+}
+
+.doc-card span {
+  color: var(--release-main);
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 700;
+  margin-top: 1rem;
+}
+
+.release-sections {
+  display: grid;
+  gap: clamp(3rem, 7vw, 5rem);
+}
+
+.release-section > h3 {
+  font-size: clamp(1.35rem, 2.5vw, 1.75rem);
+  letter-spacing: -0.03em;
   margin: 0 0 1.5rem;
 }
 
@@ -72,7 +134,7 @@
   margin-top: 2rem;
 }
 
-.release-scale > h3 {
+.release-scale > h4 {
   color: var(--color-muted-foreground);
   font-size: clamp(1.1rem, 2vw, 1.35rem);
   letter-spacing: -0.02em;
@@ -132,7 +194,7 @@
   color: var(--release-extension);
 }
 
-.release-card h4 {
+.release-card h5 {
   font-size: clamp(1.45rem, 3vw, 2rem);
   letter-spacing: -0.025em;
   margin: 1.1rem 0 0.55rem;
@@ -163,12 +225,14 @@
 }
 
 @media (min-width: 52rem) {
+  .doc-list,
   .release-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .doc-card,
   .release-card,
   .release-link span {
     transition: none;

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -12,7 +12,31 @@ import {
 const readIndex = () => readFile(new URL("../dist/index.html", import.meta.url), "utf8");
 const readRelease = (version) =>
   readFile(new URL(`../dist/${version}/index.html`, import.meta.url), "utf8");
+const readOperatorDoc = (route) =>
+  readFile(new URL(`../dist${route}/index.html`, import.meta.url), "utf8");
 const execFileAsync = promisify(execFile);
+const operatorSections = [
+  {
+    label: "はじめる",
+    routes: [
+      "/onboarding",
+      "/oauth-setup",
+      "/chrome-extension-install-guide",
+    ],
+    section: "getting-started",
+  },
+  {
+    label: "使う",
+    routes: [
+      "/features",
+      "/workflow-cheatsheet",
+      "/dashboard",
+      "/channel-workspace-migration",
+    ],
+    section: "use",
+  },
+];
+const operatorRoutes = operatorSections.flatMap(({ routes }) => routes);
 
 const readStylesheetClosure = async (html) => {
   const inlineStyles = [...html.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/g)].map(
@@ -167,6 +191,102 @@ const sectionByAttribute = (html, attribute, value) => {
   throw new Error(`${attribute}="${value}" の section が閉じられていません`);
 };
 
+const hrefsWithin = (markup) =>
+  [...markup.matchAll(/href="(\/[^"#?]*)"/g)].map((match) => match[1]);
+
+test("landing page は3区分を表示し、operator docs 7件へ1回ずつ到達できる", async () => {
+  const html = await readIndex();
+  const sectionLabels = [
+    ["getting-started", "はじめる"],
+    ["use", "使う"],
+    ["release-notes", "リリースノート"],
+  ];
+
+  for (const [section, label] of sectionLabels) {
+    const markup = sectionByAttribute(html, "data-doc-section", section);
+    assert.match(markup, new RegExp(`<h2>${label}</h2>`));
+  }
+
+  const operatorMarkup = operatorSections
+    .map(({ section }) => sectionByAttribute(html, "data-doc-section", section))
+    .join("\n");
+  const operatorHrefs = hrefsWithin(operatorMarkup).filter((href) =>
+    operatorRoutes.includes(href)
+  );
+  assert.deepEqual(operatorHrefs, operatorRoutes);
+});
+
+test("全ページ共通 sidebar と tabs は operator 区分・release規模・exact route ownership を保つ", async () => {
+  const pages = [await readRelease("v5.6.0"), await readOperatorDoc("/features")];
+
+  for (const html of pages) {
+    const sidebar = html.match(/<nav data-blume-nav-tree>([\s\S]*?)<\/nav>/)?.[1] ?? "";
+    const header = html.match(/<header\b[^>]*data-blume-header[^>]*>([\s\S]*?)<\/header>/)?.[1] ?? "";
+    const tabs = header.match(/<nav aria-label="Sections"[^>]*>([\s\S]*?)<\/nav>/)?.[1] ?? "";
+
+    for (const { label } of operatorSections) {
+      assert.match(sidebar, new RegExp(`>${label}<`));
+      assert.match(tabs, new RegExp(`>${label}<`));
+    }
+    for (const label of [
+      "本体｜大きいアップデート",
+      "本体｜小さいアップデート",
+      "Chrome 拡張｜大きいアップデート",
+      "Chrome 拡張｜小さいアップデート",
+    ]) {
+      assert.match(sidebar, new RegExp(`>${label}<`));
+    }
+    assert.match(tabs, />リリースノート</);
+    assert.deepEqual(
+      [...tabs.matchAll(/href="([^"]+)"/g)].map((match) => match[1]),
+      ["/#getting-started", "/#use", "/#release-notes"]
+    );
+
+    for (const route of operatorRoutes) {
+      assert.equal(hrefsWithin(sidebar).filter((href) => href === route).length, 1);
+    }
+  }
+});
+
+test("operator docs の7 routeを描画・検索し、内部linkとGitHub fallbackを保つ", async () => {
+  const search = JSON.parse(
+    await readFile(new URL("../dist/blume-search.json", import.meta.url), "utf8")
+  );
+  const searchRoutes = search.map(({ route }) => route);
+
+  for (const route of operatorRoutes) {
+    const html = await readOperatorDoc(route);
+    assert.match(html, /<article\b/);
+    assert.equal(searchRoutes.filter((candidate) => candidate === route).length, 1);
+  }
+
+  const features = await readOperatorDoc("/features");
+  const onboarding = await readOperatorDoc("/onboarding");
+  const oauth = await readOperatorDoc("/oauth-setup");
+  assert.match(features, /href="\/workflow-cheatsheet"/);
+  assert.match(onboarding, /href="\/oauth-setup"/);
+  assert.match(oauth, /href="\/onboarding"/);
+  assert.match(
+    onboarding,
+    /href="https:\/\/github\.com\/daiki-beppu\/youtube-automation\/blob\/main\/docs\/migration\/python-to-tayk\.md"/
+  );
+});
+
+test("非掲載領域は route、navigation、landing、search に現れない", async () => {
+  const distDirectory = new URL("../dist/", import.meta.url);
+  const generatedPaths = await readdir(distDirectory, { recursive: true });
+  const index = await readIndex();
+  const release = await readRelease("v5.6.0");
+  const search = JSON.parse(
+    await readFile(new URL("../dist/blume-search.json", import.meta.url), "utf8")
+  );
+
+  assert.equal(generatedPaths.some((path) => path.startsWith("audits/")), false);
+  assert.doesNotMatch(index, /href="\/audits(?:\/|"|#)/);
+  assert.doesNotMatch(release, /href="\/audits(?:\/|"|#)/);
+  assert.equal(search.some(({ route }) => route.startsWith("/audits")), false);
+});
+
 test("patch が 0 の version は major、それ以外は minor に分類する", () => {
   assert.equal(scaleFromVersion("v5.6.0"), "major");
   assert.equal(scaleFromVersion("ext-v0.3.0"), "major");
@@ -237,13 +357,13 @@ test("top page は kind の下に非空の更新規模 section を見出し階�
     const majorSection = sectionByAttribute(kindSection, "data-release-scale", "major");
     const minorSection = sectionByAttribute(kindSection, "data-release-scale", "minor");
 
-    assert.match(kindSection, new RegExp(`<h2>${kindLabel}</h2>`));
+    assert.match(kindSection, new RegExp(`<h3>${kindLabel}</h3>`));
     assert.equal([...kindSection.matchAll(/<section[^>]*data-release-scale=/g)].length, 2);
-    assert.match(majorSection, /<h3>大きいアップデート<\/h3>/);
-    assert.match(minorSection, /<h3>小さいアップデート<\/h3>/);
+    assert.match(majorSection, /<h4>大きいアップデート<\/h4>/);
+    assert.match(minorSection, /<h4>小さいアップデート<\/h4>/);
     assert.match(majorSection, /<ol[^>]*class="release-list"[^>]*>\s*<li>/);
     assert.match(minorSection, /<ol[^>]*class="release-list"[^>]*>\s*<li>/);
-    assert.doesNotMatch(kindSection, /<section[^>]*data-release-scale[^>]*>\s*<h3>[^<]+<\/h3>\s*<ol[^>]*>\s*<\/ol>/);
+    assert.doesNotMatch(kindSection, /<section[^>]*data-release-scale[^>]*>\s*<h4>[^<]+<\/h4>\s*<ol[^>]*>\s*<\/ol>/);
   }
 });
 
@@ -292,7 +412,7 @@ test("top page の kind × 更新規模 group は4 releaseの所属・日付・�
     );
 
     assert.deepEqual(hrefs, [expected.href]);
-    assert.match(scaleSection, new RegExp(`<h4>${expected.version}</h4>`));
+    assert.match(scaleSection, new RegExp(`<h5>${expected.version}</h5>`));
     assert.match(scaleSection, new RegExp(`<time datetime="${expected.date}">[^<]+</time>`));
     assert.match(
       scaleSection,
@@ -317,8 +437,8 @@ test("一覧は本体とChrome拡張に分かれ、それぞれ公開日の新�
   const hrefs = (markup) =>
     [...markup.matchAll(/class="release-card" href="([^"]+)"/g)].map((match) => match[1]);
 
-  assert.match(main, /<h2>本体<\/h2>/);
-  assert.match(extension, /<h2>Chrome 拡張<\/h2>/);
+  assert.match(main, /<h3>本体<\/h3>/);
+  assert.match(extension, /<h3>Chrome 拡張<\/h3>/);
   assert.deepEqual(hrefs(main), ["/v5.6.0", "/v5.5.17"]);
   assert.deepEqual(hrefs(extension), ["/ext-v0.3.0", "/ext-v0.2.5"]);
 });
@@ -335,10 +455,12 @@ test("本体とChrome拡張を区別し、詳細ページへリンクする", as
 const sidebarGroups = (html) => {
   const sidebar = html.match(/<nav data-blume-nav-tree>([\s\S]*?)<\/nav>/)?.[1] ?? "";
   const groupPattern = /<p\b[^>]*>\s*<span\b[^>]*>([^<]+)<\/span>\s*<\/p>\s*<div\b[^>]*>\s*<ul\b[^>]*>([\s\S]*?)<\/ul>/g;
-  return [...sidebar.matchAll(groupPattern)].map((match) => ({
-    label: match[1],
-    hrefs: [...match[2].matchAll(/href="(\/[^"#]+)"/g)].map((href) => href[1]),
-  }));
+  return [...sidebar.matchAll(groupPattern)]
+    .filter((match) => match[1].includes("｜"))
+    .map((match) => ({
+      label: match[1],
+      hrefs: [...match[2].matchAll(/href="(\/[^"#]+)"/g)].map((href) => href[1]),
+    }));
 };
 
 test("全詳細ページのサイドバーを kind × 更新規模の4 flat groupで表示する", async () => {


### PR DESCRIPTION
## Summary

- 3区分 landing と全ページ共通 sidebar/tabs を追加
- exact 7 routes、内部リンク・GitHub fallback・非掲載領域を regression test で固定
- navigation の唯一の定義元を含めるため、ユーザー承認により `site/blume.config.ts` を追加した4-path scope

Closes #3580