### PR TITLE
feat(dx): 進捗 hook の段分類と完了表示を追加 (#3291)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "Bash",
+        "matcher": "Bash|Task|Agent|Workflow",
         "hooks": [
           {
             "type": "command",
@@ -22,6 +22,15 @@
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Bash|Task|Agent|Workflow",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run yt-progress-hook"
+          }
+        ]
+      },
       {
         "matcher": "Edit|Write|NotebookEdit",
         "hooks": [

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -28,7 +28,18 @@
         ]
       },
       {
-        "matcher": "Bash",
+        "matcher": "Bash|Task|Agent|Workflow",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run yt-progress-hook"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Task|Agent|Workflow",
         "hooks": [
           {
             "type": "command",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
 - `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。

--- a/src/youtube_automation/commands/system/progress_hook/__init__.py
+++ b/src/youtube_automation/commands/system/progress_hook/__init__.py
@@ -1,36 +1,123 @@
-"""Claude Code のバックグラウンド Bash 開始時に進捗を表示する hook。"""
+"""Claude Code の長時間処理の開始・完了時に進捗を表示する hook。"""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
+import shlex
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import TextIO
 
-_PROGRESS = """```
-  ✓  企画
-  ✓  音源生成
-  ✓  マスター化
-  ▸  動画化
-  ○  サムネイル
-  ○  アップロード
-  ○  公開後処理
-  ○  分析
-```"""
+_STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
+_STAGE_COMMANDS = {
+    "音源生成": ("yt-generate-lyria-master", "yt-generate-suno", "yt-suno-unattended-request"),
+    "マスター化": ("yt-generate-master", "yt-finalize-master"),
+    "動画化": ("yt-generate-videos-batch", "yt-generate-loop-video", "ffmpeg"),
+    "サムネイル": ("yt-generate-image", "yt-thumbnail-text"),
+    "アップロード": ("yt-upload-collection", "yt-upload-auto", "yt-upload-shorts"),
+    "公開後処理": ("yt-pinned-comment", "yt-metadata-audit", "yt-comments-reply"),
+    "分析": ("yt-analytics", "yt-benchmark-collect", "yt-benchmark-comments", "yt-video-analyze"),
+}
+_AGENT_TOOLS = frozenset({"Task", "Agent", "Workflow"})
 
 
-def _is_background_bash(payload: object) -> bool:
-    if not isinstance(payload, Mapping) or payload.get("tool_name") != "Bash":
-        return False
+@dataclass(frozen=True)
+class _Invocation:
+    event: str
+    tool_name: str
+    tool_input: Mapping[object, object]
+    stage: str | None
+    command_name: str | None
+
+
+def _nonempty_string(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _classify_command(command: str | None) -> tuple[str | None, str | None]:
+    if command is None:
+        return None, None
+    for stage, command_names in _STAGE_COMMANDS.items():
+        for command_name in command_names:
+            if re.search(rf"(?<![\w-]){re.escape(command_name)}(?![\w-])", command):
+                return stage, command_name
+    return None, None
+
+
+def _parse_invocation(payload: object) -> _Invocation | None:
+    if not isinstance(payload, Mapping):
+        return None
+    tool_name = _nonempty_string(payload.get("tool_name"))
     tool_input = payload.get("tool_input")
-    return isinstance(tool_input, Mapping) and tool_input.get("run_in_background") is True
+    if tool_name is None or not isinstance(tool_input, Mapping):
+        return None
+    event = _nonempty_string(payload.get("hook_event_name")) or "PreToolUse"
+    command = _nonempty_string(tool_input.get("command"))
+    stage, command_name = _classify_command(command)
+    return _Invocation(event, tool_name, tool_input, stage, command_name)
+
+
+def _should_display(invocation: _Invocation) -> bool:
+    if invocation.event not in {"PreToolUse", "PostToolUse"}:
+        return False
+    if invocation.tool_name in _AGENT_TOOLS:
+        return True
+    if invocation.tool_name != "Bash":
+        return False
+    return invocation.stage is not None or invocation.tool_input.get("run_in_background") is True
+
+
+def _first_command_token(command: str | None) -> str:
+    if command is None:
+        return "Bash"
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    return tokens[0] if tokens else "Bash"
+
+
+def _unclassified_detail(invocation: _Invocation) -> str:
+    command = _nonempty_string(invocation.tool_input.get("command"))
+    subagent_type = _nonempty_string(invocation.tool_input.get("subagent_type"))
+    if invocation.tool_name == "Bash":
+        kind = _first_command_token(command)
+    else:
+        kind = subagent_type or invocation.tool_name
+    description = _nonempty_string(invocation.tool_input.get("description"))
+    return f"{kind} — {description}" if description is not None else kind
+
+
+def _render(invocation: _Invocation) -> str:
+    completed = invocation.event == "PostToolUse"
+    lines = ["```"]
+    if invocation.stage is None:
+        for index, stage in enumerate(_STAGES):
+            marker = "✓" if index <= 2 else "○"
+            lines.append(f"  {marker}  {stage}")
+        lines.append(f"  ⋯  {_unclassified_detail(invocation)}")
+    else:
+        current_index = _STAGES.index(invocation.stage)
+        for index, stage in enumerate(_STAGES):
+            if index < current_index or (completed and index == current_index):
+                marker = "✓"
+            elif index == current_index:
+                marker = "▸"
+            else:
+                marker = "○"
+            detail = f" — {invocation.command_name}" if index == current_index else ""
+            lines.append(f"  {marker}  {stage}{detail}")
+    lines.append("```")
+    return "\n".join(lines)
 
 
 def main(argv: Sequence[str] | None = None, *, stdin: TextIO | None = None) -> int:
-    """hook payload を読み、対象の Bash 開始時だけ進捗図を返す。"""
+    """hook payload を読み、表示対象の処理に進捗図を返す。"""
 
-    parser = argparse.ArgumentParser(description="バックグラウンド Bash 開始時の進捗図を claude.app へ表示する")
+    parser = argparse.ArgumentParser(description="長時間処理の進捗図を claude.app へ表示する")
     parser.parse_args(argv)
     source = stdin if stdin is not None else sys.stdin
     try:
@@ -38,6 +125,7 @@ def main(argv: Sequence[str] | None = None, *, stdin: TextIO | None = None) -> i
     except (json.JSONDecodeError, UnicodeDecodeError):
         return 0
 
-    if _is_background_bash(payload):
-        print(json.dumps({"systemMessage": _PROGRESS}, ensure_ascii=False))
+    invocation = _parse_invocation(payload)
+    if invocation is not None and _should_display(invocation):
+        print(json.dumps({"systemMessage": _render(invocation)}, ensure_ascii=False))
     return 0

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -7,17 +7,6 @@ import pytest
 
 from youtube_automation.commands.system import progress_hook
 
-EXPECTED_PROGRESS = """```
-  ✓  企画
-  ✓  音源生成
-  ✓  マスター化
-  ▸  動画化
-  ○  サムネイル
-  ○  アップロード
-  ○  公開後処理
-  ○  分析
-```"""
-
 
 def _run(payload: str, capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
     exit_code = progress_hook.main([], stdin=io.StringIO(payload))
@@ -33,7 +22,9 @@ def test_should_emit_progress_system_message_when_background_bash_starts(
     exit_code, stdout, stderr = _run(payload, capsys)
 
     assert exit_code == 0
-    assert json.loads(stdout) == {"systemMessage": EXPECTED_PROGRESS}
+    message = json.loads(stdout)["systemMessage"]
+    assert "▸" not in message
+    assert "  ⋯  Bash" in message
     assert stderr == ""
 
 
@@ -48,10 +39,126 @@ def test_should_emit_nothing_when_foreground_bash_starts(capsys: pytest.CaptureF
 
 
 @pytest.mark.parametrize(
+    ("command", "stage"),
+    [
+        ("uv run yt-generate-lyria-master", "音源生成"),
+        ("uv run yt-generate-suno", "音源生成"),
+        ("uv run yt-suno-unattended-request", "音源生成"),
+        ("uv run yt-generate-master", "マスター化"),
+        ("uv run yt-finalize-master", "マスター化"),
+        ("uv run yt-generate-videos-batch", "動画化"),
+        ("uv run yt-generate-loop-video", "動画化"),
+        ("ffmpeg -i input.mp3 output.mp4", "動画化"),
+        ("uv run yt-generate-image", "サムネイル"),
+        ("uv run yt-thumbnail-text", "サムネイル"),
+        ("uv run yt-upload-collection", "アップロード"),
+        ("uv run yt-upload-auto", "アップロード"),
+        ("uv run yt-upload-shorts", "アップロード"),
+        ("uv run yt-pinned-comment", "公開後処理"),
+        ("uv run yt-metadata-audit", "公開後処理"),
+        ("uv run yt-comments-reply", "公開後処理"),
+        ("uv run yt-analytics", "分析"),
+        ("uv run yt-benchmark-collect", "分析"),
+        ("uv run yt-benchmark-comments", "分析"),
+        ("uv run yt-video-analyze", "分析"),
+    ],
+)
+def test_should_mark_classified_stage_for_long_foreground_command(
+    command: str,
+    stage: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": command}})
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    message = json.loads(stdout)["systemMessage"]
+    assert exit_code == 0
+    assert f"  ▸  {stage} — {command.split()[2] if command.startswith('uv run ') else command.split()[0]}" in message
+    assert message.count("▸") == 1
+    assert stderr == ""
+
+
+def test_should_emit_unclassified_agent_work_with_description(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "Explore", "description": "hook 定義箇所を調査"},
+        }
+    )
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    message = json.loads(stdout)["systemMessage"]
+    assert exit_code == 0
+    assert "▸" not in message
+    assert "  ⋯  Explore — hook 定義箇所を調査" in message
+    assert stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "expected"),
+    [
+        ("Task", {"subagent_type": "general-purpose"}, "general-purpose"),
+        ("Workflow", {}, "Workflow"),
+        ("Bash", {"run_in_background": True, "command": "gh pr checks 42"}, "gh"),
+    ],
+)
+def test_should_use_nonempty_fallback_for_unclassified_work(
+    tool_name: str,
+    tool_input: dict[str, object],
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps({"hook_event_name": "PreToolUse", "tool_name": tool_name, "tool_input": tool_input})
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    message = json.loads(stdout)["systemMessage"]
+    assert exit_code == 0
+    assert f"  ⋯  {expected}" in message
+    assert stderr == ""
+
+
+def test_should_mark_classified_stage_complete_after_displayed_command_returns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ffmpeg -i input.mp3 output.mp4"},
+        }
+    )
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    message = json.loads(stdout)["systemMessage"]
+    assert exit_code == 0
+    assert "  ✓  動画化 — ffmpeg" in message
+    assert "▸" not in message
+    assert stderr == ""
+
+
+def test_should_emit_nothing_after_unclassified_foreground_command_returns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_input": {"command": "ls"}})
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         "not-json",
-        json.dumps({"tool_name": "Agent", "tool_input": {"run_in_background": True}}),
         json.dumps({"tool_name": "Bash", "tool_input": []}),
         json.dumps({"tool_name": "Bash", "tool_input": {"run_in_background": "true"}}),
     ],

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -57,11 +57,13 @@ def _session_context_command(settings: dict[str, object]) -> str:
     return commands[0]
 
 
-def _progress_hook_command(settings: dict[str, object]) -> str:
-    groups = settings["hooks"]["PreToolUse"]
-    commands = [hook["command"] for group in groups if group["matcher"] == "Bash" for hook in group["hooks"]]
-    assert commands == ["uv run yt-progress-hook"]
-    return commands[0]
+def _progress_hook_matchers(settings: dict[str, object], event: str) -> list[str]:
+    groups = settings["hooks"][event]
+    return [
+        group["matcher"]
+        for group in groups
+        if any(hook["command"] == "uv run yt-progress-hook" for hook in group["hooks"])
+    ]
 
 
 def test_settings_merge_preserves_local_values_and_accepts_hooks(tmp_path, monkeypatch) -> None:
@@ -127,13 +129,15 @@ def test_distributed_settings_include_background_progress_hook(tmp_path, monkeyp
     assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
 
     merged = json.loads(target.read_text(encoding="utf-8"))
-    assert _progress_hook_command(merged) == "uv run yt-progress-hook"
+    assert _progress_hook_matchers(merged, "PreToolUse") == ["Bash|Task|Agent|Workflow"]
+    assert _progress_hook_matchers(merged, "PostToolUse") == ["Bash|Task|Agent|Workflow"]
 
 
 def test_repository_settings_include_background_progress_hook() -> None:
     settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
 
-    assert _progress_hook_command(settings) == "uv run yt-progress-hook"
+    assert _progress_hook_matchers(settings, "PreToolUse") == ["Bash|Task|Agent|Workflow"]
+    assert _progress_hook_matchers(settings, "PostToolUse") == ["Bash|Task|Agent|Workflow"]
 
 
 def test_workspace_guard_hook_prefilters_unrelated_paths(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- PreToolUse の background Bash / Agent / Workflow と長時間前景コマンドを進捗表示対象へ拡張
- 20 コマンドを制作段へ分類し、未分類処理は description 付きの `⋯` 行で表示
- PostToolUse で開始時に表示した処理だけ完了状態を再描画

## Validation
- targeted: 44 passed
- full: 8140 passed, 1 skipped
- ruff check / format / Any usage gate: green

Closes #3291