### PR TITLE
refactor(workflow-state): skill更新をCLIへ移す (#3887)

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -68,7 +68,7 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 2. **前提未達時の state 変更禁止**: channel config gate で停止した場合、`uv run yt-init-collection` を実行しない。`collections/planning/`、`workflow-state.json`、`assets.*` を新規作成・更新しない。
 3. **Suno collection Style boundary**: Suno チャンネルで `/music --prompt` を呼ぶときは、対象 collection の絶対 path、確定企画、theme、書き込み先 `20-documentation/suno-patterns.yaml` を subagent へ渡す。collection 固有の `genre_line` / `exclude_styles` / `style_variants` / `vocal_gender` は同ファイルの root に書き、共有 `config/skills/music.yaml::prompt` を書き換えない。root に無い値だけが channel config へ fallback する。`suno_preset` は推奨入力であり、不在だけを理由に停止しない。利用可能なら TTP 根拠として渡し、無ければ `/music --prompt` が確定企画と制約から collection-local Style を設計する。`assets.music_prompts = true` は subagent 報告だけで更新せず、成果物、`yt-suno-verify`、semantic review をメインが検証した後に限る。
 4. **analytics input gate**: 入力モード判定、同日付 JSON、validator、stale 判定、自動更新、再検証は `/wf-new` の `references/freshness-rules.md::stale report の自動更新` に一元化する。`/wf-new` は判定ロジックを再定義せず、stale 判定や AskUserQuestion を先行実行しない。subagent が stale を検出した場合は、同 SSOT が返す自動更新シーケンスを同じ subagent 作業内で順次実行し、全呼び出し成功後に入力モード判定を先頭からやり直す。`yt-doctor` の `analytics_report` は予備確認にだけ使い、analytics mode の最終判定には使わない。
-5. **subagent state boundary**: 各フェーズの生成処理は Agent ツールで subagent へ一作業ずつ委譲する。Phase 2c の thumbnail / music が両方未完了の場合だけは、独立した 2 call を同じ message で同時起動する。Phase 2c それ以外と他 phase は一作業ずつ順次委譲する。subagent は `workflow-state.json` を書き込まず AskUserQuestion を実行しない。メインエージェントだけが承認、成果物検証、`assets` / `phase` / `updated_at` 更新を行う。
+5. **subagent state boundary**: 各フェーズの生成処理は Agent ツールで subagent へ一作業ずつ委譲する。Phase 2c の thumbnail / music が両方未完了の場合だけは、独立した 2 call を同じ message で同時起動する。Phase 2c それ以外と他 phase は一作業ずつ順次委譲する。subagent は `workflow-state.json` を書き込まず AskUserQuestion を実行しない。メインエージェントだけが承認、成果物検証、`assets` 更新と、owner CLI による制御面更新を行う。
 6. **failure boundary**: subagent の失敗、期待成果物欠落、現在の phase との不整合時は state を更新しない。同じ未完了ステップから再実行できる状態で停止する。Phase 2c の thumbnail / music だけは独立 branch とし、[`references/phase-2c-artifact-contract.md`](references/phase-2c-artifact-contract.md) の実成果物検証に成功した側だけを反映して、失敗側だけを再開する。
 7. **thumbnail full-mode gate**: `.claude/skills/thumbnail/config.default.yaml` と、存在する場合は `config/skills/thumbnail.yaml` を読み、deep-merge 後の `image_generation.auto_selection.enabled` / `mode` を Phase 2c より前に確定する。`enabled: true` かつ `mode: full` のときだけ Phase 2c のサムネイル AskUserQuestion をすべて省略する。mode 未設定は `selection_only` として扱い、従来の候補承認だけを省略する。full で生成・QA・自動選択に失敗した場合は state を更新せず `/thumbnail` の「full モード失敗時の手動切替」を表示して停止する。
 8. **企画選択 skip gate**: `load_config()` の `config.workflow.wf_new.skip_plan_selection` を Phase 1 より前に確定する。`true` かつ analytics mode / benchmark fallback mode のときだけ、`/wf-new` が返した推奨順 1 位を自動採用できる。minimal mode のテーマ / ジャンル / 雰囲気入力は省略せず、無人実行では `blocked` とする。
@@ -76,6 +76,12 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 10. **channel constraint verification gate**: 通常入口では `/wf-new` が現在のチャンネル規定を固定制約として解決し、候補ごとの適合結果を返すこと。未検証、FAIL、または適合結果を含む期待成果物欠落時は候補を提示・自動採用せず、state を更新せず停止する。規定の解決・候補検証ロジックは `/wf-new` の planning rules に一元化し、`/wf-new` で再定義しない。
 
 委譲時は入力パス、実行作業、期待成果物、禁止事項、完了報告形式をすべて具体値で埋める。成果物は絶対パスで受け取る。
+
+### workflow-state 制御面の更新境界
+
+対象 collection を確定したら、その絶対 path を `COLLECTION_DIR` として固定する。メインも制御面キー (`phase` / `stage` / `upload` / `updated_at`) を Edit / Write で直接変更しない。`phase` / `stage` / `upload` は必ず `uv run yt-workflow-state --collection "$COLLECTION_DIR" ...` を使い、各更新と同じ owner lock 内で `updated_at` も更新させる。制御面を変えず時刻だけ更新する必要がある場合は `uv run yt-workflow-state --collection "$COLLECTION_DIR" touch` を使う。CLI が非 0 の場合は state 更新失敗として停止し、後続へ進まない。
+
+資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のままとし、CLI 移行は #3888 に残す。資産系だけを更新した直後は上記 `touch` を実行する。
 
 ### Preselected batch plan entry（opt-in）
 
@@ -221,7 +227,7 @@ success を記録した後は同じ fixed collection を `plan --collection <fix
 - **順次実行 + Phase 2c 限定例外**: 子スキルは必ず上から順に呼び、Agent ツールで起動する subagent も一作業ずつ呼ぶ。唯一、Phase 2c で thumbnail / music が両方未完了の場合は 2 call を同じ message で同時起動する。それ以外は Phase 2c の片側再開を含め、一作業ずつ順次実行する
 - **責務分離**: 子スキルの内部手順を `/wf-new` で再実装しない。必要な前提チェックだけを行い、失敗時は子スキルの障害時ガイダンスへ誘導する
 - **停止点**: user 入力で止めるのは原則として (1) Phase 0 の pending 分析承認 (2) 企画選択 (3) サムネイル承認。pending 0 件では (1)、`workflow.wf_new.skip_plan_selection: true` の analytics mode / benchmark fallback mode では (2)、thumbnail の `mode: full` では (3) を省略する。minimal mode の直接入力確認は `skip_plan_selection` の対象外で、`ttp_mode: true` なら `/channel-research --benchmark` の案内で停止する
-- **状態更新**: メインが期待成果物を実ファイルで検証した後だけ `workflow-state.json` の該当 `assets` と `updated_at` を更新する。subagent とユーザーには編集させない
+- **状態更新**: メインが期待成果物を実ファイルで検証した後だけ `workflow-state.json` の該当 `assets` を更新し、直後に owner CLI の `touch` で `updated_at` を更新する。subagent とユーザーには編集させない
 - **再開性**: 途中失敗時は完了済み成果物を再生成せず、未完了ステップから再開できるように次に呼ぶ skill / CLI を明示する
 
 ### 実行シーケンス
@@ -283,7 +289,13 @@ Step 1（企画）を自動実行中...
 
 ユーザー選択または設定による自動選択で企画が確定したら、[`references/phase2.md`](references/phase2.md) を読み、記載された 2a / 2b / 2c / 2e / 2f / 2g を上から順に実行する。
 
-完了条件は、成果物を検証したメインが `workflow-state.json` の `phase = "prepared"` まで更新し、2g の完了ガイダンスを表示すること。Suno helper server の起動・疎通確認に失敗しても、検証・更新済みの `phase = "prepared"` は維持し、再実行手順を案内して `/wf-new` 自体は完了扱いにする。
+完了条件は、成果物を検証したメインが次の owner CLI を実行し、再読込で `phase = "prepared"` を確認してから 2g の完了ガイダンスを表示すること。
+
+```bash
+uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase prepared
+```
+
+Suno helper server の起動・疎通確認に失敗しても、CLI で検証・更新済みの `phase = "prepared"` は維持し、再実行手順を案内して `/wf-new` 自体は完了扱いにする。
 
 ## 障害時ガイダンス
 

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -22,12 +22,25 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ## Hard Gates: subagent 委譲境界
 
-1. メインエージェントだけが `workflow-state.json` を読み書きし、`phase` 遷移、`assets` / `upload` / `updated_at` 更新を行う。subagent は委譲先 skill の入力確認に必要な場合だけ state を読み、書き込まない。
+1. メインエージェントだけが `workflow-state.json` の `assets` を更新し、制御面の `phase` / `stage` / `upload` / `updated_at` は owner CLI 経由で更新する。subagent は委譲先 skill の入力確認に必要な場合だけ state を読み、書き込まない。
 2. AskUserQuestion、`skip_*_approval` の承認ゲート、候補選択、playlist 初期化などの承認はメインエージェントが完了させる。未承認の操作を subagent へ委譲しない。
 3. 各フェーズの生成・変換処理は Agent ツールで一作業ずつ subagent へ委譲する。委譲プロンプトには入力パス、実行する skill / CLI、期待成果物、state 書き込み禁止、完了報告形式を明記する。
 4. subagent 終了後、メインエージェントが期待成果物の存在と現在の `phase` / `assets` との整合を実ファイルで検証する。すべて PASS の場合だけ state を更新する。失敗、欠落、不整合時は state を変更せず、同じステップから再実行できる状態で停止する。
 
 委譲プロンプトには上記 3 の要素を具体値で埋め、成果物は絶対パスで受け取る。subagent の `status: success` だけを更新根拠にせず、実ファイルで検証する。
+
+### workflow-state 制御面の更新境界
+
+対象 collection を確定したら、その絶対 path を `COLLECTION_DIR` として固定する。メインも制御面キー (`phase` / `stage` / `upload` / `updated_at`) を Edit / Write で直接変更しない。必要な更新は次の owner CLI だけを使い、各更新と同じ owner lock 内で `updated_at` も更新させる。CLI が非 0 の場合は state を再編集せず、同じ工程から再開できる状態で停止する。
+
+```bash
+uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase <planning|prepared|mastered|publishing|complete>
+uv run yt-workflow-state --collection "$COLLECTION_DIR" set-stage <planning|live>
+uv run yt-workflow-state --collection "$COLLECTION_DIR" set-upload --video-id <video-id> [--video-url <url>] [--publish-at <timestamp>]
+uv run yt-workflow-state --collection "$COLLECTION_DIR" touch
+```
+
+資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のままとし、CLI 移行は #3888 に残す。資産系だけを更新した直後は上記 `touch` を実行する。`yt-upload-collection` / `yt-upload-auto` や owner reference script が制御面を更新済みの場合は、同じ変更を CLI で重ねない。
 
 > **このセッションで初めて `/wf-*` を呼ぶ場合は、先に [`docs/workflow-cheatsheet.md`](../../../docs/workflow-cheatsheet.md) の判定フローを 1 回だけユーザーに提示すること**。
 
@@ -154,7 +167,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - **`02-Individual-music/` に音声ファイルが 1 件以上存在（URL 記録の有無は問わない）**:
      - AskUserQuestion による URL 入力はスキップする。title list は `/music --master` Step 1.6 がローカルファイル名から自動復元するため playlist URL は不要。メインが `/music --master` の dry-run / Step 5.1 以外の検証ゲートを実行し、選曲・混入許容・over-max 例外などの承認分岐をすべて解決する。ラウドネス全曲走査は subagent 内の Step 5.1 で1回だけ行う
      - Agent ツールで subagent を起動し、対象 collection、（記録があれば）playlist URL、承認済み選択条件を入力として `/music --master` の Subagent Contract を実行させる。`workflow-state.json` 更新と雨レイヤー後処理は実行させない
-     - 期待成果物 `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` の存在をメインが確認する。`yt-raw-master-check --apply --loudness-receipt <receipt>` で receipt と現在の collection / 入力 SHA-256 / 閾値 / PASS 判定を検証し、成功時だけ `assets.raw_master` と `updated_at` を更新する。検証時に FFmpeg の全曲走査を再実行しない。雨レイヤーが有効なら、その後にメインが `/music --master` Step 5.6 を実行し、出力と state を再検証する
+     - 期待成果物 `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` の存在をメインが確認する。`yt-raw-master-check --apply --loudness-receipt <receipt>` で receipt と現在の collection / 入力 SHA-256 / 閾値 / PASS 判定を検証し、成功時だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する。検証時に FFmpeg の全曲走査を再実行しない。雨レイヤーが有効なら、その後にメインが `/music --master` Step 5.6 を実行し、出力と state を再検証する
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
    - **URL 記録済みだが `02-Individual-music/` に音声ファイルが無い**:
@@ -163,14 +176,14 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - **URL 未記録（キー自体が無い、または `null`）かつ `02-Individual-music/` に音声ファイルも無い**:
      - 従来通りユーザーにプレイリスト URL を AskUserQuestion で取得
      - URL 取得後、上記と同じくメインが `/music --master` の承認分岐を解決し、Agent ツールで Subagent Contract を委譲する
-     - メインが `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` を検証し、上記と同じ receipt 付き `yt-raw-master-check --apply` が成功した場合だけ `assets.raw_master` と `updated_at` を更新する
+     - メインが `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` を検証し、上記と同じ receipt 付き `yt-raw-master-check --apply` が成功した場合だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
 
 **Lyria パス:**
 1. `assets.music_prompts = true` + `assets.raw_master = null`:
    - Agent ツールで subagent を起動し、対象 collection と theme を入力に `/music --generate <theme>` の Lyria 3 API セグメント生成だけを実行させる（最大 ~184 秒/リクエスト）。state 書き込みと承認取得は禁止する
-   - 委譲前に期待する `02-Individual-music/` の音声ファイルと `01-master/` の raw master パスを列挙する。メインが実在を確認し、成功時だけ `assets.raw_master` と `updated_at` を更新する
+   - 委譲前に期待する `02-Individual-music/` の音声ファイルと `01-master/` の raw master パスを列挙する。メインが実在を確認し、成功時だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する
    - ガイダンス: 「生成されたセグメントをミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
    - **ここでフロー停止**
 
@@ -211,7 +224,11 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - 両 Agent とも state は入力確認に必要な範囲だけ読み、書き込まず、AskUserQuestion を実行しない。片方でも失敗または成果物欠落なら state を更新せず停止する
 2. 並列 A 完了後:
    - メインが両成果物の存在と `phase: "mastered"` との整合を確認する
-   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、`phase: "publishing"`、`assets.master_video`、`assets.description`、`description.generated`、`updated_at` を更新する
+   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、`assets.master_video`、`assets.description`、`description.generated` を更新してから、次の owner CLI で phase と `updated_at` を一体更新する
+
+     ```bash
+     uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase publishing
+     ```
 3. **アップロード承認ゲート 3-B（`skip_upload_approval = false` のとき）**:
    - 並列 A 完了直後、ユーザーに公開方法を提示する前に必ず `uv run yt-upload-collection --plan [-c <collection-name>]` を実行し、`config/schedule_config.json` / `config/channel/youtube.json` を反映した実際の公開タイミングを確定する
    - plan 結果が `📅 公開設定: 非公開でアップロード（即時公開は行いません）` の場合は、予約設定または YouTube Studio での手動公開を案内する。`📅 公開設定: 限定公開 (unlisted)` / `📅 公開設定: 非公開 (private)` が出た場合は、その公開範囲でアップロードされることを AskUserQuestion の文面に含める。`📅 公開予定: <日時>` が出た場合は「今アップロード → `<日時>` に自動で一般公開」と、実際の予約時刻を AskUserQuestion の文面に含める
@@ -235,7 +252,12 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 メインが `assets` フラグと実ファイルを突合して未完了ステップを特定し、同じ subagent 委譲から再実行する。
 - `assets.master_video = null` → 並列 A から
 - `upload.video_id = null` → 初投稿プレイリスト初期化ゲート（`uv run yt-playlist-status` → 必要なら `--init --dry-run` → 確認後 `--init`）を通してから `/publish --upload` へ進む
-- `upload.video_id != null` かつ phase / stage / live 移動が未完了 → `20-documentation/upload_tracking.json` が schema v3、全体と Complete Collection の status が `completed`、video ID が state と完全一致する場合だけ、remote upload と playlist assign を skip する。planning 側 collection を同名の `collections/live/` へ移動（同名 live が既にあれば停止）し、移動先 state の `stage: "live"`、`phase: "complete"`、`updated_at` だけを atomic write で補完する。tracking 欠落・不一致なら `upload_state_inconsistent` で停止し、upload を再実行しない
+- `upload.video_id != null` かつ phase / stage / live 移動が未完了 → `20-documentation/upload_tracking.json` が schema v3、全体と Complete Collection の status が `completed`、video ID が state と完全一致する場合だけ、remote upload と playlist assign を skip する。planning 側 collection を同名の `collections/live/` へ移動（同名 live が既にあれば停止）し、移動後の絶対 path で `COLLECTION_DIR` を固定し直して次の owner CLI を順に実行する。tracking 欠落・不一致なら `upload_state_inconsistent` で停止し、upload を再実行しない
+
+  ```bash
+  uv run yt-workflow-state --collection "$COLLECTION_DIR" set-stage live
+  uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase complete
+  ```
 
 #### `complete` → 完了案内
 
@@ -246,7 +268,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 
 ### 3. state ファイルの更新ルール
 
-state を更新するのはメインエージェントだけとし、検証 PASS 後の各操作で `updated_at` を現在時刻に更新する。subagent が state を変更した場合は失敗として扱い、変更内容を確認してから同じステップを再実行する。スキーマ詳細は `.claude/skills/wf-new/references/schema.md` を参照。
+state を更新するのはメインエージェントだけとし、検証 PASS 後の制御面操作は owner CLI で `updated_at` と一体更新する。資産系だけを更新した場合は `touch` を使う。subagent が state を変更した場合は失敗として扱い、変更内容を確認してから同じステップを再実行する。スキーマ詳細は `.claude/skills/wf-new/references/schema.md` を参照。
 
 ## 障害時ガイダンス
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。
 - `feat(channel-strategy)`: `--persona` が構造化 persona fields の全項目に実入力ファイルまたは `推測` の出典注記を要求し、暫定版から最終版まで維持する契約を追加する（#3999）。
 - `feat(documents)`: Suno / Lyria の音楽promptをreview・provenance付き JSON 正本と承認表示HTMLへ統一し、verify / semantic review / pair再読込成功後だけ workflow state を更新する（#4029）。
+- `refactor(workflow-state)`: `wf-new` / `wf-next` の制御面 state 更新を `yt-workflow-state` へ移し、phase / stage / upload / updated_at の AI による直接 Edit 指示を廃止する（#3887）。
 - `feat(workflow-state)`: 制御面の phase / stage / upload を lock + atomic update で更新し、任意 key path を JSON で取得する `yt-workflow-state` CLI を追加する（#3886）。
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
@@ -40,6 +41,7 @@ def build_parser() -> argparse.ArgumentParser:
     upload_parser.add_argument("--video-id", required=True)
     upload_parser.add_argument("--video-url")
     upload_parser.add_argument("--publish-at")
+    subparsers.add_parser("touch", help="updated_at を現在時刻へ更新")
     return parser
 
 
@@ -66,6 +68,21 @@ def _set_upload(state: WorkflowState, args: argparse.Namespace) -> None:
         upload.video_url = args.video_url
     if args.publish_at is not None:
         upload.publish_at = args.publish_at
+    _touch(state)
+
+
+def _touch(state: WorkflowState) -> None:
+    state["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _set_phase(state: WorkflowState, phase: Phase) -> None:
+    state.phase = phase
+    _touch(state)
+
+
+def _set_stage(state: WorkflowState, stage: Stage) -> None:
+    state.stage = stage
+    _touch(state)
 
 
 def run(args: argparse.Namespace) -> int:
@@ -75,12 +92,14 @@ def run(args: argparse.Namespace) -> int:
         print(json.dumps(value, ensure_ascii=False))
     elif args.command == "set-phase":
         phase = cast(Phase, args.phase)
-        update_workflow_state(state_path, lambda state: setattr(state, "phase", phase))
+        update_workflow_state(state_path, lambda state: _set_phase(state, phase))
     elif args.command == "set-stage":
         stage = cast(Stage, args.stage)
-        update_workflow_state(state_path, lambda state: setattr(state, "stage", stage))
+        update_workflow_state(state_path, lambda state: _set_stage(state, stage))
     elif args.command == "set-upload":
         update_workflow_state(state_path, lambda state: _set_upload(state, args))
+    elif args.command == "touch":
+        update_workflow_state(state_path, _touch)
     return 0
 
 

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -41,7 +41,9 @@ def test_set_phase_uses_owner_update_and_preserves_unknown_fields(tmp_path: Path
 
     assert workflow_state_cli.main(["--collection", str(collection), "set-phase", "prepared"]) == 0
 
-    assert _read_state(collection) == {"phase": "prepared", "future": {"keep": True}}
+    state = _read_state(collection)
+    assert isinstance(state.pop("updated_at"), str)
+    assert state == {"phase": "prepared", "future": {"keep": True}}
     assert not list(collection.glob(".workflow-state.*.tmp"))
 
 
@@ -85,7 +87,9 @@ def test_set_upload_creates_section_and_only_overwrites_supplied_fields(tmp_path
 
     assert workflow_state_cli.main(["--collection", str(collection), "set-upload", "--video-id", "new-video"]) == 0
 
-    assert _read_state(collection) == {
+    state = _read_state(collection)
+    assert isinstance(state.pop("updated_at"), str)
+    assert state == {
         "upload": {
             "video_id": "new-video",
             "video_url": "https://example.test/old",
@@ -112,7 +116,9 @@ def test_set_upload_creates_section_and_only_overwrites_supplied_fields(tmp_path
         )
         == 0
     )
-    assert _read_state(fresh)["upload"] == {
+    fresh_state = _read_state(fresh)
+    assert isinstance(fresh_state["updated_at"], str)
+    assert fresh_state["upload"] == {
         "video_id": "video-456",
         "video_url": "https://youtu.be/video-456",
         "publish_at": "2026-08-17T00:00:00Z",
@@ -126,3 +132,17 @@ def test_collection_defaults_to_current_collection_directory(tmp_path: Path, mon
     assert workflow_state_cli.main(["set-phase", "complete"]) == 0
 
     assert _read_state(collection)["phase"] == "complete"
+
+
+def test_control_plane_updates_refresh_updated_at_and_touch_is_available(tmp_path: Path) -> None:
+    collection = _collection(tmp_path, {"phase": "planning", "updated_at": "old", "unknown": True})
+
+    assert workflow_state_cli.main(["--collection", str(collection), "set-phase", "prepared"]) == 0
+    phase_updated_at = _read_state(collection)["updated_at"]
+    assert isinstance(phase_updated_at, str)
+    assert phase_updated_at != "old"
+
+    assert workflow_state_cli.main(["--collection", str(collection), "touch"]) == 0
+    state = _read_state(collection)
+    assert isinstance(state["updated_at"], str)
+    assert state["unknown"] is True

--- a/tests/repo/test_workflow_state_skill_cli_contract.py
+++ b/tests/repo/test_workflow_state_skill_cli_contract.py
@@ -1,0 +1,47 @@
+"""workflow skills の制御面 state 更新を owner CLI に限定する契約。"""
+
+from __future__ import annotations
+
+from tests.helpers.paths import REPO_ROOT
+
+SKILLS = {name: REPO_ROOT / ".claude" / "skills" / name / "SKILL.md" for name in ("wf-new", "wf-next")}
+
+
+def _text(skill: str) -> str:
+    return SKILLS[skill].read_text(encoding="utf-8")
+
+
+def test_workflow_skills_route_control_plane_mutations_through_owner_cli() -> None:
+    """phase / stage / upload は Edit / Write で直接変更しない。"""
+    wf_new = _text("wf-new")
+    wf_next = _text("wf-next")
+
+    for text in (wf_new, wf_next):
+        assert "制御面キー (`phase` / `stage` / `upload` / `updated_at`)" in text
+        assert "Edit / Write で直接変更しない" in text
+
+    assert 'yt-workflow-state --collection "$COLLECTION_DIR" set-phase prepared' in wf_new
+    for command in (
+        'yt-workflow-state --collection "$COLLECTION_DIR" set-phase publishing',
+        'yt-workflow-state --collection "$COLLECTION_DIR" set-stage live',
+        'yt-workflow-state --collection "$COLLECTION_DIR" set-phase complete',
+        'yt-workflow-state --collection "$COLLECTION_DIR" set-upload --video-id',
+    ):
+        assert command in wf_next
+
+
+def test_known_direct_control_plane_instructions_do_not_return() -> None:
+    """移行前の具体的な直接更新文言を縮小専用 ratchet として固定する。"""
+    wf_new = _text("wf-new")
+    wf_next = _text("wf-next")
+
+    assert '`phase = "prepared"` まで更新' not in wf_new
+    assert '`phase: "publishing"`、`assets.master_video`' not in wf_next
+    assert '`stage: "live"`、`phase: "complete"`、`updated_at` だけを atomic write' not in wf_next
+
+
+def test_asset_mutations_remain_explicitly_deferred_to_next_migration() -> None:
+    """本段で assets / planning の直接更新まで移したことにしない。"""
+    for text in map(_text, SKILLS):
+        assert "資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のまま" in text
+        assert "#3888" in text


### PR DESCRIPTION
## 概要

wf-new / wf-next に残るworkflow-state制御面キーの直接Edit指示を、検証付き `yt-workflow-state` CLIへ置換します。

## 変更内容

- phase / stage / upload / updated_at の直接Edit指示をowner CLIへ置換
- 制御面更新時の `updated_at` 自動更新と `touch` を追加
- assets / planning は次段 #3888へ明示的に据え置き
- wheel・route・siteの配布契約を追従

## 検証

- related: 139 passed
- focused/wheel: 12 passed
- full: 9,216 passed、変更外collection server timeout 2件は直列2 passed
- ruff / format / yt-skills lint/catalog/artifacts: green
- site check/build/test: 53 passed

Closes #3887