### PR TITLE
feat(skills): wf-autoをwf-new --autoへ統合する (#3740)

### DIFF
--- a/.claude/skills/automation-schedule/SKILL.md
+++ b/.claude/skills/automation-schedule/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when チャンネルの定期制作スケジュール（workfl
 ## 前後工程
 
 - `前工程`: `/setup --channel`, `/setup`
-- `後工程`: `/wf-auto`, `/wf-next`
+- `後工程`: `/wf-new`, `/wf-next`
 - `委譲先`: `なし`
 
 ## 成果物
@@ -63,7 +63,7 @@ uv run python .claude/skills/automation-schedule/references/schedule_backend.py 
 ```
 
 1. `product-codex` / `product-claude` を既定候補にする。判定不能時だけユーザーに製品を確認する。
-2. 対象 workflow の依存を `cloud` / `local` に分類し、分類根拠を表示する。既定 `wf-auto` は local（Chrome / OAuth / media / ffmpeg を利用）として扱う。
+2. 対象 workflow の依存を `cloud` / `local` に分類し、分類根拠を表示する。既定 `wf-new --auto` は local（Chrome / OAuth / media / ffmpeg を利用）として扱う。
 3. active な別 backend があれば、旧 backend の disable が承認・成功するまで停止する。
 
 ### Step 1. config と native task の dry-run
@@ -72,12 +72,12 @@ uv run python .claude/skills/automation-schedule/references/schedule_backend.py 
 uv run python .claude/skills/automation-schedule/references/schedule_config.py show
 uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --dry-run --enable \
   --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
-  [--target-workflow wf-auto] [--max-retries <N>] \
+  [--target-workflow "wf-new --auto"] [--max-retries <N>] \
   [--retry-delay-seconds <N>] [--notification terminal|none]
 uv run python .claude/skills/automation-schedule/references/schedule_backend.py plan \
   --product <codex|claude> --dependency-mode <cloud|local> \
   --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
-  [--target-workflow wf-auto] [--max-retries <N>] \
+  [--target-workflow "wf-new --auto"] [--max-retries <N>] \
   [--retry-delay-seconds <N>] [--notification terminal|none]
 ```
 
@@ -132,6 +132,6 @@ uv run python .claude/skills/automation-schedule/references/schedule_backend.py 
 
 ## Safety contract
 
-- native task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`wf-auto` の `.automation-run/` lease、状態再評価、重複 upload 防止は変更しない。
+- native task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`wf-new --auto` の `.automation-run/` lease、状態再評価、重複 upload 防止は変更しない。
 - retry は backend の再実行機能が契約を満たす場合のみ native 側へ写像する。満たさない場合は prompt 内で `max_retries` / `retry_delay_seconds` を適用する。
 - OS fallback のログは `.automation-schedule/logs/`。ネイティブの履歴は各製品の Scheduled 管理面を正とする。

--- a/.claude/skills/automation-schedule/references/schedule_backend.py
+++ b/.claude/skills/automation-schedule/references/schedule_backend.py
@@ -70,9 +70,10 @@ def build_plan(
     raw_cadence = overrides.get("cadence") or list(scheduled.cadence)
     cadence = list(raw_cadence) if not isinstance(raw_cadence, str) else raw_cadence.split(",")
     target_workflow = str(overrides.get("target_workflow") or scheduled.target_workflow)
-    if target_workflow == "automation-run":
+    if target_workflow in {"automation-run", "wf-auto"}:
         raise BackendError(
-            "--target-workflow automation-run は廃止されました。--target-workflow wf-auto へ更新してください"
+            f"--target-workflow {target_workflow} は廃止されました。"
+            "--target-workflow 'wf-new --auto' へ更新してください"
         )
     max_retries = int(overrides.get("max_retries", scheduled.max_retries))
     retry_delay_seconds = int(overrides.get("retry_delay_seconds", scheduled.retry_delay_seconds))

--- a/.claude/skills/lyria/SKILL.md
+++ b/.claude/skills/lyria/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when Vertex AI Lyria 3 でマスター音源を自動生成す
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/wf-next`
+- `前工程`: `/wf-new`, `/wf-next`
 - `後工程`: `/videoup`
 - `委譲先`: `なし`
 

--- a/.claude/skills/masterup/SKILL.md
+++ b/.claude/skills/masterup/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when Suno UI で生成した曲のプレイリストを一括 
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/suno`, `/suno-helper`
+- `前工程`: `/wf-new`, `/suno`, `/suno-helper`
 - `後工程`: `/videoup`
 - `委譲先`: `なし`
 

--- a/.claude/skills/post-publish/SKILL.md
+++ b/.claude/skills/post-publish/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when 動画公開直後の community-post → pinned-comment �
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/video-upload`
+- `前工程`: `/wf-new`, `/video-upload`
 - `後工程`: `なし`
 - `委譲先`: `/community-post`, `/pinned-comment`, `/metadata-audit`
 

--- a/.claude/skills/suno-helper/SKILL.md
+++ b/.claude/skills/suno-helper/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when Suno UI に投入する曲をブラウザで連続生成 
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/suno`, `/wf-new`
+- `前工程`: `/wf-new`, `/suno`, `/wf-new`
 - `後工程`: `/masterup`
 - `委譲先`: `なし`
 

--- a/.claude/skills/video-upload/SKILL.md
+++ b/.claude/skills/video-upload/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when コレクションの動画または release 型（単曲
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/videoup`, `/video-description`, `/playlist`, `/thumbnail`
+- `前工程`: `/wf-new`, `/videoup`, `/video-description`, `/playlist`, `/thumbnail`
 - `後工程`: `/post-publish`, `/community-post`, `/metadata-audit`, `/pinned-comment`, `/live-clean`
 - `委譲先`: `/post-publish`
 

--- a/.claude/skills/videoup/SKILL.md
+++ b/.claude/skills/videoup/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when 音声ファイルが揃い動画生成が必要なとき
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/masterup`, `/lyria`, `/loop-video`
+- `前工程`: `/wf-new`, `/masterup`, `/lyria`, `/loop-video`
 - `後工程`: `/video-upload`, `/video-description`
 - `委譲先`: `なし`
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -1,24 +1,36 @@
 ---
 name: wf-new
 purpose: 進める
-description: "Use when 新規コレクション制作を立ち上げるとき（ディレクトリ未作成）。「新しいコレクション始めたい」「制作開始」で発動。既存の進行は /wf-next"
+description: "Use when 新規コレクション制作を立ち上げるとき、または --auto で collection の有無を問わず公開後処理まで状態駆動で継続・再開するとき。「新しいコレクション始めたい」「制作開始」「制作を最初から最後まで」で発動。一段だけ進める場合は /wf-next"
 ---
 
 ## 前後工程
 
-- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`
-- `後工程`: `/wf-auto`, `/wf-next`, `/suno-helper`
-- `委譲先`: `/collection-ideate`, `/thumbnail`, `/suno`, `/lyria`, `/loop-video`
+- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`, `/automation-schedule`
+- `後工程`: `/wf-next`, `/suno-helper`, `/post-publish`, `/analytics`
+- `委譲先`: `/collection-ideate`, `/thumbnail`, `/suno`, `/lyria`, `/loop-video`, `/suno-helper`, `/masterup`, `/wf-next`, `/post-publish`
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
-- `読み込む`: `config/channel/*.json`, `config/localizations.json`, `data/benchmark_*.json`, `reports/analysis_*.md`, `data/insights.jsonl`
+- `書き込む`: `.automation-run/history.json`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
+- `読み込む`: `config/channel/*.json`, `config/localizations.json`, `data/benchmark_*.json`, `reports/analysis_*.md`, `data/insights.jsonl`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/post_publish_history.json`
+
+## モード判定
+
+`$ARGUMENTS` から `--auto` の個数を最初に数える。
+
+- 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す。state・lease・成果物は一切変更しない
+- 1 個なら対応する reference を読み、その mode だけを実行する。残りの引数はその mode の引数として扱う
+- 0 個なら従来の通常入口（新規コレクション立ち上げ）をそのまま実行する
+
+| mode | 読む reference |
+|---|---|
+| `--auto` | `references/auto.md` |
 
 ## Overview
 
 新コレクション開始オーケストレーター。子スキルを順番に呼び、通常は企画選択 + サムネイル承認の2箇所で一時停止する。`workflow.wf_new.skip_plan_selection: true` の analytics mode / benchmark fallback mode では企画選択だけを自動化する。
-`/wf-auto` から新規開始または対象 collection 固定で委譲された場合も本スキルの既存 gate と完了条件を維持し、統合 runner 側で工程を再実装しない。新規初期化後は作成した collection 名を返し、同じ run 内の再評価へ接続する。
+`/wf-new --auto` から同一 SKILL.md の通常入口へ入った場合も既存 gate と完了条件を維持し、auto mode 側で工程を再実装しない。新規初期化後は作成した collection 名を返し、同じ run 内の再評価へ接続する。
 `image_generation.auto_selection.enabled: true` かつ `mode: full` のチャンネルでは、サムネイル工程のテーマ確認・生成可否・textless 背景承認・候補承認を省略する。`planning-preview.png` があればそれを無人で最終サムネイルへ確定し、無ければ企画で確定した theme を `/thumbnail` へ渡して無人で確定する。
 Suno チャンネルではプロンプト生成後、`suno-helper` 用の `uv run yt-collection-serve` 起動と疎通確認まで行い、続きは `/suno-helper` が browser use で Suno タブ上の拡張 overlay を操作できる状態にする。
 minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気の直接入力確認が追加される既存挙動を、`ttp_mode: false` の場合だけ適用する。`true` の場合は `/benchmark` を案内して停止する。
@@ -142,17 +154,17 @@ uv run yt-init-collection "Pilot Direction Check" "pilot-direction-check" --trac
 
 ### 直接実行の canonical timing 契約
 
-`/wf-new` を直接呼んだ場合も、state 判定・lease・history/timing の正は `/wf-auto` と同じ state script とする。独自の action ID、collection ID、timing 保存処理を作らない。channel config gate を通過したら、子 skill や collection 初期化を始める前に、チャンネルルートで次の順序を守る。
+`/wf-new` をフラグなしで直接呼んだ場合も、state 判定・lease・history/timing の正は `references/auto.md` と同じ state script とする。独自の action ID、collection ID、timing 保存処理を作らない。channel config gate を通過したら、子 skill や collection 初期化を始める前に、チャンネルルートで次の順序を守る。
 
 ```bash
-STATE_SCRIPT=.claude/skills/wf-auto/references/wf-auto-state.py
+STATE_SCRIPT=.claude/skills/wf-new/references/wf-auto-state.py
 uv run python "$STATE_SCRIPT" acquire --channel-dir .
 uv run python "$STATE_SCRIPT" plan --channel-dir .
 uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
 uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())'
 ```
 
-`acquire` の `busy` / exit 20 では作業を開始しない。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した `action: wf-new` と resolver が返した collection（未作成なら `null`）だけを使い、別 action や別 collection に置き換えない。`wf-new` 以外が返った場合は本 skill で工程を推測せず、返された action を報告して `/wf-auto` からの再開を案内する。
+`acquire` の `busy` / exit 20 では作業を開始しない。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した `action: wf-new` と resolver が返した collection（未作成なら `null`）だけを使い、別 action や別 collection に置き換えない。`wf-new` 以外が返った場合は本 skill で工程を推測せず、返された action を報告して `/wf-new --auto` からの再開を案内する。
 
 collection がまだ無い段階で blocked / failed になった場合は、canonical action `wf-new` の bootstrap attempt を次の形で閉じる。同じ run ですでに閉じた human interval があれば、省略・統合せず発生順にすべて渡す。
 
@@ -160,7 +172,7 @@ collection がまだ無い段階で blocked / failed になった場合は、can
 uv run python "$STATE_SCRIPT" record-bootstrap --channel-dir . --token <token> --status blocked|failed --reason <reason> --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
 ```
 
-resolver が collection を返した場合、または `yt-init-collection` の出力 path と `workflow-state.json` の実在を検証して作成済み collection の名前を固定した後は、success / blocked / failed のすべてを同じ fixed collection、canonical action `wf-new`、同じ attempt の AI 開始時刻で閉じる。成功は既存の成果物・state 検証をすべて通過した場合だけとし、手動介入は blocked、検証失敗を含むその他は failed とする。対話 gate の時間分類と `--human-interval` は `/wf-auto` の canonical timing 契約をそのまま使う。
+resolver が collection を返した場合、または `yt-init-collection` の出力 path と `workflow-state.json` の実在を検証して作成済み collection の名前を固定した後は、success / blocked / failed のすべてを同じ fixed collection、canonical action `wf-new`、同じ attempt の AI 開始時刻で閉じる。成功は既存の成果物・state 検証をすべて通過した場合だけとし、手動介入は blocked、検証失敗を含むその他は failed とする。対話 gate の時間分類と `--human-interval` は `references/auto.md` の canonical timing 契約をそのまま使う。
 
 ```bash
 uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collection <fixed-name> --action wf-new --status success|blocked|failed --reason <reason> --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
@@ -168,7 +180,7 @@ uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collectio
 
 success を記録した後は同じ fixed collection を `plan --collection <fixed-name>` で再評価する。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。
 
-`/wf-auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-auto` に一度だけ行わせる。
+`/wf-new --auto` が token、resolver の action / collection、attempt の開始時刻を固定して同一 SKILL.md の通常入口へ入った場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を auto mode へ返し、canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ行わせる。
 
 ### 呼び出しルール
 

--- a/.claude/skills/wf-new/references/auto.md
+++ b/.claude/skills/wf-new/references/auto.md
@@ -1,8 +1,3 @@
----
-name: wf-auto
-purpose: 進める
-description: "Use when 正規入口から collection の有無を問わず、企画開始または未完了地点から制作・公開・post-publish まで状態駆動で継続・再開するとき。「制作を最初から最後まで」「wf-auto」で発動。一段だけ進める場合は /wf-next、進捗確認だけなら /wf-status"
----
 
 ## 前後工程
 
@@ -17,7 +12,7 @@ description: "Use when 正規入口から collection の有無を問わず、企
 
 ## Overview
 
-`workflow-state.json` と実成果物を毎段再評価し、新規企画または active collection の未完了地点から公開後処理まで継続する統合入口。判断・lease・履歴は `references/wf-auto-state.py` を使い、実作業は既存 `/wf-new`、`/lyria`、`/suno-helper`、`/masterup`、`/wf-next`、`/post-publish` に委譲する。子 skill の処理は本文へ複製しない。`thumbnail::textless.enabled` も独自解釈せず、`/wf-new` と `/wf-next` の契約をそのまま貫通させる。
+`workflow-state.json` と実成果物を毎段再評価し、新規企画または active collection の未完了地点から公開後処理まで継続する正規入口。判断・lease・履歴は `references/wf-auto-state.py` を使い、実作業は同一 SKILL.md の通常入口、`/lyria`、`/suno-helper`、`/masterup`、`/wf-next`、`/post-publish` に委譲する。子 skill の処理は本文へ複製しない。`thumbnail::textless.enabled` も独自解釈せず、通常入口と `/wf-next` の契約をそのまま貫通させる。
 
 ## Hard Gates
 
@@ -42,7 +37,7 @@ description: "Use when 正規入口から collection の有無を問わず、企
 チャンネルルートで実行する。
 
 ```bash
-STATE_SCRIPT=.claude/skills/wf-auto/references/wf-auto-state.py
+STATE_SCRIPT=.claude/skills/wf-new/references/wf-auto-state.py
 
 uv run python "$STATE_SCRIPT" acquire --channel-dir .
 uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
@@ -62,14 +57,14 @@ uv run python "$STATE_SCRIPT" release --channel-dir . --token <token>
 
 | 状態 | action / 処理 |
 |---|---|
-| active collection なし | `wf-new` / `no_active_collection`。`/wf-new` を新規開始する |
+| active collection なし | `wf-new` / `no_active_collection`。同一 SKILL.md の通常入口を新規開始する |
 | active collection あり | state と実成果物から未完了 action を返す |
 
 `plan` の action と委譲先:
 
 | action | 委譲先 / 処理 |
 |---|---|
-| `wf-new` | `/wf-new`。不在時は新規開始、固定済み planning では未完了工程から再開 |
+| `wf-new` | 同一 SKILL.md の通常入口。不在時は新規開始、固定済み planning では未完了工程から再開 |
 | `lyria` | `/lyria` |
 | `suno-helper` | `/suno-helper` の browser use 主導フロー。人間への handoff は login / CAPTCHA の該当操作だけ |
 | `masterup` | strict Suno 成果物を入力に `/masterup` |
@@ -139,7 +134,7 @@ resolver が `action: suno-helper` を返したら、agent 自身が `/suno-help
    `load_config()` が失敗した場合は既存チャンネル取り込みモードの `/channel-new` を案内して停止する。state resolver または上記子 skill が無ければ `/automation-update`（本リポジトリ内では `yt-skills sync`）を案内して停止する。すべて満たすまで lease と子 skill を開始しない。
 2. `acquire` で token を保持する。exit 20 / `busy` なら子 skill を開始せず終了する。
 3. 初回 `plan` を実行する。
-   - `reason: no_active_collection`: `/wf-new` を canonical action として選び、step 4 の heartbeat と AI 開始時刻取得後に `SKILL.md` を読んで、既存 gate と明示 opt-in の skip 分岐を保って新規開始する。`skip_plan_selection: true` の analytics / benchmark fallback mode は推奨順 1 位で続行し、minimal mode など設定で省略されていない入力が必要なら `record-bootstrap --status blocked --reason user_input_required --ai-started-at <current-attempt-ai-started-at>` で停止する。
+   - `reason: no_active_collection`: resolver が `action: wf-new` を返したら別 skill を呼ばず、同一 SKILL.md の通常入口を canonical action として選ぶ。step 4 の heartbeat と AI 開始時刻取得後に通常入口を読み、企画選択、thumbnail 承認、preselected manifest、channel constraint verification を含む既存 gate と明示 opt-in の skip 分岐を保って新規開始する。`skip_plan_selection: true` の analytics / benchmark fallback mode は推奨順 1 位で続行し、minimal mode など設定で省略されていない入力が必要なら `record-bootstrap --status blocked --reason user_input_required --ai-started-at <current-attempt-ai-started-at>` で停止する。
    - collection が返る: その名前を固定する。
 4. 選ばれた各 action の直前に `heartbeat` を実行する。owner なら直後に「canonical action の AI timing 契約」の開始時刻を取得して保持する。子 skill action は対応する `SKILL.md` を読み、固定 collection、期待成果物、外部公開許可を明示して委譲する。`blocked` / `complete` は同じ開始時刻取得後に terminal action として処理する。`not-owner` なら開始時刻を取得せず、action を開始しない。
 5. `/wf-new` が collection を初期化したら、出力 path と `workflow-state.json` の実在を検証して名前を固定する。step 4 で保持した開始時刻を渡して `record --action wf-new --status success --ai-started-at <current-attempt-ai-started-at>` を実行した後、同じ run 内で `plan --collection <fixed-name>` を実行する。企画選択等で対話が一時停止しても lease を保持した実行文脈へ回答を戻し、完了後に同じ固定処理を行う。

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -99,9 +99,9 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 `music_downloaded: true` かつ `raw_master: null` は、Suno 楽曲が DL 済みで raw master（クロスフェード結合出力）が未生成の中間状態を表す。
 
-#### wf-auto の判定責務
+#### wf-new --auto の判定責務
 
-`/wf-auto` は active collection が無ければ state を事前作成せず `/wf-new` へ委譲し、初期化後は返された collection を固定する。active collection があれば本 state と実成果物を一段ごとに再評価し、Lyria / Suno / masterup / 制作 / 公開 / post-publish の委譲先を選ぶ。統合 runner 自身は本ファイルを更新せず、各既存 skill の検証済み更新契約を使う。`workflow.scheduled_automation.allow_external_publish` が `false` の場合はローカル動画・metadata 生成後、YouTube 書き込み前で停止する。`.automation-run/history.json` は停止理由と再開地点の監査記録であり、本 state や成果物の代替 source of truth ではない。
+`/wf-new --auto` は active collection が無ければ state を事前作成せず `/wf-new` へ委譲し、初期化後は返された collection を固定する。active collection があれば本 state と実成果物を一段ごとに再評価し、Lyria / Suno / masterup / 制作 / 公開 / post-publish の委譲先を選ぶ。統合 runner 自身は本ファイルを更新せず、各既存 skill の検証済み更新契約を使う。`workflow.scheduled_automation.allow_external_publish` が `false` の場合はローカル動画・metadata 生成後、YouTube 書き込み前で停止する。`.automation-run/history.json` は停止理由と再開地点の監査記録であり、本 state や成果物の代替 source of truth ではない。
 
 #### Suno 定期実行 checkpoint の責務
 

--- a/.claude/skills/wf-new/references/wf-auto-state.py
+++ b/.claude/skills/wf-new/references/wf-auto-state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Resolve canonical `/wf-auto` actions and maintain its lease/history state."""
+"""Resolve canonical `/wf-new --auto` actions and maintain its lease/history state."""
 
 from __future__ import annotations
 
@@ -827,7 +827,7 @@ def acquire_lease(root: Path, *, now: float, ttl_seconds: int) -> str:
                 shutil.rmtree(lock_dir)
             else:
                 if not isinstance(expires_at, (int, float)) or isinstance(expires_at, bool) or expires_at > now:
-                    raise LeaseBusyError("別の wf-auto が実行中です")
+                    raise LeaseBusyError("別の wf-new --auto が実行中です")
                 shutil.rmtree(lock_dir)
         temporary = Path(tempfile.mkdtemp(prefix=".lease.", dir=state_dir))
         try:

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -6,7 +6,7 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ## 前後工程
 
-- `前工程`: `/wf-auto`, `/wf-new`
+- `前工程`: `/wf-new`, `/wf-new`
 - `後工程`: `/analytics`, `/flop-analysis`
 - `委譲先`: `/masterup`, `/lyria`, `/videoup`, `/video-description`, `/playlist`, `/video-upload`
 
@@ -18,7 +18,7 @@ description: "Use when 既存コレクション（collections/planning/）を一
 ## Overview
 
 既存コレクションを次工程へ進めるオーケストレーター。完了済みの素材を自動検出し、未完了のステップから再開する。
-`/wf-auto` から固定 collection を委譲された場合も本スキルが state 更新の単一責務を持つ。統合 runner の `allow_external_publish = false` 制約ではローカル動画・metadata 生成まで進め、YouTube 書き込み直前で停止する。対話 gate の承認後は同じ run へ結果を返し、resolver が実成果物を再評価する。
+`/wf-new --auto` から固定 collection を委譲された場合も本スキルが state 更新の単一責務を持つ。統合 runner の `allow_external_publish = false` 制約ではローカル動画・metadata 生成まで進め、YouTube 書き込み直前で停止する。対話 gate の承認後は同じ run へ結果を返し、resolver が実成果物を再評価する。
 
 ## Hard Gates: subagent 委譲境界
 
@@ -97,10 +97,10 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ### 直接実行の canonical timing 契約
 
-`/wf-next` を直接呼んだ場合も、state 判定・lease・history/timing の正は `/wf-auto` と同じ state script とする。下記「1. アクティブなコレクションの特定」の既存手順で対象名を `<fixed-name>` として固定した後、フェーズ処理や子 skill を開始する前に、チャンネルルートで次の順序を守る。
+`/wf-next` を直接呼んだ場合も、state 判定・lease・history/timing の正は `/wf-new --auto` と同じ state script とする。下記「1. アクティブなコレクションの特定」の既存手順で対象名を `<fixed-name>` として固定した後、フェーズ処理や子 skill を開始する前に、チャンネルルートで次の順序を守る。
 
 ```bash
-STATE_SCRIPT=.claude/skills/wf-auto/references/wf-auto-state.py
+STATE_SCRIPT=.claude/skills/wf-new/references/wf-auto-state.py
 uv run python "$STATE_SCRIPT" acquire --channel-dir .
 uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name>
 uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
@@ -120,7 +120,7 @@ resolver action と直接入口の既存責務は次の対応を正とする。
 | `blocked` | resolver の reason / resume action を変更せず blocked で閉じる |
 | `complete` | 下記 complete の既存検証を通過した場合だけ success で閉じる |
 
-既存の成果物検証、承認 gate、state 更新責務を変更せず、子 skill の終了報告だけで成功にしない。期待成果物と state を検証した後、成功だけを success、手動介入または責務外 action への handoff を blocked、検証失敗を含むその他を failed とし、すべて同じ固定 collection、resolver action、同じ attempt の AI 開始時刻で閉じる。対話 gate の時間分類と `--human-interval` は `/wf-auto` の canonical timing 契約をそのまま使う。
+既存の成果物検証、承認 gate、state 更新責務を変更せず、子 skill の終了報告だけで成功にしない。期待成果物と state を検証した後、成功だけを success、手動介入または責務外 action への handoff を blocked、検証失敗を含むその他を failed とし、すべて同じ固定 collection、resolver action、同じ attempt の AI 開始時刻で閉じる。対話 gate の時間分類と `--human-interval` は `/wf-new --auto` の canonical timing 契約をそのまま使う。
 
 ```bash
 uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collection <fixed-name> --action <resolver-action> --status success|blocked|failed --reason <reason> [--resume-action <resolver-resume-action>] --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
@@ -128,7 +128,7 @@ uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collectio
 
 status を記録した後は、成功時だけでなく blocked / failed の停止報告前にも同じ固定 collection を `plan --channel-dir . --collection <fixed-name>` で再評価し、次回の再開 action を推測しない。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。
 
-`/wf-auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-auto` に一度だけ行わせる。
+`/wf-new --auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ行わせる。
 
 ### 1. アクティブなコレクションの特定
 

--- a/.claude/skills/wf-status/SKILL.md
+++ b/.claude/skills/wf-status/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when コレクション制作の進捗を読むだけで確認
 ## 前後工程
 
 - `前工程`: `/wf-new`
-- `後工程`: `/wf-auto`, `/wf-next`
+- `後工程`: `/wf-new`, `/wf-next`
 - `委譲先`: `なし`
 
 ## 成果物
@@ -27,7 +27,7 @@ description: "Use when コレクション制作の進捗を読むだけで確認
 |---|---|
 | 「どこまで進んだ？」「読むだけ」 | ✅ 使う |
 | 「次のステップ実行して」 | ❌ `/wf-next` を使う（`/wf-status` は **実行系を一切呼ばない**） |
-| 「企画から公開後処理まで継続して」 | ❌ `/wf-auto` を使う（`/wf-status` は **実行系を一切呼ばない**） |
+| 「企画から公開後処理まで継続して」 | ❌ `/wf-new --auto` を使う（`/wf-status` は **実行系を一切呼ばない**） |
 | 「workflow-state.json を見せて」 | ✅ 使う（生 JSON ではなく phase / assets を整形表示する） |
 | 「YouTube 側の登録者数・再生数を見せて」 | ❌ `/channel-status` を使う |
 
@@ -122,5 +122,5 @@ phase 値と日本語ラベル:
 ## Cross References
 
 - 新規開始: `/wf-new`
-- 一気通貫の開始・再開: `/wf-auto`
+- 一気通貫の開始・再開: `/wf-new --auto`
 - 次ステップ実行: `/wf-next`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `/wf-auto` を `/wf-new --auto` へ統合し、排他 mode 判定、既存 state/lease/timing 契約の移設、scheduled automation の新既定と旧値拒否を追加する（#3740）。
+
 - `refactor(skills)`: `/wf-new` の Phase 2 を `references/phase2.md` へ移し、実行契約を維持したまま SKILL.md 本体を 400 行以下にする（#3870）。
 
 - `feat(skills)`: 下流 skill-config を名前空間節へ集約する `yt-skills migrate-config` を追加し、dry-run、冪等適用、同一ディレクトリ一時ファイルからの atomic replace、失敗時復元、孤児・未移行警告を提供する。現行ツリーには統合先 skill が未導入のため、移行対応表は安全のため空で提供する（#3804）。

--- a/docs/architecture/b6-integration-receipt.json
+++ b/docs/architecture/b6-integration-receipt.json
@@ -1137,14 +1137,14 @@
     },
     {
       "old_owner": "legacy..claude.skills.wf-auto.SKILL.md",
-      "exact_new_owner": ".claude/skills/wf-auto/SKILL.md",
+      "exact_new_owner": ".claude/skills/wf-new/references/auto.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"
     },
     {
       "old_owner": "legacy..claude.skills.wf-auto.references.wf-auto-state",
-      "exact_new_owner": ".claude/skills/wf-auto/references/wf-auto-state.py",
+      "exact_new_owner": ".claude/skills/wf-new/references/wf-auto-state.py",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **58 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **54 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -10,12 +10,11 @@
 
 | Skill | なにができるか |
 |---|---|
-| /wf-new | 新規コレクションの企画選択・ディレクトリ作成・素材準備（Phase 1） |
+| /wf-new | フラグなしで新規コレクションを立ち上げ、正規入口 `--auto` では active collection の有無を問わず公開後処理まで状態駆動で継続・再開 |
 | /wf-next | 既存コレクションを次の工程に 1 段進める（Phase 2-3） |
-| /wf-auto | 正規入口。active collection が無ければ企画から開始し、あれば未完了地点から制作・公開・post-publish まで同じ対象を状態駆動で継続・再開 |
 | /wf-new-batch | 複数の新規コレクションを相互差別化して一括企画し、正規 `/wf-new` を順次実行・再開 |
 | /wf-status | 制作中コレクションの進捗を読み取り表示（実行はしない） |
-| /automation-schedule | 定期制作設定（`workflow.json` の `scheduled_automation`）の生成と、既定 `/wf-auto` を起動する Claude Code / Codex ジョブの作成・更新・確認・停止 |
+| /automation-schedule | 定期制作設定（`workflow.json` の `scheduled_automation`）の生成と、既定 `/wf-new --auto` を起動する Claude Code / Codex ジョブの作成・更新・確認・停止 |
 | /collection-ideate | データドリブンに次の企画候補を提案 |
 
 ## チャンネル立ち上げ

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -32,8 +32,7 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 - `/automation-schedule` — Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。
 - `/collection-ideate` — Use when 新コレクションの企画・テーマ選定をデータドリブンに行うとき。
 - `/streaming` — Use when ライブ配信用 Vultr VPS・動画配信本体を Terraform で構築・運用・トラブルシュートするとき。
-- `/wf-auto` — Use when 正規入口から collection の有無を問わず、企画開始または未完了地点から制作・公開・post-publish まで状態駆動で継続・再開するとき。
-- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき（ディレクトリ未作成）。
+- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき、または --auto で collection の有無を問わず公開後処理まで状態駆動で継続・再開するとき。
 - `/wf-new-batch` — Use when 複数の新規コレクションを相互差別化して一括企画し、正規 /wf-new を順次実行・再開するとき。
 - `/wf-next` — Use when 既存コレクション（collections/planning/）を一段進めるとき。
 - `/wf-status` — Use when コレクション制作の進捗を読むだけで確認するとき（実行しない）。

--- a/docs/workflow-cheatsheet.md
+++ b/docs/workflow-cheatsheet.md
@@ -1,6 +1,6 @@
 # workflow チートシート
 
-`/wf-auto` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
+`/wf-new --auto` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
 
 > Skill 全体のカタログは [`docs/features.md`](features.md) を参照。
 
@@ -10,7 +10,7 @@
 ユーザーの問い                       → 呼ぶ skill
 ────────────────────────────────────────────────
 「次なに作る？」「テーマ候補が欲しい」  → /collection-ideate   （企画候補を提案する）
-「企画から公開後処理まで全部進めて」      → /wf-auto             （新規開始または未完了地点から完走）
+「企画から公開後処理まで全部進めて」      → /wf-new --auto             （新規開始または未完了地点から完走）
 「新しいコレクション始めたい」          → /wf-new              （企画選択 → ディレクトリ作成 → 素材準備）
 「制作中のやつ、次のステップやって」    → /wf-next             （phase に応じて次工程を 1 段実行）
 「どこまで進んだ？読むだけ」           → /wf-status           （実行はしない・読み取り表示のみ）
@@ -20,7 +20,7 @@
 
 | ユーザーの状況 | 使う skill |
 |---|---|
-| collection の有無を問わず **企画から公開後処理まで進めたい** | `/wf-auto`（正規入口） |
+| collection の有無を問わず **企画から公開後処理まで進めたい** | `/wf-new --auto`（正規入口） |
 | 制作中コレクションが **無い** + 企画候補も **無い** | `/collection-ideate` → 候補が決まったら `/wf-new` |
 | 制作中コレクションが **無い** + 企画候補は **頭にある** | `/wf-new`（その中で `/collection-ideate` が走る） |
 | 制作中コレクションが **ある** + 進める意思がある | `/wf-next` |
@@ -30,7 +30,7 @@
 
 | Skill | 何をする | 何をしない | 一時停止する場面 |
 |---|---|---|---|
-| `/wf-auto` | collection 不在なら `/wf-new` から開始し、存在すれば未完了地点から制作・公開・post-publish まで状態駆動で再評価する | 子 skill の実装を複製しない | 認証、CAPTCHA、承認待ち、公開未許可など人間の介入が必要な場面 |
+| `/wf-new --auto` | collection 不在なら `/wf-new` から開始し、存在すれば未完了地点から制作・公開・post-publish まで状態駆動で再評価する | 子 skill の実装を複製しない | 認証、CAPTCHA、承認待ち、公開未許可など人間の介入が必要な場面 |
 | `/collection-ideate` | analytics mode / benchmark fallback mode、または `ttp_mode: false` の minimal mode の入力でペルソナ別 3 企画候補を生成 | コレクションディレクトリは作らない | 提案表示のみ（選択は `/wf-new` 側で）。`ttp_mode: true` の minimal mode は `/benchmark` を案内して停止 |
 | `/wf-new` | 企画選択 → `yt-init-collection` でディレクトリ + `workflow-state.json` 作成 → サムネ・音楽素材生成 | 楽曲の最終マスタリングや動画化はしない | 通常は (1) 企画選択 (2) サムネ承認。`ttp_mode: false` の minimal mode は企画候補生成前にテーマ / ジャンル / 雰囲気の直接入力確認を追加し、`true` は `/benchmark` の案内で停止 |
 | `/wf-next` | `workflow-state.json::phase` に応じて次工程を 1 段実行（Suno DL / Lyria 生成 / 動画化 / アップロード） | 新規コレクションは作らない | マスター音源が無い phase = "prepared" 状態（ユーザーがミキシング+マスタリングを行う） |

--- a/examples/channel_config.example/workflow.json
+++ b/examples/channel_config.example/workflow.json
@@ -27,7 +27,7 @@
       "timezone": "Asia/Tokyo",
       "run_time": "09:00",
       "cadence": ["mon", "wed", "fri"],
-      "target_workflow": "wf-auto",
+      "target_workflow": "wf-new --auto",
       "max_retries": 1,
       "retry_delay_seconds": 300,
       "prevent_concurrent_runs": true,

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -151,13 +151,13 @@ test("実リポジトリでは9カテゴリと全skillを生成する", async ()
     await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
   ).match(/^\| \/[a-z0-9-]+ /gmu);
 
-  assert.equal(result.entries.length, 56);
-  assert.equal(skillDirectories?.length, 55);
+  assert.equal(result.entries.length, 55);
+  assert.equal(skillDirectories?.length, 54);
   assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
   assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
 });
 
