### PR TITLE
feat(doctor): check単位の部分診断を追加する (#3922)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。
 - `refactor(configuration)`: CLI の明示 channel 選択を公開 API として提供し、doctor から loader の private symbol への越境 import を解消する（#3921）。
 - `refactor(doctor)`: OAuth token の読み込み・refresh・0o600 atomic 永続化、upload 必須 scope、YouTube service 生成を `infrastructure.auth` に集約し、doctor は診断結果への変換だけを担う（#3920）。
 - `refactor(doctor)`: TTP と初期セットアップの readiness 判定を provider-neutral な `domains.channel_readiness` へ移し、doctor を診断結果へ変換する薄い adapter にする（#3919）。

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -191,7 +191,16 @@ def _channel_roots(root: Path) -> list[Path]:
 
 
 def _check_single_channel_config(channel_root: Path) -> str:
-    cmd = ["uv", "run", "yt-doctor", "--json", "--target", str(channel_root)]
+    cmd = [
+        "uv",
+        "run",
+        "yt-doctor",
+        "--check",
+        "channel_config",
+        "--json",
+        "--target",
+        str(channel_root),
+    ]
     try:
         proc = subprocess.run(
             cmd,

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 import tomllib
 import unicodedata
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, redirect_stdout
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass
@@ -1979,15 +1979,23 @@ def _declared_category(result: CheckResult) -> str:
     return definition.category if definition is not None else result.category
 
 
-def run_all_checks(channel_dir: Path) -> list[CheckResult]:
+def run_checks(channel_dir: Path, check_ids: Iterable[str]) -> list[CheckResult]:
+    """Run the selected check set in registry declaration order."""
+    selected_ids = set(check_ids)
     results: list[CheckResult] = []
     for definition in CHECK_REGISTRY:
+        if definition.id not in selected_ids:
+            continue
         result = definition.run(channel_dir)
         if result.id != definition.id:
             raise RuntimeError(f"doctor check id mismatch: declared={definition.id}, returned={result.id}")
         result.category = definition.category
         results.append(result)
     return results
+
+
+def run_all_checks(channel_dir: Path) -> list[CheckResult]:
+    return run_checks(channel_dir, (definition.id for definition in CHECK_REGISTRY))
 
 
 def summarize(results: list[CheckResult]) -> dict:
@@ -2643,6 +2651,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--json", action="store_true", help="JSON 出力 (AI 用)")
     parser.add_argument("--target", help="対象 channel dir (既定: CHANNEL_DIR env → CWD)")
     parser.add_argument(
+        "--check",
+        action="append",
+        choices=tuple(definition.id for definition in CHECK_REGISTRY),
+        help="指定 check のみ実行（複数回指定可）",
+    )
+    parser.add_argument(
         "--apply",
         action="store_true",
         help="ai-exec の診断 step を human / 決定待ちまで自動実行",
@@ -2695,7 +2709,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         apply_summary = outcome.summary
         exit_code = outcome.exit_code
     else:
-        results = run_all_checks(channel_dir)
+        results = run_checks(channel_dir, args.check) if args.check else run_all_checks(channel_dir)
     summary = summarize(results)
 
     if args.json or args.apply:

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -1131,7 +1131,16 @@ def test_apply_channel_config_check_uses_target_even_when_channel_dir_differs(
     monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
 
     def _doctor(cmd: list[str], **kwargs):
-        assert cmd == ["uv", "run", "yt-doctor", "--json", "--target", str(repo)]
+        assert cmd == [
+            "uv",
+            "run",
+            "yt-doctor",
+            "--check",
+            "channel_config",
+            "--json",
+            "--target",
+            str(repo),
+        ]
         assert kwargs["cwd"] == repo
         payload = {"checks": [{"id": "channel_config", "status": "ok", "message": "config/channel/ ロード成功"}]}
         return automation_update.subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
@@ -1176,7 +1185,16 @@ def test_channel_config_check_fails_when_workspace_has_no_channel_config(
     repo.mkdir()
 
     def _doctor(cmd: list[str], **kwargs):
-        assert cmd == ["uv", "run", "yt-doctor", "--json", "--target", str(repo)]
+        assert cmd == [
+            "uv",
+            "run",
+            "yt-doctor",
+            "--check",
+            "channel_config",
+            "--json",
+            "--target",
+            str(repo),
+        ]
         assert kwargs["cwd"] == repo
         payload = {
             "checks": [
@@ -1209,7 +1227,16 @@ def test_apply_returns_nonzero_when_target_channel_config_is_invalid(
     monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
 
     def _doctor(cmd: list[str], **kwargs):
-        assert cmd == ["uv", "run", "yt-doctor", "--json", "--target", str(repo)]
+        assert cmd == [
+            "uv",
+            "run",
+            "yt-doctor",
+            "--check",
+            "channel_config",
+            "--json",
+            "--target",
+            str(repo),
+        ]
         payload = {
             "checks": [
                 {

--- a/tests/commands/system/test_doctor_json_contract.py
+++ b/tests/commands/system/test_doctor_json_contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from youtube_automation.commands.system import doctor
 
 EXPECTED_CHECK_IDS = (
@@ -57,6 +59,53 @@ def test_json_should_expose_all_check_ids_and_check_shape(monkeypatch, tmp_path:
 
     streaming_check = next(check for check in payload["checks"] if check["id"] == "streaming_vps_state")
     assert streaming_check["data"]["reason"] == "streaming_terraform_module_missing"
+
+
+def test_check_filter_runs_repeated_ids_in_registry_order_and_scopes_summary(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    def definition(check_id: str, status: str) -> doctor.CheckDefinition:
+        return doctor.CheckDefinition(
+            id=check_id,
+            category=doctor.DATA_CATEGORY,
+            run=lambda _channel_dir: doctor.CheckResult(id=check_id, status=status, message=check_id),
+            apply_kind=doctor.ApplyKind.NONE,
+            cwd_semantics=doctor.CwdSemantics.CHANNEL,
+        )
+
+    monkeypatch.setattr(
+        doctor,
+        "CHECK_REGISTRY",
+        (definition("alpha", "warn"), definition("beta", "ok"), definition("gamma", "fail")),
+    )
+
+    code = doctor.main(["--check", "gamma", "--check", "alpha", "--json", "--target", str(tmp_path)])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [check["id"] for check in payload["checks"]] == ["alpha", "gamma"]
+    assert payload["summary"] == {
+        "ok": 0,
+        "info": 0,
+        "warn": 1,
+        "fail": 1,
+        "unknown": 0,
+        "next_check_id": "alpha",
+    }
+    assert all(
+        set(check) == {"id", "status", "message", "category", "next_action", "data"} for check in payload["checks"]
+    )
+
+
+def test_check_filter_rejects_ids_outside_registry(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "CHECK_REGISTRY", ())
+
+    with pytest.raises(SystemExit) as error:
+        doctor.main(["--check", "missing", "--json", "--target", str(tmp_path)])
+
+    assert error.value.code != 0
 
 
 def test_json_should_keep_internal_action_fields_out_of_public_contract(


### PR DESCRIPTION
## 概要

doctor registryの部分実行面として `--check <id>` を追加し、automation updateのchannel config検査を不要なnetwork checkなしで実行します。

## 変更内容

- `--check <id>` の反復指定とregistry由来choicesを追加
- 指定順に依存せずregistry宣言順で実行
- `checks` / `summary`を選択集合内に限定し、既存JSON schemaを維持
- automation_updateを `channel_config` 単一check呼出しへ変更
- フラグなしと `--apply` は従来どおり全check実行
- CHANGELOGを更新

## 検証

- 関連 / architecture: 691 passed
- full: 9,122 passed / 3 skipped
- ruff check / format check: green

Closes #3922
