### PR TITLE
fix(config): 未知キー警告のAI経路を明確化する (#3813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(config)`: skill-config の未知キー警告で、コード参照が不確実でも SKILL.md 経由で AI が読む設計は有効になり得ることを区別する（#3813）。
+
 - `fix(automation-update)`: skills sync の孤児 override 検出を multi-channel workspace まで広げ、skill directory ではなく `config.default.yaml` の有無で設定対応を判定する（#3812）。
 
 - `fix(config)`: `workflow` 直下と `wf_new` / `wf_next` の未知キーを `ConfigError` で拒否し、効かない設定が silent ignore されないようにする（#3811）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -128,7 +128,8 @@ def _warn_unknown_top_level_override_keys(
         f"skill-config {override_path} の未知のトップレベルキーを検出しました: "
         f"{', '.join(unknown_keys)}。キー名または階層を確認してください。"
         f"{suggestion_message}"
-        "値は互換性のためマージされますが、利用側に参照されない可能性があります。",
+        "値は互換性のためマージされますが、コードからは参照されない可能性があります。"
+        "SKILL.md 経由で AI が読む設計であれば意図どおりです。",
         UserWarning,
         stacklevel=3,
     )

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -83,10 +83,14 @@ def test_unknown_top_level_override_key_warns_but_still_merges(tmp_path, monkeyp
     )
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
 
-    with pytest.warns(UserWarning, match=r"thumbnail\.yaml.*auto_select"):
+    with pytest.warns(UserWarning, match=r"thumbnail\.yaml.*auto_select") as caught:
         cfg = skill_config.load_skill_config("thumbnail", use_cache=False)
 
     assert cfg["auto_select"] == {"enabled": True}
+    message = str(caught[0].message)
+    assert "コードからは参照されない可能性があります" in message
+    assert "SKILL.md 経由で AI が読む設計であれば意図どおりです" in message
+    assert "利用側に参照されない可能性があります" not in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- 未知トップレベルキー警告でコード参照と AI 参照を区別する
- 利用されないと一律に疑わせる旧表現を削除する
- 警告文の新しい契約を回帰テストで固定する

Closes #3813