### PR TITLE
feat(documents): 動画説明をJSON正本へ移行する (#4030)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -13,7 +13,7 @@ description: "Use when 整合性・動画本体・公開後メタデータ・価
 ## 成果物
 
 - `書き込む`: `docs/plans/alignment-audit.{json,html}`, `data/video_analysis/<channel>/<video-id>.json`, `reports/video_analysis/<channel>.{json,html}`
-- `読み込む`: `collections/<id>/10-assets/thumbnail.jpg`, 検証済み `collections/<id>/20-documentation/suno-prompts.json` または `lyria-prompt.json`, `collections/<id>/20-documentation/descriptions.md`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`, `data/benchmark_*.json`, 検証済み `docs/channel/personas/persona-definition.json`, `docs/plans/viewing-scene-matrix.json`, `docs/channel/creative-constraints.json`, `reports/analysis_*.json`, `data/insights.jsonl`, `config/channel/*.json`, `config/skills/audit.yaml`
+- `読み込む`: `collections/<id>/10-assets/thumbnail.jpg`, 検証済み `collections/<id>/20-documentation/suno-prompts.json` または `lyria-prompt.json`, 検証済み `collections/<id>/20-documentation/descriptions.json` + 同 basename HTML, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`, `data/benchmark_*.json`, 検証済み `docs/channel/personas/persona-definition.json`, `docs/plans/viewing-scene-matrix.json`, `docs/channel/creative-constraints.json`, `reports/analysis_*.json`, `data/insights.jsonl`, `config/channel/*.json`, `config/skills/audit.yaml`
 
 ## 想定 API call 数
 

--- a/.claude/skills/audit/references/audit-chain-manifest.json
+++ b/.claude/skills/audit/references/audit-chain-manifest.json
@@ -40,7 +40,8 @@
       "skill": "audit",
       "prerequisiteArtifacts": [
         "collections/live/*/workflow-state.json::upload.video_id",
-        "collections/live/*/20-documentation/descriptions.md"
+        "collections/live/*/20-documentation/descriptions.json",
+        "collections/live/*/20-documentation/descriptions.html"
       ],
       "outputArtifacts": [],
       "approvalGate": {

--- a/.claude/skills/audit/references/metadata.md
+++ b/.claude/skills/audit/references/metadata.md
@@ -9,13 +9,13 @@
 ## 成果物
 
 - `書き込む`: `なし`
-- `読み込む`: `collections/<id>/20-documentation/descriptions.md`, `collections/<id>/workflow-state.json`, `config/channel/*.json`
+- `読み込む`: 検証済み `collections/<id>/20-documentation/descriptions.json` + 同 basename HTML, `collections/<id>/workflow-state.json`, `config/channel/*.json`
 
 ## Overview
 
-`yt-metadata-audit` のラッパー。`collections/live/<col>/20-documentation/descriptions.md` と `workflow-state.json` の整合性、および YouTube API 側 snippet/localizations の整合性を読み取り専用で監査する。
+`yt-metadata-audit` のラッパー。`collections/live/<col>/20-documentation/descriptions.json` + 同 basename HTML と `workflow-state.json` の整合性、および YouTube API 側 snippet/localizations の整合性を読み取り専用で監査する。
 
-**修正は範囲外**。自身では修正しない。差分検出後の更新は `/video --describe` で descriptions.md を再生成し、必要に応じて運用者が別経路で YouTube 側へ反映する。
+**修正は範囲外**。自身では修正しない。差分検出後の更新は `/video --describe` で descriptions JSON+HTML pair を再生成し、必要に応じて運用者が別経路で YouTube 側へ反映する。
 
 ## 完了条件
 
@@ -41,13 +41,13 @@
 以下を確認し、満たさなければ前工程を案内して停止する:
 
 - `config/channel/` が存在すること（`load_config()` でロード可能）。存在しない場合は `/setup --import` を案内して停止する
-- `collections/live/` 配下に監査対象のコレクション（`20-documentation/descriptions.md` + `workflow-state.json`）が 1 件以上存在すること。存在しない場合は監査対象なしとして終了し、先に `/publish --upload` での公開を案内する
+- `collections/live/` 配下に監査対象のコレクション（検証済み `20-documentation/descriptions.json` + 同 basename HTML + `workflow-state.json`）が 1 件以上存在すること。存在しない場合は監査対象なしとして終了し、先に `/publish --upload` での公開を案内する
 - remote 監査（既定および `--remote`）は `auth/token.json` の OAuth 認証が必要。未認証なら `/setup` を案内するか、API 不要の `--local` に切り替える
 
 ## When to Use
 
 - 一括アップロード後に YouTube 側にメタデータが正しく反映されたか確認したいとき
-- descriptions.md を手で編集したあと、live 動画と差分が出ていないか調べたいとき
+- descriptions JSON を更新したあと、検証済み HTML pair と live 動画に差分が出ていないか調べたいとき
 - 多言語ローカライゼーションが期待通り反映されているか確認したいとき
 - 多言語チャンネルで scene_phrases の言語抜けを検出したいとき
 
@@ -56,7 +56,7 @@
 | コマンド | 説明 |
 |---------|------|
 | `uv run yt-metadata-audit` | local + remote の両方を監査 |
-| `uv run yt-metadata-audit --local` | `descriptions.md` / `workflow-state.json` のみ（API call 不要） |
+| `uv run yt-metadata-audit --local` | 検証済み `descriptions.json` + HTML / `workflow-state.json` のみ（API call 不要） |
 | `uv run yt-metadata-audit --remote` | YouTube API 側 snippet/localizations のみ |
 | `uv run yt-metadata-audit --strict` | 1 件でも issue が見つかれば exit 1（CI 用途） |
 
@@ -75,7 +75,7 @@
 引数なしで `uv run yt-metadata-audit` を実行する。`collections/live/` 配下を全件走査し、以下を検出する:
 
 **LOCAL チェック**:
-- `descriptions.md` の `タイトル案` / `Complete Collection 概要欄` セクション欠落
+- `descriptions.json` の schema / localization / quality / HTML pair 不整合
 - タイトル 100 文字超過
 - タイムスタンプ数 > `config/channel/audio.json::chapter_max`（チャンネル config が単一ソース、既定 100。variation expansion regression 検出）
 - chapter 名のローマ数字（pattern I / II / III ... = variation expansion）
@@ -96,8 +96,8 @@
 
 監査出力に基づき、ユーザーに次のアクションを案内する:
 
-- **`descriptions.md` 側の問題**（タイトル長すぎ、timestamp 過多など） → `/video --describe` で再生成
-- **YouTube 側との差分**（local と remote がずれている） → `/video --describe` で descriptions.md を最新化したあと、YouTube 側への反映は別途運用判断
+- **`descriptions.json` 側の問題**（schema、localization、quality、pair 不整合など） → `/video --describe` で再生成
+- **YouTube 側との差分**（local と remote がずれている） → `/video --describe` で descriptions JSON+HTML pair を最新化したあと、YouTube 側への反映は別途運用判断
 - **`workflow-state.json` 不在・JSON 破損** → `/wf-new` から作られた正規 state を復旧し、手編集で辻褄合わせしない
 - **多言語チャンネルの scene_phrases 言語抜け** → 該当コレクションで `yt-populate-scene-phrases` を再実行、または `workflow-state.json` を正規形式で補完（単一言語チャンネルでは `scene_phrases` 不在は正常）
 
@@ -119,7 +119,7 @@ GitHub Actions や cron で常時監視する場合は `--strict` を付ける�
 
 - `/publish --upload` — 前工程。YouTube へのアップロード + live 移行（本スキルはその後の反映確認に使う）
 - `/publish` — 前工程。公開後に本 mode で反映状態を監査する
-- `/video --describe` — descriptions.md の生成・更新（修正の入口）
+- `/video --describe` — descriptions JSON+HTML pair の生成・更新（修正の入口）
 - `yt-bulk-update-synthetic-media` — 公開済み動画の `status.containsSyntheticMedia` が `false` のまま残っている場合に `True` へ一括是正する（#606、#603 是正前のアップロード分の遡及）
 - `pyproject.toml` の `yt-metadata-audit` entry point
 - `src/youtube_automation/commands/metadata/metadata_audit.py` — 実装本体

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -13,7 +13,7 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 ## 成果物
 
 - `書き込む`: `config/channel/playlists.json`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/20-documentation/community-post.txt`, `collections/<id>/workflow-state.json`, `pinned_comment_history.json`
-- `読み込む`: `config/channel/playlists.json`, `config/channel/content.json`, `auth/token.json`, `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/20-documentation/descriptions.md`, `config/channel/*.json`, `config/schedule_config.json`
+- `読み込む`: `config/channel/playlists.json`, `config/channel/content.json`, `auth/token.json`, `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, 検証済み `collections/<id>/20-documentation/descriptions.json`, `config/channel/*.json`, `config/schedule_config.json`
 
 ## Overview
 

--- a/.claude/skills/publish/references/posting-checklist.md
+++ b/.claude/skills/publish/references/posting-checklist.md
@@ -4,7 +4,7 @@
 
 - [ ] マスター動画（`01-master/00-master.mp4` または `03-Individual-movie/*master*.mp4`）
 - [ ] サムネイル（候補順: `10-assets/thumbnail.jpg` → `10-assets/thumbnail.png`。`main.png/jpg` は textless 動画背景なので使わない）
-- [ ] 概要欄（`20-documentation/descriptions.md` — `/video --describe` で生成済み）
+- [ ] 概要欄（検証済み `20-documentation/descriptions.json` + `.html` pair — `/video --describe` で生成済み）
 
 ## 初投稿プレイリスト確認
 

--- a/.claude/skills/publish/references/publish-chain-manifest.json
+++ b/.claude/skills/publish/references/publish-chain-manifest.json
@@ -22,7 +22,8 @@
       "skill": "publish",
       "prerequisiteArtifacts": [
         "collections/<id>/01-master/*.mp4",
-        "collections/<id>/20-documentation/descriptions.md"
+        "collections/<id>/20-documentation/descriptions.json",
+        "collections/<id>/20-documentation/descriptions.html"
       ],
       "outputArtifacts": [
         "collections/<id>/20-documentation/upload_tracking.json",

--- a/.claude/skills/publish/references/upload.md
+++ b/.claude/skills/publish/references/upload.md
@@ -8,8 +8,8 @@
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/20-documentation/descriptions.md`, `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`
-- `読み込む`: `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, `collections/<id>/20-documentation/descriptions.md`, `config/channel/*.json`, `config/schedule_config.json`
+- `書き込む`: `collections/<id>/20-documentation/upload_tracking.json`, `collections/<id>/workflow-state.json`
+- `読み込む`: `collections/<id>/01-master/*.mp4`, `collections/<id>/10-assets/thumbnail.jpg`, 検証済み `collections/<id>/20-documentation/descriptions.json`, `config/channel/*.json`, `config/schedule_config.json`
 
 ## Overview
 
@@ -110,7 +110,7 @@ $ARGUMENTS
 
 1. **マスター動画**: skill-config `preflight.master_video_globs`（既定 `01-master/*.mp4` → `03-Individual-movie/*master*.mp4`）の順に探索 — 存在しなければエラー終了
 2. **サムネイル**: skill-config `preflight.thumbnail_candidates`（既定 `10-assets/thumbnail.jpg` → `10-assets/thumbnail.png`）の候補順で探索 — いずれも存在しなければエラー終了。`main.png/jpg` は textless 動画背景なので upload thumbnail には使わない
-3. **概要欄**: `20-documentation/descriptions.md` — **存在しない場合は `/video --describe` を実行して自動生成する**（対象コレクションパスを引き継ぐ）。生成完了後にアップロードフローへ進む
+3. **概要欄**: `20-documentation/descriptions.json` + `.html` pair — **存在しない場合は `/video --describe` を実行して自動生成する**（対象コレクションパスを引き継ぐ）。schema・quality・pair照合の完了後だけアップロードフローへ進む
 4. **初投稿時のプレイリスト初期化**: `config/channel/playlists.json` が存在する場合は `/publish --playlist` で `uv run yt-playlist-status` を実行する。`(未作成)` があるときは、初投稿前に `uv run yt-playlist-manager --init --dry-run` → ユーザー確認 → `uv run yt-playlist-manager --init` で playlist ID を作成・書き戻してからアップロードへ進む
 
 ### collection アップロードフロー
@@ -119,13 +119,13 @@ $ARGUMENTS
 
 0. **公開タイミング確定（必須）** — ユーザーに公開方法を案内・確認する前に必ず `uv run yt-upload-collection --plan [-c NAME]` を実行し、実際の公開挙動を確定する。`config/schedule_config.json` の予約設定や `config/channel/youtube.json` の既定時刻により、予約公開または非公開アップロードになるため、plan 結果をそのまま案内する
    - この turn でユーザーが即時公開を指定しても、アップローダーは即時公開しない。予約設定を追加して再 plan するか、非公開でアップロード後に YouTube Studio で手動公開するかを人間に選んでもらう。会話を黙って durable config で上書きしない
-1. **Complete Collection アップロード** — マスター動画、メタデータ（descriptions.md から読み込み）、サムネイル設定
+1. **Complete Collection アップロード** — マスター動画、メタデータ（検証済み descriptions.json から読み込み）、サムネイル設定
 2. **live 移動** — `collections/planning/` → `collections/live/`
 3. **公開後処理** — フラグなし chain では upload 完了後も manifest 順の `community → pinned` を続行する。各段の承認と成果物ベースの再開契約に委ね、ここで個別処理を再実装しない。`/publish --upload` の単独 mode では後段を暗黙実行せず、`/publish --community`、`/publish --pinned`、`/audit --metadata` は必要に応じて独立実行する
 
-メタデータは `descriptions.md` から title / description / tags を優先使用。存在しない場合は `BAHMetadataGenerator` で自動生成にフォールバック。
+メタデータは共通readerで検証した `descriptions.json` の title / description / tags / localizations だけを使用する。HTMLや旧Markdownはparseせず、pair欠損・schema/quality不正時はfallbackせず停止する。
 
-承認済みタイトルを 100 codepoint 以下へ短縮する必要が生じた場合は、旧版と短縮案を codepoint 数付き diff として提示し、ユーザーの再承認を得るまで `descriptions.md` の更新や upload を行わない。`--plan` は primary title だけでなく生成済み全 locale title を検証し、超過 locale を言語・文字数・実タイトル付きで fail-loud にする。
+承認済みタイトルを 100 codepoint 以下へ短縮する必要が生じた場合は、旧版と短縮案を codepoint 数付き diff として提示し、ユーザーの再承認を得るまで `descriptions.json` pair の更新や upload を行わない。`--plan` は primary title だけでなく保存済み全 locale title を検証し、超過 locale を言語・文字数・実タイトル付きで fail-loud にする。
 
 プレイリストへの動画追加は後続のアップロード経路が担う。`collection` 型では `collection_uploader` 内部の `assign_video()` に任せる。初投稿時に `/publish --playlist` で行うのは未作成プレイリストの作成と `playlist_id` 書き戻しであり、個別動画の手動 assign ではない。
 
@@ -211,7 +211,7 @@ uv run yt-upload-collection --plan -c <NAME>
 
 ## Cross References
 
-- `/video --describe` — アップロード前に descriptions.md を生成
+- `/video --describe` — アップロード前に descriptions.json + HTML pair を生成
 - `/publish --playlist` — 初投稿前のプレイリスト初期化、状態確認、手動 assign、クリーンアップ（アップロード時の自動 assign は本スキル内で実行される）
 - `/audit --metadata` — アップロード後のローカル ↔ YouTube 整合性監査
 - `/publish` — playlist → upload → community → pinned を承認・状態判定付きで実行

--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -332,7 +332,7 @@ minimal mode / benchmark fallback mode は新規チャンネル初回制作を�
 
 #### `initial_setup_readiness` — 初期セットアップ事前検査
 
-`config/skills/thumbnail.yaml` / `config/skills/music.yaml::prompt` の空欄・不備（reference_images / composition_rules の未設定、`genre_line` の文字数超過など）と、planning 中コレクションの `descriptions.md` parse 失敗を warn として一括検出する。`yt-doctor` の `next_action` に従い、開設時の初期転記は `/setup --channel`、開設後の再転記は `/setup --regenerate` 、descriptions.md の再生成は `/video --describe` を案内する。config 未転記の新規チャンネルでは `/setup --channel` 完了までの正常な中間状態として扱う。
+`config/skills/thumbnail.yaml` / `config/skills/music.yaml::prompt` の空欄・不備（reference_images / composition_rules の未設定、`genre_line` の文字数超過など）と、planning 中コレクションの `descriptions.json` schema / localization / quality / HTML pair 不整合、旧 `descriptions.md` の未移行を warn として一括検出する。`yt-doctor` の `next_action` に従い、開設時の初期転記は `/setup --channel`、開設後の再転記は `/setup --regenerate`、動画説明 pair の再生成・明示 migration は `/video --describe` を案内する。config 未転記の新規チャンネルでは `/setup --channel` 完了までの正常な中間状態として扱う。
 
 ### upload カテゴリ
 

--- a/.claude/skills/setup/references/config-generation-rules.md
+++ b/.claude/skills/setup/references/config-generation-rules.md
@@ -141,7 +141,7 @@
 
 設定生成後は `uv run yt-doctor` を実行し、`initial_setup_readiness` が OK であることを確認する。
 ここで `reference_images.default` / `composition_rules` の空欄・TBD、Suno `genre_line` の
-Style 欄 120 文字超過、planning 中 `descriptions.md` の parser 不一致を公開前に検出できる。
+Style 欄 120 文字超過、planning 中 `descriptions.json` の schema / localization / quality / HTML pair 不整合と旧 Markdown の未移行を公開前に検出できる。
 
 ## オプションセクション
 

--- a/.claude/skills/short/references/collection.md
+++ b/.claude/skills/short/references/collection.md
@@ -9,7 +9,7 @@
 
 ## ハイライトとクロップを決める
 
-`20-documentation/descriptions.md` のチャプターから `config.shorts.collection.default_count` 本を提案する。各チャプター先頭から skill-config の `collection.chapter_offset_sec` 秒後を初期値にし、ユーザーに本数・区間を確認する。
+検証済み `20-documentation/descriptions.json` + 同 basename HTML pair の `tracks` から `config.shorts.collection.default_count` 本を提案する。各チャプター先頭から skill-config の `collection.chapter_offset_sec` 秒後を初期値にし、ユーザーに本数・区間を確認する。
 
 `loop.mp4` の場合は次を実行し、中央 / x=400 / x=350 のテストフレームからクロップ位置を確認する。
 

--- a/.claude/skills/video/SKILL.md
+++ b/.claude/skills/video/SKILL.md
@@ -12,7 +12,7 @@ description: "Use when 音源と画像からマスター動画と YouTube 概要
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/01-master/*.mp4`, `collections/<id>/20-documentation/descriptions.md`, `collections/<id>/workflow-state.json`
+- `書き込む`: `collections/<id>/01-master/*.mp4`, `collections/<id>/20-documentation/descriptions.json`, `collections/<id>/20-documentation/descriptions.html`, `collections/<id>/workflow-state.json`
 - `読み込む`: `collections/<id>/01-master/<master-audio>`, `collections/<id>/10-assets/main.png`, `collections/<id>/10-assets/main.jpg`, `collections/<id>/10-assets/loop.mp4`, 検証済み `collections/<id>/20-documentation/suno-prompts.json`, `data/benchmark_*.json`, 検証済み `docs/benchmarks/benchmark-report.json`, `config/channel/*.json`, `config/skills/video.yaml`
 
 ## モード判定
@@ -63,4 +63,4 @@ uv run python .claude/skills/video/references/video-chain-state.py \
 - `--generate`: `references/generate.md` の完了条件を満たし、他 mode を実行していない
 - `--describe`: `references/describe.md` の完了条件を満たし、他 mode を実行していない
 
-実行段、skip 段、生成した master video / descriptions.md のパスを短く報告する。
+実行段、skip 段、生成した master video / descriptions.json + descriptions.html pair のパスを短く報告する。

--- a/.claude/skills/video/references/describe.md
+++ b/.claude/skills/video/references/describe.md
@@ -6,9 +6,9 @@
 
 ## 完了条件
 
-- 品質チェック（後述チェックリスト）の全項目を満たした概要欄・タイトル案・タグが `20-documentation/descriptions.md` に保存されている
+- 品質チェック（後述チェックリスト）の全項目を満たした概要欄・タイトル案・タグ・localization が、schema準拠の `20-documentation/descriptions.json` と同basename HTML pairに保存されている
 - `uv run yt-title-duplicate-check` を実行し、100 codepoint 超過が無く、重複 warning はこの段階で見直し済み
-- owner CLI の `uv run yt-workflow-state --collection <collection-path> set-description-generated true` が成功し、`assets.description = true` が保存済み
+- pair再読込後に owner CLI の `uv run yt-workflow-state --collection <collection-path> set-description-generated true` が成功し、`assets.description = true` が保存済み
 
 ## 設定読み込みゲート
 
@@ -151,7 +151,7 @@ skill-config (`.claude/skills/video/config.default.yaml::describe` / 上書き `
 
 タイトル案を決めたら、まず **100 codepoint 以内**であることを確認する（YouTube タイトル上限。超過は upload preflight で必ず fail するため、この段階で RHS の修飾語を削って短縮する。用途語・尺表記・テーマ語は残す）。
 
-続けて、`descriptions.md` に保存する前に過去 live タイトルとの重複 warning を確認する（`yt-title-duplicate-check` は 100 codepoint 超過も検出し、超過時は `--strict` に関係なく exit 1 になる）:
+続けて、candidate JSON を公開する前に過去 live タイトルとの重複 warning を確認する（`yt-title-duplicate-check` は 100 codepoint 超過も検出し、超過時は `--strict` に関係なく exit 1 になる）:
 
 ```bash
 uv run yt-title-duplicate-check "$COLLECTION_DIR" --title "$PROPOSED_TITLE"
@@ -179,7 +179,7 @@ uv run yt-title-duplicate-check "$COLLECTION_DIR" --title "$PROPOSED_TITLE"
 
 ### Cards（YouTube Studio で手動設定）
 
-概要欄生成時に、カードセクションも descriptions.md に含める。設定は skill-config の `cards` セクション参照。
+概要欄生成時に、カードセクションも `description_sections` に含める。設定は skill-config の `cards` セクション参照。
 
 - **カード種類**: 動画カード（Video card）のみ
 - **枚数**: **1動画1枚**（最小限運用）
@@ -200,11 +200,13 @@ uv run yt-title-duplicate-check "$COLLECTION_DIR" --title "$PROPOSED_TITLE"
 
 ### 概要欄保存
 
-概要欄は必ずコレクションの `20-documentation/descriptions.md` に保存する。
-保存フォーマット（ヘッダー、概要欄本文、タイトル案、タグ、Cards、品質チェック）は
-`references/description-templates.md` の「descriptions.md 保存フォーマット」セクションを参照すること。
+概要欄candidateは `video-description.schema.json` の title / description / description_sections /
+tracks / tags / localizations / provenance / quality に写像する。表示順とSEO本文は既存生成結果を変えない。
+公開・既存Markdown移行・rollback・state投影は `video-description-documents.md` の共通writer契約に従う。
+upload consumerは検証済みJSONだけを読み、HTMLやlegacy Markdownをparseしない。
 
-保存後、`uv run yt-workflow-state --collection <collection-path> set-description-generated true` を実行し、正準キー `assets.description = true` を保存する。
+pair の再読込検証後、`uv run yt-workflow-state --collection <collection-path> set-description-generated true`
+を実行し、正準キー `assets.description = true` を保存する。検証またはCLI更新が失敗した場合は完了扱いにしない。
 
 ## 障害時ガイダンス
 

--- a/.claude/skills/video/references/description-templates.md
+++ b/.claude/skills/video/references/description-templates.md
@@ -1,6 +1,6 @@
 # description スキル テンプレート集
 
-`description` スキルが出力する YouTube 概要欄のテンプレート本文と、コレクション内 `descriptions.md` の保存フォーマットをまとめる。
+`video --describe` が出力する YouTube 概要欄のテンプレート本文と、コレクション内 `descriptions.json` pair の保存フォーマットをまとめる。
 
 テンプレート更新時はこのファイルのみを編集すれば SKILL.md 本体は差し替え不要。
 
@@ -64,56 +64,18 @@ XX:XX [Track 1 of pattern B]
 
 ---
 
-## descriptions.md 保存フォーマット
+## descriptions.json 保存フォーマット
 
-概要欄生成結果はコレクションの `20-documentation/descriptions.md` に以下の構成で保存する。
+概要欄生成結果は `video-description.schema.json` 準拠の candidate JSON に写像し、
+`video-description-documents.md` の共通writerで `20-documentation/descriptions.json` + `.html` pair として公開する。
 
-````markdown
-# [Collection Name] — YouTube 概要欄
+- `title`: 承認済み公開タイトル
+- `description`: このreferenceで組み立てた最終SEO本文を改変せず保存
+- `description_sections`: 冒頭、track list、Perfect for、CTA、Cards等を最終表示順で保存
+- `tracks`: position / start / title を構造化
+- `tags`: YouTubeタグを文字列arrayで保存
+- `localizations`: localeごとの最終title / description
+- `provenance`: producer=`video` と入力source path
+- `quality`: checklist各項目と総合status。全件pass以外は公開しない
 
-*生成日: YYYY-MM-DD*
-*トラック数: N / 総時間: Xh Xm Xs*
-
----
-
-## Complete Collection 概要欄
-
-```
-[概要欄本文]
-```
-
----
-
-## タイトル案
-
-```
-[タイトル]
-```
-
----
-
-## タグ（YouTube タグ欄）
-
-```
-[タグリスト]
-```
-
----
-
-## Cards (YouTube Studio で手動設定)
-
-```
-Card ([タイミング]): "[ティーザーメッセージ]" → [リンク先動画タイトル]
-```
-
----
-
-## 品質チェック
-
-- [x] 誇張表現なし
-- [x] AI 透明性あり
-- [x] チャンネル CTA 含む
-- [x] ハッシュタグ 13個
-- [x] モバイル読みやすさ
-- [x] カードセクション含む
-````
+HTMLは同じschemaの `x-view` から生成し、最終表示順、文字数、localization差分、quality結果の確認に使う。

--- a/.claude/skills/video/references/video-chain-manifest.json
+++ b/.claude/skills/video/references/video-chain-manifest.json
@@ -21,7 +21,10 @@
       "id": "describe",
       "skill": "video",
       "prerequisiteArtifacts": ["collections/<id>/01-master/master.mp4"],
-      "outputArtifacts": ["collections/<id>/20-documentation/descriptions.md"],
+      "outputArtifacts": [
+        "collections/<id>/20-documentation/descriptions.json",
+        "collections/<id>/20-documentation/descriptions.html"
+      ],
       "approvalGate": {
         "skip": true,
         "configPath": "workflow.video.skip_approvals.describe"

--- a/.claude/skills/video/references/video-chain-state.py
+++ b/.claude/skills/video/references/video-chain-state.py
@@ -9,6 +9,9 @@ import sys
 from pathlib import Path
 from typing import TypedDict
 
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
+
 EXIT_SKIP = 0
 EXIT_RUN = 10
 EXIT_BLOCKED = 20
@@ -79,11 +82,20 @@ def evaluate(collection: Path, step: str) -> tuple[int, StateResult]:
     if step == "generate":
         return EXIT_SKIP, _result(step, "skip", "master_video_exists", [relative.as_posix()])
 
-    description = state.get("description")
-    generated = isinstance(description, dict) and description.get("generated") is True
-    output = collection / "20-documentation" / "descriptions.md"
+    assets = state.get("assets")
+    generated = isinstance(assets, dict) and assets.get("description") is True
+    output = collection / "20-documentation" / "descriptions.json"
     if generated and output.is_file():
-        return EXIT_SKIP, _result(step, "skip", "description_exists", ["20-documentation/descriptions.md"])
+        try:
+            read_video_description_metadata(output)
+        except ValidationError:
+            return EXIT_RUN, _result(step, "run", "description_pair_invalid", [])
+        return EXIT_SKIP, _result(
+            step,
+            "skip",
+            "description_exists",
+            ["20-documentation/descriptions.json", "20-documentation/descriptions.html"],
+        )
     return EXIT_RUN, _result(step, "run", "description_incomplete", [])
 
 
@@ -99,7 +111,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
         code, result = evaluate(args.collection_dir, args.step)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
+    except (OSError, ValueError, ValidationError, json.JSONDecodeError) as exc:
         code = EXIT_ERROR
         result = _result(args.step, "error", str(exc), [])
     json.dump(result, sys.stdout, ensure_ascii=False, indent=2 if args.pretty else None)

--- a/.claude/skills/video/references/video-description-documents.md
+++ b/.claude/skills/video/references/video-description-documents.md
@@ -1,0 +1,23 @@
+# 動画説明の構造化文書契約
+
+`/video --describe` の正本は `video-description.schema.json` 準拠の
+`20-documentation/descriptions.json` と、同 basename の `descriptions.html` pair とする。
+JSON は title、最終 description、表示順の section、track list、tags、localizations、provenance、
+quality check を保持する。HTML は人間確認専用で、upload / metadata consumer は parse しない。
+
+生成内容は公開先とは別の candidate JSON に保存し、全 quality check を `pass` にしてから次を実行する。
+
+```bash
+uv run yt-document-migrate <candidate.json> \
+  --target <collection-path>/20-documentation/descriptions.json \
+  --schema video-description.schema.json \
+  --workflow-state <collection-path>/workflow-state.json
+```
+
+既存 `descriptions.md` がある場合は、利用者へ移行の Yes / No を確認する。Yes の場合だけ
+`--migration-decision yes`、No の場合は `--migration-decision no` を指定する。pair の schema 検証、
+HTML 再生成照合、JSON/HTML 再読込が成功した後だけ Markdown を削除し、workflow-state owner 経由で
+`assets.description = true` にする。失敗時は旧 Markdown、pair、state を rollback する。
+
+localization の必須値、title 上限、quality status / 各 check のいずれかが不正なら公開しない。
+公開済み pair の片方欠損・改変も state / preflight / upload を成功扱いにしない。

--- a/.claude/skills/video/references/video-description.schema.json
+++ b/.claude/skills/video/references/video-description.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "video-description.schema.json",
+  "title": "動画説明・公開準備文書",
+  "description": "video が生成し publish が読む title / description / localization の JSON 正本。",
+  "type": "object",
+  "required": ["schema_version", "generated_at", "collection_id", "title", "description", "description_sections", "tracks", "tags", "localizations", "provenance", "quality"],
+  "properties": {
+    "schema_version": {"title": "Schema version", "const": 1, "x-view": {"order": 0}},
+    "generated_at": {"title": "生成日時", "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$", "x-view": {"order": 1}},
+    "collection_id": {"title": "Collection", "type": "string", "minLength": 1, "x-view": {"order": 2}},
+    "title": {"title": "公開タイトル", "type": "string", "minLength": 1, "maxLength": 100, "x-view": {"order": 10}},
+    "description": {"title": "最終概要欄", "type": "string", "minLength": 1, "x-view": {"order": 20, "presentation": "card"}},
+    "description_sections": {"title": "概要欄セクション", "type": "array", "minItems": 1, "items": {"$ref": "#/definitions/section"}, "x-view": {"order": 30, "presentation": "table"}},
+    "tracks": {"title": "Track list", "type": "array", "items": {"$ref": "#/definitions/track"}, "x-view": {"order": 40, "presentation": "table"}},
+    "tags": {"title": "YouTube tags", "type": "array", "items": {"type": "string", "minLength": 1}, "x-view": {"order": 50}},
+    "localizations": {"title": "Localization diff", "type": "object", "propertyNames": {"pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"}, "additionalProperties": {"$ref": "#/definitions/localization"}, "x-view": {"order": 60, "presentation": "card"}},
+    "provenance": {"title": "Provenance", "$ref": "#/definitions/provenance", "x-view": {"order": 70}},
+    "quality": {"title": "Quality checks", "$ref": "#/definitions/quality", "x-view": {"order": 80, "presentation": "card"}}
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "section": {
+      "type": "object",
+      "required": ["id", "heading", "body"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z][a-z0-9_-]*$"},
+        "heading": {"type": "string", "minLength": 1},
+        "body": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    },
+    "track": {
+      "type": "object",
+      "required": ["position", "start", "title"],
+      "properties": {
+        "position": {"type": "integer", "minimum": 1},
+        "start": {"type": "string", "pattern": "^[0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?$"},
+        "title": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    },
+    "localization": {
+      "type": "object",
+      "required": ["title", "description"],
+      "properties": {
+        "title": {"type": "string", "minLength": 1, "maxLength": 100},
+        "description": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["producer", "source_paths"],
+      "properties": {
+        "producer": {"const": "video"},
+        "source_paths": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      },
+      "additionalProperties": true
+    },
+    "quality_check": {
+      "type": "object",
+      "required": ["id", "status", "message"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "status": {"enum": ["pass", "fail"]},
+        "message": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    },
+    "quality": {
+      "type": "object",
+      "required": ["status", "checks"],
+      "properties": {
+        "status": {"enum": ["pass", "fail"]},
+        "checks": {"type": "array", "minItems": 1, "items": {"$ref": "#/definitions/quality_check"}}
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -141,7 +141,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 | `raw_master` | string / null | 自動生成された raw master のファイル名（/music --master or /music --generate 出力） |
 | `master_audio` | string / null | ユーザーがミキシング+マスタリングした最終マスターのファイル名。`workflow.wf_next.skip_manual_mastering: true`（raw=final 運用）のチャンネルでは `/wf-next` が `raw_master` と同じファイル名を自動設定する。`workflow.wf_next.skip_audio_approval: false`（`wf_next` の boolean は全て true=手動工程を省く向き）のチャンネルでは確定前に `/wf-next` が承認を取る |
 | `master_video` | string / null | 生成されたマスター動画のファイル名 |
-| `description` | boolean | YouTube 概要欄生成済み（`20-documentation/descriptions.md`） |
+| `description` | boolean | YouTube 概要欄の検証済み JSON+HTML pair 生成済み（`20-documentation/descriptions.{json,html}`） |
 
 `music_downloaded: true` かつ `raw_master: null` は、Suno 楽曲が DL 済みで raw master（クロスフェード結合出力）が未生成の中間状態を表す。
 

--- a/.claude/skills/wf-new/references/wf-auto-state.py
+++ b/.claude/skills/wf-new/references/wf-auto-state.py
@@ -20,9 +20,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, TypedDict
 
-from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 
 STATE_DIR_NAME = ".automation-run"
 LEASE_DIR_NAME = "lease"
@@ -577,11 +578,13 @@ def _completed_tracking_matches(collection: Path, video_id: str) -> bool:
 def _local_publish_artifacts_complete(collection: Path, assets: dict) -> bool:
     video = assets.get("master_video")
     description = assets.get("description")
-    return (
-        _artifact_file(collection, "01-master", video)
-        and description is True
-        and (collection / "20-documentation" / "descriptions.md").is_file()
-    )
+    if not (_artifact_file(collection, "01-master", video) and description is True):
+        return False
+    try:
+        read_video_description_metadata(collection / "20-documentation" / "descriptions.json")
+    except ValidationError:
+        return False
+    return True
 
 
 def _publish_followup_complete(root: Path, collection: Path, video_id: str) -> bool:

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -12,7 +12,9 @@ description: "Use when 既存コレクション（collections/planning/）を一
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/descriptions.md`, `collections/<id>/20-documentation/upload_tracking.json`
+- `書き込む`: `collections/<id>/workflow-state.json`, `collections/<id>/20-documentation/upload_tracking.json`
+
+動画説明 JSON+HTML pair の書き込みは `/video --describe` owner へ委譲する。
 - `読み込む`: `collections/<id>/workflow-state.json`, `collections/<id>/01-master/*`, `collections/<id>/10-assets/*`, `config/channel/workflow.json`
 
 ## Overview
@@ -227,7 +229,7 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 
 1. **並列 A**（2 Agent 同時起動）:
    - Agent 1: 対象 collection、`01-master/<assets.master_audio>`、`10-assets/main.png/jpg` または `loop.mp4` を入力に Skill `/video --generate` の Subagent Contract を実行。thumbnail skill-config も渡し、`textless.enabled: false` の共有 `main.jpg` を textless 再生成へ戻さない。期待成果物は `01-master/*.mp4`
-   - Agent 2 の起動前に、メインが `/video --describe` の重複トラック名を検出し、必要な表示名 mapping を確定するが、まだ `apply_track_display_names()` は呼ばない。その mapping、planning / localization、skill-config、benchmark 入力を列挙し、Agent 2 には `/video --describe` の Step 1 から品質チェック、`yt-title-duplicate-check`、`20-documentation/descriptions.md` 保存までを実行させる。`apply_track_display_names()` と `workflow-state.json` の `assets.description` 更新は実行させない
+   - Agent 2 の起動前に、メインが `/video --describe` の重複トラック名を検出し、必要な表示名 mapping を確定するが、まだ `apply_track_display_names()` は呼ばない。その mapping、planning / localization、skill-config、benchmark 入力を列挙し、Agent 2 には `/video --describe` の Step 1 から品質チェック、`yt-title-duplicate-check`、検証済み `20-documentation/descriptions.json` + 同 basename HTML 保存までを実行させる。`apply_track_display_names()` と `workflow-state.json` の `assets.description` 更新は実行させない
    - 両 Agent とも state は入力確認に必要な範囲だけ読み、書き込まず、AskUserQuestion を実行しない。片方でも失敗または成果物欠落なら state を更新せず停止する
 2. 並列 A 完了後:
    - メインが両成果物の存在と `phase: "mastered"` との整合を確認する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(workspace)`: workspace 全チャンネルの登録者数・総再生回数・動画数を YouTube `channels.list` 1 request で取得する `yt-workspace-status` を追加する（#4116）。
 - `feat(music)`: `music_engine: minimax` と長尺 instrumental master生成CLIを追加し、`/music --generate` の第3経路へ統合する（#4120）。
 - `feat(media)`: MiniMax の音楽・動画生成で共有する Bearer 認証 JSON client と `MINIMAX_API_KEY` の secret 解決経路を追加する（#4119）。
+- `feat(documents)`: 動画説明・公開準備文書を title / sections / tracks / localization / provenance / quality 付き JSON 正本とHTML表示へ移し、upload・metadata・字幕を validated JSON-only かつ fail-closed に統一する（#4030）。
 - `feat(skills)`: `yt-skills lint` が downstream 配布対象 skill を実 inventory から数え、開発専用と `SKILL.md` のない残骸を除外した総数を上限 19 件で ratchet する（#3805）。
 - `feat(skills)`: `yt-skills lint` が委譲深さ 2 以上を最長経路つきで拒否し、既存違反だけを報告付き allowlist として段階解消できる契約を追加する（#3799）。
 - `feat(doctor)`: `ttp_wf_new_readiness` が最終ペルソナの必須9セクション、非空本文、最終化、構造化項目の出典注記を検証し、不足時は `/channel-strategy --persona` へ戻す（#4000）。

--- a/src/youtube_automation/application/documents/__init__.py
+++ b/src/youtube_automation/application/documents/__init__.py
@@ -11,13 +11,19 @@ from youtube_automation.application.documents.music_prompt import (
     require_recorded_machine_verification,
     write_music_prompt_document,
 )
+from youtube_automation.application.documents.video_description import (
+    read_video_description_metadata,
+    write_video_description_document,
+)
 
 __all__ = [
     "DocumentWriteResult",
     "MarkdownMigrationDecision",
+    "read_video_description_metadata",
     "require_recorded_machine_verification",
     "write_channel_strategy_document",
     "write_collection_plan_document",
     "write_music_prompt_document",
     "write_operational_document",
+    "write_video_description_document",
 ]

--- a/src/youtube_automation/application/documents/video_description.py
+++ b/src/youtube_automation/application/documents/video_description.py
@@ -1,0 +1,68 @@
+"""動画説明 pair の品質 gate、reader、workflow-state 投影。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from youtube_automation.application.documents.migration import (
+    DocumentWriteResult,
+    MarkdownMigrationDecision,
+    write_operational_document,
+)
+from youtube_automation.core.errors import DocumentMigrationError
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
+from youtube_automation.domains.documents.schema_registry import RepositorySchema, validate_repository_document
+from youtube_automation.domains.documents.video_description import (
+    read_video_description_metadata as _read_video_description_metadata,
+)
+from youtube_automation.domains.documents.video_description import (
+    require_quality_pass,
+)
+from youtube_automation.infrastructure.documents.publishing import read_published_json_document
+
+
+def write_video_description_document(
+    json_path: Path,
+    workflow_state_path: Path,
+    build_document: Callable[[], object],
+    migration_decision: MarkdownMigrationDecision,
+) -> DocumentWriteResult:
+    """検証済み description pair の公開後だけ description state を完了する。"""
+    if json_path.name != "descriptions.json":
+        raise DocumentMigrationError("動画説明正本の filename は descriptions.json である必要があります")
+
+    def build_and_validate() -> object:
+        document = build_document()
+        validate_repository_document(RepositorySchema.VIDEO_DESCRIPTION, document)
+        require_quality_pass(document)
+        return document
+
+    result = write_operational_document(
+        json_path,
+        RepositorySchema.VIDEO_DESCRIPTION,
+        build_and_validate,
+        migration_decision,
+    )
+    if result is DocumentWriteResult.DECLINED:
+        return result
+    persisted = read_published_json_document(json_path, RepositorySchema.VIDEO_DESCRIPTION)
+    require_quality_pass(persisted)
+
+    def project(state):
+        assets = state.assets
+        if assets is None:
+            state["assets"] = {}
+            assets = state.assets
+        if assets is None:
+            raise DocumentMigrationError("workflow-state.json::assets を初期化できません")
+        assets.description = True
+        return state
+
+    update_workflow_state(workflow_state_path, project)
+    return result
+
+
+def read_video_description_metadata(json_path: Path) -> dict[str, object]:
+    """domain-owned validated reader の application facade。"""
+    return _read_video_description_metadata(json_path)

--- a/src/youtube_automation/commands/documents/migrate.py
+++ b/src/youtube_automation/commands/documents/migrate.py
@@ -13,6 +13,7 @@ from youtube_automation.application.documents import (
     write_collection_plan_document,
     write_music_prompt_document,
     write_operational_document,
+    write_video_description_document,
 )
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ValidationError
@@ -67,9 +68,13 @@ def run(args: argparse.Namespace) -> int:
             decision,
             machine_verify=require_recorded_machine_verification,
         )
+    elif schema is RepositorySchema.VIDEO_DESCRIPTION:
+        if args.workflow_state is None:
+            raise ValidationError("video description の公開には --workflow-state が必要です")
+        result = write_video_description_document(args.target, args.workflow_state, load_candidate, decision)
     else:
         if args.workflow_state is not None:
-            raise ValidationError("--workflow-state は collection plan / music prompt 専用です")
+            raise ValidationError("--workflow-state は collection plan / music prompt / video description 専用です")
         result = write_operational_document(args.target, schema, load_candidate, decision)
     print(f"{result.value}: {args.target.resolve()}")
     return 0

--- a/src/youtube_automation/commands/metadata/bulk_update_descriptions.py
+++ b/src/youtube_automation/commands/metadata/bulk_update_descriptions.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Push descriptions.md content to YouTube via videos().update(part='snippet').
+"""Push validated descriptions.json content to YouTube via videos().update(part='snippet').
 
 For each collection discovered under ``collections/live/`` that has both
-``20-documentation/descriptions.md`` and ``20-documentation/upload_tracking.json``,
+``20-documentation/descriptions.json`` + same-basename HTML and ``upload_tracking.json``,
 read its 'Complete Collection 概要欄' and 'タイトル案' sections from
-descriptions.md, and update the corresponding YouTube video's snippet
+validated JSON pair, and update the corresponding YouTube video's snippet
 (title, description, tags, categoryId).
 
 The required video_id is read from
@@ -27,13 +27,9 @@ from googleapiclient.errors import HttpError
 
 from youtube_automation.configuration import channel_dir
 from youtube_automation.core.errors import YouTubeAPIError
-from youtube_automation.domains.metadata.descriptions import (
-    build_descriptions_md_parse_diagnostics,
-    extract_descriptions_md_section,
-)
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.infrastructure.cost_tracker import log_quota
 from youtube_automation.infrastructure.google.youtube import create_authenticated_youtube_clients
-from youtube_automation.infrastructure.youtube.youtube_tag import parse_youtube_tags
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +73,7 @@ def build_snippet_update_body(video_id: str, old_snippet: dict, title: str, desc
 def discover_collections() -> list[str]:
     """``collections/live/*`` から description 更新可能な collection 名を返す.
 
-    `20-documentation/descriptions.md` と `20-documentation/upload_tracking.json`
+    検証済み `20-documentation/descriptions.json` + 同 basename HTML と `upload_tracking.json`
     が **両方** 存在する collection のみを対象とする（silent skip）.
     戻り値は決定論的な `sorted()` 順.
     """
@@ -88,16 +84,12 @@ def discover_collections() -> list[str]:
     results: list[str] = []
     for col_dir in sorted(live_dir.iterdir()):
         doc_dir = col_dir / "20-documentation"
-        if not (doc_dir / "descriptions.md").exists():
+        if not (doc_dir / "descriptions.json").exists():
             continue
         if not (doc_dir / "upload_tracking.json").exists():
             continue
         results.append(col_dir.name)
     return results
-
-
-def extract_md_section(md_text: str, header: str) -> str | None:
-    return extract_descriptions_md_section(md_text, header)
 
 
 def utf16_units(s: str) -> int:
@@ -126,29 +118,19 @@ def _execute_youtube_request(
 
 def load_collection(col: str) -> dict:
     col_dir = channel_dir() / "collections" / "live" / col
-    desc_md = (col_dir / "20-documentation" / "descriptions.md").read_text(encoding="utf-8")
+    metadata = read_video_description_metadata(col_dir / "20-documentation" / "descriptions.json")
     upload_tracking = json.loads((col_dir / "20-documentation" / "upload_tracking.json").read_text(encoding="utf-8"))
     cc = upload_tracking.get("complete_collection") or {}
     video_id = cc.get("video_id")
     if not video_id:
         raise RuntimeError(f"no complete_collection.video_id in {col}")
 
-    description = extract_md_section(desc_md, "Complete Collection 概要欄")
-    title = extract_md_section(desc_md, "タイトル案")
-    tags_raw = extract_md_section(desc_md, "タグ（YouTube タグ欄）")
-    tags = []
-    if tags_raw:
-        tags = parse_youtube_tags(tags_raw)
-
-    if not (description and title):
-        raise RuntimeError(f"descriptions.md parse failed in {col}\n{build_descriptions_md_parse_diagnostics(desc_md)}")
-
     return {
         "collection": col,
         "video_id": video_id,
-        "title": title,
-        "description": description,
-        "tags": tags,
+        "title": metadata["title"],
+        "description": metadata["description"],
+        "tags": metadata["tags"],
     }
 
 
@@ -156,7 +138,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     parser = argparse.ArgumentParser(
         description=(
-            "descriptions.md の内容を YouTube 上の公開済み動画の概要欄へ一括書き込みする（通常実行は API write）"
+            "検証済み descriptions.json の内容を YouTube 上の公開済み動画の概要欄へ一括書き込みする"
+            "（通常実行は API write）"
         )
     )
     parser.add_argument(

--- a/src/youtube_automation/commands/metadata/metadata_audit.py
+++ b/src/youtube_automation/commands/metadata/metadata_audit.py
@@ -6,11 +6,11 @@ quality bar enforced by the upload PreflightChecker, plus
 remote-side checks against YouTube API.
 
 Run periodically (or after upload) to detect drift between local
-descriptions.md and what's actually live on YouTube.
+validated descriptions.json pairs and what's actually live on YouTube.
 
 Usage:
     python3 automation/metadata_audit.py             # local + remote
-    python3 automation/metadata_audit.py --local     # only descriptions.md
+    python3 automation/metadata_audit.py --local     # only validated descriptions pair
     python3 automation/metadata_audit.py --remote    # only YouTube API
     python3 automation/metadata_audit.py --strict    # exit 1 on any issue
 """
@@ -27,10 +27,10 @@ from pathlib import Path
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.configuration.model import ChannelConfig
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.domains.metadata.descriptions import (
-    build_descriptions_md_parse_diagnostics,
     extract_descriptions_md_section,
 )
 from youtube_automation.domains.uploads.preflight import (
@@ -40,7 +40,6 @@ from youtube_automation.domains.uploads.preflight import (
     check_tags_count,
     check_tags_yt_chars,
     check_title_codepoint_limit,
-    extract_descriptions_md_tags,
     requires_scene_phrases,
 )
 from youtube_automation.infrastructure import cost_tracker
@@ -98,44 +97,32 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     supported_langs = list(config.localizations.supported_languages)
     paths = CollectionPaths(col)
 
-    desc_md = paths.descriptions_md_path
+    desc_json = paths.descriptions_json_path
     stray = list(paths.docs_dir.glob("description*"))
-    stray = [p for p in stray if p.name != "descriptions.md"]
+    stray = [p for p in stray if p.name not in {"descriptions.json", "descriptions.html"}]
     if stray:
         issues.append(f"stray description file(s): {[p.name for p in stray]}")
 
-    if not desc_md.exists():
-        issues.append("descriptions.md missing")
+    if not desc_json.exists():
+        issues.append("descriptions.json missing")
         return issues
+    try:
+        metadata = read_video_description_metadata(desc_json)
+    except ValidationError as error:
+        issues.append(f"descriptions.json invalid: {error}")
+        return issues
+    title = str(metadata["title"])
+    description = str(metadata["description"])
 
-    text = desc_md.read_text(encoding="utf-8")
-    title_raw = extract_section(text, "タイトル案")
-    description_raw = extract_section(text, "Complete Collection 概要欄")
-    if title_raw is None or description_raw is None:
-        issues.append("descriptions.md parse failed\n" + build_descriptions_md_parse_diagnostics(text))
-
-    title = title_raw.strip() if title_raw is not None else ""
-    description = description_raw.strip() if description_raw is not None else ""
-
-    if title_raw is None:
-        pass
-    elif not title:
-        issues.append("missing 'タイトル案' section")
-    elif msg := check_title_codepoint_limit(title):
+    if msg := check_title_codepoint_limit(title):
         issues.append(msg)
-
-    if description_raw is None:
-        pass
-    elif not description:
-        issues.append("missing 'Complete Collection 概要欄' section")
-    else:
-        ts_lines = [line for line in description.split("\n") if TS_RE.match(line.strip())]
-        for msg in (
-            check_chapter_count(len(ts_lines), config.audio.chapter_max),
-            check_chapter_variation_suffix(ts_lines),
-        ):
-            if msg:
-                issues.append(msg)
+    ts_lines = [line for line in description.split("\n") if TS_RE.match(line.strip())]
+    for msg in (
+        check_chapter_count(len(ts_lines), config.audio.chapter_max),
+        check_chapter_variation_suffix(ts_lines),
+    ):
+        if msg:
+            issues.append(msg)
 
     # workflow-state.json は upload preflight と同じく常に parse する。
     # 単一言語チャンネルでは scene_phrases の完全性チェックだけを不要扱いにする (#1470)。
@@ -157,9 +144,9 @@ def audit_local(col: Path, config: ChannelConfig) -> list[str]:
     else:
         issues.append("workflow-state.json missing")
 
-    # タグ件数 / quotation 文字数（preflight と同じく descriptions.md 優先）
-    prebuilt_tags = extract_descriptions_md_tags(desc_md)
-    tags = prebuilt_tags if prebuilt_tags is not None else config.content.tags.for_collection(col.name)
+    # タグ件数 / quotation 文字数（preflight と同じ JSON 正本）
+    tags_value = metadata["tags"]
+    tags = list(tags_value) if isinstance(tags_value, list) else []
     for msg in (
         check_tags_count(tags, config.content.tags.min_count),
         check_tags_yt_chars(tags),
@@ -276,7 +263,7 @@ def main() -> None:
     total_issues = 0
 
     if do_local:
-        print("─── LOCAL (descriptions.md / workflow-state.json) ───")
+        print("─── LOCAL (descriptions.json + HTML / workflow-state.json) ───")
         for col in sorted(_collections_dir().iterdir()):
             if not col.is_dir():
                 continue

--- a/src/youtube_automation/commands/metadata/title_duplicate_check.py
+++ b/src/youtube_automation/commands/metadata/title_duplicate_check.py
@@ -9,29 +9,16 @@ from pathlib import Path
 
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.errors import ConfigError
-from youtube_automation.domains.metadata.descriptions import (
-    build_descriptions_md_parse_diagnostics,
-    extract_descriptions_md_section,
-)
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.domains.uploads.preflight import check_title_codepoint_limit, check_title_duplicate_warnings
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 
-def extract_section(text: str, header: str) -> str | None:
-    return extract_descriptions_md_section(text, header)
-
-
 def read_descriptions_title(collection_dir: Path) -> str:
-    desc_path = CollectionPaths(collection_dir).descriptions_md_path
+    desc_path = CollectionPaths(collection_dir).descriptions_json_path
     if not desc_path.exists():
-        raise FileNotFoundError(f"{desc_path} not found. Pass --title to check a title before saving descriptions.md.")
-    text = desc_path.read_text(encoding="utf-8")
-    title = extract_section(text, "タイトル案")
-    if title is None:
-        raise ValueError(f"{desc_path}: descriptions.md parse failed\n{build_descriptions_md_parse_diagnostics(text)}")
-    if not title:
-        raise ValueError(f"{desc_path}: missing 'タイトル案' section")
-    return title.strip()
+        raise FileNotFoundError(f"{desc_path} not found. Pass --title before saving descriptions.json.")
+    return str(read_video_description_metadata(desc_path)["title"])
 
 
 def collect_live_titles(collections_root: Path, *, exclude_dir: Path | None = None) -> list[str]:
@@ -46,12 +33,10 @@ def collect_live_titles(collections_root: Path, *, exclude_dir: Path | None = No
             continue
         if exclude_resolved and collection.resolve() == exclude_resolved:
             continue
-        desc_path = CollectionPaths(collection).descriptions_md_path
+        desc_path = CollectionPaths(collection).descriptions_json_path
         if not desc_path.exists():
             continue
-        title = extract_section(desc_path.read_text(encoding="utf-8"), "タイトル案")
-        if title:
-            titles.append(title.strip())
+        titles.append(str(read_video_description_metadata(desc_path)["title"]))
     return titles
 
 
@@ -60,8 +45,12 @@ def build_parser() -> argparse.ArgumentParser:
         prog="yt-title-duplicate-check",
         description="Warn if a proposed title overlaps titles in collections/live.",
     )
-    parser.add_argument("collection", nargs="?", help="collection dir; used for descriptions.md title and self-exclude")
-    parser.add_argument("--title", help="proposed title to check before writing descriptions.md")
+    parser.add_argument(
+        "collection",
+        nargs="?",
+        help="collection dir; used for descriptions.json title and self-exclude",
+    )
+    parser.add_argument("--title", help="proposed title to check before writing descriptions.json pair")
     parser.add_argument(
         "--collections-root",
         type=Path,

--- a/src/youtube_automation/commands/youtube/captions_upload.py
+++ b/src/youtube_automation/commands/youtube/captions_upload.py
@@ -8,11 +8,12 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from youtube_automation.core.errors import AutomationError, ValidationError
+from youtube_automation.domains.documents.video_description import read_video_description_document
 from youtube_automation.domains.media.captions import (
     generate_srt,
+    parse_document_track_timestamps,
     parse_timestamp,
     parse_total_duration,
-    parse_track_timestamps,
     write_srt,
 )
 from youtube_automation.domains.suno.lyrics import load_suno_lyrics_entries
@@ -31,11 +32,11 @@ def _load_lyrics(path: Path) -> list[str]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="yt-captions-upload",
-        description="suno-lyrics.json と descriptions.md から SRT を生成し YouTube 字幕へ反映する",
+        description="suno-lyrics.json と検証済み descriptions.json から SRT を生成し YouTube 字幕へ反映する",
     )
     parser.add_argument("--video-id", required=True, help="対象 YouTube video ID")
     parser.add_argument("--lyrics", required=True, type=Path, help="suno-lyrics.json（単曲は plain text も可）")
-    parser.add_argument("--descriptions", required=True, type=Path, help="トラックリストを含む descriptions.md")
+    parser.add_argument("--descriptions", required=True, type=Path, help="トラックリストを含む descriptions.json")
     parser.add_argument("--language", required=True, help="字幕言語（BCP-47。例: en / ja）")
     parser.add_argument("--name", default="Lyrics", help="YouTube 字幕トラック名（既定: Lyrics）")
     parser.add_argument("--output", type=Path, help="SRT 出力先（既定: <lyrics-dir>/captions.<language>.srt）")
@@ -62,9 +63,10 @@ def _confirm_update(item: dict) -> bool:
 def main(argv: Iterable[str] | None = None) -> int:
     args = build_parser().parse_args(list(argv) if argv is not None else None)
     try:
-        descriptions_text = args.descriptions.read_text(encoding="utf-8")
-        tracks = parse_track_timestamps(descriptions_text)
-        total_duration_ms = parse_timestamp(args.end_time) if args.end_time else parse_total_duration(descriptions_text)
+        description_document = read_video_description_document(args.descriptions)
+        tracks = parse_document_track_timestamps(description_document)
+        description_text = str(description_document["description"])
+        total_duration_ms = parse_timestamp(args.end_time) if args.end_time else parse_total_duration(description_text)
         if total_duration_ms is None:
             raise ValidationError("概要欄から総時間を取得できません。--end-time を指定してください")
         lyrics = _load_lyrics(args.lyrics)

--- a/src/youtube_automation/domains/channel_readiness/readiness.py
+++ b/src/youtube_automation/domains/channel_readiness/readiness.py
@@ -13,15 +13,15 @@ from PIL import Image as PILImage
 from PIL import UnidentifiedImageError
 
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, ValidationError
 from youtube_automation.domains.analytics.benchmark import (
     TTP_VIDEO_ANALYZE_TOP_N,
     load_benchmark_videos,
     select_top_vod_benchmark_videos,
 )
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.domains.thumbnail.references import resolve_configured_benchmark_references
 from youtube_automation.domains.uploads.preflight import (
-    check_descriptions_md_parseability,
     check_suno_genre_line_char_limit,
     check_thumbnail_skill_config,
 )
@@ -1408,15 +1408,28 @@ def evaluate_initial_setup_readiness(channel_dir: Path) -> ReadinessResult:
         if msg:
             issues.append(msg)
 
-    for desc_md in _planning_descriptions_md_paths(channel_dir):
-        msg = check_descriptions_md_parseability(desc_md, allowed_root=channel_dir)
-        if msg:
-            issues.append(msg)
+    for legacy_markdown in _planning_legacy_description_paths(channel_dir):
+        if not legacy_markdown.resolve().is_relative_to(channel_dir.resolve()):
+            issues.append(f"{legacy_markdown}: channel_dir 外を参照しています")
+        else:
+            issues.append(
+                f"{legacy_markdown}: 旧 descriptions.md は明示 migration が必要です。"
+                "/video --describe で descriptions.json + descriptions.html pair へ移行してください"
+            )
+
+    for desc_json in _planning_descriptions_json_paths(channel_dir):
+        if not desc_json.resolve().is_relative_to(channel_dir.resolve()):
+            issues.append(f"{desc_json}: channel_dir 外を参照しています")
+            continue
+        try:
+            read_video_description_metadata(desc_json)
+        except ValidationError as exc:
+            issues.append(f"{desc_json}: descriptions.json pair invalid: {exc}")
 
     if not issues:
         return ReadinessResult(
             status="ok",
-            message="初期セットアップの thumbnail / suno / descriptions.md 事前検査 OK",
+            message="初期セットアップの thumbnail / suno / descriptions.json 事前検査 OK",
         )
 
     return ReadinessResult(
@@ -1426,7 +1439,7 @@ def evaluate_initial_setup_readiness(channel_dir: Path) -> ReadinessResult:
             "kind": "human",
             "instructions": (
                 "/setup --regenerate で config/skills/thumbnail.yaml と config/skills/music.yaml::prompt を再確認し、"
-                "descriptions.md の parse 失敗は /video --describe で再生成してください"
+                "descriptions.json pair の検証失敗は /video --describe で再生成してください"
             ),
         },
     )
@@ -1439,7 +1452,14 @@ def _load_skill_config_for_channel(skill: str, channel_dir: Path) -> tuple[dict,
         return {}, f"config/skills/{skill}.yaml 読み込み失敗: {exc}"
 
 
-def _planning_descriptions_md_paths(channel_dir: Path) -> list[Path]:
+def _planning_descriptions_json_paths(channel_dir: Path) -> list[Path]:
+    planning_root = channel_dir / "collections" / "planning"
+    if not planning_root.is_dir():
+        return []
+    return sorted(planning_root.glob("*/20-documentation/descriptions.json"))
+
+
+def _planning_legacy_description_paths(channel_dir: Path) -> list[Path]:
     planning_root = channel_dir / "collections" / "planning"
     if not planning_root.is_dir():
         return []

--- a/src/youtube_automation/domains/documents/schema_registry.py
+++ b/src/youtube_automation/domains/documents/schema_registry.py
@@ -29,6 +29,7 @@ class RepositorySchema(str, Enum):
     FEEDBACK_ENTRY = "feedback-entry.schema.json"
     INSIGHTS_ENTRY = "insights-entry.schema.json"
     MUSIC_PROMPT = "music-prompt.schema.json"
+    VIDEO_DESCRIPTION = "video-description.schema.json"
     WEEKLY_VOTE_LOG = "weekly_vote_log.schema.json"
 
 
@@ -46,6 +47,7 @@ _SKILL_RESOURCES = {
     RepositorySchema.FEEDBACK_ENTRY: ("skill-feedback", "references", "feedback-entry.schema.json"),
     RepositorySchema.INSIGHTS_ENTRY: ("analytics", "references", "insights-entry.schema.json"),
     RepositorySchema.MUSIC_PROMPT: ("music", "references", "music-prompt.schema.json"),
+    RepositorySchema.VIDEO_DESCRIPTION: ("video", "references", "video-description.schema.json"),
 }
 _SOURCE_SKILLS = Path(__file__).resolve().parents[4] / ".claude" / "skills"
 

--- a/src/youtube_automation/domains/documents/video_description.py
+++ b/src/youtube_automation/domains/documents/video_description.py
@@ -1,0 +1,46 @@
+"""検証済み動画説明 document の typed reader。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from youtube_automation.core.errors import DocumentMigrationError
+from youtube_automation.domains.documents.published import read_published_json_document
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
+
+
+def read_video_description_metadata(json_path: Path) -> dict[str, object]:
+    """validated JSON+HTML pair から upload 用 metadata だけを返す。"""
+    document = read_video_description_document(json_path)
+    if not isinstance(document, Mapping):
+        raise DocumentMigrationError("動画説明は JSON object で指定してください")
+    return {
+        "title": document["title"],
+        "description": document["description"],
+        "tags": document["tags"],
+        "localizations": document["localizations"],
+    }
+
+
+def read_video_description_document(json_path: Path) -> Mapping[str, object]:
+    """validated pair の完全な JSON document を返す。"""
+    document = read_published_json_document(json_path, RepositorySchema.VIDEO_DESCRIPTION)
+    require_quality_pass(document)
+    if not isinstance(document, Mapping):
+        raise DocumentMigrationError("動画説明は JSON object で指定してください")
+    return document
+
+
+def require_quality_pass(document: object) -> None:
+    """全 quality check が成功していない文書を downstream から拒否する。"""
+    if not isinstance(document, Mapping):
+        raise DocumentMigrationError("動画説明は JSON object で指定してください")
+    quality = document.get("quality")
+    if not isinstance(quality, Mapping) or quality.get("status") != "pass":
+        raise DocumentMigrationError("動画説明の quality status が PASS ではありません")
+    checks = quality.get("checks")
+    if not isinstance(checks, list) or any(
+        not isinstance(check, Mapping) or check.get("status") != "pass" for check in checks
+    ):
+        raise DocumentMigrationError("動画説明の quality check に FAIL があります")

--- a/src/youtube_automation/domains/media/captions.py
+++ b/src/youtube_automation/domains/media/captions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -58,6 +58,26 @@ def parse_track_timestamps(descriptions_text: str) -> list[TrackTimestamp]:
             )
     if not tracks:
         raise ValidationError("descriptions.md にタイムスタンプ付きトラック行がありません")
+    starts = [track.start_ms for track in tracks]
+    if starts != sorted(set(starts)):
+        raise ValidationError("トラック開始時刻は昇順かつ重複なしである必要があります")
+    return tracks
+
+
+def parse_document_track_timestamps(document: Mapping[str, object]) -> list[TrackTimestamp]:
+    """動画説明JSONの構造化track listから開始時刻を読む。"""
+    entries = document.get("tracks")
+    if not isinstance(entries, list) or not entries:
+        raise ValidationError("descriptions.json に track list がありません")
+    tracks: list[TrackTimestamp] = []
+    for entry in entries:
+        if (
+            not isinstance(entry, Mapping)
+            or not isinstance(entry.get("start"), str)
+            or not isinstance(entry.get("title"), str)
+        ):
+            raise ValidationError("descriptions.json::tracks の start / title が不正です")
+        tracks.append(TrackTimestamp(start_ms=parse_timestamp(entry["start"]), title=entry["title"]))
     starts = [track.start_ms for track in tracks]
     if starts != sorted(set(starts)):
         raise ValidationError("トラック開始時刻は昇順かつ重複なしである必要があります")

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -14,10 +14,7 @@ from youtube_automation.domains.uploads._uploader_constants import (
     UPLOAD_SOURCE_EXISTING,
     UPLOAD_SOURCE_NEW,
 )
-from youtube_automation.domains.uploads.descriptions_md import (
-    extract_body_for_localizations,
-    load_descriptions_md,
-)
+from youtube_automation.domains.uploads.description_document import load_description_document
 from youtube_automation.infrastructure.filesystem import glob_files, path_is_file
 
 logger = logging.getLogger(__name__)
@@ -98,11 +95,11 @@ class CompleteCollectionStrategy:
                 "ffprobe で読み取れる完成済みマスター動画を指定してください"
             )
 
-        # descriptions.md が最終タイトル/概要/タグを供給するなら先に読み込み、
+        # descriptions.json が最終タイトル/概要/タグを供給するなら先に読み込み、
         # 中間タイトル生成（_generate_title）を title_override でスキップする。
         # これにより title.template が未知プレースホルダ（例 {adjective}）を含んでも
         # 本来捨てられる中間タイトル生成で upload 全体がクラッシュしない（#574）。
-        prebuilt = load_descriptions_md(collection_dir)
+        prebuilt = load_description_document(collection_dir)
 
         # メタデータ生成（BAHMetadataGenerator — localizations 等）
         metadata = metadata_gen.generate_complete_collection_metadata(
@@ -111,25 +108,14 @@ class CompleteCollectionStrategy:
             duration_seconds=duration_seconds,
         )
 
-        # descriptions.md が存在すれば title/description/tags を上書き
+        # validated descriptions.json が存在すれば公開 metadata を上書き
         if prebuilt:
             metadata["title"] = prebuilt["title"]
             metadata["description"] = prebuilt["description"]
             if prebuilt["tags"]:
                 metadata["tags"] = prebuilt["tags"]
 
-            # ローカライゼーションにもキュレーション済みのタイムスタンプを使用
-            curated_timestamps = extract_body_for_localizations(prebuilt["description"])
-            scene_phrases = getattr(metadata_gen, "_last_scene_phrases", {})
-            scene_emoji = metadata_gen._load_scene_emoji()
-            if curated_timestamps:
-                metadata["localizations"] = metadata_gen.generate_localizations(
-                    metadata["title"],
-                    curated_timestamps,
-                    scene_phrases,
-                    scene_emoji=scene_emoji,
-                    duration_seconds=duration_seconds,
-                )
+            metadata["localizations"] = prebuilt["localizations"]
 
         if publish_at:
             metadata["publish_at"] = publish_at

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -11,13 +11,9 @@ from youtube_automation.configuration import load_config
 from youtube_automation.core.adapters.media import CollectionPaths, probe_duration
 from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.domains.metadata import BAHMetadataGenerator
-from youtube_automation.domains.metadata.descriptions import (
-    build_descriptions_md_parse_diagnostics,
-    extract_descriptions_md_section,
-)
 from youtube_automation.domains.uploads._complete_collection_strategy import resolve_master_video
-from youtube_automation.domains.uploads.descriptions_md import extract_md_section
 from youtube_automation.domains.uploads.preflight import (
     check_chapter_count,
     check_chapter_variation_suffix,
@@ -27,14 +23,12 @@ from youtube_automation.domains.uploads.preflight import (
     check_tags_yt_chars,
     check_title_codepoint_limit,
     check_title_template_compliance,
-    extract_descriptions_md_tags,
     requires_scene_phrases,
 )
 from youtube_automation.infrastructure.filesystem import (
     list_directory,
     path_exists,
     path_is_directory,
-    read_file_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,19 +75,20 @@ class PreflightChecker:
                 continue
             if exclude_resolved and col.resolve() == exclude_resolved:
                 continue
-            desc_path = CollectionPaths(col).descriptions_md_path
+            desc_path = CollectionPaths(col).descriptions_json_path
             if not path_exists(desc_path):
                 continue
-            title = extract_md_section(read_file_text(desc_path), "タイトル案")
-            if title:
-                titles.append(title.strip())
+            metadata = read_video_description_metadata(desc_path)
+            title = metadata["title"]
+            if isinstance(title, str):
+                titles.append(title)
         return titles
 
     def check(self, collection_dir: Path) -> None:
         """アップロード前メタデータ品質チェック (fail-loud)。
 
         過去事例の再発防止:
-        1. descriptions.md が存在すること（Track 01 仮名フォールバックを防ぐ）
+        1. 検証済み descriptions.json + HTML pair が存在すること（Track 01 仮名フォールバックを防ぐ）
         2. workflow-state.json が存在し、有効な JSON であること。多言語チャンネルでは
            workflow-state.json.scene_phrases に supported_languages が揃っていること。
            単一言語チャンネルでは populate が no-op のため scene_phrases は要求しない
@@ -107,23 +102,12 @@ class PreflightChecker:
         7. supported_languages に低 CPM 警告対象言語が含まれる場合は warning を出すこと
         """
         paths = CollectionPaths(collection_dir)
-        desc_path = paths.descriptions_md_path
+        desc_path = paths.descriptions_json_path
         if not path_exists(desc_path):
             raise ValidationError(f"❌ {desc_path} が存在しません。/video --describe を実行してください。")
-
-        text = read_file_text(desc_path)
-        title_raw = extract_descriptions_md_section(text, "タイトル案")
-        description_raw = extract_descriptions_md_section(text, "Complete Collection 概要欄")
-
-        if title_raw is None or description_raw is None:
-            raise ValidationError(
-                f"❌ {desc_path}: descriptions.md のパースに失敗\n{build_descriptions_md_parse_diagnostics(text)}"
-            )
-
-        title = title_raw.strip()
-        description = description_raw.strip()
-        if not title or not description:
-            raise ValidationError(f"❌ {desc_path}: タイトル案 / Complete Collection 概要欄 が空")
+        prebuilt = read_video_description_metadata(desc_path)
+        title = str(prebuilt["title"])
+        description = str(prebuilt["description"])
 
         if msg := check_title_codepoint_limit(title):
             raise ValidationError(f"❌ {msg}")
@@ -183,8 +167,7 @@ class PreflightChecker:
                     f"→ 既存例: collections/live/20260322-rjn-city-collection/workflow-state.json"
                 )
 
-        # 実 upload と同じ generator で全 locale の title を構築し、API 呼び出し前の
-        # --plan preflight でも YouTube の 100 codepoint 制限を検証する。
+        # JSON 正本の全 locale title を API 呼び出し前に再検証する。
         master_video = self.master_video_resolver(collection_dir)
         duration_sec = self.duration_probe(master_video)
         if duration_sec is None:
@@ -192,30 +175,9 @@ class PreflightChecker:
                 f"❌ 実マスター尺を取得できません: {master_video.name}。"
                 "ffprobe で読み取れる完成済みマスター動画を指定してください"
             )
-        generator = self.metadata_generator_factory(str(collection_dir))
-        # 同じ invocation で読み込んだ config を使い、plan と upload の設定 snapshot を揃える。
-        # 最小 stub を使う既存 unit test では localization data が無いため生成を省略する。
-        generator.config = config
-        localization_data = getattr(config.localizations, "data", {})
-        languages = localization_data.get("languages", {}) if isinstance(localization_data, dict) else {}
-        supported = localization_data.get("supported_languages", []) if isinstance(localization_data, dict) else []
-        templates_complete = bool(supported) and all(
-            languages.get(lang, {}).get("title_template") for lang in supported
-        )
-        try:
-            localizations = (
-                generator.generate_localizations(
-                    title,
-                    description,
-                    scene_phrases,
-                    scene_emoji=generator._load_scene_emoji(),
-                    duration_seconds=duration_sec,
-                )
-                if templates_complete
-                else {}
-            )
-        except ValueError as exc:
-            raise ValidationError(f"❌ ローカライズタイトル検証に失敗:\n{exc}") from exc
+        localizations = prebuilt["localizations"]
+        if not isinstance(localizations, dict):
+            raise ValidationError("❌ descriptions.json::localizations は object が必要です")
         over_limit = [
             f"{locale}={len(value.get('title', ''))}c: {value.get('title', '')!r}"
             for locale, value in localizations.items()
@@ -225,10 +187,11 @@ class PreflightChecker:
             raise ValidationError("❌ ローカライズタイトルが 100 codepoint を超過:\n  - " + "\n  - ".join(over_limit))
 
         # タグ件数 / quotation 文字数チェック
-        # descriptions.md の「タグ（YouTube タグ欄）」が _upload_complete_collection で
-        # for_collection() を上書きするため、本番と同じソースを検証する。
-        prebuilt_tags = extract_descriptions_md_tags(desc_path)
-        tags = prebuilt_tags if prebuilt_tags is not None else config.content.tags.for_collection(collection_dir.name)
+        # 本番と同じ validated JSON の tags を検証する。
+        tags_value = prebuilt["tags"]
+        if not isinstance(tags_value, list) or not all(isinstance(tag, str) for tag in tags_value):
+            raise ValidationError("❌ descriptions.json::tags は string array が必要です")
+        tags = tags_value
         issues: list[str] = []
         for msg in (
             check_tags_count(tags, config.content.tags.min_count),

--- a/src/youtube_automation/domains/uploads/description_document.py
+++ b/src/youtube_automation/domains/uploads/description_document.py
@@ -1,0 +1,30 @@
+"""動画説明 JSON+HTML pair の upload 境界。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.documents.video_description import read_video_description_metadata
+from youtube_automation.infrastructure.filesystem import glob_files, path_exists
+
+
+def load_description_document(collection_dir: Path) -> dict[str, object] | None:
+    """validated JSON 正本だけを読み、旧 Markdown は暗黙 parse しない。"""
+    paths = CollectionPaths(collection_dir)
+    source = paths.descriptions_json_path
+    if not path_exists(source):
+        if path_exists(paths.descriptions_md_path):
+            raise ValidationError(
+                f"{paths.descriptions_md_path}: 旧 descriptions.md は upload 入力にできません。"
+                "明示 migration で descriptions.json + descriptions.html pair へ移行してください"
+            )
+        stray = glob_files(paths.docs_dir, "description*")
+        if stray:
+            raise ValidationError(
+                f"descriptions.json が無いのに別名ファイルが存在します: {[path.name for path in stray]}\n"
+                "→ /video --describe で検証済み JSON+HTML pair を生成してください"
+            )
+        return None
+    return read_video_description_metadata(source)

--- a/src/youtube_automation/infrastructure/media/collection_paths.py
+++ b/src/youtube_automation/infrastructure/media/collection_paths.py
@@ -80,6 +80,10 @@ class CollectionPaths:
         return self.docs_dir / "descriptions.md"
 
     @property
+    def descriptions_json_path(self) -> Path:
+        return self.docs_dir / "descriptions.json"
+
+    @property
     def thumbnail_prompts_path(self) -> Path:
         return self.docs_dir / "thumbnail-prompts.md"
 

--- a/tests/application/documents/test_video_description.py
+++ b/tests/application/documents/test_video_description.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.application.documents.migration import MarkdownMigrationDecision
+from youtube_automation.application.documents.video_description import (
+    read_video_description_metadata,
+    write_video_description_document,
+)
+from youtube_automation.core.errors import DocumentMigrationError, DocumentRenderError, DocumentValidationError
+
+
+def _document(*, quality_status: str = "pass") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-08-16T00:00:00Z",
+        "collection_id": "rain-focus",
+        "title": "Rain Focus — Complete Collection",
+        "description": "Opening\n\n00:00 Quiet Rain\n03:12 Deep Focus\n\n#Focus",
+        "description_sections": [
+            {"id": "opening", "heading": "Opening", "body": "Opening"},
+            {"id": "track_list", "heading": "Track list", "body": "00:00 Quiet Rain\n03:12 Deep Focus"},
+        ],
+        "tracks": [
+            {"position": 1, "start": "00:00", "title": "Quiet Rain"},
+            {"position": 2, "start": "03:12", "title": "Deep Focus"},
+        ],
+        "tags": ["focus music", "rain ambience"],
+        "localizations": {"ja": {"title": "雨の集中用BGM", "description": "00:00 静かな雨\n03:12 深い集中"}},
+        "provenance": {"producer": "video", "source_paths": ["20-documentation/plan_proposals.json"]},
+        "quality": {
+            "status": quality_status,
+            "checks": [
+                {"id": "title-length", "status": quality_status, "message": "100 codepoints以内"},
+                {"id": "localizations", "status": quality_status, "message": "全locale検証済み"},
+            ],
+        },
+    }
+
+
+def _state(path: Path) -> None:
+    path.write_text(
+        json.dumps({"phase": "prepared", "assets": {"thumbnail": True}, "unknown": {"keep": True}}),
+        encoding="utf-8",
+    )
+
+
+def test_verified_description_pair_updates_state_after_reread(tmp_path: Path) -> None:
+    target = tmp_path / "20-documentation/descriptions.json"
+    target.parent.mkdir()
+    state = tmp_path / "workflow-state.json"
+    _state(state)
+
+    result = write_video_description_document(
+        target,
+        state,
+        _document,
+        MarkdownMigrationDecision.NOT_REQUIRED,
+    )
+
+    assert result.value == "created"
+    assert target.with_suffix(".html").is_file()
+    assert read_video_description_metadata(target) == {
+        "title": "Rain Focus — Complete Collection",
+        "description": "Opening\n\n00:00 Quiet Rain\n03:12 Deep Focus\n\n#Focus",
+        "tags": ["focus music", "rain ambience"],
+        "localizations": {"ja": {"title": "雨の集中用BGM", "description": "00:00 静かな雨\n03:12 深い集中"}},
+    }
+    persisted = json.loads(state.read_text())
+    assert persisted["assets"] == {"thumbnail": True, "description": True}
+    assert persisted["unknown"] == {"keep": True}
+
+
+@pytest.mark.parametrize("failure", ["quality", "localization"])
+def test_invalid_quality_or_localization_does_not_publish_or_update_state(tmp_path: Path, failure: str) -> None:
+    target = tmp_path / "20-documentation/descriptions.json"
+    target.parent.mkdir()
+    state = tmp_path / "workflow-state.json"
+    _state(state)
+    before = state.read_bytes()
+
+    def invalid_document() -> dict[str, object]:
+        document = _document(quality_status="fail" if failure == "quality" else "pass")
+        if failure == "localization":
+            document["localizations"] = {"ja": {"title": "", "description": "本文"}}
+        return document
+
+    error = DocumentMigrationError if failure == "quality" else DocumentValidationError
+    with pytest.raises(error):
+        write_video_description_document(
+            target,
+            state,
+            invalid_document,
+            MarkdownMigrationDecision.NOT_REQUIRED,
+        )
+
+    assert state.read_bytes() == before
+    assert not target.exists()
+    assert not target.with_suffix(".html").exists()
+
+
+def test_markdown_migration_requires_explicit_yes(tmp_path: Path) -> None:
+    target = tmp_path / "20-documentation/descriptions.json"
+    target.parent.mkdir()
+    target.with_suffix(".md").write_text("legacy description", encoding="utf-8")
+    state = tmp_path / "workflow-state.json"
+    _state(state)
+
+    with pytest.raises(DocumentMigrationError, match="明示的な yes/no"):
+        write_video_description_document(
+            target,
+            state,
+            _document,
+            MarkdownMigrationDecision.NOT_REQUIRED,
+        )
+
+    result = write_video_description_document(target, state, _document, MarkdownMigrationDecision.YES)
+    assert result.value == "migrated"
+    assert not target.with_suffix(".md").exists()
+
+
+def test_reader_rejects_tampered_html_pair(tmp_path: Path) -> None:
+    target = tmp_path / "20-documentation/descriptions.json"
+    target.parent.mkdir()
+    state = tmp_path / "workflow-state.json"
+    _state(state)
+    write_video_description_document(target, state, _document, MarkdownMigrationDecision.NOT_REQUIRED)
+    target.with_suffix(".html").write_text("tampered", encoding="utf-8")
+
+    with pytest.raises(DocumentRenderError, match="対応していません"):
+        read_video_description_metadata(target)

