### PR TITLE
refactor(dashboard): 応答形状を TypedDict に固定 (#3897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。
 - `fix(cli)`: `yt-benchmark-comments` と `yt-thumbnail-compare` の旧 `--channel` を共通 entrypoint が先に消費せず、`--competitor` への移行案内で誤チャンネル選択前に停止するよう修正した（#3923）。
 - `feat(skill-feedback)`: feedback entry に `resolved` / `wontfix` の終端状態と理由・更新時刻を追加し、`recorded` だけを還流候補として扱う契約を明確化した。schema 非準拠行があれば全停止する fail-closed 挙動は維持する（#3914）。
+- dashboard read model と publications 応答のキー契約を TypedDict で固定し、API JSON の既存 bytes を維持する回帰テストを追加 (#3897)
+
 - `fix(metadata)`: `apply_track_display_names` が `workflow-state.json` の読み失敗・root 非 object 時に既存 state 全体を空 dict で上書きしていた経路を `ValidationError` の fail-loud に変更し、書き込みを tempfile + `os.replace` の atomic 方式にした（#3871）。
 - `fix(masterup)`: `yt-generate-master` に存在しない bitrate / crossfade の CLI 上書き例を配布 skill から削除し、`config/skills/masterup.json` または YAML fallback の `audio` 設定を使う実装契約へ案内を統一した（#3763）。
 - `feat(channel-new)`: 既存チャンネル取り込み完了時に `wf_new_readiness` の判定を提示し、`/wf-new` 到達に必須の最短手順とブランディング・ペルソナ・追加ベンチマークなどの任意改善を分離する。警告時も取り込み自体は完了扱いを維持する（#3762）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -7,7 +7,7 @@ import json
 import logging
 import mimetypes
 import webbrowser
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.resources import files
@@ -69,7 +69,7 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: object) -> None:
         return None
 
-    def _json(self, status: HTTPStatus, payload: dict[str, object]) -> None:
+    def _json(self, status: HTTPStatus, payload: Mapping[str, object]) -> None:
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -86,7 +86,7 @@ class DashboardRequestHandler(BaseHTTPRequestHandler):
             self._json(HTTPStatus.OK, self.server.api.overview())
             return True
         if path == "/api/publications":
-            self._json(HTTPStatus.OK, cast(dict[str, object], self.server.api.model["publications"]))
+            self._json(HTTPStatus.OK, self.server.api.model["publications"])
             return True
         prefix = "/api/channels/"
         if path.startswith(prefix):

--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -6,7 +6,7 @@ import json
 import os
 import tempfile
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import TypedDict, cast
@@ -60,9 +60,10 @@ def _validate_payload(value: object) -> DashboardPublications | None:
             return None
         if not isinstance(error.get("code"), str) or not isinstance(error.get("message"), str):
             return None
-        if not isinstance(error.get("attempted_at"), str):
+        attempted_at_value = error.get("attempted_at")
+        if not isinstance(attempted_at_value, str):
             return None
-        error_attempted_at = cast(str, error["attempted_at"])
+        error_attempted_at = attempted_at_value
 
     try:
         _parse_timestamp(fetched_at, field_name="fetched_at")
@@ -125,7 +126,7 @@ def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> Dashboa
     if payload is None:
         return None
 
-    fetched_at = _parse_timestamp(cast(str, payload["fetched_at"]), field_name="fetched_at")
+    fetched_at = _parse_timestamp(payload["fetched_at"], field_name="fetched_at")
     age = now.astimezone(UTC) - fetched_at
     if age < timedelta(0) or age > CACHE_MAX_AGE:
         return None
@@ -133,32 +134,29 @@ def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> Dashboa
 
 
 def with_dashboard_publication_error(
-    payload: dict[str, object],
+    payload: Mapping[str, object],
     *,
     code: str,
     message: str,
     attempted_at: datetime,
 ) -> DashboardPublications:
     """公開履歴の前回値を維持して構造化された更新失敗を付与する。"""
-    if _validate_payload(payload) is None:
+    validated = _validate_payload(payload)
+    if validated is None:
         raise ValueError("有効な公開履歴 payload が必要です")
     if attempted_at.tzinfo is None:
         raise ValueError("attempted_at は timezone-aware datetime でなければなりません")
 
-    return cast(
-        DashboardPublications,
-        {
-            **payload,
-            "error": {
-                "code": code,
-                "message": message,
-                "attempted_at": attempted_at.astimezone(UTC).isoformat(),
-            },
-        },
+    result = validated.copy()
+    result["error"] = DashboardPublicationError(
+        code=code,
+        message=message,
+        attempted_at=attempted_at.astimezone(UTC).isoformat(),
     )
+    return result
 
 
-def save_dashboard_publications(destination: Path, payload: dict[str, object]) -> None:
+def save_dashboard_publications(destination: Path, payload: Mapping[str, object]) -> None:
     """同一ディレクトリの一時ファイルを置換して payload を原子的に保存する。"""
     descriptor, temporary_name = tempfile.mkstemp(
         dir=destination.parent,

--- a/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_publications.py
@@ -9,12 +9,29 @@ from collections import Counter
 from collections.abc import Iterable
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import cast
+from typing import TypedDict, cast
 from zoneinfo import ZoneInfo
 
 SCHEMA_VERSION = 1
 ROLLING_WINDOW_DAYS = 365
 CACHE_MAX_AGE = timedelta(hours=24)
+
+
+class DashboardPublicationError(TypedDict):
+    code: str
+    message: str
+    attempted_at: str
+
+
+class DashboardPublicationsRequired(TypedDict):
+    schema_version: int
+    fetched_at: str
+    timezone: str
+    days: dict[str, int]
+
+
+class DashboardPublications(DashboardPublicationsRequired, total=False):
+    error: DashboardPublicationError
 
 
 def _parse_timestamp(value: str, *, field_name: str) -> datetime:
@@ -24,7 +41,7 @@ def _parse_timestamp(value: str, *, field_name: str) -> datetime:
     return timestamp.astimezone(UTC)
 
 
-def _validate_payload(value: object) -> dict[str, object] | None:
+def _validate_payload(value: object) -> DashboardPublications | None:
     if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
         return None
     schema_version = value.get("schema_version")
@@ -37,6 +54,7 @@ def _validate_payload(value: object) -> dict[str, object] | None:
     if not isinstance(fetched_at, str) or not isinstance(timezone, str) or not isinstance(days, dict):
         return None
     error = value.get("error")
+    error_attempted_at: str | None = None
     if "error" in value:
         if not isinstance(error, dict):
             return None
@@ -44,11 +62,12 @@ def _validate_payload(value: object) -> dict[str, object] | None:
             return None
         if not isinstance(error.get("attempted_at"), str):
             return None
+        error_attempted_at = cast(str, error["attempted_at"])
 
     try:
         _parse_timestamp(fetched_at, field_name="fetched_at")
-        if "error" in value:
-            _parse_timestamp(cast(str, error["attempted_at"]), field_name="error.attempted_at")
+        if error_attempted_at is not None:
+            _parse_timestamp(error_attempted_at, field_name="error.attempted_at")
         ZoneInfo(timezone)
         for local_day, count in days.items():
             if not isinstance(local_day, str) or type(count) is not int or count < 0:
@@ -56,7 +75,7 @@ def _validate_payload(value: object) -> dict[str, object] | None:
             date.fromisoformat(local_day)
     except (ValueError, KeyError):
         return None
-    return cast(dict[str, object], value)
+    return cast(DashboardPublications, value)
 
 
 def build_dashboard_publications(
@@ -64,7 +83,7 @@ def build_dashboard_publications(
     *,
     timezone: str,
     fetched_at: datetime,
-) -> dict[str, object]:
+) -> DashboardPublications:
     """公開日時を rolling 365 日のローカル暦日別件数へ変換する。"""
     if fetched_at.tzinfo is None:
         raise ValueError("fetched_at は timezone-aware datetime でなければなりません")
@@ -80,15 +99,15 @@ def build_dashboard_publications(
             local_day = published_at.astimezone(local_timezone).date().isoformat()
             counts[local_day] += 1
 
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "fetched_at": fetched_at_utc.isoformat(),
-        "timezone": timezone,
-        "days": dict(sorted(counts.items())),
-    }
+    return DashboardPublications(
+        schema_version=SCHEMA_VERSION,
+        fetched_at=fetched_at_utc.isoformat(),
+        timezone=timezone,
+        days=dict(sorted(counts.items())),
+    )
 
 
-def load_dashboard_publications(source: Path) -> dict[str, object] | None:
+def load_dashboard_publications(source: Path) -> DashboardPublications | None:
     """鮮度に関係なく有効な公開履歴 cache を返す。"""
     try:
         value: object = json.loads(source.read_text(encoding="utf-8"))
@@ -97,7 +116,7 @@ def load_dashboard_publications(source: Path) -> dict[str, object] | None:
     return _validate_payload(value)
 
 
-def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> dict[str, object] | None:
+def load_fresh_dashboard_publications(source: Path, *, now: datetime) -> DashboardPublications | None:
     """有効かつ取得から24時間以内の公開履歴 cache を返す。"""
     if now.tzinfo is None:
         raise ValueError("now は timezone-aware datetime でなければなりません")
@@ -119,21 +138,24 @@ def with_dashboard_publication_error(
     code: str,
     message: str,
     attempted_at: datetime,
-) -> dict[str, object]:
+) -> DashboardPublications:
     """公開履歴の前回値を維持して構造化された更新失敗を付与する。"""
     if _validate_payload(payload) is None:
         raise ValueError("有効な公開履歴 payload が必要です")
     if attempted_at.tzinfo is None:
         raise ValueError("attempted_at は timezone-aware datetime でなければなりません")
 
-    return {
-        **payload,
-        "error": {
-            "code": code,
-            "message": message,
-            "attempted_at": attempted_at.astimezone(UTC).isoformat(),
+    return cast(
+        DashboardPublications,
+        {
+            **payload,
+            "error": {
+                "code": code,
+                "message": message,
+                "attempted_at": attempted_at.astimezone(UTC).isoformat(),
+            },
         },
-    }
+    )
 
 
 def save_dashboard_publications(destination: Path, payload: dict[str, object]) -> None:

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -8,13 +8,109 @@ import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import TypedDict, cast
 
 from youtube_automation.core.errors import DashboardChannelNotFoundError
-from youtube_automation.infrastructure.analytics.dashboard_publications import load_dashboard_publications
+from youtube_automation.infrastructure.analytics.dashboard_publications import (
+    DashboardPublicationError,
+    load_dashboard_publications,
+)
 
 SCHEMA_VERSION = 2
 LEGACY_SCHEMA_VERSION = 1
+
+
+class ErrorResponse(TypedDict):
+    code: str
+    message: str
+
+
+class PeriodResponse(TypedDict):
+    start_date: str | None
+    end_date: str | None
+
+
+class SummaryResponse(TypedDict):
+    views: int | float
+    watch_time_minutes: int | float
+    subscribers_net: int | float
+    engagements: int | float
+    average_view_percentage: int | float
+
+
+class VideoResponse(TypedDict):
+    video_id: str
+    title: str
+    views: int | float
+    impressions: int | float
+    ctr_percentage: int | float
+    likes: int | float
+    comments: int | float
+    shares: int | float
+    subscribers_gained: int | float
+    average_view_duration_seconds: int | float
+    engagements: int | float
+
+
+class ChannelSourceResponse(TypedDict):
+    id: str
+    name: str
+    status: str
+    snapshot: str | None
+    collected_at: str | None
+    period: PeriodResponse
+    scheduled_count: int | None
+    summary: SummaryResponse | None
+    videos: list[VideoResponse]
+    error: ErrorResponse | None
+
+
+class ChannelWorkflowTimingResponse(TypedDict, total=False):
+    workflow_timing: dict[str, object]
+
+
+class ChannelDetailResponse(ChannelSourceResponse, ChannelWorkflowTimingResponse):
+    refresh_error: ErrorResponse | None
+
+
+class PublicationChannelResponse(TypedDict):
+    id: str
+    name: str
+    status: str
+    fetched_at: str | None
+    timezone: str | None
+    days: dict[str, int]
+    error: DashboardPublicationError | None
+
+
+class PublicationsResponse(TypedDict):
+    days: dict[str, int]
+    channels: list[PublicationChannelResponse]
+
+
+class DashboardReadModel(TypedDict):
+    schema_version: int
+    channels: list[ChannelDetailResponse]
+    publications: PublicationsResponse
+
+
+class ChannelOverviewResponse(TypedDict):
+    id: str
+    name: str
+    status: str
+    snapshot: str | None
+    collected_at: str | None
+    period: PeriodResponse
+    scheduled_count: int | None
+    summary: SummaryResponse | None
+    error: ErrorResponse | None
+    refresh_error: ErrorResponse | None
+    video_count: int
+
+
+class OverviewResponse(TypedDict):
+    schema_version: int
+    channels: list[ChannelOverviewResponse]
 
 
 def _object(value: object) -> dict[str, object]:
@@ -82,10 +178,10 @@ def _reporting_by_video(snapshot: dict[str, object]) -> dict[str, dict[str, obje
     return result
 
 
-def _videos(snapshot: dict[str, object]) -> list[dict[str, object]]:
+def _videos(snapshot: dict[str, object]) -> list[VideoResponse]:
     analytics = _object(snapshot.get("video_analytics"))
     reporting = _reporting_by_video(snapshot)
-    videos: list[dict[str, object]] = []
+    videos: list[VideoResponse] = []
     for key, raw in analytics.items():
         source = _object(raw)
         video_id = _text(source.get("video_id"), key)
@@ -94,19 +190,19 @@ def _videos(snapshot: dict[str, object]) -> list[dict[str, object]]:
         comments = _non_negative_number(source.get("comments"))
         shares = _non_negative_number(source.get("shares"))
         videos.append(
-            {
-                "video_id": video_id,
-                "title": _text(source.get("title"), "Unknown"),
-                "views": _non_negative_number(source.get("views")),
-                "impressions": _non_negative_number(reach.get("impressions")),
-                "ctr_percentage": _non_negative_number(reach.get("ctr_percentage")),
-                "likes": likes,
-                "comments": comments,
-                "shares": shares,
-                "subscribers_gained": _non_negative_number(source.get("subscribers_gained")),
-                "average_view_duration_seconds": _non_negative_number(source.get("average_view_duration")),
-                "engagements": likes + comments + shares,
-            }
+            VideoResponse(
+                video_id=video_id,
+                title=_text(source.get("title"), "Unknown"),
+                views=_non_negative_number(source.get("views")),
+                impressions=_non_negative_number(reach.get("impressions")),
+                ctr_percentage=_non_negative_number(reach.get("ctr_percentage")),
+                likes=likes,
+                comments=comments,
+                shares=shares,
+                subscribers_gained=_non_negative_number(source.get("subscribers_gained")),
+                average_view_duration_seconds=_non_negative_number(source.get("average_view_duration")),
+                engagements=likes + comments + shares,
+            )
         )
     return sorted(videos, key=lambda item: (-cast(int | float, item["views"]), cast(str, item["video_id"])))
 
@@ -118,19 +214,19 @@ def _error_channel(
     status: str,
     code: str,
     message: str,
-) -> dict[str, object]:
-    return {
-        "id": _channel_id(channel),
-        "name": name,
-        "status": status,
-        "snapshot": None,
-        "collected_at": None,
-        "period": {"start_date": None, "end_date": None},
-        "scheduled_count": None,
-        "summary": None,
-        "videos": [],
-        "error": {"code": code, "message": message},
-    }
+) -> ChannelSourceResponse:
+    return ChannelSourceResponse(
+        id=_channel_id(channel),
+        name=name,
+        status=status,
+        snapshot=None,
+        collected_at=None,
+        period=PeriodResponse(start_date=None, end_date=None),
+        scheduled_count=None,
+        summary=None,
+        videos=[],
+        error=ErrorResponse(code=code, message=message),
+    )
 
 
 def _load_name(channel: Path) -> str:
@@ -157,34 +253,34 @@ def _ready_channel(
     name: str,
     snapshot_path: Path,
     snapshot: dict[str, object],
-) -> dict[str, object]:
+) -> ChannelSourceResponse:
     period = _object(snapshot.get("collection_period"))
     summary = _object(_object(snapshot.get("channel_analytics")).get("summary"))
     scheduled = _object(snapshot.get("scheduled_videos"))
-    return {
-        "id": _channel_id(channel),
-        "name": name,
-        "status": "ready",
-        "snapshot": snapshot_path.name,
-        "collected_at": _text(period.get("collected_at")) or None,
-        "period": {
-            "start_date": _text(period.get("start_date")) or None,
-            "end_date": _text(period.get("end_date")) or None,
-        },
-        "scheduled_count": _integer_or_none(scheduled.get("count")),
-        "summary": {
-            "views": _non_negative_number(summary.get("total_views")),
-            "watch_time_minutes": _non_negative_number(summary.get("total_watch_time")),
-            "subscribers_net": _number(summary.get("net_subscribers")),
-            "engagements": _non_negative_number(summary.get("total_engagement")),
-            "average_view_percentage": _non_negative_number(summary.get("avg_view_percentage")),
-        },
-        "videos": _videos(snapshot),
-        "error": None,
-    }
+    return ChannelSourceResponse(
+        id=_channel_id(channel),
+        name=name,
+        status="ready",
+        snapshot=snapshot_path.name,
+        collected_at=_text(period.get("collected_at")) or None,
+        period=PeriodResponse(
+            start_date=_text(period.get("start_date")) or None,
+            end_date=_text(period.get("end_date")) or None,
+        ),
+        scheduled_count=_integer_or_none(scheduled.get("count")),
+        summary=SummaryResponse(
+            views=_non_negative_number(summary.get("total_views")),
+            watch_time_minutes=_non_negative_number(summary.get("total_watch_time")),
+            subscribers_net=_number(summary.get("net_subscribers")),
+            engagements=_non_negative_number(summary.get("total_engagement")),
+            average_view_percentage=_non_negative_number(summary.get("avg_view_percentage")),
+        ),
+        videos=_videos(snapshot),
+        error=None,
+    )
 
 
-def _build_channel(channel: Path, *, allow_snapshot_fallback: bool = False) -> dict[str, object]:
+def _build_channel(channel: Path, *, allow_snapshot_fallback: bool = False) -> ChannelSourceResponse:
     try:
         name = _load_name(channel)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
@@ -224,48 +320,45 @@ def _build_channel(channel: Path, *, allow_snapshot_fallback: bool = False) -> d
     )
 
 
-def _publication_channel(channel: Path, item: dict[str, object]) -> dict[str, object]:
+def _publication_channel(channel: Path, item: ChannelDetailResponse) -> PublicationChannelResponse:
     publication_path = channel / "data" / "dashboard_publications.json"
     payload = load_dashboard_publications(publication_path)
     if payload is None:
-        return {
-            "id": item["id"],
-            "name": item["name"],
-            "status": "invalid" if publication_path.exists() else "missing",
-            "fetched_at": None,
-            "timezone": None,
-            "days": {},
-            "error": None,
-        }
+        return PublicationChannelResponse(
+            id=item["id"],
+            name=item["name"],
+            status="invalid" if publication_path.exists() else "missing",
+            fetched_at=None,
+            timezone=None,
+            days={},
+            error=None,
+        )
 
     error = payload.get("error")
-    return {
-        "id": item["id"],
-        "name": item["name"],
-        "status": "refresh_failed" if error is not None else "ready",
-        "fetched_at": payload["fetched_at"],
-        "timezone": payload["timezone"],
-        "days": payload["days"],
-        "error": error,
-    }
+    return PublicationChannelResponse(
+        id=item["id"],
+        name=item["name"],
+        status="refresh_failed" if error is not None else "ready",
+        fetched_at=payload["fetched_at"],
+        timezone=payload["timezone"],
+        days=payload["days"],
+        error=error,
+    )
 
 
 def _publication_read_model(
     channel_paths: list[Path],
-    channels: list[dict[str, object]],
-) -> dict[str, object]:
+    channels: list[ChannelDetailResponse],
+) -> PublicationsResponse:
     totals: dict[str, int] = {}
-    publication_channels: list[dict[str, object]] = []
+    publication_channels: list[PublicationChannelResponse] = []
     for channel, item in zip(channel_paths, channels, strict=True):
         publication = _publication_channel(channel, item)
         publication_channels.append(publication)
-        days = cast(dict[str, int], publication["days"])
+        days = publication["days"]
         for local_day, count in days.items():
             totals[local_day] = totals.get(local_day, 0) + count
-    return {
-        "days": dict(sorted(totals.items())),
-        "channels": publication_channels,
-    }
+    return PublicationsResponse(days=dict(sorted(totals.items())), channels=publication_channels)
 
 
 def build_dashboard_read_model(
@@ -273,17 +366,20 @@ def build_dashboard_read_model(
     *,
     refresh_errors: dict[Path, str] | None = None,
     workflow_timing_by_channel: Mapping[Path, object] | None = None,
-) -> dict[str, object]:
+) -> DashboardReadModel:
     """登録順のチャンネルから JSON serializable な read model を作る。"""
     errors = refresh_errors or {}
     workflow_timings = workflow_timing_by_channel or {}
     timing_requested = workflow_timing_by_channel is not None
-    channels: list[dict[str, object]] = []
+    channels: list[ChannelDetailResponse] = []
     for channel in channel_paths:
         refresh_message = errors.get(channel)
-        item = _build_channel(channel, allow_snapshot_fallback=refresh_message is not None)
-        item["refresh_error"] = (
-            {"code": "refresh_failed", "message": refresh_message} if refresh_message is not None else None
+        source = _build_channel(channel, allow_snapshot_fallback=refresh_message is not None)
+        item = ChannelDetailResponse(
+            **source,
+            refresh_error=(
+                ErrorResponse(code="refresh_failed", message=refresh_message) if refresh_message is not None else None
+            ),
         )
         if timing_requested:
             if channel in workflow_timings:
@@ -294,11 +390,11 @@ def build_dashboard_read_model(
                     "channel の workflow timing がありません",
                 )
         channels.append(item)
-    return {
-        "schema_version": SCHEMA_VERSION if timing_requested else LEGACY_SCHEMA_VERSION,
-        "channels": channels,
-        "publications": _publication_read_model(channel_paths, channels),
-    }
+    return DashboardReadModel(
+        schema_version=SCHEMA_VERSION if timing_requested else LEGACY_SCHEMA_VERSION,
+        channels=channels,
+        publications=_publication_read_model(channel_paths, channels),
+    )
 
 
 @dataclass(frozen=True)
@@ -313,7 +409,7 @@ class DashboardAPI:
             return []
         return [cast(dict[str, object], item) for item in channels if isinstance(item, dict)]
 
-    def overview(self) -> dict[str, object]:
+    def overview(self) -> OverviewResponse:
         """動画行を除いた全チャンネル概要を返す。"""
         overview_channels: list[dict[str, object]] = []
         for item in self._channels():
@@ -321,17 +417,17 @@ class DashboardAPI:
             overview = {key: value for key, value in item.items() if key not in {"videos", "workflow_timing"}}
             overview["video_count"] = len(videos) if isinstance(videos, list) else 0
             overview_channels.append(overview)
-        return {
-            "schema_version": self.model.get("schema_version", SCHEMA_VERSION),
-            "channels": overview_channels,
-        }
+        return OverviewResponse(
+            schema_version=cast(int, self.model.get("schema_version", SCHEMA_VERSION)),
+            channels=cast(list[ChannelOverviewResponse], overview_channels),
+        )
 
-    def channel(self, channel_id: str) -> dict[str, object]:
+    def channel(self, channel_id: str) -> ChannelDetailResponse:
         """選択チャンネルの動画を含む詳細を返す。"""
         for item in self._channels():
             if item.get("id") == channel_id:
                 detail = dict(item)
                 if not isinstance(detail.get("videos"), list):
                     detail["videos"] = []
-                return detail
+                return cast(ChannelDetailResponse, detail)
         raise DashboardChannelNotFoundError(f"dashboard channel が見つかりません: {channel_id}")

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -8,7 +8,7 @@ import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import TypeAlias, TypedDict, cast
 
 from youtube_automation.core.errors import DashboardChannelNotFoundError
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
@@ -111,6 +111,18 @@ class ChannelOverviewResponse(TypedDict):
 class OverviewResponse(TypedDict):
     schema_version: int
     channels: list[ChannelOverviewResponse]
+
+
+IncompleteChannelResponse: TypeAlias = dict[str, object]
+
+
+class IncompleteOverviewResponse(TypedDict):
+    schema_version: object
+    channels: list[IncompleteChannelResponse]
+
+
+DashboardOverviewResponse: TypeAlias = OverviewResponse | IncompleteOverviewResponse
+DashboardChannelResponse: TypeAlias = ChannelDetailResponse | IncompleteChannelResponse
 
 
 def _object(value: object) -> dict[str, object]:
@@ -409,57 +421,51 @@ class DashboardAPI:
             return []
         return [item for item in channels if isinstance(item, dict)]
 
-    def overview(self) -> OverviewResponse:
-        """動画行を除いた全チャンネル概要を返す。"""
-        overview_channels: list[ChannelOverviewResponse] = []
-        for item in self._channels():
-            videos = item.get("videos")
-            if not ChannelSourceResponse.__required_keys__ <= item.keys():
-                # DashboardAPI の型付き入力契約より前から、直接生成した不完全な
-                # model を best-effort で返す互換挙動がある。完全な型を一度作り、
-                # 実際の入力に存在しなかった required key だけを動的に除くことで、
-                # 正規 builder 経路の required-key 契約は弱めずに維持する。
-                legacy_overview = ChannelOverviewResponse(
-                    id=item.get("id", ""),
-                    name=item.get("name", ""),
-                    status=item.get("status", ""),
-                    snapshot=item.get("snapshot"),
-                    collected_at=item.get("collected_at"),
-                    period=item.get("period", PeriodResponse(start_date=None, end_date=None)),
-                    scheduled_count=item.get("scheduled_count"),
-                    summary=item.get("summary"),
-                    error=item.get("error"),
-                    refresh_error=item.get("refresh_error"),
-                    video_count=len(videos) if isinstance(videos, list) else 0,
-                )
-                for key in ChannelOverviewResponse.__required_keys__ - item.keys() - {"video_count"}:
-                    legacy_overview.pop(key, None)
-                overview_channels.append(legacy_overview)
-                continue
-            overview = ChannelOverviewResponse(
-                id=item["id"],
-                name=item["name"],
-                status=item["status"],
-                snapshot=item["snapshot"],
-                collected_at=item["collected_at"],
-                period=item["period"],
-                scheduled_count=item["scheduled_count"],
-                summary=item["summary"],
-                error=item["error"],
-                refresh_error=item["refresh_error"],
-                video_count=len(videos) if isinstance(videos, list) else 0,
-            )
-            overview_channels.append(overview)
-        return OverviewResponse(
-            schema_version=self.model.get("schema_version", SCHEMA_VERSION),
-            channels=overview_channels,
+    @staticmethod
+    def _overview_channel(item: ChannelDetailResponse) -> ChannelOverviewResponse:
+        videos = item["videos"]
+        return ChannelOverviewResponse(
+            id=item["id"],
+            name=item["name"],
+            status=item["status"],
+            snapshot=item["snapshot"],
+            collected_at=item["collected_at"],
+            period=item["period"],
+            scheduled_count=item["scheduled_count"],
+            summary=item["summary"],
+            error=item["error"],
+            refresh_error=item["refresh_error"],
+            video_count=len(videos) if isinstance(videos, list) else 0,
         )
 
-    def channel(self, channel_id: str) -> ChannelDetailResponse:
+    @staticmethod
+    def _incomplete_overview_channel(item: Mapping[str, object]) -> dict[str, object]:
+        videos = item.get("videos")
+        overview = {key: value for key, value in item.items() if key not in {"videos", "workflow_timing"}}
+        overview["video_count"] = len(videos) if isinstance(videos, list) else 0
+        return overview
+
+    def overview(self) -> DashboardOverviewResponse:
+        """動画行を除いた全チャンネル概要を返す。"""
+        channels = self._channels()
+        if any(not ChannelDetailResponse.__required_keys__ <= item.keys() for item in channels):
+            return IncompleteOverviewResponse(
+                schema_version=self.model.get("schema_version", SCHEMA_VERSION),
+                channels=[self._incomplete_overview_channel(item) for item in channels],
+            )
+        return OverviewResponse(
+            schema_version=self.model.get("schema_version", SCHEMA_VERSION),
+            channels=[self._overview_channel(item) for item in channels],
+        )
+
+    def channel(self, channel_id: str) -> DashboardChannelResponse:
         """選択チャンネルの動画を含む詳細を返す。"""
         for item in self._channels():
             if item.get("id") == channel_id:
-                detail = item.copy()
+                if ChannelDetailResponse.__required_keys__ <= item.keys():
+                    detail: DashboardChannelResponse = item.copy()
+                else:
+                    detail = dict(item.items())
                 if not isinstance(detail.get("videos"), list):
                     detail["videos"] = []
                 return detail

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -401,33 +401,66 @@ def build_dashboard_read_model(
 class DashboardAPI:
     """HTTP layer が利用する読み取り専用 JSON API service。"""
 
-    model: dict[str, object]
+    model: DashboardReadModel
 
-    def _channels(self) -> list[dict[str, object]]:
+    def _channels(self) -> list[ChannelDetailResponse]:
         channels = self.model.get("channels")
         if not isinstance(channels, list):
             return []
-        return [cast(dict[str, object], item) for item in channels if isinstance(item, dict)]
+        return [item for item in channels if isinstance(item, dict)]
 
     def overview(self) -> OverviewResponse:
         """動画行を除いた全チャンネル概要を返す。"""
-        overview_channels: list[dict[str, object]] = []
+        overview_channels: list[ChannelOverviewResponse] = []
         for item in self._channels():
             videos = item.get("videos")
-            overview = {key: value for key, value in item.items() if key not in {"videos", "workflow_timing"}}
-            overview["video_count"] = len(videos) if isinstance(videos, list) else 0
+            if not ChannelSourceResponse.__required_keys__ <= item.keys():
+                # DashboardAPI の型付き入力契約より前から、直接生成した不完全な
+                # model を best-effort で返す互換挙動がある。完全な型を一度作り、
+                # 実際の入力に存在しなかった required key だけを動的に除くことで、
+                # 正規 builder 経路の required-key 契約は弱めずに維持する。
+                legacy_overview = ChannelOverviewResponse(
+                    id=item.get("id", ""),
+                    name=item.get("name", ""),
+                    status=item.get("status", ""),
+                    snapshot=item.get("snapshot"),
+                    collected_at=item.get("collected_at"),
+                    period=item.get("period", PeriodResponse(start_date=None, end_date=None)),
+                    scheduled_count=item.get("scheduled_count"),
+                    summary=item.get("summary"),
+                    error=item.get("error"),
+                    refresh_error=item.get("refresh_error"),
+                    video_count=len(videos) if isinstance(videos, list) else 0,
+                )
+                for key in ChannelOverviewResponse.__required_keys__ - item.keys() - {"video_count"}:
+                    legacy_overview.pop(key, None)
+                overview_channels.append(legacy_overview)
+                continue
+            overview = ChannelOverviewResponse(
+                id=item["id"],
+                name=item["name"],
+                status=item["status"],
+                snapshot=item["snapshot"],
+                collected_at=item["collected_at"],
+                period=item["period"],
+                scheduled_count=item["scheduled_count"],
+                summary=item["summary"],
+                error=item["error"],
+                refresh_error=item["refresh_error"],
+                video_count=len(videos) if isinstance(videos, list) else 0,
+            )
             overview_channels.append(overview)
         return OverviewResponse(
-            schema_version=cast(int, self.model.get("schema_version", SCHEMA_VERSION)),
-            channels=cast(list[ChannelOverviewResponse], overview_channels),
+            schema_version=self.model.get("schema_version", SCHEMA_VERSION),
+            channels=overview_channels,
         )
 
     def channel(self, channel_id: str) -> ChannelDetailResponse:
         """選択チャンネルの動画を含む詳細を返す。"""
         for item in self._channels():
             if item.get("id") == channel_id:
-                detail = dict(item)
+                detail = item.copy()
                 if not isinstance(detail.get("videos"), list):
                     detail["videos"] = []
-                return cast(ChannelDetailResponse, detail)
+                return detail
         raise DashboardChannelNotFoundError(f"dashboard channel が見つかりません: {channel_id}")

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import urlopen
@@ -9,6 +10,11 @@ from urllib.request import urlopen
 import pytest
 
 from youtube_automation.commands.analytics.dashboard import create_server, main
+from youtube_automation.infrastructure.analytics.dashboard_publications import (
+    build_dashboard_publications,
+    save_dashboard_publications,
+    with_dashboard_publication_error,
+)
 
 
 def _write_channel(root: Path) -> Path:
@@ -58,22 +64,18 @@ def _write_channel(root: Path) -> Path:
         ),
         encoding="utf-8",
     )
-    (channel / "data" / "dashboard_publications.json").write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "fetched_at": "2026-07-20T13:00:00+00:00",
-                "timezone": "Asia/Tokyo",
-                "days": {"2026-07-20": 2},
-                "error": {
-                    "code": "publication_refresh_failed",
-                    "message": "quota exceeded",
-                    "attempted_at": "2026-07-20T14:00:00+00:00",
-                },
-            }
-        ),
-        encoding="utf-8",
+    publications = build_dashboard_publications(
+        ["2026-07-20T04:00:00Z", "2026-07-20T05:00:00Z"],
+        timezone="Asia/Tokyo",
+        fetched_at=datetime(2026, 7, 20, 13, tzinfo=UTC),
     )
