### PR TITLE
feat(collection-ideate): 採用プレビューを最終サムネへ引き渡す (#2513)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -14,7 +14,7 @@ description: "Use when 新コレクションの企画・テーマ選定をデー
 
 ## 完了条件
 
-企画候補をコレクションの `20-documentation/plan_proposals.md` に保存し、`workflow-state.json` の `planning.generated = true` へ更新（企画確定時は `planning.final_title` も記録）し、Next Step（`/thumbnail <theme>` → `/suno <theme>`）を案内した時点で完了。open insights を企画入力にした場合は、「open insights の消費と status 反映」に従う企画確定時の status 更新（adopted / dismissed）まで完了扱いにしない。画像生成を実施した場合は、採用企画の参照画像を `20-documentation/thumbnail-prompts.md` の `Reference Assignments` へ保存できるまで完了扱いにせず、保存失敗時は停止する。
+企画候補をコレクションの `20-documentation/plan_proposals.md` に保存し、`workflow-state.json` の `planning.generated = true` へ更新（企画確定時は `planning.final_title` も記録）し、採用画像がある場合は最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、無い場合は `/thumbnail <theme>` フォールバックを案内してから `/suno <theme>` へ進む Next Step を示した時点で完了。open insights を企画入力にした場合は、「open insights の消費と status 反映」に従う企画確定時の status 更新（adopted / dismissed）まで完了扱いにしない。画像生成を実施した場合は、採用企画の参照画像を `20-documentation/thumbnail-prompts.md` の `Reference Assignments` へ保存できるまで完了扱いにせず、保存失敗時は停止する。
 
 **JSON ペア検証 Hard Gate**: `references/freshness-rules.md` の鮮度判定へ進む前に、ファイル名日付が最新の `reports/analysis_*.md` と同日付の `.json` の存在を確認し、`.claude/skills/analytics-analyze/references/analysis-json-validator.md` の validator を同日付 JSON に実行する。exit 0 の場合だけ analytics mode の入力として使用する。Markdown だけが存在する、または validator が失敗した場合は必須入力不足として中断し、`/analytics-analyze` 再実行を案内する。
 
@@ -441,7 +441,7 @@ sequential モードでは Next Step で stock 退避は走らない（不採用
 
 企画選択時にタイトルも確定する（`workflow-state.json` の `planning.final_title` に記録）。
 
-企画確定後は `thumbnail_mode` と画像の有無で分岐する。採用画像は企画参照へ保存し、**`main.png` にはコピーしない**。不可逆操作は、参照割当の保存 → 採用画像のコピー → 不採用画像の stock 退避 → セッション cleanup の順で実行する。
+企画確定後は `thumbnail_mode` と画像の有無で分岐する。採用画像は `planning-preview.png` に保存し、最終 `thumbnail.jpg` の正規入力として後段へ引き渡す。**`main.png` にはコピーしない**。不可逆操作は、参照割当の保存 → 採用画像のコピー → 不採用画像の stock 退避 → セッション cleanup の順で実行する。
 
 画像生成を実施した場合、企画確定後かつプレビューディレクトリ削除前に、今回使用した参照割当を collection の履歴へ必ず保存する。保存に失敗した場合は処理を継続せず、エラーを解消して同じコマンドを再実行する。
 
@@ -457,7 +457,7 @@ uv run python3 .claude/skills/collection-ideate/references/record-ttp-reference-
 不採用 (`candidate_count` - 1) 枚を `assets/stock/<theme>/` に退避してからプレビューディレクトリを削除する（#364）:
 
 ```bash
-# 1. 選択した企画のプレビュー画像を企画参照として保存（最終背景 main.png にはしない）
+# 1. 選択した企画のプレビュー画像を最終 thumbnail.jpg の正規入力として保存（main.png にはしない）
 cp collections/planning/_plan-previews/<session-dir>/plan-<x>-<slug>.png <collection-path>/10-assets/planning-preview.png
 
 # 2. 不採用プレビューを stock 退避（--exclude で採用 1 枚だけ除外）
@@ -488,7 +488,7 @@ rm -rf collections/planning/_plan-previews/<session-dir>/
 不採用 (`candidate_count` - 1) 案は画像が未生成なので stock 退避は不要。`cp` 1 回 + `rm -rf` だけで済む:
 
 ```bash
-# 1. 選択した企画のプレビュー画像を企画参照として保存（最終背景 main.png にはしない）
+# 1. 選択した企画のプレビュー画像を最終 thumbnail.jpg の正規入力として保存（main.png にはしない）
 cp collections/planning/_plan-previews/<session-dir>/plan-<x>-<slug>.png <collection-path>/10-assets/planning-preview.png
 
 # 2. セッションディレクトリ削除
@@ -505,8 +505,10 @@ rm -rf collections/planning/_plan-previews/<session-dir>/
 [ -d collections/planning/_plan-previews/<session-dir> ] && rm -rf collections/planning/_plan-previews/<session-dir>/
 ```
 
-このケースも下記「企画選択後」へ合流する。
+このケースは `planning-preview.png` が無い状態を後段へ明示的に引き渡し、`/thumbnail <theme>` フォールバックへ合流する。
 
 企画選択後:
-- `/thumbnail <theme>` で、テキスト付き `thumbnail.jpg` を先に確定し、承認済み `thumbnail.jpg` から textless `main.png/jpg` を別成果物として再生成・確定する。企画プレビューは参照素材であり、`main.png` として動画背景に流用しない
+- `planning-preview.png` がある場合は、後段がその画像を最終 `thumbnail.jpg` に確定する正規入力として使い、`/thumbnail` フォールバックへは進まない
+- `planning-preview.png` が無い場合だけ `/thumbnail <theme>` フォールバックで `thumbnail.jpg` を生成・確定する
+- どちらの場合も採用プレビューを `main.png/jpg` へ直接コピーしない。textless `main.png/jpg` は後段の生成契約に従い別成果物として確定する
 - サムネイル確定後に `/suno <theme>` で SunoAI 音楽プロンプト生成（テーマ確定後に初めて実行）

--- a/.claude/skills/collection-ideate/config.default.yaml
+++ b/.claude/skills/collection-ideate/config.default.yaml
@@ -50,7 +50,8 @@ preview:
   # サムネイル生成タイミング (#354 / #450)
   # 案数 N = candidate_count (下記キー)。
   # - parallel (デフォルト): テキスト N 案 → 確認 → N 枚一括生成 → 比較選択 → 採用 1 枚 planning-preview.png + 残り stock 退避
-  #   planning-preview.png は企画参照素材。最終 thumbnail.jpg と textless main.png/jpg は後段 /thumbnail で別生成する。
+  #   planning-preview.png は最終 `thumbnail.jpg` の正規入力として後段へ引き渡す。
+  #   採用プレビューを `main.png/jpg` へ直接コピーせず、textless 背景は後段で別成果物として確定する。
   # - sequential: テキスト N 案 → 選択 → 選択 1 案だけ生成 (コスト 1/N の opt-in)
   thumbnail_mode: parallel
   # 1 回の /collection-ideate で生成する企画候補数 (テキスト案数 = 生成枚数)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
 - `fix(suno-helper)`: downloaded POST 失敗の endpoint と download phase を overlay の中断表示と無人実行の `required-action` へ保持し、token 取得先で起点 request を覆わないエラー契約を固定（#3001）。
+- `feat(collection-ideate)`: 採用した `planning-preview.png` を最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、未生成時だけ `/thumbnail` フォールバックへ合流する契約に変更（#2513）。
 
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
 

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -1009,6 +1009,34 @@ def test_collection_ideate_persists_only_the_adopted_reference_after_selection()
     assert '"$COLLECTION_PATH" "${REF_PATHS[$REF_INDEX]}"' in next_step
 
 
+def test_collection_ideate_hands_adopted_preview_to_final_thumbnail_contract() -> None:
+    ideate_dir = _repo_root() / ".claude" / "skills" / "collection-ideate"
+    skill = (ideate_dir / "SKILL.md").read_text(encoding="utf-8")
+    config = (ideate_dir / "config.default.yaml").read_text(encoding="utf-8")
+
+    next_step = _slice_between(skill, "## Next Step", "### コスト拒否 / 生成失敗で企画参照画像が無い場合")
+
+    assert "最終 `thumbnail.jpg` の正規入力" in next_step
+    assert "最終 `thumbnail.jpg` の正規入力" in config
+    assert "企画参照素材" not in next_step
+    assert "企画参照素材" not in config
+    assert "別の文字入り候補" not in next_step
+    assert "`main.png` にはコピーしない" in next_step
+
+
+def test_collection_ideate_routes_missing_preview_to_thumbnail_fallback() -> None:
+    skill = (_repo_root() / ".claude" / "skills" / "collection-ideate" / "SKILL.md").read_text(encoding="utf-8")
+
+    no_image = _slice_between(
+        skill,
+        "### コスト拒否 / 生成失敗で企画参照画像が無い場合",
+        "企画選択後:",
+    )
+
+    assert "`/thumbnail <theme>` フォールバック" in no_image
+    assert "planning-preview.png コピーはスキップ" in no_image
+
+
 def test_collection_ideate_parallel_generation_failure_continues_to_later_candidates(tmp_path: Path) -> None:
     references = [tmp_path / "fail.jpg", tmp_path / "success.jpg"]
 


### PR DESCRIPTION
## Summary
- planning-preview.png を最終 thumbnail.jpg の正規入力として引き渡す
- 未生成時だけ /thumbnail フォールバックへ合流する
- main.png/jpg の非コピー契約を維持する

Closes #2513