### PR TITLE
docs(collections): workflow-state schemaをowner型へ追従する (#3875)

### DIFF
--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -34,6 +34,10 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
   "track_count": 12,
   "music_engine": "suno | lyria",
   "planning": {
+    "activities": "Working",
+    "target_persona": "deep-work listener",
+    "final_title": "Rainy Harbor Jazz",
+    "generated": true,
     "music": {
       "engine": "suno | lyria",
       "mood": ["mellow", "introspective"],
@@ -80,6 +84,55 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
     "video_id": null,
     "video_url": null,
     "publish_at": null
+  },
+  "post_upload": {
+    "shorts": [
+      {
+        "short_num": 1,
+        "video_id": "string",
+        "uploaded_at": "ISO 8601",
+        "publish_at": null,
+        "resume_session_uri": "string"
+      }
+    ]
+  },
+  "track_display_names": {
+    "01-track.mp3": "Display Name"
+  },
+  "title_activity": "Working",
+  "thumbnail_auto_selection": {
+    "schema_version": 1,
+    "mode": "selection_only | full",
+    "selected": "thumbnail-v1.jpg",
+    "distance": 0.125,
+    "ranking": [
+      {
+        "candidate": "thumbnail-v1.jpg",
+        "distance": 0.125,
+        "width": 1280,
+        "height": 720,
+        "eligible": true,
+        "reasons": []
+      }
+    ],
+    "reference_images": ["assets/benchmarks/reference.jpg"],
+    "reference_diagnostics": {
+      "max_reference_distance": 0.5,
+      "references": [
+        {
+          "reference_image": "assets/benchmarks/reference.jpg",
+          "distance": 0.1,
+          "outlier": false
+        }
+      ]
+    },
+    "executed_at": "ISO 8601"
+  },
+  "thumbnail": {
+    "approved": true
+  },
+  "description": {
+    "generated": true
   }
 }
 ```
@@ -98,6 +151,43 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 | `description` | boolean | YouTube 概要欄生成済み（`20-documentation/descriptions.md`） |
 
 `music_downloaded: true` かつ `raw_master: null` は、Suno 楽曲が DL 済みで raw master（クロスフェード結合出力）が未生成の中間状態を表す。
+
+### stage フィールド詳細
+
+| 値 | 説明 |
+|---|---|
+| `planning` | `collections/planning/` で制作中 |
+| `live` | upload 完了後に `collections/live/` へ移動済み |
+
+`stage` は collection の配置段階を表し、制作工程の進行を表す `phase` とは独立して更新する。
+
+### post_upload フィールド
+
+`post_upload.shorts` は公開後 short の upload 状態を `short_num` ごとに保持する。`resume_session_uri` は再開可能 upload の途中だけ存在し、完了時の entry は `video_id`、`uploaded_at`、`publish_at` を持つ。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `post_upload.shorts[].short_num` | integer / null | short の番号 |
+| `post_upload.shorts[].video_id` | string | YouTube 動画 ID |
+| `post_upload.shorts[].uploaded_at` | string | upload 日時（ISO 8601） |
+| `post_upload.shorts[].publish_at` | string / null | 公開予約日時（ISO 8601） |
+| `post_upload.shorts[].resume_session_uri` | string | 再開可能 upload session URI |
+
+### track_display_names フィールド
+
+`track_display_names` は音源ファイル名を概要欄で使う表示名へ対応付ける object（`{filename: display_name}`）。重複トラック名の解消結果を再実行時にも維持する。
+
+### title_activity フィールド
+
+`title_activity` は title template に使う collection 固有の activity 文字列。設定から解決した activity より優先する。
+
+### thumbnail_auto_selection フィールド
+
+自動選択を apply したときの監査 record。`mode`、採用候補と距離、候補 ranking、参照画像と外れ値診断、実行日時を保持する。`ranking[].reasons` は候補が不適格な理由の文字列配列である。
+
+### 互換フィールド
+
+`thumbnail.approved` と `description.generated` は既存 state を読めるよう owner が保持する互換 field。正規の生成済み判定はそれぞれ `assets.thumbnail` と `assets.description` であり、新規の状態統合は個別 issue の責務とする。
 
 #### wf-new --auto の判定責務
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `docs(collections)`: `workflow-state.json` の schema 正本を owner module の型定義へ移し、追従文書との field 差分を名前付きで検出する契約を追加する（#3875）。
+
 - `feat(collections)`: `workflow-state.json` の型付き document object、未知キー保持、明示的な厳格/不在許容 read、process lock 下の atomic update を共通 owner として追加する（#3874）。
 
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,8 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 ### クラウド移譲
 
+**workflow-state**: collection の制作・公開進捗を Git 管理の `workflow-state.json` に保持する制御面 document。schema の正本と読み書き owner は `domains.collections.workflow_state` であり、追従文書は `.claude/skills/wf-new/references/schema.md`。新規 consumer は owner の `read()` / `read_or_none()` / `update()` を使い、JSON の直パース・直接書き込みを追加しない。既存の直アクセスは段階移行対象で、未知キーを保持したまま移行する。ADR-0024 の single-writer 原則では `phase` が local / cloud 間の引き渡しトークンとなり、R2 のメディアデータとは分離する。
+
 **制御面 / データ面**: ハイブリッド制作基盤の 2 面。制御面は Git（`workflow-state.json` と冪等性 tracking 群が正本）、データ面は R2（メディアの受け渡し）で、状態をデータ面に置かない（ADR-0024）。
 
 **工程所有権**: 各工程の実行者（local / cloud）が境界規則により常に一意である性質。「いま誰の番か」は Git 上の state の phase が表し、single-writer 原則により state 自体が引き渡しトークンになる。ネットワーク越しの分散ロックを作らない根拠（ADR-0024）。

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -8,7 +8,7 @@ import tempfile
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from copy import deepcopy
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal, TypedDict, cast
 
 from youtube_automation.core.errors import WorkflowStateError
 from youtube_automation.infrastructure.filesystem import JSONValue, file_lock
@@ -17,6 +17,139 @@ Phase = Literal["planning", "prepared", "mastered", "publishing", "complete"]
 Stage = Literal["planning", "live"]
 MusicEngine = Literal["suno", "lyria"]
 WorkflowStateUpdater = Callable[["WorkflowState"], "WorkflowState | None"]
+
+
+class MusicPlanningDocument(TypedDict, total=False):
+    engine: MusicEngine
+    mood: list[str]
+    atmosphere: str
+    tempo: Literal["very slow", "slow", "gentle", "moderate", "lively"]
+    instruments: list[str]
+    exclude: list[str]
+    suno_playlist_url: str | None
+
+
+class PlanningDocument(TypedDict, total=False):
+    music: MusicPlanningDocument
+    activities: str
+    target_persona: str
+    final_title: str
+    generated: bool
+
+
+class AssetsDocument(TypedDict, total=False):
+    thumbnail: bool | str
+    loop_video: bool | Literal["failed"]
+    music_prompts: bool
+    music_downloaded: bool
+    raw_master: str | None
+    master_audio: str | None
+    master_video: str | None
+    description: bool
+
+
+class MusicPairSelectionExceptionDocument(TypedDict, total=False):
+    prompt_index: int
+    variant: str | None
+    title: str
+    source: str
+    duration_sec: float
+    max_song_sec: float
+    reason: str
+
+
+class MusicPairSelectionDocument(TypedDict, total=False):
+    updated_at: str
+    exceptions_over_limit_count: int
+    exceptions_over_limit: list[MusicPairSelectionExceptionDocument]
+
+
+class UploadDocument(TypedDict, total=False):
+    video_id: str | None
+    video_url: str | None
+    publish_at: str | None
+
+
+class PostUploadShortDocument(TypedDict, total=False):
+    short_num: int | None
+    video_id: str
+    uploaded_at: str
+    publish_at: str | None
+    resume_session_uri: str
+
+
+class PostUploadDocument(TypedDict, total=False):
+    shorts: list[PostUploadShortDocument]
+
+
+class ThumbnailRankingDocument(TypedDict, total=False):
+    candidate: str
+    distance: float
+    width: int
+    height: int
+    eligible: bool
+    reasons: list[str]
+
+
+class ThumbnailReferenceDiagnosticDocument(TypedDict, total=False):
+    reference_image: str
+    distance: float
+    outlier: bool
+
+
+class ThumbnailReferenceDiagnosticsDocument(TypedDict, total=False):
+    max_reference_distance: float
+    references: list[ThumbnailReferenceDiagnosticDocument]
+
+
+class ThumbnailAutoSelectionDocument(TypedDict, total=False):
+    schema_version: int
+    mode: Literal["selection_only", "full"]
+    selected: str
+    distance: float
+    ranking: list[ThumbnailRankingDocument]
+    reference_images: list[str]
+    reference_diagnostics: ThumbnailReferenceDiagnosticsDocument
+    executed_at: str
+
+
+class ThumbnailDocument(TypedDict, total=False):
+    approved: bool
+
+
+class DescriptionDocument(TypedDict, total=False):
+    generated: bool
+
+
+class TitleTemplateCheckDocument(TypedDict, total=False):
+    allow_volume_patterns: bool
+
+
+class WorkflowStateDocument(TypedDict, total=False):
+    """workflow-state.json の schema 正本。未知キーは document object が保持する。"""
+
+    collection_name: str
+    theme: str
+    created_at: str
+    updated_at: str
+    stage: Stage
+    phase: Phase
+    selected_plan: Literal["A", "B", "C", "D", "E"]
+    track_count: int
+    music_engine: MusicEngine
+    planning: PlanningDocument
+    scene_phrases: dict[str, str]
+    title_template_check: TitleTemplateCheckDocument
+    assets: AssetsDocument
+    music_pair_selection: MusicPairSelectionDocument
+    upload: UploadDocument
+    post_upload: PostUploadDocument
+    track_display_names: dict[str, str]
+    title_activity: str
+    thumbnail_auto_selection: ThumbnailAutoSelectionDocument
+    thumbnail: ThumbnailDocument
+    description: DescriptionDocument
+
 
 _PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
 _STAGES = frozenset({"planning", "live"})

--- a/tests/repo/test_workflow_state_schema_doc.py
+++ b/tests/repo/test_workflow_state_schema_doc.py
@@ -1,0 +1,65 @@
+"""workflow-state owner と追従 schema 文書の field 契約。"""
+
+from __future__ import annotations
+
+import json
+import re
+import types
+from typing import Union, get_args, get_origin, get_type_hints, is_typeddict
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.collections.workflow_state import WorkflowStateDocument
+
+SCHEMA_PATH = REPO_ROOT / ".claude/skills/wf-new/references/schema.md"
+_SCHEMA_EXAMPLE = re.compile(r"## フィールド定義\s+```json\s+(\{.*?\})\s+```", re.DOTALL)
+
+
+def _owner_paths(annotation: object, prefix: str = "") -> set[str]:
+    if is_typeddict(annotation):
+        paths: set[str] = set()
+        for name, field_type in get_type_hints(annotation).items():
+            path = f"{prefix}.{name}" if prefix else name
+            paths.add(path)
+            paths.update(_owner_paths(field_type, path))
+        return paths
+
+    origin = get_origin(annotation)
+    if origin is list:
+        (item_type,) = get_args(annotation)
+        return _owner_paths(item_type, f"{prefix}[]")
+    if origin in (Union, types.UnionType):
+        paths: set[str] = set()
+        for member in get_args(annotation):
+            paths.update(_owner_paths(member, prefix))
+        return paths
+    return set()
+
+
+def _document_paths(value: object, owner_paths: set[str], prefix: str = "") -> set[str]:
+    if not isinstance(value, dict):
+        return set()
+
+    paths: set[str] = set()
+    for name, child in value.items():
+        path = f"{prefix}.{name}" if prefix else name
+        paths.add(path)
+        if isinstance(child, dict) and any(candidate.startswith(f"{path}.") for candidate in owner_paths):
+            paths.update(_document_paths(child, owner_paths, path))
+        elif isinstance(child, list) and child and isinstance(child[0], dict):
+            item_path = f"{path}[]"
+            if any(candidate.startswith(f"{item_path}.") for candidate in owner_paths):
+                paths.update(_document_paths(child[0], owner_paths, item_path))
+    return paths
+
+
+def test_schema_document_tracks_owner_field_names() -> None:
+    owner_paths = _owner_paths(WorkflowStateDocument)
+    match = _SCHEMA_EXAMPLE.search(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert match is not None, "schema.md field JSON example was not found"
+    documented_paths = _document_paths(json.loads(match.group(1)), owner_paths)
+
+    missing_from_document = sorted(owner_paths - documented_paths)
+    missing_from_owner = sorted(documented_paths - owner_paths)
+    assert not missing_from_document and not missing_from_owner, (
+        f"missing from schema.md: {missing_from_document}; missing from owner: {missing_from_owner}"
+    )


### PR DESCRIPTION
## 概要

workflow-state schemaの正本をowner moduleの型定義へ切り替え、追従文書とのdriftを機械検知します。

## 変更内容

- owner moduleへworkflow-state全fieldのTypedDict正本を追加
- schema.md JSON例とのrecursive field-path双方向一致契約を追加
- 欠落時に具体的なfield名を診断
- 未記載だった7系統をschema.mdへ追従
- architecture用語集へowner・直パース禁止・ADR-0024との関係を明記

## 検証

- full pytest: 9103 passed, 3 skipped
- focused: 283 passed
- ruff check / format / yt-skills lint: green
- git diff --check: green

Closes #3875
