### PR TITLE
[refactor] thumbnail の core.adapters.errors import を core.errors へ移行する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(thumbnail)`: thumbnail domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3960）。
 - `refactor(suno)`: Suno domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3959）。
 - `refactor(metadata)`: metadata domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3958）。
 - `refactor(media)`: media domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3957）。

--- a/src/youtube_automation/domains/thumbnail/archive.py
+++ b/src/youtube_automation/domains/thumbnail/archive.py
@@ -9,8 +9,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
 from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import ConfigError, ValidationError
 
 _GALLERY_RELATIVE_PATH = Path("assets/thumbnail-gallery")
 _THUMBNAIL_SUFFIXES = (".jpg", ".png")

--- a/src/youtube_automation/domains/thumbnail/references.py
+++ b/src/youtube_automation/domains/thumbnail/references.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.metadata.placeholders import is_placeholder_value
 
 DEFAULT_DEDUP_RECENT_COLLECTIONS = 5

--- a/src/youtube_automation/domains/thumbnail/selection.py
+++ b/src/youtube_automation/domains/thumbnail/selection.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from PIL import Image, UnidentifiedImageError
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.thumbnail.features import (
     extract_features_from_path,
     feature_centroid,

--- a/src/youtube_automation/domains/thumbnail/text/config.py
+++ b/src/youtube_automation/domains/thumbnail/text/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from PIL import ImageColor, ImageFont
 
-from youtube_automation.core.adapters.errors import ConfigError
+from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.thumbnail.text.models import OverlaySpec, TextStyle
 
 _DEFAULT_TITLE_SIZE = 96

--- a/src/youtube_automation/domains/thumbnail/text/renderer.py
+++ b/src/youtube_automation/domains/thumbnail/text/renderer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.thumbnail.text.models import OverlaySpec, TextStyle
 
 _FINAL_THUMBNAIL_NAMES = frozenset({"thumbnail.jpg", "thumbnail.jpeg", "thumbnail.png"})


### PR DESCRIPTION
## Summary
- `domains/thumbnail/` の 5 error consumer を `youtube_automation.core.adapters.errors` から canonical owner の `youtube_automation.core.errors` へ機械置換
- import symbol、例外 class identity、成功・失敗時の runtime behavior を維持
- facade、他 domain、contracts、`legacy_utils` は変更せず、`CHANGELOG.md` の `[Unreleased]` に #3960 の narrow entry のみ追加

## Verification
- acceptance scan: `domains/thumbnail/` の `core.adapters.errors` import **0件**、canonical import **5 files**
- runtime identity: facade と変更対象 module の `ConfigError` / `ValidationError` が `core.errors` と同一 class であることを確認
- focused success/failure: `211 passed`
- architecture/import contracts: `112 passed`
- `uv run ruff check .` / `uv run ruff format --check .`: pass（791 files formatted）
- Any gate / CHANGELOG gate / `git diff --check`: pass
- `uv build` + candidate wheel content check + installed-wheel smoke: pass（1 passed）
- non-overlapping full `pytest -n auto`: **8328 passed, 1 skipped**
- final diff: **6 files changed, 6 insertions, 5 deletions**

Closes #3960