### PR TITLE
docs(suno): collection単位のStyle手順を追加する (#2999)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -50,7 +50,7 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 ### モード判定
 
-`config/skills/suno.yaml` の `genre_line` を読み取り、以下の 4 段の決定木で上から順に判定する（先に該当した段で確定し、以降は評価しない）。
+`suno-patterns.yaml::genre_line` があればそれを、無ければ `config/skills/suno.yaml::genre_line` または `suno_preset` fallback を読み取り、以下の 4 段の決定木で上から順に判定する（先に該当した段で確定し、以降は評価しない）。
 
 1. **否定表現が先**: `instrumental` / `no vocals` / `without vocals` / `vocal-free` などの否定表現が含まれていれば、他の語より優先して**インストゥルメンタルモード**に確定する
 2. **ボーカル語の完全一致**: 1 に該当せず、`vocals` / `vocal` / `singing` / `singer` / `rap` / `choir` / `humming` / `male vocals` / `female vocals` のいずれかが完全一致で含まれていれば**ボーカルモード**
@@ -111,37 +111,27 @@ generator は pattern draft、設定、benchmark analysis、必要な References
 - `config/channel/` が存在すること（`load_config()` でロード可能）。存在しない場合は `/channel-new`（既存チャンネルは取り込みモード）を案内して停止する
 - チャンネルの音楽エンジンが Suno であること。Lyria チャンネルでは本スキルを使わず `/lyria` を案内する
 - 対象コレクション（`collections/planning/` 配下の `workflow-state.json`）が `/wf-new` で作成済みであること。無ければ `/wf-new` を案内して停止する
-- `config/skills/suno.yaml::genre_line` または `data/video_analysis/<slug>/*.json`（`suno_preset`）が利用可能であること。詳細な判定と自動準備は「前提条件チェック（hard gate）」に従う
+- collection 固有 Style を直接指定する場合は `20-documentation/suno-patterns.yaml::genre_line`、指定しない場合は `config/skills/suno.yaml::genre_line` または `data/video_analysis/<slug>/*.json`（`suno_preset`）を fallback として利用できること。解決順は「Style 入力の解決（collection 優先、preset 推奨）」に従う
 - ボーカルモードの merge 段階では `20-documentation/suno-lyrics.json` が必要。無ければ先に `/suno-lyric` を実行する
 
 ## Instructions
 
-### 前提条件チェック（hard gate）
+### Style 入力の解決（collection 優先、preset 推奨）
 
-**AI は `genre_line` を手書きしてはならない。** 方向性は必ずスクリプト（`uv run yt-video-analyze` の `suno_preset` 出力）由来とする。`/suno` 実行に入る最初のステップとして以下を機械的に判定し、不足データがあれば原則自動で収集する:
+Style は collection 境界で一度だけ解決し、次の優先順を使う。
 
-1. `config/skills/suno.yaml` の `genre_line` を読む
-2. `config/channel/analytics.json` の `benchmark.channels[].slug` を列挙
-3. 各 slug について `data/video_analysis/<slug>/*.json` の存在を確認
+1. `20-documentation/suno-patterns.yaml` の root `genre_line` を collection の effective Style とする。同じ collection だけに効かせる `exclude_styles`、`style_variants`、`vocal_gender` も root に直接書ける
+2. root に無い値は `config/skills/suno.yaml` の channel 共通値へ fallback する
+3. `genre_line` が両方で空なら、`data/video_analysis/<slug>/*.json` の集約済み `suno_preset.genre_line` を fallback として使う
+4. `suno_preset` も無い場合は、確定企画、creative constraints、benchmark 分析を根拠に generator が collection 固有の `genre_line` を設計し、`suno-patterns.yaml` に保存してよい
 
-`benchmark.channels[].slug` は自動実行と出力パスに使うため、列挙直後に `^[A-Za-z0-9][A-Za-z0-9_-]*$` で検証する。不一致の slug が 1 件でもあれば自動準備を停止し、該当 slug を修正してから再実行する。slug を shell 文字列へ直埋めしてはいけない。実行する場合は `["uv", "run", "yt-video-analyze", "--source", "benchmark", "--competitor", slug, "--top", "5"]` のような argv 配列で渡す。shell 経由が避けられない環境では `shlex.quote(slug)` 相当で quote する。
+`suno_preset` は推奨入力であり hard gate ではない。利用可能なら TTP 根拠として優先的に参照し、無ければ必要に応じて `/benchmark` と `uv run yt-video-analyze --source benchmark --competitor <slug> --top 5` で準備する。ただし取得不能だけを理由に collection-local Style の設計を停止しない。
 
-| 状態 | 判定 | アクション |
-|---|---|---|
-| `genre_line` 非空 | OK | パターン設計に進む（既存 `suno_preset` fallback は引き続き有効） |
-| `genre_line` 空 + 少なくとも 1 slug で `data/video_analysis/<slug>/*.json` 存在 | OK | `suno_preset.genre_line` を fallback として採用しパターン設計に進む |
-| `genre_line` 空 + 全 slug で `data/video_analysis/<slug>/*.json` 不在 | **自動準備** | benchmark / video-analyze を自動実行して `suno_preset` を生成してから続行する |
+`/suno` の generator と呼び出し元は、collection 固有値のために共有 config を書き換えない。別 collection の実行時はその collection 自身の `suno-patterns.yaml` を読み直し、前の collection の root 値を再利用・転記しない。これにより同一 process や連続する subagent 委譲でも collection 間の Style 混線を防ぐ。channel 全体の既定を意図的に変更するときだけ、別途ユーザーが `config/skills/suno.yaml` を更新する。
 
-自動準備の手順:
+`benchmark.channels[].slug` を自動準備へ使う場合は、列挙直後に `^[A-Za-z0-9][A-Za-z0-9_-]*$` で検証する。不一致があれば自動準備だけを停止し、該当 slug を修正してから再実行する。実行時は `["uv", "run", "yt-video-analyze", "--source", "benchmark", "--competitor", slug, "--top", "5"]` のような argv 配列で渡し、shell 文字列へ直埋めしない。
 
-1. `data/benchmark_*.json` が無ければ `/benchmark` 相当の収集を先行実行
-2. `data/benchmark_*.json` 取得済みなら、上記 validation 済み slug だけを対象に `uv run yt-video-analyze --source benchmark --competitor <slug> --top 5` 相当を argv 配列で全 benchmark slug に実行
-3. 生成された `data/video_analysis/<slug>/*.json` の `suno_preset` を fallback として採用
-4. そのまま `/suno` のパターン設計へ進む
-
-ユーザー確認が必要なのは、現実のお金のコストが発生する操作だけ。例: 有料API/有料生成の実行、Suno クレジット消費、Veo / 画像生成 / 音楽生成の新規実行、課金設定変更、外部サービスへの購入・決済。YouTube API / Analytics / ローカル解析 / 既存ファイル読み取り / benchmark 収集 / video-analyze のような準備処理は、追加課金が発生しない前提なら確認せず自動実行する。
-
-それでも `suno_preset` が取得できない場合のみ、パターン設計に進まず停止する。`genre_line` 候補を本文中で口頭提案するのは禁止（手書き相当のため）。どうしても手書きで続行する場合は、ユーザーが明示的に `config/skills/suno.yaml::genre_line` を埋めてから再実行する。
+保存後は `uv run yt-suno-verify <collection-path>` を実行する。これは `suno-patterns.yaml` の root `genre_line` と使用中 `style_variants`、channel fallback を同じ effective Style として解決し、設定済み文字数上限を検証する。`yt-collection-preflight` は標準骨格だけの検証なので Style 判定には使わない。
 
 ### 蓄積 insights 参照（lever=bgm）
 
@@ -168,9 +158,9 @@ jq -c 'select(.status == "open" and .lever == "bgm")' data/insights.jsonl
 
 ### Suno プリセット推奨（suno_preset fallback）
 
-`data/video_analysis/<slug>/*.json` の `suno_preset.genre_line` / `suno_preset.exclude_styles` を `uv run yt-generate-suno` が fallback として参照する。`config/skills/suno.yaml` の対応キーが空のとき、全 slug 横断で集約した推奨値を採用する。ユーザーが `config/skills/suno.yaml` に override を書いた瞬間にそちらが優先される（後方互換）。
+`20-documentation/suno-patterns.yaml` の root 値があれば collection-local override として最優先する。root に無いキーは `config/skills/suno.yaml` の channel 共通値へ fallback し、その対応キーも空のときだけ `data/video_analysis/<slug>/*.json` の `suno_preset.genre_line` / `suno_preset.exclude_styles` を `uv run yt-generate-suno` が全 slug 横断で集約して採用する。これにより既存の channel override 優先も維持する（後方互換）。
 
-> **方向性は必ずスクリプト由来とする（AI 手書き禁止）**: `genre_line` 空 + `suno_preset` fallback も取れない状態で本 skill が AI 推定の `genre_line` を書き起こすことは禁止する。
+> **推奨であり必須ではない**: collection 固有の方向性が確定している場合は、generator が根拠を示して `suno-patterns.yaml::genre_line` へ直接書く。共有 `config/skills/suno.yaml` へ collection 固有値を転記しない。
 
 ### 対象テーマ
 
@@ -205,6 +195,12 @@ Style フィールドの文字数上限は `config/skills/suno.yaml::style_char_
 ### Vocal Lyrics Boundary
 
 ボーカル曲の歌詞本文は `/suno-lyric` が生成する。`/suno` は `suno-lyrics.json` と `suno-patterns.yaml` の entry name を照合し、Style / 情景 / タイトルとマージするだけに限定する。
+
+### Collection vocal gender の整合
+
+ボーカル collection で `suno-patterns.yaml::vocal_gender` を指定した場合、その値は Suno UI の歌声だけでなく `/suno-lyric` へ渡す語り手の性別入力にも使う。`/suno-lyric` 委譲前に `config/skills/suno-lyric.yaml::vocal_gender` と比較し、異なる場合は collection 値を今回の生成入力として明示する。共有 config は書き換えない。
+
+`male` / `female` では歌詞本文の一人称・相手への呼びかけ・人称代名詞が意図した語り手と矛盾しないことを reviewer が確認する。`neutral` / `auto` では根拠なく性別を固定せず、collection の persona と scene に沿う中立表現を使う。`/suno-lyric` 完了後に `/suno` へ戻り、同じ `vocal_gender` を含む `suno-prompts.json` と歌詞の語り手が一致していることを semantic review で確認する。
 
 ### Lyrics Structure Auto-Reinforcement
 
@@ -444,6 +440,8 @@ Suno V5.5 では Styles 経由で実楽曲長を制御できない。望む長�
 title: Collection Title Here
 mode: instrumental  # 省略時は genre_line から自動判定
 tracks: 10  # 省略時は config の tracks_per_collection
+genre_line: lo-fi jazz, warm tape tone, felt piano, laid-back drums, slow
+exclude_styles: harsh distortion, dramatic buildups
 patterns:
   # 1 pattern = 1 scene = 固有タイトル。ceil(10/2) = 5 個の entry
   - name_jp: 屋上の静寂
@@ -473,13 +471,15 @@ patterns:
       - condensation tracing slow lines down a warm kitchen window, a kettle just finished steaming
 ```
 
+上記の `genre_line` / `exclude_styles` はこの collection だけの値であり、`config/skills/suno.yaml` へコピーしない。ボーカル collection で歌声も固定する場合は同じ root に `vocal_gender: male | female | neutral | auto` を追加し、「Collection vocal gender の整合」に従って `/suno-lyric` へ引き渡す。root 値を省略したキーだけが channel config へ fallback する。
+
 ### Step 2: スクリプトで suno-prompts.md を生成
 
 ```bash
 uv run yt-generate-suno <collection-path>
 ```
 
-`config/skills/suno.yaml` の `genre_line` + `exclude_styles` + `style_influence` をパターンに自動付加して `suno-prompts.md` と `suno-prompts.json` を生成する。ボーカルモードでは entry `name` を使い、同階層の `suno-lyrics.json` から同名 lyrics を Style とマージする。
+`suno-patterns.yaml` の collection-local `genre_line` / `exclude_styles` / `style_variants` / `vocal_gender` を優先し、省略した値だけを channel config から fallback して `suno-prompts.md` と `suno-prompts.json` を生成する。ボーカルモードでは entry `name` を使い、同階層の `suno-lyrics.json` から同名 lyrics を Style とマージする。
 
 Suno helper の Custom Duration を collection 共通で指定する場合は、チャンネル側 `config/skills/suno.yaml` に秒単位の正の整数 `duration_sec` を設定する。明示した場合だけ同じ数値を `suno-prompts.json` の全 entry へ出力し、未設定時はキー自体を省略する。`duration_sec` は生成前の目標尺であり、生成後 clip の採用範囲を表す `duration_filter` から推定・同期しない。
 
@@ -498,7 +498,7 @@ override 後は `uv run yt-generate-suno` を再実行して `suno-prompts.json`
 uv run yt-suno-verify <collection-path>
 ```
 
-`suno-prompts.json` / `suno-lyrics.json` の展開後 entry 数、entry name、歌詞構造、`genre_line` 文字数を検証し、exit 0 を確認する。その後、別コンテキスト reviewer が `suno-prompts.json` のみを読み、`.claude/skills/suno-lyric/references/review-rubric.md` に従って LLM semantic review を実行し、entry ごとに `PASS` / `FAIL` + 理由を出す。reviewer は `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field だけを判定材料にし、`review_context` 欠落を `/suno` entry の failure reason にしない。`FAIL` entry のみ最大 2 周まで generator subagent（Codex では別コンテキスト実行）に再生成させる。全 entry が `PASS` した後にだけ Suno UI へ投入する。上限到達時に `FAIL` が残る場合は Step 3 へ進まず、残課題をユーザーに提示する。
+`suno-prompts.json` / `suno-lyrics.json` の展開後 entry 数、entry name、歌詞構造に加え、patterns root と使用中 variant、channel fallback を解決した effective Style の `genre_line` 文字数を検証し、exit 0 を確認する。その後、別コンテキスト reviewer が `suno-prompts.json` のみを読み、`.claude/skills/suno-lyric/references/review-rubric.md` に従って LLM semantic review を実行し、entry ごとに `PASS` / `FAIL` + 理由を出す。reviewer は `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field だけを判定材料にし、`review_context` 欠落を `/suno` entry の failure reason にしない。`FAIL` entry のみ最大 2 周まで generator subagent（Codex では別コンテキスト実行）に再生成させる。全 entry が `PASS` した後にだけ Suno UI へ投入する。上限到達時に `FAIL` が残る場合は Step 3 へ進まず、残課題をユーザーに提示する。
 
 `yt-generate-suno` 自体は `workflow-state.json` を更新しない。`/suno` を呼び出したメインエージェント（`/wf-new` / `/wf-next` からの呼び出しと、`/suno` の直接実行を含む）が、生成された成果物、`yt-suno-verify` の成功、semantic review の全 entry `PASS` を確認した後にだけ、`assets.music_prompts = true`、`planning.music`、`updated_at` を更新する。subagent は state を書き込まない。
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -26,7 +26,7 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 
 - `config/channel/` が存在し `load_config()` でロード可能であること。存在しない場合は `/channel-new`、ロード失敗の場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
 - `/setup` が完了していること（ffmpeg / uv / automation パッケージ / OAuth）。未完なら `/setup` を案内して停止する
-- Suno チャンネルで `/suno` を呼ぶ場合は、`config/skills/suno.yaml::genre_line` または `data/video_analysis/<slug>/*.json` が必要（詳細は Hard Gates 3）
+- Suno チャンネルで `/suno` を呼ぶ場合は、collection の確定企画と書き込み先 `20-documentation/suno-patterns.yaml` を明示する。channel config と `suno_preset` は fallback / 推奨入力として扱う（詳細は Hard Gates 3）
 
 ## Hard Gates
 
@@ -34,7 +34,7 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 
 1. **channel config gate**: `config/channel/` が存在し、`load_config()` でロードできること。存在しない場合は `/channel-new`、ロード失敗の場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する。この状態では `/collection-ideate`、`/thumbnail`、`/suno`、`/lyria` を呼ばない。
 2. **前提未達時の state 変更禁止**: channel config gate で停止した場合、`uv run yt-init-collection` を実行しない。`collections/planning/`、`workflow-state.json`、`assets.*` を新規作成・更新しない。
-3. **Suno readiness gate**: Suno チャンネルで `/suno` を呼ぶ直前に、`config/skills/suno.yaml::genre_line` または `data/video_analysis/<slug>/*.json` が存在することを確認する。不足している場合は `/suno` を呼ばず、`uv run yt-video-analyze --source benchmark --competitor <slug> --top 5` を案内して停止する。AI が `genre_line` を手書き補完して続行すること、`assets.music_prompts = true` に更新することは禁止。
+3. **Suno collection Style boundary**: Suno チャンネルで `/suno` を呼ぶときは、対象 collection の絶対 path、確定企画、theme、書き込み先 `20-documentation/suno-patterns.yaml` を subagent へ渡す。collection 固有の `genre_line` / `exclude_styles` / `style_variants` / `vocal_gender` は同ファイルの root に書き、共有 `config/skills/suno.yaml` を書き換えない。root に無い値だけが channel config へ fallback する。`suno_preset` は推奨入力であり、不在だけを理由に停止しない。利用可能なら TTP 根拠として渡し、無ければ `/suno` が確定企画と制約から collection-local Style を設計する。`assets.music_prompts = true` は subagent 報告だけで更新せず、成果物、`yt-suno-verify`、semantic review をメインが検証した後に限る。
 4. **analytics input gate**: 入力モード判定、同日付 JSON、validator、stale 判定、自動更新、再検証は `/collection-ideate` の `references/freshness-rules.md::stale report の自動更新` に一元化する。`/wf-new` は判定ロジックを再定義せず、stale 判定や AskUserQuestion を先行実行しない。subagent が stale を検出した場合は、同 SSOT が返す自動更新シーケンスを同じ subagent 作業内で順次実行し、全呼び出し成功後に入力モード判定を先頭からやり直す。`yt-doctor` の `analytics_report` は予備確認にだけ使い、analytics mode の最終判定には使わない。
 5. **subagent state boundary**: 各フェーズの生成処理は Agent ツールで subagent へ一作業ずつ委譲する。subagent は `workflow-state.json` を書き込まず AskUserQuestion を実行しない。メインエージェントだけが承認、成果物検証、`assets` / `phase` / `updated_at` 更新を行う。
 6. **failure boundary**: subagent の失敗、期待成果物欠落、現在の phase との不整合時は state を更新しない。同じ未完了ステップから再実行できる状態で停止する。
@@ -285,7 +285,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 
 #### 2c. サムネイル確定 + 音楽素材生成
 
-サムネイル候補生成、承認・確定、音楽素材生成を以下の 2 substep で順に進める。Suno チャンネルでは、音楽素材生成へ進む前に `config/skills/suno.yaml::genre_line` または `data/video_analysis/<slug>/*.json` が存在することをメインが再確認する。不足時は `/suno` を起動せず、`uv run yt-video-analyze --source benchmark --competitor <slug> --top 5` を案内して停止する。AI が `genre_line` を手書き補完して続行すること、`assets.music_prompts = true` に更新することは禁止。
+サムネイル候補生成、承認・確定、音楽素材生成を以下の 2 substep で順に進める。Suno チャンネルでは、メインが対象 collection と確定企画を固定し、`config/skills/suno.yaml` と利用可能な `data/video_analysis/<slug>/*.json` を fallback / 推奨入力として `/suno` へ渡す。subagent は共有 config を変更せず、その collection の `20-documentation/suno-patterns.yaml` に effective Style 系の root 値を保存する。`suno_preset` が無くても確定企画と制約から collection-local Style を設計して続行し、検証前に `assets.music_prompts = true` へ更新しない。
 
 ##### 2c-1. サムネイル候補生成
 
@@ -362,7 +362,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 4. `thumbnail.jpg` と `main.png/jpg` の確定を検証した後だけ、メインが `assets.thumbnail = true`、`thumbnail.approved = true`、`updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
 
 5. **音楽 skill を順番に処理**:
-   - Suno: readiness gate 通過後、対象 collection と theme を指定して Agent ツールで `/suno <theme>` のプロンプト生成を委譲する
+   - Suno: 対象 collection、theme、確定企画、書き込み先 `20-documentation/suno-patterns.yaml` を指定して Agent ツールで `/suno <theme>` のプロンプト生成を委譲する。共有 `config/skills/suno.yaml` の書き換えを禁止し、collection root の Style 値と channel fallback を解決した後に `uv run yt-suno-verify <collection-path>` を通す。ボーカルでは root `vocal_gender` を `/suno-lyric` の語り手性別入力にも引き渡す
    - Lyria: 対象 collection と theme を指定して Agent ツールで `/lyria <theme>` のプロンプト設計だけを委譲する（Lyria 3 API 呼び出しは `/wf-next`）
    - subagent には state 更新と AskUserQuestion を禁止する。メインが `20-documentation/suno-prompts.json` または Lyria 設計成果物の存在を検証し、成功時だけ `assets.music_prompts = true` と `updated_at` を更新する
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
+- `docs(suno)`: `suno_preset` を hard gate から推奨入力へ変更し、collection 固有の effective Style と vocal gender を `suno-patterns.yaml` に保存して共有 channel config を変更せず `/wf-new`・`/suno-lyric`・`yt-suno-verify` へ引き渡す正規手順を追加（#2999）。
 - `fix(suno)`: `suno-patterns.yaml` が上書きした effective Style にも channel の `banned_artists` を適用し、禁止アーティスト検出時は channel Style と同じ `ConfigError` で出力前に停止する契約を固定（#2998）。
 - `docs(suno)`: `yt-collection-preflight` は標準骨格、`yt-suno-verify` は collection ごとの effective Style を含む Suno artifact の検証を担う責務境界を確定し、CLI と契約テストで固定（#3155）。
 - `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -638,7 +638,7 @@ def test_channel_new_pre_wf_new_checks_include_analytics_reporting_and_live_stre
     assert "/streaming の準備確認" in success_message
 
 
-def test_wf_new_fail_fast_contract_points_to_channel_new_and_doctor_readiness() -> None:
+def test_wf_new_fail_fast_contract_points_to_channel_new_and_collection_local_suno_style() -> None:
     wf_new = _read(".claude/skills/wf-new/SKILL.md")
     channel_new = _read(".claude/skills/channel-new/SKILL.md")
     doctor = _read("src/youtube_automation/commands/system/doctor.py")
@@ -648,8 +648,10 @@ def test_wf_new_fail_fast_contract_points_to_channel_new_and_doctor_readiness() 
     assert "config/channel/` が存在し、`load_config()` でロードできること" in hard_gates
     assert "存在しない場合は `/channel-new`" in hard_gates
     assert "ロード失敗の場合は `/channel-new`（既存チャンネル取り込みモード）" in hard_gates
-    assert "Suno readiness gate" in hard_gates
-    assert "uv run yt-video-analyze --source benchmark --competitor <slug> --top 5" in hard_gates
+    assert "Suno collection Style boundary" in hard_gates
+    assert "`20-documentation/suno-patterns.yaml`" in hard_gates
+    assert "共有 `config/skills/suno.yaml` を書き換えない" in hard_gates
+    assert "`suno_preset` は推奨入力" in hard_gates
 
     assert "既存チャンネル取り込みモード" in channel_new
     assert "ttp_wf_new_readiness" in channel_new

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -460,6 +460,43 @@ def test_suno_documents_pass_fail_loop_contract() -> None:
         assert token in text, f"/suno SKILL.md に PASS/FAIL ループ契約がない（`{token}` 不在）"
 
 
+def test_suno_documents_collection_local_effective_style_contract() -> None:
+    """Issue #2999: collection 固有 Style を共有 config へ混ぜずに解決・検証する."""
+    text = _read()
+    section = text.split("### Style 入力の解決（collection 優先、preset 推奨）", 1)[1].split("\n### ", 1)[0]
+
+    for token in (
+        "`20-documentation/suno-patterns.yaml`",
+        "`genre_line`",
+        "`exclude_styles`",
+        "`vocal_gender`",
+        "`config/skills/suno.yaml`",
+        "fallback",
+        "`suno_preset` は推奨入力",
+        "共有 config を書き換えない",
+        "collection 間",
+        "`uv run yt-suno-verify <collection-path>`",
+        "effective Style",
+    ):
+        assert token in section
+
+
+def test_suno_documents_collection_vocal_gender_handoff_to_lyric() -> None:
+    """Issue #2999: collection の歌声性別を歌詞の語り手へ引き渡す."""
+    text = _read()
+    section = text.split("### Collection vocal gender の整合", 1)[1].split("\n### ", 1)[0]
+
+    for token in (
+        "`suno-patterns.yaml::vocal_gender`",
+        "`config/skills/suno-lyric.yaml::vocal_gender`",
+        "`/suno-lyric`",
+        "語り手",
+        "人称代名詞",
+        "共有 config は書き換えない",
+    ):
+        assert token in section
+
+
 def test_suno_blocks_step_3_until_semantic_review_passes() -> None:
     """Issue #1485: /suno は semantic review 全 PASS 後だけ Suno UI 投入へ進む。"""
     text = _read()


### PR DESCRIPTION
## Summary

- `suno-patterns.yaml` へ collection-local Style を直接書く正規手順を追加
- channel fallback、collection 間の混線防止、vocal_gender の歌詞工程への引き渡しを明文化
- `yt-suno-verify` による effective Style 検証と wf-new の委譲契約を更新

Closes #2999

Depends on #3665