### PR TITLE
feat(skills): audit一括監査チェーンを追加する (#3856)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit
 purpose: 振り返る
-description: "Use when 整合性・価値ループ・動画本体・公開後メタデータを監査するとき。音楽ムード × サムネ × タイトルは --alignment、価値ループは --value-loop、動画解析は --video、ローカルと YouTube のメタデータ整合は --metadata を使う。「整合性チェック」「価値ループ監査」「動画解析」「メタデータ監査」で発動"
+description: "Use when 整合性・動画本体・公開後メタデータ・価値ループの監査を一括実行または一段だけ実行するとき。フラグなしは4監査を状態判定付きで進め、音楽ムード × サムネ × タイトルは --alignment、動画解析は --video、ローカルと YouTube のメタデータ整合は --metadata、価値ループは --value-loop を使う。「監査一括実行」「整合性チェック」「価値ループ監査」「動画解析」「メタデータ監査」で発動"
 ---
 
 ## 前後工程
@@ -39,7 +39,7 @@ video / metadata mode は次を deep-merge し、チャンネル上書きを優�
 
 - 2 個以上なら排他違反として停止し、1 つだけ指定するよう促す
 - 1 個なら対応する reference を読み、その一段だけを実行する。残りの引数はその mode の引数として扱う
-- 0 個なら互換入口として `--alignment` を実行する。chain manifest による状態判定は後続段で追加する
+- 0 個なら chain manifest に従い alignment → video → metadata → value-loop を状態判定付きで進める
 - 現段で実装済みの mode は `--alignment` / `--value-loop` / `--video` / `--metadata`
 - mode は最大 5 件とし、判定規則を複製しない
 
@@ -50,9 +50,30 @@ video / metadata mode は次を deep-merge し、チャンネル上書きを優�
 | `--video` | `references/video.md` |
 | `--metadata` | `references/metadata.md` |
 
+## 一括実行
+
+`references/audit-chain-manifest.json` と `references/audit-chain-state.py` が存在し、manifest の `chainId`、step 順、step mode、approval gate、状態判定 script が妥当であることを確認する。欠損、未知・重複 step、複数 mode、`approvalGate.skip != true` があれば停止する。全 mode は読み取り専用監査またはローカル監査レポート生成だけを行うため、chain の承認ゲートを省略する。
+
+チャンネルルートで manifest 順に次を実行する。
+
+```bash
+uv run python .claude/skills/audit/references/audit-chain-state.py \
+  --channel-dir . --step <alignment|video|metadata|value-loop>
+```
+
+| exit | `decision` | 処理 |
+|---:|---|---|
+| 0 | `skip` | 完了済みとして次段へ進む |
+| 10 | `run` | step の mode reference を読み、その一段を実行する |
+| 20 | `blocked` | `reason` と不足成果物を提示して停止する |
+| その他 | `error` | manifest / script / 入力 JSON のエラーとして停止する |
+
+実行後は同じ状態判定を再実行する。alignment / video が exit 0 にならなければ停止する。metadata / value-loop は診断結果を永続化しないため、実行後も exit 10 が正常である。metadata の表示結果は同じ会話内で value-loop の横断診断へ渡す。途中失敗時はその段で止め、再発動時は先頭から状態判定して完了済み段を skip する。
+
 ## 完了条件
 
-- フラグなし / `--alignment`: `references/alignment.md` の完了条件を満たしている
+- フラグなし: alignment と video が `skip` または実行後 `skip`、metadata と value-loop が `run` となり、4 mode の監査結果を表示している
+- `--alignment`: `references/alignment.md` の完了条件を満たしている
 - `--value-loop`: `references/value-loop.md` の完了条件を満たしている
 - `--video`: `references/video.md` の完了条件を満たしている
 - `--metadata`: `references/metadata.md` の完了条件を満たし、自身では修正していない

--- a/.claude/skills/audit/references/audit-chain-manifest.json
+++ b/.claude/skills/audit/references/audit-chain-manifest.json
@@ -1,0 +1,71 @@
+{
+  "chainId": "audit",
+  "steps": [
+    {
+      "id": "alignment",
+      "skill": "audit",
+      "prerequisiteArtifacts": [
+        "collections/live/*/workflow-state.json",
+        "collections/live/*/10-assets/thumbnail.jpg",
+        "collections/live/*/20-documentation/suno-prompts.md|lyria-prompt.md"
+      ],
+      "outputArtifacts": ["docs/plans/alignment-audit.md"],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.audit.skip_approvals.alignment"
+      },
+      "idempotency": {
+        "script": "references/audit-chain-state.py"
+      }
+    },
+    {
+      "id": "video",
+      "skill": "audit",
+      "prerequisiteArtifacts": ["collections/live/*/workflow-state.json::upload.video_id"],
+      "outputArtifacts": [
+        "data/video_analysis/<channel>/<video-id>.json",
+        "reports/video_analysis/<channel>.md"
+      ],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.audit.skip_approvals.video"
+      },
+      "idempotency": {
+        "script": "references/audit-chain-state.py"
+      }
+    },
+    {
+      "id": "metadata",
+      "skill": "audit",
+      "prerequisiteArtifacts": [
+        "collections/live/*/workflow-state.json::upload.video_id",
+        "collections/live/*/20-documentation/descriptions.md"
+      ],
+      "outputArtifacts": [],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.audit.skip_approvals.metadata"
+      },
+      "idempotency": {
+        "script": "references/audit-chain-state.py"
+      }
+    },
+    {
+      "id": "value-loop",
+      "skill": "audit",
+      "prerequisiteArtifacts": [
+        "docs/plans/alignment-audit.md",
+        "data/video_analysis/<channel>/<video-id>.json",
+        "reports/video_analysis/<channel>.md"
+      ],
+      "outputArtifacts": [],
+      "approvalGate": {
+        "skip": true,
+        "configPath": "workflow.audit.skip_approvals.value-loop"
+      },
+      "idempotency": {
+        "script": "references/audit-chain-state.py"
+      }
+    }
+  ]
+}

