### PR TITLE
fix(suno): exclude_styles の既定を空にする (#3313)

### DIFF
--- a/.claude/skills/channel-new/references/config-template/skills/suno.yaml
+++ b/.claude/skills/channel-new/references/config-template/skills/suno.yaml
@@ -12,5 +12,5 @@ workspace_name: "{{WORKSPACE_NAME}}"
 # 手書きしてしまうことを防ぐ唯一のソース）
 genre_line: "{{GENRE_LINE}}"
 
-# Suno Exclude Styles 欄。チャンネル方向性と相反するジャンルを列挙
+# Suno Exclude Styles 欄。同梱既定は空。必要な場合だけ短い除外語を列挙
 exclude_styles: "{{EXCLUDE_STYLES}}"

--- a/.claude/skills/suno/SKILL.md
+++ b/.claude/skills/suno/SKILL.md
@@ -434,9 +434,9 @@ Suno V5.5 では Styles 経由で実楽曲長を制御できない。望む長�
 
 ### 雨音・環境音の制御
 
-**雨音や環境音は楽曲に含めない。** NG ワード: rain, dripping, drops, puddles, splashing, pouring 等。OK ワード: misty, melancholic, nocturnal, bittersweet, foggy 等。全プロンプトに `no rain sound effects, no white noise, no ambient noise` を追加。`exclude_styles` にも `rain sounds, vinyl crackle, white noise, ambient noise` を含める。
+**雨音や環境音は楽曲に含めない。** NG ワード: rain, dripping, drops, puddles, splashing, pouring 等。OK ワード: misty, melancholic, nocturnal, bittersweet, foggy 等。全プロンプトに `no rain sound effects, no white noise, no ambient noise` を追加する。
 
-視聴中の注意を急に奪う展開を避けるため、同梱 `exclude_styles` は `sudden drops, risers, drum fills, hard transitions, dramatic buildups` も既定で含む。これらは Suno の独立した **Exclude Styles** 欄へ入力する値であり、Styles 本文へ連結しないため `style_char_limit` / `full_style_char_limit` の文字数には算入しない。
+同梱 `exclude_styles` は空であり、既定では Suno の **Exclude Styles** 欄を使わない。チャンネルまたは collection で追加の抑止が必要な場合だけ、`config/skills/suno.yaml` または `suno-patterns.yaml` に `sudden drops, risers, drum fills, hard transitions, dramatic buildups` などの短い除外語を明示する。これらは Styles 本文へ連結しないため `style_char_limit` / `full_style_char_limit` の文字数には算入しない。
 
 #### genre_line と exclude_styles の整合性
 

--- a/.claude/skills/suno/config.default.yaml
+++ b/.claude/skills/suno/config.default.yaml
@@ -10,7 +10,7 @@ workspace_name: ""
 genre_line: ""
 
 # Suno の Exclude Styles 欄に入れる除外語
-exclude_styles: "heavy metal, aggressive, EDM, dubstep, techno, industrial, white noise, orchestral, rain sounds, vinyl crackle, ambient noise, sudden drops, risers, drum fills, hard transitions, dramatic buildups"
+exclude_styles: ""
 
 # Style Influence (0-100、高いほどジャンル指定が強く反映される)
 style_influence: 50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。
 - `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
 - `fix(suno)`: `exclude_styles` が空のときに video_analysis の全 slug から除外語を集約する fallback を撤去し、空設定を空のまま出力へ反映する（#3311）。

--- a/tests/commands/suno/test_generate_suno_prompts.py
+++ b/tests/commands/suno/test_generate_suno_prompts.py
@@ -505,17 +505,15 @@ def test_empty_config_does_not_inherit_video_analysis_exclude_styles(channel_dir
     assert all("exclude_styles" not in entry for entry in entries)
 
 
-def test_default_exclude_styles_prevent_sudden_transitions_without_using_style_budget(channel_dir, tmp_path):
-    """急変系語彙は独立 Exclude Styles 欄へ入り、Styles 本文へ混入しないこと."""
+def test_default_config_omits_exclude_styles_from_generated_prompts(channel_dir, tmp_path):
+    """明示設定がなければ Exclude Styles 欄を生成しない."""
     patterns_path = _write_minimal_patterns(tmp_path)
 
     output = generate(patterns_path)
     entries = build_prompt_entries(patterns_path)
 
-    assert "**Exclude Styles:**" in output
-    for term in ("sudden drops", "risers", "drum fills", "hard transitions", "dramatic buildups"):
-        assert term in output
-        assert term not in entries[0]["style"]
+    assert "**Exclude Styles:**" not in output
+    assert all("exclude_styles" not in entry for entry in entries)
 
 
 def test_user_override_wins_over_video_analysis_fallback(channel_dir, tmp_path):


### PR DESCRIPTION
## Summary
- 同梱 `exclude_styles` の既定を空にし、未設定時は Markdown / JSON の Exclude Styles 出力を省略
- チャンネルまたは collection で必要な場合だけ短い除外語を明示する運用へ skill とテンプレートを更新
- 既定未設定と明示 override の回帰テストを整合

Closes #3313