### PR TITLE
refactor(uploads): workflow-state読み取りをownerへ移行する (#3881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。
 - `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。
+- `refactor(uploads)`: uploads ドメインの `workflow-state` 読み取り6ファイルを owner の型付き accessor 経由へ移行し、破損時の既存 fail-open / fail-loud 契約を維持する（#3881）。
 - `refactor(collections)`: raw master・batch video・thumbnail auto selection・DistroKid release date・Suno selection の5 writerを `workflow-state` owner の lock + atomic update へ移行する（#3880）。
 - `refactor(collections)`: collection server と Suno downloaded の `workflow-state` 読み書きを owner API へ移し、downloaded 更新を lock + atomic update に統一する（#3879）。
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -284,6 +284,10 @@ class PlanningState(_ObjectSection):
             raise WorkflowStateError("workflow-state.json::planning.music must be an object")
         return MusicPlanningState(value)
 
+    @property
+    def activities(self) -> str | None:
+        return _optional_string(self._data, "activities", "workflow-state.json::planning.activities")
+
 
 class UploadState(_ObjectSection):
     """YouTube upload state の型付き view。"""
@@ -389,6 +393,19 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def upload(self) -> UploadState | None:
         value = self._data.get("upload")
         return UploadState(value) if isinstance(value, dict) else None
+
+    @property
+    def theme(self) -> str | None:
+        return _optional_string(self._data, "theme", "workflow-state.json::theme")
+
+    @property
+    def scene_phrases(self) -> dict[str, JSONValue] | None:
+        value = self._data.get("scene_phrases")
+        return deepcopy(value) if isinstance(value, dict) else None
+
+    @property
+    def allow_volume_patterns(self) -> bool:
+        return self._section_bool("title_template_check", "allow_volume_patterns") is True
 
     @property
     def thumbnail_approved(self) -> bool:

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Callable, Dict, Optional
 
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
@@ -18,7 +18,7 @@ from youtube_automation.domains.uploads.descriptions_md import (
     extract_body_for_localizations,
     load_descriptions_md,
 )
-from youtube_automation.infrastructure.filesystem import glob_files, path_exists, path_is_file, read_json
+from youtube_automation.infrastructure.filesystem import glob_files, path_is_file
 
 logger = logging.getLogger(__name__)
 
@@ -27,23 +27,24 @@ def resolve_master_video(collection_dir: Path) -> Path:
     """workflow-state の明示値を優先し、Preview をマスター扱いしない。"""
     paths = CollectionPaths(collection_dir)
     state_path = paths.workflow_state_path
-    if path_exists(state_path):
+    try:
+        state = read_workflow_state_or_none(state_path)
+    except WorkflowStateError as exc:
+        if "root must be an object" in str(exc):
+            raise ValidationError("workflow-state.json root は object である必要があります") from exc
+        if "::assets must be an object" in str(exc):
+            raise ValidationError("workflow-state.json::assets は object である必要があります") from exc
+        raise ValidationError(f"workflow-state.json を読めません: {state_path}: {exc}") from exc
+    if state is not None:
+        assets = state.assets
         try:
-            state = read_json(state_path)
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ValidationError(f"workflow-state.json を読めません: {state_path}: {exc}") from exc
-        if not isinstance(state, dict):
-            raise ValidationError("workflow-state.json root は object である必要があります")
-        assets = state.get("assets", {})
-        if not isinstance(assets, dict):
-            raise ValidationError("workflow-state.json::assets は object である必要があります")
-        configured = assets.get("master_video")
+            configured = assets.master_video if assets is not None else None
+        except WorkflowStateError as exc:
+            raise ValidationError(
+                "workflow-state.json::assets.master_video は .mp4 のファイル名で指定してください"
+            ) from exc
         if configured is not None:
-            if (
-                not isinstance(configured, str)
-                or Path(configured).name != configured
-                or Path(configured).suffix.lower() != ".mp4"
-            ):
+            if Path(configured).name != configured or Path(configured).suffix.lower() != ".mp4":
                 raise ValidationError("workflow-state.json::assets.master_video は .mp4 のファイル名で指定してください")
             selected = paths.master_dir / configured
             if not path_is_file(selected):

--- a/src/youtube_automation/domains/uploads/_playlist_assignment.py
+++ b/src/youtube_automation/domains/uploads/_playlist_assignment.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 
 from youtube_automation.configuration import ChannelConfig, load_config
 from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.uploads.playlists import PlaylistManager
-from youtube_automation.infrastructure.filesystem import path_exists, read_file_text
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
@@ -31,12 +31,12 @@ class PlaylistAssignment:
     def assign(self, video_id: str, collection_path: Path) -> None:
         """アップロード後にプレイリストへ自動追加する。"""
         ws_path = CollectionPaths(collection_path).workflow_state_path
-        if not path_exists(ws_path):
+        try:
+            state = read_workflow_state_or_none(ws_path)
+            theme = state.theme if state is not None else None
+        except WorkflowStateError as exc:
+            logger.warning(f"workflow-state.json 読み込み失敗 ({ws_path}): {exc}")
             return
-
-        ws = json.loads(read_file_text(ws_path))
-
-        theme = ws.get("theme", "")
         if not theme:
             return
 

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from pathlib import Path
 
 from youtube_automation.configuration import load_config
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.metadata.descriptions import (
     build_descriptions_md_parse_diagnostics,
@@ -33,7 +35,6 @@ from youtube_automation.infrastructure.filesystem import (
     path_exists,
     path_is_directory,
     read_file_text,
-    read_json,
 )
 
 logger = logging.getLogger(__name__)
@@ -136,14 +137,18 @@ class PreflightChecker:
             raise ValidationError(
                 f"❌ {ws_path} が存在しません。/wf-new または /video --describe の前提を確認してください。"
             )
-        state = read_json(ws_path)
-        title_template_check = state.get("title_template_check")
+        try:
+            state = read_workflow_state(ws_path)
+        except WorkflowStateError as exc:
+            if isinstance(exc.__cause__, json.JSONDecodeError):
+                raise exc.__cause__ from exc
+            raise
 
         # タイトル鋳型準拠チェック（巻数表記・RHS 重複・鋳型逸脱を機械検出）。
         # 鋳型語彙・パターンは config 駆動、` | ` 鋳型を使うチャンネルでのみ適用。
         title_cfg = config.content.title
         template_check_cfg = {**dict(title_cfg.template_check), "template": title_cfg.template}
-        if isinstance(title_template_check, dict) and title_template_check.get("allow_volume_patterns") is True:
+        if state.allow_volume_patterns:
             template_check_cfg["volume_patterns"] = ()
         existing_titles = self._collect_live_titles(exclude_dir=collection_dir)
         msg = check_title_template_compliance(title, existing_titles, template_check_cfg)
@@ -166,7 +171,7 @@ class PreflightChecker:
         if msg:
             raise ValidationError(f"❌ {msg}: 1 パターン = 1 chapter で再生成してください。")
 
-        scene_phrases = state.get("scene_phrases") or {}
+        scene_phrases = state.scene_phrases or {}
 
         if requires_scene_phrases(config.localizations.supported_languages):
             required_langs = list(dict.fromkeys(config.localizations.supported_languages))

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -15,7 +15,8 @@ from youtube_automation.core.adapters.youtube import (
     UNIT_POOL_LIMIT,
     complete_collection_quota_plan,
 )
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.uploads._collection_uploader_constants import ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutor
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
@@ -29,7 +30,6 @@ from youtube_automation.infrastructure.filesystem import (
     path_exists,
     path_is_directory,
     read_file_text,
-    read_json,
     rename_path,
 )
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
@@ -169,19 +169,13 @@ class CollectionUploader:
         for collection in self.find_collections(("planning",)):
             state_path = CollectionPaths(collection).workflow_state_path
             try:
-                state = read_json(state_path)
-            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                state = read_workflow_state(state_path)
+            except WorkflowStateError as exc:
                 logger.warning(f"⚠️  workflow-state.json を読み取れないため候補から除外します: {state_path}: {exc}")
                 continue
 
-            upload = state.get("upload") if isinstance(state, dict) else None
-            if (
-                isinstance(state, dict)
-                and state.get("phase") == "mastered"
-                and isinstance(upload, dict)
-                and "video_id" in upload
-                and upload["video_id"] is None
-            ):
+            upload = state.upload
+            if state.phase == "mastered" and upload is not None and "video_id" in upload and upload.video_id is None:
                 candidates.append(collection)
 
         if not candidates:

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -1,13 +1,13 @@
 """YouTube playlist upload operations owned by the uploads domain."""
 
-import json
 import logging
 from pathlib import Path
 from typing import Protocol
 
 from youtube_automation.configuration import channel_dir, load_config, reset
 from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.errors import ValidationError, YouTubeAPIError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, YouTubeAPIError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.infrastructure.filesystem import (
     list_directory,
     path_exists,
@@ -213,14 +213,13 @@ class PlaylistManager:
         `activity_for_theme` fallback させる（プレイリスト追加は非致命的機能のため）。
         """
         ws_path = CollectionPaths(collection_path).workflow_state_path
-        if not path_exists(ws_path):
-            return None
         try:
-            data = read_json(ws_path)
-        except (OSError, json.JSONDecodeError) as e:
+            state = read_workflow_state_or_none(ws_path)
+            planning = state.planning if state is not None else None
+            explicit = planning.activities if planning is not None else None
+        except WorkflowStateError as e:
             logger.warning(f"workflow-state.json 読み込み失敗 ({ws_path}): {e}")
             return None
-        explicit = data.get("planning", {}).get("activities")
         return explicit if isinstance(explicit, str) and explicit else None
 
     def _list_playlist_video_ids(self, playlist_id: str) -> set[str]:
@@ -325,13 +324,12 @@ class PlaylistManager:
 
             # workflow-state.json からテーマ取得
             ws_path = paths.workflow_state_path
-            if not path_exists(ws_path):
+            state = read_workflow_state_or_none(ws_path)
+            if state is None:
                 logger.warning(f"  {col_path.name}: workflow-state.json なし — スキップ")
                 continue
 
-            ws = read_json(ws_path)
-
-            theme = ws.get("theme", "")
+            theme = state.theme
             if not theme:
                 logger.warning(f"  {col_path.name}: theme 未設定 — スキップ")
                 continue
@@ -350,7 +348,9 @@ class PlaylistManager:
                 continue
 
             # タイトル取得（表示用）
-            title = ws.get("steps", {}).get("planning", {}).get("final_title", col_path.name)
+            steps = state.get("steps")
+            planning = steps.get("planning") if isinstance(steps, dict) else None
+            title = planning.get("final_title", col_path.name) if isinstance(planning, dict) else col_path.name
 
             activity_override = self._planning_activities(col_path)
 

--- a/src/youtube_automation/domains/uploads/preflight.py
+++ b/src/youtube_automation/domains/uploads/preflight.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from youtube_automation.configuration import load_config
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.youtube import parse_youtube_tags, youtube_tag_chars
-from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.metadata.descriptions import (
     build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
@@ -31,7 +32,6 @@ from youtube_automation.infrastructure.filesystem import (
     path_is_file,
     path_is_symlink,
     read_file_text,
-    read_json,
 )
 
 YT_TAG_CHAR_LIMIT = 500
@@ -533,14 +533,16 @@ def _validate_scene_phrases(paths: CollectionPaths, supported_languages: list[st
     if not path_is_file(paths.workflow_state_path):
         return []
     try:
-        state = read_json(paths.workflow_state_path)
-    except json.JSONDecodeError:
-        return ["workflow-state.json の JSON が不正"]
-    if not isinstance(state, dict):
-        return ["workflow-state.json の root は object である必要があります"]
+        state = read_workflow_state(paths.workflow_state_path)
+    except WorkflowStateError as exc:
+        if isinstance(exc.__cause__, json.JSONDecodeError):
+            return ["workflow-state.json の JSON が不正"]
+        if "root must be an object" in str(exc):
+            return ["workflow-state.json の root は object である必要があります"]
+        raise
     if not requires_scene_phrases(supported_languages):
         return []
-    scene_phrases = state.get("scene_phrases")
+    scene_phrases = state.scene_phrases
     if not isinstance(scene_phrases, dict) or not scene_phrases:
         return ["workflow-state.json.scene_phrases なし（yt-populate-scene-phrases を実行）"]
     missing = [lang for lang in supported_languages if not scene_phrases.get(lang)]

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -118,6 +118,29 @@ def test_read_rejects_non_object_known_section(tmp_path: Path) -> None:
         read(state_path)
 
 
+def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(
+        state_path,
+        {
+            "theme": "Rainy Jazz",
+            "planning": {"activities": "focus"},
+            "scene_phrases": {"en": "continuous focus mix"},
+            "title_template_check": {"allow_volume_patterns": True},
+            "future_section": {"enabled": True},
+        },
+    )
+
+    state = read(state_path)
+
+    assert state.theme == "Rainy Jazz"
+    assert state.planning is not None
+    assert state.planning.activities == "focus"
+    assert state.scene_phrases == {"en": "continuous focus mix"}
+    assert state.allow_volume_patterns is True
+    assert state["future_section"] == {"enabled": True}
+
+
 def test_compatible_music_engine_accessor_rejects_conflicting_values(tmp_path: Path) -> None:
     state_path = tmp_path / "workflow-state.json"
     _write(state_path, {"music_engine": "suno", "planning": {"music": {"engine": "lyria"}}})

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -293,6 +293,17 @@ def test_assign_to_playlists_skips_when_no_workflow_state(tmp_path):
     playlist_manager.assign_video.assert_not_called()
 
 
+def test_assign_to_playlists_skips_when_workflow_state_is_malformed(tmp_path, caplog):
+    (tmp_path / "workflow-state.json").write_text("{broken", encoding="utf-8")
+    playlist_manager = MagicMock()
+    assignment = PlaylistAssignment(MagicMock(), config=MagicMock(), playlist_manager=playlist_manager)
+
+    assignment.assign("VIDEO_ID_123", tmp_path)
+
+    assert "workflow-state.json 読み込み失敗" in caplog.text
+    playlist_manager.assign_video.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _execute_complete_collection: resumable upload session URI 連携 (issue #381)
 # ---------------------------------------------------------------------------

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -20,12 +20,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
         "src/youtube_automation/commands/youtube/pinned_comment.py",
         "src/youtube_automation/domains/distrokid/release.py",
         "src/youtube_automation/domains/suno/prompt_resolution.py",
-        "src/youtube_automation/domains/uploads/_complete_collection_strategy.py",
-        "src/youtube_automation/domains/uploads/_playlist_assignment.py",
-        "src/youtube_automation/domains/uploads/_preflight.py",
-        "src/youtube_automation/domains/uploads/collection.py",
-        "src/youtube_automation/domains/uploads/playlists.py",
-        "src/youtube_automation/domains/uploads/preflight.py",
         "src/youtube_automation/infrastructure/analytics/workflow_timing.py",
     }
 )


### PR DESCRIPTION
## 概要

workflow-state reader移行の開始点として、uploads domainの6 readerをowner APIへ統一します。

## 変更内容

- uploadsの6 readerをowner経由へ移行
- theme / planning.activities / scene_phrases等の型付きaccessorを追加
- 直parse ratchetを6ファイル縮小
- JSON破損時の既存fail-open / fail-loud契約を維持
- main側のuploads collaborator構造と統合
- CHANGELOGを更新

## 検証

- uploads広域: 430 passed
- full: 9,176 passed / 3 skipped
- latest main rebase後 focused: 252 passed
- ruff check / format check / diff check: green

Closes #3881
