### PR TITLE
refactor(dashboard): API応答型を一元化する (#3898)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -60,7 +60,10 @@ import {
   WorkflowStepTable,
 } from "@/features/workflow-timing/workflow-step-table"
 import type {
+  ChannelDetail,
   ChannelOverview,
+  OverviewResponse,
+  PublicationActivityState,
   Summary,
   WorkflowTiming,
   WorkflowTimingCollection,
@@ -84,31 +87,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-
-type Video = {
-  video_id: string
-  title: string
-  views: number
-  impressions: number
-  ctr_percentage: number
-  likes: number
-  comments: number
-  shares: number
-  subscribers_gained: number
-  average_view_duration_seconds: number
-  engagements: number
-}
-
-type ChannelDetail = Omit<ChannelOverview, "video_count"> & {
-  videos: Video[]
-  workflow_timing: WorkflowTiming
-}
-type OverviewResponse = { schema_version: number; channels: ChannelOverview[] }
-type PublicationActivityState =
-  | { status: "loading" }
-  | { status: "ready"; data: PublicationActivityResponse }
-  | { status: "empty" }
-  | { status: "error"; message: string }
 
 const chartConfig = {
   views: { label: "再生数", color: "var(--chart-3)" },

--- a/dashboard/src/lib/dashboard-types.contract.test.ts
+++ b/dashboard/src/lib/dashboard-types.contract.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+import ts from "typescript"
+
+const apiResponseTypeNames = [
+  "Video",
+  "ChannelDetail",
+  "OverviewResponse",
+  "PublicationActivityState",
+] as const
+const appResponseTypeNames = [
+  "ChannelDetail",
+  "OverviewResponse",
+  "PublicationActivityState",
+] as const
+const sources = import.meta.glob<string>("/src/**/*.{ts,tsx}", {
+  eager: true,
+  import: "default",
+  query: "?raw",
+})
+const dashboardTypesPath = "/src/lib/dashboard-types.ts"
+const appPath = "/src/App.tsx"
+
+function sourceAt(path: string): string {
+  const source = sources[path]
+  if (source === undefined) {
+    throw new Error(`Dashboard source not found: ${path}`)
+  }
+  return source
+}
+
+function parseSource(path: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  )
+}
+
+describe("dashboard API response type ownership", () => {
+  it("exports each response type exactly once from dashboard-types.ts", () => {
+    const declarations = Object.entries(sources).flatMap(([path, source]) =>
+      parseSource(path, source).statements.flatMap((statement) => {
+        if (
+          (!ts.isTypeAliasDeclaration(statement) &&
+            !ts.isInterfaceDeclaration(statement)) ||
+          !apiResponseTypeNames.includes(
+            statement.name.text as (typeof apiResponseTypeNames)[number]
+          )
+        ) {
+          return []
+        }
+        return [{ path, statement }]
+      })
+    )
+
+    for (const name of apiResponseTypeNames) {
+      const matches = declarations.filter(
+        ({ statement }) => statement.name.text === name
+      )
+      expect(matches).toHaveLength(1)
+      expect(matches[0]?.path).toBe(dashboardTypesPath)
+      expect(
+        matches[0]?.statement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+        )
+      ).toBe(true)
+    }
+  })
+
+  it("imports App response types as type-only dependencies", () => {
+    const importedTypeNames = parseSource(
+      appPath,
+      sourceAt(appPath)
+    ).statements.flatMap((statement) => {
+      if (
+        !ts.isImportDeclaration(statement) ||
+        statement.moduleSpecifier.getText() !== '"@/lib/dashboard-types"'
+      ) {
+        return []
+      }
+      const clause = statement.importClause
+      if (!clause?.isTypeOnly || !clause.namedBindings) {
+        return []
+      }
+      return ts.isNamedImports(clause.namedBindings)
+        ? clause.namedBindings.elements.map((element) => element.name.text)
+        : []
+    })
+
+    expect(importedTypeNames).toEqual(
+      expect.arrayContaining([...appResponseTypeNames])
+    )
+  })
+})

--- a/dashboard/src/lib/dashboard-types.ts
+++ b/dashboard/src/lib/dashboard-types.ts
@@ -1,3 +1,5 @@
+import type { PublicationActivityResponse } from "@/features/publication-activity/publication-heatmap"
+
 export type Summary = {
   views: number
   watch_time_minutes: number
@@ -65,3 +67,31 @@ export type WorkflowTiming =
       collections: []
       error: WorkflowTimingError
     }
+
+export type Video = {
+  video_id: string
+  title: string
+  views: number
+  impressions: number
+  ctr_percentage: number
+  likes: number
+  comments: number
+  shares: number
+  subscribers_gained: number
+  average_view_duration_seconds: number
+  engagements: number
+}
+
+export type ChannelDetail = Omit<ChannelOverview, "video_count"> & {
+  videos: Video[]
+  workflow_timing: WorkflowTiming
+}
+export type OverviewResponse = {
+  schema_version: number
+  channels: ChannelOverview[]
+}
+export type PublicationActivityState =
+  | { status: "loading" }
+  | { status: "ready"; data: PublicationActivityResponse }
+  | { status: "empty" }
+  | { status: "error"; message: string }


### PR DESCRIPTION
## Summary
- Video / ChannelDetail / OverviewResponse / PublicationActivityState を App.tsx から dashboard-types.ts へ移し、type-only import で消費する
- TypeScript AST で dashboard/src 全体を走査し、4型の定義が dashboard-types.ts の export 各1件だけであることを固定する契約テストを追加する
- Python 応答、runtime validation、型内容、UI/runtime 挙動は変更しない

## Acceptance evidence
- production source 走査では4型の宣言が dashboard/src/lib/dashboard-types.ts に各1件だけ存在する
- origin/main の App.tsx と移動後定義を TypeScript printer で正規化した SHA-256 は4型すべて一致した
  - Video: 46e5fb14ad2a30c21d127025e1a931e72865bf676d9eef0c4a77016c25c66702
  - ChannelDetail: 9b4e337a885abf44b1b79420878ce88fb4b6c8d7f488c799497ec787c1ebc8d9
  - OverviewResponse: 54968fecc90bab5e022e85c4a860f04a493f26eebd59eeae9cf134db4de0e92d
  - PublicationActivityState: 4e400ea7aed106dbb9cfc8b571b389ae64851e01448ef3242080de94820a93eb
- production build 後の src/youtube_automation/dashboard_dist は無差分で、生成される runtime asset を維持した

## Verification
- nix develop .#extensions --command pnpm -C dashboard lint
- nix develop .#extensions --command pnpm -C dashboard typecheck
- nix develop .#extensions --command pnpm -C dashboard test (10 files / 90 tests)
- nix develop .#extensions --command pnpm -C dashboard build
- nix develop .#extensions --command pnpm -C dashboard test:e2e (12 tests)
- dashboard server/read-model/publications tests (55 tests)
- candidate wheel dashboard package smoke (1 test)
- related repository workflow contract tests (36 tests)
- uv run ruff check . / uv run ruff format --check . / any-usage-gate / git diff --check

## CHANGELOG
dashboard-only の外部挙動を変えない型移動で、CHANGELOG gate の対象 path でもないため追記しない。

Closes #3898
