### PR TITLE
feat(evals): wf-statusの読み取り専用E2Eを追加 (#3093)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ build/
 .claude/worktrees/
 .worktrees/
 
+# promptfoo local eval output
+.promptfoo/
+evals/.promptfoo/
+evals/results/
+
 # Node / extensions (WXT)
 node_modules/
 .blume/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
+- `feat(evals)`: promptfoo 0.122.0 から権限を読み取り専用へ制限した `claude -p` provider を起動し、v1 / v2 fixture 上の `/wf-status` が実行系 tool を試行せず `workflow-state.json` と fixture 全体を変更しないことをローカル E2E で検出できるようにした（#3093）。
 
 - `feat(streaming)`: 24/7 配信時だけ YouTube 配信枠復旧 CLI を既定 2 分の systemd timer で実行し、ephemeral OAuth 配備、ffmpeg 停止時 no-op、recovered 通知と journald 記録、安全な disable cleanup を行う Terraform opt-in を追加（#3675）。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,16 @@ nix develop .#extensions --command pnpm -C site test
 
 `.claude/skills/` 配下の skill を編集してから下流チャンネルリポジトリへ届くまでの一連手順（issue #2098）。
 
+### 実 skill 挙動のローカル E2E
+
+`evals/` は、静的な skill lint / repository contract では検証できない LLM の実挙動を `promptfoo` + `claude -p` で確認する独立レーンです。モデル利用料金と Claude Code の認証を伴うため、`pytest` や CI からは起動しません。
+
+```bash
+nix develop --command pnpm dlx promptfoo@0.122.0 eval -c evals/promptfooconfig.yaml
+```
+
+現在の対象、権限制限、fixture 不変確認、禁止事項 assertion の検出力確認は [`evals/README.md`](../evals/README.md) を参照してください。
+
 ### 1. 編集
 
 - 実体は常に `.claude/skills/<name>/` を編集する（`.agents/skills` は Codex CLI 探索パス用の symlink）。付属スクリプトは `.claude/skills/<name>/references/` に置く（ルート直下 `scripts/` は設けない）

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,37 @@
+# Skill E2E evaluations
+
+`promptfoo` から `claude -p` を起動し、自然言語で定義された skill の実挙動を確認するローカル評価です。通常の `pytest` には含まれず、Claude Code の認証とモデル利用料金が必要です。
+
+## wf-status
+
+第一弾は、v1 / v2 の状態を持つ評価専用チャンネルで `/wf-status` を実行します。
+
+```bash
+nix develop --command pnpm dlx promptfoo@0.122.0 eval -c evals/promptfooconfig.yaml
+```
+
+次の契約を決定的な Python assertion で判定します。
+
+- 許可外 tool の呼び出し試行が `claude -p --output-format json` の `permission_denials` に無い
+- `workflow-state.json` が実行前後で不変
+- fixture 全体が実行前後で不変
+
+provider は cwd と `CHANNEL_DIR` を `evals/fixtures/channel/` に固定します。利用可能な built-in tool は Read / Glob / Grep / Bash だけで、Bash は fixture の v2 state に対する読み取り専用 `yt-raw-master-check` 1 コマンドへ完全一致で限定します。`dontAsk`、project settings のみ、空の strict MCP config を併用するため、それ以外の実行は承認待ちにならず拒否されます。
+
+実行中に fixture の変更を検出した場合、assertion を fail にした後で開始時の byte 列へ復元します。終了後は次でも確認できます。
+
+```bash
+git diff --exit-code -- evals/fixtures/channel
+```
+
+### assertion の検出力
+
+モデルを呼ばず、意図的な禁止 tool 試行と state 変更を表す保存済み出力へ同じ assertion を適用できます。このコマンドは非 0 で終了するのが正常です。
+
+```bash
+nix develop --command pnpm dlx promptfoo@0.122.0 eval \
+  --assertions evals/assertions/wf_status_violation_check.yaml \
+  --model-outputs evals/fixtures/wf-status-violation.json
+```
+
+promptfoo の履歴と cache は既定で `~/.promptfoo/` に保存されます。リポジトリ内へ明示出力する場合は ignore 済みの `evals/results/` を使ってください。

--- a/evals/assertions/wf_status_read_only.py
+++ b/evals/assertions/wf_status_read_only.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+
+
+def _result(output: str) -> dict[str, object]:
+    parsed = json.loads(output)
+    if not isinstance(parsed, dict):
+        raise ValueError("wf-status eval output は JSON object でなければなりません")
+    return parsed
+
+
+def _grading_result(passed: bool, success: str, failure: str) -> dict[str, object]:
+    return {"pass": passed, "score": 1 if passed else 0, "reason": success if passed else failure}
+
+
+def skill_invoked(output: str, _context: dict[str, object]) -> dict[str, object]:
+    response = _result(output).get("response")
+    if not isinstance(response, str):
+        raise ValueError("wf-status eval output に response 文字列がありません")
+    invoked = "Unknown command: /wf-status" not in response
+    return _grading_result(invoked, "wf-status skill を実行", "wf-status skill が解決されていません")
+
+
+def no_execution_tool_attempts(output: str, _context: dict[str, object]) -> dict[str, object]:
+    calls = _result(output).get("tool_calls")
+    if not isinstance(calls, list):
+        raise ValueError("wf-status eval output の tool_calls が配列ではありません")
+    return _grading_result(not calls, "実行系 tool の拒否試行なし", f"許可外 tool 呼び出し: {calls}")
+
+
+def workflow_state_immutable(output: str, _context: dict[str, object]) -> dict[str, object]:
+    result = _result(output)
+    unchanged = result.get("workflow_state_unchanged")
+    changed = result.get("changed_workflow_state_files")
+    if not isinstance(unchanged, bool) or not isinstance(changed, list):
+        raise ValueError("wf-status eval output の state 変更情報が不正です")
+    return _grading_result(unchanged, "workflow-state.json は不変", f"変更を検出: {changed}")
+
+
+def fixture_clean(output: str, _context: dict[str, object]) -> dict[str, object]:
+    result = _result(output)
+    unchanged = result.get("fixture_unchanged")
+    changed = result.get("changed_fixture_files")
+    if not isinstance(unchanged, bool) or not isinstance(changed, list):
+        raise ValueError("wf-status eval output の fixture 変更情報が不正です")
+    return _grading_result(unchanged, "fixture 全体が不変", f"変更を検出して復元: {changed}")

--- a/evals/assertions/wf_status_violation_check.yaml
+++ b/evals/assertions/wf_status_violation_check.yaml
@@ -1,0 +1,8 @@
+- type: python
+  value: file://evals/assertions/wf_status_read_only.py:skill_invoked
+- type: python
+  value: file://evals/assertions/wf_status_read_only.py:no_execution_tool_attempts
+- type: python
+  value: file://evals/assertions/wf_status_read_only.py:workflow_state_immutable
+- type: python
+  value: file://evals/assertions/wf_status_read_only.py:fixture_clean

--- a/evals/fixtures/channel/collections/planning/v1-legacy/workflow-state.json
+++ b/evals/fixtures/channel/collections/planning/v1-legacy/workflow-state.json
@@ -1,0 +1,10 @@
+{
+  "collection_name": "Legacy Rain Study",
+  "theme": "legacy-rain-study",
+  "steps": {
+    "planning": {"approved": true},
+    "music": {"approved": true},
+    "video": {"approved": false},
+    "upload": {"approved": false}
+  }
+}

--- a/evals/fixtures/channel/collections/planning/v2-prepared/workflow-state.json
+++ b/evals/fixtures/channel/collections/planning/v2-prepared/workflow-state.json
@@ -1,0 +1,27 @@
+{
+  "collection_name": "Quiet Night Focus",
+  "theme": "quiet-night-focus",
+  "created_at": "2026-08-01T00:00:00.000Z",
+  "updated_at": "2026-08-01T00:00:00.000Z",
+  "stage": "planning",
+  "phase": "prepared",
+  "selected_plan": "A",
+  "track_count": 8,
+  "music_engine": "suno",
+  "planning": {},
+  "assets": {
+    "thumbnail": true,
+    "loop_video": true,
+    "music_prompts": true,
+    "music_downloaded": false,
+    "raw_master": null,
+    "master_audio": null,
+    "master_video": null,
+    "description": false
+  },
+  "upload": {
+    "video_id": null,
+    "video_url": null,
+    "publish_at": null
+  }
+}

--- a/evals/fixtures/channel/config/channel/content.json
+++ b/evals/fixtures/channel/config/channel/content.json
@@ -1,0 +1,21 @@
+{
+  "genre": {
+    "primary": "ambient",
+    "style": "calm",
+    "context": "focus"
+  },
+  "tags": {
+    "base": ["ambient music"],
+    "themes": {
+      "night": ["night focus"]
+    }
+  },
+  "descriptions": {
+    "opening": "Calm ambient music for focus.",
+    "perfect_for": ["Focus"],
+    "hashtags": ["#AmbientMusic"]
+  },
+  "title": {
+    "template": "{style} {theme} - {activity} [{duration_display}]"
+  }
+}

--- a/evals/fixtures/channel/config/channel/meta.json
+++ b/evals/fixtures/channel/config/channel/meta.json
@@ -1,0 +1,8 @@
+{
+  "channel": {
+    "name": "wf-status Eval Channel",
+    "short": "WSE",
+    "youtube_handle": "@wfstatuseval",
+    "url": "https://youtube.com/@wfstatuseval"
+  }
+}

--- a/evals/fixtures/channel/config/channel/workflow.json
+++ b/evals/fixtures/channel/config/channel/workflow.json
@@ -1,0 +1,9 @@
+{
+  "workflow": {
+    "wf_next": {
+      "skip_audio_approval": false,
+      "skip_upload_approval": false,
+      "skip_manual_mastering": false
+    }
+  }
+}

--- a/evals/fixtures/channel/config/channel/youtube.json
+++ b/evals/fixtures/channel/config/channel/youtube.json
@@ -1,0 +1,11 @@
+{
+  "youtube": {
+    "category_id": "10",
+    "privacy_status": "private",
+    "language": "ja"
+  },
+  "content_model": {
+    "type": "collection",
+    "languages": ["ja"]
+  }
+}

--- a/evals/fixtures/wf-status-violation.json
+++ b/evals/fixtures/wf-status-violation.json
@@ -1,0 +1,3 @@
+[
+  "{\"response\":\"violation fixture\",\"tool_calls\":[{\"name\":\"Bash\",\"input\":{\"command\":\"uv run yt-wf-next\"},\"denied\":true}],\"workflow_state_unchanged\":false,\"fixture_unchanged\":false,\"changed_workflow_state_files\":[\"collections/planning/v2-prepared/workflow-state.json\"],\"changed_fixture_files\":[\"collections/planning/v2-prepared/workflow-state.json\"]}"
+]

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: wf-status skill read-only contract
+
+prompts:
+  - |-
+    /wf-status
+    制作中のコレクションを読むだけで一覧表示してください。実行や更新はしないでください。
+
+providers:
+  - id: file://providers/claude_code_provider.py
+    label: claude-code-wf-status
+    config:
+      fixtureDir: fixtures/channel
+      timeoutSeconds: 240
+      maxTurns: 8
+
+evaluateOptions:
+  cache: false
+  maxConcurrency: 1
+  timeoutMs: 270000
+
+tests:
+  - description: wf-status stays read-only for v1 and v2 collections
+    assert:
+      - type: python
+        metric: skill_invoked
+        value: file://assertions/wf_status_read_only.py:skill_invoked
+      - type: python
+        metric: no_execution_tool_attempts
+        value: file://assertions/wf_status_read_only.py:no_execution_tool_attempts
+      - type: python
+        metric: workflow_state_immutable
+        value: file://assertions/wf_status_read_only.py:workflow_state_immutable
+      - type: python
+        metric: fixture_clean
+        value: file://assertions/wf_status_read_only.py:fixture_clean

--- a/evals/providers/claude_code_provider.py
+++ b/evals/providers/claude_code_provider.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+_V2_COLLECTION = "collections/planning/v2-prepared"
+_STATE_FILENAME = "workflow-state.json"
+_RAW_MASTER_COMMAND = f'uv run yt-raw-master-check {_V2_COLLECTION}; echo "EXIT=$?"'
+_MISSING = object()
+
+
+def _build_command(prompt: str, *, max_turns: int) -> list[str]:
+    evaluation_prompt = (
+        f"{prompt}\n\n"
+        "評価 fixture の外へは書き込まず、/wf-status の手順に従って読み取り専用で回答してください。"
+        f"raw master の突合には `{_RAW_MASTER_COMMAND}` の完全一致だけを使ってください。"
+    )
+    return [
+        "claude",
+        "-p",
+        "--output-format",
+        "json",
+        "--permission-mode",
+        "dontAsk",
+        "--setting-sources",
+        "project",
+        "--strict-mcp-config",
+        "--mcp-config",
+        '{"mcpServers":{}}',
+        "--tools",
+        "Read,Glob,Grep,Bash",
+        "--allowed-tools",
+        "Read",
+        "Glob",
+        "Grep",
+        f"Bash({_RAW_MASTER_COMMAND})",
+        "--no-session-persistence",
+        "--max-turns",
+        str(max_turns),
+        evaluation_prompt,
+    ]
+
+
+def _snapshot_fixture(fixture_dir: Path) -> dict[str, bytes | None]:
+    snapshot: dict[str, bytes | None] = {}
+    for path in sorted(fixture_dir.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"eval fixture に symlink は置けません: {path.relative_to(fixture_dir)}")
+        relative_path = path.relative_to(fixture_dir).as_posix()
+        snapshot[relative_path] = None if path.is_dir() else path.read_bytes()
+    return snapshot
+
+
+def _changed_files(fixture_dir: Path, before: dict[str, bytes | None]) -> list[str]:
+    after = _snapshot_fixture(fixture_dir)
+    return sorted(path for path in set(before) | set(after) if before.get(path, _MISSING) != after.get(path, _MISSING))
+
+
+def _restore_fixture(fixture_dir: Path, snapshot: dict[str, bytes | None]) -> None:
+    current = _snapshot_fixture(fixture_dir)
+    type_changes = {
+        path for path in set(current) & set(snapshot) if (current[path] is None) != (snapshot[path] is None)
+    }
+    removal_paths = (set(current) - set(snapshot)) | type_changes
+    for relative_path in sorted(removal_paths, key=lambda path: len(Path(path).parts), reverse=True):
+        path = fixture_dir / relative_path
+        if current[relative_path] is None:
+            path.rmdir()
+        else:
+            path.unlink()
+    for relative_path, content in sorted(snapshot.items(), key=lambda item: len(Path(item[0]).parts)):
+        path = fixture_dir / relative_path
+        if content is None:
+            path.mkdir(parents=True, exist_ok=True)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+
+
+def _tool_calls(payload: dict[str, object]) -> list[dict[str, object]]:
+    denials = payload.get("permission_denials")
+    if not isinstance(denials, list):
+        raise ValueError("Claude Code JSON の permission_denials が配列ではありません")
+    calls: list[dict[str, object]] = []
+    for denial in denials:
+        if not isinstance(denial, dict):
+            raise ValueError("Claude Code JSON の permission_denials 要素が object ではありません")
+        name = denial.get("tool_name")
+        tool_input = denial.get("tool_input")
+        if not isinstance(name, str) or not isinstance(tool_input, dict):
+            raise ValueError("Claude Code JSON の denied tool call が不正です")
+        calls.append({"name": name, "input": tool_input, "denied": True})
+    return calls
+
+
+def _build_output(
+    claude_stdout: str,
+    *,
+    changed_state_files: list[str],
+    changed_fixture_files: list[str],
+) -> str:
+    try:
+        payload = json.loads(claude_stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError("Claude Code JSON を parse できません") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("result"), str):
+        raise ValueError("Claude Code JSON に result 文字列がありません")
+    result = {
+        "response": payload["result"],
+        "tool_calls": _tool_calls(payload),
+        "workflow_state_unchanged": not changed_state_files,
+        "fixture_unchanged": not changed_fixture_files,
+        "changed_workflow_state_files": changed_state_files,
+        "changed_fixture_files": changed_fixture_files,
+    }
+    return json.dumps(result, ensure_ascii=False, sort_keys=True)
+
+
+def _terminate(process: subprocess.Popen[str]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        process.communicate()
+
+
+def _run_claude(command: list[str], *, fixture_dir: Path, timeout_seconds: int) -> str:
+    environment = dict(os.environ)
+    environment["CHANNEL_DIR"] = str(fixture_dir)
+    process = subprocess.Popen(
+        command,
+        cwd=fixture_dir,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, _stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as error:
+        _terminate(process)
+        raise TimeoutError(f"claude -p が {timeout_seconds} 秒で timeout しました") from error
+    if process.returncode != 0:
+        raise RuntimeError(f"claude -p が exit {process.returncode} で失敗しました")
+    return stdout
+
+
+def _positive_int(config: dict[str, object], key: str) -> int:
+    value = config.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"provider config `{key}` は正の整数でなければなりません")
+    return value
+
+
+def _fixture_dir(config: dict[str, object]) -> Path:
+    base_path = config.get("basePath")
+    relative = config.get("fixtureDir")
+    if not isinstance(base_path, str) or not isinstance(relative, str) or not relative:
+        raise ValueError("provider config に basePath / fixtureDir が必要です")
+    relative_path = Path(relative)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError("provider config `fixtureDir` は config 配下の相対 path に限定されます")
+    fixture_dir = (Path(base_path) / relative_path).resolve()
+    if not fixture_dir.is_dir():
+        raise ValueError(f"eval fixture が見つかりません: {fixture_dir}")
+    return fixture_dir
+
+
+def call_api(prompt: str, options: dict[str, object], _context: dict[str, object]) -> dict[str, object]:
+    config = options.get("config")
+    if not isinstance(config, dict):
+        return {"output": "", "error": "provider config が object ではありません"}
+    try:
+        fixture_dir = _fixture_dir(config)
+        timeout_seconds = _positive_int(config, "timeoutSeconds")
+        max_turns = _positive_int(config, "maxTurns")
+        before = _snapshot_fixture(fixture_dir)
+        try:
+            stdout = _run_claude(
+                _build_command(prompt, max_turns=max_turns),
+                fixture_dir=fixture_dir,
+                timeout_seconds=timeout_seconds,
+            )
+            changed_fixture_files = _changed_files(fixture_dir, before)
+        finally:
+            _restore_fixture(fixture_dir, before)
+        changed_state_files = [path for path in changed_fixture_files if Path(path).name == _STATE_FILENAME]
+        return {
+            "output": _build_output(
+                stdout,
+                changed_state_files=changed_state_files,
+                changed_fixture_files=changed_fixture_files,
+            ),
+            "cached": False,
+        }
+    except (OSError, RuntimeError, TimeoutError, ValueError) as error:
+        return {"output": "", "error": str(error), "cached": False}

--- a/tests/repo/test_wf_status_eval_provider.py
+++ b/tests/repo/test_wf_status_eval_provider.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+
+PROVIDER_PATH = REPO_ROOT / "evals" / "providers" / "claude_code_provider.py"
+ASSERTIONS_PATH = REPO_ROOT / "evals" / "assertions" / "wf_status_read_only.py"
+
+
+def _load_provider():
+    spec = importlib.util.spec_from_file_location("claude_code_provider", PROVIDER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"provider を load できません: {PROVIDER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_assertions():
+    spec = importlib.util.spec_from_file_location("wf_status_read_only", ASSERTIONS_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"assertion を load できません: {ASSERTIONS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_command_exposes_only_read_tools_and_exact_dry_run_cli() -> None:
+    provider = _load_provider()
+
+    command = provider._build_command("進捗を読むだけで確認して", max_turns=8)
+
+    assert command[:3] == ["claude", "-p", "--output-format"]
+    assert command[3] == "json"
+    assert command[command.index("--permission-mode") + 1] == "dontAsk"
+    assert command[command.index("--setting-sources") + 1] == "project"
+    assert command[command.index("--tools") + 1] == "Read,Glob,Grep,Bash"
+    allowed_index = command.index("--allowed-tools")
+    allowed = command[allowed_index + 1 : allowed_index + 5]
+    assert allowed == [
+        "Read",
+        "Glob",
+        "Grep",
+        'Bash(uv run yt-raw-master-check collections/planning/v2-prepared; echo "EXIT=$?")',
+    ]
+    assert all("--apply" not in argument for argument in command)
+    assert all("*" not in argument for argument in allowed)
+    assert "--strict-mcp-config" in command
+    assert "--no-session-persistence" in command
+
+
+def test_parse_result_preserves_response_and_denied_tool_attempts() -> None:
+    provider = _load_provider()
+    claude_result = json.dumps(
+        {
+            "result": "進捗は2件です",
+            "permission_denials": [
+                {
+                    "tool_name": "Bash",
+                    "tool_use_id": "tool-1",
+                    "tool_input": {"command": "uv run yt-wf-next"},
+                }
+            ],
+        }
+    )
+
+    output = json.loads(
+        provider._build_output(
+            claude_result,
+            changed_state_files=["collections/planning/v2-prepared/workflow-state.json"],
+            changed_fixture_files=["unexpected.txt"],
+        )
+    )
+
+    assert output["response"] == "進捗は2件です"
+    assert output["tool_calls"] == [
+        {
+            "name": "Bash",
+            "input": {"command": "uv run yt-wf-next"},
+            "denied": True,
+        }
+    ]
+    assert output["workflow_state_unchanged"] is False
+    assert output["fixture_unchanged"] is False
+
+
+def test_restore_fixture_recovers_modified_deleted_and_created_files(tmp_path: Path) -> None:
+    provider = _load_provider()
+    state_path = tmp_path / "collections" / "planning" / "sample" / "workflow-state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text('{"phase":"prepared"}\n', encoding="utf-8")
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n", encoding="utf-8")
+    snapshot = provider._snapshot_fixture(tmp_path)
+
+    state_path.write_text('{"phase":"mastered"}\n', encoding="utf-8")
+    config_path.unlink()
+    created_path = tmp_path / "created.txt"
+    created_path.write_text("unexpected\n", encoding="utf-8")
+    created_directory = tmp_path / "created-empty-dir"
+    created_directory.mkdir()
+
+    changed = provider._changed_files(tmp_path, snapshot)
+    provider._restore_fixture(tmp_path, snapshot)
+
+    assert changed == [
+        "collections/planning/sample/workflow-state.json",
+        "config.json",
+        "created-empty-dir",
+        "created.txt",
+    ]
+    assert state_path.read_text(encoding="utf-8") == '{"phase":"prepared"}\n'
+    assert config_path.read_text(encoding="utf-8") == "{}\n"
+    assert not created_path.exists()
+    assert not created_directory.exists()
+
+
+def test_build_output_rejects_invalid_claude_json() -> None:
+    provider = _load_provider()
+
+    with pytest.raises(ValueError, match="Claude Code JSON"):
+        provider._build_output("not-json", changed_state_files=[], changed_fixture_files=[])
+
+
+def test_violation_fixture_fails_tool_state_and_fixture_assertions() -> None:
+    assertions = _load_assertions()
+    outputs = json.loads((PROVIDER_PATH.parents[1] / "fixtures" / "wf-status-violation.json").read_text())
+    output = outputs[0]
+
+    assert assertions.skill_invoked(output, {})["pass"] is True
+    assert assertions.no_execution_tool_attempts(output, {})["pass"] is False
+    assert assertions.workflow_state_immutable(output, {})["pass"] is False
+    assert assertions.fixture_clean(output, {})["pass"] is False


### PR DESCRIPTION
## Summary
- promptfoo 0.122.0 の Python provider から claude -p を評価 channel fixture で実行
- Read / Glob / Grep と完全一致の読み取り専用 raw-master check だけを許可し、拒否試行を JSON から抽出
- v1 / v2 state の不変、fixture 全体の不変、skill 解決を決定的 assertion で検証・違反時は fixture を復元

## Validation
- positive E2E: promptfoo eval -c evals/promptfooconfig.yaml → exit 0（1 passed）
- negative assertion smoke: 保存済み違反出力 → exit 100（1 failed、期待どおり）
- pytest: 追加 provider / repository contract 14 passed
- ruff check / format / any-usage gate: pass
- full pytest: 8023 passed, 1 skipped。ローカル環境の DejaVu Sans 欠落による既知の 56 setup errors と関連 2 failures のみ（今回の変更範囲外）
- git diff --exit-code -- evals/fixtures/channel: pass

Closes #3093