### PR TITLE
feat(channel-new): 取り込み後の必須手順を診断結果で案内する (#3762)

### DIFF
--- a/.claude/skills/channel-new/SKILL.md
+++ b/.claude/skills/channel-new/SKILL.md
@@ -10,7 +10,7 @@ description: "Use when 新しい YouTube チャンネルを初期化・取り込
 
 ## 完了条件（新規開設モード）
 
-新規開設モードの `/channel-new` は以下が揃うまで完了扱いにしない。未完了のまま成功案内を出さない。既存チャンネル取り込みモードにはこの TTP 完了条件を適用しない。取り込みモードは「取り込み Step 8: 次ステップ案内」の完了条件で終了できる。
+新規開設モードの `/channel-new` は以下が揃うまで完了扱いにしない。未完了のまま成功案内を出さない。既存チャンネル取り込みモードにはこの TTP 完了条件を適用しない。取り込みモードは「取り込み Step 8: 次ステップ案内」で `wf_new_readiness` の必須／任意案内を提示すれば、その判定が `warn` でも終了できる。
 
 - `config/channel/analytics.json::benchmark.channels` に承認済み TTP 対象が 1 件以上あり、各 entry に relationship（何を転写するか）が入っている
 - `docs/channel/ttp-seed-confirmation.md` に、候補ごとの source、seed fetch 要約、承認 / 不採用判断、転写したい要素、relationship、branding snapshot 参照または description / keywords / localizations の転写方針、未反映項目が保存されている
@@ -400,7 +400,7 @@ guard が `secret-like file staged; unstaged before commit` を出した場合�
 
 - **目的**: 既に YouTube で運営中のチャンネルの情報をヒアリングし、`config/channel/*.json`（責務別分割）を生成して自動化システムに取り込む
 - **実行場所**: `/setup` 完了後の channel repo ルート。`.git` がない場合は新規開設モードの Step 2、環境未整備の場合は Step 3 と同じく `uv run yt-doctor --json` → `/setup` を先に完了させる
-- **完了条件**: `config/channel/*.json` の生成、`uv run yt-doctor --json` の `channel_config.status` が `ok`、OAuth 認証、`channel_id` の `config/channel/meta.json::channel.channel_id` 保存、次ステップ案内まで到達した時点で完了。新規開設モードの TTP 完了条件（`benchmark.channels` / `ttp-seed-confirmation.md` / branding snapshot / `ttp_wf_new_readiness`）は取り込みモードには適用しない
+- **完了条件**: `config/channel/*.json` の生成、`uv run yt-doctor --json` の `channel_config.status` が `ok`、OAuth 認証、`channel_id` の `config/channel/meta.json::channel.channel_id` 保存、`wf_new_readiness` の判定結果に基づく必須／任意の次ステップ案内まで到達した時点で完了。判定が `warn` でも取り込みは完了し、新規開設モードの TTP 完了条件（`benchmark.channels` / `ttp-seed-confirmation.md` / branding snapshot / `ttp_wf_new_readiness`）は取り込みモードには適用しない
 
 ## 設定 push モード（運用中チャンネルの設定同期）
 

--- a/.claude/skills/channel-new/references/import-mode.md
+++ b/.claude/skills/channel-new/references/import-mode.md
@@ -94,14 +94,32 @@ JSON 構文検証・config ロードテスト（`uv run yt-doctor --json` の `c
 
 ## 取り込み Step 8: 次ステップ案内
 
-config 生成・認証完了後、以下を案内:
+config 生成・認証完了後、到達可否の正本を取得する:
 
-1. **ブランディング素材**: 未作成の場合は `references/verification.md`（「ブランディング素材生成」）を参照
-2. **ベンチマーク設定**: 競合チャンネルを追加したい場合は `config/channel/analytics.json` の `benchmark.channels` を追加し `/benchmark` で収集
-3. **ペルソナ定義**: `/viewer-voice` → `/audience-persona-design` → `/viewing-scene` の順で実行
-4. **データ収集・分析**: `/analytics --collect` → `/analytics --analyze` で現状のパフォーマンスを把握
-5. **コレクション制作**: `/wf-new` で最初のコレクション制作を開始
+```bash
+uv run yt-doctor --json
+```
+
+JSON の `checks` から `id: wf_new_readiness` の結果を 1 件選び、次のとおり案内する。必須項目の内訳や実行順を config・ファイル有無から再判定せず、この check の `status` / `message` / `next_action` だけを使う。
+
+### `status: ok`
+
+- **`/wf-new` 到達に必須**: 追加作業なし。`message` を提示し、そこに示された確定した入力モードで今すぐ `/wf-new` を開始できると案内する
+- **品質を上げる任意項目**:
+  - **ブランディング素材**: 未作成の場合は `references/verification.md`（「ブランディング素材生成」）を参照
+  - **ペルソナ定義**: `/viewer-voice` → `/audience-persona-design` → `/viewing-scene` の順で実行
+  - **追加ベンチマーク**: 競合チャンネルを広げたい場合は `config/channel/analytics.json` の `benchmark.channels` を追加し `/benchmark` で収集
+  - **データ収集・分析**: `/analytics --collect` → `/analytics --analyze` で現状のパフォーマンスを把握
+
+### `status: warn`
+
+- **`/wf-new` 到達に必須**: `next_action.instructions` の不足項目と実行順を、順序を保ったまま提示する。内容をこの手順側で組み直さず、自動実行もしない
+- **品質を上げる任意項目**: 上記 `status: ok` と同じブランディング素材・ペルソナ定義・追加ベンチマーク・データ収集／分析を、必須項目とは別に提示する
+
+### 共通の完了契約
+
+`wf_new_readiness` の結果提示は Step 8 の必須手順だが、`warn` でも取り込みモード自体は完了する。`wf_new_readiness` を `ok` にすることは取り込みモードの完了条件に加えない。警告された不足項目は取り込み完了後の最短手順として引き継ぐ。
 
 Step 1 前段で「方向性見直し」が選ばれていた場合は、上記に加えて `/channel-new` の方向性検討モードへの接続を案内する。ただし、`references/direction-mode.md` の前提は新規開設モードの完了であり、既存チャンネル取り込みモードの完了だけでは満たさないため、方向性検討モードへ直行する案内はしない。新規開設モードを完了して前提を満たしたうえで、TTP メモ（`docs/channel/ttp-seed-confirmation.md` と `docs/channel/competitor-branding-snapshot.json`）または分析レポート（`docs/channel-research.md`）を入力として準備してから方向性検討モードを実行するよう案内する。入力がなければ、`references/direction-mode.md` の Step D1 に従い、新規開設モードで TTP メモを作成するか、必要に応じて `/benchmark` / `/viewer-voice` / `/channel-new` 分析モードを先に実行し、入力を準備するまで方向性検討を停止する旨も明記する。
 
-取り込みモードは、`config/channel/*.json` の生成、`uv run yt-doctor --json` の `channel_config.status` が `ok`、OAuth 認証、`channel_id` の `config/channel/meta.json::channel.channel_id` 保存、次ステップ案内まで到達した時点で完了扱いにできる。新規開設モードの `benchmark.channels`、`ttp-seed-confirmation.md`、branding snapshot、`ttp_wf_new_readiness` は取り込みモードの必須完了条件ではない。
+取り込みモードは、`config/channel/*.json` の生成、`uv run yt-doctor --json` の `channel_config.status` が `ok`、OAuth 認証、`channel_id` の `config/channel/meta.json::channel.channel_id` 保存、`wf_new_readiness` の判定結果に基づく必須／任意の次ステップ案内まで到達した時点で完了扱いにできる。新規開設モードの `benchmark.channels`、`ttp-seed-confirmation.md`、branding snapshot、`ttp_wf_new_readiness` は取り込みモードの必須完了条件ではない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。
 - `feat(doctor)`: `ttp_mode` と `/collection-ideate` の入力モードを組み合わせて `/wf-new` の到達可否を診断する `wf_new_readiness` check を追加し、転写元の無い TTP minimal mode に復旧順を案内する（#3761）。
 - `fix(suno)`: Suno の prompt 名・ZIP 内ファイル名・ローカル選曲名を、Unicode の文字・結合文字・数字だけを残す共通キーで照合し、em dash / en dash / horizontal bar の空白化とアポストロフィ除去を吸収する。正規化後に複数 prompt が候補になる場合は誤選択せず停止する（#3759）。
 - `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -573,6 +573,38 @@ def test_channel_new_import_mode_contract_is_separate_from_ttp_completion() -> N
     assert "config-template/*.json" in config_rules
 
 
+def test_channel_new_import_step_8_presents_reachable_wf_new_guidance() -> None:
+    import_mode = _read(".claude/skills/channel-new/references/import-mode.md")
+    step_8 = import_mode.split("## 取り込み Step 8:", 1)[1]
+
+    assert "uv run yt-doctor --json" in step_8
+    assert "`checks` から `id: wf_new_readiness`" in step_8
+    ok_guidance = step_8.split("### `status: ok`", 1)[1].split("### `status: warn`", 1)[0]
+    assert "`message`" in ok_guidance
+    assert "確定した入力モード" in ok_guidance
+    assert "今すぐ `/wf-new`" in ok_guidance
+    assert "品質を上げる任意項目" in ok_guidance
+    for optional_item in ("ブランディング素材", "ペルソナ定義", "追加ベンチマーク"):
+        assert optional_item in ok_guidance
+
+
+def test_channel_new_import_step_8_preserves_warn_recovery_without_blocking_import() -> None:
+    channel_new = _read(".claude/skills/channel-new/SKILL.md")
+    import_mode = _read(".claude/skills/channel-new/references/import-mode.md")
+    step_8 = import_mode.split("## 取り込み Step 8:", 1)[1]
+    warn_guidance = step_8.split("### `status: warn`", 1)[1].split("### 共通の完了契約", 1)[0]
+    completion = step_8.split("### 共通の完了契約", 1)[1]
+
+    assert "`next_action.instructions`" in warn_guidance
+    assert "順序を保ったまま" in warn_guidance
+    assert "`/wf-new` 到達に必須" in warn_guidance
+    assert "品質を上げる任意項目" in warn_guidance
+    assert "`warn` でも取り込みモード自体は完了" in completion
+    assert "`wf_new_readiness` を `ok` にすることは取り込みモードの完了条件に加えない" in completion
+    assert "`wf_new_readiness` の判定結果に基づく必須／任意の次ステップ案内" in channel_new
+    assert "ttp_mode" not in import_mode
+
+
 def test_channel_new_localizations_priority_matches_generation_rules() -> None:
     regeneration_mode = _read(".claude/skills/channel-new/references/regeneration-mode.md")
     rules = _read(".claude/skills/channel-new/references/config-generation-rules.md")


### PR DESCRIPTION
## Summary
- Step 8で`wf_new_readiness`のok/warn出力を正本として消費
- `/wf-new`到達の必須手順と品質向上の任意項目を分離
- warnでも取り込み完了条件を厳格化せず、判定条件の複製を防ぐ契約テストを追加

## Verification
- 対象contract tests（3 passed）
- `nix develop --command uv run yt-skills lint`（55 skills）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`（788 files）
- `nix develop --command uv run pytest -n auto`（8233 passed, 1 skipped）
- `git diff --check`

Closes #3762