+    publications_with_error = with_dashboard_publication_error(
+        publications,
+        code="publication_refresh_failed",
+        message="quota exceeded",
+        attempted_at=datetime(2026, 7, 20, 14, tzinfo=UTC),
+    )
+    save_dashboard_publications(channel / "data" / "dashboard_publications.json", publications_with_error)
     active = channel / "collections" / "planning" / "active"
     active.mkdir(parents=True)
     (active / "workflow-state.json").write_text(
@@ -165,6 +167,57 @@ def dashboard_server(tmp_path: Path):
 def _json(url: str) -> tuple[int, dict[str, object]]:
     with urlopen(url, timeout=5) as response:
         return response.status, json.loads(response.read())
+
+
+def _response_bytes(url: str) -> bytes:
+    with urlopen(url, timeout=5) as response:
+        assert response.status == 200
+        return response.read()
+
+
+def test_server_api_json_bytes_match_production_builder_golden(dashboard_server: str) -> None:
+    overview = _response_bytes(f"{dashboard_server}/api/channels")
+    channel_id = json.loads(overview)["channels"][0]["id"]
+    detail = _response_bytes(f"{dashboard_server}/api/channels/{channel_id}")
+    publications = _response_bytes(f"{dashboard_server}/api/publications")
+    channel_id_bytes = channel_id.encode("utf-8")
+
+    assert overview.replace(channel_id_bytes, b"<channel-id>") == (
+        b'{"schema_version": 2, "channels": [{"id": "<channel-id>", "name": "Night Drive", '
+        b'"status": "ready", "snapshot": "analytics_data_2026-07-20.json", '
+        b'"collected_at": "2026-07-20T12:00:00Z", "period": {"start_date": null, "end_date": null}, '
+        b'"scheduled_count": null, "summary": {"views": 123, "watch_time_minutes": 0, '
+        b'"subscribers_net": 0, "engagements": 0, "average_view_percentage": 0}, "error": null, '
+        b'"refresh_error": null, "video_count": 1}]}'
+    )
+    assert detail.replace(channel_id_bytes, b"<channel-id>") == (
+        b'{"id": "<channel-id>", "name": "Night Drive", "status": "ready", '
+        b'"snapshot": "analytics_data_2026-07-20.json", "collected_at": "2026-07-20T12:00:00Z", '
+        b'"period": {"start_date": null, "end_date": null}, "scheduled_count": null, '
+        b'"summary": {"views": 123, "watch_time_minutes": 0, "subscribers_net": 0, "engagements": 0, '
+        b'"average_view_percentage": 0}, "videos": [{"video_id": "video-1", "title": "Midnight", '
+        b'"views": 123, "impressions": 0, "ctr_percentage": 0, "likes": 0, "comments": 0, "shares": 0, '
+        b'"subscribers_gained": 0, "average_view_duration_seconds": 0, "engagements": 0}], "error": null, '
+        b'"refresh_error": null, "workflow_timing": {"status": "ready", "collections": '
+        b'[{"collection_id": "active", "stage": "planning", "steps": [{"action": "wf-next", '
+        b'"status": "success", "manual_baseline_seconds": 60.0, "ai_seconds": 10.0, '
+        b'"human_seconds": 5.0, "work_seconds": 15.0, "ai_inclusive_saved_seconds": 45.0, '
+        b'"human_freed_seconds": 55.0}], "totals": {"manual_baseline_seconds": 60.0, "ai_seconds": 10.0, '
+        b'"human_seconds": 5.0, "work_seconds": 15.0, "ai_inclusive_saved_seconds": 45.0, '
+        b'"human_freed_seconds": 55.0}}, {"collection_id": "latest", "stage": "live", "steps": '
+        b'[{"action": "post-publish", "status": "success", "manual_baseline_seconds": 120.0, '
+        b'"ai_seconds": 20.0, "human_seconds": 10.0, "work_seconds": 30.0, '
+        b'"ai_inclusive_saved_seconds": 90.0, "human_freed_seconds": 110.0}], "totals": '
+        b'{"manual_baseline_seconds": 120.0, "ai_seconds": 20.0, "human_seconds": 10.0, '
+        b'"work_seconds": 30.0, "ai_inclusive_saved_seconds": 90.0, "human_freed_seconds": 110.0}}]}}'
+    )
+    assert publications.replace(channel_id_bytes, b"<channel-id>") == (
+        b'{"days": {"2026-07-20": 2}, "channels": [{"id": "<channel-id>", "name": "Night Drive", '
+        b'"status": "refresh_failed", "fetched_at": "2026-07-20T13:00:00+00:00", '
+        b'"timezone": "Asia/Tokyo", "days": {"2026-07-20": 2}, "error": '
+        b'{"code": "publication_refresh_failed", "message": "quota exceeded", '
+        b'"attempted_at": "2026-07-20T14:00:00+00:00"}}]}'
+    )
 
 
 def test_server_exposes_overview_and_channel_detail(dashboard_server: str):

--- a/tests/infrastructure/analytics/test_dashboard_publications.py
+++ b/tests/infrastructure/analytics/test_dashboard_publications.py
@@ -2,11 +2,13 @@ import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import is_typeddict
 
 import pytest
 
 from youtube_automation.infrastructure.analytics import dashboard_publications
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
+    DashboardPublications,
     build_dashboard_publications,
     load_dashboard_publications,
     load_fresh_dashboard_publications,
@@ -22,6 +24,12 @@ def _publication_payload(fetched_at: str) -> dict[str, object]:
         "timezone": "UTC",
         "days": {"2026-08-08": 2},
     }
