### PR TITLE
fix(packaging): 開発専用skillを配布物から除外する (#3753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。
+- `fix(packaging)`: upstream 開発専用の `/automation-release` と `/shadcn` を wheel・sdist から物理的に除外し、editable install での表示・除外契約は維持する（#3753）。
 
 - `feat(skills)`: フラグなしの `/audit` に alignment → video → metadata → value-loop の読み取り専用 chain manifest と再開可能な状態判定を追加する。公開済み動画がない場合は理由付きで停止し、永続化しない metadata / value-loop は実行後も runnable として扱う（#3856）。
 - `feat(skills)`: `/reply` を新設し、旧 `/comments-reply` の公開済み動画コメント返信、別コンテキスト Reviewer、dry-run 後の明示承認、二重返信防止をフラグなし mode と references へ移設する（#3848）。

--- a/docs/features.md
+++ b/docs/features.md
@@ -84,11 +84,11 @@ YouTube Analytics と動画本体の解析。
 
 | Skill | なにができるか |
 |---|---|
-| /automation-release | 本リポジトリの新規リリースを作成（prepare → publish の 2 フェーズ） |
+| /automation-release | （upstream 開発専用・downstream 配布対象外）本リポジトリの新規リリースを作成（prepare → publish の 2 フェーズ） |
 | /automation-update | 下流チャンネルを upstream 最新版に追従（pin bump + `yt-skills sync` + 動作確認） |
 | /extension | Chrome 拡張の状態判定・導入・更新と、拡張向け collection server の起動・停止 |
 | /skill-feedback | スキル実行中の不具合・摩擦・改善案を append-only JSONL に構造化記録 |
-| /shadcn | `components.json` を読み、公式docs・registry差分を基準にshadcn/ui componentを追加・更新・監査 |
+| /shadcn | （upstream 開発専用・downstream 配布対象外）`components.json` を読み、公式docs・registry差分を基準にshadcn/ui componentを追加・更新・監査 |
 
 ---
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,23 @@
+"""Hatch build hook for selecting downstream-distributed skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Map production skills individually so development-only skills stay upstream."""
+
+    def initialize(self, version: str, build_data: dict[str, object]) -> None:
+        del version
+        skills_root = Path(self.root) / ".claude" / "skills"
+        dev_only = frozenset(self.config["dev-only-skills"])
+        destination_root = "youtube_automation/_skills" if self.target_name == "wheel" else ".claude/skills"
+        force_include = build_data["force_include"]
+        assert isinstance(force_include, dict)
+
+        for skill_dir in sorted(skills_root.iterdir()):
+            if skill_dir.is_dir() and skill_dir.name not in dev_only:
+                force_include[str(skill_dir)] = f"{destination_root}/{skill_dir.name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,6 @@ yt-setup-dirs = "youtube_automation.entrypoints:yt_setup_dirs"
 packages = ["src/youtube_automation"]
 
 [tool.hatch.build.targets.wheel.force-include]
-# Claude Code スキルファイルをパッケージ内 _skills/ として同梱
-# (yt-skills sync --asset skills が importlib.resources で参照する)
-".claude/skills" = "youtube_automation/_skills"
 # BGM チャンネル運営方針テンプレ (CLAUDE.md) を _claude_md/ として同梱
 # (yt-skills sync --asset claude-md が importlib.resources で参照する)
 ".claude/CLAUDE.template.md" = "youtube_automation/_claude_md/CLAUDE.template.md"
@@ -161,12 +158,17 @@ only-include = [
     "infra/terraform/gcp/README.md",
     "README.md",
     "LICENSE",
+    "hatch_build.py",
     "pyproject.toml",
 ]
 
 [tool.hatch.build.targets.sdist.force-include]
-".claude/skills" = ".claude/skills"
 "src/youtube_automation/dashboard_dist" = "src/youtube_automation/dashboard_dist"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+# runtime fallback の _DEV_ONLY_SKILL_NAMES と契約テストで一致を担保する。
+dev-only-skills = ["automation-release", "shadcn"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -97,6 +97,9 @@ _ASSET_SPECS: dict[str, dict[str, str]] = {
     },
 }
 
+# wheel/sdist では hatch_build.py が開発専用 skill を物理的に除外する一方、
+# editable install は repository の .claude/skills を直接読むため runtime 除外も必要。
+# build hook の設定値との一致は test_dev_only_skills_not_distributed.py が担保する。
 _DEV_ONLY_SKILL_NAMES = frozenset({"automation-release", "shadcn"})
 
 

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -21,6 +21,7 @@ _PROJECT_COPY_ENTRIES = (
     "docs/workflow-cheatsheet.md",
     "flake.nix",
     "flake.lock",
+    "hatch_build.py",
     "pyproject.toml",
     "uv.lock",
     "src",

--- a/tests/repo/test_b6_integration_contract.py
+++ b/tests/repo/test_b6_integration_contract.py
@@ -361,6 +361,7 @@ def test_built_sdist_contains_only_approved_members(tmp_path: Path) -> None:
         "README.md",
         "PKG-INFO",
         ".gitignore",
+        "hatch_build.py",
         "pyproject.toml",
         ".claude/CLAUDE.template.md",
         ".claude/settings.template.json",

--- a/tests/repo/test_dev_only_skills_not_distributed.py
+++ b/tests/repo/test_dev_only_skills_not_distributed.py
@@ -1,0 +1,56 @@
+"""開発専用 skill が Python 配布物へ混入しないことの契約テスト。"""
+
+from __future__ import annotations
+
+import subprocess
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.commands.system.skills_sync import _DEV_ONLY_SKILL_NAMES
+
+
+def _build(tmp_path: Path, distribution: str) -> Path:
+    output = tmp_path / distribution
+    result = subprocess.run(
+        ["uv", "build", f"--{distribution}", "--out-dir", str(output)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    artifacts = list(output.glob("*.whl" if distribution == "wheel" else "*.tar.gz"))
+    assert len(artifacts) == 1, artifacts
+    return artifacts[0]
+
+
+def test_build_exclusion_matches_runtime_dev_only_skills() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    configured = pyproject["tool"]["hatch"]["build"]["hooks"]["custom"]["dev-only-skills"]
+
+    assert frozenset(configured) == _DEV_ONLY_SKILL_NAMES
+
+
+def test_dev_only_skills_are_absent_from_wheel(tmp_path: Path) -> None:
+    wheel = _build(tmp_path, "wheel")
+
+    with zipfile.ZipFile(wheel) as archive:
+        members = archive.namelist()
+
+    for skill_name in _DEV_ONLY_SKILL_NAMES:
+        assert not any(f"youtube_automation/_skills/{skill_name}/" in member for member in members)
+    assert any("youtube_automation/_skills/setup/SKILL.md" in member for member in members)
+
+
+def test_dev_only_skills_are_absent_from_sdist(tmp_path: Path) -> None:
+    sdist = _build(tmp_path, "sdist")
+
+    with tarfile.open(sdist) as archive:
+        members = archive.getnames()
+
+    for skill_name in _DEV_ONLY_SKILL_NAMES:
+        assert not any(f"/.claude/skills/{skill_name}/" in member for member in members)
+    assert any("/.claude/skills/setup/SKILL.md" in member for member in members)


### PR DESCRIPTION
## 概要

upstream開発専用の `automation-release` と `shadcn` をwheel・sdistから物理的に除外し、下流配布物を実際の配布境界と一致させます。

## 変更内容

- Hatch build hookでdev-only skillをwheel/sdistの同梱対象から除外
- build側とruntime側の除外集合を契約テストで一致保証
- editable installでの開発専用表示・sync除外は維持
- featuresへupstream-only注記を追加
- 新mainのsite件数契約へ追従

## 検証

- full pytest: 9096 passed, 3 skipped
- related: 49 passed
- ruff check / format: green
- yt-skills lint / catalog / artifacts: green
- uv build: green（対象2 skillはwheel/sdistとも0件）
- site build / 53 tests / check: green

Closes #3753
