### PR TITLE
refactor(uploads): 公開日計算をコラボレータへ委譲する (#3930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。
+- `refactor(uploads)`: `PublishedDatesMixin` を設定と YouTube service provider を明示注入する公開日計算コラボレータへ置換し、cadence・週次マップと uploader の公開 interface を維持する（#3930）。
 - `refactor(configuration)`: CLI の明示 channel 選択を公開 API として提供し、doctor から loader の private symbol への越境 import を解消する（#3921）。
 - `refactor(doctor)`: OAuth token の読み込み・refresh・0o600 atomic 永続化、upload 必須 scope、YouTube service 生成を `infrastructure.auth` に集約し、doctor は診断結果への変換だけを担う（#3920）。
 - `refactor(doctor)`: TTP と初期セットアップの readiness 判定を provider-neutral な `domains.channel_readiness` へ移し、doctor を診断結果へ変換する薄い adapter にする（#3919）。

--- a/src/youtube_automation/domains/uploads/_published_dates.py
+++ b/src/youtube_automation/domains/uploads/_published_dates.py
@@ -1,13 +1,9 @@
-"""公開日一覧取得とスケジュール公開日時の計算ロジック。
-
-責務分割（Issue #465）の一環で ``collection_uploader.py`` から分離した。
-``self.config`` / ``self.youtube_service`` / ``self.initialize_youtube_service``
-は合成先クラス（``CollectionUploader`` 本体）が提供する。
-"""
+"""公開日一覧取得とスケジュール公開日時の計算コラボレータ。"""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import ClassVar
 
@@ -79,8 +75,8 @@ def _scheduling_enabled(schedule_cfg: dict) -> bool:
     return has_cadence or has_publish_time
 
 
-class PublishedDatesMixin:
-    """公開済み/予約済み動画の取得とスケジュール公開日時計算を提供する mixin。"""
+class PublishedDatesScheduler:
+    """設定と YouTube service provider から公開日時を計算する。"""
 
     # 曜日名 → isoweekday() マッピング（月=1, 日=7）
     _WEEKDAY_MAP: ClassVar[dict[str, int]] = {
@@ -93,7 +89,11 @@ class PublishedDatesMixin:
         "sun": 7,
     }
 
-    def _calculate_publish_at(self) -> str | None:
+    def __init__(self, config: dict, youtube_service_provider: Callable[[], object]) -> None:
+        self.config = config
+        self.youtube_service_provider = youtube_service_provider
+
+    def calculate_publish_at(self) -> str | None:
         """CC のスケジュール公開日時を計算
 
         スケジュール公開（YouTube ``status.publishAt``）を有効化する条件:
@@ -142,7 +142,7 @@ class PublishedDatesMixin:
             publish_dt += timedelta(days=1)
 
         # cadence 曜日かつ既存公開日と重複しない日を探す
-        existing_dates = self._get_published_dates()
+        existing_dates = self.get_published_dates()
         max_slide = 30  # 無限ループ防止
         for _ in range(max_slide):
             if publish_dt.isoweekday() in allowed_weekdays and publish_dt.date() not in existing_dates:
@@ -155,21 +155,20 @@ class PublishedDatesMixin:
         logger.info(f"📅 CC 公開予定: {publish_dt.isoformat()}")
         return publish_dt.isoformat()
 
-    def _get_published_dates(self) -> set:
+    def get_published_dates(self) -> set:
         """YouTube API でチャンネルの公開済み/予約済み動画の公開日セットを取得
 
         search().list() で動画IDを取得し、videos().list(part='status,snippet') で
         公開予約日時（status.publishAt）と公開日時（snippet.publishedAt）の両方を収集する。
         """
-        if not self.youtube_service:
-            self.initialize_youtube_service()
+        youtube_service = self.youtube_service_provider()
 
         tz = get_schedule_timezone(self.config)
         dates = set()
 
         try:
             # 動画IDを取得（part='id' でクォータ節約）
-            search_request = self.youtube_service.search().list(
+            search_request = youtube_service.search().list(
                 forMine=True, type="video", order="date", maxResults=50, part="id"
             )
             # 失敗 request も quota を消費するため、成否によらず記録してから既存の fail-safe に委ねる
@@ -186,7 +185,7 @@ class PublishedDatesMixin:
                 return dates
 
             # status.publishAt（公開予約）と snippet.publishedAt（公開済み）を取得
-            videos_request = self.youtube_service.videos().list(id=",".join(video_ids), part="status,snippet")
+            videos_request = youtube_service.videos().list(id=",".join(video_ids), part="status,snippet")
             videos_response = execute_youtube_request(
                 videos_request,
                 "published dates videos.list failed",
@@ -205,4 +204,4 @@ class PublishedDatesMixin:
         return dates
 
 
-__all__ = ["PublishedDatesMixin"]
+__all__ = ["PublishedDatesScheduler"]

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -18,7 +18,7 @@ from youtube_automation.core.adapters.youtube import (
 from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignmentMixin
-from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
+from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
@@ -41,7 +41,6 @@ __all__ = ["CollectionUploader"]
 class CollectionUploader(
     CompleteCollectionExecutorMixin,
     PlaylistAssignmentMixin,
-    PublishedDatesMixin,
 ):
     """Collection Uploader — CC アップロード専用
 
@@ -50,7 +49,7 @@ class CollectionUploader(
 
     責務別の挙動は mixin に分離されている（Issue #465）:
     - tracking I/O           : ``TrackingStore`` への委譲
-    - 公開日 / publishAt 計算: ``PublishedDatesMixin``
+    - 公開日 / publishAt 計算: ``PublishedDatesScheduler`` への委譲
     - プレイリスト割り当て    : ``PlaylistAssignmentMixin``
     - CC 実行ループ           : ``CompleteCollectionExecutorMixin``
     """
@@ -61,6 +60,7 @@ class CollectionUploader(
         config_path: str | None = None,
         youtube_clients: YouTubeClients | None = None,
         tracking_store: TrackingStore | None = None,
+        published_dates: PublishedDatesScheduler | None = None,
     ):
         if collections_root is None:
             collections_root = channel_dir() / "collections"
@@ -75,6 +75,7 @@ class CollectionUploader(
         self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
         self.youtube_service = None
         self.youtube_clients = youtube_clients
+        self.published_dates = published_dates or PublishedDatesScheduler(self.config, self._provide_youtube_service)
 
     # ─── 設定・初期化 ───────────────────────────────
 
@@ -114,6 +115,10 @@ class CollectionUploader(
             raise TypeError("youtube_clients is required")
         if not self.youtube_service:
             self.youtube_service = self.youtube_clients.youtube
+
+    def _provide_youtube_service(self) -> object:
+        self.initialize_youtube_service()
+        return self.youtube_service
 
     # ─── コレクション検索 ───────────────────────────
 
@@ -200,7 +205,7 @@ class CollectionUploader(
         # Complete Collection アップロード
         cc = tracking.get("complete_collection", {})
         if cc.get("status") != "completed":
-            publish_at = self._calculate_publish_at()
+            publish_at = self.published_dates.calculate_publish_at()
             return self._execute_complete_collection(collection_path, tracking, publish_at=publish_at)
 
         # 全完了
@@ -244,7 +249,7 @@ class CollectionUploader(
 
     def show_plan(self, collection_path: Path):
         """ドライラン — スケジュール計算のみ表示"""
-        publish_at = self._calculate_publish_at()
+        publish_at = self.published_dates.calculate_publish_at()
         schedule_cfg = self.config.get("schedule", {})
 
         print(f"📋 アップロード計画: {collection_path.name}")

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 
 sys.path.insert(0, str(REPO_ROOT))
@@ -398,6 +399,39 @@ def test_collection_uploader_accepts_injected_tracking_store(tmp_path: Path) -> 
     assert uploader.tracking_store is store
 
 
+def test_collection_uploader_accepts_injected_published_dates(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    published_dates = MagicMock(spec=PublishedDatesScheduler)
+
+    with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader"):
+        uploader = CollectionUploader(
+            collections_root=str(tmp_path / "collections"),
+            config_path=str(tmp_path / "schedule_config.json"),
+            published_dates=published_dates,
+        )
+
+    assert uploader.published_dates is published_dates
+
+
+def test_collection_uploader_delegates_publish_date_calculation(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    published_dates = MagicMock(spec=PublishedDatesScheduler)
+    published_dates.calculate_publish_at.return_value = "2099-01-01T20:00:00+09:00"
+
+    with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader"):
+        uploader = CollectionUploader(
+            collections_root=str(tmp_path / "collections"),
+            config_path=str(tmp_path / "schedule_config.json"),
+            published_dates=published_dates,
+        )
+
+    uploader.show_plan(tmp_path / "collection")
+
+    published_dates.calculate_publish_at.assert_called_once_with()
+
+
 def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
     """schedule_config.json を指定して CollectionUploader を構築する."""
     from youtube_automation.domains.uploads.collection import CollectionUploader
@@ -598,7 +632,7 @@ class TestDefaultPublishTimeFallback:
                 return_value="2099-01-01T20:00:00+09:00",
             ) as mock_resolve,
         ):
-            result = uploader._calculate_publish_at()
+            result = uploader.published_dates.calculate_publish_at()
 
         assert result == "2099-01-01T20:00:00+09:00"
         assert mock_resolve.called
@@ -610,7 +644,7 @@ class TestDefaultPublishTimeFallback:
         )
 
         with patch("youtube_automation.domains.uploads._published_dates.resolve_default_publish_at") as mock_resolve:
-            result = uploader._calculate_publish_at()
+            result = uploader.published_dates.calculate_publish_at()
 
         assert result is None
         assert not mock_resolve.called
@@ -619,28 +653,27 @@ class TestDefaultPublishTimeFallback:
 class TestPublishedDatesQuotaRecording:
     """Issue #2057: `_get_published_dates` が batch 回数と一致する quota を記録すること."""
 
-    def _make_uploader_with_mock_service(self, tmp_path: Path):
-        uploader, _ = _make_uploader_with_schedule_config(
-            tmp_path,
-            {"schedule": {"timezone": "Asia/Tokyo"}},
-        )
+    def _make_scheduler_with_mock_service(self):
         mock_service = MagicMock()
-        uploader.youtube_service = mock_service
-        return uploader, mock_service
+        scheduler = PublishedDatesScheduler(
+            {"schedule": {"timezone": "Asia/Tokyo"}},
+            lambda: mock_service,
+        )
+        return scheduler, mock_service
 
     def _quota_calls(self, mock_log_quota) -> list[tuple[str, str, float]]:
         return [(c.args[0], c.args[1], c.args[2]) for c in mock_log_quota.call_args_list]
 
     def test_should_record_one_quota_entry_per_batch_request(self, tmp_path):
         """要件 2: batch 回数（search 1 + videos 1）と記録件数が一致する."""
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.return_value = {"items": [{"id": {"videoId": "v1"}}]}
         mock_service.videos.return_value.list.return_value.execute.return_value = {
             "items": [{"id": "v1", "snippet": {"publishedAt": "2025-01-01T10:00:00Z"}, "status": {}}]
         }
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            dates = uploader._get_published_dates()
+            dates = scheduler.get_published_dates()
 
         assert len(dates) == 1
         assert self._quota_calls(mock_log_quota) == [
@@ -650,11 +683,11 @@ class TestPublishedDatesQuotaRecording:
 
     def test_should_record_only_search_quota_when_channel_has_no_videos(self, tmp_path):
         """要件 4 相当: videos.list を実行しない場合はその quota を記録しない."""
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.return_value = {"items": []}
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            dates = uploader._get_published_dates()
+            dates = scheduler.get_published_dates()
 
         assert dates == set()
         assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
@@ -662,37 +695,37 @@ class TestPublishedDatesQuotaRecording:
 
     @pytest.mark.parametrize("search_response", [None, {"items": None}, {"items": {}}, {"items": [None]}])
     def test_should_fail_safe_on_invalid_search_response_shapes(self, tmp_path, search_response):
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.return_value = search_response
 
-        assert uploader._get_published_dates() == set()
+        assert scheduler.get_published_dates() == set()
         mock_service.videos.return_value.list.assert_not_called()
 
     @pytest.mark.parametrize("videos_response", [None, {"items": None}, {"items": {}}, {"items": [None]}])
     def test_should_fail_safe_on_invalid_videos_response_shapes(self, tmp_path, videos_response):
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.return_value = {"items": [{"id": {"videoId": "v1"}}]}
         mock_service.videos.return_value.list.return_value.execute.return_value = videos_response
 
-        assert uploader._get_published_dates() == set()
+        assert scheduler.get_published_dates() == set()
 
     def test_should_record_quota_and_keep_fail_safe_on_api_error(self, tmp_path, caplog):
         """要件 3: API failure でも quota 記録後に既存 fail-safe（空 set + warning）を維持する."""
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.side_effect = RuntimeError("boom")
 
         with (
             patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota,
             caplog.at_level(logging.WARNING),
         ):
-            dates = uploader._get_published_dates()
+            dates = scheduler.get_published_dates()
 
         assert dates == set()
         assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
         assert any(rec.levelno == logging.WARNING for rec in caplog.records)
 
     def test_should_record_quota_for_each_retry_attempt(self, tmp_path, monkeypatch):
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         monkeypatch.setattr("youtube_automation.infrastructure.retry.time.sleep", lambda _: None)
         request = mock_service.search.return_value.list.return_value
         request.execute.side_effect = [
@@ -701,7 +734,7 @@ class TestPublishedDatesQuotaRecording:
         ]
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            assert uploader._get_published_dates() == set()
+            assert scheduler.get_published_dates() == set()
 
         assert request.execute.call_count == 2
         assert self._quota_calls(mock_log_quota) == [
@@ -710,7 +743,7 @@ class TestPublishedDatesQuotaRecording:
         ]
 
     def test_should_retry_videos_request_and_keep_published_date(self, tmp_path, monkeypatch):
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         monkeypatch.setattr("youtube_automation.infrastructure.retry.time.sleep", lambda _: None)
         mock_service.search.return_value.list.return_value.execute.return_value = {"items": [{"id": {"videoId": "v1"}}]}
         videos_request = mock_service.videos.return_value.list.return_value
@@ -720,7 +753,7 @@ class TestPublishedDatesQuotaRecording:
         ]
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            assert uploader._get_published_dates() == {datetime(2025, 1, 1).date()}
+            assert scheduler.get_published_dates() == {datetime(2025, 1, 1).date()}
 
         assert videos_request.execute.call_count == 2
         assert self._quota_calls(mock_log_quota) == [
@@ -731,11 +764,11 @@ class TestPublishedDatesQuotaRecording:
 
     @pytest.mark.parametrize("item", [{"status": {}}, {"status": {}, "snippet": {}}])
     def test_should_fail_safe_on_missing_published_date_fields(self, tmp_path, item):
-        uploader, mock_service = self._make_uploader_with_mock_service(tmp_path)
+        scheduler, mock_service = self._make_scheduler_with_mock_service()
         mock_service.search.return_value.list.return_value.execute.return_value = {"items": [{"id": {"videoId": "v1"}}]}
         mock_service.videos.return_value.list.return_value.execute.return_value = {"items": [item]}
 
-        assert uploader._get_published_dates() == set()
+        assert scheduler.get_published_dates() == set()
 
 
 class TestExecuteCompleteCollectionResume:

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -1,12 +1,11 @@
-"""PublishedDatesMixin._calculate_publish_at の cadence 曜日制約テスト。"""
+"""PublishedDatesScheduler.calculate_publish_at の cadence 曜日制約テスト。"""
 
 from datetime import date, datetime
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
-from youtube_automation.domains.uploads import _published_dates
-from youtube_automation.domains.uploads._published_dates import PublishedDatesMixin
+from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 
 TZ = ZoneInfo("Asia/Tokyo")
 
@@ -18,29 +17,28 @@ def calculate_publish_at(
     publish_time: str = "11:00",
     auto_schedule_enabled: bool = True,
 ) -> str | None:
-    """本番 mixin を固定時刻・既存公開日で実行するテストadapter。"""
+    """本番 collaborator を固定時刻・既存公開日で実行するテストadapter。"""
 
-    class Scheduler(PublishedDatesMixin):
-        def __init__(self) -> None:
-            self.config = {
-                "schedule": {
-                    "auto_schedule_enabled": auto_schedule_enabled,
-                    "cadence": cadence or [],
-                    "publish_time": publish_time,
-                    "timezone": "Asia/Tokyo",
-                }
+    scheduler = PublishedDatesScheduler(
+        {
+            "schedule": {
+                "auto_schedule_enabled": auto_schedule_enabled,
+                "cadence": cadence or [],
+                "publish_time": publish_time,
+                "timezone": "Asia/Tokyo",
             }
-
-        def _get_published_dates(self) -> set[date]:
-            return existing_dates
+        },
+        MagicMock(),
+    )
+    scheduler.get_published_dates = MagicMock(return_value=existing_dates)
 
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None):
             return now
 
-    with patch.object(_published_dates, "datetime", FixedDateTime):
-        return Scheduler()._calculate_publish_at()
+    with patch("youtube_automation.domains.uploads._published_dates.datetime", FixedDateTime):
+        return scheduler.calculate_publish_at()
 
 
 class TestCadenceScheduling:
@@ -129,45 +127,37 @@ class TestCadenceScheduling:
 
 
 class TestSchedulingEnabledHeuristic:
-    """`_scheduling_enabled` — schedule_config.json から予約公開有効性を判定するロジック."""
+    """schedule_config.json から予約公開有効性を判定する観測契約。"""
+
+    @staticmethod
+    def _calculate(schedule: dict) -> str | None:
+        scheduler = PublishedDatesScheduler({"schedule": schedule}, MagicMock())
+        scheduler.get_published_dates = MagicMock(return_value=set())
+        return scheduler.calculate_publish_at()
 
     def test_explicit_true_enables(self):
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({"auto_schedule_enabled": True}) is True
+        assert self._calculate({"auto_schedule_enabled": True}) is not None
 
     def test_explicit_false_disables_even_when_cadence_present(self):
         """auto_schedule_enabled=false が明示されていればスケジュール無効（後方互換）."""
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({"auto_schedule_enabled": False, "cadence": ["tue", "thu", "sat"]}) is False
+        assert self._calculate({"auto_schedule_enabled": False, "cadence": ["tue", "thu", "sat"]}) is None
 
     def test_cadence_alone_implies_enabled(self):
         """cadence が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({"cadence": ["tue", "thu", "sat"]}) is True
+        assert self._calculate({"cadence": ["tue", "thu", "sat"]}) is not None
 
     def test_publish_time_alone_implies_enabled(self):
         """publish_time が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({"publish_time": "20:00"}) is True
+        assert self._calculate({"publish_time": "20:00"}) is not None
 
     def test_empty_cadence_does_not_imply_enabled(self):
         """空 cadence はオプトインシグナルにならない."""
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({"cadence": []}) is False
+        assert self._calculate({"cadence": []}) is None
 
     def test_day1_time_alone_does_not_imply_enabled(self):
         """day1_time のみは過去テンプレで既定値が入っていることがあるためシグナルにしない."""
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
         # 旧テンプレ互換（auto_schedule_enabled なしで day1_time のみ）はスケジュール無効
-        assert _scheduling_enabled({"day1_time": "20:00", "timezone": "Asia/Tokyo"}) is False
+        assert self._calculate({"day1_time": "20:00", "timezone": "Asia/Tokyo"}) is None
 
     def test_empty_dict_disables(self):
-        from youtube_automation.domains.uploads._published_dates import _scheduling_enabled
-
-        assert _scheduling_enabled({}) is False
+        assert self._calculate({}) is None

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -54,7 +54,7 @@ LEGACY_AGENT_OWNERS = {
     "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearchMixin"),
     "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignmentMixin"),
     "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightMixin"),
-    "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesMixin"),
+    "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesScheduler"),
     "_tracking_io": ("youtube_automation.domains.uploads._tracking_io", "TrackingStore"),
     "_uploader_constants": (
         "youtube_automation.domains.uploads._uploader_constants",


### PR DESCRIPTION
## 概要

uploads mixin解体の次段として `PublishedDatesMixin` を明示注入可能な公開日計算collaboratorへ置換します。

## 変更内容

- configとYouTube service providerを注入する `PublishedDatesScheduler` を追加
- `CollectionUploader` はschedulerへ委譲しMixin継承を除去
- 公開method集合、cadence、週次、API quota、fail-safeを維持
- schedule testのstub host / private module importとcollection testのhost依存を縮小
- B4構造契約・CHANGELOGを更新

## 検証

- focused: 139 passed
- uploads広域: 534 passed
- full: 9,126 passed / 3 skipped
- latest main rebase後 targeted: 91 passed
- ruff check / format check: green

Closes #3930
