### PR TITLE
refactor(uploads): tracking処理をstoreへ委譲する (#3929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(cli)`: argparse 互換の共通 CLI harness を追加し、uploads 3 コマンドの引数解析・期待済みエラー・中断処理を共通境界へ集約する。各 `main(argv)` は exit code を返し、AutomationError は機密情報を除去して stderr へ出力する（#3924）。
 - `refactor(cli)`: analytics 読み取り系 7 CLI を共通 CLI harness と `main(argv)` 境界へ移行し、既存の JSON / text 出力・exit code・設定解決順を維持する（#3926）。
 - `refactor(uploads)`: `DescriptionsMdMixin` を公開純関数 module へ置換し、uploader の公開interfaceを維持したまま多重継承とテストのprivate host依存を縮小する（#3928）。
+- `refactor(uploads)`: `TrackingIOMixin` を設定・collection rootを明示注入するtracking storeへ置換し、tracking / workflow-stateの書式を維持したままexecutorを委譲へ移行する（#3929）。
 
 - `refactor(doctor)`: 30 件の診断を実行順・category・apply 種別・cwd 意味論を持つ宣言 registry へ集約し、診断・表示・JSON・自動修復の重複判定を単一化する（#3918）。
 - `feat(skills)`: `/reply --live` に旧 `/live-chat-reply` の streaming 前提ガード、認証、常駐 daemon の配備・停止・障害復旧契約を統合し、旧 skill と利用者導線を削除する（#3849）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -1,9 +1,8 @@
 """Complete Collection アップロード実行ループ。
 
 責務分割（Issue #465）の一環で ``collection_uploader.py`` から分離した。
-``self.uploader`` / ``self._load_tracking`` / ``self._save_tracking`` /
-``self._completed_tracking_record`` / ``self.config`` /
-``self._move_collection_to_live`` / ``self._update_workflow_upload`` /
+``self.uploader`` / ``self.tracking_store`` / ``self.config`` /
+``self._move_collection_to_live`` /
 ``self._assign_to_playlists`` は合成先クラス（``CollectionUploader`` 本体および
 他 mixin）が提供する。
 """
@@ -34,11 +33,11 @@ class CompleteCollectionExecutorMixin:
     """Complete Collection アップロード実行ループを提供する mixin。"""
 
     def _failed_complete_collection(self, collection_path: Path, tracking: dict, error: AutomationError) -> dict:
-        current = self._load_tracking(collection_path) or tracking
+        current = self.tracking_store.load(collection_path) or tracking
         cc_current = current.setdefault("complete_collection", {})
         cc_current["status"] = "failed"
         cc_current["error"] = _COMPLETE_COLLECTION_ERROR
-        self._save_tracking(collection_path, current)
+        self.tracking_store.save(collection_path, current)
         logger.error("❌ Complete Collection エラー: %s", redact_sensitive_data(str(error), collection_path))
         return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
 
@@ -54,11 +53,11 @@ class CompleteCollectionExecutorMixin:
 
         tracking = {
             **tracking,
-            "complete_collection": self._completed_tracking_record(complete_video, publish_at),
+            "complete_collection": self.tracking_store.completed_record(complete_video, publish_at),
             "status": TRACKING_STATUS_COMPLETED,
         }
         # YouTube 側の成功直後に正規状態を保存し、後処理失敗で video_id を失わない。
-        self._save_tracking(collection_path, tracking)
+        self.tracking_store.save(collection_path, tracking)
 
         post_processing_errors: list[str] = []
         if self.config["collections_management"].get("auto_move_to_live", True):
@@ -72,7 +71,7 @@ class CompleteCollectionExecutorMixin:
                 )
 
         try:
-            self._update_workflow_upload(collection_path, complete_video, publish_at)
+            self.tracking_store.update_workflow_upload(collection_path, complete_video, publish_at)
         except AutomationError as error:
             post_processing_errors.append("workflow_upload")
             logger.error(
@@ -86,7 +85,7 @@ class CompleteCollectionExecutorMixin:
                 "post_processing_status": "partial",
                 "post_processing_errors": post_processing_errors,
             }
-        self._save_tracking(collection_path, tracking)
+        self.tracking_store.save(collection_path, tracking)
 
         if complete_video.get("upload_source") == UPLOAD_SOURCE_EXISTING:
             logger.info("⏭️  Complete Collection は既存動画を流用")
