### PR TITLE
refactor(test): Suno契約をinventory経由へ移行 (#3906)

### DIFF
--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -30,9 +30,10 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
 
 ROOT = REPO_ROOT
-SKILLS_DIR = ROOT / ".claude" / "skills"
+SKILL_INVENTORY = SkillInventory(ROOT)
 
 # --- 1 段目: CLI → 課金 API 分類（実装の execute() / クライアント呼び出しを根拠に判定） ---
 
@@ -203,7 +204,7 @@ def _registered_clis() -> set[str]:
 
 
 def _skill_dirs() -> list[Path]:
-    return sorted(d for d in SKILLS_DIR.iterdir() if (d / "SKILL.md").is_file())
+    return [directory for directory in SKILL_INVENTORY.skill_directories() if (directory / "SKILL.md").is_file()]
 
 
 def _referenced_clis(skill_dir: Path, registered: set[str]) -> set[str]:
@@ -285,12 +286,11 @@ def test_target_set_matches_mechanical_extraction() -> None:
 @pytest.mark.parametrize("skill", sorted(TARGET_SKILLS))
 def test_target_skill_documents_estimated_api_calls(skill: str) -> None:
     """対象 skill の SKILL.md に「想定 API call 数」の見積もり契約が記載されている。"""
-    skill_md = SKILLS_DIR / skill / "SKILL.md"
+    skill_md = SKILL_INVENTORY.skill_directory(skill) / "SKILL.md"
     text = skill_md.read_text(encoding="utf-8")
 
     assert _SECTION_HEADING in text, f"{skill}/SKILL.md に `{_SECTION_HEADING}` セクションがありません"
-    section = text.split(_SECTION_HEADING, 1)[1]
-    section = re.split(r"^## ", section, maxsplit=1, flags=re.MULTILINE)[0]
+    section = SKILL_INVENTORY.section(skill, _SECTION_HEADING)
 
     assert _TABLE_HEADER in section, (
         f"{skill}/SKILL.md の想定 API call 数セクションに判定表 `{_TABLE_HEADER}` がありません"

--- a/tests/repo/test_skill_inventory_gate.py
+++ b/tests/repo/test_skill_inventory_gate.py
@@ -24,7 +24,6 @@ _LEGACY_SKILL_SCAN_ALLOWLIST = frozenset(
         "test_scripts_layout.py",
         "test_setup_channel_disclosure_contract.py",
         "test_shadcn_skill_contract.py",
-        "test_skill_api_call_estimate_contract.py",
         "test_skill_cost_documentation.py",
         "test_skill_page_generation_contract.py",
         "test_skill_shell_reference_runtime.py",

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -18,17 +18,19 @@ import re
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
 
 # リポジトリルート (tests/ の親)
 _REPO_ROOT = REPO_ROOT
-SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "suno" / "SKILL.md"
-SUNO_HELPER_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "suno-helper" / "SKILL.md"
+_SKILL_INVENTORY = SkillInventory(_REPO_ROOT)
+SKILL_MD = _SKILL_INVENTORY.skill_directory("suno") / "SKILL.md"
+SUNO_HELPER_SKILL_MD = _SKILL_INVENTORY.skill_directory("suno-helper") / "SKILL.md"
 SUNO_HELPER_README_MD = _REPO_ROOT / "extensions" / "suno-helper" / "README.md"
-WF_NEW_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
-WF_AUTO_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+WF_NEW_SKILL_MD = _SKILL_INVENTORY.skill_directory("wf-new") / "SKILL.md"
+WF_AUTO_SKILL_MD = _SKILL_INVENTORY.skill_directory("wf-auto") / "SKILL.md"
 SUNO_HELPER_PHASE_CONSTANTS_TS = _REPO_ROOT / "extensions" / "shared" / "constants.ts"
-SUNO_LYRIC_SKILL_MD = _REPO_ROOT / ".claude" / "skills" / "suno-lyric" / "SKILL.md"
-REVIEW_RUBRIC_MD = _REPO_ROOT / ".claude" / "skills" / "suno-lyric" / "references" / "review-rubric.md"
+SUNO_LYRIC_SKILL_MD = _SKILL_INVENTORY.skill_directory("suno-lyric") / "SKILL.md"
+REVIEW_RUBRIC_MD = _SKILL_INVENTORY.resolve_reference("suno-lyric", "references/review-rubric.md")
 
 
 def _read(path: Path = SKILL_MD) -> str:


### PR DESCRIPTION
## Summary
- Suno skill 文書と reference 解決を inventory API へ移行
- API call 見積り契約の列挙・section 抽出を共通 API へ置換
- 逆流防止 gate の allowlist から対象を削除

Closes #3906