### PR TITLE
feat(doctor): /wf-new 到達可否を診断する (#3761)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -35,12 +35,12 @@ description: "Use when ツール導入と GCP / OAuth の API 設定をセット
 | `bootstrap` | ffmpeg / ffprobe / uv / pyproject.toml / automation パッケージ / `yt-skills sync` / 番号付き重複ファイル検知（7 check） |
 | `api` | gcloud CLI・GCP プロジェクト・Billing・APIs・ADC・IAM・OAuth 認証・Reporting API ジョブ |
 | `channel` | config/channel/ のロード可能性・playlists.json の妥当性・playlist 作成 dry-run（3 check: `channel_config` / `playlist_config` / `playlist_create_dry_run`）。fail 時は `/channel-new`（新規開設 / 既存チャンネル取り込み / 再生成モード）を案内するだけ |
-| `data` | `/wf-new` の入力モード判定データ + 初期セットアップ事前検査（analytics_report / benchmark_data / ttp_wf_new_readiness / initial_setup_readiness）。minimal mode / benchmark fallback mode は setup のブロッカーにしない。analytics report は最新 `data/analytics_data_*.json` との相対比較に加え、`collection-ideate` の解決済み `freshness_days` を超えた絶対鮮度 stale も検出する。承認済み TTP がある場合だけ `/channel-new`（再生成モード） benchmark 反映完了を確認する |
+| `data` | `/wf-new` の入力モード判定データ + 到達可否 + 初期セットアップ事前検査（analytics_report / benchmark_data / ttp_wf_new_readiness / wf_new_readiness / initial_setup_readiness）。`ttp_mode: false` の minimal mode と benchmark fallback mode は setup のブロッカーにしない。analytics report は最新 `data/analytics_data_*.json` との相対比較に加え、`collection-ideate` の解決済み `freshness_days` を超えた絶対鮮度 stale も検出する。承認済み TTP がある場合だけ `/channel-new`（再生成モード） benchmark 反映完了を確認し、`ttp_mode: true` の minimal mode は転写元不足として警告する |
 | `upload` | upload 必須 scope 充足・channel_id 設定済み（1 check） |
 
 ### 完了条件
 
-`uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed`（全 check 緑）になり、ツール、API 認証、アップロード前提が揃った状態が完了（報告文面は「完了時」セクションを参照）。例外として `analytics_report` の stale fail だけは後続スキルが自動解消するため setup のブロッカーにせず、`checks` 配列のほかの check がすべて `ok` なら `human_required` で停止しても同じ完了状態として扱う。`data` カテゴリは `/wf-new` の入力モード確認用で、stale analytics report、minimal mode、benchmark fallback mode のいずれも新規チャンネル初回制作を止めない。新規チャンネル作成は次に `/channel-new` を実行する。
+`uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed`（全 check 緑）になり、ツール、API 認証、アップロード前提が揃った状態が完了（報告文面は「完了時」セクションを参照）。例外として `analytics_report` の stale fail だけは後続スキルが自動解消するため setup のブロッカーにせず、`checks` 配列のほかの check がすべて `ok` なら `human_required` で停止しても同じ完了状態として扱う。`data` カテゴリは `/wf-new` の入力モード確認用で、stale analytics report、`ttp_mode: false` の minimal mode、benchmark fallback mode は新規チャンネル初回制作を止めない。`wf_new_readiness` が `ttp_mode: true` × minimal mode を警告した場合は転写元を準備するまで完了扱いにしない。新規チャンネル作成は次に `/channel-new` を実行する。
 
 ## 想定 API call 数
 

--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -316,6 +316,18 @@ minimal mode / benchmark fallback mode は新規チャンネル初回制作を�
 
 `benchmark.channels` 未設定の場合は minimal mode として扱われるため、setup の完了を止めない。
 
+#### `wf_new_readiness` — `/wf-new` の到達可否
+
+`/collection-ideate` と同じ入力モード判定と `config/skills/collection-ideate.yaml::ttp_mode` の組み合わせを確認する。override ファイルまたは `ttp_mode` が未設定なら、同梱既定どおり `false` として扱う。`analytics mode`、`benchmark fallback mode`、または `ttp_mode: false` の `minimal mode` は、`yt-doctor` の message に表示されたモードのまま `/wf-new` を開始できる。
+
+`ttp_mode: true` × `minimal mode` の warning は、転写元ベンチマークが無く `/collection-ideate` から `/wf-new` へ到達できない状態を示す。`next_action.kind == "human"` の指示を次の順に扱う:
+
+1. 利用者と TTP 対象を決め、`config/channel/analytics.json::benchmark.channels` に保存する
+2. AI が `/benchmark` を実行して `data/benchmark_*.json` を生成する
+3. AI が `uv run yt-doctor --json` を再実行し、`wf_new_readiness` が `ok` になったことを確認する
+
+この check は `/wf-new` の到達可否だけを判定する。`benchmark_data` / `analytics_report` / `ttp_wf_new_readiness` の意味を変更せず、persona 文書の有無も停止条件に加えない。
+
 #### `initial_setup_readiness` — 初期セットアップ事前検査
 
 `config/skills/thumbnail.yaml` / `config/skills/suno.yaml` の空欄・不備（reference_images / composition_rules の未設定、`genre_line` の文字数超過など）と、planning 中コレクションの `descriptions.md` parse 失敗を warn として一括検出する。`yt-doctor` の `next_action` に従い、skill config の転記は `/channel-new`（再生成モード）、descriptions.md の再生成は `/video-description` を案内する。config 未転記の新規チャンネルでは `/channel-new` 完了までの正常な中間状態として扱う。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(doctor)`: `ttp_mode` と `/collection-ideate` の入力モードを組み合わせて `/wf-new` の到達可否を診断する `wf_new_readiness` check を追加し、転写元の無い TTP minimal mode に復旧順を案内する（#3761）。
 - `fix(suno)`: Suno の prompt 名・ZIP 内ファイル名・ローカル選曲名を、Unicode の文字・結合文字・数字だけを残す共通キーで照合し、em dash / en dash / horizontal bar の空白化とアポストロフィ除去を吸収する。正規化後に複数 prompt が候補になる場合は誤選択せず停止する（#3759）。
 - `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。
 - `fix(skills-sync)`: `/analytics` 統合後の旧 `analytics-collect` / `analytics-analyze` / `analytics-report` / `analytics-run` を既知の削除対象へ追加し、`yt-skills sync --prune` の候補表示と `--yes` による削除を可能にした（#3756）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -1698,6 +1698,38 @@ def check_benchmark_data(channel_dir: Path) -> CheckResult:
     )
 
 
