### PR TITLE
refactor(cli): analytics読み取り系をharnessへ移行する (#3926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(collections)`: `workflow-state.json` の型付き document object、未知キー保持、明示的な厳格/不在許容 read、process lock 下の atomic update を共通 owner として追加する（#3874）。
 - `feat(skills)`: `/automation --question <質問>` と排他フラグなしの自然文に、配布物ローカルを優先する読み取り専用 question mode を追加する。ローカルで未解決の場合だけ upstream GitHub を参照し、version 差分を明示する。回答不能時は書き込みを行わず `/skill-feedback` へ案内する（#3754）。
 - `refactor(cli)`: argparse 互換の共通 CLI harness を追加し、uploads 3 コマンドの引数解析・期待済みエラー・中断処理を共通境界へ集約する。各 `main(argv)` は exit code を返し、AutomationError は機密情報を除去して stderr へ出力する（#3924）。
+- `refactor(cli)`: analytics 読み取り系 7 CLI を共通 CLI harness と `main(argv)` 境界へ移行し、既存の JSON / text 出力・exit code・設定解決順を維持する（#3926）。
 
 - `refactor(doctor)`: 30 件の診断を実行順・category・apply 種別・cwd 意味論を持つ宣言 registry へ集約し、診断・表示・JSON・自動修復の重複判定を単一化する（#3918）。
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。

--- a/src/youtube_automation/commands/analytics/ad_coverage.py
+++ b/src/youtube_automation/commands/analytics/ad_coverage.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.core.errors import ConfigError
 
@@ -173,7 +174,7 @@ def _min_playbacks(value: str) -> int:
     return parsed
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="動画別 ads-per-playback の中央値から広告カバレッジ低下を検出")
     parser.add_argument(
         "--threshold",
@@ -215,9 +216,7 @@ def _print_text(analysis: Mapping[str, object]) -> None:
         )
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-    args = _build_parser().parse_args()
+def run(args: argparse.Namespace) -> int:
     try:
         revenue = load_latest_revenue(_channel_dir())
         analysis = analyze_ad_coverage(revenue, threshold=args.threshold, min_playbacks=args.min_playbacks)
@@ -229,6 +228,11 @@ def main() -> int:
     except ConfigError as error:
         logger.error(str(error))
         return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/channel_trend.py
+++ b/src/youtube_automation/commands/analytics/channel_trend.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from pathlib import Path
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.analytics.series.channel_trend import analyze_channel_trend
@@ -61,9 +62,7 @@ def _print_text_summary(analysis: dict) -> None:
             print(f"   {w['week_starting']}: {w['views']:>6,} views  ({delta})")
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="チャンネル全体の日次トレンドと異常検知")
     parser.add_argument(
         "--z-threshold",
@@ -72,9 +71,10 @@ def main() -> int:
         help="異常検知の z-score 閾値 (default: 2.0)",
     )
     parser.add_argument("--text", action="store_true", help="人間向けテキスト出力")
+    return parser
 
-    args = parser.parse_args()
 
+def run(args: argparse.Namespace) -> int:
     try:
         channel_dir = _channel_dir()
         daily_metrics = _load_daily_metrics(channel_dir)
@@ -92,6 +92,11 @@ def main() -> int:
     except Exception as e:
         logger.exception(f"エラー: {e}")
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/kpi_dashboard.py
+++ b/src/youtube_automation/commands/analytics/kpi_dashboard.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.analytics.kpi_dashboard import analyze_kpi_dashboard, render_markdown
@@ -54,9 +55,7 @@ def _save_reports(channel_dir: Path, analysis: Dict, markdown: str) -> List[Path
     return [json_path, md_path]
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="成長 KPI 定点ビュー（スナップショット横断のレバー別週次推移）")
     parser.add_argument("--markdown", action="store_true", help="Markdown レポートを stdout へ出力")
     parser.add_argument(
@@ -64,8 +63,10 @@ def main() -> int:
         action="store_true",
         help="reports/kpi_weekly_YYYYMMDD.json と .md を保存する",
     )
-    args = parser.parse_args()
+    return parser
 
