### PR TITLE
fix(video-upload): 後処理失敗でも動画IDを保持する (#3289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(channel-new)`: `yt-channel-init` と `/channel-new` が生成する新規チャンネル設定の `privacy_status` 既定を `private` にし、予約公開または手動公開を前提とする安全な初期状態へ変更（#3139）。
 - `fix(video-upload)`: 予約日時なしで `privacy_status=public` が指定されても即時公開せず private へ安全に降格し、plan・skill・予約公開ガイドを実挙動へ揃えた（#3138）。
 - `fix(automation-update)`: `yt-skills diff` が未知の target-only 自作 skill を prune 保護対象として報告しただけの場合は local fix guard を通し、実差分がある場合だけ `--force-sync` を要求するようにした（#3288）。
+- `fix(video-upload)`: Complete Collection の upload 成功直後に video_id を tracking へ保存し、後処理失敗を partial として原因付きで記録する。`workflow-state.json` の `upload` 未作成も初回状態として受理する（#3289）。
 
 - `fix(video-upload)`: localizations title の 100 codepoint 超過診断に、実際の duration・activities 等を含む固定部分と scene phrase の codepoint 内訳を locale ごとに表示する（#3685）。
 - `feat(evals)`: promptfoo 0.122.0 から権限を読み取り専用へ制限した `claude -p` provider を起動し、v1 / v2 fixture 上の `/wf-status` が実行系 tool を試行せず `workflow-state.json` と fixture 全体を変更しないことをローカル E2E で検出できるようにした（#3093）。

--- a/src/youtube_automation/core/adapters/security.py
+++ b/src/youtube_automation/core/adapters/security.py
@@ -1,0 +1,5 @@
+"""Security adapter boundary for domain modules."""
+
+from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
+
+__all__ = ["redact_sensitive_data"]

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from youtube_automation.core.adapters import cost_tracker
 from youtube_automation.core.adapters.errors import AutomationError, QuotaExhaustedError
+from youtube_automation.core.adapters.security import redact_sensitive_data
 from youtube_automation.core.adapters.youtube import complete_collection_quota_plan, quota_shortages
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED,
@@ -31,6 +32,76 @@ _COMPLETE_COLLECTION_ERROR = "complete collection upload failed"
 
 class CompleteCollectionExecutorMixin:
     """Complete Collection アップロード実行ループを提供する mixin。"""
+
+    def _failed_complete_collection(self, collection_path: Path, tracking: dict, error: AutomationError) -> dict:
+        current = self._load_tracking(collection_path) or tracking
+        cc_current = current.setdefault("complete_collection", {})
+        cc_current["status"] = "failed"
+        cc_current["error"] = _COMPLETE_COLLECTION_ERROR
+        self._save_tracking(collection_path, current)
+        logger.error("❌ Complete Collection エラー: %s", redact_sensitive_data(str(error), collection_path))
+        return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
+
+    def _finish_uploaded_collection(
+        self,
+        collection_path: Path,
+        tracking: dict,
+        complete_video: dict,
+        publish_at: str | None,
+    ) -> dict:
+        tracking = {
+            **tracking,
+            "complete_collection": self._completed_tracking_record(complete_video, publish_at),
+            "status": TRACKING_STATUS_COMPLETED,
+        }
+        # YouTube 側の成功直後に正規状態を保存し、後処理失敗で video_id を失わない。
+        self._save_tracking(collection_path, tracking)
+
+        post_processing_errors: list[str] = []
+        if self.config["collections_management"].get("auto_move_to_live", True):
+            try:
+                collection_path = self._move_collection_to_live(collection_path)
+            except AutomationError as error:
+                post_processing_errors.append("move_to_live")
+                logger.error(
+                    "⚠️  Complete Collection 後処理エラー (move_to_live): %s",
+                    redact_sensitive_data(str(error), collection_path),
+                )
+
+        try:
+            self._update_workflow_upload(collection_path, complete_video, publish_at)
+        except AutomationError as error:
+            post_processing_errors.append("workflow_upload")
+            logger.error(
+                "⚠️  Complete Collection 後処理エラー (workflow_upload): %s",
+                redact_sensitive_data(str(error), collection_path),
+            )
+
+        try:
+            self._assign_to_playlists(complete_video["video_id"], collection_path)
+        except AutomationError as error:
+            post_processing_errors.append("playlist_assignment")
+            logger.error(
+                "⚠️  Complete Collection 後処理エラー (playlist_assignment): %s",
+                redact_sensitive_data(str(error), collection_path),
+            )
+
+        if post_processing_errors:
+            tracking["complete_collection"] = {
+                **tracking["complete_collection"],
+                "post_processing_status": "partial",
+                "post_processing_errors": post_processing_errors,
+            }
+        self._save_tracking(collection_path, tracking)
+
+        if complete_video.get("upload_source") == UPLOAD_SOURCE_EXISTING:
+            logger.info("⏭️  Complete Collection は既存動画を流用")
+            action = ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED
+        else:
+            logger.info("✅ Complete Collection アップロード完了")
+            action = ACTION_COMPLETE_COLLECTION_UPLOADED
+        logger.info(f"📹 {complete_video['video_url']}")
+        return {"action": action, "details": {**tracking["complete_collection"]}}
 
     def _execute_complete_collection(
         self, collection_path: Path, tracking: dict, publish_at: str | None = None
@@ -84,49 +155,6 @@ class CompleteCollectionExecutorMixin:
                 on_session_uri_changed=_on_session_uri_changed,
                 on_upload_complete=_on_upload_complete,
             )
-            complete_video = result.get("complete_video")
-
-            if complete_video and "video_id" in complete_video:
-                tracking = {
-                    **tracking,
-                    "complete_collection": self._completed_tracking_record(complete_video, publish_at),
-                    "status": TRACKING_STATUS_COMPLETED,
-                }
-
-                # live 移動
-                if self.config["collections_management"].get("auto_move_to_live", True):
-                    collection_path = self._move_collection_to_live(collection_path)
-
-                self._update_workflow_upload(collection_path, complete_video, publish_at)
-                self._save_tracking(collection_path, tracking)
-
-                if complete_video.get("upload_source") == UPLOAD_SOURCE_EXISTING:
-                    logger.info("⏭️  Complete Collection は既存動画を流用")
-                else:
-                    logger.info("✅ Complete Collection アップロード完了")
-                logger.info(f"📹 {complete_video['video_url']}")
-
-                # プレイリスト自動追加
-                self._assign_to_playlists(complete_video["video_id"], collection_path)
-
-                action = (
-                    ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED
-                    if complete_video.get("upload_source") == UPLOAD_SOURCE_EXISTING
-                    else ACTION_COMPLETE_COLLECTION_UPLOADED
-                )
-                return {"action": action, "details": {**tracking["complete_collection"]}}
-            else:
-                error_msg = _COMPLETE_COLLECTION_ERROR
-                # callback が disk に書いた URI 状態（session 失効クリア等）を保ったまま
-                # status 更新を載せるため、disk から再ロードしてから書き戻す。
-                current = self._load_tracking(collection_path) or tracking
-                cc_current = current.setdefault("complete_collection", {})
-                cc_current["status"] = "failed"
-                cc_current["error"] = error_msg
-                self._save_tracking(collection_path, current)
-                logger.error(f"❌ Complete Collection 失敗: {error_msg}")
-                return {"action": "complete_collection_failed", "details": {"error": error_msg}}
-
         except QuotaExhaustedError as e:
             # リトライ可能: tracking を failed にせず、resume URI（callback が永続化済み）を
             # 温存して次回実行に委ねる
@@ -135,15 +163,23 @@ class CompleteCollectionExecutorMixin:
                 "action": ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
                 "details": {"error": "quota exhausted", "retry_after_seconds": e.retry_after_seconds},
             }
