### PR TITLE
fix(suno): exclude_styles の分析 fallback を撤去 (#3311)

### DIFF
--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -179,7 +179,7 @@ jq -c 'select(.status == "open" and .lever == "bgm")' data/insights.jsonl
 
 ### Suno プリセット推奨（suno_preset fallback）
 
-`20-documentation/suno-patterns.yaml` の root 値があれば collection-local override として最優先する。root に無いキーは `config/skills/suno.yaml` の channel 共通値へ fallback し、その対応キーも空のときだけ `data/video_analysis/<slug>/*.json` の `suno_preset.genre_line` / `suno_preset.exclude_styles` を `uv run yt-generate-suno` が全 slug 横断で集約して採用する。これにより既存の channel override 優先も維持する（後方互換）。
+`20-documentation/suno-patterns.yaml` の root 値があれば collection-local override として最優先する。root に無いキーは `config/skills/suno.yaml` の channel 共通値へ fallback する。`genre_line` は対応キーも空のときだけ `data/video_analysis/<slug>/*.json` の `suno_preset.genre_line` を `uv run yt-generate-suno` が全 slug 横断で集約して採用する。`exclude_styles` は video_analysis から継承せず、config が空なら空のまま扱う。
 
 > **推奨であり必須ではない**: collection 固有の方向性が確定している場合は、generator が根拠を示して `suno-patterns.yaml::genre_line` へ直接書く。共有 `config/skills/suno.yaml` へ collection 固有値を転記しない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。
 - `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
+- `fix(suno)`: `exclude_styles` が空のときに video_analysis の全 slug から除外語を集約する fallback を撤去し、空設定を空のまま出力へ反映する（#3311）。
 - `chore(gemini)`: video-analyze の既定を Vertex AI `global` endpoint で動画入力に対応する GA 世代 `gemini-3.5-flash` へ移行し、`yt-doctor` の非対応判定から同モデルを除外。動画入力非対応の画像生成 preview モデルを診断対象に更新（#3307）。
 - `breaking(thumbnail)`: 利用実績のない `gemini_cli` 画像 provider と subprocess 実装を削除し、指定時は `gemini`（Vertex AI）への移行先を明示する `ConfigError` で停止する（#3308）。
 - `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -376,15 +376,15 @@ def _build_advanced_json_fields(override: dict) -> dict:
 
     - override に明示されたキーのみ含める (default.yaml の既定値は無視、#900 の A 案)
     - vocal_gender は "" を「未指定」として skip する (拡張型契約と一貫させる)
-    - 他キー (style_influence: 0 / weirdness: 0 / exclude_styles: "") は明示設定なら値そのまま wire
-      (0 などの falsy 境界値が脱落しない契約は #900 で pin 済み)
+    - style_influence / weirdness の 0 は明示設定なら値そのまま wire
+    - exclude_styles の空文字は未指定として skip する
     """
     out: dict = {}
     for key in _ADVANCED_JSON_KEYS:
         if key not in override:
             continue
         value = override[key]
-        if key == "vocal_gender" and value == "":
+        if key in {"exclude_styles", "vocal_gender"} and value == "":
             continue
         out[key] = value
     return out
@@ -847,7 +847,7 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
                 "lyrics": lyrics,
             }
             # More Options 3 フィールド (#900)。channel override に明示されたキーのみ collection
-            # スコープで全 entry に載せる。0 や "" の falsy 値も有効値なので無条件に反映する
+            # スコープで全 entry に載せる。0 の falsy 値も有効値なので無条件に反映する
             # (gating は resolve 段で `key in override` 済み)。
             entry.update(resolved.advanced_json_fields)
             entries.append(entry)

--- a/src/youtube_automation/domains/suno/config.py
+++ b/src/youtube_automation/domains/suno/config.py
@@ -50,11 +50,11 @@ class ResolvedSunoConfig:
 
 
 def resolve_suno_config(suno_cfg: Mapping[str, object]) -> ResolvedSunoConfig:
-    fallback_genre, fallback_exclude = collect_video_analysis_suno_presets()
+    fallback_genre = collect_video_analysis_genre_line()
     return ResolvedSunoConfig(
         raw=suno_cfg,
         genre_line=str(suno_cfg.get("genre_line") or fallback_genre),
-        exclude_styles=str(suno_cfg.get("exclude_styles") or fallback_exclude),
+        exclude_styles=str(suno_cfg.get("exclude_styles") or ""),
     )
 
 
@@ -64,17 +64,15 @@ def infer_suno_mode(genre_line: str) -> str:
     return "vocal" if _VOCAL_PATTERN.search(genre_line) else "instrumental"
 
 
-def collect_video_analysis_suno_presets() -> tuple[str, str]:
+def collect_video_analysis_genre_line() -> str:
     try:
         base = channel_dir() / "data" / VIDEO_ANALYSIS_DIRNAME
     except ConfigError:
-        return "", ""
+        return ""
     if not base.exists():
-        return "", ""
+        return ""
 
     genre_counter: Counter[str] = Counter()
-    exclude_seen: dict[str, None] = {}
-
     for slug_dir in sorted(base.iterdir()):
         if not slug_dir.is_dir():
             continue
@@ -88,11 +86,8 @@ def collect_video_analysis_suno_presets() -> tuple[str, str]:
                 continue
             for phrase in _split_csv(preset.get("genre_line", "")):
                 genre_counter[phrase] += 1
-            for phrase in _split_csv(preset.get("exclude_styles", "")):
-                exclude_seen.setdefault(phrase, None)
 
-    top_genre = ", ".join(phrase for phrase, _ in genre_counter.most_common(_TOP_GENRE_PHRASES))
-    return top_genre, ", ".join(exclude_seen)
+    return ", ".join(phrase for phrase, _ in genre_counter.most_common(_TOP_GENRE_PHRASES))
 
 
 def _split_csv(value: object) -> list[str]:

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -483,27 +483,26 @@ def test_fallback_uses_video_analysis_genre_line_when_config_empty(channel_dir, 
     assert "warm rhodes" in output
 
 
-def test_fallback_uses_video_analysis_exclude_styles_when_config_empty(channel_dir, tmp_path):
-    """`config/skills/suno.yaml` 空欄時、video_analysis JSON の exclude_styles を採用."""
-    _write_suno_override(channel_dir, genre_line="lo-fi jazz")  # exclude_styles だけ空
+def test_empty_config_does_not_inherit_video_analysis_exclude_styles(channel_dir, tmp_path):
+    """空の channel 設定へ video_analysis の exclude_styles を継承しない."""
+    _write_suno_override(channel_dir, genre_line="lo-fi jazz", exclude_styles="")
     _write_video_analysis(
         channel_dir,
         slug="ref-channel",
         video_id="vid001",
         suno_preset={
             "genre_line": "ignored",
-            "exclude_styles": "heavy metal, EDM, dubstep",
+            "exclude_styles": "forbidden benchmark style",
             "rationale": "",
         },
     )
     patterns_path = _write_minimal_patterns(tmp_path)
 
     output = generate(patterns_path)
+    entries = build_prompt_entries(patterns_path)
 
-    assert "**Exclude Styles:**" in output
-    assert "heavy metal" in output
-    assert "EDM" in output
-    assert "dubstep" in output
+    assert "**Exclude Styles:**" not in output
+    assert all("exclude_styles" not in entry for entry in entries)
 
 
 def test_default_exclude_styles_prevent_sudden_transitions_without_using_style_budget(channel_dir, tmp_path):
@@ -562,8 +561,8 @@ def test_missing_suno_preset_falls_back_silently(channel_dir, tmp_path):
 
 
 def test_aggregates_multiple_video_analysis_jsons(channel_dir, tmp_path):
-    """2 slug × 複数 JSON で genre_line 多数決・exclude_styles 和集合が機能する."""
-    _write_suno_override(channel_dir)  # 空 override で fallback 強制
+    """2 slug × 複数 JSON では genre_line だけを多数決で集約する."""
+    _write_suno_override(channel_dir, exclude_styles="")
 
     # slug A: 2 件、共通 "lo-fi jazz" / 各自固有句あり
     _write_video_analysis(
@@ -607,10 +606,7 @@ def test_aggregates_multiple_video_analysis_jsons(channel_dir, tmp_path):
     assert "warm rhodes" in output
     assert "mellow drums" in output
 
-    # exclude_styles: 和集合で重複排除されつつ全種が現れる
-    assert "heavy metal" in output
-    assert "EDM" in output
-    assert "dubstep" in output
+    assert "**Exclude Styles:**" not in output
 
     # genre_line の出現順は多数決優先 — "lo-fi jazz" が他の単発句より先
     lo_fi_idx = output.find("lo-fi jazz")


### PR DESCRIPTION
## Summary
- `exclude_styles` が空の場合に video_analysis の除外語を集約する fallback を撤去
- 空の channel 設定では Markdown の Exclude Styles 欄と JSON の `exclude_styles` key を出力しない
- `genre_line` の video_analysis fallback は維持し、skill 契約と回帰テストを更新

Closes #3311