### PR TITLE
feat(skills): purpose別カタログを生成する (#3801)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           - name: Ruff format check
             if: needs.changes.outputs.python == 'true'
             run: nix develop --command uv run ruff format --check .
+      - name: Skill catalog check
+        if: needs.changes.outputs.python == 'true'
+        run: nix develop --command uv run yt-skills catalog --check
 
   test:
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: frontmatter の `purpose` から PDCA 順の `docs/skill-catalog.md` を生成し、`yt-skills catalog --check` と CI で最新性を検証する（#3801）。
+
 - `feat(skills)`: `yt-skills lint` で SKILL.md 本体の 400 行上限を検証し、既存の上限超過は現行行数までの allowlist として報告しながら新規超過・肥大化を拒否する（#3793）。
 
 - `feat(skills)`: 全 55 skill に 7 語 enum の `purpose` を付与し、`yt-skills lint` で欠落・enum 外・複数値を拒否する（#3788）。

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -1,0 +1,81 @@
+# Skill catalog
+
+<!-- `uv run yt-skills catalog` により生成。手で編集しないでください。 -->
+
+PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進める → 作る → 公開する / Check / Act = 振り返る
+
+## 準備する
+
+- `/automation-release` — Use when 本リポジトリの新規リリースを作成するとき。
+- `/automation-update` — Use when 下流リポジトリで automation を最新リリースへ追従させるとき。
+- `/channel-new` — Use when 既存 YouTube チャンネルを取り込むとき、収集済み benchmark/comments からチャンネル全体を分析するとき、方向性を再検討するとき、config を再生成するとき、または YouTube 側設定を同期するとき。
+- `/ext-install` — Use when Chrome 拡張（suno-helper / distrokid-helper / community-helper）のインストール・更新をするとき。
+- `/setup` — Use when ツール導入と GCP / OAuth の API 設定をセットアップ・再診断するとき、または新規 YouTube チャンネルを Step 1〜10 で開設するとき。
+- `/shadcn` — Manages shadcn components and projects — adding, searching, fixing, debugging, styling, and composing UI, including chat interfaces. Provides project context, component docs, and usage examples. Applies when working with shadcn/ui, component registries, presets, --preset codes, or any project with a components.json file. Also triggers for 'shadcn init', 'create an app with --preset', or 'switch to --preset'.
+
+## 調べる
+
+- `/benchmark` — Use when 競合チャンネルのベンチマークデータを最新化するとき。
+- `/discover-competitors` — Use when YouTube Data API で追加競合候補を自動発掘・ランキング化するとき。
+- `/market-research` — Use when 既存チャンネルから任意に市場を調べ、TTP 入替候補やニッチ仮説を根拠付きで比較するとき。
+- `/thumbnail-research` — Use when 収集済み競合サムネイルだけを再生数上位群 vs 下位群で深掘りし、勝ちパターンを抽出するとき。
+- `/viewer-voice` — Use when 競合コメントの収集・分析で視聴者インサイトを抽出するとき。
+
+## 決める
+
+- `/audience-persona-design` — Use when ターゲット視聴者を第一ペルソナとして設計・見直しするとき。
+- `/creative-constraints` — Use when ペルソナと視聴シーンを、音・映像・サムネ・タイトル・測定の機械検証可能なチャンネル制約へ翻訳するとき。
+- `/viewing-scene` — Use when 視聴シーン（いつ・どこで・なぜ聴くか）を検証・定義するとき。
+
+## 進める
+
+- `/automation-schedule` — Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。
+- `/collection-ideate` — Use when 新コレクションの企画・テーマ選定をデータドリブンに行うとき。
+- `/streaming` — Use when ライブ配信用 Vultr VPS・動画配信本体を Terraform で構築・運用・トラブルシュートするとき。
+- `/wf-auto` — Use when 正規入口から collection の有無を問わず、企画開始または未完了地点から制作・公開・post-publish まで状態駆動で継続・再開するとき。
+- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき（ディレクトリ未作成）。
+- `/wf-new-batch` — Use when 複数の新規コレクションを相互差別化して一括企画し、正規 /wf-new を順次実行・再開するとき。
+- `/wf-next` — Use when 既存コレクション（collections/planning/）を一段進めるとき。
+- `/wf-status` — Use when コレクション制作の進捗を読むだけで確認するとき（実行しない）。
+
+## 作る
+
+- `/loop-video` — Use when テキストなし main.png/jpg から Veo または Gemini Omni Flash でループ動画背景を生成するとき。
+- `/lyria` — Use when Vertex AI Lyria 3 でマスター音源を自動生成するとき。
+- `/masterup` — Use when Suno UI で生成した曲のプレイリストを一括 DL + マスター化するとき。
+- `/short` — Use when collection 型（BGM テイスター）チャンネルでショートを生成・投稿するとき。
+- `/short-release` — Use when release 型（楽曲リリース）チャンネルで JP+EN の 9:16 クリップを生成するとき。
+- `/short-thumbnail` — Use when ショート用 9:16 サムネ作成、または short.png のループ動画化をするとき。
+- `/suno` — Use when Suno UI 投入用の音楽プロンプトを生成するとき。
+- `/suno-helper` — Use when Suno UI に投入する曲をブラウザで連続生成 + playlist 追加 + 一括ダウンロードしたいとき。
+- `/suno-lyric` — Use when Suno ボーカル曲の歌詞を生成するとき。
+- `/thumbnail` — Use when コレクションの YouTube サムネイル（thumbnail.jpg）を CTR 最適化し、textless main.png/jpg を先行生成して実フォント合成するとき。
+- `/thumbnail-compare` — Use when 自チャンネルの生成済みサムネイルを競合と並べて 320px 視認性を比較検証するとき。
+- `/thumbnail-iterate` — Use when 伸びた動画を起点にサムネの勝因を分解し、統制した A/B 比較で次の勝ちサムネへ更新するとき。
+- `/thumbnail-test` — Use when 長尺動画で YouTube Studio のサムネイル A/B テストを単独で設計し、結果を記録するとき。
+- `/video-description` — Use when YouTube 概要欄を Complete Collection 形式で自動生成するとき。
+- `/videoup` — Use when 音声ファイルが揃い動画生成が必要なとき。
+
+## 公開する
+
+- `/comments-reply` — Use when 公開済み YouTube 動画のコメントへ自動返信するとき。
+- `/community-draft` — Use when コレクションの YouTube コミュニティ投稿を JSON バッチ生成するとき。
+- `/community-post` — Use when コミュニティ投稿テキスト生成から Studio 起動まで単独実行するとき。
+- `/distrokid-helper` — Use when コレクションの楽曲を DistroKid 配信用に準備し、distrokid-helper Chrome 拡張へ渡すローカルサーバーを起動したいとき（30-distrokid 生成 / disc 分割 / metadata.md / ジャケット 3000×3000 新規生成 / uv run yt-collection-serve 起動）。
+- `/live-chat-reply` — Use when 配信中の YouTube ライブチャットへ常駐 daemon で自動返信するとき。
+- `/live-clean` — Use when live コレクションの大容量メディアを削除して容量回復するとき、または collections 配下の tmp/ 残骸を掃除するとき。
+- `/pinned-comment` — Use when 新規動画へオーナー固定コメントを自動投稿するとき。
+- `/playlist` — Use when プレイリストの作成・割り当て・確認をするとき。
+- `/post-publish` — Use when 動画公開直後の community-post → pinned-comment → metadata-audit を承認ゲート付きで一括実行・途中再開するとき。
+- `/video-upload` — Use when コレクションの動画または release 型（単曲リリース）の楽曲リリース動画が完成し、YouTubeへのアップロード自動化が必要なとき。
+
+## 振り返る
+
+- `/alignment-check` — Use when 音楽ムード × サムネ × タイトルの整合性を監査するとき。
+- `/analytics` — Use when YouTube Analytics の収集・分析・レポート表示を一括実行または一段だけ実行するとき。
+- `/channel-status` — Use when チャンネルの YouTube 統計（登録者・再生回数）を取得するとき。
+- `/flop-analysis` — Use when 公開済み動画が伸びなかった原因を video_id、collection、または --since で切り分け、postmortem.md に出力するとき。
+- `/metadata-audit` — Use when ローカル descriptions.md と YouTube メタデータの整合を監査するとき。
+- `/skill-feedback` — Use when 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を構造化記録するとき、または記録済み feedback を上流 issue に還流するとき。
+- `/value-loop-audit` — Use when チャンネルの価値ループ（シーン定義→制約翻訳→公開前ゲート→指標還流）の整備状況を読み取り専用で横断診断するとき。
+- `/video-analyze` — Use when 動画本体の中身（フック構造・シーン・BGM 展開）を Gemini で解析するとき。

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -10,6 +10,7 @@ Subcommands:
     sync   : --target に展開 (--symlink でシンボリックリンク, --force で上書き)
     diff   : 同梱版と target の差分を表示
     lint   : SKILL.md frontmatter を検証 (strict YAML / name・description 非空 / double-quote)
+    catalog: purpose 別の skill catalog を生成・検証
 
 Asset 種別 (`--asset`):
     all                 : デフォルト。下記すべての asset を一括処理する
@@ -233,6 +234,7 @@ from youtube_automation.commands.system.skills_sync._ops import _ensure_target_p
 from youtube_automation.commands.system.skills_sync._ops import _has_diff as _has_diff  # noqa: E402
 from youtube_automation.commands.system.skills_sync._ops import _prune_orphans as _prune_orphans  # noqa: E402
 from youtube_automation.commands.system.skills_sync._ops import _symlink_entry as _symlink_entry  # noqa: E402
+from youtube_automation.commands.system.skills_sync._catalog import cmd_catalog as cmd_catalog  # noqa: E402
 from youtube_automation.commands.system.skills_sync._sync import cmd_sync as cmd_sync  # noqa: E402
 from youtube_automation.commands.system.skills_sync._diff import cmd_diff as cmd_diff  # noqa: E402
 from youtube_automation.commands.system.skills_sync._delegation import cmd_delegation as cmd_delegation  # noqa: E402

--- a/src/youtube_automation/commands/system/skills_sync/_catalog.py
+++ b/src/youtube_automation/commands/system/skills_sync/_catalog.py
@@ -1,0 +1,93 @@
+"""Generate the purpose-based skill catalog."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+from pathlib import Path
+from typing import Final
+
+from youtube_automation.domains.skills.inventory import SkillInventory
+
+_PURPOSE_ORDER: Final[tuple[str, ...]] = (
+    "準備する",
+    "調べる",
+    "決める",
+    "進める",
+    "作る",
+    "公開する",
+    "振り返る",
+)
+_CATALOG_PATH: Final[Path] = Path("docs/skill-catalog.md")
+
+
+def _description_summary(description: str) -> str:
+    normalized = " ".join(description.split())
+    first, separator, _remainder = normalized.partition("。")
+    return first + separator
+
+
+def render_catalog(inventory: SkillInventory) -> str:
+    """Render a deterministic Markdown catalog from skill frontmatter."""
+    groups: dict[str, list[tuple[str, str]]] = {purpose: [] for purpose in _PURPOSE_ORDER}
+    for skill_dir in inventory.skill_directories():
+        frontmatter = inventory.frontmatter(skill_dir.name)
+        if not isinstance(frontmatter, dict):
+            raise ValueError(f"{skill_dir.name}: frontmatter が dict ではありません")
+        name = frontmatter.get("name")
+        description = frontmatter.get("description")
+        purpose = frontmatter.get("purpose")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{skill_dir.name}: name が非空文字列ではありません")
+        if not isinstance(description, str) or not description.strip():
+            raise ValueError(f"{skill_dir.name}: description が非空文字列ではありません")
+        if not isinstance(purpose, str) or purpose not in groups:
+            raise ValueError(f"{skill_dir.name}: purpose が7語分類に含まれません: {purpose}")
+        groups[purpose].append((name, _description_summary(description)))
+
+    lines = [
+        "# Skill catalog",
+        "",
+        "<!-- `uv run yt-skills catalog` により生成。手で編集しないでください。 -->",
+        "",
+        "PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進める → 作る → 公開する / Check / Act = 振り返る",
+        "",
+    ]
+    for purpose in _PURPOSE_ORDER:
+        lines.extend((f"## {purpose}", ""))
+        lines.extend(f"- `/{name}` — {summary}" for name, summary in sorted(groups[purpose]))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _catalog_diff(actual: str, expected: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            actual.splitlines(keepends=True),
+            expected.splitlines(keepends=True),
+            fromfile=str(_CATALOG_PATH),
+            tofile=f"generated:{_CATALOG_PATH}",
+        )
+    )
+
+
+def cmd_catalog(args: argparse.Namespace) -> int:
+    """Generate the catalog, or verify that the checked-in catalog is current."""
+    from youtube_automation.commands.system.skills_sync import _asset_root, _editable_root
+
+    inventory = SkillInventory(_asset_root("skills"))
+    expected = render_catalog(inventory)
+    output_path = _editable_root() / _CATALOG_PATH
+
+    if args.check:
+        actual = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
+        if actual != expected:
+            print(_catalog_diff(actual, expected), end="")
+            return 1
+        print(f"skill catalog は最新です: {_CATALOG_PATH}")
+        return 0
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(expected, encoding="utf-8")
+    print(f"skill catalog を生成しました: {_CATALOG_PATH}")
+    return 0

--- a/src/youtube_automation/commands/system/skills_sync/_parser.py
+++ b/src/youtube_automation/commands/system/skills_sync/_parser.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 from youtube_automation.commands.system.skills_sync import _ASSET_SPECS, _guard_target_with_all, cmd_list
+from youtube_automation.commands.system.skills_sync._catalog import cmd_catalog
 from youtube_automation.commands.system.skills_sync._delegation import cmd_delegation
 from youtube_automation.commands.system.skills_sync._diff import cmd_diff
 from youtube_automation.commands.system.skills_sync._lint import cmd_lint
@@ -127,5 +128,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_delegation = sub.add_parser("delegation", help="SKILL.md の委譲深さと最長経路を表示")
     p_delegation.set_defaults(func=cmd_delegation, asset="skills")
+
+    p_catalog = sub.add_parser("catalog", help="purpose 別の skill catalog を生成・検証")
+    p_catalog.add_argument(
+        "--check",
+        action="store_true",
+        help="docs/skill-catalog.md が最新か検証し、差分があれば非 0 で終了する",
+    )
+    p_catalog.set_defaults(func=cmd_catalog, asset="skills")
 
     return parser

--- a/tests/commands/system/test_skills_catalog.py
+++ b/tests/commands/system/test_skills_catalog.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.commands.system import skills_sync
+from youtube_automation.commands.system.skills_sync import build_parser, main
+
+_PURPOSES = ("準備する", "調べる", "決める", "進める", "作る", "公開する", "振り返る")
+
+
+def _write_skill(skills_dir: Path, name: str, purpose: str, description: str) -> None:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f'---\nname: {name}\ndescription: "{description}"\npurpose: {purpose}\n---\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def catalog_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    skills_dir = tmp_path / ".claude" / "skills"
+    for index, purpose in enumerate(_PURPOSES):
+        _write_skill(skills_dir, f"skill-{index}", purpose, f"{purpose}の説明。二文目は載せない。")
+    _write_skill(skills_dir, "alpha", "作る", "先頭の説明。続き。")
+    monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
+    return tmp_path
+
+
+def test_catalog_parser_registers_check_flag() -> None:
+    args = build_parser().parse_args(["catalog", "--check"])
+
+    assert args.check is True
+    assert args.asset == "skills"
+
+
+def test_catalog_generates_all_purpose_sections_in_pdca_order(catalog_repo: Path) -> None:
+    assert main(["catalog"]) == 0
+
+    catalog = (catalog_repo / "docs" / "skill-catalog.md").read_text(encoding="utf-8")
+    positions = [catalog.index(f"## {purpose}") for purpose in _PURPOSES]
+    assert positions == sorted(positions)
+    assert "PDCA 対応" in catalog
+    assert "準備 = 準備する" in catalog
+    assert "Plan = 調べる → 決める" in catalog
+    assert "Do = 進める → 作る → 公開する" in catalog
+    assert "Check / Act = 振り返る" in catalog
+
+
+def test_catalog_sorts_skills_by_name_and_summarizes_first_sentence(catalog_repo: Path) -> None:
+    assert main(["catalog"]) == 0
+
+    catalog = (catalog_repo / "docs" / "skill-catalog.md").read_text(encoding="utf-8")
+    create_section = catalog.split("## 作る\n", maxsplit=1)[1].split("\n## 公開する", maxsplit=1)[0]
+    assert create_section.index("`/alpha`") < create_section.index("`/skill-4`")
+    assert "- `/alpha` — 先頭の説明。" in create_section
+    assert "続き。" not in create_section
+
+
+def test_catalog_check_succeeds_immediately_after_generation(catalog_repo: Path) -> None:
+    assert main(["catalog"]) == 0
+
+    assert main(["catalog", "--check"]) == 0
+
+
+def test_catalog_check_displays_diff_and_fails_for_stale_output(
+    catalog_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["catalog"]) == 0
+    catalog_path = catalog_repo / "docs" / "skill-catalog.md"
+    catalog_path.write_text(catalog_path.read_text(encoding="utf-8") + "手書き変更\n", encoding="utf-8")
+    capsys.readouterr()
+
+    assert main(["catalog", "--check"]) == 1
+    output = capsys.readouterr().out
+    assert "--- docs/skill-catalog.md" in output
+    assert "+++ generated:docs/skill-catalog.md" in output
+    assert "-手書き変更" in output


### PR DESCRIPTION
## 概要

`yt-skills catalog` と `--check` を追加し、frontmatter の purpose から PDCA 順の `docs/skill-catalog.md` を生成します。CI で生成物の最新性も検証します。

## 検証

- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command uv run yt-skills lint`
- `nix develop --command uv run yt-skills catalog --check`
- `PYTHONDONTWRITEBYTECODE=1 nix develop --command uv run pytest -n auto`（8970 passed, 3 skipped）

Closes #3801