### PR TITLE
fix(doctor): state管理外の配信VPSを検知する (#2524)

### DIFF
--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -253,6 +253,10 @@ uv run yt-analytics --reporting-create-job
 
 コマンドは冪等で、既存ジョブがあれば再利用する。成功後は `--apply` が再診断して次の check へ進む。
 
+#### `streaming_vps_state` — Terraform state 管理外の streaming VPS
+
+`VULTR_API_KEY` または `TF_VAR_vultr_api_key` が未設定なら読み取り診断を skip する。warning では自動 import せず、`infra/terraform/streaming/README.md` の「既存 Vultr リソースの import」に従い、表示された instance ID を対応 workspace へ手動 import する。完了後に `uv run yt-doctor --json` を再実行し、同 check が `ok` になることを確認する。
+
 ### channel カテゴリ
 
 #### `channel_config` — チャンネル設定未ロード
@@ -375,4 +379,3 @@ scope 不足の場合は、削除対象を表示して承認を得た後、AI �
 ```
 
 remote ID がまだ取得できていない channel_id 未設定は、AI が `uv run yt-channel-status` を起動して ID を取得し、上の「remote channel ID のローカル反映」に戻る。再認証が必要なら先に `uv run yt-oauth` の background flow を完了する。手書きで `meta.json` を更新しない。
-

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -37,6 +37,7 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 | workspace 作成 | `terraform -chdir=infra/terraform/streaming workspace new <workspace>` |
 | workspace 切替 | `terraform -chdir=infra/terraform/streaming workspace select <workspace>` |
 | 選択 workspace の GCS state | `workspace=$(terraform -chdir=infra/terraform/streaming workspace show); bucket=$(jq -r '.backend.config.bucket' infra/terraform/streaming/.terraform/terraform.tfstate); gcloud storage ls "gs://${bucket}/streaming/${workspace}.tfstate"` |
+| VPS / state 突合診断 | `VULTR_API_KEY="$(op read 'op://Personal/Vultr/api_key')" uv run yt-doctor --json` (`streaming_vps_state` を確認) |
 | ライブチャット自動返信 | `/live-chat-reply` |
 | 動画差し替え | `$(git rev-parse --show-toplevel)/.claude/skills/streaming/references/swap_video.sh ./new_video.mp4` |
 | 帯域チェック | `uv run yt-stream-bandwidth --check-threshold --terraform-dir infra/terraform/streaming` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(collection-ideate)`: 採用した `planning-preview.png` を最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、未生成時だけ `/thumbnail` フォールバックへ合流する契約に変更（#2513）。
 - `fix(doctor)`: TTP seed 確認で `seed 要約` と自然なユーザー承認 / 不採用表現を受理し、ユーザー承認済み例外の category・未反映内容・理由・後続 skill を同じ Markdown section の複数行箇条書きでも検証できるようにした（#2510）。
+- `fix(doctor)`: Vultr 上の `youtube-stream` タグ付き VPS と streaming GCS backend の全 workspace state を突合し、state 管理外の instance ID を読み取り専用診断で警告。Vultr API key 未設定時は外部アクセスせず skip するようにした（#2524）。
 
 - `feat(workspace)`: SessionStart で cwd 由来の対象チャンネル、または未確定時の候補と書き込み基準をコンテキストへ注入する hook を追加（#3372）。
 

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -65,6 +65,7 @@ from youtube_automation.infrastructure.collections.numbered_duplicates import (
 )
 from youtube_automation.infrastructure.retry import QUOTA_REASONS
 from youtube_automation.infrastructure.youtube.reporting_api import ReportingAPIClient
+from youtube_automation.infrastructure.youtube.streaming.state_reconciliation import reconcile_streaming_vps
 
 PYPROJECT_FILENAME = "pyproject.toml"
 CLAUDE_SKILLS_DIR = Path(".claude") / "skills"
@@ -1208,6 +1209,68 @@ def check_reporting_job(channel_dir: Path) -> CheckResult:
         id="reporting_job",
         status="ok",
         message=f"Reporting API ジョブ作成済み (jobId: {existing_job['id']})",
+    )
+
+
+def check_streaming_vps_state(channel_dir: Path) -> CheckResult:
+    """Vultr 上の streaming VPS と全 GCS workspace state を突合する。"""
+    terraform_dir = _bootstrap_root(channel_dir) / "infra" / "terraform" / "streaming"
+    if not terraform_dir.is_dir():
+        return CheckResult(
+            id="streaming_vps_state",
+            status="info",
+            message="streaming Terraform module がないため VPS state 突合をスキップ",
+            data={"reason": "streaming_terraform_module_missing"},
+        )
+
+    api_key = os.environ.get("VULTR_API_KEY", "").strip() or os.environ.get("TF_VAR_vultr_api_key", "").strip()
+    if not api_key:
+        return CheckResult(
+            id="streaming_vps_state",
+            status="info",
+            message="Vultr API key 未設定のため VPS state 突合をスキップ",
+            data={"reason": "vultr_api_key_missing"},
+        )
+
+    try:
+        inventory = reconcile_streaming_vps(
+            terraform_dir=terraform_dir,
+            api_key=api_key,
+            run_command=_run,
+        )
+    except AutomationError as error:
+        return CheckResult(
+            id="streaming_vps_state",
+            status="unknown",
+            message=f"streaming VPS state 突合に失敗: {error}",
+        )
+
+    unmanaged_ids = sorted(inventory.unmanaged_instance_ids)
+    data = {
+        "actual_instance_count": len(inventory.actual_instance_ids),
+        "managed_instance_count": len(inventory.managed_instance_ids),
+        "unmanaged_instance_ids": unmanaged_ids,
+    }
+    if unmanaged_ids:
+        return CheckResult(
+            id="streaming_vps_state",
+            status="warn",
+            message=f"Terraform state 管理外の youtube-stream VPS を検出: {', '.join(unmanaged_ids)}",
+            next_action={
+                "kind": "human",
+                "instructions": (
+                    "`infra/terraform/streaming/README.md` の既存 Vultr リソース import 手順で"
+                    "対応 workspace へ手動 import し、`uv run yt-doctor --json` を再実行してください"
+                ),
+            },
+            data=data,
+        )
+
+    return CheckResult(
+        id="streaming_vps_state",
+        status="ok",
+        message="youtube-stream VPS はすべて Terraform state 管理下",
+        data=data,
     )
 
 
