### PR TITLE
test(dashboard): 公開活動の初期表示順を固定する (#2554)

### DIFF
--- a/dashboard/e2e/dashboard.spec.ts
+++ b/dashboard/e2e/dashboard.spec.ts
@@ -304,6 +304,44 @@ test.afterAll(async () => {
   if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true })
 })
 
+test("初期表示で公開活動を概況とチャンネル比較より前に表示する", async ({
+  page,
+}) => {
+  await page.goto(baseURL)
+
+  const publicationActivity = page.getByRole("region", {
+    name: "過去365日の公開活動",
+  })
+  const overview = page.getByRole("region", { name: "概況" })
+  const comparison = page.getByRole("table", {
+    name: "チャンネル横断ストック一覧",
+  })
+  await expect(publicationActivity).toBeVisible()
+  await expect(overview).toBeVisible()
+  await expect(comparison).toBeVisible()
+
+  expect(
+    await publicationActivity.evaluate(
+      (activity, laterElement) =>
+        Boolean(
+          activity.compareDocumentPosition(laterElement) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ),
+      await overview.elementHandle()
+    )
+  ).toBe(true)
+  expect(
+    await publicationActivity.evaluate(
+      (activity, laterElement) =>
+        Boolean(
+          activity.compareDocumentPosition(laterElement) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ),
+      await comparison.elementHandle()
+    )
+  ).toBe(true)
+})
+
 test("概要から動画詳細まで keyboard で確認できる", async ({ page }) => {
   await page.setViewportSize({ width: 760, height: 900 })
   await page.goto(baseURL)


### PR DESCRIPTION
## Summary
- 実dashboardを起動するPlaywrightで公開活動・概況・チャンネル横断表を特定する
- 公開活動が概況とチャンネル横断表の両方よりDOM上で前にある初期表示契約を固定する
- focused E2E、dashboard lint、typecheckを通す

Closes #2554