### PR TITLE
fix(config): workflowの未知キーを拒否する (#3811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(config)`: `workflow` 直下と `wf_new` / `wf_next` の未知キーを `ConfigError` で拒否し、効かない設定が silent ignore されないようにする（#3811）。
+
 - `fix(dashboard)`: latest live collection の選択では `created_at` だけを緩く読み、未選択 collection の不正 phase で timing 全体を落とさず、選択対象の検証失敗は原因メッセージ付きで表示する（#3810）。
 
 - `docs(skill-feedback)`: 還流 issue から発生チャンネル欄と掲載可否の確認を廃止し、起票前の確認項目を件数とタイトルだけに整理する（#3798）。

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -622,6 +622,19 @@ def _build_workflow(merged: dict) -> Workflow:
         wf = {}
     if not isinstance(wf, dict):
         raise ConfigError(f"workflow セクションは object でなければなりません（got {type(wf).__name__}）")
+    unexpected = set(wf) - {
+        "wf_new",
+        "wf_next",
+        "post-publish",
+        "scheduled_automation",
+        "manual_baseline_minutes",
+        # 移行期間の互換性契約として引き続き無視する旧キー。
+        "post_upload",
+        "short",
+    }
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ConfigError(f"workflow に未知のキーがあります: {names}")
 
     if "wf_new" in wf:
         wf_new_raw = wf["wf_new"]
@@ -629,6 +642,10 @@ def _build_workflow(merged: dict) -> Workflow:
         wf_new_raw = {}
     if not isinstance(wf_new_raw, dict):
         raise ConfigError(f"workflow.wf_new は object でなければなりません（got {type(wf_new_raw).__name__}）")
+    unexpected = set(wf_new_raw) - {"skip_plan_selection"}
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ConfigError(f"workflow.wf_new に未知のキーがあります: {names}")
 
     if "wf_next" in wf:
         wf_next_raw = wf["wf_next"]
@@ -636,6 +653,16 @@ def _build_workflow(merged: dict) -> Workflow:
         wf_next_raw = {}
     if not isinstance(wf_next_raw, dict):
         raise ConfigError(f"workflow.wf_next は object でなければなりません（got {type(wf_next_raw).__name__}）")
+
+    unexpected = set(wf_next_raw) - {
+        "skip_audio_approval",
+        "skip_upload_approval",
+        "skip_manual_mastering",
+        "approval_gates",
+    }
+    if unexpected:
+        names = ", ".join(sorted(unexpected))
+        raise ConfigError(f"workflow.wf_next に未知のキーがあります: {names}")
 
     if "approval_gates" in wf_next_raw:
         raise ConfigError("workflow.wf_next.approval_gates は廃止されました")

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -920,6 +920,27 @@ def test_workflow_wf_new_skip_plan_selection_explicit(tmp_path, monkeypatch):
     assert load_config().workflow.wf_new.skip_plan_selection is True
 
 
+@pytest.mark.parametrize(
+    ("workflow", "message"),
+    [
+        ({"wf_new": {"skip_loop_video": True}}, "workflow.wf_new に未知のキーがあります: skip_loop_video"),
+        (
+            {"wf_next": {"mix_phase": {"skip": True}, "thumbnail": {"mode": "reuse"}}},
+            "workflow.wf_next に未知のキーがあります: mix_phase, thumbnail",
+        ),
+        ({"steps": []}, "workflow に未知のキーがあります: steps"),
+    ],
+)
+def test_workflow_unknown_keys_are_rejected(tmp_path, monkeypatch, workflow, message):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": workflow}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match=message):
+        load_config()
+
+
 @pytest.mark.parametrize("invalid", ["false", "true", 1, 0, None, {}, []])
 def test_workflow_wf_new_skip_plan_selection_must_be_boolean(tmp_path, monkeypatch, invalid):
     """#2416: truthy/falsy coercion で企画選択を誤って省略しない."""

--- a/tests/repo/test_automation_schedule_runtime_contracts.py
+++ b/tests/repo/test_automation_schedule_runtime_contracts.py
@@ -287,7 +287,7 @@ def test_schedule_config_generate_show_dry_run_shape_and_exclusive_flags(
     schedule = _load("schedule_config.py")
     workflow_path = tmp_path / "config" / "channel" / "workflow.json"
     workflow_path.parent.mkdir(parents=True)
-    workflow_path.write_text('{"workflow":{"existing":"kept"}}\n', encoding="utf-8")
+    workflow_path.write_text('{"workflow":{"manual_baseline_minutes":{"wf-next":90}}}\n', encoding="utf-8")
     monkeypatch.setattr(schedule, "_workflow_path", lambda: workflow_path)
 
     args = _generate_args(
@@ -310,7 +310,7 @@ def test_schedule_config_generate_show_dry_run_shape_and_exclusive_flags(
     args.dry_run = False
     assert schedule.cmd_generate(args) == 0
     payload = json.loads(workflow_path.read_text(encoding="utf-8"))
-    assert payload["workflow"]["existing"] == "kept"
+    assert payload["workflow"]["manual_baseline_minutes"] == {"wf-next": 90}
     assert payload["workflow"]["scheduled_automation"]["cadence"] == ["mon", "fri"]
     assert payload["workflow"]["scheduled_automation"]["allow_external_publish"] is False
 


### PR DESCRIPTION
## Summary
- workflow 直下と wf_new / wf_next の許可キーを明示する
- 未知キーを安定した順序の ConfigError で拒否する
- 既存の移行互換キーと approval_gates 専用エラーは維持する

Closes #3811