### PR TITLE
feat(skills): publishにplaylistを統合 (#3842)

### DIFF
--- a/.claude/skills/community-post/SKILL.md
+++ b/.claude/skills/community-post/SKILL.md
@@ -159,4 +159,4 @@ open "$STUDIO_URL"
 
 - `/publish --upload` — アップロード完了後、設定済みなら `/post-publish`、未設定なら本スキルを案内する
 - `/post-publish` — 公開後チェーンから対象 collection を引き継いで本スキルを呼び出す
-- `/playlist` — プレイリスト assign は別経路
+- `/publish --playlist` — プレイリスト assign は別経路

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,37 +1,38 @@
 ---
 name: publish
 purpose: 公開する
-description: "Use when 完成した動画を公開工程へ進めるとき。--upload は collection 型または release 型の YouTube アップロードを、既存の承認ゲートを保って実行する。「アップロード」「公開する」「楽曲リリースを公開」で発動。動画生成は /videoup、概要欄生成は /video-description"
+description: "Use when 完成した動画を公開工程へ進めるとき。--playlist はプレイリストの作成・割り当て・確認、--upload は YouTube アップロードを実行する。「プレイリスト作って」「初投稿」「初回投稿」「初回公開前にプレイリスト初期化」「アップロード」「公開する」で発動。動画生成は /videoup、概要欄生成は /video-description"
 ---
 
 ## 前後工程
 
-- `前工程`: `/wf-new`, `/videoup`, `/video-description`, `/playlist`, `/thumbnail`
+- `前工程`: `/wf-new`, `/videoup`, `/video-description`, `/thumbnail`
 - `後工程`: `/post-publish`, `/community-post`, `/metadata-audit`, `/pinned-comment`, `/live-clean`
 - `委譲先`: `/post-publish`
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`
-- `読み込む`: `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/20-documentation/descriptions.md`, `config/channel/*.json`, `config/schedule_config.json`
+- `書き込む`: `config/channel/playlists.json`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`
+- `読み込む`: `config/channel/playlists.json`, `config/channel/content.json`, `auth/token.json`, `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/20-documentation/descriptions.md`, `config/channel/*.json`, `config/schedule_config.json`
 
 ## Overview
 
-公開工程の統合エントリポイント。引数なしでは実行せず、排他的な mode を 1 つ指定する。
+公開工程の統合エントリポイント。引数なしでは playlist → upload の chain を状態判定付きで進め、mode 指定時はその一段だけを実行する。
 
 ## モード判定
 
-`$ARGUMENTS` から `--upload` の個数を最初に数える。
+`$ARGUMENTS` から `--playlist` / `--upload` の個数を最初に数える。
 
 - 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す
-- 1 個なら対応する reference を読み、残りの引数を upload mode の引数として扱う
-- 0 個なら利用可能な mode を表示して停止する
+- 1 個なら対応する reference を読み、その一段だけを実行する。残りの引数はその mode の引数として扱う
+- 0 個なら chain manifest に従い playlist → upload の順で状態判定して進める
 
 | mode | 読む reference |
 |---|---|
+| `--playlist` | `references/playlist.md` |
 | `--upload` | `references/upload.md` |
 
-現在は `--upload` のみを受け付ける。未知 mode、mode なし、複数 mode は利用可能な mode を表示して停止する。
+未知 mode や複数 mode は利用可能な mode を表示して停止する。
 
 ## 設定読み込みゲート
 
@@ -46,17 +47,19 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--u
 
 ## Chain Contract
 
-`references/publish-chain-manifest.json` を読み、upload step だけを実行する。実行前後に次を守る。
+`references/publish-chain-manifest.json` を読み、playlist step → upload step の順に実行する。mode 指定時は対応 step だけを実行する。実行前後に次を守る。
 
-1. `references/publish-chain-state.py --collection-dir <path> --step upload` を実行する。
+1. `references/publish-chain-state.py --channel-dir <channel-root> [--collection-dir <path>] --step <playlist|upload>` を実行する。`--collection-dir` は upload step とフラグなし chain では必須だが、playlist の単独実行では不要。
 2. exit 0 は成果物記録済みのため skip、exit 10 は run、exit 20 は state 不正のため停止する。
-3. prerequisite artifacts を検証し、`references/upload.md` の preflight と plan を完了する。
+3. prerequisite artifacts を検証し、playlist step は `references/playlist.md`、upload step は `references/upload.md` の preflight と plan を完了する。
 4. manifest の `approvalGate.configPath` を `load_config()` から解決する。値が未設定なら `approvalGate.skip` を使う。
-5. resolved skip が `false` の場合、対象 collection、`content_model.type`、動画本数、plan が示す公開日時または公開範囲を提示し、「この先は YouTube への取り消し不能な外部アップロードを実行する」と明示する。選択肢を **「アップロードする」/「中止する」** の 2 つに限定し、承認されるまで upload CLI、tracking 更新、state 更新を行わない。
+5. playlist step の gate は常に `skip=false`。status と dry-run を先に実行し、作成されるプレイリスト名と割り当て件数を提示して、明示承認されるまで実反映を行わない。upload step の resolved skip が `false` の場合、対象 collection、`content_model.type`、動画本数、plan が示す公開日時または公開範囲を提示し、「この先は YouTube への取り消し不能な外部アップロードを実行する」と明示する。選択肢を **「アップロードする」/「中止する」** の 2 つに限定し、承認されるまで upload CLI、tracking 更新、state 更新を行わない。
 6. resolved skip が `true` の場合だけ upload 承認を省略する。これは既存の `workflow.wf_next.skip_upload_approval` による自動実行互換であり、初回 playlist 作成の承認や `/post-publish` 子チェーン固有の承認は省略しない。
 7. CLI 成功後に output artifacts を実在確認する。`workflow-state.json::upload.video_id` が空なら完了扱いにしない。
 
 ## Instructions
+
+`--playlist` では `references/playlist.md` を読み、状態確認・初期化・割り当て・clean の指定操作を行う。書き込み操作は必ず dry-run → 確認 → 本番の順にする。
 
 `--upload` では `references/upload.md` を読み、`content_model.type` に応じて collection は `uv run yt-upload-collection`、release は `uv run yt-upload-auto` を使う。plan や status は read-only として先に実行できるが、実 upload は上記承認ゲートを通過してから行う。
 
@@ -69,12 +72,16 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--u
 | videos.insert（1,600 units / 本） | collection 型 1 本、release 型は言語数分 | アップロード本数 |
 | thumbnails.set（50 units / 本） | アップロード本数分 | — |
 | search.list（100 units） | 約 2 | dedup 確認 |
-| playlistItems.insert（50 units） | 割当プレイリスト数 | プレイリスト構成 |
+| playlistItems.list（1 unit） | Σ ceil(各プレイリスト項目数 / 50) | プレイリスト数・項目数 |
+| playlists.insert（50 units） | 新規作成プレイリスト数 | 未作成エントリ数 |
+| playlistItems.insert（50 units） | 割当動画本数 | プレイリスト構成 |
+| playlistItems.delete（50 units） | 削除エントリ数 | 削除済み / 非公開動画数 |
 
 - 上限 / 承認: plan は upload API を叩かず、実 upload は Chain Contract の承認ゲート通過後だけ行う。
 
 ## 完了条件
 
+- playlist step は指定操作が exit 0 で完了し、初期化時は全 `playlist_id` が記録済みである
 - upload CLI が正常終了している
 - `20-documentation/upload_tracking.json` が存在する
 - `workflow-state.json::upload.video_id` が非空文字列である

--- a/.claude/skills/publish/references/playlist.md
+++ b/.claude/skills/publish/references/playlist.md
@@ -1,8 +1,4 @@
----
-name: playlist
-purpose: 公開する
-description: "Use when プレイリストの作成・割り当て・確認をするとき。「プレイリスト作って」「初投稿」「初回投稿」「初回公開前にプレイリスト初期化」「/playlist」で発動"
----
+# Playlist mode
 
 ## 前後工程
 
@@ -123,3 +119,5 @@ uv run yt-playlist-manager --clean-deleted              # 実反映
 - `config/channel/playlists.json` — Canonical ソース
 - `src/youtube_automation/commands/youtube/playlist_manager.py` — 実装本体
 - `src/youtube_automation/commands/youtube/playlist_status.py` — 状態表示の読み取り専用 viewer
+- `.claude/skills/publish/references/playlist_manager.py` — 実装本体への同一 skill 内参照
+- `.claude/skills/publish/references/playlist_status.py` — 状態 viewer への同一 skill 内参照

--- a/.claude/skills/publish/references/publish-chain-manifest.json
+++ b/.claude/skills/publish/references/publish-chain-manifest.json
@@ -2,6 +2,22 @@
   "chainId": "publish",
   "steps": [
     {
+      "id": "playlist",
+      "skill": "publish",
+      "prerequisiteArtifacts": [
+        "config/channel/playlists.json"
+      ],
+      "outputArtifacts": [
+        "config/channel/playlists.json::playlists.*.playlist_id"
+      ],
+      "approvalGate": {
+        "skip": false
+      },
+      "idempotency": {
+        "script": "references/publish-chain-state.py"
+      }
+    },
+    {
       "id": "upload",
       "skill": "publish",
       "prerequisiteArtifacts": [

--- a/.claude/skills/publish/references/publish-chain-state.py
+++ b/.claude/skills/publish/references/publish-chain-state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Decide whether the publish upload step must run for a collection."""
+"""Decide whether publish playlist and upload steps must run."""
 
 from __future__ import annotations
 
@@ -26,10 +26,52 @@ def _result(decision: str, reason: str, *, artifacts: list[str] | None = None) -
     return result
 
 
-def evaluate(collection_dir: Path, step: str) -> tuple[int, StateResult]:
+def _evaluate_playlist(channel_dir: Path) -> tuple[int, StateResult]:
+    config_path = channel_dir / "config" / "channel" / "playlists.json"
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return EXIT_BLOCKED, _result("blocked", "playlists_config_missing")
+    except (OSError, json.JSONDecodeError):
+        return EXIT_BLOCKED, _result("blocked", "playlists_config_invalid")
+    if not isinstance(config, dict):
+        return EXIT_BLOCKED, _result("blocked", "playlists_config_invalid")
+    playlists = config.get("playlists")
+    if not isinstance(playlists, dict) or not playlists:
+        return EXIT_BLOCKED, _result("blocked", "playlists_invalid")
+
+    for value in playlists.values():
+        if isinstance(value, str):
+            if not value.strip():
+                return EXIT_RUN, _result("run", "playlist_id_missing")
+            continue
+        if not isinstance(value, dict):
+            return EXIT_BLOCKED, _result("blocked", "playlist_entry_invalid")
+        playlist_id = value.get("playlist_id")
+        if playlist_id is None:
+            return EXIT_RUN, _result("run", "playlist_id_missing")
+        if not isinstance(playlist_id, str) or not playlist_id.strip():
+            return EXIT_BLOCKED, _result("blocked", "playlist_id_invalid")
+
+    return EXIT_SKIP, _result(
+        "skip",
+        "playlist_ids_recorded",
+        artifacts=["config/channel/playlists.json::playlists.*.playlist_id"],
+    )
+
+
+def evaluate(
+    collection_dir: Path | None,
+    step: str,
+    channel_dir: Path | None = None,
+) -> tuple[int, StateResult]:
     """Return a stable exit code and JSON-serializable decision."""
+    if step == "playlist":
+        return _evaluate_playlist(channel_dir or Path.cwd())
     if step != "upload":
         return EXIT_BLOCKED, _result("blocked", "unknown_step")
+    if collection_dir is None:
+        return EXIT_BLOCKED, _result("blocked", "collection_dir_missing")
 
     state_path = collection_dir / "workflow-state.json"
     try:
@@ -61,10 +103,11 @@ def evaluate(collection_dir: Path, step: str) -> tuple[int, StateResult]:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--collection-dir", required=True, type=Path)
+    parser.add_argument("--collection-dir", type=Path)
+    parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
     parser.add_argument("--step", required=True)
     args = parser.parse_args()
-    code, result = evaluate(args.collection_dir, args.step)
+    code, result = evaluate(args.collection_dir, args.step, args.channel_dir)
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))
     return code
 

--- a/.claude/skills/publish/references/upload.md
+++ b/.claude/skills/publish/references/upload.md
@@ -2,7 +2,7 @@
 
 ## 前後工程
 
-- `前工程`: `/wf-new`, `/videoup`, `/video-description`, `/playlist`, `/thumbnail`
+- `前工程`: `/wf-new`, `/videoup`, `/video-description`, `/publish --playlist`, `/thumbnail`
 - `後工程`: `/post-publish`, `/community-post`, `/metadata-audit`, `/pinned-comment`, `/live-clean`
 - `委譲先`: `/post-publish`
 
@@ -111,7 +111,7 @@ $ARGUMENTS
 1. **マスター動画**: skill-config `preflight.master_video_globs`（既定 `01-master/*.mp4` → `03-Individual-movie/*master*.mp4`）の順に探索 — 存在しなければエラー終了
 2. **サムネイル**: skill-config `preflight.thumbnail_candidates`（既定 `10-assets/thumbnail.jpg` → `10-assets/thumbnail.png`）の候補順で探索 — いずれも存在しなければエラー終了。`main.png/jpg` は textless 動画背景なので upload thumbnail には使わない
 3. **概要欄**: `20-documentation/descriptions.md` — **存在しない場合は `/video-description` スキルを実行して自動生成する**（対象コレクションパスを引き継ぐ）。生成完了後にアップロードフローへ進む
-4. **初投稿時のプレイリスト初期化**: `config/channel/playlists.json` が存在する場合は `/playlist` スキルで `uv run yt-playlist-status` を実行する。`(未作成)` があるときは、初投稿前に `uv run yt-playlist-manager --init --dry-run` → ユーザー確認 → `uv run yt-playlist-manager --init` で playlist ID を作成・書き戻してからアップロードへ進む
+4. **初投稿時のプレイリスト初期化**: `config/channel/playlists.json` が存在する場合は `/publish --playlist` で `uv run yt-playlist-status` を実行する。`(未作成)` があるときは、初投稿前に `uv run yt-playlist-manager --init --dry-run` → ユーザー確認 → `uv run yt-playlist-manager --init` で playlist ID を作成・書き戻してからアップロードへ進む
 
 ### collection アップロードフロー
 
@@ -127,7 +127,7 @@ $ARGUMENTS
 
 承認済みタイトルを 100 codepoint 以下へ短縮する必要が生じた場合は、旧版と短縮案を codepoint 数付き diff として提示し、ユーザーの再承認を得るまで `descriptions.md` の更新や upload を行わない。`--plan` は primary title だけでなく生成済み全 locale title を検証し、超過 locale を言語・文字数・実タイトル付きで fail-loud にする。
 
-プレイリストへの動画追加は後続のアップロード経路が担う。`collection` 型では `collection_uploader` 内部の `assign_video()` に任せる。初投稿時に `/playlist` で行うのは未作成プレイリストの作成と `playlist_id` 書き戻しであり、個別動画の手動 assign ではない。
+プレイリストへの動画追加は後続のアップロード経路が担う。`collection` 型では `collection_uploader` 内部の `assign_video()` に任せる。初投稿時に `/publish --playlist` で行うのは未作成プレイリストの作成と `playlist_id` 書き戻しであり、個別動画の手動 assign ではない。
 
 ### release アップロードフロー
 
@@ -212,7 +212,7 @@ uv run yt-upload-collection --plan -c <NAME>
 ## Cross References
 
 - `/video-description` — アップロード前に descriptions.md を生成
-- `/playlist` — 初投稿前のプレイリスト初期化、状態確認、手動 assign、クリーンアップ（アップロード時の自動 assign は本スキル内で実行される）
+- `/publish --playlist` — 初投稿前のプレイリスト初期化、状態確認、手動 assign、クリーンアップ（アップロード時の自動 assign は本スキル内で実行される）
 - `/metadata-audit` — アップロード後のローカル ↔ YouTube 整合性監査
 - `/post-publish` — `workflow.post-publish` 設定時、アップロード完了後の 3 段チェーンを承認・履歴付きで実行
 - `/community-post` — `workflow.post-publish` 未設定時の後方互換。コミュニティ投稿テンプレを展開して Studio を起動（`config/channel/community.json` がある場合のみ）

--- a/.claude/skills/setup/references/channel-mode.md
+++ b/.claude/skills/setup/references/channel-mode.md
@@ -256,7 +256,7 @@ uv run yt-channel-settings push --apply
 
 ### Step 9: wf-new 接続前チェック
 
-`/wf-new` へ進む前に、reference の readiness matrix を確認する。`playlist_id` 未設定は初投稿前に `/playlist` が `yt-playlist-status` → `yt-playlist-manager --init --dry-run` → `--init` の順で解消し、初回動画は `/publish --upload` の自動 assign に任せる。Analytics / Reporting レポート取得設定が未確認でも初回制作は止めず、公開後の分析に備えて `/analytics --collect` で YouTube Analytics / Reporting API の収集前提と Reporting API job 作成状態を確認し、不足する GCP / OAuth / API 設定は `/setup` に戻す。ライブ配信を使う可能性がある場合も初回制作は止めず、YouTube Studio で Live streaming を早めに有効化する。初回配信可能になるまで最大 24 時間かかるため、初回配信へ進む前に `/streaming` で準備を確認する。
+`/wf-new` へ進む前に、reference の readiness matrix を確認する。`playlist_id` 未設定は初投稿前に `/publish --playlist` が `yt-playlist-status` → `yt-playlist-manager --init --dry-run` → `--init` の順で解消し、初回動画は `/publish --upload` の自動 assign に任せる。Analytics / Reporting レポート取得設定が未確認でも初回制作は止めず、公開後の分析に備えて `/analytics --collect` で YouTube Analytics / Reporting API の収集前提と Reporting API job 作成状態を確認し、不足する GCP / OAuth / API 設定は `/setup` に戻す。ライブ配信を使う可能性がある場合も初回制作は止めず、YouTube Studio で Live streaming を早めに有効化する。初回配信可能になるまで最大 24 時間かかるため、初回配信へ進む前に `/streaming` で準備を確認する。
 
 最後に `yt-doctor` で TTP 完了条件を確認する:
 
@@ -291,5 +291,5 @@ guard が `secret-like file staged; unstaged before commit` を出した場合�
 保存未完了として終了した場合は、以下の成功案内は出さない。作業ツリーが最初から clean、または初回 commit が成功した場合だけ最後に案内する:
 
 ```text
-チャンネル初期化が完了しました。初回保存も完了しているため、色味・構図・ムード・テンポの方向性を先に確認したい場合は、仮コレクションで任意のパイロット検証（/thumbnail → /thumbnail --compare、music_engine が suno なら /music --prompt → /suno-helper、lyria なら /lyria）を実施してから /wf-new に進めます。検証を省略する場合は、そのまま /wf-new で初回コレクション制作に進めます。初投稿前のプレイリスト未作成状態は、公開フロー内の /playlist 初期化で解消します。公開後の分析は /analytics --collect、ライブ配信を使う場合は YouTube Studio の Live streaming 有効化と /streaming の準備確認へ進んでください。
+チャンネル初期化が完了しました。初回保存も完了しているため、色味・構図・ムード・テンポの方向性を先に確認したい場合は、仮コレクションで任意のパイロット検証（/thumbnail → /thumbnail --compare、music_engine が suno なら /music --prompt → /suno-helper、lyria なら /lyria）を実施してから /wf-new に進めます。検証を省略する場合は、そのまま /wf-new で初回コレクション制作に進めます。初投稿前のプレイリスト未作成状態は、公開フロー内の /publish --playlist 初期化で解消します。公開後の分析は /analytics --collect、ライブ配信を使う場合は YouTube Studio の Live streaming 有効化と /streaming の準備確認へ進んでください。
 ```

--- a/.claude/skills/setup/references/persona-branding-readiness.md
+++ b/.claude/skills/setup/references/persona-branding-readiness.md
@@ -69,7 +69,7 @@ banner.save('branding/banner.png', optimize=True)
 | `config/skills/thumbnail.yaml` の reference images が空 | default へ存在する参照画像を設定する。意図的に後続へ回す場合は `docs/channel/ttp-seed-confirmation.md` に `ユーザー承認済み例外: thumbnail ... /thumbnail ...` として未反映内容・理由・後続 skill を残す。本格収集は `/channel-research --benchmark` に委譲する。 |
 | channel branding の icon / banner references が空 | `docs/channel/competitor-branding-snapshot.json::channel_image_references` の URL 参照を転記する。取得できない場合は TTP メモ由来の fallback 根拠を reference notes に残して画像を生成する。 |
 | `config/skills/music.yaml::prompt` が placeholder | Step 4 の初期ジャンル情報を `genre_line` に反映する。 |
-| `config/channel/playlists.json` に `playlist_id` 未設定がある | 初投稿前に `/playlist` が status → init dry-run → init の順で初期化する。初回動画の追加は `/publish --upload` の自動 assign に任せる。 |
+| `config/channel/playlists.json` に `playlist_id` 未設定がある | 初投稿前に `/publish --playlist` が status → init dry-run → init の順で初期化する。初回動画の追加は `/publish --upload` の自動 assign に任せる。 |
 | `auth/token.json` が無い | `/setup` を再実行し、OAuth 完了後に YouTube API 操作へ戻る。 |
 | Analytics / Reporting 設定が未確認 | 初回制作は止めず、`/analytics --collect` で収集前提と Reporting API job 作成状態を確認する。不足する GCP / OAuth / API 設定は `/setup` に戻す。 |
 | ライブ配信を使う可能性がある | 初回制作は止めず、YouTube Studio で早めに有効化する。初回配信へ進む前に `/streaming` で配信側を確認する。 |

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -8,7 +8,7 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 - `前工程`: `/wf-new`, `/wf-new`
 - `後工程`: `/analytics`, `/flop-analysis`
-- `委譲先`: `/masterup`, `/lyria`, `/videoup`, `/video-description`, `/playlist`, `/publish --upload`
+- `委譲先`: `/masterup`, `/lyria`, `/videoup`, `/video-description`, `/publish --playlist`, `/publish --upload`
 
 ## 成果物
 
@@ -219,10 +219,10 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - 承認されたら次ステップへ進む。却下されたら `phase` を `mastered` のままにして停止し、ガイダンス「準備が整ったら `/wf-next` を再実行してください」を表示
    - `skip_upload_approval = true` のときは確認なしでそのまま進む（従来の全自動挙動）
 4. **初投稿プレイリスト初期化**:
-   - `config/channel/playlists.json` が存在する場合、Skill `/playlist` で `uv run yt-playlist-status` を実行する
+   - `config/channel/playlists.json` が存在する場合、Skill `/publish --playlist` で `uv run yt-playlist-status` を実行する
    - `playlist_id` 未設定の `(未作成)` がある場合は、`uv run yt-playlist-manager --init --dry-run` を表示し、ユーザー確認後に `uv run yt-playlist-manager --init` を実行してから `/publish --upload` へ進む
    - この確認は `skip_upload_approval` とは別の playlist 作成ゲート。`skip_upload_approval = true` でも、YouTube 上の playlist 作成と `config/channel/playlists.json` 書き戻しを伴うため未作成 playlist がある場合は確認を省略しない
-   - ユーザーが playlist 初期化を却下した場合は `/publish --upload` を実行せず停止し、`/playlist` で初期化してから `/wf-next` を再実行するよう案内する
+   - ユーザーが playlist 初期化を却下した場合は `/publish --upload` を実行せず停止し、`/publish --playlist` で初期化してから `/wf-next` を再実行するよう案内する
    - これは YouTube 上の playlist 作成と `playlist_id` 書き戻しが目的。初回動画の追加は次の `/publish --upload` 内部の自動 assign (`assign_video()`) に任せる
    - `config/channel/playlists.json` が無い、または全 playlist に `playlist_id` がある場合はスキップ
 5. **順次**: Agent ツールで subagent を起動し、対象 collection、動画、thumbnail、description を明示して Skill `/publish --upload` の Subagent Contract の `plan` / preflight だけを実行させる。state / tracking 更新と実アップロードは実行させない

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `/publish --playlist` に旧 `/playlist` の状態確認・初期化・割り当て・cleanup 契約を統合する。chain を `playlist` → `upload` へ拡張し、playlist 作成の dry-run・明示承認を維持したまま、旧 skill directory と利用者導線・配布・site 契約を更新する（#3842）。
+
 - `feat(skills)`: `/publish --upload` を新設し、旧 `/video-upload` の collection / release 自動分岐、公開承認ゲート、post-publish 委譲を 1-step chain へ統合する。mode 別 config、旧 override 互換と `video-upload.yaml` → `publish.yaml::upload` の明示 migration を追加し、旧 skill directory と利用者導線・配布・site 契約を更新する（#3841）。
 
 - `feat(skills)`: `/music --lyric` に旧 `/suno-lyric` の歌詞生成・hard gate・generator/reviewer 契約を統合する。chain を `prompt` → `lyric` へ拡張し、mode 別 config、旧 override 互換と `suno-lyric.yaml` → `music.yaml::lyric` の明示 migration を追加して、旧 skill directory と利用者導線・配布・site 契約を更新する（#3825）。

--- a/docs/architecture/b6-integration-receipt.json
+++ b/docs/architecture/b6-integration-receipt.json
@@ -738,7 +738,7 @@
     },
     {
       "old_owner": "legacy..claude.skills.playlist.SKILL.md",
-      "exact_new_owner": ".claude/skills/playlist/SKILL.md",
+      "exact_new_owner": ".claude/skills/publish/references/playlist.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,9 +53,8 @@ YouTube への公開、視聴者対応、容量整理、コミュニティ投稿
 | Skill | なにができるか |
 |---|---|
 | /video-description | YouTube 概要欄を自動生成（情景フック + タイムスタンプ + Perfect for） |
-| /publish | `--upload` で Complete Collection を YouTube へアップロード + live 移行 |
+| /publish | `--playlist` でプレイリスト管理、`--upload` で YouTube アップロード + live 移行 |
 | /post-publish | 公開後の community-post → pinned-comment → metadata-audit を承認ゲート・実行履歴付きで一括実行 |
-| /playlist | プレイリストの作成・動画割当・状態確認（`playlists.json` 駆動） |
 | /comments-reply | ルール駆動コメント自動返信（dry-run → apply、二重返信防止） |
 | /live-chat-reply | 配信中ライブチャットの Codex 自動返信 daemon を設定・VPS 配備・運用 |
 | /pinned-comment | オーナー固定コメント自動投稿（preflight で削除済み/private を skip、dry-run → apply、二重投稿防止） |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -41,10 +41,10 @@ scope 定義の単一ソースは `src/youtube_automation/infrastructure/auth/yo
 | /channel-research --voice（コメント収集） | `yt-benchmark-comments` | `youtube.force-ssl`（`commentThreads.list` の API 要件） | `token.json` |
 | /channel-research --discover | `yt-discover-competitors` | read-only | readonly 優先 |
 | /metadata-audit | `yt-metadata-audit`（監査のみ） | read-only | readonly 優先 |
-| /playlist（状態確認） | `yt-playlist-status` | read-only | readonly 優先 |
+| /publish --playlist（状態確認） | `yt-playlist-status` | read-only | readonly 優先 |
 | /streaming（帯域集計） | `yt-stream-bandwidth` / `yt-stream-archive-check` | read-only | readonly 優先 |
 | /publish --upload | `domains/uploads/youtube.py` | write（`youtube`） | `token.json` |
-| /playlist（作成・割り当て） | `yt-playlist-manager` | write（`youtube`） | `token.json` |
+| /publish --playlist（作成・割り当て） | `yt-playlist-manager` | write（`youtube`） | `token.json` |
 | /setup（seed / 設定 push） | `yt-channel-seed` / `yt-channel-settings` | write（`youtube`） | `token.json` |
 | /video-description ほか一括更新 | `yt-bulk-update-desc` / `yt-bulk-update-synthetic-media` | write（`youtube`） | `token.json` |
 | /comments-reply | `yt-comments-reply` | write（`youtube.force-ssl`） | `token.json` |

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -47,7 +47,6 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 - `/live-chat-reply` — Use when 配信中の YouTube ライブチャットへ常駐 daemon で自動返信するとき。
 - `/live-clean` — Use when live コレクションの大容量メディアを削除して容量回復するとき、または collections 配下の tmp/ 残骸を掃除するとき。
 - `/pinned-comment` — Use when 新規動画へオーナー固定コメントを自動投稿するとき。
-- `/playlist` — Use when プレイリストの作成・割り当て・確認をするとき。
 - `/post-publish` — Use when 動画公開直後の community-post → pinned-comment → metadata-audit を承認ゲート付きで一括実行・途中再開するとき。
 - `/publish` — Use when 完成した動画を公開工程へ進めるとき。
 

--- a/docs/strategy/growth-gap-analysis.md
+++ b/docs/strategy/growth-gap-analysis.md
@@ -24,7 +24,7 @@
 | L1 | インプレッション獲得 | `/analytics --collect --include-reporting`（動画別 Imp）、traffic source 収集（`insightTrafficSourceType/Detail`）、`/channel-research --benchmark`（競合の露出獲得パターン）、`/short`（流入面の追加） | Reporting API v1 / Analytics API v2 / Data API v3 | ◯ 計測は可、施策検証は弱い |
 | L2 | CTR | `/thumbnail`（TTP ベース生成）、`/thumbnail --compare`（320px 視認性）、`yt-thumbnail-correlate`（特徴量×CTR 相関）、`/alignment-check`（サムネ×タイトル×ムード整合）、`/flop-analysis`（CTR 閾値ルーブリック） | Reporting API v1 + サムネ画像特徴量 | ◎ 最厚のレバー |
 | L3 | 視聴維持 | retention 収集（`audienceWatchRatio` / `relativeRetentionPerformance`）、`/video-analyze`（Gemini によるフック・BGM 展開解析）、`/channel-strategy --scene`（シーン別の最適尺設計） | Analytics API v2 / Vertex AI | ◯ 計測◎、原因照合が手動 |
-| L4 | 回遊・セッション | `/playlist`（`yt-playlist-manager`）、`/video-description`（Complete Collection 導線）、カード指標収集（`cardImpressions/Clicks/ClickRate`）、`/pinned-comment` `/comments-reply` `/community-post` | Analytics API v2 / Data API v3 | △ 導線は張れるが効果測定が薄い |
+| L4 | 回遊・セッション | `/publish --playlist`（`yt-playlist-manager`）、`/video-description`（Complete Collection 導線）、カード指標収集（`cardImpressions/Clicks/ClickRate`）、`/pinned-comment` `/comments-reply` `/community-post` | Analytics API v2 / Data API v3 | △ 導線は張れるが効果測定が薄い |
 | L5 | 登録転換 | `subscribersGained/Lost` の day・video 単位収集、`subscribedStatus` 別視聴データ収集、動画別転換率ランキングを含む `/analytics --analyze`、`yt-channel-trend`（日次 subs 移動平均・z-score 異常検知） | Analytics API v2 | ◯ 動画別転換率と視聴者の登録状態を分析可 |
 | L6 | SEO・メタデータ | `/video-description`（SEO 最適化概要欄）、`/metadata-audit`、`yt-title-duplicate-check`、localizations 同期（`/setup --push`、`yt-shorts-bulk-update-loc`） | ローカル config / Data API v3 | ◯ 生成◎、検索流入との突合なし |
 | L7 | 投稿頻度・タイミング | `/channel-research --benchmark`（競合の投稿間隔）、`yt-launch-curve`（投稿後 N 日の初速比較）、`yt-theme-compare`（テーマ別初速・ロングテール） | Data API v3 / 自チャンネル履歴 | △ 頻度の観測のみ、時刻・曜日分析なし |
@@ -107,7 +107,7 @@
 │        ↓                                                             │
 │  制作（/wf-new → /wf-next → /thumbnail → 公開 /publish --upload）    │
 │        ↓                                                             │
-│  公開直後: /playlist・/pinned-comment・/community-post（回遊導線）   │
+│  公開直後: /publish --playlist・/pinned-comment・/community-post     │
 │        ↓                                                             │
 │  T+7: yt-launch-curve で初速を過去中央値と比較 → 週次ループ先頭へ    │
 └──────────────────────────────────────────────────────────────────────┘

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -151,13 +151,13 @@ test("実リポジトリでは9カテゴリと全skillを生成する", async ()
     await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
   ).match(/^\| \/[a-z0-9-]+ /gmu);
 
-  assert.equal(result.entries.length, 38);
-  assert.equal(skillDirectories?.length, 37);
+  assert.equal(result.entries.length, 37);
+  assert.equal(skillDirectories?.length, 36);
   assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
   assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
 });
 
-test("production build は一覧と37個の個別ページを公開する", async () => {
+test("production build は一覧と36個の個別ページを公開する", async () => {
   const siteRoot = resolve(import.meta.dirname, "..");
   const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
   const thumbnail = await readFile(
@@ -165,7 +165,7 @@ test("production build は一覧と37個の個別ページを公開する", asyn
     "utf8"
   );
 
-  assert.match(index, /37 個の skill/);
+  assert.match(index, /36 個の skill/);
   assert.match(index, /href="\/skills\/wf-new"/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);

--- a/tests/repo/test_lifecycle_skills_no_tayk.py
+++ b/tests/repo/test_lifecycle_skills_no_tayk.py
@@ -33,7 +33,6 @@ _LIFECYCLE_SKILL_NAMES: Final[tuple[str, ...]] = (
     "thumbnail",
     "video-description",
     "analytics",
-    "playlist",
     "distrokid-helper",
 )
 

--- a/tests/repo/test_production_quality_setup_redirect_contract.py
+++ b/tests/repo/test_production_quality_setup_redirect_contract.py
@@ -28,7 +28,7 @@ TARGET_SKILLS = (
     "flop-analysis",
     "lyria",
     "metadata-audit",
-    "playlist",
+    "publish",
     "short",
     "music",
     "thumbnail",
@@ -215,12 +215,16 @@ _RAW_EXPECTED_ACTIVE_ROUTES = (
         "`/setup --import` を案内して停止する",
     ),
     _route(
-        "playlist/SKILL.md",
+        "publish/references/playlist.md",
         "## 前提",
         "`config/channel/playlists.json` が存在し、`playlists` セクションが定義されていること。"
         "未定義の場合は `/setup --regenerate` を案内する。",
     ),
-    _route("playlist/SKILL.md", "## Cross References", "- `/setup --regenerate` — `playlists.json` の初期定義"),
+    _route(
+        "publish/references/playlist.md",
+        "## Cross References",
+        "- `/setup --regenerate` — `playlists.json` の初期定義",
+    ),
     _route(
         "short/SKILL.md",
         "## 前提",
@@ -618,7 +622,11 @@ def _is_target_member(relative: str) -> bool:
     skill, separator, child = relative.partition("/")
     if skill not in TARGET_SKILLS:
         return False
-    return skill != "wf-new" or (separator == "/" and child in WF_NEW_IDEATION_MEMBERS)
+    if skill == "wf-new":
+        return separator == "/" and child in WF_NEW_IDEATION_MEMBERS
+    if skill == "publish":
+        return separator == "/" and child == "references/playlist.md"
+    return True
 
 
 def _active_route_records(overrides: dict[str, str | bytes] | None = None) -> tuple[tuple[str, str, str], ...]:
@@ -843,6 +851,7 @@ def test_initial_occurrences_have_a_complete_context_ledger() -> None:
     historical_skills = {entry[0] for entry in INITIAL_OCCURRENCE_LEDGER}
     current_owners = {
         "collection-ideate": "wf-new",
+        "playlist": "publish",
         "short-thumbnail": "short",
     }
     assert {current_owners.get(skill, skill) for skill in historical_skills} == set(TARGET_SKILLS)

--- a/tests/repo/test_publish_chain_state.py
+++ b/tests/repo/test_publish_chain_state.py
@@ -27,6 +27,56 @@ def _collection(tmp_path: Path, upload: object) -> Path:
     return collection
 
 
+def _channel(tmp_path: Path, playlists: object) -> Path:
+    channel = tmp_path / "channel"
+    config = channel / "config" / "channel"
+    config.mkdir(parents=True)
+    (config / "playlists.json").write_text(json.dumps({"playlists": playlists}), encoding="utf-8")
+    return channel
+
+
+def test_playlist_runs_when_any_playlist_id_is_missing(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": None})
+    channel = _channel(tmp_path, {"focus": {"title": "Focus", "playlist_id": None}})
+
+    code, result = module.evaluate(collection, "playlist", channel)
+
+    assert code == module.EXIT_RUN
+    assert result["decision"] == "run"
+    assert result["reason"] == "playlist_id_missing"
+
+
+def test_playlist_skips_when_all_playlist_ids_are_recorded(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": None})
+    channel = _channel(
+        tmp_path,
+        {
+            "focus": {"title": "Focus", "playlist_id": "PL-focus"},
+            "all": {"title": "All", "playlist_id": "PL-all"},
+        },
+    )
+
+    code, result = module.evaluate(collection, "playlist", channel)
+
+    assert code == module.EXIT_SKIP
+    assert result["decision"] == "skip"
+    assert result["artifacts"] == ["config/channel/playlists.json::playlists.*.playlist_id"]
+
+
+def test_playlist_blocks_on_invalid_config(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": None})
+    channel = _channel(tmp_path, "invalid")
+
+    code, result = module.evaluate(collection, "playlist", channel)
+
+    assert code == module.EXIT_BLOCKED
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "playlists_invalid"
+
+
 def test_upload_runs_when_video_id_is_missing(tmp_path: Path) -> None:
     module = _module()
     collection = _collection(tmp_path, {"video_id": None})
@@ -36,6 +86,15 @@ def test_upload_runs_when_video_id_is_missing(tmp_path: Path) -> None:
     assert code == module.EXIT_RUN
     assert result["decision"] == "run"
     assert result["reason"] == "video_id_missing"
+
+
+def test_upload_blocks_when_collection_dir_is_missing() -> None:
+    module = _module()
+
+    code, result = module.evaluate(None, "upload")
+
+    assert code == module.EXIT_BLOCKED
+    assert result["reason"] == "collection_dir_missing"
 
 
 def test_upload_skips_when_video_id_is_recorded(tmp_path: Path) -> None:

--- a/tests/repo/test_publish_playlist_skill_contract.py
+++ b/tests/repo/test_publish_playlist_skill_contract.py
@@ -1,0 +1,47 @@
+"""Contracts for replacing ``/playlist`` with ``/publish --playlist`` (#3842)."""
+
+from __future__ import annotations
+
+import json
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
+
+INVENTORY = SkillInventory(REPO_ROOT)
+PUBLISH = INVENTORY.skill_directory("publish")
+
+
+def test_publish_owns_playlist_mode_and_closed_references() -> None:
+    skill = (PUBLISH / "SKILL.md").read_text(encoding="utf-8")
+    playlist = (PUBLISH / "references" / "playlist.md").read_text(encoding="utf-8")
+
+    assert "playlist" not in {path.name for path in INVENTORY.skill_directories()}
+    assert "| `--playlist` | `references/playlist.md` |" in skill
+    assert "playlist_manager.py" in playlist
+    assert "playlist_status.py" in playlist
+    assert "publish/references/playlist_manager.py" in playlist
+    assert "publish/references/playlist_status.py" in playlist
+    assert "dry-run → 確認 → 本番" in playlist
+
+
+def test_publish_chain_runs_playlist_before_upload() -> None:
+    manifest = json.loads((PUBLISH / "references" / "publish-chain-manifest.json").read_text(encoding="utf-8"))
+
+    assert [step["id"] for step in manifest["steps"]] == ["playlist", "upload"]
+    playlist = manifest["steps"][0]
+    assert playlist == {
+        "id": "playlist",
+        "skill": "publish",
+        "prerequisiteArtifacts": ["config/channel/playlists.json"],
+        "outputArtifacts": ["config/channel/playlists.json::playlists.*.playlist_id"],
+        "approvalGate": {"skip": False},
+        "idempotency": {"script": "references/publish-chain-state.py"},
+    }
+
+
+def test_publish_without_mode_runs_the_full_chain() -> None:
+    skill = (PUBLISH / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "0 個なら chain manifest に従い playlist → upload" in skill
+    assert "playlist step" in skill
+    assert "upload step" in skill

--- a/tests/repo/test_publish_upload_skill_contract.py
+++ b/tests/repo/test_publish_upload_skill_contract.py
@@ -32,27 +32,24 @@ def test_publish_owns_upload_mode_and_legacy_assets() -> None:
 def test_publish_chain_manifest_keeps_upload_approval_gate() -> None:
     manifest = json.loads((PUBLISH / "references" / "publish-chain-manifest.json").read_text(encoding="utf-8"))
 
-    assert manifest == {
-        "chainId": "publish",
-        "steps": [
-            {
-                "id": "upload",
-                "skill": "publish",
-                "prerequisiteArtifacts": [
-                    "collections/<id>/01-master/*.mp4",
-                    "collections/<id>/20-documentation/descriptions.md",
-                ],
-                "outputArtifacts": [
-                    "collections/<id>/20-documentation/upload_tracking.json",
-                    "collections/<id>/workflow-state.json::upload.video_id",
-                ],
-                "approvalGate": {
-                    "skip": False,
-                    "configPath": "workflow.wf_next.skip_upload_approval",
-                },
-                "idempotency": {"script": "references/publish-chain-state.py"},
-            }
+    assert manifest["chainId"] == "publish"
+    upload = next(step for step in manifest["steps"] if step["id"] == "upload")
+    assert upload == {
+        "id": "upload",
+        "skill": "publish",
+        "prerequisiteArtifacts": [
+            "collections/<id>/01-master/*.mp4",
+            "collections/<id>/20-documentation/descriptions.md",
         ],
+        "outputArtifacts": [
+            "collections/<id>/20-documentation/upload_tracking.json",
+            "collections/<id>/workflow-state.json::upload.video_id",
+        ],
+        "approvalGate": {
+            "skip": False,
+            "configPath": "workflow.wf_next.skip_upload_approval",
+        },
+        "idempotency": {"script": "references/publish-chain-state.py"},
     }
 
 

--- a/tests/repo/test_setup_channel_disclosure_contract.py
+++ b/tests/repo/test_setup_channel_disclosure_contract.py
@@ -426,6 +426,7 @@ def test_moved_opening_assets_preserve_pre_move_bytes_or_owner_only_semantics() 
         payload = payload.replace(b"/music --prompt", b"/suno")
         payload = payload.replace(b"config/skills/music.yaml::prompt", b"config/skills/suno.yaml")
         payload = payload.replace(b"/publish --upload", b"/video-upload")
+        payload = payload.replace(b"/publish --playlist", b"/playlist")
         assert sha256(payload).hexdigest() == expected
 
 

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -167,7 +167,6 @@ TARGET_SKILLS: frozenset[str] = frozenset(
         "lyria",
         "metadata-audit",
         "pinned-comment",
-        "playlist",
         "setup",
         "short",
         "streaming",

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1018,13 +1018,13 @@ def test_upload_schedule_plan_must_precede_publish_guidance() -> None:
 
 
 def test_first_post_playlist_initialization_contract_is_documented() -> None:
-    playlist = _read(".claude/skills/playlist/SKILL.md")
+    playlist = _read(".claude/skills/publish/references/playlist.md")
     video_upload = _read(".claude/skills/publish/references/upload.md")
     wf_next = _read(".claude/skills/wf-next/SKILL.md")
     setup_channel = _read(".claude/skills/setup/references/channel-mode.md")
     checklist = _read(".claude/skills/publish/references/posting-checklist.md")
 
-    description = _skill_frontmatter("playlist")["description"]
+    description = _skill_frontmatter("publish")["description"]
     for trigger in ("初投稿", "初回投稿", "初回公開前にプレイリスト初期化"):
         assert trigger in description
 
@@ -1037,7 +1037,7 @@ def test_first_post_playlist_initialization_contract_is_documented() -> None:
         assert command in wf_next
         assert command in checklist
 
-    assert "/playlist" in setup_channel
+    assert "/publish --playlist" in setup_channel
     assert "`yt-playlist-status` → `yt-playlist-manager --init --dry-run` → `--init`" in setup_channel
 
     for text in (playlist, video_upload, wf_next, setup_channel, checklist):

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -23,7 +23,7 @@ def test_skill_catalog_matches_all_distributed_skills() -> None:
     skill_names = _skill_names()
     catalog_names = _catalog_names()
 
-    assert len(skill_names) == 37
+    assert len(skill_names) == 36
     assert len(catalog_names) == len(set(catalog_names))
     assert set(catalog_names) == skill_names
 

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -158,6 +158,17 @@ EXPECTED_ACTIVE_ROUTES = (
         "`/setup --regenerate` の config-generation-rules と同じ **5 個程度**）— YouTube は概要欄の最初の"
         "3ハッシュタグをタイトル下に表示するため、順序が重要",
     ),
+    _route(
+        "publish/references/playlist.md",
+        "## 前提",
+        "`config/channel/playlists.json` が存在し、`playlists` セクションが定義されていること。"
+        "未定義の場合は `/setup --regenerate` を案内する。",
+    ),
+    _route(
+        "publish/references/playlist.md",
+        "## Cross References",
+        "- `/setup --regenerate` — `playlists.json` の初期定義",
+    ),
     *(
         _route("publish/references/upload.md", "## 前提", line)
         for line in (


### PR DESCRIPTION
## 概要

- `/playlist` を `/publish --playlist` へ統合
- フラグなし `/publish` を `playlist → upload` の再開可能chainへ拡張
- playlist IDの状態判定と status → dry-run → 明示確認 → 実反映の承認契約を維持

## 検証

- 関連: 43 passed（最新mainへのrebase後）
- 変更前full pytest: 9040 passed, 3 skipped
- ruff / any-gate / yt-skills lint / catalog: green
- site buildはGoogle Fonts upstream 404で失敗（実装由来ではない）

Closes #3842