### PR TITLE
feat(channel-new): 新規設定を非公開既定にする (#3139)

### DIFF
--- a/.claude/skills/channel-new/references/config-generation-rules.md
+++ b/.claude/skills/channel-new/references/config-generation-rules.md
@@ -23,7 +23,7 @@
 - `content_model` — collection / release など
 - `music_engine` — `"suno"` または `"lyria"`（チャンネルのデフォルト音楽エンジン）
 - `genre` — primary, style, context
-- `youtube` — デフォルトのアップロード設定。アップロード metadata に使う `youtube.category_id` / `youtube.privacy_status` もここで決める
+- `youtube` — デフォルトのアップロード設定。アップロード metadata に使う `youtube.category_id` / `youtube.privacy_status` もここで決める。新規チャンネルの `privacy_status` は `private` とし、公開は予約公開またはアップロード後の手動公開で行う
 - `tags` — base, themes
 - `descriptions` — opening, sub_opening, perfect_for, hashtags
 - `analytics` — 計測対象の設定

--- a/.claude/skills/channel-new/references/config-template/youtube.json
+++ b/.claude/skills/channel-new/references/config-template/youtube.json
@@ -1,7 +1,7 @@
 {
   "youtube": {
     "category_id": "10",
-    "privacy_status": "public",
+    "privacy_status": "private",
     "language": "en"
   },
   "content_model": {

--- a/.claude/skills/channel-new/references/regeneration-mode.md
+++ b/.claude/skills/channel-new/references/regeneration-mode.md
@@ -87,7 +87,7 @@ self-check が pass したら提案をユーザーに見せ、承認 or 修正�
 | テーマ → アクティビティ・シーンの対応表 | `config/channel/content.json::title.theme_scenes`（TTP 形式・推奨）または `title.theme_activities`（レガシー） |
 | 投稿頻度 | `config/schedule_config.json`（Step R5） |
 | 音楽エンジン | `config/channel/youtube.json::music_engine`（`suno` / `lyria`） |
-| アップロード metadata | `config/channel/youtube.json::youtube.{category_id,privacy_status}` |
+| アップロード metadata | `config/channel/youtube.json::youtube.{category_id,privacy_status}`（新規生成時の `privacy_status` は `private`。公開は予約または手動） |
 | ジャンル / スタイル / コンテキスト | `config/channel/content.json::genre.{primary,style,context}` |
 
 `title.theme_scenes` を空で残すと `yt-populate-scene-phrases` が `--en` 手動指定を要求する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
 - `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。
+- `feat(channel-new)`: `yt-channel-init` と `/channel-new` が生成する新規チャンネル設定の `privacy_status` 既定を `private` にし、予約公開または手動公開を前提とする安全な初期状態へ変更（#3139）。
 - `fix(video-upload)`: 予約日時なしで `privacy_status=public` が指定されても即時公開せず private へ安全に降格し、plan・skill・予約公開ガイドを実挙動へ揃えた（#3138）。
 
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。

--- a/src/youtube_automation/commands/channel/channel_init_templates.py
+++ b/src/youtube_automation/commands/channel/channel_init_templates.py
@@ -90,7 +90,7 @@ def _render_youtube(ctx: ChannelInitContext) -> dict:
     return {
         "youtube": {
             "category_id": "10",
-            "privacy_status": "public",
+            "privacy_status": "private",
             "language": "en",
         },
         "content_model": {

--- a/tests/commands/channel/test_channel_init.py
+++ b/tests/commands/channel/test_channel_init.py
@@ -199,7 +199,7 @@ def test_youtube_json_has_expected_defaults(tmp_path):
     assert rc == 0
     youtube = _read_json(_channel_dir(tmp_path) / "youtube.json")
     assert youtube["youtube"]["category_id"] == "10"
-    assert youtube["youtube"]["privacy_status"] == "public"
+    assert youtube["youtube"]["privacy_status"] == "private"
     assert youtube["youtube"]["language"] == "en"
     assert youtube["music_engine"] == "suno"
 
@@ -1196,7 +1196,7 @@ def test_scaffold_output_is_loadable_by_new_config_loader(tmp_path, monkeypatch)
     assert config.meta.channel_name == "Demo Channel"
     assert config.meta.channel_short == "DEMO"
     assert config.youtube.api.category_id == "10"
-    assert config.youtube.api.privacy_status == "public"
+    assert config.youtube.api.privacy_status == "private"
     assert config.youtube.api.language == "en"
 
 


### PR DESCRIPTION
## 概要

新規チャンネル設定の `privacy_status` 既定を private にし、生成物と即時公開防止の実挙動を一致させます。

## 変更内容

- `yt-channel-init` の youtube.json 生成既定を private に変更
- `/channel-new` の配布テンプレートも private に統一
- config 生成・再生成ガイドを予約公開または手動公開前提へ更新
- scaffold と config loader の結合テストを更新

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 既存下流 config と public fixture は変更しない
- [x] 必要なテストを追加・更新した

## 検証

- channel init + skill docs tests: 140 passed
- `yt-skills lint`: 58 skills passed
- focused ruff check / format: passed

Closes #3139