### PR TITLE
fix(skill-feedback): 不正行を隔離して還流を継続する (#3939)

### DIFF
--- a/.claude/skills/skill-feedback/SKILL.md
+++ b/.claude/skills/skill-feedback/SKILL.md
@@ -95,8 +95,10 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 | valid terminal | no | no | leave unchanged |
 
 schema-invalid には JSON として parse できない行と、parse できても entry schema に準拠しない行を
-含む。invalid 行と terminal entry は変更しない。invalid 行の内容は警告へ転記せず、1 始まりの
-行番号と JSON parse または schema 検証の簡潔な理由だけを表示する。
+含む。invalid 行と terminal entry は変更しない。警告理由は error class、schema keyword、JSON pointer、line、column
+のうち該当する safe metadata だけから組み立てる。invalid raw bytes、instance value、validator の raw message
+は、未マスクの secret-like value や object 全体を含み得るため表示しない。たとえば `summary` が空の
+7 行目は `line 7: schema keyword=minLength pointer=/summary` と表示し、実際の値は付けない。
 
 ## 共通: 機密情報のマスク
 
@@ -166,6 +168,16 @@ terminator を保持できない、または atomic rewrite の事前検証を�
 issue 起票や disposition 更新を開始せず fail-closed に停止する。事前確認用の一時ファイルで元ログを置換せず、
 確認後に削除する。
 
+保持状態は、最新 snapshot、全行の bytes、各 line terminator、valid entry の行番号と JSON object で
+構成する。atomic rewrite が成功するたびに更新するため、置換後のファイルを読み直して全行を再分類し、
+期待した対象行だけが変わり、それ以外の bytes が保存されたことを検証してから、保持状態全体を新しい
+内容へ置き換える。検証または保持状態の更新に失敗した場合は、次の disposition 更新や issue 起票へ
+進まず停止する。
+
+この progression は処理種別をまたいで適用する。disposition rewrite の成功後も filing flow の前に最新状態へ進める。
+その際に最新 snapshot、全行の bytes、未処理 entry の保持値を置換後の内容から再構築し、処理済み entry は
+候補から除く。各 filing candidate の atomic rewrite 成功後にも同じ更新を行い、次の candidate は更新済みの最新 snapshot を基準に処理する。
+
 `status` が `"recorded"` の行だけを、元の行番号、`date`、`skill`、`category`、
 `summary` とともに一覧表示する。`context` は一覧に表示しない。候補が 0 件なら
 「未還流 feedback は 0 件」と報告して終了する。
@@ -234,6 +246,11 @@ gh api --paginate --method GET \
 この entry をスキップ」の明示 2 択を提示する。ユーザーが選ぶまでその entry を起票しない。
 スキップした entry はログも変更しない。
 
+同じ entry の前回処理で issue 作成だけが成功した可能性があり、open issue のタイトルとマスク済み本文が
+今回の生成物に完全一致する場合は `created-unrecorded` の recovery 候補として扱う。この場合は
+「それでも新規起票する」を提示せず、既存 issue URL を使う recovery rewrite を Step 5 の更新契約で
+行うか、中止するかを確認する。完全一致を証明できなければ新規起票せず fail-closed に停止する。
+
 ### Step 4: 最終承認ゲート
 
 スキップを除いた起票対象について、件数、各タイトル、発生チャンネル欄の内容を表示する。
@@ -248,7 +265,9 @@ gh api --paginate --method GET \
 
 ### Step 5: issue 起票と直後のログ更新
 
-承認済み entry を 1 件ずつ処理する。マスク済み本文を一時ファイルへ保存し、次を実行する。
+承認済み entry を 1 件ずつ処理する。各 `gh issue create` の直前にファイル全体を再読し、current bytes が最新 snapshot と完全一致
+することを検証する。不一致ならコマンドを実行せず fail-closed に停止する。一致した場合だけ、マスク済み本文を
+一時ファイルへ保存し、次を実行する。
 
 ```bash
 gh issue create \
@@ -276,8 +295,15 @@ exit code が 0 で、標準出力から当該 issue URL を取得できた場�
 terminator を連結して構成する。置換直前に現在のファイル全体が保持した snapshot と同一であることを
 再確認し、不一致なら置換せず停止する。
 
-1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する。失敗した entry は
-`recorded` のままにし、成功済み issue の URL、未処理 entry、失敗箇所を報告する。
+1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する。`gh issue create` が成功した後に
+ログ更新だけが失敗した場合は、その entry を `created-unrecorded` として行番号、作成済み issue URL、
+失敗箇所とともに報告する。同じ entry で `gh issue create` を再実行してはならない。再開時は Step 3 で
+作成済み issue のタイトルとマスク済み本文の完全一致を確認し、既存 issue URL を使う recovery rewrite
+だけを行う。recovery rewrite も current bytes と新しく取得した snapshot の一致、対象 entry の元 JSON
+object 一致、schema、行数、行順、対象外 bytes を通常更新と同じ条件で検証し、成功後は保持状態を進める。
+対応する issue を一意に証明できなければ新規起票もログ更新も行わず停止する。
+
+issue が作成されていない失敗では entry は `recorded` のままとし、未処理 entry と失敗箇所を報告する。
 
 ### Step 6: 完了報告
 

--- a/.claude/skills/skill-feedback/SKILL.md
+++ b/.claude/skills/skill-feedback/SKILL.md
@@ -18,6 +18,7 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 
 - 記録モードでは既存行を変更せず、schema 準拠の JSON object を末尾に 1 行だけ追加する
 - 還流モードでは `status="recorded"` の行だけを候補にする。`filed` / `resolved` / `wontfix` は終端状態として表示・選択・起票・変更の対象にしない
+- schema-invalid 行は行番号と schema または JSON parse の失敗理由を警告し、候補から除外する。valid な `recorded` entry の処理は継続する
 - `resolved` / `wontfix` への更新は、ユーザーが対象行と disposition を明示的に確認した場合だけ行う。空でない簡潔な `disposition_reason` と更新時刻 `disposition_at` を必須とする
 - issue 起票前に open issue のタイトルを照合し、類似候補ごとに新規起票かスキップかをユーザーに確認する
 - 起票対象、件数、タイトル、チャンネル名の掲載有無を表示し、`AskUserQuestion` で「起票する / 中止」の明示 2 択を提示する。承認されるまで `gh issue create` を絶対に実行しない
@@ -39,7 +40,8 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 - 起票に成功した行だけが `status="filed"` と `issue_url` を持つ
 - ユーザーが確認した解決済みの行だけが `status="resolved"`、意図的に起票しないと確認した行だけが `status="wontfix"` となり、`disposition_reason` と `disposition_at` を持つ
 - 未選択、スキップ、起票失敗の行は変更されていない
-- 更新後の全行が entry schema に準拠し、JSONL の行数と順序が更新前と同じである
+- 更新した行が entry schema に準拠し、JSONL の行数と順序が更新前と同じである
+- invalid 行、terminal entry、未選択、スキップ、起票失敗の行は byte-for-byte で変更されていない
 
 ## References
 
@@ -83,6 +85,18 @@ description: "Use when 下流チャンネルリポジトリでスキル実行中
 
 `recorded` だけが還流候補である。`filed` / `resolved` / `wontfix` は終端状態であり、
 次回以降の還流モードで一覧表示、選択、起票、変更を行わない。
+
+## Schema-invalid line contract
+
+| line classification | filing candidate | mutable | required action |
+|---|---|---|---|
+| schema-invalid | no | no | warn with line number and reason; continue |
+| valid recorded | yes | after approval only | continue filing flow |
+| valid terminal | no | no | leave unchanged |
+
+schema-invalid には JSON として parse できない行と、parse できても entry schema に準拠しない行を
+含む。invalid 行と terminal entry は変更しない。invalid 行の内容は警告へ転記せず、1 始まりの
+行番号と JSON parse または schema 検証の簡潔な理由だけを表示する。
 
 ## 共通: 機密情報のマスク
 
@@ -140,8 +154,17 @@ pretty print した複数行 JSON は使わない。
 ### Step 1: 前提確認と未還流 entry の一覧提示
 
 `data/feedback/feedback-log.jsonl` の存在を確認する。存在しない場合は、先に記録モードで
-feedback を記録するよう案内して停止する。各行を JSON として読み、schema に準拠しない
-行が 1 行でもあれば、行番号だけを示して停止する。壊れた行を飛ばして続行しない。
+feedback を記録するよう案内して停止する。ファイル全体を bytes の snapshot として読み、
+各 physical line の元の bytes と line terminator を行番号に対応づけて保持する。全行を先に走査し、
+JSON parse と `references/feedback-entry.schema.json` の検証結果から各行を上の contract に分類する。
+schema-invalid 行ごとに `line <行番号>: <簡潔な理由>` を警告し、候補から除外して処理を続ける。
+
+走査後、元 snapshot と同一内容を一時ファイルへ書き、同じディレクトリで atomic replace できる
+ことと、置換後に行数、行順、対象外行の byte-for-byte 同一性を検証できることを、外部副作用を
+始める前に事前確認する。読取エラーなどで全 physical line を分類できない、元 bytes と line
+terminator を保持できない、または atomic rewrite の事前検証を完了できない場合は、
+issue 起票や disposition 更新を開始せず fail-closed に停止する。事前確認用の一時ファイルで元ログを置換せず、
+確認後に削除する。
 
 `status` が `"recorded"` の行だけを、元の行番号、`date`、`skill`、`category`、
 `summary` とともに一覧表示する。`context` は一覧に表示しない。候補が 0 件なら
@@ -168,9 +191,12 @@ feedback を記録するよう案内して停止する。各行を JSON とし�
 - `disposition_reason`: ユーザーが確認した簡潔な理由
 - `disposition_at`: 更新時点の UTC を ISO 8601 date-time で記録した値
 
-terminal entry に `issue_url` を追加しない。更新後の全行が schema に準拠し、行数と行順が同じで、
-対象外の行が byte-for-byte で同一であることを確認してから元ファイルを置換する。確認失敗、
-元行の不一致、schema 検証失敗ではログを変更せず停止する。更新済みの terminal entry は Step 2
+terminal entry に `issue_url` を追加しない。更新対象行が schema に準拠し、行数と行順が同じで、
+対象外の行が byte-for-byte で同一であることを確認してから元ファイルを置換する。具体的には、
+更新対象だけを schema-valid な JSON 1 行へ serialize し、invalid 行、terminal entry、未選択行を元の bytes のまま複写する。
+更新直前にファイル全体が保持した bytes snapshot と同一であることも確認する。確認失敗、元 snapshot
+の不一致、更新対象の schema 検証失敗ではログを変更せず停止する。既存の schema-invalid 行は
+検証対象から除外して元 bytes のまま保持する。更新済みの terminal entry は Step 2
 以降へ渡さず、起票も行わない。「今回は保留」の entry は `recorded` のまま変更しない。
 
 ### Step 2: 本文案とチャンネル名の掲載可否を確認
@@ -242,9 +268,13 @@ exit code が 0 で、標準出力から当該 issue URL を取得できた場�
 
 - 更新対象は保持した行番号の 1 行だけである
 - 更新後の対象行は `status="filed"` と取得した `issue_url` を持つ
-- 全行が `references/feedback-entry.schema.json` に準拠する
+- 更新対象行が `references/feedback-entry.schema.json` に準拠する
 - 行数と行順は更新前と同じである
-- 対象以外の行は byte-for-byte で同じである
+- invalid 行、terminal entry、未選択行を含む対象以外の行は byte-for-byte で同じである
+
+一時ファイルは、更新対象行だけを JSON 1 行へ serialize し、ほかの行は保持した元 bytes と line
+terminator を連結して構成する。置換直前に現在のファイル全体が保持した snapshot と同一であることを
+再確認し、不一致なら置換せず停止する。
 
 1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する。失敗した entry は
 `recorded` のままにし、成功済み issue の URL、未処理 entry、失敗箇所を報告する。
@@ -259,4 +289,5 @@ exit code が 0 で、標準出力から当該 issue URL を取得できた場�
 
 - 起票された上流 issue のトリアージ・優先度付け
 - Analytics / flop-analysis 由来の運営知見の記録
-- schema 非準拠行を飛ばして valid entry の還流を続けること（#3939）
+- status enum と disposition metadata の追加・変更
+- feedback JSONL を処理する runtime Python 実装の追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(skill-feedback)`: schema-invalid JSONL 行を行番号と理由付きで警告して変更対象から隔離し、valid な `recorded` entry の還流を継続する。更新時は invalid・terminal・未選択行の bytes を保持し、安全な全件走査や atomic rewrite を証明できない場合は外部副作用前に停止する（#3939）。
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
 - `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。
 - `fix(cli)`: `yt-benchmark-comments` と `yt-thumbnail-compare` の旧 `--channel` を共通 entrypoint が先に消費せず、`--competitor` への移行案内で誤チャンネル選択前に停止するよう修正した（#3923）。

--- a/tests/repo/test_skill_feedback_contract.py
+++ b/tests/repo/test_skill_feedback_contract.py
@@ -161,3 +161,57 @@ def test_skill_stops_following_entries_after_filing_or_rewrite_failure() -> None
 
     assert "1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する" in skill
     assert "invalid 行と terminal entry は変更しない" in skill
+
+
+def test_skill_advances_snapshot_after_disposition_then_filing_rewrite() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "disposition rewrite の成功後も filing flow の前に最新状態へ進める" in skill
+    assert "最新 snapshot、全行の bytes、未処理 entry の保持値" in skill
+    assert "atomic rewrite が成功するたびに更新する" in skill
+
+
+def test_skill_advances_snapshot_between_multiple_filing_candidates() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "各 filing candidate の atomic rewrite 成功後" in skill
+    assert "次の candidate は更新済みの最新 snapshot を基準に処理する" in skill
+
+
+def test_skill_checks_latest_snapshot_immediately_before_each_issue_creation() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "各 `gh issue create` の直前" in skill
+    assert "current bytes が最新 snapshot と完全一致" in skill
+    assert "コマンドを実行せず fail-closed" in skill
+
+
+def test_skill_blocks_automatic_retry_after_created_issue_rewrite_failure() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "created-unrecorded" in skill
+    assert "同じ entry で `gh issue create` を再実行してはならない" in skill
+    assert "既存 issue URL を使う recovery rewrite" in skill
+
+
+def test_schema_invalid_warning_excludes_secret_like_instance_data() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+    secret_like_invalid_value = "sk-live-contract-secret-value"
+    invalid_entry_fixture = json.dumps(
+        {
+            "date": "2026-08-12T00:00:00Z",
+            "skill": "thumbnail",
+            "category": "bug",
+            "summary": "",
+            "context": secret_like_invalid_value,
+            "status": "recorded",
+        }
+    )
+    expected_warning = "line 7: schema keyword=minLength pointer=/summary"
+
+    assert secret_like_invalid_value in invalid_entry_fixture
+    assert json.loads(invalid_entry_fixture)["summary"] == ""
+    assert secret_like_invalid_value not in expected_warning
+    assert expected_warning in skill
+    assert "error class、schema keyword、JSON pointer、line、column" in skill
+    assert "invalid raw bytes、instance value、validator の raw message" in skill

--- a/tests/repo/test_skill_feedback_contract.py
+++ b/tests/repo/test_skill_feedback_contract.py
@@ -69,6 +69,24 @@ def _lifecycle_rows() -> dict[str, tuple[str, str, str]]:
     return rows
 
 
+def _invalid_line_rows() -> dict[str, tuple[str, str, str]]:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## Schema-invalid line contract\n\n"
+        r"\| line classification \| filing candidate \| mutable \| required action \|\n"
+        r"\|[-| ]+\|\n"
+        r"(?P<rows>(?:\|[^\n]+\|\n)+)",
+        skill,
+        flags=re.MULTILINE,
+    )
+    assert match is not None
+    rows: dict[str, tuple[str, str, str]] = {}
+    for row in match.group("rows").splitlines():
+        classification, candidate, mutable, action = [cell.strip() for cell in row.strip("|").split("|")]
+        rows[classification] = (candidate, mutable, action)
+    return rows
+
+
 def test_feedback_schema_declares_all_lifecycle_statuses() -> None:
     properties = _schema()["properties"]
     assert isinstance(properties, dict)
@@ -114,10 +132,32 @@ def test_skill_lifecycle_only_exposes_recorded_entries_as_filing_candidates() ->
     }
 
 
-def test_skill_keeps_schema_invalid_jsonl_fail_closed() -> None:
-    skill = _SKILL_PATH.read_text(encoding="utf-8")
-    fail_closed_contract = (
-        "schema に準拠しない\n行が 1 行でもあれば、行番号だけを示して停止する。壊れた行を飛ばして続行しない。"
-    )
+def test_skill_continues_with_valid_recorded_entries_after_invalid_line_warning() -> None:
+    assert _invalid_line_rows() == {
+        "schema-invalid": ("no", "no", "warn with line number and reason; continue"),
+        "valid recorded": ("yes", "after approval only", "continue filing flow"),
+        "valid terminal": ("no", "no", "leave unchanged"),
+    }
 
-    assert fail_closed_contract in skill
+
+def test_skill_preserves_non_target_lines_as_original_bytes() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "各 physical line の元の bytes と line terminator" in skill
+    assert "invalid 行、terminal entry、未選択行を元の bytes のまま複写" in skill
+    assert "行数、行順、対象外行の byte-for-byte 同一性" in skill
+
+
+def test_skill_fails_closed_before_side_effects_when_partial_processing_is_unsafe() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "全 physical line を分類できない" in skill
+    assert "atomic rewrite の事前検証を完了できない" in skill
+    assert "issue 起票や disposition 更新を開始せず fail-closed" in skill
+
+
+def test_skill_stops_following_entries_after_filing_or_rewrite_failure() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "1 件の起票またはログ更新が失敗したら後続 entry を起票せず停止する" in skill
+    assert "invalid 行と terminal entry は変更しない" in skill


### PR DESCRIPTION
## Summary

- schema-invalid JSONL 行を、1始まりの行番号と safe metadata だけからなる理由で警告・隔離し、valid な `recorded` entry の還流候補抽出を継続する
- 更新対象だけを再 serialize し、invalid・terminal・未選択行は元 bytes と line terminator のまま複写する
- 全件分類・元 bytes 保持・atomic rewrite 事前検証を証明できない場合は、issue 起票や disposition 更新より前に fail-closed で停止する
- #3942 の `recorded` / terminal disposition schema 契約を維持し、runtime Python と status enum は変更しない

## Acceptance evidence

- 警告: schema-invalid 行ごとに行番号を出し、理由は error class / schema keyword / JSON pointer / line / column の safe metadata だけで構成する
- 機密保護: invalid raw bytes、instance value、validator raw message を表示せず、secret-like invalid fixture が警告文へ現れない contract test を追加
- 継続: schema-invalid は候補外、valid recorded は候補、valid terminal は対象外とする機械可読 contract table を追加
- 不変性: invalid・terminal・未選択行は元 bytes と line terminator を複写し、行数・順序・対象外行の byte-for-byte 同一性を置換前に検証
- fail-closed: 全 physical line の分類、snapshot、atomic rewrite 事前検証のいずれかが成立しない場合は外部副作用前に停止
- 失敗経路: 起票/更新失敗後は後続 entry を処理せず、created-unrecorded は同じ entry の issue 再作成を禁止して既存 URL の recovery rewrite に限定

## Fix round 1 — adversarial review

- P1 snapshot progression: disposition rewrite と各 filing rewrite の成功後に、最新 snapshot・全行 bytes/terminator・未処理 entry 保持値を再構築する。各 `gh issue create` 直前にも current bytes と最新 snapshot の一致を確認し、競合時はコマンド前に停止する
- P1 recovery: issue 作成後のログ更新失敗を `created-unrecorded` として URL 付きで停止報告し、同じ entry の自動再起票を禁止。タイトルとマスク済み本文が完全一致する既存 issue URL の recovery rewrite だけを許可する
- P1 tests: disposition→filing、複数 filing candidate の sequential success、issue 作成直前の競合、created-unrecorded recovery を個別 contract test で固定
- P2 warning safety: validator の raw message / instance / invalid bytes を禁止し、safe metadata allowlist と secret-like invalid fixture を contract test で固定

## Validation

- `nix develop --command uv run pytest -q tests/repo/test_skill_feedback_contract.py` — 16 passed
- `nix develop --command uv run yt-skills lint` — 55 skills passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 790 files formatted
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh` — passed
- `git diff --check` — passed
- serialized `nix develop --command uv run pytest -n auto` with `/tmp/youtube-automation-goal-full-ci.lock.d` — 8270 passed, 1 skipped

## CHANGELOG decision

下流へ配布される `/skill-feedback` の公開還流契約が変わるため、`CHANGELOG.md` の `[Unreleased]` を更新した。entry schema の status enum / disposition metadata と runtime Python は変更していない。

Closes #3939
