### PR TITLE
feat(config): 未知キー警告の確認済み抑止を追加する (#3814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(config)`: skill-config の `acknowledged_unknown_keys` に調査済みキーを明示すると、そのキーだけ未知トップレベル警告から除外できるようにする（#3814）。
+
 - `fix(config)`: skill-config の未知キー警告で、コード参照が不確実でも SKILL.md 経由で AI が読む設計は有効になり得ることを区別する（#3813）。
 
 - `fix(automation-update)`: skills sync の孤児 override 検出を multi-channel workspace まで広げ、skill directory ではなく `config.default.yaml` の有無で設定対応を判定する（#3812）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -36,6 +36,7 @@ from youtube_automation.core.errors import ConfigError
 _cache: dict[str, dict[str, Any]] = {}
 
 _THUMBNAIL_TEXT_RENDER_MODES = frozenset({"ai_burn_in", "deterministic"})
+_ACKNOWLEDGED_UNKNOWN_KEYS = "acknowledged_unknown_keys"
 
 # #1702: 基底 config から縮小済みのキー。channel override は引き続き deep-merge で
 # 有効（挙動は壊さない）だが、後続リリースでの物理削除に先立ち DeprecationWarning で
@@ -112,10 +113,14 @@ def _find_nested_key_paths(defaults: dict[str, object], target_key: str) -> list
 
 
 def _warn_unknown_top_level_override_keys(
-    skill: str, override: dict[str, object], defaults: dict[str, object], override_path: Path
+    skill: str,
+    override: dict[str, object],
+    defaults: dict[str, object],
+    override_path: Path,
+    acknowledged: set[str],
 ) -> None:
     known_keys = defaults.keys() | _KNOWN_OVERRIDE_ONLY_KEYS.get(skill, frozenset())
-    unknown_keys = sorted(override.keys() - known_keys)
+    unknown_keys = sorted(override.keys() - known_keys - acknowledged)
     if not unknown_keys:
         return
     suggestions = [
@@ -133,6 +138,18 @@ def _warn_unknown_top_level_override_keys(
         UserWarning,
         stacklevel=3,
     )
+
+
+def _split_acknowledged_unknown_keys(
+    override: dict[str, object], override_path: Path
+) -> tuple[dict[str, object], set[str]]:
+    raw = override.get(_ACKNOWLEDGED_UNKNOWN_KEYS, [])
+    if not isinstance(raw, list) or any(not isinstance(key, str) or not key for key in raw):
+        raise ConfigError(
+            f"skill-config {override_path} の acknowledged_unknown_keys は空でない string の array で指定してください"
+        )
+    cleaned = {key: value for key, value in override.items() if key != _ACKNOWLEDGED_UNKNOWN_KEYS}
+    return cleaned, set(raw)
 
 
 def _default_path(skill: str) -> Path:
@@ -303,9 +320,9 @@ def load_skill_config(
 
     override_path = _resolve_channel_override(skill, channel_dir)
     if override_path is not None:
-        override = _load_override(override_path)
+        override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
         _warn_deprecated_override_keys(skill, override, override_path)
-        _warn_unknown_top_level_override_keys(skill, override, defaults, override_path)
+        _warn_unknown_top_level_override_keys(skill, override, defaults, override_path, acknowledged)
         merged = _deep_merge(defaults, override)
     else:
         merged = defaults
@@ -326,7 +343,8 @@ def load_channel_override(skill: str) -> dict[str, Any]:
     path = _resolve_channel_override(skill)
     if path is None:
         return {}
-    return _load_override(path)
+    override, _ = _split_acknowledged_unknown_keys(_load_override(path), path)
+    return override
 
 
 THUMBNAIL_MODE_PARALLEL = "parallel"

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -93,6 +93,46 @@ def test_unknown_top_level_override_key_warns_but_still_merges(tmp_path, monkeyp
     assert "利用側に参照されない可能性があります" not in message
 
 
+def test_acknowledged_unknown_keys_suppress_only_named_warning(tmp_path, monkeypatch):
+    channel_dir = tmp_path / "ch"
+    override_dir = channel_dir / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "suno.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "acknowledged_unknown_keys": ["tracks_per_pattern"],
+                "tracks_per_pattern": 1,
+                "duration_policy": "legacy",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with pytest.warns(UserWarning, match=r"suno\.yaml.*duration_policy") as caught:
+        cfg = skill_config.load_skill_config("suno", use_cache=False)
+
+    assert "tracks_per_pattern" not in str(caught[0].message)
+    assert cfg["tracks_per_pattern"] == 1
+    assert "acknowledged_unknown_keys" not in cfg
+    assert "acknowledged_unknown_keys" not in skill_config.load_channel_override("suno")
+
+
+@pytest.mark.parametrize("value", ["tracks_per_pattern", [""], [1], {"tracks_per_pattern": True}])
+def test_acknowledged_unknown_keys_must_be_non_empty_string_list(tmp_path, monkeypatch, value):
+    channel_dir = tmp_path / "ch"
+    override_dir = channel_dir / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "suno.yaml").write_text(
+        yaml.safe_dump({"acknowledged_unknown_keys": value, "tracks_per_pattern": 1}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with pytest.raises(ConfigError, match="acknowledged_unknown_keys は空でない string の array"):
+        skill_config.load_skill_config("suno", use_cache=False)
+
+
 @pytest.mark.parametrize(
     ("skill", "override"),
     [


### PR DESCRIPTION
## Summary
- acknowledged_unknown_keys で確認済みの未知キーだけ警告を抑止する
- メタデータを consumer 設定から除外する
- 不正なメタデータ shape を ConfigError で拒否する

Closes #3814