@@ -128,13 +127,13 @@ class CompleteCollectionExecutorMixin:
             並行更新（プレイリスト追加等が tracking を書く可能性）に備え、
             毎回 disk から再ロードしてから書き戻す。
             """
-            current = self._load_tracking(collection_path) or {}
+            current = self.tracking_store.load(collection_path) or {}
             cc_current = current.setdefault("complete_collection", {})
             if uri is None:
                 cc_current.pop("resume_session_uri", None)
             else:
                 cc_current["resume_session_uri"] = uri
-            self._save_tracking(collection_path, current)
+            self.tracking_store.save(collection_path, current)
 
         def _on_upload_complete() -> None:
             """upload 成功通知。後続の status="completed" 書き込みと整合させるため URI を消す。"""
@@ -167,11 +166,11 @@ class CompleteCollectionExecutorMixin:
         error_msg = _COMPLETE_COLLECTION_ERROR
         # callback が disk に書いた URI 状態（session 失効クリア等）を保ったまま
         # status 更新を載せるため、disk から再ロードしてから書き戻す。
-        current = self._load_tracking(collection_path) or tracking
+        current = self.tracking_store.load(collection_path) or tracking
         cc_current = current.setdefault("complete_collection", {})
         cc_current["status"] = "failed"
         cc_current["error"] = error_msg
-        self._save_tracking(collection_path, current)
+        self.tracking_store.save(collection_path, current)
         logger.error(f"❌ Complete Collection 失敗: {error_msg}")
         return {"action": "complete_collection_failed", "details": {"error": error_msg}}
 

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -1,9 +1,4 @@
-"""tracking JSON / workflow-state JSON の I/O を提供する mixin。
-
-責務分割（Issue #465）の一環で ``collection_uploader.py`` から分離した。
-挙動は分割前と同一で、``self.config`` / ``self.collections_root`` 等は
-合成先クラス（``CollectionUploader`` 本体）が提供する。
-"""
+"""tracking JSON / workflow-state JSON の永続化コラボレータ。"""
 
 from __future__ import annotations
 
@@ -30,15 +25,19 @@ from youtube_automation.infrastructure.filesystem import (
 logger = logging.getLogger(__name__)
 
 
-class TrackingIOMixin:
-    """tracking JSON / workflow-state JSON の I/O を提供する mixin。"""
+class TrackingStore:
+    """collection tracking と upload workflow state を永続化する。"""
 
-    def _get_tracking_path(self, collection_path: Path) -> Path:
+    def __init__(self, collections_root: Path, config: dict) -> None:
+        self.collections_root = collections_root
+        self.config = config
+
+    def tracking_path(self, collection_path: Path) -> Path:
         return CollectionPaths(collection_path).tracking_path
 
-    def _load_tracking(self, collection_path: Path) -> dict | None:
+    def load(self, collection_path: Path) -> dict | None:
         """tracking ファイル読み込み"""
-        tracking_file = self._get_tracking_path(collection_path)
+        tracking_file = self.tracking_path(collection_path)
         if not path_exists(tracking_file):
             return None
 
@@ -52,9 +51,9 @@ class TrackingIOMixin:
             logger.error(f"❌ tracking 破損を検出、{corrupt_path} へ退避しました（原因: {e}）")
             return None
 
-    def _save_tracking(self, collection_path: Path, tracking: dict):
+    def save(self, collection_path: Path, tracking: dict) -> None:
         """tracking 保存"""
-        tracking_file = self._get_tracking_path(collection_path)
+        tracking_file = self.tracking_path(collection_path)
         make_directory(tracking_file.parent, exist_ok=True)
         try:
             text = json.dumps(tracking, indent=2, ensure_ascii=False)
@@ -65,7 +64,7 @@ class TrackingIOMixin:
         except (OSError, TypeError, ValueError) as e:
             logger.error(f"❌ 追跡ファイル保存エラー: {tracking_file}: {e}")
 
-    def _completed_tracking_record(self, complete_video: dict, publish_at: str | None) -> dict:
+    def completed_record(self, complete_video: dict, publish_at: str | None) -> dict:
         record = {
             "video_id": complete_video["video_id"],
             "video_url": complete_video["video_url"],
@@ -77,7 +76,7 @@ class TrackingIOMixin:
             record["upload_source"] = complete_video["upload_source"]
         return record
 
-    def _update_workflow_upload(self, collection_path: Path, complete_video: dict, publish_at: str | None) -> None:
+    def update_workflow_upload(self, collection_path: Path, complete_video: dict, publish_at: str | None) -> None:
         ws_path = CollectionPaths(collection_path).workflow_state_path
         if not path_exists(ws_path):
             return
@@ -106,7 +105,7 @@ class TrackingIOMixin:
             }
         write_file_text(ws_path, json.dumps(updated_state, indent=2, ensure_ascii=False))
 
-    def _initialize_tracking(self, collection_path: Path) -> dict:
+    def initialize(self, collection_path: Path) -> dict:
         """tracking を初期化"""
         tracking = {
             "schema_version": 3,
@@ -115,8 +114,8 @@ class TrackingIOMixin:
             "complete_collection": {"status": "pending"},
         }
 
-        self._save_tracking(collection_path, tracking)
+        self.save(collection_path, tracking)
         return tracking
 
 
-__all__ = ["TrackingIOMixin"]
+__all__ = ["TrackingStore"]

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -19,7 +19,7 @@ from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignmentMixin
 from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
-from youtube_automation.domains.uploads._tracking_io import TrackingIOMixin
+from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 from youtube_automation.infrastructure.filesystem import (
@@ -42,7 +42,6 @@ class CollectionUploader(
     CompleteCollectionExecutorMixin,
     PlaylistAssignmentMixin,
     PublishedDatesMixin,
-    TrackingIOMixin,
 ):
     """Collection Uploader — CC アップロード専用
 
