### PR TITLE
feat(collections): workflow-state ownerを追加する (#3874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(collections)`: `workflow-state.json` の型付き document object、未知キー保持、明示的な厳格/不在許容 read、process lock 下の atomic update を共通 owner として追加する（#3874）。
+
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。
 - `fix(packaging)`: upstream 開発専用の `/automation-release` と `/shadcn` を wheel・sdist から物理的に除外し、editable install での表示・除外契約は維持する（#3753）。
 - `refactor(suno)`: Suno prompt の設定・patterns・歌詞解決を CLI 実行ごとに1回へ集約し、生成側へ解決済みの品質設定と duration filter を渡して、生成内容を維持したまま重複警告を解消する（#3908）。

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -97,6 +97,10 @@ class DiscoveryRegistryError(AutomationError):
     """ローカル server discovery registry の所有・容量契約エラー。"""
 
 
+class WorkflowStateError(AutomationError):
+    """workflow-state.json の読み取り・検証・永続化エラー。"""
+
+
 def _http_error_reason(error) -> str | None:
     content = getattr(error, "content", b"")
     if isinstance(content, bytes):

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -1,0 +1,356 @@
+"""workflow-state.json の document object と安全な永続化境界。"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Literal, cast
+
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.infrastructure.filesystem import JSONValue, file_lock
+
+Phase = Literal["planning", "prepared", "mastered", "publishing", "complete"]
+Stage = Literal["planning", "live"]
+MusicEngine = Literal["suno", "lyria"]
+WorkflowStateUpdater = Callable[["WorkflowState"], "WorkflowState | None"]
+
+_PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
+_STAGES = frozenset({"planning", "live"})
+_MUSIC_ENGINES = frozenset({"suno", "lyria"})
+_KNOWN_OBJECT_SECTIONS = frozenset(
+    {
+        "assets",
+        "description",
+        "music_pair_selection",
+        "planning",
+        "post_upload",
+        "scene_phrases",
+        "thumbnail",
+        "thumbnail_auto_selection",
+        "title_template_check",
+        "upload",
+    }
+)
+
+
+def _optional_string(data: Mapping[str, JSONValue], key: str, label: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise WorkflowStateError(f"{label} must be a string or null")
+    return value
+
+
+def _optional_bool(data: Mapping[str, JSONValue], key: str, label: str) -> bool | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise WorkflowStateError(f"{label} must be a boolean or null")
+    return value
+
+
+class _ObjectSection(MutableMapping[str, JSONValue]):
+    def __init__(self, data: dict[str, JSONValue]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> JSONValue:
+        return deepcopy(self._data[key])
+
+    def __setitem__(self, key: str, value: JSONValue) -> None:
+        self._data[key] = deepcopy(value)
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+class AssetsState(_ObjectSection):
+    """生成済み collection assets の型付き view。"""
+
+    @property
+    def thumbnail(self) -> bool | str | None:
+        value = self._data.get("thumbnail")
+        if value is None or isinstance(value, bool | str):
+            return value
+        raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean, string, or null")
+
+    @thumbnail.setter
+    def thumbnail(self, value: bool | str | None) -> None:
+        self._data["thumbnail"] = value
+
+    @property
+    def description(self) -> bool | None:
+        return _optional_bool(self._data, "description", "workflow-state.json::assets.description")
+
+    @description.setter
+    def description(self, value: bool) -> None:
+        self._data["description"] = value
+
+    @property
+    def raw_master(self) -> str | None:
+        return _optional_string(self._data, "raw_master", "workflow-state.json::assets.raw_master")
+
+    @raw_master.setter
+    def raw_master(self, value: str | None) -> None:
+        self._data["raw_master"] = value
+
+    @property
+    def master_audio(self) -> str | None:
+        return _optional_string(self._data, "master_audio", "workflow-state.json::assets.master_audio")
+
+    @master_audio.setter
+    def master_audio(self, value: str | None) -> None:
+        self._data["master_audio"] = value
+
+    @property
+    def master_video(self) -> str | None:
+        return _optional_string(self._data, "master_video", "workflow-state.json::assets.master_video")
+
+    @master_video.setter
+    def master_video(self, value: str | None) -> None:
+        self._data["master_video"] = value
+
+
+class MusicPlanningState(_ObjectSection):
+    """planning.music の型付き view。"""
+
+    @property
+    def engine(self) -> MusicEngine | None:
+        value = _optional_string(self._data, "engine", "workflow-state.json::planning.music.engine")
+        if value is None:
+            return None
+        if value not in _MUSIC_ENGINES:
+            raise WorkflowStateError(f"unsupported workflow-state music engine: {value}")
+        return cast(MusicEngine, value)
+
+    @engine.setter
+    def engine(self, value: MusicEngine) -> None:
+        self._data["engine"] = value
+
+
+class PlanningState(_ObjectSection):
+    """planning metadata の型付き view。"""
+
+    @property
+    def music(self) -> MusicPlanningState | None:
+        value = self._data.get("music")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise WorkflowStateError("workflow-state.json::planning.music must be an object")
+        return MusicPlanningState(value)
+
+
+class UploadState(_ObjectSection):
+    """YouTube upload state の型付き view。"""
+
+    @property
+    def video_id(self) -> str | None:
+        return _optional_string(self._data, "video_id", "workflow-state.json::upload.video_id")
+
+    @video_id.setter
+    def video_id(self, value: str | None) -> None:
+        self._data["video_id"] = value
+
+    @property
+    def video_url(self) -> str | None:
+        return _optional_string(self._data, "video_url", "workflow-state.json::upload.video_url")
+
+    @video_url.setter
+    def video_url(self, value: str | None) -> None:
+        self._data["video_url"] = value
+
+    @property
+    def publish_at(self) -> str | None:
+        return _optional_string(self._data, "publish_at", "workflow-state.json::upload.publish_at")
+
+    @publish_at.setter
+    def publish_at(self, value: str | None) -> None:
+        self._data["publish_at"] = value
+
+
+class WorkflowState(MutableMapping[str, JSONValue]):
+    """既知 section を型付きで扱い、未知キーも保持する document object。"""
+
+    def __init__(self, data: Mapping[str, JSONValue]) -> None:
+        self._data = deepcopy(dict(data))
+        self._validate_object_sections()
+
+    def __getitem__(self, key: str) -> JSONValue:
+        return deepcopy(self._data[key])
+
+    def __setitem__(self, key: str, value: JSONValue) -> None:
+        if key in _KNOWN_OBJECT_SECTIONS and not isinstance(value, dict):
+            raise WorkflowStateError(f"workflow-state.json::{key} must be an object")
+        self._data[key] = deepcopy(value)
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def _validate_object_sections(self) -> None:
+        for key in _KNOWN_OBJECT_SECTIONS & self._data.keys():
+            if not isinstance(self._data[key], dict):
+                raise WorkflowStateError(f"workflow-state.json::{key} must be an object")
+        planning = self.planning
+        if planning is not None:
+            _music = planning.music
+
+    @property
+    def phase(self) -> Phase | None:
+        value = _optional_string(self._data, "phase", "workflow-state.json::phase")
+        if value is None:
+            return None
+        if value not in _PHASES:
+            raise WorkflowStateError(f"unsupported workflow-state phase: {value}")
+        return cast(Phase, value)
+
+    @phase.setter
+    def phase(self, value: Phase) -> None:
+        if value not in _PHASES:
+            raise WorkflowStateError(f"unsupported workflow-state phase: {value}")
+        self._data["phase"] = value
+
+    @property
+    def stage(self) -> Stage | None:
+        value = _optional_string(self._data, "stage", "workflow-state.json::stage")
+        if value is None:
+            return None
+        if value not in _STAGES:
+            raise WorkflowStateError(f"unsupported workflow-state stage: {value}")
+        return cast(Stage, value)
+
+    @stage.setter
+    def stage(self, value: Stage) -> None:
+        if value not in _STAGES:
+            raise WorkflowStateError(f"unsupported workflow-state stage: {value}")
+        self._data["stage"] = value
+
+    @property
+    def planning(self) -> PlanningState | None:
+        value = self._data.get("planning")
+        return PlanningState(value) if isinstance(value, dict) else None
+
+    @property
+    def assets(self) -> AssetsState | None:
+        value = self._data.get("assets")
+        return AssetsState(value) if isinstance(value, dict) else None
+
+    @property
+    def upload(self) -> UploadState | None:
+        value = self._data.get("upload")
+        return UploadState(value) if isinstance(value, dict) else None
+
+    @property
+    def thumbnail_approved(self) -> bool:
+        legacy = self._section_bool("thumbnail", "approved")
+        assets = self.assets
+        current = assets.thumbnail if assets is not None else None
+        return legacy is True or current is True
+
+    @property
+    def description_generated(self) -> bool:
+        legacy = self._section_bool("description", "generated")
+        assets = self.assets
+        current = assets.description if assets is not None else None
+        return legacy is True or current is True
+
+    @property
+    def music_engine(self) -> MusicEngine | None:
+        top_level = _optional_string(self._data, "music_engine", "workflow-state.json::music_engine")
+        planning = self.planning
+        music = planning.music if planning is not None else None
+        nested = music.engine if music is not None else None
+        if top_level is not None and top_level not in _MUSIC_ENGINES:
+            raise WorkflowStateError(f"unsupported workflow-state music engine: {top_level}")
+        if top_level is not None and nested is not None and top_level != nested:
+            raise WorkflowStateError(
+                f"workflow-state music engine mismatch: top-level={top_level}, planning.music={nested}"
+            )
+        return nested or cast(MusicEngine | None, top_level)
+
+    def _section_bool(self, section: str, key: str) -> bool | None:
+        value = self._data.get(section)
+        if not isinstance(value, dict):
+            return None
+        return _optional_bool(value, key, f"workflow-state.json::{section}.{key}")
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        """永続化用に document の独立したコピーを返す。"""
+        return deepcopy(self._data)
+
+
+def _read_payload(path: Path) -> dict[str, JSONValue]:
+    if path.is_symlink():
+        raise WorkflowStateError(f"workflow-state.json must not be a symlink: {path}")
+    if not path.is_file():
+        raise WorkflowStateError(f"workflow-state.json is not a regular file: {path}")
+    try:
+        payload: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise WorkflowStateError(f"workflow-state.json could not be read: {path}") from exc
+    if not isinstance(payload, dict):
+        raise WorkflowStateError(f"workflow-state.json root must be an object: {path}")
+    return cast(dict[str, JSONValue], payload)
+
+
+def read(path: Path) -> WorkflowState:
+    """通常ファイルの workflow-state.json を厳密に読み込む。"""
+    return WorkflowState(_read_payload(path))
+
+
+def read_or_none(path: Path) -> WorkflowState | None:
+    """ファイル不在だけを None とし、破損や symlink は拒否する。"""
+    if path.is_symlink():
+        raise WorkflowStateError(f"workflow-state.json must not be a symlink: {path}")
+    if not path.exists():
+        return None
+    return read(path)
+
+
+def _write_atomically(path: Path, state: WorkflowState) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=".workflow-state.", suffix=".tmp")
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(state.to_dict(), stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.is_symlink():
+            raise WorkflowStateError(f"workflow-state.json must not be a symlink: {path}")
+        os.replace(temporary, path)
+    except WorkflowStateError:
+        temporary.unlink(missing_ok=True)
+        raise
+    except (OSError, TypeError, ValueError) as exc:
+        temporary.unlink(missing_ok=True)
+        raise WorkflowStateError(f"workflow-state.json could not be written: {path}") from exc
+
+
+def update(path: Path, updater: WorkflowStateUpdater) -> WorkflowState:
+    """lock 内で read-modify-write し、更新後の document を返す。"""
+    with file_lock(path):
+        current = read_or_none(path)
+        state = current if current is not None else WorkflowState({})
+        replacement = updater(state)
+        if replacement is not None:
+            state = replacement
+        _write_atomically(path, state)
+        return state

--- a/src/youtube_automation/infrastructure/filesystem/__init__.py
+++ b/src/youtube_automation/infrastructure/filesystem/__init__.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TypeAlias
 
+from youtube_automation.infrastructure.file_lock import file_lock as file_lock
+
 JSONValue: TypeAlias = str | int | float | bool | None | list["JSONValue"] | dict[str, "JSONValue"]
 
 

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -1,0 +1,196 @@
+"""workflow-state document object の契約テスト。"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.core.errors import AutomationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState, read, read_or_none, update
+
+
+def _write(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _increment_in_process(path: Path, entered, release) -> None:
+    def increment(state: WorkflowState) -> None:
+        current = state["counter"]
+        if isinstance(current, bool) or not isinstance(current, int):
+            raise AssertionError("counter must be an integer")
+        entered.set()
+        release.wait()
+        state["counter"] = current + 1
+
+    update(path, increment)
+
+
+def test_read_returns_typed_sections_and_compatible_accessors(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(
+        state_path,
+        {
+            "phase": "prepared",
+            "stage": "planning",
+            "music_engine": "suno",
+            "planning": {"music": {"engine": "suno"}},
+            "assets": {"thumbnail": False, "description": True},
+            "thumbnail": {"approved": True},
+            "description": {"generated": False},
+            "upload": {"video_id": "video-1", "video_url": None, "publish_at": None},
+        },
+    )
+
+    state = read(state_path)
+
+    assert isinstance(state, WorkflowState)
+    assert state.phase == "prepared"
+    assert state.stage == "planning"
+    assert state.assets is not None
+    assert state.assets.thumbnail is False
+    assert state.upload is not None
+    assert state.upload.video_id == "video-1"
+    assert state.thumbnail_approved is True
+    assert state.description_generated is True
+    assert state.music_engine == "suno"
+
+
+def test_update_preserves_unknown_keys_during_round_trip(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    unknown = {"nested": [1, {"future": True}]}
+    _write(state_path, {"phase": "planning", "future_section": unknown})
+
+    updated = update(state_path, lambda state: setattr(state, "phase", "prepared"))
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated.phase == "prepared"
+    assert persisted["phase"] == "prepared"
+    assert persisted["future_section"] == unknown
+
+
+def test_update_creates_missing_document_under_the_same_contract(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+
+    created = update(state_path, lambda state: setattr(state, "phase", "planning"))
+
+    assert created.phase == "planning"
+    assert read(state_path).phase == "planning"
+
+
+@pytest.mark.parametrize("payload", ["{broken", "[]", "null"])
+def test_read_rejects_broken_json_and_non_object_roots(tmp_path: Path, payload: str) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    state_path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(WorkflowStateError):
+        read(state_path)
+
+
+def test_read_and_read_or_none_distinguish_missing_file(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+
+    with pytest.raises(WorkflowStateError):
+        read(state_path)
+    assert read_or_none(state_path) is None
+
+
+def test_read_and_read_or_none_reject_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "actual.json"
+    state_path = tmp_path / "workflow-state.json"
+    _write(target, {"phase": "planning"})
+    state_path.symlink_to(target)
+
+    with pytest.raises(WorkflowStateError):
+        read(state_path)
+    with pytest.raises(WorkflowStateError):
+        read_or_none(state_path)
+
+
+def test_read_rejects_non_object_known_section(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"assets": []})
+
+    with pytest.raises(WorkflowStateError):
+        read(state_path)
+
+
+def test_compatible_music_engine_accessor_rejects_conflicting_values(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"music_engine": "suno", "planning": {"music": {"engine": "lyria"}}})
+
+    with pytest.raises(WorkflowStateError):
+        _engine = read(state_path).music_engine
+
+
+def test_update_keeps_existing_file_when_callback_fails(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    original = '{"phase":"planning","counter":0}'
+    state_path.write_text(original, encoding="utf-8")
+
+    def fail_after_mutation(state: WorkflowState) -> None:
+        state["counter"] = 1
+        raise RuntimeError("update failed")
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        update(state_path, fail_after_mutation)
+
+    assert state_path.read_text(encoding="utf-8") == original
+
+
+def test_update_keeps_existing_file_and_cleans_temp_when_replace_fails(tmp_path: Path, monkeypatch) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    original = '{"phase":"planning"}'
+    state_path.write_text(original, encoding="utf-8")
+
+    def fail_replace(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(WorkflowStateError):
+        update(state_path, lambda state: setattr(state, "phase", "prepared"))
+
+    assert state_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(".workflow-state.*.tmp")) == []
+
+
+def test_update_serializes_processes_without_losing_changes(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"counter": 0})
+    context = multiprocessing.get_context("spawn")
+    first_entered = context.Event()
+    second_entered = context.Event()
+    release_first = context.Event()
+    release_second = context.Event()
+    first = context.Process(target=_increment_in_process, args=(state_path, first_entered, release_first))
+    second = context.Process(target=_increment_in_process, args=(state_path, second_entered, release_second))
+
+    first.start()
+    try:
+        assert first_entered.wait(10)
+        second.start()
+        assert not second_entered.wait(0.2)
+        release_first.set()
+        assert second_entered.wait(10)
+        release_second.set()
+        first.join(10)
+        second.join(10)
+        assert first.exitcode == 0
+        assert second.exitcode == 0
+    finally:
+        release_first.set()
+        release_second.set()
+        for process in (first, second):
+            if process.is_alive():
+                process.terminate()
+            process.join(10)
+
+    assert read(state_path)["counter"] == 2
+
+
+def test_workflow_state_error_is_an_automation_error() -> None:
+    assert issubclass(WorkflowStateError, AutomationError)


### PR DESCRIPTION
## 概要

`workflow-state.json` のschema・読み取り・atomic更新・エラー方針を所有するdocument objectを `domains/collections` に新設します。

## 変更内容

- 型付き `WorkflowState` と既知section/accessorを追加
- 未知キーをread→update後もround-trip保存
- `read` / `read_or_none` / lock内read-modify-writeの `update` を提供
- symlink・破損JSON・非object・不在を `WorkflowStateError` で明示
- 既存file_lock + tempfile + fsync + os.replaceでatomic write
- 並行更新が失われない直列化テストを追加

## 検証

- full pytest: 9102 passed, 3 skipped
- focused: 201 passed
- ruff check / format: green
- git diff --check: green

Closes #3874
