### PR TITLE
[refactor] core.adapters.errors 自己 re-export を削除する (#3963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(core)`: consumer 移行済みの `core.adapters.errors` 自己 re-export を削除し、ドメイン例外の canonical owner を `core.errors` のみに統一する（#3963）。
 - `refactor(youtube)`: youtube domain の wildcard facade consumer import を authoritative owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外・object identity と channel seed/settings/listing の成功・失敗時挙動を維持する（#3962）。
 - `refactor(uploads)`: uploads domain の wildcard facade consumer import を canonical owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外 class identity と upload の成功・失敗・byte 挙動を維持する（#3961）。
 - `refactor(thumbnail)`: thumbnail domain の例外 import を互換 facade 経由から canonical owner の `youtube_automation.core.errors` へ移行し、例外 class identity と既存の成功・失敗時挙動を維持する（#3960）。

--- a/docs/architecture/repository-reorganization-receipt.json
+++ b/docs/architecture/repository-reorganization-receipt.json
@@ -1200,7 +1200,6 @@
         "Updated consumer: src/youtube_automation/commands/media/stock_archive.py",
         "Updated consumer: src/youtube_automation/commands/media/generate_master.py",
         "Updated consumer: src/youtube_automation/commands/media/generate_short_loop.py",
-        "Updated consumer: src/youtube_automation/core/adapters/errors.py",
         "Updated consumer: tests/domains/analytics/mixins/test_playlist_analytics.py",
         "Updated consumer: tests/configuration/test_channel_target.py",
         "Updated consumer: tests/infrastructure/youtube/test_reporting_api.py",

--- a/src/youtube_automation/core/adapters/errors.py
+++ b/src/youtube_automation/core/adapters/errors.py
@@ -1,3 +1,0 @@
-"""Core-facing error contract."""
-
-from youtube_automation.core.errors import *  # noqa: F403


### PR DESCRIPTION
## Summary

- Delete the fully migrated `src/youtube_automation/core/adapters/errors.py` self re-export so `youtube_automation.core.errors` is the sole canonical error owner.
- Remove the deleted consumer from the existing repository-reorganization receipt and add a narrow Unreleased CHANGELOG entry.
- Leave every other facade, `legacy_utils`, error class, and runtime behavior unchanged.

## Acceptance evidence

- Active source/test/skill scans: text hits for `youtube_automation.core.adapters.errors` = 0; AST import hits = 0.
- `src/youtube_automation/core/errors.py` SHA-256 before/after: `e6c3d42433ae05d206969d21945686b9434c77034c14424180fd7027a2e55307`.
- All 13 remaining `core/adapters` files match their pre-change SHA-256 inventory byte-for-byte.
- Built wheel and sdist both omit `core/adapters/errors.py` and retain all 13 other adapter files.
- Isolated installed-wheel smoke preserves canonical/compatibility class identity and `YouTubeAPIError.from_http_error` success/failure behavior; importing the deleted module raises the expected `ModuleNotFoundError`.

## Verification

- `nix develop --command uv sync --frozen` — passed
- `nix develop --command uv run ruff check .` — passed
- `nix develop --command uv run ruff format --check .` — passed (790 files)
- `PRE_PUSH_DIFF_BASE=main nix develop --command bash .github/scripts/any-usage-gate.sh` — passed
- Architecture/error/CHANGELOG/packaging contracts — 115 passed
- `YTA_CANDIDATE_WHEEL=/tmp/issue3963-build.JFp696/youtube_channels_automation-5.6.0-py3-none-any.whl nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q` — 1 passed
- `nix develop --command uv run pytest -n auto` — 8328 passed, 1 skipped
- `nix develop --command uv build --wheel --sdist` — passed
- `git diff --check` — passed

Closes #3963
