### PR TITLE
fix(thumbnail): Gemini画像既定値をGAモデルへ更新する (#3639)

### DIFF
--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -70,7 +70,7 @@ image_generation:
 
   gemini:
     # 使用する Gemini 画像生成モデル
-    model: gemini-3.1-flash-image-preview
+    model: gemini-3.1-flash-image
 
     # 生成モード:
     #   single_step   : ベンチマーク模倣 (TTP) の推奨実装。テキスト付き参照画像から

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(workspace)`: Write/Edit 対象 path が multi-channel workspace のチャンネル境界を越えないか検査する `yt-workspace-guard` CLI を追加（#3370）。
 - `fix(image)`: Gemini 画像生成の runtime fallback `_DEFAULT_GEMINI_MODEL`、設定契約 test、genai client のモデル例示を GA ID `gemini-3.1-flash-image` へ更新（#3303、#3638）。
+- `fix(thumbnail)`: thumbnail skill の配布既定値と Gemini provider fixture を GA モデル `gemini-3.1-flash-image` へ更新（#3303、#3639）。
 
 - `feat(collection-serve)`: Suno downloaded の実 ZIP 適用成功応答へ期待数・配置数・欠損数の placement summary を追加し、部分成功時の欠損理由と workflow state を同じ count に統一。playlist URL 記録だけの先行 POST は legacy 応答を維持（#3164）。
 - `feat(suno-helper)`: download flow の通常・best-effort・再試行成功結果と再試行時の全 FINISHED event で server の型付き配置 summary を保持し、既存エラー契約を維持（#3169）。

--- a/tests/infrastructure/media/test_image_provider_gemini.py
+++ b/tests/infrastructure/media/test_image_provider_gemini.py
@@ -61,7 +61,7 @@ def _fake_response(parts: list) -> MagicMock:
 
 @pytest.fixture
 def gemini_config() -> GeminiConfig:
-    return GeminiConfig(model="gemini-3.1-flash-image-preview", image_size="2K")
+    return GeminiConfig(model="gemini-3.1-flash-image", image_size="2K")
 
 
 @pytest.fixture
@@ -131,7 +131,7 @@ class TestForwardsRequestToGeminiApi:
         # Then
         assert result.success is True
         kwargs = client.models.generate_content.call_args.kwargs
-        assert kwargs["model"] == "gemini-3.1-flash-image-preview"
+        assert kwargs["model"] == "gemini-3.1-flash-image"
         # config 引数の中に aspect_ratio / image_size がセットされている
         cfg_arg = kwargs["config"]
         # GenerateContentConfig は属性アクセス可能
@@ -201,7 +201,7 @@ class TestVariationGuard:
         # Given
         ref_path = tmp_path / "ref.png"
         ref_path.write_bytes(_png_bytes())
-        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=True)
+        config = GeminiConfig(model="gemini-3.1-flash-image", variation_guard_enabled=True)
         provider = GeminiImageProvider(config)
         req = request_factory(prompt="a calm ocean sunset", references=[ref_path])
         response = _fake_response([_fake_image_part(_png_bytes())])
@@ -222,7 +222,7 @@ class TestVariationGuard:
         # Given
         ref_path = tmp_path / "ref.png"
         ref_path.write_bytes(_png_bytes())
-        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=False)
+        config = GeminiConfig(model="gemini-3.1-flash-image", variation_guard_enabled=False)
         provider = GeminiImageProvider(config)
         req = request_factory(prompt="a calm ocean sunset", references=[ref_path])
         response = _fake_response([_fake_image_part(_png_bytes())])
@@ -240,7 +240,7 @@ class TestVariationGuard:
     def test_no_references_no_guard_regardless_of_config(self, request_factory, patched_genai_client):
         """参照画像なし → variation_guard_enabled の値にかかわらず guard は付かない。"""
         # Given
-        config = GeminiConfig(model="gemini-3.1-flash-image-preview", variation_guard_enabled=True)
+        config = GeminiConfig(model="gemini-3.1-flash-image", variation_guard_enabled=True)
         provider = GeminiImageProvider(config)
         req = request_factory(prompt="a calm ocean sunset", references=[])
         response = _fake_response([_fake_image_part(_png_bytes())])


### PR DESCRIPTION
## Summary

- thumbnail skillから配布するGemini画像モデルの既定値をGA model IDへ更新
- Gemini provider fixtureと送信モデル契約を同じIDへ追従
- 配布既定値変更を独立したCHANGELOG entryへ記録

Closes #3639