@@ -50,7 +49,7 @@ class CollectionUploader(
     publishAt によるスケジュール公開を管理する。
 
     責務別の挙動は mixin に分離されている（Issue #465）:
-    - tracking I/O           : ``TrackingIOMixin``
+    - tracking I/O           : ``TrackingStore`` への委譲
     - 公開日 / publishAt 計算: ``PublishedDatesMixin``
     - プレイリスト割り当て    : ``PlaylistAssignmentMixin``
     - CC 実行ループ           : ``CompleteCollectionExecutorMixin``
@@ -61,6 +60,7 @@ class CollectionUploader(
         collections_root: str | None = None,
         config_path: str | None = None,
         youtube_clients: YouTubeClients | None = None,
+        tracking_store: TrackingStore | None = None,
     ):
         if collections_root is None:
             collections_root = channel_dir() / "collections"
@@ -72,6 +72,7 @@ class CollectionUploader(
         self.config_path = Path(config_path)
         self.uploader = YouTubeAutoUploader(str(collections_root), youtube_clients)
         self.config = self._load_config()
+        self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
         self.youtube_service = None
         self.youtube_clients = youtube_clients
 
@@ -179,9 +180,9 @@ class CollectionUploader(
             dict: {"action": str, "details": dict}
         """
         # tracking 読み込み or 初期化
-        tracking = self._load_tracking(collection_path)
+        tracking = self.tracking_store.load(collection_path)
         if tracking is None:
-            tracking = self._initialize_tracking(collection_path)
+            tracking = self.tracking_store.initialize(collection_path)
             logger.info("📋 tracking 初期化完了")
 
         # 既に完了
@@ -204,7 +205,7 @@ class CollectionUploader(
 
         # 全完了
         tracking["status"] = "completed"
-        self._save_tracking(collection_path, tracking)
+        self.tracking_store.save(collection_path, tracking)
         logger.info("✅ 全ステップ完了")
         return {"action": "all_completed", "details": {}}
 
@@ -217,7 +218,7 @@ class CollectionUploader(
 
     def show_status(self, collection_path: Path):
         """進捗表示"""
-        tracking = self._load_tracking(collection_path)
+        tracking = self.tracking_store.load(collection_path)
         if tracking is None:
             print(f"📋 {collection_path.name}")
             print("   tracking 未初期化 — 実行するとアップロードを開始します")

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from youtube_automation.domains.uploads._tracking_io import TrackingStore
 
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -380,6 +381,21 @@ def _make_uploader_with_collection_mock(tmp_path: Path):
         # auto_move_to_live を無効化してパス変動を防ぐ
         uploader.config["collections_management"]["auto_move_to_live"] = False
         return uploader, mock_inner
+
+
+def test_collection_uploader_accepts_injected_tracking_store(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    store = MagicMock(spec=TrackingStore)
+
+    with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader"):
+        uploader = CollectionUploader(
+            collections_root=str(tmp_path / "collections"),
+            config_path=str(tmp_path / "schedule_config.json"),
+            tracking_store=store,
+        )
+
+    assert uploader.tracking_store is store
 
 
 def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
@@ -745,7 +761,7 @@ class TestExecuteCompleteCollectionResume:
         }
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then
@@ -767,7 +783,7 @@ class TestExecuteCompleteCollectionResume:
         }
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then
@@ -790,7 +806,7 @@ class TestExecuteCompleteCollectionResume:
             }
         }
 
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         saved = json.loads(tracking_path.read_text(encoding="utf-8"))
@@ -812,7 +828,7 @@ class TestExecuteCompleteCollectionResume:
             }
         }
 
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at="2099-01-01T10:00:00+09:00")
 
         state = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
@@ -841,7 +857,7 @@ class TestExecuteCompleteCollectionResume:
 
         result = uploader._execute_complete_collection(
             col,
-            uploader._load_tracking(col),
+            uploader.tracking_store.load(col),
             publish_at="2099-01-01T10:00:00+09:00",
         )
 
@@ -869,8 +885,12 @@ class TestExecuteCompleteCollectionResume:
         }
         diagnostic = "workflow-state.json upload must be object"
 
-        with patch.object(uploader, "_update_workflow_upload", side_effect=ValidationError(diagnostic)):
-            result = uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
+        with patch.object(
+            uploader.tracking_store,
+            "update_workflow_upload",
+            side_effect=ValidationError(diagnostic),
+        ):
+            result = uploader._execute_complete_collection(col, uploader.tracking_store.load(col), publish_at=None)
 
         tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
         assert result["action"] == "complete_collection_uploaded"
@@ -904,7 +924,7 @@ class TestExecuteCompleteCollectionResume:
             patch.object(uploader, "_assign_to_playlists", side_effect=failure),
             pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"),
         ):
-            uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
+            uploader._execute_complete_collection(col, uploader.tracking_store.load(col), publish_at=None)
 
         tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
         assert tracking["status"] == "in_progress"
@@ -928,7 +948,7 @@ class TestExecuteCompleteCollectionResume:
             }
         }
 
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         result = uploader._execute_complete_collection(col, tracking, publish_at="2099-01-01T10:00:00+09:00")
 
         live_col = tmp_path / "collections" / "live" / col.name
@@ -968,7 +988,7 @@ class TestExecuteCompleteCollectionResume:
         mock_inner.upload_collection.side_effect = _side_effect
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then
@@ -994,7 +1014,7 @@ class TestExecuteCompleteCollectionResume:
         mock_inner.upload_collection.side_effect = _side_effect
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then: tracking 上の URI が消えている
@@ -1014,14 +1034,14 @@ class TestExecuteCompleteCollectionResume:
         mock_inner.upload_collection.side_effect = _side_effect
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then
         assert _read_resume_uri(tracking_path) is None
 
     def test_should_reload_tracking_before_persisting_uri_to_avoid_clobbering_concurrent_writes(self, tmp_path):
-        """plan §162: コールバック内で `_load_tracking` を再ロードすることで並行書き込みを保持.
+        """plan §162: コールバック内で store を再ロードすることで並行書き込みを保持.
 
         side_effect 内で callback 発火直後の disk 状態をキャプチャし、callback が
         外部からの concurrent 書き込みを保持しているかを直接検証する
@@ -1047,7 +1067,7 @@ class TestExecuteCompleteCollectionResume:
         mock_inner.upload_collection.side_effect = _side_effect
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then: callback 内で reload してから書いていれば、両キーが同時に disk に残る
@@ -1068,7 +1088,7 @@ class TestExecuteCompleteCollectionResume:
             }
         }
 
-        first_tracking = uploader._load_tracking(col)
+        first_tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, first_tracking, publish_at=None)
 
         assert mock_inner.upload_collection.call_args_list[0].kwargs["resume_session_uri"] == _SESS_PREV
@@ -1082,7 +1102,7 @@ class TestExecuteCompleteCollectionResume:
                 "file_path": "p2",
             }
         }
-        second_tracking = uploader._load_tracking(col)
+        second_tracking = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, second_tracking, publish_at=None)
 
         assert mock_inner.upload_collection.call_args_list[1].kwargs["resume_session_uri"] is None
@@ -1099,7 +1119,7 @@ class TestExecuteCompleteCollectionResume:
 
         mock_inner.upload_collection.side_effect = _first_run
 
-        tracking_first = uploader._load_tracking(col)
+        tracking_first = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking_first, publish_at=None)
 
         # 1 回目失敗で URI は tracking に残っているはず（precondition）
@@ -1115,7 +1135,7 @@ class TestExecuteCompleteCollectionResume:
                 "file_path": "p",
             }
         }
-        tracking_second = uploader._load_tracking(col)
+        tracking_second = uploader.tracking_store.load(col)
         uploader._execute_complete_collection(col, tracking_second, publish_at=None)
 
         # Then: 2 回目は同一 URI で resume している
@@ -1135,7 +1155,7 @@ class TestExecuteCompleteCollectionResume:
         mock_inner.upload_collection.side_effect = _side_effect
 
         # When
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         result = uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         # Then
@@ -1162,7 +1182,7 @@ class TestExecuteCompleteCollectionResume:
 
         mock_inner.upload_collection.side_effect = _side_effect
 
-        tracking = uploader._load_tracking(col)
+        tracking = uploader.tracking_store.load(col)
         result = uploader._execute_complete_collection(col, tracking, publish_at=None)
 
         assert result["action"] == ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED
@@ -1182,7 +1202,7 @@ class TestExecuteCompleteCollectionResume:
         secret = "secret-domain-canary"
         mock_inner.upload_collection.side_effect = AutomationError(f"access_token={secret}")
 
-        result = uploader._execute_complete_collection(col, uploader._load_tracking(col), publish_at=None)
+        result = uploader._execute_complete_collection(col, uploader.tracking_store.load(col), publish_at=None)
 
         assert result["details"]["error"] == "complete collection upload failed"
         tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
@@ -1255,7 +1275,7 @@ def test_execute_collection_suppresses_lower_default_publish_fallback_when_sched
         }
     }
 
-    tracking = uploader._load_tracking(col)
+    tracking = uploader.tracking_store.load(col)
     uploader._execute_complete_collection(col, tracking, publish_at=None)
 
     call_kwargs = mock_inner.upload_collection.call_args.kwargs
@@ -1290,28 +1310,28 @@ class TestScheduleConfigPrivacyStatusDeprecation:
         assert "upload_settings.privacy_status" not in caplog.text
 
 
-class TestTrackingIOAtomicity:
+class TestTrackingStoreAtomicity:
     """plan 020 Step 1/2: tracking JSON のアトミック書き込み・破損検出を検証する。"""
 
-    def test_save_tracking_leaves_no_tmp_file_and_roundtrips(self, tmp_path):
+    def test_save_leaves_no_tmp_file_and_roundtrips(self, tmp_path):
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
-        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
 
-        tracking = uploader._load_tracking(col)
+        tracking = store.load(col)
         tracking["status"] = "updated"
-        uploader._save_tracking(col, tracking)
+        store.save(col, tracking)
 
         tmp_path_file = tracking_path.with_suffix(tracking_path.suffix + ".tmp")
         assert not tmp_path_file.exists()
         saved = json.loads(tracking_path.read_text(encoding="utf-8"))
         assert saved["status"] == "updated"
 
-    def test_load_tracking_returns_none_and_quarantines_corrupt_file(self, tmp_path):
+    def test_load_returns_none_and_quarantines_corrupt_file(self, tmp_path):
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         tracking_path.write_text("{truncated", encoding="utf-8")
-        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
 
-        result = uploader._load_tracking(col)
+        result = store.load(col)
 
         assert result is None
         corrupt_path = tracking_path.with_suffix(".json.corrupt")

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -55,7 +55,7 @@ LEGACY_AGENT_OWNERS = {
     "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignmentMixin"),
     "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightMixin"),
     "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesMixin"),
-    "_tracking_io": ("youtube_automation.domains.uploads._tracking_io", "TrackingIOMixin"),
+    "_tracking_io": ("youtube_automation.domains.uploads._tracking_io", "TrackingStore"),
     "_uploader_constants": (
         "youtube_automation.domains.uploads._uploader_constants",
         "UPLOAD_SOURCE_EXISTING",


### PR DESCRIPTION
## 概要

uploadsの暗黙host依存をさらに縮小し、`TrackingIOMixin` を注入可能なtracking store collaboratorへ置換します。

## 変更内容

- `TrackingStore` collaboratorを追加
- `CollectionUploader` へ明示注入し、executorはstoreへ委譲
- `TrackingIOMixin` を削除
- host stub / private patchをcollaborator直接テストへ縮小
- 公開11メソッドとtracking / workflow-state形式・ownerを維持
- B4構造契約・CHANGELOGを更新

## 検証

- rebase前 full: 9,112 passed / 3 skipped
- rebase後 focused: 227 passed
- ruff check / format check / diff check: green

Closes #3929
