### PR TITLE
refactor(collections): Suno更新をowner経由へ移行する (#3879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(collections)`: collection server と Suno downloaded の `workflow-state` 読み書きを owner API へ移し、downloaded 更新を lock + atomic update に統一する（#3879）。
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -53,7 +53,8 @@ from youtube_automation.commands.collections.collection_serve_discovery import (
     handle_registry_request,
 )
 from youtube_automation.configuration import Distrokid, channel_dir, load_config
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.distrokid.metadata import parse_album_metadata
 from youtube_automation.domains.distrokid.release import (
     DISTROKID_ASSETS_PREFIX,
@@ -373,6 +374,15 @@ def find_collection_dirs(root: Path) -> list[Path]:
     return sorted(dirs, key=lambda p: p.name)
 
 
+def _read_workflow_state_lenient(path: Path) -> dict:
+    """配信一覧の fail-open 契約に合わせ、読めない state を空として扱う。"""
+    try:
+        state = read_workflow_state_or_none(path)
+    except WorkflowStateError:
+        return {}
+    return state.to_dict() if state is not None else {}
+
+
 def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
     """planning の対応する live collection が完了済みなら True を返す（#2331）。
 
@@ -383,13 +393,7 @@ def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
     if root.name != "planning" or root.parent.name != "collections":
         return False
     workflow_state = root.parent / "live" / collection_id / "workflow-state.json"
-    if not workflow_state.is_file():
-        return False
-    try:
-        data = json.loads(workflow_state.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return False
-    return isinstance(data, dict) and data.get("phase") == "complete"
+    return _read_workflow_state_lenient(workflow_state).get("phase") == "complete"
 
 
 def _find_suno_collection_dirs(root: Path) -> list[Path]:
@@ -420,14 +424,7 @@ def _determine_status(
 def _read_music_downloaded_flag(coll_dir: Path) -> bool:
     """workflow-state.json の assets.music_downloaded を読む（#1913 部分完了の貫通契約）."""
     ws_path = CollectionPaths(coll_dir).workflow_state_path
-    if not ws_path.is_file():
-        return False
-    try:
-        data = json.loads(ws_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return False
-    if not isinstance(data, dict):
-        return False
+    data = _read_workflow_state_lenient(ws_path)
     assets = data.get("assets")
     if not isinstance(assets, dict):
         return False
@@ -437,14 +434,7 @@ def _read_music_downloaded_flag(coll_dir: Path) -> bool:
 def _read_music_expected_file_count(coll_dir: Path) -> int | None:
     """workflow-state.json から full playlist download の期待ファイル数を読む."""
     ws_path = CollectionPaths(coll_dir).workflow_state_path
-    if not ws_path.is_file():
-        return None
-    try:
-        data = json.loads(ws_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    if not isinstance(data, dict):
-        return None
+    data = _read_workflow_state_lenient(ws_path)
     planning = data.get("planning")
     if not isinstance(planning, dict):
         return None
@@ -460,14 +450,7 @@ def _read_music_expected_file_count(coll_dir: Path) -> int | None:
 def _read_music_suno_playlist_url(coll_dir: Path) -> str | None:
     """workflow-state.json から保存済み Suno playlist URL を読む."""
     ws_path = CollectionPaths(coll_dir).workflow_state_path
-    if not ws_path.is_file():
-        return None
-    try:
-        data = json.loads(ws_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    if not isinstance(data, dict):
-        return None
+    data = _read_workflow_state_lenient(ws_path)
     planning = data.get("planning")
     if not isinstance(planning, dict):
         return None
@@ -483,14 +466,7 @@ def _read_music_suno_playlist_url(coll_dir: Path) -> str | None:
 def _read_workflow_theme(coll_dir: Path) -> str | None:
     """workflow-state.json から collection theme slug を読む。"""
     ws_path = CollectionPaths(coll_dir).workflow_state_path
-    if not ws_path.is_file():
-        return None
-    try:
-        data = json.loads(ws_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    if not isinstance(data, dict):
-        return None
+    data = _read_workflow_state_lenient(ws_path)
     theme = data.get("theme")
     return theme if isinstance(theme, str) and theme else None
 
@@ -1188,7 +1164,6 @@ def create_server(
                     coll_dir,
                     downloaded,
                     prompt_entries_reader=read_suno_prompt_entries,
-                    atomic_json_write=_atomic_json_write,
                 )
             except DownloadedPayloadError:
                 self.send_error(400, "Bad Request")

--- a/src/youtube_automation/domains/suno/downloaded/apply.py
+++ b/src/youtube_automation/domains/suno/downloaded/apply.py
@@ -17,7 +17,6 @@ from youtube_automation.domains.suno.downloaded.models import (
     PromptEntriesReader,
 )
 from youtube_automation.domains.suno.downloaded.workflow import (
-    AtomicJsonWriter,
     expected_download_count,
     read_pattern_count,
     update_workflow_state_downloaded,
@@ -55,10 +54,7 @@ class DownloadedApplyResult:
 def _restore_downloaded_transaction(
     *,
     music_dir: Path,
-    workflow_state_path: Path,
     music_backup_dir: Path | None,
-    workflow_existed: bool,
-    workflow_backup: bytes | None,
     restore_music: bool,
 ) -> None:
     if restore_music:
@@ -67,11 +63,6 @@ def _restore_downloaded_transaction(
             restored = music_backup_dir / "02-Individual-music"
             if restored.exists():
                 shutil.copytree(restored, music_dir)
-    if workflow_backup is not None:
-        workflow_state_path.parent.mkdir(parents=True, exist_ok=True)
-        workflow_state_path.write_bytes(workflow_backup)
-    elif not workflow_existed:
-        workflow_state_path.unlink(missing_ok=True)
 
 
 def apply_downloaded_artifacts_detailed(
@@ -79,7 +70,6 @@ def apply_downloaded_artifacts_detailed(
     payload: DownloadedPayload,
     *,
     prompt_entries_reader: PromptEntriesReader,
-    atomic_json_write: AtomicJsonWriter,
 ) -> DownloadedApplyResult:
     pattern_count = read_pattern_count(coll_dir, prompt_entries_reader=prompt_entries_reader, default=0)
     expected_count = cast(int, expected_download_count(pattern_count, payload.expected_file_count))
@@ -87,10 +77,7 @@ def apply_downloaded_artifacts_detailed(
     placed_count = payload.file_count
     paths = CollectionPaths(coll_dir)
     music_dir = paths.music_dir
-    workflow_state_path = paths.workflow_state_path
     music_backup_dir: Path | None = None
-    workflow_existed = workflow_state_path.exists()
-    workflow_backup = workflow_state_path.read_bytes() if workflow_existed else None
     restore_music_on_error = False
 
     try:
@@ -118,25 +105,18 @@ def apply_downloaded_artifacts_detailed(
             expected_file_count=result.expected_count,
             missing_reasons=result.missing_reasons,
             prompt_entries_reader=prompt_entries_reader,
-            atomic_json_write=atomic_json_write,
         )
     except DownloadedArtifactError:
         _restore_downloaded_transaction(
             music_dir=music_dir,
-            workflow_state_path=workflow_state_path,
             music_backup_dir=music_backup_dir,
-            workflow_existed=workflow_existed,
-            workflow_backup=workflow_backup,
             restore_music=restore_music_on_error,
         )
         raise
     except (OSError, ValueError, shutil.Error) as exc:
         _restore_downloaded_transaction(
             music_dir=music_dir,
-            workflow_state_path=workflow_state_path,
             music_backup_dir=music_backup_dir,
-            workflow_existed=workflow_existed,
-            workflow_backup=workflow_backup,
             restore_music=restore_music_on_error,
         )
         raise DownloadedArtifactError(str(exc)) from exc
@@ -156,11 +136,9 @@ def apply_downloaded_artifacts(
     payload: DownloadedPayload,
     *,
     prompt_entries_reader: PromptEntriesReader,
-    atomic_json_write: AtomicJsonWriter,
 ) -> int:
     return apply_downloaded_artifacts_detailed(
         coll_dir,
         payload,
         prompt_entries_reader=prompt_entries_reader,
-        atomic_json_write=atomic_json_write,
     ).placed_count

--- a/src/youtube_automation/domains/suno/downloaded/workflow.py
+++ b/src/youtube_automation/domains/suno/downloaded/workflow.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Protocol
 
 from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.suno.downloaded.models import (
     DOCUMENTATION_DIRNAME,
     SUNO_PROMPTS_JSON_FILENAME,
@@ -15,10 +16,6 @@ from youtube_automation.domains.suno.downloaded.models import (
 
 _SUNO_CLIPS_PER_PROMPT = 2
 _MISSING_REASON_KEYS = frozenset({"suno_unfulfilled", "apply_skipped"})
-
-
-class AtomicJsonWriter(Protocol):
-    def __call__(self, target: Path, data: dict, *, prefix: str) -> None: ...
 
 
 def read_pattern_count(
@@ -45,18 +42,6 @@ def expected_download_count(pattern_count: int | None, explicit_expected: int | 
     return pattern_count * _SUNO_CLIPS_PER_PROMPT
 
 
-def _read_existing_workflow_state(ws_path: Path) -> dict:
-    if not ws_path.is_file():
-        return {}
-    try:
-        data = json.loads(ws_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        raise ValueError("invalid workflow-state.json") from exc
-    if not isinstance(data, dict):
-        raise ValueError("invalid workflow-state.json: root must be an object")
-    return data
-
-
 def _validate_missing_reasons(missing_reasons: dict[str, object] | None) -> dict[str, int] | None:
     if missing_reasons is None:
         return None
@@ -78,44 +63,46 @@ def update_workflow_state_downloaded(
     expected_file_count: int | None = None,
     missing_reasons: dict[str, object] | None = None,
     prompt_entries_reader: PromptEntriesReader,
-    atomic_json_write: AtomicJsonWriter,
 ) -> None:
     validated_missing_reasons = _validate_missing_reasons(missing_reasons)
     ws_path = CollectionPaths(coll_dir).workflow_state_path
-    data = _read_existing_workflow_state(ws_path)
-
-    planning = data.setdefault("planning", {})
-    if not isinstance(planning, dict):
-        planning = {}
-        data["planning"] = planning
-    music = planning.setdefault("music", {})
-    if not isinstance(music, dict):
-        music = {}
-        planning["music"] = music
-    if suno_playlist_url:
-        music["suno_playlist_url"] = suno_playlist_url
     pattern_count = read_pattern_count(coll_dir, prompt_entries_reader=prompt_entries_reader)
     effective_expected_count = expected_download_count(pattern_count, expected_file_count)
-    if expected_file_count is not None and expected_file_count > 0:
-        music["expected_file_count"] = expected_file_count
 
-    assets = data.setdefault("assets", {})
-    if not isinstance(assets, dict):
-        assets = {}
-        data["assets"] = assets
-    if file_count > 0:
-        # 部分完了（file_count < expected）も受け入れて downloaded 扱いにする（#1913）。
-        # 不足は actual/missing_file_count で機械可読に残し、後続工程が観測する
-        music["actual_file_count"] = file_count
-        if effective_expected_count is not None:
-            missing_file_count = max(0, effective_expected_count - file_count)
-            music["missing_file_count"] = missing_file_count
-        download_complete = effective_expected_count is not None and file_count >= effective_expected_count
-        if download_complete:
-            music.pop("missing_reasons", None)
-        elif validated_missing_reasons is not None:
-            music["missing_reasons"] = validated_missing_reasons
-        assets["music_downloaded"] = True
+    def record_downloaded(state: WorkflowState) -> None:
+        planning = state.get("planning") or {}
+        if not isinstance(planning, dict):
+            planning = {}
+        music = planning.get("music") or {}
+        if not isinstance(music, dict):
+            music = {}
+        if suno_playlist_url:
+            music["suno_playlist_url"] = suno_playlist_url
+        if expected_file_count is not None and expected_file_count > 0:
+            music["expected_file_count"] = expected_file_count
 
-    ws_path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_json_write(ws_path, data, prefix=".workflow-state-")
+        assets = state.get("assets") or {}
+        if not isinstance(assets, dict):
+            assets = {}
+        if file_count > 0:
+            # 部分完了も downloaded とし、不足理由を後続工程から観測可能に保つ。
+            music["actual_file_count"] = file_count
+            if effective_expected_count is not None:
+                music["missing_file_count"] = max(0, effective_expected_count - file_count)
+            download_complete = effective_expected_count is not None and file_count >= effective_expected_count
+            if download_complete:
+                music.pop("missing_reasons", None)
+            elif validated_missing_reasons is not None:
+                music["missing_reasons"] = validated_missing_reasons
+            assets["music_downloaded"] = True
+
+        planning["music"] = music
+        state["planning"] = planning
+        state["assets"] = assets
+
+    try:
+        update_workflow_state(ws_path, record_downloaded)
+    except WorkflowStateError as error:
+        if isinstance(error.__cause__, OSError) and "could not be written" in str(error):
+            raise error.__cause__ from error
+        raise ValueError("invalid workflow-state.json") from error

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -3875,22 +3875,6 @@ def test_get_auth_token_rejects_wrong_declared_extension_origin(serve_dir, tmp_p
     assert exc_info.value.code == 403
 
 
-def test_apply_downloaded_artifacts_propagates_unknown_atomic_write_error(tmp_path):
-    """未知例外は DownloadedArtifactError に丸めず、上位へ伝播する。"""
-    coll = _make_collection(tmp_path, "20260601-clm-aaa-collection", entries=[])
-
-    def fail_unexpected(_path: Path, _data: dict, *, prefix: str) -> None:
-        raise RuntimeError("unexpected writer failure")
-
-    with pytest.raises(RuntimeError, match="unexpected writer failure"):
-        apply_downloaded_artifacts(
-            coll,
-            DownloadedPayload(file_count=0, format="mp3", suno_playlist_url="https://suno.com/playlist/abc"),
-            prompt_entries_reader=read_suno_prompt_entries,
-            atomic_json_write=fail_unexpected,
-        )
-
-
 def test_apply_downloaded_artifacts_restores_outer_backup_when_inner_music_rollback_fails(tmp_path, monkeypatch):
     """内側 commit rollback が失敗しても外側 transaction backup から music dir を戻す。"""
     coll = _make_collection(
@@ -3919,9 +3903,6 @@ def test_apply_downloaded_artifacts_restores_outer_backup_when_inner_music_rollb
         fail_staged_move_and_inner_restore,
     )
 
-    def write_json(_path: Path, _data: dict, *, prefix: str) -> None:
-        return None
-
     with pytest.raises(DownloadedArtifactError, match="simulated staged move failure|simulated inner rollback failure"):
         apply_downloaded_artifacts(
             coll,
@@ -3932,7 +3913,6 @@ def test_apply_downloaded_artifacts_restores_outer_backup_when_inner_music_rollb
                 download_path=str(zip_path),
             ),
             prompt_entries_reader=read_suno_prompt_entries,
-            atomic_json_write=write_json,
         )
 
     assert {p.name: p.read_bytes() for p in sorted(music_dir.iterdir())} == original_files
@@ -4366,8 +4346,6 @@ def test_post_downloaded_zip_output_name_collision_returns_500_without_partial_m
 
 def test_post_downloaded_workflow_write_failure_rolls_back_music_and_workflow(serve_dir, tmp_path, monkeypatch):
     """ZIP commit 後に workflow-state.json 更新が失敗しても music と workflow を元に戻す。"""
-    import youtube_automation.commands.collections.collection_serve as cs
-
     planning = tmp_path / "planning"
     coll = _make_collection(
         planning,
@@ -4381,14 +4359,14 @@ def test_post_downloaded_workflow_write_failure_rolls_back_music_and_workflow(se
     original_ws = {"planning": {"thumbnail": {"approved": True}}, "assets": {"music_downloaded": False}}
     ws_path.write_text(json.dumps(original_ws, ensure_ascii=False), encoding="utf-8")
     zip_path = _make_zip(tmp_path / "valid.zip", {"Song A.mp3": b"new-a", "Song A_1.mp3": b"new-b"})
-    original_atomic_json_write = cs._atomic_json_write
 
-    def fail_workflow_write(path: Path, data: dict, *, prefix: str) -> None:
-        if path.name == "workflow-state.json":
-            raise OSError("simulated workflow write failure")
-        original_atomic_json_write(path, data, prefix=prefix)
+    def fail_workflow_write(_path: Path, _updater) -> None:
+        raise OSError("simulated workflow write failure")
 
-    monkeypatch.setattr(cs, "_atomic_json_write", fail_workflow_write)
+    monkeypatch.setattr(
+        "youtube_automation.domains.suno.downloaded.workflow.update_workflow_state",
+        fail_workflow_write,
+    )
     base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN)
     token = _fetch_token(base)
 

--- a/tests/domains/suno/downloaded/test_apply_missing_reasons.py
+++ b/tests/domains/suno/downloaded/test_apply_missing_reasons.py
@@ -34,10 +34,6 @@ def _write_archive(path: Path, files: dict[str, bytes]) -> Path:
     return path
 
 
-def _write_json(target: Path, data: dict, *, prefix: str) -> None:
-    target.write_text(json.dumps(data), encoding="utf-8")
-
-
 def _payload(archive: Path, *, expected_count: int) -> DownloadedPayload:
     return DownloadedPayload(
         file_count=0,
@@ -62,7 +58,6 @@ def test_detailed_apply_calculates_and_persists_missing_reasons(tmp_path: Path) 
         tmp_path,
         _payload(archive, expected_count=4),
         prompt_entries_reader=read_entries,
-        atomic_json_write=_write_json,
     )
 
     assert result == DownloadedApplyResult(
@@ -87,7 +82,6 @@ def test_detailed_apply_clamps_unfulfilled_when_archive_exceeds_expected(tmp_pat
         tmp_path,
         _payload(archive, expected_count=1),
         prompt_entries_reader=read_entries,
-        atomic_json_write=_write_json,
     )
 
     assert result.suno_unfulfilled == 0
@@ -105,7 +99,6 @@ def test_legacy_apply_still_returns_placed_count(tmp_path: Path) -> None:
         tmp_path,
         _payload(archive, expected_count=2),
         prompt_entries_reader=read_entries,
-        atomic_json_write=_write_json,
     )
 
     assert placed_count == 1
@@ -120,7 +113,6 @@ def test_detailed_apply_keeps_zero_placed_fail_loud(tmp_path: Path) -> None:
             tmp_path,
             _payload(archive, expected_count=2),
             prompt_entries_reader=read_entries,
-            atomic_json_write=_write_json,
         )
 
     assert archive.exists()

--- a/tests/domains/suno/downloaded/test_workflow_missing_reasons.py
+++ b/tests/domains/suno/downloaded/test_workflow_missing_reasons.py
@@ -10,10 +10,6 @@ import pytest
 from youtube_automation.domains.suno.downloaded.workflow import update_workflow_state_downloaded
 
 
-def _write_json(target: Path, data: dict, *, prefix: str) -> None:
-    target.write_text(json.dumps(data), encoding="utf-8")
-
-
 def _read_music(collection_dir: Path) -> dict:
     state = json.loads((collection_dir / "workflow-state.json").read_text(encoding="utf-8"))
     return state["planning"]["music"]
@@ -25,7 +21,6 @@ def test_should_store_missing_reasons_as_non_negative_integers(tmp_path: Path) -
         file_count=2,
         missing_reasons={"suno_unfulfilled": 1, "apply_skipped": 1},
         prompt_entries_reader=lambda _collection_dir: [],
-        atomic_json_write=_write_json,
     )
 
     assert _read_music(tmp_path)["missing_reasons"] == {
@@ -50,7 +45,6 @@ def test_should_reject_invalid_missing_reason_counts(tmp_path: Path, key: str, i
             expected_file_count=4,
             missing_reasons=missing_reasons,
             prompt_entries_reader=lambda _collection_dir: [],
-            atomic_json_write=_write_json,
         )
 
     assert not (tmp_path / "workflow-state.json").exists()
@@ -71,7 +65,6 @@ def test_should_reject_invalid_missing_reason_shape(tmp_path: Path, missing_reas
             expected_file_count=4,
             missing_reasons=missing_reasons,
             prompt_entries_reader=lambda _collection_dir: [],
-            atomic_json_write=_write_json,
         )
 
     assert not (tmp_path / "workflow-state.json").exists()
@@ -99,7 +92,6 @@ def test_should_remove_previous_missing_reasons_when_download_is_complete(tmp_pa
         file_count=4,
         expected_file_count=4,
         prompt_entries_reader=lambda _collection_dir: [],
-        atomic_json_write=_write_json,
     )
 
     music = _read_music(tmp_path)
@@ -113,10 +105,24 @@ def test_should_preserve_existing_caller_path_without_missing_reasons(tmp_path: 
         file_count=2,
         expected_file_count=4,
         prompt_entries_reader=lambda _collection_dir: [],
-        atomic_json_write=_write_json,
     )
 
     music = _read_music(tmp_path)
     assert music["actual_file_count"] == 2
     assert music["missing_file_count"] == 2
     assert "missing_reasons" not in music
+
+
+def test_should_preserve_unknown_workflow_state_fields(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    state_path.write_text(json.dumps({"future_section": {"keep": True}}), encoding="utf-8")
+
+    update_workflow_state_downloaded(
+        tmp_path,
+        file_count=2,
+        expected_file_count=4,
+        prompt_entries_reader=lambda _collection_dir: [],
+    )
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["future_section"] == {"keep": True}

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -13,7 +13,6 @@ OWNER = "src/youtube_automation/domains/collections/workflow_state.py"
 DIRECT_IO_ALLOWLIST = frozenset(
     {
         "src/youtube_automation/commands/analytics/experiment_judge.py",
-        "src/youtube_automation/commands/collections/collection_serve.py",
         "src/youtube_automation/commands/distrokid/distrokid_prepare.py",
         "src/youtube_automation/commands/media/check_raw_master.py",
         "src/youtube_automation/commands/media/generate_videos_batch.py",
@@ -24,8 +23,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/commands/youtube/pinned_comment.py",
         "src/youtube_automation/domains/distrokid/preparation.py",
         "src/youtube_automation/domains/distrokid/release.py",
-        "src/youtube_automation/domains/suno/downloaded/apply.py",
-        "src/youtube_automation/domains/suno/downloaded/workflow.py",
         "src/youtube_automation/domains/suno/prompt_resolution.py",
         "src/youtube_automation/domains/suno/selection.py",
         "src/youtube_automation/domains/uploads/_complete_collection_strategy.py",


### PR DESCRIPTION
## 概要

workflow-state owner移行を進め、collection serverの読取経路とSuno downloaded writerをowner APIへ統一します。

## 変更内容

- collection serverのworkflow-state読取5経路をowner fail-open readerへ移行
- Suno downloaded writer / applyをlock付きatomic owner updateへ移行
- 直接backup / restore I/Oを除去
- 未知field、rollback、server lifecycleを維持
- 直I/O ratchet allowlistを3ファイル縮小
- CHANGELOGを更新

## 検証

- 関連 / lifecycle / owner: 302 passed / 2 skipped
- full: 9,173 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3879
