### PR TITLE
refactor(uploads): 重複検索をヘルパへ委譲する (#3932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
+- `refactor(uploads)`: `DedupSearchMixin` を YouTube service を明示注入する重複検索 helper へ置換し、完全一致・ghost 除外・quota 記録・fail-open 契約を維持する（#3932）。
 - `refactor(uploads)`: `PlaylistAssignmentMixin` を YouTube clients を明示注入する playlist 割り当てコラボレータへ置換し、割り当て失敗を状態確定前に伝播する契約を維持する（#3931）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。
 - `refactor(uploads)`: `PublishedDatesMixin` を設定と YouTube service provider を明示注入する公開日計算コラボレータへ置換し、cadence・週次マップと uploader の公開 interface を維持する（#3930）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -1,8 +1,7 @@
 """Complete Collection 動画アップロード経路。
 
 ``YouTubeAutoUploader`` から分離した mixin。挙動は分割前と同一で、
-``self.upload_video`` / ``self._find_existing_video_by_title``
-は合成先クラス（本体 + 他 mixin）が提供する。
+``self.upload_video`` / ``self.dedup_search`` は合成先クラスが提供する。
 """
 
 from __future__ import annotations
@@ -146,7 +145,7 @@ class CompleteCollectionMixin:
 
         # publish 直前の dedup 安全網: 同タイトル動画が own channel に既に存在すれば
         # `videos().insert()` を呼ばず既存 video_id を採用する
-        existing = self._find_existing_video_by_title(metadata["title"])
+        existing = self.dedup_search.find_existing_video_by_title(metadata["title"])
         if existing:
             logger.info(f"⚠️  既存動画を検出（upload skip）: {existing['video_url']}")
             return {

--- a/src/youtube_automation/domains/uploads/_dedup_search.py
+++ b/src/youtube_automation/domains/uploads/_dedup_search.py
@@ -1,9 +1,4 @@
-"""publish 直前の dedup 安全網（同タイトル動画の既存検出）。
-
-``YouTubeAutoUploader`` から分離した mixin。挙動は分割前と同一で、
-``self.youtube`` / ``self._ensure_service`` は合成先（``YouTubeUploadCore`` 継承クラス）
-が提供する。
-"""
+"""publish 直前の dedup 安全網（同タイトル動画の既存検出）。"""
 
 from __future__ import annotations
 
@@ -27,10 +22,13 @@ _VIDEOS_LIST_UNITS = 1
 _QUOTA_CONTEXT = "upload_dedup_search"
 
 
-class DedupSearchMixin:
-    """own channel 内の同タイトル動画検出ロジックを提供する mixin。"""
+class DedupSearch:
+    """注入された YouTube service で同タイトル動画を検索する。"""
 
-    def _find_existing_video_by_title(self, title: str) -> Optional[Dict[str, str]]:
+    def __init__(self, youtube):
+        self.youtube = youtube
+
+    def find_existing_video_by_title(self, title: str) -> Optional[Dict[str, str]]:
         """own channel 内に同タイトル（完全一致）の動画があれば video_id / video_url を返す。
 
         publish 直前の dedup 安全網。session URI 持ち越し（一次対策）が破れた場合の
@@ -43,7 +41,6 @@ class DedupSearchMixin:
         Returns:
             hit: `{"video_id": ..., "video_url": ...}` / miss: None / 検索エラー: None（fail-open）
         """
-        self._ensure_service()
         try:
             search_request = self.youtube.search().list(
                 forMine=True, type="video", q=title, maxResults=10, part="snippet"
@@ -93,7 +90,7 @@ class DedupSearchMixin:
     @staticmethod
     def _first_reusable_video(videos: list[dict], title: str) -> Optional[Dict[str, str]]:
         for video in videos:
-            if not DedupSearchMixin._is_reusable_exact_title_video(video, title):
+            if not DedupSearch._is_reusable_exact_title_video(video, title):
                 continue
             video_id = video.get("id")
             if not isinstance(video_id, str):

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -18,7 +18,7 @@ from youtube_automation.core.errors import (
 )
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._complete_collection_strategy import CompleteCollectionMixin
-from youtube_automation.domains.uploads._dedup_search import DedupSearchMixin
+from youtube_automation.domains.uploads._dedup_search import DedupSearch
 from youtube_automation.domains.uploads._preflight import PreflightMixin
 from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
@@ -236,7 +236,6 @@ __all__ = [
 
 class YouTubeAutoUploader(
     CompleteCollectionMixin,
-    DedupSearchMixin,
     PreflightMixin,
     ResumableUploader,
 ):
@@ -244,10 +243,15 @@ class YouTubeAutoUploader(
 
     YouTubeUploadCore を継承し、コレクション単位のアップロード機能を提供する。
     コアのアップロード・サムネイル・リトライロジックは YouTubeUploadCore に委譲。
-    責務別のロジック（dedup / preflight / CC 経路）は mixin に分離。
+    責務別のロジック（dedup collaborator / preflight / CC 経路）へ委譲する。
     """
 
-    def __init__(self, collections_root: Optional[str] = None, youtube_clients: YouTubeClients | None = None):
+    def __init__(
+        self,
+        collections_root: Optional[str] = None,
+        youtube_clients: YouTubeClients | None = None,
+        dedup_search: DedupSearch | None = None,
+    ) -> None:
         """
         初期化
 
@@ -260,7 +264,16 @@ class YouTubeAutoUploader(
             collections_root = channel_dir() / "collections"
 
         self.collections_root = Path(collections_root)
+        self._dedup_search = dedup_search
         self._verified_authenticated_channel_id: str | None = None
+
+    @property
+    def dedup_search(self) -> DedupSearch:
+        """注入済み helper、または認証後に生成した既定 helper を返す。"""
+        if self._dedup_search is None:
+            self._ensure_service()
+            self._dedup_search = DedupSearch(self.youtube)
+        return self._dedup_search
 
     def _verify_authenticated_upload_channel(self) -> None:
         """OAuth の実チャンネルを config と照合し、同一実行内で結果を保持する。"""

--- a/tests/domains/uploads/test_dedup_search.py
+++ b/tests/domains/uploads/test_dedup_search.py
@@ -1,0 +1,20 @@
+"""重複検索 helper の単体契約。"""
+
+from unittest.mock import MagicMock
+
+from youtube_automation.domains.uploads._dedup_search import DedupSearch
+
+
+def test_search_helper_uses_injected_youtube_service() -> None:
+    youtube = MagicMock()
+    youtube.search.return_value.list.return_value.execute.return_value = {"items": []}
+
+    assert DedupSearch(youtube).find_existing_video_by_title("Rainy Jazz") is None
+
+    youtube.search.return_value.list.assert_called_once_with(
+        forMine=True,
+        type="video",
+        q="Rainy Jazz",
+        maxResults=10,
+        part="snippet",
+    )

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -7,7 +7,7 @@ issue #381 (P0-5) で追加される以下の振る舞いを検証する:
 1. resume kwargs (`resume_session_uri`, `on_session_uri_changed`, `on_upload_complete`)
    が `upload_video` / `upload_collection` / `_upload_complete_collection` を透過して
    `YouTubeUploadCore.upload_video` まで届くこと
-2. `_find_existing_video_by_title` が own channel 内の同タイトル動画を検出すること
+2. `DedupSearch` が own channel 内の同タイトル動画を検出すること
    （fail-open: HttpError 時は None を返して upload 続行を許す）
 3. `_upload_complete_collection` が publish 直前に dedup 検索を実行し、hit 時は
    `upload_video` を呼ばずに既存 video_id / video_url を採用すること
@@ -695,7 +695,7 @@ class TestUploadCollectionForwarding:
         assets_dir.mkdir()
         (assets_dir / "thumbnail.jpg").write_bytes(b"\x00")
 
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path), dedup_search=MagicMock())
         on_session = MagicMock()
         on_complete = MagicMock()
 
@@ -703,7 +703,7 @@ class TestUploadCollectionForwarding:
         mock_gen.generate_complete_collection_metadata.return_value = _make_metadata()
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="VID_INNER") as mock_upload_video,
         ):
             # When
@@ -724,7 +724,7 @@ class TestUploadCollectionForwarding:
 
 
 # ---------------------------------------------------------------------------
-# L3b: `_find_existing_video_by_title` 単体検証
+# L3b: `DedupSearch.find_existing_video_by_title` 単体検証
 # ---------------------------------------------------------------------------
 
 
@@ -732,13 +732,10 @@ class TestFindExistingVideoByTitle:
     """publish 直前の同タイトル検索（dedup 安全網）の振る舞い."""
 
     def _make_uploader_with_mock_youtube(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
         mock_youtube = MagicMock()
-        # _ensure_service / initialize を bypass
-        uploader.youtube = mock_youtube
-        return uploader, mock_youtube
+        return DedupSearch(mock_youtube), mock_youtube
 
     def test_should_return_video_info_when_exact_title_match_exists(self, tmp_path):
         """plan 要件 #8 + #9: 完全一致 hit で video_id / video_url を返す."""
@@ -756,7 +753,7 @@ class TestFindExistingVideoByTitle:
         }
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result == {
@@ -780,7 +777,7 @@ class TestFindExistingVideoByTitle:
         }
 
         # When
-        uploader._find_existing_video_by_title("Rainy Jazz")
+        uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         mock_youtube.videos.return_value.list.assert_called_once_with(id="v9", part="status,snippet")
@@ -797,7 +794,7 @@ class TestFindExistingVideoByTitle:
         mock_youtube.videos.return_value.list.return_value.execute.return_value = {"items": []}
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -818,7 +815,7 @@ class TestFindExistingVideoByTitle:
         }
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -839,7 +836,7 @@ class TestFindExistingVideoByTitle:
         }
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -851,7 +848,7 @@ class TestFindExistingVideoByTitle:
         mock_youtube.search.return_value.list.return_value.execute.return_value = {"items": []}
 
         # When
