### PR TITLE
fix(metadata): 多言語の固定尺検出漏れを修正 (#3912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。
 - `fix(metadata)`: duration display の locale を case・region 非依存で正規化し、fr/es/it/fil は各言語の単位、未知の有効 locale は warning 付き英語単位で生成して、多言語 metadata 全体の失敗を防ぐ（#3911）。

--- a/src/youtube_automation/domains/metadata/localizations.py
+++ b/src/youtube_automation/domains/metadata/localizations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -15,10 +16,29 @@ from youtube_automation.domains.metadata.titles import (
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
 LOCALIZED_TITLE_PLACEHOLDERS = frozenset({"scene_phrase", "activities", "scene_emoji", "duration_display"})
+_DURATION_LITERAL_PREFIX = r"(?<!\w)\d+(?:[.,]\d+)?\s*"
+_JAPANESE_DURATION_PARTICLE = r"(?:の|を|に|は|が|と|で|へ|も)"
 _STATIC_DURATION_LITERAL = re.compile(
-    r"(?<!\w)\d+(?:[.,]\d+)?\s*(?:hours?|hrs?|std\.?|stunden?|時間|minutes?|mins?|min\.?|分)(?!\w)",
+    rf"{_DURATION_LITERAL_PREFIX}(?:"
+    r"(?:hours?|hrs?|std\.?|stunden?|minutes?|mins?|min\.?)(?!\w)"
+    rf"|(?:時間|分)(?=$|[^\w]|{_JAPANESE_DURATION_PARTICLE}(?=$|[^\w])))",
     re.IGNORECASE,
 )
+_LOCALIZED_STATIC_HOUR_LITERAL = {
+    "fr": re.compile(rf"{_DURATION_LITERAL_PREFIX}heures?(?!\w)", re.IGNORECASE),
+    "es": re.compile(rf"{_DURATION_LITERAL_PREFIX}horas?(?!\w)", re.IGNORECASE),
+    "it": re.compile(rf"{_DURATION_LITERAL_PREFIX}(?:ora|ore)(?!\w)", re.IGNORECASE),
+}
+
+
+def _find_static_duration_literal(template: str, locale: object) -> re.Match[str] | None:
+    matching_template = unicodedata.normalize("NFC", template)
+    static_duration = _STATIC_DURATION_LITERAL.search(matching_template)
+    if static_duration is not None or not isinstance(locale, str):
+        return static_duration
+    base_locale = locale.strip().replace("_", "-").casefold().split("-", 1)[0]
+    localized_pattern = _LOCALIZED_STATIC_HOUR_LITERAL.get(base_locale)
+    return localized_pattern.search(matching_template) if localized_pattern is not None else None
 
 
 def build_short_localizations(
@@ -119,7 +139,7 @@ def validate_localizations_title_templates(loc_data: Dict) -> List[str]:
         template = lang_data.get("title_template")
         if not isinstance(template, str):
             continue
-        static_duration = _STATIC_DURATION_LITERAL.search(template)
+        static_duration = _find_static_duration_literal(template, lang)
         if static_duration:
             errors.append(
                 f"languages.{lang}.title_template: 固定尺 {static_duration.group(0)!r} が含まれています。\n"

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1522,6 +1522,36 @@ class TestCheckChannelConfig:
         assert "config/localizations.json 検証失敗" in config_check["message"]
         assert "axis_label" in config_check["message"]
 
+    def test_main_json_reports_japanese_particle_static_duration_without_changing_exit_code(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """診断 CLI は固定尺を fail check で報告し、既存どおり診断自体は exit 0 にする。"""
+        monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
+        _write_minimal_config(tmp_path)
+        (tmp_path / "config" / "localizations.json").write_text(
+            json.dumps(
+                {
+                    "supported_languages": ["ja", "ja-JP"],
+                    "default_language": "ja",
+                    "languages": {
+                        "ja": {"title_template": "{scene_phrase} [{duration_display}]"},
+                        "ja-JP": {"title_template": "3時間の{scene_phrase}"},
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code = doctor.main(["--json", "--target", str(tmp_path)])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        config_check = next(check for check in payload["checks"] if check["id"] == "channel_config")
+        assert config_check["status"] == "fail"
+        assert "config/localizations.json 検証失敗" in config_check["message"]
+        assert "languages.ja-JP.title_template: 固定尺 '3時間'" in config_check["message"]
+
     def test_channel_dir_env_restored_after_call(self, tmp_path, monkeypatch):
         """check_channel_config 呼び出し後、CHANNEL_DIR 環境変数が元に戻っている."""
         original = str(tmp_path / "original")

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -9,6 +9,7 @@ import copy
 import json
 import shutil
 import sys
+import unicodedata
 from pathlib import Path
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
@@ -1839,21 +1840,76 @@ class TestTitleTemplateUnknownPlaceholder:
         }
         assert validate_localizations_title_templates(loc) == []
 
-    @pytest.mark.parametrize("literal", ["[3 Hours]", "[3 Std]", "3時間"])
-    def test_validate_localizations_title_templates_rejects_static_duration(self, literal):
-        loc = {"languages": {"en": {"title_template": f"{{scene_phrase}} | {literal}"}}}
+    @pytest.mark.parametrize(
+        ("locale", "literal"),
+        [
+            ("en-US", "[3 Hours]"),
+            ("de-DE", "[3 Std]"),
+            ("ja-JP", "3時間"),
+            ("ja-JP", "3時間。"),
+            ("ja-JP", "3時間の{scene_phrase}"),
+            ("FR-fr", "3 Heures de {scene_phrase}"),
+            ("es-419", "3 Horas de {scene_phrase}"),
+            ("it-IT", "3 Ore di {scene_phrase}"),
+            ("fr-FR", "1 HEURE"),
+            ("es-ES", "1 hora"),
+            ("it-IT", "1 ora"),
+            ("fr-CA", "2,5 heures"),
+            ("es-MX", "2.5 HORAS"),
+        ],
+    )
+    def test_validate_localizations_title_templates_rejects_static_duration(self, locale, literal):
+        loc = {"languages": {locale: {"title_template": f"{{scene_phrase}} | {literal}"}}}
 
         errors = validate_localizations_title_templates(loc)
 
         assert len(errors) == 1
         assert "固定尺" in errors[0]
         assert "{duration_display}" in errors[0]
+        assert f"languages.{locale}.title_template" in errors[0]
+
+    @pytest.mark.parametrize(
+        ("locale", "template"),
+        [
+            ("en-US", "x3 Hours | {scene_phrase}"),
+            ("en-US", "{scene_phrase} | 3 HoursMix"),
+            ("fr-FR", "{scene_phrase} | 3 heuresFocus"),
+            ("es-419", "{scene_phrase} | 3 horas_extra"),
+            ("it-IT", "{scene_phrase} | 3 Oregon"),
+            ("en-US", "{scene_phrase} | 3 ore"),
+            ("fr-FR", "{scene_phrase} | 3 horas"),
+            ("ja-JP", "{scene_phrase} | 3時間帯"),
+            ("ja-JP", "{scene_phrase} | 3時間のりもの"),
+            ("en-US", "{scene_phrase} | Track 3"),
+            ("en-US", "{scene_phrase} | 2026 mix"),
+        ],
+    )
+    def test_validate_localizations_title_templates_ignores_non_duration_substrings(self, locale, template):
+        loc = {"languages": {locale: {"title_template": template}}}
+
+        assert validate_localizations_title_templates(loc) == []
+
+    @pytest.mark.parametrize(
+        ("locale", "unrelated_word"),
+        [
+            ("fr-FR", "heuréka"),
+            ("es-ES", "horário"),
+            ("it-IT", "orégon"),
+        ],
+    )
+    def test_validate_localizations_title_templates_ignores_normalized_word_continuations(self, locale, unrelated_word):
+        for normalization in ("NFC", "NFD"):
+            template = unicodedata.normalize(normalization, f"{{scene_phrase}} | 3 {unrelated_word} mix")
+            loc = {"languages": {locale: {"title_template": template}}}
+
+            assert validate_localizations_title_templates(loc) == []
 
     def test_validate_localizations_title_templates_tolerates_missing_sections(self):
         # languages 無し / title_template 無し / 非 dict 言語エントリは検証対象外として黙って通す
         assert validate_localizations_title_templates({}) == []
         assert validate_localizations_title_templates({"languages": {"en": {}}}) == []
         assert validate_localizations_title_templates({"languages": {"en": "broken"}}) == []
+        assert validate_localizations_title_templates({"languages": {"en": {"title_template": 3}}}) == []
 
     # --- _generate_title 経路 ---------------------------------------------
 

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -344,29 +345,67 @@ def test_plan_preflight_rejects_overlong_localized_title(
     assert "scene_phrase=13c" in message
 
 
+@pytest.mark.parametrize(
+    ("locale", "title_template", "expected_literal"),
+    [
+        ("ja-JP", "3時間の{scene_phrase}", "3時間"),
+        ("FR-fr", "3 Heures de {scene_phrase}", "3 Heures"),
+        ("es-419", "3 Horas de {scene_phrase}", "3 Horas"),
+        ("it-IT", "3 Ore di {scene_phrase}", "3 Ore"),
+    ],
+)
 def test_plan_preflight_rejects_static_localized_duration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    locale: str,
+    title_template: str,
+    expected_literal: str,
 ) -> None:
-    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "de"])
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", locale])
     _write_json(
         channel_dir / "config" / "localizations.json",
         {
-            "supported_languages": ["en", "de"],
+            "supported_languages": ["en", locale],
             "languages": {
-                "en": {"title_template": "{scene_phrase} [3 Hours]"},
-                "de": {"title_template": "{scene_phrase} [{duration_display}]"},
+                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
+                locale: {"title_template": title_template},
             },
         },
     )
     collection_dir = _write_collection(
         channel_dir,
-        scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
+        scene_phrases={"en": "focus", locale: "localized focus"},
         description="A continuous BGM mix without chapter markers.",
     )
 
-    with pytest.raises(ValidationError, match=r"固定尺 '3 Hours'"):
+    with pytest.raises(ValidationError, match=rf"固定尺 '{re.escape(expected_literal)}'"):
         _run_preflight(channel_dir, collection_dir, monkeypatch)
+
+
+def test_plan_preflight_accepts_nfd_word_continuation_after_hour_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    locale = "es-ES"
+    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", locale])
+    title_template = unicodedata.normalize("NFD", "{scene_phrase} | 3 horário mix")
+    _write_json(
+        channel_dir / "config" / "localizations.json",
+        {
+            "supported_languages": ["en", locale],
+            "languages": {
+                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
+                locale: {"title_template": title_template},
+            },
+        },
+    )
+    collection_dir = _write_collection(
+        channel_dir,
+        scene_phrases={"en": "focus", locale: "enfoque"},
+        description="A continuous BGM mix without chapter markers.",
+    )
+
+    _run_preflight(channel_dir, collection_dir, monkeypatch)
 
 
 def test_plan_preflight_passes_actual_master_duration_to_localizations(


### PR DESCRIPTION
## Summary

- Detect Japanese fixed durations before a standalone particle, including `3時間の{scene_phrase}`.
- Detect French, Spanish, and Italian hour literals only for the matching BCP47 base locale, preserving case/region variants without treating unrelated English `ore` as a duration.
- Preserve existing English, German, Japanese punctuation/end boundaries and surface the same actionable validator error through upload preflight and `yt-doctor --json`.

## RED → GREEN

RED on `4829bfb343fd8ed8b4816577f9bf11a1691561f8`:

```text
nix develop --command uv run pytest tests/domains/metadata/test_metadata_generator.py::TestTitleTemplateUnknownPlaceholder::test_validate_localizations_title_templates_rejects_static_duration tests/domains/metadata/test_metadata_generator.py::TestTitleTemplateUnknownPlaceholder::test_validate_localizations_title_templates_ignores_non_duration_substrings tests/domains/uploads/test_preflight.py::test_plan_preflight_rejects_static_localized_duration tests/commands/system/test_doctor.py::TestCheckChannelConfig::test_main_json_reports_japanese_particle_static_duration_without_changing_exit_code -q
14 failed, 12 passed
```

GREEN on `900e412b`:

```text
same focused command
29 passed
```

Adversarial normalization RED on `900e412b`:

```text
nix develop --command uv run pytest tests/domains/metadata/test_metadata_generator.py::TestTitleTemplateUnknownPlaceholder::test_validate_localizations_title_templates_ignores_normalized_word_continuations tests/domains/uploads/test_preflight.py::test_plan_preflight_accepts_nfd_word_continuation_after_hour_prefix -q
4 failed
```

GREEN on `1ace54c0`:

```text
same adversarial command
4 passed
```

## Acceptance evidence

- Positive literals: `3時間の{scene_phrase}`, `Heure(s)`, `Hora(s)`, `Ora`/`Ore`, case variants, region/script-style BCP47 keys, decimal dot/comma, and existing en/de/ja punctuation/end forms.
- Negative boundaries: embedded identifiers, unit substrings, unrelated words/numbers, `3時間帯`, `3時間のりもの`, cross-locale `3 ore`/`3 horas`, malformed/non-string templates, plus NFC/NFD pairs for `heuréka`/`horário`/`orégon`.
- Production paths: upload preflight raises the existing `ValidationError`; `yt-doctor --json` emits `channel_config.status=fail` with the fixed-duration message and preserves diagnostic exit `0`.
- Production negative path: upload preflight accepts the NFD `3 hora\u0301rio` continuation instead of falsely reporting `3 hora`.
- Focused metadata/upload/doctor/metadata-audit/skill contracts: `726 passed`.
- Fresh `git clone --no-hardlinks`, `PYTHONDONTWRITEBYTECODE=1`: exact `1ace54c0` inventory `5 passed`; the sole authorized exact-commit full run passed `8669 passed, 1 skipped, 70 warnings`.
- Static/package on `1ace54c0`: full Ruff check and format check, Any gate, CHANGELOG contract, skill lint, `git diff --check`, wheel+sdist build, non-editable wheel validator smoke (including six NFC/NFD negatives and original NFD reporting), and installed `yt-doctor --help` passed.

## Exclusions

- No changes to #3987 skill redirects.
- No changes to #3907 Suno behavior.
- No changes to #3911 localized duration formatting.

Closes #3912
