### PR TITLE
refactor(collections): 例外 import を canonical owner へ移行 (#3955)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(collections)`: collections domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3955）。
 - `refactor(analytics)`: analytics domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3954）。
 - `fix(skill-feedback)`: schema-invalid JSONL 行を行番号と理由付きで警告して変更対象から隔離し、valid な `recorded` entry の還流を継続する。更新時は invalid・terminal・未選択行の bytes を保持し、安全な全件走査や atomic rewrite を証明できない場合は外部副作用前に停止する（#3939）。
 - `fix(wf-new)`: サムネイル確定時の state 更新を schema に存在する `assets.thumbnail` へ統一し、未定義の `thumbnail.approved` を書き込む指示を削除した（#3868）。

--- a/src/youtube_automation/domains/collections/weekly_vote_log.py
+++ b/src/youtube_automation/domains/collections/weekly_vote_log.py
@@ -41,7 +41,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Iterable
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- `domains/collections/weekly_vote_log.py` の例外 import を `youtube_automation.core.adapters.errors` から canonical owner の `youtube_automation.core.errors` へ機械置換
- imported symbols、例外 class identity、成功・失敗時の runtime behavior を維持
- `CHANGELOG.md` の `[Unreleased]` に #3955 の narrow entry を追加

## Acceptance evidence
- 旧 import scan: `rg -n "youtube_automation\\.core\\.adapters\\.errors" src/youtube_automation/domains/collections` → 0 matches
- canonical import scan: `rg -n "from youtube_automation\\.core\\.errors import ConfigError, ValidationError" src/youtube_automation/domains/collections` → `weekly_vote_log.py:44`
- direct identity/success/failure smoke → `ConfigError` / `ValidationError` are identical across canonical owner, facade, and collections consumer; valid empty log succeeds; invalid schema raises the canonical `ValidationError`

## Verification
- `nix develop --command uv run pytest tests/domains/collections tests/commands/collections -n auto` → 465 passed
- `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py tests/repo/test_import_migration_contract.py -n auto` → 95 passed
- `nix develop --command uv run pytest -n auto` → 8328 passed, 1 skipped
- `nix develop --command uv run ruff check .` → passed
- `nix develop --command uv run ruff format --check .` → 791 files already formatted
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh` → passed
- CHANGELOG path gate equivalent + `[Unreleased]` #3955 entry scan → passed
- `nix develop --command uv build` → sdist and wheel built
- `git diff --check main...HEAD` → passed

Closes #3955