### PR TITLE
fcntl 非対応環境向けのファイルロック共通ユーティリティを新設する

### DIFF
--- a/src/youtube_automation/infrastructure/file_lock.py
+++ b/src/youtube_automation/infrastructure/file_lock.py
@@ -1,0 +1,106 @@
+"""Cross-platform exclusive file locking."""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import threading
+import time
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:
+    _msvcrt = None
+
+_LOCK_FILE_SUFFIX = ".lock"
+_LOCK_REGION_BYTES = 1
+_MSVCRT_LOCK_RETRY_DELAY_SECONDS = 0.05
+_MSVCRT_LOCK_MAX_ATTEMPTS = 20
+_MSVCRT_LOCK_RETRY_ERRNOS = {
+    errno.EACCES,
+    errno.EAGAIN,
+    getattr(errno, "EDEADLK", errno.EACCES),
+}
+_MSVCRT_LOCK_RETRY_WINERRORS = {
+    32,  # ERROR_SHARING_VIOLATION
+    33,  # ERROR_LOCK_VIOLATION
+}
+_IN_PROCESS_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Prevent concurrent access to the file at ``path``."""
+    if _fcntl is None and _msvcrt is None:
+        with _IN_PROCESS_LOCK:
+            yield
+        return
+
+    lock_path = path.with_suffix(path.suffix + _LOCK_FILE_SUFFIX)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _IN_PROCESS_LOCK:
+        with lock_path.open("a+b") as lock_file:
+            _prepare_lock_file(lock_file)
+            _acquire_lock(lock_file)
+            try:
+                yield
+            finally:
+                _release_lock(lock_file)
+
+
+def _prepare_lock_file(lock_file: BinaryIO) -> None:
+    lock_file.seek(0, 2)
+    size = lock_file.tell()
+    if size < _LOCK_REGION_BYTES:
+        lock_file.write(b"\0" * (_LOCK_REGION_BYTES - size))
+        lock_file.flush()
+    lock_file.seek(0)
+
+
+def _acquire_lock(lock_file: BinaryIO) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+        return
+    if _msvcrt is not None:
+        _acquire_msvcrt_lock(lock_file)
+        return
+    raise RuntimeError("platform file locks are unavailable")
+
+
+def _acquire_msvcrt_lock(lock_file: BinaryIO) -> None:
+    last_error: OSError | None = None
+    for attempt in range(_MSVCRT_LOCK_MAX_ATTEMPTS):
+        lock_file.seek(0)
+        try:
+            _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_NBLCK, _LOCK_REGION_BYTES)
+            return
+        except OSError as error:
+            if not _is_msvcrt_lock_contention(error):
+                raise
+            last_error = error
+            if attempt == _MSVCRT_LOCK_MAX_ATTEMPTS - 1:
+                break
+            time.sleep(_MSVCRT_LOCK_RETRY_DELAY_SECONDS)
+    raise TimeoutError(f"msvcrt lock acquisition timed out after {_MSVCRT_LOCK_MAX_ATTEMPTS} attempts") from last_error
+
+
+def _is_msvcrt_lock_contention(error: OSError) -> bool:
+    return error.errno in _MSVCRT_LOCK_RETRY_ERRNOS or getattr(error, "winerror", None) in _MSVCRT_LOCK_RETRY_WINERRORS
+
+
+def _release_lock(lock_file: BinaryIO) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+        return
+    if _msvcrt is not None:
+        lock_file.seek(0)
+        _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_UNLCK, _LOCK_REGION_BYTES)
+        return
+    raise RuntimeError("platform file locks are unavailable")

--- a/tests/infrastructure/test_file_lock.py
+++ b/tests/infrastructure/test_file_lock.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import builtins
+import contextlib
+import importlib
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_FILE_LOCK_MODULE = "youtube_automation.infrastructure.file_lock"
+_MISSING_MODULE = object()
+
+
+@contextlib.contextmanager
+def _import_file_lock_without(
+    monkeypatch: pytest.MonkeyPatch,
+    unavailable_modules: set[str],
+    *,
+    msvcrt_module: ModuleType | None = None,
+) -> Iterator[ModuleType]:
+    real_import = builtins.__import__
+
+    def import_without_platform_modules(name: str, *args, **kwargs):
+        if name in unavailable_modules:
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_platform_modules)
+    previous_module = sys.modules.pop(_FILE_LOCK_MODULE, _MISSING_MODULE)
+    if msvcrt_module is not None:
+        monkeypatch.setitem(sys.modules, "msvcrt", msvcrt_module)
+    try:
+        yield importlib.import_module(_FILE_LOCK_MODULE)
+    finally:
+        sys.modules.pop(_FILE_LOCK_MODULE, None)
+        if previous_module is not _MISSING_MODULE:
+            sys.modules[_FILE_LOCK_MODULE] = previous_module
+
+
+def test_file_lock_uses_msvcrt_when_fcntl_is_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Given fcntl なし / msvcrt あり
+    When 共通ファイルロックを取得・解放する
+    Then import に成功し、msvcrt の排他ロックを利用する。
+    """
+    calls: list[tuple[int, int]] = []
+    fake_msvcrt = ModuleType("msvcrt")
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+    fake_msvcrt.locking = lambda _fd, mode, size: calls.append((mode, size))
+
+    with _import_file_lock_without(monkeypatch, {"fcntl"}, msvcrt_module=fake_msvcrt) as module:
+        with module.file_lock(tmp_path / "state.json"):
+            pass
+
+    assert calls == [(fake_msvcrt.LK_NBLCK, 1), (fake_msvcrt.LK_UNLCK, 1)]
+
+
+def test_file_lock_releases_msvcrt_lock_when_body_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Given msvcrt ロック取得後に処理が失敗する
+    When context manager から例外が送出される
+    Then ロックを解放し、元の例外を伝播する。
+    """
+    calls: list[tuple[int, int]] = []
+    fake_msvcrt = ModuleType("msvcrt")
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+    fake_msvcrt.locking = lambda _fd, mode, size: calls.append((mode, size))
+
+    with _import_file_lock_without(monkeypatch, {"fcntl"}, msvcrt_module=fake_msvcrt) as module:
+        with pytest.raises(ValueError, match="critical section failed"):
+            with module.file_lock(tmp_path / "state.json"):
+                raise ValueError("critical section failed")
+
+    assert calls == [(fake_msvcrt.LK_NBLCK, 1), (fake_msvcrt.LK_UNLCK, 1)]
+
+
+def test_file_lock_serializes_threads_without_platform_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Given fcntl / msvcrt の双方がない環境
+    When 複数スレッドが共通ファイルロックを使う
+    Then import に成功し、プロセス内ロックでクリティカルセクションを直列化する。
+    """
+    barrier = threading.Barrier(3)
+    active_count = 0
+    maximum_active_count = 0
+
+    def enter_critical_section() -> None:
+        nonlocal active_count, maximum_active_count
+        barrier.wait()
+        with module.file_lock(tmp_path / "state.json"):
+            active_count += 1
+            maximum_active_count = max(maximum_active_count, active_count)
+            time.sleep(0.02)
+            active_count -= 1
+
+    with _import_file_lock_without(monkeypatch, {"fcntl", "msvcrt"}) as module:
+        threads = [threading.Thread(target=enter_critical_section) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join()
+
+    assert maximum_active_count == 1


### PR DESCRIPTION
## Summary
- `fcntl` / `msvcrt` / プロセス内 lock の三段フォールバックを持つ共通 `file_lock` を追加
- `fcntl` 不在時の import と `msvcrt` 選択、両 OS lock 不在時のスレッド排他を回帰テストで固定
- expand 段として既存 `cost_tracker.py` と利用側は未変更

Closes #3386