--- a/.claude/skills/audit/references/audit-chain-state.py
+++ b/.claude/skills/audit/references/audit-chain-state.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Return the resumable state of one audit chain step as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+EXIT_SKIP = 0
+EXIT_RUN = 10
+EXIT_BLOCKED = 20
+EXIT_ERROR = 2
+STEPS = ("alignment", "video", "metadata", "value-loop")
+
+
+class StateResult(TypedDict):
+    step: str
+    decision: str
+    reason: str
+    artifacts: list[str]
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _result(*, step: str, decision: str, reason: str, artifacts: list[str]) -> StateResult:
+    return {"step": step, "decision": decision, "reason": reason, "artifacts": artifacts}
+
+
+def _published_videos(root: Path) -> list[str]:
+    video_ids: list[str] = []
+    for state_path in sorted((root / "collections" / "live").glob("*/workflow-state.json")):
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            relative = _relative(state_path, root)
+            raise ValueError(f"{relative} の JSON が不正です: {exc.msg}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"{_relative(state_path, root)} は JSON object である必要があります")
+        upload = payload.get("upload")
+        if upload is None:
+            continue
+        if not isinstance(upload, dict):
+            raise ValueError(f"{_relative(state_path, root)}::upload は object である必要があります")
+        video_id = upload.get("video_id")
+        if isinstance(video_id, str) and video_id.strip():
+            video_ids.append(video_id.strip())
+    return video_ids
+
+
+def _video_outputs(root: Path, video_ids: list[str]) -> list[str]:
+    paths: list[Path] = []
+    for video_id in video_ids:
+        matches = sorted((root / "data" / "video_analysis").glob(f"*/{video_id}.json"))
+        if not matches:
+            return []
+        paths.append(matches[0])
+    reports = sorted((root / "reports" / "video_analysis").glob("*.md"))
+    if not reports:
+        return []
+    paths.append(reports[0])
+    return [_relative(path, root) for path in paths]
+
+
+def evaluate(root: Path, step: str) -> tuple[int, StateResult]:
+    root = root.resolve()
+    if step == "alignment":
+        report = root / "docs" / "plans" / "alignment-audit.md"
+        if report.is_file():
+            return EXIT_SKIP, _result(
+                step=step,
+                decision="skip",
+                reason="alignment_report_exists",
+                artifacts=[_relative(report, root)],
+            )
+        return EXIT_RUN, _result(
+            step=step,
+            decision="run",
+            reason="alignment_report_missing",
+            artifacts=[],
+        )
+
+    video_ids = _published_videos(root)
+    if not video_ids:
+        return EXIT_BLOCKED, _result(
+            step=step,
+            decision="blocked",
+            reason="published_video_missing",
+            artifacts=[],
+        )
+
+    video_outputs = _video_outputs(root, video_ids)
+    if step == "video":
+        if video_outputs:
+            return EXIT_SKIP, _result(
+                step=step,
+                decision="skip",
+                reason="video_analysis_exists",
+                artifacts=video_outputs,
+            )
+        return EXIT_RUN, _result(
+            step=step,
+            decision="run",
+            reason="video_analysis_missing",
+            artifacts=[],
+        )
+
+    if step == "metadata":
+        return EXIT_RUN, _result(
+            step=step,
+            decision="run",
+            reason="metadata_audit_is_not_persisted",
+            artifacts=[],
+        )
+
+    alignment_report = root / "docs" / "plans" / "alignment-audit.md"
+    if not alignment_report.is_file():
+        return EXIT_BLOCKED, _result(
+            step=step,
+            decision="blocked",
+            reason="alignment_report_missing",
+            artifacts=[],
+        )
+    if not video_outputs:
+        return EXIT_BLOCKED, _result(
+            step=step,
+            decision="blocked",
+            reason="video_analysis_missing",
+            artifacts=[_relative(alignment_report, root)],
+        )
+    return EXIT_RUN, _result(
+        step=step,
+        decision="run",
+        reason="value_loop_audit_is_not_persisted",
+        artifacts=[_relative(alignment_report, root), *video_outputs],
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--step", choices=STEPS, required=True)
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        code, result = evaluate(args.channel_dir, args.step)
+    except (OSError, ValueError) as exc:
+        code = EXIT_ERROR
+        result = _result(step=args.step, decision="error", reason=str(exc), artifacts=[])
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2 if args.pretty else None)
+    sys.stdout.write("\n")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: フラグなしの `/audit` に alignment → video → metadata → value-loop の読み取り専用 chain manifest と再開可能な状態判定を追加する。公開済み動画がない場合は理由付きで停止し、永続化しない metadata / value-loop は実行後も runnable として扱う（#3856）。
+
 - `feat(skills)`: `/publish --clean` に旧 `/live-clean` の公開完了ガード、不可逆削除の dry-run・明示承認、大容量メディアと `tmp/` 残骸の掃除を統合する。clean は任意 mode として publish chain へ追加せず、旧 config を `publish.yaml::clean` へ移行できる互換入口と利用者導線・site 契約を更新する（#3846）。
 
 - `feat(skills)`: `/publish --pinned` に旧 `/pinned-comment` の dry-run → apply、投稿履歴、preflight、手動ピン留め契約を統合する。publish chain を `playlist` → `upload` → `community` → `pinned` へ拡張し、post-publish の承認・予約再開契約を維持したまま、旧 skill directory と利用者導線・site 契約を更新する（#3845）。

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -46,7 +46,7 @@ PDCA 対応: 準備 = 準備する / Plan = 調べる → 決める / Do = 進�
 ## 振り返る
 
 - `/analytics` — Use when YouTube Analytics の収集・分析・レポート表示を一括実行または一段だけ実行するとき。
-- `/audit` — Use when 整合性・価値ループ・動画本体・公開後メタデータを監査するとき。
+- `/audit` — Use when 整合性・動画本体・公開後メタデータ・価値ループの監査を一括実行または一段だけ実行するとき。
 - `/channel-status` — Use when チャンネルの YouTube 統計（登録者・再生回数）を取得するとき。
 - `/flop-analysis` — Use when 公開済み動画が伸びなかった原因を video_id、collection、または --since で切り分け、postmortem.md に出力するとき。
 - `/skill-feedback` — Use when 下流チャンネルリポジトリでスキル実行中の不具合・摩擦・改善案を構造化記録するとき、または記録済み feedback を上流 issue に還流するとき。

--- a/tests/repo/test_audit_chain_state.py
+++ b/tests/repo/test_audit_chain_state.py
@@ -1,0 +1,204 @@
+"""`/audit` の manifest と再開可能な状態判定を検証する。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
+
+INVENTORY = SkillInventory(REPO_ROOT)
+SKILL_DIR = INVENTORY.skill_directory("audit")
+SCRIPT = SKILL_DIR / "references" / "audit-chain-state.py"
+MANIFEST = SKILL_DIR / "references" / "audit-chain-manifest.json"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("audit_chain_state", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def state() -> ModuleType:
+    return _load_module()
+
+
+def _write(path: Path, content: str = "{}\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _published_video(root: Path, *, collection: str = "collection-a", video_id: str = "video-123") -> None:
+    _write(
+        root / "collections" / "live" / collection / "workflow-state.json",
+        json.dumps({"upload": {"video_id": video_id}}),
+    )
+
+
+def _completed_alignment(root: Path) -> None:
+    _write(root / "docs" / "plans" / "alignment-audit.md", "# audit\n")
+
+
+def _completed_video(root: Path, *, video_id: str = "video-123") -> None:
+    _write(root / "data" / "video_analysis" / "channel" / f"{video_id}.json")
+    _write(root / "reports" / "video_analysis" / "channel.md", "# report\n")
+
+
+def test_manifest_declares_four_read_only_steps_in_diagnostic_order() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["chainId"] == "audit"
+    assert [step["id"] for step in manifest["steps"]] == ["alignment", "video", "metadata", "value-loop"]
+    assert [step["skill"] for step in manifest["steps"]] == ["audit"] * 4
+    assert all(step["approvalGate"]["skip"] is True for step in manifest["steps"])
+    assert all("enabled" not in step["approvalGate"] for step in manifest["steps"])
+    assert {step["idempotency"]["script"] for step in manifest["steps"]} == {"references/audit-chain-state.py"}
+
+
+def test_flagless_audit_exposes_the_resumable_chain_contract() -> None:
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    frontmatter = INVENTORY.frontmatter("audit")
+
+    assert isinstance(frontmatter, dict)
+    assert "フラグなしは4監査を状態判定付きで進め" in frontmatter["description"]
+    assert "alignment → video → metadata → value-loop" in text
+    assert "0 = `skip`" not in text
+    for contract in ("| 0 | `skip` |", "| 10 | `run` |", "| 20 | `blocked` |"):
+        assert contract in text
+    assert "metadata / value-loop は診断結果を永続化しない" in text
+
+
+def test_e6_keeps_only_the_intended_standalone_skills() -> None:
+    skill_names = {path.name for path in INVENTORY.skill_directories()}
+
+    e6_names = {
+        "analytics",
+        "alignment-check",
+        "audit",
+        "metadata-audit",
+        "skill-feedback",
+        "value-loop-audit",
+        "video-analyze",
+    }
+    assert skill_names & e6_names == {"analytics", "audit", "skill-feedback"}
+
+
+def test_alignment_runs_without_report_and_skips_after_report_is_saved(tmp_path: Path, state: ModuleType) -> None:
+    run_code, runnable = state.evaluate(tmp_path, "alignment")
+    _completed_alignment(tmp_path)
+    skip_code, completed = state.evaluate(tmp_path, "alignment")
+
+    assert (run_code, runnable["decision"], runnable["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "alignment_report_missing",
+    )
+    assert (skip_code, completed["decision"], completed["reason"]) == (
+        state.EXIT_SKIP,
+        "skip",
+        "alignment_report_exists",
+    )
+
+
+@pytest.mark.parametrize("step", ["video", "metadata"])
+def test_published_video_modes_block_with_reason_when_no_video_is_published(
+    tmp_path: Path, state: ModuleType, step: str
+) -> None:
+    code, result = state.evaluate(tmp_path, step)
+
+    assert code == state.EXIT_BLOCKED
+    assert result["decision"] == "blocked"
+    assert result["reason"] == "published_video_missing"
+
+
+def test_video_runs_for_missing_analysis_and_skips_after_outputs_exist(tmp_path: Path, state: ModuleType) -> None:
+    _published_video(tmp_path)
+
+    run_code, runnable = state.evaluate(tmp_path, "video")
+    _completed_video(tmp_path)
+    skip_code, completed = state.evaluate(tmp_path, "video")
+
+    assert (run_code, runnable["decision"], runnable["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "video_analysis_missing",
+    )
+    assert (skip_code, completed["decision"], completed["reason"]) == (
+        state.EXIT_SKIP,
+        "skip",
+        "video_analysis_exists",
+    )
+
+
+def test_non_persistent_metadata_and_value_loop_remain_runnable(tmp_path: Path, state: ModuleType) -> None:
+    _published_video(tmp_path)
+    _completed_alignment(tmp_path)
+    _completed_video(tmp_path)
+
+    metadata_code, metadata = state.evaluate(tmp_path, "metadata")
+    value_loop_code, value_loop = state.evaluate(tmp_path, "value-loop")
+
+    assert (metadata_code, metadata["decision"], metadata["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "metadata_audit_is_not_persisted",
+    )
+    assert (value_loop_code, value_loop["decision"], value_loop["reason"]) == (
+        state.EXIT_RUN,
+        "run",
+        "value_loop_audit_is_not_persisted",
+    )
+
+
+def test_value_loop_blocks_until_persisted_diagnostics_are_complete(tmp_path: Path, state: ModuleType) -> None:
+    _published_video(tmp_path)
+
+    alignment_code, alignment = state.evaluate(tmp_path, "value-loop")
+    _completed_alignment(tmp_path)
+    video_code, video = state.evaluate(tmp_path, "value-loop")
+
+    assert (alignment_code, alignment["reason"]) == (state.EXIT_BLOCKED, "alignment_report_missing")
+    assert (video_code, video["reason"]) == (state.EXIT_BLOCKED, "video_analysis_missing")
+
+
+def test_restart_skips_persisted_steps_and_runs_non_persistent_steps(tmp_path: Path, state: ModuleType) -> None:
+    _published_video(tmp_path)
+    _completed_alignment(tmp_path)
+    _completed_video(tmp_path)
+
+    decisions = [state.evaluate(tmp_path, step) for step in state.STEPS]
+
+    assert [(code, result["decision"]) for code, result in decisions] == [
+        (state.EXIT_SKIP, "skip"),
+        (state.EXIT_SKIP, "skip"),
+        (state.EXIT_RUN, "run"),
+        (state.EXIT_RUN, "run"),
+    ]
+
+
+def test_cli_reports_malformed_workflow_state_as_error(tmp_path: Path) -> None:
+    _write(tmp_path / "collections" / "live" / "broken" / "workflow-state.json", "{broken")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--channel-dir", str(tmp_path), "--step", "video"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "error"
+    assert "workflow-state.json" in payload["reason"]


### PR DESCRIPTION
## 概要

フラグなし `/audit` に4 modeを順次実行・再開する状態駆動 chain を追加します。

Closes #3856

## 変更内容

- alignment → video → metadata → value-loop の machine-readable manifest / state helperを追加
- 公開動画なしを blocked、完了済み段を skip として決定的に判定
- 非永続監査の exit 10 契約を維持
- mode単独実行と flagless chain の境界をテストで固定

## 検証

- full: 9091 passed / 3 skipped
- focused / broad: 371 passed
- site check / build / test: 53 passed
- ruff check / format、yt-skills lint / catalog / artifacts: green
