### PR TITLE
docs(changelog): v5.6.0 に再設計移行を補記する (#3758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。
 - `fix(skills-sync)`: `/analytics` 統合後の旧 `analytics-collect` / `analytics-analyze` / `analytics-report` / `analytics-run` を既知の削除対象へ追加し、`yt-skills sync --prune` の候補表示と `--yes` による削除を可能にした（#3756）。
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
@@ -750,6 +751,15 @@ Python module 移動: あり
 | `youtube_automation.utils.config` | `youtube_automation.configuration` |
 | `youtube_automation.utils.descriptions_md` | `youtube_automation.domains.metadata.descriptions` |
 | `youtube_automation.utils.preflight_checks` | `youtube_automation.domains.uploads.preflight` |
+
+Python module 再設計: あり
+
+| 削除された import path | 移行区分 | 参考 module（置換先ではない） |
+|---|---|---|
+| `youtube_automation.utils.upload_core` | 1 対 1 代替なし（再設計） | `youtube_automation.infrastructure.google.upload` |
+| `youtube_automation.utils.youtube_service` | 1 対 1 代替なし（再設計） | `youtube_automation.infrastructure.google.youtube` |
+
+この 2 件には 1 対 1 の代替 module がない。旧 `YouTubeUploadCore` / `ServiceRegistry` の class ベースから関数ベースへ設計が変わり、利用側で責務を組み直す必要があるため、import 文だけでは移行できない。近い新 API として `youtube_automation.infrastructure.google.upload` の `create_media_upload()`、`youtube_automation.infrastructure.google.youtube` の `create_authenticated_youtube_clients()` を参照できるが、いずれも旧 class の 1 対 1 の置き換えではない。下流の独自スクリプトは必要な認証・client 保持・upload body 生成の責務を確認して再設計する。互換 facade / shim は提供しない。
 
 local fix 衝突注意:
 - flop-analysis: `/postmortem` からの改称（#2023）。下流の `config/skills/postmortem.yaml` は `config/skills/flop-analysis.yaml` へリネームが必要。旧ファイル名は警告付きの互換読み込みのみで、旧 command alias と旧 skill directory は残らない

--- a/docs/changelog-contract.md
+++ b/docs/changelog-contract.md
@@ -112,6 +112,21 @@ Python module 移動: あり
 - 1 module の移動を 1 行とし、旧 path と新 path に同じ値を書かない
 - 旧 path に互換 facade を残す移動はこの表の対象外とし、通常の Migration サマリで互換範囲を説明する
 
+旧 module の削除に伴って API が再設計され、同じ責務を持つ新 module が存在しない場合は、参考にできる新 module を「新 import path」へ書かない。1 対 1 移動の対応表とは分けて、次の行フォーマットで削除と再設計を記録する。
+
+```markdown
+Python module 再設計: あり
+
+| 削除された import path | 移行区分 | 参考 module（置換先ではない） |
+|---|---|---|
+| `youtube_automation.utils.legacy_client` | 1 対 1 代替なし（再設計） | `youtube_automation.infrastructure.google.client` |
+```
+
+- 削除された import path と参考 module は、いずれも `youtube_automation.*` から始まる fully-qualified module path とする
+- 移行区分は `1 対 1 代替なし（再設計）` とし、class ベースから関数ベースへの変更など、呼び出し側の再設計が必要なことを Migration 本文で説明する
+- 参考 module は置換先ではない。機能が近い class・関数を併記する場合も、自動置換できる API と誤認させず、利用者が責務を組み直すための参照として示す
+- 互換 facade / shim がある削除や、単純な module 移動はこの行フォーマットへ混在させない
+
 facade 無しの Python module 移動がないリリースでは、対応表を空のまま置かず、次の 1 行だけを記載する。この状態は「module を移動したが facade が無い」状態と区別される。
 
 ```markdown

--- a/tests/repo/test_import_migration_contract.py
+++ b/tests/repo/test_import_migration_contract.py
@@ -22,8 +22,12 @@ _MOVE_MARKER = "Python module 移動: あり"
 _NO_MOVE_MARKER = "Python module 移動: なし"
 _FACADE_MARKER = "互換 facade: なし"
 _TABLE_HEADER = "| 旧 import path | 新 import path |"
+_REDESIGN_MARKER = "Python module 再設計: あり"
+_REDESIGN_TABLE_HEADER = "| 削除された import path | 移行区分 | 参考 module（置換先ではない） |"
+_REDESIGN_CLASSIFICATION = "1 対 1 代替なし（再設計）"
 _MODULE_PATH_PATTERN = re.compile(r"youtube_automation(?:\.[A-Za-z_][A-Za-z0-9_]*)+\Z")
 _ROW_PATTERN = re.compile(r"\| `([^`]+)` \| `([^`]+)` \|")
+_REDESIGN_ROW_PATTERN = re.compile(rf"\| `([^`]+)` \| {_REDESIGN_CLASSIFICATION} \| `([^`]+)` \|")
 _LEGACY_UTILS_PREFIX = "youtube_automation." + "utils"
 _V560_IMPORT_MAPPINGS = [
     (
@@ -38,6 +42,18 @@ _V560_IMPORT_MAPPINGS = [
     (
         f"{_LEGACY_UTILS_PREFIX}.preflight_checks",
         "youtube_automation.domains.uploads.preflight",
+    ),
+]
+_V560_REDESIGN_MAPPINGS = [
+    (
+        f"{_LEGACY_UTILS_PREFIX}.upload_core",
+        "youtube_automation.infrastructure.google.upload",
+        "create_media_upload",
+    ),
+    (
+        f"{_LEGACY_UTILS_PREFIX}.youtube_service",
+        "youtube_automation.infrastructure.google.youtube",
+        "create_authenticated_youtube_clients",
     ),
 ]
 
@@ -101,6 +117,30 @@ def test_no_move_example_is_a_distinct_table_free_state() -> None:
     assert _FACADE_MARKER not in no_move_example
 
 
+def test_redesign_example_has_a_distinct_non_replacement_row_format() -> None:
+    examples = _markdown_examples()
+    redesign_example = next(example for example in examples if example.startswith(_REDESIGN_MARKER))
+    lines = redesign_example.splitlines()
+    rows = [_REDESIGN_ROW_PATTERN.fullmatch(line) for line in lines]
+    mappings = [match.groups() for match in rows if match is not None]
+
+    assert _REDESIGN_TABLE_HEADER in lines
+    assert "|---|---|---|" in lines
+    assert mappings
+    for removed_path, reference_path in mappings:
+        assert _MODULE_PATH_PATTERN.fullmatch(removed_path)
+        assert _MODULE_PATH_PATTERN.fullmatch(reference_path)
+        assert removed_path != reference_path
+
+
+def test_redesign_contract_does_not_represent_a_reference_as_a_replacement() -> None:
+    section = _contract_section()
+
+    assert "1 対 1 移動の対応表とは分けて" in section
+    assert "参考 module は置換先ではない" in section
+    assert "class ベースから関数ベース" in section
+
+
 def test_v560_migration_lists_the_facade_less_import_mappings() -> None:
     migration = _v560_migration_section()
     rows = [_ROW_PATTERN.fullmatch(line) for line in migration.splitlines()]
@@ -111,9 +151,53 @@ def test_v560_migration_lists_the_facade_less_import_mappings() -> None:
     assert mappings == _V560_IMPORT_MAPPINGS
 
 
+def test_v560_migration_lists_the_modules_removed_by_redesign() -> None:
+    migration = _v560_migration_section()
+    rows = [_REDESIGN_ROW_PATTERN.fullmatch(line) for line in migration.splitlines()]
+    mappings = [match.groups() for match in rows if match is not None]
+    expected = [(removed_path, reference_path) for removed_path, reference_path, _ in _V560_REDESIGN_MAPPINGS]
+
+    assert _REDESIGN_MARKER in migration
+    assert mappings == expected
+    assert "class ベースから関数ベース" in migration
+    assert "1 対 1 の置き換えではない" in migration
+
+
 def test_v560_canonical_import_paths_are_importable_in_subprocess() -> None:
     canonical_paths = [new_path for _, new_path in _V560_IMPORT_MAPPINGS]
     script = "\n".join(["import importlib", *(f'importlib.import_module("{path}")' for path in canonical_paths)])
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_v560_removed_modules_are_unimportable_and_reference_apis_are_importable() -> None:
+    legacy_paths = [old_path for old_path, _, _ in _V560_REDESIGN_MAPPINGS]
+    reference_apis = [(module_path, symbol) for _, module_path, symbol in _V560_REDESIGN_MAPPINGS]
+    script = "\n".join(
+        [
+            "import importlib",
+            f"legacy_paths = {legacy_paths!r}",
+            "for path in legacy_paths:",
+            "    try:",
+            "        importlib.import_module(path)",
+            "    except ModuleNotFoundError as exc:",
+            "        assert exc.name == path, (path, exc.name)",
+            "    else:",
+            "        raise AssertionError(f'{path} must not be importable')",
+            f"reference_apis = {reference_apis!r}",
+            "for module_path, symbol in reference_apis:",
+            "    module = importlib.import_module(module_path)",
+            "    assert callable(getattr(module, symbol))",
+        ]
+    )
 
     result = subprocess.run(
         [sys.executable, "-c", script],


### PR DESCRIPTION
## Summary
- v5.6.0 Migration に削除済み2 moduleを fully-qualified path で追記
- 1対1代替なし・classからfunctionへの再設計と、非置換の参照APIを明示
- #3476 と整合する行フォーマットと import contract test を追加

## Verification
- 関連契約テスト（28 passed）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run pytest -n auto`（8208 passed, 1 skipped）
- `nix develop --command uv run yt-skills lint`（55 skills）

Closes #3758