### PR TITLE
docs(suno): Style検証の責務境界を確定する (#3155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
+- `docs(suno)`: `yt-collection-preflight` は標準骨格、`yt-suno-verify` は collection ごとの effective Style を含む Suno artifact の検証を担う責務境界を確定し、CLI と契約テストで固定（#3155）。
 - `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。
 - `fix(streaming)`: Vultr API が import 後に復元できない `user_data` / `ssh_key_ids` の ForceNew 差分だけで稼働中の `vultr_instance` が replace されないようにし、新規構築と動画差し替えの既存結線を維持（#2527）。
 

--- a/docs/adr/0026-suno-preflight-responsibility.md
+++ b/docs/adr/0026-suno-preflight-responsibility.md
@@ -1,0 +1,46 @@
+# Suno Style 検証と collection 骨格検証の責務分離
+
+## Status
+
+accepted (2026-08-10, #3155)
+
+## Context
+
+collection 固有の `suno-patterns.yaml` が channel 設定の `genre_line` や
+`style_variants` を上書きできるようになり、Style 文字数上限などの検証には
+両方を解決した effective config が必要になった。一方、
+`yt-collection-preflight` は collection の必須ディレクトリと
+`workflow-state.json` の初期構造を検証・補完する入口であり、Suno 設定や
+生成 artifact を読み込まない。
+
+## Decision
+
+`yt-collection-preflight` は標準ディレクトリ骨格と `workflow-state.json` の
+初期構造だけを検証する。Suno の設定解決、`suno-patterns.yaml`、
+`suno-prompts.json`、`suno-lyrics.json` の内容、および collection ごとの
+effective Style は `yt-suno-verify` が検証する。
+
+したがって、patterns 側の Style がある場合も `yt-collection-preflight` に
+重複した Style 検査を追加しない。Suno artifact の生成後に
+`yt-suno-verify` を実行し、その単一の解決結果で Style 契約を判定する。
+
+## Consequences
+
+- collection の初期化直後や Suno artifact の生成前でも、骨格の補完を独立して実行できる。
+- Style の上書き優先順位と検証対象が複数入口へ複製されない。
+- `yt-collection-preflight` の成功は Suno artifact の妥当性を保証しない。Suno 工程の完了条件には `yt-suno-verify` の成功が必要になる。
+
+## Considered Options
+
+- **`yt-collection-preflight` に Style 検査を追加する**: effective Style の解決と
+  Suno artifact の読み込みを骨格検証へ複製し、artifact が未生成の初期化工程でも
+  Suno 固有の前提を持ち込むため不採用。
+- **channel config の Style だけを `yt-collection-preflight` で検査する**:
+  patterns override を反映しない結果が `yt-suno-verify` と食い違うため不採用。
+
+## Related
+
+- #2998
+- #3152
+- `src/youtube_automation/commands/collections/collection_preflight.py`
+- `src/youtube_automation/commands/suno/suno_verify.py`

--- a/src/youtube_automation/commands/collections/collection_preflight.py
+++ b/src/youtube_automation/commands/collections/collection_preflight.py
@@ -42,7 +42,7 @@ def _resolve_targets(collections: list[str], planning_root: Path | None) -> list
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="コレクションの標準ディレクトリ骨格を検証・補完する")
+    parser = argparse.ArgumentParser(description="コレクションの標準ディレクトリ骨格のみを検証・補完する")
     parser.add_argument("collections", nargs="*", help="対象コレクション（ディレクトリ名 or パス）")
     parser.add_argument("--fix", action="store_true", help="欠落サブディレクトリを冪等に作成する")
     parser.add_argument("--planning-root", type=Path, default=None, help="planning ディレクトリの明示指定")

--- a/src/youtube_automation/domains/uploads/preflight.py
+++ b/src/youtube_automation/domains/uploads/preflight.py
@@ -553,6 +553,11 @@ def check_collection(
     *,
     supported_languages: list[str] | None = None,
 ) -> tuple[bool, str]:
+    """標準骨格と workflow-state の初期構造だけを検証・補完する.
+
+    Suno の設定解決や生成 artifact の内容検証は、effective Style と同じ
+    source を読める ``yt-suno-verify`` の責務とする。
+    """
     paths = CollectionPaths(collection_dir)
     name = collection_dir.name
     langs = ["en"] if supported_languages is None else list(dict.fromkeys(supported_languages))

--- a/tests/commands/collections/test_collection_preflight.py
+++ b/tests/commands/collections/test_collection_preflight.py
@@ -77,6 +77,19 @@ class TestCheckCollection:
         assert ok
         assert line.startswith("[OK]")
 
+    def test_suno_artifact_content_is_outside_skeleton_validation(self, tmp_path):
+        """Suno artifact の内容に関係なく、標準骨格だけを検証する."""
+        collection = _make_collection(tmp_path, "20260701-tc-suno-artifact-collection")
+        (collection / "20-documentation" / "suno-patterns.yaml").write_text(
+            "genre_line: " + "x" * 121 + "\n",
+            encoding="utf-8",
+        )
+
+        ok, line = check_collection(collection, fix=False)
+
+        assert ok
+        assert line.startswith("[OK]")
+
     def test_missing_master_dir_is_ng(self, tmp_path):
         """issue #1494 の実事例: 01-master だけが欠落しているケース。"""
         subdirs = [s for s in REQUIRED_SUBDIRS if s != "01-master"]
@@ -199,3 +212,12 @@ class TestMainExitCodes:
     def test_no_targets_exits_zero(self, tmp_path, monkeypatch, capsys):
         self._run(monkeypatch, ["--planning-root", str(tmp_path)])
         assert "検証対象" in capsys.readouterr().out
+
+    def test_help_identifies_standard_skeleton_as_the_validation_scope(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["yt-collection-preflight", "--help"])
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+        assert exc.value.code == 0
+        assert "標準ディレクトリ骨格のみを検証・補完する" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- `yt-collection-preflight` を collection 骨格検証に限定
- effective Suno Style 検証を `yt-suno-verify` の責務として ADR と契約テストで固定
- `style_influence` / `weirdness` は明示要件外として変更しない

Closes #3155