### PR TITLE
refactor(workflow-state): 概要欄生成状態をassetsへ統合する (#3890)

### DIFF
--- a/.claude/skills/video/references/describe.md
+++ b/.claude/skills/video/references/describe.md
@@ -8,7 +8,7 @@
 
 - 品質チェック（後述チェックリスト）の全項目を満たした概要欄・タイトル案・タグが `20-documentation/descriptions.md` に保存されている
 - `uv run yt-title-duplicate-check` を実行し、100 codepoint 超過が無く、重複 warning はこの段階で見直し済み
-- `uv run yt-workflow-state --collection <collection-path> set-description-generated true` が成功済み
+- owner CLI の `uv run yt-workflow-state --collection <collection-path> set-description-generated true` が成功し、`assets.description = true` が保存済み
 
 ## 設定読み込みゲート
 
@@ -204,7 +204,7 @@ uv run yt-title-duplicate-check "$COLLECTION_DIR" --title "$PROPOSED_TITLE"
 保存フォーマット（ヘッダー、概要欄本文、タイトル案、タグ、Cards、品質チェック）は
 `references/description-templates.md` の「descriptions.md 保存フォーマット」セクションを参照すること。
 
-保存後、`uv run yt-workflow-state --collection <collection-path> set-description-generated true` を実行する。
+保存後、`uv run yt-workflow-state --collection <collection-path> set-description-generated true` を実行し、正準キー `assets.description = true` を保存する。
 
 ## 障害時ガイダンス
 

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -127,9 +127,6 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
       ]
     },
     "executed_at": "ISO 8601"
