### PR TITLE
refactor(uploads): ShortUploaderの重複実装を共通化する (#3935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。
 - `refactor(collections)`: raw master・batch video・thumbnail auto selection・DistroKid release date・Suno selection の5 writerを `workflow-state` owner の lock + atomic update へ移行する（#3880）。
 - `refactor(collections)`: collection server と Suno downloaded の `workflow-state` 読み書きを owner API へ移し、downloaded 更新を lock + atomic update に統一する（#3879）。
 - `refactor(collections)`: rain layer・scene phrase・track 表示名・Short upload の4 writerを `workflow-state` owner の lock + atomic update 経由へ移し、同時更新と未知 field を保持する（#3878）。

--- a/src/youtube_automation/commands/metadata/bulk_update_short_localizations.py
+++ b/src/youtube_automation/commands/metadata/bulk_update_short_localizations.py
@@ -40,7 +40,7 @@ VIDEOS_UPDATE_QUOTA_UNITS = 50
 def collect_short_videos() -> list[dict]:
     """`collections/live/*/workflow-state.json` から Shorts video_id を集める.
 
-    スキーマ: `post_upload.shorts: list[dict]`（`ShortUploader._update_workflow_state` と対称）.
+    スキーマ: `post_upload.shorts: list[dict]`（`TrackingStore.record_short_upload` と対称）.
     `20-documentation/upload_tracking.json` が無いコレクションは skip（CC URL が無いと
     description テンプレ展開が空になるため）.
 

--- a/src/youtube_automation/domains/uploads/_published_dates.py
+++ b/src/youtube_automation/domains/uploads/_published_dates.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
+from pathlib import Path
 from typing import ClassVar
 
 from youtube_automation.configuration import load_config
@@ -89,9 +90,69 @@ class PublishedDatesScheduler:
         "sun": 7,
     }
 
-    def __init__(self, config: dict, youtube_service_provider: Callable[[], object]) -> None:
+    def __init__(
+        self,
+        config: dict,
+        youtube_service_provider: Callable[[], object],
+        now_provider: Callable[[tzinfo | None], datetime] | None = None,
+    ) -> None:
         self.config = config
         self.youtube_service_provider = youtube_service_provider
+        self.now_provider = now_provider if now_provider is not None else lambda timezone: datetime.now(timezone)
+
+    def parse_persisted_datetime(self, raw: str, *, source: Path, field: str) -> datetime | None:
+        """永続化日時を読み、legacy の TZ-naive 値を schedule timezone で補正する。"""
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        if parsed.tzinfo is not None:
+            return parsed
+
+        timezone = get_schedule_timezone(self.config)
+        logger.warning(
+            "%s に TZ-naive な %s=%r が含まれます; schedule timezone %s で backfill します"
+            "（レガシーデータ救済 / #532）",
+            source,
+            field,
+            raw,
+            timezone,
+        )
+        return parsed.replace(tzinfo=timezone)
+
+    def calculate_short_publish_at(
+        self,
+        tracking: dict,
+        *,
+        tracking_path: Path,
+        publish_time: str,
+    ) -> str | None:
+        """Complete Collection 公開日時の翌日に Short の公開日時を置く。"""
+        complete_collection = tracking.get("complete_collection") or {}
+        base = complete_collection.get("publish_at")
+        base_field = "complete_collection.publish_at"
+        if not base:
+            base = complete_collection.get("upload_time")
+            base_field = "complete_collection.upload_time"
+        if not base:
+            return None
+
+        try:
+            hour, minute = (int(value) for value in publish_time.split(":"))
+        except ValueError:
+            logger.warning(f"short_publish_time のパース失敗: {publish_time}（HH:MM 形式が必要）")
+            return None
+
+        base_datetime = self.parse_persisted_datetime(base, source=tracking_path, field=base_field)
+        if base_datetime is None:
+            return None
+
+        timezone = get_schedule_timezone(self.config)
+        publish_datetime = base_datetime.astimezone(timezone) + timedelta(days=1)
+        publish_datetime = publish_datetime.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if publish_datetime <= self.now_provider(timezone):
+            return None
+        return publish_datetime.isoformat()
 
     def calculate_publish_at(self) -> str | None:
         """CC のスケジュール公開日時を計算
@@ -134,7 +195,7 @@ class PublishedDatesScheduler:
         cadence = schedule_cfg.get("cadence", [])
         allowed_weekdays = {self._WEEKDAY_MAP[d.lower()] for d in cadence} if cadence else set(range(1, 8))
 
-        now = datetime.now(tz)
+        now = self.now_provider(tz)
         publish_dt = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
 
         # 既に今日の公開時刻を過ぎていたら翌日から開始

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -10,6 +10,7 @@ from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import now_in_schedule_tz
 from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     TRACKING_STATUS_COMPLETED,
@@ -44,7 +45,7 @@ class TrackingStore:
             return None
 
         try:
-            return json.loads(read_file_text(tracking_file))
+            return self.read(collection_path)
         except (json.JSONDecodeError, UnicodeDecodeError) as e:
             # 破損ファイルを退避してから None を返す（無言で消さず証拠を保全）。
             # 呼び出し側は None を「tracking なし」として扱い dedup 探索が働く。
@@ -52,6 +53,10 @@ class TrackingStore:
             replace_file(tracking_file, corrupt_path)
             logger.error(f"❌ tracking 破損を検出、{corrupt_path} へ退避しました（原因: {e}）")
             return None
+
+    def read(self, collection_path: Path) -> dict:
+        """tracking を読み、欠落・破損時の例外を呼び出し側へ伝える。"""
+        return json.loads(read_file_text(self.tracking_path(collection_path)))
 
     def save(self, collection_path: Path, tracking: dict) -> None:
         """tracking 保存"""
@@ -106,6 +111,107 @@ class TrackingStore:
             if "workflow-state.json::upload must be an object" in str(error):
                 raise ValidationError(f"workflow-state.json upload must be object: {ws_path}") from error
             raise ValidationError(str(error)) from error
+
+    def load_workflow_state(self, workflow_state_path: Path) -> dict | None:
+        """workflow-state を読み、欠落・破損は Shorts の既存 fail-safe に合わせる。"""
+        if not path_exists(workflow_state_path):
+            return None
+        try:
+            state = read_workflow_state_or_none(workflow_state_path)
+            return state.to_dict() if state is not None else None
+        except WorkflowStateError as error:
+            logger.warning(f"workflow-state.json 読み込み失敗: {error}")
+            return None
+
+    @staticmethod
+    def _find_short_entry(shorts: list, short_num: int | None) -> dict | None:
+        for entry in shorts:
+            if isinstance(entry, dict) and entry.get("short_num") == short_num:
+                return entry
+        return None
+
+    def read_short_resume_uri(self, workflow_state_path: Path, short_num: int | None) -> str | None:
+        state = self.load_workflow_state(workflow_state_path)
+        if not state:
+            return None
+        shorts = (state.get("post_upload") or {}).get("shorts") or []
+        entry = self._find_short_entry(shorts, short_num)
+        return entry.get("resume_session_uri") if entry else None
+
+    def persist_short_resume_uri(
+        self,
+        workflow_state_path: Path,
+        short_num: int | None,
+        uri: str | None,
+    ) -> None:
+        if not path_exists(workflow_state_path):
+            logger.warning(f"workflow-state.json が無いため resume URI 永続化を skip: {workflow_state_path}")
+            return
+
+        def persist_resume_uri(state: WorkflowState) -> None:
+            post_upload = state.get("post_upload") or {}
+            if not isinstance(post_upload, dict):
+                post_upload = {}
+            shorts = post_upload.get("shorts")
+            if not isinstance(shorts, list):
+                shorts = []
+                post_upload["shorts"] = shorts
+
+            entry = self._find_short_entry(shorts, short_num)
+            if entry is None:
+                entry = {"short_num": short_num}
+                shorts.append(entry)
+            if uri is None:
+                entry.pop("resume_session_uri", None)
+            else:
+                entry["resume_session_uri"] = uri
+            state["post_upload"] = post_upload
+
+        try:
+            update_workflow_state(workflow_state_path, persist_resume_uri)
+        except WorkflowStateError as error:
+            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
+
+    def record_short_upload(
+        self,
+        collection_path: Path,
+        *,
+        short_num: int | None,
+        video_id: str,
+        publish_at: str | None,
+    ) -> None:
+        workflow_state_path = CollectionPaths(collection_path).workflow_state_path
+        if not path_exists(workflow_state_path):
+            logger.warning(f"workflow-state.json が無いため short upload 記録を skip: {workflow_state_path}")
+            return
+
+        entry = {
+            "short_num": short_num,
+            "video_id": video_id,
+            "uploaded_at": now_in_schedule_tz(self.config).isoformat(),
+            "publish_at": publish_at,
+        }
+
+        def record_uploaded_short(state: WorkflowState) -> None:
+            post_upload = state.get("post_upload") or {}
+            if not isinstance(post_upload, dict):
+                post_upload = {}
+            shorts = post_upload.get("shorts")
+            if not isinstance(shorts, list):
+                shorts = []
+                post_upload["shorts"] = shorts
+            for index, existing in enumerate(shorts):
+                if existing.get("short_num") == short_num:
+                    shorts[index] = entry
+                    break
+            else:
+                shorts.append(entry)
+            state["post_upload"] = post_upload
+
+        try:
+            update_workflow_state(workflow_state_path, record_uploaded_short)
+        except WorkflowStateError as error:
+            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
 
     def initialize(self, collection_path: Path) -> dict:
         """tracking を初期化"""

--- a/src/youtube_automation/domains/uploads/shorts.py
+++ b/src/youtube_automation/domains/uploads/shorts.py
@@ -4,24 +4,22 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.adapters.runtime import get_schedule_timezone, now_in_schedule_tz
+from youtube_automation.core.adapters.runtime import get_schedule_timezone
 from youtube_automation.core.errors import (
     AutomationError,
     QuotaExhaustedError,
     UploadError,
     ValidationError,
-    WorkflowStateError,
 )
-from youtube_automation.domains.collections.workflow_state import WorkflowState
-from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
-from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.metadata import BAHMetadataGenerator
+from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
+from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 from youtube_automation.infrastructure.filesystem import list_directory, path_exists, read_json
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
@@ -39,45 +37,23 @@ ACTION_BLOCKED = "short_upload_blocked"
 ACTION_FAILED = "short_upload_failed"
 
 
-def _backfill_naive_datetime(dt: datetime, tz, *, source: Path, field: str, raw: str) -> datetime:
-    """TZ-naive な datetime を schedule timezone で backfill する（レガシーデータ救済）.
-
-    #359 で書き込み側は `datetime.now(tz).isoformat()` の TZ-aware ISO 8601 に統一済みのため、
-    ここを踏むのは既存 live/ 配下に永続化されたレガシーデータのみ。将来 backfill 補正を
-    撤去するタイミングを判断するシグナルとして、どのファイル・どのフィールドが TZ-naive
-    だったかを warning で記録する（#532）。
-
-    Args:
-        dt: 判定対象の datetime
-        tz: backfill に使う schedule timezone
-        source: 値の出所ファイルパス（ログ用）
-        field: TZ-naive だったフィールド名（ログ用）
-        raw: パース前の生文字列（ログ用）
-
-    Returns:
-        TZ-aware な datetime（元から aware ならそのまま返す）。
-    """
-    if dt.tzinfo is not None:
-        return dt
-    logger.warning(
-        "%s に TZ-naive な %s=%r が含まれます; schedule timezone %s で backfill します（レガシーデータ救済 / #532）",
-        source,
-        field,
-        raw,
-        tz,
-    )
-    return dt.replace(tzinfo=tz)
-
-
 class ShortUploader:
     """Shorts 投稿エージェント — `YouTubeAutoUploader` 委譲版.
 
     継承禁止（plan 要件 6.6）。`self.uploader = YouTubeAutoUploader(...)` で
     アップロード I/O を委譲し、本クラスは Shorts 固有のロジック
-    （interval check / publish_at 算出 / video 探索 / state 更新）だけ持つ。
+    （interval check / video 探索 / upload orchestration）だけ持つ。
+    公開日計算と tracking / workflow-state I/O は Collection upload と同じ
+    ``PublishedDatesScheduler`` / ``TrackingStore`` を利用する。
     """
 
-    def __init__(self, collections_root: Optional[str] = None, youtube_clients: YouTubeClients | None = None):
+    def __init__(
+        self,
+        collections_root: Optional[str] = None,
+        youtube_clients: YouTubeClients | None = None,
+        tracking_store: TrackingStore | None = None,
+        published_dates: PublishedDatesScheduler | None = None,
+    ):
         self.config = load_config()
         if not self.config.shorts.enabled:
             raise UploadError(
@@ -89,6 +65,14 @@ class ShortUploader:
         self.uploader = YouTubeAutoUploader(collections_root, youtube_clients)
         self.channel_dir = channel_dir()
         self.schedule_config = self._load_schedule_config()
+        self.tracking_store = (
+            tracking_store if tracking_store is not None else TrackingStore(self.collections_root, self.schedule_config)
+        )
+        self.published_dates = (
+            published_dates
+            if published_dates is not None
+            else PublishedDatesScheduler(self.schedule_config, lambda: self.uploader.youtube)
+        )
 
     # ─── 設定読み込み ────────────────────────────────
 
@@ -129,7 +113,7 @@ class ShortUploader:
             ws_path = CollectionPaths(col_dir).workflow_state_path
             if not path_exists(ws_path):
                 continue
-            state = self._load_workflow_state(ws_path)
+            state = self.tracking_store.load_workflow_state(ws_path)
             if state is None:
                 continue
             shorts = (state.get("post_upload") or {}).get("shorts") or []
@@ -137,13 +121,13 @@ class ShortUploader:
                 uploaded_at = entry.get("uploaded_at")
                 if not uploaded_at:
                     continue
-                try:
-                    dt = datetime.fromisoformat(uploaded_at)
-                except ValueError:
-                    continue
-                dt = _backfill_naive_datetime(
-                    dt, tz, source=ws_path, field="post_upload.shorts[].uploaded_at", raw=uploaded_at
+                dt = self.published_dates.parse_persisted_datetime(
+                    uploaded_at,
+                    source=ws_path,
+                    field="post_upload.shorts[].uploaded_at",
                 )
+                if dt is None:
+                    continue
                 if latest_dt is None or dt > latest_dt:
                     latest_dt = dt
 
@@ -154,55 +138,6 @@ class ShortUploader:
         if elapsed_hours < min_hours:
             return False, f"前回 short 投稿から {elapsed_hours:.1f}h（min {min_hours}h）"
         return True, "ok"
-
-    # ─── publish_at 算出 (plan 要件 6.2) ─────────────
-
-    def _calculate_short_publish_at(self, collection_path: Path) -> Optional[str]:
-        """Shorts のスケジュール公開日時を算出.
-
-        CC `publish_at` （無ければ `upload_time`）の翌日 `short_publish_time` 時刻.
-        結果が現在より過去なら None（即時公開扱い）.
-
-        Returns:
-            ISO 8601 文字列 or None
-        """
-        tracking_path = CollectionPaths(collection_path).tracking_path
-        if not path_exists(tracking_path):
-            return None
-        try:
-            tracking = read_json(tracking_path)
-        except (json.JSONDecodeError, OSError):
-            return None
-
-        cc = tracking.get("complete_collection") or {}
-        base_str = cc.get("publish_at")
-        base_field = "complete_collection.publish_at"
-        if not base_str:
-            base_str = cc.get("upload_time")
-            base_field = "complete_collection.upload_time"
-        if not base_str:
-            return None
-
-        tz = get_schedule_timezone(self.schedule_config)
-        short_publish_time = self.config.shorts.publish_time
-        try:
-            hour, minute = (int(x) for x in short_publish_time.split(":"))
-        except ValueError:
-            logger.warning(f"short_publish_time のパース失敗: {short_publish_time}（HH:MM 形式が必要）")
-            return None
-
-        try:
-            base_dt = datetime.fromisoformat(base_str)
-        except ValueError:
-            return None
-        base_dt = _backfill_naive_datetime(base_dt, tz, source=tracking_path, field=base_field, raw=base_str)
-
-        publish_dt = base_dt.astimezone(tz) + timedelta(days=1)
-        publish_dt = publish_dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
-
-        if publish_dt <= datetime.now(tz):
-            return None
-        return publish_dt.isoformat()
 
     # ─── 動画ファイル探索 (plan 要件 6.3) ─────────────
 
@@ -250,7 +185,7 @@ class ShortUploader:
             logger.error(f"❌ upload_tracking.json が無いため Shorts 投稿不可: {tracking_path}")
             return {"action": ACTION_FAILED, "details": {"error": f"tracking missing: {tracking_path}"}}
         try:
-            tracking = read_json(tracking_path)
+            tracking = self.tracking_store.read(collection_path)
         except (json.JSONDecodeError, OSError):
             logger.error("❌ upload_tracking.json 読み込み失敗")
             return {"action": ACTION_FAILED, "details": {"error": _TRACKING_READ_ERROR}}
@@ -274,7 +209,11 @@ class ShortUploader:
             return {"action": ACTION_FAILED, "details": {"error": "short metadata generation failed"}}
 
         # 5. publish_at 算出
-        publish_at = self._calculate_short_publish_at(collection_path)
+        publish_at = self.published_dates.calculate_short_publish_at(
+            tracking,
+            tracking_path=tracking_path,
+            publish_time=self.config.shorts.publish_time,
+        )
         if publish_at:
             metadata["publish_at"] = publish_at
 
@@ -286,11 +225,11 @@ class ShortUploader:
         #    中断→再実行時に同一 session を再開し video_id 重複を防ぐ。tracking 媒体は
         #    CC の upload_tracking.json ではなく workflow-state.json.post_upload.shorts[]。
         ws_path = CollectionPaths(collection_path).workflow_state_path
-        resume_session_uri = self._read_short_resume_uri(ws_path, short_num)
+        resume_session_uri = self.tracking_store.read_short_resume_uri(ws_path, short_num)
 
         def _on_session_uri_changed(uri: Optional[str]) -> None:
             """upload 中の session URI 変化を該当 short entry に永続化する。"""
-            self._persist_short_resume_uri(ws_path, short_num, uri)
+            self.tracking_store.persist_short_resume_uri(ws_path, short_num, uri)
 
         def _on_upload_complete() -> None:
             """upload 成功通知。後続の最終記録と整合させるため URI を消す。"""
@@ -322,7 +261,7 @@ class ShortUploader:
             return {"action": ACTION_FAILED, "details": {"error": "upload_video returned None"}}
 
         # 8. workflow-state 更新（list 形式 upsert by short_num）
-        self._update_workflow_state(
+        self.tracking_store.record_short_upload(
             collection_path,
             short_num=short_num,
             video_id=video_id,
@@ -349,129 +288,21 @@ class ShortUploader:
         logger.warning(f"short-thumbnail.{{jpg,png}} が見つかりません — サムネ未設定で upload します: {assets}")
         return None
 
-    # ─── workflow-state I/O ──────────────────────────
-
-    def _load_workflow_state(self, ws_path: Path) -> Optional[dict]:
-        """workflow-state.json を読み込む。ファイル無 / パース失敗時は None（warning）。"""
-        if not path_exists(ws_path):
-            return None
-        try:
-            state = read_workflow_state_or_none(ws_path)
-            return state.to_dict() if state is not None else None
-        except WorkflowStateError as e:
-            logger.warning(f"workflow-state.json 読み込み失敗: {e}")
-            return None
-
-    @staticmethod
-    def _find_short_entry(shorts: list, short_num: Optional[int]) -> Optional[dict]:
-        """`post_upload.shorts` から short_num 一致の entry を返す（無ければ None）。"""
-        for entry in shorts:
-            if isinstance(entry, dict) and entry.get("short_num") == short_num:
-                return entry
-        return None
-
-    def _read_short_resume_uri(self, ws_path: Path, short_num: Optional[int]) -> Optional[str]:
-        """該当 short entry に永続化済みの resumable upload session URI を読む (#466)。
-
-        ファイル無 / entry 無 / 未保存なら None（＝フレッシュ実行）。
-        """
-        state = self._load_workflow_state(ws_path)
-        if not state:
-            return None
-        shorts = (state.get("post_upload") or {}).get("shorts") or []
-        entry = self._find_short_entry(shorts, short_num)
-        return entry.get("resume_session_uri") if entry else None
-
-    def _persist_short_resume_uri(self, ws_path: Path, short_num: Optional[int], uri: Optional[str]) -> None:
-        """該当 short entry の `resume_session_uri` を upsert / 削除する (#466)。
-
-        並行更新に備え毎回 disk から再ロードしてから書き戻す（CC の
-        `_on_session_uri_changed` と同思想）。`uri=None` で削除。entry が未作成なら
-        short_num のみの entry を append して URI を載せる。ファイル無 → warning skip。
-        """
-        if not path_exists(ws_path):
-            logger.warning(f"workflow-state.json が無いため resume URI 永続化を skip: {ws_path}")
-            return
-
-        def persist_resume_uri(state: WorkflowState) -> None:
-            post_upload = state.get("post_upload") or {}
-            if not isinstance(post_upload, dict):
-                post_upload = {}
-            shorts = post_upload.get("shorts")
-            if not isinstance(shorts, list):
-                shorts = []
-                post_upload["shorts"] = shorts
-
-            entry = self._find_short_entry(shorts, short_num)
-            if entry is None:
-                entry = {"short_num": short_num}
-                shorts.append(entry)
-            if uri is None:
-                entry.pop("resume_session_uri", None)
-            else:
-                entry["resume_session_uri"] = uri
-            state["post_upload"] = post_upload
-
-        try:
-            update_workflow_state(ws_path, persist_resume_uri)
-        except WorkflowStateError as error:
-            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
-
-    # ─── workflow-state 更新 (plan アンチパターン #10) ─
-
-    def _update_workflow_state(
-        self,
-        collection_path: Path,
-        *,
-        short_num: Optional[int],
-        video_id: str,
-        publish_at: Optional[str],
-    ) -> None:
-        """`post_upload.shorts: list[dict]` に short_num をキーに upsert.
-
-        ファイル無 → warning ログのみで skip（致命的にしない）.
-        書き手（本メソッド）と読み手（`bulk_update_short_localizations.collect_short_videos`）が
-        同 PR 内で対称検証されるスキーマ.
-        """
-        ws_path = CollectionPaths(collection_path).workflow_state_path
-        if not path_exists(ws_path):
-            logger.warning(f"workflow-state.json が無いため short upload 記録を skip: {ws_path}")
-            return
-
-        entry = {
-            "short_num": short_num,
-            "video_id": video_id,
-            "uploaded_at": now_in_schedule_tz(self.schedule_config).isoformat(),
-            "publish_at": publish_at,
-        }
-
-        def record_uploaded_short(state: WorkflowState) -> None:
-            post_upload = state.get("post_upload") or {}
-            if not isinstance(post_upload, dict):
-                post_upload = {}
-            shorts = post_upload.get("shorts")
-            if not isinstance(shorts, list):
-                shorts = []
-                post_upload["shorts"] = shorts
-            for index, existing in enumerate(shorts):
-                if existing.get("short_num") == short_num:
-                    shorts[index] = entry
-                    break
-            else:
-                shorts.append(entry)
-            state["post_upload"] = post_upload
-
-        try:
-            update_workflow_state(ws_path, record_uploaded_short)
-        except WorkflowStateError as error:
-            logger.warning(f"workflow-state.json 読み込み/書き込み失敗: {error}")
-
     # ─── ドライラン ──────────────────────────────────
 
     def show_plan(self, collection_path: Path, short_num: Optional[int] = None) -> None:
         """ドライラン: 投稿予定の計算結果のみ表示."""
         ok, msg = self._check_upload_interval()
-        publish_at = self._calculate_short_publish_at(collection_path)
+        tracking = self.tracking_store.load(collection_path)
+        publish_at = (
+            self.published_dates.calculate_short_publish_at(
+                tracking,
+                tracking_path=self.tracking_store.tracking_path(collection_path),
+                publish_time=self.config.shorts.publish_time,
+            )
+            if tracking is not None
+            else None
+        )
         paths = CollectionPaths(collection_path)
         target_path = paths.short_video_search_paths(short_num)[0]
         display_target = Path(target_path).relative_to(paths.root)

--- a/tests/domains/uploads/test_short_uploader.py
+++ b/tests/domains/uploads/test_short_uploader.py
@@ -6,11 +6,11 @@ plan §171 / test-design.md §44-50 §86 §117-122 §146-147 を満たすケー�
 委譲設計（`YouTubeAutoUploader` を所有）を検証し、継承禁止の規約を回帰させる。
 
 主要シナリオ:
-- `_calculate_short_publish_at`: CC publish_at + 1day + config.shorts.publish_time の計算と TZ 適用
+- `PublishedDatesScheduler.calculate_short_publish_at`: CC publish_at + 1day + Shorts 公開時刻の計算
 - `_check_upload_interval`: config.shorts.min_hours_between_shorts_per_collection の境界
 - `_find_short_video`: `shorts/short-NN-*.mp4` 優先・`short.mp4` fallback・両方無で FileNotFoundError
 - `upload_short`: 委譲先 `YouTubeAutoUploader.upload_video` の呼出・結果分岐
-- `_update_workflow_state`: `post_upload.shorts: list[dict]` で upsert by short_num
+- `TrackingStore.record_short_upload`: `post_upload.shorts: list[dict]` で upsert by short_num
 - `__init__`: `config.shorts.enabled=false` で UploadError
 """
 
@@ -112,12 +112,13 @@ def _make_short_uploader(
     """
     from youtube_automation.domains.uploads import shorts as su_mod
 
-    with patch.object(su_mod, "YouTubeAutoUploader") as mock_cls:
+    with (
+        patch.object(su_mod, "YouTubeAutoUploader") as mock_cls,
+        patch.object(su_mod.ShortUploader, "_load_schedule_config", return_value=schedule_config or {}),
+    ):
         mock_uploader = MagicMock()
         mock_cls.return_value = mock_uploader
         uploader = su_mod.ShortUploader()
-        # schedule_config を差し替え（デフォルトは {}）
-        uploader.schedule_config = schedule_config or {}
         yield uploader, mock_uploader
 
 
@@ -131,6 +132,18 @@ def _freeze_short_uploader_now(monkeypatch, frozen: datetime) -> None:
             return frozen if tz is None else frozen.astimezone(tz)
 
     monkeypatch.setattr(su_mod, "datetime", _Fake)
+    monkeypatch.setattr("youtube_automation.domains.uploads._published_dates.datetime", _Fake)
+
+
+def _calculate_shared_short_publish_at(uploader, collection_path: Path) -> str | None:
+    tracking = uploader.tracking_store.load(collection_path)
+    if tracking is None:
+        return None
+    return uploader.published_dates.calculate_short_publish_at(
+        tracking,
+        tracking_path=uploader.tracking_store.tracking_path(collection_path),
+        publish_time=uploader.config.shorts.publish_time,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +173,23 @@ class TestInit:
             # Then: `uploader.uploader` 属性が YouTubeAutoUploader モックを指す
             assert uploader.uploader is mock_inner
 
+    def test_short_uploader_accepts_shared_tracking_and_published_date_collaborators(self):
+        """Collection uploader と同じ collaborator を明示注入できる。"""
+        from youtube_automation.domains.uploads import shorts as su_mod
+        from youtube_automation.domains.uploads.collection import PublishedDatesScheduler, TrackingStore
+
+        tracking_store = MagicMock(spec=TrackingStore)
+        published_dates = MagicMock(spec=PublishedDatesScheduler)
+
+        with patch.object(su_mod, "YouTubeAutoUploader"):
+            uploader = su_mod.ShortUploader(
+                tracking_store=tracking_store,
+                published_dates=published_dates,
+            )
+
+        assert uploader.tracking_store is tracking_store
+        assert uploader.published_dates is published_dates
+
     def test_init_raises_when_shorts_disabled(self, tmp_path, monkeypatch):
         """`config.shorts.enabled=False` の channel では `__init__` が `UploadError` を投げる."""
         import shutil
@@ -187,7 +217,7 @@ class TestInit:
 
 
 class TestCalculateShortPublishAt:
-    """`_calculate_short_publish_at`: CC publish_at + 1day + short_publish_time."""
+    """共有 scheduler による CC publish_at + 1day + short_publish_time。"""
 
     def _freeze_now(self, monkeypatch, frozen: datetime):
         _freeze_short_uploader_now(monkeypatch, frozen)
@@ -201,7 +231,7 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 1, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-            publish_at = uploader._calculate_short_publish_at(col)
+            publish_at = _calculate_shared_short_publish_at(uploader, col)
 
         # Then: CC の翌日 (2099-01-03) 08:00 JST
         assert publish_at is not None
@@ -217,7 +247,7 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 10, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-            publish_at = uploader._calculate_short_publish_at(col)
+            publish_at = _calculate_shared_short_publish_at(uploader, col)
 
         # Then: 過去のため None
         assert publish_at is None
@@ -236,7 +266,7 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 1, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-            publish_at = uploader._calculate_short_publish_at(col)
+            publish_at = _calculate_shared_short_publish_at(uploader, col)
 
         # Then: upload_time の翌日 08:00 JST
         assert publish_at is not None
@@ -256,7 +286,7 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 1, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-            publish_at = uploader._calculate_short_publish_at(col)
+            publish_at = _calculate_shared_short_publish_at(uploader, col)
 
         # Then: 翌日 08:00 JST（TZ が JST で組み立てられる）
         assert publish_at is not None
@@ -278,8 +308,8 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 1, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-            with caplog.at_level(logging.WARNING, logger="youtube_automation.domains.uploads.shorts"):
-                uploader._calculate_short_publish_at(col)
+            with caplog.at_level(logging.WARNING, logger="youtube_automation.domains.uploads._published_dates"):
+                _calculate_shared_short_publish_at(uploader, col)
 
         # Then: warning にファイル名・フィールド名・naive 検知が含まれる
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -296,8 +326,8 @@ class TestCalculateShortPublishAt:
             self._freeze_now(monkeypatch, datetime(2099, 1, 1, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")))
 
             # When
-        with caplog.at_level(logging.WARNING, logger="youtube_automation.domains.uploads.shorts"):
-            uploader._calculate_short_publish_at(col)
+        with caplog.at_level(logging.WARNING, logger="youtube_automation.domains.uploads._published_dates"):
+            _calculate_shared_short_publish_at(uploader, col)
 
         # Then: TZ-naive warning は出ない
         assert not any("TZ-naive" in r.getMessage() for r in caplog.records)
@@ -308,7 +338,7 @@ class TestCalculateShortPublishAt:
         col = _setup_collection(tmp_path, has_tracking=False)
         with _make_short_uploader(schedule_config={"schedule": {"timezone": "Asia/Tokyo"}}) as (uploader, _):
             # When
-            publish_at = uploader._calculate_short_publish_at(col)
+            publish_at = _calculate_shared_short_publish_at(uploader, col)
 
         # Then
         assert publish_at is None
@@ -614,14 +644,49 @@ class TestUploadShort:
         assert result["action"] == "short_uploaded"
         assert result["details"]["video_id"] == "VIDEO_NEW"
 
+    def test_upload_uses_injected_shared_collaborators(self, tmp_path):
+        from youtube_automation.domains.uploads import shorts as su_mod
+        from youtube_automation.domains.uploads.collection import PublishedDatesScheduler, TrackingStore
+
+        col = _setup_collection(tmp_path)
+        tracking_path = col / "20-documentation" / "upload_tracking.json"
+        tracking = json.loads(tracking_path.read_text(encoding="utf-8"))
+        tracking_store = MagicMock(spec=TrackingStore)
+        tracking_store.read.return_value = tracking
+        tracking_store.read_short_resume_uri.return_value = None
+        published_dates = MagicMock(spec=PublishedDatesScheduler)
+        published_dates.calculate_short_publish_at.return_value = "2099-01-03T08:00:00+09:00"
+
+        with patch.object(su_mod, "YouTubeAutoUploader") as uploader_class:
+            uploader_class.return_value.upload_video.return_value = "VIDEO_NEW"
+            uploader = su_mod.ShortUploader(
+                tracking_store=tracking_store,
+                published_dates=published_dates,
+            )
+            uploader._check_upload_interval = lambda: (True, "ok")
+
+            result = uploader.upload_short(col)
+
+        assert result["action"] == "short_uploaded"
+        published_dates.calculate_short_publish_at.assert_called_once_with(
+            tracking,
+            tracking_path=tracking_path,
+            publish_time=uploader.config.shorts.publish_time,
+        )
+        tracking_store.record_short_upload.assert_called_once_with(
+            col,
+            short_num=None,
+            video_id="VIDEO_NEW",
+            publish_at="2099-01-03T08:00:00+09:00",
+        )
+
     def test_publish_at_future_passed_into_metadata(self, tmp_path, monkeypatch):
         """publish_at が未来日なら metadata に反映される."""
         # Given
         col = _setup_collection(tmp_path)
         with _make_short_uploader(schedule_config={"schedule": {"timezone": "Asia/Tokyo"}}) as (uploader, mock_inner):
             self._patch_interval_ok(uploader)
-            # _calculate_short_publish_at を未来日に差し替え
-            uploader._calculate_short_publish_at = lambda _col: "2099-01-03T08:00:00+09:00"
+            uploader.published_dates.calculate_short_publish_at = MagicMock(return_value="2099-01-03T08:00:00+09:00")
             mock_inner.upload_video.return_value = "VIDEO_X"
 
             # When
@@ -802,7 +867,7 @@ class TestUploadShort:
 
 
 class TestUpdateWorkflowState:
-    """`_update_workflow_state` のスキーマ: `post_upload.shorts: list[dict]` で `short_num` をキーに upsert.
+    """共有 store のスキーマ: `post_upload.shorts: list[dict]` で `short_num` をキーに upsert.
 
     `bulk_update_short_localizations.collect_short_videos` と同スキーマで対称検証する。
     """
@@ -817,7 +882,7 @@ class TestUpdateWorkflowState:
         ws_path.write_text(json.dumps(state), encoding="utf-8")
         with _make_short_uploader() as (uploader, _):
             # When
-            uploader._update_workflow_state(
+            uploader.tracking_store.record_short_upload(
                 col,
                 short_num=1,
                 video_id="V1",
@@ -837,7 +902,7 @@ class TestUpdateWorkflowState:
         """uploaded_at は schedule timezone 付き ISO 8601 で書かれる."""
         col = _setup_collection(tmp_path)
         with _make_short_uploader(schedule_config={"schedule": {"timezone": "UTC"}}) as (uploader, _):
-            uploader._update_workflow_state(col, short_num=1, video_id="V1", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=1, video_id="V1", publish_at=None)
 
         ws = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
         uploaded_at = ws["post_upload"]["shorts"][0]["uploaded_at"]
@@ -850,10 +915,10 @@ class TestUpdateWorkflowState:
         # Given: 既に short_num=1 で V1 を書いた状態
         col = _setup_collection(tmp_path)
         with _make_short_uploader() as (uploader, _):
-            uploader._update_workflow_state(col, short_num=1, video_id="V1", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=1, video_id="V1", publish_at=None)
 
             # When: 同じ short_num=1 を別 video_id で再 upsert
-            uploader._update_workflow_state(col, short_num=1, video_id="V1_NEW", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=1, video_id="V1_NEW", publish_at=None)
 
         # Then: list の長さは 1 のままで V1_NEW に置換
         ws = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
@@ -866,10 +931,10 @@ class TestUpdateWorkflowState:
         # Given: short_num=1 を書く
         col = _setup_collection(tmp_path)
         with _make_short_uploader() as (uploader, _):
-            uploader._update_workflow_state(col, short_num=1, video_id="V1", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=1, video_id="V1", publish_at=None)
 
             # When: short_num=2 を書く
-            uploader._update_workflow_state(col, short_num=2, video_id="V2", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=2, video_id="V2", publish_at=None)
 
         # Then: list の長さは 2
         ws = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
@@ -885,7 +950,7 @@ class TestUpdateWorkflowState:
         col.mkdir(parents=True)
         with _make_short_uploader() as (uploader, _):
             # When: 例外を投げず処理が終わる
-            uploader._update_workflow_state(col, short_num=1, video_id="V1", publish_at=None)
+            uploader.tracking_store.record_short_upload(col, short_num=1, video_id="V1", publish_at=None)
 
         # Then: ファイルは作成されない
         assert not (col / "workflow-state.json").exists()
@@ -949,7 +1014,7 @@ class TestShortResumableUri:
 
         ws = json.loads((col / "workflow-state.json").read_text(encoding="utf-8"))
         entry = next(s for s in ws["post_upload"]["shorts"] if s["short_num"] == 3)
-        # 最終記録（_update_workflow_state）で video_id が載り、URI は除去される
+        # 最終記録で video_id が載り、URI は除去される
         assert entry["video_id"] == "V"
         assert "resume_session_uri" not in entry
 
@@ -991,13 +1056,13 @@ class TestShortResumableUri:
         assert entry["resume_session_uri"] == "https://resume/MID"
 
     def test_read_resume_uri_helper(self, tmp_path):
-        """_read_short_resume_uri: entry 無→None / 保存済→値."""
+        """共有 store の resume URI 読み取りは entry 無→None / 保存済→値。"""
         col = _setup_collection(tmp_path)
         ws_path = col / "workflow-state.json"
         with _make_short_uploader() as (uploader, _):
-            assert uploader._read_short_resume_uri(ws_path, 1) is None
+            assert uploader.tracking_store.read_short_resume_uri(ws_path, 1) is None
             self._write_shorts_state(col, [{"short_num": 1, "resume_session_uri": "https://resume/X"}])
-            assert uploader._read_short_resume_uri(ws_path, 1) == "https://resume/X"
+            assert uploader.tracking_store.read_short_resume_uri(ws_path, 1) == "https://resume/X"
 
     def test_persist_resume_uri_skips_when_state_missing(self, tmp_path):
         """workflow-state.json が無ければ resume URI 永続化を skip（致命的にしない）."""
@@ -1005,5 +1070,5 @@ class TestShortResumableUri:
         col.mkdir(parents=True)
         ws_path = col / "workflow-state.json"
         with _make_short_uploader() as (uploader, _):
-            uploader._persist_short_resume_uri(ws_path, 1, "https://resume/X")
+            uploader.tracking_store.persist_short_resume_uri(ws_path, 1, "https://resume/X")
         assert not ws_path.exists()


### PR DESCRIPTION
## 概要

uploads collaborator化の最終段として、ShortUploader内の公開日・trackingコピー実装を共通collaboratorへ統合します。

## 変更内容

- publish_at計算とlegacy日時補正を `PublishedDatesScheduler` へ委譲
- tracking / workflow-state読書きを `TrackingStore` へ委譲
- CollectionUploaderと同じcollaborator seamをShortUploaderへ明示注入
- short upload、show plan、interval、resumable URI、state記録の既存挙動を維持
- 第2consumer seamを注入テストと実フローで固定
- testsのuploads private module直接import 0を維持
- CHANGELOGを更新

## 検証

- related: 558 passed
- focused: 98 passed
- full: 9,184 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3935
