### PR TITLE
fix(streaming): import後のVPS置換を防ぐ (#2527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。
+- `fix(streaming)`: Vultr API が import 後に復元できない `user_data` / `ssh_key_ids` の ForceNew 差分だけで稼働中の `vultr_instance` が replace されないようにし、新規構築と動画差し替えの既存結線を維持（#2527）。
+
 - `fix(doctor)`: `initial_setup_readiness` でも有効な thumbnail ユーザー承認済み例外を尊重し、承認済みの規約外参照パスだけで恒久的に warn にならないようにした（#2509）。
 - `fix(suno-helper)`: downloaded POST 失敗の endpoint と download phase を overlay の中断表示と無人実行の `required-action` へ保持し、token 取得先で起点 request を覆わないエラー契約を固定（#3001）。
 - `feat(wf-new)`: 採用済み `planning-preview.png` を AI 再生成や重複承認なしで原子的に `thumbnail.jpg` へ形式変換し、プレビュー不在時だけ既存 `/thumbnail` 生成へフォールバックする経路を追加（#2514）。

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -135,7 +135,9 @@ terraform plan
 
 import しなかった 2 resource は state に存在しないため、plan では `# tls_private_key.ssh_host will be created` と `# null_resource.deploy will be created` がそれぞれ `+ create` 予定になる。この 2 件の `+ create` だけなら import 漏れや instance replacement ではなく、未管理 resource を Terraform 管理へ加える想定差分である。
 
-既存 VPS の SSH host key と新規の `tls_private_key.ssh_host` は一致しない。さらに、その生成鍵を埋め込む `vultr_instance.this.user_data` と provisioner の `host_key` は既存 VPS の値を Terraform から復元できない。同じ plan に `vultr_instance.this must be replaced` が併記された場合に限り、破壊的な instance replacement として **apply しない**。既存 host key と `user_data` を保全した移行方針が別途承認されるまで停止し、`terraform apply` や `-target` で差分を部分適用しない。
+`vultr_instance.this` は、Vultr API が import 後に読み戻せない `user_data` と `ssh_key_ids` の差分だけを `lifecycle.ignore_changes` で無視する。これらの差分だけで `vultr_instance.this must be replaced` にはならない。この lifecycle は既存 instance の差分判定にだけ作用し、新規構築時は従来どおり両属性を Vultr API へ渡す。
+
+既存 VPS の SSH host key と新規の `tls_private_key.ssh_host` は一致せず、provisioner の `host_key` に既存 VPS の値を Terraform から復元できない。そのため、この手順は state 復旧と非破壊 plan の確認までとし、`tls_private_key.ssh_host` / `null_resource.deploy` の create 予定は **apply しない**。`user_data` / `ssh_key_ids` 以外の変更が原因で同じ plan に `vultr_instance.this must be replaced` が併記された場合も、破壊的な instance replacement として停止し、`terraform apply` や `-target` で差分を部分適用しない。
 
 ## ライブチャット自動返信（opt-in）
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -71,6 +71,11 @@ resource "vultr_instance" "this" {
     ssh_host_private_key = tls_private_key.ssh_host.private_key_openssh
     ssh_host_public_key  = local.ssh_host_public_key
   })
+
+  lifecycle {
+    # Vultr API が import 時に復元できない ForceNew 属性だけで稼働中 VPS を replace しない。
+    ignore_changes = [user_data, ssh_key_ids]
+  }
 }
 
 resource "null_resource" "deploy" {

--- a/tests/repo/streaming/test_main_tf.py
+++ b/tests/repo/streaming/test_main_tf.py
@@ -119,11 +119,7 @@ class TestMainTf:
         assert lifecycle is not None, "vultr_instance.this に lifecycle が無い"
         ignore_changes = re.search(r"ignore_changes\s*=\s*\[([^]]+)\]", lifecycle, flags=re.DOTALL)
         assert ignore_changes is not None, "lifecycle.ignore_changes が無い"
-        ignored_attributes = {
-            value.strip()
-            for value in ignore_changes.group(1).split(",")
-            if value.strip()
-        }
+        ignored_attributes = {value.strip() for value in ignore_changes.group(1).split(",") if value.strip()}
         assert ignored_attributes == {"user_data", "ssh_key_ids"}
 
     def test_null_resource_connection_enables_host_key_verification(self):

--- a/tests/repo/streaming/test_main_tf.py
+++ b/tests/repo/streaming/test_main_tf.py
@@ -107,6 +107,25 @@ class TestMainTf:
             "cloud-init に ssh_host_public_key が渡されていない"
         )
 
+    def test_vultr_instance_ignores_import_only_force_new_differences(self):
+        """Given import 後に API から復元できない force-new 属性
+        When vultr_instance.this の lifecycle を読む
+        Then user_data / ssh_key_ids だけを ignore し、instance replacement を防ぐ。
+        """
+        text = strip_hcl_comments(read_file(_MAIN_TF))
+        block = extract_block(text, r'resource\s+"vultr_instance"\s+"this"')
+        assert block is not None
+        lifecycle = extract_block(block, r"lifecycle")
+        assert lifecycle is not None, "vultr_instance.this に lifecycle が無い"
+        ignore_changes = re.search(r"ignore_changes\s*=\s*\[([^]]+)\]", lifecycle, flags=re.DOTALL)
+        assert ignore_changes is not None, "lifecycle.ignore_changes が無い"
+        ignored_attributes = {
+            value.strip()
+            for value in ignore_changes.group(1).split(",")
+            if value.strip()
+        }
+        assert ignored_attributes == {"user_data", "ssh_key_ids"}
+
     def test_null_resource_connection_enables_host_key_verification(self):
         """Given main.tf
         When null_resource.deploy.connection を読む


### PR DESCRIPTION
## Summary
- import 後の user_data / ssh_key_ids 差分だけで VPS を replace しない
- 新規構築時の属性注入と動画差し替え結線を維持する
- Terraform validate と HCL 契約テストで安全性を固定する

Closes #2527