### PR TITLE
feat(analytics): 全動画のVPDランキングを追加 (#3781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: 公開活動ヒートマップから月・曜日の軸ラベルと余分な外枠グリッドを削除し、日別セルとアクセシブルな内訳・凡例を維持する（#3772）。
 - `feat(dashboard)`: 7 / 30 / 90 日の期間プリセットを追加し、選択日数を検証して全チャンネルの Analytics を再収集できるようにする（#3769）。
 - `feat(dashboard)`: `POST /api/refresh` と排他制御を追加し、画面のデータ更新ボタンから全チャンネルの再収集と read model の再取得を行えるようにする（#3768）。
+- `feat(analytics)`: 全 uploads をページ走査し Data API の累計 `viewCount` を 50 件ずつ取得して、UTC 公開日齢で正規化した VPD の上位・中間・下位群を JSON / text で確定する `yt-vpd-rank` を追加した（#3781）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ yt-thumbnail-text = "youtube_automation.entrypoints:yt_thumbnail_text"
 yt-title-duplicate-check = "youtube_automation.entrypoints:yt_title_duplicate_check"
 yt-traffic-trend = "youtube_automation.entrypoints:yt_traffic_trend"
 yt-video-analyze = "youtube_automation.entrypoints:yt_video_analyze"
+yt-vpd-rank = "youtube_automation.entrypoints:yt_vpd_rank"
 yt-vote-log = "youtube_automation.entrypoints:yt_vote_log"
 yt-wf-batch = "youtube_automation.entrypoints:yt_wf_batch"
 

--- a/src/youtube_automation/commands/analytics/vpd_rank.py
+++ b/src/youtube_automation/commands/analytics/vpd_rank.py
@@ -44,7 +44,8 @@ def _print_text(result: dict[str, object]) -> None:
         for item in group["items"]:
             print(
                 f"- {item['video_id']}  vpd={item['vpd']}  views={item['cumulative_views']}  "
-                f"days={item['days_since_publish']}  {item['title']}"
+                f"days={item['days_since_publish']}  duration={item['duration'] or 'undetermined'}  "
+                f"{item['title']}"
             )
 
 

--- a/src/youtube_automation/commands/analytics/vpd_rank.py
+++ b/src/youtube_automation/commands/analytics/vpd_rank.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""yt-vpd-rank: 全チャンネル動画の views-per-day 群を出力する。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Sequence
+from datetime import datetime
+
+from youtube_automation.commands.analytics.analytics_system import AnalyticsSystem
+from youtube_automation.core.errors import AuthError, AutomationError
+from youtube_automation.infrastructure.analytics.vpd_metrics import (
+    build_vpd_ranking,
+    collect_all_video_statistics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _load_ranking(*, min_age_days: int, top_count: int | None, now: datetime | None = None) -> dict[str, object]:
+    system = AnalyticsSystem()
+    if not system.authenticate():
+        raise AuthError("YouTube read-only 認証に失敗しました")
+    if system.collector is None:
+        raise AuthError("YouTube collector を初期化できませんでした")
+    videos = collect_all_video_statistics(system.collector)
+    return build_vpd_ranking(videos, now=now, min_age_days=min_age_days, top_count=top_count)
+
+
+def _print_text(result: dict[str, object]) -> None:
+    print(
+        f"VPD ranking: N={result['n']} K={result['k']} "
+        f"min_age_days={result['min_age_days']} excluded={result['excluded_count']}"
+    )
+    groups = result["groups"]
+    assert isinstance(groups, dict)
+    for name in ("top", "middle", "bottom"):
+        group = groups[name]
+        assert isinstance(group, dict)
+        print(f"\n{name.upper()} ({group['count']}) vpd={group['min_vpd']}..{group['max_vpd']}")
+        for item in group["items"]:
+            print(
+                f"- {item['video_id']}  vpd={item['vpd']}  views={item['cumulative_views']}  "
+                f"days={item['days_since_publish']}  {item['title']}"
+            )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="全動画の累計 views-per-day 上位・中間・下位群を確定")
+    parser.add_argument("--min-age-days", type=int, default=7, help="公開後の最低経過日数 (default: 7)")
+    parser.add_argument("--top-count", type=int, help="上位群・下位群それぞれの件数")
+    parser.add_argument("--text", action="store_true", help="人間向けテキスト出力")
+    args = parser.parse_args(argv)
+
+    try:
+        result = _load_ranking(min_age_days=args.min_age_days, top_count=args.top_count)
+        if args.text:
+            _print_text(result)
+        else:
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+    except AutomationError as error:
+        logger.error(str(error))
+        return 2
+    except Exception as error:
+        logger.exception("VPD ranking の作成に失敗しました: %s", error)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/youtube_automation/domains/analytics/mixins/video_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/video_analytics.py
@@ -62,6 +62,7 @@ class VideoAnalyticsMixin:
                             "video_id": video_id,
                             "title": video_detail.get("title", "Unknown"),
                             "published_at": video_detail.get("published_at"),
+                            "view_count": video_detail.get("view_count"),
                             "collection_type": self._classify_video_type(video_detail.get("title", "")),
                             "views": row[1],
                             "watch_time_minutes": row[2],
@@ -167,6 +168,7 @@ class VideoAnalyticsMixin:
                     snippet = item["snippet"]
                     content_details = item.get("contentDetails", {})
                     topic_details = item.get("topicDetails", {})
+                    statistics = item.get("statistics", {})
 
                     all_details[video_id] = {
                         "title": snippet["title"],
@@ -178,6 +180,7 @@ class VideoAnalyticsMixin:
                         "dimension": content_details.get("dimension", ""),
                         "caption": content_details.get("caption", "false"),
                         "topic_categories": topic_details.get("topicCategories", []),
+                        "view_count": statistics.get("viewCount"),
                     }
 
             return all_details
@@ -185,6 +188,10 @@ class VideoAnalyticsMixin:
         except YouTubeAPIError as e:
             logger.warning(f"YouTube API エラー（動画詳細取得）: {e}")
             return {}
+
+    def get_video_details(self, video_ids: List[str]) -> Dict:
+        """Data API の動画詳細を 50 件ずつ取得する公開境界。"""
+        return self._get_video_details(video_ids)
 
     def _classify_video_type(self, title: str) -> str:
         """動画タイプ分類（Complete Collection vs Individual Track）"""

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -145,6 +145,7 @@ yt_thumbnail_correlate = _make_entrypoint("youtube_automation.commands.thumbnail
 yt_thumbnail_text = _make_entrypoint("youtube_automation.commands.thumbnail.thumbnail_text")
 yt_title_duplicate_check = _make_entrypoint("youtube_automation.commands.metadata.title_duplicate_check")
 yt_video_analyze = _make_entrypoint("youtube_automation.commands.analytics.video_analyze")
+yt_vpd_rank = _make_entrypoint("youtube_automation.commands.analytics.vpd_rank")
 yt_vote_log = _make_entrypoint("youtube_automation.commands.collections.vote_log")
 yt_wf_batch = _make_entrypoint("youtube_automation.commands.uploads.wf_batch")
 yt_upload_auto = _make_entrypoint("youtube_automation.commands.uploads.youtube_auto_uploader")

--- a/src/youtube_automation/infrastructure/analytics/vpd_metrics.py
+++ b/src/youtube_automation/infrastructure/analytics/vpd_metrics.py
@@ -1,0 +1,137 @@
+"""全チャンネル動画の views-per-day ランキング構築。"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from fractions import Fraction
+from typing import Protocol
+
+from youtube_automation.core.errors import ValidationError
+
+
+class _VideoCollector(Protocol):
+    def get_all_channel_videos(self, refresh: bool = False) -> list[dict]: ...
+
+    def get_video_details(self, video_ids: list[str]) -> dict[str, dict]: ...
+
+
+def _parse_view_count(value: object, video_id: str) -> int:
+    if isinstance(value, bool):
+        raise ValidationError(f"videos.list statistics.viewCount が不正です: {video_id}")
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise ValidationError(f"videos.list statistics.viewCount が不正です: {video_id}") from error
+    if parsed < 0 or str(parsed) != str(value):
+        raise ValidationError(f"videos.list statistics.viewCount が不正です: {video_id}")
+    return parsed
+
+
+def collect_all_video_statistics(collector: _VideoCollector) -> list[dict[str, object]]:
+    """uploads playlist 全ページを起点に累計 viewCount を全件取得する。"""
+    uploads = collector.get_all_channel_videos(refresh=True)
+    video_ids = [video["video_id"] for video in uploads]
+    details: dict[str, dict] = {}
+    for start in range(0, len(video_ids), 50):
+        batch = video_ids[start : start + 50]
+        details.update(collector.get_video_details(batch))
+
+    result: list[dict[str, object]] = []
+    for video in uploads:
+        video_id = video["video_id"]
+        detail = details.get(video_id)
+        if not isinstance(detail, dict) or "view_count" not in detail:
+            raise ValidationError(f"videos.list statistics.viewCount がありません: {video_id}")
+        result.append(
+            {
+                "video_id": video_id,
+                "title": video["title"],
+                "published_at": video["published_at"],
+                "cumulative_views": _parse_view_count(detail["view_count"], video_id),
+            }
+        )
+    return result
+
+
+def _published_utc(value: object, video_id: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValidationError(f"published_at が不正です: {video_id}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValidationError(f"published_at が不正です: {video_id}") from error
+    if parsed.tzinfo is None:
+        raise ValidationError(f"published_at に timezone がありません: {video_id}")
+    return parsed.astimezone(timezone.utc)
+
+
+def _group(items: list[dict[str, object]]) -> dict[str, object]:
+    vpds = [float(item["vpd"]) for item in items]
+    return {
+        "count": len(items),
+        "min_vpd": min(vpds) if vpds else None,
+        "max_vpd": max(vpds) if vpds else None,
+        "items": items,
+    }
+
+
+def build_vpd_ranking(
+    videos: list[dict[str, object]],
+    *,
+    now: datetime | None = None,
+    min_age_days: int = 7,
+    top_count: int | None = None,
+) -> dict[str, object]:
+    """累計 views / UTC 公開日齢を計算し、上位・中間・下位へ分割する。"""
+    if min_age_days < 0:
+        raise ValidationError("min-age-days は 0 以上で指定してください")
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        raise ValidationError("now は timezone-aware datetime でなければなりません")
+    reference_date = reference.astimezone(timezone.utc).date()
+
+    ranked_with_ratio: list[tuple[Fraction, dict[str, object]]] = []
+    excluded_count = 0
+    for video in videos:
+        video_id = video.get("video_id")
+        if not isinstance(video_id, str) or not video_id:
+            raise ValidationError("video_id が不正です")
+        published = _published_utc(video.get("published_at"), video_id)
+        age_days = max(0, (reference_date - published.date()).days)
+        if age_days < min_age_days:
+            excluded_count += 1
+            continue
+        days_since_publish = max(1, age_days)
+        views = _parse_view_count(video.get("cumulative_views"), video_id)
+        ratio = Fraction(views, days_since_publish)
+        item = {
+            "video_id": video_id,
+            "title": video.get("title", ""),
+            "published_at": video["published_at"],
+            "cumulative_views": views,
+            "days_since_publish": days_since_publish,
+            "vpd": round(float(ratio), 6),
+        }
+        ranked_with_ratio.append((ratio, item))
+
+    ranked_with_ratio.sort(key=lambda pair: (-pair[0], str(pair[1]["video_id"])))
+    ranking = [item for _, item in ranked_with_ratio]
+    n = len(ranking)
+    if n < 2:
+        raise ValidationError("vpd の群分けには対象動画が 2 本以上必要です")
+
+    k = math.ceil(n / 4) if top_count is None else top_count
+    if k < 1 or k > n // 2:
+        raise ValidationError(f"top-count は 1 以上 {n // 2} 以下で指定してください")
+    top = ranking[:k]
+    middle = ranking[k : n - k]
+    bottom = ranking[n - k :]
+    return {
+        "n": n,
+        "k": k,
+        "min_age_days": min_age_days,
+        "excluded_count": excluded_count,
+        "ranking": ranking,
+        "groups": {"top": _group(top), "middle": _group(middle), "bottom": _group(bottom)},
+    }

--- a/src/youtube_automation/infrastructure/analytics/vpd_metrics.py
+++ b/src/youtube_automation/infrastructure/analytics/vpd_metrics.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 from typing import Protocol
 
 from youtube_automation.core.errors import ValidationError
+from youtube_automation.infrastructure.analytics.retention_timeline import parse_iso8601_duration
 
 
 class _VideoCollector(Protocol):
@@ -26,6 +27,18 @@ def _parse_view_count(value: object, video_id: str) -> int:
     if parsed < 0 or str(parsed) != str(value):
         raise ValidationError(f"videos.list statistics.viewCount が不正です: {video_id}")
     return parsed
+
+
+def _normalize_duration(value: object) -> str | None:
+    """YouTube の正の ISO 8601 動画尺だけを保持する。"""
+    if not isinstance(value, str):
+        return None
+    duration = value.strip()
+    try:
+        parse_iso8601_duration(duration)
+    except ValidationError:
+        return None
+    return duration
 
 
 def collect_all_video_statistics(collector: _VideoCollector) -> list[dict[str, object]]:
@@ -49,6 +62,7 @@ def collect_all_video_statistics(collector: _VideoCollector) -> list[dict[str, o
                 "title": video["title"],
                 "published_at": video["published_at"],
                 "cumulative_views": _parse_view_count(detail["view_count"], video_id),
+                "duration": _normalize_duration(detail.get("duration")),
             }
         )
     return result
@@ -110,6 +124,7 @@ def build_vpd_ranking(
             "title": video.get("title", ""),
             "published_at": video["published_at"],
             "cumulative_views": views,
+            "duration": _normalize_duration(video.get("duration")),
             "days_since_publish": days_since_publish,
             "vpd": round(float(ratio), 6),
         }

--- a/tests/commands/analytics/test_vpd_rank.py
+++ b/tests/commands/analytics/test_vpd_rank.py
@@ -15,12 +15,19 @@ from youtube_automation.infrastructure.analytics.vpd_metrics import (
 NOW = datetime(2026, 8, 13, 12, tzinfo=timezone.utc)
 
 
-def _video(video_id: str, published_at: str, views: object) -> dict[str, object]:
+def _video(
+    video_id: str,
+    published_at: str,
+    views: object,
+    *,
+    duration: object = "PT1M",
+) -> dict[str, object]:
     return {
         "video_id": video_id,
         "title": f"title-{video_id}",
         "published_at": published_at,
         "cumulative_views": views,
+        "duration": duration,
     }
 
 
@@ -43,7 +50,13 @@ class _Collector:
 
     def get_video_details(self, video_ids: list[str]) -> dict[str, dict[str, object]]:
         self.batches.append(video_ids)
-        return {video_id: {"view_count": str(index + 1)} for index, video_id in enumerate(video_ids)}
+        return {
+            video_id: {
+                "view_count": str(index + 1),
+                "duration": f"PT{int(video_id.removeprefix('v')) + 1}M",
+            }
+            for index, video_id in enumerate(video_ids)
+        }
 
 
 def test_collects_every_paginated_upload_and_batches_statistics_at_fifty() -> None:
@@ -55,6 +68,30 @@ def test_collects_every_paginated_upload_and_batches_statistics_at_fifty() -> No
     assert [len(batch) for batch in collector.batches] == [50, 1]
     assert [item["video_id"] for item in result] == collector.video_ids
     assert result[-1]["cumulative_views"] == 1
+    assert result[0]["duration"] == "PT1M"
+    assert result[49]["duration"] == "PT50M"
+    assert result[50]["duration"] == "PT51M"
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        {"view_count": "1"},
+        {"view_count": "1", "duration": None},
+        {"view_count": "1", "duration": ""},
+        {"view_count": "1", "duration": "not-a-duration"},
+        {"view_count": "1", "duration": "PT0S"},
+        {"view_count": "1", "duration": 60},
+    ],
+)
+def test_missing_or_invalid_duration_is_explicitly_undetermined(details: dict[str, object]) -> None:
+    collector = _Collector()
+    collector.video_ids = ["v00"]
+    collector.get_video_details = lambda _ids: {"v00": details}  # type: ignore[method-assign]
+
+    result = collect_all_video_statistics(collector)
+
+    assert result[0]["duration"] is None
 
 
 @pytest.mark.parametrize("details", [{}, {"v00": {}}, {"v00": {"view_count": "invalid"}}])
@@ -127,7 +164,10 @@ def test_top_count_override_and_empty_middle_group_are_supported() -> None:
 
 def test_json_and_text_render_the_same_ranking(monkeypatch, capsys) -> None:
     ranking = build_vpd_ranking(
-        [_video("a", "2026-01-01T00:00:00Z", 20), _video("b", "2026-01-01T00:00:00Z", 10)],
+        [
+            _video("a", "2026-01-01T00:00:00Z", 20, duration="PT2M"),
+            _video("b", "2026-01-01T00:00:00Z", 10, duration="invalid"),
+        ],
         now=NOW,
     )
     monkeypatch.setattr(cli, "_load_ranking", lambda **_kwargs: ranking)
@@ -138,6 +178,8 @@ def test_json_and_text_render_the_same_ranking(monkeypatch, capsys) -> None:
     text_output = capsys.readouterr().out
 
     assert json_output == ranking
+    assert [item["duration"] for item in ranking["ranking"]] == ["PT2M", None]
     for item in ranking["ranking"]:
         assert item["video_id"] in text_output
         assert str(item["vpd"]) in text_output
+        assert f"duration={item['duration'] or 'undetermined'}" in text_output

--- a/tests/commands/analytics/test_vpd_rank.py
+++ b/tests/commands/analytics/test_vpd_rank.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from youtube_automation.commands.analytics import vpd_rank as cli
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.infrastructure.analytics.vpd_metrics import (
+    build_vpd_ranking,
+    collect_all_video_statistics,
+)
+
+NOW = datetime(2026, 8, 13, 12, tzinfo=timezone.utc)
+
+
+def _video(video_id: str, published_at: str, views: object) -> dict[str, object]:
+    return {
+        "video_id": video_id,
+        "title": f"title-{video_id}",
+        "published_at": published_at,
+        "cumulative_views": views,
+    }
+
+
+class _Collector:
+    def __init__(self) -> None:
+        self.video_ids = [f"v{i:02d}" for i in range(51)]
+        self.pages_refreshed: list[bool] = []
+        self.batches: list[list[str]] = []
+
+    def get_all_channel_videos(self, refresh: bool = False) -> list[dict[str, str]]:
+        self.pages_refreshed.append(refresh)
+        return [
+            {
+                "video_id": video_id,
+                "title": f"title-{video_id}",
+                "published_at": "2026-07-01T00:00:00Z",
+            }
+            for video_id in self.video_ids
+        ]
+
+    def get_video_details(self, video_ids: list[str]) -> dict[str, dict[str, object]]:
+        self.batches.append(video_ids)
+        return {video_id: {"view_count": str(index + 1)} for index, video_id in enumerate(video_ids)}
+
+
+def test_collects_every_paginated_upload_and_batches_statistics_at_fifty() -> None:
+    collector = _Collector()
+
+    result = collect_all_video_statistics(collector)
+
+    assert collector.pages_refreshed == [True]
+    assert [len(batch) for batch in collector.batches] == [50, 1]
+    assert [item["video_id"] for item in result] == collector.video_ids
+    assert result[-1]["cumulative_views"] == 1
+
+
+@pytest.mark.parametrize("details", [{}, {"v00": {}}, {"v00": {"view_count": "invalid"}}])
+def test_missing_or_invalid_view_count_fails_closed(details: dict[str, object]) -> None:
+    collector = _Collector()
+    collector.video_ids = ["v00"]
+    collector.get_video_details = lambda _ids: details  # type: ignore[method-assign]
+
+    with pytest.raises(ValidationError, match="viewCount"):
+        collect_all_video_statistics(collector)
+
+
+def test_ranks_by_vpd_then_video_id_and_uses_utc_calendar_age() -> None:
+    result = build_vpd_ranking(
+        [
+            _video("b", "2026-08-12T23:59:00-05:00", 100),  # UTC 8/13: age 0 -> 1
+            _video("a", "2026-08-13T00:01:00+09:00", 100),  # UTC 8/12: age 1
+            _video("c", "2026-08-11T00:00:00Z", 100),
+            _video("d", "2026-08-09T00:00:00Z", 10),
+        ],
+        now=NOW,
+        min_age_days=0,
+    )
+
+    assert result["k"] == 1
+    assert [(item["video_id"], item["days_since_publish"]) for item in result["ranking"]] == [
+        ("a", 1),
+        ("b", 1),
+        ("c", 2),
+        ("d", 4),
+    ]
+
+
+def test_min_age_default_and_quartile_size_partition_the_population() -> None:
+    videos = [_video(f"v{i}", f"2026-07-{i + 1:02d}T00:00:00Z", i + 1) for i in range(7)]
+    videos.append(_video("recent", "2026-08-13T00:00:00Z", 100))
+
+    result = build_vpd_ranking(videos, now=NOW)
+
+    assert result["n"] == 7
+    assert result["k"] == 2
+    assert result["min_age_days"] == 7
+    assert result["excluded_count"] == 1
+    assert [result["groups"][name]["count"] for name in ("top", "middle", "bottom")] == [2, 3, 2]
+
+
+def test_fewer_than_two_eligible_videos_fails() -> None:
+    with pytest.raises(ValidationError, match="2 本以上"):
+        build_vpd_ranking([_video("v", "2026-01-01T00:00:00Z", 1)], now=NOW)
+
+
+@pytest.mark.parametrize("top_count", [0, 3])
+def test_top_count_must_keep_top_and_bottom_disjoint(top_count: int) -> None:
+    videos = [_video(f"v{i}", "2026-01-01T00:00:00Z", i) for i in range(4)]
+
+    with pytest.raises(ValidationError, match="top-count"):
+        build_vpd_ranking(videos, now=NOW, top_count=top_count)
+
+
+def test_top_count_override_and_empty_middle_group_are_supported() -> None:
+    result = build_vpd_ranking(
+        [_video("a", "2026-01-01T00:00:00Z", 2), _video("b", "2026-01-01T00:00:00Z", 1)],
+        now=NOW,
+        top_count=1,
+    )
+
+    assert result["k"] == 1
+    assert result["groups"]["middle"] == {"count": 0, "min_vpd": None, "max_vpd": None, "items": []}
+
+
+def test_json_and_text_render_the_same_ranking(monkeypatch, capsys) -> None:
+    ranking = build_vpd_ranking(
+        [_video("a", "2026-01-01T00:00:00Z", 20), _video("b", "2026-01-01T00:00:00Z", 10)],
+        now=NOW,
+    )
+    monkeypatch.setattr(cli, "_load_ranking", lambda **_kwargs: ranking)
+
+    assert cli.main([]) == 0
+    json_output = json.loads(capsys.readouterr().out)
+    assert cli.main(["--text"]) == 0
+    text_output = capsys.readouterr().out
+
+    assert json_output == ranking
+    for item in ranking["ranking"]:
+        assert item["video_id"] in text_output
+        assert str(item["vpd"]) in text_output

--- a/tests/domains/analytics/mixins/test_video_analytics.py
+++ b/tests/domains/analytics/mixins/test_video_analytics.py
@@ -61,6 +61,7 @@ class TestGetVideoAnalytics:
                     "topicDetails": {
                         "topicCategories": ["https://en.wikipedia.org/wiki/Music"],
                     },
+                    "statistics": {"viewCount": "54321"},
                 }
             ]
         }
@@ -70,6 +71,7 @@ class TestGetVideoAnalytics:
         assert len(result) == 1
         video = result[0]
         assert video["video_id"] == "VID_001"
+        assert video["view_count"] == "54321"
         assert video["views"] == 1000
         assert video["watch_time_minutes"] == 500
         assert video["average_view_duration"] == 300
@@ -187,6 +189,7 @@ class TestGetVideoDetails:
                     "topicDetails": {
                         "topicCategories": ["https://en.wikipedia.org/wiki/Music"],
                     },
+                    "statistics": {"viewCount": "12345"},
                 }
             ]
         }
@@ -197,3 +200,4 @@ class TestGetVideoDetails:
         assert result["VID_001"]["definition"] == "hd"
         assert result["VID_001"]["caption"] == "true"
         assert len(result["VID_001"]["topic_categories"]) == 1
+        assert result["VID_001"]["view_count"] == "12345"

--- a/tests/domains/youtube/test_video_listing.py
+++ b/tests/domains/youtube/test_video_listing.py
@@ -128,6 +128,22 @@ class _FakeVideos:
 
 
 class TestGetAllChannelVideosCache:
+    def test_fetches_more_than_fifty_uploads_across_every_page(self) -> None:
+        first_page = [_video_item(f"V{i:02d}", "2026-01-01T00:00:00Z") for i in range(50)]
+        playlist_items = _FakePlaylistItems(
+            pages=[
+                {"items": first_page, "nextPageToken": "1"},
+                {"items": [_video_item("V50", "2026-01-01T00:00:00Z")]},
+            ]
+        )
+        collector = _StubCollector(playlist_items)
+
+        videos = collector.get_all_channel_videos(refresh=True)
+
+        assert len(videos) == 51
+        assert videos[-1]["video_id"] == "V50"
+        assert playlist_items.call_count == 2
+
     def test_second_call_uses_cache(self) -> None:
         playlist_items = _FakePlaylistItems(pages=[{"items": [_video_item("V1", "2026-01-01T00:00:00Z")]}])
         collector = _StubCollector(playlist_items)

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -122,6 +122,7 @@ NON_BILLED_CLIS: dict[str, str] = {
     "yt-title-duplicate-check": "ローカルのタイトル照合のみ",
     "yt-traffic-trend": "収集済み analytics_data_*.json のローカル分析のみ",
     "yt-vote-log": "ローカルの投票ログ記録のみ",
+    "yt-vpd-rank": "YouTube Data API（無料枠）で全動画の累計再生回数を取得",
 }
 
 # --- 2 段目: skill → 対象 / 非対象 ---

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -83,6 +83,7 @@ EXPECTED_ENTRYPOINT_MODULES = {
     "yt-title-duplicate-check": "youtube_automation.commands.metadata.title_duplicate_check",
     "yt-traffic-trend": "youtube_automation.commands.analytics.traffic_trend",
     "yt-video-analyze": "youtube_automation.commands.analytics.video_analyze",
+    "yt-vpd-rank": "youtube_automation.commands.analytics.vpd_rank",
     "yt-vote-log": "youtube_automation.commands.collections.vote_log",
     "yt-wf-batch": "youtube_automation.commands.uploads.wf_batch",
     "yt-upload-auto": "youtube_automation.commands.uploads.youtube_auto_uploader",


### PR DESCRIPTION
## Summary

- uploads を全ページ取得し、videos.list を50件単位で照会して全動画の累計 viewCount と duration を同一snapshotへ永続化
- UTC の公開日齢で VPD を算出し、設定可能な最小日齢・上位件数に従って top / middle / bottom を決定的に分類
- JSON/text CLI、欠損・境界・tie・51動画ページングの回帰テスト、CLI登録契約、CHANGELOGを追加

## Validation

- focused duration evidence: 17 passed
- analytics suite: 368 passed
- related contracts: 152 passed
- ruff check / format: passed

Closes #3781