@@ -3150,6 +3213,7 @@ def run_all_checks(channel_dir: Path) -> list[CheckResult]:
         check_oauth_token(channel_dir),
         check_oauth_token_readonly(channel_dir),
         check_reporting_job(channel_dir),
+        check_streaming_vps_state(channel_dir),
         check_channel_config(channel_dir),
         check_playlist_config(channel_dir),
         check_playlist_create_dry_run(channel_dir),

--- a/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
+++ b/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
@@ -9,14 +9,17 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
-from urllib.parse import urlparse
+from urllib.parse import urlencode
 
 from youtube_automation.core.errors import ConfigError, YouTubeAPIError
 
-_VULTR_INSTANCES_URL = "https://api.vultr.com/v2/instances?per_page=500"
+_VULTR_INSTANCES_ENDPOINT = "https://api.vultr.com/v2/instances"
+_VULTR_PAGE_SIZE = 500
+_VULTR_INSTANCES_URL = f"{_VULTR_INSTANCES_ENDPOINT}?{urlencode({'per_page': _VULTR_PAGE_SIZE})}"
 _STREAMING_TAG = "youtube-stream"
 _HTTP_TIMEOUT_SECONDS = 30
 _COMMAND_TIMEOUT_SECONDS = 30
+_GCLOUD_EMPTY_STATE_MESSAGES = ("matched no URLs", "One or more URLs matched no objects.")
 
 CommandRunner = Callable[..., tuple[int, str, str]]
 
@@ -39,9 +42,9 @@ def fetch_tagged_instance_ids(*, api_key: str) -> frozenset[str]:
         payload = _fetch_vultr_page(url=url, api_key=api_key)
         instances = payload.get("instances")
         if not isinstance(instances, list):
-            raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
-        for instance in instances:
-            instance_id, tags = _parse_vultr_instance(instance)
+            raise _unexpected_vultr_shape("instances")
+        for index, instance in enumerate(instances):
+            instance_id, tags = _parse_vultr_instance(instance, index=index)
             if _STREAMING_TAG in tags:
                 instance_ids.add(instance_id)
         url = _next_page_url(payload)
