### PR TITLE
fix(benchmark): preserve manual report analysis

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -92,6 +92,8 @@ uv run yt-benchmark-collect -v               # 詳細ログ
 5. サムネイル画像を `docs/benchmarks/thumbnails/` にダウンロード
 6. `data/benchmark_YYYYMMDD.json` に中間データ保存
 7. `docs/benchmarks/*.md`（個別 + common-patterns + README）を自動生成
+   - 個別レポートは `benchmark:generated:start/end` 間だけを再生成し、`benchmark:user:start/end` 間の手書き分析を保持する
+   - marker が欠損・重複・順序不正なら、手書き内容を失わないよう全 Markdown の更新前に停止する
    - 該当動画が 0 件のチャンネルは「該当動画なし」注記付きの空レポートになる
 
 ### Step 2: サムネイル分析（subagent）
@@ -107,7 +109,10 @@ uv run yt-benchmark-collect -v               # 詳細ログ
    - **キャラ活動**: キャラクターの動作（いなければ 'none'）
    - **雰囲気**: 全体のムード・ライティング・環境効果
    - **強み**: 効果的な要素のリスト
-4. 分析結果を `docs/benchmarks/{slug}.md` の末尾に `## サムネイル分析` セクションとして追記
+4. 分析結果を `docs/benchmarks/{slug}.md` の `<!-- benchmark:user:start -->` と
+   `<!-- benchmark:user:end -->` の間に `## サムネイル分析` セクションとして記録する
+   - marker の外側やファイル末尾には追記しない
+   - 旧形式に末尾の `## サムネイル分析` がある場合、次回収集時に user 領域へ自動移行される
 
 ### Step 3: 結果確認・戦略的評価
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(streaming)`: active broadcast / ingest 状態を確認し、active ingest だけが残った場合に upcoming 配信枠を冪等再利用、または新規作成して bind → live 遷移する `yt-stream-broadcast-recover` CLI を追加。dry-run、構造化結果、secret 非出力を備えた（#3674）。
 - `fix(suno-helper)`: 現行 Base UI の可視 dialog から Download 確認ボタンと M4A / MP3 / WAV の3形式を持つ一意なモーダルを検出し、M4A 既定から MP3 を選択して同じモーダルの閉鎖まで待機するよう修正。DOM 契約不一致時は Suno UI 変更を明示する（#3039）。
+- `fix(benchmark)`: 個別 benchmark Markdown の自動生成領域と手書きサムネイル分析領域を marker で分離し、旧形式の分析を移行・保持したまま全レポートを原子的に更新するようにした（#3050）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 

--- a/src/youtube_automation/commands/analytics/benchmark_collector.py
+++ b/src/youtube_automation/commands/analytics/benchmark_collector.py
@@ -46,6 +46,7 @@ from youtube_automation.infrastructure.analytics.benchmark_analyzer import (
 )
 from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
 from youtube_automation.infrastructure.cost_tracker import log_quota
+from youtube_automation.infrastructure.filesystem import write_text_files_transactionally
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 from youtube_automation.infrastructure.observability.profile import section
 from youtube_automation.infrastructure.retry import execute_with_retry
@@ -62,6 +63,56 @@ _DESCRIPTION_TTP_SECTION_TITLE = "概要欄TTPサンプル"
 _DESCRIPTION_TTP_SAMPLE_LIMIT = 3
 _SHORT_THUMBNAIL_KEYS = ("high", "medium", "default")
 _DEFAULT_THUMBNAIL_KEYS = ("maxres", "standard", "high", "medium", "default")
+_GENERATED_START = "<!-- benchmark:generated:start -->"
+_GENERATED_END = "<!-- benchmark:generated:end -->"
+_USER_START = "<!-- benchmark:user:start -->"
+_USER_END = "<!-- benchmark:user:end -->"
+_REPORT_MARKERS = (_GENERATED_START, _GENERATED_END, _USER_START, _USER_END)
+_LEGACY_USER_HEADING = "## サムネイル分析"
+
+
+def _render_managed_report(generated: str, user: str = "") -> str:
+    """Render a channel report with explicit generated/user ownership regions."""
+    generated = generated.rstrip("\r\n")
+    user = user.strip("\r\n")
+    user_body = f"{user}\n" if user else ""
+    return f"{_GENERATED_START}\n{generated}\n{_GENERATED_END}\n\n{_USER_START}\n{user_body}{_USER_END}\n"
+
+
+def _extract_marker_region(content: str, start: str, end: str, path: Path) -> str:
+    lines = content.splitlines()
+    for marker in _REPORT_MARKERS:
+        if content.count(marker) != 1 or lines.count(marker) != 1:
+            raise ConfigError(
+                f"{path}: benchmark report marker が欠損・重複・行内配置されています: {marker}. "
+                "手書き分析を退避し、4 marker を各1行に復元して再実行してください。"
+            )
+    positions = [content.index(marker) for marker in _REPORT_MARKERS]
+    if positions != sorted(positions):
+        raise ConfigError(
+            f"{path}: benchmark report marker の順序が不正です。generated start/end, "
+            "user start/end の順に復元して再実行してください。"
+        )
+    start_at = content.index(start) + len(start)
+    end_at = content.index(end, start_at)
+    return content[start_at:end_at].strip("\r\n")
+
+
+def _existing_user_content(path: Path) -> str:
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8")
+    if any(marker in content for marker in _REPORT_MARKERS):
+        return _extract_marker_region(content, _USER_START, _USER_END, path)
+
+    lines = content.splitlines(keepends=True)
+    matches = [i for i, line in enumerate(lines) if line.rstrip("\r\n") == _LEGACY_USER_HEADING]
+    if len(matches) > 1:
+        raise ConfigError(
+            f"{path}: legacy の '{_LEGACY_USER_HEADING}' が複数あります。"
+            "手書き分析を1セクションへ統合して再実行してください。"
+        )
+    return "".join(lines[matches[0] :]).strip("\r\n") if matches else ""
 
 
 def _markdown_code_fence(content: str) -> str:
@@ -768,7 +819,7 @@ class BenchmarkReportGenerator:
         md_map = {}
 
         for channel in data.get("channels", []):
-            md_map[channel["slug"]] = self._generate_channel_md(channel)
+            md_map[channel["slug"]] = _render_managed_report(self._generate_channel_md(channel))
 
         # common-patterns は全チャンネルのデータが必要
         if data.get("channels"):
@@ -778,12 +829,20 @@ class BenchmarkReportGenerator:
         return md_map
 
     def write_markdown(self, md_map: dict[str, str]):
-        """Markdown ファイルを書き出す。"""
+        """Markdown ファイルを事前検証後に一括で原子的に書き出す。"""
         self.benchmarks_dir.mkdir(parents=True, exist_ok=True)
-
+        contents = {}
         for key, content in md_map.items():
             path = self.benchmarks_dir / f"{key}.md"
-            path.write_text(content, encoding="utf-8")
+            if _GENERATED_START in content:
+                generated = _extract_marker_region(content, _GENERATED_START, _GENERATED_END, path)
+                content = _render_managed_report(generated, _existing_user_content(path))
+            contents[path] = content
+
+        if not contents:
+            return
+        write_text_files_transactionally(contents)
+        for path in contents:
             logger.info("Markdown 更新: %s", path.name)
 
     def generate_playlists_markdown(self, playlists_results: list[dict]) -> dict[str, str]:

--- a/tests/commands/analytics/test_benchmark_collector_channels_batch.py
+++ b/tests/commands/analytics/test_benchmark_collector_channels_batch.py
@@ -837,3 +837,117 @@ class TestBenchmarkReportGeneratorDescriptionSamples:
 
         # Then: 空の概要欄セクションを作らない
         assert "## 概要欄TTPサンプル" not in markdown
+
+
+class TestBenchmarkReportUserRegion:
+    def _generator(self, tmp_path):
+        config = SimpleNamespace(analytics=SimpleNamespace(benchmark=SimpleNamespace(channels=[])))
+        return BenchmarkReportGenerator(config, tmp_path, date(2026, 8, 10))
+
+    def test_generate_markdown_marks_only_channel_reports(self, tmp_path, monkeypatch):
+        generator = self._generator(tmp_path)
+        monkeypatch.setattr(generator, "_generate_channel_md", lambda _channel: "# generated")
+        monkeypatch.setattr(generator, "_generate_common_patterns", lambda _data: "# common")
+        monkeypatch.setattr(generator, "_generate_readme", lambda _data: "# index")
+
+        reports = generator.generate_markdown({"channels": [{"slug": "reference"}]})
+
+        assert "<!-- benchmark:generated:start -->" in reports["reference"]
+        assert "<!-- benchmark:user:start -->" in reports["reference"]
+        assert "benchmark:generated" not in reports["common-patterns"]
+        assert "benchmark:generated" not in reports["README"]
+
+    def test_preserves_marked_user_content_while_replacing_generated_content(self, tmp_path):
+        path = tmp_path / "reference.md"
+        path.write_text(
+            benchmark_collector._render_managed_report("old generated", "## サムネイル分析\nhand written"),
+            encoding="utf-8",
+        )
+
+        self._generator(tmp_path).write_markdown(
+            {"reference": benchmark_collector._render_managed_report("new generated")}
+        )
+
+        result = path.read_text(encoding="utf-8")
+        assert "new generated" in result
+        assert "old generated" not in result
+        assert "## サムネイル分析\nhand written" in result
+
+    def test_migrates_legacy_manual_thumbnail_section(self, tmp_path):
+        path = tmp_path / "reference.md"
+        path.write_text(
+            "# old generated\n\n## サムネイル分析（Gemini API）\nautomatic\n\n## サムネイル分析\nmanual notes\n",
+            encoding="utf-8",
+        )
+
+        self._generator(tmp_path).write_markdown(
+            {"reference": benchmark_collector._render_managed_report("# refreshed")}
+        )
+
+        result = path.read_text(encoding="utf-8")
+        assert "# refreshed" in result
+        assert "manual notes" in result
+        assert "automatic" not in result
+        assert result.count("<!-- benchmark:user:start -->") == 1
+
+    def test_empty_user_region_is_valid(self, tmp_path):
+        path = tmp_path / "reference.md"
+        path.write_text(benchmark_collector._render_managed_report("old"), encoding="utf-8")
+
+        self._generator(tmp_path).write_markdown({"reference": benchmark_collector._render_managed_report("new")})
+
+        assert "<!-- benchmark:user:start -->\n<!-- benchmark:user:end -->" in path.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "broken",
+        [
+            "<!-- benchmark:generated:start -->\nold\n<!-- benchmark:generated:end -->\n",
+            benchmark_collector._render_managed_report("old").replace(
+                "<!-- benchmark:user:end -->", "<!-- benchmark:user:start -->"
+            ),
+            "<!-- benchmark:user:start -->\nmanual\n<!-- benchmark:user:end -->\n"
+            "<!-- benchmark:generated:start -->\nold\n<!-- benchmark:generated:end -->\n",
+        ],
+        ids=["missing-markers", "duplicate-marker", "wrong-order"],
+    )
+    def test_invalid_markers_abort_all_files_before_publish(self, tmp_path, broken):
+        valid_path = tmp_path / "valid.md"
+        broken_path = tmp_path / "broken.md"
+        valid_path.write_text(benchmark_collector._render_managed_report("valid old"), encoding="utf-8")
+        broken_path.write_text(broken, encoding="utf-8")
+
+        with pytest.raises(ConfigError, match="marker"):
+            self._generator(tmp_path).write_markdown(
+                {
+                    "valid": benchmark_collector._render_managed_report("valid new"),
+                    "broken": benchmark_collector._render_managed_report("broken new"),
+                }
+            )
+
+        assert "valid old" in valid_path.read_text(encoding="utf-8")
+        assert broken_path.read_text(encoding="utf-8") == broken
+
+    def test_transaction_failure_leaves_existing_reports_unchanged(self, tmp_path, monkeypatch):
+        path = tmp_path / "reference.md"
+        original = benchmark_collector._render_managed_report("old", "manual")
+        path.write_text(original, encoding="utf-8")
+
+        def fail_publish(_contents):
+            raise OSError("publish failed")
+
+        monkeypatch.setattr(benchmark_collector, "write_text_files_transactionally", fail_publish)
+
+        with pytest.raises(OSError, match="publish failed"):
+            self._generator(tmp_path).write_markdown({"reference": benchmark_collector._render_managed_report("new")})
+
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_unmanaged_shared_report_remains_backward_compatible(self, tmp_path):
+        self._generator(tmp_path).write_markdown({"README": "# Benchmark index\n"})
+
+        assert (tmp_path / "README.md").read_text(encoding="utf-8") == "# Benchmark index\n"
+
+    def test_empty_report_map_remains_a_noop(self, tmp_path):
+        self._generator(tmp_path).write_markdown({})
+
+        assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## 概要

`yt-benchmark-collect` の再生成で手書きサムネイル分析が消える問題を修正します。

Closes #3050

## 変更内容

- 個別レポートに generated/user 管理 marker を追加
- 旧形式の `## サムネイル分析` を user 領域へ自動移行
- marker 異常時は全書き込み前に actionable error で停止
- 全 Markdown を rollback 可能な一括 transaction で公開
- benchmark skill、CHANGELOG、回帰テストを更新

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] `uv run pytest tests/commands/analytics/test_benchmark_collector_channels_batch.py tests/application/analytics/test_benchmark_collector_no_fallback.py -q` (61 passed)
- [x] `uv run yt-skills lint benchmark`

## 関連

- #3050