+def check_wf_new_readiness(channel_dir: Path) -> CheckResult:
+    input_mode = _resolve_wf_new_input_mode(channel_dir)
+    collection_ideate_config = load_skill_config("collection-ideate", use_cache=False, channel_dir=channel_dir)
+    ttp_mode = collection_ideate_config.get("ttp_mode", False) is True
+    ttp_mode_display = str(ttp_mode).lower()
+
+    if ttp_mode and input_mode.mode == "minimal mode":
+        return CheckResult(
+            id="wf_new_readiness",
+            status="warn",
+            category=DATA_CATEGORY,
+            message=(
+                "minimal mode / ttp_mode: true では転写元ベンチマークが必須のため、"
+                "/collection-ideate が停止し /wf-new へ到達不可"
+            ),
+            next_action={
+                "kind": "human",
+                "instructions": (
+                    "config/channel/analytics.json::benchmark.channels に TTP 対象を保存 → "
+                    "/benchmark を実行 → `uv run yt-doctor --json` を再実行してください"
+                ),
+            },
+        )
+
+    return CheckResult(
+        id="wf_new_readiness",
+        status="ok",
+        category=DATA_CATEGORY,
+        message=f"{input_mode.mode} / ttp_mode: {ttp_mode_display} で /wf-new を開始可能",
+    )
+
+
 def check_ttp_wf_new_readiness(channel_dir: Path) -> CheckResult:
     persona_definition = channel_dir / "docs" / "channel" / "personas" / "persona-definition.md"
     missing_persona = [] if persona_definition.is_file() else ["docs/channel/personas/persona-definition.md 未作成"]
@@ -3230,6 +3262,7 @@ def run_all_checks(channel_dir: Path) -> list[CheckResult]:
         check_analytics_report(channel_dir),
         check_benchmark_data(channel_dir),
         check_ttp_wf_new_readiness(channel_dir),
