### PR TITLE
fix(benchmark): 前期比較の走査範囲を確保 (#3051)

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -61,10 +61,11 @@ Step 1 のスクリプトが exit 0 で終了して `docs/benchmarks/*.md` と `
 | API | call 数 / 実行 | 変動要因 |
 |---|---|---|
 | YouTube Data API v3（channels.list、1 unit/call） | ceil(チャンネル数/50) units | ベンチマークチャンネル数 |
-| YouTube Data API v3（playlistItems.list + videos.list、各 1 unit） | 鮮度切れチャンネルあたり各 1 call（1 チャンネルあたり計約 4 units） | 鮮度切れチャンネル数、`scan_recent`（既定 50） |
+| YouTube Data API v3（playlistItems.list + videos.list、各 1 unit） | 鮮度切れチャンネルごとに `2 × ceil(scan_recent / 50)` units | 鮮度切れチャンネル数、`scan_recent`（既定 150） |
 | Vertex AI Gemini（サムネイル分析） | 既定 OFF で 0。有効時はサムネイル枚数分 | `gemini_thumbnail_analysis: true` の場合のみ |
 
 - 上限 / 承認: `freshness_days` 以内のチャンネルは再収集せず、サムネイル DL は CDN 直取得で quota を消費しない。`-y` / `--force` なしの実行では収集前に `[Y/n]` 確認プロンプトで停止する。
+- 通常収集の上限式は `ceil(更新チャンネル数 / 50) + 更新チャンネル数 × 2 × ceil(scan_recent / 50)`。先頭項は共有の `channels.list`、後半は各チャンネルの `playlistItems.list` と `videos.list`。1 チャンネルなら `scan_recent: 50` で最大 3 units、既定 150 で最大 7 units（投稿総数が少ない場合は早期終了して減る）。
 
 ## 実行フロー
 
@@ -87,7 +88,7 @@ uv run yt-benchmark-collect -v               # 詳細ログ
 スクリプトが自動で以下を実行:
 1. `config/channel/analytics.json` の `benchmark.channels` から対象チャンネルを読み込み
 2. `docs/benchmarks/*.md` の更新日時で鮮度チェック（`freshness_days` 日以上前なら更新）
-3. YouTube Data API で**直近 `scan_recent` 本（既定 50）** を走査し、**`min_views` 以上（既定 10,000）** の動画だけを抽出
+3. YouTube Data API で**直近 `scan_recent` 本（既定 150）** を走査し、**`min_views` 以上（既定 10,000）** の動画だけを抽出
 4. 派生指標算出（日次再生数・ER%・投稿間隔トレンド）
 5. サムネイル画像を `docs/benchmarks/thumbnails/` にダウンロード
 6. `data/benchmark_YYYYMMDD.json` に中間データ保存
@@ -159,7 +160,7 @@ subagent へは次を具体値で渡す:
 
 | 項目 | 既定 | 説明 |
 |---|---|---|
-| `scan_recent` | 50 | チャンネルあたりの走査プール本数（直近 N 投稿） |
+| `scan_recent` | 150 | チャンネルあたりの走査プール本数（直近 N 投稿、50 本単位で API call が増加） |
 | `min_views` | 10000 | ベンチマーク対象の視聴数しきい値 |
 | `freshness_days` | 3 | レポート更新間隔（日） |
 | `gemini_thumbnail_analysis` | false | Gemini API によるサムネイル分析（Vertex AI 課金あり、通常は不要） |
@@ -169,7 +170,7 @@ subagent へは次を具体値で渡す:
 
 ## コストに関する注意
 
-- **YouTube Data API**: 無料枠内（10,000 units/day）。1チャンネルあたり約 4 ユニット
+- **YouTube Data API**: 無料枠内（10,000 units/day）。通常収集は上記ページング式で、1 チャンネルなら既定 150 本で最大 7 units
 - **サムネイル分析**: デフォルトではエージェントが実行（追加コストなし）
 - **Gemini サムネイル分析** (`gemini_thumbnail_analysis: true`): Vertex AI 課金が発生する。10チャンネル × 各 20 本 = 200 回の API 呼び出しで数千円になる可能性があるため、通常は OFF のままにすること
 

--- a/.claude/skills/benchmark/config.default.yaml
+++ b/.claude/skills/benchmark/config.default.yaml
@@ -7,7 +7,7 @@
 # config/channel/analytics.json 側で管理する。この YAML では走査・分析の動作パラメータのみ扱う。
 
 # チャンネルあたりの走査プール本数（直近 N 投稿）
-scan_recent: 50
+scan_recent: 150
 
 # ベンチマーク対象とする視聴数しきい値（これ未満の動画は分析対象外）
 min_views: 10000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(streaming)`: active broadcast / ingest 状態を確認し、active ingest だけが残った場合に upcoming 配信枠を冪等再利用、または新規作成して bind → live 遷移する `yt-stream-broadcast-recover` CLI を追加。dry-run、構造化結果、secret 非出力を備えた（#3674）。
 - `fix(suno-helper)`: 現行 Base UI の可視 dialog から Download 確認ボタンと M4A / MP3 / WAV の3形式を持つ一意なモーダルを検出し、M4A 既定から MP3 を選択して同じモーダルの閉鎖まで待機するよう修正。DOM 契約不一致時は Suno UI 変更を明示する（#3039）。
 - `fix(benchmark)`: 個別 benchmark Markdown の自動生成領域と手書きサムネイル分析領域を marker で分離し、旧形式の分析を移行・保持したまま全レポートを原子的に更新するようにした（#3050）。
+- `fix(benchmark)`: 高頻度競合でも TTP の前期比較を回収できるよう `scan_recent` 既定を 150 に引き上げ、不足時に観測投稿密度から 50 本単位の推奨値と設定先を返し、Data API quota 上限をページング式で表示するようにした（#3051）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 

--- a/src/youtube_automation/commands/analytics/benchmark_collector.py
+++ b/src/youtube_automation/commands/analytics/benchmark_collector.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 
 # channels.list バッチ単位（YouTube Data API 上限）
 _CHANNELS_BATCH_SIZE = 50
+_SCAN_PAGE_SIZE = 50
+_DEFAULT_SCAN_RECENT = 150
 # quota 記録（Issue #2056）: read 系 list operation は 1 request = 1 unit
 _QUOTA_SERVICE = "youtube-data-api"
 _READ_QUOTA_UNITS = 1
@@ -113,6 +115,15 @@ def _existing_user_content(path: Path) -> str:
             "手書き分析を1セクションへ統合して再実行してください。"
         )
     return "".join(lines[matches[0] :]).strip("\r\n") if matches else ""
+
+
+def estimate_collection_quota_units(*, channel_count: int, scan_recent: int) -> int:
+    """通常収集の Data API read quota 上限を 50 件ページ単位で返す。"""
+    if channel_count <= 0:
+        return 0
+    scan_pages = max(0, (scan_recent + _SCAN_PAGE_SIZE - 1) // _SCAN_PAGE_SIZE)
+    channel_batches = (channel_count + _CHANNELS_BATCH_SIZE - 1) // _CHANNELS_BATCH_SIZE
+    return channel_batches + channel_count * scan_pages * 2
 
 
 def _markdown_code_fence(content: str) -> str:
@@ -228,7 +239,7 @@ class BenchmarkCollector:
                 空辞書で握りつぶさず、欠落を呼び出し側へ伝播させる
         """
         channel_id = channel_info["id"]
-        scan_recent = self.benchmark_config.get("scan_recent", 50)
+        scan_recent = self.benchmark_config.get("scan_recent", _DEFAULT_SCAN_RECENT)
         min_views = self.benchmark_config.get("min_views", 10000)
 
         if not ch_item:
@@ -1351,12 +1362,17 @@ def main():
         logger.info("--keep-thumbnails: サムネイルは常に保持されるようになりました（このフラグは不要）")
 
     analyze_thumbnails = collector.benchmark_config.get("gemini_thumbnail_analysis", False)
-    scan_recent = collector.benchmark_config.get("scan_recent", 50)
+    scan_recent = collector.benchmark_config.get("scan_recent", _DEFAULT_SCAN_RECENT)
     num_channels = len(collector.config.analytics.benchmark.channels)
 
     print("\n=== Benchmark Collector ===")
     print(f"  対象チャンネル: {num_channels} 件")
     print(f"  走査プール: {scan_recent} 本/ch")
+    print(
+        "  Data API quota 上限目安: "
+        f"{estimate_collection_quota_units(channel_count=num_channels, scan_recent=scan_recent)} units"
+        "（全対象を更新する場合）"
+    )
     print(f"  鮮度基準: {collector.benchmark_config.get('freshness_days', 3)} 日")
     if args.no_thumbnails:
         print("  サムネイル分析: OFF（--no-thumbnails）")

--- a/src/youtube_automation/commands/channel/channel_init_templates.py
+++ b/src/youtube_automation/commands/channel/channel_init_templates.py
@@ -106,7 +106,7 @@ def _render_analytics(ctx: ChannelInitContext) -> dict:
         "analytics": {"collection_filter_keywords": ["Complete Collection", ctx.short]},
         "benchmark": {
             "channels": list(ctx.benchmark_channels),
-            "scan_recent": 50,
+            "scan_recent": 150,
             "min_views": 10000,
             "freshness_days": 3,
             "gemini_thumbnail_analysis": False,

--- a/src/youtube_automation/infrastructure/analytics/ttp_health.py
+++ b/src/youtube_automation/infrastructure/analytics/ttp_health.py
@@ -4,6 +4,56 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
+_SCAN_PAGE_SIZE = 50
+_DEFAULT_SCAN_RECENT = 150
+_BENCHMARK_CONFIG_PATH = "config/skills/benchmark.yaml"
+
+
+def _round_up_to_scan_page(value: int) -> int:
+    return max(_SCAN_PAGE_SIZE, ((value + _SCAN_PAGE_SIZE - 1) // _SCAN_PAGE_SIZE) * _SCAN_PAGE_SIZE)
+
+
+def _coverage_recommendation(upload_scan: dict, reference_date: date, prior_start: date) -> dict:
+    """観測した投稿密度から比較期間を覆う走査本数を保守的に見積もる。"""
+    try:
+        scanned_count = max(0, int(upload_scan.get("scanned_count", 0)))
+    except (TypeError, ValueError):
+        scanned_count = 0
+
+    oldest_upload_at = upload_scan.get("oldest_upload_at")
+    try:
+        oldest_date = date.fromisoformat(oldest_upload_at)
+    except (TypeError, ValueError):
+        oldest_date = None
+
+    latest_upload_at = upload_scan.get("latest_upload_at")
+    try:
+        latest_date = date.fromisoformat(latest_upload_at)
+    except (TypeError, ValueError):
+        latest_date = reference_date
+
+    observed_span_days = max(0, (latest_date - oldest_date).days) if oldest_date is not None else 0
+    required_span_days = max(1, (latest_date - prior_start).days)
+    if scanned_count > 0 and observed_span_days > 0:
+        estimated_count = (scanned_count * required_span_days + observed_span_days - 1) // observed_span_days
+    else:
+        estimated_count = scanned_count + 1
+
+    # 不完全と判定された現在値より必ず先の API page まで走査する。
+    recommended_scan_recent = _round_up_to_scan_page(max(_DEFAULT_SCAN_RECENT, estimated_count, scanned_count + 1))
+    return {
+        "recommended_scan_recent": recommended_scan_recent,
+        "config_path": _BENCHMARK_CONFIG_PATH,
+        "config_key": "scan_recent",
+        "coverage": {
+            "scanned_count": scanned_count,
+            "latest_upload_at": latest_upload_at,
+            "oldest_upload_at": oldest_upload_at,
+            "observed_span_days": observed_span_days,
+            "required_span_days": required_span_days,
+        },
+    }
+
 
 def _window(start: date, end: date, videos: list[tuple[date, int]]) -> dict:
     values = [views for published_at, views in videos if start <= published_at <= end]
@@ -144,13 +194,18 @@ def evaluate_ttp_health(
             coverage_complete = oldest_date is not None and oldest_date <= prior_start
 
         if not coverage_complete:
+            recommendation = _coverage_recommendation(upload_scan, reference_date, prior_start)
+            recommended_scan_recent = recommendation["recommended_scan_recent"]
             insufficiencies.append(
                 {
                     "kind": "incomplete_window_coverage",
                     "detail": (
                         f"走査範囲が前期開始日 {prior_start.isoformat()} まで到達していません"
                         f"（oldest_upload_at={upload_scan.get('oldest_upload_at')!r}）。"
+                        f" {_BENCHMARK_CONFIG_PATH} に scan_recent: {recommended_scan_recent} 以上を設定して"
+                        " /benchmark を再実行してください。"
                     ),
+                    **recommendation,
                 }
             )
         elif prior_window["video_count"] == 0:

--- a/tests/commands/analytics/test_benchmark_quota_wiring.py
+++ b/tests/commands/analytics/test_benchmark_quota_wiring.py
@@ -24,6 +24,7 @@ from youtube_automation.commands.analytics.benchmark_collector import (
     _QUOTA_SERVICE,
     _READ_QUOTA_UNITS,
     BenchmarkCollector,
+    estimate_collection_quota_units,
 )
 from youtube_automation.commands.analytics.fetch_benchmark_comments import BenchmarkCommentCollector
 from youtube_automation.core.errors import YouTubeAPIError
@@ -75,6 +76,11 @@ def _video_item(video_id: str) -> dict:
 
 def _buckets(calls: list[dict]) -> list[str]:
     return [c["bucket"] for c in calls]
+
+
+@pytest.mark.parametrize(("scan_recent", "expected_units"), [(0, 1), (50, 3), (150, 7)])
+def test_collection_quota_estimate_matches_50_item_paging(scan_recent, expected_units) -> None:
+    assert estimate_collection_quota_units(channel_count=1, scan_recent=scan_recent) == expected_units
 
 
 class TestBenchmarkCollectorQuotaWiring:

--- a/tests/commands/channel/test_channel_init.py
+++ b/tests/commands/channel/test_channel_init.py
@@ -229,7 +229,11 @@ def test_analytics_json_has_default_benchmark_parameters(tmp_path):
     analytics = _read_json(_channel_dir(tmp_path) / "analytics.json")
     bm = analytics["benchmark"]
     assert bm["channels"] == []
-    assert "scan_recent" in bm
+    assert bm["scan_recent"] == 150
+    default_config = yaml.safe_load(
+        (REPO_ROOT / ".claude/skills/benchmark/config.default.yaml").read_text(encoding="utf-8")
+    )
+    assert default_config["scan_recent"] == bm["scan_recent"]
     assert "min_views" in bm
     assert "freshness_days" in bm
     assert "gemini_thumbnail_analysis" in bm

--- a/tests/infrastructure/analytics/test_ttp_health.py
+++ b/tests/infrastructure/analytics/test_ttp_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 from types import SimpleNamespace
 
 from youtube_automation.commands.analytics import ttp_health as ttp_health_cli
@@ -98,6 +99,35 @@ def test_incomplete_coverage_is_insufficient_not_healthy() -> None:
     assert result["status"] == "insufficient_data"
     assert result["alerts"] == []
     assert {item["kind"] for item in result["insufficiencies"]} == {"incomplete_window_coverage"}
+    insufficiency = result["insufficiencies"][0]
+    assert insufficiency["recommended_scan_recent"] == 150
+    assert insufficiency["config_path"] == "config/skills/benchmark.yaml"
+    assert insufficiency["config_key"] == "scan_recent"
+    assert insufficiency["coverage"] == {
+        "scanned_count": 2,
+        "latest_upload_at": "2026-06-15",
+        "oldest_upload_at": "2026-03-17",
+        "observed_span_days": 90,
+        "required_span_days": 150,
+    }
+    assert "scan_recent: 150" in insufficiency["detail"]
+
+
+def test_high_frequency_scan_50_has_no_prior_window_but_scan_150_recovers_it() -> None:
+    reference = date.fromisoformat(REFERENCE_DATE)
+    offsets = [round(index * 60 / 49) for index in range(50)] + [round(61 + index * 119 / 99) for index in range(100)]
+    high_frequency_videos = [_video((reference - timedelta(days=offset)).isoformat(), 20_000) for offset in offsets]
+
+    result_at_50 = _channel_result(_benchmark(high_frequency_videos[:50], complete=False))
+    result_at_150 = _channel_result(_benchmark(high_frequency_videos, complete=False))
+
+    assert result_at_50["prior_window"]["video_count"] == 0
+    insufficiency = next(
+        item for item in result_at_50["insufficiencies"] if item["kind"] == "incomplete_window_coverage"
+    )
+    assert insufficiency["recommended_scan_recent"] == 150
+    assert result_at_150["prior_window"]["video_count"] > 0
+    assert result_at_150["status"] == "healthy"
 
 
 def test_missing_benchmark_entry_is_missing_data() -> None:


### PR DESCRIPTION
## 概要

高頻度の競合でも TTP health の前期 90 日を比較できるよう、benchmark の走査既定と不足診断を改善します。

## 変更内容

- `scan_recent` 既定を 50 から 150 に引き上げ、skill config・channel init・運用文書を整合
- `incomplete_window_coverage` に、実測投稿密度から 50 本単位で算出した保守的な推奨値を追加
- 設定先 `config/skills/benchmark.yaml`、設定キー、観測本数、最新/最古日、観測/必要 span を構造化出力
- Data API quota 上限を `ceil(channels / 50) + channels × 2 × ceil(scan_recent / 50)` として CLI・文書・テストで固定
- 高頻度 fixture で 50 本では前期 0、150 本では前期あり・healthy へ回復する回帰を追加

## 検証

- ruff check / format check: green
- `yt-skills lint benchmark`: green
- benchmark / TTP health / channel init / skill docs 周辺: 200 passed
- fast suite: 6912 passed。残る 56 setup errors は worktree 環境で DejaVu Sans を発見できない既存 thumbnail_text 環境エラー

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加
- [x] 必要な fixture / unit / config 契約テストを追加・更新
- [x] 無制限の自動走査拡張は導入せず、quota 上限を予測可能に維持

Closes #3051
