### PR TITLE
fix(extensions): 無効な配信元更新を遮断する (#4079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
 - `fix(site)`: production の onboarding exact 4 path を Pages Function の共有 key で fail-closed に保護し、明示 preview binding だけを bypass する runtime gate と運用契約を追加する（#4002）。
 - `fix(site)`: onboarding の直接表示と Markdown 生成を維持しつつ、公開 navigation・トップページ・検索・AI 出力・sitemap から除外して HTML に noindex を付与する（#4001）。
+- `fix(extensions)`: 配信元候補が空の disabled selector では forced / programmatic open event を共有 field 境界で遮断し、registry refresh と listbox open を発火させない（#4079）。
 - `perf(masterup)`: ラウドネス全曲走査を1回だけ実行して入力 SHA-256・実測値・閾値・判定を receipt 化し、親 orchestration は receipt 検証成功後だけ raw master state を更新する fail-closed 契約へ変更した（#3777）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。

--- a/extensions/distrokid-helper/tests/server-source-field.test.tsx
+++ b/extensions/distrokid-helper/tests/server-source-field.test.tsx
@@ -154,6 +154,30 @@ describe("ServerSourceField and Shadow portal ref", () => {
     ).toBe(true);
   });
 
+  it("should not refresh when a no-source disabled trigger receives forced open events", async () => {
+    const onRefresh = vi.fn(async () => undefined);
+    await renderField({ sources: [], value: "", onRefresh });
+    const trigger = shadow.querySelector<HTMLButtonElement>("#server-source")!;
+
+    let pointerAllowed = true;
+    let clickAllowed = true;
+    await act(async () => {
+      pointerAllowed = trigger.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+      );
+      clickAllowed = trigger.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+      await Promise.resolve();
+    });
+
+    expect(trigger.disabled).toBe(true);
+    expect(pointerAllowed).toBe(false);
+    expect(clickAllowed).toBe(false);
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(shadow.querySelector('[role="listbox"]')).toBeNull();
+  });
+
   it("forwards callback/object refs, resolves the portal parent, and clears it on null", async () => {
     const callbackRef = vi.fn();
     const objectRef = createRef<HTMLButtonElement>();

--- a/extensions/shared-ui/src/server-source-field.tsx
+++ b/extensions/shared-ui/src/server-source-field.tsx
@@ -72,6 +72,24 @@ export function ServerSourceField({
       setOpen(false);
     }
   }, [interactionDisabled]);
+  React.useEffect(() => {
+    const field = fieldRef.current;
+    if (!field) return;
+    const blockDisabledOpen = (event: Event): void => {
+      if (!interactionDisabledRef.current) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+    const openEvents = ["pointerdown", "mousedown", "click", "keydown"];
+    for (const eventName of openEvents) {
+      field.addEventListener(eventName, blockDisabledOpen, true);
+    }
+    return () => {
+      for (const eventName of openEvents) {
+        field.removeEventListener(eventName, blockDisabledOpen, true);
+      }
+    };
+  }, []);
 
   const handleOpenChange = (nextOpen: boolean): void => {
     if (!nextOpen) {


### PR DESCRIPTION
## Summary

- disabled または配信元候補が空の selector では、強制 click を受けても registry 再取得を開始しない共有境界を追加
- enabled 時の refresh 挙動を保ちつつ、disabled/no-source の回帰を focused unit と E2E で検証
- 変更内容を CHANGELOG に記録

## Validation

- shared selector focused unit: 5 passed
- 対象 Playwright E2E: 2 passed
- extension compile / check / build: passed
- extension unit: 1456 passed

Closes #4079