+
+def run(args: argparse.Namespace) -> int:
     try:
         channel_dir = _channel_dir()
         snapshots = _load_snapshots(channel_dir)
@@ -88,6 +89,11 @@ def main() -> int:
     except Exception as e:
         logger.exception(f"エラー: {e}")
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/launch_curve.py
+++ b/src/youtube_automation/commands/analytics/launch_curve.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.analytics.analysis.launch_curve_analyzer import (
@@ -161,9 +162,7 @@ def _print_text_summary(analysis: Dict) -> None:
         )
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="動画の launch curve を過去ベンチマークと比較")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--video", help="対象動画 ID")
@@ -180,9 +179,10 @@ def main() -> int:
         action="store_true",
         help="可視化 PNG も出力（デフォルトは出力しない）",
     )
+    return parser
 
-    args = parser.parse_args()
 
+def run(args: argparse.Namespace) -> int:
     try:
         channel_dir = _channel_dir()
         daily = load_latest_daily_snapshot(channel_dir / "data")
@@ -233,6 +233,11 @@ def main() -> int:
     except Exception as e:
         logger.exception(f"エラー: {e}")
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/theme_compare.py
+++ b/src/youtube_automation/commands/analytics/theme_compare.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from pathlib import Path
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import ConfigError
@@ -57,9 +58,7 @@ def _print_text_summary(analysis: dict) -> None:
         print(f"   {t['theme']:<15} (n={t['video_count']}): {peaks_str}")
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="テーマ別 launch curve 比較")
     parser.add_argument(
         "--peak-days",
@@ -67,8 +66,10 @@ def main() -> int:
         help="比較する日齢 (カンマ区切り, default: 3,7,30)",
     )
     parser.add_argument("--text", action="store_true", help="人間向けテキスト出力")
+    return parser
 
-    args = parser.parse_args()
+
+def run(args: argparse.Namespace) -> int:
     peak_days = tuple(int(d) for d in args.peak_days.split(","))
 
     try:
@@ -104,6 +105,11 @@ def main() -> int:
     except Exception as e:
         logger.exception(f"エラー: {e}")
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/traffic_trend.py
+++ b/src/youtube_automation/commands/analytics/traffic_trend.py
@@ -14,6 +14,7 @@ import logging
 import sys
 from pathlib import Path
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.analytics.traffic_trend import analyze_traffic_trend
@@ -59,9 +60,7 @@ def _print_text_summary(analysis: dict) -> None:
         print("\n🔍 YT_SEARCH 検索語: データなし（`yt-analytics` の再収集で取得）")
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="流入源シェア推移とデバイス別集計")
     parser.add_argument(
         "--top-search",
@@ -70,9 +69,10 @@ def main() -> int:
         help="YT_SEARCH 検索語トップ N の件数 (default: 10)",
     )
     parser.add_argument("--text", action="store_true", help="人間向けテキスト出力")
+    return parser
 
-    args = parser.parse_args()
 
+def run(args: argparse.Namespace) -> int:
     try:
         channel_dir = _channel_dir()
         snapshots = _load_snapshots(channel_dir)
@@ -96,6 +96,11 @@ def main() -> int:
     except Exception as e:
         logger.exception(f"エラー: {e}")
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/ttp_health.py
+++ b/src/youtube_automation/commands/analytics/ttp_health.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from youtube_automation.application.analytics.benchmark_query import find_latest_benchmark_json
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.infrastructure.analytics.ttp_health import evaluate_ttp_health
 
@@ -48,14 +49,16 @@ def build_report(
     )
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="benchmark.channels の TTP 健全性を JSON で出力")
     parser.add_argument("--stale-days", type=int, default=60)
     parser.add_argument("--decline-ratio", type=float, default=0.5)
     parser.add_argument("--window-days", type=int, default=90)
     parser.add_argument("--pretty", action="store_true")
-    args = parser.parse_args(argv)
+    return parser
 
