### PR TITLE
fix(metadata): 表示名永続化で workflow-state 全体の消失を防ぐ (#3871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。
 - `feat(doctor)`: `ttp_mode` と `/collection-ideate` の入力モードを組み合わせて `/wf-new` の到達可否を診断する `wf_new_readiness` check を追加し、転写元の無い TTP minimal mode に復旧順を案内する（#3761）。

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -11,8 +11,10 @@ Features:
 
 import json
 import logging
+import os
 import re
 import subprocess
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
@@ -55,6 +57,23 @@ from youtube_automation.domains.metadata.titles import (
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
 logger = logging.getLogger(__name__)
+
+
+def _write_workflow_state(workflow_state_path: Path, state: Dict) -> None:
+    """workflow-state.json を同一ディレクトリの一時ファイル + os.replace で原子的に更新する。"""
+    payload = json.dumps(state, ensure_ascii=False, indent=2) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        dir=workflow_state_path.parent,
+        prefix=".workflow-state.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_name, workflow_state_path)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
 
 
 class BAHMetadataGenerator:
@@ -498,6 +517,10 @@ class BAHMetadataGenerator:
             - `self.tracks[i]["title"]` を上書き
             - `workflow-state.json` の `track_display_names` キーに
               `{filename: display_name}` 形式で永続化（既存キーは保持）
+
+        Raises:
+            ValidationError: 既存 workflow-state.json が破損・読取不能な場合
+                （既存 state の消失を防ぐため上書きせず中断する）
         """
         if not name_map:
             return
@@ -518,17 +541,23 @@ class BAHMetadataGenerator:
         ws_path = paths.workflow_state_path
         state: Dict = {}
         if ws_path.exists():
+            # 読み失敗時に state={} で続行すると、下の書き込みで
+            # 既存 state 全体（phase / assets / upload 等）を消してしまうため fail-loud にする
             try:
                 with open(ws_path, "r", encoding="utf-8") as f:
-                    state = json.load(f) or {}
-            except (json.JSONDecodeError, OSError):
-                state = {}
+                    state = json.load(f)
+            except json.JSONDecodeError as e:
+                raise ValidationError(f"workflow-state.json のパースに失敗: {e}") from e
+            except OSError as e:
+                raise ValidationError(f"workflow-state.json を読めません: {e}") from e
+            if not isinstance(state, dict):
+                raise ValidationError("workflow-state.json の root は object である必要があります")
         existing = state.get("track_display_names") or {}
         if not isinstance(existing, dict):
             existing = {}
         existing.update(filename_map)
         state["track_display_names"] = existing
-        ws_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        _write_workflow_state(ws_path, state)
 
     # ─── タイトル生成（2026リブランド） ─────────────────
 

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -1325,6 +1325,76 @@ class TestApplyTrackDisplayNames:
         gen._apply_persisted_display_names()
         assert gen.tracks[0]["title"] == "Persisted Name"
 
+    def test_corrupted_state_fails_loud_and_preserves_file(self, tmp_path):
+        """破損した workflow-state.json を空 dict で上書きしない（データ消失防止）."""
+        gen = _make_generator()
+        gen.collection_path = tmp_path
+        ws_path = tmp_path / "workflow-state.json"
+        corrupted = '{"phase": "upload", "assets": {'
+        ws_path.write_text(corrupted, encoding="utf-8")
+
+        gen.tracks = [_track("01-pattern-a-foo.mp3", "Original", "00:00", "a")]
+
+        with pytest.raises(ValidationError):
+            gen.apply_track_display_names({0: "New Name"})
+
+        # 既存内容（phase / assets 等）が失われていないこと
+        assert ws_path.read_text(encoding="utf-8") == corrupted
+
+    def test_non_dict_state_fails_loud_and_preserves_file(self, tmp_path):
+        """root が object でない workflow-state.json は上書きせず fail-loud."""
+        import json as _json
+
+        gen = _make_generator()
+        gen.collection_path = tmp_path
+        ws_path = tmp_path / "workflow-state.json"
+        ws_path.write_text(_json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+        gen.tracks = [_track("01-pattern-a-foo.mp3", "Original", "00:00", "a")]
+
+        with pytest.raises(ValidationError):
+            gen.apply_track_display_names({0: "New Name"})
+
+        assert _json.loads(ws_path.read_text(encoding="utf-8")) == ["not", "a", "dict"]
+
+    def test_unreadable_state_fails_loud(self, tmp_path):
+        """一時的 I/O エラー（OSError）でも state={} フォールバックしない."""
+        gen = _make_generator()
+        gen.collection_path = tmp_path
+        # ディレクトリを置くと exists() は True だが open() が IsADirectoryError(OSError)
+        ws_path = tmp_path / "workflow-state.json"
+        ws_path.mkdir()
+
+        gen.tracks = [_track("01-pattern-a-foo.mp3", "Original", "00:00", "a")]
+
+        with pytest.raises(ValidationError):
+            gen.apply_track_display_names({0: "New Name"})
+
+    def test_write_failure_preserves_existing_state(self, tmp_path, monkeypatch):
+        """書き込み途中の失敗で既存 workflow-state.json が壊れない（atomic write）."""
+        import json as _json
+        import os as _os
+
+        gen = _make_generator()
+        gen.collection_path = tmp_path
+        ws_path = tmp_path / "workflow-state.json"
+        original = _json.dumps({"phase": "upload", "collection_name": "Test"})
+        ws_path.write_text(original, encoding="utf-8")
+
+        gen.tracks = [_track("01-pattern-a-foo.mp3", "Original", "00:00", "a")]
+
+        def _fail_replace(src, dst):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(_os, "replace", _fail_replace)
+
+        with pytest.raises(OSError):
+            gen.apply_track_display_names({0: "New Name"})
+
+        # 元ファイルが無傷で、一時ファイルの残骸も無いこと
+        assert ws_path.read_text(encoding="utf-8") == original
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["workflow-state.json"]
+
 
 # ===========================================================================
 # 17. pattern 表示名解決ロジック


### PR DESCRIPTION
Closes #3871

## 変更内容

`apply_track_display_names()`（`domains/metadata/service.py`）のデータ消失経路を修正する。

- **fail-loud 化**: `workflow-state.json` の読み失敗（`JSONDecodeError` / `OSError`）と root 非 object を `ValidationError` で中断し、既存 state（phase / assets / upload / planning 等）を空 dict で上書きしない。方針は `commands/uploads/wf_batch.py::_load_state` と同一
- **atomic write 化**: 書き戻しを `write_text` から tempfile + `os.replace` の `_write_workflow_state()` へ変更（`wf_batch.py::_write_state` と同形）。途中失敗時は一時ファイルを掃除して元ファイルを無傷で残す
- 回帰テスト 4 件を追加（破損 JSON / 非 dict root / IsADirectoryError による OSError / `os.replace` 失敗時の原本保全と tmp 残骸なし）

## 検証

- 修正前に破損 JSON テストが red（例外なしで全体上書き）になることを確認済み
- `tests/domains/metadata/test_metadata_generator.py` 176 件 green、`ruff check` pass

## 補足

workflow-state owner module 導入計画が別途進行中だが、本件はデータ消失リスクのため先行修正（issue 記載どおり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)