### PR TITLE
refactor(skills): 新規開設誘導を setup に移す (#3985)

### DIFF
--- a/.claude/skills/audience-persona-design/SKILL.md
+++ b/.claude/skills/audience-persona-design/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when ターゲット視聴者を第一ペルソナとして設
 
 入口で実行コンテキストを次のどちらかに確定し、Phase 5 の `/viewing-scene` まで同じ値を引き継ぐ。
 
-- **新規開設（公開前）**: `/channel-new` Step 7 から呼ばれた経路。`docs/plans/viewer-voice-analysis.md`、`docs/channel/ttp-seed-confirmation.md`、`docs/channel/competitor-branding-snapshot.json` を競合 / TTP 入力として扱う。任意の `/benchmark` 成果物や、自チャンネル公開後の `reports/analysis_*.md` は前提にしない
+- **新規開設（公開前）**: `/setup --channel` Step 7 から呼ばれた経路（`.claude/skills/setup/references/persona-branding-readiness.md`）。`docs/plans/viewer-voice-analysis.md`、`docs/channel/ttp-seed-confirmation.md`、`docs/channel/competitor-branding-snapshot.json` を競合 / TTP 入力として扱う。任意の `/benchmark` 成果物や、自チャンネル公開後の `reports/analysis_*.md` は前提にしない
 - **公開後**: 通常の見直し経路。従来どおり viewer-voice、benchmark、Web 調査、自チャンネル Analytics を入力にする
 
 ## 完了条件
@@ -53,7 +53,7 @@ description: "Use when ターゲット視聴者を第一ペルソナとして設
 
 ### 停止する fail
 
-- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/channel-new`、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
+- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/setup --channel` Step 4、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
 - `docs/plans/viewer-voice-analysis.md` が無い → 前工程 `/viewer-voice` を案内して停止する
 
 ## 実行フロー
@@ -165,7 +165,7 @@ options:
 | WebSearch 不可 | 検索結果が取得できない | 手動入力で代替するか、当該分析をスキップする |
 | viewer-voice 未実施 | `docs/plans/viewer-voice-analysis.md` が無い | `/viewer-voice` を先に実行するよう案内して停止する |
 | viewing-scene 未反映 | `docs/plans/viewing-scene-matrix.md` が無い | 暫定 `persona-definition.md` 保存後に `/viewing-scene` を実行し、結果を反映して最終化する |
-| 公開前入力不在 | 新規開設（公開前）で競合 / TTP / viewer-voice 成果物が不足 | `/channel-new` Step 5 または Step 7 の該当前工程へ戻る |
+| 公開前入力不在 | 新規開設（公開前）で競合 / TTP / viewer-voice 成果物が不足 | `/setup --channel` Step 5 または Step 7 の該当前工程へ戻る |
 | 公開後入力不在 | 公開後に `data/` のベンチマーク/Analytics スナップショットが無い | 先に `/benchmark`・`/analytics --collect` 等を実行して入力を用意 |
 
 ## 関連ファイル

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -39,8 +39,8 @@ Step 1 のスクリプトが exit 0 で終了して `docs/benchmarks/*.md` と `
 
 ### 停止する fail
 
-- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/channel-new`、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
-- `config/channel/analytics.json::benchmark.channels` に承認済みベンチマークチャンネルが設定されていない → `/channel-new` / `/discover-competitors` を案内して停止する
+- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/setup --channel` Step 4、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
+- `config/channel/analytics.json::benchmark.channels` に承認済みベンチマークチャンネルが設定されていない → `/setup --channel` Step 5（`.claude/skills/setup/references/ttp-seed-and-duration.md`）/ `/discover-competitors` を案内して停止する
 - `auth/token.json` が存在しない、または OAuth 認証が無効 → `/setup` を案内して停止する
 
 ### 許容する fail

--- a/.claude/skills/discover-competitors/SKILL.md
+++ b/.claude/skills/discover-competitors/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when YouTube Data API で追加競合候補を自動発掘・�
 
 ## 前後工程
 
-- `前工程`: `/benchmark`, `/channel-new`
+- `前工程`: `/benchmark`, `/setup`
 - `後工程`: `/viewer-voice`, `/benchmark`
 
 ## Overview
@@ -18,7 +18,7 @@ description: "Use when YouTube Data API で追加競合候補を自動発掘・�
 - 出力: ランキング付き Markdown + 同名 CSV（スコア内訳列付き）
 - 想定時間: 5 分以内（初回または強制更新時の API quota 約 660 units。24 時間以内の同一検索条件はキャッシュを利用）
 
-`/channel-new` の標準フローでは実行しない。TTP 対象確認後に追加の競合候補を広げたい場合や、複数のニッチ仮説を
+前工程の `/setup` は `/setup --channel` Step 6（`.claude/skills/setup/references/persona-branding-readiness.md`）を指す。標準フローでは本スキルを実行せず、必要性を確認して委譲する。TTP 対象確認後に追加の競合候補を広げたい場合や、複数のニッチ仮説を
 並行検証したい場合に、このスキルを任意で走らせる。
 
 ## 完了条件
@@ -80,7 +80,7 @@ Step 3 の実行で出力ペア（Markdown ランキング + 同名 CSV）を生
 |--------|--------|---------------|
 | **既存チャンネル**で競合再発掘 | チャンネル config | `config/channel/content.json` の `genre` / `tags.base` / `descriptions.perfect_for` |
 | **既存チャンネル**で類似帯探索 | 既存ベンチマーク | `config/channel/analytics.json` の `benchmark.channels` を YouTube で開いてタイトル頻出語を抽出 |
-| **新規チャンネル企画** | `/channel-new` の TTP メモと初期 config | `config/channel/content.json::genre.{primary,style,context}` / `tags.base` / TTP メモ内の用途・シーン語彙 |
+| **新規チャンネル企画** | `/setup --channel` Step 1/4/5 の TTP メモと初期 config | `config/channel/content.json::genre.{primary,style,context}` / `tags.base` / TTP メモ内の用途・シーン語彙 |
 | **完全に手探り** | ユーザー宣言 | 「夜カフェ系の lo-fi」のような自然文を Claude が分解 |
 
 config からの抽出例（rjn）:
@@ -206,6 +206,6 @@ subagent へは次を具体値で渡す:
 
 ## Cross References
 
-- `/channel-new`: TTP 対象確認と初期 config 生成。追加競合発掘が必要な場合に本スキルへ委譲
+- `/setup --channel`: TTP 対象確認と初期 config 生成。Step 6 で追加競合発掘が必要な場合に本スキルへ委譲
 - `/benchmark`: 発掘済みチャンネルのベンチマークデータ収集
 - `/channel-new` 分析モード: 収集データの徹底分析

--- a/.claude/skills/discover-competitors/SKILL.md
+++ b/.claude/skills/discover-competitors/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when YouTube Data API で追加競合候補を自動発掘・�
 
 ## 前後工程
 
-- `前工程`: `/benchmark`, `/setup`
+- `前工程`: `/benchmark`, `/setup --channel`
 - `後工程`: `/viewer-voice`, `/benchmark`
 
 ## Overview
@@ -18,7 +18,7 @@ description: "Use when YouTube Data API で追加競合候補を自動発掘・�
 - 出力: ランキング付き Markdown + 同名 CSV（スコア内訳列付き）
 - 想定時間: 5 分以内（初回または強制更新時の API quota 約 660 units。24 時間以内の同一検索条件はキャッシュを利用）
 
-前工程の `/setup` は `/setup --channel` Step 6（`.claude/skills/setup/references/persona-branding-readiness.md`）を指す。標準フローでは本スキルを実行せず、必要性を確認して委譲する。TTP 対象確認後に追加の競合候補を広げたい場合や、複数のニッチ仮説を
+このスキルの前工程は `/setup --channel` Step 6（`.claude/skills/setup/references/persona-branding-readiness.md`）を指す。標準フローでは本スキルを実行せず、必要性を確認して委譲する。TTP 対象確認後に追加の競合候補を広げたい場合や、複数のニッチ仮説を
 並行検証したい場合に、このスキルを任意で走らせる。
 
 ## 完了条件
@@ -46,7 +46,7 @@ Step 3 の実行で出力ペア（Markdown ランキング + 同名 CSV）を生
 
 ### 停止する fail
 
-- 実行場所がチャンネルリポジトリ（`CHANNEL_DIR`）配下ではない → `/channel-new` を案内して停止する
+- 実行場所がチャンネルリポジトリ（`CHANNEL_DIR`）配下ではない → 新規・未作成チャンネルは `/setup --channel`、既存チャンネルの取り込みは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
 - `auth/token.json` が存在しない、または OAuth 認証が無効 → `/setup` の OAuth 認証を案内して停止する
 
 ### 許容する fail

--- a/.claude/skills/market-research/SKILL.md
+++ b/.claude/skills/market-research/SKILL.md
@@ -94,4 +94,4 @@ TTP 入替候補は、現行 TTP より優れると観測できた軸と劣る�
 - `/discover-competitors` — 追加競合を API で広く発掘・ランキング化する場合
 - `/benchmark` — 承認済み候補の動画・サムネイルデータを収集する場合
 - `/channel-new` 分析モード — 収集済み benchmark / comments を詳細分析する場合
-- `/channel-new` — 初回 TTP 確認と channel config 生成を行う場合
+- `/setup --channel` Step 1/4/5（`.claude/skills/setup/references/new-channel-bootstrap.md` / `ttp-seed-and-duration.md`）— 初回 TTP 確認と channel config 生成を行う場合

--- a/.claude/skills/viewer-voice/SKILL.md
+++ b/.claude/skills/viewer-voice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: viewer-voice
-description: "Use when 競合コメントの収集・分析で視聴者インサイトを抽出するとき。「視聴者の声」「コメント分析」「ユーザーリサーチ」で発動。/audience-persona-design の必須入力（viewer-voice-analysis.md）を作る。新規開設では /channel-new Step 7 で必須、公開後の再分析では任意"
+description: "Use when 競合コメントの収集・分析で視聴者インサイトを抽出するとき。「視聴者の声」「コメント分析」「ユーザーリサーチ」で発動。/audience-persona-design の必須入力（viewer-voice-analysis.md）を作る。新規開設では /setup --channel Step 7 で必須、公開後の再分析では任意"
 ---
 
 ## 前後工程
@@ -12,7 +12,7 @@ description: "Use when 競合コメントの収集・分析で視聴者インサ
 
 承認済みベンチマークチャンネルの1万再生以上の動画から YouTube Data API でコメントを取得し、
 感情・利用シーン・リクエスト・キャラ愛着の4軸で分析する。
-`/setup --channel` の新規開設モードでは Step 7 の必須前工程として実行する。その互換入口である `/channel-new` の新規開設モードでも同じ契約を適用する。公開後の再分析では、コメントを含む視聴者インサイトが必要になった時点で明示的に実行する。
+`/setup --channel` の新規開設モードでは Step 7 の必須前工程として実行する（`.claude/skills/setup/references/persona-branding-readiness.md`）。公開後の再分析では、コメントを含む視聴者インサイトが必要になった時点で明示的に実行する。
 
 ## 完了条件
 
@@ -30,8 +30,8 @@ description: "Use when 競合コメントの収集・分析で視聴者インサ
 
 ### 停止する fail
 
-- `config/channel/` が存在しない、または `load_config()` でロードできない → `/channel-new`（既存チャンネルは取り込みモード）を案内して停止する
-- `config/channel/analytics.json::benchmark.channels` に承認済みベンチマークチャンネルが設定されていない → `/channel-new` / `/discover-competitors` を案内して停止する
+- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/setup --channel` Step 4、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
+- `config/channel/analytics.json::benchmark.channels` に承認済みベンチマークチャンネルが設定されていない → `/setup --channel` Step 5 / `/discover-competitors` を案内して停止する
 - `auth/token.json` が存在しない、または OAuth 認証が無効 → `/setup` を案内して停止する
 
 ### 許容する fail

--- a/.claude/skills/viewing-scene/SKILL.md
+++ b/.claude/skills/viewing-scene/SKILL.md
@@ -15,7 +15,7 @@ YouTube 検索需要調査で、注力すべきシーンと最適な動画尺を
 
 入口で渡された実行コンテキストにより入力だけを切り替える。時間帯・行動・感情状態・動画尺を検証する分析観点と、Phase 2〜3 の意思決定手順は変えない。
 
-- **新規開設（公開前）**: `/channel-new` Step 7 → `/audience-persona-design` から明示的に引き継がれた場合だけ使用する。自チャンネル Analytics の代わりに、既存の競合 / TTP / viewer-voice 成果物を初回仮説の入力にする
+- **新規開設（公開前）**: `/setup --channel` Step 7（`.claude/skills/setup/references/persona-branding-readiness.md`）→ `/audience-persona-design` から明示的に引き継がれた場合だけ使用する。自チャンネル Analytics の代わりに、既存の競合 / TTP / viewer-voice 成果物を初回仮説の入力にする
 - **公開後**: 通常の直接実行および公開後の見直しで使用する。従来どおり自チャンネル Analytics report と benchmark を入力にする。実行コンテキストが明示されない場合もこちらとして扱う
 
 ## 完了条件
@@ -41,9 +41,9 @@ Phase 3 で AskUserQuestion によりメインシーンと動画尺の方針を�
 
 ### 停止する fail
 
-- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/channel-new`、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
+- `config/channel/` が存在しない、または `load_config()` でロードできない → 新規チャンネルは `/setup --channel` Step 4、既存チャンネルは `/channel-new`（既存チャンネル取り込みモード）を案内して停止する
 - `docs/channel/personas/persona-definition.md` が無い → 前工程 `/audience-persona-design` を案内して停止する
-- 新規開設（公開前）で `docs/plans/viewer-voice-analysis.md`、`docs/channel/ttp-seed-confirmation.md`、`docs/channel/competitor-branding-snapshot.json` のいずれかが無い → `/channel-new` Step 5 または Step 7 の該当前工程へ戻るよう案内して停止する
+- 新規開設（公開前）で `docs/plans/viewer-voice-analysis.md`、`docs/channel/ttp-seed-confirmation.md`、`docs/channel/competitor-branding-snapshot.json` のいずれかが無い → `/setup --channel` Step 5 または Step 7 の該当前工程へ戻るよう案内して停止する
 - 公開後に `reports/analysis_*.md` が無い → 前工程 `/analytics --collect` → `/analytics --analyze` を案内して停止する
 
 ### 許容する fail
@@ -109,7 +109,7 @@ AskUserQuestion でメインシーンと動画尺の方針を確認。
 | 状況 | 兆候 | 対処 |
 |---|---|---|
 | WebSearch 不可 | 検索結果が取得できない | 手動入力で代替するか、当該分析をスキップする |
-| 公開前入力不在 | 新規開設（公開前）で競合 / TTP / viewer-voice 成果物が不足 | `/channel-new` Step 5 または Step 7 の該当前工程へ戻る |
+| 公開前入力不在 | 新規開設（公開前）で競合 / TTP / viewer-voice 成果物が不足 | `/setup --channel` Step 5 または Step 7 の該当前工程へ戻る |
 | 公開後入力不在 | 公開後に `data/` のベンチマーク/Analytics スナップショットが無い | 先に `/benchmark`・`/analytics --collect` 等を実行して入力を用意 |
 
 ## 関連ファイル

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
+- `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
 - `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。
 - `refactor(setup)`: 排他的な `/setup --channel` を追加し、新規開設 Step 1〜10 の canonical contract と opening-only references / helpers の owner を setup へ移した。旧 `/channel-new` の opening trigger・Step 1〜10 は setup contract への互換入口として維持し、取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産も変更しない（#3983）。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ REPO_CONTRACT_MODULES = frozenset(
         "test_no_google_auth_httplib2_direct_import.py",
         "test_pytest_lane_contract.py",
         "test_readme_dev_install_documentation.py",
+        "test_research_persona_setup_handoff_contract.py",
         "test_scripts_layout.py",
         "test_skill_api_call_estimate_contract.py",
         "test_skill_cost_documentation.py",

--- a/tests/repo/test_research_persona_setup_handoff_contract.py
+++ b/tests/repo/test_research_persona_setup_handoff_contract.py
@@ -17,55 +17,101 @@ TARGET_SKILLS = (
     "viewer-voice",
     "viewing-scene",
 )
-EXPECTED_CHANNEL_NEW_OCCURRENCES = {
-    "audience-persona-design": 1,
-    "benchmark": 3,
-    "discover-competitors": 5,
-    "market-research": 3,
-    "thumbnail-research": 3,
-    "video-analyze": 1,
-    "viewer-voice": 1,
-    "viewing-scene": 1,
-}
-EXPECTED_SETUP_OCCURRENCES = {
-    "audience-persona-design": 3,
-    "benchmark": 2,
-    "discover-competitors": 3,
-    "market-research": 1,
-    "thumbnail-research": 0,
-    "video-analyze": 0,
-    "viewer-voice": 4,
-    "viewing-scene": 4,
-}
-OPENING_ROUTE_MARKERS = {
-    "audience-persona-design": (
-        "`/setup --channel` Step 7 から呼ばれた経路",
-        "新規チャンネルは `/setup --channel` Step 4",
-        "`/setup --channel` Step 5 または Step 7",
+
+
+def _occurrences(
+    skill: str,
+    redirected: tuple[tuple[str, str], ...],
+    residual: tuple[tuple[str, str], ...],
+) -> tuple[tuple[str, str, str, str], ...]:
+    return tuple((skill, occurrence, context, "redirected") for occurrence, context in redirected) + tuple(
+        (skill, occurrence, context, "residual") for occurrence, context in residual
+    )
+
+
+# The 35 /channel-new occurrences on main before #3985, classified by execution context.
+OCCURRENCE_LEDGER = (
+    *_occurrences(
+        "audience-persona-design",
+        (("prelaunch-entry", "new-opening"), ("missing-config-new", "new-opening"), ("missing-input", "new-opening")),
+        (("missing-config-existing", "existing-import"),),
     ),
-    "benchmark": (
-        "新規チャンネルは `/setup --channel` Step 4",
-        "`/setup --channel` Step 5（`.claude/skills/setup/references/ttp-seed-and-duration.md`）",
+    *_occurrences(
+        "benchmark",
+        (("missing-config-new", "new-opening"), ("missing-benchmarks", "new-opening")),
+        (
+            ("frontmatter-analysis", "analysis"),
+            ("downstream-analysis", "analysis"),
+            ("missing-config-existing", "existing-import"),
+        ),
     ),
-    "discover-competitors": (
-        "前工程の `/setup` は `/setup --channel` Step 6",
-        "標準フローでは本スキルを実行せず",
-        "`/setup --channel` Step 1/4/5",
-        "`/setup --channel`: TTP 対象確認と初期 config 生成",
+    *_occurrences(
+        "discover-competitors",
+        (
+            ("upstream-setup", "new-opening"),
+            ("new-channel-seed", "new-opening"),
+            ("setup-cross-reference", "new-opening"),
+        ),
+        (
+            ("frontmatter-analysis", "analysis"),
+            ("outside-channel-existing", "existing-import"),
+            ("direction-mode", "direction"),
+            ("regeneration-mode", "regeneration"),
+            ("analysis-cross-reference", "analysis"),
+        ),
     ),
-    "market-research": ("`/setup --channel` Step 1/4/5（`.claude/skills/setup/references/new-channel-bootstrap.md`",),
-    "viewer-voice": (
-        "新規開設では /setup --channel Step 7 で必須",
-        "`/setup --channel` の新規開設モードでは Step 7",
-        "新規チャンネルは `/setup --channel` Step 4",
-        "`/setup --channel` Step 5 / `/discover-competitors`",
+    *_occurrences(
+        "market-research",
+        (("setup-cross-reference", "new-opening"),),
+        (
+            ("frontmatter-analysis", "analysis"),
+            ("analysis-table", "analysis"),
+            ("analysis-cross-reference", "analysis"),
+        ),
     ),
-    "viewing-scene": (
-        "`/setup --channel` Step 7（`.claude/skills/setup/references/persona-branding-readiness.md`）→ ",
-        "新規チャンネルは `/setup --channel` Step 4",
-        "`/setup --channel` Step 5 または Step 7",
-        "`/setup --channel` Step 5 または Step 7",
+    *_occurrences(
+        "thumbnail-research",
+        (),
+        (
+            ("frontmatter-analysis", "analysis"),
+            ("desire-vocabulary", "shared-reference"),
+            ("analysis-cross-reference", "analysis"),
+        ),
     ),
+    *_occurrences("video-analyze", (), (("direction-caller", "direction"),)),
+    *_occurrences(
+        "viewer-voice",
+        (
+            ("frontmatter-prelaunch", "new-opening"),
+            ("prelaunch-entry", "new-opening"),
+            ("missing-config-new", "new-opening"),
+            ("missing-benchmarks", "new-opening"),
+        ),
+        (("missing-config-existing", "existing-import"),),
+    ),
+    *_occurrences(
+        "viewing-scene",
+        (
+            ("prelaunch-entry", "new-opening"),
+            ("missing-config-new", "new-opening"),
+            ("missing-input", "new-opening"),
+            ("missing-input-guidance", "new-opening"),
+        ),
+        (("missing-config-existing", "existing-import"),),
+    ),
+)
+
+# SHA-256 of ordered ``section heading + active route line`` records. This binds
+# every route to its exact active Markdown context without duplicating long prose.
+ROUTE_CONTEXT_SHA256 = {
+    "audience-persona-design": "07abb23816cc3c7de0497ab7b4906d756c48009c416eae84afd755ae11ac1d3c",
+    "benchmark": "477ff4325d535455a107b86cd091d539e119267dc63f800525527a2f38baf1ca",
+    "discover-competitors": "5674e18a4fb70b2eef85cbc72e64b35000666230ee71e6ec957f1e306ba08edb",
+    "market-research": "b54b28a9d6cddd9d91e49002b787b38a7b5381546a6fa643532d34aef451bfef",
+    "thumbnail-research": "ea3a96bf784d4d510491d9c2ac5f516dfaa6984f0e6acfbc0754c8b753662609",
+    "video-analyze": "f28ee9c9b0a18c3ecae15b631f970d780b18bda72185a25935b56f0a66ba6552",
+    "viewer-voice": "d805ae103e78d460505834402d19333151c2a7a5b09e87ac394bceabe8436373",
+    "viewing-scene": "c11dca52ed69e846b14fc51bcd46859a6bb4ac937844cc9f472ad8c81ddde393",
 }
 SETUP_ASSET_OWNERS = {
     "audience-persona-design": "persona-branding-readiness.md",
@@ -95,7 +141,7 @@ RESIDUAL_LINE_MARKERS = {
 }
 RESIDUAL_SHA256 = {
     "benchmark": "2fb95bb4e810ba0ca2bf7ece521a8aac529fb461c7d970540ea32ede584f9b03",
-    "discover-competitors": "c44dfd9e96135f2886f05c7853b1c4ec3db0d20e8326f93b2d147abf2ac3fdcc",
+    "discover-competitors": "91325074ff74f89681a6972f3c56c5c093dfd4aa779f0ca4425e66d348a3a891",
     "market-research": "a6350cc0f44adf9895aefb0b98fc177415b5bebb55e17b3fb056d3df8d111448",
 }
 
@@ -104,15 +150,41 @@ def _skill_text(skill: str) -> str:
     return (SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")
 
 
+def _active_route_snapshot(text: str) -> tuple[bytes, bool]:
+    section = "frontmatter"
+    records: list[str] = []
+    in_fence = False
+    in_html_comment = False
+    inactive_route = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        has_route = "/channel-new" in line or "/setup --channel" in line
+        starts_comment = "<!--" in line
+        ends_comment = "-->" in line
+        if in_fence or in_html_comment or starts_comment or "~~" in line:
+            inactive_route |= has_route
+            if in_html_comment and ends_comment:
+                in_html_comment = False
+            elif starts_comment and not ends_comment:
+                in_html_comment = True
+            continue
+        if line.startswith("##"):
+            section = line
+        if has_route:
+            records.append(f"{section}\0{line}")
+    return "\n".join(records).encode(), inactive_route
+
+
 def _route_violations(skill: str, text: str) -> set[str]:
     violations = set()
-    if text.count("/channel-new") != EXPECTED_CHANNEL_NEW_OCCURRENCES[skill]:
-        violations.add("channel-new occurrence ledger")
-    if text.count("/setup --channel") != EXPECTED_SETUP_OCCURRENCES[skill]:
-        violations.add("setup occurrence ledger")
-    for marker in OPENING_ROUTE_MARKERS.get(skill, ()):
-        if marker not in text:
-            violations.add(f"opening route:{marker}")
+    snapshot, inactive_route = _active_route_snapshot(text)
+    if sha256(snapshot).hexdigest() != ROUTE_CONTEXT_SHA256[skill]:
+        violations.add("active route context ledger")
+    if inactive_route:
+        violations.add("inactive Markdown route")
     asset = SETUP_ASSET_OWNERS.get(skill)
     if asset is not None and f".claude/skills/setup/references/{asset}" not in text:
         violations.add(f"setup asset:{asset}")
@@ -120,9 +192,10 @@ def _route_violations(skill: str, text: str) -> set[str]:
 
 
 def test_all_eight_skills_match_the_context_classified_occurrence_ledger() -> None:
-    assert set(EXPECTED_CHANNEL_NEW_OCCURRENCES) == set(TARGET_SKILLS)
-    assert set(EXPECTED_SETUP_OCCURRENCES) == set(TARGET_SKILLS)
-    assert sum(EXPECTED_CHANNEL_NEW_OCCURRENCES.values()) == 18
+    assert {entry[0] for entry in OCCURRENCE_LEDGER} == set(TARGET_SKILLS)
+    assert len(OCCURRENCE_LEDGER) == 35
+    assert sum(entry[3] == "redirected" for entry in OCCURRENCE_LEDGER) == 17
+    assert sum(entry[3] == "residual" for entry in OCCURRENCE_LEDGER) == 18
 
     for skill in TARGET_SKILLS:
         assert _route_violations(skill, _skill_text(skill)) == set()
@@ -131,16 +204,46 @@ def test_all_eight_skills_match_the_context_classified_occurrence_ledger() -> No
 def test_opening_route_validator_detects_wrong_redirect_and_residual_overwrite() -> None:
     audience = _skill_text("audience-persona-design")
     wrong_redirect = audience.replace("`/setup --channel` Step 7", "`/channel-new` Step 7", 1)
-    assert _route_violations("audience-persona-design", wrong_redirect) >= {
-        "channel-new occurrence ledger",
-        "setup occurrence ledger",
-    }
+    assert "active route context ledger" in _route_violations("audience-persona-design", wrong_redirect)
 
     discover = _skill_text("discover-competitors")
     residual_overwrite = discover.replace("/channel-new 分析モード", "/setup --channel", 1)
-    assert _route_violations("discover-competitors", residual_overwrite) >= {
-        "channel-new occurrence ledger",
-        "setup occurrence ledger",
+    assert "active route context ledger" in _route_violations("discover-competitors", residual_overwrite)
+
+
+def test_route_validator_rejects_inactive_mixed_swapped_and_relocated_routes() -> None:
+    audience = _skill_text("audience-persona-design")
+    canonical = next(line for line in audience.splitlines() if "新規チャンネルは `/setup --channel` Step 4" in line)
+    inactive_mixed = audience.replace(
+        canonical,
+        "~~新規チャンネルは /setup --channel Step 4~~ 新規チャンネルは /channel-new Step 4、既存チャンネルは /setup",
+    )
+    assert _route_violations("audience-persona-design", inactive_mixed) >= {
+        "active route context ledger",
+        "inactive Markdown route",
+    }
+
+    swapped = audience.replace(
+        "新規チャンネルは `/setup --channel` Step 4、既存チャンネルは `/channel-new`",
+        "新規チャンネルは `/channel-new` Step 4、既存チャンネルは `/setup --channel`",
+    )
+    assert "active route context ledger" in _route_violations("audience-persona-design", swapped)
+
+    relocated = audience.replace(canonical + "\n", "").replace(
+        "## 障害時ガイダンス", f"## 障害時ガイダンス\n\n{canonical}"
+    )
+    assert "active route context ledger" in _route_violations("audience-persona-design", relocated)
+
+    commented = audience.replace(canonical, f"<!-- {canonical} -->\n新規チャンネルは `/channel-new` Step 4")
+    assert _route_violations("audience-persona-design", commented) >= {
+        "active route context ledger",
+        "inactive Markdown route",
+    }
+
+    multiline_comment = audience.replace(canonical, f"<!--\n{canonical}\n-->")
+    assert _route_violations("audience-persona-design", multiline_comment) >= {
+        "active route context ledger",
+        "inactive Markdown route",
     }
 
 

--- a/tests/repo/test_research_persona_setup_handoff_contract.py
+++ b/tests/repo/test_research_persona_setup_handoff_contract.py
@@ -1,0 +1,158 @@
+"""Research/persona opening handoffs owned by ``/setup --channel``."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+TARGET_SKILLS = (
+    "audience-persona-design",
+    "benchmark",
+    "discover-competitors",
+    "market-research",
+    "thumbnail-research",
+    "video-analyze",
+    "viewer-voice",
+    "viewing-scene",
+)
+EXPECTED_CHANNEL_NEW_OCCURRENCES = {
+    "audience-persona-design": 1,
+    "benchmark": 3,
+    "discover-competitors": 5,
+    "market-research": 3,
+    "thumbnail-research": 3,
+    "video-analyze": 1,
+    "viewer-voice": 1,
+    "viewing-scene": 1,
+}
+EXPECTED_SETUP_OCCURRENCES = {
+    "audience-persona-design": 3,
+    "benchmark": 2,
+    "discover-competitors": 3,
+    "market-research": 1,
+    "thumbnail-research": 0,
+    "video-analyze": 0,
+    "viewer-voice": 4,
+    "viewing-scene": 4,
+}
+OPENING_ROUTE_MARKERS = {
+    "audience-persona-design": (
+        "`/setup --channel` Step 7 から呼ばれた経路",
+        "新規チャンネルは `/setup --channel` Step 4",
+        "`/setup --channel` Step 5 または Step 7",
+    ),
+    "benchmark": (
+        "新規チャンネルは `/setup --channel` Step 4",
+        "`/setup --channel` Step 5（`.claude/skills/setup/references/ttp-seed-and-duration.md`）",
+    ),
+    "discover-competitors": (
+        "前工程の `/setup` は `/setup --channel` Step 6",
+        "標準フローでは本スキルを実行せず",
+        "`/setup --channel` Step 1/4/5",
+        "`/setup --channel`: TTP 対象確認と初期 config 生成",
+    ),
+    "market-research": ("`/setup --channel` Step 1/4/5（`.claude/skills/setup/references/new-channel-bootstrap.md`",),
+    "viewer-voice": (
+        "新規開設では /setup --channel Step 7 で必須",
+        "`/setup --channel` の新規開設モードでは Step 7",
+        "新規チャンネルは `/setup --channel` Step 4",
+        "`/setup --channel` Step 5 / `/discover-competitors`",
+    ),
+    "viewing-scene": (
+        "`/setup --channel` Step 7（`.claude/skills/setup/references/persona-branding-readiness.md`）→ ",
+        "新規チャンネルは `/setup --channel` Step 4",
+        "`/setup --channel` Step 5 または Step 7",
+        "`/setup --channel` Step 5 または Step 7",
+    ),
+}
+SETUP_ASSET_OWNERS = {
+    "audience-persona-design": "persona-branding-readiness.md",
+    "benchmark": "ttp-seed-and-duration.md",
+    "discover-competitors": "persona-branding-readiness.md",
+    "market-research": "new-channel-bootstrap.md",
+    "viewer-voice": "persona-branding-readiness.md",
+    "viewing-scene": "persona-branding-readiness.md",
+}
+UNCHANGED_SKILL_SHA256 = {
+    "thumbnail-research": "4f1052032ca41873e9642e8a25824a5c64e9330c15df77e90d0046e0dbc12f94",
+    "video-analyze": "b1049a71ace16481363318d89886c14ef49401fd0d77691e73b36ab167bdeb96",
+}
+RESIDUAL_LINE_MARKERS = {
+    "benchmark": ("description:", "- `後工程`:"),
+    "discover-competitors": (
+        "description:",
+        "- 実行場所がチャンネルリポジトリ",
+        "- 方向性決定・config 生成",
+        "- `/channel-new` 分析モード:",
+    ),
+    "market-research": (
+        "description:",
+        "| `/channel-new` 分析モード |",
+        "- `/channel-new` 分析モード —",
+    ),
+}
+RESIDUAL_SHA256 = {
+    "benchmark": "2fb95bb4e810ba0ca2bf7ece521a8aac529fb461c7d970540ea32ede584f9b03",
+    "discover-competitors": "c44dfd9e96135f2886f05c7853b1c4ec3db0d20e8326f93b2d147abf2ac3fdcc",
+    "market-research": "a6350cc0f44adf9895aefb0b98fc177415b5bebb55e17b3fb056d3df8d111448",
+}
+
+
+def _skill_text(skill: str) -> str:
+    return (SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _route_violations(skill: str, text: str) -> set[str]:
+    violations = set()
+    if text.count("/channel-new") != EXPECTED_CHANNEL_NEW_OCCURRENCES[skill]:
+        violations.add("channel-new occurrence ledger")
+    if text.count("/setup --channel") != EXPECTED_SETUP_OCCURRENCES[skill]:
+        violations.add("setup occurrence ledger")
+    for marker in OPENING_ROUTE_MARKERS.get(skill, ()):
+        if marker not in text:
+            violations.add(f"opening route:{marker}")
+    asset = SETUP_ASSET_OWNERS.get(skill)
+    if asset is not None and f".claude/skills/setup/references/{asset}" not in text:
+        violations.add(f"setup asset:{asset}")
+    return violations
+
+
+def test_all_eight_skills_match_the_context_classified_occurrence_ledger() -> None:
+    assert set(EXPECTED_CHANNEL_NEW_OCCURRENCES) == set(TARGET_SKILLS)
+    assert set(EXPECTED_SETUP_OCCURRENCES) == set(TARGET_SKILLS)
+    assert sum(EXPECTED_CHANNEL_NEW_OCCURRENCES.values()) == 18
+
+    for skill in TARGET_SKILLS:
+        assert _route_violations(skill, _skill_text(skill)) == set()
+
+
+def test_opening_route_validator_detects_wrong_redirect_and_residual_overwrite() -> None:
+    audience = _skill_text("audience-persona-design")
+    wrong_redirect = audience.replace("`/setup --channel` Step 7", "`/channel-new` Step 7", 1)
+    assert _route_violations("audience-persona-design", wrong_redirect) >= {
+        "channel-new occurrence ledger",
+        "setup occurrence ledger",
+    }
+
+    discover = _skill_text("discover-competitors")
+    residual_overwrite = discover.replace("/channel-new 分析モード", "/setup --channel", 1)
+    assert _route_violations("discover-competitors", residual_overwrite) >= {
+        "channel-new occurrence ledger",
+        "setup occurrence ledger",
+    }
+
+
+def test_skills_without_opening_occurrences_remain_byte_identical() -> None:
+    for skill, expected in UNCHANGED_SKILL_SHA256.items():
+        payload = (SKILLS_DIR / skill / "SKILL.md").read_bytes()
+        assert sha256(payload).hexdigest() == expected
+
+
+def test_analysis_and_direction_residual_routes_remain_byte_identical() -> None:
+    for skill, markers in RESIDUAL_LINE_MARKERS.items():
+        lines = (SKILLS_DIR / skill / "SKILL.md").read_bytes().splitlines(keepends=True)
+        selected = [next(line for line in lines if line.decode().startswith(marker)) for marker in markers]
+        payload = b"".join(selected)
+        assert sha256(payload).hexdigest() == RESIDUAL_SHA256[skill]

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -25,9 +25,10 @@ def test_all_skills_use_machine_readable_chain_block() -> None:
         r"- `後工程`: (?P<downstream>[^\n]+)\n",
         re.DOTALL,
     )
+    chain_reference = r"`(?:/[a-z0-9-]+|/setup --channel)`"
     chain_value = re.compile(
-        r"^(?:`なし`|`\*`（共通基盤としてほぼ全スキル）|"
-        r"`/[a-z0-9-]+`(?:, `/[a-z0-9-]+`)*)$"
+        rf"^(?:`なし`|`\*`（共通基盤としてほぼ全スキル）|"
+        rf"{chain_reference}(?:, {chain_reference})*)$"
     )
     known_skills = {path.parent.name for path in skill_paths}
 
@@ -39,7 +40,7 @@ def test_all_skills_use_machine_readable_chain_block() -> None:
         for direction in ("upstream", "downstream"):
             value = match.group(direction)
             assert chain_value.fullmatch(value), f"{path}: {direction} の書式が不正: {value}"
-            for reference in re.findall(r"`/([a-z0-9-]+)`", value):
+            for reference in re.findall(r"`/([a-z0-9-]+)(?: --channel)?`", value):
                 assert reference in known_skills, f"{path}: 存在しない skill 参照 /{reference}"
 
 
@@ -875,7 +876,7 @@ def test_channel_new_followup_skill_routing_uses_new_contract() -> None:
     features = _read("docs/features.md")
 
     assert "/channel-new Step 5 の前段" not in discover
-    assert "前工程の `/setup` は `/setup --channel` Step 6" in discover
+    assert "このスキルの前工程は `/setup --channel` Step 6" in discover
     assert "標準フローでは本スキルを実行せず" in discover
     assert "ユーザー承認と relationship メモを必ず残す" in discover
     assert "genre_keywords" not in discover

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -343,7 +343,8 @@ def test_setup_channel_ttp_hearing_routes_direction_to_residual_mode() -> None:
 
     viewer_voice = _read(".claude/skills/viewer-voice/SKILL.md")
     assert "新規開設モードでは Step 7 の必須前工程" in viewer_voice
-    assert "その互換入口である `/channel-new` の新規開設モードでも同じ契約を適用する" in viewer_voice
+    assert "その互換入口である `/channel-new` の新規開設モード" not in viewer_voice
+    assert ".claude/skills/setup/references/persona-branding-readiness.md" in viewer_voice
     assert "公開後の再分析では" in viewer_voice
     assert "標準フローでは実行せず" not in viewer_voice
 
@@ -874,7 +875,8 @@ def test_channel_new_followup_skill_routing_uses_new_contract() -> None:
     features = _read("docs/features.md")
 
     assert "/channel-new Step 5 の前段" not in discover
-    assert "`/channel-new` の標準フローでは実行しない" in discover
+    assert "前工程の `/setup` は `/setup --channel` Step 6" in discover
+    assert "標準フローでは本スキルを実行せず" in discover
     assert "ユーザー承認と relationship メモを必ず残す" in discover
     assert "genre_keywords" not in discover
     assert "target_scene" not in discover


### PR DESCRIPTION
## Summary

- research / persona 系 8 skill の opening handoff だけを `/setup --channel` の対応 Step / asset owner へ移行
- `discover-competitors` の非チャンネル実行を、新規・未作成は `/setup --channel`、既存取り込みは `/channel-new` に文脈分岐
- active Markdown の section + 完全行を固定する occurrence ledger と mutation 契約で、非アクティブ Markdown/comment、opening/import 交換、marker 移動、residual over-rewrite を拒否
- analysis・direction・existing/import・regeneration・shared-reference の `/channel-new` 経路を維持

## Outcomes

- main 初期 occurrence: 35
- opening redirect: 17
- residual preserved: 18
- byte-identical skills:
  - `thumbnail-research`: `4f1052032ca41873e9642e8a25824a5c64e9330c15df77e90d0046e0dbc12f94`
  - `video-analyze`: `b1049a71ace16481363318d89886c14ef49401fd0d77691e73b36ab167bdeb96`

## Verification

- focused persona / analysis / docs: 80 passed
- repo_contract: 621 passed, 7841 deselected
- full serialized clean clone: 8461 passed, 1 skipped
- candidate wheel + isolated downstream sync + installed `yt-skills diff`: passed
- candidate sdist setup-channel owner contract: passed
- packaging contract: 2 passed
- 8-skill lint, Ruff check/format, Any gate, CHANGELOG contract: passed

Closes #3985
