### PR TITLE
feat(skills): publishに固定コメントを統合する (#3845)

### DIFF
--- a/.claude/skills/post-publish/SKILL.md
+++ b/.claude/skills/post-publish/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: post-publish
 purpose: 公開する
-description: "Use when 動画公開直後の community-post → pinned-comment → metadata-audit を承認ゲート付きで一括実行・途中再開するとき。「公開後処理」「post publish」「アップロード後を続けて」で発動。各処理を単独実行する場合は対応する子スキルを使う"
+description: "Use when 動画公開直後の community-post → pinned-comment → metadata-audit を承認ゲート付きで一括実行・途中再開するとき。「公開後処理」「post publish」「アップロード後を続けて」で発動。各処理を単独実行する場合は対応する publish mode または子スキルを使う"
 ---
 
 ## 前後工程
 
 - `前工程`: `/wf-new`, `/publish --upload`
 - `後工程`: `なし`
-- `委譲先`: `/publish --community`, `/pinned-comment`, `/metadata-audit`
+- `委譲先`: `/publish --community`, `/publish --pinned`, `/metadata-audit`
 
 ## 成果物
 
@@ -19,7 +19,7 @@ description: "Use when 動画公開直後の community-post → pinned-comment �
 
 - `config/channel/` と対象 `collections/live/<collection>/workflow-state.json` が存在し、`load_config()` でロード可能であること。満たさなければ `/publish --upload` を案内して停止する。
 - `references/post-publish-chain-manifest.json` と `references/post-publish-chain-state.py` を読み、chain ID、step 順、重複 ID、未知 step、state script 参照を検証する。`approvalGate.skip` は `true = 承認省略`。旧 `enabled` だけなら `skip = not enabled` として解決し、両方の同時指定は拒否する。違反時は停止する。
-- `load_config().workflow.post_publish.configured` が `false` ならチェーンを開始しない。従来互換として `/publish --community <collection>` だけを案内し、`/pinned-comment` と `/metadata-audit` は手動実行できると表示して終了する。
+- `load_config().workflow.post_publish.configured` が `false` ならチェーンを開始しない。従来互換として `/publish --community <collection>` だけを案内し、`/publish --pinned` と `/metadata-audit` は手動実行できると表示して終了する。
 - 解決済み `approvalGate.skip` が `false` の step は、外部反映の直前に対象動画 ID・対象コレクション・件数を表示し、明示 2 択で承認されるまで子 skill を実行しない。却下時は履歴を更新せずチェーンを停止する。
 - 子 skill の内部手順を再実装しない。各段で子 SKILL.md を読み、単独発動との共通手順をそのまま実行する。
 
@@ -57,7 +57,7 @@ uv run python .claude/skills/post-publish/references/post-publish-chain-state.py
 2. manifest の gate を解決する。`skip` はそのまま、旧 `enabled` は `skip = not enabled` とする。正規 `configPath` の `load_config().workflow.post_publish.skip_approvals` を読み、`false` の step だけ承認対象にする。未指定は `true`（承認省略）。channel config の旧 `approval_gates` は loader が逆向きの後方互換 alias として解決し、同一 step への新旧同時指定は `ConfigError` にする。
 3. manifest 順に状態判定を実行する。exit 0 は skip、exit 20 は停止する。`pinned-comment` が exit 30 の場合は `--mark-pending-until-publish` を実行し、返された `pending_until` と同じ collection/video ID の再開コマンドを表示する。この時点では `pinned-comment` を dry-run/apply とも呼ばない。
 4. exit 10 かつ `skip_approvals` が `false` の場合、対象 video ID・collection・実行件数 1 件を表示する。外部投稿は公開後に取り消しが必要になり得ることを警告し、「この step を実行する」「チェーンを中止する」の 2 択で確認する。中止時は履歴を変更せず、再開コマンドを表示して停止する。
-5. 子 skill を対象 collection 付きで実行する。`community-post` step は `/publish --community` へ委譲して Studio 投稿準備、`pinned-comment` は dry-run の PASS 条件を確認して apply、`metadata-audit` は既定の local + remote 監査を実行する。チェーン gate で承認済みの step は、同じ video ID・件数の子 skill 承認を再度求めない。`skip_approvals` が `true` でも子 skill 自身が必須としている safety gate は省略しない。
+5. 子 skill または publish mode を対象 collection 付きで実行する。`community-post` step は `/publish --community` へ委譲して Studio 投稿準備、`pinned-comment` step は `/publish --pinned` へ委譲して dry-run の PASS 条件を確認後に apply、`metadata-audit` は既定の local + remote 監査を実行する。チェーン gate で承認済みの step は、同じ video ID・件数の委譲先承認を再度求めない。`skip_approvals` が `true` でも委譲先が必須としている safety gate は省略しない。
 6. 子 skill の完了条件を満たした場合だけ `--mark-complete` を実行する。失敗時は mark せず停止する。
 7. 3 step 後に状態判定を再実行し、全て exit 0 であることと履歴の video ID を短く報告する。
 

--- a/.claude/skills/post-publish/references/post-publish-chain-manifest.json
+++ b/.claude/skills/post-publish/references/post-publish-chain-manifest.json
@@ -14,7 +14,7 @@
     },
     {
       "id": "pinned-comment",
-      "skill": "pinned-comment",
+      "skill": "publish",
       "prerequisiteArtifacts": ["collections/live/*/workflow-state.json"],
       "outputArtifacts": ["post_publish_history.json"],
       "approvalGate": {

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,37 +1,38 @@
 ---
 name: publish
 purpose: 公開する
-description: "Use when 完成した動画を公開工程へ進めるとき。--playlist はプレイリストの作成・割り当て・確認、--upload は YouTube アップロード、--community はコミュニティ投稿を準備し、--batch で JSON バッチ生成へ切り替える。「プレイリスト作って」「初投稿」「初回投稿」「初回公開前にプレイリスト初期化」「コミュニティ投稿」「投稿バッチ」「投稿準備」「アップロード」「公開する」で発動。動画生成は /video の generate mode、概要欄生成は /video-description"
+description: "Use when 完成した動画を公開工程へ進めるとき。--playlist はプレイリスト管理、--upload は YouTube アップロード、--community はコミュニティ投稿準備、--batch は JSON バッチ生成、--pinned はオーナー固定コメント投稿を実行する。「プレイリスト作って」「初投稿」「初回投稿」「初回公開前にプレイリスト初期化」「コミュニティ投稿」「投稿バッチ」「固定コメント」「ピンコメント」「アップロード」「公開する」で発動。動画生成は /video の generate mode、概要欄生成は /video-description"
 ---
 
 ## 前後工程
 
 - `前工程`: `/wf-new`, `/video --generate`, `/video-description`, `/thumbnail`
-- `後工程`: `/post-publish`, `/metadata-audit`, `/pinned-comment`, `/live-clean`
+- `後工程`: `/post-publish`, `/metadata-audit`, `/live-clean`
 - `委譲先`: `/post-publish`
 
 ## 成果物
 
-- `書き込む`: `config/channel/playlists.json`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`
+- `書き込む`: `config/channel/playlists.json`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/20-documentation/community-post.txt`, `collections/<id>/workflow-state.json`, `pinned_comment_history.json`
 - `読み込む`: `config/channel/playlists.json`, `config/channel/content.json`, `auth/token.json`, `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/20-documentation/descriptions.md`, `config/channel/*.json`, `config/schedule_config.json`
 
 ## Overview
 
-公開工程の統合エントリポイント。引数なしでは playlist → upload → community の chain を状態判定付きで進め、mode 指定時はその一段だけを実行する。
+公開工程の統合エントリポイント。引数なしでは playlist → upload → community → pinned の chain を状態判定付きで進め、mode 指定時はその一段だけを実行する。
 
 ## モード判定
 
-`$ARGUMENTS` から `--playlist` / `--upload` / `--community` の個数を最初に数える。
+`$ARGUMENTS` から `--playlist` / `--upload` / `--community` / `--pinned` の個数を最初に数える。
 
 - 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す
 - 1 個なら対応する reference を読み、その一段だけを実行する。残りの引数はその mode の引数として扱う
-- 0 個なら chain manifest に従い playlist → upload → community の順で状態判定して進める
+- 0 個なら chain manifest に従い playlist → upload → community → pinned の順で状態判定して進める
 
 | mode | 読む reference |
 |---|---|
 | `--playlist` | `references/playlist.md` |
 | `--upload` | `references/upload.md` |
 | `--community` | `references/community.md` |
+| `--pinned` | `references/pinned.md` |
 
 未知 mode や複数 mode は利用可能な mode を表示して停止する。
 
@@ -41,7 +42,7 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 |---|---|
 | `--batch` | `--community` の config テンプレートから投稿バッチ JSON を生成する |
 
-`--batch` は明示した `--community` と組み合わせた場合だけ有効。`--playlist` / `--upload` との併用、または mode なしの `--batch` はエラーとして停止し、無視や chain 実行への fallback をしない。
+`--batch` は明示した `--community` と組み合わせた場合だけ有効。`--playlist` / `--upload` / `--pinned` との併用、または mode なしの `--batch` はエラーとして停止し、無視や chain 実行への fallback をしない。
 
 ## 設定読み込みゲート
 
@@ -56,16 +57,17 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 
 ## Chain Contract
 
-`references/publish-chain-manifest.json` を読み、playlist step → upload step → community step の順に実行する。mode 指定時は対応 step だけを実行する。実行前後に次を守る。
+`references/publish-chain-manifest.json` を読み、playlist step → upload step → community step → pinned step の順に実行する。mode 指定時は対応 step だけを実行する。実行前後に次を守る。
 
-1. `references/publish-chain-state.py --channel-dir <channel-root> [--collection-dir <path>] --step <playlist|upload|community>` を実行する。`--collection-dir` は upload/community の collection mode とフラグなし chain では必須だが、playlist と community の URL mode では不要。
+1. `references/publish-chain-state.py --channel-dir <channel-root> [--collection-dir <path>] --step <playlist|upload|community|pinned>` を実行する。`--collection-dir` は upload/community/pinned の collection mode とフラグなし chain では必須だが、playlist と community/pinned の video ID 直接指定では不要。
 2. exit 0 は成果物記録済みのため skip、exit 10 は run、exit 20 は state 不正のため停止する。
-3. prerequisite artifacts を検証し、playlist step は `references/playlist.md`、upload step は `references/upload.md`、community step は `references/community.md` の前提を満たす。
+3. prerequisite artifacts を検証し、playlist step は `references/playlist.md`、upload step は `references/upload.md`、community step は `references/community.md`、pinned step は `references/pinned.md` の前提を満たす。
 4. manifest の `approvalGate.configPath` を `load_config()` から解決する。値が未設定なら `approvalGate.skip` を使う。
 5. playlist step の gate は常に `skip=false`。status と dry-run を先に実行し、作成されるプレイリスト名と割り当て件数を提示して、明示承認されるまで実反映を行わない。upload step の resolved skip が `false` の場合、対象 collection、`content_model.type`、動画本数、plan が示す公開日時または公開範囲を提示し、「この先は YouTube への取り消し不能な外部アップロードを実行する」と明示する。選択肢を **「アップロードする」/「中止する」** の 2 つに限定し、承認されるまで upload CLI、tracking 更新、state 更新を行わない。
 6. community step は manifest の `workflow.post-publish.skip_approvals.community-post` を正規 config path とし、`config/channel/workflow.json::post_publish.skip_approvals.community_post` から解決する。旧 `workflow.json::post_publish.approval_gates.community_post` が有効なら逆向き alias により resolved skip は `false` になる。同一 step への新旧同時指定は拒否し、resolved skip が `false` の場合は対象 collection/動画と Studio 投稿準備 1 件を提示して、承認されるまで community mode を実行しない。
-7. resolved skip が `true` の場合だけ upload/community の各承認を省略する。upload は既存の `workflow.wf_next.skip_upload_approval`、community は既存 post-publish 設定の互換であり、初回 playlist 作成の承認や `/post-publish` の他 step 固有の承認は省略しない。
-8. 各 step 成功後に output artifacts を実在確認する。`workflow-state.json::upload.video_id` が空なら upload/community を完了扱いにしない。
+7. pinned step は manifest の `workflow.post-publish.skip_approvals.pinned-comment` を正規 config path とし、`config/channel/workflow.json::post_publish.skip_approvals.pinned_comment` から解決する。旧 `workflow.json::post_publish.approval_gates.pinned_comment` が有効なら逆向き alias により resolved skip は `false` になる。同一 step への新旧同時指定は拒否し、resolved skip が `false` の場合は dry-run の対象 video ID・件数・代表テキストを提示して、「投稿する」/「キャンセル」の 2 択で承認されるまで apply を実行しない。
+8. resolved skip が `true` の場合だけ upload/community/pinned の chain gate を省略する。pinned reference 自身の safety gate は、同じ video ID・件数への明示承認を引き継げない限り省略しない。
+9. 各 step 成功後に output artifacts を実在確認する。`workflow-state.json::upload.video_id` が空なら upload/community/pinned を完了扱いにしない。
 
 ## Instructions
 
@@ -74,6 +76,8 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 `--upload` では `references/upload.md` を読み、`content_model.type` に応じて collection は `uv run yt-upload-collection`、release は `uv run yt-upload-auto` を使う。plan や status は read-only として先に実行できるが、実 upload は上記承認ゲートを通過してから行う。
 
 `--community` では `references/community.md` を読む。`--batch` なしは固定テンプレを保存・クリップボードへコピーして Studio を開き、動画添付と投稿はユーザーが手動実行する。`--community --batch` は同 reference の batch 分岐だけを実行し、単発投稿の保存・`pbcopy`・Studio 起動を行わない。
+
+`--pinned` では `references/pinned.md` を読み、`yt-pinned-comment` の `--dry-run` で PASS 条件を確認してから、承認ゲート後に `--apply` で投稿する。ピン留め自体は Studio UI で手動実行する。
 
 `/post-publish` が構成済みなら upload 完了後にその chain へ委譲する。community-post、pinned-comment、metadata-audit の承認・履歴・再開契約をここへ複製しない。
 
@@ -97,4 +101,6 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 - upload CLI が正常終了している
 - `20-documentation/upload_tracking.json` が存在する
 - `workflow-state.json::upload.video_id` が非空文字列である
+- community step は `20-documentation/community-post.txt` が非空である
+- pinned step は対象 video ID が設定済み history file の `posted` に記録済みであり、Studio UI の手動ピン留めを案内済みである
 - collection 型では既存手順どおり `collections/live/` へ移動済み、release 型では対象全言語が処理済みである

--- a/.claude/skills/publish/references/pinned.md
+++ b/.claude/skills/publish/references/pinned.md
@@ -1,8 +1,4 @@
----
-name: pinned-comment
-purpose: 公開する
-description: "Use when 新規動画へオーナー固定コメントを自動投稿するとき。「固定コメント」「ピンコメント」で発動。dry-run 後 apply、ピン留めは Studio で手動"
----
+# Pinned mode
 
 ## 前後工程
 
@@ -12,7 +8,7 @@ description: "Use when 新規動画へオーナー固定コメントを自動投
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/20-documentation/pinned_comment_history.json`
+- `書き込む`: `pinned_comment_history.json`
 - `読み込む`: `collections/<id>/20-documentation/upload_tracking.json`, `config/channel/pinned-comment.json`, `auth/token.json`
 
 ## Overview
@@ -36,7 +32,7 @@ Phase 2 の apply が exit 0 で終了し、Studio UI での手動ピン留め�
 
 ## チェーンからの呼出
 
-単独発動では従来どおり Phase 1 後の承認ゲートを必須とする。`/post-publish` から同じ video ID・対象件数を明示して承認済みで呼ばれた場合、その承認を Phase 2 の承認として引き継ぎ、重複確認せず apply へ進める。チェーン gate が無効または対象が一致しない場合は、単独発動と同じ承認を省略しない。apply が exit 0 の場合だけチェーンへ完了を返す。
+単独発動では従来どおり Phase 1 後の承認ゲートを必須とする。`/publish` chain または `/post-publish` から同じ video ID・対象件数を明示して承認済みで呼ばれた場合、その承認を Phase 2 の承認として引き継ぎ、重複確認せず apply へ進める。チェーン gate が承認を省略した場合、または対象が一致しない場合は、単独発動と同じ承認を省略しない。apply が exit 0 の場合だけチェーンへ完了を返す。
 
 ## 設定 (`config/channel/pinned-comment.json`)
 
@@ -125,7 +121,7 @@ uv run yt-pinned-comment --collection collections/live/<latest-dir> --apply --la
 4. Studio UI でピン留め
 5. `pinned_comment_history.json` に記録され、同一 video_id への二重投稿は防止される
 
-公開後 3 処理を一括実行する場合は `/post-publish <collection>` を使う。本スキルの単独発動も従来どおり利用できる。
+公開後 3 処理を一括実行する場合は `/post-publish <collection>` を使う。`/publish --pinned` の単独発動も従来どおり利用できる。
 
 ## トラブルシュート
 

--- a/.claude/skills/publish/references/publish-chain-manifest.json
+++ b/.claude/skills/publish/references/publish-chain-manifest.json
@@ -52,6 +52,23 @@
       "idempotency": {
         "script": "references/publish-chain-state.py"
       }
+    },
+    {
+      "id": "pinned",
+      "skill": "publish",
+      "prerequisiteArtifacts": [
+        "collections/<id>/workflow-state.json::upload.video_id"
+      ],
+      "outputArtifacts": [
+        "pinned_comment_history.json"
+      ],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.post-publish.skip_approvals.pinned-comment"
+      },
+      "idempotency": {
+        "script": "references/publish-chain-state.py"
+      }
     }
   ]
 }

--- a/.claude/skills/publish/references/publish-chain-state.py
+++ b/.claude/skills/publish/references/publish-chain-state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Decide whether publish playlist, upload, and community steps must run."""
+"""Decide whether publish playlist, upload, community, and pinned steps must run."""
 
 from __future__ import annotations
 
@@ -60,6 +60,51 @@ def _evaluate_playlist(channel_dir: Path) -> tuple[int, StateResult]:
     )
 
 
+def _evaluate_pinned(channel_dir: Path, video_id: str) -> tuple[int, StateResult]:
+    config_path = channel_dir / "config" / "channel" / "pinned-comment.json"
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_missing")
+    except (OSError, json.JSONDecodeError):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+    if not isinstance(config, dict):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+    pinned_config = config.get("pinned_comment")
+    if not isinstance(pinned_config, dict):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+    history_file = pinned_config.get("history_file")
+    if not isinstance(history_file, str) or not history_file.strip():
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+
+    relative_history = Path(history_file)
+    if relative_history.is_absolute():
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+    channel_root = channel_dir.resolve()
+    history_path = (channel_dir / relative_history).resolve()
+    if not history_path.is_relative_to(channel_root):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_config_invalid")
+
+    try:
+        history = json.loads(history_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return EXIT_RUN, _result("run", "pinned_comment_missing")
+    except (OSError, json.JSONDecodeError):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_history_invalid")
+    if not isinstance(history, dict) or history.get("schema_version") != 1:
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_history_invalid")
+    posted = history.get("posted")
+    if not isinstance(posted, dict):
+        return EXIT_BLOCKED, _result("blocked", "pinned_comment_history_invalid")
+    if video_id not in posted:
+        return EXIT_RUN, _result("run", "pinned_comment_missing")
+    return EXIT_SKIP, _result(
+        "skip",
+        "pinned_comment_recorded",
+        artifacts=[relative_history.as_posix()],
+    )
+
+
 def evaluate(
     collection_dir: Path | None,
     step: str,
@@ -68,9 +113,9 @@ def evaluate(
     """Return a stable exit code and JSON-serializable decision."""
     if step == "playlist":
         return _evaluate_playlist(channel_dir or Path.cwd())
-    if step not in {"upload", "community"}:
+    if step not in {"upload", "community", "pinned"}:
         return EXIT_BLOCKED, _result("blocked", "unknown_step")
-    if step == "community" and collection_dir is None:
+    if step in {"community", "pinned"} and collection_dir is None:
         return EXIT_RUN, _result("run", "collection_not_provided")
     if collection_dir is None:
         return EXIT_BLOCKED, _result("blocked", "collection_dir_missing")
@@ -92,11 +137,12 @@ def evaluate(
         return EXIT_BLOCKED, _result("blocked", "upload_state_invalid")
 
     video_id = upload.get("video_id")
-    if step == "community":
+    if step in {"community", "pinned"}:
         if video_id is None:
             return EXIT_BLOCKED, _result("blocked", "video_id_missing")
         if not isinstance(video_id, str) or not video_id.strip():
             return EXIT_BLOCKED, _result("blocked", "video_id_invalid")
+    if step == "community":
         output = collection_dir / "20-documentation" / "community-post.txt"
         try:
             exists = output.is_file() and bool(output.read_text(encoding="utf-8").strip())
@@ -109,6 +155,8 @@ def evaluate(
             "community_post_recorded",
             artifacts=["20-documentation/community-post.txt"],
         )
+    if step == "pinned":
+        return _evaluate_pinned(channel_dir or Path.cwd(), video_id)
     if video_id is None:
         return EXIT_RUN, _result("run", "video_id_missing")
     if not isinstance(video_id, str) or not video_id.strip():

--- a/.claude/skills/publish/references/upload.md
+++ b/.claude/skills/publish/references/upload.md
@@ -3,7 +3,7 @@
 ## 前後工程
 
 - `前工程`: `/wf-new`, `/video --generate`, `/video-description`, `/publish --playlist`, `/thumbnail`
-- `後工程`: `/post-publish`, `/publish --community`, `/metadata-audit`, `/pinned-comment`, `/live-clean`
+- `後工程`: `/post-publish`, `/publish --community`, `/publish --pinned`, `/metadata-audit`, `/live-clean`
 - `委譲先`: `/post-publish`
 
 ## 成果物
@@ -121,7 +121,7 @@ $ARGUMENTS
    - この turn でユーザーが即時公開を指定しても、アップローダーは即時公開しない。予約設定を追加して再 plan するか、非公開でアップロード後に YouTube Studio で手動公開するかを人間に選んでもらう。会話を黙って durable config で上書きしない
 1. **Complete Collection アップロード** — マスター動画、メタデータ（descriptions.md から読み込み）、サムネイル設定
 2. **live 移動** — `collections/planning/` → `collections/live/`
-3. **公開後処理** — `load_config().workflow.post_publish.configured` が `true` なら、live 移動後のコレクションパスを `/post-publish` に引き継ぎ、manifest 順の `community-post → pinned-comment → metadata-audit` を実行する。チェーン側の承認・履歴・再開契約に委ね、ここで子スキルを個別に再実装しない。未設定（`false`）なら後方互換として、`config/channel/community.json` が存在する場合だけ従来どおり `/publish --community` を案内し、後続 2 スキルは手動実行のままとする
+3. **公開後処理** — `load_config().workflow.post_publish.configured` が `true` なら、live 移動後のコレクションパスを `/post-publish` に引き継ぎ、manifest 順の `community-post → pinned-comment → metadata-audit` を実行する。チェーン側の承認・履歴・再開契約に委ね、ここで委譲先を個別に再実装しない。未設定（`false`）なら後方互換として、`config/channel/community.json` が存在する場合だけ従来どおり `/publish --community` を案内し、`/publish --pinned` と `/metadata-audit` は手動実行のままとする
 
 メタデータは `descriptions.md` から title / description / tags を優先使用。存在しない場合は `BAHMetadataGenerator` で自動生成にフォールバック。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `/publish --pinned` に旧 `/pinned-comment` の dry-run → apply、投稿履歴、preflight、手動ピン留め契約を統合する。publish chain を `playlist` → `upload` → `community` → `pinned` へ拡張し、post-publish の承認・予約再開契約を維持したまま、旧 skill directory と利用者導線・site 契約を更新する（#3845）。
+
 - `feat(skills)`: `/publish --community --batch` modifier に旧 `/community-draft` の決定的 JSON 投稿バッチ生成を統合する。`--batch` は community mode 専用として fail-closed に検証し、generator・利用者導線・配布・site 契約を新 owner へ移す（#3844）。
 
 - `feat(skills)`: `/publish --community` に旧 `/community-post` の固定テンプレ保存・クリップボードコピー・Studio 起動契約を統合する。chain を `playlist` → `upload` → `community` へ拡張し、post-publish の承認設定と旧 override 互換を維持したまま、旧 skill directory と利用者導線・配布・site 契約を更新する（#3843）。

--- a/docs/architecture/b6-integration-receipt.json
+++ b/docs/architecture/b6-integration-receipt.json
@@ -731,7 +731,7 @@
     },
     {
       "old_owner": "legacy..claude.skills.pinned-comment.SKILL.md",
-      "exact_new_owner": ".claude/skills/pinned-comment/SKILL.md",
+      "exact_new_owner": ".claude/skills/publish/references/pinned.md",
       "symbols": [],
       "consumers": [],
       "handoff": "B6"

--- a/docs/features.md
+++ b/docs/features.md
@@ -51,11 +51,10 @@ YouTube への公開、視聴者対応、容量整理、コミュニティ投稿
 | Skill | なにができるか |
 |---|---|
 | /video-description | YouTube 概要欄を自動生成（情景フック + タイムスタンプ + Perfect for） |
-| /publish | `--playlist` でプレイリスト管理、`--upload` で YouTube アップロード + live 移行、`--community` で投稿文準備 + Studio 起動、`--community --batch` で JSON 投稿バッチ生成 |
+| /publish | `--playlist` でプレイリスト管理、`--upload` で YouTube アップロード + live 移行、`--community` で投稿文準備 + Studio 起動、`--community --batch` で JSON 投稿バッチ生成、`--pinned` で固定コメント投稿 |
 | /post-publish | 公開後の community-post → pinned-comment → metadata-audit を承認ゲート・実行履歴付きで一括実行 |
 | /comments-reply | ルール駆動コメント自動返信（dry-run → apply、二重返信防止） |
 | /live-chat-reply | 配信中ライブチャットの Codex 自動返信 daemon を設定・VPS 配備・運用 |
-| /pinned-comment | オーナー固定コメント自動投稿（preflight で削除済み/private を skip、dry-run → apply、二重投稿防止） |
 | /metadata-audit | ローカル descriptions.md と YouTube 上メタデータの整合性監査 |
 | /live-clean | live コレクションの大容量メディアを削除してディスク回復 |
 | /short | collection 型の生成・ローカライズ投稿と release 型の JP+EN クリップ生成を設定から自動分岐 |

--- a/docs/oauth-scopes.md
+++ b/docs/oauth-scopes.md
@@ -48,7 +48,7 @@ scope 定義の単一ソースは `src/youtube_automation/infrastructure/auth/yo
 | /setup（seed / 設定 push） | `yt-channel-seed` / `yt-channel-settings` | write（`youtube`） | `token.json` |
 | /video-description ほか一括更新 | `yt-bulk-update-desc` / `yt-bulk-update-synthetic-media` | write（`youtube`） | `token.json` |
 | /comments-reply | `yt-comments-reply` | write（`youtube.force-ssl`） | `token.json` |
-| /pinned-comment | `yt-pinned-comment` | write（`youtube.force-ssl`） | `token.json` |
+| /publish --pinned | `yt-pinned-comment` | write（`youtube.force-ssl`） | `token.json` |
 | 字幕アップロード | `yt-captions-upload` | write（`youtube.force-ssl`） | `token.json` |
 | /streaming（stream key 取得） | `yt-fetch-stream-key` | write（`youtube`） | `token_streaming.json` |
 

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -42,7 +42,6 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 - `/distrokid-helper` — Use when コレクションの楽曲を DistroKid 配信用に準備し、distrokid-helper Chrome 拡張へ渡すローカルサーバーを起動したいとき（30-distrokid 生成 / disc 分割 / metadata.md / ジャケット 3000×3000 新規生成 / uv run yt-collection-serve 起動）。
 - `/live-chat-reply` — Use when 配信中の YouTube ライブチャットへ常駐 daemon で自動返信するとき。
 - `/live-clean` — Use when live コレクションの大容量メディアを削除して容量回復するとき、または collections 配下の tmp/ 残骸を掃除するとき。
-- `/pinned-comment` — Use when 新規動画へオーナー固定コメントを自動投稿するとき。
 - `/post-publish` — Use when 動画公開直後の community-post → pinned-comment → metadata-audit を承認ゲート付きで一括実行・途中再開するとき。
 - `/publish` — Use when 完成した動画を公開工程へ進めるとき。
 

--- a/docs/strategy/growth-gap-analysis.md
+++ b/docs/strategy/growth-gap-analysis.md
@@ -24,7 +24,7 @@
 | L1 | インプレッション獲得 | `/analytics --collect --include-reporting`（動画別 Imp）、traffic source 収集（`insightTrafficSourceType/Detail`）、`/channel-research --benchmark`（競合の露出獲得パターン）、`/short`（流入面の追加） | Reporting API v1 / Analytics API v2 / Data API v3 | ◯ 計測は可、施策検証は弱い |
 | L2 | CTR | `/thumbnail`（TTP ベース生成）、`/thumbnail --compare`（320px 視認性）、`yt-thumbnail-correlate`（特徴量×CTR 相関）、`/alignment-check`（サムネ×タイトル×ムード整合）、`/flop-analysis`（CTR 閾値ルーブリック） | Reporting API v1 + サムネ画像特徴量 | ◎ 最厚のレバー |
 | L3 | 視聴維持 | retention 収集（`audienceWatchRatio` / `relativeRetentionPerformance`）、`/video-analyze`（Gemini によるフック・BGM 展開解析）、`/channel-strategy --scene`（シーン別の最適尺設計） | Analytics API v2 / Vertex AI | ◯ 計測◎、原因照合が手動 |
-| L4 | 回遊・セッション | `/publish --playlist`（`yt-playlist-manager`）、`/video-description`（Complete Collection 導線）、カード指標収集（`cardImpressions/Clicks/ClickRate`）、`/pinned-comment` `/comments-reply` `/publish --community` | Analytics API v2 / Data API v3 | △ 導線は張れるが効果測定が薄い |
+| L4 | 回遊・セッション | `/publish --playlist`（`yt-playlist-manager`）、`/video-description`（Complete Collection 導線）、カード指標収集（`cardImpressions/Clicks/ClickRate`）、`/publish --pinned` `/comments-reply` `/publish --community` | Analytics API v2 / Data API v3 | △ 導線は張れるが効果測定が薄い |
 | L5 | 登録転換 | `subscribersGained/Lost` の day・video 単位収集、`subscribedStatus` 別視聴データ収集、動画別転換率ランキングを含む `/analytics --analyze`、`yt-channel-trend`（日次 subs 移動平均・z-score 異常検知） | Analytics API v2 | ◯ 動画別転換率と視聴者の登録状態を分析可 |
 | L6 | SEO・メタデータ | `/video-description`（SEO 最適化概要欄）、`/metadata-audit`、`yt-title-duplicate-check`、localizations 同期（`/setup --push`、`yt-shorts-bulk-update-loc`） | ローカル config / Data API v3 | ◯ 生成◎、検索流入との突合なし |
 | L7 | 投稿頻度・タイミング | `/channel-research --benchmark`（競合の投稿間隔）、`yt-launch-curve`（投稿後 N 日の初速比較）、`yt-theme-compare`（テーマ別初速・ロングテール） | Data API v3 / 自チャンネル履歴 | △ 頻度の観測のみ、時刻・曜日分析なし |
@@ -107,7 +107,7 @@
 │        ↓                                                             │
 │  制作（/wf-new → /wf-next → /thumbnail → 公開 /publish --upload）    │
 │        ↓                                                             │
-│  公開直後: /publish --playlist・/pinned-comment・/publish --community│
+│  公開直後: /publish --playlist・/publish --pinned・/publish --community│
 │        ↓                                                             │
 │  T+7: yt-launch-curve で初速を過去中央値と比較 → 週次ループ先頭へ    │
 └──────────────────────────────────────────────────────────────────────┘

--- a/site/tests/skill-page-source.test.mjs
+++ b/site/tests/skill-page-source.test.mjs
@@ -151,13 +151,13 @@ test("実リポジトリでは9カテゴリと全skillを生成する", async ()
     await readFile(join(repositoryRoot, "docs/features.md"), "utf8")
   ).match(/^\| \/[a-z0-9-]+ /gmu);
 
-  assert.equal(result.entries.length, 33);
-  assert.equal(skillDirectories?.length, 32);
+  assert.equal(result.entries.length, 32);
+  assert.equal(skillDirectories?.length, 31);
   assert.equal(parseSkillCategories(await readFile(join(repositoryRoot, "docs/features.md"), "utf8")).length, 9);
   assert.doesNotMatch(result.entries[0].body.text, /## 未分類/);
 });
 
-test("production build は一覧と32個の個別ページを公開する", async () => {
+test("production build は一覧と31個の個別ページを公開する", async () => {
   const siteRoot = resolve(import.meta.dirname, "..");
   const index = await readFile(join(siteRoot, "dist/skills/index.html"), "utf8");
   const thumbnail = await readFile(
@@ -165,7 +165,7 @@ test("production build は一覧と32個の個別ページを公開する", asyn
     "utf8"
   );
 
-  assert.match(index, /32 個の skill/);
+  assert.match(index, /31 個の skill/);
   assert.match(index, /href="\/skills\/wf-new"/);
   assert.equal((index.match(/<h1\b/g) ?? []).length, 1);
   assert.match(index, /<h1[^>]*>全 skill 一覧<\/h1>/);

--- a/tests/repo/test_post_publish_chain.py
+++ b/tests/repo/test_post_publish_chain.py
@@ -64,7 +64,7 @@ def test_manifest_declares_ordered_gated_chain() -> None:
 
     assert manifest["chainId"] == "post-publish"
     assert [step["id"] for step in manifest["steps"]] == list(STEPS)
-    assert [step["skill"] for step in manifest["steps"]] == ["publish", "pinned-comment", "metadata-audit"]
+    assert [step["skill"] for step in manifest["steps"]] == ["publish", "publish", "metadata-audit"]
     assert len({step["id"] for step in manifest["steps"]}) == len(STEPS)
     assert all(step["approvalGate"]["skip"] is True for step in manifest["steps"])
     assert all("enabled" not in step["approvalGate"] for step in manifest["steps"])
@@ -199,8 +199,12 @@ def test_child_skills_support_chain_and_standalone_invocation() -> None:
     assert "/post-publish" in community
     assert "単独" in community
 
-    for name in ("pinned-comment", "metadata-audit"):
-        text = (ROOT / ".claude" / "skills" / name / "SKILL.md").read_text(encoding="utf-8")
+    paths = (
+        ROOT / ".claude/skills/publish/references/pinned.md",
+        ROOT / ".claude/skills/metadata-audit/SKILL.md",
+    )
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
         assert "/post-publish" in text
         assert "単独" in text
 

--- a/tests/repo/test_publish_chain_state.py
+++ b/tests/repo/test_publish_chain_state.py
@@ -152,3 +152,52 @@ def test_community_blocks_until_upload_is_recorded(tmp_path: Path) -> None:
 
     assert code == module.EXIT_BLOCKED
     assert result["reason"] == "video_id_missing"
+
+
+def _write_pinned_config(channel: Path, history_file: str = "pinned_comment_history.json") -> None:
+    config = channel / "config/channel"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "pinned-comment.json").write_text(
+        json.dumps({"pinned_comment": {"history_file": history_file}}),
+        encoding="utf-8",
+    )
+
+
+def test_pinned_runs_when_video_is_not_in_history(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": "youtube-id"})
+    channel = tmp_path / "channel"
+    _write_pinned_config(channel)
+
+    code, result = module.evaluate(collection, "pinned", channel)
+
+    assert code == module.EXIT_RUN
+    assert result["reason"] == "pinned_comment_missing"
+
+
+def test_pinned_skips_when_video_is_recorded_in_configured_history(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": "youtube-id"})
+    channel = tmp_path / "channel"
+    _write_pinned_config(channel, "history/pins.json")
+    history = channel / "history/pins.json"
+    history.parent.mkdir()
+    history.write_text(json.dumps({"schema_version": 1, "posted": {"youtube-id": {}}}), encoding="utf-8")
+
+    code, result = module.evaluate(collection, "pinned", channel)
+
+    assert code == module.EXIT_SKIP
+    assert result["artifacts"] == ["history/pins.json"]
+
+
+def test_pinned_blocks_on_invalid_history(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, {"video_id": "youtube-id"})
+    channel = tmp_path / "channel"
+    _write_pinned_config(channel)
+    (channel / "pinned_comment_history.json").write_text("[]", encoding="utf-8")
+
+    code, result = module.evaluate(collection, "pinned", channel)
+
+    assert code == module.EXIT_BLOCKED
+    assert result["reason"] == "pinned_comment_history_invalid"

--- a/tests/repo/test_publish_community_skill_contract.py
+++ b/tests/repo/test_publish_community_skill_contract.py
@@ -31,7 +31,7 @@ def test_publish_chain_appends_community_with_existing_approval_resolution() -> 
     manifest = json.loads((PUBLISH / "references" / "publish-chain-manifest.json").read_text(encoding="utf-8"))
     skill = (PUBLISH / "SKILL.md").read_text(encoding="utf-8")
 
-    assert [step["id"] for step in manifest["steps"]] == ["playlist", "upload", "community"]
+    assert [step["id"] for step in manifest["steps"]][:3] == ["playlist", "upload", "community"]
     community = manifest["steps"][2]
     assert community == {
         "id": "community",

--- a/tests/repo/test_publish_pinned_skill_contract.py
+++ b/tests/repo/test_publish_pinned_skill_contract.py
@@ -1,0 +1,62 @@
+"""Contracts for replacing ``/pinned-comment`` with ``/publish --pinned`` (#3845)."""
+
+from __future__ import annotations
+
+import json
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
+
+INVENTORY = SkillInventory(REPO_ROOT)
+PUBLISH = INVENTORY.skill_directory("publish")
+
+
+def _section(text: str, heading: str, next_heading: str) -> str:
+    return text.split(heading, 1)[1].split(next_heading, 1)[0]
+
+
+def test_publish_owns_pinned_mode_without_promoting_cli_arguments() -> None:
+    skill = (PUBLISH / "SKILL.md").read_text(encoding="utf-8")
+    pinned = (PUBLISH / "references" / "pinned.md").read_text(encoding="utf-8")
+    modes = _section(skill, "## モード判定", "## 修飾フラグ")
+    modifiers = _section(skill, "## 修飾フラグ", "## 設定読み込みゲート")
+
+    assert "pinned-comment" not in {path.name for path in INVENTORY.skill_directories()}
+    assert "| `--pinned` | `references/pinned.md` |" in modes
+    assert "--dry-run" not in modes and "--apply" not in modes
+    assert "--dry-run" not in modifiers and "--apply" not in modifiers
+    assert "yt-pinned-comment" in pinned
+    assert "--dry-run" in pinned and "--apply" in pinned
+    assert "Studio UI" in pinned and "手動ピン留め" in pinned
+
+
+def test_publish_chain_appends_pinned_with_existing_approval_resolution() -> None:
+    manifest = json.loads((PUBLISH / "references" / "publish-chain-manifest.json").read_text(encoding="utf-8"))
+    skill = (PUBLISH / "SKILL.md").read_text(encoding="utf-8")
+
+    assert [step["id"] for step in manifest["steps"]] == ["playlist", "upload", "community", "pinned"]
+    assert manifest["steps"][3] == {
+        "id": "pinned",
+        "skill": "publish",
+        "prerequisiteArtifacts": ["collections/<id>/workflow-state.json::upload.video_id"],
+        "outputArtifacts": ["pinned_comment_history.json"],
+        "approvalGate": {
+            "skip": True,
+            "configPath": "workflow.post-publish.skip_approvals.pinned-comment",
+        },
+        "idempotency": {"script": "references/publish-chain-state.py"},
+    }
+    assert "workflow.json::post_publish.approval_gates.pinned_comment" in skill
+    assert "workflow.json::post_publish.skip_approvals.pinned_comment" in skill
+    assert "承認されるまで" in skill
+
+
+def test_post_publish_delegates_pinned_step_to_publish() -> None:
+    manifest = json.loads(
+        (REPO_ROOT / ".claude/skills/post-publish/references/post-publish-chain-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["steps"][1]["id"] == "pinned-comment"
+    assert manifest["steps"][1]["skill"] == "publish"

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -162,7 +162,6 @@ TARGET_SKILLS: frozenset[str] = frozenset(
         "live-chat-reply",
         "music",
         "metadata-audit",
-        "pinned-comment",
         "setup",
         "short",
         "streaming",

--- a/tests/repo/test_skill_page_generation_contract.py
+++ b/tests/repo/test_skill_page_generation_contract.py
@@ -23,7 +23,7 @@ def test_skill_catalog_matches_all_distributed_skills() -> None:
     skill_names = _skill_names()
     catalog_names = _catalog_names()
 
-    assert len(skill_names) == 32
+    assert len(skill_names) == 31
     assert len(catalog_names) == len(set(catalog_names))
     assert set(catalog_names) == skill_names
 

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -269,6 +269,7 @@ MUTABLE_FILES = frozenset(path for path, _, _ in EXPECTED_ACTIVE_ROUTES if path 
     "publish/references/posting-checklist.md",
     "publish/references/community.md",
     "publish/references/generate_batch.py",
+    "publish/references/pinned.md",
     "publish/references/publish-chain-manifest.json",
     "publish/references/publish-chain-state.py",
     "publish/references/scheduled-publish.md",


### PR DESCRIPTION
## 概要

旧 `/pinned-comment` を `/publish --pinned` へ統合し、公開後 chain を固定コメントまで拡張します。

Closes #3845

## 変更内容

- dry-run → 明示承認 → apply、preflight、history、Studio 手動ピン留めの既存契約を維持
- publish chain を playlist → upload → community → pinned へ拡張
- 既存 approval 設定互換と、custom history file を使う冪等 state 判定を追加
- 旧 skill と利用者導線、catalog / site / owner 契約を更新

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
- [x] 下流互換を維持した
- [x] 必要なテストを追加・更新した

## 検証

- related: 136 passed
- full: 9064 passed / 3 skipped
- ruff check / format、yt-skills lint / catalog / delegation / artifacts、site check / source tests: green
- site production build は既知の外部 Google Fonts URL 404 のみ
