### PR TITLE
fix(doctor): 承認済みサムネ例外を初期検査へ反映 (#2509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
+
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
 
 - `feat(workspace)`: 下流の Edit/Write hook でチャンネル関連 path だけを事前抽出し、workspace 境界判定 CLI の拒否理由と exit code をエージェントへ返すようにした（#3371）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -2795,11 +2795,27 @@ def _suno_music_readiness(channel_dir: Path, channels: list[dict[str, object]]) 
 def check_initial_setup_readiness(channel_dir: Path) -> CheckResult:
     issues: list[str] = []
 
+    approved_exceptions: set[str] = set()
+    seed_confirmation = channel_dir / "docs" / "channel" / "ttp-seed-confirmation.md"
+    if seed_confirmation.is_file():
+        try:
+            seed_text = seed_confirmation.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            issues.append(f"docs/channel/ttp-seed-confirmation.md 読み込み失敗: {exc}")
+        else:
+            approved_exceptions, _ = _approved_ttp_exceptions(seed_text)
+
     thumbnail_cfg, thumbnail_error = _load_skill_config_for_channel("thumbnail", channel_dir)
     if thumbnail_error:
         issues.append(thumbnail_error)
     else:
-        issues.extend(check_thumbnail_skill_config(channel_dir, thumbnail_cfg))
+        issues.extend(
+            check_thumbnail_skill_config(
+                channel_dir,
+                thumbnail_cfg,
+                skip_reference_images="thumbnail" in approved_exceptions,
+            )
+        )
 
     suno_cfg, suno_error = _load_skill_config_for_channel("suno", channel_dir)
     if suno_error:

--- a/src/youtube_automation/domains/uploads/preflight.py
+++ b/src/youtube_automation/domains/uploads/preflight.py
@@ -132,14 +132,19 @@ def check_suno_genre_line_char_limit(suno_cfg: Mapping[str, object]) -> str | No
     )
 
 
-def check_thumbnail_skill_config(channel_dir: Path, thumbnail_cfg: Mapping[str, object]) -> list[str]:
+def check_thumbnail_skill_config(
+    channel_dir: Path,
+    thumbnail_cfg: Mapping[str, object],
+    *,
+    skip_reference_images: bool = False,
+) -> list[str]:
     """thumbnail skill-config の初期セットアップ漏れを検出する."""
     image_generation = _as_mapping(thumbnail_cfg.get("image_generation"))
     gemini = _as_mapping(image_generation.get("gemini"))
     generation_mode = str(gemini.get("generation_mode") or "single_step").strip()
 
     issues: list[str] = []
-    if generation_mode == "single_step":
+    if generation_mode == "single_step" and not skip_reference_images:
         single_step = _as_mapping(gemini.get("single_step"))
         max_attempts = _positive_int(single_step.get("max_attempts"), default=1)
         rotate = _bool(single_step.get("rotate"), default=True)

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1927,6 +1927,63 @@ class TestCheckInitialSetupReadiness:
 
         assert r.status == "ok"
 
+    def test_approved_thumbnail_exception_allows_non_benchmark_reference(self, tmp_path):
+        ref = tmp_path / "branding" / "proven-thumbnail.jpg"
+        ref.parent.mkdir(parents=True)
+        ref.write_bytes(b"jpg")
+        skills_dir = tmp_path / "config" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "thumbnail.yaml").write_text(
+            "\n".join(
+                [
+                    "image_generation:",
+                    "  gemini:",
+                    "    generation_mode: single_step",
+                    "    reference_images:",
+                    "      default:",
+                    "        - branding/proven-thumbnail.jpg",
+                    "      path_base: channel_dir",
+                    "    composition_rules:",
+                    '      text_lines: "2 lines"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (skills_dir / "suno.yaml").write_text('genre_line: "lo-fi jazz"\n', encoding="utf-8")
+        seed_confirmation = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_confirmation.parent.mkdir(parents=True)
+        seed_confirmation.write_text(
+            "- 未反映項目: ユーザー承認済み例外: thumbnail reference は実績画像を使うため"
+            "後続 /thumbnail で確認し、benchmark path への転写はスキップ\n",
+            encoding="utf-8",
+        )
+
+        r = doctor.check_initial_setup_readiness(tmp_path)
+
+        assert r.status == "ok"
+
+    def test_approved_thumbnail_exception_keeps_composition_validation(self, tmp_path):
+        skills_dir = tmp_path / "config" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "thumbnail.yaml").write_text(
+            "image_generation:\n  gemini:\n    composition_rules:\n      text_lines: TBD\n",
+            encoding="utf-8",
+        )
+        (skills_dir / "suno.yaml").write_text('genre_line: "lo-fi jazz"\n', encoding="utf-8")
+        seed_confirmation = tmp_path / "docs" / "channel" / "ttp-seed-confirmation.md"
+        seed_confirmation.parent.mkdir(parents=True)
+        seed_confirmation.write_text(
+            "- 未反映項目: ユーザー承認済み例外: thumbnail reference は実績画像を使うため"
+            "後続 /thumbnail で確認し、benchmark path への転写はスキップ\n",
+            encoding="utf-8",
+        )
+
+        r = doctor.check_initial_setup_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert "composition_rules" in r.message
+        assert "reference_images.default" not in r.message
+
     def test_descriptions_md_symlink_escape_warns_without_reading_external_heading(self, tmp_path):
         outside = tmp_path.parent / f"{tmp_path.name}-outside"
         outside_desc = outside / "descriptions.md"


### PR DESCRIPTION
## Summary
- initial_setup_readiness で thumbnail 承認例外を尊重する
- 参照画像検査だけを省略し composition 検査は維持する
- doctor の非対称な判定を回帰テストで固定する

Closes #2509