+
+
+def test_dashboard_publications_response_contract_is_a_typed_dict() -> None:
+    assert is_typeddict(DashboardPublications)
+    assert DashboardPublications.__required_keys__ == frozenset({"schema_version", "fetched_at", "timezone", "days"})
+    assert DashboardPublications.__optional_keys__ == frozenset({"error"})
 
 
 def test_build_dashboard_publications_groups_by_local_calendar_day() -> None:

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -557,3 +557,38 @@ def test_dashboard_api_filters_non_object_channels_and_non_list_videos() -> None
 
     assert api.overview()["channels"] == [{"id": "valid", "name": "Valid", "video_count": 0}]
     assert api.channel("valid")["videos"] == []
+
+
+def test_dashboard_api_preserves_channel_without_refresh_error() -> None:
+    channel = {
+        "id": "legacy",
+        "name": "Legacy",
+        "status": "ready",
+        "snapshot": None,
+        "collected_at": None,
+        "period": {"start_date": None, "end_date": None},
+        "scheduled_count": None,
+        "summary": None,
+        "videos": [],
+        "error": None,
+    }
+    api = DashboardAPI({"schema_version": 1, "channels": [channel]})
+
+    assert api.overview() == {
+        "schema_version": 1,
+        "channels": [
+            {
+                "id": "legacy",
+                "name": "Legacy",
+                "status": "ready",
+                "snapshot": None,
+                "collected_at": None,
+                "period": {"start_date": None, "end_date": None},
+                "scheduled_count": None,
+                "summary": None,
+                "error": None,
+                "video_count": 0,
+            }
+        ],
+    }
+    assert api.channel("legacy") == channel

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -11,9 +11,11 @@ import pytest
 from youtube_automation.core.errors import DashboardChannelNotFoundError
 from youtube_automation.infrastructure.analytics.dashboard_read_model import (
     ChannelDetailResponse,
+    ChannelOverviewResponse,
     DashboardAPI,
     DashboardReadModel,
     OverviewResponse,
+    PublicationChannelResponse,
     PublicationsResponse,
     build_dashboard_read_model,
 )
