### PR TITLE
fix(site): skill ページの H1 重複を解消する

### DIFF
--- a/site/skill-page-source.ts
+++ b/site/skill-page-source.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 import type { ContentSource, SourceEntry } from "blume/sources/types";
+import { extractMarkdownTitle } from "./markdown-title.ts";
 import { operatorDocReleaseField } from "./operator-doc-source.ts";
 
 const GITHUB_SKILL_BASE =
@@ -175,22 +176,26 @@ const assertInsideRepository = (repositoryRoot: string, path: string): string =>
 const sourceEntry = (
   ref: string,
   slug: string,
-  text: string,
+  markdown: string,
   editUrl?: string
-): SourceEntry => ({
-  body: { format: "md", text },
-  data: {
-    kind: operatorDocReleaseField,
-    released_at: operatorDocReleaseField,
-    summary: operatorDocReleaseField,
-    type: "doc",
-    version: operatorDocReleaseField,
-  },
-  ...(editUrl ? { editUrl } : {}),
-  raw: `---\ntype: doc\n---\n\n${text}`,
-  ref,
-  slug,
-});
+): SourceEntry => {
+  const { text, title } = extractMarkdownTitle(markdown);
+  return {
+    body: { format: "md", text },
+    data: {
+      kind: operatorDocReleaseField,
+      released_at: operatorDocReleaseField,
+      summary: operatorDocReleaseField,
+      title,
+      type: "doc",
+      version: operatorDocReleaseField,
+    },
+    ...(editUrl ? { editUrl } : {}),
+    raw: `---\ntitle: ${JSON.stringify(title)}\ntype: doc\n---\n\n${text}`,
+    ref,
+    slug,
+  };
+};
 
 const loadSkillEntries = async (repositoryRoot: string): Promise<SourceEntry[]> => {
   const skillsRoot = resolve(repositoryRoot, ".claude/skills");

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -108,6 +108,24 @@ test("一覧と全 skill ページを生成し、参照をサイト内リンク�
   assert.doesNotMatch(beta.body.text, /## 前提/);
 });
 
+test("一覧と個別ページの先頭 H1 を title へ分離する", async () => {
+  const repositoryRoot = await createRepository();
+  const source = createSkillPageSource({ repositoryRoot });
+  const result = await source.load();
+
+  const index = result.entries.find((entry) => entry.slug === "/skills");
+  const alpha = result.entries.find((entry) => entry.slug === "/skills/alpha");
+
+  assert.equal(index.data.title, "全 skill 一覧");
+  assert.doesNotMatch(index.body.text, /^# /mu);
+  assert.match(index.body.text, /^## category one$/mu);
+  assert.match(index.raw, /^---\ntitle: "全 skill 一覧"\ntype: doc\n---\n\n/mu);
+  assert.equal(alpha.data.title, "/alpha");
+  assert.doesNotMatch(alpha.body.text, /^# /mu);
+  assert.match(alpha.body.text, /^## 前提$/mu);
+  assert.match(alpha.raw, /^---\ntitle: "\/alpha"\ntype: doc\n---\n\n/mu);
+});
+
 test("skill を追加するとカタログ更新前でも個別ページが増える", async () => {
   const repositoryRoot = await createRepository();
   const source = createSkillPageSource({ repositoryRoot });
@@ -149,7 +167,11 @@ test("production build は一覧と55個の個別ページを公開する", asyn
 
   assert.match(index, /55 個の skill/);
   assert.match(index, /href="\/skills\/wf-new-batch"/);
+  assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
+  assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);
   assert.match(thumbnail, /href="\/skills\/thumbnail-compare"/);
+  assert.equal((thumbnail.match(/<h1\b/g) ?? []).length, 1);
+  assert.match(thumbnail, /<h1[^>]*>\/thumbnail<\/h1>/);
   assert.match(thumbnail, /<h2[^>]*>.*?前提.*?<\/h2>/);
   assert.doesNotMatch(thumbnail, /Subagent Contract|run_in_background|Gotchas/);
 });


### PR DESCRIPTION
## Summary

- #3734 の共通ヘルパーを skill page source に適用
- index／個別ページの先頭 H1 を title へ分離し、本文の見出し階層を維持
- 生成 HTML で H1 が 1 つになる回帰テストを追加

Closes #3735