### PR TITLE
feat(dx): 実データから進捗図の完了段を判定 (#3292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(dx)`: 進捗図 hook が `planning/`・`live/` の `workflow-state.json` と公開後履歴・分析レポートから実際の完了段を判定し、対象を特定できない場合も最新コレクションまたは固定表示へ安全にフォールバックするようにした（#3292）。
 - `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。

--- a/src/youtube_automation/commands/system/progress_hook/__init__.py
+++ b/src/youtube_automation/commands/system/progress_hook/__init__.py
@@ -11,7 +11,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TextIO
 
-_STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
+from youtube_automation.commands.system.progress_hook.workflow_state import STAGES as _STAGES
+from youtube_automation.commands.system.progress_hook.workflow_state import load_progress_snapshot
+
 _STAGE_COMMANDS = {
     "音源生成": ("yt-generate-lyria-master", "yt-generate-suno", "yt-suno-unattended-request"),
     "マスター化": ("yt-generate-master", "yt-finalize-master"),
@@ -31,6 +33,7 @@ class _Invocation:
     tool_input: Mapping[object, object]
     stage: str | None
     command_name: str | None
+    cwd: str | None
 
 
 def _nonempty_string(value: object) -> str | None:
@@ -57,7 +60,8 @@ def _parse_invocation(payload: object) -> _Invocation | None:
     event = _nonempty_string(payload.get("hook_event_name")) or "PreToolUse"
     command = _nonempty_string(tool_input.get("command"))
     stage, command_name = _classify_command(command)
-    return _Invocation(event, tool_name, tool_input, stage, command_name)
+    cwd = _nonempty_string(payload.get("cwd"))
+    return _Invocation(event, tool_name, tool_input, stage, command_name, cwd)
 
 
 def _should_display(invocation: _Invocation) -> bool:
@@ -93,16 +97,26 @@ def _unclassified_detail(invocation: _Invocation) -> str:
 
 def _render(invocation: _Invocation) -> str:
     completed = invocation.event == "PostToolUse"
+    command = _nonempty_string(invocation.tool_input.get("command"))
+    snapshot = load_progress_snapshot(invocation.cwd, command)
     lines = ["```"]
     if invocation.stage is None:
         for index, stage in enumerate(_STAGES):
-            marker = "✓" if index <= 2 else "○"
+            marker = (
+                "✓"
+                if (snapshot is not None and stage in snapshot.completed_stages) or (snapshot is None and index <= 2)
+                else "○"
+            )
             lines.append(f"  {marker}  {stage}")
         lines.append(f"  ⋯  {_unclassified_detail(invocation)}")
     else:
         current_index = _STAGES.index(invocation.stage)
         for index, stage in enumerate(_STAGES):
-            if index < current_index or (completed and index == current_index):
+            if snapshot is not None and not completed and index == current_index:
+                marker = "▸"
+            elif snapshot is not None:
+                marker = "✓" if stage in snapshot.completed_stages else "○"
+            elif index < current_index or (completed and index == current_index):
                 marker = "✓"
             elif index == current_index:
                 marker = "▸"

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -1,0 +1,189 @@
+"""下流チャンネルの正規状態から進捗図の完了段を解決する。"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
+
+# /wf-status が定義する v2 phase 語彙を正規の段判定にも使う。
+WF_STATUS_PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
+_POST_PUBLISH_STEPS = frozenset({"community-post", "pinned-comment", "metadata-audit"})
+_ANALYSIS_REPORT = re.compile(r"analysis_(\d{8})\.md\Z")
+
+
+@dataclass(frozen=True)
+class ProgressSnapshot:
+    """選択したコレクションから解決済みの完了段。"""
+
+    completed_stages: frozenset[str]
+
+
+def _read_object(path: Path) -> Mapping[object, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise ValueError(f"JSON root is not an object: {path}")
+    return value
+
+
+def _find_channel_root(cwd: Path) -> Path | None:
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / "collections").is_dir():
+            return candidate
+    return None
+
+
+def _state_paths(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for location in ("planning", "live"):
+        base = root / "collections" / location
+        if base.is_dir():
+            paths.extend(path for path in base.glob("*/workflow-state.json") if path.is_file())
+    return paths
+
+
+def _select_state(paths: list[Path], command: str | None) -> Path | None:
+    if not paths:
+        return None
+    if command is not None:
+        named = [path for path in paths if path.parent.name in command]
+        if named:
+            return max(named, key=lambda path: len(path.parent.name))
+    return max(paths, key=lambda path: path.stat().st_mtime_ns)
+
+
+def _skip_manual_mastering(root: Path) -> bool:
+    config_path = root / "config" / "channel" / "workflow.json"
+    if not config_path.is_file():
+        return False
+    config = _read_object(config_path)
+    workflow = config.get("workflow")
+    if not isinstance(workflow, Mapping):
+        raise ValueError("workflow must be an object")
+    wf_next = workflow.get("wf_next", {})
+    if not isinstance(wf_next, Mapping):
+        raise ValueError("workflow.wf_next must be an object")
+    value = wf_next.get("skip_manual_mastering", False)
+    if not isinstance(value, bool):
+        raise ValueError("workflow.wf_next.skip_manual_mastering must be boolean")
+    return value
+
+
+def _file_asset_present(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _thumbnail_present(value: object) -> bool:
+    return value is True or _file_asset_present(value)
+
+
+def _video_id(state: Mapping[object, object]) -> str | None:
+    upload = state.get("upload", {})
+    if not isinstance(upload, Mapping):
+        return None
+    value = upload.get("video_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _post_publish_complete(root: Path, video_id: str | None) -> bool:
+    if video_id is None:
+        return False
+    path = root / "post_publish_history.json"
+    if not path.is_file():
+        return False
+    history = _read_object(path)
+    videos = history.get("videos")
+    if not isinstance(videos, Mapping):
+        return False
+    video = videos.get(video_id)
+    if not isinstance(video, Mapping):
+        return False
+    completed = video.get("completed")
+    return (
+        isinstance(completed, Mapping)
+        and _POST_PUBLISH_STEPS.issubset(completed)
+        and all(isinstance(completed[step], str) and completed[step] for step in _POST_PUBLISH_STEPS)
+    )
+
+
+def _publish_date(state: Mapping[object, object]) -> date | None:
+    upload = state.get("upload", {})
+    if not isinstance(upload, Mapping):
+        return None
+    value = upload.get("publish_at")
+    if not isinstance(value, str) or not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+
+
+def _analysis_complete(root: Path, published_on: date | None) -> bool:
+    if published_on is None:
+        return False
+    reports = root / "reports"
+    if not reports.is_dir():
+        return False
+    for path in reports.glob("analysis_*.md"):
+        match = _ANALYSIS_REPORT.fullmatch(path.name)
+        if path.is_file() and match is not None:
+            try:
+                report_date = datetime.strptime(match.group(1), "%Y%m%d").date()
+            except ValueError:
+                continue
+            if report_date >= published_on:
+                return True
+    return False
+
+
+def _completed_stages(root: Path, state: Mapping[object, object]) -> frozenset[str]:
+    phase = state.get("phase")
+    if phase not in WF_STATUS_PHASES:
+        raise ValueError(f"unsupported workflow phase: {phase!r}")
+    assets = state.get("assets")
+    if not isinstance(assets, Mapping):
+        raise ValueError("assets must be an object")
+
+    completed: set[str] = set()
+    if phase != "planning":
+        completed.add("企画")
+    if _file_asset_present(assets.get("raw_master")):
+        completed.add("音源生成")
+    if _file_asset_present(assets.get("master_audio")) or (
+        _skip_manual_mastering(root) and _file_asset_present(assets.get("raw_master"))
+    ):
+        completed.add("マスター化")
+    if _file_asset_present(assets.get("video")) or _file_asset_present(assets.get("master_video")):
+        completed.add("動画化")
+    if _thumbnail_present(assets.get("thumbnail")):
+        completed.add("サムネイル")
+    if phase == "complete":
+        completed.add("アップロード")
+
+    video_id = _video_id(state)
+    if _post_publish_complete(root, video_id):
+        completed.add("公開後処理")
+    if _analysis_complete(root, _publish_date(state)):
+        completed.add("分析")
+    return frozenset(completed)
+
+
+def load_progress_snapshot(cwd: str | None, command: str | None) -> ProgressSnapshot | None:
+    """コレクションが無い、または状態を安全に読めない場合は fallback を指示する。"""
+
+    if cwd is None:
+        return None
+    try:
+        root = _find_channel_root(Path(cwd).resolve())
+        if root is None:
+            return None
+        state_path = _select_state(_state_paths(root), command)
+        if state_path is None:
+            return None
+        state = _read_object(state_path)
+        return ProgressSnapshot(_completed_stages(root, state))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        return None

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -2,16 +2,59 @@ from __future__ import annotations
 
 import io
 import json
+import os
+from pathlib import Path
 
 import pytest
 
+from tests.helpers.paths import FIXTURES_DIR
 from youtube_automation.commands.system import progress_hook
+
+_FIXTURES = FIXTURES_DIR / "progress_hook"
 
 
 def _run(payload: str, capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
     exit_code = progress_hook.main([], stdin=io.StringIO(payload))
     captured = capsys.readouterr()
     return exit_code, captured.out, captured.err
+
+
+def _write_collection(
+    channel: Path,
+    location: str,
+    name: str,
+    state: dict[str, object],
+    *,
+    modified_at: float | None = None,
+) -> Path:
+    collection = channel / "collections" / location / name
+    collection.mkdir(parents=True)
+    state_path = collection / "workflow-state.json"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    if modified_at is not None:
+        os.utime(state_path, (modified_at, modified_at))
+    return collection
+
+
+def _progress_message(
+    channel: Path,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    command: str = "uv run yt-generate-videos-batch",
+    event: str = "PreToolUse",
+) -> str:
+    payload = json.dumps(
+        {
+            "cwd": str(channel),
+            "hook_event_name": event,
+            "tool_name": "Bash",
+            "tool_input": {"command": command, "run_in_background": True},
+        }
+    )
+    exit_code, stdout, stderr = _run(payload, capsys)
+    assert exit_code == 0
+    assert stderr == ""
+    return json.loads(stdout)["systemMessage"]
 
 
 def test_should_emit_progress_system_message_when_background_bash_starts(
@@ -36,6 +79,251 @@ def test_should_emit_nothing_when_foreground_bash_starts(capsys: pytest.CaptureF
     assert exit_code == 0
     assert stdout == ""
     assert stderr == ""
+
+
+def test_should_keep_fixed_pipeline_when_repository_has_no_collections(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    message = _progress_message(tmp_path, capsys, command="gh pr checks 42")
+
+    assert "  ✓  マスター化" in message
+    assert "  ○  動画化" in message
+    assert "  ⋯  gh" in message
+
+
+def test_should_mark_real_asset_stages_from_workflow_state(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = json.loads((_FIXTURES / "workflow-state-mastered.json").read_text(encoding="utf-8"))
+    _write_collection(tmp_path, "planning", "mastered-collection", state)
+
+    message = _progress_message(tmp_path, capsys)
+
+    assert "  ✓  企画" in message
+    assert "  ✓  音源生成" in message
+    assert "  ✓  マスター化" in message
+    assert "  ▸  動画化" in message
+    assert "  ✓  サムネイル" in message
+    assert "  ○  アップロード" in message
+
+
+def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "new-collection",
+        {
+            "phase": "prepared",
+            "assets": {"raw_master": None, "master_audio": None, "video": None, "thumbnail": None},
+        },
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-generate-master")
+
+    assert "  ✓  企画" in message
+    assert "  ○  音源生成" in message
+    assert "  ▸  マスター化" in message
+    assert "  ○  動画化" in message
+
+
+def test_should_use_raw_master_for_mastering_when_manual_mastering_is_skipped(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "raw-final",
+        {
+            "phase": "prepared",
+            "assets": {"raw_master": "raw.wav", "master_audio": None},
+        },
+    )
+    config_dir = tmp_path / "config" / "channel"
+    config_dir.mkdir(parents=True)
+    (config_dir / "workflow.json").write_text(
+        json.dumps({"workflow": {"wf_next": {"skip_manual_mastering": True}}}),
+        encoding="utf-8",
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-generate-videos-batch")
+
+    assert "  ✓  マスター化" in message
+
+
+def test_should_prefer_named_collection_across_planning_and_live(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "newer-incomplete",
+        {"phase": "prepared", "assets": {"raw_master": None}},
+        modified_at=200,
+    )
+    _write_collection(
+        tmp_path,
+        "live",
+        "selected-live",
+        {
+            "phase": "complete",
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "video": "video.mp4"},
+        },
+        modified_at=100,
+    )
+
+    message = _progress_message(
+        tmp_path,
+        capsys,
+        command="uv run yt-analytics collections/live/selected-live",
+    )
+
+    assert "  ✓  アップロード" in message
+    assert "  ▸  分析" in message
+
+
+def test_should_use_latest_workflow_state_when_command_does_not_name_collection(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "older-complete",
+        {"phase": "complete", "assets": {"raw_master": "raw.wav"}},
+        modified_at=100,
+    )
+    _write_collection(
+        tmp_path,
+        "live",
+        "newer-incomplete",
+        {"phase": "planning", "assets": {"raw_master": None}},
+        modified_at=200,
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-generate-master")
+
+    assert "  ○  企画" in message
+    assert "  ▸  マスター化" in message
+
+
+def test_should_mark_post_publish_and_analysis_from_channel_artifacts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    collection = _write_collection(
+        tmp_path,
+        "live",
+        "published",
+        {
+            "phase": "complete",
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "video": "video.mp4"},
+            "upload": {"video_id": "video-123", "publish_at": "2026-07-20T12:00:00+09:00"},
+        },
+    )
+    assert collection.is_dir()
+    (tmp_path / "post_publish_history.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "videos": {
+                    "video-123": {
+                        "completed": {
+                            "community-post": "2026-07-20T00:00:00+00:00",
+                            "pinned-comment": "2026-07-20T00:01:00+00:00",
+                            "metadata-audit": "2026-07-20T00:02:00+00:00",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "analysis_20260719.md").write_text("old", encoding="utf-8")
+    (reports / "analysis_20260720.md").write_text("current", encoding="utf-8")
+
+    message = _progress_message(
+        tmp_path,
+        capsys,
+        command="uv run yt-analytics published",
+        event="PostToolUse",
+    )
+
+    assert "  ✓  公開後処理" in message
+    assert "  ✓  分析" in message
+
+
+def test_should_not_complete_post_publish_for_other_video_or_analysis_before_publish(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "live",
+        "published",
+        {
+            "phase": "complete",
+            "assets": {},
+            "upload": {"video_id": "target-video", "publish_at": "2026-07-20T12:00:00+09:00"},
+        },
+    )
+    (tmp_path / "post_publish_history.json").write_text(
+        json.dumps(
+            {
+                "videos": {
+                    "other-video": {
+                        "completed": {
+                            "community-post": "done",
+                            "pinned-comment": "done",
+                            "metadata-audit": "done",
+                        }
+                    },
+                    "target-video": {
+                        "completed": {
+                            "community-post": "done",
+                            "pinned-comment": "done",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "analysis_20261340.md").write_text("invalid date", encoding="utf-8")
+    (reports / "analysis_20260719.md").write_text("too old", encoding="utf-8")
+
+    message = _progress_message(tmp_path, capsys, command="gh pr checks 42")
+
+    assert "  ○  公開後処理" in message
+    assert "  ○  分析" in message
+
+
+@pytest.mark.parametrize("bad_state", ["not-json", "[]", '{"phase":"prepared","assets":[]}'])
+def test_should_fall_back_to_fixed_pipeline_when_workflow_state_is_invalid(
+    tmp_path: Path,
+    bad_state: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    collection = tmp_path / "collections" / "planning" / "broken"
+    collection.mkdir(parents=True)
+    (collection / "workflow-state.json").write_text(bad_state, encoding="utf-8")
+
+    message = _progress_message(tmp_path, capsys, command="gh pr checks 42")
+
+    assert "  ✓  企画" in message
+    assert "  ✓  マスター化" in message
+    assert "  ○  動画化" in message
+    assert "  ⋯  gh" in message
 
 
 @pytest.mark.parametrize(

--- a/tests/fixtures/progress_hook/workflow-state-mastered.json
+++ b/tests/fixtures/progress_hook/workflow-state-mastered.json
@@ -1,0 +1,15 @@
+{
+  "collection_name": "Mastered Collection",
+  "phase": "mastered",
+  "updated_at": "2026-08-01T00:00:00+00:00",
+  "assets": {
+    "raw_master": "raw.wav",
+    "master_audio": "master.wav",
+    "video": null,
+    "thumbnail": true
+  },
+  "upload": {
+    "video_id": null,
+    "publish_at": null
+  }
+}


### PR DESCRIPTION
## Summary
- `collections/planning/` と `collections/live/` の workflow-state / assets から対象コレクションと完了段を判定
- post-publish 履歴と分析 reports を反映し、進捗図の `✓/○` とコレクション名を実状態へ接続
- 状態なし・破損時も hook を阻害しない fail-open と fixture 契約を追加

## Validation
- targeted: 42 passed
- full: 8151 passed, 1 skipped
- ruff check / format / Any usage gate: green

Closes #3292