### PR TITLE
refactor(workflow-state): サムネイル承認をassetsへ統合する (#3889)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -21,7 +21,7 @@ description: "Use when コレクションの YouTube サムネイル（thumbnail
 以下を deep-merge した値を設定として使う。
 1. `.claude/skills/thumbnail/config.default.yaml`
 2. `config/skills/thumbnail.yaml`（存在する場合）
-合成規則は `youtube_automation.configuration.skills.load_skill_config("thumbnail")` と同じで、チャンネル上書きが優先される。`loop` default は互換入口 `load_skill_config("loop-video")` が旧 `config/skills/loop-video.yaml` と deep-merge する。存在しない override は未設定として扱い、勝手に作成しない。 **Hard Gate**: `archive.enabled: true` の場合、確定直後のアーカイブが設定不正・確定サムネ欠落・シンボリックリンク・コピー失敗で失敗したら後工程へ進まず停止する。ギャラリー保存を成功したように扱わない。`textless.enabled` は boolean だけを許可し、`false` の共用処理が失敗した場合も `thumbnail.approved` を更新せず停止する。
+合成規則は `youtube_automation.configuration.skills.load_skill_config("thumbnail")` と同じで、チャンネル上書きが優先される。`loop` default は互換入口 `load_skill_config("loop-video")` が旧 `config/skills/loop-video.yaml` と deep-merge する。存在しない override は未設定として扱い、勝手に作成しない。 **Hard Gate**: `archive.enabled: true` の場合、確定直後のアーカイブが設定不正・確定サムネ欠落・シンボリックリンク・コピー失敗で失敗したら後工程へ進まず停止する。ギャラリー保存を成功したように扱わない。`textless.enabled` は boolean だけを許可し、`false` の共用処理が失敗した場合も `assets.thumbnail` を更新せず停止する。
 ## 前提
 `config/channel/` が存在すること（`load_config()` でロード可能）。 `config/skills/thumbnail.yaml` はオプション。`yt-skills sync` で配布される `config.default.yaml` がそのまま使われるため、default 動作で問題なければ作成不要。カスタマイズしたい場合のみ `config.default.yaml` をコピーして `config/skills/thumbnail.yaml` に置き、必要な値だけ上書きする（deep-merge される）。 `config/channel/` が存在しない場合、ユーザーに確認:
 - **新規チャンネル** → `/setup --channel` を案内
@@ -137,7 +137,7 @@ uv run python .claude/skills/thumbnail/references/finalize_planning_preview.py <
 ```bash
 uv run python .claude/skills/thumbnail/references/share_thumbnail_as_main.py <collection-path>
 ```
-スクリプトは `thumbnail.jpg` を一時ファイルへ `shutil.copyfile()` でコピーし、SHA-256 一致後に `10-assets/main.jpg` へ置換する。既存 `main.jpg` は更新し、競合する `main.png` は削除する。exit 0 と JSON の `status: SHARED`、同一 SHA-256、`main.png` 不在を確認するまで `thumbnail.approved = true` にしない。`thumbnail-prompts.md` には textless 生成プロンプトを捏造せず、`textless.enabled=false`、`source=10-assets/thumbnail.jpg`、`destination=10-assets/main.jpg`、検証済み SHA-256 を記録する。 thumbnail analysis JSON+HTML pair が存在する場合は、`read_published_json_document(..., RepositorySchema.CHANNEL_RESEARCH_REPORT)` が返す JSON の `winning_patterns` と `application_candidates` だけを、参照画像選定と差分プロンプトの入力にする。pair を検証できず競合サムネイルの勝ちパターンを先に深掘りする場合は `/channel-research --thumbnail` を実行する。
+スクリプトは `thumbnail.jpg` を一時ファイルへ `shutil.copyfile()` でコピーし、SHA-256 一致後に `10-assets/main.jpg` へ置換する。既存 `main.jpg` は更新し、競合する `main.png` は削除する。exit 0 と JSON の `status: SHARED`、同一 SHA-256、`main.png` 不在を確認するまで `assets.thumbnail = true` にしない。`thumbnail-prompts.md` には textless 生成プロンプトを捏造せず、`textless.enabled=false`、`source=10-assets/thumbnail.jpg`、`destination=10-assets/main.jpg`、検証済み SHA-256 を記録する。 thumbnail analysis JSON+HTML pair が存在する場合は、`read_published_json_document(..., RepositorySchema.CHANNEL_RESEARCH_REPORT)` が返す JSON の `winning_patterns` と `application_candidates` だけを、参照画像選定と差分プロンプトの入力にする。pair を検証できず競合サムネイルの勝ちパターンを先に深掘りする場合は `/channel-research --thumbnail` を実行する。
 1. 「thumbnail-text-profile 適用」節の手順で、フォント選定・コピー生成制約・配置を確定する（profile 不在なら実効デフォルト値のまま進む。エラーにしない）。
 2. ベンチマーク先サムネを参照画像にして、検証済み thumbnail analysis JSON がある場合はその勝ちパターンも使い、構図・色温度・主役スケール・背景テクスチャを踏襲した textless 背景候補 `main-v*.png/jpg` を生成する。差分プロンプトには `single_step.text_strip_clause` 相当の除去指示を展開し、タイトル文字・字幕・ロゴ・透かしを焼き込ませない（参照画像の選定・プロンプト構築・CLI 引数は「Single-Step / TTP モード」章の機構を流用する）。
 3. 背景候補は「手動候補の比較選択 Hard Gate」に従い、各候補を thumbnail check CLI で検証してから比較・選択する。候補が 1 枚なら `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json` の成功とユーザー承認後に `cp main-v1.png main.png` で確定する。`mode: full` では `open` と AskUserQuestion を省略し、check が exit 0 かつ期待した画像ファイルが存在するときに既存の自動経路で確定する。
@@ -174,7 +174,7 @@ uv run yt-generate-image \
   --ab-pattern a --output <collection-path>/10-assets/thumbnail-a-v1.jpg -y
 ```
    決定的合成経路では `variation` の構図・配色を textless 背景候補の生成へ反映し、コピー差分は pattern ごとの `yt-thumbnail-text --title ... --output thumbnail-<name>-v1.jpg` に反映する。`mode: full` 以外では各 pattern で `/thumbnail --compare` と目視確認を行い、個別にユーザー承認を得る。`full` では AskUserQuestion を省略し、期待候補が存在することを検証して自動確定した後、全 pattern を `/thumbnail --compare` へ回す。
-3. `full` 以外では承認済み候補だけを、`full` では存在検証に成功した候補だけを `10-assets/thumbnail-<name>.jpg` へ確定する。全 pattern の承認が揃うまでは `thumbnail.approved` を `true` にしない（`full` では全 pattern の自動確定完了を承認完了として扱う）。
+3. `full` 以外では承認済み候補だけを、`full` では存在検証に成功した候補だけを `10-assets/thumbnail-<name>.jpg` へ確定する。全 pattern の承認が揃うまでは `assets.thumbnail` を `true` にしない（`full` では全 pattern の自動確定完了を承認完了として扱う）。
 4. 全 pattern 確定後、先頭 pattern を互換出力へコピーする（例: `cmp thumbnail-a.jpg thumbnail.jpg` が成功する内容にする）。`/publish --upload` は従来どおり `thumbnail.jpg` を使うため変更不要。
 5. `20-documentation/thumbnail-prompts.md` の `A/B Test Pattern Prompts` に、全 pattern の name / final output / variation / API へ渡した最終プロンプトを保存する。
 6. YouTube Studio で対象動画のサムネイル編集を開き、**Test & compare** から最大 3 枚の `thumbnail-<name>.jpg` を手動登録する。公式 API はないため、このスキルから自動登録しない。

--- a/.claude/skills/thumbnail/references/loop.md
+++ b/.claude/skills/thumbnail/references/loop.md
@@ -124,7 +124,7 @@ $ARGUMENTS
 ```
 
 引数が指定されている場合、そのコレクションを対象とします。
-未指定の場合、`collections/planning/` から `thumbnail.approved = true` かつ `loop.mp4` が未生成のコレクションを自動検出します。
+未指定の場合、`collections/planning/` から `assets.thumbnail = true` かつ `loop.mp4` が未生成のコレクションを自動検出します。判定は workflow-state owner の `thumbnail_approved` accessor を使うため、既存 state の `thumbnail.approved = true` も読み取り互換として扱います。
 
 ### 前提条件
 

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -128,9 +128,6 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
     },
     "executed_at": "ISO 8601"
   },
