### PR TITLE
perf(dev): ローカルCIを影響テスト選別へ切り替える (#4012)

### DIFF
--- a/.github/scripts/run-affected-tests.py
+++ b/.github/scripts/run-affected-tests.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""worktree の変更pathへ共通selectorを適用してpytestを安全に実行する。"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+SELECTOR: Final = Path(".github/scripts/select-affected-tests.py")
+
+
+def _git(*arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _resolves_commit(reference: str) -> bool:
+    if not reference:
+        return False
+    return _git("rev-parse", "--verify", "--quiet", f"{reference}^{{commit}}", check=False).returncode == 0
+
+
+def _diff_base() -> str | None:
+    explicit = os.environ.get("PRE_PUSH_DIFF_BASE", "")
+    candidates = [explicit] if explicit else ["origin/main", "main"]
+    for reference in candidates:
+        if _resolves_commit(reference):
+            return _git("merge-base", reference, "HEAD").stdout.strip()
+    return None
+
+
+def _lines(result: subprocess.CompletedProcess[str]) -> list[str]:
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def changed_paths() -> list[str]:
+    paths: set[str] = set()
+    base = _diff_base()
+    if base is None:
+        return []
+    paths.update(_lines(_git("diff", "--name-only", f"{base}...HEAD")))
+    paths.update(_lines(_git("diff", "--name-only")))
+    paths.update(_lines(_git("diff", "--cached", "--name-only")))
+    paths.update(_lines(_git("ls-files", "--others", "--exclude-standard")))
+    return sorted(paths)
+
+
+def _load_plan(paths: list[str]) -> dict[str, object]:
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as changed_file:
+        changed_file.write("".join(f"{path}\n" for path in paths))
+        changed_file.flush()
+        result = subprocess.run(
+            [sys.executable, str(SELECTOR), "--format", "json", changed_file.name],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict) or set(payload) != {"mode", "targets"}:
+        raise ValueError("invalid affected-test plan keys")
+    return payload
+
+
+def _validated_targets(payload: dict[str, object]) -> list[str] | None:
+    mode = payload["mode"]
+    targets = payload["targets"]
+    if mode == "all" and targets == []:
+        return None
+    if mode != "selected" or not isinstance(targets, list) or not targets:
+        raise ValueError("invalid affected-test plan")
+    validated: list[str] = []
+    for target in targets:
+        if not isinstance(target, str):
+            raise ValueError("affected-test target must be a string")
+        pure = PurePosixPath(target)
+        if (
+            pure.is_absolute()
+            or ".." in pure.parts
+            or not target.startswith("tests/")
+            or pure.as_posix() != target
+            or not Path(target).is_file()
+        ):
+            raise ValueError(f"unsafe affected-test target: {target}")
+        validated.append(target)
+    if validated != sorted(set(validated)):
+        raise ValueError("affected-test targets must be sorted and unique")
+    return validated
+
+
+def _total_test_modules() -> int:
+    return sum(
+        1 for path in Path("tests").rglob("*.py") if path.name.startswith("test_") or path.name.endswith("_test.py")
+    )
+
+
+def main() -> int:
+    try:
+        targets = _validated_targets(_load_plan(changed_paths()))
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, ValueError) as error:
+        print(f"affected-test selection failed: {error}", file=sys.stderr)
+        return 2
+
+    total = _total_test_modules()
+    command = ["nix", "develop", "--command", "uv", "run", "pytest", "-n", "auto"]
+    if targets is None:
+        print(f"Full pytest suite: {total}/{total} targets")
+    else:
+        print(f"Selected pytest targets: {len(targets)}/{total}")
+        command.extend(["--", *targets])
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.takt/facets/instructions/yt-auto-ci-verify.md
+++ b/.takt/facets/instructions/yt-auto-ci-verify.md
@@ -3,10 +3,12 @@ Act as a read-only CI-equivalent delivery gate. Inspect `.github/workflows/ci.ym
 ```bash
 nix develop --command uv run ruff check .
 nix develop --command uv run ruff format --check .
-nix develop --command uv run pytest -n auto
+python .github/scripts/run-affected-tests.py
 bash .github/scripts/any-usage-gate.sh
 git diff --check
 ```
+
+The affected-test runner collects committed, staged, unstaged, and untracked worktree paths, applies the same selector as pull-request CI, reports selected/total target counts, and runs the exact full `pytest -n auto` suite when the plan is `ALL`. This dependency-based selection is the required CI contract, not permission to manually skip tests, narrow scope, add marker filters, or omit a target. The unselected surface remains protected by the exact full suite on CI's `main` push.
 
 Also run applicable packaging, frontend/extension, ADR, skill, and CHANGELOG checks selected by the CI path contract. Never edit files, skip tests, narrow scope, or reinterpret a failed command as success.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(analytics)`: VPD 上位・下位群を同一集計器で機械属性と目視 5 属性に分け、known denominator の 60% / 20pp 境界から相関上の勝ち・負け・保留を返す `yt-win-pattern` を追加した（#3782）。
 - `feat(analytics)`: 全 uploads をページ走査し Data API の累計 `viewCount` を 50 件ずつ取得して、UTC 公開日齢で正規化した VPD の上位・中間・下位群を JSON / text で確定する `yt-vpd-rank` を追加した（#3781）。
 - `feat(setup)`: `/setup --channel` Step 1 の質問を TTP 対象と branding 方針だけに絞り、転写要素と relationship は全要素 TTP 準拠の既定値として自動記録する。投稿頻度と動画尺の seed-only 仮説扱いは維持する（#3997）。
+- `perf(dev)`: takt `ci_verify` とworktreeのローカルtest入口をPR CI共通selectorへ切り替え、selected件数を表示しつつfail-safe変更では無選別full suiteを維持する（#4012）。
 - `perf(ci)`: PR のPython test jobを影響test selectorの安全なtarget配列へ切り替え、選別件数を記録しつつ、fail-safe planとmain pushでは無選別full suiteを維持する（#4011）。
 - `feat(ci)`: 変更pathから鏡像・推移的import・repository契約の影響pytest targetを算出し、不明・削除・基盤変更・解析失敗では全suiteへfail-safeする共通selectorを追加する（#4010）。
 - `fix(metadata)`: localization title の固定尺検出で `3時間の{scene_phrase}` と fr/es/it の `heure(s)` / `hora(s)` / `ora` / `ore` を認識し、Unicode 正規化形式を問わない単語境界を保ったまま実尺追従漏れを公開前診断で停止する（#3912）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,11 +49,12 @@ uv run pytest tests/ --ignore=tests/integration -n auto   # ユニットのみ�
 uv run pytest tests/ --ignore=tests/integration -n auto -m "not repo_contract and not slow"  # behavioral fast lane
 uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract  # docs / CI / packaging 契約
 uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 tool / process / 待機を含む lane
+python .github/scripts/run-affected-tests.py                              # worktree差分へCI共通selectorを適用
 ```
 
 - **既定は直列**（`addopts` には入れない）。単一ファイル・単一テストのデバッグ実行で worker 起動オーバーヘッドを毎回払わないため、また `-x` / `--pdb` など直列前提のオプションと干渉しないため。フルスイートを回すときに明示的に `-n auto` を付ける
 - **marker の境界**: `repo_contract` は production behavior を起動せず repository 内の docs / CI / workflow / packaging を読むテスト、`slow` は実 Nix・ffmpeg・socket TTL・外部 tool/process・意図的待機を含むテストに付ける。分類の単一 registry は `tests/conftest.py` にあり、module は basename、個別 node は basename と test 識別子で登録するため、`tests/` 以下の配置に依存しない。同じ basename の source module は登録できない。存在・CI無選別の回帰契約は `tests/repo/test_pytest_lane_contract.py` が担う。両方に該当するテストは両 marker を持つ
-- **fast lane の位置づけ**: behavioral fast lane は Python product code の短い red/green loop 用で、repository-only / slow test と `tests/integration/` を除く。変更した対象の直接テストは marker にかかわらず別途実行し、PR 前または CI では無選別の全スイートを必ず通す
+- **fast lane の位置づけ**: behavioral fast lane は Python product code の短い red/green loop 用で、repository-only / slow test と `tests/integration/` を除く。変更した対象の直接テストは marker にかかわらず別途実行する。PR CI と takt `ci_verify` は marker lane ではなく共通selectorを使い、選別漏れの最終担保はCIの `main` pushが実行する無選別full suiteとする
 
 変更種別ごとの最小入口:
 
@@ -68,7 +69,7 @@ uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 
 - **CI では `-n auto` を有効化済み**（`.github/workflows/ci.yml` の test ジョブ）
 - **外部 GitHub Actions は full commit SHA で固定**し、追跡する stable version を同じ `uses:` 行のコメントに残す。複数 workflow で同じ action を使う場合も SHA/version を統一し、`tests/repo/test_github_actions_pinning.py` で mutable ref・drift・未棚卸し action を拒否する
 - **CI の changed-path 分岐**: `.github/scripts/classify-ci-paths.sh` が PR と `main` push の差分を Python / packaging / Windows / ADR / 3 helper に分類する。branch protection の required check である `lint` / `test` job は path filter や job-level `if` で消さず、extension-only 変更では成功する軽量 step を返して Nix・uv・pytest を起動しない。空 diff は全 gate を有効化する fail-safe とし、分類変更時は `tests/repo/test_actions_parallel_workflows.py` の対応表も更新する
-- **影響テスト選別エンジン**: `.github/scripts/select-affected-tests.py <changed-paths-file>` は、1行1pathの変更一覧から production import の推移的な逆参照、鏡像 test、直接変更 test、repository契約の明示対応表を統合し、pytest targetを決定的に1行1件で返す。`--format json` でも同じplanを出力する。空入力、削除・rename旧path、未知/config/docs path、解析失敗、`tests/conftest.py`・helper・fixture・依存lock等のfail-safe pathでは `ALL` を返す。markerでは絞り込まない。PR の `test` job は selected plan の target だけを安全な shell array で実行し target数/全test module数を記録する。`ALL` と `main` push は exact `pytest -n auto` の全suiteを実行するため、選別漏れは merge 後に検出される。extension-only の required job lightweight success とローカルの全suite入口は維持する
+- **影響テスト選別エンジン**: `.github/scripts/select-affected-tests.py <changed-paths-file>` は、1行1pathの変更一覧から production import の推移的な逆参照、鏡像 test、直接変更 test、repository契約の明示対応表を統合し、pytest targetを決定的に1行1件で返す。`--format json` でも同じplanを出力する。空入力、削除・rename旧path、未知/config/docs path、解析失敗、`tests/conftest.py`・helper・fixture・依存lock等のfail-safe pathでは `ALL` を返す。markerでは絞り込まない。PR の `test` job とローカルの `python .github/scripts/run-affected-tests.py` はselected planを安全なargvで実行しtarget数/全test module数を記録する。local runnerはmerge-base以降のcommitに加えstaged・unstaged・untracked pathも統合する。`ALL` と `main` push はexact `pytest -n auto`の全suiteを実行するため、選別漏れはmerge後に検出される。extension-only の required job lightweight success は維持する
 - worker ごとの分離: `tests/conftest.py` が `CHANNEL_DIR` の tmp コピーを **worker プロセスごとに独立して** 作り直す（controller が自動設定した値を環境変数継承でそのまま共有しない）。ユーザーが明示的に `CHANNEL_DIR` を指定した場合は全 worker がその指定を尊重する
 - 注意: nix devShell / CLI を実 subprocess で叩く契約テストはホスト負荷に敏感で、混雑したマシンでは並列時に所要時間が大きく伸びることがある
 

--- a/tests/repo/test_pytest_lane_contract.py
+++ b/tests/repo/test_pytest_lane_contract.py
@@ -219,6 +219,15 @@ def test_development_documents_each_pytest_lane_command() -> None:
         assert expression in development
 
 
+def test_development_documents_local_selection_and_main_full_safety_net() -> None:
+    development = (ROOT / "docs/development.md").read_text(encoding="utf-8")
+
+    assert "python .github/scripts/run-affected-tests.py" in development
+    assert "main" in development
+    assert "選別漏れ" in development
+    assert "marker" in development
+
+
 def test_development_documents_position_independent_lane_registry() -> None:
     """REQ-3042-07b: development docs describe registry placement independence."""
     development = (ROOT / "docs/development.md").read_text(encoding="utf-8")

--- a/tests/repo/test_takt_workflow_contract.py
+++ b/tests/repo/test_takt_workflow_contract.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -13,6 +17,7 @@ TAKT = REPO_ROOT / ".takt"
 WORKFLOWS = TAKT / "workflows"
 STEPS = TAKT / "steps"
 FACETS = TAKT / "facets"
+LOCAL_TEST_GATE = REPO_ROOT / ".github/scripts/run-affected-tests.py"
 
 PUBLIC_WORKFLOWS = {
     "audit-unit-split",
@@ -217,6 +222,160 @@ def test_delivery_lanes_put_ci_before_final_gate_and_spillover() -> None:
         names = [str(step["name"]) for step in _steps(_workflow(name))]
         assert names.index("ci_verify") < names.index("final_gate") < names.index("spillover")
         assert _step(_workflow(name), "ci_verify").get("uses") == "ci-verify"
+
+
+def test_ci_verify_uses_affected_test_gate_without_weakening_other_baselines() -> None:
+    instruction = (FACETS / "instructions" / "yt-auto-ci-verify.md").read_text(encoding="utf-8")
+
+    assert "python .github/scripts/run-affected-tests.py" in instruction
+    assert "nix develop --command uv run pytest -n auto\n" not in instruction
+    for command in (
+        "nix develop --command uv run ruff check .",
+        "nix develop --command uv run ruff format --check .",
+        "bash .github/scripts/any-usage-gate.sh",
+        "git diff --check",
+    ):
+        assert command in instruction
+    assert "skip" in instruction
+    assert "scope" in instruction
+    assert "main" in instruction
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        env=os.environ
+        | {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_AUTHOR_NAME": "local-test-gate",
+            "GIT_AUTHOR_EMAIL": "local-test-gate@example.invalid",
+            "GIT_COMMITTER_NAME": "local-test-gate",
+            "GIT_COMMITTER_EMAIL": "local-test-gate@example.invalid",
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _local_gate_repository(tmp_path: Path) -> tuple[Path, str, Path]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "-q", "-b", "work")
+    for relative in (
+        ".github/scripts/select-affected-tests.py",
+        ".github/scripts/run-affected-tests.py",
+    ):
+        destination = repository / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative, destination)
+    source = repository / "src/youtube_automation/core/leaf.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    test = repository / "tests/core/test_leaf.py"
+    test.parent.mkdir(parents=True)
+    test.write_text(
+        "from youtube_automation.core.leaf import VALUE\n\ndef test_leaf(): assert VALUE == 1\n",
+        encoding="utf-8",
+    )
+    conftest = repository / "tests/conftest.py"
+    conftest.write_text("", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-q", "-m", "base")
+    base = _git(repository, "rev-parse", "HEAD")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    nix = fake_bin / "nix"
+    nix.write_text(
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$NIX_ARGS_LOG"\n',
+        encoding="utf-8",
+    )
+    nix.chmod(0o755)
+    return repository, base, fake_bin
+
+
+def _run_local_gate(repository: Path, base: str, fake_bin: Path, args_log: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(repository / ".github/scripts/run-affected-tests.py")],
+        cwd=repository,
+        env=os.environ
+        | {
+            "PRE_PUSH_DIFF_BASE": base,
+            "NIX_ARGS_LOG": str(args_log),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_local_ci_gate_runs_selected_target_and_reports_count(tmp_path: Path) -> None:
+    repository, base, fake_bin = _local_gate_repository(tmp_path)
+    source = repository / "src/youtube_automation/core/leaf.py"
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+    args_log = tmp_path / "selected-args.txt"
+
+    result = _run_local_gate(repository, base, fake_bin, args_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Selected pytest targets: 1/1" in result.stdout
+    assert args_log.read_text(encoding="utf-8").splitlines() == [
+        "develop",
+        "--command",
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        "auto",
+        "--",
+        "tests/core/test_leaf.py",
+    ]
+
+
+def test_local_ci_gate_runs_full_suite_for_fail_safe_change(tmp_path: Path) -> None:
+    repository, base, fake_bin = _local_gate_repository(tmp_path)
+    (repository / "tests/conftest.py").write_text("VALUE = 1\n", encoding="utf-8")
+    args_log = tmp_path / "all-args.txt"
+
+    result = _run_local_gate(repository, base, fake_bin, args_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Full pytest suite: 1/1 targets" in result.stdout
+    assert args_log.read_text(encoding="utf-8").splitlines() == [
+        "develop",
+        "--command",
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        "auto",
+    ]
+
+
+def test_local_ci_gate_runs_full_suite_when_diff_base_cannot_be_resolved(tmp_path: Path) -> None:
+    repository, _, fake_bin = _local_gate_repository(tmp_path)
+    source = repository / "src/youtube_automation/core/leaf.py"
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+    args_log = tmp_path / "missing-base-args.txt"
+
+    result = _run_local_gate(repository, "missing-base", fake_bin, args_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Full pytest suite: 1/1 targets" in result.stdout
+    assert args_log.read_text(encoding="utf-8").splitlines() == [
+        "develop",
+        "--command",
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        "auto",
+    ]
 
 
 def test_no_planning_step_can_bypass_required_delivery_gates() -> None:


### PR DESCRIPTION
## Summary
- local `ci_verify` が committed / staged / unstaged / untracked の変更を共通 affected-test selector へ渡す runner を追加しました。
- selected plan は検証済みargvで対象pytestだけを実行し、解析不能・未知差分・ALLでは exact full suiteへfail-safeします。
- main pushのfull safety netとmarker laneとの違いをdocs/契約へ同期し、全public workflowのprompt展開を検証しました。

## Validation
- focused workflow/runner contracts: 53 passed
- final local runner: Full 349/349, 8703 passed / 1 skipped
- Ruff check/format、any gate、diff check: green
- `takt --version`: 0.55.1
- `takt workflow doctor`: public workflow 7/7 OK
- `takt prompt`: delivery 4 workflowsはrunner exactly once、audit 3 workflowsはrunner 0
- `takt add` / `takt run` / queue mutation / workflow execution は未実行

Closes #4012
