### PR TITLE
refactor(analytics): 例外 import を canonical owner へ移行する (#3954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(analytics)`: analytics domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3954）。
 - `fix(skill-feedback)`: schema-invalid JSONL 行を行番号と理由付きで警告して変更対象から隔離し、valid な `recorded` entry の還流を継続する。更新時は invalid・terminal・未選択行の bytes を保持し、安全な全件走査や atomic rewrite を証明できない場合は外部副作用前に停止する（#3939）。
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。
 - `fix(metadata)`: `yt-bulk-update-desc --help` に公開済み動画の概要欄を一括書き込みする通常実行と、API write を行わない `--dry-run` プレビュー、`--only` の対象絞り込みを明記した（#3796）。

--- a/src/youtube_automation/domains/analytics/collection/strategic_analytics.py
+++ b/src/youtube_automation/domains/analytics/collection/strategic_analytics.py
@@ -10,8 +10,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
 from youtube_automation.core.adapters.observability import section
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/audience_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/audience_analytics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/channel_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/channel_analytics.py
@@ -10,7 +10,7 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/ctr_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/ctr_analytics.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/playlist_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/playlist_analytics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Dict
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/analytics/mixins/retention_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/retention_analytics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/traffic_source_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/traffic_source_analytics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/mixins/video_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/video_analytics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401

--- a/src/youtube_automation/domains/analytics/reporting/reporting_analytics.py
+++ b/src/youtube_automation/domains/analytics/reporting/reporting_analytics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from youtube_automation.core.adapters.errors import AutomationError
+from youtube_automation.core.errors import AutomationError
 from youtube_automation.domains.analytics.ports import ReportingClient
 
 logger = logging.getLogger(__name__)

--- a/src/youtube_automation/domains/analytics/service.py
+++ b/src/youtube_automation/domains/analytics/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 from youtube_automation.domains.analytics.collection.strategic_analytics import StrategicAnalyticsMixin
 from youtube_automation.domains.analytics.mixins.audience_analytics import AudienceAnalyticsMixin
 from youtube_automation.domains.analytics.mixins.channel_analytics import ChannelAnalyticsMixin


### PR DESCRIPTION
## Summary

- `src/youtube_automation/domains/analytics/` の `youtube_automation.core.adapters.errors` import 11件を canonical owner の `youtube_automation.core.errors` へ機械置換
- imported symbols、例外 class identity、analytics の成功・失敗時 runtime behavior を維持
- `CHANGELOG.md` の `[Unreleased]` に #3954 の限定エントリを追加

## Acceptance evidence

- source scan: old import 0件 / canonical import 11件
- identity probe: `AutomationError` と `YouTubeAPIError` は旧 facade と canonical owner でそれぞれ `is` 同一
- focused analytics + architecture/import/CHANGELOG/Any contracts: 233 passed
- full suite: 8328 passed, 1 skipped
- packaging smoke: wheel + sdist build成功、installed-wheel skills sync 1 passed、dashboard packaging 1 passed

## Commands and results

- `rg -n "youtube_automation\.core\.adapters\.errors" src/youtube_automation/domains/analytics` → 0 matches
- `rg -n "youtube_automation\.core\.errors" src/youtube_automation/domains/analytics` → 11 matches
- `nix develop --command uv run python -c "... identity assertions ..."` → `exception_identity=identical`
- `nix develop --command uv run ruff check .` → All checks passed
- `nix develop --command uv run ruff format --check .` → 791 files already formatted
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh` → pass
- `nix develop --command uv run pytest -q tests/domains/analytics tests/test_analytics_cli_integration.py tests/contracts/architecture/test_repository_reorganization_contract.py tests/repo/test_import_migration_contract.py tests/repo/test_changelog_ci_contract.py tests/repo/test_any_usage_gate.py` → 233 passed
- `nix develop --command uv sync --frozen` → pass
- `nix develop --command uv build` → wheel + sdist built
- `YTA_CANDIDATE_WHEEL=... nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q` → 1 passed
- `YTA_CANDIDATE_WHEEL=... nix develop --command uv run pytest tests/repo/test_dashboard_packaging.py -q` → 1 passed
- `nix develop --command uv run pytest -n auto` → 8328 passed, 1 skipped
- `git diff --check` → pass

## CHANGELOG

`[Unreleased]` に `refactor(analytics)` エントリを追加。Migration は不要（公開 API、import mapping、runtime behavior の変更なし）。

Closes #3954