### PR TITLE
feat(skill-feedback): 終端 disposition を追加する (#3914)

### DIFF
--- a/.claude/skills/skill-feedback/SKILL.md
+++ b/.claude/skills/skill-feedback/SKILL.md
@@ -17,7 +17,8 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 ## Hard Gates
 
 - 記録モードでは既存行を変更せず、schema 準拠の JSON object を末尾に 1 行だけ追加する
-- 還流モードでは `status="recorded"` の行だけを候補にする。`status="filed"` の行は表示も起票もせず、二重起票を防ぐ
+- 還流モードでは `status="recorded"` の行だけを候補にする。`filed` / `resolved` / `wontfix` は終端状態として表示・選択・起票・変更の対象にしない
+- `resolved` / `wontfix` への更新は、ユーザーが対象行と disposition を明示的に確認した場合だけ行う。空でない簡潔な `disposition_reason` と更新時刻 `disposition_at` を必須とする
 - issue 起票前に open issue のタイトルを照合し、類似候補ごとに新規起票かスキップかをユーザーに確認する
 - 起票対象、件数、タイトル、チャンネル名の掲載有無を表示し、`AskUserQuestion` で「起票する / 中止」の明示 2 択を提示する。承認されるまで `gh issue create` を絶対に実行しない
 - GitHub issue は外部へ反映され、起票後はこのスキルから取り消せないことを承認時に警告する
@@ -36,6 +37,7 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 
 - ユーザーが承認した entry ごとに、上流へ `feedback` ラベル付き issue が 1 件起票されている
 - 起票に成功した行だけが `status="filed"` と `issue_url` を持つ
+- ユーザーが確認した解決済みの行だけが `status="resolved"`、意図的に起票しないと確認した行だけが `status="wontfix"` となり、`disposition_reason` と `disposition_at` を持つ
 - 未選択、スキップ、起票失敗の行は変更されていない
 - 更新後の全行が entry schema に準拠し、JSONL の行数と順序が更新前と同じである
 
@@ -65,8 +67,22 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 | `category` | yes | `bug` / `friction` / `idea` のいずれか |
 | `summary` | yes | 1 文の要約 |
 | `context` | yes | 再現状況・エラー抜粋・期待と実際の差分 |
-| `status` | yes | 未還流は `recorded`、起票済みは `filed` |
+| `status` | yes | 未還流は `recorded`、起票済みは `filed`、解決確認済みは `resolved`、意図的な見送りは `wontfix` |
 | `issue_url` | filed only | `filed` にした GitHub issue の URL |
+| `disposition_reason` | resolved / wontfix only | 終端 disposition にした根拠を 1 文で簡潔に記録する |
+| `disposition_at` | resolved / wontfix only | disposition 更新日時。ISO 8601 の date-time 文字列 |
+
+## Entry lifecycle contract
+
+| status | filing candidate | terminal | required metadata |
+|---|---|---|---|
+| recorded | yes | no | none |
+| filed | no | yes | issue_url |
+| resolved | no | yes | disposition_reason, disposition_at |
+| wontfix | no | yes | disposition_reason, disposition_at |
+
+`recorded` だけが還流候補である。`filed` / `resolved` / `wontfix` は終端状態であり、
+次回以降の還流モードで一覧表示、選択、起票、変更を行わない。
 
 ## 共通: 機密情報のマスク
 
@@ -131,8 +147,31 @@ feedback を記録するよう案内して停止する。各行を JSON とし�
 `summary` とともに一覧表示する。`context` は一覧に表示しない。候補が 0 件なら
 「未還流 feedback は 0 件」と報告して終了する。
 
-ユーザーに起票する行を選んでもらう。選択した各行について、行番号と元の JSON object
-全体を保持する。以後の更新対象はこの組で識別し、同内容の entry が複数あっても混同しない。
+`filed` / `resolved` / `wontfix` の行は終端 entry のため、一覧表示、選択、起票、
+状態更新のいずれにも含めない。
+
+ユーザーに各 `recorded` entry の扱いを「起票候補 / 解決済み / 意図的に見送り / 今回は保留」
+から選んでもらう。選択した各行について、行番号と元の JSON object 全体を保持する。
+以後の更新対象はこの組で識別し、同内容の entry が複数あっても混同しない。
+
+### Step 1a: 非起票の終端 disposition を確定
+
+「解決済み」は現行版で問題が解決していると検証できた entry だけに使い、`resolved` とする。
+「意図的に見送り」は問題を確認した上で起票しないと判断した entry だけに使い、`wontfix` とする。
+各 entry について、空でない 1 文の簡潔な理由をユーザーに確認する。推測で理由を補わない。
+
+対象行、更新後の status、理由を表示し、`AskUserQuestion` で「disposition を記録する / 中止」の
+明示 2 択を提示する。確認された場合だけ、保持した行番号の現在値が元 JSON object と完全一致する
+ことを確認し、次のフィールドを 1 回の atomic rewrite で更新する。
+
+- `status`: `resolved` または `wontfix`
+- `disposition_reason`: ユーザーが確認した簡潔な理由
+- `disposition_at`: 更新時点の UTC を ISO 8601 date-time で記録した値
+
+terminal entry に `issue_url` を追加しない。更新後の全行が schema に準拠し、行数と行順が同じで、
+対象外の行が byte-for-byte で同一であることを確認してから元ファイルを置換する。確認失敗、
+元行の不一致、schema 検証失敗ではログを変更せず停止する。更新済みの terminal entry は Step 2
+以降へ渡さず、起票も行わない。「今回は保留」の entry は `recorded` のまま変更しない。
 
 ### Step 2: 本文案とチャンネル名の掲載可否を確認
 
@@ -212,10 +251,12 @@ exit code が 0 で、標準出力から当該 issue URL を取得できた場�
 
 ### Step 6: 完了報告
 
-起票した issue のタイトルと URL、`filed` に更新した行番号、スキップした entry を報告する。
+起票した issue のタイトルと URL、`filed` に更新した行番号、`resolved` / `wontfix` に更新した
+行番号と理由、スキップした entry を報告する。
 機密値、本文全文、長い error log は再掲しない。
 
 ## Non-goals
 
 - 起票された上流 issue のトリアージ・優先度付け
 - Analytics / flop-analysis 由来の運営知見の記録
+- schema 非準拠行を飛ばして valid entry の還流を続けること（#3939）

--- a/.claude/skills/skill-feedback/references/feedback-entry.schema.json
+++ b/.claude/skills/skill-feedback/references/feedback-entry.schema.json
@@ -32,11 +32,20 @@
     },
     "status": {
       "type": "string",
-      "enum": ["recorded", "filed"]
+      "enum": ["recorded", "filed", "resolved", "wontfix"]
     },
     "issue_url": {
       "type": "string",
       "format": "uri"
+    },
+    "disposition_reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Concise reason for marking the feedback resolved or intentionally wontfix."
+    },
+    "disposition_at": {
+      "type": "string",
+      "format": "date-time"
     }
   },
   "allOf": [
@@ -50,7 +59,13 @@
         "required": ["status"]
       },
       "then": {
-        "required": ["issue_url"]
+        "required": ["issue_url"],
+        "not": {
+          "anyOf": [
+            { "required": ["disposition_reason"] },
+            { "required": ["disposition_at"] }
+          ]
+        }
       }
     },
     {
@@ -63,6 +78,42 @@
         "required": ["status"]
       },
       "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["issue_url"] },
