### PR TITLE
refactor(configuration): channel選択を公開API化する (#3921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(configuration)`: CLI の明示 channel 選択を公開 API として提供し、doctor から loader の private symbol への越境 import を解消する（#3921）。
 - `refactor(doctor)`: OAuth token の読み込み・refresh・0o600 atomic 永続化、upload 必須 scope、YouTube service 生成を `infrastructure.auth` に集約し、doctor は診断結果への変換だけを担う（#3920）。
 - `refactor(doctor)`: TTP と初期セットアップの readiness 判定を provider-neutral な `domains.channel_readiness` へ移し、doctor を診断結果へ変換する薄い adapter にする（#3919）。
 - `docs(collections)`: `workflow-state.json` の schema 正本を owner module の型定義へ移し、追従文書との field 差分を名前付きで検出する契約を追加する（#3875）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -35,10 +35,10 @@ from youtube_automation.commands.system.automation_update_refs import UPSTREAM_R
 from youtube_automation.commands.system.skills_sync import bundled_skill_names
 from youtube_automation.configuration import (
     channel_dir,
+    explicit_channel_selection,
     find_workspace_root,
     workspace_channels,
 )
-from youtube_automation.configuration.loader import _explicit_channel_selection
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import AutomationError, ConfigError, YouTubeAPIError
 from youtube_automation.domains.channel_readiness import (
@@ -2289,7 +2289,7 @@ def resolve_channel_dir(target: Optional[str]) -> Path:
         return channel_dir().resolve()
     except ConfigError:
         selection_requested = (
-            _explicit_channel_selection() is not None
+            explicit_channel_selection() is not None
             or bool(os.environ.get("CHANNEL"))
             or bool(os.environ.get("CHANNEL_DIR"))
             or find_workspace_root(cwd) is not None

--- a/src/youtube_automation/configuration/__init__.py
+++ b/src/youtube_automation/configuration/__init__.py
@@ -3,6 +3,7 @@
 公開 API:
     load_config() -> ChannelConfig   # シングルトン取得（初回に glob ロード + .env ロード）
     channel_dir() -> Path            # config/channel/ を含むプロジェクトルート解決
+    explicit_channel_selection()     # CLI の明示 channel slug を参照
     find_workspace_root()            # cwd 祖先から workspace root を検出
     workspace_channels()             # workspace の slug と channel dir を列挙
     select_channel()                 # CLI の明示 channel slug を初回解決へ渡す
@@ -18,6 +19,7 @@ from youtube_automation.configuration.community_draft import CommunityDraft
 from youtube_automation.configuration.distrokid import Distrokid
 from youtube_automation.configuration.loader import (
     channel_dir,
+    explicit_channel_selection,
     find_workspace_root,
     load_config,
     reset,
@@ -35,6 +37,7 @@ __all__ = [
     "PinnedComment",
     "Shorts",
     "channel_dir",
+    "explicit_channel_selection",
     "find_workspace_root",
     "load_config",
     "reset",

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -135,7 +135,7 @@ def select_channel(slug: str | None) -> None:
     _explicit_channel = slug
 
 
-def _explicit_channel_selection() -> str | None:
+def explicit_channel_selection() -> str | None:
     """共通 CLI wrapper が受け取った明示 channel slug を返す."""
     return _explicit_channel
 

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -1757,6 +1757,14 @@ def test_explicit_channel_selects_workspace_slug(tmp_path, monkeypatch):
     assert channel_dir() == (workspace / "channels" / "beta").resolve()
 
 
+def test_explicit_channel_selection_is_available_through_public_configuration_api() -> None:
+    import youtube_automation.configuration as configuration
+
+    configuration.select_channel("alpha")
+
+    assert configuration.explicit_channel_selection() == "alpha"
+
+
 def test_config_reset_can_preserve_explicit_channel_selection(tmp_path, monkeypatch):
     workspace = _setup_workspace(tmp_path, "alpha", "beta")
     monkeypatch.chdir(workspace)

--- a/tests/configuration/test_configuration_migration_contract.py
+++ b/tests/configuration/test_configuration_migration_contract.py
@@ -102,6 +102,7 @@ def test_configuration_public_api_preserves_the_specified_exports():
         "PinnedComment",
         "Shorts",
         "channel_dir",
+        "explicit_channel_selection",
         "find_workspace_root",
         "load_config",
         "reset",

--- a/tests/contracts/architecture/test_repository_reorganization_contract.py
+++ b/tests/contracts/architecture/test_repository_reorganization_contract.py
@@ -186,6 +186,7 @@ PUBLIC_CONFIGURATION_SYMBOLS = {
     "PinnedComment",
     "Shorts",
     "channel_dir",
+    "explicit_channel_selection",
     "find_workspace_root",
     "load_config",
     "reset",


### PR DESCRIPTION
## 概要

doctorがimportしていたconfiguration loaderのprivate channel選択関数を公開API化し、module境界を明示します。

## 変更内容

- `explicit_channel_selection()` をconfiguration公開APIへ追加
- doctorのprivate `_explicit_channel_selection` 越境importを除去
- CHANNEL / CHANNEL_DIR / `--target` の解決結果を不変維持
- architecture・公開面契約・CHANGELOGを追従
- スコープ外のprivate越境36箇所は未変更

## 検証

- 関連 / architecture: 871 passed
- full: 9,121 passed / 3 skipped
- ruff check / format check: green

Closes #3921
