### PR TITLE
refactor(metadata): 例外 import を canonical owner へ移行する (#3958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(metadata)`: metadata domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3958）。
 - `refactor(media)`: media domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3957）。
 - `refactor(distrokid)`: DistroKid domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3956）。
 - `refactor(collections)`: collections domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3955）。

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -23,7 +23,6 @@ import yaml
 
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.adapters.errors import ValidationError
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
 from youtube_automation.core.adapters.runtime import (
     format_duration_display,
@@ -31,6 +30,7 @@ from youtube_automation.core.adapters.runtime import (
     format_localized_duration_display,
     format_timestamp,
 )
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
 from youtube_automation.domains.metadata.descriptions import (
     build_complete_collection_description,

--- a/src/youtube_automation/domains/metadata/titles.py
+++ b/src/youtube_automation/domains/metadata/titles.py
@@ -6,7 +6,7 @@ import re
 import string
 from typing import Dict
 
-from youtube_automation.core.adapters.errors import ValidationError
+from youtube_automation.core.errors import ValidationError
 
 # `pattern-b1-` のような variation 接尾辞を保持する。
 _PATTERN_KEY_RE = re.compile(r"^\d+-pattern-([a-d]\d*)-", re.IGNORECASE)


### PR DESCRIPTION
## Summary
- `domains/metadata/` の `core.adapters.errors` import 2件を canonical `core.errors` へ機械置換
- import symbol・例外 class identity・既存の成功/失敗時挙動を維持
- `[Unreleased]` に metadata migration を記録

## Evidence
- legacy import scan: metadata 内 0件
- canonical import scan: `service.py` / `titles.py` の2件
- identity: legacy facade / canonical owner / metadata consumers の `ValidationError` が同一 object
- diff: 3 files changed, 3 insertions(+), 2 deletions(-)

## Validation
- `nix develop --command uv run pytest tests/domains/metadata -q` (208 passed)
- `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py tests/repo/test_import_migration_contract.py -q` (95 passed)
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `bash .github/scripts/any-usage-gate.sh`
- CHANGELOG gate equivalent + `git diff --check`
- `nix develop --command uv sync --frozen`
- `nix develop --command uv build`
- installed-wheel sync smoke (1 passed)
- installed-wheel dashboard smoke (1 passed)
- `nix develop --command uv run pytest -n auto` (8328 passed, 1 skipped)

## CHANGELOG
- Added a narrow `refactor(metadata)` entry under `[Unreleased]`.

Closes #3958