### PR TITLE
refactor(doctor): OAuth認証処理をauth境界へ集約する (#3920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(doctor)`: OAuth token の読み込み・refresh・0o600 atomic 永続化、upload 必須 scope、YouTube service 生成を `infrastructure.auth` に集約し、doctor は診断結果への変換だけを担う（#3920）。
 - `refactor(doctor)`: TTP と初期セットアップの readiness 判定を provider-neutral な `domains.channel_readiness` へ移し、doctor を診断結果へ変換する薄い adapter にする（#3919）。
 - `docs(collections)`: `workflow-state.json` の schema 正本を owner module の型定義へ移し、追従文書との field 差分を名前付きで検出する契約を追加する（#3875）。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.collections.weekly_vote_log` | 週次投票ログ reader、initializer、schema、保存・検証 |
 | `infrastructure.media.image_provider` | 画像生成プロバイダー抽象化（Gemini / OpenAI 切り替え） |
 | `infrastructure.media.stock` | ボツ画像ストック化（`assets/stock/<theme>/` への退避・列挙・整理、隣接 `.meta.json` 管理） |
-| `infrastructure.auth.youtube` | OAuth 2.0 トークン管理 |
+| `infrastructure.auth` | OAuth 2.0 token の読み込み・refresh・atomic 永続化、scope と YouTube service 生成 |
 | `infrastructure.secrets` | シークレット解決（`_SECRET_REFS` で参照定義） |
 | `application.live_chat.{codex,filters,history,models,runner}` | active broadcast のチャット取得、Codex 構造化判定、入出力フィルタ、PT 日次・時間・連続 user 上限、重複防止履歴、返信投稿 loop |
 | `commands.youtube.live_chat_reply` | `yt-live-chat-reply` 常駐 CLI。`comments.live_chat.enabled` を opt-in とし、VPS では独立した `live-chat-reply.service` から起動 |

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -26,9 +26,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Optional
 
-from google.auth.exceptions import RefreshError, TransportError
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
+from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from httplib2 import HttpLib2Error
@@ -49,7 +47,17 @@ from youtube_automation.domains.channel_readiness import (
     evaluate_initial_setup_readiness,
     evaluate_ttp_wf_new_readiness,
 )
-from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler, resolve_client_secrets_location
+from youtube_automation.infrastructure.auth import (
+    UPLOAD_REQUIRED_SCOPES,
+    OAuthCredentialState,
+    build_youtube_service,
+    load_credentials,
+    load_refreshable_credentials,
+)
+from youtube_automation.infrastructure.auth.youtube import (
+    YouTubeOAuthHandler,
+    resolve_client_secrets_location,
+)
 from youtube_automation.infrastructure.collections.numbered_duplicates import (
     CLEANUP_GUIDE_URL,
     format_duplicate_name,
@@ -88,11 +96,6 @@ REQUIRED_APIS = [
     "youtubereporting.googleapis.com",
     "aiplatform.googleapis.com",
     "generativelanguage.googleapis.com",
-]
-
-UPLOAD_REQUIRED_SCOPES = [
-    "https://www.googleapis.com/auth/youtube",
-    "https://www.googleapis.com/auth/youtube.force-ssl",
 ]
 
 MAX_DISPLAY_VALUE_LEN = 120
@@ -1034,77 +1037,7 @@ def check_oauth_client_sharing(channel_dir: Path) -> CheckResult:
     )
 
 
-@dataclass(frozen=True)
-class _OAuthCredentialState:
-    credentials: Credentials | None = None
-    refreshed: bool = False
-    error: str | None = None
-    reauthentication_required: bool = False
-
-
-def _persist_refreshed_credentials(token_path: Path, credentials: Credentials) -> None:
-    """refresh 済み credentials を token.json へ 0o600 で atomic に保存する。"""
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=token_path.parent,
-            prefix=f".{token_path.name}.",
-            delete=False,
-        ) as temporary:
-            temporary.write(credentials.to_json())
-            temporary.flush()
-            os.fsync(temporary.fileno())
-            temporary_path = Path(temporary.name)
-        temporary_path.chmod(0o600)
-        os.replace(temporary_path, token_path)
-    finally:
-        if temporary_path is not None and temporary_path.exists():
-            temporary_path.unlink()
-
-
-def _load_refreshable_oauth_credentials(token_path: Path) -> _OAuthCredentialState:
-    """token を読み、期限切れなら refresh token で更新して永続化する。"""
-    try:
-        credentials = Credentials.from_authorized_user_file(str(token_path))
-    except (OSError, ValueError) as error:
-        return _OAuthCredentialState(
-            error=f"OAuth トークンが不正です: {error}",
-            reauthentication_required=True,
-        )
-
-    refreshed = False
-    if credentials.expired:
-        if not credentials.refresh_token:
-            return _OAuthCredentialState(
-                error="OAuth トークンが期限切れで、更新用トークンがありません",
-                reauthentication_required=True,
-            )
-        try:
-            credentials.refresh(Request())
-        except RefreshError:
-            return _OAuthCredentialState(
-                error="OAuth トークンの更新に失敗しました。更新用トークンが失効しています",
-                reauthentication_required=True,
-            )
-        except TransportError as error:
-            return _OAuthCredentialState(error=f"OAuth トークン更新時の通信に失敗しました: {error}")
-        try:
-            _persist_refreshed_credentials(token_path, credentials)
-        except OSError as error:
-            return _OAuthCredentialState(error=f"更新した OAuth トークンの保存に失敗しました: {error}")
-        refreshed = True
-
-    if not credentials.valid:
-        return _OAuthCredentialState(
-            error="OAuth トークンが利用できません",
-            reauthentication_required=True,
-        )
-    return _OAuthCredentialState(credentials=credentials, refreshed=refreshed)
-
-
-def _oauth_failure_action(state: _OAuthCredentialState) -> dict | None:
+def _oauth_failure_action(state: OAuthCredentialState) -> dict | None:
     if not state.reauthentication_required:
         return None
     return _youtube_oauth_action("更新用トークンが利用できないため、ブラウザで OAuth 同意を完了してください。")
