### PR TITLE
refactor(uploads): preflightをコラボレータへ委譲する (#3933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
+- `refactor(uploads)`: `PreflightMixin` の MRO hook を、認証チャンネル照合後に明示注入した preflight checker を呼ぶ合成へ置換し、既存の判定・エラー契約を維持する（#3933）。
 - `refactor(uploads)`: `DedupSearchMixin` を YouTube service を明示注入する重複検索 helper へ置換し、完全一致・ghost 除外・quota 記録・fail-open 契約を維持する（#3932）。
 - `refactor(uploads)`: `PlaylistAssignmentMixin` を YouTube clients を明示注入する playlist 割り当てコラボレータへ置換し、割り当て失敗を状態確定前に伝播する契約を維持する（#3931）。
 - `feat(doctor)`: registry の check ID を `--check <id>` で複数選択し、宣言順・対象集合内 summary を保って部分診断できるようにし、automation update の channel config 確認を単一 check 実行へ切り替える（#3922）。

--- a/src/youtube_automation/commands/metadata/metadata_audit.py
+++ b/src/youtube_automation/commands/metadata/metadata_audit.py
@@ -2,7 +2,7 @@
 """Audit metadata across all live videos.
 
 Checks each video published from collections/live/ against the same
-quality bar enforced by youtube_auto_uploader._preflight_check, plus
+quality bar enforced by the upload PreflightChecker, plus
 remote-side checks against YouTube API.
 
 Run periodically (or after upload) to detect drift between local

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -1,7 +1,4 @@
-"""アップロード前メタデータ品質チェック（fail-loud preflight）。
-
-``YouTubeAutoUploader`` から分離した mixin。挙動は分割前と同一。
-"""
+"""アップロード前メタデータ品質チェック（fail-loud preflight）。"""
 
 from __future__ import annotations
 
@@ -42,8 +39,29 @@ from youtube_automation.infrastructure.filesystem import (
 logger = logging.getLogger(__name__)
 
 
-class PreflightMixin:
-    """アップロード前メタデータ検証を提供する mixin。"""
+class PreflightChecker:
+    """明示された collection root と依存でメタデータを検証する。"""
+
+    def __init__(
+        self,
+        collections_root: Path,
+        *,
+        config_loader=None,
+        duration_probe=None,
+        metadata_generator_factory=None,
+        master_video_resolver=None,
+        allow_duration_outside_target: bool = False,
+    ) -> None:
+        self.collections_root = collections_root
+        self.config_loader = config_loader if config_loader is not None else load_config
+        self.duration_probe = duration_probe if duration_probe is not None else probe_duration
+        self.metadata_generator_factory = (
+            metadata_generator_factory if metadata_generator_factory is not None else BAHMetadataGenerator
+        )
+        self.master_video_resolver = (
+            master_video_resolver if master_video_resolver is not None else resolve_master_video
+        )
+        self.allow_duration_outside_target = allow_duration_outside_target
 
     def _collect_live_titles(self, exclude_dir: Path | None = None) -> list[str]:
         """既存 live コレクションの公開タイトル（`## タイトル案`）を収集する (#602).
@@ -70,11 +88,7 @@ class PreflightMixin:
                 titles.append(title.strip())
         return titles
 
-    def preflight_check(self, collection_dir: Path) -> None:
-        """公開されたアップロード前検証操作。"""
-        self._preflight_check(collection_dir)
-
-    def _preflight_check(self, collection_dir: Path) -> None:
+    def check(self, collection_dir: Path) -> None:
         """アップロード前メタデータ品質チェック (fail-loud)。
 
         過去事例の再発防止:
@@ -113,7 +127,7 @@ class PreflightMixin:
         if msg := check_title_codepoint_limit(title):
             raise ValidationError(f"❌ {msg}")
 
-        config = load_config()
+        config = self.config_loader()
 
         # workflow-state.json 自体は全チャンネルで必須。scene_phrases 完全性だけを
         # 単一言語チャンネルでは不要扱いにする（populate 側と同じ判定を共有 #1470）。
@@ -166,14 +180,14 @@ class PreflightMixin:
 
         # 実 upload と同じ generator で全 locale の title を構築し、API 呼び出し前の
         # --plan preflight でも YouTube の 100 codepoint 制限を検証する。
-        master_video = resolve_master_video(collection_dir)
-        duration_sec = probe_duration(master_video)
+        master_video = self.master_video_resolver(collection_dir)
+        duration_sec = self.duration_probe(master_video)
         if duration_sec is None:
             raise ValidationError(
                 f"❌ 実マスター尺を取得できません: {master_video.name}。"
                 "ffprobe で読み取れる完成済みマスター動画を指定してください"
             )
-        generator = BAHMetadataGenerator(str(collection_dir))
+        generator = self.metadata_generator_factory(str(collection_dir))
         # 同じ invocation で読み込んだ config を使い、plan と upload の設定 snapshot を揃える。
         # 最小 stub を使う既存 unit test では localization data が無いため生成を省略する。
         generator.config = config
@@ -226,7 +240,7 @@ class PreflightMixin:
                 target_min * 60 if target_min is not None else None,
                 target_max * 60 if target_max is not None else None,
             )
-            if duration_issue and not getattr(self, "allow_duration_outside_target", False):
+            if duration_issue and not self.allow_duration_outside_target:
                 issues.append(
                     f"{duration_issue}; config/channel/audio.json の target を満たす動画を再生成するか、"
                     "operator 判断で --allow-duration-outside-target を明示してください"

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -19,7 +19,7 @@ from youtube_automation.core.errors import (
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._complete_collection_strategy import CompleteCollectionMixin
 from youtube_automation.domains.uploads._dedup_search import DedupSearch
-from youtube_automation.domains.uploads._preflight import PreflightMixin
+from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
     UPLOAD_SOURCE_NEW,
@@ -236,7 +236,6 @@ __all__ = [
 
 class YouTubeAutoUploader(
     CompleteCollectionMixin,
-    PreflightMixin,
     ResumableUploader,
 ):
     """YouTube自動アップロードメインクラス
@@ -251,6 +250,7 @@ class YouTubeAutoUploader(
         collections_root: Optional[str] = None,
         youtube_clients: YouTubeClients | None = None,
         dedup_search: DedupSearch | None = None,
+        preflight_checker: PreflightChecker | None = None,
     ) -> None:
         """
         初期化
@@ -265,6 +265,9 @@ class YouTubeAutoUploader(
 
         self.collections_root = Path(collections_root)
         self._dedup_search = dedup_search
+        self.preflight_checker = (
+            preflight_checker if preflight_checker is not None else PreflightChecker(self.collections_root)
+        )
         self._verified_authenticated_channel_id: str | None = None
 
     @property
@@ -287,7 +290,7 @@ class YouTubeAutoUploader(
     def preflight_check(self, collection_dir: Path) -> None:
         """チャンネル本人性を確認してからメタデータ品質を検証する。"""
         self._verify_authenticated_upload_channel()
-        super().preflight_check(collection_dir)
+        self.preflight_checker.check(collection_dir)
 
     def upload_video(
         self,

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -12,18 +11,7 @@ from youtube_automation.commands.media import populate_scene_phrases
 from youtube_automation.configuration import load_config, reset
 from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.metadata import BAHMetadataGenerator
-from youtube_automation.domains.uploads._preflight import PreflightMixin
-
-
-class _PreflightHarness(PreflightMixin):
-    def __init__(self, collections_root: Path) -> None:
-        self.collections_root = collections_root
-
-    @staticmethod
-    def _extract_md_section(text: str, header: str) -> str | None:
-        pattern = rf"^## {re.escape(header)}\n```(?:\w+)?\n(.*?)\n```"
-        match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
-        return match.group(1) if match else None
+from youtube_automation.domains.uploads._preflight import PreflightChecker
 
 
 def _write_json(path: Path, data: dict) -> None:
@@ -260,8 +248,7 @@ class TestMainCLI:
         master_dir = collection_dir / "01-master"
         master_dir.mkdir()
         (master_dir / "master.mp4").write_bytes(b"probe is mocked")
-        monkeypatch.setattr("youtube_automation.domains.uploads._preflight.probe_duration", lambda _: 3600)
-        _PreflightHarness(ch / "collections")._preflight_check(collection_dir)
+        PreflightChecker(ch / "collections", duration_probe=lambda _: 3600).check(collection_dir)
 
         gen = object.__new__(BAHMetadataGenerator)
         gen.config = load_config()

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -120,7 +120,6 @@ def test_collection_preflight_uses_public_inner_uploader_operation(monkeypatch, 
 
     outer_preflight.assert_called_once_with(target)
     uploader.uploader.preflight_check.assert_called_once_with(target)
-    uploader.uploader._preflight_check.assert_not_called()
 
 
 def _write_cli_title_collection(channel_dir: Path, *, title_template_check: dict[str, object] | None) -> Path:

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -1,4 +1,4 @@
-"""PreflightMixin の collection upload 前チェックの回帰テスト."""
+"""PreflightChecker の collection upload 前チェックの回帰テスト."""
 
 from __future__ import annotations
 
@@ -11,13 +11,8 @@ import pytest
 
 from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import ValidationError
-from youtube_automation.domains.uploads._preflight import PreflightMixin
+from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
-
-
-class _PreflightHarness(PreflightMixin):
-    def __init__(self, collections_root: Path) -> None:
-        self.collections_root = collections_root
 
 
 def _write_json(path: Path, data: dict) -> None:
@@ -126,15 +121,17 @@ def _run_preflight(
     *,
     allow_duration_outside_target: bool = False,
     duration_seconds: float = 3600,
+    metadata_generator_factory=None,
 ) -> None:
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
-    monkeypatch.setattr(
-        "youtube_automation.domains.uploads._preflight.probe_duration",
-        lambda _: duration_seconds,
-    )
-    harness = _PreflightHarness(channel_dir / "collections")
-    harness.allow_duration_outside_target = allow_duration_outside_target
-    harness._preflight_check(collection_dir)
+    checker_kwargs = {
+        "duration_probe": lambda _: duration_seconds,
+        "allow_duration_outside_target": allow_duration_outside_target,
+    }
+    if metadata_generator_factory is not None:
+        checker_kwargs["metadata_generator_factory"] = metadata_generator_factory
+    checker = PreflightChecker(channel_dir / "collections", **checker_kwargs)
+    checker.check(collection_dir)
 
 
 def test_heading_mismatch_reports_expected_missing_detected_and_fix_example(tmp_path: Path) -> None:
@@ -156,7 +153,7 @@ A continuous BGM mix without chapter markers.
     )
 
     with pytest.raises(ValidationError) as excinfo:
-        _PreflightHarness(tmp_path / "collections")._preflight_check(collection_dir)
+        PreflightChecker(tmp_path / "collections").check(collection_dir)
 
     message = str(excinfo.value)
     assert "期待する見出し（完全一致）" in message
@@ -186,7 +183,7 @@ A continuous BGM mix without chapter markers.
     )
 
     with pytest.raises(ValidationError) as excinfo:
-        _PreflightHarness(tmp_path / "collections")._preflight_check(collection_dir)
+        PreflightChecker(tmp_path / "collections").check(collection_dir)
 
     message = str(excinfo.value)
     assert "タイトル案 / Complete Collection 概要欄 が空" in message
@@ -436,9 +433,13 @@ def test_plan_preflight_passes_actual_master_duration_to_localizations(
         scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
         description="A continuous BGM mix without chapter markers.",
     )
-    monkeypatch.setattr("youtube_automation.domains.uploads._preflight.BAHMetadataGenerator", _Generator)
-
-    _run_preflight(channel_dir, collection_dir, monkeypatch, duration_seconds=10 * 3600 + 32 * 60)
+    _run_preflight(
+        channel_dir,
+        collection_dir,
+        monkeypatch,
+        duration_seconds=10 * 3600 + 32 * 60,
+        metadata_generator_factory=_Generator,
+    )
 
     assert captured == {"duration_seconds": 10 * 3600 + 32 * 60}
 
@@ -549,13 +550,10 @@ def test_upload_collection_reports_unreachable_tags_min_count_from_channel_confi
         tags=["a" * 17] * 26 + ["b" * 27],
     )
     monkeypatch.setenv("CHANNEL_DIR", str(channel_dir))
-    monkeypatch.setattr(
-        "youtube_automation.domains.uploads._preflight.probe_duration",
-        lambda _: 3600,
-    )
 
     assert load_config().content.tags.min_count == 30
-    uploader = YouTubeAutoUploader(str(channel_dir / "collections"))
+    checker = PreflightChecker(channel_dir / "collections", duration_probe=lambda _: 3600)
+    uploader = YouTubeAutoUploader(str(channel_dir / "collections"), preflight_checker=checker)
     monkeypatch.setattr(uploader, "_verify_authenticated_upload_channel", lambda: None)
 
     with pytest.raises(ValidationError) as excinfo:

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -124,9 +124,11 @@ class TestUploadChannelIdentityPreflight:
         from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
         youtube = _youtube_service_with_authenticated_channel("UC_TOKEN_OWNER")
+        preflight_checker = MagicMock()
         uploader = YouTubeAutoUploader(
             collections_root=str(tmp_path),
             youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+            preflight_checker=preflight_checker,
         )
 
         with (
@@ -134,13 +136,12 @@ class TestUploadChannelIdentityPreflight:
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
             ),
-            patch.object(uploader, "_preflight_check") as metadata_preflight,
             pytest.raises(ConfigError, match="channel_id mismatch"),
         ):
             uploader.preflight_check(tmp_path / "collection")
 
         youtube.channels.return_value.list.assert_called_once_with(part="id", mine=True)
-        metadata_preflight.assert_not_called()
+        preflight_checker.check.assert_not_called()
         youtube.videos.return_value.insert.assert_not_called()
 
     def test_matching_authenticated_channel_continues_metadata_preflight(self, tmp_path):
@@ -148,9 +149,11 @@ class TestUploadChannelIdentityPreflight:
         from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
         youtube = _youtube_service_with_authenticated_channel("UC_CONFIGURED")
+        preflight_checker = MagicMock()
         uploader = YouTubeAutoUploader(
             collections_root=str(tmp_path),
             youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+            preflight_checker=preflight_checker,
         )
         collection = tmp_path / "collection"
 
@@ -159,11 +162,10 @@ class TestUploadChannelIdentityPreflight:
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
             ),
-            patch.object(uploader, "_preflight_check") as metadata_preflight,
         ):
             uploader.preflight_check(collection)
 
-        metadata_preflight.assert_called_once_with(collection)
+        preflight_checker.check.assert_called_once_with(collection)
 
     def test_rejects_empty_authenticated_channel_response(self, tmp_path):
         from youtube_automation.core.errors import YouTubeAPIError
@@ -171,9 +173,11 @@ class TestUploadChannelIdentityPreflight:
         from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
         youtube = _youtube_service_with_authenticated_channel(None)
+        preflight_checker = MagicMock()
         uploader = YouTubeAutoUploader(
             collections_root=str(tmp_path),
             youtube_clients=YouTubeClients(full_handler=SimpleNamespace(get_youtube_service=lambda: youtube)),
+            preflight_checker=preflight_checker,
         )
 
         with (
@@ -181,12 +185,11 @@ class TestUploadChannelIdentityPreflight:
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
             ),
-            patch.object(uploader, "_preflight_check") as metadata_preflight,
             pytest.raises(YouTubeAPIError, match="authenticated user has no YouTube channel"),
         ):
             uploader.preflight_check(tmp_path / "collection")
 
-        metadata_preflight.assert_not_called()
+        preflight_checker.check.assert_not_called()
 
 
 def _make_preflight_config(supported_languages: list[str]) -> SimpleNamespace:
@@ -250,55 +253,44 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
 
 
 # ---------------------------------------------------------------------------
-# Issue #587: `_preflight_check` localization quality gates
+# Issue #587: preflight localization quality gates
 # ---------------------------------------------------------------------------
 
 
 class TestPreflightLocalizationLanguages:
     def test_should_pass_when_supported_scene_languages_are_present(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja"])
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(tmp_path, config_loader=lambda: _make_preflight_config(["ja", "en"]))
 
-        with patch(
-            "youtube_automation.domains.uploads._preflight.load_config",
-            return_value=_make_preflight_config(["ja", "en"]),
-        ):
-            uploader._preflight_check(col_dir)
+        checker.check(col_dir)
 
     def test_should_pass_when_required_high_cpm_languages_are_present(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja", "de"])
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(tmp_path, config_loader=lambda: _make_preflight_config(["ja", "en", "de"]))
 
-        with patch(
-            "youtube_automation.domains.uploads._preflight.load_config",
-            return_value=_make_preflight_config(["ja", "en", "de"]),
-        ):
-            uploader._preflight_check(col_dir)
+        checker.check(col_dir)
 
     def test_should_warn_and_continue_when_low_cpm_language_is_present(self, tmp_path, caplog):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja", "de", "ko"])
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_preflight_config(["ja", "en", "de", "ko"]),
+        )
 
-        with (
-            patch(
-                "youtube_automation.domains.uploads._preflight.load_config",
-                return_value=_make_preflight_config(["ja", "en", "de", "ko"]),
-            ),
-            caplog.at_level(logging.WARNING),
-        ):
-            uploader._preflight_check(col_dir)
+        with caplog.at_level(logging.WARNING):
+            checker.check(col_dir)
 
         assert any("ko" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------
-# Issue #602: `_preflight_check` タイトル鋳型準拠ゲート
+# Issue #602: preflight タイトル鋳型準拠ゲート
 # ---------------------------------------------------------------------------
 
 
@@ -372,7 +364,7 @@ class TestPreflightTitleTemplateCompliance:
     """#602: 鋳型逸脱・巻数表記・RHS 重複を preflight で block する."""
 
     def test_should_fail_on_volume_and_rhs_duplicate(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         _write_live_title(
             tmp_path,
@@ -383,17 +375,16 @@ class TestPreflightTitleTemplateCompliance:
             tmp_path,
             "Funky Spirit Vol.2 | 3 Hours of Soulful Retro Funk Grooves",
         )
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_title_template_config(["ja", "en", "de"]),
+        )
 
-        with patch(
-            "youtube_automation.domains.uploads._preflight.load_config",
-            return_value=_make_title_template_config(["ja", "en", "de"]),
-        ):
-            with pytest.raises(ValidationError, match="タイトル鋳型違反"):
-                uploader._preflight_check(col_dir)
+        with pytest.raises(ValidationError, match="タイトル鋳型違反"):
+            checker.check(col_dir)
 
     def test_should_pass_on_compliant_title(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         _write_live_title(
             tmp_path,
@@ -404,16 +395,15 @@ class TestPreflightTitleTemplateCompliance:
             tmp_path,
             "Bright Funk & Soul Spirit | 3 Hours of Feel-Good Retro Grooves",
         )
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_title_template_config(["ja", "en", "de"]),
+        )
 
-        with patch(
-            "youtube_automation.domains.uploads._preflight.load_config",
-            return_value=_make_title_template_config(["ja", "en", "de"]),
-        ):
-            uploader._preflight_check(col_dir)
+        checker.check(col_dir)
 
     def test_should_allow_opted_in_volume_without_disabling_default_detection(self, tmp_path):
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
 
         opted_in_collection = _write_title_collection(
             tmp_path,
@@ -432,19 +422,19 @@ class TestPreflightTitleTemplateCompliance:
             status="false",
             title_template_check={"allow_volume_patterns": False},
         )
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_title_template_config(["ja", "en", "de"]),
+        )
 
-        with patch(
-            "youtube_automation.domains.uploads._preflight.load_config",
-            return_value=_make_title_template_config(["ja", "en", "de"]),
-        ):
-            uploader._preflight_check(opted_in_collection)
-            with pytest.raises(ValidationError, match="巻数表記を検出"):
-                uploader._preflight_check(default_collection)
-            with pytest.raises(ValidationError, match="巻数表記を検出"):
-                uploader._preflight_check(false_collection)
+        checker.check(opted_in_collection)
+        with pytest.raises(ValidationError, match="巻数表記を検出"):
+            checker.check(default_collection)
+        with pytest.raises(ValidationError, match="巻数表記を検出"):
+            checker.check(false_collection)
 
     def test_upload_collection_reaches_post_preflight_for_opted_in_volume(self, tmp_path):
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
         from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 
         class PostPreflightReached(Exception):
@@ -455,14 +445,14 @@ class TestPreflightTitleTemplateCompliance:
             "Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves",
             title_template_check={"allow_volume_patterns": True},
         )
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_title_template_config(["ja", "en", "de"]),
+        )
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path), preflight_checker=checker)
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch(
-                "youtube_automation.domains.uploads._preflight.load_config",
-                return_value=_make_title_template_config(["ja", "en", "de"]),
-            ),
             patch(
                 "youtube_automation.domains.uploads.youtube.BAHMetadataGenerator",
                 side_effect=PostPreflightReached,
@@ -472,20 +462,21 @@ class TestPreflightTitleTemplateCompliance:
             uploader.upload_collection(collection)
 
     def test_upload_collection_rejects_default_volume_before_metadata_generation(self, tmp_path):
+        from youtube_automation.domains.uploads._preflight import PreflightChecker
         from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 
         collection = _write_title_collection(
             tmp_path,
             "Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves",
         )
-        uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_title_template_config(["ja", "en", "de"]),
+        )
+        uploader = YouTubeAutoUploader(collections_root=str(tmp_path), preflight_checker=checker)
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch(
-                "youtube_automation.domains.uploads._preflight.load_config",
-                return_value=_make_title_template_config(["ja", "en", "de"]),
-            ),
             patch(
                 "youtube_automation.domains.uploads.youtube.BAHMetadataGenerator",
                 side_effect=AssertionError("metadata generation must not run"),
@@ -657,7 +648,7 @@ class TestUploadCollectionForwarding:
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch.object(uploader, "_preflight_check"),
+            patch.object(uploader.preflight_checker, "check"),
             patch.object(
                 uploader,
                 "_upload_complete_collection",
@@ -1592,7 +1583,7 @@ class TestDefaultPublishAt:
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch.object(uploader, "_preflight_check"),
+            patch.object(uploader.preflight_checker, "check"),
             patch.object(
                 uploader,
                 "_upload_complete_collection",
@@ -1623,7 +1614,7 @@ class TestDefaultPublishAt:
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch.object(uploader, "_preflight_check"),
+            patch.object(uploader.preflight_checker, "check"),
             patch.object(
                 uploader,
                 "_upload_complete_collection",
@@ -1647,7 +1638,7 @@ class TestDefaultPublishAt:
 
         with (
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch.object(uploader, "_preflight_check"),
+            patch.object(uploader.preflight_checker, "check"),
             patch.object(
                 uploader,
                 "_upload_complete_collection",

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -53,7 +53,7 @@ LEGACY_AGENT_OWNERS = {
     ),
     "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearch"),
     "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignment"),
-    "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightMixin"),
+    "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightChecker"),
     "_published_dates": ("youtube_automation.domains.uploads._published_dates", "PublishedDatesScheduler"),
     "_tracking_io": ("youtube_automation.domains.uploads._tracking_io", "TrackingStore"),
     "_uploader_constants": (
@@ -216,6 +216,13 @@ def test_descriptions_md_is_a_public_pure_function_owner() -> None:
         "extract_body_for_localizations",
         "extract_md_section",
     }.issubset(vars(owner))
+
+
+def test_upload_preflight_uses_explicit_checker_without_mro_hook() -> None:
+    source = (SRC / "domains" / "uploads" / "youtube.py").read_text(encoding="utf-8")
+
+    assert "super().preflight_check" not in source
+    assert "self.preflight_checker.check(collection_dir)" in source
 
 
 @pytest.mark.parametrize("filename", UPLOADER_ENTRYPOINTS)


### PR DESCRIPTION
## 概要

uploads mixin解体を進め、`PreflightMixin` とMRO hookを明示注入型checkerへ置換します。

## 変更内容

- `PreflightChecker` collaboratorを追加
- uploaderは認証チャンネル照合→checker.checkを明示順序で実行
- public/private二段hookと `super().preflight_check` MRO依存を撤去
- config / duration probe / metadata generator / master resolverを注入可能化
- stub host / private module patchをchecker直接テストへ移行
- B4でMRO hook不在を固定し、公開method集合・観測契約を維持
- CHANGELOGを更新

## 検証

- focused: 255 passed
- uploads・関連: 621 passed
- full: 9,173 passed / 3 skipped（既知lifecycle timeoutは単独green）
- ruff check / format check: green

Closes #3933
