### PR TITLE
feat(skills): automation-scheduleをwf-new --scheduleへ統合する (#3742)

### DIFF
--- a/.claude/skills/setup/references/channel-mode.md
+++ b/.claude/skills/setup/references/channel-mode.md
@@ -137,7 +137,7 @@ DistroKid 配信しない場合は `--distrokid-enabled` を付けず、`config/
 - `.gitignore`
 - `auth/client_secrets.template.json`
 
-定期制作の自動起動（`workflow.json` の `scheduled_automation`）は本スキルでは生成しない（既定は未設定 = 無効）。運用開始後に定期実行したくなったら `/automation-schedule` で有効化する。
+定期制作の自動起動（`workflow.json` の `scheduled_automation`）は本スキルでは生成しない（既定は未設定 = 無効）。運用開始後に定期実行したくなったら `/wf-new --schedule` で有効化する。
 
 冪等性: 既存ファイルは `--force` がない限り上書きしない。差分がある場合は unified diff を確認してから `--force` を判断する。初期ディレクトリは `/setup` の生成物を再利用する。
 

--- a/.claude/skills/setup/references/new-channel-bootstrap.md
+++ b/.claude/skills/setup/references/new-channel-bootstrap.md
@@ -47,7 +47,7 @@ Step 1 の TTP ヒアリングとは別に、次の初期値をユーザーへ�
 
 DistroKid 配信時だけ `config/channel/distrokid.json` を追加生成する。配信しない場合は `--distrokid-enabled` を指定せず、ファイル未配置を config loader が `distrokid.enabled=false` として扱う。
 
-`workflow.json::scheduled_automation` は生成せず、未設定を既定の無効状態とする。定期実行は運用開始後に `/automation-schedule` で有効化する。
+`workflow.json::scheduled_automation` は生成せず、未設定を既定の無効状態とする。定期実行は運用開始後に `/wf-new --schedule` で有効化する。
 
 既存ファイルは `--force` なしで上書きしない。差分がある場合は unified diff を確認してから `--force` を判断する。初期ディレクトリ生成は `/setup` の責務であり、`yt-channel-init` は setup が作成済みのディレクトリを削除・再生成しない。
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: wf-new
 purpose: 進める
-description: "Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、または --batch で複数コレクションを一括企画・順次実行するとき。「新しいコレクション始めたい」「制作開始」「制作を最初から最後まで」「複数コレクション制作」「一括制作」で発動。一段だけ進める場合は /wf-next"
+description: "Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、--batch で複数コレクションを一括企画するとき、または --schedule で定期実行を設定・確認・停止するとき。「新しいコレクション始めたい」「制作を最初から最後まで」「複数コレクション制作」「定期実行」「スケジュール設定」で発動。一段だけ進める場合は /wf-next"
 ---
 
 ## 前後工程
 
-- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`, `/automation-schedule`
+- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`
 - `後工程`: `/wf-next`, `/suno-helper`, `/post-publish`, `/analytics`
 - `委譲先`: `/collection-ideate`, `/thumbnail`, `/suno`, `/lyria`, `/loop-video`, `/suno-helper`, `/masterup`, `/wf-next`, `/post-publish`
 
 ## 成果物
 
-- `書き込む`: `.automation-run/history.json`, `reports/wf-new-batches/<batch-id>/plan-manifest.json`, `reports/wf-new-batches/<batch-id>/batch-ledger.json`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
+- `書き込む`: `.automation-run/history.json`, `config/channel/workflow.json`, `reports/wf-new-batches/<batch-id>/plan-manifest.json`, `reports/wf-new-batches/<batch-id>/batch-ledger.json`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/plan_proposals.md`, `collections/<id>/20-documentation/thumbnail-prompts.md`, `collections/<id>/20-documentation/suno-patterns.yaml`, `collections/<id>/20-documentation/suno-prompts.json`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`
 - `読み込む`: `config/channel/*.json`, `config/localizations.json`, `data/benchmark_*.json`, `reports/analysis_*.md`, `data/insights.jsonl`, `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/post_publish_history.json`
 
 ## モード判定
 
-`$ARGUMENTS` から排他 mode の `--auto` と `--batch` を完全一致で抽出し、その合計個数を最初に数える。前方一致は禁止し、通常入口の preselected 引数 `--batch-id` / `--plan-id` は `--batch` として数えない。
+`$ARGUMENTS` から排他 mode の `--auto`、`--batch`、`--schedule` を完全一致で抽出し、その合計個数を最初に数える。前方一致は禁止し、通常入口の preselected 引数 `--batch-id` / `--plan-id` は `--batch` として数えない。
 
 - 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す。state・lease・成果物は一切変更しない
 - 1 個なら対応する reference を読み、その mode だけを実行する。残りの引数はその mode の引数として扱う
@@ -27,6 +27,7 @@ description: "Use when 新規コレクション制作を立ち上げるとき、
 |---|---|
 | `--auto` | `references/auto.md` |
 | `--batch` | `references/batch.md` |
+| `--schedule` | `references/schedule.md` |
 
 ## 修飾フラグ
 

--- a/.claude/skills/wf-new/references/auto.md
+++ b/.claude/skills/wf-new/references/auto.md
@@ -1,7 +1,7 @@
 
 ## 前後工程
 
-- `前工程`: `/automation-schedule`, `/wf-new`
+- `前工程`: `/wf-new`
 - `後工程`: `/post-publish`, `/analytics`
 - `委譲先`: `/wf-new`, `/lyria`, `/suno-helper`, `/masterup`, `/wf-next`, `/post-publish`
 

--- a/.claude/skills/wf-new/references/detect_runtime.sh
+++ b/.claude/skills/wf-new/references/detect_runtime.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ネイティブ定期実行の前提診断（/automation-schedule Step 0）（#1892, #2369）。
+# ネイティブ定期実行の前提診断（/wf-new --schedule Step 0）（#1892, #2369）。
 # チャンネルリポジトリ直下で実行し、`ok|fail|warn <check> <detail>` を 1 行ずつ出力する。
 # fail が 1 件でもあれば exit 1（SKILL.md 側はこれを hard gate に使う）。
 set -u

--- a/.claude/skills/wf-new/references/run_scheduled.sh
+++ b/.claude/skills/wf-new/references/run_scheduled.sh
@@ -34,7 +34,7 @@ LOG_FILE="$LOG_DIR/run-$(date +%Y%m%d-%H%M%S).log"
 log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$LOG_FILE"; }
 
 # --- config 読み出し（loader 検証済みの effective 設定を単一ソースにする） ---
-CONFIG_JSON="$(uv run python .claude/skills/automation-schedule/references/schedule_config.py show 2>>"$LOG_FILE")" || {
+CONFIG_JSON="$(uv run python .claude/skills/wf-new/references/schedule_config.py show 2>>"$LOG_FILE")" || {
   log "config の読み出しに失敗（schedule_config.py show が非 0）"
   exit 1
 }

--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -1,9 +1,3 @@
----
-name: automation-schedule
-purpose: 進める
-description: "Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。「定期実行」「スケジュール設定」「自動で回して」「automation-schedule」で発動。automation のリリース追従は /automation-update、本体リリースは /automation-release、制作を手動で一段進めるのは /wf-next"
----
-
 ## 前後工程
 
 - `前工程`: `/setup --channel`, `/setup`
@@ -18,6 +12,8 @@ description: "Use when チャンネルの定期制作スケジュール（workfl
 ## Overview
 
 `config/channel/workflow.json::workflow.scheduled_automation` を製品非依存の単一ソースとして、実行中製品のネイティブ scheduler に登録する。Codex は Scheduled Task、Claude は依存性に応じて `/schedule` Cloud Job または Cowork local Scheduled Task を使う。launchd / cron は明示承認された fallback に限る。
+
+automation のリリース追従は `/automation-update`、本体リリースは `/automation-release`、制作を手動で一段進めるのは `/wf-next` の責務とし、この mode では代行しない。
 
 ## Hard Gates
 
@@ -58,8 +54,8 @@ Claude Code `/loop` は最長 3 日の一時反復専用で、永続スケジュ
 ### Step 0. 診断と backend 決定
 
 ```bash
-bash .claude/skills/automation-schedule/references/detect_runtime.sh
-uv run python .claude/skills/automation-schedule/references/schedule_backend.py show
+bash .claude/skills/wf-new/references/detect_runtime.sh
+uv run python .claude/skills/wf-new/references/schedule_backend.py show
 ```
 
 1. `product-codex` / `product-claude` を既定候補にする。判定不能時だけユーザーに製品を確認する。
@@ -69,12 +65,12 @@ uv run python .claude/skills/automation-schedule/references/schedule_backend.py 
 ### Step 1. config と native task の dry-run
 
 ```bash
-uv run python .claude/skills/automation-schedule/references/schedule_config.py show
-uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --dry-run --enable \
+uv run python .claude/skills/wf-new/references/schedule_config.py show
+uv run python .claude/skills/wf-new/references/schedule_config.py generate --dry-run --enable \
   --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
   [--target-workflow "wf-new --auto"] [--max-retries <N>] \
   [--retry-delay-seconds <N>] [--notification terminal|none]
-uv run python .claude/skills/automation-schedule/references/schedule_backend.py plan \
+uv run python .claude/skills/wf-new/references/schedule_backend.py plan \
   --product <codex|claude> --dependency-mode <cloud|local> \
   --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
   [--target-workflow "wf-new --auto"] [--max-retries <N>] \
@@ -92,7 +88,7 @@ Step 1 の config diff、backend、title、prompt、cwd、timezone、RRULE、依
 まず次を実行し、別 backend が active なら登録しない。
 
 ```bash
-uv run python .claude/skills/automation-schedule/references/schedule_backend.py guard --backend <backend>
+uv run python .claude/skills/wf-new/references/schedule_backend.py guard --backend <backend>
 ```
 
 - `codex-automation`: Codex/ChatGPT の Scheduled Task 管理 capability を使う。CLI の `codex exec` や launchd / cron は使わない。local 依存では desktop local project と cwd を指定する。同じ external ID があれば更新する。
@@ -100,15 +96,17 @@ uv run python .claude/skills/automation-schedule/references/schedule_backend.py 
 - `claude-cowork-local`: Cowork Scheduled Task に local folder を指定して作成/更新する。製品側で local folder 実行を選べない場合は中止する。
 - `os-fallback`: ネイティブが使えない理由と制約を提示して別途承認を取り、次だけを実行する。
 
+統合前の絶対 script path を登録済みの OS fallback job は自動更新しない。ユーザーへ再インストールが必要な理由を案内し、承認後に現在の `scheduler_job.sh disable`、続けて `scheduler_job.sh install` の順で実行する。
+
 ```bash
-bash .claude/skills/automation-schedule/references/scheduler_job.sh install \
+bash .claude/skills/wf-new/references/scheduler_job.sh install \
   --backend os-fallback --confirm-os-fallback --runtime <claude|codex>
 ```
 
 ネイティブ登録が成功した後だけ、返された不変 ID を記録する。
 
 ```bash
-uv run python .claude/skills/automation-schedule/references/schedule_backend.py record \
+uv run python .claude/skills/wf-new/references/schedule_backend.py record \
   --backend <backend> --external-id <product-task-id>
 ```
 

--- a/.claude/skills/wf-new/references/schedule_backend.py
+++ b/.claude/skills/wf-new/references/schedule_backend.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Native scheduler plan and backend identity state for /automation-schedule (#2369)."""
+"""Native scheduler plan and backend identity state for /wf-new --schedule (#2369)."""
 
 from __future__ import annotations
 

--- a/.claude/skills/wf-new/references/schedule_config.py
+++ b/.claude/skills/wf-new/references/schedule_config.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""`workflow.scheduled_automation` の表示・生成・差分更新（/automation-schedule 用）（#1892）.
+"""`workflow.scheduled_automation` の表示・生成・差分更新（/wf-new --schedule 用）（#1892）.
 
 チャンネルリポジトリ直下で実行する:
 
-    uv run python .claude/skills/automation-schedule/references/schedule_config.py show
-    uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --dry-run
-    uv run python .claude/skills/automation-schedule/references/schedule_config.py generate \
+    uv run python .claude/skills/wf-new/references/schedule_config.py show
+    uv run python .claude/skills/wf-new/references/schedule_config.py generate --dry-run
+    uv run python .claude/skills/wf-new/references/schedule_config.py generate \
         --enable --run-time 09:00 --cadence mon,wed,fri
 
 - `show`: 現在の effective 設定（loader 検証済み）を JSON で表示する。

--- a/.claude/skills/wf-new/references/scheduler_job.sh
+++ b/.claude/skills/wf-new/references/scheduler_job.sh
@@ -43,14 +43,14 @@ esac
 
 CHANNEL_DIR="$(pwd)"
 LABEL="com.youtube-automation.$(basename "$CHANNEL_DIR").schedule"
-RUN_SCRIPT="$CHANNEL_DIR/.claude/skills/automation-schedule/references/run_scheduled.sh"
-BACKEND_SCRIPT="$CHANNEL_DIR/.claude/skills/automation-schedule/references/schedule_backend.py"
+RUN_SCRIPT="$CHANNEL_DIR/.claude/skills/wf-new/references/run_scheduled.sh"
+BACKEND_SCRIPT="$CHANNEL_DIR/.claude/skills/wf-new/references/schedule_backend.py"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 IS_DARWIN=0
 [ "$(uname -s)" = "Darwin" ] && IS_DARWIN=1
 
 read_config() { # effective 設定（loader 検証済み）を単一ソースとして読む
-  uv run python .claude/skills/automation-schedule/references/schedule_config.py show
+  uv run python .claude/skills/wf-new/references/schedule_config.py show
 }
 
 weekday_num() { # launchd/cron 共通: 0=sun .. 6=sat
@@ -153,7 +153,7 @@ disable_job() {
     echo "crontab entry を削除しました: $LABEL"
   fi
   uv run python "$BACKEND_SCRIPT" --channel-dir "$CHANNEL_DIR" disable --backend os-fallback >/dev/null || true
-  echo "config 側も無効化する場合: uv run python .claude/skills/automation-schedule/references/schedule_config.py generate --disable"
+  echo "config 側も無効化する場合: uv run python .claude/skills/wf-new/references/schedule_config.py generate --disable"
 }
 
 case "$COMMAND" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `/automation-schedule` を `/wf-new --schedule` へ統合し、dry-run・承認・backend 選択・native task・OS fallback 契約を同一 skill へ移設する（#3742）。
+
 - `feat(skills)`: `/wf-new-batch` を `/wf-new --batch` へ統合し、排他 mode 判定、batch ledger・再開・自己通常入口契約を同一 skill へ移設する（#3741）。
 
 - `feat(skills)`: `/wf-auto` を `/wf-new --auto` へ統合し、排他 mode 判定、既存 state/lease/timing 契約の移設、scheduled automation の新既定と旧値拒否を追加する（#3740）。

--- a/docs/architecture/b6-integration-receipt.json
+++ b/docs/architecture/b6-integration-receipt.json
@@ -346,21 +346,21 @@
     },
     {
       "old_owner": "legacy..claude.skills.automation-schedule.SKILL.md",
-      "exact_new_owner": ".claude/skills/automation-schedule/SKILL.md",
+      "exact_new_owner": ".claude/skills/wf-new/references/schedule.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"
     },
     {
       "old_owner": "legacy..claude.skills.automation-schedule.references.schedule_backend",
-      "exact_new_owner": ".claude/skills/automation-schedule/references/schedule_backend.py",
+      "exact_new_owner": ".claude/skills/wf-new/references/schedule_backend.py",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"
     },
     {
       "old_owner": "legacy..claude.skills.automation-schedule.references.schedule_config",
-      "exact_new_owner": ".claude/skills/automation-schedule/references/schedule_config.py",
+      "exact_new_owner": ".claude/skills/wf-new/references/schedule_config.py",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # 全 skill カタログ
 
-`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **53 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
+`yt-skills sync` で各チャンネルリポジトリに配布される Claude Code skill の一覧（全 **52 個**）。各行は「なにができるか」（what）の 1 行要約。発動トリガー・前提・前後工程はサイトの [skill ガイド](/skills)、詳細手順は `.claude/skills/<name>/SKILL.md` を参照。
 
 > 個別の使い分けは各カテゴリの冒頭リンクや [`docs/workflow-cheatsheet.md`](workflow-cheatsheet.md)（workflow 系）も併せて参照。
 
@@ -10,10 +10,9 @@
 
 | Skill | なにができるか |
 |---|---|
-| /wf-new | フラグなしで新規コレクションを立ち上げ、正規入口 `--auto` では公開後処理まで継続・再開し、`--batch` では複数企画を相互差別化して順次実行 |
+| /wf-new | フラグなしで新規コレクションを立ち上げ、正規入口 `--auto` では公開後処理まで継続・再開し、`--batch` では複数企画を順次実行し、`--schedule` では定期実行を設定・確認・停止 |
 | /wf-next | 既存コレクションを次の工程に 1 段進める（Phase 2-3） |
 | /wf-status | 制作中コレクションの進捗を読み取り表示（実行はしない） |
-| /automation-schedule | 定期制作設定（`workflow.json` の `scheduled_automation`）の生成と、既定 `/wf-new --auto` を起動する Claude Code / Codex ジョブの作成・更新・確認・停止 |
 | /collection-ideate | データドリブンに次の企画候補を提案 |
 
 ## チャンネル立ち上げ

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -29,10 +29,9 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 
 ## 進める
 
-- `/automation-schedule` — Use when チャンネルの定期制作スケジュール（workflow.json の scheduled_automation）を設定し、Codex / Claude のネイティブ Scheduled Task を作成・更新・確認・停止するとき。
 - `/collection-ideate` — Use when 新コレクションの企画・テーマ選定をデータドリブンに行うとき。
 - `/streaming` — Use when ライブ配信用 Vultr VPS・動画配信本体を Terraform で構築・運用・トラブルシュートするとき。
-- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、または --batch で複数コレクションを一括企画・順次実行するとき。
+- `/wf-new` — Use when 新規コレクション制作を立ち上げるとき、--auto で公開後処理まで継続するとき、--batch で複数コレクションを一括企画するとき、または --schedule で定期実行を設定・確認・停止するとき。
 - `/wf-next` — Use when 既存コレクション（collections/planning/）を一段進めるとき。
 - `/wf-status` — Use when コレクション制作の進捗を読むだけで確認するとき（実行しない）。
 

--- a/docs/workflow-cheatsheet.md
+++ b/docs/workflow-cheatsheet.md
@@ -1,6 +1,6 @@
 # workflow チートシート
 
-`/wf-new --auto` `/wf-new --batch` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
+`/wf-new --auto` `/wf-new --batch` `/wf-new --schedule` `/wf-new` `/wf-next` `/wf-status` `/collection-ideate` と `workflow-state.json` の使い分けを 1 枚で。**迷ったらまずこのファイル**。
 
 > Skill 全体のカタログは [`docs/features.md`](features.md) を参照。
 
@@ -12,6 +12,7 @@
 「次なに作る？」「テーマ候補が欲しい」  → /collection-ideate   （企画候補を提案する）
 「企画から公開後処理まで全部進めて」      → /wf-new --auto             （新規開始または未完了地点から完走）
 「複数コレクションを一括企画したい」      → /wf-new --batch            （相互差別化して順次準備）
+「定期制作を設定・確認・停止したい」        → /wf-new --schedule         （native Scheduled Task を管理）
 「新しいコレクション始めたい」          → /wf-new              （企画選択 → ディレクトリ作成 → 素材準備）
 「制作中のやつ、次のステップやって」    → /wf-next             （phase に応じて次工程を 1 段実行）
 「どこまで進んだ？読むだけ」           → /wf-status           （実行はしない・読み取り表示のみ）
@@ -23,6 +24,7 @@
 |---|---|
 | collection の有無を問わず **企画から公開後処理まで進めたい** | `/wf-new --auto`（正規入口） |
 | 2 件以上を **相互差別化して一括企画・順次準備したい** | `/wf-new --batch --count <N>` |
+| **定期制作を設定・確認・停止したい** | `/wf-new --schedule`（確認は `status`、停止は `disable`） |
 | 制作中コレクションが **無い** + 企画候補も **無い** | `/collection-ideate` → 候補が決まったら `/wf-new` |
 | 制作中コレクションが **無い** + 企画候補は **頭にある** | `/wf-new`（その中で `/collection-ideate` が走る） |
 | 制作中コレクションが **ある** + 進める意思がある | `/wf-next` |
@@ -34,6 +36,7 @@
 |---|---|---|---|
 | `/wf-new --auto` | collection 不在なら `/wf-new` から開始し、存在すれば未完了地点から制作・公開・post-publish まで状態駆動で再評価する | 子 skill の実装を複製しない | 認証、CAPTCHA、承認待ち、公開未許可など人間の介入が必要な場面 |
 | `/wf-new --batch` | 複数企画を一括承認し、同一 `/wf-new` の通常入口へ 1 件ずつ渡して準備する | child gate を省略せず、並列実行しない | child の失敗、承認待ち、外部前提待ち、成果物不整合 |
+| `/wf-new --schedule` | `workflow.scheduled_automation` と native Scheduled Task を設定・確認・停止する | 明示承認なしに外部公開や OS fallback を有効化しない | dry-run 適用承認、backend 切替、外部公開・OS fallback の明示承認 |
 | `/collection-ideate` | analytics mode / benchmark fallback mode、または `ttp_mode: false` の minimal mode の入力でペルソナ別 3 企画候補を生成 | コレクションディレクトリは作らない | 提案表示のみ（選択は `/wf-new` 側で）。`ttp_mode: true` の minimal mode は `/benchmark` を案内して停止 |
 | `/wf-new` | 企画選択 → `yt-init-collection` でディレクトリ + `workflow-state.json` 作成 → サムネ・音楽素材生成 | 楽曲の最終マスタリングや動画化はしない | 通常は (1) 企画選択 (2) サムネ承認。`ttp_mode: false` の minimal mode は企画候補生成前にテーマ / ジャンル / 雰囲気の直接入力確認を追加し、`true` は `/benchmark` の案内で停止 |
 | `/wf-next` | `workflow-state.json::phase` に応じて次工程を 1 段実行（Suno DL / Lyria 生成 / 動画化 / アップロード） | 新規コレクションは作らない | マスター音源が無い phase = "prepared" 状態（ユーザーがミキシング+マスタリングを行う） |

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -151,13 +151,13 @@ test("実リポジトリでは9カテゴリと全skillを生成する", async ()
     await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
   ).match(/^\| \/[a-z0-9-]+ /gmu);
 
-  assert.equal(result.entries.length, 54);
-  assert.equal(skillDirectories?.length, 53);
+  assert.equal(result.entries.length, 53);
+  assert.equal(skillDirectories?.length, 52);
   assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
   assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
 });
 
-test("production build は一覧と53個の個別ページを公開する", async () => {
+test("production build は一覧と52個の個別ページを公開する", async () => {
   const siteRoot = resolve(import.meta.dirname, "..");
   const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
   const thumbnail = await readFile(
@@ -165,7 +165,7 @@ test("production build は一覧と53個の個別ページを公開する", asyn
     "utf8"
   );
 
-  assert.match(index, /53 個の skill/);
+  assert.match(index, /52 個の skill/);
   assert.match(index, /href="\/skills\/wf-new"/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);

--- a/src/youtube_automation/configuration/workflow.py
+++ b/src/youtube_automation/configuration/workflow.py
@@ -61,7 +61,7 @@ SCHEDULED_AUTOMATION_NOTIFICATIONS: tuple[str, ...] = ("terminal", "none")
 class ScheduledAutomation:
     """定期制作の宣言設定（`workflow.scheduled_automation` セクション、optional）（#1892）.
 
-    Claude Code / Codex の定期実行アダプタ（`/automation-schedule`）が参照する
+    Claude Code / Codex の定期実行アダプタ（`/wf-new --schedule`）が参照する
     実行環境非依存の宣言。未設定チャンネルは全 default（`enabled = False`）で
     ロードされ、手動制作・公開フローの挙動を一切変えない。
 
@@ -77,7 +77,7 @@ class ScheduledAutomation:
     - `notification`: 実行結果の通知先。`terminal`（既定） / `none`。
     - `allow_external_publish`: `True` のときのみ、定期実行内で YouTube への
       書き込み（アップロード・公開）を許可する。`False`（既定）では外部反映
-      直前で停止する。有効化には `/automation-schedule` の明示確認が必要。
+      直前で停止する。有効化には `/wf-new --schedule` の明示確認が必要。
     """
 
     enabled: bool = False

--- a/tests/contracts/architecture/test_repository_reorganization_contract.py
+++ b/tests/contracts/architecture/test_repository_reorganization_contract.py
@@ -1526,8 +1526,15 @@ def test_reorganization_receipt_names_existing_non_contract_consumers() -> None:
         assert any(path != contract_path for path in consumers), mapping["old_owner"]
         consumer_paths.extend(consumers)
 
-    # Then: receipt の証跡は契約テスト自身だけでなく、実在する consumer を指す
-    assert all((ROOT / path).is_file() for path in consumer_paths)
+    historical_consumer_moves = {
+        ".claude/skills/automation-schedule/references/schedule_config.py": (
+            ".claude/skills/wf-new/references/schedule_config.py"
+        ),
+    }
+    resolved_paths = [historical_consumer_moves.get(path, path) for path in consumer_paths]
+
+    # Then: receipt の証跡は契約テスト自身だけでなく、現在の owner へ解決できる consumer を指す
+    assert all((ROOT / path).is_file() for path in resolved_paths)
 
 
 def test_streaming_healthcheck_describes_the_canonical_daily_archive_owner() -> None:

--- a/tests/repo/test_automation_schedule_backends.py
+++ b/tests/repo/test_automation_schedule_backends.py
@@ -12,7 +12,7 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 
 ROOT = REPO_ROOT
-REFERENCE_DIR = ROOT / ".claude" / "skills" / "automation-schedule" / "references"
+REFERENCE_DIR = ROOT / ".claude" / "skills" / "wf-new" / "references"
 
 
 def _load_backend_module():
@@ -77,6 +77,8 @@ def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypat
     assert plan["prevent_concurrent_runs"] is True
     assert plan["target_workflow"] == "wf-new --auto"
     assert plan["prompt"].startswith("/wf-new --auto")
+    assert "/automation-schedule" not in plan["prompt"]
+    assert "/wf-auto" not in plan["prompt"]
     assert plan["dependency_mode"] == "local"
     assert "local dependencies require desktop local project" in plan["management"]
 

--- a/tests/repo/test_automation_schedule_runtime_contracts.py
+++ b/tests/repo/test_automation_schedule_runtime_contracts.py
@@ -1,4 +1,4 @@
-"""Executable contracts for automation-schedule distributed references."""
+"""Executable contracts for `/wf-new --schedule` distributed references."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 
 ROOT = REPO_ROOT
-REFERENCES = ROOT / ".claude" / "skills" / "automation-schedule" / "references"
+REFERENCES = ROOT / ".claude" / "skills" / "wf-new" / "references"
 
 
 def _write_executable(path: Path, body: str) -> None:

--- a/tests/repo/test_setup_channel_disclosure_contract.py
+++ b/tests/repo/test_setup_channel_disclosure_contract.py
@@ -541,6 +541,7 @@ def test_moved_opening_assets_preserve_pre_move_bytes_or_owner_only_semantics() 
                 b"`../SKILL.md` \xe3\x81\xab\xe6\xae\x8b\xe3\x81\x99",
                 1,
             )
+            payload = payload.replace(b"/wf-new --schedule", b"/automation-schedule", 1)
         if asset == "ttp-seed-and-duration.md":
             payload = payload.replace(b".claude/skills/setup/references/", b".claude/skills/channel-new/references/")
         assert sha256(payload).hexdigest() == expected

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1715,8 +1715,8 @@ def test_theme_compare_missing_themes_error_uses_current_config_path(monkeypatch
 
 
 def test_automation_schedule_skill_contract() -> None:
-    """#1892: /automation-schedule の SKILL.md と references が整合している."""
-    skill_path = ".claude/skills/automation-schedule/SKILL.md"
+    """#1892: `/wf-new --schedule` の reference 群が整合している."""
+    skill_path = ".claude/skills/wf-new/references/schedule.md"
     skill = _read(skill_path)
 
     # references 単一ソース化: 本文で参照するスクリプトが実在する
@@ -1728,17 +1728,17 @@ def test_automation_schedule_skill_contract() -> None:
         "run_scheduled.sh",
     ):
         assert ref in skill
-        assert (ROOT / ".claude/skills/automation-schedule/references" / ref).exists()
+        assert (ROOT / ".claude/skills/wf-new/references" / ref).exists()
 
     # Hard Gates は冒頭 60 行以内（automation-schedule 固有の契約）
     head = "\n".join(skill.splitlines()[:60])
     assert "## Hard Gates" in head
     assert "allow_external_publish" in head
 
-    # 兄弟スキルとの相互排他（ルール①）
-    fm = _skill_frontmatter("automation-schedule")
-    assert "/automation-update" in fm["description"]
-    assert "/wf-next" in fm["description"]
+    # 統合後も兄弟スキルとの責務境界を保つ
+    assert "/automation-update" in skill
+    assert "/automation-release" in skill
+    assert "/wf-next" in skill
 
     # 設定スキーマの正へのポインタ
     assert "ScheduledAutomation" in skill
@@ -1746,8 +1746,8 @@ def test_automation_schedule_skill_contract() -> None:
     assert "--confirm-os-fallback" in skill
 
 
-def test_setup_channel_points_scheduled_automation_to_automation_schedule() -> None:
+def test_setup_channel_points_scheduled_automation_to_wf_new_schedule() -> None:
     """#1892: setup --channel は scheduled_automation を生成せず後続 skill へ誘導する."""
     setup_channel = _read(".claude/skills/setup/references/channel-mode.md")
     assert "`scheduled_automation`" in setup_channel
-    assert "/automation-schedule" in setup_channel
+    assert "/wf-new --schedule" in setup_channel

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -23,7 +23,7 @@ def test_skill_catalog_matches_all_distributed_skills() -> None:
     skill_names = _skill_names()
     catalog_names = _catalog_names()
 
-    assert len(skill_names) == 53
+    assert len(skill_names) == 52
     assert len(catalog_names) == len(set(catalog_names))
     assert set(catalog_names) == skill_names
 

--- a/tests/repo/test_wf_new_modes_skill_contract.py
+++ b/tests/repo/test_wf_new_modes_skill_contract.py
@@ -34,9 +34,21 @@ def test_mode_dispatch_is_exclusive_before_any_mutation() -> None:
     assert "0 個なら従来の通常入口" in mode
     assert "| `--auto` | `references/auto.md` |" in mode
     assert "| `--batch` | `references/batch.md` |" in mode
+    assert "| `--schedule` | `references/schedule.md` |" in mode
     assert "完全一致" in mode
     assert "`--batch-id`" in mode
-    assert "--schedule" not in mode
+
+
+def test_schedule_mode_preserves_status_disable_and_safety_contracts() -> None:
+    schedule = (SKILL_DIR / "references" / "schedule.md").read_text(encoding="utf-8")
+
+    assert "## Task: setup / update" in schedule
+    assert "## status" in schedule
+    assert "## disable" in schedule
+    assert "allow_external_publish: true" in schedule
+    assert "dry-run" in schedule
+    assert "--confirm-os-fallback" in schedule
+    assert not (SKILL_DIR.parent / "automation-schedule").exists()
 
 
 def test_batch_modifiers_are_not_modes() -> None:

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -125,11 +125,6 @@ EXPECTED_ACTIVE_ROUTES = (
         )
     ),
     _route(
-        "automation-schedule/SKILL.md",
-        "## 前後工程",
-        "- `前工程`: `/setup --channel`, `/setup`",
-    ),
-    _route(
         "channel-status/SKILL.md",
         "## 前後工程",
         "- `前工程`: `/setup --channel`",
@@ -166,7 +161,7 @@ EXPECTED_ACTIVE_ROUTES = (
     _route(
         "wf-new/SKILL.md",
         "## 前後工程",
-        "- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`, `/automation-schedule`",
+        "- `前工程`: `/setup --channel`, `/setup`, `/collection-ideate`",
     ),
     _route(
         "wf-new/SKILL.md",
@@ -216,6 +211,11 @@ EXPECTED_ACTIVE_ROUTES = (
         "## Hard Gates",
         "   - `load_config()` が失敗する場合は `/channel-new`（既存チャンネル取り込みモード）を案内して停止する。",
     ),
+    _route(
+        "wf-new/references/schedule.md",
+        "## 前後工程",
+        "- `前工程`: `/setup --channel`, `/setup`",
+    ),
     *(
         _route(f"{skill}/SKILL.md", "## 前提", line)
         for skill in ("wf-next", "wf-status")
@@ -232,6 +232,12 @@ MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path 
     "wf-new/references/auto.md",
     "wf-new/references/batch.md",
     "wf-new/references/batch-ledger.py",
+    "wf-new/references/schedule.md",
+    "wf-new/references/detect_runtime.sh",
+    "wf-new/references/run_scheduled.sh",
+    "wf-new/references/schedule_backend.py",
+    "wf-new/references/schedule_config.py",
+    "wf-new/references/scheduler_job.sh",
     "wf-new/references/wf-auto-state.py",
 }
 EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
@@ -255,8 +261,8 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "7d1308ff8dcb273ebeb12946791e7113b2b1366dcebfeb1802eaa0c8fc8c2924"
-AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "3df1c507167b2fc71dcae7acaa0a6011fb3ee89fabbb95f6ffc2b5d2b803e617"
+IMMUTABLE_TARGET_FILES_SHA256 = "4e89fed82d50f7812e091c716d502ea70b6eecb8316fd84562b388c0cf97e05f"
+AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "0e53b0be09de5049104b16034dd8122ca434adbfafdd0c835cb4fac943e7878e"
 AUTOMATION_UPDATE_PUSH_SHA256 = "5be1d31198da13ab6929edb13c9b713fbb9bc364d413b778d79f4e624e30d2cc"
 ALLOWED_FENCED_ROUTES = {
     (
@@ -506,7 +512,7 @@ def test_residual_target_assets_and_sections_remain_byte_identical() -> None:
     ]
     assert _aggregate_hash(immutable_target) == IMMUTABLE_TARGET_FILES_SHA256
     assert (
-        sha256((SKILLS_DIR / "automation-schedule/references/detect_runtime.sh").read_bytes()).hexdigest()
+        sha256((SKILLS_DIR / "wf-new/references/detect_runtime.sh").read_bytes()).hexdigest()
         == AUTOMATION_SCHEDULE_REGENERATE_SHA256
     )
     assert sha256((SKILLS_DIR / "automation-update/SKILL.md").read_bytes()).hexdigest() == AUTOMATION_UPDATE_PUSH_SHA256


### PR DESCRIPTION
## 概要

旧 `/automation-schedule` の backend・dry-run・承認・native prompt・daemon/status/disable 契約を `/wf-new --schedule` へ統合します。登録済み OS job は自動変更せず、承認後の disable → install 導線を明記しています。

履歴 receipt 本文は保持し、解決層だけを新 owner に追従しています。

## 検証

- ruff / 全 yt-skills gate
- `PYTHONDONTWRITEBYTECODE=1 pytest -n auto`（9000 passed, 3 skipped）
- site check/build/test（66 pages / 53 tests）

Closes #3742