### PR TITLE
fix(suno-helper): E2Eで拡張機能を有効化する (#4094)

### DIFF
--- a/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
+++ b/extensions/suno-helper/tests/e2e/overlay-drag.spec.ts
@@ -16,6 +16,7 @@ test("実ビルドした overlay は drag・最小化・automation selector 契�
     context = await chromium.launchPersistentContext(profile, {
       channel: "chromium",
       headless: false,
+      ignoreDefaultArgs: ["--disable-extensions"],
       args: [
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
@@ -28,6 +29,13 @@ test("実ビルドした overlay は drag・最小化・automation selector 契�
     let worker = context.serviceWorkers()[0];
     worker ??= await context.waitForEvent("serviceworker");
     expect(worker.url()).toContain("chrome-extension://");
+
+    const commandLinePage = await context.newPage();
+    await commandLinePage.goto("chrome://version/");
+    await expect(commandLinePage.locator("#command_line")).not.toContainText(
+      /(?:^|\s)--disable-extensions(?:\s|$)/
+    );
+    await commandLinePage.close();
 
     await context.route("https://suno.com/create", (route) =>
       route.fulfill({

--- a/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
+++ b/extensions/suno-helper/tests/e2e/server-source-refresh.spec.ts
@@ -98,6 +98,7 @@ test("最初の開操作では停止済み候補を提示せず、検出完了�
     context = await chromium.launchPersistentContext(profile, {
       channel: "chromium",
       headless: false,
+      ignoreDefaultArgs: ["--disable-extensions"],
       args: [
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,
@@ -188,6 +189,7 @@ test("配信元候補が空なら操作不能な専用表示を保つ", async ()
     context = await chromium.launchPersistentContext(profile, {
       channel: "chromium",
       headless: false,
+      ignoreDefaultArgs: ["--disable-extensions"],
       args: [
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,


### PR DESCRIPTION
## Summary
- Playwright persistent-context起動で、既定の単独 `--disable-extensions` だけを除外し、既存のunpacked extension load flagsを有効にしました。
- 3つすべてのE2E launcherへ同一契約を適用し、content scriptが実DOMへmountする既存検証を維持しました。
- `chrome://version` の実command lineを検査し、競合flagが再混入しない回帰assertionを追加しました。

## Validation
- TDD: 実argv競合検出でred → 実装後green
- full E2E: 17 passed
- unit: 73 files / 1456 tests passed
- compile / check / build: green
- test skip / only / timeout / selector緩和なし

Closes #4094
