### PR TITLE
fix(thumbnail): Codex構図ルールの非推奨化を防ぐ (#3913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(thumbnail)`: Codex provider が prompt へ決定的に注入する `composition_rules` は deprecated 扱いせず、他の移行対象には Codex 固有の移行先を案内する（#3913）。
+
 - `fix(thumbnail)`: auto-selection の既定 aspect tolerance を Gemini の 1K / 2K 出力における 64px 丸めを吸収する 0.06 へ広げる（#3867）。
 
 - `feat(config)`: skill-config の `acknowledged_unknown_keys` に調査済みキーを明示すると、そのキーだけ未知トップレベル警告から除外できるようにする（#3814）。

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -68,7 +68,9 @@ _KNOWN_OVERRIDE_ONLY_KEYS: dict[str, frozenset[str]] = {
 }
 
 
-def _collect_deprecated_override_keys(skill: str, override: dict[str, object]) -> list[str]:
+def _collect_deprecated_override_keys(
+    skill: str, override: dict[str, object], *, codex_provider: bool = False
+) -> list[str]:
     """override に含まれる deprecated キーを dotted path のリストで返す。"""
     found: list[str] = []
     for key_path in _DEPRECATED_OVERRIDE_KEYS.get(skill, ()):
@@ -78,20 +80,33 @@ def _collect_deprecated_override_keys(skill: str, override: dict[str, object]) -
                 break
             node = node[key]
         else:
-            found.append(".".join(key_path))
+            dotted_path = ".".join(key_path)
+            if not (codex_provider and dotted_path.startswith("image_generation.gemini.composition_rules.")):
+                found.append(dotted_path)
     return found
 
 
-def _warn_deprecated_override_keys(skill: str, override: dict[str, object], override_path: Path) -> None:
-    deprecated_keys = _collect_deprecated_override_keys(skill, override)
+def _warn_deprecated_override_keys(
+    skill: str,
+    override: dict[str, object],
+    override_path: Path,
+    merged: dict[str, object],
+) -> None:
+    image_generation = merged.get("image_generation")
+    codex_provider = isinstance(image_generation, dict) and image_generation.get("provider") == "codex"
+    deprecated_keys = _collect_deprecated_override_keys(skill, override, codex_provider=codex_provider)
     if not deprecated_keys:
         return
+    migration_target = (
+        "image_generation.codex.default_prompt_template または single_step の opt-in clause"
+        if codex_provider
+        else "diff_prompt_template / thumbnail_text.text_overlay_prompt の本文"
+    )
     warnings.warn(
         f"skill-config {override_path} の deprecated キーを検出しました: "
         f"{', '.join(deprecated_keys)}。これらは基底 config から縮小済みで、"
         "後続リリースで削除予定です（現時点では従来どおり deep-merge されます）。"
-        "意図は diff_prompt_template / thumbnail_text.text_overlay_prompt の本文へ"
-        "移行してください (#1702)。",
+        f"意図は {migration_target} へ移行してください (#1702)。",
         DeprecationWarning,
         stacklevel=3,
     )
@@ -321,9 +336,9 @@ def load_skill_config(
     override_path = _resolve_channel_override(skill, channel_dir)
     if override_path is not None:
         override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
-        _warn_deprecated_override_keys(skill, override, override_path)
-        _warn_unknown_top_level_override_keys(skill, override, defaults, override_path, acknowledged)
         merged = _deep_merge(defaults, override)
+        _warn_deprecated_override_keys(skill, override, override_path, merged)
+        _warn_unknown_top_level_override_keys(skill, override, defaults, override_path, acknowledged)
     else:
         merged = defaults
 

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -226,6 +226,36 @@ def test_thumbnail_deprecated_override_keys_warn_but_still_merge(tmp_path, monke
     assert gemini["thumbnail_text"]["copy_position"] == "left of character"
 
 
+def test_thumbnail_codex_composition_rules_are_not_deprecated(tmp_path, monkeypatch):
+    channel_dir = tmp_path / "ch"
+    override_dir = channel_dir / "config" / "skills"
+    override_dir.mkdir(parents=True)
+    (override_dir / "thumbnail.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "codex",
+                    "gemini": {
+                        "composition_rules": {
+                            "environment": "bright studio",
+                            "background": "light gray",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cfg = skill_config.load_skill_config("thumbnail", use_cache=False)
+
+    assert not [warning for warning in caught if issubclass(warning.category, DeprecationWarning)]
+    assert cfg["image_generation"]["gemini"]["composition_rules"]["background"] == "light gray"
+
+
 def test_thumbnail_override_without_deprecated_keys_does_not_warn(tmp_path, monkeypatch):
     """#1702: 縮小後の実効キーだけの override では DeprecationWarning を出さない。"""
     channel_dir = tmp_path / "ch"


### PR DESCRIPTION
## Summary
- merged config から thumbnail の実効 provider を判定する
- Codex で有効な composition_rules を deprecated 対象から除外する
- Codex provider 向けに機能する移行先を案内する

Closes #3913