### PR TITLE
refactor(workflow-state): 残存domain readerをownerへ移行する (#3883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。
+- `refactor(workflow-state)`: Suno prompt と DistroKid prepare / release の残存3 readerを owner の型付き accessor 経由へ移し、破損時の既存診断と未知 field を維持する（#3883）。
 - `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。
 - `refactor(metadata)`: metadata service・metadata audit・Shorts localization の `workflow-state` 読み取りを owner の型付き accessor 経由へ移し、破損 JSON をドメイン診断へ変換する（#3882）。
 - `refactor(uploads)`: uploads ドメインの `workflow-state` 読み取り6ファイルを owner の型付き accessor 経由へ移行し、破損時の既存 fail-open / fail-loud 契約を維持する（#3881）。

--- a/src/youtube_automation/commands/distrokid/distrokid_prepare.py
+++ b/src/youtube_automation/commands/distrokid/distrokid_prepare.py
@@ -27,7 +27,8 @@ from PIL import Image, UnidentifiedImageError
 
 from youtube_automation.application.distrokid.disc_query import find_distrokid_discs
 from youtube_automation.configuration import load_config
-from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.distrokid.preparation import (
     _MAX_TRACKS_PER_DISC,
     COVER_ART_FILENAME,
@@ -355,14 +356,15 @@ def _cmd_verify(args: argparse.Namespace) -> None:
     paths = CollectionPaths(collection_dir)
     if paths.workflow_state_path.is_file():
         try:
-            state = json.loads(paths.workflow_state_path.read_text(encoding="utf-8"))
-            publish_at = (state.get("planning") or {}).get("publish_target_at")
+            state = read_workflow_state(paths.workflow_state_path)
+            planning = state.planning
+            publish_at = planning.publish_target_at if planning is not None else None
             if not publish_at:
                 warnings.append(
                     "workflow-state.json の planning.publish_target_at が未設定です。"
                     "\n  yt-distrokid-prepare build --release-date YYYY-MM-DD で設定できます。"
                 )
-        except (json.JSONDecodeError, OSError):
+        except WorkflowStateError:
             warnings.append("workflow-state.json の読み取りに失敗しました。")
     else:
         warnings.append("workflow-state.json が存在しません（publish_target_at 未設定）。")

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -301,6 +301,10 @@ class PlanningState(_ObjectSection):
     def scene_emoji(self) -> str | None:
         return _optional_string(self._data, "scene_emoji", "workflow-state.json::planning.scene_emoji")
 
+    @property
+    def publish_target_at(self) -> str | None:
+        return _optional_string(self._data, "publish_target_at", "workflow-state.json::planning.publish_target_at")
+
 
 class PostUploadState(_ObjectSection):
     """公開後処理の型付き view。"""
@@ -436,6 +440,15 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     @property
     def title_activity(self) -> str | None:
         return _optional_string(self._data, "title_activity", "workflow-state.json::title_activity")
+
+    @property
+    def track_count(self) -> int | None:
+        value = self._data.get("track_count")
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise WorkflowStateError("workflow-state.json::track_count must be an integer or null")
+        return value
 
     @property
     def track_display_names(self) -> dict[str, JSONValue] | None:

--- a/src/youtube_automation/domains/distrokid/release.py
+++ b/src/youtube_automation/domains/distrokid/release.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 from youtube_automation.configuration.distrokid import Distrokid
 from youtube_automation.core.adapters.media import CollectionPaths
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.distrokid.metadata import (
     parse_album_metadata,
     parse_track_table,
@@ -38,10 +39,6 @@ DISTROKID_ASSETS_PREFIX = "/distrokid/assets/"
 #   → COLLECTIONS_ROUTE + "/<id>" + DISTROKID_COLLECTION_ASSETS_PREFIX
 DISTROKID_COLLECTION_RELEASE_SUFFIX = "/distrokid/{disc}/release.json"
 DISTROKID_COLLECTION_ASSETS_PREFIX = "/distrokid/assets/"
-
-# workflow-state.json 内のリリース予定日のキー。
-_PLANNING_KEY = "planning"
-_PUBLISH_TARGET_KEY = "publish_target_at"
 
 # 30-distrokid disc-source の固定ファイル名。
 _METADATA_FILENAME = "metadata.md"
@@ -86,21 +83,22 @@ def _read_release_date(paths: CollectionPaths) -> str | None:
     if not state_path.is_file():
         return None
     try:
-        raw_state = state_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise ConfigError(f"workflow-state.json を読み取れませんでした: {state_path}: {exc}") from exc
+        state = read_workflow_state(state_path)
+    except WorkflowStateError as exc:
+        cause = exc.__cause__
+        if isinstance(cause, json.JSONDecodeError):
+            raise ConfigError(f"workflow-state.json が不正な JSON です: {state_path}") from exc
+        if "root must be an object" in str(exc):
+            raise ConfigError(f"workflow-state.json のトップレベルが object ではありません: {state_path}") from exc
+        if "::planning must be an object" in str(exc):
+            raise ConfigError(f"workflow-state.json の planning が object ではありません: {state_path}") from exc
+        detail = f": {cause}" if isinstance(cause, OSError) else ""
+        raise ConfigError(f"workflow-state.json を読み取れませんでした: {state_path}{detail}") from exc
+    planning = state.planning
     try:
-        data = json.loads(raw_state)
-    except json.JSONDecodeError as exc:
-        raise ConfigError(f"workflow-state.json が不正な JSON です: {state_path}") from exc
-    if not isinstance(data, dict):
-        raise ConfigError(f"workflow-state.json のトップレベルが object ではありません: {state_path}")
-    planning = data.get(_PLANNING_KEY)
-    if planning is None:
-        planning = {}
-    elif not isinstance(planning, dict):
-        raise ConfigError(f"workflow-state.json の planning が object ではありません: {state_path}")
-    raw = planning.get(_PUBLISH_TARGET_KEY)
+        raw = planning.publish_target_at if planning is not None else None
+    except WorkflowStateError as exc:
+        raise ConfigError("planning.publish_target_at を ISO 8601 形式で指定してください") from exc
     return _normalize_release_date(raw)
 
 

--- a/src/youtube_automation/domains/suno/prompt_resolution.py
+++ b/src/youtube_automation/domains/suno/prompt_resolution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import math
 import re
 from collections.abc import Callable, Mapping, Sequence, Set
@@ -14,7 +13,8 @@ from typing import cast
 import yaml
 
 from youtube_automation.configuration.skills import load_channel_override, load_skill_config
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.suno.config import ResolvedSunoConfig, infer_suno_mode, resolve_suno_config
 from youtube_automation.domains.suno.downloaded.models import (
     DOCUMENTATION_DIRNAME,
@@ -457,12 +457,14 @@ def _read_workflow_track_count(workflow_state_path: Path) -> int:
     if not workflow_state_path.is_file():
         raise ConfigError(f"workflow-state.json is required for vocal mode: {workflow_state_path}")
     try:
-        data = json.loads(workflow_state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        state = read_workflow_state(workflow_state_path)
+        track_count = state.track_count
+    except WorkflowStateError as exc:
+        if "root must be an object" in str(exc):
+            raise ConfigError(
+                f"workflow-state.json のトップレベルは object である必要があります: {workflow_state_path}"
+            ) from exc
         raise ConfigError(f"workflow-state.json を読み取れませんでした: {workflow_state_path}") from exc
-    if not isinstance(data, Mapping):
-        raise ConfigError(f"workflow-state.json のトップレベルは object である必要があります: {workflow_state_path}")
-    track_count = data.get("track_count")
     issue = positive_integer_issue(track_count, "workflow-state.json::track_count")
     if issue is not None:
         raise ConfigError(f"{issue}: {workflow_state_path}")

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -126,9 +126,11 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
             "theme": "Rainy Jazz",
             "collection_name": "Rainy Jazz Collection",
             "title_activity": "focus",
+            "track_count": 12,
             "planning": {
                 "activities": "focus",
                 "scene_emoji": "🌧️",
+                "publish_target_at": "2026-09-01T08:00:00+09:00",
                 "music": {"patterns": {"a": {"display_name": "Rain Window"}}},
             },
             "scene_phrases": {"en": "continuous focus mix"},
@@ -151,10 +153,35 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
     assert state.allow_volume_patterns is True
     assert state.collection_name == "Rainy Jazz Collection"
     assert state.title_activity == "focus"
+    assert state.track_count == 12
+    assert state.planning.publish_target_at == "2026-09-01T08:00:00+09:00"
     assert state.track_display_names == {"01-rain.wav": "Rain Window"}
     assert state.post_upload is not None
     assert state.post_upload.shorts == [{"short_num": 1, "video_id": "short-1"}]
     assert state["future_section"] == {"enabled": True}
+
+
+@pytest.mark.parametrize(
+    "payload, access",
+    [
+        ({"track_count": "12"}, lambda state: state.track_count),
+        ({"track_count": True}, lambda state: state.track_count),
+        (
+            {"planning": {"publish_target_at": 20260901}},
+            lambda state: state.planning.publish_target_at,
+        ),
+    ],
+)
+def test_domain_reader_accessors_reject_wrong_types(
+    tmp_path: Path,
+    payload: dict[str, object],
+    access,
+) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, payload)
+
+    with pytest.raises(WorkflowStateError):
+        access(read(state_path))
 
 
 def test_compatible_music_engine_accessor_rejects_conflicting_values(tmp_path: Path) -> None:

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -13,11 +13,8 @@ OWNER = "src/youtube_automation/domains/collections/workflow_state.py"
 DIRECT_IO_ALLOWLIST = frozenset(
     {
         "src/youtube_automation/commands/analytics/experiment_judge.py",
-        "src/youtube_automation/commands/distrokid/distrokid_prepare.py",
         "src/youtube_automation/commands/system/progress_hook/workflow_state.py",
         "src/youtube_automation/commands/youtube/pinned_comment.py",
-        "src/youtube_automation/domains/distrokid/release.py",
-        "src/youtube_automation/domains/suno/prompt_resolution.py",
         "src/youtube_automation/infrastructure/analytics/workflow_timing.py",
     }
 )


### PR DESCRIPTION
## 概要

workflow-state reader移行をSuno・DistroKidへ広げ、残存domain readerをtyped owner APIへ統一します。

## 変更内容

- Suno / DistroKidの残存3 readerをowner APIへ移行
- `track_count` / `planning.publish_target_at` accessorを追加
- 破損root / planning / OSError診断を維持
- unknown field保持を回帰固定
- 直parse ratchet allowlistを3ファイル縮小
- CHANGELOGを更新

## 検証

- focused: 256 passed
- 広域: 520 passed
- full: 9,186 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3883
