### PR TITLE
refactor(cost): ファイルロック実装を一本化する (#3894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。
 - `refactor(setup)`: 排他的な `/setup --channel` を追加し、新規開設 Step 1〜10 の canonical contract と opening-only references / helpers の owner を setup へ移した。旧 `/channel-new` の opening trigger・Step 1〜10 は setup contract への互換入口として維持し、取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産も変更しない（#3983）。

--- a/src/youtube_automation/infrastructure/cost_tracker.py
+++ b/src/youtube_automation/infrastructure/cost_tracker.py
@@ -27,26 +27,13 @@
 
 from __future__ import annotations
 
-import contextlib
-import errno
 import json
-import threading
-import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Literal
+from typing import Literal
 
-try:
-    import fcntl as _fcntl
-except ImportError:
-    _fcntl = None
-
-try:
-    import msvcrt as _msvcrt
-except ImportError:
-    _msvcrt = None
-
+from youtube_automation.infrastructure.file_lock import file_lock as _file_lock
 from youtube_automation.infrastructure.observability.profile import section
 
 Category = Literal["image", "video", "audio", "analysis"]
@@ -75,21 +62,6 @@ _LEGACY_UNIT_BY_CATEGORY: dict[Category, str] = {
     "analysis": "call",
 }
 
-_LOCK_FILE_SUFFIX = ".lock"
-_LOCK_REGION_BYTES = 1
-_MSVCRT_LOCK_RETRY_DELAY_SECONDS = 0.05
-_MSVCRT_LOCK_MAX_ATTEMPTS = 20
-_MSVCRT_LOCK_RETRY_ERRNOS = {
-    errno.EACCES,
-    errno.EAGAIN,
-    getattr(errno, "EDEADLK", errno.EACCES),
-}
-_MSVCRT_LOCK_RETRY_WINERRORS = {
-    32,  # ERROR_SHARING_VIOLATION
-    33,  # ERROR_LOCK_VIOLATION
-}
-_IN_PROCESS_LOCK = threading.Lock()
-
 
 def _channel_dir() -> Path:
     """チャンネルディレクトリを ChannelConfig 経由で解決。"""
@@ -108,77 +80,6 @@ def relative_to_channel_dir(path: Path) -> str:
         return path.relative_to(_channel_dir()).as_posix()
     except ValueError:
         return str(path)
-
-
-@contextlib.contextmanager
-def _file_lock(path: Path):
-    """生成履歴ファイルの読み書き競合を防ぐ排他ロック。"""
-    if _fcntl is None and _msvcrt is None:
-        with _IN_PROCESS_LOCK:
-            yield
-        return
-
-    lock_path = path.with_suffix(path.suffix + _LOCK_FILE_SUFFIX)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with _IN_PROCESS_LOCK:
-        with lock_path.open("a+b") as lock_f:
-            _prepare_lock_file(lock_f)
-            _acquire_lock(lock_f)
-            try:
-                yield
-            finally:
-                _release_lock(lock_f)
-
-
-def _prepare_lock_file(lock_f: BinaryIO) -> None:
-    lock_f.seek(0, 2)
-    size = lock_f.tell()
-    if size < _LOCK_REGION_BYTES:
-        lock_f.write(b"\0" * (_LOCK_REGION_BYTES - size))
-        lock_f.flush()
-    lock_f.seek(0)
-
-
-def _acquire_lock(lock_f: BinaryIO) -> None:
-    if _fcntl is not None:
-        _fcntl.flock(lock_f.fileno(), _fcntl.LOCK_EX)
-        return
-    if _msvcrt is not None:
-        _acquire_msvcrt_lock(lock_f)
-        return
-    raise RuntimeError("platform file locks are unavailable")
-
-
-def _acquire_msvcrt_lock(lock_f: BinaryIO) -> None:
-    last_error: OSError | None = None
-    for attempt in range(_MSVCRT_LOCK_MAX_ATTEMPTS):
-        lock_f.seek(0)
-        try:
-            _msvcrt.locking(lock_f.fileno(), _msvcrt.LK_NBLCK, _LOCK_REGION_BYTES)
-            return
-        except OSError as e:
-            if not _is_msvcrt_lock_contention(e):
-                raise
-            last_error = e
-            if attempt == _MSVCRT_LOCK_MAX_ATTEMPTS - 1:
-                break
-            time.sleep(_MSVCRT_LOCK_RETRY_DELAY_SECONDS)
-    raise TimeoutError(f"msvcrt lock acquisition timed out after {_MSVCRT_LOCK_MAX_ATTEMPTS} attempts") from last_error
-
-
-def _is_msvcrt_lock_contention(error: OSError) -> bool:
-    return error.errno in _MSVCRT_LOCK_RETRY_ERRNOS or getattr(error, "winerror", None) in _MSVCRT_LOCK_RETRY_WINERRORS
-
-
-def _release_lock(lock_f: BinaryIO) -> None:
-    if _fcntl is not None:
-        _fcntl.flock(lock_f.fileno(), _fcntl.LOCK_UN)
-        return
-    if _msvcrt is not None:
-        lock_f.seek(0)
-        _msvcrt.locking(lock_f.fileno(), _msvcrt.LK_UNLCK, _LOCK_REGION_BYTES)
-        return
-    raise RuntimeError("platform file locks are unavailable")
 
 
 def log_generation(

--- a/tests/infrastructure/test_cost_tracker.py
+++ b/tests/infrastructure/test_cost_tracker.py
@@ -23,6 +23,7 @@ import pytest
 
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.infrastructure import cost_tracker
+from youtube_automation.infrastructure import file_lock as file_lock_module
 
 
 @pytest.fixture
@@ -81,6 +82,14 @@ def _write_audio_entries_concurrently(count: int) -> None:
         ]
         for f in futures:
             f.result()
+
+
+def test_cost_tracker_uses_canonical_file_lock_owner() -> None:
+    """Given cost tracker の排他境界
+    When lock callable の owner identity を確認する
+    Then infrastructure.file_lock の canonical 実装を直接利用する。
+    """
+    assert cost_tracker._file_lock is file_lock_module.file_lock
 
 
 # ============================================================
@@ -247,8 +256,8 @@ def test_log_generation_uses_fcntl_when_available(tmp_channel: Path, monkeypatch
             raise AssertionError("msvcrt should not be used when fcntl is available")
 
     fake_fcntl = FakeFcntl()
-    monkeypatch.setattr(cost_tracker, "_fcntl", fake_fcntl)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", UnexpectedMsvcrt())
+    monkeypatch.setattr(file_lock_module, "_fcntl", fake_fcntl)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", UnexpectedMsvcrt())
 
     entry = cost_tracker.log_generation(
         "image",
@@ -344,8 +353,8 @@ def test_log_generation_uses_msvcrt_when_fcntl_is_unavailable(tmp_channel: Path,
             self.calls.append((mode, nbytes))
 
     fake_msvcrt = FakeMsvcrt()
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", fake_msvcrt)
 
     N = 20
     _write_audio_entries_concurrently(N)
@@ -381,9 +390,9 @@ def test_log_generation_retries_msvcrt_lock_contention(tmp_channel: Path, monkey
 
     fake_msvcrt = FakeMsvcrt()
     sleep_calls: list[float] = []
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", fake_msvcrt)
-    monkeypatch.setattr(cost_tracker.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_lock_module.time, "sleep", sleep_calls.append)
 
     entry = cost_tracker.log_generation(
         "image",
@@ -402,8 +411,8 @@ def test_log_generation_retries_msvcrt_lock_contention(tmp_channel: Path, monkey
         (fake_msvcrt.LK_UNLCK, 1),
     ]
     assert sleep_calls == [
-        cost_tracker._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
-        cost_tracker._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
+        file_lock_module._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
+        file_lock_module._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
     ]
 
 
@@ -427,9 +436,9 @@ def test_log_generation_does_not_retry_non_contention_msvcrt_errors(tmp_channel:
 
     fake_msvcrt = FakeMsvcrt()
     sleep_calls: list[float] = []
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", fake_msvcrt)
-    monkeypatch.setattr(cost_tracker.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_lock_module.time, "sleep", sleep_calls.append)
 
     entry = cost_tracker.log_generation(
         "image",
@@ -463,10 +472,10 @@ def test_log_generation_stops_after_msvcrt_contention_retry_limit(tmp_channel: P
 
     fake_msvcrt = FakeMsvcrt()
     sleep_calls: list[float] = []
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", fake_msvcrt)
-    monkeypatch.setattr(cost_tracker, "_MSVCRT_LOCK_MAX_ATTEMPTS", 3)
-    monkeypatch.setattr(cost_tracker.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_lock_module, "_MSVCRT_LOCK_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(file_lock_module.time, "sleep", sleep_calls.append)
 
     entry = cost_tracker.log_generation(
         "image",
@@ -482,8 +491,8 @@ def test_log_generation_stops_after_msvcrt_contention_retry_limit(tmp_channel: P
         (fake_msvcrt.LK_NBLCK, 1),
     ]
     assert sleep_calls == [
-        cost_tracker._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
-        cost_tracker._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
+        file_lock_module._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
+        file_lock_module._MSVCRT_LOCK_RETRY_DELAY_SECONDS,
     ]
 
 
@@ -507,8 +516,8 @@ def test_log_generation_releases_msvcrt_lock_when_write_fails(tmp_channel: Path,
         raise RuntimeError(f"forced read failure: {path.name}")
 
     fake_msvcrt = FakeMsvcrt()
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", fake_msvcrt)
     monkeypatch.setattr(cost_tracker, "_read_entries", fail_read_entries)
 
     entry = cost_tracker.log_generation(
@@ -538,8 +547,8 @@ def test_log_generation_without_platform_file_lock_preserves_threaded_writes(tmp
     When 同一プロセス内で並列に cost 記録する
     Then プロセス内ロックで全エントリが保持される。
     """
-    monkeypatch.setattr(cost_tracker, "_fcntl", None)
-    monkeypatch.setattr(cost_tracker, "_msvcrt", None)
+    monkeypatch.setattr(file_lock_module, "_fcntl", None)
+    monkeypatch.setattr(file_lock_module, "_msvcrt", None)
 
     N = 20
     _write_audio_entries_concurrently(N)


### PR DESCRIPTION
## Summary
- `cost_tracker` 内の fcntl / msvcrt / in-process file lock 重複実装を削除し、`infrastructure.file_lock.file_lock` を唯一の owner にした
- `cost_tracker._file_lock` は canonical callable と同一 object のまま維持し、既存の `generate_videos_batch` import 契約を変更していない
- cost generation / quota logging の排他・failure・cleanup・concurrency 契約を canonical module seam で検証するよう更新した

## Acceptance evidence
- owner identity: `cost_tracker._file_lock is file_lock.file_lock`
- locking semantics: fcntl の `LOCK_EX` / `LOCK_UN`、msvcrt の acquire / release と contention retry / retry limit を既存テストで確認
- failure / cleanup: non-contention error は retry せず既存の `None` 契約を維持し、critical section failure 後も unlock を確認
- concurrency counterexamples: platform lock あり／なし双方で threaded writes の欠落なしと maximum active count 1 を確認
- source scan: lock implementation definitions は `src/youtube_automation/infrastructure/file_lock.py` の 1 箇所のみ
- packaging: candidate wheel / sdist を buildし、両 module の同梱と隔離 venv へ install 後の owner identity を確認

## Verification

```text
$ nix develop --command uv run pytest tests/infrastructure/test_cost_tracker.py::test_cost_tracker_uses_canonical_file_lock_owner -q
1 failed in 1.09s
```

```text
$ nix develop --command uv run pytest tests/infrastructure/test_cost_tracker.py tests/infrastructure/test_file_lock.py -q
44 passed in 0.30s
```

```text
$ nix develop --command uv run pytest tests/commands/analytics/test_cost_tracker_quota.py tests/commands/media/test_generate_videos_batch.py -q
38 passed in 0.34s
```

```text
$ nix develop --command uv run ruff check .
All checks passed!

$ nix develop --command uv run ruff format --check .
788 files already formatted

$ PRE_PUSH_DIFF_BASE=origin/main nix develop --command bash .github/scripts/any-usage-gate.sh
exit 0

$ git diff --check
exit 0
```

```text
$ nix develop --command uv run pytest -n auto
8482 passed, 1 skipped, 70 warnings in 166.66s
```

```text
$ nix develop --command uv build --wheel --sdist ...
Successfully built youtube_channels_automation-5.6.0.tar.gz
Successfully built youtube_channels_automation-5.6.0-py3-none-any.whl
installed-wheel owner identity: PASS
wheel/sdist build and installed import: PASS
```

Closes #3894
