### PR TITLE
refactor(dashboard): Python↔TS応答契約を機械検証する (#3899)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test"

--- a/dashboard/src/lib/__fixtures__/overview.golden.json
+++ b/dashboard/src/lib/__fixtures__/overview.golden.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 2,
+  "channels": [
+    {
+      "id": "channel-ready",
+      "name": "Contract Ready",
+      "status": "ready",
+      "snapshot": "analytics_data_20260812.json",
+      "collected_at": "2026-08-12T00:00:00+00:00",
+      "period": {
+        "start_date": "2026-08-01",
+        "end_date": "2026-08-12"
+      },
+      "scheduled_count": 2,
+      "summary": {
+        "views": 1200,
+        "watch_time_minutes": 420,
+        "subscribers_net": 8,
+        "engagements": 31,
+        "average_view_percentage": 62.5
+      },
+      "error": null,
+      "refresh_error": {
+        "code": "refresh_failed",
+        "message": "refresh failed"
+      },
+      "video_count": 1
+    },
+    {
+      "id": "channel-invalid",
+      "name": "invalid",
+      "status": "invalid_channel",
+      "snapshot": null,
+      "collected_at": null,
+      "period": {
+        "start_date": null,
+        "end_date": null
+      },
+      "scheduled_count": null,
+      "summary": null,
+      "error": {
+        "code": "meta_invalid",
+        "message": "Expecting value: line 1 column 1 (char 0)"
+      },
+      "refresh_error": null,
+      "video_count": 0
+    }
+  ]
+}

--- a/dashboard/src/lib/dashboard-types.contract.test.ts
+++ b/dashboard/src/lib/dashboard-types.contract.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, it } from "vitest"
 import ts from "typescript"
 
+import overviewGolden from "@/lib/__fixtures__/overview.golden.json"
+import {
+  DASHBOARD_SCHEMA_VERSION,
+  type ChannelOverview,
+  type OverviewResponse,
+  type Summary,
+} from "@/lib/dashboard-types"
+
+type SameKeys<Left, Right> = [
+  Exclude<keyof Left, keyof Right>,
+  Exclude<keyof Right, keyof Left>,
+] extends [never, never]
+  ? true
+  : false
+
+type GoldenChannel = (typeof overviewGolden.channels)[number]
+
+const overviewFixture: OverviewResponse = overviewGolden
+const overviewKeysMatch: SameKeys<typeof overviewGolden, OverviewResponse> =
+  true
+const channelKeysMatch: SameKeys<GoldenChannel, ChannelOverview> = true
+const periodKeysMatch: SameKeys<
+  GoldenChannel["period"],
+  ChannelOverview["period"]
+> = true
+const summaryKeysMatch: SameKeys<
+  NonNullable<GoldenChannel["summary"]>,
+  Summary
+> = true
+const errorKeysMatch: SameKeys<
+  NonNullable<GoldenChannel["error"]>,
+  NonNullable<ChannelOverview["error"]>
+> = true
+const refreshErrorKeysMatch: SameKeys<
+  NonNullable<GoldenChannel["refresh_error"]>,
+  NonNullable<ChannelOverview["refresh_error"]>
+> = true
+
 const apiResponseTypeNames = [
   "Video",
   "ChannelDetail",
@@ -92,5 +130,19 @@ describe("dashboard API response type ownership", () => {
     expect(importedTypeNames).toEqual(
       expect.arrayContaining([...appResponseTypeNames])
     )
+  })
+})
+
+describe("Python dashboard overview schema contract", () => {
+  it("accepts the generated Python response as the exact TypeScript response shape", () => {
+    expect(overviewFixture.schema_version).toBe(DASHBOARD_SCHEMA_VERSION)
+    expect([
+      overviewKeysMatch,
+      channelKeysMatch,
+      periodKeysMatch,
+      summaryKeysMatch,
+      errorKeysMatch,
+      refreshErrorKeysMatch,
+    ]).toEqual([true, true, true, true, true, true])
   })
 })

