### PR TITLE
feat(streaming): deploy broadcast recovery timer

### DIFF
--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -44,6 +44,7 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 | 月間帯域見積もり用の MP4 実測 | `uv run yt-stream-bandwidth --probe-bitrate ./stream.mp4` |
 | アーカイブ件数確認（11h+1h 運用時） | `uv run yt-stream-archive-check --expected 2` |
 | ingest 稼働中に消えた配信枠を復旧 | `uv run yt-stream-broadcast-recover --stream-id <stream-id> --title '<stable-title>' --dry-run` で確認後、`--dry-run` を外す |
+| 24/7 の配信枠自動復旧を配備 | `OP_BROADCAST_RECOVERY_TOKEN_REF=... OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF=... .claude/skills/streaming/references/deploy_broadcast_recovery.sh` |
 | サービス状態 | `ssh -i ~/.ssh/yt_stream_key root@$(terraform -chdir=infra/terraform/streaming output -raw instance_ip) systemctl status youtube-stream` |
 | ログ追跡 | 同上 + `journalctl -u youtube-stream -f` |
 | 破棄 | §5 |
@@ -134,6 +135,8 @@ ffmpeg -i input.mp4 \
 - `/etc/logrotate.d/youtube-stream`（daily / rotate 7 / copytruncate）
 - `/etc/youtube-stream-healthcheck.env`（mode 0600、Discord webhook URL）
 