+
+def run(args: argparse.Namespace) -> int:
     report = build_report(
         data_dir=channel_dir() / "data",
         stale_days=args.stale_days,
@@ -71,6 +74,10 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/tests/commands/analytics/test_ad_coverage.py
+++ b/tests/commands/analytics/test_ad_coverage.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import json
-import sys
 import tomllib
 from pathlib import Path
 
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
-from youtube_automation import entrypoints
 from youtube_automation.commands.analytics import ad_coverage
 from youtube_automation.core.errors import ConfigError
 
@@ -158,7 +156,7 @@ def test_analyze_rejects_unhashable_revenue_status_as_config_error(status: objec
         ad_coverage.analyze_ad_coverage(revenue, threshold=0.5, min_playbacks=100)
 
 
-def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_cli_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkeypatch, capsys) -> None:
     _write_snapshot(tmp_path, "20260801", _available_revenue({"old": _video(200, 0.1)}))
     _write_snapshot(
         tmp_path,
@@ -172,9 +170,7 @@ def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkey
         ),
     )
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--threshold", "0.7"])
-
-    assert entrypoints.yt_ad_coverage() == 0
+    assert ad_coverage.main(["--threshold", "0.7"]) == 0
 
     output = json.loads(capsys.readouterr().out)
     assert output["threshold"] == 0.7