--- a/dashboard/src/lib/dashboard-types.contract.test.ts
+++ b/dashboard/src/lib/dashboard-types.contract.test.ts
@@ -4,39 +4,38 @@ import ts from "typescript"
 import overviewGolden from "@/lib/__fixtures__/overview.golden.json"
 import {
   DASHBOARD_SCHEMA_VERSION,
-  type ChannelOverview,
   type OverviewResponse,
-  type Summary,
 } from "@/lib/dashboard-types"
 
-type SameKeys<Left, Right> = [
-  Exclude<keyof Left, keyof Right>,
-  Exclude<keyof Right, keyof Left>,
-] extends [never, never]
-  ? true
+type KeysOfUnion<Value> = Value extends Value ? keyof Value : never
+type PresentValue<Value> = Exclude<Value, null | undefined>
+type NullishValue<Value> = Extract<Value, null | undefined>
+type NormalizeObjectUnion<Value> = [PresentValue<Value>] extends [never]
+  ? NullishValue<Value>
+  : [PresentValue<Value>] extends [object]
+    ? MergeObjectUnion<PresentValue<Value>> | NullishValue<Value>
+    : Value
+type FieldOfUnion<Value, Key extends PropertyKey> =
+  Value extends Record<Key, infer Field> ? Field : never
+type MergeObjectUnion<Value> = {
+  [Key in KeysOfUnion<Value>]: NormalizeObjectUnion<FieldOfUnion<Value, Key>>
+}
+type BidirectionallyExact<Left, Right> = [Left] extends [Right]
+  ? [Right] extends [Left]
+    ? true
+    : false
   : false
 
 type GoldenChannel = (typeof overviewGolden.channels)[number]
+type GoldenChannelShape = MergeObjectUnion<GoldenChannel>
+type GoldenOverviewShape = Omit<typeof overviewGolden, "channels"> & {
+  channels: GoldenChannelShape[]
+}
 
 const overviewFixture: OverviewResponse = overviewGolden
