### PR TITLE
refactor(youtube): facade import を authoritative owner へ移行する (#3962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(youtube)`: youtube domain の wildcard facade consumer import を authoritative owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外・object identity と channel seed/settings/listing の成功・失敗時挙動を維持する（#3962）。
 - `refactor(uploads)`: uploads domain の wildcard facade consumer import を canonical owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外 class identity と upload の成功・失敗・byte 挙動を維持する（#3961）。
 - `refactor(thumbnail)`: thumbnail domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3960）。
 - `refactor(suno)`: Suno domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3959）。

--- a/src/youtube_automation/domains/youtube/channel_seed.py
+++ b/src/youtube_automation/domains/youtube/channel_seed.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from youtube_automation.core.adapters.browser import RedirectRejectedError, fetch_html, parse_url
-from youtube_automation.core.adapters.errors import ValidationError, YouTubeAPIError
-from youtube_automation.core.adapters.google.upload import HttpError
-from youtube_automation.core.adapters.google.youtube import execute_youtube_request, validate_youtube_response_items
+from youtube_automation.core.errors import ValidationError, YouTubeAPIError
+from youtube_automation.infrastructure.browser import RedirectRejectedError, fetch_html, parse_url
+from youtube_automation.infrastructure.google.upload import HttpError
+from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
 
 CHANNELS_PART = "snippet,statistics,contentDetails"
 PLAYLIST_ITEMS_PART = "snippet"

--- a/src/youtube_automation/domains/youtube/channel_settings.py
+++ b/src/youtube_automation/domains/youtube/channel_settings.py
@@ -33,8 +33,8 @@ import logging
 import shlex
 from typing import Any
 
-from youtube_automation.core.adapters.errors import ConfigError, ValidationError, YouTubeAPIError
-from youtube_automation.core.adapters.google.youtube import execute_youtube_request, validate_youtube_response_items
+from youtube_automation.core.errors import ConfigError, ValidationError, YouTubeAPIError
+from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
 
 logger = logging.getLogger(__name__)
 

--- a/src/youtube_automation/domains/youtube/video_listing.py
+++ b/src/youtube_automation/domains/youtube/video_listing.py
@@ -9,7 +9,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List
 
-from youtube_automation.core.adapters.errors import YouTubeAPIError
+from youtube_automation.core.errors import YouTubeAPIError
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401


### PR DESCRIPTION
## Summary

- `domains/youtube/` の `core.adapters.errors` consumer を `core.errors` へ移行しました。
- browser と Google YouTube/upload consumer を許可済み authoritative infrastructure module へ移行しました。
- facade 実装、他 domain、legacy_utils、architecture inventory、テスト実装には変更を加えていません。

## Acceptance evidence

- scoped facade imports: AST scan / `rg` ともに 0 件
- changed symbols: 全 14 consumer binding が authoritative owner の同一 object であることを確認
- behavior: channel seed/settings/listing の既存 success/failure 129 tests が変更前後とも成功
- scope: import 文を除く base/current AST が 3 source file すべて完全一致、変更は 3 source file + narrow CHANGELOG 1 行のみ
- facade preservation: 4 facade の SHA-256 が base と一致し、base diff は空
- imports: 4 import-order/cycle subprocess smoke が成功

## Validation

- `nix develop --command uv sync --frozen` — pass
- focused seed/settings/listing: `129 passed`
- architecture/import contracts: `84 passed`
- `nix develop --command uv run ruff check .` — pass
- `nix develop --command uv run ruff format --check .` — `791 files already formatted`
- `PRE_PUSH_DIFF_BASE=4c374a39bc2ab977acc53c05d303afb4ff5493e8 bash .github/scripts/any-usage-gate.sh` — pass
- `nix develop --command uv build` — wheel + sdist built
- installed-wheel downstream sync smoke — `1 passed`
- installed-wheel dashboard smoke — `1 passed`
- non-overlapping `nix develop --command uv run pytest -n auto` — `8328 passed, 1 skipped`
- `git diff --check 4c374a39bc2ab977acc53c05d303afb4ff5493e8...HEAD` — pass

## CHANGELOG

`[Unreleased]` に #3962 の authoritative import migration と identity/behavior preservation を 1 行追記しました。

Closes #3962