### PR TITLE
feat(skills): mode referenceのlint契約を追加 (#3750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `yt-skills lint` で mode 表の reference が skill 相対の `references/<flag>.md` として実在し、mode 間で共有されていないことを検証する（#3750）。
+
 - `feat(skills)`: `yt-skills lint` で description の値なしフラグが mode / modifier 表のどちらか一方に定義され、排他 mode が 5 個以下かつ同時指定停止を明記する契約を検証し、既存違反を種別単位で猶予できる allowlist を追加する（#3749）。
 
 - `refactor(skills)`: skill 列挙・frontmatter 検証・Markdown セクション・reference 解決を `domains.skills` の inventory へ集約し、repo と wheel の両 root で同じ判定を使えるようにする（#3902）。

--- a/docs/skill-design/skill-authoring-guidelines.md
+++ b/docs/skill-design/skill-authoring-guidelines.md
@@ -116,6 +116,8 @@ frontmatter の `purpose:` は必須であり、次の 7 語のいずれか 1 �
 mode と modifier は次のように分けて記載する。
 
 - mode は `## モード判定` 節の `| mode | 読む reference |` 表に載せる
+- mode ごとの手順は skill ディレクトリからの相対パス `references/<flag>.md` に 1 mode 1 ファイルで置く。`<flag>` は `--` を除いたフラグ名と一致させ、複数 mode で共有しない
+- SKILL.md 本体には mode 判定と全 mode 共通の前提・完了条件を残し、mode 固有の手順と完了条件は対応する reference を必要になった時点で読む
 - modifier は `## 修飾フラグ` 節の別表に載せ、mode 表には載せない
 - 両者とも `--` 前置を必須とし、`mode=<name>` 形式や bare word の名前を新規に導入しない。本リポジトリの skill は日本語の自然言語引数を取るため、bare word は通常の引数と衝突し、静的に判別できない
 - 値を伴う variant も名前付き引数として表現する

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -1,4 +1,4 @@
-"""yt-skills lint — SKILL.md の軽量契約検証 (Issues #2096, #3749)。
+"""yt-skills lint — SKILL.md の軽量契約検証 (Issues #2096, #3749, #3750)。
 
 skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず秒単位で回すための
 サブコマンド。検証ロジックは domains.skills.inventory を単一ソースとし、既存の
@@ -12,6 +12,7 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
        (値内の `: ` がマッピング区切りと誤解釈されるのを防ぐ規約)
     5. description の値なしフラグが mode / modifier 表のどちらか一方に属する
     6. mode は 5 個以下で、2 個以上の同時指定を停止する旨がある
+    7. mode ごとにフラグ名と対応する実在 reference を 1 ファイル持つ
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ _ALLOWLISTED_VIOLATIONS = frozenset(
     {
         ("flop-analysis", "flag_tables_missing"),
         ("shadcn", "flag_tables_missing"),
+        ("setup", "mode_reference_name_mismatch"),
     }
 )
 

--- a/src/youtube_automation/domains/skills/inventory.py
+++ b/src/youtube_automation/domains/skills/inventory.py
@@ -14,6 +14,7 @@ _MARKDOWN_HEADING = re.compile(r"^(?P<marks>#{1,6})\s+\S")
 _DESCRIPTION_FLAG = re.compile(r"(?<![\w-])--[a-z0-9]+(?:-[a-z0-9]+)*(?![a-z0-9-])")
 _VALUE_PLACEHOLDER = re.compile(r"\s*<[^>\n]+>")
 _TABLE_FLAG = re.compile(r"^`(?P<flag>--[a-z0-9]+(?:-[a-z0-9]+)*)`$")
+_TABLE_REFERENCE = re.compile(r"^`(?P<reference>[^`]+)`$")
 _MODE_HEADING = "## モード判定"
 _MODIFIER_HEADING = "## 修飾フラグ"
 _MAX_MODES = 5
@@ -95,10 +96,10 @@ def lint_skill_contract(skill_dir: Path) -> list[SkillLintViolation]:
     parsed = parse_frontmatter(text)
     if not isinstance(parsed, dict) or not isinstance(parsed["description"], str):
         raise AssertionError("lint_frontmatter_text accepted an invalid frontmatter shape")
-    return _lint_flag_contract(text, parsed["description"])
+    return _lint_flag_contract(skill_dir, text, parsed["description"])
 
 
-def _lint_flag_contract(text: str, description: str) -> list[SkillLintViolation]:
+def _lint_flag_contract(skill_dir: Path, text: str, description: str) -> list[SkillLintViolation]:
     description_flags = _extract_description_flags(description)
     mode_section = _optional_markdown_section(text, _MODE_HEADING)
     modifier_section = _optional_markdown_section(text, _MODIFIER_HEADING)
@@ -111,7 +112,8 @@ def _lint_flag_contract(text: str, description: str) -> list[SkillLintViolation]
             )
         ]
 
