### PR TITLE
feat(setup): 状態再開可能な2段chainを実装する (#3988)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ guard が exit 2 を返したら、その出力だけを提示して即時停止
 
 - 2 個以上なら、同じ flag の重複を含めて排他違反として停止し、1 つだけ指定するよう促す。この拒否経路では reference を Read せず、ファイル作成・更新、repo 初期化、API call、stage / commit を一切行わない
 - 1 個なら対応する reference を読み、その一段だけを実行する。残りの引数はその mode の引数として扱う
-- 0 個なら chain manifest に従い tool を状態判定付きで進める
+- 0 個なら chain manifest に従い `tool` → `channel` を状態判定付きで進める
 
 | mode | 読む reference |
 |---|---|
@@ -33,22 +33,25 @@ guard が exit 2 を返したら、その出力だけを提示して即時停止
 
 ## 一括実行
 
-`references/setup-chain-manifest.json` と `references/setup-chain-state.py` が存在し、manifest の `chainId`、step 順、step mode、approval gate、状態判定 script が妥当であることを確認する。欠損、未知・重複 step、複数 mode、`approvalGate.skip != true` があれば停止する。旧 `enabled` だけの gate は `skip = not enabled` として解決し、`skip` と `enabled` の同時指定は拒否する。
+`references/setup-chain-state.py` は `references/setup-chain-manifest.json` を実行前に strict 検証する。`chainId`、`tool` → `channel` の順序、未知・重複 step、prerequisite / output artifact、approval gate、状態判定 script のいずれかが不正なら `error` で停止する。旧 `enabled` だけの gate は `skip = not enabled` として解決し、`skip` と `enabled` の同時指定は拒否する。
 
-最初の bootstrap で `uv`、`pyproject.toml`、automation package のいずれかが無く状態判定 script を起動できない場合は、`tool` を `run` として `references/tool.md` を実行する。起動可能ならチャンネルルートで manifest 順に次を実行する。
+最初の bootstrap で `uv`、`pyproject.toml`、automation package のいずれかが無く状態判定 script を起動できない場合は、`tool` だけを `run` として `references/tool.md` を実行する。script が起動可能になったら先頭から状態判定を再開する。起動可能ならチャンネルルートで manifest 順に各 step を判定する。
 
 ```bash
 uv run python .claude/skills/setup/references/setup-chain-state.py \
-  --channel-dir . --step tool
+  --channel-dir . --step <tool|channel>
 ```
 
 | exit | `decision` | 処理 |
 |---:|---|---|
-| 0 | `skip` | setup 済みとして終了する |
-| 10 | `run` | `references/tool.md` を読み、現行の診断 wizard を実行する |
-| その他 | `error` | doctor / script のエラーとして停止する |
+| 0 | `skip` | 完了済みとして次の step へ進む。最終 step なら終了する |
+| 10 | `run` | `tool` は `references/tool.md`、`channel` は `references/channel-mode.md` を読み、その一段だけ実行する |
+| 20 | `blocked` | prerequisite 未完了として停止し、後段を実行しない |
+| 2 | `error` | manifest / doctor / script のエラーとして停止し、後段を実行しない |
 
-実行後は同じ状態判定を再実行し、exit 0 にならなければ停止する。既存の stale analytics 完了例外も exit 0 とする。途中失敗時はその段で止め、再発動時は状態判定から再開する。
+各 step の実行後は同じ状態判定を再実行し、exit 0 にならなければ停止する。`tool` 完了済みなら `channel` から再開し、`channel` 完了済みならどの副作用も再実行しない。既存の stale analytics 完了例外も `tool` の exit 0 とする。途中失敗時はその段で止め、後段を実行せず、再発動時は状態判定から再開する。
+
+明示 `--tool` / `--channel` はこの一括実行へ入らない。選択した reference の完了条件だけを実行・判定し、もう一段を暗黙実行しない。各 reference 内の不可逆操作・外部反映の承認 gate は chain の `approvalGate.skip` では省略されない。
 
 ## 想定 API call 数
 
@@ -62,7 +65,7 @@ uv run python .claude/skills/setup/references/setup-chain-state.py \
 
 ## 完了条件
 
-- フラグなし: tool が `skip` または実行後 `skip` になっている
+- フラグなし: `tool` と `channel` が manifest 順にどちらも `skip` になっている
 - `--tool`: `references/tool.md` の完了条件だけを満たしている
 - `--channel`: `references/channel-mode.md` の Step 1〜10 と完了条件をすべて満たしている
 

--- a/.claude/skills/setup/references/setup-chain-manifest.json
+++ b/.claude/skills/setup/references/setup-chain-manifest.json
@@ -5,10 +5,79 @@
       "id": "tool",
       "skill": "setup",
       "prerequisiteArtifacts": [],
-      "outputArtifacts": [],
+      "outputArtifacts": [
+        "doctor:ffmpeg",
+        "doctor:ffprobe",
+        "doctor:uv",
+        "doctor:uv_project",
+        "doctor:automation_package",
+        "doctor:skills_synced",
+        "doctor:gcloud",
+        "doctor:gcloud_account",
+        "doctor:gcp_project",
+        "doctor:billing_linked",
+        "doctor:apis_enabled",
+        "doctor:adc",
+        "doctor:adc_quota_project",
+        "doctor:iam_aiplatform_user",
+        "auth/client_secrets.json",
+        "auth/token.json"
+      ],
       "approvalGate": {
         "skip": true,
         "configPath": "workflow.setup.skip_approvals.tool"
+      },
+      "idempotency": {
+        "script": "references/setup-chain-state.py"
+      }
+    },
+    {
+      "id": "channel",
+      "skill": "setup",
+      "prerequisiteArtifacts": [
+        "doctor:ffmpeg",
+        "doctor:ffprobe",
+        "doctor:uv",
+        "doctor:uv_project",
+        "doctor:automation_package",
+        "doctor:skills_synced",
+        "doctor:gcloud",
+        "doctor:gcloud_account",
+        "doctor:gcp_project",
+        "doctor:billing_linked",
+        "doctor:apis_enabled",
+        "doctor:adc",
+        "doctor:adc_quota_project",
+        "doctor:iam_aiplatform_user",
+        "auth/client_secrets.json",
+        "auth/token.json"
+      ],
+      "outputArtifacts": [
+        "config/channel/meta.json",
+        "config/channel/content.json",
+        "config/channel/youtube.json",
+        "config/channel/analytics.json",
+        "config/channel/playlists.json",
+        "config/channel/workflow.json",
+        "config/channel/audio.json",
+        "config/localizations.json",
+        "config/schedule_config.json",
+        "config/skills/suno.yaml",
+        "config/skills/thumbnail.yaml",
+        "docs/channel/ttp-seed-confirmation.md",
+        "docs/channel/competitor-branding-snapshot.json",
+        "docs/plans/viewer-voice-analysis.md",
+        "docs/plans/viewing-scene-matrix.md",
+        "docs/channel/personas/persona-definition.md",
+        "branding/icon.*",
+        "branding/banner.*",
+        "doctor:ttp_wf_new_readiness",
+        "doctor:initial_setup_readiness",
+        "git:clean"
+      ],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.setup.skip_approvals.channel"
       },
       "idempotency": {
         "script": "references/setup-chain-state.py"

--- a/.claude/skills/setup/references/setup-chain-manifest.json
+++ b/.claude/skills/setup/references/setup-chain-manifest.json
@@ -64,6 +64,7 @@
         "config/schedule_config.json",
         "config/skills/suno.yaml",
         "config/skills/thumbnail.yaml",
+        "doctor:channel_config",
         "docs/channel/ttp-seed-confirmation.md",
         "docs/channel/competitor-branding-snapshot.json",
         "docs/plans/viewer-voice-analysis.md",

--- a/.claude/skills/setup/references/setup-chain-state.py
+++ b/.claude/skills/setup/references/setup-chain-state.py
@@ -76,8 +76,8 @@ _FILE_CHECK_IDS = {
     "auth/token.json": "oauth_token",
 }
 _BRANDING_ARTIFACTS = {
-    "branding/icon.*": ({".png": "PNG"}, 1.0, 4 * 1024 * 1024),
-    "branding/banner.*": ({".png": "PNG", ".jpg": "JPEG", ".jpeg": "JPEG"}, 16 / 9, 6 * 1024 * 1024),
+    "branding/icon.*": ({".png": "PNG"}, (1, 1), 4 * 1024 * 1024),
+    "branding/banner.*": ({".png": "PNG", ".jpg": "JPEG", ".jpeg": "JPEG"}, (16, 9), 6 * 1024 * 1024),
 }
 _STEP_KEYS = frozenset({"id", "skill", "prerequisiteArtifacts", "outputArtifacts", "approvalGate", "idempotency"})
 
@@ -182,20 +182,49 @@ def _check_map(checks: list[doctor.CheckResult]) -> dict[str, str]:
     return statuses
 
 
-def _git_status(root: Path) -> str:
-    result = subprocess.run(
-        ["git", "status", "--porcelain", "--untracked-files=all"],
+def _run_git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
         cwd=root,
         text=True,
         capture_output=True,
         check=False,
     )
-    if result.returncode != 0:
+
+
+def _artifact_committed(root: Path, artifact: str) -> bool:
+    if artifact.startswith(("doctor:", "git:")):
+        return True
+    if artifact in _BRANDING_ARTIFACTS:
+        formats, ratio, max_size = _BRANDING_ARTIFACTS[artifact]
+        candidates = [path for path in root.glob(artifact) if _valid_branding_image(path, formats, ratio, max_size)]
+    else:
+        candidates = [root / artifact]
+    return any(
+        _run_git(root, "cat-file", "-e", f"HEAD:{path.relative_to(root).as_posix()}").returncode == 0
+        for path in candidates
+    )
+
+
+def _git_status(root: Path, artifacts: list[str]) -> str:
+    top_level = _run_git(root, "rev-parse", "--show-toplevel")
+    if top_level.returncode != 0:
         return "missing"
-    return "ready" if not result.stdout else "dirty"
+    if Path(top_level.stdout.strip()).resolve() != root:
+        return "root_mismatch"
+    if _run_git(root, "rev-parse", "--verify", "HEAD").returncode != 0:
+        return "unborn"
+    status = _run_git(root, "status", "--porcelain", "--untracked-files=all")
+    if status.returncode != 0:
+        return "missing"
+    if status.stdout:
+        return "dirty"
+    if not all(_artifact_committed(root, artifact) for artifact in artifacts):
+        return "unsaved"
+    return "ready"
 
 
-def _valid_branding_image(path: Path, formats: dict[str, str], expected_ratio: float, max_size: int) -> bool:
+def _valid_branding_image(path: Path, formats: dict[str, str], ratio: tuple[int, int], max_size: int) -> bool:
     try:
         metadata = path.lstat()
         if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_size == 0:
@@ -213,13 +242,14 @@ def _valid_branding_image(path: Path, formats: dict[str, str], expected_ratio: f
         return False
     if actual_format != expected_format or width <= 0 or height <= 0:
         return False
-    return abs(width / height - expected_ratio) <= 0.03
+    ratio_width, ratio_height = ratio
+    return width * ratio_height == height * ratio_width
 
 
 def _branding_status(root: Path, artifact: str) -> str:
-    formats, expected_ratio, max_size = _BRANDING_ARTIFACTS[artifact]
+    formats, ratio, max_size = _BRANDING_ARTIFACTS[artifact]
     candidates = sorted(root.glob(artifact))
-    if any(_valid_branding_image(path, formats, expected_ratio, max_size) for path in candidates):
+    if any(_valid_branding_image(path, formats, ratio, max_size) for path in candidates):
         return "ready"
     return "invalid" if candidates else "missing"
 
@@ -231,7 +261,7 @@ def _artifact_payload(root: Path, statuses: dict[str, str], artifacts: list[str]
             check_status = statuses.get(artifact.removeprefix("doctor:"), "missing")
             status = "ready" if check_status == "ok" else check_status
         elif artifact == "git:clean":
-            status = _git_status(root)
+            status = _git_status(root, artifacts)
         elif artifact in _BRANDING_ARTIFACTS:
             status = _branding_status(root, artifact)
         else:

--- a/.claude/skills/setup/references/setup-chain-state.py
+++ b/.claude/skills/setup/references/setup-chain-state.py
@@ -1,26 +1,103 @@
 #!/usr/bin/env python3
-"""Return the resumable state of the setup tool step as JSON."""
+"""Return the deterministic resumable state of one setup chain step."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from youtube_automation.commands.system import doctor
 from youtube_automation.core.errors import ConfigError
 
 EXIT_SKIP = 0
 EXIT_RUN = 10
+EXIT_BLOCKED = 20
 EXIT_ERROR = 2
-_STEPS = ("tool",)
-_UNRESOLVED_STATUSES = frozenset({"fail", "warn", "unknown"})
+STEPS = ("tool", "channel")
+TOOL_CHECK_IDS = (
+    "ffmpeg",
+    "ffprobe",
+    "uv",
+    "uv_project",
+    "automation_package",
+    "skills_synced",
+    "gcloud",
+    "gcloud_account",
+    "gcp_project",
+    "billing_linked",
+    "apis_enabled",
+    "adc",
+    "adc_quota_project",
+    "iam_aiplatform_user",
+    "client_secrets",
+    "oauth_token",
+)
+CHANNEL_CHECK_IDS = ("ttp_wf_new_readiness", "initial_setup_readiness")
+TOOL_OUTPUT_ARTIFACTS = (
+    *(f"doctor:{check_id}" for check_id in TOOL_CHECK_IDS[:-2]),
+    "auth/client_secrets.json",
+    "auth/token.json",
+)
+CHANNEL_OUTPUT_ARTIFACTS = (
+    "config/channel/meta.json",
+    "config/channel/content.json",
+    "config/channel/youtube.json",
+    "config/channel/analytics.json",
+    "config/channel/playlists.json",
+    "config/channel/workflow.json",
+    "config/channel/audio.json",
+    "config/localizations.json",
+    "config/schedule_config.json",
+    "config/skills/suno.yaml",
+    "config/skills/thumbnail.yaml",
+    "docs/channel/ttp-seed-confirmation.md",
+    "docs/channel/competitor-branding-snapshot.json",
+    "docs/plans/viewer-voice-analysis.md",
+    "docs/plans/viewing-scene-matrix.md",
+    "docs/channel/personas/persona-definition.md",
+    "branding/icon.*",
+    "branding/banner.*",
+    "doctor:ttp_wf_new_readiness",
+    "doctor:initial_setup_readiness",
+    "git:clean",
+)
+_ALLOWED_CHECK_STATUSES = frozenset({"ok", "info", "warn", "fail", "unknown"})
+_FILE_CHECK_IDS = {
+    "auth/client_secrets.json": "client_secrets",
+    "auth/token.json": "oauth_token",
+}
+_STEP_KEYS = frozenset({"id", "skill", "prerequisiteArtifacts", "outputArtifacts", "approvalGate", "idempotency"})
+
+
+class ManifestError(ValueError):
+    """The setup manifest cannot safely drive the chain."""
+
+
+class SetupStep(TypedDict):
+    id: str
+    skill: str
+    prerequisiteArtifacts: list[str]
+    outputArtifacts: list[str]
+    approvalGate: dict[str, object]
+    idempotency: dict[str, str]
+
+
+class SetupManifest(TypedDict):
+    chainId: str
+    steps: list[SetupStep]
 
 
 class CheckPayload(TypedDict):
     id: str
+    status: str
+
+
+class ArtifactPayload(TypedDict):
+    artifact: str
     status: str
 
 
@@ -29,54 +106,171 @@ class StateResult(TypedDict):
     decision: str
     reason: str
     checks: list[CheckPayload]
+    artifacts: list[ArtifactPayload]
 
 
-def _payload(checks: list[doctor.CheckResult]) -> list[CheckPayload]:
-    return [{"id": check.id, "status": check.status} for check in checks]
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ManifestError(message)
 
 
-def evaluate(checks: list[doctor.CheckResult], step: str) -> tuple[int, StateResult]:
-    if step not in _STEPS:
+def _approval_skip(gate: object) -> bool:
+    _require(isinstance(gate, dict), "approvalGate must be an object")
+    keys = set(gate)
+    _require(keys in ({"skip", "configPath"}, {"enabled", "configPath"}), "approvalGate schema is invalid")
+    if "skip" in gate:
+        _require(isinstance(gate["skip"], bool), "approvalGate.skip must be boolean")
+        return cast(bool, gate["skip"])
+    _require(isinstance(gate["enabled"], bool), "approvalGate.enabled must be boolean")
+    return not cast(bool, gate["enabled"])
+
+
+def _validate_step(step: object, expected_id: str, prerequisites: tuple[str, ...], outputs: tuple[str, ...]) -> None:
+    _require(isinstance(step, dict), "step must be an object")
+    _require(set(step) == _STEP_KEYS, f"{expected_id} step schema is invalid")
+    _require(step["id"] == expected_id, f"expected {expected_id} step")
+    _require(step["skill"] == "setup", f"{expected_id} step skill must be setup")
+    _require(step["prerequisiteArtifacts"] == list(prerequisites), f"{expected_id} prerequisites drifted")
+    _require(step["outputArtifacts"] == list(outputs), f"{expected_id} outputs drifted")
+    gate = step["approvalGate"]
+    _require(_approval_skip(gate), f"{expected_id} approval gate must fail closed")
+    _require(
+        gate["configPath"] == f"workflow.setup.skip_approvals.{expected_id}",
+        f"{expected_id} approval config path is invalid",
+    )
+    _require(
+        step["idempotency"] == {"script": "references/setup-chain-state.py"},
+        f"{expected_id} idempotency script is invalid",
+    )
+
+
+def load_manifest(path: Path) -> SetupManifest:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ManifestError(str(exc)) from exc
+    _require(isinstance(raw, dict) and set(raw) == {"chainId", "steps"}, "root schema is invalid")
+    _require(raw["chainId"] == "setup", "chainId must be setup")
+    steps = raw["steps"]
+    _require(isinstance(steps, list), "steps must be an array")
+    _require(
+        [step.get("id") if isinstance(step, dict) else None for step in steps] == list(STEPS),
+        "steps must be tool then channel",
+    )
+    _validate_step(steps[0], "tool", (), TOOL_OUTPUT_ARTIFACTS)
+    _validate_step(steps[1], "channel", TOOL_OUTPUT_ARTIFACTS, CHANNEL_OUTPUT_ARTIFACTS)
+    return cast(SetupManifest, raw)
+
+
+def _check_map(checks: list[doctor.CheckResult]) -> dict[str, str]:
+    statuses: dict[str, str] = {}
+    for check in checks:
+        if check.id in statuses:
+            raise ValueError(f"duplicate doctor check: {check.id}")
+        if check.status not in _ALLOWED_CHECK_STATUSES:
+            raise ValueError(f"invalid doctor status for {check.id}: {check.status}")
+        statuses[check.id] = check.status
+    return statuses
+
+
+def _git_status(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return "missing"
+    return "ready" if not result.stdout else "dirty"
+
+
+def _artifact_payload(root: Path, statuses: dict[str, str], artifacts: list[str]) -> list[ArtifactPayload]:
+    payload: list[ArtifactPayload] = []
+    for artifact in artifacts:
+        if artifact.startswith("doctor:"):
+            check_status = statuses.get(artifact.removeprefix("doctor:"), "missing")
+            status = "ready" if check_status == "ok" else check_status
+        elif artifact == "git:clean":
+            status = _git_status(root)
+        else:
+            exists = any(path.is_file() for path in root.glob(artifact))
+            check_id = _FILE_CHECK_IDS.get(artifact)
+            check_status = statuses.get(check_id, "missing") if check_id is not None else "ok"
+            status = "ready" if exists and check_status == "ok" else check_status if exists else "missing"
+        payload.append({"artifact": artifact, "status": status})
+    return payload
+
+
+def _result(
+    step: str, decision: str, reason: str, checks: list[CheckPayload], artifacts: list[ArtifactPayload]
+) -> StateResult:
+    return {"step": step, "decision": decision, "reason": reason, "checks": checks, "artifacts": artifacts}
+
+
+def evaluate(
+    root: Path,
+    checks: list[doctor.CheckResult],
+    manifest: SetupManifest,
+    step: str,
+) -> tuple[int, StateResult]:
+    if step not in STEPS:
         raise ValueError(f"unknown setup step: {step}")
+    root = root.resolve()
+    statuses = _check_map(checks)
+    selected = next(item for item in manifest["steps"] if item["id"] == step)
+    if step == "channel":
+        prerequisites = _artifact_payload(root, statuses, selected["prerequisiteArtifacts"])
+        if any(item["status"] != "ready" for item in prerequisites):
+            return EXIT_BLOCKED, _result(step, "blocked", "tool_prerequisites_incomplete", [], prerequisites)
 
-    unresolved = [check for check in checks if check.status in _UNRESOLVED_STATUSES]
-    if not unresolved:
-        return EXIT_SKIP, {
-            "step": step,
-            "decision": "skip",
-            "reason": "setup_ready",
-            "checks": [],
-        }
-    if len(unresolved) == 1 and unresolved[0].id == "analytics_report" and unresolved[0].status == "fail":
-        return EXIT_SKIP, {
-            "step": step,
-            "decision": "skip",
-            "reason": "setup_ready_analytics_report_stale",
-            "checks": _payload(unresolved),
-        }
-    return EXIT_RUN, {
-        "step": step,
-        "decision": "run",
-        "reason": "setup_checks_unresolved",
-        "checks": _payload(unresolved),
-    }
+    artifacts = _artifact_payload(root, statuses, selected["outputArtifacts"])
+    incomplete = [item for item in artifacts if item["status"] != "ready"]
+    if incomplete:
+        if step == "tool":
+            checks_payload = [
+                {"id": item["artifact"].removeprefix("doctor:"), "status": item["status"]}
+                for item in incomplete
+                if item["artifact"].startswith("doctor:")
+            ]
+            return EXIT_RUN, _result(step, "run", "tool_checks_unresolved", checks_payload, artifacts)
+        return EXIT_RUN, _result(step, "run", "channel_outputs_incomplete", [], artifacts)
+
+    stale = [check for check in checks if check.id == "analytics_report" and check.status == "fail"]
+    if step == "tool" and len(stale) == 1:
+        return EXIT_SKIP, _result(
+            step,
+            "skip",
+            "tool_ready_analytics_report_stale",
+            [{"id": "analytics_report", "status": "fail"}],
+            artifacts,
+        )
+    reason = "tool_ready" if step == "tool" else "channel_ready"
+    return EXIT_SKIP, _result(step, "skip", reason, [], artifacts)
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
-    parser.add_argument("--step", choices=_STEPS, required=True)
+    parser.add_argument("--manifest", type=Path, default=Path(__file__).with_name("setup-chain-manifest.json"))
+    parser.add_argument("--step", choices=STEPS, required=True)
     parser.add_argument("--pretty", action="store_true")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    root = args.channel_dir.resolve()
     try:
-        code, result = evaluate(doctor.run_all_checks(args.channel_dir.resolve()), args.step)
+        manifest = load_manifest(args.manifest.resolve())
+        code, result = evaluate(root, doctor.run_all_checks(root), manifest, args.step)
+    except ManifestError as exc:
+        code = EXIT_ERROR
+        result = _result(args.step, "error", f"invalid manifest: {exc}", [], [])
     except (ConfigError, OSError, ValueError) as exc:
         code = EXIT_ERROR
-        result = {"step": args.step, "decision": "error", "reason": str(exc), "checks": []}
+        result = _result(args.step, "error", str(exc), [], [])
     json.dump(result, sys.stdout, ensure_ascii=False, indent=2 if args.pretty else None)
     sys.stdout.write("\n")
     return code

--- a/.claude/skills/setup/references/setup-chain-state.py
+++ b/.claude/skills/setup/references/setup-chain-state.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import stat
 import subprocess
 import sys
 from pathlib import Path
 from typing import TypedDict, cast
+
+from PIL import Image as PILImage
+from PIL import UnidentifiedImageError
 
 from youtube_automation.commands.system import doctor
 from youtube_automation.core.errors import ConfigError
@@ -36,7 +40,7 @@ TOOL_CHECK_IDS = (
     "client_secrets",
     "oauth_token",
 )
-CHANNEL_CHECK_IDS = ("ttp_wf_new_readiness", "initial_setup_readiness")
+CHANNEL_CHECK_IDS = ("channel_config", "ttp_wf_new_readiness", "initial_setup_readiness")
 TOOL_OUTPUT_ARTIFACTS = (
     *(f"doctor:{check_id}" for check_id in TOOL_CHECK_IDS[:-2]),
     "auth/client_secrets.json",
@@ -54,6 +58,7 @@ CHANNEL_OUTPUT_ARTIFACTS = (
     "config/schedule_config.json",
     "config/skills/suno.yaml",
     "config/skills/thumbnail.yaml",
+    "doctor:channel_config",
     "docs/channel/ttp-seed-confirmation.md",
     "docs/channel/competitor-branding-snapshot.json",
     "docs/plans/viewer-voice-analysis.md",
@@ -69,6 +74,10 @@ _ALLOWED_CHECK_STATUSES = frozenset({"ok", "info", "warn", "fail", "unknown"})
 _FILE_CHECK_IDS = {
     "auth/client_secrets.json": "client_secrets",
     "auth/token.json": "oauth_token",
+}
+_BRANDING_ARTIFACTS = {
+    "branding/icon.*": ({".png": "PNG"}, 1.0, 4 * 1024 * 1024),
+    "branding/banner.*": ({".png": "PNG", ".jpg": "JPEG", ".jpeg": "JPEG"}, 16 / 9, 6 * 1024 * 1024),
 }
 _STEP_KEYS = frozenset({"id", "skill", "prerequisiteArtifacts", "outputArtifacts", "approvalGate", "idempotency"})
 
@@ -186,6 +195,35 @@ def _git_status(root: Path) -> str:
     return "ready" if not result.stdout else "dirty"
 
 
+def _valid_branding_image(path: Path, formats: dict[str, str], expected_ratio: float, max_size: int) -> bool:
+    try:
+        metadata = path.lstat()
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_size == 0:
+            return False
+        if metadata.st_size > max_size:
+            return False
+        expected_format = formats.get(path.suffix.lower())
+        if expected_format is None:
+            return False
+        with PILImage.open(path) as image:
+            width, height = image.size
+            actual_format = image.format
+            image.verify()
+    except (OSError, UnidentifiedImageError):
+        return False
+    if actual_format != expected_format or width <= 0 or height <= 0:
+        return False
+    return abs(width / height - expected_ratio) <= 0.03
+
+
+def _branding_status(root: Path, artifact: str) -> str:
+    formats, expected_ratio, max_size = _BRANDING_ARTIFACTS[artifact]
+    candidates = sorted(root.glob(artifact))
+    if any(_valid_branding_image(path, formats, expected_ratio, max_size) for path in candidates):
+        return "ready"
+    return "invalid" if candidates else "missing"
+
+
 def _artifact_payload(root: Path, statuses: dict[str, str], artifacts: list[str]) -> list[ArtifactPayload]:
     payload: list[ArtifactPayload] = []
     for artifact in artifacts:
@@ -194,6 +232,8 @@ def _artifact_payload(root: Path, statuses: dict[str, str], artifacts: list[str]
             status = "ready" if check_status == "ok" else check_status
         elif artifact == "git:clean":
             status = _git_status(root)
+        elif artifact in _BRANDING_ARTIFACTS:
+            status = _branding_status(root, artifact)
         else:
             exists = any(path.is_file() for path in root.glob(artifact))
             check_id = _FILE_CHECK_IDS.get(artifact)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。
 - `refactor(setup)`: 排他的な `/setup --channel` を追加し、新規開設 Step 1〜10 の canonical contract と opening-only references / helpers の owner を setup へ移した。旧 `/channel-new` の opening trigger・Step 1〜10 は setup contract への互換入口として維持し、取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産も変更しない（#3983）。
 - `refactor(setup)`: GCP / OAuth / ADC bootstrap の正規入口を `/setup --tool` doctor wizard に一意化し、手動 script と Terraform 配布資産を `setup/references/` へ移して source / wheel / sdist / `yt-skills sync` の到達契約を維持する（#3984）。

--- a/tests/commands/system/test_setup_chain_state.py
+++ b/tests/commands/system/test_setup_chain_state.py
@@ -1,0 +1,203 @@
+"""Deterministic setup chain state and fail-closed manifest contracts."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.commands.system import doctor
+
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "setup" / "references" / "setup-chain-state.py"
+MANIFEST = REPO_ROOT / ".claude" / "skills" / "setup" / "references" / "setup-chain-manifest.json"
+
+
+def _load_state() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_chain_state_contract", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def state() -> ModuleType:
+    return _load_state()
+
+
+def _checks(state: ModuleType, **statuses: str) -> list[doctor.CheckResult]:
+    check_ids = (*state.TOOL_CHECK_IDS, *state.CHANNEL_CHECK_IDS)
+    return [
+        doctor.CheckResult(id=check_id, status=statuses.get(check_id, "ok"), message=check_id) for check_id in check_ids
+    ]
+
+
+def _write_file_artifacts(root: Path, artifacts: list[str]) -> None:
+    for artifact in artifacts:
+        if artifact.startswith(("doctor:", "git:")):
+            continue
+        path = root / artifact.replace("*", "png")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ready\n", encoding="utf-8")
+
+
+def _commit_workspace(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Setup Test", "-c", "user.email=setup@example.invalid", "commit", "-qm", "ready"],
+        cwd=root,
+        check=True,
+    )
+
+
+def test_channel_is_blocked_until_tool_prerequisites_are_complete(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    _write_file_artifacts(tmp_path, manifest["steps"][0]["outputArtifacts"])
+
+    code, result = state.evaluate(tmp_path, _checks(state, oauth_token="warn"), manifest, "channel")
+
+    assert (code, result["decision"], result["reason"]) == (
+        state.EXIT_BLOCKED,
+        "blocked",
+        "tool_prerequisites_incomplete",
+    )
+    assert {artifact["artifact"] for artifact in result["artifacts"] if artifact["status"] != "ready"} == {
+        "auth/token.json"
+    }
+
+
+def test_channel_runs_after_tool_and_skips_after_outputs_are_saved(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"])
+    checks = _checks(state)
+
+    run_code, run_result = state.evaluate(tmp_path, checks, manifest, "channel")
+    _write_file_artifacts(tmp_path, channel["outputArtifacts"])
+    _commit_workspace(tmp_path)
+    first_complete = state.evaluate(tmp_path, checks, manifest, "channel")
+    second_complete = state.evaluate(tmp_path, checks, manifest, "channel")
+
+    assert (run_code, run_result["decision"], run_result["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "channel_outputs_incomplete",
+    )
+    assert first_complete == second_complete
+    assert first_complete[0] == state.EXIT_SKIP
+    assert first_complete[1]["decision"] == "skip"
+    assert first_complete[1]["reason"] == "channel_ready"
+
+
+def test_channel_stays_run_when_initial_save_is_dirty(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    _commit_workspace(tmp_path)
+    (tmp_path / "config" / "channel" / "meta.json").write_text("changed\n", encoding="utf-8")
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert result["reason"] == "channel_outputs_incomplete"
+    assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {"git:clean"}
+
+
+def test_unrelated_informational_doctor_check_does_not_change_tool_decision(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    _write_file_artifacts(tmp_path, manifest["steps"][0]["outputArtifacts"])
+    checks = _checks(state)
+    checks.append(doctor.CheckResult(id="oauth_client_sharing", status="info", message="shared client available"))
+
+    code, result = state.evaluate(tmp_path, checks, manifest, "tool")
+
+    assert code == state.EXIT_SKIP
+    assert result["decision"] == "skip"
+    assert result["reason"] == "tool_ready"
+
+
+def _write_manifest(tmp_path: Path, payload: dict[str, object]) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "add_step",
+        "remove_step",
+        "reorder_steps",
+        "duplicate_step",
+        "unknown_step",
+        "prerequisite_drift",
+        "output_drift",
+        "approval_not_skipped",
+    ],
+)
+def test_manifest_mutations_fail_closed(tmp_path: Path, state: ModuleType, mutation: str) -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    mutated = copy.deepcopy(manifest)
+    steps = mutated["steps"]
+    if mutation == "add_step":
+        steps.append(copy.deepcopy(steps[-1]))
+        steps[-1]["id"] = "extra"
+    elif mutation == "remove_step":
+        steps.pop()
+    elif mutation == "reorder_steps":
+        steps.reverse()
+    elif mutation == "duplicate_step":
+        steps[1]["id"] = "tool"
+    elif mutation == "unknown_step":
+        steps[1]["id"] = "research"
+    elif mutation == "prerequisite_drift":
+        steps[1]["prerequisiteArtifacts"] = steps[1]["prerequisiteArtifacts"][:-1]
+    elif mutation == "output_drift":
+        steps[1]["outputArtifacts"].append("docs/channel/unowned.md")
+    elif mutation == "approval_not_skipped":
+        steps[1]["approvalGate"]["skip"] = False
+
+    with pytest.raises(state.ManifestError):
+        state.load_manifest(_write_manifest(tmp_path, mutated))
+
+
+def test_manifest_rejects_unknown_schema_and_mixed_approval_fields(tmp_path: Path, state: ModuleType) -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    unknown = copy.deepcopy(manifest)
+    unknown["steps"][0]["unexpected"] = True
+    mixed = copy.deepcopy(manifest)
+    mixed["steps"][0]["approvalGate"]["enabled"] = False
+
+    with pytest.raises(state.ManifestError):
+        state.load_manifest(_write_manifest(tmp_path / "unknown", unknown))
+    with pytest.raises(state.ManifestError):
+        state.load_manifest(_write_manifest(tmp_path / "mixed", mixed))
+
+
+def test_invalid_manifest_cli_errors_before_doctor_execution(tmp_path: Path) -> None:
+    invalid = _write_manifest(tmp_path, {"chainId": "setup", "steps": []})
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--channel-dir", str(tmp_path), "--manifest", str(invalid), "--step", "tool"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "error"
+    assert payload["reason"].startswith("invalid manifest:")
+    assert payload["artifacts"] == []

--- a/tests/commands/system/test_setup_chain_state.py
+++ b/tests/commands/system/test_setup_chain_state.py
@@ -124,6 +124,98 @@ def test_channel_stays_run_when_initial_save_is_dirty(tmp_path: Path, state: Mod
     assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {"git:clean"}
 
 
+def test_channel_does_not_inherit_clean_ancestor_repository(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    parent = tmp_path / "parent"
+    channel_root = parent / "channel"
+    parent.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=parent, check=True)
+    (parent / ".gitignore").write_text("channel/\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore"], cwd=parent, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Setup Test", "-c", "user.email=setup@example.invalid", "commit", "-qm", "parent"],
+        cwd=parent,
+        check=True,
+    )
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(channel_root, tool["outputArtifacts"] + channel["outputArtifacts"])
+
+    code, result = state.evaluate(channel_root, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "git:clean": "root_mismatch"
+    }
+
+
+def test_channel_does_not_treat_unborn_repository_as_saved(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "git:clean": "unborn"
+    }
+
+
+def test_channel_does_not_accept_nested_directory_inside_committed_repository(
+    tmp_path: Path, state: ModuleType
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    repo = tmp_path / "repo"
+    channel_root = repo / "nested-channel"
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(channel_root, tool["outputArtifacts"] + channel["outputArtifacts"])
+    _commit_workspace(repo)
+
+    code, result = state.evaluate(channel_root, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "git:clean": "root_mismatch"
+    }
+
+
+def test_channel_does_not_accept_ignored_setup_output_as_saved(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    ignored_output = "config/channel/meta.json"
+    (tmp_path / ".gitignore").write_text(f"/{ignored_output}\n", encoding="utf-8")
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "git:clean": "unsaved"
+    }
+
+
+def test_channel_does_not_accept_untracked_file_after_initial_save(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    _commit_workspace(tmp_path)
+    (tmp_path / "untracked.txt").write_text("not saved\n", encoding="utf-8")
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "git:clean": "dirty"
+    }
+
+
 @pytest.mark.parametrize("channel_config_status", ["fail", "warn"])
 def test_channel_does_not_skip_when_channel_config_is_unresolved(
     tmp_path: Path, state: ModuleType, channel_config_status: str
@@ -254,7 +346,8 @@ def test_channel_branding_glob_rejects_invalid_matches(
 
     assert code == state.EXIT_RUN
     assert result["decision"] == "run"
-    assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {f"branding/{kind}.*"}
+    statuses = {item["artifact"]: item["status"] for item in result["artifacts"]}
+    assert statuses[f"branding/{kind}.*"] == "invalid"
 
 
 @pytest.mark.parametrize(
@@ -283,7 +376,8 @@ def test_channel_branding_glob_rejects_unsupported_valid_image_formats(
 
     assert code == state.EXIT_RUN
     assert result["decision"] == "run"
-    assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {f"branding/{kind}.*"}
+    statuses = {item["artifact"]: item["status"] for item in result["artifacts"]}
+    assert statuses[f"branding/{kind}.*"] == "invalid"
 
 
 def test_channel_branding_globs_accept_valid_png_and_jpeg(tmp_path: Path, state: ModuleType) -> None:
@@ -302,6 +396,60 @@ def test_channel_branding_globs_accept_valid_png_and_jpeg(tmp_path: Path, state:
         item["artifact"]: item["status"] for item in result["artifacts"] if item["artifact"].startswith("branding/")
     }
     assert branding == {"branding/icon.*": "ready", "branding/banner.*": "ready"}
+
+
+@pytest.mark.parametrize(
+    ("kind", "size"),
+    [
+        ("icon", (799, 800)),
+        ("icon", (801, 800)),
+        ("banner", (1599, 900)),
+        ("banner", (1601, 900)),
+        ("banner", (1800, 1000)),
+    ],
+)
+def test_channel_branding_rejects_near_ratio_misses(
+    tmp_path: Path, state: ModuleType, kind: str, size: tuple[int, int]
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    PILImage.new("RGB", size, color=(40, 80, 120)).save(tmp_path / "branding" / f"{kind}.png", format="PNG")
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    statuses = {item["artifact"]: item["status"] for item in result["artifacts"]}
+    assert statuses[f"branding/{kind}.*"] == "invalid"
+
+
+@pytest.mark.parametrize(
+    ("icon_size", "banner_size"),
+    [
+        ((64, 64), (16, 9)),
+        ((800, 800), (2048, 1152)),
+        ((1200, 1200), (2560, 1440)),
+    ],
+)
+def test_channel_branding_accepts_exact_ratio_at_multiple_resolutions(
+    tmp_path: Path,
+    state: ModuleType,
+    icon_size: tuple[int, int],
+    banner_size: tuple[int, int],
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    PILImage.new("RGB", icon_size, color=(40, 80, 120)).save(tmp_path / "branding" / "icon.png", format="PNG")
+    PILImage.new("RGB", banner_size, color=(120, 80, 40)).save(tmp_path / "branding" / "banner.png", format="PNG")
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_SKIP
+    assert result["decision"] == "skip"
 
 
 def test_unrelated_informational_doctor_check_does_not_change_tool_decision(tmp_path: Path, state: ModuleType) -> None:

--- a/tests/commands/system/test_setup_chain_state.py
+++ b/tests/commands/system/test_setup_chain_state.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from PIL import Image as PILImage
 
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.system import doctor
@@ -43,6 +44,16 @@ def _checks(state: ModuleType, **statuses: str) -> list[doctor.CheckResult]:
 def _write_file_artifacts(root: Path, artifacts: list[str]) -> None:
     for artifact in artifacts:
         if artifact.startswith(("doctor:", "git:")):
+            continue
+        if artifact == "branding/icon.*":
+            path = root / "branding" / "icon.png"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            PILImage.new("RGB", (800, 800), color=(40, 80, 120)).save(path, format="PNG")
+            continue
+        if artifact == "branding/banner.*":
+            path = root / "branding" / "banner.png"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            PILImage.new("RGB", (2048, 1152), color=(120, 80, 40)).save(path, format="PNG")
             continue
         path = root / artifact.replace("*", "png")
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -111,6 +122,186 @@ def test_channel_stays_run_when_initial_save_is_dirty(tmp_path: Path, state: Mod
     assert result["decision"] == "run"
     assert result["reason"] == "channel_outputs_incomplete"
     assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {"git:clean"}
+
+
+@pytest.mark.parametrize("channel_config_status", ["fail", "warn"])
+def test_channel_does_not_skip_when_channel_config_is_unresolved(
+    tmp_path: Path, state: ModuleType, channel_config_status: str
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(
+        tmp_path,
+        _checks(state, channel_config=channel_config_status),
+        manifest,
+        "channel",
+    )
+
+    assert (code, result["decision"], result["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "channel_outputs_incomplete",
+    )
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "doctor:channel_config": channel_config_status
+    }
+
+
+def test_channel_does_not_skip_when_channel_config_check_is_missing(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    _commit_workspace(tmp_path)
+    checks = [check for check in _checks(state) if check.id != "channel_config"]
+
+    code, result = state.evaluate(tmp_path, checks, manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "doctor:channel_config": "missing"
+    }
+
+
+def test_present_but_invalid_channel_config_does_not_skip(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    (tmp_path / "config" / "channel" / "meta.json").write_text("not-json\n", encoding="utf-8")
+    _commit_workspace(tmp_path)
+    real_config_check = doctor.check_channel_config(tmp_path)
+    checks = [check for check in _checks(state) if check.id != "channel_config"] + [real_config_check]
+
+    code, result = state.evaluate(tmp_path, checks, manifest, "channel")
+
+    assert real_config_check.status == "fail"
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"]: item["status"] for item in result["artifacts"] if item["status"] != "ready"} == {
+        "doctor:channel_config": "fail"
+    }
+
+
+def _write_valid_branding(root: Path, *, banner_format: str = "PNG", banner_suffix: str = ".png") -> None:
+    branding = root / "branding"
+    branding.mkdir(parents=True, exist_ok=True)
+    PILImage.new("RGB", (800, 800), color=(40, 80, 120)).save(branding / "icon.png", format="PNG")
+    PILImage.new("RGB", (2048, 1152), color=(120, 80, 40)).save(
+        branding / f"banner{banner_suffix}", format=banner_format
+    )
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["icon", "banner"],
+)
+@pytest.mark.parametrize(
+    ("suffix", "mutation"),
+    [
+        (".txt", "text"),
+        (".png", "empty"),
+        (".png", "corrupt"),
+        (".png", "directory"),
+        (".png", "symlink"),
+        (".png", "broken_symlink"),
+        (".png.backup", "false_positive"),
+        (".png", "wrong_ratio"),
+        (".png", "oversize"),
+        (".png", "format_mismatch"),
+    ],
+)
+def test_channel_branding_glob_rejects_invalid_matches(
+    tmp_path: Path, state: ModuleType, kind: str, suffix: str, mutation: str
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    valid = tmp_path / "branding" / f"{kind}.png"
+    valid.unlink()
+    invalid = tmp_path / "branding" / f"{kind}{suffix}"
+    if mutation == "text":
+        invalid.write_text("not an image\n", encoding="utf-8")
+    elif mutation == "empty":
+        invalid.write_bytes(b"")
+    elif mutation in {"corrupt", "false_positive"}:
+        invalid.write_bytes(b"\x89PNG\r\n\x1a\ntruncated")
+    elif mutation == "directory":
+        invalid.mkdir()
+    elif mutation == "symlink":
+        target = tmp_path / f"valid-{kind}.png"
+        size = (800, 800) if kind == "icon" else (2048, 1152)
+        PILImage.new("RGB", size, color=(40, 80, 120)).save(target, format="PNG")
+        invalid.symlink_to(target)
+    elif mutation == "broken_symlink":
+        invalid.symlink_to(tmp_path / "missing-image.png")
+    elif mutation == "wrong_ratio":
+        PILImage.new("RGB", (800, 600), color=(40, 80, 120)).save(invalid, format="PNG")
+    elif mutation == "oversize":
+        size = (800, 800) if kind == "icon" else (2048, 1152)
+        max_size = 4 * 1024 * 1024 if kind == "icon" else 6 * 1024 * 1024
+        PILImage.new("RGB", size, color=(40, 80, 120)).save(invalid, format="PNG")
+        with invalid.open("ab") as stream:
+            stream.write(b"x" * max_size)
+    elif mutation == "format_mismatch":
+        size = (800, 800) if kind == "icon" else (2048, 1152)
+        PILImage.new("RGB", size, color=(40, 80, 120)).save(invalid, format="JPEG")
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {f"branding/{kind}.*"}
+
+
+@pytest.mark.parametrize(
+    ("kind", "suffix", "image_format", "size"),
+    [
+        ("icon", ".jpg", "JPEG", (800, 800)),
+        ("banner", ".webp", "WEBP", (2048, 1152)),
+    ],
+)
+def test_channel_branding_glob_rejects_unsupported_valid_image_formats(
+    tmp_path: Path,
+    state: ModuleType,
+    kind: str,
+    suffix: str,
+    image_format: str,
+    size: tuple[int, int],
+) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    (tmp_path / "branding" / f"{kind}.png").unlink()
+    PILImage.new("RGB", size, color=(40, 80, 120)).save(tmp_path / "branding" / f"{kind}{suffix}", format=image_format)
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_RUN
+    assert result["decision"] == "run"
+    assert {item["artifact"] for item in result["artifacts"] if item["status"] != "ready"} == {f"branding/{kind}.*"}
+
+
+def test_channel_branding_globs_accept_valid_png_and_jpeg(tmp_path: Path, state: ModuleType) -> None:
+    manifest = state.load_manifest(MANIFEST)
+    tool, channel = manifest["steps"]
+    _write_file_artifacts(tmp_path, tool["outputArtifacts"] + channel["outputArtifacts"])
+    (tmp_path / "branding" / "banner.png").unlink()
+    _write_valid_branding(tmp_path, banner_format="JPEG", banner_suffix=".jpg")
+    _commit_workspace(tmp_path)
+
+    code, result = state.evaluate(tmp_path, _checks(state), manifest, "channel")
+
+    assert code == state.EXIT_SKIP
+    assert result["decision"] == "skip"
+    branding = {
+        item["artifact"]: item["status"] for item in result["artifacts"] if item["artifact"].startswith("branding/")
+    }
+    assert branding == {"branding/icon.*": "ready", "branding/banner.*": "ready"}
 
 
 def test_unrelated_informational_doctor_check_does_not_change_tool_decision(tmp_path: Path, state: ModuleType) -> None:

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -184,6 +184,7 @@ def test_setup_chain_manifest_declares_tool_then_channel_with_machine_detectable
     assert {
         "config/channel/meta.json",
         "config/channel/analytics.json",
+        "doctor:channel_config",
         "docs/channel/ttp-seed-confirmation.md",
         "docs/channel/competitor-branding-snapshot.json",
         "docs/channel/personas/persona-definition.md",

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -88,12 +88,23 @@ def test_setup_skill_declares_exclusive_tool_channel_modes_and_default_chain() -
     assert "mode flag（`--tool` / `--channel`）の出現数" in text
     assert "2 個以上なら、同じ flag の重複を含めて排他違反として停止" in text
     assert "1 個なら対応する reference を読み、その一段だけを実行する" in text
-    assert "0 個なら chain manifest に従い tool を状態判定付きで進める" in text
+    assert "0 個なら chain manifest に従い `tool` → `channel` を状態判定付きで進める" in text
     assert "| `--tool` | `references/tool.md` |" in text
     assert "| `--channel` | `references/channel-mode.md` |" in text
 
 
-@pytest.mark.parametrize("arguments", [("--tool", "--channel"), ("--channel", "--channel")])
+def test_setup_explicit_modes_never_enter_the_default_chain() -> None:
+    text = _SETUP_SKILL.read_text(encoding="utf-8")
+
+    assert "明示 `--tool` / `--channel` はこの一括実行へ入らない" in text
+    assert "もう一段を暗黙実行しない" in text
+    assert "各 reference 内の不可逆操作・外部反映の承認 gate" in text
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [("--tool", "--channel"), ("--tool", "--tool"), ("--channel", "--channel")],
+)
 def test_setup_mode_guard_rejects_multiple_modes_without_artifact_mutation(
     tmp_path: Path,
     arguments: tuple[str, ...],
@@ -154,70 +165,99 @@ def test_setup_tool_is_the_canonical_gcp_oauth_adc_bootstrap_entrypoint() -> Non
         assert contract in tool
 
 
-def test_setup_chain_manifest_declares_exactly_one_tool_step() -> None:
+def test_setup_chain_manifest_declares_tool_then_channel_with_machine_detectable_artifacts() -> None:
     manifest = json.loads(_SETUP_CHAIN_MANIFEST.read_text(encoding="utf-8"))
 
-    assert manifest == {
-        "chainId": "setup",
-        "steps": [
-            {
-                "id": "tool",
-                "skill": "setup",
-                "prerequisiteArtifacts": [],
-                "outputArtifacts": [],
-                "approvalGate": {
-                    "skip": True,
-                    "configPath": "workflow.setup.skip_approvals.tool",
-                },
-                "idempotency": {"script": "references/setup-chain-state.py"},
-            }
-        ],
-    }
+    assert manifest["chainId"] == "setup"
+    assert [step["id"] for step in manifest["steps"]] == ["tool", "channel"]
+    tool, channel = manifest["steps"]
+    assert tool["prerequisiteArtifacts"] == []
+    assert channel["prerequisiteArtifacts"] == tool["outputArtifacts"]
+    assert {
+        "doctor:automation_package",
+        "doctor:skills_synced",
+        "doctor:gcp_project",
+        "doctor:adc",
+        "auth/client_secrets.json",
+        "auth/token.json",
+    }.issubset(tool["outputArtifacts"])
+    assert {
+        "config/channel/meta.json",
+        "config/channel/analytics.json",
+        "docs/channel/ttp-seed-confirmation.md",
+        "docs/channel/competitor-branding-snapshot.json",
+        "docs/channel/personas/persona-definition.md",
+        "branding/icon.*",
+        "branding/banner.*",
+        "doctor:ttp_wf_new_readiness",
+        "git:clean",
+    }.issubset(channel["outputArtifacts"])
+    assert all(step["approvalGate"]["skip"] is True for step in manifest["steps"])
+    assert {step["idempotency"]["script"] for step in manifest["steps"]} == {"references/setup-chain-state.py"}
 
 
-def test_setup_chain_state_runs_unresolved_tool_and_skips_ready_tool() -> None:
+def test_setup_chain_state_runs_unresolved_tool_and_skips_ready_tool(tmp_path: Path) -> None:
     state = _load_setup_chain_state()
-    unresolved = [doctor.CheckResult(id="uv", status="fail", message="uv missing")]
-    ready = [doctor.CheckResult(id="uv", status="ok", message="uv ready")]
+    manifest = state.load_manifest(_SETUP_CHAIN_MANIFEST)
+    unresolved = [
+        doctor.CheckResult(id=check_id, status="fail" if check_id == "uv" else "ok", message=check_id)
+        for check_id in state.TOOL_CHECK_IDS
+    ]
+    ready = [doctor.CheckResult(id=check_id, status="ok", message=check_id) for check_id in state.TOOL_CHECK_IDS]
+    for artifact in manifest["steps"][0]["outputArtifacts"]:
+        if not artifact.startswith("doctor:"):
+            path = tmp_path / artifact
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("ready\n", encoding="utf-8")
 
-    run_code, run_result = state.evaluate(unresolved, "tool")
-    skip_code, skip_result = state.evaluate(ready, "tool")
+    run_code, run_result = state.evaluate(tmp_path, unresolved, manifest, "tool")
+    skip_code, skip_result = state.evaluate(tmp_path, ready, manifest, "tool")
 
     assert (run_code, run_result["decision"], run_result["reason"]) == (
         state.EXIT_RUN,
         "run",
-        "setup_checks_unresolved",
+        "tool_checks_unresolved",
     )
     assert run_result["checks"] == [{"id": "uv", "status": "fail"}]
     assert (skip_code, skip_result["decision"], skip_result["reason"]) == (
         state.EXIT_SKIP,
         "skip",
-        "setup_ready",
+        "tool_ready",
     )
     assert skip_result["checks"] == []
 
 
-def test_setup_chain_state_preserves_stale_analytics_completion_exception() -> None:
+def test_setup_chain_state_preserves_stale_analytics_completion_exception(tmp_path: Path) -> None:
     state = _load_setup_chain_state()
-    checks = [
-        doctor.CheckResult(id="uv", status="ok", message="uv ready"),
+    manifest = state.load_manifest(_SETUP_CHAIN_MANIFEST)
+    checks = [doctor.CheckResult(id=check_id, status="ok", message=check_id) for check_id in state.TOOL_CHECK_IDS]
+    checks.append(
         doctor.CheckResult(id="analytics_report", status="fail", message="stale report"),
-    ]
+    )
+    for artifact in manifest["steps"][0]["outputArtifacts"]:
+        if not artifact.startswith("doctor:"):
+            path = tmp_path / artifact
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("ready\n", encoding="utf-8")
 
-    code, result = state.evaluate(checks, "tool")
+    code, result = state.evaluate(tmp_path, checks, manifest, "tool")
 
     assert code == state.EXIT_SKIP
     assert result["decision"] == "skip"
-    assert result["reason"] == "setup_ready_analytics_report_stale"
+    assert result["reason"] == "tool_ready_analytics_report_stale"
     assert result["checks"] == [{"id": "analytics_report", "status": "fail"}]
 
 
-def test_setup_chain_state_is_idempotent_for_the_same_doctor_state() -> None:
+def test_setup_chain_state_is_idempotent_for_the_same_doctor_state(tmp_path: Path) -> None:
     state = _load_setup_chain_state()
-    checks = [doctor.CheckResult(id="oauth_token", status="warn", message="login required")]
+    manifest = state.load_manifest(_SETUP_CHAIN_MANIFEST)
+    checks = [
+        doctor.CheckResult(id=check_id, status="warn" if check_id == "oauth_token" else "ok", message=check_id)
+        for check_id in state.TOOL_CHECK_IDS
+    ]
 
-    first = state.evaluate(checks, "tool")
-    second = state.evaluate(checks, "tool")
+    first = state.evaluate(tmp_path, checks, manifest, "tool")
+    second = state.evaluate(tmp_path, checks, manifest, "tool")
 
     assert first == second
 

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -185,6 +185,14 @@ assert "wheel-identity-check" not in legacy._cache
     distributed_references = downstream / ".claude" / "skills" / "setup" / "references"
     channel_mode = distributed_references / "channel-mode.md"
     assert channel_mode.is_file()
+    setup_manifest = distributed_references / "setup-chain-manifest.json"
+    setup_state = distributed_references / "setup-chain-state.py"
+    assert setup_manifest.is_file()
+    assert setup_state.is_file()
+    assert os.access(setup_state, os.X_OK)
+    state_help = _run(python, setup_state, "--help", cwd=downstream, env=clean_env)
+    assert state_help.returncode == 0, state_help.stderr
+    assert "--step {tool,channel}" in state_help.stdout
     opening_assets = {
         "new-channel-bootstrap.md",
         "ttp-seed-and-duration.md",
@@ -288,6 +296,17 @@ def test_candidate_sdist_contains_setup_channel_owner_once(tmp_path: Path) -> No
         assert channel_new_matches == []
     assert any(str(path).endswith("/.claude/skills/setup/references/channel-mode.md") for path in names)
     assert any(str(path).endswith("/.claude/skills/setup/references/setup-mode-guard.py") for path in names)
+    manifest_members = [
+        member
+        for member in members
+        if member.name.endswith("/.claude/skills/setup/references/setup-chain-manifest.json")
+    ]
+    state_members = [
+        member for member in members if member.name.endswith("/.claude/skills/setup/references/setup-chain-state.py")
+    ]
+    assert len(manifest_members) == 1
+    assert len(state_members) == 1
+    assert state_members[0].mode & 0o111
     for relative in _CHANNEL_NEW_SHARED_ASSETS:
         matches = [
             member for member in members if member.name.endswith(f"/.claude/skills/channel-new/references/{relative}")


### PR DESCRIPTION
## Summary
- フラグなし `/setup` を strict manifest の `tool` → `channel` 2段 chain にする
- doctor・成果物・git 保存状態から `run` / `skip` / `blocked` / `error` を決定し、前提未達や途中失敗で後段を止める
- explicit `--tool` / `--channel` の隔離、stale analytics 例外、source / wheel / sdist / installed 配布契約を維持する

## Acceptance evidence
- success / failure / blocked / resume / idempotency の unit・subprocess test
- manifest add / remove / reorder / duplicate / unknown、prerequisite / output drift、approval gate の mutation test
- mode 排他違反時の no-write test と explicit mode 非 chain 契約
- packaged state script の executable bit、manifest、下流 `.agents/skills` link、非 editable install smoke
- 初回親レビューで実 doctor に存在しない `env_file` と合法な `info` status の反例を検出し修正
- fix round 1: `doctor:channel_config` を channel 完了契約へ追加し、fail / warn / missing と実際の不正 config が `channel_ready` にならないことを固定
- fix round 1: icon / banner の通常ファイル、許可拡張子と実形式、decode / verify、非空、上限サイズを fail-closed 検証し、txt・空・破損・directory・symlink・broken symlink・偽 suffix・比率・oversize・形式不一致を拒否
- fix round 2: `git:clean` は resolved git top-level と channel root の一致、HEAD の存在、clean status、全channel成果物の HEAD 保存を要求し、ancestor / nested repo、ignored output、unborn repo、dirty / untracked を拒否
- fix round 2: icon は `width == height`、banner は `width * 9 == height * 16` の整数比較で厳密判定し、799x800 / 801x800 / 1599x900 / 1601x900 / 1800x1000 を拒否、複数の正確な解像度を受理

## Verification
- `nix develop --command uv run pytest tests/commands/system/test_setup_chain_state.py tests/commands/system/test_setup_skill.py tests/commands/system/test_doctor.py -q` — 463 passed
- clean clone: `nix develop --command uv run pytest tests/repo -q` — 1265 passed, 1 skipped
- clean clone: `nix develop --command uv run pytest` — 8481 passed, 1 skipped
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command bash .github/scripts/any-usage-gate.sh`
- `nix develop --command uv run yt-skills lint`
- clean clone: `nix develop --command uv sync --frozen`
- clean clone: `nix develop --command uv build --offline --wheel --sdist --out-dir <temp-dir>`
- clean clone: `YTA_CANDIDATE_WHEEL=<temp-wheel> nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q` — 2 passed

Closes #3988