### PR TITLE
fix(collection-serve): Windowsで起動可能にする (#3387)

### DIFF
--- a/.github/scripts/classify-ci-paths.sh
+++ b/.github/scripts/classify-ci-paths.sh
@@ -55,7 +55,7 @@ while IFS= read -r path || [ -n "$path" ]; do
   esac
 
   case "$path" in
-    src/youtube_automation/infrastructure/cost_tracker* | tests/infrastructure/test_cost_tracker.py | pyproject.toml | uv.lock | flake.nix | flake.lock | .github/workflows/ci.yml)
+    src/youtube_automation/infrastructure/cost_tracker* | tests/infrastructure/test_cost_tracker.py | src/youtube_automation/infrastructure/file_lock.py | tests/infrastructure/test_file_lock.py | src/youtube_automation/commands/collections/collection_serve.py | tests/commands/collections/test_collection_serve.py | tests/commands/collections/test_collection_serve_lifecycle.py | pyproject.toml | uv.lock | flake.nix | flake.lock | .github/workflows/ci.yml)
       windows=true
       ;;
   esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
         run: uv sync
       - name: Test cost tracker on Windows
         run: uv run pytest tests/infrastructure/test_cost_tracker.py -q
+      - name: Test collection serve import on Windows
+        run: uv run pytest tests/commands/collections/test_collection_serve.py::test_module_import_succeeds_without_fcntl -q
 
   changelog:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(collection-serve)`: 共通ファイルロックを使って `fcntl` 非対応環境でも起動時の排他を維持し、Windows で `yt-collection-serve` を import・起動できるようにした（#3387）。
+
 - `fix(masterup)`: Step 5.1 のラウドネス検証スクリプトが見つからない場合を、逸脱 FAIL の exit 2 ではなく起動エラーの exit 1 として明示する事前検証を追加した（#3317）。
 
 - `fix(masterup)`: channel の目標尺が SSOT の場合、skill-config の `audio.target_duration_min` が同値でも無視されることを stderr へ警告し、同梱設定コメントと skill の優先順位説明を実挙動へ揃えた（#3318）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import fcntl
 import hashlib
 import http.client
 import json
@@ -87,6 +86,7 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
     ChromeExtensionOrigin,
     resolve_unpacked_extension_origin,
 )
+from youtube_automation.infrastructure.file_lock import file_lock
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 DEFAULT_PORT = 7873
@@ -725,19 +725,14 @@ def _lifecycle_stop_path(record: _LifecycleRecord, attempt_token: str) -> str:
 
 
 def _startup_lock_path(root: Path, port: int) -> Path:
-    return root / f".collection-serve-{port}.lock"
+    return root / f".collection-serve-{port}"
 
 
 @contextlib.contextmanager
 def _startup_lock(path: Path):
     """同じ lifecycle record に対する check→bind→publish を直列化する。"""
-    descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
-    try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    with file_lock(path):
         yield
-    finally:
-        fcntl.flock(descriptor, fcntl.LOCK_UN)
-        os.close(descriptor)
 
 
 def _read_pid_file(path: Path) -> _LifecycleRecord | None:

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import signal
 import socket
+import subprocess
 import sys
 import threading
 import urllib.error
@@ -85,6 +86,33 @@ _VERSION_ROUTE = "/version"
 
 # 外部 HTTP 契約（#1352）: 拡張が接続先 selector の label 更新に使う配信元情報。
 _SERVER_INFO_ROUTE = "/server-info"
+
+
+def test_module_import_succeeds_without_fcntl() -> None:
+    """Given fcntl がない環境, When module を import, Then ImportError にならない。"""
+    script = """
+import builtins
+import importlib
+
+original_import = builtins.__import__
+
+def import_without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ImportError("No module named 'fcntl'")
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = import_without_fcntl
+importlib.import_module("youtube_automation.commands.collections.collection_serve")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _collection_prompts_route(cid: str) -> str:

--- a/tests/repo/test_actions_parallel_workflows.py
+++ b/tests/repo/test_actions_parallel_workflows.py
@@ -226,7 +226,14 @@ def test_extensions_pull_request_trigger_keeps_path_filter() -> None:
             ["extensions/shared-ui/src/button.tsx"],
             {"suno", "distrokid", "community"},
         ),
-        (["src/youtube_automation/commands/collections/collection_serve.py"], {"python", "packaging"}),
+        (
+            ["src/youtube_automation/commands/collections/collection_serve.py"],
+            {"python", "packaging", "windows"},
+        ),
+        (
+            ["src/youtube_automation/infrastructure/file_lock.py"],
+            {"python", "packaging", "windows"},
+        ),
         (
             ["src/youtube_automation/infrastructure/cost_tracker.py"],
             {"python", "packaging", "windows"},
@@ -270,6 +277,12 @@ def test_ci_required_jobs_always_report_but_gate_heavy_python_steps() -> None:
 
     assert jobs["build-smoke"]["if"] == "needs.changes.outputs.packaging == 'true'"
     assert jobs["windows-cost-tracker"]["if"] == "needs.changes.outputs.windows == 'true'"
+    windows_steps = jobs["windows-cost-tracker"]["steps"]
+    collection_serve_import_test = (
+        "uv run pytest tests/commands/collections/test_collection_serve.py"
+        "::test_module_import_succeeds_without_fcntl -q"
+    )
+    assert any(step.get("run") == collection_serve_import_test for step in windows_steps)
     assert jobs["adr-numbering"]["if"] == "needs.changes.outputs.adr == 'true'"
 
 


### PR DESCRIPTION
## Summary
- `yt-collection-serve` の起動時排他を共通 cross-platform `file_lock` へ移行
- `fcntl` 不在時の fresh-process import 回帰テストを追加
- collection-serve / 共通ロック変更で Windows CI を起動し、Windows 上でも import を検証

Closes #3387