### PR TITLE
perf(masterup): cleanupを曲単位でbounded並列化する (#3860)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -70,7 +70,7 @@ TS CLI `uv run yt-generate-master` は `audio` の実行時既定値を組み込
 | `post_processing.rain_layers.output_name` | `master-rain.wav` | 後処理出力ファイル名（`01-master/` 配下）。成功時に `workflow-state.json::assets.raw_master` がこの名前へ書き換わる |
 | `post_processing.rain_layers.output_codec` / `.output_sample_rate` | `pcm_s16le` / `44100` | 出力 WAV の ffmpeg コーデックとサンプリングレート（ステレオ固定）。後段の外部 DAW でミキシング+マスタリングする運用想定 |
 | `post_processing.suno_audio_cleanup.enabled` | `true` | Suno ダウンロード直後の個別音源に、無音カット / EQ / dynaudnorm / limiter / LUFS 正規化 / 末尾 fade guard を適用する。従来挙動へ戻す場合はチャンネル側で `false` にする |
-| `post_processing.suno_audio_cleanup.max_workers` | `2` | `apply` の曲単位最大並列数。CLI `--jobs` が優先し、`--jobs 1` で直列実行する |
+| `post_processing.suno_audio_cleanup.max_workers` | `2` | `apply` の曲単位最大並列数（1〜8）。CLI `--jobs` が優先し、`--jobs 1` で従来どおり main thread の直列実行を選ぶ。範囲外は処理開始前に失敗する |
 | `post_processing.suno_audio_cleanup.loudnorm.I` | `-14` | YouTube 向け LUFS 正規化の目標値。チャンネル側 `config/skills/masterup.json` 優先、既存 `masterup.yaml` fallback で調整可能 |
 | `validation.loudness_deviation.max_lu` | `2.0` | マスター結合前に許容するコレクション内 integrated LUFS の最大差（LU）。0 より大きい数値のみ |
 | `pair_selection.mode` | `auto` | `suno-prompts.json` の `lyrics` から歌詞あり/なしを判定し、歌詞ありならペアから 1 曲、歌詞なしなら 2 clip 両方を採用する。`never` で整理をスキップ |
@@ -325,7 +325,7 @@ uv run yt-suno-audio-cleanup apply <collection-path>  # 元ファイルを origi
 uv run yt-suno-audio-cleanup apply <collection-path> --jobs 1  # 明示的な直列実行
 ```
 
-`apply` は曲単位で最大2件を並列処理する。最大並列数は `--jobs` → `post_processing.suno_audio_cleanup.max_workers` → `2` の順で解決する。失敗時は新しい曲を投入せず、開始済み処理を回収してファイル名順にエラーを報告する。`plan` は並列処理や ffmpeg 実行を行わず、従来どおりファイル名順のコマンドだけを表示する。
+`apply` は曲単位で最大2件を並列処理する。最大並列数は `--jobs` → `post_processing.suno_audio_cleanup.max_workers` → `2` の順で解決し、安全上限は8とする。失敗時は新しい曲を投入せず、開始済み処理を回収してファイル名順にエラーを報告する。`--jobs 1` は worker thread を作らず、従来どおり各曲の進捗と例外を直ちに呼び出し元へ渡す。`plan` はファイル名順に ffprobe で長さを調べてコマンドを表示するが、ffmpeg encode は起動しない。
 
 適用内容:
 

--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -70,6 +70,7 @@ TS CLI `uv run yt-generate-master` は `audio` の実行時既定値を組み込
 | `post_processing.rain_layers.output_name` | `master-rain.wav` | 後処理出力ファイル名（`01-master/` 配下）。成功時に `workflow-state.json::assets.raw_master` がこの名前へ書き換わる |
 | `post_processing.rain_layers.output_codec` / `.output_sample_rate` | `pcm_s16le` / `44100` | 出力 WAV の ffmpeg コーデックとサンプリングレート（ステレオ固定）。後段の外部 DAW でミキシング+マスタリングする運用想定 |
 | `post_processing.suno_audio_cleanup.enabled` | `true` | Suno ダウンロード直後の個別音源に、無音カット / EQ / dynaudnorm / limiter / LUFS 正規化 / 末尾 fade guard を適用する。従来挙動へ戻す場合はチャンネル側で `false` にする |
+| `post_processing.suno_audio_cleanup.max_workers` | `2` | `apply` の曲単位最大並列数。CLI `--jobs` が優先し、`--jobs 1` で直列実行する |
 | `post_processing.suno_audio_cleanup.loudnorm.I` | `-14` | YouTube 向け LUFS 正規化の目標値。チャンネル側 `config/skills/masterup.json` 優先、既存 `masterup.yaml` fallback で調整可能 |
 | `validation.loudness_deviation.max_lu` | `2.0` | マスター結合前に許容するコレクション内 integrated LUFS の最大差（LU）。0 より大きい数値のみ |
 | `pair_selection.mode` | `auto` | `suno-prompts.json` の `lyrics` から歌詞あり/なしを判定し、歌詞ありならペアから 1 曲、歌詞なしなら 2 clip 両方を採用する。`never` で整理をスキップ |
@@ -321,7 +322,10 @@ uv run yt-suno-select-tracks <collection-path> --dry-run
 ```bash
 uv run yt-suno-audio-cleanup plan <collection-path>   # まず対象と ffmpeg filter を確認
 uv run yt-suno-audio-cleanup apply <collection-path>  # 元ファイルを originals-pre-cleanup/ に退避して同名置換
+uv run yt-suno-audio-cleanup apply <collection-path> --jobs 1  # 明示的な直列実行
 ```
+
+`apply` は曲単位で最大2件を並列処理する。最大並列数は `--jobs` → `post_processing.suno_audio_cleanup.max_workers` → `2` の順で解決する。失敗時は新しい曲を投入せず、開始済み処理を回収してファイル名順にエラーを報告する。`plan` は並列処理や ffmpeg 実行を行わず、従来どおりファイル名順のコマンドだけを表示する。
 
 適用内容:
 

--- a/.claude/skills/masterup/config.default.yaml
+++ b/.claude/skills/masterup/config.default.yaml
@@ -129,7 +129,7 @@ validation:
 post_processing:
   suno_audio_cleanup:
     enabled: true               # 既定 ON。false で Suno DL 後の個別音源 cleanup を無効化
-    max_workers: 2              # apply の曲単位最大並列数。CLI --jobs が優先
+    max_workers: 2              # apply の曲単位最大並列数 (1〜8)。CLI --jobs が優先
     backup_originals: true      # 02-Individual-music/originals-pre-cleanup/ に元ファイルを保存
     bitrate: "192k"             # libmp3lame 出力ビットレート (未指定なら audio.bitrate)
     codec: "libmp3lame"

--- a/.claude/skills/masterup/config.default.yaml
+++ b/.claude/skills/masterup/config.default.yaml
@@ -129,6 +129,7 @@ validation:
 post_processing:
   suno_audio_cleanup:
     enabled: true               # 既定 ON。false で Suno DL 後の個別音源 cleanup を無効化
+    max_workers: 2              # apply の曲単位最大並列数。CLI --jobs が優先
     backup_originals: true      # 02-Individual-music/originals-pre-cleanup/ に元ファイルを保存
     bitrate: "192k"             # libmp3lame 出力ビットレート (未指定なら audio.bitrate)
     codec: "libmp3lame"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
+- `perf(masterup)`: `yt-suno-audio-cleanup apply` を曲単位の bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の上限解決、直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。
 - `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。
 - `refactor(setup)`: 排他的な `/setup --channel` を追加し、新規開設 Step 1〜10 の canonical contract と opening-only references / helpers の owner を setup へ移した。旧 `/channel-new` の opening trigger・Step 1〜10 は setup contract への互換入口として維持し、取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産も変更しない（#3983）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
 - `perf(masterup)`: `yt-suno-audio-cleanup apply` を曲単位の bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の上限解決、直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。
+- `perf(masterup)`: `yt-suno-audio-cleanup apply` を安全上限8の曲単位 bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の解決、main thread の直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。
 - `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。
 - `refactor(setup)`: 排他的な `/setup --channel` を追加し、新規開設 Step 1〜10 の canonical contract と opening-only references / helpers の owner を setup へ移した。旧 `/channel-new` の opening trigger・Step 1〜10 は setup contract への互換入口として維持し、取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産も変更しない（#3983）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
-- `perf(masterup)`: `yt-suno-audio-cleanup apply` を曲単位の bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の上限解決、直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。
 - `perf(masterup)`: `yt-suno-audio-cleanup apply` を安全上限8の曲単位 bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の解決、main thread の直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。
 - `feat(setup)`: フラグなし `/setup` を strict manifest と決定的 state resolver による `tool` → `channel` の再開可能な chain にし、前提未達・不正 manifest・途中失敗では後段を止め、完了済み段の副作用を再実行しない（#3988）。
 - `refactor(channel-new)`: 新規開設 trigger と Step 1〜10 の互換実行を `/channel-new` から除去し、opening 文脈を artifact 無変更のまま `/setup --channel` へ案内して停止する residual 5-mode contract に固定した。取り込み・分析・方向性検討・再生成・設定 push と共有 branding/config 資産は変更しない（#3982）。

--- a/src/youtube_automation/commands/suno/suno_audio_cleanup.py
+++ b/src/youtube_automation/commands/suno/suno_audio_cleanup.py
@@ -12,6 +12,7 @@ import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError, ValidationError
@@ -23,6 +24,7 @@ _SKILL_NAME = "masterup"
 _BACKUP_DIRNAME = "originals-pre-cleanup"
 _SUPPORTED_EXTS = tuple(sorted(AUDIO_EXTS))
 _DEFAULT_MAX_WORKERS = 2
+_MAX_WORKERS_LIMIT = 8
 
 
 @dataclass(frozen=True)
@@ -96,14 +98,19 @@ def resolve_max_workers(cli_jobs: int | None, skill_cfg: Mapping[str, object]) -
         post = _as_mapping(skill_cfg.get("post_processing"), "post_processing")
         raw = _as_mapping(post.get("suno_audio_cleanup"), "post_processing.suno_audio_cleanup")
         config_value = raw.get("max_workers", _DEFAULT_MAX_WORKERS)
-        if isinstance(config_value, bool) or not isinstance(config_value, int) or config_value < 1:
+        if (
+            isinstance(config_value, bool)
+            or not isinstance(config_value, int)
+            or not 1 <= config_value <= _MAX_WORKERS_LIMIT
+        ):
             raise ConfigError(
-                "skill-config の post_processing.suno_audio_cleanup.max_workers は 1 以上の整数である必要があります: "
+                "skill-config の post_processing.suno_audio_cleanup.max_workers は "
+                f"1 以上 {_MAX_WORKERS_LIMIT} 以下の整数である必要があります: "
                 f"{config_value!r}"
             )
         return config_value
-    if isinstance(cli_jobs, bool) or not isinstance(cli_jobs, int) or cli_jobs < 1:
-        raise ValidationError(f"jobs は 1 以上の整数である必要があります: {cli_jobs!r}")
+    if isinstance(cli_jobs, bool) or not isinstance(cli_jobs, int) or not 1 <= cli_jobs <= _MAX_WORKERS_LIMIT:
+        raise ValidationError(f"jobs は 1 以上 {_MAX_WORKERS_LIMIT} 以下の整数である必要があります: {cli_jobs!r}")
     return cli_jobs
 
 
@@ -111,9 +118,11 @@ def _positive_jobs(value: str) -> int:
     try:
         jobs = int(value)
     except ValueError as error:
-        raise argparse.ArgumentTypeError("--jobs は 1 以上の整数を指定してください") from error
-    if jobs < 1:
-        raise argparse.ArgumentTypeError("--jobs は 1 以上の整数を指定してください")
+        raise argparse.ArgumentTypeError(
+            f"--jobs は 1 以上 {_MAX_WORKERS_LIMIT} 以下の整数を指定してください"
+        ) from error
+    if not 1 <= jobs <= _MAX_WORKERS_LIMIT:
+        raise argparse.ArgumentTypeError(f"--jobs は 1 以上 {_MAX_WORKERS_LIMIT} 以下の整数を指定してください")
     return jobs
 
 
@@ -274,6 +283,20 @@ def _process_files_parallel(
     return results, errors
 
 
+def _process_files_sequential(
+    files: list[Path],
+    cfg: CleanupConfig,
+    *,
+    force: bool,
+    quiet: bool,
+) -> int:
+    changed = 0
+    for path in files:
+        if process_file(path, cfg, apply=True, force=force, quiet=quiet):
+            changed += 1
+    return changed
+
+
 def cleanup_collection(
     collection_dir: Path,
     *,
@@ -289,6 +312,8 @@ def cleanup_collection(
             print("post_processing.suno_audio_cleanup.enabled=false のため何もしません")
         return 0
 
+    max_workers = resolve_max_workers(jobs, skill_cfg) if apply else None
+
     files = collect_audio_files(collection_dir)
     if not files:
         music_dir = CollectionPaths(collection_dir).music_dir
@@ -302,8 +327,13 @@ def cleanup_collection(
             print(f"planned: {len(files)} file(s), changed=0")
         return 0
 
-    max_workers = resolve_max_workers(jobs, skill_cfg)
-    results, errors = _process_files_parallel(files, cfg, max_workers=max_workers, force=force)
+    if max_workers == 1:
+        changed = _process_files_sequential(files, cfg, force=force, quiet=quiet)
+        if not quiet:
+            print(f"processed: {len(files)} file(s), changed={changed}")
+        return 0
+
+    results, errors = _process_files_parallel(files, cfg, max_workers=cast(int, max_workers), force=force)
     if not quiet:
         for path in files:
             if path not in results:
@@ -336,7 +366,10 @@ def build_parser() -> argparse.ArgumentParser:
         p.add_argument(
             "--jobs",
             type=_positive_jobs,
-            help="maximum concurrent files (default: post_processing.suno_audio_cleanup.max_workers, then 2)",
+            help=(
+                f"maximum concurrent files, 1-{_MAX_WORKERS_LIMIT} "
+                "(default: post_processing.suno_audio_cleanup.max_workers, then 2)"
+            ),
         )
     return parser
 

--- a/src/youtube_automation/commands/suno/suno_audio_cleanup.py
+++ b/src/youtube_automation/commands/suno/suno_audio_cleanup.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import os
 import shutil
 import subprocess
@@ -21,6 +22,7 @@ from youtube_automation.infrastructure.media.probe import probe_duration
 _SKILL_NAME = "masterup"
 _BACKUP_DIRNAME = "originals-pre-cleanup"
 _SUPPORTED_EXTS = tuple(sorted(AUDIO_EXTS))
+_DEFAULT_MAX_WORKERS = 2
 
 
 @dataclass(frozen=True)
@@ -65,7 +67,6 @@ def resolve_cleanup_config(skill_cfg: Mapping[str, object]) -> CleanupConfig:
     trim = _as_mapping(raw.get("trim_silence"), "post_processing.suno_audio_cleanup.trim_silence")
     limiter = _as_mapping(raw.get("limiter"), "post_processing.suno_audio_cleanup.limiter")
     tail = _as_mapping(raw.get("tail_fade_guard"), "post_processing.suno_audio_cleanup.tail_fade_guard")
-
     return CleanupConfig(
         enabled=bool(raw.get("enabled", False)),
         backup_originals=bool(raw.get("backup_originals", True)),
@@ -88,6 +89,32 @@ def resolve_cleanup_config(skill_cfg: Mapping[str, object]) -> CleanupConfig:
         bitrate=str(raw.get("bitrate") or audio.get("bitrate") or "192k"),
         codec=str(raw.get("codec") or "libmp3lame"),
     )
+
+
+def resolve_max_workers(cli_jobs: int | None, skill_cfg: Mapping[str, object]) -> int:
+    if cli_jobs is None:
+        post = _as_mapping(skill_cfg.get("post_processing"), "post_processing")
+        raw = _as_mapping(post.get("suno_audio_cleanup"), "post_processing.suno_audio_cleanup")
+        config_value = raw.get("max_workers", _DEFAULT_MAX_WORKERS)
+        if isinstance(config_value, bool) or not isinstance(config_value, int) or config_value < 1:
+            raise ConfigError(
+                "skill-config の post_processing.suno_audio_cleanup.max_workers は 1 以上の整数である必要があります: "
+                f"{config_value!r}"
+            )
+        return config_value
+    if isinstance(cli_jobs, bool) or not isinstance(cli_jobs, int) or cli_jobs < 1:
+        raise ValidationError(f"jobs は 1 以上の整数である必要があります: {cli_jobs!r}")
+    return cli_jobs
+
+
+def _positive_jobs(value: str) -> int:
+    try:
+        jobs = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("--jobs は 1 以上の整数を指定してください") from error
+    if jobs < 1:
+        raise argparse.ArgumentTypeError("--jobs は 1 以上の整数を指定してください")
+    return jobs
 
 
 def _output_codec_for(path: Path, cfg: CleanupConfig) -> str:
@@ -207,8 +234,56 @@ def process_file(path: Path, cfg: CleanupConfig, *, apply: bool, force: bool, qu
     return True
 
 
-def cleanup_collection(collection_dir: Path, *, apply: bool, force: bool = False, quiet: bool = False) -> int:
-    cfg = resolve_cleanup_config(load_skill_config(_SKILL_NAME))
+def _process_files_parallel(
+    files: list[Path],
+    cfg: CleanupConfig,
+    *,
+    max_workers: int,
+    force: bool,
+) -> tuple[dict[Path, bool], dict[Path, Exception]]:
+    results: dict[Path, bool] = {}
+    errors: dict[Path, Exception] = {}
+    next_index = 0
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=min(max_workers, len(files)))
+    pending: dict[concurrent.futures.Future[bool], Path] = {}
+
+    def submit_next() -> None:
+        nonlocal next_index
+        path = files[next_index]
+        next_index += 1
+        future = executor.submit(process_file, path, cfg, apply=True, force=force, quiet=True)
+        pending[future] = path
+
+    try:
+        for _ in range(min(max_workers, len(files))):
+            submit_next()
+        while pending:
+            done, _ = concurrent.futures.wait(pending, return_when=concurrent.futures.FIRST_COMPLETED)
+            for future in done:
+                path = pending.pop(future)
+                try:
+                    results[path] = future.result()
+                except Exception as error:
+                    errors[path] = error
+            if errors:
+                continue
+            for _ in range(min(len(done), len(files) - next_index)):
+                submit_next()
+    finally:
+        executor.shutdown(wait=True, cancel_futures=True)
+    return results, errors
+
+
+def cleanup_collection(
+    collection_dir: Path,
+    *,
+    apply: bool,
+    jobs: int | None = None,
+    force: bool = False,
+    quiet: bool = False,
+) -> int:
+    skill_cfg = load_skill_config(_SKILL_NAME)
+    cfg = resolve_cleanup_config(skill_cfg)
     if not cfg.enabled and not force:
         if not quiet:
             print("post_processing.suno_audio_cleanup.enabled=false のため何もしません")
@@ -220,14 +295,29 @@ def cleanup_collection(collection_dir: Path, *, apply: bool, force: bool = False
         supported_exts = ", ".join(_SUPPORTED_EXTS)
         raise ValidationError(f"音声ファイル ({supported_exts}) が見つかりません: {music_dir}")
 
-    changed = 0
-    for path in files:
-        if process_file(path, cfg, apply=apply, force=force, quiet=quiet):
-            changed += 1
+    if not apply:
+        for path in files:
+            process_file(path, cfg, apply=False, force=force, quiet=quiet)
+        if not quiet:
+            print(f"planned: {len(files)} file(s), changed=0")
+        return 0
+
+    max_workers = resolve_max_workers(jobs, skill_cfg)
+    results, errors = _process_files_parallel(files, cfg, max_workers=max_workers, force=force)
+    if not quiet:
+        for path in files:
+            if path not in results:
+                continue
+            message = "cleaned" if results[path] else "skip already cleaned"
+            suffix = " (backup exists)" if not results[path] else ""
+            print(f"{message}: {path.name}{suffix}")
+    if errors:
+        details = "\n".join(f"{path.name}: {errors[path]}" for path in files if path in errors)
+        raise RuntimeError(f"audio cleanup failed:\n{details}")
 
     if not quiet:
-        action = "processed" if apply else "planned"
-        print(f"{action}: {len(files)} file(s), changed={changed}")
+        changed = sum(results.values())
+        print(f"processed: {len(files)} file(s), changed={changed}")
     return 0
 
 
@@ -243,6 +333,11 @@ def build_parser() -> argparse.ArgumentParser:
             help="run even when config is disabled; reprocess existing backups",
         )
         p.add_argument("--quiet", action="store_true")
+        p.add_argument(
+            "--jobs",
+            type=_positive_jobs,
+            help="maximum concurrent files (default: post_processing.suno_audio_cleanup.max_workers, then 2)",
+        )
     return parser
 
 
@@ -252,6 +347,7 @@ def main(argv: list[str] | None = None) -> int:
     return cleanup_collection(
         collection_dir,
         apply=args.command == "apply",
+        jobs=args.jobs,
         force=args.force,
         quiet=args.quiet,
     )

--- a/tests/commands/suno/test_suno_audio_cleanup.py
+++ b/tests/commands/suno/test_suno_audio_cleanup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from youtube_automation.commands.suno.suno_audio_cleanup import (
     collect_audio_files,
     process_file,
     resolve_cleanup_config,
+    resolve_max_workers,
 )
 from youtube_automation.core.errors import ConfigError
 
@@ -42,6 +44,7 @@ def test_resolve_cleanup_config_accepts_overrides() -> None:
             "post_processing": {
                 "suno_audio_cleanup": {
                     "enabled": True,
+                    "max_workers": 4,
                     "loudnorm": {"I": -16, "TP": -2},
                     "eq": {"muddiness_gain_db": -3},
                 }
@@ -58,6 +61,57 @@ def test_resolve_cleanup_config_accepts_overrides() -> None:
 def test_resolve_cleanup_config_rejects_bad_shape() -> None:
     with pytest.raises(ConfigError):
         resolve_cleanup_config({"post_processing": {"suno_audio_cleanup": "yes"}})
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, "2", None])
+def test_resolve_max_workers_rejects_invalid_config_value(value: object) -> None:
+    with pytest.raises(ConfigError, match="max_workers"):
+        resolve_max_workers(None, {"post_processing": {"suno_audio_cleanup": {"max_workers": value}}})
+
+
+def test_resolve_max_workers_prefers_cli_value() -> None:
+    invalid_lower_precedence = {"post_processing": {"suno_audio_cleanup": {"max_workers": "invalid"}}}
+    assert resolve_max_workers(3, invalid_lower_precedence) == 3
+
+
+def test_resolve_max_workers_uses_config_then_safe_default() -> None:
+    configured = {"post_processing": {"suno_audio_cleanup": {"max_workers": 4}}}
+    assert resolve_max_workers(None, configured) == 4
+    assert resolve_max_workers(None, {}) == 2
+
+
+def test_parser_rejects_non_positive_jobs_before_execution() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        mod.build_parser().parse_args(["apply", "collection", "--jobs", "0"])
+
+    assert exc_info.value.code == 2
+
+
+def test_main_passes_jobs_to_cleanup_collection(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(mod, "resolve_collection_dir", lambda value: Path(value))
+
+    def fake_cleanup_collection(collection_dir, *, apply, jobs, force, quiet):
+        captured.update(
+            collection_dir=collection_dir,
+            apply=apply,
+            jobs=jobs,
+            force=force,
+            quiet=quiet,
+        )
+        return 0
+
+    monkeypatch.setattr(mod, "cleanup_collection", fake_cleanup_collection)
+
+    assert mod.main(["apply", "collection", "--jobs", "3"]) == 0
+    assert captured == {
+        "collection_dir": Path("collection"),
+        "apply": True,
+        "jobs": 3,
+        "force": False,
+        "quiet": False,
+    }
 
 
 def test_build_filter_contains_expected_ffmpeg_steps() -> None:
@@ -83,6 +137,229 @@ def test_cleanup_collection_disabled_is_noop(tmp_path: Path, monkeypatch, capsys
     rc = cleanup_collection(collection, apply=False)
     assert rc == 0
     assert "enabled=false" in capsys.readouterr().out
+
+
+def test_cleanup_collection_apply_uses_bounded_default_concurrency(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(4)])
+    lock = threading.Lock()
+    two_running = threading.Event()
+    active = 0
+    peak = 0
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        nonlocal active, peak
+        assert apply is True
+        assert quiet is True
+        with lock:
+            active += 1
+            peak = max(peak, active)
+            if active == 2:
+                two_running.set()
+        assert two_running.wait(timeout=1)
+        with lock:
+            active -= 1
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    assert cleanup_collection(collection, apply=True, quiet=True) == 0
+    assert peak == 2
+
+
+def test_cleanup_collection_jobs_one_preserves_sequential_execution(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(3)])
+    active = 0
+    peak = 0
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True, "max_workers": 3}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        active -= 1
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    assert cleanup_collection(collection, apply=True, jobs=1, quiet=True) == 0
+    assert peak == 1
+
+
+def test_cleanup_collection_stops_submitting_after_failure(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(5)])
+    both_started = threading.Event()
+    started: list[str] = []
+    lock = threading.Lock()
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        with lock:
+            started.append(path.name)
+            if len(started) == 2:
+                both_started.set()
+        assert both_started.wait(timeout=1)
+        if path.name == "01.mp3":
+            raise RuntimeError("intentional failure")
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    with pytest.raises(RuntimeError, match="01.mp3.*intentional failure"):
+        cleanup_collection(collection, apply=True, quiet=True)
+
+    assert started == ["00.mp3", "01.mp3"]
+
+
+def test_cleanup_collection_cancellation_waits_for_started_work_and_does_not_submit_more(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(4)])
+    both_started = threading.Event()
+    release_peer = threading.Event()
+    started: list[str] = []
+    finished: list[str] = []
+    lock = threading.Lock()
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        with lock:
+            started.append(path.name)
+            if len(started) == 2:
+                both_started.set()
+        assert both_started.wait(timeout=1)
+        if path.name == "00.mp3":
+            release_peer.set()
+            raise KeyboardInterrupt
+        assert release_peer.wait(timeout=1)
+        finished.append(path.name)
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    with pytest.raises(KeyboardInterrupt):
+        cleanup_collection(collection, apply=True, quiet=True)
+
+    assert started == ["00.mp3", "01.mp3"]
+    assert finished == ["01.mp3"]
+
+
+def test_cleanup_collection_reports_results_in_filename_order(tmp_path: Path, monkeypatch, capsys) -> None:
+    collection = _make_collection(tmp_path, ["03.mp3", "01.mp3", "02.mp3"])
+    all_started = threading.Barrier(3)
+    third_finished = threading.Event()
+    second_finished = threading.Event()
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True, "max_workers": 3}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        all_started.wait(timeout=1)
+        if path.name == "02.mp3":
+            assert third_finished.wait(timeout=1)
+            second_finished.set()
+        elif path.name == "01.mp3":
+            assert second_finished.wait(timeout=1)
+        else:
+            third_finished.set()
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    assert cleanup_collection(collection, apply=True) == 0
+    output = capsys.readouterr().out
+    assert output.index("cleaned: 01.mp3") < output.index("cleaned: 02.mp3") < output.index("cleaned: 03.mp3")
+
+
+def test_cleanup_collection_aggregates_errors_in_filename_order(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, ["03.mp3", "01.mp3", "02.mp3"])
+    all_started = threading.Barrier(3)
+    third_finished = threading.Event()
+    second_finished = threading.Event()
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True, "max_workers": 3}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        all_started.wait(timeout=1)
+        if path.name == "02.mp3":
+            assert third_finished.wait(timeout=1)
+            second_finished.set()
+        elif path.name == "01.mp3":
+            assert second_finished.wait(timeout=1)
+        else:
+            third_finished.set()
+        raise RuntimeError(f"failed {path.name}")
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        cleanup_collection(collection, apply=True, quiet=True)
+
+    message = str(exc_info.value)
+    assert message.index("01.mp3") < message.index("02.mp3") < message.index("03.mp3")
+
+
+def test_cleanup_collection_plan_stays_sequential_and_deterministic(tmp_path: Path, monkeypatch, capsys) -> None:
+    collection = _make_collection(tmp_path, ["02.mp3", "01.mp3"])
+    active = 0
+    peak = 0
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+    monkeypatch.setattr(mod, "probe_duration", lambda _path: 60)
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("plan must not execute ffmpeg")
+
+    monkeypatch.setattr(mod.subprocess, "run", fail_run)
+    real_process_file = mod.process_file
+
+    def observed_process_file(*args, **kwargs):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            return real_process_file(*args, **kwargs)
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(mod, "process_file", observed_process_file)
+
+    assert cleanup_collection(collection, apply=False, jobs=2) == 0
+    output = capsys.readouterr().out
+    assert peak == 1
+    assert output.index("01.mp3") < output.index("02.mp3")
 
 
 def test_process_file_apply_backs_up_original_and_replaces(tmp_path: Path, monkeypatch) -> None:

--- a/tests/commands/suno/test_suno_audio_cleanup.py
+++ b/tests/commands/suno/test_suno_audio_cleanup.py
@@ -63,7 +63,7 @@ def test_resolve_cleanup_config_rejects_bad_shape() -> None:
         resolve_cleanup_config({"post_processing": {"suno_audio_cleanup": "yes"}})
 
 
-@pytest.mark.parametrize("value", [0, -1, True, 1.5, "2", None])
+@pytest.mark.parametrize("value", [0, -1, 9, 10**100, True, 1.5, "2", None])
 def test_resolve_max_workers_rejects_invalid_config_value(value: object) -> None:
     with pytest.raises(ConfigError, match="max_workers"):
         resolve_max_workers(None, {"post_processing": {"suno_audio_cleanup": {"max_workers": value}}})
@@ -75,16 +75,56 @@ def test_resolve_max_workers_prefers_cli_value() -> None:
 
 
 def test_resolve_max_workers_uses_config_then_safe_default() -> None:
-    configured = {"post_processing": {"suno_audio_cleanup": {"max_workers": 4}}}
-    assert resolve_max_workers(None, configured) == 4
+    configured = {"post_processing": {"suno_audio_cleanup": {"max_workers": 8}}}
+    assert resolve_max_workers(None, configured) == 8
     assert resolve_max_workers(None, {}) == 2
 
 
-def test_parser_rejects_non_positive_jobs_before_execution() -> None:
+@pytest.mark.parametrize("value", [0, 9, 10**100])
+def test_parser_rejects_jobs_outside_safe_range_before_execution(value: int) -> None:
     with pytest.raises(SystemExit) as exc_info:
-        mod.build_parser().parse_args(["apply", "collection", "--jobs", "0"])
+        mod.build_parser().parse_args(["apply", "collection", "--jobs", str(value)])
 
     assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize("value", [0, 9, 10**100, True])
+def test_resolve_max_workers_rejects_invalid_programmatic_cli_value(value: object) -> None:
+    with pytest.raises(mod.ValidationError, match="jobs"):
+        resolve_max_workers(value, {})
+
+
+@pytest.mark.parametrize(
+    ("jobs", "configured", "error_type"),
+    [(9, 2, mod.ValidationError), (None, 9, ConfigError)],
+)
+def test_cleanup_collection_rejects_unsafe_jobs_before_collecting_files(
+    tmp_path: Path,
+    monkeypatch,
+    jobs: int | None,
+    configured: int,
+    error_type: type[Exception],
+) -> None:
+    collection = _make_collection(tmp_path, ["00.mp3"])
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True, "max_workers": configured}}},
+    )
+
+    def fail_collect(_collection):
+        raise AssertionError("files must not be collected before jobs validation")
+
+    monkeypatch.setattr(mod, "collect_audio_files", fail_collect)
+
+    with pytest.raises(error_type):
+        cleanup_collection(collection, apply=True, jobs=jobs)
+
+
+@pytest.mark.parametrize("value", [1, 8])
+def test_parser_accepts_jobs_boundary_values(value: int) -> None:
+    args = mod.build_parser().parse_args(["apply", "collection", "--jobs", str(value)])
+    assert args.jobs == value
 
 
 def test_main_passes_jobs_to_cleanup_collection(monkeypatch) -> None:
@@ -172,10 +212,45 @@ def test_cleanup_collection_apply_uses_bounded_default_concurrency(tmp_path: Pat
     assert peak == 2
 
 
-def test_cleanup_collection_jobs_one_preserves_sequential_execution(tmp_path: Path, monkeypatch) -> None:
-    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(3)])
+def test_cleanup_collection_caps_concurrency_at_explicit_upper_boundary(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(16)])
+    lock = threading.Lock()
+    eight_running = threading.Event()
     active = 0
     peak = 0
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+            if active == 8:
+                eight_running.set()
+        assert eight_running.wait(timeout=1)
+        with lock:
+            active -= 1
+        return True
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    assert cleanup_collection(collection, apply=True, jobs=8, quiet=True) == 0
+    assert peak == 8
+
+
+def test_cleanup_collection_jobs_one_uses_legacy_main_thread_and_immediate_progress(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    collection = _make_collection(tmp_path, [f"{index:02d}.mp3" for index in range(3)])
+    main_thread = threading.current_thread()
+    observed_threads: list[threading.Thread] = []
 
     monkeypatch.setattr(
         mod,
@@ -184,16 +259,57 @@ def test_cleanup_collection_jobs_one_preserves_sequential_execution(tmp_path: Pa
     )
 
     def fake_process_file(path, cfg, *, apply, force, quiet):
-        nonlocal active, peak
-        active += 1
-        peak = max(peak, active)
-        active -= 1
+        observed_threads.append(threading.current_thread())
+        assert quiet is False
+        if path.name != "00.mp3":
+            assert f"cleaned: {int(path.stem) - 1:02d}.mp3" in capsys.readouterr().out
+        print(f"cleaned: {path.name}")
         return True
 
     monkeypatch.setattr(mod, "process_file", fake_process_file)
 
-    assert cleanup_collection(collection, apply=True, jobs=1, quiet=True) == 0
-    assert peak == 1
+    assert cleanup_collection(collection, apply=True, jobs=1) == 0
+    assert observed_threads == [main_thread, main_thread, main_thread]
+
+
+def test_cleanup_collection_jobs_one_preserves_original_exception_type_and_message(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, ["00.mp3", "01.mp3"])
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    def fake_process_file(path, cfg, *, apply, force, quiet):
+        raise ValueError("legacy exact failure")
+
+    monkeypatch.setattr(mod, "process_file", fake_process_file)
+
+    with pytest.raises(ValueError, match="^legacy exact failure$"):
+        cleanup_collection(collection, apply=True, jobs=1)
+
+
+def test_cleanup_collection_jobs_one_prints_skip_progress_immediately(tmp_path: Path, monkeypatch, capsys) -> None:
+    collection = _make_collection(tmp_path, ["00.mp3", "01.mp3"])
+    music = collection / "02-Individual-music"
+    backup = music / "originals-pre-cleanup"
+    backup.mkdir()
+    for name in ("00.mp3", "01.mp3"):
+        (backup / name).write_bytes(b"original")
+
+    monkeypatch.setattr(
+        mod,
+        "load_skill_config",
+        lambda _skill: {"post_processing": {"suno_audio_cleanup": {"enabled": True}}},
+    )
+
+    assert cleanup_collection(collection, apply=True, jobs=1) == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "skip already cleaned: 00.mp3 (backup exists)",
+        "skip already cleaned: 01.mp3 (backup exists)",
+        "processed: 2 file(s), changed=0",
+    ]
 
 
 def test_cleanup_collection_stops_submitting_after_failure(tmp_path: Path, monkeypatch) -> None:
@@ -327,7 +443,7 @@ def test_cleanup_collection_aggregates_errors_in_filename_order(tmp_path: Path, 
     assert message.index("01.mp3") < message.index("02.mp3") < message.index("03.mp3")
 
 
-def test_cleanup_collection_plan_stays_sequential_and_deterministic(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_cleanup_collection_plan_stays_sequential_without_ffmpeg_encode(tmp_path: Path, monkeypatch, capsys) -> None:
     collection = _make_collection(tmp_path, ["02.mp3", "01.mp3"])
     active = 0
     peak = 0
@@ -339,10 +455,10 @@ def test_cleanup_collection_plan_stays_sequential_and_deterministic(tmp_path: Pa
     )
     monkeypatch.setattr(mod, "probe_duration", lambda _path: 60)
 
-    def fail_run(*args, **kwargs):
-        raise AssertionError("plan must not execute ffmpeg")
+    def fail_encode(*args, **kwargs):
+        raise AssertionError("plan must not execute ffmpeg encode")
 
-    monkeypatch.setattr(mod.subprocess, "run", fail_run)
+    monkeypatch.setattr(mod.subprocess, "run", fail_encode)
     real_process_file = mod.process_file
 
     def observed_process_file(*args, **kwargs):

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -333,6 +333,7 @@ def test_load_skill_config_masterup_enables_suno_cleanup_by_default(tmp_path, mo
     cfg = skill_config.load_skill_config("masterup", use_cache=False)
 
     assert cfg["post_processing"]["suno_audio_cleanup"]["enabled"] is True
+    assert cfg["post_processing"]["suno_audio_cleanup"]["max_workers"] == 2
     assert cfg["post_processing"]["suno_audio_cleanup"]["loudnorm"]["I"] == -14
 
 


### PR DESCRIPTION
## Summary

- `yt-suno-audio-cleanup apply` を曲単位の sliding bounded worker pool で処理し、同時実行数を `--jobs` → `post_processing.suno_audio_cleanup.max_workers` → `2` の順で解決する
- CLI/config/programmatic input を安全上限1〜8に制限し、範囲外・巨大値をファイル収集前に fail closed にする
- `--jobs 1` は worker thread・buffering・例外 wrapping を使わない従来の main-thread 逐次経路とし、即時の cleaned/skip progress と元例外型/文言を維持する
- 並列失敗時は新規投入を止め、開始済み task を回収し、結果・集約エラーを入力ファイル名順で出力する。tmp → backup → `os.replace`、codec、`--force`、`--quiet` も維持する

## Acceptance evidence

- bounded concurrency: 既定値 peak=2、明示上限 `--jobs 8` peak=8。CLI/config/programmatic の境界1/8を受理し、0/9/巨大値/不正型を拒否
- legacy sequential: jobs=1 は3曲すべて main thread、前曲の進捗が次曲開始前に観測可能。skip進捗とsummaryも即時順序を固定し、`ValueError("legacy exact failure")` の型・文言をそのまま伝播
- deterministic / fail-closed: 逆順完了でも stdout と複数エラーがファイル名順。失敗または cancellation 後は初期投入済みだけを回収し、残りを未投入のまま維持
- atomic/resource safety: ffmpeg failure、final replace failure、backup有無、cancellation shutdown の回帰テストを維持
- plan: ファイル名順に ffprobe で duration を取得して command を表示するが、ffmpeg encode は起動しない
- performance: 下記の完全な実行可能 benchmark で、同一12曲相当2秒WAVを毎回fresh copyし、warmup後にjobs=1/2を各3回実測。中央値44.88%短縮（基準25%）

## Verification

exact diff を `.git` 付き `--no-hardlinks` clean local clone へ適用して実行:

```text
$ nix develop --command uv run ruff check .
All checks passed!

$ nix develop --command uv run ruff format --check .
788 files already formatted

$ nix develop --command uv run yt-skills lint
lint 合格: 55 skill

$ nix develop --command uv run pytest tests/commands/suno/test_suno_audio_cleanup.py tests/configuration/test_skill_config.py tests/repo/test_channel_new_residual_contract.py -q
102 passed in 2.19s

$ nix develop --command uv run pytest -n auto
8514 passed, 1 skipped, 70 warnings in 215.52s
```

## Reproducible ffmpeg benchmark

Host: Apple M4 / 16 GiB / macOS 26.6.1 arm64 / 10 logical CPUs / Python 3.14.6 / ffmpeg 8.1.2.

```bash
nix develop --command uv run python - <<'PY'
import math
import os
import platform
import shutil
import statistics
import struct
import subprocess
import sys
import tempfile
import time
import wave
from pathlib import Path

from youtube_automation.commands.suno import suno_audio_cleanup as mod

print(f"platform={platform.platform()}")
print(f"machine={platform.machine()} cpu_count={os.cpu_count()} python={sys.version.split()[0]}")
print(subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True, check=True).stdout.splitlines()[0])

