### PR TITLE
test(cost): fixtureをGAモデルIDへ統一 (#3641)

### DIFF
--- a/tests/commands/analytics/test_cost_tracker_quota.py
+++ b/tests/commands/analytics/test_cost_tracker_quota.py
@@ -316,7 +316,7 @@ def test_cli_default_summary_appends_quota_when_present(tmp_channel: Path, monke
     When 引数なしで yt-cost-report を実行
     Then 生成サマリに続けて quota サマリが表示される。
     """
-    cost_tracker.log_generation("image", model="gemini-3.1-flash-image-preview", quantity=1, unit="image")
+    cost_tracker.log_generation("image", model="gemini-3.1-flash-image", quantity=1, unit="image")
     cost_tracker.log_quota("youtube-data-api", "videos.insert", 1600)
     capsys.readouterr()
     assert _run_cli(monkeypatch, []) == 0
@@ -330,7 +330,7 @@ def test_cli_default_summary_without_quota_is_backward_compatible(tmp_channel: P
     When 引数なしで yt-cost-report を実行
     Then 従来どおり生成サマリのみで quota セクションは表示されない。
     """
-    cost_tracker.log_generation("image", model="gemini-3.1-flash-image-preview", quantity=1, unit="image")
+    cost_tracker.log_generation("image", model="gemini-3.1-flash-image", quantity=1, unit="image")
     capsys.readouterr()
     assert _run_cli(monkeypatch, []) == 0
     out = capsys.readouterr().out

--- a/tests/infrastructure/media/test_stock.py
+++ b/tests/infrastructure/media/test_stock.py
@@ -89,7 +89,7 @@ class TestArchiveToStock:
                 "source_role": "thumbnail_candidate",
                 "prompt": "warm candlelit interior",
                 "provider": "gemini",
-                "model": "gemini-3.1-flash-image-preview",
+                "model": "gemini-3.1-flash-image",
             },
             channel_dir=channel,
         )

--- a/tests/infrastructure/test_cost_tracker.py
+++ b/tests/infrastructure/test_cost_tracker.py
@@ -95,14 +95,14 @@ def test_log_generation_image_records_metadata_with_null_cost(tmp_channel: Path)
     """
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
         metadata={"image_size": "2K", "aspect_ratio": "16:9"},
     )
     assert entry is not None
     assert entry["category"] == "image"
-    assert entry["model"] == "gemini-3.1-flash-image-preview"
+    assert entry["model"] == "gemini-3.1-flash-image"
     assert entry["unit"] == "image"
     assert entry["estimated_cost_usd"] is None
     assert entry["metadata"]["image_size"] == "2K"
@@ -195,7 +195,7 @@ def test_log_generation_gpt_image_2_keeps_image_size_metadata_without_cost(tmp_c
 @pytest.mark.parametrize(
     "category, model, unit",
     [
-        ("image", "gemini-3.1-flash-image-preview", "image"),
+        ("image", "gemini-3.1-flash-image", "image"),
         ("video", "veo-3.1-lite-generate-preview", "second"),
         ("audio", "lyria-3-pro-preview", "song"),
     ],
@@ -252,7 +252,7 @@ def test_log_generation_uses_fcntl_when_available(tmp_channel: Path, monkeypatch
 
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
     )
@@ -387,7 +387,7 @@ def test_log_generation_retries_msvcrt_lock_contention(tmp_channel: Path, monkey
 
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
     )
@@ -433,7 +433,7 @@ def test_log_generation_does_not_retry_non_contention_msvcrt_errors(tmp_channel:
 
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
     )
@@ -470,7 +470,7 @@ def test_log_generation_stops_after_msvcrt_contention_retry_limit(tmp_channel: P
 
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
     )
@@ -513,7 +513,7 @@ def test_log_generation_releases_msvcrt_lock_when_write_fails(tmp_channel: Path,
 
     entry = cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
     )
@@ -558,7 +558,7 @@ def test_log_generation_without_platform_file_lock_preserves_threaded_writes(tmp
 @pytest.mark.parametrize(
     "category, model",
     [
-        ("image", "gemini-3.1-flash-image-preview"),
+        ("image", "gemini-3.1-flash-image"),
         ("video", "veo-3.1-lite-generate-preview"),
         ("audio", "lyria-3-pro-preview"),
     ],
@@ -580,7 +580,7 @@ def test_log_generation_rejects_empty_unit(tmp_channel: Path):
     with pytest.raises(ValueError, match="unit"):
         cost_tracker.log_generation(
             "image",
-            model="gemini-3.1-flash-image-preview",
+            model="gemini-3.1-flash-image",
             quantity=1,
             unit="",
         )
@@ -594,7 +594,7 @@ def test_log_generation_rejects_empty_unit(tmp_channel: Path):
 def test_read_all_combines_all_categories(tmp_channel: Path):
     cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
         metadata={"image_size": "1K"},
@@ -629,7 +629,7 @@ def test_read_log_reads_legacy_float_estimated_cost_usd(tmp_channel: Path):
                 {
                     "timestamp": "2026-04-01T10:00:00+00:00",
                     "category": "image",
-                    "model": "gemini-3.1-flash-image-preview",
+                    "model": "gemini-3.1-flash-image",
                     "quantity": 1,
                     "unit": "image",
                     "estimated_cost_usd": 0.04,
@@ -709,7 +709,7 @@ def test_print_last_report_omits_usd_jpy(tmp_channel: Path, capsys):
     """
     cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
         metadata={"image_size": "2K"},
@@ -740,7 +740,7 @@ def test_print_summary_shows_monthly_counts_only(tmp_channel: Path, capsys):
                 {
                     "timestamp": "2026-03-15T10:00:00+00:00",
                     "category": "image",
-                    "model": "gemini-3.1-flash-image-preview",
+                    "model": "gemini-3.1-flash-image",
                     "quantity": 1,
                     "unit": "image",
                     "estimated_cost_usd": None,
@@ -749,7 +749,7 @@ def test_print_summary_shows_monthly_counts_only(tmp_channel: Path, capsys):
                 {
                     "timestamp": "2026-04-10T10:00:00+00:00",
                     "category": "image",
-                    "model": "gemini-3.1-flash-image-preview",
+                    "model": "gemini-3.1-flash-image",
                     "quantity": 1,
                     "unit": "image",
                     "estimated_cost_usd": None,
@@ -796,7 +796,7 @@ def test_print_last_report_with_null_cost_does_not_emit_dollar(tmp_channel: Path
     """
     cost_tracker.log_generation(
         "image",
-        model="gemini-3.1-flash-image-preview",
+        model="gemini-3.1-flash-image",
         quantity=1,
         unit="image",
         metadata={"image_size": "2K"},
@@ -840,7 +840,7 @@ def test_log_generation_rejects_cost_usd_keyword(tmp_channel: Path):
     with pytest.raises(TypeError, match="cost_usd"):
         cost_tracker.log_generation(
             "image",
-            model="gemini-3.1-flash-image-preview",
+            model="gemini-3.1-flash-image",
             quantity=1,
             unit="image",
             cost_usd=0.04,  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- stock / cost tracking / quota表示のfixtureをGA model IDへ統一
- 現行テスト群から廃止済み3.1 preview IDを除去

Closes #3641