### PR TITLE
fix(suno): patternsの禁止Styleを生成前に拒否する (#2998)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
+- `fix(suno)`: `suno-patterns.yaml` が上書きした effective Style にも channel の `banned_artists` を適用し、禁止アーティスト検出時は channel Style と同じ `ConfigError` で出力前に停止する契約を固定（#2998）。
 - `docs(suno)`: `yt-collection-preflight` は標準骨格、`yt-suno-verify` は collection ごとの effective Style を含む Suno artifact の検証を担う責務境界を確定し、CLI と契約テストで固定（#3155）。
 - `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。
 - `fix(streaming)`: Vultr API が import 後に復元できない `user_data` / `ssh_key_ids` の ForceNew 差分だけで稼働中の `vultr_instance` が replace されないようにし、新規構築と動画差し替えの既存結線を維持（#2527）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -830,16 +830,18 @@ def main():
     if not patterns_path.exists():
         parser.error(f"{patterns_path} not found")
 
-    md_path = patterns_path.parent / SUNO_PROMPTS_MD_FILENAME
-    md_path.write_text(generate(patterns_path))
-    print(f"Generated: {md_path}")
-
-    json_path = patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME
     entries = build_prompt_entries(patterns_path)
+    markdown = generate(patterns_path)
     payload = {
         "entries": entries,
         "duration_filter": _duration_filter_from_config(load_skill_config("suno")),
     }
+
+    md_path = patterns_path.parent / SUNO_PROMPTS_MD_FILENAME
+    md_path.write_text(markdown)
+    print(f"Generated: {md_path}")
+
+    json_path = patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME
     json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Generated: {json_path}")
 

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -1143,6 +1143,28 @@ def test_main_writes_suno_prompts_json_alongside_md(channel_dir, tmp_path, monke
     assert json_path.exists(), "suno-prompts.json が併出されること"
 
 
+@pytest.mark.parametrize("style_source", ["channel", "patterns"])
+def test_main_rejects_banned_artist_before_writing_outputs(
+    channel_dir,
+    tmp_path,
+    monkeypatch,
+    style_source,
+):
+    """channel/patterns どちらの Style でも同じ ConfigError で生成を止める."""
+    banned_style = "lo-fi jazz inspired by Drake"
+    channel_style = banned_style if style_source == "channel" else "lo-fi jazz"
+    patterns_style = banned_style if style_source == "patterns" else None
+    _write_suno_override(channel_dir, genre_line=channel_style, banned_artists=["Drake"])
+    patterns_path = _write_minimal_patterns(tmp_path, genre_line=patterns_style)
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
+
+    with pytest.raises(ConfigError, match="Banned artist.*Drake"):
+        main()
+
+    assert not (patterns_path.parent / "suno-prompts.md").exists()
+    assert not (patterns_path.parent / "suno-prompts.json").exists()
+
+
 def test_main_json_output_is_loadable_array_of_entries(channel_dir, tmp_path, monkeypatch):
     """Given main 実行後の suno-prompts.json
     When json.loads する


### PR DESCRIPTION
## Summary

- patterns / channel 由来の禁止アーティストを同一 severity で検出
- 出力前に `ConfigError` で停止する統合契約を追加
- Style 文字数検証は #3152、責務境界は下段 #3155 の契約を維持

Closes #2998

Depends on #3662