### PR TITLE
fix(image): Gemini画像モデルのGA版を既定化する (#3638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(workspace)`: 下流の Edit/Write hook でチャンネル関連 path だけを事前抽出し、workspace 境界判定 CLI の拒否理由と exit code をエージェントへ返すようにした（#3371）。
 
 - `feat(workspace)`: Write/Edit 対象 path が multi-channel workspace のチャンネル境界を越えないか検査する `yt-workspace-guard` CLI を追加（#3370）。
+- `fix(image)`: Gemini 画像生成の runtime fallback `_DEFAULT_GEMINI_MODEL`、設定契約 test、genai client のモデル例示を GA ID `gemini-3.1-flash-image` へ更新（#3303、#3638）。
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
 - `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果と再試行時の全 FINISHED event で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。

--- a/src/youtube_automation/infrastructure/media/genai_client.py
+++ b/src/youtube_automation/infrastructure/media/genai_client.py
@@ -7,8 +7,8 @@ GCP プロジェクト / API 有効化 / ADC を整えたうえで使用する�
 環境変数:
 - `GOOGLE_CLOUD_PROJECT` (任意) — 未設定なら ADC quota project から自動解決
 
-Vertex AI はモデルごとにサポート region が異なる (2026-04 現在):
-- `gemini-3.1-flash-image-preview` などの画像系: `global` のみ
+Vertex AI はモデルごとにサポート region が異なる (2026-08 現在):
+- `gemini-3.1-flash-image` などの画像系: `global` のみ
 - `veo-3.1-fast-generate-001` などの Veo 系: `us-central1` など region 指定
 
 呼び出し側はモデル用途に合わせて `create_global_genai_client()` または

--- a/src/youtube_automation/infrastructure/media/image_provider/config.py
+++ b/src/youtube_automation/infrastructure/media/image_provider/config.py
@@ -23,7 +23,7 @@ SUPPORTED_PROVIDERS: tuple[str, ...] = ("gemini", "openai", "codex", "gemini_cli
 OPENAI_SUPPORTED_ASPECT_RATIOS: tuple[str, ...] = ("16:9", "9:16")
 
 # 既定値（skill-config 不在時のフォールバック）
-_DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-image-preview"
+_DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-image"
 _DEFAULT_GEMINI_IMAGE_SIZE = "2K"
 
 # gemini_cli provider 既定値（サブスク認証の gemini CLI 経由 / nano-banana）

--- a/tests/infrastructure/media/test_image_provider_config.py
+++ b/tests/infrastructure/media/test_image_provider_config.py
@@ -32,7 +32,7 @@ class TestParseImageGenerationConfig:
             "image_generation": {
                 "provider": "gemini",
                 "gemini": {
-                    "model": "gemini-3.1-flash-image-preview",
+                    "model": "gemini-3.1-flash-image",
                     "image_size": "2K",
                 },
             }
@@ -44,8 +44,19 @@ class TestParseImageGenerationConfig:
         # Then
         assert isinstance(cfg, ImageGenerationConfig)
         assert cfg.provider == "gemini"
-        assert cfg.gemini.model == "gemini-3.1-flash-image-preview"
+        assert cfg.gemini.model == "gemini-3.1-flash-image"
         assert cfg.gemini.image_size == "2K"
+
+    def test_should_use_ga_model_when_gemini_model_is_omitted(self):
+        # Given: Gemini provider で model 未指定
+        skill_cfg = {"image_generation": {"provider": "gemini", "gemini": {}}}
+
+        # When
+        cfg = parse_image_generation_config(skill_cfg)
+
+        # Then
+        assert cfg.gemini is not None
+        assert cfg.gemini.model == "gemini-3.1-flash-image"
 
     def test_parses_image_generation_namespace_for_openai(self):
         # Given
@@ -586,12 +597,12 @@ class TestGeminiConfigDoesNotRestrictAspectRatio:
         # Given: GeminiConfig の必須キーだけを渡す
         # When
         cfg = GeminiConfig(
-            model="gemini-3.1-flash-image-preview",
+            model="gemini-3.1-flash-image",
             image_size="2K",
         )
 
         # Then: aspect_ratio は config レベルでは保持しない（Request 側で渡す）
-        assert cfg.model == "gemini-3.1-flash-image-preview"
+        assert cfg.model == "gemini-3.1-flash-image"
         assert cfg.image_size == "2K"
         assert not hasattr(cfg, "aspect_ratio") or getattr(cfg, "aspect_ratio", None) is None
 


### PR DESCRIPTION
## Summary

- Vertex AI画像生成のruntime fallbackを`gemini-3.1-flash-image`へ更新
- model未指定時の設定契約、クライアント例示、CHANGELOGをGA model IDへ追従
- GA例示の確認時点を2026-08へ更新

## Scope exception

方針Aとして、新規5段目を増やさず既存stackをatomic mergeするため、この最下段だけは通常の3-path上限にCHANGELOGを加えた4 pathsを明示的に許容する。次段#3643にもskill配布既定値用の独立CHANGELOG差分を持たせ、両段のgateを自己完結させる。

Closes #3638