### PR TITLE
fix(analytics): 動画別収益の非対応メトリクスを除外する (#3837)

### DIFF
--- a/.claude/skills/analytics/references/collect.md
+++ b/.claude/skills/analytics/references/collect.md
@@ -154,7 +154,7 @@ subagent へは次を具体値で渡す:
 
 `yt-analytics` は基本メトリクスとは別クエリで
 `estimatedRevenue` / `monetizedPlaybacks` / `adImpressions` / `cpm` / `playbackBasedCpm` を収集する。
-日別・動画別に `adImpressions / monetizedPlaybacks` の `ads_per_playback` も保存する。
+日別では `adImpressions / monetizedPlaybacks` の `ads_per_playback` も保存する。
 成果物では `revenue_analytics.daily_metrics` と `revenue_analytics.by_video` に保存し、
 各行の `rpm` は `estimated_revenue / views * 1000` で算出する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。
 - `fix(skills-sync)`: `/analytics` 統合後の旧 `analytics-collect` / `analytics-analyze` / `analytics-report` / `analytics-run` を既知の削除対象へ追加し、`yt-skills sync --prune` の候補表示と `--yes` による削除を可能にした（#3756）。
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
+- `fix(analytics)`: 動画別収益クエリから YouTube Analytics API 非対応の `adImpressions` を除外し、日次クエリでは広告表示回数の収集を維持する（#3837）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
 - `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。
 - `fix(wf-new)`: `/collection-ideate` と `/wf-new` が現在の channel config・方向性・第一ペルソナ・視聴シーン・creative constraints を固定制約として候補ごとに検証し、違反案を提示・保存・state 反映しない fail-closed gate を追加した（#3727）。

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+_DAILY_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+_VIDEO_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
 
 
 class RevenueAnalyticsMixin:
@@ -30,7 +31,7 @@ class RevenueAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics=_REVENUE_METRICS,
+                metrics=_DAILY_REVENUE_METRICS,
                 dimensions="day",
             )
             daily_response = daily_request
@@ -39,7 +40,7 @@ class RevenueAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics=_REVENUE_METRICS,
+                metrics=_VIDEO_REVENUE_METRICS,
                 dimensions="video",
                 sort="-estimatedRevenue",
             )
@@ -57,8 +58,8 @@ class RevenueAnalyticsMixin:
                 "summary": {},
             }
 
-        daily_metrics = [self._revenue_row(row, dimension_key="date") for row in daily_response.get("rows", [])]
-        by_video = {row[0]: self._revenue_row(row, dimension_key="video_id") for row in video_response.get("rows", [])}
+        daily_metrics = [self._daily_revenue_row(row) for row in daily_response.get("rows", [])]
+        by_video = {row[0]: self._video_revenue_row(row) for row in video_response.get("rows", [])}
         total_views = sum(row["views"] for row in daily_metrics)
         total_revenue = sum(row["estimated_revenue"] for row in daily_metrics)
 
@@ -76,15 +77,15 @@ class RevenueAnalyticsMixin:
         }
 
     @staticmethod
-    def _revenue_row(row: list[object], *, dimension_key: str) -> dict[str, str | int | float]:
-        """dimension + monetary metrics の API row を安定したキーへ変換する。"""
+    def _daily_revenue_row(row: list[object]) -> dict[str, str | int | float]:
+        """日次の monetary metrics を安定したキーへ変換する。"""
         dimension = str(row[0])
         views = int(row[1])
         estimated_revenue = float(row[2])
         monetized_playbacks = int(row[3])
         ad_impressions = int(row[4])
         return {
-            dimension_key: dimension,
+            "date": dimension,
             "views": views,
             "estimated_revenue": estimated_revenue,
             "monetized_playbacks": monetized_playbacks,
@@ -92,6 +93,21 @@ class RevenueAnalyticsMixin:
             "ads_per_playback": RevenueAnalyticsMixin._calculate_ads_per_playback(ad_impressions, monetized_playbacks),
             "cpm": float(row[5]),
             "playback_based_cpm": float(row[6]),
+            "rpm": RevenueAnalyticsMixin._calculate_rpm(estimated_revenue, views),
+        }
+
+    @staticmethod
+    def _video_revenue_row(row: list[object]) -> dict[str, str | int | float]:
+        """動画別の monetary metrics を安定したキーへ変換する。"""
+        views = int(row[1])
+        estimated_revenue = float(row[2])
+        return {
+            "video_id": str(row[0]),
+            "views": views,
+            "estimated_revenue": estimated_revenue,
+            "monetized_playbacks": int(row[3]),
+            "cpm": float(row[4]),
+            "playback_based_cpm": float(row[5]),
             "rpm": RevenueAnalyticsMixin._calculate_rpm(estimated_revenue, views),
         }
 

--- a/tests/domains/analytics/mixins/test_revenue_analytics.py
+++ b/tests/domains/analytics/mixins/test_revenue_analytics.py
@@ -26,7 +26,7 @@ def test_collects_daily_and_video_revenue_metrics():
                 ["2026-07-02", 3000, 21.0, 1500, 4500, 14.0, 12.0],
             ],
         },
-        {"rows": [["video-1", 1000, 8.0, 600, 1800, 13.0, 11.0]]},
+        {"rows": [["video-1", 1000, 8.0, 600, 13.0, 11.0]]},
     ]
     service.query.reset_mock()
 
@@ -43,8 +43,6 @@ def test_collects_daily_and_video_revenue_metrics():
         "views": 1000,
         "estimated_revenue": 8.0,
         "monetized_playbacks": 600,
-        "ad_impressions": 1800,
-        "ads_per_playback": 3.0,
         "cpm": 13.0,
         "playback_based_cpm": 11.0,
         "rpm": 8.0,
@@ -57,6 +55,9 @@ def test_collects_daily_and_video_revenue_metrics():
     }
     assert service.query.call_args_list[0].kwargs["metrics"] == (
         "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+    )
+    assert service.query.call_args_list[1].kwargs["metrics"] == (
+        "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
     )
 
 
@@ -77,7 +78,7 @@ def test_zero_views_and_empty_responses_have_stable_available_summary():
     zero_service = MagicMock()
     zero_service.query.side_effect = [
         {"currency": "JPY", "rows": [["2026-07-01", 0, 0.0, 0, 3, 0.0, 0.0]]},
-        {"rows": [["video-1", 0, 0.0, 0, 3, 0.0, 0.0]]},
+        {"rows": [["video-1", 0, 0.0, 0, 0.0, 0.0]]},
     ]
 
     zero = DummyCollector(zero_service).get_revenue_analytics("2026-07-01", "2026-07-01")
@@ -85,7 +86,6 @@ def test_zero_views_and_empty_responses_have_stable_available_summary():
     assert zero["daily_metrics"][0]["rpm"] == 0.0
     assert zero["daily_metrics"][0]["ads_per_playback"] == 0.0
     assert zero["by_video"]["video-1"]["rpm"] == 0.0
-    assert zero["by_video"]["video-1"]["ads_per_playback"] == 0.0
     assert zero["summary"]["rpm"] == 0.0
 
     empty_service = MagicMock()

--- a/tests/test_analytics_cli_integration.py
+++ b/tests/test_analytics_cli_integration.py
@@ -42,7 +42,7 @@ class _AnalyticsReports:
             return _Request({"rows": [["VIDEO_1", "2026-04-01", 100]]})
         if dimensions == "video":
             if "estimatedRevenue" in metrics:
-                return _Request({"rows": [["VIDEO_1", 100, 2.5, 80, 160, 4.0, 5.0]]})
+                return _Request({"rows": [["VIDEO_1", 100, 2.5, 80, 4.0, 5.0]]})
             if metrics.startswith("views,estimatedMinutesWatched"):
                 return _Request({"rows": [["VIDEO_1", 100, 500, 120, 5, 0, 1, 2, 4]]})
             return _Request({"rows": [["VIDEO_1", 100, 5, 1, 500]]})
@@ -216,8 +216,14 @@ def test_yt_analytics_collects_and_saves_subscribed_status_via_cli(cli_dependenc
         },
         "total_views": 100,
     }
-    assert payload["video_analytics"]["VIDEO_1"]["ad_impressions"] == 160
-    assert payload["video_analytics"]["VIDEO_1"]["ads_per_playback"] == 2.0
+    assert payload["video_analytics"]["VIDEO_1"]["estimated_revenue"] == 2.5
+    revenue_queries = [query for query in reports.queries if "estimatedRevenue" in query["metrics"]]
+    assert next(query for query in revenue_queries if query["dimensions"] == "day")["metrics"] == (
+        "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+    )
+    assert next(query for query in revenue_queries if query["dimensions"] == "video")["metrics"] == (
+        "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+    )
     assert any(query.get("dimensions") == "subscribedStatus" for query in reports.queries)
 
 


### PR DESCRIPTION
## Summary

- 日次・動画別の収益メトリクス契約を分離
- 動画別クエリから非対応の `adImpressions` を除外し、日次収集は維持
- 単体テストと CLI 統合テストでクエリ契約を固定

Closes #3837