### PR TITLE
feat(doctor): ペルソナの中身をreadinessで検証する (#4000)

### DIFF
--- a/.claude/skills/audit/references/value-loop.md
+++ b/.claude/skills/audit/references/value-loop.md
@@ -20,7 +20,7 @@
 
 | 工程 | `○` の条件（すべて必須） | `×` の条件（1つでも該当） | `×` の次アクション |
 |---|---|---|---|
-| 1. シーン定義 | `docs/channel/personas/persona-definition.md` と `docs/plans/viewing-scene-matrix.md` が存在し、persona に `viewing-scene 未検証` がない | 2ファイルのいずれかがない、または未検証注記がある | `/channel-strategy --scene` |
+| 1. シーン定義 | `ttp_wf_new_readiness` の `message` に `persona-definition.md` の不足診断がなく、`docs/plans/viewing-scene-matrix.md` が存在し、persona に `viewing-scene 未検証` がない | doctor に persona 不足診断がある、scene ファイルがない、または未検証注記がある | doctor の `next_action` または `/channel-strategy --scene` |
 | 2. 制約翻訳 | `docs/channel/creative-constraints.md` が存在し、レベル2見出し `音` `映像` `サムネ` `タイトル` `測定` が各1件ある | ファイルがない、または必須見出しが1つでもない | `/channel-strategy --constraints` |
 | 3. 公開前ゲート | 直近公開コレクションを一意に特定でき、`docs/plans/alignment-audit.md` にそのコレクション名が1回以上ある | 公開コレクションを特定できない、レポートがない、またはレポートに対象名がない | `/audit --alignment` |
 | 4. 指標還流 | `data/insights.jsonl` に有効な analysis または postmortem 由来エントリが1件以上あり、うち1件以上が `status: adopted` かつ `status_note` に `creative-constraints.md` または既存 config の JSON Pointer がある | レポート/postmortemがない、insightsがない、該当エントリがない、または採用先の痕跡がない | `/analytics --flop` または `/analytics --analyze` |
@@ -35,7 +35,7 @@
 
 ### 2. シーン定義を判定
 
-判定表の工程1をそのまま適用する。存在するファイルはパスを根拠欄へ記載し、不在パスも省略しない。
+`uv run yt-doctor --json --check ttp_wf_new_readiness --target "$CHANNEL_DIR"` を読み取り専用で実行し、`message` に `persona-definition.md` の不足があれば、その診断と `next_action` をそのまま根拠へ引用する。TTP 側だけの `warn` を persona 不足とは扱わず、persona の見出しや出典を本 mode で再実装しない。その結果と判定表の工程1を適用し、存在するファイルはパスを根拠欄へ記載し、不在パスも省略しない。`viewing-scene 未検証` は従来どおり本工程で判定する。
 
 ### 3. 制約翻訳を判定
 

--- a/.claude/skills/setup/references/channel-mode.md
+++ b/.claude/skills/setup/references/channel-mode.md
@@ -217,7 +217,7 @@ Step 6〜9 を始める前に [persona / branding / readiness の実施詳細](p
 
 `/channel-strategy --persona` へ `docs/plans/viewer-voice-analysis.md`、`docs/channel/ttp-seed-confirmation.md`、`docs/channel/competitor-branding-snapshot.json`、任意の `/channel-research --benchmark` 成果物を渡す。`reports/analysis_*.md` は要求しない。構造化 persona fields の出典注記は persona mode の `references/persona.md` を唯一の正とし、暫定保存から最終更新まで維持する。`/channel-strategy --persona` から同じ実行コンテキストを引き継いで `/channel-strategy --scene` を実行し、`docs/plans/viewing-scene-matrix.md` を生成してから、最終 `docs/channel/personas/persona-definition.md` を更新する。
 
-最終 `persona-definition.md` が通常ファイルとして存在し、構造化 persona fields の各項目に persona mode 所有の出典注記が維持されていることを確認する。欠落している場合は Step 7 未完了として成功案内を出さず、Step 8 へ進まない。
+最終 `persona-definition.md` が通常ファイルとして存在し、persona mode 所有の必須9セクションと非空本文が揃い、「暫定」表記がなく、構造化 persona fields の各項目に出典注記が維持されていることを確認する。規定の正は `references/persona.md`、機械判定は `yt-doctor --json --check ttp_wf_new_readiness` とし、いずれかが欠ける場合は Step 7 未完了として成功案内を出さず、Step 8 へ進まない。
 
 ### Step 8: branding 初回反映
 

--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -314,6 +314,8 @@ minimal mode / benchmark fallback mode は新規チャンネル初回制作を�
 - `config/skills/thumbnail.yaml::image_generation.gemini.reference_images.default` に `data/thumbnail_compare/benchmark/...` の相対パスを転記する
 - 完了後に `uv run yt-doctor --apply --json <apply_flags>` を再実行し、`ttp_wf_new_readiness` が ok になることを確認する
 
+同じ check は最終 `persona-definition.md` についても、persona mode 所有の必須セクション、非空本文、最終化、構造化項目の出典注記を検証する。persona 不足は `ttp-seed-confirmation.md` のユーザー承認済み例外では抑制せず、`next_action` の `/channel-strategy --persona` に戻って解消する。
+
 `benchmark.channels` 未設定の場合は minimal mode として扱われるため、setup の完了を止めない。
 
 #### `wf_new_readiness` — `/wf-new` の到達可否

--- a/.claude/skills/setup/references/persona-branding-readiness.md
+++ b/.claude/skills/setup/references/persona-branding-readiness.md
@@ -75,4 +75,4 @@ banner.save('branding/banner.png', optimize=True)
 | Analytics / Reporting 設定が未確認 | 初回制作は止めず、`/analytics --collect` で収集前提と Reporting API job 作成状態を確認する。不足する GCP / OAuth / API 設定は `/setup` に戻す。 |
 | ライブ配信を使う可能性がある | 初回制作は止めず、YouTube Studio で早めに有効化する。初回配信へ進む前に `/streaming` で配信側を確認する。 |
 
-`ttp_wf_new_readiness` の不足を意図的にスキップする場合だけ、`docs/channel/ttp-seed-confirmation.md` にユーザー承認済み例外を残す。それ以外は不足を解消してから doctor を再実行する。
+`ttp_wf_new_readiness` の TTP 転写不足を意図的にスキップする場合だけ、`docs/channel/ttp-seed-confirmation.md` にユーザー承認済み例外を残す。`persona-definition.md` の構造不足は例外対象にせず、doctor の `next_action` に従って `/channel-strategy --persona` へ戻る。それ以外は不足を解消してから doctor を再実行する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(skills)`: `yt-skills lint` が downstream 配布対象 skill を実 inventory から数え、開発専用と `SKILL.md` のない残骸を除外した総数を上限 19 件で ratchet する（#3805）。
 - `feat(skills)`: `yt-skills lint` が委譲深さ 2 以上を最長経路つきで拒否し、既存違反だけを報告付き allowlist として段階解消できる契約を追加する（#3799）。
+- `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。
 - `feat(channel-strategy)`: `--persona` が構造化 persona fields の全項目に実入力ファイルまたは `推測` の出典注記を要求し、暫定版から最終版まで維持する契約を追加する（#3999）。
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。
 - `feat(analytics)`: 最新 analytics と upload tracking を読み取り専用で照合し、postmortem 未作成 collection を human / JSON で列挙する `yt-postmortem-pending` を追加する（#3790）。

--- a/src/youtube_automation/domains/channel_readiness/readiness.py
+++ b/src/youtube_automation/domains/channel_readiness/readiness.py
@@ -31,6 +31,31 @@ UNSUPPORTED_THUMBNAIL_MODELS = {
     "gemini-3.1-flash-image-preview",
     "gemini-3-pro-image-preview",
 }
+_PERSONA_SECTIONS = (
+    "第一ペルソナ",
+    "コメント由来の語彙",
+    "感情トリガー",
+    "利用シーン",
+    "検索キーワード",
+    "避けるべき訴求",
+    "自チャンネルへの示唆",
+    "タイトル・タグ・概要欄・サムネ・音楽ムードへの影響",
+    "候補の棄却・統合メモ",
+)
+_STRUCTURED_PERSONA_SECTIONS = frozenset(
+    {
+        "コメント由来の語彙",
+        "感情トリガー",
+        "利用シーン",
+        "検索キーワード",
+        "避けるべき訴求",
+        "自チャンネルへの示唆",
+    }
+)
+_MARKDOWN_HEADING = re.compile(r"^\s{0,3}(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
+_MARKDOWN_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+_MARKDOWN_LIST_ITEM = re.compile(r"^\s*(?:[-+*]|\d+[.)])[ \t]+")
+_PERSONA_SOURCE_ANNOTATION = re.compile(r"出典:\s*(?:推測|[A-Za-z0-9_.-]+\.(?:md|json))(?=[）)\]}、,;；\s]*$)")
 
 
 @dataclass(frozen=True)
@@ -60,7 +85,7 @@ def _matching_files(directory: Path, pattern: str) -> list[Path]:
 
 def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
     persona_definition = channel_dir / "docs" / "channel" / "personas" / "persona-definition.md"
-    missing_persona = [] if persona_definition.is_file() else ["docs/channel/personas/persona-definition.md 未作成"]
+    missing_persona = _missing_persona_readiness_items(persona_definition)
     missing_persona_suffix = ("; " + "; ".join(missing_persona)) if missing_persona else ""
 
     analytics_path = channel_dir / "config" / "channel" / "analytics.json"
@@ -73,9 +98,10 @@ def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
             ),
             next_action={
                 "kind": "human",
-                "instructions": (
+                "instructions": _with_persona_recovery(
                     "/setup --channel Step 4 で config を生成し、Step 5 以降で承認済み TTP 対象を "
-                    "config/channel/analytics.json::benchmark.channels に保存してください"
+                    "config/channel/analytics.json::benchmark.channels に保存してください",
+                    missing_persona,
                 ),
             },
         )
@@ -87,7 +113,10 @@ def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
             message="TTP 完了条件が未充足: " + analytics_read.error + missing_persona_suffix,
             next_action={
                 "kind": "human",
-                "instructions": "config/channel/analytics.json を修正してから yt-doctor を再実行してください",
+                "instructions": _with_persona_recovery(
+                    "config/channel/analytics.json を修正してから yt-doctor を再実行してください",
+                    missing_persona,
+                ),
             },
         )
 
@@ -103,9 +132,10 @@ def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
             ),
             next_action={
                 "kind": "human",
-                "instructions": (
+                "instructions": _with_persona_recovery(
                     "/setup --channel Step 1/5 に戻り、TTP 対象を確認して "
-                    "config/channel/analytics.json::benchmark.channels に承認済み対象を保存してください"
+                    "config/channel/analytics.json::benchmark.channels に承認済み対象を保存してください",
+                    missing_persona,
                 ),
             },
         )
