### PR TITLE
fix: hook 変更後の再起動を案内する (#3839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(automation-update)`: multi-channel workspace の `channels/<slug>/config/channel/` を Step 7 smoke check の対象として全件検証し、single-channel と config 未生成時の既存契約を維持する（#3755）。
 - `fix(analytics)`: 日次・動画別の収益クエリを独立して処理し、片方の API 失敗時も成功データを `partial` として保存する（#3840）。
 - `fix(analytics)`: 動画別収益クエリから YouTube Analytics API 非対応の `adImpressions` を除外し、日次クエリでは広告表示回数の収集を維持する（#3837）。
+- `fix(automation-update)`: `apply --accept-hooks` で hook 設定が実際に追加・更新された場合だけ、変更は次回の Claude Code セッションから有効になるため再起動が必要と完了出力で案内する（#3839）。
 - `fix(workspace)`: workspace root で実行した境界 guard が横断データ用 `data/feedback/` の相対・絶対パスを許可し、チャンネル内 cwd と他の root レイアウトでは既存の越境ブロックを維持する（#3838）。
 - `breaking(skills)`: Analytics の収集・分析・表示・一括実行を `/analytics` に統合し、一段実行を排他的な `--collect` / `--analyze` / `--report` へ移行した。下流更新では `yt-skills sync --prune` で旧 skill ディレクトリを除去し、`config/skills/` の旧 Analytics 設定を `config/skills/analytics.yaml` へ統合する（#3729）。
 - `feat(skills-sync)`: `yt-skills sync --asset skills` 後に、対応する同梱 skill がない下流 `config/skills/*.yaml` / `*.json` を削除せず報告する（#3728）。

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -262,6 +262,20 @@ def _skills_diff_has_changes(root: Path) -> bool:
     return any(marker in output for marker in local_fix_markers)
 
 
+def _hooks_snapshot(root: Path) -> dict[str, object] | None:
+    settings_path = root / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return {}
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(settings, dict):
+        return None
+    hooks = settings.get("hooks", {})
+    return hooks if isinstance(hooks, dict) else None
+
+
 def cmd_check(args: argparse.Namespace) -> int:
     try:
         root = _resolve_repo_root(args.target)
@@ -349,6 +363,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
     print(f"pin 形式: {_describe_pin(pin)}")
     if new_ref:
         print(f"追従先: {new_ref}")
+    hooks_before = _hooks_snapshot(root)
 
     def step_worktree() -> None:
         status = _git_status_porcelain(root)
@@ -440,6 +455,12 @@ def cmd_apply(args: argparse.Namespace) -> int:
             )
             return 1
     print("✓ 追従が完了しました。commit / push は本 CLI の責務外です（スキル / 人間側で実施してください）")
+    hooks_after = _hooks_snapshot(root)
+    if args.accept_hooks and hooks_before is not None and hooks_after is not None and hooks_before != hooks_after:
+        print(
+            "⚠ hook の変更は次回の Claude Code セッションから有効になります。"
+            "現在のセッションには反映されないため、Claude Code を再起動してください。"
+        )
     return 0
 
 

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -1005,6 +1005,54 @@ def test_apply_accept_hooks_propagates_explicit_approval(
     assert ["uv", "run", "yt-skills", "sync", "--force", "--accept-hooks"] in recorded_commands
 
 
+def test_apply_accept_hooks_reports_that_changed_hooks_start_next_session(
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    settings_path = repo / ".claude" / "settings.json"
+    settings_path.parent.mkdir()
+    settings_path.write_text('{"permissions": {}}', encoding="utf-8")
+
+    def _run_and_add_hook(cmd: list[str], cwd: Path) -> int:
+        if cmd[:4] == ["uv", "run", "yt-skills", "sync"]:
+            settings_path.write_text(
+                json.dumps(
+                    {
+                        "permissions": {},
+                        "hooks": {
+                            "SessionStart": [
+                                {"hooks": [{"type": "command", "command": "uv run yt-session-start-context"}]}
+                            ]
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+        return 0
+
+    monkeypatch.setattr(automation_update, "_run_command", _run_and_add_hook)
+    monkeypatch.setattr(automation_update, "_check_channel_config", lambda root: "config/channel/ ロード成功")
+    monkeypatch.setattr(automation_update, "_git_status_porcelain", lambda root: "")
+    monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
+
+    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--accept-hooks"]) == 0
+
+    assert "hook の変更は次回の Claude Code セッションから有効になります" in capsys.readouterr().out
+
+
+def test_apply_accept_hooks_omits_next_session_notice_when_hooks_are_unchanged(
+    tmp_path: Path,
+    no_network,
+    recorded_commands: list[list[str]],
+    capsys: pytest.CaptureFixture,
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+
+    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--accept-hooks"]) == 0
+
+    assert "次回の Claude Code セッション" not in capsys.readouterr().out
+
+
 def test_apply_force_sync_bypasses_local_fix_diff_guard(
     tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch, recorded_commands: list[list[str]]
 ) -> None:


### PR DESCRIPTION
## Summary

- apply 前後の hook 設定を比較し、実際に変更された成功時だけ再起動を案内
- hook の変更がない実行では案内を表示しない
- automation-update の CLI 出力契約をテストで固定

Closes #3839