### PR TITLE
feat(ci): 影響テスト選別器を追加する (#4010)

### DIFF
--- a/.github/scripts/select-affected-tests.py
+++ b/.github/scripts/select-affected-tests.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""変更 path から影響する pytest module の保守的な実行計画を作る。"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import json
+import sys
+from collections import defaultdict, deque
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+ALL = None
+SOURCE_PREFIX: Final = "src/youtube_automation/"
+TEST_PREFIX: Final = "tests/"
+FAIL_SAFE_EXACT: Final = frozenset(
+    {
+        "tests/conftest.py",
+        "pyproject.toml",
+        "uv.lock",
+        "flake.nix",
+        "flake.lock",
+        "src/youtube_automation/__init__.py",
+        ".github/scripts/select-affected-tests.py",
+    }
+)
+FAIL_SAFE_PREFIXES: Final = ("tests/helpers/", "tests/fixtures/")
+PATH_TEST_MAP: Final = (
+    (".github/workflows/", ("tests/repo/test_actions_parallel_workflows.py",)),
+    (
+        "docs/adr/",
+        (
+            "tests/repo/test_b6_integration_contract.py",
+            "tests/repo/test_site_repository_contract.py",
+        ),
+    ),
+    ("CHANGELOG.md", ("tests/repo/test_changelog_ci_contract.py",)),
+)
+
+
+def _is_test_module(path: Path) -> bool:
+    return path.suffix == ".py" and (path.name.startswith("test_") or path.name.endswith("_test.py"))
+
+
+def _module_name(relative: str) -> str | None:
+    if not relative.endswith(".py"):
+        return None
+    if relative.startswith("src/"):
+        relative = relative.removeprefix("src/")
+    elif relative.startswith("tests/"):
+        relative = relative.removeprefix("tests/")
+    else:
+        return None
+    parts = PurePosixPath(relative).with_suffix("").parts
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else None
+
+
+def _imports(path: Path, module: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported_module = node.module or ""
+            if node.level:
+                package = module if path.name == "__init__.py" else module.rpartition(".")[0]
+                imported_module = importlib.util.resolve_name(f"{'.' * node.level}{imported_module}", package)
+            if imported_module:
+                imported.add(imported_module)
+                imported.update(f"{imported_module}.{alias.name}" for alias in node.names)
+    return imported
+
+
+def _validate_path(repository: Path, changed: str) -> bool:
+    if not changed or "\\" in changed:
+        return False
+    pure = PurePosixPath(changed)
+    if pure.is_absolute() or ".." in pure.parts or pure.as_posix() != changed:
+        return False
+    return (repository / pure).is_file()
+
+
+def _mapped_tests(changed: str) -> tuple[str, ...] | None:
+    for pattern, targets in PATH_TEST_MAP:
+        if (pattern.endswith("/") and changed.startswith(pattern)) or changed == pattern:
+            return targets
+    return None
+
+
+def select_targets(repository: Path, changed_paths: list[str]) -> tuple[str, ...] | None:
+    """Return sorted test targets, or ``None`` for the ALL fail-safe plan."""
+    changed_paths = list(dict.fromkeys(changed_paths))
+    if not changed_paths:
+        return ALL
+    if any(path in FAIL_SAFE_EXACT or path.startswith(FAIL_SAFE_PREFIXES) for path in changed_paths):
+        return ALL
+
+    try:
+        source_paths = sorted((repository / "src/youtube_automation").rglob("*.py"))
+        test_paths = sorted((repository / "tests").rglob("*.py"))
+        module_paths = [*source_paths, *test_paths]
+        module_by_path = {
+            path.relative_to(repository).as_posix(): _module_name(path.relative_to(repository).as_posix())
+            for path in module_paths
+        }
+        importers: dict[str, set[str]] = defaultdict(set)
+        for path in module_paths:
+            relative = path.relative_to(repository).as_posix()
+            importer = module_by_path[relative]
+            if importer is None:
+                continue
+            for imported in _imports(path, importer):
+                importers[imported].add(importer)
+
+        path_by_module = {module: relative for relative, module in module_by_path.items() if module is not None}
+        selected: set[str] = set()
+        changed_modules: list[str] = []
+        for changed in changed_paths:
+            if not _validate_path(repository, changed):
+                return ALL
+            mapped = _mapped_tests(changed)
+            if mapped is not None:
+                if not all((repository / target).is_file() for target in mapped):
+                    return ALL
+                selected.update(mapped)
+                continue
+            path = repository / changed
+            if changed.startswith(TEST_PREFIX) and _is_test_module(path):
+                selected.add(changed)
+            elif changed.startswith(SOURCE_PREFIX) and changed.endswith(".py"):
+                module = module_by_path.get(changed)
+                if module is None:
+                    return ALL
+                changed_modules.append(module)
+                source_relative = PurePosixPath(changed.removeprefix(SOURCE_PREFIX))
+                mirror_name = (
+                    "test___init__.py" if source_relative.name == "__init__.py" else f"test_{source_relative.name}"
+                )
+                mirror = PurePosixPath("tests", source_relative.parent, mirror_name).as_posix()
+                if (repository / mirror).is_file():
+                    selected.add(mirror)
+            else:
+                return ALL
+
+        queue = deque(changed_modules)
+        visited = set(changed_modules)
+        while queue:
+            module = queue.popleft()
+            for importer in sorted(importers.get(module, ())):
+                if importer in visited:
+                    continue
+                visited.add(importer)
+                queue.append(importer)
+                relative = path_by_module.get(importer)
+                if relative and relative.startswith(TEST_PREFIX):
+                    path = repository / relative
+                    if _is_test_module(path):
+                        selected.add(relative)
+        if not selected:
+            return ALL
+        if not all((repository / target).is_file() for target in selected):
+            return ALL
+        return tuple(sorted(selected))
+    except (OSError, SyntaxError, UnicodeError, ValueError):
+        return ALL
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("changed_paths", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        changed = arguments.changed_paths.read_text(encoding="utf-8").splitlines()
+        plan = select_targets(Path.cwd(), changed)
+    except (OSError, UnicodeError):
+        plan = ALL
+    if arguments.format == "json":
+        payload = {
+            "mode": "all" if plan is ALL else "selected",
+            "targets": [] if plan is ALL else list(plan),
+        }
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    elif plan is ALL:
+        print("ALL")
+    else:
+        print(*plan, sep="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(analytics)`: VPD 上位・下位群を同一集計器で機械属性と目視 5 属性に分け、known denominator の 60% / 20pp 境界から相関上の勝ち・負け・保留を返す `yt-win-pattern` を追加した（#3782）。
 - `feat(analytics)`: 全 uploads をページ走査し Data API の累計 `viewCount` を 50 件ずつ取得して、UTC 公開日齢で正規化した VPD の上位・中間・下位群を JSON / text で確定する `yt-vpd-rank` を追加した（#3781）。
 - `feat(setup)`: `/setup --channel` Step 1 の質問を TTP 対象と branding 方針だけに絞り、転写要素と relationship は全要素 TTP 準拠の既定値として自動記録する。投稿頻度と動画尺の seed-only 仮説扱いは維持する（#3997）。
+- `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。
 - `fix(analytics)`: `yt-ad-coverage` が部分成功の収益 snapshot を受理し、動画別データが空なら unavailable 相当の JSON を exit 0 で返して分析パイプラインを継続する（#3910）。
 - `fix(automation-update)`: 追従後診断を `yt-doctor --json` の exact `channel_config.status` 判定へ揃え、doctor 全体の exit code 0 で config fail を見逃す手順を修正する（#3915）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,7 @@ uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 
 - **CI では `-n auto` を有効化済み**（`.github/workflows/ci.yml` の test ジョブ）
 - **外部 GitHub Actions は full commit SHA で固定**し、追跡する stable version を同じ `uses:` 行のコメントに残す。複数 workflow で同じ action を使う場合も SHA/version を統一し、`tests/repo/test_github_actions_pinning.py` で mutable ref・drift・未棚卸し action を拒否する
 - **CI の changed-path 分岐**: `.github/scripts/classify-ci-paths.sh` が PR と `main` push の差分を Python / packaging / Windows / ADR / 3 helper に分類する。branch protection の required check である `lint` / `test` job は path filter や job-level `if` で消さず、extension-only 変更では成功する軽量 step を返して Nix・uv・pytest を起動しない。空 diff は全 gate を有効化する fail-safe とし、分類変更時は `tests/repo/test_actions_parallel_workflows.py` の対応表も更新する
+- **影響テスト選別エンジン**: `.github/scripts/select-affected-tests.py <changed-paths-file>` は、1行1pathの変更一覧から production import の推移的な逆参照、鏡像 test、直接変更 test、repository契約の明示対応表を統合し、pytest targetを決定的に1行1件で返す。`--format json` でも同じplanを出力する。空入力、削除・rename旧path、未知/config/docs path、解析失敗、`tests/conftest.py`・helper・fixture・依存lock等のfail-safe pathでは `ALL` を返す。markerでは絞り込まない。この段階ではCIとローカルの既存実行経路は切り替えない
 - worker ごとの分離: `tests/conftest.py` が `CHANNEL_DIR` の tmp コピーを **worker プロセスごとに独立して** 作り直す（controller が自動設定した値を環境変数継承でそのまま共有しない）。ユーザーが明示的に `CHANNEL_DIR` を指定した場合は全 worker がその指定を尊重する
 - 注意: nix devShell / CLI を実 subprocess で叩く契約テストはホスト負荷に敏感で、混雑したマシンでは並列時に所要時間が大きく伸びることがある
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ REPO_CONTRACT_MODULES = frozenset(
         "test_no_google_auth_httplib2_direct_import.py",
         "test_pytest_lane_contract.py",
         "test_readme_dev_install_documentation.py",
+        "test_select_affected_tests.py",
         "test_research_persona_setup_handoff_contract.py",
         "test_scripts_layout.py",
         "test_skill_api_call_estimate_contract.py",

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github/scripts/select-affected-tests.py"
+
+
+def _load_selector():
+    spec = importlib.util.spec_from_file_location("select_affected_tests", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(repository: Path, relative: str, content: str = "") -> None:
+    path = repository / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _synthetic_repository(tmp_path: Path) -> Path:
+    repository = tmp_path / "repository"
+    _write(repository, "src/youtube_automation/__init__.py")
+    _write(repository, "src/youtube_automation/core/__init__.py")
+    _write(repository, "src/youtube_automation/core/leaf.py", "VALUE = 1\n")
+    _write(
+        repository,
+        "src/youtube_automation/core/middle.py",
+        "from youtube_automation.core.leaf import VALUE\n",
+    )
+    _write(repository, "src/youtube_automation/other.py", "VALUE = 2\n")
+    _write(
+        repository,
+        "tests/core/test_middle.py",
+        "from youtube_automation.core.middle import VALUE\n",
+    )
+    _write(repository, "tests/core/test_leaf.py", "def test_leaf():\n    assert True\n")
+    _write(
+        repository,
+        "tests/test_direct.py",
+        "from youtube_automation.core.leaf import VALUE\n",
+    )
+    _write(
+        repository,
+        "tests/test_other.py",
+        "from youtube_automation.other import VALUE\n",
+    )
+    _write(repository, "tests/repo/test_actions_parallel_workflows.py")
+    _write(repository, "tests/repo/test_changelog_ci_contract.py")
+    _write(repository, "tests/repo/test_b6_integration_contract.py")
+    _write(repository, "tests/repo/test_site_repository_contract.py")
+    _write(repository, ".github/workflows/ci.yml")
+    _write(repository, "docs/adr/0024-example.md")
+    _write(repository, "CHANGELOG.md")
+    return repository
+
+
+def test_source_change_selects_only_direct_and_transitive_importers(tmp_path: Path) -> None:
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+
+    result = selector.select_targets(repository, ["src/youtube_automation/core/leaf.py"])
+
+    assert result == (
+        "tests/core/test_leaf.py",
+        "tests/core/test_middle.py",
+        "tests/test_direct.py",
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_path",
+    [
+        "tests/conftest.py",
+        "tests/helpers/factory.py",
+        "tests/fixtures/config.json",
+        "pyproject.toml",
+        "uv.lock",
+        "flake.nix",
+        "flake.lock",
+        "src/youtube_automation/__init__.py",
+        ".github/scripts/select-affected-tests.py",
+    ],
+)
+def test_fail_safe_paths_select_all(tmp_path: Path, changed_path: str) -> None:
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+
+    assert selector.select_targets(repository, [changed_path]) is None
+
+
+def test_workflow_adr_changelog_and_direct_test_use_explicit_mapping(tmp_path: Path) -> None:
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+
+    assert selector.select_targets(repository, [".github/workflows/ci.yml"]) == (
+        "tests/repo/test_actions_parallel_workflows.py",
+    )
+    assert selector.select_targets(repository, ["docs/adr/0024-example.md"]) == (
+        "tests/repo/test_b6_integration_contract.py",
+        "tests/repo/test_site_repository_contract.py",
+    )
+    assert selector.select_targets(repository, ["CHANGELOG.md"]) == ("tests/repo/test_changelog_ci_contract.py",)
+    assert selector.select_targets(repository, ["tests/repo/test_actions_parallel_workflows.py"]) == (
+        "tests/repo/test_actions_parallel_workflows.py",
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_paths",
+    [
+        ["unknown/file.txt"],
+        ["/absolute/path.py"],
+        ["../outside.py"],
+        ["src\\youtube_automation\\core\\leaf.py"],
+        ["tests/deleted_test.py"],
+        ["tests/deleted_test.py", "tests/test_direct.py"],
+        [".github/workflows/deleted.yml"],
+        ["docs/adr/deleted.md"],
+    ],
+)
+def test_unknown_unsafe_deleted_and_rename_like_inputs_fail_safe(tmp_path: Path, changed_paths: list[str]) -> None:
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+
+    assert selector.select_targets(repository, changed_paths) is None
+
+
+def test_parse_failure_fails_safe_instead_of_returning_partial_plan(tmp_path: Path) -> None:
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+    _write(repository, "src/youtube_automation/core/broken.py", "def broken(:\n")
+
+    assert selector.select_targets(repository, ["src/youtube_automation/core/leaf.py"]) is None
+
+
+def _run_cli(changes: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments, str(changes)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_empty_input_prints_exact_all_and_json_has_same_plan(tmp_path: Path) -> None:
+    changes = tmp_path / "changes.txt"
+    changes.write_text("", encoding="utf-8")
+
+    text_result = _run_cli(changes)
+    json_result = _run_cli(changes, "--format", "json")
+
+    assert text_result.returncode == 0
+    assert text_result.stdout == "ALL\n"
+    assert text_result.stderr == ""
+    assert json_result.returncode == 0
+    assert json.loads(json_result.stdout) == {"mode": "all", "targets": []}
+
+
+def test_cli_output_is_deterministic_unique_and_existing_subset(tmp_path: Path) -> None:
+    changes = tmp_path / "changes.txt"
+    changes.write_text(
+        "src/youtube_automation/configuration/channel_target.py\n"
+        "src/youtube_automation/configuration/channel_target.py\n",
+        encoding="utf-8",
+    )
+
+    first = _run_cli(changes)
+    second = _run_cli(changes)
+    json_result = _run_cli(changes, "--format", "json")
+
+    assert first.returncode == second.returncode == json_result.returncode == 0
+    assert first.stdout == second.stdout
+    targets = first.stdout.splitlines()
+    assert targets == sorted(set(targets))
+    assert targets
+    all_tests = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "tests").rglob("*.py")
+        if path.name.startswith("test_") or path.name.endswith("_test.py")
+    }
+    assert set(targets) <= all_tests
+    assert all((REPO_ROOT / target).is_file() for target in targets)
+    assert json.loads(json_result.stdout) == {"mode": "selected", "targets": targets}
+
+
+def test_cli_missing_argument_is_usage_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "usage:" in result.stderr


### PR DESCRIPTION
## Summary

- production AST importの逆参照・鏡像・直接test・repository contract mappingを統合した決定的 affected-test selectorを追加
- 空入力、基盤/未知/config/docs、削除・rename旧path、unsafe path、解析失敗を `ALL` へfail-safe
- text/JSON同一plan、path subset、docs、CHANGELOG、実行契約テストを追加

## Validation

- focused and adjacent: 41 passed
- related repository contracts: 88 passed
- full pytest: 8690 passed, 1 skipped
- full Ruff/format and any-usage gate: passed

Closes #4010