@@ -1127,7 +1060,7 @@ def check_oauth_token(channel_dir: Path) -> CheckResult:
             status="fail",
             message=f"token.json 読み込み失敗: {e}",
         )
-    state = _load_refreshable_oauth_credentials(path)
+    state = load_refreshable_credentials(path)
     if state.credentials is None:
         return CheckResult(
             id="oauth_token",
@@ -1171,7 +1104,7 @@ def check_reporting_job(channel_dir: Path) -> CheckResult:
             message="OAuth トークン未取得または不正のためスキップ",
         )
 
-    state = _load_refreshable_oauth_credentials(token_path)
+    state = load_refreshable_credentials(token_path)
     if state.credentials is None:
         return CheckResult(
             id="reporting_job",
@@ -1861,7 +1794,7 @@ def check_upload_ready(channel_dir: Path) -> CheckResult:
         )
 
     try:
-        credentials = Credentials.from_authorized_user_file(str(token_path))
+        credentials = load_credentials(token_path)
     except (OSError, ValueError) as error:
         return CheckResult(
             id="upload_ready",
@@ -1872,7 +1805,7 @@ def check_upload_ready(channel_dir: Path) -> CheckResult:
         )
 
     try:
-        service = build("youtube", "v3", credentials=credentials)
+        service = build_youtube_service(credentials)
         response = service.channels().list(part="id,snippet", mine=True).execute()
     except RefreshError:
         return CheckResult(

--- a/src/youtube_automation/infrastructure/auth/__init__.py
+++ b/src/youtube_automation/infrastructure/auth/__init__.py
@@ -1,1 +1,16 @@
-"""OAuth boundary modules."""
+"""Canonical OAuth credential and YouTube service boundary."""
+
+from youtube_automation.infrastructure.auth.tokens import (
+    OAuthCredentialState,
+    load_credentials,
+    load_refreshable_credentials,
+)
+from youtube_automation.infrastructure.auth.youtube import UPLOAD_REQUIRED_SCOPES, build_youtube_service
+
+__all__ = [
+    "UPLOAD_REQUIRED_SCOPES",
+    "OAuthCredentialState",
+    "build_youtube_service",
+    "load_credentials",
+    "load_refreshable_credentials",
+]

--- a/src/youtube_automation/infrastructure/auth/tokens.py
+++ b/src/youtube_automation/infrastructure/auth/tokens.py
@@ -1,7 +1,12 @@
-"""OAuth token path conventions."""
+"""OAuth credential loading, refresh, and persistence boundary."""
 
+import os
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
+from google.auth.exceptions import RefreshError, TransportError
+from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 
 
@@ -10,16 +15,87 @@ def token_path(auth_dir: Path, filename: str = "token.json") -> Path:
     return auth_dir / filename
 
 
-def load_credentials(path: Path, scopes: list[str]) -> Credentials:
+@dataclass(frozen=True)
+class OAuthCredentialState:
+    credentials: Credentials | None = None
+    refreshed: bool = False
+    error: str | None = None
+    reauthentication_required: bool = False
+
+
+def load_credentials(path: Path, scopes: list[str] | None = None) -> Credentials:
     """Load authorized-user credentials from the selected token path."""
+    if scopes is None:
+        return Credentials.from_authorized_user_file(str(path))
     return Credentials.from_authorized_user_file(str(path), scopes)
 
 
 def save_credentials(path: Path, credentials: Credentials) -> None:
-    """Persist credentials with the token file's restrictive permission contract."""
-    import os
+    """Atomically persist credentials with mode ``0o600``."""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temporary:
+            temporary.write(credentials.to_json())
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.chmod(0o600)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
 
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as token:
-        token.write(credentials.to_json())
-    os.chmod(path, 0o600)
+
+def load_refreshable_credentials(path: Path) -> OAuthCredentialState:
+    """Load credentials and refresh an expired access token when possible."""
+    try:
+        credentials = load_credentials(path)
+    except (OSError, ValueError) as error:
+        return OAuthCredentialState(
+            error=f"OAuth トークンが不正です: {error}",
+            reauthentication_required=True,
+        )
+
+    refreshed = False
+    if credentials.expired:
+        if not credentials.refresh_token:
+            return OAuthCredentialState(
+                error="OAuth トークンが期限切れで、更新用トークンがありません",
+                reauthentication_required=True,
+            )
+        try:
+            credentials.refresh(Request())
+        except RefreshError:
+            return OAuthCredentialState(
+                error="OAuth トークンの更新に失敗しました。更新用トークンが失効しています",
+                reauthentication_required=True,
+            )
+        except TransportError as error:
+            return OAuthCredentialState(error=f"OAuth トークン更新時の通信に失敗しました: {error}")
+        try:
+            save_credentials(path, credentials)
+        except OSError as error:
+            return OAuthCredentialState(error=f"更新した OAuth トークンの保存に失敗しました: {error}")
+        refreshed = True
+
+    if not credentials.valid:
+        return OAuthCredentialState(
+            error="OAuth トークンが利用できません",
+            reauthentication_required=True,
+        )
+    return OAuthCredentialState(credentials=credentials, refreshed=refreshed)
+
+
+__all__ = [
+    "OAuthCredentialState",
+    "load_credentials",
+    "load_refreshable_credentials",
+    "save_credentials",
+    "token_path",
+]

--- a/src/youtube_automation/infrastructure/auth/youtube.py
+++ b/src/youtube_automation/infrastructure/auth/youtube.py
@@ -35,6 +35,16 @@ from youtube_automation.infrastructure.vcs.worktree import main_worktree_root
 
 logger = logging.getLogger(__name__)
 
+UPLOAD_REQUIRED_SCOPES = (
+    "https://www.googleapis.com/auth/youtube",
+    "https://www.googleapis.com/auth/youtube.force-ssl",
+)
+
+
+def build_youtube_service(credentials: Credentials):
+    """Build the canonical YouTube Data API v3 service."""
+    return build("youtube", "v3", credentials=credentials)
+
 
 def client_secrets_file_candidates(channel_dir: Path) -> list[Path]:
     """ファイルとして配置された client_secrets.json の候補を検索順で返す。"""
@@ -109,8 +119,7 @@ class YouTubeOAuthHandler:
     # yt-analytics-monetary.readonly は Reporting API v1 (#84) で
     # videoThumbnailImpressions / videoThumbnailImpressionsClickThroughRate を取得するため必須。
     SCOPES: ClassVar[list[str]] = [
-        "https://www.googleapis.com/auth/youtube",
-        "https://www.googleapis.com/auth/youtube.force-ssl",
+        *UPLOAD_REQUIRED_SCOPES,
         "https://www.googleapis.com/auth/yt-analytics.readonly",
         "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
     ]
@@ -360,10 +369,10 @@ class YouTubeOAuthHandler:
         return credentials
 
     def _save_credentials(self):
-        """認証情報をファイルに 0o600 で保存する。
+        """認証情報をファイルに atomic かつ 0o600 で保存する。
 
-        プロセス umask に依存せず必ず 0o600 で作成し、既存ファイル上書き時も
-        chmod で保険をかける（``O_TRUNC`` は既存ファイルの mode を変更しない）。
+        同じディレクトリの一時ファイルを fsync してから置換するため、既存 token を
+        部分書き込みで壊さず、プロセス umask に依存せず必ず 0o600 で保存する。
         書き込み失敗時は ``ConfigError`` として raise する（握りつぶし禁止 ―
         失敗を黙って成功扱いすると毎回ブラウザ認証が走る運用障害になる）。
 
@@ -390,7 +399,7 @@ class YouTubeOAuthHandler:
             self.authenticate()
 
         try:
-            service = build("youtube", "v3", credentials=self.credentials)
+            service = build_youtube_service(self.credentials)
             print("✅ YouTube Data API サービス接続成功")
             return service
         except HttpError as e:

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -22,6 +22,7 @@ from PIL import Image as PILImage
 import youtube_automation.infrastructure.secrets as secrets_module
 from youtube_automation.commands.system import doctor
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.infrastructure.auth import tokens as auth_tokens
 
 
 def _mock_running_distribution(
@@ -791,7 +792,7 @@ class TestOAuthToken:
         credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=True)
         credentials.to_json.return_value = '{"token": "refreshed", "scopes": ["a"]}'
         monkeypatch.setattr(
-            doctor.Credentials,
+            auth_tokens.Credentials,
             "from_authorized_user_file",
             lambda *_args, **_kwargs: credentials,
         )
@@ -811,7 +812,7 @@ class TestOAuthToken:
         credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
         credentials.refresh.side_effect = RefreshError("invalid_grant")
         monkeypatch.setattr(
-            doctor.Credentials,
+            auth_tokens.Credentials,
             "from_authorized_user_file",
             lambda *_args, **_kwargs: credentials,
         )
@@ -830,7 +831,7 @@ class TestOAuthToken:
         credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
         credentials.refresh.side_effect = TransportError("network unavailable")
         monkeypatch.setattr(
-            doctor.Credentials,
+            auth_tokens.Credentials,
             "from_authorized_user_file",
             lambda *_args, **_kwargs: credentials,
         )
@@ -1080,7 +1081,7 @@ class TestReportingJob:
             credentials.token = "refreshed-access-token"
             credentials.expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1)
 
