### PR TITLE
fix(wf-new): サムネイル state 指示を schema に揃える (#3868)

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -321,7 +321,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 1. 企画選択時に承認済みの同じ画像なので、文字入り候補の生成・再選択・thumbnail の AskUserQuestion は行わない。`10-assets/thumbnail.jpg` を `/thumbnail-compare` で 320px 視認性検証し、署名・透かし・ロゴ・手指破綻の既存目視 QA を通す。失敗時は state を更新せず停止する
 2. QA 成功後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。archive の Hard Gate は既存契約どおり維持する
 3. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。`mode: full` は生成可否と textless 背景承認を質問せず既存の check 成功後に確定し、それ以外は既存どおり textless 候補だけをプレビュー・承認して `main.png/jpg` へ確定する。`false` なら textless 生成・承認を省略し、`share_thumbnail_as_main.py <collection-path>` を実行して `status: SHARED`、同一 SHA-256、`main.png` 不在を検証する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ `assets.thumbnail = true`、`thumbnail.approved = true`、`updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ `assets.thumbnail = true`、`updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
 
 以下の mode 別分岐は `status: MISSING` から既存 `/thumbnail` フォールバックへ進んだ場合だけ実行する。
 
@@ -330,7 +330,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 1. AskUserQuestion と `open` を実行せず、`uv run yt-thumbnail-auto-select <collection-path> --dry-run` が exit 0 であることを確認してから `uv run yt-thumbnail-auto-select <collection-path> --apply` を実行する。`10-assets/thumbnail.jpg` と `workflow-state.json::thumbnail_auto_selection.mode == "full"` を検証する
 2. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。生成可否と textless 背景承認は質問せず、`yt-thumbnail-check` が exit 0 かつ候補が存在するときだけ `10-assets/main.png/jpg` へ確定コピーする。`false` なら textless 委譲・生成・承認を再要求せず、`share_thumbnail_as_main.py <collection-path>` を実行し、`status: SHARED`、`thumbnail.jpg` と `main.jpg` の同一 SHA-256、`main.png` 不在を検証する
 3. `/thumbnail-compare` の 320px 視認性検証はスコープ外のまま省略せず、自動確定後に別途実行する。失敗しても不適格候補を強制採用せず、`/thumbnail` の「full モード失敗時の手動切替」を表示して state を更新せず停止する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ、`assets.thumbnail = true`、`thumbnail.approved = true`、`updated_at` を更新して音楽素材生成へ進む
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ、`assets.thumbnail = true`、`updated_at` を更新して音楽素材生成へ進む
 
 **`selection_only` または auto-selection 無効**（従来フロー）:
 
@@ -360,7 +360,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
    - `thumbnail.jpg` と `main.png/jpg` を同一画像で代用しない。`main.png` を `thumbnail.jpg` にコピーする旧運用は禁止
    - QA が NG、再生成、または中断の場合は `/collection-ideate` または `/thumbnail` の該当生成ステップへ戻し、state を更新せず停止する
 
-4. `thumbnail.jpg` と `main.png/jpg` の確定を検証した後だけ、メインが `assets.thumbnail = true`、`thumbnail.approved = true`、`updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
+4. `thumbnail.jpg` と `main.png/jpg` の確定を検証した後だけ、メインが `assets.thumbnail = true`、`updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
 
 5. **音楽 skill を順番に処理**:
    - Suno: 対象 collection、theme、確定企画、書き込み先 `20-documentation/suno-patterns.yaml` を指定して Agent ツールで `/suno <theme>` のプロンプト生成を委譲する。共有 `config/skills/suno.yaml` の書き換えを禁止し、collection root の Style 値と channel fallback を解決した後に `uv run yt-suno-verify <collection-path>` を通す。ボーカルでは root `vocal_gender` を `/suno-lyric` の語り手性別入力にも引き渡す

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
 - `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -157,11 +157,26 @@ def test_wf_new_preview_path_keeps_quality_state_and_textless_contracts() -> Non
 
     for contract in (
         "/thumbnail-compare",
-        "assets.thumbnail = true",
-        "thumbnail.approved = true",
         "未設定または `true`",
         "share_thumbnail_as_main.py <collection-path>",
     ):
         assert contract in approval_step
     assert "`planning-preview.png` から確定済み" in approval_step
     assert "再度 AskUserQuestion にかけない" in approval_step
+
+
+def test_wf_new_records_thumbnail_approval_in_canonical_asset_state_only() -> None:
+    skill = _WF_NEW_SKILL.read_text(encoding="utf-8")
+    approval_step = skill.split("##### 2c-2. サムネイル承認・確定 + 音楽素材生成", 1)[1].split(
+        "#### 2e. ループ動画生成", 1
+    )[0]
+
+    state_assignments = re.findall(r"(?:`)?([a-z_]+(?:\.[a-z_]+)+)\s*=\s*true", approval_step)
+    thumbnail_state_updates = [line for line in approval_step.splitlines() if "assets.thumbnail = true" in line]
+
+    assert state_assignments.count("assets.thumbnail") == 3
+    assert "thumbnail.approved" not in state_assignments
+    assert len(thumbnail_state_updates) == 3
+    for update in thumbnail_state_updates:
+        assert "thumbnail.jpg" in update
+        assert "main.png/jpg" in update


### PR DESCRIPTION
## Summary
- `/wf-new` の3つのサムネイル確定経路から、schema に存在しない `thumbnail.approved` 更新指示を削除
- `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ canonical `assets.thumbnail = true` を更新する gate を維持
- state assignment を観測する repository-contract test で3経路と未定義 field の再混入を検出

## Acceptance evidence
- `.claude/skills/wf-new/SKILL.md` 内の `thumbnail.approved`: 0件
- `assets.thumbnail = true`: 3経路すべてで `thumbnail.jpg` と `main.png/jpg` の確定検証後にのみ更新
- workflow-state runtime schema と thumbnail 実装は未変更

## Validation
- `nix develop --command uv run pytest tests/test_wf_new_analytics_fallback_skill_contract.py tests/configuration/test_thumbnail_skill_assets.py -q` — 95 passed
- `nix develop --command uv run yt-skills lint` — 55 skills passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 788 files formatted
- `bash .github/scripts/any-usage-gate.sh` — passed
- `git diff --check` — passed
- packaging smoke: installed-wheel 1 passed; dashboard packaging 1 passed
- full `pytest -n auto`: 8229 passed / 19 unrelated subprocess timeout failures under parallel load; the exact 19 failed nodes then passed serially (19 passed)

## CHANGELOG decision
`.claude/skills/` は CI の CHANGELOG gate 対象なので、`CHANGELOG.md` の `[Unreleased]` に #3868 の fix entry を追加した。

Closes #3868