### PR TITLE
fix(suno): prompt成果物を一組で原子的に公開 (#3669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 
 - `fix(suno)`: effective `genre_line` の hard guard `style_char_limit: 120` を維持しつつ、完成形 Style の soft quality budget を `full_style_char_limit: 256` へ分離。明示した新キー、明示した legacy キー、既定値の順で解決し、既存チャンネルの override を保ったまま構造的な警告を解消（#2589）。
+- `fix(suno)`: `suno-prompts.md` / JSON を同一ディレクトリの一時ファイルへ書き切ってから一組で公開し、commit 途中失敗時は元の有無を含めて両成果物を rollback するようにした（#3669）。
 - `fix(suno)`: collection-local `style_variants` を持たない legacy collection の variant key drift を、patterns path・移行手順・既存成果物の stale 状態と再検証コマンド付きで診断し、失敗時の既存 MD/JSON を不変に保つようにした（#3668）。
 - `docs(thumbnail)`: 承認済み画像生成を subagent / background session で実行する場合は stdin を `/dev/null` へ閉じ、process の exit と成果物を観測するまで完了報告しない契約を追加（#2950）。
 - `docs(suno)`: `suno_preset` を hard gate から推奨入力へ変更し、collection 固有の effective Style と vocal gender を `suno-patterns.yaml` に保存して共有 channel config を変更せず `/wf-new`・`/suno-lyric`・`yt-suno-verify` へ引き渡す正規手順を追加（#2999）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -34,6 +34,7 @@ from youtube_automation.domains.suno.downloaded.validation import (
     surrounding_whitespace_issue,
 )
 from youtube_automation.domains.suno.lyrics import load_suno_lyrics_by_name
+from youtube_automation.infrastructure.filesystem import write_text_files_transactionally
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 _STYLE_VARIATION_BANNED_ADJECTIVES = frozenset(
@@ -895,11 +896,14 @@ def main():
     }
 
     md_path = patterns_path.parent / SUNO_PROMPTS_MD_FILENAME
-    md_path.write_text(markdown)
-    print(f"Generated: {md_path}")
-
     json_path = patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME
-    json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    write_text_files_transactionally(
+        {
+            md_path: markdown,
+            json_path: json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        }
+    )
+    print(f"Generated: {md_path}")
     print(f"Generated: {json_path}")
 
 

--- a/src/youtube_automation/infrastructure/filesystem/__init__.py
+++ b/src/youtube_automation/infrastructure/filesystem/__init__.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TypeAlias
 
@@ -66,6 +68,97 @@ def write_file_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
 
 def replace_file(source: Path, destination: Path) -> None:
     os.replace(source, destination)
+
+
+def _temporary_path(target: Path, *, suffix: str) -> tuple[int, Path]:
+    descriptor, name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=suffix,
+    )
+    return descriptor, Path(name)
+
+
+def _write_temporary_text(target: Path, text: str, *, encoding: str) -> Path:
+    descriptor, temporary = _temporary_path(target, suffix=".tmp")
+    try:
+        with os.fdopen(descriptor, "w", encoding=encoding) as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except (OSError, UnicodeError):
+        temporary.unlink(missing_ok=True)
+        raise
+    return temporary
+
+
+def _reserve_backup_path(target: Path) -> Path:
+    descriptor, backup = _temporary_path(target, suffix=".backup")
+    os.close(descriptor)
+    return backup
+
+
+def _rollback_files(
+    targets: list[Path],
+    original_targets: set[Path],
+    backups: dict[Path, Path],
+    backed_up_targets: set[Path],
+) -> None:
+    rollback_errors: list[OSError] = []
+    for target in reversed(targets):
+        try:
+            if target in backed_up_targets:
+                target.unlink(missing_ok=True)
+                replace_file(backups[target], target)
+            elif target not in original_targets:
+                target.unlink(missing_ok=True)
+        except OSError as exc:
+            rollback_errors.append(exc)
+    if rollback_errors:
+        raise OSError("transactional file publish rollback failed") from rollback_errors[0]
+
+
+def _cleanup_paths(paths: list[Path]) -> None:
+    for path in paths:
+        path.unlink(missing_ok=True)
+
+
+def write_text_files_transactionally(contents: Mapping[Path, str], *, encoding: str = "utf-8") -> None:
+    """Publish text files as one rollback-capable transaction.
+
+    Process termination and filesystem loss are outside this local transaction's
+    guarantees. All temporary and backup files are created beside their targets.
+    """
+    targets = list(contents)
+    if not targets:
+        raise ValueError("transactional file publish requires at least one target")
+    if len({target.parent for target in targets}) != 1:
+        raise ValueError("transactional file publish targets must share one directory")
+
+    temporaries: dict[Path, Path] = {}
+    backups: dict[Path, Path] = {}
+    original_targets = {target for target in targets if target.exists()}
+    backed_up_targets: set[Path] = set()
+    try:
+        temporaries = {target: _write_temporary_text(target, contents[target], encoding=encoding) for target in targets}
+        for target in targets:
+            if target not in original_targets:
+                continue
+            backup = _reserve_backup_path(target)
+            backups[target] = backup
+            replace_file(target, backup)
+            backed_up_targets.add(target)
+        for target in targets:
+            replace_file(temporaries[target], target)
+    except (OSError, UnicodeError) as publish_error:
+        try:
+            _rollback_files(targets, original_targets, backups, backed_up_targets)
+        except OSError as rollback_error:
+            _cleanup_paths(list(temporaries.values()))
+            raise rollback_error from publish_error
+        _cleanup_paths([*temporaries.values(), *backups.values()])
+        raise
+    _cleanup_paths([*temporaries.values(), *backups.values()])
 
 
 def current_working_directory() -> Path:

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -15,6 +15,7 @@ from youtube_automation.commands.suno.generate_suno_prompts import build_prompt_
 from youtube_automation.configuration import skills as skill_config
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.suno.config import infer_suno_mode
+from youtube_automation.infrastructure import filesystem
 
 # `_skills/<skill>/config.default.yaml` の解決元になる editable install のソースツリー
 _DEFAULT_YAML = REPO_ROOT / ".claude" / "skills" / "suno" / "config.default.yaml"
