### PR TITLE
refactor(workflow-state): 資産系更新を owner CLI に統一する (#3888)

### DIFF
--- a/.claude/skills/music/references/generate.md
+++ b/.claude/skills/music/references/generate.md
@@ -312,7 +312,7 @@ Lyria 3 Pro は **1 リクエストあたり最大約 184 秒（~3 分）** ま�
 - **成果物**: `01-master/master.mp3`、音楽プロンプト成果物
 - **委譲しない処理**: `skip_generation_approval: false` のときの課金承認と候補選択。メインが確定してから起動する（`true` なら保存済み生成条件を渡して起動できる）
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と owner CLI 実行はメインが行う。
 
 ## 設定読み込みゲート
 
@@ -534,17 +534,17 @@ bash "$(git rev-parse --show-toplevel)/.claude/skills/music/references/worktree_
 
 事前確認には `--dry-run` を付ける。
 
-## Step 5: 完了時の更新
+## Step 5: owner CLI による完了時の更新
 
-- `workflow-state.json` の `planning.music` セクションを populate（下記参照）
-- `assets.music_prompts = true` に更新
-- `assets.raw_master` に生成されたマスター音源ファイル名（例: `master.mp3`）を記録
+- 下記 `planning.music` object を JSON として `uv run yt-workflow-state --collection <collection-path> set-planning music <json-value>` へ渡す
+- `uv run yt-workflow-state --collection <collection-path> set-asset music_prompts true` を実行する
+- 生成されたマスター音源ファイル名（例: `master.mp3`）を JSON string として `set-asset raw_master <json-value>` へ渡す
 
 最終マスター確定（`assets.master_audio`）と `phase: "mastered"` への遷移は、ユーザーがミキシング+マスタリングした最終ファイルを `01-master/` に配置した後に `/wf-next` が検出して更新する（本スキルの責務外）。
 
 ### planning.music スキーマ
 
-`/alignment-check` がコレクション横断で音楽 mood × サムネ × タイトルの整合を機械的に判定できるよう、`workflow-state.json` の `planning.music` セクションを populate する。新規制作分は必須。
+`/audit --alignment` がコレクション横断で音楽 mood × サムネ × タイトルの整合を機械的に判定できるよう、上記 owner CLI に渡す `planning.music` object を組み立てる。新規制作分は必須。
 
 ```json
 {

--- a/.claude/skills/music/references/lyric.md
+++ b/.claude/skills/music/references/lyric.md
@@ -17,7 +17,7 @@
 - **委譲しない処理**: 引用候補と歌詞方針の選択。メインが確定してから起動する
 - **例外**: 入力確認に必要な `workflow-state.json::planning.music` を読み取ってよい（書き込みは不可）
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と owner CLI 実行はメインが行う。
 
 ## Responsibilities
 

--- a/.claude/skills/music/references/master.md
+++ b/.claude/skills/music/references/master.md
@@ -35,7 +35,7 @@ SunoAI 楽曲のクロスフェード結合でマスター音源を自動生成�
 - **成果物**: `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json`
 - **委譲しない処理**: 選曲・混入許容・over-max 例外採用の承認。Step 5.6 の雨レイヤー後処理は成果物生成時に `workflow-state.json` を更新するためメインが実行する
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。Step 5.1 の全曲走査は subagent が1回だけ実行して receipt を返し、メインは FFmpeg を再実行せず receipt を検証する。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証、receipt 検証、state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。Step 5.1 の全曲走査は subagent が1回だけ実行して receipt を返し、メインは FFmpeg を再実行せず receipt を検証する。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証、receipt 検証、owner CLI 実行はメインが行う。
 
 ## 設定読み込みゲート
 
@@ -485,7 +485,7 @@ audio:
 
 `uv run yt-finalize-master` が master.mp3 を **loudnorm 二段で in-place 上書き**するのに対し、`uv run yt-apply-rain-layers` は raw master と `branding/rain_layers/*.wav` を **amix のみ**で合成し**別ファイル**（既定 `01-master/master-rain.wav`）に書き出す軽い後処理 CLI。後段で外部 DAW のミキシング+マスタリングを挟む運用（raw master を保持したまま雨レイヤー付きバージョンを並行管理したい場合）向け。
 
-この CLI は出力成功時に `workflow-state.json::assets.raw_master` を更新し、成果物生成だけを行うオプションを持たない。subagent 実行時はこの Step を実行せず、subagent の成果物をメインエージェントが検証して state を更新した後、メインエージェントが次のコマンドを実行する。
+この CLI は出力成功時に `workflow-state.json::assets.raw_master` を owner 経由で更新し、成果物生成だけを行うオプションを持たない。subagent 実行時はこの Step を実行せず、subagent の成果物をメインエージェントが検証して `yt-workflow-state` を実行した後、メインエージェントが次のコマンドを実行する。
 
 ```bash
 uv run yt-apply-rain-layers                       # CWD がコレクションディレクトリ
@@ -534,8 +534,7 @@ fi
 
 ### 完了時の更新
 
-- `workflow-state.json` の `assets.raw_master` に生成したマスターファイル名（例: `"master.mp3"`）を記録
-- `updated_at` を現在時刻に更新
+生成したマスターファイル名（例: `master.mp3`）を JSON string として `uv run yt-workflow-state --collection <collection-path> set-asset raw_master <json-value>` へ渡す。owner CLI が同じ lock 内で `updated_at` も更新する。
 
 `phase` は `"prepared"` のまま変更しない。`raw_master` → `master_audio` 確定後の `"mastered"` フェーズ遷移は `/wf-next` の責務（本スキルはユーザーのミキシング+マスタリング前の raw master 生成までを担う）。
 

--- a/.claude/skills/publish/references/community.md
+++ b/.claude/skills/publish/references/community.md
@@ -74,7 +74,7 @@
 ### Hard Gates
 
 - `config/channel/community-draft.json` が存在し、`load_config().community_draft.posts` が空でないこと。欠落時は `examples/channel_config.example/community-draft.example.json` をコピーしてチャンネル値へ書き換えるよう案内し、設定が完了するまで停止する。
-- 対象 collection の `workflow-state.json::planning.final_title` と `planning.publish_target_at` が非空であること。`final_title` 欠落時は `/wf-new` 経由で企画を確定するよう案内して停止する。`publish_target_at` 欠落時は planned YouTube publish datetime を timezone 付き ISO 8601 で同フィールドへ記録するよう案内し、記録されるまで停止する。
+- 対象 collection の `workflow-state.json::planning.final_title` と `planning.publish_target_at` が非空であること。`final_title` 欠落時は `/wf-new` 経由で企画を確定するよう案内して停止する。`publish_target_at` 欠落時は planned YouTube publish datetime を timezone 付き ISO 8601 の JSON string とし、`uv run yt-workflow-state --collection <collection-path> set-planning publish_target_at <json-value>` で記録してから続行する。
 - 対象 collection は `CHANNEL_DIR` 配下の実在パスを指定する。
 
 変数解決・日時計算・path 検証・JSON schema の単一ソースは `references/generate_batch.py` とし、本文で再実装しない。

--- a/.claude/skills/publish/references/upload.md
+++ b/.claude/skills/publish/references/upload.md
@@ -27,7 +27,7 @@ Complete Collection を YouTube にアップロードし、`planning/` → `live
 - **成果物**: plan では検証した動画とメタデータ成果物
 - **委譲しない処理**: 実アップロード、公開時刻とメタデータの承認。state や tracking を更新する実アップロード CLI は承認後にメインが実行し、`20-documentation/upload_tracking.json` と対象動画の存在を検証する
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state を owner 経由で更新する実 upload CLI の実行はメインが行う。
 
 ## 設定読み込みゲート
 

--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -30,14 +30,14 @@ description: "Use when コレクションの YouTube サムネイル（thumbnail
 - `textless.enabled` が未設定または `true` なら、`10-assets/thumbnail.jpg`（テキスト付き YouTube サムネ）と `10-assets/main.png`（または `main.jpg`、textless 動画背景）が**別成果物として**確定済み。`false` なら確定済み `thumbnail.jpg` と SHA-256 が一致する `main.jpg` が存在し、`main.png` が存在しない。`auto_selection.mode: full` 以外では必要な候補がユーザー承認済み。`ab_test.enabled: true` の場合は全 `thumbnail-<name>.jpg` も確定済み（`full` 以外では個別承認済み）で、`thumbnail.jpg` が先頭 pattern と同一内容
 - テキスト付きサムネは `mode: full` 以外では承認前に、`full` では自動確定後に `/thumbnail --compare` の 320px 視認性検証を通過している
 - `20-documentation/thumbnail-prompts.md` に textless 背景用プロンプトとテキスト付きサムネの生成記録を保存済み。`textless.enabled: false` では textless プロンプトの代わりに共用設定、コピー元、コピー先、検証済み SHA-256 を保存済み
-- `workflow-state.json` の `thumbnail.approved = true` に更新済み
+- `uv run yt-workflow-state --collection <collection-path> set-thumbnail-approved true` が成功済み
 - `archive.enabled: true` の場合は `assets/thumbnail-gallery/<collection-dir-name>.<ext>` に確定サムネを保存済み
 **全自動 Hard Gate**: deep-merge 後の `image_generation.auto_selection.enabled: true` かつ `mode: full` のときだけ、テーマ確認・生成可否（`confirm_cost()`）・textless 背景承認・テキスト付き候補承認の 4 ゲートをすべて省略する。`enabled: true` でも `mode` が未設定または `selection_only` なら候補承認だけを省略し、残り 3 ゲートは従来どおり実行する。`enabled: false` / 未設定なら全ゲートを維持する。`full` でテーマを一意に解決できない、生成コマンドが非 0、期待成果物がない、または自動選択に失敗した場合は silent fallback せず、後述の「full モード失敗時の手動切替」に従って停止する。
 ## Subagent Contract
 - **入力**: 対象コレクション、生成対象（`thumbnail` / `main`）
 - **成果物**: `10-assets/thumbnail-vN.jpg/png` または `10-assets/main-vN.png/jpg`、`20-documentation/thumbnail-prompts.md`
 - **委譲しない処理**: 候補画像生成前の承認、および候補承認後の確定コピーと state 更新
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と owner CLI 実行はメインが行う。
 ## 勝ちパターン参照ゲート
 プロンプト構築前に [参照画像と検証済み insights](references/reference-and-insights.md) を読み、`data/thumbnail-iterate/champion.json`、完了済み thumbnail test 履歴、`data/insights.jsonl` を検証して反映する。insights schema の単一ソースは `.claude/skills/analytics/references/insights-entry.schema.json`。`jq -c 'select(.status == "open" and .lever == "thumbnail")' data/insights.jsonl` で選別し、`status` を含むエントリの書き換え・追記はしない（status 反映は `/wf-new`、追記は `yt-experiment judge` 等の writer の責務）。検証不能な値は使わず、通常生成 mode から champion JSON・test 履歴・insights を更新しない。 **読み順**: 標準フローは「ワークフロー > 標準生成順序とファイル契約」から読み、実効 `text_render.mode` に対応する経路へ進む。「フォント安定化」章は 2 経路の再現性差を確認するときに読む。「codex 経由の生成」章は `image_generation.provider: codex` のチャンネルのみ、「自動選択」章は該当機能を明示的に使うチャンネルのみ参照すればよい。
 ## When to Use
@@ -375,7 +375,7 @@ JSON
 ```
 `config/skills/thumbnail.yaml` の `image_generation.stock.enabled: false` に設定するとこの CLI は退避せず単純削除（従来挙動）に戻る。
 ### `workflow-state.json` 更新
-画像確認・承認後、`thumbnail.approved = true` を更新する。`textless.enabled: false` では `share_thumbnail_as_main.py` の成功と `thumbnail.jpg` / `main.jpg` の SHA-256 一致、`main.png` 不在を確認した後だけ更新する。`mode: full` では目視確認と AskUserQuestion を省略し、既存の自動確定成功を承認完了として扱う。`ab_test.enabled: true` の場合は、設定された全 pattern の `thumbnail-<name>.jpg` が存在し、各 pattern の承認（`full` では自動確定）が完了し、`thumbnail.jpg` が先頭 pattern と同一内容であることを確認してからだけ更新する。一部 pattern の承認・確定に失敗した状態では `false` のままにする。 `yt-thumbnail-auto-select --apply` で確定した場合は、選択候補・distance・ランキング・参照画像ごとの centroid distance / outlier 判定・実行時刻が `thumbnail_auto_selection` キーに監査ログとして自動記録される（#1370、#2952）。
+画像確認・承認後、`uv run yt-workflow-state --collection <collection-path> set-thumbnail-approved true` を実行する。`textless.enabled: false` では `share_thumbnail_as_main.py` の成功と `thumbnail.jpg` / `main.jpg` の SHA-256 一致、`main.png` 不在を確認した後だけ実行する。`mode: full` では目視確認と AskUserQuestion を省略し、既存の自動確定成功を承認完了として扱う。`ab_test.enabled: true` の場合は、設定された全 pattern の `thumbnail-<name>.jpg` が存在し、各 pattern の承認（`full` では自動確定）が完了し、`thumbnail.jpg` が先頭 pattern と同一内容であることを確認してからだけ実行する。一部 pattern の承認・確定に失敗した状態では `false` のままにする。 `yt-thumbnail-auto-select --apply` で確定した場合は、選択候補・distance・ランキング・参照画像ごとの centroid distance / outlier 判定・実行時刻が `thumbnail_auto_selection` キーに監査ログとして自動記録される（#1370、#2952）。
 ## stock 退避と再利用
 不採用画像は `<channel_dir>/assets/stock/<theme-slug>/` に画像と隣接メタデータを退避する。メタデータの schema、retention、参照プールへの合成条件は [quality / operations 詳細](references/quality-and-operations.md) を読む。 stock の操作 CLI:
 | CLI | 用途 |

--- a/.claude/skills/thumbnail/references/loop.md
+++ b/.claude/skills/thumbnail/references/loop.md
@@ -44,7 +44,7 @@ Veo 3.1（既定）または Gemini Omni Flash を使い、コレクションの
 - **成果物**: 生成または補正した `10-assets/loop.mp4`、使用 mode
 - **委譲しない処理**: 対応する skip が `false` のときの Veo 課金・再生成・品質確認の承認（`true` の gate は設定による opt-in として委譲できる）。skip されていない品質確認はメインが担当する
 
-subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実行しない。承認が要る処理は、メインが承認を得るまで委譲しない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と owner CLI 実行はメインが行う。
 
 ## 設定読み込みゲート
 

--- a/.claude/skills/video/references/describe.md
+++ b/.claude/skills/video/references/describe.md
@@ -8,7 +8,7 @@
 
 - 品質チェック（後述チェックリスト）の全項目を満たした概要欄・タイトル案・タグが `20-documentation/descriptions.md` に保存されている
 - `uv run yt-title-duplicate-check` を実行し、100 codepoint 超過が無く、重複 warning はこの段階で見直し済み
-- `workflow-state.json` の `description.generated = true` に更新済み
+- `uv run yt-workflow-state --collection <collection-path> set-description-generated true` が成功済み
 
 ## 設定読み込みゲート
 
@@ -204,7 +204,7 @@ uv run yt-title-duplicate-check "$COLLECTION_DIR" --title "$PROPOSED_TITLE"
 保存フォーマット（ヘッダー、概要欄本文、タイトル案、タグ、Cards、品質チェック）は
 `references/description-templates.md` の「descriptions.md 保存フォーマット」セクションを参照すること。
 
-保存後、`workflow-state.json` の `description.generated = true` に更新する。
+保存後、`uv run yt-workflow-state --collection <collection-path> set-description-generated true` を実行する。
 
 ## 障害時ガイダンス
 

--- a/.claude/skills/video/references/generate.md
+++ b/.claude/skills/video/references/generate.md
@@ -17,7 +17,7 @@ Suno 系チャンネルは `/music --master`、Lyria 系チャンネルは `/mus
 - **成果物**: `01-master/*.mp4`、probe 検証結果
 - **例外**: `generate_videos.sh` の実行に必要な範囲で `workflow-state.json` を読み取ってよい（書き込みは不可）
 
-subagent は `workflow-state.json` へ書き込まない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と state 更新はメインが行う。
+subagent は `workflow-state.json` へ書き込まない。完了報告は `status: success | failure`、成果物の絶対パス一覧、エラー。成果物の存在検証と owner CLI 実行はメインが行う。
 
 ## 前提
 
@@ -70,7 +70,7 @@ $ARGUMENTS
    `loop.mp4` があると `generate_videos.sh` が自動的に動画背景を使用（静止画の代わり）
 4. **任意プレビュー**: effect / overlays の短尺確認が必要な場合は `generate_videos.sh --preview 20 <collection-path>` を実行する。プレビューは `*-Master.mp4` と `workflow-state.json` を変更しない
 5. **動画生成**: `generate_videos.sh` を実行する（所要時間とログの扱いは「所要時間と完了報告」を参照）
-6. **workflow-state.json 更新**: 全尺生成の成功後だけ `assets.master_video` に生成された動画ファイル名（例: `01-master/Theme-Name-Master.mp4`）を記録する。プレビューのみでは更新しない
+6. **workflow-state.json 更新**: 全尺生成の成功後だけ、生成された動画ファイル名を JSON string として `uv run yt-workflow-state --collection <collection-path> set-asset master_video <json-value>` へ渡す。プレビューのみでは実行しない
 
 ### 自動検出される要素
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -81,7 +81,7 @@ minimal mode では企画候補生成前にテーマ / ジャンル / 雰囲気�
 
 対象 collection を確定したら、その絶対 path を `COLLECTION_DIR` として固定する。メインも制御面キー (`phase` / `stage` / `upload` / `updated_at`) を Edit / Write で直接変更しない。`phase` / `stage` / `upload` は必ず `uv run yt-workflow-state --collection "$COLLECTION_DIR" ...` を使い、各更新と同じ owner lock 内で `updated_at` も更新させる。制御面を変えず時刻だけ更新する必要がある場合は `uv run yt-workflow-state --collection "$COLLECTION_DIR" touch` を使う。CLI が非 0 の場合は state 更新失敗として停止し、後続へ進まない。
 
-資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のままとし、CLI 移行は #3888 に残す。資産系だけを更新した直後は上記 `touch` を実行する。
+資産系キー (`assets.*` / `planning.*`) も直接変更せず、`set-asset` / `set-planning` を使う。共通の文書 writer や owner reference script が state を更新済みの場合は、同じ変更を CLI で重ねない。
 
 ### Preselected batch plan entry（opt-in）
 

--- a/.claude/skills/wf-new/references/auto.md
+++ b/.claude/skills/wf-new/references/auto.md
@@ -22,7 +22,7 @@
 4. **一段ごとに再評価**: 子 skill 完了後、同じ run 内で固定 collection を `plan` し直す。前 decision から次 action を推測しない。state と成果物が変化しない成功報告は `failed` として停止する。
 5. **手動介入を突破しない**: 対話実行では子 skill の企画選択・承認へ回答後、同じ run 内で再評価する。`workflow.wf_new.skip_plan_selection` または子 skill-config の `skip_*_approval` / `skip_cost_confirm` が `true` の停止点はチャンネル設定による明示 opt-in なので突破には当たらず続行する。それ以外のユーザー入力、login、CAPTCHA、課金確認、承認待ちが無人実行で必要なら自動承認せず `blocked` と再開 action を履歴へ記録する。Suno の UI 非互換・拡張障害・生成失敗は人間操作の blocker に広げず、agent が診断・再試行するか根拠付き `failed` とする。
 6. **不可逆操作を重複させない**: upload reconciliation、Suno 成果物数、publish idempotency は state resolver と委譲先の既存契約に従う。既存 video ID の remote upload や完了済み投稿を再発行しない。
-7. **state 更新責務を維持**: 本 skill と state resolver は `workflow-state.json` を直接更新しない。更新は `/wf-new`、`/wf-next` と各子 skill が成果物検証後に行う。
+7. **state 更新責務を維持**: 本 skill と state resolver は `workflow-state.json` を直接更新しない。成果物検証後の更新も `/wf-new`、`/wf-next` と各子 skill が owner CLI または state-owning CLI 経由で行う。
 8. **長時間処理の待機主体を消さない**: 子 agent に Monitor を arm させて self-stop / completed にしてはならない。実行中 tool call を維持するか background session を30秒以下の間隔で poll させ、終了を自分で観測してから報告させる。
 
 ## 完了条件

--- a/.claude/skills/wf-new/references/ideate.md
+++ b/.claude/skills/wf-new/references/ideate.md
@@ -445,7 +445,9 @@ sequential モードでは Next Step で stock 退避は走らない（不採用
 
 ## Next Step
 
-企画選択時にタイトルも確定する（`workflow-state.json` の `planning.final_title` に記録）。
+企画選択時にタイトルも確定する。`collection-plan-documents.md` の owner CLI が
+JSON+HTML pair の検証と同じ成功境界で `workflow-state.json` の
+`planning.final_title` へ投影する。
 
 企画確定後は `thumbnail_mode` と画像の有無で分岐する。採用画像は `planning-preview.png` に保存し、最終 `thumbnail.jpg` の正規入力として後段へ引き渡す。**`main.png` にはコピーしない**。不可逆操作は、参照割当の保存 → 採用画像のコピー → 不採用画像の stock 退避 → セッション cleanup の順で実行する。
 

--- a/.claude/skills/wf-new/references/phase2.md
+++ b/.claude/skills/wf-new/references/phase2.md
@@ -103,7 +103,7 @@ initial dispatch を行った場合は両 Agent の完了を待つ。片方の�
 1. 企画選択時に承認済みの同じ画像なので、文字入り候補の生成・再選択・thumbnail の AskUserQuestion は行わない。`10-assets/thumbnail.jpg` を `/thumbnail --compare` で 320px 視認性検証し、署名・透かし・ロゴ・手指破綻の既存目視 QA を通す。失敗時は state を更新せず停止する
 2. QA 成功後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。archive の Hard Gate は既存契約どおり維持する
 3. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。`mode: full` は生成可否と textless 背景承認を質問せず既存の check 成功後に確定し、それ以外は既存どおり textless 候補だけをプレビュー・承認して `main.png/jpg` へ確定する。`false` なら textless 生成・承認を省略し、`share_thumbnail_as_main.py <collection-path>` を実行して `status: SHARED`、同一 SHA-256、`main.png` 不在を検証する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `uv run yt-workflow-state --collection "$COLLECTION_DIR" set-asset thumbnail true` を実行する。この `thumbnail.jpg` を再度 AskUserQuestion にかけない
 
 以下の mode 別分岐は `status: MISSING` から既存 `/thumbnail` フォールバックへ進んだ場合だけ実行する。
 
@@ -112,7 +112,7 @@ initial dispatch を行った場合は両 Agent の完了を待つ。片方の�
 1. AskUserQuestion と `open` を実行せず、`uv run yt-thumbnail-auto-select <collection-path> --dry-run` が exit 0 であることを確認してから `uv run yt-thumbnail-auto-select <collection-path> --apply` を実行する。`10-assets/thumbnail.jpg` と `workflow-state.json::thumbnail_auto_selection.mode == "full"` を検証する
 2. `textless.enabled` が未設定または `true` なら、確定した `thumbnail.jpg` を入力、生成対象 `main` を指定して別 subagent へ委譲する。生成可否と textless 背景承認は質問せず、`yt-thumbnail-check` が exit 0 かつ候補が存在するときだけ `10-assets/main.png/jpg` へ確定コピーする。`false` なら textless 委譲・生成・承認を再要求せず、`share_thumbnail_as_main.py <collection-path>` を実行し、`status: SHARED`、`thumbnail.jpg` と `main.jpg` の同一 SHA-256、`main.png` 不在を検証する
 3. `/thumbnail --compare` の 320px 視認性検証はスコープ外のまま省略せず、自動確定後に別途実行する。失敗しても不適格候補を強制採用せず、`/thumbnail` の「full モード失敗時の手動切替」を表示して state を更新せず停止する
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新して、music branch の成果物検証へ進む
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `uv run yt-workflow-state --collection "$COLLECTION_DIR" set-asset thumbnail true` を実行して、music branch の成果物検証へ進む
 
 **`selection_only` または auto-selection 無効**（従来フロー）:
 
@@ -142,7 +142,7 @@ initial dispatch を行った場合は両 Agent の完了を待つ。片方の�
    - `thumbnail.jpg` と `main.png/jpg` を同一画像で代用しない。`main.png` を `thumbnail.jpg` にコピーする旧運用は禁止
    - QA が NG、再生成、または中断の場合は `/wf-new` または `/thumbnail` の該当生成ステップへ戻し、state を更新せず停止する
 
-4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `assets.thumbnail = true` と `updated_at` を更新する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
+4. `thumbnail.jpg` と `main.png/jpg` の確定検証結果を Phase 2c 成果物・再開契約へ thumbnail branch の結果として渡し、成功時だけメインが `uv run yt-workflow-state --collection "$COLLECTION_DIR" set-asset thumbnail true` を実行する。このゲートで承認済みの `thumbnail.jpg` を再度 AskUserQuestion にかけない。
 
 5. **join 後の branch 適用**:
    - メインが Suno の `suno-patterns.yaml` / `suno-prompts.json` / `yt-suno-verify` / semantic review、または Lyria の設計成果物を検証し、music branch の結果を Phase 2c 成果物・再開契約へ渡す
@@ -152,9 +152,9 @@ initial dispatch を行った場合は両 Agent の完了を待つ。片方の�
 
 サムネイル承認後、`config/skills/loop-video.yaml::enabled` を確認する。
 
-- `enabled: false` の場合: `/thumbnail --loop` は呼ばず、既定では textless `main.png/jpg` の静止画背景運用として続行する。`thumbnail::textless.enabled: false` では例外として文字入りの共有 `main.jpg` が正規入力である。`assets.loop_video = false` を維持し、`phase = "prepared"` に更新する
+- `enabled: false` の場合: `/thumbnail --loop` は呼ばず、既定では textless `main.png/jpg` の静止画背景運用として続行する。`thumbnail::textless.enabled: false` では例外として文字入りの共有 `main.jpg` が正規入力である。owner CLI の `set-asset loop_video false`、続けて `set-phase prepared` を実行する
 - `enabled` 未指定 or `true` の場合: Agent ツールで subagent を起動し、`main.png/jpg` を入力、`10-assets/loop.mp4` を期待成果物として `/thumbnail --loop` の生成だけを委譲する。`thumbnail::textless.enabled: false` の共有 `main.jpg` も正規入力として渡す
-  - 成功: メインが `loop.mp4` の存在を確認後、`assets.loop_video = true`、`phase = "prepared"`、`updated_at` を更新する
+  - 成功: メインが `loop.mp4` の存在を確認後、owner CLI の `set-asset loop_video true`、続けて `set-phase prepared` を実行する
   - 失敗または欠落: state は更新せず、同じ loop-video 委譲から再試行できる状態で停止する
 
 #### 2f. Suno helper server 起動（Suno のみ）

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -22,7 +22,7 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ## Hard Gates: subagent 委譲境界
 
-1. メインエージェントだけが `workflow-state.json` の `assets` を更新し、制御面の `phase` / `stage` / `upload` / `updated_at` は owner CLI 経由で更新する。subagent は委譲先 skill の入力確認に必要な場合だけ state を読み、書き込まない。
+1. メインエージェントだけが owner CLI 経由で `workflow-state.json` の `assets` と制御面の `phase` / `stage` / `upload` / `updated_at` を更新する。subagent は委譲先 skill の入力確認に必要な場合だけ state を読み、書き込まない。
 2. AskUserQuestion、`skip_*_approval` の承認ゲート、候補選択、playlist 初期化などの承認はメインエージェントが完了させる。未承認の操作を subagent へ委譲しない。
 3. 各フェーズの生成・変換処理は Agent ツールで一作業ずつ subagent へ委譲する。委譲プロンプトには入力パス、実行する skill / CLI、期待成果物、state 書き込み禁止、完了報告形式を明記する。
 4. subagent 終了後、メインエージェントが期待成果物の存在と現在の `phase` / `assets` との整合を実ファイルで検証する。すべて PASS の場合だけ state を更新する。失敗、欠落、不整合時は state を変更せず、同じステップから再実行できる状態で停止する。
@@ -40,7 +40,7 @@ uv run yt-workflow-state --collection "$COLLECTION_DIR" set-upload --video-id <v
 uv run yt-workflow-state --collection "$COLLECTION_DIR" touch
 ```
 
-資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のままとし、CLI 移行は #3888 に残す。資産系だけを更新した直後は上記 `touch` を実行する。`yt-upload-collection` / `yt-upload-auto` や owner reference script が制御面を更新済みの場合は、同じ変更を CLI で重ねない。
+資産系キー (`assets.*` / `planning.*`) も直接変更せず、`set-asset` / `set-planning` を使う。`yt-upload-collection` / `yt-upload-auto` や owner reference script が state を更新済みの場合は、同じ変更を CLI で重ねない。
 
 > **このセッションで初めて `/wf-*` を呼ぶ場合は、先に [`docs/workflow-cheatsheet.md`](../../../docs/workflow-cheatsheet.md) の判定フローを 1 回だけユーザーに提示すること**。
 
@@ -167,7 +167,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - **`02-Individual-music/` に音声ファイルが 1 件以上存在（URL 記録の有無は問わない）**:
      - AskUserQuestion による URL 入力はスキップする。title list は `/music --master` Step 1.6 がローカルファイル名から自動復元するため playlist URL は不要。メインが `/music --master` の dry-run / Step 5.1 以外の検証ゲートを実行し、選曲・混入許容・over-max 例外などの承認分岐をすべて解決する。ラウドネス全曲走査は subagent 内の Step 5.1 で1回だけ行う
      - Agent ツールで subagent を起動し、対象 collection、（記録があれば）playlist URL、承認済み選択条件を入力として `/music --master` の Subagent Contract を実行させる。`workflow-state.json` 更新と雨レイヤー後処理は実行させない
-     - 期待成果物 `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` の存在をメインが確認する。`yt-raw-master-check --apply --loudness-receipt <receipt>` で receipt と現在の collection / 入力 SHA-256 / 閾値 / PASS 判定を検証し、成功時だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する。検証時に FFmpeg の全曲走査を再実行しない。雨レイヤーが有効なら、その後にメインが `/music --master` Step 5.6 を実行し、出力と state を再検証する
+     - 期待成果物 `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` の存在をメインが確認する。`yt-raw-master-check --apply --loudness-receipt <receipt>` で receipt と現在の collection / 入力 SHA-256 / 閾値 / PASS 判定を検証する。この CLI が `assets.raw_master` と `updated_at` を owner 経由で更新するため、`yt-workflow-state` で重ねて更新しない。検証時に FFmpeg の全曲走査を再実行しない。雨レイヤーが有効なら、その後にメインが `/music --master` Step 5.6 を実行し、出力と state を再検証する
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
    - **URL 記録済みだが `02-Individual-music/` に音声ファイルが無い**:
@@ -176,14 +176,14 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - **URL 未記録（キー自体が無い、または `null`）かつ `02-Individual-music/` に音声ファイルも無い**:
      - 従来通りユーザーにプレイリスト URL を AskUserQuestion で取得
      - URL 取得後、上記と同じくメインが `/music --master` の承認分岐を解決し、Agent ツールで Subagent Contract を委譲する
-     - メインが `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` を検証し、上記と同じ receipt 付き `yt-raw-master-check --apply` が成功した場合だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する
+     - メインが `01-master/master.*`、`01-master/.selection.log`、`01-master/.loudness-receipt.json` を検証し、上記と同じ receipt 付き `yt-raw-master-check --apply` を実行する。この CLI が owner 経由で state を更新するため重ねて変更しない
      - ガイダンス: 「raw master をミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
      - **ここでフロー停止**
 
 **Lyria パス:**
 1. `assets.music_prompts = true` + `assets.raw_master = null`:
    - Agent ツールで subagent を起動し、対象 collection と theme を入力に `/music --generate <theme>` の Lyria 3 API セグメント生成だけを実行させる（最大 ~184 秒/リクエスト）。state 書き込みと承認取得は禁止する
-   - 委譲前に期待する `02-Individual-music/` の音声ファイルと `01-master/` の raw master パスを列挙する。メインが実在を確認し、成功時だけ `assets.raw_master` を更新して owner CLI の `touch` を実行する
+   - 委譲前に期待する `02-Individual-music/` の音声ファイルと `01-master/` の raw master パスを列挙する。メインが実在を確認し、成功時だけ生成ファイル名を JSON string として `yt-workflow-state --collection "$COLLECTION_DIR" set-asset raw_master <json-value>` へ渡す
    - ガイダンス: 「生成されたセグメントをミキシング+マスタリングし、最終マスターを 01-master/ に配置後、`/wf-next` を再実行してください」
    - **ここでフロー停止**
 
@@ -224,7 +224,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - 両 Agent とも state は入力確認に必要な範囲だけ読み、書き込まず、AskUserQuestion を実行しない。片方でも失敗または成果物欠落なら state を更新せず停止する
 2. 並列 A 完了後:
    - メインが両成果物の存在と `phase: "mastered"` との整合を確認する
-   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、`assets.master_video`、`assets.description`、`description.generated` を更新してから、次の owner CLI で phase と `updated_at` を一体更新する
+   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、動画ファイル名を JSON string として `set-asset master_video <json-value>`、`set-asset description true`、`set-description-generated true` の各 owner CLI を実行してから、次の owner CLI で phase と `updated_at` を一体更新する
 
      ```bash
      uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。
 - `feat(channel-strategy)`: `--persona` が構造化 persona fields の全項目に実入力ファイルまたは `推測` の出典注記を要求し、暫定版から最終版まで維持する契約を追加する（#3999）。
 - `feat(documents)`: Suno / Lyria の音楽promptをreview・provenance付き JSON 正本と承認表示HTMLへ統一し、verify / semantic review / pair再読込成功後だけ workflow state を更新する（#4029）。
+- `refactor(workflow-state)`: assets / planning / post-upload の型付き更新を `yt-workflow-state` に追加し、全 skill の資産系 state 更新を owner CLI 経由へ移して AI の直接 Edit 指示を廃止する（#3888）。
 - `refactor(workflow-state)`: `wf-new` / `wf-next` の制御面 state 更新を `yt-workflow-state` へ移し、phase / stage / upload / updated_at の AI による直接 Edit 指示を廃止する（#3887）。
 - `feat(workflow-state)`: 制御面の phase / stage / upload を lock + atomic update で更新し、任意 key path を JSON で取得する `yt-workflow-state` CLI を追加する（#3886）。
 - `feat(wf-new)`: 企画前の Phase 0 で未 postmortem を列挙し、コスト承認後に `/analytics --flop` へ全件を順次委譲して insights を最新化する再開可能な振り返り gate を追加する（#3791）。

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from typing import cast
 
 from youtube_automation.commands._shared.cli_harness import run_cli
-from youtube_automation.domains.collections.workflow_state import Phase, Stage, WorkflowState
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import AssetKey, Phase, PlanningKey, Stage, WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.filesystem import JSONValue
@@ -18,6 +19,23 @@ from youtube_automation.infrastructure.media.collection_paths import resolve_col
 
 _PHASE_CHOICES: tuple[Phase, ...] = ("planning", "prepared", "mastered", "publishing", "complete")
 _STAGE_CHOICES: tuple[Stage, ...] = ("planning", "live")
+_ASSET_CHOICES: tuple[AssetKey, ...] = (
+    "thumbnail",
+    "loop_video",
+    "music_prompts",
+    "music_downloaded",
+    "raw_master",
+    "master_audio",
+    "master_video",
+    "description",
+)
+_PLANNING_CHOICES: tuple[PlanningKey, ...] = (
+    "generated",
+    "final_title",
+    "target_persona",
+    "publish_target_at",
+    "music",
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,6 +59,20 @@ def build_parser() -> argparse.ArgumentParser:
     upload_parser.add_argument("--video-id", required=True)
     upload_parser.add_argument("--video-url")
     upload_parser.add_argument("--publish-at")
+    asset_parser = subparsers.add_parser("set-asset", help="生成 asset の JSON 値を更新")
+    asset_parser.add_argument("key", choices=_ASSET_CHOICES)
+    asset_parser.add_argument("value", help="JSON 値（文字列は JSON の二重引用符を含める）")
+    planning_parser = subparsers.add_parser("set-planning", help="planning の JSON 値を更新")
+    planning_parser.add_argument("key", choices=_PLANNING_CHOICES)
+    planning_parser.add_argument("value", help="JSON 値（文字列は JSON の二重引用符を含める）")
+    for command, help_text in (
+        ("set-thumbnail-approved", "thumbnail 承認状態を更新"),
+        ("set-description-generated", "概要欄生成状態を更新"),
+    ):
+        bool_parser = subparsers.add_parser(command, help=help_text)
+        bool_parser.add_argument("value", choices=("true", "false"))
+    shorts_parser = subparsers.add_parser("set-post-upload-shorts", help="shorts 公開記録を JSON 配列で更新")
+    shorts_parser.add_argument("value", help="short record の JSON 配列")
     subparsers.add_parser("touch", help="updated_at を現在時刻へ更新")
     return parser
 
@@ -85,6 +117,55 @@ def _set_stage(state: WorkflowState, stage: Stage) -> None:
     _touch(state)
 
 
+def _json_value(raw: str) -> JSONValue:
+    try:
+        return cast(JSONValue, json.loads(raw))
+    except json.JSONDecodeError as exc:
+        raise WorkflowStateError(f"value must be valid JSON: {exc.msg}") from exc
+
+
+def _set_asset(state: WorkflowState, key: AssetKey, value: JSONValue) -> None:
+    if state.assets is None:
+        state["assets"] = {}
+    assets = state.assets
+    assert assets is not None
+    assets.set_known(key, value)
+    _touch(state)
+
+
+def _set_planning(state: WorkflowState, key: PlanningKey, value: JSONValue) -> None:
+    if state.planning is None:
+        state["planning"] = {}
+    planning = state.planning
+    assert planning is not None
+    planning.set_known(key, value)
+    _touch(state)
+
+
+def _set_post_upload_shorts(state: WorkflowState, value: JSONValue) -> None:
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise WorkflowStateError("workflow-state.json::post_upload.shorts must be an array of objects")
+    if state.post_upload is None:
+        state["post_upload"] = {}
+    post_upload = state.post_upload
+    assert post_upload is not None
+    post_upload.shorts = cast(list[dict[str, JSONValue]], value)
+    _touch(state)
+
+
+def _set_completion_flag(
+    state: WorkflowState,
+    *,
+    thumbnail: bool | None = None,
+    description: bool | None = None,
+) -> None:
+    if thumbnail is not None:
+        state.set_thumbnail_approved(thumbnail)
+    if description is not None:
+        state.set_description_generated(description)
+    _touch(state)
+
+
 def run(args: argparse.Namespace) -> int:
     state_path = _state_path(args.collection)
     if args.command == "get":
@@ -98,6 +179,18 @@ def run(args: argparse.Namespace) -> int:
         update_workflow_state(state_path, lambda state: _set_stage(state, stage))
     elif args.command == "set-upload":
         update_workflow_state(state_path, lambda state: _set_upload(state, args))
+    elif args.command == "set-asset":
+        key = cast(AssetKey, args.key)
+        update_workflow_state(state_path, lambda state: _set_asset(state, key, _json_value(args.value)))
+    elif args.command == "set-planning":
+        key = cast(PlanningKey, args.key)
+        update_workflow_state(state_path, lambda state: _set_planning(state, key, _json_value(args.value)))
+    elif args.command == "set-thumbnail-approved":
+        update_workflow_state(state_path, lambda state: _set_completion_flag(state, thumbnail=args.value == "true"))
+    elif args.command == "set-description-generated":
+        update_workflow_state(state_path, lambda state: _set_completion_flag(state, description=args.value == "true"))
+    elif args.command == "set-post-upload-shorts":
+        update_workflow_state(state_path, lambda state: _set_post_upload_shorts(state, _json_value(args.value)))
     elif args.command == "touch":
         update_workflow_state(state_path, _touch)
     return 0

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -17,6 +17,17 @@ Phase = Literal["planning", "prepared", "mastered", "publishing", "complete"]
 Stage = Literal["planning", "live"]
 MusicEngine = Literal["suno", "lyria"]
 WorkflowStateUpdater = Callable[["WorkflowState"], "WorkflowState | None"]
+AssetKey = Literal[
+    "thumbnail",
+    "loop_video",
+    "music_prompts",
+    "music_downloaded",
+    "raw_master",
+    "master_audio",
+    "master_video",
+    "description",
+]
+PlanningKey = Literal["generated", "final_title", "target_persona", "publish_target_at", "music"]
 
 
 class MusicPlanningDocument(TypedDict, total=False):
@@ -154,6 +165,7 @@ class WorkflowStateDocument(TypedDict, total=False):
 _PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
 _STAGES = frozenset({"planning", "live"})
 _MUSIC_ENGINES = frozenset({"suno", "lyria"})
+_MUSIC_TEMPOS = frozenset({"very slow", "slow", "gentle", "moderate", "lively"})
 _KNOWN_OBJECT_SECTIONS = frozenset(
     {
         "assets",
@@ -258,6 +270,21 @@ class AssetsState(_ObjectSection):
     def video(self) -> str | None:
         return _optional_string(self._data, "video", "workflow-state.json::assets.video")
 
+    def set_known(self, key: AssetKey, value: JSONValue) -> None:
+        """CLI が公開する asset key を schema 検証して更新する。"""
+        if key == "thumbnail":
+            if value is not None and not isinstance(value, bool | str):
+                raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean, string, or null")
+        elif key == "loop_video":
+            if not isinstance(value, bool) and value != "failed":
+                raise WorkflowStateError("workflow-state.json::assets.loop_video must be a boolean or 'failed'")
+        elif key in {"music_prompts", "music_downloaded", "description"}:
+            if not isinstance(value, bool):
+                raise WorkflowStateError(f"workflow-state.json::assets.{key} must be a boolean")
+        elif value is not None and not isinstance(value, str):
+            raise WorkflowStateError(f"workflow-state.json::assets.{key} must be a string or null")
+        self._data[key] = deepcopy(value)
+
 
 class MusicPlanningState(_ObjectSection):
     """planning.music の型付き view。"""
@@ -283,6 +310,19 @@ class MusicPlanningState(_ObjectSection):
         if not isinstance(value, dict):
             raise WorkflowStateError("workflow-state.json::planning.music.patterns must be an object")
         return deepcopy(value)
+
+    def validate_known(self) -> None:
+        """CLI から受け取る既知 field の型を検証する。"""
+        _engine = self.engine
+        for key in ("mood", "instruments", "exclude"):
+            value = self._data.get(key)
+            if value is not None and (not isinstance(value, list) or not all(isinstance(item, str) for item in value)):
+                raise WorkflowStateError(f"workflow-state.json::planning.music.{key} must be an array of strings")
+        for key in ("atmosphere", "suno_playlist_url"):
+            _optional_string(self._data, key, f"workflow-state.json::planning.music.{key}")
+        tempo = _optional_string(self._data, "tempo", "workflow-state.json::planning.music.tempo")
+        if tempo is not None and tempo not in _MUSIC_TEMPOS:
+            raise WorkflowStateError(f"unsupported workflow-state music tempo: {tempo}")
 
 
 class PlanningState(_ObjectSection):
@@ -317,6 +357,20 @@ class PlanningState(_ObjectSection):
     def final_title(self) -> str | None:
         return _optional_string(self._data, "final_title", "workflow-state.json::planning.final_title")
 
+    def set_known(self, key: PlanningKey, value: JSONValue) -> None:
+        """CLI が公開する planning key を schema 検証して更新する。"""
+        if key == "generated":
+            if not isinstance(value, bool):
+                raise WorkflowStateError("workflow-state.json::planning.generated must be a boolean")
+        elif key == "music":
+            if not isinstance(value, dict):
+                raise WorkflowStateError("workflow-state.json::planning.music must be an object")
+            music = MusicPlanningState(value)
+            music.validate_known()
+        elif not isinstance(value, str):
+            raise WorkflowStateError(f"workflow-state.json::planning.{key} must be a string")
+        self._data[key] = deepcopy(value)
+
 
 class PostUploadState(_ObjectSection):
     """公開後処理の型付き view。"""
@@ -329,6 +383,20 @@ class PostUploadState(_ObjectSection):
         if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
             raise WorkflowStateError("workflow-state.json::post_upload.shorts must be an array of objects")
         return deepcopy(value)
+
+    @shorts.setter
+    def shorts(self, value: list[dict[str, JSONValue]]) -> None:
+        if not all(isinstance(item, dict) for item in value):
+            raise WorkflowStateError("workflow-state.json::post_upload.shorts must be an array of objects")
+        for index, item in enumerate(value):
+            short_num = item.get("short_num")
+            if short_num is not None and (isinstance(short_num, bool) or not isinstance(short_num, int)):
+                raise WorkflowStateError(
+                    f"workflow-state.json::post_upload.shorts[{index}].short_num must be an integer or null"
+                )
+            for key in ("video_id", "uploaded_at", "publish_at", "resume_session_uri"):
+                _optional_string(item, key, f"workflow-state.json::post_upload.shorts[{index}].{key}")
+        self._data["shorts"] = deepcopy(value)
 
 
 class UploadState(_ObjectSection):
@@ -440,6 +508,16 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def post_upload(self) -> PostUploadState | None:
         value = self._data.get("post_upload")
         return PostUploadState(value) if isinstance(value, dict) else None
+
+    def set_thumbnail_approved(self, approved: bool) -> None:
+        section = self._data.setdefault("thumbnail", {})
+        assert isinstance(section, dict)
+        section["approved"] = approved
+
+    def set_description_generated(self, generated: bool) -> None:
+        section = self._data.setdefault("description", {})
+        assert isinstance(section, dict)
+        section["generated"] = generated
 
     @property
     def theme(self) -> str | None:

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -146,3 +146,77 @@ def test_control_plane_updates_refresh_updated_at_and_touch_is_available(tmp_pat
     state = _read_state(collection)
     assert isinstance(state["updated_at"], str)
     assert state["unknown"] is True
+
+
+@pytest.mark.parametrize(
+    ("command", "section", "key", "value"),
+    [
+        (("set-asset", "music_prompts", "true"), "assets", "music_prompts", True),
+        (("set-asset", "master_video", '"01-master/video.mp4"'), "assets", "master_video", "01-master/video.mp4"),
+        (("set-planning", "generated", "true"), "planning", "generated", True),
+        (("set-planning", "final_title", '"Rainy Harbor"'), "planning", "final_title", "Rainy Harbor"),
+        (
+            ("set-planning", "music", '{"engine":"suno","mood":["mellow"]}'),
+            "planning",
+            "music",
+            {"engine": "suno", "mood": ["mellow"]},
+        ),
+    ],
+)
+def test_typed_asset_and_planning_updates_preserve_unknown_fields(
+    tmp_path: Path,
+    command: tuple[str, ...],
+    section: str,
+    key: str,
+    value: object,
+) -> None:
+    collection = _collection(tmp_path, {section: {"future": "keep"}, "unknown": {"keep": True}})
+
+    assert workflow_state_cli.main(["--collection", str(collection), *command]) == 0
+
+    state = _read_state(collection)
+    assert isinstance(state.pop("updated_at"), str)
+    assert state[section] == {"future": "keep", key: value}
+    assert state["unknown"] == {"keep": True}
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("set-asset", "music_prompts", '"yes"'),
+        ("set-asset", "master_video", "true"),
+        ("set-planning", "generated", '"yes"'),
+        ("set-planning", "music", "[]"),
+        ("set-planning", "music", '{"mood":"mellow"}'),
+        ("set-post-upload-shorts", "{}"),
+        ("set-post-upload-shorts", '[{"video_id":1}]'),
+    ],
+)
+def test_typed_updates_reject_invalid_json_types_without_mutation(
+    tmp_path: Path,
+    command: tuple[str, ...],
+) -> None:
+    collection = _collection(tmp_path, {"unknown": {"keep": True}})
+    state_path = collection / "workflow-state.json"
+    before = state_path.read_bytes()
+
+    assert workflow_state_cli.main(["--collection", str(collection), *command]) == 1
+
+    assert state_path.read_bytes() == before
+
+
+def test_legacy_completion_and_post_upload_sections_have_typed_commands(tmp_path: Path) -> None:
+    collection = _collection(tmp_path, {"future": {"keep": True}})
+
+    assert workflow_state_cli.main(["--collection", str(collection), "set-thumbnail-approved", "true"]) == 0
+    assert workflow_state_cli.main(["--collection", str(collection), "set-description-generated", "true"]) == 0
+    shorts = '[{"short_num":1,"video_id":"short-1","uploaded_at":"2026-08-16T00:00:00Z"}]'
+    assert workflow_state_cli.main(["--collection", str(collection), "set-post-upload-shorts", shorts]) == 0
+
+    state = _read_state(collection)
+    assert state["thumbnail"] == {"approved": True}
+    assert state["description"] == {"generated": True}
+    assert state["post_upload"] == {
+        "shorts": [{"short_num": 1, "video_id": "short-1", "uploaded_at": "2026-08-16T00:00:00Z"}]
+    }
+    assert state["future"] == {"keep": True}

--- a/tests/repo/test_suno_skill_doc.py
+++ b/tests/repo/test_suno_skill_doc.py
@@ -565,14 +565,15 @@ def test_suno_documents_workflow_state_writer_boundary() -> None:
         "共通writer",
         "`yt-suno-verify` の成功",
         "semantic review の全 entry `PASS`",
-        "`assets.music_prompts = true`",
+        "owner API で `assets.music_prompts = true`",
+        "`planning.music` と `updated_at` の既存投影",
         "subagent は state を書き込まない",
     ):
         assert token in step_2, f"/music --prompt Step 2 に state writer 境界がない（`{token}` 不在）"
 
     assert "保存後、`workflow-state.json` の `assets.music_prompts = true` に更新する" not in step_2
     assert "`/wf-new` または `/wf-next` のメインエージェント" not in step_2
-    _assert_before(step_2, "全 entry が `PASS`", "`assets.music_prompts = true`")
+    _assert_before(step_2, "全 entry `PASS`", "owner API で `assets.music_prompts = true`")
 
 
 def test_review_rubric_documents_required_semantic_viewpoints() -> None:

--- a/tests/repo/test_videoup_cli_help_ownership_contract.py
+++ b/tests/repo/test_videoup_cli_help_ownership_contract.py
@@ -46,7 +46,9 @@ def test_skill_keeps_local_generation_and_state_safety_contracts() -> None:
     assert "AskUserQuestion" not in steps
     assert "承認分岐" not in steps
     assert "全尺生成の成功後だけ" in steps
-    assert "プレビューのみでは更新しない" in steps
+    assert "プレビューのみでは実行しない" in steps
+    assert "yt-workflow-state" in steps
+    assert "set-asset master_video" in steps
 
 
 def test_skill_keeps_input_overlay_and_long_running_safety_contracts() -> None:

--- a/tests/repo/test_workflow_state_skill_cli_contract.py
+++ b/tests/repo/test_workflow_state_skill_cli_contract.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.domains.skills.inventory import SkillInventory
 
 SKILLS = {name: REPO_ROOT / ".claude" / "skills" / name / "SKILL.md" for name in ("wf-new", "wf-next")}
+INVENTORY = SkillInventory(REPO_ROOT)
 
 
 def _text(skill: str) -> str:
@@ -40,8 +42,22 @@ def test_known_direct_control_plane_instructions_do_not_return() -> None:
     assert '`stage: "live"`、`phase: "complete"`、`updated_at` だけを atomic write' not in wf_next
 
 
-def test_asset_mutations_remain_explicitly_deferred_to_next_migration() -> None:
-    """本段で assets / planning の直接更新まで移したことにしない。"""
-    for text in map(_text, SKILLS):
-        assert "資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のまま" in text
-        assert "#3888" in text
+def test_asset_mutations_are_routed_through_owner_cli() -> None:
+    """資産系 state を AI の Edit / Write に戻さない。"""
+    documents = (path for directory in INVENTORY.skill_directories() for path in directory.rglob("*.md"))
+    text = "\n".join(path.read_text(encoding="utf-8") for path in documents)
+
+    for phrase in (
+        "資産系キー (`assets.*` / `planning.*`) はこの段では直接更新のまま",
+        "`thumbnail.approved = true` を更新する",
+        "`description.generated = true` に更新する",
+        "成功時だけ `assets.raw_master` を更新して owner CLI の `touch`",
+        "`assets.master_video`、`assets.description`、`description.generated` を更新してから",
+        "`assets.music_prompts = true`、`planning.music`、`updated_at` を更新する",
+    ):
+        assert phrase not in text
+
+    assert "set-asset" in text
+    assert "set-planning" in text
+    assert "set-thumbnail-approved" in text
+    assert "set-description-generated" in text

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -370,8 +370,10 @@ MUTABLE_FILES = frozenset(
     "thumbnail/SKILL.md",
     "video/SKILL.md",
     "video/references/describe.md",
+    "video/references/generate.md",
     "wf-new/references/freshness-rules.md",
     "wf-new/references/ideate.md",
+    "wf-next/SKILL.md",
 }
 EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
     {
@@ -394,7 +396,7 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "2346a57d57872634a407b56c429c2f83ec2ffd6e93f06d40c0d42ff317285b4e"
+IMMUTABLE_TARGET_FILES_SHA256 = "f18ea6a8ace9729a5cc2f01f339c3c3f60bb84a4b1b07927c7720bd4d989f8f0"
 AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "11d460f727fe50c41f00571b416a1486cb07d0b1548524bc650a7161c16f6c42"
 AUTOMATION_UPDATE_PUSH_SHA256 = "ced3211760d9ff0abd20ec3cdc402501b424f48581ef3a618d51c0d9ee12840c"
 ALLOWED_FENCED_ROUTES = {

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -2334,7 +2334,9 @@ def test_video_generate_keeps_preview_local_and_updates_state_only_after_full_ge
     assert "AskUserQuestion" not in skill
     assert "承認分岐" not in skill
     assert "全尺生成の成功後だけ" in skill
-    assert "プレビューのみでは更新しない" in skill
+    assert "プレビューのみでは実行しない" in skill
+    assert "yt-workflow-state" in skill
+    assert "set-asset master_video" in skill
 
 
 # ─── Loop artifact warning (#868) ────────────────────────

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -206,9 +206,9 @@ def test_wf_new_records_thumbnail_approval_in_canonical_asset_state_only() -> No
     )[0]
 
     state_assignments = re.findall(r"(?:`)?([a-z_]+(?:\.[a-z_]+)+)\s*=\s*true", approval_step)
-    thumbnail_state_updates = [line for line in approval_step.splitlines() if "assets.thumbnail = true" in line]
+    thumbnail_state_updates = [line for line in approval_step.splitlines() if "set-asset thumbnail true" in line]
 
-    assert state_assignments.count("assets.thumbnail") == 3
+    assert "assets.thumbnail" not in state_assignments
     assert "thumbnail.approved" not in state_assignments
     assert len(thumbnail_state_updates) == 3
     for update in thumbnail_state_updates:


### PR DESCRIPTION
## 概要

全skillに残るworkflow-state資産系キーの直接Edit指示を、型・schema検証付きowner CLIへ置換します。

## 変更内容

- `set-asset` / `set-planning` / `set-thumbnail-approved` / `set-description-generated` / `set-post-upload-shorts` を追加
- owner updateのlock + atomic + unknown field保持を利用
- 統合後の現owner 7 skillでassets/planning/post_uploadの直接Edit指示を置換
- 全 `.claude/skills` の直接Edit 0件をratchet契約化

## 検証

- focused/広域: 2,338 passed
- rebase後 focused: 261 passed
- full: 一度9,229 passed/3 skipped、最終再走の変更外selector race 1件は単独green
- ruff / format / yt-skills: green
- wheel smoke: 2 passed
- site check/build/test: 53 passed

Closes #3888