### PR TITLE
chore(gemini): video-analyzeをGAモデルへ移行 (#3307)

### DIFF
--- a/.claude/skills/video-analyze/SKILL.md
+++ b/.claude/skills/video-analyze/SKILL.md
@@ -112,7 +112,7 @@ skill-config (`.claude/skills/video-analyze/config.default.yaml`):
 
 | 項目 | 既定 | 説明 |
 |---|---|---|
-| `model` | `gemini-2.5-flash` | 動画入力対応 Gemini モデル |
+| `model` | `gemini-3.5-flash` | Vertex AI global endpoint の動画入力対応 GA Gemini モデル |
 | `delay_sec` | 10 | 動画間の API レート対策ウェイト (秒) |
 | `analysis_window_sec` | 900 | 解析するクリップ窓 (秒)。動画冒頭からこの秒数のみ Gemini に渡す。bool ではない正の整数のみ有効 |
 | `prompt` | 汎用プロンプト | ジャンル/世界観に合わせて `config/skills/video-analyze.yaml` で上書き推奨 |

--- a/.claude/skills/video-analyze/config.default.yaml
+++ b/.claude/skills/video-analyze/config.default.yaml
@@ -4,7 +4,7 @@
 # チャンネル側では config/skills/video-analyze.yaml に上書き値を置く。
 
 # Gemini モデル名 (動画入力対応モデルを指定)
-model: gemini-2.5-flash
+model: gemini-3.5-flash
 
 # API レート制限対策の動画間ウェイト (秒)
 delay_sec: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `chore(gemini)`: video-analyze の既定を Vertex AI `global` endpoint で動画入力に対応する GA 世代 `gemini-3.5-flash` へ移行し、`yt-doctor` の非対応判定から同モデルを除外。動画入力非対応の画像生成 preview モデルを診断対象に更新（#3307）。
 - `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。
 - `chore(gemini)`: Vertex AI の `global` endpoint で画像・テキスト入力に対応する GA 世代 `gemini-3.5-flash` を thumbnail-check、benchmark サムネイル解析、collection-ideate の既定モデルへ採用し、ELA 移行予定の `gemini-2.5-flash` から移行（#3306）。
 - `feat(dx)`: 進捗図 hook が `planning/`・`live/` の `workflow-state.json` と公開後履歴・分析レポートから実際の完了段を判定し、対象を特定できない場合も最新コレクションまたは固定表示へ安全にフォールバックするようにした（#3292）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -103,7 +103,7 @@ UPLOAD_REQUIRED_SCOPES = [
 ]
 
 UNSUPPORTED_VIDEO_ANALYZE_MODELS = {
-    "gemini-3.5-flash",
+    "gemini-3.1-flash-image-preview",
 }
 UNSUPPORTED_THUMBNAIL_MODELS = {
     "gemini-3.1-flash-image-preview",

--- a/tests/commands/analytics/test_video_analyze_cli.py
+++ b/tests/commands/analytics/test_video_analyze_cli.py
@@ -426,7 +426,7 @@ class TestMainPassesAnalysisWindow:
     def test_analysis_window_sec_flows_from_cfg_to_analyzer(self, tmp_path):
         # Given: skill-config が窓幅 600 を返す (境界で 1 度だけ解決する既存方針)
         cfg = {
-            "model": "gemini-2.5-flash",
+            "model": "gemini-3.5-flash",
             "prompt": "analyze",
             "delay_sec": 0,
             "analysis_window_sec": 600,
@@ -450,6 +450,13 @@ class TestMainPassesAnalysisWindow:
 
 
 class TestAnalysisWindowSkillConfig:
+    def test_default_model_supports_video_on_vertex_global_endpoint(self, tmp_path):
+        # Given: チャンネル側 override なし
+        cfg = load_skill_config("video-analyze", use_cache=False, channel_dir=tmp_path)
+
+        # Then: Vertex AI global endpoint の動画入力対応 GA モデル
+        assert cfg["model"] == "gemini-3.5-flash"
+
     def test_default_window_is_900(self, tmp_path):
         # Given: チャンネル側 override なし
         cfg = load_skill_config("video-analyze", use_cache=False, channel_dir=tmp_path)
@@ -475,7 +482,7 @@ class TestAnalysisWindowValidation:
     def test_rejects_non_positive_or_non_int_window(self, value):
         # Given: skill-config から読み込まれた契約外の窓幅
         cfg = {
-            "model": "gemini-2.5-flash",
+            "model": "gemini-3.5-flash",
             "prompt": "analyze",
             "delay_sec": 0,
             "analysis_window_sec": value,

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -4557,7 +4557,20 @@ class TestCheckTtpWfNewReadinessChannelNew:
         assert r.status == "warn"
         assert "data/video_analysis の channel_dir 外参照を拒否" in r.message
 
-    def test_old_video_analyze_model_warns(self, tmp_path):
+    def test_video_input_unsupported_model_warns(self, tmp_path):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        (tmp_path / "config" / "skills" / "video-analyze.yaml").write_text(
+            "model: gemini-3.1-flash-image-preview\n",
+            encoding="utf-8",
+        )
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert "video-analyze model が旧/非対応: gemini-3.1-flash-image-preview" in r.message
+
+    def test_video_input_supported_ga_model_does_not_warn(self, tmp_path):
         _write_ttp_analytics(tmp_path, [_ttp_channel()])
         _write_ttp_readiness_files(tmp_path)
         (tmp_path / "config" / "skills" / "video-analyze.yaml").write_text(
@@ -4567,8 +4580,7 @@ class TestCheckTtpWfNewReadinessChannelNew:
 
         r = doctor.check_ttp_wf_new_readiness(tmp_path)
 
-        assert r.status == "warn"
-        assert "video-analyze model が旧/非対応: gemini-3.5-flash" in r.message
+        assert "video-analyze model が旧/非対応" not in r.message
 
     @pytest.mark.parametrize(
         "model",


### PR DESCRIPTION
## Summary
- video-analyze の既定を `gemini-3.5-flash` へ移行
- doctor の対応・非対応モデル判定を新既定と整合
- 公式 Vertex AI サンプルで global endpoint の動画入力対応を確認（課金を伴う実生成は未実施）

## Verification
- 対象テスト 442件
- ruff check / format / skill lint
- full pytest: 8,165 passed

Closes #3307
