### PR TITLE
feat(skills): 配布skill総数を上限で制限する (#3805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(skills)`: `yt-skills lint` が downstream 配布対象 skill を実 inventory から数え、開発専用と `SKILL.md` のない残骸を除外した総数を上限 19 件で ratchet する（#3805）。
 - `feat(skills)`: `yt-skills lint` が委譲深さ 2 以上を最長経路つきで拒否し、既存違反だけを報告付き allowlist として段階解消できる契約を追加する（#3799）。
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -1,6 +1,6 @@
 """yt-skills lint — SKILL.md の軽量契約検証。
 
-Issues #2096, #3749, #3750, #3751, #3793, #3799, #3802, #3803, #3804。
+Issues #2096, #3749, #3750, #3751, #3793, #3799, #3802, #3803, #3804, #3805。
 
 skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず秒単位で回すための
 サブコマンド。frontmatter / flag の検証ロジックは domains.skills.inventory を
@@ -22,6 +22,7 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
     12. 成果物ブロックと `書き込む` 宣言行が存在する
     13. skill-config の登録キーと config.default.yaml が双方向に一致する
     14. 下流に移行対応表の旧 skill-config が残っていない
+    15. downstream 配布対象の skill が総数上限以下である
 """
 
 from __future__ import annotations
@@ -30,12 +31,13 @@ import argparse
 from pathlib import Path
 from typing import Final
 
-from youtube_automation.commands.system.skills_sync import _migrate_config
+from youtube_automation.commands.system.skills_sync import _DEV_ONLY_SKILL_NAMES, _migrate_config
 from youtube_automation.commands.system.skills_sync._delegation import DelegationGraph, format_path
 from youtube_automation.configuration import skills as skill_config
 from youtube_automation.domains.skills.inventory import SkillInventory, SkillLintViolation, lint_skill_contract
 
 _SKILL_MD_MAX_LINES: Final[int] = 400
+_MAX_SKILL_COUNT: Final[int] = 19
 _SKILL_MD_LINE_LIMIT_VIOLATION: Final[str] = "skill_md_line_limit_exceeded"
 _DELEGATION_DEPTH_VIOLATION: Final[str] = "delegation_depth_exceeded"
 
@@ -134,13 +136,32 @@ def _lint_unmigrated_skill_configs(channel_dir: Path) -> list[str]:
     ]
 
 
+def _distributed_skill_names(inventory: SkillInventory) -> tuple[str, ...]:
+    """Return real sync candidates, excluding dev-only and non-skill residue."""
+    return tuple(
+        skill_dir.name
+        for skill_dir in inventory.skill_directories()
+        if (skill_dir / "SKILL.md").is_file() and skill_dir.name not in _DEV_ONLY_SKILL_NAMES
+    )
+
+
+def _skill_count_violation(inventory: SkillInventory) -> str | None:
+    count = len(_distributed_skill_names(inventory))
+    if count <= _MAX_SKILL_COUNT:
+        return None
+    return (
+        f"配布対象の skill が {count} 件です (上限 {_MAX_SKILL_COUNT} 件 — "
+        "新しい skill を足すなら既存 skill の mode として畳めないかを先に検討してください)"
+    )
+
+
 def cmd_lint(args: argparse.Namespace) -> int:
     """`yt-skills lint [<skill>...]` — skill 契約を検証し違反があれば非ゼロ exit。"""
     from youtube_automation.commands.system.skills_sync import _asset_root
 
     root = _asset_root("skills")
     inventory = SkillInventory(root)
-    available = [path.name for path in inventory.skill_directories()]
+    available = [path.name for path in inventory.skill_directories() if (path / "SKILL.md").is_file()]
 
     requested: list[str] = getattr(args, "skills", None) or []
     if requested:
@@ -155,8 +176,11 @@ def cmd_lint(args: argparse.Namespace) -> int:
     skill_config_violations = (
         [] if requested else [*_lint_skill_config_contract(inventory), *_lint_unmigrated_skill_configs(Path.cwd())]
     )
+    skill_count_violation = None if requested else _skill_count_violation(inventory)
     for violation in skill_config_violations:
         print(f"skill-config: {violation}")
+    if skill_count_violation is not None:
+        print(skill_count_violation)
 
     graph = DelegationGraph.load(inventory)
 
