### PR TITLE
refactor(uploads): playlist割り当てをコラボレータへ委譲する (#3931)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
+- `refactor(uploads)`: `PlaylistAssignmentMixin` を YouTube clients を明示注入する playlist 割り当てコラボレータへ置換し、割り当て失敗を状態確定前に伝播する契約を維持する（#3931）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。
 - `refactor(uploads)`: `PublishedDatesMixin` を設定と YouTube service provider を明示注入する公開日計算コラボレータへ置換し、cadence・週次マップと uploader の公開 interface を維持する（#3930）。
 - `refactor(configuration)`: CLI の明示 channel 選択を公開 API として提供し、doctor から loader の private symbol への越境 import を解消する（#3921）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -2,9 +2,8 @@
 
 責務分割（Issue #465）の一環で ``collection_uploader.py`` から分離した。
 ``self.uploader`` / ``self.tracking_store`` / ``self.config`` /
-``self._move_collection_to_live`` /
-``self._assign_to_playlists`` は合成先クラス（``CollectionUploader`` 本体および
-他 mixin）が提供する。
+``self._move_collection_to_live`` / ``self.playlist_assignment`` は合成先クラス
+（``CollectionUploader`` 本体）が提供する。
 """
 
 from __future__ import annotations
@@ -49,7 +48,7 @@ class CompleteCollectionExecutorMixin:
         publish_at: str | None,
     ) -> dict:
         # playlist 所有権エラー時にローカル状態を成功確定しないため、最初に割り当てる。
-        self._assign_to_playlists(complete_video["video_id"], collection_path)
+        self.playlist_assignment.assign(complete_video["video_id"], collection_path)
 
         tracking = {
             **tracking,

--- a/src/youtube_automation/domains/uploads/_playlist_assignment.py
+++ b/src/youtube_automation/domains/uploads/_playlist_assignment.py
@@ -6,18 +6,29 @@ import json
 import logging
 from pathlib import Path
 
-from youtube_automation.configuration import load_config
+from youtube_automation.configuration import ChannelConfig, load_config
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.domains.uploads.playlists import PlaylistManager
 from youtube_automation.infrastructure.filesystem import path_exists, read_file_text
+from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
 
 
-class PlaylistAssignmentMixin:
-    """アップロード後にプレイリストへ自動追加する mixin。"""
+class PlaylistAssignment:
+    """YouTube clients を明示的に受けて動画をプレイリストへ割り当てる。"""
 
-    def _assign_to_playlists(self, video_id: str, collection_path: Path):
+    def __init__(
+        self,
+        youtube_clients: YouTubeClients | None,
+        config: ChannelConfig | None = None,
+        playlist_manager: PlaylistManager | None = None,
+    ) -> None:
+        self.youtube_clients = youtube_clients
+        self.config = config
+        self.playlist_manager = playlist_manager
+
+    def assign(self, video_id: str, collection_path: Path) -> None:
         """アップロード後にプレイリストへ自動追加する。"""
         ws_path = CollectionPaths(collection_path).workflow_state_path
         if not path_exists(ws_path):
@@ -29,15 +40,18 @@ class PlaylistAssignmentMixin:
         if not theme:
             return
 
-        config = load_config()
+        config = self.config if self.config is not None else load_config()
         if not config.playlists.items:
             return
 
-        clients = self.youtube_clients
-        pm = PlaylistManager(clients=clients)
+        pm = (
+            self.playlist_manager
+            if self.playlist_manager is not None
+            else PlaylistManager(clients=self.youtube_clients)
+        )
         assigned = pm.assign_video(video_id, theme, collection_path=collection_path)
         if assigned:
             logger.info(f"📋 プレイリスト追加: {assigned}")
 
 
-__all__ = ["PlaylistAssignmentMixin"]
+__all__ = ["PlaylistAssignment"]

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -17,7 +17,7 @@ from youtube_automation.core.adapters.youtube import (
 )
 from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
-from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignmentMixin
+from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
@@ -40,7 +40,6 @@ __all__ = ["CollectionUploader"]
 
 class CollectionUploader(
     CompleteCollectionExecutorMixin,
-    PlaylistAssignmentMixin,
 ):
     """Collection Uploader — CC アップロード専用
 
@@ -50,7 +49,7 @@ class CollectionUploader(
     責務別の挙動は mixin に分離されている（Issue #465）:
     - tracking I/O           : ``TrackingStore`` への委譲
     - 公開日 / publishAt 計算: ``PublishedDatesScheduler`` への委譲
-    - プレイリスト割り当て    : ``PlaylistAssignmentMixin``
+    - プレイリスト割り当て    : ``PlaylistAssignment`` への委譲
     - CC 実行ループ           : ``CompleteCollectionExecutorMixin``
     """
 
@@ -61,6 +60,7 @@ class CollectionUploader(
         youtube_clients: YouTubeClients | None = None,
         tracking_store: TrackingStore | None = None,
         published_dates: PublishedDatesScheduler | None = None,
+        playlist_assignment: PlaylistAssignment | None = None,
     ):
         if collections_root is None:
             collections_root = channel_dir() / "collections"
@@ -76,6 +76,9 @@ class CollectionUploader(
         self.youtube_service = None
         self.youtube_clients = youtube_clients
         self.published_dates = published_dates or PublishedDatesScheduler(self.config, self._provide_youtube_service)
+        self.playlist_assignment = (
+            playlist_assignment if playlist_assignment is not None else PlaylistAssignment(youtube_clients)
+        )
 
     # ─── 設定・初期化 ───────────────────────────────
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -3,7 +3,7 @@ CollectionUploader のユニットテスト
 
 テスト対象: agents/collection_uploader.py
 
-#77 回帰テスト: `_assign_to_playlists()` の import パス誤りで
+#77 回帰テスト: playlist assignment の import パス誤りで
 プレイリスト自動追加が常時失敗していたバグを検出するためのテスト。
 """
 
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 
@@ -218,7 +219,7 @@ def test_main_title_preflight_honors_collection_opt_in_for_each_cli_entry(
 
 
 # ---------------------------------------------------------------------------
-# _assign_to_playlists
+# PlaylistAssignment.assign
 # ---------------------------------------------------------------------------
 
 
@@ -231,12 +232,11 @@ def workflow_state_file(tmp_path):
 
 
 def test_assign_to_playlists_calls_playlist_manager(workflow_state_file):
-    """`_assign_to_playlists` が PlaylistManager.assign_video を theme 付きで呼ぶ。
+    """`PlaylistAssignment.assign` が PlaylistManager.assign_video を theme 付きで呼ぶ。
 
     #77 の回帰防止: import パスが正しくなければ以前は ImportError が warning に
     握り潰されて何も呼ばれなかった。
     """
-    from youtube_automation.domains.uploads.collection import CollectionUploader
     from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
     mock_config = MagicMock()
@@ -245,18 +245,11 @@ def test_assign_to_playlists_calls_playlist_manager(workflow_state_file):
     mock_pm_instance = MagicMock()
     mock_pm_instance.assign_video.return_value = ["all"]
 
-    with (
-        patch("youtube_automation.domains.uploads._playlist_assignment.load_config", return_value=mock_config),
-        patch(
-            "youtube_automation.domains.uploads._playlist_assignment.PlaylistManager",
-            return_value=mock_pm_instance,
-        ) as mock_pm_class,
-    ):
-        clients = YouTubeClients(full_handler=MagicMock())
-        fake_self = SimpleNamespace(youtube_clients=clients)
-        CollectionUploader._assign_to_playlists(fake_self, "VIDEO_ID_123", workflow_state_file)
+    clients = YouTubeClients(full_handler=MagicMock())
+    assignment = PlaylistAssignment(clients, config=mock_config, playlist_manager=mock_pm_instance)
 
-    mock_pm_class.assert_called_once_with(clients=clients)
+    assignment.assign("VIDEO_ID_123", workflow_state_file)
+
     mock_pm_instance.assign_video.assert_called_once_with(
         "VIDEO_ID_123", "Rainy Jazz", collection_path=workflow_state_file
     )
@@ -265,56 +258,42 @@ def test_assign_to_playlists_calls_playlist_manager(workflow_state_file):
 def test_assign_to_playlists_propagates_playlist_api_failure(workflow_state_file):
     """post-upload の playlist API 失敗を workflow 呼び出し元へ伝播する。"""
     from youtube_automation.core.errors import YouTubeAPIError
-    from youtube_automation.domains.uploads.collection import CollectionUploader
 
     mock_config = MagicMock()
     mock_config.playlists.items = {"all": {"title": "All", "playlist_id": "PL_ALL"}}
     failure = YouTubeAPIError("playlistItems.insert failed", status_code=403)
 
-    with (
-        patch("youtube_automation.domains.uploads._playlist_assignment.load_config", return_value=mock_config),
-        patch("youtube_automation.domains.uploads._playlist_assignment.PlaylistManager") as manager_class,
-        pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"),
-    ):
-        manager_class.return_value.assign_video.side_effect = failure
-        CollectionUploader._assign_to_playlists(
-            SimpleNamespace(youtube_clients=MagicMock()),
-            "VIDEO_ID_123",
-            workflow_state_file,
-        )
+    playlist_manager = MagicMock()
+    playlist_manager.assign_video.side_effect = failure
+    assignment = PlaylistAssignment(MagicMock(), config=mock_config, playlist_manager=playlist_manager)
+
+    with pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"):
+        assignment.assign("VIDEO_ID_123", workflow_state_file)
 
 
 def test_assign_to_playlists_skips_when_no_theme(tmp_path):
     """theme が空なら PlaylistManager を呼ばずに return する"""
-    from youtube_automation.domains.uploads.collection import CollectionUploader
-
     ws_path = tmp_path / "workflow-state.json"
     ws_path.write_text(json.dumps({"theme": ""}), encoding="utf-8")
 
-    with (
-        patch("youtube_automation.domains.uploads._playlist_assignment.load_config") as mock_load,
-        patch("youtube_automation.domains.uploads._playlist_assignment.PlaylistManager") as mock_pm_class,
-    ):
-        fake_self = MagicMock()
-        CollectionUploader._assign_to_playlists(fake_self, "VIDEO_ID_123", tmp_path)
+    mock_config = MagicMock()
+    playlist_manager = MagicMock()
+    assignment = PlaylistAssignment(MagicMock(), config=mock_config, playlist_manager=playlist_manager)
 
-    mock_load.assert_not_called()
-    mock_pm_class.assert_not_called()
+    assignment.assign("VIDEO_ID_123", tmp_path)
+
+    playlist_manager.assign_video.assert_not_called()
 
 
 def test_assign_to_playlists_skips_when_no_workflow_state(tmp_path):
     """workflow-state.json がなければ何もしない"""
-    from youtube_automation.domains.uploads.collection import CollectionUploader
+    mock_config = MagicMock()
+    playlist_manager = MagicMock()
+    assignment = PlaylistAssignment(MagicMock(), config=mock_config, playlist_manager=playlist_manager)
 
-    with (
-        patch("youtube_automation.domains.uploads._playlist_assignment.load_config") as mock_load,
-        patch("youtube_automation.domains.uploads._playlist_assignment.PlaylistManager") as mock_pm_class,
-    ):
-        fake_self = MagicMock()
-        CollectionUploader._assign_to_playlists(fake_self, "VIDEO_ID_123", tmp_path)
+    assignment.assign("VIDEO_ID_123", tmp_path)
 
-    mock_load.assert_not_called()
-    mock_pm_class.assert_not_called()
+    playlist_manager.assign_video.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -412,6 +391,21 @@ def test_collection_uploader_accepts_injected_published_dates(tmp_path: Path) ->
         )
 
     assert uploader.published_dates is published_dates
+
+
+def test_collection_uploader_accepts_injected_playlist_assignment(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    playlist_assignment = MagicMock(spec=PlaylistAssignment)
+
+    with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader"):
+        uploader = CollectionUploader(
+            collections_root=str(tmp_path / "collections"),
+            config_path=str(tmp_path / "schedule_config.json"),
+            playlist_assignment=playlist_assignment,
+        )
+
+    assert uploader.playlist_assignment is playlist_assignment
 
 
 def test_collection_uploader_delegates_publish_date_calculation(tmp_path: Path) -> None:
@@ -954,7 +948,7 @@ class TestExecuteCompleteCollectionResume:
         failure = YouTubeAPIError("playlistItems.insert failed", status_code=403)
 
         with (
-            patch.object(uploader, "_assign_to_playlists", side_effect=failure),
+            patch.object(uploader.playlist_assignment, "assign", side_effect=failure),
             pytest.raises(YouTubeAPIError, match="playlistItems.insert failed"),
         ):
             uploader._execute_complete_collection(col, uploader.tracking_store.load(col), publish_at=None)

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -52,7 +52,7 @@ LEGACY_AGENT_OWNERS = {
         "CompleteCollectionMixin",
     ),
     "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearchMixin"),
-    "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignmentMixin"),
+    "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignment"),
     "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightMixin"),
     "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesScheduler"),
     "_tracking_io": ("youtube_automation.domains.uploads._tracking_io", "TrackingStore"),


### PR DESCRIPTION
## 概要

uploads mixin解体の次段として `PlaylistAssignmentMixin` を明示注入可能なplaylist assignment collaboratorへ置換します。

## 変更内容

- config / PlaylistManager / YouTubeClientsを注入する `PlaylistAssignment` collaboratorを追加
- CollectionUploaderとexecutorは `playlist_assignment.assign` へ委譲
- Mixin継承とstub host / module patchを除去し直接注入へ移行
- API失敗伝播と状態未確定の既存契約を維持
- 公開method集合を不変維持
- B4構造契約・CHANGELOGを更新

## 検証

- uploads広域: 535 passed
- full: 9,129 passed / 3 skipped
- latest main rebase後 focused: 140 passed
- ruff check / format check: green

Closes #3931
