### PR TITLE
refactor(core): browser google facade を削除する (#3965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(core)`: consumer 移行済みの browser / google.youtube / google.upload wildcard facade を削除し、provider-neutral な authoritative infrastructure module を唯一の import owner にする（#3965）。
 - `refactor(core)`: consumer 移行済みの filesystem / process / quota wildcard facade を削除し、provider-neutral な authoritative infrastructure module を唯一の import owner にする（#3964）。
 - `refactor(core)`: consumer 移行済みの `core.adapters.errors` 自己 re-export を削除し、ドメイン例外の canonical owner を `core.errors` のみに統一する（#3963）。
 - `refactor(youtube)`: youtube domain の wildcard facade consumer import を authoritative owner の `core.errors` と provider-neutral な `infrastructure` module へ移行し、例外・object identity と channel seed/settings/listing の成功・失敗時挙動を維持する（#3962）。

--- a/src/youtube_automation/core/adapters/browser.py
+++ b/src/youtube_automation/core/adapters/browser.py
@@ -1,3 +1,0 @@
-"""Browser adapter boundary."""
-
-from youtube_automation.infrastructure.browser import *  # noqa: F403

--- a/src/youtube_automation/core/adapters/google/upload.py
+++ b/src/youtube_automation/core/adapters/google/upload.py
@@ -1,3 +1,0 @@
-"""Google upload adapter boundary."""
-
-from youtube_automation.infrastructure.google.upload import *  # noqa: F403

--- a/src/youtube_automation/core/adapters/google/youtube.py
+++ b/src/youtube_automation/core/adapters/google/youtube.py
@@ -1,3 +1,0 @@
-"""Google YouTube adapter boundary."""
-
-from youtube_automation.infrastructure.google.youtube import *  # noqa: F403


### PR DESCRIPTION
## Summary

- Delete the migrated `core.adapters.browser`, `core.adapters.google.youtube`, and `core.adapters.google.upload` wildcard facades.
- Keep the authoritative browser/Google infrastructure owners, runtime behavior, `legacy_utils`, all other adapter files, and the #3966 final-surface contract unchanged.
- Add one narrow `[Unreleased]` changelog entry for the facade removal.

## Verification

- `nix develop --command uv sync --frozen` — pass (`Checked 63 packages`)
- focused browser/Google owner, retry, YouTube/upload behavior, and architecture suites — `378 passed`
- `nix develop --command uv run pytest -n auto` — `8328 passed, 1 skipped`
- `nix develop --command uv run ruff check .` — pass
- `nix develop --command uv run ruff format --check .` — `784 files already formatted`
- `PRE_PUSH_DIFF_BASE=46beb990ed513436eefde5f14622782401b47399 nix develop --command bash .github/scripts/any-usage-gate.sh` — pass
- active source/test/skill AST and text inventory — 0 imports, dynamic strings, aliases, or path references to all three deleted facades
- authoritative consumer object identity smoke — 13 bindings checked
- SHA-256 comparison — every other `core/adapters` file and all three authoritative owner modules are byte-identical to the base
- `nix develop --command uv build --out-dir <temporary-directory>` — wheel and sdist built; all three deleted facades are absent and authoritative owners are present in both archives
- candidate-wheel `test_skills_sync_installed_wheel.py` + `test_dashboard_packaging.py` — `2 passed`
- `git diff --check 46beb990ed513436eefde5f14622782401b47399` — pass

## Exact scope

The diff is limited to the three requested file deletions and one `CHANGELOG.md` line. No tests/contracts were weakened, deleted, or skipped; #3966 is not implemented early.

## CHANGELOG

`[Unreleased]` records that the migrated browser / google.youtube / google.upload wildcard facades were removed and their authoritative infrastructure modules are the only import owners.

Closes #3965
