### PR TITLE
breaking(thumbnail): AI焼き込みを既定経路へ戻す (#3312)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -75,7 +75,7 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 履歴の `performed_same` / `inconclusive` は強い方針へ還元しない。履歴の作成・追記は `/thumbnail-test` の責務であり、このスキルから変更しない。
 
-**読み順**: 標準フローは「ワークフロー > 標準生成順序とファイル契約」から読む。「フォント安定化」章は標準経路（決定的合成）の設定詳細としてあわせて読む。「codex 経由の生成」章は `image_generation.provider: codex` のチャンネルのみ、「自動選択」章は該当機能を明示的に使うチャンネルのみ参照すればよい。
+**読み順**: 標準フローは「ワークフロー > 標準生成順序とファイル契約」から読み、実効 `text_render.mode` に対応する経路へ進む。「フォント安定化」章は 2 経路の再現性差を確認するときに読む。「codex 経由の生成」章は `image_generation.provider: codex` のチャンネルのみ、「自動選択」章は該当機能を明示的に使うチャンネルのみ参照すればよい。
 
 ## 蓄積 insights 参照（lever=thumbnail）
 
@@ -288,7 +288,11 @@ uv run python .claude/skills/thumbnail/references/finalize_planning_preview.py <
 
 `status: MISSING` の場合だけ、`/wf-new` は既存の `/thumbnail <theme>` 候補生成へフォールバックする。空ファイルや代替画像を作らない。変換エラーは `MISSING` とみなさず、既存成果物と state を変更せず停止する。
 
-`/thumbnail` の標準手順は、**textless 動画背景の生成 → `yt-thumbnail-text` による実フォント合成**の 2 段構成で進める（#1907）。タイトル文字は AI に焼き込ませず、承認済みの textless 背景へ実フォント（Pillow 描画）で決定的に合成する。同一の背景・テキスト・設定なら常に同一出力になり、AI っぽい書体の揺れが発生しない。
+最初に deep-merge 済み skill-config を読み、`text_render.mode` を解決する。未設定または `ai_burn_in` は既定の AI 焼き込み経路、`deterministic` は決定的合成経路を使う。それ以外の値は画像生成 API を呼ぶ前に `ConfigError` で停止し、許容値 `ai_burn_in` / `deterministic` を表示する。provider によってこの分岐を変えない。
+
+**AI 焼き込み経路（既定）**: 「Single-Step / TTP モード」または「Two-Phase モード」の手順で、最初にテキスト付き `10-assets/thumbnail-v*.jpg/png` を生成する。`/thumbnail-compare` とユーザー承認後に `thumbnail.jpg` を確定し、承認済み `thumbnail.jpg` を参照して textless `main-v*.png/jpg` を再生成・承認する。書体の厳密な再現は保証されない。
+
+**決定的合成経路（`text_render.mode: deterministic` の opt-in）**: **textless 動画背景の生成 → `yt-thumbnail-text` による実フォント合成**の 2 段構成で進める（#1907）。タイトル文字は AI に焼き込ませず、承認済みの textless 背景へ実フォント（Pillow 描画）で決定的に合成する。同一の背景・テキスト・設定なら常に同一出力になり、AI っぽい書体の揺れが発生しない。
 
 ただし deep-merge 後の `textless.enabled: false` は明示 opt-in の共用経路とする。この場合は textless 候補の AI 生成、セルフチェック、プレビュー、承認をすべて省略し、テキスト付き最終 `10-assets/thumbnail.jpg` の確定後に次を実行する。
 
@@ -319,7 +323,7 @@ uv run yt-thumbnail-text \
 
 `thumbnail.jpg` はアップロード用、`main.png/jpg` は動画背景・loop-video 入力用の成果物とする。`textless.enabled` が未設定または `true` では文字入りと文字なしを分離し、両者を同一画像で代用しない。`false` だけは上記の検証済みコピーを正規契約とする。symlink や拡張子偽装では代用しない。
 
-**AI 焼き込み経路（fallback・非既定）**: 手書き風タイポグラフィなど実フォントで再現できない表現を運用者が明示的に選んだときだけ、従来の「テキスト付き YouTube サムネ → 承認済みサムネから textless 動画背景」の順で Single-Step / Two-Phase / codex 章のテキスト付き候補生成手順を使う（経路は残すが #1907 では改修しない）。この場合、書体の厳密な再現は保証されないことをユーザーに伝える。
+決定的合成経路は `text_render.mode: deterministic` の場合だけ使う。未設定 / `ai_burn_in` では上記の textless 先行手順へ入らず、AI 焼き込み経路を実行する。
 
 ### Test & compare 用 A/B pattern（opt-in）
 
@@ -380,7 +384,7 @@ uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py 
 
 ### Single-Step / TTP モード（`generation_mode: "single_step"`、デフォルト・推奨）
 
-> **#1907 以降の位置づけ**: 標準フローはこの章の TTP 機構（参照画像選定・差分プロンプト構築・CLI 引数）を **textless 背景候補 `main-v*.png/jpg` の生成**に流用し、テキストは `yt-thumbnail-text` で合成する。この章に書かれた「テキスト付き候補を先に生成 → 承認済み `thumbnail.jpg` から textless 再生成」の順序は **AI 焼き込み経路（fallback・非既定）**の手順であり、運用者が明示的に選んだときだけ使う。
+> **経路の位置づけ**: この章の「テキスト付き候補を先に生成 → 承認済み `thumbnail.jpg` から textless 再生成」が、未設定 / `text_render.mode: ai_burn_in` の標準手順である。`text_render.mode: deterministic` の場合だけ、同じ TTP 機構（参照画像選定・差分プロンプト構築・CLI 引数）を textless 背景候補 `main-v*.png/jpg` の生成に流用し、テキストを `yt-thumbnail-text` で合成する。
 
 ベンチマーク模倣（**TTP**: trace / imitate）の標準実装。テキスト付きベンチマーク参照画像（背景テクスチャ・オブジェクト配置・主役スケール・文字レイアウトを含む）を参照にして、**維持する勝ちパターンと差し替えるタイトルだけ**をプロンプトで指示する。1 回目の生成では、YouTube 用のテキスト付き `thumbnail-v*.jpg/png` 候補を作る。承認後、その `thumbnail.jpg` から textless `main-v*.png/jpg` を再生成する。
 
@@ -536,14 +540,14 @@ Two-Phase は旧チャンネル向けのフォールバック。使う場合も�
 
 ## フォント安定化（#1332 / #1907）
 
-「サムネの文字フォントが毎回バラバラになる」問題への対処。フォントの扱いは 2 経路あり、#1907 以降は決定的合成経路が標準フローの既定になった。
+「サムネの文字フォントが毎回バラバラになる」問題への対処。フォントの扱いは 2 経路あり、`text_render.mode` で選択する。
 
 | 経路 | 仕組み | フォント再現性 |
 |---|---|---|
-| **決定的合成経路**（`yt-thumbnail-text`・**既定**） | textless 背景に実フォントファイル（.ttf/.otf/.ttc）を Pillow で描画 | **完全に安定**。同一の背景・テキスト・設定なら常に同一出力 |
-| **AI プロンプト経路**（fallback・非既定） | テキスト付きサムネ生成プロンプトで書体の雰囲気を指示（`thumbnail_text.font` / `single_step.typography_clause`） | **保証されない**。AI 画像生成はフォント名を厳密に再現できず、同じ指示でも生成ごとに書体が揺れる |
+| **AI プロンプト経路**（`ai_burn_in`・**既定**） | テキスト付きサムネ生成プロンプトで書体の雰囲気を指示（`thumbnail_text.font` / `single_step.typography_clause`） | **保証されない**。AI 画像生成はフォント名を厳密に再現できず、同じ指示でも生成ごとに書体が揺れる |
+| **決定的合成経路**（`deterministic`・opt-in） | textless 背景に実フォントファイル（.ttf/.otf/.ttc）を Pillow で描画 | **完全に安定**。同一の背景・テキスト・設定なら常に同一出力 |
 
-標準は「標準生成順序とファイル契約」の `yt-thumbnail-text` 経路とし、textless 背景の承認後に合成する。文字入り画像を `--background` に流用しない。AI プロンプト経路は fallback であり、フォントの厳密な再現を保証しない。
+「標準生成順序とファイル契約」の標準は AI プロンプト経路で文字入りサムネを先に確定する。決定的合成を選んだ場合は textless 背景の承認後に合成し、文字入り画像を `--background` に流用しない。`yt-thumbnail-text` が失敗しても AI 経路へ無断で切り替えない。
 
 font config、`typography_clause`、ライセンス、失敗時の切り替えは [quality / operations 詳細](references/quality-and-operations.md) を読む。`yt-thumbnail-text` が失敗したら理由を表示して終了コード 1 で停止し、無断で fallback しない。
 

--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -9,6 +9,14 @@
 textless:
   enabled: true
 
+# サムネイルへのテキスト描画経路。
+# ai_burn_in（既定）: 文字入り thumbnail 候補を AI 生成・承認し、承認済み
+# thumbnail から textless main を再生成する。書体は生成ごとに揺れる。
+# deterministic: textless main を先に確定し、yt-thumbnail-text で実フォントを
+# 合成する。同じ背景・テキスト・設定なら同一出力になる。
+text_render:
+  mode: ai_burn_in
+
 # 承認済みサムネイルのギャラリー保存 (#1942)。
 # true の場合、確定直後に assets/thumbnail-gallery/<collection-dir-name>.<ext>
 # へ元の拡張子・内容のままコピーする。false なら従来どおり何も作らない。
@@ -79,9 +87,8 @@ image_generation:
     #   single_step   : ベンチマーク模倣 (TTP) の推奨実装。テキスト付き参照画像から
     #                   差分のみ指示して text-included thumbnail 候補を生成する。
     #                   reference_images.default が必須。
-    #                   #1907 以降の標準フローは同じ TTP 機構を textless 背景候補の
-    #                   生成に流用し、テキストは yt-thumbnail-text で決定的に合成する
-    #                   (text-included 候補の直接生成は AI 焼き込み fallback)。
+    #                   text_render.mode=deterministic のときだけ同じ TTP 機構を
+    #                   textless 背景候補の生成に流用し、yt-thumbnail-text で合成する。
     #   two_phase     : 既存参照から text-included thumbnail を先に確定し、
     #                   承認済み thumbnail から textless main を後続再生成するフォールバック
     #   diff_from_reference : 既存キャラ画像を参照に差分のみ指示

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。
 - `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
 - `fix(suno)`: `exclude_styles` が空のときに video_analysis の全 slug から除外語を集約する fallback を撤去し、空設定を空のまま出力へ反映する（#3311）。
+- `breaking(thumbnail)`: `/thumbnail` の既定生成順序を文字入りサムネの生成・承認 → 承認済みサムネから textless main 再生成へ戻し、textless 先行の実フォント合成は `text_render.mode: deterministic` の明示 opt-in とした。不正な mode は画像生成前に `ConfigError` で停止する（#3312）。
 - `chore(gemini)`: video-analyze の既定を Vertex AI `global` endpoint で動画入力に対応する GA 世代 `gemini-3.5-flash` へ移行し、`yt-doctor` の非対応判定から同モデルを除外。動画入力非対応の画像生成 preview モデルを診断対象に更新（#3307）。
 - `breaking(thumbnail)`: 利用実績のない `gemini_cli` 画像 provider と subprocess 実装を削除し、指定時は `gemini`（Vertex AI）への移行先を明示する `ConfigError` で停止する（#3308）。
 - `feat(doctor)`: 下流の `config/skills/thumbnail.yaml` に廃止済み Gemini preview 画像モデルが明示されている場合、`yt-doctor` が実行前に警告するようにした（#3304）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -13,7 +13,7 @@ postmortem は `flop-analysis.yaml` を優先し、旧 `postmortem.yaml` だけ�
     bg = cfg.get("image_generation", {}).get("gemini", {}).get("brand_background")
 
 設計方針:
-- スキーマ検証なし。YAML のコメントで説明、コード側は .get() でゆるく適応
+- 原則スキーマ検証なし。実行経路を切り替える一部の列挙値だけ Fail Fast で検証
 - プロセス内キャッシュ (skill 名ごと)。reset() でクリア可
 - editable install / wheel 両対応 (importlib.resources)
 """
@@ -33,6 +33,8 @@ from youtube_automation.configuration import channel_dir as configured_channel_d
 from youtube_automation.core.errors import ConfigError
 
 _cache: dict[str, dict[str, Any]] = {}
+
+_THUMBNAIL_TEXT_RENDER_MODES = frozenset({"ai_burn_in", "deterministic"})
 
 # #1702: 基底 config から縮小済みのキー。channel override は引き続き deep-merge で
 # 有効（挙動は壊さない）だが、後続リリースでの物理削除に先立ち DeprecationWarning で
@@ -246,6 +248,22 @@ def _load_override(path: Path) -> dict[str, Any]:
     return _load_yaml(path)
 
 
+def _validate_thumbnail_text_render(config: dict[str, Any]) -> None:
+    text_render = config.get("text_render")
+    if not isinstance(text_render, dict):
+        raise ConfigError("thumbnail.text_render.mode は ai_burn_in / deterministic のいずれかで指定してください")
+    mode = text_render.get("mode")
+    if mode not in _THUMBNAIL_TEXT_RENDER_MODES:
+        raise ConfigError(
+            f"thumbnail.text_render.mode は ai_burn_in / deterministic のいずれかで指定してください: {mode!r}"
+        )
+
+
+def _validate_skill_config(skill: str, config: dict[str, Any]) -> None:
+    if skill == "thumbnail":
+        _validate_thumbnail_text_render(config)
+
+
 def load_skill_config(
     skill: str,
     *,
@@ -280,6 +298,8 @@ def load_skill_config(
         merged = _deep_merge(defaults, override)
     else:
         merged = defaults
+
+    _validate_skill_config(skill, merged)
 
     if use_shared_cache:
         _cache[skill] = merged

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import stat
 import warnings
+from collections.abc import Mapping
 from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any
@@ -248,7 +249,7 @@ def _load_override(path: Path) -> dict[str, Any]:
     return _load_yaml(path)
 
 
-def _validate_thumbnail_text_render(config: dict[str, Any]) -> None:
+def _validate_thumbnail_text_render(config: Mapping[str, object]) -> None:
     text_render = config.get("text_render")
     if not isinstance(text_render, dict):
         raise ConfigError("thumbnail.text_render.mode は ai_burn_in / deterministic のいずれかで指定してください")
@@ -259,7 +260,7 @@ def _validate_thumbnail_text_render(config: dict[str, Any]) -> None:
         )
 
 
-def _validate_skill_config(skill: str, config: dict[str, Any]) -> None:
+def _validate_skill_config(skill: str, config: Mapping[str, object]) -> None:
     if skill == "thumbnail":
         _validate_thumbnail_text_render(config)
 

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -332,8 +332,8 @@ def test_thumbnail_provider_guidance_owns_protocol_and_failure_details_once() ->
         assert combined.count(detail) == 1
 
 
-def test_thumbnail_skill_documents_textless_first_deterministic_flow() -> None:
-    """#1907: 標準フローは textless 背景を先に確定し yt-thumbnail-text で実フォント合成する。"""
+def test_thumbnail_skill_documents_ai_burn_in_default_and_deterministic_opt_in() -> None:
+    """#3312: AI 焼き込みを既定に戻し、決定的合成は明示 opt-in とする。"""
     skill = _read_thumbnail_skill()
 
     standard_block = _slice_between(
@@ -364,17 +364,21 @@ def test_thumbnail_skill_documents_textless_first_deterministic_flow() -> None:
         "config/skills/loop-video.yaml::enabled: false",
         "静止画背景",
         "両者を同一画像で代用しない",
-        "AI 焼き込み経路（fallback・非既定）",
+        "AI 焼き込み経路（既定）",
+        "text_render.mode: deterministic",
     ):
         assert required in standard_block
 
-    # textless 背景の確定が実フォント合成より先
+    # deterministic 経路では textless 背景の確定が実フォント合成より先
     assert standard_block.find("cp main-v1.png main.png") < standard_block.find("uv run yt-thumbnail-text")
-    # AI 焼き込みは運用者の明示選択のみ
-    assert "運用者が明示的に選んだときだけ" in standard_block
+    # 既定は文字入り候補を先に生成し、決定的合成だけを明示 opt-in にする
+    assert standard_block.find("AI 焼き込み経路（既定）") < standard_block.find(
+        "決定的合成経路（`text_render.mode: deterministic`"
+    )
+    assert "未設定または `ai_burn_in` は既定" in standard_block
 
-    # AI 焼き込み経路（Single-Step 章）は fallback として従来契約のまま残す（#1901 の順序を維持）
-    assert "AI 焼き込み経路（fallback・非既定）**の手順" in single_step_block
+    # AI 焼き込み経路（Single-Step 章）が未設定 / ai_burn_in の標準手順
+    assert "未設定 / `text_render.mode: ai_burn_in` の標準手順" in single_step_block
     for required in (
         "/thumbnail-compare",
         "cp thumbnail-v1.jpg thumbnail.jpg",
@@ -901,8 +905,8 @@ def test_thumbnail_skill_two_phase_keeps_thumbnail_and_main_separate() -> None:
     assert "既に存在する場合は Phase 1 をスキップ" not in two_phase_block
 
 
-def test_thumbnail_skill_deterministic_text_path_is_standard_default() -> None:
-    """#1907: 決定的合成経路が標準の既定で、textless 背景を先に確定してから合成する。"""
+def test_thumbnail_skill_ai_text_path_is_default_and_deterministic_is_opt_in() -> None:
+    """#3312: フォント経路表も AI 既定 / deterministic opt-in とする。"""
     skill = _read_thumbnail_skill()
     font_block = _slice_between(skill, "## フォント安定化", "## 自動選択")
     font_details = _slice_between(
@@ -911,19 +915,15 @@ def test_thumbnail_skill_deterministic_text_path_is_standard_default() -> None:
         "## auto-selection",
     )
 
-    # 経路表の既定は決定的合成、AI プロンプト経路は fallback
-    assert "**決定的合成経路**（`yt-thumbnail-text`・**既定**）" in font_block
-    assert "**AI プロンプト経路**（fallback・非既定）" in font_block
-    assert "**AI プロンプト経路**（既定）" not in font_block
+    assert "**AI プロンプト経路**（`ai_burn_in`・**既定**）" in font_block
+    assert "**決定的合成経路**（`deterministic`・opt-in）" in font_block
 
     assert "標準生成順序とファイル契約" in font_block
+    assert "文字入りサムネを先に確定" in font_block
     assert "textless 背景の承認後に合成" in font_block
     assert "image_generation.gemini.thumbnail_text.overlay.font.title" in font_details
     assert "文字入り画像を `--background` に流用しない" in font_block
-    # 旧契約（テキスト付き先行）の手順は標準から撤去済み
-    combined = font_block + font_details
-    assert "最初にテキスト付き `thumbnail-v*.jpg` を生成・承認して" not in combined
-    assert "標準 `/thumbnail` フローから自動分岐しない" not in combined
+    assert "AI 経路へ無断で切り替えない" in font_block
 
 
 def test_loop_video_skill_uses_textless_main_image_and_respects_disabled_channels() -> None:
@@ -978,6 +978,45 @@ def test_thumbnail_default_config_disables_ab_test_by_default() -> None:
     config = _load_thumbnail_default_config()
 
     assert config["ab_test"] == {"enabled": False, "patterns": []}
+
+
+def test_thumbnail_default_config_uses_ai_burn_in_text_render_mode() -> None:
+    config = _load_thumbnail_default_config()
+
+    assert config["text_render"] == {"mode": "ai_burn_in"}
+
+
+@pytest.mark.parametrize("mode", ["ai_burn_in", "deterministic"])
+def test_thumbnail_text_render_mode_accepts_supported_values(tmp_path, mode) -> None:
+    from youtube_automation.configuration import skills as skill_config
+
+    override_dir = tmp_path / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "thumbnail.yaml").write_text(f"text_render:\n  mode: {mode}\n", encoding="utf-8")
+
+    merged = skill_config.load_skill_config("thumbnail", use_cache=False, channel_dir=tmp_path)
+
+    assert merged["text_render"]["mode"] == mode
+
+
+@pytest.mark.parametrize(
+    "text_render_yaml",
+    [
+        "text_render: unsupported\n",
+        "text_render:\n  mode: unsupported\n",
+        "text_render:\n  mode: null\n",
+    ],
+)
+def test_thumbnail_text_render_mode_rejects_invalid_values(tmp_path, text_render_yaml) -> None:
+    from youtube_automation.configuration import skills as skill_config
+    from youtube_automation.core.errors import ConfigError
+
+    override_dir = tmp_path / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "thumbnail.yaml").write_text(text_render_yaml, encoding="utf-8")
+
+    with pytest.raises(ConfigError, match=r"text_render\.mode.*ai_burn_in.*deterministic"):
+        skill_config.load_skill_config("thumbnail", use_cache=False, channel_dir=tmp_path)
 
 
 def test_thumbnail_skill_documents_ab_test_outputs_prompts_and_approval_contract() -> None:


### PR DESCRIPTION
## Summary

- `/thumbnail` の既定順序を文字入りサムネの生成・承認から textless main 再生成へ戻す
- 決定的な実フォント合成は `text_render.mode: deterministic` の opt-in として維持する
- mode の不正 shape・値を skill-config 読み込み時に `ConfigError` で拒否する

## Verification

- `uv run pytest tests/configuration/test_thumbnail_skill_assets.py -q`
- `uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run yt-skills lint thumbnail`

Closes #3312