### PR TITLE
refactor(doctor): 診断checkを宣言registryへ集約する (#3918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collections)`: `workflow-state.json` の型付き document object、未知キー保持、明示的な厳格/不在許容 read、process lock 下の atomic update を共通 owner として追加する（#3874）。
 - `feat(skills)`: `/automation --question <質問>` と排他フラグなしの自然文に、配布物ローカルを優先する読み取り専用 question mode を追加する。ローカルで未解決の場合だけ upstream GitHub を参照し、version 差分を明示する。回答不能時は書き込みを行わず `/skill-feedback` へ案内する（#3754）。
 
+- `refactor(doctor)`: 30 件の診断を実行順・category・apply 種別・cwd 意味論を持つ宣言 registry へ集約し、診断・表示・JSON・自動修復の重複判定を単一化する（#3918）。
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。
 - `fix(packaging)`: upstream 開発専用の `/automation-release` と `/shadcn` を wheel・sdist から物理的に除外し、editable install での表示・除外契約は維持する（#3753）。
 - `refactor(suno)`: Suno prompt の設定・patterns・歌詞解決を CLI 実行ごとに1回へ集約し、生成側へ解決済みの品質設定と duration filter を渡して、生成内容を維持したまま重複警告を解消する（#3908）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -22,8 +22,9 @@ from contextlib import contextmanager, redirect_stdout
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass
 from datetime import date, datetime
+from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import yaml
 from google.auth.exceptions import RefreshError, TransportError
@@ -124,6 +125,33 @@ class CheckResult:
     category: str = API_CATEGORY  # bootstrap / api / channel / data / upload
     next_action: Optional[dict] = None
     data: Optional[dict] = None
+
+
+class ApplyKind(Enum):
+    """診断の apply 可否と特別な入力契約。"""
+
+    NONE = "none"
+    AI_EXEC = "ai-exec"
+    PROJECT = "project"
+    BILLING = "billing"
+
+
+class CwdSemantics(Enum):
+    """apply command を実行する基準ディレクトリ。"""
+
+    CHANNEL = "channel"
+    BOOTSTRAP_ROOT = "bootstrap-root"
+
+
+@dataclass(frozen=True)
+class CheckDefinition:
+    """1 件の doctor check を構成する宣言。"""
+
+    id: str
+    category: str
+    run: Callable[[Path], CheckResult]
+    apply_kind: ApplyKind
+    cwd_semantics: CwdSemantics
 
 
 def _ai_exec_action(
@@ -3234,39 +3262,111 @@ def check_upload_ready(channel_dir: Path) -> CheckResult:
     )
 
 
+def _without_channel_dir(check: Callable[[], CheckResult]) -> Callable[[Path], CheckResult]:
+    def run(_channel_dir: Path) -> CheckResult:
+        return check()
+
+    return run
+
+
+CHECK_REGISTRY = (
+    CheckDefinition(
+        "ffmpeg", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffmpeg), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
+    ),
+    CheckDefinition(
+        "ffprobe", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffprobe), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
+    ),
+    CheckDefinition(
+        "uv", BOOTSTRAP_CATEGORY, _without_channel_dir(check_uv), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
+    ),
+    CheckDefinition("uv_project", BOOTSTRAP_CATEGORY, check_uv_project, ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT),
+    CheckDefinition(
+        "automation_package",
+        BOOTSTRAP_CATEGORY,
+        check_automation_package,
+        ApplyKind.NONE,
+        CwdSemantics.BOOTSTRAP_ROOT,
+    ),
+    CheckDefinition(
+        "skills_synced",
+        BOOTSTRAP_CATEGORY,
+        check_skills_synced,
+        ApplyKind.AI_EXEC,
+        CwdSemantics.BOOTSTRAP_ROOT,
+    ),
+    CheckDefinition(
+        "numbered_duplicates",
+        BOOTSTRAP_CATEGORY,
+        check_numbered_duplicates,
+        ApplyKind.NONE,
+        CwdSemantics.BOOTSTRAP_ROOT,
+    ),
+    CheckDefinition("gcloud", API_CATEGORY, _without_channel_dir(check_gcloud), ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "gcloud_account", API_CATEGORY, _without_channel_dir(check_gcloud_account), ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("gcp_project", API_CATEGORY, check_gcp_project, ApplyKind.PROJECT, CwdSemantics.CHANNEL),
+    CheckDefinition("billing_linked", API_CATEGORY, check_billing, ApplyKind.BILLING, CwdSemantics.CHANNEL),
+    CheckDefinition("apis_enabled", API_CATEGORY, check_apis_enabled, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL),
+    CheckDefinition("adc", API_CATEGORY, _without_channel_dir(check_adc), ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "adc_quota_project", API_CATEGORY, check_adc_quota_project, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition(
+        "iam_aiplatform_user", API_CATEGORY, check_iam_aiplatform_user, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("client_secrets", API_CATEGORY, check_client_secrets, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "oauth_client_sharing", API_CATEGORY, check_oauth_client_sharing, ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("oauth_token", API_CATEGORY, check_oauth_token, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "oauth_token_readonly", API_CATEGORY, check_oauth_token_readonly, ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("reporting_job", API_CATEGORY, check_reporting_job, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "streaming_vps_state", API_CATEGORY, check_streaming_vps_state, ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("channel_config", CHANNEL_CATEGORY, check_channel_config, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition("playlist_config", CHANNEL_CATEGORY, check_playlist_config, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "playlist_create_dry_run",
+        CHANNEL_CATEGORY,
+        check_playlist_create_dry_run,
+        ApplyKind.NONE,
+        CwdSemantics.CHANNEL,
+    ),
+    CheckDefinition("analytics_report", DATA_CATEGORY, check_analytics_report, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition("benchmark_data", DATA_CATEGORY, check_benchmark_data, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "ttp_wf_new_readiness", DATA_CATEGORY, check_ttp_wf_new_readiness, ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("wf_new_readiness", DATA_CATEGORY, check_wf_new_readiness, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition(
+        "initial_setup_readiness", DATA_CATEGORY, check_initial_setup_readiness, ApplyKind.NONE, CwdSemantics.CHANNEL
+    ),
+    CheckDefinition("upload_ready", UPLOAD_CATEGORY, check_upload_ready, ApplyKind.NONE, CwdSemantics.CHANNEL),
+)
+
+
+def _check_definition(check_id: str) -> CheckDefinition | None:
+    return next((definition for definition in CHECK_REGISTRY if definition.id == check_id), None)
+
+
+def _declared_category(result: CheckResult) -> str:
+    definition = _check_definition(result.id)
+    return definition.category if definition is not None else result.category
+
+
 def run_all_checks(channel_dir: Path) -> list[CheckResult]:
-    return [
-        check_ffmpeg(),
-        check_ffprobe(),
-        check_uv(),
-        check_uv_project(channel_dir),
-        check_automation_package(channel_dir),
-        check_skills_synced(channel_dir),
-        check_numbered_duplicates(channel_dir),
-        check_gcloud(),
-        check_gcloud_account(),
-        check_gcp_project(channel_dir),
-        check_billing(channel_dir),
-        check_apis_enabled(channel_dir),
-        check_adc(),
-        check_adc_quota_project(channel_dir),
-        check_iam_aiplatform_user(channel_dir),
-        check_client_secrets(channel_dir),
-        check_oauth_client_sharing(channel_dir),
-        check_oauth_token(channel_dir),
-        check_oauth_token_readonly(channel_dir),
-        check_reporting_job(channel_dir),
-        check_streaming_vps_state(channel_dir),
-        check_channel_config(channel_dir),
-        check_playlist_config(channel_dir),
-        check_playlist_create_dry_run(channel_dir),
-        check_analytics_report(channel_dir),
-        check_benchmark_data(channel_dir),
-        check_ttp_wf_new_readiness(channel_dir),
-        check_wf_new_readiness(channel_dir),
-        check_initial_setup_readiness(channel_dir),
-        check_upload_ready(channel_dir),
-    ]
+    results: list[CheckResult] = []
+    for definition in CHECK_REGISTRY:
+        result = definition.run(channel_dir)
+        if result.id != definition.id:
+            raise RuntimeError(f"doctor check id mismatch: declared={definition.id}, returned={result.id}")
+        result.category = definition.category
+        results.append(result)
+    return results
 
 
 def summarize(results: list[CheckResult]) -> dict:
@@ -3328,6 +3428,7 @@ def _public_next_action(action: dict | None) -> dict | None:
 
 def _check_result_to_dict(result: CheckResult) -> dict:
     payload = asdict(result)
+    payload["category"] = _declared_category(result)
     payload["next_action"] = _public_next_action(result.next_action)
     return payload
 
@@ -3396,6 +3497,28 @@ def _forced_project_check(
     return CheckResult(id="gcp_project", status="fail", message=f"project {project_id} を選択")
 
 
+def _apply_kind_for(result: CheckResult) -> ApplyKind:
+    definition = _check_definition(result.id)
+    if definition is not None:
+        return definition.apply_kind
+    if result.id == "gcp_project":
+        return ApplyKind.PROJECT
+    if result.id == "billing_linked":
+        return ApplyKind.BILLING
+    return ApplyKind.AI_EXEC
+
+
+def _apply_cwd_for(result: CheckResult, channel_dir: Path) -> Path:
+    definition = _check_definition(result.id)
+    if definition is not None:
+        semantics = definition.cwd_semantics
+    elif result.category == BOOTSTRAP_CATEGORY:
+        semantics = CwdSemantics.BOOTSTRAP_ROOT
+    else:
+        semantics = CwdSemantics.CHANNEL
+    return _bootstrap_root(channel_dir) if semantics is CwdSemantics.BOOTSTRAP_ROOT else channel_dir
+
+
 def _run_apply_loop(
     channel_dir: Path,
     project_id: str | None,
@@ -3409,7 +3532,8 @@ def _run_apply_loop(
         unresolved = _forced_project_check(results, project_id, current_project_id) or _first_unresolved_check(results)
         if unresolved is None:
             return _apply_outcome(results, "completed", executed)
-        if unresolved.id == "gcp_project" and project_id is None:
+        apply_kind = _apply_kind_for(unresolved)
+        if apply_kind is ApplyKind.PROJECT and project_id is None:
             return _apply_outcome(
                 results,
                 "decision_required",
@@ -3418,7 +3542,7 @@ def _run_apply_loop(
                 next_action={"kind": "decision", "flag": "--project-id"},
             )
         if (
-            unresolved.id == "billing_linked"
+            apply_kind is ApplyKind.BILLING
             and billing_account is None
             and unresolved.next_action
             and unresolved.next_action.get("kind") == "ai-exec"
@@ -3431,9 +3555,9 @@ def _run_apply_loop(
                 next_action={"kind": "decision", "flag": "--billing-account"},
             )
         action = unresolved.next_action
-        if unresolved.id == "gcp_project" and project_id is not None:
+        if apply_kind is ApplyKind.PROJECT and project_id is not None:
             action = _ai_exec_action(["gcloud", "config", "set", "project", project_id])
-        elif unresolved.id == "billing_linked" and billing_account is not None:
+        elif apply_kind is ApplyKind.BILLING and billing_account is not None:
             active_project_id = _project_id_for(channel_dir)
             if not active_project_id:
                 return _apply_outcome(
@@ -3454,7 +3578,12 @@ def _run_apply_loop(
                     f"--billing-account={billing_account}",
                 ]
             )
-        if not action or action.get("kind") != "ai-exec" or action.get("auto_apply") is False:
+        if (
+            apply_kind is ApplyKind.NONE
+            or not action
+            or action.get("kind") != "ai-exec"
+            or action.get("auto_apply") is False
+        ):
             return _apply_outcome(
                 results,
                 "human_required",
@@ -3493,7 +3622,7 @@ def _run_apply_loop(
                 exit_code=1,
             )
         attempted_steps.add(step_key)
-        command_cwd = _bootstrap_root(channel_dir) if unresolved.category == BOOTSTRAP_CATEGORY else channel_dir
+        command_cwd = _apply_cwd_for(unresolved, channel_dir)
         returncode, _stdout, stderr = _run_apply_command(argv, command_cwd)
         executed.append(ExecutedStep(unresolved.id, command, returncode))
         if returncode != 0:
@@ -3507,7 +3636,7 @@ def _run_apply_loop(
                 stderr=stderr,
                 exit_code=1,
             )
-        if unresolved.id == "gcp_project" and project_id is not None:
+        if apply_kind is ApplyKind.PROJECT and project_id is not None:
             _APPLY_PROJECT_ID.set(project_id)
             os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
 
@@ -3786,8 +3915,9 @@ def render_table(results: list[CheckResult], summary: dict, channel_dir: Path) -
 
     current_category: Optional[str] = None
     for r in results:
-        if r.category != current_category:
-            current_category = r.category
+        category = _declared_category(r)
+        if category != current_category:
+            current_category = category
             lines.append("")
             lines.append(f"=== {current_category} ===")
             lines.append(f"{'STATUS':<8} {'CHECK':<22} MESSAGE")

--- a/tests/commands/system/test_doctor_registry.py
+++ b/tests/commands/system/test_doctor_registry.py
@@ -1,0 +1,105 @@
+"""yt-doctor の宣言的 check registry 契約。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.commands.system import doctor
+
+EXPECTED_CHECK_IDS = (
+    "ffmpeg",
+    "ffprobe",
+    "uv",
+    "uv_project",
+    "automation_package",
+    "skills_synced",
+    "numbered_duplicates",
+    "gcloud",
+    "gcloud_account",
+    "gcp_project",
+    "billing_linked",
+    "apis_enabled",
+    "adc",
+    "adc_quota_project",
+    "iam_aiplatform_user",
+    "client_secrets",
+    "oauth_client_sharing",
+    "oauth_token",
+    "oauth_token_readonly",
+    "reporting_job",
+    "streaming_vps_state",
+    "channel_config",
+    "playlist_config",
+    "playlist_create_dry_run",
+    "analytics_report",
+    "benchmark_data",
+    "ttp_wf_new_readiness",
+    "wf_new_readiness",
+    "initial_setup_readiness",
+    "upload_ready",
+)
+
+
+def test_registry_declares_unique_checks_in_execution_order() -> None:
+    assert tuple(definition.id for definition in doctor.CHECK_REGISTRY) == EXPECTED_CHECK_IDS
+    assert len({definition.id for definition in doctor.CHECK_REGISTRY}) == len(doctor.CHECK_REGISTRY)
+
+
+def test_registry_categories_are_contiguous() -> None:
+    categories = [definition.category for definition in doctor.CHECK_REGISTRY]
+
+    assert list(dict.fromkeys(categories)) == [
+        doctor.BOOTSTRAP_CATEGORY,
+        doctor.API_CATEGORY,
+        doctor.CHANNEL_CATEGORY,
+        doctor.DATA_CATEGORY,
+        doctor.UPLOAD_CATEGORY,
+    ]
+    for category in set(categories):
+        indexes = [index for index, value in enumerate(categories) if value == category]
+        assert indexes == list(range(indexes[0], indexes[-1] + 1))
+
+
+def test_registry_declares_apply_and_cwd_semantics() -> None:
+    definitions = {definition.id: definition for definition in doctor.CHECK_REGISTRY}
+
+    assert definitions["gcp_project"].apply_kind is doctor.ApplyKind.PROJECT
+    assert definitions["billing_linked"].apply_kind is doctor.ApplyKind.BILLING
+    assert definitions["skills_synced"].apply_kind is doctor.ApplyKind.AI_EXEC
+    assert definitions["channel_config"].apply_kind is doctor.ApplyKind.NONE
+    assert definitions["skills_synced"].cwd_semantics is doctor.CwdSemantics.BOOTSTRAP_ROOT
+    assert definitions["apis_enabled"].cwd_semantics is doctor.CwdSemantics.CHANNEL
+
+
+def test_new_registry_declaration_drives_run_render_and_apply(monkeypatch, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    channel = workspace / "channels" / "alpha"
+    (channel / "config" / "channel").mkdir(parents=True)
+    diagnoses = iter(("fail", "ok"))
+
+    def check_example(_channel_dir: Path) -> doctor.CheckResult:
+        status = next(diagnoses)
+        action = doctor._ai_exec_action(["example", "--fix"]) if status == "fail" else None
+        return doctor.CheckResult(id="example", status=status, message=status, category="example", next_action=action)
+
+    definition = doctor.CheckDefinition(
+        id="example",
+        category="example",
+        run=check_example,
+        apply_kind=doctor.ApplyKind.AI_EXEC,
+        cwd_semantics=doctor.CwdSemantics.BOOTSTRAP_ROOT,
+    )
+    monkeypatch.setattr(doctor, "CHECK_REGISTRY", (definition,))
+    commands: list[tuple[list[str], Path]] = []
+    monkeypatch.setattr(
+        doctor,
+        "_run_apply_command",
+        lambda argv, cwd: commands.append((argv, cwd)) or (0, "", ""),
+    )
+
+    outcome = doctor.run_apply(channel)
+
+    assert [result.id for result in outcome.results] == ["example"]
+    assert commands == [(["example", "--fix"], workspace)]
+    assert "=== example ===" in doctor.render_table(outcome.results, doctor.summarize(outcome.results), channel)
+    assert doctor._check_result_to_dict(outcome.results[0])["category"] == "example"


### PR DESCRIPTION
## 概要

yt-doctorの30 checkを宣言registryへ集約し、実行・apply・表示・JSON出力の重複分岐を等価変換します。

## 変更内容

- id / category / 実行関数 / apply種別 / cwd意味論を持つcheck宣言を追加
- run_all_checks / apply loop / render / JSONをregistry駆動へ変更
- 宣言順=実行順、first-unresolved、category連続表示を維持
- forced project checkのindex比較とbootstrap cwd切替を維持
- check関数signatureを変えず、関数+宣言1件で追加可能に変更
- registryの順序・属性・追加反映契約を追加

## 検証

- focused/C1: 440 passed
- full: 実装assertionはgreen（負荷系timeoutのみ、全件直列再走green）
- ruff check / format: green

Closes #3918