@@ -1141,6 +1142,60 @@ def test_main_writes_suno_prompts_json_alongside_md(channel_dir, tmp_path, monke
     json_path = patterns_path.parent / "suno-prompts.json"
     assert md_path.exists(), "既存の md 出力は維持されること"
     assert json_path.exists(), "suno-prompts.json が併出されること"
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".suno-prompts")]
+
+
+@pytest.mark.parametrize(
+    ("original_md", "original_json"),
+    [
+        (None, None),
+        (b"old markdown\n", None),
+        (None, b'{"old": true}\n'),
+        (b"old markdown\n", b'{"old": true}\n'),
+    ],
+)
+def test_main_rolls_back_both_outputs_when_second_commit_fails(
+    channel_dir,
+    tmp_path,
+    monkeypatch,
+    original_md,
+    original_json,
+):
+    """2個目の成果物 commit 失敗時は、元の有無を含めて一組で復元する。"""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz, soft piano")
+    patterns_path = _write_minimal_patterns(tmp_path)
+    md_path = patterns_path.parent / "suno-prompts.md"
+    json_path = patterns_path.parent / "suno-prompts.json"
+    if original_md is not None:
+        md_path.write_bytes(original_md)
+    if original_json is not None:
+        json_path.write_bytes(original_json)
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
+
+    real_replace = filesystem.replace_file
+    failed = False
+
+    def fail_json_commit_once(source: Path, destination: Path) -> None:
+        nonlocal failed
+        if destination == json_path and not failed:
+            failed = True
+            raise OSError("simulated second commit failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(filesystem, "replace_file", fail_json_commit_once)
+
+    with pytest.raises(OSError, match="simulated second commit failure"):
+        main()
+
+    if original_md is None:
+        assert not md_path.exists()
+    else:
+        assert md_path.read_bytes() == original_md
+    if original_json is None:
+        assert not json_path.exists()
+    else:
+        assert json_path.read_bytes() == original_json
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".suno-prompts")]
 
 
 @pytest.mark.parametrize("style_source", ["channel", "patterns"])
@@ -2195,6 +2250,7 @@ def test_main_legacy_style_variant_drift_preserves_stale_outputs(channel_dir, tm
     assert f"uv run yt-suno-verify {patterns_path.parent}" in message
     assert md_path.read_bytes() == original_md
     assert json_path.read_bytes() == original_json
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".suno-prompts")]
     assert not [warning for warning in caught if "未知のトップレベルキー" in str(warning.message)]
 
 


### PR DESCRIPTION
## Summary

- Suno prompt MD / JSON を同一 directory の一時 file へ事前 write
- 一組として commitし、2個目の failure 時は元の存在状態まで rollback
- success / validation failure / second commit failure と残骸 cleanup を回帰テストで固定

Closes #3669

Depends on #3672