### PR TITLE
refactor(workflow-state): command readerをownerへ移行する (#3884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。
+- `refactor(workflow-state)`: analytics・progress hook・pinned comment に残る `workflow-state` readerを owner の型付き accessor 経由へ移し、direct I/O allowlist を空にする（#3884）。
 - `refactor(workflow-state)`: Suno prompt と DistroKid prepare / release の残存3 readerを owner の型付き accessor 経由へ移し、破損時の既存診断と未知 field を維持する（#3883）。
 - `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。
 - `refactor(metadata)`: metadata service・metadata audit・Shorts localization の `workflow-state` 読み取りを owner の型付き accessor 経由へ移し、破損 JSON をドメイン診断へ変換する（#3882）。

--- a/src/youtube_automation/commands/analytics/experiment_judge.py
+++ b/src/youtube_automation/commands/analytics/experiment_judge.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 from youtube_automation.commands.analytics import experiment_transaction as transaction
 from youtube_automation.commands.analytics.analytics_system import AnalyticsSystem
-from youtube_automation.core.errors import AuthError, ValidationError
+from youtube_automation.core.errors import AuthError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.infrastructure.analytics.vpd_metrics import _parse_view_count, _published_utc
 
 _VERDICTS = frozenset({"improved", "no_change", "worse"})
@@ -124,6 +125,22 @@ def _nested_video_id(value: object, *keys: str) -> str | None:
     return current.strip()
 
 
+def _workflow_video_id(path: Path) -> str | None:
+    try:
+        state = read_workflow_state(path)
+        upload = state.upload
+        upload_value = upload.video_id if upload is not None else None
+        value = upload_value if upload_value is not None else state.video_id
+        context = "upload.video_id" if upload_value is not None else "video_id"
+    except WorkflowStateError as error:
+        raise ValidationError(f"collection state JSON を読めません: {path}") from error
+    if value is None:
+        return None
+    if not value.strip():
+        raise ValidationError(f"{context} は空でない video_id にしてください")
+    return value.strip()
+
+
 def resolve_target(channel_root: Path, target: str) -> TargetResolution:
     if Path(target).name != target or target in {".", ".."}:
         return TargetResolution(target, None)
@@ -133,11 +150,9 @@ def resolve_target(channel_root: Path, target: str) -> TargetResolution:
         tracking_path = live / "20-documentation" / "upload_tracking.json"
         workflow_path = live / "workflow-state.json"
         tracking = _json_object(tracking_path) if tracking_path.exists() else {}
-        workflow = _json_object(workflow_path) if workflow_path.exists() else {}
         video_id = (
             _nested_video_id(tracking, "complete_collection", "video_id")
-            or _nested_video_id(workflow, "upload", "video_id")
-            or _nested_video_id(workflow, "video_id")
+            or (_workflow_video_id(workflow_path) if workflow_path.exists() else None)
             or _nested_video_id(tracking, "video_id")
         )
         return TargetResolution(video_id, None if video_id is not None else "unpublished")

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+
 STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
 
 # /wf-status が定義する v2 phase 語彙を正規の段判定にも使う。
@@ -37,23 +41,23 @@ def _find_channel_root(cwd: Path) -> Path | None:
     return None
 
 
-def _state_paths(root: Path) -> list[Path]:
+def _collection_paths(root: Path) -> list[Path]:
     paths: list[Path] = []
     for location in ("planning", "live"):
         base = root / "collections" / location
         if base.is_dir():
-            paths.extend(path for path in base.glob("*/workflow-state.json") if path.is_file())
+            paths.extend(path.parent for path in base.glob("*/workflow-state.json") if path.is_file())
     return paths
 
 
-def _select_state(paths: list[Path], command: str | None) -> Path | None:
+def _select_collection(paths: list[Path], command: str | None) -> Path | None:
     if not paths:
         return None
     if command is not None:
-        named = [path for path in paths if path.parent.name in command]
+        named = [path for path in paths if path.name in command]
         if named:
-            return max(named, key=lambda path: len(path.parent.name))
-    return max(paths, key=lambda path: path.stat().st_mtime_ns)
+            return max(named, key=lambda path: len(path.name))
+    return max(paths, key=lambda path: (path / "workflow-state.json").stat().st_mtime_ns)
 
 
 def _skip_manual_mastering(root: Path) -> bool:
@@ -81,12 +85,10 @@ def _thumbnail_present(value: object) -> bool:
     return value is True or _file_asset_present(value)
 
 
-def _video_id(state: Mapping[object, object]) -> str | None:
-    upload = state.get("upload", {})
-    if not isinstance(upload, Mapping):
-        return None
-    value = upload.get("video_id")
-    return value if isinstance(value, str) and value else None
+def _video_id(state: WorkflowState) -> str | None:
+    upload = state.upload
+    value = upload.video_id if upload is not None else None
+    return value if value else None
 
 
 def _publish_followup_complete(root: Path, collection: Path, video_id: str | None) -> bool:
@@ -113,12 +115,10 @@ def _publish_followup_complete(root: Path, collection: Path, video_id: str | Non
     return history.get("schema_version") == 1 and isinstance(posted, Mapping) and video_id in posted
 
 
-def _publish_date(state: Mapping[object, object]) -> date | None:
-    upload = state.get("upload", {})
-    if not isinstance(upload, Mapping):
-        return None
-    value = upload.get("publish_at")
-    if not isinstance(value, str) or not value:
+def _publish_date(state: WorkflowState) -> date | None:
+    upload = state.upload
+    value = upload.publish_at if upload is not None else None
+    if not value:
         return None
     return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
 
@@ -141,26 +141,26 @@ def _analysis_complete(root: Path, published_on: date | None) -> bool:
     return False
 
 
-def _completed_stages(root: Path, collection: Path, state: Mapping[object, object]) -> frozenset[str]:
-    phase = state.get("phase")
+def _completed_stages(root: Path, collection: Path, state: WorkflowState) -> frozenset[str]:
+    phase = state.phase
     if phase not in WF_STATUS_PHASES:
         raise ValueError(f"unsupported workflow phase: {phase!r}")
-    assets = state.get("assets")
-    if not isinstance(assets, Mapping):
+    assets = state.assets
+    if assets is None:
         raise ValueError("assets must be an object")
 
     completed: set[str] = set()
     if phase != "planning":
         completed.add("企画")
-    if _file_asset_present(assets.get("raw_master")):
+    if _file_asset_present(assets.raw_master):
         completed.add("音源生成")
-    if _file_asset_present(assets.get("master_audio")) or (
-        _skip_manual_mastering(root) and _file_asset_present(assets.get("raw_master"))
+    if _file_asset_present(assets.master_audio) or (
+        _skip_manual_mastering(root) and _file_asset_present(assets.raw_master)
     ):
         completed.add("マスター化")
-    if _file_asset_present(assets.get("video")) or _file_asset_present(assets.get("master_video")):
+    if _file_asset_present(assets.video) or _file_asset_present(assets.master_video):
         completed.add("動画化")
-    if _thumbnail_present(assets.get("thumbnail")):
+    if _thumbnail_present(assets.thumbnail):
         completed.add("サムネイル")
     if phase == "complete":
         completed.add("アップロード")
@@ -182,10 +182,11 @@ def load_progress_snapshot(cwd: str | None, command: str | None) -> ProgressSnap
         root = _find_channel_root(Path(cwd).resolve())
         if root is None:
             return None
-        state_path = _select_state(_state_paths(root), command)
-        if state_path is None:
+        collection = _select_collection(_collection_paths(root), command)
+        if collection is None:
             return None
-        state = _read_object(state_path)
-        return ProgressSnapshot(_completed_stages(root, state_path.parent, state))
-    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        state_path = collection / "workflow-state.json"
+        state = read_workflow_state(state_path)
+        return ProgressSnapshot(_completed_stages(root, collection, state))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError, WorkflowStateError):
         return None

--- a/src/youtube_automation/commands/youtube/pinned_comment.py
+++ b/src/youtube_automation/commands/youtube/pinned_comment.py
@@ -27,13 +27,15 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, cast
 
 from googleapiclient.errors import HttpError
 
 from youtube_automation.configuration import channel_dir as _channel_dir
 from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import AutomationError, ValidationError, YouTubeAPIError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.infrastructure.auth.youtube import YouTubeOAuthHandler
 from youtube_automation.infrastructure.cost_tracker import log_quota
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
@@ -87,7 +89,7 @@ def render_template(
     )
 
 
-def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, dict | None]]:
+def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, WorkflowState | None]]:
     """コレクションから ``(video_id, workflow_state)`` のペアを解決する.
 
     video_id 解決の fallback chain（upstream の書き込み先差異を吸収）:
@@ -100,10 +102,9 @@ def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, di
     """
     paths = CollectionPaths(collection_path)
 
-    state: dict | None = None
+    state: WorkflowState | None = None
     if paths.workflow_state_path.exists():
-        with open(paths.workflow_state_path, "r", encoding="utf-8") as f:
-            state = json.load(f)
+        state = read_workflow_state(paths.workflow_state_path)
 
     video_id: str | None = None
     if paths.tracking_path.exists():
@@ -112,7 +113,8 @@ def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, di
         video_id = (tracking.get("complete_collection") or {}).get("video_id")
 
     if not video_id and state:
-        video_id = (state.get("upload") or {}).get("video_id") or state.get("video_id")
+        upload = state.upload
+        video_id = (upload.video_id if upload is not None else None) or state.video_id
 
     if not video_id:
         raise ValidationError(
@@ -210,23 +212,30 @@ def post_top_level_comment(youtube, video_id: str, text: str) -> str:
     return resp["snippet"]["topLevelComment"]["id"]
 
 
-def _resolve_scene(state: dict | None, lang: str) -> dict[str, str]:
+def _resolve_scene(state: WorkflowState | dict | None, lang: str) -> dict[str, str]:
     """workflow-state からテンプレート展開用の値を取り出す."""
-    state = state or {}
-    planning = state.get("planning") or {}
-    scene_phrases = state.get("scene_phrases") or {}
-    video_title = planning.get("final_title_en") or planning.get("final_title") or state.get("collection_name", "")
+    if state is None:
+        return {"video_title": "", "scene_phrase": "", "theme": "", "scene_emoji": ""}
+    if isinstance(state, dict):
+        state = WorkflowState(state)
+    planning = state.planning
+    scene_phrases = state.scene_phrases or {}
+    video_title = (
+        ((planning.final_title_en or planning.final_title) if planning is not None else None)
+        or state.collection_name
+        or ""
+    )
     scene_phrase = scene_phrases.get(lang) or scene_phrases.get("en", "")
     return {
         "video_title": video_title,
-        "scene_phrase": scene_phrase,
-        "theme": state.get("theme", ""),
-        "scene_emoji": planning.get("scene_emoji", ""),
+        "scene_phrase": cast(str, scene_phrase),
+        "theme": state.theme or "",
+        "scene_emoji": (planning.scene_emoji if planning is not None else None) or "",
     }
 
 
 def build_plan(
-    targets: list[tuple[str, dict | None]],
+    targets: list[tuple[str, WorkflowState | dict | None]],
     *,
     history: dict,
     status_map: dict[str, dict | None],

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -254,6 +254,10 @@ class AssetsState(_ObjectSection):
     def master_video(self, value: str | None) -> None:
         self._data["master_video"] = value
 
+    @property
+    def video(self) -> str | None:
+        return _optional_string(self._data, "video", "workflow-state.json::assets.video")
+
 
 class MusicPlanningState(_ObjectSection):
     """planning.music の型付き view。"""
@@ -304,6 +308,14 @@ class PlanningState(_ObjectSection):
     @property
     def publish_target_at(self) -> str | None:
         return _optional_string(self._data, "publish_target_at", "workflow-state.json::planning.publish_target_at")
+
+    @property
+    def final_title_en(self) -> str | None:
+        return _optional_string(self._data, "final_title_en", "workflow-state.json::planning.final_title_en")
+
+    @property
+    def final_title(self) -> str | None:
+        return _optional_string(self._data, "final_title", "workflow-state.json::planning.final_title")
 
 
 class PostUploadState(_ObjectSection):
@@ -432,6 +444,14 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     @property
     def theme(self) -> str | None:
         return _optional_string(self._data, "theme", "workflow-state.json::theme")
+
+    @property
+    def created_at(self) -> str | None:
+        return _optional_string(self._data, "created_at", "workflow-state.json::created_at")
+
+    @property
+    def video_id(self) -> str | None:
+        return _optional_string(self._data, "video_id", "workflow-state.json::video_id")
 
     @property
     def collection_name(self) -> str | None:

--- a/src/youtube_automation/infrastructure/analytics/workflow_timing.py
+++ b/src/youtube_automation/infrastructure/analytics/workflow_timing.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from types import ModuleType
 from typing import Protocol, cast
 
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+
 
 class _TimingUnavailableError(ValueError):
     def __init__(self, reason: str) -> None:
@@ -85,11 +88,10 @@ def _collection_sort_key(collection: Path) -> tuple[str, str]:
     """完全検証せず created_at だけを読んで latest live を選ぶ。"""
     state_path = collection / "workflow-state.json"
     try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        state = None
-    created_at = state.get("created_at") if isinstance(state, dict) else None
-    return (created_at if isinstance(created_at, str) else "9999", collection.name)
+        created_at = read_workflow_state(state_path).created_at
+    except WorkflowStateError:
+        created_at = None
+    return (created_at or "9999", collection.name)
 
 
 def _collection_history(history: dict[str, object], channel: Path, collection: Path) -> dict[str, object]:

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -127,12 +127,17 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
             "collection_name": "Rainy Jazz Collection",
             "title_activity": "focus",
             "track_count": 12,
+            "created_at": "2026-08-16T09:00:00+09:00",
+            "video_id": "legacy-video",
             "planning": {
                 "activities": "focus",
                 "scene_emoji": "🌧️",
                 "publish_target_at": "2026-09-01T08:00:00+09:00",
+                "final_title_en": "Rainy Focus",
+                "final_title": "雨の集中時間",
                 "music": {"patterns": {"a": {"display_name": "Rain Window"}}},
             },
+            "assets": {"video": "master.mp4"},
             "scene_phrases": {"en": "continuous focus mix"},
             "title_template_check": {"allow_volume_patterns": True},
             "track_display_names": {"01-rain.wav": "Rain Window"},
@@ -154,7 +159,13 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
     assert state.collection_name == "Rainy Jazz Collection"
     assert state.title_activity == "focus"
     assert state.track_count == 12
+    assert state.created_at == "2026-08-16T09:00:00+09:00"
+    assert state.video_id == "legacy-video"
     assert state.planning.publish_target_at == "2026-09-01T08:00:00+09:00"
+    assert state.planning.final_title_en == "Rainy Focus"
+    assert state.planning.final_title == "雨の集中時間"
+    assert state.assets is not None
+    assert state.assets.video == "master.mp4"
     assert state.track_display_names == {"01-rain.wav": "Rain Window"}
     assert state.post_upload is not None
     assert state.post_upload.shorts == [{"short_num": 1, "video_id": "short-1"}]

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -10,14 +10,7 @@ from pathlib import Path
 from tests.helpers.paths import REPO_ROOT
 
 OWNER = "src/youtube_automation/domains/collections/workflow_state.py"
-DIRECT_IO_ALLOWLIST = frozenset(
-    {
-        "src/youtube_automation/commands/analytics/experiment_judge.py",
-        "src/youtube_automation/commands/system/progress_hook/workflow_state.py",
-        "src/youtube_automation/commands/youtube/pinned_comment.py",
-        "src/youtube_automation/infrastructure/analytics/workflow_timing.py",
-    }
-)
+DIRECT_IO_ALLOWLIST = frozenset()
 
 _PATH_NAME = re.compile(r"(?:workflow_state|workflow|ws)_(?:file|path)$")
 _CONTEXTUAL_PATH_NAME = re.compile(r"state_(?:file|path)$")


### PR DESCRIPTION
## 概要

workflow-state Python reader移行を完了し、commands横断の残存直I/Oをtyped owner APIへ統一します。

## 変更内容

- experiment judge / progress hook / pinned comment / workflow timingの残存5 I/Oをowner経由へ移行
- `created_at` / legacy `video_id` / `assets.video` / planning titles accessorを追加
- fail-open / fail-loud / unknown field契約を維持
- 直parse ratchet allowlistを空に変更
- CHANGELOGを更新

## 検証

- focused: 129 passed
- 広域: 830 passed
- full: 9,189 passed / 3 skipped
- ruff check / format check / diff check: green

Closes #3884
