### PR TITLE
refactor(metadata): workflow-state読み取りをownerへ移行する (#3882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。
 - `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。
+- `refactor(metadata)`: metadata service・metadata audit・Shorts localization の `workflow-state` 読み取りを owner の型付き accessor 経由へ移し、破損 JSON をドメイン診断へ変換する（#3882）。
 - `refactor(uploads)`: uploads ドメインの `workflow-state` 読み取り6ファイルを owner の型付き accessor 経由へ移行し、破損時の既存 fail-open / fail-loud 契約を維持する（#3881）。
 - `refactor(collections)`: raw master・batch video・thumbnail auto selection・DistroKid release date・Suno selection の5 writerを `workflow-state` owner の lock + atomic update へ移行する（#3880）。
 - `refactor(collections)`: collection server と Suno downloaded の `workflow-state` 読み書きを owner API へ移し、downloaded 更新を lock + atomic update に統一する（#3879）。

--- a/src/youtube_automation/commands/metadata/bulk_update_short_localizations.py
+++ b/src/youtube_automation/commands/metadata/bulk_update_short_localizations.py
@@ -19,6 +19,8 @@ import sys
 import time
 
 from youtube_automation.configuration import channel_dir, load_config
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.metadata import build_short_localizations
 from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
 from youtube_automation.infrastructure.cost_tracker import log_quota
@@ -57,27 +59,27 @@ def collect_short_videos() -> list[dict]:
     for col_dir in sorted(live_dir.iterdir()):
         paths = CollectionPaths(col_dir)
         ws_path = paths.workflow_state_path
-        if not ws_path.exists():
-            continue
         tracking_path = paths.tracking_path
         if not tracking_path.exists():
             # tracking 無は CC URL を引けないので Shorts も skip
             continue
         try:
-            with open(ws_path, "r", encoding="utf-8") as f:
-                state = json.load(f)
+            state = read_workflow_state_or_none(ws_path)
+            if state is None:
+                continue
             with open(tracking_path, "r", encoding="utf-8") as f:
                 tracking = json.load(f)
-        except (json.JSONDecodeError, OSError) as e:
+            collection_name = state.collection_name or col_dir.name
+            theme = state.theme or ""
+            post_upload = state.post_upload
+            shorts = post_upload.shorts if post_upload is not None else []
+        except (WorkflowStateError, json.JSONDecodeError, OSError) as e:
             logger.warning(f"⚠️  {col_dir.name} 読み込み失敗: {e}")
             continue
 
         cc = tracking.get("complete_collection") or {}
         cc_video_url = cc.get("video_url", "")
-        collection_name = state.get("collection_name") or col_dir.name
-        theme = state.get("theme", "") or ""
-
-        for entry in (state.get("post_upload") or {}).get("shorts") or []:
+        for entry in shorts:
             video_id = entry.get("video_id")
             if not video_id:
                 continue

--- a/src/youtube_automation/commands/metadata/metadata_audit.py
+++ b/src/youtube_automation/commands/metadata/metadata_audit.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.configuration.model import ChannelConfig
 from youtube_automation.configuration.skills import load_skill_config
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.metadata.descriptions import (
     build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
@@ -139,15 +141,19 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     # 単一言語チャンネルでは scene_phrases の完全性チェックだけを不要扱いにする (#1470)。
     ws = paths.workflow_state_path
     if ws.exists():
-        state = json.loads(ws.read_text(encoding="utf-8"))
-        if requires_scene_phrases(supported_langs):
-            sp = state.get("scene_phrases") or {}
-            required = list(dict.fromkeys(supported_langs))
-            missing = [lang for lang in required if not sp.get(lang)]
-            if missing:
-                issues.append(
-                    f"workflow-state.scene_phrases missing langs: {missing[:6]}{'…' if len(missing) > 6 else ''}"
-                )
+        try:
+            state = read_workflow_state(ws)
+            scene_phrases = state.scene_phrases or {}
+        except WorkflowStateError as error:
+            issues.append(f"workflow-state.json invalid: {error}")
+        else:
+            if requires_scene_phrases(supported_langs):
+                required = list(dict.fromkeys(supported_langs))
+                missing = [lang for lang in required if not scene_phrases.get(lang)]
+                if missing:
+                    issues.append(
+                        f"workflow-state.scene_phrases missing langs: {missing[:6]}{'…' if len(missing) > 6 else ''}"
+                    )
     else:
         issues.append("workflow-state.json missing")
 

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -271,6 +271,15 @@ class MusicPlanningState(_ObjectSection):
     def engine(self, value: MusicEngine) -> None:
         self._data["engine"] = value
 
+    @property
+    def patterns(self) -> dict[str, JSONValue] | None:
+        value = self._data.get("patterns")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise WorkflowStateError("workflow-state.json::planning.music.patterns must be an object")
+        return deepcopy(value)
+
 
 class PlanningState(_ObjectSection):
     """planning metadata の型付き view。"""
@@ -287,6 +296,23 @@ class PlanningState(_ObjectSection):
     @property
     def activities(self) -> str | None:
         return _optional_string(self._data, "activities", "workflow-state.json::planning.activities")
+
+    @property
+    def scene_emoji(self) -> str | None:
+        return _optional_string(self._data, "scene_emoji", "workflow-state.json::planning.scene_emoji")
+
+
+class PostUploadState(_ObjectSection):
+    """公開後処理の型付き view。"""
+
+    @property
+    def shorts(self) -> list[dict[str, JSONValue]]:
+        value = self._data.get("shorts")
+        if value is None:
+            return []
+        if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+            raise WorkflowStateError("workflow-state.json::post_upload.shorts must be an array of objects")
+        return deepcopy(value)
 
 
 class UploadState(_ObjectSection):
@@ -395,8 +421,30 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         return UploadState(value) if isinstance(value, dict) else None
 
     @property
+    def post_upload(self) -> PostUploadState | None:
+        value = self._data.get("post_upload")
+        return PostUploadState(value) if isinstance(value, dict) else None
+
+    @property
     def theme(self) -> str | None:
         return _optional_string(self._data, "theme", "workflow-state.json::theme")
+
+    @property
+    def collection_name(self) -> str | None:
+        return _optional_string(self._data, "collection_name", "workflow-state.json::collection_name")
+
+    @property
+    def title_activity(self) -> str | None:
+        return _optional_string(self._data, "title_activity", "workflow-state.json::title_activity")
+
+    @property
+    def track_display_names(self) -> dict[str, JSONValue] | None:
+        value = self._data.get("track_display_names")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise WorkflowStateError("workflow-state.json::track_display_names must be an object")
+        return deepcopy(value)
 
     @property
     def scene_phrases(self) -> dict[str, JSONValue] | None:

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -57,13 +57,12 @@ from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 logger = logging.getLogger(__name__)
 
 
-def _read_workflow_state_lenient(workflow_state_path: Path) -> dict:
+def _read_workflow_state_lenient(workflow_state_path: Path) -> WorkflowState | None:
     """既存の best-effort reader 用に owner の失敗を空 state へ変換する。"""
     try:
-        state = read_workflow_state_or_none(workflow_state_path)
+        return read_workflow_state_or_none(workflow_state_path)
     except WorkflowStateError:
-        return {}
-    return state.to_dict() if state is not None else {}
+        return None
 
 
 class BAHMetadataGenerator:
@@ -366,7 +365,13 @@ class BAHMetadataGenerator:
         ws_path = paths.workflow_state_path
         result: Dict[str, str] = {}
         state = _read_workflow_state_lenient(ws_path)
-        patterns = ((state.get("planning") or {}).get("music") or {}).get("patterns") or {}
+        try:
+            planning = state.planning if state is not None else None
+            music = planning.music if planning is not None else None
+            patterns = music.patterns if music is not None else None
+        except WorkflowStateError:
+            return result
+        patterns = patterns or {}
         for letter, data in patterns.items():
             key = str(letter).lower()
             if not isinstance(data, dict):
@@ -474,8 +479,11 @@ class BAHMetadataGenerator:
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
         state = _read_workflow_state_lenient(ws_path)
-        name_map = state.get("track_display_names") or {}
-        if not isinstance(name_map, dict) or not name_map:
+        try:
+            name_map = state.track_display_names if state is not None else None
+        except WorkflowStateError:
+            return
+        if not name_map:
             return
         for track in self.tracks:
             persisted = name_map.get(track.get("filename"))
@@ -544,8 +552,12 @@ class BAHMetadataGenerator:
         paths = CollectionPaths(self.collection_path)
         workflow_state_path = paths.workflow_state_path
         state = _read_workflow_state_lenient(workflow_state_path)
-        if state.get("collection_name"):
-            name = state["collection_name"]
+        try:
+            configured_name = state.collection_name if state is not None else None
+        except WorkflowStateError:
+            configured_name = None
+        if configured_name:
+            name = configured_name
             name = re.sub(r"\s+Collection$", "", name, flags=re.IGNORECASE)
             return name
 
@@ -561,8 +573,12 @@ class BAHMetadataGenerator:
         paths = CollectionPaths(self.collection_path)
         workflow_state_path = paths.workflow_state_path
         state = _read_workflow_state_lenient(workflow_state_path)
-        if state.get("title_activity"):
-            return state["title_activity"]
+        try:
+            title_activity = state.title_activity if state is not None else None
+        except WorkflowStateError:
+            title_activity = None
+        if title_activity:
+            return title_activity
 
         theme = self._extract_theme_name()
         return self.config.content.title.activity_for_theme(theme)
@@ -611,13 +627,10 @@ class BAHMetadataGenerator:
     def _load_scene_phrases(self) -> Dict[str, str]:
         """workflow-state.json から scene_phrases を読み込み"""
         state = self._load_workflow_state()
-        scene_phrases = state.get("scene_phrases", {})
-        if not isinstance(scene_phrases, dict):
-            raise ValidationError("workflow-state.json::scene_phrases は object である必要があります")
-        return scene_phrases
+        return state.scene_phrases or {}
 
-    def _load_workflow_state(self) -> dict:
-        """workflow-state.json を読み込む。存在しない場合は空 dict を返す。"""
+    def _load_workflow_state(self) -> WorkflowState:
+        """workflow-state.json を読み込む。存在しない場合は空 document を返す。"""
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
         try:
@@ -632,18 +645,18 @@ class BAHMetadataGenerator:
                 if f"workflow-state.json::{section} must be an object" in message:
                     raise ValidationError(f"workflow-state.json::{section} は object である必要があります") from error
             raise ValidationError(f"workflow-state.json を読み込めません: {ws_path}: {error}") from error
-        return state.to_dict() if state is not None else {}
+        return state if state is not None else WorkflowState({})
 
     def _load_scene_emoji(self) -> str:
         """workflow-state.json から planning.scene_emoji を読み込み"""
         state = self._load_workflow_state()
-        planning = state.get("planning", {})
-        if not isinstance(planning, dict):
-            raise ValidationError("workflow-state.json::planning は object である必要があります")
-        scene_emoji = planning.get("scene_emoji", "")
-        if not isinstance(scene_emoji, str):
-            raise ValidationError("workflow-state.json::planning.scene_emoji は string である必要があります")
-        return scene_emoji
+        planning = state.planning
+        if planning is None:
+            return ""
+        try:
+            return planning.scene_emoji or ""
+        except WorkflowStateError as error:
+            raise ValidationError("workflow-state.json::planning.scene_emoji は string である必要があります") from error
 
     def generate_localizations(
         self,
@@ -857,7 +870,10 @@ class BAHMetadataGenerator:
         paths = CollectionPaths(self.collection_path)
         ws_path = paths.workflow_state_path
         state = _read_workflow_state_lenient(ws_path)
-        return state.get("theme", "") or ""
+        try:
+            return (state.theme if state is not None else None) or ""
+        except WorkflowStateError:
+            return ""
 
     def generate_shorts_metadata(self, cc_video_url: str) -> Dict:
         """Shorts 用メタデータを生成する.

--- a/tests/commands/metadata/test_metadata_audit.py
+++ b/tests/commands/metadata/test_metadata_audit.py
@@ -157,8 +157,8 @@ class TestAuditLocalPreflightContract:
 
         assert audit_local(collection_dir, _audit_config(["en"])) == []
 
-    def test_single_language_channel_malformed_workflow_state_fails(self, tmp_path: Path) -> None:
-        """単一言語でも workflow-state.json 自体の破損は audit で見逃さない (#1470)."""
+    def test_single_language_channel_malformed_workflow_state_is_reported(self, tmp_path: Path) -> None:
+        """破損した workflow-state.json は素の JSONDecodeError を漏らさず監査結果へ載せる."""
         collection_dir = _write_local_collection(
             tmp_path,
             scene_phrases={},
@@ -166,8 +166,9 @@ class TestAuditLocalPreflightContract:
         )
         (collection_dir / "workflow-state.json").write_text("{not json", encoding="utf-8")
 
-        with pytest.raises(json.JSONDecodeError):
-            audit_local(collection_dir, _audit_config(["en"]))
+        issues = audit_local(collection_dir, _audit_config(["en"]))
+
+        assert any("workflow-state.json invalid" in issue for issue in issues)
 
     def test_heading_mismatch_reports_descriptions_md_diagnostics(self, tmp_path: Path) -> None:
         collection_dir = _write_local_collection(

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -124,9 +124,17 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
         state_path,
         {
             "theme": "Rainy Jazz",
-            "planning": {"activities": "focus"},
+            "collection_name": "Rainy Jazz Collection",
+            "title_activity": "focus",
+            "planning": {
+                "activities": "focus",
+                "scene_emoji": "🌧️",
+                "music": {"patterns": {"a": {"display_name": "Rain Window"}}},
+            },
             "scene_phrases": {"en": "continuous focus mix"},
             "title_template_check": {"allow_volume_patterns": True},
+            "track_display_names": {"01-rain.wav": "Rain Window"},
+            "post_upload": {"shorts": [{"short_num": 1, "video_id": "short-1"}]},
             "future_section": {"enabled": True},
         },
     )
@@ -136,8 +144,16 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
     assert state.theme == "Rainy Jazz"
     assert state.planning is not None
     assert state.planning.activities == "focus"
+    assert state.planning.scene_emoji == "🌧️"
+    assert state.planning.music is not None
+    assert state.planning.music.patterns == {"a": {"display_name": "Rain Window"}}
     assert state.scene_phrases == {"en": "continuous focus mix"}
     assert state.allow_volume_patterns is True
+    assert state.collection_name == "Rainy Jazz Collection"
+    assert state.title_activity == "focus"
+    assert state.track_display_names == {"01-rain.wav": "Rain Window"}
+    assert state.post_upload is not None
+    assert state.post_upload.shorts == [{"short_num": 1, "video_id": "short-1"}]
     assert state["future_section"] == {"enabled": True}
 
 

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -14,8 +14,6 @@ DIRECT_IO_ALLOWLIST = frozenset(
     {
         "src/youtube_automation/commands/analytics/experiment_judge.py",
         "src/youtube_automation/commands/distrokid/distrokid_prepare.py",
-        "src/youtube_automation/commands/metadata/bulk_update_short_localizations.py",
-        "src/youtube_automation/commands/metadata/metadata_audit.py",
         "src/youtube_automation/commands/system/progress_hook/workflow_state.py",
         "src/youtube_automation/commands/youtube/pinned_comment.py",
         "src/youtube_automation/domains/distrokid/release.py",


### PR DESCRIPTION
## 概要

workflow-state reader移行をmetadata domainへ広げ、3 readerをtyped owner APIへ統一します。

## 変更内容

- metadata系3 readerをowner APIへ移行
- metadata service用accessorとpost-upload Shorts accessorを追加
- metadata auditの破損JSONを監査診断へ変換
- unknown fieldと既存fail-open / fail-loud契約を維持
- 直parse ratchet allowlistを2ファイル縮小
- CHANGELOGを更新

## 検証

- pre-rebase full: 9,184 passed / 3 skipped
- latest main rebase後 combined focused: 520 passed
- ruff check / format check / diff check: green

Closes #3882
