### PR TITLE
fix(streaming): 24/7配信の再起動を高速化する (#3029)

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -106,7 +106,7 @@ ffmpeg -i input.mp4 \
 
 `yt-stream-bandwidth --probe-bitrate` は container 全体の平均 bitrate を見る月間帯域見積もり用。配信元 MP4 の preflight 合否は `terraform plan` / `apply` の stream-level 検証を正とする。
 
-配信サイクルを変える場合は `terraform.tfvars` で `stream_hours` / `break_hours` を指定する。0 は無制限を意味し、`stream_hours=0` では `RuntimeMaxSec` を出力しない。`break_hours=0` では `RestartSec=10s` を出力する。
+配信サイクルを変える場合は `terraform.tfvars` で `stream_hours` / `break_hours` を指定する。0 は無制限を意味し、`stream_hours=0` では `RuntimeMaxSec` を出力しない。`break_hours=0` では `RestartSec=2s`（`crash_restart_seconds` で 1〜300 秒に上書き可）を出力する。永続的な起動失敗は 60 秒間に 10 回で停止し、healthcheck の anomaly 通知後に手動で原因を直して再起動する。
 
 ## §2 動画差し替え
 

--- a/.claude/skills/streaming/references/healthcheck.sh
+++ b/.claude/skills/streaming/references/healthcheck.sh
@@ -7,7 +7,7 @@
 #   manual  : inactive+dead+success    （systemctl stop）
 #   anomaly : 上記以外                 （kill -9 / failed / Result≠success など）
 #
-# break_hours=0 の RestartSec=10s はクラッシュ時の短い再起動間隔。failed / Result≠success は anomaly。
+# break_hours=0 の RestartSec=2s（既定）はクラッシュ時の短い再起動間隔。failed / Result≠success は anomaly。
 #
 # 状態変化チェック（連打防止）: 前回 classify 結果を $STATE_DIR/last_status に保存し、
 # anomaly 突入時と anomaly からの復帰時のみ通知する。同種類の連続は無音。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno)`: effective `genre_line` の hard guard `style_char_limit: 120` を維持しつつ、完成形 Style の soft quality budget を `full_style_char_limit: 256` へ分離。明示した新キー、明示した legacy キー、既定値の順で解決し、既存チャンネルの override を保ったまま構造的な警告を解消（#2589）。
 - `fix(suno)`: `suno-prompts.md` / JSON を同一ディレクトリの一時ファイルへ書き切ってから一組で公開し、commit 途中失敗時は元の有無を含めて両成果物を rollback するようにした（#3669）。
 - `fix(suno)`: collection-local `style_variants` を持たない legacy collection の variant key drift を、patterns path・移行手順・既存成果物の stale 状態と再検証コマンド付きで診断し、失敗時の既存 MD/JSON を不変に保つようにした（#3668）。
+- `fix(streaming)`: 24/7 配信のクラッシュ再起動間隔を 10 秒から既定 2 秒へ短縮し、`crash_restart_seconds`（1〜300 秒）で上書き可能にした。11h+1h の計画休止は維持し、永続障害は 60 秒間 10 回の systemd start limit で過剰再試行を停止する（#3029）。
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
 - `docs(suno)`: `suno_preset` を hard gate から推奨入力へ変更し、collection 固有の effective Style と vocal gender を `suno-patterns.yaml` に保存して共有 channel config を変更せず `/wf-new`・`/suno-lyric`・`yt-suno-verify` へ引き渡す正規手順を追加（#2999）。
 - `fix(suno)`: `suno-patterns.yaml` が上書きした effective Style にも channel の `banned_artists` を適用し、禁止アーティスト検出時は channel Style と同じ `ConfigError` で出力前に停止する契約を固定（#2998）。

--- a/docs/adr/0014-streaming-continuous-default.md
+++ b/docs/adr/0014-streaming-continuous-default.md
@@ -15,7 +15,7 @@ accepted (2026-06-24)。
 1. **デフォルトを 24/7 連続配信（`RuntimeMaxSec` なし）にする。** アーカイブは生成されなくなるが、配信の中断がなくなる
 2. **Terraform 変数 `stream_hours`（default=0）と `break_hours`（default=0）を導入する。** 0 は「無制限」を意味し、24/7 モードを表す。休憩モードが必要な場合は `stream_hours=11, break_hours=1` のように設定する
 3. **設定の置き場所は Terraform 変数のみ。** VPS 上での手動変更は `terraform apply` で上書きされる前提（single source of truth）
-4. **systemd unit テンプレートの条件分岐**: `stream_hours > 0` のとき `RuntimeMaxSec` を出力、`break_hours > 0` のとき `RestartSec=Xh` else `RestartSec=10s`（クラッシュ時の再起動間隔）。`Restart=always` は常に出力
+4. **systemd unit テンプレートの条件分岐**: `stream_hours > 0` のとき `RuntimeMaxSec` を出力、`break_hours > 0` のとき `RestartSec=Xh`、それ以外は `RestartSec=2s`（`crash_restart_seconds` で上書き可能）。`Restart=always` は常に出力し、永続障害は 60 秒間 10 回の start limit で抑止する
 5. **Python 定数を更新**: `THEORETICAL_HOURS_PER_DAY=24`、`ARCHIVES_EXPECTED=False`（boolean）。稼働率計算は `ARCHIVES_EXPECTED=False` のとき従来のアーカイブ数ベース計算をスキップ
 6. **ヘルスチェックの `idle` 状態分類は残す。** 休憩モード時に正しく動作するために必要で、24/7 モードでは到達しないだけ
 

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -2,7 +2,7 @@
 
 Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に常時配信する Terraform モジュール。`terraform apply` 一発で「VPS 作成 → cloud-init で OS 準備 → 動画 + systemd unit + 設定ファイル配置 → 配信開始」までを完結する。
 
-配信はデフォルトで `RuntimeMaxSec` を省略し、`Restart=always` + `RestartSec=10s` により **24/7 連続配信** として自律的に回る。YouTube アーカイブ生成を優先する場合は `stream_hours=11` / `break_hours=1` を指定し、従来の **11 時間配信 → 1 時間休止 → 自動再開** に切り替える。
+配信はデフォルトで `RuntimeMaxSec` を省略し、`Restart=always` + `RestartSec=2s` により **24/7 連続配信** として自律的に回る。再起動間隔は `crash_restart_seconds`（1〜300 秒）で上書きできる。YouTube アーカイブ生成を優先する場合は `stream_hours=11` / `break_hours=1` を指定し、従来の **11 時間配信 → 1 時間休止 → 自動再開** に切り替える。
 
 ## 管理するリソース
 
@@ -224,8 +224,9 @@ ffmpeg -i input.mp4 \
 systemd unit が以下の挙動を持つ:
 
 - `stream_hours=0`: `RuntimeMaxSec` 行を省略し、配信時間を systemd 側では制限しない
-- `break_hours=0`: `RestartSec=10s` を出力し、クラッシュ時は 10 秒後に再起動する
+- `break_hours=0`: `RestartSec=2s` を出力し、クラッシュ時は 2 秒後に再起動する（`crash_restart_seconds` で 1〜300 秒に上書き可）
 - `stream_hours=11` / `break_hours=1`: `RuntimeMaxSec=11h` + `RestartSec=1h` を出力し、11 時間配信 → 1 時間休止 → 自動再開のサイクルにする
+- 起動失敗が 60 秒間に 10 回へ達した場合は systemd の start limit で停止する。healthcheck の anomaly 通知を確認し、原因を解消してから `systemctl reset-failed youtube-stream && systemctl restart youtube-stream` で復旧する
 - `ExecStart` は `${var.install_root}/bin/run-ffmpeg.sh` へ展開されたラッパーのみを呼ぶ。`VIDEO` / `RTMP_URL` は systemd の `EnvironmentFile=/etc/youtube-stream.env`（PID 1 が root で読み込み env を子プロセスへ注入）経由で渡るため、unit 行にも、`DynamicUser=yes` 配下のラッパー側の `source` にも露出しない（`systemctl show` / `/proc/<pid>/cmdline` の unit レベル経路を遮断）
 - 音声は動画ファイルの音声トラックを送出（`-c:a copy`、再エンコードなし）
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -80,11 +80,12 @@ resource "vultr_instance" "this" {
 
 resource "null_resource" "deploy" {
   triggers = {
-    instance_id  = vultr_instance.this.id
-    video_hash   = filemd5(var.video_path)
-    ssh_host_key = local.ssh_host_public_key_sha
-    stream_hours = tostring(var.stream_hours)
-    break_hours  = tostring(var.break_hours)
+    instance_id           = vultr_instance.this.id
+    video_hash            = filemd5(var.video_path)
+    ssh_host_key          = local.ssh_host_public_key_sha
+    stream_hours          = tostring(var.stream_hours)
+    break_hours           = tostring(var.break_hours)
+    crash_restart_seconds = tostring(var.crash_restart_seconds)
     # SHA256 は不可逆なので nonsensitive() で剥がし triggers map に格納する
     # （terraform 1.5+ は sensitive 値の派生も sensitive 扱いするため必須）
     stream_key      = nonsensitive(sha256(var.stream_key))
@@ -144,9 +145,10 @@ resource "null_resource" "deploy" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/youtube-stream.service.tftpl", {
-      install_root = var.install_root
-      stream_hours = var.stream_hours
-      break_hours  = var.break_hours
+      install_root          = var.install_root
+      stream_hours          = var.stream_hours
+      break_hours           = var.break_hours
+      crash_restart_seconds = var.crash_restart_seconds
     })
     destination = "/etc/systemd/system/youtube-stream.service"
   }

--- a/infra/terraform/streaming/templates/youtube-stream.service.tftpl
+++ b/infra/terraform/streaming/templates/youtube-stream.service.tftpl
@@ -1,7 +1,8 @@
 [Unit]
 Description=YouTube Live Stream (ffmpeg -> RTMP)
 After=network-online.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=60
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -39,7 +40,7 @@ Restart=always
 %{ if stream_hours > 0 && break_hours > 0 }
 RestartSec=${break_hours}h
 %{ else }
-RestartSec=10s
+RestartSec=${crash_restart_seconds}s
 %{ endif }
 
 [Install]

--- a/infra/terraform/streaming/terraform.tfvars.example
+++ b/infra/terraform/streaming/terraform.tfvars.example
@@ -30,10 +30,12 @@ allowed_ssh_cidr = ["203.0.113.5/32"]
 # channel_slug     = "005ch-abyss"
 
 # 配信サイクル:
-#   0 / 0 は 24/7 連続配信（RuntimeMaxSec なし、クラッシュ時は 10 秒後に再起動）。
+#   0 / 0 は 24/7 連続配信（RuntimeMaxSec なし、クラッシュ時は既定 2 秒後に再起動）。
 #   従来の 11 時間配信 + 1 時間休止に戻す場合は 11 / 1 を指定する。
+#   永続的な起動失敗は 60 秒間に 10 回で停止し、healthcheck が異常を通知する。
 # stream_hours = 0
 # break_hours  = 0
+# crash_restart_seconds = 2  # 1〜300 秒。環境に合わせて上書き可能
 
 # ライブチャット返信 daemon（既定 false / opt-in）:
 # secret 3 種は tfvars に書かず、1Password 参照を渡して専用ラッパーを実行する。

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -58,12 +58,27 @@ variable "stream_hours" {
 
 variable "break_hours" {
   type        = number
-  description = "配信終了後の休止時間（時間）。0 は休止なしを表し、クラッシュ時の再起動間隔 RestartSec=10s を使用する"
+  description = "配信終了後の休止時間（時間）。0 は休止なしを表し、クラッシュ時は crash_restart_seconds 後に再起動する"
   default     = 0
 
   validation {
     condition     = var.break_hours >= 0
     error_message = "break_hours は 0 以上を指定してください（0 = 休止なし、正数 = 休止時間（時間））。"
+  }
+}
+
+variable "crash_restart_seconds" {
+  type        = number
+  description = "計画休止を使わないときのクラッシュ再起動間隔（秒）。24/7 配信の短い断絶から素早く復帰する"
+  default     = 2
+
+  validation {
+    condition = (
+      var.crash_restart_seconds >= 1 &&
+      var.crash_restart_seconds <= 300 &&
+      floor(var.crash_restart_seconds) == var.crash_restart_seconds
+    )
+    error_message = "crash_restart_seconds は 1〜300 の整数で指定してください。"
   }
 }
 

--- a/tests/repo/streaming/test_main_tf.py
+++ b/tests/repo/streaming/test_main_tf.py
@@ -466,7 +466,7 @@ class TestMainTfNullResource:
 
         - instance_id = vultr_instance.this.id（VPS 再作成時の再 deploy）
         - video_hash = filemd5(var.video_path)（動画差分での再 deploy）
-        - stream_hours / break_hours（配信サイクル差分での再 deploy）
+        - stream_hours / break_hours / crash_restart_seconds（配信サイクル差分での再 deploy）
         - stream_key（sha256 ハッシュ。stream key 差分での再 deploy）
         """
         text = strip_hcl_comments(read_file(_MAIN_TF))
@@ -486,6 +486,10 @@ class TestMainTfNullResource:
         assert re.search(r"break_hours\s*=\s*tostring\(\s*var\.break_hours\s*\)", triggers), (
             "triggers.break_hours が tostring(var.break_hours) でない"
         )
+        assert re.search(
+            r"crash_restart_seconds\s*=\s*tostring\(\s*var\.crash_restart_seconds\s*\)",
+            triggers,
+        ), "triggers.crash_restart_seconds が tostring(var.crash_restart_seconds) でない"
         assert re.search(r"\bstream_key\s*=", triggers), "triggers.stream_key が無い"
 
     def test_triggers_systemd_unit_hashes_service_tftpl(self):
@@ -517,7 +521,7 @@ class TestMainTfNullResource:
         """Given main.tf
         When ``null_resource.deploy`` 内の ``provisioner "file"`` を読む
         Then ``content = templatefile("${path.module}/templates/youtube-stream.service.tftpl",``
-             ``{ install_root = var.install_root, stream_hours = var.stream_hours, break_hours = var.break_hours })``
+             ``{ install_root, stream_hours, break_hours, crash_restart_seconds })``
              と ``destination = "/etc/systemd/system/youtube-stream.service"`` のペアが
              同一 provisioner 内に宣言されている (#212)。
 
@@ -532,7 +536,8 @@ class TestMainTfNullResource:
             r'"\$\{path\.module\}/templates/youtube-stream\.service\.tftpl"\s*,\s*\{'
             r"[^}]*install_root\s*=\s*var\.install_root"
             r"[^}]*stream_hours\s*=\s*var\.stream_hours"
-            r"[^}]*break_hours\s*=\s*var\.break_hours[^}]*\}\s*\)"
+            r"[^}]*break_hours\s*=\s*var\.break_hours"
+            r"[^}]*crash_restart_seconds\s*=\s*var\.crash_restart_seconds[^}]*\}\s*\)"
         )
         destination_pattern = r'destination\s*=\s*"/etc/systemd/system/youtube-stream\.service"'
         match = re.search(
@@ -547,7 +552,8 @@ class TestMainTfNullResource:
         )
         assert match or match_alt, (
             'provisioner "file" で content=templatefile("${path.module}/templates/'
-            'youtube-stream.service.tftpl", { install_root, stream_hours, break_hours }) → '
+            'youtube-stream.service.tftpl", { install_root, stream_hours, break_hours, '
+            "crash_restart_seconds }) → "
             "/etc/systemd/system/youtube-stream.service への配信が宣言されていない"
         )
 

--- a/tests/repo/streaming/test_systemd_unit.py
+++ b/tests/repo/streaming/test_systemd_unit.py
@@ -43,7 +43,11 @@ class TestSystemdUnitTemplate:
         assert re.search(pattern, service, flags=re.MULTILINE), message
 
     @staticmethod
-    def _render_cycle_template(stream_hours: int, break_hours: int) -> str:
+    def _render_cycle_template(
+        stream_hours: int,
+        break_hours: int,
+        crash_restart_seconds: int = 2,
+    ) -> str:
         """Terraform templatefile の cycle 条件だけをテスト用に展開する。"""
         text = read_file(_SYSTEMD_TFTPL)
         text = text.replace("${install_root}", "/opt/youtube-stream")
@@ -61,7 +65,11 @@ class TestSystemdUnitTemplate:
                 text,
                 flags=re.DOTALL,
             )
