### PR TITLE
refactor(collections): 制御面writerをowner経由へ移行する (#3877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。
 - `refactor(configuration)`: CLI の明示 channel 選択を公開 API として提供し、doctor から loader の private symbol への越境 import を解消する（#3921）。

--- a/src/youtube_automation/commands/collections/init_collection.py
+++ b/src/youtube_automation/commands/collections/init_collection.py
@@ -16,12 +16,13 @@ Example:
 """
 
 import argparse
-import json
 import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 # --- パス解決 ---
@@ -101,9 +102,7 @@ def main():
     # workflow-state.json 生成
     state = build_state(args.collection_name, args.theme, args.track_count, args.selected_plan, music_engine)
     state_path = base_path / "workflow-state.json"
-    with open(state_path, "w") as f:
-        json.dump(state, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    update_workflow_state(state_path, lambda _current: WorkflowState(state))
 
     print(f"[OK] コレクション作成完了: {base_path}")
     print(f"  テーマ: {args.theme}")

--- a/src/youtube_automation/commands/uploads/wf_batch.py
+++ b/src/youtube_automation/commands/uploads/wf_batch.py
@@ -43,17 +43,24 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import (
+    WorkflowState,
+)
+from youtube_automation.domains.collections.workflow_state import (
+    read as read_workflow_state,
+)
+from youtube_automation.domains.collections.workflow_state import (
+    update as update_workflow_state,
+)
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 # 02-Individual-music/ のダウンロード済み判定に使う音声拡張子（/wf-next Suno パスと同一）。
@@ -119,30 +126,13 @@ def _load_state(workflow_state_path: Path) -> dict:
         raise ValidationError(f"workflow-state.json が見つかりません: {workflow_state_path}")
 
     try:
-        state = json.loads(workflow_state_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as e:
-        raise ValidationError(f"workflow-state.json のパースに失敗: {e}") from e
-
-    if not isinstance(state, dict):
-        raise ValidationError("workflow-state.json の root は object である必要があります")
-    return state
-
-
-def _write_state(workflow_state_path: Path, state: dict) -> None:
-    """workflow-state.json を同一ディレクトリの一時ファイル + os.replace で原子的に更新する。"""
-    payload = json.dumps(state, ensure_ascii=False, indent=2) + "\n"
-    fd, tmp_name = tempfile.mkstemp(
-        dir=workflow_state_path.parent,
-        prefix=".workflow-state.",
-        suffix=".tmp",
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(payload)
-        os.replace(tmp_name, workflow_state_path)
-    except BaseException:
-        Path(tmp_name).unlink(missing_ok=True)
-        raise
+        return read_workflow_state(workflow_state_path).to_dict()
+    except WorkflowStateError as error:
+        if "root must be an object" in str(error):
+            raise ValidationError("workflow-state.json の root は object である必要があります") from error
+        if isinstance(error.__cause__, json.JSONDecodeError):
+            raise ValidationError(f"workflow-state.json のパースに失敗: {error.__cause__}") from error
+        raise ValidationError(str(error)) from error
 
 
 def _utc_now() -> str:
@@ -306,15 +296,26 @@ def _record_master_video(collection_dir: Path) -> str:
     video = paths.find_master_video()
     if video is None:
         raise ValidationError("01-master/ にマスター動画 (*.mp4) が生成されていません")
+    if not paths.workflow_state_path.is_file():
+        raise ValidationError(f"workflow-state.json が見つかりません: {paths.workflow_state_path}")
 
-    state = _load_state(paths.workflow_state_path)
-    assets = state.setdefault("assets", {})
-    if not isinstance(assets, dict):
-        raise ValidationError("workflow-state.json::assets は object である必要があります")
-    assets["master_video"] = video.name
-    state["phase"] = "publishing"
-    state["updated_at"] = _utc_now()
-    _write_state(paths.workflow_state_path, state)
+    def record_master_video(state: WorkflowState) -> None:
+        assets = state.assets
+        if assets is None:
+            state["assets"] = {}
+            assets = state.assets
+        if assets is None:
+            raise ValidationError("workflow-state.json::assets は object である必要があります")
+        assets.master_video = video.name
+        state.phase = "publishing"
+        state["updated_at"] = _utc_now()
+
+    try:
+        update_workflow_state(paths.workflow_state_path, record_master_video)
+    except WorkflowStateError as error:
+        if "workflow-state.json::assets must be an object" in str(error):
+            raise ValidationError("workflow-state.json::assets は object である必要があります") from error
+        raise ValidationError(str(error)) from error
     return video.name
 
 

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import now_in_schedule_tz
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     TRACKING_STATUS_COMPLETED,
     WORKFLOW_PHASE_COMPLETE,
@@ -81,29 +83,29 @@ class TrackingStore:
         if not path_exists(ws_path):
             return
 
-        state = json.loads(read_file_text(ws_path))
-        upload = state.get("upload", {})
-        if not isinstance(upload, dict):
-            raise ValidationError(f"workflow-state.json upload must be object: {ws_path}")
+        def record_upload(state: WorkflowState) -> None:
+            upload = state.upload
+            if upload is None:
+                state["upload"] = {}
+                upload = state.upload
+            if upload is None:
+                raise ValidationError(f"workflow-state.json upload must be object: {ws_path}")
+            upload.video_id = complete_video["video_id"]
+            upload.video_url = complete_video["video_url"]
+            upload.publish_at = publish_at
+            state["updated_at"] = now_in_schedule_tz(self.config).isoformat()
+            if collection_path.parent.name == WORKFLOW_STAGE_LIVE:
+                state.stage = WORKFLOW_STAGE_LIVE
+                state.phase = WORKFLOW_PHASE_COMPLETE
 
-        updated_upload = {
-            **upload,
-            "video_id": complete_video["video_id"],
-            "video_url": complete_video["video_url"],
-            "publish_at": publish_at,
-        }
-        updated_state = {
-            **state,
-            "upload": updated_upload,
-            "updated_at": now_in_schedule_tz(self.config).isoformat(),
-        }
-        if collection_path.parent.name == WORKFLOW_STAGE_LIVE:
-            updated_state = {
-                **updated_state,
-                "stage": WORKFLOW_STAGE_LIVE,
-                "phase": WORKFLOW_PHASE_COMPLETE,
-            }
-        write_file_text(ws_path, json.dumps(updated_state, indent=2, ensure_ascii=False))
+        try:
+            update_workflow_state(ws_path, record_upload)
+        except WorkflowStateError as error:
+            if isinstance(error.__cause__, json.JSONDecodeError):
+                raise error.__cause__ from error
+            if "workflow-state.json::upload must be an object" in str(error):
+                raise ValidationError(f"workflow-state.json upload must be object: {ws_path}") from error
+            raise ValidationError(str(error)) from error
 
     def initialize(self, collection_path: Path) -> dict:
         """tracking を初期化"""

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -1338,3 +1338,27 @@ class TestTrackingStoreAtomicity:
         assert corrupt_path.exists()
         assert corrupt_path.read_text(encoding="utf-8") == "{truncated"
         assert not tracking_path.exists()
+
+    def test_workflow_upload_preserves_update_committed_before_owner_callback(self, tmp_path, monkeypatch):
+        from youtube_automation.domains.collections.workflow_state import update as owner_update
+        from youtube_automation.domains.uploads import _tracking_io
+
+        col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
+        state_path = col / "workflow-state.json"
+        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
+
+        def update_after_concurrent_writer(path, updater):
+            owner_update(path, lambda state: state.__setitem__("concurrent_marker", "preserved"))
+            return owner_update(path, updater)
+
+        monkeypatch.setattr(_tracking_io, "update_workflow_state", update_after_concurrent_writer)
+
+        store.update_workflow_upload(
+            col,
+            {"video_id": "video-1", "video_url": "https://youtu.be/video-1"},
+            "2099-01-01T00:00:00Z",
+        )
+
+        persisted = json.loads(state_path.read_text(encoding="utf-8"))
+        assert persisted["concurrent_marker"] == "preserved"
+        assert persisted["upload"]["video_id"] == "video-1"

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -14,7 +14,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
     {
         "src/youtube_automation/commands/analytics/experiment_judge.py",
         "src/youtube_automation/commands/collections/collection_serve.py",
-        "src/youtube_automation/commands/collections/init_collection.py",
         "src/youtube_automation/commands/distrokid/distrokid_prepare.py",
         "src/youtube_automation/commands/media/apply_rain_layers.py",
         "src/youtube_automation/commands/media/check_raw_master.py",
@@ -24,7 +23,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/commands/metadata/metadata_audit.py",
         "src/youtube_automation/commands/system/progress_hook/workflow_state.py",
         "src/youtube_automation/commands/thumbnail/auto_select_thumbnail.py",
-        "src/youtube_automation/commands/uploads/wf_batch.py",
         "src/youtube_automation/commands/youtube/pinned_comment.py",
         "src/youtube_automation/domains/distrokid/preparation.py",
         "src/youtube_automation/domains/distrokid/release.py",
@@ -36,7 +34,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/domains/uploads/_complete_collection_strategy.py",
         "src/youtube_automation/domains/uploads/_playlist_assignment.py",
         "src/youtube_automation/domains/uploads/_preflight.py",
-        "src/youtube_automation/domains/uploads/_tracking_io.py",
         "src/youtube_automation/domains/uploads/collection.py",
         "src/youtube_automation/domains/uploads/playlists.py",
         "src/youtube_automation/domains/uploads/preflight.py",


### PR DESCRIPTION
## 概要

workflow-state owner移行の最初の実装段として、制御面writer 3箇所をlock付きatomic owner APIへ移します。

## 変更内容

- collection初期化、wf batch、uploads tracking writerをowner `update()` 経由へ移行
- lock + atomic replaceにより同時更新時のフィールド消失を防止
- `_tracking_io` の同時更新回帰テストを追加
- 直I/O ratchet allowlistを30から27ファイルへ縮小
- workflow-state形式と観測結果を維持
- CHANGELOGを更新

## 検証

- full: 9,130 passed / 3 skipped
- latest main rebase後 focused: 134 passed
- ruff check / format check: green

Closes #3877
