### PR TITLE
chore(gemini): Vertex AI既定モデルをGA世代へ移行 (#3306)

### DIFF
--- a/.claude/skills/benchmark/config.default.yaml
+++ b/.claude/skills/benchmark/config.default.yaml
@@ -22,7 +22,7 @@ gemini_thumbnail_analysis: false
 
 # Gemini サムネイル分析の詳細設定（gemini_thumbnail_analysis: true 時のみ使用）
 thumbnail_analysis:
-  model: gemini-2.5-flash
+  model: gemini-3.5-flash
   delay_sec: 5  # API レート制限対策の待機秒数
   # Gemini に渡すプロンプト。チャンネルのジャンル/世界観に合わせて
   # config/skills/benchmark.yaml で上書きを推奨。

--- a/.claude/skills/collection-ideate/config.default.yaml
+++ b/.claude/skills/collection-ideate/config.default.yaml
@@ -107,4 +107,4 @@ self_check:
   # 不合格時の再生成最大回数。0 にすると warn 表示のみで再生成しない。
   max_regeneration_attempts: 0
   # Gemini モデル (vision/text)。未指定なら video-analyze と同じデフォルトを使う。
-  model: "gemini-2.5-flash"
+  model: "gemini-3.5-flash"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。
+- `chore(gemini)`: Vertex AI の `global` endpoint で画像・テキスト入力に対応する GA 世代 `gemini-3.5-flash` を thumbnail-check、benchmark サムネイル解析、collection-ideate の既定モデルへ採用し、ELA 移行予定の `gemini-2.5-flash` から移行（#3306）。
 - `feat(dx)`: 進捗図 hook が `planning/`・`live/` の `workflow-state.json` と公開後履歴・分析レポートから実際の完了段を判定し、対象を特定できない場合も最新コレクションまたは固定表示へ安全にフォールバックするようにした（#3292）。
 - `feat(dx)`: 進捗図 hook を subagent / workflow・分類済み前景処理・完了時にも発火させ、実行コマンドに対応する段または具体的な未分類作業を表示（#3291）。
 - `feat(dx)`: バックグラウンド Bash 開始時に固定パイプラインの進捗図を Claude Code hook の `systemMessage` で claude.app へ表示する `yt-progress-hook` CLI を追加（#3290）。

--- a/src/youtube_automation/commands/analytics/benchmark_collector.py
+++ b/src/youtube_automation/commands/analytics/benchmark_collector.py
@@ -717,13 +717,16 @@ class BenchmarkCollector:
         logger.info("サムネイルDL: %d 件（スキップ: %d 件）→ %s", downloaded, skipped, thumbnails_dir)
 
 
+_DEFAULT_THUMBNAIL_ANALYSIS_MODEL = "gemini-3.5-flash"
+
+
 class BenchmarkThumbnailAnalyzer:
     """ベンチマークサムネイルの Gemini 分析"""
 
     def __init__(self, benchmarks_dir: Path):
         self.benchmarks_dir = benchmarks_dir
         cfg = load_skill_config("benchmark").get("thumbnail_analysis", {})
-        self.model = cfg.get("model", "gemini-2.5-flash")
+        self.model = cfg.get("model", _DEFAULT_THUMBNAIL_ANALYSIS_MODEL)
         self.delay_sec = float(cfg.get("delay_sec", 5))
         self.prompt = cfg.get("prompt", "").strip()
 
@@ -1377,7 +1380,7 @@ def main():
     if args.no_thumbnails:
         print("  サムネイル分析: OFF（--no-thumbnails）")
     elif analyze_thumbnails:
-        model = collector.benchmark_config.get("thumbnail_analysis", {}).get("model", "gemini-2.5-flash")
+        model = collector.benchmark_config.get("thumbnail_analysis", {}).get("model", _DEFAULT_THUMBNAIL_ANALYSIS_MODEL)
         print(f"  サムネイル分析: Gemini ({model}) — Vertex AI 課金が発生します")
     else:
         print("  サムネイル分析: ON（エージェント — 追加課金なし）")

--- a/src/youtube_automation/commands/thumbnail/thumbnail_check.py
+++ b/src/youtube_automation/commands/thumbnail/thumbnail_check.py
@@ -41,7 +41,7 @@ from youtube_automation.infrastructure.media.composition_lock import build_self_
 logger = logging.getLogger(__name__)
 
 SKILL_NAME = "collection-ideate"
-_DEFAULT_MODEL = "gemini-2.5-flash"
+_DEFAULT_MODEL = "gemini-3.5-flash"
 
 # benchmark_collector.py:561-563 / video_analyzer と同方式のコードフェンス除去
 _CODE_FENCE_HEAD = re.compile(r"^```(?:json)?\s*")

--- a/tests/commands/analytics/test_benchmark_collector_channels_batch.py
+++ b/tests/commands/analytics/test_benchmark_collector_channels_batch.py
@@ -118,6 +118,13 @@ def _thumbnail_data() -> dict:
 
 
 class TestBenchmarkThumbnailAnalyzer:
+    def test_uses_vertex_ga_default_when_model_is_unspecified(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(benchmark_collector, "load_skill_config", lambda _skill: {})
+
+        analyzer = BenchmarkThumbnailAnalyzer(tmp_path)
+
+        assert analyzer.model == "gemini-3.5-flash"
+
     def test_missing_genai_dependency_preserves_collected_data(self, monkeypatch, tmp_path):
         analyzer = _thumbnail_analyzer(monkeypatch, tmp_path)
         data = _thumbnail_data()

--- a/tests/commands/thumbnail/test_thumbnail_check_cli.py
+++ b/tests/commands/thumbnail/test_thumbnail_check_cli.py
@@ -44,6 +44,14 @@ def test_resolve_check_config_normalizes_non_mapping_no_logo_guard(monkeypatch):
     assert resolved["no_logo_guard"] == {}
 
 
+def test_resolve_check_config_uses_vertex_ga_default_when_model_is_unspecified(monkeypatch):
+    monkeypatch.setattr(thumbnail_check, "load_skill_config", lambda _name: {})
+
+    resolved = thumbnail_check._resolve_check_config(None)
+
+    assert resolved["model"] == "gemini-3.5-flash"
+
+
 # ---------------------------------------------------------------------------
 # _parse_json_response
 # ---------------------------------------------------------------------------
@@ -105,7 +113,7 @@ def test_check_image_passes_when_all_yes(tmp_path):
             }
         )
     )
-    result = thumbnail_check._check_image(image_path=image, prompt="prompt", client=client, model="gemini-2.5-flash")
+    result = thumbnail_check._check_image(image_path=image, prompt="prompt", client=client, model="gemini-test")
     assert result.passed is True
     assert len(result.checks) == 2
     assert result.error is None


### PR DESCRIPTION
## Summary
- thumbnail-check / benchmark / collection-ideate の Vertex AI 既定モデルを `gemini-3.5-flash` へ移行
- global endpoint のモデル取得と text/image の `count_tokens` で入力対応を確認
- 課金を伴う3入口の実生成は未実施

## Verification
- 対象テスト 62件
- ruff check / format / skill lint
- full pytest: 8,158 passed, 1 skipped（専用 MPLCONFIGDIR）

Closes #3306