-        uploader._find_existing_video_by_title("Rainy Jazz")
+        uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         mock_youtube.search.return_value.list.assert_called_once()
@@ -873,7 +870,7 @@ class TestFindExistingVideoByTitle:
         }
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -895,7 +892,7 @@ class TestFindExistingVideoByTitle:
             ]
         }
 
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result == {
             "video_id": "v9",
@@ -912,7 +909,7 @@ class TestFindExistingVideoByTitle:
             ]
         }
 
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
         mock_youtube.videos.return_value.list.assert_not_called()
@@ -924,7 +921,7 @@ class TestFindExistingVideoByTitle:
         mock_youtube.search.return_value.list.return_value.execute.return_value = {"items": []}
 
         # When
-        result = uploader._find_existing_video_by_title("Rainy Jazz")
+        result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -937,7 +934,7 @@ class TestFindExistingVideoByTitle:
 
         # When
         with caplog.at_level(logging.WARNING):
-            result = uploader._find_existing_video_by_title("Rainy Jazz")
+            result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         # Then
         assert result is None
@@ -951,15 +948,13 @@ class TestFindExistingVideoByTitle:
 
 
 class TestDedupSearchQuotaRecording:
-    """`_find_existing_video_by_title` が実 request ごとに quota を記録すること."""
+    """重複検索 helper が実 request ごとに quota を記録すること."""
 
     def _make_uploader_with_mock_youtube(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
         mock_youtube = MagicMock()
-        uploader.youtube = mock_youtube
-        return uploader, mock_youtube
+        return DedupSearch(mock_youtube), mock_youtube
 
     def _quota_calls(self, mock_log_quota) -> list[tuple[str, str, float]]:
         return [(c.args[0], c.args[1], c.args[2]) for c in mock_log_quota.call_args_list]
@@ -975,7 +970,7 @@ class TestDedupSearchQuotaRecording:
         }
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            result = uploader._find_existing_video_by_title("Rainy Jazz")
+            result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result is not None
         assert self._quota_calls(mock_log_quota) == [
@@ -989,7 +984,7 @@ class TestDedupSearchQuotaRecording:
         mock_youtube.search.return_value.list.return_value.execute.return_value = {"items": []}
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            result = uploader._find_existing_video_by_title("Rainy Jazz")
+            result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
         assert self._quota_calls(mock_log_quota) == [("youtube-data-api", "search.list", 1)]
@@ -1004,7 +999,7 @@ class TestDedupSearchQuotaRecording:
             patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota,
             caplog.at_level(logging.WARNING),
         ):