config = {
    "post_processing": {
        "suno_audio_cleanup": {
            "enabled": True,
            "max_workers": 2,
            "backup_originals": False,
            "trim_silence": {"enabled": False},
            "eq": {"enabled": False},
            "volume_smoothing": False,
            "limiter": {"enabled": False},
            "loudnorm": {"enabled": False},
            "tail_fade_guard": {"enabled": False},
        }
    }
}
original_loader = mod.load_skill_config
mod.load_skill_config = lambda _skill: config

try:
    with tempfile.TemporaryDirectory(prefix="issue-3860-benchmark-") as raw:
        root = Path(raw)
        fixture = root / "fixture.wav"
        with wave.open(str(fixture), "wb") as output:
            output.setnchannels(1)
            output.setsampwidth(2)
            output.setframerate(44100)
            frames = bytearray()
            for index in range(44100 * 2):
                sample = int(12000 * math.sin(2 * math.pi * 440 * index / 44100))
                frames.extend(struct.pack("<h", sample))
            output.writeframes(frames)

        def run(jobs: int, iteration: str) -> float:
            collection = root / f"jobs-{jobs}-{iteration}"
            music = collection / "02-Individual-music"
            music.mkdir(parents=True)
            for index in range(12):
                shutil.copyfile(fixture, music / f"{index:02d}.wav")
            started = time.perf_counter()
            result = mod.cleanup_collection(collection, apply=True, jobs=jobs, quiet=True)
            elapsed = time.perf_counter() - started
            if result != 0 or len(list(music.glob("*.wav"))) != 12:
                raise SystemExit(f"benchmark processing failed: jobs={jobs} result={result}")
            return elapsed

        run(2, "warmup")
        timings = {1: [], 2: []}
        for iteration in range(3):
            for jobs in (1, 2):
                timings[jobs].append(run(jobs, str(iteration)))
        sequential = statistics.median(timings[1])
        bounded = statistics.median(timings[2])
        improvement = (sequential - bounded) / sequential * 100
        print(f"jobs=1 samples={timings[1]} median={sequential:.6f}s")
        print(f"jobs=2 samples={timings[2]} median={bounded:.6f}s")
        print(f"median improvement={improvement:.2f}%")
        if improvement < 25:
            raise SystemExit("performance threshold not met")
