### PR TITLE
refactor(distrokid): 例外 import を canonical owner へ移行する (#3956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(distrokid)`: DistroKid domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3956）。
 - `refactor(collections)`: collections domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3955）。
 - `refactor(analytics)`: analytics domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3954）。
 - `fix(skill-feedback)`: schema-invalid JSONL 行を行番号と理由付きで警告して変更対象から隔離し、valid な `recorded` entry の還流を継続する。更新時は invalid・terminal・未選択行の bytes を保持し、安全な全件走査や atomic rewrite を証明できない場合は外部副作用前に停止する（#3939）。

--- a/src/youtube_automation/domains/distrokid/metadata.py
+++ b/src/youtube_automation/domains/distrokid/metadata.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 
 # アルバム情報表の `項目` ラベル → payload canonical key。
 _ALBUM_LABEL_MAP = {

--- a/src/youtube_automation/domains/distrokid/preparation.py
+++ b/src/youtube_automation/domains/distrokid/preparation.py
@@ -24,8 +24,8 @@ from pathlib import Path
 
 from PIL import Image, UnidentifiedImageError
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
 from youtube_automation.core.adapters.runtime import format_duration_mss
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.distrokid.metadata import (
     parse_album_metadata,
     parse_track_table,

--- a/src/youtube_automation/domains/distrokid/release.py
+++ b/src/youtube_automation/domains/distrokid/release.py
@@ -14,8 +14,8 @@ from datetime import datetime
 from pathlib import Path
 
 from youtube_automation.configuration.distrokid import Distrokid
-from youtube_automation.core.adapters.errors import ConfigError
 from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.distrokid.metadata import (
     parse_album_metadata,
     parse_track_table,

--- a/src/youtube_automation/domains/distrokid/specification.py
+++ b/src/youtube_automation/domains/distrokid/specification.py
@@ -33,7 +33,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 
 # spec.json のファイル名（SSOT として 30-distrokid/ 直下に置く）（#941）。
 SPEC_FILENAME = "spec.json"


### PR DESCRIPTION
## Summary

- `domains/distrokid/` の4 consumerを `youtube_automation.core.errors` へ直接移行
- imported symbol、例外 class identity、成功・失敗時の runtime behaviorを維持
- `[Unreleased]` に narrow CHANGELOG entryを追加

## Acceptance evidence

- old import scan: `src/youtube_automation/domains/distrokid/` で `youtube_automation.core.adapters.errors` 0件
- canonical import scan: 4 consumerすべて `youtube_automation.core.errors`
- identity contract: facade / canonical owner / DistroKid consumer の `ConfigError`・`ValidationError` が同一 class、canonical `ConfigError` の失敗経路を直接確認
- focused success/failure: 163 passed

## Verification

- `nix develop --command uv run pytest tests/domains/distrokid tests/commands/distrokid/test_distrokid_prepare.py -q` — 163 passed
- `nix develop --command uv run pytest tests/contracts/architecture tests/repo/test_import_migration_contract.py tests/repo/test_changelog_ci_contract.py tests/repo/test_any_usage_gate.py -q` — 107 passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — 791 files already formatted
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh` — passed
- `nix develop --command uv sync --frozen` — passed
- `nix develop --command uv build` — wheel and sdist built
- installed-wheel packaging smoke — 2 passed
- `nix develop --command uv run pytest -n auto` — 8328 passed, 1 skipped
- `git diff --check` — passed

## CHANGELOG

`CHANGELOG.md` の `[Unreleased]` に #3956 の canonical error import migration を追記。

Closes #3956