### PR TITLE
fix(thumbnail): 参照画像の外れ値を事前検出する (#2952)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -557,7 +557,7 @@ TTP 参照画像が固定されているチャンネルでは、候補生成後�
 | `enabled: true`, `mode: selection_only` または mode 未設定 | 実行 | 実行 | 実行 | **省略**（#1370 の従来挙動） |
 | `enabled: true`, `mode: full` | **省略** | **省略**（生成 CLI に `-y`） | **省略** | **省略** |
 
-`selection_only` の既存手順は変更しない。`auto_selection.enabled` が false / 未設定のチャンネルも従来の手動承認フローを使う。
+`selection_only` の既存手順は変更しない。参照プールに `max_reference_distance`（既定 0.40）超過があれば参照ごとの構造化診断を出して警告継続し、`full` は strict 参照生成の API 呼び出し前と自動選択前に停止する。prompt の色・背景指定は参照プール外れ値の代替対策にしない。`auto_selection.enabled` が false / 未設定のチャンネルも従来の手動承認フローを使う。
 
 有効化キーと採点パラメータは [quality / operations 詳細](references/quality-and-operations.md) を読む。
 
@@ -682,7 +682,7 @@ JSON
 
 画像確認・承認後、`thumbnail.approved = true` を更新する。`textless.enabled: false` では `share_thumbnail_as_main.py` の成功と `thumbnail.jpg` / `main.jpg` の SHA-256 一致、`main.png` 不在を確認した後だけ更新する。`mode: full` では目視確認と AskUserQuestion を省略し、既存の自動確定成功を承認完了として扱う。`ab_test.enabled: true` の場合は、設定された全 pattern の `thumbnail-<name>.jpg` が存在し、各 pattern の承認（`full` では自動確定）が完了し、`thumbnail.jpg` が先頭 pattern と同一内容であることを確認してからだけ更新する。一部 pattern の承認・確定に失敗した状態では `false` のままにする。
 
-`yt-thumbnail-auto-select --apply` で確定した場合は、選択候補・distance・ランキング・実行時刻が `thumbnail_auto_selection` キーに監査ログとして自動記録される（#1370）。
+`yt-thumbnail-auto-select --apply` で確定した場合は、選択候補・distance・ランキング・参照画像ごとの centroid distance / outlier 判定・実行時刻が `thumbnail_auto_selection` キーに監査ログとして自動記録される（#1370、#2952）。
 
 ## stock 退避と再利用
 

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -67,6 +67,9 @@ image_generation:
     min_height: 720
     # 16:9 判定の許容誤差 (|width/height - 16/9| がこの値以下なら適格)
     aspect_tolerance: 0.01
+    # 参照画像ごとの centroid 距離上限。超過時は selection_only では警告、
+    # full では生成 API 呼び出し前および自動選択前に停止する。
+    max_reference_distance: 0.40
 
   gemini:
     # 使用する Gemini 画像生成モデル

--- a/.claude/skills/thumbnail/references/quality-and-operations.md
+++ b/.claude/skills/thumbnail/references/quality-and-operations.md
@@ -26,9 +26,9 @@ single_step の初回 `diff_prompt_template` はテキスト付き `thumbnail-v*
 
 ## auto-selection 設定と採点
 
-`image_generation.auto_selection` で `enabled`、`mode`、`min_width`、`min_height`、`aspect_tolerance` を設定する。`selection_only` は候補承認だけを省略し、`full` は `SKILL.md` の表に示す 4 ゲートを省略する。
+`image_generation.auto_selection` で `enabled`、`mode`、`min_width`、`min_height`、`aspect_tolerance`、`max_reference_distance`（既定 0.40）を設定する。`selection_only` は候補承認だけを省略し、`full` は `SKILL.md` の表に示す 4 ゲートを省略する。
 
-`image_generation.gemini.reference_images.default` の各参照画像から brightness / contrast / saturation / dominant_hue / colorfulness を抽出して centroid を作る。16:9 と最小解像度を満たす候補を採点し、centroid への distance が最小の候補を選ぶ。apply 時は PNG 候補を必要に応じて JPEG へ変換し、`thumbnail_auto_selection` に選択候補・distance・ランキング・実行時刻を記録する。
+`image_generation.gemini.reference_images.default` の各参照画像から brightness / contrast / saturation / dominant_hue / colorfulness を抽出して centroid を作る。各参照の centroid 距離が上限を超えた場合、`selection_only` は構造化診断を残して警告継続し、`full` は候補確定前に停止する。`yt-generate-image --ttp-strict-references` でも同じ診断を生成 API 呼び出し前に行う。16:9 と最小解像度を満たす候補を採点し、centroid への distance が最小の候補を選ぶ。apply 時は PNG 候補を必要に応じて JPEG へ変換し、`thumbnail_auto_selection` に選択候補・distance・ランキング・参照ごとの診断・実行時刻を記録する。prompt の色・背景指定だけを参照プールの構造的な外れ値対策として扱わない。
 
 候補なし、参照なし、解像度や 16:9 条件を満たす候補なし、確定済みファイル存在、無効設定は silent fallback せず停止する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
+
 - `feat(streaming)`: optional な `channel_slug` を Vultr instance の label / tags に反映し、未指定時の既存名と replace 対象の hostname を維持した（#2525）。
 - `fix(streaming)`: Vultr API が import 後に復元できない `user_data` / `ssh_key_ids` の ForceNew 差分だけで稼働中の `vultr_instance` が replace されないようにし、新規構築と動画差し替えの既存結線を維持（#2527）。
 

--- a/src/youtube_automation/commands/media/generate_image.py
+++ b/src/youtube_automation/commands/media/generate_image.py
@@ -19,11 +19,15 @@ import sys
 import time
 from pathlib import Path
 
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.thumbnail.references import (
     format_reference_assignment,
     plan_ttp_reference_assignments,
     resolve_dedup_recent_collections,
+)
+from youtube_automation.domains.thumbnail.selection import (
+    diagnose_reference_pool,
+    resolve_auto_selection_settings,
 )
 from youtube_automation.infrastructure.media.image_provider import (
     ImageGenerationRequest,
@@ -66,6 +70,25 @@ def _channel_root() -> Path:
     from youtube_automation.configuration import channel_dir
 
     return channel_dir()
+
+
+def _preflight_reference_pool(reference_assignments: list[Path | None], skill_cfg: dict) -> None:
+    references = [reference for reference in reference_assignments if reference is not None]
+    settings = resolve_auto_selection_settings(skill_cfg)
+    diagnostic = diagnose_reference_pool(
+        references,
+        max_reference_distance=settings.max_reference_distance,
+    )
+    if not diagnostic.outliers:
+        return
+    details = ", ".join(f"{item.path}: distance={item.distance:.4f}" for item in diagnostic.outliers)
+    message = (
+        "参照画像プールに centroid 距離の外れ値があります "
+        f"(max_reference_distance={diagnostic.max_reference_distance:.4f}): {details}"
+    )
+    if settings.enabled and settings.mode == "full":
+        raise ValidationError(message)
+    print(f"[WARN] {message}", file=sys.stderr)
 
 
 def _required_mapping(value: object, key: str) -> dict:
@@ -521,10 +544,11 @@ def main():
                 channel_dir=_channel_root(),
                 dedup_recent_collections=dedup_recent_collections,
             )
+            _preflight_reference_pool(reference_assignments, skill_cfg)
         else:
             benchmark_root = None
             reference_assignments = plan_reference_assignments(reference_images, cli_max_attempts, rotate)
-    except ConfigError as e:
+    except (ConfigError, ValidationError) as e:
         print(f"[ERROR] {e}")
         sys.exit(1)
 

--- a/src/youtube_automation/commands/thumbnail/auto_select_thumbnail.py
+++ b/src/youtube_automation/commands/thumbnail/auto_select_thumbnail.py
@@ -42,14 +42,12 @@ from PIL import Image, UnidentifiedImageError
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.thumbnail.archive import archive_approved_thumbnail_transaction
-from youtube_automation.domains.thumbnail.features import (
-    extract_features_from_path,
-    feature_centroid,
-)
 from youtube_automation.domains.thumbnail.references import resolve_configured_benchmark_references
 from youtube_automation.domains.thumbnail.selection import (
     CandidateScore,
+    ReferencePoolDiagnostic,
     _image_generation_section,
+    diagnose_reference_pool,
     resolve_auto_selection_settings,
     score_candidates,
     select_best,
@@ -205,6 +203,7 @@ def record_workflow_state(
     channel_root: Path,
     executed_at: str,
     mode: str,
+    reference_diagnostic: ReferencePoolDiagnostic,
 ) -> None:
     """検証済みの workflow-state に選択の監査ログを記録して書き戻す。"""
     record: dict[str, object] = {
@@ -214,6 +213,7 @@ def record_workflow_state(
         "distance": round(best.distance, 4),
         "ranking": _ranking_payload(scores),
         "reference_images": [_relative_to_channel(path, channel_root) for path in reference_images],
+        "reference_diagnostics": _reference_diagnostic_payload(reference_diagnostic, channel_root),
         "executed_at": executed_at,
     }
     validate_audit_record(record)
@@ -277,6 +277,35 @@ def validate_audit_record(record: dict[str, object]) -> None:
         if not isinstance(reasons, list) or any(not isinstance(reason, str) for reason in reasons):
             raise ValidationError(f"{key}.reasons は文字列の list である必要があります: {reasons!r}")
 
+    diagnostics = record.get("reference_diagnostics")
+    if not isinstance(diagnostics, dict):
+        raise ValidationError(
+            f"thumbnail_auto_selection.reference_diagnostics は object である必要があります: {diagnostics!r}"
+        )
+    threshold = diagnostics.get("max_reference_distance")
+    if not _finite_number(threshold) or threshold < 0:
+        raise ValidationError(
+            "thumbnail_auto_selection.reference_diagnostics.max_reference_distance は "
+            "0 以上の有限数値である必要があります: "
+            f"{threshold!r}"
+        )
+    references = diagnostics.get("references")
+    if not isinstance(references, list) or not references:
+        raise ValidationError(
+            "thumbnail_auto_selection.reference_diagnostics.references は非空 list である必要があります: "
+            f"{references!r}"
+        )
+    for index, entry in enumerate(references):
+        key = f"thumbnail_auto_selection.reference_diagnostics.references[{index}]"
+        if not isinstance(entry, dict):
+            raise ValidationError(f"{key} は object である必要があります: {entry!r}")
+        if not isinstance(entry.get("reference_image"), str) or not entry["reference_image"].strip():
+            raise ValidationError(f"{key}.reference_image は非空文字列である必要があります")
+        if not _finite_number(entry.get("distance")) or entry["distance"] < 0:
+            raise ValidationError(f"{key}.distance は 0 以上の有限数値である必要があります")
+        if not isinstance(entry.get("outlier"), bool):
+            raise ValidationError(f"{key}.outlier は boolean である必要があります")
+
     executed_at = record.get("executed_at")
     if not isinstance(executed_at, str):
         raise ValidationError(
@@ -313,6 +342,31 @@ def _ranking_payload(scores: list[CandidateScore]) -> list[dict[str, Any]]:
         }
         for score in scores
     ]
+
+
+def _reference_diagnostic_payload(
+    diagnostic: ReferencePoolDiagnostic,
+    channel_root: Path,
+) -> dict[str, Any]:
+    return {
+        "max_reference_distance": diagnostic.max_reference_distance,
+        "references": [
+            {
+                "reference_image": _relative_to_channel(reference.path, channel_root),
+                "distance": round(reference.distance, 4),
+                "outlier": reference.outlier,
+            }
+            for reference in diagnostic.references
+        ],
+    }
+
+
+def _reference_outlier_message(diagnostic: ReferencePoolDiagnostic) -> str:
+    details = ", ".join(f"{item.path}: distance={item.distance:.4f}" for item in diagnostic.outliers)
+    return (
+        "参照画像プールに centroid 距離の外れ値があります "
+        f"(max_reference_distance={diagnostic.max_reference_distance:.4f}): {details}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +408,7 @@ def _render_json(
     channel_root: Path,
     workflow_state_updated: bool | None,
     auto_selection_mode: str,
+    reference_diagnostic: ReferencePoolDiagnostic,
 ) -> str:
     return json.dumps(
         {
@@ -369,6 +424,7 @@ def _render_json(
             "target": str(target),
             "ranking": _ranking_payload(scores),
             "reference_images": [_relative_to_channel(path, channel_root) for path in reference_images],
+            "reference_diagnostics": _reference_diagnostic_payload(reference_diagnostic, channel_root),
             "workflow_state_updated": workflow_state_updated,
         },
         ensure_ascii=False,
@@ -415,6 +471,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: コレクションディレクトリではありません (10-assets/ が必要): {collection}", file=sys.stderr)
         return 2
 
+    reference_diagnostic: ReferencePoolDiagnostic | None = None
+    channel_root: Path | None = None
     try:
         cfg = load_skill_config(SKILL_NAME)
         settings = resolve_auto_selection_settings(cfg)
@@ -430,17 +488,22 @@ def main(argv: list[str] | None = None) -> int:
 
         channel_root = channel_dir()
         reference_images = resolve_reference_images(cfg, channel_root)
-        try:
-            centroid = feature_centroid([extract_features_from_path(path) for path in reference_images])
-        except (OSError, UnidentifiedImageError) as exc:
-            raise ValidationError(f"参照画像を読み込めません: {exc}") from exc
+        reference_diagnostic = diagnose_reference_pool(
+            reference_images,
+            max_reference_distance=settings.max_reference_distance,
+        )
+        if reference_diagnostic.outliers:
+            message = _reference_outlier_message(reference_diagnostic)
+            if settings.mode == _MODE_FULL:
+                raise ValidationError(message)
+            print(f"[WARN] {message}", file=sys.stderr)
 
         candidates = discover_candidates(paths.assets_dir)
         if not candidates:
             patterns = ", ".join(_CANDIDATE_PATTERNS)
             raise ValidationError(f"thumbnail 候補が見つかりません: {paths.assets_dir} (対象: {patterns})")
 
-        scores = score_candidates(candidates, centroid, settings)
+        scores = score_candidates(candidates, reference_diagnostic.centroid, settings)
         best = select_best(scores, mode=settings.mode)
 
         target = paths.assets_dir / _TARGET_FILENAME
@@ -468,6 +531,7 @@ def main(argv: list[str] | None = None) -> int:
                         channel_root=channel_root,
                         executed_at=datetime.now(timezone.utc).isoformat(),
                         mode=settings.mode,
+                        reference_diagnostic=reference_diagnostic,
                     )
             except (ConfigError, ValidationError) as exc:
                 rollback_errors = []
@@ -495,7 +559,10 @@ def main(argv: list[str] | None = None) -> int:
     except (ConfigError, ValidationError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         if args.json:
-            print(json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False))
+            payload: dict[str, Any] = {"status": "error", "error": str(exc)}
+            if reference_diagnostic is not None and channel_root is not None:
+                payload["reference_diagnostics"] = _reference_diagnostic_payload(reference_diagnostic, channel_root)
+            print(json.dumps(payload, ensure_ascii=False))
         return 1
 
     mode = "apply" if args.apply else "dry-run"
@@ -511,6 +578,7 @@ def main(argv: list[str] | None = None) -> int:
                 channel_root=channel_root,
                 workflow_state_updated=workflow_state_updated,
                 auto_selection_mode=settings.mode,
+                reference_diagnostic=reference_diagnostic,
             )
         )
     else:

--- a/src/youtube_automation/commands/thumbnail/auto_select_thumbnail.py
+++ b/src/youtube_automation/commands/thumbnail/auto_select_thumbnail.py
@@ -347,7 +347,7 @@ def _ranking_payload(scores: list[CandidateScore]) -> list[dict[str, Any]]:
 def _reference_diagnostic_payload(
     diagnostic: ReferencePoolDiagnostic,
     channel_root: Path,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     return {
         "max_reference_distance": diagnostic.max_reference_distance,
         "references": [
@@ -559,7 +559,7 @@ def main(argv: list[str] | None = None) -> int:
     except (ConfigError, ValidationError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         if args.json:
-            payload: dict[str, Any] = {"status": "error", "error": str(exc)}
+            payload: dict[str, object] = {"status": "error", "error": str(exc)}
             if reference_diagnostic is not None and channel_root is not None:
                 payload["reference_diagnostics"] = _reference_diagnostic_payload(reference_diagnostic, channel_root)
             print(json.dumps(payload, ensure_ascii=False))

--- a/src/youtube_automation/domains/thumbnail/selection.py
+++ b/src/youtube_automation/domains/thumbnail/selection.py
@@ -11,6 +11,7 @@ from PIL import Image, UnidentifiedImageError
 from youtube_automation.core.adapters.errors import ConfigError, ValidationError
 from youtube_automation.domains.thumbnail.features import (
     extract_features_from_path,
+    feature_centroid,
     feature_distance,
 )
 
@@ -18,6 +19,7 @@ _TARGET_ASPECT = 16 / 9
 _DEFAULT_MIN_WIDTH = 1280
 _DEFAULT_MIN_HEIGHT = 720
 _DEFAULT_ASPECT_TOLERANCE = 0.01
+_DEFAULT_MAX_REFERENCE_DISTANCE = 0.40
 _MODE_SELECTION_ONLY = "selection_only"
 _MODE_FULL = "full"
 _ALLOWED_MODES = (_MODE_SELECTION_ONLY, _MODE_FULL)
@@ -30,6 +32,25 @@ class AutoSelectionSettings:
     min_width: int
     min_height: int
     aspect_tolerance: float
+    max_reference_distance: float = _DEFAULT_MAX_REFERENCE_DISTANCE
+
+
+@dataclass(frozen=True)
+class ReferenceDiagnostic:
+    path: Path
+    distance: float
+    outlier: bool
+
+
+@dataclass(frozen=True)
+class ReferencePoolDiagnostic:
+    centroid: dict[str, float]
+    max_reference_distance: float
+    references: list[ReferenceDiagnostic]
+
+    @property
+    def outliers(self) -> list[ReferenceDiagnostic]:
+        return [reference for reference in self.references if reference.outlier]
 
 
 @dataclass(frozen=True)
@@ -68,6 +89,16 @@ def resolve_auto_selection_settings(cfg: dict[str, object]) -> AutoSelectionSett
         or tolerance < 0
     ):
         raise ConfigError(f"auto_selection.aspect_tolerance は 0 以上の数値である必要があります: {tolerance!r}")
+    max_reference_distance = raw.get("max_reference_distance", _DEFAULT_MAX_REFERENCE_DISTANCE)
+    if (
+        isinstance(max_reference_distance, bool)
+        or not isinstance(max_reference_distance, (int, float))
+        or not math.isfinite(max_reference_distance)
+        or max_reference_distance < 0
+    ):
+        raise ConfigError(
+            f"auto_selection.max_reference_distance は 0 以上の有限数値である必要があります: {max_reference_distance!r}"
+        )
     enabled = raw.get("enabled", False)
     if not isinstance(enabled, bool):
         raise ConfigError(f"auto_selection.enabled は boolean である必要があります: {enabled!r}")
@@ -82,6 +113,37 @@ def resolve_auto_selection_settings(cfg: dict[str, object]) -> AutoSelectionSett
         min_width=positive_int("min_width", _DEFAULT_MIN_WIDTH),
         min_height=positive_int("min_height", _DEFAULT_MIN_HEIGHT),
         aspect_tolerance=float(tolerance),
+        max_reference_distance=float(max_reference_distance),
+    )
+
+
+def diagnose_reference_pool(
+    reference_images: list[Path],
+    *,
+    max_reference_distance: float,
+) -> ReferencePoolDiagnostic:
+    """Measure every reference against the pool centroid and flag outliers."""
+    if not reference_images:
+        raise ValidationError("参照画像プールが空です")
+    try:
+        features = [extract_features_from_path(path) for path in reference_images]
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ValidationError(f"参照画像を読み込めません: {exc}") from exc
+    centroid = feature_centroid(features)
+    references = []
+    for path, feature in zip(reference_images, features, strict=True):
+        distance = feature_distance(feature, centroid)
+        references.append(
+            ReferenceDiagnostic(
+                path=path,
+                distance=distance,
+                outlier=distance > max_reference_distance,
+            )
+        )
+    return ReferencePoolDiagnostic(
+        centroid=centroid,
+        max_reference_distance=max_reference_distance,
+        references=references,
     )
 
 

--- a/tests/commands/media/test_generate_image_parallel.py
+++ b/tests/commands/media/test_generate_image_parallel.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from PIL import Image
 
 import youtube_automation.commands.media.generate_image as generate_image_module
 from youtube_automation.commands.media.generate_image import (
@@ -758,8 +759,8 @@ def _benchmark_refs(tmp_path: Path, count: int) -> list[Path]:
     ref_dir = tmp_path / "data" / "thumbnail_compare" / "benchmark" / "jazzgak"
     ref_dir.mkdir(parents=True)
     refs = [ref_dir / f"ref-{idx}.jpg" for idx in range(count)]
-    for ref in refs:
-        ref.write_bytes(b"fake image")
+    for index, ref in enumerate(refs):
+        Image.new("RGB", (160, 90), (20 + index, 30 + index, 80 + index)).save(ref)
     return refs
 
 
@@ -865,6 +866,106 @@ def test_record_ttp_reference_assignments_wraps_persistence_failure(
 
 
 class TestGenerateImageCLIReferenceContract:
+    def test_strict_full_mode_rejects_outlier_before_provider_call(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        refs = _benchmark_refs(tmp_path, 3)
+        Image.new("RGB", (160, 90), (220, 20, 20)).save(refs[-1])
+        provider = _FakeProvider()
+        argv = [
+            "--prompt",
+            "prompt",
+            "--output",
+            str(tmp_path / "thumbnail-v1.jpg"),
+            "--max-attempts",
+            "3",
+            "--ttp-strict-references",
+            "-y",
+        ]
+        for ref in refs:
+            argv.extend(["--reference", str(ref)])
+        skill_cfg = {
+            "image_generation": {
+                "auto_selection": {
+                    "enabled": True,
+                    "mode": "full",
+                    "max_reference_distance": 0.1,
+                },
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "single_step": {"max_attempts": 3, "rotate": True},
+                    "reference_images": {"default": [str(ref) for ref in refs]},
+                },
+            }
+        }
+        _patch_generate_image_cli(
+            monkeypatch,
+            argv,
+            provider=provider,
+            channel_root=tmp_path,
+            skill_cfg_override=skill_cfg,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            generate_image_main()
+
+        assert exc_info.value.code == 1
+        assert provider.requests == []
+        assert "distance=" in capsys.readouterr().out
+
+    def test_strict_selection_only_warns_and_continues(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        refs = _benchmark_refs(tmp_path, 3)
+        Image.new("RGB", (160, 90), (220, 20, 20)).save(refs[-1])
+        provider = _FakeProvider()
+        argv = [
+            "--prompt",
+            "prompt",
+            "--output",
+            str(tmp_path / "thumbnail-v1.jpg"),
+            "--max-attempts",
+            "3",
+            "--ttp-strict-references",
+            "-y",
+        ]
+        for ref in refs:
+            argv.extend(["--reference", str(ref)])
+        skill_cfg = {
+            "image_generation": {
+                "auto_selection": {
+                    "enabled": True,
+                    "mode": "selection_only",
+                    "max_reference_distance": 0.1,
+                },
+                "gemini": {
+                    "generation_mode": "single_step",
+                    "single_step": {"max_attempts": 3, "rotate": True},
+                    "reference_images": {"default": [str(ref) for ref in refs]},
+                },
+            }
+        }
+        _patch_generate_image_cli(
+            monkeypatch,
+            argv,
+            provider=provider,
+            channel_root=tmp_path,
+            skill_cfg_override=skill_cfg,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            generate_image_main()
+
+        assert exc_info.value.code == 0
+        assert len(provider.requests) == 3
+        assert "[WARN]" in capsys.readouterr().err
+
     def test_single_step_cli_assigns_one_unique_reference_per_attempt(
         self,
         tmp_path: Path,

--- a/tests/commands/thumbnail/test_thumbnail_auto_selection.py
+++ b/tests/commands/thumbnail/test_thumbnail_auto_selection.py
@@ -17,10 +17,11 @@ import youtube_automation.commands.thumbnail.auto_select_thumbnail as auto_selec
 from youtube_automation.commands.thumbnail.auto_select_thumbnail import main, validate_audit_record
 from youtube_automation.configuration import skills as skill_config
 from youtube_automation.core.errors import ConfigError, ValidationError
-from youtube_automation.domains.thumbnail.features import feature_centroid, feature_distance
+from youtube_automation.domains.thumbnail.features import extract_features_from_path, feature_centroid, feature_distance
 from youtube_automation.domains.thumbnail.selection import (
     AutoSelectionSettings,
     CandidateScore,
+    diagnose_reference_pool,
     resolve_auto_selection_settings,
     score_candidates,
     select_best,
@@ -60,17 +61,44 @@ def test_auto_selection_rejects_invalid_numeric_boundaries(key, value):
 
 
 def test_auto_selection_accepts_zero_aspect_tolerance():
-    settings = resolve_auto_selection_settings({"image_generation": {"auto_selection": {"aspect_tolerance": 0}}})
+    settings = resolve_auto_selection_settings(
+        {"image_generation": {"auto_selection": {"aspect_tolerance": 0, "max_reference_distance": 0}}}
+    )
     assert settings.aspect_tolerance == 0.0
+    assert settings.max_reference_distance == 0.0
+
+
+def test_auto_selection_defaults_reference_distance_threshold_to_point_four():
+    settings = resolve_auto_selection_settings({})
+    assert settings.max_reference_distance == 0.40
+
+
+@pytest.mark.parametrize("value", [True, -0.1, float("nan"), float("inf"), "0.4"])
+def test_auto_selection_rejects_invalid_reference_distance_threshold(value):
+    with pytest.raises(ConfigError, match="max_reference_distance"):
+        resolve_auto_selection_settings({"image_generation": {"auto_selection": {"max_reference_distance": value}}})
+
+
+def test_reference_pool_diagnostic_reports_each_reference(tmp_path: Path):
+    refs = [tmp_path / "near-a.jpg", tmp_path / "near-b.jpg", tmp_path / "outlier.jpg"]
+    for path, color in zip(refs, (*_REF_COLORS, _FAR_COLOR), strict=True):
+        _solid_image(path, color)
+
+    diagnostic = diagnose_reference_pool(refs, max_reference_distance=0.1)
+
+    assert [item.path for item in diagnostic.references] == refs
+    assert diagnostic.max_reference_distance == 0.1
+    assert any(item.outlier for item in diagnostic.references)
+    assert all(math.isfinite(item.distance) and item.distance >= 0 for item in diagnostic.references)
 
 
 def test_score_candidates_breaks_equal_distance_tie_by_path(tmp_path: Path):
-    settings = AutoSelectionSettings(True, "selection_only", 160, 90, 0.01)
+    settings = AutoSelectionSettings(True, "selection_only", 160, 90, 0.01, 0.4)
     a = tmp_path / "a.jpg"
     b = tmp_path / "b.jpg"
     Image.new("RGB", _SIZE_16_9, _NEAR_COLOR).save(a)
     Image.new("RGB", _SIZE_16_9, _NEAR_COLOR).save(b)
-    centroid = feature_centroid([auto_select_thumbnail.extract_features_from_path(a)])
+    centroid = feature_centroid([extract_features_from_path(a)])
 
     scores = score_candidates([b, a], centroid, settings)
     selected = select_best(scores, mode=settings.mode)
@@ -114,7 +142,15 @@ def _solid_image(path, color, size=_SIZE_16_9):
     Image.new("RGB", size, color).save(path)
 
 
-def _write_channel_config(channel_dir, *, enabled=True, mode=None, refs=_REF_RELPATHS, archive_config=None):
+def _write_channel_config(
+    channel_dir,
+    *,
+    enabled=True,
+    mode=None,
+    refs=_REF_RELPATHS,
+    archive_config=None,
+    max_reference_distance=None,
+):
     skills_dir = channel_dir / "config" / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
     cfg = {
@@ -131,6 +167,8 @@ def _write_channel_config(channel_dir, *, enabled=True, mode=None, refs=_REF_REL
     }
     if mode is not None:
         cfg["image_generation"]["auto_selection"]["mode"] = mode
+    if max_reference_distance is not None:
+        cfg["image_generation"]["auto_selection"]["max_reference_distance"] = max_reference_distance
     (skills_dir / "thumbnail.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
 
@@ -143,13 +181,21 @@ def _setup_channel(
     refs=_REF_RELPATHS,
     ref_colors=_REF_COLORS,
     archive_config=None,
+    max_reference_distance=None,
 ):
     channel_dir = tmp_path / "channel"
     # refs は空タプルで渡されるケース（test_no_reference_images_errors）があり、
     # ref_colors とは意図的に非同長になり得るため strict=False（zip 既定 = 挙動保存）
     for relpath, color in zip(refs, ref_colors, strict=False):
         _solid_image(channel_dir / relpath, color)
-    _write_channel_config(channel_dir, enabled=enabled, mode=mode, refs=refs, archive_config=archive_config)
+    _write_channel_config(
+        channel_dir,
+        enabled=enabled,
+        mode=mode,
+        refs=refs,
+        archive_config=archive_config,
+        max_reference_distance=max_reference_distance,
+    )
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
     return channel_dir
 
@@ -179,6 +225,10 @@ def _valid_audit_record():
                 "reasons": [],
             }
         ],
+        "reference_diagnostics": {
+            "max_reference_distance": 0.4,
+            "references": [{"reference_image": "benchmark/ref.jpg", "distance": 0.1, "outlier": False}],
+        },
         "executed_at": "2026-07-18T12:34:56+00:00",
     }
 
@@ -207,6 +257,52 @@ def test_mode_selection_only_explicit(tmp_path, monkeypatch, capsys):
     payload = json.loads(captured.out)
     assert payload["selected"]["candidate"] == "thumbnail-v1.jpg"
     assert payload["auto_selection_mode"] == "selection_only"
+
+
+def test_selection_only_warns_and_emits_structured_reference_diagnostics(tmp_path, monkeypatch, capsys):
+    refs = (*_REF_RELPATHS, "data/thumbnail_compare/benchmark/SIDEEP/SIDEEP_outlier.jpg")
+    _setup_channel(
+        tmp_path,
+        monkeypatch,
+        mode="selection_only",
+        refs=refs,
+        ref_colors=(*_REF_COLORS, _FAR_COLOR),
+        max_reference_distance=0.1,
+    )
+    collection = _setup_collection(tmp_path)
+    _solid_image(collection / "10-assets" / "thumbnail-v1.jpg", _NEAR_COLOR)
+
+    code, captured = _run_json([str(collection), "--dry-run", "--json"], capsys)
+
+    assert code == 0
+    assert "[WARN]" in captured.err
+    payload = json.loads(captured.out)
+    diagnostics = payload["reference_diagnostics"]
+    assert diagnostics["max_reference_distance"] == 0.1
+    assert len(diagnostics["references"]) == 3
+    assert any(item["outlier"] for item in diagnostics["references"])
+
+
+def test_full_mode_rejects_reference_outlier_before_selection(tmp_path, monkeypatch, capsys):
+    refs = (*_REF_RELPATHS, "data/thumbnail_compare/benchmark/SIDEEP/SIDEEP_outlier.jpg")
+    _setup_channel(
+        tmp_path,
+        monkeypatch,
+        mode="full",
+        refs=refs,
+        ref_colors=(*_REF_COLORS, _FAR_COLOR),
+        max_reference_distance=0.1,
+    )
+    collection = _setup_collection(tmp_path)
+    _solid_image(collection / "10-assets" / "thumbnail-v1.jpg", _NEAR_COLOR)
+
+    code, captured = _run_json([str(collection), "--apply", "--json"], capsys)
+
+    assert code == 1
+    assert "参照画像プール" in captured.err
+    assert not (collection / "10-assets" / "thumbnail.jpg").exists()
+    diagnostics = json.loads(captured.out)["reference_diagnostics"]
+    assert any(item["outlier"] for item in diagnostics["references"])
 
 
 def test_invalid_mode_errors_non_zero_exit(tmp_path, monkeypatch, capsys):

--- a/tests/test_b3_domain_migration_contract.py
+++ b/tests/test_b3_domain_migration_contract.py
@@ -382,6 +382,7 @@ def test_thumbnail_selection_keeps_config_validation_and_tie_breaking(tmp_path: 
         min_height=90,
         aspect_tolerance=0.02,
         mode="selection_only",
+        max_reference_distance=0.4,
     )
     image_paths = []
     for name in ("b.jpg", "a.jpg"):

--- a/tests/test_codex_thumbnail_routing.py
+++ b/tests/test_codex_thumbnail_routing.py
@@ -109,8 +109,8 @@ def _benchmark_refs(channel_root: Path, *names: str, channel: str = "winner") ->
     root = channel_root / "data" / "thumbnail_compare" / "benchmark" / channel
     root.mkdir(parents=True, exist_ok=True)
     paths = [root / name for name in names]
-    for path in paths:
-        path.write_bytes(b"reference")
+    for index, path in enumerate(paths):
+        Image.new("RGB", (160, 90), (20 + index, 30 + index, 80 + index)).save(path)
     return paths
 
 


### PR DESCRIPTION
## 概要

TTP 参照画像プールの centroid 距離外れ値を生成・自動選択前に検出し、参照ローテーションでブランド整合性が崩れる経路を fail-loud にします。

## 変更内容

- max_reference_distance を既定 0.40、有限かつ 0 以上の override として追加
- 参照ごとの distance / outlier を構造化診断として JSON と workflow-state に記録
- selection_only は警告継続、full は自動選択前に停止
- yt-generate-image --ttp-strict-references の full は provider 初期化・API 呼び出し前に停止
- thumbnail skill の設定例・運用契約と CHANGELOG を更新

## 検証

- uv run pytest -q tests/commands/thumbnail/test_thumbnail_auto_selection.py tests/commands/media/test_generate_image_parallel.py tests/test_b3_domain_migration_contract.py tests/test_codex_thumbnail_routing.py::test_parallel_api_route_assigns_one_reference_per_attempt （181 passed）
- uv run ruff check （変更 Python / tests）
- uv run yt-skills lint thumbnail
- git diff --check
- 全 suite: 7950 passed / 1 skipped。今回の valid-image fixture 修正前の関連失敗 1 件は修正済み。残る 55 件は worktree 環境で DejaVu Sans を発見できない既存環境エラー。

## チェックリスト

- [x] CHANGELOG.md の Unreleased にエントリを追加
- [x] 必要なテストを追加・更新
- [x] 下流固有ファイル名を hardcode していない

Closes #2952

Related: #2953