finally:
    mod.load_skill_config = original_loader
PY
```

```text
platform=macOS-26.6.1-arm64-arm-64bit-Mach-O
machine=arm64 cpu_count=10 python=3.14.6
ffmpeg version 8.1.2 Copyright (c) 2000-2026 the FFmpeg developers
jobs=1 samples=[1.015443917014636, 1.0333131669904105, 1.05701216700254] median=1.033313s
jobs=2 samples=[0.5710316670010798, 0.5695360419922508, 0.5613014159898739] median=0.569536s
median improvement=44.88%
```

Closes #3860



### Required CI rerun evidence

- Initial test attempt: 1 failed, 8513 passed, 1 skipped; the sole failure was the out-of-scope tests/commands/collections/test_collection_serve_lifecycle.py::test_console_script_unexpected_sigterm_remains_traceable_failure, where server.communicate(timeout=10) timed out after SIGTERM. No collection server/test code was changed.
- The same exact head was already green in the clean --no-hardlinks clone full suite: 8514 passed, 1 skipped.
- Accepted failed-job rerun, without code changes: test passed in 3m50s (run 31587322786, job 94085286935).



### Final stack sync evidence

- gh stack sync completed without conflicts after main advanced.
- Head: f956326e37fae13ec04bd43d26b418aa536552d7
- Base main: f72332fba3c556245a2cf0d4951b4809e831dbec
- Fresh required CI run: 31588076591 (pending at evidence refresh; final status is reported by GitHub checks).


- Final fresh CI result for head f956326e37fae13ec04bd43d26b418aa536552d7: required lint passed in 37s and test passed in 4m0s; all related checks green.



### Final reviewer cleanup evidence

- Removed only the superseded duplicate #3860 CHANGELOG entry; retained the corrected safe-cap/main-thread entry.
- Commit diff: CHANGELOG.md only, 1 deletion. Implementation, config, and test blobs are unchanged from the CLEAR-reviewed head.
- Head: 9ebf2697c439b661f3ae89305b82ee169fb85bba
- Base main: f72332fba3c556245a2cf0d4951b4809e831dbec
- Fresh required CI run: 31588605258.


- Fresh required CI result for head 9ebf2697c439b661f3ae89305b82ee169fb85bba: lint passed in 43s and test passed in 3m51s; all related checks green.
