### PR TITLE
fix(suno): semantic reviewをファイル単位へ集約 (#3301)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -76,6 +76,8 @@ Style プロンプト生成は generator に委譲し、品質検証は生成と
 
 generator は pattern draft、設定、benchmark analysis、必要な References を読んで `20-documentation/suno-prompts.md` と `20-documentation/suno-prompts.json` を作る。reviewer は生成時のメモや会話を読まず、成果物 `20-documentation/suno-prompts.json` と `/suno-lyric` の `references/review-rubric.md` のみを読んで検証する。`suno-prompts.json` の reviewer 入力は既存 consumer 互換の `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field に限定する。`/suno` reviewer は `review_context` を要求せず、不足する theme / scene / quote 情報を外部資料で補完しない。
 
+LLM semantic review はファイル単位で実行する。各 review round では `suno-prompts.json` 全体を 1 回の reviewer 呼び出しへ渡し、その 1 回で全 entry の判定を返させる。entry ごと・チャンクごとに reviewer を起動しない。複数 reviewer への分割や並列化もしない。`FAIL` entry を再生成した次の round でも、更新済みファイル全体を同じ 1 回の呼び出しで再検証する。
+
 検証順序は必ず直列にする:
 
 1. `uv run yt-suno-verify <collection-path>` を実行し、曲数・entry name・section tag・Style 文字数などの機械的検証が exit 0 で通過したことを確認する
@@ -500,7 +502,7 @@ override 後は `uv run yt-generate-suno` を再実行して `suno-prompts.json`
 uv run yt-suno-verify <collection-path>
 ```
 
-`suno-prompts.json` / `suno-lyrics.json` の展開後 entry 数、entry name、歌詞構造に加え、patterns root と使用中 variant、channel fallback を解決した effective Style の `genre_line` 文字数を検証し、exit 0 を確認する。その後、別コンテキスト reviewer が `suno-prompts.json` のみを読み、`.claude/skills/suno-lyric/references/review-rubric.md` に従って LLM semantic review を実行し、entry ごとに `PASS` / `FAIL` + 理由を出す。reviewer は `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field だけを判定材料にし、`review_context` 欠落を `/suno` entry の failure reason にしない。`FAIL` entry のみ最大 2 周まで generator subagent（Codex では別コンテキスト実行）に再生成させる。全 entry が `PASS` した後にだけ Suno UI へ投入する。上限到達時に `FAIL` が残る場合は Step 3 へ進まず、残課題をユーザーに提示する。
+`suno-prompts.json` / `suno-lyrics.json` の展開後 entry 数、entry name、歌詞構造に加え、patterns root と使用中 variant、channel fallback を解決した effective Style の `genre_line` 文字数を検証し、exit 0 を確認する。その後、別コンテキスト reviewer が `suno-prompts.json` 全体をファイル単位の 1 回の呼び出しで読み、`.claude/skills/suno-lyric/references/review-rubric.md` に従って LLM semantic review を実行し、全 entry の `PASS` / `FAIL` + 理由をまとめて出す。reviewer は `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field だけを判定材料にし、`review_context` 欠落を `/suno` entry の failure reason にしない。`FAIL` entry のみ最大 2 周まで generator subagent（Codex では別コンテキスト実行）に再生成させ、各 round は更新済み JSON 全体を reviewer 1 回で再検証する。全 entry が `PASS` した後にだけ Suno UI へ投入する。上限到達時に `FAIL` が残る場合は Step 3 へ進まず、残課題をユーザーに提示する。
 
 `yt-generate-suno` 自体は `workflow-state.json` を更新しない。`/suno` を呼び出したメインエージェント（`/wf-new` / `/wf-next` からの呼び出しと、`/suno` の直接実行を含む）が、生成された成果物、`yt-suno-verify` の成功、semantic review の全 entry `PASS` を確認した後にだけ、`assets.music_prompts = true`、`planning.music`、`updated_at` を更新する。subagent は state を書き込まない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dx)`: 進捗図 hook が `planning/`・`live/` の `workflow-state.json` と公開後履歴・分析レポートから実際の完了段を判定し、対象を特定できない場合も最新コレクションまたは固定表示へ安全にフォールバックするようにした（#3292）。
 - `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。
+- `fix(suno)`: generator→reviewer 品質ゲートの semantic review を entry / chunk ごとの複数起動から、全 `suno-prompts.json` を判定する round あたり 1 回のファイル単位呼び出しへ統一（#3301）。
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
 - `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。
 - `feat(channel-new)`: `yt-channel-init` と `/channel-new` が生成する新規チャンネル設定の `privacy_status` 既定を `private` にし、予約公開または手動公開を前提とする安全な初期状態へ変更（#3139）。

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -460,6 +460,20 @@ def test_suno_documents_pass_fail_loop_contract() -> None:
         assert token in text, f"/suno SKILL.md に PASS/FAIL ループ契約がない（`{token}` 不在）"
 
 
+def test_suno_semantic_review_uses_one_file_level_call_per_round() -> None:
+    """Issue #3301: /suno reviewer は entry ごとに起動せず全成果物を一括評価する。"""
+    text = _read()
+    quality_gate = text.split("### Generator-Reviewer Quality Gate", 1)[1].split("\n### ", 1)[0]
+
+    for token in (
+        "ファイル単位",
+        "1 回",
+        "全 entry",
+        "entry ごと・チャンクごとに reviewer を起動しない",
+    ):
+        assert token in quality_gate, f"/suno semantic review の一括呼び出し契約がない（`{token}` 不在）"
+
+
 def test_suno_documents_collection_local_effective_style_contract() -> None:
     """Issue #2999: collection 固有 Style を共有 config へ混ぜずに解決・検証する."""
     text = _read()


### PR DESCRIPTION
## Summary
- `suno-prompts.json` 全体を review round あたり 1 回の reviewer 呼び出しで判定する
- entry / chunk ごとの reviewer 起動と複数 reviewer への分割を禁止し、再生成後も全 entry を一括再検証する
- semantic review の実行契約を回帰テストで固定する

Closes #3301