### PR TITLE
refactor(workflow-state): 旧video_id fallbackを削除する (#3893)

### DIFF
--- a/.claude/skills/publish/references/pinned.md
+++ b/.claude/skills/publish/references/pinned.md
@@ -125,6 +125,7 @@ uv run yt-pinned-comment --collection collections/live/<latest-dir> --apply --la
 
 ## トラブルシュート
 
+- `workflow-state.json の top-level video_id はサポートされていません` → 旧 top-level `video_id` を値として利用せず、`uv run yt-workflow-state --collection <path> set-upload --video-id <video-id>` で正準の `upload.video_id` へ修復してから再実行
 - `pinned_comment.enabled=false です` → `config/channel/pinned-comment.json` で `enabled: true` に変更
 - `SKIP ... already_posted` ばかり → 対象動画は既に投稿済み。`pinned_comment_history.json` を確認
 - `SKIP ... video_not_found` → 削除済み / 存在しない video_id。collection の状態ファイルを確認

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -273,6 +273,8 @@ top-level `music_engine` は既存 state の読み取り専用互換 field で�
 `/wf-status` は `steps` キーの有無で旧/新スキーマを判別し、旧スキーマの場合は従来の表示を行う。
 旧スキーマの live コレクションは変換不要（読み取り専用）。
 
+旧 top-level `video_id` は公開対象の判定に使用しない。`/publish --pinned` など公開後処理を再開する場合は、`uv run yt-workflow-state --collection <path> set-upload --video-id <video-id>` で正準の `upload.video_id` へ修復する。
+
 ## 更新ルール
 
 - 各操作で `updated_at` を現在時刻（ISO 8601 UTC）に上書き

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(workflow-state)`: 旧 top-level `video_id` fallback と typed accessor を削除し、公開済み動画の正準 read を `upload.video_id` に限定する（#3893）。
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
 - `refactor(workflow-state)`: collection の音楽エンジンを `planning.music.engine` へ統合し、旧 top-level `music_engine` は一致検証付きの読み取り互換だけに限定する（#3891）。

--- a/src/youtube_automation/commands/analytics/experiment_judge.py
+++ b/src/youtube_automation/commands/analytics/experiment_judge.py
@@ -129,15 +129,20 @@ def _workflow_video_id(path: Path) -> str | None:
     try:
         state = read_workflow_state(path)
         upload = state.upload
-        upload_value = upload.video_id if upload is not None else None
-        value = upload_value if upload_value is not None else state.video_id
-        context = "upload.video_id" if upload_value is not None else "video_id"
+        value = upload.video_id if upload is not None else None
+        if value is None and "video_id" in state:
+            raise ValidationError(
+                "workflow-state.json の top-level video_id はサポートされていません。"
+                "正準キー upload.video_id へ修復してください:\n"
+                f'uv run yt-workflow-state --collection "{path.parent}" '
+                "set-upload --video-id <video-id>"
+            )
     except WorkflowStateError as error:
         raise ValidationError(f"collection state JSON を読めません: {path}") from error
     if value is None:
         return None
     if not value.strip():
-        raise ValidationError(f"{context} は空でない video_id にしてください")
+        raise ValidationError("upload.video_id は空でない video_id にしてください")
     return value.strip()
 
 

--- a/src/youtube_automation/commands/youtube/pinned_comment.py
+++ b/src/youtube_automation/commands/youtube/pinned_comment.py
@@ -92,11 +92,13 @@ def render_template(
 def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, WorkflowState | None]]:
     """コレクションから ``(video_id, workflow_state)`` のペアを解決する.
 
-    video_id 解決の fallback chain（upstream の書き込み先差異を吸収）:
+    video_id 解決の優先順:
         1. ``20-documentation/upload_tracking.json`` の ``complete_collection.video_id``
            （`CollectionUploader` が書く正規の場所）
         2. ``workflow-state.json`` の ``upload.video_id``
-        3. ``workflow-state.json`` トップレベルの ``video_id``（後方互換）
+
+    ``workflow-state.json`` トップレベルの旧 ``video_id`` は値として読まず、
+    owner CLI による ``upload.video_id`` への修復を要求する。
 
     scene 情報（scene_phrases / planning.scene_emoji / theme）は workflow-state.json から取る。
     """
@@ -114,7 +116,14 @@ def resolve_targets_from_collection(collection_path: Path) -> list[tuple[str, Wo
 
     if not video_id and state:
         upload = state.upload
-        video_id = (upload.video_id if upload is not None else None) or state.video_id
+        video_id = upload.video_id if upload is not None else None
+        if not video_id and "video_id" in state:
+            raise ValidationError(
+                "workflow-state.json の top-level video_id はサポートされていません。"
+                "正準キー upload.video_id へ修復してください:\n"
+                f'uv run yt-workflow-state --collection "{collection_path}" '
+                "set-upload --video-id <video-id>"
+            )
 
     if not video_id:
         raise ValidationError(

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -540,10 +540,6 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         return _optional_string(self._data, "created_at", "workflow-state.json::created_at")
 
     @property
-    def video_id(self) -> str | None:
-        return _optional_string(self._data, "video_id", "workflow-state.json::video_id")
-
-    @property
     def collection_name(self) -> str | None:
         return _optional_string(self._data, "collection_name", "workflow-state.json::collection_name")
 

--- a/tests/commands/analytics/test_experiment_judge.py
+++ b/tests/commands/analytics/test_experiment_judge.py
@@ -200,7 +200,7 @@ def test_planning_collection_is_unpublished_without_snapshot_and_bytes_stay_same
     assert path.read_bytes() == before
 
 
-@pytest.mark.parametrize("source", ["tracking", "workflow_upload", "workflow_top"])
+@pytest.mark.parametrize("source", ["tracking", "workflow_upload"])
 def test_live_collection_resolves_video_id_in_contract_order(tmp_path, source: str) -> None:
     collection = tmp_path / "collections" / "live" / "next"
     collection.mkdir(parents=True)
@@ -214,10 +214,6 @@ def test_live_collection_resolves_video_id_in_contract_order(tmp_path, source: s
         _write_object(tracking, {"complete_collection": {}})
         _write_object(workflow, {"upload": {"video_id": "FROM_UPLOAD"}, "video_id": "FROM_TOP"})
         expected_id = "FROM_UPLOAD"
-    else:
-        _write_object(tracking, {"complete_collection": {}})
-        _write_object(workflow, {"upload": {}, "video_id": "FROM_TOP"})
-        expected_id = "FROM_TOP"
     _write_jsonl(tmp_path / "data" / "experiments.jsonl", [_experiment(target="next")])
     captured: list[str] = []
 
@@ -227,6 +223,22 @@ def test_live_collection_resolves_video_id_in_contract_order(tmp_path, source: s
 
     _judge(tmp_path, snapshot)
     assert captured == [expected_id]
+
+
+def test_live_collection_rejects_toplevel_only_video_id_with_canonical_repair_guidance(tmp_path) -> None:
+    collection = tmp_path / "collections" / "live" / "next"
+    collection.mkdir(parents=True)
+    _write_object(collection / "workflow-state.json", {"video_id": "FROM_TOP"})
+    _write_jsonl(tmp_path / "data" / "experiments.jsonl", [_experiment(target="next")])
+
+    with pytest.raises(ValidationError) as exc_info:
+        _judge(tmp_path, lambda _ids: pytest.fail("legacy top-level video_id must not be fetched"))
+
+    message = str(exc_info.value)
+    assert "top-level video_id" in message
+    assert "upload.video_id" in message
+    assert "yt-workflow-state" in message
+    assert "set-upload --video-id <video-id>" in message
 
 
 def test_non_collection_target_is_exact_video_id_and_missing_is_structured_skip(tmp_path) -> None:

--- a/tests/commands/youtube/test_pinned_comment.py
+++ b/tests/commands/youtube/test_pinned_comment.py
@@ -346,15 +346,22 @@ def test_resolve_prefers_tracking_video_id(tmp_path):
 
 
 def test_resolve_falls_back_to_workflow_upload_video_id(tmp_path):
-    col = _make_collection(tmp_path, workflow={"upload": {"video_id": "WF1"}})
+    col = _make_collection(tmp_path, workflow={"upload": {"video_id": "WF1"}, "video_id": "TOP1"})
     targets = resolve_targets_from_collection(col)
     assert targets[0][0] == "WF1"
 
 
-def test_resolve_falls_back_to_toplevel_video_id(tmp_path):
+def test_resolve_rejects_toplevel_only_video_id_with_canonical_repair_guidance(tmp_path):
     col = _make_collection(tmp_path, workflow={"video_id": "TOP1"})
-    targets = resolve_targets_from_collection(col)
-    assert targets[0][0] == "TOP1"
+
+    with pytest.raises(ValidationError) as exc_info:
+        resolve_targets_from_collection(col)
+
+    message = str(exc_info.value)
+    assert "top-level video_id" in message
+    assert "upload.video_id" in message
+    assert "yt-workflow-state" in message
+    assert "set-upload --video-id <video-id>" in message
 
 
 def test_resolve_raises_when_no_video_id(tmp_path):

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -205,6 +205,7 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
             "track_count": 12,
             "created_at": "2026-08-16T09:00:00+09:00",
             "video_id": "legacy-video",
+            "upload": {"video_id": "canonical-video"},
             "planning": {
                 "activities": "focus",
                 "scene_emoji": "🌧️",
@@ -236,7 +237,11 @@ def test_upload_read_accessors_return_typed_values_and_keep_unknown_fields(tmp_p
     assert state.title_activity == "focus"
     assert state.track_count == 12
     assert state.created_at == "2026-08-16T09:00:00+09:00"
-    assert state.video_id == "legacy-video"
+    assert state.upload is not None
+    assert state.upload.video_id == "canonical-video"
+    assert state["video_id"] == "legacy-video"
+    with pytest.raises(AttributeError):
+        _legacy_video_id = state.video_id
     assert state.planning.publish_target_at == "2026-09-01T08:00:00+09:00"
     assert state.planning.final_title_en == "Rainy Focus"
     assert state.planning.final_title == "雨の集中時間"

--- a/tests/repo/test_publish_pinned_skill_contract.py
+++ b/tests/repo/test_publish_pinned_skill_contract.py
@@ -58,3 +58,11 @@ def test_publish_manifest_owns_pinned_step() -> None:
 
     pinned = next(step for step in manifest["steps"] if step["id"] == "pinned")
     assert pinned["skill"] == "publish"
+
+
+def test_pinned_reference_routes_legacy_video_id_repair_through_owner_cli() -> None:
+    reference = (PUBLISH / "references" / "pinned.md").read_text(encoding="utf-8")
+
+    assert "top-level `video_id`" in reference
+    assert "`upload.video_id`" in reference
+    assert "yt-workflow-state --collection <path> set-upload --video-id <video-id>" in reference


### PR DESCRIPTION
## 概要

legacy top-level `video_id` の読み取りfallbackを削除し、`upload.video_id` を唯一の正準readへ統一します。

## 変更内容

- `WorkflowState.video_id` typed accessorを削除
- pinned commentとanalytics experimentのtop-level fallbackを削除
- top-level only stateは値を利用せず、owner CLI修復案内付きValidationError
- nested upload.video_id、tracking優先の既存挙動を維持
- unknown raw legacy keyはround-trip保持するがAPIへ昇格しない
- publish/wf-new文書、schema、CHANGELOGを追従

## 検証

- focused: 100 + 最終89 passed
- full: 9,409 passed / 3 skipped（既知affected-tests並列干渉1件は単独green）
- ruff / format / yt-skills / Any: green
- build + wheel smoke: green

Closes #3893
