### PR TITLE
feat(ci): skill e2e eval を workflow_dispatch と nightly で自動実行する

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,81 @@
+name: Skill E2E eval
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 18 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  auth-check:
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.auth.outputs.available }}
+    steps:
+      - name: Check Claude authentication
+        id: auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -n "$CLAUDE_CODE_OAUTH_TOKEN" || -n "$ANTHROPIC_API_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::Skill E2E eval skipped: neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is configured."
+          {
+            echo "## Skill E2E eval"
+            echo
+            echo "⏭️ Skipped: neither \`CLAUDE_CODE_OAUTH_TOKEN\` nor \`ANTHROPIC_API_KEY\` is configured."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  eval:
+    needs: auth-check
+    if: needs.auth-check.outputs.available == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - name: Install Claude Code
+        run: |
+          nix develop --command npm install --global --prefix "$RUNNER_TEMP/claude-code" @anthropic-ai/claude-code@2.1.226
+          echo "$RUNNER_TEMP/claude-code/bin" >> "$GITHUB_PATH"
+      - name: Run skill E2E eval
+        id: promptfoo
+        continue-on-error: true
+        run: |
+          mkdir -p evals/results
+          nix develop --command pnpm dlx promptfoo@0.122.0 eval \
+            -c evals/promptfooconfig.yaml \
+            --output evals/results/ci.json
+      - name: Summarize assertions
+        if: always()
+        run: |
+          {
+            echo "## Skill E2E eval"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ ! -f evals/results/ci.json ]]; then
+            echo "❌ No promptfoo result file was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          nix develop --command jq -r '
+            .results.results[]?.gradingResult.componentResults[]?
+            | "- \(if .pass then "✅" else "❌" end) `\(.assertion.metric // .assertion.value // .assertion.type)`: \(.reason)"
+          ' evals/results/ci.json >> "$GITHUB_STEP_SUMMARY"
+      - name: Fail when assertions fail
+        if: steps.promptfoo.outcome == 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
 - `feat(evals)`: promptfoo 0.122.0 から権限を読み取り専用へ制限した `claude -p` provider を起動し、v1 / v2 fixture 上の `/wf-status` が実行系 tool を試行せず `workflow-state.json` と fixture 全体を変更しないことをローカル E2E で検出できるようにした（#3093）。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,13 +131,13 @@ nix develop .#extensions --command pnpm -C site test
 
 ### 実 skill 挙動のローカル E2E
 
-`evals/` は、静的な skill lint / repository contract では検証できない LLM の実挙動を `promptfoo` + `claude -p` で確認する独立レーンです。モデル利用料金と Claude Code の認証を伴うため、`pytest` や CI からは起動しません。
+`evals/` は、静的な skill lint / repository contract では検証できない LLM の実挙動を `promptfoo` + `claude -p` で確認する独立レーンです。モデル利用料金と Claude Code の認証を伴うため、`pytest` や pull request CI からは起動しません。
 
 ```bash
 nix develop --command pnpm dlx promptfoo@0.122.0 eval -c evals/promptfooconfig.yaml
 ```
 