-        monkeypatch.setattr(doctor.Credentials, "refresh", refresh)
+        monkeypatch.setattr(auth_tokens.Credentials, "refresh", refresh)
         monkeypatch.setattr(
             doctor,
             "build",
@@ -3179,11 +3180,11 @@ def _mock_upload_channel_api(monkeypatch, *, items=None, error: BaseException | 
     else:
         execute.return_value = {"items": items if items is not None else [{"id": _CHANNEL_ID}]}
     monkeypatch.setattr(
-        doctor.Credentials,
+        auth_tokens.Credentials,
         "from_authorized_user_file",
         lambda _path: MagicMock(),
     )
-    monkeypatch.setattr(doctor, "build", lambda *_args, **_kwargs: service)
+    monkeypatch.setattr(doctor, "build_youtube_service", lambda _credentials: service)
     return service
 
 

--- a/tests/infrastructure/auth/test_token_credentials.py
+++ b/tests/infrastructure/auth/test_token_credentials.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from google.auth.exceptions import RefreshError, TransportError
+
+from youtube_automation.infrastructure.auth import tokens
+from youtube_automation.infrastructure.auth import youtube as youtube_auth
+
+
+def test_expired_credentials_are_refreshed_and_atomically_persisted(monkeypatch, tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    token_path.write_text('{"token": "stale"}', encoding="utf-8")
+    credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=True)
+    credentials.to_json.return_value = '{"token": "refreshed"}'
+    monkeypatch.setattr(tokens, "load_credentials", lambda _path: credentials)
+
+    state = tokens.load_refreshable_credentials(token_path)
+
+    assert state.credentials is credentials
+    assert state.refreshed is True
+    assert state.error is None
+    credentials.refresh.assert_called_once()
+    assert token_path.read_text(encoding="utf-8") == '{"token": "refreshed"}'
+    assert token_path.stat().st_mode & 0o777 == 0o600
+    assert list(tmp_path.glob(f".{token_path.name}.*")) == []
+
+
+def test_refresh_error_requires_reauthentication(monkeypatch, tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
+    credentials.refresh.side_effect = RefreshError("invalid_grant")
+    monkeypatch.setattr(tokens, "load_credentials", lambda _path: credentials)
+
+    state = tokens.load_refreshable_credentials(token_path)
+
+    assert state.credentials is None
+    assert state.error == "OAuth トークンの更新に失敗しました。更新用トークンが失効しています"
+    assert state.reauthentication_required is True
+
+
+def test_transport_error_does_not_require_reauthentication(monkeypatch, tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    credentials = MagicMock(expired=True, refresh_token="refresh-token", valid=False)
+    credentials.refresh.side_effect = TransportError("offline")
+    monkeypatch.setattr(tokens, "load_credentials", lambda _path: credentials)
+
+    state = tokens.load_refreshable_credentials(token_path)
+
+    assert state.credentials is None
+    assert state.error == "OAuth トークン更新時の通信に失敗しました: offline"
+    assert state.reauthentication_required is False
+
+
+def test_atomic_save_failure_preserves_existing_token(monkeypatch, tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    token_path.write_text('{"token": "original"}', encoding="utf-8")
+    credentials = MagicMock()
+    credentials.to_json.return_value = '{"token": "replacement"}'
+    monkeypatch.setattr(tokens.os, "replace", MagicMock(side_effect=OSError("replace failed")))
+
+    try:
+        tokens.save_credentials(token_path, credentials)
+    except OSError as error:
+        assert str(error) == "replace failed"
+    else:
+        raise AssertionError("save_credentials must propagate atomic replacement failures")
+
+    assert token_path.read_text(encoding="utf-8") == '{"token": "original"}'
+    assert list(tmp_path.glob(f".{token_path.name}.*")) == []
+
+
+def test_upload_required_scopes_are_owned_by_auth_boundary() -> None:
+    assert youtube_auth.UPLOAD_REQUIRED_SCOPES == (
+        "https://www.googleapis.com/auth/youtube",
+        "https://www.googleapis.com/auth/youtube.force-ssl",
+    )
+
+
+def test_build_youtube_service_uses_authenticated_credentials(monkeypatch) -> None:
+    credentials = MagicMock()
+    service = MagicMock()
+    build = MagicMock(return_value=service)
+    monkeypatch.setattr(youtube_auth, "build", build)
+
+    assert youtube_auth.build_youtube_service(credentials) is service
+    build.assert_called_once_with("youtube", "v3", credentials=credentials)


### PR DESCRIPTION
## 概要

doctorが再実装していたOAuth token処理を `infrastructure/auth` の公開境界へ移し、認証ロジックを一本化します。

## 変更内容

- token load / refreshと失敗分類をauth境界へ移管
- refresh後tokenの0o600 atomic永続化を共通化
- upload required scopesとYouTube service factoryをauth ownerへ集約
- `check_oauth_token` / `check_upload_ready` の観測契約を維持
- architecture / CHANGELOG / auth・doctorテストを更新

## 検証

- focused: 373 passed
- 広域: 753 passed
- full: 9,119 passed / 3 skipped
- ruff check / format check: green

Closes #3920
