### PR TITLE
refactor(suno): prompt設定解決をdomainへ抽出する (#3907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。
+- `refactor(suno)`: prompt 生成の設定・patterns・歌詞・track count 解決と事後検証を `domains.suno.prompt_resolution` へ抽出し、command 側の pattern 生成と既存の 2 回解決配線、出力・警告・失敗契約を維持する（#3907）。
 - `fix(metadata)`: duration display の locale を case・region 非依存で正規化し、fr/es/it/fil は各言語の単位、未知の有効 locale は warning 付き英語単位で生成して、多言語 metadata 全体の失敗を防ぐ（#3911）。
 - `refactor(skills)`: workflow / upload 系 11 skill の新規開設誘導だけを `/setup --channel` へ移し、既存取り込み・再生成・設定 push・共有 reference の `/channel-new` 経路と既存 failure gate を維持した（#3986）。
 - `refactor(legacy-utils)`: canonical owner と同一だった `legacy_utils/{worktree,profile}.py` を削除し、確認済み下流 facade 5 本の import・親属性・module/symbol identity・patch/state 挙動と配布互換は維持したまま、facade への実装・未許可 import/alias の再導入および削除 path の symlink/hardlink 復活を recursive 契約テストで拒否する（#3896）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -7,87 +7,25 @@ import math
 import re
 import sys
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
-
-import yaml
 
 from youtube_automation.configuration.skills import load_channel_override, load_skill_config
 from youtube_automation.core.errors import ConfigError
-from youtube_automation.domains.suno.config import infer_suno_mode, resolve_suno_config
+from youtube_automation.domains.suno import prompt_resolution
 from youtube_automation.domains.suno.downloaded.models import (
     DOCUMENTATION_DIRNAME,
-    SUNO_LYRICS_JSON_FILENAME,
     SUNO_PATTERNS_FILENAME,
     SUNO_PROMPTS_JSON_FILENAME,
     SUNO_PROMPTS_MD_FILENAME,
 )
 from youtube_automation.domains.suno.downloaded.validation import (
-    positive_integer_issue,
-    require_instrumental_track_count,
-    require_matching_suno_lyrics_names,
-    require_unique_entry_names,
-    require_vocal_track_count,
     suno_prompt_entry_names,
     surrounding_whitespace_issue,
 )
 from youtube_automation.domains.suno.lyrics import load_suno_lyrics_by_name
 from youtube_automation.infrastructure.filesystem import write_text_files_transactionally
-from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
-
-_STYLE_VARIATION_BANNED_ADJECTIVES = frozenset(
-    {
-        "thundering",
-        "blazing",
-        "crushing",
-        "soaring",
-        "screaming",
-        "devastating",
-        "explosive",
-        "ferocious",
-        "towering",
-        "surging",
-        "crystalline",
-        "shimmering",
-        "lush",
-        "sweeping",
-        "majestic",
-        "glorious",
-        "echoing",
-    }
-)
-_STYLE_VARIATION_ENVIRONMENT_NG_WORDS = frozenset(
-    {
-        "ambient noise",
-        "dripping",
-        "drops",
-        "puddles",
-        "pouring",
-        "rain",
-        "rain sounds",
-        "splashing",
-        "streaming water",
-        "trickling",
-        "vinyl crackle",
-        "white noise",
-    }
-)
-_STYLE_VARIATION_BARE_INSTRUMENTS = frozenset(
-    {
-        "bass",
-        "cello",
-        "drums",
-        "flute",
-        "guitar",
-        "organ",
-        "piano",
-        "strings",
-        "synth",
-        "trumpet",
-    }
-)
 
 # ---------------------------------------------------------------------------
 # Quality rules (#904): suno-bgm ベースの品質ガード
@@ -96,10 +34,11 @@ _STYLE_VARIATION_BARE_INSTRUMENTS = frozenset(
 # Style text の 5 要素順序: ジャンル名 → 音響特性 → キー楽器 → リズム/ベース → テンポ
 # 厳密な順序検証は不可能（自然言語のため）だが、テンポ語が先頭付近にある場合は警告する
 _TEMPO_WORDS = frozenset({"very slow", "slow", "gentle", "moderate", "lively", "fast", "uptempo", "downtempo"})
-_DEFAULT_FULL_STYLE_CHAR_LIMIT = 256
 
 
-def validate_style_char_limit(style_text: str, *, limit: int = _DEFAULT_FULL_STYLE_CHAR_LIMIT) -> list[str]:
+def validate_style_char_limit(
+    style_text: str, *, limit: int = prompt_resolution.DEFAULT_FULL_STYLE_CHAR_LIMIT
+) -> list[str]:
     """Style テキストが文字数上限を超えていないか検証する.
 
     Returns: 警告メッセージのリスト (空なら問題なし)。
@@ -108,22 +47,6 @@ def validate_style_char_limit(style_text: str, *, limit: int = _DEFAULT_FULL_STY
     if len(style_text) > limit:
         warnings_list.append(f"Style text exceeds {limit} char limit ({len(style_text)} chars): {style_text[:80]}...")
     return warnings_list
-
-
-def _resolve_full_style_char_limit(suno: Mapping[str, object], override: Mapping[str, object]) -> int:
-    """完成形 Style の soft budget を後方互換の優先順位で解決する."""
-    if "full_style_char_limit" in override:
-        value = override["full_style_char_limit"]
-        source = "full_style_char_limit"
-    elif "style_char_limit" in override:
-        value = override["style_char_limit"]
-        source = "style_char_limit"
-    else:
-        value = suno.get("full_style_char_limit", _DEFAULT_FULL_STYLE_CHAR_LIMIT)
-        source = "full_style_char_limit"
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ConfigError(f"config/skills/suno.yaml::{source} must be a positive integer")
-    return value
 
 
 def validate_banned_artists(style_text: str, banned_artists: list[str]) -> list[str]:
@@ -225,95 +148,10 @@ def _style_line(tempo: str | None, effective_style: str, variation_descriptor: s
     return ", ".join(parts) + ","
 
 
-def _build_variation_sequence(pools: Mapping[str, list[str]]) -> list[str]:
-    # Sort axes so channel config key order cannot change generated prompts.
-    axes = [pools[name] for name in sorted(pools) if pools[name]]
-    if not axes:
-        return []
-    sequence: list[str] = []
-    for i in range(max(len(axis) for axis in axes)):
-        for axis in axes:
-            if i < len(axis):
-                sequence.append(axis[i])
-    return sequence
-
-
-def _variation_descriptor(entry_index: int, sequence: list[str]) -> str:
+def _variation_descriptor(entry_index: int, sequence: Sequence[str]) -> str:
     if entry_index == 0 or not sequence:
         return ""
     return sequence[(entry_index - 1) % len(sequence)]
-
-
-@dataclass(frozen=True)
-class _ResolvedStyleVariation:
-    enabled: bool
-    sequence: list[str]
-
-
-def _contains_token_or_phrase(text: str, phrase: str) -> bool:
-    if " " in phrase:
-        return phrase in text
-    return re.search(rf"\b{re.escape(phrase)}\b", text) is not None
-
-
-def _validate_style_variation_descriptor(axis: str, descriptor: str, banned_artists: list[str]) -> None:
-    normalized = " ".join(descriptor.lower().split())
-    if normalized in _STYLE_VARIATION_BARE_INSTRUMENTS:
-        raise ConfigError(f"suno.style_variation.pools.{axis} の descriptor は裸楽器名を使用できません: {descriptor!r}")
-    for word in sorted(_STYLE_VARIATION_BANNED_ADJECTIVES):
-        if _contains_token_or_phrase(normalized, word):
-            raise ConfigError(
-                f"suno.style_variation.pools.{axis} の descriptor に禁止形容詞を含めることはできません: {descriptor!r}"
-            )
-    for word in sorted(_STYLE_VARIATION_ENVIRONMENT_NG_WORDS):
-        if _contains_token_or_phrase(normalized, word):
-            raise ConfigError(
-                f"suno.style_variation.pools.{axis} の descriptor に"
-                f"雨音・環境音 NG ワードを含めることはできません: {descriptor!r}"
-            )
-    for artist in banned_artists:
-        if isinstance(artist, str) and artist.strip() and artist.lower() in normalized:
-            raise ConfigError(
-                f"suno.style_variation.pools.{axis} の descriptor に"
-                f"アーティスト名を含めることはできません: {descriptor!r}"
-            )
-
-
-def _resolve_style_variation(raw: object, *, banned_artists: list[str] | None = None) -> _ResolvedStyleVariation:
-    if raw is None:
-        raise ConfigError("suno.style_variation は mapping である必要があります: None")
-    if not isinstance(raw, Mapping):
-        raise ConfigError(f"suno.style_variation は mapping である必要があります: {raw!r}")
-
-    enabled = raw.get("enabled", False)
-    if not isinstance(enabled, bool):
-        raise ConfigError(f"suno.style_variation.enabled は bool である必要があります: {enabled!r}")
-
-    pools_raw = raw.get("pools", {})
-    if pools_raw is None:
-        raise ConfigError("suno.style_variation.pools は mapping である必要があります: None")
-    if not isinstance(pools_raw, Mapping):
-        raise ConfigError(f"suno.style_variation.pools は mapping である必要があります: {pools_raw!r}")
-
-    pools: dict[str, list[str]] = {}
-    for axis, descriptors_raw in pools_raw.items():
-        if not isinstance(axis, str) or not axis.strip():
-            raise ConfigError(f"suno.style_variation.pools の axis 名は非空文字列である必要があります: {axis!r}")
-        if not isinstance(descriptors_raw, list):
-            raise ConfigError(
-                f"suno.style_variation.pools.{axis} は list[str] である必要があります: {descriptors_raw!r}"
-            )
-        descriptors: list[str] = []
-        for descriptor in descriptors_raw:
-            if not isinstance(descriptor, str) or not descriptor.strip():
-                raise ConfigError(
-                    f"suno.style_variation.pools.{axis} の descriptor は非空文字列である必要があります: {descriptor!r}"
-                )
-            _validate_style_variation_descriptor(axis, descriptor, banned_artists or [])
-            descriptors.append(descriptor)
-        pools[axis] = descriptors
-
-    return _ResolvedStyleVariation(enabled=enabled, sequence=_build_variation_sequence(pools) if enabled else [])
 
 
 @dataclass
@@ -323,30 +161,8 @@ class _ResolvedPattern:
     style_label: str
     entry_names: list[str]
     style_lines: list[str]  # scenes と同じ長さ。entry ごとの Styles 第 1 行 (#1456)
-    scenes: list[str]
+    scenes: Sequence[str]
     lyrics_by_scene: list[str]  # scenes と同じ長さ。各値は rstrip 済み。歌詞が無ければ ""
-
-
-# suno-prompts.json へ wire する More Options の key 一覧 (#900, vocal_gender / duration_sec 追加)。
-# JSON への反映は **channel override (config/skills/suno.yaml) に明示設定されたキーのみ**。
-# config.default.yaml 同梱の既定値 (style_influence: 50 等) は JSON には載せない
-# (= 「何も足さない既存 collection は name/style/lyrics の 3 キーちょうど」の後方互換を守るため)。
-# MD 出力は従来どおり merged 値 (既定込み) を表示する。
-# vocal_gender は suno-helper 拡張が Suno UI Voice section の Male / Female ボタン押下に使う
-# (拡張型契約: "male" | "female" | "neutral" | "auto")。空文字は「未指定」として JSON 出力から省く
-# (_build_advanced_json_fields の skip ロジック参照)。
-_DURATION_SEC_KEY = "duration_sec"
-_ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender", _DURATION_SEC_KEY)
-_VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
-
-
-def _validate_duration_sec_override(override: Mapping[str, object]) -> None:
-    """明示された duration_sec が正の整数であることを検証する。"""
-    if _DURATION_SEC_KEY not in override:
-        return
-    value = override[_DURATION_SEC_KEY]
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ConfigError("config/skills/suno.yaml::duration_sec must be a positive integer")
 
 
 def _duration_filter_from_config(suno: dict) -> dict:
@@ -371,27 +187,8 @@ def _duration_filter_from_config(suno: dict) -> dict:
     return {"min_sec": min_sec, "max_sec": max_sec}
 
 
-def _build_advanced_json_fields(override: dict) -> dict:
-    """channel override から JSON 反映用 advanced フィールド dict を構築する (#900)。
-
-    - override に明示されたキーのみ含める (default.yaml の既定値は無視、#900 の A 案)
-    - vocal_gender は "" を「未指定」として skip する (拡張型契約と一貫させる)
-    - style_influence / weirdness の 0 は明示設定なら値そのまま wire
-    - exclude_styles の空文字は未指定として skip する
-    """
-    out: dict = {}
-    for key in _ADVANCED_JSON_KEYS:
-        if key not in override:
-            continue
-        value = override[key]
-        if key in {"exclude_styles", "vocal_gender"} and value == "":
-            continue
-        out[key] = value
-    return out
-
-
 @dataclass
-class _ResolvedPrompts:
+class _GeneratedPrompts:
     title: str
     is_vocal: bool
     style_influence: int
@@ -400,7 +197,7 @@ class _ResolvedPrompts:
     full_style_char_limit: int
     # channel override に明示設定された More Options フィールドのみを保持する (#900)。
     # collection スコープ: 全 entry に同じ値が載る。未設定キーは dict に含めない。
-    advanced_json_fields: dict
+    advanced_json_fields: Mapping[str, object]
     patterns: list[_ResolvedPattern]
 
 
@@ -414,15 +211,6 @@ def _entry_names_from_resolved(resolved: list[_ResolvedPattern]) -> list[str]:
     for p in resolved:
         names.extend(p.entry_names)
     return names
-
-
-def _load_external_lyrics(lyrics_path: Path) -> dict[str, str]:
-    """`suno-lyrics.json` から entry name -> lyrics を読み込む.
-
-    `/suno-lyric` は lyrics 専任で、`/suno` がここで Style と結合する。
-    vocal mode のファイル必須チェックは呼び出し元で行う。
-    """
-    return load_suno_lyrics_by_name(lyrics_path)
 
 
 def _require_pattern_name_without_padding(
@@ -440,199 +228,17 @@ def _require_pattern_name_without_padding(
         raise ConfigError(f"{patterns_path}: {issue}")
 
 
-def _vocal_workflow_state_path(patterns_path: Path) -> Path | None:
-    """Return the workflow-state path for a standard collection artifact.
-
-    The CLI also accepts a standalone patterns file, which has no collection
-    workflow state to validate.  A file in the standard
-    ``20-documentation/suno-patterns.yaml`` location must have one.
-    """
-    if patterns_path.name != SUNO_PATTERNS_FILENAME or patterns_path.parent.name != DOCUMENTATION_DIRNAME:
-        return None
-    return CollectionPaths(patterns_path.parent.parent).workflow_state_path
-
-
-def _read_vocal_workflow_track_count(workflow_state_path: Path) -> int:
-    if not workflow_state_path.is_file():
-        raise ConfigError(f"workflow-state.json is required for vocal mode: {workflow_state_path}")
-    try:
-        data = json.loads(workflow_state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ConfigError(f"workflow-state.json を読み取れませんでした: {workflow_state_path}") from exc
-    if not isinstance(data, Mapping):
-        raise ConfigError(f"workflow-state.json のトップレベルは object である必要があります: {workflow_state_path}")
-
-    track_count = data.get("track_count")
-    issue = positive_integer_issue(track_count, "workflow-state.json::track_count")
-    if issue is not None:
-        raise ConfigError(f"{issue}: {workflow_state_path}")
-    return cast(int, track_count)
-
-
-def _read_vocal_patterns_track_count(data: Mapping[str, object], patterns_path: Path) -> int:
-    track_count = data.get("tracks")
-    issue = positive_integer_issue(track_count, "suno-patterns.yaml::tracks")
-    if issue is not None:
-        raise ConfigError(f"{issue}: {patterns_path}")
-    return cast(int, track_count)
-
-
-def _resolve_genre_line(data: Mapping[str, object], channel_fallback: str, patterns_path: Path) -> str:
-    if "genre_line" not in data:
-        return channel_fallback
-    genre_line = data["genre_line"]
-    if not isinstance(genre_line, str):
-        raise ConfigError(f"{patterns_path}: genre_line must be a string")
-    return genre_line
-
-
-def _resolve_exclude_styles(
-    data: Mapping[str, object],
-    channel_fallback: str,
-    channel_json_fields: dict,
-    patterns_path: Path,
-) -> tuple[str, dict]:
-    if "exclude_styles" not in data:
-        return channel_fallback, channel_json_fields
-    exclude_styles = data["exclude_styles"]
-    if not isinstance(exclude_styles, str):
-        raise ConfigError(f"{patterns_path}: exclude_styles must be a string")
-    return exclude_styles, {**channel_json_fields, "exclude_styles": exclude_styles}
-
-
-def _resolve_vocal_gender(data: Mapping[str, object], channel_json_fields: dict, patterns_path: Path) -> dict:
-    if "vocal_gender" not in data:
-        return channel_json_fields
-    vocal_gender = data["vocal_gender"]
-    if not isinstance(vocal_gender, str) or (vocal_gender and vocal_gender not in _VOCAL_GENDERS):
-        raise ConfigError(f"{patterns_path}: vocal_gender must be empty or one of: male, female, neutral, auto")
-    resolved_fields = channel_json_fields.copy()
-    if vocal_gender:
-        resolved_fields["vocal_gender"] = vocal_gender
-    else:
-        resolved_fields.pop("vocal_gender", None)
-    return resolved_fields
-
-
-def _resolve_style_variants(
-    data: Mapping[str, object], channel_fallback: object, patterns_path: Path
-) -> tuple[Mapping[str, Mapping[str, str]], bool]:
-    if "style_variants" not in data:
-        return cast(Mapping[str, Mapping[str, str]], channel_fallback), True
-    style_variants = data["style_variants"]
-    if not isinstance(style_variants, Mapping):
-        raise ConfigError(f"{patterns_path}: style_variants must be a mapping")
-    for key, variant in style_variants.items():
-        if not isinstance(key, str) or not key:
-            raise ConfigError(f"{patterns_path}: style_variants keys must be non-empty strings")
-        if not isinstance(variant, Mapping):
-            raise ConfigError(f"{patterns_path}: style_variants.{key} must be a mapping")
-        for field_name in ("name", "genre_line"):
-            if not isinstance(variant.get(field_name), str):
-                raise ConfigError(f"{patterns_path}: style_variants.{key}.{field_name} must be a string")
-    return cast(Mapping[str, Mapping[str, str]], style_variants), False
-
-
-def _undefined_style_variant_error(style_key: object, patterns_path: Path, uses_channel_fallback: bool) -> ConfigError:
-    base_message = f"{patterns_path}: pattern.style に未定義の style variant が指定されています: {style_key!r}。"
-    if not uses_channel_fallback:
-        return ConfigError(
-            base_message
-            + "collection-local style_variants にこの key を追加するか、pattern.style の typo を修正してください。"
-        )
-
-    message = (
-        base_message + "patterns root に style_variants がない legacy collection のため、"
-        "channel fallback drift（config/skills/suno.yaml 側で key が変更・削除された可能性）があります。"
-        "channel 共有設定には依存せず、必要な定義を collection-local "
-        "suno-patterns.yaml::style_variants へ移してください。"
-    )
-    existing_outputs = [
-        path.name
-        for path in (
-            patterns_path.parent / SUNO_PROMPTS_MD_FILENAME,
-            patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME,
-        )
-        if path.exists()
-    ]
-    if existing_outputs:
-        collection_path = (
-            patterns_path.parent.parent if patterns_path.parent.name == DOCUMENTATION_DIRNAME else patterns_path.parent
-        )
-        message += (
-            f"既存成果物 ({', '.join(existing_outputs)}) は更新されず stale のままです。"
-            "設定修正後に再生成し、"
-            f"`uv run yt-suno-verify {collection_path}` を実行してください。"
-        )
-    return ConfigError(message)
-
-
-def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
-    """config + patterns.yaml を解決し、md / JSON 双方の共通中間表現を返す."""
-    suno = load_skill_config("suno")
-    # JSON 反映は channel override に明示されたキーのみ gating する (#900、A 案)。merged config では
-    # default.yaml の既定値と区別できないため、override 単体を別途読む。
-    override = load_channel_override("suno")
-    _validate_duration_sec_override(override)
-    full_style_char_limit = _resolve_full_style_char_limit(suno, override)
-    advanced_json_fields = _build_advanced_json_fields(override)
-    resolved_suno = resolve_suno_config(suno)
-
-    with open(patterns_path) as f:
-        data = yaml.safe_load(f)
-
-    genre_line = _resolve_genre_line(data, resolved_suno.genre_line, patterns_path)
-    mood_descriptors = suno.get("mood_descriptors", "")
-    exclude_styles, advanced_json_fields = _resolve_exclude_styles(
-        data,
-        resolved_suno.exclude_styles,
-        advanced_json_fields,
+def _resolve_prompts(patterns_path: Path) -> _GeneratedPrompts:
+    resolution = prompt_resolution.resolve_from_path(
         patterns_path,
+        skill_config_loader=load_skill_config,
+        channel_override_loader=load_channel_override,
+        lyrics_loader=load_suno_lyrics_by_name,
     )
-    advanced_json_fields = _resolve_vocal_gender(data, advanced_json_fields, patterns_path)
-    style_variants, uses_channel_style_variants = _resolve_style_variants(
-        data,
-        suno.get("style_variants", {}),
-        patterns_path,
-    )
-    style_influence = suno.get("style_influence", 50)
-    weirdness = suno.get("weirdness", 50)
-
-    style_variation = _resolve_style_variation(
-        suno.get("style_variation"),
-        banned_artists=suno.get("banned_artists", []),
-    )
-
-    base_parts = [genre_line]
-    if mood_descriptors:
-        base_parts.append(mood_descriptors)
-    base_style = ", ".join(base_parts)
-
-    title = data.get("title", "Suno Prompts")
-    patterns = data.get("patterns", [])
-
-    mode = data.get("mode", infer_suno_mode(genre_line))
-    is_vocal = mode == "vocal"
-    workflow_state_path = _vocal_workflow_state_path(patterns_path) if is_vocal else None
-    workflow_track_count = (
-        _read_vocal_workflow_track_count(workflow_state_path) if workflow_state_path is not None else None
-    )
-    patterns_track_count = (
-        _read_vocal_patterns_track_count(data, patterns_path) if is_vocal and workflow_state_path else None
-    )
-    external_lyrics_path = patterns_path.parent / SUNO_LYRICS_JSON_FILENAME
-    has_external_lyrics = is_vocal and external_lyrics_path.exists()
-    if is_vocal and not has_external_lyrics:
-        raise ConfigError(
-            f"{SUNO_LYRICS_JSON_FILENAME} is required for vocal mode. "
-            f"Run /suno-lyric first and write: {external_lyrics_path}"
-        )
-    external_lyrics = _load_external_lyrics(external_lyrics_path) if is_vocal else {}
-
     resolved: list[_ResolvedPattern] = []
     expected_external_lyrics_names: set[str] = set()
     entry_index = 0
-    for pattern_index, pattern in enumerate(patterns, 1):
+    for pattern_index, pattern in enumerate(resolution.patterns, 1):
         tempo = pattern.get("tempo")
         style_key = pattern.get("style")
         name_jp = pattern["name_jp"]
@@ -640,16 +246,13 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
         _require_pattern_name_without_padding(patterns_path, pattern_index, "name_jp", name_jp)
         _require_pattern_name_without_padding(patterns_path, pattern_index, "name_en", name_en)
 
-        # Per-pattern style variant override
-        if style_key and style_key not in style_variants:
-            raise _undefined_style_variant_error(style_key, patterns_path, uses_channel_style_variants)
-        has_explicit_variant = bool(style_key)
-        if has_explicit_variant:
-            variant = style_variants[style_key]
+        variant = prompt_resolution.resolve_style_variant(resolution, style_key)
+        has_explicit_variant = variant is not None
+        if variant is not None:
             effective_style = variant["genre_line"]
             style_label = f" [{style_key}: {variant['name']}]"
         else:
-            effective_style = base_style
+            effective_style = resolution.base_style
             style_label = ""
 
         scenes = pattern["scenes"]
@@ -660,15 +263,15 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
         lyrics_by_scene = []
         style_lines = []
         for entry_name in entry_names:
-            if has_external_lyrics:
+            if resolution.has_external_lyrics:
                 expected_external_lyrics_names.add(entry_name)
-                lyrics_by_scene.append(external_lyrics.get(entry_name, ""))
+                lyrics_by_scene.append(resolution.external_lyrics.get(entry_name, ""))
             else:
                 lyrics_by_scene.append(fallback_lyrics)
 
             descriptor = ""
-            if style_variation.enabled and not has_explicit_variant:
-                descriptor = _variation_descriptor(entry_index, style_variation.sequence)
+            if resolution.style_variation.enabled and not has_explicit_variant:
+                descriptor = _variation_descriptor(entry_index, resolution.style_variation.sequence)
             style_lines.append(_style_line(tempo, effective_style, descriptor))
             # Explicit variants keep their override style but still reserve the YAML entry position.
             entry_index += 1
@@ -685,43 +288,22 @@ def _resolve_prompts(patterns_path: Path) -> _ResolvedPrompts:
             )
         )
 
-    if has_external_lyrics:
-        require_matching_suno_lyrics_names(
-            lyrics_path=external_lyrics_path,
-            expected_names=expected_external_lyrics_names,
-            actual_names=set(external_lyrics),
-        )
+    entry_names = _entry_names_from_resolved(resolved)
+    prompt_resolution.validate_generated_prompts(
+        resolution,
+        entry_names=entry_names,
+        entries_count=sum(len(pattern.scenes) for pattern in resolved),
+        expected_external_lyrics_names=expected_external_lyrics_names,
+    )
 
-    # インストモード: yaml `tracks:` (コレクション上書き) > config `tracks_per_collection` の順で曲数を解決し、
-    # ceil(N/2) と yaml の entry 数 (scene 行数の合計) が一致するか fail-loud で検証する。
-    # ボーカルの標準 collection は workflow-state.json::track_count を SSOT とし、yaml `tracks:` の完全一致と
-    # prompt entry 数の下限を検証する。standalone patterns file は workflow state を持たないため対象外。
-    # tracks_per_collection が未指定の旧インスト運用は silent skip して後方互換を保つ。
-    if not is_vocal:
-        tracks_override = data.get("tracks")
-        tracks_per_collection = tracks_override if tracks_override is not None else suno.get("tracks_per_collection")
-        if tracks_per_collection is not None:
-            entries_count = sum(len(p.scenes) for p in resolved)
-            require_instrumental_track_count(patterns_path, entries_count, tracks_per_collection)
-    elif workflow_track_count is not None and patterns_track_count is not None:
-        require_vocal_track_count(
-            entries_count=len(_entry_names_from_resolved(resolved)),
-            patterns_tracks=patterns_track_count,
-            workflow_track_count=workflow_track_count,
-        )
-
-    # 全曲ユニーク title: Suno UI Song Title 欄に注入される最終 name の重複を fail-loud で弾く。
-    # インスト・ボーカル両モード一律で、後工程の同名 clip 追跡不能を生成時に弾く。
-    require_unique_entry_names(patterns_path, _entry_names_from_resolved(resolved))
-
-    return _ResolvedPrompts(
-        title=title,
-        is_vocal=is_vocal,
-        style_influence=style_influence,
-        weirdness=weirdness,
-        exclude_styles=exclude_styles,
-        full_style_char_limit=full_style_char_limit,
-        advanced_json_fields=advanced_json_fields,
+    return _GeneratedPrompts(
+        title=resolution.title,
+        is_vocal=resolution.is_vocal,
+        style_influence=resolution.style_influence,
+        weirdness=resolution.weirdness,
+        exclude_styles=resolution.exclude_styles,
+        full_style_char_limit=resolution.full_style_char_limit,
+        advanced_json_fields=resolution.advanced_json_fields,
         patterns=resolved,
     )
 

--- a/src/youtube_automation/domains/suno/prompt_resolution.py
+++ b/src/youtube_automation/domains/suno/prompt_resolution.py
@@ -1,0 +1,629 @@
+"""Resolve Suno prompt inputs before command-side pattern generation."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence, Set
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import cast
+
+import yaml
+
+from youtube_automation.configuration.skills import load_channel_override, load_skill_config
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.suno.config import ResolvedSunoConfig, infer_suno_mode, resolve_suno_config
+from youtube_automation.domains.suno.downloaded.models import (
+    DOCUMENTATION_DIRNAME,
+    SUNO_LYRICS_JSON_FILENAME,
+    SUNO_PATTERNS_FILENAME,
+    SUNO_PROMPTS_JSON_FILENAME,
+    SUNO_PROMPTS_MD_FILENAME,
+)
+from youtube_automation.domains.suno.downloaded.validation import (
+    positive_integer_issue,
+    require_instrumental_track_count,
+    require_matching_suno_lyrics_names,
+    require_unique_entry_names,
+    require_vocal_track_count,
+)
+from youtube_automation.domains.suno.lyrics import load_suno_lyrics_by_name
+
+DEFAULT_FULL_STYLE_CHAR_LIMIT = 256
+
+_DURATION_SEC_KEY = "duration_sec"
+_ADVANCED_JSON_KEYS = ("style_influence", "weirdness", "exclude_styles", "vocal_gender", _DURATION_SEC_KEY)
+_VOCAL_GENDERS = frozenset({"male", "female", "neutral", "auto"})
+_STYLE_VARIATION_BANNED_ADJECTIVES = frozenset(
+    {
+        "thundering",
+        "blazing",
+        "crushing",
+        "soaring",
+        "screaming",
+        "devastating",
+        "explosive",
+        "ferocious",
+        "towering",
+        "surging",
+        "crystalline",
+        "shimmering",
+        "lush",
+        "sweeping",
+        "majestic",
+        "glorious",
+        "echoing",
+    }
+)
+_STYLE_VARIATION_ENVIRONMENT_NG_WORDS = frozenset(
+    {
+        "ambient noise",
+        "dripping",
+        "drops",
+        "puddles",
+        "pouring",
+        "rain",
+        "rain sounds",
+        "splashing",
+        "streaming water",
+        "trickling",
+        "vinyl crackle",
+        "white noise",
+    }
+)
+_STYLE_VARIATION_BARE_INSTRUMENTS = frozenset(
+    {
+        "bass",
+        "cello",
+        "drums",
+        "flute",
+        "guitar",
+        "organ",
+        "piano",
+        "strings",
+        "synth",
+        "trumpet",
+    }
+)
+
+_StaleOutputInventory = tuple[tuple[str, ...], Path]
+_StaleOutputInventoryLoader = Callable[[], _StaleOutputInventory]
+
+
+@dataclass(frozen=True)
+class ResolvedStyleVariation:
+    enabled: bool
+    sequence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedPrompts:
+    patterns_path: Path
+    title: str
+    is_vocal: bool
+    genre_line: str
+    base_style: str
+    style_influence: int
+    weirdness: int
+    exclude_styles: str
+    full_style_char_limit: int
+    advanced_json_fields: Mapping[str, object]
+    style_variants: Mapping[str, Mapping[str, str]]
+    uses_channel_style_variants: bool
+    style_variation: ResolvedStyleVariation
+    patterns: tuple[Mapping[str, object], ...]
+    external_lyrics_path: Path
+    external_lyrics: Mapping[str, str]
+    has_external_lyrics: bool
+    workflow_track_count: int | None
+    patterns_track_count: int | None
+    tracks_per_collection: object | None
+    _stale_output_inventory_loader: _StaleOutputInventoryLoader = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class _ResolvedBase:
+    patterns_path: Path
+    data: Mapping[str, object]
+    title: str
+    is_vocal: bool
+    genre_line: str
+    base_style: str
+    style_influence: int
+    weirdness: int
+    exclude_styles: str
+    full_style_char_limit: int
+    advanced_json_fields: Mapping[str, object]
+    style_variants: Mapping[str, Mapping[str, str]]
+    uses_channel_style_variants: bool
+    style_variation: ResolvedStyleVariation
+    patterns: tuple[Mapping[str, object], ...]
+    tracks_per_collection: object | None
+
+
+@dataclass(frozen=True)
+class _ResolvedConfigHead:
+    resolved_suno: ResolvedSunoConfig
+    full_style_char_limit: int
+    advanced_json_fields: dict[str, object]
+
+
+_SkillConfigLoader = Callable[[str], Mapping[str, object]]
+_LyricsLoader = Callable[[Path], Mapping[str, str]]
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, Set):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
+
+
+def _freeze_mapping(values: Mapping[str, object]) -> Mapping[str, object]:
+    return cast(Mapping[str, object], _freeze_value(values))
+
+
+def _resolve_full_style_char_limit(config: Mapping[str, object], override: Mapping[str, object]) -> int:
+    if "full_style_char_limit" in override:
+        value = override["full_style_char_limit"]
+        source = "full_style_char_limit"
+    elif "style_char_limit" in override:
+        value = override["style_char_limit"]
+        source = "style_char_limit"
+    else:
+        value = config.get("full_style_char_limit", DEFAULT_FULL_STYLE_CHAR_LIMIT)
+        source = "full_style_char_limit"
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConfigError(f"config/skills/suno.yaml::{source} must be a positive integer")
+    return value
+
+
+def _validate_duration_sec_override(override: Mapping[str, object]) -> None:
+    if _DURATION_SEC_KEY not in override:
+        return
+    value = override[_DURATION_SEC_KEY]
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConfigError("config/skills/suno.yaml::duration_sec must be a positive integer")
+
+
+def _build_advanced_json_fields(override: Mapping[str, object]) -> dict[str, object]:
+    fields: dict[str, object] = {}
+    for key in _ADVANCED_JSON_KEYS:
+        if key not in override:
+            continue
+        value = override[key]
+        if key in {"exclude_styles", "vocal_gender"} and value == "":
+            continue
+        fields[key] = value
+    return fields
+
+
+def _resolve_config_head(config: Mapping[str, object], override: Mapping[str, object]) -> _ResolvedConfigHead:
+    _validate_duration_sec_override(override)
+    full_style_char_limit = _resolve_full_style_char_limit(config, override)
+    advanced_json_fields = _build_advanced_json_fields(override)
+    resolved_suno = resolve_suno_config(config)
+    return _ResolvedConfigHead(
+        resolved_suno=resolved_suno,
+        full_style_char_limit=full_style_char_limit,
+        advanced_json_fields=advanced_json_fields,
+    )
+
+
+def _resolve_genre_line(data: Mapping[str, object], channel_fallback: str, patterns_path: Path) -> str:
+    if "genre_line" not in data:
+        return channel_fallback
+    genre_line = data["genre_line"]
+    if not isinstance(genre_line, str):
+        raise ConfigError(f"{patterns_path}: genre_line must be a string")
+    return genre_line
+
+
+def _resolve_exclude_styles(
+    data: Mapping[str, object],
+    channel_fallback: str,
+    channel_json_fields: Mapping[str, object],
+    patterns_path: Path,
+) -> tuple[str, dict[str, object]]:
+    if "exclude_styles" not in data:
+        return channel_fallback, dict(channel_json_fields)
+    exclude_styles = data["exclude_styles"]
+    if not isinstance(exclude_styles, str):
+        raise ConfigError(f"{patterns_path}: exclude_styles must be a string")
+    return exclude_styles, {**channel_json_fields, "exclude_styles": exclude_styles}
+
+
+def _resolve_vocal_gender(
+    data: Mapping[str, object], channel_json_fields: Mapping[str, object], patterns_path: Path
+) -> dict[str, object]:
+    if "vocal_gender" not in data:
+        return dict(channel_json_fields)
+    vocal_gender = data["vocal_gender"]
+    if not isinstance(vocal_gender, str) or (vocal_gender and vocal_gender not in _VOCAL_GENDERS):
+        raise ConfigError(f"{patterns_path}: vocal_gender must be empty or one of: male, female, neutral, auto")
+    resolved_fields = dict(channel_json_fields)
+    if vocal_gender:
+        resolved_fields["vocal_gender"] = vocal_gender
+    else:
+        resolved_fields.pop("vocal_gender", None)
+    return resolved_fields
+
+
+def _resolve_style_variants(
+    data: Mapping[str, object], channel_fallback: object, patterns_path: Path
+) -> tuple[Mapping[str, Mapping[str, str]], bool]:
+    if "style_variants" not in data:
+        frozen = _freeze_value(channel_fallback)
+        return cast(Mapping[str, Mapping[str, str]], frozen), True
+    style_variants = data["style_variants"]
+    if not isinstance(style_variants, Mapping):
+        raise ConfigError(f"{patterns_path}: style_variants must be a mapping")
+    for key, variant in style_variants.items():
+        if not isinstance(key, str) or not key:
+            raise ConfigError(f"{patterns_path}: style_variants keys must be non-empty strings")
+        if not isinstance(variant, Mapping):
+            raise ConfigError(f"{patterns_path}: style_variants.{key} must be a mapping")
+        for field_name in ("name", "genre_line"):
+            if not isinstance(variant.get(field_name), str):
+                raise ConfigError(f"{patterns_path}: style_variants.{key}.{field_name} must be a string")
+    frozen = _freeze_value(style_variants)
+    return cast(Mapping[str, Mapping[str, str]], frozen), False
+
+
+def _contains_token_or_phrase(text: str, phrase: str) -> bool:
+    if " " in phrase:
+        return phrase in text
+    return re.search(rf"\b{re.escape(phrase)}\b", text) is not None
+
+
+def _validate_style_variation_descriptor(axis: str, descriptor: str, banned_artists: list[str]) -> None:
+    normalized = " ".join(descriptor.lower().split())
+    if normalized in _STYLE_VARIATION_BARE_INSTRUMENTS:
+        raise ConfigError(f"suno.style_variation.pools.{axis} の descriptor は裸楽器名を使用できません: {descriptor!r}")
+    for word in sorted(_STYLE_VARIATION_BANNED_ADJECTIVES):
+        if _contains_token_or_phrase(normalized, word):
+            raise ConfigError(
+                f"suno.style_variation.pools.{axis} の descriptor に禁止形容詞を含めることはできません: {descriptor!r}"
+            )
+    for word in sorted(_STYLE_VARIATION_ENVIRONMENT_NG_WORDS):
+        if _contains_token_or_phrase(normalized, word):
+            raise ConfigError(
+                f"suno.style_variation.pools.{axis} の descriptor に"
+                f"雨音・環境音 NG ワードを含めることはできません: {descriptor!r}"
+            )
+    for artist in banned_artists:
+        if isinstance(artist, str) and artist.strip() and artist.lower() in normalized:
+            raise ConfigError(
+                f"suno.style_variation.pools.{axis} の descriptor に"
+                f"アーティスト名を含めることはできません: {descriptor!r}"
+            )
+
+
+def _build_variation_sequence(pools: Mapping[str, list[str]]) -> list[str]:
+    axes = [pools[name] for name in sorted(pools) if pools[name]]
+    if not axes:
+        return []
+    sequence: list[str] = []
+    for index in range(max(len(axis) for axis in axes)):
+        for axis in axes:
+            if index < len(axis):
+                sequence.append(axis[index])
+    return sequence
+
+
+def _resolve_style_variation(raw: object, *, banned_artists: list[str] | None = None) -> ResolvedStyleVariation:
+    if raw is None:
+        raise ConfigError("suno.style_variation は mapping である必要があります: None")
+    if not isinstance(raw, Mapping):
+        raise ConfigError(f"suno.style_variation は mapping である必要があります: {raw!r}")
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ConfigError(f"suno.style_variation.enabled は bool である必要があります: {enabled!r}")
+
+    pools_raw = raw.get("pools", {})
+    if pools_raw is None:
+        raise ConfigError("suno.style_variation.pools は mapping である必要があります: None")
+    if not isinstance(pools_raw, Mapping):
+        raise ConfigError(f"suno.style_variation.pools は mapping である必要があります: {pools_raw!r}")
+
+    pools: dict[str, list[str]] = {}
+    for axis, descriptors_raw in pools_raw.items():
+        if not isinstance(axis, str) or not axis.strip():
+            raise ConfigError(f"suno.style_variation.pools の axis 名は非空文字列である必要があります: {axis!r}")
+        if not isinstance(descriptors_raw, list):
+            raise ConfigError(
+                f"suno.style_variation.pools.{axis} は list[str] である必要があります: {descriptors_raw!r}"
+            )
+        descriptors: list[str] = []
+        for descriptor in descriptors_raw:
+            if not isinstance(descriptor, str) or not descriptor.strip():
+                raise ConfigError(
+                    f"suno.style_variation.pools.{axis} の descriptor は非空文字列である必要があります: {descriptor!r}"
+                )
+            _validate_style_variation_descriptor(axis, descriptor, banned_artists or [])
+            descriptors.append(descriptor)
+        pools[axis] = descriptors
+
+    sequence = _build_variation_sequence(pools) if enabled else []
+    return ResolvedStyleVariation(enabled=enabled, sequence=tuple(sequence))
+
+
+def _resolve_base(
+    patterns: Mapping[str, object],
+    config: Mapping[str, object],
+    override: Mapping[str, object],
+    patterns_path: Path,
+    *,
+    config_head: _ResolvedConfigHead | None = None,
+) -> _ResolvedBase:
+    head = config_head if config_head is not None else _resolve_config_head(config, override)
+    genre_line = _resolve_genre_line(patterns, head.resolved_suno.genre_line, patterns_path)
+    exclude_styles, advanced_json_fields = _resolve_exclude_styles(
+        patterns, head.resolved_suno.exclude_styles, head.advanced_json_fields, patterns_path
+    )
+    advanced_json_fields = _resolve_vocal_gender(patterns, advanced_json_fields, patterns_path)
+    style_variants, uses_channel_style_variants = _resolve_style_variants(
+        patterns, config.get("style_variants", {}), patterns_path
+    )
+    style_variation = _resolve_style_variation(
+        config.get("style_variation"),
+        banned_artists=cast(list[str], config.get("banned_artists", [])),
+    )
+
+    base_parts = [genre_line]
+    mood_descriptors = config.get("mood_descriptors", "")
+    if mood_descriptors:
+        base_parts.append(cast(str, mood_descriptors))
+    mode = patterns.get("mode", infer_suno_mode(genre_line))
+    is_vocal = mode == "vocal"
+    tracks_override = patterns.get("tracks")
+    tracks_per_collection = tracks_override if tracks_override is not None else config.get("tracks_per_collection")
+
+    return _ResolvedBase(
+        patterns_path=patterns_path,
+        data=patterns,
+        title=cast(str, patterns.get("title", "Suno Prompts")),
+        is_vocal=is_vocal,
+        genre_line=genre_line,
+        base_style=", ".join(base_parts),
+        style_influence=cast(int, config.get("style_influence", 50)),
+        weirdness=cast(int, config.get("weirdness", 50)),
+        exclude_styles=exclude_styles,
+        full_style_char_limit=head.full_style_char_limit,
+        advanced_json_fields=_freeze_mapping(advanced_json_fields),
+        style_variants=style_variants,
+        uses_channel_style_variants=uses_channel_style_variants,
+        style_variation=style_variation,
+        patterns=tuple(
+            _freeze_mapping(pattern) for pattern in cast(list[Mapping[str, object]], patterns.get("patterns", []))
+        ),
+        tracks_per_collection=_freeze_value(tracks_per_collection),
+    )
+
+
+def _workflow_state_path(patterns_path: Path) -> Path | None:
+    if patterns_path.name != SUNO_PATTERNS_FILENAME or patterns_path.parent.name != DOCUMENTATION_DIRNAME:
+        return None
+    return patterns_path.parent.parent.resolve() / "workflow-state.json"
+
+
+def _read_workflow_track_count(workflow_state_path: Path) -> int:
+    if not workflow_state_path.is_file():
+        raise ConfigError(f"workflow-state.json is required for vocal mode: {workflow_state_path}")
+    try:
+        data = json.loads(workflow_state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"workflow-state.json を読み取れませんでした: {workflow_state_path}") from exc
+    if not isinstance(data, Mapping):
+        raise ConfigError(f"workflow-state.json のトップレベルは object である必要があります: {workflow_state_path}")
+    track_count = data.get("track_count")
+    issue = positive_integer_issue(track_count, "workflow-state.json::track_count")
+    if issue is not None:
+        raise ConfigError(f"{issue}: {workflow_state_path}")
+    return cast(int, track_count)
+
+
+def _patterns_track_count(base: _ResolvedBase, workflow_state_path: Path | None) -> int | None:
+    if not base.is_vocal or workflow_state_path is None:
+        return None
+    track_count = base.data.get("tracks")
+    issue = positive_integer_issue(track_count, "suno-patterns.yaml::tracks")
+    if issue is not None:
+        raise ConfigError(f"{issue}: {base.patterns_path}")
+    return cast(int, track_count)
+
+
+def _finalize(
+    base: _ResolvedBase,
+    *,
+    workflow_track_count: int | None,
+    patterns_track_count: int | None,
+    lyrics: Mapping[str, str] | None,
+    existing_output_names: tuple[str, ...],
+    verification_collection_path: Path,
+    stale_output_inventory_loader: _StaleOutputInventoryLoader | None = None,
+) -> ResolvedPrompts:
+    external_lyrics_path = base.patterns_path.parent / SUNO_LYRICS_JSON_FILENAME
+    if base.is_vocal and lyrics is None:
+        raise ConfigError(
+            f"{SUNO_LYRICS_JSON_FILENAME} is required for vocal mode. "
+            f"Run /suno-lyric first and write: {external_lyrics_path}"
+        )
+    frozen_output_names = tuple(existing_output_names)
+    if stale_output_inventory_loader is None:
+        inventory = (frozen_output_names, verification_collection_path)
+
+        def load_stale_output_inventory() -> _StaleOutputInventory:
+            return inventory
+
+        stale_output_inventory_loader = load_stale_output_inventory
+
+    return ResolvedPrompts(
+        patterns_path=base.patterns_path,
+        title=base.title,
+        is_vocal=base.is_vocal,
+        genre_line=base.genre_line,
+        base_style=base.base_style,
+        style_influence=base.style_influence,
+        weirdness=base.weirdness,
+        exclude_styles=base.exclude_styles,
+        full_style_char_limit=base.full_style_char_limit,
+        advanced_json_fields=base.advanced_json_fields,
+        style_variants=base.style_variants,
+        uses_channel_style_variants=base.uses_channel_style_variants,
+        style_variation=base.style_variation,
+        patterns=base.patterns,
+        external_lyrics_path=external_lyrics_path,
+        external_lyrics=MappingProxyType({} if lyrics is None else dict(lyrics)),
+        has_external_lyrics=base.is_vocal,
+        workflow_track_count=workflow_track_count,
+        patterns_track_count=patterns_track_count,
+        tracks_per_collection=base.tracks_per_collection,
+        _stale_output_inventory_loader=stale_output_inventory_loader,
+    )
+
+
+def resolve(
+    patterns: Mapping[str, object],
+    config: Mapping[str, object],
+    override: Mapping[str, object],
+    *,
+    patterns_path: Path,
+    workflow_state_path: Path | None,
+    workflow_track_count: int | None,
+    lyrics: Mapping[str, str] | None,
+    existing_output_names: tuple[str, ...],
+    verification_collection_path: Path,
+) -> ResolvedPrompts:
+    """Resolve loaded mappings without performing file I/O."""
+    base = _resolve_base(patterns, config, override, patterns_path)
+    if base.is_vocal and workflow_state_path is not None and workflow_track_count is None:
+        raise ConfigError(f"workflow-state.json is required for vocal mode: {workflow_state_path}")
+    return _finalize(
+        base,
+        workflow_track_count=workflow_track_count,
+        patterns_track_count=_patterns_track_count(base, workflow_state_path),
+        lyrics=lyrics,
+        existing_output_names=existing_output_names,
+        verification_collection_path=verification_collection_path,
+    )
+
+
+def resolve_from_path(
+    patterns_path: Path,
+    *,
+    skill_config_loader: _SkillConfigLoader | None = None,
+    channel_override_loader: _SkillConfigLoader | None = None,
+    lyrics_loader: _LyricsLoader | None = None,
+) -> ResolvedPrompts:
+    """Load config and prompt artifacts, then delegate mapping resolution."""
+    config = (load_skill_config if skill_config_loader is None else skill_config_loader)("suno")
+    override = (load_channel_override if channel_override_loader is None else channel_override_loader)("suno")
+    config_head = _resolve_config_head(config, override)
+    with open(patterns_path) as file:
+        patterns = cast(Mapping[str, object], yaml.safe_load(file))
+
+    base = _resolve_base(patterns, config, override, patterns_path, config_head=config_head)
+    workflow_state_path = _workflow_state_path(patterns_path) if base.is_vocal else None
+    workflow_track_count = _read_workflow_track_count(workflow_state_path) if workflow_state_path is not None else None
+    external_lyrics_path = patterns_path.parent / SUNO_LYRICS_JSON_FILENAME
+    if base.is_vocal and not external_lyrics_path.exists():
+        lyrics = None
+    else:
+        loader = load_suno_lyrics_by_name if lyrics_loader is None else lyrics_loader
+        lyrics = loader(external_lyrics_path) if base.is_vocal else None
+    verification_collection_path = (
+        patterns_path.parent.parent if patterns_path.parent.name == DOCUMENTATION_DIRNAME else patterns_path.parent
+    )
+
+    def load_stale_output_inventory() -> _StaleOutputInventory:
+        names = tuple(
+            path.name
+            for path in (
+                patterns_path.parent / SUNO_PROMPTS_MD_FILENAME,
+                patterns_path.parent / SUNO_PROMPTS_JSON_FILENAME,
+            )
+            if path.exists()
+        )
+        return names, verification_collection_path
+
+    return _finalize(
+        base,
+        workflow_track_count=workflow_track_count,
+        patterns_track_count=_patterns_track_count(base, workflow_state_path),
+        lyrics=lyrics,
+        existing_output_names=(),
+        verification_collection_path=verification_collection_path,
+        stale_output_inventory_loader=load_stale_output_inventory,
+    )
+
+
+def resolve_style_variant(resolved: ResolvedPrompts, style_key: object) -> Mapping[str, str] | None:
+    if not style_key:
+        return None
+    if style_key in resolved.style_variants:
+        return resolved.style_variants[cast(str, style_key)]
+
+    base_message = (
+        f"{resolved.patterns_path}: pattern.style に未定義の style variant が指定されています: {style_key!r}。"
+    )
+    if not resolved.uses_channel_style_variants:
+        raise ConfigError(
+            base_message
+            + "collection-local style_variants にこの key を追加するか、pattern.style の typo を修正してください。"
+        )
+
+    message = (
+        base_message + "patterns root に style_variants がない legacy collection のため、"
+        "channel fallback drift（config/skills/suno.yaml 側で key が変更・削除された可能性）があります。"
+        "channel 共有設定には依存せず、必要な定義を collection-local "
+        "suno-patterns.yaml::style_variants へ移してください。"
+    )
+    existing_output_names, verification_collection_path = resolved._stale_output_inventory_loader()
+    if existing_output_names:
+        message += (
+            f"既存成果物 ({', '.join(existing_output_names)}) は更新されず stale のままです。"
+            "設定修正後に再生成し、"
+            f"`uv run yt-suno-verify {verification_collection_path}` を実行してください。"
+        )
+    raise ConfigError(message)
+
+
+def validate_generated_prompts(
+    resolved: ResolvedPrompts,
+    *,
+    entry_names: list[str],
+    entries_count: int,
+    expected_external_lyrics_names: set[str],
+) -> None:
+    """Apply post-generation count, lyrics, and uniqueness contracts."""
+    if resolved.has_external_lyrics:
+        require_matching_suno_lyrics_names(
+            lyrics_path=resolved.external_lyrics_path,
+            expected_names=expected_external_lyrics_names,
+            actual_names=set(resolved.external_lyrics),
+        )
+
+    if not resolved.is_vocal:
+        if resolved.tracks_per_collection is not None:
+            require_instrumental_track_count(
+                resolved.patterns_path,
+                entries_count,
+                resolved.tracks_per_collection,
+            )
+    elif resolved.workflow_track_count is not None and resolved.patterns_track_count is not None:
+        require_vocal_track_count(
+            entries_count=len(entry_names),
+            patterns_tracks=resolved.patterns_track_count,
+            workflow_track_count=resolved.workflow_track_count,
+        )
+
+    require_unique_entry_names(resolved.patterns_path, entry_names)

--- a/tests/commands/suno/test_generate_suno_prompt_resolution_boundary.py
+++ b/tests/commands/suno/test_generate_suno_prompt_resolution_boundary.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import yaml
+
+from youtube_automation.commands.suno import generate_suno_prompts
+from youtube_automation.domains.suno import prompt_resolution
+
+
+def test_markdown_and_json_paths_preserve_two_resolution_calls(monkeypatch, tmp_path: Path):
+    channel_dir = tmp_path / "channel"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+    patterns_path = tmp_path / "patterns.yaml"
+    patterns_path.write_text(
+        yaml.safe_dump(
+            {
+                "title": "Focus Set",
+                "mode": "instrumental",
+                "tracks": 2,
+                "patterns": [
+                    {
+                        "name_jp": "集中",
+                        "name_en": "Focus",
+                        "tempo": "slow",
+                        "scenes": ["soft piano and brushed drums"],
+                    }
+                ],
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    real_resolve_from_path = prompt_resolution.resolve_from_path
+    resolved_paths: list[Path] = []
+
+    def resolve_from_path(path: Path, **loaders) -> prompt_resolution.ResolvedPrompts:
+        resolved_paths.append(path)
+        return real_resolve_from_path(path, **loaders)
+
+    monkeypatch.setattr(prompt_resolution, "resolve_from_path", resolve_from_path)
+
+    entries = generate_suno_prompts.build_prompt_entries(patterns_path)
+    markdown = generate_suno_prompts.generate(patterns_path)
+
+    assert resolved_paths == [patterns_path, patterns_path]
+    assert entries[0]["name"] == "集中 — Focus"
+    assert "### 集中 — Focus" in markdown
+
+
+def test_legacy_command_loader_patches_govern_both_resolution_calls(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "patterns.yaml"
+    patterns_path.write_text(
+        yaml.safe_dump(
+            {
+                "title": "Vocal Set",
+                "mode": "vocal",
+                "patterns": [
+                    {
+                        "name_jp": "集中",
+                        "name_en": "Focus",
+                        "tempo": "slow",
+                        "scenes": ["soft vocal"],
+                    }
+                ],
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    (patterns_path.parent / "suno-lyrics.json").write_text("{}", encoding="utf-8")
+    calls = {"config": 0, "override": 0, "lyrics": 0}
+
+    def load_skill_config(_name: str):
+        calls["config"] += 1
+        return {
+            "genre_line": "patched vocal jazz",
+            "exclude_styles": "noise",
+            "style_variants": {},
+            "style_variation": {"enabled": False, "pools": {}},
+            "banned_artists": [],
+        }
+
+    def load_channel_override(_name: str):
+        calls["override"] += 1
+        return {}
+
+    def load_suno_lyrics_by_name(path: Path):
+        calls["lyrics"] += 1
+        assert path == patterns_path.parent / "suno-lyrics.json"
+        return {"集中 — Focus": "patched lyrics"}
+
+    def deny_domain_loader(*_args, **_kwargs):
+        raise AssertionError("command-local patch seam was bypassed")
+
+    monkeypatch.setattr(generate_suno_prompts, "load_skill_config", load_skill_config)
+    monkeypatch.setattr(generate_suno_prompts, "load_channel_override", load_channel_override)
+    monkeypatch.setattr(generate_suno_prompts, "load_suno_lyrics_by_name", load_suno_lyrics_by_name)
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", deny_domain_loader)
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", deny_domain_loader)
+    monkeypatch.setattr(prompt_resolution, "load_suno_lyrics_by_name", deny_domain_loader)
+
+    entries = generate_suno_prompts.build_prompt_entries(patterns_path)
+    markdown = generate_suno_prompts.generate(patterns_path)
+
+    assert calls == {"config": 3, "override": 2, "lyrics": 2}
+    assert entries[0]["lyrics"] == "patched lyrics"
+    assert "patched vocal jazz" in markdown

--- a/tests/domains/suno/test_prompt_resolution.py
+++ b/tests/domains/suno/test_prompt_resolution.py
@@ -1,0 +1,328 @@
+import builtins
+from collections import UserList
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+import yaml
+
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.suno import prompt_resolution
+
+
+def _config() -> dict[str, object]:
+    return {
+        "genre_line": "lo-fi jazz, soft piano",
+        "exclude_styles": "harsh noise",
+        "full_style_char_limit": 300,
+        "mood_descriptors": "warm, focused",
+        "style_influence": 45,
+        "weirdness": 55,
+        "style_variants": {
+            "night": {"name": "Night", "genre_line": "late-night jazz"},
+        },
+        "style_variation": {"enabled": False, "pools": {}},
+        "banned_artists": [],
+    }
+
+
+def _patterns() -> dict[str, object]:
+    return {
+        "title": "Focus Set",
+        "mode": "instrumental",
+        "patterns": [],
+    }
+
+
+def test_resolve_from_path_matches_mapping_core(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "patterns.yaml"
+    patterns = _patterns()
+    patterns_path.write_text(yaml.safe_dump(patterns), encoding="utf-8")
+    config = _config()
+    override = {"style_influence": 0, "vocal_gender": "male"}
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", lambda _name: config)
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", lambda _name: override)
+
+    from_path = prompt_resolution.resolve_from_path(patterns_path)
+    from_mapping = prompt_resolution.resolve(
+        patterns,
+        config,
+        override,
+        patterns_path=patterns_path,
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=None,
+        existing_output_names=(),
+        verification_collection_path=patterns_path.parent,
+    )
+
+    assert from_path == from_mapping
+    assert from_path.base_style == "lo-fi jazz, soft piano, warm, focused"
+    assert from_path.advanced_json_fields == {"style_influence": 0, "vocal_gender": "male"}
+
+
+def test_resolve_from_path_validates_collection_before_missing_vocal_workflow(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "collection" / "20-documentation" / "suno-patterns.yaml"
+    patterns_path.parent.mkdir(parents=True)
+    patterns_path.write_text(
+        yaml.safe_dump({**_patterns(), "mode": "vocal", "exclude_styles": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", lambda _name: _config())
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", lambda _name: {})
+
+    with pytest.raises(ConfigError, match=r"suno-patterns\.yaml: exclude_styles must be a string"):
+        prompt_resolution.resolve_from_path(patterns_path)
+
+
+def test_resolve_from_path_does_not_probe_stale_outputs_for_valid_input(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "patterns.yaml"
+    patterns_path.write_text(yaml.safe_dump(_patterns()), encoding="utf-8")
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", lambda _name: _config())
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", lambda _name: {})
+    original_exists = Path.exists
+
+    def reject_stale_probe(path: Path) -> bool:
+        if path.name in {"suno-prompts.md", "suno-prompts.json"}:
+            raise OSError("stale output probe must be demand-driven")
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "exists", reject_stale_probe)
+
+    resolved = prompt_resolution.resolve_from_path(patterns_path)
+
+    assert not resolved.is_vocal
+
+
+def test_resolve_from_path_probes_stale_outputs_only_for_undefined_channel_variant(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "20-documentation" / "suno-patterns.yaml"
+    patterns_path.parent.mkdir(parents=True)
+    patterns_path.write_text(yaml.safe_dump(_patterns()), encoding="utf-8")
+    (patterns_path.parent / "suno-prompts.md").write_text("stale", encoding="utf-8")
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", lambda _name: _config())
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", lambda _name: {})
+    original_exists = Path.exists
+    probed_names: list[str] = []
+
+    def record_stale_probe(path: Path) -> bool:
+        if path.name in {"suno-prompts.md", "suno-prompts.json"}:
+            probed_names.append(path.name)
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "exists", record_stale_probe)
+
+    resolved = prompt_resolution.resolve_from_path(patterns_path)
+    assert probed_names == []
+
+    with pytest.raises(ConfigError, match="suno-prompts.md"):
+        prompt_resolution.resolve_style_variant(resolved, "missing")
+
+    assert probed_names == ["suno-prompts.md", "suno-prompts.json"]
+
+
+def test_resolve_applies_collection_fields_without_mutating_override(tmp_path: Path):
+    patterns_path = tmp_path / "patterns.yaml"
+    patterns = {
+        **_patterns(),
+        "genre_line": "collection jazz",
+        "exclude_styles": "collection noise",
+        "vocal_gender": "",
+        "style_variants": {},
+    }
+    override = {"exclude_styles": "channel noise", "vocal_gender": "female"}
+
+    resolved = prompt_resolution.resolve(
+        patterns,
+        _config(),
+        override,
+        patterns_path=patterns_path,
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=None,
+        existing_output_names=(),
+        verification_collection_path=patterns_path.parent,
+    )
+
+    assert resolved.genre_line == "collection jazz"
+    assert resolved.exclude_styles == "collection noise"
+    assert resolved.advanced_json_fields == {"exclude_styles": "collection noise"}
+    assert resolved.style_variants == {}
+    assert not resolved.uses_channel_style_variants
+    assert override == {"exclude_styles": "channel noise", "vocal_gender": "female"}
+
+
+def test_resolve_style_variant_reports_loader_supplied_stale_outputs_for_channel_fallback(tmp_path: Path):
+    patterns_path = tmp_path / "20-documentation" / "suno-patterns.yaml"
+    resolved = prompt_resolution.resolve(
+        _patterns(),
+        _config(),
+        {},
+        patterns_path=patterns_path,
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=None,
+        existing_output_names=("suno-prompts.md",),
+        verification_collection_path=tmp_path,
+    )
+
+    with pytest.raises(ConfigError) as exc_info:
+        prompt_resolution.resolve_style_variant(resolved, "missing")
+
+    message = str(exc_info.value)
+    assert str(patterns_path) in message
+    assert "channel fallback drift" in message
+    assert "既存成果物 (suno-prompts.md) は更新されず stale のまま" in message
+    assert f"uv run yt-suno-verify {tmp_path}" in message
+
+
+def test_mapping_core_and_variant_resolution_do_not_touch_filesystem_or_loaders(monkeypatch, tmp_path: Path):
+    patterns_path = tmp_path / "20-documentation" / "suno-patterns.yaml"
+    original_open = builtins.open
+    original_path_methods = {name: getattr(Path, name) for name in ("resolve", "exists", "is_file", "read_text")}
+
+    def deny_loader(*_args, **_kwargs):
+        raise AssertionError("mapping core must not call configuration or lyrics loaders")
+
+    def deny_target_open(file, *args, **kwargs):
+        if str(file).startswith(str(tmp_path)):
+            raise AssertionError("mapping core must not open files")
+        return original_open(file, *args, **kwargs)
+
+    def deny_target_path_method(name):
+        original = original_path_methods[name]
+
+        def guarded(path, *args, **kwargs):
+            if str(path).startswith(str(tmp_path)):
+                raise AssertionError(f"mapping core must not call Path.{name}")
+            return original(path, *args, **kwargs)
+
+        return guarded
+
+    monkeypatch.setattr(builtins, "open", deny_target_open)
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", deny_loader)
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", deny_loader)
+    monkeypatch.setattr(prompt_resolution, "load_suno_lyrics_by_name", deny_loader)
+    for name in original_path_methods:
+        monkeypatch.setattr(Path, name, deny_target_path_method(name))
+
+    resolved = prompt_resolution.resolve(
+        _patterns(),
+        _config(),
+        {},
+        patterns_path=patterns_path,
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=None,
+        existing_output_names=("suno-prompts.json",),
+        verification_collection_path=tmp_path,
+    )
+
+    with pytest.raises(ConfigError, match="suno-prompts.json"):
+        prompt_resolution.resolve_style_variant(resolved, "missing")
+
+
+def test_resolve_snapshots_and_freezes_caller_owned_nested_values(tmp_path: Path):
+    patterns = {
+        **_patterns(),
+        "patterns": [
+            {
+                "name_jp": "集中",
+                "name_en": "Focus",
+                "scenes": ["soft piano"],
+                "metadata": {"tags": ["original"]},
+            }
+        ],
+    }
+    config = _config()
+    override = {"style_influence": {"levels": [45]}}
+    lyrics = {"集中 — Focus": "original lyrics"}
+    resolved = prompt_resolution.resolve(
+        patterns,
+        config,
+        override,
+        patterns_path=tmp_path / "patterns.yaml",
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=lyrics,
+        existing_output_names=(),
+        verification_collection_path=tmp_path,
+    )
+
+    patterns["patterns"][0]["scenes"].append("mutated scene")
+    patterns["patterns"][0]["metadata"]["tags"].append("mutated tag")
+    config["style_variants"]["night"]["genre_line"] = "mutated style"
+    override["style_influence"]["levels"].append(99)
+    lyrics["集中 — Focus"] = "mutated lyrics"
+
+    assert resolved.patterns[0]["scenes"] == ("soft piano",)
+    assert resolved.patterns[0]["metadata"]["tags"] == ("original",)
+    assert resolved.style_variants["night"]["genre_line"] == "late-night jazz"
+    assert resolved.advanced_json_fields["style_influence"] == {"levels": (45,)}
+    assert resolved.external_lyrics["集中 — Focus"] == "original lyrics"
+    with pytest.raises(TypeError):
+        resolved.advanced_json_fields["new"] = "forbidden"
+    with pytest.raises(TypeError):
+        resolved.style_variants["night"]["genre_line"] = "forbidden"
+
+
+def test_resolve_snapshots_bytearray_and_non_list_mutable_sequences(tmp_path: Path):
+    byte_values = bytearray(b"\x01\x02")
+    sequence_values = UserList([{"payload": bytearray(b"\x03\x04")}])
+    override = {
+        "style_influence": byte_values,
+        "weirdness": sequence_values,
+    }
+
+    resolved = prompt_resolution.resolve(
+        _patterns(),
+        _config(),
+        override,
+        patterns_path=tmp_path / "patterns.yaml",
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=None,
+        existing_output_names=(),
+        verification_collection_path=tmp_path,
+    )
+    byte_values.append(3)
+    sequence_values[0]["payload"].append(5)
+    sequence_values.append({"payload": bytearray(b"\x06")})
+
+    assert resolved.advanced_json_fields["style_influence"] == b"\x01\x02"
+    assert resolved.advanced_json_fields["weirdness"] == ({"payload": b"\x03\x04"},)
+
+
+class _FalseyLyrics(Mapping[str, str]):
+    def __init__(self, values: Mapping[str, str]):
+        self._values = dict(values)
+
+    def __getitem__(self, key: str) -> str:
+        return self._values[key]
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def test_resolve_preserves_nonempty_falsey_lyrics_mapping(tmp_path: Path):
+    lyrics = _FalseyLyrics({"Focus": "kept lyrics"})
+
+    resolved = prompt_resolution.resolve(
+        {**_patterns(), "mode": "vocal"},
+        _config(),
+        {},
+        patterns_path=tmp_path / "patterns.yaml",
+        workflow_state_path=None,
+        workflow_track_count=None,
+        lyrics=lyrics,
+        existing_output_names=(),
+        verification_collection_path=tmp_path,
+    )
+
+    assert resolved.has_external_lyrics
+    assert resolved.external_lyrics == {"Focus": "kept lyrics"}


### PR DESCRIPTION
## Summary

- Extract Suno prompt configuration resolution into `domains/suno/prompt_resolution.py` as a pure mapping core plus a thin path/config loader.
- Keep phase 6 pattern generation in `generate_suno_prompts.py` and preserve the existing two independent resolution calls.
- Run pure phases 1–5 validation before workflow-state, lyrics, or other dependent filesystem reads, preserving the established validation/error order.
- Defer stale `suno-prompts.md` / `suno-prompts.json` inventory until the undefined channel-fallback style-variant diagnostic actually needs it.
- Snapshot accepted caller-owned mappings, byte buffers, general non-text sequences, and set-like containers recursively into immutable result values.
- Preserve the established command-local patch seams for `load_skill_config`, `load_channel_override`, and `load_suno_lyrics_by_name` across both resolution calls.

## Behavior preservation and scope

- Existing prompt output, warning text, validation failures, and two-pass observation behavior remain covered by the unchanged command suite plus boundary/equivalence regressions.
- Invalid collection config is rejected before a missing vocal workflow-state file is observed; valid instrumental resolution performs no stale-output probes.
- Stale-output files are inspected only when reporting an undefined style variant inherited from channel fallback.
- A nonempty `Mapping` with false truthiness is retained as lyrics; only `None` means absent lyrics.
- Caller mutations to nested patterns, style variants, lyrics, advanced JSON mappings/lists, `bytearray`, and non-list mutable sequences cannot change the resolved result.
- No existing tests or contracts were deleted, skipped, or weakened.
- This PR does **not** implement #3908 single-resolution wiring, ADR-0009 schema unification, #3987 production/quality skills, or #3915 automation-update work.
- Both the upstream #3915 CHANGELOG entry and this #3907 entry remain present.

## Acceptance evidence

Exact head: `b88951ec7ae60941bd299a4b42ce2bbb7c417e4c`  
Exact base: `4829bfb343fd8ed8b4816577f9bf11a1691561f8`

- RED first: `nix develop --command uv run pytest tests/domains/suno/test_prompt_resolution.py -q` — `4 failed, 6 passed` before the fix (validation order, two eager stale-probe observations, and mutable byte-buffer aliasing).
- GREEN boundary set: `nix develop --command uv run pytest tests/commands/suno/test_generate_suno_prompt_resolution_boundary.py tests/domains/suno/test_prompt_resolution.py -q` — `12 passed`.
- Focused existing + domain suite: `nix develop --command uv run pytest tests/commands/suno tests/domains/suno/test_prompt_resolution.py -q` — `402 passed, 22 warnings`.
- Fresh `git clone --no-hardlinks`, detached at the exact head, with `PYTHONDONTWRITEBYTECODE=1`: `nix develop --command uv run pytest -n auto` — `8652 passed, 1 skipped, 70 warnings` in `168.53s`.
- Same exact-head fresh-clone proof: `nix develop --command uv run pytest tests/repo/test_channel_new_residual_contract.py -q` — `5 passed`.
- `nix develop --command uv sync --frozen` — passed (`Checked 63 packages`).
- `nix develop --command uv run ruff check .` — passed (`All checks passed!`).
- `nix develop --command uv run ruff format --check .` — passed (`797 files already formatted`).
- `PRE_PUSH_DIFF_BASE=4829bfb343fd8ed8b4816577f9bf11a1691561f8 nix develop --command bash .github/scripts/any-usage-gate.sh` — passed.
- `nix develop --command uv run pytest tests/repo/test_changelog_ci_contract.py -q` — `7 passed`.
- `git diff --check` — passed.
- `nix develop --command uv build`, wheel/sdist member checks, isolated `uv pip install`, and installed import smoke — passed; both archives contain `youtube_automation/domains/suno/prompt_resolution.py`.

## Issue graph

- Parent: #3938
- `blockedBy`: none
- Blocks: #3908
- Sub-issues: none

Closes #3907
