### PR TITLE
fix(video-upload): プレイリスト失敗を伝播する (#3717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(video-upload)`: post-upload の `playlistItems.insert` 失敗を workflow と CLI へ伝播し、プレイリスト割り当て成功前の completed state 確定・live 移動・workflow 更新を防ぐ（#3717）。
 - `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。
 - `fix(video-upload)`: upload preflight で OAuth 認証済みチャンネル ID と `config/channel/meta.json` を照合し、不一致時は動画作成やローカル state 更新より前に停止する（#3716）。
 - `feat(analytics)`: 収集済み動画の ads-per-playback をチャンネル中央値と比較し、低カバレッジの疑いを抽出する `yt-ad-coverage` CLI を追加（#3310）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -49,6 +49,9 @@ class CompleteCollectionExecutorMixin:
         complete_video: dict,
         publish_at: str | None,
     ) -> dict:
+        # playlist 所有権エラー時にローカル状態を成功確定しないため、最初に割り当てる。
+        self._assign_to_playlists(complete_video["video_id"], collection_path)
+
         tracking = {
             **tracking,
             "complete_collection": self._completed_tracking_record(complete_video, publish_at),
@@ -74,15 +77,6 @@ class CompleteCollectionExecutorMixin:
             post_processing_errors.append("workflow_upload")
             logger.error(
                 "⚠️  Complete Collection 後処理エラー (workflow_upload): %s",
-                redact_sensitive_data(str(error), collection_path),
-            )
-
-        try:
-            self._assign_to_playlists(complete_video["video_id"], collection_path)
-        except AutomationError as error:
-            post_processing_errors.append("playlist_assignment")
-            logger.error(
-                "⚠️  Complete Collection 後処理エラー (playlist_assignment): %s",
                 redact_sensitive_data(str(error), collection_path),
             )
 

--- a/src/youtube_automation/domains/uploads/_playlist_assignment.py
+++ b/src/youtube_automation/domains/uploads/_playlist_assignment.py
@@ -7,9 +7,7 @@ import logging
 from pathlib import Path
 
 from youtube_automation.configuration import load_config
-from youtube_automation.core.adapters.errors import ConfigError, YouTubeAPIError
 from youtube_automation.core.adapters.filesystem import path_exists, read_file_text
-from youtube_automation.core.adapters.google.upload import HttpError
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.domains.uploads.playlists import PlaylistManager
 
@@ -20,7 +18,7 @@ class PlaylistAssignmentMixin:
     """アップロード後にプレイリストへ自動追加する mixin。"""
 
     def _assign_to_playlists(self, video_id: str, collection_path: Path):
-        """アップロード後にプレイリストへ自動追加（失敗してもアップロードはブロックしない）"""
+        """アップロード後にプレイリストへ自動追加する。"""
         ws_path = CollectionPaths(collection_path).workflow_state_path
         if not path_exists(ws_path):
             return
@@ -35,14 +33,11 @@ class PlaylistAssignmentMixin:
         if not config.playlists.items:
             return
 
-        try:
-            clients = self.youtube_clients
-            pm = PlaylistManager(clients=clients)
-            assigned = pm.assign_video(video_id, theme, collection_path=collection_path)
-            if assigned:
-                logger.info(f"📋 プレイリスト追加: {assigned}")
-        except (ConfigError, YouTubeAPIError, HttpError) as e:
-            logger.warning(f"⚠️  プレイリスト追加エラー（非致命的）: {e}")
+        clients = self.youtube_clients
+        pm = PlaylistManager(clients=clients)
+        assigned = pm.assign_video(video_id, theme, collection_path=collection_path)
+        if assigned:
+            logger.info(f"📋 プレイリスト追加: {assigned}")
 
 
 __all__ = ["PlaylistAssignmentMixin"]

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -106,24 +106,20 @@ class PlaylistManager:
         where = "末尾" if position is None else f"position={position}"
         logger.info(f"➕ Adding video {video_id} to playlist {playlist_id} ({where})")
 
-        try:
-            snippet: dict = {
-                "playlistId": playlist_id,
-                "resourceId": {"kind": "youtube#video", "videoId": video_id},
-            }
-            if position is not None:
-                snippet["position"] = position
-            request = youtube.playlistItems().insert(part="snippet", body={"snippet": snippet})
-            execute_youtube_request(
-                request,
-                "playlistItems.insert failed",
-                on_attempt=_log_playlist_quota("playlistItems.insert", playlist_id=playlist_id, video_id=video_id),
-            )
-            logger.info(f"✅ Video added to playlist ({where})")
-            return True
-        except (TypeError, ValueError, OSError, ValidationError, YouTubeAPIError) as e:
-            logger.error(f"❌ Failed to add video to playlist: {e}")
-            return False
+        snippet: dict = {
+            "playlistId": playlist_id,
+            "resourceId": {"kind": "youtube#video", "videoId": video_id},
+        }
+        if position is not None:
+            snippet["position"] = position
+        request = youtube.playlistItems().insert(part="snippet", body={"snippet": snippet})
+        execute_youtube_request(
+            request,
+            "playlistItems.insert failed",
+            on_attempt=_log_playlist_quota("playlistItems.insert", playlist_id=playlist_id, video_id=video_id),
+        )
+        logger.info(f"✅ Video added to playlist ({where})")
+        return True
 
     # ─── プレイリスト解決 ──────────────────────────────
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -89,6 +89,25 @@ def test_main_exits_before_state_changes_when_channel_identity_preflight_fails(m
     mock_uploader.show_status.assert_not_called()
 
 
+def test_collection_cli_returns_nonzero_when_playlist_assignment_fails(monkeypatch, tmp_path):
+    """post-upload playlist 失敗は CLI の非ゼロ終了へ伝播する。"""
+    from youtube_automation.commands.uploads import collection_uploader
+    from youtube_automation.core.errors import YouTubeAPIError
+
+    target = tmp_path / "collections" / "planning" / "20990101-test-collection"
+    target.mkdir(parents=True)
+    uploader = MagicMock()
+    uploader.find_collection.return_value = target
+    uploader.execute_next_step.side_effect = YouTubeAPIError("playlistItems.insert failed", status_code=403)
+
+    monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "-c", target.name])
+    with (
+        patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=uploader),
+        pytest.raises(SystemExit, match="1"),
+    ):
+        collection_uploader.main()
+
+
 def test_collection_preflight_uses_public_inner_uploader_operation(monkeypatch, tmp_path):
     """Collection domain は内部 uploader の private preflight を直接呼ばない。"""
     from youtube_automation.domains.uploads import collection as collection_domain
@@ -244,6 +263,28 @@ def test_assign_to_playlists_calls_playlist_manager(workflow_state_file):
     mock_pm_instance.assign_video.assert_called_once_with(
         "VIDEO_ID_123", "Rainy Jazz", collection_path=workflow_state_file
     )
+
+
+def test_assign_to_playlists_propagates_playlist_api_failure(workflow_state_file):
+    """post-upload の playlist API 失敗を workflow 呼び出し元へ伝播する。"""
+    from youtube_automation.core.errors import YouTubeAPIError
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    mock_config = MagicMock()
+    mock_config.playlists.items = {"all": {"title": "All", "playlist_id": "PL_ALL"}}
+    failure = YouTubeAPIError("playlistItems.insert failed", status_code=403)
+
+    with (
+        patch("youtube_automation.domains.uploads._playlist_assignment.load_config", return_value=mock_config),
+        patch("youtube_automation.domains.uploads._playlist_assignment.PlaylistManager") as manager_class,
+        pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"),
+    ):
+        manager_class.return_value.assign_video.side_effect = failure
+        CollectionUploader._assign_to_playlists(
+            SimpleNamespace(youtube_clients=MagicMock()),
+            "VIDEO_ID_123",
+            workflow_state_file,
+        )
 
 
 def test_assign_to_playlists_skips_when_no_theme(tmp_path):
@@ -849,6 +890,37 @@ class TestExecuteCompleteCollectionResume:
         assert tracking["complete_collection"]["video_id"] == "V_PRESERVED"
         assert tracking["complete_collection"]["post_processing_status"] == "partial"
         assert any(diagnostic in record.getMessage() for record in caplog.records)
+
+    def test_playlist_failure_prevents_completed_state_workflow_update_and_live_move(self, tmp_path):
+        """playlistItems.insert 失敗時は planning の未完了 state を維持して例外を返す。"""
+        from youtube_automation.core.errors import YouTubeAPIError
+
+        col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
+        uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
+        uploader.config["collections_management"]["auto_move_to_live"] = True
+        mock_inner.upload_collection.return_value = {
+            "complete_video": {
+                "video_id": "V_PLAYLIST_FAILED",
+                "video_url": "https://www.youtube.com/watch?v=V_PLAYLIST_FAILED",
+                "title": "t",
+                "file_path": "p",
+            }
+        }
+        state_before = (col / "workflow-state.json").read_text(encoding="utf-8")
+        failure = YouTubeAPIError("playlistItems.insert failed", status_code=403)
+
+        with (
+            patch.object(uploader, "_assign_to_playlists", side_effect=failure),
+            pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"),
+        ):
+            uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
+
+        tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
+        assert tracking["status"] == "in_progress"
+        assert tracking["complete_collection"]["status"] == "pending"
+        assert (col / "workflow-state.json").read_text(encoding="utf-8") == state_before
+        assert col.is_dir()
+        assert not (tmp_path / "collections" / "live" / col.name).exists()
 
     def test_should_distinguish_dedup_skip_and_keep_tracking_workflow_consistent_after_live_move(self, tmp_path):
         """dedup skip 時も live 移動後の tracking/workflow-state に既存 video_id を記録する."""

--- a/tests/domains/uploads/test_playlist_manager.py
+++ b/tests/domains/uploads/test_playlist_manager.py
@@ -19,7 +19,7 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, YouTubeAPIError
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 # ---------------------------------------------------------------------------
@@ -404,12 +404,11 @@ class TestAddVideoToPlaylist:
         assert result is True
 
     def test_failure(self, manager, mock_youtube):
-        """API 例外時は False を返す"""
+        """API 例外時は呼び出し元へ失敗を伝播する。"""
         mock_youtube.playlistItems.return_value.insert.return_value.execute.side_effect = OSError("API Error")
 
-        result = manager._add_video_to_playlist("PL123", "VID456")
-
-        assert result is False
+        with pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"):
+            manager._add_video_to_playlist("PL123", "VID456")
 
     def test_passes_correct_body(self, manager, mock_youtube):
         """playlistId / resourceId / position が body に渡される"""
@@ -615,13 +614,13 @@ class TestQuotaLogging:
         assert quota_log.call_count == 3
         assert quota_log.call_args.args == ("youtube-data-api", "playlists.insert", 50)
 
-    def test_add_video_failure_still_records_quota_and_keeps_error(self, manager, mock_youtube, quota_log):
-        """add 失敗時も quota が記録され、元のエラーハンドリング（False 返却）が維持される"""
+    def test_add_video_failure_records_quota_and_propagates_error(self, manager, mock_youtube, quota_log):
+        """playlistItems.insert 失敗は quota を記録し、呼び出し元へ伝播する。"""
         mock_youtube.playlistItems.return_value.insert.return_value.execute.side_effect = OSError("API Error")
 
-        result = manager._add_video_to_playlist("PL_F", "VID_F")
+        with pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"):
+            manager._add_video_to_playlist("PL_F", "VID_F")
 
-        assert result is False
         assert quota_log.call_count == 3
         assert quota_log.call_args.args == ("youtube-data-api", "playlistItems.insert", 50)
 


### PR DESCRIPTION
## Summary

- playlistItems.insert 失敗を workflow / CLI へ fail-loud で伝播
- 割り当て成功前の completed 保存・planning→live 移動・workflow 完了更新を防止
- 失敗時の planning / in_progress / 非ゼロ終了と正常経路を回帰テストで固定

Closes #3717