@@ -129,12 +159,13 @@ def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
             + note_suffix,
             next_action={
                 "kind": "human",
-                "instructions": (
+                "instructions": _with_persona_recovery(
                     "/setup --channel Step 5-9 または "
                     "/setup --regenerate Step R3.5 の不足項目を解消してください。"
                     "意図的にスキップする場合は docs/channel/ttp-seed-confirmation.md に "
                     "ユーザー承認済み例外として未反映項目を明記し、最後に `uv run yt-doctor --json` で "
-                    "`ttp_wf_new_readiness` が ok になることを確認してください"
+                    "`ttp_wf_new_readiness` が ok になることを確認してください",
+                    missing_persona,
                 ),
             },
         )
@@ -145,6 +176,75 @@ def evaluate_ttp_wf_new_readiness(channel_dir: Path) -> ReadinessResult:
             "TTP 対象承認・branding snapshot・benchmark docs・thumbnail / music readiness が "
             "/wf-new 接続可能（/setup --regenerate 完了相当）" + note_suffix
         ),
+    )
+
+
+def _missing_persona_readiness_items(path: Path) -> list[str]:
+    relative = "docs/channel/personas/persona-definition.md"
+    if not path.is_file():
+        return [f"{relative} 未作成"]
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [f"{relative} を読み込めません ({exc})"]
+
+    sections = _persona_markdown_sections(text)
+    missing: list[str] = []
+    for name in _PERSONA_SECTIONS:
+        if name not in sections:
+            missing.append(f"{relative} 必須セクション欠落: {name}")
+        elif not any(line.strip() for line in sections[name]):
+            missing.append(f"{relative} 本文空: {name}")
+    if "暫定" in text:
+        missing.append(f"{relative} が未最終化（「暫定」表記あり）")
+    for name in _PERSONA_SECTIONS:
+        if name not in _STRUCTURED_PERSONA_SECTIONS or name not in sections:
+            continue
+        items = [line for line in sections[name] if _MARKDOWN_LIST_ITEM.match(line)]
+        if not items or any(not _PERSONA_SOURCE_ANNOTATION.search(item) for item in items):
+            missing.append(f"{relative} 出典注記不足: {name}")
+    return missing
+
+
+def _persona_markdown_sections(text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    active_name: str | None = None
+    active_level = 0
+    fence_marker: str | None = None
+    for line in text.splitlines():
+        fence = _MARKDOWN_FENCE.match(line)
+        if fence:
+            marker = fence.group(1)
+            if fence_marker is None:
+                fence_marker = marker
+            elif marker[0] == fence_marker[0] and len(marker) >= len(fence_marker):
+                fence_marker = None
+            continue
+        if fence_marker is not None:
+            continue
+
+        heading = _MARKDOWN_HEADING.match(line)
+        if heading:
+            level = len(heading.group(1))
+            name = heading.group(2).strip()
+            if active_name is not None and level <= active_level:
+                active_name = None
+            if name in _PERSONA_SECTIONS:
+                sections.setdefault(name, [])
+                active_name = name
+                active_level = level
+            continue
+        if active_name is not None:
+            sections[active_name].append(line)
+    return sections
+
+
+def _with_persona_recovery(instructions: str, missing_persona: list[str]) -> str:
+    if not missing_persona:
+        return instructions
+    return (
+        instructions + "。ペルソナの不足はユーザー承認済み例外にせず、"
+        "/channel-strategy --persona で最終 persona-definition.md を更新してください"
     )
 
 

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -3260,12 +3260,44 @@ def _semantic_duration_ttp_evidence() -> str:
 """
 
 
+def _valid_persona_definition() -> str:
+    return """# ペルソナ定義
+
+## 第一ペルソナ
+深い集中を求める在宅ワーカー。
+
+## コメント由来の語彙
+- calm focus（出典: viewer-voice-analysis.md）
+
+## 感情トリガー
+- 安心感（出典: viewer-voice-analysis.md）
+
+## 利用シーン
+- 平日の深夜作業（出典: viewing-scene-matrix.md）
+
+## 検索キーワード
+- deep focus music（出典: benchmark_20260816.json）
+
+## 避けるべき訴求
+- 強い煽り（出典: 推測）
+
+## 自チャンネルへの示唆
+- 静かな導入を保つ（出典: analysis_audience.md）
+
+## タイトル・タグ・概要欄・サムネ・音楽ムードへの影響
+低彩度の画面と穏やかな語彙を使う。
+
+## 候補の棄却・統合メモ
+通勤中の視聴候補は利用時間が一致しないため統合しない。
+"""
+
+
 def _write_ttp_readiness_files(base: Path) -> None:
     docs_channel = base / "docs" / "channel"
     docs_channel.mkdir(parents=True, exist_ok=True)
     personas_dir = docs_channel / "personas"
     personas_dir.mkdir(parents=True, exist_ok=True)
-    (personas_dir / "persona-definition.md").write_text("# First persona\n", encoding="utf-8")
+    (personas_dir / "persona-definition.md").write_text(_valid_persona_definition(), encoding="utf-8")
     (docs_channel / "ttp-seed-confirmation.md").write_text(
         "\n".join(
             [
@@ -3452,14 +3484,114 @@ class TestCheckTtpWfNewReadinessChannelNew:
         assert r.status == "warn"
         assert "docs/channel/personas/persona-definition.md 未作成" in r.message
 
-    def test_empty_persona_definition_is_accepted_as_existing(self, tmp_path):
+    def test_empty_persona_definition_warns_with_persona_recovery(self, tmp_path):
         _write_ttp_analytics(tmp_path, [_ttp_channel()])
         _write_ttp_readiness_files(tmp_path)
         (tmp_path / "docs" / "channel" / "personas" / "persona-definition.md").write_text("", encoding="utf-8")
 
         r = doctor.check_ttp_wf_new_readiness(tmp_path)
 
-        assert r.status == "ok"
+        assert r.status == "warn"
+        assert "必須セクション欠落" in r.message
+        assert r.next_action is not None
+        assert "/channel-strategy --persona" in r.next_action["instructions"]
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            "第一ペルソナ",
+            "コメント由来の語彙",
+            "感情トリガー",
+            "利用シーン",
+            "検索キーワード",
+            "避けるべき訴求",
+            "自チャンネルへの示唆",
+            "タイトル・タグ・概要欄・サムネ・音楽ムードへの影響",
+            "候補の棄却・統合メモ",
+        ],
+    )
+    def test_missing_required_persona_section_warns_even_when_named_inside_fence(self, tmp_path, section):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        persona_path = tmp_path / "docs" / "channel" / "personas" / "persona-definition.md"
+        persona = _valid_persona_definition()
+        heading = f"## {section}"
+        start = persona.index(heading)
+        following = persona.find("\n## ", start + len(heading))
+        end = len(persona) if following == -1 else following + 1
+        persona_path.write_text(persona[:start] + f"```markdown\n{heading}\n```\n" + persona[end:], encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert f"必須セクション欠落: {section}" in r.message
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            "第一ペルソナ",
+            "コメント由来の語彙",
+            "感情トリガー",
+            "利用シーン",
+            "検索キーワード",
+            "避けるべき訴求",
+            "自チャンネルへの示唆",
+            "タイトル・タグ・概要欄・サムネ・音楽ムードへの影響",
+            "候補の棄却・統合メモ",
+        ],
+    )
+    def test_empty_required_persona_section_warns(self, tmp_path, section):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        persona_path = tmp_path / "docs" / "channel" / "personas" / "persona-definition.md"
+        persona = _valid_persona_definition()
+        heading = f"## {section}"
+        start = persona.index(heading) + len(heading)
+        following = persona.find("\n## ", start)
+        end = len(persona) if following == -1 else following
+        persona_path.write_text(persona[:start] + "\n" + persona[end:], encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert f"本文空: {section}" in r.message
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            "コメント由来の語彙",
+            "感情トリガー",
+            "利用シーン",
+            "検索キーワード",
+            "避けるべき訴求",
+            "自チャンネルへの示唆",
+        ],
+    )
+    def test_structured_persona_section_item_without_source_warns(self, tmp_path, section):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        persona_path = tmp_path / "docs" / "channel" / "personas" / "persona-definition.md"
+        persona = _valid_persona_definition()
+        heading = f"## {section}"
+        item_start = persona.index("- ", persona.index(heading))
+        item_end = persona.index("\n", item_start)
+        persona_path.write_text(persona[:item_start] + "- 根拠不明の項目" + persona[item_end:], encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert f"出典注記不足: {section}" in r.message
+
+    def test_provisional_persona_definition_warns(self, tmp_path):
+        _write_ttp_analytics(tmp_path, [_ttp_channel()])
+        _write_ttp_readiness_files(tmp_path)
+        persona_path = tmp_path / "docs" / "channel" / "personas" / "persona-definition.md"
+        persona_path.write_text("暫定版\n" + _valid_persona_definition(), encoding="utf-8")
+
+        r = doctor.check_ttp_wf_new_readiness(tmp_path)
+
+        assert r.status == "warn"
+        assert "未最終化（「暫定」表記あり）" in r.message
 
     def test_main_json_reports_missing_persona_definition_through_public_cli(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))

--- a/tests/domains/channel_readiness/test_readiness.py
+++ b/tests/domains/channel_readiness/test_readiness.py
@@ -13,6 +13,8 @@ def test_ttp_readiness_reports_missing_analytics_config(tmp_path) -> None:
         "kind": "human",
         "instructions": (
             "/setup --channel Step 4 で config を生成し、Step 5 以降で承認済み TTP 対象を "
-            "config/channel/analytics.json::benchmark.channels に保存してください"
+            "config/channel/analytics.json::benchmark.channels に保存してください。"
+            "ペルソナの不足はユーザー承認済み例外にせず、/channel-strategy --persona で最終 "
+            "persona-definition.md を更新してください"
         ),
     }

--- a/tests/repo/test_audit_skill_contract.py
+++ b/tests/repo/test_audit_skill_contract.py
@@ -104,6 +104,8 @@ def test_value_loop_mode_diagnoses_all_four_integrated_stages_without_writes() -
         assert route in value_loop
     assert "ファイルの作成・変更・削除" in value_loop
     assert "結果はチャット内にだけ表示" in value_loop
+    assert "yt-doctor --json --check ttp_wf_new_readiness" in value_loop
+    assert "persona の見出しや出典を本 mode で再実装しない" in value_loop
 
 
 def test_video_mode_keeps_gemini_analysis_outputs_and_external_read_only_boundary() -> None:

--- a/tests/repo/test_setup_channel_disclosure_contract.py
+++ b/tests/repo/test_setup_channel_disclosure_contract.py
@@ -24,7 +24,7 @@ OPENING_ASSETS = {
 BEFORE_MOVE_SHA256 = {
     "new-channel-bootstrap.md": "dbae6fc0b7bba180d8c7ec3a40667428ca584e50977127e7ab7a21e9391160c4",
     "ttp-seed-and-duration.md": "2b61abd7944f29740bdd34b1a12b17cb83d3789f9128541dba982270fc62bb4f",
-    "persona-branding-readiness.md": "6e7fb3a0923b95b7300b5569e527b7446619fb84c00b985067966e77205c0f8a",
+    "persona-branding-readiness.md": "ba3546666759d4626d0bbef255071f8976c61efd30d8eec5de883bc8ee116daf",
     "derive_ttp_duration.py": "8440e25a6b527498ab1eddbd07918ccd0e2ac2d81f326c94991a731432c5d2f2",
     "initial_save_guard.sh": "93e9503da8d1e1c2680f682be25c053988fd0fd45fa3bf193e8272d2dd704ac3",
 }


### PR DESCRIPTION
## 概要

ペルソナ正本の存在確認だけだった `ttp_wf_new_readiness` を、現owner規定に沿う決定的な中身検証へ引き上げます。

## 変更内容

- `domains/channel_readiness` でuntrusted Markdownを構造解析
- 必須9 section、本文非空、暫定表記禁止を検証
- 6 structured sectionの全itemにcanonical `出典:` を要求
- 既存TTP診断を維持し、不正personaのnext_actionを `/channel-strategy --persona` へ更新
- setup/value-loop導線と契約を追従

## 検証

- full: 9,242 passed / 3 skipped
- rebase後 focused: 461 passed
- site build/test: 53 passed
- ruff check / format / `yt-skills lint`: green

Closes #4000