### PR TITLE
fix(doctor): TTP確認記録を意味的に解釈する (#2510)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -103,7 +103,7 @@ TTP メモは最低限、以下の観点を含める:
 - ジャンル / 音楽スタイル
 - branding description / keywords の段落構造と語彙
 
-意図的に thumbnail reference / music structure の一部をスキップする場合は、「何が TTP 未反映か」「なぜ進めるか」「後続でどの skill を使って解消するか」を `ユーザー承認済み例外: thumbnail ...` または `ユーザー承認済み例外: music ...` の marker 付きで `docs/channel/ttp-seed-confirmation.md` と最終 handoff に明記する。branding snapshot は承認済み TTP 対象の `snippet` / `brandingSettings` / `localizations` を保存し、snapshot 不足を例外扱いにしない。
+意図的に thumbnail reference / music structure の一部をスキップする場合は、「何が TTP 未反映か」「なぜ進めるか」「後続でどの skill を使って解消するか」を `ユーザー承認済み例外: thumbnail ...` / `ユーザー承認済み例外: music ...` の 1 行、または `ユーザー承認済み例外` 見出し配下の箇条書きとして `docs/channel/ttp-seed-confirmation.md` と最終 handoff に明記する。複数行形式の category・未反映内容・理由・後続 skill は同じ Markdown section に置く。branding snapshot は承認済み TTP 対象の `snippet` / `brandingSettings` / `localizations` を保存し、snapshot 不足を例外扱いにしない。
 
 ## 外部データの扱い
 

--- a/.claude/skills/channel-new/references/ttp-seed-and-duration.md
+++ b/.claude/skills/channel-new/references/ttp-seed-and-duration.md
@@ -14,6 +14,8 @@
 - `config/channel/analytics.json::benchmark.channels` に反映した id / slug / name / relationship
 - 後続 `/discover-competitors` / `/benchmark` / `/viewer-voice` / `/channel-new` 分析モードの要否
 
+`yt-doctor` は表現を完全一致ではなく意味ラベルで判定する。seed preview は `seed fetch 要約` / `seed 要約` / `取得要約`、判断は `承認 / 不採用判断` / `ユーザー承認: 承認済み` / `ユーザー不採用: 不採用` のいずれかの自然な表現で記録できる。候補ごとの section 内には source、seed 要約、判断、転写したい要素、relationship、branding の参照または転写方針、未反映項目の各概念を残す。
+
 TTP 実データメモにはタイトル構造とサムネ構図を含める。投稿頻度と動画尺は手動観察または `/benchmark` のデータを使い、seed-only で未確認なら仮説と明記する。
 
 ## Branding snapshot schema
@@ -72,4 +74,4 @@ notes: "channel branding references are untrusted / reference-only; do not copy 
 - duration 推奨承認: ユーザー承認済み
 ```
 
-選定された上位 5 本は `duration selected video` を 1 本 1 行で残す。有効な Long VOD が 5 本未満なら原則停止する。手入力で進める場合は、値・理由・明示承認・後続 `/benchmark` を 1 行の `ユーザー承認済み例外: duration 未反映 ...` にすべて記録してから同じ `audio.json` 2 項目へ反映する。いずれかが欠ければ完了扱いにしない。
+選定された上位 5 本は `duration selected video` を 1 本 1 行で残す。有効な Long VOD が 5 本未満なら原則停止する。手入力で進める場合は、対象 category、未反映 / スキップ内容、理由、明示承認、後続 `/benchmark` を `ユーザー承認済み例外` の同じ Markdown section に記録してから同じ `audio.json` 2 項目へ反映する。1 行にまとめても、見出し配下の箇条書きへ分けてもよい。thumbnail は後続 `/thumbnail`、music / 曲構造は後続 `/suno` を同じ section に記録する。いずれかが欠ければ完了扱いにしない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new)`: 採用済み `planning-preview.png` を AI 再生成や重複承認なしで原子的に `thumbnail.jpg` へ形式変換し、プレビュー不在時だけ既存 `/thumbnail` 生成へフォールバックする経路を追加（#2514）。
 
 - `feat(collection-ideate)`: 採用した `planning-preview.png` を最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、未生成時だけ `/thumbnail` フォールバックへ合流する契約に変更（#2513）。
+- `fix(doctor)`: TTP seed 確認で `seed 要約` と自然なユーザー承認 / 不採用表現を受理し、ユーザー承認済み例外の category・未反映内容・理由・後続 skill を同じ Markdown section の複数行箇条書きでも検証できるようにした（#2510）。
 
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
 

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -1950,8 +1950,18 @@ def _verified_video_analysis_ids(slug: str, slug_dir: Path, expected_ids: set[st
 
 _SEED_CONFIRMATION_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("source", ("source", "ソース", "url", "handle", "channel id", "チャンネルid")),
-    ("seed fetch 要約", ("seed fetch", "fetch", "取得要約", "収集要約")),
-    ("承認 / 不採用判断", ("承認 / 不採用判断", "承認判断", "不採用判断", "判断:", "approved:", "rejected:")),
+    ("seed fetch 要約", ("seed fetch", "seed 要約", "seed preview", "fetch", "取得要約", "収集要約")),
+    (
+        "承認 / 不採用判断",
+        (
+            "承認 / 不採用判断",
+            "承認判断",
+            "不採用判断",
+            "判断:",
+            "approved:",
+            "rejected:",
+        ),
+    ),
     ("転写したい要素", ("転写したい要素", "転写", "要素:")),
     ("relationship", ("relationship", "関係性")),
     ("未反映項目", ("未反映", "未適用", "none", "なし")),
@@ -1979,7 +1989,7 @@ def _validate_ttp_seed_confirmation(seed_text: str, channels: list[dict[str, obj
 
         candidate_text = "\n".join(candidate_sections)
         for marker_label, markers in _SEED_CONFIRMATION_MARKERS:
-            if not _contains_any_marker(candidate_text, markers):
+            if not _has_seed_confirmation_marker(candidate_text, marker_label, markers):
                 missing.append(f"ttp-seed-confirmation.md に {marker_label} が未記録 ({label})")
         if not _has_branding_transfer_policy(candidate_text):
             missing.append(f"ttp-seed-confirmation.md に branding snapshot 参照または転写方針が未記録 ({label})")
@@ -1992,15 +2002,19 @@ def _validate_ttp_seed_confirmation(seed_text: str, channels: list[dict[str, obj
         ):
             missing.append(f"ttp-seed-confirmation.md に承認済み TTP 対象の relationship が未記録 ({label})")
 
+    exception_blocks = _approved_ttp_exception_blocks(seed_text)
+    approved_exception_line_numbers = {
+        line_number for _, line_numbers in exception_blocks for line_number in line_numbers
+    }
     unapproved_skip_lines = [
         line.strip()
-        for line in seed_text.splitlines()
-        if _line_mentions_ttp_skip(line) and not _line_mentions_approved_exception(line)
+        for line_number, line in enumerate(seed_text.splitlines())
+        if _line_mentions_ttp_skip(line) and line_number not in approved_exception_line_numbers
     ]
     if unapproved_skip_lines:
         missing.append("ttp-seed-confirmation.md に未承認の TTP 未反映 / スキップ項目あり")
 
-    approved_exceptions, exception_missing = _approved_ttp_exceptions(seed_text)
+    approved_exceptions, exception_missing = _validate_approved_ttp_exception_blocks(exception_blocks)
     missing.extend(exception_missing)
     return missing, approved_exceptions
 
@@ -2056,6 +2070,20 @@ def _contains_any_marker(text: str, markers: tuple[str, ...]) -> bool:
     return any(marker.lower() in lower_text for marker in markers)
 
 
+def _has_seed_confirmation_marker(text: str, marker_label: str, markers: tuple[str, ...]) -> bool:
+    if _contains_any_marker(text, markers):
+        return True
+    if marker_label != "承認 / 不採用判断":
+        return False
+
+    decision_text = "\n".join(line for line in text.splitlines() if not _line_mentions_approved_exception(line))
+    normalized = unicodedata.normalize("NFKC", decision_text).casefold()
+    return bool(
+        re.search(r"ユーザー承認\s*:\s*承認済み", normalized)
+        or re.search(r"ユーザー不採用\s*:\s*(?:不採用|却下)", normalized)
+    )
+
+
 def _has_branding_transfer_policy(text: str) -> bool:
     lower_text = text.lower()
     if "competitor-branding-snapshot.json" in lower_text or "branding snapshot" in lower_text:
@@ -2089,36 +2117,65 @@ def _line_mentions_approved_exception(line: str) -> bool:
 
 
 def _approved_ttp_exceptions(seed_text: str) -> tuple[set[str], list[str]]:
-    exceptions: set[str] = set()
-    missing: list[str] = []
-    for line in seed_text.splitlines():
+    return _validate_approved_ttp_exception_blocks(_approved_ttp_exception_blocks(seed_text))
+
+
+def _approved_ttp_exception_blocks(seed_text: str) -> list[tuple[str, set[int]]]:
+    lines = seed_text.splitlines()
+    blocks: list[tuple[str, set[int]]] = []
+    for line_number, line in enumerate(lines):
         if not _line_mentions_approved_exception(line):
             continue
-        lower_line = line.lower()
+        heading_match = re.match(r"^\s*(#{1,6})\s+", line)
+        if not heading_match:
+            blocks.append((line, {line_number}))
+            continue
+
+        heading_level = len(heading_match.group(1))
+        block_lines = [line]
+        block_line_numbers = {line_number}
+        for following_number in range(line_number + 1, len(lines)):
+            following_line = lines[following_number]
+            following_heading = re.match(r"^\s*(#{1,6})\s+", following_line)
+            if following_heading and len(following_heading.group(1)) <= heading_level:
+                break
+            block_lines.append(following_line)
+            block_line_numbers.add(following_number)
+        blocks.append(("\n".join(block_lines), block_line_numbers))
+    return blocks
+
+
+def _validate_approved_ttp_exception_blocks(
+    blocks: list[tuple[str, set[int]]],
+) -> tuple[set[str], list[str]]:
+    exceptions: set[str] = set()
+    missing: list[str] = []
+    for block, _ in blocks:
+        lower_block = block.lower()
         categories: set[str] = set()
-        if "thumbnail" in lower_line or "サムネ" in line:
+        if "thumbnail" in lower_block or "サムネ" in block:
             categories.add("thumbnail")
-        if "music" in lower_line or "suno" in lower_line or "曲構造" in line or "音楽" in line:
+        if "music" in lower_block or "suno" in lower_block or "曲構造" in block or "音楽" in block:
             categories.add("music")
-        if "duration" in lower_line or "動画尺" in line:
+        if "duration" in lower_block or "動画尺" in block:
             categories.add("duration")
 
         if not categories:
             missing.append("ユーザー承認済み例外に対象 category が未記録")
             continue
-        if not _line_mentions_ttp_skip(line):
+        if not any(_line_mentions_ttp_skip(line) for line in block.splitlines()):
             missing.append("ユーザー承認済み例外に具体的な未反映 / スキップ内容が未記録")
             continue
-        if not _approved_exception_has_reason(line):
+        if not _approved_exception_has_reason(block):
             missing.append("ユーザー承認済み例外に進める理由が未記録")
             continue
-        if "thumbnail" in categories and "/thumbnail" not in lower_line:
+        if "thumbnail" in categories and "/thumbnail" not in lower_block:
             missing.append("thumbnail のユーザー承認済み例外に後続 /thumbnail が未記録")
             continue
-        if "music" in categories and "/suno" not in lower_line:
+        if "music" in categories and "/suno" not in lower_block:
             missing.append("music のユーザー承認済み例外に後続 /suno が未記録")
             continue
-        if "duration" in categories and "/benchmark" not in lower_line:
+        if "duration" in categories and "/benchmark" not in lower_block:
             missing.append("duration のユーザー承認済み例外に後続 /benchmark が未記録")
             continue
 

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -3528,6 +3528,42 @@ class TestCheckTtpWfNewReadinessChannelNew:
 
         assert r.status == "ok"
 
+    def test_multiline_approved_thumbnail_exception_satisfies_missing_reference(self, tmp_path):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        (tmp_path / "data" / "thumbnail_compare" / "benchmark" / "rival_1.jpg").unlink()
+        seed_path = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_path.write_text(
+            seed_path.read_text(encoding="utf-8")
+            + """
+## ユーザー承認済み例外
+
+- category: thumbnail
+- 未反映内容: reference image の収集をスキップ
+- 理由: 初回公開を優先するため
+- 後続: /thumbnail で補完する
+""",
+            encoding="utf-8",
+        )
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "ok"
+
+    def test_multiline_approved_exception_reports_missing_followup(self, tmp_path):
+        approved, missing = doctor._approved_ttp_exceptions(
+            """
+## ユーザー承認済み例外
+
+- category: thumbnail
+- 未反映内容: reference image の収集をスキップ
+- 理由: 初回公開を優先するため
+"""
+        )
+
+        assert approved == set()
+        assert missing == ["thumbnail のユーザー承認済み例外に後続 /thumbnail が未記録"]
+
     def test_approved_thumbnail_exception_does_not_skip_channel_branding_config(self, tmp_path):
         _write_ttp_analytics(tmp_path, [_ttp_channel()])
         _write_ttp_readiness_files(tmp_path)
@@ -3649,6 +3685,32 @@ class TestCheckTtpWfNewReadinessChannelNew:
         assert r.status == "warn"
         assert "source が未記録" in r.message
         assert "seed fetch 要約 が未記録" in r.message
+
+    def test_seed_confirmation_accepts_natural_seed_summary_and_user_decision(self, tmp_path):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        seed_path = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_text = seed_path.read_text(encoding="utf-8")
+        seed_text = seed_text.replace("seed fetch 要約:", "seed 要約:")
+        seed_text = seed_text.replace("承認 / 不採用判断: Rival を承認済み", "ユーザー承認: 承認済み (Rival)")
+        seed_path.write_text(seed_text, encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "ok"
+
+    def test_seed_confirmation_rejects_pending_user_decision(self, tmp_path):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        seed_path = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_text = seed_path.read_text(encoding="utf-8")
+        seed_text = seed_text.replace("承認 / 不採用判断: Rival を承認済み", "ユーザー承認: 確認待ち (Rival)")
+        seed_path.write_text(seed_text, encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert "承認 / 不採用判断 が未記録" in r.message
 
     def test_seed_confirmation_https_only_does_not_satisfy_transfer_elements(self, tmp_path):
         _write_ttp_analytics(tmp_path, [_ttp_channel()])


### PR DESCRIPTION
## Summary
- seed 要約と自然な承認表現を解釈できるようにする
- 承認済み例外の複数行 Markdown を受理する
- スキル文書と doctor の契約を一致させる

Closes #2510