### PR TITLE
fix(metadata): 多言語の尺表示を正規化する (#3911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(metadata)`: duration display の locale を case・region 非依存で正規化し、fr/es/it/fil は各言語の単位、未知の有効 locale は warning 付き英語単位で生成して、多言語 metadata 全体の失敗を防ぐ（#3911）。
 - `refactor(skills)`: workflow / upload 系 11 skill の新規開設誘導だけを `/setup --channel` へ移し、既存取り込み・再生成・設定 push・共有 reference の `/channel-new` 経路と既存 failure gate を維持した（#3986）。
 - `refactor(legacy-utils)`: canonical owner と同一だった `legacy_utils/{worktree,profile}.py` を削除し、確認済み下流 facade 5 本の import・親属性・module/symbol identity・patch/state 挙動と配布互換は維持したまま、facade への実装・未許可 import/alias の再導入および削除 path の symlink/hardlink 復活を recursive 契約テストで拒否する（#3896）。
 - `refactor(cost)`: `cost_tracker` の重複ファイルロック実装を削除し、owner identity と既存の排他・失敗・cleanup・並列書き込み契約を維持したまま `infrastructure.file_lock` の canonical 実装へ一本化する（#3894）。

--- a/src/youtube_automation/domains/metadata/localizations.py
+++ b/src/youtube_automation/domains/metadata/localizations.py
@@ -174,12 +174,29 @@ def validate_scene_phrases(
         ValueError: 多言語チャンネルで scene_phrases が一部言語で欠落している場合、
             または `localizations.json` に `title_template` が無い言語がある場合.
     """
+    violations, _ = _validate_and_format_scene_titles(
+        scene_phrases,
+        config,
+        duration_seconds,
+        scene_emoji=scene_emoji,
+    )
+    return violations
+
+
+def _validate_and_format_scene_titles(
+    scene_phrases: Dict[str, str],
+    config,
+    duration_seconds: int | float,
+    *,
+    scene_emoji: str,
+) -> tuple[List[SceneTitleViolation], Dict[str, str]]:
+    """多言語タイトルを一度だけ検証・生成し、service と結果を共有する."""
     loc_config = config.localizations.data
     supported = loc_config.get("supported_languages", [])
 
     # 単一言語チャンネルは scene_phrases 不要（populate も no-op）#1470
     if not requires_scene_phrases(supported):
-        return []
+        return [], {}
 
     missing_langs = [lang for lang in supported if not scene_phrases.get(lang)]
     if missing_langs:
@@ -195,6 +212,7 @@ def validate_scene_phrases(
     best_for_line = desc_metadata.get("best_for", "Study, Focus, Late Night")
 
     violations: List[SceneTitleViolation] = []
+    titles: Dict[str, str] = {}
     for lang in supported:
         lang_data = loc_config["languages"].get(lang, {})
         title_tpl = lang_data.get("title_template")
@@ -202,7 +220,11 @@ def validate_scene_phrases(
             raise ValueError(f"localizations.json: language '{lang}' に title_template が無い")
         activities = lang_data.get("activities", best_for_line)
         scene = scene_phrases[lang]
-        duration_display = format_localized_duration_display(duration_seconds, lang)
+        duration_display = (
+            format_localized_duration_display(duration_seconds, lang)
+            if "duration_display" in _referenced_placeholders(title_tpl)
+            else ""
+        )
         title = format_title_template(
             title_tpl,
             _localized_title_values(
@@ -213,6 +235,7 @@ def validate_scene_phrases(
             ),
             context=f"localizations.json: language '{lang}' の title_template",
         )
+        titles[lang] = title
         if len(title) > 100:
             fixed_title = format_title_template(
                 title_tpl,
@@ -236,7 +259,7 @@ def validate_scene_phrases(
                     template=title_tpl,
                 )
             )
-    return violations
+    return violations, titles
 
 
 def format_scene_title_violations(violations: List[SceneTitleViolation]) -> str:

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -27,7 +27,6 @@ from youtube_automation.core.adapters.media import CollectionPaths, probe_durati
 from youtube_automation.core.adapters.runtime import (
     format_duration_display,
     format_duration_short,
-    format_localized_duration_display,
     format_timestamp,
 )
 from youtube_automation.core.errors import ValidationError
@@ -37,11 +36,10 @@ from youtube_automation.domains.metadata.descriptions import (
     build_short_description,
 )
 from youtube_automation.domains.metadata.localizations import (
-    _localized_title_values,
+    _validate_and_format_scene_titles,
     build_short_localizations,
     format_scene_title_violations,
     validate_localizations_title_templates,
-    validate_scene_phrases,
 )
 from youtube_automation.domains.metadata.tags import (
     build_collection_tags,
@@ -52,7 +50,6 @@ from youtube_automation.domains.metadata.titles import (
     _extract_pattern_key,
     build_collection_title,
     build_short_title,
-    format_title_template,
 )
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
@@ -725,7 +722,7 @@ class BAHMetadataGenerator:
 
         # 欠落チェック + 100 codepoint 超過を全言語まとめて検出する
         # （従来は 1 言語ずつ fail していたため多言語対応チャンネルで再アップロードを繰り返していた）
-        violations = validate_scene_phrases(
+        violations, localized_titles = _validate_and_format_scene_titles(
             scene_phrases,
             self.config,
             duration_seconds,
@@ -742,21 +739,8 @@ class BAHMetadataGenerator:
             lang_data = loc_config["languages"].get(lang, {})
             desc_data = lang_data.get("description", {})
 
-            # --- タイトル ---（validate_scene_phrases 済みなので必須キーは揃っている前提）
-            scene = scene_phrases[lang]
-            title_tpl = lang_data["title_template"]
-            activities = lang_data.get("activities", best_for_line)
-            duration_display = format_localized_duration_display(duration_seconds, lang)
-            loc_title = format_title_template(
-                title_tpl,
-                _localized_title_values(
-                    scene_phrase=scene,
-                    activities=activities,
-                    scene_emoji=scene_emoji,
-                    duration_display=duration_display,
-                ),
-                context=f"localizations.json: language '{lang}' の title_template",
-            )
+            # --- タイトル ---（検証時に同じ入力から生成済み）
+            loc_title = localized_titles[lang]
 
             # --- 概要欄（ハイブリッド方式）---
             opening_poem = desc_data.get("opening_poem", "")

--- a/src/youtube_automation/infrastructure/runtime/time_utils.py
+++ b/src/youtube_automation/infrastructure/runtime/time_utils.py
@@ -8,6 +8,41 @@ Usage:
     )
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+_GRANDFATHERED_LANGUAGE_TAGS = frozenset(
+    {
+        "art-lojban",
+        "cel-gaulish",
+        "en-gb-oed",
+        "i-ami",
+        "i-bnn",
+        "i-default",
+        "i-enochian",
+        "i-hak",
+        "i-klingon",
+        "i-lux",
+        "i-mingo",
+        "i-navajo",
+        "i-pwn",
+        "i-tao",
+        "i-tay",
+        "i-tsu",
+        "no-bok",
+        "no-nyn",
+        "sgn-be-fr",
+        "sgn-be-nl",
+        "sgn-ch-de",
+        "zh-guoyu",
+        "zh-hakka",
+        "zh-min",
+        "zh-min-nan",
+        "zh-xiang",
+    }
+)
+
 
 def format_duration_mss(seconds: float) -> str:
     """秒数を m:ss 形式にフォーマット（例: 225.0 → '3:45'）。"""
@@ -67,18 +102,111 @@ def format_duration_display(total_seconds: int | float) -> str:
 
 
 def format_localized_duration_display(total_seconds: int | float, locale: str) -> str:
-    """共通の丸め数値を locale ごとの単位で表示する."""
+    """共通の丸め数値を locale の単位で表示し、未知の有効 locale は英語 fallback を警告する."""
+    if not isinstance(locale, str):
+        raise TypeError(f"locale は文字列でなければなりません: {type(locale).__name__}")
+    normalized_locale = locale.strip().replace("_", "-")
+    if not _is_well_formed_bcp47_tag(normalized_locale):
+        raise ValueError(f"locale の形式が不正です: {locale!r}")
+
+    base_locale = normalized_locale.casefold().split("-", 1)[0]
     value, unit = _rounded_duration(total_seconds)
     units = {
         "en": {"minute": "min", "hour": "Hour" if value == "1" else "Hours"},
         "de": {"minute": "Min", "hour": "Std"},
         "ja": {"minute": "分", "hour": "時間"},
+        "fr": {"minute": "min", "hour": "heure" if value == "1" else "heures"},
+        "es": {"minute": "min", "hour": "hora" if value == "1" else "horas"},
+        "it": {"minute": "min", "hour": "ora" if value == "1" else "ore"},
+        "fil": {"minute": "min", "hour": "oras"},
     }
-    locale_units = units.get(locale)
+    locale_units = units.get(base_locale)
     if locale_units is None:
-        raise ValueError(f"duration_display に対応していない locale: {locale!r}。対応 locale は ja, en, de です")
-    separator = "" if locale == "ja" else " "
+        # YouTube が追加した有効 locale で metadata 全体を止めず、英語使用を warning で可視化する。
+        logger.warning("duration_display locale %r has no dedicated units; using English units", locale)
+        locale_units = units["en"]
+    separator = "" if base_locale == "ja" else " "
     return f"{value}{separator}{locale_units[unit]}"
+
+
+def _is_well_formed_bcp47_tag(locale: str) -> bool:
+    """RFC 5646 の Language-Tag ABNF と重複禁止規則を構造検証する."""
+    if not locale or not locale.isascii():
+        return False
+    subtags = locale.casefold().split("-")
+    if any(not _is_alphanumeric(subtag, minimum=1, maximum=8) for subtag in subtags):
+        return False
+    if locale.casefold() in _GRANDFATHERED_LANGUAGE_TAGS:
+        return True
+    if subtags[0] == "x":
+        return len(subtags) > 1
+
+    language = subtags[0]
+    if not _is_alpha(language, minimum=2, maximum=8):
+        return False
+    if len(language) == 4 or len(language) > 4:
+        index = 1
+    else:
+        index = 1
+        extlang_count = 0
+        while index < len(subtags) and extlang_count < 3 and _is_alpha(subtags[index], minimum=3, maximum=3):
+            index += 1
+            extlang_count += 1
+
+    if index < len(subtags) and _is_alpha(subtags[index], minimum=4, maximum=4):
+        index += 1
+    if index < len(subtags) and (
+        _is_alpha(subtags[index], minimum=2, maximum=2) or (len(subtags[index]) == 3 and subtags[index].isdigit())
+    ):
+        index += 1
+
+    variants: set[str] = set()
+    while index < len(subtags) and _is_variant(subtags[index]):
+        if subtags[index] in variants:
+            return False
+        variants.add(subtags[index])
+        index += 1
+
+    extension_singletons: set[str] = set()
+    while index < len(subtags) and _is_extension_singleton(subtags[index]):
+        singleton = subtags[index]
+        if singleton in extension_singletons:
+            return False
+        extension_singletons.add(singleton)
+        index += 1
+        extension_start = index
+        while index < len(subtags) and _is_alphanumeric(subtags[index], minimum=2, maximum=8):
+            index += 1
+        if index == extension_start:
+            return False
+
+    if index < len(subtags) and subtags[index] == "x":
+        index += 1
+        private_use_start = index
+        while index < len(subtags) and _is_alphanumeric(subtags[index], minimum=1, maximum=8):
+            index += 1
+        if index == private_use_start:
+            return False
+
+    return index == len(subtags)
+
+
+def _is_alpha(value: str, *, minimum: int, maximum: int) -> bool:
+    return minimum <= len(value) <= maximum and value.isascii() and value.isalpha()
+
+
+def _is_alphanumeric(value: str, *, minimum: int, maximum: int) -> bool:
+    return minimum <= len(value) <= maximum and value.isascii() and value.isalnum()
+
+
+def _is_variant(value: str) -> bool:
+    return _is_alphanumeric(value, minimum=5, maximum=8) or (
+        len(value) == 4 and value[0].isdigit() and _is_alphanumeric(value, minimum=4, maximum=4)
+    )
+
+
+def _is_extension_singleton(value: str) -> bool:
+    return len(value) == 1 and value != "x" and value.isascii() and value.isalnum()
 
 
 def _rounded_duration(total_seconds: int | float) -> tuple[str, str]:

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -5,6 +5,7 @@ BAHMetadataGenerator のユニットテスト
 副作用のない純粋ロジック（タイムスタンプ計算、ファイル名サニタイズ、メタデータ生成）を検証する。
 """
 
+import copy
 import json
 import shutil
 import sys
@@ -470,6 +471,143 @@ class TestGenerateCompleteCollectionMetadata:
         assert "ja" in locs
         assert "雨の街の夜テスト" in locs["ja"]["title"]
 
+    def test_generate_localizations_handles_supported_and_unknown_locales_with_or_without_duration_placeholder(
+        self, caplog
+    ):
+        gen = _make_generator()
+        gen.config = copy.deepcopy(gen.config)
+        supported = ["fr", "es", "it", "fil", "EN-us", "xx-ZZ"]
+        gen.config.localizations.data.clear()
+        gen.config.localizations.data.update(
+            {
+                "supported_languages": supported,
+                "languages": {
+                    lang: {
+                        "title_template": ("{scene_phrase} [{duration_display}]" if lang != "fil" else "{scene_phrase}")
+                    }
+                    for lang in supported
+                },
+            }
+        )
+        scene_phrases = {lang: f"focus {lang}" for lang in supported}
+
+        with caplog.at_level("WARNING"):
+            localizations = gen.generate_localizations(
+                english_title="Focus",
+                timestamp_body="00:00 Track 1",
+                scene_phrases=scene_phrases,
+                duration_seconds=90 * 60,
+            )
+
+        assert set(localizations) == set(supported)
+        assert localizations["fr"]["title"] == "focus fr [1.5 heures]"
+        assert localizations["es"]["title"] == "focus es [1.5 horas]"
+        assert localizations["it"]["title"] == "focus it [1.5 ore]"
+        assert localizations["fil"]["title"] == "focus fil"
+        assert localizations["EN-us"]["title"] == "focus EN-us [1.5 Hours]"
+        assert localizations["xx-ZZ"]["title"] == "focus xx-ZZ [1.5 Hours]"
+        assert "xx-ZZ" in caplog.text
+
+    @pytest.mark.parametrize(
+        "title_template, expected_calls, expected_warning_count",
+        [
+            ("{scene_phrase}", [], 0),
+            ("{scene_phrase} [{duration_display}]", ["pt-BR", "en"], 1),
+        ],
+    )
+    def test_generation_computes_duration_only_when_referenced_and_warns_once(
+        self,
+        title_template,
+        expected_calls,
+        expected_warning_count,
+        caplog,
+        monkeypatch,
+    ):
+        import youtube_automation.domains.metadata.localizations as localizations_module
+
+        gen = _make_generator()
+        gen.config = copy.deepcopy(gen.config)
+        supported = ["pt-BR", "en"]
+        gen.config.localizations.data.clear()
+        gen.config.localizations.data.update(
+            {
+                "supported_languages": supported,
+                "languages": {lang: {"title_template": title_template} for lang in supported},
+            }
+        )
+        calls = []
+        original_formatter = localizations_module.format_localized_duration_display
+
+        def tracked_formatter(duration_seconds, locale):
+            calls.append(locale)
+            return original_formatter(duration_seconds, locale)
+
+        monkeypatch.setattr(localizations_module, "format_localized_duration_display", tracked_formatter)
+
+        with caplog.at_level("WARNING"):
+            result = gen.generate_localizations(
+                english_title="Focus",
+                timestamp_body="00:00 Track 1",
+                scene_phrases={"pt-BR": "foco", "en": "focus"},
+                duration_seconds=3600,
+            )
+
+        warnings = [record for record in caplog.records if "duration_display locale" in record.getMessage()]
+        assert calls == expected_calls
+        assert len(warnings) == expected_warning_count
+        assert result["pt-BR"]["title"] == ("foco" if not expected_calls else "foco [1 Hour]")
+
+    @pytest.mark.parametrize(
+        "locale",
+        [
+            "en-a-aaa-b-bbb",
+            "en-x-private",
+            "x-private",
+            "i-default",
+        ],
+    )
+    def test_generation_accepts_structurally_valid_bcp47_locale(self, locale):
+        gen = _make_generator()
+        gen.config = copy.deepcopy(gen.config)
+        supported = [locale, "en"]
+        gen.config.localizations.data.clear()
+        gen.config.localizations.data.update(
+            {
+                "supported_languages": supported,
+                "languages": {lang: {"title_template": "{scene_phrase} [{duration_display}]"} for lang in supported},
+            }
+        )
+
+        result = gen.generate_localizations(
+            english_title="Focus",
+            timestamp_body="00:00 Track 1",
+            scene_phrases={locale: "focus locale", "en": "focus en"},
+            duration_seconds=3600,
+        )
+
+        assert result[locale]["title"] == "focus locale [1 Hour]"
+
+    @pytest.mark.parametrize("locale", ["en-12", "de-419-DE", "en-US-Latn"])
+    def test_generation_rejects_structurally_invalid_bcp47_locale(self, locale):
+        gen = _make_generator()
+        gen.config = copy.deepcopy(gen.config)
+        supported = [locale, "en"]
+        gen.config.localizations.data.clear()
+        gen.config.localizations.data.update(
+            {
+                "supported_languages": supported,
+                "languages": {lang: {"title_template": "{scene_phrase} [{duration_display}]"} for lang in supported},
+            }
+        )
+
+        with pytest.raises(ValueError, match="locale"):
+            gen.generate_localizations(
+                english_title="Focus",
+                timestamp_body="00:00 Track 1",
+                scene_phrases={locale: "focus locale", "en": "focus en"},
+                duration_seconds=3600,
+            )
+
     def test_localizations_missing_phrases_raises(self):
         """scene_phrase が一部欠落していると ValueError を raise する（fail-silent 防止）"""
         gen = _make_generator()
@@ -650,9 +788,8 @@ class TestFormatDurationDisplay:
     def test_localized_duration_uses_common_rounded_number(self, seconds, locale, expected):
         assert format_localized_duration_display(seconds, locale) == expected
 
-    def test_localized_duration_rejects_unsupported_locale(self):
-        with pytest.raises(ValueError, match="対応していない locale"):
-            format_localized_duration_display(3600, "fr")
+    def test_localized_duration_supports_french(self):
+        assert format_localized_duration_display(3600, "fr") == "1 heure"
 
     def test_very_short(self):
         """60秒 = 1分 → 最小 5 min"""
@@ -918,6 +1055,47 @@ class TestValidateScenePhrases:
         config = load_config()
         violations = validate_scene_phrases(_all_langs_phrases("short phrase"), config, 3600)
         assert violations == []
+
+    def test_supported_and_unknown_locales_validate_with_or_without_duration_placeholder(self, caplog, monkeypatch):
+        from types import SimpleNamespace
+
+        import youtube_automation.domains.metadata.localizations as localizations_module
+
+        supported = ["fr", "es", "it", "fil", "EN-us", "xx-ZZ"]
+        config = SimpleNamespace(
+            localizations=SimpleNamespace(
+                data={
+                    "supported_languages": supported,
+                    "languages": {
+                        lang: {
+                            "title_template": (
+                                "{scene_phrase} [{duration_display}]" if lang != "fil" else "{scene_phrase}"
+                            )
+                        }
+                        for lang in supported
+                    },
+                }
+            ),
+            content=SimpleNamespace(descriptions=SimpleNamespace(metadata={})),
+        )
+        scene_phrases = {lang: "focus" for lang in supported}
+        calls = []
+        original_formatter = localizations_module.format_localized_duration_display
+
+        def tracked_formatter(duration_seconds, locale):
+            calls.append(locale)
+            return original_formatter(duration_seconds, locale)
+
+        monkeypatch.setattr(localizations_module, "format_localized_duration_display", tracked_formatter)
+
+        with caplog.at_level("WARNING"):
+            violations = validate_scene_phrases(scene_phrases, config, 3600)
+
+        assert violations == []
+        assert calls == ["fr", "es", "it", "EN-us", "xx-ZZ"]
+        warnings = [record for record in caplog.records if "duration_display locale" in record.getMessage()]
+        assert len(warnings) == 1
+        assert "xx-ZZ" in warnings[0].getMessage()
 
     def test_single_language_over_limit(self):
         """1 言語だけ超過すれば 1 件返る"""

--- a/tests/infrastructure/runtime/test_time_utils.py
+++ b/tests/infrastructure/runtime/test_time_utils.py
@@ -11,6 +11,7 @@ from youtube_automation.infrastructure.runtime.time_utils import (
     format_duration_mmss,
     format_duration_mss,
     format_duration_short,
+    format_localized_duration_display,
     format_timestamp,
 )
 
@@ -162,3 +163,70 @@ class TestFormatDurationDisplay:
     )
     def test_rounds_to_half_hours_above_135min(self, seconds, expected):
         assert format_duration_display(seconds) == expected
+
+
+class TestFormatLocalizedDurationDisplay:
+    @pytest.mark.parametrize(
+        ("locale", "expected"),
+        [
+            ("ja", "1.5時間"),
+            ("en", "1.5 Hours"),
+            ("de", "1.5 Std"),
+            ("fr", "1.5 heures"),
+            ("ES-es", "1.5 horas"),
+            ("it_IT", "1.5 ore"),
+            ("fil-PH", "1.5 oras"),
+        ],
+    )
+    def test_formats_supported_base_locale_after_case_and_region_normalization(self, locale, expected):
+        assert format_localized_duration_display(90 * 60, locale) == expected
+
+    def test_unknown_valid_locale_uses_observable_english_fallback(self, caplog):
+        with caplog.at_level("WARNING"):
+            result = format_localized_duration_display(3600, "pt-BR")
+
+        assert result == "1 Hour"
+        assert "pt-BR" in caplog.text
+        assert "English" in caplog.text
+
+    @pytest.mark.parametrize(
+        "locale",
+        [
+            "en-a-aaa-b-bbb",
+            "en-x-private",
+            "x-private",
+            "i-default",
+        ],
+    )
+    def test_accepts_structurally_valid_bcp47_tags(self, locale):
+        assert format_localized_duration_display(3600, locale) == "1 Hour"
+
+    @pytest.mark.parametrize(
+        "locale",
+        [
+            "en-12",
+            "de-419-DE",
+            "en-US-Latn",
+            "en-a-aaa-a-bbb",
+            "en-1901-1901",
+        ],
+    )
+    def test_rejects_structurally_invalid_bcp47_tags(self, locale):
+        with pytest.raises(ValueError, match="locale"):
+            format_localized_duration_display(3600, locale)
+
+    @pytest.mark.parametrize(
+        ("locale", "expected_bytes"),
+        [
+            ("ja", "1時間".encode()),
+            ("en", b"1 Hour"),
+            ("de", b"1 Std"),
+        ],
+    )
+    def test_preserves_existing_54_minute_output_bytes(self, locale, expected_bytes):
+        assert format_localized_duration_display(54 * 60, locale).encode() == expected_bytes
+
+    @pytest.mark.parametrize("locale", ["", "   ", None, 42])
+    def test_invalid_locale_fails_loudly(self, locale):
+        with pytest.raises((TypeError, ValueError), match="locale"):
+            format_localized_duration_display(3600, locale)


### PR DESCRIPTION
## Summary

- Normalize case/region variants and validate locale structure against the [RFC 5646 Language-Tag ABNF](https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1), including extension, private-use, grandfathered, ordering, and duplicate constraints.
- Preserve existing ja/en/de bytes and rounding; add dedicated fr/es/it/fil units.
- Use an observable English fallback for structurally valid unknown locales; invalid locale values fail loudly.
- Compute `{duration_display}` only when the template references it, and share the validated title with service generation so one locale warns at most once per generation.

## Reproduction (before fix)

```text
$ uv run pytest -q tests/infrastructure/runtime/test_time_utils.py::TestFormatLocalizedDurationDisplay tests/domains/metadata/test_metadata_generator.py::TestGenerateCompleteCollectionMetadata::test_generate_localizations_handles_supported_and_unknown_locales_with_or_without_duration_placeholder tests/domains/metadata/test_metadata_generator.py::TestValidateScenePhrases::test_supported_and_unknown_locales_validate_with_or_without_duration_placeholder
7 failed, 7 passed in 3.56s
ValueError: duration_display に対応していない locale: 'fr'。対応 locale は ja, en, de です

$ uv run pytest -q tests/infrastructure/runtime/test_time_utils.py::TestFormatLocalizedDurationDisplay tests/domains/metadata/test_metadata_generator.py::TestGenerateCompleteCollectionMetadata::test_generation_computes_duration_only_when_referenced_and_warns_once tests/domains/metadata/test_metadata_generator.py::TestGenerateCompleteCollectionMetadata::test_generation_accepts_structurally_valid_bcp47_locale tests/domains/metadata/test_metadata_generator.py::TestGenerateCompleteCollectionMetadata::test_generation_rejects_structurally_invalid_bcp47_locale
17 failed, 16 passed in 0.63s
```

The second RED captures valid `en-a-aaa-b-bbb`, `en-x-private`, `x-private`, and `i-default` rejection; invalid `en-12`, `de-419-DE`, and `en-US-Latn` acceptance; unnecessary computation without the placeholder; and duplicate warning emission.

## Acceptance evidence

```text
$ uv run pytest -q tests/infrastructure/runtime/test_time_utils.py tests/domains/metadata/test_metadata_generator.py
252 passed in 0.77s

$ uv run pytest -q tests/domains/metadata tests/domains/uploads tests/commands/metadata tests/commands/uploads tests/commands/channel/test_channel_init.py tests/commands/media/test_populate_scene_phrases.py tests/repo/test_domains_reorganization.py
929 passed in 49.85s

$ git clone --no-hardlinks --branch codex/issue-3911-localized-duration-fallback /Users/mba/.codex/worktrees/7219/00-automation /tmp/issue3911-clean.cPxMIs && cd /tmp/issue3911-clean.cPxMIs && uv run pytest -n auto
8592 passed, 1 skipped, 60 warnings in 117.36s

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
793 files already formatted

$ bash .github/scripts/any-usage-gate.sh
exit 0

$ git diff --check
exit 0

$ uv build --out-dir /tmp/issue3911-dist.tFCzSo
Successfully built youtube_channels_automation-5.6.0.tar.gz
Successfully built youtube_channels_automation-5.6.0-py3-none-any.whl

$ uv pip install --python /tmp/issue3911-wheel-venv.Ow7FSS/bin/python /tmp/issue3911-dist.tFCzSo/youtube_channels_automation-5.6.0-py3-none-any.whl
Installed youtube-channels-automation==5.6.0
$ /tmp/issue3911-wheel-venv.Ow7FSS/bin/python -c "from youtube_automation.infrastructure.runtime.time_utils import format_localized_duration_display; assert format_localized_duration_display(3240, 'ja') == '1時間'; assert format_localized_duration_display(3240, 'en-a-aaa') == '1 Hour'"
exit 0

$ uv pip install --python /tmp/issue3911-sdist-venv.LTvQON/bin/python /tmp/issue3911-dist.tFCzSo/youtube_channels_automation-5.6.0.tar.gz
Installed youtube-channels-automation==5.6.0
$ /tmp/issue3911-sdist-venv.LTvQON/bin/python -c "from youtube_automation.infrastructure.runtime.time_utils import format_localized_duration_display; assert format_localized_duration_display(3240, 'de') == '1 Std'; assert format_localized_duration_display(3240, 'x-private') == '1 Hour'"
exit 0
```

## Branches

```text
head: codex/issue-3911-localized-duration-fallback
base: main
commit: 2dd8c9735d5db6fe10a4197b9c7f274ce293e097
```

## Required CI

```text
$ gh pr checks 4003 --required
lint  pass  38s
test  pass  3m10s
```

Closes #3911
