### PR TITLE
fix(video-description): clip indexをタイトルから除去する (#3316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(video-upload)`: post-upload の `playlistItems.insert` 失敗を workflow と CLI へ伝播し、プレイリスト割り当て成功前の completed state 確定・live 移動・workflow 更新を防ぐ（#3717）。
+- `fix(video-description)`: Suno の正準 `NN{a|b}-Title` ファイル名から clip index を除去して同一曲の variant を重複検出し、表示名リネーム手順へ確実に渡す（#3316）。
 - `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。
 - `fix(video-upload)`: upload preflight で OAuth 認証済みチャンネル ID と `config/channel/meta.json` を照合し、不一致時は動画作成やローカル state 更新より前に停止する（#3716）。
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -233,6 +233,9 @@ class BAHMetadataGenerator:
         # プレフィックス削除 ("8bit ")
         title = re.sub(r"^8bit\s+", "", title, flags=re.IGNORECASE)
 
+        # 同じ曲の clip variant を番号込みの別タイトルとして扱わない
+        title = re.sub(r"^\d{2,}[ab]-", "", title, flags=re.IGNORECASE)
+
         # 番号プレフィックス削除 ("01-", "02-" 等)
         title = re.sub(r"^\d{2}-", "", title)
 

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -1251,6 +1251,25 @@ class TestDetectDuplicateTrackTitles:
         # 表現は元のタイトルどちらか 1 つに正規化される（実装依存）が、indices は両方含む
         assert any(sorted(v) == [0, 1] for v in result.values())
 
+    def test_canonical_suno_clip_variants_are_grouped_by_track_title(self, tmp_path, monkeypatch):
+        collection = tmp_path / "20260810-live-night-focus"
+        music_dir = collection / "02-Individual-music"
+        music_dir.mkdir(parents=True)
+        (music_dir / "01a-Headphones On At Two.m4a").write_bytes(b"audio")
+        (music_dir / "01b-Headphones On At Two.m4a").write_bytes(b"audio")
+
+        gen = _make_generator("20260810-live-night-focus")
+        gen.collection_path = collection
+        monkeypatch.setattr(gen, "_get_audio_duration", lambda _path: 60)
+
+        tracks = gen.analyze_audio_files()
+
+        assert [track["title"] for track in tracks] == [
+            "Headphones on at Two",
+            "Headphones on at Two",
+        ]
+        assert gen.detect_duplicate_track_titles() == {"Headphones on at Two": [0, 1]}
+
 
 # ===========================================================================
 # 16. 同名楽曲リネームの適用と永続化


### PR DESCRIPTION
## Summary
- Suno の正準 `NN{a|b}-Title` から clip variant prefix を title 導出時に除去
- 同一曲の a/b variant を `detect_duplicate_track_titles()` が重複として検出する回帰テストを追加

Closes #3316