### PR TITLE
fix(wf-new): 定期実行でwrite tokenを更新する (#3937)

### DIFF
--- a/.claude/skills/wf-new/references/run_scheduled.sh
+++ b/.claude/skills/wf-new/references/run_scheduled.sh
@@ -92,6 +92,15 @@ notify() { # $1=message
   fi
 }
 
+# access token の更新は OAuth token endpoint だけを使い、YouTube Data API quota を消費しない。
+# workflow retry の外で1回だけ実行し、失敗時は投稿工程を開始しない。
+if ! uv run yt-oauth --refresh-only >>"$LOG_FILE" 2>&1; then
+  log 'write token の非対話更新に失敗。workflow は開始しません。対話可能なターミナルで `uv run yt-oauth` を実行してください'
+  notify "write token の更新に失敗しました。対話ターミナルで OAuth 再認証が必要です"
+  exit 1
+fi
+log "write token の非対話更新に成功"
+
 attempt=0
 max_attempts=$((MAX_RETRIES + 1))
 while [ "$attempt" -lt "$max_attempts" ]; do

--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -7,7 +7,7 @@
 ## 成果物
 
 - `書き込む`: `config/channel/workflow.json`
-- `読み込む`: `config/channel/workflow.json`
+- `読み込む`: `config/channel/workflow.json`, `auth/token.json`
 
 ## Overview
 
@@ -23,6 +23,7 @@ automation のリリース追従は `/automation --update`、本体リリース�
 4. **OS fallback は自動選択しない。** 理由・常時起動要件・製品側の履歴/停止UIを使えない制約を示し、明示承認後だけ `--confirm-os-fallback` を使う。
 5. **同一チャンネルに複数 backend を作らない。** `schedule_backend.py show/guard` で active backend を確認し、切替時は旧 backend を先に disable する。外部登録成功後だけ ID を `record` する。
 6. Step 0 の `fail` が残る場合は停止する。認証操作だけは人間に依頼し、コマンド実行・設定作成は AI が行う。
+7. **local 定期実行の開始時に write token を非対話更新する。** `uv run yt-oauth --refresh-only` を1回だけ実行し、失敗時は workflow を開始・再試行せず、対話ターミナルでの `uv run yt-oauth` を案内する。この更新は YouTube Data API quota を消費しない。local token を持たない cloud job には追加しない。
 
 ## Backend selection
 
@@ -132,4 +133,5 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py record \
 
 - native task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`wf-new --auto` の `.automation-run/` lease、状態再評価、重複 upload 防止は変更しない。
 - retry は backend の再実行機能が契約を満たす場合のみ native 側へ写像する。満たさない場合は prompt 内で `max_retries` / `retry_delay_seconds` を適用する。
+- local native task の prompt と OS fallback は、workflow retry の外側で `uv run yt-oauth --refresh-only` を1回だけ実行する。既存 local native task は `/wf-new --schedule` の update で新しい prompt へ更新する。
 - OS fallback のログは `.automation-schedule/logs/`。ネイティブの履歴は各製品の Scheduled 管理面を正とする。

--- a/.claude/skills/wf-new/references/schedule_backend.py
+++ b/.claude/skills/wf-new/references/schedule_backend.py
@@ -21,6 +21,8 @@ BACKENDS = (
 )
 PRODUCTS = ("codex", "claude")
 DEPENDENCY_MODES = ("cloud", "local")
+WRITE_TOKEN_REFRESH_COMMAND = "uv run yt-oauth --refresh-only"
+WRITE_TOKEN_REAUTH_COMMAND = "uv run yt-oauth"
 
 
 class BackendError(ValueError):
@@ -80,7 +82,17 @@ def build_plan(
     allow_external_publish = bool(overrides.get("allow_external_publish", scheduled.allow_external_publish))
     backend = select_backend(product=product, dependency_mode=dependency_mode, os_fallback=os_fallback)
     cwd = channel_dir().resolve()
-    prompt = f"/{target_workflow}"
+    if dependency_mode == "local":
+        prompt = (
+            "定期実行の開始時に write OAuth token の保守として "
+            f"`{WRITE_TOKEN_REFRESH_COMMAND}` を1回だけ実行する。"
+            "この更新は YouTube Data API を呼び出さない。更新に失敗した場合は workflow を開始せず、"
+            "認証エラーをそのまま再試行せずに停止し、対話可能なターミナルで "
+            f"`{WRITE_TOKEN_REAUTH_COMMAND}` を実行するよう報告する。"
+            f"\n\n更新成功後に /{target_workflow} を実行する。"
+        )
+    else:
+        prompt = f"/{target_workflow}"
     if not allow_external_publish:
         prompt += "\n\n制約: YouTube への書き込みは実行せず、外部反映を伴うステップの直前で停止して報告する。"
     if max_retries:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(wf-new)`: 定期実行の開始時に write OAuth token を API quota 消費なしで1回更新し、失効・更新失敗時は workflow を開始せず、機密情報を除去した再認証手順を報告する（#3937）。
 - `feat(skills)`: `yt-skills lint` が downstream 配布対象 skill を実 inventory から数え、開発専用と `SKILL.md` のない残骸を除外した総数を上限 19 件で ratchet する（#3805）。
 - `feat(skills)`: `yt-skills lint` が委譲深さ 2 以上を最長経路つきで拒否し、既存違反だけを報告付き allowlist として段階解消できる契約を追加する（#3799）。
 - `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。

--- a/src/youtube_automation/commands/system/oauth.py
+++ b/src/youtube_automation/commands/system/oauth.py
@@ -74,7 +74,14 @@ def main(argv: list[str] | None = None) -> None:
         paths = []
         if auth_handler is not None:
             paths.extend([auth_handler.client_secrets_file, auth_handler.token_file])
-        logger.error("CLI 実行失敗: %s", redact_sensitive_data(str(e), *paths))
+        message = redact_sensitive_data(str(e), *paths)
+        if args.refresh_only:
+            logger.error(
+                "CLI 実行失敗: %s。対話可能なターミナルで `uv run yt-oauth` を実行して再認証してください",
+                message,
+            )
+        else:
+            logger.error("CLI 実行失敗: %s", message)
         sys.exit(1)
 
 

--- a/tests/infrastructure/auth/test_oauth_readonly_token.py
+++ b/tests/infrastructure/auth/test_oauth_readonly_token.py
@@ -291,6 +291,23 @@ class TestMainReadonlyFlag:
         mock_cls.return_value.authenticate.assert_not_called()
         mock_cls.return_value.test_connection.assert_not_called()
 
+    def test_refresh_failure_redacts_secret_and_reports_interactive_reauthentication(self, caplog):
+        from youtube_automation.commands.system import oauth as oauth_cli
+
+        leaked_refresh_token = "1//secret-refresh-token"
+        mock_cls = MagicMock()
+        mock_cls.return_value.refresh_existing_credentials.side_effect = AuthError(
+            f"invalid_grant refresh_token={leaked_refresh_token}"
+        )
+        caplog.set_level("ERROR", logger=oauth_cli.__name__)
+
+        with patch.object(oauth_cli, "YouTubeOAuthHandler", mock_cls), pytest.raises(SystemExit) as error:
+            oauth_cli.main(["--refresh-only"])
+
+        assert error.value.code == 1
+        assert leaked_refresh_token not in caplog.text
+        assert "uv run yt-oauth`" in caplog.text
+
     def test_readonly_flag_uses_create_readonly(self):
         from youtube_automation.commands.system import oauth as oauth_cli
 

--- a/tests/repo/test_automation_schedule_backends.py
+++ b/tests/repo/test_automation_schedule_backends.py
@@ -76,11 +76,38 @@ def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypat
     assert "最大 4 回再試行" in plan["prompt"]
     assert plan["prevent_concurrent_runs"] is True
     assert plan["target_workflow"] == "wf-new --auto"
-    assert plan["prompt"].startswith("/wf-new --auto")
+    assert plan["prompt"].index("uv run yt-oauth --refresh-only") < plan["prompt"].index("/wf-new --auto")
+    assert "YouTube Data API を呼び出さない" in plan["prompt"]
+    assert "uv run yt-oauth`" in plan["prompt"]
     assert "/automation-schedule" not in plan["prompt"]
     assert "/wf-auto" not in plan["prompt"]
     assert plan["dependency_mode"] == "local"
     assert "local dependencies require desktop local project" in plan["management"]
+
+
+def test_cloud_plan_does_not_require_local_write_token_maintenance(tmp_path, monkeypatch):
+    scheduled = SimpleNamespace(
+        target_workflow="wf-new --auto",
+        allow_external_publish=False,
+        timezone="Asia/Tokyo",
+        run_time="09:05",
+        cadence=("mon",),
+        max_retries=0,
+        retry_delay_seconds=300,
+        prevent_concurrent_runs=True,
+        notification="none",
+    )
+    monkeypatch.setattr(
+        backend,
+        "load_config",
+        lambda: SimpleNamespace(workflow=SimpleNamespace(scheduled_automation=scheduled)),
+    )
+    monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
+
+    plan = backend.build_plan(product="claude", dependency_mode="cloud")
+
+    assert plan["prompt"].startswith("/wf-new --auto")
+    assert "yt-oauth" not in plan["prompt"]
 
 
 @pytest.mark.parametrize("removed_target", ["automation-run", "wf-auto"])

--- a/tests/repo/test_automation_schedule_runtime_contracts.py
+++ b/tests/repo/test_automation_schedule_runtime_contracts.py
@@ -99,6 +99,10 @@ if [[ "$*" == *"schedule_config.py show"* ]]; then
   printf '%s\n' "$SCHEDULE_JSON"
   exit "${FAKE_CONFIG_RC:-0}"
 fi
+if [[ "$*" == "run yt-oauth --refresh-only" ]]; then
+  printf 'oauth:%s\n' "$*" >> "$RUNTIME_CALLS"
+  exit "${FAKE_OAUTH_RC:-0}"
+fi
 if [[ "$1" == "run" && "$2" == "python" ]]; then
   shift 2
   exec python3 "$@"
@@ -199,13 +203,39 @@ def test_run_scheduled_recovers_stale_lock_retries_and_preserves_publish_gate(tm
     assert result.returncode == 0
     assert counter.read_text(encoding="utf-8") == "2"
     call_text = calls.read_text(encoding="utf-8")
+    assert call_text.count("oauth:run yt-oauth --refresh-only") == 1
     assert call_text.count("codex:exec") == 2
+    assert call_text.index("oauth:") < call_text.index("codex:exec")
     assert "YouTube への書き込み" in call_text
     assert "sleep:3" in call_text
     assert "notify:" in call_text
     assert not lock.exists()
     log = next((tmp_path / ".automation-schedule" / "logs").iterdir()).read_text(encoding="utf-8")
     assert "stale lock" in log
+
+
+def test_run_scheduled_stops_before_workflow_when_write_token_refresh_fails(tmp_path: Path) -> None:
+    env, calls, counter = _scheduled_env(tmp_path, _config(max_retries=2))
+    env["FAKE_OAUTH_RC"] = "1"
+
+    result = _run(
+        "run_scheduled.sh",
+        "--channel-dir",
+        str(tmp_path),
+        "--runtime",
+        "codex",
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert result.returncode == 1
+    call_lines = calls.read_text(encoding="utf-8").splitlines()
+    assert call_lines[0] == "oauth:run yt-oauth --refresh-only"
+    assert not any(line.startswith(("codex:", "claude:")) for line in call_lines)
+    assert not counter.exists()
+    log = next((tmp_path / ".automation-schedule" / "logs").iterdir()).read_text(encoding="utf-8")
+    assert "write token" in log
+    assert "uv run yt-oauth`" in log
 
 
 def test_run_scheduled_failure_and_unknown_runtime_have_nonzero_exit(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要

local定期実行でもwrite tokenを保守し、投稿間隔が空いたchannelで次回投稿時まで失効が潜伏する問題を防ぎます。

## 変更内容

- 既存 `yt-oauth --refresh-only` を唯一のauth ownerとして再利用
- native schedule promptとOS fallbackでworkflow retry外に1回だけrefresh
- refresh失敗時はworkflowを開始せず、secretをredactして対話 `yt-oauth` を案内
- tokenを持たないcloud backendとreadonly経路は不変

## 検証

- full: 9,219 passed / 3 skipped
- rebase後 focused: 69 passed
- ruff / format / bash-n / yt-skills: green
- site check/build/test: 53 passed
- 実token/API/ブラウザ操作なし

Closes #3937