### PR TITLE
test(image): fixtureと未指定モデル貫通契約をGAへ統一 (#3640)

### DIFF
--- a/tests/infrastructure/media/test_image_provider_composition.py
+++ b/tests/infrastructure/media/test_image_provider_composition.py
@@ -109,7 +109,7 @@ class TestResolveCostPerImage:
         When resolve_cost_per_image を呼ぶ
         Then None を返す。
         """
-        cfg = {"image_generation": {"gemini": {"model": "gemini-3.1-flash-image-preview"}}}
+        cfg = {"image_generation": {"gemini": {"model": "gemini-3.1-flash-image"}}}
 
         result = resolve_cost_per_image(cfg, "gemini")
 
@@ -147,7 +147,7 @@ class TestConfirmCost:
         """
         monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
 
-        assert confirm_cost("gemini-3.1-flash-image-preview", 0.101) is True
+        assert confirm_cost("gemini-3.1-flash-image", 0.101) is True
 
         out = capsys.readouterr().out
         assert "$0.101" in out
@@ -159,7 +159,7 @@ class TestConfirmCost:
         """
         monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
 
-        assert confirm_cost("gemini-3.1-flash-image-preview", None) is True
+        assert confirm_cost("gemini-3.1-flash-image", None) is True
 
         out = capsys.readouterr().out
         assert "不明" in out
@@ -172,7 +172,7 @@ class TestConfirmCost:
         """
         monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
 
-        assert confirm_cost("gemini-3.1-flash-image-preview", None) is False
+        assert confirm_cost("gemini-3.1-flash-image", None) is False
 
     def test_numeric_cost_with_user_no_returns_false(self, monkeypatch: pytest.MonkeyPatch):
         """Given cost_per_image=0.101 / ユーザー 'N'
@@ -181,7 +181,7 @@ class TestConfirmCost:
         """
         monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
 
-        assert confirm_cost("gemini-3.1-flash-image-preview", 0.101) is False
+        assert confirm_cost("gemini-3.1-flash-image", 0.101) is False
 
     def test_none_cost_with_eof_returns_false(self, monkeypatch: pytest.MonkeyPatch):
         """Given cost_per_image=None / 入力で EOFError
@@ -194,7 +194,7 @@ class TestConfirmCost:
 
         monkeypatch.setattr("builtins.input", _raise_eof)
 
-        assert confirm_cost("gemini-3.1-flash-image-preview", None) is False
+        assert confirm_cost("gemini-3.1-flash-image", None) is False
 
 
 # ============================================================
@@ -218,7 +218,7 @@ class TestLogImageCost:
         output = tmp_channel / "collections" / "foo" / "main.png"
 
         entry = log_image_cost(
-            model="gemini-3.1-flash-image-preview",
+            model="gemini-3.1-flash-image",
             image_size="2K",
             aspect_ratio="16:9",
             output_file=output,
@@ -248,7 +248,7 @@ class TestLogImageCost:
 
         with pytest.raises(TypeError, match="cost_usd"):
             log_image_cost(
-                model="gemini-3.1-flash-image-preview",
+                model="gemini-3.1-flash-image",
                 image_size="2K",
                 aspect_ratio="16:9",
                 output_file=output,

--- a/tests/infrastructure/media/test_image_provider_factory.py
+++ b/tests/infrastructure/media/test_image_provider_factory.py
@@ -24,7 +24,7 @@ from youtube_automation.infrastructure.media.image_provider.openai import OpenAI
 def _gemini_config() -> ImageGenerationConfig:
     return ImageGenerationConfig(
         provider="gemini",
-        gemini=GeminiConfig(model="gemini-3.1-flash-image-preview", image_size="2K"),
+        gemini=GeminiConfig(model="gemini-3.1-flash-image", image_size="2K"),
         openai=None,
     )
 

--- a/tests/infrastructure/media/test_image_provider_integration.py
+++ b/tests/infrastructure/media/test_image_provider_integration.py
@@ -12,14 +12,18 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
+from PIL import Image
 
 from youtube_automation.configuration import reset as reset_config
 from youtube_automation.configuration import skills as skill_config
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.media.image import ImageGenerationRequest
 from youtube_automation.infrastructure.media.image_provider import (
     get_provider,
     load_image_generation_config,
@@ -81,10 +85,10 @@ class TestProviderSwitchEndToEnd:
         assert cfg.openai.aspect_ratio == "16:9"
         assert cfg.openai.quality == "high"
 
-    def test_gemini_provider_selected_from_yaml(self, tmp_path: Path, monkeypatch):
-        """Given skill-config YAML が `image_generation.provider: gemini` を宣言
-        When ロード → ファクトリ
-        Then GeminiImageProvider が返り、model が末端まで届く。
+    def test_gemini_default_model_reaches_vertex_api(self, tmp_path: Path, monkeypatch):
+        """Given skill-config override が Gemini model を省略
+        When ロード → ファクトリ → generate を実行
+        Then GA model ID が Vertex API 呼び出しへ届く。
         """
         # Given
         channel_dir = tmp_path / "ch"
@@ -96,21 +100,43 @@ class TestProviderSwitchEndToEnd:
                 "image_generation": {
                     "provider": "gemini",
                     "gemini": {
-                        "model": "gemini-3.1-flash-image-preview",
                         "image_size": "2K",
                     },
                 }
             },
         )
+        image_bytes = io.BytesIO()
+        Image.new("RGB", (16, 16), color=(0, 0, 0)).save(image_bytes, format="PNG")
+        image_part = MagicMock()
+        image_part.inline_data.data = image_bytes.getvalue()
+        image_part.text = None
+        response = MagicMock(parts=[image_part])
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value = response
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.media.image_provider.gemini.create_global_genai_client",
+            lambda: mock_client,
+        )
 
         # When
         cfg = load_image_generation_config()
         provider = get_provider(cfg)
+        result = provider.generate(
+            ImageGenerationRequest(
+                prompt="a serene mountain at dawn",
+                output_path=channel_dir / "out.png",
+                aspect_ratio="16:9",
+                image_size="2K",
+            )
+        )
 
         # Then
         assert cfg.provider == "gemini"
         assert isinstance(provider, GeminiImageProvider)
-        assert cfg.gemini.model == "gemini-3.1-flash-image-preview"
+        assert result.success is True
+        sent_model = mock_client.models.generate_content.call_args.kwargs["model"]
+        assert sent_model == "gemini-3.1-flash-image"
+        assert not sent_model.endswith("-preview")
 
     def test_codex_provider_selected_from_yaml_and_rejected_by_api_factory(self, tmp_path: Path, monkeypatch):
         """Given skill-config YAML が `image_generation.provider: codex` を宣言


### PR DESCRIPTION
## Summary

- model未指定のskill configからfactory・mock Vertex送信までを貫通し、GA ID送信を固定
- image provider integration / factory / composition fixtureをGA model IDへ統一
- scope外の`gemini_cli` fixtureは既定の2.5 preview IDを維持

Closes #3640