### PR TITLE
fix(suno): 完成形 Style の soft budget を分離する

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -100,7 +100,7 @@ generator は pattern draft、設定、benchmark analysis、必要な References
 - **明示 override 優先**: pattern に `style: <variant-key>` がある entry は `style_variants` の genre_line をそのまま使い、自動バリエーションは付与しない（通し番号は消費する）
 - **プール定義**: `config.default.yaml::style_variation.pools` に axis 名（`texture` / `rhythm` 等）→ descriptor 配列で定義する。axis 名の辞書順で round-robin に interleave した列を循環割り当てる。チャンネル側 `config/skills/suno.yaml` では axis 単位で丸ごと置換（deep-merge のリスト置換）・axis 追加・空リスト上書きによる axis 無効化ができる
 - **設定契約**: `style_variation` は mapping、`enabled` は bool、`pools` は mapping、各 axis は `list[str]`。descriptor は非空文字列のみ有効で、契約外 shape は `uv run yt-generate-suno` が `ConfigError` で停止する
-- **語彙の制約**: descriptor に禁止形容詞（`references/suno-examples.md`）・雨音／環境音 NG ワード・楽器名の裸置き・アーティスト名を入れない。`style_char_limit`（既定 120）の上限は descriptor 込みの Style 文で検証される
+- **語彙の制約**: descriptor に禁止形容詞（`references/suno-examples.md`）・雨音／環境音 NG ワード・楽器名の裸置き・アーティスト名を入れない。descriptor と情景行を含む完成形 Style は `full_style_char_limit`（既定 256）の soft quality budget で検証される
 - **重複検証**: 生成時に全 entry の Style 文（第 1 行 + 情景行）が完全一致する組があれば `uv run yt-generate-suno` が警告する
 - **無効化**: チャンネル側で `style_variation.enabled: false` を設定すると従来動作（全 entry 同一の Style 第 1 行）に戻る
 
@@ -182,7 +182,9 @@ Style テキストは以下の順序で構成する。順序を守ることで S
 
 ### Configurable Character Limit
 
