### PR TITLE
fix(video-upload): 認証チャンネルを投稿前に照合する (#3716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。
+- `fix(video-upload)`: upload preflight で OAuth 認証済みチャンネル ID と `config/channel/meta.json` を照合し、不一致時は動画作成やローカル state 更新より前に停止する（#3716）。
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。
 - `feat(analytics)`: 収益メトリクスへ広告インプレッションを追加し、日別・動画別の ads-per-playback を保存する（#3309）。
 - `fix(suno)`: `exclude_styles` が空のときに video_analysis の全 slug から除外語を集約する fallback を撤去し、空設定を空のまま出力へ反映する（#3311）。

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.adapters.errors import (
     AutomationError,
+    ConfigError,
     QuotaExhaustedError,
     UploadError,
     ValidationError,
@@ -16,7 +17,11 @@ from youtube_automation.core.adapters.errors import (
 )
 from youtube_automation.core.adapters.filesystem import file_size, path_exists, remove_file
 from youtube_automation.core.adapters.google.upload import HttpError, create_media_upload
-from youtube_automation.core.adapters.google.youtube import YouTubeClients, execute_youtube_request
+from youtube_automation.core.adapters.google.youtube import (
+    YouTubeClients,
+    execute_youtube_request,
+    validate_youtube_response_items,
+)
 from youtube_automation.core.adapters.process import compress_image
 from youtube_automation.core.adapters.runtime import resolve_default_publish_at as _resolve_default_publish_at
 from youtube_automation.domains.metadata import BAHMetadataGenerator
@@ -49,6 +54,35 @@ def _parse_retry_after(resp) -> float | None:
         return float(raw)
     except (TypeError, ValueError):
         return None
+
+
+def _authenticated_channel_id(youtube) -> str:
+    response = execute_youtube_request(
+        youtube.channels().list(part="id", mine=True),
+        "channels.list(mine=True) failed",
+    )
+    try:
+        items = validate_youtube_response_items(response, "channels.list(mine=True)")
+    except ValidationError as error:
+        raise YouTubeAPIError(str(error)) from error
+    if not items:
+        raise YouTubeAPIError("authenticated user has no YouTube channel")
+    item = items[0]
+    if not isinstance(item, dict) or not isinstance(item.get("id"), str) or not item["id"]:
+        raise YouTubeAPIError("channels.list(mine=True) returned an invalid channel item")
+    return item["id"]
+
+
+def _verify_upload_channel_id(expected_channel_id: str, authenticated_channel_id: str) -> None:
+    if expected_channel_id and expected_channel_id != authenticated_channel_id:
+        raise ConfigError(
+            "channel_id mismatch: ローカル config と認証済みチャンネルが一致しません。\n"
+            f"  config/channel/meta.json (channel.channel_id): {expected_channel_id}\n"
+            f"  authenticated channel (channels().list mine=True): {authenticated_channel_id}\n"
+            "→ 別チャンネルへの誤投稿を防ぐためアップロードを中止しました。\n"
+            "  auth/token.json を削除して対象チャンネルで再認証するか、"
+            "meta.json の channel.channel_id を確認してください"
+        )
 
 
 class ResumableUploader:
@@ -228,6 +262,21 @@ class YouTubeAutoUploader(
             collections_root = channel_dir() / "collections"
 
         self.collections_root = Path(collections_root)
+        self._verified_authenticated_channel_id: str | None = None
+
+    def _verify_authenticated_upload_channel(self) -> None:
+        """OAuth の実チャンネルを config と照合し、同一実行内で結果を保持する。"""
+        if self._verified_authenticated_channel_id is not None:
+            return
+        self._ensure_service()
+        authenticated_channel_id = _authenticated_channel_id(self.youtube)
+        _verify_upload_channel_id(load_config().meta.channel_id, authenticated_channel_id)
+        self._verified_authenticated_channel_id = authenticated_channel_id
+
+    def preflight_check(self, collection_dir: Path) -> None:
+        """チャンネル本人性を確認してからメタデータ品質を検証する。"""
+        self._verify_authenticated_upload_channel()
+        super().preflight_check(collection_dir)
 
     def upload_video(
         self,
@@ -350,7 +399,7 @@ class YouTubeAutoUploader(
                 logger.info(f"チャンネル既定の予約投稿時刻を適用: publish_at={publish_at}")
 
         # アップロード前メタデータ検証
-        self._preflight_check(collection_dir)
+        self.preflight_check(collection_dir)
 
         # メタデータ生成器初期化
         metadata_gen = BAHMetadataGenerator(str(collection_dir))

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -66,6 +66,29 @@ def test_main_runs_shared_preflight_before_plan_or_execute(monkeypatch, tmp_path
     getattr(mock_uploader, method_name).assert_called_once_with(target)
 
 
+def test_main_exits_before_state_changes_when_channel_identity_preflight_fails(monkeypatch, tmp_path):
+    """認証チャンネル不一致時は orchestration を開始せず非ゼロ終了する。"""
+    from youtube_automation.commands.uploads import collection_uploader
+    from youtube_automation.core.errors import ConfigError
+
+    target = tmp_path / "collections" / "planning" / "20990101-test-collection"
+    target.mkdir(parents=True)
+    mock_uploader = MagicMock()
+    mock_uploader.find_collection.return_value = target
+    mock_uploader.ensure_upload_preflight.side_effect = ConfigError("channel_id mismatch")
+
+    monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "-c", target.name])
+    with (
+        patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=mock_uploader),
+        pytest.raises(SystemExit, match="1"),
+    ):
+        collection_uploader.main()
+
+    mock_uploader.execute_next_step.assert_not_called()
+    mock_uploader.show_plan.assert_not_called()
+    mock_uploader.show_status.assert_not_called()
+
+
 def test_collection_preflight_uses_public_inner_uploader_operation(monkeypatch, tmp_path):
     """Collection domain は内部 uploader の private preflight を直接呼ばない。"""
     from youtube_automation.domains.uploads import collection as collection_domain
@@ -165,6 +188,7 @@ def test_main_title_preflight_honors_collection_opt_in_for_each_cli_entry(
     with (
         patch("youtube_automation.domains.uploads._preflight.load_config", return_value=_title_preflight_config()),
         patch("youtube_automation.domains.uploads._preflight.probe_duration", return_value=3600),
+        patch("youtube_automation.domains.uploads.youtube.YouTubeAutoUploader._verify_authenticated_upload_channel"),
         patch.object(CollectionUploader, method_name) as mock_action,
     ):
         if expected_outcome == "pass":

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -523,6 +523,7 @@ def test_upload_collection_reports_unreachable_tags_min_count_from_channel_confi
 
     assert load_config().content.tags.min_count == 30
     uploader = YouTubeAutoUploader(str(channel_dir / "collections"))
+    monkeypatch.setattr(uploader, "_verify_authenticated_upload_channel", lambda: None)
 
     with pytest.raises(ValidationError) as excinfo:
         uploader.upload_collection(str(collection_dir), apply_default_publish_at=False)

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -110,6 +110,85 @@ def _make_metadata(title: str = "Rainy Jazz") -> dict:
     }
 
 
+def _youtube_service_with_authenticated_channel(channel_id: str | None) -> MagicMock:
+    youtube = MagicMock()
+    items = [] if channel_id is None else [{"id": channel_id}]
+    youtube.channels.return_value.list.return_value.execute.return_value = {"items": items}
+    return youtube
+
+
+class TestUploadChannelIdentityPreflight:
+    def test_rejects_mismatched_authenticated_channel_before_metadata_preflight(self, tmp_path):
+        from youtube_automation.core.errors import ConfigError
+        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.infrastructure.google.youtube import YouTubeClients
+
+        youtube = _youtube_service_with_authenticated_channel("UC_TOKEN_OWNER")
+        uploader = YouTubeAutoUploader(
+            collections_root=str(tmp_path),
+            youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+        )
+
+        with (
+            patch(
+                "youtube_automation.domains.uploads.youtube.load_config",
+                return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
+            ),
+            patch.object(uploader, "_preflight_check") as metadata_preflight,
+            pytest.raises(ConfigError, match="channel_id mismatch"),
+        ):
+            uploader.preflight_check(tmp_path / "collection")
+
+        youtube.channels.return_value.list.assert_called_once_with(part="id", mine=True)
+        metadata_preflight.assert_not_called()
+        youtube.videos.return_value.insert.assert_not_called()
+
+    def test_matching_authenticated_channel_continues_metadata_preflight(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.infrastructure.google.youtube import YouTubeClients
+
+        youtube = _youtube_service_with_authenticated_channel("UC_CONFIGURED")
+        uploader = YouTubeAutoUploader(
+            collections_root=str(tmp_path),
+            youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+        )
+        collection = tmp_path / "collection"
+
+        with (
+            patch(
+                "youtube_automation.domains.uploads.youtube.load_config",
+                return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
+            ),
+            patch.object(uploader, "_preflight_check") as metadata_preflight,
+        ):
+            uploader.preflight_check(collection)
+
+        metadata_preflight.assert_called_once_with(collection)
+
+    def test_rejects_empty_authenticated_channel_response(self, tmp_path):
+        from youtube_automation.core.errors import YouTubeAPIError
+        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.infrastructure.google.youtube import YouTubeClients
+
+        youtube = _youtube_service_with_authenticated_channel(None)
+        uploader = YouTubeAutoUploader(
+            collections_root=str(tmp_path),
+            youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+        )
+
+        with (
+            patch(
+                "youtube_automation.domains.uploads.youtube.load_config",
+                return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
+            ),
+            patch.object(uploader, "_preflight_check") as metadata_preflight,
+            pytest.raises(YouTubeAPIError, match="authenticated user has no YouTube channel"),
+        ):
+            uploader.preflight_check(tmp_path / "collection")
+
+        metadata_preflight.assert_not_called()
+
+
 def _make_preflight_config(supported_languages: list[str]) -> SimpleNamespace:
     return SimpleNamespace(
         audio=SimpleNamespace(
@@ -379,6 +458,7 @@ class TestPreflightTitleTemplateCompliance:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch(
                 "youtube_automation.domains.uploads._preflight.load_config",
                 return_value=_make_title_template_config(["ja", "en", "de"]),
@@ -401,6 +481,7 @@ class TestPreflightTitleTemplateCompliance:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch(
                 "youtube_automation.domains.uploads._preflight.load_config",
                 return_value=_make_title_template_config(["ja", "en", "de"]),
@@ -575,6 +656,7 @@ class TestUploadCollectionForwarding:
         on_complete = MagicMock()
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader, "_preflight_check"),
             patch.object(
                 uploader,
@@ -1517,6 +1599,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader, "_preflight_check"),
             patch.object(
                 uploader,
@@ -1547,6 +1630,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader, "_preflight_check"),
             patch.object(
                 uploader,
@@ -1570,6 +1654,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader, "_preflight_check"),
             patch.object(
                 uploader,


### PR DESCRIPTION
## Summary

- public upload の preflight で OAuth 実チャンネル ID と config の channel_id を照合
- 不一致または空応答を videos.insert / state 変更前に fail-loud 化
- CLI 非ゼロ終了と一致時の既存経路を回帰テストで固定

Closes #3716