### PR TITLE
feat(doctor): yt-doctor が下流 config の旧 preview 画像モデル指定を検知して警告する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。
 - `feat(dx)`: 進捗図 hook が `planning/`・`live/` の `workflow-state.json` と公開後履歴・分析レポートから実際の完了段を判定し、対象を特定できない場合も最新コレクションまたは固定表示へ安全にフォールバックするようにした（#3292）。
 - `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -105,6 +105,10 @@ UPLOAD_REQUIRED_SCOPES = [
 UNSUPPORTED_VIDEO_ANALYZE_MODELS = {
     "gemini-3.5-flash",
 }
+UNSUPPORTED_THUMBNAIL_MODELS = {
+    "gemini-3.1-flash-image-preview",
+    "gemini-3-pro-image-preview",
+}
 
 MAX_DISPLAY_VALUE_LEN = 120
 GCP_PROJECT_ID_RE = re.compile(r"[a-z][a-z0-9-]{4,28}[a-z0-9]\Z")
@@ -1879,6 +1883,12 @@ def _missing_ttp_readiness_items(channel_dir: Path, channels: list[dict[str, obj
     thumbnail_read = _skill_config_mapping(channel_dir, "thumbnail")
     if thumbnail_read.error:
         missing.append(thumbnail_read.error)
+    thumbnail_override = _read_yaml_mapping(channel_dir / "config" / "skills" / "thumbnail.yaml").data
+    image_generation = thumbnail_override.get("image_generation")
+    gemini = image_generation.get("gemini") if isinstance(image_generation, dict) else None
+    model = gemini.get("model") if isinstance(gemini, dict) else None
+    if isinstance(model, str) and model in UNSUPPORTED_THUMBNAIL_MODELS:
+        missing.append(f"thumbnail model が旧/非対応: {model}")
     if "thumbnail" not in approved_exceptions:
         thumbnail_missing = _thumbnail_ttp_reference_missing_reason(channel_dir, thumbnail_read.data)
         if thumbnail_missing:

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -4570,6 +4570,47 @@ class TestCheckTtpWfNewReadinessChannelNew:
         assert r.status == "warn"
         assert "video-analyze model が旧/非対応: gemini-3.5-flash" in r.message
 
+    @pytest.mark.parametrize(
+        "model",
+        ["gemini-3.1-flash-image-preview", "gemini-3-pro-image-preview"],
+    )
+    def test_explicit_old_thumbnail_model_warns(self, tmp_path, model):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        config_path = tmp_path / "config" / "skills" / "thumbnail.yaml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                "  gemini:\n",
+                f"  gemini:\n    model: {model}\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert f"thumbnail model が旧/非対応: {model}" in r.message
+
+    @pytest.mark.parametrize("model", [None, "gemini-3.1-flash-image"])
+    def test_supported_or_implicit_thumbnail_model_does_not_warn(self, tmp_path, model):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        if model is not None:
+            config_path = tmp_path / "config" / "skills" / "thumbnail.yaml"
+            config_path.write_text(
+                config_path.read_text(encoding="utf-8").replace(
+                    "  gemini:\n",
+                    f"  gemini:\n    model: {model}\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert "thumbnail model が旧/非対応" not in r.message
+
     def test_suno_long_genre_line_warns_even_with_variants(self, tmp_path):
         _write_ttp_analytics(tmp_path, [_ttp_channel()])
         _write_ttp_readiness_files(tmp_path)


### PR DESCRIPTION
## Summary
- 下流 thumbnail override に明示された廃止済み preview 画像モデルを `yt-doctor` で警告
- 配布既定値だけを使う場合と GA モデル指定は警告しない境界を回帰テストで固定

Closes #3304