-test("production build は一覧と55個の個別ページを公開する", async () => {
+test("production build は一覧と54個の個別ページを公開する", async () => {
   const siteRoot = resolve(import.meta.dirname, "..");
   const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
   const thumbnail = await readFile(
@@ -165,7 +165,7 @@ test("production build は一覧と55個の個別ページを公開する", asyn
     "utf8"
   );
 
-  assert.match(index, /55 個の skill/);
+  assert.match(index, /54 個の skill/);
   assert.match(index, /href="\/skills\/wf-new-batch"/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -796,10 +796,10 @@ def _build_scheduled_automation(wf: dict) -> ScheduledAutomation:
     prefix = "workflow.scheduled_automation"
     defaults = ScheduledAutomation()
     target_workflow = _scheduled_str(raw, "target_workflow", prefix, defaults.target_workflow)
-    if target_workflow == "automation-run":
+    if target_workflow in {"automation-run", "wf-auto"}:
         raise ConfigError(
-            f"{prefix}.target_workflow: automation-run は廃止されました。"
-            "config/channel/workflow.json の値を wf-auto へ更新してください"
+            f"{prefix}.target_workflow: {target_workflow} は廃止されました。"
+            "config/channel/workflow.json の値を wf-new --auto へ更新してください"
         )
     return ScheduledAutomation(
         enabled=_scheduled_bool(raw, "enabled", prefix, defaults.enabled),

--- a/src/youtube_automation/configuration/workflow.py
+++ b/src/youtube_automation/configuration/workflow.py
@@ -69,7 +69,7 @@ class ScheduledAutomation:
     - `timezone`: IANA タイムゾーン名（例 `Asia/Tokyo`）。スケジュール時刻の解釈に使う。
     - `run_time`: 定期起動時刻（`HH:MM`、24 時間表記）。
     - `cadence`: 起動する曜日の配列。`SCHEDULED_AUTOMATION_CADENCE_DAYS` の部分集合。
-    - `target_workflow`: 起動する skill 名（既定 `wf-auto`。先頭 `/` なし）。
+    - `target_workflow`: 起動する skill と mode（既定 `wf-new --auto`。先頭 `/` なし）。
     - `max_retries`: 実行失敗時の再試行回数（0 = 再試行なし）。
     - `retry_delay_seconds`: 再試行までの待機秒数。
     - `prevent_concurrent_runs`: `True`（既定）のとき、前回実行が生存中なら
@@ -84,7 +84,7 @@ class ScheduledAutomation:
     timezone: str = "Asia/Tokyo"
     run_time: str = "09:00"
     cadence: tuple[str, ...] = SCHEDULED_AUTOMATION_CADENCE_DAYS
-    target_workflow: str = "wf-auto"
+    target_workflow: str = "wf-new --auto"
     max_retries: int = 0
     retry_delay_seconds: int = 300
     prevent_concurrent_runs: bool = True

--- a/src/youtube_automation/infrastructure/analytics/workflow_timing.py
+++ b/src/youtube_automation/infrastructure/analytics/workflow_timing.py
@@ -38,7 +38,7 @@ def _load_module(path: Path) -> _TimingRunner:
     module_name = "youtube_automation._wf_auto_state_dashboard"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"wf-auto timing module をロードできません: {path}")
+        raise RuntimeError(f"wf-new --auto timing module をロードできません: {path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     try:
@@ -51,12 +51,12 @@ def _load_module(path: Path) -> _TimingRunner:
 
 @cache
 def _runner() -> _TimingRunner:
-    resource = files("youtube_automation").joinpath("_skills", "wf-auto", "references", "wf-auto-state.py")
+    resource = files("youtube_automation").joinpath("_skills", "wf-new", "references", "wf-auto-state.py")
     with as_file(resource) as resource_path:
         if resource_path.is_file():
             return _load_module(resource_path)
     source_path = (
-        Path(__file__).resolve().parents[4] / ".claude" / "skills" / "wf-auto" / "references" / "wf-auto-state.py"
+        Path(__file__).resolve().parents[4] / ".claude" / "skills" / "wf-new" / "references" / "wf-auto-state.py"
     )
     if not source_path.is_file():
         raise RuntimeError("wf-auto-state.py が package resource と source checkout のどちらにもありません")

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -2419,7 +2419,7 @@ def test_scheduled_automation_absent_uses_disabled_defaults(tmp_path, monkeypatc
     assert sa.timezone == "Asia/Tokyo"
     assert sa.run_time == "09:00"
     assert sa.cadence == ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
-    assert sa.target_workflow == "wf-auto"
+    assert sa.target_workflow == "wf-new --auto"
     assert sa.max_retries == 0
     assert sa.retry_delay_seconds == 300
     assert sa.prevent_concurrent_runs is True
@@ -2468,7 +2468,17 @@ def test_scheduled_automation_rejects_removed_automation_run_target(tmp_path, mo
     ch = _setup_channel(tmp_path, sections)
     monkeypatch.setenv("CHANNEL_DIR", str(ch))
 
-    with pytest.raises(ConfigError, match=r"target_workflow.*automation-run.*wf-auto"):
+    with pytest.raises(ConfigError, match=r"target_workflow.*automation-run.*wf-new --auto"):
+        load_config()
+
+
+def test_scheduled_automation_rejects_removed_wf_auto_target(tmp_path, monkeypatch):
+    sections = _minimal_sections()
+    sections["workflow.json"] = {"workflow": {"scheduled_automation": {"target_workflow": "wf-auto"}}}
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    with pytest.raises(ConfigError, match=r"target_workflow.*wf-auto.*wf-new --auto"):
         load_config()
 
 

--- a/tests/repo/test_automation_run_state.py
+++ b/tests/repo/test_automation_run_state.py
@@ -1,4 +1,4 @@
-"""Canonical wf-auto state resolver contracts after the automation-run migration."""
+"""Canonical wf-new --auto state resolver contracts after the automation-run migration."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from types import ModuleType
 from tests.helpers.paths import REPO_ROOT
 
 ROOT = REPO_ROOT
-SCRIPT = ROOT / ".claude" / "skills" / "wf-auto" / "references" / "wf-auto-state.py"
+SCRIPT = ROOT / ".claude" / "skills" / "wf-new" / "references" / "wf-auto-state.py"
 
 
 def _load_state_module() -> ModuleType:

--- a/tests/repo/test_automation_schedule_backends.py
+++ b/tests/repo/test_automation_schedule_backends.py
@@ -43,7 +43,7 @@ def test_native_backend_selection(product, dependency_mode, os_fallback, expecte
 
 def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypatch):
     scheduled = SimpleNamespace(
-        target_workflow="wf-auto",
+        target_workflow="wf-new --auto",
         allow_external_publish=False,
         timezone="Asia/Tokyo",
         run_time="09:05",
@@ -75,15 +75,16 @@ def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypat
     assert plan["retry_delay_seconds"] == 300
     assert "最大 4 回再試行" in plan["prompt"]
     assert plan["prevent_concurrent_runs"] is True
-    assert plan["target_workflow"] == "wf-auto"
-    assert plan["prompt"].startswith("/wf-auto")
+    assert plan["target_workflow"] == "wf-new --auto"
+    assert plan["prompt"].startswith("/wf-new --auto")
     assert plan["dependency_mode"] == "local"
     assert "local dependencies require desktop local project" in plan["management"]
 
 
-def test_plan_rejects_removed_automation_run_override(tmp_path, monkeypatch):
+@pytest.mark.parametrize("removed_target", ["automation-run", "wf-auto"])
+def test_plan_rejects_removed_target_override(tmp_path, monkeypatch, removed_target):
     scheduled = SimpleNamespace(
-        target_workflow="wf-auto",
+        target_workflow="wf-new --auto",
         allow_external_publish=False,
         timezone="Asia/Tokyo",
         run_time="09:05",
@@ -100,11 +101,11 @@ def test_plan_rejects_removed_automation_run_override(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
 
-    with pytest.raises(backend.BackendError, match=r"automation-run.*wf-auto"):
+    with pytest.raises(backend.BackendError, match=rf"{removed_target}.*wf-new --auto"):
         backend.build_plan(
             product="codex",
             dependency_mode="local",
-            overrides={"target_workflow": "automation-run"},
+            overrides={"target_workflow": removed_target},
         )
 
 

--- a/tests/repo/test_automation_schedule_runtime_contracts.py
+++ b/tests/repo/test_automation_schedule_runtime_contracts.py
@@ -136,7 +136,7 @@ exit 0
 def _config(**overrides: object) -> dict[str, object]:
     value: dict[str, object] = {
         "enabled": True,
-        "target_workflow": "wf-auto",
+        "target_workflow": "wf-new --auto",
         "max_retries": 0,
         "retry_delay_seconds": 3,
         "prevent_concurrent_runs": True,
@@ -294,7 +294,7 @@ def test_schedule_config_generate_show_dry_run_shape_and_exclusive_flags(
         enable=True,
         run_time="08:45",
         cadence="mon,fri",
-        target_workflow="wf-auto",
+        target_workflow="wf-new --auto",
         max_retries=2,
         retry_delay_seconds=10,
         notification="none",

--- a/tests/repo/test_production_quality_setup_redirect_contract.py
+++ b/tests/repo/test_production_quality_setup_redirect_contract.py
@@ -317,7 +317,7 @@ ISSUE_3986_OWNED_PATHS = frozenset(
         ".claude/skills/channel-status/SKILL.md",
         ".claude/skills/video-description/SKILL.md",
         ".claude/skills/video-upload/SKILL.md",
-        ".claude/skills/wf-auto/SKILL.md",
+        ".claude/skills/wf-new/references/auto.md",
         ".claude/skills/wf-new-batch/SKILL.md",
         ".claude/skills/wf-new/SKILL.md",
         ".claude/skills/wf-next/SKILL.md",
@@ -1012,6 +1012,6 @@ def test_issue_3987_commit_has_exact_semantic_diff_scope() -> None:
 
 def test_diff_scope_contract_rejects_missing_target_and_unrelated_mutations() -> None:
     missing_target = EXPECTED_ISSUE_3987_CHANGED_PATHS - {".claude/skills/thumbnail/SKILL.md"}
-    unrelated = EXPECTED_ISSUE_3987_CHANGED_PATHS | {".claude/skills/wf-auto/SKILL.md"}
+    unrelated = EXPECTED_ISSUE_3987_CHANGED_PATHS | {".claude/skills/wf-new/references/auto.md"}
     assert missing_target != EXPECTED_ISSUE_3987_CHANGED_PATHS
     assert unrelated != EXPECTED_ISSUE_3987_CHANGED_PATHS

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -134,7 +134,7 @@ def test_workflow_schema_references_existing_skill_schema() -> None:
 
 
 def test_wf_auto_is_the_integrated_entrypoint_without_copying_child_workflows() -> None:
-    wf_auto = _read(".claude/skills/wf-auto/SKILL.md")
+    wf_auto = _read(".claude/skills/wf-new/references/auto.md")
     wf_new = _read_wf_new()
     wf_next = _read(".claude/skills/wf-next/SKILL.md")
     wf_status = _read(".claude/skills/wf-status/SKILL.md")
@@ -147,21 +147,21 @@ def test_wf_auto_is_the_integrated_entrypoint_without_copying_child_workflows() 
     assert "無人実行" in wf_auto
     assert "allow_external_publish" in wf_auto
     assert "references/wf-auto-state.py" in wf_auto
-    assert "/wf-auto" in wf_new
-    assert "/wf-auto" in wf_next
-    assert "/wf-auto" in wf_status
-    assert "/wf-auto" in schema
+    assert "/wf-new --auto" in wf_new
+    assert "/wf-new --auto" in wf_next
+    assert "/wf-new --auto" in wf_status
+    assert "/wf-new --auto" in schema
 
 
 def test_wf_auto_is_the_only_integrated_workflow_entrypoint() -> None:
-    canonical = _read(".claude/skills/wf-auto/SKILL.md")
+    canonical = _read(".claude/skills/wf-new/references/auto.md")
     features = _read("docs/features.md")
     cheatsheet = _read("docs/workflow-cheatsheet.md")
 
     assert "正規入口" in canonical
     assert not (ROOT / ".claude/skills/automation-run").exists()
     assert "正規入口" in features and "| /automation-run |" not in features
-    assert "/wf-auto" in cheatsheet
+    assert "/wf-new --auto" in cheatsheet
 
 
 def test_theme_compare_docs_and_error_use_content_tags_themes() -> None:

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -23,7 +23,7 @@ def test_skill_catalog_matches_all_distributed_skills() -> None:
     skill_names = _skill_names()
     catalog_names = _catalog_names()
 
-    assert len(skill_names) == 55
+    assert len(skill_names) == 54
     assert len(catalog_names) == len(set(catalog_names))
     assert set(catalog_names) == skill_names
 

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -28,7 +28,7 @@ SUNO_HELPER_SKILL_MD = _SKILL_INVENTORY.skill_directory("suno-helper") / "SKILL.
 SUNO_HELPER_README_MD = _REPO_ROOT / "extensions" / "suno-helper" / "README.md"
 WF_NEW_SKILL_MD = _SKILL_INVENTORY.skill_directory("wf-new") / "SKILL.md"
 WF_NEW_PHASE2_MD = _SKILL_INVENTORY.resolve_reference("wf-new", "references/phase2.md")
-WF_AUTO_SKILL_MD = _SKILL_INVENTORY.skill_directory("wf-auto") / "SKILL.md"
+WF_AUTO_SKILL_MD = _SKILL_INVENTORY.resolve_reference("wf-new", "references/auto.md")
 SUNO_HELPER_PHASE_CONSTANTS_TS = _REPO_ROOT / "extensions" / "shared" / "constants.ts"
 SUNO_LYRIC_SKILL_MD = _SKILL_INVENTORY.skill_directory("suno-lyric") / "SKILL.md"
 REVIEW_RUBRIC_MD = _SKILL_INVENTORY.resolve_reference("suno-lyric", "references/review-rubric.md")
@@ -353,7 +353,7 @@ def test_wf_new_hands_off_to_suno_helper_browser_use_flow() -> None:
 
 
 def test_wf_auto_runs_suno_helper_browser_flow_instead_of_handing_it_off() -> None:
-    """Issue #2454: 認証以外の Suno 工程は wf-auto の agent が完走する。"""
+    """Issue #2454: 認証以外の Suno 工程は wf-new --auto の agent が完走する。"""
     text = _read_wf_auto()
     section = text.split("### `suno-helper` action の自律実行契約", 1)[1].split("\n## ", 1)[0]
 

--- a/tests/repo/test_unattended_approval_skip_contract.py
+++ b/tests/repo/test_unattended_approval_skip_contract.py
@@ -32,7 +32,7 @@ def test_wf_new_auto_selection_is_rank_one_and_excludes_minimal_mode() -> None:
 
 
 def test_wf_auto_recognizes_explicit_skip_settings() -> None:
-    text = _text("wf-auto")
+    text = (SKILLS / "wf-new" / "references" / "auto.md").read_text(encoding="utf-8")
 
     assert "workflow.wf_new.skip_plan_selection" in text
     assert "skip_*_approval" in text

--- a/tests/repo/test_wf_auto_ai_timing_skill_contract.py
+++ b/tests/repo/test_wf_auto_ai_timing_skill_contract.py
@@ -1,4 +1,4 @@
-"""`/wf-auto` canonical action の AI timing 実行契約を検証する。"""
+"""`/wf-new --auto` canonical action の AI timing 実行契約を検証する。"""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import re
 
 from tests.helpers.paths import REPO_ROOT
 
-SKILL_MD = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+SKILL_MD = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "auto.md"
 
 
 def _section(text: str, heading: str) -> str:

--- a/tests/repo/test_wf_auto_human_timing_skill_contract.py
+++ b/tests/repo/test_wf_auto_human_timing_skill_contract.py
@@ -1,4 +1,4 @@
-"""`/wf-auto` の同一 run 人間介入 gate timing 契約を検証する。"""
+"""`/wf-new --auto` の同一 run 人間介入 gate timing 契約を検証する。"""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import re
 
 from tests.helpers.paths import REPO_ROOT
 
-SKILL_MD = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+SKILL_MD = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "auto.md"
 
 
 def _section(text: str, heading: str) -> str:

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -1,4 +1,4 @@
-"""`/wf-auto` の新規開始・固定・再開契約テスト。"""
+"""`/wf-new --auto` の新規開始・固定・再開契約テスト。"""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 
 ROOT = REPO_ROOT
-SKILL_DIR = ROOT / ".claude" / "skills" / "wf-auto"
+SKILL_DIR = ROOT / ".claude" / "skills" / "wf-new"
 SCRIPT = SKILL_DIR / "references" / "wf-auto-state.py"
 
 

--- a/tests/repo/test_wf_new_modes_skill_contract.py
+++ b/tests/repo/test_wf_new_modes_skill_contract.py
@@ -1,0 +1,46 @@
+"""`/wf-new` の排他 mode と `--auto` 統合契約を検証する。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "wf-new"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+AUTO_MD = SKILL_DIR / "references" / "auto.md"
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^##\s|\Z)",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"`{heading}` セクションが見つかりません")
+    return match.group("body")
+
+
+def test_mode_dispatch_is_exclusive_before_any_mutation() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    mode = _section(skill, "## モード判定")
+
+    assert skill.index("## モード判定") < skill.index("## 前提")
+    assert "$ARGUMENTS" in mode
+    assert "2 個以上" in mode
+    assert "state・lease・成果物は一切変更しない" in mode
+    assert "1 個なら" in mode
+    assert "0 個なら従来の通常入口" in mode
+    assert "| `--auto` | `references/auto.md` |" in mode
+    assert "--batch" not in mode
+    assert "--schedule" not in mode
+
+
+def test_auto_mode_reuses_the_normal_entry_for_wf_new_action() -> None:
+    auto = AUTO_MD.read_text(encoding="utf-8")
+
+    assert "resolver が `action: wf-new`" in auto
+    assert "同一 SKILL.md の通常入口" in auto
+    for gate in ("企画選択", "thumbnail 承認", "preselected manifest", "channel constraint verification"):
+        assert gate in auto

--- a/tests/repo/test_wf_new_timing_skill_contract.py
+++ b/tests/repo/test_wf_new_timing_skill_contract.py
@@ -8,7 +8,7 @@ from tests.helpers.paths import REPO_ROOT
 
 WF_NEW_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
 WF_NEW_PHASE2 = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "phase2.md"
-WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "auto.md"
 
 
 def _wf_new_text() -> str:
@@ -86,4 +86,4 @@ def test_wf_auto_delegation_reuses_one_lease_and_attempt() -> None:
 
     assert "実行文脈を再利用" in direct
     assert "nested `acquire`" in direct
-    assert "canonical history の記録と lease 解放は `/wf-auto` に一度だけ" in direct
+    assert "canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ" in direct

--- a/tests/repo/test_wf_next_timing_skill_contract.py
+++ b/tests/repo/test_wf_next_timing_skill_contract.py
@@ -7,7 +7,7 @@ import re
 from tests.helpers.paths import REPO_ROOT
 
 WF_NEXT_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-next" / "SKILL.md"
-WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-auto" / "SKILL.md"
+WF_AUTO_SKILL = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "auto.md"
 
 
 def _section(text: str, heading: str) -> str:
@@ -99,6 +99,6 @@ def test_delegation_reuses_one_lease_attempt_and_history_record() -> None:
 
     assert "実行文脈を再利用" in direct
     assert "nested `acquire`" in direct
-    assert "canonical history の記録と lease 解放は `/wf-auto` に一度だけ" in direct
+    assert "canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ" in direct
     assert "release --channel-dir . --token <token>" in direct
     assert "他 token" in direct

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -164,21 +164,9 @@ EXPECTED_ACTIVE_ROUTES = (
         )
     ),
     _route(
-        "wf-auto/SKILL.md",
-        "## 実行手順",
-        "1. `config/channel/` が無ければ `/setup --channel` を案内して停止する。",
-    ),
-    _route(
-        "wf-auto/SKILL.md",
-        "## 実行手順",
-        "   `load_config()` が失敗した場合は既存チャンネル取り込みモードの `/channel-new` を案内して停止する。"
-        "state resolver または上記子 skill が無ければ `/automation-update`（本リポジトリ内では "
-        "`yt-skills sync`）を案内して停止する。すべて満たすまで lease と子 skill を開始しない。",
-    ),
-    _route(
         "wf-new/SKILL.md",
         "## 前後工程",
-        "- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`",
+        "- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`, `/automation-schedule`",
     ),
     _route(
         "wf-new/SKILL.md",
@@ -200,6 +188,18 @@ EXPECTED_ACTIVE_ROUTES = (
         "wf-new/SKILL.md",
         "## Hard Gates",
         "   - `load_config()` が失敗する場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する。",
+    ),
+    _route(
+        "wf-new/references/auto.md",
+        "## 実行手順",
+        "1. `config/channel/` が無ければ `/setup --channel` を案内して停止する。",
+    ),
+    _route(
+        "wf-new/references/auto.md",
+        "## 実行手順",
+        "   `load_config()` が失敗した場合は既存チャンネル取り込みモードの `/channel-new` を案内して停止する。"
+        "state resolver または上記子 skill が無ければ `/automation-update`（本リポジトリ内では "
+        "`yt-skills sync`）を案内して停止する。すべて満たすまで lease と子 skill を開始しない。",
     ),
     *(
         _route(f"{skill}/SKILL.md", "## 前提", line)
@@ -229,6 +229,8 @@ EXPECTED_ACTIVE_ROUTES = (
 MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path != "automation-update/SKILL.md") | {
     "wf-new/references/phase-2c-artifact-contract.md",
     "wf-new/references/phase2.md",
+    "wf-new/references/auto.md",
+    "wf-new/references/wf-auto-state.py",
 }
 EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
     {
@@ -251,7 +253,7 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "3586bfd3687e8f72ba28e1f5bcd795c79c0059901abeffe5c6bcdd6f2a37d6b5"
+IMMUTABLE_TARGET_FILES_SHA256 = "371f61933a99d5557e05dc9c50fd201d9df8f3422600a7014458db8112b85a12"
 AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "3df1c507167b2fc71dcae7acaa0a6011fb3ee89fabbb95f6ffc2b5d2b803e617"
 AUTOMATION_UPDATE_PUSH_SHA256 = "5be1d31198da13ab6929edb13c9b713fbb9bc364d413b778d79f4e624e30d2cc"
 ALLOWED_FENCED_ROUTES = {


### PR DESCRIPTION
## 概要

旧 `/wf-auto` の lease・state resolver・timing・委譲・完了条件を `/wf-new --auto` の排他 mode へ統合します。scheduled target の既定も更新し、旧値は案内付き `ConfigError` とします。

履歴文書は変更せず、配布・package resource・site・現行 skill 参照まで追従しています。

## 検証

- ruff / 全 yt-skills gate
- 関連 496 tests、wheel/sdist 2 tests
- `PYTHONDONTWRITEBYTECODE=1 pytest -n auto`（8999 passed, 3 skipped）
- site check/build/test（53 passed）

Closes #3740