### PR TITLE
refactor(uploads): mixin継承を明示委譲へ置換する (#3934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。
 - `refactor(collections)`: collection 初期化、batch 動画遷移、upload 完了の3 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新の消失を防ぐ（#3877）。
 - `test(collections)`: `workflow-state.json` の owner 外 direct I/O 30 ファイルを縮小専用 allowlist として固定し、新規越境を file・line・operation 付きで診断する契約を追加する（#3876）。
+- `refactor(uploads)`: uploads domain の残存 mixin 継承を全廃し、Complete Collection の strategy / executor を `YouTubeAutoUploader` / `CollectionUploader` から明示委譲する構成へ置換する（#3934）。
 - `refactor(uploads)`: `PreflightMixin` の MRO hook を、認証チャンネル照合後に明示注入した preflight checker を呼ぶ合成へ置換し、既存の判定・エラー契約を維持する（#3933）。
 - `refactor(uploads)`: `DedupSearchMixin` を YouTube service を明示注入する重複検索 helper へ置換し、完全一致・ghost 除外・quota 記録・fail-open 契約を維持する（#3932）。
 - `refactor(uploads)`: `PlaylistAssignmentMixin` を YouTube clients を明示注入する playlist 割り当てコラボレータへ置換し、割り当て失敗を状態確定前に伝播する契約を維持する（#3931）。

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -1,10 +1,4 @@
-"""Complete Collection アップロード実行ループ。
-
-責務分割（Issue #465）の一環で ``collection_uploader.py`` から分離した。
-``self.uploader`` / ``self.tracking_store`` / ``self.config`` /
-``self._move_collection_to_live`` / ``self.playlist_assignment`` は合成先クラス
-（``CollectionUploader`` 本体）が提供する。
-"""
+"""Complete Collection アップロード実行 collaborator。"""
 
 from __future__ import annotations
 
@@ -28,10 +22,24 @@ logger = logging.getLogger(__name__)
 _COMPLETE_COLLECTION_ERROR = "complete collection upload failed"
 
 
-class CompleteCollectionExecutorMixin:
-    """Complete Collection アップロード実行ループを提供する mixin。"""
+class CompleteCollectionExecutor:
+    """明示された collaborator で Complete Collection 実行ループを進める。"""
 
-    def _failed_complete_collection(self, collection_path: Path, tracking: dict, error: AutomationError) -> dict:
+    def __init__(
+        self,
+        uploader,
+        tracking_store,
+        config: dict,
+        playlist_assignment,
+        move_collection_to_live,
+    ) -> None:
+        self.uploader = uploader
+        self.tracking_store = tracking_store
+        self.config = config
+        self.playlist_assignment = playlist_assignment
+        self.move_collection_to_live = move_collection_to_live
+
+    def failed(self, collection_path: Path, tracking: dict, error: AutomationError) -> dict:
         current = self.tracking_store.load(collection_path) or tracking
         cc_current = current.setdefault("complete_collection", {})
         cc_current["status"] = "failed"
@@ -40,7 +48,7 @@ class CompleteCollectionExecutorMixin:
         logger.error("❌ Complete Collection エラー: %s", redact_sensitive_data(str(error), collection_path))
         return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
 
-    def _finish_uploaded_collection(
+    def finish(
         self,
         collection_path: Path,
         tracking: dict,
@@ -61,7 +69,7 @@ class CompleteCollectionExecutorMixin:
         post_processing_errors: list[str] = []
         if self.config["collections_management"].get("auto_move_to_live", True):
             try:
-                collection_path = self._move_collection_to_live(collection_path)
+                collection_path = self.move_collection_to_live(collection_path)
             except AutomationError as error:
                 post_processing_errors.append("move_to_live")
                 logger.error(
@@ -95,9 +103,7 @@ class CompleteCollectionExecutorMixin:
         logger.info(f"📹 {complete_video['video_url']}")
         return {"action": action, "details": {**tracking["complete_collection"]}}
 
-    def _execute_complete_collection(
-        self, collection_path: Path, tracking: dict, publish_at: str | None = None
-    ) -> dict:
+    def run(self, collection_path: Path, tracking: dict, publish_at: str | None = None) -> dict:
         """Complete Collection アップロード"""
         logger.info("📅 Complete Collection アップロード開始")
         logger.info(f"🎵 コレクション: {collection_path.name}")
@@ -156,11 +162,11 @@ class CompleteCollectionExecutorMixin:
                 "details": {"error": "quota exhausted", "retry_after_seconds": e.retry_after_seconds},
             }
         except AutomationError as error:
-            return self._failed_complete_collection(collection_path, tracking, error)
+            return self.failed(collection_path, tracking, error)
 
         complete_video = result.get("complete_video")
         if complete_video and "video_id" in complete_video:
-            return self._finish_uploaded_collection(collection_path, tracking, complete_video, publish_at)
+            return self.finish(collection_path, tracking, complete_video, publish_at)
 
         error_msg = _COMPLETE_COLLECTION_ERROR
         # callback が disk に書いた URI 状態（session 失効クリア等）を保ったまま
@@ -174,4 +180,4 @@ class CompleteCollectionExecutorMixin:
         return {"action": "complete_collection_failed", "details": {"error": error_msg}}
 
 
-__all__ = ["CompleteCollectionExecutorMixin"]
+__all__ = ["CompleteCollectionExecutor"]

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -1,8 +1,4 @@
-"""Complete Collection 動画アップロード経路。
-
-``YouTubeAutoUploader`` から分離した mixin。挙動は分割前と同一で、
-``self.upload_video`` / ``self.dedup_search`` は合成先クラスが提供する。
-"""
+"""Complete Collection 動画アップロード strategy。"""
 
 from __future__ import annotations
 
@@ -71,10 +67,14 @@ def resolve_master_video(collection_dir: Path) -> Path:
     return candidates[0]
 
 
-class CompleteCollectionMixin:
-    """Complete Collection 動画のアップロード経路を提供する mixin。"""
+class CompleteCollectionStrategy:
+    """明示された upload 操作と dedup collaborator で動画を公開する。"""
 
-    def _upload_complete_collection(
+    def __init__(self, upload_video, dedup_search) -> None:
+        self.upload_video = upload_video
+        self.dedup_search = dedup_search
+
+    def upload(
         self,
         collection_dir: Path,
         metadata_gen: BAHMetadataGenerator,
@@ -179,3 +179,6 @@ class CompleteCollectionMixin:
             }
         else:
             return {"error": "Complete Collection アップロード失敗"}
+
+
+__all__ = ["CompleteCollectionStrategy", "resolve_master_video"]

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -16,7 +16,8 @@ from youtube_automation.core.adapters.youtube import (
     complete_collection_quota_plan,
 )
 from youtube_automation.core.errors import ValidationError
-from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutorMixin
+from youtube_automation.domains.uploads._collection_uploader_constants import ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED
+from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutor
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
@@ -35,22 +36,27 @@ from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["CollectionUploader"]
+__all__ = [
+    "ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED",
+    "CollectionUploader",
+    "CompleteCollectionExecutor",
+    "PlaylistAssignment",
+    "PublishedDatesScheduler",
+    "TrackingStore",
+]
 
 
-class CollectionUploader(
-    CompleteCollectionExecutorMixin,
-):
+class CollectionUploader:
     """Collection Uploader — CC アップロード専用
 
     Complete Collection を YouTube にアップロードし、
     publishAt によるスケジュール公開を管理する。
 
-    責務別の挙動は mixin に分離されている（Issue #465）:
+    責務別の挙動は collaborator へ委譲する:
     - tracking I/O           : ``TrackingStore`` への委譲
     - 公開日 / publishAt 計算: ``PublishedDatesScheduler`` への委譲
     - プレイリスト割り当て    : ``PlaylistAssignment`` への委譲
-    - CC 実行ループ           : ``CompleteCollectionExecutorMixin``
+    - CC 実行ループ           : ``CompleteCollectionExecutor``
     """
 
     def __init__(
@@ -61,6 +67,7 @@ class CollectionUploader(
         tracking_store: TrackingStore | None = None,
         published_dates: PublishedDatesScheduler | None = None,
         playlist_assignment: PlaylistAssignment | None = None,
+        complete_collection_executor: CompleteCollectionExecutor | None = None,
     ):
         if collections_root is None:
             collections_root = channel_dir() / "collections"
@@ -78,6 +85,17 @@ class CollectionUploader(
         self.published_dates = published_dates or PublishedDatesScheduler(self.config, self._provide_youtube_service)
         self.playlist_assignment = (
             playlist_assignment if playlist_assignment is not None else PlaylistAssignment(youtube_clients)
+        )
+        self.complete_collection_executor = (
+            complete_collection_executor
+            if complete_collection_executor is not None
+            else CompleteCollectionExecutor(
+                self.uploader,
+                self.tracking_store,
+                self.config,
+                self.playlist_assignment,
+                self._move_collection_to_live,
+            )
         )
 
     # ─── 設定・初期化 ───────────────────────────────
@@ -216,6 +234,26 @@ class CollectionUploader(
         self.tracking_store.save(collection_path, tracking)
         logger.info("✅ 全ステップ完了")
         return {"action": "all_completed", "details": {}}
+
+    def _failed_complete_collection(self, collection_path: Path, tracking: dict, error) -> dict:
+        return self.complete_collection_executor.failed(collection_path, tracking, error)
+
+    def _finish_uploaded_collection(
+        self,
+        collection_path: Path,
+        tracking: dict,
+        complete_video: dict,
+        publish_at: str | None,
+    ) -> dict:
+        return self.complete_collection_executor.finish(collection_path, tracking, complete_video, publish_at)
+
+    def _execute_complete_collection(
+        self,
+        collection_path: Path,
+        tracking: dict,
+        publish_at: str | None = None,
+    ) -> dict:
+        return self.complete_collection_executor.run(collection_path, tracking, publish_at)
 
     def ensure_upload_preflight(self, collection_path: Path) -> None:
         """CLI の各入口で共通の骨格・タイトル preflight を実行する。"""

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -17,7 +17,7 @@ from youtube_automation.core.errors import (
     YouTubeAPIError,
 )
 from youtube_automation.domains.metadata import BAHMetadataGenerator
-from youtube_automation.domains.uploads._complete_collection_strategy import CompleteCollectionMixin
+from youtube_automation.domains.uploads._complete_collection_strategy import CompleteCollectionStrategy
 from youtube_automation.domains.uploads._dedup_search import DedupSearch
 from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads._uploader_constants import (
@@ -229,15 +229,15 @@ __all__ = [
     "UPLOAD_SOURCE_EXISTING",
     "UPLOAD_SOURCE_NEW",
     "YOUTUBE_VIDEO_URL_PREFIX",
+    "CompleteCollectionStrategy",
+    "DedupSearch",
+    "PreflightChecker",
     "ResumableUploader",
     "YouTubeAutoUploader",
 ]
 
 
-class YouTubeAutoUploader(
-    CompleteCollectionMixin,
-    ResumableUploader,
-):
+class YouTubeAutoUploader(ResumableUploader):
     """YouTube自動アップロードメインクラス
 
     YouTubeUploadCore を継承し、コレクション単位のアップロード機能を提供する。
@@ -251,6 +251,7 @@ class YouTubeAutoUploader(
         youtube_clients: YouTubeClients | None = None,
         dedup_search: DedupSearch | None = None,
         preflight_checker: PreflightChecker | None = None,
+        complete_collection_strategy: CompleteCollectionStrategy | None = None,
     ) -> None:
         """
         初期化
@@ -268,6 +269,7 @@ class YouTubeAutoUploader(
         self.preflight_checker = (
             preflight_checker if preflight_checker is not None else PreflightChecker(self.collections_root)
         )
+        self._complete_collection_strategy = complete_collection_strategy
         self._verified_authenticated_channel_id: str | None = None
 
     @property
@@ -291,6 +293,31 @@ class YouTubeAutoUploader(
         """チャンネル本人性を確認してからメタデータ品質を検証する。"""
         self._verify_authenticated_upload_channel()
         self.preflight_checker.check(collection_dir)
+
+    def _upload_complete_collection(
+        self,
+        collection_dir: Path,
+        metadata_gen: BAHMetadataGenerator,
+        publish_at: Optional[str] = None,
+        *,
+        resume_session_uri: Optional[str] = None,
+        on_session_uri_changed: Optional[Callable[[Optional[str]], None]] = None,
+        on_upload_complete: Optional[Callable[[], None]] = None,
+    ) -> Optional[Dict]:
+        """Complete Collection strategy へ明示的に委譲する。"""
+        strategy = (
+            self._complete_collection_strategy
+            if self._complete_collection_strategy is not None
+            else CompleteCollectionStrategy(self.upload_video, self.dedup_search)
+        )
+        return strategy.upload(
+            collection_dir,
+            metadata_gen,
+            publish_at,
+            resume_session_uri=resume_session_uri,
+            on_session_uri_changed=on_session_uri_changed,
+            on_upload_complete=on_upload_complete,
+        )
 
     def upload_video(
         self,

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -11,7 +11,7 @@ from youtube_automation.commands.media import populate_scene_phrases
 from youtube_automation.configuration import load_config, reset
 from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.metadata import BAHMetadataGenerator
-from youtube_automation.domains.uploads._preflight import PreflightChecker
+from youtube_automation.domains.uploads.youtube import PreflightChecker
 
 
 def _write_json(path: Path, data: dict) -> None:

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -21,9 +21,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
-from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
-from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
-from youtube_automation.domains.uploads._tracking_io import TrackingStore
+from youtube_automation.domains.uploads.collection import PlaylistAssignment, PublishedDatesScheduler, TrackingStore
 
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -405,6 +403,21 @@ def test_collection_uploader_accepts_injected_playlist_assignment(tmp_path: Path
         )
 
     assert uploader.playlist_assignment is playlist_assignment
+
+
+def test_collection_uploader_delegates_to_injected_complete_collection_executor(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    executor = MagicMock()
+    executor.run.return_value = {"action": "delegated"}
+    uploader = CollectionUploader(collections_root=str(tmp_path), complete_collection_executor=executor)
+    collection = tmp_path / "collection"
+    tracking = {"status": "pending"}
+
+    assert uploader._execute_complete_collection(collection, tracking, publish_at="2099-01-01T00:00:00Z") == {
+        "action": "delegated"
+    }
+    executor.run.assert_called_once_with(collection, tracking, "2099-01-01T00:00:00Z")
 
 
 def test_collection_uploader_delegates_publish_date_calculation(tmp_path: Path) -> None:
@@ -1195,9 +1208,7 @@ class TestExecuteCompleteCollectionResume:
         （callback が既に永続化済み）を温存したまま次回実行に委ねる。
         """
         from youtube_automation.core.errors import QuotaExhaustedError
-        from youtube_automation.domains.uploads._collection_uploader_constants import (
-            ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
-        )
+        from youtube_automation.domains.uploads.collection import ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED
 
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)

--- a/tests/domains/uploads/test_dedup_search.py
+++ b/tests/domains/uploads/test_dedup_search.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from youtube_automation.domains.uploads._dedup_search import DedupSearch
+from youtube_automation.domains.uploads.youtube import DedupSearch
 
 
 def test_search_helper_uses_injected_youtube_service() -> None:

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -11,8 +11,7 @@ import pytest
 
 from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import ValidationError
-from youtube_automation.domains.uploads._preflight import PreflightChecker
-from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+from youtube_automation.domains.uploads.youtube import PreflightChecker, YouTubeAutoUploader
 
 
 def _write_json(path: Path, data: dict) -> None:

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
-from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
+from youtube_automation.domains.uploads.collection import PublishedDatesScheduler
 
 TZ = ZoneInfo("Asia/Tokyo")
 

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -259,7 +259,7 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
 
 class TestPreflightLocalizationLanguages:
     def test_should_pass_when_supported_scene_languages_are_present(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja"])
         checker = PreflightChecker(tmp_path, config_loader=lambda: _make_preflight_config(["ja", "en"]))
@@ -267,7 +267,7 @@ class TestPreflightLocalizationLanguages:
         checker.check(col_dir)
 
     def test_should_pass_when_required_high_cpm_languages_are_present(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja", "de"])
         checker = PreflightChecker(tmp_path, config_loader=lambda: _make_preflight_config(["ja", "en", "de"]))
@@ -275,7 +275,7 @@ class TestPreflightLocalizationLanguages:
         checker.check(col_dir)
 
     def test_should_warn_and_continue_when_low_cpm_language_is_present(self, tmp_path, caplog):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         col_dir = _write_preflight_collection(tmp_path, ["en", "ja", "de", "ko"])
         checker = PreflightChecker(
@@ -364,7 +364,7 @@ class TestPreflightTitleTemplateCompliance:
     """#602: 鋳型逸脱・巻数表記・RHS 重複を preflight で block する."""
 
     def test_should_fail_on_volume_and_rhs_duplicate(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         _write_live_title(
             tmp_path,
@@ -384,7 +384,7 @@ class TestPreflightTitleTemplateCompliance:
             checker.check(col_dir)
 
     def test_should_pass_on_compliant_title(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         _write_live_title(
             tmp_path,
@@ -403,7 +403,7 @@ class TestPreflightTitleTemplateCompliance:
         checker.check(col_dir)
 
     def test_should_allow_opted_in_volume_without_disabling_default_detection(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
 
         opted_in_collection = _write_title_collection(
             tmp_path,
@@ -434,8 +434,7 @@ class TestPreflightTitleTemplateCompliance:
             checker.check(false_collection)
 
     def test_upload_collection_reaches_post_preflight_for_opted_in_volume(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads.youtube import PreflightChecker, YouTubeAutoUploader
 
         class PostPreflightReached(Exception):
             pass
@@ -462,8 +461,7 @@ class TestPreflightTitleTemplateCompliance:
             uploader.upload_collection(collection)
 
     def test_upload_collection_rejects_default_volume_before_metadata_generation(self, tmp_path):
-        from youtube_automation.domains.uploads._preflight import PreflightChecker
-        from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+        from youtube_automation.domains.uploads.youtube import PreflightChecker, YouTubeAutoUploader
 
         collection = _write_title_collection(
             tmp_path,
@@ -673,6 +671,26 @@ class TestUploadCollectionForwarding:
         assert call_kwargs.get("on_session_uri_changed") is on_session
         assert call_kwargs.get("on_upload_complete") is on_complete
 
+
+def test_uploader_delegates_complete_collection_to_injected_strategy(tmp_path):
+    from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
+
+    strategy = MagicMock()
+    strategy.upload.return_value = {"video_id": "v1"}
+    uploader = YouTubeAutoUploader(collections_root=str(tmp_path), complete_collection_strategy=strategy)
+    collection = tmp_path / "collection"
+    metadata_generator = MagicMock()
+
+    assert uploader._upload_complete_collection(collection, metadata_generator) == {"video_id": "v1"}
+    strategy.upload.assert_called_once_with(
+        collection,
+        metadata_generator,
+        None,
+        resume_session_uri=None,
+        on_session_uri_changed=None,
+        on_upload_complete=None,
+    )
+
     def test_should_forward_resume_kwargs_from_complete_collection_to_upload_video(self, tmp_path):
         """`_upload_complete_collection` が `self.upload_video` に resume kwargs を渡す."""
         # Given
@@ -723,7 +741,7 @@ class TestFindExistingVideoByTitle:
     """publish 直前の同タイトル検索（dedup 安全網）の振る舞い."""
 
     def _make_uploader_with_mock_youtube(self, tmp_path):
-        from youtube_automation.domains.uploads._dedup_search import DedupSearch
+        from youtube_automation.domains.uploads.youtube import DedupSearch
 
         mock_youtube = MagicMock()
         return DedupSearch(mock_youtube), mock_youtube
@@ -942,7 +960,7 @@ class TestDedupSearchQuotaRecording:
     """重複検索 helper が実 request ごとに quota を記録すること."""
 
     def _make_uploader_with_mock_youtube(self, tmp_path):
-        from youtube_automation.domains.uploads._dedup_search import DedupSearch
+        from youtube_automation.domains.uploads.youtube import DedupSearch
 
         mock_youtube = MagicMock()
         return DedupSearch(mock_youtube), mock_youtube
@@ -1287,7 +1305,7 @@ class TestUploadCompleteCollectionDedup:
         mock_youtube = MagicMock()
         mock_youtube.search.return_value.list.return_value.execute.side_effect = _make_http_error(500)
         uploader.youtube = mock_youtube
-        from youtube_automation.domains.uploads._dedup_search import DedupSearch
+        from youtube_automation.domains.uploads.youtube import DedupSearch
 
         uploader._dedup_search = DedupSearch(mock_youtube)
 
@@ -1685,7 +1703,7 @@ class TestNormalizePublishAt:
     [{"snippet": {"title": "Rainy Jazz"}}, {"id": {"videoId": "v9"}}],
 )
 def test_dedup_fails_open_for_invalid_search_response_shape(tmp_path, search_item):
-    from youtube_automation.domains.uploads._dedup_search import DedupSearch
+    from youtube_automation.domains.uploads.youtube import DedupSearch
 
     uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {"items": [search_item]}
@@ -1695,7 +1713,7 @@ def test_dedup_fails_open_for_invalid_search_response_shape(tmp_path, search_ite
 
 @pytest.mark.parametrize("response", [None, {"items": None}, {"items": {}}])
 def test_dedup_fails_open_for_invalid_search_response_container(tmp_path, response):
-    from youtube_automation.domains.uploads._dedup_search import DedupSearch
+    from youtube_automation.domains.uploads.youtube import DedupSearch
 
     uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = response
@@ -1712,7 +1730,7 @@ def test_dedup_fails_open_for_invalid_search_response_container(tmp_path, respon
     ],
 )
 def test_dedup_fails_open_for_invalid_video_response_shape(tmp_path, video_item):
-    from youtube_automation.domains.uploads._dedup_search import DedupSearch
+    from youtube_automation.domains.uploads.youtube import DedupSearch
 
     uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {
@@ -1725,7 +1743,7 @@ def test_dedup_fails_open_for_invalid_video_response_shape(tmp_path, video_item)
 
 @pytest.mark.parametrize("response", [None, {"items": None}, {"items": {}}])
 def test_dedup_fails_open_for_invalid_video_response_container(tmp_path, response):
-    from youtube_automation.domains.uploads._dedup_search import DedupSearch
+    from youtube_automation.domains.uploads.youtube import DedupSearch
 
     uploader = DedupSearch(MagicMock())
     uploader.youtube.search.return_value.list.return_value.execute.return_value = {

--- a/tests/test_b4_reorganization_contract.py
+++ b/tests/test_b4_reorganization_contract.py
@@ -43,14 +43,6 @@ LEGACY_AGENT_OWNERS = {
         "youtube_automation.domains.uploads._collection_uploader_constants",
         "ACTION_COMPLETE_COLLECTION_UPLOADED",
     ),
-    "_complete_collection_executor": (
-        "youtube_automation.domains.uploads._complete_collection_executor",
-        "CompleteCollectionExecutorMixin",
-    ),
-    "_complete_collection_strategy": (
-        "youtube_automation.domains.uploads._complete_collection_strategy",
-        "CompleteCollectionMixin",
-    ),
     "_dedup_search": ("youtube_automation.domains.uploads._dedup_search", "DedupSearch"),
     "_playlist_assignment": ("youtube_automation.domains.uploads._playlist_assignment", "PlaylistAssignment"),
     "_preflight": ("youtube_automation.domains.uploads._preflight", "PreflightChecker"),
@@ -223,6 +215,41 @@ def test_upload_preflight_uses_explicit_checker_without_mro_hook() -> None:
 
     assert "super().preflight_check" not in source
     assert "self.preflight_checker.check(collection_dir)" in source
+
+
+def test_upload_domain_has_no_mixin_classes_or_test_private_imports() -> None:
+    mixins: list[str] = []
+    for path in (SRC / "domains" / "uploads").glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        mixins.extend(
+            node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name.endswith("Mixin")
+        )
+
+    private_imports: list[str] = []
+    for path in (ROOT / "tests").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module is not None
+                and node.module.startswith("youtube_automation.domains.uploads._")
+            ):
+                private_imports.append(node.module)
+            elif isinstance(node, ast.Import):
+                private_imports.extend(
+                    alias.name for alias in node.names if alias.name.startswith("youtube_automation.domains.uploads._")
+                )
+
+    assert mixins == []
+    assert private_imports == []
+
+
+def test_upload_hosts_keep_only_the_real_resumable_base() -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+    from youtube_automation.domains.uploads.youtube import ResumableUploader, YouTubeAutoUploader
+
+    assert YouTubeAutoUploader.__bases__ == (ResumableUploader,)
+    assert CollectionUploader.__bases__ == (object,)
 
 
 @pytest.mark.parametrize("filename", UPLOADER_ENTRYPOINTS)


### PR DESCRIPTION
## 概要

uploads内部構造の区切りとしてmixin継承を全廃し、executor / strategyを明示collaboratorへ置換します。

## 変更内容

- CompleteCollectionExecutorMixin / CompleteCollectionMixinを通常collaboratorへ置換
- YouTubeAutoUploaderはResumableUploaderのみ継承
- CollectionUploaderはobject直下とし、既存private/public経路から明示委譲
- testsのuploads private module直接importをゼロ化
- 残存 `*Mixin` classゼロ、host base、注入委譲をB4/単体契約で固定
- 公開11メソッドを不変維持
- CHANGELOGを更新

## 検証

- focused: 517 passed
- full: 9,177 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3934