-        restart_sec = f"RestartSec={break_hours}h" if stream_hours > 0 and break_hours > 0 else "RestartSec=10s"
+        restart_sec = (
+            f"RestartSec={break_hours}h"
+            if stream_hours > 0 and break_hours > 0
+            else f"RestartSec={crash_restart_seconds}s"
+        )
         text = re.sub(
             r"%\{\s*if stream_hours > 0 && break_hours > 0\s*\}\n.*?%\{\s*else\s*\}\n.*?%\{\s*endif\s*\}",
             restart_sec,
@@ -180,20 +188,20 @@ class TestSystemdUnitTemplate:
         """Given .tftpl
         When [Service] を読む
         Then break_hours > 0 のとき ``RestartSec=${break_hours}h``、
-             0 のとき ``RestartSec=10s`` が出力される。
+             0 のとき ``RestartSec=${crash_restart_seconds}s`` が出力される。
         """
         text = read_file(_SYSTEMD_TFTPL)
         assert "%{ if stream_hours > 0 && break_hours > 0 }" in text, (
             "stream_hours > 0 && break_hours > 0 の条件分岐が無い"
         )
         assert "RestartSec=${break_hours}h" in text, "RestartSec が break_hours 変数で出力されていない"
-        assert "RestartSec=10s" in text, "break_hours=0 用の RestartSec=10s が無い"
+        assert "RestartSec=${crash_restart_seconds}s" in text, "break_hours=0 用の configurable RestartSec が無い"
         default_service = self._section(self._render_cycle_template(0, 0), "Service")
         legacy_service = self._section(self._render_cycle_template(11, 1), "Service")
         assert default_service is not None
         assert legacy_service is not None
-        assert re.search(r"^RestartSec=10s\s*$", default_service, flags=re.MULTILINE), (
-            "break_hours=0 で RestartSec=10s が出力されない"
+        assert re.search(r"^RestartSec=2s\s*$", default_service, flags=re.MULTILINE), (
+            "break_hours=0 で既定 RestartSec=2s が出力されない"
         )
         assert re.search(r"^RestartSec=1h\s*$", legacy_service, flags=re.MULTILINE), (
             "break_hours=1 で RestartSec=1h が出力されない"
@@ -202,16 +210,16 @@ class TestSystemdUnitTemplate:
     def test_service_restart_sec_ignores_break_hours_when_stream_hours_zero(self):
         """Given stream_hours=0 (24/7 モード) かつ break_hours=1
         When テンプレートを展開する
-        Then ``RestartSec=10s`` が出力される（break_hours は無視される）。
+        Then ``RestartSec=2s`` が出力される（break_hours は無視される）。
 
         stream_hours=0 では RuntimeMaxSec が省略されるため、RestartSec が長時間になると
         クラッシュ時の再起動が遅延する。24/7 モードでは break_hours を無視して
-        常にクラッシュ再起動用の 10s を使う。
+        常にクラッシュ再起動用の既定 2s を使う。
         """
         service = self._section(self._render_cycle_template(0, 1), "Service")
         assert service is not None
-        assert re.search(r"^RestartSec=10s\s*$", service, flags=re.MULTILINE), (
-            "stream_hours=0, break_hours=1 で RestartSec=10s が出力されない（24/7 モードでは break_hours を無視すべき）"
+        assert re.search(r"^RestartSec=2s\s*$", service, flags=re.MULTILINE), (
+            "stream_hours=0, break_hours=1 で RestartSec=2s が出力されない（24/7 モードでは break_hours を無視すべき）"
         )
         assert not re.search(r"^RestartSec=1h\s*$", service, flags=re.MULTILINE), (
             "stream_hours=0 なのに RestartSec=1h が出力されている"
@@ -235,16 +243,25 @@ class TestSystemdUnitTemplate:
     def test_service_custom_cycle_no_break(self):
         """Given stream_hours=6, break_hours=0
         When テンプレートを展開する
-        Then RuntimeMaxSec=6h が出力され、RestartSec=10s（クラッシュ再起動）になる。
+        Then RuntimeMaxSec=6h が出力され、RestartSec=2s（クラッシュ再起動）になる。
         """
         service = self._section(self._render_cycle_template(6, 0), "Service")
         assert service is not None
         assert re.search(r"^RuntimeMaxSec=6h\s*$", service, flags=re.MULTILINE), (
             "stream_hours=6 で RuntimeMaxSec=6h が出力されない"
         )
-        assert re.search(r"^RestartSec=10s\s*$", service, flags=re.MULTILINE), (
-            "stream_hours=6, break_hours=0 で RestartSec=10s が出力されない"
+        assert re.search(r"^RestartSec=2s\s*$", service, flags=re.MULTILINE), (
+            "stream_hours=6, break_hours=0 で RestartSec=2s が出力されない"
         )
+
+    def test_crash_restart_seconds_override_does_not_change_planned_break(self):
+        """24/7 の override は反映し、11h+1h の計画休止は常に 1h を維持する。"""
+        continuous = self._render_cycle_template(0, 0, crash_restart_seconds=7)
+        planned = self._render_cycle_template(11, 1, crash_restart_seconds=7)
+
+        assert re.search(r"^RestartSec=7s\s*$", continuous, flags=re.MULTILINE)
+        assert re.search(r"^RestartSec=1h\s*$", planned, flags=re.MULTILINE)
+        assert not re.search(r"^RestartSec=7s\s*$", planned, flags=re.MULTILINE)
 
     def test_install_section_wanted_by_multi_user(self):
         """Given .tftpl
@@ -403,7 +420,12 @@ class TestSystemdUnitTemplate:
         text = read_file(_SYSTEMD_TFTPL)
         interpolations = re.findall(r"\$\{[^}]+\}", text)
         assert interpolations, "Terraform 補間が無い（install_root の配線検証になっていない）"
-        assert set(interpolations) <= {"${install_root}", "${stream_hours}", "${break_hours}"}, (
+        assert set(interpolations) <= {
+            "${install_root}",
+            "${stream_hours}",
+            "${break_hours}",
+            "${crash_restart_seconds}",
+        }, (
             "templatefile() に渡していない補間が残っている（systemd で参照したい場合は $NAME と書く / "
             "terraform で渡したい場合は templatefile() の variables map に追加する）"
         )
@@ -424,20 +446,18 @@ class TestSystemdUnitTemplate:
             flags=re.IGNORECASE,
         ), "ffmpeg -i に動画パスが直書きされている（$VIDEO を使うこと）"
 
-    def test_unit_section_start_limit_interval_sec_zero(self):
+    def test_unit_section_limits_persistent_crash_loop(self):
         """Given .tftpl
         When [Unit] セクションを読む
-        Then ``StartLimitIntervalSec=0`` が宣言されている (#214)。
+        Then 60 秒間 10 回の start limit が宣言されている。
 
-        起動失敗カウントの時間窓を無効化し、``Restart=always`` + ``RestartSec``
-        サイクルが ``StartLimitHit`` で永続停止する経路を遮断する。
+        2 秒再起動を無制限に続けず、healthcheck が通知できる failed 状態で停止する。
         """
         text = read_file(_SYSTEMD_TFTPL)
         unit = self._section(text, "Unit")
         assert unit is not None
-        assert re.search(r"^StartLimitIntervalSec=0\s*$", unit, flags=re.MULTILINE), (
-            "[Unit].StartLimitIntervalSec=0 が無い（起動失敗連発で StartLimitHit 永続停止する余地が残る）"
-        )
+        assert re.search(r"^StartLimitIntervalSec=60\s*$", unit, flags=re.MULTILINE)
+        assert re.search(r"^StartLimitBurst=10\s*$", unit, flags=re.MULTILINE)
 
     def test_service_success_exit_status_sigterm_143(self):
         """Given .tftpl

--- a/tests/repo/streaming/test_terraform_meta.py
+++ b/tests/repo/streaming/test_terraform_meta.py
@@ -473,6 +473,7 @@ class TestTfvarsExampleStreamCycle:
         raw = read_file(_TFVARS_EXAMPLE)
         assert "# stream_hours = 0" in raw, "stream_hours の任意サンプルが無い"
         assert "# break_hours  = 0" in raw, "break_hours の任意サンプルが無い"
+        assert "# crash_restart_seconds = 2" in raw, "crash_restart_seconds の任意サンプルが無い"
         assert "24/7" in raw, "0 / 0 が 24/7 連続配信である説明が無い"
 
 

--- a/tests/repo/streaming/test_variables_tf.py
+++ b/tests/repo/streaming/test_variables_tf.py
@@ -186,7 +186,7 @@ class TestVariablesTfNullResource:
         When break_hours 変数定義を読む
         Then type=number, default=0, description あり、非負 validation が宣言されている。
 
-        0 は休止なしを表し、systemd unit では RestartSec=10s を使う。
+        0 は休止なしを表し、systemd unit では crash_restart_seconds を使う。
         負数は > 0 分岐の else 側に入り休止なしモードに黙って吸収されるため、非負を検証する。
         """
         text = strip_hcl_comments(read_file(_VARIABLES_TF))
@@ -205,6 +205,20 @@ class TestVariablesTfNullResource:
             r"error_message\s*=\s*\"",
             validation,
         ), "break_hours.validation.error_message が宣言されていない"
+
+    def test_crash_restart_seconds_has_safe_configurable_default(self):
+        """クラッシュ再起動間隔は既定2秒で、1〜300の整数だけを受理する。"""
+        text = strip_hcl_comments(read_file(_VARIABLES_TF))
+        block = extract_block(text, r'variable\s+"crash_restart_seconds"')
+        assert block is not None
+        assert re.search(r"type\s*=\s*number", block)
+        assert re.search(r"default\s*=\s*2\b", block)
+        assert re.search(r"description\s*=", block)
+        validation = extract_block(block, r"validation")
+        assert validation is not None
+        assert "var.crash_restart_seconds >= 1" in validation
+        assert "var.crash_restart_seconds <= 300" in validation
+        assert "floor(var.crash_restart_seconds) == var.crash_restart_seconds" in validation
 
     def test_stream_key_is_sensitive_string_with_no_default(self):
         """Given variables.tf


### PR DESCRIPTION
## Summary
- 24/7 / breakなし配信のクラッシュ復帰を既定10秒から2秒へ短縮
- `crash_restart_seconds`（1〜300秒）で環境別に上書き可能
- 11h+1h の計画休止は維持し、永続障害は60秒10回のsystemd start limitで停止・通知

## Verification
- streaming focused: 372 passed
- Terraform fmt / init -backend=false / validate
- Ruff check / format check
- `yt-skills lint streaming`
- `uv sync --frozen` / `uv build`

Closes #3029