### PR TITLE
fix(video-upload): 多言語タイトルに実マスター尺を反映 (#3684)

### DIFF
--- a/.claude/skills/channel-new/references/localizations-template.json
+++ b/.claude/skills/channel-new/references/localizations-template.json
@@ -3,11 +3,11 @@
   "default_language": "en",
   "languages": {
     "ja": {
-      "title_template": "{scene_phrase} | ジャズBGM ({activities})",
+      "title_template": "{scene_phrase} | ジャズBGM ({activities}) [{duration_display}]",
       "description_opening": "落ち着いたジャズ音楽。"
     },
     "en": {
-      "title_template": "{scene_phrase} | Jazz BGM ({activities})",
+      "title_template": "{scene_phrase} | Jazz BGM ({activities}) [{duration_display}]",
       "description_opening": "Relaxing jazz music."
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(benchmark)`: 個別 benchmark Markdown の自動生成領域と手書きサムネイル分析領域を marker で分離し、旧形式の分析を移行・保持したまま全レポートを原子的に更新するようにした（#3050）。
 - `fix(benchmark)`: 高頻度競合でも TTP の前期比較を回収できるよう `scan_recent` 既定を 150 に引き上げ、不足時に観測投稿密度から 50 本単位の推奨値と設定先を返し、Data API quota 上限をページング式で表示するようにした（#3051）。
 - `feat(site)`: `.claude/skills/*/SKILL.md` の frontmatter・前提・前後工程だけから skill 一覧と58個の個別ページを動的生成し、前後の skill をサイト内リンクで辿れるようにした（#3064）。
+- `fix(video-upload)`: Complete Collection の実マスター尺を primary / localizations / preflight へ共通入力として渡し、`{duration_display}` を ja/en/de の単位で展開。固定の `3 Hours` / `3 Std` 等を含む localization title template は公開前に停止する（#3684）。
 
 - `fix(thumbnail)`: TTP 参照プールの centroid 距離外れ値を参照ごとに診断し、`selection_only` は警告継続、`full` は strict 画像生成の API 呼び出し前と自動選択前に停止するようにした（#2952）。
 

--- a/examples/localizations.example.json
+++ b/examples/localizations.example.json
@@ -2,7 +2,7 @@
   "supported_languages": ["ja", "en", "de"],
   "languages": {
     "ja": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "ゲーム · 勉強 · 集中",
       "description": {
         "opening_poem": "ピクセルの夜、冒険の調べ",
@@ -12,7 +12,7 @@
       }
     },
     "en": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "Gaming · Study · Focus",
       "description": {
         "opening_poem": "Pixel nights, melodies of adventure",
@@ -22,7 +22,7 @@
       }
     },
     "de": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "Gaming · Lernen · Fokus",
       "description": {
         "opening_poem": "Pixelnacht, Melodie des Abenteuers",

--- a/src/youtube_automation/commands/channel/channel_init_templates.py
+++ b/src/youtube_automation/commands/channel/channel_init_templates.py
@@ -166,7 +166,7 @@ def _template_literal(value: str) -> str:
 
 def _render_language_template(lang: str, ctx: ChannelInitContext) -> dict[str, str]:
     genre_label = _template_literal(ctx.genre)
-    title_template = f"{{scene_phrase}} | {genre_label} BGM ({{activities}})"
+    title_template = f"{{scene_phrase}} | {genre_label} BGM ({{activities}}) [{{duration_display}}]"
     openings: dict[str, str] = {
         "ja": f"{ctx.style}の{ctx.genre}音楽。",
         "de": f"{ctx.style} {ctx.genre} Musik.",

--- a/src/youtube_automation/core/adapters/runtime.py
+++ b/src/youtube_automation/core/adapters/runtime.py
@@ -9,6 +9,7 @@ from youtube_automation.infrastructure.runtime.time_utils import (
     format_duration_display,
     format_duration_mss,
     format_duration_short,
+    format_localized_duration_display,
     format_timestamp,
 )
 
@@ -16,6 +17,7 @@ __all__ = [
     "format_duration_display",
     "format_duration_mss",
     "format_duration_short",
+    "format_localized_duration_display",
     "format_timestamp",
     "get_schedule_timezone",
     "now_in_schedule_tz",

--- a/src/youtube_automation/domains/metadata/localizations.py
+++ b/src/youtube_automation/domains/metadata/localizations.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Dict, List
 
+from youtube_automation.core.adapters.runtime import format_localized_duration_display
 from youtube_automation.domains.metadata.descriptions import build_short_description
 from youtube_automation.domains.metadata.titles import (
     _referenced_placeholders,
@@ -12,7 +14,11 @@ from youtube_automation.domains.metadata.titles import (
 )
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
-LOCALIZED_TITLE_PLACEHOLDERS = frozenset({"scene_phrase", "activities", "scene_emoji"})
+LOCALIZED_TITLE_PLACEHOLDERS = frozenset({"scene_phrase", "activities", "scene_emoji", "duration_display"})
+_STATIC_DURATION_LITERAL = re.compile(
+    r"(?<!\w)\d+(?:[.,]\d+)?\s*(?:hours?|hrs?|std\.?|stunden?|時間|minutes?|mins?|min\.?|分)(?!\w)",
+    re.IGNORECASE,
+)
 
 
 def build_short_localizations(
@@ -73,9 +79,20 @@ def build_short_localizations(
     return localizations
 
 
-def _localized_title_values(*, scene_phrase: str, activities: str, scene_emoji: str) -> Dict[str, str]:
+def _localized_title_values(
+    *,
+    scene_phrase: str,
+    activities: str,
+    scene_emoji: str,
+    duration_display: str,
+) -> Dict[str, str]:
     """localizations の title_template に渡す values を組み立てる."""
-    return {"scene_phrase": scene_phrase, "activities": activities, "scene_emoji": scene_emoji}
+    return {
+        "scene_phrase": scene_phrase,
+        "activities": activities,
+        "scene_emoji": scene_emoji,
+        "duration_display": duration_display,
+    }
 
 
 def validate_localizations_title_templates(loc_data: Dict) -> List[str]:
@@ -102,6 +119,13 @@ def validate_localizations_title_templates(loc_data: Dict) -> List[str]:
         template = lang_data.get("title_template")
         if not isinstance(template, str):
             continue
+        static_duration = _STATIC_DURATION_LITERAL.search(template)
+        if static_duration:
+            errors.append(
+                f"languages.{lang}.title_template: 固定尺 {static_duration.group(0)!r} が含まれています。\n"
+                "  → 固定値を `{duration_display}` に置き換えて、実マスター尺を表示してください。\n"
+                f"  → テンプレート: {template}"
+            )
         unknown = _referenced_placeholders(template) - LOCALIZED_TITLE_PLACEHOLDERS
         if unknown:
             errors.append(
@@ -125,6 +149,7 @@ class SceneTitleViolation:
 def validate_scene_phrases(
     scene_phrases: Dict[str, str],
     config,
+    duration_seconds: int | float,
     scene_emoji: str = "",
 ) -> List[SceneTitleViolation]:
     """scene_phrases を localizations の全言語で試算し、100 codepoint 超過を一括検出する.
@@ -137,6 +162,7 @@ def validate_scene_phrases(
     Args:
         scene_phrases: {"en": ..., "ja": ..., ...} コレクション別の感情フレーズ翻訳
         config: `load_config()` の戻り値
+        duration_seconds: primary title と共有する実マスター秒数
 
     Returns:
         違反のリスト。空なら全言語 100 codepoint 以内.
@@ -173,9 +199,15 @@ def validate_scene_phrases(
             raise ValueError(f"localizations.json: language '{lang}' に title_template が無い")
         activities = lang_data.get("activities", best_for_line)
         scene = scene_phrases[lang]
+        duration_display = format_localized_duration_display(duration_seconds, lang)
         title = format_title_template(
             title_tpl,
-            _localized_title_values(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji),
+            _localized_title_values(
+                scene_phrase=scene,
+                activities=activities,
+                scene_emoji=scene_emoji,
+                duration_display=duration_display,
+            ),
             context=f"localizations.json: language '{lang}' の title_template",
         )
         if len(title) > 100:

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -26,6 +26,7 @@ from youtube_automation.core.adapters.media import CollectionPaths, probe_durati
 from youtube_automation.core.adapters.runtime import (
     format_duration_display,
     format_duration_short,
+    format_localized_duration_display,
     format_timestamp,
 )
 from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
@@ -37,6 +38,7 @@ from youtube_automation.domains.metadata.localizations import (
     _localized_title_values,
     build_short_localizations,
     format_scene_title_violations,
+    validate_localizations_title_templates,
     validate_scene_phrases,
 )
 from youtube_automation.domains.metadata.tags import (
@@ -568,7 +570,7 @@ class BAHMetadataGenerator:
         theme = self._extract_theme_name()
         return self.config.content.title.activity_for_theme(theme)
 
-    def _generate_title(self, total_seconds: int) -> str:
+    def _generate_title(self, total_seconds: int | float) -> str:
         """channel_config のテンプレートでタイトルを生成（100文字制限）"""
         theme = self._extract_theme_name()
         activity = self._get_activity()
@@ -651,6 +653,8 @@ class BAHMetadataGenerator:
         timestamp_body: str,
         scene_phrases: Dict[str, str] | None = None,
         scene_emoji: str = "",
+        *,
+        duration_seconds: int | float,
     ) -> Dict:
         """各言語のローカライズされたタイトル・説明文を生成（jazzgak. TTP ハイブリッド方式）
 
@@ -661,6 +665,7 @@ class BAHMetadataGenerator:
             english_title: 英語デフォルトタイトル（フォールバック用）
             timestamp_body: タイムスタンプ部分（全言語共通、ヘッダーなし）
             scene_phrases: {"ja": "雨の街の夜...", ...} コレクション別の感情フレーズ翻訳
+            duration_seconds: primary title と共有する実マスター秒数
 
         Returns:
             YouTube API 用 localizations 辞書
@@ -675,6 +680,10 @@ class BAHMetadataGenerator:
         if not requires_scene_phrases(loc_config.get("supported_languages", [])):
             return {}
 
+        template_errors = validate_localizations_title_templates(loc_config)
+        if template_errors:
+            raise ValueError("localizations.json の title_template が不正です:\n" + "\n".join(template_errors))
+
         # 英語固定パーツ（config/channel/content.json の descriptions.metadata から取得）
         desc_metadata = self.config.content.descriptions.metadata
         genre_line = desc_metadata.get("genre", "Jazz")
@@ -684,7 +693,12 @@ class BAHMetadataGenerator:
 
         # 欠落チェック + 100 codepoint 超過を全言語まとめて検出する
         # （従来は 1 言語ずつ fail していたため多言語対応チャンネルで再アップロードを繰り返していた）
-        violations = validate_scene_phrases(scene_phrases, self.config, scene_emoji=scene_emoji)
+        violations = validate_scene_phrases(
+            scene_phrases,
+            self.config,
+            duration_seconds,
+            scene_emoji=scene_emoji,
+        )
         if violations:
             raise ValueError(
                 f"localizations の {len(violations)} 言語でタイトルが 100 codepoint を超過:\n"
@@ -700,9 +714,15 @@ class BAHMetadataGenerator:
             scene = scene_phrases[lang]
             title_tpl = lang_data["title_template"]
             activities = lang_data.get("activities", best_for_line)
+            duration_display = format_localized_duration_display(duration_seconds, lang)
             loc_title = format_title_template(
                 title_tpl,
-                _localized_title_values(scene_phrase=scene, activities=activities, scene_emoji=scene_emoji),
+                _localized_title_values(
+                    scene_phrase=scene,
+                    activities=activities,
+                    scene_emoji=scene_emoji,
+                    duration_display=duration_display,
+                ),
                 context=f"localizations.json: language '{lang}' の title_template",
             )
 
@@ -751,7 +771,13 @@ class BAHMetadataGenerator:
 
         return localizations
 
-    def generate_complete_collection_metadata(self, title_override: str | None = None, loops: int = 1) -> Dict:
+    def generate_complete_collection_metadata(
+        self,
+        title_override: str | None = None,
+        loops: int = 1,
+        *,
+        duration_seconds: int | float | None = None,
+    ) -> Dict:
         """
         Complete Collection 用メタデータ生成
 
@@ -763,6 +789,8 @@ class BAHMetadataGenerator:
                 `KeyError`/`ValidationError` で巻き込まれない（#574）。
             loops: master のループ回数。`format_timestamps_text(loops=loops)` に渡し、
                 全ループ分のチャプターを展開する。既定 1（従来挙動）。
+            duration_seconds: upload/preflight が probe した実マスター秒数。metadata 単体生成では
+                track のクロスフェード補正済み合計を使う。
 
         Returns:
             Dict: YouTube アップロード用メタデータ
@@ -772,11 +800,12 @@ class BAHMetadataGenerator:
 
         crossfade = self._crossfade_sec
         total_duration = sum(track["duration"] for track in self.tracks) - max(0, len(self.tracks) - 1) * crossfade
+        effective_duration = total_duration if duration_seconds is None else duration_seconds
 
         # タイトル生成（2026リブランド）。
         # title_override がある（descriptions.md で最終タイトルが確定する）場合は
         # 中間タイトル生成をスキップし、未知プレースホルダ由来のクラッシュを避ける。
-        title = title_override if title_override else self._generate_title(total_duration)
+        title = title_override if title_override else self._generate_title(effective_duration)
 
         timestamp_body = self.format_timestamps_text(loops=loops)
         perfect_for_lines = "\n".join(f"• {item}" for item in list(self.config.content.descriptions.perfect_for))
@@ -808,7 +837,13 @@ class BAHMetadataGenerator:
         scene_phrases = self._load_scene_phrases()
         scene_emoji = self._load_scene_emoji()
         self._last_scene_phrases = scene_phrases
-        localizations = self.generate_localizations(title, timestamp_body, scene_phrases, scene_emoji=scene_emoji)
+        localizations = self.generate_localizations(
+            title,
+            timestamp_body,
+            scene_phrases,
+            scene_emoji=scene_emoji,
+            duration_seconds=effective_duration,
+        )
 
         return {
             "title": title,

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Optional
 
 from youtube_automation.core.adapters.errors import ValidationError
 from youtube_automation.core.adapters.filesystem import glob_files, path_exists, path_is_file, read_json
-from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
@@ -88,6 +88,12 @@ class CompleteCollectionMixin:
         paths = CollectionPaths(collection_dir)
 
         master_video = resolve_master_video(collection_dir)
+        duration_seconds = probe_duration(master_video)
+        if duration_seconds is None:
+            raise ValidationError(
+                f"実マスター尺を取得できません: {master_video.name}。"
+                "ffprobe で読み取れる完成済みマスター動画を指定してください"
+            )
 
         # descriptions.md が最終タイトル/概要/タグを供給するなら先に読み込み、
         # 中間タイトル生成（_generate_title）を title_override でスキップする。
@@ -97,7 +103,9 @@ class CompleteCollectionMixin:
 
         # メタデータ生成（BAHMetadataGenerator — localizations 等）
         metadata = metadata_gen.generate_complete_collection_metadata(
-            loops=1, title_override=prebuilt["title"] if prebuilt else None
+            loops=1,
+            title_override=prebuilt["title"] if prebuilt else None,
+            duration_seconds=duration_seconds,
         )
 
         # descriptions.md が存在すれば title/description/tags を上書き
@@ -113,7 +121,11 @@ class CompleteCollectionMixin:
             scene_emoji = metadata_gen._load_scene_emoji()
             if curated_timestamps:
                 metadata["localizations"] = metadata_gen.generate_localizations(
-                    metadata["title"], curated_timestamps, scene_phrases, scene_emoji=scene_emoji
+                    metadata["title"],
+                    curated_timestamps,
+                    scene_phrases,
+                    scene_emoji=scene_emoji,
+                    duration_seconds=duration_seconds,
                 )
 
         if publish_at:

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -166,6 +166,13 @@ class PreflightMixin:
 
         # 実 upload と同じ generator で全 locale の title を構築し、API 呼び出し前の
         # --plan preflight でも YouTube の 100 codepoint 制限を検証する。
+        master_video = resolve_master_video(collection_dir)
+        duration_sec = probe_duration(master_video)
+        if duration_sec is None:
+            raise ValidationError(
+                f"❌ 実マスター尺を取得できません: {master_video.name}。"
+                "ffprobe で読み取れる完成済みマスター動画を指定してください"
+            )
         generator = BAHMetadataGenerator(str(collection_dir))
         # 同じ invocation で読み込んだ config を使い、plan と upload の設定 snapshot を揃える。
         # 最小 stub を使う既存 unit test では localization data が無いため生成を省略する。
@@ -183,6 +190,7 @@ class PreflightMixin:
                     description,
                     scene_phrases,
                     scene_emoji=generator._load_scene_emoji(),
+                    duration_seconds=duration_sec,
                 )
                 if templates_complete
                 else {}
@@ -213,21 +221,16 @@ class PreflightMixin:
         target_min = getattr(config.audio, "target_duration_min", None)
         target_max = getattr(config.audio, "target_duration_max", None)
         if target_min is not None or target_max is not None:
-            master_video = resolve_master_video(collection_dir)
-            duration_sec = probe_duration(master_video)
-            if duration_sec is None:
-                issues.append(f"duration probe failed for {master_video.name}")
-            else:
-                duration_issue = check_duration(
-                    duration_sec,
-                    target_min * 60 if target_min is not None else None,
-                    target_max * 60 if target_max is not None else None,
+            duration_issue = check_duration(
+                duration_sec,
+                target_min * 60 if target_min is not None else None,
+                target_max * 60 if target_max is not None else None,
+            )
+            if duration_issue and not getattr(self, "allow_duration_outside_target", False):
+                issues.append(
+                    f"{duration_issue}; config/channel/audio.json の target を満たす動画を再生成するか、"
+                    "operator 判断で --allow-duration-outside-target を明示してください"
                 )
-                if duration_issue and not getattr(self, "allow_duration_outside_target", False):
-                    issues.append(
-                        f"{duration_issue}; config/channel/audio.json の target を満たす動画を再生成するか、"
-                        "operator 判断で --allow-duration-outside-target を明示してください"
-                    )
 
         if issues:
             raise ValidationError("❌ preflight failed:\n  - " + "\n  - ".join(issues))

--- a/src/youtube_automation/infrastructure/runtime/time_utils.py
+++ b/src/youtube_automation/infrastructure/runtime/time_utils.py
@@ -37,7 +37,7 @@ def format_timestamp(seconds: int) -> str:
     return f"{minutes:02d}:{secs:02d}"
 
 
-def format_duration_short(total_seconds: int) -> str:
+def format_duration_short(total_seconds: int | float) -> str:
     """秒数を短縮デュレーション表示に変換（例: '1h', '2.5h', '25m'）。"""
     total_minutes = total_seconds / 60
     if total_minutes < 35:
@@ -50,7 +50,7 @@ def format_duration_short(total_seconds: int) -> str:
     return f"{rounded_half}h"
 
 
-def format_duration_display(total_seconds: int) -> str:
+def format_duration_display(total_seconds: int | float) -> str:
     """秒数を人間可読なデュレーション表示に丸める。
 
     ルール:
@@ -60,22 +60,41 @@ def format_duration_display(total_seconds: int) -> str:
     - 105-135分 → "2 Hours"
     - 以降 0.5時間単位
     """
+    value, unit = _rounded_duration(total_seconds)
+    if unit == "minute":
+        return f"{value} min"
+    return f"{value} Hour" if value == "1" else f"{value} Hours"
+
+
+def format_localized_duration_display(total_seconds: int | float, locale: str) -> str:
+    """共通の丸め数値を locale ごとの単位で表示する."""
+    value, unit = _rounded_duration(total_seconds)
+    units = {
+        "en": {"minute": "min", "hour": "Hour" if value == "1" else "Hours"},
+        "de": {"minute": "Min", "hour": "Std"},
+        "ja": {"minute": "分", "hour": "時間"},
+    }
+    locale_units = units.get(locale)
+    if locale_units is None:
+        raise ValueError(f"duration_display に対応していない locale: {locale!r}。対応 locale は ja, en, de です")
+    separator = "" if locale == "ja" else " "
+    return f"{value}{separator}{locale_units[unit]}"
+
+
+def _rounded_duration(total_seconds: int | float) -> tuple[str, str]:
+    """既存の尺丸め規則を表示用の数値と単位種別へ正規化する."""
     total_minutes = total_seconds / 60
-
     if total_minutes < 35:
-        rounded = round(total_minutes / 5) * 5
-        rounded = max(rounded, 5)
-        return f"{rounded} min"
-
+        rounded_minutes = max(round(total_minutes / 5) * 5, 5)
+        return str(rounded_minutes), "minute"
     if total_minutes < 75:
-        return "1 Hour"
+        return "1", "hour"
     if total_minutes < 105:
-        return "1.5 Hours"
+        return "1.5", "hour"
     if total_minutes < 135:
-        return "2 Hours"
+        return "2", "hour"
 
-    total_hours = total_minutes / 60
-    rounded_half = round(total_hours * 2) / 2
-    if rounded_half == int(rounded_half):
-        return f"{int(rounded_half)} Hours"
-    return f"{rounded_half} Hours"
+    rounded_hours = round(total_minutes / 30) / 2
+    if rounded_hours == int(rounded_hours):
+        return str(int(rounded_hours)), "hour"
+    return str(rounded_hours), "hour"

--- a/tests/commands/channel/test_channel_init.py
+++ b/tests/commands/channel/test_channel_init.py
@@ -688,7 +688,7 @@ def test_generated_localization_title_templates_match_metadata_contract(tmp_path
     monkeypatch.setenv("CHANNEL_DIR", str(tmp_path))
     config = load_config()
     scene_phrases = {lang: f"{lang} quiet study room" for lang in config.localizations.supported_languages}
-    violations = validate_scene_phrases(scene_phrases, config)
+    violations = validate_scene_phrases(scene_phrases, config, 3600)
 
     # Then: localizations の title_template は scene_phrase 契約で format できる
     assert violations == []

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -257,6 +257,10 @@ class TestMainCLI:
         state = json.loads((collection_dir / "workflow-state.json").read_text(encoding="utf-8"))
         assert "scene_phrases" not in state
 
+        master_dir = collection_dir / "01-master"
+        master_dir.mkdir()
+        (master_dir / "master.mp4").write_bytes(b"probe is mocked")
+        monkeypatch.setattr("youtube_automation.domains.uploads._preflight.probe_duration", lambda _: 3600)
         _PreflightHarness(ch / "collections")._preflight_check(collection_dir)
 
         gen = object.__new__(BAHMetadataGenerator)
@@ -266,6 +270,7 @@ class TestMainCLI:
                 "Late-night neon city, jazz between rain and streetlights | 3 Hours of Study",
                 "00:00 Intro",
                 {},
+                duration_seconds=3600,
             )
             == {}
         )

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -37,7 +37,10 @@ from youtube_automation.domains.metadata.localizations import (
 )
 from youtube_automation.domains.metadata.placeholders import is_placeholder_value
 from youtube_automation.domains.metadata.titles import _extract_pattern_key
-from youtube_automation.infrastructure.runtime.time_utils import format_duration_display
+from youtube_automation.infrastructure.runtime.time_utils import (
+    format_duration_display,
+    format_localized_duration_display,
+)
 
 # ---------------------------------------------------------------------------
 # ヘルパー: 最小限の初期化でインスタンスを取得する
@@ -462,6 +465,7 @@ class TestGenerateCompleteCollectionMetadata:
             english_title="Test English Title",
             timestamp_body="00:00 01. Track 1",
             scene_phrases=self._all_phrases(),
+            duration_seconds=3600,
         )
         assert "ja" in locs
         assert "雨の街の夜テスト" in locs["ja"]["title"]
@@ -475,6 +479,7 @@ class TestGenerateCompleteCollectionMetadata:
                 english_title="English Fallback Title",
                 timestamp_body="00:00 Track 1",
                 scene_phrases={"ja": "雨"},
+                duration_seconds=3600,
             )
 
     def test_localizations_description_hybrid_structure(self):
@@ -485,6 +490,7 @@ class TestGenerateCompleteCollectionMetadata:
             english_title="Test",
             timestamp_body="00:00 01. Track 1",
             scene_phrases=self._all_phrases(),
+            duration_seconds=3600,
         )
         ja_desc = locs["ja"]["description"]
         assert "- Genre :" in ja_desc
@@ -502,6 +508,7 @@ class TestGenerateCompleteCollectionMetadata:
             english_title="Test",
             timestamp_body="00:00 Track 1",
             scene_phrases=self._all_phrases(),
+            duration_seconds=3600,
         )
         for lang, loc in locs.items():
             assert len(loc["description"]) <= 5000, f"{lang} description exceeds 5000 chars"
@@ -515,6 +522,7 @@ class TestGenerateCompleteCollectionMetadata:
                 english_title="Fallback",
                 timestamp_body="",
                 scene_phrases={},
+                duration_seconds=3600,
             )
 
     @staticmethod
@@ -553,6 +561,7 @@ class TestGenerateCompleteCollectionMetadata:
                 english_title="Test",
                 timestamp_body="00:00 01. Track 1",
                 scene_phrases=self._all_phrases(),
+                duration_seconds=3600,
             )
             assert len(locs) >= 2  # 多言語チャンネルで全言語に反映されることを確認
             for lang, loc in locs.items():
@@ -626,6 +635,24 @@ class TestFormatDurationDisplay:
 
     def test_two_hours(self):
         assert format_duration_display(7200) == "2 Hours"
+
+    @pytest.mark.parametrize(
+        "seconds,locale,expected",
+        [
+            (8 * 3600 + 10 * 60, "en", "8 Hours"),
+            (8 * 3600 + 10 * 60, "de", "8 Std"),
+            (8 * 3600 + 10 * 60, "ja", "8時間"),
+            (10 * 3600 + 32 * 60, "en", "10.5 Hours"),
+            (10 * 3600 + 32 * 60, "de", "10.5 Std"),
+            (10 * 3600 + 32 * 60, "ja", "10.5時間"),
+        ],
+    )
+    def test_localized_duration_uses_common_rounded_number(self, seconds, locale, expected):
+        assert format_localized_duration_display(seconds, locale) == expected
+
+    def test_localized_duration_rejects_unsupported_locale(self):
+        with pytest.raises(ValueError, match="対応していない locale"):
+            format_localized_duration_display(3600, "fr")
 
     def test_very_short(self):
         """60秒 = 1分 → 最小 5 min"""
@@ -889,7 +916,7 @@ class TestValidateScenePhrases:
     def test_all_within_limit_returns_empty(self):
         """全言語で 100 codepoint 以内なら空リスト"""
         config = load_config()
-        violations = validate_scene_phrases(_all_langs_phrases("short phrase"), config)
+        violations = validate_scene_phrases(_all_langs_phrases("short phrase"), config, 3600)
         assert violations == []
 
     def test_single_language_over_limit(self):
@@ -897,7 +924,7 @@ class TestValidateScenePhrases:
         config = load_config()
         phrases = _all_langs_phrases("short phrase")
         phrases["ja"] = "あ" * 90  # template + activities 込みで 100 超過
-        violations = validate_scene_phrases(phrases, config)
+        violations = validate_scene_phrases(phrases, config, 3600)
         assert len(violations) == 1
         assert violations[0].lang == "ja"
         assert violations[0].length > 100
@@ -906,7 +933,7 @@ class TestValidateScenePhrases:
         """複数言語が超過していれば 1 言語ずつ fail せず全件まとめて返る（#78 の主目的）"""
         config = load_config()
         phrases = _all_langs_phrases("あ" * 90)
-        violations = validate_scene_phrases(phrases, config)
+        violations = validate_scene_phrases(phrases, config, 3600)
         # sample_channel の supported_languages 5 つ全てが超過するはず
         assert len(violations) == len(config.localizations.supported_languages)
         langs = {v.lang for v in violations}
@@ -917,7 +944,7 @@ class TestValidateScenePhrases:
         config = load_config()
         phrases = _all_langs_phrases("short phrase")
         phrases["ja"] = "あ" * 90
-        violations = validate_scene_phrases(phrases, config)
+        violations = validate_scene_phrases(phrases, config, 3600)
         v = violations[0]
         assert isinstance(v, SceneTitleViolation)
         assert v.length == len(v.title)
@@ -927,26 +954,26 @@ class TestValidateScenePhrases:
         """scene_phrases に不足言語があれば ValueError（existing 挙動を踏襲）"""
         config = load_config()
         with pytest.raises(ValueError, match="scene_phrases"):
-            validate_scene_phrases({"ja": "あ"}, config)
+            validate_scene_phrases({"ja": "あ"}, config, 3600)
 
     def test_empty_scene_phrases_raises(self):
         """空辞書はそのまま全言語欠落扱いで raise"""
         config = load_config()
         with pytest.raises(ValueError, match="scene_phrases"):
-            validate_scene_phrases({}, config)
+            validate_scene_phrases({}, config, 3600)
 
     def test_single_language_channel_empty_scene_phrases_ok(self):
         """単一言語チャンネルは scene_phrases 不要（populate no-op と対称 #1470）"""
         from types import SimpleNamespace
 
         config = SimpleNamespace(localizations=SimpleNamespace(data={"supported_languages": ["en"], "languages": {}}))
-        assert validate_scene_phrases({}, config) == []
+        assert validate_scene_phrases({}, config, 3600) == []
 
     def test_format_scene_title_violations_joins_all(self):
         """format_scene_title_violations は全件を複数行にまとめる（CLI で 1 回で報告するため）"""
         config = load_config()
         phrases = _all_langs_phrases("あ" * 90)
-        violations = validate_scene_phrases(phrases, config)
+        violations = validate_scene_phrases(phrases, config, 3600)
         text = format_scene_title_violations(violations)
         for v in violations:
             assert f"[{v.lang}]" in text
@@ -963,7 +990,7 @@ class TestGenerateLocalizationsSingleLanguage:
         gen.config = SimpleNamespace(
             localizations=SimpleNamespace(data={"supported_languages": ["en"], "languages": {}})
         )
-        assert gen.generate_localizations("Continuous Focus Mix", "00:00 Intro", {}) == {}
+        assert gen.generate_localizations("Continuous Focus Mix", "00:00 Intro", {}, duration_seconds=3600) == {}
 
     def test_malformed_workflow_state_fails_before_scene_phrases_fallback(self, tmp_path):
         from types import SimpleNamespace
@@ -993,6 +1020,7 @@ class TestGenerateLocalizationsBulkReport:
                 english_title="Test",
                 timestamp_body="",
                 scene_phrases=phrases,
+                duration_seconds=3600,
             )
         msg = str(excinfo.value)
         for lang in config.localizations.supported_languages:
@@ -1472,7 +1500,12 @@ class TestTitleTemplateUnknownPlaceholder:
 
     def test_localized_title_values_keys_match_allowed_placeholders(self):
         """uploader が渡す values のキー集合と許可リスト定数の drift を防ぐ。"""
-        values = _localized_title_values(scene_phrase="Rainy", activities="Study", scene_emoji="🌧")
+        values = _localized_title_values(
+            scene_phrase="Rainy",
+            activities="Study",
+            scene_emoji="🌧",
+            duration_display="10.5 Hours",
+        )
         assert set(values) == set(LOCALIZED_TITLE_PLACEHOLDERS)
 
     def test_validate_localizations_title_templates_detects_unknown_placeholder(self):
@@ -1492,10 +1525,20 @@ class TestTitleTemplateUnknownPlaceholder:
     def test_validate_localizations_title_templates_accepts_allowed_placeholders(self):
         loc = {
             "languages": {
-                "en": {"title_template": "{scene_phrase} | Jazz BGM ({activities}) {scene_emoji}"},
+                "en": {"title_template": "{scene_phrase} | Jazz BGM ({activities}) {scene_emoji} [{duration_display}]"},
             }
         }
         assert validate_localizations_title_templates(loc) == []
+
+    @pytest.mark.parametrize("literal", ["[3 Hours]", "[3 Std]", "3時間"])
+    def test_validate_localizations_title_templates_rejects_static_duration(self, literal):
+        loc = {"languages": {"en": {"title_template": f"{{scene_phrase}} | {literal}"}}}
+
+        errors = validate_localizations_title_templates(loc)
+
+        assert len(errors) == 1
+        assert "固定尺" in errors[0]
+        assert "{duration_display}" in errors[0]
 
     def test_validate_localizations_title_templates_tolerates_missing_sections(self):
         # languages 無し / title_template 無し / 非 dict 言語エントリは検証対象外として黙って通す
@@ -1525,6 +1568,19 @@ class TestTitleTemplateUnknownPlaceholder:
         meta = gen_with_tracks.generate_complete_collection_metadata()
         assert len(meta["title"]) > 0
 
+    def test_primary_and_localized_titles_share_master_duration_number(self, gen_with_tracks):
+        object.__setattr__(
+            gen_with_tracks.config.content.title,
+            "template",
+            "{scene_phrase} [{duration_display}]",
+        )
+        metadata = gen_with_tracks.generate_complete_collection_metadata(duration_seconds=10 * 3600 + 32 * 60)
+
+        assert "10.5 Hours" in metadata["title"]
+        assert "10.5時間" in metadata["localizations"]["ja"]["title"]
+        assert "10.5 Hours" in metadata["localizations"]["en"]["title"]
+        assert "10.5 Std" in metadata["localizations"]["de"]["title"]
+
     # --- localizations.json::title_template 経路 ---------------------------
 
     def test_localizations_unknown_placeholder_raises_actionable(self):
@@ -1534,7 +1590,7 @@ class TestTitleTemplateUnknownPlaceholder:
         config.localizations.data["languages"][lang]["title_template"] = "{adjective} {scene_phrase}"
         scene_phrases = {lng: "phrase" for lng in supported}
         with pytest.raises(ValidationError) as exc:
-            validate_scene_phrases(scene_phrases, config)
+            validate_scene_phrases(scene_phrases, config, 3600)
         msg = str(exc.value)
         assert "adjective" in msg
         assert lang in msg

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -87,6 +87,7 @@ def _write_cli_title_collection(channel_dir: Path, *, title_template_check: dict
     collection = channel_dir / "collections" / "planning" / "20990101-volume-collection"
     for subdir in ("01-master", "02-Individual-music", "03-Individual-movie", "10-assets", "20-documentation"):
         (collection / subdir).mkdir(parents=True, exist_ok=True)
+    (collection / "01-master" / "master.mp4").write_bytes(b"probe is mocked")
     (collection / "20-documentation" / "descriptions.md").write_text(
         """## タイトル案
 ```
@@ -163,6 +164,7 @@ def test_main_title_preflight_honors_collection_opt_in_for_each_cli_entry(
 
     with (
         patch("youtube_automation.domains.uploads._preflight.load_config", return_value=_title_preflight_config()),
+        patch("youtube_automation.domains.uploads._preflight.probe_duration", return_value=3600),
         patch.object(CollectionUploader, method_name) as mock_action,
     ):
         if expected_outcome == "pass":

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -118,6 +118,9 @@ Continuous Focus Mix
         encoding="utf-8",
     )
     _write_json(collection_dir / "workflow-state.json", {"scene_phrases": scene_phrases})
+    master_dir = collection_dir / "01-master"
+    master_dir.mkdir(parents=True)
+    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
     return collection_dir
 
 
@@ -127,8 +130,13 @@ def _run_preflight(
     monkeypatch: pytest.MonkeyPatch,
     *,
     allow_duration_outside_target: bool = False,
+    duration_seconds: float = 3600,
 ) -> None:
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+    monkeypatch.setattr(
+        "youtube_automation.domains.uploads._preflight.probe_duration",
+        lambda _: duration_seconds,
+    )
     harness = _PreflightHarness(channel_dir / "collections")
     harness.allow_duration_outside_target = allow_duration_outside_target
     harness._preflight_check(collection_dir)
@@ -332,6 +340,72 @@ def test_plan_preflight_rejects_overlong_localized_title(
         _run_preflight(channel_dir, collection_dir, monkeypatch)
 
 
+def test_plan_preflight_rejects_static_localized_duration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "de"])
+    _write_json(
+        channel_dir / "config" / "localizations.json",
+        {
+            "supported_languages": ["en", "de"],
+            "languages": {
+                "en": {"title_template": "{scene_phrase} [3 Hours]"},
+                "de": {"title_template": "{scene_phrase} [{duration_display}]"},
+            },
+        },
+    )
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+
+    with pytest.raises(ValidationError, match=r"固定尺 '3 Hours'"):
+        _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_plan_preflight_passes_actual_master_duration_to_localizations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, float] = {}
+
+    class _Generator:
+        def __init__(self, _collection_dir: str) -> None:
+            self.config = None
+
+        @staticmethod
+        def _load_scene_emoji() -> str:
+            return ""
+
+        def generate_localizations(self, *_args, duration_seconds: float, **_kwargs):
+            captured["duration_seconds"] = duration_seconds
+            return {"en": {"title": "Focus [10.5 Hours]"}}
+
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "de"])
+    _write_json(
+        channel_dir / "config" / "localizations.json",
+        {
+            "supported_languages": ["en", "de"],
+            "languages": {
+                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
+                "de": {"title_template": "{scene_phrase} [{duration_display}]"},
+            },
+        },
+    )
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+    monkeypatch.setattr("youtube_automation.domains.uploads._preflight.BAHMetadataGenerator", _Generator)
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch, duration_seconds=10 * 3600 + 32 * 60)
+
+    assert captured == {"duration_seconds": 10 * 3600 + 32 * 60}
+
+
 def test_target_duration_config_allows_video_inside_target(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -347,11 +421,6 @@ def test_target_duration_config_allows_video_inside_target(
         scene_phrases={"en": "continuous focus mix"},
         description="A continuous BGM mix without chapter markers.",
     )
-    master_dir = collection_dir / "01-master"
-    master_dir.mkdir(parents=True)
-    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
-    monkeypatch.setattr("youtube_automation.domains.uploads._preflight.probe_duration", lambda _: 60 * 60)
-
     _run_preflight(channel_dir, collection_dir, monkeypatch)
 
 
@@ -370,16 +439,11 @@ def test_target_duration_config_blocks_short_video_without_override(
         scene_phrases={"en": "continuous focus mix"},
         description="A continuous BGM mix without chapter markers.",
     )
-    master_dir = collection_dir / "01-master"
-    master_dir.mkdir(parents=True)
-    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
-    monkeypatch.setattr("youtube_automation.domains.uploads._preflight.probe_duration", lambda _: 50 * 60 + 29)
-
     with pytest.raises(
         ValidationError,
         match=r"duration: 50m .*target 1h00m〜1h30m.*--allow-duration-outside-target",
     ):
-        _run_preflight(channel_dir, collection_dir, monkeypatch)
+        _run_preflight(channel_dir, collection_dir, monkeypatch, duration_seconds=50 * 60 + 29)
 
 
 def test_target_duration_override_allows_short_video(
@@ -397,16 +461,12 @@ def test_target_duration_override_allows_short_video(
         scene_phrases={"en": "continuous focus mix"},
         description="A continuous BGM mix without chapter markers.",
     )
-    master_dir = collection_dir / "01-master"
-    master_dir.mkdir(parents=True)
-    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
-    monkeypatch.setattr("youtube_automation.domains.uploads._preflight.probe_duration", lambda _: 50 * 60 + 29)
-
     _run_preflight(
         channel_dir,
         collection_dir,
         monkeypatch,
         allow_duration_outside_target=True,
+        duration_seconds=50 * 60 + 29,
     )
 
 
@@ -452,6 +512,10 @@ def test_upload_collection_reports_unreachable_tags_min_count_from_channel_confi
         tags=["a" * 17] * 26 + ["b" * 27],
     )
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+    monkeypatch.setattr(
+        "youtube_automation.domains.uploads._preflight.probe_duration",
+        lambda _: 3600,
+    )
 
     assert load_config().content.tags.min_count == 30
     uploader = YouTubeAutoUploader(str(channel_dir / "collections"))

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -33,6 +33,18 @@ from youtube_automation.core.errors import ValidationError
 sys.path.insert(0, str(REPO_ROOT))
 
 
+@pytest.fixture(autouse=True)
+def _mock_complete_collection_master_duration(monkeypatch):
+    monkeypatch.setattr(
+        "youtube_automation.domains.uploads._complete_collection_strategy.probe_duration",
+        lambda _: 10 * 3600 + 32 * 60,
+    )
+    monkeypatch.setattr(
+        "youtube_automation.domains.uploads._preflight.probe_duration",
+        lambda _: 10 * 3600 + 32 * 60,
+    )
+
+
 def test_main_without_action_prints_usage(monkeypatch, capsys):
     from youtube_automation.commands.uploads import youtube_auto_uploader
 
@@ -152,6 +164,9 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
         json.dumps({"scene_phrases": scene_phrases}),
         encoding="utf-8",
     )
+    master_dir = col_dir / "01-master"
+    master_dir.mkdir()
+    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
     return col_dir
 
 
@@ -259,6 +274,9 @@ def _write_title_collection(
         json.dumps(workflow_state),
         encoding="utf-8",
     )
+    master_dir = col_dir / "01-master"
+    master_dir.mkdir()
+    (master_dir / "master.mp4").write_bytes(b"probe is mocked")
     return col_dir
 
 
@@ -1025,6 +1043,9 @@ class TestUploadCompleteCollectionDedup:
         assert result["video_id"] == "v9"
         assert result["video_url"] == "https://www.youtube.com/watch?v=v9"
         assert result["upload_source"] == "existing_video"
+        assert mock_gen.generate_complete_collection_metadata.call_args.kwargs["duration_seconds"] == (
+            10 * 3600 + 32 * 60
+        )
 
     def test_should_proceed_with_upload_when_dedup_search_returns_none(self, tmp_path):
         """dedup miss 時は通常通り `upload_video` を呼ぶ."""

--- a/tests/fixtures/sample_channel/config/localizations.json
+++ b/tests/fixtures/sample_channel/config/localizations.json
@@ -2,7 +2,7 @@
   "supported_languages": ["ja", "en", "de"],
   "languages": {
     "ja": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "ゲーム · 勉強 · 集中",
       "description": {
         "opening_poem": "ピクセルの夜、冒険の調べ",
@@ -12,7 +12,7 @@
       }
     },
     "en": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "Gaming · Study · Focus",
       "description": {
         "opening_poem": "Pixel nights, melodies of adventure",
@@ -22,7 +22,7 @@
       }
     },
     "de": {
-      "title_template": "{scene_phrase} | RPG BGM ({activities})",
+      "title_template": "{scene_phrase} | RPG BGM ({activities}) [{duration_display}]",
       "activities": "Gaming · Lernen · Fokus",
       "description": {
         "opening_poem": "Pixelnacht, Melodie des Abenteuers",

--- a/tests/repo/test_domains_reorganization.py
+++ b/tests/repo/test_domains_reorganization.py
@@ -338,8 +338,14 @@ def test_metadata_private_helpers_are_owned_by_their_leaf_modules() -> None:
 
     assert titles._extract_pattern_key("01-pattern-b1-song") == "b1"
     assert localizations._localized_title_values.__module__ == localizations.__name__
-    assert localizations._localized_title_values(scene_phrase="Rain", activities="Study", scene_emoji="☔") == {
+    assert localizations._localized_title_values(
+        scene_phrase="Rain",
+        activities="Study",
+        scene_emoji="☔",
+        duration_display="10.5 Hours",
+    ) == {
         "scene_phrase": "Rain",
         "activities": "Study",
         "scene_emoji": "☔",
+        "duration_display": "10.5 Hours",
     }


### PR DESCRIPTION
## Summary

- primary と localizations のタイトルへ同じ実マスター尺を伝搬
- ja / en / de の単位で `{duration_display}` を展開し、8時間超・10時間超も同じ丸め数値を表示
- 固定尺を含む legacy template は公開前に fail closed
- 同梱 template・example と preflight 回帰を更新

Closes #3684
