### PR TITLE
refactor(workflow-state): skill scriptをownerへ移行する (#3885)

### DIFF
--- a/.claude/skills/publish/references/generate_batch.py
+++ b/.claude/skills/publish/references/generate_batch.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 
 _ALLOWED_VARIABLES = frozenset({"title", "date", "custom_message"})
 
@@ -37,24 +39,28 @@ class CommunityPost:
     visibility: str = "public"
 
 
-def _read_state(collection: Path) -> dict[str, object]:
+def _read_state(collection: Path) -> WorkflowState:
     state_path = collection / "workflow-state.json"
+    if not state_path.exists():
+        raise ConfigError(f"workflow-state.json が見つかりません: {state_path}")
     try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise ConfigError(f"workflow-state.json が見つかりません: {state_path}") from exc
-    except json.JSONDecodeError as exc:
+        return read_workflow_state(state_path)
+    except WorkflowStateError as exc:
+        if "root must be an object" in str(exc):
+            raise ConfigError("workflow-state.json の root は object でなければなりません") from exc
+        if "::planning must be an object" in str(exc):
+            raise ConfigError("workflow-state.json::planning が未設定です") from exc
         raise ConfigError(f"workflow-state.json が不正な JSON です: {state_path}: {exc}") from exc
-    if not isinstance(state, dict):
-        raise ConfigError("workflow-state.json の root は object でなければなりません")
-    return state
 
 
-def _planning_value(state: dict[str, object], key: str) -> str:
-    planning = state.get("planning")
-    if not isinstance(planning, dict):
+def _planning_value(state: WorkflowState, key: str) -> str:
+    planning = state.planning
+    if planning is None:
         raise ConfigError("workflow-state.json::planning が未設定です")
-    value = planning.get(key)
+    try:
+        value = planning.final_title if key == "final_title" else planning.publish_target_at
+    except WorkflowStateError as exc:
+        raise ConfigError(f"workflow-state.json::planning.{key} が未設定です") from exc
     if not isinstance(value, str) or not value.strip():
         raise ConfigError(f"workflow-state.json::planning.{key} が未設定です")
     return value

--- a/.claude/skills/publish/references/publish-chain-state.py
+++ b/.claude/skills/publish/references/publish-chain-state.py
@@ -8,6 +8,9 @@ import json
 from pathlib import Path
 from typing import NotRequired, TypedDict
 
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+
 EXIT_SKIP = 0
 EXIT_RUN = 10
 EXIT_BLOCKED = 20
@@ -122,21 +125,21 @@ def evaluate(
 
     state_path = collection_dir / "workflow-state.json"
     try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return EXIT_RUN, _result("run", "workflow_state_missing")
-    except (OSError, json.JSONDecodeError):
+        state = read_workflow_state(state_path)
+    except WorkflowStateError as exc:
+        if not state_path.exists():
+            return EXIT_RUN, _result("run", "workflow_state_missing")
+        if "::upload must be an object" in str(exc):
+            return EXIT_BLOCKED, _result("blocked", "upload_state_invalid")
         return EXIT_BLOCKED, _result("blocked", "workflow_state_invalid")
-
-    if not isinstance(state, dict):
-        return EXIT_BLOCKED, _result("blocked", "workflow_state_invalid")
-    upload = state.get("upload")
+    upload = state.upload
     if upload is None:
         return EXIT_RUN, _result("run", "video_id_missing")
-    if not isinstance(upload, dict):
-        return EXIT_BLOCKED, _result("blocked", "upload_state_invalid")
 
-    video_id = upload.get("video_id")
+    try:
+        video_id = upload.video_id
+    except WorkflowStateError:
+        return EXIT_BLOCKED, _result("blocked", "video_id_invalid")
     if step in {"community", "pinned"}:
         if video_id is None:
             return EXIT_BLOCKED, _result("blocked", "video_id_missing")

--- a/.claude/skills/wf-new/references/wf-auto-state.py
+++ b/.claude/skills/wf-new/references/wf-auto-state.py
@@ -20,6 +20,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, TypedDict
 
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+
 STATE_DIR_NAME = ".automation-run"
 LEASE_DIR_NAME = "lease"
 LEASE_FILE_NAME = "lease.json"
@@ -388,25 +392,34 @@ def _inside(root: Path, path: Path, field: str) -> Path:
     return path
 
 
-def _state(collection: Path) -> dict:
+def _state(collection: Path) -> WorkflowState:
     state_path = collection / "workflow-state.json"
     if state_path.is_symlink() or not state_path.is_file():
         raise ValueError(f"workflow-state.json は通常ファイルでなければなりません: {state_path}")
-    state = _read_object(state_path)
-    phase = state.get("phase")
+    try:
+        state = read_workflow_state(state_path)
+    except WorkflowStateError as exc:
+        cause = exc.__cause__
+        if isinstance(cause, (OSError, json.JSONDecodeError)):
+            raise ValueError(f"JSON を読めません: {state_path}: {cause}") from exc
+        if "root must be an object" in str(exc):
+            raise ValueError(f"JSON root は object でなければなりません: {state_path}") from exc
+        raise ValueError(str(exc)) from exc
+    try:
+        phase = state.phase
+    except WorkflowStateError as exc:
+        raw_phase = state.get("phase")
+        raise ValueError(f"未対応 phase です: {raw_phase!r}") from exc
     if phase not in PHASES:
         raise ValueError(f"未対応 phase です: {phase!r}")
     return state
 
 
-def _engine(state: dict) -> str:
-    top_level = state.get("music_engine")
-    planning = state.get("planning")
-    planning_music = planning.get("music") if isinstance(planning, dict) else None
-    nested = planning_music.get("engine") if isinstance(planning_music, dict) else None
-    if top_level in ENGINES and nested in ENGINES and top_level != nested:
-        raise ValueError(f"music engine が不一致です: top-level={top_level}, planning.music={nested}")
-    engine = nested or top_level
+def _engine(state: WorkflowState) -> str:
+    try:
+        engine = state.music_engine
+    except WorkflowStateError as exc:
+        raise ValueError(str(exc)) from exc
     if engine not in ENGINES:
         raise ValueError(f"未対応 music engine です: {engine!r}")
     return engine
@@ -414,8 +427,11 @@ def _engine(state: dict) -> str:
 
 def _collection_sort_key(collection: Path) -> tuple[str, str]:
     state = _state(collection)
-    created_at = state.get("created_at")
-    return (created_at if isinstance(created_at, str) else "9999", collection.name)
+    try:
+        created_at = state.created_at
+    except WorkflowStateError as exc:
+        raise ValueError(str(exc)) from exc
+    return (created_at or "9999", collection.name)
 
 
 def select_collection(root: Path, requested: str | None = None) -> Path:
@@ -438,7 +454,7 @@ def select_collection(root: Path, requested: str | None = None) -> Path:
     if planning_root.is_dir():
         for state_path in planning_root.glob("*/workflow-state.json"):
             collection = state_path.parent
-            if _state(collection).get("phase") != "complete":
+            if _state(collection).phase != "complete":
                 candidates.append(collection.resolve())
     if not candidates:
         raise NoActiveCollectionError("未完了の planning collection がありません")

--- a/.claude/skills/wf-next/references/master_audio_transition.py
+++ b/.claude/skills/wf-next/references/master_audio_transition.py
@@ -11,7 +11,11 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import AssetsState, WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 
 AUDIO_EXTENSIONS = (".m4a", ".wav", ".flac", ".aac", ".mp3")
 JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
@@ -45,27 +49,22 @@ def _approval_arg(value: str) -> bool:
     raise argparse.ArgumentTypeError("must be yes or no")
 
 
-def _load_state(path: Path) -> JsonObject:
+def _load_state(path: Path) -> WorkflowState:
     _validate_state_path(path)
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid workflow-state.json: {exc}") from exc
-    except OSError as exc:
-        raise ValueError(f"workflow-state.json could not be read: {exc}") from exc
-    if not isinstance(data, dict):
-        raise ValueError("workflow-state.json root must be an object")
-    assets = data.get("assets")
-    if not isinstance(assets, dict):
+        state = read_workflow_state(path)
+    except WorkflowStateError as exc:
+        cause = exc.__cause__
+        if isinstance(cause, json.JSONDecodeError):
+            raise ValueError(f"invalid workflow-state.json: {cause}") from exc
+        if "root must be an object" in str(exc):
+            raise ValueError("workflow-state.json root must be an object") from exc
+        if "::assets must be an object" in str(exc):
+            raise ValueError("workflow-state.json::assets must be an object") from exc
+        raise ValueError(f"workflow-state.json could not be read: {cause or exc}") from exc
+    if state.assets is None:
         raise ValueError("workflow-state.json::assets must be an object")
-    return cast(JsonObject, data)
-
-
-def _write_state(path: Path, state: JsonObject) -> None:
-    _validate_state_path(path)
-    tmp_path = path.with_name(f".{path.name}.tmp")
-    tmp_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    tmp_path.replace(path)
+    return state
 
 
 def _validate_state_path(path: Path) -> None:
@@ -167,15 +166,11 @@ def _copy_to_worktree(candidate: MasterCandidate, master_dir: Path) -> Path:
     return target
 
 
-def _json_assets(state: JsonObject) -> JsonObject:
-    assets = state["assets"]
-    if not isinstance(assets, dict):
+def _json_assets(state: WorkflowState) -> AssetsState:
+    assets = state.assets
+    if assets is None:
         raise ValueError("workflow-state.json::assets must be an object")
-    return cast(JsonObject, assets)
-
-
-def _json_string(value: JsonValue) -> str | None:
-    return value if isinstance(value, str) else None
+    return assets
 
 
 def _utc_now() -> str:
@@ -274,20 +269,28 @@ def _master_dirs(collection: Path, master_dir: Path, main_repo_root: Path | None
     return dirs
 
 
-def _adopt(state_path: Path, state: JsonObject, assets: JsonObject, selected: str, reason: str) -> None:
-    assets["master_audio"] = selected
-    state["phase"] = "mastered"
-    state["updated_at"] = _utc_now()
-    _write_state(state_path, state)
-    _emit(
-        "adopted", master_audio=selected, phase="mastered", reason=reason, updated_at=_json_string(state["updated_at"])
-    )
+def _adopt(state_path: Path, selected: str, reason: str) -> None:
+    updated_at = _utc_now()
+
+    def apply_transition(state: WorkflowState) -> None:
+        assets = state.assets
+        if assets is None:
+            raise WorkflowStateError("workflow-state.json::assets must be an object")
+        assets.master_audio = selected
+        state.phase = "mastered"
+        state["updated_at"] = updated_at
+
+    try:
+        update_workflow_state(state_path, apply_transition)
+    except WorkflowStateError as exc:
+        raise ValueError(str(exc)) from exc
+    _emit("adopted", master_audio=selected, phase="mastered", reason=reason, updated_at=updated_at)
 
 
-def _validate_phase_and_pending(state: JsonObject, assets: JsonObject) -> bool:
+def _validate_phase_and_pending(state: WorkflowState, assets: AssetsState) -> bool:
     raw_master = _validate_filename(assets.get("raw_master"), "assets.raw_master")
     current_master = _validate_filename(assets.get("master_audio"), "assets.master_audio")
-    if state.get("phase") != "prepared":
+    if state.phase != "prepared":
         _emit("noop", reason="phase is not prepared")
         return False
     if raw_master is None or current_master is not None:
@@ -296,7 +299,7 @@ def _validate_phase_and_pending(state: JsonObject, assets: JsonObject) -> bool:
     return True
 
 
-def _raw_master(assets: JsonObject) -> str:
+def _raw_master(assets: AssetsState) -> str:
     raw_master = _validate_filename(assets.get("raw_master"), "assets.raw_master")
     if raw_master is None:
         raise ValueError("workflow-state.json::assets.raw_master must be set")
@@ -311,8 +314,8 @@ def _resolve_transition(
     args: argparse.Namespace,
     collection: Path,
     state_path: Path,
-    state: JsonObject,
-    assets: JsonObject,
+    state: WorkflowState,
+    assets: AssetsState,
     master_dir: Path,
 ) -> int:
     if not _validate_phase_and_pending(state, assets):
@@ -338,7 +341,7 @@ def _resolve_transition(
         return 0
 
     _prepare_selected_file(selected_candidate, master_dir, selected)
-    _adopt(state_path, state, assets, selected, reason)
+    _adopt(state_path, selected, reason)
     return 0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。
+- `refactor(workflow-state)`: wf-new・wf-next・publish の配布 reference script 4本を package owner 経由へ移し、master audio 遷移を lock + atomic update に統一する（#3885）。
 - `refactor(workflow-state)`: analytics・progress hook・pinned comment に残る `workflow-state` readerを owner の型付き accessor 経由へ移し、direct I/O allowlist を空にする（#3884）。
 - `refactor(workflow-state)`: Suno prompt と DistroKid prepare / release の残存3 readerを owner の型付き accessor 経由へ移し、破損時の既存診断と未知 field を維持する（#3883）。
 - `refactor(uploads)`: `ShortUploader` が複製していた公開日計算と tracking / workflow-state I/O を `PublishedDatesScheduler` / `TrackingStore` の共通コラボレータへ統合する（#3935）。

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -293,6 +293,16 @@ assert "wheel-identity-check" not in legacy._cache
         source = SkillInventory(repo_root).skills_root / relative
         assert target.read_bytes() == source.read_bytes()
 
+    workflow_state_scripts = (
+        target_skills / "publish" / "references" / "generate_batch.py",
+        target_skills / "publish" / "references" / "publish-chain-state.py",
+        target_skills / "wf-new" / "references" / "wf-auto-state.py",
+        target_skills / "wf-next" / "references" / "master_audio_transition.py",
+    )
+    for script in workflow_state_scripts:
+        help_result = _run(python, script, "--help", cwd=downstream, env=clean_env)
+        assert help_result.returncode == 0, help_result.stderr
+
     for target_relative, source_relative in _FILE_ASSETS.items():
         assert (downstream / target_relative).read_bytes() == (repo_root / source_relative).read_bytes()
 

--- a/tests/repo/test_wf_next_master_audio_transition.py
+++ b/tests/repo/test_wf_next_master_audio_transition.py
@@ -21,9 +21,11 @@ def _collection(tmp_path: Path) -> Path:
             {
                 "phase": "prepared",
                 "updated_at": "2000-01-01T00:00:00Z",
+                "future_root": {"kept": True},
                 "assets": {
                     "raw_master": "raw-master.wav",
                     "master_audio": None,
+                    "future_asset": "kept",
                 },
             }
         ),
@@ -86,6 +88,8 @@ def test_raw_final_adopts_raw_master_when_skip_manual_mastering_is_true(tmp_path
     assert state["phase"] == "mastered"
     assert state["updated_at"] != "2000-01-01T00:00:00Z"
     assert state["updated_at"].endswith("Z")
+    assert state["future_root"] == {"kept": True}
+    assert state["assets"]["future_asset"] == "kept"
 
 
 def test_raw_final_disabled_waits_without_state_update(tmp_path: Path) -> None:

--- a/tests/repo/test_workflow_state_owner_contract.py
+++ b/tests/repo/test_workflow_state_owner_contract.py
@@ -11,6 +11,12 @@ from tests.helpers.paths import REPO_ROOT
 
 OWNER = "src/youtube_automation/domains/collections/workflow_state.py"
 DIRECT_IO_ALLOWLIST = frozenset()
+SKILL_REFERENCE_READERS = (
+    ".claude/skills/publish/references/generate_batch.py",
+    ".claude/skills/publish/references/publish-chain-state.py",
+    ".claude/skills/wf-new/references/wf-auto-state.py",
+    ".claude/skills/wf-next/references/master_audio_transition.py",
+)
 
 _PATH_NAME = re.compile(r"(?:workflow_state|workflow|ws)_(?:file|path)$")
 _CONTEXTUAL_PATH_NAME = re.compile(r"state_(?:file|path)$")
@@ -250,3 +256,15 @@ def test_removed_direct_io_requires_allowlist_entry_removal(tmp_path: Path) -> N
     assert _ratchet_diagnostics(findings, frozenset({"src/youtube_automation/commands/migrated.py"})) == [
         "stale workflow-state allowlist entry: src/youtube_automation/commands/migrated.py (remove this entry)"
     ]
+
+
+def test_distributed_skill_reference_readers_use_workflow_state_owner() -> None:
+    for relative in SKILL_REFERENCE_READERS:
+        source = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        assert "youtube_automation.domains.collections.workflow_state" in source, relative
+        assert "json.loads(state_path.read_text" not in source, relative
+        assert "_read_object(state_path)" not in source, relative
+
+    transition = (REPO_ROOT / SKILL_REFERENCE_READERS[-1]).read_text(encoding="utf-8")
+    assert "update as update_workflow_state" in transition
+    assert "_write_state" not in transition

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -328,6 +328,7 @@ MUTABLE_FILES = frozenset(
     "wf-new/references/schema.md",
     "wf-new/references/validate-batch-manifest.py",
     "wf-new/references/wf-auto-state.py",
+    "wf-next/references/master_audio_transition.py",
     "wf-new/references/collection-ideate.config.default.yaml",
     "wf-new/references/collection-lifecycle.md",
     "wf-new/references/freshness_action.py",
@@ -361,7 +362,7 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "11600a59d0b573771be55cf4614c594cd4f88a4e00cd08d9ea7c3bb5186765ac"
+IMMUTABLE_TARGET_FILES_SHA256 = "2d4e28a4974f1e7500303a3d50a0e1ca386fb17cb9bfea2c7abad16fee24835f"
 AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "11d460f727fe50c41f00571b416a1486cb07d0b1548524bc650a7161c16f6c42"
 AUTOMATION_UPDATE_PUSH_SHA256 = "ced3211760d9ff0abd20ec3cdc402501b424f48581ef3a618d51c0d9ee12840c"
 ALLOWED_FENCED_ROUTES = {


### PR DESCRIPTION
## 概要

workflow-state reader移行の区切りとして、配布skill reference script 4本の自前parserをpackage ownerへ統一します。

## 変更内容

- wf-new / wf-next / publish配下4 scriptから自前workflow-state parseを除去
- package owner importへ移行
- master audio transitionをlock付きatomic owner update化
- unknown field保持を回帰固定
- candidate wheel→隔離venv→下流sync後の4 script import / help smokeを追加
- wheel / hash / transition契約とCHANGELOGを更新

## 検証

- latest main rebase後 focused: 130 passed
- pre-rebase full: 9,189 passed / 3 skipped（対象外selector flakeは単独green）
- ruff check / format check / yt-skills lint / catalog / artifacts: green
- wheel smoke: green

Closes #3885
