### PR TITLE
fix(automation-update): 保護対象skillをlocal fixから除外 (#3288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。
 - `feat(channel-new)`: `yt-channel-init` と `/channel-new` が生成する新規チャンネル設定の `privacy_status` 既定を `private` にし、予約公開または手動公開を前提とする安全な初期状態へ変更（#3139）。
 - `fix(video-upload)`: 予約日時なしで `privacy_status=public` が指定されても即時公開せず private へ安全に降格し、plan・skill・予約公開ガイドを実挙動へ揃えた（#3138）。
+- `fix(automation-update)`: `yt-skills diff` が未知の target-only 自作 skill を prune 保護対象として報告しただけの場合は local fix guard を通し、実差分がある場合だけ `--force-sync` を要求するようにした（#3288）。
 
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
 - `feat(evals)`: promptfoo 0.122.0 から権限を読み取り専用へ制限した `claude -p` provider を起動し、v1 / v2 fixture 上の `/wf-status` が実行系 tool を試行せず `workflow-state.json` と fixture 全体を変更しないことをローカル E2E で検出できるようにした（#3093）。

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -231,12 +231,12 @@ def _skills_diff_has_changes(root: Path) -> bool:
     output = "\n".join(part for part in [proc.stdout, proc.stderr] if part)
     local_fix_markers = (
         "内容が異なる",
-        "target にのみ存在",
         "target がファイルではありません",
     )
     safe_missing_markers = (
         "同梱版にのみ存在",
         "target が存在しません",
+        "target にのみ存在 (未知のローカル entry として prune から保護されます)",
     )
     known_markers = local_fix_markers + safe_missing_markers
     if proc.returncode != 0 and not any(marker in output for marker in known_markers):

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -865,6 +865,32 @@ def test_apply_local_fix_diff_requires_explicit_sync_decision(
     assert 'tag = "v5.5.0"' in (repo / "pyproject.toml").read_text(encoding="utf-8")
 
 
+def test_apply_allows_protected_local_skill_without_force_sync(
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(automation_update, "_run_command", lambda cmd, cwd: commands.append(cmd) or 0)
+    monkeypatch.setattr(automation_update, "_check_channel_config", lambda root: "config/channel/ ロード成功")
+    monkeypatch.setattr(automation_update, "_git_status_porcelain", lambda root: "")
+
+    def _diff_protected_local(*args, **kwargs):
+        return automation_update.subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=(
+                "target にのみ存在 (未知のローカル entry として prune から保護されます):\n"
+                "  - youtube-production-manager\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(automation_update.subprocess, "run", _diff_protected_local)
+
+    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0"]) == 0
+    assert commands
+
+
 def test_skills_diff_missing_target_is_not_local_fix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def _diff_missing(*args, **kwargs):
         return automation_update.subprocess.CompletedProcess(
@@ -875,6 +901,23 @@ def test_skills_diff_missing_target_is_not_local_fix(tmp_path: Path, monkeypatch
         )
 
     monkeypatch.setattr(automation_update.subprocess, "run", _diff_missing)
+
+    assert automation_update._skills_diff_has_changes(tmp_path) is False
+
+
+def test_skills_diff_protected_local_skill_is_not_local_fix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _diff_protected_local(*args, **kwargs):
+        return automation_update.subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=(
+                "target にのみ存在 (未知のローカル entry として prune から保護されます):\n"
+                "  - youtube-production-manager\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(automation_update.subprocess, "run", _diff_protected_local)
 
     assert automation_update._skills_diff_has_changes(tmp_path) is False
 


### PR DESCRIPTION
## Summary
- 未知の target-only 自作 skill の prune 保護報告を安全な差分として分類
- 実差分がない plain apply を --force-sync なしで継続
- guard 単体と apply 結合経路の回帰テストを追加

Closes #3288