@@ -83,80 +85,30 @@ def _write_publications(
     (channel / "data" / "dashboard_publications.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_dashboard_api_json_bytes_remain_stable() -> None:
-    channel = {
-        "id": "channel-1",
-        "name": "Night Drive",
-        "status": "ready",
-        "snapshot": "analytics_data_20260720.json",
-        "collected_at": "2026-07-20T12:00:00Z",
-        "period": {"start_date": "2026-07-01", "end_date": "2026-07-20"},
-        "scheduled_count": 2,
-        "summary": {
-            "views": 900,
-            "watch_time_minutes": 420,
-            "subscribers_net": 8,
-            "engagements": 31,
-            "average_view_percentage": 62.5,
-        },
-        "videos": [
-            {
-                "video_id": "video-b",
-                "title": "Later video",
-                "views": 700,
-                "impressions": 1000,
-                "ctr_percentage": 4.5,
-                "likes": 20,
-                "comments": 4,
-                "shares": 3,
-                "subscribers_gained": 2,
-                "average_view_duration_seconds": 180,
-                "engagements": 27,
-            }
-        ],
-        "error": None,
-        "refresh_error": None,
-        "workflow_timing": {"status": "ready", "collections": []},
-    }
-    api = DashboardAPI(
-        {
-            "schema_version": 2,
-            "channels": [channel],
-            "publications": {"days": {}, "channels": []},
-        }
-    )
-
-    overview_bytes = json.dumps(api.overview(), ensure_ascii=False).encode("utf-8")
-    detail_bytes = json.dumps(api.channel("channel-1"), ensure_ascii=False).encode("utf-8")
-
-    assert overview_bytes == (
-        b'{"schema_version": 2, "channels": [{"id": "channel-1", "name": "Night Drive", '
-        b'"status": "ready", "snapshot": "analytics_data_20260720.json", '
-        b'"collected_at": "2026-07-20T12:00:00Z", "period": {"start_date": "2026-07-01", '
-        b'"end_date": "2026-07-20"}, "scheduled_count": 2, "summary": {"views": 900, '
-        b'"watch_time_minutes": 420, "subscribers_net": 8, "engagements": 31, '
-        b'"average_view_percentage": 62.5}, "error": null, "refresh_error": null, "video_count": 1}]}'
-    )
-    assert detail_bytes == (
-        b'{"id": "channel-1", "name": "Night Drive", "status": "ready", '
-        b'"snapshot": "analytics_data_20260720.json", "collected_at": "2026-07-20T12:00:00Z", '
-        b'"period": {"start_date": "2026-07-01", "end_date": "2026-07-20"}, '
-        b'"scheduled_count": 2, "summary": {"views": 900, "watch_time_minutes": 420, '
-        b'"subscribers_net": 8, "engagements": 31, "average_view_percentage": 62.5}, '
-        b'"videos": [{"video_id": "video-b", "title": "Later video", "views": 700, '
-        b'"impressions": 1000, "ctr_percentage": 4.5, "likes": 20, "comments": 4, "shares": 3, '
-        b'"subscribers_gained": 2, "average_view_duration_seconds": 180, "engagements": 27}], '
-        b'"error": null, "refresh_error": null, "workflow_timing": {"status": "ready", "collections": []}}'
-    )
-
-
 def test_dashboard_api_response_contracts_are_typed_dicts() -> None:
     assert is_typeddict(DashboardReadModel)
     assert is_typeddict(OverviewResponse)
+    assert is_typeddict(ChannelOverviewResponse)
     assert is_typeddict(ChannelDetailResponse)
     assert is_typeddict(PublicationsResponse)
+    assert is_typeddict(PublicationChannelResponse)
     assert DashboardReadModel.__required_keys__ == frozenset({"schema_version", "channels", "publications"})
     assert OverviewResponse.__required_keys__ == frozenset({"schema_version", "channels"})
+    assert ChannelOverviewResponse.__required_keys__ == frozenset(
+        {
+            "id",
+            "name",
+            "status",
+            "snapshot",
+            "collected_at",
+            "period",
+            "scheduled_count",
+            "summary",
+            "error",
+            "refresh_error",
+            "video_count",
+        }
+    )
     assert ChannelDetailResponse.__required_keys__ == frozenset(
         {
             "id",
@@ -174,6 +126,9 @@ def test_dashboard_api_response_contracts_are_typed_dicts() -> None:
     )
     assert ChannelDetailResponse.__optional_keys__ == frozenset({"workflow_timing"})
     assert PublicationsResponse.__required_keys__ == frozenset({"days", "channels"})
+    assert PublicationChannelResponse.__required_keys__ == frozenset(
+        {"id", "name", "status", "fetched_at", "timezone", "days", "error"}
+    )
 
 
 def test_read_model_aggregates_publication_days_and_channel_cache_state(tmp_path: Path) -> None:

--- a/tests/infrastructure/analytics/test_dashboard_read_model.py
+++ b/tests/infrastructure/analytics/test_dashboard_read_model.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import is_typeddict
 
 import pytest
 
 from youtube_automation.core.errors import DashboardChannelNotFoundError
-from youtube_automation.infrastructure.analytics.dashboard_read_model import DashboardAPI, build_dashboard_read_model
+from youtube_automation.infrastructure.analytics.dashboard_read_model import (
+    ChannelDetailResponse,
+    DashboardAPI,
+    DashboardReadModel,
+    OverviewResponse,
+    PublicationsResponse,
+    build_dashboard_read_model,
+)
 
 
 def _write_channel(channel: Path, *, name: str, snapshots: dict[str, dict]) -> None:
@@ -73,6 +81,99 @@ def _write_publications(
     if error is not None:
         payload["error"] = error
     (channel / "data" / "dashboard_publications.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_dashboard_api_json_bytes_remain_stable() -> None:
+    channel = {
+        "id": "channel-1",
+        "name": "Night Drive",
+        "status": "ready",
+        "snapshot": "analytics_data_20260720.json",
+        "collected_at": "2026-07-20T12:00:00Z",
+        "period": {"start_date": "2026-07-01", "end_date": "2026-07-20"},
+        "scheduled_count": 2,
+        "summary": {
+            "views": 900,
+            "watch_time_minutes": 420,
+            "subscribers_net": 8,
+            "engagements": 31,
+            "average_view_percentage": 62.5,
+        },
+        "videos": [
+            {
+                "video_id": "video-b",
+                "title": "Later video",
+                "views": 700,
+                "impressions": 1000,
+                "ctr_percentage": 4.5,
+                "likes": 20,
+                "comments": 4,
+                "shares": 3,
+                "subscribers_gained": 2,
+                "average_view_duration_seconds": 180,
+                "engagements": 27,
+            }
+        ],
+        "error": None,
+        "refresh_error": None,
+        "workflow_timing": {"status": "ready", "collections": []},
+    }
+    api = DashboardAPI(
+        {
+            "schema_version": 2,
+            "channels": [channel],
+            "publications": {"days": {}, "channels": []},
+        }
+    )
+
+    overview_bytes = json.dumps(api.overview(), ensure_ascii=False).encode("utf-8")
+    detail_bytes = json.dumps(api.channel("channel-1"), ensure_ascii=False).encode("utf-8")
+
+    assert overview_bytes == (
+        b'{"schema_version": 2, "channels": [{"id": "channel-1", "name": "Night Drive", '
+        b'"status": "ready", "snapshot": "analytics_data_20260720.json", '
+        b'"collected_at": "2026-07-20T12:00:00Z", "period": {"start_date": "2026-07-01", '
+        b'"end_date": "2026-07-20"}, "scheduled_count": 2, "summary": {"views": 900, '
+        b'"watch_time_minutes": 420, "subscribers_net": 8, "engagements": 31, '
+        b'"average_view_percentage": 62.5}, "error": null, "refresh_error": null, "video_count": 1}]}'
+    )
+    assert detail_bytes == (
+        b'{"id": "channel-1", "name": "Night Drive", "status": "ready", '
+        b'"snapshot": "analytics_data_20260720.json", "collected_at": "2026-07-20T12:00:00Z", '
+        b'"period": {"start_date": "2026-07-01", "end_date": "2026-07-20"}, '
+        b'"scheduled_count": 2, "summary": {"views": 900, "watch_time_minutes": 420, '
+        b'"subscribers_net": 8, "engagements": 31, "average_view_percentage": 62.5}, '
+        b'"videos": [{"video_id": "video-b", "title": "Later video", "views": 700, '
+        b'"impressions": 1000, "ctr_percentage": 4.5, "likes": 20, "comments": 4, "shares": 3, '
+        b'"subscribers_gained": 2, "average_view_duration_seconds": 180, "engagements": 27}], '
+        b'"error": null, "refresh_error": null, "workflow_timing": {"status": "ready", "collections": []}}'
+    )
+
+
+def test_dashboard_api_response_contracts_are_typed_dicts() -> None:
+    assert is_typeddict(DashboardReadModel)
+    assert is_typeddict(OverviewResponse)
+    assert is_typeddict(ChannelDetailResponse)
+    assert is_typeddict(PublicationsResponse)
+    assert DashboardReadModel.__required_keys__ == frozenset({"schema_version", "channels", "publications"})
+    assert OverviewResponse.__required_keys__ == frozenset({"schema_version", "channels"})
+    assert ChannelDetailResponse.__required_keys__ == frozenset(
+        {
+            "id",
+            "name",
+            "status",
+            "snapshot",
+            "collected_at",
+            "period",
+            "scheduled_count",
+            "summary",
+            "videos",
+            "error",
+            "refresh_error",
+        }
+    )
+    assert ChannelDetailResponse.__optional_keys__ == frozenset({"workflow_timing"})
+    assert PublicationsResponse.__required_keys__ == frozenset({"days", "channels"})
 
 
 def test_read_model_aggregates_publication_days_and_channel_cache_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- dashboard read model、overview/channel API、publications cache 応答を nested TypedDict と contextual constructor で固定
- production builder から HTTP consumer まで TypedDict を接続し、required key の追加・削除を Pyright で検出可能にした
- runtime validation・TypeScript 型・後続 #3898/#3899 は変更せず、既存の正規化・fallback・JSON 順序を維持

## Acceptance evidence
- 型契約: `DashboardAPI.model` は `DashboardReadModel`。完全なproduction modelでは `OverviewResponse` / `ChannelDetailResponse`、実行時互換の不完全modelでは `IncompleteOverviewResponse` / `IncompleteChannelResponse` を明示unionで返す
- required/optional key: `ChannelOverviewResponse`、`ChannelDetailResponse`、`PublicationChannelResponse` を含む契約テストを追加。constructorからrequired keyを追加・削除するとPyrightが検出する
- Pyright baseline差分: base `4eb5e9c` は3 errors（既存 `dashboard.py:67,200` と `dashboard_publications.py:51`）。現在は既存 `dashboard.py:67,200` の2 errorsのみで、PR由来0。publication refresh consumerを含めて確認
- API JSON byte equivalence: production builders → publication error付与 → save/load → read model → server endpointを通るgoldenでoverview/channel/publicationsの生JSON bytesを固定。workflow timing optional fieldとpublication error pathも含む
- runtime behavior: invalid/incomplete model互換を維持し、関連テスト67 passed

## Fix round 1
- `DashboardAPI.model` とoverview/channelのfinal cast・任意dict経路を除去し、HTTP/publication refresh consumerまで型経路を接続
- 手組みdictだけのbyteテストをproduction builder・cache read model・実endpointを通るbyte-exact goldenへ置換

## Fix round 2
- exact regressionとして、`ChannelSourceResponse`の全required keyを持つが`refresh_error`だけ欠けるchannelを追加。修正前は`KeyError: refresh_error`、修正後はoverview/channelともbase互換の応答でpass
- complete判定を`ChannelDetailResponse.__required_keys__`へ変更し、`refresh_error`を含む全required keyを確認
- incomplete応答を明示unionで表現。total TypedDictからrequired keyをdynamic popする処理を削除し、cast/Any/ignore/popによる回避なし
- fix round 1のproduction byte goldenを維持

## Verification
- `nix shell nixpkgs#pyright -c pyright src/youtube_automation/infrastructure/analytics/dashboard_read_model.py src/youtube_automation/infrastructure/analytics/dashboard_publications.py src/youtube_automation/infrastructure/analytics/dashboard_refresh.py src/youtube_automation/commands/analytics/dashboard.py`（base 3 → current 2、PR由来0）
- exact regression: `test_dashboard_api_preserves_channel_without_refresh_error`（修正前KeyError → 修正後pass）
- related tests: `67 passed`
- `nix develop .#extensions --command pnpm -C dashboard typecheck`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `bash .github/scripts/any-usage-gate.sh`
- `git diff --check`
- `nix develop --command uv run pytest -n auto`（`/tmp/youtube-automation-goal-full-ci.lock.d`をmkdirで排他取得しtrap解放、8266 passed, 1 skipped）

## CHANGELOG
Python runtime sourceを変更するため`[Unreleased]`に#3897のentryを追加済み（skip-changelog不使用）。fix round 1/2は同一挙動の型契約・回帰証拠強化なので追加entryなし。

Closes #3897