### PR TITLE
feat(music): MiniMaxのボーカル曲生成を追加する (#4121)

### DIFF
--- a/.claude/skills/music/SKILL.md
+++ b/.claude/skills/music/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: music
 purpose: 作る
-description: "Use when 音楽制作を状態判定付きで一括実行または一段だけ実行するとき。Suno UI 投入用の Style / プロンプト生成は --prompt、ボーカル曲の歌詞生成は --lyric、music_engine に応じた音源生成は --generate、Suno 音源の一括 DL とマスター化は --master を使う。「音楽制作」「Suno プロンプト」「歌詞生成」「Suno 連続生成」「Lyria」「マスター化」「vocal」「rap」で発動"
+description: "Use when 音楽制作を状態判定付きで一括実行または一段だけ実行するとき。Suno UI 投入用の Style / プロンプト生成は --prompt、Suno / MiniMax ボーカル曲の歌詞生成は --lyric、music_engine に応じた音源生成は --generate、Suno 音源の一括 DL とマスター化は --master を使う。「音楽制作」「Suno プロンプト」「歌詞生成」「Suno 連続生成」「MiniMax vocal」「Lyria」「マスター化」「vocal」「rap」で発動"
 ---
 
 ## 前後工程
@@ -50,7 +50,7 @@ prompt文書の保存・表示・既存Markdown移行・state更新は `referenc
 
 loader は `load_skill_config("music.prompt")` を使う。存在しない override は勝手に作成しない。旧 `config/skills/suno.yaml` と `load_skill_config("suno")` は互換入口として維持するが、新規生成先にはしない。既存の旧 config は `uv run yt-skills migrate-config --channel-dir . --dry-run` で差分を確認し、明示 apply した場合だけ `config/skills/music.yaml::prompt` へ移す。
 
-`--lyric` は `.claude/skills/music/config.default.yaml::lyric` と `config/skills/music.yaml::lyric` を同様に deep-merge し、`load_skill_config("music.lyric")` を使う。旧 `config/skills/suno-lyric.yaml` と `load_skill_config("suno-lyric")` は互換入口として維持し、明示 migration 時だけ `config/skills/music.yaml::lyric` へ移す。
+`--lyric` は `.claude/skills/music/config.default.yaml::lyric` と `config/skills/music.yaml::lyric` を同様に deep-merge し、`load_skill_config("music.lyric")` を使う。`music_engine` が `suno` または `minimax` のボーカル collection で実行し、`lyria` と instrumental collection は歌詞不要として停止する。旧 `config/skills/suno-lyric.yaml` と `load_skill_config("suno-lyric")` は互換入口として維持し、明示 migration 時だけ `config/skills/music.yaml::lyric` へ移す。
 
 `--generate` は `music_engine` を先に一度だけ解決し、`load_skill_config("music.generate")` の結果から engine 節を一度だけ選ぶ。Suno は `.claude/skills/music/config.default.yaml::generate.suno` と旧 `config/skills/suno-helper.yaml`、Lyria は `::generate.lyria` と旧 `config/skills/lyria.yaml`、MiniMax は `::generate.minimax` と `config/skills/music.yaml::generate.minimax` を deep-merge する。互換入口 `load_skill_config("suno-helper")` / `load_skill_config("lyria")` を維持し、存在しない override は勝手に作成しない。
 
@@ -60,7 +60,7 @@ Suno 経路の server lifecycle は `extension/references/serve.md` を直接読
 
 ## 一括実行
 
-`references/music-chain-manifest.json` と `references/music-chain-state.py` を検証する。chain は `prompt` → `lyric` → `generate` → `master` の 4 step。Suno の instrumental collection では不要な `lyric` の blocked 判定を完了済みとして扱い、`generate` へ進む。Lyria / MiniMax は `music_engine` により `generate` へ直接分岐し、`master` は完了済みとして skip する。
+`references/music-chain-manifest.json` と `references/music-chain-state.py` を検証する。chain は `prompt` → `lyric` → `generate` → `master` の 4 step。Suno / MiniMax の instrumental collection では不要な `lyric` の blocked 判定を完了済みとして扱い、`generate` へ進む。MiniMax vocal は `lyric` の検証済み成果物を `generate` に渡す。Lyria は `music_engine` により `generate` へ直接分岐し、Lyria / MiniMax の `master` は完了済みとして skip する。
 
 ```bash
 uv run python .claude/skills/music/references/music-chain-state.py \
@@ -92,6 +92,6 @@ uv run python .claude/skills/music/references/music-chain-state.py \
 |---|---|---|
 | Suno UI | entry 数分の Generate（1 Generate = 2 clips） | 選択 entry 数、duration guard 再生成、resume 状態 |
 | Vertex AI Lyria 3（yt-generate-lyria-master） | N call、N = ceil((audio.target_duration_min + duration_padding_min) × 60 / 184)（上限 60） | 目標尺、padding、retry。既存 segment は resume で skip |
-| MiniMax Music（yt-generate-minimax-master） | N call、N = ceil((audio.target_duration_min + duration_padding_min) × 60 / 300)（上限 60） | 目標尺、padding、retry。既存 segment は resume で skip |
+| MiniMax Music（yt-generate-minimax-master） | instrumental は N call、N = ceil((audio.target_duration_min + duration_padding_min) × 60 / 300)（上限 60）。vocal は 1 call | 目標尺、padding、retry、`--lyrics`。既存 segment / vocal master は resume で skip |
 
 - 上限 / 承認: Suno はログイン・CAPTCHA・credit 確認を自動突破しない。Lyria は `skip_generation_approval: false`、MiniMax は生成条件とcall数の提示後に明示承認し、どちらも 60 segment hard cap を維持する。

--- a/.claude/skills/music/references/generate.md
+++ b/.claude/skills/music/references/generate.md
@@ -8,13 +8,13 @@
 |---|---|---|
 | `suno` | 下記 Suno 経路。collection server を起動または再利用し、Chrome 拡張で連続生成・playlist 追加・一括 download を行う | `02-Individual-music/` と strict 6 点 |
 | `lyria` | 下記 Lyria 経路。Vertex AI Lyria 3 でセグメント生成・結合を行う | `01-master/master.mp3` |
-| `minimax` | 下記 MiniMax 経路。MiniMax Music でインスト segment生成・結合を行う | `01-master/master.mp3` |
+| `minimax` | 下記 MiniMax 経路。instrumental は segment生成・結合、vocal は検証済み歌詞から1曲を直接生成する | `01-master/master.mp3` |
 
 値が `suno` / `lyria` / `minimax` 以外、または未設定なら設定不整合として停止する。利用者に別 engine の skill を案内せず、同じ `/music --generate` の入口で自動分岐する。
 
 ## MiniMax 経路
 
-`music_engine: minimax` では `.claude/skills/music/config.default.yaml::generate.minimax` と `config/skills/music.yaml::generate.minimax` を deep-merge する。対象 collection のテーマ、creative constraints、採用済み方向性から instrumental style prompt と filename slug を決め、生成回数と model を提示して generation approval を得た後、次を実行する。
+`music_engine: minimax` では `.claude/skills/music/config.default.yaml::generate.minimax` と `config/skills/music.yaml::generate.minimax` を deep-merge する。対象 collection のテーマ、creative constraints、採用済み方向性から style prompt と filename slug を決める。`suno-patterns.yaml` が vocal を示す場合は、`/music --lyric` の機械検証と semantic review が成功した1曲分の `20-documentation/suno-lyrics.json` を必須とする。生成回数と model を提示して generation approval を得た後に実行する。
 
 ```bash
 uv run yt-generate-minimax-master \
@@ -26,9 +26,11 @@ uv run yt-generate-minimax-master \
   --collection <collection-path>
 ```
 
-CLI は1 segmentを最大300秒として必要数を算出し、MiniMax Musicの `output_format: hex` / `is_instrumental: true` で逐次生成する。成功ごとに `data/audio_costs.json` へ `unit: song` を記録し、`02-Individual-music/<NN>_<slug>.mp3` をresume可能に保存する。全segmentが揃った場合だけ既存 `generate_master.generate_master()` へ渡し、`01-master/master.mp3` を生成する。中断時の支払い済みaudioは `tmp/minimax-recovered/<sha256>.mp3` へ退避する。
+vocal の場合は同じ CLI に `--lyrics 20-documentation/suno-lyrics.json` を追加する。CLI は歌詞ファイルを API 呼び出し前に検証し、section tag を含む本文を変更せず `lyrics` に、`is_instrumental: false` を payload に設定する。1回の生成結果を `01-master/master.mp3` へ直接保存し、segment分割・`generate_master` 結合は行わない。
 
-完了条件は `01-master/master.mp3` が非空で、実行時に新規生成したsegment数と同数の `unit: song` cost entryが残ること。失敗時は既存segmentを保持し、同じcommandの再実行で未生成分から再開する。
+instrumental は従来どおり1 segmentを最大300秒として必要数を算出し、`output_format: hex` / `is_instrumental: true` で逐次生成する。成功ごとに `data/audio_costs.json` へ `unit: song` を記録し、`02-Individual-music/<NN>_<slug>.mp3` をresume可能に保存する。全segmentが揃った場合だけ既存 `generate_master.generate_master()` へ渡し、`01-master/master.mp3` を生成する。vocal / instrumental とも中断時の支払い済みaudioは `tmp/minimax-recovered/<sha256>.mp3` へ退避する。
+
+完了条件は `01-master/master.mp3` が非空で、instrumental は新規segment数、vocal は1件の `unit: song` cost entryが残ること。成功後は owner CLI の `set-asset raw_master '"master.mp3"'` で workflow state を更新する。失敗時は既存segmentを保持し、vocal master は公開せず、同じcommandの再実行で未生成分から再開する。
 
 Suno 経路の server lifecycle は `.claude/skills/extension/references/serve.md` をファイル参照で読み、`--suno` の起動・既存 server 再利用・疎通確認・停止契約をそのまま実行する。`/extension` へ委譲せず、このファイルの手順を複製しない。
 

--- a/.claude/skills/music/references/lyric.md
+++ b/.claude/skills/music/references/lyric.md
@@ -1,13 +1,13 @@
 ## Overview
 
-`/music --lyric` は Suno ボーカル曲の **Lyrics 専任**。`/music --prompt` は orchestration + Style / title / scene / JSON merge を担当し、本 skill は歌詞本文だけを作る。
+`/music --lyric` は Suno / MiniMax ボーカル曲の **Lyrics 専任**。`/music --prompt` は orchestration + Style / title / scene / JSON merge を担当し、本 skill は歌詞本文だけを作る。
 
 ```
 /music --lyric  ->  20-documentation/suno-lyrics.{md,json}
                        |
 /music --prompt        ->  20-documentation/suno-prompts.{md,json}
                        |
-/music --generate ->  Suno UI
+/music --generate ->  Suno UI / MiniMax Music API
 ```
 
 ## Subagent Contract
@@ -41,7 +41,7 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 以下を確認し、満たさなければ前工程を案内して停止する（機械的な停止条件は後述の Hard Gates が正）:
 
-- チャンネルの `music_engine` が `suno` で、`genre_line` または `suno-patterns.yaml::mode` がボーカルを示すこと。インストゥルメンタルのみのチャンネル / コレクションでは歌詞生成不要として停止する
+- チャンネルの `music_engine` が `suno` または `minimax` で、`genre_line` または `suno-patterns.yaml::mode` がボーカルを示すこと。`lyria` とインストゥルメンタルのみのチャンネル / コレクションでは歌詞生成不要として停止する
 - 対象コレクションの `20-documentation/suno-patterns.yaml` が存在すること。無ければ先に `/music --prompt` の pattern draft 作成を案内して停止する
 - persona reference として `docs/channel/personas/persona-definition.md` を読む。無い場合のみ旧 `docs/audience-persona.md` を legacy fallback として参照する
 
@@ -74,7 +74,7 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 ## Hard Gates
 
-1. `music_engine` が `suno` でない場合は停止する
+1. `music_engine` が `suno` / `minimax` のどちらでもない場合は停止する
 2. `genre_line` または `suno-patterns.yaml::mode` がボーカルを示さない場合は、歌詞生成不要として停止する
 3. `20-documentation/suno-patterns.yaml` が無い場合は停止し、先に `/music --prompt` の pattern draft を作るよう案内する
 4. `workflow-state.json::planning.music` が空でも完全停止はしないが、曲ごとの scene と persona reference を優先して進める
@@ -118,7 +118,7 @@ generator は `suno-patterns.yaml`、persona reference、設定、必要な Refe
 6. Lyrics は V5.5 向けに section tags を明示する。基本形は `[Intro]`, `[Verse 1]`, `[Pre-Chorus]`, `[Chorus]`, `[Verse 2]`, `[Instrumental]`, `[Bridge]`, `[Final Chorus]`, `[Extended Outro]`, `[Outro]`。`[Verse]` / `[Chorus]` だけでなく `[Intro]` `[Pre-Chorus]` `[Bridge]` `[Extended Outro]` `[Outro]` も曲ごとの scene / persona に合わせて書き分け、他の曲から本文を流用しない（Suno は歌詞テキストに強く追従するため、これらが同一だと全曲の入り・終わりが似通う）
 7. `suno-lyrics.md` と `suno-lyrics.json` を `20-documentation/` に出力する。`preserve_existing: true` の場合、既存 entry は上書きしない
 8. `uv run yt-suno-verify <collection-path>` 通過後、別コンテキスト reviewer が `suno-lyrics.json` のみを読み、entry ごとに `PASS` / `FAIL` + 理由を出す。`FAIL` entry のみ最大 2 周まで再生成し、上限到達時は残課題をユーザーに提示する
-9. 出力後、`/music --prompt` に戻って Style と Lyrics をマージする
+9. 出力後、Suno は `/music --prompt` に戻って Style と Lyrics をマージし、MiniMax は `/music --generate` が検証済み `suno-lyrics.json` を直接消費する
 
 ## Output Contract
 
@@ -176,4 +176,4 @@ JSON root は配列。各 entry は `/music --prompt` が `name` でマージで
 
 ## Next Step
 
-完了後は `/music --prompt` を実行する。`/music --prompt` は `suno-lyrics.json` を優先して読み、Style と Lyrics を `suno-prompts.json` にマージする。
+完了後、Suno は `/music --prompt` を実行し、`suno-lyrics.json` を優先して Style と Lyrics を `suno-prompts.json` にマージする。MiniMax は `/music --generate` を実行し、同じ `suno-lyrics.json` を `yt-generate-minimax-master --lyrics` へ渡す。

--- a/.claude/skills/music/references/music-chain-state.py
+++ b/.claude/skills/music/references/music-chain-state.py
@@ -108,11 +108,11 @@ def _evaluate_lyric(collection_path: Path) -> tuple[int, dict[str, object]]:
 
     channel_dir = _channel_dir(collection_path)
     youtube_config = _load_mapping(channel_dir / "config" / "channel" / "youtube.json")
-    if youtube_config.get("music_engine") != "suno":
+    if youtube_config.get("music_engine") not in {"suno", "minimax"}:
         return EXIT_BLOCKED, {
             "step": "lyric",
             "decision": "blocked",
-            "reason": "music_engine_not_suno",
+            "reason": "music_engine_not_lyric_capable",
         }
 
     patterns_path = collection_path / _PROMPT_OUTPUTS[0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(documents)`: 生成運用成果物の owner・schema・consumer inventory を正本化し、`yt-skills lint` で Markdown writer、JSON/HTML pair 欠落、orphan、未検証 consumer、stale allowlist を具体 path 付きで拒否する（#4031）。
 - `feat(wf-new)`: 構造化企画候補を永続card HTMLで比較し、共通loopback brokerまたは明示terminal/automatic経路から検証済みproposal IDだけを既存企画確定ownerへ渡す（#4016）。
+- `feat(music)`: MiniMax Music で検証済み `suno-lyrics.json` から歌詞・ボーカル入りの1曲を生成し、`/music --lyric` と `--generate` の再開可能な経路へ統合する（#4121）。
 - `feat(wf-status)`: canonical workflow state と実成果物からread-only viewを作り、client filter付き固定HTML snapshotをatomic overwriteして既定browserで開く（#4032）。
 - `refactor(workflow-state)`: collection の音楽エンジンを `planning.music.engine` へ統合し、旧 top-level `music_engine` は一致検証付きの読み取り互換だけに限定する（#3891）。
 - `refactor(workflow-state)`: 概要欄生成状態を `assets.description` へ統合し、旧 `description.generated` は owner accessor の読み取り互換だけに限定する（#3890）。

--- a/src/youtube_automation/commands/media/generate_minimax_master.py
+++ b/src/youtube_automation/commands/media/generate_minimax_master.py
@@ -16,6 +16,7 @@ from youtube_automation.commands.media import generate_master
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError, GeneratorError, ValidationError
+from youtube_automation.domains.suno.lyrics import load_suno_lyrics_entries
 from youtube_automation.infrastructure import cost_tracker
 from youtube_automation.infrastructure.media import minimax_client
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths, resolve_collection_dir
@@ -26,6 +27,8 @@ _MAX_SEGMENT_COUNT = 60
 _DEFAULT_MAX_RETRIES = 3
 _RECOVERY_SUBDIR = ("tmp", "minimax-recovered")
 _AUDIO_SETTING = {"sample_rate": 44100, "bitrate": 256000, "format": "mp3"}
+_MAX_PROMPT_CHARS = 2000
+_MAX_LYRICS_CHARS = 3500
 
 
 def _mapping(value: object, label: str) -> Mapping[object, object]:
@@ -117,14 +120,41 @@ def _persist_segment(audio: bytes, segment_path: Path) -> None:
         ) from error
 
 
-def _payload(prompt: str, model: str) -> dict[str, object]:
-    return {
+def _payload(prompt: str, model: str, *, lyrics: str | None) -> dict[str, object]:
+    payload: dict[str, object] = {
         "model": model,
         "prompt": prompt,
-        "is_instrumental": True,
+        "is_instrumental": lyrics is None,
         "output_format": "hex",
         "audio_setting": dict(_AUDIO_SETTING),
     }
+    if lyrics is not None:
+        payload["lyrics"] = lyrics
+    return payload
+
+
+def _request_audio_with_retries(
+    *,
+    label: str,
+    payload: Mapping[str, object],
+    timeout: float,
+    max_retries: int,
+) -> bytes:
+    if max_retries < 0:
+        raise ValidationError("--max-retries は 0 以上が必要です")
+
+    for attempt in range(max_retries + 1):
+        if attempt > 0:
+            wait_seconds = min(30, attempt * 10)
+            print(f"  [{label}] retry {attempt}/{max_retries} ({wait_seconds}s 待機)")
+            time.sleep(wait_seconds)
+        try:
+            body = minimax_client.request_json(_MUSIC_PATH, payload, timeout=timeout)
+            return _extract_audio(body)
+        except GeneratorError:
+            if attempt == max_retries:
+                raise GeneratorError(f"MiniMax {label} は {max_retries + 1} 回失敗しました") from None
+    raise AssertionError("retry loop must return or raise")
 
 
 def _generate_segment(
@@ -140,35 +170,81 @@ def _generate_segment(
     if segment_path.is_file() and segment_path.stat().st_size > 0:
         print(f"  [skip] {label} — 既に存在 ({segment_path.name})")
         return
-    if max_retries < 0:
-        raise ValidationError("--max-retries は 0 以上が必要です")
+    audio = _request_audio_with_retries(
+        label=label,
+        payload=_payload(prompt, model, lyrics=None),
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+    _persist_segment(audio, segment_path)
+    cost_tracker.log_generation(
+        "audio",
+        model=model,
+        quantity=1,
+        unit="song",
+        metadata={
+            "segment": label,
+            "output_file": cost_tracker.relative_to_channel_dir(segment_path),
+        },
+    )
+    print(f"  [{label}] 完了 ({segment_path.stat().st_size / 1024:.0f} KB)")
 
-    for attempt in range(max_retries + 1):
-        if attempt > 0:
-            wait_seconds = min(30, attempt * 10)
-            print(f"  [{label}] retry {attempt}/{max_retries} ({wait_seconds}s 待機)")
-            time.sleep(wait_seconds)
-        try:
-            body = minimax_client.request_json(_MUSIC_PATH, _payload(prompt, model), timeout=timeout)
-            audio = _extract_audio(body)
-        except GeneratorError:
-            if attempt == max_retries:
-                raise GeneratorError(f"MiniMax {label} は {max_retries + 1} 回失敗しました") from None
-            continue
 
-        _persist_segment(audio, segment_path)
-        cost_tracker.log_generation(
-            "audio",
-            model=model,
-            quantity=1,
-            unit="song",
-            metadata={
-                "segment": label,
-                "output_file": cost_tracker.relative_to_channel_dir(segment_path),
-            },
-        )
-        print(f"  [{label}] 完了 ({segment_path.stat().st_size / 1024:.0f} KB)")
+def _resolve_lyrics_path(collection: Path, argument: str) -> Path:
+    path = Path(argument)
+    return path if path.is_absolute() else collection / path
+
+
+def _load_vocal_lyrics(collection: Path, argument: str) -> str:
+    path = _resolve_lyrics_path(collection, argument)
+    if path.is_symlink() or not path.is_file():
+        raise ValidationError(f"--lyrics は存在する通常ファイルを指定してください: {path}")
+    try:
+        entries = load_suno_lyrics_entries(path)
+    except OSError as error:
+        raise ValidationError(f"--lyrics を読み込めません: {path}") from error
+    if len(entries) != 1:
+        raise ValidationError(f"MiniMax vocal 生成の --lyrics は1曲分だけ必要です (got {len(entries)})")
+    lyrics = entries[0].lyrics
+    if not lyrics:
+        raise ValidationError("MiniMax vocal 生成の lyrics は空にできません")
+    if len(lyrics) > _MAX_LYRICS_CHARS:
+        raise ValidationError(f"MiniMax vocal 生成の lyrics は {_MAX_LYRICS_CHARS} 文字以下が必要です")
+    return lyrics
+
+
+def _generate_vocal_master(
+    *,
+    master_path: Path,
+    prompt: str,
+    lyrics: str,
+    model: str,
+    timeout: float,
+    max_retries: int,
+) -> None:
+    if master_path.is_file() and master_path.stat().st_size > 0:
+        print(f"  [skip] vocal — 既に存在 ({master_path.name})")
         return
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        raise ValidationError(f"MiniMax vocal 生成の --prompt は {_MAX_PROMPT_CHARS} 文字以下が必要です")
+    audio = _request_audio_with_retries(
+        label="vocal",
+        payload=_payload(prompt, model, lyrics=lyrics),
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+    _persist_segment(audio, master_path)
+    cost_tracker.log_generation(
+        "audio",
+        model=model,
+        quantity=1,
+        unit="song",
+        metadata={
+            "mode": "vocal",
+            "output_file": cost_tracker.relative_to_channel_dir(master_path),
+        },
+    )
+    print(f"  [vocal] 完了 ({master_path.stat().st_size / 1024:.0f} KB)")
 
 
 def _number(config: Mapping[object, object], key: str, label: str) -> float:
@@ -209,10 +285,14 @@ def _resolve_target_duration(argument: float | None) -> float:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="yt-generate-minimax-master",
-        description="MiniMax Music segments を生成し、長尺 master.mp3 へ結合する。",
+        description="MiniMax Music で instrumental 長尺または歌詞付き vocal の master.mp3 を生成する。",
     )
-    parser.add_argument("--prompt", required=True, help="MiniMax Music に渡す instrumental style prompt")
+    parser.add_argument("--prompt", required=True, help="MiniMax Music に渡す style prompt")
     parser.add_argument("--name", required=True, help="segment filename slug")
+    parser.add_argument(
+        "--lyrics",
+        help="MiniMax vocal に渡す suno-lyrics.json（相対 path は collection 起点。省略時は instrumental）",
+    )
     parser.add_argument("--collection", help="collection directory（省略時は CWD から解決）")
     parser.add_argument("--target-duration", type=float, help="目標尺（分。省略時は channel audio config）")
     parser.add_argument("--model", help="MiniMax Music model（省略時は music.generate.minimax.model）")
@@ -229,9 +309,33 @@ def build_parser() -> argparse.ArgumentParser:
 def run(args: argparse.Namespace) -> int:
     collection = resolve_collection_dir(args.collection)
     paths = CollectionPaths(collection)
-    paths.music_dir.mkdir(parents=True, exist_ok=True)
 
     minimax_config = _minimax_config()
+    model = args.model or _string(minimax_config, "model", "music.generate.minimax")
+    timeout = _number(minimax_config, "request_timeout_sec", "music.generate.minimax")
+    if timeout <= 0:
+        raise ConfigError("music.generate.minimax.request_timeout_sec は 0 より大きい値が必要です")
+
+    if args.lyrics is not None:
+        lyrics = _load_vocal_lyrics(collection, args.lyrics)
+        master_path = paths.master_dir / "master.mp3"
+        print("\n  yt-generate-minimax-master")
+        print(f"  Collection : {collection}")
+        print("  Mode       : vocal (1 song)")
+        print(f"  Model      : {model}\n")
+        _generate_vocal_master(
+            master_path=master_path,
+            prompt=args.prompt,
+            lyrics=lyrics,
+            model=model,
+            timeout=timeout,
+            max_retries=args.max_retries,
+        )
+        print(f"\n  Master audio: {master_path}")
+        cost_tracker.print_last_report()
+        return 0
+
+    paths.music_dir.mkdir(parents=True, exist_ok=True)
     master_config = _master_audio_config()
     target_duration = _resolve_target_duration(args.target_duration)
     padding_min = (
@@ -239,10 +343,6 @@ def run(args: argparse.Namespace) -> int:
         if args.padding_min is not None
         else _number(minimax_config, "duration_padding_min", "music.generate.minimax")
     )
-    model = args.model or _string(minimax_config, "model", "music.generate.minimax")
-    timeout = _number(minimax_config, "request_timeout_sec", "music.generate.minimax")
-    if timeout <= 0:
-        raise ConfigError("music.generate.minimax.request_timeout_sec は 0 より大きい値が必要です")
     segment_count = _resolve_segment_count(target_duration, padding_min)
     crossfade = _number(master_config, "crossfade_duration", "masterup.audio")
     bitrate = _string(master_config, "bitrate", "masterup.audio")

--- a/tests/commands/media/test_generate_minimax_master.py
+++ b/tests/commands/media/test_generate_minimax_master.py
@@ -50,6 +50,14 @@ def _response(audio: bytes = b"MINIMAX_MP3") -> dict[str, object]:
     }
 
 
+def _lyrics(path: Path, lyrics: str = "[Intro]\n夜が明ける\n\n[Verse 1]\n静かな朝\n\n[Chorus]\n歩き出そう") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps([{"name": "夜明け — Dawn", "lyrics": lyrics}], ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
 def test_extract_audio_accepts_official_completed_hex_response() -> None:
     assert generate_minimax_master._extract_audio(_response(b"audio")) == b"audio"
 
@@ -132,6 +140,209 @@ def test_run_generates_segments_logs_each_song_and_combines_existing_master_path
         assert call.kwargs["quantity"] == 1
         assert call.kwargs["unit"] == "song"
     generate_master.assert_called_once_with(collection, 2.5, "256k")
+
+
+def test_vocal_run_sends_verified_lyrics_once_and_writes_master_without_segment_combination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = _collection(tmp_path)
+    lyrics_path = collection / "20-documentation/suno-lyrics.json"
+    lyrics = "[Intro]\n夜が明ける\n\n[Verse 1]\n静かな朝\n\n[Chorus]\n歩き出そう"
+    _lyrics(lyrics_path, lyrics)
+    _configs(monkeypatch)
+    request_json = Mock(return_value=_response(b"VOCAL_MP3"))
+    monkeypatch.setattr(generate_minimax_master.minimax_client, "request_json", request_json)
+    log_generation = Mock()
+    monkeypatch.setattr(generate_minimax_master.cost_tracker, "log_generation", log_generation)
+    monkeypatch.setattr(generate_minimax_master.cost_tracker, "print_last_report", Mock())
+    combine = Mock(side_effect=AssertionError("vocal generation must not combine segments"))
+    monkeypatch.setattr(generate_minimax_master.generate_master, "generate_master", combine)
+
+    result = generate_minimax_master.main(
+        [
+            "--prompt",
+            "Japanese indie folk, hopeful dawn",
+            "--lyrics",
+            "20-documentation/suno-lyrics.json",
+            "--name",
+            "dawn",
+            "--collection",
+            str(collection),
+        ]
+    )
+
+    assert result == 0
+    request_json.assert_called_once_with(
+        "/v1/music_generation",
+        {
+            "model": "music-3.0",
+            "prompt": "Japanese indie folk, hopeful dawn",
+            "lyrics": lyrics,
+            "is_instrumental": False,
+            "output_format": "hex",
+            "audio_setting": {"sample_rate": 44100, "bitrate": 256000, "format": "mp3"},
+        },
+        timeout=360.0,
+    )
+    assert (collection / "01-master/master.mp3").read_bytes() == b"VOCAL_MP3"
+    assert list((collection / "02-Individual-music").iterdir()) == []
+    combine.assert_not_called()
+    log_generation.assert_called_once()
+    assert log_generation.call_args.args == ("audio",)
+    assert log_generation.call_args.kwargs["quantity"] == 1
+    assert log_generation.call_args.kwargs["unit"] == "song"
+    assert log_generation.call_args.kwargs["metadata"]["mode"] == "vocal"
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "missing",
+        "multiple",
+        "empty",
+        "too_long",
+    ],
+)
+def test_vocal_input_failure_stops_before_paid_api_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fixture: str,
+) -> None:
+    collection = _collection(tmp_path)
+    lyrics_path = collection / "20-documentation/suno-lyrics.json"
+    if fixture == "multiple":
+        lyrics_path.parent.mkdir(parents=True)
+        lyrics_path.write_text(
+            json.dumps(
+                [
+                    {"name": "one", "lyrics": "[Verse]\none"},
+                    {"name": "two", "lyrics": "[Verse]\ntwo"},
+                ]
+            ),
+            encoding="utf-8",
+        )
+    elif fixture == "empty":
+        _lyrics(lyrics_path, "")
+    elif fixture == "too_long":
+        _lyrics(lyrics_path, "[Verse]\n" + "a" * 3493)
+    _configs(monkeypatch)
+    request_json = Mock(side_effect=AssertionError("invalid lyrics must not spend credits"))
+    monkeypatch.setattr(generate_minimax_master.minimax_client, "request_json", request_json)
+
+    result = generate_minimax_master.main(
+        [
+            "--prompt",
+            "vocal song",
+            "--lyrics",
+            "20-documentation/suno-lyrics.json",
+            "--name",
+            "song",
+            "--collection",
+            str(collection),
+        ]
+    )
+
+    assert result != 0
+    request_json.assert_not_called()
+    assert not (collection / "01-master/master.mp3").exists()
+
+
+def test_vocal_resume_skips_api_and_duplicate_cost_when_master_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = _collection(tmp_path)
+    _lyrics(collection / "20-documentation/suno-lyrics.json")
+    master = collection / "01-master/master.mp3"
+    master.write_bytes(b"existing-vocal")
+    _configs(monkeypatch)
+    request_json = Mock(side_effect=AssertionError("completed vocal must not regenerate"))
+    monkeypatch.setattr(generate_minimax_master.minimax_client, "request_json", request_json)
+    log_generation = Mock()
+    monkeypatch.setattr(generate_minimax_master.cost_tracker, "log_generation", log_generation)
+    monkeypatch.setattr(generate_minimax_master.cost_tracker, "print_last_report", Mock())
+
+    assert (
+        generate_minimax_master.main(
+            [
+                "--prompt",
+                "vocal song",
+                "--lyrics",
+                "20-documentation/suno-lyrics.json",
+                "--name",
+                "song",
+                "--collection",
+                str(collection),
+            ]
+        )
+        == 0
+    )
+
+    assert master.read_bytes() == b"existing-vocal"
+    request_json.assert_not_called()
+    log_generation.assert_not_called()
+
+
+def test_vocal_api_failure_keeps_master_absent_and_does_not_log_cost(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = _collection(tmp_path)
+    _lyrics(collection / "20-documentation/suno-lyrics.json")
+    _configs(monkeypatch)
+    request_json = Mock(side_effect=GeneratorError("safe upstream failure"))
+    monkeypatch.setattr(generate_minimax_master.minimax_client, "request_json", request_json)
+    log_generation = Mock()
+    monkeypatch.setattr(generate_minimax_master.cost_tracker, "log_generation", log_generation)
+
+    result = generate_minimax_master.main(
+        [
+            "--prompt",
+            "vocal song",
+            "--lyrics",
+            "20-documentation/suno-lyrics.json",
+            "--name",
+            "song",
+            "--max-retries",
+            "0",
+            "--collection",
+            str(collection),
+        ]
+    )
+
+    assert result != 0
+    request_json.assert_called_once()
+    log_generation.assert_not_called()
+    assert not (collection / "01-master/master.mp3").exists()
+
+
+def test_vocal_prompt_limit_is_checked_before_paid_api_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = _collection(tmp_path)
+    _lyrics(collection / "20-documentation/suno-lyrics.json")
+    _configs(monkeypatch)
+    request_json = Mock(side_effect=AssertionError("oversized prompt must not spend credits"))
+    monkeypatch.setattr(generate_minimax_master.minimax_client, "request_json", request_json)
+
+    result = generate_minimax_master.main(
+        [
+            "--prompt",
+            "p" * 2001,
+            "--lyrics",
+            "20-documentation/suno-lyrics.json",
+            "--name",
+            "song",
+            "--collection",
+            str(collection),
+        ]
+    )
+
+    assert result != 0
+    request_json.assert_not_called()
+    assert not (collection / "01-master/master.mp3").exists()
 
 
 def test_resume_skips_existing_segment_without_api_or_duplicate_cost(

--- a/tests/repo/test_music_lyric_contract.py
+++ b/tests/repo/test_music_lyric_contract.py
@@ -140,13 +140,33 @@ def test_music_lyric_state_runs_then_skips_after_outputs_exist(tmp_path: Path) -
     assert json.loads(after.stdout)["decision"] == "skip"
 
 
+def test_music_lyric_state_runs_for_minimax_vocal_collection(tmp_path: Path) -> None:
+    collection = _write_channel(tmp_path, music_engine="minimax", genre_line="soulful female vocals", mode="vocal")
+
+    result = _run_state(collection)
+
+    assert result.returncode == 10
+    assert json.loads(result.stdout)["decision"] == "run"
+
+
 def test_music_lyric_state_blocks_lyria_engine(tmp_path: Path) -> None:
     collection = _write_channel(tmp_path, music_engine="lyria", genre_line="soulful female vocals", mode="vocal")
 
     result = _run_state(collection)
 
     assert result.returncode == 20
-    assert json.loads(result.stdout)["reason"] == "music_engine_not_suno"
+    assert json.loads(result.stdout)["reason"] == "music_engine_not_lyric_capable"
+
+
+def test_music_lyric_state_keeps_minimax_instrumental_collection_blocked(tmp_path: Path) -> None:
+    collection = _write_channel(
+        tmp_path, music_engine="minimax", genre_line="ambient instrumental", mode="instrumental"
+    )
+
+    result = _run_state(collection)
+
+    assert result.returncode == 20
+    assert json.loads(result.stdout)["reason"] == "lyrics_not_required"
 
 
 def test_music_lyric_state_blocks_instrumental_collection(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要

既存MiniMax music engineへ、歌詞込みvocal曲を生成する `--lyrics` 経路を追加します。

## 変更内容

- 既存suno-lyrics schemaをAPI課金前に検証
- section tagと歌詞構造を保持
- 1曲1 API callでmasterへ直接保存
- resume、per-song cost、content-addressed recovery
- shape / 3,500字 / prompt上限をfail-closed検証
- music chainのMiniMax vocal lyric gateとskill導線を更新
- instrumental MiniMax / Suno / Lyriaの既存経路を維持

## 検証

- focused: 83 passed
- full: 9,397 passed / 3 skipped（parallel temp-dir race 1件は単独green）
- ruff / format / yt-skills: green
- build + wheel smoke: green
- isolated wheel `--help`: green
- 実API・secret・課金なし

Closes #4121