-const overviewKeysMatch: SameKeys<typeof overviewGolden, OverviewResponse> =
-  true
-const channelKeysMatch: SameKeys<GoldenChannel, ChannelOverview> = true
-const periodKeysMatch: SameKeys<
-  GoldenChannel["period"],
-  ChannelOverview["period"]
-> = true
-const summaryKeysMatch: SameKeys<
-  NonNullable<GoldenChannel["summary"]>,
-  Summary
-> = true
-const errorKeysMatch: SameKeys<
-  NonNullable<GoldenChannel["error"]>,
-  NonNullable<ChannelOverview["error"]>
-> = true
-const refreshErrorKeysMatch: SameKeys<
-  NonNullable<GoldenChannel["refresh_error"]>,
-  NonNullable<ChannelOverview["refresh_error"]>
+const overviewTypesMatch: BidirectionallyExact<
+  GoldenOverviewShape,
+  OverviewResponse
 > = true
 
 const apiResponseTypeNames = [
@@ -136,13 +135,6 @@ describe("dashboard API response type ownership", () => {
 describe("Python dashboard overview schema contract", () => {
   it("accepts the generated Python response as the exact TypeScript response shape", () => {
     expect(overviewFixture.schema_version).toBe(DASHBOARD_SCHEMA_VERSION)
-    expect([
-      overviewKeysMatch,
-      channelKeysMatch,
-      periodKeysMatch,
-      summaryKeysMatch,
-      errorKeysMatch,
-      refreshErrorKeysMatch,
-    ]).toEqual([true, true, true, true, true, true])
+    expect(overviewTypesMatch).toBe(true)
   })
 })

--- a/dashboard/src/lib/dashboard-types.ts
+++ b/dashboard/src/lib/dashboard-types.ts
@@ -1,5 +1,7 @@
 import type { PublicationActivityResponse } from "@/features/publication-activity/publication-heatmap"
 
+export const DASHBOARD_SCHEMA_VERSION = 2
+
 export type Summary = {
   views: number
   watch_time_minutes: number

--- a/tests/commands/analytics/test_dashboard_schema_contract.py
+++ b/tests/commands/analytics/test_dashboard_schema_contract.py
@@ -1,0 +1,122 @@
+"""Python と dashboard TypeScript が共有する overview 応答契約。"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.commands.analytics.dashboard import create_server
+from youtube_automation.infrastructure.analytics.dashboard_read_model import (
+    SCHEMA_VERSION,
+    ChannelOverviewResponse,
+    ErrorResponse,
+    OverviewResponse,
+    PeriodResponse,
+    SummaryResponse,
+)
+
+GOLDEN_PATH = REPO_ROOT / "dashboard" / "src" / "lib" / "__fixtures__" / "overview.golden.json"
+UPDATE_ENV = "UPDATE_DASHBOARD_SCHEMA_GOLDEN"
+REGEN_COMMAND = (
+    f"{UPDATE_ENV}=1 uv run pytest "
+    "tests/commands/analytics/test_dashboard_schema_contract.py::test_python_overview_matches_dashboard_golden -q"
+)
+
+
+def _write_ready_channel(channel: Path) -> None:
+    meta = channel / "config" / "channel" / "meta.json"
+    meta.parent.mkdir(parents=True)
+    meta.write_text(json.dumps({"channel": {"name": "Contract Ready"}}), encoding="utf-8")
+    data = channel / "data"
+    data.mkdir()
+    (data / "analytics_data_20260812.json").write_text(
+        json.dumps(
+            {
+                "collection_period": {
+                    "start_date": "2026-08-01",
+                    "end_date": "2026-08-12",
+                    "collected_at": "2026-08-12T00:00:00+00:00",
+                },
+                "channel_analytics": {
+                    "summary": {
+                        "total_views": 1200,
+                        "total_watch_time": 420,
+                        "net_subscribers": 8,
+                        "total_engagement": 31,
+                        "avg_view_percentage": 62.5,
+                    }
+                },
+                "scheduled_videos": {"count": 2},
+                "video_analytics": {"video-1": {"title": "Contract Video", "views": 900}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_invalid_channel(channel: Path) -> None:
+    meta = channel / "config" / "channel" / "meta.json"
+    meta.parent.mkdir(parents=True)
+    meta.write_text("not-json", encoding="utf-8")
+
+
+def _contract_payload(tmp_path: Path) -> OverviewResponse:
+    ready = tmp_path / "ready"
+    invalid = tmp_path / "invalid"
+    _write_ready_channel(ready)
+    _write_invalid_channel(invalid)
+    server = create_server(
+        port=0,
+        channel_paths=[ready, invalid],
+        refresh_errors={ready: "refresh failed"},
+    )
+    try:
+        overview = server.api.overview()
+    finally:
+        server.server_close()
+    assert set(overview) == OverviewResponse.__required_keys__
+    assert overview["schema_version"] == SCHEMA_VERSION
+
+    channels = overview["channels"]
+    assert all(set(channel) == ChannelOverviewResponse.__required_keys__ for channel in channels)
+    ready_channel, invalid_channel = channels
+    assert ready_channel["summary"] is not None
+    assert set(ready_channel["summary"]) == SummaryResponse.__required_keys__
+    assert set(ready_channel["period"]) == PeriodResponse.__required_keys__
+    assert ready_channel["refresh_error"] is not None
+    assert set(ready_channel["refresh_error"]) == ErrorResponse.__required_keys__
+    assert invalid_channel["error"] is not None
+    assert set(invalid_channel["error"]) == ErrorResponse.__required_keys__
+
+    ready_channel["id"] = "channel-ready"
+    invalid_channel["id"] = "channel-invalid"
+    return overview
+
+
+def _assert_golden_matches(generated: str, committed: str) -> None:
+    assert generated == committed, (
+        f"dashboard overview schema drifted from {GOLDEN_PATH.relative_to(REPO_ROOT)}. "
+        f"Review the Python/TypeScript contract, then regenerate with: {REGEN_COMMAND}"
+    )
+
+
+def test_python_overview_matches_dashboard_golden(tmp_path: Path) -> None:
+    generated = json.dumps(_contract_payload(tmp_path), ensure_ascii=False, indent=2) + "\n"
+    if os.environ.get(UPDATE_ENV) == "1":
+        GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN_PATH.write_text(generated, encoding="utf-8")
+    if not GOLDEN_PATH.exists():
+        pytest.fail(f"dashboard overview golden is missing. Generate it with: {REGEN_COMMAND}")
+
+    committed = GOLDEN_PATH.read_text(encoding="utf-8")
+
+    _assert_golden_matches(generated, committed)
+
+
+def test_schema_drift_diagnostic_names_the_regeneration_command() -> None:
+    with pytest.raises(AssertionError, match=UPDATE_ENV):
+        _assert_golden_matches('{"schema_version": 3}\n', '{"schema_version": 2}\n')


### PR DESCRIPTION
## Summary
- `create_server()` の実 composition から overview golden fixture を生成し、Python TypedDict required keys と committed JSON の drift を再生成コマンド付きで検出する
- golden の複数 channel object union を required property shape へ再帰正規化し、応答全体と `OverviewResponse` の双方向 assignability を compile-time に要求する。key・property type・requiredness の片側 drift を拒否する
- Python/TS の schema version は共有 fixture と TS 定数の Vitest assertion で突合する。solution-style tsconfig を実際に検査するよう `typecheck` を `tsc -b --noEmit` へ補正する
- runtime validation・API・UI 挙動は変更しない

## Acceptance evidence
- Python response key drift: 一時的に `OverviewResponse` と実 constructor へ `contract_probe` を追加すると Python contract が exit 1。golden drift と `UPDATE_DASHBOARD_SCHEMA_GOLDEN=1 ...` の再生成診断を表示
- TypeScript response key drift: 一時的に `OverviewResponse.contract_probe` を required 追加すると `pnpm -C dashboard typecheck` が exit 2（TS2741 fixture key missing、TS2322 exact mismatch）
- TypeScript requiredness drift: 一時的に `ChannelOverview.scheduled_count` を optional 化すると `pnpm -C dashboard typecheck` が exit 2（TS2322 at bidirectional exact contract）
- TypeScript widening drift: 一時的に `ChannelOverview.error.code` を `string | number` へ拡張すると `pnpm -C dashboard typecheck` が exit 2（TS2322 at bidirectional exact contract）
- schema version drift: Python `SCHEMA_VERSION` の片側変更は Python contract が exit 1、TS `DASHBOARD_SCHEMA_VERSION` の片側変更は Vitest が exit 1（fixture 2 / expected 3）
- success path: 実 `create_server()` → `build_dashboard_read_model()` → `DashboardAPI.overview()` の ready/invalid/refresh-error response から fixture を生成し、normal run では committed bytes と一致

## Verification
- `nix develop --command uv run pytest tests/commands/analytics/test_dashboard_schema_contract.py tests/infrastructure/analytics/test_dashboard_read_model.py tests/commands/analytics/test_dashboard_server.py tests/repo/test_tests_layout_contract.py -q` — 49 passed
- `nix develop .#extensions --command pnpm -C dashboard lint` — passed
- `nix develop .#extensions --command pnpm -C dashboard typecheck` — passed (`tsc -b --noEmit`)
- `nix develop .#extensions --command pnpm -C dashboard test` — 10 files / 91 tests passed
- `nix develop .#extensions --command pnpm -C dashboard build` + `git diff --exit-code -- src/youtube_automation/dashboard_dist` — passed; generated distribution unchanged
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 791 files already formatted
- `bash .github/scripts/any-usage-gate.sh` — passed
- `git diff --check` — passed
- `nix develop --command uv sync --frozen` + `nix develop --command uv build` + installed-wheel sync/dashboard smokes — 2 passed
- serialized `nix develop --command uv run pytest -n auto` — 8276 passed, 1 skipped (initial implementation head; fix round 2 is TS contract-only, and all affected gates above were rerun)

## Fix rounds
- Round 1: full pytest exposed the commands test-layout owner contract. Fixture generation was routed through the real `create_server()` composition, preserving the issue-specified test location and strengthening the production path evidence; focused and full suites then passed.
- Round 2: adversarial mutation review showed key equality plus golden→TS assignment allowed optionality and widening. Replaced it with recursively normalized, bidirectional exact response assignability; both reported mutations now fail typecheck, and all affected local gates pass.

## CHANGELOG
- Not updated. The repository changelog gate covers `src/youtube_automation/`, skills/template, and `pyproject.toml`; this PR changes dashboard contract/typecheck tests, their fixture, and the dashboard typecheck script only, without runtime/API/UI behavior change. No `skip-changelog` label is required.

Closes #3899
