### PR TITLE
refactor(workflow-state): 音楽エンジンをplanningへ統合する (#3891)

### DIFF
--- a/.claude/skills/music/references/generate.md
+++ b/.claude/skills/music/references/generate.md
@@ -367,7 +367,7 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 1. **チャンネルのデフォルト** — `/channel-strategy --direction`（方向性検討モード）で `suno` / `lyria` / `minimax` を検討 → `/setup --regenerate` が `config/channel/youtube.json` の `music_engine` に書き込む
 2. **コレクション単位の上書き** — `/wf-new` の `yt-init-collection --music-engine lyria` でコレクション毎に上書き可能（省略時はチャンネル設定を継承）
-3. **このスキルが呼ばれるとき** — `/wf-new` が `workflow-state.json` の `music_engine = "lyria"` を判定して `/music --generate` を自動実行する。手動で `/music --generate <theme>` を叩いた場合もこのスキルに入る
+3. **このスキルが呼ばれるとき** — `/wf-new` が `workflow-state.json` の `planning.music.engine = "lyria"` を判定して `/music --generate` を自動実行する。手動で `/music --generate <theme>` を叩いた場合もこのスキルに入る
 
 ## Quick Reference
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -159,7 +159,7 @@ uv run yt-init-collection "Pilot Direction Check" "pilot-direction-check" --trac
 1. コマンド出力の `collections/planning/YYYYMMDD-<short>-pilot-direction-check-collection/` を控える。
 2. `/thumbnail pilot-direction-check` を実行し、`10-assets/main.png` / `10-assets/main.jpg` と `10-assets/thumbnail.jpg` で色味・構図を確認する。
 3. `/thumbnail --compare` を実行し、ベンチマーク競合との 320px 表示を確認する。現行の `yt-thumbnail-compare` は `collections/live/*/10-assets/thumbnail.jpg` を収集するため、仮コレクションの `thumbnail.jpg` を比較へ含める場合は一時的に `collections/live/_pilot-thumbnail-compare/10-assets/thumbnail.jpg` へコピーし、比較後に `collections/live/_pilot-thumbnail-compare/` を削除する。
-4. `workflow-state.json::music_engine` が `suno` なら `/music --prompt pilot-direction-check` でプロンプトを生成し、続けて `/music --generate` で Suno UI へ投入・音源生成して試聴する。`lyria` / `minimax` なら `/music --generate pilot-direction-check` を実行して生成音源を試聴し、ムード・テンポを確認する。
+4. `workflow-state.json::planning.music.engine` が `suno` なら `/music --prompt pilot-direction-check` でプロンプトを生成し、続けて `/music --generate` で Suno UI へ投入・音源生成して試聴する。`lyria` / `minimax` なら `/music --generate pilot-direction-check` を実行して生成音源を試聴し、ムード・テンポを確認する。
 5. NG の場合は試作物を破棄し、サムネは `config/skills/thumbnail.yaml` の `image_generation.gemini.reference_images.default` / `composition_rules.*` / `diff_prompt_template`、Suno は `config/skills/music.yaml::prompt` の `genre_line` / `exclude_styles` / `style_influence` / `style_variation.*`、Lyria は `config/skills/lyria.yaml` の `prompt_prefix` / `style_hints` / `default_bpm` / `default_intensity` を調整して再試作する。
 6. OK の場合は、仮コレクションを削除して `/wf-new` を再実行する。仮コレクションを本制作へ昇格する場合は削除せず、既存 `collections/planning/` の続きとして `/wf-next` を使う。
 

--- a/.claude/skills/wf-new/references/phase2.md
+++ b/.claude/skills/wf-new/references/phase2.md
@@ -69,7 +69,7 @@ uv run yt-populate-scene-phrases <collection-dir-name> \
 ##### 2c-1. サムネイル候補生成
 
 1. **メインが共有入力と再開対象を固定**:
-   - 対象 collection の絶対 path、確定企画、`workflow-state.json::theme`、`music_engine`、thumbnail の effective auto-selection / textless 設定を実ファイルから固定する。以後の 2 call に同じ値を渡し、subagent に推測させない
+   - 対象 collection の絶対 path、確定企画、`workflow-state.json::theme`、`planning.music.engine`、thumbnail の effective auto-selection / textless 設定を実ファイルから固定する。以後の 2 call に同じ値を渡し、subagent に推測させない
    - Phase 2c 成果物・再開契約で flag と実成果物を branch ごとに再検証する。flag が `true` なのに成果物が欠落・破損・不整合なら dispatch せず fail-closed に停止する
    - 両 branch が検証成功済みなら initial dispatch を省略する。片側だけが未完了なら、その 1 call だけを起動し、成功済み側を exactly-two の数合わせで再生成・再承認しない
 

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -32,7 +32,6 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
   "phase": "planning | prepared | mastered | publishing | complete",
   "selected_plan": "A | B | C | D | E",
   "track_count": 12,
-  "music_engine": "suno | lyria | minimax",
   "planning": {
     "activities": "Working",
     "target_persona": "deep-work listener",
@@ -183,6 +182,8 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 `thumbnail.approved` と `description.generated` は既存 state の読み取り専用互換 field であり、workflow-state owner の `thumbnail_approved` / `description_generated` accessor だけが解釈する。新規 write はそれぞれ `assets.thumbnail` / `assets.description` だけを更新し、互換 field を出力しない。
 
+top-level `music_engine` は既存 state の読み取り専用互換 field であり、workflow-state owner の `music_engine` accessor だけが解釈する。`planning.music.engine` と併存する場合は値の一致を必須とし、不一致なら停止する。新規 write は `planning.music.engine` だけを更新し、互換 field を出力しない。
+
 #### wf-new --auto の判定責務
 
 `/wf-new --auto` は active collection が無ければ state を事前作成せず `/wf-new` へ委譲し、初期化後は返された collection を固定する。active collection があれば本 state と実成果物を一段ごとに再評価し、Lyria / Suno / masterup / 制作 / 公開 / publish の委譲先を選ぶ。統合 runner 自身は本ファイルを更新せず、各既存 skill の検証済み更新契約を使う。`workflow.scheduled_automation.allow_external_publish` が `false` の場合はローカル動画・metadata 生成後、YouTube 書き込み前で停止する。`.automation-run/history.json` は停止理由と再開地点の監査記録であり、本 state や成果物の代替 source of truth ではない。
@@ -226,7 +227,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 ### planning フィールド詳細
 
-`planning` は各企画フェーズスキルが populate する正規化メタデータ。`init_collection.py` は空オブジェクト `{}` で初期化する。
+`planning` は各企画フェーズスキルが populate する正規化メタデータ。`init_collection.py` は正準の音楽エンジンを `{"music": {"engine": "..."}}` に初期化する。
 
 #### planning.music
 
@@ -234,7 +235,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|---|------|
-| `planning.music.engine` | `"suno" \| "lyria" \| "minimax"` | Yes | 音楽エンジン（top-level `music_engine` と一致）|
+| `planning.music.engine` | `"suno" \| "lyria" \| "minimax"` | Yes | 音楽エンジンの正準キー |
 | `planning.music.mood` | string[] | Yes | 感情語 1-3 個（例: `["mellow", "introspective"]`）|
 | `planning.music.atmosphere` | string | Yes | コレクション全体の世界観 1 文（英語）|
 | `planning.music.tempo` | string | Yes | `"very slow"` / `"slow"` / `"gentle"` / `"moderate"` / `"lively"` のいずれか |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
+- `refactor(workflow-state)`: collection の音楽エンジンを `planning.music.engine` へ統合し、旧 top-level `music_engine` は一致検証付きの読み取り互換だけに限定する（#3891）。
 - `refactor(workflow-state)`: 概要欄生成状態を `assets.description` へ統合し、旧 `description.generated` は owner accessor の読み取り互換だけに限定する（#3890）。
 - `refactor(workflow-state)`: サムネイル承認状態を boolean の `assets.thumbnail` へ統合し、旧 `thumbnail.approved` は owner accessor の読み取り互換だけに限定する（#3889）。
 - `fix(wf-new)`: 定期実行の開始時に write OAuth token を API quota 消費なしで1回更新し、失効・更新失敗時は workflow を開始せず、機密情報を除去した再認証手順を報告する（#3937）。

--- a/src/youtube_automation/commands/collections/init_collection.py
+++ b/src/youtube_automation/commands/collections/init_collection.py
@@ -41,8 +41,7 @@ def build_state(collection_name: str, theme: str, track_count: int, selected_pla
         "phase": "planning",
         "selected_plan": selected_plan,
         "track_count": track_count,
-        "music_engine": music_engine,
-        "planning": {},
+        "planning": {"music": {"engine": music_engine}},
         "assets": {
             "thumbnail": False,
             "loop_video": False,

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -134,11 +134,7 @@ def _set_asset(state: WorkflowState, key: AssetKey, value: JSONValue) -> None:
 
 
 def _set_planning(state: WorkflowState, key: PlanningKey, value: JSONValue) -> None:
-    if state.planning is None:
-        state["planning"] = {}
-    planning = state.planning
-    assert planning is not None
-    planning.set_known(key, value)
+    state.set_planning_known(key, value)
     _touch(state)
 
 

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -139,7 +139,6 @@ class WorkflowStateDocument(TypedDict, total=False):
     phase: Phase
     selected_plan: Literal["A", "B", "C", "D", "E"]
     track_count: int
-    music_engine: MusicEngine
     planning: PlanningDocument
     scene_phrases: dict[str, str]
     title_template_check: TitleTemplateCheckDocument
@@ -528,6 +527,13 @@ class WorkflowState(MutableMapping[str, JSONValue]):
             legacy.pop("generated", None)
             if not legacy:
                 del self._data["description"]
+
+    def set_planning_known(self, key: PlanningKey, value: JSONValue) -> None:
+        planning = self._data.setdefault("planning", {})
+        assert isinstance(planning, dict)
+        PlanningState(planning).set_known(key, value)
+        if key == "music":
+            self._data.pop("music_engine", None)
 
     @property
     def theme(self) -> str | None:

--- a/tests/commands/collections/test_init_collection.py
+++ b/tests/commands/collections/test_init_collection.py
@@ -104,7 +104,8 @@ class TestScaffold:
             assert state["theme"] == "init-scaffold"
             assert state["track_count"] == 7
             assert state["selected_plan"] == "D"
-            assert state["music_engine"] == "lyria"
+            assert state["planning"]["music"]["engine"] == "lyria"
+            assert "music_engine" not in state
         finally:
             import shutil
 
@@ -117,7 +118,8 @@ class TestScaffold:
         collection = _created_collection()
         try:
             state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
-            assert state["music_engine"] == expected_engine
+            assert state["planning"]["music"]["engine"] == expected_engine
+            assert "music_engine" not in state
             assert state["track_count"] == 12
             assert state["selected_plan"] == "A"
         finally:
@@ -131,7 +133,8 @@ class TestScaffold:
         collection = next(planning.glob("*-minimax-scaffold-collection"))
         try:
             state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
-            assert state["music_engine"] == "minimax"
+            assert state["planning"]["music"]["engine"] == "minimax"
+            assert "music_engine" not in state
         finally:
             import shutil
 

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -180,6 +180,29 @@ def test_typed_asset_and_planning_updates_preserve_unknown_fields(
     assert state["unknown"] == {"keep": True}
 
 
+def test_set_planning_music_writes_canonical_engine_and_removes_legacy_key(tmp_path: Path) -> None:
+    collection = _collection(
+        tmp_path,
+        {
+            "music_engine": "suno",
+            "planning": {"future": "keep"},
+            "unknown": {"keep": True},
+        },
+    )
+
+    assert (
+        workflow_state_cli.main(
+            ["--collection", str(collection), "set-planning", "music", '{"engine":"lyria","mood":["mellow"]}']
+        )
+        == 0
+    )
+
+    state = _read_state(collection)
+    assert state["planning"] == {"future": "keep", "music": {"engine": "lyria", "mood": ["mellow"]}}
+    assert "music_engine" not in state
+    assert state["unknown"] == {"keep": True}
+
+
 @pytest.mark.parametrize(
     "command",
     [

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -37,7 +37,6 @@ def test_read_returns_typed_sections_and_compatible_accessors(tmp_path: Path) ->
         {
             "phase": "prepared",
             "stage": "planning",
-            "music_engine": "suno",
             "planning": {"music": {"engine": "suno"}},
             "assets": {"thumbnail": False, "description": True},
             "thumbnail": {"approved": True},
@@ -280,9 +279,27 @@ def test_compatible_music_engine_accessor_rejects_conflicting_values(tmp_path: P
         _engine = read(state_path).music_engine
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"music_engine": "lyria"},
+        {"planning": {"music": {"engine": "lyria"}}},
+        {"music_engine": "lyria", "planning": {"music": {"engine": "lyria"}}},
+    ],
+)
+def test_music_engine_accessor_reads_canonical_and_legacy_shapes(
+    tmp_path: Path,
+    payload: dict[str, JSONValue],
+) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, payload)
+
+    assert read(state_path).music_engine == "lyria"
+
+
 def test_music_engine_accepts_minimax_in_owner_schema(tmp_path: Path) -> None:
     state_path = tmp_path / "workflow-state.json"
-    _write(state_path, {"music_engine": "minimax", "planning": {"music": {"engine": "minimax"}}})
+    _write(state_path, {"planning": {"music": {"engine": "minimax"}}})
 
     assert read(state_path).music_engine == "minimax"
 

--- a/tests/repo/test_automation_run_state.py
+++ b/tests/repo/test_automation_run_state.py
@@ -32,7 +32,6 @@ def _write_collection(root: Path, name: str, created_at: str, *, phase: str = "p
                 "created_at": created_at,
                 "phase": phase,
                 "stage": "planning",
-                "music_engine": "lyria",
                 "assets": {"raw_master": None},
                 "upload": {"video_id": None},
                 "planning": {"music": {"engine": "lyria"}},

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -58,7 +58,6 @@ def _collection(
         "created_at": "2026-07-21T00:00:00+00:00",
         "stage": stage,
         "phase": phase,
-        "music_engine": engine,
         "planning": {"music": {"engine": engine}},
         "assets": {
             "music_prompts": True,
@@ -109,6 +108,29 @@ def test_minimax_collection_routes_to_music_generate_without_suno_fallback(tmp_p
     assert decision["action"] == "minimax"
     assert decision["reason"] == "minimax_generation_required"
     assert decision["resume_action"] == "minimax"
+
+
+def test_legacy_music_engine_only_state_remains_routable(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(tmp_path, "20260721-legacy", engine="lyria")
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["music_engine"] = state["planning"]["music"].pop("engine")
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    decision = runner.resolve_action(tmp_path, collection.name, config=_config(runner))
+
+    assert decision["action"] == "lyria"
+
+
+def test_conflicting_music_engine_state_fails_before_action_selection(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(tmp_path, "20260721-conflict", engine="lyria")
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["music_engine"] = "suno"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="music engine mismatch"):
+        runner.resolve_action(tmp_path, collection.name, config=_config(runner))
 
 
 def test_interactive_approval_replans_same_collection_in_same_run(tmp_path: Path, runner: ModuleType) -> None:

--- a/tests/repo/test_wf_new_phase_2c_parallel_dispatch_contract.py
+++ b/tests/repo/test_wf_new_phase_2c_parallel_dispatch_contract.py
@@ -44,7 +44,7 @@ def test_phase_2c_freezes_shared_inputs_before_one_exactly_two_call_dispatch() -
         "対象 collection の絶対 path",
         "確定企画",
         "theme",
-        "music_engine",
+        "planning.music.engine",
         "auto-selection",
         "textless",
     )

--- a/tests/repo/test_workflow_state_skill_cli_contract.py
+++ b/tests/repo/test_workflow_state_skill_cli_contract.py
@@ -86,3 +86,15 @@ def test_description_completion_routes_use_only_the_canonical_asset_key() -> Non
     assert "assets.description" in wf_next
     assert "description.generated" not in wf_next
     assert wf_next.count("set-description-generated true") == 1
+
+
+def test_workflow_music_engine_routes_use_the_canonical_planning_key() -> None:
+    wf_new = _text("wf-new")
+    music_generate = (REPO_ROOT / ".claude" / "skills" / "music" / "references" / "generate.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (wf_new, music_generate):
+        assert "planning.music.engine" in text
+    assert "workflow-state.json::music_engine" not in wf_new
+    assert 'workflow-state.json` の `music_engine = "lyria"' not in music_generate


### PR DESCRIPTION
## 概要

workflow stateの音楽engineを `planning.music.engine` に一本化し、旧top-level `music_engine` は検証付き読み取り互換だけに限定します。

## 変更内容

- 新規collectionとowner CLIは正準nested keyだけを書き込む
- top-only / nested-only / 両方一致の旧stateをowner accessorで互換read
- 両キー不一致はwf-autoのaction選択前にfail
- init_collection、workflow-state owner/CLI、wf-auto helperを更新
- wf-new/music schema、skill契約、fixtures、CHANGELOGを追従
- #4032の新workflow-status HTML owner契約を保持

## 検証

- pre-rebase full: 9,388 passed / 3 skipped
- post-rebase focused: 135 passed
- ruff / format / yt-skills: green
- wheel smoke: 2 passed

Closes #3891
