### PR TITLE
feat(streaming): チャンネル別のVPS識別名を追加する (#2525)

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -73,6 +73,7 @@ cd infra/terraform/streaming
 cp terraform.tfvars.example terraform.tfvars
 # → video_path を絶対パスに書き換え
 # → allowed_ssh_cidr を operator の IP/32 に書き換え（例: ["203.0.113.5/32"]、`curl -s ifconfig.me` で取得）
+# → 複数チャンネル運用では channel_slug を設定（例: `005ch-abyss`）
 
 export TF_VAR_vultr_api_key=$(op read 'op://Personal/Vultr/api_key')
 export TF_VAR_stream_key=$(op read 'op://Personal/YouTube/stream_key')
@@ -84,6 +85,8 @@ terraform apply
 ```
 
 apply 完了で 1 本目の配信が即開始。`terraform output -raw instance_ip` で IP を確認。
+
+`channel_slug` を指定すると Vultr の instance `label` / `tags` は `youtube-stream-<channel_slug>` になり、複数チャンネルの VPS を一覧で識別できる。未指定時は従来の `youtube-stream` を維持する。Vultr provider では hostname 変更が instance の replace を誘発するため、`hostname` は `youtube-stream` のまま変更しない。
 
 `terraform plan` / `apply` は、ローカルに `ffprobe` があれば配信元 MP4 をプリフライト検証する。`run-ffmpeg.sh` は `-c:v copy` で映像をストリームコピーするため、ソース動画のキーフレーム間隔・ビットレート・H.264 profile が YouTube Live 品質をそのまま決める。キーフレーム最大間隔 > 4 秒、または 1080p で 4,500 Kbps 未満 / 720p で 2,500 Kbps 未満なら plan 時点で止まる。H.264 High profile 以外は warning。`ffprobe` が無い場合は soft skip される。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。
 - `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
 - `fix(suno-helper)`: downloaded POST 失敗の endpoint と download phase を overlay の中断表示と無人実行の `required-action` へ保持し、token 取得先で起点 request を覆わないエラー契約を固定（#3001）。
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -81,6 +81,7 @@ terraform workspace select <workspace>
 export TF_VAR_video_path="$(realpath /path/to/<workspace>/video.mp4)"
 export TF_VAR_stream_key="$(op read 'op://Personal/<workspace>-YouTube/stream_key')"
 export TF_VAR_discord_webhook_url="$(op read 'op://Personal/<workspace>-Discord-Webhook/url')"
+export TF_VAR_channel_slug="<workspace>"
 
 # workspace → state → plan の順で照合する
 terraform workspace show
@@ -91,7 +92,9 @@ terraform plan
 terraform apply
 ```
 
-`terraform workspace show` が意図した `<workspace>` と完全一致することを最初に確認する。既存 workspace では `terraform state list` がそのチャンネルの既存リソースを示すこと、新規 workspace では意図どおり空であることを確認する。最後に `terraform plan` の対象動画、作成・変更・削除されるリソースが選択中のチャンネルに限られることを確認する。workspace が違う、既存 state が空、または plan に別チャンネルの削除・置換や想定外の変更が含まれる場合は **apply しない**。正しい workspace を再選択し、3 つの `TF_VAR_*` を再注入して `workspace show` から確認し直す。
+`terraform workspace show` が意図した `<workspace>` と完全一致することを最初に確認する。既存 workspace では `terraform state list` がそのチャンネルの既存リソースを示すこと、新規 workspace では意図どおり空であることを確認する。最後に `terraform plan` の対象動画、作成・変更・削除されるリソースが選択中のチャンネルに限られることを確認する。workspace が違う、既存 state が空、または plan に別チャンネルの削除・置換や想定外の変更が含まれる場合は **apply しない**。正しい workspace を再選択し、4 つの `TF_VAR_*` を再注入して `workspace show` から確認し直す。
+
+`channel_slug` は Vultr instance の `label` / `tags` を `youtube-stream-<channel_slug>` にして一覧上の識別を可能にする。未指定時は従来の `youtube-stream` のままで差分は出ない。Vultr provider v2.32 では `hostname` が ForceNew のため、既存 instance を replace しないよう hostname は固定する。
 
 ## 既存 Vultr リソースの import
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -1,4 +1,5 @@
 locals {
+  instance_name           = var.channel_slug == "" ? "youtube-stream" : "youtube-stream-${var.channel_slug}"
   scripts_dir             = "${path.module}/../../../.claude/skills/streaming/references"
   ssh_host_key_algorithm  = "ED25519"
   ssh_host_public_key     = trimspace(tls_private_key.ssh_host.public_key_openssh)
@@ -58,8 +59,8 @@ resource "vultr_instance" "this" {
   plan     = var.plan
   os_id    = var.os_id
   hostname = "youtube-stream"
-  label    = "youtube-stream"
-  tags     = ["youtube-stream"]
+  label    = local.instance_name
+  tags     = [local.instance_name]
 
   firewall_group_id = vultr_firewall_group.stream.id
 

--- a/infra/terraform/streaming/terraform.tfvars.example
+++ b/infra/terraform/streaming/terraform.tfvars.example
@@ -27,6 +27,7 @@ allowed_ssh_cidr = ["203.0.113.5/32"]
 # region           = "nrt"
 # plan             = "vc2-1c-2gb"
 # os_id            = 2284
+# channel_slug     = "005ch-abyss"
 
 # 配信サイクル:
 #   0 / 0 は 24/7 連続配信（RuntimeMaxSec なし、クラッシュ時は 10 秒後に再起動）。

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -28,6 +28,12 @@ variable "os_id" {
   default     = 2284
 }
 
+variable "channel_slug" {
+  type        = string
+  description = "Vultr instance の label / tags に付与するチャンネル識別子。空文字は従来の youtube-stream を維持する"
+  default     = ""
+}
+
 variable "video_path" {
   type        = string
   description = "VPS にアップロードするローカル動画ファイルの絶対パス（環境依存のため必須項目）"

--- a/tests/repo/streaming/test_main_tf.py
+++ b/tests/repo/streaming/test_main_tf.py
@@ -139,7 +139,7 @@ class TestMainTf:
     def test_vultr_instance_uses_plural_tags_not_deprecated_tag(self):
         """Given main.tf
         When vultr_instance.this を読む
-        Then 単数 tag ではなく複数 tags を使い、"youtube-stream" を含む。
+        Then 単数 tag ではなく複数 tags を使い、解決済み instance name を含む。
 
         Vultr provider v2.x で単数 tag は非推奨。
         """
@@ -147,19 +147,34 @@ class TestMainTf:
         block = extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
         assert block is not None
         assert re.search(r"\btags\s*=\s*\[", block), "tags 属性（複数形）が無い"
-        assert re.search(r'tags\s*=\s*\[\s*"youtube-stream"\s*\]', block), 'tags = ["youtube-stream"] の形式でない'
+        assert re.search(r"tags\s*=\s*\[\s*local\.instance_name\s*\]", block), (
+            "tags が解決済み local.instance_name を参照していない"
+        )
         # 旧属性 `tag = "..."`（単一文字列）を使っていないこと
         assert not re.search(r'(?<!s)\btag\s*=\s*"', block), "旧形式の単数 tag を使っている（Vultr v2.x で非推奨）"
 
-    def test_vultr_instance_label_is_youtube_stream(self):
+    def test_vultr_instance_label_uses_resolved_instance_name(self):
         """Given main.tf
         When vultr_instance.this.label を読む
-        Then "youtube-stream" が設定されている（運用識別用）。
+        Then channel_slug を反映する解決済み instance name が設定されている。
         """
         text = strip_hcl_comments(read_file(_MAIN_TF))
         block = extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
         assert block is not None
-        assert re.search(r'label\s*=\s*"youtube-stream"', block), 'label = "youtube-stream" が設定されていない'
+        assert re.search(r"label\s*=\s*local\.instance_name", block), (
+            "label が解決済み local.instance_name を参照していない"
+        )
+
+    def test_instance_name_preserves_default_and_appends_channel_slug(self):
+        """Given channel_slug の設定有無
+        When locals.instance_name を解決する
+        Then 未指定は従来名、指定時は channel slug 付きの名前になる。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        assert re.search(
+            r'instance_name\s*=\s*var\.channel_slug\s*==\s*""\s*\?\s*"youtube-stream"\s*:\s*"youtube-stream-\$\{var\.channel_slug\}"',
+            text,
+        ), "instance_name が channel_slug 未指定時の後方互換と指定時の識別名を両立していない"
 
     def test_vultr_instance_hostname_is_youtube_stream(self):
         """Given main.tf

--- a/tests/repo/streaming/test_terraform_meta.py
+++ b/tests/repo/streaming/test_terraform_meta.py
@@ -338,6 +338,16 @@ class TestTfvarsExample:
             "TF_VAR_vultr_api_key の案内コメントが無い（運用者が secret 注入方法を発見できない）"
         )
 
+    def test_documents_optional_channel_slug(self):
+        """Given terraform.tfvars.example
+        When 任意項目を読む
+        Then channel_slug のチャンネル別設定例を発見できる。
+        """
+        raw = read_file(_TFVARS_EXAMPLE)
+        assert re.search(r'^#\s*channel_slug\s*=\s*"005ch-abyss"', raw, flags=re.MULTILINE), (
+            "channel_slug のコメント付き設定例が無い"
+        )
+
 
 # ============================================================================
 # terraform.tfvars.example — #125 で video_path / TF_VAR_stream_key 注入手順を追記

--- a/tests/repo/streaming/test_variables_tf.py
+++ b/tests/repo/streaming/test_variables_tf.py
@@ -88,6 +88,18 @@ class TestVariablesTf:
         assert re.search(r"default\s*=\s*2284\b", block), "os_id.default が 2284 でない"
         assert re.search(r"description\s*=", block), "os_id.description が無い（マジックナンバー禁止）"
 
+    def test_channel_slug_is_optional_string_with_empty_default(self):
+        """Given variables.tf
+        When channel_slug 変数定義を読む
+        Then string 型かつ空文字 default で既存名を維持する。
+        """
+        text = strip_hcl_comments(read_file(_VARIABLES_TF))
+        block = extract_block(text, r'variable\s+"channel_slug"')
+        assert block is not None, 'variable "channel_slug" が存在しない'
+        assert re.search(r"type\s*=\s*string", block), "channel_slug.type が string でない"
+        assert re.search(r'default\s*=\s*""', block), 'channel_slug.default が空文字でない'
+        assert re.search(r"description\s*=", block), "channel_slug.description が無い"
+
 
 # ============================================================================
 # variables.tf — #125 追加変数（video_path / stream_key）

--- a/tests/repo/streaming/test_variables_tf.py
+++ b/tests/repo/streaming/test_variables_tf.py
@@ -97,7 +97,7 @@ class TestVariablesTf:
         block = extract_block(text, r'variable\s+"channel_slug"')
         assert block is not None, 'variable "channel_slug" が存在しない'
         assert re.search(r"type\s*=\s*string", block), "channel_slug.type が string でない"
-        assert re.search(r'default\s*=\s*""', block), 'channel_slug.default が空文字でない'
+        assert re.search(r'default\s*=\s*""', block), "channel_slug.default が空文字でない"
         assert re.search(r"description\s*=", block), "channel_slug.description が無い"
 
 


### PR DESCRIPTION
## Summary
- optional channel_slug を Vultr label/tags に反映する
- 未指定時の youtube-stream と hostname 固定を維持する
- Terraform validate と streaming 契約テストで互換性を固定する

Closes #2525