-    mode_rows = _extract_table_flags(mode_section, ("mode", "読む reference"))
+    mode_entries = _extract_mode_entries(mode_section)
+    mode_rows = tuple(flag for flag, _reference in mode_entries)
     modifier_rows = _extract_table_flags(modifier_section, ("modifier", "効果"))
     mode_flags = set(mode_rows)
     modifier_flags = set(modifier_rows)
@@ -145,6 +147,7 @@ def _lint_flag_contract(text: str, description: str) -> list[SkillLintViolation]
                 "## モード判定に、2 個以上の同時指定を停止する旨がありません",
             )
         )
+    violations.extend(_lint_mode_references(skill_dir, mode_entries))
     return violations
 
 
@@ -164,6 +167,18 @@ def _optional_markdown_section(text: str, heading: str) -> str | None:
 
 
 def _extract_table_flags(section: str | None, expected_header: tuple[str, str]) -> tuple[str, ...]:
+    return tuple(flag for flag, _value in _extract_table_rows(section, expected_header))
+
+
+def _extract_mode_entries(section: str | None) -> tuple[tuple[str, str], ...]:
+    entries: list[tuple[str, str]] = []
+    for flag, value in _extract_table_rows(section, ("mode", "読む reference")):
+        match = _TABLE_REFERENCE.fullmatch(value)
+        entries.append((flag, match.group("reference") if match is not None else value))
+    return tuple(entries)
+
+
+def _extract_table_rows(section: str | None, expected_header: tuple[str, str]) -> tuple[tuple[str, str], ...]:
     if section is None:
         return ()
     lines = [line.strip() for line in section.splitlines()]
@@ -173,10 +188,10 @@ def _extract_table_flags(section: str | None, expected_header: tuple[str, str]) 
     except ValueError:
         return ()
 
-    flags: list[str] = []
+    rows: list[tuple[str, str]] = []
     for line in lines[header_index + 2 :]:
         if not line.startswith("|"):
-            if flags:
+            if rows:
                 break
             continue
         cells = [cell.strip() for cell in line.strip("|").split("|")]
@@ -184,8 +199,48 @@ def _extract_table_flags(section: str | None, expected_header: tuple[str, str]) 
             continue
         match = _TABLE_FLAG.fullmatch(cells[0])
         if match is not None:
-            flags.append(match.group("flag"))
-    return tuple(flags)
+            rows.append((match.group("flag"), cells[1]))
+    return tuple(rows)
+
+
+def _lint_mode_references(skill_dir: Path, mode_entries: tuple[tuple[str, str], ...]) -> list[SkillLintViolation]:
+    violations: list[SkillLintViolation] = []
+    modes_by_reference: dict[str, list[str]] = {}
+
+    for flag, reference in mode_entries:
+        modes_by_reference.setdefault(reference, []).append(flag)
+        expected = f"references/{flag.removeprefix('--')}.md"
+        if Path(reference).is_absolute():
+            violations.append(
+                SkillLintViolation(
+                    "mode_reference_not_relative",
+                    f"{flag} の reference は skill ディレクトリからの相対パスで書いてください: {reference}",
+                )
+            )
+        elif not (skill_dir / reference).is_file():
+            violations.append(
+                SkillLintViolation(
+                    "mode_reference_missing",
+                    f"{flag} の reference が見つかりません: {reference}",
+                )
+            )
+        if reference != expected:
+            violations.append(
+                SkillLintViolation(
+                    "mode_reference_name_mismatch",
+                    f"{flag} の reference がフラグ名と一致しません: {reference} (期待: {expected})",
+                )
+            )
+
+    for reference, flags in modes_by_reference.items():
+        if len(flags) > 1:
+            violations.append(
+                SkillLintViolation(
+                    "mode_reference_shared",
+                    f"mode ごとに別の reference が必要です: {', '.join(flags)} が {reference} を共有しています",
+                )
+            )
+    return violations
 
 
 def _states_exclusive_stop(section: str) -> bool:

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -14,6 +14,7 @@ import pytest
 from youtube_automation.commands.system import skills_sync
 from youtube_automation.commands.system.skills_sync import build_parser, main
 from youtube_automation.domains.skills.inventory import lint_frontmatter_text, lint_skill
+from tests.helpers.paths import REPO_ROOT
 
 _VALID_SKILL_MD = '---\nname: good-skill\ndescription: "Use when: 良い skill のとき"\n---\n\n# good\n'
 
