### PR TITLE
feat(skills-sync): 孤児skill-configを報告する (#3728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。
 - `fix(wf-new)`: `/collection-ideate` と `/wf-new` が現在の channel config・方向性・第一ペルソナ・視聴シーン・creative constraints を固定制約として候補ごとに検証し、違反案を提示・保存・state 反映しない fail-closed gate を追加した（#3727）。
 - `fix(collection-serve)`: 共通ファイルロックを使って `fcntl` 非対応環境でも起動時の排他を維持し、Windows で `yt-collection-serve` を import・起動できるようにした（#3387）。
 - `docs(thumbnail)`: 手動生成で成功候補が複数ある場合、全候補を同時表示・320px 検証して候補番号を受け取るまで確定せず、選択された候補だけを `thumbnail.jpg` / `main.png` として確定する比較選択契約を追加した（#3622）。

--- a/src/youtube_automation/commands/system/skills_sync/_ops.py
+++ b/src/youtube_automation/commands/system/skills_sync/_ops.py
@@ -5,6 +5,7 @@
 - `_copy_entry` / `_symlink_entry`: 単一 entry の配置
 - `_ensure_agents_skills_symlink`: Codex 探索パス `.agents/skills` の symlink を張る
 - `_prune_orphans`: 既知の upstream orphan の列挙・削除
+- `_report_orphan_skill_configs`: 対応する同梱 skill がない channel override の報告
 - `_has_diff`: `filecmp.dircmp` の再帰的差分検出
 """
 
@@ -42,9 +43,31 @@ _KNOWN_REMOVED_SKILL_NAMES = frozenset(
     }
 )
 
+_SKILL_CONFIG_SUFFIXES = frozenset({".json", ".yaml"})
+_COMPATIBLE_SKILL_CONFIG_NAMES = frozenset({"postmortem"})
+
 
 def _prunable_orphan_names(entry_names: set[str], bundled: set[str]) -> set[str]:
     return (entry_names - bundled) & _KNOWN_REMOVED_SKILL_NAMES
+
+
+def _orphan_skill_config_names(config_dir: Path, bundled: set[str]) -> list[str]:
+    """対応する同梱 skill がない channel override 名を返す。"""
+    if not config_dir.is_dir():
+        return []
+    configured = {
+        entry.stem for entry in config_dir.iterdir() if entry.is_file() and entry.suffix in _SKILL_CONFIG_SUFFIXES
+    }
+    return sorted(configured - bundled - _COMPATIBLE_SKILL_CONFIG_NAMES)
+
+
+def _report_orphan_skill_configs(target_dir: Path, bundled: set[str]) -> None:
+    """標準 skills 配置に対応する channel override の孤児を報告する。"""
+    if not (target_dir.name == "skills" and target_dir.parent.name == ".claude"):
+        return
+    config_dir = target_dir.parent.parent / "config" / "skills"
+    for name in _orphan_skill_config_names(config_dir, bundled):
+        print(f"  [warn] 対応する skill が同梱されていません: {name}")
 
 
 def _ensure_target_parent(target: Path) -> None:

--- a/src/youtube_automation/commands/system/skills_sync/_sync.py
+++ b/src/youtube_automation/commands/system/skills_sync/_sync.py
@@ -19,6 +19,7 @@ from youtube_automation.commands.system.skills_sync._ops import (
     _ensure_agents_skills_symlink,
     _ensure_target_parent,
     _prune_orphans,
+    _report_orphan_skill_configs,
     _symlink_entry,
 )
 from youtube_automation.commands.system.skills_sync._settings import sync_settings_asset
@@ -176,14 +177,17 @@ def _sync_dir_asset(
         prefix = "[dry-run] " if args.dry_run else ""
         print(f"  {prefix}{result:>8}: {name}")
 
+    # orphan 判定は **全集合** で行う (--only でフィルタしない)。
+    # `--only` 集合と混同すると bundled の他 entry が孤児と誤認される。
+    bundled = set(all_entries)
     if args.prune:
-        # bundled は **全集合** で判定する (--only でフィルタしない)。
-        # `--only` 集合と混同すると bundled の他 entry が誤って prune される。
-        bundled = set(all_entries)
         do_delete = args.yes and not args.dry_run
         prune_counts = _prune_orphans(target_dir, bundled, do_delete=do_delete)
         for key, val in prune_counts.items():
             counts[key] = counts.get(key, 0) + val
+
+    if args.asset == "skills":
+        _report_orphan_skill_configs(target_dir, bundled)
 
     # skills 配布時は Codex CLI の探索パス `.agents/skills` も併設する。
     # 標準レイアウト (`.claude/skills`) でないときは対象外 (None) でスキップ。

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -236,6 +236,103 @@ def test_cmd_sync_skills_copies_skill_dirs(fake_repo: Path, tmp_path: Path) -> N
     assert (target / "channel-direction" / "SKILL.md").exists()
 
 
+@pytest.mark.parametrize("suffix", [".yaml", ".json"])
+def test_cmd_sync_skills_reports_orphan_skill_config(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    suffix: str,
+) -> None:
+    # Given: 対応する同梱 skill がない channel override
+    channel_dir = tmp_path / "out"
+    target = channel_dir / ".claude" / "skills"
+    config = channel_dir / "config" / "skills" / f"analytics-collect{suffix}"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+
+    # When: skills を sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: 孤児名を報告するが設定ファイルは残す
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "対応する skill が同梱されていません: analytics-collect" in out
+    assert config.exists()
+
+
+def test_cmd_sync_skills_prune_does_not_delete_orphan_skill_config(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Given: 同梱外の skill config
+    channel_dir = tmp_path / "out"
+    target = channel_dir / ".claude" / "skills"
+    config = channel_dir / "config" / "skills" / "analytics-report.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("enabled: true\n", encoding="utf-8")
+
+    # When: 削除承認付き prune で sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force", "--prune", "--yes"])
+    rc = args.func(args)
+
+    # Then: config は列挙されるだけで削除されない
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "対応する skill が同梱されていません: analytics-report" in out
+    assert config.exists()
+
+
+def test_cmd_sync_skills_does_not_report_postmortem_compat_config(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Given: flop-analysis が互換 override として読む postmortem config
+    channel_dir = tmp_path / "out"
+    target = channel_dir / ".claude" / "skills"
+    config = channel_dir / "config" / "skills" / "postmortem.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+
+    # When: skills を sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: 互換 config は孤児報告の観測行に含まれない
+    assert rc == 0
+    warning_lines = [line for line in capsys.readouterr().out.splitlines() if "同梱されていません" in line]
+    assert warning_lines == []
+    assert config.exists()
+
+
+def test_cmd_sync_skills_without_orphan_config_emits_no_orphan_report(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Given: 同梱 skill と対応する config だけがある
+    channel_dir = tmp_path / "out"
+    target = channel_dir / ".claude" / "skills"
+    config = channel_dir / "config" / "skills" / "channel-research.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+
+    # When: skills を sync
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    rc = args.func(args)
+
+    # Then: 追加の孤児報告は出ない
+    assert rc == 0
+    warning_lines = [line for line in capsys.readouterr().out.splitlines() if "同梱されていません" in line]
+    assert warning_lines == []
+
+
 def test_cmd_sync_warns_on_numbered_duplicates_in_target(
     fake_repo: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- `config/skills/` 直下の YAML/JSON を同梱 skill 一覧と照合し、孤児設定を sync 後に報告
- 設定ファイルは `--prune --yes` でも削除せず、互換 override の `postmortem` は除外
- 孤児なし・互換名・非削除の境界をテストで固定

Closes #3728