### PR TITLE
feat(skills): wf-new-batchをwf-new --batchへ統合する (#3741)

### DIFF
--- a/.claude/skills/collection-ideate/SKILL.md
+++ b/.claude/skills/collection-ideate/SKILL.md
@@ -90,7 +90,7 @@ Phase 3 では単なる候補 `N` 件ではなく、制作へ渡せる確定 pla
 
 保存前 Hard Gate として、`requested_count == N`、`plans` がちょうど `N` 件、`approved_at` と全必須 field が非空、`track_count >= 1`、`music_engine` が `suno` または `lyria`、`plan_id` と `theme_slug` と既存 slug が各集合内で一意であることを検証する。特に `theme_slug` が batch 内で一意かつ既存 collection と衝突しないこと、全比較行が重複・欠落なく揃うことを必須とする。1 件でも失敗したら manifest を更新せず停止する。保存は同一 directory の一時ファイルを完全に書いて検証した後の **atomic rename** とし、失敗時に既存 manifest を保つ。
 
-batch mode では collection directory と `workflow-state.json` を作成・更新しない。open insights を使った場合の status 更新は全件承認後に通常契約どおり行い、更新失敗時は manifest を complete として保存しない。manifest の保存と再読込検証が成功した時点だけ batch plan mode の完了とし、次工程 `/wf-new-batch` へ `batch_id` を渡す。
+batch mode では collection directory と `workflow-state.json` を作成・更新しない。open insights を使った場合の status 更新は全件承認後に通常契約どおり行い、更新失敗時は manifest を complete として保存しない。manifest の保存と再読込検証が成功した時点だけ batch plan mode の完了とし、次工程 `/wf-new --batch` へ `batch_id` を渡す。
 
 ## 前提スキル状態確認
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wf-new
 purpose: 進める
-description: "Use when 新規コレクション制作を立ち上げるとき、または --auto で collection の有無を問わず公開後処理まで状態駆動で継続・再開するとき。「新しいコレクション始めたい」「制作開始」「制作を最初から最後まで」で発動。一段だけ進める場合は /wf-next"
+description: "Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、または --batch で複数コレクションを一括企画・順次実行するとき。「新しいコレクション始めたい」「制作開始」「制作を最初から最後まで」「複数コレクション制作」「一括制作」で発動。一段だけ進める場合は /wf-next"
 ---
 
 ## 前後工程
@@ -12,12 +12,12 @@ description: "Use when 新規コレクション制作を立ち上げるとき、
 
 ## 成果物
 
-- `書き込む`: `.automation-run/history.json`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
+- `書き込む`: `.automation-run/history.json`, `reports/wf-new-batches/<batch-id>/plan-manifest.json`, `reports/wf-new-batches/<batch-id>/batch-ledger.json`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
 - `読み込む`: `config/channel/*.json`, `config/localizations.json`, `data/benchmark_*.json`, `reports/analysis_*.md`, `data/insights.jsonl`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/post_publish_history.json`
 
 ## モード判定
 
-`$ARGUMENTS` から `--auto` の個数を最初に数える。
+`$ARGUMENTS` から排他 mode の `--auto` と `--batch` を完全一致で抽出し、その合計個数を最初に数える。前方一致は禁止し、通常入口の preselected 引数 `--batch-id` / `--plan-id` は `--batch` として数えない。
 
 - 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す。state・lease・成果物は一切変更しない
 - 1 個なら対応する reference を読み、その mode だけを実行する。残りの引数はその mode の引数として扱う
@@ -26,6 +26,14 @@ description: "Use when 新規コレクション制作を立ち上げるとき、
 | mode | 読む reference |
 |---|---|
 | `--auto` | `references/auto.md` |
+| `--batch` | `references/batch.md` |
+
+## 修飾フラグ
+
+| flag | 対象 mode | 用途 |
+|---|---|---|
+| `--count <N>` | `--batch` | 2 件以上の初回 batch を開始する |
+| `--resume <batch-id>` | `--batch` | 中断済み batch を再開する |
 
 ## Overview
 

--- a/.claude/skills/wf-new/references/batch-ledger.py
+++ b/.claude/skills/wf-new/references/batch-ledger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate and atomically update `/wf-new-batch` ledger state."""
+"""Validate and atomically update `/wf-new --batch` ledger state."""
 
 from __future__ import annotations
 

--- a/.claude/skills/wf-new/references/batch.md
+++ b/.claude/skills/wf-new/references/batch.md
@@ -1,9 +1,3 @@
----
-name: wf-new-batch
-purpose: 進める
-description: "Use when 複数の新規コレクションを相互差別化して一括企画し、正規 /wf-new を順次実行・再開するとき。「複数コレクション制作」「一括制作」「batch 制作」で発動"
----
-
 ## 前後工程
 
 - `前工程`: `/setup --channel`, `/setup`
@@ -32,8 +26,8 @@ manifest の全 plan が `completed` で、各 collection を実ファイルか�
 
 ## Entry contract
 
-- 初回: `/wf-new-batch --count <N>`。`N` は 2 以上の整数でなければ停止する
-- 再開: `/wf-new-batch --resume <batch-id>`。`batch-id` は `[a-z0-9][a-z0-9-]*` に一致しなければ停止する
+- 初回: `/wf-new --batch --count <N>`。`N` は 2 以上の整数でなければ停止する
+- 再開: `/wf-new --batch --resume <batch-id>`。`batch-id` は `[a-z0-9][a-z0-9-]*` に一致しなければ停止する
 - `--count` と `--resume` は同時指定不可。どちらもない、または両方ある場合は state を変更せず使い方を表示する
 
 通常の `/wf-new` を batch と推測して起動しない。batch-id から組み立てる canonical directory は `reports/wf-new-batches/<batch-id>/` だけとし、外部 path や `..` を受け入れない。
@@ -78,7 +72,7 @@ manifest 順に各 plan を実ファイルと照合する。`completed` は再�
 `pending` / `in_progress` / `blocked` / `failed` も、canonical child を呼ぶ前に same-provenance collection の actual state を必ず照合する。`phase == "prepared"` かつ構成に応じた hard artifacts がすべて有効なら、child 完了後・ledger completed 更新前に crash した window と判定する。検証した `batch_id`、`plan_id`、`phase`、`hard_artifacts_valid`、`collection_dir` だけを一時 actual JSON に書き、次を実行する。
 
 ```bash
-uv run python3 .claude/skills/wf-new-batch/references/batch-ledger.py reconcile \
+uv run python3 .claude/skills/wf-new/references/batch-ledger.py reconcile \
   "reports/wf-new-batches/<batch-id>/batch-ledger.json" \
   --plan-id "<plan-id>" --actual "<verified-actual.json>" --updated-at "<ISO-8601>"
 ```
@@ -90,7 +84,7 @@ uv run python3 .claude/skills/wf-new-batch/references/batch-ledger.py reconcile 
 plan は manifest 順に 1 件ずつ処理し、複数の `/wf-new` を並列に起動しない。
 
 1. 対象 plan を `batch-ledger.py transition` で `in_progress`、batch の `current_plan_id` を対象 ID として atomic 更新する
-2. `/wf-new --batch-id <batch-id> --plan-id <plan-id>` を呼び、preselected batch plan entry に検証・初期化・再開を委譲する
+2. `/wf-new --batch-id <batch-id> --plan-id <plan-id>` を呼ぶ。これは別 skill ではなく同一 SKILL.md の通常入口（排他 mode 0 個 + preselected 引数の経路）であり、preselected batch plan entry に検証・初期化・再開を自己委譲する
 3. child が停止した場合は原因を分類する
    - ユーザー承認、認証、必要仕様、外部サービス待ち: plan と batch を `blocked`
    - 実行・成果物検証の失敗: plan と batch を `failed`
@@ -104,11 +98,11 @@ plan は manifest 順に 1 件ずつ処理し、複数の `/wf-new` を並列に
 
 全 plan が `completed` になったら、manifest 件数と ledger 件数、plan-id/order、collection provenance をもう一度照合し、各 collection の通常 `/wf-new` 完了条件と hard artifacts を再検証する。全件成功後だけ batch status を `completed`、`current_plan_id` を `null` に atomic 更新する。
 
-1 件でも不一致なら該当 plan と batch を `blocked` に戻し、証拠と `resume_action` を残す。完了済みの他 plan は変更せず、修復後に `/wf-new-batch --resume <batch-id>` で再検証する。
+1 件でも不一致なら該当 plan と batch を `blocked` に戻し、証拠と `resume_action` を残す。完了済みの他 plan は変更せず、修復後に `/wf-new --batch --resume <batch-id>` で再検証する。
 
 ## 想定 API call 数
 
-この skill 自体は外部 API を呼ばない。初回の `/collection-ideate` 1 回と、plan ごとの `/wf-new` が各 child skill の API call を行う。見積もり、上限、承認は各 child の契約をそのまま適用し、batch 件数を理由に省略しない。
+この mode 自体は外部 API を呼ばない。初回の `/collection-ideate` 1 回と、plan ごとの同一 SKILL.md の通常入口が各 child skill の API call を行う。見積もり、上限、承認は各 child の契約をそのまま適用し、batch 件数を理由に省略しない。
 
 ## 完了報告
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `/wf-new-batch` を `/wf-new --batch` へ統合し、排他 mode 判定、batch ledger・再開・自己通常入口契約を同一 skill へ移設する（#3741）。
+
 - `feat(skills)`: `/wf-auto` を `/wf-new --auto` へ統合し、排他 mode 判定、既存 state/lease/timing 契約の移設、scheduled automation の新既定と旧値拒否を追加する（#3740）。
 
 - `refactor(skills)`: `/wf-new` の Phase 2 を `references/phase2.md` へ移し、実行契約を維持したまま SKILL.md 本体を 400 行以下にする（#3870）。

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **54 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **53 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -10,9 +10,8 @@
 
 | Skill | なにができるか |
 |---|---|
-| /wf-new | フラグなしで新規コレクションを立ち上げ、正規入口 `--auto` では active collection の有無を問わず公開後処理まで状態駆動で継続・再開 |
+| /wf-new | フラグなしで新規コレクションを立ち上げ、正規入口 `--auto` では公開後処理まで継続・再開し、`--batch` では複数企画を相互差別化して順次実行 |
 | /wf-next | 既存コレクションを次の工程に 1 段進める（Phase 2-3） |
-| /wf-new-batch | 複数の新規コレクションを相互差別化して一括企画し、正規 `/wf-new` を順次実行・再開 |
 | /wf-status | 制作中コレクションの進捗を読み取り表示（実行はしない） |
 | /automation-schedule | 定期制作設定（`workflow.json` の `scheduled_automation`）の生成と、既定 `/wf-new --auto` を起動する Claude Code / Codex ジョブの作成・更新・確認・停止 |
 | /collection-ideate | データドリブンに次の企画候補を提案 |

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -32,8 +32,7 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 - `/automation-schedule` — Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。
 - `/collection-ideate` — Use when 新コレクションの企画・テーマ選定をデータドリブンに行うとき。
 - `/streaming` — Use when ライブ配信用 Vultr VPS・動画配信本体を Terraform で構築・運用・トラブルシュートするとき。
-- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき、または --auto で collection の有無を問わず公開後処理まで状態駆動で継続・再開するとき。
-- `/wf-new-batch` — Use when 複数の新規コレクションを相互差別化して一括企画し、正規 /wf-new を順次実行・再開するとき。
+- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、または --batch で複数コレクションを一括企画・順次実行するとき。
 - `/wf-next` — Use when 既存コレクション（collections/planning/）を一段進めるとき。
 - `/wf-status` — Use when コレクション制作の進捗を読むだけで確認するとき（実行しない）。
 

--- a/docs/workflow-cheatsheet.md
+++ b/docs/workflow-cheatsheet.md
@@ -1,6 +1,6 @@
 # workflow チートシート
 
-`/wf-new --auto` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
+`/wf-new --auto` `/wf-new --batch` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
 
 > Skill 全体のカタログは [`docs/features.md`](features.md) を参照。
 
@@ -11,6 +11,7 @@
 ────────────────────────────────────────────────
 「次なに作る？」「テーマ候補が欲しい」  → /collection-ideate   （企画候補を提案する）
 「企画から公開後処理まで全部進めて」      → /wf-new --auto             （新規開始または未完了地点から完走）
+「複数コレクションを一括企画したい」      → /wf-new --batch            （相互差別化して順次準備）
 「新しいコレクション始めたい」          → /wf-new              （企画選択 → ディレクトリ作成 → 素材準備）
 「制作中のやつ、次のステップやって」    → /wf-next             （phase に応じて次工程を 1 段実行）
 「どこまで進んだ？読むだけ」           → /wf-status           （実行はしない・読み取り表示のみ）
@@ -21,6 +22,7 @@
 | ユーザーの状況 | 使う skill |
 |---|---|
 | collection の有無を問わず **企画から公開後処理まで進めたい** | `/wf-new --auto`（正規入口） |
+| 2 件以上を **相互差別化して一括企画・順次準備したい** | `/wf-new --batch --count <N>` |
 | 制作中コレクションが **無い** + 企画候補も **無い** | `/collection-ideate` → 候補が決まったら `/wf-new` |
 | 制作中コレクションが **無い** + 企画候補は **頭にある** | `/wf-new`（その中で `/collection-ideate` が走る） |
 | 制作中コレクションが **ある** + 進める意思がある | `/wf-next` |
@@ -31,6 +33,7 @@
 | Skill | 何をする | 何をしない | 一時停止する場面 |
 |---|---|---|---|
 | `/wf-new --auto` | collection 不在なら `/wf-new` から開始し、存在すれば未完了地点から制作・公開・post-publish まで状態駆動で再評価する | 子 skill の実装を複製しない | 認証、CAPTCHA、承認待ち、公開未許可など人間の介入が必要な場面 |
+| `/wf-new --batch` | 複数企画を一括承認し、同一 `/wf-new` の通常入口へ 1 件ずつ渡して準備する | child gate を省略せず、並列実行しない | child の失敗、承認待ち、外部前提待ち、成果物不整合 |
 | `/collection-ideate` | analytics mode / benchmark fallback mode、または `ttp_mode: false` の minimal mode の入力でペルソナ別 3 企画候補を生成 | コレクションディレクトリは作らない | 提案表示のみ（選択は `/wf-new` 側で）。`ttp_mode: true` の minimal mode は `/benchmark` を案内して停止 |
 | `/wf-new` | 企画選択 → `yt-init-collection` でディレクトリ + `workflow-state.json` 作成 → サムネ・音楽素材生成 | 楽曲の最終マスタリングや動画化はしない | 通常は (1) 企画選択 (2) サムネ承認。`ttp_mode: false` の minimal mode は企画候補生成前にテーマ / ジャンル / 雰囲気の直接入力確認を追加し、`true` は `/benchmark` の案内で停止 |
 | `/wf-next` | `workflow-state.json::phase` に応じて次工程を 1 段実行（Suno DL / Lyria 生成 / 動画化 / アップロード） | 新規コレクションは作らない | マスター音源が無い phase = "prepared" 状態（ユーザーがミキシング+マスタリングを行う） |

--- a/site/tests/operator-doc-source.test.mjs
+++ b/site/tests/operator-doc-source.test.mjs
@@ -159,11 +159,11 @@ test("anchor、絶対 URL、非 Markdown link は変更しない", () => {
 });
 
 test("features の skill 行は個別ページへの導線にする", () => {
-  const markdown = "| /thumbnail | CTR 最適化 |\n| /wf-new-batch | 一括企画 |\n";
+  const markdown = "| /thumbnail | CTR 最適化 |\n| /wf-new | 新規・一括企画 |\n";
 
   assert.equal(
     rewriteFeatureSkillLinks(markdown),
     "| [/thumbnail](/skills/thumbnail) | CTR 最適化 |\n" +
-      "| [/wf-new-batch](/skills/wf-new-batch) | 一括企画 |\n"
+      "| [/wf-new](/skills/wf-new) | 新規・一括企画 |\n"
   );
 });

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -151,13 +151,13 @@ test("実リポジトリでは9カテゴリと全skillを生成する", async ()
     await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
   ).match(/^\| \/[a-z0-9-]+ /gmu);
 
-  assert.equal(result.entries.length, 55);
-  assert.equal(skillDirectories?.length, 54);
+  assert.equal(result.entries.length, 54);
+  assert.equal(skillDirectories?.length, 53);
   assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
   assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
 });
 
-test("production build は一覧と54個の個別ページを公開する", async () => {
+test("production build は一覧と53個の個別ページを公開する", async () => {
   const siteRoot = resolve(import.meta.dirname, "..");
   const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
   const thumbnail = await readFile(
@@ -165,8 +165,8 @@ test("production build は一覧と54個の個別ページを公開する", asyn
     "utf8"
   );
 
-  assert.match(index, /54 個の skill/);
-  assert.match(index, /href="\/skills\/wf-new-batch"/);
+  assert.match(index, /53 個の skill/);
+  assert.match(index, /href="\/skills\/wf-new"/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);
   assert.match(thumbnail, /href="\/skills\/thumbnail-compare"/);

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -23,7 +23,7 @@ def test_skill_catalog_matches_all_distributed_skills() -> None:
     skill_names = _skill_names()
     catalog_names = _catalog_names()
 
-    assert len(skill_names) == 54
+    assert len(skill_names) == 53
     assert len(catalog_names) == len(set(catalog_names))
     assert set(catalog_names) == skill_names
 

--- a/tests/repo/test_wf_new_batch_skill_contract.py
+++ b/tests/repo/test_wf_new_batch_skill_contract.py
@@ -11,6 +11,8 @@ from tests.helpers.paths import REPO_ROOT
 from youtube_automation.domains.skills.inventory import SkillInventory
 
 _SKILL_INVENTORY = SkillInventory(REPO_ROOT)
+BATCH_REFERENCE = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "batch.md"
+BATCH_LEDGER = REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "batch-ledger.py"
 
 
 def _read_skill(name: str) -> str:
@@ -19,6 +21,10 @@ def _read_skill(name: str) -> str:
     if name == "wf-new":
         paths.append(_SKILL_INVENTORY.resolve_reference(name, "references/phase2.md"))
     return "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+
+def _read_batch_reference() -> str:
+    return BATCH_REFERENCE.read_text(encoding="utf-8")
 
 
 def _load_reference(name: str, path: Path) -> ModuleType:
@@ -196,7 +202,7 @@ def test_batch_manifest_validator_rejects_structural_mismatches(case: str, mutat
 def test_batch_ledger_allows_only_declared_transitions() -> None:
     state = _load_reference(
         "batch_ledger_transitions",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = state.transition_plan(
         _valid_ledger(),
@@ -226,7 +232,7 @@ def test_batch_ledger_allows_only_declared_transitions() -> None:
 def test_batch_ledger_guardedly_blocks_completed_plan_after_revalidation_drift() -> None:
     state = _load_reference(
         "batch_ledger_guarded_downgrade",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = _valid_ledger()
     for index, plan_id in enumerate(("plan-a", "plan-b"), start=1):
@@ -273,7 +279,7 @@ def test_batch_ledger_guardedly_blocks_completed_plan_after_revalidation_drift()
 def test_batch_ledger_rejects_second_active_plan() -> None:
     state = _load_reference(
         "batch_ledger_single_active",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = state.transition_plan(
         _valid_ledger(),
@@ -294,7 +300,7 @@ def test_batch_ledger_rejects_second_active_plan() -> None:
 def test_batch_ledger_rejects_current_plan_status_mismatch() -> None:
     state = _load_reference(
         "batch_ledger_current_coherence",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = _valid_ledger()
     ledger["current_plan_id"] = "plan-a"
@@ -313,7 +319,7 @@ def test_batch_ledger_rejects_current_plan_status_mismatch() -> None:
 def test_batch_ledger_atomic_failure_preserves_previous_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     state = _load_reference(
         "batch_ledger_atomic",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     path = tmp_path / "batch-ledger.json"
     original = _valid_ledger()
@@ -338,7 +344,7 @@ def test_batch_ledger_atomic_failure_preserves_previous_file(tmp_path: Path, mon
 def test_batch_ledger_reconciles_child_complete_crash_without_changing_actual_state() -> None:
     state = _load_reference(
         "batch_ledger_reconcile",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = state.transition_plan(
         _valid_ledger(),
@@ -370,7 +376,7 @@ def test_batch_ledger_reconciles_child_complete_crash_without_changing_actual_st
 def test_batch_ledger_does_not_reconcile_incomplete_or_mismatched_actual_state() -> None:
     state = _load_reference(
         "batch_ledger_reconcile_negative",
-        REPO_ROOT / ".claude" / "skills" / "wf-new-batch" / "references" / "batch-ledger.py",
+        BATCH_LEDGER,
     )
     ledger = state.transition_plan(
         _valid_ledger(),
@@ -431,7 +437,7 @@ def test_wf_new_normal_entry_does_not_infer_preselected_mode() -> None:
 
 
 def test_wf_new_batch_is_sequential_resumable_and_delegates_to_wf_new() -> None:
-    text = _read_skill("wf-new-batch")
+    text = _read_batch_reference()
 
     assert "reports/wf-new-batches/<batch-id>/batch-ledger.json" in text
     assert "`/collection-ideate` を 1 回だけ" in text
@@ -448,10 +454,18 @@ def test_wf_new_batch_is_sequential_resumable_and_delegates_to_wf_new() -> None:
 
 
 def test_wf_new_batch_done_requires_every_canonical_wf_new_completion() -> None:
-    text = _read_skill("wf-new-batch")
+    text = _read_batch_reference()
 
     assert "全 plan が `completed`" in text
     assert '`phase == "prepared"`' in text
     assert "hard artifacts" in text
     assert "approval gate" in text
     assert "batch ledger だけを根拠に Done としない" in text
+
+
+def test_wf_new_batch_assets_are_owned_by_wf_new() -> None:
+    skill = _read_skill("wf-new")
+
+    assert "reports/wf-new-batches/<batch-id>/plan-manifest.json" in skill
+    assert "reports/wf-new-batches/<batch-id>/batch-ledger.json" in skill
+    assert not (REPO_ROOT / ".claude" / "skills" / "wf-new-batch").exists()

--- a/tests/repo/test_wf_new_modes_skill_contract.py
+++ b/tests/repo/test_wf_new_modes_skill_contract.py
@@ -1,4 +1,4 @@
-"""`/wf-new` の排他 mode と `--auto` 統合契約を検証する。"""
+"""`/wf-new` の排他 mode と統合契約を検証する。"""
 
 from __future__ import annotations
 
@@ -33,8 +33,18 @@ def test_mode_dispatch_is_exclusive_before_any_mutation() -> None:
     assert "1 個なら" in mode
     assert "0 個なら従来の通常入口" in mode
     assert "| `--auto` | `references/auto.md` |" in mode
-    assert "--batch" not in mode
+    assert "| `--batch` | `references/batch.md` |" in mode
+    assert "完全一致" in mode
+    assert "`--batch-id`" in mode
     assert "--schedule" not in mode
+
+
+def test_batch_modifiers_are_not_modes() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    modifiers = _section(skill, "## 修飾フラグ")
+
+    assert "| `--count <N>` | `--batch` |" in modifiers
+    assert "| `--resume <batch-id>` | `--batch` |" in modifiers
 
 
 def test_auto_mode_reuses_the_normal_entry_for_wf_new_action() -> None:

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -201,6 +201,21 @@ EXPECTED_ACTIVE_ROUTES = (
         "state resolver または上記子 skill が無ければ `/automation-update`（本リポジトリ内では "
         "`yt-skills sync`）を案内して停止する。すべて満たすまで lease と子 skill を開始しない。",
     ),
+    _route(
+        "wf-new/references/batch.md",
+        "## 前後工程",
+        "- `前工程`: `/setup --channel`, `/setup`",
+    ),
+    _route(
+        "wf-new/references/batch.md",
+        "## Hard Gates",
+        "   - `config/channel/` が存在しない場合は `/setup --channel` を案内して停止する。",
+    ),
+    _route(
+        "wf-new/references/batch.md",
+        "## Hard Gates",
+        "   - `load_config()` が失敗する場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する。",
+    ),
     *(
         _route(f"{skill}/SKILL.md", "## 前提", line)
         for skill in ("wf-next", "wf-status")
@@ -209,27 +224,14 @@ EXPECTED_ACTIVE_ROUTES = (
             "- **既存チャンネル**（YouTube で既に運営中）→ `/channel-new`（既存チャンネル取り込みモード）を案内",
         )
     ),
-    _route(
-        "wf-new-batch/SKILL.md",
-        "## 前後工程",
-        "- `前工程`: `/setup --channel`, `/setup`",
-    ),
-    _route(
-        "wf-new-batch/SKILL.md",
-        "## Hard Gates",
-        "   - `config/channel/` が存在しない場合は `/setup --channel` を案内して停止する。",
-    ),
-    _route(
-        "wf-new-batch/SKILL.md",
-        "## Hard Gates",
-        "   - `load_config()` が失敗する場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する。",
-    ),
 )
 
 MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path != "automation-update/SKILL.md") | {
     "wf-new/references/phase-2c-artifact-contract.md",
     "wf-new/references/phase2.md",
     "wf-new/references/auto.md",
+    "wf-new/references/batch.md",
+    "wf-new/references/batch-ledger.py",
     "wf-new/references/wf-auto-state.py",
 }
 EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
@@ -253,7 +255,7 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "371f61933a99d5557e05dc9c50fd201d9df8f3422600a7014458db8112b85a12"
+IMMUTABLE_TARGET_FILES_SHA256 = "7d1308ff8dcb273ebeb12946791e7113b2b1366dcebfeb1802eaa0c8fc8c2924"
 AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "3df1c507167b2fc71dcae7acaa0a6011fb3ee89fabbb95f6ffc2b5d2b803e617"
 AUTOMATION_UPDATE_PUSH_SHA256 = "5be1d31198da13ab6929edb13c9b713fbb9bc364d413b778d79f4e624e30d2cc"
 ALLOWED_FENCED_ROUTES = {


### PR DESCRIPTION
## 概要

旧 `/wf-new-batch` の batch ledger・resume・順次実行を `/wf-new --batch` へ統合します。`--batch` は完全一致で判定し、通常入口の `--batch-id` を誤認しません。

## 検証

- ruff / 全 yt-skills gate
- 中核 48、wheel/docs 77 tests
- `PYTHONDONTWRITEBYTECODE=1 pytest -n auto`（9000 passed, 3 skipped）
- site check/build/test（53 passed）

Closes #3741