-            result = uploader._find_existing_video_by_title("Rainy Jazz")
+            result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
         assert self._quota_calls(mock_log_quota) == [
@@ -1026,7 +1021,7 @@ class TestDedupSearchQuotaRecording:
             patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota,
             caplog.at_level(logging.WARNING),
         ):
-            result = uploader._find_existing_video_by_title("Rainy Jazz")
+            result = uploader.find_existing_video_by_title("Rainy Jazz")
 
         assert result is None
         assert self._quota_calls(mock_log_quota) == [
@@ -1047,7 +1042,7 @@ class TestDedupSearchQuotaRecording:
         ]
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            assert uploader._find_existing_video_by_title("Rainy Jazz") is None
+            assert uploader.find_existing_video_by_title("Rainy Jazz") is None
 
         assert request.execute.call_count == 2
         assert self._quota_calls(mock_log_quota) == [
@@ -1068,7 +1063,7 @@ class TestDedupSearchQuotaRecording:
         ]
 
         with patch("youtube_automation.infrastructure.quota.log_quota") as mock_log_quota:
-            assert uploader._find_existing_video_by_title("Rainy Jazz") == {
+            assert uploader.find_existing_video_by_title("Rainy Jazz") == {
                 "video_id": "v9",
                 "video_url": "https://www.youtube.com/watch?v=v9",
             }
@@ -1100,7 +1095,7 @@ class TestUploadCompleteCollectionDedup:
         assets_dir.mkdir()
         (assets_dir / "thumbnail.jpg").write_bytes(b"\x00")
 
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path), dedup_search=MagicMock())
         mock_gen = MagicMock()
         mock_gen.generate_complete_collection_metadata.return_value = _make_metadata("Rainy Jazz")
         return uploader, col_dir, mock_gen
