### PR TITLE
feat(workspace): PreToolUse hook で workspace のチャンネル境界外への Write/Edit を block する

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -20,6 +20,10 @@
           {
             "type": "command",
             "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *auth/client_secrets.json|*auth/token.json|*.env) echo \"BLOCKED: $f は AI から直接編集禁止。専用ツール経由で更新してください\" >&2; exit 2;; esac; done"
+          },
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in channels|channels/*|*/channels|*/channels/*|collections|collections/*|*/collections|*/collections/*|config/channel|config/channel/*|*/config/channel|*/config/channel/*|assets|assets/*|*/assets|*/assets/*|data|data/*|*/data|*/data/*|auth|auth/*|*/auth|*/auth/*) uv run yt-workspace-guard check $CLAUDE_FILE_PATHS; exit $?;; esac; done; exit 0"
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(workspace)`: 下流の Edit/Write hook でチャンネル関連 path だけを事前抽出し、workspace 境界判定 CLI の拒否理由と exit code をエージェントへ返すようにした（#3371）。
+
 - `feat(workspace)`: Write/Edit 対象 path が multi-channel workspace のチャンネル境界を越えないか検査する `yt-workspace-guard` CLI を追加（#3370）。
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
 
+from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.system import skills_sync
 
 
@@ -32,6 +35,19 @@ def _template(root: Path) -> None:
 def _run(root: Path, target: Path, monkeypatch, *extra: str) -> int:
     monkeypatch.setattr(skills_sync, "_editable_root", lambda: root)
     return skills_sync.main(["sync", "--asset", "settings", "--target", str(target), *extra])
+
+
+def _workspace_guard_command(settings: dict[str, object]) -> str:
+    groups = settings["hooks"]["PreToolUse"]
+    commands = [
+        hook["command"]
+        for group in groups
+        if group["matcher"] == "Edit|Write"
+        for hook in group["hooks"]
+        if "yt-workspace-guard" in hook["command"]
+    ]
+    assert len(commands) == 1
+    return commands[0]
 
 
 def test_settings_merge_preserves_local_values_and_accepts_hooks(tmp_path, monkeypatch) -> None:
@@ -68,6 +84,49 @@ def test_settings_noninteractive_skips_hooks_but_merges_permissions(tmp_path, mo
     merged = json.loads(target.read_text(encoding="utf-8"))
     assert merged["permissions"]["allow"]
     assert "hooks" not in merged
+
+
+def test_distributed_settings_include_workspace_guard_alongside_auth_hook(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "downstream" / ".claude" / "settings.json"
+
+    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    command = _workspace_guard_command(merged)
+    assert "uv run yt-workspace-guard check $CLAUDE_FILE_PATHS" in command
+    all_commands = [hook["command"] for group in merged["hooks"]["PreToolUse"] for hook in group["hooks"]]
+    assert any("auth/client_secrets.json" in candidate for candidate in all_commands)
+
+
+def test_workspace_guard_hook_prefilters_unrelated_paths(tmp_path) -> None:
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.template.json").read_text(encoding="utf-8"))
+    command = _workspace_guard_command(settings)
+    env = {**os.environ, "CLAUDE_FILE_PATHS": "README.md docs/guide.md", "PATH": str(tmp_path)}
+
+    result = subprocess.run(command, shell=True, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_workspace_guard_hook_propagates_block_and_paths(tmp_path) -> None:
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.template.json").read_text(encoding="utf-8"))
+    command = _workspace_guard_command(settings)
+    invocation = tmp_path / "invocation"
+    fake_uv = tmp_path / "uv"
+    fake_uv.write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$*" > "{invocation}"\necho "channel mismatch" >&2\nexit 2\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+    paths = "channels/beta/collections/new workspace/assets/cover.png"
+    env = {**os.environ, "CLAUDE_FILE_PATHS": paths, "PATH": str(tmp_path)}
+
+    result = subprocess.run(command, shell=True, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 2
+    assert result.stderr == "channel mismatch\n"
+    assert invocation.read_text(encoding="utf-8") == f"run yt-workspace-guard check {paths}\n"
 
 
 def test_settings_invalid_target_is_not_overwritten(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Edit/Write の PreToolUse hook に workspace guard prefilter を追加
- exit code・stderr・全対象 path の伝搬、auth hook 共存、settings sync 配布を検証

Closes #3371