### PR TITLE
fix(metadata): bulk update CLI の help 契約を明示 (#3796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
+- `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。
 - `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。

--- a/src/youtube_automation/commands/metadata/bulk_update_descriptions.py
+++ b/src/youtube_automation/commands/metadata/bulk_update_descriptions.py
@@ -154,9 +154,20 @@ def load_collection(col: str) -> dict:
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--only", help="comma-separated substring filter for collection names")
+    parser = argparse.ArgumentParser(
+        description=(
+            "descriptions.md の内容を YouTube 上の公開済み動画の概要欄へ一括書き込みする（通常実行は API write）"
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="YouTube への書き込みを行わず、更新予定を安全にプレビューする",
+    )
+    parser.add_argument(
+        "--only",
+        help="collection 名のカンマ区切り部分一致フィルター（指定した collection のみ対象）",
+    )
     args = parser.parse_args()
 
     targets = discover_collections()

--- a/tests/commands/metadata/test_bulk_update_descriptions_from_md.py
+++ b/tests/commands/metadata/test_bulk_update_descriptions_from_md.py
@@ -464,6 +464,28 @@ class TestMainTargetSelection:
         assert result.stdout == ""
         assert result.stderr == "INFO: nothing to do\n"
 
+    def test_console_entrypoint_help_should_explain_write_and_safe_preview_contract(self):
+        """``--help`` だけで通常実行の write と dry-run の no-write を判別できる."""
+        entrypoint = Path(sys.executable).with_name("yt-bulk-update-desc")
+        assert entrypoint.is_file()
+
+        result = subprocess.run(
+            [entrypoint, "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        help_text = " ".join(result.stdout.split())
+
+        assert result.returncode == 0
+        assert result.stderr == ""
+        assert "YouTube 上の公開済み動画の概要欄へ一括書き込みする" in help_text
+        assert "通常実行は API write" in help_text
+        assert "--dry-run" in help_text
+        assert "YouTube への書き込みを行わず、更新予定を安全にプレビューする" in help_text
+        assert "--only ONLY" in help_text
+        assert "collection 名のカンマ区切り部分一致フィルター" in help_text
+
 
 # ---------------------------------------------------------------------------
 # 3. main — 既存挙動の維持（リグレッションガード）


### PR DESCRIPTION
## Summary

- `yt-bulk-update-desc --help` に、公開済み YouTube 動画の概要欄へ一括書き込みする通常実行の契約を追加
- `--dry-run` を API write なしの安全なプレビュー、`--only` を collection 部分一致フィルターとして明記
- 実 console entrypoint の help 回帰テストを追加

## Acceptance evidence

- 修正前: exit 0 だが command description がなく、`--dry-run` も無説明
- 修正後: exit 0 で `YouTube 上の公開済み動画の概要欄へ一括書き込みする`、`通常実行は API write`、`YouTube への書き込みを行わず、更新予定を安全にプレビューする`、`collection 名のカンマ区切り部分一致フィルター` を表示
- 既存テストで通常実行は `videos().update().execute()` を呼び、`--dry-run` は呼ばない契約を維持

## Validation

- `nix develop --command uv run pytest tests/commands/metadata/test_bulk_update_descriptions_from_md.py -q` — 47 passed
- 関連 CLI help contract tests — 122 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed
- `bash .github/scripts/any-usage-gate.sh` — passed
- `git diff --check` — passed
- packaging: frozen sync、wheel/sdist build、installed-wheel smoke 2件 — passed
- full `pytest -n auto` — 8245 passed / 1 skipped / 3 unrelated collection-server timeout failures; 各失敗は単独再実行で green（テスト変更・skip・timeout 緩和なし）。正本の PR CI で再検証

## CHANGELOG decision

Required: `src/youtube_automation/` のユーザー可視 CLI help 変更のため、`CHANGELOG.md` の `[Unreleased]` を更新。

Closes #3796