### PR TITLE
[site-operator-docs] 公開導線・deploy 手順・release note を更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `docs(site)`: 公開サイトをリリースノート専用から下流運用者向けドキュメントへ拡張し、「はじめる」「使う」「リリースノート」の目的別 navigation に統一した。`ONBOARDING.md`、`docs/oauth-setup.md`、`docs/features.md`、`docs/workflow-cheatsheet.md`、`docs/chrome-extension-install-guide.md`、`docs/dashboard.md`、`docs/channel-workspace-migration.md` の7原本を read-in-place allowlist で掲載し、allowlist 内リンクは公開 route、掲載外の運用資料は GitHub 原本へ fallback する。ADR・audit・内部運用資料は公開境界の外に維持し、Cloudflare Pages の watch 設定と preview 受け入れ手順を更新した（#3579、#3580、#3581、#3582）。
 - `docs(automation-release)`: Python 本体と Chrome 拡張の GitHub Release publish 完了後、同一 release 情報から公開リリースノート案を生成し、明示承認後だけ branch protection 下の専用 PR へ載せる post-release flow を追加した。site は PR pending とし、merge 後に production 公開される。既存の Python / extension publish contract は変更しない（#3586）。
 - `feat(suno-helper)`: prompt entry の `duration_sec` が明示された場合、解決済みの Custom Duration button を押してから既存の bridge-first / keydown fallback 経路で Duration slider へ秒数を注入するようにした（#3160）。
 - `feat(suno-helper)`: prompt entry の optional な `duration_sec` を wire 型で受理し、明示された数値を失わず保持するようにした（#3153）。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ YouTube チャンネル運営を自動化するツールキット。Analytics �
 - **ベンチマーク分析** - 競合チャンネルのパフォーマンス比較
 - **プレイリスト管理** - プレイリストの自動作成・動画追加
 - **Analytics dashboard** - `yt-dashboard` で収集済みチャンネル指標をローカル横断表示（[利用手順](docs/dashboard.md)）
-- **公開リリースノート** - 本体と Chrome 拡張の更新内容を共通形式で掲載（[公開サイト](https://youtube-automation-release-notes.pages.dev/) / [公開ノートのソース](docs/release-notes/)）
+- **運用者向け公開ドキュメント（公開リリースノート）** - 「はじめる」「使う」「リリースノート」の区分で、セットアップ、OAuth、skill / workflow、dashboard、workspace 移行、本体と Chrome 拡張の更新内容を掲載（[公開サイト](https://youtube-automation-release-notes.pages.dev/) / [掲載原本](ONBOARDING.md)）
 
 > **個別 skill のカタログ**: `yt-skills sync` で配布される全 46 skill の「なにができるか」一覧は [`docs/features.md`](docs/features.md) を参照。
 >

--- a/docs/release-notes-deployment.md
+++ b/docs/release-notes-deployment.md
@@ -1,6 +1,6 @@
-# リリースノートサイトの公開
+# 運用者向けドキュメントサイトの公開
 
-公開リリースノートは Cloudflare Pages の
+セットアップ・利用手順とリリースノートをまとめた運用者向け公開ドキュメントは、Cloudflare Pages の
 [`youtube-automation-release-notes`](https://youtube-automation-release-notes.pages.dev/)
 プロジェクトから配信する。
 
@@ -18,7 +18,7 @@
 | pnpm | `11.15.1`（`site/package.json::packageManager` と `PNPM_VERSION`） |
 | Production deploy | `main` への push で自動実行 |
 | Preview deploy | repository 内の production 以外の全 branch / pull request |
-| Build watch paths | `site/**`, `docs/release-notes/**` |
+| Build watch paths | `site/**`, `docs/release-notes/**`, `ONBOARDING.md`, `docs/oauth-setup.md`, `docs/features.md`, `docs/workflow-cheatsheet.md`, `docs/chrome-extension-install-guide.md`, `docs/dashboard.md`, `docs/channel-workspace-migration.md` |
 
 Cloudflare Pages の GitHub integration が commit を取得し、production branch では
 `https://youtube-automation-release-notes.pages.dev/`、それ以外では commit 固有 URL と
@@ -26,7 +26,44 @@ branch alias を生成する。fork から作成された pull request には pr
 
 `site/wrangler.jsonc` は Direct Upload で同じ出力境界を使うための設定である。Git integration
 の build 設定は Cloudflare 側に保持されるため、変更時はこの表と Cloudflare Pages project
-の両方を同じ値へ更新する。
+の両方を同じ値へ更新する。既存 project の名前、production URL、custom domain は変更しない。
+
+### repository workflow と Build watch paths
+
+`.github/workflows/site.yml` の `on.push.paths` / `on.pull_request.paths` は GitHub Actions の実行条件、
+Cloudflare Pages Git integration の **Build watch paths** は Pages build の実行条件であり、別々の設定である。
+片方を編集しても、もう片方へ自動同期されない。公開原本を追加・削除するときは両方を同じ変更で更新し、
+次の一覧と一致することを確認する。
+
+```text
+site/**
+docs/release-notes/**
+ONBOARDING.md
+docs/oauth-setup.md
+docs/features.md
+docs/workflow-cheatsheet.md
+docs/chrome-extension-install-guide.md
+docs/dashboard.md
+docs/channel-workspace-migration.md
+```
+
+Cloudflare Dashboard で既存の `youtube-automation-release-notes` project を開き、Git integration の
+Build watch paths を上記9項目へ更新して保存する。保存後は設定画面を再表示し、各項目が完全一致すること、
+`docs/**` のように公開対象外まで含む広い pattern がないことを確認する。
+
+## Preview 受け入れ確認
+
+site を変更した pull request では、Cloudflare Pages の commit 固有 preview build が成功してから次を確認する。
+fork からの pull request には preview URL が作られないため、同一 repository の branch で確認する。
+
+- トップページと sidebar / tabs に「はじめる」「使う」「リリースノート」の3区分が表示される。
+- 次の7ページが preview URL 配下で表示される: `/onboarding/`、`/oauth-setup/`、`/chrome-extension-install-guide/`、`/features/`、`/workflow-cheatsheet/`、`/dashboard/`、`/channel-workspace-migration/`。
+- `/features/` から `/workflow-cheatsheet/`、`/onboarding/` と `/oauth-setup/` の相互リンクが preview 内の route を指す。
+- `/onboarding/` の Python 版から `tayk` への移行リンクは、GitHub の `docs/migration/python-to-tayk.md` 原本へ fallback する。
+- `/audits/` route が生成されず、navigation と検索結果にも内部 audit が現れない。
+
+この checklist は local build の代替ではない。pull request の commit と preview URL を記録し、上記を確認した後に
+merge する。merge 後は production build と `https://youtube-automation-release-notes.pages.dev/` の表示を確認する。
 
 ## ローカル検証と手動公開
 


### PR DESCRIPTION
## Summary

- 運用者向け公開サイトの説明、Build watch設定9件、preview受入手順を追加
- 公開境界と CHANGELOG を更新

## External acceptance

- Cloudflare Dashboard の Build watch paths 更新と preview URL 確認は認証が必要なため pending
- ユーザー承認により、外部受入 pending を明記した状態で提出

Closes #3582