### PR TITLE
fix(config): override専用キーの誤警告を防ぐ (#3795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(config)`: skill-config の未知キー検査で、`suno` と `videoup` が override や同梱 script から直接参照する正規のトップレベルキーを誤検知しないようにする（#3795）。
+
 - `fix(analytics)`: 動画別収益クエリへ必須の `maxResults=200` を付与して HTTP 400 を解消する（#3771）。
 
 - `feat(wf-new)`: Phase 2c の thumbnail と music を exactly-two Agent で同時 dispatch する（#4096）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -58,6 +58,14 @@ _DEPRECATED_OVERRIDE_KEYS: dict[str, tuple[tuple[str, ...], ...]] = {
     ),
 }
 
+# config.default.yaml との merge ではなく、load_channel_override() や skill 同梱
+# script から直接参照する正規のトップレベルキー。defaults に値を置くと「明示設定の
+# 有無」を区別できなくなるため、未知キー検査だけで skill ごとに宣言する。
+_KNOWN_OVERRIDE_ONLY_KEYS: dict[str, frozenset[str]] = {
+    "suno": frozenset({"tracklist_strategy", "vocal_gender"}),
+    "videoup": frozenset({"effect", "shrink"}),
+}
+
 
 def _collect_deprecated_override_keys(skill: str, override: dict[str, object]) -> list[str]:
     """override に含まれる deprecated キーを dotted path のリストで返す。"""
@@ -104,9 +112,10 @@ def _find_nested_key_paths(defaults: dict[str, object], target_key: str) -> list
 
 
 def _warn_unknown_top_level_override_keys(
-    override: dict[str, object], defaults: dict[str, object], override_path: Path
+    skill: str, override: dict[str, object], defaults: dict[str, object], override_path: Path
 ) -> None:
-    unknown_keys = sorted(override.keys() - defaults.keys())
+    known_keys = defaults.keys() | _KNOWN_OVERRIDE_ONLY_KEYS.get(skill, frozenset())
+    unknown_keys = sorted(override.keys() - known_keys)
     if not unknown_keys:
         return
     suggestions = [
@@ -295,7 +304,7 @@ def load_skill_config(
     if override_path is not None:
         override = _load_override(override_path)
         _warn_deprecated_override_keys(skill, override, override_path)
-        _warn_unknown_top_level_override_keys(override, defaults, override_path)
+        _warn_unknown_top_level_override_keys(skill, override, defaults, override_path)
         merged = _deep_merge(defaults, override)
     else:
         merged = defaults

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -89,6 +89,46 @@ def test_unknown_top_level_override_key_warns_but_still_merges(tmp_path, monkeyp
     assert cfg["auto_select"] == {"enabled": True}
 
 
+@pytest.mark.parametrize(
+    ("skill", "override"),
+    [
+        ("suno", {"vocal_gender": "female", "tracklist_strategy": "ttp"}),
+        ("videoup", {"effect": {"type": "particles"}, "shrink": {"enabled": True}}),
+    ],
+)
+def test_known_override_only_top_level_keys_do_not_warn(tmp_path, monkeypatch, skill, override):
+    """#3795: default 外でも正規の直接参照キーは未知キー扱いしない。"""
+    channel_dir = tmp_path / "ch"
+    override_dir = channel_dir / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / f"{skill}.yaml").write_text(yaml.safe_dump(override), encoding="utf-8")
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cfg = skill_config.load_skill_config(skill, use_cache=False)
+
+    assert not [warning for warning in caught if "未知のトップレベルキー" in str(warning.message)]
+    assert all(cfg[key] == value for key, value in override.items())
+
+
+def test_known_override_only_keys_do_not_hide_genuinely_unknown_key(tmp_path, monkeypatch):
+    """#3795: allowlist と同居する未知キーには従来どおり警告する。"""
+    channel_dir = tmp_path / "ch"
+    override_dir = channel_dir / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "suno.yaml").write_text(
+        yaml.safe_dump({"vocal_gender": "female", "tracks_per_pattern": 3}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with pytest.warns(UserWarning, match=r"suno\.yaml.*tracks_per_pattern") as caught:
+        skill_config.load_skill_config("suno", use_cache=False)
+
+    assert "vocal_gender" not in str(caught[0].message)
+
+
 def test_misplaced_top_level_override_key_warns_with_nested_path(tmp_path, monkeypatch):
     """#2558: nested schema と同名の誤配置には正しい dotted path を示す。"""
     channel_dir = tmp_path / "ch"


### PR DESCRIPTION
## Summary
- load_channel_override 経由で有効な skill 固有キーを既知キーとして扱う
- 真の未知キーに対する警告は維持する
- 回帰テストと CHANGELOG を追加する

Closes #3795