### PR TITLE
fix(video-upload): ローカライズタイトル超過の内訳を表示 (#3685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
+
 - `feat(streaming)`: 24/7 配信時だけ YouTube 配信枠復旧 CLI を既定 2 分の systemd timer で実行し、ephemeral OAuth 配備、ffmpeg 停止時 no-op、recovered 通知と journald 記録、安全な disable cleanup を行う Terraform opt-in を追加（#3675）。
 
 - `feat(streaming)`: active broadcast / ingest 状態を確認し、active ingest だけが残った場合に upcoming 配信枠を冪等再利用、または新規作成して bind → live 遷移する `yt-stream-broadcast-recover` CLI を追加。dry-run、構造化結果、secret 非出力を備えた（#3674）。

--- a/src/youtube_automation/domains/metadata/localizations.py
+++ b/src/youtube_automation/domains/metadata/localizations.py
@@ -142,6 +142,9 @@ class SceneTitleViolation:
 
     lang: str
     length: int
+    excess: int
+    fixed_length: int
+    scene_phrase_length: int
     title: str
     template: str
 
@@ -211,10 +214,24 @@ def validate_scene_phrases(
             context=f"localizations.json: language '{lang}' の title_template",
         )
         if len(title) > 100:
+            fixed_title = format_title_template(
+                title_tpl,
+                _localized_title_values(
+                    scene_phrase="",
+                    activities=activities,
+                    scene_emoji=scene_emoji,
+                    duration_display=duration_display,
+                ),
+                context=f"localizations.json: language '{lang}' の title_template",
+            )
+            fixed_length = len(fixed_title)
             violations.append(
                 SceneTitleViolation(
                     lang=lang,
                     length=len(title),
+                    excess=len(title) - 100,
+                    fixed_length=fixed_length,
+                    scene_phrase_length=len(title) - fixed_length,
                     title=title,
                     template=title_tpl,
                 )
@@ -224,4 +241,8 @@ def validate_scene_phrases(
 
 def format_scene_title_violations(violations: List[SceneTitleViolation]) -> str:
     """違反リストを人間可読な複数行テキストに整形する（CLI / エラーメッセージ共通）."""
-    return "\n".join(f"  - [{v.lang}] {v.length} codepoints (+{v.length - 100}): {v.title}" for v in violations)
+    return "\n".join(
+        f"  - [{v.lang}] {v.length} codepoints "
+        f"(+{v.excess}; fixed={v.fixed_length}c; scene_phrase={v.scene_phrase_length}c): {v.title}"
+        for v in violations
+    )

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -950,6 +950,42 @@ class TestValidateScenePhrases:
         assert v.length == len(v.title)
         assert "{scene_phrase}" in v.template
 
+    def test_violation_breakdown_uses_actual_expanded_title(self):
+        from types import SimpleNamespace
+
+        config = SimpleNamespace(
+            localizations=SimpleNamespace(
+                data={
+                    "supported_languages": ["en", "de"],
+                    "languages": {
+                        "en": {
+                            "title_template": "{scene_phrase} | BGM ({activities}) [{duration_display}]",
+                            "activities": "Study",
+                        },
+                        "de": {
+                            "title_template": "{scene_phrase} | BGM ({activities}) [{duration_display}]",
+                            "activities": "Lernen",
+                        },
+                    },
+                }
+            ),
+            content=SimpleNamespace(descriptions=SimpleNamespace(metadata={})),
+        )
+        scene_phrases = {"en": "x" * 90, "de": "y" * 90}
+
+        violations = validate_scene_phrases(scene_phrases, config, 10 * 3600 + 32 * 60)
+
+        assert len(violations) == 2
+        expected_fixed_titles = {
+            "en": " | BGM (Study) [10.5 Hours]",
+            "de": " | BGM (Lernen) [10.5 Std]",
+        }
+        for violation in violations:
+            assert violation.excess == violation.length - 100
+            assert violation.fixed_length == len(expected_fixed_titles[violation.lang])
+            assert violation.scene_phrase_length == len(scene_phrases[violation.lang])
+            assert violation.length == violation.fixed_length + violation.scene_phrase_length
+
     def test_missing_phrase_raises(self):
         """scene_phrases に不足言語があれば ValueError（existing 挙動を踏襲）"""
         config = load_config()
@@ -978,6 +1014,9 @@ class TestValidateScenePhrases:
         for v in violations:
             assert f"[{v.lang}]" in text
             assert str(v.length) in text
+            assert f"fixed={v.fixed_length}c" in text
+            assert f"scene_phrase={v.scene_phrase_length}c" in text
+            assert f"+{v.excess}" in text
 
 
 class TestGenerateLocalizationsSingleLanguage:
@@ -1025,6 +1064,9 @@ class TestGenerateLocalizationsBulkReport:
         msg = str(excinfo.value)
         for lang in config.localizations.supported_languages:
             assert f"[{lang}]" in msg
+        for violation in validate_scene_phrases(phrases, config, 3600):
+            assert f"fixed={violation.fixed_length}c" in msg
+            assert f"scene_phrase={violation.scene_phrase_length}c" in msg
 
 
 # ===========================================================================

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -336,8 +336,12 @@ def test_plan_preflight_rejects_overlong_localized_title(
         description="A continuous BGM mix without chapter markers.",
     )
 
-    with pytest.raises(ValidationError, match=r"\[de\] 114 codepoints.*ruhiger Fokus"):
+    with pytest.raises(ValidationError, match=r"\[de\] 114 codepoints.*ruhiger Fokus") as excinfo:
         _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+    message = str(excinfo.value)
+    assert "fixed=101c" in message
+    assert "scene_phrase=13c" in message
 
 
 def test_plan_preflight_rejects_static_localized_duration(


### PR DESCRIPTION
## Summary

- locale title の 100 codepoint violation に総数・超過分・固定部分・scene phrase の内訳を保持
- ValueError と preflight で言語ごとの内訳を一括表示
- duration placeholder と activities を含む実展開結果から固定部分を算出

Closes #3685
