### PR TITLE
feat(skills): SKILL.mdの400行上限を検証する (#3793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `yt-skills lint` で SKILL.md 本体の 400 行上限を検証し、既存の上限超過は現行行数までの allowlist として報告しながら新規超過・肥大化を拒否する（#3793）。
+
 - `feat(skills)`: 全 55 skill に 7 語 enum の `purpose` を付与し、`yt-skills lint` で欠落・enum 外・複数値を拒否する（#3788）。
 
 - `feat(skills)`: 全 SKILL.md に機械抽出可能な `委譲先` 宣言を追加し、`yt-skills delegation` で委譲深さ・最長経路・循環を計測、lint で宣言欠落と循環を拒否する（#3751）。

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -1,8 +1,8 @@
-"""yt-skills lint — SKILL.md の軽量契約検証 (Issues #2096, #3749, #3750, #3751)。
+"""yt-skills lint — SKILL.md の軽量契約検証 (Issues #2096, #3749, #3750, #3751, #3793)。
 
 skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず秒単位で回すための
-サブコマンド。検証ロジックは domains.skills.inventory を単一ソースとし、既存の
-回帰テストも同じ domain API を使う。
+サブコマンド。frontmatter / flag の検証ロジックは domains.skills.inventory を
+単一ソースとし、既存の回帰テストも同じ domain API を使う。
 
 検証内容 (strict YAML 契約 + skill frontmatter / mode 規約):
     1. SKILL.md が frontmatter デリミタ `---` で始まり、閉じ `---` を持つ
@@ -15,14 +15,33 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
     7. mode は 5 個以下で、2 個以上の同時指定を停止する旨がある
     8. mode ごとにフラグ名と対応する実在 reference を 1 ファイル持つ
     9. 委譲先の宣言行が存在し、有向グラフに循環がない
+    10. SKILL.md 本体が 400 行以下である
 """
 
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
+from typing import Final
 
 from youtube_automation.commands.system.skills_sync._delegation import DelegationGraph, format_path
-from youtube_automation.domains.skills.inventory import SkillInventory, lint_skill_contract
+from youtube_automation.domains.skills.inventory import SkillInventory, SkillLintViolation, lint_skill_contract
+
+_SKILL_MD_MAX_LINES: Final[int] = 400
+_SKILL_MD_LINE_LIMIT_VIOLATION: Final[str] = "skill_md_line_limit_exceeded"
+
+# 統合前から上限を超えている skill は、現状より悪化させない範囲で段階的に是正する。
+# channel-new は当初 450 行だったが既に上限内へ短縮されたため、猶予から除外済み。
+_ALLOWLISTED_SKILL_MD_LINE_COUNTS: Final[dict[str, int]] = {
+    "automation-release": 633,
+    "automation-update": 566,
+    "collection-ideate": 532,
+    "loop-video": 405,
+    "masterup": 561,
+    "suno": 589,
+    "thumbnail": 743,
+    "wf-new": 478,
+}
 
 _ALLOWLISTED_VIOLATIONS = frozenset(
     {
@@ -31,6 +50,31 @@ _ALLOWLISTED_VIOLATIONS = frozenset(
         ("setup", "mode_reference_name_mismatch"),
     }
 )
+
+
+def _lint_skill_md_line_count(skill_dir: Path) -> tuple[SkillLintViolation | None, int]:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return None, 0
+    line_count = len(skill_md.read_text(encoding="utf-8").splitlines())
+    if line_count <= _SKILL_MD_MAX_LINES:
+        return None, line_count
+    return (
+        SkillLintViolation(
+            _SKILL_MD_LINE_LIMIT_VIOLATION,
+            f"SKILL.md が {line_count} 行です (上限 {_SKILL_MD_MAX_LINES} 行 — references/ へ切り出してください)",
+        ),
+        line_count,
+    )
+
+
+def _is_allowlisted(name: str, violation: SkillLintViolation, line_count: int) -> bool:
+    if (name, violation.identifier) in _ALLOWLISTED_VIOLATIONS:
+        return True
+    if violation.identifier != _SKILL_MD_LINE_LIMIT_VIOLATION:
+        return False
+    allowed_line_count = _ALLOWLISTED_SKILL_MD_LINE_COUNTS.get(name)
+    return allowed_line_count is not None and line_count <= allowed_line_count
 
 
 def cmd_lint(args: argparse.Namespace) -> int:
@@ -55,17 +99,19 @@ def cmd_lint(args: argparse.Namespace) -> int:
 
     failed_skills: set[str] = set()
     for name in targets:
-        violations = lint_skill_contract(root / name)
+        skill_dir = root / name
+        violations = lint_skill_contract(skill_dir)
+        line_violation, line_count = _lint_skill_md_line_count(skill_dir)
+        if line_violation is not None:
+            violations.append(line_violation)
         if name in graph.missing:
             print(f"{name}: `委譲先` 行がありません")
             failed_skills.add(name)
-        blocking = [
-            violation for violation in violations if (name, violation.identifier) not in _ALLOWLISTED_VIOLATIONS
-        ]
+        blocking = [violation for violation in violations if not _is_allowlisted(name, violation, line_count)]
         if blocking:
             failed_skills.add(name)
         for violation in violations:
-            suffix = " [allowlist]" if (name, violation.identifier) in _ALLOWLISTED_VIOLATIONS else ""
+            suffix = " [allowlist]" if _is_allowlisted(name, violation, line_count) else ""
             print(f"{name}: {violation.message}{suffix}")
 
     target_set = set(targets)

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -37,6 +37,11 @@ def _write_skill(skills_dir: Path, name: str, content: str) -> None:
     (skills_dir / name / "SKILL.md").write_text(content, encoding="utf-8")
 
 
+def _skill_md_with_line_count(line_count: int, *, name: str = "good-skill") -> str:
+    lines = _VALID_SKILL_MD.replace("good-skill", name).splitlines()
+    return "\n".join([*lines, *(["本文"] * (line_count - len(lines)))])
+
+
 @pytest.fixture
 def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """tmp_path にダミーの skills ツリーを仕込み editable fallback を向ける。"""
@@ -226,6 +231,60 @@ purpose: 振り返る
     out = capsys.readouterr().out
     assert "--since" in out
     assert "未登録" in out
+
+
+def test_cli_lint_skill_md_over_400_lines_reports_count_and_exits_nonzero(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "long-skill", _skill_md_with_line_count(401, name="long-skill"))
+
+    assert main(["lint", "long-skill"]) == 1
+    out = capsys.readouterr().out
+    assert "long-skill: SKILL.md が 401 行です (上限 400 行 — references/ へ切り出してください)" in out
+
+
+def test_cli_lint_skill_md_at_400_lines_exits_zero(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "limit-skill", _skill_md_with_line_count(400, name="limit-skill"))
+
+    assert main(["lint", "limit-skill"]) == 0
+    out = capsys.readouterr().out
+    assert "limit-skill: SKILL.md" not in out
+
+
+def test_cli_lint_allowlisted_skill_md_line_violation_is_reported_without_failing(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "thumbnail", _skill_md_with_line_count(401, name="thumbnail"))
+
+    assert main(["lint", "thumbnail"]) == 0
+    out = capsys.readouterr().out
+    assert "thumbnail: SKILL.md が 401 行です" in out
+    assert "[allowlist]" in out
+
+
+def test_cli_lint_allowlisted_skill_md_growth_exits_nonzero(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "thumbnail", _skill_md_with_line_count(744, name="thumbnail"))
+
+    assert main(["lint", "thumbnail"]) == 1
+    out = capsys.readouterr().out
+    assert "thumbnail: SKILL.md が 744 行です" in out
+    assert "[allowlist]" not in out
+
+
+def test_cli_lint_does_not_count_reference_lines(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    reference = skills_dir / "good-skill" / "references" / "details.md"
+    reference.parent.mkdir()
+    reference.write_text("\n".join(["詳細"] * 500), encoding="utf-8")
+
+    assert main(["lint", "good-skill"]) == 0
+    assert "SKILL.md が" not in capsys.readouterr().out
 
 
 def test_cli_lint_missing_mode_reference_reports_skill_flag_and_path(


### PR DESCRIPTION
## 概要

SKILL.md 本体の 400 行上限を `yt-skills lint` で検証します。既存超過は現在行数を cap とする allowlist で猶予し、追加肥大化を拒否します。

## 検証

- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run yt-skills lint`
- `nix develop --command uv run pytest -n auto`（8965 passed, 3 skipped）

Closes #3793