### PR TITLE
fix(automation-update): 孤児skill設定を正しく検出する (#3812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(automation-update)`: skills sync の孤児 override 検出を multi-channel workspace まで広げ、skill directory ではなく `config.default.yaml` の有無で設定対応を判定する（#3812）。
+
 - `fix(config)`: `workflow` 直下と `wf_new` / `wf_next` の未知キーを `ConfigError` で拒否し、効かない設定が silent ignore されないようにする（#3811）。
 
 - `fix(dashboard)`: latest live collection の選択では `created_at` だけを緩く読み、未選択 collection の不正 phase で timing 全体を落とさず、選択対象の検証失敗は原因メッセージ付きで表示する（#3810）。

--- a/src/youtube_automation/commands/system/skills_sync/_ops.py
+++ b/src/youtube_automation/commands/system/skills_sync/_ops.py
@@ -55,23 +55,34 @@ def _prunable_orphan_names(entry_names: set[str], bundled: set[str]) -> set[str]
     return (entry_names - bundled) & _KNOWN_REMOVED_SKILL_NAMES
 
 
-def _orphan_skill_config_names(config_dir: Path, bundled: set[str]) -> list[str]:
-    """対応する同梱 skill がない channel override 名を返す。"""
+def _orphan_skill_config_names(config_dir: Path, configurable: set[str]) -> list[str]:
+    """対応する同梱 default config がない channel override 名を返す。"""
     if not config_dir.is_dir():
         return []
     configured = {
         entry.stem for entry in config_dir.iterdir() if entry.is_file() and entry.suffix in _SKILL_CONFIG_SUFFIXES
     }
-    return sorted(configured - bundled - _COMPATIBLE_SKILL_CONFIG_NAMES)
+    return sorted(configured - configurable - _COMPATIBLE_SKILL_CONFIG_NAMES)
 
 
-def _report_orphan_skill_configs(target_dir: Path, bundled: set[str]) -> None:
+def _report_orphan_skill_configs(target_dir: Path, source_dir: Path) -> None:
     """標準 skills 配置に対応する channel override の孤児を報告する。"""
     if not (target_dir.name == "skills" and target_dir.parent.name == ".claude"):
         return
-    config_dir = target_dir.parent.parent / "config" / "skills"
-    for name in _orphan_skill_config_names(config_dir, bundled):
-        print(f"  [warn] 対応する skill が同梱されていません: {name}")
+    configurable = {
+        skill_dir.name
+        for skill_dir in source_dir.iterdir()
+        if skill_dir.is_dir() and (skill_dir / "config.default.yaml").is_file()
+    }
+    workspace = target_dir.parent.parent
+    config_dirs = [workspace / "config" / "skills"]
+    channels_dir = workspace / "channels"
+    if channels_dir.is_dir():
+        config_dirs.extend(channel / "config" / "skills" for channel in channels_dir.iterdir() if channel.is_dir())
+    for config_dir in config_dirs:
+        for name in _orphan_skill_config_names(config_dir, configurable):
+            location = config_dir.relative_to(workspace).as_posix()
+            print(f"  [warn] 対応する skill が同梱されていません: {name} ({location})")
 
 
 def _ensure_target_parent(target: Path) -> None:

--- a/src/youtube_automation/commands/system/skills_sync/_sync.py
+++ b/src/youtube_automation/commands/system/skills_sync/_sync.py
@@ -187,7 +187,7 @@ def _sync_dir_asset(
             counts[key] = counts.get(key, 0) + val
 
     if args.asset == "skills":
-        _report_orphan_skill_configs(target_dir, bundled)
+        _report_orphan_skill_configs(target_dir, root)
 
     # skills 配布時は Codex CLI の探索パス `.agents/skills` も併設する。
     # 標準レイアウト (`.claude/skills`) でないときは対象外 (None) でスキップ。

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -35,6 +35,7 @@ def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     skills_dir.mkdir(parents=True)
     (skills_dir / "channel-research").mkdir()
     (skills_dir / "channel-research" / "SKILL.md").write_text("# research\n", encoding="utf-8")
+    (skills_dir / "channel-research" / "config.default.yaml").write_text("{}\n", encoding="utf-8")
     (skills_dir / "channel-direction").mkdir()
     (skills_dir / "channel-direction" / "SKILL.md").write_text("# direction\n", encoding="utf-8")
     (tmp_path / ".claude" / "settings.template.json").write_text(
@@ -331,6 +332,44 @@ def test_cmd_sync_skills_without_orphan_config_emits_no_orphan_report(
     assert rc == 0
     warning_lines = [line for line in capsys.readouterr().out.splitlines() if "同梱されていません" in line]
     assert warning_lines == []
+
+
+def test_cmd_sync_skills_reports_orphan_configs_in_multi_channel_workspace(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    target = workspace / ".claude" / "skills"
+    config = workspace / "channels" / "ambient" / "config" / "skills" / "missing.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force"])
+    assert args.func(args) == 0
+
+    assert "対応する skill が同梱されていません: missing" in capsys.readouterr().out
+
+
+def test_cmd_sync_skills_reports_config_for_skill_without_default_config(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill = fake_repo / ".claude" / "skills" / "wf-next"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("# wf-next\n", encoding="utf-8")
+    channel = tmp_path / "out"
+    config = channel / "config" / "skills" / "wf-next.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(channel / ".claude" / "skills"), "--force"])
+    assert args.func(args) == 0
+
+    assert "対応する skill が同梱されていません: wf-next" in capsys.readouterr().out
 
 
 def test_cmd_sync_warns_on_numbered_duplicates_in_target(


### PR DESCRIPTION
## Summary
- multi-channel workspace の各 config/skills を孤児検出対象にする
- config.default.yaml の有無で override 対応 skill を判定する
- 警告に workspace 相対の config directory を含める

Closes #3812