--- a/tests/commands/documents/test_migrate.py
+++ b/tests/commands/documents/test_migrate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.documents import migrate
 
 
@@ -127,4 +128,33 @@ def test_music_prompt_cli_requires_reviewed_candidate_and_updates_state(tmp_path
 
     assert result == 0
     assert json.loads(state.read_text())["assets"]["music_prompts"] is True
+    assert "created:" in capsys.readouterr().out
+
+
+def test_video_description_cli_publishes_pair_and_updates_state(tmp_path: Path, capsys) -> None:
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    fixture = write_video_description_pair(fixture_dir)
+    candidate = tmp_path / "candidate.json"
+    candidate.write_bytes(fixture.read_bytes())
+    target = tmp_path / "20-documentation/descriptions.json"
+    target.parent.mkdir()
+    state = tmp_path / "workflow-state.json"
+    state.write_text(json.dumps({"phase": "prepared", "assets": {}}), encoding="utf-8")
+
+    result = migrate.main(
+        [
+            str(candidate),
+            "--target",
+            str(target),
+            "--schema",
+            "video-description.schema.json",
+            "--workflow-state",
+            str(state),
+        ]
+    )
+
+    assert result == 0
+    assert target.with_suffix(".html").is_file()
+    assert json.loads(state.read_text())["assets"]["description"] is True
     assert "created:" in capsys.readouterr().out

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.media import populate_scene_phrases
 from youtube_automation.configuration import load_config, reset
 from youtube_automation.core.errors import ConfigError, ValidationError
@@ -100,21 +101,14 @@ def _setup_channel(
     return ch
 
 
-def _write_descriptions_md(collection_dir: Path) -> None:
+def _write_descriptions_pair(collection_dir: Path) -> None:
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True, exist_ok=True)
-    (docs_dir / "descriptions.md").write_text(
-        """## タイトル案
-```
-Late-night neon city, jazz between rain and streetlights | 3 Hours of Study
-```
-
-## Complete Collection 概要欄
-```
-A continuous BGM mix without chapter markers.
-```
-""",
-        encoding="utf-8",
+    write_video_description_pair(
+        docs_dir,
+        title="Late-night neon city, jazz between rain and streetlights | 3 Hours of Study",
+        description="A continuous BGM mix without chapter markers.",
+        tracks=[],
     )
 
 
@@ -235,7 +229,7 @@ class TestMainCLI:
             collection_name=collection_name,
         )
         collection_dir = ch / "collections" / "planning" / collection_name
-        _write_descriptions_md(collection_dir)
+        _write_descriptions_pair(collection_dir)
         monkeypatch.setenv("CHANNEL_DIR", str(ch))
 
         rc = populate_scene_phrases.main([collection_name])

--- a/tests/commands/metadata/test_bulk_update_descriptions_from_md.py
+++ b/tests/commands/metadata/test_bulk_update_descriptions_from_md.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -34,7 +35,7 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from youtube_automation.configuration import reset
-from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.core.errors import DocumentRenderError, DocumentValidationError, YouTubeAPIError
 
 # ---------------------------------------------------------------------------
 # ヘルパー
@@ -63,7 +64,7 @@ def _make_collection_with_descriptions(
     omit_video_id: bool = False,
     omit_sections: list[str] | None = None,
 ) -> Path:
-    """`live/<name>/20-documentation/{descriptions.md, upload_tracking.json}` を作成.
+    """`live/<name>/20-documentation/{descriptions.json, upload_tracking.json}` を作成.
 
     欠落系（ケース 6/7/8/21/22/23）は `omit_*` フラグで variant 化する.
     """
@@ -85,15 +86,19 @@ def _make_collection_with_descriptions(
 
     if not omit_descriptions:
         omits = set(omit_sections or [])
-        sections: list[str] = []
-        if "概要欄" not in omits:
-            sections.append(f"## Complete Collection 概要欄\n\n```\n{description}\n```\n")
-        if "タイトル案" not in omits:
-            sections.append(f"## タイトル案\n\n```\n{title}\n```\n")
-        if "タグ" not in omits:
-            tags_str = ", ".join(tags or ["tag1", "tag2"])
-            sections.append(f"## タグ（YouTube タグ欄）\n\n```\n{tags_str}\n```\n")
-        (doc / "descriptions.md").write_text("\n".join(sections), encoding="utf-8")
+        source = write_video_description_pair(
+            doc,
+            title=title,
+            description=description,
+            tags=[] if "タグ" in omits else [tag.strip('"') for tag in (tags or ["tag1", "tag2"])],
+        )
+        if omits:
+            document = json.loads(source.read_text(encoding="utf-8"))
+            if "概要欄" in omits:
+                document.pop("description")
+            if "タイトル案" in omits:
+                document.pop("title")
+            source.write_text(json.dumps(document), encoding="utf-8")
 
     return col
 
@@ -592,48 +597,6 @@ class TestMainExecution:
             for c in sleep_mock.call_args_list:
                 assert c == call(0.4)
 
-    def test_should_keep_old_title_when_new_title_exceeds_100_utf16_units(self, tmp_path, monkeypatch, caplog):
-        """新タイトル UTF-16 > 100 units 時は old title を保持し description のみ更新."""
-        from youtube_automation.commands.metadata import bulk_update_descriptions as mod
-
-        # Given: 101 units の新タイトル（BMP 文字 1 個 = 1 unit）
-        long_title = "x" * 101
-        ch = _setup_channel(tmp_path)
-        _make_collection_with_descriptions(
-            ch,
-            "alpha",
-            video_id="V_ALPHA",
-            title=long_title,
-            description="new desc",
-        )
-        monkeypatch.setenv("CHANNEL_DIR", str(ch))
-        reset()
-        monkeypatch.setattr(sys, "argv", ["yt-bulk-update-desc"])
-        caplog.set_level(logging.INFO, logger=mod.__name__)
-        yt_mock = _build_youtube_mock(
-            [
-                _snippet("V_ALPHA", title="kept old title", description="old desc"),
-            ]
-        )
-
-        with (
-            patch.object(mod, "create_authenticated_youtube_clients", return_value=SimpleNamespace(youtube=yt_mock)),
-            patch.object(mod.time, "sleep"),
-        ):
-            # When
-            mod.main()
-
-            # Then
-            update_call = yt_mock.videos.return_value.update.call_args_list[0]
-            body = update_call.kwargs["body"]
-            assert body["snippet"]["title"] == "kept old title"
-            assert body["snippet"]["description"] == "new desc"
-            assert (
-                "WARNING",
-                "⚠️  V_ALPHA (alpha): new title is 101 UTF-16 units (>100). "
-                "Keeping old title; updating description only.",
-            ) in [(record.levelname, record.message) for record in caplog.records]
-
     def test_should_accept_new_title_at_exactly_100_utf16_units(self, tmp_path, monkeypatch):
         """REQ-2805-01: UTF-16 ちょうど 100 units は新 title を保持する."""
         from youtube_automation.commands.metadata import bulk_update_descriptions as mod
@@ -739,7 +702,7 @@ class TestMainExecution:
 
         ch = _setup_channel(tmp_path)
         col = _make_collection_with_descriptions(ch, "alpha")
-        descriptions_path = col / "20-documentation" / "descriptions.md"
+        descriptions_path = col / "20-documentation" / "descriptions.json"
         original_read_text = Path.read_text
 
         def read_text_with_failure(path: Path, *args, **kwargs):
@@ -754,7 +717,7 @@ class TestMainExecution:
 
         with (
             patch.object(mod, "create_authenticated_youtube_clients") as clients_mock,
-            pytest.raises(OSError, match="metadata unavailable"),
+            pytest.raises(DocumentRenderError, match="structured document pair を読めません"),
         ):
             mod.main()
 
@@ -1007,16 +970,10 @@ class TestLoadCollection:
         reset()
 
         # When/Then
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(DocumentValidationError) as excinfo:
             mod.load_collection("alpha")
 
-        message = str(excinfo.value)
-        assert "descriptions.md parse failed in alpha" in message
-        assert "期待する見出し（完全一致）" in message
-        assert ("不足/不一致の見出し:\n  - ## Complete Collection 概要欄") in message
-        assert "検出した ## 見出し" in message
-        assert "修正例" in message
-        assert "/video --describe を再実行" in message
+        assert "schema keyword=required pointer=/" in str(excinfo.value)
 
     def test_should_raise_when_title_section_missing(self, tmp_path, monkeypatch):
         """`タイトル案` セクション欠落で `RuntimeError`."""
@@ -1029,16 +986,10 @@ class TestLoadCollection:
         reset()
 
         # When/Then
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(DocumentValidationError) as excinfo:
             mod.load_collection("alpha")
 
-        message = str(excinfo.value)
-        assert "descriptions.md parse failed in alpha" in message
-        assert "期待する見出し（完全一致）" in message
-        assert ("不足/不一致の見出し:\n  - ## タイトル案") in message
-        assert "検出した ## 見出し" in message
-        assert "修正例" in message
-        assert "/video --describe を再実行" in message
+        assert "schema keyword=required pointer=/" in str(excinfo.value)
 
     def test_should_strip_double_quotes_from_tags(self, tmp_path, monkeypatch):
         """ダブルクォートで囲まれたタグから引用符を除去する (#1096)."""
@@ -1157,34 +1108,6 @@ class TestBuildSnippetUpdateBody:
         assert body["snippet"]["title"] == "new title"
         assert body["snippet"]["description"] == "new desc"
         assert body["snippet"]["tags"] == ["new-tag-1", "new-tag-2"]
-
-
-class TestExtractMdSection:
-    """`load_collection` の Error テスト経路の前提となる補助 utility."""
-
-    def test_should_return_fenced_body_when_header_matches(self):
-        from youtube_automation.commands.metadata import bulk_update_descriptions as mod
-
-        # Given
-        md = "## Complete Collection 概要欄\n\n```\nhello world\n```\n"
-
-        # When
-        result = mod.extract_md_section(md, "Complete Collection 概要欄")
-
-        # Then
-        assert result == "hello world"
-
-    def test_should_return_none_when_header_missing(self):
-        from youtube_automation.commands.metadata import bulk_update_descriptions as mod
-
-        # Given
-        md = "## Other Section\n\n```\nbody\n```\n"
-
-        # When
-        result = mod.extract_md_section(md, "Complete Collection 概要欄")
-
-        # Then
-        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/metadata/test_metadata_audit.py
+++ b/tests/commands/metadata/test_metadata_audit.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.metadata.metadata_audit import audit_local, audit_remote
 
 _ZH_ISSUE_TOKEN = "zh codes"  # `metadata_audit.py` のエラー文言 "YT zh codes are ..." に対応
@@ -70,19 +71,16 @@ def _write_local_collection(
     collection_dir = tmp_path / "20260622-test-collection"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True)
-    (docs_dir / "descriptions.md").write_text(
-        f"""## {title_heading}
-```
-Continuous Focus Mix
-```
-
-## Complete Collection 概要欄
-```
-{description}
-```
-""",
-        encoding="utf-8",
+    source = write_video_description_pair(
+        docs_dir,
+        title="Continuous Focus Mix",
+        description=description,
+        tags=["fallback"],
     )
+    if title_heading != "タイトル案":
+        document = json.loads(source.read_text(encoding="utf-8"))
+        document["title"] = ""
+        source.write_text(json.dumps(document), encoding="utf-8")
     if write_workflow_state:
         (collection_dir / "workflow-state.json").write_text(
             json.dumps({"scene_phrases": scene_phrases}, ensure_ascii=False),
@@ -170,7 +168,7 @@ class TestAuditLocalPreflightContract:
 
         assert any("workflow-state.json invalid" in issue for issue in issues)
 
-    def test_heading_mismatch_reports_descriptions_md_diagnostics(self, tmp_path: Path) -> None:
+    def test_invalid_description_pair_reports_schema_diagnostic(self, tmp_path: Path) -> None:
         collection_dir = _write_local_collection(
             tmp_path,
             scene_phrases={"en": "continuous focus mix"},
@@ -182,15 +180,10 @@ class TestAuditLocalPreflightContract:
 
         assert len(issues) == 1
         message = issues[0]
-        assert "descriptions.md parse failed" in message
-        assert "期待する見出し（完全一致）" in message
-        assert ("不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）") in message
-        assert "検出した ## 見出し" in message
-        assert "## タイトル" in message
-        assert "修正例" in message
-        assert "/video --describe を再実行" in message
+        assert "descriptions.json invalid" in message
+        assert "pointer=/title" in message
 
-    def test_parse_failure_keeps_independent_local_audits(self, tmp_path: Path) -> None:
+    def test_invalid_description_pair_stops_metadata_audit_fail_closed(self, tmp_path: Path) -> None:
         collection_dir = _write_local_collection(
             tmp_path,
             scene_phrases={},
@@ -203,9 +196,8 @@ class TestAuditLocalPreflightContract:
 
         issues = audit_local(collection_dir, cfg)
 
-        assert any("descriptions.md parse failed" in issue for issue in issues)
-        assert any("workflow-state.json missing" in issue for issue in issues)
-        assert any("tags count: 1 (min 2)" in issue for issue in issues)
+        assert len(issues) == 1
+        assert "descriptions.json invalid" in issues[0]
 
 
 class TestAuditRemoteZhCodes:

--- a/tests/commands/metadata/test_title_duplicate_check.py
+++ b/tests/commands/metadata/test_title_duplicate_check.py
@@ -1,4 +1,4 @@
-"""title_duplicate_check の descriptions.md 読み込み契約テスト."""
+"""title_duplicate_check の descriptions.json 読み込み契約テスト."""
 
 from __future__ import annotations
 
@@ -6,87 +6,23 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.metadata.title_duplicate_check import read_descriptions_title
 
 
-def _write_descriptions_md(collection_dir: Path, text: str) -> None:
+def _write_description_pair(collection_dir: Path, title: str) -> None:
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True)
-    (docs_dir / "descriptions.md").write_text(text, encoding="utf-8")
+    write_video_description_pair(docs_dir, title=title)
 
 
-def _valid_descriptions_md(title: str) -> str:
-    return f"""## タイトル案
-```
-{title}
-```
+def test_read_descriptions_title_rejects_legacy_markdown(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "20-documentation"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "descriptions.md").write_text("legacy", encoding="utf-8")
 
-## Complete Collection 概要欄
-```
-0:00 Track
-```
-
-## タグ（YouTube タグ欄）
-```
-ambient, focus
-```
-"""
-
-
-def test_read_descriptions_title_reports_heading_mismatch_diagnostics(tmp_path: Path) -> None:
-    _write_descriptions_md(
-        tmp_path,
-        """## タイトル
-```
-Continuous Focus Mix
-```
-
-## Complete Collection 概要欄
-```
-A continuous BGM mix without chapter markers.
-```
-""",
-    )
-
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(FileNotFoundError, match="descriptions.json"):
         read_descriptions_title(tmp_path)
-
-    message = str(excinfo.value)
-    assert "descriptions.md parse failed" in message
-    assert "期待する見出し（完全一致）" in message
-    assert "不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）" in message
-    assert "検出した ## 見出し" in message
-    assert "## タイトル" in message
-    assert "修正例" in message
-    assert "/video --describe を再実行" in message
-
-
-def test_read_descriptions_title_rejects_level3_heading(tmp_path: Path) -> None:
-    _write_descriptions_md(
-        tmp_path,
-        """### タイトル案
-```
-Continuous Focus Mix
-```
-
-## Complete Collection 概要欄
-```
-A continuous BGM mix without chapter markers.
-```
-
-## タグ（YouTube タグ欄）
-```
-ambient, focus
-```
-""",
-    )
-
-    with pytest.raises(ValueError) as excinfo:
-        read_descriptions_title(tmp_path)
-
-    message = str(excinfo.value)
-    assert "不足/不一致の見出し:\n  - ## タイトル案" in message
-    assert "検出した ## 見出し:\n  - ## Complete Collection 概要欄\n  - ## タグ（YouTube タグ欄）" in message
 
 
 def test_main_rejects_title_over_100_codepoints(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -105,26 +41,6 @@ def test_main_rejects_title_over_100_codepoints(tmp_path: Path, capsys: pytest.C
     assert "title duplicate warning" not in captured.out
 
 
-def test_main_rejects_descriptions_title_over_100_codepoints(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Given descriptions.md のタイトル案が 100 codepoint を超える
-    When collection 指定で yt-title-duplicate-check を実行する
-    Then descriptions.md 入口でも upload preflight と同じ上限で fail-loud する。
-    """
-    from youtube_automation.commands.metadata.title_duplicate_check import main
-
-    collection = tmp_path / "collections" / "planning" / "current"
-    long_title = "Late Night Smooth Jazz | " + "a" * 80
-    _write_descriptions_md(collection, _valid_descriptions_md(long_title))
-
-    rc = main([str(collection), "--collections-root", str(tmp_path / "collections")])
-
-    captured = capsys.readouterr()
-    assert rc == 1
-    assert "YouTube 制限 100 を超過" in captured.out
-
-
 def test_main_rejects_long_title_before_duplicate_warning(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Given 100 codepoint 超過かつ既存タイトルと重複するタイトル
     When yt-title-duplicate-check を実行する
@@ -133,9 +49,6 @@ def test_main_rejects_long_title_before_duplicate_warning(tmp_path: Path, capsys
     from youtube_automation.commands.metadata.title_duplicate_check import main
 
     long_title = "Late Night Smooth Jazz | " + "a" * 80
-    live_collection = tmp_path / "collections" / "live" / "published"
-    _write_descriptions_md(live_collection, _valid_descriptions_md(long_title))
-
     rc = main(["--title", long_title, "--collections-root", str(tmp_path / "collections")])
 
     captured = capsys.readouterr()
@@ -156,7 +69,7 @@ def test_main_duplicate_warning_respects_strict_mode(
 
     title = "Rainy Night Focus Mix"
     existing = tmp_path / "collections" / "live" / "published"
-    _write_descriptions_md(existing, _valid_descriptions_md(title))
+    _write_description_pair(existing, title)
 
     rc = main(
         [
@@ -181,7 +94,7 @@ def test_main_excludes_the_current_live_collection_from_duplicate_check(
 
     current = tmp_path / "collections" / "live" / "current"
     title = "Rainy Night Focus Mix"
-    _write_descriptions_md(current, _valid_descriptions_md(title))
+    _write_description_pair(current, title)
 
     rc = main(
         [

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -20,6 +20,7 @@ from httplib2 import ServerNotFoundError
 from PIL import Image as PILImage
 
 import youtube_automation.infrastructure.secrets as secrets_module
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.system import doctor
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
@@ -237,23 +238,9 @@ def _write_thumbnail_skill_config(base: Path, references: list[str] | str) -> No
     )
 
 
-def _write_valid_descriptions_md(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        "## タイトル案\n"
-        "```\n"
-        "Title\n"
-        "```\n"
-        "## Complete Collection 概要欄\n"
-        "```\n"
-        "Body\n"
-        "```\n"
-        "## タグ（YouTube タグ欄）\n"
-        "```\n"
-        "tag\n"
-        "```\n",
-        encoding="utf-8",
-    )
+def _write_valid_description_pair(documentation: Path) -> None:
+    documentation.mkdir(parents=True, exist_ok=True)
+    write_video_description_pair(documentation, title="Title", description="Body", tags=["tag"])
 
 
 def _write_complete_ttp_artifacts(base: Path) -> Path:
@@ -1896,7 +1883,7 @@ class TestCheckInitialSetupReadiness:
 
         assert os.environ.get("CHANNEL_DIR") == original
 
-    def test_warns_for_thumbnail_suno_and_descriptions_md_issues(self, tmp_path):
+    def test_warns_for_thumbnail_suno_and_legacy_descriptions_issues(self, tmp_path):
         skills_dir = tmp_path / "config" / "skills"
         skills_dir.mkdir(parents=True)
         (skills_dir / "thumbnail.yaml").write_text(
@@ -1944,7 +1931,7 @@ class TestCheckInitialSetupReadiness:
         assert "reference_images.default" in r.message
         assert "composition_rules" in r.message
         assert "genre_line" in r.message
-        assert "descriptions.md parse failed" in r.message
+        assert "旧 descriptions.md は明示 migration が必要" in r.message
         assert r.next_action is not None
         assert "/setup --regenerate" in r.next_action["instructions"]
         assert "/video --describe" in r.next_action["instructions"]
@@ -1975,8 +1962,8 @@ class TestCheckInitialSetupReadiness:
             f'genre_line: "{"x" * 373}"\nstyle_char_limit: 373\n',
             encoding="utf-8",
         )
-        desc = tmp_path / "collections" / "planning" / "alpha" / "20-documentation" / "descriptions.md"
-        _write_valid_descriptions_md(desc)
+        docs = tmp_path / "collections" / "planning" / "alpha" / "20-documentation"
+        _write_valid_description_pair(docs)
 
         r = doctor.check_initial_setup_readiness(tmp_path)
 
@@ -2039,7 +2026,7 @@ class TestCheckInitialSetupReadiness:
         assert "composition_rules" in r.message
         assert "reference_images.default" not in r.message
 
-    def test_descriptions_md_symlink_escape_warns_without_reading_external_heading(self, tmp_path):
+    def test_legacy_descriptions_symlink_escape_warns_without_reading_external_heading(self, tmp_path):
         outside = tmp_path.parent / f"{tmp_path.name}-outside"
         outside_desc = outside / "descriptions.md"
         outside.mkdir()
@@ -2057,15 +2044,16 @@ class TestCheckInitialSetupReadiness:
         assert "channel_dir 外" in r.message
         assert "SECRET_HEADING" not in r.message
 
-    def test_descriptions_md_invalid_utf8_warns_without_exception(self, tmp_path):
-        desc = tmp_path / "collections" / "planning" / "alpha" / "20-documentation" / "descriptions.md"
+    def test_descriptions_json_invalid_utf8_warns_without_exception(self, tmp_path):
+        desc = tmp_path / "collections" / "planning" / "alpha" / "20-documentation" / "descriptions.json"
         desc.parent.mkdir(parents=True)
         desc.write_bytes(b"\xff\xfe\xfa")
 
         r = doctor.check_initial_setup_readiness(tmp_path)
 
         assert r.status == "warn"
-        assert "descriptions.md を読み取れません" in r.message
+        assert "descriptions.json pair invalid" in r.message
+        assert "structured document pair を読めません" in r.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/youtube/test_captions_upload_cli.py
+++ b/tests/commands/youtube/test_captions_upload_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.commands.youtube import captions_upload
 from youtube_automation.commands.youtube.captions_upload import main
 from youtube_automation.core.errors import YouTubeAPIError
@@ -24,10 +25,13 @@ def test_dry_run_generates_srt_without_youtube_api(tmp_path, monkeypatch):
         ),
         encoding="utf-8",
     )
-    descriptions = tmp_path / "descriptions.md"
-    descriptions.write_text(
-        "## Complete Collection 概要欄\n\n```\n🎵 Album - 2 tracks, 04:00\n00:00 First\n02:00 Second\n```\n",
-        encoding="utf-8",
+    descriptions = write_video_description_pair(
+        tmp_path,
+        description="🎵 Album - 2 tracks, 04:00\n00:00 First\n02:00 Second",
+        tracks=[
+            {"position": 1, "start": "00:00", "title": "First"},
+            {"position": 2, "start": "02:00", "title": "Second"},
+        ],
     )
     output = tmp_path / "out.srt"
 
@@ -55,8 +59,11 @@ def _cli_files(tmp_path, *, include_duration=True):
     lyrics = tmp_path / "lyrics.txt"
     lyrics.write_text("Hello", encoding="utf-8")
     duration = ", 01:00" if include_duration else ""
-    descriptions = tmp_path / "descriptions.md"
-    descriptions.write_text(f"🎵 One track{duration}\n00:00 First\n", encoding="utf-8")
+    descriptions = write_video_description_pair(
+        tmp_path,
+        description=f"🎵 One track{duration}\n00:00 First",
+        tracks=[{"position": 1, "start": "00:00", "title": "First"}],
+    )
     return lyrics, descriptions
 
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.domains.uploads.collection import PlaylistAssignment, PublishedDatesScheduler, TrackingStore
 
 sys.path.insert(0, str(REPO_ROOT))
@@ -126,25 +127,11 @@ def _write_cli_title_collection(channel_dir: Path, *, title_template_check: dict
     for subdir in ("01-master", "02-Individual-music", "03-Individual-movie", "10-assets", "20-documentation"):
         (collection / subdir).mkdir(parents=True, exist_ok=True)
     (collection / "01-master" / "master.mp4").write_bytes(b"probe is mocked")
-    (collection / "20-documentation" / "descriptions.md").write_text(
-        """## タイトル案
-```
-Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves
-```
-
-## Complete Collection 概要欄
-```
-00:00 Opening Groove
-10:00 Midnight Funk
-20:00 Last Call Soul
-```
-
-## タグ（YouTube タグ欄）
-```
-soul funk, retro groove, study music
-```
-""",
-        encoding="utf-8",
+    write_video_description_pair(
+        collection / "20-documentation",
+        title="Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves",
+        description="00:00 Opening Groove\n10:00 Midnight Funk\n20:00 Last Call Soul",
+        tags=["soul funk", "retro groove", "study music"],
     )
     state: dict[str, object] = {"scene_phrases": {lang: {"title": f"title-{lang}"} for lang in ("ja", "en", "de")}}
     if title_template_check is not None:

--- a/tests/domains/uploads/test_description_document.py
+++ b/tests/domains/uploads/test_description_document.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.video_description import write_video_description_pair
+from youtube_automation.core.errors import DocumentRenderError, ValidationError
+from youtube_automation.domains.uploads.description_document import load_description_document
+
+
+def test_upload_loader_reads_only_validated_json_pair(tmp_path: Path) -> None:
+    documentation = tmp_path / "20-documentation"
+    documentation.mkdir()
+    write_video_description_pair(documentation, tags=["focus", "rain"])
+
+    metadata = load_description_document(tmp_path)
+
+    assert metadata is not None
+    assert metadata["title"] == "Rain Focus — Complete Collection"
+    assert metadata["tags"] == ["focus", "rain"]
+
+
+def test_upload_loader_rejects_legacy_markdown_instead_of_parsing_it(tmp_path: Path) -> None:
+    documentation = tmp_path / "20-documentation"
+    documentation.mkdir()
+    (documentation / "descriptions.md").write_text("## タイトル案\n```\nlegacy\n```", encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="明示 migration"):
+        load_description_document(tmp_path)
+
+
+def test_upload_loader_fails_closed_when_pair_is_tampered(tmp_path: Path) -> None:
+    documentation = tmp_path / "20-documentation"
+    documentation.mkdir()
+    source = write_video_description_pair(documentation)
+    source.with_suffix(".html").write_text("tampered", encoding="utf-8")
+
+    with pytest.raises(DocumentRenderError, match="対応していません"):
+        load_description_document(tmp_path)

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import json
-import re
-import unicodedata
 from pathlib import Path
 
 import pytest
 
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.uploads.youtube import PreflightChecker, YouTubeAutoUploader
@@ -79,32 +78,16 @@ def _write_collection(
     scene_phrases: dict[str, str],
     description: str,
     tags: list[str] | None = None,
+    title: str = "Continuous Focus Mix",
 ) -> Path:
     collection_dir = channel_dir / "collections" / "planning" / "20260622-tc-continuous"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True, exist_ok=True)
-    tags_section = (
-        ""
-        if tags is None
-        else f"""\n## タグ（YouTube タグ欄）
-```
-{", ".join(tags)}
-```
-"""
-    )
-    (docs_dir / "descriptions.md").write_text(
-        f"""## タイトル案
-```
-Continuous Focus Mix
-```
-
-## Complete Collection 概要欄
-```
-{description}
-```
-{tags_section}
-""",
-        encoding="utf-8",
+    write_video_description_pair(
+        docs_dir,
+        title=title,
+        description=description,
+        tags=[] if tags is None else tags,
     )
     _write_json(collection_dir / "workflow-state.json", {"scene_phrases": scene_phrases})
     master_dir = collection_dir / "01-master"
@@ -133,7 +116,7 @@ def _run_preflight(
     checker.check(collection_dir)
 
 
-def test_heading_mismatch_reports_expected_missing_detected_and_fix_example(tmp_path: Path) -> None:
+def test_legacy_markdown_is_not_parsed_by_preflight(tmp_path: Path) -> None:
     collection_dir = tmp_path / "collections" / "planning" / "20260630-heading-typo"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True)
@@ -154,39 +137,22 @@ A continuous BGM mix without chapter markers.
     with pytest.raises(ValidationError) as excinfo:
         PreflightChecker(tmp_path / "collections").check(collection_dir)
 
-    message = str(excinfo.value)
-    assert "期待する見出し（完全一致）" in message
-    assert ("不足/不一致の見出し:\n  - ## タイトル案\n  - ## タグ（YouTube タグ欄）") in message
-    assert "検出した ## 見出し" in message
-    assert "## タイトル" in message
-    assert "修正例" in message
-    assert "/video --describe を再実行" in message
+    assert "descriptions.json が存在しません" in str(excinfo.value)
 
 
-def test_empty_sections_keep_empty_section_error(tmp_path: Path) -> None:
+def test_invalid_json_pair_fails_closed(tmp_path: Path) -> None:
     collection_dir = tmp_path / "collections" / "planning" / "20260630-empty-title"
     docs_dir = collection_dir / "20-documentation"
     docs_dir.mkdir(parents=True)
-    (docs_dir / "descriptions.md").write_text(
-        """## タイトル案
-```
-
-```
-
-## Complete Collection 概要欄
-```
-A continuous BGM mix without chapter markers.
-```
-""",
-        encoding="utf-8",
-    )
+    source = write_video_description_pair(docs_dir)
+    document = json.loads(source.read_text(encoding="utf-8"))
+    document["title"] = ""
+    source.write_text(json.dumps(document), encoding="utf-8")
 
     with pytest.raises(ValidationError) as excinfo:
         PreflightChecker(tmp_path / "collections").check(collection_dir)
 
-    message = str(excinfo.value)
-    assert "タイトル案 / Complete Collection 概要欄 が空" in message
-    assert "不足/不一致の見出し" not in message
+    assert "pointer=/title" in str(excinfo.value)
 
 
 def test_en_only_channel_without_timestamps_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -210,15 +176,7 @@ def test_three_part_title_template_passes_collection_preflight(tmp_path: Path, m
         channel_dir,
         scene_phrases={"en": "continuous focus mix"},
         description="A continuous BGM mix without chapter markers.",
-    )
-    descriptions_path = collection_dir / "20-documentation" / "descriptions.md"
-    descriptions = descriptions_path.read_text(encoding="utf-8")
-    descriptions_path.write_text(
-        descriptions.replace(
-            "Continuous Focus Mix",
-            "YAKAP NG PAMILYA 💛 | Inspirational Pinoy Reggae Music 2026 | Awit ng Pagmamahal",
-        ),
-        encoding="utf-8",
+        title="YAKAP NG PAMILYA 💛 | Inspirational Pinoy Reggae Music 2026 | Awit ng Pagmamahal",
     )
 
     _run_preflight(channel_dir, collection_dir, monkeypatch)
@@ -304,143 +262,6 @@ def test_low_cpm_localization_warning_still_runs(
     _run_preflight(channel_dir, collection_dir, monkeypatch)
 
     assert "low CPM localization languages included: ko" in caplog.text
-
-
-def test_plan_preflight_rejects_overlong_localized_title(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "de"])
-    _write_json(
-        channel_dir / "config" / "localizations.json",
-        {
-            "supported_languages": ["en", "de"],
-            "languages": {
-                "en": {"title_template": "{scene_phrase}"},
-                "de": {"title_template": "{scene_phrase} " + "x" * 100},
-            },
-        },
-    )
-    collection_dir = _write_collection(
-        channel_dir,
-        scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
-        description="A continuous BGM mix without chapter markers.",
-    )
-
-    with pytest.raises(ValidationError, match=r"\[de\] 114 codepoints.*ruhiger Fokus") as excinfo:
-        _run_preflight(channel_dir, collection_dir, monkeypatch)
-
-    message = str(excinfo.value)
-    assert "fixed=101c" in message
-    assert "scene_phrase=13c" in message
-
-
-@pytest.mark.parametrize(
-    ("locale", "title_template", "expected_literal"),
-    [
-        ("ja-JP", "3時間の{scene_phrase}", "3時間"),
-        ("FR-fr", "3 Heures de {scene_phrase}", "3 Heures"),
-        ("es-419", "3 Horas de {scene_phrase}", "3 Horas"),
-        ("it-IT", "3 Ore di {scene_phrase}", "3 Ore"),
-    ],
-)
-def test_plan_preflight_rejects_static_localized_duration(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    locale: str,
-    title_template: str,
-    expected_literal: str,
-) -> None:
-    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", locale])
-    _write_json(
-        channel_dir / "config" / "localizations.json",
-        {
-            "supported_languages": ["en", locale],
-            "languages": {
-                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
-                locale: {"title_template": title_template},
-            },
-        },
-    )
-    collection_dir = _write_collection(
-        channel_dir,
-        scene_phrases={"en": "focus", locale: "localized focus"},
-        description="A continuous BGM mix without chapter markers.",
-    )
-
-    with pytest.raises(ValidationError, match=rf"固定尺 '{re.escape(expected_literal)}'"):
-        _run_preflight(channel_dir, collection_dir, monkeypatch)
-
-
-def test_plan_preflight_accepts_nfd_word_continuation_after_hour_prefix(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    locale = "es-ES"
-    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", locale])
-    title_template = unicodedata.normalize("NFD", "{scene_phrase} | 3 horário mix")
-    _write_json(
-        channel_dir / "config" / "localizations.json",
-        {
-            "supported_languages": ["en", locale],
-            "languages": {
-                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
-                locale: {"title_template": title_template},
-            },
-        },
-    )
-    collection_dir = _write_collection(
-        channel_dir,
-        scene_phrases={"en": "focus", locale: "enfoque"},
-        description="A continuous BGM mix without chapter markers.",
-    )
-
-    _run_preflight(channel_dir, collection_dir, monkeypatch)
-
-
-def test_plan_preflight_passes_actual_master_duration_to_localizations(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, float] = {}
-
-    class _Generator:
-        def __init__(self, _collection_dir: str) -> None:
-            self.config = None
-
-        @staticmethod
-        def _load_scene_emoji() -> str:
-            return ""
-
-        def generate_localizations(self, *_args, duration_seconds: float, **_kwargs):
-            captured["duration_seconds"] = duration_seconds
-            return {"en": {"title": "Focus [10.5 Hours]"}}
-
-    channel_dir = _write_minimal_channel(tmp_path, youtube_language="en", supported_languages=["en", "de"])
-    _write_json(
-        channel_dir / "config" / "localizations.json",
-        {
-            "supported_languages": ["en", "de"],
-            "languages": {
-                "en": {"title_template": "{scene_phrase} [{duration_display}]"},
-                "de": {"title_template": "{scene_phrase} [{duration_display}]"},
-            },
-        },
-    )
-    collection_dir = _write_collection(
-        channel_dir,
-        scene_phrases={"en": "focus", "de": "ruhiger Fokus"},
-        description="A continuous BGM mix without chapter markers.",
-    )
-    _run_preflight(
-        channel_dir,
-        collection_dir,
-        monkeypatch,
-        duration_seconds=10 * 3600 + 32 * 60,
-        metadata_generator_factory=_Generator,
-    )
-
-    assert captured == {"duration_seconds": 10 * 3600 + 32 * 60}
 
 
 def test_target_duration_config_allows_video_inside_target(

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -28,6 +28,7 @@ from googleapiclient.errors import HttpError
 from httplib2 import Response
 
 from tests.helpers.paths import REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.core.errors import ValidationError
 
 sys.path.insert(0, str(REPO_ROOT))
@@ -218,28 +219,11 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
     col_dir = tmp_path / "20990101-foo-collection"
     doc_dir = col_dir / "20-documentation"
     doc_dir.mkdir(parents=True)
-    (doc_dir / "descriptions.md").write_text(
-        "\n".join(
-            [
-                "## タイトル案",
-                "```",
-                "Rainy Jazz for Focus",
-                "```",
-                "",
-                "## Complete Collection 概要欄",
-                "```",
-                "00:00 Opening Rain",
-                "10:00 Warm Desk Light",
-                "20:00 Last Train Home",
-                "```",
-                "",
-                "## タグ（YouTube タグ欄）",
-                "```",
-                "rainy jazz, focus music, night study",
-                "```",
-            ]
-        ),
-        encoding="utf-8",
+    write_video_description_pair(
+        doc_dir,
+        title="Rainy Jazz for Focus",
+        description="00:00 Opening Rain\n10:00 Warm Desk Light\n20:00 Last Train Home",
+        tags=["rainy jazz", "focus music", "night study"],
     )
     scene_phrases = {lang: {"title": f"title-{lang}"} for lang in scene_languages}
     (col_dir / "workflow-state.json").write_text(
@@ -314,28 +298,11 @@ def _write_title_collection(
     col_dir = tmp_path / status / "20990101-foo-collection"
     doc_dir = col_dir / "20-documentation"
     doc_dir.mkdir(parents=True)
-    (doc_dir / "descriptions.md").write_text(
-        "\n".join(
-            [
-                "## タイトル案",
-                "```",
-                title,
-                "```",
-                "",
-                "## Complete Collection 概要欄",
-                "```",
-                "00:00 Opening Groove",
-                "10:00 Midnight Funk",
-                "20:00 Last Call Soul",
-                "```",
-                "",
-                "## タグ（YouTube タグ欄）",
-                "```",
-                "soul funk, retro groove, study music",
-                "```",
-            ]
-        ),
-        encoding="utf-8",
+    write_video_description_pair(
+        doc_dir,
+        title=title,
+        description="00:00 Opening Groove\n10:00 Midnight Funk\n20:00 Last Call Soul",
+        tags=["soul funk", "retro groove", "study music"],
     )
     scene_phrases = {lang: {"title": f"title-{lang}"} for lang in ["en", "ja", "de"]}
     workflow_state: dict[str, object] = {"scene_phrases": scene_phrases}
@@ -354,10 +321,7 @@ def _write_title_collection(
 def _write_live_title(tmp_path: Path, slug: str, title: str) -> None:
     doc_dir = tmp_path / "live" / slug / "20-documentation"
     doc_dir.mkdir(parents=True)
-    (doc_dir / "descriptions.md").write_text(
-        f"## タイトル案\n```\n{title}\n```\n",
-        encoding="utf-8",
-    )
+    write_video_description_pair(doc_dir, title=title)
 
 
 class TestPreflightTitleTemplateCompliance:
@@ -1196,29 +1160,18 @@ class TestUploadCompleteCollectionDedup:
         (col_dir / "10-assets").mkdir()
         (col_dir / "10-assets" / "thumbnail.jpg").write_bytes(b"\x00")
         (col_dir / "20-documentation").mkdir()
-        (col_dir / "20-documentation" / "descriptions.md").write_text(
-            "\n".join(
-                [
-                    "## タイトル案",
-                    "```",
-                    "Circuit Collection",
-                    "```",
-                    "",
-                    "## Complete Collection 概要欄",
-                    "```",
-                    "00:00 Curated Circuit Door",
-                    "```",
-                    "",
-                    "## タグ（YouTube タグ欄）",
-                    "```",
-                    "circuit music, focus music",
-                    "```",
-                ]
-            ),
-            encoding="utf-8",
-        )
         config = load_config()
         scene_phrases = {lang: f"quiet circuit room {lang}" for lang in config.localizations.supported_languages}
+        write_video_description_pair(
+            col_dir / "20-documentation",
+            title="Circuit Collection",
+            description="00:00 Curated Circuit Door",
+            tags=["circuit music", "focus music"],
+            localizations={
+                lang: {"title": f"Circuit Collection {lang}", "description": "00:00 Curated Circuit Door"}
+                for lang in config.localizations.supported_languages
+            },
+        )
         (col_dir / "workflow-state.json").write_text(
             json.dumps({"scene_phrases": scene_phrases}),
             encoding="utf-8",

--- a/tests/helpers/video_description.py
+++ b/tests/helpers/video_description.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from youtube_automation.domains.documents.rendering import render_repository_document
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
+
+
+def write_video_description_pair(
+    documentation: Path,
+    *,
+    title: str = "Rain Focus — Complete Collection",
+    description: str = "Opening\n\n00:00 Quiet Rain\n\n#Focus",
+    tags: list[str] | None = None,
+    localizations: dict[str, object] | None = None,
+    tracks: list[dict[str, object]] | None = None,
+) -> Path:
+    document = {
+        "schema_version": 1,
+        "generated_at": "2026-08-16T00:00:00Z",
+        "collection_id": documentation.parent.name,
+        "title": title,
+        "description": description,
+        "description_sections": [{"id": "body", "heading": "Description", "body": description}],
+        "tracks": [{"position": 1, "start": "00:00", "title": "Quiet Rain"}] if tracks is None else tracks,
+        "tags": ["focus music"] if tags is None else tags,
+        "localizations": {} if localizations is None else localizations,
+        "provenance": {"producer": "video", "source_paths": ["workflow-state.json"]},
+        "quality": {
+            "status": "pass",
+            "checks": [{"id": "metadata", "status": "pass", "message": "fixture verified"}],
+        },
+    }
+    source = documentation / "descriptions.json"
+    source.write_text(json.dumps(document), encoding="utf-8")
+    source.with_suffix(".html").write_text(
+        render_repository_document(RepositorySchema.VIDEO_DESCRIPTION, document),
+        encoding="utf-8",
+    )
+    return source

--- a/tests/infrastructure/media/test_collection_paths.py
+++ b/tests/infrastructure/media/test_collection_paths.py
@@ -88,6 +88,7 @@ class TestFilePathProperties:
     def test_descriptions_md_path(self, tmp_path):
         paths = CollectionPaths(tmp_path)
         assert paths.descriptions_md_path == tmp_path / "20-documentation" / "descriptions.md"
+        assert paths.descriptions_json_path == tmp_path / "20-documentation" / "descriptions.json"
 
     def test_thumbnail_prompts_path(self, tmp_path):
         paths = CollectionPaths(tmp_path)

--- a/tests/repo/test_channel_new_residual_contract.py
+++ b/tests/repo/test_channel_new_residual_contract.py
@@ -16,7 +16,7 @@ SETUP_REFERENCES = REPO_ROOT / ".claude" / "skills" / "setup" / "references"
 
 SETUP_ASSET_SHA256 = {
     "claude-md-template.md": "64882d3cbe6c1d69c982f723d2a62bf67a88aa6895dddc79b75ce3c45857bbdd",
-    "config-generation-rules.md": "13797bb024570b0063453a7c3ec7b7b055a702a00231c9df0d4ae4197b915910",
+    "config-generation-rules.md": "73067404592646cc3073f9ca1912c703f57f25fc9a6f597c4843622f8f3f9188",
     "config-template/analytics.json": "4344ad8d4c9a1c81958b721eb3d999172f14f71f17d863a1708492ce687b68d2",
     "config-template/audio.json": "c55033dc448cb91fe3cdb47e20f220c5879c05f95855d918a8e72297a5f20a43",
     "config-template/content.json": "5a60fc3327bb2cca1daa5da3744dc218495f3f0f304aebdad41fd2ba32d1bed0",

--- a/tests/repo/test_publish_upload_skill_contract.py
+++ b/tests/repo/test_publish_upload_skill_contract.py
@@ -39,7 +39,8 @@ def test_publish_chain_manifest_keeps_upload_approval_gate() -> None:
         "skill": "publish",
         "prerequisiteArtifacts": [
             "collections/<id>/01-master/*.mp4",
-            "collections/<id>/20-documentation/descriptions.md",
+            "collections/<id>/20-documentation/descriptions.json",
+            "collections/<id>/20-documentation/descriptions.html",
         ],
         "outputArtifacts": [
             "collections/<id>/20-documentation/upload_tracking.json",

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -197,6 +197,7 @@ assert set(schema_registry.repository_schema_names()) == {
     "feedback-entry.schema.json",
     "insights-entry.schema.json",
     "music-prompt.schema.json",
+    "video-description.schema.json",
     "weekly_vote_log.schema.json",
 }
 rendering = importlib.import_module("youtube_automation.domains.documents.rendering")

--- a/tests/repo/test_video_chain_state.py
+++ b/tests/repo/test_video_chain_state.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 
 from tests.helpers.paths import REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 
 SCRIPT = REPO_ROOT / ".claude" / "skills" / "video" / "references" / "video-chain-state.py"
 
@@ -93,14 +94,36 @@ def test_describe_skips_only_when_state_and_description_file_are_complete(tmp_pa
     (collection / "01-master" / "master.mp4").touch()
     docs = collection / "20-documentation"
     docs.mkdir()
-    (docs / "descriptions.md").write_text("# description\n", encoding="utf-8")
+    write_video_description_pair(docs)
     state_path = collection / "workflow-state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
-    state["description"] = {"generated": True}
+    state["assets"]["description"] = True
     state_path.write_text(json.dumps(state), encoding="utf-8")
 
     code, result = module.evaluate(collection, "describe")
 
     assert code == module.EXIT_SKIP
     assert result["decision"] == "skip"
-    assert result["artifacts"] == ["20-documentation/descriptions.md"]
+    assert result["artifacts"] == [
+        "20-documentation/descriptions.json",
+        "20-documentation/descriptions.html",
+    ]
+
+
+def test_describe_does_not_skip_when_published_pair_is_tampered(tmp_path: Path) -> None:
+    module = _module()
+    collection = _collection(tmp_path, "01-master/master.mp4")
+    (collection / "01-master" / "master.mp4").touch()
+    docs = collection / "20-documentation"
+    docs.mkdir()
+    source = write_video_description_pair(docs)
+    source.with_suffix(".html").write_text("tampered", encoding="utf-8")
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["assets"]["description"] = True
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    code, result = module.evaluate(collection, "describe")
+
+    assert code == module.EXIT_RUN
+    assert result["reason"] == "description_pair_invalid"

--- a/tests/repo/test_video_generate_skill_contract.py
+++ b/tests/repo/test_video_generate_skill_contract.py
@@ -61,7 +61,10 @@ def test_video_chain_manifest_runs_generate_then_describe_without_approval_gates
             "id": "describe",
             "skill": "video",
             "prerequisiteArtifacts": ["collections/<id>/01-master/master.mp4"],
-            "outputArtifacts": ["collections/<id>/20-documentation/descriptions.md"],
+            "outputArtifacts": [
+                "collections/<id>/20-documentation/descriptions.json",
+                "collections/<id>/20-documentation/descriptions.html",
+            ],
             "approvalGate": {
                 "skip": True,
                 "configPath": "workflow.video.skip_approvals.describe",

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -13,6 +13,7 @@ from types import ModuleType
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 
 ROOT = REPO_ROOT
 SKILL_DIR = ROOT / ".claude" / "skills" / "wf-new"
@@ -164,7 +165,7 @@ def test_existing_collection_resumes_from_verified_artifacts(tmp_path: Path, run
     )
     (collection / "01-master" / "master.wav").touch()
     (collection / "01-master" / "video.mp4").touch()
-    (collection / "20-documentation" / "descriptions.md").touch()
+    write_video_description_pair(collection / "20-documentation")
 
     decision = runner.resolve_action(tmp_path, config=_config(runner, publish=False))
 

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -315,6 +315,7 @@ MUTABLE_FILES = frozenset(
     "publish/references/pinned.md",
     "publish/references/publish-chain-manifest.json",
     "publish/references/publish-chain-state.py",
+    "publish/references/upload.md",
     "publish/references/scheduled-publish.md",
     "wf-new/references/phase-2c-artifact-contract.md",
     "wf-new/references/phase2.md",
@@ -371,6 +372,11 @@ MUTABLE_FILES = frozenset(
     "video/SKILL.md",
     "video/references/describe.md",
     "video/references/generate.md",
+    "video/references/description-templates.md",
+    "video/references/video-chain-manifest.json",
+    "video/references/video-chain-state.py",
+    "video/references/video-description-documents.md",
+    "video/references/video-description.schema.json",
     "wf-new/references/freshness-rules.md",
     "wf-new/references/ideate.md",
     "wf-next/SKILL.md",
@@ -396,7 +402,7 @@ EXPECTED_ISSUE_3986_CHANGED_PATHS = frozenset(
         "tests/repo/test_workflow_upload_setup_redirect_contract.py",
     }
 )
-IMMUTABLE_TARGET_FILES_SHA256 = "f18ea6a8ace9729a5cc2f01f339c3c3f60bb84a4b1b07927c7720bd4d989f8f0"
+IMMUTABLE_TARGET_FILES_SHA256 = "6b89c6acba681f832ec248468bed8a22d8c92d53f2e787648e8b31dba44a156f"
 AUTOMATION_SCHEDULE_REGENERATE_SHA256 = "11d460f727fe50c41f00571b416a1486cb07d0b1548524bc650a7161c16f6c42"
 AUTOMATION_UPDATE_PUSH_SHA256 = "ced3211760d9ff0abd20ec3cdc402501b424f48581ef3a618d51c0d9ee12840c"
 ALLOWED_FENCED_ROUTES = {


### PR DESCRIPTION
## 概要

動画説明・公開準備文書をschema検証済み `descriptions.json` 正本と同basename HTML表示へ移行します。

## 変更内容

- 動画説明schema、JSON+HTML publisher/readerを追加
- schema・localization・quality・pair mismatchをfail-closed化
- upload / metadata / captions consumerをvalidated JSON-onlyへ移行
- legacy Markdownは明示migrationとrollbackを必須化
- pair再読込成功後だけworkflow stateへ投影
- video / publish / audit / setup / short / workflow skill契約を更新
- wheel/sdist resources、CHANGELOG、architecture契約を追従

## 検証

- full: 9,283 passed / 3 skipped
- post-rebase focused: 1,253 passed
- ruff / format / yt-skills lint・artifacts: green
- wheel + sdist build: green
- wheel smoke: 2 passed
- site build/check + 53 tests: green
- ブラウザ実機・外部APIなし

Closes #4030
