### PR TITLE
refactor(core): filesystem process quota facade を削除する (#3964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(core)`: consumer 移行済みの filesystem / process / quota wildcard facade を削除し、provider-neutral な authoritative infrastructure module を唯一の import owner にする（#3964）。
 - `refactor(core)`: consumer 移行済みの `core.adapters.errors` 自己 re-export を削除し、ドメイン例外の canonical owner を `core.errors` のみに統一する（#3963）。
 - `refactor(youtube)`: youtube domain の wildcard facade consumer import を authoritative owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外・object identity と channel seed/settings/listing の成功・失敗時挙動を維持する（#3962）。
 - `refactor(uploads)`: uploads domain の wildcard facade consumer import を canonical owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外 class identity と upload の成功・失敗・byte 挙動を維持する（#3961）。

--- a/src/youtube_automation/core/adapters/filesystem.py
+++ b/src/youtube_automation/core/adapters/filesystem.py
@@ -1,3 +1,0 @@
-"""Filesystem adapter boundary."""
-
-from youtube_automation.infrastructure.filesystem import *  # noqa: F403

--- a/src/youtube_automation/core/adapters/process.py
+++ b/src/youtube_automation/core/adapters/process.py
@@ -1,3 +1,0 @@
-"""Process adapter boundary."""
-
-from youtube_automation.infrastructure.process import *  # noqa: F403

--- a/src/youtube_automation/core/adapters/quota.py
+++ b/src/youtube_automation/core/adapters/quota.py
@@ -1,3 +1,0 @@
-"""Quota adapter boundary."""
-
-from youtube_automation.infrastructure.quota import *  # noqa: F403


### PR DESCRIPTION
## Summary

- Delete the migrated `core.adapters.filesystem`, `core.adapters.process`, and `core.adapters.quota` wildcard facades.
- Keep the authoritative `infrastructure.filesystem`, `infrastructure.process`, and `infrastructure.quota` owners and all remaining adapter files unchanged.
- Add the required narrow `[Unreleased]` changelog entry.

## Verification

- `nix develop --command uv sync --frozen`
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- focused filesystem/process/quota owner and architecture tests: 113 passed
- `nix develop --command uv run pytest -n auto`: 8328 passed, 1 skipped
- source/test/skill AST and text inventory: 0 imports, dynamic strings, or alias uses of the three facades
- wheel and sdist archive inventory: all three facade files absent
- isolated installed-wheel owner/import smoke and packaged-resource smoke: passed
- `PRE_PUSH_DIFF_BASE=main bash .github/scripts/any-usage-gate.sh`
- `git diff --check`

## Scope

The diff contains only the three requested deletions and `CHANGELOG.md`; `#3965` and `#3966` are not implemented here.

Closes #3964