@@ -56,40 +59,43 @@ def _fetch_vultr_page(*, url: str, api_key: str) -> dict[str, object]:
     except (urllib.error.URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise YouTubeAPIError(f"Vultr instances API request failed: {error}") from error
     if not isinstance(payload, dict) or not all(isinstance(key, str) for key in payload):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+        raise _unexpected_vultr_shape("$")
     return cast(dict[str, object], payload)
 
 
-def _parse_vultr_instance(instance: object) -> tuple[str, frozenset[str]]:
+def _parse_vultr_instance(instance: object, *, index: int) -> tuple[str, frozenset[str]]:
+    field_path = f"instances[{index}]"
     if not isinstance(instance, dict):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+        raise _unexpected_vultr_shape(field_path)
     instance_id = instance.get("id")
     tags = instance.get("tags")
-    if not isinstance(instance_id, str) or not instance_id or not isinstance(tags, list):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+    if not isinstance(instance_id, str) or not instance_id:
+        raise _unexpected_vultr_shape(f"{field_path}.id")
+    if not isinstance(tags, list):
+        raise _unexpected_vultr_shape(f"{field_path}.tags")
     if not all(isinstance(tag, str) for tag in tags):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+        raise _unexpected_vultr_shape(f"{field_path}.tags")
     return instance_id, frozenset(tags)
 
 
 def _next_page_url(payload: dict[str, object]) -> str | None:
     meta = payload.get("meta")
-    if meta is None:
-        return None
     if not isinstance(meta, dict):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+        raise _unexpected_vultr_shape("meta")
     links = meta.get("links")
     if not isinstance(links, dict):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
-    next_url = links.get("next")
-    if next_url in (None, ""):
+        raise _unexpected_vultr_shape("meta.links")
+    next_cursor = links.get("next")
+    if not isinstance(next_cursor, str):
+        raise _unexpected_vultr_shape("meta.links.next")
+    if next_cursor == "":
         return None
-    if not isinstance(next_url, str):
-        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
-    parsed = urlparse(next_url)
-    if parsed.scheme != "https" or parsed.netloc != "api.vultr.com" or parsed.path != "/v2/instances":
-        raise YouTubeAPIError(f"Vultr instances API returned invalid next URL: {next_url!r}")
-    return next_url
+    query = urlencode({"per_page": _VULTR_PAGE_SIZE, "cursor": next_cursor})
+    return f"{_VULTR_INSTANCES_ENDPOINT}?{query}"
+
+
+def _unexpected_vultr_shape(field_path: str) -> YouTubeAPIError:
+    return YouTubeAPIError(f"Vultr instances API field `{field_path}` has unexpected shape")
 
 
 def load_managed_instance_ids(*, terraform_dir: Path, run_command: CommandRunner) -> frozenset[str]:
@@ -102,7 +108,7 @@ def load_managed_instance_ids(*, terraform_dir: Path, run_command: CommandRunner
         cwd=terraform_dir,
     )
     if returncode != 0:
-        if "matched no URLs" in stderr:
+        if any(message in stderr for message in _GCLOUD_EMPTY_STATE_MESSAGES):
             return frozenset()
         raise ConfigError(f"streaming Terraform state 一覧の取得に失敗: {stderr.strip() or returncode}")
 

--- a/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
+++ b/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
@@ -8,7 +8,7 @@ import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import cast
 from urllib.parse import urlparse
 
 from youtube_automation.core.errors import ConfigError, YouTubeAPIError
@@ -48,16 +48,16 @@ def fetch_tagged_instance_ids(*, api_key: str) -> frozenset[str]:
     return frozenset(instance_ids)
 
 
-def _fetch_vultr_page(*, url: str, api_key: str) -> dict[str, Any]:
+def _fetch_vultr_page(*, url: str, api_key: str) -> dict[str, object]:
     request = urllib.request.Request(url, headers={"Authorization": f"Bearer {api_key}"})
     try:
         with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS) as response:
-            payload: Any = json.loads(response.read().decode("utf-8"))
+            payload: object = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise YouTubeAPIError(f"Vultr instances API request failed: {error}") from error
-    if not isinstance(payload, dict):
+    if not isinstance(payload, dict) or not all(isinstance(key, str) for key in payload):
         raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
-    return payload
+    return cast(dict[str, object], payload)
 
 
 def _parse_vultr_instance(instance: object) -> tuple[str, frozenset[str]]:
@@ -72,13 +72,16 @@ def _parse_vultr_instance(instance: object) -> tuple[str, frozenset[str]]:
     return instance_id, frozenset(tags)
 
 
-def _next_page_url(payload: dict[str, Any]) -> str | None:
+def _next_page_url(payload: dict[str, object]) -> str | None:
     meta = payload.get("meta")
     if meta is None:
         return None
-    if not isinstance(meta, dict) or not isinstance(meta.get("links"), dict):
+    if not isinstance(meta, dict):
         raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
-    next_url = meta["links"].get("next")
+    links = meta.get("links")
+    if not isinstance(links, dict):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+    next_url = links.get("next")
     if next_url in (None, ""):
         return None
     if not isinstance(next_url, str):

