### PR TITLE
fix(site): onboardingを公開導線から除外する (#4001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `perf(dev)`: takt `ci_verify` とworktreeのローカルtest入口をPR CI共通selectorへ切り替え、selected件数を表示しつつfail-safe変更では無選別full suiteを維持する（#4012）。
 - `perf(ci)`: PR のPython test jobを影響test selectorの安全なtarget配列へ切り替え、選別件数を記録しつつ、fail-safe planとmain pushでは無選別full suiteを維持する（#4011）。
 - `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
+- `fix(site)`: onboarding の直接表示と Markdown 生成を維持しつつ、公開 navigation・トップページ・検索・AI 出力・sitemap から除外して HTML に noindex を付与する（#4001）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。

--- a/docs/release-notes-deployment.md
+++ b/docs/release-notes-deployment.md
@@ -57,8 +57,9 @@ site を変更した pull request では、Cloudflare Pages の commit 固有 pr
 fork からの pull request には preview URL が作られないため、同一 repository の branch で確認する。
 
 - トップページと sidebar / tabs に「はじめる」「使う」「リリースノート」の3区分が表示される。
-- 次の7ページが preview URL 配下で表示される: `/onboarding/`、`/oauth-setup/`、`/chrome-extension-install-guide/`、`/features/`、`/workflow-cheatsheet/`、`/dashboard/`、`/channel-workspace-migration/`。
-- `/features/` から `/workflow-cheatsheet/`、`/onboarding/` と `/oauth-setup/` の相互リンクが preview 内の route を指す。
+- 公開 navigation とトップページには次の6ページだけが表示される: `/oauth-setup/`、`/chrome-extension-install-guide/`、`/features/`、`/workflow-cheatsheet/`、`/dashboard/`、`/channel-workspace-migration/`。
+- `/onboarding/` は直接 URL で表示でき、robots noindex を持つ一方、sidebar、トップページ、検索、AI 出力、sitemap には現れない。
+- `/features/` から `/workflow-cheatsheet/`、`/onboarding/` と `/oauth-setup/` の相互リンクは preview 内の route を指す。
 - `/onboarding/` の Python 版から `tayk` への移行リンクは、GitHub の `docs/migration/python-to-tayk.md` 原本へ fallback する。
 - `/audits/` route が生成されず、navigation と検索結果にも内部 audit が現れない。
 

--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -48,11 +48,7 @@ export default defineConfig({
     sidebar: [
       {
         label: "はじめる",
-        items: [
-          "/onboarding",
-          "/oauth-setup",
-          "/chrome-extension-install-guide",
-        ],
+        items: ["/oauth-setup", "/chrome-extension-install-guide"],
       },
       {
         label: "使う",

--- a/site/operator-doc-source.ts
+++ b/site/operator-doc-source.ts
@@ -31,6 +31,12 @@ export const operatorDocMap = [
 /** Internal marker allowing staged operator entries through release-only fields. */
 export const operatorDocReleaseField = Symbol("operator-doc-release-field");
 
+const onboardingDiscoveryMetadata = {
+  ai: { exclude: true },
+  noindex: true,
+  search: { exclude: true },
+} as const;
+
 const normalizedRepositoryPath = (path: string): string => {
   const normalized = posix.normalize(path.replaceAll("\\", "/"));
   if (
@@ -170,6 +176,12 @@ export const createOperatorDocSource = (options: {
         ? rewriteFeatureSkillLinks(rewritten)
         : rewritten;
     const { text, title } = extractMarkdownTitle(rendered);
+    const discoveryMetadata =
+      mapping.source === "ONBOARDING.md" ? onboardingDiscoveryMetadata : {};
+    const rawDiscoveryMetadata =
+      mapping.source === "ONBOARDING.md"
+        ? "ai:\n  exclude: true\nnoindex: true\nsearch:\n  exclude: true\nseo:\n  noindex: true\n"
+        : "";
     return {
       body: { format: "md", text },
       data: {
@@ -179,9 +191,10 @@ export const createOperatorDocSource = (options: {
         title,
         type: "doc",
         version: operatorDocReleaseField,
+        ...discoveryMetadata,
       },
       editUrl: `${GITHUB_BLOB_BASE}${mapping.source}`,
-      raw: `---\ntitle: ${JSON.stringify(title)}\ntype: doc\n---\n\n${text}`,
+      raw: `---\ntitle: ${JSON.stringify(title)}\ntype: doc\n${rawDiscoveryMetadata}---\n\n${text}`,
       ref: mapping.source,
       slug: mapping.route,
     };

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -20,11 +20,6 @@ const operatorSections = [
     label: "はじめる",
     pages: [
       {
-        description: "導入から最初のコレクション制作までの標準手順",
-        href: "/onboarding",
-        label: "セットアップ",
-      },
-      {
         description: "Google Cloud と YouTube API の設定・トラブルシューティング",
         href: "/oauth-setup",
         label: "OAuth",

--- a/site/tests/operator-doc-source.test.mjs
+++ b/site/tests/operator-doc-source.test.mjs
@@ -32,7 +32,7 @@ const createRepository = async (map = operatorDocMap) => {
   return repositoryRoot;
 };
 
-test("operator document map は公開対象7件だけを明示列挙する", () => {
+test("operator document map は生成対象7件だけを明示列挙する", () => {
   assert.deepEqual(
     operatorDocMap.map(({ source }) => source),
     expectedSources
@@ -57,9 +57,17 @@ test("source は build ごとに原本を読み、安定 route と doc type を�
   assert.equal(second.entries[0].data.title, "Second");
   assert.equal(first.entries[0].slug, operatorDocMap[0].route);
   assert.equal(first.entries[0].data.type, "doc");
+  assert.deepEqual(first.entries[0].data.ai, { exclude: true });
+  assert.deepEqual(first.entries[0].data.search, { exclude: true });
+  assert.equal(first.entries[0].data.noindex, true);
+  for (const entry of first.entries.slice(1)) {
+    assert.equal(entry.data.ai, undefined);
+    assert.equal(entry.data.search, undefined);
+    assert.equal(entry.data.noindex, undefined);
+  }
   assert.equal(
     first.entries[0].raw,
-    '---\ntitle: "First"\ntype: doc\n---\n\n## Details\n\nFirst body\n'
+    '---\ntitle: "First"\ntype: doc\nai:\n  exclude: true\nnoindex: true\nsearch:\n  exclude: true\nseo:\n  noindex: true\n---\n\n## Details\n\nFirst body\n'
   );
 });
 

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -18,11 +18,7 @@ const execFileAsync = promisify(execFile);
 const operatorSections = [
   {
     label: "はじめる",
-    routes: [
-      "/onboarding",
-      "/oauth-setup",
-      "/chrome-extension-install-guide",
-    ],
+    routes: ["/oauth-setup", "/chrome-extension-install-guide"],
     section: "getting-started",
   },
   {
@@ -194,7 +190,7 @@ const sectionByAttribute = (html, attribute, value) => {
 const hrefsWithin = (markup) =>
   [...markup.matchAll(/href="(\/[^"#?]*)"/g)].map((match) => match[1]);
 
-test("landing page は3区分を表示し、operator docs 7件へ1回ずつ到達できる", async () => {
+test("landing page は3区分を表示し、公開operator docs 6件だけへ1回ずつ到達できる", async () => {
   const html = await readIndex();
   const sectionLabels = [
     ["getting-started", "はじめる"],
@@ -214,6 +210,7 @@ test("landing page は3区分を表示し、operator docs 7件へ1回ずつ到�
     operatorRoutes.includes(href)
   );
   assert.deepEqual(operatorHrefs, operatorRoutes);
+  assert.doesNotMatch(operatorMarkup, /href="\/onboarding(?:\/|"|#)/);
 });
 
 test("全ページ共通 sidebar と tabs は operator 区分・release規模・exact route ownership を保つ", async () => {
@@ -245,10 +242,11 @@ test("全ページ共通 sidebar と tabs は operator 区分・release規模・
     for (const route of operatorRoutes) {
       assert.equal(hrefsWithin(sidebar).filter((href) => href === route).length, 1);
     }
+    assert.equal(hrefsWithin(sidebar).includes("/onboarding"), false);
   }
 });
 
-test("operator docs の7 routeを描画・検索し、内部linkとGitHub fallbackを保つ", async () => {
+test("onboarding は直接描画だけを維持し、公開operator docs 6件だけを検索へ載せる", async () => {
   const search = JSON.parse(
     await readFile(new URL("../dist/blume-search.json", import.meta.url), "utf8")
   );
@@ -260,8 +258,15 @@ test("operator docs の7 routeを描画・検索し、内部linkとGitHub fallba
     assert.equal(searchRoutes.filter((candidate) => candidate === route).length, 1);
   }
 
-  const features = await readOperatorDoc("/features");
   const onboarding = await readOperatorDoc("/onboarding");
+  assert.match(onboarding, /<article\b/);
+  assert.match(
+    onboarding,
+    /<meta(?=[^>]*name="robots")(?=[^>]*content="noindex")[^>]*>/i
+  );
+  assert.equal(searchRoutes.includes("/onboarding"), false);
+
+  const features = await readOperatorDoc("/features");
   const oauth = await readOperatorDoc("/oauth-setup");
   assert.match(features, /href="\/workflow-cheatsheet"/);
   assert.match(onboarding, /href="\/oauth-setup"/);
@@ -298,6 +303,41 @@ test("operator docs の7 route は原本の先頭見出しを唯一の H1 とし
     assert.deepEqual(headings, [expectedTitle]);
     if (route === "/onboarding") {
       assert.match(html, /<h2 id="1-このリポジトリは何か">/);
+    }
+  }
+});
+
+test("AI出力はonboardingだけを除外し、直接取得用Markdown生成は維持する", async () => {
+  const llms = await readFile(new URL("../dist/llms.txt", import.meta.url), "utf8");
+  const llmsFull = await readFile(new URL("../dist/llms-full.txt", import.meta.url), "utf8");
+
+  assert.doesNotMatch(llms, /\[Onboarding\]\(\/onboarding\)/i);
+  assert.doesNotMatch(llmsFull, /^# Onboarding$/mu);
+  assert.doesNotMatch(llmsFull, /## 1\. このリポジトリは何か/);
+  for (const route of operatorRoutes) {
+    assert.match(llms, new RegExp(route.replaceAll("/", "\\/")));
+    assert.match(llmsFull, new RegExp(`^Source: ${route}$`, "mu"));
+  }
+  for (const extension of ["md", "mdx"]) {
+    const markdown = await readFile(
+      new URL(`../dist/onboarding.${extension}`, import.meta.url),
+      "utf8"
+    );
+    assert.match(markdown, /このリポジトリは何か/);
+  }
+});
+
+test("sitemap が生成された場合だけ onboarding route を含めない", async () => {
+  const generatedPaths = await readdir(new URL("../dist/", import.meta.url), {
+    recursive: true,
+  });
+  const sitemapPaths = generatedPaths.filter((path) => /(?:^|\/)sitemap[^/]*\.xml$/u.test(path));
+
+  for (const path of sitemapPaths) {
+    const sitemap = await readFile(new URL(`../dist/${path}`, import.meta.url), "utf8");
+    assert.doesNotMatch(sitemap, /\/onboarding\/?(?:<|$)/);
+    for (const route of operatorRoutes) {
+      assert.match(sitemap, new RegExp(`${route}/?`));
     }
   }
 });


### PR DESCRIPTION
## Summary

- onboarding の直接HTML・Markdown・MDX生成と内部相互リンクを維持し、HTMLへ noindex を付与
- sidebar・landing・AI出力・検索・sitemapから onboarding だけを除外し、他6 operator routeを維持
- artifact tests、deployment docs、CHANGELOGを更新

## Validation

- frozen install: passed
- site check: 0 errors
- build: 69 pages
- site tests: 46/46 passed
- repo/site/skill/CHANGELOG contracts: 18 passed

Closes #4001