### PR TITLE
feat(hybrid): MediaStore と R2 転送基盤を追加する (#4044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
+- `feat(hybrid)`: 工程境界専用の `MediaStore` port と checksum 検証付き Local / Cloudflare R2 adapterを追加し、bucket・prefix・path・symlink 境界と secret 解決を fail-closed に固定する（#4044）。
 - `refactor(workflow-state)`: 旧 top-level `video_id` fallback と typed accessor を削除し、公開済み動画の正準 read を `upload.video_id` に限定する（#3893）。
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(documents)`: 生成運用成果物の owner・schema・consumer inventory を正本化し、`yt-skills lint` で Markdown writer、JSON/HTML pair 欠落、orphan、未検証 consumer、stale allowlist を具体 path 付きで拒否する（#4031）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.uploads.youtube` | 再開可能アップロード・サムネイル圧縮の共通コア |
 | `core.errors` | ドメイン例外（`AutomationError` 基底、`ConfigError` / `YouTubeAPIError` / `ValidationError` / `UploadError`） |
 | `infrastructure.media.collection_paths` | コレクションディレクトリ構造の解決 |
+| `infrastructure.media_store` | 境界転送専用の fail-closed Local / Cloudflare R2 adapter（工程内部へは注入しない） |
 | `domains.suno` | Suno 設定、歌詞、プロンプト、プレイリスト、選曲の生成・検証 |
 | `domains.suno.downloaded` | downloaded payload、workflow、検証、archive、apply transaction |
 | `domains.suno.name_matching` | prompt・playlist・downloaded filename 共通の名前正規化と曖昧性検出 |
@@ -223,6 +224,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.channel_readiness` | TTP 対象・branding・benchmark・制作設定の provider-neutral なチャンネル準備判定 |
 | `domains.thumbnail` | サムネ特徴量、相関、参照、archive、選択 policy（Pillow） |
 | `domains.media` | 音声、字幕、画像、動画の provider-neutral model / policy |
+| `domains.media_store` | 工程境界の `<channel>/<collection>/<handoff>/` key、checksum metadata、push / pull / exists port |
 | `domains.distrokid` | DistroKid naming、metadata、specification、preparation、release policy |
 | `domains.collections.weekly_vote_log` | 週次投票ログ reader、initializer、schema、保存・検証 |
 | `domains.documents.schema_registry` | リポジトリ所有 JSON Schema の固定 inventory、Draft 7 compile cache、値非表示の検証エラー変換。外部 schema path は受け取らない |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pyyaml>=6,<7",
     "requests>=2,<3",
     "fastjsonschema>=2.21,<3",
+    "boto3>=1.40,<2",
 ]
 
 [project.urls]

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -125,6 +125,10 @@ class WorkflowStateError(AutomationError):
     """workflow-state.json の読み取り・検証・永続化エラー。"""
 
 
+class MediaStoreError(AutomationError):
+    """境界メディアの転送・完全性検証エラー。"""
+
+
 def _http_error_reason(error) -> str | None:
     content = getattr(error, "content", b"")
     if isinstance(content, bytes):

--- a/src/youtube_automation/domains/media_store.py
+++ b/src/youtube_automation/domains/media_store.py
@@ -1,0 +1,56 @@
+"""境界受け渡し用メディアストアの provider-neutral 契約。"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from youtube_automation.core.errors import ValidationError
+
+_KEY_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def _validate_segment(field: str, value: str) -> None:
+    if not _KEY_SEGMENT_RE.fullmatch(value) or value in {".", ".."}:
+        raise ValidationError(f"MediaKey.{field} は安全な単一 path segment である必要があります: {value!r}")
+
+
+@dataclass(frozen=True)
+class MediaKey:
+    """ADR-0024 の ``<channel>/<collection>/<handoff>/<name>`` キー。"""
+
+    channel: str
+    collection: str
+    handoff: str
+    name: str
+
+    def __post_init__(self) -> None:
+        for field in ("channel", "collection", "handoff", "name"):
+            _validate_segment(field, getattr(self, field))
+
+    def as_posix(self) -> str:
+        return "/".join((self.channel, self.collection, self.handoff, self.name))
+
+
+@dataclass(frozen=True)
+class MediaObjectMetadata:
+    """provider に依存しない転送済みオブジェクトの検証情報。"""
+
+    size: int
+    sha256: str
+    etag: str | None = None
+
+
+@runtime_checkable
+class MediaStore(Protocol):
+    """工程境界でのみ使う push / pull / 存在確認の最小 port。"""
+
+    def push(self, source: Path, key: MediaKey) -> MediaObjectMetadata: ...
+
+    def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata: ...
+
+    def exists(self, key: MediaKey) -> bool: ...
+
+    def metadata(self, key: MediaKey) -> MediaObjectMetadata | None: ...

--- a/src/youtube_automation/infrastructure/media_store/__init__.py
+++ b/src/youtube_automation/infrastructure/media_store/__init__.py
@@ -1,0 +1,6 @@
+"""MediaStore の local / R2 adapter。"""
+
+from youtube_automation.infrastructure.media_store.local import LocalMediaStore
+from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
+
+__all__ = ["LocalMediaStore", "R2MediaStore", "R2MediaStoreConfig"]

--- a/src/youtube_automation/infrastructure/media_store/_files.py
+++ b/src/youtube_automation/infrastructure/media_store/_files.py
@@ -1,0 +1,68 @@
+"""MediaStore adapter 間で共有する fail-closed filesystem helper。"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from youtube_automation.core.errors import MediaStoreError
+
+_COPY_CHUNK_SIZE = 1024 * 1024
+
+
+def sha256_file(path: Path) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as source:
+        while chunk := source.read(_COPY_CHUNK_SIZE):
+            digest.update(chunk)
+            size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def require_regular_source(path: Path) -> None:
+    if path.is_symlink():
+        raise MediaStoreError(f"転送元にシンボリックリンクは使えません: {path.name}")
+    if not path.is_file():
+        raise MediaStoreError(f"転送元ファイルが見つかりません: {path.name}")
+
+
+def reject_symlink_components(path: Path, *, boundary: Path | None = None) -> None:
+    if boundary is None:
+        current = path
+        while not current.exists() and current != current.parent:
+            current = current.parent
+        if current.is_symlink():
+            raise MediaStoreError(f"出力先にシンボリックリンクは使えません: {current.name}")
+        return
+
+    try:
+        relative = path.relative_to(boundary)
+    except ValueError as exc:
+        raise MediaStoreError("出力先が MediaStore root の境界外です") from exc
+    current = boundary
+    for component in relative.parts:
+        current /= component
+        if current.is_symlink():
+            raise MediaStoreError(f"出力先にシンボリックリンクは使えません: {component}")
+
+
+@contextmanager
+def atomic_destination(destination: Path) -> Iterator[Path]:
+    reject_symlink_components(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    reject_symlink_components(destination.parent)
+    descriptor, raw_temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+    os.close(descriptor)
+    temporary = Path(raw_temporary)
+    try:
+        yield temporary
+        reject_symlink_components(destination)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise

--- a/src/youtube_automation/infrastructure/media_store/local.py
+++ b/src/youtube_automation/infrastructure/media_store/local.py
@@ -1,0 +1,61 @@
+"""Filesystem を使う MediaStore adapter。"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from youtube_automation.core.errors import MediaStoreError
+from youtube_automation.domains.media_store import MediaKey, MediaObjectMetadata
+from youtube_automation.infrastructure.media_store._files import (
+    atomic_destination,
+    reject_symlink_components,
+    require_regular_source,
+    sha256_file,
+)
+
+
+class LocalMediaStore:
+    """ローカル root の内側だけへ streaming copy する store。"""
+
+    def __init__(self, root: Path) -> None:
+        if root.is_symlink():
+            raise MediaStoreError("MediaStore root にシンボリックリンクは使えません")
+        self._root = root.absolute()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, key: MediaKey) -> Path:
+        destination = self._root.joinpath(*key.as_posix().split("/"))
+        reject_symlink_components(destination, boundary=self._root)
+        return destination
+
+    def push(self, source: Path, key: MediaKey) -> MediaObjectMetadata:
+        require_regular_source(source)
+        size, checksum = sha256_file(source)
+        destination = self._path(key)
+        with atomic_destination(destination) as temporary:
+            with source.open("rb") as input_file, temporary.open("wb") as output_file:
+                shutil.copyfileobj(input_file, output_file)
+        return MediaObjectMetadata(size=size, sha256=checksum)
+
+    def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
+        source = self._path(key)
+        if not source.is_file():
+            raise MediaStoreError(f"MediaStore object が見つかりません: {key.as_posix()}")
+        with atomic_destination(destination) as temporary:
+            with source.open("rb") as input_file, temporary.open("wb") as output_file:
+                shutil.copyfileobj(input_file, output_file)
+            size, checksum = sha256_file(temporary)
+        return MediaObjectMetadata(size=size, sha256=checksum)
+
+    def exists(self, key: MediaKey) -> bool:
+        return self.metadata(key) is not None
+
+    def metadata(self, key: MediaKey) -> MediaObjectMetadata | None:
+        path = self._path(key)
+        if not path.exists():
+            return None
+        if not path.is_file():
+            raise MediaStoreError(f"MediaStore object が通常ファイルではありません: {key.as_posix()}")
+        size, checksum = sha256_file(path)
+        return MediaObjectMetadata(size=size, sha256=checksum)

--- a/src/youtube_automation/infrastructure/media_store/r2.py
+++ b/src/youtube_automation/infrastructure/media_store/r2.py
@@ -1,0 +1,229 @@
+"""Cloudflare R2 の S3-compatible MediaStore adapter。"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Protocol, cast
+
+from youtube_automation.core.errors import ConfigError, MediaStoreError
+from youtube_automation.domains.media_store import MediaKey, MediaObjectMetadata
+from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
+from youtube_automation.infrastructure.media_store._files import atomic_destination, require_regular_source, sha256_file
+from youtube_automation.infrastructure.secrets import get_secret
+
+_BUCKET_RE = re.compile(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]\Z")
+_IDENTIFIER_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+_PREFIX_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_DEFAULT_MULTIPART_CHUNK_SIZE = 100 * 1024 * 1024
+
+
+class _S3Client(Protocol):
+    def upload_fileobj(
+        self,
+        file_object: BinaryIO,
+        bucket: str,
+        key: str,
+        *,
+        ExtraArgs: dict[str, object],
+        Config: object,
+    ) -> None: ...
+
+    def download_fileobj(
+        self,
+        bucket: str,
+        key: str,
+        file_object: BinaryIO,
+        *,
+        Config: object,
+    ) -> None: ...
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]: ...
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ConfigError(f"R2 MediaStore の設定 {name} がありません")
+    return value
+
+
+def _validate_prefix(prefix: str) -> None:
+    if not prefix:
+        return
+    if prefix.startswith("/") or prefix.endswith("/"):
+        raise ConfigError("R2 MediaStore の prefix は相対 path かつ末尾 slash なしで指定してください")
+    if any(not _PREFIX_SEGMENT_RE.fullmatch(segment) or segment in {".", ".."} for segment in prefix.split("/")):
+        raise ConfigError("R2 MediaStore の prefix に境界外 path は指定できません")
+
+
+@dataclass(frozen=True)
+class R2MediaStoreConfig:
+    """R2 接続情報。token は既存 secret owner からだけ取得する。"""
+
+    account_id: str
+    access_key_id: str
+    api_token: str
+    bucket: str
+    prefix: str = ""
+
+    def __post_init__(self) -> None:
+        for field in ("account_id", "access_key_id"):
+            if not _IDENTIFIER_RE.fullmatch(getattr(self, field)):
+                raise ConfigError(f"R2 MediaStore の {field} が不正です")
+        if not self.api_token.strip():
+            raise ConfigError("R2 MediaStore の api_token は空にできません")
+        if not _BUCKET_RE.fullmatch(self.bucket) or ".." in self.bucket:
+            raise ConfigError("R2 MediaStore の bucket が不正です")
+        _validate_prefix(self.prefix)
+
+    @classmethod
+    def from_environment(cls) -> R2MediaStoreConfig:
+        return cls(
+            account_id=_required_environment("R2_ACCOUNT_ID"),
+            access_key_id=_required_environment("R2_ACCESS_KEY_ID"),
+            api_token=get_secret("R2_API_TOKEN"),
+            bucket=_required_environment("R2_BUCKET"),
+            prefix=os.environ.get("R2_PREFIX", "").strip(),
+        )
+
+    @property
+    def endpoint_url(self) -> str:
+        return f"https://{self.account_id}.r2.cloudflarestorage.com"
+
+    @property
+    def secret_access_key(self) -> str:
+        return hashlib.sha256(self.api_token.encode("utf-8")).hexdigest()
+
+
+def _build_client(config: R2MediaStoreConfig) -> tuple[_S3Client, object]:
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+    from botocore.config import Config
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=config.endpoint_url,
+        aws_access_key_id=config.access_key_id,
+        aws_secret_access_key=config.secret_access_key,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+    )
+    transfer = TransferConfig(
+        multipart_threshold=_DEFAULT_MULTIPART_CHUNK_SIZE,
+        multipart_chunksize=_DEFAULT_MULTIPART_CHUNK_SIZE,
+    )
+    return cast(_S3Client, client), transfer
+
+
+def _status_code(exc: Exception) -> int | None:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return None
+    metadata = response.get("ResponseMetadata")
+    if not isinstance(metadata, dict):
+        return None
+    status = metadata.get("HTTPStatusCode")
+    return status if isinstance(status, int) else None
+
+
+class R2MediaStore:
+    """bucket / prefix 境界を constructor で固定した R2 adapter。"""
+
+    def __init__(
+        self,
+        config: R2MediaStoreConfig,
+        *,
+        client: _S3Client | None = None,
+        transfer_config: object | None = None,
+    ) -> None:
+        self._config = config
+        if client is None or transfer_config is None:
+            built_client, built_transfer = _build_client(config)
+            self._client = client or built_client
+            self._transfer_config = transfer_config or built_transfer
+        else:
+            self._client = client
+            self._transfer_config = transfer_config
+
+    def _object_key(self, key: MediaKey) -> str:
+        parts = (self._config.prefix, key.as_posix()) if self._config.prefix else (key.as_posix(),)
+        return "/".join(parts)
+
+    def _error(self, operation: str, exc: Exception) -> MediaStoreError:
+        message = redact_sensitive_data(str(exc))
+        for secret in (self._config.api_token, self._config.access_key_id, self._config.secret_access_key):
+            message = message.replace(secret, "<redacted-token>")
+        return MediaStoreError(f"R2 MediaStore {operation} に失敗しました: {message}")
+
+    def push(self, source: Path, key: MediaKey) -> MediaObjectMetadata:
+        require_regular_source(source)
+        size, checksum = sha256_file(source)
+        object_key = self._object_key(key)
+        try:
+            with source.open("rb") as file_object:
+                self._client.upload_fileobj(
+                    file_object,
+                    self._config.bucket,
+                    object_key,
+                    ExtraArgs={"Metadata": {"sha256": checksum}},
+                    Config=self._transfer_config,
+                )
+            remote = self.metadata(key)
+        except Exception as exc:
+            raise self._error("push", exc) from exc
+        if remote is None or remote.size != size or remote.sha256 != checksum:
+            raise MediaStoreError(f"R2 MediaStore push 後の完全性検証に失敗しました: {key.as_posix()}")
+        return remote
+
+    def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
+        remote = self.metadata(key)
+        if remote is None:
+            raise MediaStoreError(f"R2 MediaStore object が見つかりません: {key.as_posix()}")
+        try:
+            with atomic_destination(destination) as temporary:
+                with temporary.open("wb") as file_object:
+                    self._client.download_fileobj(
+                        self._config.bucket,
+                        self._object_key(key),
+                        file_object,
+                        Config=self._transfer_config,
+                    )
+                size, checksum = sha256_file(temporary)
+                if size != remote.size or checksum != remote.sha256:
+                    raise MediaStoreError(f"R2 MediaStore pull の checksum 検証に失敗しました: {key.as_posix()}")
+        except MediaStoreError:
+            raise
+        except Exception as exc:
+            raise self._error("pull", exc) from exc
+        return remote
+
+    def exists(self, key: MediaKey) -> bool:
+        return self.metadata(key) is not None
+
+    def metadata(self, key: MediaKey) -> MediaObjectMetadata | None:
+        try:
+            response = self._client.head_object(Bucket=self._config.bucket, Key=self._object_key(key))
+        except Exception as exc:
+            if _status_code(exc) == 404:
+                return None
+            raise self._error("metadata", exc) from exc
+        size = response.get("ContentLength")
+        raw_metadata = response.get("Metadata")
+        etag = response.get("ETag")
+        checksum = raw_metadata.get("sha256") if isinstance(raw_metadata, dict) else None
+        if not isinstance(size, int) or size < 0 or not isinstance(checksum, str) or not _SHA256_RE.fullmatch(checksum):
+            raise MediaStoreError(f"R2 MediaStore metadata が不正です: {key.as_posix()}")
+        return MediaObjectMetadata(
+            size=size,
+            sha256=checksum,
+            etag=etag.strip('"') if isinstance(etag, str) else None,
+        )

--- a/src/youtube_automation/infrastructure/secrets.py
+++ b/src/youtube_automation/infrastructure/secrets.py
@@ -27,6 +27,7 @@ _SECRET_REFS: dict[str, str] = {
     "OPENAI_API_KEY": "op://Personal/OpenAI_API_Key/credential",
     "GEMINI_API_KEY": "op://Personal/Gemini_API_Key/credential",
     "MINIMAX_API_KEY": "op://Personal/MiniMax_API_Key/credential",
+    "R2_API_TOKEN": "op://Personal/Cloudflare_R2_API_Token/credential",
     "YOUTUBE_STREAM_KEY": "op://Personal/YouTube/stream_key",
     "VULTR_API_KEY": "op://Personal/Vultr/api_key",
     "STREAM_WEBHOOK_URL": "op://Personal/Stream_Notification_Webhook/url",

--- a/tests/domains/test_media_store.py
+++ b/tests/domains/test_media_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.media_store import MediaKey
+
+
+def test_media_key_builds_the_canonical_handoff_path() -> None:
+    key = MediaKey(channel="ambient-lab", collection="rain-night", handoff="video-upload", name="Master.mp4")
+
+    assert key.as_posix() == "ambient-lab/rain-night/video-upload/Master.mp4"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("channel", "../other-channel"),
+        ("collection", "/absolute"),
+        ("handoff", "video/upload"),
+        ("name", "nested/Master.mp4"),
+        ("name", ".."),
+    ],
+)
+def test_media_key_rejects_paths_outside_the_canonical_boundary(field: str, value: str) -> None:
+    values = {
+        "channel": "ambient-lab",
+        "collection": "rain-night",
+        "handoff": "video-upload",
+        "name": "Master.mp4",
+    }
+    values[field] = value
+
+    with pytest.raises(ValidationError, match=field):
+        MediaKey(**values)

--- a/tests/infrastructure/media_store/test_local.py
+++ b/tests/infrastructure/media_store/test_local.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.core.errors import MediaStoreError
+from youtube_automation.domains.media_store import MediaKey
+from youtube_automation.infrastructure.media_store.local import LocalMediaStore
+
+
+def _key() -> MediaKey:
+    return MediaKey("ambient-lab", "rain-night", "video-upload", "Master.mp4")
+
+
+def test_push_pull_round_trip_preserves_checksum(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    payload = (b"streamed-media-payload" * 4096) + b"end"
+    source.write_bytes(payload)
+    store = LocalMediaStore(tmp_path / "store")
+
+    pushed = store.push(source, _key())
+    destination = tmp_path / "download" / "Master.mp4"
+    pulled = store.pull(_key(), destination)
+
+    expected_checksum = hashlib.sha256(payload).hexdigest()
+    assert destination.read_bytes() == payload
+    assert pushed.sha256 == pulled.sha256 == expected_checksum
+    assert store.exists(_key()) is True
+    assert store.metadata(_key()) == pushed
+
+
+def test_missing_object_is_reported_without_creating_destination(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    destination = tmp_path / "download.bin"
+
+    assert store.exists(_key()) is False
+    assert store.metadata(_key()) is None
+    with pytest.raises(MediaStoreError, match="見つかりません"):
+        store.pull(_key(), destination)
+    assert not destination.exists()
+
+
+def test_push_rejects_a_symlink_source(tmp_path: Path) -> None:
+    real_source = tmp_path / "real.bin"
+    real_source.write_bytes(b"secret")
+    linked_source = tmp_path / "linked.bin"
+    linked_source.symlink_to(real_source)
+
+    with pytest.raises(MediaStoreError, match="シンボリックリンク"):
+        LocalMediaStore(tmp_path / "store").push(linked_source, _key())
+
+
+def test_pull_rejects_a_symlink_in_the_destination_path(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    store = LocalMediaStore(tmp_path / "store")
+    store.push(source, _key())
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(MediaStoreError, match="シンボリックリンク"):
+        store.pull(_key(), linked_parent / "download.bin")
+    assert not (outside / "download.bin").exists()
+
+
+def test_push_rejects_a_symlink_below_the_store_root(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    root = tmp_path / "store"
+    store = LocalMediaStore(root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "ambient-lab").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(MediaStoreError, match="シンボリックリンク"):
+        store.push(source, _key())
+    assert list(outside.iterdir()) == []

--- a/tests/infrastructure/media_store/test_r2.py
+++ b/tests/infrastructure/media_store/test_r2.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from youtube_automation.core.errors import ConfigError, MediaStoreError
+from youtube_automation.domains.media_store import MediaKey
+from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], tuple[bytes, dict[str, str]]] = {}
+
+    def upload_fileobj(
+        self,
+        file_object: io.BufferedReader,
+        bucket: str,
+        key: str,
+        *,
+        ExtraArgs: dict[str, object],
+        Config: object,
+    ) -> None:
+        del Config
+        metadata = ExtraArgs["Metadata"]
+        assert isinstance(metadata, dict)
+        self.objects[(bucket, key)] = (file_object.read(), metadata)
+
+    def download_fileobj(
+        self,
+        bucket: str,
+        key: str,
+        file_object: io.BufferedWriter,
+        *,
+        Config: object,
+    ) -> None:
+        del Config
+        file_object.write(self.objects[(bucket, key)][0])
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        try:
+            payload, metadata = self.objects[(Bucket, Key)]
+        except KeyError as exc:
+            raise FakeClientError(404, "missing") from exc
+        return {"ContentLength": len(payload), "Metadata": metadata, "ETag": '"fixture-etag"'}
+
+
+class FakeClientError(Exception):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.response = {"ResponseMetadata": {"HTTPStatusCode": status}}
+
+
+def _config() -> R2MediaStoreConfig:
+    return R2MediaStoreConfig(
+        account_id="account-id",
+        access_key_id="access-key-id",
+        api_token="api-token-value",
+        bucket="media-handoffs",
+        prefix="automation/v1",
+    )
+
+
+def _key() -> MediaKey:
+    return MediaKey("ambient-lab", "rain-night", "video-upload", "Master.mp4")
+
+
+def test_r2_push_pull_round_trip_uses_scoped_bucket_and_prefix(tmp_path: Path) -> None:
+    client = FakeS3Client()
+    store = R2MediaStore(_config(), client=client, transfer_config=object())
+    payload = b"r2-streaming-payload" * 8192
+    source = tmp_path / "Master.mp4"
+    source.write_bytes(payload)
+
+    pushed = store.push(source, _key())
+    destination = tmp_path / "download" / "Master.mp4"
+    pulled = store.pull(_key(), destination)
+
+    object_key = "automation/v1/ambient-lab/rain-night/video-upload/Master.mp4"
+    assert ("media-handoffs", object_key) in client.objects
+    assert destination.read_bytes() == payload
+    assert pushed.sha256 == pulled.sha256 == hashlib.sha256(payload).hexdigest()
+    assert store.exists(_key()) is True
+    assert store.metadata(_key()) == pushed
+
+
+def test_r2_config_resolves_api_token_through_the_secret_owner() -> None:
+    environment = {
+        "R2_ACCOUNT_ID": "account-id",
+        "R2_ACCESS_KEY_ID": "access-key-id",
+        "R2_BUCKET": "media-handoffs",
+        "R2_PREFIX": "automation/v1",
+    }
+    with (
+        patch.dict("os.environ", environment, clear=True),
+        patch("youtube_automation.infrastructure.media_store.r2.get_secret", return_value="api-token") as secret,
+    ):
+        config = R2MediaStoreConfig.from_environment()
+
+    assert config.api_token == "api-token"
+    secret.assert_called_once_with("R2_API_TOKEN")
+
+
+def test_r2_s3_secret_is_derived_without_using_the_raw_api_token() -> None:
+    config = _config()
+
+    assert config.secret_access_key == hashlib.sha256(config.api_token.encode()).hexdigest()
+    assert config.secret_access_key != config.api_token
+
+
+def test_r2_config_fails_closed_when_authentication_is_missing() -> None:
+    environment = {
+        "R2_ACCOUNT_ID": "account-id",
+        "R2_ACCESS_KEY_ID": "access-key-id",
+        "R2_BUCKET": "media-handoffs",
+    }
+    with (
+        patch.dict("os.environ", environment, clear=True),
+        patch(
+            "youtube_automation.infrastructure.media_store.r2.get_secret",
+            side_effect=ConfigError("R2_API_TOKEN unavailable"),
+        ),
+    ):
+        with pytest.raises(ConfigError, match="R2_API_TOKEN"):
+            R2MediaStoreConfig.from_environment()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("account_id", "account.example/escape"),
+        ("bucket", "../other-bucket"),
+        ("bucket", "media..handoffs"),
+        ("prefix", "../other-prefix"),
+        ("prefix", "/absolute"),
+    ],
+)
+def test_r2_config_rejects_bucket_or_prefix_boundary_escape(field: str, value: str) -> None:
+    values = {
+        "account_id": "account-id",
+        "access_key_id": "access-key-id",
+        "api_token": "api-token-value",
+        "bucket": "media-handoffs",
+        "prefix": "automation/v1",
+    }
+    values[field] = value
+
+    with pytest.raises(ConfigError, match=field):
+        R2MediaStoreConfig(**values)
+
+
+def test_r2_errors_are_redacted_and_do_not_expose_credentials(tmp_path: Path) -> None:
+    class FailingClient(FakeS3Client):
+        def upload_fileobj(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise RuntimeError("token=api-token-value authorization=access-key-id")
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload")
+    store = R2MediaStore(_config(), client=FailingClient(), transfer_config=object())
+
+    with pytest.raises(MediaStoreError) as raised:
+        store.push(source, _key())
+    message = str(raised.value)
+    assert "api-token-value" not in message
+    assert "access-key-id" not in message
+
+
+def test_r2_pull_removes_partial_output_when_checksum_does_not_match(tmp_path: Path) -> None:
+    class CorruptingClient(FakeS3Client):
+        def download_fileobj(
+            self,
+            bucket: str,
+            key: str,
+            file_object: io.BufferedWriter,
+            *,
+            Config: object,
+        ) -> None:
+            del bucket, key, Config
+            file_object.write(b"corrupt")
+
+    client = CorruptingClient()
+    store = R2MediaStore(_config(), client=client, transfer_config=object())
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"expected")
+    store.push(source, _key())
+    destination = tmp_path / "download.bin"
+
+    with pytest.raises(MediaStoreError, match="checksum"):
+        store.pull(_key(), destination)
+    assert not destination.exists()
+
+
+def test_r2_metadata_without_checksum_is_rejected(tmp_path: Path) -> None:
+    del tmp_path
+
+    class MetadataMissingClient(FakeS3Client):
+        def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            del Bucket, Key
+            return {"ContentLength": 7, "Metadata": {}, "ETag": '"fixture"'}
+
+    store = R2MediaStore(_config(), client=MetadataMissingClient(), transfer_config=object())
+
+    with pytest.raises(MediaStoreError, match="metadata が不正"):
+        store.metadata(_key())

--- a/tests/infrastructure/test_secrets.py
+++ b/tests/infrastructure/test_secrets.py
@@ -29,7 +29,13 @@ from youtube_automation.infrastructure.secrets import (
 )
 
 _TEST_SECRET = "CLIENT_SECRETS_JSON"
-_MANAGED_SECRETS = ("CLIENT_SECRETS_JSON", "OPENAI_API_KEY", "GEMINI_API_KEY", "MINIMAX_API_KEY")
+_MANAGED_SECRETS = (
+    "CLIENT_SECRETS_JSON",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "MINIMAX_API_KEY",
+    "R2_API_TOKEN",
+)
 _OP_READ_DISABLED_ENV = secrets_module._OP_READ_DISABLED_ENV
 
 
@@ -199,6 +205,10 @@ class TestOpenAIApiKeyRegistered:
         ):
             with pytest.raises(ConfigError, match="OPENAI_API_KEY"):
                 get_secret("OPENAI_API_KEY")
+
+
+def test_r2_api_token_is_registered_without_embedding_its_value() -> None:
+    assert _SECRET_REFS["R2_API_TOKEN"].startswith("op://")
 
 
 class TestGeminiApiKeyRegistered:

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.72"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/cc/f22093524c3b38e94ba2d0e6743d7e264f7190d149c8dceaf9603822c595/boto3-1.43.72.tar.gz", hash = "sha256:6280ce03cc85e9110fd9fb7e2fbf11eae0b1177cb041a0d69aa88edc9d178cf9", size = 112688, upload-time = "2026-08-14T19:24:53.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/b7/fa7b827ce0fc9bd697381e40f59d69a74c6ab553e246271685ec0acc75b2/boto3-1.43.72-py3-none-any.whl", hash = "sha256:f1bbbad5ed8d8a8c64edb0cd092dc443c95a85623b2ac88b6f6d633717605f00", size = 140025, upload-time = "2026-08-14T19:24:52.013Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.72"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/99/a8cfeaea98d5085a493af909d09d174466482235a7fda291be18c9a5a76e/botocore-1.43.72.tar.gz", hash = "sha256:1b878c69081e8e9d55aa4c0d85683e7b07f0e274a5554662f9507a46641be3d2", size = 15949280, upload-time = "2026-08-14T19:24:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/27/35814fd8701a6b8be0aa47a7fcbd1ea0706189410a47d71ff29ddcc3ad4d/botocore-1.43.72-py3-none-any.whl", hash = "sha256:de5a1bcf8d7602c6cefc15016f15dad82981e339192531f31fa9483e11feea47", size = 15641880, upload-time = "2026-08-14T19:24:45.882Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -721,6 +749,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1574,6 +1611,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "schedule"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1782,6 +1831,7 @@ name = "youtube-channels-automation"
 version = "5.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "fastjsonschema" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -1808,6 +1858,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.40,<2" },
     { name = "fastjsonschema", specifier = ">=2.21,<3" },
     { name = "google-api-python-client", specifier = ">=2,<3" },
     { name = "google-auth-httplib2", specifier = ">=0.3,<1" },


### PR DESCRIPTION
## 概要

ローカルとCloudflare R2を同じ安全な境界で扱うMediaStore abstractionを追加します。

## 変更内容

- MediaStore protocol、LocalMediaStore、R2MediaStoreを追加
- canonical object keyとbucket/prefix境界を強制
- path traversal、symlink、外部bucket逸脱をfail-closed拒否
- streaming multipart upload/download
- SHA-256 metadataの保存・再検証
- temp + fsync + replaceによるatomic pull
- R2 tokenを既存secret解決順へ統合
- network/HTTP/config errorから認証情報をredact
- architecture、CHANGELOG、wheel dependencyを追従
- 既存local workflowへの注入は行わず不変

## 検証

- full: 9,434 passed / 3 skipped
- post-rebase focused: 244 passed
- ruff / format / Any / lock / build: green
- isolated wheel install + Local roundtrip + R2 dependency smoke: green
- 実R2・課金・ブラウザなし

Closes #4044
