### PR TITLE
fix(suno): 記号を共通正規化して名前照合する (#3759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(suno)`: Suno の prompt 名・ZIP 内ファイル名・ローカル選曲名を、Unicode の文字・結合文字・数字だけを残す共通キーで照合し、em dash / en dash / horizontal bar の空白化とアポストロフィ除去を吸収する。正規化後に複数 prompt が候補になる場合は誤選択せず停止する（#3759）。
 - `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。
 - `fix(skills-sync)`: `/analytics` 統合後の旧 `analytics-collect` / `analytics-analyze` / `analytics-report` / `analytics-run` を既知の削除対象へ追加し、`yt-skills sync --prune` の候補表示と `--yes` による削除を可能にした（#3756）。
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,6 +184,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `infrastructure.media.collection_paths` | コレクションディレクトリ構造の解決 |
 | `domains.suno` | Suno 設定、歌詞、プロンプト、プレイリスト、選曲の生成・検証 |
 | `domains.suno.downloaded` | downloaded payload、workflow、検証、archive、apply transaction |
+| `domains.suno.name_matching` | prompt・playlist・downloaded filename 共通の名前正規化と曖昧性検出 |
 | `domains.metadata` | `service` の状態付き orchestration と titles / descriptions / tags / localizations leaf |
 | `domains.analytics` | Analytics の Protocol、収集、分析、レポート、時系列 policy。SDK/client は adapter 境界で解決 |
 | `domains.thumbnail` | サムネ特徴量、相関、参照、archive、選択 policy（Pillow） |

--- a/src/youtube_automation/commands/suno/suno_verify_playlist.py
+++ b/src/youtube_automation/commands/suno/suno_verify_playlist.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,8 +15,11 @@ from youtube_automation.domains.suno.downloaded.archive import (
     _AUDIO_EXTENSIONS,
     _CANONICAL_MUSIC_FILENAME_RE,
     _sanitize_output_stem,
-    _suno_name_lookup_candidates,
     canonicalize_noncanonical_music_files,
+)
+from youtube_automation.domains.suno.name_matching import (
+    normalize_suno_name_for_lookup,
+    suno_name_lookup_candidates,
 )
 from youtube_automation.domains.suno.playlist import (
     format_verification_report,
@@ -28,7 +30,6 @@ from youtube_automation.domains.suno.playlist import (
 from youtube_automation.domains.suno.prompts import read_suno_prompt_entries
 from youtube_automation.infrastructure.media.collection_paths import resolve_collection_dir
 
-_APOSTROPHE_RE = re.compile(r"['’]")
 _TITLE_SOURCE_ERROR = (
     "playlist 曲名の入力元は --titles / --titles-file / --music-dir / stdin のいずれか 1 つにしてください"
 )
@@ -42,16 +43,13 @@ class SunoPromptTitleIdentity:
 
 def _suno_title_aliases(value: str) -> tuple[str, ...]:
     aliases: list[str] = []
-    for candidate in _suno_name_lookup_candidates(value):
+    for candidate in suno_name_lookup_candidates(value):
         try:
             sanitized = _sanitize_output_stem(candidate)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
         if sanitized and sanitized not in aliases:
             aliases.append(sanitized)
-        without_apostrophe = _APOSTROPHE_RE.sub("", sanitized)
-        if without_apostrophe and without_apostrophe not in aliases:
-            aliases.append(without_apostrophe)
     return tuple(aliases)
 
 
@@ -91,7 +89,7 @@ def _build_music_dir_title_lookups(
     for identity in identities:
         for alias in identity.aliases:
             exact_lookup.setdefault(alias, set()).add(identity.canonical_title)
-            normalized_lookup.setdefault(normalize_title(alias), set()).add(identity.canonical_title)
+            normalized_lookup.setdefault(normalize_suno_name_for_lookup(alias), set()).add(identity.canonical_title)
     return exact_lookup, normalized_lookup
 
 
@@ -131,7 +129,10 @@ def _read_music_dir_titles(
         indexed_title = identities[entry_index - 1].canonical_title
         canonical_titles = exact_title_lookup.get(title)
         if canonical_titles is None:
-            canonical_titles = normalized_title_lookup.get(normalize_title(title), set())
+            canonical_titles = normalized_title_lookup.get(normalize_suno_name_for_lookup(title), set())
+            if len(canonical_titles) > 1:
+                matches = ", ".join(sorted(canonical_titles))
+                raise ValidationError(f"ambiguous Suno name {title!r}: matches {matches}")
         canonical_title = indexed_title if indexed_title in canonical_titles else None
         if canonical_title is None:
             titles.append(audio_path.name)

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -16,6 +16,11 @@ from youtube_automation.domains.suno.downloaded.models import (
     DownloadedArtifactError,
     PromptEntriesReader,
 )
+from youtube_automation.domains.suno.name_matching import (
+    SunoNameIndex,
+    split_suno_duplicate_stem,
+    suno_name_lookup_candidates,
+)
 
 _AUDIO_EXTENSIONS = frozenset({".mp3", ".m4a", ".wav"})
 _ZIP_MAX_TOTAL_SIZE = 2 * 1024 * 1024 * 1024
@@ -95,44 +100,8 @@ def extract_downloaded_archive(
 
 _CANONICAL_MUSIC_FILENAME_RE = re.compile(r"^(?P<index>\d{2,})(?P<variant>[ab])-(?P<title>.+)$")
 # ブラウザ手動 DL の重複ベース名（`Title (1).mp3`）と Suno ZIP 由来の `Title_1.mp3` を同一 entry の別 clip とみなす
-_DUP_SUFFIX_RE = re.compile(r"^(?P<base>.+?)(?:\s*\((?P<paren>\d+)\)|_(?P<underscore>\d+))$")
-_SUNO_TRACK_PREFIX_RE = re.compile(r"^Track\s+\d+\s+(.+)$", re.IGNORECASE)
-_LATIN_TITLE_TAIL_RE = re.compile(r"([A-Za-z][A-Za-z0-9 &'(),.!?:/-]*)$")
-# Suno はダウンロード ZIP 内のファイル名からアポストロフィを除去する（例: Greed's Rhythm → Greeds Rhythm.m4a）。
-# typographic apostrophe（U+2019）も同一視する。それ以外の記号は Suno 仕様が未確認のため除去しない
-_APOSTROPHE_RE = re.compile(r"['’]")
-_LOOKUP_EM_DASH_RE = re.compile(r"\s*—\s*")
-_LOOKUP_SPACE_RE = re.compile(r"\s+")
 _OUTPUT_STEM_SEPARATOR_RE = re.compile(r"[\\/]+")
 _OUTPUT_STEM_SPACE_RE = re.compile(r"\s+")
-
-
-def _strip_suno_track_prefix(stem: str) -> str:
-    match = _SUNO_TRACK_PREFIX_RE.match(stem.strip())
-    if match is None:
-        return stem.strip()
-    return match.group(1).strip()
-
-
-def _suno_name_lookup_candidates(name: str) -> list[str]:
-    base = _strip_suno_track_prefix(name)
-    candidates = [base]
-    if " — " in base:
-        candidates.append(base.split(" — ", 1)[1].strip())
-    tail_match = _LATIN_TITLE_TAIL_RE.search(base)
-    if tail_match:
-        candidates.append(tail_match.group(1).strip())
-
-    deduped: list[str] = []
-    for candidate in candidates:
-        if candidate and candidate not in deduped:
-            deduped.append(candidate)
-    return deduped
-
-
-def _normalize_suno_name_for_lookup(name: str) -> str:
-    with_canonical_dash = _LOOKUP_EM_DASH_RE.sub(" — ", name)
-    return _LOOKUP_SPACE_RE.sub(" ", with_canonical_dash).strip()
 
 
 def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str]]:
@@ -141,18 +110,12 @@ def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str]]:
     raw_stems = [relative_stem, member_path.stem]
     deduped: list[tuple[str, str]] = []
     for raw_stem in raw_stems:
-        dup_match = _DUP_SUFFIX_RE.fullmatch(raw_stem.strip())
-        if dup_match is not None and int(dup_match.group("paren") or dup_match.group("underscore")) == 1:
-            stem = dup_match.group("base")
-            variant = "b"
-        else:
-            stem = raw_stem
-            variant = "a"
-        for candidate in _suno_name_lookup_candidates(stem):
-            for lookup in (candidate, _normalize_suno_name_for_lookup(candidate)):
-                item = (lookup, variant)
-                if lookup and item not in deduped:
-                    deduped.append(item)
+        stem, duplicate_number = split_suno_duplicate_stem(raw_stem)
+        variant = "b" if duplicate_number == 1 else "a"
+        for candidate in suno_name_lookup_candidates(stem):
+            item = (candidate, variant)
+            if item not in deduped:
+                deduped.append(item)
     return deduped
 
 
@@ -164,55 +127,41 @@ def _sanitize_output_stem(stem: str) -> str:
     return sanitized
 
 
-def _build_name_to_index(coll_dir: Path, prompt_entries_reader: PromptEntriesReader) -> dict[str, int]:
+def _build_name_to_index(coll_dir: Path, prompt_entries_reader: PromptEntriesReader) -> SunoNameIndex:
     prompts_path = coll_dir / DOCUMENTATION_DIRNAME / SUNO_PROMPTS_JSON_FILENAME
-    name_to_index: dict[str, int] = {}
     if not prompts_path.is_file():
-        return name_to_index
+        return SunoNameIndex.build([])
     try:
         prompts = prompt_entries_reader(coll_dir)
     except ValueError as exc:
         print(f"[yt-collection-serve] invalid {SUNO_PROMPTS_JSON_FILENAME}: {prompts_path}: {exc}")
         raise ValueError(f"invalid {SUNO_PROMPTS_JSON_FILENAME}") from exc
+    alias_groups: list[tuple[int, tuple[str, ...]]] = []
     for i, entry in enumerate(prompts, 1):
         if not isinstance(entry, dict):
             raise ValueError(f"invalid {SUNO_PROMPTS_JSON_FILENAME}: entry {i} must be an object")
         full_name = entry.get("name", "")
         if not isinstance(full_name, str):
             raise ValueError(f"invalid {SUNO_PROMPTS_JSON_FILENAME}: entry {i}.name must be a string")
-        parts = full_name.split(" — ", 1)
-        english_name = parts[1] if len(parts) == 2 else full_name
-        for candidate in _suno_name_lookup_candidates(english_name):
-            name_to_index[candidate] = i
-        for candidate in _suno_name_lookup_candidates(full_name):
-            name_to_index[candidate] = i
         title = entry.get("title")
         if title is not None and not isinstance(title, str):
             raise ValueError(f"invalid {SUNO_PROMPTS_JSON_FILENAME}: entry {i}.title must be a string")
-        if title:
-            for candidate in _suno_name_lookup_candidates(title):
-                name_to_index.setdefault(candidate, i)
-    # Suno が ZIP ファイル名から除去するアポストロフィの除去版キーを fallback として登録する (#1787)。
-    # exact match を優先するため setdefault（既存キーは上書きしない）
-    for key, track_index in list(name_to_index.items()):
-        stripped = _APOSTROPHE_RE.sub("", key)
-        if stripped and stripped != key:
-            name_to_index.setdefault(stripped, track_index)
-        normalized = _normalize_suno_name_for_lookup(key)
-        if normalized and normalized != key:
-            name_to_index.setdefault(normalized, track_index)
-    return name_to_index
+        sources = (full_name, title) if title else (full_name,)
+        aliases = tuple(
+            dict.fromkeys(candidate for source in sources for candidate in suno_name_lookup_candidates(source))
+        )
+        alias_groups.append((i, aliases))
+    return SunoNameIndex.build(alias_groups)
 
 
 def _music_stem_lookup_candidates(stem: str) -> list[tuple[str, int]]:
     """非正準形 stem から (照合候補, 重複連番) を列挙する。重複連番 0 は suffix なしの基準ファイル。"""
     candidates: list[tuple[str, int]] = []
-    for candidate in _suno_name_lookup_candidates(stem):
+    for candidate in suno_name_lookup_candidates(stem):
         candidates.append((candidate, 0))
-    dup_match = _DUP_SUFFIX_RE.fullmatch(stem.strip())
-    if dup_match is not None:
-        dup_no = int(dup_match.group("paren") or dup_match.group("underscore"))
-        for candidate in _suno_name_lookup_candidates(dup_match.group("base")):
+    base, dup_no = split_suno_duplicate_stem(stem)
+    if dup_no:
+        for candidate in suno_name_lookup_candidates(base):
             item = (candidate, dup_no)
             if item not in candidates:
                 candidates.append(item)
@@ -231,8 +180,8 @@ def canonicalize_noncanonical_music_files(
     """
     if not music_dir.is_dir():
         return []
-    name_to_index = _build_name_to_index(coll_dir, prompt_entries_reader)
-    if not name_to_index:
+    name_index = _build_name_to_index(coll_dir, prompt_entries_reader)
+    if not name_index:
         return []
 
     occupied_variants: dict[int, set[str]] = {}
@@ -246,11 +195,12 @@ def canonicalize_noncanonical_music_files(
                 canonical_match.group("variant")
             )
             continue
-        for candidate, dup_no in _music_stem_lookup_candidates(audio_path.stem):
-            track_num = name_to_index.get(candidate)
-            if track_num is not None:
-                matched_files.setdefault(track_num, []).append((dup_no, audio_path.name, audio_path, candidate))
-                break
+        lookup_candidates = _music_stem_lookup_candidates(audio_path.stem)
+        resolved = name_index.resolve_with_candidate(candidate for candidate, _ in lookup_candidates)
+        if resolved is not None:
+            track_num, lookup = resolved
+            dup_no = next(number for candidate, number in lookup_candidates if candidate == lookup)
+            matched_files.setdefault(track_num, []).append((dup_no, audio_path.name, audio_path, lookup))
 
     renames: list[tuple[Path, Path]] = []
     planned_dests: set[str] = set()
@@ -291,7 +241,7 @@ def _extract_and_rename_music_to_dir(
         print(f"[yt-collection-serve] ZIP が無効です（skip）: {download_path}")
         return DownloadedArchiveResult(audio_count=0, placed_count=0)
 
-    name_to_index = _build_name_to_index(coll_dir, prompt_entries_reader)
+    name_index = _build_name_to_index(coll_dir, prompt_entries_reader)
     target_dir.mkdir(parents=True, exist_ok=True)
     tmp_dir = tempfile.mkdtemp(prefix="suno-extract-")
     try:
@@ -321,18 +271,13 @@ def _extract_and_rename_music_to_dir(
                     print(f"[yt-collection-serve] 危険な ZIP entry をスキップします: {info.filename}")
                     continue
                 extracted_path = Path(zf.extract(info, tmp_dir))
-                track_num = None
-                lookup = ""
-                variant = "a"
-                for candidate, candidate_variant in _zip_member_lookup_candidates(info.filename):
-                    if candidate in name_to_index:
-                        lookup = candidate
-                        variant = candidate_variant
-                        track_num = name_to_index[candidate]
-                        break
-                if track_num is None:
+                lookup_candidates = _zip_member_lookup_candidates(info.filename)
+                resolved = name_index.resolve_with_candidate(candidate for candidate, _ in lookup_candidates)
+                if resolved is None:
                     print(f"[yt-collection-serve] prompts に未対応の音声ファイルをスキップします: {info.filename}")
                     continue
+                track_num, lookup = resolved
+                variant = next(value for candidate, value in lookup_candidates if candidate == lookup)
                 extracted_audio.append((extracted_path, lookup, track_num, variant))
 
         moved_count = 0

--- a/src/youtube_automation/domains/suno/name_matching.py
+++ b/src/youtube_automation/domains/suno/name_matching.py
@@ -1,0 +1,139 @@
+"""Suno prompt names and downloaded filenames share this matching policy."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Hashable, Iterable
+from dataclasses import dataclass
+from typing import TypeVar
+
+_SUNO_TRACK_PREFIX_RE = re.compile(r"^Track\s+\d+\s+(.+)$", re.IGNORECASE)
+_LATIN_TITLE_TAIL_RE = re.compile(r"([A-Za-z][A-Za-z0-9 &'(),.!?:/-]*)$")
+_DUP_SUFFIX_RE = re.compile(r"^(?P<base>.+?)(?:\s*\((?P<paren>\d+)\)|_(?P<underscore>\d+))$")
+
+_Identifier = TypeVar("_Identifier", bound=Hashable)
+
+
+class AmbiguousSunoNameError(ValueError):
+    """A filename resolves to more than one prompt after normalization."""
+
+
+def normalize_suno_name_for_lookup(value: str) -> str:
+    """Build a case-insensitive key from Unicode letters, marks, and numbers.
+
+    Suno can remove punctuation while leaving or inserting whitespace in archive
+    filenames.  NFKC first aligns compatibility forms; retaining only semantic
+    letter/mark/number characters then gives every punctuation, symbol, and
+    whitespace character one policy instead of maintaining a character list.
+    """
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(char for char in normalized if unicodedata.category(char)[0] in {"L", "M", "N"})
+
+
+def suno_name_lookup_candidates(name: str) -> tuple[str, ...]:
+    """Return full and derived aliases in most-specific-first order."""
+    prefix_match = _SUNO_TRACK_PREFIX_RE.match(name.strip())
+    base = prefix_match.group(1).strip() if prefix_match is not None else name.strip()
+    candidates = [base]
+    dash_positions = [index for index, char in enumerate(base) if unicodedata.category(char) == "Pd"]
+    candidates.extend(base[index + 1 :].strip() for index in dash_positions)
+    tail_match = _LATIN_TITLE_TAIL_RE.search(base)
+    if tail_match is not None:
+        candidates.append(tail_match.group(1).strip())
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def split_suno_duplicate_stem(stem: str) -> tuple[str, int]:
+    """Split Suno's ``Title_1`` / browser ``Title (1)`` duplicate suffix."""
+    match = _DUP_SUFFIX_RE.fullmatch(stem.strip())
+    if match is None:
+        return stem.strip(), 0
+    duplicate_number = int(match.group("paren") or match.group("underscore"))
+    return match.group("base"), duplicate_number
+
+
+@dataclass(frozen=True, slots=True)
+class SunoNameIndex:
+    """Resolve exact aliases and accept only unique normalized matches."""
+
+    exact: dict[str, _Identifier]
+    normalized: dict[str, frozenset[_Identifier]]
+
+    @classmethod
+    def build(
+        cls,
+        alias_groups: Iterable[tuple[_Identifier, Iterable[str]]],
+    ) -> SunoNameIndex:
+        exact: dict[str, _Identifier] = {}
+        normalized: dict[str, set[_Identifier]] = {}
+        for identifier, aliases in alias_groups:
+            for alias in aliases:
+                if not alias:
+                    continue
+                exact[alias] = identifier
+                key = normalize_suno_name_for_lookup(alias)
+                if key:
+                    normalized.setdefault(key, set()).add(identifier)
+        return cls(
+            exact=exact,
+            normalized={key: frozenset(values) for key, values in normalized.items()},
+        )
+
+    def __bool__(self) -> bool:
+        return bool(self.exact)
+
+    def resolve(self, candidates: Iterable[str]) -> _Identifier | None:
+        resolved = self.resolve_with_candidate(candidates)
+        return None if resolved is None else resolved[0]
+
+    def resolve_with_candidate(
+        self,
+        candidates: Iterable[str],
+    ) -> tuple[_Identifier, str] | None:
+        ordered = tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+        if not ordered:
+            return None
+
+        full_name = ordered[0]
+        exact_full = self.exact.get(full_name)
+        if exact_full is not None:
+            return exact_full, full_name
+        if not _has_non_latin_letters(full_name):
+            normalized_full = self._normalized_match(full_name)
+            if normalized_full is not None:
+                return normalized_full, full_name
+        for candidate in ordered[1:]:
+            exact_alias = self.exact.get(candidate)
+            if exact_alias is not None:
+                return exact_alias, candidate
+        normalized_full = self._normalized_match(full_name)
+        if normalized_full is not None:
+            return normalized_full, full_name
+        for candidate in ordered[1:]:
+            normalized_alias = self._normalized_match(candidate)
+            if normalized_alias is not None:
+                return normalized_alias, candidate
+        return None
+
+    def _normalized_match(self, candidate: str) -> _Identifier | None:
+        key = normalize_suno_name_for_lookup(candidate)
+        return self._unique_match(candidate, self.normalized.get(key))
+
+    @staticmethod
+    def _unique_match(
+        candidate: str,
+        matches: frozenset[_Identifier] | None,
+    ) -> _Identifier | None:
+        if not matches:
+            return None
+        if len(matches) > 1:
+            identifiers = ", ".join(str(identifier) for identifier in sorted(matches, key=str))
+            raise AmbiguousSunoNameError(f"ambiguous Suno name {candidate!r}: matches {identifiers}")
+        return next(iter(matches))
+
+
+def _has_non_latin_letters(value: str) -> bool:
+    return any(
+        unicodedata.category(char).startswith("L") and "LATIN" not in unicodedata.name(char, "") for char in value
+    )

--- a/src/youtube_automation/domains/suno/playlist.py
+++ b/src/youtube_automation/domains/suno/playlist.py
@@ -11,24 +11,21 @@ fail-loud で検出する。
 
 from __future__ import annotations
 
-import re
 import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping
 
 from youtube_automation.core.adapters.errors import ValidationError
+from youtube_automation.domains.suno.name_matching import normalize_suno_name_for_lookup
 from youtube_automation.domains.suno.prompts import read_suno_prompt_entries
 
-_WS_RE = re.compile(r"\s+")
 _MAX_DISPLAY_TEXT_LEN = 200
 
 
 def normalize_title(value: str) -> str:
-    """タイトル照合キーを正規化する（NFKC + 空白圧縮 + casefold）."""
-    text = unicodedata.normalize("NFKC", value)
-    text = _WS_RE.sub(" ", text).strip()
-    return text.casefold()
+    """タイトル照合キーを Suno filename と同じ方針で正規化する."""
+    return normalize_suno_name_for_lookup(value)
 
 
 @dataclass(frozen=True)

--- a/src/youtube_automation/domains/suno/selection.py
+++ b/src/youtube_automation/domains/suno/selection.py
@@ -23,6 +23,12 @@ from pathlib import Path
 
 from youtube_automation.core.adapters.errors import ValidationError
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
+from youtube_automation.domains.suno.name_matching import (
+    AmbiguousSunoNameError,
+    SunoNameIndex,
+    split_suno_duplicate_stem,
+    suno_name_lookup_candidates,
+)
 from youtube_automation.domains.suno.prompts import read_suno_prompt_entries
 
 DOCUMENTATION_DIRNAME = "20-documentation"
@@ -42,6 +48,7 @@ _STOCK_TEMPLATE_FIELDS = {"collection_slug", "song_id", "title_slug", "ext"}
 class PromptEntry:
     index: int
     has_lyrics: bool
+    aliases: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -307,10 +314,20 @@ def load_prompts(collection_dir: Path) -> list[PromptEntry]:
     for i, entry in enumerate(data, 1):
         if not isinstance(entry, Mapping):
             raise ValidationError(f"{SUNO_PROMPTS_JSON_FILENAME}: entry {i} must be an object")
+        name = entry.get("name")
+        title = entry.get("title")
+        if not isinstance(name, str) or not name.strip():
+            raise ValidationError(f"{SUNO_PROMPTS_JSON_FILENAME}: entry {i}.name must be a non-empty string")
+        if title is not None and not isinstance(title, str):
+            raise ValidationError(f"{SUNO_PROMPTS_JSON_FILENAME}: entry {i}.title must be a string")
+        sources = (name, title) if title and title.strip() else (name,)
         prompts.append(
             PromptEntry(
                 index=i,
                 has_lyrics=_has_substantive_lyrics(entry.get("lyrics")),
+                aliases=tuple(
+                    dict.fromkeys(candidate for source in sources for candidate in suno_name_lookup_candidates(source))
+                ),
             )
         )
     return prompts
@@ -321,25 +338,31 @@ def _slugify(value: str) -> str:
     return slug or "untitled"
 
 
-def _parse_candidate(path: Path) -> tuple[int, str, str] | None:
+def _parse_candidate(path: Path, name_index: SunoNameIndex) -> tuple[int, str, str] | None:
     if path.suffix.lower() not in _AUDIO_EXTENSIONS:
         return None
     match = _DOWNLOADED_NAME_RE.match(path.stem)
-    if match is None:
+    if match is not None:
+        return int(match.group("idx")), (match.group("variant") or ""), match.group("title")
+    base, duplicate_number = split_suno_duplicate_stem(path.stem)
+    prompt_index = name_index.resolve(suno_name_lookup_candidates(base))
+    if prompt_index is None:
         return None
-    return int(match.group("idx")), (match.group("variant") or ""), match.group("title")
+    variant = "b" if duplicate_number == 1 else "a"
+    return prompt_index, variant, base
 
 
-def collect_candidates(collection_dir: Path) -> list[Candidate]:
+def collect_candidates(collection_dir: Path, prompts: Mapping[int, PromptEntry]) -> list[Candidate]:
     music_dir = collection_dir / "02-Individual-music"
     if not music_dir.is_dir():
         raise ValidationError(f"02-Individual-music が見つかりません: {music_dir}")
     candidates: list[Candidate] = []
     invalid_audio: list[str] = []
+    name_index = SunoNameIndex.build((prompt.index, prompt.aliases) for prompt in prompts.values())
     for path in sorted(music_dir.iterdir(), key=lambda p: p.name):
         if not path.is_file():
             continue
-        parsed = _parse_candidate(path)
+        parsed = _parse_candidate(path, name_index)
         if parsed is None:
             if path.suffix.lower() in _AUDIO_EXTENSIONS:
                 invalid_audio.append(path.name)
@@ -858,7 +881,10 @@ def select_suno_tracks(
         return SelectionResult([], [], [], [], [], [], {}, parsed_cfg.pair.selection_log_path)
 
     prompts = {p.index: p for p in load_prompts(collection_dir)}
-    candidates = collect_candidates(collection_dir)
+    try:
+        candidates = collect_candidates(collection_dir, prompts)
+    except AmbiguousSunoNameError as exc:
+        raise ValidationError(str(exc)) from exc
     _validate_download_complete(prompts, candidates)
     plan = _plan_suno_selection(
         collection_dir=collection_dir,

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -3087,6 +3087,39 @@ def test_extract_apostrophe_exact_match_still_wins(tmp_path):
     assert [f.name for f in music_dir.iterdir()] == ["01a-Greed's Rhythm.mp3"]
 
 
+@pytest.mark.parametrize("separator", ["—", "–", "―"])
+def test_extract_symbol_normalized_zip_names_match_prompts(tmp_path, separator):
+    coll = _make_collection(
+        tmp_path,
+        "20260601-clm-aaa-collection",
+        entries=[{"name": f"Midnight {separator} Echo", "style": "s", "lyrics": ""}],
+    )
+    zip_path = _make_zip(tmp_path / "download.zip", {"Midnight Echo.mp3": b"audio"})
+
+    result = extract_and_rename_music(coll, str(zip_path))
+
+    assert result == 1
+    music_dir = coll / "02-Individual-music"
+    assert [f.name for f in music_dir.iterdir()] == ["01a-Midnight Echo.mp3"]
+
+
+def test_extract_rejects_zip_name_ambiguous_after_symbol_normalization(tmp_path):
+    coll = _make_collection(
+        tmp_path,
+        "20260601-clm-aaa-collection",
+        entries=[
+            {"name": "AB — C", "style": "s", "lyrics": ""},
+            {"name": "A — BC", "style": "s", "lyrics": ""},
+        ],
+    )
+    zip_path = _make_zip(tmp_path / "download.zip", {"ABC.mp3": b"audio"})
+
+    with pytest.raises(DownloadedArtifactError, match="ambiguous Suno name"):
+        extract_and_rename_music(coll, str(zip_path))
+
+    assert not (coll / "02-Individual-music").exists()
+
+
 def test_extract_unmatched_files(tmp_path):
     """prompts にマッチしないファイルは配置せず、完了件数にも数えない。"""
     coll = _make_collection(

--- a/tests/commands/suno/test_suno_select_tracks.py
+++ b/tests/commands/suno/test_suno_select_tracks.py
@@ -88,6 +88,37 @@ def test_instrumental_prompt_keeps_both_clips_after_duration_filter(tmp_path, mo
     assert result.mode_counts == {"vocal": 0, "instrumental": 1}
 
 
+@pytest.mark.parametrize("separator", ["—", "–", "―"])
+def test_symbol_normalized_noncanonical_names_are_selected(tmp_path, monkeypatch, separator):
+    collection = _make_collection(
+        tmp_path,
+        [{"name": f"Midnight {separator} Echo", "lyrics": ""}],
+    )
+    first = _write_audio(collection, "Midnight Echo.mp3")
+    second = _write_audio(collection, "Midnight Echo_1.mp3")
+    monkeypatch.setattr(suno_track_selection, "probe_duration", lambda _: 120.0)
+
+    result = suno_track_selection.select_suno_tracks(collection, _cfg(), dry_run=True)
+
+    assert result.kept == [first, second]
+    assert result.mode_counts == {"vocal": 0, "instrumental": 1}
+
+
+def test_noncanonical_name_collision_stops_selection(tmp_path, monkeypatch):
+    collection = _make_collection(
+        tmp_path,
+        [
+            {"name": "AB — C", "lyrics": ""},
+            {"name": "A — BC", "lyrics": ""},
+        ],
+    )
+    _write_audio(collection, "ABC.mp3")
+    monkeypatch.setattr(suno_track_selection, "probe_duration", lambda _: 120.0)
+
+    with pytest.raises(ValidationError, match="ambiguous Suno name"):
+        suno_track_selection.select_suno_tracks(collection, _cfg(), dry_run=True)
+
+
 def test_prompt_response_envelope_keeps_track_selection_compatible(tmp_path, monkeypatch):
     collection = _make_collection(
         tmp_path,

--- a/tests/domains/suno/test_name_matching.py
+++ b/tests/domains/suno/test_name_matching.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.suno.name_matching import normalize_suno_name_for_lookup
+from youtube_automation.domains.suno.playlist import verify_playlist_titles
+
+
+def test_normalization_uses_one_unicode_category_policy_for_symbols_and_whitespace() -> None:
+    assert normalize_suno_name_for_lookup(" Ｇｒｅｅｄ’ｓ\tRhythm — ☆ ") == "greedsrhythm"
+
+
+@pytest.mark.parametrize("separator", ["—", "–", "―"])
+def test_playlist_matching_treats_dash_family_like_removed_zip_separators(separator: str) -> None:
+    result = verify_playlist_titles(
+        [f"Midnight {separator} Echo"],
+        ["Midnight Echo"],
+        expected_clips_per_entry=1,
+    )
+
+    assert result.ok
+    assert result.matched == {f"Midnight {separator} Echo": 1}
+
+
+def test_playlist_matching_keeps_apostrophe_removed_regression() -> None:
+    result = verify_playlist_titles(
+        ["Greed's Rhythm"],
+        ["Greeds Rhythm"],
+        expected_clips_per_entry=1,
+    )
+
+    assert result.ok
+
+
+def test_playlist_matching_rejects_names_that_collide_after_symbol_normalization() -> None:
+    with pytest.raises(ValidationError, match="正規化後に衝突"):
+        verify_playlist_titles(
+            ["AB — C", "A — BC"],
+            ["ABC"],
+            expected_clips_per_entry=1,
+        )

--- a/tests/repo/test_domains_reorganization.py
+++ b/tests/repo/test_domains_reorganization.py
@@ -42,6 +42,7 @@ _DOMAIN_MODULES = (
     f"{_DOWNLOADED_ROOT}.apply",
     f"{_SUNO_ROOT}.config",
     f"{_SUNO_ROOT}.lyrics",
+    f"{_SUNO_ROOT}.name_matching",
     f"{_SUNO_ROOT}.prompts",
     f"{_SUNO_ROOT}.playlist",
     f"{_SUNO_ROOT}.selection",
@@ -177,7 +178,10 @@ def test_domain_dependency_edges_are_one_way() -> None:
             f"{_DOWNLOADED_ROOT}.workflow",
             f"{_DOWNLOADED_ROOT}.models",
         },
-        f"{_DOWNLOADED_ROOT}.archive": {f"{_DOWNLOADED_ROOT}.models"},
+        f"{_DOWNLOADED_ROOT}.archive": {
+            f"{_DOWNLOADED_ROOT}.models",
+            f"{_SUNO_ROOT}.name_matching",
+        },
         f"{_DOWNLOADED_ROOT}.apply": {
             f"{_DOWNLOADED_ROOT}.archive",
             f"{_DOWNLOADED_ROOT}.workflow",


### PR DESCRIPTION
## Summary
- Unicodeカテゴリ方針の共通Suno名正規化と一意解決器を追加
- ZIP展開・playlist検証・track選択で同一ロジックを共有
- em/en/horizontal dashとapostropheを吸収し、衝突時はfail-loud

## Verification
- 関連suite（361 passed）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run pytest -n auto`（8222 passed, 1 skipped）
- `git diff --check`

Closes #3759