### PR TITLE
analytics: yt-ad-coverageで広告カバレッジ低下を検出する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。
 - `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
 - `chore(gemini)`: video-analyze の既定を Vertex AI `global` endpoint で動画入力に対応する GA 世代 `gemini-3.5-flash` へ移行し、`yt-doctor` の非対応判定から同モデルを除外。動画入力非対応の画像生成 preview モデルを診断対象に更新（#3307）。
 - `breaking(thumbnail)`: 利用実績のない `gemini_cli` 画像 provider と subprocess 実装を削除し、指定時は `gemini`（Vertex AI）への移行先を明示する `ConfigError` で停止する（#3308）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/daiki-beppu/youtube-automation"
 [project.scripts]
 yt-audio-visualizer-fill = "youtube_automation.entrypoints:yt_audio_visualizer_fill"
 # CLI script entry points (yt-* prefix)
+yt-ad-coverage = "youtube_automation.entrypoints:yt_ad_coverage"
 yt-analytics = "youtube_automation.entrypoints:yt_analytics"
 yt-apply-rain-layers = "youtube_automation.entrypoints:yt_apply_rain_layers"
 yt-automation-update = "youtube_automation.entrypoints:yt_automation_update"

--- a/src/youtube_automation/commands/analytics/ad_coverage.py
+++ b/src/youtube_automation/commands/analytics/ad_coverage.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""収集済み収益データから広告カバレッジ低下の疑いを抽出する CLI。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+
+from youtube_automation.configuration import channel_dir as _channel_dir
+from youtube_automation.core.errors import ConfigError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VideoAdCoverage:
+    video_id: str
+    monetized_playbacks: int
+    ads_per_playback: float
+
+
+def _parse_non_negative_float(value: object, *, field: str, video_id: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ConfigError(f"revenue_analytics.by_video.{video_id}.{field} は数値で指定してください")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ConfigError(f"revenue_analytics.by_video.{video_id}.{field} は有限の非負数で指定してください")
+    return parsed
+
+
+def _parse_video_rows(by_video: object) -> list[VideoAdCoverage]:
+    if not isinstance(by_video, Mapping):
+        raise ConfigError("revenue_analytics.by_video は JSON object である必要があります")
+
+    videos: list[VideoAdCoverage] = []
+    for video_id, raw_metrics in by_video.items():
+        if not isinstance(video_id, str) or not video_id:
+            raise ConfigError("revenue_analytics.by_video の video ID は空でない文字列である必要があります")
+        if not isinstance(raw_metrics, Mapping):
+            raise ConfigError(f"revenue_analytics.by_video.{video_id} は JSON object である必要があります")
+
+        playbacks = raw_metrics.get("monetized_playbacks")
+        if isinstance(playbacks, bool) or not isinstance(playbacks, int) or playbacks < 0:
+            raise ConfigError(
+                f"revenue_analytics.by_video.{video_id}.monetized_playbacks は非負の整数で指定してください"
+            )
+        ads_per_playback = _parse_non_negative_float(
+            raw_metrics.get("ads_per_playback"),
+            field="ads_per_playback",
+            video_id=video_id,
+        )
+        videos.append(VideoAdCoverage(video_id, playbacks, ads_per_playback))
+    return videos
+
+
+def analyze_ad_coverage(
+    revenue_analytics: Mapping[str, object], *, threshold: float, min_playbacks: int
+) -> dict[str, object]:
+    """中央値比が閾値未満の動画を抽出する。"""
+    if not 0 < threshold <= 1:
+        raise ConfigError("threshold は 0 より大きく 1 以下で指定してください")
+    if min_playbacks < 1:
+        raise ConfigError("min_playbacks は 1 以上で指定してください")
+
+    status = revenue_analytics.get("status")
+    if status == "unavailable":
+        reason = revenue_analytics.get("reason")
+        if not isinstance(reason, str) or not reason:
+            raise ConfigError("unavailable な revenue_analytics.reason は空でない文字列である必要があります")
+        return {
+            "status": "unavailable",
+            "reason": reason,
+            "warning_count": 0,
+            "warnings": [],
+        }
+    if status != "available":
+        raise ConfigError("revenue_analytics.status は available または unavailable である必要があります")
+
+    videos = _parse_video_rows(revenue_analytics.get("by_video"))
+    eligible = [video for video in videos if video.monetized_playbacks >= min_playbacks]
+    median_value = float(median(video.ads_per_playback for video in eligible)) if eligible else None
+
+    warnings: list[dict[str, object]] = []
+    if median_value is not None and median_value > 0:
+        for video in eligible:
+            median_ratio = video.ads_per_playback / median_value
+            if median_ratio < threshold:
+                warnings.append(
+                    {
+                        "video_id": video.video_id,
+                        "ads_per_playback": video.ads_per_playback,
+                        "median_ratio": median_ratio,
+                    }
+                )
+        warnings.sort(key=lambda warning: (float(warning["median_ratio"]), str(warning["video_id"])))
+
+    return {
+        "status": "available",
+        "threshold": threshold,
+        "min_playbacks": min_playbacks,
+        "eligible_video_count": len(eligible),
+        "median_ads_per_playback": median_value,
+        "warning_count": len(warnings),
+        "warnings": warnings,
+    }
+
+
+def load_latest_revenue(channel_root: Path) -> Mapping[str, object]:
+    """最新 analytics snapshot の revenue_analytics を検証して返す。"""
+    candidates = sorted((channel_root / "data").glob("analytics_data_*.json"))
+    if not candidates:
+        raise ConfigError("analytics_data_*.json が見つかりません。先に `yt-analytics` を実行してください。")
+    path = candidates[-1]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise ConfigError(f"{path.name} を読み込めません: {error}") from error
+    if not isinstance(payload, Mapping):
+        raise ConfigError(f"{path.name} は JSON object である必要があります")
+    revenue = payload.get("revenue_analytics")
+    if not isinstance(revenue, Mapping):
+        raise ConfigError(f"{path.name}.revenue_analytics は JSON object である必要があります")
+    return revenue
+
+
+def _threshold(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("0 より大きく 1 以下の数値を指定してください") from error
+    if not math.isfinite(parsed) or not 0 < parsed <= 1:
+        raise argparse.ArgumentTypeError("0 より大きく 1 以下の数値を指定してください")
+    return parsed
+
+
+def _min_playbacks(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("1 以上の整数を指定してください") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("1 以上の整数を指定してください")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="動画別 ads-per-playback の中央値から広告カバレッジ低下を検出")
+    parser.add_argument(
+        "--threshold",
+        type=_threshold,
+        default=0.5,
+        help="警告対象とする中央値比の上限（未満、default: 0.5）",
+    )
+    parser.add_argument(
+        "--min-playbacks",
+        type=_min_playbacks,
+        default=100,
+        help="中央値計算と警告に含める最小 monetized playback 数（default: 100）",
+    )
+    parser.add_argument("--text", action="store_true", help="人間向けテキスト出力")
+    return parser
+
+
+def _print_text(analysis: Mapping[str, object]) -> None:
+    if analysis["status"] == "unavailable":
+        print(f"収益データを取得できません: {analysis['reason']}")
+        return
+
+    print("広告カバレッジ診断")
+    print(f"対象動画: {analysis['eligible_video_count']} 件")
+    median_value = analysis["median_ads_per_playback"]
+    if isinstance(median_value, float):
+        print(f"ads-per-playback 中央値: {median_value:.4f}")
+    else:
+        print("ads-per-playback 中央値: 算出対象なし")
+    print(f"警告: {analysis['warning_count']} 件")
+    for warning in analysis["warnings"]:
+        if not isinstance(warning, Mapping):
+            raise ConfigError("warnings の内部契約が不正です")
+        print(
+            "ミッドロール広告が欠けた疑い: "
+            f"{warning['video_id']} "
+            f"ads-per-playback={float(warning['ads_per_playback']):.4f} "
+            f"中央値比={float(warning['median_ratio']):.1%}"
+        )
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    args = _build_parser().parse_args()
+    try:
+        revenue = load_latest_revenue(_channel_dir())
+        analysis = analyze_ad_coverage(revenue, threshold=args.threshold, min_playbacks=args.min_playbacks)
+        if args.text:
+            _print_text(analysis)
+        else:
+            print(json.dumps(analysis, ensure_ascii=False, indent=2))
+        return 0
+    except ConfigError as error:
+        logger.error(str(error))
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -74,6 +74,7 @@ def _make_entrypoint(module_path: str, function_name: str = "main") -> Callable[
 
 
 yt_analytics = _make_entrypoint("youtube_automation.commands.analytics.analytics_system")
+yt_ad_coverage = _make_entrypoint("youtube_automation.commands.analytics.ad_coverage")
 yt_audio_visualizer_fill = _make_entrypoint("youtube_automation.commands.media.audio_visualizer_fill")
 yt_apply_rain_layers = _make_entrypoint("youtube_automation.commands.media.apply_rain_layers")
 yt_automation_update = _make_entrypoint("youtube_automation.commands.system.automation_update")

--- a/tests/commands/analytics/test_ad_coverage.py
+++ b/tests/commands/analytics/test_ad_coverage.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation import entrypoints
+from youtube_automation.commands.analytics import ad_coverage
+from youtube_automation.core.errors import ConfigError
+
+
+def _available_revenue(by_video: dict[str, dict[str, int | float]]) -> dict[str, object]:
+    return {
+        "status": "available",
+        "by_video": by_video,
+    }
+
+
+def _video(playbacks: int, ads_per_playback: float) -> dict[str, int | float]:
+    return {
+        "monetized_playbacks": playbacks,
+        "ads_per_playback": ads_per_playback,
+    }
+
+
+def _write_snapshot(root: Path, stamp: str, revenue: dict[str, object]) -> None:
+    data_dir = root / "data"
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / f"analytics_data_{stamp}.json").write_text(
+        json.dumps({"revenue_analytics": revenue}),
+        encoding="utf-8",
+    )
+
+
+def test_analyze_warns_for_video_below_default_median_ratio() -> None:
+    revenue = _available_revenue(
+        {
+            "video-normal-a": _video(500, 2.0),
+            "video-normal-b": _video(400, 2.2),
+            "video-low": _video(300, 0.4),
+        }
+    )
+
+    result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+    assert result["median_ads_per_playback"] == 2.0
+    assert result["warning_count"] == 1
+    assert result["warnings"] == [
+        {
+            "video_id": "video-low",
+            "ads_per_playback": 0.4,
+            "median_ratio": 0.2,
+        }
+    ]
+
+
+def test_analyze_uses_overridden_threshold() -> None:
+    revenue = _available_revenue(
+        {
+            "video-mid": _video(300, 1.2),
+            "video-baseline": _video(300, 2.0),
+            "video-high": _video(300, 2.8),
+        }
+    )
+
+    default_result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+    overridden_result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.7, min_playbacks=100)
+
+    assert default_result["warning_count"] == 0
+    assert [warning["video_id"] for warning in overridden_result["warnings"]] == ["video-mid"]
+    assert overridden_result["warnings"][0]["median_ratio"] == pytest.approx(0.6)
+
+
+def test_analyze_excludes_low_playbacks_from_median_and_warnings() -> None:
+    revenue = _available_revenue(
+        {
+            "video-low-sample": _video(99, 0.0),
+            "video-a": _video(100, 2.0),
+            "video-b": _video(200, 4.0),
+        }
+    )
+
+    result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+    assert result["eligible_video_count"] == 2
+    assert result["median_ads_per_playback"] == 3.0
+    assert result["warnings"] == []
+
+
+def test_analyze_preserves_unavailable_reason_without_warnings() -> None:
+    revenue = {
+        "status": "unavailable",
+        "reason": "monetary data forbidden",
+        "by_video": {},
+    }
+
+    result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+    assert result == {
+        "status": "unavailable",
+        "reason": "monetary data forbidden",
+        "warning_count": 0,
+        "warnings": [],
+    }
+
+
+def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_snapshot(tmp_path, "20260801", _available_revenue({"old": _video(200, 0.1)}))
+    _write_snapshot(
+        tmp_path,
+        "20260802",
+        _available_revenue(
+            {
+                "video-mid": _video(300, 1.2),
+                "video-baseline": _video(300, 2.0),
+                "video-high": _video(300, 2.8),
+            }
+        ),
+    )
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--threshold", "0.7"])
+
+    assert entrypoints.yt_ad_coverage() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["threshold"] == 0.7
+    assert [warning["video_id"] for warning in output["warnings"]] == ["video-mid"]
+    assert output["warnings"][0]["ads_per_playback"] == 1.2
+    assert output["warnings"][0]["median_ratio"] == pytest.approx(0.6)
+
+
+def test_cli_text_reports_zero_warnings(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_snapshot(
+        tmp_path,
+        "20260802",
+        _available_revenue({"video-a": _video(300, 2.0), "video-b": _video(300, 2.0)}),
+    )
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--text"])
+
+    assert ad_coverage.main() == 0
+
+    assert "警告: 0 件" in capsys.readouterr().out
+
+
+def test_cli_text_reports_unavailable_reason(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_snapshot(
+        tmp_path,
+        "20260802",
+        {"status": "unavailable", "reason": "monetary data forbidden", "by_video": {}},
+    )
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--text"])
+
+    assert ad_coverage.main() == 0
+
+    output = capsys.readouterr().out
+    assert "収益データを取得できません" in output
+    assert "monetary data forbidden" in output
+    assert "ミッドロール広告が欠けた疑い" not in output
+
+
+def test_cli_returns_two_for_invalid_snapshot_shape(tmp_path: Path, monkeypatch, caplog) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "analytics_data_20260802.json").write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
+
+    assert ad_coverage.main() == 2
+
+    assert "JSON object" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--threshold", "0"],
+        ["--threshold", "1.1"],
+        ["--threshold", "nan"],
+        ["--min-playbacks", "0"],
+        ["--min-playbacks", "1.5"],
+    ],
+)
+def test_cli_rejects_invalid_detection_options(arguments: list[str], monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", *arguments])
+
+    with pytest.raises(SystemExit) as exited:
+        ad_coverage.main()
+
+    assert exited.value.code == 2
+
+
+def test_analyze_rejects_non_object_video_metrics() -> None:
+    revenue = {"status": "available", "by_video": []}
+
+    with pytest.raises(ConfigError, match="by_video は JSON object"):
+        ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+
+def test_project_script_registers_entrypoint() -> None:
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert project["project"]["scripts"]["yt-ad-coverage"] == "youtube_automation.entrypoints:yt_ad_coverage"
+
+
+def test_load_latest_revenue_raises_when_snapshot_is_missing(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match=r"analytics_data_\*\.json が見つかりません"):
+        ad_coverage.load_latest_revenue(tmp_path)

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -77,6 +77,7 @@ BILLED_CLIS: dict[str, str] = {
 
 # 課金 API を呼ばない CLI（ローカル処理・無料 API のみ）。
 NON_BILLED_CLIS: dict[str, str] = {
+    "yt-ad-coverage": "収集済み analytics_data_*.json のローカル分析のみ",
     "yt-apply-rain-layers": "ローカル ffmpeg 合成のみ",
     "yt-audio-visualizer-fill": "ローカルの Pillow 画像生成のみ",
     "yt-automation-update": "バージョン pin bump / git 操作のみ",

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 EXPECTED_ENTRYPOINT_MODULES = {
+    "yt-ad-coverage": "youtube_automation.commands.analytics.ad_coverage",
     "yt-analytics": "youtube_automation.commands.analytics.analytics_system",
     "yt-apply-rain-layers": "youtube_automation.commands.media.apply_rain_layers",
     "yt-audio-visualizer-fill": "youtube_automation.commands.media.audio_visualizer_fill",


### PR DESCRIPTION
## Summary
- 収集済みスナップショットから広告カバレッジ中央値を算出
- threshold/min-playbacks による警告対象の絞り込みを追加
- unavailable、JSON/text、CLI到達経路をテストで固定

Closes #3310