### PR TITLE
refactor(legacy-utils): facade純度を固定する (#3896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `refactor(skills)`: workflow / upload 系 11 skill の新規開設誘導だけを `/setup --channel` へ移し、既存取り込み・再生成・設定 push・共有 reference の `/channel-new` 経路と既存 failure gate を維持した（#3986）。
-- `refactor(legacy-utils)`: canonical owner と同一だった `legacy_utils/{worktree,profile}.py` を削除し、確認済み下流 facade 5 本の import・symbol identity・挙動と配布互換は維持したまま、facade への関数・class・実行文・任意代入の再導入を recursive 契約テストで拒否する（#3896）。
+- `refactor(legacy-utils)`: canonical owner と同一だった `legacy_utils/{worktree,profile}.py` を削除し、確認済み下流 facade 5 本の import・親属性・module/symbol identity・patch/state 挙動と配布互換は維持したまま、facade への実装・未許可 import/alias の再導入および削除 path の symlink/hardlink 復活を recursive 契約テストで拒否する（#3896）。
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
 - `perf(masterup)`: `yt-suno-audio-cleanup apply` を安全上限8の曲単位 bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の解決、main thread の直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `refactor(skills)`: workflow / upload 系 11 skill の新規開設誘導だけを `/setup --channel` へ移し、既存取り込み・再生成・設定 push・共有 reference の `/channel-new` 経路と既存 failure gate を維持した（#3986）。
+- `refactor(legacy-utils)`: canonical owner と同一だった `legacy_utils/{worktree,profile}.py` を削除し、確認済み下流 facade 5 本の import・symbol identity・挙動と配布互換は維持したまま、facade への関数・class・実行文・任意代入の再導入を recursive 契約テストで拒否する（#3896）。
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。
 - `refactor(skills)`: research / persona 系 8 skill の新規開設 handoff と config 未生成時の誘導だけを `/setup --channel` の対応 Step へ移し、分析・方向性検討・既存取り込み・再生成・共有 reference の `/channel-new` 経路は維持した（#3985）。
 - `perf(masterup)`: `yt-suno-audio-cleanup apply` を安全上限8の曲単位 bounded 並列処理にし、CLI `--jobs` → skill-config → 既定値2の解決、main thread の直列 override、ファイル単位原子性、失敗後の未投入停止、決定的な結果・エラー順を維持する（#3860）。

--- a/bench/README.md
+++ b/bench/README.md
@@ -32,7 +32,7 @@ uv run python -m bench.main --only cost_tracker
 
 ## section logger との連携
 
-`YT_PROFILE=1` を併用すると各 bench 内の section 計測 (`utils/profile.py`) も stderr に流れる。詳細プロファイルを JSONL で取りたい場合:
+`YT_PROFILE=1` を併用すると各 bench 内の section 計測 (`infrastructure/observability/profile.py`) も stderr に流れる。詳細プロファイルを JSONL で取りたい場合:
 
 ```bash
 YT_PROFILE=1 YT_PROFILE_OUT=/tmp/profile.jsonl \

--- a/docs/architecture/repository-reorganization-receipt.json
+++ b/docs/architecture/repository-reorganization-receipt.json
@@ -657,7 +657,6 @@
         "Canonical owner: src/youtube_automation/infrastructure/observability/profile.py",
         "Moved-source audit: src/youtube_automation/utils/profile.py",
         "Updated consumer: src/youtube_automation/infrastructure/cost_tracker.py",
-        "Updated consumer: src/youtube_automation/infrastructure/legacy_utils/profile.py",
         "Updated consumer: src/youtube_automation/infrastructure/media/veo_generator.py",
         "Updated consumer: src/youtube_automation/commands/analytics/benchmark_collector.py",
         "Updated consumer: src/youtube_automation/commands/media/generate_image.py",

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/__init__.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/__init__.py
@@ -1,4 +1,26 @@
 """Compatibility facade for the downstream image-provider import path."""
 
+import sys
+
 from youtube_automation.infrastructure.media.image_provider import *  # noqa: F403
-from youtube_automation.infrastructure.media.image_provider import prompt_schema as prompt_schema
+from youtube_automation.infrastructure.media.image_provider import (
+    composition as composition,
+)
+from youtube_automation.infrastructure.media.image_provider import (
+    config as config,
+)
+from youtube_automation.infrastructure.media.image_provider import (
+    gemini as gemini,
+)
+from youtube_automation.infrastructure.media.image_provider import (
+    openai as openai,
+)
+from youtube_automation.infrastructure.media.image_provider import (
+    prompt_schema as prompt_schema,
+)
+
+sys.modules[f"{__name__}.composition"] = composition
+sys.modules[f"{__name__}.config"] = config
+sys.modules[f"{__name__}.gemini"] = gemini
+sys.modules[f"{__name__}.openai"] = openai
+sys.modules[f"{__name__}.prompt_schema"] = prompt_schema

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/__init__.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/__init__.py
@@ -1,12 +1,4 @@
 """Compatibility facade for the downstream image-provider import path."""
 
-import importlib
-import sys
-
 from youtube_automation.infrastructure.media.image_provider import *  # noqa: F403
 from youtube_automation.infrastructure.media.image_provider import prompt_schema as prompt_schema
-
-for _name in ("config", "composition", "prompt_schema", "gemini", "openai"):
-    _module = importlib.import_module(f"youtube_automation.infrastructure.media.image_provider.{_name}")
-    sys.modules[f"{__name__}.{_name}"] = _module
-    setattr(sys.modules[__name__], _name, _module)

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/composition.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/composition.py
@@ -1,3 +1,7 @@
-"""Compatibility facade for image-provider composition helpers."""
+"""Compatibility module alias for image-provider composition helpers."""
 
-from youtube_automation.infrastructure.media.image_provider.composition import *  # noqa: F403
+import sys
+
+from youtube_automation.infrastructure.media.image_provider import composition as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/composition.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/composition.py
@@ -1,0 +1,3 @@
+"""Compatibility facade for image-provider composition helpers."""
+
+from youtube_automation.infrastructure.media.image_provider.composition import *  # noqa: F403

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/config.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/config.py
@@ -1,3 +1,7 @@
-"""Compatibility facade for image-provider configuration helpers."""
+"""Compatibility module alias for image-provider configuration helpers."""
 
-from youtube_automation.infrastructure.media.image_provider.config import *  # noqa: F403
+import sys
+
+from youtube_automation.infrastructure.media.image_provider import config as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/config.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/config.py
@@ -1,0 +1,3 @@
+"""Compatibility facade for image-provider configuration helpers."""
+
+from youtube_automation.infrastructure.media.image_provider.config import *  # noqa: F403

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/gemini.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/gemini.py
@@ -1,0 +1,3 @@
+"""Compatibility facade for the Gemini image provider."""
+
+from youtube_automation.infrastructure.media.image_provider.gemini import *  # noqa: F403

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/gemini.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/gemini.py
@@ -1,3 +1,7 @@
-"""Compatibility facade for the Gemini image provider."""
+"""Compatibility module alias for the Gemini image provider."""
 
-from youtube_automation.infrastructure.media.image_provider.gemini import *  # noqa: F403
+import sys
+
+from youtube_automation.infrastructure.media.image_provider import gemini as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/openai.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/openai.py
@@ -1,0 +1,3 @@
+"""Compatibility facade for the OpenAI image provider."""
+
+from youtube_automation.infrastructure.media.image_provider.openai import *  # noqa: F403

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/openai.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/openai.py
@@ -1,3 +1,7 @@
-"""Compatibility facade for the OpenAI image provider."""
+"""Compatibility module alias for the OpenAI image provider."""
 
-from youtube_automation.infrastructure.media.image_provider.openai import *  # noqa: F403
+import sys
+
+from youtube_automation.infrastructure.media.image_provider import openai as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/prompt_schema.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/prompt_schema.py
@@ -1,0 +1,3 @@
+"""Compatibility facade for the shared image prompt schema."""
+
+from youtube_automation.infrastructure.media.image_provider.prompt_schema import *  # noqa: F403

--- a/src/youtube_automation/infrastructure/legacy_utils/image_provider/prompt_schema.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/image_provider/prompt_schema.py
@@ -1,3 +1,7 @@
-"""Compatibility facade for the shared image prompt schema."""
+"""Compatibility module alias for the shared image prompt schema."""
 
-from youtube_automation.infrastructure.media.image_provider.prompt_schema import *  # noqa: F403
+import sys
+
+from youtube_automation.infrastructure.media.image_provider import prompt_schema as _canonical
+
+sys.modules[__name__] = _canonical

--- a/src/youtube_automation/infrastructure/legacy_utils/profile.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/profile.py
@@ -1,1 +1,0 @@
-../observability/profile.py

--- a/src/youtube_automation/infrastructure/legacy_utils/worktree.py
+++ b/src/youtube_automation/infrastructure/legacy_utils/worktree.py
@@ -1,1 +1,0 @@
-../vcs/worktree.py

--- a/tests/contracts/architecture/test_repository_reorganization_contract.py
+++ b/tests/contracts/architecture/test_repository_reorganization_contract.py
@@ -9,6 +9,7 @@ import ast
 import importlib
 import json
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -732,15 +733,167 @@ def _distribution_python_sources(wheel: Path, sdist: Path) -> tuple[set[str], se
         sdist_sources = {
             Path(*Path(member.name).parts[1:]).as_posix()
             for member in archive.getmembers()
-            if member.isfile() and member.name.endswith(".py")
+            if member.name.endswith(".py")
         }
     return wheel_sources, sdist_sources
 
 
-def _is_string_sequence(node: ast.AST) -> bool:
-    return isinstance(node, (ast.List, ast.Tuple)) and all(
-        isinstance(element, ast.Constant) and isinstance(element.value, str) for element in node.elts
-    )
+def _source_python_entries(source_root: Path) -> set[str]:
+    return {path.relative_to(source_root).as_posix() for path in source_root.rglob("*.py")}
+
+
+def _duplicate_legacy_utils_source_offenders(source_root: Path) -> list[str]:
+    entries = _source_python_entries(source_root)
+    offenders = [f"reintroduced duplicate source: {path}" for path in sorted(entries & REMOVED_DUPLICATE_LEGACY_UTILS)]
+    offenders.extend(f"missing canonical owner: {path}" for path in sorted(CANONICAL_LEGACY_UTILS_OWNERS - entries))
+    return offenders
+
+
+def _duplicate_legacy_utils_artifact_offenders(wheel: Path, sdist: Path) -> list[str]:
+    wheel_sources, sdist_sources = _distribution_python_sources(wheel, sdist)
+    removed_wheel = {f"youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
+    removed_sdist = {f"src/youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
+    canonical_wheel = {f"youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
+    canonical_sdist = {f"src/youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
+    offenders = [f"wheel reintroduced duplicate source: {path}" for path in sorted(wheel_sources & removed_wheel)]
+    offenders.extend(f"sdist reintroduced duplicate source: {path}" for path in sorted(sdist_sources & removed_sdist))
+    offenders.extend(f"wheel missing canonical owner: {path}" for path in sorted(canonical_wheel - wheel_sources))
+    offenders.extend(f"sdist missing canonical owner: {path}" for path in sorted(canonical_sdist - sdist_sources))
+    return offenders
+
+
+_LEGACY_FACADE_IMPORTS = {
+    "audio_visualizer_mask.py": {
+        ("youtube_automation.infrastructure.media.audio_visualizer_mask", (("*", None),)),
+    },
+    "channel_target.py": {
+        ("youtube_automation.configuration", (("channel_target", "_canonical"),)),
+    },
+    "cli_arguments.py": {
+        ("youtube_automation.commands._shared", (("arguments", "_canonical"),)),
+    },
+    "collection_paths.py": {
+        ("youtube_automation.infrastructure.media.collection_paths", (("*", None),)),
+    },
+    "genai_client.py": {
+        (
+            "youtube_automation.infrastructure.media.genai_client",
+            (
+                ("GLOBAL_LOCATION", None),
+                ("VEO_LOCATION", None),
+                ("create_genai_client", None),
+                ("create_global_genai_client", None),
+                ("create_veo_genai_client", None),
+            ),
+        ),
+    },
+    "image_provider/__init__.py": {
+        ("youtube_automation.infrastructure.media.image_provider", (("*", None),)),
+        (
+            "youtube_automation.infrastructure.media.image_provider",
+            (("composition", "composition"),),
+        ),
+        ("youtube_automation.infrastructure.media.image_provider", (("config", "config"),)),
+        ("youtube_automation.infrastructure.media.image_provider", (("gemini", "gemini"),)),
+        ("youtube_automation.infrastructure.media.image_provider", (("openai", "openai"),)),
+        (
+            "youtube_automation.infrastructure.media.image_provider",
+            (("prompt_schema", "prompt_schema"),),
+        ),
+    },
+    "image_provider/composition.py": {
+        (
+            "youtube_automation.infrastructure.media.image_provider",
+            (("composition", "_canonical"),),
+        ),
+    },
+    "image_provider/config.py": {
+        ("youtube_automation.infrastructure.media.image_provider", (("config", "_canonical"),)),
+    },
+    "image_provider/gemini.py": {
+        ("youtube_automation.infrastructure.media.image_provider", (("gemini", "_canonical"),)),
+    },
+    "image_provider/openai.py": {
+        ("youtube_automation.infrastructure.media.image_provider", (("openai", "_canonical"),)),
+    },
+    "image_provider/prompt_schema.py": {
+        (
+            "youtube_automation.infrastructure.media.image_provider",
+            (("prompt_schema", "_canonical"),),
+        ),
+    },
+    "setup_directory_contract.py": {
+        ("youtube_automation.infrastructure.collections.setup_directory_contract", (("*", None),)),
+        (
+            "youtube_automation.infrastructure.collections.setup_directory_contract",
+            (
+                ("SETUP_DIRECTORIES", None),
+                ("validate_existing_setup_directories", None),
+                ("validate_setup_directory_target", None),
+            ),
+        ),
+    },
+    "skill_config.py": {
+        ("youtube_automation.configuration", (("skills", "_canonical"),)),
+    },
+}
+_LEGACY_FACADE_SYMBOL_ALIASES = {
+    "cli_arguments.py": {"CompetitorArgumentParser": "CompetitorArgumentParser"},
+    "skill_config.py": {
+        "_cache": "_cache",
+        "_collect_deprecated_override_keys": "_collect_deprecated_override_keys",
+        "_warn_deprecated_override_keys": "_warn_deprecated_override_keys",
+        "_default_path": "_default_path",
+        "_channel_override_path": "_channel_override_path",
+        "_channel_override_candidates": "_channel_override_candidates",
+        "_override_candidate_exists": "_override_candidate_exists",
+        "_resolve_channel_override": "_resolve_channel_override",
+        "_deep_merge": "_deep_merge",
+        "_load_yaml": "_load_yaml",
+        "_load_json": "_load_json",
+        "_load_override": "_load_override",
+        "THUMBNAIL_MODE_PARALLEL": "THUMBNAIL_MODE_PARALLEL",
+        "THUMBNAIL_MODE_SEQUENTIAL": "THUMBNAIL_MODE_SEQUENTIAL",
+        "load_skill_config": "load_skill_config",
+        "load_channel_override": "load_channel_override",
+        "get_collection_ideate_thumbnail_mode": "get_collection_ideate_thumbnail_mode",
+        "reset": "reset",
+    },
+}
+_LEGACY_FACADE_ALL = {
+    "genai_client.py": (
+        "GLOBAL_LOCATION",
+        "VEO_LOCATION",
+        "create_genai_client",
+        "create_global_genai_client",
+        "create_veo_genai_client",
+    ),
+    "setup_directory_contract.py": (
+        "SETUP_DIRECTORIES",
+        "validate_existing_setup_directories",
+        "validate_setup_directory_target",
+    ),
+}
+_LEGACY_FACADE_MODULE_ALIASES = frozenset(
+    {
+        "channel_target.py",
+        "image_provider/composition.py",
+        "image_provider/config.py",
+        "image_provider/gemini.py",
+        "image_provider/openai.py",
+        "image_provider/prompt_schema.py",
+    }
+)
+_LEGACY_FACADE_CHILD_MODULE_ALIASES = {
+    "image_provider/__init__.py": frozenset({"composition", "config", "gemini", "openai", "prompt_schema"}),
+}
+_LEGACY_FACADE_PATHS = frozenset(
+    {
+        "__init__.py",
+        "schemas/__init__.py",
+        *_LEGACY_FACADE_IMPORTS,
+    }
+)
 
 
 def _is_module_alias_target(node: ast.AST) -> bool:
@@ -758,24 +911,79 @@ def _is_module_alias_target(node: ast.AST) -> bool:
     return isinstance(key, ast.Name) and key.id == "__name__"
 
 
-def _is_reexport_assignment(node: ast.Assign) -> bool:
+def _historical_child_alias_name(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Subscript):
+        return None
+    modules = node.value
+    if not (
+        isinstance(modules, ast.Attribute)
+        and isinstance(modules.value, ast.Name)
+        and modules.value.id == "sys"
+        and modules.attr == "modules"
+    ):
+        return None
+    key = node.slice
+    if not isinstance(key, ast.JoinedStr) or len(key.values) != 2:
+        return None
+    parent, suffix = key.values
+    if not (
+        isinstance(parent, ast.FormattedValue)
+        and isinstance(parent.value, ast.Name)
+        and parent.value.id == "__name__"
+        and parent.conversion == -1
+        and parent.format_spec is None
+        and isinstance(suffix, ast.Constant)
+        and isinstance(suffix.value, str)
+        and suffix.value.startswith(".")
+    ):
+        return None
+    return suffix.value.removeprefix(".")
+
+
+def _is_allowed_reexport_assignment(relative: str, node: ast.Assign) -> bool:
     if len(node.targets) != 1:
         return False
     target = node.targets[0]
     if isinstance(target, ast.Name) and target.id == "__all__":
-        return _is_string_sequence(node.value)
-    if isinstance(target, ast.Name):
-        return (
-            isinstance(node.value, ast.Attribute)
-            and isinstance(node.value.value, ast.Name)
-            and node.value.value.id.startswith("_")
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            return False
+        values = tuple(
+            element.value
+            for element in node.value.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
         )
-    return _is_module_alias_target(target) and isinstance(node.value, ast.Name) and node.value.id.startswith("_")
+        return len(values) == len(node.value.elts) and values == _LEGACY_FACADE_ALL.get(relative)
+    if isinstance(target, ast.Name):
+        aliases = _LEGACY_FACADE_SYMBOL_ALIASES.get(relative, {})
+        return (
+            aliases.get(target.id) is not None
+            and isinstance(node.value, ast.Attribute)
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "_canonical"
+            and node.value.attr == aliases[target.id]
+        )
+    is_whole_module_alias = (
+        relative in _LEGACY_FACADE_MODULE_ALIASES
+        and _is_module_alias_target(target)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "_canonical"
+    )
+    child_alias = _historical_child_alias_name(target)
+    is_child_module_alias = (
+        child_alias in _LEGACY_FACADE_CHILD_MODULE_ALIASES.get(relative, frozenset())
+        and isinstance(node.value, ast.Name)
+        and node.value.id == child_alias
+    )
+    return is_whole_module_alias or is_child_module_alias
 
 
 def _legacy_facade_purity_offenders(legacy_root: Path) -> list[str]:
     offenders: list[str] = []
     for path in sorted(legacy_root.rglob("*.py")):
+        relative = path.relative_to(legacy_root).as_posix()
+        if relative not in _LEGACY_FACADE_PATHS:
+            offenders.append(f"{relative}: unexpected facade path")
+            continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for statement in tree.body:
             is_docstring = (
@@ -783,12 +991,25 @@ def _legacy_facade_purity_offenders(legacy_root: Path) -> list[str]:
                 and isinstance(statement.value, ast.Constant)
                 and isinstance(statement.value.value, str)
             )
-            is_reexport_import = isinstance(statement, ast.ImportFrom)
-            is_sys_import = isinstance(statement, ast.Import) and all(alias.name == "sys" for alias in statement.names)
-            is_reexport_assignment = isinstance(statement, ast.Assign) and _is_reexport_assignment(statement)
+            import_signature = (
+                (
+                    statement.module,
+                    tuple((alias.name, alias.asname) for alias in statement.names),
+                )
+                if isinstance(statement, ast.ImportFrom) and statement.level == 0
+                else None
+            )
+            is_reexport_import = import_signature in _LEGACY_FACADE_IMPORTS.get(relative, set())
+            is_sys_import = (
+                (relative in _LEGACY_FACADE_MODULE_ALIASES or relative in _LEGACY_FACADE_CHILD_MODULE_ALIASES)
+                and isinstance(statement, ast.Import)
+                and tuple((alias.name, alias.asname) for alias in statement.names) == (("sys", None),)
+            )
+            is_reexport_assignment = isinstance(statement, ast.Assign) and _is_allowed_reexport_assignment(
+                relative, statement
+            )
             if is_docstring or is_reexport_import or is_sys_import or is_reexport_assignment:
                 continue
-            relative = path.relative_to(legacy_root).as_posix()
             offenders.append(f"{relative}:{statement.lineno}: {type(statement).__name__}")
     return offenders
 
@@ -800,26 +1021,6 @@ def test_legacy_utils_contains_only_declarative_reexport_facades() -> None:
 
     # Then: no implementation, control flow, or import-time execution remains
     assert offenders == []
-
-
-def test_legacy_utils_purity_allows_only_declarative_reexport_shapes(tmp_path: Path) -> None:
-    # Given: a facade composed only of a docstring, imports, aliases, and __all__
-    facade = tmp_path / "facades" / "example.py"
-    facade.parent.mkdir()
-    facade.write_text(
-        '"""Compatibility facade."""\n'
-        "import sys\n"
-        "from canonical import exported as exported\n"
-        "from canonical import module as _canonical\n"
-        "alias = _canonical.alias\n"
-        "sys.modules[__name__] = _canonical\n"
-        '__all__ = ["alias", "exported"]\n',
-        encoding="utf-8",
-    )
-
-    # When: the generic recursive purity scanner inspects the facade
-    # Then: the supported declarative re-export surface is accepted
-    assert _legacy_facade_purity_offenders(facade.parent) == []
 
 
 @pytest.mark.parametrize(
@@ -839,10 +1040,11 @@ def test_legacy_utils_purity_rejects_implementation_reintroduction_mutations(
     mutation_name: str,
     source: str,
 ) -> None:
-    # Given: an arbitrary new facade file with one prohibited implementation shape
-    facade = tmp_path / "facades" / f"{mutation_name}.py"
-    facade.parent.mkdir(exist_ok=True)
-    facade.write_text(source, encoding="utf-8")
+    # Given: a real allowed facade with one prohibited implementation shape appended
+    facades = tmp_path / "facades"
+    shutil.copytree(LEGACY_UTILS, facades, symlinks=True)
+    facade = facades / "cli_arguments.py"
+    facade.write_text(f"{facade.read_text(encoding='utf-8')}\n{source}", encoding="utf-8")
 
     # When: the same recursive scanner used for production source inspects it
     offenders = _legacy_facade_purity_offenders(facade.parent)
@@ -851,14 +1053,126 @@ def test_legacy_utils_purity_rejects_implementation_reintroduction_mutations(
     assert offenders, mutation_name
 
 
+@pytest.mark.parametrize(
+    ("relative_path", "source"),
+    [
+        (
+            "cli_arguments.py",
+            "from youtube_automation.commands._shared import arguments as _canonical\n__path__ = _canonical.__path__\n",
+        ),
+        (
+            "cli_arguments.py",
+            "from youtube_automation.commands._shared import arguments as _canonical\n"
+            "__builtins__ = _canonical.__builtins__\n",
+        ),
+        (
+            "cli_arguments.py",
+            "from youtube_automation.commands._shared import arguments as _canonical\nrun = _canonical.side_effect\n",
+        ),
+        (
+            "channel_target.py",
+            "import sys\nimport evil as _canonical\nsys.modules[__name__] = _canonical\n",
+        ),
+        (
+            "image_provider/config.py",
+            "import sys\n"
+            "from youtube_automation.infrastructure.media.image_provider import openai as _canonical\n"
+            "sys.modules[__name__] = _canonical\n",
+        ),
+        ("collection_paths.py", "from evil.side_effect import *\n"),
+    ],
+)
+def test_legacy_utils_purity_rejects_fail_open_declarative_mutations(
+    tmp_path: Path,
+    relative_path: str,
+    source: str,
+) -> None:
+    # Given: an existing facade is replaced by a superficially declarative mutation
+    facades = tmp_path / "facades"
+    shutil.copytree(LEGACY_UTILS, facades, symlinks=True)
+    (facades / relative_path).write_text(source, encoding="utf-8")
+
+    # When: the production purity scanner checks the path-specific facade contract
+    offenders = _legacy_facade_purity_offenders(facades)
+
+    # Then: arbitrary aliases, import dunders, and external import redirects are rejected
+    assert offenders, relative_path
+
+
+@pytest.mark.parametrize(
+    ("expected", "mutation"),
+    [
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            'sys.modules[f"{__name__}.evil"] = config',
+        ),
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            'sys.modules[f"{__name__}.config"] = openai',
+        ),
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            'sys.modules[f"{__name__!r}.config"] = config',
+        ),
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            'sys.modules[f"{__name__!a}.config"] = config',
+        ),
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            'sys.modules[f"{__name__:>80}.config"] = config',
+        ),
+        (
+            'sys.modules[f"{__name__}.config"] = config',
+            "sys.modules[f\"{__name__:{print('facade side effect')}}.config\"] = config",
+        ),
+    ],
+)
+def test_legacy_utils_purity_rejects_unapproved_parent_child_module_aliases(
+    tmp_path: Path,
+    expected: str,
+    mutation: str,
+) -> None:
+    # Given: a real parent facade redirects an unknown key or the wrong canonical child
+    facades = tmp_path / "facades"
+    shutil.copytree(LEGACY_UTILS, facades, symlinks=True)
+    parent = facades / "image_provider" / "__init__.py"
+    source = parent.read_text(encoding="utf-8")
+    assert expected in source
+    parent.write_text(source.replace(expected, mutation), encoding="utf-8")
+
+    # When: the path-aware purity scanner checks its exact child alias declarations
+    offenders = _legacy_facade_purity_offenders(facades)
+
+    # Then: only the five approved key-to-canonical-module pairs are accepted
+    assert offenders
+
+
 def test_duplicate_legacy_utils_sources_are_removed_but_canonical_owners_remain() -> None:
     # Given: the duplicate facade paths and their canonical implementation owners
-    source_files = {path.relative_to(SRC).as_posix() for path in SRC.rglob("*.py") if path.is_file()}
-
     # When: the source distribution boundary is enumerated
+    offenders = _duplicate_legacy_utils_source_offenders(SRC)
+
     # Then: duplicate paths are absent and both canonical owners remain present
-    assert source_files.isdisjoint(REMOVED_DUPLICATE_LEGACY_UTILS)
-    assert CANONICAL_LEGACY_UTILS_OWNERS <= source_files
+    assert offenders == []
+
+
+def test_duplicate_legacy_utils_source_symlink_mutation_is_detected(tmp_path: Path) -> None:
+    # Given: a dangling symlink reintroduces one deleted Python path
+    source_root = tmp_path / "youtube_automation"
+    shutil.copytree(LEGACY_UTILS, source_root / "infrastructure" / "legacy_utils", symlinks=True)
+    for owner in CANONICAL_LEGACY_UTILS_OWNERS:
+        canonical = source_root / owner
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("# canonical owner\n", encoding="utf-8")
+    mutation = source_root / "infrastructure" / "legacy_utils" / "profile.py"
+    mutation.symlink_to("../observability/missing-profile.py")
+
+    # When: every Python directory entry is enumerated regardless of file type
+    offenders = _duplicate_legacy_utils_source_offenders(source_root)
+
+    # Then: the deleted path cannot return as a dangling symlink unnoticed
+    assert "reintroduced duplicate source: infrastructure/legacy_utils/profile.py" in offenders
 
 
 def test_built_distributions_exclude_duplicate_legacy_utils_sources(tmp_path: Path) -> None:
@@ -866,17 +1180,52 @@ def test_built_distributions_exclude_duplicate_legacy_utils_sources(tmp_path: Pa
     wheel, sdist = _build_distributions(ROOT, tmp_path / "legacy-utils-dist")
 
     # When: every Python source member in both archives is enumerated
-    wheel_sources, sdist_sources = _distribution_python_sources(wheel, sdist)
-    removed_wheel = {f"youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
-    removed_sdist = {f"src/youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
-    canonical_wheel = {f"youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
-    canonical_sdist = {f"src/youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
+    offenders = _duplicate_legacy_utils_artifact_offenders(wheel, sdist)
 
     # Then: neither archive ships a duplicate and both ship the canonical owners
-    assert wheel_sources.isdisjoint(removed_wheel)
-    assert sdist_sources.isdisjoint(removed_sdist)
-    assert canonical_wheel <= wheel_sources
-    assert canonical_sdist <= sdist_sources
+    assert offenders == []
+
+
+def test_distribution_symlink_and_hardlink_mutations_are_detected(tmp_path: Path) -> None:
+    # Given: real built archives are copied with deleted paths restored as links
+    wheel, sdist = _build_distributions(ROOT, tmp_path / "original-dist")
+    mutated_wheel = tmp_path / "mutated.whl"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(mutated_wheel, "w") as target:
+        for member in source.infolist():
+            target.writestr(member, source.read(member.filename))
+        link = zipfile.ZipInfo("youtube_automation/infrastructure/legacy_utils/profile.py")
+        link.create_system = 3
+        link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        target.writestr(link, "../observability/profile.py")
+
+    mutated_sdist = tmp_path / "mutated.tar.gz"
+    with tarfile.open(sdist) as source, tarfile.open(mutated_sdist, "w:gz") as target:
+        members = source.getmembers()
+        for member in members:
+            target.addfile(member, source.extractfile(member) if member.isfile() else None)
+        package_root = Path(members[0].name).parts[0]
+        symlink = tarfile.TarInfo(f"{package_root}/src/youtube_automation/infrastructure/legacy_utils/profile.py")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "../observability/profile.py"
+        target.addfile(symlink)
+        hardlink = tarfile.TarInfo(f"{package_root}/src/youtube_automation/infrastructure/legacy_utils/worktree.py")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = f"{package_root}/src/youtube_automation/infrastructure/vcs/worktree.py"
+        target.addfile(hardlink)
+
+    # When: every Python archive member name is enumerated regardless of member type
+    offenders = _duplicate_legacy_utils_artifact_offenders(mutated_wheel, mutated_sdist)
+
+    # Then: wheel symlinks and sdist symlink/hardlink entries all violate the absence contract
+    assert (
+        "wheel reintroduced duplicate source: youtube_automation/infrastructure/legacy_utils/profile.py"
+    ) in offenders
+    assert (
+        "sdist reintroduced duplicate source: src/youtube_automation/infrastructure/legacy_utils/profile.py"
+    ) in offenders
+    assert (
+        "sdist reintroduced duplicate source: src/youtube_automation/infrastructure/legacy_utils/worktree.py"
+    ) in offenders
 
 
 def test_built_distributions_contain_the_exact_core_adapter_surface(tmp_path: Path) -> None:
@@ -1666,4 +2015,83 @@ assert mask.parse_size("12x34") == (12, 34)
     )
 
     # Then: every facade delegates behavior to its canonical owner without divergence
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("submodule", ("config", "composition", "prompt_schema", "gemini", "openai"))
+def test_image_provider_submodule_facades_preserve_canonical_module_identity(submodule: str) -> None:
+    # Given: a downstream image-provider submodule path and its canonical owner
+    code = f"""
+import importlib
+
+facade = importlib.import_module("youtube_automation.utils.image_provider.{submodule}")
+canonical = importlib.import_module("youtube_automation.infrastructure.media.image_provider.{submodule}")
+assert facade is canonical
+"""
+
+    # When: both paths are imported in an isolated interpreter
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    # Then: patching and module state share the exact canonical module object
+    assert result.returncode == 0, result.stderr
+
+
+def test_image_provider_parent_import_registers_exact_canonical_child_modules() -> None:
+    # Given: a fresh interpreter that imports only the historical parent facade
+    code = """
+import importlib
+import sys
+
+parent_name = "youtube_automation.utils.image_provider"
+parent = importlib.import_module(parent_name)
+for child in ("config", "composition", "prompt_schema", "gemini", "openai"):
+    canonical_name = f"youtube_automation.infrastructure.media.image_provider.{child}"
+    canonical = sys.modules[canonical_name]
+    assert getattr(parent, child) is canonical
+    assert sys.modules[f"{parent_name}.{child}"] is canonical
+"""
+
+    # When: parent attributes and import registry entries are observed without child imports
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    # Then: all five historical child surfaces retain exact canonical module identity
+    assert result.returncode == 0, result.stderr
+
+
+def test_image_provider_composition_facade_preserves_patch_and_globals_seam() -> None:
+    # Given: downstream code imports the historical composition submodule
+    code = """
+import importlib
+
+facade = importlib.import_module("youtube_automation.utils.image_provider.composition")
+canonical = importlib.import_module("youtube_automation.infrastructure.media.image_provider.composition")
+original = facade.log_image_cost
+assert original.__globals__ is facade.__dict__
+replacement = object()
+facade.log_image_cost = replacement
+assert canonical.log_image_cost is replacement
+"""
+
+    # When: a downstream patch mutates the facade module
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    # Then: the canonical owner observes the same patch and function globals
     assert result.returncode == 0, result.stderr

--- a/tests/contracts/architecture/test_repository_reorganization_contract.py
+++ b/tests/contracts/architecture/test_repository_reorganization_contract.py
@@ -257,6 +257,47 @@ EXPECTED_CORE_ADAPTER_FILES = frozenset(
 CORE_ADAPTER_DOC_START = "<!-- core-adapter-surface:start -->"
 CORE_ADAPTER_DOC_END = "<!-- core-adapter-surface:end -->"
 
+LEGACY_UTILS = SRC / "infrastructure" / "legacy_utils"
+REMOVED_DUPLICATE_LEGACY_UTILS = frozenset(
+    {
+        "infrastructure/legacy_utils/profile.py",
+        "infrastructure/legacy_utils/worktree.py",
+    }
+)
+CANONICAL_LEGACY_UTILS_OWNERS = frozenset(
+    {
+        "infrastructure/observability/profile.py",
+        "infrastructure/vcs/worktree.py",
+    }
+)
+CONFIRMED_DOWNSTREAM_FACADES = (
+    (
+        "youtube_automation.infrastructure.errors",
+        "youtube_automation.core.errors",
+        "ConfigError",
+    ),
+    (
+        "youtube_automation.utils.skill_config",
+        "youtube_automation.configuration.skills",
+        "reset",
+    ),
+    (
+        "youtube_automation.utils.collection_paths",
+        "youtube_automation.infrastructure.media.collection_paths",
+        "CollectionPaths",
+    ),
+    (
+        "youtube_automation.utils.image_provider",
+        "youtube_automation.infrastructure.media.image_provider",
+        "PromptSchema",
+    ),
+    (
+        "youtube_automation.utils.audio_visualizer_mask",
+        "youtube_automation.infrastructure.media.audio_visualizer_mask",
+        "parse_size",
+    ),
+)
+
 
 def test_core_adapter_source_surface_is_exact() -> None:
     # Given: #3895 後に保持する明示 adapter と package file の最終集合
@@ -682,6 +723,160 @@ def _built_core_adapter_surface_offenders(wheel: Path, sdist: Path) -> list[str]
     offenders.extend(f"sdist missing core adapter file: {path}" for path in sorted(expected_sdist - sdist_surface))
     offenders.extend(f"sdist unexpected core adapter file: {path}" for path in sorted(sdist_surface - expected_sdist))
     return offenders
+
+
+def _distribution_python_sources(wheel: Path, sdist: Path) -> tuple[set[str], set[str]]:
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_sources = {member for member in archive.namelist() if member.endswith(".py")}
+    with tarfile.open(sdist) as archive:
+        sdist_sources = {
+            Path(*Path(member.name).parts[1:]).as_posix()
+            for member in archive.getmembers()
+            if member.isfile() and member.name.endswith(".py")
+        }
+    return wheel_sources, sdist_sources
+
+
+def _is_string_sequence(node: ast.AST) -> bool:
+    return isinstance(node, (ast.List, ast.Tuple)) and all(
+        isinstance(element, ast.Constant) and isinstance(element.value, str) for element in node.elts
+    )
+
+
+def _is_module_alias_target(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Subscript):
+        return False
+    modules = node.value
+    if not (
+        isinstance(modules, ast.Attribute)
+        and isinstance(modules.value, ast.Name)
+        and modules.value.id == "sys"
+        and modules.attr == "modules"
+    ):
+        return False
+    key = node.slice
+    return isinstance(key, ast.Name) and key.id == "__name__"
+
+
+def _is_reexport_assignment(node: ast.Assign) -> bool:
+    if len(node.targets) != 1:
+        return False
+    target = node.targets[0]
+    if isinstance(target, ast.Name) and target.id == "__all__":
+        return _is_string_sequence(node.value)
+    if isinstance(target, ast.Name):
+        return (
+            isinstance(node.value, ast.Attribute)
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id.startswith("_")
+        )
+    return _is_module_alias_target(target) and isinstance(node.value, ast.Name) and node.value.id.startswith("_")
+
+
+def _legacy_facade_purity_offenders(legacy_root: Path) -> list[str]:
+    offenders: list[str] = []
+    for path in sorted(legacy_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for statement in tree.body:
+            is_docstring = (
+                isinstance(statement, ast.Expr)
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, str)
+            )
+            is_reexport_import = isinstance(statement, ast.ImportFrom)
+            is_sys_import = isinstance(statement, ast.Import) and all(alias.name == "sys" for alias in statement.names)
+            is_reexport_assignment = isinstance(statement, ast.Assign) and _is_reexport_assignment(statement)
+            if is_docstring or is_reexport_import or is_sys_import or is_reexport_assignment:
+                continue
+            relative = path.relative_to(legacy_root).as_posix()
+            offenders.append(f"{relative}:{statement.lineno}: {type(statement).__name__}")
+    return offenders
+
+
+def test_legacy_utils_contains_only_declarative_reexport_facades() -> None:
+    # Given: every Python member of the recursive compatibility-facade namespace
+    # When: the facade purity contract classifies every top-level statement
+    offenders = _legacy_facade_purity_offenders(LEGACY_UTILS)
+
+    # Then: no implementation, control flow, or import-time execution remains
+    assert offenders == []
+
+
+def test_legacy_utils_purity_allows_only_declarative_reexport_shapes(tmp_path: Path) -> None:
+    # Given: a facade composed only of a docstring, imports, aliases, and __all__
+    facade = tmp_path / "facades" / "example.py"
+    facade.parent.mkdir()
+    facade.write_text(
+        '"""Compatibility facade."""\n'
+        "import sys\n"
+        "from canonical import exported as exported\n"
+        "from canonical import module as _canonical\n"
+        "alias = _canonical.alias\n"
+        "sys.modules[__name__] = _canonical\n"
+        '__all__ = ["alias", "exported"]\n',
+        encoding="utf-8",
+    )
+
+    # When: the generic recursive purity scanner inspects the facade
+    # Then: the supported declarative re-export surface is accepted
+    assert _legacy_facade_purity_offenders(facade.parent) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation_name", "source"),
+    [
+        ("function", "def implementation():\n    return 1\n"),
+        ("class", "class Implementation:\n    pass\n"),
+        ("assignment", "state = {}\n"),
+        ("control-flow", "if True:\n    value = 1\n"),
+        ("side-effect", "print('facade import')\n"),
+        ("import-time-call", "initialize()\n"),
+        ("plain-import", "import side_effect_module\n"),
+    ],
+)
+def test_legacy_utils_purity_rejects_implementation_reintroduction_mutations(
+    tmp_path: Path,
+    mutation_name: str,
+    source: str,
+) -> None:
+    # Given: an arbitrary new facade file with one prohibited implementation shape
+    facade = tmp_path / "facades" / f"{mutation_name}.py"
+    facade.parent.mkdir(exist_ok=True)
+    facade.write_text(source, encoding="utf-8")
+
+    # When: the same recursive scanner used for production source inspects it
+    offenders = _legacy_facade_purity_offenders(facade.parent)
+
+    # Then: the mutation cannot reintroduce executable implementation into a facade
+    assert offenders, mutation_name
+
+
+def test_duplicate_legacy_utils_sources_are_removed_but_canonical_owners_remain() -> None:
+    # Given: the duplicate facade paths and their canonical implementation owners
+    source_files = {path.relative_to(SRC).as_posix() for path in SRC.rglob("*.py") if path.is_file()}
+
+    # When: the source distribution boundary is enumerated
+    # Then: duplicate paths are absent and both canonical owners remain present
+    assert source_files.isdisjoint(REMOVED_DUPLICATE_LEGACY_UTILS)
+    assert CANONICAL_LEGACY_UTILS_OWNERS <= source_files
+
+
+def test_built_distributions_exclude_duplicate_legacy_utils_sources(tmp_path: Path) -> None:
+    # Given: wheel and sdist built from the current repository source
+    wheel, sdist = _build_distributions(ROOT, tmp_path / "legacy-utils-dist")
+
+    # When: every Python source member in both archives is enumerated
+    wheel_sources, sdist_sources = _distribution_python_sources(wheel, sdist)
+    removed_wheel = {f"youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
+    removed_sdist = {f"src/youtube_automation/{path}" for path in REMOVED_DUPLICATE_LEGACY_UTILS}
+    canonical_wheel = {f"youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
+    canonical_sdist = {f"src/youtube_automation/{path}" for path in CANONICAL_LEGACY_UTILS_OWNERS}
+
+    # Then: neither archive ships a duplicate and both ship the canonical owners
+    assert wheel_sources.isdisjoint(removed_wheel)
+    assert sdist_sources.isdisjoint(removed_sdist)
+    assert canonical_wheel <= wheel_sources
+    assert canonical_sdist <= sdist_sources
 
 
 def test_built_distributions_contain_the_exact_core_adapter_surface(tmp_path: Path) -> None:
@@ -1416,20 +1611,59 @@ assert 'identity-check' not in first._cache
     assert result.returncode == 0, result.stderr
 
 
-@pytest.mark.parametrize(
-    "legacy_module",
-    [
-        "youtube_automation.infrastructure.errors",
-        "youtube_automation.utils.skill_config",
-        "youtube_automation.utils.collection_paths",
-        "youtube_automation.utils.image_provider",
-        "youtube_automation.utils.audio_visualizer_mask",
-    ],
-)
-def test_only_confirmed_downstream_imports_remain_as_compatibility_facades(legacy_module: str) -> None:
+@pytest.mark.parametrize(("legacy_module", "canonical_module", "symbol"), CONFIRMED_DOWNSTREAM_FACADES)
+def test_only_confirmed_downstream_imports_remain_as_compatibility_facades(
+    legacy_module: str,
+    canonical_module: str,
+    symbol: str,
+) -> None:
     # Given: 計画で下流利用を確認した旧 import path
     # When: 旧 path を下流利用可能な facade として解決する
     module = importlib.import_module(legacy_module)
+    canonical = importlib.import_module(canonical_module)
 
-    # Then: facade は空の placeholder ではなく、公開 module としてロードできる
+    # Then: facade は公開 module としてロードでき、canonical symbol identity を保つ
     assert module.__name__ == legacy_module
+    assert getattr(module, symbol) is getattr(canonical, symbol)
+
+
+def test_confirmed_downstream_facades_preserve_runtime_behavior() -> None:
+    # Given: the five confirmed downstream facades loaded in an isolated interpreter
+    code = """
+import importlib
+from pathlib import Path
+
+errors = importlib.import_module("youtube_automation.infrastructure.errors")
+try:
+    raise errors.ConfigError("facade-behavior")
+except errors.ConfigError as exc:
+    assert str(exc) == "facade-behavior"
+
+skills = importlib.import_module("youtube_automation.utils.skill_config")
+canonical_skills = importlib.import_module("youtube_automation.configuration.skills")
+skills.reset()
+skills._cache["facade-behavior"] = {}
+canonical_skills.reset("facade-behavior")
+assert "facade-behavior" not in skills._cache
+
+paths = importlib.import_module("youtube_automation.utils.collection_paths")
+assert paths.CollectionPaths("example").root == Path("example").resolve()
+
+image_provider = importlib.import_module("youtube_automation.utils.image_provider")
+assert image_provider.PromptSchema(primary_request="facade-behavior").primary_request == "facade-behavior"
+
+mask = importlib.import_module("youtube_automation.utils.audio_visualizer_mask")
+assert mask.parse_size("12x34") == (12, 34)
+"""
+
+    # When: representative behavior is exercised through each historical path
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    # Then: every facade delegates behavior to its canonical owner without divergence
+    assert result.returncode == 0, result.stderr

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -130,6 +130,7 @@ def test_candidate_wheel_syncs_all_assets_into_clean_downstream(tmp_path: Path) 
         "-c",
         """
 import importlib
+import sys
 
 legacy_modules = (
     "youtube_automation.infrastructure.errors",
@@ -174,11 +175,26 @@ canonical_image_provider = importlib.import_module("youtube_automation.infrastru
 assert image_provider.PromptSchema is canonical_image_provider.PromptSchema
 assert image_provider.PromptSchema(primary_request="wheel").primary_request == "wheel"
 for submodule in ("config", "composition", "prompt_schema", "gemini", "openai"):
+    canonical_name = f"youtube_automation.infrastructure.media.image_provider.{submodule}"
+    canonical_submodule = sys.modules[canonical_name]
+    assert getattr(image_provider, submodule) is canonical_submodule
+    assert sys.modules[f"youtube_automation.utils.image_provider.{submodule}"] is canonical_submodule
+for submodule in ("config", "composition", "prompt_schema", "gemini", "openai"):
     facade_submodule = importlib.import_module(f"youtube_automation.utils.image_provider.{submodule}")
     canonical_submodule = importlib.import_module(
         f"youtube_automation.infrastructure.media.image_provider.{submodule}"
     )
-    assert facade_submodule.__name__ != canonical_submodule.__name__
+    assert facade_submodule is canonical_submodule
+
+composition = importlib.import_module("youtube_automation.utils.image_provider.composition")
+canonical_composition = importlib.import_module(
+    "youtube_automation.infrastructure.media.image_provider.composition"
+)
+original_log_image_cost = composition.log_image_cost
+assert original_log_image_cost.__globals__ is composition.__dict__
+replacement_log_image_cost = object()
+composition.log_image_cost = replacement_log_image_cost
+assert canonical_composition.log_image_cost is replacement_log_image_cost
 
 mask = importlib.import_module("youtube_automation.utils.audio_visualizer_mask")
 canonical_mask = importlib.import_module("youtube_automation.infrastructure.media.audio_visualizer_mask")

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -142,6 +142,49 @@ for module_name in legacy_modules:
     module = importlib.import_module(module_name)
     assert module.__name__ == module_name
 
+removed_modules = (
+    "youtube_automation.infrastructure.legacy_utils.profile",
+    "youtube_automation.infrastructure.legacy_utils.worktree",
+    "youtube_automation.utils.profile",
+    "youtube_automation.utils.worktree",
+)
+for module_name in removed_modules:
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        assert exc.name == module_name
+    else:
+        raise AssertionError(f"removed duplicate module remains importable: {module_name}")
+
+errors = importlib.import_module("youtube_automation.infrastructure.errors")
+canonical_errors = importlib.import_module("youtube_automation.core.errors")
+assert errors.ConfigError is canonical_errors.ConfigError
+try:
+    raise errors.ConfigError("wheel-facade-behavior")
+except errors.ConfigError as exc:
+    assert str(exc) == "wheel-facade-behavior"
+
+paths = importlib.import_module("youtube_automation.utils.collection_paths")
+canonical_paths = importlib.import_module("youtube_automation.infrastructure.media.collection_paths")
+assert paths.CollectionPaths is canonical_paths.CollectionPaths
+assert paths.CollectionPaths("example").collection_name == "example"
+
+image_provider = importlib.import_module("youtube_automation.utils.image_provider")
+canonical_image_provider = importlib.import_module("youtube_automation.infrastructure.media.image_provider")
+assert image_provider.PromptSchema is canonical_image_provider.PromptSchema
+assert image_provider.PromptSchema(primary_request="wheel").primary_request == "wheel"
+for submodule in ("config", "composition", "prompt_schema", "gemini", "openai"):
+    facade_submodule = importlib.import_module(f"youtube_automation.utils.image_provider.{submodule}")
+    canonical_submodule = importlib.import_module(
+        f"youtube_automation.infrastructure.media.image_provider.{submodule}"
+    )
+    assert facade_submodule.__name__ != canonical_submodule.__name__
+
+mask = importlib.import_module("youtube_automation.utils.audio_visualizer_mask")
+canonical_mask = importlib.import_module("youtube_automation.infrastructure.media.audio_visualizer_mask")
+assert mask.parse_size is canonical_mask.parse_size
+assert mask.parse_size("12x34") == (12, 34)
+
 canonical = importlib.import_module("youtube_automation.configuration.channel_target")
 legacy_channel_target = importlib.import_module("youtube_automation.infrastructure.legacy_utils.channel_target")
 compat_channel_target = importlib.import_module("youtube_automation.utils.channel_target")
@@ -154,6 +197,9 @@ legacy = importlib.import_module("youtube_automation.infrastructure.legacy_utils
 canonical_skills = importlib.import_module("youtube_automation.configuration.skills")
 assert legacy.reset is canonical_skills.reset
 assert legacy._cache is canonical_skills._cache
+compat_skills = importlib.import_module("youtube_automation.utils.skill_config")
+assert compat_skills.reset is canonical_skills.reset
+assert compat_skills._cache is canonical_skills._cache
 legacy.reset()
 legacy._cache["wheel-identity-check"] = {}
 canonical_skills.reset("wheel-identity-check")


### PR DESCRIPTION
## Summary

- Remove only the obsolete `infrastructure/legacy_utils/{profile,worktree}.py` paths while retaining `infrastructure/{observability/profile,vcs/worktree}.py` as canonical owners.
- Enforce a recursive, path-aware exact allowlist for every `legacy_utils` facade: only each file's canonical internal imports, exact symbol/module aliases and `__all__`, the six known whole-module aliases, and the five exact image-provider parent child aliases are accepted.
- Preserve the five confirmed downstream facades. Importing only `youtube_automation.utils.image_provider` exposes `config`, `composition`, `prompt_schema`, `gemini`, and `openai` as exact canonical module attributes and registers all five historical `sys.modules` keys. Direct child imports, monkeypatch/state, and function-globals identity remain canonical in source and an isolated wheel install.
- Enumerate all `.py` source entries and wheel/sdist member names regardless of file/link type, so deleted paths cannot return as dangling symlinks, archive symlinks, or hardlinks.

## Scope boundaries

- No `core/adapters`, `utils/__init__.__path__`, canonical runtime implementation, playlist code/tests, or broader architecture cleanup changes.
- Existing generated/untracked state was preserved.
- Final branch head is `ac95e4d84f5d3fbb05a2228342730eec63171a05`, rebased by `gh stack sync` onto main `b683e84e6d3c23e401befc23888fd1dba3c7d4eb`.
- This PR remains draft for adversarial parent review; it is not ready or merged.

## Acceptance evidence

- `gh api graphql ... issue(number:3896) { comments parent subIssues blockedBy blocking timelineItems }` — issue open; no comments, children, or blockers; parent #3938; no duplicate implementation PR.
- Exhaustive production/test/skill/docs/packaging inventory covered static imports and aliases/stars, dynamic import APIs, literal strings/paths, wheel/sdist contents, and downstream use. No active consumer remains for the deleted paths; canonical consumers use `infrastructure.observability.profile` and `infrastructure.vcs.worktree`.
- Earlier facade/link RED: `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py -q -k 'legacy_utils_purity_rejects_fail_open or duplicate_legacy_utils_source_symlink or distribution_symlink_and_hardlink or image_provider_submodule_facades or image_provider_composition_facade'` — `12 failed, 1 passed` before those fixes.
- Parent-alias RED: `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py::test_image_provider_parent_import_registers_exact_canonical_child_modules -q` — failed with `AttributeError: module 'youtube_automation.utils.image_provider' has no attribute 'config'` before the static parent aliases.
- F-string exactness RED: `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py::test_legacy_utils_purity_rejects_unapproved_parent_child_module_aliases -q` — `4 failed, 2 passed`; `!r`, `!a`, static `:>80`, and nested executable `{print('facade side effect')}` format-spec mutations all passed the old checker. Requiring `FormattedValue.conversion == -1` and `format_spec is None` made the same six cases pass.
- `git clone --no-hardlinks --branch codex/issue-3896-legacy-utils-facade-purity /Users/mba/.codex/worktrees/325c/00-automation /tmp/issue-3896-rebased.ter4yG/repository`, followed by exact head/base, clean index/worktree, and independent `.git` checks — head `ac95e4d84f5d3fbb05a2228342730eec63171a05`, merge-base `b683e84e6d3c23e401befc23888fd1dba3c7d4eb`.
- `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py -q -k 'legacy_utils_contains_only or legacy_utils_purity or image_provider_parent_import or image_provider_submodule_facades or image_provider_composition_facade or duplicate_legacy_utils or distribution_symlink_and_hardlink'` — `31 passed, 153 deselected`.
- `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py tests/repo/test_skills_sync_installed_wheel.py -q` — `186 passed`; includes parent-only source and isolated-wheel imports, all five exact parent attrs/registry entries, direct child identity, patch/state behavior, f-string mutations, link mutations, artifact absence, and canonical-owner presence.
- `nix develop --command uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract -q` — `659 passed`.
- `nix develop --command uv run pytest -n 4 -q` — `8557 passed, 1 skipped`.
- `nix develop --command uv run ruff check .` — pass.
- `nix develop --command uv run ruff format --check .` — `793 files already formatted` after rebasing onto main.
- `nix develop --command uv run pytest tests/repo/test_any_usage_gate.py tests/repo/test_changelog_ci_contract.py -q` — `12 passed`.
- `git diff --check origin/main...HEAD` — pass.

Closes #3896
