### PR TITLE
fix(tests): worktree store を analytics 走査から除外する (#3901)

### DIFF
--- a/tests/repo/test_analytics_consolidation.py
+++ b/tests/repo/test_analytics_consolidation.py
@@ -3,13 +3,47 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from pathlib import Path
 
 import yaml
 
-from tests.helpers.paths import REPO_ROOT
+from tests.helpers.paths import REPO_ROOT, WORKTREE_STORE_PREFIXES, is_inside_worktree_store
 
 SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "analytics"
 LEGACY_MODES = ("collect", "analyze", "report", "run")
+_REPOSITORY_SCAN_EXCLUDED_DIRS = {".git", ".venv", ".direnv"}
+
+
+def _repository_files(root: Path) -> Iterator[Path]:
+    worktree_stores = tuple(
+        store for prefix in WORKTREE_STORE_PREFIXES if is_inside_worktree_store(store := root.joinpath(*prefix), root)
+    )
+    for path in root.rglob("*"):
+        if any(path.is_relative_to(store) for store in worktree_stores):
+            continue
+        if not path.is_file() or _REPOSITORY_SCAN_EXCLUDED_DIRS.intersection(path.parts):
+            continue
+        yield path
+
+
+def test_repository_scan_keeps_repo_files_and_skips_worktree_stores(tmp_path: Path) -> None:
+    repo_file = tmp_path / "tests" / "contract.py"
+    repo_file.parent.mkdir()
+    repo_file.write_text("repo", encoding="utf-8")
+
+    worktree_files = {
+        tmp_path / ".worktrees" / "legacy" / "contract.py",
+        tmp_path / ".claude" / "worktrees" / "current" / "contract.py",
+    }
+    for path in worktree_files:
+        path.parent.mkdir(parents=True)
+        path.write_text("worktree", encoding="utf-8")
+
+    scanned = set(_repository_files(tmp_path))
+
+    assert repo_file in scanned
+    assert scanned.isdisjoint(worktree_files)
 
 
 def test_analytics_exposes_full_chain_and_exclusive_modes() -> None:
@@ -39,9 +73,7 @@ def test_legacy_analytics_entrypoints_and_paths_are_removed() -> None:
     legacy_skill_paths = tuple(f".claude/skills/{name}/" for name in legacy_names)
     legacy_config_paths = tuple(f"config/skills/{name}.yaml" for name in legacy_names)
     offenders: list[str] = []
-    for path in REPO_ROOT.rglob("*"):
-        if not path.is_file() or {".git", ".venv", ".direnv"}.intersection(path.parts):
-            continue
+    for path in _repository_files(REPO_ROOT):
         try:
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:

--- a/tests/repo/test_scripts_layout.py
+++ b/tests/repo/test_scripts_layout.py
@@ -60,38 +60,11 @@ _LEGACY_CHANNEL_SETUP_REFERENCES = (
     "channel-setup" + "/references",
     ".claude/skills/" + "channel-setup",
 )
-_STALE_REFERENCE_EXCLUDED_DIRS = {
-    ".git",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".takt",
-    ".venv",
-    ".worktrees",
-    "__pycache__",
-    "node_modules",
-}
-_STALE_REFERENCE_EXCLUDED_FILES = {"CHANGELOG.md"}
-_STALE_REFERENCE_EXCLUDED_PATH_PREFIXES = {
-    ("docs", "audits"),
-    ("docs", "superpowers"),
-}
-
-
 # ---------- 共通ヘルパー ----------
 
 
 def _bash_available() -> bool:
     return shutil.which("bash") is not None
-
-
-def _is_stale_reference_scan_target(path: Path) -> bool:
-    relative = path.relative_to(_REPO_ROOT)
-    if relative.name in _STALE_REFERENCE_EXCLUDED_FILES:
-        return False
-    if any(relative.parts[: len(prefix)] == prefix for prefix in _STALE_REFERENCE_EXCLUDED_PATH_PREFIXES):
-        return False
-    return not any(part in _STALE_REFERENCE_EXCLUDED_DIRS for part in relative.parts)
 
 
 # ---------- ルート scripts/ から skill 固有ファイルが消えているか ----------


### PR DESCRIPTION
## Summary
- Analytics consolidation の repository scan が `tests.helpers.paths.is_inside_worktree_store` と同じ SSOT から `.worktrees` / `.claude/worktrees` を確定し、file 判定・`read_text` より前に除外するよう変更
- repo 本体の file は走査対象に残り、両 worktree store は除外される regression test を追加
- 呼び出し元が存在しない stale-reference scan helper と旧 `.worktrees` 一名だけの除外集合を削除
- `Path.rglob` は維持し、新しい scan engine への移行は行わない

## Acceptance evidence
- Before（メイン checkout、変更前ロジック）: 819,682 paths / 450,876 `read_text`、うち `.claude/worktrees` は 641,777 paths / 318,564 reads、110.245 秒
- After（同じ checkout、新 iterator）: 132,312 `read_text`、worktree store reads 0。経過 161.174 秒は既存 `rglob` が store 内を列挙し続ける制約と同時 I/O 負荷を含むため、改善の根拠は read 件数で判定
- Regression: repo file は scan 対象、`.worktrees` と `.claude/worktrees` の fixture file は双方 scan 対象外

## Validation
- `nix develop --command uv run pytest -q tests/repo/test_analytics_consolidation.py tests/repo/test_scripts_layout.py` — 23 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 788 files already formatted
- `nix develop --command uv run pytest -n auto` — 8248 passed, 1 skipped
- `git diff --check` — passed

## CHANGELOG
更新なし。変更は `tests/` のみで、`docs/development.md` の CHANGELOG gate は tests-only 変更を自動 skip する。

Closes #3901