### PR TITLE
feat(media): MiniMax API共通クライアントを追加する (#4119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(wf-new)`: 定期実行の開始時に write OAuth token を API quota 消費なしで1回更新し、失効・更新失敗時は workflow を開始せず、機密情報を除去した再認証手順を報告する（#3937）。
 - `feat(workspace)`: workspace 全チャンネルの登録者数・総再生回数・動画数を YouTube `channels.list` 1 request で取得する `yt-workspace-status` を追加する（#4116）。
+- `feat(media)`: MiniMax の音楽・動画生成で共有する Bearer 認証 JSON client と `MINIMAX_API_KEY` の secret 解決経路を追加する（#4119）。
 - `feat(skills)`: `yt-skills lint` が downstream 配布対象 skill を実 inventory から数え、開発専用と `SKILL.md` のない残骸を除外した総数を上限 19 件で ratchet する（#3805）。
 - `feat(skills)`: `yt-skills lint` が委譲深さ 2 以上を最長経路つきで拒否し、既存違反だけを報告付き allowlist として段階解消できる契約を追加する（#3799）。
 - `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。

--- a/src/youtube_automation/infrastructure/media/minimax_client.py
+++ b/src/youtube_automation/infrastructure/media/minimax_client.py
@@ -1,0 +1,67 @@
+"""MiniMax media API の認証と JSON HTTP 往復を所有する共通 client。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import requests
+
+from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.secrets import get_secret
+
+_BASE_URL = "https://api.minimax.io"
+
+
+def get_api_key() -> str:
+    """既存の secret resolver から MiniMax API key を解決する。"""
+    return get_secret("MINIMAX_API_KEY")
+
+
+def _url_for_path(path: str) -> str:
+    if not path.startswith("/") or path.startswith("//") or "://" in path:
+        raise GeneratorError("MiniMax API path は / で始まる相対 path である必要があります")
+    return f"{_BASE_URL}{path}"
+
+
+def _http_status(response: requests.Response | None) -> int | None:
+    if response is None:
+        return None
+    status_code = response.status_code
+    return status_code if isinstance(status_code, int) else None
+
+
+def request_json(
+    path: str,
+    payload: Mapping[str, object],
+    *,
+    timeout: float,
+) -> dict[str, object]:
+    """MiniMax API に JSON を POST し、JSON object response を返す。
+
+    認証情報、request payload、response body、下位例外の文言はエラーへ含めない。
+    """
+    url = _url_for_path(path)
+    api_key = get_api_key()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=timeout)
+        response.raise_for_status()
+    except requests.Timeout:
+        raise GeneratorError("MiniMax API request が timeout しました") from None
+    except requests.HTTPError as error:
+        status = _http_status(error.response)
+        detail = f" (status={status})" if status is not None else ""
+        raise GeneratorError(f"MiniMax API HTTP error{detail}") from None
+    except requests.RequestException:
+        raise GeneratorError("MiniMax API request に失敗しました") from None
+
+    try:
+        body = response.json()
+    except requests.exceptions.JSONDecodeError:
+        raise GeneratorError("MiniMax API response を JSON として解釈できません") from None
+    if not isinstance(body, dict):
+        raise GeneratorError("MiniMax API response は JSON object である必要があります")
+    return body

--- a/src/youtube_automation/infrastructure/secrets.py
+++ b/src/youtube_automation/infrastructure/secrets.py
@@ -26,6 +26,7 @@ _SECRET_REFS: dict[str, str] = {
     "CLIENT_SECRETS_JSON": "op://Personal/YouTube_OAuth_Client_Secrets/credential",
     "OPENAI_API_KEY": "op://Personal/OpenAI_API_Key/credential",
     "GEMINI_API_KEY": "op://Personal/Gemini_API_Key/credential",
+    "MINIMAX_API_KEY": "op://Personal/MiniMax_API_Key/credential",
     "YOUTUBE_STREAM_KEY": "op://Personal/YouTube/stream_key",
     "VULTR_API_KEY": "op://Personal/Vultr/api_key",
     "STREAM_WEBHOOK_URL": "op://Personal/Stream_Notification_Webhook/url",

--- a/tests/infrastructure/media/test_minimax_client.py
+++ b/tests/infrastructure/media/test_minimax_client.py
@@ -1,0 +1,124 @@
+"""MiniMax 共通 HTTP クライアントの契約テスト。"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.media import minimax_client
+
+
+def test_get_api_key_uses_registered_secret_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_secret = Mock(return_value="resolved-key")
+    monkeypatch.setattr(minimax_client, "get_secret", get_secret)
+
+    assert minimax_client.get_api_key() == "resolved-key"
+    get_secret.assert_called_once_with("MINIMAX_API_KEY")
+
+
+def test_request_json_posts_object_with_bearer_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = Mock(spec=requests.Response)
+    response.json.return_value = {"trace_id": "trace-1", "data": {"task_id": "task-1"}}
+    post = Mock(return_value=response)
+    monkeypatch.setattr(minimax_client, "get_api_key", Mock(return_value="minimax-secret"))
+    monkeypatch.setattr(minimax_client.requests, "post", post)
+    payload = {"model": "music-2.6", "prompt": "ambient"}
+
+    result = minimax_client.request_json("/v1/music_generation", payload, timeout=30)
+
+    assert result == {"trace_id": "trace-1", "data": {"task_id": "task-1"}}
+    post.assert_called_once_with(
+        "https://api.minimax.io/v1/music_generation",
+        json=payload,
+        headers={
+            "Authorization": "Bearer minimax-secret",
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.parametrize("status_code", [400, 503])
+def test_request_json_converts_http_error_without_exposing_secret(
+    status_code: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "minimax-secret-that-must-not-leak"
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.raise_for_status.side_effect = requests.HTTPError(
+        f"failure with {secret}",
+        response=response,
+    )
+    monkeypatch.setattr(minimax_client, "get_api_key", Mock(return_value=secret))
+    monkeypatch.setattr(minimax_client.requests, "post", Mock(return_value=response))
+
+    with pytest.raises(GeneratorError) as exc_info:
+        minimax_client.request_json("/v1/music_generation", {"prompt": secret}, timeout=30)
+
+    assert f"status={status_code}" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+    assert not isinstance(exc_info.value, requests.RequestException)
+
+
+def test_request_json_converts_timeout_without_exposing_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "minimax-secret-that-must-not-leak"
+    monkeypatch.setattr(minimax_client, "get_api_key", Mock(return_value=secret))
+    monkeypatch.setattr(
+        minimax_client.requests,
+        "post",
+        Mock(side_effect=requests.Timeout(f"timeout with {secret}")),
+    )
+
+    with pytest.raises(GeneratorError) as exc_info:
+        minimax_client.request_json("/v1/video_generation", {"prompt": secret}, timeout=12)
+
+    assert "timeout" in str(exc_info.value).lower()
+    assert secret not in str(exc_info.value)
+    assert not isinstance(exc_info.value, requests.RequestException)
+
+
+def test_request_json_converts_json_decode_error_without_exposing_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "minimax-secret-that-must-not-leak"
+    response = Mock(spec=requests.Response)
+    response.json.side_effect = requests.exceptions.JSONDecodeError("invalid", secret, 0)
+    monkeypatch.setattr(minimax_client, "get_api_key", Mock(return_value=secret))
+    monkeypatch.setattr(minimax_client.requests, "post", Mock(return_value=response))
+
+    with pytest.raises(GeneratorError) as exc_info:
+        minimax_client.request_json("/v1/music_generation", {"prompt": secret}, timeout=30)
+
+    assert "JSON" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("body", [[], "text", 1, None])
+def test_request_json_rejects_non_object_response(body: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    response = Mock(spec=requests.Response)
+    response.json.return_value = body
+    monkeypatch.setattr(minimax_client, "get_api_key", Mock(return_value="minimax-secret"))
+    monkeypatch.setattr(minimax_client.requests, "post", Mock(return_value=response))
+
+    with pytest.raises(GeneratorError, match="JSON object"):
+        minimax_client.request_json("/v1/music_generation", {}, timeout=30)
+
+
+def test_request_json_rejects_external_url_before_resolving_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_api_key = Mock(side_effect=AssertionError("secret must not be resolved"))
+    post = Mock()
+    monkeypatch.setattr(minimax_client, "get_api_key", get_api_key)
+    monkeypatch.setattr(minimax_client.requests, "post", post)
+
+    with pytest.raises(GeneratorError, match="path"):
+        minimax_client.request_json("https://example.com/steal", {}, timeout=30)
+
+    get_api_key.assert_not_called()
+    post.assert_not_called()

--- a/tests/infrastructure/test_secrets.py
+++ b/tests/infrastructure/test_secrets.py
@@ -29,7 +29,7 @@ from youtube_automation.infrastructure.secrets import (
 )
 
 _TEST_SECRET = "CLIENT_SECRETS_JSON"
-_MANAGED_SECRETS = ("CLIENT_SECRETS_JSON", "OPENAI_API_KEY", "GEMINI_API_KEY")
+_MANAGED_SECRETS = ("CLIENT_SECRETS_JSON", "OPENAI_API_KEY", "GEMINI_API_KEY", "MINIMAX_API_KEY")
 _OP_READ_DISABLED_ENV = secrets_module._OP_READ_DISABLED_ENV
 
 
@@ -213,6 +213,45 @@ class TestGeminiApiKeyRegistered:
         with patch.dict(os.environ, {_OP_READ_DISABLED_ENV: "1"}):
             with pytest.raises(ConfigError, match="GEMINI_API_KEY"):
                 get_secret("GEMINI_API_KEY")
+
+
+class TestMiniMaxApiKeyRegistered:
+    def test_minimax_api_key_uses_expected_op_reference(self):
+        assert _SECRET_REFS["MINIMAX_API_KEY"] == "op://Personal/MiniMax_API_Key/credential"
+
+    def test_minimax_api_key_returns_from_environ_before_op(self):
+        os.environ["MINIMAX_API_KEY"] = "minimax-from-env"
+        with patch("youtube_automation.infrastructure.secrets.subprocess.run") as mock_run:
+            assert get_secret("MINIMAX_API_KEY") == "minimax-from-env"
+        mock_run.assert_not_called()
+
+    def test_minimax_api_key_falls_back_to_op_read(self):
+        with (
+            patch.dict(os.environ, {_OP_READ_DISABLED_ENV: "0"}),
+            patch("youtube_automation.infrastructure.secrets.shutil.which", return_value="/usr/bin/op"),
+            patch("youtube_automation.infrastructure.secrets.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["op", "read", _SECRET_REFS["MINIMAX_API_KEY"]],
+                returncode=0,
+                stdout="minimax-from-op\n",
+                stderr="",
+            )
+
+            assert get_secret("MINIMAX_API_KEY") == "minimax-from-op"
+
+        mock_run.assert_called_once_with(
+            ["op", "read", "op://Personal/MiniMax_API_Key/credential"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=secrets_module._OP_READ_TIMEOUT_SEC,
+        )
+
+    def test_minimax_api_key_fails_loud_when_unavailable(self):
+        with patch.dict(os.environ, {_OP_READ_DISABLED_ENV: "1"}):
+            with pytest.raises(ConfigError, match="MINIMAX_API_KEY"):
+                get_secret("MINIMAX_API_KEY")
 
 
 # ---------- Issue #110: 帯域モニタリング用シークレット ----------


### PR DESCRIPTION
## 概要

MiniMaxの音楽・動画生成で共用するAPI key解決とHTTP JSON clientを追加します。

## 変更内容

- `MINIMAX_API_KEY` をenv→1Password→ConfigErrorの既存secret経路へ登録
- 公式 `https://api.minimax.io` 配下だけを許可するBearer POST client
- 外部URLを拒否
- timeout / HTTP / network / JSON decode / non-object responseをsecret非露出の `GeneratorError` へ変換
- 既存Lyria/Veo経路は不変

## 検証

- full: 9,299 passed / 3 skipped
- media regression: 587 passed
- focused: 47 passed
- ruff / format / Any gate: green
- 実API/secret/op readなし（mockのみ）

Closes #4119