### PR TITLE
feat(site): skill個別ページを動的生成する (#3064)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - ".claude/skills/**"
       - "docs/release-notes/**"
       - "ONBOARDING.md"
       - "docs/oauth-setup.md"
@@ -19,6 +20,7 @@ on:
   pull_request:
     paths:
       - "site/**"
+      - ".claude/skills/**"
       - "docs/release-notes/**"
       - "ONBOARDING.md"
       - "docs/oauth-setup.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(suno-helper)`: 現行 Base UI の可視 dialog から Download 確認ボタンと M4A / MP3 / WAV の3形式を持つ一意なモーダルを検出し、M4A 既定から MP3 を選択して同じモーダルの閉鎖まで待機するよう修正。DOM 契約不一致時は Suno UI 変更を明示する（#3039）。
 - `fix(benchmark)`: 個別 benchmark Markdown の自動生成領域と手書きサムネイル分析領域を marker で分離し、旧形式の分析を移行・保持したまま全レポートを原子的に更新するようにした（#3050）。
 - `fix(benchmark)`: 高頻度競合でも TTP の前期比較を回収できるよう `scan_recent` 既定を 150 に引き上げ、不足時に観測投稿密度から 50 本単位の推奨値と設定先を返し、Data API quota 上限をページング式で表示するようにした（#3051）。
+- `feat(site)`: `.claude/skills/*/SKILL.md` の frontmatter・前提・前後工程だけから skill 一覧と58個の個別ページを動的生成し、前後の skill をサイト内リンクで辿れるようにした（#3064）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 - `docs/dashboard.md`
 - `docs/channel-workspace-migration.md`
 
-source は build ごとに原本を読み、掲載対象間の相対 Markdown link を site route、対象外の repository 内 Markdown link を GitHub の原本へ解決する。原本を移動・永続コピーせず、Blume が所有する `site/.blume/` の一時 staging と `site/dist/` の生成だけを行う。GitHub Actions の site workflow も同じ7原本を個別 path として監視し、broad な `docs/**` は使わない。
+source は build ごとに原本を読み、掲載対象間の相対 Markdown link を site route、対象外の repository 内 Markdown link を GitHub の原本へ解決する。加えて `site/skill-page-source.ts` は `.claude/skills/*/SKILL.md` を動的に走査し、frontmatter の `name` / `description` と `## 前提` / `## 前後工程` だけから `/skills` と個別ページを生成する。カテゴリの正は `docs/features.md` の9分類に置き、実行手順や内部契約は公開しない。どちらも原本を移動・永続コピーせず、Blume が所有する `site/.blume/` の一時 staging と `site/dist/` の生成だけを行う。GitHub Actions の site workflow は7原本を個別 path として、skill ページは `.claude/skills/**` として監視し、broad な `docs/**` は使わない。
 
 公開境界は allowlist で閉じる。`docs/adr/`、`docs/audits/`、`docs/investigations/`、`docs/research/`、`docs/strategy/`、`docs/benchmarks/`、および `docs/development.md` や `docs/takt-operations.md` などの development workflow 文書は暗黙収集せず、navigation・search・生成 route に含めない。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,7 +108,7 @@ component 追加前は対象 workspace で `shadcn info` と registry/公式 doc
 
 ## リリースノートサイト開発
 
-`site/` は ADR-0023 / ADR-0021 で許可された Blume ベースの公開静的サイトで、`docs/release-notes/*.md` を唯一のコンテンツソースとして読む。Node.js / pnpm は dashboard・extensions と同じ Nix toolchain を使い、ambient `pnpm` や `npx` は使わない。
+`site/` は ADR-0023 / ADR-0021 で許可された Blume ベースの公開静的サイトで、`docs/release-notes/*.md`、明示 allowlist の運用文書、`.claude/skills/*/SKILL.md` の公開可能な規定フィールドだけを読む。skill ページ生成も `site/` の TypeScript 内で完結し、Python CLI を起動しない。Node.js / pnpm は dashboard・extensions と同じ Nix toolchain を使い、ambient `pnpm` や `npx` は使わない。
 
 ```bash
 nix develop .#extensions --command pnpm -C site install --frozen-lockfile

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **57 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガーや詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **58 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -13,6 +13,7 @@
 | /wf-new | 新規コレクションの企画選択・ディレクトリ作成・素材準備（Phase 1） |
 | /wf-next | 既存コレクションを次の工程に 1 段進める（Phase 2-3） |
 | /wf-auto | 正規入口。active collection が無ければ企画から開始し、あれば未完了地点から制作・公開・post-publish まで同じ対象を状態駆動で継続・再開 |
+| /wf-new-batch | 複数の新規コレクションを相互差別化して一括企画し、正規 `/wf-new` を順次実行・再開 |
 | /wf-status | 制作中コレクションの進捗を読み取り表示（実行はしない） |
 | /automation-schedule | 定期制作設定（`workflow.json` の `scheduled_automation`）の生成と、既定 `/wf-auto` を起動する Claude Code / Codex ジョブの作成・更新・確認・停止 |
 | /collection-ideate | データドリブンに次の企画候補を提案 |
@@ -126,4 +127,4 @@ YouTube Analytics と動画本体の解析。
 
 ---
 
-> このカタログの整合性は CI で担保していない。新規 skill を追加・削除した場合は本ファイルも更新すること。`ls .claude/skills/ | wc -l` の結果と本ファイルの行数（`| /` 始まり）が一致することを確認する。
+> このカタログと `.claude/skills/*/SKILL.md` の件数・名称・9カテゴリ分類は CI で照合する。新規 skill を追加・削除した場合は本ファイルも更新すること。

--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -9,6 +9,7 @@ import {
   operatorDocReleaseField,
 } from "./operator-doc-source";
 import { releaseFrontmatter } from "./release-schema";
+import { createSkillPageSource } from "./skill-page-source";
 
 const lightAccent = dadsTokens.Color.Key["800"].$value;
 const darkAccent = dadsTokens.Color.Key["400"].$value;
@@ -34,6 +35,10 @@ export default defineConfig({
         source: createOperatorDocSource({ map: operatorDocMap, repositoryRoot }),
         type: "custom",
       },
+      {
+        source: createSkillPageSource({ repositoryRoot }),
+        type: "custom",
+      },
     ],
   },
   frontmatter: {
@@ -52,6 +57,7 @@ export default defineConfig({
       {
         label: "使う",
         items: [
+          "/skills",
           "/features",
           "/workflow-cheatsheet",
           "/dashboard",

--- a/site/operator-doc-source.ts
+++ b/site/operator-doc-source.ts
@@ -125,6 +125,12 @@ export const rewriteMarkdownLinks = (
   );
 };
 
+export const rewriteFeatureSkillLinks = (markdown: string): string =>
+  markdown.replace(
+    /^(\|\s*)\/([a-z0-9]+(?:-[a-z0-9]+)*)(\s*\|)/gmu,
+    "$1[/$2](/skills/$2)$3"
+  );
+
 const assertReadableSource = (repositoryRoot: string, source: string): string => {
   const path = resolve(repositoryRoot, source);
   if (!existsSync(path)) {
@@ -157,7 +163,11 @@ export const createOperatorDocSource = (options: {
   const readEntry = async (mapping: OperatorDocMapping): Promise<SourceEntry> => {
     const path = assertReadableSource(repositoryRoot, mapping.source);
     const original = await readFile(path, "utf8");
-    const text = rewriteMarkdownLinks(original, mapping.source, map);
+    const rewritten = rewriteMarkdownLinks(original, mapping.source, map);
+    const text =
+      mapping.source === "docs/features.md"
+        ? rewriteFeatureSkillLinks(rewritten)
+        : rewritten;
     return {
       body: { format: "md", text },
       data: {

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -41,7 +41,12 @@ const operatorSections = [
     label: "使う",
     pages: [
       {
-        description: "チャンネル運営で利用できる skill の一覧",
+        description: "発動条件・前提・前後工程を辿れる skill の個別ガイド",
+        href: "/skills",
+        label: "skill ガイド",
+      },
+      {
+        description: "チャンネル運営で利用できる skill の1行カタログ",
         href: "/features",
         label: "skill カタログ",
       },

--- a/site/skill-page-source.ts
+++ b/site/skill-page-source.ts
@@ -1,0 +1,260 @@
+import { existsSync, realpathSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
+import type { ContentSource, SourceEntry } from "blume/sources/types";
+import { operatorDocReleaseField } from "./operator-doc-source.ts";
+
+const GITHUB_SKILL_BASE =
+  "https://github.com/daiki-beppu/youtube-automation/blob/main/.claude/skills/";
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export interface SkillPage {
+  readonly category?: string;
+  readonly description: string;
+  readonly name: string;
+  readonly prerequisites?: string;
+  readonly workflow: string;
+}
+
+export interface SkillCategory {
+  readonly label: string;
+  readonly skills: readonly string[];
+}
+
+const extractSection = (markdown: string, heading: string): string | undefined => {
+  const lines = markdown.split("\n");
+  const start = lines.findIndex((line) => line === `## ${heading}`);
+  if (start === -1) return undefined;
+  const end = lines.findIndex(
+    (line, index) => index > start && line.startsWith("## ")
+  );
+  return lines.slice(start + 1, end === -1 ? undefined : end).join("\n").trim();
+};
+
+const parseQuotedField = (
+  frontmatter: string,
+  field: string,
+  skillName: string
+): string => {
+  const match = frontmatter.match(
+    new RegExp(`^${field}:\\s*("(?:[^"\\\\]|\\\\.)*")\\s*$`, "mu")
+  );
+  if (!match) {
+    throw new Error(`Skill ${skillName} is missing a double-quoted ${field}`);
+  }
+  try {
+    return JSON.parse(match[1]) as string;
+  } catch (error) {
+    throw new Error(`Skill ${skillName} has an invalid ${field}`, { cause: error });
+  }
+};
+
+export const parseSkillMarkdown = (
+  markdown: string,
+  directoryName: string
+): SkillPage => {
+  const frontmatterMatch = markdown.match(/^---\n([\s\S]*?)\n---(?:\n|$)/u);
+  if (!frontmatterMatch) {
+    throw new Error(`Skill ${directoryName} is missing frontmatter`);
+  }
+  const nameMatch = frontmatterMatch[1].match(/^name:\s*([^\s]+)\s*$/mu);
+  const name = nameMatch?.[1];
+  if (!name || !SKILL_NAME_PATTERN.test(name)) {
+    throw new Error(`Skill ${directoryName} has an invalid name`);
+  }
+  if (name !== directoryName) {
+    throw new Error(
+      `Skill ${directoryName} frontmatter name does not match directory: ${name}`
+    );
+  }
+  const workflow = extractSection(markdown, "前後工程");
+  if (!workflow) {
+    throw new Error(`Skill ${name} is missing section: 前後工程`);
+  }
+  return {
+    description: parseQuotedField(frontmatterMatch[1], "description", name),
+    name,
+    prerequisites: extractSection(markdown, "前提"),
+    workflow,
+  };
+};
+
+export const parseSkillCategories = (markdown: string): SkillCategory[] => {
+  const categories: Array<{ label: string; skills: string[] }> = [];
+  let current: { label: string; skills: string[] } | undefined;
+  for (const line of markdown.split("\n")) {
+    const heading = line.match(/^## ([^#].*)$/u);
+    if (heading) {
+      current = { label: heading[1].trim(), skills: [] };
+      categories.push(current);
+      continue;
+    }
+    const row = line.match(
+      /^\|\s*(?:\[`)?\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:`?\]\(\/skills\/[^)]+\))?\s*\|/u
+    );
+    if (row && current) current.skills.push(row[1]);
+  }
+  return categories.filter((category) => category.skills.length > 0);
+};
+
+const linkSkillReferences = (
+  markdown: string,
+  skillNames: ReadonlySet<string>
+): string => {
+  let linked = markdown;
+  const names = [...skillNames].sort((left, right) => right.length - left.length);
+  for (const name of names) {
+    const escaped = name;
+    linked = linked.replace(
+      new RegExp("`/" + escaped + "`", "gu"),
+      `[/${name}](/skills/${name})`
+    );
+    linked = linked.replace(
+      new RegExp(`(?<![\\w/.(\\[])\\/${escaped}(?![\\w-]|\\)\\])`, "gu"),
+      `[/${name}](/skills/${name})`
+    );
+  }
+  return linked;
+};
+
+const renderSkillPage = (
+  skill: SkillPage,
+  skillNames: ReadonlySet<string>
+): string => {
+  const sections = [
+    `# /${skill.name}`,
+    linkSkillReferences(skill.description, skillNames),
+  ];
+  if (skill.prerequisites) {
+    sections.push(
+      "## 前提",
+      linkSkillReferences(skill.prerequisites, skillNames)
+    );
+  }
+  sections.push("## 前後工程", linkSkillReferences(skill.workflow, skillNames));
+  return `${sections.join("\n\n")}\n`;
+};
+
+const renderSkillIndex = (
+  skills: readonly SkillPage[],
+  categories: readonly SkillCategory[]
+): string => {
+  const byName = new Map(skills.map((skill) => [skill.name, skill]));
+  const categorized = new Set(categories.flatMap((category) => category.skills));
+  const sections = categories.map((category) => {
+    const rows = category.skills.map((name) => {
+      const skill = byName.get(name);
+      if (!skill) {
+        throw new Error(`Skill catalog references missing skill: ${name}`);
+      }
+      return `- [/${name}](/skills/${name}) — ${skill.description}`;
+    });
+    return `## ${category.label}\n\n${rows.join("\n")}`;
+  });
+  const uncategorized = skills
+    .filter((skill) => !categorized.has(skill.name))
+    .map(
+      (skill) =>
+        `- [/${skill.name}](/skills/${skill.name}) — ${skill.description}`
+    );
+  if (uncategorized.length > 0) {
+    sections.push(`## 未分類\n\n${uncategorized.join("\n")}`);
+  }
+  return `# 全 skill 一覧\n\n${skills.length} 個の skill を用途別に掲載しています。\n\n${sections.join("\n\n")}\n`;
+};
+
+const assertInsideRepository = (repositoryRoot: string, path: string): string => {
+  const realRoot = realpathSync(repositoryRoot);
+  const realPath = realpathSync(path);
+  if (realPath !== realRoot && !realPath.startsWith(`${realRoot}${sep}`)) {
+    throw new Error(`Skill source escapes repository: ${path}`);
+  }
+  return realPath;
+};
+
+const sourceEntry = (
+  ref: string,
+  slug: string,
+  text: string,
+  editUrl?: string
+): SourceEntry => ({
+  body: { format: "md", text },
+  data: {
+    kind: operatorDocReleaseField,
+    released_at: operatorDocReleaseField,
+    summary: operatorDocReleaseField,
+    type: "doc",
+    version: operatorDocReleaseField,
+  },
+  ...(editUrl ? { editUrl } : {}),
+  raw: `---\ntype: doc\n---\n\n${text}`,
+  ref,
+  slug,
+});
+
+const loadSkillEntries = async (repositoryRoot: string): Promise<SourceEntry[]> => {
+  const skillsRoot = resolve(repositoryRoot, ".claude/skills");
+  const catalogPath = resolve(repositoryRoot, "docs/features.md");
+  if (!existsSync(skillsRoot) || !existsSync(catalogPath)) {
+    throw new Error("Skill pages require .claude/skills and docs/features.md");
+  }
+  assertInsideRepository(repositoryRoot, skillsRoot);
+  assertInsideRepository(repositoryRoot, catalogPath);
+  const directories = (await readdir(skillsRoot, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  const skills = await Promise.all(
+    directories.map(async (directoryName) => {
+      const path = join(skillsRoot, directoryName, "SKILL.md");
+      if (!existsSync(path)) return undefined;
+      const realPath = assertInsideRepository(repositoryRoot, path);
+      return parseSkillMarkdown(await readFile(realPath, "utf8"), directoryName);
+    })
+  );
+  const pages = skills.filter((skill): skill is SkillPage => skill !== undefined);
+  const names = new Set(pages.map((skill) => skill.name));
+  if (names.size !== pages.length) throw new Error("Duplicate skill names detected");
+  const categories = parseSkillCategories(await readFile(catalogPath, "utf8"));
+  const entries = pages.map((skill) => {
+    const text = renderSkillPage(skill, names);
+    return sourceEntry(
+      `${skill.name}.md`,
+      `/skills/${skill.name}`,
+      text,
+      `${GITHUB_SKILL_BASE}${skill.name}/SKILL.md`
+    );
+  });
+  entries.unshift(
+    sourceEntry(
+      "index.md",
+      "/skills",
+      renderSkillIndex(pages, categories),
+      "https://github.com/daiki-beppu/youtube-automation/blob/main/docs/features.md"
+    )
+  );
+  return entries;
+};
+
+export const createSkillPageSource = (options: {
+  readonly repositoryRoot: string;
+}): ContentSource => {
+  const repositoryRoot = resolve(options.repositoryRoot);
+  return {
+    load: async () => ({ diagnostics: [], entries: await loadSkillEntries(repositoryRoot) }),
+    name: "skill-pages",
+    read: async (ref) => {
+      const entry = (await loadSkillEntries(repositoryRoot)).find(
+        (candidate) => candidate.ref === ref
+      );
+      if (!entry) throw new Error(`Unknown skill page source: ${ref}`);
+      return entry.body.text;
+    },
+    staged: true,
+    validate: () => {
+      if (!existsSync(resolve(repositoryRoot, ".claude/skills"))) {
+        throw new Error("Skill source root not found: .claude/skills");
+      }
+    },
+  };
+};

--- a/site/tests/operator-doc-source.test.mjs
+++ b/site/tests/operator-doc-source.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   createOperatorDocSource,
   operatorDocMap,
+  rewriteFeatureSkillLinks,
   rewriteMarkdownLinks,
 } from "../operator-doc-source.ts";
 
@@ -141,5 +142,15 @@ test("anchor、絶対 URL、非 Markdown link は変更しない", () => {
   assert.equal(
     rewriteMarkdownLinks(markdown, "docs/features.md", operatorDocMap),
     markdown
+  );
+});
+
+test("features の skill 行は個別ページへの導線にする", () => {
+  const markdown = "| /thumbnail | CTR 最適化 |\n| /wf-new-batch | 一括企画 |\n";
+
+  assert.equal(
+    rewriteFeatureSkillLinks(markdown),
+    "| [/thumbnail](/skills/thumbnail) | CTR 最適化 |\n" +
+      "| [/wf-new-batch](/skills/wf-new-batch) | 一括企画 |\n"
   );
 });

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import {
+  createSkillPageSource,
+  parseSkillCategories,
+  parseSkillMarkdown,
+} from "../skill-page-source.ts";
+
+const skillMarkdown = ({
+  description = "Use when test。後続は /beta",
+  name = "alpha",
+  prerequisites = "",
+} = {}) => `---
+name: ${name}
+description: ${JSON.stringify(description)}
+---
+
+## 前後工程
+
+- \`前工程\`: \`なし\`
+- \`後工程\`: \`/beta\`
+${prerequisites}
+## Task
+
+INTERNAL INSTRUCTION MUST NOT LEAK
+`;
+
+const catalog = `# 全 skill カタログ
+
+## category one
+
+| Skill | なにができるか |
+|---|---|
+| /alpha | alpha |
+
+## category two
+
+| Skill | なにができるか |
+|---|---|
+| /beta | beta |
+`;
+
+const createRepository = async () => {
+  const root = await mkdtemp(join(tmpdir(), "skill-page-source-"));
+  await mkdir(join(root, ".claude/skills/alpha"), { recursive: true });
+  await mkdir(join(root, ".claude/skills/beta"), { recursive: true });
+  await mkdir(join(root, "docs"), { recursive: true });
+  await writeFile(
+    join(root, ".claude/skills/alpha/SKILL.md"),
+    skillMarkdown({ prerequisites: "\n## 前提\n\nalpha prerequisite\n\n" }),
+    "utf8"
+  );
+  await writeFile(
+    join(root, ".claude/skills/beta/SKILL.md"),
+    skillMarkdown({ description: "Use when beta", name: "beta" }),
+    "utf8"
+  );
+  await writeFile(join(root, "docs/features.md"), catalog, "utf8");
+  return root;
+};
+
+test("frontmatter と公開2節だけを抽出する", () => {
+  const parsed = parseSkillMarkdown(
+    skillMarkdown({ prerequisites: "\n## 前提\n\nrequired\n\n" }),
+    "alpha"
+  );
+
+  assert.equal(parsed.name, "alpha");
+  assert.equal(parsed.description, "Use when test。後続は /beta");
+  assert.equal(parsed.prerequisites, "required");
+  assert.match(parsed.workflow, /後工程/);
+  assert.doesNotMatch(parsed.workflow, /INTERNAL INSTRUCTION/);
+});
+
+test("description 欠損は該当 skill 名を示して拒否する", () => {
+  const markdown = skillMarkdown().replace(/^description:.*\n/mu, "");
+  assert.throws(
+    () => parseSkillMarkdown(markdown, "alpha"),
+    /alpha.*description/i
+  );
+});
+
+test("features のカテゴリと skill 順を抽出する", () => {
+  assert.deepEqual(parseSkillCategories(catalog), [
+    { label: "category one", skills: ["alpha"] },
+    { label: "category two", skills: ["beta"] },
+  ]);
+});
+
+test("一覧と全 skill ページを生成し、参照をサイト内リンクへ変換する", async () => {
+  const repositoryRoot = await createRepository();
+  const source = createSkillPageSource({ repositoryRoot });
+  const result = await source.load();
+
+  assert.equal(result.entries.length, 3);
+  assert.deepEqual(
+    result.entries.map((entry) => entry.slug),
+    ["/skills", "/skills/alpha", "/skills/beta"]
+  );
+  const alpha = result.entries.find((entry) => entry.slug === "/skills/alpha");
+  assert.match(alpha.body.text, /\[\/beta\]\(\/skills\/beta\)/);
+  assert.match(alpha.body.text, /## 前提\n\nalpha prerequisite/);
+  assert.doesNotMatch(alpha.body.text, /Task|Gotchas|Subagent|INTERNAL/);
+  const beta = result.entries.find((entry) => entry.slug === "/skills/beta");
+  assert.doesNotMatch(beta.body.text, /## 前提/);
+});
+
+test("skill を追加するとカタログ更新前でも個別ページが増える", async () => {
+  const repositoryRoot = await createRepository();
+  const source = createSkillPageSource({ repositoryRoot });
+  const before = await source.load();
+  await mkdir(join(repositoryRoot, ".claude/skills/gamma"), { recursive: true });
+  await writeFile(
+    join(repositoryRoot, ".claude/skills/gamma/SKILL.md"),
+    skillMarkdown({ description: "Use when gamma", name: "gamma" }),
+    "utf8"
+  );
+  const after = await source.load();
+
+  assert.equal(after.entries.length, before.entries.length + 1);
+  assert(after.entries.some((entry) => entry.slug === "/skills/gamma"));
+  assert.match(after.entries[0].body.text, /## 未分類/);
+});
+
+test("実リポジトリでは9カテゴリと全skillを生成する", async () => {
+  const repositoryRoot = resolve(import.meta.dirname, "../..");
+  const source = createSkillPageSource({ repositoryRoot });
+  const result = await source.load();
+  const skillDirectories = (
+    await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
+  ).match(/^\| \/[a-z0-9-]+ /gmu);
+
+  assert.equal(result.entries.length, 59);
+  assert.equal(skillDirectories?.length, 58);
+  assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
+  assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
+});
+
+test("production build は一覧と58個の個別ページを公開する", async () => {
+  const siteRoot = resolve(import.meta.dirname, "..");
+  const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
+  const thumbnail = await readFile(
+    join(siteRoot, "dist/skills/thumbnail/index.html"),
+    "utf8"
+  );
+
+  assert.match(index, /58 個の skill/);
+  assert.match(index, /href="\/skills\/wf-new-batch"/);
+  assert.match(thumbnail, /href="\/skills\/thumbnail-compare"/);
+  assert.match(thumbnail, /<h2[^>]*>.*?前提.*?<\/h2>/);
+  assert.doesNotMatch(thumbnail, /Subagent Contract|run_in_background|Gotchas/);
+});

--- a/tests/repo/test_site_repository_contract.py
+++ b/tests/repo/test_site_repository_contract.py
@@ -55,6 +55,7 @@ def test_site_workflow_checks_every_stacked_pull_request_and_main_push() -> None
     triggers = _triggers(workflow)
     expected_paths = [
         "site/**",
+        ".claude/skills/**",
         "docs/release-notes/**",
         *OPERATOR_DOC_SOURCES,
         ".github/workflows/site.yml",

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -1,0 +1,67 @@
+"""SKILL.md と公開 skill ページの動的生成契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
+FEATURES_PATH = REPO_ROOT / "docs" / "features.md"
+SOURCE_PATH = REPO_ROOT / "site" / "skill-page-source.ts"
+
+
+def _skill_names() -> set[str]:
+    return {path.parent.name for path in SKILLS_ROOT.glob("*/SKILL.md")}
+
+
+def _catalog_names() -> list[str]:
+    return re.findall(r"^\| /([a-z0-9-]+) \|", FEATURES_PATH.read_text(encoding="utf-8"), re.MULTILINE)
+
+
+def test_skill_catalog_matches_all_distributed_skills() -> None:
+    skill_names = _skill_names()
+    catalog_names = _catalog_names()
+
+    assert len(skill_names) == 58
+    assert len(catalog_names) == len(set(catalog_names))
+    assert set(catalog_names) == skill_names
+
+
+def test_skill_catalog_keeps_exactly_nine_categories() -> None:
+    features = FEATURES_PATH.read_text(encoding="utf-8")
+    categories = re.findall(r"^## ([^\n]+)\n(?:(?!^## ).)*?^\| /", features, re.MULTILINE | re.DOTALL)
+
+    assert categories == [
+        "ワークフロー管理",
+        "チャンネル立ち上げ",
+        "オーディエンス・ポジショニング検証",
+        "企画・コンテンツ生成",
+        "公開・運用",
+        "分析・振り返り",
+        "ベンチマーク",
+        "配信インフラ",
+        "リポジトリメンテ",
+    ]
+
+
+def test_every_skill_has_stable_page_inputs() -> None:
+    for skill_path in SKILLS_ROOT.glob("*/SKILL.md"):
+        markdown = skill_path.read_text(encoding="utf-8")
+        assert re.search(r"^name: [a-z0-9-]+$", markdown, re.MULTILINE), skill_path.parent.name
+        assert re.search(r'^description: "(?:[^"\\]|\\.)*"$', markdown, re.MULTILINE), skill_path.parent.name
+        assert "## 前後工程\n" in markdown, skill_path.parent.name
+
+
+def test_site_build_owns_dynamic_skill_routes_without_python_runtime() -> None:
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    config = (REPO_ROOT / "site/blume.config.ts").read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github/workflows/site.yml").read_text(encoding="utf-8")
+
+    assert 'resolve(repositoryRoot, ".claude/skills")' in source
+    assert 'resolve(repositoryRoot, "docs/features.md")' in source
+    assert 'slug: "/skills"' not in source  # index and pages share the same sourceEntry path
+    assert '"/skills"' in source and "`/skills/${skill.name}`" in source
+    assert "createSkillPageSource" in config
+    assert '".claude/skills/**"' in workflow
+    assert "python" not in source.lower()


### PR DESCRIPTION
## 概要

`.claude/skills/*/SKILL.md` の公開可能な規定フィールドだけから、skill 一覧と個別ページをサイトビルド時に動的生成します。

Closes #3064

## 変更内容

- frontmatter の name / description と `## 前提` / `## 前後工程` だけを抽出
- 9カテゴリの `/skills` 一覧と58個の `/skills/<name>` ページを生成
- 前後工程の skill 参照と既存 features 表をサイト内リンク化
- skill 追加、入力欠損、件数不一致、内部手順非掲載を契約テストで固定
- site CI を `.claude/skills/**` の変更でも起動

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 下流配布物は変更していない
- [x] 必要なテストを追加・更新した

## 検証

- site check / build / 39 tests
- focused pytest 84件
- full pytest 8036 passed / 1 skipped
- ruff check / format、yt-skills lint、any usage gate