### PR TITLE
fix(suno-helper): 無人実行にdownload失敗理由を保持 (#3001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
+- `fix(suno-helper)`: downloaded POST 失敗の endpoint と download phase を overlay の中断表示と無人実行の `required-action` へ保持し、token 取得先で起点 request を覆わないエラー契約を固定（#3001）。
 
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
 

--- a/extensions/suno-helper/lib/unattended-run.ts
+++ b/extensions/suno-helper/lib/unattended-run.ts
@@ -489,12 +489,17 @@ export function nextUnattendedRunState(options: {
     };
   }
   if (progress.phase === PHASE.ERROR) {
-    const stopReason = classifyUnattendedStop(progress.message ?? "run error");
+    const message = progress.message ?? "run error";
+    const stopReason = classifyUnattendedStop(message);
+    const requiredAction = requiredActionFor(stopReason);
     return {
       ...common,
       status: "manual-intervention",
       stopReason,
-      requiredAction: requiredActionFor(stopReason),
+      requiredAction:
+        stopReason === "run-error"
+          ? `${message} / ${requiredAction}`
+          : requiredAction,
     };
   }
   return { ...common, status: "running" };

--- a/extensions/suno-helper/tests/background-handlers.test.ts
+++ b/extensions/suno-helper/tests/background-handlers.test.ts
@@ -1831,8 +1831,11 @@ describe('background onMessage("postDownloaded"): privileged POST boundary', () 
   });
 
   it("Given shared api rejects When handler runs Then rejection を呼び出し側へ伝播する", async () => {
+    const apiError = new Error(
+      "POST /collections/coll-1/downloaded failed: 403 Forbidden"
+    );
     const { handlers } = await loadBackground({
-      postDownloadedError: new Error("POST downloaded failed: 403 Forbidden"),
+      postDownloadedError: apiError,
     });
 
     await expect(
@@ -1848,7 +1851,11 @@ describe('background onMessage("postDownloaded"): privileged POST boundary', () 
         },
         sender: { tab: { id: 42 } },
       })
-    ).rejects.toThrow("403");
+    ).rejects.toBe(apiError);
+    expect(apiError.message).toBe(
+      "POST /collections/coll-1/downloaded failed: 403 Forbidden"
+    );
+    expect(apiError.message).not.toContain("GET /auth/token");
   });
 
   it("Given sender tab が無い When handler runs Then shared api に委譲しない", async () => {

--- a/extensions/suno-helper/tests/phase-to-status.test.ts
+++ b/extensions/suno-helper/tests/phase-to-status.test.ts
@@ -110,6 +110,22 @@ describe("phaseToStatus: 終了 phase の文言と error フラグ", () => {
     expect(result.error).toBe(true);
   });
 
+  it("Given downloaded POST の 403 When phaseToStatus Then endpoint と downloading phase だけを中断理由に表示する", () => {
+    const result = statusOf({
+      phase: PHASE.ERROR,
+      index: 1,
+      total: 3,
+      message:
+        "POST /collections/collection/downloaded failed: 403 Forbidden (phase=downloading)",
+    });
+
+    expect(result.text).toBe(
+      "中断: POST /collections/collection/downloaded failed: 403 Forbidden (phase=downloading)"
+    );
+    expect(result.text).not.toContain("GET /auth/token");
+    expect(result.error).toBe(true);
+  });
+
   it("Given ERROR (message 無し) When phaseToStatus Then message 部は空文字で握りつぶさず表示する", () => {
     const result = statusOf({ phase: PHASE.ERROR, index: 1, total: 3 });
 

--- a/extensions/suno-helper/tests/unattended-run.test.ts
+++ b/extensions/suno-helper/tests/unattended-run.test.ts
@@ -372,6 +372,32 @@ describe("nextUnattendedRunState", () => {
     });
   });
 
+  it("downloaded POST の失敗理由を無人実行の required action へ保持する", () => {
+    const message =
+      "POST /collections/collection/downloaded failed: 403 Forbidden (phase=downloading)";
+
+    const state = nextUnattendedRunState({
+      request: REQUEST,
+      progress: {
+        phase: "error",
+        index: 5,
+        total: 5,
+        message,
+      },
+      deferredIndices: [],
+      now: 2000,
+    });
+
+    expect(state).toMatchObject({
+      status: "manual-intervention",
+      checkpoint: "entries",
+      stopReason: "run-error",
+      message,
+    });
+    expect(state.requiredAction).toContain(message);
+    expect(state.requiredAction).not.toContain("GET /auth/token");
+  });
+
   it("marks the run complete only after the terminal phase", () => {
     expect(
       nextUnattendedRunState({


### PR DESCRIPTION
## Summary
- download 失敗の endpoint と phase を overlay に保持する
- unattended required-action に失敗理由を伝播する
- phase/status 表示契約を回帰テストで固定する

Closes #3001