-Style フィールドの文字数上限は `config/skills/suno.yaml::style_char_limit` で設定する（既定 **120 文字**）。`uv run yt-generate-suno` はビルド時に超過を警告し、`uv run yt-suno-verify` は設定上限を超えた `genre_line` と使用中の `style_variants.*.genre_line` をエラーにする。5-Element Order に従って要素を絞り込むか、意図的な長文 Style 運用では実際の上限を設定する。
+`config/skills/suno.yaml::style_char_limit`（既定 **120 文字**）は effective `genre_line` の hard guard であり、`uv run yt-suno-verify` は root と使用中の `style_variants.*.genre_line` の超過をエラーにする。第 1 行、descriptor、情景行を結合した完成形 Style は別の `full_style_char_limit`（既定 **256 文字**）を soft quality budget として使い、`uv run yt-generate-suno` が超過を警告する。256 は [Suno v4.5 公式 Help の詳細 Style 例](https://help.suno.com/en/articles/5782849)を収容する保守的な推奨値であり、Suno platform の hard limit を表さない。
+
+チャンネル側で `full_style_char_limit` を明示した場合はその値を使う。未指定で既存の `style_char_limit` だけが明示されているチャンネルでは、従来どおり同じ値を完成形 Style の警告にも使う。両方とも未指定なら完成形 Style には既定 256 を使う。
 
 ### Artist Name Prohibition
 
@@ -413,7 +415,7 @@ Suno V5.5 では Styles 経由で実楽曲長を制御できない。望む長�
 
 **雨音や環境音は楽曲に含めない。** NG ワード: rain, dripping, drops, puddles, splashing, pouring 等。OK ワード: misty, melancholic, nocturnal, bittersweet, foggy 等。全プロンプトに `no rain sound effects, no white noise, no ambient noise` を追加。`exclude_styles` にも `rain sounds, vinyl crackle, white noise, ambient noise` を含める。
 
-視聴中の注意を急に奪う展開を避けるため、同梱 `exclude_styles` は `sudden drops, risers, drum fills, hard transitions, dramatic buildups` も既定で含む。これらは Suno の独立した **Exclude Styles** 欄へ入力する値であり、Styles 本文へ連結しないため `style_char_limit` の文字数には算入しない。
+視聴中の注意を急に奪う展開を避けるため、同梱 `exclude_styles` は `sudden drops, risers, drum fills, hard transitions, dramatic buildups` も既定で含む。これらは Suno の独立した **Exclude Styles** 欄へ入力する値であり、Styles 本文へ連結しないため `style_char_limit` / `full_style_char_limit` の文字数には算入しない。
 
 #### genre_line と exclude_styles の整合性
 

--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -21,8 +21,12 @@ weirdness: 50
 # 歌詞構造の自動タグ付け ([Verse], [Chorus] 等を AI が自動挿入)
 auto_lyrics_structure: true
 
-# Style 欄の文字数上限 (チャンネル側 config/skills/suno.yaml で上書き可能)
+# effective genre_line の hard guard (yt-suno-verify がエラーにする)
 style_char_limit: 120
+
+# 第1行 + 情景行からなる完成形 Style の soft quality budget
+# Suno v4.5 公式 Help の 256 文字例を収容する保守的な推奨値であり、platform hard limit ではない
+full_style_char_limit: 256
 
 # Style テキストに含めてはならないアーティスト名 (Suno ポリシー / ベストプラクティス)
 # 著名アーティスト名を Style に入れると生成がブロックされるか品質が低下する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno)`: effective `genre_line` の hard guard `style_char_limit: 120` を維持しつつ、完成形 Style の soft quality budget を `full_style_char_limit: 256` へ分離。明示した新キー、明示した legacy キー、既定値の順で解決し、既存チャンネルの override を保ったまま構造的な警告を解消（#2589）。
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
 - `docs(suno)`: `suno_preset` を hard gate から推奨入力へ変更し、collection 固有の effective Style と vocal gender を `suno-patterns.yaml` に保存して共有 channel config を変更せず `/wf-new`・`/suno-lyric`・`yt-suno-verify` へ引き渡す正規手順を追加（#2999）。
 - `fix(suno)`: `suno-patterns.yaml` が上書きした effective Style にも channel の `banned_artists` を適用し、禁止アーティスト検出時は channel Style と同じ `ConfigError` で出力前に停止する契約を固定（#2998）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -95,9 +95,10 @@ _STYLE_VARIATION_BARE_INSTRUMENTS = frozenset(
 # Style text の 5 要素順序: ジャンル名 → 音響特性 → キー楽器 → リズム/ベース → テンポ
 # 厳密な順序検証は不可能（自然言語のため）だが、テンポ語が先頭付近にある場合は警告する
 _TEMPO_WORDS = frozenset({"very slow", "slow", "gentle", "moderate", "lively", "fast", "uptempo", "downtempo"})
+_DEFAULT_FULL_STYLE_CHAR_LIMIT = 256
 
 
-def validate_style_char_limit(style_text: str, *, limit: int = 120) -> list[str]:
+def validate_style_char_limit(style_text: str, *, limit: int = _DEFAULT_FULL_STYLE_CHAR_LIMIT) -> list[str]:
     """Style テキストが文字数上限を超えていないか検証する.
 
     Returns: 警告メッセージのリスト (空なら問題なし)。
@@ -106,6 +107,22 @@ def validate_style_char_limit(style_text: str, *, limit: int = 120) -> list[str]
     if len(style_text) > limit:
         warnings_list.append(f"Style text exceeds {limit} char limit ({len(style_text)} chars): {style_text[:80]}...")
     return warnings_list
+
+
+def _resolve_full_style_char_limit(suno: Mapping[str, object], override: Mapping[str, object]) -> int:
+    """完成形 Style の soft budget を後方互換の優先順位で解決する."""
+    if "full_style_char_limit" in override:
+        value = override["full_style_char_limit"]
+        source = "full_style_char_limit"
+    elif "style_char_limit" in override:
+        value = override["style_char_limit"]
+        source = "style_char_limit"
+    else:
+        value = suno.get("full_style_char_limit", _DEFAULT_FULL_STYLE_CHAR_LIMIT)
+        source = "full_style_char_limit"
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConfigError(f"config/skills/suno.yaml::{source} must be a positive integer")
+    return value
 
 
 def validate_banned_artists(style_text: str, banned_artists: list[str]) -> list[str]:
@@ -379,6 +396,7 @@ class _ResolvedPrompts:
     style_influence: int
     weirdness: int
     exclude_styles: str
+    full_style_char_limit: int
     # channel override に明示設定された More Options フィールドのみを保持する (#900)。
     # collection スコープ: 全 entry に同じ値が載る。未設定キーは dict に含めない。
     advanced_json_fields: dict
@@ -521,6 +539,7 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
     # default.yaml の既定値と区別できないため、override 単体を別途読む。
     override = load_channel_override("suno")
     _validate_duration_sec_override(override)
+    full_style_char_limit = _resolve_full_style_char_limit(suno, override)
     advanced_json_fields = _build_advanced_json_fields(override)
     resolved_suno = resolve_suno_config(suno)
 
@@ -662,6 +681,7 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
         style_influence=style_influence,
         weirdness=weirdness,
         exclude_styles=exclude_styles,
+        full_style_char_limit=full_style_char_limit,
         advanced_json_fields=advanced_json_fields,
         patterns=resolved,
     )
@@ -747,7 +767,6 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
     """
     resolved = _resolve_prompts(patterns_path)
     suno = load_skill_config("suno")
-    style_char_limit = suno.get("style_char_limit", 120)
     banned_artists = suno.get("banned_artists", [])
     auto_lyrics = suno.get("auto_lyrics_structure", False)
 
@@ -771,11 +790,11 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
             full_style = f"{style_line}\n{scene}"
 
             # Quality rules: Style テキストの検証 (#904)
-            # style_char_limit と banned_artists は完成形の full_style を検証する。
+            # full_style_char_limit と banned_artists は完成形の full_style を検証する。
             # 5 要素順序チェックは genre_line（ユーザーが config に書く部分）を検証する。
             # Styles 第 1 行の先頭は `_style_line` が tempo を置くため、
             # full_style での先頭テンポ検知は false positive になる。
-            report.warnings.extend(validate_style_char_limit(full_style, limit=style_char_limit))
+            report.warnings.extend(validate_style_char_limit(full_style, limit=resolved.full_style_char_limit))
             report.errors.extend(validate_banned_artists(full_style, banned_artists))
 
             # auto_lyrics_structure: 歌詞構造の自動補強 (#904)

--- a/tests/commands/suno/test_suno_prompt_quality_rules.py
+++ b/tests/commands/suno/test_suno_prompt_quality_rules.py
@@ -39,7 +39,7 @@ def _write_suno_override(channel: Path, **overrides) -> None:
     (channel / "config" / "skills" / "suno.yaml").write_text(yaml.safe_dump(overrides), encoding="utf-8")
 
 
-def _write_minimal_patterns(dir_: Path, **extra_top) -> Path:
+def _write_minimal_patterns(dir_: Path, *, scene: str = "a quiet scene description", **extra_top) -> Path:
     payload: dict = {
         "title": "Test Collection",
         "mode": "instrumental",
@@ -49,7 +49,7 @@ def _write_minimal_patterns(dir_: Path, **extra_top) -> Path:
                 "name_jp": "テスト",
                 "name_en": "Test",
                 "tempo": "slow",
-                "scenes": ["a quiet scene description"],
+                "scenes": [scene],
             }
         ],
     }
