### PR TITLE
feat(setup): 排他 tool chain を追加する (#3744)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: "Use when ツール導入と GCP / OAuth の API 設定をセットアップ・再診断するとき。「セットアップして」「環境構築」「/setup」「旧 /onboard」で発動。yt-doctor 診断 wizard。新規チャンネルの config・ペルソナ・branding を作る場合は /channel-new を使う"
+description: "Use when ツール導入と GCP / OAuth の API 設定をセットアップ・再診断するとき。「セットアップして」「環境構築」「/setup」「旧 /onboard」で発動。フラグなしは状態判定付きで進め、yt-doctor 診断 wizard だけは排他的な --tool を使う。新規チャンネルの config・ペルソナ・branding を作る場合は /channel-new を使う"
 ---
 
 ## 前後工程
@@ -8,177 +8,52 @@ description: "Use when ツール導入と GCP / OAuth の API 設定をセット
 - `前工程`: `なし`
 - `後工程`: `*`（共通基盤としてほぼ全スキル）
 
-## Overview
+## モード判定
 
-このスキルは **AI が指揮を取るツール・API 設定 wizard** である。automation CLI 導入後は `uv run yt-doctor --apply --json` に診断と安全な `ai-exec` の連続実行を委ね、`apply.stop_reason` が示す human 操作・利用者の決定・コマンド失敗だけを対話的に解決する。
+`$ARGUMENTS` から `--tool` の個数を最初に数える。
 
-責務は「automation ツールが動き、API 認証とアップロード前提が通る状態」まで。新規チャンネルの TTP 対象確認、config 生成、ペルソナ、branding は `/channel-new` が担当する。
+- 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す
+- 1 個なら対応する reference を読み、その一段だけを実行する。残りの引数はその mode の引数として扱う
+- 0 個なら chain manifest に従い tool を状態判定付きで進める
 
-利用者は GCP / OAuth に不慣れな前提。**すべてのコマンドの起動・実行・再診断は AI または setup スクリプトが担当する。** 利用者には、ブラウザ上のログイン・アカウント選択・OAuth 同意・秘密情報入力など、認証本人にしか行えない操作だけを `[HUMAN STEP]` として依頼する。
+| mode | 読む reference |
+|---|---|
+| `--tool` | `references/tool.md` |
 
-## 前提
+`--tool` は `uv run yt-setup-dirs` を含む現行 wizard をそのまま実行する。Google Auth Platform の Branding / Audience / Clients 設定と `client_secrets.json` の既存契約も `references/tool.md` で維持する。`/setup` では `config/channel/*.json` を生成しない。新規チャンネルの TTP 対象確認、config 生成、ペルソナ、branding は `/channel-new` の責務であり、この段では変更しない。運用設定の `workflow.post-publish.skip_approvals` も `references/tool.md` の既存インタビューで扱う。
 
-本スキルはセットアップの起点であり、前工程スキルの成果物を要求しない。確認するのは以下のみ:
+## 一括実行
 
-- 実行場所がチャンネル用ディレクトリであること（空フォルダ可。automation CLI の導入から「起動時のチェック」の手順で行う）
-- `uv` が利用可能であること。無ければ最初の step（bootstrap カテゴリの `uv` check）でインストールを案内する
-- 利用者が Google アカウントを持ち、AI / setup が起動した認証フローに対して、自分のブラウザでログイン・OAuth 同意・Google Auth Platform 設定を行えること（認証本人にしかできない `[HUMAN STEP]` として依頼する）
+`references/setup-chain-manifest.json` と `references/setup-chain-state.py` が存在し、manifest の `chainId`、step 順、step mode、approval gate、状態判定 script が妥当であることを確認する。欠損、未知・重複 step、複数 mode、`approvalGate.skip != true` があれば停止する。旧 `enabled` だけの gate は `skip = not enabled` として解決し、`skip` と `enabled` の同時指定は拒否する。
 
-`config/channel/*.json` の存在は前提にしない（channel カテゴリの check が fail でも `/channel-new` を案内するだけで setup 自体は完了できる）。
+最初の bootstrap で `uv`、`pyproject.toml`、automation package のいずれかが無く状態判定 script を起動できない場合は、`tool` を `run` として `references/tool.md` を実行する。起動可能ならチャンネルルートで manifest 順に次を実行する。
 
-### カテゴリ別チェック構成
+```bash
+uv run python .claude/skills/setup/references/setup-chain-state.py \
+  --channel-dir . --step tool
+```
 
-`yt-doctor` は診断を 5 カテゴリで段階表示する:
+| exit | `decision` | 処理 |
+|---:|---|---|
+| 0 | `skip` | setup 済みとして終了する |
+| 10 | `run` | `references/tool.md` を読み、現行の診断 wizard を実行する |
+| その他 | `error` | doctor / script のエラーとして停止する |
 
-| カテゴリ | 内容 |
-|---------|------|
-| `bootstrap` | ffmpeg / ffprobe / uv / pyproject.toml / automation パッケージ / `yt-skills sync` / 番号付き重複ファイル検知（7 check） |
-| `api` | gcloud CLI・GCP プロジェクト・Billing・APIs・ADC・IAM・OAuth 認証・Reporting API ジョブ |
-| `channel` | config/channel/ のロード可能性・playlists.json の妥当性・playlist 作成 dry-run（3 check: `channel_config` / `playlist_config` / `playlist_create_dry_run`）。fail 時は `/channel-new`（新規開設 / 既存チャンネル取り込み / 再生成モード）を案内するだけ |
-| `data` | `/wf-new` の入力モード判定データ + 到達可否 + 初期セットアップ事前検査（analytics_report / benchmark_data / ttp_wf_new_readiness / wf_new_readiness / initial_setup_readiness）。`ttp_mode: false` の minimal mode と benchmark fallback mode は setup のブロッカーにしない。analytics report は最新 `data/analytics_data_*.json` との相対比較に加え、`collection-ideate` の解決済み `freshness_days` を超えた絶対鮮度 stale も検出する。承認済み TTP がある場合だけ `/channel-new`（再生成モード） benchmark 反映完了を確認し、`ttp_mode: true` の minimal mode は転写元不足として警告する |
-| `upload` | upload 必須 scope 充足・channel_id 設定済み（1 check） |
-
-### 完了条件
-
-`uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed`（全 check 緑）になり、ツール、API 認証、アップロード前提が揃った状態が完了（報告文面は「完了時」セクションを参照）。例外として `analytics_report` の stale fail だけは後続スキルが自動解消するため setup のブロッカーにせず、`checks` 配列のほかの check がすべて `ok` なら `human_required` で停止しても同じ完了状態として扱う。`data` カテゴリは `/wf-new` の入力モード確認用で、stale analytics report、`ttp_mode: false` の minimal mode、benchmark fallback mode は新規チャンネル初回制作を止めない。`wf_new_readiness` が `ttp_mode: true` × minimal mode を警告した場合は転写元を準備するまで完了扱いにしない。新規チャンネル作成は次に `/channel-new` を実行する。
+実行後は同じ状態判定を再実行し、exit 0 にならなければ停止する。既存の stale analytics 完了例外も exit 0 とする。途中失敗時はその段で止め、再発動時は状態判定から再開する。
 
 ## 想定 API call 数
 
 | API | call 数 / 実行 | 変動要因 |
 |---|---|---|
-| YouTube Data API（oauth_token 手順の `uv run yt-oauth` 接続テスト） | 約 1 call | OAuth 認証の実行有無 |
-| YouTube Reporting API（`uv run yt-doctor` 診断 + `uv run yt-analytics --reporting-create-job`、無料枠） | 数 call（quota 課金なし） | Reporting job の作成有無 |
-| Vertex AI（Gemini / Veo / Lyria） | 0（`gcloud services enable` は API 有効化のみで生成呼び出しなし） | — |
+| YouTube Data API（oauth_token 手順の接続テスト） | 約 1 call | OAuth 認証の実行有無 |
+| YouTube Reporting API | 数 call（quota 課金なし） | Reporting job の作成有無 |
+| Vertex AI（Gemini / Veo / Lyria） | 0 | API 有効化のみで生成呼び出しなし |
 
-- 上限 / 承認: plain 診断（`uv run yt-doctor --json`）と書き込み系 check（playlist_create_dry_run 等）は読み取り専用 / dry-run で、YouTube 側への変更は発生しない。`yt-doctor --apply` は別であり、ローカルの skill 同期・古い managed skill 削除と、GCP の project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成を行い得る。そのため以下の承認 gate を通す。
+- 上限 / 承認: `--tool` とフラグなし chain は、`references/tool.md` の既存の変更 plan・承認 gate・API 上限をそのまま適用する
 
-## 起動時のチェック
+## 完了条件
 
-空フォルダでは `yt-doctor` がまだ存在しないため、最初にライブ配信予定を確認してから automation CLI を導入する:
+- フラグなし: tool が `skip` または実行後 `skip` になっている
+- `--tool`: `references/tool.md` の完了条件だけを満たしている
 
-1. 利用者に「このチャンネルで近いうちにライブ配信または 24/7 配信を予定していますか？」と 1 問だけ確認する
-   - 予定なしの場合: 追加案内はせず、次の手順へ進む
-   - 予定ありの場合: YouTube のライブ配信有効化はリクエストから最大 24 時間かかるため、今すぐ有効化しておくよう注意喚起し、以下を **[HUMAN STEP]** として案内する。ただし、この有効化完了は `/setup` のブロッカーにせず、案内後は次の手順へ進む
-
-```
-> [HUMAN STEP]
-> YouTube のライブ配信有効化は、リクエストから最大 24 時間かかる場合があります。
-> 近いうちにライブ配信または 24/7 配信を行う予定があるため、今すぐ有効化リクエストだけ済ませてください。
->
-> 手順:
->   1. https://studio.youtube.com を開く
->   2. 右上の「作成」から「ライブ配信開始」を選ぶ
->   3. 画面の案内に従ってライブ配信の有効化をリクエストする
->
-> 有効化完了は待たずに、/setup wizard はこのまま続行します。
-```
-
-2. `uv` が無ければ `uv` step の公式コマンドを AI が実行する
-3. `pyproject.toml` が無ければ `uv init` を Bash で実行する
-4. `pyproject.toml` に `youtube-channels-automation` 依存が無ければ `uv add git+https://github.com/daiki-beppu/youtube-automation.git` を Bash で実行する
-5. `uv run yt-skills sync --asset skills --force` / `uv run yt-skills sync --asset claude-md` / `uv run yt-skills sync --asset auth-template` を Bash で実行する
-6. `uv run yt-setup-dirs` を Bash で実行し、OAuth クライアント JSON の配置先 `auth/` など setup に必要な最小ディレクトリを作成する
-7. 初回のみ `uv run yt-doctor --json` を読み取り preflight として実行し、`checks[].next_action` から現時点の変更対象・コマンドを表示する。project ID がすでに解決できる場合は、後述の「GCP 変更 plan の承認」に従って連続実行で新たに到達し得る変更も全件表示する。`skills_synced` が prune を求める場合は、実在する managed legacy skill の削除対象パスを 1 件ずつ列挙する。その上で AskUserQuestion により「表示した変更を実行」/「中止」の明示 2 択を提示し、「GCP 変更は外部反映され、prune は列挙したファイルを削除する」と警告する。承認されなければここで停止する
-8. 承認後、収集済み決定 flag を保持する `apply_flags` を空で初期化し、`uv run yt-doctor --apply --json <apply_flags>` を 1 回実行して JSON の `apply.stop_reason` を読む。初回は flag 無しの `uv run yt-doctor --apply --json` となる
-9. `completed`: 冒頭の「完了条件」を確認し、「運用設定インタビュー」後に「完了時」を報告する
-10. `human_required`: `apply.check_id` の §Steps を参照する。`apply.next_action.reason == "authentication"` なら `apply.next_action.cmd` を AI が対話 session で起動してから、ブラウザ認証だけを `[HUMAN STEP]` として依頼する。その他は対応する `[HUMAN STEP]` を 1 つだけ依頼して停止する。認証コマンドまたは人間操作の完了後、必要な後処理と現在の `apply_flags` をすべて付けた手順 8 の再診断は AI が行う。`analytics_report` stale の例外は「完了条件」に従う
-11. `decision_required`: `apply.check_id` が `gcp_project` なら project ID、`billing_linked` なら billing account ID を利用者に 1 問で確認する。値を `apply_flags` へ仮追加または同名 flag の値を仮置換し、後述の「GCP 変更 plan の承認」で、その flag により新たに実行可能になる全コマンドと正確な project / account を再表示する。AskUserQuestion の「表示した GCP 変更を実行」/「中止」の 2 択で承認された後だけ flag を確定して再実行する。以後 `completed` まで全 flag を毎回付け、値を変更するたびに plan を再表示・再承認する。project と billing が両方決定済みなら `uv run yt-doctor --apply --json --project-id <project-id> --billing-account <billing-id>` となる
-12. `command_failed`: `apply.check_id` / `apply.cmd` / `apply.stderr` を利用者に示し、AI が §Steps に沿って原因を診断・解消してから、現在の `apply_flags` をすべて付けて手順 8 を再実行する。認証・承認入力以外のコマンドを利用者へ委ねない
-
-`--apply` は `ai-exec` を診断順に連続実行し、各コマンド後に再診断する。AI は `apply.executed` を実行済み履歴として読み、§Steps に残る同じ `ai-exec` コマンドを重複実行してはならない。`stop_reason` が上記 4 値以外、または JSON が読めない場合は安全側に停止し、CLI 出力を示す。
-
-### GCP 変更 plan の承認
-
-project ID が解決済み、または `apply_flags` へ `--project-id` / `--billing-account` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、billing account ID（決定済みの場合）、active account と、§Steps に記載した project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成のうち未解決の全コマンドを展開して表示する。
-
-表示後、「これらは project `<project-id>` の外部 GCP 状態を変更する」と警告し、AskUserQuestion で「表示した GCP 変更を実行」/「中止」の 2 択を提示する。承認されるまで flag 付き `--apply` を実行しない。値の追加・変更は前回の承認を無効にし、必ず plan を再表示して承認を取り直す。
-
-`/setup` は `uv run yt-setup-dirs` で `auth/`, `branding/`, `collections/`, `data/`, `docs/channel/personas/`, `docs/benchmarks/`, `research/` を冪等に作成する。`/setup` では `config/channel/*.json` を生成しない。新規チャンネルの config、TTP メモ、ペルソナ、branding は引き続き `/channel-new` の責務。
-
-## 認証コマンドと人間操作の責務
-
-以下の認証コマンドも、利用者へ実行を依頼してはならない。AI が PTY 付きの対話 session、または setup スクリプトの inherited stdio で起動し、プロセスを維持する:
-
-- `gcloud auth login`
-- `gcloud auth application-default login`
-- `uv run yt-oauth`
-
-人間は開いたブラウザでログイン・アカウント選択・OAuth 同意だけを行う。認可コード、password、token、client secret をチャットへ貼らせない。YouTube OAuth は AI が `uv run yt-oauth` を background session で起動し、stdout の同意 URL を利用者へ中継する。PKCE の `code_verifier` を保持するため、AI は認証開始時と同じプロセスを完了まで維持し、別プロセスでコマンドを再実行しない。認証プロセスが exit 0 になったら AI が `yt-doctor --apply` を再実行する。exit 非 0 なら stderr を確認して再試行条件を案内する。
-
-**Google Auth Platform の Branding / Audience / Clients 設定と client secret の Download JSON** (Google Cloud Console GUI 操作) は gcloud / Terraform に該当 API が存在しないため、これも `[HUMAN STEP]` で依頼する。ダウンロード後の `client_secrets.json` 配置と再診断は AI が `yt-doctor --fix-client-secrets` で行う。
-
-## [HUMAN STEP] の書き方
-
-利用者に認証操作を依頼するときは、先に AI が認証コマンドを対話 session で起動し、必ず以下の形式でブラウザ操作だけを依頼する:
-
-```
-> [HUMAN STEP]
-> 認証コマンドは setup が起動済みです。開いたブラウザで Google ログインと同意を完了してください。
-> password・認可コード・token はチャットへ貼らないでください。
-```
-
-認証プロセスの終了を session で待ち、待機中は 60 秒以内の間隔で進捗を伝える。exit 0 後は該当 step の後処理と、現在の `apply_flags` をすべて付けた `uv run yt-doctor --apply --json <apply_flags>` を AI が実行して新しい `apply.stop_reason` を確認する（`client_secrets` は `yt-doctor --fix-client-secrets` を先に実行する）。認証以外のコマンドも利用者へ実行依頼せず、AI / setup が実行する。
-
-例外: 「起動時のチェック」のライブ配信有効化リクエスト案内は、リードタイム確保のための早期注意喚起である。`[HUMAN STEP]` 書式で案内するが、完了待ちはせず wizard を通常どおり続行する。
-
-## Steps (check id ごとの対応手順)
-
-`yt-doctor` が FAILED / WARNING を返したら、その `check_id` に対応する節を
-[references/check-runbook.md](references/check-runbook.md) から読む。全 check の手順を先読みしない。
-
-収録している check id: `ffmpeg` / `uv` / `uv_project` / `automation_package` / `skills_synced` /
-`numbered_duplicates` / `gcloud` / `gcloud_account` / `gcp_project` / `billing_linked` / `apis_enabled` /
-`adc` / `adc_quota_project` / `iam_aiplatform_user` / `client_secrets` / `oauth_token` / `reporting_job` ほか。
-
-## 運用設定インタビュー
-
-冒頭の「完了条件」に従い、条件を満たした後、完了報告の**直前**に実行する。`/setup` の再診断時も同じ手順で現在の運用設定を確認する。
-
-### 実行条件と共通ルール
-
-1. `config/channel/` が存在せず `channel_config` の未生成経路に入った場合は、インタビューを実行しない。`channel_config` の手順どおり「運用設定は `/channel-new` 完了後に `/setup` を再実行して設定できます」と案内する。`/setup` は config を生成しない。
-2. `config/channel/` がロード可能なら、`config/channel/workflow.json` は任意であり、未存在でもインタビューを実行する。下表の workflow 6 行は、`workflow.json` またはその入れ子のキーが未設定なら表の default を現在値として扱う。回答が現在値と異なる場合は、必要な入れ子を含む `workflow.json` を作成または更新する。
-3. 下表の各行について、質問する直前に config を読んで現在値を取得する。現在値を利用者に質問してはならない。loop-video はまず `.claude/skills/loop-video/config.default.yaml` を読み、`config/skills/loop-video.yaml` が存在する場合はそれも読んで、`youtube_automation.configuration.skills.load_skill_config("loop-video")` と同じ deep-merge（default の上に override）で `enabled` の現在値を解決する。override に `enabled` が無い場合も default の値を現在値とする。
-4. 質問は必ず 1 問ずつ表示し、回答を待ってから次の行へ進む。各質問には現在値と、現在値を維持する推奨回答を添える。複数の質問をまとめて表示してはならない。
-5. 回答が現在値と同じならファイルを編集しない。異なる場合だけ、その行の config を Edit で更新する。既存 `config/skills/loop-video.yaml` を更新するときは `enabled` だけを変更し、ほかの override キーを保持する。
-
-| 順番 | config | キー | default | 質問と推奨回答 |
-| --- | --- | --- | --- | --- |
-| 1 | `config/channel/workflow.json` | `workflow.wf_next.skip_audio_approval` | `true` | 「音源承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
-| 2 | `config/channel/workflow.json` | `workflow.wf_next.skip_upload_approval` | `true` | 「アップロード承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
-| 3 | `config/channel/workflow.json` | `workflow.wf_next.skip_manual_mastering` | `false` | 「手動マスタリング検出をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のマスタリングフローを変えないため）」 |
-| 4 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.community-post` | `true` | 「コミュニティ投稿前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
-| 5 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.pinned-comment` | `true` | 「固定コメント前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
-| 6 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.metadata-audit` | `true` | 「メタデータ監査前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
-| 7 | `config/skills/loop-video.yaml` | `enabled` | `true` | 「ループ動画生成を有効にしますか？ 現在値: `<current>`。Veo API の利用には課金が発生します。推奨: 現在値を維持（既存の Veo 利用方針を変えないため）」 |
-
-`workflow.wf_next.skip_*_approval` と `workflow.post-publish.skip_approvals.*` はすべて `true = 承認省略`。`workflow.wf_next.skip_manual_mastering` を `true` にすると、最終マスター候補がなくても raw master を最終音源として採用する。
-
-`config/skills/loop-video.yaml` が存在しない場合は、解決した現在値と異なる回答のときだけ、回答値を `enabled` に持つ override ファイルを新規作成する。現在値のままなら override ファイルを作成してはならない。
-
-## 完了時
-
-冒頭の「完了条件」に従い、条件を満たして「運用設定インタビュー」を終えたら:
-
-```
-✓ setup 完了。
-  - automation ツールと同期済みスキルが利用できます
-  - GCP / OAuth / ADC の API 認証が通ります
-  - 動画アップロードに必要な OAuth scope と channel_id が揃っています
-  新規チャンネルを作る場合は、次に /channel-new を実行してください。
-```
-
-を表示して終了。
-
-## 関連スキル
-
-- `/channel-new`: 新規チャンネルの TTP 対象確認、config 生成、ペルソナ、branding (`channel_config` fail・新規チャンネルの場合)
-- `/channel-new`（既存チャンネル取り込みモード）: 既存チャンネル設定の取り込み (`channel_config` fail・既存 config ありの場合)
-- `/channel-status`: OAuth token 生成とチャンネル ID 確認
-- `/wf-new`: config 作成後の新規コレクション制作開始
-
-## 上級者向け: terraform ルート
-
-複数チャンネルを横断管理したい / 別 PC へ引っ越したい / GCP 側の drift を検出したい場合は `infra/terraform/gcp/` の README を参照。tfstate で構成管理できる代わりに `terraform.tfvars` 編集の 1 ステップが増える。
-
-AI が tfvars を Write して `.claude/skills/channel-new/references/gcp-terraform-apply.sh --auto-approve` を Bash で叩けば自動化可能。Google Auth Platform の Branding / Audience Test users / Clients 設定と `client_secrets.json` 配置は両ルート共通。
+実行または skip と、状態判定の `reason` を短く報告する。

--- a/.claude/skills/setup/references/setup-chain-manifest.json
+++ b/.claude/skills/setup/references/setup-chain-manifest.json
@@ -1,0 +1,18 @@
+{
+  "chainId": "setup",
+  "steps": [
+    {
+      "id": "tool",
+      "skill": "setup",
+      "prerequisiteArtifacts": [],
+      "outputArtifacts": [],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.setup.skip_approvals.tool"
+      },
+      "idempotency": {
+        "script": "references/setup-chain-state.py"
+      }
+    }
+  ]
+}

--- a/.claude/skills/setup/references/setup-chain-state.py
+++ b/.claude/skills/setup/references/setup-chain-state.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Return the resumable state of the setup tool step as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+from youtube_automation.commands.system import doctor
+from youtube_automation.core.errors import ConfigError
+
+EXIT_SKIP = 0
+EXIT_RUN = 10
+EXIT_ERROR = 2
+_STEPS = ("tool",)
+_UNRESOLVED_STATUSES = frozenset({"fail", "warn", "unknown"})
+
+
+class CheckPayload(TypedDict):
+    id: str
+    status: str
+
+
+class StateResult(TypedDict):
+    step: str
+    decision: str
+    reason: str
+    checks: list[CheckPayload]
+
+
+def _payload(checks: list[doctor.CheckResult]) -> list[CheckPayload]:
+    return [{"id": check.id, "status": check.status} for check in checks]
+
+
+def evaluate(checks: list[doctor.CheckResult], step: str) -> tuple[int, StateResult]:
+    if step not in _STEPS:
+        raise ValueError(f"unknown setup step: {step}")
+
+    unresolved = [check for check in checks if check.status in _UNRESOLVED_STATUSES]
+    if not unresolved:
+        return EXIT_SKIP, {
+            "step": step,
+            "decision": "skip",
+            "reason": "setup_ready",
+            "checks": [],
+        }
+    if len(unresolved) == 1 and unresolved[0].id == "analytics_report" and unresolved[0].status == "fail":
+        return EXIT_SKIP, {
+            "step": step,
+            "decision": "skip",
+            "reason": "setup_ready_analytics_report_stale",
+            "checks": _payload(unresolved),
+        }
+    return EXIT_RUN, {
+        "step": step,
+        "decision": "run",
+        "reason": "setup_checks_unresolved",
+        "checks": _payload(unresolved),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--step", choices=_STEPS, required=True)
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        code, result = evaluate(doctor.run_all_checks(args.channel_dir.resolve()), args.step)
+    except (ConfigError, OSError, ValueError) as exc:
+        code = EXIT_ERROR
+        result = {"step": args.step, "decision": "error", "reason": str(exc), "checks": []}
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2 if args.pretty else None)
+    sys.stdout.write("\n")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/setup/references/tool.md
+++ b/.claude/skills/setup/references/tool.md
@@ -1,0 +1,176 @@
+# tool
+
+## Overview
+
+このスキルは **AI が指揮を取るツール・API 設定 wizard** である。automation CLI 導入後は `uv run yt-doctor --apply --json` に診断と安全な `ai-exec` の連続実行を委ね、`apply.stop_reason` が示す human 操作・利用者の決定・コマンド失敗だけを対話的に解決する。
+
+責務は「automation ツールが動き、API 認証とアップロード前提が通る状態」まで。新規チャンネルの TTP 対象確認、config 生成、ペルソナ、branding は `/channel-new` が担当する。
+
+利用者は GCP / OAuth に不慣れな前提。**すべてのコマンドの起動・実行・再診断は AI または setup スクリプトが担当する。** 利用者には、ブラウザ上のログイン・アカウント選択・OAuth 同意・秘密情報入力など、認証本人にしか行えない操作だけを `[HUMAN STEP]` として依頼する。
+
+## 前提
+
+本スキルはセットアップの起点であり、前工程スキルの成果物を要求しない。確認するのは以下のみ:
+
+- 実行場所がチャンネル用ディレクトリであること（空フォルダ可。automation CLI の導入から「起動時のチェック」の手順で行う）
+- `uv` が利用可能であること。無ければ最初の step（bootstrap カテゴリの `uv` check）でインストールを案内する
+- 利用者が Google アカウントを持ち、AI / setup が起動した認証フローに対して、自分のブラウザでログイン・OAuth 同意・Google Auth Platform 設定を行えること（認証本人にしかできない `[HUMAN STEP]` として依頼する）
+
+`config/channel/*.json` の存在は前提にしない（channel カテゴリの check が fail でも `/channel-new` を案内するだけで setup 自体は完了できる）。
+
+### カテゴリ別チェック構成
+
+`yt-doctor` は診断を 5 カテゴリで段階表示する:
+
+| カテゴリ | 内容 |
+|---------|------|
+| `bootstrap` | ffmpeg / ffprobe / uv / pyproject.toml / automation パッケージ / `yt-skills sync` / 番号付き重複ファイル検知（7 check） |
+| `api` | gcloud CLI・GCP プロジェクト・Billing・APIs・ADC・IAM・OAuth 認証・Reporting API ジョブ |
+| `channel` | config/channel/ のロード可能性・playlists.json の妥当性・playlist 作成 dry-run（3 check: `channel_config` / `playlist_config` / `playlist_create_dry_run`）。fail 時は `/channel-new`（新規開設 / 既存チャンネル取り込み / 再生成モード）を案内するだけ |
+| `data` | `/wf-new` の入力モード判定データ + 到達可否 + 初期セットアップ事前検査（analytics_report / benchmark_data / ttp_wf_new_readiness / wf_new_readiness / initial_setup_readiness）。`ttp_mode: false` の minimal mode と benchmark fallback mode は setup のブロッカーにしない。analytics report は最新 `data/analytics_data_*.json` との相対比較に加え、`collection-ideate` の解決済み `freshness_days` を超えた絶対鮮度 stale も検出する。承認済み TTP がある場合だけ `/channel-new`（再生成モード） benchmark 反映完了を確認し、`ttp_mode: true` の minimal mode は転写元不足として警告する |
+| `upload` | upload 必須 scope 充足・channel_id 設定済み（1 check） |
+
+### 完了条件
+
+`uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed`（全 check 緑）になり、ツール、API 認証、アップロード前提が揃った状態が完了（報告文面は「完了時」セクションを参照）。例外として `analytics_report` の stale fail だけは後続スキルが自動解消するため setup のブロッカーにせず、`checks` 配列のほかの check がすべて `ok` なら `human_required` で停止しても同じ完了状態として扱う。`data` カテゴリは `/wf-new` の入力モード確認用で、stale analytics report、`ttp_mode: false` の minimal mode、benchmark fallback mode は新規チャンネル初回制作を止めない。`wf_new_readiness` が `ttp_mode: true` × minimal mode を警告した場合は転写元を準備するまで完了扱いにしない。新規チャンネル作成は次に `/channel-new` を実行する。
+
+## 想定 API call 数
+
+| API | call 数 / 実行 | 変動要因 |
+|---|---|---|
+| YouTube Data API（oauth_token 手順の `uv run yt-oauth` 接続テスト） | 約 1 call | OAuth 認証の実行有無 |
+| YouTube Reporting API（`uv run yt-doctor` 診断 + `uv run yt-analytics --reporting-create-job`、無料枠） | 数 call（quota 課金なし） | Reporting job の作成有無 |
+| Vertex AI（Gemini / Veo / Lyria） | 0（`gcloud services enable` は API 有効化のみで生成呼び出しなし） | — |
+
+- 上限 / 承認: plain 診断（`uv run yt-doctor --json`）と書き込み系 check（playlist_create_dry_run 等）は読み取り専用 / dry-run で、YouTube 側への変更は発生しない。`yt-doctor --apply` は別であり、ローカルの skill 同期・古い managed skill 削除と、GCP の project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成を行い得る。そのため以下の承認 gate を通す。
+
+## 起動時のチェック
+
+空フォルダでは `yt-doctor` がまだ存在しないため、最初にライブ配信予定を確認してから automation CLI を導入する:
+
+1. 利用者に「このチャンネルで近いうちにライブ配信または 24/7 配信を予定していますか？」と 1 問だけ確認する
+   - 予定なしの場合: 追加案内はせず、次の手順へ進む
+   - 予定ありの場合: YouTube のライブ配信有効化はリクエストから最大 24 時間かかるため、今すぐ有効化しておくよう注意喚起し、以下を **[HUMAN STEP]** として案内する。ただし、この有効化完了は `/setup` のブロッカーにせず、案内後は次の手順へ進む
+
+```
+> [HUMAN STEP]
+> YouTube のライブ配信有効化は、リクエストから最大 24 時間かかる場合があります。
+> 近いうちにライブ配信または 24/7 配信を行う予定があるため、今すぐ有効化リクエストだけ済ませてください。
+>
+> 手順:
+>   1. https://studio.youtube.com を開く
+>   2. 右上の「作成」から「ライブ配信開始」を選ぶ
+>   3. 画面の案内に従ってライブ配信の有効化をリクエストする
+>
+> 有効化完了は待たずに、/setup wizard はこのまま続行します。
+```
+
+2. `uv` が無ければ `uv` step の公式コマンドを AI が実行する
+3. `pyproject.toml` が無ければ `uv init` を Bash で実行する
+4. `pyproject.toml` に `youtube-channels-automation` 依存が無ければ `uv add git+https://github.com/daiki-beppu/youtube-automation.git` を Bash で実行する
+5. `uv run yt-skills sync --asset skills --force` / `uv run yt-skills sync --asset claude-md` / `uv run yt-skills sync --asset auth-template` を Bash で実行する
+6. `uv run yt-setup-dirs` を Bash で実行し、OAuth クライアント JSON の配置先 `auth/` など setup に必要な最小ディレクトリを作成する
+7. 初回のみ `uv run yt-doctor --json` を読み取り preflight として実行し、`checks[].next_action` から現時点の変更対象・コマンドを表示する。project ID がすでに解決できる場合は、後述の「GCP 変更 plan の承認」に従って連続実行で新たに到達し得る変更も全件表示する。`skills_synced` が prune を求める場合は、実在する managed legacy skill の削除対象パスを 1 件ずつ列挙する。その上で AskUserQuestion により「表示した変更を実行」/「中止」の明示 2 択を提示し、「GCP 変更は外部反映され、prune は列挙したファイルを削除する」と警告する。承認されなければここで停止する
+8. 承認後、収集済み決定 flag を保持する `apply_flags` を空で初期化し、`uv run yt-doctor --apply --json <apply_flags>` を 1 回実行して JSON の `apply.stop_reason` を読む。初回は flag 無しの `uv run yt-doctor --apply --json` となる
+9. `completed`: 冒頭の「完了条件」を確認し、「運用設定インタビュー」後に「完了時」を報告する
+10. `human_required`: `apply.check_id` の §Steps を参照する。`apply.next_action.reason == "authentication"` なら `apply.next_action.cmd` を AI が対話 session で起動してから、ブラウザ認証だけを `[HUMAN STEP]` として依頼する。その他は対応する `[HUMAN STEP]` を 1 つだけ依頼して停止する。認証コマンドまたは人間操作の完了後、必要な後処理と現在の `apply_flags` をすべて付けた手順 8 の再診断は AI が行う。`analytics_report` stale の例外は「完了条件」に従う
+11. `decision_required`: `apply.check_id` が `gcp_project` なら project ID、`billing_linked` なら billing account ID を利用者に 1 問で確認する。値を `apply_flags` へ仮追加または同名 flag の値を仮置換し、後述の「GCP 変更 plan の承認」で、その flag により新たに実行可能になる全コマンドと正確な project / account を再表示する。AskUserQuestion の「表示した GCP 変更を実行」/「中止」の 2 択で承認された後だけ flag を確定して再実行する。以後 `completed` まで全 flag を毎回付け、値を変更するたびに plan を再表示・再承認する。project と billing が両方決定済みなら `uv run yt-doctor --apply --json --project-id <project-id> --billing-account <billing-id>` となる
+12. `command_failed`: `apply.check_id` / `apply.cmd` / `apply.stderr` を利用者に示し、AI が §Steps に沿って原因を診断・解消してから、現在の `apply_flags` をすべて付けて手順 8 を再実行する。認証・承認入力以外のコマンドを利用者へ委ねない
+
+`--apply` は `ai-exec` を診断順に連続実行し、各コマンド後に再診断する。AI は `apply.executed` を実行済み履歴として読み、§Steps に残る同じ `ai-exec` コマンドを重複実行してはならない。`stop_reason` が上記 4 値以外、または JSON が読めない場合は安全側に停止し、CLI 出力を示す。
+
+### GCP 変更 plan の承認
+
+project ID が解決済み、または `apply_flags` へ `--project-id` / `--billing-account` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、billing account ID（決定済みの場合）、active account と、§Steps に記載した project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成のうち未解決の全コマンドを展開して表示する。
+
+表示後、「これらは project `<project-id>` の外部 GCP 状態を変更する」と警告し、AskUserQuestion で「表示した GCP 変更を実行」/「中止」の 2 択を提示する。承認されるまで flag 付き `--apply` を実行しない。値の追加・変更は前回の承認を無効にし、必ず plan を再表示して承認を取り直す。
+
+`/setup` は `uv run yt-setup-dirs` で `auth/`, `branding/`, `collections/`, `data/`, `docs/channel/personas/`, `docs/benchmarks/`, `research/` を冪等に作成する。`/setup` では `config/channel/*.json` を生成しない。新規チャンネルの config、TTP メモ、ペルソナ、branding は引き続き `/channel-new` の責務。
+
+## 認証コマンドと人間操作の責務
+
+以下の認証コマンドも、利用者へ実行を依頼してはならない。AI が PTY 付きの対話 session、または setup スクリプトの inherited stdio で起動し、プロセスを維持する:
+
+- `gcloud auth login`
+- `gcloud auth application-default login`
+- `uv run yt-oauth`
+
+人間は開いたブラウザでログイン・アカウント選択・OAuth 同意だけを行う。認可コード、password、token、client secret をチャットへ貼らせない。YouTube OAuth は AI が `uv run yt-oauth` を background session で起動し、stdout の同意 URL を利用者へ中継する。PKCE の `code_verifier` を保持するため、AI は認証開始時と同じプロセスを完了まで維持し、別プロセスでコマンドを再実行しない。認証プロセスが exit 0 になったら AI が `yt-doctor --apply` を再実行する。exit 非 0 なら stderr を確認して再試行条件を案内する。
+
+**Google Auth Platform の Branding / Audience / Clients 設定と client secret の Download JSON** (Google Cloud Console GUI 操作) は gcloud / Terraform に該当 API が存在しないため、これも `[HUMAN STEP]` で依頼する。ダウンロード後の `client_secrets.json` 配置と再診断は AI が `yt-doctor --fix-client-secrets` で行う。
+
+## [HUMAN STEP] の書き方
+
+利用者に認証操作を依頼するときは、先に AI が認証コマンドを対話 session で起動し、必ず以下の形式でブラウザ操作だけを依頼する:
+
+```
+> [HUMAN STEP]
+> 認証コマンドは setup が起動済みです。開いたブラウザで Google ログインと同意を完了してください。
+> password・認可コード・token はチャットへ貼らないでください。
+```
+
+認証プロセスの終了を session で待ち、待機中は 60 秒以内の間隔で進捗を伝える。exit 0 後は該当 step の後処理と、現在の `apply_flags` をすべて付けた `uv run yt-doctor --apply --json <apply_flags>` を AI が実行して新しい `apply.stop_reason` を確認する（`client_secrets` は `yt-doctor --fix-client-secrets` を先に実行する）。認証以外のコマンドも利用者へ実行依頼せず、AI / setup が実行する。
+
+例外: 「起動時のチェック」のライブ配信有効化リクエスト案内は、リードタイム確保のための早期注意喚起である。`[HUMAN STEP]` 書式で案内するが、完了待ちはせず wizard を通常どおり続行する。
+
+## Steps (check id ごとの対応手順)
+
+`yt-doctor` が FAILED / WARNING を返したら、その `check_id` に対応する節を
+[references/check-runbook.md](check-runbook.md) から読む。全 check の手順を先読みしない。
+
+収録している check id: `ffmpeg` / `uv` / `uv_project` / `automation_package` / `skills_synced` /
+`numbered_duplicates` / `gcloud` / `gcloud_account` / `gcp_project` / `billing_linked` / `apis_enabled` /
+`adc` / `adc_quota_project` / `iam_aiplatform_user` / `client_secrets` / `oauth_token` / `reporting_job` ほか。
+
+## 運用設定インタビュー
+
+冒頭の「完了条件」に従い、条件を満たした後、完了報告の**直前**に実行する。`/setup` の再診断時も同じ手順で現在の運用設定を確認する。
+
+### 実行条件と共通ルール
+
+1. `config/channel/` が存在せず `channel_config` の未生成経路に入った場合は、インタビューを実行しない。`channel_config` の手順どおり「運用設定は `/channel-new` 完了後に `/setup` を再実行して設定できます」と案内する。`/setup` は config を生成しない。
+2. `config/channel/` がロード可能なら、`config/channel/workflow.json` は任意であり、未存在でもインタビューを実行する。下表の workflow 6 行は、`workflow.json` またはその入れ子のキーが未設定なら表の default を現在値として扱う。回答が現在値と異なる場合は、必要な入れ子を含む `workflow.json` を作成または更新する。
+3. 下表の各行について、質問する直前に config を読んで現在値を取得する。現在値を利用者に質問してはならない。loop-video はまず `.claude/skills/loop-video/config.default.yaml` を読み、`config/skills/loop-video.yaml` が存在する場合はそれも読んで、`youtube_automation.configuration.skills.load_skill_config("loop-video")` と同じ deep-merge（default の上に override）で `enabled` の現在値を解決する。override に `enabled` が無い場合も default の値を現在値とする。
+4. 質問は必ず 1 問ずつ表示し、回答を待ってから次の行へ進む。各質問には現在値と、現在値を維持する推奨回答を添える。複数の質問をまとめて表示してはならない。
+5. 回答が現在値と同じならファイルを編集しない。異なる場合だけ、その行の config を Edit で更新する。既存 `config/skills/loop-video.yaml` を更新するときは `enabled` だけを変更し、ほかの override キーを保持する。
+
+| 順番 | config | キー | default | 質問と推奨回答 |
+| --- | --- | --- | --- | --- |
+| 1 | `config/channel/workflow.json` | `workflow.wf_next.skip_audio_approval` | `true` | 「音源承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 2 | `config/channel/workflow.json` | `workflow.wf_next.skip_upload_approval` | `true` | 「アップロード承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 3 | `config/channel/workflow.json` | `workflow.wf_next.skip_manual_mastering` | `false` | 「手動マスタリング検出をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持（既存のマスタリングフローを変えないため）」 |
+| 4 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.community-post` | `true` | 「コミュニティ投稿前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 5 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.pinned-comment` | `true` | 「固定コメント前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 6 | `config/channel/workflow.json` | `workflow.post-publish.skip_approvals.metadata-audit` | `true` | 「メタデータ監査前の承認をスキップしますか？ 現在値: `<current>`。推奨: 現在値を維持」 |
+| 7 | `config/skills/loop-video.yaml` | `enabled` | `true` | 「ループ動画生成を有効にしますか？ 現在値: `<current>`。Veo API の利用には課金が発生します。推奨: 現在値を維持（既存の Veo 利用方針を変えないため）」 |
+
+`workflow.wf_next.skip_*_approval` と `workflow.post-publish.skip_approvals.*` はすべて `true = 承認省略`。`workflow.wf_next.skip_manual_mastering` を `true` にすると、最終マスター候補がなくても raw master を最終音源として採用する。
+
+`config/skills/loop-video.yaml` が存在しない場合は、解決した現在値と異なる回答のときだけ、回答値を `enabled` に持つ override ファイルを新規作成する。現在値のままなら override ファイルを作成してはならない。
+
+## 完了時
+
+冒頭の「完了条件」に従い、条件を満たして「運用設定インタビュー」を終えたら:
+
+```
+✓ setup 完了。
+  - automation ツールと同期済みスキルが利用できます
+  - GCP / OAuth / ADC の API 認証が通ります
+  - 動画アップロードに必要な OAuth scope と channel_id が揃っています
+  新規チャンネルを作る場合は、次に /channel-new を実行してください。
+```
+
+を表示して終了。
+
+## 関連スキル
+
+- `/channel-new`: 新規チャンネルの TTP 対象確認、config 生成、ペルソナ、branding (`channel_config` fail・新規チャンネルの場合)
+- `/channel-new`（既存チャンネル取り込みモード）: 既存チャンネル設定の取り込み (`channel_config` fail・既存 config ありの場合)
+- `/channel-status`: OAuth token 生成とチャンネル ID 確認
+- `/wf-new`: config 作成後の新規コレクション制作開始
+
+## 上級者向け: terraform ルート
+
+複数チャンネルを横断管理したい / 別 PC へ引っ越したい / GCP 側の drift を検出したい場合は `infra/terraform/gcp/` の README を参照。tfstate で構成管理できる代わりに `terraform.tfvars` 編集の 1 ステップが増える。
+
+AI が tfvars を Write して `.claude/skills/channel-new/references/gcp-terraform-apply.sh --auto-approve` を Bash で叩けば自動化可能。Google Auth Platform の Branding / Audience Test users / Clients 設定と `client_secrets.json` 配置は両ルート共通。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(setup)`: `/setup` に排他的な `--tool` mode と 1-step chain manifest を追加し、フラグなし実行を `yt-doctor` の現在状態に応じて再開・skip できるようにする（#3744）。
 - `refactor(core)`: #3895 後の `core.adapters` を 7 個の明示 adapter/package file に固定し、wildcard facade、literal dynamic import consumer、拡張子を問わない file surface の増減、domain への外部 SDK・認証・network・process import、wheel/sdist の配布差分を repository contract で拒否する（#3966）。
 - `refactor(core)`: consumer 移行済みの browser / google.youtube / google.upload wildcard facade を削除し、provider-neutral な authoritative infrastructure module を唯一の import owner にする（#3965）。
 - `refactor(core)`: consumer 移行済みの filesystem / process / quota wildcard facade を削除し、provider-neutral な authoritative infrastructure module を唯一の import owner にする（#3964）。

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import importlib.util
+import json
 import os
 import re
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import yaml
 
@@ -14,7 +18,10 @@ from youtube_automation.commands.system import doctor
 _REPO_ROOT = REPO_ROOT
 _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
 _SETUP_SKILL = _SKILLS_DIR / "setup" / "SKILL.md"
+_SETUP_TOOL = _SKILLS_DIR / "setup" / "references" / "tool.md"
 _SETUP_RUNBOOK = _SKILLS_DIR / "setup" / "references" / "check-runbook.md"
+_SETUP_CHAIN_MANIFEST = _SKILLS_DIR / "setup" / "references" / "setup-chain-manifest.json"
+_SETUP_CHAIN_STATE = _SKILLS_DIR / "setup" / "references" / "setup-chain-state.py"
 _FRESHNESS_RULES = _SKILLS_DIR / "collection-ideate" / "references" / "freshness-rules.md"
 _CHANNEL_NEW_SKILL = _SKILLS_DIR / "channel-new" / "SKILL.md"
 _ONBOARD_DIR = _SKILLS_DIR / "onboard"
@@ -27,11 +34,26 @@ _CURRENT_SETUP_DOCS = [
 def _setup_text() -> str:
     """SKILL.md 本体 + 段階的開示で切り出した references/ を合わせた全文。
 
-    check id ごとの対応手順は `references/check-runbook.md` へ分離したため、
-    「/setup の手順として書かれていること」を担保する契約は両方を対象にする。
+    tool wizard と check id ごとの対応手順は references/ へ分離したため、
+    「/setup の手順として書かれていること」を担保する契約は 3 ファイルを対象にする。
     SKILL.md 本体に残っていること自体が要件のものだけ `_SETUP_SKILL` を直接読む。
     """
-    return _SETUP_SKILL.read_text(encoding="utf-8") + "\n" + _SETUP_RUNBOOK.read_text(encoding="utf-8")
+    return (
+        _SETUP_SKILL.read_text(encoding="utf-8")
+        + "\n"
+        + _SETUP_TOOL.read_text(encoding="utf-8")
+        + "\n"
+        + _SETUP_RUNBOOK.read_text(encoding="utf-8")
+    )
+
+
+def _load_setup_chain_state() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_chain_state", _SETUP_CHAIN_STATE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _frontmatter(skill_md: Path) -> dict:
@@ -51,6 +73,86 @@ def test_onboard_skill_directory_is_removed() -> None:
 def test_setup_skill_frontmatter_matches_directory_name() -> None:
     frontmatter = _frontmatter(_SETUP_SKILL)
     assert frontmatter["name"] == "setup"
+
+
+def test_setup_skill_declares_exclusive_tool_mode_and_default_chain() -> None:
+    text = _SETUP_SKILL.read_text(encoding="utf-8")
+    description = _frontmatter(_SETUP_SKILL)["description"]
+
+    assert "--tool" in description
+    assert "`$ARGUMENTS` から `--tool` の個数を最初に数える" in text
+    assert "2 個以上なら排他違反として停止し、1 つだけ指定するよう促す" in text
+    assert "1 個なら対応する reference を読み、その一段だけを実行する" in text
+    assert "0 個なら chain manifest に従い tool を状態判定付きで進める" in text
+    assert "| `--tool` | `references/tool.md` |" in text
+
+
+def test_setup_chain_manifest_declares_exactly_one_tool_step() -> None:
+    manifest = json.loads(_SETUP_CHAIN_MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest == {
+        "chainId": "setup",
+        "steps": [
+            {
+                "id": "tool",
+                "skill": "setup",
+                "prerequisiteArtifacts": [],
+                "outputArtifacts": [],
+                "approvalGate": {
+                    "skip": True,
+                    "configPath": "workflow.setup.skip_approvals.tool",
+                },
+                "idempotency": {"script": "references/setup-chain-state.py"},
+            }
+        ],
+    }
+
+
+def test_setup_chain_state_runs_unresolved_tool_and_skips_ready_tool() -> None:
+    state = _load_setup_chain_state()
+    unresolved = [doctor.CheckResult(id="uv", status="fail", message="uv missing")]
+    ready = [doctor.CheckResult(id="uv", status="ok", message="uv ready")]
+
+    run_code, run_result = state.evaluate(unresolved, "tool")
+    skip_code, skip_result = state.evaluate(ready, "tool")
+
+    assert (run_code, run_result["decision"], run_result["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "setup_checks_unresolved",
+    )
+    assert run_result["checks"] == [{"id": "uv", "status": "fail"}]
+    assert (skip_code, skip_result["decision"], skip_result["reason"]) == (
+        state.EXIT_SKIP,
+        "skip",
+        "setup_ready",
+    )
+    assert skip_result["checks"] == []
+
+
+def test_setup_chain_state_preserves_stale_analytics_completion_exception() -> None:
+    state = _load_setup_chain_state()
+    checks = [
+        doctor.CheckResult(id="uv", status="ok", message="uv ready"),
+        doctor.CheckResult(id="analytics_report", status="fail", message="stale report"),
+    ]
+
+    code, result = state.evaluate(checks, "tool")
+
+    assert code == state.EXIT_SKIP
+    assert result["decision"] == "skip"
+    assert result["reason"] == "setup_ready_analytics_report_stale"
+    assert result["checks"] == [{"id": "analytics_report", "status": "fail"}]
+
+
+def test_setup_chain_state_is_idempotent_for_the_same_doctor_state() -> None:
+    state = _load_setup_chain_state()
+    checks = [doctor.CheckResult(id="oauth_token", status="warn", message="login required")]
+
+    first = state.evaluate(checks, "tool")
+    second = state.evaluate(checks, "tool")
+
+    assert first == second
 
 
 def test_setup_skill_description_mentions_new_and_legacy_commands() -> None:
@@ -154,7 +256,7 @@ def test_setup_skill_gates_numbered_duplicate_deletion() -> None:
 
 
 def test_setup_skill_keeps_pre_doctor_bootstrap_in_skill() -> None:
-    text = _SETUP_SKILL.read_text(encoding="utf-8")
+    text = _SETUP_TOOL.read_text(encoding="utf-8")
     startup = text.split("## 起動時のチェック", 1)[1].split("## 認証コマンドと人間操作の責務", 1)[0]
 
     assert "`pyproject.toml` が無ければ `uv init`" in startup


### PR DESCRIPTION
## Summary

- `/setup` に analytics と同じ排他 mode 判定を追加し、`--tool` で既存 `yt-doctor` wizard だけを実行できるようにした
- フラグなし実行向けに schema 準拠の 1-step setup chain manifest と、doctor 状態による run / skip / stale analytics 例外判定を追加した
- 既存 wizard 本文を `references/tool.md` へ移設し、channel-new の mode や後続 issue の機能は変更していない

## Verification

- `nix develop --command uv run pytest tests/commands/system/test_setup_skill.py -q` — 35 passed
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract -q` — 614 passed
- `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q` — 1 passed
- `nix develop --command uv run pytest -n auto` — 8401 passed, 1 skipped
- `nix develop --command uv run yt-skills lint` — 55 skills passed
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `PRE_PUSH_DIFF_BASE=origin/main bash .github/scripts/any-usage-gate.sh`
- `nix develop --command uv sync --frozen`
- `nix develop --command uv build --out-dir <temp>`; wheel / sdist の setup 4 asset を確認
- `git diff --cached --check`

## State coverage

- unresolved doctor checks: `run` / exit 10
- ready doctor checks: `skip` / exit 0
- stale `analytics_report` only: existing completion exceptionとして `skip` / exit 0
- identical doctor state: identical decision（idempotent）
- `tool` は先頭 step で prerequisite がなく、未解決 check は既存 wizard が解消するため blocked 状態は持たない

## CHANGELOG

- `[Unreleased]` に #3744 の setup chain 追加を記載

Closes #3744
