### PR TITLE
feat(suno-helper): Duration指定をUIへ確実に反映する (#2507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `fix(suno-helper)`: `duration_sec` 指定時に Duration の Custom button と slider を実 DOM から解決し、UI 公開範囲外・selector 不在・操作不受理・読戻し不一致では Generate 前に原因付きで停止するようにした。未指定 entry の UI 状態は変更しない（#2507）。
 - `docs(site)`: 公開サイトをリリースノート専用から下流運用者向けドキュメントへ拡張し、「はじめる」「使う」「リリースノート」の目的別 navigation に統一した。`ONBOARDING.md`、`docs/oauth-setup.md`、`docs/features.md`、`docs/workflow-cheatsheet.md`、`docs/chrome-extension-install-guide.md`、`docs/dashboard.md`、`docs/channel-workspace-migration.md` の7原本を read-in-place allowlist で掲載し、allowlist 内リンクは公開 route、掲載外の運用資料は GitHub 原本へ fallback する。ADR・audit・内部運用資料は公開境界の外に維持し、Cloudflare Pages の watch 設定と preview 受け入れ手順を更新した（#3579、#3580、#3581、#3582）。
 - `docs(automation-release)`: Python 本体と Chrome 拡張の GitHub Release publish 完了後、同一 release 情報から公開リリースノート案を生成し、明示承認後だけ branch protection 下の専用 PR へ載せる post-release flow を追加した。site は PR pending とし、merge 後に production 公開される。既存の Python / extension publish contract は変更しない（#3586）。
 - `feat(suno-helper)`: prompt entry の `duration_sec` が明示された場合、解決済みの Custom Duration button を押してから既存の bridge-first / keydown fallback 経路で Duration slider へ秒数を注入するようにした（#3160）。

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -34,6 +34,8 @@ const SELECTORS = {
   weirdness:
     '[role="slider"][aria-label*="weirdness" i], [role="slider"][aria-label*="bizarre" i]',
   styleInfluence: '[role="slider"][aria-label*="influence" i]',
+  duration: '[role="slider"][aria-label*="duration" i]',
+  durationButtons: 'button[type="button"]',
   // Voice section の Male / Female ボタン (chrome-devtools-mcp 実機検証で確認)。
   // aria-label / data-testid を持たないため、`data-selected` 属性 (Suno が排他トグル用に意図して
   // 付けた属性) で候補を全 query → textContent 完全一致で Male/Female を絞り込む方式を採用。
@@ -48,7 +50,7 @@ const SELECTORS = {
 const SLIDER_READBACK_POLL_MS = 100;
 /** step ごとの読み戻し検証の最大 poll 回数。これを超えても不変なら fail-loud で throw。 */
 const SLIDER_READBACK_MAX_POLLS = 5;
-/** slider が target に到達するまでの最大 step 数。Suno slider は 0-100 整数なので余裕を持たせた上限。 */
+/** slider が target に到達するまでの最小 step 上限。大きい値域では初期差分から拡張する。 */
 const SLIDER_MAX_STEPS = 150;
 
 /**
@@ -492,6 +494,10 @@ export async function setSliderValue(
 ): Promise<void> {
   slider.focus();
   const read = (): number => Number(slider.getAttribute("aria-valuenow"));
+  const maxSteps = Math.max(
+    SLIDER_MAX_STEPS,
+    Math.ceil(Math.abs(target - read())) * 2
+  );
   const fail = (): never => {
     throw new Error(
       `slider 値の注入に失敗しました（target=${target}, actual=${slider.getAttribute("aria-valuenow")}, ` +
@@ -499,7 +505,7 @@ export async function setSliderValue(
         "keydown 後も aria-valuenow が変化しませんでした。Suno の UI 変更の可能性があります。"
     );
   };
-  for (let step = 0; step < SLIDER_MAX_STEPS; step++) {
+  for (let step = 0; step < maxSteps; step++) {
     const current = read();
     if (current === target) {
       return;
@@ -527,7 +533,7 @@ export async function setSliderValue(
   }
 }
 
-/** More Options の advanced フィールド解決結果（#900, vocal gender 追加）。不在は null（fail-soft）。 */
+/** More Options の advanced フィールド解決結果（#900, vocal gender / Duration 追加）。 */
 export interface ResolvedAdvancedFields {
   excludeStyles: HTMLInputElement | HTMLTextAreaElement | null;
   weirdness: HTMLElement | null;
@@ -563,6 +569,37 @@ function pickPreferVisible<T extends HTMLElement>(els: T[]): T | null {
   return els.find(isVisible) ?? els[0] ?? null;
 }
 
+function domDistance(first: HTMLElement, second: HTMLElement): number {
+  const firstAncestors = new Map<HTMLElement, number>();
+  let distance = 0;
+  for (let node: HTMLElement | null = first; node; node = node.parentElement) {
+    firstAncestors.set(node, distance++);
+  }
+  distance = 0;
+  for (let node: HTMLElement | null = second; node; node = node.parentElement) {
+    const firstDistance = firstAncestors.get(node);
+    if (firstDistance !== undefined) {
+      return firstDistance + distance;
+    }
+    distance++;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+function pickClosestPreferVisible<T extends HTMLElement>(
+  reference: HTMLElement,
+  candidates: T[]
+): T | null {
+  const visible = candidates.filter(isVisible);
+  const pool = visible.length > 0 ? visible : candidates;
+  return (
+    pool.toSorted(
+      (left, right) =>
+        domDistance(reference, left) - domDistance(reference, right)
+    )[0] ?? null
+  );
+}
+
 /**
  * Advanced タブ > More Options の 3 フィールドを解決する（#900）。
  * visible 優先、なければ DOM 上の最初の要素を返す（collapsed 時の null 化を回避）。
@@ -583,12 +620,24 @@ export function resolveAdvancedFields(): ResolvedAdvancedFields {
   const styleInfluence = pickPreferVisible(
     Array.from(document.querySelectorAll<HTMLElement>(SELECTORS.styleInfluence))
   );
+  const durationSlider = pickPreferVisible(
+    Array.from(document.querySelectorAll<HTMLElement>(SELECTORS.duration))
+  );
+  const durationCustomButtons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>(SELECTORS.durationButtons)
+  ).filter((button) => button.textContent?.trim().toLowerCase() === "custom");
+  const durationCustomButton = durationSlider
+    ? pickClosestPreferVisible(durationSlider, durationCustomButtons)
+    : null;
   return {
     excludeStyles,
     weirdness,
     styleInfluence,
     vocalGender: resolveVocalGenderButtons(),
-    duration: null,
+    duration:
+      durationSlider && durationCustomButton
+        ? { customButton: durationCustomButton, slider: durationSlider }
+        : null,
   };
 }
 
@@ -668,6 +717,35 @@ async function injectSliderValue(
   await setSliderValue(slider, target);
 }
 
+function readDurationSliderAttribute(
+  slider: HTMLElement,
+  attribute: "aria-valuemin" | "aria-valuemax" | "aria-valuenow"
+): number {
+  const raw = slider.getAttribute(attribute);
+  const value = raw === null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new FatalRunError(
+      `Duration slider の ${attribute} が有効な数値ではありません。Suno の UI 変更の可能性があります。`
+    );
+  }
+  return value;
+}
+
+function validateDurationTarget(slider: HTMLElement, target: number): void {
+  const min = readDurationSliderAttribute(slider, "aria-valuemin");
+  const max = readDurationSliderAttribute(slider, "aria-valuemax");
+  if (
+    !Number.isInteger(target) ||
+    target <= 0 ||
+    target < min ||
+    target > max
+  ) {
+    throw new FatalRunError(
+      `Duration ${target} 秒は UI の対応範囲 ${min}〜${max} 秒外です。値を範囲内の正の整数へ変更してください。`
+    );
+  }
+}
+
 export async function injectAdvancedFields(
   entry: AdvancedFieldValues,
   fields: ResolvedAdvancedFields,
@@ -695,13 +773,28 @@ export async function injectAdvancedFields(
       target.click();
     }
   }
-  if (entry.duration_sec !== undefined && fields.duration) {
+  if (entry.duration_sec !== undefined) {
+    if (!fields.duration) {
+      throw new FatalRunError(
+        "Duration の Custom button または slider が見つかりません。Suno の「書く」モードでその他のオプションを開いてから再実行してください。"
+      );
+    }
+    validateDurationTarget(fields.duration.slider, entry.duration_sec);
     fields.duration.customButton.click();
     await injectSliderValue(
       fields.duration.slider,
       entry.duration_sec,
       options.bridgeSetSlider
     );
+    const actual = readDurationSliderAttribute(
+      fields.duration.slider,
+      "aria-valuenow"
+    );
+    if (actual !== entry.duration_sec) {
+      throw new FatalRunError(
+        `Duration slider の読戻し値 ${actual} 秒が指定値 ${entry.duration_sec} 秒と一致しません。生成を停止します。`
+      );
+    }
   }
   if (entry.weirdness != null) {
     // slider 未検出は throw せず warn + skip（#1720）。値は UI で手動設定でき Create を跨いで

--- a/extensions/shared/dom.ts
+++ b/extensions/shared/dom.ts
@@ -746,96 +746,113 @@ function validateDurationTarget(slider: HTMLElement, target: number): void {
   }
 }
 
+function injectExcludeStyles(
+  value: string | undefined,
+  field: HTMLInputElement | HTMLTextAreaElement | null
+): void {
+  if (value === undefined) {
+    return;
+  }
+  if (!field) {
+    throw new FatalRunError(
+      "Exclude styles 欄が見つかりません。Suno の「書く」モードでその他のオプションを開いてから再実行してください。"
+    );
+  }
+  setNativeValue(field, value);
+}
+
+function injectVocalGender(
+  value: AdvancedFieldValues["vocal_gender"],
+  fields: ResolvedAdvancedFields["vocalGender"]
+): void {
+  if (value !== "male" && value !== "female") {
+    return;
+  }
+  const target = value === "male" ? fields.male : fields.female;
+  if (!target) {
+    throw new FatalRunError(
+      `Vocal gender button (${value}) が見つかりません。Suno の UI 変更の可能性があります。`
+    );
+  }
+  if (target.getAttribute("data-selected") !== "true") {
+    target.click();
+  }
+}
+
+async function injectDuration(
+  value: number | undefined,
+  fields: ResolvedAdvancedFields["duration"],
+  bridgeSetSlider: AdvancedInjectOptions["bridgeSetSlider"]
+): Promise<void> {
+  if (value === undefined) {
+    return;
+  }
+  if (!fields) {
+    throw new FatalRunError(
+      "Duration の Custom button または slider が見つかりません。Suno の「書く」モードでその他のオプションを開いてから再実行してください。"
+    );
+  }
+  validateDurationTarget(fields.slider, value);
+  fields.customButton.click();
+  await injectSliderValue(fields.slider, value, bridgeSetSlider);
+  const actual = readDurationSliderAttribute(fields.slider, "aria-valuenow");
+  if (actual !== value) {
+    throw new FatalRunError(
+      `Duration slider の読戻し値 ${actual} 秒が指定値 ${value} 秒と一致しません。生成を停止します。`
+    );
+  }
+}
+
+type OptionalSliderName = "Weirdness" | "Style Influence";
+
+async function injectOptionalSlider(
+  value: number | null | undefined,
+  slider: HTMLElement | null,
+  name: OptionalSliderName,
+  options: AdvancedInjectOptions
+): Promise<void> {
+  if (value == null) {
+    return;
+  }
+  if (!slider) {
+    console.warn(
+      `[suno-helper] ${name} slider が見つかりません（Suno の UI 変更の可能性）。注入を skip して続行します。`
+    );
+    options.onSliderSkip?.(name);
+    return;
+  }
+  try {
+    await injectSliderValue(slider, value, options.bridgeSetSlider);
+  } catch (error) {
+    console.warn(`[suno-helper] ${name} slider 注入を skip:`, error);
+    options.onSliderSkip?.(name);
+  }
+}
+
 export async function injectAdvancedFields(
   entry: AdvancedFieldValues,
   fields: ResolvedAdvancedFields,
   options: AdvancedInjectOptions = {}
 ): Promise<void> {
-  if (entry.exclude_styles !== undefined) {
-    if (!fields.excludeStyles) {
-      throw new FatalRunError(
-        "Exclude styles 欄が見つかりません。Suno の「書く」モードでその他のオプションを開いてから再実行してください。"
-      );
-    }
-    setNativeValue(fields.excludeStyles, entry.exclude_styles);
-  }
-  if (entry.vocal_gender === "male" || entry.vocal_gender === "female") {
-    const target =
-      entry.vocal_gender === "male"
-        ? fields.vocalGender.male
-        : fields.vocalGender.female;
-    if (!target) {
-      throw new FatalRunError(
-        `Vocal gender button (${entry.vocal_gender}) が見つかりません。Suno の UI 変更の可能性があります。`
-      );
-    }
-    if (target.getAttribute("data-selected") !== "true") {
-      target.click();
-    }
-  }
-  if (entry.duration_sec !== undefined) {
-    if (!fields.duration) {
-      throw new FatalRunError(
-        "Duration の Custom button または slider が見つかりません。Suno の「書く」モードでその他のオプションを開いてから再実行してください。"
-      );
-    }
-    validateDurationTarget(fields.duration.slider, entry.duration_sec);
-    fields.duration.customButton.click();
-    await injectSliderValue(
-      fields.duration.slider,
-      entry.duration_sec,
-      options.bridgeSetSlider
-    );
-    const actual = readDurationSliderAttribute(
-      fields.duration.slider,
-      "aria-valuenow"
-    );
-    if (actual !== entry.duration_sec) {
-      throw new FatalRunError(
-        `Duration slider の読戻し値 ${actual} 秒が指定値 ${entry.duration_sec} 秒と一致しません。生成を停止します。`
-      );
-    }
-  }
-  if (entry.weirdness != null) {
-    // slider 未検出は throw せず warn + skip（#1720）。値は UI で手動設定でき Create を跨いで
-    // 永続するため、Suno のリネーム / UI 改装で run 全体を中断しない。
-    if (!fields.weirdness) {
-      console.warn(
-        "[suno-helper] Weirdness slider が見つかりません（Suno の UI 変更の可能性）。注入を skip して続行します。"
-      );
-      options.onSliderSkip?.("Weirdness");
-    } else {
-      try {
-        await injectSliderValue(
-          fields.weirdness,
-          entry.weirdness,
-          options.bridgeSetSlider
-        );
-      } catch (e) {
-        console.warn("[suno-helper] Weirdness slider 注入を skip:", e);
-        options.onSliderSkip?.("Weirdness");
-      }
-    }
-  }
-  if (entry.style_influence != null) {
-    if (!fields.styleInfluence) {
-      console.warn(
-        "[suno-helper] Style Influence slider が見つかりません（Suno の UI 変更の可能性）。注入を skip して続行します。"
-      );
-      options.onSliderSkip?.("Style Influence");
-    } else {
-      try {
-        await injectSliderValue(
-          fields.styleInfluence,
-          entry.style_influence,
-          options.bridgeSetSlider
-        );
-      } catch (e) {
-        console.warn("[suno-helper] Style Influence slider 注入を skip:", e);
-        options.onSliderSkip?.("Style Influence");
-      }
-    }
-  }
+  injectExcludeStyles(entry.exclude_styles, fields.excludeStyles);
+  injectVocalGender(entry.vocal_gender, fields.vocalGender);
+  await injectDuration(
+    entry.duration_sec,
+    fields.duration,
+    options.bridgeSetSlider
+  );
+  await injectOptionalSlider(
+    entry.weirdness,
+    fields.weirdness,
+    "Weirdness",
+    options
+  );
+  await injectOptionalSlider(
+    entry.style_influence,
+    fields.styleInfluence,
+    "Style Influence",
+    options
+  );
 }
 
 /**

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -98,6 +98,8 @@ build 後は `.output/chrome-mv3/manifest.json`、zip 後は `.output/suno-helpe
 6. 全件完了後、対象 clip を一括選択 → playlist 追加 → More menu の **Download all** → format 選択 → ZIP ダウンロード完了監視 → `POST /collections/<id>/downloaded` で ZIP パス通知、まで実行する。サーバーは ZIP を展開し、`02-Individual-music/` と `workflow-state.json` を更新する。
 7. captcha challenge は waiting-captcha 表示で解消（多くは自動 verify）を待って続行する。entry 単位の一時的な失敗は Balanced 固定の上限で自動リトライし、上限超過分はスキップして完走する（#948）。スキップされた entry は一覧表示され、**失敗分のみ再実行** で再投入できる。
 
+prompt entry に `duration_sec` がある場合は、各 Generate 前に Duration の **Custom** を選択し、Suno UI の slider が公開する最小値・最大値の範囲内で指定秒数を注入する。selector 不在、範囲外、操作不受理、読戻し不一致は entry をエラー停止し、popup に原因を表示する。`duration_sec` がない entry では Auto / Custom と slider の現在状態を変更しない。
+
 通知は初期状態で ON。最終 `FINISHED` は OS 通知と明るい3音上昇音、`ERROR` はエラー概要付き OS 通知と短い2音下降ベルで知らせる。手動 `STOPPED` と collection queue の途中完了では通知しない。Switch の設定は再読み込み後も維持され、旧 preset 設定は enabled を保ったまま自動移行される。OS 通知と Web Audio は独立して試行するため、一方の失敗は run 結果へ影響しない。
 
 複数 collection queue は各 collection の `/downloaded` 完了または失敗結果を extension storage へ保存してから Suno タブを再読み込みする。この境界処理が clip tracker と Suno 内部 multi-select を collection 間で破棄し、次の collection は保存済み index から自動開始する。タブ再読み込みや Stop で中断した queue は同じ current collection から再開でき、全件終了後は summary の **失敗したコレクションだけ再実行** を使う。

--- a/extensions/suno-helper/tests/dom.test.ts
+++ b/extensions/suno-helper/tests/dom.test.ts
@@ -1612,6 +1612,44 @@ describe("resolveAdvancedFields: More Options 3 フィールドの解決 (#900, 
     expect(fields.styleInfluence).toBe(styleInfluence);
   });
 
+  it("Given Duration Custom button と slider が存在 When 解決する Then controls を同じ field として返す", () => {
+    const customButton = document.createElement("button");
+    customButton.type = "button";
+    customButton.textContent = "Custom";
+    document.body.appendChild(customButton);
+    setRect(customButton, VISIBLE_RECT);
+    const slider = addSlider({ ariaLabel: "Duration", value: 120 });
+    slider.setAttribute("aria-valuemin", "60");
+    slider.setAttribute("aria-valuemax", "480");
+
+    const fields = resolveAdvancedFields();
+
+    expect(fields.duration).toEqual({ customButton, slider });
+  });
+
+  it("Given 同名 Custom button が複数存在 When 解決する Then Duration slider に最も近い button を返す", () => {
+    const unrelatedSection = document.createElement("section");
+    const unrelatedButton = document.createElement("button");
+    unrelatedButton.type = "button";
+    unrelatedButton.textContent = "Custom";
+    unrelatedSection.appendChild(unrelatedButton);
+    document.body.appendChild(unrelatedSection);
+    setRect(unrelatedButton, VISIBLE_RECT);
+
+    const durationSection = document.createElement("section");
+    const durationButton = document.createElement("button");
+    durationButton.type = "button";
+    durationButton.textContent = "Custom";
+    const durationSlider = addSlider({ ariaLabel: "Duration", value: 120 });
+    durationSection.append(durationButton, durationSlider);
+    document.body.appendChild(durationSection);
+    setRect(durationButton, VISIBLE_RECT);
+
+    const fields = resolveAdvancedFields();
+
+    expect(fields.duration?.customButton).toBe(durationButton);
+  });
+
   it("Given 要素が何も無い When 解決する Then すべて null（throw しない fail-soft）", () => {
     const fields = resolveAdvancedFields();
 

--- a/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
+++ b/extensions/suno-helper/tests/e2e/suno-inject.spec.ts
@@ -34,6 +34,8 @@ const MOCK_SUNO_HTML = `<!doctype html>
     <input id="exclude" placeholder="Exclude styles" maxlength="1000" />
     <div id="weirdness" role="slider" aria-label="Weirdness" aria-valuenow="0" tabindex="0"></div>
     <div id="style-influence" role="slider" aria-label="Style Influence" aria-valuenow="50" tabindex="0"></div>
+    <button id="duration-custom" type="button">Custom</button>
+    <div id="duration" role="slider" aria-label="Duration" aria-valuemin="60" aria-valuemax="480" aria-valuenow="120" tabindex="0"></div>
     <button id="generate">Create</button>
     <iframe id="hcaptcha-none" src="https://hcaptcha-assets-prod.suno.com/captcha/v1/0" style="display:none;width:0;height:0;border:0"></iframe>
     <iframe id="hcaptcha-hidden" src="https://hcaptcha-assets-prod.suno.com/captcha/v1/4" title="hCaptchaチャレンジ" style="visibility:hidden;width:300px;height:150px;border:0"></iframe>
@@ -69,6 +71,9 @@ const MOCK_SUNO_HTML = `<!doctype html>
           else if (e.key === 'ArrowLeft') slider.setAttribute('aria-valuenow', String(cur - 1));
         });
       }
+      document.getElementById('duration-custom').addEventListener('click', (e) => {
+        e.currentTarget.setAttribute('aria-pressed', 'true');
+      });
       document.getElementById('generate').addEventListener('click', () => {
         document.getElementById('clicked').textContent = 'yes';
       });
@@ -177,7 +182,7 @@ test("Suno mock へ Style/Lyrics を注入し Generate を押下できる", asyn
     setNativeValue(style, "lofi, jazzy, rainy night");
     setNativeValue(lyrics, "la la la");
     setNativeValue(title, "Midnight Cafe");
-    (document.querySelector("button") as HTMLButtonElement).click();
+    (document.querySelector("#generate") as HTMLButtonElement).click();
   });
 
   // React 互換注入: UI 側の onChange が値を取り込めている (= input イベントが届いた)
@@ -341,6 +346,8 @@ test("Suno mock へ More Options 3 フィールド (exclude/weirdness/style_infl
       'input[placeholder="Exclude styles"]'
     ) as HTMLInputElement;
     setNativeValue(exclude, "hyperpop, edm");
+    document.getElementById("duration-custom")!.click();
+    setSliderValue(document.getElementById("duration")!, 180);
     setSliderValue(
       document.querySelector(
         '[role="slider"][aria-label="Weirdness"]'
@@ -365,6 +372,14 @@ test("Suno mock へ More Options 3 フィールド (exclude/weirdness/style_infl
   await expect(page.locator("#style-influence")).toHaveAttribute(
     "aria-valuenow",
     "85"
+  );
+  await expect(page.locator("#duration")).toHaveAttribute(
+    "aria-valuenow",
+    "180"
+  );
+  await expect(page.locator("#duration-custom")).toHaveAttribute(
+    "aria-pressed",
+    "true"
   );
 });
 

--- a/extensions/suno-helper/tests/inject-advanced.test.ts
+++ b/extensions/suno-helper/tests/inject-advanced.test.ts
@@ -379,6 +379,8 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
       const slider = makeSlider(120, { respond: false });
       const resolvedAriaLabel = "resolved-duration-slider";
       slider.setAttribute("aria-label", resolvedAriaLabel);
+      slider.setAttribute("aria-valuemin", "60");
+      slider.setAttribute("aria-valuemax", "480");
       const bridgeSetSlider = vi.fn(
         async (_ariaLabel: string, target: number) => {
           order.push("slider");
@@ -400,12 +402,14 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
       expect(slider.getAttribute("aria-valuenow")).toBe("180");
     });
 
-    it("Given duration_sec=180 + bridge false When 注入 Then Custom click 後に keydown fallback で180へ動かす", async () => {
+    it("Given duration_sec=300 + bridge false When 注入 Then 150 step を超えても keydown fallback で300へ動かす", async () => {
       const order: string[] = [];
       const customButton = document.createElement("button");
       customButton.addEventListener("click", () => order.push("custom"));
-      const slider = makeSlider(179);
+      const slider = makeSlider(120);
       slider.setAttribute("aria-label", "resolved-duration-slider");
+      slider.setAttribute("aria-valuemin", "60");
+      slider.setAttribute("aria-valuemax", "480");
       slider.addEventListener("keydown", () => order.push("keydown"));
       const bridgeSetSlider = vi.fn(async () => {
         order.push("bridge");
@@ -413,13 +417,14 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
       });
 
       await injectAdvancedFields(
-        { duration_sec: 180 },
+        { duration_sec: 300 },
         { ...ALL_NULL, duration: { customButton, slider } },
         { bridgeSetSlider }
       );
 
-      expect(order).toEqual(["custom", "bridge", "keydown"]);
-      expect(slider.getAttribute("aria-valuenow")).toBe("180");
+      expect(order.slice(0, 3)).toEqual(["custom", "bridge", "keydown"]);
+      expect(order.filter((event) => event === "keydown")).toHaveLength(180);
+      expect(slider.getAttribute("aria-valuenow")).toBe("300");
     });
 
     it("Given duration_sec 未指定 + 解決済み controls When 注入 Then controls に触れず slider 値を維持する", async () => {
@@ -441,6 +446,46 @@ describe("injectAdvancedFields: 非対称契約 (fail-loud / fail-soft, #900)", 
       expect(bridgeSetSlider).not.toHaveBeenCalled();
       expect(keydown).not.toHaveBeenCalled();
       expect(slider.getAttribute("aria-valuenow")).toBe("120");
+    });
+
+    it("Given duration_sec 指定 + controls 不在 When 注入 Then selector error で fail-loud に停止する", async () => {
+      await expect(
+        injectAdvancedFields({ duration_sec: 180 }, ALL_NULL)
+      ).rejects.toThrow(/Duration.*見つかりません/);
+    });
+
+    it("Given duration_sec が DOM 公開範囲外 When 注入 Then Custom を押さず fail-loud に停止する", async () => {
+      const customButton = document.createElement("button");
+      const customClick = vi.spyOn(customButton, "click");
+      const slider = makeSlider(120);
+      slider.setAttribute("aria-label", "Duration");
+      slider.setAttribute("aria-valuemin", "60");
+      slider.setAttribute("aria-valuemax", "240");
+
+      await expect(
+        injectAdvancedFields(
+          { duration_sec: 300 },
+          { ...ALL_NULL, duration: { customButton, slider } }
+        )
+      ).rejects.toThrow(/Duration.*60.*240/);
+      expect(customClick).not.toHaveBeenCalled();
+    });
+
+    it("Given bridge が成功を返しても slider 読戻し不一致 When 注入 Then fail-loud に停止する", async () => {
+      const customButton = document.createElement("button");
+      const slider = makeSlider(120, { respond: false });
+      slider.setAttribute("aria-label", "Duration");
+      slider.setAttribute("aria-valuemin", "60");
+      slider.setAttribute("aria-valuemax", "480");
+      const bridgeSetSlider = vi.fn().mockResolvedValue(true);
+
+      await expect(
+        injectAdvancedFields(
+          { duration_sec: 180 },
+          { ...ALL_NULL, duration: { customButton, slider } },
+          { bridgeSetSlider }
+        )
+      ).rejects.toThrow(/Duration.*読.*120.*180/);
     });
   });
 


### PR DESCRIPTION
## Summary
- Duration Custom と slider を実 DOM から解決する
- 範囲・操作・読戻しを Generate 前に検証する
- 未指定時の UI 維持と selector 競合を回帰テストで固定する

Closes #2507