-現在の対象、権限制限、fixture 不変確認、禁止事項 assertion の検出力確認は [`evals/README.md`](../evals/README.md) を参照してください。
+GitHub Actions では独立した `evals.yml` を nightly / `workflow_dispatch` で起動します。Actions secret の `CLAUDE_CODE_OAUTH_TOKEN` または `ANTHROPIC_API_KEY` がどちらも未設定なら、有料の eval job を理由付きで skip します。現在の対象、権限制限、fixture 不変確認、禁止事項 assertion の検出力確認、CI の summary 契約は [`evals/README.md`](../evals/README.md) を参照してください。
 
 ### 1. 編集
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -35,3 +35,9 @@ nix develop --command pnpm dlx promptfoo@0.122.0 eval \
 ```
 
 promptfoo の履歴と cache は既定で `~/.promptfoo/` に保存されます。リポジトリ内へ明示出力する場合は ignore 済みの `evals/results/` を使ってください。
+
+## GitHub Actions
+
+`.github/workflows/evals.yml` は、この評価だけを毎日 18:17 UTC（03:17 JST）と `workflow_dispatch` で実行します。通常の pull request CI には含めません。認証には Actions secret の `CLAUDE_CODE_OAUTH_TOKEN` または `ANTHROPIC_API_KEY` を使用します。
+
+両方の secret が未設定なら、認証確認 job が理由を notice と `$GITHUB_STEP_SUMMARY` に記録し、有料の eval job を明示的に skip します。secret をリポジトリへ追加するまでは、手動実行もこの skip 契約の確認だけを行います。評価を実行した場合は assertion ごとの成否と理由を summary に記録し、失敗 assertion があれば workflow も失敗します。

--- a/tests/repo/test_evals_workflow.py
+++ b/tests/repo/test_evals_workflow.py
@@ -1,0 +1,83 @@
+"""有料の skill E2E eval を独立 workflow で安全に実行する契約。"""
+
+from __future__ import annotations
+
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/evals.yml"
+
+
+def _workflow() -> dict[str, object]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def test_evals_workflow_is_manual_and_nightly_but_not_a_pr_gate() -> None:
+    triggers = _triggers(_workflow())
+
+    assert set(triggers) == {"workflow_dispatch", "schedule"}
+    assert triggers["workflow_dispatch"] is None
+    assert triggers["schedule"] == [{"cron": "17 18 * * *"}]
+
+
+def test_missing_auth_explicitly_skips_the_paid_eval() -> None:
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    auth = jobs["auth-check"]
+    eval_job = jobs["eval"]
+    auth_step = auth["steps"][0]
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert auth["outputs"] == {"available": "${{ steps.auth.outputs.available }}"}
+    assert auth_step["env"] == {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+        "ANTHROPIC_API_KEY": "${{ secrets.ANTHROPIC_API_KEY }}",
+    }
+    auth_script = auth_step["run"]
+    assert "available=false" in auth_script
+    assert "::notice::" in auth_script
+    assert "GITHUB_STEP_SUMMARY" in auth_script
+    assert eval_job["needs"] == "auth-check"
+    assert eval_job["if"] == "needs.auth-check.outputs.available == 'true'"
+
+
+def test_authenticated_eval_uses_pinned_tools_and_reports_assertion_failures() -> None:
+    eval_job = _workflow()["jobs"]["eval"]
+    steps = eval_job["steps"]
+
+    assert steps[0]["uses"] == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    assert steps[1]["uses"] == "cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342"
+    assert "@anthropic-ai/claude-code@2.1.226" in steps[2]["run"]
+
+    promptfoo = next(step for step in steps if step.get("id") == "promptfoo")
+    assert promptfoo["continue-on-error"] is True
+    assert "pnpm dlx promptfoo@0.122.0 eval" in promptfoo["run"]
+    assert "-c evals/promptfooconfig.yaml" in promptfoo["run"]
+    assert "--output evals/results/ci.json" in promptfoo["run"]
+
+    summary = next(step for step in steps if step.get("name") == "Summarize assertions")
+    assert summary["if"] == "always()"
+    assert "GITHUB_STEP_SUMMARY" in summary["run"]
+    assert "gradingResult.componentResults" in summary["run"]
+    assert ".assertion.metric" in summary["run"]
+    assert ".reason" in summary["run"]
+
+    failure = steps[-1]
+    assert failure["if"] == "steps.promptfoo.outcome == 'failure'"
+    assert "exit 1" in failure["run"]
+
+
+def test_evals_remain_separate_from_the_required_ci_workflow() -> None:
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "promptfoo" not in ci
+    assert "evals/promptfooconfig.yaml" not in ci


### PR DESCRIPTION
## 概要

#3093 で追加した skill E2E eval を、必須 PR CI と分離した手動/nightly workflow から実行します。Claude 認証 secret が無い場合は有料 job を理由付きで明示的に skip します。

## 変更内容

- `workflow_dispatch` と毎日 18:17 UTC の schedule を持つ `evals.yml` を追加
- `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` の有無を先行 job で判定し、未設定理由を notice と Job Summary に記録
- promptfoo の assertion ごとの成否・理由を Job Summary に記録し、失敗を workflow status へ反映
- workflow の trigger・secret・pinning・failure propagation を repository contract test で固定
- 運用手順と CHANGELOG を更新（`ci.yml` と provider は変更なし）

## 検証

- [x] `nix develop --command uv run ruff check .`
- [x] `nix develop --command uv run ruff format --check .`
- [x] workflow / action pinning / CHANGELOG / any gate: 23 passed
- [x] 全 pytest を完走: 8043 passed, 1 skipped。ローカル Nix/macOS の DejaVu Sans 不在に起因する既知の 2 failed / 56 errors（変更範囲外）
- [x] branch ref の `workflow_dispatch` を実測: workflow が default branch に未掲載のため GitHub API が `HTTP 404: workflow evals.yml not found on the default branch` を返した。マージ前には run を生成できない制約を確認
- [x] Actions secrets 一覧は空。secret は作成せず、未設定時は `auth-check` が notice/summary を出して `eval` job を skip する契約を repository test で固定

## マージ後の実測

`evals.yml` が default branch に掲載された後、Actions secrets が空のまま `workflow_dispatch` を起動すると、`auth-check` は成功し `eval` job は理由付き skip になる設計です。マージ前は GitHub の default-branch 制約により dispatch run 自体を作成できません。

## 関連

Closes #3094
Depends on #3692