### PR TITLE
refactor(workflow-state): assets.videoのデッドパスを削除する (#3892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
 - `refactor(workflow-state)`: collection の音楽エンジンを `planning.music.engine` へ統合し、旧 top-level `music_engine` は一致検証付きの読み取り互換だけに限定する（#3891）。
 - `refactor(workflow-state)`: 概要欄生成状態を `assets.description` へ統合し、旧 `description.generated` は owner accessor の読み取り互換だけに限定する（#3890）。

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -157,7 +157,7 @@ def _completed_stages(root: Path, collection: Path, state: WorkflowState) -> fro
         _skip_manual_mastering(root) and _file_asset_present(assets.raw_master)
     ):
         completed.add("マスター化")
-    if _file_asset_present(assets.video) or _file_asset_present(assets.master_video):
+    if _file_asset_present(assets.master_video):
         completed.add("動画化")
     if state.thumbnail_approved:
         completed.add("サムネイル")

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -259,10 +259,6 @@ class AssetsState(_ObjectSection):
     def master_video(self, value: str | None) -> None:
         self._data["master_video"] = value
 
-    @property
-    def video(self) -> str | None:
-        return _optional_string(self._data, "video", "workflow-state.json::assets.video")
-
     def set_known(self, key: AssetKey, value: JSONValue) -> None:
         """CLI が公開する asset key を schema 検証して更新する。"""
         if key == "thumbnail":

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -144,7 +144,7 @@ def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
         "new-collection",
         {
             "phase": "prepared",
-            "assets": {"raw_master": None, "master_audio": None, "video": None, "thumbnail": False},
+            "assets": {"raw_master": None, "master_audio": None, "master_video": None, "thumbnail": False},
         },
     )
 
@@ -154,6 +154,44 @@ def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
     assert "  ○  音源生成" in message
     assert "  ▸  マスター化" in message
     assert "  ○  動画化" in message
+
+
+def test_should_not_mark_video_stage_from_unknown_legacy_video_asset(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "legacy-video",
+        {
+            "phase": "prepared",
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "video": "legacy.mp4"},
+        },
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-thumbnail-text")
+
+    assert "  ○  動画化" in message
+
+
+def test_should_mark_video_stage_from_canonical_master_video_asset(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "canonical-video",
+        {
+            "phase": "prepared",
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "master_video": "master.mp4"},
+        },
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-thumbnail-text")
+
+    assert "  ✓  動画化" in message
 
 
 def test_should_read_legacy_thumbnail_approval_through_owner_accessor(
@@ -218,7 +256,7 @@ def test_should_prefer_named_collection_across_planning_and_live(
         "selected-live",
         {
             "phase": "complete",
-            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "video": "video.mp4"},
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "master_video": "video.mp4"},
         },
         modified_at=100,
     )
@@ -268,7 +306,7 @@ def test_should_mark_post_publish_and_analysis_from_channel_artifacts(
         "published",
         {
             "phase": "complete",
-            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "video": "video.mp4"},
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "master_video": "video.mp4"},
             "upload": {"video_id": "video-123", "publish_at": "2026-07-20T12:00:00+09:00"},
         },
     )

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -241,11 +241,23 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
     assert state.planning.final_title_en == "Rainy Focus"
     assert state.planning.final_title == "雨の集中時間"
     assert state.assets is not None
-    assert state.assets.video == "master.mp4"
+    assert state.assets["video"] == "master.mp4"
+    with pytest.raises(AttributeError):
+        _legacy_video = state.assets.video
     assert state.track_display_names == {"01-rain.wav": "Rain Window"}
     assert state.post_upload is not None
     assert state.post_upload.shorts == [{"short_num": 1, "video_id": "short-1"}]
     assert state["future_section"] == {"enabled": True}
+
+
+def test_update_preserves_unknown_legacy_asset_fields_without_typed_accessors(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(state_path, {"phase": "planning", "assets": {"video": "legacy.mp4", "future": {"keep": True}}})
+
+    update(state_path, lambda state: setattr(state, "phase", "prepared"))
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["assets"] == {"video": "legacy.mp4", "future": {"keep": True}}
 
 
 @pytest.mark.parametrize(

--- a/tests/fixtures/progress_hook/workflow-state-mastered.json
+++ b/tests/fixtures/progress_hook/workflow-state-mastered.json
@@ -5,7 +5,7 @@
   "assets": {
     "raw_master": "raw.wav",
     "master_audio": "master.wav",
-    "video": null,
+    "master_video": null,
     "thumbnail": true
   },
   "upload": {


### PR DESCRIPTION
## 概要

writerが存在しない `assets.video` の明示型・progress分岐を削除し、動画化判定を `assets.master_video` に一本化します。

## 変更内容

- `AssetsState.video` の明示accessorを削除
- progress hookの `assets.video OR assets.master_video` を正準master_videoだけへ変更
- 旧 `assets.video` はunknown mappingとしてread/update round-trip保持
- legacy fieldを属性APIや進捗判定へ再昇格しない契約を追加
- CHANGELOG、owner/progress fixturesを追従

## 検証

- full: 9,409 passed / 3 skipped
- focused: 79 passed
- ruff / format / yt-skills / Any gate: green
- wheel smoke: 2 passed

Closes #3892
