### PR TITLE
fix(analytics): partial 収益を広告カバレッジで受理する (#3910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。
 - `fix(metadata)`: duration display の locale を case・region 非依存で正規化し、fr/es/it/fil は各言語の単位、未知の有効 locale は warning 付き英語単位で生成して、多言語 metadata 全体の失敗を防ぐ（#3911）。
 - `refactor(skills)`: workflow / upload 系 11 skill の新規開設誘導だけを `/setup --channel` へ移し、既存取り込み・再生成・設定 push・共有 reference の `/channel-new` 経路と既存 failure gate を維持した（#3986）。

--- a/src/youtube_automation/commands/analytics/ad_coverage.py
+++ b/src/youtube_automation/commands/analytics/ad_coverage.py
@@ -60,6 +60,20 @@ def _parse_video_rows(by_video: object) -> list[VideoAdCoverage]:
     return videos
 
 
+def _partial_unavailable_reason(errors: object) -> str:
+    if not isinstance(errors, Mapping) or not errors:
+        raise ConfigError("partial な revenue_analytics.errors は空でない JSON object である必要があります")
+
+    reasons: list[str] = []
+    for dimension, reason in errors.items():
+        if not isinstance(dimension, str) or not dimension:
+            raise ConfigError("revenue_analytics.errors の dimension は空でない文字列である必要があります")
+        if not isinstance(reason, str) or not reason:
+            raise ConfigError(f"revenue_analytics.errors.{dimension} は空でない文字列である必要があります")
+        reasons.append(f"{dimension}: {reason}")
+    return "; ".join(reasons)
+
+
 def analyze_ad_coverage(
     revenue_analytics: Mapping[str, object], *, threshold: float, min_playbacks: int
 ) -> dict[str, object]:
@@ -70,6 +84,8 @@ def analyze_ad_coverage(
         raise ConfigError("min_playbacks は 1 以上で指定してください")
 
     status = revenue_analytics.get("status")
+    if not isinstance(status, str):
+        raise ConfigError("revenue_analytics.status は available、partial、unavailable のいずれかである必要があります")
     if status == "unavailable":
         reason = revenue_analytics.get("reason")
         if not isinstance(reason, str) or not reason:
@@ -80,10 +96,17 @@ def analyze_ad_coverage(
             "warning_count": 0,
             "warnings": [],
         }
-    if status != "available":
-        raise ConfigError("revenue_analytics.status は available または unavailable である必要があります")
+    if status not in {"available", "partial"}:
+        raise ConfigError("revenue_analytics.status は available、partial、unavailable のいずれかである必要があります")
 
     videos = _parse_video_rows(revenue_analytics.get("by_video"))
+    if status == "partial" and not videos:
+        return {
+            "status": "unavailable",
+            "reason": _partial_unavailable_reason(revenue_analytics.get("errors")),
+            "warning_count": 0,
+            "warnings": [],
+        }
     eligible = [video for video in videos if video.monetized_playbacks >= min_playbacks]
     median_value = float(median(video.ads_per_playback for video in eligible)) if eligible else None
 

--- a/tests/commands/analytics/test_ad_coverage.py
+++ b/tests/commands/analytics/test_ad_coverage.py
@@ -108,6 +108,56 @@ def test_analyze_preserves_unavailable_reason_without_warnings() -> None:
     }
 
 
+def test_analyze_accepts_partial_revenue_with_video_coverage_data() -> None:
+    revenue = {
+        "status": "partial",
+        "errors": {"day": "daily query forbidden"},
+        "by_video": {
+            "video-normal": _video(300, 2.0),
+            "video-low": _video(300, 0.4),
+        },
+    }
+
+    result = ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+    assert result["status"] == "available"
+    assert result["warning_count"] == 1
+    assert [warning["video_id"] for warning in result["warnings"]] == ["video-low"]
+
+
+def test_analyze_partial_revenue_keeps_missing_coverage_metrics_fail_closed() -> None:
+    revenue = {
+        "status": "partial",
+        "errors": {"day": "daily query forbidden"},
+        "by_video": {
+            "video-1": {
+                "monetized_playbacks": 600,
+                "estimated_revenue": 8.0,
+                "cpm": 13.0,
+            }
+        },
+    }
+
+    with pytest.raises(ConfigError, match="ads_per_playback は数値"):
+        ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+
+@pytest.mark.parametrize("status", [None, "unknown", 1])
+def test_analyze_rejects_unknown_or_malformed_revenue_status(status: object) -> None:
+    revenue = {"status": status, "by_video": {}}
+
+    with pytest.raises(ConfigError, match="available、partial、unavailable"):
+        ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+
+@pytest.mark.parametrize("status", [[], {}], ids=["list", "object"])
+def test_analyze_rejects_unhashable_revenue_status_as_config_error(status: object) -> None:
+    revenue = {"status": status, "by_video": {}}
+
+    with pytest.raises(ConfigError, match="available、partial、unavailable"):
+        ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
+
+
 def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkeypatch, capsys) -> None:
     _write_snapshot(tmp_path, "20260801", _available_revenue({"old": _video(200, 0.1)}))
     _write_snapshot(
@@ -131,6 +181,32 @@ def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkey
     assert [warning["video_id"] for warning in output["warnings"]] == ["video-mid"]
     assert output["warnings"][0]["ads_per_playback"] == 1.2
     assert output["warnings"][0]["median_ratio"] == pytest.approx(0.6)
+
+
+def test_entrypoint_degrades_empty_partial_video_data_without_breaking_pipeline(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_snapshot(
+        tmp_path,
+        "20260802",
+        {
+            "status": "partial",
+            "errors": {"video": "video query unsupported"},
+            "daily_metrics": [{"date": "2026-08-01", "estimated_revenue": 10.0}],
+            "by_video": {},
+        },
+    )
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
+
+    assert entrypoints.yt_ad_coverage() == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "unavailable",
+        "reason": "video: video query unsupported",
+        "warning_count": 0,
+        "warnings": [],
+    }
 
 
 def test_cli_text_reports_zero_warnings(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -174,6 +250,21 @@ def test_cli_returns_two_for_invalid_snapshot_shape(tmp_path: Path, monkeypatch,
     assert ad_coverage.main() == 2
 
     assert "JSON object" in caplog.text
+
+
+@pytest.mark.parametrize("status", [[], {}], ids=["list", "object"])
+def test_cli_returns_two_without_traceback_for_unhashable_revenue_status(
+    status: object, tmp_path: Path, monkeypatch, caplog, capsys
+) -> None:
+    _write_snapshot(tmp_path, "20260802", {"status": status, "by_video": {}})
+    monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
+
+    assert ad_coverage.main() == 2
+
+    captured = capsys.readouterr()
+    assert "available、partial、unavailable" in caplog.text
+    assert "Traceback" not in captured.err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- `revenue_analytics.status=partial` を `yt-ad-coverage` の既知 status として受理する
- partial かつ `by_video` が空なら producer の `errors` を reason に保持した unavailable 相当 JSON を返し、exit 0 でパイプラインを継続する
- status が文字列であることを membership 判定前に検証し、list / object を含む malformed status を既存どおり `ConfigError` / CLI exit 2 / traceback なしで fail closed にする
- partial かつ分析可能な動画別データは既存 available 経路で解析し、available / unavailable の既存出力を維持する

## Exact revision and scope

- Head: `95a36d4cf82705aecded594703f814ff2bf3e628`
- Base: `main` (`5a5b900a5b010d379f7c5ee828869e38eb8c9e4e` at branch creation)
- 3 files, `+117/-2`: `CHANGELOG.md` `+1/-0`; `ad_coverage.py` `+25/-2`; `test_ad_coverage.py` `+91/-0`

## Red → Green

- Initial RED: `nix develop --command uv run pytest tests/commands/analytics/test_ad_coverage.py -q` → `6 failed, 16 passed`; partial CLI reproduced exit 2
- Blocker RED: `... pytest tests/commands/analytics/test_ad_coverage.py -q -k unhashable` → `4 failed, 22 deselected`; direct and CLI list/object statuses escaped as `TypeError: unhashable type`
- Blocker GREEN: the same selection → `4 passed, 22 deselected`; list/object now raise `ConfigError`, CLI exits 2, and no traceback is emitted
- Focused production and analytics contracts → `129 passed`

## Clean-room validation

Executed from a fresh `git clone --no-hardlinks` checked out detached at the exact head, with `PYTHONDONTWRITEBYTECODE=1` set from the start:

- residual inventory contract → `5 passed`
- focused production and analytics contracts → `129 passed`
- `ruff check .` → passed
- `ruff format --check .` → `794 files already formatted`
- Any-usage gate → passed
- CI-equivalent changed-path / `CHANGELOG.md` gate → passed
- `git diff --check origin/main...HEAD` → passed
- `pytest -n auto` → `8640 passed, 1 skipped, 70 warnings` in `200.76s`
- wheel and sdist build passed; both contain `entrypoints.py` and `commands/analytics/ad_coverage.py`
- candidate wheel installed non-editably in an isolated venv: partial+empty exits 0 with the exact degraded JSON; malformed list and object each exit 2 with `ConfigError` and no traceback / `TypeError`

## Generated-artifact incident

During an earlier polluted-worktree full run, I incorrectly deleted the ignored generated artifact `.claude/skills/channel-new/references/__pycache__/fetch_branding_snapshot.cpython-314.pyc` after the inventory contract detected it. I immediately regenerated the same path with the same Python interpreter using the absolute source path; its restored observed size is 7757 bytes and current SHA-256 is `48d7f336c25f043ba4d44107b6d7f8fc65bc2fc40f57b38029c9962782ee85ad`. The polluted/interrupted worktree runs are excluded from final evidence. Neither that worktree nor the fresh clone/artifact environments were cleaned.

## Scope exclusions

- No provider-query / `dimensions=video` / `cpm` / `playbackBasedCpm` optimization
- No broad producer/consumer status-enum refactor
- No production/quality skill (#3987), Suno resolver (#3907), other branch, or other worktree changes

Closes #3910
