### PR TITLE
fix(suno-helper): 形式モーダル検出をBase UIへ追従する (#3039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(streaming)`: 24/7 配信時だけ YouTube 配信枠復旧 CLI を既定 2 分の systemd timer で実行し、ephemeral OAuth 配備、ffmpeg 停止時 no-op、recovered 通知と journald 記録、安全な disable cleanup を行う Terraform opt-in を追加（#3675）。
 
 - `feat(streaming)`: active broadcast / ingest 状態を確認し、active ingest だけが残った場合に upcoming 配信枠を冪等再利用、または新規作成して bind → live 遷移する `yt-stream-broadcast-recover` CLI を追加。dry-run、構造化結果、secret 非出力を備えた（#3674）。
+- `fix(suno-helper)`: 現行 Base UI の可視 dialog から Download 確認ボタンと M4A / MP3 / WAV の3形式を持つ一意なモーダルを検出し、M4A 既定から MP3 を選択して同じモーダルの閉鎖まで待機するよう修正。DOM 契約不一致時は Suno UI 変更を明示する（#3039）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 

--- a/extensions/suno-helper/lib/download.ts
+++ b/extensions/suno-helper/lib/download.ts
@@ -9,9 +9,10 @@ const CLIP_ROW_SELECTOR =
   '[data-testid="clip-row"], .clip-row, article, [role="group"]';
 const CONTEXT_MENU_SELECTOR = 'div[data-context-menu="true"]';
 const DOWNLOAD_MENU_ITEM_TEXT = /download\s*all/i;
-const FORMAT_MODAL_SELECTOR = "div.modal-class.modal-overlay";
-const FORMAT_OPTION_SELECTOR = "button.flex.w-full";
-const DOWNLOAD_CONFIRM_SELECTOR = "button.hxc-btn-variant-primary";
+const DIALOG_SELECTOR = '[role="dialog"]';
+const BUTTON_SELECTOR = "button";
+const DOWNLOAD_CONFIRM_LABEL = "Download";
+const FORMAT_OPTION_LABELS = ["M4A", "MP3", "WAV"] as const;
 const MENU_APPEAR_POLL_MS = 10;
 const MENU_APPEAR_TIMEOUT_MS = 1500;
 const MAX_DOWNLOAD_MENU_ATTEMPTS = 3;
@@ -20,27 +21,6 @@ const MODAL_APPEAR_TIMEOUT_MS = 10000;
 const MODAL_CLOSE_POLL_MS = 200;
 const MODAL_CLOSE_TIMEOUT_MS = 120000;
 const SETTLE_AFTER_CLICK_MS = 500;
-
-async function waitForElement<T extends HTMLElement>(
-  selector: string,
-  timeoutMs: number,
-  pollMs: number,
-  filter?: (el: T) => boolean
-): Promise<T> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const candidates = document.querySelectorAll<T>(selector);
-    for (const el of candidates) {
-      if (!filter || filter(el)) {
-        return el;
-      }
-    }
-    await sleep(pollMs);
-  }
-  throw new Error(
-    `waitForElement timed out: selector="${selector}" (${timeoutMs}ms)`
-  );
-}
 
 function findElementByTextContent<T extends HTMLElement>(
   parent: HTMLElement | Document,
@@ -54,6 +34,67 @@ function findElementByTextContent<T extends HTMLElement>(
     }
   }
   return null;