@@ -81,6 +81,12 @@ def test_style_char_limit_exact_boundary():
     """ちょうど上限は OK."""
     result = validate_style_char_limit("x" * 120, limit=120)
     assert result == []
+
+
+def test_style_char_limit_uses_full_style_soft_budget_by_default():
+    """既定の完成形 Style budget は 256 文字を境界に警告する."""
+    assert validate_style_char_limit("x" * 256) == []
+    assert "257 chars" in validate_style_char_limit("x" * 257)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +264,73 @@ def test_build_prompt_entries_style_char_limit_warns(channel_dir, tmp_path, caps
     assert "[WARN]" in captured.err
 
 
+def test_build_prompt_entries_default_full_style_budget_accepts_256_chars(channel_dir, tmp_path, capsys):
+    """override なしでは公式 v4.5 例を収める 256 文字まで完成形 Style を許容する."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    patterns_path = _write_minimal_patterns(tmp_path, scene="x" * 238)
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert len(entries[0]["style"]) == 256
+    assert "Style text exceeds" not in capsys.readouterr().err
+
+
+def test_build_prompt_entries_default_full_style_budget_warns_above_256_chars(channel_dir, tmp_path, capsys):
+    """override なしでは 256 文字を超えた完成形 Style を soft warning にする."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz")
+    patterns_path = _write_minimal_patterns(tmp_path, scene="x" * 239)
+
+    entries = build_prompt_entries(patterns_path)
+
+    assert len(entries[0]["style"]) == 257
+    assert "Style text exceeds 256 char limit" in capsys.readouterr().err
+
+
+def test_build_prompt_entries_explicit_full_style_limit_overrides_legacy_limit(channel_dir, tmp_path, capsys):
+    """新旧両キー指定時は full_style_char_limit を完成形 Style に使う."""
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        style_char_limit=10,
+        full_style_char_limit=256,
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    build_prompt_entries(patterns_path)
+
+    assert "Style text exceeds" not in capsys.readouterr().err
+
+
+def test_build_prompt_entries_explicit_full_style_limit_warns(channel_dir, tmp_path, capsys):
+    """full_style_char_limit の明示値を完成形 Style の soft budget に使う."""
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        full_style_char_limit=40,
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    build_prompt_entries(patterns_path)
+
+    assert "Style text exceeds 40 char limit" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("invalid_limit", [0, -1, True, "256"])
+def test_build_prompt_entries_rejects_invalid_full_style_limit(channel_dir, tmp_path, invalid_limit):
+    """full_style_char_limit は正の整数以外を fail-loud で拒否する."""
+    from youtube_automation.core.errors import ConfigError
+
+    _write_suno_override(
+        channel_dir,
+        genre_line="lo-fi jazz",
+        full_style_char_limit=invalid_limit,
+    )
+    patterns_path = _write_minimal_patterns(tmp_path)
+
+    with pytest.raises(ConfigError, match="full_style_char_limit must be a positive integer"):
+        build_prompt_entries(patterns_path)
+
+
 def test_build_prompt_entries_auto_lyrics_instrumental(channel_dir, tmp_path):
     """Given auto_lyrics_structure: true + インストモード
     When build_prompt_entries を呼ぶ
@@ -324,6 +397,7 @@ def test_default_yaml_has_quality_rule_keys():
     assert data["model"] == "V5.5", "model の既定値は V5.5"
     assert data["auto_lyrics_structure"] is True, "auto_lyrics_structure: true が追加されるべき"
     assert data["style_char_limit"] == 120, "style_char_limit: 120 が追加されるべき"
+    assert data["full_style_char_limit"] == 256, "full_style_char_limit: 256 が追加されるべき"
     assert isinstance(data["banned_artists"], list), "banned_artists はリスト型であるべき"
     assert len(data["banned_artists"]) >= 25, "banned_artists は 25 件以上であるべき"
 


### PR DESCRIPTION
## Summary

- effective `genre_line` の hard guard は既存の `style_char_limit: 120` のまま維持
- 完成形 Style 専用の soft quality budget `full_style_char_limit: 256` を追加
- `明示 full > 明示 legacy style_char_limit > default full` の優先順位で既存 override を維持
- 256 は [Suno v4.5 公式 Help](https://help.suno.com/en/articles/5782849) の詳細 Style 例を根拠とし、platform hard limit とは扱わない

## Verification

- focused Suno tests: 85 passed
- `uv run yt-skills lint`
- `uv run ruff check .`
- `uv run ruff format --check .`
- full pytest は 7,956 passed。変更外の DejaVu Sans 不在により thumbnail 系 2 failed / 56 setup errors（CI 環境で再確認）

Closes #2589