### PR TITLE
fix(site): operator doc ページの H1 重複を解消する

### DIFF
--- a/site/markdown-title.ts
+++ b/site/markdown-title.ts
@@ -1,0 +1,14 @@
+export interface MarkdownWithTitle {
+  readonly text: string;
+  readonly title: string;
+}
+
+export const extractMarkdownTitle = (markdown: string): MarkdownWithTitle => {
+  const heading = /^#[ \t]+([^\r\n]*)(?:\r?\n|$)/u.exec(markdown);
+  const title = heading?.[1].trim();
+  if (!heading || !title) {
+    throw new Error("Markdown must start with a non-empty leading H1");
+  }
+  const text = markdown.slice(heading[0].length).replace(/^\r?\n/u, "");
+  return { text, title };
+};

--- a/site/operator-doc-source.ts
+++ b/site/operator-doc-source.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { isAbsolute, posix, resolve, sep } from "node:path";
 import type { ContentSource, SourceEntry } from "blume/sources/types";
+import { extractMarkdownTitle } from "./markdown-title.ts";
 
 const GITHUB_BLOB_BASE =
   "https://github.com/daiki-beppu/youtube-automation/blob/main/";
@@ -164,21 +165,23 @@ export const createOperatorDocSource = (options: {
     const path = assertReadableSource(repositoryRoot, mapping.source);
     const original = await readFile(path, "utf8");
     const rewritten = rewriteMarkdownLinks(original, mapping.source, map);
-    const text =
+    const rendered =
       mapping.source === "docs/features.md"
         ? rewriteFeatureSkillLinks(rewritten)
         : rewritten;
+    const { text, title } = extractMarkdownTitle(rendered);
     return {
       body: { format: "md", text },
       data: {
         kind: operatorDocReleaseField,
         released_at: operatorDocReleaseField,
         summary: operatorDocReleaseField,
+        title,
         type: "doc",
         version: operatorDocReleaseField,
       },
       editUrl: `${GITHUB_BLOB_BASE}${mapping.source}`,
-      raw: `---\ntype: doc\n---\n\n${text}`,
+      raw: `---\ntitle: ${JSON.stringify(title)}\ntype: doc\n---\n\n${text}`,
       ref: mapping.source,
       slug: mapping.route,
     };

--- a/site/tests/markdown-title.test.mjs
+++ b/site/tests/markdown-title.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { extractMarkdownTitle } from "../markdown-title.ts";
+
+test("先頭 H1 を title と本文へ分離し、後続の見出し階層を保つ", () => {
+  const markdown = "# Page title\n\nIntroduction\n\n## Details\n\nBody\n";
+
+  const result = extractMarkdownTitle(markdown);
+
+  assert.deepEqual(result, {
+    text: "Introduction\n\n## Details\n\nBody\n",
+    title: "Page title",
+  });
+});
+
+test("先頭に H1 がない本文は明示的に拒否する", () => {
+  const markdown = "Introduction\n\n## Details\n";
+
+  assert.throws(() => extractMarkdownTitle(markdown), /leading H1/i);
+});
+
+test("空の先頭 H1 は明示的に拒否する", () => {
+  const markdown = "#   \n\nBody\n";
+
+  assert.throws(() => extractMarkdownTitle(markdown), /leading H1/i);
+});

--- a/site/tests/operator-doc-source.test.mjs
+++ b/site/tests/operator-doc-source.test.mjs
@@ -45,17 +45,22 @@ test("source は build ごとに原本を読み、安定 route と doc type を�
   const source = createOperatorDocSource({ map: operatorDocMap, repositoryRoot });
   const onboarding = join(repositoryRoot, "ONBOARDING.md");
 
-  await writeFile(onboarding, "# First\n", "utf8");
+  await writeFile(onboarding, "# First\n\n## Details\n\nFirst body\n", "utf8");
   const first = await source.load();
-  await writeFile(onboarding, "# Second\n", "utf8");
+  await writeFile(onboarding, "# Second\n\n## Details\n\nSecond body\n", "utf8");
   const second = await source.load();
 
   assert.equal(first.entries.length, 7);
-  assert.equal(first.entries[0].body.text, "# First\n");
-  assert.equal(second.entries[0].body.text, "# Second\n");
+  assert.equal(first.entries[0].body.text, "## Details\n\nFirst body\n");
+  assert.equal(second.entries[0].body.text, "## Details\n\nSecond body\n");
+  assert.equal(first.entries[0].data.title, "First");
+  assert.equal(second.entries[0].data.title, "Second");
   assert.equal(first.entries[0].slug, operatorDocMap[0].route);
   assert.equal(first.entries[0].data.type, "doc");
-  assert.match(first.entries[0].raw, /^---\ntype: doc\n---/);
+  assert.equal(
+    first.entries[0].raw,
+    '---\ntitle: "First"\ntype: doc\n---\n\n## Details\n\nFirst body\n'
+  );
 });
 
 test("存在しない原本は解決対象を示して fail closed する", async () => {

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -272,6 +272,36 @@ test("operator docs の7 routeを描画・検索し、内部linkとGitHub fallba
   );
 });
 
+test("operator docs の7 route は原本の先頭見出しを唯一の H1 として描画する", async () => {
+  const expectedTitles = new Map([
+    ["/onboarding", "Onboarding"],
+    [
+      "/oauth-setup",
+      "GCP / YouTube API セットアップ（手動ルートと参照情報）",
+    ],
+    ["/features", "全 skill カタログ"],
+    ["/workflow-cheatsheet", "workflow チートシート"],
+    ["/chrome-extension-install-guide", "Chrome 拡張インストールガイド"],
+    ["/dashboard", "Analytics dashboard"],
+    [
+      "/channel-workspace-migration",
+      "単一チャンネル repository から workspace への移行",
+    ],
+  ]);
+
+  for (const [route, expectedTitle] of expectedTitles) {
+    const html = await readOperatorDoc(route);
+    const headings = [...html.matchAll(/<h1(?:\s[^>]*)?>([^<]+)<\/h1>/g)].map(
+      (match) => match[1]
+    );
+
+    assert.deepEqual(headings, [expectedTitle]);
+    if (route === "/onboarding") {
+      assert.match(html, /<h2 id="1-このリポジトリは何か">/);
+    }
+  }
+});
+
 test("非掲載領域は route、navigation、landing、search に現れない", async () => {
   const distDirectory = new URL("../dist/", import.meta.url);
   const generatedPaths = await readdir(distDirectory, { recursive: true });


### PR DESCRIPTION
## Summary

- operator doc の先頭 H1 を抽出し、本文から除去
- 抽出タイトルを SourceEntry の data と raw frontmatter に反映
- 7 ルートの生成 HTML で H1 が 1 つになる回帰テストを追加

Closes #3734