### PR TITLE
fix(site): onboardingを共有keyで保護する (#4002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `perf(dev)`: takt `ci_verify` とworktreeのローカルtest入口をPR CI共通selectorへ切り替え、selected件数を表示しつつfail-safe変更では無選別full suiteを維持する（#4012）。
 - `perf(ci)`: PR のPython test jobを影響test selectorの安全なtarget配列へ切り替え、選別件数を記録しつつ、fail-safe planとmain pushでは無選別full suiteを維持する（#4011）。
 - `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
+- `fix(site)`: production の onboarding exact 4 path を Pages Function の共有 key で fail-closed に保護し、明示 preview binding だけを bypass する runtime gate と運用契約を追加する（#4002）。
 - `fix(site)`: onboarding の直接表示と Markdown 生成を維持しつつ、公開 navigation・トップページ・検索・AI 出力・sitemap から除外して HTML に noindex を付与する（#4001）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。

--- a/docs/adr/0023-release-notes-site.md
+++ b/docs/adr/0023-release-notes-site.md
@@ -15,6 +15,7 @@ GitHub Release の本文だけでは、本体と Chrome 拡張を横断して更
 - lockfile を commit し、Nix の固定 Node.js / pnpm で `install --frozen-lockfile`、`check`、`test`、`build` を行う。
 - `site/.blume/` と `site/dist/` は再生成可能な成果物として git 管理しない。
 - Cloudflare Pages を配信境界とし、pull request は preview、`main` は production とする。品質検証 workflow と deploy workflow は分離する。
+- root `site/functions/_middleware.ts` を静的 asset の前段に置き、onboarding の exact 4 path だけを共有 key で保護する。runtime は明示 binding `SITE_ENVIRONMENT` の exact `preview` だけを bypass し、production・未設定・未知値は fail-closed とする。build-time system variable `CF_PAGES_BRANCH` は runtime 判定に使わない。
 - Python wheel / sdist は従来の Hatch allowlist を維持し、`site/` の source・依存・生成物を一切同梱しない。実 archive の配布境界を pytest で検証する。
 
 ## Consequences
@@ -22,6 +23,7 @@ GitHub Release の本文だけでは、本体と Chrome 拡張を横断して更
 - 公開ノートの追加時は Markdown 契約とサイト build の両方が CI gate になる。
 - サイト障害や Node dependency は Python CLI と下流チャンネルの install を壊さない。
 - build output を repository から直接配信せず、Cloudflare Pages が commit から再生成する。
+- Production の onboarding は URL 共有型の目隠しであり認証ではない。secret は Pages Dashboard に保持し、漏えい時は commit なしで rotate した後、deployment の retry または新規 deployment で反映する。
 
 ## Considered Options
 

--- a/docs/release-notes-deployment.md
+++ b/docs/release-notes-deployment.md
@@ -28,6 +28,30 @@ branch alias を生成する。fork から作成された pull request には pr
 の build 設定は Cloudflare 側に保持されるため、変更時はこの表と Cloudflare Pages project
 の両方を同じ値へ更新する。既存 project の名前、production URL、custom domain は変更しない。
 
+### onboarding の共有 key gate
+
+`/onboarding`、`/onboarding/`、`/onboarding.md`、`/onboarding.mdx` は root Pages Function が保護する。
+Cloudflare Dashboard の Pages project で **Settings → Variables and Secrets** を開き、Production と
+Preview の両 scope に次の binding を設定する。値を repository、`wrangler.jsonc`、build log に書かない。
+
+| Scope | `SITE_ENVIRONMENT`（plain text） | `ONBOARDING_KEY`（encrypted secret） |
+| --- | --- | --- |
+| Production | `production` | 十分に長いランダムな共有 key |
+| Preview | `preview` | Production と異なる preview 用 key |
+
+runtime の preview 判定は `SITE_ENVIRONMENT` の値が exact `preview` の場合だけであり、その場合は
+onboarding を key なしで表示する。`production`、binding 未設定、大小文字違い、未知値はすべて
+Production 相当として fail-closed になる。`CF_PAGES_BRANCH` は Pages の build-time system variable で、
+Function の runtime 環境判定には使わない。
+
+Production の共有 URL は `https://youtube-automation-release-notes.pages.dev/onboarding/?key=<key>` とする。
+これは認証ではなく、URL を知る人だけを通す目隠しである。URL は browser history、server log、
+screen capture、転送、外部 link の Referer から漏れる可能性があるため、必要な運営者だけへ安全な経路で共有し、
+公開 channel や issue / pull request へ貼らない。漏えいが疑われたら Dashboard で Production secret を新しい値へ
+rotate し、最新 Production deployment を retry するか新規 deployment を作成して binding を反映する。
+commit は不要だが、再 deployment 前の instance が新しい secret を読むとはみなさない。反映確認後に新 URL を共有し、
+旧 URL が `/` へ 302 redirect されることも確認する。
+
 ### repository workflow と Build watch paths
 
 `.github/workflows/site.yml` の `on.push.paths` / `on.pull_request.paths` は GitHub Actions の実行条件、
@@ -59,6 +83,7 @@ fork からの pull request には preview URL が作られないため、同一
 - トップページと sidebar / tabs に「はじめる」「使う」「リリースノート」の3区分が表示される。
 - 公開 navigation とトップページには次の6ページだけが表示される: `/oauth-setup/`、`/chrome-extension-install-guide/`、`/features/`、`/workflow-cheatsheet/`、`/dashboard/`、`/channel-workspace-migration/`。
 - `/onboarding/` は直接 URL で表示でき、robots noindex を持つ一方、sidebar、トップページ、検索、AI 出力、sitemap には現れない。
+- Preview の `/onboarding/` は `SITE_ENVIRONMENT=preview` により key なしで表示できる。
 - `/features/` から `/workflow-cheatsheet/`、`/onboarding/` と `/oauth-setup/` の相互リンクは preview 内の route を指す。
 - `/onboarding/` の Python 版から `tayk` への移行リンクは、GitHub の `docs/migration/python-to-tayk.md` 原本へ fallback する。
 - `/audits/` route が生成されず、navigation と検索結果にも内部 audit が現れない。

--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -1,0 +1,59 @@
+type SiteEnvironment = "preview" | "production";
+
+export interface OnboardingGateEnv {
+  readonly SITE_ENVIRONMENT?: SiteEnvironment;
+  readonly ONBOARDING_KEY?: string;
+}
+
+interface OnboardingGateContext {
+  readonly request: Request;
+  readonly env: OnboardingGateEnv;
+  next(): Promise<Response>;
+}
+
+const PROTECTED_PATHS: readonly string[] = [
+  "/onboarding",
+  "/onboarding/",
+  "/onboarding.md",
+  "/onboarding.mdx",
+];
+
+async function keysMatch(provided: string, expected: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [providedHash, expectedHash] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(provided)),
+    crypto.subtle.digest("SHA-256", encoder.encode(expected)),
+  ]);
+  const providedBytes = new Uint8Array(providedHash);
+  const expectedBytes = new Uint8Array(expectedHash);
+  let difference = 0;
+  for (let index = 0; index < providedBytes.length; index += 1) {
+    difference |= providedBytes[index] ^ expectedBytes[index];
+  }
+  return difference === 0;
+}
+
+export async function onRequest(context: OnboardingGateContext): Promise<Response> {
+  if (context.env.SITE_ENVIRONMENT === "preview") {
+    return context.next();
+  }
+
+  const url = new URL(context.request.url);
+  if (!PROTECTED_PATHS.includes(url.pathname)) {
+    return context.next();
+  }
+
+  const expectedKey = context.env.ONBOARDING_KEY;
+  const providedKey = url.searchParams.get("key");
+  if (
+    expectedKey !== undefined &&
+    expectedKey.length > 0 &&
+    providedKey !== null &&
+    providedKey.length > 0 &&
+    (await keysMatch(providedKey, expectedKey))
+  ) {
+    return context.next();
+  }
+
+  return Response.redirect(new URL("/", url.origin), 302);
+}

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "blume build",
-    "check": "blume check",
+    "check": "tsc --project tsconfig.functions.json && blume check",
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {

--- a/site/tests/onboarding-gate.test.mjs
+++ b/site/tests/onboarding-gate.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readFile } from "node:fs/promises";
+
+import { onRequest } from "../functions/_middleware.ts";
+
+const ORIGIN = "https://docs.example.test";
+const PROTECTED_PATHS = [
+  "/onboarding",
+  "/onboarding/",
+  "/onboarding.md",
+  "/onboarding.mdx",
+];
+const PUBLIC_OPERATOR_PATHS = [
+  "/oauth-setup/",
+  "/chrome-extension-install-guide/",
+  "/features/",
+  "/workflow-cheatsheet/",
+  "/dashboard/",
+  "/channel-workspace-migration/",
+];
+
+async function invoke({
+  path = "/onboarding/",
+  siteEnvironment = "production",
+  onboardingKey = "correct-key",
+} = {}) {
+  let nextCount = 0;
+  const nextResponse = new Response(`asset:${path}`, { status: 200 });
+  const env = {};
+  if (siteEnvironment !== null) env.SITE_ENVIRONMENT = siteEnvironment;
+  if (onboardingKey !== null) env.ONBOARDING_KEY = onboardingKey;
+
+  const response = await onRequest({
+    request: new Request(`${ORIGIN}${path}`),
+    env,
+    next: async () => {
+      nextCount += 1;
+      return nextResponse;
+    },
+  });
+  return { response, nextCount, nextResponse };
+}
+
+async function assertRedirect(result) {
+  assert.equal(result.nextCount, 0);
+  assert.equal(result.response.status, 302);
+  assert.equal(result.response.headers.get("location"), `${ORIGIN}/`);
+  assert.equal(await result.response.text(), "");
+}
+
+async function assertPassedThrough(result) {
+  assert.equal(result.nextCount, 1);
+  assert.equal(result.response, result.nextResponse);
+  assert.match(await result.response.text(), /^asset:/);
+}
+
+test("production は保護対象4パスだけを正しいkeyで後段へ渡す", async () => {
+  for (const path of PROTECTED_PATHS) {
+    await assertPassedThrough(await invoke({ path: `${path}?key=correct-key` }));
+  }
+});
+
+test("production は保護対象4パスの誤った・欠落・空keyを同一originのrootへredirectする", async () => {
+  for (const path of PROTECTED_PATHS) {
+    for (const suffix of ["", "?key=wrong-key", "?key="]) {
+      await assertRedirect(await invoke({ path: `${path}${suffix}` }));
+    }
+  }
+});
+
+test("production はsecretが欠落または空なら正しい候補keyでもfail closedになる", async () => {
+  for (const onboardingKey of [null, ""]) {
+    await assertRedirect(
+      await invoke({
+        path: "/onboarding/?key=correct-key&return=https://attacker.example/",
+        onboardingKey,
+      }),
+    );
+  }
+});
+
+test("環境が欠落・未知・productionなら保護し、exact previewだけをkeyなしで通す", async () => {
+  for (const siteEnvironment of [null, "staging", "Preview", "production"]) {
+    await assertRedirect(await invoke({ siteEnvironment }));
+  }
+  await assertPassedThrough(await invoke({ siteEnvironment: "preview" }));
+});
+
+test("preview はsecretの状態や保護対象pathに関係なく後段へ一度だけ渡す", async () => {
+  for (const path of PROTECTED_PATHS) {
+    await assertPassedThrough(
+      await invoke({ path, siteEnvironment: "preview", onboardingKey: null }),
+    );
+  }
+});
+
+test("公開operator 6 routeと大小文字・prefix・suffix境界は常に後段へ渡す", async () => {
+  const boundaries = [
+    "/Onboarding",
+    "/ONBOARDING.md",
+    "/onboarding.html",
+    "/onboarding/child",
+    "/onboarding-md",
+    "/onboarding.mdx/child",
+  ];
+  for (const path of [...PUBLIC_OPERATOR_PATHS, ...boundaries]) {
+    await assertPassedThrough(
+      await invoke({ path, siteEnvironment: null, onboardingKey: null }),
+    );
+  }
+});
+
+test("deploy文書とADRはruntime binding・secret rotation・CF_PAGES_BRANCH非依存を固定する", async () => {
+  const deployment = await readFile(
+    new URL("../../docs/release-notes-deployment.md", import.meta.url),
+    "utf8",
+  );
+  const adr = await readFile(
+    new URL("../../docs/adr/0023-release-notes-site.md", import.meta.url),
+    "utf8",
+  );
+
+  for (const contract of [deployment, adr]) {
+    assert.match(contract, /SITE_ENVIRONMENT/);
+    assert.match(contract, /CF_PAGES_BRANCH/);
+    assert.match(contract, /runtime[^\n]*(?:使わない|判定)/i);
+    assert.match(contract, /(?:retry|再 deployment|新規 deployment)/i);
+    assert.match(contract, /commit (?:は?不要|なし)/i);
+  }
+  assert.match(deployment, /ONBOARDING_KEY/);
+  assert.match(deployment, /Production と\nPreview の両 scope/);
+  assert.match(deployment, /(?:漏えい|漏れる)/);
+});

--- a/site/tsconfig.functions.json
+++ b/site/tsconfig.functions.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["functions/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- production と未設定・未知環境では onboarding のexact 4 pathsを共有keyでfail-closed保護し、exact previewのみbypass
- 他6 public routeと類似prefixを素通しし、不一致時はqueryを捨てて同一origin `/` へ302 redirect
- strict Functions typecheck、Node 24境界テスト、Dashboard bindings/Secret・共有・漏えい・rotation/redeploy運用、ADR、CHANGELOGを追加

## Validation

- Node 24 focused: 7/7 passed
- site check: 0 errors
- build: 69 pages
- site tests: 53/53 passed
- repo and CHANGELOG contracts: 14/14 passed

Closes #4002