### PR TITLE
refactor(collections): 非atomic writerをowner経由へ移行する (#3878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。

--- a/src/youtube_automation/commands/media/apply_rain_layers.py
+++ b/src/youtube_automation/commands/media/apply_rain_layers.py
@@ -25,7 +25,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import shlex
 import shutil
 import subprocess
@@ -35,7 +34,9 @@ from typing import Any
 
 from youtube_automation.configuration import channel_dir
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.media.collection_paths import (
     CollectionPaths,
     resolve_collection_dir,
@@ -168,23 +169,25 @@ def _update_workflow_state_raw_master(workflow_state_path: Path, new_name: str) 
     if not workflow_state_path.is_file():
         return False
 
+    def record_raw_master(state: WorkflowState) -> None:
+        assets = state.assets
+        if assets is None:
+            state["assets"] = {}
+            assets = state.assets
+        if assets is None:
+            raise ValidationError("workflow-state.json::assets は object である必要があります")
+        assets.raw_master = new_name
+
     try:
-        state = json.loads(workflow_state_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as e:
-        raise ValidationError(f"workflow-state.json のパースに失敗: {e}") from e
-
-    if not isinstance(state, dict):
-        raise ValidationError("workflow-state.json の root は object である必要があります")
-
-    assets = state.setdefault("assets", {})
-    if not isinstance(assets, dict):
-        raise ValidationError("workflow-state.json::assets は object である必要があります")
-
-    assets["raw_master"] = new_name
-    workflow_state_path.write_text(
-        json.dumps(state, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
+        update_workflow_state(workflow_state_path, record_raw_master)
+    except WorkflowStateError as error:
+        if isinstance(error.__cause__, OSError):
+            raise error.__cause__ from error
+        if "root must be an object" in str(error):
+            raise ValidationError("workflow-state.json の root は object である必要があります") from error
+        if "workflow-state.json::assets must be an object" in str(error):
+            raise ValidationError("workflow-state.json::assets は object である必要があります") from error
+        raise ValidationError(f"workflow-state.json のパースに失敗: {error}") from error
     return True
 
 

--- a/src/youtube_automation/commands/media/populate_scene_phrases.py
+++ b/src/youtube_automation/commands/media/populate_scene_phrases.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.errors import AutomationError, ConfigError, ValidationError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
 logger = logging.getLogger(__name__)
@@ -185,7 +187,7 @@ def main(argv: list[str] | None = None) -> int:
         ws_path = col_path / "workflow-state.json"
         if not ws_path.exists():
             raise ConfigError(f"{ws_path} が存在しません")
-        state = json.loads(ws_path.read_text(encoding="utf-8"))
+        state = read_workflow_state(ws_path).to_dict()
 
         supported = list(config.localizations.supported_languages)
         if not requires_scene_phrases(supported):
@@ -226,11 +228,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\n--dry-run: {ws_path} には書き込みません")
             return 0
 
-        state["scene_phrases"] = scene_phrases
-        ws_path.write_text(
-            json.dumps(state, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
+        update_workflow_state(ws_path, lambda current: current.__setitem__("scene_phrases", scene_phrases))
         print(f"✅ {args.collection}: scene_phrases に {len(scene_phrases)} 言語を書き込みました")
         return 0
     except AutomationError as exc:

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -11,10 +11,8 @@ Features:
 
 import json
 import logging
-import os
 import re
 import subprocess
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
@@ -29,7 +27,10 @@ from youtube_automation.core.adapters.runtime import (
     format_duration_short,
     format_timestamp,
 )
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
 from youtube_automation.domains.metadata.descriptions import (
     build_complete_collection_description,
@@ -56,21 +57,13 @@ from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 logger = logging.getLogger(__name__)
 
 
-def _write_workflow_state(workflow_state_path: Path, state: Dict) -> None:
-    """workflow-state.json を同一ディレクトリの一時ファイル + os.replace で原子的に更新する。"""
-    payload = json.dumps(state, ensure_ascii=False, indent=2) + "\n"
-    fd, tmp_name = tempfile.mkstemp(
-        dir=workflow_state_path.parent,
-        prefix=".workflow-state.",
-        suffix=".tmp",
-    )
+def _read_workflow_state_lenient(workflow_state_path: Path) -> dict:
+    """既存の best-effort reader 用に owner の失敗を空 state へ変換する。"""
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(payload)
-        os.replace(tmp_name, workflow_state_path)
-    except BaseException:
-        Path(tmp_name).unlink(missing_ok=True)
-        raise
+        state = read_workflow_state_or_none(workflow_state_path)
+    except WorkflowStateError:
+        return {}
+    return state.to_dict() if state is not None else {}
 
 
 class BAHMetadataGenerator:
@@ -372,13 +365,7 @@ class BAHMetadataGenerator:
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
         result: Dict[str, str] = {}
-        if not ws_path.exists():
-            return result
-        try:
-            with open(ws_path, "r", encoding="utf-8") as f:
-                state = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return result
+        state = _read_workflow_state_lenient(ws_path)
         patterns = ((state.get("planning") or {}).get("music") or {}).get("patterns") or {}
         for letter, data in patterns.items():
             key = str(letter).lower()
@@ -486,13 +473,7 @@ class BAHMetadataGenerator:
         """
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
-        if not ws_path.exists():
-            return
-        try:
-            with open(ws_path, "r", encoding="utf-8") as f:
-                state = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return
+        state = _read_workflow_state_lenient(ws_path)
         name_map = state.get("track_display_names") or {}
         if not isinstance(name_map, dict) or not name_map:
             return
@@ -533,25 +514,25 @@ class BAHMetadataGenerator:
 
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
-        state: Dict = {}
-        if ws_path.exists():
-            # 読み失敗時に state={} で続行すると、下の書き込みで
-            # 既存 state 全体（phase / assets / upload 等）を消してしまうため fail-loud にする
-            try:
-                with open(ws_path, "r", encoding="utf-8") as f:
-                    state = json.load(f)
-            except json.JSONDecodeError as e:
-                raise ValidationError(f"workflow-state.json のパースに失敗: {e}") from e
-            except OSError as e:
-                raise ValidationError(f"workflow-state.json を読めません: {e}") from e
-            if not isinstance(state, dict):
-                raise ValidationError("workflow-state.json の root は object である必要があります")
-        existing = state.get("track_display_names") or {}
-        if not isinstance(existing, dict):
-            existing = {}
-        existing.update(filename_map)
-        state["track_display_names"] = existing
-        _write_workflow_state(ws_path, state)
+
+        def persist_display_names(state: WorkflowState) -> None:
+            existing = state.get("track_display_names") or {}
+            if not isinstance(existing, dict):
+                existing = {}
+            existing.update(filename_map)
+            state["track_display_names"] = existing
+
+        try:
+            update_workflow_state(ws_path, persist_display_names)
+        except WorkflowStateError as error:
+            cause = error.__cause__
+            if isinstance(cause, OSError) and "could not be written" in str(error):
+                raise cause from error
+            if "root must be an object" in str(error):
+                raise ValidationError("workflow-state.json の root は object である必要があります") from error
+            if isinstance(cause, json.JSONDecodeError):
+                raise ValidationError(f"workflow-state.json のパースに失敗: {cause}") from error
+            raise ValidationError(f"workflow-state.json を読めません: {error}") from error
 
     # ─── タイトル生成（2026リブランド） ─────────────────
 
@@ -562,16 +543,11 @@ class BAHMetadataGenerator:
         """
         paths = CollectionPaths(self.collection_path)
         workflow_state_path = paths.workflow_state_path
-        if workflow_state_path.exists():
-            try:
-                with open(workflow_state_path, "r", encoding="utf-8") as f:
-                    state = json.load(f)
-                if state.get("collection_name"):
-                    name = state["collection_name"]
-                    name = re.sub(r"\s+Collection$", "", name, flags=re.IGNORECASE)
-                    return name
-            except (json.JSONDecodeError, KeyError):
-                pass
+        state = _read_workflow_state_lenient(workflow_state_path)
+        if state.get("collection_name"):
+            name = state["collection_name"]
+            name = re.sub(r"\s+Collection$", "", name, flags=re.IGNORECASE)
+            return name
 
         name = self.collection_name
         name = re.sub(r"\s+Collection$", "", name, flags=re.IGNORECASE)
@@ -584,14 +560,9 @@ class BAHMetadataGenerator:
         """
         paths = CollectionPaths(self.collection_path)
         workflow_state_path = paths.workflow_state_path
-        if workflow_state_path.exists():
-            try:
-                with open(workflow_state_path, "r", encoding="utf-8") as f:
-                    state = json.load(f)
-                if state.get("title_activity"):
-                    return state["title_activity"]
-            except (json.JSONDecodeError, KeyError):
-                pass
+        state = _read_workflow_state_lenient(workflow_state_path)
+        if state.get("title_activity"):
+            return state["title_activity"]
 
         theme = self._extract_theme_name()
         return self.config.content.title.activity_for_theme(theme)
@@ -649,18 +620,19 @@ class BAHMetadataGenerator:
         """workflow-state.json を読み込む。存在しない場合は空 dict を返す。"""
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
-        if not ws_path.exists():
-            return {}
         try:
-            with open(ws_path, "r", encoding="utf-8") as f:
-                state = json.load(f)
-        except json.JSONDecodeError as exc:
-            raise ValidationError(f"workflow-state.json の JSON パースに失敗: {ws_path}: {exc}") from exc
-        except OSError as exc:
-            raise ValidationError(f"workflow-state.json を読み込めません: {ws_path}: {exc}") from exc
-        if not isinstance(state, dict):
-            raise ValidationError(f"workflow-state.json の root は object である必要があります: {ws_path}")
-        return state
+            state = read_workflow_state_or_none(ws_path)
+        except WorkflowStateError as error:
+            message = str(error)
+            if "root must be an object" in message:
+                raise ValidationError(
+                    f"workflow-state.json の root は object である必要があります: {ws_path}"
+                ) from error
+            for section in ("planning", "scene_phrases"):
+                if f"workflow-state.json::{section} must be an object" in message:
+                    raise ValidationError(f"workflow-state.json::{section} は object である必要があります") from error
+            raise ValidationError(f"workflow-state.json を読み込めません: {ws_path}: {error}") from error
+        return state.to_dict() if state is not None else {}
 
     def _load_scene_emoji(self) -> str:
         """workflow-state.json から planning.scene_emoji を読み込み"""
@@ -884,14 +856,8 @@ class BAHMetadataGenerator:
         """
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
-        if ws_path.exists():
-            try:
-                with open(ws_path, "r", encoding="utf-8") as f:
-                    state = json.load(f)
-                return state.get("theme", "") or ""
-            except (json.JSONDecodeError, KeyError):
-                pass
-        return ""
+        state = _read_workflow_state_lenient(ws_path)
+        return state.get("theme", "") or ""
 
     def generate_shorts_metadata(self, cc_video_url: str) -> Dict:
         """Shorts 用メタデータを生成する.

--- a/src/youtube_automation/domains/uploads/shorts.py
+++ b/src/youtube_automation/domains/uploads/shorts.py
@@ -11,10 +11,19 @@ from typing import Optional
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import get_schedule_timezone, now_in_schedule_tz
-from youtube_automation.core.errors import AutomationError, QuotaExhaustedError, UploadError, ValidationError
+from youtube_automation.core.errors import (
+    AutomationError,
+    QuotaExhaustedError,
+    UploadError,
+    ValidationError,
+    WorkflowStateError,
+)
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
-from youtube_automation.infrastructure.filesystem import list_directory, path_exists, read_json, write_json
+from youtube_automation.infrastructure.filesystem import list_directory, path_exists, read_json
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
@@ -120,9 +129,8 @@ class ShortUploader:
             ws_path = CollectionPaths(col_dir).workflow_state_path
             if not path_exists(ws_path):
                 continue
-            try:
-                state = read_json(ws_path)
-            except (json.JSONDecodeError, OSError):
+            state = self._load_workflow_state(ws_path)
+            if state is None:
                 continue
             shorts = (state.get("post_upload") or {}).get("shorts") or []
             for entry in shorts:
@@ -348,17 +356,11 @@ class ShortUploader:
         if not path_exists(ws_path):
             return None
         try:
-            return read_json(ws_path)
-        except (json.JSONDecodeError, OSError) as e:
+            state = read_workflow_state_or_none(ws_path)
+            return state.to_dict() if state is not None else None
+        except WorkflowStateError as e:
             logger.warning(f"workflow-state.json 読み込み失敗: {e}")
             return None
-
-    def _save_workflow_state(self, ws_path: Path, state: dict) -> None:
-        """workflow-state.json を書き戻す。失敗時は warning のみ（致命的にしない）。"""
-        try:
-            write_json(ws_path, state)
-        except OSError as e:
-            logger.warning(f"workflow-state.json 書き込み失敗: {e}")
 
     @staticmethod
     def _find_short_entry(shorts: list, short_num: Optional[int]) -> Optional[dict]:
@@ -390,27 +392,30 @@ class ShortUploader:
         if not path_exists(ws_path):
             logger.warning(f"workflow-state.json が無いため resume URI 永続化を skip: {ws_path}")
             return
-        state = self._load_workflow_state(ws_path)
-        if state is None:
-            return
 
-        post_upload = state.setdefault("post_upload", {})
-        shorts = post_upload.get("shorts")
-        if not isinstance(shorts, list):
-            shorts = []
-            post_upload["shorts"] = shorts
+        def persist_resume_uri(state: WorkflowState) -> None:
+            post_upload = state.get("post_upload") or {}
+            if not isinstance(post_upload, dict):
+                post_upload = {}
+            shorts = post_upload.get("shorts")
+            if not isinstance(shorts, list):
+                shorts = []
+                post_upload["shorts"] = shorts
 
-        entry = self._find_short_entry(shorts, short_num)
-        if entry is None:
-            entry = {"short_num": short_num}
-            shorts.append(entry)
+            entry = self._find_short_entry(shorts, short_num)
+            if entry is None:
+                entry = {"short_num": short_num}
+                shorts.append(entry)
+            if uri is None:
+                entry.pop("resume_session_uri", None)
+            else:
+                entry["resume_session_uri"] = uri
+            state["post_upload"] = post_upload
 
-        if uri is None:
-            entry.pop("resume_session_uri", None)
-        else:
-            entry["resume_session_uri"] = uri
-
-        self._save_workflow_state(ws_path, state)
+        try:
+            update_workflow_state(ws_path, persist_resume_uri)
+        except WorkflowStateError as error:
+            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
 
     # ─── workflow-state 更新 (plan アンチパターン #10) ─
 
@@ -433,16 +438,6 @@ class ShortUploader:
             logger.warning(f"workflow-state.json が無いため short upload 記録を skip: {ws_path}")
             return
 
-        state = self._load_workflow_state(ws_path)
-        if state is None:
-            return
-
-        post_upload = state.setdefault("post_upload", {})
-        shorts = post_upload.get("shorts")
-        if not isinstance(shorts, list):
-            shorts = []
-            post_upload["shorts"] = shorts
-
         entry = {
             "short_num": short_num,
             "video_id": video_id,
@@ -450,14 +445,26 @@ class ShortUploader:
             "publish_at": publish_at,
         }
 
-        for i, existing in enumerate(shorts):
-            if existing.get("short_num") == short_num:
-                shorts[i] = entry
-                break
-        else:
-            shorts.append(entry)
+        def record_uploaded_short(state: WorkflowState) -> None:
+            post_upload = state.get("post_upload") or {}
+            if not isinstance(post_upload, dict):
+                post_upload = {}
+            shorts = post_upload.get("shorts")
+            if not isinstance(shorts, list):
+                shorts = []
+                post_upload["shorts"] = shorts
+            for index, existing in enumerate(shorts):
+                if existing.get("short_num") == short_num:
+                    shorts[index] = entry
+                    break
+            else:
+                shorts.append(entry)
+            state["post_upload"] = post_upload
 
-        self._save_workflow_state(ws_path, state)
+        try:
+            update_workflow_state(ws_path, record_uploaded_short)
+        except WorkflowStateError as error:
+            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
 
     # ─── ドライラン ──────────────────────────────────
 

--- a/tests/commands/media/test_apply_rain_layers.py
+++ b/tests/commands/media/test_apply_rain_layers.py
@@ -471,7 +471,12 @@ class TestApplyRainLayersRun:
         collection = _setup_collection(tmp_path, n_rain=1)
         wf = collection / "workflow-state.json"
         wf.write_text(
-            json.dumps({"assets": {"raw_master": "master.mp3", "master_audio": None}}),
+            json.dumps(
+                {
+                    "assets": {"raw_master": "master.mp3", "master_audio": None},
+                    "future_section": {"keep": True},
+                }
+            ),
             encoding="utf-8",
         )
         monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/ffmpeg")
@@ -487,6 +492,7 @@ class TestApplyRainLayersRun:
         state = json.loads(wf.read_text(encoding="utf-8"))
         assert state["assets"]["raw_master"] == "master-rain.wav"
         assert state["assets"]["master_audio"] is None  # 他フィールドは触らない
+        assert state["future_section"] == {"keep": True}
 
     def test_workflow_state_missing_is_not_fatal(self, tmp_path, monkeypatch):
         # Given: workflow-state.json が存在しない (古いコレクション or 別レイアウト)

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -306,7 +306,7 @@ class TestMainCLI:
         ch = _setup_channel(
             tmp_path,
             supported_languages=["en", "ja", "ko"],
-            workflow_state={"theme": "city"},
+            workflow_state={"theme": "city", "future_section": {"keep": True}},
         )
         monkeypatch.setenv("CHANNEL_DIR", str(ch))
 
@@ -326,6 +326,7 @@ class TestMainCLI:
         assert ws["scene_phrases"]["en"] == "Late-night neon city, jazz between rain and streetlights"
         assert ws["scene_phrases"]["ja"] == "深夜のネオン街"
         assert ws["scene_phrases"]["ko"] == "심야 네온"
+        assert ws["future_section"] == {"keep": True}
 
     def test_writes_translated_phrases_from_file(self, tmp_path, monkeypatch):
         ch = _setup_channel(

--- a/tests/domains/metadata/test_metadata_generator.py
+++ b/tests/domains/metadata/test_metadata_generator.py
@@ -1464,7 +1464,10 @@ class TestApplyTrackDisplayNames:
         gen = _make_generator()
         gen.collection_path = tmp_path
         ws_path = tmp_path / "workflow-state.json"
-        ws_path.write_text(_json.dumps({"collection_name": "Test"}), encoding="utf-8")
+        ws_path.write_text(
+            _json.dumps({"collection_name": "Test", "future_section": {"keep": True}}),
+            encoding="utf-8",
+        )
 
         gen.tracks = [
             _track("01-pattern-a-foo.mp3", "Original A", "00:00", "a"),
@@ -1480,6 +1483,7 @@ class TestApplyTrackDisplayNames:
         assert state["track_display_names"]["02-pattern-b-bar.mp3"] == "Focused Pulse"
         # 既存キーが壊れない
         assert state["collection_name"] == "Test"
+        assert state["future_section"] == {"keep": True}
 
     def test_loads_persisted_names_in_analyze(self, tmp_path, monkeypatch):
         """workflow-state.json の track_display_names が次回ロード時に適用される."""
@@ -1572,7 +1576,7 @@ class TestApplyTrackDisplayNames:
 
         # 元ファイルが無傷で、一時ファイルの残骸も無いこと
         assert ws_path.read_text(encoding="utf-8") == original
-        assert sorted(p.name for p in tmp_path.iterdir()) == ["workflow-state.json"]
+        assert list(tmp_path.glob(".workflow-state.*.tmp")) == []
 
 
 # ===========================================================================

--- a/tests/domains/uploads/test_short_uploader.py
+++ b/tests/domains/uploads/test_short_uploader.py
@@ -811,6 +811,10 @@ class TestUpdateWorkflowState:
         """初回書き込みで `post_upload.shorts = [{...}]` の list を作る."""
         # Given: workflow-state.json が空
         col = _setup_collection(tmp_path)
+        ws_path = col / "workflow-state.json"
+        state = json.loads(ws_path.read_text(encoding="utf-8"))
+        state["future_section"] = {"keep": True}
+        ws_path.write_text(json.dumps(state), encoding="utf-8")
         with _make_short_uploader() as (uploader, _):
             # When
             uploader._update_workflow_state(
@@ -827,6 +831,7 @@ class TestUpdateWorkflowState:
         assert len(shorts) == 1
         assert shorts[0]["short_num"] == 1
         assert shorts[0]["video_id"] == "V1"
+        assert ws["future_section"] == {"keep": True}
 
     def test_uploaded_at_is_schedule_timezone_aware(self, tmp_path):
         """uploaded_at は schedule timezone 付き ISO 8601 で書かれる."""

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -15,10 +15,8 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/commands/analytics/experiment_judge.py",
         "src/youtube_automation/commands/collections/collection_serve.py",
         "src/youtube_automation/commands/distrokid/distrokid_prepare.py",
-        "src/youtube_automation/commands/media/apply_rain_layers.py",
         "src/youtube_automation/commands/media/check_raw_master.py",
         "src/youtube_automation/commands/media/generate_videos_batch.py",
-        "src/youtube_automation/commands/media/populate_scene_phrases.py",
         "src/youtube_automation/commands/metadata/bulk_update_short_localizations.py",
         "src/youtube_automation/commands/metadata/metadata_audit.py",
         "src/youtube_automation/commands/system/progress_hook/workflow_state.py",
@@ -26,7 +24,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/commands/youtube/pinned_comment.py",
         "src/youtube_automation/domains/distrokid/preparation.py",
         "src/youtube_automation/domains/distrokid/release.py",
-        "src/youtube_automation/domains/metadata/service.py",
         "src/youtube_automation/domains/suno/downloaded/apply.py",
         "src/youtube_automation/domains/suno/downloaded/workflow.py",
         "src/youtube_automation/domains/suno/prompt_resolution.py",
@@ -37,7 +34,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/domains/uploads/collection.py",
         "src/youtube_automation/domains/uploads/playlists.py",
         "src/youtube_automation/domains/uploads/preflight.py",
-        "src/youtube_automation/domains/uploads/shorts.py",
         "src/youtube_automation/infrastructure/analytics/workflow_timing.py",
     }
 )


### PR DESCRIPTION
## 概要

workflow-state owner移行を進め、非atomicだった4 writerをlock付きatomic owner APIへ置換します。

## 変更内容

- 4つの非atomic writerをowner `update()` 経由へ移行
- 同時更新時のfield消失を防止
- 未知fieldと既存の警告・エラー観測を維持
- 直I/O ratchet allowlistを4ファイル縮小
- CHANGELOGを更新

## 検証

- focused: 339 passed
- full: 9,173 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3878
