### PR TITLE
feat(suno): duration_sec を既知の任意設定として登録 (#2506)

### DIFF
--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -123,7 +123,7 @@ tracks_per_collection: 20
 # Suno helper の Custom Duration へ渡す collection 共通の目標尺（秒）。
 # channel override に正の整数を明示した場合だけ全 prompt entry へ出力し、未設定時はキーを省略する。
 # 生成後 clip の採用範囲を決める duration_filter とは独立し、自動推定・同期しない。
-# duration_sec: 180
+duration_sec: null
 
 # Suno helper の playlist 採用判定に使う collection 単位 duration guard（秒）。
 # 生成された clip がこの範囲外なら playlist 追加対象から除外される。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(suno-helper)`: prompt entry の `duration_sec` が明示された場合、解決済みの Custom Duration button を押してから既存の bridge-first / keydown fallback 経路で Duration slider へ秒数を注入するようにした（#3160）。
 - `feat(suno-helper)`: prompt entry の optional な `duration_sec` を wire 型で受理し、明示された数値を失わず保持するようにした（#3153）。
 - `docs(suno)`: optional な `duration_sec` の単位・値域・明示時のみ全 entry へ出力する契約と、生成後の採用範囲を担う `duration_filter` との責務分離を配布設定と Suno 手順へ記載した（#3133）。
-- `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#3132）。
+- `feat(suno)`: channel override に明示した `duration_sec` を、既定値や `duration_filter` から補完せず全 prompt entry へ数値として出力するようにした（#2506, #3132）。
 - `feat(suno)`: channel override の `duration_sec` を正の整数に限定し、bool・文字列・float・非有限値・0 以下を prompt 生成前に `ConfigError` で拒否する検証境界を追加した（#3131）。
 - `docs(streaming)`: `/streaming` の Quick Reference にチャンネル別 Terraform workspace の確認・作成・切替入口を追加し、切替後のチャンネル固有 `TF_VAR_*` 再注入と README 正本への導線を明示した（#3184）。
 - `refactor(skill-feedback)`: legacy `/feedback` entrypoint を廃止し、canonical `/skill-feedback` のみを公開するようにした（#3190）。

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -1159,6 +1160,30 @@ def test_main_json_output_is_loadable_array_of_entries(channel_dir, tmp_path, mo
     assert len(data["entries"]) == 1
     # #900: strict 等価から subset 検証へ緩和 (build_prompt_entries 側の relaxation と同様)。
     assert {"name", "style", "lyrics"} <= set(data["entries"][0])
+
+
+def test_main_json_output_applies_duration_sec_to_every_entry(channel_dir, tmp_path, monkeypatch):
+    """明示した duration_sec を CLI が生成する全 JSON entry へ数値で出力する。"""
+    _write_suno_override(
+        channel_dir,
+        genre_line="dream pop vocals",
+        duration_sec=180,
+    )
+    patterns_path = _write_vocal_patterns(tmp_path, ["scene one", "scene two"])
+    _write_suno_lyrics_json(
+        tmp_path,
+        ["歌もの — Vocal (Variation 1)", "歌もの — Vocal (Variation 2)"],
+    )
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        main()
+
+    data = json.loads((patterns_path.parent / "suno-prompts.json").read_text(encoding="utf-8"))
+    assert [entry["duration_sec"] for entry in data["entries"]] == [180, 180]
+    assert all(isinstance(entry["duration_sec"], int) for entry in data["entries"])
+    assert not [warning for warning in caught if "duration_sec" in str(warning.message)]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- duration_sec を既知の optional skill 設定として登録する
- 未設定時は prompt entry への出力を省略する
- 全 entry への数値反映と警告抑止を回帰テストで固定する

Closes #2506