### PR TITLE
fix(dashboard): 不正phaseの影響と原因消失を防ぐ (#3810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(dashboard)`: latest live collection の選択では `created_at` だけを緩く読み、未選択 collection の不正 phase で timing 全体を落とさず、選択対象の検証失敗は原因メッセージ付きで表示する（#3810）。
+
 - `docs(skill-feedback)`: 還流 issue から発生チャンネル欄と掲載可否の確認を廃止し、起票前の確認項目を件数とタイトルだけに整理する（#3798）。
 
 - `fix(config)`: skill-config の未知キー検査で、`suno` と `videoup` が override や同梱 script から直接参照する正規のトップレベルキーを誤検知しないようにする（#3795）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -50,8 +50,12 @@ def _build_channel_workflow_timing(channel: Path) -> dict[str, object] | None:
             return {"status": "unavailable", "reason": "collection_missing", "collections": []}
         config = load_config_from_path(channel)
         return build_workflow_timing(channel, config.workflow.manual_baseline_minutes)
-    except (ConfigError, OSError, ValueError):
-        return None
+    except (ConfigError, OSError, ValueError) as exc:
+        return {
+            "status": "error",
+            "collections": [],
+            "error": {"code": "workflow_timing_failed", "message": str(exc)},
+        }
 
 
 class DashboardServer(ThreadingHTTPServer):

--- a/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_read_model.py
@@ -180,6 +180,17 @@ def _workflow_timing(value: object) -> dict[str, object]:
     timing = cast(dict[str, object], value)
     status = timing.get("status")
     collections = timing.get("collections")
+    if status == "error":
+        error = timing.get("error")
+        if (
+            isinstance(collections, list)
+            and not collections
+            and isinstance(error, dict)
+            and _text(error.get("code"))
+            and _text(error.get("message"))
+        ):
+            return timing
+        return _workflow_timing_error("workflow_timing_invalid", "error workflow timing の形式が不正です")
     if status not in {"ready", "unavailable", "in_progress"} or not isinstance(collections, list):
         return _workflow_timing_error("workflow_timing_invalid", "workflow timing の status/collections が不正です")
     if any(not isinstance(collection, dict) for collection in collections):

--- a/src/youtube_automation/infrastructure/analytics/workflow_timing.py
+++ b/src/youtube_automation/infrastructure/analytics/workflow_timing.py
@@ -27,8 +27,6 @@ class _TimingRunner(Protocol):
 
     def select_collection(self, root: Path, requested: str | None = None) -> Path: ...
 
-    def _collection_sort_key(self, collection: Path) -> tuple[str, str]: ...
-
     def summarize_time_savings(
         self,
         history: dict[str, object],
@@ -76,11 +74,22 @@ def _selected_collections(channel: Path, runner: _TimingRunner) -> list[tuple[st
 
     live_states = list((channel / "collections" / "live").glob("*/workflow-state.json"))
     if live_states:
-        latest_path = max((state.parent for state in live_states), key=runner._collection_sort_key)
+        latest_path = max((state.parent for state in live_states), key=_collection_sort_key)
         latest = runner.select_collection(channel, str(latest_path.resolve()))
         if active is None or latest != active:
             selected.append(("live", latest))
     return selected
+
+
+def _collection_sort_key(collection: Path) -> tuple[str, str]:
+    """完全検証せず created_at だけを読んで latest live を選ぶ。"""
+    state_path = collection / "workflow-state.json"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        state = None
+    created_at = state.get("created_at") if isinstance(state, dict) else None
+    return (created_at if isinstance(created_at, str) else "9999", collection.name)
 
 
 def _collection_history(history: dict[str, object], channel: Path, collection: Path) -> dict[str, object]:

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -397,7 +397,7 @@ def test_server_exposes_saved_publication_read_model(dashboard_server: str) -> N
     ("timing_state", "expected_status", "expected_code"),
     [
         ("unavailable", "unavailable", None),
-        ("error", "error", "workflow_timing_invalid"),
+        ("error", "error", "workflow_timing_failed"),
     ],
 )
 def test_server_keeps_analytics_payload_when_workflow_timing_is_unavailable_or_error(
@@ -458,6 +458,30 @@ def test_server_isolates_corrupt_history_from_healthy_channel(tmp_path: Path) ->
         assert healthy_overview["summary"]["views"] == 123
         assert healthy_detail["videos"][0]["title"] == "Midnight"
         assert healthy_detail["workflow_timing"]["status"] == "ready"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_server_exposes_workflow_timing_failure_reason(tmp_path: Path) -> None:
+    channel = _write_channel(tmp_path)
+    state_path = channel / "collections" / "live" / "latest" / "workflow-state.json"
+    state_path.write_text(json.dumps({"phase": "live", "created_at": "2026-07-20"}), encoding="utf-8")
+
+    server = create_server(port=0, channel_paths=[channel])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        _, overview = _json(f"{base_url}/api/channels")
+        _, detail = _json(f"{base_url}/api/channels/{overview['channels'][0]['id']}")
+
+        assert detail["workflow_timing"] == {
+            "status": "error",
+            "collections": [],
+            "error": {"code": "workflow_timing_failed", "message": "未対応 phase です: 'live'"},
+        }
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/tests/infrastructure/analytics/test_workflow_timing.py
+++ b/tests/infrastructure/analytics/test_workflow_timing.py
@@ -135,6 +135,20 @@ def test_build_workflow_timing_returns_canonical_step_and_total_metrics(tmp_path
     assert latest["totals"]["work_seconds"] == 20.0
 
 
+def test_build_workflow_timing_ignores_invalid_phase_in_unselected_live_collection(tmp_path: Path) -> None:
+    _write_collection(tmp_path, "live", "older", phase="live", created_at="2026-07-01")
+    _write_collection(tmp_path, "live", "latest", phase="complete", created_at="2026-08-01")
+    _write_history(
+        tmp_path,
+        [_attempt("collections/live/latest", "post-publish", "success", 15, 5)],
+    )
+
+    result = build_workflow_timing(tmp_path, {"post-publish": 2.0})
+
+    assert result["status"] == "ready"
+    assert [item["collection_id"] for item in result["collections"]] == ["latest"]
+
+
 @pytest.mark.parametrize(
     ("history", "baseline", "reason"),
     [


### PR DESCRIPTION
## Summary
- latest collection 選択時に無関係な不正 phase の影響を受けないようにする
- workflow timing 構築失敗の種類と原因メッセージを read model に保持する
- dashboard API で具体的な失敗原因を公開する回帰テストを追加する

Closes #3810