-  },
-  "description": {
-    "generated": true
   }
 }
 ```
@@ -184,7 +181,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 ### 互換フィールド
 
-`thumbnail.approved` は既存 state の読み取り専用互換 field であり、workflow-state owner の `thumbnail_approved` accessor だけが解釈する。新規 write は `assets.thumbnail` だけを更新し、互換 field を出力しない。`description.generated` は既存 state を読めるよう owner が保持する互換 field で、正規の生成済み判定は `assets.description` とする。
+`thumbnail.approved` と `description.generated` は既存 state の読み取り専用互換 field であり、workflow-state owner の `thumbnail_approved` / `description_generated` accessor だけが解釈する。新規 write はそれぞれ `assets.thumbnail` / `assets.description` だけを更新し、互換 field を出力しない。
 
 #### wf-new --auto の判定責務
 

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -227,11 +227,11 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 
 1. **並列 A**（2 Agent 同時起動）:
    - Agent 1: 対象 collection、`01-master/<assets.master_audio>`、`10-assets/main.png/jpg` または `loop.mp4` を入力に Skill `/video --generate` の Subagent Contract を実行。thumbnail skill-config も渡し、`textless.enabled: false` の共有 `main.jpg` を textless 再生成へ戻さない。期待成果物は `01-master/*.mp4`
-   - Agent 2 の起動前に、メインが `/video --describe` の重複トラック名を検出し、必要な表示名 mapping を確定するが、まだ `apply_track_display_names()` は呼ばない。その mapping、planning / localization、skill-config、benchmark 入力を列挙し、Agent 2 には `/video --describe` の Step 1 から品質チェック、`yt-title-duplicate-check`、`20-documentation/descriptions.md` 保存までを実行させる。`apply_track_display_names()` と `workflow-state.json` の `description.generated` 更新は実行させない
+   - Agent 2 の起動前に、メインが `/video --describe` の重複トラック名を検出し、必要な表示名 mapping を確定するが、まだ `apply_track_display_names()` は呼ばない。その mapping、planning / localization、skill-config、benchmark 入力を列挙し、Agent 2 には `/video --describe` の Step 1 から品質チェック、`yt-title-duplicate-check`、`20-documentation/descriptions.md` 保存までを実行させる。`apply_track_display_names()` と `workflow-state.json` の `assets.description` 更新は実行させない
    - 両 Agent とも state は入力確認に必要な範囲だけ読み、書き込まず、AskUserQuestion を実行しない。片方でも失敗または成果物欠落なら state を更新せず停止する
 2. 並列 A 完了後:
    - メインが両成果物の存在と `phase: "mastered"` との整合を確認する
-   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、動画ファイル名を JSON string として `set-asset master_video <json-value>`、`set-asset description true`、`set-description-generated true` の各 owner CLI を実行してから、次の owner CLI で phase と `updated_at` を一体更新する
+   - PASS 後だけ、メインが確定済み表示名 mapping を `apply_track_display_names()` で永続化し、動画ファイル名を JSON string として `set-asset master_video <json-value>`、概要欄完了を正準キー `assets.description` へ保存する `set-description-generated true` の各 owner CLI を実行してから、次の owner CLI で phase と `updated_at` を一体更新する
 
      ```bash
      uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
+- `refactor(workflow-state)`: 概要欄生成状態を `assets.description` へ統合し、旧 `description.generated` は owner accessor の読み取り互換だけに限定する（#3890）。
 - `refactor(workflow-state)`: サムネイル承認状態を boolean の `assets.thumbnail` へ統合し、旧 `thumbnail.approved` は owner accessor の読み取り互換だけに限定する（#3889）。
 - `fix(wf-new)`: 定期実行の開始時に write OAuth token を API quota 消費なしで1回更新し、失効・更新失敗時は workflow を開始せず、機密情報を除去した再認証手順を報告する（#3937）。
 - `feat(workspace)`: workspace 全チャンネルの登録者数・総再生回数・動画数を YouTube `channels.list` 1 request で取得する `yt-workspace-status` を追加する（#4116）。

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -124,10 +124,6 @@ class ThumbnailAutoSelectionDocument(TypedDict, total=False):
     executed_at: str
 
 
-class DescriptionDocument(TypedDict, total=False):
-    generated: bool
-
-
 class TitleTemplateCheckDocument(TypedDict, total=False):
     allow_volume_patterns: bool
 
@@ -154,7 +150,6 @@ class WorkflowStateDocument(TypedDict, total=False):
     track_display_names: dict[str, str]
     title_activity: str
     thumbnail_auto_selection: ThumbnailAutoSelectionDocument
-    description: DescriptionDocument
 
 
 _PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
@@ -522,9 +517,17 @@ class WorkflowState(MutableMapping[str, JSONValue]):
                 del self._data["thumbnail"]
 
     def set_description_generated(self, generated: bool) -> None:
-        section = self._data.setdefault("description", {})
-        assert isinstance(section, dict)
-        section["generated"] = generated
+        if not isinstance(generated, bool):
+            raise WorkflowStateError("workflow-state.json::assets.description must be a boolean")
+        assets = self._data.setdefault("assets", {})
+        assert isinstance(assets, dict)
+        AssetsState(assets).description = generated
+
+        legacy = self._data.get("description")
+        if isinstance(legacy, dict):
+            legacy.pop("generated", None)
+            if not legacy:
+                del self._data["description"]
 
     @property
     def theme(self) -> str | None:

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -214,9 +214,9 @@ def test_legacy_completion_and_post_upload_sections_have_typed_commands(tmp_path
     assert workflow_state_cli.main(["--collection", str(collection), "set-post-upload-shorts", shorts]) == 0
 
     state = _read_state(collection)
-    assert state["assets"] == {"thumbnail": True}
+    assert state["assets"] == {"thumbnail": True, "description": True}
     assert "thumbnail" not in state
-    assert state["description"] == {"generated": True}
+    assert "description" not in state
     assert state["post_upload"] == {
         "shorts": [{"short_num": 1, "video_id": "short-1", "uploaded_at": "2026-08-16T00:00:00Z"}]
     }

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -89,6 +89,44 @@ def test_thumbnail_approval_write_creates_assets_and_drops_empty_legacy_section(
     assert json.loads(state_path.read_text(encoding="utf-8")) == {"assets": {"thumbnail": True}}
 
 
+def test_description_completion_write_uses_canonical_asset_and_removes_legacy_field(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(
+        state_path,
+        {
+            "assets": {"description": False, "future_asset": "keep"},
+            "description": {"generated": True, "future_field": "keep"},
+            "future_section": {"keep": True},
+        },
+    )
+
+    update(state_path, lambda state: state.set_description_generated(False))
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["assets"] == {"description": False, "future_asset": "keep"}
+    assert persisted["description"] == {"future_field": "keep"}
+    assert persisted["future_section"] == {"keep": True}
+    assert read(state_path).description_generated is False
+
+
+def test_description_completion_write_creates_assets_and_drops_empty_legacy_section(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"description": {"generated": False}})
+
+    update(state_path, lambda state: state.set_description_generated(True))
+
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {"assets": {"description": True}}
+
+
+def test_description_completion_reads_legacy_state_through_compatibility_accessor(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"assets": {"description": False}, "description": {"generated": True}})
+
+    state = read(state_path)
+
+    assert state.description_generated is True
+
+
 @pytest.mark.parametrize("value", [None, "10-assets/thumbnail.jpg", 1])
 def test_assets_thumbnail_rejects_non_boolean_values(value: JSONValue) -> None:
     payload: dict[str, JSONValue] = {"assets": {"thumbnail": value}}

--- a/tests/repo/test_workflow_state_skill_cli_contract.py
+++ b/tests/repo/test_workflow_state_skill_cli_contract.py
@@ -73,3 +73,16 @@ def test_thumbnail_approval_routes_use_only_the_canonical_asset_key() -> None:
     assert "thumbnail.approved = true" not in thumbnail_skill
     assert "assets.thumbnail = true" in loop_reference
     assert "owner の `thumbnail_approved` accessor" in loop_reference
+
+
+def test_description_completion_routes_use_only_the_canonical_asset_key() -> None:
+    video_description = (REPO_ROOT / ".claude" / "skills" / "video" / "references" / "describe.md").read_text(
+        encoding="utf-8"
+    )
+    wf_next = _text("wf-next")
+
+    assert "assets.description" in video_description
+    assert "description.generated" not in video_description
+    assert "assets.description" in wf_next
+    assert "description.generated" not in wf_next
+    assert wf_next.count("set-description-generated true") == 1


### PR DESCRIPTION
## 概要

workflow stateの概要欄生成状態を `assets.description` に一本化し、旧 `description.generated` は読み取り互換だけに限定します。

## 変更内容

- owner semantic setter / CLIは正準キーだけを書き、旧fieldを除去
- unknown sibling fieldを保持
- `description_generated` accessorで旧stateを読み取り互換
- `/video --describe` と `/wf-next` をowner CLI writeへ統一
- typed schema、skill導線、ratchet契約を更新

## 検証

- full: 9,381 passed / 3 skipped
- focused: 76 passed
- ruff / format / yt-skills / Any gate: green
- wheel smoke: 2 passed

Closes #3890
