### PR TITLE
fix(playlist): activity のカンマ区切りを受理 (#3099)

### DIFF
--- a/.claude/skills/channel-new/references/config-generation-rules.md
+++ b/.claude/skills/channel-new/references/config-generation-rules.md
@@ -66,6 +66,9 @@
 | `theme_scenes` | テーマ → アクティビティ + 英語シーンフレーズのマッピング（TTP 形式・推奨）。`{theme: {activities: "...", scene: "..."}}` 形式。`yt-populate-scene-phrases` の `--en` 自動補完に使われる |
 | `theme_activities` | テーマ → アクティビティのマッピング（レガシー形式）。`theme_scenes` 未設定のときのみ参照される |
 
+`activities` に複数の値を書く場合はカンマ区切り（例: `"Focus, Study, Writing"`）を使う。
+プレイリスト自動割り当ては既存 config の中黒区切り（`"Focus · Study · Writing"`）も受理する。
+
 `theme_scenes` / `theme_activities` をどちらも空のまま `/channel-new`（再生成モード）を抜けると
 下流 `yt-populate-scene-phrases` が手動 `--en` 指定を要求する。channel-direction.md で
 テーマ群が確定しているなら空のまま終了しないこと（issue #567）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
+- `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。
+
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
 - `feat(evals)`: promptfoo 0.122.0 から権限を読み取り専用へ制限した `claude -p` provider を起動し、v1 / v2 fixture 上の `/wf-status` が実行系 tool を試行せず `workflow-state.json` と fixture 全体を変更しないことをローカル E2E で検出できるようにした（#3093）。
 

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -145,8 +145,8 @@ class PlaylistManager:
                 matched.append(key)
                 continue
 
-            # activity ベースのマッチング（"Study · Focus · Late Night" → ["Study", "Focus", "Late Night"]）
-            activities = [a.strip() for a in activity.split("·")]
+            # 中黒は従来形式、カンマは channel-new の生成形式として下流 config に存在する。
+            activities = [a.strip() for a in activity.replace("·", ",").split(",")]
             if any(a in pl.get("auto_add_activities", []) for a in activities):
                 matched.append(key)
                 continue

--- a/tests/domains/uploads/test_playlist_manager.py
+++ b/tests/domains/uploads/test_playlist_manager.py
@@ -108,6 +108,15 @@ class TestResolvePlaylists:
         result = manager.resolve_playlists("battle arena")
         assert "battle" in result
 
+    @pytest.mark.parametrize("separator", ["·", ","])
+    def test_activity_matching_accepts_supported_separators(self, manager, separator):
+        """複数 activity は中黒とカンマのどちらでもマッチする."""
+        activity = separator.join(["Focus", "Gaming", "Writing"])
+
+        result = manager.resolve_playlists("battle arena", activity=activity)
+
+        assert "battle" in result
+
     def test_theme_keyword_matching(self, manager):
         """theme キーワードベースのマッチング"""
         result = manager.resolve_playlists("Deep Ocean Waves")


### PR DESCRIPTION
## Summary
- `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈する
- `auto_add_activities` の割り当て漏れを両区切りの回帰テストで固定する
- channel-new の生成ルールに推奨区切りと既存形式の受理を明記する

Closes #3099