### PR TITLE
refactor(skills): inventory エンジンへ走査を集約 (#3902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(skills)`: skill 列挙・frontmatter 検証・Markdown セクション・reference 解決を `domains.skills` の inventory へ集約し、repo と wheel の両 root で同じ判定を使えるようにする（#3902）。
+
 - `fix(collection-serve)`: Chrome 拡張の自動検出パスとプロセス生存確認を OS ごとに切り替え、Windows で `yt-collection-serve --allow-extension` がクラッシュする問題を修正する（#4106）。
 
 - `feat(setup)`: `yt-oauth --refresh-only` で既存 refresh token を非対話更新し、ブラウザ認証や YouTube API 接続テストなしで token を延命できるようにする（#3936）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.suno` | Suno 設定、歌詞、プロンプト、プレイリスト、選曲の生成・検証 |
 | `domains.suno.downloaded` | downloaded payload、workflow、検証、archive、apply transaction |
 | `domains.suno.name_matching` | prompt・playlist・downloaded filename 共通の名前正規化と曖昧性検出 |
+| `domains.skills` | skill 列挙、frontmatter、Markdown セクション、reference 解決の provider-neutral inventory |
 | `domains.metadata` | `service` の状態付き orchestration と titles / descriptions / tags / localizations leaf |
 | `domains.analytics` | Analytics の Protocol、収集、分析、レポート、時系列 policy。SDK/client は adapter 境界で解決 |
 | `domains.thumbnail` | サムネ特徴量、相関、参照、archive、選択 policy（Pillow） |

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -236,10 +236,10 @@ from youtube_automation.commands.system.skills_sync._ops import _symlink_entry a
 from youtube_automation.commands.system.skills_sync._sync import cmd_sync as cmd_sync  # noqa: E402
 from youtube_automation.commands.system.skills_sync._diff import cmd_diff as cmd_diff  # noqa: E402
 from youtube_automation.commands.system.skills_sync._lint import cmd_lint as cmd_lint  # noqa: E402
-from youtube_automation.commands.system.skills_sync._lint import lint_frontmatter_text as lint_frontmatter_text  # noqa: E402
-from youtube_automation.commands.system.skills_sync._lint import lint_skill as lint_skill  # noqa: E402
 from youtube_automation.commands.system.skills_sync._parser import _resolve_default_target as _resolve_default_target  # noqa: E402
 from youtube_automation.commands.system.skills_sync._parser import build_parser as build_parser  # noqa: E402
+from youtube_automation.domains.skills.inventory import lint_frontmatter_text as lint_frontmatter_text  # noqa: E402
+from youtube_automation.domains.skills.inventory import lint_skill as lint_skill  # noqa: E402
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -1,8 +1,8 @@
 """yt-skills lint — SKILL.md frontmatter の軽量検証 (Issue #2096)。
 
 skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず秒単位で回すための
-サブコマンド。検証ロジックはこのモジュールを単一ソースとし、既存の回帰テスト
-(tests/commands/system/test_skill_frontmatter_yaml.py) もここを import して同じ判定基準を使う。
+サブコマンド。検証ロジックは domains.skills.inventory を単一ソースとし、既存の
+回帰テストも同じ domain API を使う。
 
 検証内容 (Issue #652 の strict YAML 契約 + CLAUDE.md「skill frontmatter」規約):
     1. SKILL.md が frontmatter デリミタ `---` で始まり、閉じ `---` を持つ
@@ -15,75 +15,8 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
 from __future__ import annotations
 
 import argparse
-import re
-from pathlib import Path
 
-import yaml
-
-_FRONTMATTER_DELIMITER = "---"
-
-# frontmatter 内の description 行が double-quoted string で始まることを検査する。
-# 値が複数行に折り返されていても、開始行が `description: "` であればよい。
-_DESCRIPTION_DOUBLE_QUOTED = re.compile(r'^description:\s*"', re.MULTILINE)
-
-
-def extract_frontmatter(text: str) -> str:
-    """先頭の `---` から次の `---` までの frontmatter ブロックを返す。
-
-    デリミタが欠けている場合は `ValueError` を raise する (呼び出し側で
-    violation メッセージに変換する)。
-    """
-    lines = text.split("\n")
-    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
-        raise ValueError("SKILL.md が frontmatter デリミタ '---' で始まっていません")
-    for i in range(1, len(lines)):
-        if lines[i].strip() == _FRONTMATTER_DELIMITER:
-            return "\n".join(lines[1:i])
-    raise ValueError("frontmatter の閉じデリミタ '---' が見つかりません")
-
-
-def lint_frontmatter_text(text: str) -> list[str]:
-    """SKILL.md 全文を検証し、違反メッセージのリストを返す (空 = 合格)。
-
-    最初に構造 (デリミタ / YAML パース) を検証し、破綻していたらその時点の
-    violation だけ返す (壊れた frontmatter に対するキー検査は無意味なため)。
-    """
-    try:
-        frontmatter = extract_frontmatter(text)
-    except ValueError as exc:
-        return [str(exc)]
-
-    try:
-        parsed = yaml.safe_load(frontmatter)
-    except yaml.YAMLError as exc:
-        return [f"frontmatter が strict YAML として解釈できません: {exc}"]
-
-    if not isinstance(parsed, dict):
-        return ["frontmatter が dict として解釈できません"]
-
-    violations: list[str] = []
-    for key in ("name", "description"):
-        if key not in parsed:
-            violations.append(f"frontmatter に '{key}' がありません")
-        elif not isinstance(parsed[key], str):
-            violations.append(f"'{key}' が文字列ではありません")
-        elif not parsed[key].strip():
-            violations.append(f"'{key}' が空です")
-
-    if "description" in parsed and not _DESCRIPTION_DOUBLE_QUOTED.search(frontmatter):
-        violations.append(
-            'description が double-quoted string ではありません (CLAUDE.md 規約: description: "..." で書く)'
-        )
-
-    return violations
-
-
-def lint_skill(skill_dir: Path) -> list[str]:
-    """skill ディレクトリ 1 件を検証し、違反メッセージのリストを返す。"""
-    skill_md = skill_dir / "SKILL.md"
-    if not skill_md.is_file():
-        return ["SKILL.md がありません"]
-    return lint_frontmatter_text(skill_md.read_text(encoding="utf-8"))
+from youtube_automation.domains.skills.inventory import SkillInventory, lint_skill
 
 
 def cmd_lint(args: argparse.Namespace) -> int:
@@ -91,7 +24,8 @@ def cmd_lint(args: argparse.Namespace) -> int:
     from youtube_automation.commands.system.skills_sync import _asset_root
 
     root = _asset_root("skills")
-    available = sorted(p.name for p in root.iterdir() if p.is_dir())
+    inventory = SkillInventory(root)
+    available = [path.name for path in inventory.skill_directories()]
 
     requested: list[str] = getattr(args, "skills", None) or []
     if requested:

--- a/src/youtube_automation/domains/skills/__init__.py
+++ b/src/youtube_automation/domains/skills/__init__.py
@@ -1,0 +1,19 @@
+"""Skill document inventory and parsing domain."""
+
+from youtube_automation.domains.skills.inventory import (
+    SkillInventory,
+    extract_frontmatter,
+    extract_markdown_section,
+    lint_frontmatter_text,
+    lint_skill,
+    parse_frontmatter,
+)
+
+__all__ = [
+    "SkillInventory",
+    "extract_frontmatter",
+    "extract_markdown_section",
+    "lint_frontmatter_text",
+    "lint_skill",
+    "parse_frontmatter",
+]

--- a/src/youtube_automation/domains/skills/inventory.py
+++ b/src/youtube_automation/domains/skills/inventory.py
@@ -1,0 +1,149 @@
+"""Provider-neutral inventory and parsing for distributed skill documents."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_FRONTMATTER_DELIMITER = "---"
+_DESCRIPTION_DOUBLE_QUOTED = re.compile(r'^description:\s*"', re.MULTILINE)
+_MARKDOWN_HEADING = re.compile(r"^(?P<marks>#{1,6})\s+\S")
+
+
+def extract_frontmatter(text: str) -> str:
+    """Return the YAML frontmatter block from a SKILL.md document."""
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
+        raise ValueError("SKILL.md が frontmatter デリミタ '---' で始まっていません")
+    for index in range(1, len(lines)):
+        if lines[index].strip() == _FRONTMATTER_DELIMITER:
+            return "\n".join(lines[1:index])
+    raise ValueError("frontmatter の閉じデリミタ '---' が見つかりません")
+
+
+def parse_frontmatter(text: str) -> object:
+    """Parse SKILL.md frontmatter with strict YAML semantics."""
+    return _parse_frontmatter_block(extract_frontmatter(text))
+
+
+def _parse_frontmatter_block(frontmatter: str) -> object:
+    return yaml.safe_load(frontmatter)
+
+
+def lint_frontmatter_text(text: str) -> list[str]:
+    """Return frontmatter contract violations for one SKILL.md document."""
+    try:
+        frontmatter = extract_frontmatter(text)
+        parsed = _parse_frontmatter_block(frontmatter)
+    except ValueError as exc:
+        return [str(exc)]
+    except yaml.YAMLError as exc:
+        return [f"frontmatter が strict YAML として解釈できません: {exc}"]
+
+    if not isinstance(parsed, dict):
+        return ["frontmatter が dict として解釈できません"]
+
+    violations: list[str] = []
+    for key in ("name", "description"):
+        if key not in parsed:
+            violations.append(f"frontmatter に '{key}' がありません")
+        elif not isinstance(parsed[key], str):
+            violations.append(f"'{key}' が文字列ではありません")
+        elif not parsed[key].strip():
+            violations.append(f"'{key}' が空です")
+
+    if "description" in parsed and not _DESCRIPTION_DOUBLE_QUOTED.search(frontmatter):
+        violations.append(
+            'description が double-quoted string ではありません (CLAUDE.md 規約: description: "..." で書く)'
+        )
+    return violations
+
+
+def lint_skill(skill_dir: Path) -> list[str]:
+    """Return frontmatter contract violations for one skill directory."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return ["SKILL.md がありません"]
+    return lint_frontmatter_text(skill_md.read_text(encoding="utf-8"))
+
+
+def extract_markdown_section(text: str, heading: str) -> str:
+    """Return the body below an exact heading through the next peer heading."""
+    heading_match = _MARKDOWN_HEADING.match(heading)
+    if heading_match is None:
+        raise ValueError(f"Markdown 見出しではありません: {heading}")
+    target_level = len(heading_match.group("marks"))
+    lines = text.splitlines(keepends=True)
+    start: int | None = None
+    for index, line in enumerate(lines):
+        if line.rstrip("\r\n") == heading:
+            start = index + 1
+            break
+    if start is None:
+        raise ValueError(f"`{heading}` セクションが見つかりません")
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        match = _MARKDOWN_HEADING.match(lines[index])
+        if match is not None and len(match.group("marks")) <= target_level:
+            end = index
+            break
+    return "".join(lines[start:end])
+
+
+@dataclass(frozen=True, slots=True)
+class SkillInventory:
+    """Query skill documents from a repository or an installed asset root."""
+
+    root: Path
+
+    @property
+    def skills_root(self) -> Path:
+        repository_skills = self.root / ".claude" / "skills"
+        return repository_skills if repository_skills.is_dir() else self.root
+
+    def skill_directories(self) -> tuple[Path, ...]:
+        """List immediate skill directories while excluding nested worktree stores."""
+        if not self.skills_root.is_dir():
+            return ()
+        directories = (
+            path for path in self.skills_root.iterdir() if path.is_dir() and not self._is_worktree_store_entry(path)
+        )
+        return tuple(sorted(directories, key=lambda path: path.name))
+
+    def skill_directory(self, skill: str) -> Path:
+        """Resolve one skill directory from its inventory name."""
+        return self.skills_root / skill
+
+    def frontmatter(self, skill: str) -> object:
+        """Read and parse one skill's frontmatter."""
+        text = (self.skill_directory(skill) / "SKILL.md").read_text(encoding="utf-8")
+        return parse_frontmatter(text)
+
+    def section(self, skill: str, heading: str) -> str:
+        """Read one skill and extract an exact Markdown heading section."""
+        text = (self.skill_directory(skill) / "SKILL.md").read_text(encoding="utf-8")
+        return extract_markdown_section(text, heading)
+
+    def resolve_reference(self, skill: str, reference: str) -> Path:
+        """Resolve a local reference path relative to its skill directory."""
+        path_text = reference.split("#", maxsplit=1)[0]
+        if not path_text:
+            raise ValueError("reference path が空です")
+        path = Path(path_text)
+        if path.is_absolute():
+            raise ValueError(f"reference path は相対パスである必要があります: {reference}")
+        return (self.skill_directory(skill) / path).resolve()
+
+    def reference_exists(self, skill: str, reference: str) -> bool:
+        """Return whether a resolved skill reference points to a file."""
+        return self.resolve_reference(skill, reference).is_file()
+
+    def _is_worktree_store_entry(self, path: Path) -> bool:
+        relative = path.relative_to(self.skills_root)
+        if relative.parts[0] == ".worktrees":
+            return True
+        return relative.parts[0] == ".claude" and (path / "worktrees").is_dir()

--- a/tests/commands/system/test_skill_frontmatter_yaml.py
+++ b/tests/commands/system/test_skill_frontmatter_yaml.py
@@ -4,9 +4,8 @@ description 値内の `: ` (コロン+スペース) は strict YAML ではマッ
 誤解釈されパースが破綻する。全 skill の frontmatter を double-quoted string に統一し、
 将来 strict YAML パーサで読む経路が追加されても壊れないことを保証する。
 
-検証ロジックの単一ソースは `yt-skills lint` 側
-(youtube_automation.commands.system.skills_sync._lint) にあり、本テストはそれを全 skill に
-適用する回帰テスト (Issue #2096)。判定基準を変える場合は _lint 側を修正すること。
+検証ロジックの単一ソースは `domains.skills.inventory` にあり、本テストはそれを全
+skill に適用する回帰テスト (Issue #2096)。判定基準を変える場合は domain 側を修正すること。
 """
 
 from __future__ import annotations
@@ -16,13 +15,18 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
-from youtube_automation.commands.system.skills_sync._lint import lint_skill
+from youtube_automation.commands.system import skills_sync
+from youtube_automation.domains.skills.inventory import lint_skill
 
 # リポジトリルート (tests/ の親)
 _REPO_ROOT = REPO_ROOT
 _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
 
 _SKILL_DIRS = sorted(p.parent for p in _SKILLS_DIR.glob("*/SKILL.md"))
+
+
+def test_command_adapter_reexports_domain_lint() -> None:
+    assert skills_sync.lint_skill is lint_skill
 
 
 def test_skill_files_discovered() -> None:

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -13,7 +13,7 @@ import pytest
 
 from youtube_automation.commands.system import skills_sync
 from youtube_automation.commands.system.skills_sync import build_parser, main
-from youtube_automation.commands.system.skills_sync._lint import lint_frontmatter_text, lint_skill
+from youtube_automation.domains.skills.inventory import lint_frontmatter_text, lint_skill
 
 _VALID_SKILL_MD = '---\nname: good-skill\ndescription: "Use when: 良い skill のとき"\n---\n\n# good\n'
 

--- a/tests/domains/skills/test_inventory.py
+++ b/tests/domains/skills/test_inventory.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.domains.skills.inventory import (
+    SkillInventory,
+    extract_markdown_section,
+    parse_frontmatter,
+)
+
+
+def _write_skill(root: Path, name: str, *, description: str = "説明") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f'---\nname: {name}\ndescription: "{description}"\n---\n\n## 本文\n\n{name}\n',
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_repo_and_wheel_roots_produce_the_same_inventory(tmp_path: Path) -> None:
+    # Given: repository layout and installed-wheel layout with the same skills
+    repo_root = tmp_path / "repo"
+    wheel_root = tmp_path / "wheel" / "_skills"
+    for root in (repo_root / ".claude" / "skills", wheel_root):
+        _write_skill(root, "alpha", description="shared")
+        _write_skill(root, "beta", description="shared")
+
+    # When: both supported roots are queried
+    repo_inventory = SkillInventory(repo_root)
+    wheel_inventory = SkillInventory(wheel_root)
+
+    # Then: enumeration and parsing produce the same results
+    assert [path.name for path in repo_inventory.skill_directories()] == ["alpha", "beta"]
+    assert [path.name for path in wheel_inventory.skill_directories()] == ["alpha", "beta"]
+    assert repo_inventory.frontmatter("alpha") == wheel_inventory.frontmatter("alpha")
+
+
+def test_repository_root_resolves_claude_skills_and_excludes_worktree_store(tmp_path: Path) -> None:
+    # Given: a repository skill and a skill-like file inside the linked-worktree store
+    expected = _write_skill(tmp_path / ".claude" / "skills", "alpha")
+    _write_skill(tmp_path / ".claude" / "worktrees" / "nested" / ".claude" / "skills", "shadow")
+    _write_skill(tmp_path / ".worktrees" / "legacy" / ".claude" / "skills", "legacy-shadow")
+
+    # When: the repository root is injected
+    inventory = SkillInventory(tmp_path)
+
+    # Then: only the canonical repository skill root is enumerated
+    assert inventory.skills_root == tmp_path / ".claude" / "skills"
+    assert inventory.skill_directories() == (expected,)
+
+
+def test_direct_wheel_root_enumerates_skill_directories_in_name_order(tmp_path: Path) -> None:
+    # Given: a wheel-derived _skills root
+    wheel_root = tmp_path / "package" / "_skills"
+    beta = _write_skill(wheel_root, "beta")
+    alpha = _write_skill(wheel_root, "alpha")
+
+    # When / Then: direct root injection produces a stable inventory
+    assert SkillInventory(wheel_root).skill_directories() == (alpha, beta)
+
+
+def test_frontmatter_parser_returns_strict_yaml_mapping() -> None:
+    # Given: a valid SKILL.md document
+    text = '---\nname: sample\ndescription: "sample: description"\n---\n\nBody\n'
+
+    # When: frontmatter is parsed
+    parsed = parse_frontmatter(text)
+
+    # Then: YAML values are available without the document body
+    assert parsed == {"name": "sample", "description": "sample: description"}
+
+
+def test_markdown_section_stops_at_same_or_higher_heading() -> None:
+    # Given: a section with a nested heading followed by a sibling section
+    text = "# Title\n\n## Target\n\nfirst\n\n### Nested\n\nsecond\n\n## Next\n\nthird\n"
+
+    # When: the target section is extracted
+    section = extract_markdown_section(text, "## Target")
+
+    # Then: nested content is included and the sibling section is excluded
+    assert section == "\nfirst\n\n### Nested\n\nsecond\n\n"
+
+
+def test_markdown_section_rejects_missing_heading() -> None:
+    with pytest.raises(ValueError, match="セクションが見つかりません"):
+        extract_markdown_section("## Present\n", "## Missing")
+
+
+def test_reference_resolution_reports_existing_and_missing_files(tmp_path: Path) -> None:
+    # Given: a skill with one reference file
+    skill_dir = _write_skill(tmp_path / "_skills", "sample")
+    reference = skill_dir / "references" / "details.md"
+    reference.parent.mkdir()
+    reference.write_text("details", encoding="utf-8")
+    inventory = SkillInventory(tmp_path / "_skills")
+
+    # When / Then: paths resolve from the skill directory and existence is explicit
+    assert inventory.resolve_reference("sample", "references/details.md") == reference.resolve()
+    assert inventory.reference_exists("sample", "references/details.md")
+    assert not inventory.reference_exists("sample", "references/missing.md")


### PR DESCRIPTION
## Summary
- repo／wheel の root 注入と worktree store 除外を持つ skill inventory を domain に新設
- frontmatter lint、Markdown section、reference 解決を共通 API 化
- `yt-skills lint` を inventory 経由へ移行し、既存判定を維持

Closes #3902