@@ -1112,7 +1107,7 @@ class TestUploadCompleteCollectionDedup:
         existing = {"video_id": "v9", "video_url": "https://www.youtube.com/watch?v=v9"}
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=existing),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=existing),
             patch.object(uploader, "upload_video", return_value="SHOULD_NOT_BE_CALLED") as mock_upload_video,
         ):
             # When
@@ -1133,7 +1128,7 @@ class TestUploadCompleteCollectionDedup:
         uploader, col_dir, mock_gen = self._setup(tmp_path)
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="VID_NEW") as mock_upload_video,
         ):
             # When
@@ -1155,7 +1150,7 @@ class TestUploadCompleteCollectionDedup:
         )
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="VID") as upload,
         ):
             uploader._upload_complete_collection(col_dir, mock_gen)
@@ -1170,7 +1165,7 @@ class TestUploadCompleteCollectionDedup:
         master.write_bytes(b"master")
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="VID") as upload,
         ):
             uploader._upload_complete_collection(col_dir, mock_gen)
@@ -1236,10 +1231,10 @@ class TestUploadCompleteCollectionDedup:
         monkeypatch.setattr(_subprocess, "run", mock_subprocess_run)
         monkeypatch.setattr(metadata_generator_module, "probe_duration", fake_probe_duration)
 
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path), dedup_search=MagicMock())
         metadata_gen = BAHMetadataGenerator(str(col_dir))
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="VID_NEW") as mock_upload_video,
         ):
             result = uploader._upload_complete_collection(col_dir, metadata_gen, publish_at=None)
@@ -1262,7 +1257,7 @@ class TestUploadCompleteCollectionDedup:
         (col_dir / "10-assets" / "main.png").write_bytes(b"textless-background")
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=None),
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
             patch.object(uploader, "upload_video", return_value="SHOULD_NOT_BE_CALLED") as mock_upload_video,
             pytest.raises(ValidationError, match="アップロード用サムネイルが見つかりません"),
         ):
@@ -1280,7 +1275,9 @@ class TestUploadCompleteCollectionDedup:
         existing = {"video_id": "v9", "video_url": "https://www.youtube.com/watch?v=v9"}
 
         with (
-            patch.object(uploader, "_find_existing_video_by_title", return_value=existing) as mock_find_existing,
+            patch.object(
+                uploader.dedup_search, "find_existing_video_by_title", return_value=existing
+            ) as mock_find_existing,
             patch.object(uploader, "upload_video", return_value="SHOULD_NOT_BE_CALLED") as mock_upload_video,
             pytest.raises(ValidationError, match="アップロード用サムネイルが見つかりません"),
         ):
@@ -1294,11 +1291,14 @@ class TestUploadCompleteCollectionDedup:
         # Given
         uploader, col_dir, mock_gen = self._setup(tmp_path)
 
