### PR TITLE
feat(wf-new): 企画プレビューを最終サムネに確定する (#2514)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -278,6 +278,16 @@ uv run yt-generate-image \
 
 ### 標準生成順序とファイル契約
 
+`/wf-new` から実行され、採用済み `10-assets/planning-preview.png` がある場合だけ、通常の候補生成より前に次の決定的確定経路を使う。`/thumbnail` の単独実行ではこの分岐を推測せず、通常の生成モードに従う。
+
+```bash
+uv run python .claude/skills/thumbnail/references/finalize_planning_preview.py <collection-path>
+```
+
+`status: FINALIZED` は Pillow による RGB JPEG 形式変換と原子的な `10-assets/thumbnail.jpg` 置換が成功したことを表す。構図変更、テキスト追加、AI 生成、候補再選択は行わない。既存 `thumbnail.jpg` は変換と JPEG の dimensions 検証が完了するまで保持する。確定後は `/thumbnail-compare` と既存目視 QA、承認済みサムネイルの archive Hard Gate を通すが、企画選択時と同じ画像を thumbnail の AskUserQuestion へ再度出さない。その後の `textless.enabled` 未設定 / `true` の textless `main.png/jpg` 生成と、`false` の `share_thumbnail_as_main.py` 共用、state 更新ゲートは通常契約を維持する。
+
+`status: MISSING` の場合だけ、`/wf-new` は既存の `/thumbnail <theme>` 候補生成へフォールバックする。空ファイルや代替画像を作らない。変換エラーは `MISSING` とみなさず、既存成果物と state を変更せず停止する。
+
 `/thumbnail` の標準手順は、**textless 動画背景の生成 → `yt-thumbnail-text` による実フォント合成**の 2 段構成で進める（#1907）。タイトル文字は AI に焼き込ませず、承認済みの textless 背景へ実フォント（Pillow 描画）で決定的に合成する。同一の背景・テキスト・設定なら常に同一出力になり、AI っぽい書体の揺れが発生しない。
 
 ただし deep-merge 後の `textless.enabled: false` は明示 opt-in の共用経路とする。この場合は textless 候補の AI 生成、セルフチェック、プレビュー、承認をすべて省略し、テキスト付き最終 `10-assets/thumbnail.jpg` の確定後に次を実行する。

--- a/.claude/skills/thumbnail/references/finalize_planning_preview.py
+++ b/.claude/skills/thumbnail/references/finalize_planning_preview.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Finalize an adopted planning preview as the upload thumbnail."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from PIL import Image
+
+from youtube_automation.core.errors import ValidationError
+
+_JPEG_QUALITY = 100
+
+
+def finalize_planning_preview(collection_dir: Path) -> dict[str, str]:
+    """Convert planning-preview.png to thumbnail.jpg without changing composition."""
+    assets_dir = collection_dir.resolve() / "10-assets"
+    source = assets_dir / "planning-preview.png"
+    destination = assets_dir / "thumbnail.jpg"
+
+    if source.is_symlink():
+        raise ValidationError(f"planning preview は通常ファイルである必要があります: {source}")
+    if not source.exists():
+        return {"status": "MISSING", "source": str(source)}
+    if not source.is_file():
+        raise ValidationError(f"planning preview は通常ファイルである必要があります: {source}")
+
+    temporary_path: Path | None = None
+    try:
+        file_descriptor, temporary_name = tempfile.mkstemp(
+            dir=assets_dir,
+            prefix=".thumbnail-preview-",
+            suffix=".jpg",
+        )
+        os.close(file_descriptor)
+        temporary_path = Path(temporary_name)
+
+        with Image.open(source) as opened:
+            opened.load()
+            source_size = opened.size
+            opened.convert("RGB").save(
+                temporary_path,
+                format="JPEG",
+                quality=_JPEG_QUALITY,
+                subsampling=0,
+            )
+
+        with Image.open(temporary_path) as converted:
+            converted.load()
+            if converted.format != "JPEG" or converted.size != source_size:
+                raise ValidationError("planning preview の JPEG 形式変換を検証できませんでした")
+
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+    return {
+        "status": "FINALIZED",
+        "source": str(source),
+        "destination": str(destination),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="planning-preview.png を AI 再生成せず thumbnail.jpg に確定します",
+    )
+    parser.add_argument("collection_dir", type=Path, help="対象 collection directory")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    result = finalize_planning_preview(args.collection_dir)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -12,7 +12,7 @@ description: "Use when 新規コレクション制作を立ち上げるとき（
 
 新コレクション開始オーケストレーター。子スキルを順番に呼び、通常は企画選択 + サムネイル承認の2箇所で一時停止する。`workflow.wf_new.skip_plan_selection: true` の analytics mode / benchmark fallback mode では企画選択だけを自動化する。
 `/wf-auto` から新規開始または対象 collection 固定で委譲された場合も本スキルの既存 gate と完了条件を維持し、統合 runner 側で工程を再実装しない。新規初期化後は作成した collection 名を返し、同じ run 内の再評価へ接続する。
-`image_generation.auto_selection.enabled: true` かつ `mode: full` のチャンネルでは、サムネイル工程のテーマ確認・生成可否・textless 背景承認・候補承認を省略し、企画で確定した theme を `/thumbnail` へ渡して無人で確定する。
+`image_generation.auto_selection.enabled: true` かつ `mode: full` のチャンネルでは、サムネイル工程のテーマ確認・生成可否・textless 背景承認・候補承認を省略する。`planning-preview.png` があればそれを無人で最終サムネイルへ確定し、無ければ企画で確定した theme を `/thumbnail` へ渡して無人で確定する。
 Suno チャンネルではプロンプト生成後、`suno-helper` 用の `uv run yt-collection-serve` 起動と疎通確認まで行い、続きは `/suno-helper` が browser use で Suno タブ上の拡張 overlay を操作できる状態にする。
 minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気の直接入力確認が追加される既存挙動を、`ttp_mode: false` の場合だけ適用する。`true` の場合は `/benchmark` を案内して停止する。
 アナリティクス未収集の新チャンネルでも、ベンチマークから初回企画を開始する。`ttp_mode: false` の場合だけ、ベンチマークも無ければユーザー直接入力を使う。
@@ -173,8 +173,8 @@ success を記録した後は同じ fixed collection を `plan --collection <fix
 | 1 | subagent: `/collection-ideate` | 入力モード候補を渡し、成果物検証後にメインが企画選択で停止 | 選択企画、プレビュー画像 |
 | 2 | `uv run yt-init-collection` | 選択企画から collection dir と初期 state を作る | `workflow-state.json` |
 | 3 | `uv run yt-populate-scene-phrases` | 多言語チャンネルの scene phrases を初期化 | `scene_phrases` |
-| 4 | subagent: `/thumbnail` | テキスト付き候補生成を委譲し、メインが成果物を検証する | `10-assets/thumbnail-vN.jpg/png` |
-| 5 | user 承認 + subagent: `/thumbnail` | 通常はテキスト付き候補を承認・確定後、textless 候補生成を委譲し、承認・確定・state 更新を行う。`thumbnail::textless.enabled: false` では確定済み thumbnail を `main.jpg` へ共用する。`mode: full` は承認を省略して自動確定する | `10-assets/thumbnail.jpg`, `10-assets/main.png/jpg` |
+| 4 | preview finalizer または subagent: `/thumbnail` | `planning-preview.png` があれば決定的 JPEG 変換で確定し、無い場合だけテキスト付き候補生成を委譲する | `10-assets/thumbnail.jpg` または `thumbnail-vN.jpg/png` |
+| 5 | quality gate + textless subagent | 採用済み `planning-preview.png` があれば再承認せず品質検証し、無い場合は `/thumbnail` 候補を既存契約で確定する。その後は textless 候補生成または `textless.enabled: false` の `main.jpg` 共用、state 更新を行う。`mode: full` は承認を省略する | `10-assets/thumbnail.jpg`, `10-assets/main.png/jpg` |
 | 6 | subagent: `/suno` または `/lyria` | 音楽エンジンに応じたプロンプト生成を委譲し、メインが成果物を検証する | `suno-prompts.json` または Lyria 設計 |
 | 7 | subagent: `/loop-video` または静止背景運用 | `loop-video.enabled=true` なら生成を委譲しメインが検証。`enabled=false` なら Veo を呼ばず、メインが既存 textless `main.png/jpg` を静止背景として使う | `10-assets/loop.mp4` または textless `10-assets/main.png/jpg` |
 | 8 | subagent: `uv run yt-collection-serve`（Suno のみ） | server 起動と疎通確認を委譲し、結果をメインが検証する | `http://localhost:<PORT>` |
@@ -289,21 +289,40 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 
 ##### 2c-1. サムネイル候補生成
 
-このステップはサムネイル候補の生成までを行う。候補の承認と確定は 2c-2 に一元化する。`mode: full` では承認ゲートではなく自動確定分岐として実行する。
+このステップは採用済み企画プレビューの確定、またはプレビューが無い場合のサムネイル候補生成までを行う。候補の承認と確定は 2c-2 に一元化する。`mode: full` では承認ゲートではなく自動確定分岐として実行する。
 
 1. **企画成果物を collection に固定**:
-   - 選択した企画のプレビュー画像は企画参照として保存する。`10-assets/main.png` にはコピーしない
+   - 選択した企画のプレビュー画像は `10-assets/planning-preview.png` に保存する。`10-assets/main.png/jpg` にはコピーしない
    - Phase 1 の企画候補一覧と選択結果を `20-documentation/` に保存
    - プレビューディレクトリの自セッション分を削除
 
-2. **サムネイル skill を順番に処理**:
+2. **企画プレビューの有無を決定的に解決**:
+
+   ```bash
+   uv run python .claude/skills/thumbnail/references/finalize_planning_preview.py <collection-path>
+   ```
+
+   - `status: FINALIZED`: `planning-preview.png` を RGB JPEG へ原子的に形式変換した同じ画像内容の `10-assets/thumbnail.jpg` が確定済み。文字入り候補の AI 生成、再選択、thumbnail の AskUserQuestion を行わず、2c-2 の品質検証へ進む
+   - `status: MISSING`: 空ファイルや代替画像を作らず、下記の既存 `/thumbnail <theme>` フォールバックへ進む
+   - コマンド失敗、symlink、画像として読めない入力、JPEG 検証失敗: 既存 `thumbnail.jpg` と state を変更せず停止する
+
+3. **`status: MISSING` の場合だけサムネイル skill を順番に処理**:
    - `single_step` モードまたは `image_generation.provider: codex` を含め、mode / provider にかかわらず、メインが対象 collection、Phase 1 で確定し `workflow-state.json::theme` に保存した theme、生成対象 `thumbnail` を指定して Agent ツールで `/thumbnail <theme>` の Subagent Contract を委譲する。subagent はテキスト付き候補と `20-documentation/thumbnail-prompts.md` を生成するが、承認、確定コピー、state 更新は行わない。`mode: full` では生成可否を質問せず `-y` 相当で進める
    - メインの承認・確定と 2c-2 の別 subagent 委譲を合わせ、テキスト付き `10-assets/thumbnail.jpg` を先に生成・承認し、承認済み `thumbnail.jpg` からテキストなし `10-assets/main.png` または `main.jpg` を再生成する既存 `/thumbnail` 契約を維持する
-   - メインが候補ファイルと `thumbnail-prompts.md` の存在を検証する。ここでは AskUserQuestion、確定コピー、state 更新を行わず Phase 2d へ進む
+   - メインが候補ファイルと `thumbnail-prompts.md` の存在を検証する。ここでは AskUserQuestion、確定コピー、state 更新を行わず 2c-2 へ進む
 
 ##### 2c-2. サムネイル承認・確定 + 音楽素材生成
 
 このステップにテキスト付き候補の承認ゲートと `mode: full` の自動確定分岐を一元化する。最初に thumbnail の `config.default.yaml` と `config/skills/thumbnail.yaml` を deep-merge し、`textless.enabled` を確定する。未設定は既定の `true` として扱う。以下の 1〜4 は mode 別に実行する。
+
+**`planning-preview.png` から確定済み**:
+
+1. 企画選択時に承認済みの同じ画像なので、文字入り候補の生成・再選択・thumbnail の AskUserQuestion は行わない。`10-assets/thumbnail.jpg` を `/thumbnail-compare` で 320px 視認性検証し、署名・透かし・ロゴ・手指破綻の既存目視 QA を通す。失敗時は state を更新せず停止する
+2. QA 成功後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。archive の Hard Gate は既存契約どおり維持する
+3. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。`mode: full` は生成可否と textless 背景承認を質問せず既存の check 成功後に確定し、それ以外は既存どおり textless 候補だけをプレビュー・承認して `main.png/jpg` へ確定する。`false` なら textless 生成・承認を省略し、`share_thumbnail_as_main.py <collection-path>` を実行して `status: SHARED`、同一 SHA-256、`main.png` 不在を検証する
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ `assets.thumbnail = true`、`thumbnail.approved = true`、`updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
+
+以下の mode 別分岐は `status: MISSING` から既存 `/thumbnail` フォールバックへ進んだ場合だけ実行する。
 
 **`mode: full`**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
 - `fix(suno-helper)`: downloaded POST 失敗の endpoint と download phase を overlay の中断表示と無人実行の `required-action` へ保持し、token 取得先で起点 request を覆わないエラー契約を固定（#3001）。
+- `feat(wf-new)`: 採用済み `planning-preview.png` を AI 再生成や重複承認なしで原子的に `thumbnail.jpg` へ形式変換し、プレビュー不在時だけ既存 `/thumbnail` 生成へフォールバックする経路を追加（#2514）。
+
 - `feat(collection-ideate)`: 採用した `planning-preview.png` を最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、未生成時だけ `/thumbnail` フォールバックへ合流する契約に変更（#2513）。
 
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from PIL import Image, ImageChops, ImageStat
 
 from tests.helpers.paths import REPO_ROOT
 
@@ -402,6 +403,115 @@ def _load_shared_main_module(name: str):
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_preview_finalizer_module(name: str):
+    script = _repo_root() / ".claude/skills/thumbnail/references/finalize_planning_preview.py"
+    spec = importlib.util.spec_from_file_location(name, script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_finalize_planning_preview_preserves_visual_content(tmp_path: Path) -> None:
+    module = _load_preview_finalizer_module("finalize_planning_preview")
+    collection = tmp_path / "collection"
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True)
+    preview = assets / "planning-preview.png"
+    source = Image.new("RGB", (48, 32), "#17324d")
+    for x in range(24, 48):
+        for y in range(16, 32):
+            source.putpixel((x, y), (220, 145, 38))
+    source.save(preview, "PNG")
+
+    result = module.finalize_planning_preview(collection)
+
+    thumbnail = assets / "thumbnail.jpg"
+    with Image.open(thumbnail) as converted:
+        assert converted.format == "JPEG"
+        assert converted.size == source.size
+        difference = ImageStat.Stat(ImageChops.difference(source, converted.convert("RGB")))
+    assert max(difference.mean) < 1.0
+    assert result == {
+        "status": "FINALIZED",
+        "source": str(preview),
+        "destination": str(thumbnail),
+    }
+    assert not list(assets.glob(".thumbnail-preview-*"))
+
+
+def test_finalize_planning_preview_reports_missing_without_creating_thumbnail(tmp_path: Path) -> None:
+    module = _load_preview_finalizer_module("finalize_planning_preview_missing")
+    collection = tmp_path / "collection"
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True)
+
+    result = module.finalize_planning_preview(collection)
+
+    assert result == {
+        "status": "MISSING",
+        "source": str(assets / "planning-preview.png"),
+    }
+    assert not (assets / "thumbnail.jpg").exists()
+
+
+def test_finalize_planning_preview_failure_preserves_existing_thumbnail(tmp_path: Path) -> None:
+    module = _load_preview_finalizer_module("finalize_planning_preview_failure")
+    collection = tmp_path / "collection"
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True)
+    (assets / "planning-preview.png").write_bytes(b"not-an-image")
+    thumbnail = assets / "thumbnail.jpg"
+    thumbnail.write_bytes(b"existing-thumbnail")
+
+    with pytest.raises(OSError):
+        module.finalize_planning_preview(collection)
+
+    assert thumbnail.read_bytes() == b"existing-thumbnail"
+    assert not list(assets.glob(".thumbnail-preview-*"))
+
+
+def test_finalize_planning_preview_rejects_broken_symlink(tmp_path: Path) -> None:
+    module = _load_preview_finalizer_module("finalize_planning_preview_broken_symlink")
+    collection = tmp_path / "collection"
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True)
+    preview = assets / "planning-preview.png"
+    preview.symlink_to(assets / "missing.png")
+    thumbnail = assets / "thumbnail.jpg"
+    thumbnail.write_bytes(b"existing-thumbnail")
+
+    with pytest.raises(module.ValidationError, match="通常ファイル"):
+        module.finalize_planning_preview(collection)
+
+    assert thumbnail.read_bytes() == b"existing-thumbnail"
+    assert not list(assets.glob(".thumbnail-preview-*"))
+
+
+def test_finalize_planning_preview_permission_failure_preserves_existing_thumbnail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_preview_finalizer_module("finalize_planning_preview_permission")
+    collection = tmp_path / "collection"
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True)
+    Image.new("RGB", (8, 8), "navy").save(assets / "planning-preview.png", "PNG")
+    thumbnail = assets / "thumbnail.jpg"
+    thumbnail.write_bytes(b"existing-thumbnail")
+
+    def deny_temporary_file(*_args, **_kwargs):
+        raise PermissionError("injected permission failure")
+
+    monkeypatch.setattr(module.tempfile, "mkstemp", deny_temporary_file)
+
+    with pytest.raises(PermissionError, match="injected permission failure"):
+        module.finalize_planning_preview(collection)
+
+    assert thumbnail.read_bytes() == b"existing-thumbnail"
 
 
 def test_thumbnail_textless_shared_main_default_and_contract() -> None:

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -12,6 +12,7 @@ from youtube_automation.commands.system import doctor
 
 _REPO_ROOT = REPO_ROOT
 _FRESHNESS_RULES = _REPO_ROOT / ".claude" / "skills" / "collection-ideate" / "references" / "freshness-rules.md"
+_WF_NEW_SKILL = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
 
 
 def _freshness_script() -> str:
@@ -131,3 +132,36 @@ def test_freshness_script_returns_refresh_contract_for_stale_analytics(
 
     assert result.returncode == 3
     assert f"AUTO_REFRESH_SKILLS={expected_refresh}" in result.stdout
+
+
+def test_wf_new_routes_preview_finalization_before_thumbnail_fallback() -> None:
+    skill = _WF_NEW_SKILL.read_text(encoding="utf-8")
+    thumbnail_step = skill.split("##### 2c-1. サムネイル候補生成", 1)[1].split(
+        "##### 2c-2. サムネイル承認・確定 + 音楽素材生成", 1
+    )[0]
+
+    finalizer = "finalize_planning_preview.py <collection-path>"
+    assert finalizer in thumbnail_step
+    assert "status: FINALIZED" in thumbnail_step
+    assert "status: MISSING" in thumbnail_step
+    assert thumbnail_step.index(finalizer) < thumbnail_step.index("/thumbnail <theme>")
+    assert "FINALIZED" in thumbnail_step and "AI 生成" in thumbnail_step
+    assert "MISSING" in thumbnail_step and "既存 `/thumbnail <theme>`" in thumbnail_step
+
+
+def test_wf_new_preview_path_keeps_quality_state_and_textless_contracts() -> None:
+    skill = _WF_NEW_SKILL.read_text(encoding="utf-8")
+    approval_step = skill.split("##### 2c-2. サムネイル承認・確定 + 音楽素材生成", 1)[1].split(
+        "#### 2e. ループ動画生成", 1
+    )[0]
+
+    for contract in (
+        "/thumbnail-compare",
+        "assets.thumbnail = true",
+        "thumbnail.approved = true",
+        "未設定または `true`",
+        "share_thumbnail_as_main.py <collection-path>",
+    ):
+        assert contract in approval_step
+    assert "`planning-preview.png` から確定済み" in approval_step
+    assert "再度 AskUserQuestion にかけない" in approval_step


### PR DESCRIPTION
## Summary
- planning-preview.png を非AIかつ原子的に JPEG へ確定する
- FINALIZED は候補再生成と再承認を省略する
- MISSING のみ既存 /thumbnail へフォールバックする

Closes #2514