### PR TITLE
fix(analytics): 収益クエリの部分成功を保持する (#3840)

### DIFF
--- a/.claude/skills/analytics/references/collect.md
+++ b/.claude/skills/analytics/references/collect.md
@@ -158,8 +158,9 @@ subagent へは次を具体値で渡す:
 成果物では `revenue_analytics.daily_metrics` と `revenue_analytics.by_video` に保存し、
 各行の `rpm` は `estimated_revenue / views * 1000` で算出する。
 
-収益化未承認または monetary data へのアクセス不可の場合は、警告ログを出して
-`revenue_analytics.status: "unavailable"` と空の収益データを保存する。これは許容する fail であり、
+日次・動画別の片方だけを取得できた場合は `revenue_analytics.status: "partial"` とし、
+成功したデータと失敗した dimension の `errors` を保存する。両方を取得できない場合は
+`revenue_analytics.status: "unavailable"` と空の収益データを保存する。どちらも許容する fail であり、
 views / CTR / retention など既存メトリクスの収集は継続する。
 
 データ収集完了後:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs(changelog)`: v5.6.0 Migration に `youtube_automation.utils.upload_core` / `youtube_automation.utils.youtube_service` の削除を補記し、1 対 1 の代替がない class ベースから関数ベースへの再設計を、近い新 API を置換先と誤認させない独立形式で記録した（#3758）。
 - `fix(skills-sync)`: `/analytics` 統合後の旧 `analytics-collect` / `analytics-analyze` / `analytics-report` / `analytics-run` を既知の削除対象へ追加し、`yt-skills sync --prune` の候補表示と `--yes` による削除を可能にした（#3756）。
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
+- `fix(analytics)`: 日次・動画別の収益クエリを独立して処理し、片方の API 失敗時も成功データを `partial` として保存する（#3840）。
 - `fix(analytics)`: 動画別収益クエリから YouTube Analytics API 非対応の `adImpressions` を除外し、日次クエリでは広告表示回数の収集を維持する（#3837）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
 - `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -26,54 +26,109 @@ class RevenueAnalyticsMixin:
         収益取得を基本メトリクスと別クエリにすることで、収益化状態が既存収集を
         失敗させないようにしている。
         """
-        try:
-            daily_request = self.analytics_service.query(
-                ids=f"channel=={self.channel_id}",
-                startDate=start_date,
-                endDate=end_date,
-                metrics=_DAILY_REVENUE_METRICS,
-                dimensions="day",
-            )
-            daily_response = daily_request
+        daily_response, daily_error = self._get_daily_revenue(start_date, end_date)
+        video_response, video_error = self._get_video_revenue(start_date, end_date)
+        errors = {
+            dimension: str(error)
+            for dimension, error in (("day", daily_error), ("video", video_error))
+            if error is not None
+        }
 
-            video_request = self.analytics_service.query(
-                ids=f"channel=={self.channel_id}",
-                startDate=start_date,
-                endDate=end_date,
-                metrics=_VIDEO_REVENUE_METRICS,
-                dimensions="video",
-                sort="-estimatedRevenue",
-            )
-            video_response = video_request
-        except YouTubeAPIError as error:
-            logger.warning(
-                "収益メトリクスを取得できないため skip します。基本メトリクスの収集は継続します: %s",
-                error,
-            )
+        if daily_response is None and video_response is None:
             return {
                 "status": "unavailable",
-                "reason": str(error),
+                "reason": "; ".join(f"{dimension}: {reason}" for dimension, reason in errors.items()),
+                "errors": errors,
                 "daily_metrics": [],
                 "by_video": {},
                 "summary": {},
             }
 
-        daily_metrics = [self._daily_revenue_row(row) for row in daily_response.get("rows", [])]
-        by_video = {row[0]: self._video_revenue_row(row) for row in video_response.get("rows", [])}
-        total_views = sum(row["views"] for row in daily_metrics)
-        total_revenue = sum(row["estimated_revenue"] for row in daily_metrics)
-
-        return {
-            "status": "available",
-            "currency": daily_response.get("currency"),
+        daily_metrics = (
+            [self._daily_revenue_row(row) for row in daily_response.get("rows", [])]
+            if daily_response is not None
+            else []
+        )
+        by_video = (
+            {row[0]: self._video_revenue_row(row) for row in video_response.get("rows", [])}
+            if video_response is not None
+            else {}
+        )
+        result: dict[str, object] = {
+            "status": "partial" if errors else "available",
+            "currency": self._revenue_currency(daily_response, video_response),
             "daily_metrics": daily_metrics,
             "by_video": by_video,
-            "summary": {
-                "estimated_revenue": total_revenue,
-                "monetized_playbacks": sum(row["monetized_playbacks"] for row in daily_metrics),
-                "views": total_views,
-                "rpm": self._calculate_rpm(total_revenue, total_views),
-            },
+            "summary": self._revenue_summary(daily_metrics) if daily_response is not None else {},
+        }
+        if errors:
+            result["errors"] = errors
+        return result
+
+    def _get_daily_revenue(
+        self, start_date: str, end_date: str
+    ) -> tuple[dict[str, object] | None, YouTubeAPIError | None]:
+        """日次収益を取得し、失敗情報を動画別クエリから隔離する。"""
+        try:
+            return (
+                self.analytics_service.query(
+                    ids=f"channel=={self.channel_id}",
+                    startDate=start_date,
+                    endDate=end_date,
+                    metrics=_DAILY_REVENUE_METRICS,
+                    dimensions="day",
+                ),
+                None,
+            )
+        except YouTubeAPIError as error:
+            logger.warning(
+                "日次収益メトリクスを取得できません。基本メトリクスの収集は継続します: %s",
+                error,
+            )
+            return None, error
+
+    def _get_video_revenue(
+        self, start_date: str, end_date: str
+    ) -> tuple[dict[str, object] | None, YouTubeAPIError | None]:
+        """動画別収益を取得し、失敗情報を日次クエリから隔離する。"""
+        try:
+            return (
+                self.analytics_service.query(
+                    ids=f"channel=={self.channel_id}",
+                    startDate=start_date,
+                    endDate=end_date,
+                    metrics=_VIDEO_REVENUE_METRICS,
+                    dimensions="video",
+                    sort="-estimatedRevenue",
+                ),
+                None,
+            )
+        except YouTubeAPIError as error:
+            logger.warning(
+                "動画別収益メトリクスを取得できません。基本メトリクスの収集は継続します: %s",
+                error,
+            )
+            return None, error
+
+    @staticmethod
+    def _revenue_currency(daily_response: dict[str, object] | None, video_response: dict[str, object] | None) -> object:
+        """成功した収益レスポンスから通貨を返す。"""
+        if daily_response is not None:
+            return daily_response.get("currency")
+        if video_response is not None:
+            return video_response.get("currency")
+        raise ValueError("収益レスポンスがありません")
+
+    @staticmethod
+    def _revenue_summary(daily_metrics: list[dict[str, str | int | float]]) -> dict[str, int | float]:
+        """日次収益から期間集計を算出する。"""
+        total_views = sum(int(row["views"]) for row in daily_metrics)
+        total_revenue = sum(float(row["estimated_revenue"]) for row in daily_metrics)
+        return {
+            "estimated_revenue": total_revenue,
+            "monetized_playbacks": sum(int(row["monetized_playbacks"]) for row in daily_metrics),
+            "views": total_views,
+            "rpm": RevenueAnalyticsMixin._calculate_rpm(total_revenue, total_views),
         }
 
     @staticmethod

--- a/tests/domains/analytics/mixins/test_revenue_analytics.py
+++ b/tests/domains/analytics/mixins/test_revenue_analytics.py
@@ -61,9 +61,49 @@ def test_collects_daily_and_video_revenue_metrics():
     )
 
 
-def test_monetary_api_failure_warns_and_returns_unavailable(caplog):
+def test_returns_daily_metrics_as_partial_when_video_query_fails(caplog):
     service = MagicMock()
-    service.query.side_effect = YouTubeAPIError("monetary data forbidden", status_code=403, reason="forbidden")
+    service.query.side_effect = [
+        {"currency": "USD", "rows": [["2026-07-01", 2000, 10.0, 1000, 2500, 12.5, 10.0]]},
+        YouTubeAPIError("video query unsupported", status_code=400, reason="badRequest"),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = DummyCollector(service).get_revenue_analytics("2026-07-01", "2026-07-01")
+
+    assert result["status"] == "partial"
+    assert result["daily_metrics"][0]["estimated_revenue"] == 10.0
+    assert result["by_video"] == {}
+    assert result["summary"]["estimated_revenue"] == 10.0
+    assert result["errors"] == {"video": "video query unsupported"}
+    assert "動画別収益メトリクス" in caplog.text
+
+
+def test_returns_video_metrics_as_partial_when_daily_query_fails(caplog):
+    service = MagicMock()
+    service.query.side_effect = [
+        YouTubeAPIError("daily query forbidden", status_code=403, reason="forbidden"),
+        {"currency": "JPY", "rows": [["video-1", 1000, 8.0, 600, 13.0, 11.0]]},
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        result = DummyCollector(service).get_revenue_analytics("2026-07-01", "2026-07-01")
+
+    assert result["status"] == "partial"
+    assert result["currency"] == "JPY"
+    assert result["daily_metrics"] == []
+    assert result["by_video"]["video-1"]["estimated_revenue"] == 8.0
+    assert result["summary"] == {}
+    assert result["errors"] == {"day": "daily query forbidden"}
+    assert "日次収益メトリクス" in caplog.text
+
+
+def test_returns_unavailable_when_both_monetary_queries_fail(caplog):
+    service = MagicMock()
+    service.query.side_effect = [
+        YouTubeAPIError("daily query forbidden", status_code=403, reason="forbidden"),
+        YouTubeAPIError("video query unsupported", status_code=400, reason="badRequest"),
+    ]
 
     with caplog.at_level(logging.WARNING):
         result = DummyCollector(service).get_revenue_analytics("2026-07-01", "2026-07-02")
@@ -71,6 +111,12 @@ def test_monetary_api_failure_warns_and_returns_unavailable(caplog):
     assert result["status"] == "unavailable"
     assert result["daily_metrics"] == []
     assert result["by_video"] == {}
+    assert result["errors"] == {
+        "day": "daily query forbidden",
+        "video": "video query unsupported",
+    }
+    assert result["reason"] == "day: daily query forbidden; video: video query unsupported"
+    assert service.query.call_count == 2
     assert "基本メトリクスの収集は継続" in caplog.text
 
 

--- a/tests/repo/test_analytics_revenue_skill_contract.py
+++ b/tests/repo/test_analytics_revenue_skill_contract.py
@@ -9,6 +9,7 @@ def test_analytics_collect_documents_graceful_monetary_skip():
     skill = (ROOT / ".claude/skills/analytics/references/collect.md").read_text()
 
     assert "estimatedRevenue" in skill
+    assert 'revenue_analytics.status: "partial"' in skill
     assert 'revenue_analytics.status: "unavailable"' in skill
     assert "既存メトリクスの収集は継続" in skill
 

--- a/tests/test_analytics_cli_integration.py
+++ b/tests/test_analytics_cli_integration.py
@@ -11,10 +11,11 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from youtube_automation import entrypoints
+from youtube_automation.core.errors import YouTubeAPIError
 
 
 class _Request:
-    def __init__(self, response: dict | None = None, error: HttpError | None = None) -> None:
+    def __init__(self, response: dict | None = None, error: HttpError | YouTubeAPIError | None = None) -> None:
         self.response = response or {}
         self.error = error
 
@@ -27,6 +28,8 @@ class _Request:
 class _AnalyticsReports:
     def __init__(self, subscribed_status_error: HttpError | None = None) -> None:
         self.subscribed_status_error = subscribed_status_error
+        self.daily_revenue_error: YouTubeAPIError | None = None
+        self.video_revenue_error: YouTubeAPIError | None = None
         self.queries: list[dict] = []
 
     def query(self, **kwargs: str | int) -> _Request:
@@ -42,7 +45,10 @@ class _AnalyticsReports:
             return _Request({"rows": [["VIDEO_1", "2026-04-01", 100]]})
         if dimensions == "video":
             if "estimatedRevenue" in metrics:
-                return _Request({"rows": [["VIDEO_1", 100, 2.5, 80, 4.0, 5.0]]})
+                return _Request(
+                    {"rows": [["VIDEO_1", 100, 2.5, 80, 4.0, 5.0]]},
+                    error=self.video_revenue_error,
+                )
             if metrics.startswith("views,estimatedMinutesWatched"):
                 return _Request({"rows": [["VIDEO_1", 100, 500, 120, 5, 0, 1, 2, 4]]})
             return _Request({"rows": [["VIDEO_1", 100, 5, 1, 500]]})
@@ -53,7 +59,10 @@ class _AnalyticsReports:
         if dimensions == "day" and metrics.startswith("views,estimatedMinutesWatched,averageViewDuration"):
             return _Request({"rows": [["2026-04-01", 100, 500, 120, 4, 0, 5, 0, 1, 2, 50, 0, 0, 0]]})
         if dimensions == "day" and "estimatedRevenue" in metrics:
-            return _Request({"rows": [["2026-04-01", 100, 2.5, 80, 160, 4.0, 5.0]]})
+            return _Request(
+                {"rows": [["2026-04-01", 100, 2.5, 80, 160, 4.0, 5.0]]},
+                error=self.daily_revenue_error,
+            )
         if dimensions == "day":
             return _Request({"rows": [["2026-04-01", 100, 500]]})
         return _Request({"rows": [[100, 5, 1, 2, 4]]})
@@ -238,3 +247,22 @@ def test_yt_analytics_returns_failure_when_subscribed_status_collection_fails(cl
 
     assert exited.value.code == 1
     assert not list((tmp_path / "data").glob("analytics_data_*.json"))
+
+
+def test_yt_analytics_saves_daily_revenue_when_video_revenue_query_fails(cli_dependencies) -> None:
+    tmp_path, reports = cli_dependencies
+    reports.video_revenue_error = YouTubeAPIError("video query unsupported", status_code=400, reason="badRequest")
+
+    with patch.object(sys, "argv", ["yt-analytics", "--days", "7"]):
+        with pytest.raises(SystemExit) as exited:
+            entrypoints.yt_analytics()
+
+    assert exited.value.code == 0
+    saved_files = list((tmp_path / "data").glob("analytics_data_*.json"))
+    assert len(saved_files) == 1
+    payload = json.loads(saved_files[0].read_text(encoding="utf-8"))
+    revenue = payload["revenue_analytics"]
+    assert revenue["status"] == "partial"
+    assert revenue["daily_metrics"][0]["estimated_revenue"] == 2.5
+    assert revenue["by_video"] == {}
+    assert revenue["errors"]["video"]


### PR DESCRIPTION
## Summary

- 日次・動画別の API 呼び出しとエラー処理を分離
- 一方が失敗しても成功データを `partial` とエラー情報付きで保持
- 両方失敗時の `unavailable` と CLI 保存経路をテストで固定

Closes #3840