--- a/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
+++ b/src/youtube_automation/infrastructure/youtube/streaming/state_reconciliation.py
@@ -1,0 +1,188 @@
+"""Vultr streaming VPS と Terraform GCS state の読み取り専用突合。"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from youtube_automation.core.errors import ConfigError, YouTubeAPIError
+
+_VULTR_INSTANCES_URL = "https://api.vultr.com/v2/instances?per_page=500"
+_STREAMING_TAG = "youtube-stream"
+_HTTP_TIMEOUT_SECONDS = 30
+_COMMAND_TIMEOUT_SECONDS = 30
+
+CommandRunner = Callable[..., tuple[int, str, str]]
+
+
+@dataclass(frozen=True)
+class StreamingVpsInventory:
+    actual_instance_ids: frozenset[str]
+    managed_instance_ids: frozenset[str]
+
+    @property
+    def unmanaged_instance_ids(self) -> frozenset[str]:
+        return self.actual_instance_ids - self.managed_instance_ids
+
+
+def fetch_tagged_instance_ids(*, api_key: str) -> frozenset[str]:
+    """Vultr API の streaming tag 付き instance ID を全 page から取得する。"""
+    instance_ids: set[str] = set()
+    url: str | None = _VULTR_INSTANCES_URL
+    while url is not None:
+        payload = _fetch_vultr_page(url=url, api_key=api_key)
+        instances = payload.get("instances")
+        if not isinstance(instances, list):
+            raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+        for instance in instances:
+            instance_id, tags = _parse_vultr_instance(instance)
+            if _STREAMING_TAG in tags:
+                instance_ids.add(instance_id)
+        url = _next_page_url(payload)
+    return frozenset(instance_ids)
+
+
+def _fetch_vultr_page(*, url: str, api_key: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS) as response:
+            payload: Any = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise YouTubeAPIError(f"Vultr instances API request failed: {error}") from error
+    if not isinstance(payload, dict):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+    return payload
+
+
+def _parse_vultr_instance(instance: object) -> tuple[str, frozenset[str]]:
+    if not isinstance(instance, dict):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+    instance_id = instance.get("id")
+    tags = instance.get("tags")
+    if not isinstance(instance_id, str) or not instance_id or not isinstance(tags, list):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+    if not all(isinstance(tag, str) for tag in tags):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {instance!r}")
+    return instance_id, frozenset(tags)
+
+
+def _next_page_url(payload: dict[str, Any]) -> str | None:
+    meta = payload.get("meta")
+    if meta is None:
+        return None
+    if not isinstance(meta, dict) or not isinstance(meta.get("links"), dict):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+    next_url = meta["links"].get("next")
+    if next_url in (None, ""):
+        return None
+    if not isinstance(next_url, str):
+        raise YouTubeAPIError(f"Vultr instances API returned unexpected shape: {payload!r}")
+    parsed = urlparse(next_url)
+    if parsed.scheme != "https" or parsed.netloc != "api.vultr.com" or parsed.path != "/v2/instances":
+        raise YouTubeAPIError(f"Vultr instances API returned invalid next URL: {next_url!r}")
+    return next_url
+
+
+def load_managed_instance_ids(*, terraform_dir: Path, run_command: CommandRunner) -> frozenset[str]:
+    """initialized GCS backend の全 workspace state から Vultr instance ID を読む。"""
+    bucket, prefix = _load_gcs_backend(terraform_dir)
+    state_root = f"gs://{bucket}/{prefix}"
+    returncode, stdout, stderr = run_command(
+        ["gcloud", "storage", "ls", f"{state_root}/*.tfstate"],
+        _COMMAND_TIMEOUT_SECONDS,
+        cwd=terraform_dir,
+    )
+    if returncode != 0:
+        if "matched no URLs" in stderr:
+            return frozenset()
+        raise ConfigError(f"streaming Terraform state 一覧の取得に失敗: {stderr.strip() or returncode}")
+
+    state_uris = [line.strip() for line in stdout.splitlines() if line.strip()]
+    managed_ids: set[str] = set()
+    for state_uri in state_uris:
+        if not state_uri.startswith(f"{state_root}/") or not state_uri.endswith(".tfstate"):
+            raise ConfigError(f"streaming Terraform state URI has unexpected shape: {state_uri!r}")
+        managed_ids.update(_load_state_instance_ids(state_uri, terraform_dir, run_command))
+    return frozenset(managed_ids)
+
+
+def _load_gcs_backend(terraform_dir: Path) -> tuple[str, str]:
+    metadata_path = terraform_dir / ".terraform" / "terraform.tfstate"
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        message = f"streaming backend metadata がありません: `{terraform_dir}` で terraform init を実行してください"
+        raise ConfigError(message) from error
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ConfigError(f"streaming backend metadata を読み込めません: {error}") from error
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("backend"), dict):
+        raise ConfigError("streaming backend metadata has unexpected shape")
+    backend = payload["backend"]
+    config = backend.get("config")
+    if backend.get("type") != "gcs" or not isinstance(config, dict):
+        raise ConfigError("streaming backend metadata has unexpected shape")
+    bucket = config.get("bucket")
+    prefix = config.get("prefix")
+    if not isinstance(bucket, str) or not bucket or not isinstance(prefix, str) or not prefix:
+        raise ConfigError("streaming GCS backend config has unexpected shape")
+    return bucket.rstrip("/"), prefix.strip("/")
+
+
+def _load_state_instance_ids(
+    state_uri: str,
+    terraform_dir: Path,
+    run_command: CommandRunner,
+) -> set[str]:
+    returncode, stdout, stderr = run_command(
+        ["gcloud", "storage", "cat", state_uri],
+        _COMMAND_TIMEOUT_SECONDS,
+        cwd=terraform_dir,
+    )
+    if returncode != 0:
+        raise ConfigError(f"streaming Terraform state の取得に失敗 ({state_uri}): {stderr.strip() or returncode}")
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as error:
+        raise ConfigError(f"streaming Terraform state が不正 JSON ({state_uri}): {error}") from error
+    return _parse_state_instance_ids(payload, state_uri)
+
+
+def _parse_state_instance_ids(payload: object, state_uri: str) -> set[str]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("resources"), list):
+        raise ConfigError(f"streaming Terraform state has unexpected shape ({state_uri})")
+    instance_ids: set[str] = set()
+    for resource in payload["resources"]:
+        if not isinstance(resource, dict):
+            raise ConfigError(f"streaming Terraform state has unexpected shape ({state_uri})")
+        if resource.get("type") != "vultr_instance":
+            continue
+        instances = resource.get("instances")
+        if not isinstance(instances, list):
+            raise ConfigError(f"streaming Terraform state has unexpected shape ({state_uri})")
+        for instance in instances:
+            if not isinstance(instance, dict) or not isinstance(instance.get("attributes"), dict):
+                raise ConfigError(f"streaming Terraform state has unexpected shape ({state_uri})")
+            instance_id = instance["attributes"].get("id")
+            if not isinstance(instance_id, str) or not instance_id:
+                raise ConfigError(f"streaming Terraform state has unexpected shape ({state_uri})")
+            instance_ids.add(instance_id)
+    return instance_ids
+
+
+def reconcile_streaming_vps(
+    *,
+    terraform_dir: Path,
+    api_key: str,
+    run_command: CommandRunner,
+) -> StreamingVpsInventory:
+    """Terraform 管理 ID と Vultr 実インスタンス ID を読み取り専用で突合する。"""
+    managed_ids = load_managed_instance_ids(terraform_dir=terraform_dir, run_command=run_command)
+    actual_ids = fetch_tagged_instance_ids(api_key=api_key)
+    return StreamingVpsInventory(actual_instance_ids=actual_ids, managed_instance_ids=managed_ids)

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1327,8 +1327,8 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 7 bootstrap + 13 api + 3 channel + 4 data + 1 upload = 28
-        assert len(payload["checks"]) == 28
+        # 7 bootstrap + 14 api + 3 channel + 4 data + 1 upload = 29
+        assert len(payload["checks"]) == 29
         for c in payload["checks"]:
             assert c["status"] in ("ok", "info", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
@@ -5247,20 +5247,93 @@ class TestCheckNumberedDuplicates:
         assert r.status == "ok"
 
 
+class TestStreamingVpsState:
+    def test_skips_without_vultr_api_key(self, monkeypatch, tmp_path):
+        (tmp_path / "infra" / "terraform" / "streaming").mkdir(parents=True)
+        monkeypatch.delenv("VULTR_API_KEY", raising=False)
+        monkeypatch.delenv("TF_VAR_vultr_api_key", raising=False)
+        reconcile = MagicMock(side_effect=AssertionError("must not access external state"))
+        monkeypatch.setattr(doctor, "reconcile_streaming_vps", reconcile)
+
+        result = doctor.check_streaming_vps_state(tmp_path)
+
+        assert result.status == "info"
+        assert result.data == {"reason": "vultr_api_key_missing"}
+        reconcile.assert_not_called()
+
+    def test_warns_with_unmanaged_tagged_instance_ids(self, monkeypatch, tmp_path):
+        terraform_dir = tmp_path / "infra" / "terraform" / "streaming"
+        terraform_dir.mkdir(parents=True)
+        monkeypatch.setenv("VULTR_API_KEY", "secret")
+        inventory = MagicMock(
+            actual_instance_ids=frozenset({"managed", "unmanaged"}),
+            managed_instance_ids=frozenset({"managed"}),
+            unmanaged_instance_ids=frozenset({"unmanaged"}),
+        )
+        reconcile = MagicMock(return_value=inventory)
+        monkeypatch.setattr(doctor, "reconcile_streaming_vps", reconcile)
+
+        result = doctor.check_streaming_vps_state(tmp_path)
+
+        assert result.status == "warn"
+        assert result.data == {
+            "actual_instance_count": 2,
+            "managed_instance_count": 1,
+            "unmanaged_instance_ids": ["unmanaged"],
+        }
+        assert result.next_action["kind"] == "human"
+        assert "import" in result.next_action["instructions"]
+        reconcile.assert_called_once_with(
+            terraform_dir=terraform_dir,
+            api_key="secret",
+            run_command=doctor._run,
+        )
+
+    def test_is_ok_when_all_tagged_instances_are_managed(self, monkeypatch, tmp_path):
+        (tmp_path / "infra" / "terraform" / "streaming").mkdir(parents=True)
+        monkeypatch.setenv("TF_VAR_vultr_api_key", "terraform-secret")
+        monkeypatch.delenv("VULTR_API_KEY", raising=False)
+        inventory = MagicMock(
+            actual_instance_ids=frozenset({"managed"}),
+            managed_instance_ids=frozenset({"managed"}),
+            unmanaged_instance_ids=frozenset(),
+        )
+        monkeypatch.setattr(doctor, "reconcile_streaming_vps", MagicMock(return_value=inventory))
+
+        result = doctor.check_streaming_vps_state(tmp_path)
+
+        assert result.status == "ok"
+        assert result.data["unmanaged_instance_ids"] == []
+
+    def test_reports_unknown_when_reconciliation_fails(self, monkeypatch, tmp_path):
+        (tmp_path / "infra" / "terraform" / "streaming").mkdir(parents=True)
+        monkeypatch.setenv("VULTR_API_KEY", "secret")
+        monkeypatch.setattr(
+            doctor,
+            "reconcile_streaming_vps",
+            MagicMock(side_effect=ConfigError("backend unavailable")),
+        )
+
+        result = doctor.check_streaming_vps_state(tmp_path)
+
+        assert result.status == "unknown"
+        assert "backend unavailable" in result.message
+
+
 class TestRunAllChecksExtended:
-    def test_returns_28_checks(self, monkeypatch, tmp_path):
-        """7 bootstrap + 13 api + 3 channel + 4 data + 1 upload = 計 28 件."""
+    def test_returns_29_checks(self, monkeypatch, tmp_path):
+        """7 bootstrap + 14 api + 3 channel + 4 data + 1 upload = 計 29 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 28
+        assert len(results) == 29
 
