### PR TITLE
analytics: ads-per-playbackを収集する

### DIFF
--- a/.claude/skills/analytics-collect/SKILL.md
+++ b/.claude/skills/analytics-collect/SKILL.md
@@ -161,7 +161,8 @@ subagent へは次を具体値で渡す:
 ### 収益メトリクス
 
 `yt-analytics` は基本メトリクスとは別クエリで
-`estimatedRevenue` / `monetizedPlaybacks` / `cpm` / `playbackBasedCpm` を収集する。
+`estimatedRevenue` / `monetizedPlaybacks` / `adImpressions` / `cpm` / `playbackBasedCpm` を収集する。
+日別・動画別に `adImpressions / monetizedPlaybacks` の `ads_per_playback` も保存する。
 成果物では `revenue_analytics.daily_metrics` と `revenue_analytics.by_video` に保存し、
 各行の `rpm` は `estimated_revenue / views * 1000` で算出する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
 - `chore(gemini)`: video-analyze の既定を Vertex AI `global` endpoint で動画入力に対応する GA 世代 `gemini-3.5-flash` へ移行し、`yt-doctor` の非対応判定から同モデルを除外。動画入力非対応の画像生成 preview モデルを診断対象に更新（#3307）。
 - `breaking(thumbnail)`: 利用実績のない `gemini_cli` 画像 provider と subprocess 実装を削除し、指定時は `gemini`（Vertex AI）への移行先を明示する `ConfigError` で停止する（#3308）。
 - `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
 
 
 class RevenueAnalyticsMixin:
@@ -81,16 +81,24 @@ class RevenueAnalyticsMixin:
         dimension = str(row[0])
         views = int(row[1])
         estimated_revenue = float(row[2])
+        monetized_playbacks = int(row[3])
+        ad_impressions = int(row[4])
         return {
             dimension_key: dimension,
             "views": views,
             "estimated_revenue": estimated_revenue,
-            "monetized_playbacks": int(row[3]),
-            "cpm": float(row[4]),
-            "playback_based_cpm": float(row[5]),
+            "monetized_playbacks": monetized_playbacks,
+            "ad_impressions": ad_impressions,
+            "ads_per_playback": RevenueAnalyticsMixin._calculate_ads_per_playback(ad_impressions, monetized_playbacks),
+            "cpm": float(row[5]),
+            "playback_based_cpm": float(row[6]),
             "rpm": RevenueAnalyticsMixin._calculate_rpm(estimated_revenue, views),
         }
 
     @staticmethod
     def _calculate_rpm(estimated_revenue: float, views: int) -> float:
         return estimated_revenue / views * 1000 if views else 0.0
+
+    @staticmethod
+    def _calculate_ads_per_playback(ad_impressions: int, monetized_playbacks: int) -> float:
+        return ad_impressions / monetized_playbacks if monetized_playbacks else 0.0

--- a/tests/domains/analytics/mixins/test_revenue_analytics.py
+++ b/tests/domains/analytics/mixins/test_revenue_analytics.py
@@ -22,11 +22,11 @@ def test_collects_daily_and_video_revenue_metrics():
         {
             "currency": "USD",
             "rows": [
-                ["2026-07-01", 2000, 10.0, 1000, 12.5, 10.0],
-                ["2026-07-02", 3000, 21.0, 1500, 14.0, 12.0],
+                ["2026-07-01", 2000, 10.0, 1000, 2500, 12.5, 10.0],
+                ["2026-07-02", 3000, 21.0, 1500, 4500, 14.0, 12.0],
             ],
         },
-        {"rows": [["video-1", 1000, 8.0, 600, 13.0, 11.0]]},
+        {"rows": [["video-1", 1000, 8.0, 600, 1800, 13.0, 11.0]]},
     ]
     service.query.reset_mock()
 
@@ -36,11 +36,15 @@ def test_collects_daily_and_video_revenue_metrics():
     assert result["currency"] == "USD"
     assert result["daily_metrics"][0]["estimated_revenue"] == 10.0
     assert result["daily_metrics"][0]["rpm"] == 5.0
+    assert result["daily_metrics"][0]["ad_impressions"] == 2500
+    assert result["daily_metrics"][0]["ads_per_playback"] == 2.5
     assert result["by_video"]["video-1"] == {
         "video_id": "video-1",
         "views": 1000,
         "estimated_revenue": 8.0,
         "monetized_playbacks": 600,
+        "ad_impressions": 1800,
+        "ads_per_playback": 3.0,
         "cpm": 13.0,
         "playback_based_cpm": 11.0,
         "rpm": 8.0,
@@ -52,7 +56,7 @@ def test_collects_daily_and_video_revenue_metrics():
         "rpm": 6.2,
     }
     assert service.query.call_args_list[0].kwargs["metrics"] == (
-        "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+        "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
     )
 
 
@@ -72,14 +76,16 @@ def test_monetary_api_failure_warns_and_returns_unavailable(caplog):
 def test_zero_views_and_empty_responses_have_stable_available_summary():
     zero_service = MagicMock()
     zero_service.query.side_effect = [
-        {"currency": "JPY", "rows": [["2026-07-01", 0, 0.0, 0, 0.0, 0.0]]},
-        {"rows": [["video-1", 0, 0.0, 0, 0.0, 0.0]]},
+        {"currency": "JPY", "rows": [["2026-07-01", 0, 0.0, 0, 3, 0.0, 0.0]]},
+        {"rows": [["video-1", 0, 0.0, 0, 3, 0.0, 0.0]]},
     ]
 
     zero = DummyCollector(zero_service).get_revenue_analytics("2026-07-01", "2026-07-01")
 
     assert zero["daily_metrics"][0]["rpm"] == 0.0
+    assert zero["daily_metrics"][0]["ads_per_playback"] == 0.0
     assert zero["by_video"]["video-1"]["rpm"] == 0.0
+    assert zero["by_video"]["video-1"]["ads_per_playback"] == 0.0
     assert zero["summary"]["rpm"] == 0.0
 
     empty_service = MagicMock()

--- a/tests/test_analytics_cli_integration.py
+++ b/tests/test_analytics_cli_integration.py
@@ -42,7 +42,7 @@ class _AnalyticsReports:
             return _Request({"rows": [["VIDEO_1", "2026-04-01", 100]]})
         if dimensions == "video":
             if "estimatedRevenue" in metrics:
-                return _Request({"rows": [["VIDEO_1", 100, 2.5, 80, 4.0, 5.0]]})
+                return _Request({"rows": [["VIDEO_1", 100, 2.5, 80, 160, 4.0, 5.0]]})
             if metrics.startswith("views,estimatedMinutesWatched"):
                 return _Request({"rows": [["VIDEO_1", 100, 500, 120, 5, 0, 1, 2, 4]]})
             return _Request({"rows": [["VIDEO_1", 100, 5, 1, 500]]})
@@ -53,7 +53,7 @@ class _AnalyticsReports:
         if dimensions == "day" and metrics.startswith("views,estimatedMinutesWatched,averageViewDuration"):
             return _Request({"rows": [["2026-04-01", 100, 500, 120, 4, 0, 5, 0, 1, 2, 50, 0, 0, 0]]})
         if dimensions == "day" and "estimatedRevenue" in metrics:
-            return _Request({"rows": [["2026-04-01", 100, 2.5, 80, 4.0, 5.0]]})
+            return _Request({"rows": [["2026-04-01", 100, 2.5, 80, 160, 4.0, 5.0]]})
         if dimensions == "day":
             return _Request({"rows": [["2026-04-01", 100, 500]]})
         return _Request({"rows": [[100, 5, 1, 2, 4]]})
@@ -216,6 +216,8 @@ def test_yt_analytics_collects_and_saves_subscribed_status_via_cli(cli_dependenc
         },
         "total_views": 100,
     }
+    assert payload["video_analytics"]["VIDEO_1"]["ad_impressions"] == 160
+    assert payload["video_analytics"]["VIDEO_1"]["ads_per_playback"] == 2.0
     assert any(query.get("dimensions") == "subscribedStatus" for query in reports.queries)
 
 


### PR DESCRIPTION
## Summary
- adImpressions を収益クエリへ追加
- 日別・動画別に ad_impressions と ads_per_playback を保存
- 0除算とCLI保存経路をテストで固定

Closes #3309