### PR TITLE
refactor(test): 配布参照とwheel検証をinventory経由へ移行 (#3905)

### DIFF
--- a/tests/repo/test_distributed_skill_references.py
+++ b/tests/repo/test_distributed_skill_references.py
@@ -16,14 +16,15 @@ import tomllib
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
 
 _REPO_ROOT = REPO_ROOT
-_SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
+_SKILL_INVENTORY = SkillInventory(_REPO_ROOT)
 _CLAUDE_TEMPLATE = _REPO_ROOT / ".claude" / "CLAUDE.template.md"
-_RELEASE_SKILL = _SKILLS_DIR / "automation-release" / "SKILL.md"
-_RELEASE_CONTRACTS = _SKILLS_DIR / "automation-release" / "references" / "release-contracts.md"
-_CHANGELOG_PROMOTION = _SKILLS_DIR / "automation-release" / "references" / "changelog-promotion.md"
-_PREPARE_CHECKLIST = _SKILLS_DIR / "automation-release" / "references" / "prepare-checklist.md"
+_RELEASE_SKILL = _SKILL_INVENTORY.skill_directory("automation-release") / "SKILL.md"
+_RELEASE_CONTRACTS = _SKILL_INVENTORY.resolve_reference("automation-release", "references/release-contracts.md")
+_CHANGELOG_PROMOTION = _SKILL_INVENTORY.resolve_reference("automation-release", "references/changelog-promotion.md")
+_PREPARE_CHECKLIST = _SKILL_INVENTORY.resolve_reference("automation-release", "references/prepare-checklist.md")
 
 # 配布ファイル内で走査する拡張子（prose / スクリプト双方に参照が現れうる）
 _SCANNED_SUFFIXES = (".md", ".py", ".sh")
@@ -50,7 +51,12 @@ def _wheel_included_paths() -> frozenset[str]:
 
 def _distributed_files() -> list[Path]:
     """wheel に同梱され `yt-skills sync` で下流へ配布されるテキストファイル。"""
-    files = [p for p in sorted(_SKILLS_DIR.rglob("*")) if p.is_file() and p.suffix in _SCANNED_SUFFIXES]
+    files = [
+        path
+        for skill_dir in _SKILL_INVENTORY.skill_directories()
+        for path in sorted(skill_dir.rglob("*"))
+        if path.is_file() and path.suffix in _SCANNED_SUFFIXES
+    ]
     files.append(_CLAUDE_TEMPLATE)
     return files
 
@@ -95,7 +101,7 @@ def test_no_claude_md_section_number_references() -> None:
 
 def test_videoup_encoder_benchmark_contract_is_self_contained() -> None:
     """videoup の配布物だけで encoder 採用基準と安全な fallback を判断できる。"""
-    skill = (_SKILLS_DIR / "videoup" / "SKILL.md").read_text(encoding="utf-8")
+    skill = (_SKILL_INVENTORY.skill_directory("videoup") / "SKILL.md").read_text(encoding="utf-8")
 
     assert "median wall-clock が `libx264 medium` baseline より 20% 以上短い候補だけ" in skill
     assert "H.264 / yuv420p / profile / maxrate / bufsize / fps / AAC / duration" in skill

--- a/tests/repo/test_skill_inventory_gate.py
+++ b/tests/repo/test_skill_inventory_gate.py
@@ -15,7 +15,6 @@ _LEGACY_SKILL_SCAN_ALLOWLIST = frozenset(
     {
         "test_analytics_consolidation.py",
         "test_analytics_run_state.py",
-        "test_distributed_skill_references.py",
         "test_flop_analysis_skill_contract.py",
         "test_lifecycle_skills_no_tayk.py",
         "test_live_chat_reply_skill_contract.py",
@@ -30,7 +29,6 @@ _LEGACY_SKILL_SCAN_ALLOWLIST = frozenset(
         "test_skill_page_generation_contract.py",
         "test_skill_shell_reference_runtime.py",
         "test_skills_rename.py",
-        "test_skills_sync_installed_wheel.py",
         "test_unattended_approval_skip_contract.py",
         "test_workflow_upload_setup_redirect_contract.py",
     }

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -10,6 +10,7 @@ import tarfile
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
 
 _FILE_ASSETS = {
     Path(".claude/CLAUDE.md"): Path(".claude/CLAUDE.template.md"),
@@ -86,14 +87,24 @@ def _candidate_sdist(repo_root: Path, tmp_path: Path) -> Path:
 
 
 def _tracked_skill_files(repo_root: Path) -> set[Path]:
-    result = _run("git", "ls-files", "--", ".claude/skills", cwd=repo_root)
+    inventory = SkillInventory(repo_root)
+    skills_root = inventory.skills_root.relative_to(repo_root)
+    result = _run("git", "ls-files", "--", skills_root, cwd=repo_root)
     assert result.returncode == 0, result.stderr
-    prefix = Path(".claude/skills")
     dev_only = {"automation-release", "shadcn"}
     return {
         relative
         for line in result.stdout.splitlines()
-        if line and (relative := Path(line).relative_to(prefix)).parts[0] not in dev_only
+        if line and (relative := Path(line).relative_to(skills_root)).parts[0] not in dev_only
+    }
+
+
+def _inventory_files(inventory: SkillInventory) -> set[Path]:
+    return {
+        path.relative_to(inventory.skills_root)
+        for skill_dir in inventory.skill_directories()
+        for path in skill_dir.rglob("*")
+        if path.is_file() or path.is_symlink()
     }
 
 
@@ -131,6 +142,16 @@ def test_candidate_wheel_syncs_all_assets_into_clean_downstream(tmp_path: Path) 
         """
 import importlib
 import sys
+from pathlib import Path
+
+import youtube_automation
+
+from youtube_automation.domains.skills.inventory import SkillInventory
+
+wheel_skills_root = Path(youtube_automation.__file__).resolve().parent / "_skills"
+wheel_inventory = SkillInventory(wheel_skills_root)
+assert wheel_inventory.skills_root == wheel_skills_root
+assert "setup" in {path.name for path in wheel_inventory.skill_directories()}
 
 legacy_modules = (
     "youtube_automation.infrastructure.errors",
@@ -231,14 +252,14 @@ assert "wheel-identity-check" not in legacy._cache
     assert synced.returncode == 0, synced.stderr
 
     source_skill_files = _tracked_skill_files(repo_root)
-    target_skills = downstream / ".claude" / "skills"
-    target_skill_files = {
-        path.relative_to(target_skills) for path in target_skills.rglob("*") if path.is_file() or path.is_symlink()
-    }
+    target_inventory = SkillInventory(downstream)
+    target_skills = target_inventory.skills_root
+    assert target_skills == downstream / ".claude" / "skills"
+    target_skill_files = _inventory_files(target_inventory)
     assert target_skill_files == source_skill_files
     for relative in source_skill_files:
         target = target_skills / relative
-        source = repo_root / ".claude" / "skills" / relative
+        source = SkillInventory(repo_root).skills_root / relative
         assert target.read_bytes() == source.read_bytes()
 
     for target_relative, source_relative in _FILE_ASSETS.items():


### PR DESCRIPTION
## Summary
- 配布 reference 検証を inventory API へ移行
- installed wheel の `_skills/` root 注入経路を実テストで通過
- 逆流防止 gate の allowlist から 2 対象を削除

Closes #3905