### PR TITLE
fix(automation-update): multi-channel の設定を検証する (#3755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
 - `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。
 - `fix(wf-new)`: `/collection-ideate` と `/wf-new` が現在の channel config・方向性・第一ペルソナ・視聴シーン・creative constraints を固定制約として候補ごとに検証し、違反案を提示・保存・state 反映しない fail-closed gate を追加した（#3727）。

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -180,12 +180,22 @@ def _run_command(cmd: list[str], cwd: Path) -> int:
         raise _StepFailed(f"{' '.join(cmd)} を起動できません: {e}") from e
 
 
-def _check_channel_config(root: Path) -> str:
-    cmd = ["uv", "run", "yt-doctor", "--json", "--target", str(root)]
+def _channel_roots(root: Path) -> list[Path]:
+    candidates = [root] if (root / "config" / "channel").is_dir() else []
+    candidates.extend(
+        channel_root
+        for channel_root in sorted((root / "channels").glob("*"))
+        if channel_root.is_dir() and (channel_root / "config" / "channel").is_dir()
+    )
+    return candidates or [root]
+
+
+def _check_single_channel_config(channel_root: Path) -> str:
+    cmd = ["uv", "run", "yt-doctor", "--json", "--target", str(channel_root)]
     try:
         proc = subprocess.run(
             cmd,
-            cwd=root,
+            cwd=channel_root,
             capture_output=True,
             text=True,
             check=False,
@@ -214,6 +224,14 @@ def _check_channel_config(root: Path) -> str:
     if proc.returncode != 0:
         return f"{success_message}（warning: yt-doctor の他 check が失敗し exit code {proc.returncode}）"
     return success_message
+
+
+def _check_channel_config(root: Path) -> str:
+    channel_roots = _channel_roots(root)
+    results = [_check_single_channel_config(channel_root) for channel_root in channel_roots]
+    if len(results) == 1:
+        return results[0]
+    return f"{len(results)} チャンネルの config/channel/ ロード成功"
 
 
 def _skills_diff_has_changes(root: Path) -> bool:

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -1093,6 +1093,60 @@ def test_apply_channel_config_check_uses_target_even_when_channel_dir_differs(
     assert main(["apply", "--target", str(repo), "--tag", "v5.6.0"]) == 0
 
 
+def test_channel_config_check_validates_every_channel_in_multi_channel_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(INLINE_TABLE_PYPROJECT, encoding="utf-8")
+    channel_roots = [repo / "channels" / slug for slug in ("ambient", "jazz")]
+    for channel_root in channel_roots:
+        (channel_root / "config" / "channel").mkdir(parents=True)
+    observed_targets: list[Path] = []
+
+    def _doctor(cmd: list[str], **kwargs):
+        target = Path(cmd[-1])
+        observed_targets.append(target)
+        assert kwargs["cwd"] == target
+        payload = {"checks": [{"id": "channel_config", "status": "ok", "message": "config/channel/ ロード成功"}]}
+        return automation_update.subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(automation_update.subprocess, "run", _doctor)
+
+    result = automation_update._check_channel_config(repo)
+
+    assert observed_targets == channel_roots
+    assert result == "2 チャンネルの config/channel/ ロード成功"
+
+
+def test_channel_config_check_fails_when_workspace_has_no_channel_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "workspace"
+    repo.mkdir()
+
+    def _doctor(cmd: list[str], **kwargs):
+        assert cmd == ["uv", "run", "yt-doctor", "--json", "--target", str(repo)]
+        assert kwargs["cwd"] == repo
+        payload = {
+            "checks": [
+                {
+                    "id": "channel_config",
+                    "status": "fail",
+                    "message": "config/channel/ ディレクトリが存在しない",
+                }
+            ]
+        }
+        return automation_update.subprocess.CompletedProcess(cmd, 1, json.dumps(payload), "")
+
+    monkeypatch.setattr(automation_update.subprocess, "run", _doctor)
+
+    with pytest.raises(automation_update._StepFailed, match="config/channel/ ディレクトリが存在しない"):
+        automation_update._check_channel_config(repo)
+
+
 def test_apply_returns_nonzero_when_target_channel_config_is_invalid(
     tmp_path: Path,
     no_network,


### PR DESCRIPTION
## Summary
- multi-channel workspace の `channels/<slug>/config/channel/` を smoke check 対象として検出
- 検出した全チャンネル設定を検証し、single-channel と未生成時の既存契約を維持
- 再現・回帰テストを追加

## Verification
- `nix develop --command uv run pytest tests/commands/system/test_automation_update.py -n auto`（91 passed）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run pytest -n auto`（8191 passed, 1 skipped）

Closes #3755