### PR TITLE
feat(wf-new): Phase 2cの部分再開契約を追加する (#4095)

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -41,7 +41,7 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 3. **Suno collection Style boundary**: Suno チャンネルで `/suno` を呼ぶときは、対象 collection の絶対 path、確定企画、theme、書き込み先 `20-documentation/suno-patterns.yaml` を subagent へ渡す。collection 固有の `genre_line` / `exclude_styles` / `style_variants` / `vocal_gender` は同ファイルの root に書き、共有 `config/skills/suno.yaml` を書き換えない。root に無い値だけが channel config へ fallback する。`suno_preset` は推奨入力であり、不在だけを理由に停止しない。利用可能なら TTP 根拠として渡し、無ければ `/suno` が確定企画と制約から collection-local Style を設計する。`assets.music_prompts = true` は subagent 報告だけで更新せず、成果物、`yt-suno-verify`、semantic review をメインが検証した後に限る。
 4. **analytics input gate**: 入力モード判定、同日付 JSON、validator、stale 判定、自動更新、再検証は `/collection-ideate` の `references/freshness-rules.md::stale report の自動更新` に一元化する。`/wf-new` は判定ロジックを再定義せず、stale 判定や AskUserQuestion を先行実行しない。subagent が stale を検出した場合は、同 SSOT が返す自動更新シーケンスを同じ subagent 作業内で順次実行し、全呼び出し成功後に入力モード判定を先頭からやり直す。`yt-doctor` の `analytics_report` は予備確認にだけ使い、analytics mode の最終判定には使わない。
 5. **subagent state boundary**: 各フェーズの生成処理は Agent ツールで subagent へ一作業ずつ委譲する。subagent は `workflow-state.json` を書き込まず AskUserQuestion を実行しない。メインエージェントだけが承認、成果物検証、`assets` / `phase` / `updated_at` 更新を行う。
-6. **failure boundary**: subagent の失敗、期待成果物欠落、現在の phase との不整合時は state を更新しない。同じ未完了ステップから再実行できる状態で停止する。
+6. **failure boundary**: subagent の失敗、期待成果物欠落、現在の phase との不整合時は state を更新しない。同じ未完了ステップから再実行できる状態で停止する。Phase 2c の thumbnail / music だけは独立 branch とし、[`references/phase-2c-artifact-contract.md`](references/phase-2c-artifact-contract.md) の実成果物検証に成功した側だけを反映して、失敗側だけを再開する。
 7. **thumbnail full-mode gate**: `.claude/skills/thumbnail/config.default.yaml` と、存在する場合は `config/skills/thumbnail.yaml` を読み、deep-merge 後の `image_generation.auto_selection.enabled` / `mode` を Phase 2c より前に確定する。`enabled: true` かつ `mode: full` のときだけ Phase 2c のサムネイル AskUserQuestion をすべて省略する。mode 未設定は `selection_only` として扱い、従来の候補承認だけを省略する。full で生成・QA・自動選択に失敗した場合は state を更新せず `/thumbnail` の「full モード失敗時の手動切替」を表示して停止する。
 8. **企画選択 skip gate**: `load_config()` の `config.workflow.wf_new.skip_plan_selection` を Phase 1 より前に確定する。`true` かつ analytics mode / benchmark fallback mode のときだけ、`/collection-ideate` が返した推奨順 1 位を自動採用できる。minimal mode のテーマ / ジャンル / 雰囲気入力は省略せず、無人実行では `blocked` とする。
 9. **preselected manifest gate**: `--batch-id` / `--plan-id` を受け取った場合は直下の opt-in 契約を state mutation 前に通す。不正な manifest を通常の Phase 1 へ fallback させない。
@@ -292,6 +292,8 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 
 サムネイル候補生成、承認・確定、音楽素材生成を以下の 2 substep で順に進める。Suno チャンネルでは、メインが対象 collection と確定企画を固定し、`config/skills/suno.yaml` と利用可能な `data/video_analysis/<slug>/*.json` を fallback / 推奨入力として `/suno` へ渡す。subagent は共有 config を変更せず、その collection の `20-documentation/suno-patterns.yaml` に effective Style 系の root 値を保存する。`suno_preset` が無くても確定企画と制約から collection-local Style を設計して続行し、検証前に `assets.music_prompts = true` へ更新しない。
 
+各 branch の成果物検証、state 適用、partial failure、再開判定は、最初に [`Phase 2c 成果物・再開契約`](references/phase-2c-artifact-contract.md) を読み、その契約だけを正とする。この段では同時 dispatch を導入せず、既存の順次実行を維持する。
+
 ##### 2c-1. サムネイル候補生成
 
 このステップは採用済み企画プレビューの確定、またはプレビューが無い場合のサムネイル候補生成までを行う。候補の承認と確定は 2c-2 に一元化する。`mode: full` では承認ゲートではなく自動確定分岐として実行する。
@@ -325,7 +327,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 1. 企画選択時に承認済みの同じ画像なので、文字入り候補の生成・再選択・thumbnail の AskUserQuestion は行わない。`10-assets/thumbnail.jpg` を `/thumbnail-compare` で 320px 視認性検証し、署名・透かし・ロゴ・手指破綻の既存目視 QA を通す。失敗時は state を更新せず停止する
 2. QA 成功後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。archive の Hard Gate は既存契約どおり維持する
 3. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。`mode: full` は生成可否と textless 背景承認を質問せず既存の check 成功後に確定し、それ以外は既存どおり textless 候補だけをプレビュー・承認して `main.png/jpg` へ確定する。`false` なら textless 生成・承認を省略し、`share_thumbnail_as_main.py <collection-path>` を実行して `status: SHARED`、同一 SHA-256、`main.png` 不在を検証する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ `assets.thumbnail = true`、`updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
 
 以下の mode 別分岐は `status: MISSING` から既存 `/thumbnail` フォールバックへ進んだ場合だけ実行する。
 
@@ -334,7 +336,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 1. AskUserQuestion と `open` を実行せず、`uv run yt-thumbnail-auto-select <collection-path> --dry-run` が exit 0 であることを確認してから `uv run yt-thumbnail-auto-select <collection-path> --apply` を実行する。`10-assets/thumbnail.jpg` と `workflow-state.json::thumbnail_auto_selection.mode == "full"` を検証する
 2. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。生成可否と textless 背景承認は質問せず、`yt-thumbnail-check` が exit 0 かつ候補が存在するときだけ `10-assets/main.png/jpg` へ確定コピーする。`false` なら textless 委譲・生成・承認を再要求せず、`share_thumbnail_as_main.py <collection-path>` を実行し、`status: SHARED`、`thumbnail.jpg` と `main.jpg` の同一 SHA-256、`main.png` 不在を検証する
 3. `/thumbnail-compare` の 320px 視認性検証はスコープ外のまま省略せず、自動確定後に別途実行する。失敗しても不適格候補を強制採用せず、`/thumbnail` の「full モード失敗時の手動切替」を表示して state を更新せず停止する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証後だけ、`assets.thumbnail = true`、`updated_at` を更新して音楽素材生成へ進む
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新して、既存の順序どおり音楽素材生成へ進む
 
 **`selection_only` または auto-selection 無効**（従来フロー）:
 
@@ -364,14 +366,14 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
    - `thumbnail.jpg` と `main.png/jpg` を同一画像で代用しない。`main.png` を `thumbnail.jpg` にコピーする旧運用は禁止
    - QA が NG、再生成、または中断の場合は `/collection-ideate` または `/thumbnail` の該当生成ステップへ戻し、state を更新せず停止する
 
-4. `thumbnail.jpg` と `main.png/jpg` の確定を検証した後だけ、メインが `assets.thumbnail = true`、`updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
 
 5. **音楽 skill を順番に処理**:
    - Suno: 対象 collection、theme、確定企画、書き込み先 `20-documentation/suno-patterns.yaml` を指定して Agent ツールで `/suno <theme>` のプロンプト生成を委譲する。共有 `config/skills/suno.yaml` の書き換えを禁止し、collection root の Style 値と channel fallback を解決した後に `uv run yt-suno-verify <collection-path>` を通す。ボーカルでは root `vocal_gender` を `/suno-lyric` の語り手性別入力にも引き渡す
    - Lyria: 対象 collection と theme を指定して Agent ツールで `/lyria <theme>` のプロンプト設計だけを委譲する（Lyria 3 API 呼び出しは `/wf-next`）
-   - subagent には state 更新と AskUserQuestion を禁止する。メインが `20-documentation/suno-prompts.json` または Lyria 設計成果物の存在を検証し、成功時だけ `assets.music_prompts = true` と `updated_at` を更新する
+   - subagent には state 更新と AskUserQuestion を禁止する。メインが `20-documentation/suno-prompts.json` または Lyria 設計成果物を検証し、Phase 2c 成果物・再開契約へ music branch の結果として渡す
 
-音楽素材生成に失敗した場合はエラーを報告し、次に手動で呼ぶべき `/suno` または `/lyria` コマンドを表示して停止する。
+音楽素材生成または成果物検証に失敗した場合は、Phase 2c 成果物・再開契約に従って thumbnail の成功結果を保持し、次に呼ぶべき `/suno` または `/lyria` コマンドを表示して停止する。
 
 #### 2e. ループ動画生成
 

--- a/.claude/skills/wf-new/references/phase-2c-artifact-contract.md
+++ b/.claude/skills/wf-new/references/phase-2c-artifact-contract.md
@@ -1,0 +1,55 @@
+# Phase 2c 成果物・再開契約
+
+Phase 2c の thumbnail branch と music branch は、生成順序とは独立にこの契約で結果を確定する。各 branch の検証、state 適用、停止案内はメインエージェントが所有し、subagent は `workflow-state.json` を書き込まない。
+
+## Branch 検証
+
+subagent の完了報告は成功根拠にしない。メインエージェントが同じ固定済み collection の実成果物を読み、branch ごとに成功または失敗と理由を確定する。片方の検証失敗を、もう片方の検証結果へ伝播させない。
+
+### thumbnail
+
+- mode 別の承認または自動確定と既存 QA が完了している
+- `/thumbnail-compare` の 320px 視認性検証に合格している
+- `10-assets/thumbnail.jpg` が存在し、画像として読み取れる
+- `textless.enabled` が `true` の場合は、確定済みの `10-assets/main.png` または `10-assets/main.jpg` が存在し、既存 check に合格している
+- `textless.enabled` が `false` の場合は `share_thumbnail_as_main.py` の `status: SHARED`、`thumbnail.jpg` と `main.jpg` の同一 SHA-256、`main.png` 不在を確認している
+
+候補だけ、未承認の画像、空ファイル、symlink、QA 不合格、片方しかない確定成果物は失敗とする。
+
+### music
+
+Suno は次をすべて満たす場合だけ成功とする。
+
+- `20-documentation/suno-patterns.yaml` と `20-documentation/suno-prompts.json` が対象 collection に存在する
+- `uv run yt-suno-verify <collection-path>` が exit 0 になる
+- semantic review が成功する
+
+Lyria は対象 collection の `20-documentation/lyria-prompt.md` が存在し、Engine、Channel、Model、最終プロンプト、API 入力パラメータ、目標尺とセグメント数、品質チェックを持ち、固定済み theme と `music_engine: lyria` に整合する場合だけ成功とする。この Phase では Lyria API の音源生成を成功条件に含めない。
+
+## State 適用
+
+独立検証した2結果をメインエージェントだけが branch ごとに直列適用する。成功した branch の flag と `updated_at` だけを更新し、失敗 branch、既存の成功済み flag、`phase`、その他の state は変更しない。両 branch が成功するまで後続 phase へ進めない。
+
+| thumbnail | music | state mutation |
+|---|---|---|
+| 成功 | 成功 | `assets.thumbnail = true` と `assets.music_prompts = true` |
+| 失敗 | 成功 | `assets.music_prompts = true` だけ |
+| 成功 | 失敗 | `assets.thumbnail = true` だけ |
+| 失敗 | 失敗 | 変更しない |
+
+成功済み flag を `false` に戻さない。失敗 branch の flag を `true` にしない。state の読み取り・更新・再読み取りを一度に1 branchずつ行い、subagent の同時書き込みや一方の古い snapshot による上書きを許可しない。
+
+片側または両側が失敗した場合は、成功結果を適用した後に停止する。失敗した branch、実際の検証失敗理由、同じ collection での再開 action を表示する。
+
+## 再開判定
+
+Phase 2c の開始時は flag だけで完了を判断せず、flag と実成果物を再検証する。
+
+- flag が `true` で実成果物も検証成功: 検証成功済み branch は再生成・再承認しない
+- flag が `false` で実成果物が検証成功: subagent を再実行せず、State 適用へ進む
+- flag が `false` で実成果物が未完成または検証失敗: その branch だけを再実行する
+- flag が `true` なのに対応成果物が欠落・破損・不整合: 完了扱いせず fail-closed に停止し、正常な別 branch の state と成果物は変更しない
+
+thumbnail branch だけが未完了なら、`finalize_planning_preview.py` の決定結果に従って preview の品質検証・確定または `/thumbnail <theme>` から再開する。music branch だけが未完了なら、固定済み engine に従い `/suno <theme>` または `/lyria <theme>` から再開する。
+
+停止報告には collection path、失敗 branch、失敗理由、保持した成功 branch、次の action を含める。別 collection や別 theme へ切り替えず、同じ collection の未完了 branch だけを対象にする。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(wf-new)`: Phase 2c の thumbnail / music 成果物を独立検証し、片側失敗時も成功側の state を保持して失敗 branch だけを再開する契約を追加する（#4095）。
 - `feat(dashboard)`: 収集済み日次指標を返す `GET /api/trends` と、palette 非依存の色相別系列で全チャンネルの再生数推移を比較する折れ線グラフを追加する（#3776）。
 - `fix(dashboard)`: 公開活動ヒートマップの内訳をフロー外の浮動レイヤーにし、セル間のgapでは維持してグリッド退出時だけ閉じることで点滅とレイアウトシフトを防ぐ（#3774）。
 - `feat(dashboard)`: 公開活動ヒートマップの53週列を11px下限の可変正方形セルにし、狭幅時の領域内スクロールを保ちながら親コンテナ幅いっぱいに広げる（#3773）。

--- a/docs/workflow-cheatsheet.md
+++ b/docs/workflow-cheatsheet.md
@@ -42,6 +42,8 @@
 
 subagent が失敗した、期待成果物が無い、または現在の phase と整合しない場合、メインは state を更新しない。次の `/wf-new` / `/wf-next` は同じ未完了ステップから再開する。`skip_audio_approval` / `skip_upload_approval`、`skip_manual_mastering`、thumbnail 承認、playlist 初期化承認はメインが config と実ファイルを確認して処理する。廃止済みの `approval_gates.audio` / `approval_gates.upload` が残っている場合は `ConfigError` で停止する。
 
+例外として `/wf-new` Phase 2c の thumbnail / music は独立 branch である。メインは実成果物を branch ごとに検証し、成功した branch の `assets` flag だけを更新して保持する。片側が失敗した場合は、次回も成功側を再生成・再承認せず、失敗した branch だけを同じ collection で再開する。flag と成果物が不整合なら完了扱いせず停止する。Phase 2c 以外は従来どおり、失敗した作業について state を更新しない。
+
 ```
 Phase 1 ─ 企画 + 素材準備           /wf-new
    ├─ /collection-ideate            (analytics mode / benchmark fallback mode、または ttp_mode=false の minimal mode で 3 候補生成)

--- a/tests/repo/test_wf_new_phase_2c_artifact_contract.py
+++ b/tests/repo/test_wf_new_phase_2c_artifact_contract.py
@@ -1,0 +1,109 @@
+"""`/wf-new` Phase 2c の branch 単位成果物・再開契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "wf-new"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+CONTRACT_MD = SKILL_DIR / "references" / "phase-2c-artifact-contract.md"
+WORKFLOW_CHEATSHEET = REPO_ROOT / "docs" / "workflow-cheatsheet.md"
+
+
+def _section(markdown: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^##\s|\Z)",
+        markdown,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"`{heading}` セクションが見つかりません")
+    return match.group("body")
+
+
+def test_skill_dispatches_phase_2c_artifact_contract_before_result_handling() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    relative_reference = CONTRACT_MD.relative_to(SKILL_DIR).as_posix()
+
+    phase_2c = skill.index("#### 2c. サムネイル確定 + 音楽素材生成")
+    dispatch = skill.index(f"]({relative_reference})", phase_2c)
+    thumbnail_step = skill.index("##### 2c-1.", dispatch)
+
+    assert CONTRACT_MD.is_file()
+    assert phase_2c < dispatch < thumbnail_step
+
+
+def test_contract_requires_independent_real_artifact_validation() -> None:
+    contract = CONTRACT_MD.read_text(encoding="utf-8")
+    validation = _section(contract, "## Branch 検証")
+
+    for thumbnail_evidence in (
+        "`10-assets/thumbnail.jpg`",
+        "`10-assets/main.png` または `10-assets/main.jpg`",
+        "`/thumbnail-compare`",
+    ):
+        assert thumbnail_evidence in validation
+    for suno_evidence in (
+        "`20-documentation/suno-patterns.yaml`",
+        "`20-documentation/suno-prompts.json`",
+        "`uv run yt-suno-verify <collection-path>`",
+        "semantic review",
+    ):
+        assert suno_evidence in validation
+    assert "`20-documentation/lyria-prompt.md`" in validation
+    assert "subagent の完了報告" in validation
+    assert "成功根拠にしない" in validation
+
+
+def test_contract_commits_only_successful_branches_and_preserves_failures() -> None:
+    contract = CONTRACT_MD.read_text(encoding="utf-8")
+    result_application = _section(contract, "## State 適用")
+
+    expected_rows = (
+        "| 成功 | 成功 | `assets.thumbnail = true` と `assets.music_prompts = true` |",
+        "| 失敗 | 成功 | `assets.music_prompts = true` だけ |",
+        "| 成功 | 失敗 | `assets.thumbnail = true` だけ |",
+        "| 失敗 | 失敗 | 変更しない |",
+    )
+    for row in expected_rows:
+        assert row in result_application
+    assert "メインエージェントだけ" in result_application
+    assert "branch ごとに直列" in result_application
+    assert "成功済み flag を `false` に戻さない" in result_application
+    assert "失敗 branch の flag を `true` にしない" in result_application
+
+
+def test_contract_fails_closed_on_state_artifact_mismatch() -> None:
+    contract = CONTRACT_MD.read_text(encoding="utf-8")
+    resume = _section(contract, "## 再開判定")
+
+    assert "flag と実成果物を再検証" in resume
+    assert "flag が `true`" in resume
+    assert "欠落・破損" in resume
+    assert "不整合" in resume
+    assert "fail-closed" in resume
+    assert "正常な別 branch の state と成果物は変更しない" in resume
+
+
+def test_contract_resumes_only_the_failed_branch() -> None:
+    contract = CONTRACT_MD.read_text(encoding="utf-8")
+    resume = _section(contract, "## 再開判定")
+
+    assert "検証成功済み branch は再生成・再承認しない" in resume
+    assert "thumbnail branch だけ" in resume
+    assert "`/suno <theme>`" in resume
+    assert "`/lyria <theme>`" in resume
+    assert "同じ collection" in resume
+    assert "失敗理由" in resume
+
+
+def test_workflow_docs_distinguish_phase_2c_partial_commit_from_other_failures() -> None:
+    docs = WORKFLOW_CHEATSHEET.read_text(encoding="utf-8")
+
+    assert "Phase 2c" in docs
+    assert "成功した branch の `assets` flag だけ" in docs
+    assert "失敗した branch だけ" in docs
+    assert "Phase 2c 以外" in docs
+    assert "state を更新しない" in docs

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -226,7 +226,9 @@ EXPECTED_ACTIVE_ROUTES = (
     ),
 )
 
-MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path != "automation-update/SKILL.md")
+MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path != "automation-update/SKILL.md") | {
+    "wf-new/references/phase-2c-artifact-contract.md"
+}
 EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
     {
         ".claude/skills/analytics/SKILL.md",


### PR DESCRIPTION
## Summary
- `/wf-new` Phase 2c の thumbnail / music を、実成果物を個別に検証して成功側だけ状態へ反映する共通契約へ分離しました。
- 片側失敗時は成功側の成果物と flag を保持し、再開時は失敗側だけを実行する fail-closed な partial-state 規則を定義しました。
- repository contract、workflow docs、CHANGELOG を同期し、次段の同時 dispatch が利用する単一の正本を追加しました。

## Validation
- focused contract: 6 passed（TDD red 6 → green）
- adjacent/compatibility: 85 passed、追加修正後の関連8 passed
- wheel downstream: 1 passed
- `yt-skills lint`: 55 skills passed
- Ruff check/format、any gate、diff check: green
- full suite: 8686 passed / 1 skipped。変更関連3件は修正後green、残る2件は並行検証によるcollection-server port競合/停止timeoutで個別再検証済み

Closes #4095
