### PR TITLE
fix(workspace): feedback横断データを許可する (#3838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
 - `fix(analytics)`: 日次・動画別の収益クエリを独立して処理し、片方の API 失敗時も成功データを `partial` として保存する（#3840）。
 - `fix(analytics)`: 動画別収益クエリから YouTube Analytics API 非対応の `adImpressions` を除外し、日次クエリでは広告表示回数の収集を維持する（#3837）。
+- `fix(workspace)`: workspace root で実行した境界 guard が横断データ用 `data/feedback/` の相対・絶対パスを許可し、チャンネル内 cwd と他の root レイアウトでは既存の越境ブロックを維持する（#3838）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
 - `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。
 - `fix(wf-new)`: `/collection-ideate` と `/wf-new` が現在の channel config・方向性・第一ペルソナ・視聴シーン・creative constraints を固定制約として候補ごとに検証し、違反案を提示・保存・state 反映しない fail-closed gate を追加した（#3727）。

--- a/src/youtube_automation/commands/channel/workspace_guard.py
+++ b/src/youtube_automation/commands/channel/workspace_guard.py
@@ -18,6 +18,7 @@ _ROOT_CHANNEL_LAYOUTS = (
     ("data",),
     ("auth",),
 )
+_WORKSPACE_FEEDBACK_LAYOUT = ("data", "feedback")
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -56,12 +57,23 @@ def _is_root_channel_layout(path: Path, workspace_root: Path) -> bool:
     return any(relative_parts[: len(prefix)] == prefix for prefix in _ROOT_CHANNEL_LAYOUTS)
 
 
+def _is_workspace_feedback_layout(path: Path, workspace_root: Path) -> bool:
+    try:
+        relative_parts = path.relative_to(workspace_root).parts
+    except ValueError:
+        return False
+    return relative_parts[: len(_WORKSPACE_FEEDBACK_LAYOUT)] == _WORKSPACE_FEEDBACK_LAYOUT
+
+
 def _blocked_reason(
     target: Path,
     workspace_root: Path,
+    cwd: Path,
     current_slug: str | None,
     channels: dict[str, Path],
 ) -> str | None:
+    if cwd == workspace_root and _is_workspace_feedback_layout(target, workspace_root):
+        return None
     if _is_root_channel_layout(target, workspace_root):
         return f"workspace root のチャンネル専用レイアウトです (cwd slug={current_slug or '(none)'})"
 
@@ -83,7 +95,7 @@ def check_paths(raw_paths: list[str], cwd: Path) -> list[tuple[str, str]]:
     blocked: list[tuple[str, str]] = []
     for raw_path in raw_paths:
         target = _resolve_target(raw_path, resolved_cwd, workspace_root)
-        reason = _blocked_reason(target, workspace_root, current_slug, channels)
+        reason = _blocked_reason(target, workspace_root, resolved_cwd, current_slug, channels)
         if reason is not None:
             blocked.append((raw_path, reason))
     return blocked

--- a/tests/commands/channel/test_workspace_guard.py
+++ b/tests/commands/channel/test_workspace_guard.py
@@ -49,6 +49,27 @@ def test_check_allows_channel_path_from_workspace_root(tmp_path, monkeypatch, ca
     assert capsys.readouterr().err == ""
 
 
+@pytest.mark.parametrize("absolute", [False, True], ids=["relative", "absolute"])
+def test_check_allows_workspace_feedback_from_workspace_root(tmp_path, absolute, monkeypatch, capsys):
+    _make_channel(tmp_path, "alpha")
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "data" / "feedback" / "feedback-log.jsonl"
+    raw_target = str(target) if absolute else "data/feedback/feedback-log.jsonl"
+
+    assert workspace_guard.main(["check", raw_target]) == workspace_guard.EXIT_OK
+    assert capsys.readouterr().err == ""
+
+
+def test_check_blocks_workspace_root_channel_config_from_workspace_root(tmp_path, monkeypatch, capsys):
+    _make_channel(tmp_path, "alpha")
+    monkeypatch.chdir(tmp_path)
+
+    rc = workspace_guard.main(["check", "config/channel/meta.json"])
+
+    assert rc == workspace_guard.EXIT_BLOCKED
+    assert "config/channel/meta.json" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize("layout", ["collections", "config/channel", "assets", "data", "auth"])
 def test_check_blocks_workspace_root_channel_layout(tmp_path, layout, monkeypatch, capsys):
     current = _make_channel(tmp_path, "alpha")


### PR DESCRIPTION
## Summary

- workspace root から `data/feedback/` の相対・絶対パスを許可
- root のチャンネル専用レイアウトとチャンネル間越境のブロックを維持
- workspace guard の回帰テストを追加

Closes #3838