### PR TITLE
fix(cli): 競合CLIのchannel先食いを防ぐ (#3923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
 - `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。
+- `fix(cli)`: `yt-benchmark-comments` と `yt-thumbnail-compare` の旧 `--channel` を共通 entrypoint が先に消費せず、`--competitor` への移行案内で誤チャンネル選択前に停止するよう修正した（#3923）。
 - `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -13,7 +13,9 @@ _CHANNEL_OPTION_CONFLICTS = {
     "youtube_automation.commands.channel.channel",
     "youtube_automation.commands.channel.channel_import",
     "youtube_automation.commands.analytics.benchmark_collector",
+    "youtube_automation.commands.analytics.fetch_benchmark_comments",
     "youtube_automation.commands.analytics.video_analyze",
+    "youtube_automation.commands.thumbnail.compare_thumbnails",
 }
 
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from youtube_automation import entrypoints
+from youtube_automation.commands._shared.arguments import CompetitorArgumentParser
 from youtube_automation.core.errors import ConfigError
 
 
@@ -59,3 +62,33 @@ def test_run_rejects_non_callable_module_attribute(monkeypatch: pytest.MonkeyPat
 
     with pytest.raises(TypeError, match="dummy.module:main is not callable"):
         entrypoints._run("dummy.module")
+
+
+@pytest.mark.parametrize(
+    "cli_entrypoint",
+    [
+        pytest.param(entrypoints.yt_benchmark_comments, id="benchmark-comments"),
+        pytest.param(entrypoints.yt_thumbnail_compare, id="thumbnail-compare"),
+    ],
+)
+def test_competitor_cli_rejects_channel_without_selecting_self_channel(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    cli_entrypoint: Callable[[], object],
+) -> None:
+    select_channel = Mock()
+    parser = CompetitorArgumentParser()
+    monkeypatch.setattr(sys, "argv", ["yt-command", "--channel", "competitor-x"])
+    monkeypatch.setattr(entrypoints, "configure_utf8_stdio", lambda: None)
+    monkeypatch.setattr(
+        entrypoints,
+        "import_module",
+        lambda _path: SimpleNamespace(main=lambda: parser.parse_args()),
+    )
+    monkeypatch.setattr("youtube_automation.configuration.select_channel", select_channel)
+
+    with pytest.raises(SystemExit, match="2"):
+        cli_entrypoint()
+
+    assert "--channel は --competitor に変わりました" in capsys.readouterr().err
+    select_channel.assert_not_called()


### PR DESCRIPTION
## Summary
- `yt-benchmark-comments` と `yt-thumbnail-compare` を `_CHANNEL_OPTION_CONFLICTS` に追加し、共通 entrypoint が旧 `--channel` を自チャンネル指定として先に消費しないようにした
- 公開 entrypoint から `CompetitorArgumentParser` までを通す回帰テストで、`--competitor` 移行案内・exit 2・`select_channel` 未呼び出しを2 CLIそれぞれ固定した
- 既存の `benchmark_collector` / `video_analyze` 競合契約と argv 前処理方式は変更していない

## Acceptance evidence
- 修正前再現: 追加した `tests/test_entrypoints.py` の2ケースがともに `Failed: DID NOT RAISE SystemExit` となり、entrypoint が `--channel` を先食いしていたことを確認
- 修正後: 同2ケースは `--channel は --competitor に変わりました` を stderr に出して exit 2 となり、`select_channel` は未呼び出し
- 対象テスト: `8 passed`
- full suite: `8249 passed, 1 skipped`

## Validation
- `nix develop --command uv run pytest -q tests/test_entrypoints.py`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run pytest -n auto`
- `git diff --check`

## CHANGELOG
`src/youtube_automation/entrypoints.py` の利用者向け CLI 挙動を修正するため、`CHANGELOG.md` の `[Unreleased]` に `fix(cli)` entry を追加した。

Closes #3923