-    def test_13_api_checks_present(self, monkeypatch, tmp_path):
-        """readonly token と oauth_client_sharing を含む 13 check が api カテゴリにある."""
+    def test_14_api_checks_present(self, monkeypatch, tmp_path):
+        """streaming VPS state 突合を含む 14 check が api カテゴリにある."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         api_results = [r for r in results if r.category == "api"]
-        assert len(api_results) == 13
-        assert api_results[-1].id == "reporting_job"
+        assert len(api_results) == 14
+        assert api_results[-1].id == "streaming_vps_state"
         assert any(r.id == "oauth_client_sharing" for r in api_results)
         assert any(r.id == "oauth_token_readonly" for r in api_results)
 
@@ -5282,6 +5355,7 @@ class TestRunAllChecksExtended:
         assert "initial_setup_readiness" in ids
         assert "upload_ready" in ids
         assert "reporting_job" in ids
+        assert "streaming_vps_state" in ids
 
     def test_category_order_bootstrap_then_api_then_channel_then_data_then_upload(self, monkeypatch, tmp_path):
         """runway 順序: bootstrap → api → channel → data → upload."""

--- a/tests/infrastructure/youtube/test_stream_state_reconciliation.py
+++ b/tests/infrastructure/youtube/test_stream_state_reconciliation.py
@@ -24,14 +24,13 @@ class _Response:
 
 
 def test_fetch_tagged_instances_filters_vultr_tags_and_paginates() -> None:
+    first_page_instances = [{"id": f"managed-{index}", "tags": ["youtube-stream"]} for index in range(500)]
+    untrusted_cursor = "https://attacker.example/collect?token=opaque value"
     pages = [
         _Response(
             {
-                "instances": [
-                    {"id": "managed", "tags": ["youtube-stream"]},
-                    {"id": "other", "tags": ["batch"]},
-                ],
-                "meta": {"links": {"next": "https://api.vultr.com/v2/instances?cursor=next"}},
+                "instances": first_page_instances,
+                "meta": {"links": {"next": untrusted_cursor}},
             }
         ),
         _Response(
@@ -48,9 +47,16 @@ def test_fetch_tagged_instances_filters_vultr_tags_and_paginates() -> None:
     ) as mock_open:
         result = state_reconciliation.fetch_tagged_instance_ids(api_key="secret")
 
-    assert result == frozenset({"managed", "unmanaged"})
+    assert len(result) == 501
+    assert "managed-499" in result
+    assert "unmanaged" in result
     assert mock_open.call_count == 2
     assert all(call.args[0].get_header("Authorization") == "Bearer secret" for call in mock_open.call_args_list)
+    assert mock_open.call_args_list[0].args[0].full_url == "https://api.vultr.com/v2/instances?per_page=500"
+    assert mock_open.call_args_list[1].args[0].full_url == (
+        "https://api.vultr.com/v2/instances?per_page=500&"
+        "cursor=https%3A%2F%2Fattacker.example%2Fcollect%3Ftoken%3Dopaque+value"
+    )
 
 
 @pytest.mark.parametrize(
@@ -60,8 +66,13 @@ def test_fetch_tagged_instances_filters_vultr_tags_and_paginates() -> None:
         {},
         {"instances": {}},
         {"instances": [{"id": "vps", "tags": "youtube-stream"}]},
+        {"instances": []},
+        {"instances": [], "meta": None},
         {"instances": [], "meta": []},
+        {"instances": [], "meta": {}},
         {"instances": [], "meta": {"links": []}},
+        {"instances": [], "meta": {"links": {}}},
+        {"instances": [], "meta": {"links": {"next": None}}},
         {"instances": [], "meta": {"links": {"next": 1}}},
     ],
 )
@@ -72,6 +83,31 @@ def test_fetch_tagged_instances_rejects_unexpected_api_shapes(payload: object) -
     ):
         with pytest.raises(YouTubeAPIError, match="unexpected shape"):
             state_reconciliation.fetch_tagged_instance_ids(api_key="secret")
+
+
+@pytest.mark.parametrize(
+    ("payload", "field_path"),
+    [
+        ({"instances": {"default_password": "do-not-leak"}}, "instances"),
+        (
+            {
+                "instances": [{"id": "vps", "tags": 1, "default_password": "do-not-leak"}],
+                "meta": {"links": {"next": ""}},
+            },
+            "instances[0].tags",
+        ),
+    ],
+)
+def test_fetch_tagged_instances_does_not_expose_response_secrets(payload: object, field_path: str) -> None:
+    with patch(
+        "youtube_automation.infrastructure.youtube.streaming.state_reconciliation.urllib.request.urlopen",
+        return_value=_Response(payload),
+    ):
+        with pytest.raises(YouTubeAPIError) as exc_info:
+            state_reconciliation.fetch_tagged_instance_ids(api_key="secret")
+
+    assert field_path in str(exc_info.value)
+    assert "do-not-leak" not in str(exc_info.value)
 
 
 def test_load_managed_ids_reads_every_gcs_workspace_state(tmp_path) -> None:
@@ -112,6 +148,26 @@ def test_load_managed_ids_fails_when_backend_metadata_is_missing(tmp_path) -> No
             terraform_dir=tmp_path,
             run_command=lambda *_args, **_kwargs: (0, "", ""),
         )
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    ["CommandException: matched no URLs", "One or more URLs matched no objects."],
+)
+def test_load_managed_ids_treats_gcloud_empty_listing_as_empty(tmp_path, stderr: str) -> None:
+    metadata = tmp_path / ".terraform" / "terraform.tfstate"
+    metadata.parent.mkdir()
+    metadata.write_text(
+        json.dumps({"backend": {"type": "gcs", "config": {"bucket": "bucket", "prefix": "streaming"}}}),
+        encoding="utf-8",
+    )
+
+    result = state_reconciliation.load_managed_instance_ids(
+        terraform_dir=tmp_path,
+        run_command=lambda *_args, **_kwargs: (1, "", stderr),
+    )
+
+    assert result == frozenset()
 
 
 def test_load_managed_ids_rejects_malformed_state_instead_of_ignoring_it(tmp_path) -> None:

--- a/tests/infrastructure/youtube/test_stream_state_reconciliation.py
+++ b/tests/infrastructure/youtube/test_stream_state_reconciliation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from youtube_automation.core.errors import ConfigError, YouTubeAPIError
+from youtube_automation.infrastructure.youtube.streaming import state_reconciliation
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+def test_fetch_tagged_instances_filters_vultr_tags_and_paginates() -> None:
+    pages = [
+        _Response(
+            {
+                "instances": [
+                    {"id": "managed", "tags": ["youtube-stream"]},
+                    {"id": "other", "tags": ["batch"]},
+                ],
+                "meta": {"links": {"next": "https://api.vultr.com/v2/instances?cursor=next"}},
+            }
+        ),
+        _Response(
+            {
+                "instances": [{"id": "unmanaged", "tags": ["youtube-stream", "prod"]}],
+                "meta": {"links": {"next": ""}},
+            }
+        ),
+    ]
+
+    with patch(
+        "youtube_automation.infrastructure.youtube.streaming.state_reconciliation.urllib.request.urlopen",
+        side_effect=pages,
+    ) as mock_open:
+        result = state_reconciliation.fetch_tagged_instance_ids(api_key="secret")
+
+    assert result == frozenset({"managed", "unmanaged"})
+    assert mock_open.call_count == 2
+    assert all(call.args[0].get_header("Authorization") == "Bearer secret" for call in mock_open.call_args_list)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [[], {}, {"instances": {}}, {"instances": [{"id": "vps", "tags": "youtube-stream"}]}],
+)
+def test_fetch_tagged_instances_rejects_unexpected_api_shapes(payload: object) -> None:
+    with patch(
+        "youtube_automation.infrastructure.youtube.streaming.state_reconciliation.urllib.request.urlopen",
+        return_value=_Response(payload),
+    ):
+        with pytest.raises(YouTubeAPIError, match="unexpected shape"):
+            state_reconciliation.fetch_tagged_instance_ids(api_key="secret")
+
+
+def test_load_managed_ids_reads_every_gcs_workspace_state(tmp_path) -> None:
+    terraform_dir = tmp_path / "streaming"
+    metadata = terraform_dir / ".terraform" / "terraform.tfstate"
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text(
+        json.dumps({"backend": {"type": "gcs", "config": {"bucket": "state-bucket", "prefix": "streaming"}}}),
+        encoding="utf-8",
+    )
+    commands: list[list[str]] = []
+
+    def run_command(cmd: list[str], _timeout: int, *, cwd=None) -> tuple[int, str, str]:
+        commands.append(cmd)
+        if cmd[:3] == ["gcloud", "storage", "ls"]:
+            return 0, "gs://state-bucket/streaming/a.tfstate\ngs://state-bucket/streaming/b.tfstate\n", ""
+        instance_id = "a-id" if cmd[-1].endswith("a.tfstate") else "b-id"
+        state = {
+            "resources": [
+                {"type": "vultr_instance", "instances": [{"attributes": {"id": instance_id}}]},
+                {"type": "local_file", "instances": [{"attributes": {"id": "ignored"}}]},
+            ]
+        }
+        return 0, json.dumps(state), ""
+
+    result = state_reconciliation.load_managed_instance_ids(
+        terraform_dir=terraform_dir,
+        run_command=run_command,
+    )
+
+    assert result == frozenset({"a-id", "b-id"})
+    assert commands[0] == ["gcloud", "storage", "ls", "gs://state-bucket/streaming/*.tfstate"]
+
+
+def test_load_managed_ids_fails_when_backend_metadata_is_missing(tmp_path) -> None:
+    with pytest.raises(ConfigError, match="terraform init"):
+        state_reconciliation.load_managed_instance_ids(
+            terraform_dir=tmp_path,
+            run_command=lambda *_args, **_kwargs: (0, "", ""),
+        )
+
+
+def test_load_managed_ids_rejects_malformed_state_instead_of_ignoring_it(tmp_path) -> None:
+    metadata = tmp_path / ".terraform" / "terraform.tfstate"
+    metadata.parent.mkdir()
+    metadata.write_text(
+        json.dumps({"backend": {"type": "gcs", "config": {"bucket": "bucket", "prefix": "streaming"}}}),
+        encoding="utf-8",
+    )
+
+    def run_command(cmd: list[str], _timeout: int, *, cwd=None) -> tuple[int, str, str]:
+        if cmd[2] == "ls":
+            return 0, "gs://bucket/streaming/default.tfstate\n", ""
+        return 0, json.dumps({"resources": {}}), ""
+
+    with pytest.raises(ConfigError, match="unexpected shape"):
+        state_reconciliation.load_managed_instance_ids(terraform_dir=tmp_path, run_command=run_command)

--- a/tests/infrastructure/youtube/test_stream_state_reconciliation.py
+++ b/tests/infrastructure/youtube/test_stream_state_reconciliation.py
@@ -55,7 +55,15 @@ def test_fetch_tagged_instances_filters_vultr_tags_and_paginates() -> None:
 
 @pytest.mark.parametrize(
     "payload",
-    [[], {}, {"instances": {}}, {"instances": [{"id": "vps", "tags": "youtube-stream"}]}],
+    [
+        [],
+        {},
+        {"instances": {}},
+        {"instances": [{"id": "vps", "tags": "youtube-stream"}]},
+        {"instances": [], "meta": []},
+        {"instances": [], "meta": {"links": []}},
+        {"instances": [], "meta": {"links": {"next": 1}}},
+    ],
 )
 def test_fetch_tagged_instances_rejects_unexpected_api_shapes(payload: object) -> None:
     with patch(


### PR DESCRIPTION
## Summary
- Vultr の配信VPSと全 GCS workspace state を read-only 突合する
- 管理外 ID を doctor warning と手動 import 導線で報告する
- API key 未設定や module 不在は外部通信なしで skip する

Closes #2524