### PR TITLE
refactor(suno): prompt解決を実行境界に集約する (#3908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。
 - `fix(packaging)`: upstream 開発専用の `/automation-release` と `/shadcn` を wheel・sdist から物理的に除外し、editable install での表示・除外契約は維持する（#3753）。
+- `refactor(suno)`: Suno prompt の設定・patterns・歌詞解決を CLI 実行ごとに1回へ集約し、生成側へ解決済みの品質設定と duration filter を渡して、生成内容を維持したまま重複警告を解消する（#3908）。
 
 - `feat(skills)`: 旧 `/channel-status` の登録者数・総再生回数・動画別パフォーマンス表示を `/analytics --status` へ統合する。status は分析 chain に含めず、`/wf-status` との YouTube 統計 / 制作進捗の責務境界と利用者導線を新 owner へ更新する（#3851）。
 - `feat(skills)`: フラグなしの `/audit` に alignment → video → metadata → value-loop の読み取り専用 chain manifest と再開可能な状態判定を追加する。公開済み動画がない場合は理由付きで停止し、永続化しない metadata / value-loop は実行後も runnable として扱う（#3856）。

--- a/src/youtube_automation/commands/suno/generate_suno_prompts.py
+++ b/src/youtube_automation/commands/suno/generate_suno_prompts.py
@@ -3,7 +3,6 @@
 
 import argparse
 import json
-import math
 import re
 import sys
 from collections import Counter
@@ -11,7 +10,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from youtube_automation.configuration.skills import load_channel_override, load_skill_config
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.suno import prompt_resolution
 from youtube_automation.domains.suno.downloaded.models import (
@@ -24,7 +22,6 @@ from youtube_automation.domains.suno.downloaded.validation import (
     suno_prompt_entry_names,
     surrounding_whitespace_issue,
 )
-from youtube_automation.domains.suno.lyrics import load_suno_lyrics_by_name
 from youtube_automation.infrastructure.filesystem import write_text_files_transactionally
 
 # ---------------------------------------------------------------------------
@@ -49,7 +46,7 @@ def validate_style_char_limit(
     return warnings_list
 
 
-def validate_banned_artists(style_text: str, banned_artists: list[str]) -> list[str]:
+def validate_banned_artists(style_text: str, banned_artists: Sequence[str]) -> list[str]:
     """Style テキストに禁止アーティスト名が含まれていないか検証する.
 
     Returns: エラーメッセージのリスト (空なら問題なし)。
@@ -165,28 +162,6 @@ class _ResolvedPattern:
     lyrics_by_scene: list[str]  # scenes と同じ長さ。各値は rstrip 済み。歌詞が無ければ ""
 
 
-def _duration_filter_from_config(suno: dict) -> dict:
-    raw = suno.get("duration_filter", {})
-    if raw is None:
-        raw = {}
-    if not isinstance(raw, dict):
-        raise ConfigError("config/skills/music.yaml::prompt.duration_filter must be a mapping")
-    min_sec = raw.get("min_sec", 60)
-    max_sec = raw.get("max_sec", 300)
-    if (
-        isinstance(min_sec, bool)
-        or isinstance(max_sec, bool)
-        or not isinstance(min_sec, (int, float))
-        or not isinstance(max_sec, (int, float))
-        or not math.isfinite(min_sec)
-        or not math.isfinite(max_sec)
-    ):
-        raise ConfigError("config/skills/music.yaml::prompt.duration_filter min_sec/max_sec must be finite numeric")
-    if min_sec < 0 or max_sec < 0 or min_sec > max_sec:
-        raise ConfigError("config/skills/music.yaml::prompt.duration_filter must satisfy 0 <= min_sec <= max_sec")
-    return {"min_sec": min_sec, "max_sec": max_sec}
-
-
 @dataclass
 class _GeneratedPrompts:
     title: str
@@ -194,6 +169,10 @@ class _GeneratedPrompts:
     style_influence: int
     weirdness: int
     exclude_styles: str
+    genre_line: str
+    banned_artists: tuple[str, ...]
+    auto_lyrics_structure: bool
+    duration_filter: Mapping[str, int | float]
     full_style_char_limit: int
     # channel override に明示設定された More Options フィールドのみを保持する (#900)。
     # collection スコープ: 全 entry に同じ値が載る。未設定キーは dict に含めない。
@@ -229,12 +208,7 @@ def _require_pattern_name_without_padding(
 
 
 def _resolve_prompts(patterns_path: Path) -> _GeneratedPrompts:
-    resolution = prompt_resolution.resolve_from_path(
-        patterns_path,
-        skill_config_loader=load_skill_config,
-        channel_override_loader=load_channel_override,
-        lyrics_loader=load_suno_lyrics_by_name,
-    )
+    resolution = prompt_resolution.resolve_from_path(patterns_path)
     resolved: list[_ResolvedPattern] = []
     expected_external_lyrics_names: set[str] = set()
     entry_index = 0
@@ -302,14 +276,18 @@ def _resolve_prompts(patterns_path: Path) -> _GeneratedPrompts:
         style_influence=resolution.style_influence,
         weirdness=resolution.weirdness,
         exclude_styles=resolution.exclude_styles,
+        genre_line=resolution.genre_line,
+        banned_artists=resolution.banned_artists,
+        auto_lyrics_structure=resolution.auto_lyrics_structure,
+        duration_filter=resolution.duration_filter,
         full_style_char_limit=resolution.full_style_char_limit,
         advanced_json_fields=resolution.advanced_json_fields,
         patterns=resolved,
     )
 
 
-def generate(patterns_path: Path) -> str:
-    resolved = _resolve_prompts(patterns_path)
+def generate(patterns_path: Path, *, resolved: _GeneratedPrompts | None = None) -> str:
+    resolved = _resolve_prompts(patterns_path) if resolved is None else resolved
 
     lines = [
         f"# Suno Prompts — {resolved.title}",
@@ -370,7 +348,7 @@ def generate(patterns_path: Path) -> str:
     return "\n".join(lines) + "\n"
 
 
-def build_prompt_entries(patterns_path: Path) -> list[dict]:
+def build_prompt_entries(patterns_path: Path, *, resolved: _GeneratedPrompts | None = None) -> list[dict]:
     """拡張へ配信する `[{name, style, lyrics}]` を md と同じ部品から派生させる.
 
     `_resolve_prompts()` が作る entry_names 単位で出力する。
@@ -386,18 +364,14 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
 
     Style 重複検証 (#1456): 全 entry の Style 文が完全一致する組があれば警告する
     """
-    resolved = _resolve_prompts(patterns_path)
-    suno = load_skill_config("music.prompt")
-    banned_artists = suno.get("banned_artists", [])
-    auto_lyrics = suno.get("auto_lyrics_structure", False)
+    resolved = _resolve_prompts(patterns_path) if resolved is None else resolved
 
     report = QualityReport()
 
     # 5 要素順序チェックは genre_line（ユーザーが config に書く部分）を 1 回だけ検証する。
     # Styles 第 1 行の先頭は `_style_line` が tempo を置くため full_style では false positive になる。
-    genre_line = suno.get("genre_line", "")
-    if genre_line:
-        report.warnings.extend(validate_5_element_order(genre_line))
+    if resolved.genre_line:
+        report.warnings.extend(validate_5_element_order(resolved.genre_line))
 
     entries: list[dict] = []
     for pattern in resolved.patterns:
@@ -416,11 +390,11 @@ def build_prompt_entries(patterns_path: Path) -> list[dict]:
             # Styles 第 1 行の先頭は `_style_line` が tempo を置くため、
             # full_style での先頭テンポ検知は false positive になる。
             report.warnings.extend(validate_style_char_limit(full_style, limit=resolved.full_style_char_limit))
-            report.errors.extend(validate_banned_artists(full_style, banned_artists))
+            report.errors.extend(validate_banned_artists(full_style, resolved.banned_artists))
 
             # auto_lyrics_structure: 歌詞構造の自動補強 (#904)
             lyrics = lyrics_source
-            if auto_lyrics:
+            if resolved.auto_lyrics_structure:
                 lyrics = apply_auto_lyrics_structure(lyrics, is_vocal=resolved.is_vocal)
 
             entry = {
@@ -470,11 +444,12 @@ def main():
     if not patterns_path.exists():
         parser.error(f"{patterns_path} not found")
 
-    entries = build_prompt_entries(patterns_path)
-    markdown = generate(patterns_path)
+    resolved = _resolve_prompts(patterns_path)
+    entries = build_prompt_entries(patterns_path, resolved=resolved)
+    markdown = generate(patterns_path, resolved=resolved)
     payload = {
         "entries": entries,
-        "duration_filter": _duration_filter_from_config(load_skill_config("music.prompt")),
+        "duration_filter": dict(resolved.duration_filter),
     }
 
     md_path = patterns_path.parent / SUNO_PROMPTS_MD_FILENAME

--- a/src/youtube_automation/domains/suno/prompt_resolution.py
+++ b/src/youtube_automation/domains/suno/prompt_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Callable, Mapping, Sequence, Set
 from dataclasses import dataclass, field
@@ -104,6 +105,9 @@ class ResolvedPrompts:
     title: str
     is_vocal: bool
     genre_line: str
+    banned_artists: tuple[str, ...]
+    auto_lyrics_structure: bool
+    duration_filter: Mapping[str, int | float]
     base_style: str
     style_influence: int
     weirdness: int
@@ -130,6 +134,9 @@ class _ResolvedBase:
     title: str
     is_vocal: bool
     genre_line: str
+    banned_artists: tuple[str, ...]
+    auto_lyrics_structure: bool
+    duration_filter: Mapping[str, int | float]
     base_style: str
     style_influence: int
     weirdness: int
@@ -146,6 +153,9 @@ class _ResolvedBase:
 @dataclass(frozen=True)
 class _ResolvedConfigHead:
     resolved_suno: ResolvedSunoConfig
+    banned_artists: tuple[str, ...]
+    auto_lyrics_structure: bool
+    duration_filter: Mapping[str, int | float]
     full_style_char_limit: int
     advanced_json_fields: dict[str, object]
 
@@ -205,6 +215,28 @@ def _build_advanced_json_fields(override: Mapping[str, object]) -> dict[str, obj
     return fields
 
 
+def _resolve_duration_filter(config: Mapping[str, object]) -> Mapping[str, int | float]:
+    raw = config.get("duration_filter", {})
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, Mapping):
+        raise ConfigError("config/skills/music.yaml::prompt.duration_filter must be a mapping")
+    min_sec = raw.get("min_sec", 60)
+    max_sec = raw.get("max_sec", 300)
+    if (
+        isinstance(min_sec, bool)
+        or isinstance(max_sec, bool)
+        or not isinstance(min_sec, (int, float))
+        or not isinstance(max_sec, (int, float))
+        or not math.isfinite(min_sec)
+        or not math.isfinite(max_sec)
+    ):
+        raise ConfigError("config/skills/music.yaml::prompt.duration_filter min_sec/max_sec must be finite numeric")
+    if min_sec < 0 or max_sec < 0 or min_sec > max_sec:
+        raise ConfigError("config/skills/music.yaml::prompt.duration_filter must satisfy 0 <= min_sec <= max_sec")
+    return MappingProxyType({"min_sec": min_sec, "max_sec": max_sec})
+
+
 def _resolve_config_head(config: Mapping[str, object], override: Mapping[str, object]) -> _ResolvedConfigHead:
     _validate_duration_sec_override(override)
     full_style_char_limit = _resolve_full_style_char_limit(config, override)
@@ -212,6 +244,9 @@ def _resolve_config_head(config: Mapping[str, object], override: Mapping[str, ob
     resolved_suno = resolve_suno_config(config)
     return _ResolvedConfigHead(
         resolved_suno=resolved_suno,
+        banned_artists=tuple(cast(list[str], config.get("banned_artists", []))),
+        auto_lyrics_structure=cast(bool, config.get("auto_lyrics_structure", False)),
+        duration_filter=_resolve_duration_filter(config),
         full_style_char_limit=full_style_char_limit,
         advanced_json_fields=advanced_json_fields,
     )
@@ -393,6 +428,9 @@ def _resolve_base(
         title=cast(str, patterns.get("title", "Suno Prompts")),
         is_vocal=is_vocal,
         genre_line=genre_line,
+        banned_artists=head.banned_artists,
+        auto_lyrics_structure=head.auto_lyrics_structure,
+        duration_filter=head.duration_filter,
         base_style=", ".join(base_parts),
         style_influence=cast(int, config.get("style_influence", 50)),
         weirdness=cast(int, config.get("weirdness", 50)),
@@ -471,6 +509,9 @@ def _finalize(
         title=base.title,
         is_vocal=base.is_vocal,
         genre_line=base.genre_line,
+        banned_artists=base.banned_artists,
+        auto_lyrics_structure=base.auto_lyrics_structure,
+        duration_filter=base.duration_filter,
         base_style=base.base_style,
         style_influence=base.style_influence,
         weirdness=base.weirdness,

--- a/tests/commands/suno/test_generate_suno_prompt_resolution_boundary.py
+++ b/tests/commands/suno/test_generate_suno_prompt_resolution_boundary.py
@@ -1,3 +1,5 @@
+import json
+import sys
 from pathlib import Path
 
 import yaml
@@ -6,7 +8,7 @@ from youtube_automation.commands.suno import generate_suno_prompts
 from youtube_automation.domains.suno import prompt_resolution
 
 
-def test_markdown_and_json_paths_preserve_two_resolution_calls(monkeypatch, tmp_path: Path):
+def test_main_resolves_once_and_writes_the_existing_markdown_and_json(monkeypatch, tmp_path: Path):
     channel_dir = tmp_path / "channel"
     (channel_dir / "config" / "skills").mkdir(parents=True)
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
@@ -39,15 +41,50 @@ def test_markdown_and_json_paths_preserve_two_resolution_calls(monkeypatch, tmp_
 
     monkeypatch.setattr(prompt_resolution, "resolve_from_path", resolve_from_path)
 
-    entries = generate_suno_prompts.build_prompt_entries(patterns_path)
-    markdown = generate_suno_prompts.generate(patterns_path)
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
 
-    assert resolved_paths == [patterns_path, patterns_path]
-    assert entries[0]["name"] == "集中 — Focus"
-    assert "### 集中 — Focus" in markdown
+    generate_suno_prompts.main()
+
+    assert resolved_paths == [patterns_path]
+    assert (tmp_path / "suno-prompts.md").read_text(encoding="utf-8") == (
+        "# Suno Prompts — Focus Set\n"
+        "\n"
+        "## SunoAI 推奨設定\n"
+        "\n"
+        "| パラメータ | 値 |\n"
+        "|-----------|-----|\n"
+        "| Mode | Custom |\n"
+        "| Weirdness | 50% |\n"
+        "| Style Influence | 50% |\n"
+        "| Instrumental | ON（インストモード） |\n"
+        "| Lyrics | (空) |\n"
+        "\n"
+        "---\n"
+        "\n"
+        "## Pattern A: 集中 — Focus\n"
+        "\n"
+        "### 集中 — Focus\n"
+        "**Styles:**\n"
+        "```\n"
+        "slow, ,\n"
+        "soft piano and brushed drums\n"
+        "```\n"
+        "\n"
+        "---\n"
+    )
+    assert json.loads((tmp_path / "suno-prompts.json").read_text(encoding="utf-8")) == {
+        "entries": [
+            {
+                "name": "集中 — Focus",
+                "style": "slow, ,\nsoft piano and brushed drums",
+                "lyrics": "[Instrumental]\n\n[Extended Outro]",
+            }
+        ],
+        "duration_filter": {"min_sec": 60, "max_sec": 300},
+    }
 
 
-def test_legacy_command_loader_patches_govern_both_resolution_calls(monkeypatch, tmp_path: Path):
+def test_main_loads_each_prompt_input_once_at_the_resolution_boundary(monkeypatch, tmp_path: Path):
     patterns_path = tmp_path / "patterns.yaml"
     patterns_path.write_text(
         yaml.safe_dump(
@@ -89,19 +126,14 @@ def test_legacy_command_loader_patches_govern_both_resolution_calls(monkeypatch,
         assert path == patterns_path.parent / "suno-lyrics.json"
         return {"集中 — Focus": "patched lyrics"}
 
-    def deny_domain_loader(*_args, **_kwargs):
-        raise AssertionError("command-local patch seam was bypassed")
+    monkeypatch.setattr(prompt_resolution, "load_skill_config", load_skill_config)
+    monkeypatch.setattr(prompt_resolution, "load_channel_override", load_channel_override)
+    monkeypatch.setattr(prompt_resolution, "load_suno_lyrics_by_name", load_suno_lyrics_by_name)
+    monkeypatch.setattr(sys, "argv", ["yt-generate-suno", str(patterns_path)])
 
-    monkeypatch.setattr(generate_suno_prompts, "load_skill_config", load_skill_config)
-    monkeypatch.setattr(generate_suno_prompts, "load_channel_override", load_channel_override)
-    monkeypatch.setattr(generate_suno_prompts, "load_suno_lyrics_by_name", load_suno_lyrics_by_name)
-    monkeypatch.setattr(prompt_resolution, "load_skill_config", deny_domain_loader)
-    monkeypatch.setattr(prompt_resolution, "load_channel_override", deny_domain_loader)
-    monkeypatch.setattr(prompt_resolution, "load_suno_lyrics_by_name", deny_domain_loader)
+    generate_suno_prompts.main()
 
-    entries = generate_suno_prompts.build_prompt_entries(patterns_path)
-    markdown = generate_suno_prompts.generate(patterns_path)
-
-    assert calls == {"config": 3, "override": 2, "lyrics": 2}
-    assert entries[0]["lyrics"] == "patched lyrics"
-    assert "patched vocal jazz" in markdown
+    assert calls == {"config": 1, "override": 1, "lyrics": 1}
+    payload = json.loads((tmp_path / "suno-prompts.json").read_text(encoding="utf-8"))
+    assert payload["entries"][0]["lyrics"] == "patched lyrics"
+    assert "patched vocal jazz" in (tmp_path / "suno-prompts.md").read_text(encoding="utf-8")

--- a/tests/domains/suno/test_prompt_resolution.py
+++ b/tests/domains/suno/test_prompt_resolution.py
@@ -58,6 +58,10 @@ def test_resolve_from_path_matches_mapping_core(monkeypatch, tmp_path: Path):
 
     assert from_path == from_mapping
     assert from_path.base_style == "lo-fi jazz, soft piano, warm, focused"
+    assert from_path.genre_line == "lo-fi jazz, soft piano"
+    assert from_path.banned_artists == ()
+    assert not from_path.auto_lyrics_structure
+    assert from_path.duration_filter == {"min_sec": 60, "max_sec": 300}
     assert from_path.advanced_json_fields == {"style_influence": 0, "vocal_gender": "male"}
 
 


### PR DESCRIPTION
## 概要

Suno prompt生成の設定解決を実行境界で1回だけ行い、生成側へ解決済み値を渡す構造に整理します。

## 変更内容

- ResolvedPromptsへgenre_line / banned_artists / auto_lyrics_structure / duration_filterを集約
- mainでprompt解決を1回だけ実行し、JSON/Markdown生成へ同じ結果を共有
- 生成コマンド側のload_skill_config・channel override・lyrics loader直参照を除去
- loader/config/patterns/lyricsが各1回だけ解決される境界契約を追加
- 生成内容のexact contractを追加して出力不変を保証

## 検証

- full pytest: 9086 passed, 3 skipped
- related: 237 passed
- ruff check / format: green
- 最新mainへrebase後、related 237 passedを再確認

Closes #3908