+            { "required": ["disposition_reason"] },
+            { "required": ["disposition_at"] }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "resolved"
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["disposition_reason", "disposition_at"],
+        "not": {
+          "required": ["issue_url"]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "wontfix"
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["disposition_reason", "disposition_at"],
         "not": {
           "required": ["issue_url"]
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
 - `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。
 - `fix(cli)`: `yt-benchmark-comments` と `yt-thumbnail-compare` の旧 `--channel` を共通 entrypoint が先に消費せず、`--competitor` への移行案内で誤チャンネル選択前に停止するよう修正した（#3923）。
+- `feat(skill-feedback)`: feedback entry に `resolved` / `wontfix` の終端状態と理由・更新時刻を追加し、`recorded` だけを還流候補として扱う契約を明確化した。schema 非準拠行があれば全停止する fail-closed 挙動は維持する（#3914）。
 - `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。

--- a/tests/repo/test_skill_feedback_contract.py
+++ b/tests/repo/test_skill_feedback_contract.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+
+_SKILL_PATH = REPO_ROOT / ".claude/skills/skill-feedback/SKILL.md"
+_SCHEMA_PATH = REPO_ROOT / ".claude/skills/skill-feedback/references/feedback-entry.schema.json"
+
+
+def _schema() -> dict[str, object]:
+    loaded = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _status_rule(status: str) -> dict[str, object]:
+    rules = _schema()["allOf"]
+    assert isinstance(rules, list)
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        condition = rule.get("if")
+        if not isinstance(condition, dict):
+            continue
+        properties = condition.get("properties")
+        if isinstance(properties, dict) and properties.get("status") == {"const": status}:
+            then = rule.get("then")
+            assert isinstance(then, dict)
+            return then
+    raise AssertionError(f"status={status!r} の schema rule が存在しない")
+
+
+def _prohibited_fields(rule: dict[str, object]) -> set[str]:
+    prohibited: set[str] = set()
+    not_clause = rule.get("not")
+    assert isinstance(not_clause, dict)
+    required = not_clause.get("required")
+    if isinstance(required, list):
+        prohibited.update(required)
+    any_of = not_clause.get("anyOf", [])
+    assert isinstance(any_of, list)
+    for branch in any_of:
+        assert isinstance(branch, dict)
+        branch_required = branch.get("required")
+        assert isinstance(branch_required, list)
+        prohibited.update(branch_required)
+    return prohibited
+
+
+def _lifecycle_rows() -> dict[str, tuple[str, str, str]]:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## Entry lifecycle contract\n\n"
+        r"\| status \| filing candidate \| terminal \| required metadata \|\n"
+        r"\|[-| ]+\|\n"
+        r"(?P<rows>(?:\|[^\n]+\|\n)+)",
+        skill,
+        flags=re.MULTILINE,
+    )
+    assert match is not None
+    rows: dict[str, tuple[str, str, str]] = {}
+    for row in match.group("rows").splitlines():
+        status, candidate, terminal, metadata = [cell.strip() for cell in row.strip("|").split("|")]
+        rows[status] = (candidate, terminal, metadata)
+    return rows
+
+
+def test_feedback_schema_declares_all_lifecycle_statuses() -> None:
+    properties = _schema()["properties"]
+    assert isinstance(properties, dict)
+
+    assert properties["status"]["enum"] == ["recorded", "filed", "resolved", "wontfix"]
+
+
+@pytest.mark.parametrize(
+    ("status", "required", "prohibited"),
+    (
+        ("recorded", set(), {"issue_url", "disposition_reason", "disposition_at"}),
+        ("filed", {"issue_url"}, {"disposition_reason", "disposition_at"}),
+        ("resolved", {"disposition_reason", "disposition_at"}, {"issue_url"}),
+        ("wontfix", {"disposition_reason", "disposition_at"}, {"issue_url"}),
+    ),
+)
+def test_feedback_schema_enforces_metadata_for_each_status(
+    status: str,
+    required: set[str],
+    prohibited: set[str],
+) -> None:
+    rule = _status_rule(status)
+
+    assert set(rule.get("required", [])) == required
+    assert _prohibited_fields(rule) == prohibited
+
+
+def test_terminal_disposition_metadata_has_nonempty_reason_and_timestamp_contract() -> None:
+    properties = _schema()["properties"]
+    assert isinstance(properties, dict)
+
+    assert properties["disposition_reason"]["type"] == "string"
+    assert properties["disposition_reason"]["minLength"] == 1
+    assert properties["disposition_at"] == {"type": "string", "format": "date-time"}
+
+
+def test_skill_lifecycle_only_exposes_recorded_entries_as_filing_candidates() -> None:
+    assert _lifecycle_rows() == {
+        "recorded": ("yes", "no", "none"),
+        "filed": ("no", "yes", "issue_url"),
+        "resolved": ("no", "yes", "disposition_reason, disposition_at"),
+        "wontfix": ("no", "yes", "disposition_reason, disposition_at"),
+    }
+
+
+def test_skill_keeps_schema_invalid_jsonl_fail_closed() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+    fail_closed_contract = (
+        "schema に準拠しない\n行が 1 行でもあれば、行番号だけを示して停止する。壊れた行を飛ばして続行しない。"
+    )
+
+    assert fail_closed_contract in skill


### PR DESCRIPTION
## Summary

- feedback entry schema に verified resolved の `resolved` と意図的見送りの `wontfix` を追加
- terminal disposition に簡潔な `disposition_reason` と ISO 8601 `disposition_at` を必須化
- `recorded` だけを filing candidate とし、`filed` / `resolved` / `wontfix` を表示・選択・起票・再変更しない skill lifecycle を定義
- schema-invalid JSONL は行番号を示して全停止する fail-closed 契約を維持。skip 提案は #3939 へ分離

## Acceptance evidence

- recorded: filing candidate=yes、terminal=no、issue/disposition metadata 禁止
- filed: filing candidate=no、terminal=yes、`issue_url` 必須、disposition metadata 禁止
- resolved / wontfix: filing candidate=no、terminal=yes、`disposition_reason` / `disposition_at` 必須、`issue_url` 禁止
- schema と SKILL lifecycle table を横断する contract tests 8 件を追加
- fail-closed 文言を contract test で固定し、invalid-line skip を実装していない

## Validation

- `nix develop --command uv run pytest -q tests/repo/test_skill_feedback_contract.py` — 8 passed
- `nix develop --command uv run yt-skills lint` — 55 skills passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 789 files formatted
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh` — passed
- `git diff --check main...HEAD` — passed
- packaging CI equivalent: `uv sync --frozen`、`uv build`、installed-wheel sync smoke、dashboard packaging smoke — passed
- full `pytest -n auto`: 8252 passed / 1 skipped。無関係な subprocess timeout 3 件は各 test の単独再実行で全て passed

## CHANGELOG decision

Public な downstream skill / JSONL schema contract の追加なので `CHANGELOG.md` の `[Unreleased]` を更新した。既存 `recorded` / `filed` entry は引き続き schema-valid で、強制 migration は不要。

Closes #3914
