### PR TITLE
fix(suno): generator入力コンテキストを限定する (#3302)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -74,7 +74,26 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 Style プロンプト生成は generator に委譲し、品質検証は生成とは別コンテキストの reviewer が行う。Claude Code では subagent 起動として扱い、Codex では同等の別エージェント / 別コンテキスト実行に読み替える。
 
-generator は pattern draft、設定、benchmark analysis、必要な References を読んで `20-documentation/suno-prompts.md` と `20-documentation/suno-prompts.json` を作る。reviewer は生成時のメモや会話を読まず、成果物 `20-documentation/suno-prompts.json` と `/suno-lyric` の `references/review-rubric.md` のみを読んで検証する。`suno-prompts.json` の reviewer 入力は既存 consumer 互換の `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field に限定する。`/suno` reviewer は `review_context` を要求せず、不足する theme / scene / quote 情報を外部資料で補完しない。
+generator は下記の bounded context だけを読み、`20-documentation/suno-prompts.md` と `20-documentation/suno-prompts.json` を作る。
+
+#### Generator context budget
+
+generator を起動する前に、呼び出し元が次の manifest を collection 境界で 1 回だけ解決する。generator は source file を探索せず、この範囲を越えて入力を増やさない。
+
+| source | generator へ渡す範囲 |
+|---|---|
+| `20-documentation/suno-patterns.yaml` | pattern draft 全体（collection-local の正規入力） |
+| Suno skill config | `genre_line`、`exclude_styles`、使用中 variant、文字数 budget、生成数など今回の出力へ効く effective key と値だけ |
+| `docs/channel/creative-constraints.md` | `## 音` section だけ。ファイル全文を読まない |
+| `data/video_analysis/<slug>/*.json` | `suno_preset` / `bgm_arc` / `scene_timeline[].summary` の projection だけ。元 JSON 全文を読まない |
+| `data/insights.jsonl` | validator 通過後の open `lever=bgm` entry だけ |
+| skill References | 適用する quality rule の該当 section だけ。例示集・rubric 全文を先回りで読まない |
+
+benchmark の Markdown analysis、他 lever の insight、`config/channel/` 全体、別 collection の資料は generator 入力にしない。必要な field / section は呼び出し元が抽出して一度に渡し、生成中の各 entry や再生成 round で同じ資料を読み直さない。必須 field が projection に無い場合は原典を丸ごと読むのではなく、欠けた field 名を呼び出し元へ返して manifest を 1 回だけ更新する。
+
+#### Reviewer context budget
+
+reviewer は生成時のメモや会話を読まず、成果物 `20-documentation/suno-prompts.json` と `/suno-lyric` の `references/review-rubric.md` のみを読んで検証する。`suno-prompts.json` の reviewer 入力は既存 consumer 互換の `name`, `style`, `lyrics` と、存在する場合のみ More Options 補助 field に限定する。`/suno` reviewer は `review_context` を要求せず、不足する theme / scene / quote 情報を外部資料で補完しない。
 
 LLM semantic review はファイル単位で実行する。各 review round では `suno-prompts.json` 全体を 1 回の reviewer 呼び出しへ渡し、その 1 回で全 entry の判定を返させる。entry ごと・チャンクごとに reviewer を起動しない。複数 reviewer への分割や並列化もしない。`FAIL` entry を再生成した次の round でも、更新済みファイル全体を同じ 1 回の呼び出しで再検証する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。
 - `fix(suno)`: generator→reviewer 品質ゲートの semantic review を entry / chunk ごとの複数起動から、全 `suno-prompts.json` を判定する round あたり 1 回のファイル単位呼び出しへ統一（#3301）。
+- `fix(suno)`: generator subagent の入力を collection pattern、effective config key、音制約、benchmark JSON の必要 field、open BGM insight に限定し、分析・設定ファイル全文の反復読み込みを防ぐ bounded context 契約を追加（#3302）。
 - `feat(ci)`: skill E2E eval を pull request CI から分離した `workflow_dispatch` / nightly workflow で実行し、Claude 認証 secret 未設定時は理由を summary に残して有料 job を明示的に skip する（#3094）。
 - `fix(playlist)`: `theme_scenes.activities` のカンマ区切りと中黒区切りを同じ複数 activity として解釈し、`auto_add_activities` によるプレイリスト割り当て漏れを防止（#3099）。
 - `feat(channel-new)`: `yt-channel-init` と `/channel-new` が生成する新規チャンネル設定の `privacy_status` 既定を `private` にし、予約公開または手動公開を前提とする安全な初期状態へ変更（#3139）。

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -474,6 +474,23 @@ def test_suno_semantic_review_uses_one_file_level_call_per_round() -> None:
         assert token in quality_gate, f"/suno semantic review の一括呼び出し契約がない（`{token}` 不在）"
 
 
+def test_suno_generator_uses_a_bounded_context_manifest() -> None:
+    """Issue #3302: generator は必要な field / section だけを入力にする。"""
+    text = _read()
+    context_contract = text.split("#### Generator context budget", 1)[1].split("\n#### ", 1)[0]
+
+    for token in (
+        "`20-documentation/suno-patterns.yaml`",
+        "effective key",
+        "`## 音`",
+        "`suno_preset` / `bgm_arc` / `scene_timeline[].summary`",
+        "`lever=bgm`",
+        "全文を読まない",
+        "同じ資料を読み直さない",
+    ):
+        assert token in context_contract, f"/suno generator の bounded context 契約がない（`{token}` 不在）"
+
+
 def test_suno_documents_collection_local_effective_style_contract() -> None:
     """Issue #2999: collection 固有 Style を共有 config へ混ぜずに解決・検証する."""
     text = _read()


### PR DESCRIPTION
## Summary

- generator subagent の入力を collection-local pattern と出力に必要な effective key / section に限定
- benchmark analysis・設定全体・別 collection の資料を入力から除外し、entry / 再生成 round ごとの再読を禁止
- bounded context manifest の配布契約をテストで固定

Closes #3302