+}
+
+function findButtonByExactLabel(
+  parent: HTMLElement,
+  label: string
+): HTMLButtonElement | null {
+  for (const button of parent.querySelectorAll<HTMLButtonElement>(
+    BUTTON_SELECTOR
+  )) {
+    const accessibleLabel =
+      button.getAttribute("aria-label") ?? button.textContent?.trim();
+    if (accessibleLabel?.toLowerCase() === label.toLowerCase()) {
+      return button;
+    }
+  }
+  return null;
+}
+
+function isVisibleDialog(dialog: HTMLElement): boolean {
+  if (dialog.hidden || dialog.getAttribute("aria-hidden") === "true") {
+    return false;
+  }
+  const style = getComputedStyle(dialog);
+  return style.display !== "none" && style.visibility !== "hidden";
+}
+
+function resolveFormatModal(): HTMLElement | null {
+  const matchingDialogs = Array.from(
+    document.querySelectorAll<HTMLElement>(DIALOG_SELECTOR)
+  ).filter(
+    (dialog) =>
+      isVisibleDialog(dialog) &&
+      FORMAT_OPTION_LABELS.every((label) =>
+        findButtonByExactLabel(dialog, label)
+      ) &&
+      findButtonByExactLabel(dialog, DOWNLOAD_CONFIRM_LABEL)
+  );
+  if (matchingDialogs.length > 1) {
+    throw new Error(
+      "ダウンロード形式モーダルが複数見つかりました。Suno の UI 変更の可能性があります。"
+    );
+  }
+  return matchingDialogs[0] ?? null;
+}
+
+async function waitForFormatModal(
+  timeoutMs: number,
+  pollMs: number
+): Promise<HTMLElement> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const modal = resolveFormatModal();
+    if (modal) {
+      return modal;
+    }
+    await sleep(pollMs);
+  }
+  throw new Error(
+    `Download 確認ボタンと M4A / MP3 / WAV を持つ可視ダイアログが見つかりませんでした (${timeoutMs}ms)。` +
+      "Suno の UI 変更の可能性があります。"
+  );
 }
 
 function resolveClipRowFromSelectButton(
@@ -143,9 +184,7 @@ async function waitForDownloadMenuItem(
 
 function selectFormatInModal(modal: HTMLElement, format: string): void {
   const formatPattern = new RegExp(`^${format}$`, "i");
-  const candidates = modal.querySelectorAll<HTMLButtonElement>(
-    FORMAT_OPTION_SELECTOR
-  );
+  const candidates = modal.querySelectorAll<HTMLButtonElement>(BUTTON_SELECTOR);
   for (const btn of candidates) {
     if (btn.disabled) continue;
     if (btn.textContent && formatPattern.test(btn.textContent.trim())) {
@@ -160,7 +199,7 @@ function selectFormatInModal(modal: HTMLElement, format: string): void {
 }
 
 function clickDownloadConfirm(modal: HTMLElement): void {
-  const btn = modal.querySelector<HTMLButtonElement>(DOWNLOAD_CONFIRM_SELECTOR);
+  const btn = findButtonByExactLabel(modal, DOWNLOAD_CONFIRM_LABEL);
   if (!btn) {
     throw new Error(
       "ダウンロード確認ボタンが見つかりませんでした。Suno の UI 変更の可能性があります。"
@@ -176,11 +215,7 @@ async function waitForFormatModalClose(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (
-      !modal.isConnected ||
-      !document.contains(modal) ||
-      !document.querySelector(FORMAT_MODAL_SELECTOR)
-    ) {
+    if (!modal.isConnected || !document.contains(modal)) {
       return;
     }
     await sleep(pollMs);
@@ -217,8 +252,7 @@ function defaultDownloadDeps(): TriggerDownloadAllDeps {
     findMoreButton: findScopedMoreButton,
     waitForDownloadMenuItem: (timeoutMs, pollMs) =>
       waitForDownloadMenuItem(timeoutMs, pollMs),
-    waitForFormatModal: (timeoutMs, pollMs) =>
-      waitForElement<HTMLElement>(FORMAT_MODAL_SELECTOR, timeoutMs, pollMs),
+    waitForFormatModal,
     waitForModalClose: waitForFormatModalClose,
     selectFormat: selectFormatInModal,
     clickConfirm: clickDownloadConfirm,

--- a/extensions/suno-helper/tests/download.test.ts
+++ b/extensions/suno-helper/tests/download.test.ts
@@ -12,6 +12,33 @@ function stubElement(): HTMLElement {
   return { click: vi.fn() } as unknown as HTMLElement;
 }
 
+interface FormatModalFixtureOptions {
+  confirm?: boolean;
+  formats?: readonly string[];
+  hidden?: boolean;
+  mp3Disabled?: boolean;
+  testId?: string;
+}
+
+function formatModalFixture(options: FormatModalFixtureOptions = {}): string {
+  const formats = options.formats ?? ["M4A", "MP3", "WAV"];
+  const formatButtons = formats
+    .map(
+      (format) =>
+        `<button class="flex w-full"${
+          format === "MP3" && options.mp3Disabled ? " disabled" : ""
+        }${format === "M4A" ? ' aria-pressed="true"' : ""}>${format}</button>`
+    )
+    .join("");
+  const confirm =
+    options.confirm === false
+      ? ""
+      : '<button class="hxc-btn-variant-primary">Download</button>';
+  return `<div role="dialog" data-open data-base-ui-focusable data-testid="${
+    options.testId ?? "format-modal"
+  }"${options.hidden ? " hidden" : ""}>${formatButtons}${confirm}</div>`;
+}
+
 function createMockDeps(
   overrides?: Partial<TriggerDownloadAllDeps>
 ): TriggerDownloadAllDeps {
@@ -225,12 +252,9 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button aria-label="Download all">Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">M4A</button>
-        <button class="flex w-full">MP3</button>
-        <button class="flex w-full">WAV</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      <div role="dialog" data-testid="unrelated-dialog"><button>Cancel</button></div>
+      ${formatModalFixture({ hidden: true, testId: "hidden-format-modal" })}
+      ${formatModalFixture()}
     `;
     const more = document.querySelector<HTMLButtonElement>(
       'button[aria-label="More options"]'
@@ -238,10 +262,13 @@ describe("triggerDownloadAll", () => {
     const downloadAll = document.querySelector<HTMLButtonElement>(
       'button[aria-label="Download all"]'
     )!;
+    const formatModal = document.querySelector<HTMLElement>(
+      '[data-testid="format-modal"]'
+    )!;
     const mp3 = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
+      formatModal.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
     ).find((button) => button.textContent?.trim() === "MP3")!;
-    const confirm = document.querySelector<HTMLButtonElement>(
+    const confirm = formatModal.querySelector<HTMLButtonElement>(
       "button.hxc-btn-variant-primary"
     )!;
     more.addEventListener("click", () => clicked.push("more"));
@@ -249,7 +276,7 @@ describe("triggerDownloadAll", () => {
     mp3.addEventListener("click", () => clicked.push("mp3"));
     confirm.addEventListener("click", () => {
       clicked.push("confirm");
-      document.querySelector(".modal-class.modal-overlay")?.remove();
+      document.querySelector('[data-testid="format-modal"]')?.remove();
     });
 
     await triggerDownloadAll("mp3");
@@ -272,23 +299,26 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button aria-label="Download all">Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">MP3</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture()}
     `;
     document
       .querySelector<HTMLButtonElement>('button[aria-label="Download all"]')!
       .addEventListener("click", () => clicked.push("download-all"));
-    document
-      .querySelector<HTMLButtonElement>("button.flex.w-full")!
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
+    )
+      .find((button) => button.textContent?.trim() === "MP3")!
       .addEventListener("click", () => clicked.push("mp3"));
     document
       .querySelector<HTMLButtonElement>("button.hxc-btn-variant-primary")!
       .addEventListener("click", () => {
         clicked.push("confirm");
         setTimeout(() => {
-          document.querySelector(".modal-class.modal-overlay")?.remove();
+          document.body.insertAdjacentHTML(
+            "beforeend",
+            formatModalFixture({ testId: "next-format-modal" })
+          );
+          document.querySelector('[data-testid="format-modal"]')?.remove();
         }, 11_000);
       });
 
@@ -314,10 +344,7 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button aria-label="Download all">Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">MP3</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture()}
     `;
     document
       .querySelector<HTMLButtonElement>('[data-testid="unrelated-more"]')!
@@ -328,14 +355,16 @@ describe("triggerDownloadAll", () => {
     document
       .querySelector<HTMLButtonElement>('button[aria-label="Download all"]')!
       .addEventListener("click", () => clicked.push("download-all"));
-    document
-      .querySelector<HTMLButtonElement>("button.flex.w-full")!
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
+    )
+      .find((button) => button.textContent?.trim() === "MP3")!
       .addEventListener("click", () => clicked.push("mp3"));
     document
       .querySelector<HTMLButtonElement>("button.hxc-btn-variant-primary")!
       .addEventListener("click", () => {
         clicked.push("confirm");
-        document.querySelector(".modal-class.modal-overlay")?.remove();
+        document.querySelector('[data-testid="format-modal"]')?.remove();
       });
 
     await triggerDownloadAll("mp3");
@@ -366,10 +395,7 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button aria-label="Download all">Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">M4A</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture()}
     `;
     document
       .querySelector<HTMLButtonElement>('[data-testid="list-row-more"]')!
@@ -384,7 +410,7 @@ describe("triggerDownloadAll", () => {
       .querySelector<HTMLButtonElement>("button.hxc-btn-variant-primary")!
       .addEventListener("click", () => {
         clicked.push("confirm");
-        document.querySelector(".modal-class.modal-overlay")?.remove();
+        document.querySelector('[data-testid="format-modal"]')?.remove();
       });
 
     await triggerDownloadAll("m4a");
@@ -411,10 +437,7 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button aria-label="Download all">Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">MP3</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture()}
     `;
     document
       .querySelector<HTMLButtonElement>('[data-testid="selected-row-more"]')!
@@ -422,14 +445,16 @@ describe("triggerDownloadAll", () => {
     document
       .querySelector<HTMLButtonElement>('button[aria-label="Download all"]')!
       .addEventListener("click", () => clicked.push("download-all"));
-    document
-      .querySelector<HTMLButtonElement>("button.flex.w-full")!
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
+    )
+      .find((button) => button.textContent?.trim() === "MP3")!
       .addEventListener("click", () => clicked.push("mp3"));
     document
       .querySelector<HTMLButtonElement>("button.hxc-btn-variant-primary")!
       .addEventListener("click", () => {
         clicked.push("confirm");
-        document.querySelector(".modal-class.modal-overlay")?.remove();
+        document.querySelector('[data-testid="format-modal"]')?.remove();
       });
 
     await triggerDownloadAll("mp3");
@@ -482,10 +507,7 @@ describe("triggerDownloadAll", () => {
       <div data-context-menu="true">
         <button>Download all</button>
       </div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">MP3</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture()}
     `;
     const downloadAll = Array.from(
       document.querySelectorAll<HTMLButtonElement>("button")
@@ -495,7 +517,7 @@ describe("triggerDownloadAll", () => {
       .querySelector<HTMLButtonElement>("button.hxc-btn-variant-primary")!
       .addEventListener("click", () => {
         clicked.push("confirm");
-        document.querySelector(".modal-class.modal-overlay")?.remove();
+        document.querySelector('[data-testid="format-modal"]')?.remove();
       });
 
     await triggerDownloadAll("mp3");
@@ -514,16 +536,14 @@ describe("triggerDownloadAll", () => {
         </article>
       </div>
       <div data-context-menu="true"><button>Download all</button></div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full" disabled>MP3</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture({ mp3Disabled: true })}
     `;
 
     await expect(triggerDownloadAll("mp3")).rejects.toThrow(/形式 "mp3"/);
   });
 
-  it("DOM fixture: default deps は format button が無ければ throw する", async () => {
+  it("DOM fixture: 形式3択が崩れた場合は UI 変更を示して throw する", async () => {
+    vi.useFakeTimers();
     vi.stubGlobal("PointerEvent", MouseEvent);
     document.body.innerHTML = `
       <div class="clip-browser-list-scroller">
@@ -534,16 +554,18 @@ describe("triggerDownloadAll", () => {
         </article>
       </div>
       <div data-context-menu="true"><button>Download all</button></div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">WAV</button>
-        <button class="hxc-btn-variant-primary">Download</button>
-      </div>
+      ${formatModalFixture({ formats: ["M4A", "WAV"] })}
     `;
 
-    await expect(triggerDownloadAll("mp3")).rejects.toThrow(/形式 "mp3"/);
+    const result = triggerDownloadAll("mp3");
+    const rejection = expect(result).rejects.toThrow(/Suno の UI 変更/);
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    await rejection;
   });
 
-  it("DOM fixture: default deps は confirm button が無ければ throw する", async () => {
+  it("DOM fixture: Download 確認ボタンが無ければ UI 変更を示して throw する", async () => {
+    vi.useFakeTimers();
     vi.stubGlobal("PointerEvent", MouseEvent);
     document.body.innerHTML = `
       <div class="clip-browser-list-scroller">
@@ -554,13 +576,38 @@ describe("triggerDownloadAll", () => {
         </article>
       </div>
       <div data-context-menu="true"><button>Download all</button></div>
-      <div class="modal-class modal-overlay">
-        <button class="flex w-full">MP3</button>
-      </div>
+      ${formatModalFixture({ confirm: false })}
     `;
 
-    await expect(triggerDownloadAll("mp3")).rejects.toThrow(
-      /ダウンロード確認ボタン/
+    const result = triggerDownloadAll("mp3");
+    const rejection = expect(result).rejects.toThrow(/Suno の UI 変更/);
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    await rejection;
+  });
+
+  it("DOM fixture: 形式モーダルが複数可視なら一意に決めず UI 変更を示す", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("PointerEvent", MouseEvent);
+    document.body.innerHTML = `
+      <div class="clip-browser-list-scroller">
+        <article>
+          <img src="clip.jpg" alt="" />
+          <div class="multi-select-button"><button aria-label="Deselect clip">Selected</button></div>
+          <button aria-label="More options">...</button>
+        </article>
+      </div>
+      <div data-context-menu="true"><button>Download all</button></div>
+      ${formatModalFixture({ testId: "format-modal-a" })}
+      ${formatModalFixture({ testId: "format-modal-b" })}
+    `;
+
+    const result = triggerDownloadAll("mp3");
+    const rejection = expect(result).rejects.toThrow(
+      /形式モーダルが複数.*Suno の UI 変更/
     );
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await rejection;
   });
 });

--- a/extensions/suno-helper/tests/e2e/download-format-modal.spec.ts
+++ b/extensions/suno-helper/tests/e2e/download-format-modal.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test("Base UI の一意な可視形式 dialog で M4A 既定から MP3 を選び Download できる", async ({
+  page,
+}) => {
+  await page.setContent(`
+    <div role="dialog"><button>Cancel</button></div>
+    <div role="dialog" hidden>
+      <button>M4A</button><button>MP3</button><button>WAV</button><button>Download</button>
+    </div>
+    <div role="dialog" data-open data-base-ui-focusable>
+      <button aria-pressed="true">M4A</button>
+      <button aria-pressed="false">MP3</button>
+      <button aria-pressed="false">WAV</button>
+      <button>Download</button>
+    </div>
+    <script>
+      const dialog = document.querySelector('[role="dialog"][data-open]');
+      for (const button of dialog.querySelectorAll('button')) {
+        button.addEventListener('click', () => {
+          if (button.textContent === 'MP3') {
+            for (const option of dialog.querySelectorAll('[aria-pressed]')) {
+              option.setAttribute('aria-pressed', String(option === button));
+            }
+          }
+          if (button.textContent === 'Download') dialog.remove();
+        });
+      }
+    </script>
+  `);
+
+  const formatDialog = page
+    .getByRole("dialog")
+    .filter({ has: page.getByRole("button", { name: "M4A", exact: true }) })
+    .filter({ has: page.getByRole("button", { name: "MP3", exact: true }) })
+    .filter({ has: page.getByRole("button", { name: "WAV", exact: true }) })
+    .filter({
+      has: page.getByRole("button", { name: "Download", exact: true }),
+    });
+
+  await expect(formatDialog).toHaveCount(1);
+  await expect(
+    formatDialog.getByRole("button", { name: "M4A", exact: true })
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await formatDialog.getByRole("button", { name: "MP3", exact: true }).click();
+  await expect(
+    formatDialog.getByRole("button", { name: "MP3", exact: true })
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await formatDialog
+    .getByRole("button", { name: "Download", exact: true })
+    .click();
+  await expect(formatDialog).toHaveCount(0);
+});


### PR DESCRIPTION
## 概要

Suno の現行 Base UI に合わせ、Download 確認ボタンと M4A / MP3 / WAV の3形式を持つ一意な可視 dialog を形式モーダルとして検出します。

## 変更内容

- role=dialog のうち形式3択と Download 確認を持つ可視モーダルだけを選択
- M4A が既定選択された状態から MP3 を完全一致で選択
- 確認後は検出済みの同一 modal 参照が DOM から切断されるまで待機
- 不一致・複数一致を Suno UI 変更の可能性付き actionable error に変更
- Base UI fixture、Vitest 回帰、Chromium E2E を追加し、旧 class selector を削除

## 検証

- TypeScript compile / Ultracite check
- Vitest: 1,456 passed
- Playwright: 17 passed
- WXT production build 成功
- any-usage gate / git diff check

ビルド成果物は .output 配下で commit しないリポジトリ契約を維持しています。

Closes #3039