-        # 実 youtube.search を HttpError で失敗させ、`_find_existing_video_by_title`
+        # 実 youtube.search を HttpError で失敗させ、helper の重複検索
         # の fail-open 経路（HttpError → warning + None 返却）を実コードで通す
         mock_youtube = MagicMock()
         mock_youtube.search.return_value.list.return_value.execute.side_effect = _make_http_error(500)
         uploader.youtube = mock_youtube
+        from youtube_automation.domains.uploads._dedup_search import DedupSearch
+
+        uploader._dedup_search = DedupSearch(mock_youtube)
 
         with (
             patch.object(uploader, "upload_video", return_value="VID_AFTER_FAILOPEN") as mock_upload_video,
@@ -1694,24 +1694,22 @@ class TestNormalizePublishAt:
     [{"snippet": {"title": "Rainy Jazz"}}, {"id": {"videoId": "v9"}}],
 )
 def test_dedup_fails_open_for_invalid_search_response_shape(tmp_path, search_item):
-    from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+    from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-    uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
-    uploader.youtube = MagicMock()
+    uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {"items": [search_item]}
 
-    assert uploader._find_existing_video_by_title("Rainy Jazz") is None
+    assert uploader.find_existing_video_by_title("Rainy Jazz") is None
 
 
 @pytest.mark.parametrize("response", [None, {"items": None}, {"items": {}}])
 def test_dedup_fails_open_for_invalid_search_response_container(tmp_path, response):
-    from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+    from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-    uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
-    uploader.youtube = MagicMock()
+    uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = response
 
-    assert uploader._find_existing_video_by_title("Rainy Jazz") is None
+    assert uploader.find_existing_video_by_title("Rainy Jazz") is None
 
 
 @pytest.mark.parametrize(
@@ -1723,27 +1721,25 @@ def test_dedup_fails_open_for_invalid_search_response_container(tmp_path, respon
     ],
 )
 def test_dedup_fails_open_for_invalid_video_response_shape(tmp_path, video_item):
-    from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+    from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-    uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
-    uploader.youtube = MagicMock()
+    uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {
         "items": [{"id": {"videoId": "v9"}, "snippet": {"title": "Rainy Jazz"}}]
     }
     uploader.youtube.videos.return_value.list.return_value.execute.return_value = {"items": [video_item]}
 
-    assert uploader._find_existing_video_by_title("Rainy Jazz") is None
+    assert uploader.find_existing_video_by_title("Rainy Jazz") is None
 
 
 @pytest.mark.parametrize("response", [None, {"items": None}, {"items": {}}])
 def test_dedup_fails_open_for_invalid_video_response_container(tmp_path, response):
-    from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+    from youtube_automation.domains.uploads._dedup_search import DedupSearch
 
-    uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
-    uploader.youtube = MagicMock()
+    uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {
         "items": [{"id": {"videoId": "v9"}, "snippet": {"title": "Rainy Jazz"}}]
     }
     uploader.youtube.videos.return_value.list.return_value.execute.return_value = response
 
-    assert uploader._find_existing_video_by_title("Rainy Jazz") is None
+    assert uploader.find_existing_video_by_title("Rainy Jazz") is None

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -51,7 +51,7 @@ LEGACY_AGENT_OWNERS = {
         "youtube_automation.domains.uploads._complete_collection_strategy",
         "CompleteCollectionMixin",
     ),
-    "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearchMixin"),
+    "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearch"),
     "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignment"),
     "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightMixin"),
     "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesScheduler"),


### PR DESCRIPTION
## 概要

uploads mixin解体を進め、`DedupSearchMixin` をYouTube service明示注入のhelperへ置換します。

## 変更内容

- `DedupSearch` helperを追加しYouTube serviceを明示注入
- YouTubeAutoUploaderはcollaboratorを保持し、defaultはservice確立後にlazy作成
- CompleteCollection strategyをhelper委譲へ変更
- 完全一致、ghost除外、videos.list再検証、retry単位quota、fail-openのテストをhelper直接入力へ移行
- 公開11メソッドを不変維持
- B4 owner契約・CHANGELOGを更新

## 検証

- focused: 76 passed
- uploads / B4 broad: 480 passed
- full: 9,173 passed / 3 skipped
- ruff check / format check: green

Closes #3932