-        except AutomationError:
-            # 例外パスでも callback が書いた disk 状態を尊重するため再ロード
-            current = self._load_tracking(collection_path) or tracking
-            cc_current = current.setdefault("complete_collection", {})
-            cc_current["status"] = "failed"
-            cc_current["error"] = _COMPLETE_COLLECTION_ERROR
-            self._save_tracking(collection_path, current)
-            logger.error("❌ Complete Collection エラー")
-            return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
+        except AutomationError as error:
+            return self._failed_complete_collection(collection_path, tracking, error)
+
+        complete_video = result.get("complete_video")
+        if complete_video and "video_id" in complete_video:
+            return self._finish_uploaded_collection(collection_path, tracking, complete_video, publish_at)
+
+        error_msg = _COMPLETE_COLLECTION_ERROR
+        # callback が disk に書いた URI 状態（session 失効クリア等）を保ったまま
+        # status 更新を載せるため、disk から再ロードしてから書き戻す。
+        current = self._load_tracking(collection_path) or tracking
+        cc_current = current.setdefault("complete_collection", {})
+        cc_current["status"] = "failed"
+        cc_current["error"] = error_msg
+        self._save_tracking(collection_path, current)
+        logger.error(f"❌ Complete Collection 失敗: {error_msg}")
+        return {"action": "complete_collection_failed", "details": {"error": error_msg}}
 
 
 __all__ = ["CompleteCollectionExecutorMixin"]

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -83,7 +83,7 @@ class TrackingIOMixin:
             return
 
         state = json.loads(read_file_text(ws_path))
