### PR TITLE
refactor(suno): 例外 import を canonical owner へ移行する (#3959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(suno)`: Suno domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3959）。
 - `refactor(metadata)`: metadata domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3958）。
 - `refactor(media)`: media domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3957）。
 - `refactor(distrokid)`: DistroKid domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3956）。

--- a/src/youtube_automation/domains/suno/config.py
+++ b/src/youtube_automation/domains/suno/config.py
@@ -9,8 +9,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 from youtube_automation.configuration import channel_dir
-from youtube_automation.core.adapters.errors import ConfigError
 from youtube_automation.core.adapters.media import VIDEO_ANALYSIS_DIRNAME
+from youtube_automation.core.errors import ConfigError
 
 _TOP_GENRE_PHRASES = 8
 _VOCAL_TERMS = (

--- a/src/youtube_automation/domains/suno/downloaded/validation.py
+++ b/src/youtube_automation/domains/suno/downloaded/validation.py
@@ -12,7 +12,7 @@ from typing import cast
 
 import yaml
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.suno.downloaded.models import (
     DOCUMENTATION_DIRNAME,
     SUNO_LYRICS_JSON_FILENAME,

--- a/src/youtube_automation/domains/suno/lyrics.py
+++ b/src/youtube_automation/domains/suno/lyrics.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 
 SUNO_LYRICS_JSON_FILENAME = "suno-lyrics.json"
 

--- a/src/youtube_automation/domains/suno/playlist.py
+++ b/src/youtube_automation/domains/suno/playlist.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Mapping
 
-from youtube_automation.core.adapters.errors import ValidationError
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.suno.name_matching import normalize_suno_name_for_lookup
 from youtube_automation.domains.suno.prompts import read_suno_prompt_entries
 

--- a/src/youtube_automation/domains/suno/selection.py
+++ b/src/youtube_automation/domains/suno/selection.py
@@ -21,8 +21,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ValidationError
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.suno.name_matching import (
     AmbiguousSunoNameError,
     SunoNameIndex,


### PR DESCRIPTION
## Summary
- `domains/suno/` の5つの error consumer を `youtube_automation.core.errors` へ直接移行
- 例外 class identity と既存の成功・失敗時挙動を維持
- `[Unreleased]` に Suno batch の狭い変更記録を追加

## Verification
- old import scan: 0件、canonical import: 5件
- error class identity smoke: passed
- `uv run pytest tests/domains/suno tests/commands/suno -q`: 462 passed
- architecture/import contracts: 112 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed (791 files formatted)
- Any gate / CHANGELOG gate / `git diff --check`: passed
- `uv build`: sdist + wheel built
- installed-wheel smoke: 2 passed
- `uv run pytest -n auto`: 8328 passed, 1 skipped

## Required CI
- `lint`: passed (43s)
- `test`: passed (3m36s)
- `build-smoke`: passed (46s)
- `any-gate`: passed (8s)
- `changelog`: passed (8s)
- `changes`: passed (7s)
- path-inapplicable `adr-numbering` / `windows-cost-tracker`: skipped by CI design

Note: an initial repo-wide `uv run pytest` without `-n auto` was stopped safely at about 50% after the acceptance command was clarified; the required non-overlapping `uv run pytest -n auto` was then run from the start and passed. No tests were skipped or weakened.

Closes #3959
