### PR TITLE
refactor(media): 例外 import を canonical owner へ移行する (#3957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(media)`: media domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3957）。
 - `refactor(distrokid)`: DistroKid domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3956）。
 - `refactor(collections)`: collections domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3955）。
 - `refactor(analytics)`: analytics domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3954）。

--- a/src/youtube_automation/domains/media/captions.py
+++ b/src/youtube_automation/domains/media/captions.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ValidationError
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.metadata.descriptions import extract_descriptions_md_section
 
 _TIMESTAMP_RE = re.compile(r"^(?P<timestamp>(?:\d{1,2}:)?\d{1,2}:\d{2})\s+(?P<title>.+?)\s*$")

--- a/src/youtube_automation/domains/media/video_type.py
+++ b/src/youtube_automation/domains/media/video_type.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 
 
 class VideoType(str, Enum):


### PR DESCRIPTION
## Summary

- domains/media の core.adapters.errors import 2 件を canonical core.errors へ機械置換
- imported symbol、例外 class identity、成功・失敗時の runtime behavior を維持
- core/adapters/media.py および facade・他 domain・architecture contract は変更なし

## Verification

- source scan: media legacy imports 0、canonical imports 2
- exception identity assertion: facade / canonical / media consumer が同一 class
- uv run pytest tests/infrastructure/media/test_video_type.py tests/infrastructure/test_captions.py -q — 30 passed
- architecture/import contracts — 176 passed
- uv run ruff check .
- uv run ruff format --check .
- PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh
- CHANGELOG gate equivalent
- uv build + installed-wheel sync/dashboard smoke — passed
- uv run pytest -n auto — 8328 passed, 1 skipped
- git diff --check
- core/adapters/media.py SHA-256 unchanged: 0b6b29896efa38aa3ad2b26f7a9fbfa3ac295aa8d65fd81cf55151fd40dc90d6

## Changelog

- [Unreleased] に #3957 の narrow entry を追加

Closes #3957
