### PR TITLE
[refactor] uploads の wildcard facade consumer を authoritative module へ移行する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(uploads)`: uploads domain の wildcard facade consumer import を canonical owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外 class identity と upload の成功・失敗・byte 挙動を維持する（#3961）。
 - `refactor(thumbnail)`: thumbnail domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3960）。
 - `refactor(suno)`: Suno domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3959）。
 - `refactor(metadata)`: metadata domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3958）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -14,9 +14,9 @@ import logging
 from pathlib import Path
 
 from youtube_automation.core.adapters import cost_tracker
-from youtube_automation.core.adapters.errors import AutomationError, QuotaExhaustedError
 from youtube_automation.core.adapters.security import redact_sensitive_data
 from youtube_automation.core.adapters.youtube import complete_collection_quota_plan, quota_shortages
+from youtube_automation.core.errors import AutomationError, QuotaExhaustedError
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED,
     ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -13,14 +13,14 @@ import logging
 from pathlib import Path
 from typing import Callable, Dict, Optional
 
-from youtube_automation.core.adapters.errors import ValidationError
-from youtube_automation.core.adapters.filesystem import glob_files, path_exists, path_is_file, read_json
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
     UPLOAD_SOURCE_NEW,
 )
+from youtube_automation.infrastructure.filesystem import glob_files, path_exists, path_is_file, read_json
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/_dedup_search.py
+++ b/src/youtube_automation/domains/uploads/_dedup_search.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import logging
 from typing import Dict, Optional
 
-from youtube_automation.core.adapters.errors import ValidationError, YouTubeAPIError
-from youtube_automation.core.adapters.google.youtube import execute_youtube_request, validate_youtube_response_items
-from youtube_automation.core.adapters.quota import youtube_quota_recorder
+from youtube_automation.core.errors import ValidationError, YouTubeAPIError
 from youtube_automation.domains.uploads._uploader_constants import (
     _REUSABLE_UPLOAD_STATUSES,
     YOUTUBE_VIDEO_URL_PREFIX,
 )
+from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
+from youtube_automation.infrastructure.quota import youtube_quota_recorder
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/_descriptions_md.py
+++ b/src/youtube_automation/domains/uploads/_descriptions_md.py
@@ -9,15 +9,15 @@ import logging
 import re
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ValidationError
-from youtube_automation.core.adapters.filesystem import glob_files, path_exists, read_file_text
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.youtube import parse_youtube_tags
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.metadata.descriptions import (
     DESCRIPTIONS_MD_RECREATE_GUIDE,
     build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
 )
+from youtube_automation.infrastructure.filesystem import glob_files, path_exists, read_file_text
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/_playlist_assignment.py
+++ b/src/youtube_automation/domains/uploads/_playlist_assignment.py
@@ -7,9 +7,9 @@ import logging
 from pathlib import Path
 
 from youtube_automation.configuration import load_config
-from youtube_automation.core.adapters.filesystem import path_exists, read_file_text
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.domains.uploads.playlists import PlaylistManager
+from youtube_automation.infrastructure.filesystem import path_exists, read_file_text
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -11,15 +11,8 @@ import re
 from pathlib import Path
 
 from youtube_automation.configuration import load_config
-from youtube_automation.core.adapters.errors import ValidationError
-from youtube_automation.core.adapters.filesystem import (
-    list_directory,
-    path_exists,
-    path_is_directory,
-    read_file_text,
-    read_json,
-)
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.metadata.descriptions import (
     build_descriptions_md_parse_diagnostics,
@@ -37,6 +30,13 @@ from youtube_automation.domains.uploads.preflight import (
     check_title_template_compliance,
     extract_descriptions_md_tags,
     requires_scene_phrases,
+)
+from youtube_automation.infrastructure.filesystem import (
+    list_directory,
+    path_exists,
+    path_is_directory,
+    read_file_text,
+    read_json,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/youtube_automation/domains/uploads/_published_dates.py
+++ b/src/youtube_automation/domains/uploads/_published_dates.py
@@ -12,10 +12,10 @@ from datetime import datetime, timedelta
 from typing import ClassVar
 
 from youtube_automation.configuration import load_config
-from youtube_automation.core.adapters.errors import ValidationError, YouTubeAPIError
-from youtube_automation.core.adapters.google.youtube import execute_youtube_request, validate_youtube_response_items
-from youtube_automation.core.adapters.quota import youtube_quota_recorder
 from youtube_automation.core.adapters.runtime import get_schedule_timezone, resolve_default_publish_at
+from youtube_automation.core.errors import ValidationError, YouTubeAPIError
+from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
+from youtube_automation.infrastructure.quota import youtube_quota_recorder
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -11,20 +11,20 @@ import json
 import logging
 from pathlib import Path
 
-from youtube_automation.core.adapters.errors import ValidationError
-from youtube_automation.core.adapters.filesystem import (
+from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.adapters.runtime import now_in_schedule_tz
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.uploads._collection_uploader_constants import (
+    TRACKING_STATUS_COMPLETED,
+    WORKFLOW_PHASE_COMPLETE,
+    WORKFLOW_STAGE_LIVE,
+)
+from youtube_automation.infrastructure.filesystem import (
     make_directory,
     path_exists,
     read_file_text,
     replace_file,
     write_file_text,
-)
-from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.adapters.runtime import now_in_schedule_tz
-from youtube_automation.domains.uploads._collection_uploader_constants import (
-    TRACKING_STATUS_COMPLETED,
-    WORKFLOW_PHASE_COMPLETE,
-    WORKFLOW_STAGE_LIVE,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -8,8 +8,21 @@ from pathlib import Path
 import schedule
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.adapters.errors import ValidationError
-from youtube_automation.core.adapters.filesystem import (
+from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.adapters.youtube import (
+    DAILY_BUCKET_LIMITS,
+    UNIT_COSTS,
+    UNIT_POOL_LIMIT,
+    complete_collection_quota_plan,
+)
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
+from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignmentMixin
+from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
+from youtube_automation.domains.uploads._tracking_io import TrackingIOMixin
+from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
+from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+from youtube_automation.infrastructure.filesystem import (
     list_directory,
     make_directory,
     path_exists,
@@ -18,20 +31,7 @@ from youtube_automation.core.adapters.filesystem import (
     read_json,
     rename_path,
 )
-from youtube_automation.core.adapters.google.youtube import YouTubeClients
-from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.adapters.youtube import (
-    DAILY_BUCKET_LIMITS,
-    UNIT_COSTS,
-    UNIT_POOL_LIMIT,
-    complete_collection_quota_plan,
-)
-from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
-from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignmentMixin
-from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
-from youtube_automation.domains.uploads._tracking_io import TrackingIOMixin
-from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
-from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -6,17 +6,17 @@ from pathlib import Path
 from typing import Protocol
 
 from youtube_automation.configuration import channel_dir, load_config, reset
-from youtube_automation.core.adapters.errors import ValidationError, YouTubeAPIError
-from youtube_automation.core.adapters.filesystem import (
+from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import ValidationError, YouTubeAPIError
+from youtube_automation.infrastructure.filesystem import (
     list_directory,
     path_exists,
     path_is_directory,
     read_json,
     write_json,
 )
-from youtube_automation.core.adapters.google.youtube import execute_youtube_request, validate_youtube_response_items
-from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.adapters.quota import youtube_quota_recorder
+from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
+from youtube_automation.infrastructure.quota import youtube_quota_recorder
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/preflight.py
+++ b/src/youtube_automation/domains/uploads/preflight.py
@@ -12,16 +12,9 @@ from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 
 from youtube_automation.configuration import load_config
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError
-from youtube_automation.core.adapters.filesystem import (
-    path_exists,
-    path_is_file,
-    path_is_symlink,
-    read_file_text,
-    read_json,
-)
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.youtube import parse_youtube_tags, youtube_tag_chars
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.metadata.descriptions import (
     build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
@@ -32,6 +25,13 @@ from youtube_automation.domains.thumbnail.references import (
     plan_ttp_reference_assignments,
     resolve_configured_benchmark_references,
     resolve_dedup_recent_collections,
+)
+from youtube_automation.infrastructure.filesystem import (
+    path_exists,
+    path_is_file,
+    path_is_symlink,
+    read_file_text,
+    read_json,
 )
 
 YT_TAG_CHAR_LIMIT = 500

--- a/src/youtube_automation/domains/uploads/shorts.py
+++ b/src/youtube_automation/domains/uploads/shorts.py
@@ -9,13 +9,13 @@ from pathlib import Path
 from typing import Optional
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.adapters.errors import AutomationError, QuotaExhaustedError, UploadError, ValidationError
-from youtube_automation.core.adapters.filesystem import list_directory, path_exists, read_json, write_json
-from youtube_automation.core.adapters.google.youtube import YouTubeClients
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import get_schedule_timezone, now_in_schedule_tz
+from youtube_automation.core.errors import AutomationError, QuotaExhaustedError, UploadError, ValidationError
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+from youtube_automation.infrastructure.filesystem import list_directory, path_exists, read_json, write_json
+from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.adapters.errors import (
+from youtube_automation.core.adapters.runtime import resolve_default_publish_at as _resolve_default_publish_at
+from youtube_automation.core.errors import (
     AutomationError,
     ConfigError,
     QuotaExhaustedError,
@@ -15,15 +16,6 @@ from youtube_automation.core.adapters.errors import (
     ValidationError,
     YouTubeAPIError,
 )
-from youtube_automation.core.adapters.filesystem import file_size, path_exists, remove_file
-from youtube_automation.core.adapters.google.upload import HttpError, create_media_upload
-from youtube_automation.core.adapters.google.youtube import (
-    YouTubeClients,
-    execute_youtube_request,
-    validate_youtube_response_items,
-)
-from youtube_automation.core.adapters.process import compress_image
-from youtube_automation.core.adapters.runtime import resolve_default_publish_at as _resolve_default_publish_at
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._complete_collection_strategy import CompleteCollectionMixin
 from youtube_automation.domains.uploads._dedup_search import DedupSearchMixin
@@ -37,6 +29,14 @@ from youtube_automation.domains.uploads._uploader_constants import (
 from youtube_automation.domains.uploads.policy import SESSION_EXPIRED_HTTP_STATUSES, RetryDecision, ThumbnailCompression
 from youtube_automation.domains.uploads.preflight import check_title_codepoint_limit
 from youtube_automation.domains.youtube.channel_settings import build_upload_status_flags
+from youtube_automation.infrastructure.filesystem import file_size, path_exists, remove_file
+from youtube_automation.infrastructure.google.upload import HttpError, create_media_upload
+from youtube_automation.infrastructure.google.youtube import (
+    YouTubeClients,
+    execute_youtube_request,
+    validate_youtube_response_items,
+)
+from youtube_automation.infrastructure.process import compress_image
 
 logger = logging.getLogger(__name__)
 
@@ -384,7 +384,7 @@ class YouTubeAutoUploader(
             Dict: アップロード結果
         """
         collection_dir = Path(collection_path)
-        from youtube_automation.core.adapters.filesystem import path_exists
+        from youtube_automation.infrastructure.filesystem import path_exists
 
         if not path_exists(collection_dir):
             raise FileNotFoundError(f"コレクションディレクトリが見つかりません: {collection_path}")
@@ -490,7 +490,7 @@ class YouTubeAutoUploader(
 
         for status in status_filter:
             status_dir = self.collections_root / status
-            from youtube_automation.core.adapters.filesystem import list_directory, path_exists, path_is_directory
+            from youtube_automation.infrastructure.filesystem import list_directory, path_exists, path_is_directory
 
             if path_exists(status_dir):
                 collections = [


### PR DESCRIPTION
## Summary
- `domains/uploads/` の `core.adapters.errors` consumer を `core.errors` へ移行
- filesystem / process / quota / google.youtube / google.upload consumer を列挙済み authoritative infrastructure module へ移行
- `core.adapters.runtime` / `media` / `youtube` の明示 re-export と全 facade 実装を変更せず、例外・関数・class identity と upload runtime/byte 挙動を維持

## Acceptance evidence
- scoped wildcard-facade import scan: **0 offenders**
- authoritative/facade imported symbol identity smoke: **89 identities checked**
- focused upload + architecture + infrastructure suite: **578 passed**
- full suite: **8328 passed, 1 skipped**
- facade byte proof: base `bf133cd7` との差分 0。9ファイルの SHA-256 は変更前後で一致
  - `errors.py`: `48ec96423ef5f2a09a1b53cd2450c54ac0463d8cecb054fa166fc31abcf5bb6a`
  - `filesystem.py`: `1f1de49a2f6a4c51190768b265afc56b69044cdc1c6331e10f9490e88ab8029f`
  - `process.py`: `f283d19fcd706859552a111719748de81589d3bc7ce7feeeac8a2c7fca4095bc`
  - `quota.py`: `44709f877c9431a2a83c452ac827d509631189722a720ff2d2f070b1e9870977`
  - `google/youtube.py`: `961a2243dff3bf9688c6f3b98afcc8a6bc1284d88b73bb2424cf818157efef0b`
  - `google/upload.py`: `39555daa346ed37286e4c6ec6e4f6c2121f028d3c8d2d1c5d9b7c4520d0f6e32`
  - `runtime.py`: `7249f7cfc75b807c01b2f44f2d82e19198ab59052e7d0229d8c28a43d3496db4`
  - `media.py`: `0b6b29896efa38aa3ad2b26f7a9fbfa3ac295aa8d65fd81cf55151fd40dc90d6`
  - `youtube.py`: `b6aed767a8cb9e05dbd259f733fea468d9ac5367faa18b7d74ac886f4bdb7493`

## Exact verification
- `nix develop --command uv run pytest -q tests/domains/uploads tests/integration/test_upload_core.py tests/test_b4_reorganization_contract.py tests/contracts/architecture/test_repository_reorganization_contract.py tests/infrastructure/google/test_infrastructure_google_upload.py` → **578 passed**
- authoritative/facade AST-driven identity smoke → **89 checked**
- `nix develop --command uv run ruff check .` → **All checks passed**
- `nix develop --command uv run ruff format --check .` → **791 files already formatted**
- `PRE_PUSH_DIFF_BASE=bf133cd7eca2587324c2fa40bd9d289e727f2169 nix develop --command bash .github/scripts/any-usage-gate.sh` → **exit 0**
- CI-equivalent CHANGELOG path predicate → **significant source and CHANGELOG.md both present**
- `nix develop --command uv sync --frozen` → **Checked 63 packages**
- `nix develop --command uv build --out-dir <temporary-directory>` → **wheel and sdist built**
- candidate wheel installed smoke (`test_skills_sync_installed_wheel.py` + `test_dashboard_packaging.py`) → **2 passed**
- `nix develop --command uv run pytest -n auto` → **8328 passed, 1 skipped**
- `git diff --check bf133cd7eca2587324c2fa40bd9d289e727f2169` → **exit 0**

## CHANGELOG
`[Unreleased]` に `refactor(uploads)` の narrow entry を追加。

Closes #3961