@@ -192,6 +216,9 @@ def cmd_lint(args: argparse.Namespace) -> int:
         return 1
     if skill_config_violations:
         print(f"lint 失敗: skill-config 契約に {len(skill_config_violations)} 件の違反があります (source: {root})")
+        return 1
+    if skill_count_violation is not None:
+        print(f"lint 失敗: 配布対象 skill の総数上限を超えています (source: {root})")
         return 1
     print(f"lint 合格: {len(targets)} skill (source: {root})")
     return 0

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -49,6 +49,14 @@ def _skill_md_with_line_count(line_count: int, *, name: str = "good-skill") -> s
     return "\n".join([*lines, *(["本文"] * (line_count - len(lines)))])
 
 
+def _populate_valid_skill_count(skills_dir: Path, total: int) -> None:
+    """Add valid distributed skills until fake_repo has ``total`` entries."""
+    existing = sum((path / "SKILL.md").is_file() for path in skills_dir.iterdir())
+    for index in range(existing, total):
+        name = f"count-skill-{index:02d}"
+        _write_skill(skills_dir, name, _VALID_SKILL_MD.replace("good-skill", name))
+
+
 @pytest.fixture
 def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """tmp_path にダミーの skills ツリーを仕込み editable fallback を向ける。"""
@@ -583,6 +591,64 @@ def test_authoring_guidelines_require_shallow_delegation_or_chain_manifest() -> 
     assert "委譲先を持つ skill の委譲先がさらに別 skill へ委譲してはいけない" in guidelines
     assert "[chain-manifest-schema.md](chain-manifest-schema.md)" in guidelines
     assert "薄いインタープリタ方式" in guidelines
+
+
+def test_cli_lint_rejects_distributed_skill_count_above_limit(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _populate_valid_skill_count(fake_repo / ".claude" / "skills", 20)
+
+    assert main(["lint"]) == 1
+    out = capsys.readouterr().out
+    assert (
+        "配布対象の skill が 20 件です (上限 19 件 — "
+        "新しい skill を足すなら既存 skill の mode として畳めないかを先に検討してください)"
+    ) in out
+
+
+def test_cli_lint_accepts_distributed_skill_count_at_limit(fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _populate_valid_skill_count(fake_repo / ".claude" / "skills", 19)
+
+    assert main(["lint"]) == 0
+    assert "lint 合格: 19 skill" in capsys.readouterr().out
+
+
+def test_cli_lint_does_not_count_directory_without_skill_md(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _populate_valid_skill_count(skills_dir, 19)
+    (skills_dir / "__pycache__").mkdir()
+
+    assert main(["lint"]) == 0
+    out = capsys.readouterr().out
+    assert "lint 合格: 19 skill" in out
+    assert "配布対象の skill" not in out
+
+
+@pytest.mark.parametrize("dev_only_name", ["automation-release", "shadcn"])
+def test_cli_lint_does_not_count_dev_only_skill(
+    fake_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+    dev_only_name: str,
+) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _populate_valid_skill_count(skills_dir, 19)
+    _write_skill(skills_dir, dev_only_name, _VALID_SKILL_MD.replace("good-skill", dev_only_name))
+
+    assert main(["lint"]) == 0
+    assert "配布対象の skill" not in capsys.readouterr().out
+
+
+def test_distributed_skill_count_limit_matches_current_inventory() -> None:
+    inventory = SkillInventory(REPO_ROOT / ".claude" / "skills")
+    distributed = {
+        path.name
+        for path in inventory.skill_directories()
+        if (path / "SKILL.md").is_file() and path.name not in _lint._DEV_ONLY_SKILL_NAMES
+    }
+
+    assert len(distributed) == _lint._MAX_SKILL_COUNT == 19
 
 
 def test_cli_delegation_reports_each_depth_longest_path_and_summary(


### PR DESCRIPTION
## 概要

統合後の配布対象skill数を19件でratchetし、skillが再び増殖する変更をlintで防ぎます。

## 変更内容

- 実inventoryからSKILL.mdを持つ配布対象skillを集計
- `automation-release` / `shadcn` のdev-onlyを除外
- SKILL.mdなしの残骸directoryを件数・lint対象から除外
- 20件以上は統合を促す具体診断付きでexit non-zero
- 19件境界、dev-only/残骸除外、現inventoryと上限一致のstale ratchetを契約化

## 検証

- related: 155 passed
- full: 9,210 passed / 3 skipped
- ruff check / format check: green
- `yt-skills lint`: green

Closes #3805