### PR TITLE
feat(workspace): SessionStart hook で対象チャンネルのコンテキストをセッションへ注入する

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -27,6 +27,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run yt-workspace-guard context"
+          }
+        ]
+      }
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
+
 - `feat(workspace)`: 下流の Edit/Write hook でチャンネル関連 path だけを事前抽出し、workspace 境界判定 CLI の拒否理由と exit code をエージェントへ返すようにした（#3371）。
 
 - `feat(workspace)`: Write/Edit 対象 path が multi-channel workspace のチャンネル境界を越えないか検査する `yt-workspace-guard` CLI を追加（#3370）。

--- a/src/youtube_automation/commands/channel/workspace_guard.py
+++ b/src/youtube_automation/commands/channel/workspace_guard.py
@@ -23,11 +23,12 @@ _ROOT_CHANNEL_LAYOUTS = (
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="yt-workspace-guard",
-        description="書き込み対象 path が workspace のチャンネル境界内か検査します。",
+        description="workspace のチャンネル境界を検査し、セッションの対象チャンネルを表示します。",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     check = subparsers.add_parser("check", help="1 件以上の path をチャンネル境界に照らして検査します。")
     check.add_argument("paths", nargs="+", metavar="path", help="Write/Edit の対象 path")
+    subparsers.add_parser("context", help="cwd からセッションの対象チャンネルと path 基準を表示します。")
     return parser
 
 
@@ -88,11 +89,40 @@ def check_paths(raw_paths: list[str], cwd: Path) -> list[tuple[str, str]]:
     return blocked
 
 
+def _find_channel_ancestor(start: Path) -> Path | None:
+    for candidate in [start, *start.parents]:
+        if (candidate / "config" / "channel").is_dir():
+            return candidate
+    return None
+
+
+def context_lines(cwd: Path) -> list[str]:
+    """cwd から SessionStart へ注入する最小コンテキストを組み立てる。"""
+    resolved_cwd = cwd.expanduser().resolve()
+    workspace_root = find_workspace_root(resolved_cwd)
+    if workspace_root is None:
+        channel = _find_channel_ancestor(resolved_cwd)
+        return [f"channel_dir={channel}"] if channel is not None else []
+
+    channels = workspace_channels(workspace_root)
+    current_slug = _channel_slug(resolved_cwd, channels)
+    if current_slug is None:
+        candidates = ", ".join(channels)
+        return [f"チャンネル未確定。候補: {candidates}。書き込み前に対象チャンネルの channels/<slug>/ を基準にすること"]
+
+    channel = channels[current_slug].resolve()
+    return [f"channel={current_slug}", f"channel_dir={channel}", "相対パスはこの dir 基準"]
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    if args.command == "context":
+        for line in context_lines(Path.cwd()):
+            print(line)
+        return EXIT_OK
+
     if args.command != "check":
         raise AssertionError(f"未対応の command です: {args.command}")
-
     blocked = check_paths(args.paths, Path.cwd())
     for path, reason in blocked:
         print(f"BLOCK: {path}: {reason}", file=sys.stderr)

--- a/tests/commands/channel/test_workspace_guard.py
+++ b/tests/commands/channel/test_workspace_guard.py
@@ -83,12 +83,51 @@ def test_check_always_allows_paths_outside_workspace(tmp_path, monkeypatch, caps
     assert capsys.readouterr().err == ""
 
 
+def test_context_prints_workspace_channel_and_path_base(tmp_path, monkeypatch, capsys):
+    channel = _make_channel(tmp_path, "alpha")
+    working_dir = channel / "collections" / "planning"
+    working_dir.mkdir(parents=True)
+    monkeypatch.chdir(working_dir)
+
+    assert workspace_guard.main(["context"]) == workspace_guard.EXIT_OK
+
+    output = capsys.readouterr().out
+    assert "channel=alpha" in output
+    assert f"channel_dir={channel}" in output
+    assert "相対パスはこの dir 基準" in output
+
+
+def test_context_from_workspace_root_prints_unresolved_candidates(tmp_path, monkeypatch, capsys):
+    _make_channel(tmp_path, "zeta")
+    _make_channel(tmp_path, "alpha")
+    monkeypatch.chdir(tmp_path)
+
+    assert workspace_guard.main(["context"]) == workspace_guard.EXIT_OK
+
+    output = capsys.readouterr().out
+    assert "チャンネル未確定" in output
+    assert "候補: alpha, zeta" in output
+    assert "channels/<slug>/" in output
+
+
+def test_context_in_single_channel_repo_prints_only_channel_dir(tmp_path, monkeypatch, capsys):
+    (tmp_path / "config" / "channel").mkdir(parents=True)
+    working_dir = tmp_path / "collections" / "planning"
+    working_dir.mkdir(parents=True)
+    monkeypatch.chdir(working_dir)
+
+    assert workspace_guard.main(["context"]) == workspace_guard.EXIT_OK
+
+    assert capsys.readouterr().out == f"channel_dir={tmp_path}\n"
+
+
 def test_help_documents_check_and_path_arguments(capsys):
     with pytest.raises(SystemExit, match="0"):
         workspace_guard.main(["--help"])
 
     output = capsys.readouterr().out
     assert "check" in output
+    assert "context" in output
     assert "path" in output
     assert "チャンネル境界" in output
 

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -50,6 +50,13 @@ def _workspace_guard_command(settings: dict[str, object]) -> str:
     return commands[0]
 
 
+def _session_context_command(settings: dict[str, object]) -> str:
+    groups = settings["hooks"]["SessionStart"]
+    commands = [hook["command"] for group in groups for hook in group["hooks"]]
+    assert commands == ["uv run yt-workspace-guard context"]
+    return commands[0]
+
+
 def test_settings_merge_preserves_local_values_and_accepts_hooks(tmp_path, monkeypatch) -> None:
     _template(tmp_path)
     target = tmp_path / "downstream" / ".claude" / "settings.json"
@@ -96,6 +103,15 @@ def test_distributed_settings_include_workspace_guard_alongside_auth_hook(tmp_pa
     assert "uv run yt-workspace-guard check $CLAUDE_FILE_PATHS" in command
     all_commands = [hook["command"] for group in merged["hooks"]["PreToolUse"] for hook in group["hooks"]]
     assert any("auth/client_secrets.json" in candidate for candidate in all_commands)
+
+
+def test_distributed_settings_include_session_start_context_hook(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "downstream" / ".claude" / "settings.json"
+
+    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    assert _session_context_command(merged) == "uv run yt-workspace-guard context"
 
 
 def test_workspace_guard_hook_prefilters_unrelated_paths(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- `yt-workspace-guard context` を追加
- workspace channel/root/single-channel repo のコンテキスト出力を実装
- SessionStart hook を settings 配布対象へ追加

Closes #3372