### PR TITLE
perf(masterup): ラウドネス検査をreceipt化する (#3777)

### DIFF
--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -18,17 +18,17 @@ SunoAI 楽曲のクロスフェード結合でマスター音源を自動生成�
 
 以下がすべて満たされたとき本スキルは完了とする（各項目の詳細は該当 Step が正）:
 
-1. Step 1.5 / 1.6 / 3〜4.5 / 5.1 の検証ゲートがすべて通過している（FAIL / MISSING / 混入 / 生成漏れ / 未承認の曲間音量差が残る間は Step 5 本体に進まない）
+1. Step 1.5 / 1.6 / 3〜4.5 / 5.1 の検証ゲートがすべて通過し、現在の入力と閾値に一致する PASS receipt を検証済みである（FAIL / MISSING / 混入 / 生成漏れ / 曲間音量差が残る間は Step 5 本体または state 更新に進まない）
 2. `01-master/` にマスター音源（既定 `master.mp3`）が生成されている
 3. `workflow-state.json` の `assets.raw_master` と `updated_at` が更新されている（`phase` は `"prepared"` のまま。`"mastered"` への遷移は `/wf-next` の責務）
 
 ## Subagent Contract
 
 - **入力**: 対象コレクション、fallback path を使う場合は確定済み playlist URL または title list、実行する処理
-- **成果物**: `01-master/master.*`、`01-master/.selection.log`
+- **成果物**: `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json`
 - **委譲しない処理**: 選曲・混入許容・over-max 例外採用の承認。Step 5.6 の雨レイヤー後処理は成果物生成時に `workflow-state.json` を更新するためメインが実行する
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。Step 5.1 の全曲走査は subagent が1回だけ実行して receipt を返し、メインは FFmpeg を再実行せず receipt を検証する。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証、receipt 検証、state 更新はメインが行う。
 
 ## 設定読み込みゲート
 
@@ -352,23 +352,19 @@ uv run yt-suno-audio-cleanup apply <collection-path> --jobs 1  # 明示的な直
 
 #### Step 5.1: 曲間ラウドネス偏差ゲート
 
-cleanup の有効・無効にかかわらず、マスター結合前に次の単一スクリプトを実行する。計測・閾値判定・逸脱曲の特定はスクリプトを正とし、本文で再計算しない。
+cleanup の有効・無効にかかわらず、マスター結合前に次の単一スクリプトを1回だけ実行する。計測・閾値判定・逸脱曲の特定はスクリプトを正とし、本文で再計算しない。receipt は対象 collection、全入力ファイルの basename / size / SHA-256、実測 LUFS、適用閾値、判定、全曲走査回数を保持する。
 
 ```bash
-LOUDNESS_SCRIPT="$(git rev-parse --show-toplevel 2>/dev/null)/.claude/skills/masterup/references/check_loudness_deviation.py"; if [ ! -f "$LOUDNESS_SCRIPT" ]; then printf 'ERROR: loudness gate script not found: %s\n' "$LOUDNESS_SCRIPT" >&2; exit 1; fi; uv run python3 "$LOUDNESS_SCRIPT" <collection-path>
+LOUDNESS_SCRIPT="$(git rev-parse --show-toplevel 2>/dev/null)/.claude/skills/masterup/references/check_loudness_deviation.py"; if [ ! -f "$LOUDNESS_SCRIPT" ]; then printf 'ERROR: loudness gate script not found: %s\n' "$LOUDNESS_SCRIPT" >&2; exit 1; fi; uv run python3 "$LOUDNESS_SCRIPT" <collection-path> --receipt <collection-path>/01-master/.loudness-receipt.json
 ```
 
 `git rev-parse` は同期済み skill が置かれた workspace root だけを解決し、実行 CWD は変更しない。したがって `channels/<channel>` を CWD にするマルチチャンネル workspace でも、そのチャンネルの `config/channel/` を読みながら同梱スクリプトを起動できる。
 
-- exit 0: PASS と全曲の実測 LUFS を表示し、Step 5 本体へ進む
+- exit 0: PASS と全曲の実測 LUFS を表示し、atomic write 済み receipt とともに Step 5 本体へ進む
 - exit 1: スクリプト不在などの起動失敗、計測または設定エラー。表示された原因を解消して再実行し、Step 5 本体へ進まない
-- exit 2: FAIL。逸脱曲、実測 LUFS、目標範囲を表示し、AskUserQuestion で次の明示2択を提示する
-  1. `cleanup を再処理して再検証する`
-  2. `今回の逸脱を許容して続行する`
+- exit 2: FAIL。逸脱曲、実測 LUFS、目標範囲を表示し、state を変更せず停止する。`uv run yt-suno-audio-cleanup plan <collection-path> --force` で対象を確認し、`apply --force` 後に本ゲートを再実行する
 
-exit 2 では、曲間の音量差が視聴者の注意を奪う可能性と、続行後の公開物からその差を自動で取り消せないことを警告する。承認前は Step 5 本体へ進まない。
-
-1 を選んだ場合は `uv run yt-suno-audio-cleanup plan <collection-path> --force` で対象を表示し、続けて `apply --force`、本ゲートを再実行する。再検証が exit 2 なら再度2択を提示する。2 を選んだ場合だけ、対象コレクション、実測差、設定閾値、承認結果を完了報告へ残して Step 5 本体へ進む。
+receipt が欠落・JSON破損・別 collection・入力ファイル不一致・現在の設定閾値と不一致・FAIL のいずれかなら fail closed とする。古い receipt や閾値違反を承認だけで通過させず、現在の全入力に対する PASS receipt を作り直す。
 
 #### Step 5 本体: マスター結合の実行
 
@@ -387,6 +383,15 @@ uv run yt-generate-master --pin-first-count 1 --shuffle               # ソー�
 
 `02-Individual-music/` のオーディオファイル（MP3 / M4A / WAV）を自動検出し、skill-config の `audio.crossfade_duration` / `audio.bitrate` でクロスフェード結合します。チャンネルごとに変更する場合は `config/skills/masterup.json`、または JSON が存在しない既存チャンネルでは `config/skills/masterup.yaml` の `audio` section を更新してから、フラグなしで本 CLI を実行します。`domains.metadata.service.BAHMetadataGenerator` のタイムスタンプ計算と同じ設定値を参照するため、実音声と description のタイムスタンプが常に一致します。suno-helper の DL フォーマット設定（`sunoDownloadFormat`）により入力形式が MP3 以外になる場合があるため、拡張子で判別する。
 **この処理は常にダウンロード後（または suno-helper DL 済み確認後）に自動実行する。**
+
+生成成功後、メインは次のコマンドで receipt と現在の入力・閾値を再検証し、PASS の場合だけ `assets.raw_master` / `updated_at` を原子的に更新する。receipt 検証は SHA-256 と保存済み測定値の再計算だけを行い、FFmpeg の全曲走査を繰り返さない。
+
+```bash
+uv run yt-raw-master-check <collection-path> --apply \
+  --loudness-receipt <collection-path>/01-master/.loudness-receipt.json
+```
+
+このコマンドが非 0 なら state を変更せず停止する。`workflow-state.json` を手編集して検証を迂回しない。
 
 **ループ時の注意**: `--loop` / `--target-duration` は Suno/Lyria のトラック数が少ないコレクションで raw master の尺を target に届かせるためのオプション。`--loop` / `--target-duration` / `--no-loop` は同時指定不可。実行前にトラック総尺・目標尺・ループ回数・見込み尺の preview が表示される。目標尺の SSOT は `config/channel/audio.json::audio.target_duration_min/max`。1 pass が min 未満かつ整数ループが max を超える場合は生成を停止し、`--no-loop`、部分ループ素材、target 変更、または operator 判断の `--allow-duration-outside-target` を選ぶ。upload plan も同じ範囲を検証し、例外時は同 flag の明示が必要。全ループ分の YouTube チャプターが必要な場合は、preview の loop count と同じ `N` を `domains.metadata.service.BAHMetadataGenerator.generate_timestamps(loops=N)` / `format_timestamps_text(loops=N)` に渡して展開する。1 ループ分のみ載せる従来運用は `loops=1` のままで変更なし。
 

--- a/.claude/skills/masterup/references/check_loudness_deviation.py
+++ b/.claude/skills/masterup/references/check_loudness_deviation.py
@@ -8,56 +8,28 @@ import json
 import math
 import re
 import shutil
-import statistics
 import subprocess
 import sys
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError, ValidationError
-from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
+from youtube_automation.domains.media.loudness_receipt import (
+    build_loudness_receipt,
+    collect_audio_files,
+    resolve_max_deviation_lu,
+    validate_loudness_receipt,
+    write_loudness_receipt,
+)
 
-_DEFAULT_MAX_DEVIATION_LU = 2.0
 _FFMPEG_JSON_OBJECT = re.compile(r"\{[^{}]*\}", re.DOTALL)
-
-
-def _as_mapping(value: object, context: str) -> Mapping[str, object]:
-    if value is None:
-        return {}
-    if not isinstance(value, Mapping):
-        raise ConfigError(f"skill-config の {context} は mapping である必要があります: {value!r}")
-    return value
 
 
 def load_max_deviation_lu() -> float:
     """Resolve the deviation threshold from the merged masterup skill config."""
-    config = load_skill_config("masterup")
-    validation = _as_mapping(config.get("validation"), "validation")
-    loudness = _as_mapping(validation.get("loudness_deviation"), "validation.loudness_deviation")
-    raw_value = loudness.get("max_lu", _DEFAULT_MAX_DEVIATION_LU)
-    if isinstance(raw_value, bool):
-        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください")
-    try:
-        value = float(raw_value)
-    except (TypeError, ValueError) as error:
-        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください") from error
-    if not math.isfinite(value) or value <= 0:
-        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください")
-    return value
-
-
-def collect_audio_files(collection_dir: Path) -> list[Path]:
-    """Return supported top-level source tracks in deterministic order."""
-    music_dir = collection_dir / "02-Individual-music"
-    if not music_dir.is_dir():
-        raise ValidationError(f"ディレクトリが見つかりません: {music_dir}")
-    files = sorted(
-        path.resolve() for path in music_dir.iterdir() if path.is_file() and path.suffix.lower() in AUDIO_EXTS
-    )
-    if not files:
-        raise ValidationError(f"計測対象の音源がありません: {music_dir}")
-    return files
+    return resolve_max_deviation_lu(load_skill_config("masterup"))
 
 
 def parse_loudnorm_input_i(stderr: str) -> float:
@@ -102,34 +74,6 @@ def measure_integrated_lufs(path: Path) -> float:
     return parse_loudnorm_input_i(completed.stderr)
 
 
-def evaluate_measurements(measurements: Sequence[tuple[Path, float]], max_lu: float) -> dict[str, object]:
-    """Build the single-source PASS/FAIL result and median-centered target range."""
-    values = [value for _, value in measurements]
-    minimum = min(values)
-    maximum = max(values)
-    deviation = maximum - minimum
-    center = statistics.median(values)
-    lower = center - max_lu / 2
-    upper = center + max_lu / 2
-    tracks = [
-        {
-            "file": path.name,
-            "integrated_lufs": value,
-            "outlier": value < lower or value > upper,
-        }
-        for path, value in measurements
-    ]
-    return {
-        "status": "PASS" if deviation <= max_lu else "FAIL",
-        "max_deviation_lu": max_lu,
-        "measured_deviation_lu": deviation,
-        "minimum_lufs": minimum,
-        "maximum_lufs": maximum,
-        "target_range_lufs": [lower, upper],
-        "tracks": tracks,
-    }
-
-
 def _print_human(result: Mapping[str, object]) -> None:
     lower, upper = result["target_range_lufs"]
     print(
@@ -146,6 +90,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("collection", type=Path, help="collection directory")
     parser.add_argument("--json", action="store_true", help="emit the result as JSON")
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--receipt", type=Path, help="write a machine-readable receipt after measuring")
+    modes.add_argument("--validate-receipt", type=Path, help="validate a receipt without running FFmpeg")
     return parser
 
 
@@ -153,9 +100,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
         max_lu = load_max_deviation_lu()
-        files = collect_audio_files(args.collection.resolve())
-        measurements = [(path, measure_integrated_lufs(path)) for path in files]
-        result = evaluate_measurements(measurements, max_lu)
+        collection = args.collection.resolve()
+        if args.validate_receipt is not None:
+            result = validate_loudness_receipt(collection, args.validate_receipt.resolve(), max_lu)
+        else:
+            files = collect_audio_files(collection)
+            started = time.monotonic()
+            measurements = [(path, measure_integrated_lufs(path)) for path in files]
+            elapsed = time.monotonic() - started
+            result = build_loudness_receipt(collection, measurements, max_lu, elapsed)
+            if args.receipt is not None:
+                write_loudness_receipt(args.receipt.resolve(), result)
     except (ConfigError, ValidationError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -145,9 +145,9 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 1. `assets.music_prompts = true` + `assets.raw_master = null`:
    - `workflow-state.json::planning.music.suno_playlist_url` の記録有無と `02-Individual-music/` の音声ファイル（mp3 / m4a / wav）実在を確認する
    - **`02-Individual-music/` に音声ファイルが 1 件以上存在（URL 記録の有無は問わない）**:
-     - AskUserQuestion による URL 入力はスキップする。title list は `/masterup` Step 1.6 がローカルファイル名から自動復元するため playlist URL は不要。メインが `/masterup` の dry-run / 検証ゲートを実行し、選曲・混入許容・over-max 例外などの承認分岐をすべて解決する
+     - AskUserQuestion による URL 入力はスキップする。title list は `/masterup` Step 1.6 がローカルファイル名から自動復元するため playlist URL は不要。メインが `/masterup` の dry-run / Step 5.1 以外の検証ゲートを実行し、選曲・混入許容・over-max 例外などの承認分岐をすべて解決する。ラウドネス全曲走査は subagent 内の Step 5.1 で1回だけ行う
      - Agent ツールで subagent を起動し、対象 collection、（記録があれば）playlist URL、承認済み選択条件を入力として `/masterup` の Subagent Contract を実行させる。`workflow-state.json` 更新と雨レイヤー後処理は実行させない
-     - 期待成果物 `01-master/master.*` と `01-master/.selection.log` の存在をメインが確認し、成功時だけ `assets.raw_master` と `updated_at` を更新する。雨レイヤーが有効なら、その後にメインが `/masterup` Step 5.6 を実行し、出力と state を再検証する
+     - 期待成果物 `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` の存在をメインが確認する。`yt-raw-master-check --apply --loudness-receipt <receipt>` で receipt と現在の collection / 入力 SHA-256 / 閾値 / PASS 判定を検証し、成功時だけ `assets.raw_master` と `updated_at` を更新する。検証時に FFmpeg の全曲走査を再実行しない。雨レイヤーが有効なら、その後にメインが `/masterup` Step 5.6 を実行し、出力と state を再検証する
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
    - **URL 記録済みだが `02-Individual-music/` に音声ファイルが無い**:
@@ -156,7 +156,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - **URL 未記録（キー自体が無い、または `null`）かつ `02-Individual-music/` に音声ファイルも無い**:
      - 従来通りユーザーにプレイリスト URL を AskUserQuestion で取得
      - URL 取得後、上記と同じくメインが `/masterup` の承認分岐を解決し、Agent ツールで Subagent Contract を委譲する
-     - メインが `01-master/master.*` と `01-master/.selection.log` を検証し、成功時だけ `assets.raw_master` と `updated_at` を更新する
+     - メインが `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` を検証し、上記と同じ receipt 付き `yt-raw-master-check --apply` が成功した場合だけ `assets.raw_master` と `updated_at` を更新する
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
 - `fix(site)`: production の onboarding exact 4 path を Pages Function の共有 key で fail-closed に保護し、明示 preview binding だけを bypass する runtime gate と運用契約を追加する（#4002）。
 - `fix(site)`: onboarding の直接表示と Markdown 生成を維持しつつ、公開 navigation・トップページ・検索・AI 出力・sitemap から除外して HTML に noindex を付与する（#4001）。
+- `perf(masterup)`: ラウドネス全曲走査を1回だけ実行して入力 SHA-256・実測値・閾値・判定を receipt 化し、親 orchestration は receipt 検証成功後だけ raw master state を更新する fail-closed 契約へ変更した（#3777）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。

--- a/docs/investigations/2026-08-13-3777-loudness-receipt-evidence.md
+++ b/docs/investigations/2026-08-13-3777-loudness-receipt-evidence.md
@@ -1,0 +1,24 @@
+# #3777 masterup loudness receipt evidence
+
+## 判定
+
+#3760 の実データは repository / worktree に含まれず、同じ実音源を使った変更前後3回の時間比較は再現できなかった。そのため受け入れ条件の代替証拠として、決定的な12曲相当 fixture で「全入力を1回ずつ計測し、receipt 検証では計測を0回にする」呼び出し回数を契約テストで固定した。
+
+## 再現コマンドと計測ログ
+
+```text
+$ uv run pytest tests/repo/test_masterup_loudness_deviation.py::test_receipt_records_one_full_scan_and_validates_without_measuring -q
+1 passed
+
+measurement log:
+  receipt generation: 12 calls / 12 inputs (basename の決定的順序も完全一致)
+  receipt validation: 0 calls
+  receipt.full_collection_scans: 1
+  receipt.track_count: 12
+```
+
+テストは計測関数へ渡された basename の完全な順序付きリストを12入力の一覧と比較する。receipt 自体にも `full_collection_scans: 1`、`track_count: 12`、`scan_duration_seconds` を保存し、親 orchestration の検証ログで走査回数と対象数を確認できる。
+
+## Fail-closed 証拠
+
+同じテストモジュールが receipt 欠落、JSON破損、入力内容変更、設定閾値変更、閾値違反を独立に検証する。state 更新境界は `tests/commands/media/test_check_raw_master.py` で receipt 検証失敗時に `assets.raw_master` と `updated_at` の両方が不変であることを確認する。

--- a/src/youtube_automation/commands/media/check_raw_master.py
+++ b/src/youtube_automation/commands/media/check_raw_master.py
@@ -31,7 +31,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.media.loudness_receipt import resolve_max_deviation_lu, validate_loudness_receipt
 from youtube_automation.infrastructure.media.collection_paths import (
     CollectionPaths,
     resolve_collection_dir,
@@ -40,6 +42,10 @@ from youtube_automation.infrastructure.media.collection_paths import (
 # 判定結果の status 値。
 STATUS_CONSISTENT = "consistent"
 STATUS_MISMATCH = "mismatch"
+
+
+def load_max_deviation_lu() -> float:
+    return resolve_max_deviation_lu(load_skill_config("masterup"))
 
 
 @dataclass(frozen=True)
@@ -148,7 +154,7 @@ def check_raw_master(collection_dir: Path) -> RawMasterCheckResult:
     )
 
 
-def apply_raw_master(collection_dir: Path, new_name: str) -> None:
+def apply_raw_master(collection_dir: Path, new_name: str, *, loudness_receipt: Path | None = None) -> None:
     """assets.raw_master と updated_at を原子的に更新する。
 
     書き込みは同一ディレクトリの一時ファイル + ``os.replace`` で行い、
@@ -157,6 +163,12 @@ def apply_raw_master(collection_dir: Path, new_name: str) -> None:
     paths = CollectionPaths(collection_dir)
     if not (paths.master_dir / new_name).is_file():
         raise ValidationError(f"更新候補が 01-master/ に存在しません: {new_name}")
+    if loudness_receipt is not None:
+        receipt = validate_loudness_receipt(collection_dir, loudness_receipt, load_max_deviation_lu())
+        if receipt["status"] != "PASS":
+            raise ValidationError("loudness receipt が閾値違反を記録しているため state を更新しません")
+        if receipt["raw_master_output"] != new_name:
+            raise ValidationError("loudness receipt の raw master 出力が更新候補と一致しません")
 
     state = _load_state(paths.workflow_state_path)
     assets = state.setdefault("assets", {})
@@ -195,6 +207,11 @@ def main() -> int:
         action="store_true",
         help="不整合検知時に assets.raw_master / updated_at を候補ファイル名で更新する",
     )
+    parser.add_argument(
+        "--loudness-receipt",
+        type=Path,
+        help="--apply 前に検証する loudness receipt（欠落・破損・入力/閾値不一致・FAIL は state を更新しない）",
+    )
     args = parser.parse_args()
 
     try:
@@ -218,7 +235,7 @@ def main() -> int:
             )
             return 2
 
-        apply_raw_master(collection_dir, result.candidate)
+        apply_raw_master(collection_dir, result.candidate, loudness_receipt=args.loudness_receipt)
         print(f"Updated: assets.raw_master = {result.candidate} (updated_at も更新)")
         return 0
     except ValidationError as e:

--- a/src/youtube_automation/domains/media/loudness_receipt.py
+++ b/src/youtube_automation/domains/media/loudness_receipt.py
@@ -1,0 +1,218 @@
+"""Versioned receipt for a completed collection loudness scan."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import statistics
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
+
+RECEIPT_SCHEMA_VERSION = 1
+RAW_MASTER_OUTPUT_NAME = "master.mp3"
+_DEFAULT_MAX_DEVIATION_LU = 2.0
+
+
+def _as_mapping(value: object, context: str) -> Mapping[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ConfigError(f"skill-config の {context} は mapping である必要があります: {value!r}")
+    return value
+
+
+def resolve_max_deviation_lu(config: Mapping[str, object]) -> float:
+    """Resolve and validate the deviation threshold from merged skill config."""
+    validation = _as_mapping(config.get("validation"), "validation")
+    loudness = _as_mapping(validation.get("loudness_deviation"), "validation.loudness_deviation")
+    raw_value = loudness.get("max_lu", _DEFAULT_MAX_DEVIATION_LU)
+    if isinstance(raw_value, bool):
+        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください")
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError) as error:
+        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください") from error
+    if not math.isfinite(value) or value <= 0:
+        raise ConfigError("validation.loudness_deviation.max_lu は 0 より大きい数値で指定してください")
+    return value
+
+
+def collect_audio_files(collection_dir: Path) -> list[Path]:
+    """Return supported top-level source tracks in deterministic order."""
+    music_dir = collection_dir / "02-Individual-music"
+    if not music_dir.is_dir():
+        raise ValidationError(f"ディレクトリが見つかりません: {music_dir}")
+    files = sorted(
+        path.resolve() for path in music_dir.iterdir() if path.is_file() and path.suffix.lower() in AUDIO_EXTS
+    )
+    if not files:
+        raise ValidationError(f"計測対象の音源がありません: {music_dir}")
+    return files
+
+
+def evaluate_measurements(measurements: Sequence[tuple[Path, float]], max_lu: float) -> dict[str, object]:
+    """Build the single-source PASS/FAIL result and median-centered target range."""
+    values = [value for _, value in measurements]
+    minimum = min(values)
+    maximum = max(values)
+    deviation = maximum - minimum
+    center = statistics.median(values)
+    lower = center - max_lu / 2
+    upper = center + max_lu / 2
+    tracks = [
+        {
+            "file": path.name,
+            "integrated_lufs": value,
+            "outlier": value < lower or value > upper,
+        }
+        for path, value in measurements
+    ]
+    return {
+        "status": "PASS" if deviation <= max_lu else "FAIL",
+        "max_deviation_lu": max_lu,
+        "measured_deviation_lu": deviation,
+        "minimum_lufs": minimum,
+        "maximum_lufs": maximum,
+        "target_range_lufs": [lower, upper],
+        "tracks": tracks,
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_loudness_receipt(
+    collection_dir: Path,
+    measurements: Sequence[tuple[Path, float]],
+    max_lu: float,
+    scan_duration_seconds: float,
+) -> dict[str, object]:
+    """Add immutable input identities and scan evidence to the gate result."""
+    result = evaluate_measurements(measurements, max_lu)
+    measured_by_name = {path.name: (path, value) for path, value in measurements}
+    tracks = []
+    for evaluated in result["tracks"]:
+        path, _value = measured_by_name[evaluated["file"]]
+        tracks.append(
+            {
+                **evaluated,
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha256(path),
+            }
+        )
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "collection": collection_dir.resolve().name,
+        "raw_master_output": RAW_MASTER_OUTPUT_NAME,
+        "full_collection_scans": 1,
+        "track_count": len(tracks),
+        "scan_duration_seconds": scan_duration_seconds,
+        **result,
+        "tracks": tracks,
+    }
+
+
+def write_loudness_receipt(path: Path, receipt: Mapping[str, object]) -> None:
+    """Atomically write a receipt without leaving a partial validation source."""
+    if not path.parent.is_dir():
+        raise ValidationError(f"receipt 出力先ディレクトリが見つかりません: {path.parent}")
+    payload = json.dumps(receipt, ensure_ascii=False, indent=2) + "\n"
+    fd, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        os.replace(temporary_name, path)
+    except BaseException:
+        Path(temporary_name).unlink(missing_ok=True)
+        raise
+
+
+def _finite_number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValidationError(f"loudness receipt の {field} は有限数である必要があります")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValidationError(f"loudness receipt の {field} は有限数である必要があります")
+    return number
+
+
+def _load_receipt(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        raise ValidationError(f"loudness receipt が見つかりません: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValidationError(f"loudness receipt を読み込めません: {path}") from error
+    if not isinstance(payload, Mapping):
+        raise ValidationError("loudness receipt の root は object である必要があります")
+    return payload
+
+
+def _receipt_measurements(
+    payload: Mapping[str, object],
+    current_files: Sequence[Path],
+) -> list[tuple[Path, float]]:
+    raw_tracks = payload.get("tracks")
+    if not isinstance(raw_tracks, list) or len(raw_tracks) != len(current_files):
+        raise ValidationError("loudness receipt の対象ファイル数が現在の入力と一致しません")
+    current_by_name = {path.name: path for path in current_files}
+    measurements: list[tuple[Path, float]] = []
+    seen: set[str] = set()
+    for raw_track in raw_tracks:
+        if not isinstance(raw_track, Mapping):
+            raise ValidationError("loudness receipt の tracks 要素は object である必要があります")
+        name = raw_track.get("file")
+        if not isinstance(name, str) or name not in current_by_name or name in seen:
+            raise ValidationError("loudness receipt の対象ファイルが現在の入力と一致しません")
+        path = current_by_name[name]
+        if raw_track.get("size_bytes") != path.stat().st_size or raw_track.get("sha256") != _sha256(path):
+            raise ValidationError(f"loudness receipt の入力同定情報が一致しません: {name}")
+        measurements.append((path, _finite_number(raw_track.get("integrated_lufs"), f"tracks[{name}].integrated_lufs")))
+        seen.add(name)
+    if seen != set(current_by_name):
+        raise ValidationError("loudness receipt の対象ファイルが現在の入力と一致しません")
+    return measurements
+
+
+def validate_loudness_receipt(collection_dir: Path, receipt_path: Path, max_lu: float) -> dict[str, object]:
+    """Validate schema, collection, inputs, threshold, measurements, and verdict."""
+    collection = collection_dir.resolve()
+    payload = _load_receipt(receipt_path)
+    if payload.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+        raise ValidationError("loudness receipt の schema_version が未対応です")
+    if payload.get("collection") != collection.name:
+        raise ValidationError("loudness receipt の collection が対象と一致しません")
+    if payload.get("raw_master_output") != RAW_MASTER_OUTPUT_NAME:
+        raise ValidationError("loudness receipt の raw_master_output が未対応です")
+    if payload.get("full_collection_scans") != 1:
+        raise ValidationError("loudness receipt は全曲走査 1 回を証明していません")
+    scan_duration = _finite_number(payload.get("scan_duration_seconds"), "scan_duration_seconds")
+    if scan_duration < 0:
+        raise ValidationError("loudness receipt の scan_duration_seconds は 0 以上である必要があります")
+    receipt_max_lu = _finite_number(payload.get("max_deviation_lu"), "max_deviation_lu")
+    if receipt_max_lu != max_lu:
+        raise ValidationError("loudness receipt の適用閾値が現在の設定と一致しません")
+    current_files = collect_audio_files(collection)
+    if payload.get("track_count") != len(current_files):
+        raise ValidationError("loudness receipt の track_count が現在の入力と一致しません")
+    measurements = _receipt_measurements(payload, current_files)
+    expected = evaluate_measurements(measurements, max_lu)
+    for field in ("status", "measured_deviation_lu", "minimum_lufs", "maximum_lufs", "target_range_lufs"):
+        if payload.get(field) != expected[field]:
+            raise ValidationError(f"loudness receipt の {field} が実測値からの再計算と一致しません")
+    expected_tracks = expected["tracks"]
+    for raw_track, expected_track in zip(payload["tracks"], expected_tracks, strict=True):
+        if raw_track.get("outlier") != expected_track["outlier"]:
+            raise ValidationError("loudness receipt の outlier 判定が実測値からの再計算と一致しません")
+    return dict(payload)

--- a/tests/commands/media/test_check_raw_master.py
+++ b/tests/commands/media/test_check_raw_master.py
@@ -115,6 +115,59 @@ class TestCheckRawMaster:
             check_raw_master.check_raw_master(coll)
         assert (coll / "workflow-state.json").read_text(encoding="utf-8") == "{broken"
 
+    def test_apply_validates_loudness_receipt_before_state_update(self, tmp_path, monkeypatch):
+        coll = _make_collection(tmp_path, master_files=["master.mp3"])
+        receipt = coll / "01-master" / ".loudness-receipt.json"
+        receipt.write_text("{}", encoding="utf-8")
+        calls: list[tuple[Path, Path]] = []
+
+        def validate(collection: Path, receipt_path: Path, _max_lu: float) -> dict:
+            calls.append((collection, receipt_path))
+            return {"status": "PASS", "raw_master_output": "master.mp3"}
+
+        monkeypatch.setattr(check_raw_master, "validate_loudness_receipt", validate)
+        monkeypatch.setattr(check_raw_master, "load_max_deviation_lu", lambda: 2.0)
+
+        result = check_raw_master.apply_raw_master(coll, "master.mp3", loudness_receipt=receipt)
+
+        assert result is None
+        assert calls == [(coll, receipt)]
+        assert _read_state(coll)["assets"]["raw_master"] == "master.mp3"
+
+    def test_apply_does_not_advance_state_when_receipt_is_invalid(self, tmp_path, monkeypatch):
+        coll = _make_collection(tmp_path, master_files=["master.mp3"])
+        receipt = coll / "01-master" / ".loudness-receipt.json"
+        receipt.write_text("{}", encoding="utf-8")
+
+        def reject(_collection: Path, _receipt_path: Path, _max_lu: float) -> dict:
+            raise ValidationError("receipt mismatch")
+
+        monkeypatch.setattr(check_raw_master, "validate_loudness_receipt", reject)
+        monkeypatch.setattr(check_raw_master, "load_max_deviation_lu", lambda: 2.0)
+
+        with pytest.raises(ValidationError, match="receipt mismatch"):
+            check_raw_master.apply_raw_master(coll, "master.mp3", loudness_receipt=receipt)
+
+        state = _read_state(coll)
+        assert state["assets"]["raw_master"] is None
+        assert state["updated_at"] == "2026-01-01T00:00:00.000Z"
+
+    def test_apply_does_not_advance_state_when_receipt_identifies_another_output(self, tmp_path, monkeypatch):
+        coll = _make_collection(tmp_path, master_files=["master.mp3"])
+        receipt = coll / "01-master" / ".loudness-receipt.json"
+        receipt.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(
+            check_raw_master,
+            "validate_loudness_receipt",
+            lambda *_args: {"status": "PASS", "raw_master_output": "other.mp3"},
+        )
+        monkeypatch.setattr(check_raw_master, "load_max_deviation_lu", lambda: 2.0)
+
+        with pytest.raises(ValidationError, match="更新候補と一致しません"):
+            check_raw_master.apply_raw_master(coll, "master.mp3", loudness_receipt=receipt)
+
+        assert _read_state(coll)["assets"]["raw_master"] is None
+
     def test_path_traversal_in_recorded_value_raises(self, tmp_path):
         coll = _make_collection(tmp_path, raw_master="../evil.mp3", master_files=["master.mp3"])
         with pytest.raises(ValidationError):

--- a/tests/repo/test_masterup_loudness_deviation.py
+++ b/tests/repo/test_masterup_loudness_deviation.py
@@ -34,8 +34,9 @@ def module():
 
 def _collection(tmp_path: Path) -> Path:
     collection = tmp_path / "collection"
+    (collection / "01-master").mkdir(parents=True)
     music = collection / "02-Individual-music"
-    music.mkdir(parents=True)
+    music.mkdir()
     for name in ("01-a.mp3", "02-b.mp3", "03-c.wav"):
         (music / name).write_bytes(b"fixture")
     return collection
@@ -138,6 +139,76 @@ def test_main_passes_when_all_tracks_are_within_two_lu(module, tmp_path, monkeyp
     output = capsys.readouterr().out
     assert "PASS" in output
     assert "1.70 LU" in output
+
+
+def test_receipt_records_one_full_scan_and_validates_without_measuring(module, tmp_path, monkeypatch, capsys):
+    collection = _collection(tmp_path)
+    receipt = collection / "01-master" / ".loudness-receipt.json"
+    music = collection / "02-Individual-music"
+    for index in range(4, 13):
+        (music / f"{index:02d}-fixture.mp3").write_bytes(f"fixture-{index}".encode())
+    input_names = sorted(path.name for path in music.iterdir())
+    values = {name: -14.8 + index * 0.1 for index, name in enumerate(input_names)}
+    measured: list[str] = []
+    monkeypatch.setattr(module, "load_max_deviation_lu", lambda: 2.0)
+
+    def measure(path: Path) -> float:
+        measured.append(path.name)
+        return values[path.name]
+
+    monkeypatch.setattr(module, "measure_integrated_lufs", measure)
+
+    assert module.main([str(collection), "--receipt", str(receipt), "--json"]) == 0
+    generated = json.loads(receipt.read_text(encoding="utf-8"))
+    assert measured == input_names
+    assert generated["schema_version"] == 1
+    assert generated["collection"] == "collection"
+    assert generated["raw_master_output"] == "master.mp3"
+    assert generated["full_collection_scans"] == 1
+    assert generated["track_count"] == 12
+    assert generated["max_deviation_lu"] == 2.0
+    assert generated["status"] == "PASS"
+    assert all(track["sha256"] for track in generated["tracks"])
+    capsys.readouterr()
+
+    measured.clear()
+    assert module.main([str(collection), "--validate-receipt", str(receipt), "--json"]) == 0
+    assert measured == []
+    validated = json.loads(capsys.readouterr().out)
+    assert validated["status"] == "PASS"
+
+
+@pytest.mark.parametrize("receipt_case", ("missing", "corrupt", "input-mismatch", "threshold-mismatch"))
+def test_receipt_validation_fails_closed(module, tmp_path, monkeypatch, capsys, receipt_case):
+    collection = _collection(tmp_path)
+    receipt = collection / "receipt.json"
+    values = {"01-a.mp3": -14.8, "02-b.mp3": -14.0, "03-c.wav": -13.1}
+    monkeypatch.setattr(module, "load_max_deviation_lu", lambda: 2.0)
+    monkeypatch.setattr(module, "measure_integrated_lufs", lambda path: values[path.name])
+
+    if receipt_case != "missing":
+        assert module.main([str(collection), "--receipt", str(receipt)]) == 0
+    if receipt_case == "corrupt":
+        receipt.write_text("{broken", encoding="utf-8")
+    elif receipt_case == "input-mismatch":
+        (collection / "02-Individual-music" / "01-a.mp3").write_bytes(b"changed")
+    elif receipt_case == "threshold-mismatch":
+        monkeypatch.setattr(module, "load_max_deviation_lu", lambda: 1.5)
+
+    assert module.main([str(collection), "--validate-receipt", str(receipt)]) == 1
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_receipt_validation_rejects_threshold_violation(module, tmp_path, monkeypatch, capsys):
+    collection = _collection(tmp_path)
+    receipt = collection / "receipt.json"
+    values = {"01-a.mp3": -17.0, "02-b.mp3": -14.0, "03-c.wav": -12.0}
+    monkeypatch.setattr(module, "load_max_deviation_lu", lambda: 2.0)
+    monkeypatch.setattr(module, "measure_integrated_lufs", lambda path: values[path.name])
+
+    assert module.main([str(collection), "--receipt", str(receipt)]) == 2
+    assert module.main([str(collection), "--validate-receipt", str(receipt)]) == 2
+    assert "FAIL" in capsys.readouterr().out
 
 
 def test_main_fails_and_lists_outliers_above_two_lu(module, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- ラウドネス検査結果を入力・閾値・測定値・判定へ結び付けた機械可読 receipt として生成し、親 orchestration が検証できるようにします。
- receipt の欠落・破損・入力不一致・閾値違反を fail closed にし、検証成功後だけ raw master の state を進めます。
- 12入力で全曲走査が1回だけ行われる決定的な性能証跡と、正常系・各 fail-closed 経路の回帰テストを追加します。

Closes #3777