### PR TITLE
fix(suno): legacy variant drift の復旧診断を追加 (#3668)

### DIFF
--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -70,6 +70,7 @@ model: V5.5
 # 代表ジャンル (lo-fi / ambient / piano / nature) の参考テンプレ — 実値は
 # `/video-analyze --source benchmark` の `suno_preset.genre_line` を起点に
 # チャンネル側 config/skills/suno.yaml で上書き推奨
+style_variants: {}
 # style_variants:
 #   lo-fi:
 #     name: "lo-fi jazz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 
 - `fix(suno)`: effective `genre_line` の hard guard `style_char_limit: 120` を維持しつつ、完成形 Style の soft quality budget を `full_style_char_limit: 256` へ分離。明示した新キー、明示した legacy キー、既定値の順で解決し、既存チャンネルの override を保ったまま構造的な警告を解消（#2589）。
+- `fix(suno)`: collection-local `style_variants` を持たない legacy collection の variant key drift を、patterns path・移行手順・既存成果物の stale 状態と再検証コマンド付きで診断し、失敗時の既存 MD/JSON を不変に保つようにした（#3668）。
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
 - `docs(suno)`: `suno_preset` を hard gate から推奨入力へ変更し、collection 固有の effective Style と vocal gender を `suno-patterns.yaml` に保存して共有 channel config を変更せず `/wf-new`・`/suno-lyric`・`yt-suno-verify` へ引き渡す正規手順を追加（#2999）。
 - `fix(suno)`: `suno-patterns.yaml` が上書きした effective Style にも channel の `banned_artists` を適用し、禁止アーティスト検出時は channel Style と同じ `ConfigError` で出力前に停止する契約を固定（#2998）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -515,9 +515,9 @@ def _resolve_vocal_gender(data: Mapping[str, object], channel_json_fields: dict,
 
 def _resolve_style_variants(
     data: Mapping[str, object], channel_fallback: object, patterns_path: Path
-) -> Mapping[str, Mapping[str, str]]:
+) -> tuple[Mapping[str, Mapping[str, str]], bool]:
     if "style_variants" not in data:
-        return cast(Mapping[str, Mapping[str, str]], channel_fallback)
+        return cast(Mapping[str, Mapping[str, str]], channel_fallback), True
     style_variants = data["style_variants"]
     if not isinstance(style_variants, Mapping):
         raise ConfigError(f"{patterns_path}: style_variants must be a mapping")
@@ -529,7 +529,41 @@ def _resolve_style_variants(
         for field_name in ("name", "genre_line"):
             if not isinstance(variant.get(field_name), str):
                 raise ConfigError(f"{patterns_path}: style_variants.{key}.{field_name} must be a string")
-    return cast(Mapping[str, Mapping[str, str]], style_variants)
+    return cast(Mapping[str, Mapping[str, str]], style_variants), False
+
+
+def _undefined_style_variant_error(style_key: object, patterns_path: Path, uses_channel_fallback: bool) -> ConfigError:
+    base_message = f"{patterns_path}: pattern.style に未定義の style variant が指定されています: {style_key!r}。"
+    if not uses_channel_fallback:
+        return ConfigError(
+            base_message
+            + "collection-local style_variants にこの key を追加するか、pattern.style の typo を修正してください。"
+        )
+
+    message = (
+        base_message + "patterns root に style_variants がない legacy collection のため、"
+        "channel fallback drift（config/skills/suno.yaml 側で key が変更・削除された可能性）があります。"
+        "channel 共有設定には依存せず、必要な定義を collection-local "
+        "suno-patterns.yaml::style_variants へ移してください。"
+    )
+    existing_outputs = [
+        path.name
+        for path in (
+            patterns_path.parent / SUNO_PROMPTS_MD_FILENAME,
+            patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME,
+        )
+        if path.exists()
+    ]
+    if existing_outputs:
+        collection_path = (
+            patterns_path.parent.parent if patterns_path.parent.name == DOCUMENTATION_DIRNAME else patterns_path.parent
+        )
+        message += (
+            f"既存成果物 ({', '.join(existing_outputs)}) は更新されず stale のままです。"
+            "設定修正後に再生成し、"
+            f"`uv run yt-suno-verify {collection_path}` を実行してください。"
+        )
+    return ConfigError(message)
 
 
 def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
@@ -555,7 +589,11 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
         patterns_path,
     )
     advanced_json_fields = _resolve_vocal_gender(data, advanced_json_fields, patterns_path)
-    style_variants = _resolve_style_variants(data, suno.get("style_variants", {}), patterns_path)
+    style_variants, uses_channel_style_variants = _resolve_style_variants(
+        data,
+        suno.get("style_variants", {}),
+        patterns_path,
+    )
     style_influence = suno.get("style_influence", 50)
     weirdness = suno.get("weirdness", 50)
 
@@ -603,7 +641,7 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
 
         # Per-pattern style variant override
         if style_key and style_key not in style_variants:
-            raise ConfigError(f"pattern.style に未定義の style variant が指定されています: {style_key!r}")
+            raise _undefined_style_variant_error(style_key, patterns_path, uses_channel_style_variants)
         has_explicit_variant = bool(style_key)
         if has_explicit_variant:
             variant = style_variants[style_key]

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -2148,8 +2148,54 @@ def test_empty_patterns_style_variants_does_not_inherit_channel_keys(channel_dir
         style_variants={},
     )
 
-    with pytest.raises(ConfigError, match="未定義の style variant"):
+    with pytest.raises(ConfigError) as exc_info:
         build_prompt_entries(patterns_path)
+
+    message = str(exc_info.value)
+    assert "未定義の style variant" in message
+    assert "ambient" in message
+    assert str(patterns_path) in message
+    assert "channel fallback drift" not in message
+
+
+def test_main_legacy_style_variant_drift_preserves_stale_outputs(channel_dir, tmp_path, monkeypatch):
+    """legacy fallback の key drift は復旧手順を示し、既存成果物を変更しない。"""
+    _write_suno_override(
+        channel_dir,
+        genre_line="channel base",
+        style_variants={"opening": {"name": "Opening", "genre_line": "soft opening"}},
+    )
+    entries_def = _four_distinct_entries()
+    entries_def[0]["style"] = "intro"
+    patterns_path = _write_patterns_with_explicit_entries(
+        tmp_path,
+        entries=entries_def,
+        tracks_top=8,
+    )
+    md_path = patterns_path.parent / "suno-prompts.md"
+    json_path = patterns_path.parent / "suno-prompts.json"
+    original_md = b"legacy markdown\n"
+    original_json = b'{"legacy": true}\n'
+    md_path.write_bytes(original_md)
+    json_path.write_bytes(original_json)
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ConfigError) as exc_info:
+            main()
+
+    message = str(exc_info.value)
+    assert "intro" in message
+    assert str(patterns_path) in message
+    assert "channel fallback drift" in message
+    assert "suno-patterns.yaml::style_variants" in message
+    assert "stale" in message
+    assert "再生成" in message
+    assert f"uv run yt-suno-verify {patterns_path.parent}" in message
+    assert md_path.read_bytes() == original_md
+    assert json_path.read_bytes() == original_json
+    assert not [warning for warning in caught if "未知のトップレベルキー" in str(warning.message)]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- legacy collection の channel `style_variants` drift を source-aware に診断
- collection-local variant への復旧手順と stale 成果物の未更新を明示
- 既存 MD / JSON の byte 不変と verify 導線を回帰テストで固定

Closes #3668