-        upload = state.get("upload")
+        upload = state.get("upload", {})
         if not isinstance(upload, dict):
             raise ValidationError(f"workflow-state.json upload must be object: {ws_path}")
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -766,6 +766,66 @@ class TestExecuteCompleteCollectionResume:
             "publish_at": "2099-01-01T10:00:00+09:00",
         }
 
+    def test_should_initialize_missing_workflow_upload_when_complete_collection_succeeds(self, tmp_path):
+        """upload 未作成の workflow-state でも成功した video_id を記録する."""
+        col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
+        state_path = col / "workflow-state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state.pop("upload")
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
+        mock_inner.upload_collection.return_value = {
+            "complete_video": {
+                "video_id": "V_MISSING_UPLOAD",
+                "video_url": "https://www.youtube.com/watch?v=V_MISSING_UPLOAD",
+                "title": "t",
+                "file_path": "p",
+            }
+        }
+
+        result = uploader._execute_complete_collection(
+            col,
+            uploader._load_tracking(col),
+            publish_at="2099-01-01T10:00:00+09:00",
+        )
+
+        saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert result["action"] == "complete_collection_uploaded"
+        assert saved_state["upload"] == {
+            "video_id": "V_MISSING_UPLOAD",
+            "video_url": "https://www.youtube.com/watch?v=V_MISSING_UPLOAD",
+            "publish_at": "2099-01-01T10:00:00+09:00",
+        }
+
+    def test_should_preserve_uploaded_video_when_workflow_post_processing_fails(self, tmp_path, caplog):
+        """upload 成功後の workflow 更新失敗は partial とし、再 upload を誘発しない."""
+        from youtube_automation.core.errors import ValidationError
+
+        col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
+        uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
+        mock_inner.upload_collection.return_value = {
+            "complete_video": {
+                "video_id": "V_PRESERVED",
+                "video_url": "https://www.youtube.com/watch?v=V_PRESERVED",
+                "title": "t",
+                "file_path": "p",
+            }
+        }
+        diagnostic = "workflow-state.json upload must be object"
+
+        with patch.object(uploader, "_update_workflow_upload", side_effect=ValidationError(diagnostic)):
+            result = uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
+
+        tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert result["action"] == "complete_collection_uploaded"
+        assert result["details"]["video_id"] == "V_PRESERVED"
+        assert result["details"]["post_processing_status"] == "partial"
+        assert tracking["status"] == "completed"
+        assert tracking["complete_collection"]["status"] == "completed"
+        assert tracking["complete_collection"]["video_id"] == "V_PRESERVED"
+        assert tracking["complete_collection"]["post_processing_status"] == "partial"
+        assert any(diagnostic in record.getMessage() for record in caplog.records)
+
     def test_should_distinguish_dedup_skip_and_keep_tracking_workflow_consistent_after_live_move(self, tmp_path):
         """dedup skip 時も live 移動後の tracking/workflow-state に既存 video_id を記録する."""
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
@@ -1026,14 +1086,14 @@ class TestExecuteCompleteCollectionResume:
         # callback が既に永続化した resume URI は温存されている
         assert saved["complete_collection"]["resume_session_uri"] == _SESS_NEW
 
-    def test_complete_collection_failure_does_not_expose_exception_text(self, tmp_path, caplog):
-        """Complete Collection の失敗本文を tracking・結果・ログへ転送しない."""
+    def test_complete_collection_failure_logs_redacted_exception_text(self, tmp_path, caplog):
+        """Complete Collection の失敗原因を log に残し、secret は redaction する."""
         from youtube_automation.core.errors import AutomationError
 
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        canary = "access-token-domain-canary"
-        mock_inner.upload_collection.side_effect = AutomationError(canary)
+        secret = "secret-domain-canary"
+        mock_inner.upload_collection.side_effect = AutomationError(f"access_token={secret}")
 
         result = uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
 
@@ -1041,8 +1101,8 @@ class TestExecuteCompleteCollectionResume:
         tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
         assert tracking["complete_collection"]["error"] == "complete collection upload failed"
         error_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR]
-        assert error_messages == ["❌ Complete Collection エラー"]
-        assert all(canary not in message for message in error_messages)
+        assert error_messages == ["❌ Complete Collection エラー: access_token=<redacted-token>"]
+        assert all(secret not in message for message in error_messages)
 
 
 class TestShowPlanPrivacyDisplay:


### PR DESCRIPTION
## Summary
- workflow-state の upload 未作成を初回状態として受理する
- YouTube upload 成功直後に video_id を tracking へ永続化する
- 後処理失敗は redacted 診断付き partial とし、再 upload を防ぐ

Closes #3289