@@ -148,6 +149,44 @@ description: "Use --since"
     out = capsys.readouterr().out
     assert "--since" in out
     assert "未登録" in out
+
+
+def test_cli_lint_missing_mode_reference_reports_skill_flag_and_path(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(
+        skills_dir,
+        "mode-skill",
+        """---
+name: mode-skill
+description: "Use --fast"
+---
+
+## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `references/fast.md` |
+""",
+    )
+
+    assert main(["lint", "mode-skill"]) == 1
+    out = capsys.readouterr().out
+    assert "mode-skill: --fast の reference が見つかりません: references/fast.md" in out
+
+
+def test_cli_lint_analytics_mode_references_are_valid(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: REPO_ROOT)
+
+    assert main(["lint", "analytics"]) == 0
+    out = capsys.readouterr().out
+    assert "lint 合格: 1 skill" in out
+    assert "analytics:" not in out
 
 
 def test_cli_lint_single_skill_filters_targets(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -11,10 +11,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.system import skills_sync
 from youtube_automation.commands.system.skills_sync import build_parser, main
 from youtube_automation.domains.skills.inventory import lint_frontmatter_text, lint_skill
-from tests.helpers.paths import REPO_ROOT
 
 _VALID_SKILL_MD = '---\nname: good-skill\ndescription: "Use when: 良い skill のとき"\n---\n\n# good\n'
 

--- a/tests/domains/skills/test_inventory.py
+++ b/tests/domains/skills/test_inventory.py
@@ -230,3 +230,115 @@ def test_lint_skill_requires_exclusive_mode_instruction(tmp_path: Path) -> None:
     violations = lint_skill(skill_dir)
 
     assert any("2 個以上" in violation and "停止" in violation for violation in violations)
+
+
+def test_lint_skill_reports_missing_mode_reference(tmp_path: Path) -> None:
+    skill_dir = _write_flag_skill(
+        tmp_path,
+        "sample",
+        "Use --fast",
+        """## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `references/fast.md` |
+""",
+    )
+
+    violations = lint_skill(skill_dir)
+
+    assert "--fast の reference が見つかりません: references/fast.md" in violations
+
+
+def test_lint_skill_reports_absolute_mode_reference(tmp_path: Path) -> None:
+    skill_dir = _write_flag_skill(
+        tmp_path,
+        "sample",
+        "Use --fast",
+        """## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `/tmp/fast.md` |
+""",
+    )
+
+    violations = lint_skill(skill_dir)
+
+    assert any("--fast" in violation and "相対パス" in violation for violation in violations)
+
+
+def test_lint_skill_reports_mode_reference_name_mismatch(tmp_path: Path) -> None:
+    skill_dir = _write_flag_skill(
+        tmp_path,
+        "sample",
+        "Use --fast",
+        """## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `references/details.md` |
+""",
+    )
+    reference = skill_dir / "references" / "details.md"
+    reference.parent.mkdir()
+    reference.write_text("details", encoding="utf-8")
+
+    violations = lint_skill(skill_dir)
+
+    assert any(
+        "--fast" in violation and "references/fast.md" in violation and "一致" in violation for violation in violations
+    )
+
+
+def test_lint_skill_reports_shared_mode_reference(tmp_path: Path) -> None:
+    skill_dir = _write_flag_skill(
+        tmp_path,
+        "sample",
+        "Use --fast / --safe",
+        """## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `references/fast.md` |
+| `--safe` | `references/fast.md` |
+""",
+    )
+    reference = skill_dir / "references" / "fast.md"
+    reference.parent.mkdir()
+    reference.write_text("details", encoding="utf-8")
+
+    violations = lint_skill(skill_dir)
+
+    assert any("--fast" in violation and "--safe" in violation and "共有" in violation for violation in violations)
+
+
+def test_lint_skill_accepts_one_existing_named_reference_per_mode(tmp_path: Path) -> None:
+    skill_dir = _write_flag_skill(
+        tmp_path,
+        "sample",
+        "Use --fast / --safe",
+        """## モード判定
+
+2 個以上の同時指定なら停止する。
+
+| mode | 読む reference |
+|---|---|
+| `--fast` | `references/fast.md` |
+| `--safe` | `references/safe.md` |
+""",
+    )
+    references = skill_dir / "references"
+    references.mkdir()
+    (references / "fast.md").write_text("fast", encoding="utf-8")
+    (references / "safe.md").write_text("safe", encoding="utf-8")
+
+    assert lint_skill(skill_dir) == []


### PR DESCRIPTION
## Summary
- mode 表から reference を抽出し、相対パス・実在・命名・非共有を検証
- 欠落 reference を skill／mode／期待パス付きで報告
- 既存命名差を明示 allowlist に隔離し、ガイドラインを更新

Closes #3750