@@ -183,9 +179,7 @@ def test_entrypoint_reads_latest_snapshot_and_prints_json(tmp_path: Path, monkey
     assert output["warnings"][0]["median_ratio"] == pytest.approx(0.6)
 
 
-def test_entrypoint_degrades_empty_partial_video_data_without_breaking_pipeline(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_cli_degrades_empty_partial_video_data_without_breaking_pipeline(tmp_path: Path, monkeypatch, capsys) -> None:
     _write_snapshot(
         tmp_path,
         "20260802",
@@ -197,9 +191,7 @@ def test_entrypoint_degrades_empty_partial_video_data_without_breaking_pipeline(
         },
     )
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
-
-    assert entrypoints.yt_ad_coverage() == 0
+    assert ad_coverage.main([]) == 0
 
     assert json.loads(capsys.readouterr().out) == {
         "status": "unavailable",
@@ -216,9 +208,7 @@ def test_cli_text_reports_zero_warnings(tmp_path: Path, monkeypatch, capsys) -> 
         _available_revenue({"video-a": _video(300, 2.0), "video-b": _video(300, 2.0)}),
     )
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--text"])
-
-    assert ad_coverage.main() == 0
+    assert ad_coverage.main(["--text"]) == 0
 
     assert "警告: 0 件" in capsys.readouterr().out
 
@@ -230,9 +220,7 @@ def test_cli_text_reports_unavailable_reason(tmp_path: Path, monkeypatch, capsys
         {"status": "unavailable", "reason": "monetary data forbidden", "by_video": {}},
     )
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", "--text"])
-
-    assert ad_coverage.main() == 0
+    assert ad_coverage.main(["--text"]) == 0
 
     output = capsys.readouterr().out
     assert "収益データを取得できません" in output
@@ -245,9 +233,7 @@ def test_cli_returns_two_for_invalid_snapshot_shape(tmp_path: Path, monkeypatch,
     data_dir.mkdir()
     (data_dir / "analytics_data_20260802.json").write_text("[]", encoding="utf-8")
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
-
-    assert ad_coverage.main() == 2
+    assert ad_coverage.main([]) == 2
 
     assert "JSON object" in caplog.text
 
@@ -258,9 +244,7 @@ def test_cli_returns_two_without_traceback_for_unhashable_revenue_status(
 ) -> None:
     _write_snapshot(tmp_path, "20260802", {"status": status, "by_video": {}})
     monkeypatch.setattr(ad_coverage, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage"])
-
-    assert ad_coverage.main() == 2
+    assert ad_coverage.main([]) == 2
 
     captured = capsys.readouterr()
     assert "available、partial、unavailable" in caplog.text
@@ -277,11 +261,9 @@ def test_cli_returns_two_without_traceback_for_unhashable_revenue_status(
         ["--min-playbacks", "1.5"],
     ],
 )
-def test_cli_rejects_invalid_detection_options(arguments: list[str], monkeypatch) -> None:
-    monkeypatch.setattr(sys, "argv", ["yt-ad-coverage", *arguments])
-
+def test_cli_rejects_invalid_detection_options(arguments: list[str]) -> None:
     with pytest.raises(SystemExit) as exited:
-        ad_coverage.main()
+        ad_coverage.main(arguments)
 
     assert exited.value.code == 2
 

--- a/tests/commands/analytics/test_channel_trend.py
+++ b/tests/commands/analytics/test_channel_trend.py
@@ -193,9 +193,7 @@ def test_cli_uses_latest_snapshot_and_prints_json(tmp_path, monkeypatch, capsys)
     _write_snapshot(data_dir / "analytics_data_20260401.json", 10)
     _write_snapshot(data_dir / "analytics_data_20260402.json", 25)
     monkeypatch.setattr(channel_trend_cli, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr("sys.argv", ["yt-channel-trend"])
-
-    assert channel_trend_cli.main() == 0
+    assert channel_trend_cli.main([]) == 0
 
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["total_views"] == 25
@@ -207,9 +205,7 @@ def test_cli_prints_human_readable_text(tmp_path, monkeypatch, capsys):
     data_dir.mkdir()
     _write_snapshot(data_dir / "analytics_data_20260401.json", 25)
     monkeypatch.setattr(channel_trend_cli, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr("sys.argv", ["yt-channel-trend", "--text"])
-
-    assert channel_trend_cli.main() == 0
+    assert channel_trend_cli.main(["--text"]) == 0
 
     output = capsys.readouterr().out
     assert "チャンネルトレンド分析" in output
@@ -219,7 +215,5 @@ def test_cli_prints_human_readable_text(tmp_path, monkeypatch, capsys):
 
 def test_cli_returns_two_when_snapshot_is_missing(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(channel_trend_cli, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr("sys.argv", ["yt-channel-trend"])
-
-    assert channel_trend_cli.main() == 2
+    assert channel_trend_cli.main([]) == 2
     assert "analytics_data_*.json が見つかりません" in caplog.text

--- a/tests/commands/analytics/test_kpi_dashboard.py
+++ b/tests/commands/analytics/test_kpi_dashboard.py
@@ -225,9 +225,7 @@ class TestCli:
 
         self._write_snapshots(tmp_path)
         monkeypatch.setattr(cli, "_channel_dir", lambda: tmp_path)
-        monkeypatch.setattr("sys.argv", ["yt-kpi-dashboard", "--save"])
-
-        assert cli.main() == 0
+        assert cli.main(["--save"]) == 0
         analysis = json.loads(capsys.readouterr().out)
         assert analysis["snapshot_count"] == 2
         assert len(analysis["weekly_kpi"]) == 2
@@ -241,9 +239,7 @@ class TestCli:
 
         self._write_snapshots(tmp_path)
         monkeypatch.setattr(cli, "_channel_dir", lambda: tmp_path)
-        monkeypatch.setattr("sys.argv", ["yt-kpi-dashboard", "--markdown"])
-
-        assert cli.main() == 0
+        assert cli.main(["--markdown"]) == 0
         assert "| 週 (月曜開始) |" in capsys.readouterr().out
 
     def test_cli_skips_broken_snapshot(self, tmp_path, monkeypatch, capsys):
@@ -252,7 +248,5 @@ class TestCli:
         self._write_snapshots(tmp_path)
         (tmp_path / "data" / "analytics_data_20260120.json").write_text("{broken", encoding="utf-8")
         monkeypatch.setattr(cli, "_channel_dir", lambda: tmp_path)
-        monkeypatch.setattr("sys.argv", ["yt-kpi-dashboard"])
-
-        assert cli.main() == 0
+        assert cli.main([]) == 0
         assert json.loads(capsys.readouterr().out)["snapshot_count"] == 2

--- a/tests/commands/analytics/test_traffic_trend.py
+++ b/tests/commands/analytics/test_traffic_trend.py
@@ -131,9 +131,7 @@ class TestTrafficTrendCli:
                 search_terms=[{"detail": "lofi music", "views": 30, "watch_time_minutes": 90}],
             ),
         )
-        monkeypatch.setattr("sys.argv", ["yt-traffic-trend"])
-
-        assert traffic_trend.main() == 0
+        assert traffic_trend.main([]) == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["summary"]["top_source"] == "YT_SEARCH"
         assert payload["latest"]["search_terms"][0]["detail"] == "lofi music"
@@ -141,9 +139,7 @@ class TestTrafficTrendCli:
     def test_main_without_data_returns_2(self, channel_with_data, monkeypatch, capsys):
         from youtube_automation.commands.analytics import traffic_trend
 
-        monkeypatch.setattr("sys.argv", ["yt-traffic-trend"])
-
-        assert traffic_trend.main() == 2
+        assert traffic_trend.main([]) == 2
 
     def test_main_without_traffic_sources_returns_2(self, channel_with_data, monkeypatch):
         from youtube_automation.commands.analytics import traffic_trend
@@ -153,9 +149,7 @@ class TestTrafficTrendCli:
             "analytics_data_20260701_120000.json",
             {"collection_period": {"end_date": "2026-07-01"}, "collection_depth": "basic"},
         )
-        monkeypatch.setattr("sys.argv", ["yt-traffic-trend"])
-
-        assert traffic_trend.main() == 2
+        assert traffic_trend.main([]) == 2
 
     def test_main_text_output(self, channel_with_data, monkeypatch, capsys):
         from youtube_automation.commands.analytics import traffic_trend
@@ -165,9 +159,7 @@ class TestTrafficTrendCli:
             "analytics_data_20260701_120000.json",
             _snapshot("2026-07-01", sources={"BROWSE": {"views": 40, "view_share_percent": 100.0}}),
         )
-        monkeypatch.setattr("sys.argv", ["yt-traffic-trend", "--text"])
-
-        assert traffic_trend.main() == 0
+        assert traffic_trend.main(["--text"]) == 0
         out = capsys.readouterr().out
         assert "流入源・デバイス分析" in out
         assert "BROWSE" in out

--- a/tests/infrastructure/analytics/test_launch_curve_data.py
+++ b/tests/infrastructure/analytics/test_launch_curve_data.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -123,10 +122,9 @@ def test_launch_curve_latest_png_handles_mixed_missing_impressions_and_ctr(tmp_p
         )
 
     monkeypatch.setattr(launch_curve, "_channel_dir", lambda: tmp_path)
-    monkeypatch.setattr(sys, "argv", ["yt-launch-curve", "--latest", "--png"])
     monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "matplotlib"))
 
-    assert launch_curve.main() == 0
+    assert launch_curve.main(["--latest", "--png"]) == 0
     payload = json.loads(capsys.readouterr().out)
 
     assert payload["target"]["video_id"] == "v2"

--- a/tests/infrastructure/analytics/test_theme_performance.py
+++ b/tests/infrastructure/analytics/test_theme_performance.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -137,12 +136,10 @@ def _install_cli_inputs(monkeypatch, *, frame=None, themes=None, daily=_DAILY_PR
 @pytest.mark.parametrize("text_mode", [False, True])
 def test_theme_compare_main_emits_json_and_text(monkeypatch, capsys, text_mode):
     _install_cli_inputs(monkeypatch)
-    argv = ["yt-theme-compare", "--peak-days", "3,6"]
+    argv = ["--peak-days", "3,6"]
     if text_mode:
         argv.append("--text")
-    monkeypatch.setattr(sys, "argv", argv)
-
-    assert theme_compare.main() == 0
+    assert theme_compare.main(argv) == 0
 
     output = capsys.readouterr().out
     if text_mode:
@@ -164,20 +161,17 @@ def test_theme_compare_main_emits_json_and_text(monkeypatch, capsys, text_mode):
 )
 def test_theme_compare_main_returns_config_error(monkeypatch, caplog, overrides, message):
     _install_cli_inputs(monkeypatch, **overrides)
-    monkeypatch.setattr(sys, "argv", ["yt-theme-compare"])
-
     with caplog.at_level(logging.ERROR):
-        assert theme_compare.main() == 2
+        assert theme_compare.main([]) == 2
 
     assert message in caplog.text
 
 
 def test_theme_compare_main_returns_one_for_unexpected_error(monkeypatch, caplog):
-    monkeypatch.setattr(sys, "argv", ["yt-theme-compare"])
     monkeypatch.setattr(theme_compare, "_channel_dir", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
 
     with caplog.at_level(logging.ERROR):
-        assert theme_compare.main() == 1
+        assert theme_compare.main([]) == 1
 
     assert "boom" in caplog.text
 

--- a/tests/repo/test_cli_harness_gate.py
+++ b/tests/repo/test_cli_harness_gate.py
@@ -9,26 +9,19 @@ from tests.helpers.paths import REPO_ROOT
 
 COMMANDS_ROOT = REPO_ROOT / "src/youtube_automation/commands"
 HARNESS_MODULE = "youtube_automation.commands._shared.cli_harness"
-LEGACY_CLI_LIMIT = 78
+LEGACY_CLI_LIMIT = 71
 
 # #3925 導入時点の未移行 CLI。既存互換のため凍結し、移行した module は削除する。
 LEGACY_CLI_ALLOWLIST: frozenset[str] = frozenset(
     {
-        "youtube_automation.commands.analytics.ad_coverage",
         "youtube_automation.commands.analytics.analytics_system",
         "youtube_automation.commands.analytics.benchmark_collector",
-        "youtube_automation.commands.analytics.channel_trend",
         "youtube_automation.commands.analytics.cost_report",
         "youtube_automation.commands.analytics.dashboard",
         "youtube_automation.commands.analytics.discover_competitors",
         "youtube_automation.commands.analytics.experiment",
         "youtube_automation.commands.analytics.fetch_benchmark_comments",
-        "youtube_automation.commands.analytics.kpi_dashboard",
-        "youtube_automation.commands.analytics.launch_curve",
         "youtube_automation.commands.analytics.retention_timeline",
-        "youtube_automation.commands.analytics.theme_compare",
-        "youtube_automation.commands.analytics.traffic_trend",
-        "youtube_automation.commands.analytics.ttp_health",
         "youtube_automation.commands.analytics.video_analyze",
         "youtube_automation.commands.analytics.video_validator",
         "youtube_automation.commands.analytics.vpd_rank",

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1711,7 +1711,6 @@ def test_theme_compare_missing_themes_error_uses_current_config_path(monkeypatch
     config = SimpleNamespace(content=SimpleNamespace(tags=SimpleNamespace(themes={})))
 
     caplog.set_level(logging.ERROR, logger="youtube_automation.commands.analytics.theme_compare")
-    monkeypatch.setattr(sys, "argv", ["yt-theme-compare"])
     monkeypatch.setattr(theme_compare, "_channel_dir", lambda: ROOT)
     monkeypatch.setattr(theme_compare, "load_config", lambda: config)
     monkeypatch.setattr(theme_compare, "load_latest_daily_snapshot", lambda _path: {"daily": []})
@@ -1722,7 +1721,7 @@ def test_theme_compare_missing_themes_error_uses_current_config_path(monkeypatch
         lambda **_kwargs: pd.DataFrame([{"video_id": "video", "days_since_publish": 0}]),
     )
 
-    assert theme_compare.main() == 2
+    assert theme_compare.main([]) == 2
     assert "config/channel/content.json::tags.themes" in caplog.text
 
 


### PR DESCRIPTION
## 概要

Analytics の読み取り系7 CLIを共通 `run_cli` harnessへ等価移行し、新規CLIのharness採用ratchetを前進させます。

## 変更内容

- traffic / channel trend / launch curve / theme compare / ad coverage / TTP health / KPI dashboard を `build_parser` / `run` / `main(argv) -> int` に分離
- stdoutのJSON/text極性、exit code、config解決順を維持
- 対象テストの `sys.argv` monkeypatchを除去
- harness gate allowlistと上限を78件から71件へ縮小
- CHANGELOGを更新

## 検証

- focused: 114 passed
- 広域 / help / entrypoint: 990 passed
- full: 9,110 passed / 3 skipped
- ruff check / format check: green

Closes #3926