-  "thumbnail": {
-    "approved": true
-  },
   "description": {
     "generated": true
   }
@@ -187,7 +184,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 ### 互換フィールド
 
-`thumbnail.approved` と `description.generated` は既存 state を読めるよう owner が保持する互換 field。正規の生成済み判定はそれぞれ `assets.thumbnail` と `assets.description` であり、新規の状態統合は個別 issue の責務とする。
+`thumbnail.approved` は既存 state の読み取り専用互換 field であり、workflow-state owner の `thumbnail_approved` accessor だけが解釈する。新規 write は `assets.thumbnail` だけを更新し、互換 field を出力しない。`description.generated` は既存 state を読めるよう owner が保持する互換 field で、正規の生成済み判定は `assets.description` とする。
 
 #### wf-new --auto の判定責務
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
+- `refactor(workflow-state)`: サムネイル承認状態を boolean の `assets.thumbnail` へ統合し、旧 `thumbnail.approved` は owner accessor の読み取り互換だけに限定する（#3889）。
 - `fix(wf-new)`: 定期実行の開始時に write OAuth token を API quota 消費なしで1回更新し、失効・更新失敗時は workflow を開始せず、機密情報を除去した再認証手順を報告する（#3937）。
 - `feat(workspace)`: workspace 全チャンネルの登録者数・総再生回数・動画数を YouTube `channels.list` 1 request で取得する `yt-workspace-status` を追加する（#4116）。
 - `feat(music)`: `music_engine: minimax` と長尺 instrumental master生成CLIを追加し、`/music --generate` の第3経路へ統合する（#4120）。

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -83,10 +83,6 @@ def _file_asset_present(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
-def _thumbnail_present(value: object) -> bool:
-    return value is True or _file_asset_present(value)
-
-
 def _video_id(state: WorkflowState) -> str | None:
     upload = state.upload
     value = upload.video_id if upload is not None else None
@@ -163,7 +159,7 @@ def _completed_stages(root: Path, collection: Path, state: WorkflowState) -> fro
         completed.add("マスター化")
     if _file_asset_present(assets.video) or _file_asset_present(assets.master_video):
         completed.add("動画化")
-    if _thumbnail_present(assets.thumbnail):
+    if state.thumbnail_approved:
         completed.add("サムネイル")
     if phase == "complete":
         completed.add("アップロード")

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -49,7 +49,7 @@ class PlanningDocument(TypedDict, total=False):
 
 
 class AssetsDocument(TypedDict, total=False):
-    thumbnail: bool | str
+    thumbnail: bool
     loop_video: bool | Literal["failed"]
     music_prompts: bool
     music_downloaded: bool
@@ -124,10 +124,6 @@ class ThumbnailAutoSelectionDocument(TypedDict, total=False):
     executed_at: str
 
 
-class ThumbnailDocument(TypedDict, total=False):
-    approved: bool
-
-
 class DescriptionDocument(TypedDict, total=False):
     generated: bool
 
@@ -158,7 +154,6 @@ class WorkflowStateDocument(TypedDict, total=False):
     track_display_names: dict[str, str]
     title_activity: str
     thumbnail_auto_selection: ThumbnailAutoSelectionDocument
-    thumbnail: ThumbnailDocument
     description: DescriptionDocument
 
 
@@ -224,14 +219,18 @@ class AssetsState(_ObjectSection):
     """生成済み collection assets の型付き view。"""
 
     @property
-    def thumbnail(self) -> bool | str | None:
-        value = self._data.get("thumbnail")
-        if value is None or isinstance(value, bool | str):
+    def thumbnail(self) -> bool | None:
+        if "thumbnail" not in self._data:
+            return None
+        value = self._data["thumbnail"]
+        if isinstance(value, bool):
             return value
-        raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean, string, or null")
+        raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean")
 
     @thumbnail.setter
-    def thumbnail(self, value: bool | str | None) -> None:
+    def thumbnail(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean")
         self._data["thumbnail"] = value
 
     @property
@@ -273,8 +272,8 @@ class AssetsState(_ObjectSection):
     def set_known(self, key: AssetKey, value: JSONValue) -> None:
         """CLI が公開する asset key を schema 検証して更新する。"""
         if key == "thumbnail":
-            if value is not None and not isinstance(value, bool | str):
-                raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean, string, or null")
+            if not isinstance(value, bool):
+                raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean")
         elif key == "loop_video":
             if not isinstance(value, bool) and value != "failed":
                 raise WorkflowStateError("workflow-state.json::assets.loop_video must be a boolean or 'failed'")
@@ -510,9 +509,17 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         return PostUploadState(value) if isinstance(value, dict) else None
 
     def set_thumbnail_approved(self, approved: bool) -> None:
-        section = self._data.setdefault("thumbnail", {})
-        assert isinstance(section, dict)
-        section["approved"] = approved
+        if not isinstance(approved, bool):
+            raise WorkflowStateError("workflow-state.json::assets.thumbnail must be a boolean")
+        assets = self._data.setdefault("assets", {})
+        assert isinstance(assets, dict)
+        AssetsState(assets).thumbnail = approved
+
+        legacy = self._data.get("thumbnail")
+        if isinstance(legacy, dict):
+            legacy.pop("approved", None)
+            if not legacy:
+                del self._data["thumbnail"]
 
     def set_description_generated(self, generated: bool) -> None:
         section = self._data.setdefault("description", {})

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -214,7 +214,8 @@ def test_legacy_completion_and_post_upload_sections_have_typed_commands(tmp_path
     assert workflow_state_cli.main(["--collection", str(collection), "set-post-upload-shorts", shorts]) == 0
 
     state = _read_state(collection)
-    assert state["thumbnail"] == {"approved": True}
+    assert state["assets"] == {"thumbnail": True}
+    assert "thumbnail" not in state
     assert state["description"] == {"generated": True}
     assert state["post_upload"] == {
         "shorts": [{"short_num": 1, "video_id": "short-1", "uploaded_at": "2026-08-16T00:00:00Z"}]

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -144,7 +144,7 @@ def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
         "new-collection",
         {
             "phase": "prepared",
-            "assets": {"raw_master": None, "master_audio": None, "video": None, "thumbnail": None},
+            "assets": {"raw_master": None, "master_audio": None, "video": None, "thumbnail": False},
         },
     )
 
@@ -154,6 +154,26 @@ def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
     assert "  ○  音源生成" in message
     assert "  ▸  マスター化" in message
     assert "  ○  動画化" in message
+
+
+def test_should_read_legacy_thumbnail_approval_through_owner_accessor(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "legacy-thumbnail",
+        {
+            "phase": "prepared",
+            "assets": {"thumbnail": False},
+            "thumbnail": {"approved": True},
+        },
+    )
+
+    message = _progress_message(tmp_path, capsys)
+
+    assert "  ✓  サムネイル" in message
 
 
 def test_should_use_raw_master_for_mastering_when_manual_mastering_is_skipped(

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -1110,7 +1110,7 @@ def test_thumbnail_skill_documents_ab_test_outputs_prompts_and_approval_contract
         "先頭 pattern",
         "thumbnail.jpg",
         "A/B Test Pattern Prompts",
-        "全 pattern の承認が揃うまでは `thumbnail.approved` を `true` にしない",
+        "全 pattern の承認が揃うまでは `assets.thumbnail` を `true` にしない",
         "Test & compare",
         "公式 API はない",
     ):
@@ -1946,7 +1946,8 @@ def test_thumbnail_skill_routes_quality_details_without_moving_hard_gates() -> N
     assert "**Hard Gate**" in "\n".join(skill.splitlines()[:60])
     assert "/thumbnail --compare" in skill
     assert "ユーザー承認" in skill
-    assert "thumbnail.approved = true" in skill
+    assert "assets.thumbnail = true" in skill
+    assert "thumbnail.approved = true" not in skill
 
 
 def test_thumbnail_quality_and_operations_owns_details_once() -> None:

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -11,6 +11,7 @@ import pytest
 
 from youtube_automation.core.errors import AutomationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read, read_or_none, update
+from youtube_automation.infrastructure.filesystem import JSONValue
 
 
 def _write(path: Path, payload: object) -> None:
@@ -57,6 +58,44 @@ def test_read_returns_typed_sections_and_compatible_accessors(tmp_path: Path) ->
     assert state.thumbnail_approved is True
     assert state.description_generated is True
     assert state.music_engine == "suno"
+
+
+def test_thumbnail_approval_write_uses_canonical_asset_and_removes_legacy_field(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(
+        state_path,
+        {
+            "assets": {"thumbnail": False, "future_asset": "keep"},
+            "thumbnail": {"approved": True, "future_field": "keep"},
+            "future_section": {"keep": True},
+        },
+    )
+
+    update(state_path, lambda state: state.set_thumbnail_approved(False))
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["assets"] == {"thumbnail": False, "future_asset": "keep"}
+    assert persisted["thumbnail"] == {"future_field": "keep"}
+    assert persisted["future_section"] == {"keep": True}
+    assert read(state_path).thumbnail_approved is False
+
+
+def test_thumbnail_approval_write_creates_assets_and_drops_empty_legacy_section(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"thumbnail": {"approved": False}})
+
+    update(state_path, lambda state: state.set_thumbnail_approved(True))
+
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {"assets": {"thumbnail": True}}
+
+
+@pytest.mark.parametrize("value", [None, "10-assets/thumbnail.jpg", 1])
+def test_assets_thumbnail_rejects_non_boolean_values(value: JSONValue) -> None:
+    payload: dict[str, JSONValue] = {"assets": {"thumbnail": value}}
+    state = WorkflowState(payload)
+
+    with pytest.raises(WorkflowStateError, match=r"assets\.thumbnail must be a boolean"):
+        assert state.assets is not None and state.assets.thumbnail
 
 
 def test_update_preserves_unknown_keys_during_round_trip(tmp_path: Path) -> None:

--- a/tests/repo/test_workflow_state_skill_cli_contract.py
+++ b/tests/repo/test_workflow_state_skill_cli_contract.py
@@ -61,3 +61,15 @@ def test_asset_mutations_are_routed_through_owner_cli() -> None:
     assert "set-planning" in text
     assert "set-thumbnail-approved" in text
     assert "set-description-generated" in text
+
+
+def test_thumbnail_approval_routes_use_only_the_canonical_asset_key() -> None:
+    thumbnail_skill = (REPO_ROOT / ".claude" / "skills" / "thumbnail" / "SKILL.md").read_text(encoding="utf-8")
+    loop_reference = (REPO_ROOT / ".claude" / "skills" / "thumbnail" / "references" / "loop.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "assets.thumbnail" in thumbnail_skill
+    assert "thumbnail.approved = true" not in thumbnail_skill
+    assert "assets.thumbnail = true" in loop_reference
+    assert "owner の `thumbnail_approved` accessor" in loop_reference


### PR DESCRIPTION
## 概要

workflow stateのサムネ承認状態を `assets.thumbnail` に一本化し、旧 `thumbnail.approved` は読み取り互換だけに限定します。

## 変更内容

- `assets.thumbnail` をboolean正準キーとしてowner型・schemaへ反映
- `set_thumbnail_approved` / CLIは正準キーだけを書き、旧キーを除去
- unknown sibling fieldを保持
- owner accessorで旧stateを読み取り互換
- progress hookをowner accessorへ接続
- thumbnail / wf-new導線とratchet契約を更新

## 検証

- full: 9,332 passed / 3 skipped
- rebase後 focused: 177 passed
- ruff / format / yt-skills / Any gate: green
- wheel smoke: 2 passed

Closes #3889