+        check_wf_new_readiness(channel_dir),
         check_initial_setup_readiness(channel_dir),
         check_upload_ready(channel_dir),
     ]

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1327,8 +1327,8 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 7 bootstrap + 14 api + 3 channel + 4 data + 1 upload = 29
-        assert len(payload["checks"]) == 29
+        # 7 bootstrap + 14 api + 3 channel + 5 data + 1 upload = 30
+        assert len(payload["checks"]) == 30
         for c in payload["checks"]:
             assert c["status"] in ("ok", "info", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
@@ -2794,6 +2794,93 @@ class TestCheckBenchmarkData:
         assert r.status == "ok"
         assert "analytics mode" in r.message
         assert "minimal mode" not in r.message
+
+
+class TestCheckWfNewReadiness:
+    @staticmethod
+    def _write_input_mode(channel_dir: Path, input_mode: str) -> None:
+        if input_mode == "analytics mode":
+            reports_dir = channel_dir / "reports"
+            reports_dir.mkdir()
+            (reports_dir / "analysis_20240101.md").write_text("# Analysis", encoding="utf-8")
+        elif input_mode == "benchmark fallback mode":
+            data_dir = channel_dir / "data"
+            data_dir.mkdir()
+            (data_dir / "benchmark_20240101.json").write_text("{}", encoding="utf-8")
+
+    @staticmethod
+    def _write_ttp_mode(channel_dir: Path, value: bool | None) -> None:
+        config_dir = channel_dir / "config" / "skills"
+        config_dir.mkdir(parents=True)
+        content = "{}\n" if value is None else f"ttp_mode: {str(value).lower()}\n"
+        (config_dir / "collection-ideate.yaml").write_text(content, encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        ("ttp_mode", "input_mode"),
+        [
+            (False, "analytics mode"),
+            (False, "benchmark fallback mode"),
+            (None, "minimal mode"),
+            (True, "analytics mode"),
+            (True, "benchmark fallback mode"),
+        ],
+    )
+    def test_all_reachable_mode_combinations_are_ok(self, tmp_path, ttp_mode, input_mode):
+        """ttp_mode=true × minimal mode 以外の 5 通りは /wf-new を開始できる."""
+        self._write_input_mode(tmp_path, input_mode)
+        self._write_ttp_mode(tmp_path, ttp_mode)
+
+        result = doctor.check_wf_new_readiness(tmp_path)
+
+        expected_ttp_mode = "true" if ttp_mode is True else "false"
+        assert result.id == "wf_new_readiness"
+        assert result.status == "ok"
+        assert result.category == "data"
+        assert input_mode in result.message
+        assert f"ttp_mode: {expected_ttp_mode}" in result.message
+        assert "/wf-new を開始可能" in result.message
+        assert result.next_action is None
+
+    def test_ttp_minimal_mode_warns_with_ordered_recovery(self, tmp_path):
+        """ttp_mode=true × minimal mode は転写元不足として最短復旧順を返す."""
+        self._write_ttp_mode(tmp_path, True)
+
+        result = doctor.check_wf_new_readiness(tmp_path)
+
+        assert result.status == "warn"
+        assert "minimal mode" in result.message
+        assert "ttp_mode: true" in result.message
+        assert "転写元ベンチマークが必須" in result.message
+        assert "/wf-new へ到達不可" in result.message
+        assert result.next_action is not None
+        assert result.next_action["kind"] == "human"
+        instructions = result.next_action["instructions"]
+        assert instructions.index("benchmark.channels") < instructions.index("/benchmark")
+        assert instructions.index("/benchmark") < instructions.index("yt-doctor")
+
+    def test_missing_skill_override_defaults_ttp_mode_to_false(self, tmp_path):
+        """channel override 自体が無い場合も同梱既定 false で minimal mode を許容する."""
+        result = doctor.check_wf_new_readiness(tmp_path)
+
+        assert result.status == "ok"
+        assert "minimal mode" in result.message
+        assert "ttp_mode: false" in result.message
+
+    def test_main_json_exposes_warn_contract(self, monkeypatch, tmp_path, capsys):
+        """公開 --json 出力で wf_new_readiness の status と next_action を保持する."""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        _write_minimal_config(tmp_path)
+        self._write_ttp_mode(tmp_path, True)
+
+        code = doctor.main(["--json", "--target", str(tmp_path)])
+
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        result = next(check for check in payload["checks"] if check["id"] == "wf_new_readiness")
+        assert result["status"] == "warn"
+        assert result["category"] == "data"
+        assert result["next_action"]["kind"] == "human"
+        assert "benchmark.channels" in result["next_action"]["instructions"]
 
 
 class TestCheckTtpWfNewReadinessChannelSetup:
@@ -5374,11 +5461,11 @@ class TestStreamingVpsState:
 
 
 class TestRunAllChecksExtended:
-    def test_returns_29_checks(self, monkeypatch, tmp_path):
-        """7 bootstrap + 14 api + 3 channel + 4 data + 1 upload = 計 29 件."""
+    def test_returns_30_checks(self, monkeypatch, tmp_path):
+        """7 bootstrap + 14 api + 3 channel + 5 data + 1 upload = 計 30 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 29
+        assert len(results) == 30
 
     def test_14_api_checks_present(self, monkeypatch, tmp_path):
         """streaming VPS state 突合を含む 14 check が api カテゴリにある."""
@@ -5405,6 +5492,7 @@ class TestRunAllChecksExtended:
         assert "analytics_report" in ids
         assert "benchmark_data" in ids
         assert "ttp_wf_new_readiness" in ids
+        assert "wf_new_readiness" in ids
         assert "initial_setup_readiness" in ids
         assert "upload_ready" in ids
         assert "reporting_job" in ids
@@ -5451,16 +5539,17 @@ class TestRunAllChecksExtended:
         }
 
     def test_data_checks_include_readiness_checks(self, monkeypatch, tmp_path):
-        """data カテゴリは analytics / benchmark と 2 種類の readiness check を含む."""
+        """data カテゴリは analytics / benchmark と 3 種類の readiness check を含む."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        data_ids = {r.id for r in results if r.category == "data"}
-        assert data_ids == {
+        data_ids = [r.id for r in results if r.category == "data"]
+        assert data_ids == [
             "analytics_report",
             "benchmark_data",
             "ttp_wf_new_readiness",
+            "wf_new_readiness",
             "initial_setup_readiness",
-        }
+        ]
 
     def test_upload_ready_is_only_upload_check(self, monkeypatch, tmp_path):
         """upload カテゴリは upload_ready の 1 件のみ."""
@@ -5506,6 +5595,7 @@ class TestRenderTableCategories:
         assert "analytics_report" in output
         assert "benchmark_data" in output
         assert "ttp_wf_new_readiness" in output
+        assert "wf_new_readiness" in output
         assert "initial_setup_readiness" in output
         assert "upload_ready" in output
 

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -319,14 +319,26 @@ def test_channel_new_setup_gate_does_not_require_doctor_all_green() -> None:
 def test_setup_skill_handles_ttp_wf_new_readiness_next_check() -> None:
     text = _setup_text()
     assert (
-        "`data` | `/wf-new` の入力モード判定データ + 初期セットアップ事前検査"
-        "（analytics_report / benchmark_data / ttp_wf_new_readiness / initial_setup_readiness）" in text
+        "（analytics_report / benchmark_data / ttp_wf_new_readiness / wf_new_readiness / "
+        "initial_setup_readiness）" in text
     )
     assert "#### `ttp_wf_new_readiness` — 承認済み TTP の `/channel-new` benchmark 反映状態" in text
     assert "/channel-new benchmark 反映未完了" in text
     assert "`config/skills/thumbnail.yaml::image_generation.gemini.reference_images.default`" in text
     assert "`data/thumbnail_compare/benchmark/`" in text
     assert "uv run yt-doctor --apply --json" in text
+
+
+def test_setup_skill_handles_wf_new_readiness_next_check() -> None:
+    text = _setup_text()
+    section = text.split("#### `wf_new_readiness`", 1)[1].split("\n#### `initial_setup_readiness`", 1)[0]
+
+    assert "`ttp_mode: true` × `minimal mode`" in section
+    assert '`next_action.kind == "human"`' in section
+    assert section.index("benchmark.channels") < section.index("/benchmark")
+    assert section.index("/benchmark") < section.index("yt-doctor --json")
+    assert "persona 文書の有無も停止条件に加えない" in section
+    assert "`benchmark_data` / `analytics_report` / `ttp_wf_new_readiness` の意味を変更せず" in section
 
 
 def test_setup_stale_report_guidance_delegates_to_collection_ideate_contract() -> None:


### PR DESCRIPTION
## Summary
- `wf_new_readiness` checkをTTP readiness直後へ追加
- 既存入力モード解決を再利用し、ttp_modeとの6組み合わせを判定
- warn時の最短復旧順、JSON出力、setup SKILL/runbook契約を追加

## Verification
- doctor/setup/docs関連（479 passed）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run pytest -n auto`（8231 passed, 1 skipped）
- `nix develop --command uv run yt-skills lint`（55 skills）

Closes #3761