### PR TITLE
fix(masterup): 起動失敗と逸脱終了コードを分離する (#3317)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -353,13 +353,13 @@ uv run yt-suno-audio-cleanup apply <collection-path>  # 元ファイルを origi
 cleanup の有効・無効にかかわらず、マスター結合前に次の単一スクリプトを実行する。計測・閾値判定・逸脱曲の特定はスクリプトを正とし、本文で再計算しない。
 
 ```bash
-uv run python3 "$(git rev-parse --show-toplevel)/.claude/skills/masterup/references/check_loudness_deviation.py" <collection-path>
+LOUDNESS_SCRIPT="$(git rev-parse --show-toplevel 2>/dev/null)/.claude/skills/masterup/references/check_loudness_deviation.py"; if [ ! -f "$LOUDNESS_SCRIPT" ]; then printf 'ERROR: loudness gate script not found: %s\n' "$LOUDNESS_SCRIPT" >&2; exit 1; fi; uv run python3 "$LOUDNESS_SCRIPT" <collection-path>
 ```
 
 `git rev-parse` は同期済み skill が置かれた workspace root だけを解決し、実行 CWD は変更しない。したがって `channels/<channel>` を CWD にするマルチチャンネル workspace でも、そのチャンネルの `config/channel/` を読みながら同梱スクリプトを起動できる。
 
 - exit 0: PASS と全曲の実測 LUFS を表示し、Step 5 本体へ進む
-- exit 1: 計測または設定エラー。表示された原因を解消して再実行し、Step 5 本体へ進まない
+- exit 1: スクリプト不在などの起動失敗、計測または設定エラー。表示された原因を解消して再実行し、Step 5 本体へ進まない
 - exit 2: FAIL。逸脱曲、実測 LUFS、目標範囲を表示し、AskUserQuestion で次の明示2択を提示する
   1. `cleanup を再処理して再検証する`
   2. `今回の逸脱を許容して続行する`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(masterup)`: Step 5.1 のラウドネス検証スクリプトが見つからない場合を、逸脱 FAIL の exit 2 ではなく起動エラーの exit 1 として明示する事前検証を追加した（#3317）。
+
 - `fix(video-upload)`: post-upload の `playlistItems.insert` 失敗を workflow と CLI へ伝播し、プレイリスト割り当て成功前の completed state 確定・live 移動・workflow 更新を防ぐ（#3717）。
 - `fix(video-description)`: Suno の正準 `NN{a|b}-Title` ファイル名から clip index を除去して同一曲の variant を重複検出し、表示名リネーム手順へ確実に渡す（#3316）。
 - `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。

--- a/tests/repo/test_masterup_loudness_deviation.py
+++ b/tests/repo/test_masterup_loudness_deviation.py
@@ -68,7 +68,7 @@ print(json.dumps({"cwd": str(Path.cwd()), "script": str(Path(__file__).resolve()
     documented = next(
         line
         for line in SKILL.read_text(encoding="utf-8").splitlines()
-        if line.startswith("uv run python3 ") and SCRIPT.name in line
+        if "uv run python3 " in line and SCRIPT.name in line
     )
     command = documented.replace("<collection-path>", shlex.quote(str(collection)))
     env = os.environ.copy()
@@ -91,6 +91,33 @@ print(json.dumps({"cwd": str(Path.cwd()), "script": str(Path(__file__).resolve()
         "script": str(distributed_script),
         "collection": str(collection),
     }
+
+
+def test_documented_invocation_reports_missing_script_as_startup_error(tmp_path: Path) -> None:
+    """#3317: script 不在は逸脱 FAIL ではなく起動エラーとして exit 1 にする。"""
+    workspace = tmp_path / "workspace"
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+    collection = workspace / "collections" / "planning" / "demo"
+    collection.mkdir(parents=True)
+    documented = next(
+        line
+        for line in SKILL.read_text(encoding="utf-8").splitlines()
+        if "uv run python3 " in line and SCRIPT.name in line
+    )
+    command = documented.replace("<collection-path>", shlex.quote(str(collection)))
+
+    completed = subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/bash",
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "ERROR:" in completed.stderr
+    assert SCRIPT.name in completed.stderr
 
 
 def test_parse_loudnorm_input_i_uses_ffmpeg_json(module):


### PR DESCRIPTION
## Summary
- Step 5.1 の起動前に配布スクリプトの存在を検証し、不在時は ERROR と exit 1 で停止
- 実測逸脱の exit 2 と起動失敗を回帰テストで区別
- masterup の終了コード分岐表へ起動失敗を明記

Closes #3317