+`enable_broadcast_recovery=true` かつ `stream_hours=0` では、専用 user と 0600 OAuth files、`youtube-broadcast-recovery.service/.timer` も配備される。既定 120 秒ごとに ffmpeg service と ingest を確認し、active broadcast が消えたときだけ upcoming 再利用または create → bind → live を行う。`recovered` は既存 notify 経路へ送り、結果は常に `journalctl -t youtube-broadcast-recovery` に残る。導入、disable cleanup、資格情報更新、明示承認が必要な手動終了テストは [README の「24/7 broadcast 自動復旧 timer」](../../../infra/terraform/streaming/README.md#247-broadcast-自動復旧-timer) を正本とする。
+
 healthcheck は systemd 状態を 4 通りに分類し、**真の異常のみ通知**:
 
 | 状態 | 分類 | 通知 |
@@ -165,6 +168,7 @@ healthcheck は systemd 状態を 4 通りに分類し、**真の異常のみ通
 | `Permission denied (publickey)` | ssh-agent に鍵が登録されていない or 鍵ペアが食い違っている。`ssh-add -l` で確認し、未登録なら `ssh-add ~/.ssh/yt_stream_key`。鍵ペアが対になっていなければ `ssh-keygen -t ed25519 -f ~/.ssh/yt_stream_key` で再生成して `ssh-add` し直す。**`ssh -i` 経由の手動 SSH が通っても判定材料にならない（provisioner は agent 経由）** |
 | `Error: Output refers to sensitive values` | `triggers` を `nonsensitive(sha256(...))` でラップ済みのはず。`main.tf` を確認 |
 | Discord 通知が来ない | `/etc/youtube-stream-healthcheck.env` の `DISCORD_WEBHOOK_URL` を確認 / 実行ログは `journalctl -t youtube-stream-healthcheck --since '15 min ago'` で参照 / 構文だけ確かめたい場合は `bash -n /opt/youtube-stream/bin/healthcheck.sh`（実行されない）。**`bash -x` は trace 出力に `DISCORD_WEBHOOK_URL` が展開されるため使わない。誤って実行した場合も出力をどこにも貼り付けない**（`notify.sh` が `/etc/youtube-stream-healthcheck.env` を `source` してそのまま `curl` するため） |
+| broadcast 復旧 timer が動かない | `systemctl status youtube-broadcast-recovery.timer`、`journalctl -t youtube-broadcast-recovery --since '15 min ago'`、`/var/lib/youtube-broadcast-recovery/last-result.json` を確認。`stream_hours>0` と `youtube-stream.service` inactive は安全な disable/no-op |
 | 帯域 80% 超アラート | README §超過時の対応方針（4 Mbps → 3 Mbps 化 / プランアップ）|
 | 11h+1h 運用で 1 日のアーカイブが 2 本未満 | `RuntimeMaxSec` 到達前に `failed` した可能性。`journalctl -u youtube-stream --since today` |
 | `Invalid value for variable` (`allowed_ssh_cidr`) で plan が落ちる | `terraform.tfvars` の `allowed_ssh_cidr` が空 `[]`。`curl -s ifconfig.me` で取得した IP を `/32` 付きで 1 件以上記入 |

--- a/.claude/skills/streaming/references/deploy_broadcast_recovery.sh
+++ b/.claude/skills/streaming/references/deploy_broadcast_recovery.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# deploy_broadcast_recovery.sh — ephemeral OAuth を注入して broadcast recovery timer を配備する
+#
+# Usage:
+#   OP_BROADCAST_RECOVERY_TOKEN_REF='op://<vault>/<item>/<field>' \
+#   OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>' \
+#   deploy_broadcast_recovery.sh [--tf-dir DIR] [--auto-approve]
+
+set -euo pipefail
+
+TF_DIR="infra/terraform/streaming"
+AUTO_APPROVE=false
+
+log() { printf '\033[0;36m[broadcast-recovery-deploy]\033[0m %s\n' "$*"; }
+ok() { printf '\033[0;32m[ok]\033[0m %s\n' "$*"; }
+error() { printf '\033[0;31m[error]\033[0m %s\n' "$*" >&2; }
+usage() { sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tf-dir) TF_DIR="$2"; shift 2 ;;
+    --tf-dir=*) TF_DIR="${1#*=}"; shift ;;
+    --auto-approve) AUTO_APPROVE=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) error "未知の引数: $1"; usage; exit 2 ;;
+  esac
+done
+
+for command_name in terraform op python3; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    error "$command_name が見つかりません"
+    exit 1
+  }
+done
+
+for ref_name in OP_BROADCAST_RECOVERY_TOKEN_REF OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF; do
+  [[ -n "${!ref_name:-}" ]] || {
+    error "$ref_name に 1Password secret reference を設定してください"
+    exit 1
+  }
+done
+
+[[ -d "$TF_DIR" && -f "$TF_DIR/main.tf" ]] || {
+  error "Terraform module が見つかりません: $TF_DIR"
+  exit 1
+}
+
+TF_VAR_broadcast_recovery_youtube_token_json="$(op read "$OP_BROADCAST_RECOVERY_TOKEN_REF")" || {
+  status=$?
+  error "1Password token の取得に失敗しました"
+  exit "$status"
+}
+TF_VAR_broadcast_recovery_client_secrets_json="$(op read "$OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF")" || {
+  status=$?
+  error "1Password client secrets の取得に失敗しました"
+  exit "$status"
+}
+export TF_VAR_broadcast_recovery_youtube_token_json
+export TF_VAR_broadcast_recovery_client_secrets_json
+
+cleanup() {
+  unset TF_VAR_broadcast_recovery_youtube_token_json
+  unset TF_VAR_broadcast_recovery_client_secrets_json
+}
+trap cleanup EXIT HUP INT TERM
+
+for json_value in \
+  "$TF_VAR_broadcast_recovery_youtube_token_json" \
+  "$TF_VAR_broadcast_recovery_client_secrets_json"; do
+  printf '%s' "$json_value" | python3 -m json.tool >/dev/null || {
+    error "1Password から取得した値が JSON ではありません"
+    exit 1
+  }
+done
+
+if command -v shasum >/dev/null 2>&1; then
+  CREDENTIALS_REVISION="$(printf '%s\0%s' \
+    "$TF_VAR_broadcast_recovery_youtube_token_json" \
+    "$TF_VAR_broadcast_recovery_client_secrets_json" | shasum -a 256 | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  CREDENTIALS_REVISION="$(printf '%s\0%s' \
+    "$TF_VAR_broadcast_recovery_youtube_token_json" \
+    "$TF_VAR_broadcast_recovery_client_secrets_json" | sha256sum | awk '{print $1}')"
+else
+  error "shasum または sha256sum が見つかりません"
+  exit 1
+fi
+
+export TF_VAR_enable_broadcast_recovery=true
+export TF_VAR_broadcast_recovery_credentials_revision="$CREDENTIALS_REVISION"
+
+log "terraform plan（OAuth JSON は ephemeral のため plan/state/triggers に保存されません）"
+terraform -chdir="$TF_DIR" plan
+
+log "terraform apply"
+if $AUTO_APPROVE; then
+  terraform -chdir="$TF_DIR" apply -auto-approve
+else
+  terraform -chdir="$TF_DIR" apply
+fi
+
+ok "youtube-broadcast-recovery.timer の配備が完了しました"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(streaming)`: 24/7 配信時だけ YouTube 配信枠復旧 CLI を既定 2 分の systemd timer で実行し、ephemeral OAuth 配備、ffmpeg 停止時 no-op、recovered 通知と journald 記録、安全な disable cleanup を行う Terraform opt-in を追加（#3675）。
+
 - `feat(streaming)`: active broadcast / ingest 状態を確認し、active ingest だけが残った場合に upcoming 配信枠を冪等再利用、または新規作成して bind → live 遷移する `yt-stream-broadcast-recover` CLI を追加。dry-run、構造化結果、secret 非出力を備えた（#3674）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。

--- a/infra/terraform/streaming/README.md
+++ b/infra/terraform/streaming/README.md
@@ -13,6 +13,7 @@ Vultr VPS をプロビジョニングし、ローカル MP4 を YouTube Live に
 - `vultr_instance` × 1（Ubuntu 24.04 LTS / vc2-1c-2gb / 東京リージョン）
 - `null_resource.deploy` × 1（動画アップロード + `EnvironmentFile` 配置 + systemd 起動 + 死活監視配置）
 - `null_resource.live_chat_reply` × 0..1（opt-in のライブチャット返信 daemon。認証・config 配布 + Codex / Python package + systemd 起動）
+- `null_resource.broadcast_recovery` × 0..1（24/7 専用 opt-in。OAuth / 復旧 CLI + 2 分 systemd timer 配布）
 
 ## 前提
 
@@ -175,6 +176,38 @@ terraform -chdir=infra/terraform/streaming apply -var='enable_live_chat_reply=fa
 opt-out は unit、`/var/lib/live-chat-reply` の OAuth / Codex 認証、専用 venv を削除する。既存 `youtube-stream` の unit、動画、stream key には触れない。token 失効時は人間がブラウザ認証を行って 1Password の値を更新し、同じラッパーを再実行する。
 
 設計根拠: [Terraform ephemeral values](https://developer.hashicorp.com/terraform/language/manage-sensitive-data#ephemeral-values)、[Terraform file provisioner](https://developer.hashicorp.com/terraform/language/block/resource#file)、[OpenAI Codex](https://github.com/openai/codex)、[1Password secret references](https://developer.1password.com/docs/cli/secret-references/)。
+
+## 24/7 broadcast 自動復旧 timer
+
+`enable_broadcast_recovery=true` かつ `stream_hours=0` のときだけ、`youtube-broadcast-recovery.timer` が既定 120 秒間隔で #3674 の復旧 CLI を実行する。`stream_hours>0` へ切り替えると resource が destroy されるため、11h+1h の計画休止中に配信枠を作らない。各回の runner も `youtube-stream.service` が inactive なら API write をせず `waiting_ingest` を journald に残す。
+
+```hcl
+enable_broadcast_recovery          = true
+broadcast_recovery_stream_id       = "<persistent-live-stream-id>"
+broadcast_recovery_title           = "<再試行でも変えない title>"
+broadcast_recovery_automation_git_ref = "<release-tag-or-commit-sha>"
+# broadcast_recovery_interval_seconds = 120
+```
+
+OAuth JSON は tfvars に書かず、1Password の secret reference だけを deploy wrapper へ渡す。wrapper は JSON 本文を argv / log に出さず ephemeral Terraform 変数へ注入し、終了時に shell 変数を unset する。state / plan / triggers には本文ではなく非秘密の SHA-256 revision だけが残る。VPS では専用 user `youtube-broadcast-recovery` 所有の `/var/lib/youtube-broadcast-recovery/channel/auth/{token_streaming.json,client_secrets.json}` に mode `0600` で保持する。
+
+```bash
+export OP_BROADCAST_RECOVERY_TOKEN_REF='op://<vault>/<item>/<field>'
+export OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>'
+.claude/skills/streaming/references/deploy_broadcast_recovery.sh
+
+# 状態・構造化結果・journal
+systemctl status youtube-broadcast-recovery.timer
+cat /var/lib/youtube-broadcast-recovery/last-result.json
+journalctl -t youtube-broadcast-recovery --since '15 min ago'
+
+# disable: plan で broadcast_recovery だけが destroy されることを確認して apply
+terraform -chdir=infra/terraform/streaming apply -var='enable_broadcast_recovery=false'
+```
+
+`recovered` のときだけ既存 `notify.sh` を呼ぶ。webhook 未設定・不正・送信失敗でも、通知開始と復旧結果は先に journald へ記録される。automation Git ref、OAuth revision、interval、service/timer/runner/notifier の hash は独立 resource の triggers なので、VPS を再作成せず再配備できる。disable は timer/service、専用 venv、OAuth、`last-result.json` を削除し、既存 ffmpeg と動画には触れない。
+
+実機検証で配信枠を手動終了すると視聴者影響が生じるため、明示承認なしに実行しない。承認後は (1) `youtube-stream.service` と ingest が active、(2) upcoming 再利用対象の有無、(3) `last-result.json` baseline を記録し、対象 broadcast だけを手動終了する。最大 2 分後に `status=recovered`、同じ stream への bind、broadcast が 1 件だけ、journald と通知の記録を確認する。最後に同じ service を手動再実行して `healthy` no-op となり増殖しないことを確認する。
 
 ## 配信元動画のプリフライト
 

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -12,8 +12,10 @@ locals {
   live_chat_config_hash = var.enable_live_chat_reply ? sha256(join("", [
     for name in sort(tolist(local.live_chat_config_files)) : filesha256("${local.live_chat_config_dir}/${name}")
   ])) : "disabled"
-  live_chat_install_root = "${var.install_root}/live-chat-reply"
-  live_chat_state_root   = "/var/lib/live-chat-reply"
+  live_chat_install_root          = "${var.install_root}/live-chat-reply"
+  live_chat_state_root            = "/var/lib/live-chat-reply"
+  broadcast_recovery_install_root = "${var.install_root}/broadcast-recovery"
+  broadcast_recovery_state_root   = "/var/lib/youtube-broadcast-recovery"
 }
 
 data "external" "source_video_preflight" {
@@ -320,6 +322,136 @@ resource "null_resource" "live_chat_reply" {
       "systemctl disable --now live-chat-reply 2>/dev/null || true",
       "rm -f /etc/systemd/system/live-chat-reply.service",
       "rm -rf /var/lib/live-chat-reply ${self.triggers.install_root}",
+      "systemctl daemon-reload",
+    ]
+  }
+}
+
+resource "null_resource" "broadcast_recovery" {
+  count      = var.enable_broadcast_recovery && var.stream_hours == 0 ? 1 : 0
+  depends_on = [null_resource.deploy]
+
+  triggers = {
+    instance_id         = vultr_instance.this.id
+    instance_ip         = vultr_instance.this.main_ip
+    ssh_host_key        = local.ssh_host_public_key
+    credentials         = var.broadcast_recovery_credentials_revision
+    automation_git_ref  = var.broadcast_recovery_automation_git_ref
+    interval_seconds    = tostring(var.broadcast_recovery_interval_seconds)
+    stream_id           = var.broadcast_recovery_stream_id
+    title_hash          = sha256(var.broadcast_recovery_title)
+    install_root        = local.broadcast_recovery_install_root
+    service_unit        = filemd5("${path.module}/templates/youtube-broadcast-recovery.service.tftpl")
+    timer_unit          = filemd5("${path.module}/templates/youtube-broadcast-recovery.timer.tftpl")
+    runner_script       = filemd5("${path.module}/scripts/run-broadcast-recovery.sh")
+    notification_script = filemd5("${path.module}/scripts/notify-broadcast-recovery.sh")
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.broadcast_recovery_stream_id != ""
+      error_message = "enable_broadcast_recovery=true では broadcast_recovery_stream_id が必要です。"
+    }
+    precondition {
+      condition     = var.broadcast_recovery_title != ""
+      error_message = "enable_broadcast_recovery=true では broadcast_recovery_title が必要です。"
+    }
+    precondition {
+      condition     = length(var.broadcast_recovery_credentials_revision) == 64
+      error_message = "broadcast_recovery_credentials_revision に deploy script が生成する SHA-256 を指定してください。"
+    }
+  }
+
+  connection {
+    type     = "ssh"
+    host     = self.triggers.instance_ip
+    user     = "root"
+    agent    = true
+    host_key = self.triggers.ssh_host_key
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "install -d -m 0700 -o root -g root /run/youtube-broadcast-recovery",
+    ]
+  }
+
+  provisioner "file" {
+    content     = var.broadcast_recovery_youtube_token_json
+    destination = "/run/youtube-broadcast-recovery/token_streaming.json"
+  }
+
+  provisioner "file" {
+    content     = var.broadcast_recovery_client_secrets_json
+    destination = "/run/youtube-broadcast-recovery/client_secrets.json"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/youtube-broadcast-recovery.service.tftpl", {
+      install_root        = local.broadcast_recovery_install_root
+      state_root          = local.broadcast_recovery_state_root
+      stream_install_root = var.install_root
+      stream_id_b64       = base64encode(var.broadcast_recovery_stream_id)
+      title_b64           = base64encode(var.broadcast_recovery_title)
+    })
+    destination = "/run/youtube-broadcast-recovery/youtube-broadcast-recovery.service"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/youtube-broadcast-recovery.timer.tftpl", {
+      interval_seconds = var.broadcast_recovery_interval_seconds
+    })
+    destination = "/run/youtube-broadcast-recovery/youtube-broadcast-recovery.timer"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/run-broadcast-recovery.sh"
+    destination = "/run/youtube-broadcast-recovery/run-broadcast-recovery.sh"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/notify-broadcast-recovery.sh"
+    destination = "/run/youtube-broadcast-recovery/notify-broadcast-recovery.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -eu",
+      "trap 'rm -rf /run/youtube-broadcast-recovery' EXIT HUP INT TERM",
+      "export DEBIAN_FRONTEND=noninteractive",
+      "apt-get update -qq",
+      "apt-get install -y -qq ca-certificates git python3-venv",
+      "python3 -m json.tool /run/youtube-broadcast-recovery/token_streaming.json >/dev/null",
+      "python3 -m json.tool /run/youtube-broadcast-recovery/client_secrets.json >/dev/null",
+      "id -u youtube-broadcast-recovery >/dev/null 2>&1 || useradd --system --home-dir ${local.broadcast_recovery_state_root} --create-home --shell /usr/sbin/nologin youtube-broadcast-recovery",
+      "install -d -m 0755 -o root -g root ${local.broadcast_recovery_install_root}/bin",
+      "install -d -m 0700 -o youtube-broadcast-recovery -g youtube-broadcast-recovery ${local.broadcast_recovery_state_root}/channel/auth",
+      "install -m 0600 -o youtube-broadcast-recovery -g youtube-broadcast-recovery /run/youtube-broadcast-recovery/token_streaming.json ${local.broadcast_recovery_state_root}/channel/auth/token_streaming.json",
+      "install -m 0600 -o youtube-broadcast-recovery -g youtube-broadcast-recovery /run/youtube-broadcast-recovery/client_secrets.json ${local.broadcast_recovery_state_root}/channel/auth/client_secrets.json",
+      "python3 -m venv ${local.broadcast_recovery_install_root}/venv",
+      "${local.broadcast_recovery_install_root}/venv/bin/pip install --quiet --upgrade pip",
+      "${local.broadcast_recovery_install_root}/venv/bin/pip install --quiet --upgrade git+https://github.com/daiki-beppu/youtube-automation.git@${var.broadcast_recovery_automation_git_ref}",
+      "install -m 0755 -o root -g root /run/youtube-broadcast-recovery/run-broadcast-recovery.sh ${local.broadcast_recovery_install_root}/bin/run-broadcast-recovery.sh",
+      "install -m 0755 -o root -g root /run/youtube-broadcast-recovery/notify-broadcast-recovery.sh ${local.broadcast_recovery_install_root}/bin/notify-broadcast-recovery.sh",
+      "install -m 0644 -o root -g root /run/youtube-broadcast-recovery/youtube-broadcast-recovery.service /etc/systemd/system/youtube-broadcast-recovery.service",
+      "install -m 0644 -o root -g root /run/youtube-broadcast-recovery/youtube-broadcast-recovery.timer /etc/systemd/system/youtube-broadcast-recovery.timer",
+      "rm -rf /run/youtube-broadcast-recovery",
+      "trap - EXIT HUP INT TERM",
+      "systemctl daemon-reload",
+      "systemctl enable --now youtube-broadcast-recovery.timer",
+      "systemctl is-active --quiet youtube-broadcast-recovery.timer",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when       = destroy
+    on_failure = continue
+    inline = [
+      "systemctl disable --now youtube-broadcast-recovery.timer 2>/dev/null || true",
+      "systemctl stop youtube-broadcast-recovery.service 2>/dev/null || true",
+      "rm -f /etc/systemd/system/youtube-broadcast-recovery.service /etc/systemd/system/youtube-broadcast-recovery.timer",
+      "rm -rf /var/lib/youtube-broadcast-recovery ${self.triggers.install_root}",
+      "rm -rf /run/youtube-broadcast-recovery",
       "systemctl daemon-reload",
     ]
   }

--- a/infra/terraform/streaming/scripts/notify-broadcast-recovery.sh
+++ b/infra/terraform/streaming/scripts/notify-broadcast-recovery.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Notify only a successful recovery; always leave the outcome in journald.
+
+set -euo pipefail
+
+readonly RESULT_FILE="${BROADCAST_RECOVERY_RESULT:-/var/lib/youtube-broadcast-recovery/last-result.json}"
+readonly NOTIFY_SCRIPT="${YOUTUBE_STREAM_NOTIFY_SCRIPT:-/opt/youtube-stream/bin/notify.sh}"
+
+if [[ ! -r "$RESULT_FILE" ]]; then
+  printf 'result file is unavailable; notification skipped\n' \
+    | systemd-cat --identifier=youtube-broadcast-recovery --priority=warning
+  exit 0
+fi
+
+if grep -q '"status"[[:space:]]*:[[:space:]]*"recovered"' "$RESULT_FILE"; then
+  printf 'status=recovered; sending operator notification\n' \
+    | systemd-cat --identifier=youtube-broadcast-recovery
+  if [[ -x "$NOTIFY_SCRIPT" ]]; then
+    "$NOTIFY_SCRIPT" "YouTube live broadcast was recovered automatically" || true
+  else
+    printf 'notify.sh is unavailable; recovery remains recorded in journald\n' \
+      | systemd-cat --identifier=youtube-broadcast-recovery --priority=warning
+  fi
+else
+  printf 'broadcast recovery check completed without mutation\n' \
+    | systemd-cat --identifier=youtube-broadcast-recovery
+fi

--- a/infra/terraform/streaming/scripts/run-broadcast-recovery.sh
+++ b/infra/terraform/streaming/scripts/run-broadcast-recovery.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run broadcast recovery only while the 24/7 ffmpeg service is active.
+
+set -euo pipefail
+
+readonly RESULT_FILE="${BROADCAST_RECOVERY_RESULT:-/var/lib/youtube-broadcast-recovery/last-result.json}"
+readonly RECOVERY_CLI="${BROADCAST_RECOVERY_CLI:-/opt/youtube-stream/broadcast-recovery/venv/bin/yt-stream-broadcast-recover}"
+readonly STREAM_ID_B64="${BROADCAST_RECOVERY_STREAM_ID_B64:?BROADCAST_RECOVERY_STREAM_ID_B64 is required}"
+readonly TITLE_B64="${BROADCAST_RECOVERY_TITLE_B64:?BROADCAST_RECOVERY_TITLE_B64 is required}"
+
+umask 0077
+mkdir -p "$(dirname "$RESULT_FILE")"
+tmp_file="$(mktemp "${RESULT_FILE}.tmp.XXXXXX")"
+cleanup() { rm -f "$tmp_file"; }
+trap cleanup EXIT HUP INT TERM
+
+write_result() {
+  printf '%s\n' "$1" >"$tmp_file"
+  printf '%s\n' "$1" | systemd-cat --identifier=youtube-broadcast-recovery
+  mv -f "$tmp_file" "$RESULT_FILE"
+}
+
+BROADCAST_RECOVERY_STREAM_ID="$(printf '%s' "$STREAM_ID_B64" | base64 --decode)"
+BROADCAST_RECOVERY_TITLE="$(printf '%s' "$TITLE_B64" | base64 --decode)"
+export BROADCAST_RECOVERY_STREAM_ID BROADCAST_RECOVERY_TITLE
+
+if ! systemctl is-active --quiet youtube-stream.service; then
+  write_result "{\"status\":\"waiting_ingest\",\"action\":\"none_stream_service_inactive\",\"stream_id\":\"$BROADCAST_RECOVERY_STREAM_ID\",\"broadcast_id\":null,\"dry_run\":false,\"changed\":false}"
+  exit 0
+fi
+
+if output="$("$RECOVERY_CLI" \
+  --stream-id "$BROADCAST_RECOVERY_STREAM_ID" \
+  --title "$BROADCAST_RECOVERY_TITLE")"; then
+  write_result "$output"
+else
+  status=$?
+  printf 'broadcast recovery command failed (exit=%s)\n' "$status" \
+    | systemd-cat --identifier=youtube-broadcast-recovery --priority=err
+  exit "$status"
+fi

--- a/infra/terraform/streaming/templates/youtube-broadcast-recovery.service.tftpl
+++ b/infra/terraform/streaming/templates/youtube-broadcast-recovery.service.tftpl
@@ -1,0 +1,40 @@
+[Unit]
+Description=Recover missing YouTube live broadcast
+Wants=network-online.target
+After=network-online.target youtube-stream.service
+
+[Service]
+Type=oneshot
+User=youtube-broadcast-recovery
+Group=youtube-broadcast-recovery
+WorkingDirectory=${state_root}/channel
+Environment=CHANNEL_DIR=${state_root}/channel
+Environment=BROADCAST_RECOVERY_CLI=${install_root}/venv/bin/yt-stream-broadcast-recover
+Environment=BROADCAST_RECOVERY_STREAM_ID_B64=${stream_id_b64}
+Environment=BROADCAST_RECOVERY_TITLE_B64=${title_b64}
+Environment=BROADCAST_RECOVERY_RESULT=${state_root}/last-result.json
+Environment=YOUTUBE_STREAM_NOTIFY_SCRIPT=${stream_install_root}/bin/notify.sh
+UMask=0077
+ExecStart=${install_root}/bin/run-broadcast-recovery.sh
+ExecStartPost=+${install_root}/bin/notify-broadcast-recovery.sh
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=${state_root}
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RemoveIPC=yes

--- a/infra/terraform/streaming/templates/youtube-broadcast-recovery.timer.tftpl
+++ b/infra/terraform/streaming/templates/youtube-broadcast-recovery.timer.tftpl
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check YouTube live broadcast every ${interval_seconds} seconds
+
+[Timer]
+OnBootSec=${interval_seconds}s
+OnUnitActiveSec=${interval_seconds}s
+AccuracySec=15s
+Persistent=false
+Unit=youtube-broadcast-recovery.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/terraform/streaming/terraform.tfvars.example
+++ b/infra/terraform/streaming/terraform.tfvars.example
@@ -48,3 +48,15 @@ allowed_ssh_cidr = ["203.0.113.5/32"]
 # OP_LIVE_CHAT_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>' \
 # OP_CODEX_AUTH_REF='op://<vault>/<item>/<field>' \
 # .claude/skills/streaming/references/deploy_live_chat.sh /absolute/path/to/channel
+
+# 24/7 broadcast 自動復旧（既定 false / stream_hours=0 専用）:
+# OAuth JSON は tfvars に書かず、1Password 参照を専用ラッパーへ渡す。
+# enable_broadcast_recovery             = true
+# broadcast_recovery_stream_id          = "<persistent-live-stream-id>"
+# broadcast_recovery_title              = "<stable-broadcast-title>"
+# broadcast_recovery_interval_seconds   = 120
+# broadcast_recovery_automation_git_ref = "<release-tag-or-commit-sha>"
+#
+# OP_BROADCAST_RECOVERY_TOKEN_REF='op://<vault>/<item>/<field>' \
+# OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF='op://<vault>/<item>/<field>' \
+# .claude/skills/streaming/references/deploy_broadcast_recovery.sh

--- a/infra/terraform/streaming/variables.tf
+++ b/infra/terraform/streaming/variables.tf
@@ -168,3 +168,79 @@ variable "live_chat_codex_auth_json" {
   ephemeral   = true
   default     = ""
 }
+
+variable "enable_broadcast_recovery" {
+  type        = bool
+  description = "24/7 配信で YouTube broadcast 復旧 timer を配備する opt-in"
+  default     = false
+}
+
+variable "broadcast_recovery_stream_id" {
+  type        = string
+  description = "復旧対象の persistent YouTube live stream ID"
+  default     = ""
+
+  validation {
+    condition     = var.broadcast_recovery_stream_id == "" || can(regex("^[0-9A-Za-z_-]+$", var.broadcast_recovery_stream_id))
+    error_message = "broadcast_recovery_stream_id は英数字と _- のみ指定できます。"
+  }
+}
+
+variable "broadcast_recovery_title" {
+  type        = string
+  description = "復旧する broadcast title。未 bind upcoming 枠の冪等キーとして固定する"
+  default     = ""
+
+  validation {
+    condition     = !strcontains(var.broadcast_recovery_title, "\n") && !strcontains(var.broadcast_recovery_title, "\r")
+    error_message = "broadcast_recovery_title に改行は使用できません。"
+  }
+}
+
+variable "broadcast_recovery_interval_seconds" {
+  type        = number
+  description = "broadcast 復旧 timer の実行間隔（秒）"
+  default     = 120
+
+  validation {
+    condition = (
+      var.broadcast_recovery_interval_seconds >= 30 &&
+      var.broadcast_recovery_interval_seconds <= 3600 &&
+      floor(var.broadcast_recovery_interval_seconds) == var.broadcast_recovery_interval_seconds
+    )
+    error_message = "broadcast_recovery_interval_seconds は 30〜3600 の整数で指定してください。"
+  }
+}
+
+variable "broadcast_recovery_automation_git_ref" {
+  type        = string
+  description = "復旧 CLI を VPS に install する youtube-automation Git ref。commit SHA pin を推奨"
+  default     = "main"
+
+  validation {
+    condition     = can(regex("^[0-9A-Za-z._/-]+$", var.broadcast_recovery_automation_git_ref))
+    error_message = "broadcast_recovery_automation_git_ref は Git ref に使える英数字と ._/- のみ指定できます。"
+  }
+}
+
+variable "broadcast_recovery_credentials_revision" {
+  type        = string
+  description = "ephemeral OAuth 認証差し替えを検知する非秘密 SHA-256"
+  default     = ""
+}
+
+variable "broadcast_recovery_youtube_token_json" {
+  type        = string
+  description = "streaming 用 YouTube OAuth token JSON。state / plan に保存しない ephemeral secret"
+  sensitive   = true
+  ephemeral   = true
+  default     = ""
+}
+
+variable "broadcast_recovery_client_secrets_json" {
+  type        = string
+  description = "YouTube OAuth client secrets JSON。state / plan に保存しない ephemeral secret"
+  sensitive   = true
+  ephemeral   = true
+  default     = ""
+}

--- a/tests/repo/streaming/test_broadcast_recovery_deployment.py
+++ b/tests/repo/streaming/test_broadcast_recovery_deployment.py
@@ -1,0 +1,195 @@
+"""YouTube broadcast recovery timer deployment contract (#3675)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from tests.helpers.hcl import extract_block, read_file, strip_hcl_comments
+from tests.repo.streaming._helpers import _MAIN_TF, _STREAMING_DIR, _VARIABLES_TF
+
+_UNIT = _STREAMING_DIR / "templates" / "youtube-broadcast-recovery.service.tftpl"
+_TIMER = _STREAMING_DIR / "templates" / "youtube-broadcast-recovery.timer.tftpl"
+_RUNNER = _STREAMING_DIR / "scripts" / "run-broadcast-recovery.sh"
+_NOTIFIER = _STREAMING_DIR / "scripts" / "notify-broadcast-recovery.sh"
+_DEPLOY = _STREAMING_DIR.parents[2] / ".claude/skills/streaming/references/deploy_broadcast_recovery.sh"
+
+
+def test_variables_are_opt_in_validated_and_secrets_are_ephemeral() -> None:
+    text = strip_hcl_comments(read_file(_VARIABLES_TF))
+    enabled = extract_block(text, r'variable\s+"enable_broadcast_recovery"')
+    assert enabled is not None
+    assert re.search(r"default\s*=\s*false", enabled)
+
+    interval = extract_block(text, r'variable\s+"broadcast_recovery_interval_seconds"')
+    assert interval is not None
+    assert re.search(r"default\s*=\s*120", interval)
+    assert "floor(var.broadcast_recovery_interval_seconds)" in interval
+
+    for name in (
+        "broadcast_recovery_youtube_token_json",
+        "broadcast_recovery_client_secrets_json",
+    ):
+        block = extract_block(text, rf'variable\s+"{name}"')
+        assert block is not None
+        assert re.search(r"sensitive\s*=\s*true", block)
+        assert re.search(r"ephemeral\s*=\s*true", block)
+
+
+def test_resource_is_24_7_only_and_redeploys_without_instance_replacement() -> None:
+    text = strip_hcl_comments(read_file(_MAIN_TF))
+    block = extract_block(text, r'resource\s+"null_resource"\s+"broadcast_recovery"')
+    assert block is not None
+    assert re.search(
+        r"count\s*=\s*var\.enable_broadcast_recovery\s*&&\s*var\.stream_hours\s*==\s*0\s*\?\s*1\s*:\s*0",
+        block,
+    )
+    assert "depends_on = [null_resource.deploy]" in block
+
+    triggers = extract_block(block, r"triggers")
+    assert triggers is not None
+    assert re.search(r"credentials\s*=\s*var\.broadcast_recovery_credentials_revision", triggers)
+    assert re.search(r"automation_git_ref\s*=\s*var\.broadcast_recovery_automation_git_ref", triggers)
+    assert re.search(r"interval_seconds\s*=\s*tostring\(var\.broadcast_recovery_interval_seconds\)", triggers)
+    assert "youtube-broadcast-recovery.service.tftpl" in triggers
+    assert "youtube-broadcast-recovery.timer.tftpl" in triggers
+    assert "run-broadcast-recovery.sh" in triggers
+    assert "notify-broadcast-recovery.sh" in triggers
+    assert "broadcast_recovery_youtube_token_json" not in triggers
+    assert "broadcast_recovery_client_secrets_json" not in triggers
+
+
+def test_deployment_uses_dedicated_user_0600_credentials_and_safe_cleanup() -> None:
+    block = extract_block(
+        strip_hcl_comments(read_file(_MAIN_TF)),
+        r'resource\s+"null_resource"\s+"broadcast_recovery"',
+    )
+    assert block is not None
+    assert "useradd --system" in block
+    assert "youtube-broadcast-recovery" in block
+    assert "install -m 0600 -o youtube-broadcast-recovery -g youtube-broadcast-recovery" in block
+    assert "/auth/token_streaming.json" in block
+    assert "/auth/client_secrets.json" in block
+    assert "systemctl enable --now youtube-broadcast-recovery.timer" in block
+    assert "systemctl disable --now youtube-broadcast-recovery.timer" in block
+    assert "youtube-broadcast-recovery.service" in block
+    assert "rm -rf /var/lib/youtube-broadcast-recovery ${self.triggers.install_root}" in block
+    assert "rm -rf /run/youtube-broadcast-recovery" in block
+
+
+def test_systemd_timer_and_service_enforce_gate_and_journal_contract() -> None:
+    unit = read_file(_UNIT)
+    timer = read_file(_TIMER)
+    assert "Type=oneshot" in unit
+    assert "User=youtube-broadcast-recovery" in unit
+    assert "ExecStart=${install_root}/bin/run-broadcast-recovery.sh" in unit
+    assert "ExecStartPost=+${install_root}/bin/notify-broadcast-recovery.sh" in unit
+    assert "ReadWritePaths=${state_root}" in unit
+    assert "OnBootSec=${interval_seconds}s" in timer
+    assert "OnUnitActiveSec=${interval_seconds}s" in timer
+    assert "Persistent=false" in timer
+
+    runner = read_file(_RUNNER)
+    assert "systemctl is-active --quiet youtube-stream.service" in runner
+    assert "yt-stream-broadcast-recover" in runner
+    assert "systemd-cat --identifier=youtube-broadcast-recovery" in runner
+    assert '--stream-id "$BROADCAST_RECOVERY_STREAM_ID"' in runner
+    assert '--title "$BROADCAST_RECOVERY_TITLE"' in runner
+    assert "set -x" not in runner
+
+    notifier = read_file(_NOTIFIER)
+    assert '"status"[[:space:]]*:[[:space:]]*"recovered"' in notifier
+    assert "notify.sh" in notifier
+    assert "systemd-cat --identifier=youtube-broadcast-recovery" in notifier
+
+
+def test_deploy_wrapper_reads_1password_and_unsets_secrets() -> None:
+    script = read_file(_DEPLOY)
+    assert _DEPLOY.stat().st_mode & 0o111
+    assert 'op read "$OP_BROADCAST_RECOVERY_TOKEN_REF"' in script
+    assert 'op read "$OP_BROADCAST_RECOVERY_CLIENT_SECRETS_REF"' in script
+    assert "export TF_VAR_broadcast_recovery_youtube_token_json" in script
+    assert "export TF_VAR_broadcast_recovery_client_secrets_json" in script
+    assert "export TF_VAR_broadcast_recovery_credentials_revision" in script
+    assert "trap cleanup EXIT HUP INT TERM" in script
+    assert 'terraform -chdir="$TF_DIR" plan' in script
+    assert 'terraform -chdir="$TF_DIR" apply' in script
+    assert "set -x" not in script
+
+
+def _executable(path: Path, body: str) -> Path:
+    path.write_text(f"#!/usr/bin/env bash\nset -eu\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _runner_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    journal = tmp_path / "journal.log"
+    cli_calls = tmp_path / "cli-calls.log"
+    _executable(bin_dir / "systemd-cat", f"cat >>{journal}")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "BROADCAST_RECOVERY_RESULT": str(tmp_path / "last-result.json"),
+            "BROADCAST_RECOVERY_STREAM_ID_B64": "c3RyZWFtLTE=",
+            "BROADCAST_RECOVERY_TITLE_B64": "Q2hhbm5lbCBsaXZl",
+            "CLI_CALLS": str(cli_calls),
+        }
+    )
+    return env, journal, cli_calls
+
+
+def test_runner_is_noop_when_ffmpeg_service_is_inactive(tmp_path: Path) -> None:
+    env, journal, cli_calls = _runner_env(tmp_path)
+    bin_dir = Path(env["PATH"].split(":", 1)[0])
+    _executable(bin_dir / "systemctl", "exit 3")
+    cli = _executable(bin_dir / "recover-cli", 'printf "%s\\n" "$*" >>"$CLI_CALLS"')
+    env["BROADCAST_RECOVERY_CLI"] = str(cli)
+
+    completed = subprocess.run(["bash", str(_RUNNER)], env=env, check=False, capture_output=True, text=True)
+
+    assert completed.returncode == 0
+    result = json.loads(Path(env["BROADCAST_RECOVERY_RESULT"]).read_text(encoding="utf-8"))
+    assert result["status"] == "waiting_ingest"
+    assert result["action"] == "none_stream_service_inactive"
+    assert not cli_calls.exists()
+    assert "waiting_ingest" in journal.read_text(encoding="utf-8")
+
+
+def test_runner_invokes_recovery_with_decoded_stable_identity(tmp_path: Path) -> None:
+    env, journal, cli_calls = _runner_env(tmp_path)
+    bin_dir = Path(env["PATH"].split(":", 1)[0])
+    _executable(bin_dir / "systemctl", "exit 0")
+    cli = _executable(
+        bin_dir / "recover-cli",
+        'printf "%s\\n" "$*" >>"$CLI_CALLS"\nprintf \'{"status":"recovered","action":"created_broadcast"}\\n\'',
+    )
+    env["BROADCAST_RECOVERY_CLI"] = str(cli)
+
+    completed = subprocess.run(["bash", str(_RUNNER)], env=env, check=False, capture_output=True, text=True)
+
+    assert completed.returncode == 0
+    assert "--stream-id stream-1 --title Channel live" in cli_calls.read_text(encoding="utf-8")
+    assert json.loads(Path(env["BROADCAST_RECOVERY_RESULT"]).read_text(encoding="utf-8"))["status"] == "recovered"
+    assert "created_broadcast" in journal.read_text(encoding="utf-8")
+
+
+def test_notifier_records_and_sends_only_recovered_result(tmp_path: Path) -> None:
+    env, journal, _ = _runner_env(tmp_path)
+    notify_calls = tmp_path / "notify-calls.log"
+    notify = _executable(tmp_path / "notify.sh", f'printf "%s\\n" "$*" >>{notify_calls}')
+    result = tmp_path / "last-result.json"
+    result.write_text('{"status":"recovered"}\n', encoding="utf-8")
+    env["YOUTUBE_STREAM_NOTIFY_SCRIPT"] = str(notify)
+
+    completed = subprocess.run(["bash", str(_NOTIFIER)], env=env, check=False, capture_output=True, text=True)
+
+    assert completed.returncode == 0
+    assert "recovered automatically" in notify_calls.read_text(encoding="utf-8")
+    assert "status=recovered" in journal.read_text(encoding="utf-8")


### PR DESCRIPTION
## 概要

#3674 の冪等復旧 CLI を 24/7 streaming VPS に安全に配備し、既定 120 秒の systemd timer で監視・復旧・通知します。有限サイクル運用では resource 自体を生成しません。

Closes #3675

## 変更内容

- `enable_broadcast_recovery && stream_hours == 0` のときだけ独立 `null_resource.broadcast_recovery` を配備
- dedicated oneshot service + timer を追加し、`youtube-stream.service` inactive は API 前に構造化 `waiting_ingest` no-op
- persistent stream ID と stable title で #3674 CLI を実行し、結果を原子的に state file と journald へ保存
- `recovered` だけ root の既存 `notify.sh` へ渡し、webhook 未設定・不正・送信失敗でも journald 記録を先行
- token/client secrets は 1Password wrapper → sensitive+ephemeral Terraform variables → `/run` 0700 staging → dedicated user 所有 0600 files に限定。plan/state/triggers/log/argv に本文を残さない
- automation Git ref、非秘密 credential revision、interval、service/timer/runner/notifier hash の変更で VPS replacement なしに再配備
- opt-out または `stream_hours>0` で timer/service、OAuth、state、venv を cleanup。既存 ffmpeg/video は維持
- runbook、tfvars example、明示承認後だけ行う手動 broadcast 終了の実機検証手順を追加（実機変更は未実施）

## 検証

- `terraform -chdir=infra/terraform/streaming init -backend=false -input=false`
- `terraform -chdir=infra/terraform/streaming validate`
- `terraform -chdir=infra/terraform/streaming fmt -check`
- `bash -n` (runner / notifier / deploy wrapper)
- `uv run pytest -q tests/repo/streaming` — 269 passed
- `uv run yt-skills lint`
- `uv run ruff check .`
- `uv run ruff format --check .`

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 必要なテストを追加・更新した
- [x] Migration: default false の opt-in のため既存下流に必須移行なし。利用時の導入/disable 手順は README と streaming skill に記載
- [x] 実機の配信終了は破壊的操作のため実行せず、明示承認後の検証手順のみ記載

## Stack / 関連

- Base PR: #3680
- Parent: #3030