### PR TITLE
docs(automation-release): CLI撤去時の利用側監査を追加 (#3073)

### DIFF
--- a/.claude/skills/automation-release/references/prepare-checklist.md
+++ b/.claude/skills/automation-release/references/prepare-checklist.md
@@ -61,6 +61,16 @@ awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
 5. 対象となる facade 無し移動が 0 件なら、監査結果と `### Migration` に `Python module 移動: なし` を明示する。
 <!-- import-migration-audit-contract:end -->
 
+### 4b. CLI 撤去・改名時の利用側監査（必須）
+
+previous tag から HEAD までに `pyproject.toml::[project.scripts]` の entry point が撤去または改名されている場合、release 前に次を完了する。CLI 実装と entry point だけを消しても、skill や smoke check が旧コマンドを起動すると下流の更新処理が最後に失敗するため、利用側まで同じ変更で移行する。
+
+1. `git diff "${previous_tag}..HEAD" -- pyproject.toml` で撤去・改名された `yt-*` 名と代替 CLI を列挙する。
+2. 撤去名ごとに `git grep -n -F -- '<撤去したCLI名>'` を実行し、現行の production code、`.claude/skills/`、運用 docs、テストに残る実行参照を確認する。履歴説明として残す `CHANGELOG.md` と過去 release notes は現行利用側に数えない。
+3. 特に `yt-automation-update apply` の smoke check と、撤去 CLI を案内していた skill を確認する。設定検証 CLI の置換では、対象 repo を明示して実行できる現行 `yt-doctor --json --target <repo>` へ移行する。
+4. 代替 CLI を実際に呼ぶ正常系の回帰テストを追加し、公開入口から exit 0 になることを確認する。旧 CLI の文字列不在だけをテストの根拠にしない。
+5. 撤去名の現行利用側参照が 0 件、代替経路のテストが green になるまで release prepare を停止する。
+
 ### 5. 開いている release/* ブランチが無い
 
 ```bash

--- a/.claude/skills/distrokid-helper/references/pii-gitignore.md
+++ b/.claude/skills/distrokid-helper/references/pii-gitignore.md
@@ -55,4 +55,4 @@ DistroKid（distrokid.com/new）の songwriter 欄は法的な実名登録を求
 
 - `distrokid.json` はローカルに実体があれば `load_config` / `yt-collection-serve` から通常どおり読める（git 管理の有無は動作に影響しない）
 - 新しいクローン・別マシンにはファイルが存在しないため、手動で再作成が必要になる。1Password 等のシークレット管理にファイル内容を控えておくと復元しやすい
-- `yt-config-migrate` / `yt-doctor` などの診断はファイルの存在を前提とするため、クローン直後は再作成してから実行する
+- `yt-doctor` などの診断はファイルの存在を前提とするため、クローン直後は再作成してから実行する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(benchmark)`: 高頻度競合でも TTP の前期比較を回収できるよう `scan_recent` 既定を 150 に引き上げ、不足時に観測投稿密度から 50 本単位の推奨値と設定先を返し、Data API quota 上限をページング式で表示するようにした（#3051）。
 - `feat(site)`: `.claude/skills/*/SKILL.md` の frontmatter・前提・前後工程だけから skill 一覧と58個の個別ページを動的生成し、前後の skill をサイト内リンクで辿れるようにした（#3064）。
 - `fix(video-upload)`: Complete Collection の実マスター尺を primary / localizations / preflight へ共通入力として渡し、`{duration_display}` を ja/en/de の単位で展開。固定の `3 Hours` / `3 Std` 等を含む localization title template は公開前に停止する（#3684）。
+- `docs(automation-release)`: CLI 撤去・改名時に entry point だけでなく `yt-automation-update apply` の smoke check、配布 skill、運用 docs、正常系回帰を同じ変更で追随させる release prepare 監査を追加し、撤去済み `yt-config-migrate` の現行 doc 参照を解消（#3073）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 


### PR DESCRIPTION
## 概要

`yt-config-migrate` 撤去時に automation-update の smoke check が追随漏れした問題について、現行修正を確認し、CLI 撤去・改名時の release prepare 監査を追加します。

## 変更内容

- previous tag との差分から撤去・改名された `yt-*` entry point を列挙する手順を追加
- production code、配布 skill、運用 docs、tests の利用側参照を監査
- `yt-automation-update apply` の smoke check と代替 CLI の正常系回帰を必須化
- 履歴資料と現行利用側を区別し、現行利用側が残る場合は release prepare を停止
- active skill に残っていた `yt-config-migrate` の旧案内を `yt-doctor` に更新

現行の automation-update は既に `yt-doctor --json --target <repo>` を使っており、旧 CLI 参照は active code / skill / tests / entry point 範囲で 0 件です。

## 検証

- automation-update / skill docs 周辺: 160 passed
- `yt-skills lint automation-release distrokid-helper`: green
- `git diff --check`: green

Closes #3073
