### PR TITLE
feat(setup): OAuth tokenの非対話更新を追加する (#3936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(setup)`: `yt-oauth --refresh-only` で既存 refresh token を非対話更新し、ブラウザ認証や YouTube API 接続テストなしで token を延命できるようにする（#3936）。
+
 - `fix(thumbnail)`: Codex provider が prompt へ決定的に注入する `composition_rules` は deprecated 扱いせず、他の移行対象には Codex 固有の移行先を案内する（#3913）。
 
 - `fix(thumbnail)`: auto-selection の既定 aspect tolerance を Gemini の 1K / 2K 出力における 64px 丸めを吸収する 0.06 へ広げる（#3867）。

--- a/src/youtube_automation/commands/system/oauth.py
+++ b/src/youtube_automation/commands/system/oauth.py
@@ -29,6 +29,11 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="read-only スコープの token.readonly.json を発行する（write scope を含まない。#1699）",
     )
+    parser.add_argument(
+        "--refresh-only",
+        action="store_true",
+        help="既存 refresh token で非対話更新する（ブラウザ認証・API 接続テストは行わない）",
+    )
     args = parser.parse_args(argv)
 
     mode_label = "read-only" if args.readonly else "full access"
@@ -39,9 +44,18 @@ def main(argv: list[str] | None = None) -> None:
     try:
         # OAuth ハンドラー初期化
         if args.readonly:
-            auth_handler = YouTubeOAuthHandler.create_readonly()
+            auth_handler = (
+                YouTubeOAuthHandler.create_readonly(interactive=False)
+                if args.refresh_only
+                else YouTubeOAuthHandler.create_readonly()
+            )
         else:
-            auth_handler = YouTubeOAuthHandler()
+            auth_handler = YouTubeOAuthHandler(interactive=False) if args.refresh_only else YouTubeOAuthHandler()
+
+        if args.refresh_only:
+            auth_handler.refresh_existing_credentials()
+            print("\n✅ OAuth token の非対話更新が完了しました。")
+            return
 
         # 認証実行
         auth_handler.authenticate()

--- a/src/youtube_automation/infrastructure/auth/youtube.py
+++ b/src/youtube_automation/infrastructure/auth/youtube.py
@@ -340,6 +340,25 @@ class YouTubeOAuthHandler:
 
         return self.credentials
 
+    def refresh_existing_credentials(self) -> Credentials:
+        """既存 refresh token だけを使い、ブラウザを開かず access token を更新する。"""
+        if not self.token_file.is_file():
+            raise AuthError(f"既存の OAuth token がありません: {self.token_file}")
+        try:
+            credentials = Credentials.from_authorized_user_file(str(self.token_file), self._scopes)
+        except (OSError, ValueError) as exc:
+            raise AuthError("既存の OAuth token を読み込めません") from exc
+        if not credentials.refresh_token:
+            raise AuthError("既存の OAuth token に refresh token がありません")
+        try:
+            credentials.refresh(Request())
+        except google.auth.exceptions.GoogleAuthError as exc:
+            logger.warning("token refresh 失敗: %s", redact_sensitive_data(str(exc)))
+            raise AuthError("OAuth token の更新に失敗しました。refresh token が失効している可能性があります") from exc
+        self.credentials = credentials
+        self._save_credentials()
+        return credentials
+
     def _save_credentials(self):
         """認証情報をファイルに 0o600 で保存する。
 

--- a/tests/infrastructure/auth/test_oauth_handler_exceptions.py
+++ b/tests/infrastructure/auth/test_oauth_handler_exceptions.py
@@ -670,6 +670,31 @@ class TestAuthenticateRefresh:
             handler.authenticate()
 
 
+class TestRefreshExistingCredentials:
+    def test_refreshes_valid_access_token_and_saves_it(self, tmp_path: Path, monkeypatch):
+        token_path = tmp_path / "token.json"
+        token_path.write_text("{}")
+        handler = _make_handler(tmp_path, token_path=token_path)
+        credentials = _make_credentials(expired=False, valid=True, refresh_token="rt")
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.auth.youtube.Credentials.from_authorized_user_file",
+            MagicMock(return_value=credentials),
+        )
+        monkeypatch.setattr(handler, "_save_credentials", MagicMock())
+
+        result = handler.refresh_existing_credentials()
+
+        assert result is credentials
+        credentials.refresh.assert_called_once()
+        handler._save_credentials.assert_called_once_with()
+
+    def test_missing_token_fails_without_interactive_fallback(self, tmp_path: Path):
+        handler = _make_handler(tmp_path, token_path=tmp_path / "missing.json")
+
+        with pytest.raises(AuthError, match="既存の OAuth token がありません"):
+            handler.refresh_existing_credentials()
+
+
 # ===========================================================================
 # 7. L159 — 新規認証（#26〜#32）
 # ===========================================================================

--- a/tests/infrastructure/auth/test_oauth_readonly_token.py
+++ b/tests/infrastructure/auth/test_oauth_readonly_token.py
@@ -279,6 +279,18 @@ class TestYouTubeClientsReadonly:
 
 
 class TestMainReadonlyFlag:
+    def test_refresh_only_uses_noninteractive_handler_without_connection_test(self):
+        from youtube_automation.commands.system import oauth as oauth_cli
+
+        mock_cls = MagicMock()
+        with patch.object(oauth_cli, "YouTubeOAuthHandler", mock_cls):
+            oauth_cli.main(["--refresh-only"])
+
+        mock_cls.assert_called_once_with(interactive=False)
+        mock_cls.return_value.refresh_existing_credentials.assert_called_once_with()
+        mock_cls.return_value.authenticate.assert_not_called()
+        mock_cls.return_value.test_connection.assert_not_called()
+
     def test_readonly_flag_uses_create_readonly(self):
         from youtube_automation.commands.system import oauth as oauth_cli
 


### PR DESCRIPTION
## Summary
- yt-oauth --refresh-only で既存 refresh token を非対話更新する
- browser OAuth と API 接続テストへフォールバックしない
- readonly token と失敗時の fail-fast を回帰テストで保証する

Closes #3936