### PR TITLE
fix(masterup): 無視される目標尺設定を警告する (#3318)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -109,12 +109,12 @@ Lyria で音源を生成するチャンネルでは `/lyria` が `01-master/mast
 | `uv run yt-suno-verify-playlist` | ローカル音声ファイル名または playlist 曲名の突合（混入 / 生成漏れ / clip 不足を fail-loud 検出） | `uv run yt-suno-verify-playlist <collection> --music-dir 02-Individual-music` |
 | (skill-config) `pair_selection.mode` | 歌詞-aware 採用整理。歌詞ありならペア片方、歌詞なしなら両方採用 | `mode: auto` |
 | (skill-config) `pair_selection.min_song_sec` / `.max_song_sec` | 短すぎる / 長すぎる Suno 失敗生成を master から除外 | `min_song_sec: 45`, `max_song_sec: 300` |
-| (skill-config) `audio.target_duration_min` | CLI フラグ未指定時のデフォルト目標尺（分）。`config/skills/masterup.json` 優先、既存 `masterup.yaml` fallback で設定 | `target_duration_min: 120` |
+| (skill-config) `audio.target_duration_min` | 旧 channel override。`config/channel/audio.json` が未設定のときだけ、CLI フラグ未指定時の互換 fallback として使用 | `target_duration_min: 120` |
 | (skill-config) `audio.shuffle` | CLI フラグ未指定時のデフォルトシャッフル設定 | `shuffle: true` |
 | (skill-config) `audio.shuffle_seed` | `audio.shuffle: true` 時のデフォルト seed（整数） | `shuffle_seed: 42` |
 | (skill-config) `audio.pin_first_count` | CLI フラグ未指定時のデフォルト先頭固定数（`0` = 固定なし） | `pin_first_count: 1` |
 
-`uv run yt-generate-master` の値は CLI フラグ > `config/skills/masterup.json` > `config/skills/masterup.yaml` > 組み込み default の順で解決される。組み込み default の `audio.bitrate` / `audio.crossfade_duration` は同梱 `config.default.yaml` と同期テストで固定する。`--crossfade-duration` / `audio.crossfade_duration` は 0 より大きい数値でなければならない。
+`uv run yt-generate-master` の値は通常 CLI フラグ > `config/skills/masterup.json` > `config/skills/masterup.yaml` > 組み込み default の順で解決される。ただし目標尺は CLI フラグ > `config/channel/audio.json` > skill-config の順で、skill-config の `audio.target_duration_min` は channel 側未設定時だけの互換 fallback。組み込み default の `audio.bitrate` / `audio.crossfade_duration` は同梱 `config.default.yaml` と同期テストで固定する。`--crossfade-duration` / `audio.crossfade_duration` は 0 より大きい数値でなければならない。
 
 ## Suno fallback 経路
 

--- a/.claude/skills/masterup/config.default.yaml
+++ b/.claude/skills/masterup/config.default.yaml
@@ -14,9 +14,10 @@ audio:
   # `audio.finalize.bitrate` が明示指定されていればそちらが uv run yt-finalize-master の出力に勝つ。
   bitrate: "192k"
 
-  # CLI フラグ (`--loop` / `--target-duration`) が両方未指定のときに
-  # `uv run yt-generate-master --target-duration MIN` 相当のデフォルト値として使われる。
-  # 同梱デフォルトでは未設定 (= 1 ループで終了)。チャンネル側で opt-in する。
+  # 旧 channel override。config/channel/audio.json に target_duration_min がある場合は
+  # そちらが SSOT となり、この値は警告付きで無視される。channel 側未設定時のみ、
+  # CLI フラグ (`--loop` / `--target-duration`) 未指定時の互換 fallback として使われる。
+  # 同梱デフォルトでは未設定 (= 1 ループで終了)。
   # target_duration_min: 120
 
   # CLI フラグ (`--shuffle` / `--shuffle-seed`) のいずれも未指定のときに

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(masterup)`: Step 5.1 のラウドネス検証スクリプトが見つからない場合を、逸脱 FAIL の exit 2 ではなく起動エラーの exit 1 として明示する事前検証を追加した（#3317）。
 
+- `fix(masterup)`: channel の目標尺が SSOT の場合、skill-config の `audio.target_duration_min` が同値でも無視されることを stderr へ警告し、同梱設定コメントと skill の優先順位説明を実挙動へ揃えた（#3318）。
 - `fix(video-upload)`: post-upload の `playlistItems.insert` 失敗を workflow と CLI へ伝播し、プレイリスト割り当て成功前の completed state 確定・live 移動・workflow 更新を防ぐ（#3717）。
 - `fix(video-description)`: Suno の正準 `NN{a|b}-Title` ファイル名から clip index を除去して同一曲の variant を重複検出し、表示名リネーム手順へ確実に渡す（#3316）。
 - `fix(suno)`: 同梱 `exclude_styles` の既定を空にし、チャンネルまたは collection が明示した場合だけ Suno の Exclude Styles 欄を使うように変更（#3313）。

--- a/src/youtube_automation/commands/media/generate_master.py
+++ b/src/youtube_automation/commands/media/generate_master.py
@@ -487,11 +487,13 @@ def main() -> int:
         if args.loop is None and args.target_duration is None and not args.no_loop:
             channel_target = channel_audio.target_duration_min
             skill_target = audio.get(_TARGET_DURATION_MIN_KEY)
-            if channel_target is not None and skill_target is not None and float(channel_target) != float(skill_target):
+            if channel_target is not None and skill_target is not None:
                 print(
-                    "  Duration target: "
-                    f"channel={channel_target:g}分 / skill={float(skill_target):g}分 "
-                    "→ config/channel/audio.json を SSOT として採用"
+                    "WARNING: masterup.audio.target_duration_min の "
+                    f"skill-config={float(skill_target):g}分は無視し、"
+                    f"channel={channel_target:g}分 "
+                    "(config/channel/audio.json の SSOT) を採用します",
+                    file=sys.stderr,
                 )
             effective_target = channel_target if channel_target is not None else skill_target
             if effective_target is not None:

--- a/tests/commands/media/test_generate_master.py
+++ b/tests/commands/media/test_generate_master.py
@@ -367,7 +367,36 @@ class TestCliSkillConfigTargetDuration:
         assert generate_master.main() == 0
         assert captured["kwargs"]["target_duration_min"] == 60
         assert captured["kwargs"]["target_duration_max"] == 90
-        assert "channel=60分 / skill=120分" in capsys.readouterr().out
+        captured_output = capsys.readouterr()
+        assert captured_output.out == ""
+        assert "WARNING" in captured_output.err
+        assert "skill-config=120分" in captured_output.err
+        assert "channel=60分" in captured_output.err
+        assert "無視" in captured_output.err
+
+    def test_equal_skill_target_still_warns_that_channel_target_wins(self, monkeypatch, tmp_path, capsys):
+        # Given: channel と skill-config に同じ値が設定されていても skill-config は参照されない
+        captured = self._patch_main_dependencies(
+            monkeypatch,
+            {"audio": {"target_duration_min": 60}},
+        )
+        monkeypatch.setattr(
+            "youtube_automation.commands.media.generate_master.load_config",
+            lambda: SimpleNamespace(
+                audio=SimpleNamespace(
+                    target_duration_min=60,
+                    target_duration_max=90,
+                )
+            ),
+        )
+        monkeypatch.setattr("sys.argv", ["yt-generate-master", str(tmp_path)])
+
+        # When
+        assert generate_master.main() == 0
+
+        # Then: 値の一致に隠れず、skill-config が無視される事実を警告する
+        assert captured["kwargs"]["target_duration_min"] == 60
+        assert "skill-config=60分" in capsys.readouterr().err
 
     def test_cli_loop_ignores_skill_config_target_duration(self, monkeypatch, tmp_path):
         # Given: --loop 指定時は skill-config の target_duration_min を黙って無視


### PR DESCRIPTION
## Summary
- channel の目標尺が SSOT の場合、skill-config の同値・異値を問わず無視を stderr へ警告
- masterup の同梱設定コメントと設定優先順位を実挙動へ統一
- skill-config が黙って無視されないリグレッションテストを追加

Closes #3318