### PR TITLE
fix(analytics): 動画別収益クエリの上限を指定する (#3771)

### DIFF
--- a/.claude/skills/analytics/references/collect.md
+++ b/.claude/skills/analytics/references/collect.md
@@ -157,6 +157,8 @@ subagent へは次を具体値で渡す:
 日別では `adImpressions / monetizedPlaybacks` の `ads_per_playback` も保存する。
 成果物では `revenue_analytics.daily_metrics` と `revenue_analytics.by_video` に保存し、
 各行の `rpm` は `estimated_revenue / views * 1000` で算出する。
+動画別収益は YouTube Analytics API の Top videos 契約に従い、`sort=-estimatedRevenue` と
+`maxResults=200` を組み合わせて取得する。
 
 日次・動画別の片方だけを取得できた場合は `revenue_analytics.status: "partial"` とし、
 成功したデータと失敗した dimension の `errors` を保存する。両方を取得できない場合は

--- a/.claude/skills/suno-helper/SKILL.md
+++ b/.claude/skills/suno-helper/SKILL.md
@@ -181,6 +181,7 @@ overlay / popup 上部の live region と root の `data-suno-phase` に進捗�
 |---|---|
 | `injecting` | Style/Lyrics を当該 entry に注入中 |
 | `generating` | Generate 押下後、Suno の生成完了待ち（最大 3 分） |
+| `waiting-generation` | Generate 投入後、生成完了の検知待ち |
 | `waiting-captcha` | CAPTCHA / bot check の解消待ち。多くは自動 verify 後に `generating` へ戻る |
 | `waiting-slot` | Suno のキュー上限に達した。空きスロット待ち（in-flight 変化があれば継続）|
 | `submitted` | 高速モード（内部値: queue）のみ。投入 ACK 済み・生成未完了（琥珀色）。全 entry 投入後の完了待ちで `done` へ遷移 |
@@ -188,6 +189,7 @@ overlay / popup 上部の live region と root の `data-suno-phase` に進捗�
 | `entry-failed` | 当該 entry は失敗としてスキップし、run 全体は次 entry へ継続 |
 | `adding-to-playlist` | 全 entry 完了、clip を一括 playlist 化中 |
 | `downloading` | playlist 追加完了後、全 clip を ZIP 一括ダウンロード中 |
+| `placing-archive` | browser download 完了後、server が ZIP を検証・配置中 |
 | `finished` | DL 通知成功。`placed > 0` なら部分配置も終端成功とし、status に配置数 / 期待数 / 欠損数と `missing_reasons` の内訳を表示 |
 | `stopped` | user が停止ボタンで中断 |
 | `error` | server reject を含む失敗（赤色で停止）。`placed = 0` は成功へ縮退せずこの phase |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(analytics)`: 動画別収益クエリへ必須の `maxResults=200` を付与して HTTP 400 を解消する（#3771）。
+
 - `feat(wf-new)`: Phase 2c の thumbnail と music を exactly-two Agent で同時 dispatch する（#4096）。
 
 - `feat(wf-new)`: Phase 2c の thumbnail / music 成果物を独立検証し、片側失敗時も成功側の state を保持して失敗 branch だけを再開する契約を追加する（#4095）。

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 _DAILY_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
 _VIDEO_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+_VIDEO_REVENUE_MAX_RESULTS = 200
 
 
 class RevenueAnalyticsMixin:
@@ -100,6 +101,7 @@ class RevenueAnalyticsMixin:
                     metrics=_VIDEO_REVENUE_METRICS,
                     dimensions="video",
                     sort="-estimatedRevenue",
+                    maxResults=_VIDEO_REVENUE_MAX_RESULTS,
                 ),
                 None,
             )

--- a/tests/domains/analytics/mixins/test_revenue_analytics.py
+++ b/tests/domains/analytics/mixins/test_revenue_analytics.py
@@ -59,6 +59,7 @@ def test_collects_daily_and_video_revenue_metrics():
     assert service.query.call_args_list[1].kwargs["metrics"] == (
         "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
     )
+    assert service.query.call_args_list[1].kwargs["maxResults"] == 200
 
 
 def test_returns_daily_metrics_as_partial_when_video_query_fails(caplog):

--- a/tests/test_analytics_cli_integration.py
+++ b/tests/test_analytics_cli_integration.py
@@ -230,9 +230,9 @@ def test_yt_analytics_collects_and_saves_subscribed_status_via_cli(cli_dependenc
     assert next(query for query in revenue_queries if query["dimensions"] == "day")["metrics"] == (
         "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
     )
-    assert next(query for query in revenue_queries if query["dimensions"] == "video")["metrics"] == (
-        "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
-    )
+    video_revenue_query = next(query for query in revenue_queries if query["dimensions"] == "video")
+    assert video_revenue_query["metrics"] == ("views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm")
+    assert video_revenue_query["maxResults"] == 200
     assert any(query.get("dimensions") == "subscribedStatus" for query in reports.queries)
 
 


### PR DESCRIPTION
## Summary
- 既にマージ済みの子issueが分離した日別/動画別収益と失敗隔離を維持し、親issueに残ったTop videos API契約を修正しました。
- `dimensions=video` と `sort=-estimatedRevenue` のqueryへ公式上限 `maxResults=200` を追加し、全チャンネルのHTTP 400を防ぎます。
- unit/CLI契約、analytics collect docs、CHANGELOGを同期しました。

## Validation
- TDD: missing `maxResults` red → focused 6 passed
- analytics proportional: 128 passed
- `yt-skills lint`: 55 skills passed
- Ruff check/format、any gate、diff check: green
- full suite: 8861 passed / 1 skipped。変更外parallel determinism 1件はisolated 1/1 green

Closes #3771
